### PR TITLE
fix: Force mail driver to 'array' during tests

### DIFF
--- a/iznik-batch/tests/TestCase.php
+++ b/iznik-batch/tests/TestCase.php
@@ -19,6 +19,20 @@ abstract class TestCase extends BaseTestCase
     // This rolls back each test's changes, ensuring test isolation.
     use DatabaseTransactions;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Force mail driver to 'array' for testing.
+        // Laravel's TestCase creates a fresh application for each test via refreshApplication().
+        // Even though bootstrap.php clears the config cache, Laravel reads config from env vars
+        // which in Docker include MAIL_MAILER=smtp from docker-compose.yml.
+        // phpunit.xml sets MAIL_MAILER=array but only affects the process environment, not
+        // the docker-compose environment variables that Laravel reads.
+        config(['mail.default' => 'array']);
+        \Illuminate\Support\Facades\Mail::forgetMailers();
+    }
+
     /**
      * Create a test user with an email address.
      */

--- a/iznik-batch/tests/bootstrap.php
+++ b/iznik-batch/tests/bootstrap.php
@@ -1,5 +1,15 @@
 <?php
 
+// Clear config cache before loading Laravel.
+// When running tests, we need phpunit.xml env vars to take effect.
+// If config is cached, Laravel ignores env vars and uses the cached values.
+// The cached config has MAIL_MAILER=smtp (from docker-compose), which breaks
+// tests that expect the array driver from phpunit.xml.
+$configCachePath = __DIR__.'/../bootstrap/cache/config.php';
+if (file_exists($configCachePath)) {
+    @unlink($configCachePath);
+}
+
 // Validate bootstrap cache files before loading Laravel.
 // If services.php is empty or corrupted (returns non-array), delete it.
 // Laravel will regenerate it on bootstrap.
@@ -36,6 +46,9 @@ $app->make(\Illuminate\Contracts\Console\Kernel::class)->bootstrap();
 
 // Force config to use test database
 config(['database.connections.mysql.database' => 'iznik_batch_test']);
+
+// Note: Mail driver is set via phpunit.xml <env name="MAIL_MAILER" value="array" force="true"/>
+// This works because we clear the config cache above, so Laravel reads from env vars.
 
 // Ensure test database exists
 $pdo = new PDO('mysql:host='.env('DB_HOST'), env('DB_USERNAME'), env('DB_PASSWORD'));


### PR DESCRIPTION
## Summary

- Fixed EmailSpoolerServiceTest failures caused by mail driver misconfiguration
- Tests were failing because `processSpool()` was trying to connect to SMTP server instead of using the array transport

## Root Cause

Two issues were preventing phpunit.xml's `MAIL_MAILER=array` from taking effect:

1. **Cached config**: The Docker container has a cached config (`bootstrap/cache/config.php`) with `MAIL_MAILER=smtp` baked in (from docker-compose.yml environment). When config is cached, Laravel completely ignores environment variables.

2. **Fresh app per test**: Laravel's TestCase creates a fresh application for each test via `refreshApplication()`. Even after clearing the cache, the fresh app reads from Docker's environment variables (which include `MAIL_MAILER=smtp` from docker-compose.yml), ignoring phpunit.xml env vars.

## Solution

1. **In `tests/bootstrap.php`**: Delete `config.php` cache before Laravel bootstraps, so Laravel reads from environment
2. **In `TestCase::setUp()`**: Explicitly set `config(['mail.default' => 'array'])` after each test's fresh application is created
3. Call `Mail::forgetMailers()` to clear any cached mailer instances

## Local vs CircleCI

- **Local Docker**: Has `MAIL_MAILER=smtp` set in docker-compose.yml environment, plus cached config
- **CircleCI**: Uses same Docker setup, same issues apply

Both need this fix for tests to pass.

## Test Plan

- [x] Run `EmailSpoolerServiceTest` - all 17 tests now pass
- [ ] Run full iznik-batch test suite via CircleCI