### PR TITLE
fix: Chat email copy-to-self shows correct sender name

### DIFF
--- a/iznik-batch/app/Services/ChatNotificationService.php
+++ b/iznik-batch/app/Services/ChatNotificationService.php
@@ -181,9 +181,14 @@ class ChatNotificationService
                 }
 
                 // Get the sender in the conversation.
-                // For Mod2Mod, the sender is the message author.
-                // For User2User/User2Mod, it's the "other" user in the chat.
+                // For Mod2Mod, the sender is always the message author.
+                // For User2User/User2Mod:
+                //   - If this is a copy-to-self (recipient is the message author), use the message author.
+                //   - Otherwise, use the "other" user in the chat.
                 if ($chatType === ChatRoom::TYPE_MOD2MOD) {
+                    $sendingFrom = $message->user;
+                } elseif ($message->userid === $sendingTo->id) {
+                    // Copy-to-self: recipient is the message author, so sender should be themselves.
                     $sendingFrom = $message->user;
                 } else {
                     $sendingFrom = $this->getOtherUser($chatRoom, $sendingTo);


### PR DESCRIPTION
## Summary
- Fixed bug where copy-to-self chat emails showed the other user's name instead of the sender's own name
- Added test case to verify correct behavior for NOTIFS_EMAIL_MINE scenario

## Code Quality Review
- **Deficiency Analysis**: The bug occurred because `getOtherUser()` was always called for User2User chats without checking if this was a copy-to-self notification
- **Consistency Check**: Fix follows existing pattern of checking `$message->userid === $sendingTo->id` for copy-to-self detection
- **Duplication**: No new duplication introduced

## Test Plan
- [x] Added test `test_notify_by_email_copy_to_self_shows_own_name_not_other_user`
- [x] Verified test fails before fix, passes after fix
- [x] Ran full ChatNotificationServiceTest suite - all tests pass

Fixes #27