### PR TITLE
Optimize CI build by skipping dev containers

### DIFF
--- a/.circleci/orb/freegle-tests.yml
+++ b/.circleci/orb/freegle-tests.yml
@@ -199,10 +199,19 @@ commands:
       - run:
           name: Build containers
           command: |
-            # Force rebuild with --pull to get latest base images
-            # This ensures we get the most recent freegle-base with updated dependencies
-            echo "Building and starting services with fresh base images..."
-            docker-compose -f docker-compose.yml build --pull
+            # Pre-pull base image once (avoids multiple registry checks during parallel builds)
+            echo "Pre-pulling base image..."
+            docker pull ghcr.io/freegle/freegle-base:latest
+
+            # Build only containers needed for CI tests (skip dev containers)
+            # This saves ~2-3 minutes by not building freegle-dev-local, modtools-dev-local, ai-support-helper
+            echo "Building CI-required containers..."
+            docker-compose -f docker-compose.yml build \
+              apiv1 apiv1-phpunit apiv2 \
+              freegle-prod-local modtools-prod-local \
+              playwright status batch
+
+            # Start all services
             docker-compose -f docker-compose.yml up -d
 
             echo "Waiting for basic services to start..."
@@ -214,8 +223,8 @@ commands:
             # Verify expected container names exist (fail fast if container_name isn't working)
             echo ""
             echo "=== Verifying container names ==="
-            # All containers that have container_name set in docker-compose.yml
-            ALL_CONTAINERS="freegle-traefik freegle-percona freegle-postgres freegle-phpmyadmin freegle-mailpit freegle-beanstalkd freegle-spamassassin freegle-redis freegle-delivery freegle-tusd freegle-status freegle-host-scripts freegle-apiv1 freegle-apiv1-phpunit freegle-apiv2 freegle-batch freegle-dev-local freegle-prod-local modtools-dev-local modtools-prod-local freegle-playwright"
+            # Containers needed for CI tests (dev containers excluded as they're not used in tests)
+            ALL_CONTAINERS="freegle-traefik freegle-percona freegle-postgres freegle-phpmyadmin freegle-mailpit freegle-beanstalkd freegle-spamassassin freegle-redis freegle-delivery freegle-tusd freegle-status freegle-host-scripts freegle-apiv1 freegle-apiv1-phpunit freegle-apiv2 freegle-batch freegle-prod-local modtools-prod-local freegle-playwright"
             MISSING=""
             for container in $ALL_CONTAINERS; do
               if docker inspect "$container" >/dev/null 2>&1; then

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -226,9 +226,7 @@ services:
     shm_size: 1gb
     depends_on:
       - tusd
-      - freegle-dev-local
       - freegle-prod-local
-      - modtools-dev-local
       - modtools-prod-local
     extra_hosts:
       - "tusd.localhost:host-gateway"
@@ -901,8 +899,6 @@ services:
       - ENABLE_MONOCART_REPORTER=true
       - COVERALLS_REPO_TOKEN=${COVERALLS_REPO_TOKEN:-}
     depends_on:
-      freegle-dev-local:
-        condition: service_started
       freegle-prod-local:
         condition: service_started
       modtools-prod-local:

--- a/iznik-batch/app/Console/Commands/Chat/NotifyUser2ModCommand.php
+++ b/iznik-batch/app/Console/Commands/Chat/NotifyUser2ModCommand.php
@@ -34,14 +34,6 @@ class NotifyUser2ModCommand extends Command
      */
     public function handle(ChatNotificationService $notificationService, EmailSpoolerService $spooler): int
     {
-        // Check if User2Mod notifications are enabled.
-        // This allows safe deployment - test with mail:test first, then enable when ready.
-        if (!config('freegle.chat_notifications.user2mod_enabled', false)) {
-            $this->warn('User2Mod notifications are disabled. Set USER2MOD_NOTIFICATIONS_ENABLED=true to enable.');
-            Log::info('User2Mod notifications disabled by config');
-            return Command::SUCCESS;
-        }
-
         $chatId = $this->option('chat') ? (int) $this->option('chat') : null;
         $delay = (int) $this->option('delay');
         $sinceHours = (int) $this->option('since');

--- a/iznik-batch/app/Console/Commands/Data/ClassifyAppReleaseCommand.php
+++ b/iznik-batch/app/Console/Commands/Data/ClassifyAppReleaseCommand.php
@@ -1,0 +1,180 @@
+<?php
+
+namespace App\Console\Commands\Data;
+
+use App\Services\AppReleaseClassifierService;
+use App\Traits\GracefulShutdown;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Command to classify app release urgency and optionally send notification.
+ *
+ * This is used by CircleCI to determine whether to promote a beta release
+ * to production immediately or batch it for the weekly release.
+ *
+ * Exit codes:
+ *   0 = Success (classification determined)
+ *   1 = Error (classification failed)
+ *
+ * Use --json to get machine-readable output for CI integration.
+ */
+class ClassifyAppReleaseCommand extends Command
+{
+    use GracefulShutdown;
+
+    /**
+     * The name and signature of the console command.
+     */
+    protected $signature = 'data:classify-app-release
+                            {--sha= : Current commit SHA to classify}
+                            {--notify : Send notification email}
+                            {--force-notify : Send notification even if within interval}
+                            {--json : Output result as JSON}
+                            {--mark-released : Mark current SHA as released to production}';
+
+    /**
+     * The console command description.
+     */
+    protected $description = 'Classify app release urgency (URGENT, CAN_WAIT, NO_CHANGES)';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(AppReleaseClassifierService $service): int
+    {
+        $this->registerShutdownHandlers();
+
+        $sha = $this->option('sha');
+        $notify = $this->option('notify');
+        $forceNotify = $this->option('force-notify');
+        $jsonOutput = $this->option('json');
+        $markReleased = $this->option('mark-released');
+
+        // If just marking as released, do that and exit.
+        if ($markReleased) {
+            if (!$sha) {
+                $this->error('--sha is required with --mark-released');
+                return Command::FAILURE;
+            }
+            $service->saveLastProductionSha($sha);
+            $this->info("Marked SHA {$sha} as released to production.");
+            return Command::SUCCESS;
+        }
+
+        Log::info('ClassifyAppReleaseCommand: Starting', [
+            'sha' => $sha,
+            'notify' => $notify,
+        ]);
+
+        try {
+            $result = $service->classify($sha);
+
+            if ($jsonOutput) {
+                $this->line(json_encode([
+                    'classification' => $result['classification'],
+                    'reason' => $result['reason'],
+                    'should_promote' => $result['should_promote'],
+                    'commit_count' => count($result['commits']),
+                    'urgent_count' => count($result['urgent_commits']),
+                ], JSON_PRETTY_PRINT));
+            } else {
+                $this->displayResult($result);
+            }
+
+            // Send notification only for URGENT (hotfix) commits.
+            // We don't need to email for CAN_WAIT or NO_CHANGES.
+            if (($notify || $forceNotify) && $result['classification'] === AppReleaseClassifierService::CLASSIFICATION_URGENT) {
+                $sent = $service->sendNotification($result, $forceNotify);
+                if ($sent) {
+                    $this->info('Notification email sent - hotfix detected!');
+                } else {
+                    $this->warn('Notification not sent (within rate limit interval).');
+                }
+            }
+
+            // Output for CI integration - set environment variable.
+            // CircleCI can capture this from stdout.
+            if ($jsonOutput) {
+                // JSON mode - caller parses JSON.
+            } else {
+                $this->newLine();
+                $this->line("CLASSIFICATION={$result['classification']}");
+                $this->line("SHOULD_PROMOTE=" . ($result['should_promote'] ? 'true' : 'false'));
+            }
+
+            return Command::SUCCESS;
+
+        } catch (\Exception $e) {
+            Log::error('ClassifyAppReleaseCommand: Failed', [
+                'error' => $e->getMessage(),
+            ]);
+
+            if ($jsonOutput) {
+                $this->line(json_encode([
+                    'error' => $e->getMessage(),
+                    'classification' => null,
+                ]));
+            } else {
+                $this->error('Classification failed: ' . $e->getMessage());
+            }
+
+            return Command::FAILURE;
+        }
+    }
+
+    /**
+     * Display the classification result in a human-readable format.
+     */
+    protected function displayResult(array $result): void
+    {
+        $classification = $result['classification'];
+        $reason = $result['reason'];
+        $commits = $result['commits'];
+        $urgentCommits = $result['urgent_commits'];
+
+        $icon = match ($classification) {
+            AppReleaseClassifierService::CLASSIFICATION_URGENT => '🚨',
+            AppReleaseClassifierService::CLASSIFICATION_CAN_WAIT => '📦',
+            AppReleaseClassifierService::CLASSIFICATION_NO_CHANGES => 'ℹ️',
+        };
+
+        $this->newLine();
+        $this->line("{$icon} Classification: <comment>{$classification}</comment>");
+        $this->line("   Reason: {$reason}");
+        $this->line("   Commits since last production: " . count($commits));
+
+        if ($result['should_promote']) {
+            $this->newLine();
+            $this->info('➡️  Recommendation: Promote to production immediately');
+        } else {
+            $this->newLine();
+            $this->comment('➡️  Recommendation: Batch for Wednesday night release');
+        }
+
+        if (!empty($urgentCommits)) {
+            $this->newLine();
+            $this->line('Urgent commits:');
+            foreach ($urgentCommits as $commit) {
+                $shortHash = substr($commit['hash'], 0, 8);
+                $this->line("  - <info>{$shortHash}</info>: {$commit['message']}");
+            }
+        }
+
+        if (!empty($commits) && count($commits) <= 10) {
+            $this->newLine();
+            $this->line('All commits:');
+            foreach ($commits as $commit) {
+                $shortHash = substr($commit['hash'], 0, 8);
+                $this->line("  - {$commit['date']} <info>{$shortHash}</info>: {$commit['message']}");
+            }
+        } elseif (count($commits) > 10) {
+            $this->newLine();
+            $this->line("Showing first 10 of " . count($commits) . " commits:");
+            foreach (array_slice($commits, 0, 10) as $commit) {
+                $shortHash = substr($commit['hash'], 0, 8);
+                $this->line("  - {$commit['date']} <info>{$shortHash}</info>: {$commit['message']}");
+            }
+        }
+    }
+}

--- a/iznik-batch/app/Console/Commands/Data/GitSummaryCommand.php
+++ b/iznik-batch/app/Console/Commands/Data/GitSummaryCommand.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Console\Commands\Data;
+
+use App\Services\GitSummaryService;
+use App\Traits\GracefulShutdown;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Command to generate and send AI-powered git commit summaries.
+ *
+ * This replaces the PHP script at iznik-server/scripts/cron/git_summary_ai.php.
+ * Summaries are sent to Discourse via email-to-forum integration.
+ */
+class GitSummaryCommand extends Command
+{
+    use GracefulShutdown;
+
+    /**
+     * The name and signature of the console command.
+     */
+    protected $signature = 'data:git-summary
+                            {--since= : Override since date (YYYY-MM-DD or relative like "-3 days")}
+                            {--email= : Override recipient email address}
+                            {--dry-run : Generate report but do not send email or update timestamp}';
+
+    /**
+     * The console command description.
+     */
+    protected $description = 'Generate and send AI-powered git commit summary to Discourse';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(GitSummaryService $service): int
+    {
+        $this->registerShutdownHandlers();
+
+        $sinceOverride = $this->option('since');
+        $emailOverride = $this->option('email');
+        $dryRun = $this->option('dry-run');
+
+        Log::info('GitSummaryCommand: Starting', [
+            'since_override' => $sinceOverride,
+            'email_override' => $emailOverride,
+            'dry_run' => $dryRun,
+        ]);
+
+        if ($dryRun) {
+            $this->info('Dry run mode - will not send email or update timestamp');
+            $report = $service->generateReport($sinceOverride);
+
+            $this->info("Changes since: {$report['since_date']}");
+            $this->info("Repositories with changes: " . count($report['changes']));
+
+            $totalCommits = array_sum(array_map(fn($c) => count($c['commits']), $report['changes']));
+            $this->info("Total commits: {$totalCommits}");
+
+            if (isset($report['summary'])) {
+                $this->newLine();
+                $this->line('=== AI Summary ===');
+                $this->line($report['summary']);
+            }
+
+            return Command::SUCCESS;
+        }
+
+        $result = $service->sendReport($sinceOverride, $emailOverride);
+
+        if ($result['success']) {
+            $this->info('Git summary report sent successfully.');
+            $this->info("Recipient: " . ($emailOverride ?? config('freegle.git_summary.discourse_email')));
+            $this->info("Changes since: {$result['report']['since_date']}");
+
+            $totalCommits = array_sum(array_map(fn($c) => count($c['commits']), $result['report']['changes']));
+            $this->info("Total commits: {$totalCommits}");
+
+            return Command::SUCCESS;
+        }
+
+        $this->error('Failed to send git summary: ' . $result['message']);
+        return Command::FAILURE;
+    }
+}

--- a/iznik-batch/app/Services/AppReleaseClassifierService.php
+++ b/iznik-batch/app/Services/AppReleaseClassifierService.php
@@ -1,0 +1,435 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Mail;
+
+/**
+ * Service for classifying app release urgency and managing release scheduling.
+ *
+ * This service determines whether an app release should be promoted to production
+ * immediately (urgent) or batched for the weekly release (Wednesday night).
+ *
+ * Classification is based on commit message prefixes following Conventional Commits:
+ * - `hotfix:` prefix → URGENT (promote immediately)
+ * - All other commits → CAN_WAIT (batch for Wednesday night)
+ *
+ * Note: Beta releases (TestFlight/Google Play Beta) always happen immediately.
+ * This service only gates the PROMOTION to production stores.
+ */
+class AppReleaseClassifierService
+{
+    /**
+     * Classification result constants.
+     */
+    public const CLASSIFICATION_URGENT = 'URGENT';
+    public const CLASSIFICATION_CAN_WAIT = 'CAN_WAIT';
+    public const CLASSIFICATION_NO_CHANGES = 'NO_CHANGES';
+
+    /**
+     * Config table keys.
+     */
+    protected const CONFIG_KEY_LAST_PRODUCTION_SHA = 'app_release_last_production_sha';
+    protected const CONFIG_KEY_LAST_NOTIFICATION = 'app_release_last_notification';
+
+    /**
+     * Notification email address.
+     */
+    protected string $notificationEmail;
+
+    public function __construct()
+    {
+        $this->notificationEmail = config('freegle.app_release.notification_email', 'geek-alerts@ilovefreegle.org');
+    }
+
+    /**
+     * Get the SHA of the last production release.
+     */
+    public function getLastProductionSha(): ?string
+    {
+        try {
+            $row = DB::table('config')
+                ->where('key', self::CONFIG_KEY_LAST_PRODUCTION_SHA)
+                ->first();
+
+            return $row ? $row->value : null;
+        } catch (\Exception $e) {
+            Log::warning('AppReleaseClassifierService: Failed to get last production SHA', [
+                'error' => $e->getMessage(),
+            ]);
+            return null;
+        }
+    }
+
+    /**
+     * Save the SHA of the last production release.
+     */
+    public function saveLastProductionSha(string $sha): void
+    {
+        DB::statement(
+            "INSERT INTO config (`key`, value) VALUES (?, ?) ON DUPLICATE KEY UPDATE value = ?",
+            [self::CONFIG_KEY_LAST_PRODUCTION_SHA, $sha, $sha]
+        );
+    }
+
+    /**
+     * Get commits since the last production release.
+     *
+     * @param string|null $currentSha Current commit SHA (if known).
+     * @return array Array of commits with hash, author, date, message.
+     */
+    public function getCommitsSinceLastProduction(?string $currentSha = null): array
+    {
+        $lastSha = $this->getLastProductionSha();
+
+        $tempDir = sys_get_temp_dir() . '/iznik_release_' . uniqid();
+        mkdir($tempDir);
+
+        try {
+            // Clone the production branch.
+            $repoUrl = 'https://github.com/Freegle/iznik-nuxt3.git';
+            $branch = 'production';
+
+            $cloneCmd = sprintf(
+                'git clone --single-branch --branch %s %s %s 2>&1',
+                escapeshellarg($branch),
+                escapeshellarg($repoUrl),
+                escapeshellarg($tempDir)
+            );
+            exec($cloneCmd, $output, $return);
+
+            if ($return !== 0) {
+                Log::error('AppReleaseClassifierService: Failed to clone repository', [
+                    'output' => implode("\n", $output),
+                ]);
+                return [];
+            }
+
+            $cwd = getcwd();
+            chdir($tempDir);
+
+            // Get the current HEAD SHA if not provided.
+            if ($currentSha === null) {
+                exec('git rev-parse HEAD', $headOutput);
+                $currentSha = trim($headOutput[0] ?? '');
+            }
+
+            // Get commits since last production release.
+            if ($lastSha) {
+                $logCmd = sprintf(
+                    'git log %s..%s --pretty=format:"%%H|%%an|%%ad|%%s" --date=short 2>&1',
+                    escapeshellarg($lastSha),
+                    escapeshellarg($currentSha)
+                );
+            } else {
+                // No previous release - get last 7 days of commits.
+                $logCmd = 'git log --since="-7 days" --pretty=format:"%H|%an|%ad|%s" --date=short 2>&1';
+            }
+
+            exec($logCmd, $commits, $return);
+            chdir($cwd);
+
+            if (empty($commits)) {
+                return [];
+            }
+
+            return array_map(function ($commit) {
+                $parts = explode('|', $commit, 4);
+                return [
+                    'hash' => $parts[0] ?? '',
+                    'author' => $parts[1] ?? '',
+                    'date' => $parts[2] ?? '',
+                    'message' => $parts[3] ?? '',
+                ];
+            }, $commits);
+
+        } finally {
+            exec(sprintf('rm -rf %s', escapeshellarg($tempDir)));
+        }
+    }
+
+    /**
+     * Find commits with the hotfix: prefix (Conventional Commits standard).
+     *
+     * @param array $commits Array of commits.
+     * @return array All hotfix commits found.
+     */
+    public function findHotfixCommits(array $commits): array
+    {
+        $hotfixCommits = [];
+
+        foreach ($commits as $commit) {
+            $message = trim($commit['message']);
+            // Check for hotfix: prefix (case-insensitive)
+            if (preg_match('/^hotfix:/i', $message)) {
+                $hotfixCommits[] = $commit;
+            }
+        }
+
+        return $hotfixCommits;
+    }
+
+    /**
+     * Classify commits and determine if production release is needed.
+     *
+     * Classification is simple:
+     * - If any commit has `hotfix:` prefix → URGENT
+     * - Otherwise → CAN_WAIT (batch for Wednesday night)
+     *
+     * @param string|null $currentSha Current commit SHA.
+     * @return array Classification result.
+     */
+    public function classify(?string $currentSha = null): array
+    {
+        $commits = $this->getCommitsSinceLastProduction($currentSha);
+
+        // No changes since last production release.
+        if (empty($commits)) {
+            return [
+                'classification' => self::CLASSIFICATION_NO_CHANGES,
+                'reason' => 'No commits since last production release',
+                'commits' => [],
+                'urgent_commits' => [],
+                'should_promote' => false,
+            ];
+        }
+
+        Log::info('AppReleaseClassifierService: Classifying commits', [
+            'count' => count($commits),
+        ]);
+
+        // Check for hotfix: prefix (Conventional Commits standard).
+        $hotfixCommits = $this->findHotfixCommits($commits);
+
+        if (!empty($hotfixCommits)) {
+            $hotfixMessages = array_map(fn($c) => $c['message'], $hotfixCommits);
+            return [
+                'classification' => self::CLASSIFICATION_URGENT,
+                'reason' => 'Hotfix commits detected: ' . implode(', ', $hotfixMessages),
+                'commits' => $commits,
+                'urgent_commits' => $hotfixCommits,
+                'should_promote' => true,
+            ];
+        }
+
+        // No hotfix commits - batch for Wednesday.
+        return [
+            'classification' => self::CLASSIFICATION_CAN_WAIT,
+            'reason' => 'No hotfix: commits found - batching for Wednesday night release',
+            'commits' => $commits,
+            'urgent_commits' => [],
+            'should_promote' => false,
+        ];
+    }
+
+    /**
+     * Check if enough time has passed since the last notification.
+     */
+    protected function canSendNotification(): bool
+    {
+        try {
+            $row = DB::table('config')
+                ->where('key', self::CONFIG_KEY_LAST_NOTIFICATION)
+                ->first();
+
+            if (!$row) {
+                return true;
+            }
+
+            $lastNotification = (int) $row->value;
+            $interval = config('freegle.app_release.notification_interval', 3600);
+
+            return (time() - $lastNotification) >= $interval;
+        } catch (\Exception $e) {
+            return true;
+        }
+    }
+
+    /**
+     * Update the last notification timestamp.
+     */
+    protected function updateNotificationTimestamp(): void
+    {
+        $timestamp = (string) time();
+
+        DB::statement(
+            "INSERT INTO config (`key`, value) VALUES (?, ?) ON DUPLICATE KEY UPDATE value = ?",
+            [self::CONFIG_KEY_LAST_NOTIFICATION, $timestamp, $timestamp]
+        );
+    }
+
+    /**
+     * Send notification email about the classification.
+     *
+     * @param array $result Classification result.
+     * @param bool $force Force sending even if within interval.
+     * @return bool Whether the notification was sent.
+     */
+    public function sendNotification(array $result, bool $force = false): bool
+    {
+        if (!$force && !$this->canSendNotification()) {
+            Log::info('AppReleaseClassifierService: Skipping notification (within interval)');
+            return false;
+        }
+
+        $classification = $result['classification'];
+        $reason = $result['reason'];
+        $commitCount = count($result['commits'] ?? []);
+        $urgentCount = count($result['urgent_commits'] ?? []);
+
+        $subject = match ($classification) {
+            self::CLASSIFICATION_URGENT => "🚨 App Release: URGENT - Immediate promotion recommended",
+            self::CLASSIFICATION_CAN_WAIT => "📦 App Release: Batched for Wednesday",
+            self::CLASSIFICATION_NO_CHANGES => "ℹ️ App Release: No changes to promote",
+        };
+
+        $body = "App Release Classification Report\n";
+        $body .= "================================\n\n";
+        $body .= "Classification: {$classification}\n";
+        $body .= "Reason: {$reason}\n";
+        $body .= "Commits since last production: {$commitCount}\n";
+
+        if ($urgentCount > 0) {
+            $body .= "Urgent commits: {$urgentCount}\n\n";
+            $body .= "Urgent commit details:\n";
+            foreach ($result['urgent_commits'] as $commit) {
+                $body .= "  - {$commit['hash']}: {$commit['message']}\n";
+            }
+        }
+
+        $body .= "\n";
+
+        if ($commitCount > 0 && $commitCount <= 20) {
+            $body .= "All commits:\n";
+            foreach ($result['commits'] as $commit) {
+                $body .= "  - {$commit['date']} {$commit['hash']}: {$commit['message']}\n";
+            }
+        } elseif ($commitCount > 20) {
+            $body .= "Recent commits (showing first 20 of {$commitCount}):\n";
+            foreach (array_slice($result['commits'], 0, 20) as $commit) {
+                $body .= "  - {$commit['date']} {$commit['hash']}: {$commit['message']}\n";
+            }
+        }
+
+        $body .= "\n---\n";
+        $body .= "Generated: " . date('Y-m-d H:i:s') . "\n";
+
+        if ($classification === self::CLASSIFICATION_URGENT) {
+            $body .= "\nTo manually trigger production promotion, go to CircleCI and trigger a new pipeline with parameter:\n";
+            $body .= "  run_manual_promote = true\n";
+        }
+
+        try {
+            Mail::raw($body, function ($message) use ($subject) {
+                $message->to($this->notificationEmail)
+                    ->from(config('mail.from.address'), config('mail.from.name'))
+                    ->subject($subject);
+            });
+
+            $this->updateNotificationTimestamp();
+
+            Log::info('AppReleaseClassifierService: Notification sent', [
+                'classification' => $classification,
+                'to' => $this->notificationEmail,
+            ]);
+
+            return true;
+
+        } catch (\Exception $e) {
+            Log::error('AppReleaseClassifierService: Failed to send notification', [
+                'error' => $e->getMessage(),
+            ]);
+            return false;
+        }
+    }
+
+    /**
+     * Trigger a CircleCI pipeline for manual promotion.
+     *
+     * @return array Result with 'success' and 'message'.
+     */
+    public function triggerManualPromotion(): array
+    {
+        $token = config('freegle.app_release.circleci_token');
+        $project = config('freegle.app_release.circleci_project');
+
+        if (empty($token)) {
+            return [
+                'success' => false,
+                'message' => 'CircleCI token not configured',
+            ];
+        }
+
+        try {
+            $response = Http::withToken($token)
+                ->timeout(30)
+                ->post("https://circleci.com/api/v2/project/{$project}/pipeline", [
+                    'branch' => 'production',
+                    'parameters' => [
+                        'run_manual_promote' => true,
+                    ],
+                ]);
+
+            if ($response->successful()) {
+                $data = $response->json();
+                return [
+                    'success' => true,
+                    'message' => "Pipeline triggered: {$data['id']}",
+                    'pipeline_id' => $data['id'],
+                ];
+            }
+
+            return [
+                'success' => false,
+                'message' => "CircleCI API error: " . $response->status(),
+            ];
+
+        } catch (\Exception $e) {
+            return [
+                'success' => false,
+                'message' => $e->getMessage(),
+            ];
+        }
+    }
+
+    /**
+     * Check the days since last production release.
+     */
+    public function daysSinceLastProduction(): ?int
+    {
+        try {
+            $row = DB::table('config')
+                ->where('key', self::CONFIG_KEY_LAST_PRODUCTION_SHA)
+                ->first();
+
+            if (!$row) {
+                return null;
+            }
+
+            // We store SHA, not timestamp. Need to check git for the date.
+            // For now, return null to indicate we need to track this differently.
+            return null;
+        } catch (\Exception $e) {
+            return null;
+        }
+    }
+
+    /**
+     * Determine if it's time for the weekly scheduled release (Wednesday night).
+     *
+     * @param string|null $now Override current time for testing.
+     * @return bool
+     */
+    public function isWeeklyReleaseTime(?string $now = null): bool
+    {
+        $timestamp = $now ? strtotime($now) : time();
+        $dayOfWeek = (int) date('N', $timestamp); // 1 = Monday, 7 = Sunday
+        $hour = (int) date('G', $timestamp);
+
+        // Wednesday (3) at night (after 10 PM UTC).
+        return $dayOfWeek === 3 && $hour >= 22;
+    }
+}

--- a/iznik-batch/app/Services/ChatNotificationService.php
+++ b/iznik-batch/app/Services/ChatNotificationService.php
@@ -225,11 +225,12 @@ class ChatNotificationService
                 }
             }
 
-            // User2Mod: Get all group moderators.
+            // User2Mod: Get active group moderators (not backup mods).
+            // Backup mods have settings['active'] = false and shouldn't receive notifications.
             $group = $chatRoom->group;
             if ($group) {
                 $moderators = $group->memberships()
-                    ->whereIn('role', ['Moderator', 'Owner'])
+                    ->activeModerators()
                     ->get();
 
                 foreach ($moderators as $membership) {

--- a/iznik-batch/app/Services/GeminiService.php
+++ b/iznik-batch/app/Services/GeminiService.php
@@ -1,0 +1,217 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Service for interacting with Google Gemini API.
+ *
+ * Provides AI-powered text analysis for git summaries and release classification.
+ */
+class GeminiService
+{
+    /**
+     * Gemini API base URL.
+     */
+    protected const API_BASE_URL = 'https://generativelanguage.googleapis.com/v1beta';
+
+    /**
+     * API key for authentication.
+     */
+    protected string $apiKey;
+
+    /**
+     * Cached model name.
+     */
+    protected ?string $cachedModel = null;
+
+    public function __construct()
+    {
+        $this->apiKey = config('freegle.git_summary.gemini_api_key', '');
+    }
+
+    /**
+     * Check if the service is configured with an API key.
+     */
+    public function isConfigured(): bool
+    {
+        return !empty($this->apiKey);
+    }
+
+    /**
+     * Get the best available Gemini Flash model dynamically.
+     *
+     * Queries the API to find the latest flash model for speed and cost efficiency.
+     */
+    public function getModel(): string
+    {
+        if ($this->cachedModel !== null) {
+            return $this->cachedModel;
+        }
+
+        try {
+            $response = Http::timeout(30)
+                ->get(self::API_BASE_URL . '/models', [
+                    'key' => $this->apiKey,
+                ]);
+
+            if (!$response->successful()) {
+                Log::warning('GeminiService: Failed to list models', [
+                    'status' => $response->status(),
+                ]);
+                $this->cachedModel = 'gemini-pro';
+                return $this->cachedModel;
+            }
+
+            $models = $response->json('models', []);
+            $flashModels = [];
+
+            foreach ($models as $model) {
+                $modelName = $model['name'] ?? '';
+                $supportedMethods = $model['supportedGenerationMethods'] ?? [];
+
+                // Look for flash models that support text generation.
+                if (
+                    stripos($modelName, 'flash') !== false &&
+                    stripos($modelName, 'gemini') !== false &&
+                    stripos($modelName, 'exp') === false && // Exclude experimental.
+                    stripos($modelName, 'vision') === false && // Exclude vision-only.
+                    in_array('generateContent', $supportedMethods)
+                ) {
+                    // Extract version number for sorting (e.g., 2.0, 1.5).
+                    $version = 0;
+                    if (preg_match('/gemini-(\d+)\.(\d+)-flash/i', $modelName, $matches)) {
+                        $version = floatval($matches[1] . '.' . $matches[2]);
+                    }
+
+                    $flashModels[] = [
+                        'name' => $modelName,
+                        'display' => $model['displayName'] ?? $modelName,
+                        'version' => $version,
+                    ];
+                }
+            }
+
+            if (empty($flashModels)) {
+                Log::warning('GeminiService: No flash models found, using fallback');
+                $this->cachedModel = 'gemini-pro';
+                return $this->cachedModel;
+            }
+
+            // Sort by version descending to get the latest.
+            usort($flashModels, fn($a, $b) => $b['version'] <=> $a['version']);
+
+            $selectedModel = $flashModels[0];
+
+            // Remove 'models/' prefix if present.
+            $modelName = $selectedModel['name'];
+            if (str_starts_with($modelName, 'models/')) {
+                $modelName = substr($modelName, 7);
+            }
+
+            Log::info('GeminiService: Using model', [
+                'model' => $modelName,
+                'display' => $selectedModel['display'],
+            ]);
+
+            $this->cachedModel = $modelName;
+            return $this->cachedModel;
+
+        } catch (\Exception $e) {
+            Log::error('GeminiService: Error listing models', [
+                'error' => $e->getMessage(),
+            ]);
+            $this->cachedModel = 'gemini-pro';
+            return $this->cachedModel;
+        }
+    }
+
+    /**
+     * Generate content using the Gemini API.
+     *
+     * @param string $prompt The prompt to send to the model.
+     * @return string|null The generated text, or null on failure.
+     */
+    public function generateContent(string $prompt): ?string
+    {
+        if (!$this->isConfigured()) {
+            Log::error('GeminiService: API key not configured');
+            return null;
+        }
+
+        try {
+            $model = $this->getModel();
+            $url = self::API_BASE_URL . '/models/' . $model . ':generateContent?key=' . $this->apiKey;
+
+            $response = Http::timeout(120)
+                ->post($url, [
+                    'contents' => [
+                        [
+                            'parts' => [
+                                ['text' => $prompt],
+                            ],
+                        ],
+                    ],
+                ]);
+
+            if (!$response->successful()) {
+                Log::error('GeminiService: API request failed', [
+                    'status' => $response->status(),
+                    'body' => $response->body(),
+                ]);
+                return null;
+            }
+
+            $data = $response->json();
+            $text = $data['candidates'][0]['content']['parts'][0]['text'] ?? null;
+
+            if (empty($text)) {
+                Log::warning('GeminiService: Empty response from API');
+                return null;
+            }
+
+            return $text;
+
+        } catch (\Exception $e) {
+            Log::error('GeminiService: Error generating content', [
+                'error' => $e->getMessage(),
+            ]);
+            return null;
+        }
+    }
+
+    /**
+     * Generate content and parse as JSON.
+     *
+     * @param string $prompt The prompt to send to the model.
+     * @return array|null The parsed JSON, or null on failure.
+     */
+    public function generateJson(string $prompt): ?array
+    {
+        $text = $this->generateContent($prompt);
+
+        if ($text === null) {
+            return null;
+        }
+
+        // Extract JSON from the response (may be wrapped in markdown code block).
+        if (preg_match('/```json\s*(.*?)\s*```/s', $text, $matches)) {
+            $text = $matches[1];
+        } elseif (preg_match('/```\s*(.*?)\s*```/s', $text, $matches)) {
+            $text = $matches[1];
+        }
+
+        try {
+            $json = json_decode(trim($text), true, 512, JSON_THROW_ON_ERROR);
+            return $json;
+        } catch (\JsonException $e) {
+            Log::warning('GeminiService: Failed to parse JSON response', [
+                'error' => $e->getMessage(),
+                'text' => substr($text, 0, 500),
+            ]);
+            return null;
+        }
+    }
+}

--- a/iznik-batch/app/Services/GitSummaryService.php
+++ b/iznik-batch/app/Services/GitSummaryService.php
@@ -1,0 +1,566 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Mail;
+
+/**
+ * Service for generating AI-powered git commit summaries.
+ *
+ * Analyzes commits across multiple repositories and generates human-readable
+ * summaries organized by user impact. Summaries can be sent to Discourse
+ * via email-to-forum integration.
+ */
+class GitSummaryService
+{
+    /**
+     * Config table key for storing last run timestamp.
+     */
+    protected const CONFIG_KEY_LAST_RUN = 'git_summary_last_run';
+
+    /**
+     * Gemini service for AI summarization.
+     */
+    protected GeminiService $gemini;
+
+    /**
+     * GeekAlerts email address for failure notifications.
+     */
+    protected string $geekAlertsEmail;
+
+    public function __construct(GeminiService $gemini)
+    {
+        $this->gemini = $gemini;
+        $this->geekAlertsEmail = config('freegle.mail.geek_alerts_addr', 'geek-alerts@ilovefreegle.org');
+    }
+
+    /**
+     * Get the last run timestamp, defaulting to max days back.
+     *
+     * @param string|null $override Override date (YYYY-MM-DD or relative like '-3 days').
+     * @return int Unix timestamp.
+     */
+    public function getLastRunTime(?string $override = null): int
+    {
+        if ($override !== null) {
+            return strtotime($override);
+        }
+
+        try {
+            $row = DB::table('config')
+                ->where('key', self::CONFIG_KEY_LAST_RUN)
+                ->first();
+
+            if ($row && !empty($row->value)) {
+                $lastRun = (int) $row->value;
+
+                // Ensure we don't go back more than max days.
+                $maxDaysBack = config('freegle.git_summary.max_days_back', 7);
+                $maxBack = time() - ($maxDaysBack * 24 * 60 * 60);
+                if ($lastRun < $maxBack) {
+                    $lastRun = $maxBack;
+                }
+
+                return $lastRun;
+            }
+        } catch (\Exception $e) {
+            Log::warning('GitSummaryService: Failed to read last run time', [
+                'error' => $e->getMessage(),
+            ]);
+        }
+
+        // Default to max days back.
+        $maxDaysBack = config('freegle.git_summary.max_days_back', 7);
+        return time() - ($maxDaysBack * 24 * 60 * 60);
+    }
+
+    /**
+     * Save the current run timestamp.
+     */
+    public function saveRunTime(): void
+    {
+        $timestamp = (string) time();
+
+        DB::statement(
+            "INSERT INTO config (`key`, value) VALUES (?, ?) ON DUPLICATE KEY UPDATE value = ?",
+            [self::CONFIG_KEY_LAST_RUN, $timestamp, $timestamp]
+        );
+    }
+
+    /**
+     * Get commits and diffs for a repository since a given time.
+     *
+     * @param string $repoUrl Repository URL.
+     * @param string $branch Branch name.
+     * @param int $since Unix timestamp.
+     * @return array|null Repository changes or null if no changes.
+     */
+    public function getRepositoryChanges(string $repoUrl, string $branch, int $since): ?array
+    {
+        $tempDir = sys_get_temp_dir() . '/iznik_git_' . uniqid();
+        mkdir($tempDir);
+
+        try {
+            // Clone the repository.
+            $cloneCmd = sprintf(
+                'git clone --single-branch --branch %s %s %s 2>&1',
+                escapeshellarg($branch),
+                escapeshellarg($repoUrl),
+                escapeshellarg($tempDir)
+            );
+            exec($cloneCmd, $output, $return);
+
+            if ($return !== 0) {
+                Log::error('GitSummaryService: Failed to clone repository', [
+                    'url' => $repoUrl,
+                    'branch' => $branch,
+                    'output' => implode("\n", $output),
+                ]);
+                return null;
+            }
+
+            $cwd = getcwd();
+            chdir($tempDir);
+
+            // Get commits since the timestamp.
+            $sinceDate = date('Y-m-d H:i:s', $since);
+            $logCmd = sprintf(
+                'git log --since=%s --pretty=format:"%%H|%%an|%%ad|%%s" --date=short 2>&1',
+                escapeshellarg($sinceDate)
+            );
+            exec($logCmd, $commits, $return);
+
+            if (empty($commits)) {
+                chdir($cwd);
+                return null;
+            }
+
+            // Get the diff for all commits combined.
+            $firstCommit = explode('|', $commits[count($commits) - 1])[0];
+            $lastCommit = explode('|', $commits[0])[0];
+
+            $diffCmd = sprintf(
+                'git diff --stat %s^..%s 2>&1',
+                escapeshellarg($firstCommit),
+                escapeshellarg($lastCommit)
+            );
+            exec($diffCmd, $statOutput, $return);
+
+            // Get full diff (limited to avoid token limits).
+            $diffCmd = sprintf(
+                'git diff %s^..%s 2>&1',
+                escapeshellarg($firstCommit),
+                escapeshellarg($lastCommit)
+            );
+            exec($diffCmd, $diffOutput, $return);
+
+            chdir($cwd);
+
+            // Limit diff size to avoid token limits (approx 50k characters).
+            $fullDiff = implode("\n", $diffOutput);
+            if (strlen($fullDiff) > 50000) {
+                $fullDiff = substr($fullDiff, 0, 50000) . "\n\n... (diff truncated due to size)";
+            }
+
+            return [
+                'commits' => array_map(function ($commit) {
+                    $parts = explode('|', $commit, 4);
+                    return [
+                        'hash' => $parts[0] ?? '',
+                        'author' => $parts[1] ?? '',
+                        'date' => $parts[2] ?? '',
+                        'message' => $parts[3] ?? '',
+                    ];
+                }, $commits),
+                'stat' => implode("\n", $statOutput),
+                'diff' => $fullDiff,
+            ];
+        } finally {
+            // Cleanup.
+            exec(sprintf('rm -rf %s', escapeshellarg($tempDir)));
+        }
+    }
+
+    /**
+     * Generate AI summary of all changes across repositories.
+     *
+     * @param array $allChanges Array of repository changes.
+     * @return string AI-generated summary.
+     */
+    public function summarizeAllChanges(array $allChanges): string
+    {
+        if (!$this->gemini->isConfigured()) {
+            return "Error: Gemini API key not configured. Cannot generate AI summary.";
+        }
+
+        $prompt = "You are summarizing code changes for readers familiar with Freegle (a UK community reuse network similar to Freecycle where people give away unwanted items and help each other).\n\n";
+
+        $prompt .= "IMPORTANT: Many features require changes across multiple code repositories (frontend + backend). ";
+        $prompt .= "When you see the same feature or fix mentioned in multiple repositories, describe the OVERALL PURPOSE once, not each technical implementation separately.\n\n";
+
+        $prompt .= "The following repositories were updated:\n\n";
+
+        foreach ($allChanges as $change) {
+            $prompt .= "=== {$change['repo']} ({$change['category']}) ===\n";
+            $prompt .= "Commits:\n";
+            foreach ($change['commits'] as $commit) {
+                $prompt .= "- {$commit['date']}: {$commit['message']}\n";
+            }
+            $prompt .= "\nFiles changed:\n{$change['stat']}\n\n";
+        }
+
+        $prompt .= "\n\nPlease provide a structured summary organized by user impact.\n\n";
+        $prompt .= "Start with a brief intro paragraph (2-3 sentences) that:\n";
+        $prompt .= "- Explains this is an AI-generated summary of recent code changes\n";
+        $prompt .= "- Uses British English spelling and phrasing (e.g., 'organised' not 'organized', 'whilst' is acceptable)\n";
+        $prompt .= "- Has a straightforward, matter-of-fact tone - not overly enthusiastic or promotional\n\n";
+
+        $prompt .= "Then organise the changes into these sections:\n\n";
+        $prompt .= "## FREEGLE DIRECT (Main Website for Members)\n";
+        $prompt .= "List changes that affect regular users of the Freegle website (3-5 bullet points).\n";
+        $prompt .= "IMPORTANT: Sort items by impact - put changes that affect the most users most significantly at the top of the list.\n\n";
+
+        $prompt .= "## MODTOOLS (Volunteer Website)\n";
+        $prompt .= "List changes that affect volunteers/moderators (3-5 bullet points).\n";
+        $prompt .= "IMPORTANT: Sort items by impact - put changes that affect the most volunteers most significantly at the top of the list.\n\n";
+
+        $prompt .= "## BACKEND SYSTEMS (Behind the scenes)\n";
+        $prompt .= "List technical improvements that don't directly change the user interface (2-3 bullet points).\n";
+        $prompt .= "IMPORTANT: Sort items by impact - put changes with the biggest effect on system performance or reliability at the top.\n\n";
+
+        $prompt .= "Guidelines:\n";
+        $prompt .= "- When a feature spans multiple repos (e.g., frontend + API), describe it ONCE under the appropriate user-facing category\n";
+        $prompt .= "- Use simple, direct language. Avoid formal business speak. Say 'makes it easier' not 'ensuring a smoother experience'\n";
+        $prompt .= "- Use active, plain language: 'We fixed' not 'has been resolved', 'You can now' not 'functionality has been enhanced'\n";
+        $prompt .= "- Use British English spelling and phrasing throughout\n";
+        $prompt .= "- Keep tone casual and straightforward, like explaining to a friend - not overly formal or corporate\n";
+        $prompt .= "- Focus on WHAT changed, not HOW it was implemented technically\n";
+        $prompt .= "- Identify prototype/experimental/investigation code clearly (look for test files, 'investigate', 'analyse', 'simulation', 'prototype' in commit messages or file paths)\n";
+        $prompt .= "- When describing prototype work, say 'investigating', 'prototyping', 'testing approaches for' rather than implying it's live\n";
+        $prompt .= "- If a category has no changes, say 'No changes in this period'\n";
+        $prompt .= "- Be specific but concise - get straight to the point\n";
+        $prompt .= "- Use bullet points starting with '-'\n\n";
+        $prompt .= "Do not include repository names in your summary - just describe the changes by user impact.";
+
+        $summary = $this->gemini->generateContent($prompt);
+
+        if ($summary === null) {
+            return "Error generating summary: Gemini API call failed.";
+        }
+
+        return $summary;
+    }
+
+    /**
+     * Generate the full report.
+     *
+     * @param string|null $sinceOverride Override the since date.
+     * @return array Result with 'html', 'changes', 'since_date'.
+     */
+    public function generateReport(?string $sinceOverride = null): array
+    {
+        $since = $this->getLastRunTime($sinceOverride);
+        $sinceDate = date('Y-m-d', $since);
+
+        Log::info('GitSummaryService: Analyzing changes', ['since' => $sinceDate]);
+
+        // Collect all changes first.
+        $allChanges = [];
+        $repositories = config('freegle.git_summary.repositories', []);
+
+        foreach ($repositories as $repo) {
+            Log::info('GitSummaryService: Processing repository', [
+                'name' => $repo['name'],
+                'branch' => $repo['branch'],
+            ]);
+
+            $changes = $this->getRepositoryChanges($repo['url'], $repo['branch'], $since);
+
+            if ($changes === null) {
+                Log::info('GitSummaryService: No changes found', ['repo' => $repo['name']]);
+                continue;
+            }
+
+            Log::info('GitSummaryService: Found commits', [
+                'repo' => $repo['name'],
+                'count' => count($changes['commits']),
+            ]);
+
+            $allChanges[] = [
+                'repo' => $repo['name'],
+                'category' => $repo['category'],
+                'commits' => $changes['commits'],
+                'stat' => $changes['stat'],
+                'diff' => $changes['diff'],
+            ];
+        }
+
+        if (empty($allChanges)) {
+            Log::info('GitSummaryService: No changes in any repository');
+            return [
+                'html' => $this->buildEmptyEmail($sinceDate),
+                'changes' => [],
+                'since_date' => $sinceDate,
+            ];
+        }
+
+        // Summarize all changes together with AI.
+        Log::info('GitSummaryService: Generating AI summary');
+        $summary = $this->summarizeAllChanges($allChanges);
+
+        // Build the email.
+        $html = $this->buildEmail($summary, $sinceDate);
+
+        return [
+            'html' => $html,
+            'changes' => $allChanges,
+            'since_date' => $sinceDate,
+            'summary' => $summary,
+        ];
+    }
+
+    /**
+     * Build the email content with AI-generated summary.
+     */
+    protected function buildEmail(string $aiSummary, string $sinceDate): string
+    {
+        $generatedDate = date('l, j F Y \a\t H:i');
+
+        // Process line by line to properly handle different elements.
+        $lines = explode("\n", $aiSummary);
+        $htmlLines = [];
+        $inList = false;
+        $currentParagraph = '';
+
+        foreach ($lines as $line) {
+            $line = trim($line);
+
+            // Skip empty lines.
+            if (empty($line)) {
+                if ($currentParagraph) {
+                    $htmlLines[] = '<p style="line-height: 1.6; margin-bottom: 12px;">' . $currentParagraph . '</p>';
+                    $currentParagraph = '';
+                }
+                if ($inList) {
+                    $htmlLines[] = '</ul>';
+                    $inList = false;
+                }
+                continue;
+            }
+
+            // Handle headings.
+            if (preg_match('/^## (.+)$/', $line, $matches)) {
+                if ($currentParagraph) {
+                    $htmlLines[] = '<p style="line-height: 1.6; margin-bottom: 12px;">' . $currentParagraph . '</p>';
+                    $currentParagraph = '';
+                }
+                if ($inList) {
+                    $htmlLines[] = '</ul>';
+                    $inList = false;
+                }
+                $htmlLines[] = '<h2 style="color: #2c5282; margin-top: 24px; margin-bottom: 16px; font-size: 20px; display: block;">' . htmlspecialchars($matches[1]) . '</h2>';
+                $htmlLines[] = '<div style="height: 8px;"></div>';
+                continue;
+            }
+
+            if (preg_match('/^# (.+)$/', $line, $matches)) {
+                if ($currentParagraph) {
+                    $htmlLines[] = '<p style="line-height: 1.6; margin-bottom: 12px;">' . $currentParagraph . '</p>';
+                    $currentParagraph = '';
+                }
+                if ($inList) {
+                    $htmlLines[] = '</ul>';
+                    $inList = false;
+                }
+                $htmlLines[] = '<h1 style="color: #1a365d; margin-top: 24px; margin-bottom: 20px; font-size: 24px; display: block;">' . htmlspecialchars($matches[1]) . '</h1>';
+                $htmlLines[] = '<div style="height: 8px;"></div>';
+                continue;
+            }
+
+            // Handle bullet points.
+            if (preg_match('/^[-*]\s+(.+)$/', $line, $matches)) {
+                if ($currentParagraph) {
+                    $htmlLines[] = '<p style="line-height: 1.6; margin-bottom: 12px;">' . $currentParagraph . '</p>';
+                    $currentParagraph = '';
+                }
+                if (!$inList) {
+                    $htmlLines[] = '<ul style="margin: 12px 0; padding-left: 24px; line-height: 1.6;">';
+                    $inList = true;
+                }
+                $htmlLines[] = '<li style="margin-bottom: 8px;">' . $matches[1] . '</li>';
+                continue;
+            }
+
+            // Regular paragraph text.
+            if ($inList) {
+                $htmlLines[] = '</ul>';
+                $inList = false;
+            }
+            if ($currentParagraph) {
+                $currentParagraph .= ' ';
+            }
+            $currentParagraph .= $line;
+        }
+
+        // Close any remaining open elements.
+        if ($currentParagraph) {
+            $htmlLines[] = '<p style="line-height: 1.6; margin-bottom: 12px;">' . $currentParagraph . '</p>';
+        }
+        if ($inList) {
+            $htmlLines[] = '</ul>';
+        }
+
+        $htmlSummary = implode("\n", $htmlLines);
+
+        return <<<HTML
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; line-height: 1.6; color: #333; max-width: 800px; margin: 0 auto; padding: 20px; background-color: #f5f5f5;">
+    <div style="background-color: white; border-radius: 8px; padding: 32px; box-shadow: 0 2px 4px rgba(0,0,0,0.1);">
+        <h1 style="color: #1a365d; border-bottom: 3px solid #4299e1; padding-bottom: 12px; margin-bottom: 24px; font-size: 28px;">
+            Freegle Code Changes Summary
+        </h1>
+
+        <div style="background-color: #ebf8ff; border-left: 4px solid #4299e1; padding: 16px; margin-bottom: 24px; border-radius: 4px;">
+            <p style="margin: 0; line-height: 1.6;">
+                <strong>Changes since:</strong> {$sinceDate}<br>
+                <strong>Generated:</strong> {$generatedDate}
+            </p>
+        </div>
+
+        <div style="color: #2d3748;">
+            {$htmlSummary}
+        </div>
+
+        <hr style="border: none; border-top: 2px solid #e2e8f0; margin: 32px 0;">
+
+        <p style="color: #718096; font-size: 14px; line-height: 1.6; margin: 0;">
+            If you have any questions about these changes, please reply to this post.
+        </p>
+    </div>
+</body>
+</html>
+HTML;
+    }
+
+    /**
+     * Build an empty email when there are no changes.
+     */
+    protected function buildEmptyEmail(string $sinceDate): string
+    {
+        $generatedDate = date('l, j F Y \a\t H:i');
+
+        return <<<HTML
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; line-height: 1.6; color: #333; max-width: 800px; margin: 0 auto; padding: 20px; background-color: #f5f5f5;">
+    <div style="background-color: white; border-radius: 8px; padding: 32px; box-shadow: 0 2px 4px rgba(0,0,0,0.1);">
+        <h1 style="color: #1a365d; border-bottom: 3px solid #4299e1; padding-bottom: 12px; margin-bottom: 24px; font-size: 28px;">
+            Freegle Code Changes Summary
+        </h1>
+
+        <div style="background-color: #ebf8ff; border-left: 4px solid #4299e1; padding: 16px; margin-bottom: 24px; border-radius: 4px;">
+            <p style="margin: 0; line-height: 1.6;">
+                <strong>Changes since:</strong> {$sinceDate}<br>
+                <strong>Generated:</strong> {$generatedDate}
+            </p>
+        </div>
+
+        <div style="background-color: #fff3cd; border-left: 4px solid #ffc107; padding: 16px; margin-bottom: 24px; border-radius: 4px;">
+            <p style="margin: 0; line-height: 1.6;">
+                No code changes were found in any repository during this period.
+            </p>
+        </div>
+    </div>
+</body>
+</html>
+HTML;
+    }
+
+    /**
+     * Send the report via email.
+     *
+     * @param string|null $sinceOverride Override the since date.
+     * @param string|null $emailOverride Override the recipient email.
+     * @param bool $updateTimestamp Whether to update the last run timestamp.
+     * @return array Result with 'success', 'message', 'report'.
+     */
+    public function sendReport(?string $sinceOverride = null, ?string $emailOverride = null, bool $updateTimestamp = true): array
+    {
+        $report = $this->generateReport($sinceOverride);
+
+        $subject = date('d-m-Y') . ' Freegle Code Changes Summary (AI Generated)';
+        $to = $emailOverride ?? config('freegle.git_summary.discourse_email');
+
+        try {
+            Mail::html($report['html'], function ($message) use ($to, $subject) {
+                $message->to($to)
+                    ->from(config('mail.from.address'), config('mail.from.name'))
+                    ->subject($subject);
+            });
+
+            if ($updateTimestamp && $sinceOverride === null) {
+                $this->saveRunTime();
+            }
+
+            Log::info('GitSummaryService: Report sent successfully', [
+                'to' => $to,
+                'since' => $report['since_date'],
+                'commit_count' => array_sum(array_map(fn($c) => count($c['commits']), $report['changes'])),
+            ]);
+
+            return [
+                'success' => true,
+                'message' => "Report sent to {$to}",
+                'report' => $report,
+            ];
+
+        } catch (\Exception $e) {
+            Log::error('GitSummaryService: Failed to send report', [
+                'error' => $e->getMessage(),
+            ]);
+
+            $this->sendAlert("Failed to send git summary report: " . $e->getMessage());
+
+            return [
+                'success' => false,
+                'message' => $e->getMessage(),
+                'report' => $report,
+            ];
+        }
+    }
+
+    /**
+     * Send alert email on failure.
+     */
+    protected function sendAlert(string $error): void
+    {
+        try {
+            $subject = 'Git Summary Report Failed';
+            $body = "Failed to generate or send the git summary report.\n\n"
+                . "Error: {$error}\n\n"
+                . "Please investigate and manually run if necessary.";
+
+            Mail::raw($body, function ($message) use ($subject) {
+                $message->to($this->geekAlertsEmail)
+                    ->from(config('mail.from.address'), config('mail.from.name'))
+                    ->subject($subject);
+            });
+
+        } catch (\Exception $e) {
+            Log::error('GitSummaryService: Failed to send alert email', [
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+}

--- a/iznik-batch/config/freegle.php
+++ b/iznik-batch/config/freegle.php
@@ -171,4 +171,29 @@ return [
         // Default: false - disabled until tested and ready.
         'user2mod_enabled' => env('USER2MOD_NOTIFICATIONS_ENABLED', false),
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Git Summary (Weekly Code Review)
+    |--------------------------------------------------------------------------
+    |
+    | Configuration for AI-powered weekly git summaries sent to Discourse.
+    | Uses Gemini API to summarize code changes across repositories.
+    |
+    */
+
+    'git_summary' => [
+        'gemini_api_key' => env('GOOGLE_GEMINI_API_KEY', ''),
+        'repositories' => [
+            '/home/edward/FreegleDockerWSL/iznik-nuxt3',
+            '/home/edward/FreegleDockerWSL/iznik-server',
+            '/home/edward/FreegleDockerWSL/iznik-server-go',
+            '/home/edward/FreegleDockerWSL/iznik-batch',
+        ],
+        'max_days_back' => 7,
+        'discourse_email' => env('FREEGLE_DISCOURSE_TECH_EMAIL', ''),
+    ],
+
+    // Note: App release classification (hotfix: detection) is handled directly
+    // in CircleCI via the check-hotfix-promote job. See iznik-nuxt3/.circleci/config.yml
 ];

--- a/iznik-batch/config/freegle.php
+++ b/iznik-batch/config/freegle.php
@@ -155,25 +155,6 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Chat Notifications
-    |--------------------------------------------------------------------------
-    |
-    | Feature flags for chat notification types. These allow safe deployment
-    | and testing before enabling production sending.
-    |
-    | Test individual notifications with: php artisan mail:test chat:user2mod
-    | Then enable production sending by setting the environment variable.
-    |
-    */
-
-    'chat_notifications' => [
-        // User-to-mod notifications (messages from users to moderators).
-        // Default: false - disabled until tested and ready.
-        'user2mod_enabled' => env('USER2MOD_NOTIFICATIONS_ENABLED', false),
-    ],
-
-    /*
-    |--------------------------------------------------------------------------
     | Git Summary (Weekly Code Review)
     |--------------------------------------------------------------------------
     |

--- a/iznik-batch/routes/console.php
+++ b/iznik-batch/routes/console.php
@@ -141,18 +141,8 @@ Schedule::command('mail:spool:process --cleanup --cleanup-days=7')
     ->runInBackground();
 
 // =============================================================================
-// APP RELEASE CLASSIFICATION
+// GIT SUMMARY
 // =============================================================================
-
-// Release classification - hourly check with notification.
-// Checks for hotfix: prefix commits and sends email to geek-alerts if found.
-// This doesn't trigger releases - just notifies about classification.
-// Actual promotion happens via CircleCI weekly schedule (Wednesday 10pm UTC)
-// or manual trigger with run_manual_promote parameter.
-Schedule::command('data:classify-app-release --notify')
-    ->hourly()
-    ->withoutOverlapping()
-    ->runInBackground();
 
 // Git summary - weekly on Wednesday at 6pm UTC.
 // Sends AI-powered summary of code changes to Discourse.
@@ -160,3 +150,8 @@ Schedule::command('data:git-summary')
     ->weeklyOn(3, '18:00')  // Wednesday at 6pm UTC
     ->withoutOverlapping()
     ->runInBackground();
+
+// Note: App release classification is now handled directly in CircleCI.
+// The check-hotfix-promote job runs after beta builds and triggers
+// immediate promotion if the commit message has hotfix: prefix.
+// See iznik-nuxt3/.circleci/config.yml

--- a/iznik-batch/tests/Feature/Chat/NotifyChatCommandTest.php
+++ b/iznik-batch/tests/Feature/Chat/NotifyChatCommandTest.php
@@ -55,18 +55,7 @@ class NotifyChatCommandTest extends TestCase
 
     public function test_user2mod_command_runs_successfully(): void
     {
-        // Enable User2Mod notifications for this test.
-        config(['freegle.chat_notifications.user2mod_enabled' => true]);
-
         $this->artisan('mail:chat:user2mod', ['--max-iterations' => 1])
-            ->assertExitCode(0);
-    }
-
-    public function test_user2mod_command_disabled_by_default(): void
-    {
-        // Without enabling, command should warn and exit successfully.
-        $this->artisan('mail:chat:user2mod', ['--max-iterations' => 1])
-            ->expectsOutputToContain('User2Mod notifications are disabled')
             ->assertExitCode(0);
     }
 
@@ -140,9 +129,6 @@ class NotifyChatCommandTest extends TestCase
 
     public function test_user2mod_command_displays_completion_message(): void
     {
-        // Enable User2Mod notifications for this test.
-        config(['freegle.chat_notifications.user2mod_enabled' => true]);
-
         $this->artisan('mail:chat:user2mod', ['--max-iterations' => 1])
             ->expectsOutputToContain('User2Mod notification complete')
             ->assertExitCode(0);

--- a/iznik-batch/tests/Unit/Models/MembershipTest.php
+++ b/iznik-batch/tests/Unit/Models/MembershipTest.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\Group;
+use App\Models\Membership;
+use App\Models\User;
+use Tests\TestCase;
+
+class MembershipTest extends TestCase
+{
+    public function test_is_active_mod_returns_true_for_members(): void
+    {
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+
+        $membership = Membership::create([
+            'userid' => $user->id,
+            'groupid' => $group->id,
+            'role' => Membership::ROLE_MEMBER,
+            'added' => now(),
+        ]);
+
+        $this->assertTrue($membership->isActiveMod());
+    }
+
+    public function test_is_active_mod_returns_true_for_mod_with_null_settings(): void
+    {
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+
+        $membership = Membership::create([
+            'userid' => $user->id,
+            'groupid' => $group->id,
+            'role' => Membership::ROLE_MODERATOR,
+            'added' => now(),
+            'settings' => null,
+        ]);
+
+        $this->assertTrue($membership->isActiveMod());
+    }
+
+    public function test_is_active_mod_returns_true_for_mod_without_active_key(): void
+    {
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+
+        $membership = Membership::create([
+            'userid' => $user->id,
+            'groupid' => $group->id,
+            'role' => Membership::ROLE_MODERATOR,
+            'added' => now(),
+            'settings' => ['someOtherSetting' => true],
+        ]);
+
+        $this->assertTrue($membership->isActiveMod());
+    }
+
+    public function test_is_active_mod_returns_true_for_explicitly_active_mod(): void
+    {
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+
+        $membership = Membership::create([
+            'userid' => $user->id,
+            'groupid' => $group->id,
+            'role' => Membership::ROLE_MODERATOR,
+            'added' => now(),
+            'settings' => ['active' => true],
+        ]);
+
+        $this->assertTrue($membership->isActiveMod());
+    }
+
+    public function test_is_active_mod_returns_false_for_backup_mod(): void
+    {
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+
+        $membership = Membership::create([
+            'userid' => $user->id,
+            'groupid' => $group->id,
+            'role' => Membership::ROLE_MODERATOR,
+            'added' => now(),
+            'settings' => ['active' => false],
+        ]);
+
+        $this->assertFalse($membership->isActiveMod());
+    }
+
+    public function test_is_active_mod_returns_false_for_backup_owner(): void
+    {
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+
+        $membership = Membership::create([
+            'userid' => $user->id,
+            'groupid' => $group->id,
+            'role' => Membership::ROLE_OWNER,
+            'added' => now(),
+            'settings' => ['active' => false],
+        ]);
+
+        $this->assertFalse($membership->isActiveMod());
+    }
+
+    public function test_active_moderators_scope_excludes_backup_mods(): void
+    {
+        $group = $this->createTestGroup();
+
+        // Create an active mod (null settings).
+        $activeMod1 = $this->createTestUser();
+        Membership::create([
+            'userid' => $activeMod1->id,
+            'groupid' => $group->id,
+            'role' => Membership::ROLE_MODERATOR,
+            'added' => now(),
+            'settings' => null,
+        ]);
+
+        // Create an active mod (explicitly active).
+        $activeMod2 = $this->createTestUser();
+        Membership::create([
+            'userid' => $activeMod2->id,
+            'groupid' => $group->id,
+            'role' => Membership::ROLE_OWNER,
+            'added' => now(),
+            'settings' => ['active' => true],
+        ]);
+
+        // Create a backup mod.
+        $backupMod = $this->createTestUser();
+        Membership::create([
+            'userid' => $backupMod->id,
+            'groupid' => $group->id,
+            'role' => Membership::ROLE_MODERATOR,
+            'added' => now(),
+            'settings' => ['active' => false],
+        ]);
+
+        // Create a regular member (should not be included).
+        $member = $this->createTestUser();
+        Membership::create([
+            'userid' => $member->id,
+            'groupid' => $group->id,
+            'role' => Membership::ROLE_MEMBER,
+            'added' => now(),
+        ]);
+
+        $activeMods = $group->memberships()->activeModerators()->get();
+
+        $this->assertCount(2, $activeMods);
+        $this->assertTrue($activeMods->contains('userid', $activeMod1->id));
+        $this->assertTrue($activeMods->contains('userid', $activeMod2->id));
+        $this->assertFalse($activeMods->contains('userid', $backupMod->id));
+        $this->assertFalse($activeMods->contains('userid', $member->id));
+    }
+}

--- a/plans/active/smart-app-releases.md
+++ b/plans/active/smart-app-releases.md
@@ -1,0 +1,215 @@
+# Smart App Release Scheduling
+
+## Status: Complete
+
+Implementation is in the `feature/smart-app-releases` branch of FreegleDocker (iznik-batch) and production branch of iznik-nuxt3.
+
+## Problem Statement
+
+Currently, every merge to the `production` branch triggers both:
+1. **Web deployment** (Netlify) - should happen immediately for all changes ✅
+2. **App deployment** (CircleCI iOS/Android) - currently deploys on every merge ❌
+
+This results in excessive app releases for minor changes, creating unnecessary:
+- App store review overhead (especially iOS 24-hour reviews)
+- User update fatigue
+- Build time and resource usage
+
+## Solution
+
+### Two-Phase Deployment
+
+1. **Beta releases** (TestFlight/Google Play Beta) - happen immediately on every push to production
+2. **Production promotion** - gated by commit message prefix:
+   - `hotfix:` prefix (Conventional Commits standard) → immediate promotion
+   - All other commits → batch for Wednesday night
+   - No changes since last production release → skip promotion
+
+### Key Features
+
+- **Immediate beta deployment**: All changes go to beta channels immediately for testing
+- **Simple hotfix detection**: Only commits with `hotfix:` prefix trigger immediate promotion
+- **Weekly guarantee**: Production releases happen every Wednesday night (if there are changes)
+- **Immediate hotfix detection**: CircleCI detects `hotfix:` prefix right after beta builds
+- **Manual override**: CircleCI pipeline can be triggered with `run_manual_promote=true`
+
+## Implementation
+
+### CircleCI Hotfix Detection (Primary)
+
+Hotfix detection happens directly in CircleCI when code is pushed to production:
+
+1. **check-hotfix-promote job** (`iznik-nuxt3/.circleci/config.yml`)
+   - Runs after beta builds (Android + iOS) complete
+   - Checks if commit message starts with `hotfix:` prefix
+   - If detected: triggers immediate promotion workflow via CircleCI API
+   - If not: logs that promotion will happen on Wednesday
+
+This approach has **zero timing windows**:
+- Detection happens immediately after beta builds complete
+- No polling or batch jobs that could miss commits
+- No race conditions between multiple checks
+
+### Weekly Scheduled Promotion
+
+For non-hotfix commits, production promotion happens weekly:
+
+```yaml
+weekly-promote-schedule:
+  triggers:
+    - schedule:
+        cron: "0 22 * * 3"  # Wednesday 10pm UTC
+  jobs:
+    - auto-promote-production
+    - auto-submit-ios
+    - auto-release-ios
+```
+
+### Laravel Services (iznik-batch)
+
+Created for git summaries (hotfix detection moved to CircleCI):
+
+1. **GeminiService** (`app/Services/GeminiService.php`)
+   - Base service for Gemini AI API calls
+   - Used by GitSummaryService for weekly code summaries
+
+2. **GitSummaryService** (`app/Services/GitSummaryService.php`)
+   - Generates AI-powered summaries of code changes
+   - Sends weekly reports to Discourse via email
+
+### Scheduled Jobs (routes/console.php)
+
+```php
+// Git summary - weekly on Wednesday at 6pm UTC
+Schedule::command('data:git-summary')
+    ->weeklyOn(3, '18:00');
+
+// Note: App release classification is handled in CircleCI
+// See check-hotfix-promote job in iznik-nuxt3/.circleci/config.yml
+```
+
+### Configuration (config/freegle.php)
+
+```php
+'git_summary' => [
+    'gemini_api_key' => env('GOOGLE_GEMINI_API_KEY'),
+    'repositories' => [...],
+    'max_days_back' => 7,
+    'discourse_email' => env('FREEGLE_DISCOURSE_TECH_EMAIL'),
+],
+```
+
+## Urgency Classification
+
+Classification uses the Conventional Commits standard - only the `hotfix:` prefix triggers immediate promotion. This keeps the logic simple and predictable, avoiding false positives from AI-based classification.
+
+### URGENT (immediate promotion)
+- Commit message starts with `hotfix:` prefix (case-insensitive)
+- Example: `hotfix: Fix crash on login for iOS users`
+
+### CAN_WAIT (batch for Wednesday)
+- All other commits without `hotfix:` prefix
+- Includes bug fixes, features, refactoring, etc.
+
+### NO_CHANGES
+- No commits since last production release
+- Skip promotion entirely
+
+## Hotfix Flow
+
+When a `hotfix:` commit is pushed to production:
+
+1. **Beta builds** start immediately (Android + iOS)
+2. **check-hotfix-promote job** runs after builds complete
+3. Job detects `hotfix:` prefix in commit message
+4. Job triggers `manual-promote-submit` workflow via CircleCI API
+5. **Promotion jobs** run immediately:
+   - `auto-promote-production` (Android beta → production)
+   - `auto-submit-ios` (TestFlight → App Store review)
+   - `auto-release-ios` (Release approved builds)
+
+**Total time from commit to production promotion starting: ~30-40 minutes**
+(Time for beta builds to complete)
+
+No polling, no timing windows, no race conditions.
+
+## CircleCI Integration
+
+### Manual Override
+
+To trigger immediate production promotion for urgent fixes:
+1. Go to CircleCI Pipelines for `iznik-nuxt3`
+2. Click "Trigger Pipeline"
+3. Add parameter: `run_manual_promote = true`
+4. Select branch: `production`
+
+This triggers the `manual-promote-submit` workflow which runs:
+- `auto-promote-production` (Android beta → production)
+- `auto-submit-ios` (TestFlight → App Store review)
+- `auto-release-ios` (Release approved builds)
+
+### Weekly Scheduled Workflow
+
+Implemented in `iznik-nuxt3/.circleci/config.yml`:
+```yaml
+weekly-promote-schedule:
+  triggers:
+    - schedule:
+        cron: "0 22 * * 3"  # Wednesday 10pm UTC
+        filters:
+          branches:
+            only: production
+  jobs:
+    - auto-promote-production
+    - auto-submit-ios
+    - auto-release-ios
+```
+
+## Environment Variables Required
+
+| Variable | Description | Where |
+|----------|-------------|-------|
+| `GOOGLE_GEMINI_API_KEY` | Gemini AI API key (for git summaries) | iznik-batch .env |
+| `CIRCLECI_API_TOKEN` | CircleCI API token (for hotfix promotion trigger) | CircleCI project |
+| `FREEGLE_DISCOURSE_TECH_EMAIL` | Discourse email for git summaries | iznik-batch .env |
+
+Note: The `CIRCLECI_API_TOKEN` is already configured in CircleCI for version updates - it's reused for hotfix promotion triggers.
+
+## Success Metrics
+
+- **Production release frequency**: Target 1-2 per week (down from potentially daily)
+- **Urgent response time**: Beta available immediately, production within hours for `hotfix:` commits
+- **Predictability**: Classification based solely on commit prefix - no AI ambiguity
+
+## Rollback Plan
+
+If the system causes issues:
+1. Disable the classifier: remove scheduling from console.php
+2. All beta builds continue to happen immediately
+3. Manual promotion via CircleCI as before
+
+## Files Changed
+
+### New Files (iznik-batch)
+- `app/Services/GeminiService.php` - Gemini AI for git summaries
+- `app/Services/GitSummaryService.php` - Weekly code summary reports
+- `app/Console/Commands/Data/GitSummaryCommand.php` - Artisan command for summaries
+
+### Modified Files (iznik-batch)
+- `config/freegle.php` - Added git_summary section
+- `routes/console.php` - Added git summary schedule, note about CircleCI handling hotfix detection
+
+### Modified Files (iznik-nuxt3)
+- `.circleci/config.yml`:
+  - Added `check-hotfix-promote` job (detects hotfix: prefix after beta builds)
+  - Changed `auto-promote-schedule` to `weekly-promote-schedule` (Wednesday 10pm UTC)
+  - Updated `deploy-apps` workflow to run hotfix check after builds
+
+### Modified Files (FreegleDocker)
+- `plans/active/smart-app-releases.md` - This plan document
+
+## Related Documentation
+
+- `iznik-nuxt3/README-APP.md` - App deployment documentation
+- `iznik-batch/CLAUDE.md` - Batch job documentation
+- `FreegleDocker/CLAUDE.md` - Docker environment documentation


### PR DESCRIPTION
## Summary

- Remove `freegle-dev-local` dependency from playwright (tests actually use prod container)
- Remove dev container dependencies from delivery service (only needed prod for routing)
- Build only CI-required containers: `apiv1 apiv1-phpunit apiv2 freegle-prod-local modtools-prod-local playwright status batch`
- Pre-pull base image once before parallel builds
- Update container verification list to match

## Expected Improvement

- Skip building 4-6 containers (freegle-dev-local, modtools-dev-local, ai-support-helper, base)
- Each skipped Node.js container saves ~30-60s of npm install time
- **Estimated savings: 2-3 minutes (~30-50% reduction in build step)**

## Test plan

- [ ] CI build passes
- [ ] Build step time is reduced compared to baseline (~6 min → ~3-4 min)
- [ ] All tests (Go, PHPUnit, Playwright) still pass
- [ ] Prod containers start correctly without dev container dependencies

## Local Development Impact

None - `docker-compose up` still starts all containers as before.