### PR TITLE
Use noreply@ilovefreegle.org as From address for AMP email whitelisting

### DIFF
--- a/.claude/skills/ralph/SKILL.md
+++ b/.claude/skills/ralph/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ralph
-description: "MUST use for any non-trivial development task - implements iterative development with status tracking, validation, and one-task-at-a-time approach. Use when implementing features, fixing bugs, refactoring, or any task requiring more than a single simple change."
+description: "MUST use for any non-trivial development task in FreegleDocker - implements iterative development with status tracking, validation, and one-task-at-a-time approach. Use when implementing features, fixing bugs, refactoring, or any task requiring more than a single simple change."
 ---
 
 # Ralph Iterative Development Approach
@@ -40,24 +40,112 @@ For each subtask:
 5. Update the status table
 6. Move to next task
 
-## 3. Critical Rules
+## 3. Code Quality Review (MANDATORY)
+
+Before marking the overall task complete, perform a thorough code quality review:
+
+### 3.1 Deficiency Analysis
+Explicitly look for problems or deficiencies in your changes:
+- **Logic errors**: Edge cases not handled? Null/empty checks missing?
+- **Security issues**: Input validation? SQL injection? XSS?
+- **Performance**: Unnecessary loops? N+1 queries? Missing indexes?
+- **Error handling**: What happens when things fail?
+- **Config dependencies**: Are required config values always present?
+
+### 3.2 Consistency Check
+Check for inconsistencies with how similar problems are solved elsewhere:
+- Search for similar patterns in the codebase (e.g., other envelope() methods, similar services)
+- Ensure your approach matches established patterns
+- If you deviate from patterns, document WHY with a comment
+- Check naming conventions match existing code
+
+### 3.3 Code Duplication Refactoring
+Every change should improve code quality, not decrease it:
+- **Identify duplication**: Is there existing code that does something similar?
+- **Extract common logic**: Create shared helpers/traits for repeated patterns
+- **Don't copy-paste**: If you find yourself copying code, refactor instead
+- **Clean up nearby code**: If you see small improvements near your changes, make them
+- **Remove dead code**: If your change makes code obsolete, delete it
+
+### 3.4 Document Future Improvements
+During review, you may identify issues that are out of scope for this change. **Document these for the PR**:
+- Keep a running list of "Future Improvements" identified during review
+- Include patterns that could be improved but aren't blocking
+- Note technical debt discovered but not addressed
+- These go in the PR description under "## Future Improvements"
+
+### 3.5 Test Quality
+- Tests should test behavior, not implementation details
+- Tests should be readable and self-documenting
+- Avoid testing the same thing multiple ways
+- Mock external dependencies, not internal logic
+
+## 4. Critical Rules
 
 - **ONE task at a time** - do not try to do multiple things at once
 - **NEVER mark complete without validation/testing**
 - **NEVER accept flaky tests** - fix the root cause instead of adding retries
 - **NEVER skip test coverage** - it's mandatory
-- Run `eslint --fix` on changed files
+- **NEVER skip the Code Quality Review** - it catches real bugs
+- Run `eslint --fix` on changed files (for JS/TS)
+- Run `php artisan pint` on changed files (for PHP)
 - Update the status table after completing each task
 
-## 4. Completion Criteria
+## 5. Completion Criteria
 
 Only declare the overall task complete when:
 - All subtasks are ✅ Complete
 - All relevant tests pass
+- Code Quality Review completed (Section 3)
 - Code follows coding standards in codingstandards.md
 - Changes have been validated appropriately
+- No code duplication introduced
 
-## 5. If Blocked
+## 6. PR Description Format
+
+When creating a PR, include:
+
+```markdown
+## Summary
+[1-3 bullet points of what was done]
+
+## Code Quality Review
+- **Deficiency Analysis**: [Any issues found and addressed]
+- **Consistency Check**: [Patterns verified/followed]
+- **Duplication**: [Any refactoring done]
+
+## Future Improvements
+[Issues identified during review that are out of scope but worth noting]
+- [ ] [Improvement 1]
+- [ ] [Improvement 2]
+
+## Test Plan
+[How to verify the changes work]
+
+Fixes #[issue number]
+```
+
+**IMPORTANT**: Do NOT include "Generated with Claude Code" or any AI attribution in PR descriptions.
+
+### 6.1 Updating PRs
+
+After Code Quality Review, always update the PR to reflect the final state:
+
+1. **Check for comments first**: Run `gh api repos/{owner}/{repo}/issues/{pr_number}/comments --jq 'length'`
+2. **If no comments exist**: Update the PR body directly using the REST API:
+   ```bash
+   gh api repos/{owner}/{repo}/pulls/{pr_number} --method PATCH -f body="..."
+   ```
+3. **If comments exist**: Add a reply comment instead of editing the PR body:
+   ```bash
+   gh pr comment {pr_number} --body "## Updated Code Quality Review\n..."
+   ```
+
+This preserves discussion context while keeping the PR description accurate.
+
+**REST API Note**: Always use `gh api` with REST endpoints for PR updates, NOT `gh pr edit`. The `gh pr edit` command uses GraphQL which triggers deprecation errors related to Projects Classic, causing updates to silently fail.
+
+## 7. If Blocked
 
 If you need user input or are blocked:
 - Mark the task as ❌ Blocked

--- a/iznik-batch/EMAIL-MIGRATION-GUIDE.md
+++ b/iznik-batch/EMAIL-MIGRATION-GUIDE.md
@@ -541,13 +541,35 @@ const TYPE_COMPLETED = 'Completed';
 // etc.
 ```
 
-### 4. Reply-To Format
+### 4. From Address (IMPORTANT for AMP)
 ```php
-// Standard format from iznik-server
+// ALWAYS use noreply as From address - required for AMP email whitelisting
+public function envelope(): Envelope
+{
+    return new Envelope(
+        from: new Address(
+            config('freegle.mail.noreply_addr'),  // noreply@ilovefreegle.org
+            $this->fromDisplayName                 // Sender's display name
+        ),
+        replyTo: [new Address($this->replyToAddress, $this->fromDisplayName)],
+        subject: $this->getSubject(),
+    );
+}
+```
+
+**Why noreply@ilovefreegle.org?**
+- This address is whitelisted with Gmail/Yahoo for sending AMP emails
+- Using any other From address (like notify-xxx@users.ilovefreegle.org) breaks AMP delivery
+- The sender's name still appears to recipients (via display name)
+- Replies still work correctly (via Reply-To header)
+
+### 5. Reply-To Format
+```php
+// Standard format from iznik-server - used for routing replies
 $replyTo = 'notify-' . $chatId . '-' . $userId . '@' . USER_DOMAIN;
 ```
 
-### 5. Notification Preference Checks
+### 6. Notification Preference Checks
 ```php
 // Check if user wants email notifications
 $emailNotifs = $user->notifsOn(User::NOTIFS_EMAIL);
@@ -629,3 +651,4 @@ When adding a new email type:
 10. **Write tests first** - based on iznik-server behavior
 11. **Add feature flag check** - respect FREEGLE_MAIL_ENABLED_TYPES setting
 12. **Include footer in ALL templates** - MJML, text, AND AMP must have consistent footers
+13. **Use noreply as From address** - required for AMP email whitelisting; use Reply-To for routing

--- a/iznik-batch/app/Mail/Chat/ChatNotification.php
+++ b/iznik-batch/app/Mail/Chat/ChatNotification.php
@@ -202,11 +202,18 @@ class ChatNotification extends MjmlMailable
 
     /**
      * Get the message envelope with custom from/replyTo.
+     *
+     * Uses noreply@ilovefreegle.org as the From address because it's whitelisted
+     * for AMP email sending. The notify address is preserved as Reply-To so that
+     * replies still route correctly through the chat system.
      */
     public function envelope(): Envelope
     {
         return new Envelope(
-            from: new Address($this->replyToAddress, $this->fromDisplayName),
+            from: new Address(
+                config('freegle.mail.noreply_addr'),
+                $this->fromDisplayName
+            ),
             replyTo: [new Address($this->replyToAddress, $this->fromDisplayName)],
             subject: $this->getSubject(),
         );

--- a/iznik-batch/tests/Unit/Mail/ChatNotificationTest.php
+++ b/iznik-batch/tests/Unit/Mail/ChatNotificationTest.php
@@ -29,29 +29,15 @@ class ChatNotificationTest extends TestCase
         $user1 = $this->createTestUser($options['user1_attrs'] ?? []);
         $user2 = $this->createTestUser($options['user2_attrs'] ?? []);
 
-        $room = ChatRoom::create([
-            'chattype' => ChatRoom::TYPE_USER2USER,
-            'user1' => $user1->id,
-            'user2' => $user2->id,
-            'created' => now(),
-        ]);
+        $room = $this->createTestChatRoom($user1, $user2);
 
-        $messageAttrs = array_merge([
-            'chatid' => $room->id,
-            'userid' => $user1->id,
-            'message' => $options['message_text'] ?? 'Test message',
-            'type' => $options['message_type'] ?? ChatMessage::TYPE_DEFAULT,
-            'date' => now(),
-            'reviewrequired' => 0,
-            'processingrequired' => 0,
-            'processingsuccessful' => 1,
-            'mailedtoall' => 0,
-            'seenbyall' => 0,
-            'reviewrejected' => 0,
-            'platform' => 1,
-        ], $options['message_attrs'] ?? []);
+        $messageAttrs = array_merge(
+            ['message' => $options['message_text'] ?? 'Test message'],
+            ['type' => $options['message_type'] ?? ChatMessage::TYPE_DEFAULT],
+            $options['message_attrs'] ?? []
+        );
 
-        $message = ChatMessage::create($messageAttrs);
+        $message = $this->createTestChatMessage($room, $user1, $messageAttrs);
 
         $mail = new ChatNotification(
             $user2,
@@ -65,25 +51,63 @@ class ChatNotificationTest extends TestCase
     }
 
     /**
-     * Create a standard ChatMessage with sensible defaults.
-     * Use this when you need to create additional messages in a room.
+     * Create a User2Mod chat setup for testing moderator notifications.
+     *
+     * @param array $options Optional overrides:
+     *   - member_attrs: array of attributes for the member
+     *   - moderator_attrs: array of attributes for the moderator (if needed)
+     *   - group_attrs: array of attributes for the group
+     *   - message_text: string message content
+     *   - message_type: ChatMessage type constant
+     *   - message_attrs: array of additional message attributes
+     *   - sender: 'member' or 'moderator' (default: 'member')
+     *   - recipient: 'member' or 'moderator' (default: 'member' - member receives notification)
+     * @return array{member: User, moderator: User|null, group: \App\Models\Group, room: ChatRoom, message: ChatMessage, mail: ChatNotification}
      */
-    protected function createChatMessage(ChatRoom $room, User $sender, array $overrides = []): ChatMessage
+    protected function createUser2ModChatSetup(array $options = []): array
     {
-        return ChatMessage::create(array_merge([
-            'chatid' => $room->id,
-            'userid' => $sender->id,
-            'message' => 'Test message',
-            'type' => ChatMessage::TYPE_DEFAULT,
-            'date' => now(),
-            'reviewrequired' => 0,
-            'processingrequired' => 0,
-            'processingsuccessful' => 1,
-            'mailedtoall' => 0,
-            'seenbyall' => 0,
-            'reviewrejected' => 0,
-            'platform' => 1,
-        ], $overrides));
+        $member = $this->createTestUser($options['member_attrs'] ?? []);
+        $moderator = isset($options['moderator_attrs']) || ($options['recipient'] ?? 'member') === 'moderator'
+            ? $this->createTestUser($options['moderator_attrs'] ?? [])
+            : null;
+        $group = $this->createTestGroup($options['group_attrs'] ?? []);
+
+        $room = ChatRoom::create([
+            'chattype' => ChatRoom::TYPE_USER2MOD,
+            'user1' => $member->id,
+            'groupid' => $group->id,
+            'created' => now(),
+        ]);
+
+        $sender = ($options['sender'] ?? 'member') === 'member' ? $member : $moderator;
+
+        $messageAttrs = array_merge(
+            ['message' => $options['message_text'] ?? 'Test message'],
+            ['type' => $options['message_type'] ?? ChatMessage::TYPE_DEFAULT],
+            $options['message_attrs'] ?? []
+        );
+
+        $message = $this->createTestChatMessage($room, $sender, $messageAttrs);
+
+        // Determine recipient and sender for the mail object
+        $recipientType = $options['recipient'] ?? 'member';
+        if ($recipientType === 'moderator') {
+            $mailRecipient = $moderator;
+            $mailSender = $member;
+        } else {
+            $mailRecipient = $member;
+            $mailSender = ($options['sender'] ?? 'member') === 'moderator' ? $moderator : null;
+        }
+
+        $mail = new ChatNotification(
+            $mailRecipient,
+            $mailSender,
+            $room,
+            $message,
+            ChatRoom::TYPE_USER2MOD
+        );
+
+        return compact('member', 'moderator', 'group', 'room', 'message', 'mail');
     }
 
     public function test_chat_notification_can_be_constructed(): void
@@ -244,38 +268,11 @@ class ChatNotificationTest extends TestCase
 
     public function test_chat_notification_no_sender_subject(): void
     {
-        $user1 = $this->createTestUser();
-        $user2 = $this->createTestUser();
+        // Test with null sender to verify fallback subject
+        ['user2' => $user2, 'room' => $room, 'message' => $message] = $this->createUser2UserChatSetup();
 
-        $room = ChatRoom::create([
-            'chattype' => ChatRoom::TYPE_USER2USER,
-            'user1' => $user1->id,
-            'user2' => $user2->id,
-            'created' => now(),
-        ]);
-
-        $message = ChatMessage::create([
-            'chatid' => $room->id,
-            'userid' => $user1->id,
-            'message' => 'Test message',
-            'type' => ChatMessage::TYPE_DEFAULT,
-            'date' => now(),
-            'reviewrequired' => 0,
-            'processingrequired' => 0,
-            'processingsuccessful' => 1,
-            'mailedtoall' => 0,
-            'seenbyall' => 0,
-            'reviewrejected' => 0,
-            'platform' => 1,
-        ]);
-
-        $mail = new ChatNotification(
-            $user2,
-            null,
-            $room,
-            $message,
-            ChatRoom::TYPE_USER2USER
-        );
+        // Create mail with null sender (edge case)
+        $mail = new ChatNotification($user2, null, $room, $message, ChatRoom::TYPE_USER2USER);
 
         // Without an interested message, subject is the fallback.
         $this->assertEquals('[Freegle] You have a new message', $mail->replySubject);
@@ -332,38 +329,7 @@ class ChatNotificationTest extends TestCase
 
     public function test_chat_notification_envelope_has_subject(): void
     {
-        $user1 = $this->createTestUser();
-        $user2 = $this->createTestUser();
-
-        $room = ChatRoom::create([
-            'chattype' => ChatRoom::TYPE_USER2USER,
-            'user1' => $user1->id,
-            'user2' => $user2->id,
-            'created' => now(),
-        ]);
-
-        $message = ChatMessage::create([
-            'chatid' => $room->id,
-            'userid' => $user1->id,
-            'message' => 'Test message',
-            'type' => ChatMessage::TYPE_DEFAULT,
-            'date' => now(),
-            'reviewrequired' => 0,
-            'processingrequired' => 0,
-            'processingsuccessful' => 1,
-            'mailedtoall' => 0,
-            'seenbyall' => 0,
-            'reviewrejected' => 0,
-            'platform' => 1,
-        ]);
-
-        $mail = new ChatNotification(
-            $user2,
-            $user1,
-            $room,
-            $message,
-            ChatRoom::TYPE_USER2USER
-        );
+        ['mail' => $mail] = $this->createUser2UserChatSetup();
 
         $envelope = $mail->envelope();
 
@@ -372,44 +338,12 @@ class ChatNotificationTest extends TestCase
 
     public function test_chat_notification_decodes_emojis(): void
     {
-        $user1 = $this->createTestUser();
-        $user2 = $this->createTestUser();
-
-        $room = ChatRoom::create([
-            'chattype' => ChatRoom::TYPE_USER2USER,
-            'user1' => $user1->id,
-            'user2' => $user2->id,
-            'created' => now(),
-        ]);
-
         // Message with emoji escape sequences (as stored in database with double backslashes from frontend).
-        $message = ChatMessage::create([
-            'chatid' => $room->id,
-            'userid' => $user1->id,
-            'message' => 'Hello \\\\u1f600\\\\u world \\\\u2764\\\\u',
-            'type' => ChatMessage::TYPE_DEFAULT,
-            'date' => now(),
-            'reviewrequired' => 0,
-            'processingrequired' => 0,
-            'processingsuccessful' => 1,
-            'mailedtoall' => 0,
-            'seenbyall' => 0,
-            'reviewrejected' => 0,
-            'platform' => 1,
+        ['mail' => $mail] = $this->createUser2UserChatSetup([
+            'message_text' => 'Hello \\\\u1f600\\\\u world \\\\u2764\\\\u',
         ]);
 
-        $mail = new ChatNotification(
-            $user2,
-            $user1,
-            $room,
-            $message,
-            ChatRoom::TYPE_USER2USER
-        );
-
-        // Build the email to trigger message preparation.
         $mail->build();
-
-        // Get the rendered HTML content.
         $html = $mail->render();
 
         // Verify emojis are decoded - the HTML should contain actual emoji characters.
@@ -423,39 +357,10 @@ class ChatNotificationTest extends TestCase
 
     public function test_chat_notification_handles_compound_emojis(): void
     {
-        $user1 = $this->createTestUser();
-        $user2 = $this->createTestUser();
-
-        $room = ChatRoom::create([
-            'chattype' => ChatRoom::TYPE_USER2USER,
-            'user1' => $user1->id,
-            'user2' => $user2->id,
-            'created' => now(),
-        ]);
-
         // Message with compound emoji (flag emoji with two code points, double backslashes from frontend).
-        $message = ChatMessage::create([
-            'chatid' => $room->id,
-            'userid' => $user1->id,
-            'message' => 'From \\\\u1f1ec-1f1e7\\\\u with love',
-            'type' => ChatMessage::TYPE_DEFAULT,
-            'date' => now(),
-            'reviewrequired' => 0,
-            'processingrequired' => 0,
-            'processingsuccessful' => 1,
-            'mailedtoall' => 0,
-            'seenbyall' => 0,
-            'reviewrejected' => 0,
-            'platform' => 1,
+        ['mail' => $mail] = $this->createUser2UserChatSetup([
+            'message_text' => 'From \\\\u1f1ec-1f1e7\\\\u with love',
         ]);
-
-        $mail = new ChatNotification(
-            $user2,
-            $user1,
-            $room,
-            $message,
-            ChatRoom::TYPE_USER2USER
-        );
 
         $mail->build();
         $html = $mail->render();
@@ -520,38 +425,12 @@ class ChatNotificationTest extends TestCase
 
     public function test_chat_notification_promised_message_type(): void
     {
-        $user1 = $this->createTestUser(['fullname' => 'Alice']);
-        $user2 = $this->createTestUser(['fullname' => 'Bob']);
-
-        $room = ChatRoom::create([
-            'chattype' => ChatRoom::TYPE_USER2USER,
-            'user1' => $user1->id,
-            'user2' => $user2->id,
-            'created' => now(),
+        ['mail' => $mail] = $this->createUser2UserChatSetup([
+            'user1_attrs' => ['fullname' => 'Alice'],
+            'user2_attrs' => ['fullname' => 'Bob'],
+            'message_text' => '',
+            'message_type' => ChatMessage::TYPE_PROMISED,
         ]);
-
-        $message = ChatMessage::create([
-            'chatid' => $room->id,
-            'userid' => $user1->id,
-            'message' => '',
-            'type' => ChatMessage::TYPE_PROMISED,
-            'date' => now(),
-            'reviewrequired' => 0,
-            'processingrequired' => 0,
-            'processingsuccessful' => 1,
-            'mailedtoall' => 0,
-            'seenbyall' => 0,
-            'reviewrejected' => 0,
-            'platform' => 1,
-        ]);
-
-        $mail = new ChatNotification(
-            $user2,
-            $user1,
-            $room,
-            $message,
-            ChatRoom::TYPE_USER2USER
-        );
 
         $mail->build();
         $html = $mail->render();
@@ -561,38 +440,12 @@ class ChatNotificationTest extends TestCase
 
     public function test_chat_notification_nudge_message_type(): void
     {
-        $user1 = $this->createTestUser(['fullname' => 'Alice']);
-        $user2 = $this->createTestUser(['fullname' => 'Bob']);
-
-        $room = ChatRoom::create([
-            'chattype' => ChatRoom::TYPE_USER2USER,
-            'user1' => $user1->id,
-            'user2' => $user2->id,
-            'created' => now(),
+        ['mail' => $mail] = $this->createUser2UserChatSetup([
+            'user1_attrs' => ['fullname' => 'Alice'],
+            'user2_attrs' => ['fullname' => 'Bob'],
+            'message_text' => '',
+            'message_type' => ChatMessage::TYPE_NUDGE,
         ]);
-
-        $message = ChatMessage::create([
-            'chatid' => $room->id,
-            'userid' => $user1->id,
-            'message' => '',
-            'type' => ChatMessage::TYPE_NUDGE,
-            'date' => now(),
-            'reviewrequired' => 0,
-            'processingrequired' => 0,
-            'processingsuccessful' => 1,
-            'mailedtoall' => 0,
-            'seenbyall' => 0,
-            'reviewrejected' => 0,
-            'platform' => 1,
-        ]);
-
-        $mail = new ChatNotification(
-            $user2,
-            $user1,
-            $room,
-            $message,
-            ChatRoom::TYPE_USER2USER
-        );
 
         $mail->build();
         $html = $mail->render();
@@ -603,38 +456,12 @@ class ChatNotificationTest extends TestCase
 
     public function test_chat_notification_completed_message_type(): void
     {
-        $user1 = $this->createTestUser(['fullname' => 'Alice']);
-        $user2 = $this->createTestUser(['fullname' => 'Bob']);
-
-        $room = ChatRoom::create([
-            'chattype' => ChatRoom::TYPE_USER2USER,
-            'user1' => $user1->id,
-            'user2' => $user2->id,
-            'created' => now(),
+        ['mail' => $mail] = $this->createUser2UserChatSetup([
+            'user1_attrs' => ['fullname' => 'Alice'],
+            'user2_attrs' => ['fullname' => 'Bob'],
+            'message_text' => '',
+            'message_type' => ChatMessage::TYPE_COMPLETED,
         ]);
-
-        $message = ChatMessage::create([
-            'chatid' => $room->id,
-            'userid' => $user1->id,
-            'message' => '',
-            'type' => ChatMessage::TYPE_COMPLETED,
-            'date' => now(),
-            'reviewrequired' => 0,
-            'processingrequired' => 0,
-            'processingsuccessful' => 1,
-            'mailedtoall' => 0,
-            'seenbyall' => 0,
-            'reviewrejected' => 0,
-            'platform' => 1,
-        ]);
-
-        $mail = new ChatNotification(
-            $user2,
-            $user1,
-            $room,
-            $message,
-            ChatRoom::TYPE_USER2USER
-        );
 
         $mail->build();
         $html = $mail->render();
@@ -644,38 +471,7 @@ class ChatNotificationTest extends TestCase
 
     public function test_chat_notification_reply_to_format(): void
     {
-        $user1 = $this->createTestUser();
-        $user2 = $this->createTestUser();
-
-        $room = ChatRoom::create([
-            'chattype' => ChatRoom::TYPE_USER2USER,
-            'user1' => $user1->id,
-            'user2' => $user2->id,
-            'created' => now(),
-        ]);
-
-        $message = ChatMessage::create([
-            'chatid' => $room->id,
-            'userid' => $user1->id,
-            'message' => 'Test',
-            'type' => ChatMessage::TYPE_DEFAULT,
-            'date' => now(),
-            'reviewrequired' => 0,
-            'processingrequired' => 0,
-            'processingsuccessful' => 1,
-            'mailedtoall' => 0,
-            'seenbyall' => 0,
-            'reviewrejected' => 0,
-            'platform' => 1,
-        ]);
-
-        $mail = new ChatNotification(
-            $user2,
-            $user1,
-            $room,
-            $message,
-            ChatRoom::TYPE_USER2USER
-        );
+        ['user2' => $user2, 'room' => $room, 'mail' => $mail] = $this->createUser2UserChatSetup();
 
         $envelope = $mail->envelope();
 
@@ -687,38 +483,9 @@ class ChatNotificationTest extends TestCase
 
     public function test_chat_notification_from_display_name(): void
     {
-        $user1 = $this->createTestUser(['fullname' => 'Alice Smith']);
-        $user2 = $this->createTestUser();
-
-        $room = ChatRoom::create([
-            'chattype' => ChatRoom::TYPE_USER2USER,
-            'user1' => $user1->id,
-            'user2' => $user2->id,
-            'created' => now(),
+        ['mail' => $mail] = $this->createUser2UserChatSetup([
+            'user1_attrs' => ['fullname' => 'Alice Smith'],
         ]);
-
-        $message = ChatMessage::create([
-            'chatid' => $room->id,
-            'userid' => $user1->id,
-            'message' => 'Test',
-            'type' => ChatMessage::TYPE_DEFAULT,
-            'date' => now(),
-            'reviewrequired' => 0,
-            'processingrequired' => 0,
-            'processingsuccessful' => 1,
-            'mailedtoall' => 0,
-            'seenbyall' => 0,
-            'reviewrejected' => 0,
-            'platform' => 1,
-        ]);
-
-        $mail = new ChatNotification(
-            $user2,
-            $user1,
-            $room,
-            $message,
-            ChatRoom::TYPE_USER2USER
-        );
 
         $envelope = $mail->envelope();
 
@@ -736,38 +503,9 @@ class ChatNotificationTest extends TestCase
      */
     public function test_chat_notification_from_uses_noreply_reply_to_uses_notify(): void
     {
-        $user1 = $this->createTestUser(['fullname' => 'Alice Smith']);
-        $user2 = $this->createTestUser();
-
-        $room = ChatRoom::create([
-            'chattype' => ChatRoom::TYPE_USER2USER,
-            'user1' => $user1->id,
-            'user2' => $user2->id,
-            'created' => now(),
+        ['user2' => $user2, 'room' => $room, 'mail' => $mail] = $this->createUser2UserChatSetup([
+            'user1_attrs' => ['fullname' => 'Alice Smith'],
         ]);
-
-        $message = ChatMessage::create([
-            'chatid' => $room->id,
-            'userid' => $user1->id,
-            'message' => 'Test',
-            'type' => ChatMessage::TYPE_DEFAULT,
-            'date' => now(),
-            'reviewrequired' => 0,
-            'processingrequired' => 0,
-            'processingsuccessful' => 1,
-            'mailedtoall' => 0,
-            'seenbyall' => 0,
-            'reviewrejected' => 0,
-            'platform' => 1,
-        ]);
-
-        $mail = new ChatNotification(
-            $user2,
-            $user1,
-            $room,
-            $message,
-            ChatRoom::TYPE_USER2USER
-        );
 
         $envelope = $mail->envelope();
 
@@ -792,44 +530,17 @@ class ChatNotificationTest extends TestCase
 
     public function test_chat_notification_with_previous_messages(): void
     {
-        $user1 = $this->createTestUser();
-        $user2 = $this->createTestUser();
+        ['user1' => $user1, 'user2' => $user2, 'room' => $room] = $this->createUser2UserChatSetup();
 
-        $room = ChatRoom::create([
-            'chattype' => ChatRoom::TYPE_USER2USER,
-            'user1' => $user1->id,
-            'user2' => $user2->id,
-            'created' => now(),
-        ]);
-
-        $prevMessage = ChatMessage::create([
-            'chatid' => $room->id,
-            'userid' => $user1->id,
+        // Create previous message
+        $prevMessage = $this->createTestChatMessage($room, $user1, [
             'message' => 'Previous message',
-            'type' => ChatMessage::TYPE_DEFAULT,
             'date' => now()->subMinutes(5),
-            'reviewrequired' => 0,
-            'processingrequired' => 0,
-            'processingsuccessful' => 1,
-            'mailedtoall' => 0,
-            'seenbyall' => 0,
-            'reviewrejected' => 0,
-            'platform' => 1,
         ]);
 
-        $message = ChatMessage::create([
-            'chatid' => $room->id,
-            'userid' => $user2->id,
+        // Create latest message from user2
+        $message = $this->createTestChatMessage($room, $user2, [
             'message' => 'Latest message',
-            'type' => ChatMessage::TYPE_DEFAULT,
-            'date' => now(),
-            'reviewrequired' => 0,
-            'processingrequired' => 0,
-            'processingsuccessful' => 1,
-            'mailedtoall' => 0,
-            'seenbyall' => 0,
-            'reviewrejected' => 0,
-            'platform' => 1,
         ]);
 
         $mail = new ChatNotification(
@@ -900,76 +611,17 @@ class ChatNotificationTest extends TestCase
 
     public function test_chat_notification_chat_url_contains_room_id(): void
     {
-        $user1 = $this->createTestUser();
-        $user2 = $this->createTestUser();
-
-        $room = ChatRoom::create([
-            'chattype' => ChatRoom::TYPE_USER2USER,
-            'user1' => $user1->id,
-            'user2' => $user2->id,
-            'created' => now(),
-        ]);
-
-        $message = ChatMessage::create([
-            'chatid' => $room->id,
-            'userid' => $user1->id,
-            'message' => 'Test',
-            'type' => ChatMessage::TYPE_DEFAULT,
-            'date' => now(),
-            'reviewrequired' => 0,
-            'processingrequired' => 0,
-            'processingsuccessful' => 1,
-            'mailedtoall' => 0,
-            'seenbyall' => 0,
-            'reviewrejected' => 0,
-            'platform' => 1,
-        ]);
-
-        $mail = new ChatNotification(
-            $user2,
-            $user1,
-            $room,
-            $message,
-            ChatRoom::TYPE_USER2USER
-        );
+        ['room' => $room, 'mail' => $mail] = $this->createUser2UserChatSetup();
 
         $this->assertStringContainsString('/chats/' . $room->id, $mail->chatUrl);
     }
 
     public function test_chat_notification_image_message_type(): void
     {
-        $user1 = $this->createTestUser();
-        $user2 = $this->createTestUser();
-
-        $room = ChatRoom::create([
-            'chattype' => ChatRoom::TYPE_USER2USER,
-            'user1' => $user1->id,
-            'user2' => $user2->id,
-            'created' => now(),
+        ['mail' => $mail] = $this->createUser2UserChatSetup([
+            'message_text' => '',
+            'message_type' => ChatMessage::TYPE_IMAGE,
         ]);
-
-        $message = ChatMessage::create([
-            'chatid' => $room->id,
-            'userid' => $user1->id,
-            'message' => '',
-            'type' => ChatMessage::TYPE_IMAGE,
-            'date' => now(),
-            'reviewrequired' => 0,
-            'processingrequired' => 0,
-            'processingsuccessful' => 1,
-            'mailedtoall' => 0,
-            'seenbyall' => 0,
-            'reviewrejected' => 0,
-            'platform' => 1,
-        ]);
-
-        $mail = new ChatNotification(
-            $user2,
-            $user1,
-            $room,
-            $message,
-            ChatRoom::TYPE_USER2USER
-        );
 
         $mail->build();
         $html = $mail->render();
@@ -979,38 +631,12 @@ class ChatNotificationTest extends TestCase
 
     public function test_chat_notification_reneged_message_type(): void
     {
-        $user1 = $this->createTestUser(['fullname' => 'Alice']);
-        $user2 = $this->createTestUser(['fullname' => 'Bob']);
-
-        $room = ChatRoom::create([
-            'chattype' => ChatRoom::TYPE_USER2USER,
-            'user1' => $user1->id,
-            'user2' => $user2->id,
-            'created' => now(),
+        ['mail' => $mail] = $this->createUser2UserChatSetup([
+            'user1_attrs' => ['fullname' => 'Alice'],
+            'user2_attrs' => ['fullname' => 'Bob'],
+            'message_text' => '',
+            'message_type' => ChatMessage::TYPE_RENEGED,
         ]);
-
-        $message = ChatMessage::create([
-            'chatid' => $room->id,
-            'userid' => $user1->id,
-            'message' => '',
-            'type' => ChatMessage::TYPE_RENEGED,
-            'date' => now(),
-            'reviewrequired' => 0,
-            'processingrequired' => 0,
-            'processingsuccessful' => 1,
-            'mailedtoall' => 0,
-            'seenbyall' => 0,
-            'reviewrejected' => 0,
-            'platform' => 1,
-        ]);
-
-        $mail = new ChatNotification(
-            $user2,
-            $user1,
-            $room,
-            $message,
-            ChatRoom::TYPE_USER2USER
-        );
 
         $mail->build();
         $html = $mail->render();
@@ -1025,55 +651,12 @@ class ChatNotificationTest extends TestCase
         config(['freegle.amp.enabled' => true]);
         config(['freegle.amp.secret' => 'test-secret-key']);
 
-        // Debug: Verify config was set correctly.
-        $configEnabled = config('freegle.amp.enabled');
-        $configSecret = config('freegle.amp.secret');
-
-        $user1 = $this->createTestUser();
-        $user2 = $this->createTestUser();
-
-        // Debug: Check user state.
-        $user2Exists = $user2->exists;
-        $user2Id = $user2->id;
-        $user2Fresh = $user2->fresh();
-        $user2FreshExists = $user2Fresh ? $user2Fresh->exists : 'fresh() returned null';
-
-        $room = ChatRoom::create([
-            'chattype' => ChatRoom::TYPE_USER2USER,
-            'user1' => $user1->id,
-            'user2' => $user2->id,
-            'created' => now(),
-        ]);
-
-        $message = ChatMessage::create([
-            'chatid' => $room->id,
-            'userid' => $user1->id,
-            'message' => 'Test message',
-            'type' => ChatMessage::TYPE_DEFAULT,
-            'date' => now(),
-            'reviewrequired' => 0,
-            'processingrequired' => 0,
-            'processingsuccessful' => 1,
-            'mailedtoall' => 0,
-            'seenbyall' => 0,
-            'reviewrejected' => 0,
-            'platform' => 1,
-        ]);
-
-        $mail = new ChatNotification(
-            $user2,
-            $user1,
-            $room,
-            $message,
-            ChatRoom::TYPE_USER2USER
-        );
+        ['user2' => $user2, 'mail' => $mail] = $this->createUser2UserChatSetup();
 
         // Debug: Check mail object state before build.
         $recipientExists = $mail->recipient->exists;
         $chatType = $mail->chatType;
         $recipientEmail = $mail->recipient->email_preferred;
-
-        // Debug: Check if footer partial view exists.
         $footerViewExists = view()->exists('emails.mjml.partials.footer');
 
         $mail->build();
@@ -1084,47 +667,23 @@ class ChatNotificationTest extends TestCase
         preg_match('/This email was sent[^<]*/', $html, $footerMatch);
         $footerText = $footerMatch[0] ?? 'FOOTER NOT FOUND';
 
-        // Debug: Check for any mj-section with footer color.
-        $hasFooterColor = strpos($html, '#f5f5f5') !== false;
-        $htmlLength = strlen($html);
-
-        // Debug: Look for any footer-like content.
-        $hasCharityRef = strpos($html, 'XT32865') !== false;
-        $hasWeaversField = strpos($html, 'Weaver') !== false;
-
         // Build debug message for assertion failure.
         $debug = sprintf(
             "\n=== DEBUG INFO ===\n" .
             "config('freegle.amp.enabled'): %s\n" .
-            "config('freegle.amp.secret'): %s\n" .
-            "user2->exists: %s\n" .
-            "user2->id: %s\n" .
-            "user2->fresh()->exists: %s\n" .
             "mail->recipient->exists: %s\n" .
             "mail->recipient->email_preferred: %s\n" .
             "mail->chatType: %s\n" .
-            "ChatRoom::TYPE_USER2USER: %s\n" .
             "footer view exists: %s\n" .
             "HTML length: %d\n" .
-            "Has footer bg color (#f5f5f5): %s\n" .
-            "Has charity ref (XT32865): %s\n" .
-            "Has Weavers Field address: %s\n" .
             "Footer text found: %s\n" .
             "==================\n",
-            var_export($configEnabled, true),
-            var_export($configSecret, true),
-            var_export($user2Exists, true),
-            var_export($user2Id, true),
-            var_export($user2FreshExists, true),
+            var_export(config('freegle.amp.enabled'), true),
             var_export($recipientExists, true),
             var_export($recipientEmail, true),
             var_export($chatType, true),
-            var_export(ChatRoom::TYPE_USER2USER, true),
             var_export($footerViewExists, true),
-            $htmlLength,
-            var_export($hasFooterColor, true),
-            var_export($hasCharityRef, true),
-            var_export($hasWeaversField, true),
+            strlen($html),
             $footerText
         );
 
@@ -1138,38 +697,7 @@ class ChatNotificationTest extends TestCase
         config(['freegle.amp.enabled' => false]);
         config(['freegle.amp.secret' => null]);
 
-        $user1 = $this->createTestUser();
-        $user2 = $this->createTestUser();
-
-        $room = ChatRoom::create([
-            'chattype' => ChatRoom::TYPE_USER2USER,
-            'user1' => $user1->id,
-            'user2' => $user2->id,
-            'created' => now(),
-        ]);
-
-        $message = ChatMessage::create([
-            'chatid' => $room->id,
-            'userid' => $user1->id,
-            'message' => 'Test message',
-            'type' => ChatMessage::TYPE_DEFAULT,
-            'date' => now(),
-            'reviewrequired' => 0,
-            'processingrequired' => 0,
-            'processingsuccessful' => 1,
-            'mailedtoall' => 0,
-            'seenbyall' => 0,
-            'reviewrejected' => 0,
-            'platform' => 1,
-        ]);
-
-        $mail = new ChatNotification(
-            $user2,
-            $user1,
-            $room,
-            $message,
-            ChatRoom::TYPE_USER2USER
-        );
+        ['mail' => $mail] = $this->createUser2UserChatSetup();
 
         $mail->build();
         $html = $mail->render();
@@ -1184,38 +712,7 @@ class ChatNotificationTest extends TestCase
         config(['freegle.amp.enabled' => true]);
         config(['freegle.amp.secret' => 'test-secret-key']);
 
-        $user = $this->createTestUser();
-        $group = $this->createTestGroup();
-
-        $room = ChatRoom::create([
-            'chattype' => ChatRoom::TYPE_USER2MOD,
-            'user1' => $user->id,
-            'groupid' => $group->id,
-            'created' => now(),
-        ]);
-
-        $message = ChatMessage::create([
-            'chatid' => $room->id,
-            'userid' => $user->id,
-            'message' => 'Test message',
-            'type' => ChatMessage::TYPE_DEFAULT,
-            'date' => now(),
-            'reviewrequired' => 0,
-            'processingrequired' => 0,
-            'processingsuccessful' => 1,
-            'mailedtoall' => 0,
-            'seenbyall' => 0,
-            'reviewrejected' => 0,
-            'platform' => 1,
-        ]);
-
-        $mail = new ChatNotification(
-            $user,
-            null,
-            $room,
-            $message,
-            ChatRoom::TYPE_USER2MOD
-        );
+        ['mail' => $mail] = $this->createUser2ModChatSetup();
 
         $mail->build();
         $html = $mail->render();
@@ -1226,89 +723,30 @@ class ChatNotificationTest extends TestCase
 
     public function test_own_message_notification_sets_flag_correctly(): void
     {
-        $user1 = $this->createTestUser(['fullname' => 'Alice']);
-        $user2 = $this->createTestUser(['fullname' => 'Bob']);
-
-        $room = ChatRoom::create([
-            'chattype' => ChatRoom::TYPE_USER2USER,
-            'user1' => $user1->id,
-            'user2' => $user2->id,
-            'created' => now(),
-        ]);
-
-        // Message sent by user1.
-        $message = ChatMessage::create([
-            'chatid' => $room->id,
-            'userid' => $user1->id,
-            'message' => 'Test message',
-            'type' => ChatMessage::TYPE_DEFAULT,
-            'date' => now(),
-            'reviewrequired' => 0,
-            'processingrequired' => 0,
-            'processingsuccessful' => 1,
-            'mailedtoall' => 0,
-            'seenbyall' => 0,
-            'reviewrejected' => 0,
-            'platform' => 1,
-        ]);
+        ['user1' => $user1, 'user2' => $user2, 'room' => $room, 'message' => $message, 'mail' => $normalMail] =
+            $this->createUser2UserChatSetup([
+                'user1_attrs' => ['fullname' => 'Alice'],
+                'user2_attrs' => ['fullname' => 'Bob'],
+            ]);
 
         // Normal notification: recipient (user2) is NOT the message sender.
-        $normalMail = new ChatNotification(
-            $user2,
-            $user1,
-            $room,
-            $message,
-            ChatRoom::TYPE_USER2USER
-        );
         $this->assertFalse($normalMail->isOwnMessage, 'isOwnMessage should be false for normal notifications');
 
         // Own message notification: recipient (user1) IS the message sender.
-        $ownMail = new ChatNotification(
-            $user1,
-            $user1,
-            $room,
-            $message,
-            ChatRoom::TYPE_USER2USER
-        );
+        $ownMail = new ChatNotification($user1, $user1, $room, $message, ChatRoom::TYPE_USER2USER);
         $this->assertTrue($ownMail->isOwnMessage, 'isOwnMessage should be true when recipient sent the message');
     }
 
     public function test_own_message_notification_shows_copy_of_your_message(): void
     {
-        $user1 = $this->createTestUser(['fullname' => 'Alice']);
-        $user2 = $this->createTestUser(['fullname' => 'Bob']);
-
-        $room = ChatRoom::create([
-            'chattype' => ChatRoom::TYPE_USER2USER,
-            'user1' => $user1->id,
-            'user2' => $user2->id,
-            'created' => now(),
-        ]);
-
-        // Message sent by user1.
-        $message = ChatMessage::create([
-            'chatid' => $room->id,
-            'userid' => $user1->id,
-            'message' => 'Hello Bob!',
-            'type' => ChatMessage::TYPE_DEFAULT,
-            'date' => now(),
-            'reviewrequired' => 0,
-            'processingrequired' => 0,
-            'processingsuccessful' => 1,
-            'mailedtoall' => 0,
-            'seenbyall' => 0,
-            'reviewrejected' => 0,
-            'platform' => 1,
+        ['user1' => $user1, 'room' => $room, 'message' => $message] = $this->createUser2UserChatSetup([
+            'user1_attrs' => ['fullname' => 'Alice'],
+            'user2_attrs' => ['fullname' => 'Bob'],
+            'message_text' => 'Hello Bob!',
         ]);
 
         // Own message notification: recipient (user1) IS the message sender.
-        $mail = new ChatNotification(
-            $user1,
-            $user1,
-            $room,
-            $message,
-            ChatRoom::TYPE_USER2USER
-        );
+        $mail = new ChatNotification($user1, $user1, $room, $message, ChatRoom::TYPE_USER2USER);
 
         $mail->build();
         $html = $mail->render();
@@ -1321,39 +759,13 @@ class ChatNotificationTest extends TestCase
 
     public function test_own_message_notification_shows_view_conversation_button(): void
     {
-        $user1 = $this->createTestUser(['fullname' => 'Alice']);
-        $user2 = $this->createTestUser(['fullname' => 'Bob']);
-
-        $room = ChatRoom::create([
-            'chattype' => ChatRoom::TYPE_USER2USER,
-            'user1' => $user1->id,
-            'user2' => $user2->id,
-            'created' => now(),
-        ]);
-
-        $message = ChatMessage::create([
-            'chatid' => $room->id,
-            'userid' => $user1->id,
-            'message' => 'Test message',
-            'type' => ChatMessage::TYPE_DEFAULT,
-            'date' => now(),
-            'reviewrequired' => 0,
-            'processingrequired' => 0,
-            'processingsuccessful' => 1,
-            'mailedtoall' => 0,
-            'seenbyall' => 0,
-            'reviewrejected' => 0,
-            'platform' => 1,
+        ['user1' => $user1, 'room' => $room, 'message' => $message] = $this->createUser2UserChatSetup([
+            'user1_attrs' => ['fullname' => 'Alice'],
+            'user2_attrs' => ['fullname' => 'Bob'],
         ]);
 
         // Own message notification.
-        $mail = new ChatNotification(
-            $user1,
-            $user1,
-            $room,
-            $message,
-            ChatRoom::TYPE_USER2USER
-        );
+        $mail = new ChatNotification($user1, $user1, $room, $message, ChatRoom::TYPE_USER2USER);
 
         $mail->build();
         $html = $mail->render();
@@ -1365,39 +777,13 @@ class ChatNotificationTest extends TestCase
 
     public function test_own_message_notification_does_not_show_you_indicator(): void
     {
-        $user1 = $this->createTestUser(['fullname' => 'Alice']);
-        $user2 = $this->createTestUser(['fullname' => 'Bob']);
-
-        $room = ChatRoom::create([
-            'chattype' => ChatRoom::TYPE_USER2USER,
-            'user1' => $user1->id,
-            'user2' => $user2->id,
-            'created' => now(),
-        ]);
-
-        $message = ChatMessage::create([
-            'chatid' => $room->id,
-            'userid' => $user1->id,
-            'message' => 'Test message',
-            'type' => ChatMessage::TYPE_DEFAULT,
-            'date' => now(),
-            'reviewrequired' => 0,
-            'processingrequired' => 0,
-            'processingsuccessful' => 1,
-            'mailedtoall' => 0,
-            'seenbyall' => 0,
-            'reviewrejected' => 0,
-            'platform' => 1,
+        ['user1' => $user1, 'room' => $room, 'message' => $message] = $this->createUser2UserChatSetup([
+            'user1_attrs' => ['fullname' => 'Alice'],
+            'user2_attrs' => ['fullname' => 'Bob'],
         ]);
 
         // Own message notification.
-        $mail = new ChatNotification(
-            $user1,
-            $user1,
-            $room,
-            $message,
-            ChatRoom::TYPE_USER2USER
-        );
+        $mail = new ChatNotification($user1, $user1, $room, $message, ChatRoom::TYPE_USER2USER);
 
         $mail->build();
         $html = $mail->render();
@@ -1413,39 +799,13 @@ class ChatNotificationTest extends TestCase
 
     public function test_own_message_notification_shows_your_message_label(): void
     {
-        $user1 = $this->createTestUser(['fullname' => 'Alice']);
-        $user2 = $this->createTestUser(['fullname' => 'Bob']);
-
-        $room = ChatRoom::create([
-            'chattype' => ChatRoom::TYPE_USER2USER,
-            'user1' => $user1->id,
-            'user2' => $user2->id,
-            'created' => now(),
-        ]);
-
-        $message = ChatMessage::create([
-            'chatid' => $room->id,
-            'userid' => $user1->id,
-            'message' => 'Test message',
-            'type' => ChatMessage::TYPE_DEFAULT,
-            'date' => now(),
-            'reviewrequired' => 0,
-            'processingrequired' => 0,
-            'processingsuccessful' => 1,
-            'mailedtoall' => 0,
-            'seenbyall' => 0,
-            'reviewrejected' => 0,
-            'platform' => 1,
+        ['user1' => $user1, 'room' => $room, 'message' => $message] = $this->createUser2UserChatSetup([
+            'user1_attrs' => ['fullname' => 'Alice'],
+            'user2_attrs' => ['fullname' => 'Bob'],
         ]);
 
         // Own message notification.
-        $mail = new ChatNotification(
-            $user1,
-            $user1,
-            $room,
-            $message,
-            ChatRoom::TYPE_USER2USER
-        );
+        $mail = new ChatNotification($user1, $user1, $room, $message, ChatRoom::TYPE_USER2USER);
 
         $mail->build();
         $html = $mail->render();
@@ -1456,40 +816,12 @@ class ChatNotificationTest extends TestCase
 
     public function test_user2mod_moderator_notification_uses_modtools_url(): void
     {
-        $member = $this->createTestUser(['fullname' => 'Alice Member']);
-        $moderator = $this->createTestUser(['fullname' => 'Bob Moderator']);
-        $group = $this->createTestGroup();
-
-        $room = ChatRoom::create([
-            'chattype' => ChatRoom::TYPE_USER2MOD,
-            'user1' => $member->id,
-            'groupid' => $group->id,
-            'created' => now(),
+        ['mail' => $mail] = $this->createUser2ModChatSetup([
+            'member_attrs' => ['fullname' => 'Alice Member'],
+            'moderator_attrs' => ['fullname' => 'Bob Moderator'],
+            'message_text' => 'Help me please',
+            'recipient' => 'moderator',
         ]);
-
-        $message = ChatMessage::create([
-            'chatid' => $room->id,
-            'userid' => $member->id,
-            'message' => 'Help me please',
-            'type' => ChatMessage::TYPE_DEFAULT,
-            'date' => now(),
-            'reviewrequired' => 0,
-            'processingrequired' => 0,
-            'processingsuccessful' => 1,
-            'mailedtoall' => 0,
-            'seenbyall' => 0,
-            'reviewrejected' => 0,
-            'platform' => 1,
-        ]);
-
-        // Moderator receives notification.
-        $mail = new ChatNotification(
-            $moderator,
-            $member,
-            $room,
-            $message,
-            ChatRoom::TYPE_USER2MOD
-        );
 
         // Moderator should have isModerator flag set.
         $this->assertTrue($mail->isModerator);
@@ -1500,39 +832,10 @@ class ChatNotificationTest extends TestCase
 
     public function test_user2mod_member_notification_uses_user_site_url(): void
     {
-        $member = $this->createTestUser(['fullname' => 'Alice Member']);
-        $group = $this->createTestGroup();
-
-        $room = ChatRoom::create([
-            'chattype' => ChatRoom::TYPE_USER2MOD,
-            'user1' => $member->id,
-            'groupid' => $group->id,
-            'created' => now(),
+        ['mail' => $mail] = $this->createUser2ModChatSetup([
+            'member_attrs' => ['fullname' => 'Alice Member'],
+            'message_text' => 'Help me please',
         ]);
-
-        $message = ChatMessage::create([
-            'chatid' => $room->id,
-            'userid' => $member->id,
-            'message' => 'Help me please',
-            'type' => ChatMessage::TYPE_DEFAULT,
-            'date' => now(),
-            'reviewrequired' => 0,
-            'processingrequired' => 0,
-            'processingsuccessful' => 1,
-            'mailedtoall' => 0,
-            'seenbyall' => 0,
-            'reviewrejected' => 0,
-            'platform' => 1,
-        ]);
-
-        // Member receives notification (recipient is user1, the member).
-        $mail = new ChatNotification(
-            $member,
-            null,
-            $room,
-            $message,
-            ChatRoom::TYPE_USER2MOD
-        );
 
         // Member should NOT have isModerator flag set.
         $this->assertFalse($mail->isModerator);
@@ -1543,42 +846,12 @@ class ChatNotificationTest extends TestCase
 
     public function test_user2mod_moderator_subject_includes_member_info(): void
     {
-        $member = $this->createTestUser([
-            'fullname' => 'Alice Member',
+        ['group' => $group, 'mail' => $mail] = $this->createUser2ModChatSetup([
+            'member_attrs' => ['fullname' => 'Alice Member'],
+            'moderator_attrs' => ['fullname' => 'Bob Moderator'],
+            'message_text' => 'Help me please',
+            'recipient' => 'moderator',
         ]);
-        $moderator = $this->createTestUser(['fullname' => 'Bob Moderator']);
-        $group = $this->createTestGroup();
-
-        $room = ChatRoom::create([
-            'chattype' => ChatRoom::TYPE_USER2MOD,
-            'user1' => $member->id,
-            'groupid' => $group->id,
-            'created' => now(),
-        ]);
-
-        $message = ChatMessage::create([
-            'chatid' => $room->id,
-            'userid' => $member->id,
-            'message' => 'Help me please',
-            'type' => ChatMessage::TYPE_DEFAULT,
-            'date' => now(),
-            'reviewrequired' => 0,
-            'processingrequired' => 0,
-            'processingsuccessful' => 1,
-            'mailedtoall' => 0,
-            'seenbyall' => 0,
-            'reviewrejected' => 0,
-            'platform' => 1,
-        ]);
-
-        // Moderator receives notification.
-        $mail = new ChatNotification(
-            $moderator,
-            $member,
-            $room,
-            $message,
-            ChatRoom::TYPE_USER2MOD
-        );
 
         // Subject should be "Member conversation on {GroupShortName} with {MemberName} ({email})".
         $this->assertStringContainsString('Member conversation on', $mail->replySubject);
@@ -1590,39 +863,10 @@ class ChatNotificationTest extends TestCase
 
     public function test_user2mod_member_subject_mentions_volunteers(): void
     {
-        $member = $this->createTestUser(['fullname' => 'Alice Member']);
-        $group = $this->createTestGroup();
-
-        $room = ChatRoom::create([
-            'chattype' => ChatRoom::TYPE_USER2MOD,
-            'user1' => $member->id,
-            'groupid' => $group->id,
-            'created' => now(),
+        ['mail' => $mail] = $this->createUser2ModChatSetup([
+            'member_attrs' => ['fullname' => 'Alice Member'],
+            'message_text' => 'Help me please',
         ]);
-
-        $message = ChatMessage::create([
-            'chatid' => $room->id,
-            'userid' => $member->id,
-            'message' => 'Help me please',
-            'type' => ChatMessage::TYPE_DEFAULT,
-            'date' => now(),
-            'reviewrequired' => 0,
-            'processingrequired' => 0,
-            'processingsuccessful' => 1,
-            'mailedtoall' => 0,
-            'seenbyall' => 0,
-            'reviewrejected' => 0,
-            'platform' => 1,
-        ]);
-
-        // Member receives notification.
-        $mail = new ChatNotification(
-            $member,
-            null,
-            $room,
-            $message,
-            ChatRoom::TYPE_USER2MOD
-        );
 
         // Subject should be "Your conversation with the {groupName} Volunteers".
         $this->assertStringContainsString('Your conversation with the', $mail->replySubject);
@@ -1631,40 +875,12 @@ class ChatNotificationTest extends TestCase
 
     public function test_user2mod_moderator_notification_shows_modtools_styling(): void
     {
-        $member = $this->createTestUser(['fullname' => 'Alice Member']);
-        $moderator = $this->createTestUser(['fullname' => 'Bob Moderator']);
-        $group = $this->createTestGroup();
-
-        $room = ChatRoom::create([
-            'chattype' => ChatRoom::TYPE_USER2MOD,
-            'user1' => $member->id,
-            'groupid' => $group->id,
-            'created' => now(),
+        ['mail' => $mail] = $this->createUser2ModChatSetup([
+            'member_attrs' => ['fullname' => 'Alice Member'],
+            'moderator_attrs' => ['fullname' => 'Bob Moderator'],
+            'message_text' => 'Help me please',
+            'recipient' => 'moderator',
         ]);
-
-        $message = ChatMessage::create([
-            'chatid' => $room->id,
-            'userid' => $member->id,
-            'message' => 'Help me please',
-            'type' => ChatMessage::TYPE_DEFAULT,
-            'date' => now(),
-            'reviewrequired' => 0,
-            'processingrequired' => 0,
-            'processingsuccessful' => 1,
-            'mailedtoall' => 0,
-            'seenbyall' => 0,
-            'reviewrejected' => 0,
-            'platform' => 1,
-        ]);
-
-        // Moderator receives notification.
-        $mail = new ChatNotification(
-            $moderator,
-            $member,
-            $room,
-            $message,
-            ChatRoom::TYPE_USER2MOD
-        );
 
         $mail->build();
         $html = $mail->render();
@@ -1678,40 +894,12 @@ class ChatNotificationTest extends TestCase
 
     public function test_user2mod_moderator_notification_shows_reply_to_member_button(): void
     {
-        $member = $this->createTestUser(['fullname' => 'Alice Member']);
-        $moderator = $this->createTestUser(['fullname' => 'Bob Moderator']);
-        $group = $this->createTestGroup();
-
-        $room = ChatRoom::create([
-            'chattype' => ChatRoom::TYPE_USER2MOD,
-            'user1' => $member->id,
-            'groupid' => $group->id,
-            'created' => now(),
+        ['mail' => $mail] = $this->createUser2ModChatSetup([
+            'member_attrs' => ['fullname' => 'Alice Member'],
+            'moderator_attrs' => ['fullname' => 'Bob Moderator'],
+            'message_text' => 'Help me please',
+            'recipient' => 'moderator',
         ]);
-
-        $message = ChatMessage::create([
-            'chatid' => $room->id,
-            'userid' => $member->id,
-            'message' => 'Help me please',
-            'type' => ChatMessage::TYPE_DEFAULT,
-            'date' => now(),
-            'reviewrequired' => 0,
-            'processingrequired' => 0,
-            'processingsuccessful' => 1,
-            'mailedtoall' => 0,
-            'seenbyall' => 0,
-            'reviewrejected' => 0,
-            'platform' => 1,
-        ]);
-
-        // Moderator receives notification.
-        $mail = new ChatNotification(
-            $moderator,
-            $member,
-            $room,
-            $message,
-            ChatRoom::TYPE_USER2MOD
-        );
 
         $mail->build();
         $html = $mail->render();
@@ -1722,40 +910,12 @@ class ChatNotificationTest extends TestCase
 
     public function test_user2mod_member_property_set_for_moderators(): void
     {
-        $member = $this->createTestUser(['fullname' => 'Alice Member']);
-        $moderator = $this->createTestUser(['fullname' => 'Bob Moderator']);
-        $group = $this->createTestGroup();
-
-        $room = ChatRoom::create([
-            'chattype' => ChatRoom::TYPE_USER2MOD,
-            'user1' => $member->id,
-            'groupid' => $group->id,
-            'created' => now(),
+        ['member' => $member, 'mail' => $mail] = $this->createUser2ModChatSetup([
+            'member_attrs' => ['fullname' => 'Alice Member'],
+            'moderator_attrs' => ['fullname' => 'Bob Moderator'],
+            'message_text' => 'Help me please',
+            'recipient' => 'moderator',
         ]);
-
-        $message = ChatMessage::create([
-            'chatid' => $room->id,
-            'userid' => $member->id,
-            'message' => 'Help me please',
-            'type' => ChatMessage::TYPE_DEFAULT,
-            'date' => now(),
-            'reviewrequired' => 0,
-            'processingrequired' => 0,
-            'processingsuccessful' => 1,
-            'mailedtoall' => 0,
-            'seenbyall' => 0,
-            'reviewrejected' => 0,
-            'platform' => 1,
-        ]);
-
-        // Moderator receives notification.
-        $mail = new ChatNotification(
-            $moderator,
-            $member,
-            $room,
-            $message,
-            ChatRoom::TYPE_USER2MOD
-        );
 
         // Member property should be set.
         $this->assertNotNull($mail->member);
@@ -1764,38 +924,12 @@ class ChatNotificationTest extends TestCase
 
     public function test_chat_notification_modmail_message_type(): void
     {
-        $user1 = $this->createTestUser(['fullname' => 'Alice']);
-        $user2 = $this->createTestUser(['fullname' => 'Bob']);
-
-        $room = ChatRoom::create([
-            'chattype' => ChatRoom::TYPE_USER2USER,
-            'user1' => $user1->id,
-            'user2' => $user2->id,
-            'created' => now(),
+        ['mail' => $mail] = $this->createUser2UserChatSetup([
+            'user1_attrs' => ['fullname' => 'Alice'],
+            'user2_attrs' => ['fullname' => 'Bob'],
+            'message_text' => 'Please be aware of our group rules.',
+            'message_type' => ChatMessage::TYPE_MODMAIL,
         ]);
-
-        $message = ChatMessage::create([
-            'chatid' => $room->id,
-            'userid' => $user1->id,
-            'message' => 'Please be aware of our group rules.',
-            'type' => ChatMessage::TYPE_MODMAIL,
-            'date' => now(),
-            'reviewrequired' => 0,
-            'processingrequired' => 0,
-            'processingsuccessful' => 1,
-            'mailedtoall' => 0,
-            'seenbyall' => 0,
-            'reviewrejected' => 0,
-            'platform' => 1,
-        ]);
-
-        $mail = new ChatNotification(
-            $user2,
-            $user1,
-            $room,
-            $message,
-            ChatRoom::TYPE_USER2USER
-        );
 
         $mail->build();
         $html = $mail->render();
@@ -1806,40 +940,13 @@ class ChatNotificationTest extends TestCase
 
     public function test_chat_notification_reporteduser_message_type(): void
     {
-        $member = $this->createTestUser(['fullname' => 'Alice Member']);
-        $moderator = $this->createTestUser(['fullname' => 'Bob Moderator']);
-        $group = $this->createTestGroup();
-
-        $room = ChatRoom::create([
-            'chattype' => ChatRoom::TYPE_USER2MOD,
-            'user1' => $member->id,
-            'groupid' => $group->id,
-            'created' => now(),
+        ['mail' => $mail] = $this->createUser2ModChatSetup([
+            'member_attrs' => ['fullname' => 'Alice Member'],
+            'moderator_attrs' => ['fullname' => 'Bob Moderator'],
+            'message_text' => 'This person was rude to me.',
+            'message_type' => ChatMessage::TYPE_REPORTEDUSER,
+            'recipient' => 'moderator',
         ]);
-
-        $message = ChatMessage::create([
-            'chatid' => $room->id,
-            'userid' => $member->id,
-            'message' => 'This person was rude to me.',
-            'type' => ChatMessage::TYPE_REPORTEDUSER,
-            'date' => now(),
-            'reviewrequired' => 0,
-            'processingrequired' => 0,
-            'processingsuccessful' => 1,
-            'mailedtoall' => 0,
-            'seenbyall' => 0,
-            'reviewrejected' => 0,
-            'platform' => 1,
-        ]);
-
-        // Moderator receives notification about the reported user.
-        $mail = new ChatNotification(
-            $moderator,
-            $member,
-            $room,
-            $message,
-            ChatRoom::TYPE_USER2MOD
-        );
 
         $mail->build();
         $html = $mail->render();
@@ -1850,39 +957,13 @@ class ChatNotificationTest extends TestCase
 
     public function test_chat_notification_reminder_message_type(): void
     {
-        $user1 = $this->createTestUser(['fullname' => 'Alice']);
-        $user2 = $this->createTestUser(['fullname' => 'Bob']);
-
-        $room = ChatRoom::create([
-            'chattype' => ChatRoom::TYPE_USER2USER,
-            'user1' => $user1->id,
-            'user2' => $user2->id,
-            'created' => now(),
-        ]);
-
         // TYPE_REMINDER is used by Tryst for automatic handover reminders.
-        $message = ChatMessage::create([
-            'chatid' => $room->id,
-            'userid' => $user1->id,
-            'message' => "Automatic reminder: Handover at 2pm. Please confirm that's still ok or let them know if things have changed. Everybody hates a no-show...",
-            'type' => ChatMessage::TYPE_REMINDER,
-            'date' => now(),
-            'reviewrequired' => 0,
-            'processingrequired' => 0,
-            'processingsuccessful' => 1,
-            'mailedtoall' => 0,
-            'seenbyall' => 0,
-            'reviewrejected' => 0,
-            'platform' => 1,
+        ['mail' => $mail] = $this->createUser2UserChatSetup([
+            'user1_attrs' => ['fullname' => 'Alice'],
+            'user2_attrs' => ['fullname' => 'Bob'],
+            'message_text' => "Automatic reminder: Handover at 2pm. Please confirm that's still ok or let them know if things have changed. Everybody hates a no-show...",
+            'message_type' => ChatMessage::TYPE_REMINDER,
         ]);
-
-        $mail = new ChatNotification(
-            $user2,
-            $user1,
-            $room,
-            $message,
-            ChatRoom::TYPE_USER2USER
-        );
 
         $mail->build();
         $html = $mail->render();
@@ -1894,39 +975,10 @@ class ChatNotificationTest extends TestCase
 
     public function test_user2mod_member_property_null_for_members(): void
     {
-        $member = $this->createTestUser(['fullname' => 'Alice Member']);
-        $group = $this->createTestGroup();
-
-        $room = ChatRoom::create([
-            'chattype' => ChatRoom::TYPE_USER2MOD,
-            'user1' => $member->id,
-            'groupid' => $group->id,
-            'created' => now(),
+        ['member' => $member, 'mail' => $mail] = $this->createUser2ModChatSetup([
+            'member_attrs' => ['fullname' => 'Alice Member'],
+            'message_text' => 'Help me please',
         ]);
-
-        $message = ChatMessage::create([
-            'chatid' => $room->id,
-            'userid' => $member->id,
-            'message' => 'Help me please',
-            'type' => ChatMessage::TYPE_DEFAULT,
-            'date' => now(),
-            'reviewrequired' => 0,
-            'processingrequired' => 0,
-            'processingsuccessful' => 1,
-            'mailedtoall' => 0,
-            'seenbyall' => 0,
-            'reviewrejected' => 0,
-            'platform' => 1,
-        ]);
-
-        // Member receives notification.
-        $mail = new ChatNotification(
-            $member,
-            null,
-            $room,
-            $message,
-            ChatRoom::TYPE_USER2MOD
-        );
 
         // Member property should still be set (it's the member in the chat).
         $this->assertNotNull($mail->member);


### PR DESCRIPTION
## Summary
- Changed ChatNotification to use `noreply@ilovefreegle.org` as the From address (whitelisted for AMP)
- Reply-To remains as `notify-{chatid}-{userid}@users.ilovefreegle.org` for proper reply routing
- Refactored ChatNotificationTest with helper methods, reducing ~950 lines of boilerplate
- Updated Ralph skill with Code Quality Review and PR management sections

## Ralph Skill Improvements
- Added **Section 3: Code Quality Review (MANDATORY)**
  - Deficiency Analysis (logic errors, security, performance, error handling)
  - Consistency Check (patterns, naming conventions)
  - Code Duplication Refactoring
  - Document Future Improvements for PR
  - Test Quality guidelines
- Added **Section 6: PR Description Format** with template
- Added **Section 6.1: PR Update Rules**
  - Check for comments before editing PR body
  - Use REST API (`gh api`) to avoid GraphQL deprecation errors
  - Add comment instead of edit if discussion exists
- Added `php artisan pint` for PHP linting
- Renumbered sections to accommodate new content

## Code Quality Review
- **Deficiency Analysis**: No issues found. Change is minimal - swapping email address source. Config value has sensible default.
- **Consistency Check**: Verified against WelcomeMail.php - same pattern of using `config('freegle.mail.noreply_addr')` as From address. The addition of Reply-To is appropriate since ChatNotification needs replies to route through the chat system.
- **Duplication**: Added two helper methods to reduce test boilerplate:
  - `createUser2UserChatSetup()` - abstracts User2User chat setup
  - `createUser2ModChatSetup()` - abstracts User2Mod chat setup
  - Both use existing base class helpers (`createTestChatRoom()`, `createTestChatMessage()`)
  - Net reduction of ~950 lines across 47 tests

## Future Improvements
- [ ] Some complex tests still use manual setup (e.g., tests needing TYPE_INTERESTED messages with specific ref message ordering) - could add helper if this pattern is needed elsewhere
- [ ] PHPUnit "risky test" warnings could be addressed by updating XML config

## Test Plan
- All 47 ChatNotification tests pass (94 assertions)
- Test `test_chat_notification_from_uses_noreply_reply_to_uses_notify` verifies:
  - From address is `noreply@ilovefreegle.org`
  - From name contains sender's display name
  - Reply-To is the notify address for chat routing

Fixes #12