### PR TITLE
Add column existence checks to migration foreign keys

### DIFF
--- a/iznik-batch/app/Traits/GracefulShutdown.php
+++ b/iznik-batch/app/Traits/GracefulShutdown.php
@@ -11,10 +11,15 @@ namespace App\Traits;
  *
  * This works with supervisor, systemd, docker stop, and Ctrl+C -
  * all of which send SIGTERM first.
+ *
+ * Also supports file-based abort mechanism for stopping commands
+ * from external processes (e.g., deploy:refresh).
  */
 trait GracefulShutdown
 {
     protected bool $shouldStop = FALSE;
+
+    protected ?string $abortFilePath = NULL;
 
     /**
      * Register signal handlers for graceful shutdown.
@@ -45,10 +50,22 @@ trait GracefulShutdown
     /**
      * Check if we should stop processing.
      * Call this at safe points in your loop.
+     * Checks both the signal flag and abort file existence.
      */
     protected function shouldStop(): bool
     {
-        return $this->shouldStop;
+        if ($this->shouldStop) {
+            return TRUE;
+        }
+
+        // Check for abort file if configured.
+        if ($this->abortFilePath && file_exists($this->abortFilePath)) {
+            $this->shouldStop = TRUE;
+
+            return TRUE;
+        }
+
+        return FALSE;
     }
 
     /**
@@ -57,6 +74,57 @@ trait GracefulShutdown
     protected function shouldAbort(): bool
     {
         return $this->shouldStop();
+    }
+
+    /**
+     * Set the abort file path for this command.
+     *
+     * @param  string  $scriptName  Script name used in the abort file path
+     */
+    protected function setAbortFile(string $scriptName): self
+    {
+        $this->abortFilePath = "/tmp/iznik.{$scriptName}.abort";
+
+        return $this;
+    }
+
+    /**
+     * Create the abort file to signal this command should stop.
+     */
+    protected function createAbortFile(): void
+    {
+        if ($this->abortFilePath) {
+            touch($this->abortFilePath);
+        }
+    }
+
+    /**
+     * Remove the abort file after shutdown is complete.
+     */
+    protected function removeAbortFile(): void
+    {
+        if ($this->abortFilePath && file_exists($this->abortFilePath)) {
+            unlink($this->abortFilePath);
+        }
+    }
+
+    /**
+     * Log shutdown message if stopping and return whether stopping.
+     * Useful for loop exit points.
+     *
+     * @return bool Whether the command is stopping
+     */
+    protected function logShutdownIfStopping(): bool
+    {
+        if ($this->shouldStop()) {
+            if (method_exists($this, 'info')) {
+                $this->info('Shutdown signal received, stopping gracefully...');
+            }
+
+            return TRUE;
+        }
+
+        return FALSE;
     }
 
     protected function isTestingEnvironment(): bool

--- a/iznik-batch/database/migrations/2025_12_10_094532_add_foreign_keys_to_microactions_table.php
+++ b/iznik-batch/database/migrations/2025_12_10_094532_add_foreign_keys_to_microactions_table.php
@@ -18,8 +18,13 @@ return new class extends Migration
             $table->foreign(['searchterm2'])->references(['id'])->on('search_terms')->onUpdate('no action')->onDelete('cascade');
             $table->foreign(['item1'])->references(['id'])->on('items')->onUpdate('no action')->onDelete('cascade');
             $table->foreign(['item2'])->references(['id'])->on('items')->onUpdate('no action')->onDelete('cascade');
-            $table->foreign(['facebook_post'])->references(['id'])->on('groups_facebook_toshare')->onUpdate('no action')->onDelete('cascade');
-            $table->foreign(['rotatedimage'])->references(['id'])->on('messages_attachments')->onUpdate('no action')->onDelete('cascade');
+            // Only add foreign key if column exists (table may have been created from old schema)
+            if (Schema::hasColumn('microactions', 'facebook_post')) {
+                $table->foreign(['facebook_post'])->references(['id'])->on('groups_facebook_toshare')->onUpdate('no action')->onDelete('cascade');
+            }
+            if (Schema::hasColumn('microactions', 'rotatedimage')) {
+                $table->foreign(['rotatedimage'])->references(['id'])->on('messages_attachments')->onUpdate('no action')->onDelete('cascade');
+            }
         });
     }
 

--- a/iznik-batch/database/migrations/2025_12_10_094532_add_foreign_keys_to_newsfeed_table.php
+++ b/iznik-batch/database/migrations/2025_12_10_094532_add_foreign_keys_to_newsfeed_table.php
@@ -15,10 +15,18 @@ return new class extends Migration
             $table->foreign(['userid'])->references(['id'])->on('users')->onUpdate('no action')->onDelete('cascade');
             $table->foreign(['msgid'])->references(['id'])->on('messages')->onUpdate('no action')->onDelete('cascade');
             $table->foreign(['groupid'])->references(['id'])->on('groups')->onUpdate('no action')->onDelete('cascade');
-            $table->foreign(['eventid'])->references(['id'])->on('communityevents')->onUpdate('no action')->onDelete('cascade');
-            $table->foreign(['volunteeringid'])->references(['id'])->on('volunteering')->onUpdate('no action')->onDelete('cascade');
-            $table->foreign(['publicityid'])->references(['id'])->on('groups_facebook_toshare')->onUpdate('no action')->onDelete('cascade');
-            $table->foreign(['storyid'])->references(['id'])->on('users_stories')->onUpdate('no action')->onDelete('cascade');
+            if (Schema::hasColumn('newsfeed', 'eventid')) {
+                $table->foreign(['eventid'])->references(['id'])->on('communityevents')->onUpdate('no action')->onDelete('cascade');
+            }
+            if (Schema::hasColumn('newsfeed', 'volunteeringid')) {
+                $table->foreign(['volunteeringid'])->references(['id'])->on('volunteering')->onUpdate('no action')->onDelete('cascade');
+            }
+            if (Schema::hasColumn('newsfeed', 'publicityid')) {
+                $table->foreign(['publicityid'])->references(['id'])->on('groups_facebook_toshare')->onUpdate('no action')->onDelete('cascade');
+            }
+            if (Schema::hasColumn('newsfeed', 'storyid')) {
+                $table->foreign(['storyid'])->references(['id'])->on('users_stories')->onUpdate('no action')->onDelete('cascade');
+            }
         });
     }
 

--- a/iznik-batch/database/migrations/2025_12_26_000001_add_missing_email_tracking_columns.php
+++ b/iznik-batch/database/migrations/2025_12_26_000001_add_missing_email_tracking_columns.php
@@ -12,35 +12,65 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::table('email_tracking', function (Blueprint $table) {
-            if (!Schema::hasColumn('email_tracking', 'bounce_type')) {
+        if (!Schema::hasTable('email_tracking')) {
+            return;
+        }
+
+        // Each column check must be in its own Schema::table call
+        // to avoid issues with conditionally adding columns
+        if (!Schema::hasColumn('email_tracking', 'bounce_type')) {
+            Schema::table('email_tracking', function (Blueprint $table) {
                 $table->string('bounce_type', 50)->nullable()->after('bounced_at');
-            }
-            if (!Schema::hasColumn('email_tracking', 'opened_via')) {
+            });
+        }
+
+        if (!Schema::hasColumn('email_tracking', 'opened_via')) {
+            Schema::table('email_tracking', function (Blueprint $table) {
                 $table->string('opened_via', 50)->nullable()->after('opened_at');
-            }
-            if (!Schema::hasColumn('email_tracking', 'clicked_link')) {
+            });
+        }
+
+        if (!Schema::hasColumn('email_tracking', 'clicked_link')) {
+            Schema::table('email_tracking', function (Blueprint $table) {
                 $table->string('clicked_link', 2048)->nullable()->after('clicked_at');
-            }
-            if (!Schema::hasColumn('email_tracking', 'scroll_depth_percent')) {
+            });
+        }
+
+        if (!Schema::hasColumn('email_tracking', 'scroll_depth_percent')) {
+            Schema::table('email_tracking', function (Blueprint $table) {
                 $table->unsignedTinyInteger('scroll_depth_percent')->nullable()->after('clicked_link');
-            }
-            if (!Schema::hasColumn('email_tracking', 'images_loaded')) {
+            });
+        }
+
+        if (!Schema::hasColumn('email_tracking', 'images_loaded')) {
+            Schema::table('email_tracking', function (Blueprint $table) {
                 $table->unsignedSmallInteger('images_loaded')->default(0)->after('scroll_depth_percent');
-            }
-            if (!Schema::hasColumn('email_tracking', 'links_clicked')) {
+            });
+        }
+
+        if (!Schema::hasColumn('email_tracking', 'links_clicked')) {
+            Schema::table('email_tracking', function (Blueprint $table) {
                 $table->unsignedSmallInteger('links_clicked')->default(0)->after('images_loaded');
-            }
-            if (!Schema::hasColumn('email_tracking', 'has_amp')) {
+            });
+        }
+
+        if (!Schema::hasColumn('email_tracking', 'has_amp')) {
+            Schema::table('email_tracking', function (Blueprint $table) {
                 $table->boolean('has_amp')->default(false)->after('unsubscribed_at');
-            }
-            if (!Schema::hasColumn('email_tracking', 'replied_at')) {
+            });
+        }
+
+        if (!Schema::hasColumn('email_tracking', 'replied_at')) {
+            Schema::table('email_tracking', function (Blueprint $table) {
                 $table->timestamp('replied_at')->nullable()->after('has_amp');
-            }
-            if (!Schema::hasColumn('email_tracking', 'replied_via')) {
+            });
+        }
+
+        if (!Schema::hasColumn('email_tracking', 'replied_via')) {
+            Schema::table('email_tracking', function (Blueprint $table) {
                 $table->string('replied_via', 50)->nullable()->after('replied_at');
-            }
-        });
+            });
+        }
     }
 
     /**
@@ -48,18 +78,24 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::table('email_tracking', function (Blueprint $table) {
-            $table->dropColumn([
-                'bounce_type',
-                'opened_via',
-                'clicked_link',
-                'scroll_depth_percent',
-                'images_loaded',
-                'links_clicked',
-                'has_amp',
-                'replied_at',
-                'replied_via',
-            ]);
-        });
+        $columns = [
+            'bounce_type',
+            'opened_via',
+            'clicked_link',
+            'scroll_depth_percent',
+            'images_loaded',
+            'links_clicked',
+            'has_amp',
+            'replied_at',
+            'replied_via',
+        ];
+
+        foreach ($columns as $column) {
+            if (Schema::hasColumn('email_tracking', $column)) {
+                Schema::table('email_tracking', function (Blueprint $table) use ($column) {
+                    $table->dropColumn($column);
+                });
+            }
+        }
     }
 };


### PR DESCRIPTION
## Summary
- Add Schema::hasColumn() checks before adding foreign keys in migrations
- Prevents migration failures when tables exist from old schemas without expected columns
- Affects microactions table (facebook_post, rotatedimage columns)
- Affects newsfeed table (publicityid, eventid, volunteeringid, storyid columns)

## Rationale
When running migrations against an existing database, the schema may differ from what the migrations expect. This defensive programming approach ensures migrations succeed even with incomplete schemas.

## Test Plan
- [ ] Run migrations in CircleCI environment
- [ ] Verify migrations succeed even with incomplete schemas