### PR TITLE
feat: Track has_amp field in email tracking

### DIFF
--- a/iznik-batch/app/Mail/Chat/ChatNotification.php
+++ b/iznik-batch/app/Mail/Chat/ChatNotification.php
@@ -178,6 +178,12 @@ class ChatNotification extends MjmlMailable
         // Only pass user ID if it's a persisted user (exists in database).
         $userId = $this->recipient->exists ? $this->recipient->id : null;
 
+        // Determine if this email will include AMP content.
+        // This must match the logic in build() that decides whether to render AMP.
+        $hasAmp = $this->isAmpEnabled()
+            && $this->chatType === ChatRoom::TYPE_USER2USER
+            && $this->recipient->exists;
+
         $this->initTracking(
             'ChatNotification',
             $this->recipient->email_preferred,
@@ -188,7 +194,8 @@ class ChatNotification extends MjmlMailable
                 'chat_id' => $chatRoom->id,
                 'sender_id' => $sender?->id,
                 'message_id' => $message->id,
-            ]
+            ],
+            $hasAmp
         );
     }
 

--- a/iznik-batch/app/Mail/Traits/TrackableEmail.php
+++ b/iznik-batch/app/Mail/Traits/TrackableEmail.php
@@ -32,6 +32,7 @@ trait TrackableEmail
      * @param int|null $groupId Group ID if applicable
      * @param string|null $subject Email subject line
      * @param array|null $metadata Additional context (message_id, etc.)
+     * @param bool $hasAmp Whether this email includes AMP content
      */
     protected function initTracking(
         string $emailType,
@@ -39,7 +40,8 @@ trait TrackableEmail
         ?int $userId = null,
         ?int $groupId = null,
         ?string $subject = null,
-        ?array $metadata = null
+        ?array $metadata = null,
+        bool $hasAmp = false
     ): void {
         $this->tracking = EmailTracking::createForEmail(
             $emailType,
@@ -47,7 +49,8 @@ trait TrackableEmail
             $userId,
             $groupId,
             $subject,
-            $metadata
+            $metadata,
+            $hasAmp
         );
     }
 

--- a/iznik-batch/app/Models/EmailTracking.php
+++ b/iznik-batch/app/Models/EmailTracking.php
@@ -37,6 +37,7 @@ class EmailTracking extends Model
         'opened_at',
         'clicked_at',
         'unsubscribed_at',
+        'has_amp',
     ];
 
     protected $casts = [
@@ -66,7 +67,8 @@ class EmailTracking extends Model
         ?int $userId = null,
         ?int $groupId = null,
         ?string $subject = null,
-        ?array $metadata = null
+        ?array $metadata = null,
+        bool $hasAmp = false
     ): self {
         // Validate that user exists to avoid foreign key constraint failures.
         // If user doesn't exist, set userId to null.
@@ -88,6 +90,7 @@ class EmailTracking extends Model
             'subject' => $subject,
             'metadata' => $metadata,
             'sent_at' => now(),
+            'has_amp' => $hasAmp,
         ]);
     }
 

--- a/iznik-batch/database/migrations/2026_01_15_000000_add_has_amp_to_email_tracking.php
+++ b/iznik-batch/database/migrations/2026_01_15_000000_add_has_amp_to_email_tracking.php
@@ -1,0 +1,109 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * Adds missing columns to email_tracking table to match Go API model.
+     * These columns enable:
+     * - has_amp: Track which emails include AMP content (for ModTools stats)
+     * - replied_at/replied_via: Track email replies
+     * - bounce_type: Categorize bounce reasons
+     * - opened_via: How the email was opened (pixel, click, etc)
+     * - clicked_link: Which link was clicked
+     * - scroll_depth_percent: Estimated scroll depth
+     * - images_loaded/links_clicked: Engagement counters
+     */
+    public function up(): void
+    {
+        if (!Schema::hasTable('email_tracking')) {
+            return;
+        }
+
+        Schema::table('email_tracking', function (Blueprint $table) {
+            // Add columns only if they don't exist
+            if (!Schema::hasColumn('email_tracking', 'bounce_type')) {
+                $table->string('bounce_type', 50)->nullable()->after('bounced_at');
+            }
+        });
+
+        Schema::table('email_tracking', function (Blueprint $table) {
+            if (!Schema::hasColumn('email_tracking', 'opened_via')) {
+                $table->string('opened_via', 50)->nullable()->after('opened_at');
+            }
+        });
+
+        Schema::table('email_tracking', function (Blueprint $table) {
+            if (!Schema::hasColumn('email_tracking', 'clicked_link')) {
+                $table->string('clicked_link', 500)->nullable()->after('clicked_at');
+            }
+        });
+
+        Schema::table('email_tracking', function (Blueprint $table) {
+            if (!Schema::hasColumn('email_tracking', 'scroll_depth_percent')) {
+                $table->unsignedTinyInteger('scroll_depth_percent')->nullable()->after('clicked_link');
+            }
+        });
+
+        Schema::table('email_tracking', function (Blueprint $table) {
+            if (!Schema::hasColumn('email_tracking', 'images_loaded')) {
+                $table->unsignedSmallInteger('images_loaded')->default(0)->after('scroll_depth_percent');
+            }
+        });
+
+        Schema::table('email_tracking', function (Blueprint $table) {
+            if (!Schema::hasColumn('email_tracking', 'links_clicked')) {
+                $table->unsignedSmallInteger('links_clicked')->default(0)->after('images_loaded');
+            }
+        });
+
+        Schema::table('email_tracking', function (Blueprint $table) {
+            if (!Schema::hasColumn('email_tracking', 'has_amp')) {
+                $table->boolean('has_amp')->default(false)->after('unsubscribed_at');
+            }
+        });
+
+        Schema::table('email_tracking', function (Blueprint $table) {
+            if (!Schema::hasColumn('email_tracking', 'replied_at')) {
+                $table->timestamp('replied_at')->nullable()->after('has_amp');
+            }
+        });
+
+        Schema::table('email_tracking', function (Blueprint $table) {
+            if (!Schema::hasColumn('email_tracking', 'replied_via')) {
+                $table->string('replied_via', 50)->nullable()->after('replied_at');
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        $columns = [
+            'bounce_type',
+            'opened_via',
+            'clicked_link',
+            'scroll_depth_percent',
+            'images_loaded',
+            'links_clicked',
+            'has_amp',
+            'replied_at',
+            'replied_via',
+        ];
+
+        foreach ($columns as $column) {
+            if (Schema::hasColumn('email_tracking', $column)) {
+                Schema::table('email_tracking', function (Blueprint $table) use ($column) {
+                    $table->dropColumn($column);
+                });
+            }
+        }
+    }
+};

--- a/iznik-batch/tests/TestCase.php
+++ b/iznik-batch/tests/TestCase.php
@@ -20,6 +20,32 @@ abstract class TestCase extends BaseTestCase
     use DatabaseTransactions;
 
     /**
+     * Ensure tests are run via the status container, not directly.
+     *
+     * This prevents Claude from accidentally running tests directly with
+     * `docker exec freegle-batch php artisan test` instead of via the
+     * status container API which manages test isolation and reporting.
+     */
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        if (!env('VIA_STATUS_CONTAINER')) {
+            fwrite(STDERR, "\n\n");
+            fwrite(STDERR, "╔════════════════════════════════════════════════════════════════╗\n");
+            fwrite(STDERR, "║  ERROR: Tests must be run via the status container!            ║\n");
+            fwrite(STDERR, "║                                                                ║\n");
+            fwrite(STDERR, "║  Use: curl -X POST http://localhost:8081/api/tests/php         ║\n");
+            fwrite(STDERR, "║  Or:  curl -X POST http://localhost:8081/api/tests/laravel     ║\n");
+            fwrite(STDERR, "║                                                                ║\n");
+            fwrite(STDERR, "║  DO NOT run: docker exec freegle-batch php artisan test        ║\n");
+            fwrite(STDERR, "╚════════════════════════════════════════════════════════════════╝\n");
+            fwrite(STDERR, "\n");
+            exit(1);
+        }
+    }
+
+    /**
      * Create a test user with an email address.
      */
     protected function createTestUser(array $attributes = []): User

--- a/iznik-batch/tests/Unit/Mail/ChatNotificationTest.php
+++ b/iznik-batch/tests/Unit/Mail/ChatNotificationTest.php
@@ -721,6 +721,51 @@ class ChatNotificationTest extends TestCase
         $this->assertStringNotContainsString('sent with AMP', $html);
     }
 
+    public function test_chat_notification_tracking_has_amp_true_when_amp_enabled(): void
+    {
+        // Set up AMP config.
+        config(['freegle.amp.enabled' => true]);
+        config(['freegle.amp.secret' => 'test-secret-key']);
+
+        ['mail' => $mail] = $this->createUser2UserChatSetup();
+
+        // Get the tracking record.
+        $tracking = $mail->getTracking();
+
+        $this->assertNotNull($tracking);
+        $this->assertTrue((bool) $tracking->has_amp, 'has_amp should be true for User2User chat with AMP enabled');
+    }
+
+    public function test_chat_notification_tracking_has_amp_false_when_amp_disabled(): void
+    {
+        // Disable AMP.
+        config(['freegle.amp.enabled' => false]);
+        config(['freegle.amp.secret' => null]);
+
+        ['mail' => $mail] = $this->createUser2UserChatSetup();
+
+        // Get the tracking record.
+        $tracking = $mail->getTracking();
+
+        $this->assertNotNull($tracking);
+        $this->assertFalse((bool) $tracking->has_amp, 'has_amp should be false when AMP is disabled');
+    }
+
+    public function test_chat_notification_tracking_has_amp_false_for_user2mod(): void
+    {
+        // Enable AMP globally, but User2Mod should still have has_amp=false.
+        config(['freegle.amp.enabled' => true]);
+        config(['freegle.amp.secret' => 'test-secret-key']);
+
+        ['mail' => $mail] = $this->createUser2ModChatSetup();
+
+        // Get the tracking record.
+        $tracking = $mail->getTracking();
+
+        $this->assertNotNull($tracking);
+        $this->assertFalse((bool) $tracking->has_amp, 'has_amp should be false for User2Mod chat (AMP only for User2User)');
+    }
+
     public function test_own_message_notification_sets_flag_correctly(): void
     {
         ['user1' => $user1, 'user2' => $user2, 'room' => $room, 'message' => $message, 'mail' => $normalMail] =

--- a/iznik-batch/tests/Unit/Models/EmailTrackingModelTest.php
+++ b/iznik-batch/tests/Unit/Models/EmailTrackingModelTest.php
@@ -57,6 +57,42 @@ class EmailTrackingModelTest extends TestCase
         $this->assertNull($tracking->groupid);
         $this->assertNull($tracking->subject);
         $this->assertNull($tracking->metadata);
+        $this->assertFalse((bool) $tracking->has_amp);
+    }
+
+    public function test_create_for_email_with_amp_enabled(): void
+    {
+        $email = $this->uniqueEmail('tracking');
+        $tracking = EmailTracking::createForEmail(
+            'ChatNotification',
+            $email,
+            null,
+            null,
+            'Test Subject',
+            null,
+            true // hasAmp = true
+        );
+
+        $this->assertNotNull($tracking->id);
+        $this->assertEquals('ChatNotification', $tracking->email_type);
+        $this->assertTrue((bool) $tracking->has_amp);
+    }
+
+    public function test_create_for_email_with_amp_disabled(): void
+    {
+        $email = $this->uniqueEmail('tracking');
+        $tracking = EmailTracking::createForEmail(
+            'ChatNotification',
+            $email,
+            null,
+            null,
+            'Test Subject',
+            null,
+            false // hasAmp = false
+        );
+
+        $this->assertNotNull($tracking->id);
+        $this->assertFalse((bool) $tracking->has_amp);
     }
 
     public function test_user_relationship(): void

--- a/status/server.js
+++ b/status/server.js
@@ -1990,7 +1990,8 @@ const httpServer = http.createServer(async (req, res) => {
 
         echo "Running Laravel tests serially with coverage..."
         # Using PHPUnit directly instead of ParaTest to avoid hanging at 90%
-        docker exec freegle-batch vendor/bin/phpunit --testsuite=Unit,Feature --coverage-clover=/tmp/laravel-coverage.xml 2>&1
+        # VIA_STATUS_CONTAINER ensures tests can only run through this API, not directly
+        docker exec -e VIA_STATUS_CONTAINER=1 freegle-batch vendor/bin/phpunit --testsuite=Unit,Feature --coverage-clover=/tmp/laravel-coverage.xml 2>&1
       `,
       ],
       { stdio: "pipe" }


### PR DESCRIPTION
## Summary
- **User-visible change**: ModTools Support Tools now correctly show statistics for "Sent with AMP" - previously this was always showing 0 because the tracking field wasn't being set
- Track which email notifications include AMP content for better analytics
- Add safeguard to prevent tests from being run directly (must use status container API)

## Code Quality Review
- **Deficiency Analysis**: Added null safety check for has_amp boolean cast in tests
- **Consistency Check**: Followed existing TrackableEmail pattern for parameter passing
- **Duplication**: No duplication introduced; uses existing tracking infrastructure

## Test Plan
- [ ] Verify `has_amp` field is correctly set via unit tests
- [ ] Verify ChatNotification sets `has_amp=true` for User2User chats with AMP enabled
- [ ] Verify ChatNotification sets `has_amp=false` for User2Mod chats (AMP only for User2User)
- [ ] Verify ModTools Support Tools shows correct AMP statistics after emails are sent