### PR TITLE
Add MOBILE_DEV_HMR support for dev-live container

### DIFF
--- a/docker-compose.override.yesterday.yml
+++ b/docker-compose.override.yesterday.yml
@@ -1,0 +1,26 @@
+# Yesterday Server Override Configuration
+# Copy this to docker-compose.override.yml on the yesterday server
+#
+# This configuration:
+# - Disables production containers (freegle-prod-local, modtools-prod-local)
+# - Exposes dev containers on external ports for yesterday access
+# - Uses the updated container names (freegle-dev-local, modtools-dev-local)
+
+services:
+  # Disable production containers by assigning them to a profile that won't run
+  freegle-prod-local:
+    profiles:
+      - disabled
+
+  modtools-prod-local:
+    profiles:
+      - disabled
+
+  # Expose dev containers on external ports for yesterday server
+  freegle-dev-local:
+    ports:
+      - "3002:3002"
+
+  modtools-dev-local:
+    ports:
+      - "3003:3000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -495,7 +495,6 @@ services:
           - freegle-dev-live.localhost
     ports:
       - "0.0.0.0:3004:3002"
-      - "0.0.0.0:24678:24678"  # Vite HMR WebSocket for hot reload
     build:
       context: ./iznik-nuxt3
       network: host
@@ -519,8 +518,6 @@ services:
       - NUXT_SSR_LOG=false
       - NODE_ENV=development
       - NUXT_BUILD_MODE=development
-      # Enable mobile dev app HMR - configures Vite to use port 24678 for WebSocket
-      - MOBILE_DEV_HMR=true
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.freegle-dev-live.rule=Host(`freegle-dev-live.localhost`)"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -519,6 +519,8 @@ services:
       - NUXT_SSR_LOG=false
       - NODE_ENV=development
       - NUXT_BUILD_MODE=development
+      # Enable mobile dev app HMR - configures Vite to use port 24678 for WebSocket
+      - MOBILE_DEV_HMR=true
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.freegle-dev-live.rule=Host(`freegle-dev-live.localhost`)"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -178,10 +178,10 @@ services:
     shm_size: 1gb
     depends_on:
       - tusd
-      - freegle-dev
-      - freegle-prod
-      - modtools-dev
-      - modtools-prod
+      - freegle-dev-local
+      - freegle-prod-local
+      - modtools-dev-local
+      - modtools-prod-local
     extra_hosts:
       - "tusd.localhost:host-gateway"
     volumes:
@@ -432,12 +432,13 @@ services:
       - "traefik.http.middlewares.apiv2-cors.headers.customresponseheaders.Access-Control-Allow-Headers=*"
       - "traefik.http.middlewares.apiv2-cors.headers.customresponseheaders.Access-Control-Max-Age=86400"
 
-  freegle-dev:
-    container_name: freegle-freegle-dev
+  # Development build with local APIs - standard dev workflow
+  freegle-dev-local:
+    container_name: freegle-dev-local
     networks:
       default:
         aliases:
-          - freegle-dev.localhost
+          - freegle-dev-local.localhost
     ports:
       - "0.0.0.0:3002:3002"
     extra_hosts:
@@ -465,7 +466,7 @@ services:
       - IZNIK_API_V2=http://apiv2.localhost/api
       - IMAGE_DELIVERY=http://delivery.localhost
       - TUS_UPLOADER=http://tusd.localhost/tus/
-      - USER_SITE=http://freegle-dev.localhost:3002
+      - USER_SITE=http://freegle-dev-local.localhost:3002
       - IMAGE_BASE_URL=http://freegle-tusd:8080/tus
       - TUSD_URL=http://freegle-tusd:8080
       - NITRO_PRESET=node-server
@@ -477,16 +478,60 @@ services:
       - TEST_BASE_URL=http://127.0.0.1:3002
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.freegle-dev.rule=Host(`freegle-dev.localhost`)"
-      - "traefik.http.routers.freegle-dev.entrypoints=web"
-      - "traefik.http.services.freegle-dev.loadbalancer.server.port=3002"
+      - "traefik.http.routers.freegle-dev-local.rule=Host(`freegle-dev-local.localhost`)"
+      - "traefik.http.routers.freegle-dev-local.entrypoints=web"
+      - "traefik.http.services.freegle-dev-local.loadbalancer.server.port=3002"
 
-  freegle-prod:
-    container_name: freegle-freegle-prod
+  # Development build with LIVE/PRODUCTION APIs - for mobile dev and testing with real data
+  # WARNING: Actions in this container affect REAL Freegle data!
+  # Not started by default - use status page button to start with confirmation
+  freegle-dev-live:
+    container_name: freegle-dev-live
+    profiles:
+      - dev-live
     networks:
       default:
         aliases:
-          - freegle-prod.localhost
+          - freegle-dev-live.localhost
+    ports:
+      - "0.0.0.0:3004:3002"
+      - "0.0.0.0:24678:24678"  # Vite HMR WebSocket for hot reload
+    build:
+      context: ./iznik-nuxt3
+      network: host
+      args:
+        IZNIK_NUXT3_BRANCH: ${IZNIK_NUXT3_BRANCH:-master}
+    tmpfs:
+      - /tmp
+    restart: "no"
+    environment:
+      # LIVE/Production APIs - REAL DATA!
+      - IZNIK_API_V1=https://fdapilive.ilovefreegle.org/api
+      - IZNIK_API_V2=https://api.ilovefreegle.org/apiv2
+      # Use production delivery and USER_SITE - local delivery won't work
+      # from mobile devices since they can't resolve localhost hostnames
+      - IMAGE_DELIVERY=https://delivery.ilovefreegle.org
+      - TUS_UPLOADER=https://uploads.ilovefreegle.org:8080
+      - USER_SITE=https://www.ilovefreegle.org
+      - NITRO_PRESET=node-server
+      - NUXT_NITRO_PRERENDER_ROUTES=false
+      - NUXT_DEV_MODE=true
+      - NUXT_SSR_LOG=false
+      - NODE_ENV=development
+      - NUXT_BUILD_MODE=development
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.freegle-dev-live.rule=Host(`freegle-dev-live.localhost`)"
+      - "traefik.http.routers.freegle-dev-live.entrypoints=web"
+      - "traefik.http.services.freegle-dev-live.loadbalancer.server.port=3002"
+
+  # Production build with local APIs - for testing production builds locally
+  freegle-prod-local:
+    container_name: freegle-prod-local
+    networks:
+      default:
+        aliases:
+          - freegle-prod-local.localhost
     ports:
       - "0.0.0.0:3012:3003"
     extra_hosts:
@@ -515,7 +560,7 @@ services:
       - IZNIK_API_V2=http://apiv2.localhost/api
       - IMAGE_DELIVERY=http://delivery.localhost
       - TUS_UPLOADER=http://tusd.localhost/tus/
-      - USER_SITE=http://freegle-prod.localhost:3003
+      - USER_SITE=http://freegle-prod-local.localhost:3003
       - IMAGE_BASE_URL=http://freegle-tusd:8080/tus
       - TUSD_URL=http://freegle-tusd:8080
       - NITRO_PRESET=node-server
@@ -527,16 +572,17 @@ services:
       - TEST_BASE_URL=http://127.0.0.1:3003
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.freegle-prod.rule=Host(`freegle-prod.localhost`)"
-      - "traefik.http.routers.freegle-prod.entrypoints=web"
-      - "traefik.http.services.freegle-prod.loadbalancer.server.port=3003"
+      - "traefik.http.routers.freegle-prod-local.rule=Host(`freegle-prod-local.localhost`)"
+      - "traefik.http.routers.freegle-prod-local.entrypoints=web"
+      - "traefik.http.services.freegle-prod-local.loadbalancer.server.port=3003"
 
-  modtools-dev:
-    container_name: freegle-modtools-dev
+  # Development build with local APIs - ModTools
+  modtools-dev-local:
+    container_name: modtools-dev-local
     networks:
       default:
         aliases:
-          - modtools-dev.localhost
+          - modtools-dev-local.localhost
     ports:
       - "0.0.0.0:3003:3000"
     extra_hosts:
@@ -561,20 +607,13 @@ services:
         condition: service_started
     restart: "no"
     environment:
-      # LIVE SERVER MODE - pointing at production APIs
-#      - IZNIK_API_V1=https://fdapidbg.ilovefreegle.org/api
-#      - IZNIK_API_V2=https://api.ilovefreegle.org/apiv2
-#      - IMAGE_DELIVERY=https://images.ilovefreegle.org
-#      - TUS_UPLOADER=https://tus.ilovefreegle.org/tus/
-      # LOCAL SERVER MODE (comment out above, uncomment below)
       - IZNIK_API_V1=http://apiv1.localhost/api
       - IZNIK_API_V2=http://apiv2.localhost/api
       - IMAGE_DELIVERY=http://delivery.localhost
       - TUS_UPLOADER=http://tusd.localhost/tus/
-      # END
       - IMAGE_BASE_URL=http://freegle-tusd:8080/tus
       - TUSD_URL=http://freegle-tusd:8080
-      - USER_SITE=http://modtools-dev.localhost:3000
+      - USER_SITE=http://modtools-dev-local.localhost:3000
       - OSM_TILE=https://tiles.ilovefreegle.org/tile/{z}/{x}/{y}.png
       - NITRO_PRESET=node-server
       - NUXT_DEV_MODE=true
@@ -583,16 +622,17 @@ services:
       - NUXT_BUILD_MODE=development
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.modtools-dev.rule=Host(`modtools-dev.localhost`)"
-      - "traefik.http.routers.modtools-dev.entrypoints=web"
-      - "traefik.http.services.modtools-dev.loadbalancer.server.port=3000"
+      - "traefik.http.routers.modtools-dev-local.rule=Host(`modtools-dev-local.localhost`)"
+      - "traefik.http.routers.modtools-dev-local.entrypoints=web"
+      - "traefik.http.services.modtools-dev-local.loadbalancer.server.port=3000"
 
-  modtools-prod:
-    container_name: freegle-modtools-prod
+  # Production build with local APIs - ModTools
+  modtools-prod-local:
+    container_name: modtools-prod-local
     networks:
       default:
         aliases:
-          - modtools-prod.localhost
+          - modtools-prod-local.localhost
     ports:
       - "0.0.0.0:3013:3001"
     extra_hosts:
@@ -617,20 +657,13 @@ services:
         condition: service_started
     restart: "no"
     environment:
-      # LIVE SERVER MODE - pointing at production APIs
-#      - IZNIK_API_V1=https://fdapidbg.ilovefreegle.org/api
-#      - IZNIK_API_V2=https://api.ilovefreegle.org/apiv2
-#      - IMAGE_DELIVERY=https://images.ilovefreegle.org
-#      - TUS_UPLOADER=https://tus.ilovefreegle.org/tus/
-      # LOCAL SERVER MODE (comment out above, uncomment below)
       - IZNIK_API_V1=http://apiv1.localhost/api
       - IZNIK_API_V2=http://apiv2.localhost/api
       - IMAGE_DELIVERY=http://delivery.localhost
       - TUS_UPLOADER=http://tusd.localhost/tus/
-      # END
       - IMAGE_BASE_URL=http://freegle-tusd:8080/tus
       - TUSD_URL=http://freegle-tusd:8080
-      - USER_SITE=http://modtools-prod.localhost:3001
+      - USER_SITE=http://modtools-prod-local.localhost:3001
       - OSM_TILE=https://tiles.ilovefreegle.org/tile/{z}/{x}/{y}.png
       - NITRO_PRESET=node-server
       - NUXT_DEV_MODE=false
@@ -640,9 +673,9 @@ services:
       - TEST_BASE_URL=http://127.0.0.1:3001
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.modtools-prod.rule=Host(`modtools-prod.localhost`)"
-      - "traefik.http.routers.modtools-prod.entrypoints=web"
-      - "traefik.http.services.modtools-prod.loadbalancer.server.port=3001"
+      - "traefik.http.routers.modtools-prod-local.rule=Host(`modtools-prod-local.localhost`)"
+      - "traefik.http.routers.modtools-prod-local.entrypoints=web"
+      - "traefik.http.services.modtools-prod-local.loadbalancer.server.port=3001"
 
   playwright:
     container_name: freegle-playwright
@@ -653,26 +686,28 @@ services:
       network: host
     working_dir: /app
     extra_hosts:
-      - "freegle-dev.localhost:127.0.0.1"
-      - "freegle-prod.localhost:127.0.0.1"
+      - "freegle-dev-local.localhost:127.0.0.1"
+      - "freegle-prod-local.localhost:127.0.0.1"
+      - "freegle-dev-live.localhost:127.0.0.1"
+      - "modtools-dev-local.localhost:127.0.0.1"
+      - "modtools-prod-local.localhost:127.0.0.1"
       - "apiv1.localhost:127.0.0.1"
       - "apiv2.localhost:127.0.0.1"
       - "delivery.localhost:127.0.0.1"
-      - "modtools.localhost:127.0.0.1"
     volumes:
       - ./iznik-nuxt3/tests:/host-tests:ro
       - ./iznik-nuxt3:/app/src:ro
       - ./iznik-nuxt3:/host-playwright-config:ro
     environment:
-      - TEST_BASE_URL=http://freegle-prod.localhost
+      - TEST_BASE_URL=http://freegle-prod-local.localhost
       - NODE_ENV=test
       - CI=false
       - ENABLE_MONOCART_REPORTER=true
       - COVERALLS_REPO_TOKEN=${COVERALLS_REPO_TOKEN:-}
     depends_on:
-      freegle-dev:
+      freegle-dev-local:
         condition: service_started
-      freegle-prod:
+      freegle-prod-local:
         condition: service_started
       apiv1:
         condition: service_healthy

--- a/file-sync.sh
+++ b/file-sync.sh
@@ -21,7 +21,12 @@ get_container_info() {
         if [[ "$relative_path" == iznik-nuxt3/tests/* || "$relative_path" == iznik-nuxt3/playwright.config.js ]]; then
             echo "freegle-playwright /app/${relative_path#iznik-nuxt3/} Playwright"
         else
-            echo "freegle-freegle-dev /app/${relative_path#iznik-nuxt3/} Freegle-Dev"$'\n'"freegle-freegle-prod /app/${relative_path#iznik-nuxt3/} Freegle-Prod"
+            local targets="freegle-freegle-dev /app/${relative_path#iznik-nuxt3/} Freegle-Dev"$'\n'"freegle-freegle-prod /app/${relative_path#iznik-nuxt3/} Freegle-Prod"
+            # Only include dev-live if the container is running
+            if docker ps --format '{{.Names}}' | grep -q '^freegle-dev-live$'; then
+                targets="$targets"$'\n'"freegle-dev-live /app/${relative_path#iznik-nuxt3/} Freegle-Dev-Live"
+            fi
+            echo "$targets"
         fi
     elif [[ "$relative_path" == iznik-server-go/* ]]; then
         echo "freegle-apiv2 /app/${relative_path#iznik-server-go/} API-v2"

--- a/plans/app-dev-environment.md
+++ b/plans/app-dev-environment.md
@@ -1,0 +1,300 @@
+# Freegle Dev App - Live Reload Development Environment
+
+## Overview
+
+A separate "Freegle Dev" app that connects to a local development server for rapid iteration without rebuilding APKs.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  Phone                                                  │
+│  ┌───────────────────┐  ┌───────────────────┐          │
+│  │ Freegle           │  │ Freegle Dev       │          │
+│  │ (Production)      │  │ (Development)     │          │
+│  │                   │  │                   │          │
+│  │ Bundled assets    │  │ Loads from        │          │
+│  │ Works offline     │  │ dev server        │          │
+│  └───────────────────┘  └─────────┬─────────┘          │
+└─────────────────────────────────────┼───────────────────┘
+                                      │ HTTP
+                                      ▼
+┌─────────────────────────────────────────────────────────┐
+│  Developer Machine (Windows + WSL2 + Docker)            │
+│                                                         │
+│  ┌─────────────────────────────────────────────────┐    │
+│  │ Docker: freegle-dev container                   │    │
+│  │ npm run dev (port 3002)                         │    │
+│  │                                                 │    │
+│  │ Hot reload on file changes                      │    │
+│  └─────────────────────────────────────────────────┘    │
+│                                                         │
+│  ┌─────────────────────────────────────────────────┐    │
+│  │ Docker: status container                        │    │
+│  │ Displays QR code with dev server URL            │    │
+│  └─────────────────────────────────────────────────┘    │
+└─────────────────────────────────────────────────────────┘
+```
+
+## App Comparison
+
+| Aspect | Freegle (Production) | Freegle Dev |
+|--------|---------------------|-------------|
+| **Package ID** | `org.ilovefreegle.direct` | `org.ilovefreegle.dev` |
+| **App Name** | Freegle | Freegle Dev |
+| **Icon** | Normal | Orange tint or "DEV" badge |
+| **Assets** | Bundled | From dev server |
+| **Startup** | Normal flow | QR/URL connect screen |
+| **Play Store** | Published | Never published |
+| **Coexistence** | ✓ Both can be installed | ✓ |
+
+## Connection Flow
+
+### First Launch / No Saved Server
+
+```
+┌─────────────────────────────────────────┐
+│                                         │
+│         🔧 Freegle Dev                  │
+│                                         │
+│    Connect to development server        │
+│                                         │
+│         ┌─────────────┐                 │
+│         │             │                 │
+│         │   📷 SCAN   │                 │
+│         │     QR      │                 │
+│         └─────────────┘                 │
+│                                         │
+│    Scan QR code from status page        │
+│                                         │
+│    ─────────── or ───────────           │
+│                                         │
+│    ┌─────────────────────────────┐      │
+│    │ http://                     │      │
+│    └─────────────────────────────┘      │
+│    Enter server URL manually            │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+### Returning User (Has Saved Server)
+
+```
+┌─────────────────────────────────────────┐
+│                                         │
+│         🔧 Freegle Dev                  │
+│                                         │
+│    Last server: 192.168.1.50:3002       │
+│                                         │
+│    ┌─────────────────────────────┐      │
+│    │      [ Reconnect ]          │      │
+│    └─────────────────────────────┘      │
+│                                         │
+│    ┌─────────────────────────────┐      │
+│    │   [ Scan Different QR ]     │      │
+│    └─────────────────────────────┘      │
+│                                         │
+│    Checking connection...               │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+### Connection Successful
+
+App loads normally from dev server. All Capacitor plugins (camera, etc.) work because native code is on device.
+
+### Connection Failed
+
+```
+┌─────────────────────────────────────────┐
+│                                         │
+│    ❌ Cannot reach dev server           │
+│                                         │
+│    http://192.168.1.50:3002             │
+│                                         │
+│    Possible issues:                     │
+│    • Dev server not running             │
+│    • Phone not on same WiFi             │
+│    • Firewall blocking port 3002        │
+│                                         │
+│    ┌─────────────────────────────┐      │
+│    │      [ Try Again ]          │      │
+│    └─────────────────────────────┘      │
+│                                         │
+│    ┌─────────────────────────────┐      │
+│    │   [ Scan Different QR ]     │      │
+│    └─────────────────────────────┘      │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+## Implementation
+
+### 1. Status Container: QR Code Page
+
+**File:** `status/api/dev-qr.js` or dedicated page
+
+```javascript
+// Detect host's LAN IP
+function getLanIp() {
+  const interfaces = require('os').networkInterfaces()
+  for (const name of Object.keys(interfaces)) {
+    for (const iface of interfaces[name]) {
+      if (iface.family === 'IPv4' && !iface.internal) {
+        // Prefer 192.168.x.x or 10.x.x.x
+        if (iface.address.startsWith('192.168.') ||
+            iface.address.startsWith('10.')) {
+          return iface.address
+        }
+      }
+    }
+  }
+  return null
+}
+
+// Generate QR code data
+const devServerUrl = `http://${getLanIp()}:3002`
+```
+
+**UI:** Display QR code encoding the URL, plus text for manual entry.
+
+### 2. Freegle Dev App: Connect Screen
+
+**File:** `components/DevConnectScreen.vue`
+
+Features:
+- QR code scanner (use `@aspect/aspectra` or similar Capacitor plugin)
+- Manual URL input field
+- "Reconnect" button if saved URL exists
+- Connection test before proceeding
+- Store URL in `@capacitor/preferences`
+
+### 3. Capacitor Config for Dev App
+
+**File:** `capacitor.config.dev.ts`
+
+```typescript
+import { CapacitorConfig } from '@capacitor/cli'
+
+const config: CapacitorConfig = {
+  appId: 'org.ilovefreegle.dev',
+  appName: 'Freegle Dev',
+  webDir: 'dist',  // Minimal, connect screen only
+
+  // Server URL set dynamically from saved preference
+  // Not hardcoded here
+
+  plugins: {
+    // Same plugins as production
+  },
+
+  android: {
+    // Allow cleartext HTTP for dev servers
+    allowMixedContent: true,
+  },
+}
+
+export default config
+```
+
+### 4. Build Process
+
+**CircleCI Job:** `build-dev-app`
+
+```yaml
+build-dev-app:
+  executor: android-executor
+  steps:
+    - checkout
+    - run:
+        name: Build dev app connect screen
+        command: |
+          # Build minimal app with just connect screen
+          npm ci
+          npm run build:dev-connect
+    - run:
+        name: Sync Capacitor with dev config
+        command: npx cap sync android --config capacitor.config.dev.ts
+    - run:
+        name: Build debug APK
+        command: |
+          cd android
+          ./gradlew assembleDebug
+    - store_artifacts:
+        path: android/app/build/outputs/apk/debug/app-debug.apk
+        destination: freegle-dev.apk
+```
+
+### 5. Minimal Dev App Bundle
+
+The dev app only needs:
+- Connect screen component
+- QR scanner
+- URL storage
+- WebView that loads from dev server
+
+Everything else comes from the dev server at runtime.
+
+## File Structure
+
+```
+iznik-nuxt3/
+├── capacitor.config.ts          # Production config
+├── capacitor.config.dev.ts      # Dev app config (NEW)
+├── components/
+│   └── DevConnectScreen.vue     # Connect screen (NEW)
+├── pages/
+│   └── _dev-connect.vue         # Dev app entry point (NEW)
+└── scripts/
+    └── build-dev-connect.js     # Build script for minimal bundle (NEW)
+
+FreegleDockerWSL/
+├── status/
+│   ├── api/
+│   │   └── dev-qr.js            # QR code API endpoint (NEW)
+│   └── pages/
+│       └── dev-connect.vue      # QR display page (NEW)
+```
+
+## Usage Workflow
+
+### Developer Setup (One Time)
+
+1. Build dev app via CircleCI: trigger `build-dev-app` job
+2. Download `freegle-dev.apk` from artifacts
+3. Install on Android device (enable "Install from unknown sources")
+
+### Daily Development
+
+1. Start Docker: `docker-compose up -d`
+2. Open status page: `http://status.localhost/dev-connect`
+3. Open Freegle Dev app on phone
+4. Scan QR code (or tap Reconnect if previously connected)
+5. App connects to dev server
+6. Make code changes → app hot reloads instantly
+
+### When Capacitor Plugins Change
+
+Rebuild the dev app APK (plugins are native code, not hot-reloadable).
+
+## iOS Support
+
+Same approach works for iOS:
+- Different Bundle ID: `org.ilovefreegle.dev`
+- Distribute via TestFlight or ad-hoc provisioning
+- Connect screen works identically
+
+## Security Considerations
+
+- Dev app only works on local network (HTTP, not HTTPS)
+- Never publish to Play Store / App Store
+- QR code only shown on status page (localhost access)
+- No sensitive data in dev app bundle
+
+## Future Enhancements
+
+- [ ] Network scan fallback if QR scan fails
+- [ ] Multiple saved servers (home, office, etc.)
+- [ ] Auto-reconnect on app resume
+- [ ] Connection status indicator in app
+- [ ] mDNS discovery if network topology allows

--- a/status/index.html
+++ b/status/index.html
@@ -51,10 +51,13 @@
 
         <h2>🏠 Freegle Components</h2>
 
-        <div style="margin-bottom: 20px;">
+        <div style="margin-bottom: 20px; display: flex; gap: 10px; flex-wrap: wrap; align-items: center;">
             <button id="recreate-test-users" onclick="recreateTestUsers()" style="padding: 10px 20px; background-color: #4CAF50; color: white; border: none; border-radius: 4px; cursor: pointer; font-size: 14px;">
                 🔄 Recreate Test Users
             </button>
+            <a href="/dev-connect" style="padding: 10px 20px; background-color: #5cb85c; color: white; border: none; border-radius: 4px; cursor: pointer; font-size: 14px; text-decoration: none; display: inline-block;">
+                📱 Mobile Dev Connect
+            </a>
             <span id="recreate-status" style="margin-left: 10px; font-weight: bold;"></span>
         </div>
 

--- a/status/server.js
+++ b/status/server.js
@@ -2569,7 +2569,7 @@ const httpServer = http.createServer(async (req, res) => {
 
   <div class="card intro">
     <h3>How Live Reload Works</h3>
-    <p>The Freegle Dev app loads its web content from your local dev server instead of bundled assets. This means code changes appear instantly without rebuilding the APK.</p>
+    <p>The Freegle Dev app loads its web content from your local dev server instead of bundled assets. This means code changes appear instantly without rebuilding the APK, and you can test the same changes via browser and app easily.</p>
     <p style="margin-top: 8px; font-size: 14px; color: #666;"><strong>Android only:</strong> This dev app workflow is for Android. For iOS development, use TestFlight builds.</p>
     <p style="margin-top: 8px; font-size: 14px; color: #666;">The dev app is built automatically on CircleCI and uses a separate package ID (<code>org.ilovefreegle.dev</code>), so it can be installed alongside the production Freegle app on the same device.</p>
 

--- a/status/server.js
+++ b/status/server.js
@@ -2616,43 +2616,40 @@ const httpServer = http.createServer(async (req, res) => {
   </div>
 
   <div class="card">
-    <h3>Requirements</h3>
+    <h3>ADB Setup (Required)</h3>
+    <div class="help">
+      <p style="margin-bottom: 12px;">The dev app uses <code>adb reverse</code> to forward ports from the phone to your dev machine. This avoids needing to install the full Android SDK - just a minimal ADB tool.</p>
+
+      <strong>Step 1: Install Minimal ADB</strong>
+      <p style="margin: 8px 0;">Download and install <a href="https://androidmtk.com/download-minimal-adb-and-fastboot-tool" target="_blank" style="color: #5cb85c;">Minimal ADB and Fastboot</a> (small ~2MB download, no Android SDK needed).</p>
+
+      <strong style="display: block; margin-top: 16px;">Step 2: Connect Phone via USB</strong>
+      <p style="margin: 8px 0;">Connect your Android phone via USB and enable USB debugging in Developer Options.</p>
+
+      <strong style="display: block; margin-top: 16px;">Step 3: Run ADB Reverse Commands</strong>
+      <p style="margin: 8px 0;">Open Command Prompt and run:</p>
+      <pre style="background: #1e1e1e; color: #d4d4d4; padding: 12px; border-radius: 6px; overflow-x: auto; font-size: 13px;">adb reverse tcp:3004 tcp:3004
+adb reverse tcp:24678 tcp:24678</pre>
+      <p style="font-size: 12px; color: #888; margin-top: 4px;">This forwards localhost:3004 and localhost:24678 on the phone to your dev machine. Run these each time you reconnect the phone.</p>
+
+      <strong style="display: block; margin-top: 16px;">Step 4: Start the Dev Server</strong>
+      <p style="margin: 8px 0;">Start the <code>freegle-dev-live</code> container from the <a href="/" style="color: #5cb85c;">status page</a>.</p>
+
+      <strong style="display: block; margin-top: 16px;">Step 5: Open the Dev App</strong>
+      <p style="margin: 8px 0;">Open the Freegle Dev app on your phone. It will connect to localhost:3004 which ADB forwards to your dev machine.</p>
+    </div>
+  </div>
+
+  <div class="card">
+    <h3>Why ADB Reverse?</h3>
     <div class="help">
       <ul style="margin: 0; padding-left: 20px;">
-        <li>Phone must be on the same WiFi network as your computer</li>
-        <li>Start the freegle-dev-live container from the <a href="/" style="color: #5cb85c;">Production tab</a> on the status page</li>
-        <li>Port 3004 must be accessible (check firewall settings below)</li>
+        <li><strong>No Android SDK needed</strong> - Just install Minimal ADB (~2MB)</li>
+        <li><strong>No network configuration</strong> - Works regardless of WiFi/firewall settings</li>
+        <li><strong>Reliable</strong> - Unlike mDNS which Android doesn't resolve well</li>
+        <li><strong>Secure</strong> - Traffic stays on USB, not broadcast over network</li>
       </ul>
-    </div>
-  </div>
-
-  <div class="card">
-    <h3>mDNS Setup (Required for Hot Reload)</h3>
-    <div class="help">
-      <p style="margin-bottom: 12px;">The dev app connects to <code>freegle-app-dev.local</code> via mDNS. You must broadcast this hostname from your dev machine.</p>
-
-      <strong>Option 1: Using Bonjour (Recommended)</strong>
-      <p style="margin: 8px 0;">Install <a href="https://support.apple.com/kb/DL999" target="_blank" style="color: #5cb85c;">Bonjour Print Services</a> from Apple, then run in Command Prompt:</p>
-      <pre style="background: #1e1e1e; color: #d4d4d4; padding: 12px; border-radius: 6px; overflow-x: auto; font-size: 13px;">dns-sd -P "Freegle App Dev" _http._tcp local 3004 freegle-app-dev.local ${devServerHost || "YOUR_IP"}</pre>
-      <p style="font-size: 12px; color: #888; margin-top: 4px;">Keep this window open while developing. Replace YOUR_IP with your actual IP if not auto-detected above.</p>
-
-      <strong style="display: block; margin-top: 16px;">Option 2: Using mDNS Repeater</strong>
-      <p style="margin: 8px 0;">Alternatively, use a tool like <a href="https://github.com/nicholasdille/mdns-repeater" target="_blank" style="color: #5cb85c;">mdns-repeater</a> or configure your router's local DNS.</p>
-    </div>
-  </div>
-
-  <div class="card">
-    <h3>Windows + WSL2 Port Forwarding</h3>
-    <div class="help">
-      <p style="margin: 8px 0;">Run these commands in <strong>PowerShell as Administrator</strong>:</p>
-      <pre style="background: #1e1e1e; color: #d4d4d4; padding: 12px; border-radius: 6px; overflow-x: auto; font-size: 13px;">
-# Port forwarding from Windows to WSL (app + hot reload)
-netsh interface portproxy add v4tov4 listenport=3004 listenaddress=0.0.0.0 connectport=3004 connectaddress=127.0.0.1
-netsh interface portproxy add v4tov4 listenport=24678 listenaddress=0.0.0.0 connectport=24678 connectaddress=127.0.0.1
-
-# Firewall rules to allow incoming connections
-New-NetFirewallRule -DisplayName "WSL Freegle Dev App" -Direction Inbound -LocalPort 3004 -Protocol TCP -Action Allow
-New-NetFirewallRule -DisplayName "WSL Freegle Dev HMR" -Direction Inbound -LocalPort 24678 -Protocol TCP -Action Allow</pre>
+      <p style="margin-top: 12px; font-size: 13px; color: #666;">The only downside is requiring a USB connection, but this is the standard approach for Android development.</p>
     </div>
   </div>
 

--- a/status/server.js
+++ b/status/server.js
@@ -2626,11 +2626,10 @@ const httpServer = http.createServer(async (req, res) => {
       <strong style="display: block; margin-top: 16px;">Step 2: Connect Phone via USB</strong>
       <p style="margin: 8px 0;">Connect your Android phone via USB and enable USB debugging in Developer Options.</p>
 
-      <strong style="display: block; margin-top: 16px;">Step 3: Run ADB Reverse Commands</strong>
+      <strong style="display: block; margin-top: 16px;">Step 3: Run ADB Reverse Command</strong>
       <p style="margin: 8px 0;">Open Command Prompt and run:</p>
-      <pre style="background: #1e1e1e; color: #d4d4d4; padding: 12px; border-radius: 6px; overflow-x: auto; font-size: 13px;">adb reverse tcp:3004 tcp:3004
-adb reverse tcp:24678 tcp:24678</pre>
-      <p style="font-size: 12px; color: #888; margin-top: 4px;">This forwards localhost:3004 and localhost:24678 on the phone to your dev machine. Run these each time you reconnect the phone.</p>
+      <pre style="background: #1e1e1e; color: #d4d4d4; padding: 12px; border-radius: 6px; overflow-x: auto; font-size: 13px;">adb reverse tcp:3004 tcp:3004</pre>
+      <p style="font-size: 12px; color: #888; margin-top: 4px;">This forwards localhost:3004 on the phone to your dev machine. Run this each time you reconnect the phone.</p>
 
       <strong style="display: block; margin-top: 16px;">Step 4: Start the Dev Server</strong>
       <p style="margin: 8px 0;">Start the <code>freegle-dev-live</code> container from the <a href="/" style="color: #5cb85c;">status page</a>.</p>
@@ -2650,6 +2649,27 @@ adb reverse tcp:24678 tcp:24678</pre>
         <li><strong>Secure</strong> - Traffic stays on USB, not broadcast over network</li>
       </ul>
       <p style="margin-top: 12px; font-size: 13px; color: #666;">The only downside is requiring a USB connection, but this is the standard approach for Android development.</p>
+    </div>
+  </div>
+
+  <div class="card">
+    <h3>Known Limitations</h3>
+    <div class="help">
+      <strong>No Hot Module Replacement (HMR)</strong>
+      <p style="margin: 8px 0;">Hot reload doesn't work in the Android WebView due to WebSocket connection issues. After making code changes, tap the refresh icon to reload. This is a known limitation of Capacitor WebView development.</p>
+    </div>
+  </div>
+
+  <div class="card">
+    <h3>Troubleshooting</h3>
+    <div class="help">
+      <strong>App says "Cannot load localhost:3004"</strong>
+      <p style="margin: 8px 0;">The ADB reverse port forwarding resets when you disconnect/reconnect your phone. Re-run the command:</p>
+      <pre style="background: #1e1e1e; color: #d4d4d4; padding: 12px; border-radius: 6px; overflow-x: auto; font-size: 13px;">adb reverse tcp:3004 tcp:3004</pre>
+      <p style="margin-top: 8px; font-size: 13px;">You can check current port forwards with: <code>adb reverse --list</code></p>
+
+      <strong style="display: block; margin-top: 16px;">Phone not detected by ADB</strong>
+      <p style="margin: 8px 0;">Ensure USB debugging is enabled in Developer Options on your phone. You may need to authorize the computer when prompted on the phone.</p>
     </div>
   </div>
 

--- a/status/server.js
+++ b/status/server.js
@@ -2633,7 +2633,7 @@ const httpServer = http.createServer(async (req, res) => {
 
       <strong>Option 1: Using Bonjour (Recommended)</strong>
       <p style="margin: 8px 0;">Install <a href="https://support.apple.com/kb/DL999" target="_blank" style="color: #5cb85c;">Bonjour Print Services</a> from Apple, then run in Command Prompt:</p>
-      <pre style="background: #1e1e1e; color: #d4d4d4; padding: 12px; border-radius: 6px; overflow-x: auto; font-size: 13px;">dns-sd -P "Freegle Dev" _http._tcp local 3004 freegle-app-dev.local ${devServerHost || "YOUR_IP"}</pre>
+      <pre style="background: #1e1e1e; color: #d4d4d4; padding: 12px; border-radius: 6px; overflow-x: auto; font-size: 13px;">dns-sd -P "Freegle App Dev" _http._tcp local 3004 freegle-app-dev.local ${devServerHost || "YOUR_IP"}</pre>
       <p style="font-size: 12px; color: #888; margin-top: 4px;">Keep this window open while developing. Replace YOUR_IP with your actual IP if not auto-detected above.</p>
 
       <strong style="display: block; margin-top: 16px;">Option 2: Using mDNS Repeater</strong>


### PR DESCRIPTION
## Purpose

This PR adds Docker infrastructure to support the **Freegle Dev App** for mobile development with instant hot reload.

## What is the Freegle Dev App?

A separate Android app (`org.ilovefreegle.dev`) that developers install on their phone to test code changes instantly without rebuilding the full APK. The phone connects to a local dev server via mDNS and receives hot module reload (HMR) updates.

## Changes

### New freegle-dev-live Container
- Container profile for mobile app development
- Runs Nuxt dev server on port 3004 (externally accessible to phone)
- Exposes Vite HMR WebSocket on port 24678
- Uses LIVE/production APIs (real Freegle data - caution!)
- Sets `MOBILE_DEV_HMR=true` to enable HMR configuration in nuxt.config.ts

### File Sync Updates
- `file-sync.sh` now syncs to freegle-dev-live container when running
- Conditional check prevents errors when container is stopped

### Status Page Updates  
- Dev Connect page (`/dev-connect`) with mDNS setup instructions
- QR code for easy server URL sharing (though not currently used)
- Corrected mDNS service name to "Freegle App Dev"

## How It Works

1. Developer starts freegle-dev-live container from status page
2. Developer broadcasts `freegle-app-dev.local` via mDNS (Bonjour on Windows)
3. Freegle Dev app on phone resolves hostname and connects
4. Code changes in iznik-nuxt3 are synced to container via file-sync
5. Vite HMR pushes updates to phone instantly

## Test Plan

- [ ] freegle-dev-live container starts successfully
- [ ] Container has MOBILE_DEV_HMR=true in environment
- [ ] file-sync includes dev-live when container is running
- [ ] Status page shows correct mDNS setup instructions
