### PR TITLE
[WIP] Add debug markers and null safety to footer email partial

### DIFF
--- a/iznik-batch/resources/views/emails/mjml/partials/footer.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/partials/footer.blade.php
@@ -1,7 +1,8 @@
+<!-- freegle-email-footer-start -->
 <mj-section background-color="#f5f5f5" padding="20px">
   <mj-column>
     <mj-text font-size="12px" color="#666666" align="center" line-height="1.6">
-      This email was sent{{ !empty($ampIncluded) ? ' with AMP' : '' }} to {{ $email }}<br/>
+      This email was sent{{ !empty($ampIncluded) ? ' with AMP' : '' }} to {{ $email ?? 'you' }}<br/>
       <a href="{{ $settingsUrl ?? config('freegle.sites.user') . '/settings' }}" style="color: #338808;">Change your email settings</a> &bull;
       <a href="{{ $unsubscribeUrl ?? config('freegle.sites.user') . '/unsubscribe' }}" style="color: #338808;">Unsubscribe</a>
     </mj-text>
@@ -12,3 +13,4 @@
     </mj-text>
   </mj-column>
 </mj-section>
+<!-- freegle-email-footer-end -->


### PR DESCRIPTION
## Summary
This PR contains fixes for the ChatNotificationTest AMP indicator test which checks that the footer renders correctly.

Fixes included:
- Add start/end markers for easier debugging (<!-- freegle-email-footer-start/end -->)
- Add null safety for email variable ({{ $email ?? 'you' }})

## Status
⚠️ **Work in Progress** - These fixes have not yet resolved the flaky test. Further investigation needed.

## Test plan
- [ ] Run ChatNotificationTest AMP indicator test
- [ ] Verify footer renders with correct content

🤖 Generated with [Claude Code](https://claude.ai/code)