### PR TITLE
feat: Incoming email migration - Postfix container and Laravel processing

### DIFF
--- a/.circleci/orb/freegle-tests.yml
+++ b/.circleci/orb/freegle-tests.yml
@@ -164,26 +164,6 @@ commands:
             echo "Current working directory: $(pwd)"
             ls -la secrets/
 
-      - restore_cache:
-          keys:
-            - nuxt-output-v3-freegle-{{ checksum "iznik-nuxt3/package.json" }}-{{ checksum "iznik-nuxt3/nuxt.config.ts" }}
-            - nuxt-output-v3-freegle-{{ checksum "iznik-nuxt3/package.json" }}
-            - nuxt-output-v3-freegle-
-      - restore_cache:
-          keys:
-            - nuxt-output-v3-modtools-{{ checksum "iznik-nuxt3/modtools/package.json" }}-{{ checksum "iznik-nuxt3/modtools/nuxt.config.ts" }}
-            - nuxt-output-v3-modtools-{{ checksum "iznik-nuxt3/modtools/package.json" }}
-            - nuxt-output-v3-modtools-
-      - run:
-          name: Restore Nuxt build cache to build contexts
-          command: |
-            echo "=== Nuxt build cache restoration DISABLED ==="
-            echo "Cache restoration was causing stale builds - the cache key only checks"
-            echo "package.json and nuxt.config.ts, not actual source code changes."
-            echo "Builds will be slower but always fresh."
-            echo ""
-            echo "TODO: Re-enable with improved cache key that includes source checksum"
-
       - run:
           name: Build containers
           command: |
@@ -1662,40 +1642,6 @@ jobs:
       - wait-for-basic-services
 
       - wait-for-prod-container
-
-      # Extract and cache Nuxt build output AFTER containers are healthy
-      # This ensures the npm run build has completed inside the containers
-      - run:
-          name: Extract and save Nuxt build cache
-          command: |
-            echo "=== Extracting Nuxt build cache (.output) ==="
-
-            # Create cache directories
-            mkdir -p ~/nuxt-cache/freegle
-            mkdir -p ~/nuxt-cache/modtools/modtools
-
-            # Extract Freegle .output cache (the production build output)
-            if docker inspect freegle-prod-local >/dev/null 2>&1; then
-              docker cp freegle-prod-local:/app/.output ~/nuxt-cache/freegle/.output 2>/dev/null && \
-                echo "✅ Extracted Freegle .output cache ($(du -sh ~/nuxt-cache/freegle/.output | cut -f1))" || \
-                echo "ℹ️  No Freegle .output directory found in container"
-            fi
-
-            # Extract ModTools .output cache
-            if docker inspect modtools-prod-local >/dev/null 2>&1; then
-              docker cp modtools-prod-local:/app/modtools/.output ~/nuxt-cache/modtools/modtools/.output 2>/dev/null && \
-                echo "✅ Extracted ModTools .output cache ($(du -sh ~/nuxt-cache/modtools/modtools/.output | cut -f1))" || \
-                echo "ℹ️  No ModTools .output directory found"
-            fi
-
-      - save_cache:
-          key: nuxt-output-v3-freegle-{{ checksum "iznik-nuxt3/package.json" }}-{{ checksum "iznik-nuxt3/nuxt.config.ts" }}
-          paths:
-            - ~/nuxt-cache/freegle
-      - save_cache:
-          key: nuxt-output-v3-modtools-{{ checksum "iznik-nuxt3/modtools/package.json" }}-{{ checksum "iznik-nuxt3/modtools/nuxt.config.ts" }}
-          paths:
-            - ~/nuxt-cache/modtools
 
       # Wait for batch container migrations to complete BEFORE loading schema.sql
       # This prevents race conditions where schema.sql's DROP TABLE statements interfere with

--- a/.circleci/orb/freegle-tests.yml
+++ b/.circleci/orb/freegle-tests.yml
@@ -2112,6 +2112,61 @@ jobs:
             else
               echo "❌ Tests failed"
               echo "Laravel: $LARAVEL_TESTS_PASSED, Go: $GO_TESTS_PASSED, PHP: $PHP_TESTS_PASSED, Playwright: $PLAYWRIGHT_TESTS_PASSED"
+              echo ""
+
+              # Extract and display failure details from test output files
+              # This ensures failures are visible even if earlier output was truncated
+
+              if [ "$LARAVEL_TESTS_PASSED" != "true" ] && [ -f ~/test-output/laravel.out ]; then
+                echo "=== Laravel (iznik-batch) Failure Details ==="
+                # Show PHPUnit failure summary (lines after "There were X failures:")
+                if grep -q "There were .* failures" ~/test-output/laravel.out; then
+                  grep -A 100 "There were .* failures" ~/test-output/laravel.out | head -80
+                else
+                  # Show last 50 lines if no standard failure marker
+                  echo "(Showing last 50 lines of output)"
+                  tail -50 ~/test-output/laravel.out
+                fi
+                echo ""
+              fi
+
+              if [ "$GO_TESTS_PASSED" != "true" ] && [ -f ~/test-output/go.out ]; then
+                echo "=== Go Test Failure Details ==="
+                # Show lines containing FAIL or error
+                if grep -q "FAIL\|Error\|panic" ~/test-output/go.out; then
+                  grep -B 2 -A 5 "FAIL\|Error\|panic" ~/test-output/go.out | head -60
+                else
+                  echo "(Showing last 50 lines of output)"
+                  tail -50 ~/test-output/go.out
+                fi
+                echo ""
+              fi
+
+              if [ "$PHP_TESTS_PASSED" != "true" ] && [ -f ~/test-output/php.out ]; then
+                echo "=== PHP (iznik-server) Failure Details ==="
+                if grep -q "FAILURES\|There were .* failures" ~/test-output/php.out; then
+                  grep -A 100 "There were .* failures" ~/test-output/php.out | head -80
+                else
+                  echo "(Showing last 50 lines of output)"
+                  tail -50 ~/test-output/php.out
+                fi
+                echo ""
+              fi
+
+              if [ "$PLAYWRIGHT_TESTS_PASSED" != "true" ] && [ -f ~/test-output/playwright.out ]; then
+                echo "=== Playwright Failure Details ==="
+                # Show lines containing failure markers
+                if grep -q "✘\|Error:\|failed" ~/test-output/playwright.out; then
+                  grep -B 2 -A 10 "✘\|Error:\|failed" ~/test-output/playwright.out | head -60
+                else
+                  echo "(Showing last 50 lines of output)"
+                  tail -50 ~/test-output/playwright.out
+                fi
+                echo ""
+              fi
+
+              echo "=== Full logs available in artifacts ==="
+              echo "Download test-output/*.out files for complete details"
               exit 1
             fi
           when: always

--- a/.circleci/orb/freegle-tests.yml
+++ b/.circleci/orb/freegle-tests.yml
@@ -1921,7 +1921,16 @@ jobs:
               GO_STATUS=$([ -f /tmp/go-result ] && cat /tmp/go-result || echo 'running')
               GO_COMPLETED=$([ -f /tmp/go-completed ] && cat /tmp/go-completed || echo '0')
               GO_TOTAL=$([ -f /tmp/go-total ] && cat /tmp/go-total || echo '0')
-              GO_DISPLAY=$([ "$GO_STATUS" = "running" ] && echo "running ($GO_COMPLETED/$GO_TOTAL)" || echo "$GO_STATUS")
+              # Go doesn't have a pre-count, so show just completed when total is 0
+              if [ "$GO_STATUS" = "running" ]; then
+                if [ "$GO_TOTAL" -gt 0 ]; then
+                  GO_DISPLAY="running ($GO_COMPLETED/$GO_TOTAL)"
+                else
+                  GO_DISPLAY="running ($GO_COMPLETED)"
+                fi
+              else
+                GO_DISPLAY="$GO_STATUS"
+              fi
 
               PHP_STATUS=$([ -f /tmp/php-result ] && cat /tmp/php-result || echo 'running')
               PHP_COMPLETED=$([ -f /tmp/php-completed ] && cat /tmp/php-completed || echo '0')
@@ -1931,7 +1940,16 @@ jobs:
               PLAYWRIGHT_STATUS=$([ -f /tmp/playwright-result ] && cat /tmp/playwright-result || echo 'running')
               PLAYWRIGHT_COMPLETED=$([ -f /tmp/playwright-completed ] && cat /tmp/playwright-completed || echo '0')
               PLAYWRIGHT_TOTAL=$([ -f /tmp/playwright-total ] && cat /tmp/playwright-total || echo '0')
-              PLAYWRIGHT_DISPLAY=$([ "$PLAYWRIGHT_STATUS" = "running" ] && echo "running ($PLAYWRIGHT_COMPLETED/$PLAYWRIGHT_TOTAL)" || echo "$PLAYWRIGHT_STATUS")
+              # Cap completed at total for display (symbol counting can double-count at end)
+              if [ "$PLAYWRIGHT_STATUS" = "running" ]; then
+                if [ "$PLAYWRIGHT_TOTAL" -gt 0 ] && [ "$PLAYWRIGHT_COMPLETED" -gt "$PLAYWRIGHT_TOTAL" ]; then
+                  PLAYWRIGHT_DISPLAY="running ($PLAYWRIGHT_TOTAL/$PLAYWRIGHT_TOTAL)"
+                else
+                  PLAYWRIGHT_DISPLAY="running ($PLAYWRIGHT_COMPLETED/$PLAYWRIGHT_TOTAL)"
+                fi
+              else
+                PLAYWRIGHT_DISPLAY="$PLAYWRIGHT_STATUS"
+              fi
 
               echo "[${elapsed_min}m] iznik-batch: $LARAVEL_DISPLAY | Go: $GO_DISPLAY | iznik-server: $PHP_DISPLAY | Playwright: $PLAYWRIGHT_DISPLAY"
 

--- a/.claude/check-test-command.sh
+++ b/.claude/check-test-command.sh
@@ -26,6 +26,8 @@ TEST_PATTERNS=(
   "artisan test"
   "artisan dusk"
   "vendor/bin/phpunit"
+  "vitest"
+  "npx vitest"
 )
 
 IS_TEST_COMMAND=false
@@ -46,12 +48,13 @@ if echo "$COMMAND" | grep -qE -- "--list|--help"; then
 fi
 
 # Block the command
-echo "BLOCKED: Do not run tests directly. Use the status container API instead:" >&2
+echo "BLOCKED: Do not run tests directly. Use the status container API or CI:" >&2
 echo "" >&2
 echo "  Playwright:   curl -X POST http://localhost:8081/api/tests/playwright" >&2
 echo "  PHPUnit:      curl -X POST http://localhost:8081/api/tests/php" >&2
 echo "  Go tests:     curl -X POST http://localhost:8081/api/tests/go" >&2
 echo "  iznik-batch:  curl -X POST http://localhost:8081/api/tests/iznik-batch" >&2
+echo "  Vitest:       Push to branch and check CircleCI (runs in iznik-nuxt3 repo)" >&2
 echo "" >&2
 echo "To check status: curl -s http://localhost:8081/api/tests/<type>/status | jq '.'" >&2
 exit 2

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 !/conf/grafana-provisioning/
 !/conf/alloy/
 !/conf/logrotate/
+!/conf/postfix/
 /.claude/settings.local.json
 /logs/
 /.idea/prettier.xml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -370,25 +370,27 @@ Set `SENTRY_AUTH_TOKEN` in `.env` to enable (see `SENTRY-INTEGRATION.md` for ful
 
 **Auto-prune rule**: Keep only entries from the last 7 days. Delete older entries when adding new ones.
 
-### 2026-01-26 - Incoming Email Migration Plan & Test Fixes
-- **Status**: 🔄 Plan complete, tests fixed, CI pending
+### 2026-01-26 - Incoming Email Migration Plan Major Update
+- **Status**: ✅ Plan updated based on detailed review
 - **Branch**: `feature/incoming-email-migration` (FreegleDocker)
-- **Plan Created**: `plans/active/incoming-email-to-docker.md` (1100+ lines)
-- **Key Sections**:
-  1. Dual postfix architecture (separate incoming/outgoing for prioritization)
-  2. Dual spam detection (SpamAssassin + Freegle custom checks)
-  3. Spam review UI with clear "why spam" explanations
-  4. Two-tier moderation (chat review vs incoming spam queue)
-  5. ModTools email statistics dashboard
-  6. Phased switchover from Exim/iznik-server
-- **Test Fixes** (feature/options-api-migration-tdd in iznik-nuxt3):
-  - Added misc store and linkify mocks for ChatMessageText.spec.js
-  - Added misc store and linkify mocks for ChatMessageInterested.spec.js
-  - Fixed Pinia "getActivePinia() was called but no active Pinia" error
-  - Commit: adca3fe7 pushed, CI running
-- **Hook Update**: Added vitest/npx vitest to test-blocking hook
-- **Issue Created**: https://github.com/Freegle/iznik-nuxt3/issues/142 (Vitest status API)
-- **Next**: Wait for CI, then this plan is ready for implementation phases
+- **Plan File**: `plans/active/incoming-email-to-docker.md` (1200 lines)
+- **Key Changes (commit e59ce5f)**:
+  1. **Architecture**: Changed from dual postfix to single postfix (simpler)
+  2. **Database**: Removed new `incoming_spam_queue` table, use existing `messages` table
+  3. **Spam Detection**: Added section explaining Freegle checks complement (not duplicate) external filters
+  4. **Flood Protection**: Added Part 3A with rate limiting and attack pattern detection
+  5. **Chat Spam**: Clarified that spam is silently black-holed (no user feedback)
+  6. **Moderator Access**: Changed spam approval from Support/Admin to all moderators
+  7. **Archiving**: Replaced MailPit with Piler for production, added ModTools integration options
+- **Research Completed**:
+  - Rspamd vs SpamAssassin feature comparison (Rspamd 10x faster, machine learning)
+  - Piler REST API integration options (iframe, API, deep link)
+  - Email bomb/flood defense strategies (rate limiting, honeypots, burst detection)
+- **Key Technical Findings**:
+  - `messages.spamtype` and `messages.spamreason` columns already exist
+  - Chat spam IS silently black-holed (no user notification) per ChatMessage.php:485
+  - Bounce suspension: 3 permanent OR 50 total (including temporary) per Bounce.php
+- **Next**: Plan is ready for implementation phases
 
 ### 2026-01-26 - Clickable Links in ModTools Chat Messages
 - **Status**: ✅ Complete

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -370,6 +370,26 @@ Set `SENTRY_AUTH_TOKEN` in `.env` to enable (see `SENTRY-INTEGRATION.md` for ful
 
 **Auto-prune rule**: Keep only entries from the last 7 days. Delete older entries when adding new ones.
 
+### 2026-01-26 - Incoming Email Migration Plan & Test Fixes
+- **Status**: 🔄 Plan complete, tests fixed, CI pending
+- **Branch**: `feature/incoming-email-migration` (FreegleDocker)
+- **Plan Created**: `plans/active/incoming-email-to-docker.md` (1100+ lines)
+- **Key Sections**:
+  1. Dual postfix architecture (separate incoming/outgoing for prioritization)
+  2. Dual spam detection (SpamAssassin + Freegle custom checks)
+  3. Spam review UI with clear "why spam" explanations
+  4. Two-tier moderation (chat review vs incoming spam queue)
+  5. ModTools email statistics dashboard
+  6. Phased switchover from Exim/iznik-server
+- **Test Fixes** (feature/options-api-migration-tdd in iznik-nuxt3):
+  - Added misc store and linkify mocks for ChatMessageText.spec.js
+  - Added misc store and linkify mocks for ChatMessageInterested.spec.js
+  - Fixed Pinia "getActivePinia() was called but no active Pinia" error
+  - Commit: adca3fe7 pushed, CI running
+- **Hook Update**: Added vitest/npx vitest to test-blocking hook
+- **Issue Created**: https://github.com/Freegle/iznik-nuxt3/issues/142 (Vitest status API)
+- **Next**: Wait for CI, then this plan is ready for implementation phases
+
 ### 2026-01-26 - Clickable Links in ModTools Chat Messages
 - **Status**: ✅ Complete
 - **Branch**: master (iznik-nuxt3 submodule)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -370,6 +370,32 @@ Set `SENTRY_AUTH_TOKEN` in `.env` to enable (see `SENTRY-INTEGRATION.md` for ful
 
 **Auto-prune rule**: Keep only entries from the last 7 days. Delete older entries when adding new ones.
 
+### 2026-01-27 - Incoming Email Migration Phase A Self-Review Complete
+- **Status**: ✅ Complete (845 tests passing)
+- **Branch**: `feature/incoming-email-migration` (iznik-batch submodule)
+- **Goal**: Self-review and fix all code quality issues identified in Phase A
+- **Tasks Completed (9 total)**:
+  1. ✅ Fixed unused constructor dependency in IncomingMailService
+  2. ✅ Fixed isSelfSent check against tests
+  3. ✅ Fixed latestmessage type (string 'User2User' vs ChatRoom::TYPE_USER2USER)
+  4. ✅ Fixed ChatMessage::TYPE_DEFAULT constant (was TYPE_INTERESTED)
+  5. ✅ Added proper return codes for all handlers (no more exceptions)
+  6. ✅ Reviewed worry words against iznik-server
+  7. ✅ Fixed hardcoded domain names - using config constants (freegle.mail.*)
+  8. ✅ Implemented all TODOs: FBL processing, ReplyTo chat, Volunteers message, TN secret validation, direct mail routing
+  9. ✅ Fixed tests to use real database records (10 tests updated with proper fixtures)
+- **Config Changes** (`config/freegle.php`):
+  - Added `trashnothing_domain` - TN domain detection
+  - Added `trashnothing_secret` - TN mail authentication
+- **Helper Methods Added** (`IncomingMailService.php`):
+  - `getOrCreateUserChat()` - Find/create User2User chat
+  - `getOrCreateUser2ModChat()` - Find/create User2Mod chat
+- **Test Improvements**:
+  - All tests now use `createTestUser()`, `createTestGroup()`, `createMembership()`
+  - Added negative test cases (e.g., "when user not found" → DROPPED)
+  - Tests: 835 → 845 (+10 edge case tests)
+- **Key Learning**: Tests using placeholder IDs fail silently with DROPPED result - always verify tests fail for the right reason first
+
 ### 2026-01-27 - Incoming Email Plan TLS and Domain Documentation
 - **Status**: ✅ Complete
 - **Branch**: `feature/incoming-email-migration` (FreegleDocker)

--- a/conf/postfix/Dockerfile
+++ b/conf/postfix/Dockerfile
@@ -1,0 +1,26 @@
+FROM alpine:3.19
+
+RUN apk add --no-cache postfix postfix-pcre bash curl
+
+# Create mail user for running the pipe
+RUN adduser -D -u 1000 mail-handler
+
+# Copy configuration files
+COPY main.cf /etc/postfix/main.cf
+COPY master.cf /etc/postfix/master.cf
+COPY transport /etc/postfix/transport
+COPY freegle-mail-handler /usr/local/bin/freegle-mail-handler
+RUN chmod +x /usr/local/bin/freegle-mail-handler
+
+# Build the transport map
+RUN postmap /etc/postfix/transport
+
+# Create spool directories
+RUN mkdir -p /var/spool/postfix && \
+    postfix set-permissions
+
+# Expose SMTP port
+EXPOSE 25
+
+# Start postfix in foreground
+CMD ["postfix", "start-fg"]

--- a/conf/postfix/freegle-mail-handler
+++ b/conf/postfix/freegle-mail-handler
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Freegle Mail Handler - bridges Postfix to Laravel via HTTP
+#
+# Called by Postfix pipe transport with: ${sender} ${recipient}
+# Email content is piped via stdin
+#
+# Exit codes:
+#   0  - Success (message processed or dropped intentionally)
+#   75 - Temporary failure (Postfix will retry)
+#   Other - Permanent failure (message bounced)
+
+SENDER="$1"
+RECIPIENT="$2"
+
+# Read email from stdin
+EMAIL_CONTENT=$(cat)
+
+# Log for debugging
+logger -t freegle-mail "Processing mail from ${SENDER} to ${RECIPIENT}"
+
+# Call Laravel via HTTP endpoint on the batch container
+# The batch container runs PHP's built-in server on port 8080
+RESPONSE=$(echo "$EMAIL_CONTENT" | curl -s -w "\n%{http_code}" \
+    --max-time 60 \
+    -X POST \
+    -H "Content-Type: message/rfc822" \
+    -H "X-Envelope-From: ${SENDER}" \
+    -H "X-Envelope-To: ${RECIPIENT}" \
+    --data-binary @- \
+    "http://freegle-batch:8080/api/mail/incoming" 2>&1)
+
+# Extract HTTP status code (last line)
+HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
+BODY=$(echo "$RESPONSE" | sed '$d')
+
+# Map HTTP codes to Postfix exit codes
+case "$HTTP_CODE" in
+    200|201|202|204)
+        # Success
+        logger -t freegle-mail "Success: mail processed"
+        exit 0
+        ;;
+    503|502|504)
+        # Service unavailable - temporary failure, retry later
+        logger -t freegle-mail "Temporary failure (HTTP $HTTP_CODE): $BODY"
+        exit 75
+        ;;
+    000)
+        # Connection failed - temporary failure
+        logger -t freegle-mail "Connection failed to batch container"
+        exit 75
+        ;;
+    *)
+        # Other errors - log and accept (don't bounce spam/invalid mail)
+        logger -t freegle-mail "Error (HTTP $HTTP_CODE): $BODY - accepting anyway"
+        exit 0
+        ;;
+esac

--- a/conf/postfix/main.cf
+++ b/conf/postfix/main.cf
@@ -1,0 +1,49 @@
+# Postfix main configuration for Freegle incoming mail processing
+# This container receives mail and pipes it to Laravel for processing
+
+# Basic settings
+smtpd_banner = $myhostname ESMTP Freegle Mail Server
+biff = no
+append_dot_mydomain = no
+readme_directory = no
+
+# Hostname and domain settings
+myhostname = mail.ilovefreegle.org
+mydomain = ilovefreegle.org
+myorigin = $mydomain
+
+# Network settings - listen on all interfaces in container
+inet_interfaces = all
+inet_protocols = ipv4
+
+# Accept mail for these domains (virtual mailbox domains)
+mydestination =
+virtual_mailbox_domains = groups.ilovefreegle.org, users.ilovefreegle.org, user.trashnothing.com, ilovefreegle.org
+
+# Transport maps - route all accepted domains to the freegle pipe
+transport_maps = hash:/etc/postfix/transport
+
+# Concurrency limits for Laravel pipe transport
+# Limit parallel deliveries to avoid overwhelming the server
+freegle_destination_concurrency_limit = 4
+default_process_limit = 50
+
+# Size limits
+message_size_limit = 26214400
+mailbox_size_limit = 0
+
+# TLS settings for incoming connections (opportunistic)
+smtpd_tls_cert_file = /etc/ssl/certs/ssl-cert-snakeoil.pem
+smtpd_tls_key_file = /etc/ssl/private/ssl-cert-snakeoil.key
+smtpd_tls_security_level = may
+smtpd_tls_loglevel = 1
+
+# Relay restrictions - only accept mail for our domains
+smtpd_relay_restrictions = permit_mynetworks, reject_unauth_destination
+
+# Queue settings
+maximal_queue_lifetime = 1d
+bounce_queue_lifetime = 1d
+
+# Logging
+maillog_file = /dev/stdout

--- a/conf/postfix/master.cf
+++ b/conf/postfix/master.cf
@@ -1,0 +1,50 @@
+# Postfix master process configuration
+# ==========================================================================
+# service type  private unpriv  chroot  wakeup  maxproc command + args
+#               (yes)   (yes)   (no)    (never) (100)
+# ==========================================================================
+
+# SMTP server - receives incoming mail
+smtp      inet  n       -       n       -       -       smtpd
+
+# Standard Postfix services
+pickup    unix  n       -       n       60      1       pickup
+cleanup   unix  n       -       n       -       0       cleanup
+qmgr      unix  n       -       n       300     1       qmgr
+tlsmgr    unix  -       -       n       1000?   1       tlsmgr
+rewrite   unix  -       -       n       -       -       trivial-rewrite
+bounce    unix  -       -       n       -       0       bounce
+defer     unix  -       -       n       -       0       bounce
+trace     unix  -       -       n       -       0       bounce
+verify    unix  -       -       n       -       1       verify
+flush     unix  n       -       n       1000?   0       flush
+proxymap  unix  -       -       n       -       -       proxymap
+proxywrite unix -       -       n       -       1       proxymap
+smtp      unix  -       -       n       -       -       smtp
+relay     unix  -       -       n       -       -       smtp
+showq     unix  n       -       n       -       -       showq
+error     unix  -       -       n       -       -       error
+retry     unix  -       -       n       -       -       error
+discard   unix  -       -       n       -       -       discard
+local     unix  -       n       n       -       -       local
+virtual   unix  -       n       n       -       -       virtual
+lmtp      unix  -       -       n       -       -       lmtp
+anvil     unix  -       -       n       -       1       anvil
+scache    unix  -       -       n       -       1       scache
+postlog   unix-dgram n  -       n       -       1       postlogd
+
+# ==========================================================================
+# Freegle mail pipe - delivers to Laravel for processing
+# ==========================================================================
+# flags=F - fold recipient addresses to lowercase
+# user=mail-handler - run as unprivileged user
+# argv - the command to execute with sender and recipient
+#
+# The Laravel batch container is accessed via docker exec from the host.
+# This requires the postfix container to have access to the docker socket.
+#
+# Alternative: Use HTTP endpoint instead of pipe (see comments below)
+# ==========================================================================
+
+freegle   unix  -       n       n       -       4       pipe
+  flags=F user=mail-handler argv=/usr/local/bin/freegle-mail-handler ${sender} ${recipient}

--- a/conf/postfix/transport
+++ b/conf/postfix/transport
@@ -1,0 +1,10 @@
+# Postfix transport map for Freegle domains
+# Format: domain    transport:nexthop
+#
+# All Freegle domains are routed to the "freegle" pipe transport
+# which delivers to Laravel via the mail handler script
+
+groups.ilovefreegle.org     freegle:
+users.ilovefreegle.org      freegle:
+user.trashnothing.com       freegle:
+ilovefreegle.org            freegle:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1256,6 +1256,35 @@ services:
       start_period: 180s
 
   # =========================================
+  # Incoming Mail Processing (Postfix)
+  # =========================================
+  # Receives incoming mail and routes to Laravel for processing.
+  # IMPORTANT: This container does NOT receive mail until MX records are updated.
+  # Safe to run - mail only arrives when DNS points to this server.
+
+  postfix:
+    container_name: freegle-postfix
+    profiles:
+      - mail
+    build:
+      context: ./conf/postfix
+      dockerfile: Dockerfile
+    networks:
+      - default
+    ports:
+      - "25:25"
+    depends_on:
+      batch:
+        condition: service_healthy
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "postfix status || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
+  # =========================================
   # MCP Support Tools (Privacy-Preserving Log Analysis)
   # =========================================
 

--- a/iznik-batch/app/Console/Commands/IncomingMailCommand.php
+++ b/iznik-batch/app/Console/Commands/IncomingMailCommand.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Services\Mail\Incoming\IncomingMailService;
+use App\Services\Mail\Incoming\MailParserService;
+use App\Services\Mail\Incoming\RoutingResult;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Process incoming email from Postfix.
+ *
+ * This command is the entry point for Postfix to deliver incoming emails.
+ * It reads the raw email from stdin (or --stdin-content for testing),
+ * parses it, and routes it using IncomingMailService.
+ *
+ * Usage from Postfix master.cf:
+ *   freegle unix - n n - - pipe
+ *     flags=F user=www-data argv=/usr/bin/php /path/artisan mail:incoming ${sender} ${recipient}
+ *
+ * Exit codes (per sysexits.h):
+ *   0 (EX_OK) - Message processed successfully
+ *   75 (EX_TEMPFAIL) - Temporary failure, Postfix should retry
+ */
+class IncomingMailCommand extends Command
+{
+    protected $signature = 'mail:incoming
+        {sender : The envelope sender (MAIL FROM)}
+        {recipient : The envelope recipient (RCPT TO)}
+        {--stdin-content= : Raw email content (for testing, instead of stdin)}';
+
+    protected $description = 'Process incoming email from Postfix';
+
+    /**
+     * Postfix exit codes.
+     */
+    private const EX_OK = 0;
+
+    private const EX_TEMPFAIL = 75;
+
+    public function handle(MailParserService $parser, IncomingMailService $service): int
+    {
+        $sender = $this->argument('sender');
+        $recipient = $this->argument('recipient');
+
+        // Get raw email content from stdin or test option
+        $rawEmail = $this->option('stdin-content');
+        if ($rawEmail === null) {
+            $rawEmail = file_get_contents('php://stdin');
+        }
+
+        try {
+            // Parse the email
+            $parsed = $parser->parse($rawEmail, $sender, $recipient);
+
+            // Log verbose info if requested
+            if ($this->output->isVerbose()) {
+                $this->line("From: {$parsed->fromAddress}");
+                $this->line("Subject: {$parsed->subject}");
+                $this->line("Envelope-From: {$sender}");
+                $this->line("Envelope-To: {$recipient}");
+            }
+
+            // Route the email
+            $result = $service->route($parsed);
+
+            // Output the result
+            $this->line($result->value);
+
+            // Log for monitoring
+            Log::channel('incoming_mail')->info('Mail processed', [
+                'source' => 'batch',
+                'job' => 'mail:incoming',
+                'envelope_from' => $sender,
+                'envelope_to' => $recipient,
+                'from_address' => $parsed->fromAddress,
+                'subject' => $parsed->subject,
+                'message_id' => $parsed->messageId,
+                'routing_result' => $result->value,
+            ]);
+
+            return $result->getExitCode();
+
+        } catch (\Throwable $e) {
+            // Log the error
+            Log::channel('incoming_mail')->error('Mail processing failed', [
+                'source' => 'batch',
+                'job' => 'mail:incoming',
+                'envelope_from' => $sender,
+                'envelope_to' => $recipient,
+                'error' => $e->getMessage(),
+                'trace' => $e->getTraceAsString(),
+            ]);
+
+            // For unrecoverable errors, still return success to prevent endless retries
+            // Only return TEMPFAIL for transient database/connection errors
+            if ($this->isTransientError($e)) {
+                $this->error('Temporary failure: '.$e->getMessage());
+
+                return self::EX_TEMPFAIL;
+            }
+
+            // Log and drop the message
+            $this->error('Processing failed: '.$e->getMessage());
+
+            return self::EX_OK;
+        }
+    }
+
+    /**
+     * Check if an exception represents a transient error.
+     *
+     * Transient errors are temporary issues that Postfix should retry.
+     */
+    private function isTransientError(\Throwable $e): bool
+    {
+        $message = strtolower($e->getMessage());
+
+        // Database connection errors
+        if (str_contains($message, 'connection refused') ||
+            str_contains($message, 'too many connections') ||
+            str_contains($message, 'connection timed out') ||
+            str_contains($message, 'deadlock')) {
+            return true;
+        }
+
+        // MySQL-specific transient errors
+        if ($e instanceof \PDOException) {
+            $errorCode = $e->getCode();
+            // 2002: Can't connect to local MySQL server
+            // 2006: MySQL server has gone away
+            // 1040: Too many connections
+            // 1205: Lock wait timeout
+            // 1213: Deadlock found
+            if (in_array($errorCode, ['2002', '2006', '1040', '1205', '1213'])) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/iznik-batch/app/Console/Commands/Mail/RecoverMissedWelcomeMailsCommand.php
+++ b/iznik-batch/app/Console/Commands/Mail/RecoverMissedWelcomeMailsCommand.php
@@ -8,7 +8,6 @@ use App\Models\EmailTracking;
 use App\Models\User;
 use App\Services\EmailSpoolerService;
 use Illuminate\Console\Command;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Mail;
 
@@ -16,11 +15,12 @@ class RecoverMissedWelcomeMailsCommand extends Command
 {
     use FeatureFlags;
 
-    private const EMAIL_TYPE = "Welcome";
+    private const EMAIL_TYPE = 'Welcome';
+
     /**
      * The name and signature of the console command.
      */
-    protected $signature = "mail:welcome:recover
+    protected $signature = 'mail:welcome:recover
                             {--start= : Start date of transition window (Y-m-d H:i:s)}
                             {--end= : End date of transition window (Y-m-d H:i:s)}
                             {--limit=100 : Maximum emails to send per run}
@@ -28,12 +28,12 @@ class RecoverMissedWelcomeMailsCommand extends Command
                             {--check-activity : Only send to users with no activity (no logins/messages)}
                             {--spool : Spool emails instead of sending directly}
                             {--dry-run : Show what would be sent without actually sending}
-                            {--force : Send even if user appears to have received welcome already}";
+                            {--force : Send even if user appears to have received welcome already}';
 
     /**
      * The console command description.
      */
-    protected $description = "Recover and send welcome emails to users who may have been missed during the transition to batch sending";
+    protected $description = 'Recover and send welcome emails to users who may have been missed during the transition to batch sending';
 
     /**
      * Execute the console command.
@@ -41,23 +41,25 @@ class RecoverMissedWelcomeMailsCommand extends Command
     public function handle(EmailSpoolerService $spooler): int
     {
         // Check if Welcome emails are enabled for this batch system.
-        if (!self::isEmailTypeEnabled(self::EMAIL_TYPE)) {
+        if (! self::isEmailTypeEnabled(self::EMAIL_TYPE)) {
             $this->info("Welcome emails are not enabled in iznik-batch. Set FREEGLE_MAIL_ENABLED_TYPES in .env to include 'Welcome'.");
+
             return Command::SUCCESS;
         }
 
-        $startDate = $this->option("start");
-        $endDate = $this->option("end");
-        $limit = (int) $this->option("limit");
-        $checkTracking = $this->option("check-tracking");
-        $checkActivity = $this->option("check-activity");
-        $spool = $this->option("spool");
-        $dryRun = $this->option("dry-run");
-        $force = $this->option("force");
+        $startDate = $this->option('start');
+        $endDate = $this->option('end');
+        $limit = (int) $this->option('limit');
+        $checkTracking = $this->option('check-tracking');
+        $checkActivity = $this->option('check-activity');
+        $spool = $this->option('spool');
+        $dryRun = $this->option('dry-run');
+        $force = $this->option('force');
 
-        if (!$startDate || !$endDate) {
-            $this->error("Both --start and --end dates are required.");
+        if (! $startDate || ! $endDate) {
+            $this->error('Both --start and --end dates are required.');
             $this->line("Example: php artisan mail:welcome:recover --start='2024-12-23 00:00:00' --end='2024-12-24 00:00:00'");
+
             return Command::FAILURE;
         }
 
@@ -65,24 +67,25 @@ class RecoverMissedWelcomeMailsCommand extends Command
             $start = new \DateTime($startDate);
             $end = new \DateTime($endDate);
         } catch (\Exception $e) {
-            $this->error("Invalid date format. Use Y-m-d H:i:s format.");
+            $this->error('Invalid date format. Use Y-m-d H:i:s format.');
+
             return Command::FAILURE;
         }
 
         $this->info("Searching for users created between {$startDate} and {$endDate}...");
 
         // Build query for users in the transition window.
-        $query = User::whereNull("deleted")
-            ->where("added", ">=", $start)
-            ->where("added", "<=", $end)
-            ->whereHas("emails", function ($q) {
-                $q->whereNull("bounced");
+        $query = User::whereNull('deleted')
+            ->where('added', '>=', $start)
+            ->where('added', '<=', $end)
+            ->whereHas('emails', function ($q) {
+                $q->whereNull('bounced');
             });
 
         // Optionally exclude users who have a welcome email in tracking table.
-        if ($checkTracking && !$force) {
-            $query->whereDoesntHave("emailTracking", function ($q) {
-                $q->where("email_type", "welcome");
+        if ($checkTracking && ! $force) {
+            $query->whereDoesntHave('emailTracking', function ($q) {
+                $q->where('email_type', 'welcome');
             });
         }
 
@@ -90,22 +93,23 @@ class RecoverMissedWelcomeMailsCommand extends Command
         if ($checkActivity) {
             $query->where(function ($q) {
                 // No logins since creation.
-                $q->whereNull("lastaccess")
-                    ->orWhereRaw("lastaccess = added");
+                $q->whereNull('lastaccess')
+                    ->orWhereRaw('lastaccess = added');
             });
         }
 
         $totalUsers = $query->count();
-        $this->info("Found {$totalUsers} users in transition window" .
-            ($checkTracking ? " without welcome tracking record" : "") .
-            ($checkActivity ? " with no activity" : "") . ".");
+        $this->info("Found {$totalUsers} users in transition window".
+            ($checkTracking ? ' without welcome tracking record' : '').
+            ($checkActivity ? ' with no activity' : '').'.');
 
         if ($totalUsers === 0) {
-            $this->info("No users need recovery.");
+            $this->info('No users need recovery.');
+
             return Command::SUCCESS;
         }
 
-        $users = $query->orderBy("id")->limit($limit)->get();
+        $users = $query->orderBy('id')->limit($limit)->get();
 
         $this->info("Processing {$users->count()} users (limit: {$limit})...");
         $this->newLine();
@@ -118,43 +122,46 @@ class RecoverMissedWelcomeMailsCommand extends Command
         foreach ($users as $user) {
             // Get the user's preferred email address.
             $email = $user->emails()
-                ->whereNull("bounced")
-                ->orderByDesc("preferred")
-                ->orderByDesc("validated")
+                ->whereNull('bounced')
+                ->orderByDesc('preferred')
+                ->orderByDesc('validated')
                 ->first();
 
-            if (!$email) {
+            if (! $email) {
                 $this->warn("User {$user->id} has no valid email address, skipping.");
                 $skipped++;
+
                 continue;
             }
 
             // Double-check tracking table if requested.
-            if ($checkTracking && !$force) {
-                $hasWelcome = EmailTracking::where("userid", $user->id)
-                    ->where("email_type", "welcome")
+            if ($checkTracking && ! $force) {
+                $hasWelcome = EmailTracking::where('userid', $user->id)
+                    ->where('email_type', 'welcome')
                     ->exists();
 
                 if ($hasWelcome) {
                     $this->line("User {$user->id} already has welcome tracking record, skipping.");
                     $alreadyWelcomed++;
+
                     continue;
                 }
             }
 
             // Show user details.
-            $activityStatus = $user->lastaccess ? "active" : "no activity";
+            $activityStatus = $user->lastaccess ? 'active' : 'no activity';
             $this->line(sprintf(
-                "User %d: %s (%s) - added %s [%s]",
+                'User %d: %s (%s) - added %s [%s]',
                 $user->id,
                 $email->email,
-                $user->fullname ?? "no name",
+                $user->fullname ?? 'no name',
                 $user->added,
                 $activityStatus
             ));
 
             if ($dryRun) {
                 $sent++;
+
                 continue;
             }
 
@@ -166,27 +173,27 @@ class RecoverMissedWelcomeMailsCommand extends Command
                 );
 
                 if ($spool) {
-                    $spooler->spool($mailable, $email->email, "welcome");
-                    $this->info("  -> Spooled welcome mail");
+                    $spooler->spool($mailable, $email->email, 'welcome');
+                    $this->info('  -> Spooled welcome mail');
                 } else {
                     Mail::to($email->email)->send($mailable);
-                    $this->info("  -> Sent welcome mail");
+                    $this->info('  -> Sent welcome mail');
                 }
 
                 $sent++;
 
-                Log::info("Recovery welcome mail sent", [
-                    "user_id" => $user->id,
-                    "email" => $email->email,
-                    "transition_recovery" => true,
-                    "spooled" => $spool,
+                Log::info('Recovery welcome mail sent', [
+                    'user_id' => $user->id,
+                    'email' => $email->email,
+                    'transition_recovery' => true,
+                    'spooled' => $spool,
                 ]);
             } catch (\Exception $e) {
                 $this->error("  -> Failed: {$e->getMessage()}");
-                Log::error("Recovery welcome mail failed", [
-                    "user_id" => $user->id,
-                    "email" => $email->email,
-                    "error" => $e->getMessage(),
+                Log::error('Recovery welcome mail failed', [
+                    'user_id' => $user->id,
+                    'email' => $email->email,
+                    'error' => $e->getMessage(),
                 ]);
                 $errors++;
             }
@@ -194,19 +201,19 @@ class RecoverMissedWelcomeMailsCommand extends Command
 
         $this->newLine();
         $this->table(
-            ["Metric", "Count"],
+            ['Metric', 'Count'],
             [
-                ["Total in window", $totalUsers],
-                ["Processed", $users->count()],
-                ["Sent/Would send", $sent],
-                ["Already welcomed", $alreadyWelcomed],
-                ["Skipped (no email)", $skipped],
-                ["Errors", $errors],
+                ['Total in window', $totalUsers],
+                ['Processed', $users->count()],
+                ['Sent/Would send', $sent],
+                ['Already welcomed', $alreadyWelcomed],
+                ['Skipped (no email)', $skipped],
+                ['Errors', $errors],
             ]
         );
 
         if ($dryRun) {
-            $this->warn("Dry run - no emails were actually sent.");
+            $this->warn('Dry run - no emails were actually sent.');
         }
 
         if ($totalUsers > $limit) {

--- a/iznik-batch/app/Console/Commands/Mail/SendPendingWelcomeMailsCommand.php
+++ b/iznik-batch/app/Console/Commands/Mail/SendPendingWelcomeMailsCommand.php
@@ -21,27 +21,29 @@ class SendPendingWelcomeMailsCommand extends Command
     /**
      * The name and signature of the console command.
      */
-    protected $signature = "mail:welcome:send
+    protected $signature = 'mail:welcome:send
                             {--limit=100 : Maximum welcome mails to send per run}
                             {--days=1 : Only process users added within this many days}
                             {--spool : Spool emails instead of sending directly}
-                            {--dry-run : Show what would be sent without actually sending}";
+                            {--dry-run : Show what would be sent without actually sending}';
 
     /**
      * The console command description.
      */
-    protected $description = "Send pending welcome emails to new users";
+    protected $description = 'Send pending welcome emails to new users';
 
-    private const JOB_TYPE = "welcome";
-    private const EMAIL_TYPE = "Welcome";
+    private const JOB_TYPE = 'welcome';
+
+    private const EMAIL_TYPE = 'Welcome';
 
     /**
      * Execute the console command.
      */
     public function handle(EmailSpoolerService $spooler): int
     {
-        if (!$this->acquireLock()) {
+        if (! $this->acquireLock()) {
             $this->info('Already running, exiting.');
+
             return Command::SUCCESS;
         }
 
@@ -58,15 +60,16 @@ class SendPendingWelcomeMailsCommand extends Command
     protected function doHandle(EmailSpoolerService $spooler): int
     {
         // Check if Welcome emails are enabled for this batch system.
-        if (!self::isEmailTypeEnabled(self::EMAIL_TYPE)) {
+        if (! self::isEmailTypeEnabled(self::EMAIL_TYPE)) {
             $this->info("Welcome emails are not enabled in iznik-batch. Set FREEGLE_MAIL_ENABLED_TYPES in .env to include 'Welcome'.");
+
             return Command::SUCCESS;
         }
 
-        $limit = (int) $this->option("limit");
-        $days = (int) $this->option("days");
-        $spool = $this->option("spool");
-        $dryRun = $this->option("dry-run");
+        $limit = (int) $this->option('limit');
+        $days = (int) $this->option('days');
+        $spool = $this->option('spool');
+        $dryRun = $this->option('dry-run');
 
         $this->info("Looking for pending welcome mails (limit: {$limit}, days: {$days})...");
 
@@ -76,15 +79,15 @@ class SendPendingWelcomeMailsCommand extends Command
         // If this is the first run (no last_processed_id), initialize to current max user ID.
         // This assumes all existing users were welcomed synchronously before this batch system.
         if ($progress->last_processed_id === null) {
-            $maxUserId = DB::table("users")->max("id") ?? 0;
+            $maxUserId = DB::table('users')->max('id') ?? 0;
             $this->info("First run detected. Initializing last_processed_id to {$maxUserId}.");
             $progress->last_processed_id = $maxUserId;
             $progress->last_processed_at = now();
             $progress->save();
 
-            if (!$dryRun) {
-                Log::info("Welcome mail batch initialized", [
-                    "last_processed_id" => $maxUserId,
+            if (! $dryRun) {
+                Log::info('Welcome mail batch initialized', [
+                    'last_processed_id' => $maxUserId,
                 ]);
             }
         }
@@ -99,13 +102,13 @@ class SendPendingWelcomeMailsCommand extends Command
         $cutoffDate = now()->subDays($days);
         $lastProcessedId = $progress->last_processed_id;
 
-        $users = User::where("id", ">", $lastProcessedId)
-            ->whereNull("deleted")
-            ->where("added", ">=", $cutoffDate)
-            ->whereHas("emails", function ($query) {
-                $query->whereNull("bounced");
+        $users = User::where('id', '>', $lastProcessedId)
+            ->whereNull('deleted')
+            ->where('added', '>=', $cutoffDate)
+            ->whereHas('emails', function ($query) {
+                $query->whereNull('bounced');
             })
-            ->orderBy("id")
+            ->orderBy('id')
             ->limit($limit)
             ->get();
 
@@ -119,16 +122,17 @@ class SendPendingWelcomeMailsCommand extends Command
         foreach ($users as $user) {
             // Get the user's preferred email address.
             $email = $user->emails()
-                ->whereNull("bounced")
-                ->orderByDesc("preferred")
-                ->orderByDesc("validated")
+                ->whereNull('bounced')
+                ->orderByDesc('preferred')
+                ->orderByDesc('validated')
                 ->first();
 
-            if (!$email) {
+            if (! $email) {
                 $this->warn("User {$user->id} has no valid email address, skipping.");
                 $skipped++;
                 // Still update progress even if skipped - we processed this user.
                 $lastSuccessfulId = $user->id;
+
                 continue;
             }
 
@@ -136,6 +140,7 @@ class SendPendingWelcomeMailsCommand extends Command
                 $this->line("Would send welcome mail to: {$email->email} (user {$user->id})");
                 $sent++;
                 $lastSuccessfulId = $user->id;
+
                 continue;
             }
 
@@ -147,7 +152,7 @@ class SendPendingWelcomeMailsCommand extends Command
                 );
 
                 if ($spool) {
-                    $spooler->spool($mailable, $email->email, "welcome");
+                    $spooler->spool($mailable, $email->email, 'welcome');
                     $this->line("Spooled welcome mail for: {$email->email}");
                 } else {
                     Mail::to($email->email)->send($mailable);
@@ -160,17 +165,17 @@ class SendPendingWelcomeMailsCommand extends Command
                 // Update progress after each successful send.
                 $progress->markProcessed($lastSuccessfulId);
 
-                Log::info("Welcome mail sent", [
-                    "user_id" => $user->id,
-                    "email" => $email->email,
-                    "spooled" => $spool,
+                Log::info('Welcome mail sent', [
+                    'user_id' => $user->id,
+                    'email' => $email->email,
+                    'spooled' => $spool,
                 ]);
             } catch (\Exception $e) {
                 $this->error("Failed to send welcome mail to {$email->email}: {$e->getMessage()}");
-                Log::error("Welcome mail failed", [
-                    "user_id" => $user->id,
-                    "email" => $email->email,
-                    "error" => $e->getMessage(),
+                Log::error('Welcome mail failed', [
+                    'user_id' => $user->id,
+                    'email' => $email->email,
+                    'error' => $e->getMessage(),
                 ]);
                 $errors++;
                 // Do not update progress on error - we will retry this user next run.
@@ -179,23 +184,23 @@ class SendPendingWelcomeMailsCommand extends Command
         }
 
         // Final progress update (for skipped users).
-        if ($lastSuccessfulId > $lastProcessedId && !$dryRun) {
+        if ($lastSuccessfulId > $lastProcessedId && ! $dryRun) {
             $progress->markProcessed($lastSuccessfulId);
         }
 
         $this->newLine();
         $this->table(
-            ["Metric", "Count"],
+            ['Metric', 'Count'],
             [
-                ["Sent", $sent],
-                ["Skipped", $skipped],
-                ["Errors", $errors],
-                ["Last Processed ID", $lastSuccessfulId],
+                ['Sent', $sent],
+                ['Skipped', $skipped],
+                ['Errors', $errors],
+                ['Last Processed ID', $lastSuccessfulId],
             ]
         );
 
         if ($dryRun) {
-            $this->warn("Dry run - no emails were actually sent.");
+            $this->warn('Dry run - no emails were actually sent.');
         }
 
         return Command::SUCCESS;

--- a/iznik-batch/app/Console/Commands/Mail/SendTestChatNotificationCommand.php
+++ b/iznik-batch/app/Console/Commands/Mail/SendTestChatNotificationCommand.php
@@ -25,8 +25,9 @@ class SendTestChatNotificationCommand extends Command
 
         if ($chatId) {
             $chatRoom = ChatRoom::find($chatId);
-            if (!$chatRoom) {
+            if (! $chatRoom) {
                 $this->error("Chat room {$chatId} not found.");
+
                 return 1;
             }
         } else {
@@ -34,11 +35,12 @@ class SendTestChatNotificationCommand extends Command
             $chatRoom = ChatRoom::whereHas('messages', function ($q) {
                 $q->where('date', '>=', now()->subDays(30));
             })
-            ->where('chattype', ChatRoom::TYPE_USER2USER)
-            ->first();
+                ->where('chattype', ChatRoom::TYPE_USER2USER)
+                ->first();
 
-            if (!$chatRoom) {
+            if (! $chatRoom) {
                 $this->error('No chat rooms with recent messages found.');
+
                 return 1;
             }
         }
@@ -49,8 +51,9 @@ class SendTestChatNotificationCommand extends Command
         $user1 = User::find($chatRoom->user1);
         $user2 = User::find($chatRoom->user2);
 
-        if (!$user1 || !$user2) {
+        if (! $user1 || ! $user2) {
             $this->error('Could not find users for this chat room.');
+
             return 1;
         }
 
@@ -61,8 +64,9 @@ class SendTestChatNotificationCommand extends Command
             ->with(['user', 'refMessage'])
             ->first();
 
-        if (!$latestMessage) {
+        if (! $latestMessage) {
             $this->error('No messages found in this chat room.');
+
             return 1;
         }
 
@@ -91,7 +95,7 @@ class SendTestChatNotificationCommand extends Command
         // In this case, the recipient IS the sender (they get a copy of their own message).
         if ($this->option('own-message')) {
             $recipient = $sender;
-            $this->info("Simulating OWN MESSAGE notification (copy to self).");
+            $this->info('Simulating OWN MESSAGE notification (copy to self).');
         } else {
             // Normal case: recipient is the OTHER user in the chat.
             $recipient = $latestMessage->userid === $user1->id ? $user2 : $user1;
@@ -99,14 +103,15 @@ class SendTestChatNotificationCommand extends Command
 
         $toEmail = $this->option('to') ?? $recipient->email_preferred;
 
-        if (!$toEmail) {
-            $this->error("Recipient has no email address. Use --to to specify one.");
+        if (! $toEmail) {
+            $this->error('Recipient has no email address. Use --to to specify one.');
+
             return 1;
         }
 
         // Use display names or generate meaningful ones for clarity.
-        $senderDisplayName = $sender->displayname ?: 'User' . $sender->id;
-        $recipientDisplayName = $recipient->displayname ?: 'User' . $recipient->id;
+        $senderDisplayName = $sender->displayname ?: 'User'.$sender->id;
+        $recipientDisplayName = $recipient->displayname ?: 'User'.$recipient->id;
 
         $this->info("Sending test email to: {$toEmail}");
         $this->info("Message sender: {$senderDisplayName}");
@@ -129,7 +134,7 @@ class SendTestChatNotificationCommand extends Command
         Mail::to($toEmail)->send($mail);
 
         $this->info('Test email sent successfully!');
-        $this->info("Check Mailpit at http://mailpit.localhost to view it.");
+        $this->info('Check Mailpit at http://mailpit.localhost to view it.');
 
         return 0;
     }

--- a/iznik-batch/app/Console/Commands/Mail/SendUnifiedDigestCommand.php
+++ b/iznik-batch/app/Console/Commands/Mail/SendUnifiedDigestCommand.php
@@ -24,7 +24,7 @@ class SendUnifiedDigestCommand extends Command
      */
     protected $description = "Send unified Freegle digests containing posts from all user's communities";
 
-    private const EMAIL_TYPE = "UnifiedDigest";
+    private const EMAIL_TYPE = 'UnifiedDigest';
 
     /**
      * Execute the console command.
@@ -32,19 +32,21 @@ class SendUnifiedDigestCommand extends Command
     public function handle(UnifiedDigestService $service): int
     {
         // Check if UnifiedDigest emails are enabled for this batch system.
-        if (!self::isEmailTypeEnabled(self::EMAIL_TYPE)) {
+        if (! self::isEmailTypeEnabled(self::EMAIL_TYPE)) {
             $this->info("UnifiedDigest emails are not enabled in iznik-batch. Set FREEGLE_MAIL_ENABLED_TYPES in .env to include 'UnifiedDigest'.");
+
             return Command::SUCCESS;
         }
 
-        $mode = $this->option("mode");
-        $userId = $this->option("user") ? (int) $this->option("user") : null;
-        $limit = (int) $this->option("limit");
-        $dryRun = $this->option("dry-run");
+        $mode = $this->option('mode');
+        $userId = $this->option('user') ? (int) $this->option('user') : null;
+        $limit = (int) $this->option('limit');
+        $dryRun = $this->option('dry-run');
 
         // Validate mode.
-        if (!in_array($mode, [UnifiedDigestService::MODE_DAILY, UnifiedDigestService::MODE_IMMEDIATE])) {
+        if (! in_array($mode, [UnifiedDigestService::MODE_DAILY, UnifiedDigestService::MODE_IMMEDIATE])) {
             $this->error("Invalid mode '{$mode}'. Must be 'daily' or 'immediate'.");
+
             return Command::FAILURE;
         }
 
@@ -55,10 +57,11 @@ class SendUnifiedDigestCommand extends Command
         }
 
         if ($dryRun) {
-            $this->warn("Dry run mode - no emails will actually be sent.");
+            $this->warn('Dry run mode - no emails will actually be sent.');
             // In dry run mode, we just show what would happen.
             // The service doesn't support dry-run internally, so we just report.
             $this->info("Would process digests for users with {$mode} mode.");
+
             return Command::SUCCESS;
         }
 
@@ -67,16 +70,16 @@ class SendUnifiedDigestCommand extends Command
 
         $this->newLine();
         $this->table(
-            ["Metric", "Count"],
+            ['Metric', 'Count'],
             [
-                ["Users Processed", $stats["users_processed"]],
-                ["Emails Sent", $stats["emails_sent"]],
-                ["No New Posts", $stats["no_new_posts"]],
-                ["Errors", $stats["errors"]],
+                ['Users Processed', $stats['users_processed']],
+                ['Emails Sent', $stats['emails_sent']],
+                ['No New Posts', $stats['no_new_posts']],
+                ['Errors', $stats['errors']],
             ]
         );
 
-        if ($stats["errors"] > 0) {
+        if ($stats['errors'] > 0) {
             $this->warn("There were {$stats['errors']} errors. Check logs for details.");
         }
 

--- a/iznik-batch/app/Console/Commands/Mail/TestMailCommand.php
+++ b/iznik-batch/app/Console/Commands/Mail/TestMailCommand.php
@@ -3,7 +3,6 @@
 namespace App\Console\Commands\Mail;
 
 use App\Mail\Chat\ChatNotification;
-use App\Mail\Digest\MultipleDigest;
 use App\Mail\Digest\SingleDigest;
 use App\Mail\Donation\AskForDonation;
 use App\Mail\Donation\DonationThankYou;
@@ -93,6 +92,7 @@ class TestMailCommand extends Command
     {
         if ($this->option('list')) {
             $this->listEmailTypes();
+
             return Command::SUCCESS;
         }
 
@@ -100,14 +100,16 @@ class TestMailCommand extends Command
         $dryRun = $this->option('dry-run');
         $allTypes = $this->option('all-types');
 
-        if (!$type) {
-            $this->error("Email type is required. Use --list to see available types.");
+        if (! $type) {
+            $this->error('Email type is required. Use --list to see available types.');
+
             return Command::FAILURE;
         }
 
-        if (!isset($this->emailTypes[$type])) {
+        if (! isset($this->emailTypes[$type])) {
             $this->error("Unknown email type: {$type}");
             $this->listEmailTypes();
+
             return Command::FAILURE;
         }
 
@@ -123,8 +125,9 @@ class TestMailCommand extends Command
         try {
             $mailable = $this->buildMailable($type);
 
-            if (!$mailable) {
+            if (! $mailable) {
                 DB::rollBack();
+
                 return Command::FAILURE;
             }
 
@@ -167,12 +170,13 @@ class TestMailCommand extends Command
                 if ($stats['sent'] > 0) {
                     $this->info("Test email sent successfully! (spool ID: {$spoolId})");
                 } else {
-                    $this->warn("Email spooled but not sent yet. Check spool directory.");
+                    $this->warn('Email spooled but not sent yet. Check spool directory.');
                 }
             }
         } catch (\Exception $e) {
-            $this->error("Error: " . $e->getMessage());
+            $this->error('Error: '.$e->getMessage());
             DB::rollBack();
+
             return Command::FAILURE;
         }
 
@@ -194,8 +198,9 @@ class TestMailCommand extends Command
         };
 
         $toEmail = $this->option('to');
-        if (!$toEmail) {
-            $this->error("Please specify --to=email to find chat messages for that user");
+        if (! $toEmail) {
+            $this->error('Please specify --to=email to find chat messages for that user');
+
             return Command::FAILURE;
         }
 
@@ -204,8 +209,9 @@ class TestMailCommand extends Command
             $q->where('email', $toEmail);
         })->first();
 
-        if (!$recipient) {
+        if (! $recipient) {
             $this->error("No user found with email: {$toEmail}");
+
             return Command::FAILURE;
         }
 
@@ -223,11 +229,12 @@ class TestMailCommand extends Command
             try {
                 $mailable = $this->buildChatNotificationForType($chatType, $recipient, $messageType);
 
-                if (!$mailable) {
+                if (! $mailable) {
                     $skippedTypes[] = $messageType;
                     $this->warn("Skipped {$messageType} - no messages found");
                     DB::rollBack();
                     $this->newLine();
+
                     continue;
                 }
 
@@ -263,11 +270,11 @@ class TestMailCommand extends Command
                         $this->info("Sent {$messageType} notification (spool ID: {$spoolId})");
                         $sentCount++;
                     } else {
-                        $this->warn("Spooled but not sent yet");
+                        $this->warn('Spooled but not sent yet');
                     }
                 }
             } catch (\Exception $e) {
-                $this->error("Error for {$messageType}: " . $e->getMessage());
+                $this->error("Error for {$messageType}: ".$e->getMessage());
                 $skippedTypes[] = $messageType;
             }
 
@@ -275,17 +282,17 @@ class TestMailCommand extends Command
             $this->newLine();
 
             // Small delay between sends to avoid overwhelming the mail server.
-            if (!$dryRun) {
+            if (! $dryRun) {
                 usleep(500000); // 0.5 second
             }
         }
 
         $this->newLine();
-        $this->info("=== Summary ===");
+        $this->info('=== Summary ===');
         $this->info("Sent: {$sentCount} emails");
 
-        if (!empty($skippedTypes)) {
-            $this->warn("Skipped types (no messages found): " . implode(', ', $skippedTypes));
+        if (! empty($skippedTypes)) {
+            $this->warn('Skipped types (no messages found): '.implode(', ', $skippedTypes));
         }
 
         return Command::SUCCESS;
@@ -342,8 +349,9 @@ class TestMailCommand extends Command
         $messageType = $this->option('message-type');
 
         // Find recipient by email.
-        if (!$toEmail) {
-            $this->error("Please specify --to=email to find chat messages for that user");
+        if (! $toEmail) {
+            $this->error('Please specify --to=email to find chat messages for that user');
+
             return null;
         }
 
@@ -352,8 +360,9 @@ class TestMailCommand extends Command
             $q->where('email', $toEmail);
         })->first();
 
-        if (!$recipient) {
+        if (! $recipient) {
             $this->error("No user found with email: {$toEmail}");
+
             return null;
         }
 
@@ -362,8 +371,9 @@ class TestMailCommand extends Command
         // For User2Mod, check the --as option to determine perspective.
         $perspective = $this->option('as');
         if ($chatType === ChatRoom::TYPE_USER2MOD && $perspective) {
-            if (!in_array($perspective, ['member', 'mod'])) {
+            if (! in_array($perspective, ['member', 'mod'])) {
                 $this->error("Invalid --as option: {$perspective}. Use 'member' or 'mod'.");
+
                 return null;
             }
             $this->info("Testing as: {$perspective}");
@@ -385,7 +395,7 @@ class TestMailCommand extends Command
                 ->whereHas('group', function ($q) use ($recipient) {
                     $q->whereHas('memberships', function ($mq) use ($recipient) {
                         $mq->where('userid', $recipient->id)
-                           ->whereIn('role', ['Moderator', 'Owner']);
+                            ->whereIn('role', ['Moderator', 'Owner']);
                     });
                 });
         } else {
@@ -403,9 +413,10 @@ class TestMailCommand extends Command
             $q->where('userid', '!=', $recipient->id);
         })->orderBy('id', 'desc')->first();
 
-        if (!$chatRoom) {
-            $this->error("No {$chatType} chat with messages found for user {$recipient->id}" .
+        if (! $chatRoom) {
+            $this->error("No {$chatType} chat with messages found for user {$recipient->id}".
                 ($perspective === 'mod' ? ' as moderator' : ''));
+
             return null;
         }
 
@@ -418,8 +429,9 @@ class TestMailCommand extends Command
             ->with(['user', 'refMessage'])
             ->first();
 
-        if (!$latestMessage) {
-            $this->error("No messages from other users found in this chat");
+        if (! $latestMessage) {
+            $this->error('No messages from other users found in this chat');
+
             return null;
         }
 
@@ -436,7 +448,7 @@ class TestMailCommand extends Command
             ->get()
             ->reverse();
 
-        $this->info("Found latest message from " . ($sender?->displayname ?? 'unknown') . ", plus " . $previousMessages->count() . " previous messages");
+        $this->info('Found latest message from '.($sender?->displayname ?? 'unknown').', plus '.$previousMessages->count().' previous messages');
 
         $mailable = new ChatNotification($recipient, $sender, $chatRoom, $latestMessage, $chatType, $previousMessages);
 
@@ -444,7 +456,7 @@ class TestMailCommand extends Command
         $ampOverride = $this->getAmpOverride();
         if ($ampOverride !== null) {
             $mailable->setAmpOverride($ampOverride);
-            $this->info("AMP email: " . ($ampOverride ? 'ON' : 'OFF') . " (override)");
+            $this->info('AMP email: '.($ampOverride ? 'ON' : 'OFF').' (override)');
         }
 
         return $mailable;
@@ -481,7 +493,7 @@ class TestMailCommand extends Command
             }
         }
 
-        if (!$latestMessage) {
+        if (! $latestMessage) {
             // Try to find any recent message of this type (limit search for performance).
             // Only search last 30 days and use indexed columns.
             $since = now()->subDays(30);
@@ -506,6 +518,7 @@ class TestMailCommand extends Command
                 $this->warn("Using chat from different user to find {$messageType} message");
             } else {
                 $this->warn("No {$messageType} messages found in any {$chatType} chat");
+
                 return null;
             }
         }
@@ -548,8 +561,9 @@ class TestMailCommand extends Command
 
         // Get user.
         $user = $userId ? User::find($userId) : User::whereHas('emails')->inRandomOrder()->first();
-        if (!$user) {
-            $this->error("User not found");
+        if (! $user) {
+            $this->error('User not found');
+
             return null;
         }
 
@@ -564,8 +578,9 @@ class TestMailCommand extends Command
             $group = $membership ? Group::find($membership->groupid) : Group::inRandomOrder()->first();
         }
 
-        if (!$group) {
-            $this->error("No group found");
+        if (! $group) {
+            $this->error('No group found');
+
             return null;
         }
 
@@ -580,8 +595,9 @@ class TestMailCommand extends Command
             })->inRandomOrder()->first();
         }
 
-        if (!$message) {
+        if (! $message) {
             $this->error("No message found for group {$group->nameshort}");
+
             return null;
         }
 
@@ -598,8 +614,9 @@ class TestMailCommand extends Command
         $userId = $this->option('user');
 
         $user = $userId ? User::find($userId) : User::whereHas('emails')->inRandomOrder()->first();
-        if (!$user) {
-            $this->error("User not found");
+        if (! $user) {
+            $this->error('User not found');
+
             return null;
         }
 
@@ -623,8 +640,9 @@ class TestMailCommand extends Command
         $userId = $this->option('user');
 
         $user = $userId ? User::find($userId) : User::whereHas('emails')->inRandomOrder()->first();
-        if (!$user) {
-            $this->error("User not found");
+        if (! $user) {
+            $this->error('User not found');
+
             return null;
         }
 
@@ -641,8 +659,9 @@ class TestMailCommand extends Command
         $userId = $this->option('user');
 
         $user = $userId ? User::find($userId) : User::whereHas('emails')->inRandomOrder()->first();
-        if (!$user) {
-            $this->error("User not found");
+        if (! $user) {
+            $this->error('User not found');
+
             return null;
         }
 
@@ -653,7 +672,7 @@ class TestMailCommand extends Command
         if ($location) {
             $this->info("User location: {$location->name} ({$location->lat}, {$location->lng})");
         } else {
-            $this->warn("User has no location set - nearby offers will not be shown");
+            $this->warn('User has no location set - nearby offers will not be shown');
         }
 
         // WelcomeMail takes email, optional password, and user ID for nearby offers.
@@ -689,12 +708,12 @@ class TestMailCommand extends Command
             $rendered = $mailable->render();
             // Show a truncated preview.
             if (strlen($rendered) > 2000) {
-                $this->line(substr($rendered, 0, 2000) . "\n\n... (truncated, " . strlen($rendered) . " total characters)");
+                $this->line(substr($rendered, 0, 2000)."\n\n... (truncated, ".strlen($rendered).' total characters)');
             } else {
                 $this->line($rendered);
             }
         } catch (\Exception $e) {
-            $this->error("Could not render email: " . $e->getMessage());
+            $this->error('Could not render email: '.$e->getMessage());
         }
 
         $this->newLine();

--- a/iznik-batch/app/Console/Commands/Mail/ValidateMailParsingCommand.php
+++ b/iznik-batch/app/Console/Commands/Mail/ValidateMailParsingCommand.php
@@ -1,0 +1,252 @@
+<?php
+
+namespace App\Console\Commands\Mail;
+
+use App\Services\Mail\Incoming\MailParserService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Validates that Laravel mail parsing produces identical results to the PHP implementation.
+ *
+ * This command fetches messages from the database and compares how they would be
+ * parsed/routed by the new Laravel code vs the stored results from the original PHP code.
+ *
+ * Usage:
+ *   php artisan mail:validate-parsing           # Validate last 100 messages
+ *   php artisan mail:validate-parsing --limit=500
+ *   php artisan mail:validate-parsing --message-id=12345
+ *   php artisan mail:validate-parsing --dry-run  # Show what would be validated
+ */
+class ValidateMailParsingCommand extends Command
+{
+    protected $signature = 'mail:validate-parsing
+        {--limit=100 : Number of messages to validate}
+        {--message-id= : Validate a specific message ID}
+        {--type= : Filter by message type (Offer, Wanted, etc.)}
+        {--dry-run : Show what would be validated without actually running}
+        {--verbose : Show detailed comparison for each message}';
+
+    protected $description = 'Validate that Laravel mail parsing matches PHP implementation';
+
+    private MailParserService $parser;
+
+    private int $totalChecked = 0;
+
+    private int $matched = 0;
+
+    private int $mismatched = 0;
+
+    private array $mismatches = [];
+
+    public function __construct(MailParserService $parser)
+    {
+        parent::__construct();
+        $this->parser = $parser;
+    }
+
+    public function handle(): int
+    {
+        $limit = (int) $this->option('limit');
+        $messageId = $this->option('message-id');
+        $type = $this->option('type');
+        $dryRun = $this->option('dry-run');
+        $verbose = $this->option('verbose');
+
+        $this->info('Mail Parsing Validation');
+        $this->info('======================');
+        $this->newLine();
+
+        // Build query
+        $query = DB::table('messages')
+            ->select([
+                'messages.id',
+                'messages.source',
+                'messages.message',
+                'messages.fromaddr',
+                'messages.envelopefrom',
+                'messages.envelopeto',
+                'messages.subject',
+                'messages.messageid',
+                'messages.type',
+                'messages.lastroute',
+                'messages.spamtype',
+                'messages.spamreason',
+            ])
+            ->whereNotNull('messages.message')
+            ->where('messages.message', '!=', '')
+            ->orderBy('messages.id', 'desc');
+
+        if ($messageId) {
+            $query->where('messages.id', $messageId);
+            $limit = 1;
+        }
+
+        if ($type) {
+            $query->where('messages.type', $type);
+        }
+
+        $query->limit($limit);
+
+        if ($dryRun) {
+            $count = $query->count();
+            $this->info("Would validate {$count} messages");
+            $this->info('Query: '.$query->toSql());
+
+            return self::SUCCESS;
+        }
+
+        $this->info("Validating up to {$limit} messages...");
+        $this->newLine();
+
+        $progressBar = $this->output->createProgressBar($limit);
+
+        $query->chunk(100, function ($messages) use ($progressBar, $verbose) {
+            foreach ($messages as $message) {
+                $this->validateMessage($message, $verbose);
+                $progressBar->advance();
+            }
+        });
+
+        $progressBar->finish();
+        $this->newLine(2);
+
+        // Summary
+        $this->info('Validation Summary');
+        $this->info('==================');
+        $this->info("Total checked: {$this->totalChecked}");
+        $this->info("Matched: {$this->matched}");
+        $this->warn("Mismatched: {$this->mismatched}");
+
+        if ($this->mismatched > 0) {
+            $this->newLine();
+            $this->error('Mismatches found:');
+
+            $headers = ['Message ID', 'Field', 'Expected (PHP)', 'Actual (Laravel)'];
+            $rows = [];
+
+            foreach ($this->mismatches as $mismatch) {
+                $rows[] = [
+                    $mismatch['id'],
+                    $mismatch['field'],
+                    $this->truncate($mismatch['expected'], 30),
+                    $this->truncate($mismatch['actual'], 30),
+                ];
+            }
+
+            $this->table($headers, $rows);
+
+            return self::FAILURE;
+        }
+
+        $this->info('All messages validated successfully!');
+
+        return self::SUCCESS;
+    }
+
+    private function validateMessage(object $message, bool $verbose): void
+    {
+        $this->totalChecked++;
+
+        // The raw message is stored in the 'message' column
+        $rawEmail = $message->message;
+        if (empty($rawEmail)) {
+            return;
+        }
+
+        // Parse using our new Laravel service
+        $envelopeFrom = $message->envelopefrom ?? $message->fromaddr ?? '';
+        $envelopeTo = $message->envelopeto ?? '';
+
+        try {
+            $parsed = $this->parser->parse($rawEmail, $envelopeFrom, $envelopeTo);
+        } catch (\Exception $e) {
+            $this->recordMismatch($message->id, 'parse_error', 'success', $e->getMessage());
+
+            return;
+        }
+
+        $allMatch = true;
+
+        // Compare subject
+        if ($message->subject !== $parsed->subject) {
+            $this->recordMismatch($message->id, 'subject', $message->subject, $parsed->subject);
+            $allMatch = false;
+        }
+
+        // Compare from address
+        if ($message->fromaddr && $message->fromaddr !== $parsed->fromAddress) {
+            $this->recordMismatch($message->id, 'fromaddr', $message->fromaddr, $parsed->fromAddress);
+            $allMatch = false;
+        }
+
+        // Compare message ID
+        if ($message->messageid && $message->messageid !== $parsed->messageId) {
+            // Normalize by removing angle brackets
+            $expectedMsgId = trim($message->messageid, '<>');
+            $actualMsgId = $parsed->messageId;
+            if ($expectedMsgId !== $actualMsgId) {
+                $this->recordMismatch($message->id, 'messageid', $expectedMsgId, $actualMsgId);
+                $allMatch = false;
+            }
+        }
+
+        // Compare type detection (bounce, chat reply, etc.)
+        $this->validateTypeDetection($message, $parsed, $allMatch);
+
+        if ($allMatch) {
+            $this->matched++;
+        } else {
+            $this->mismatched++;
+        }
+
+        if ($verbose) {
+            $status = $allMatch ? '✓' : '✗';
+            $this->line("  {$status} Message #{$message->id}: {$message->subject}");
+        }
+    }
+
+    private function validateTypeDetection(object $message, $parsed, bool &$allMatch): void
+    {
+        // Check bounce detection
+        $isBounceInDb = str_starts_with($message->envelopeto ?? '', 'bounce-');
+        if ($isBounceInDb !== $parsed->isBounce()) {
+            // Only flag if it's a clear bounce address pattern
+            if ($isBounceInDb) {
+                $this->recordMismatch($message->id, 'is_bounce', 'true', 'false');
+                $allMatch = false;
+            }
+        }
+
+        // Check chat reply detection
+        $isChatReplyInDb = str_starts_with($message->envelopeto ?? '', 'notify-');
+        if ($isChatReplyInDb !== $parsed->isChatNotificationReply()) {
+            if ($isChatReplyInDb) {
+                $this->recordMismatch($message->id, 'is_chat_reply', 'true', 'false');
+                $allMatch = false;
+            }
+        }
+    }
+
+    private function recordMismatch(int $id, string $field, ?string $expected, ?string $actual): void
+    {
+        $this->mismatches[] = [
+            'id' => $id,
+            'field' => $field,
+            'expected' => $expected ?? '(null)',
+            'actual' => $actual ?? '(null)',
+        ];
+    }
+
+    private function truncate(?string $value, int $length): string
+    {
+        if ($value === null) {
+            return '(null)';
+        }
+        if (strlen($value) <= $length) {
+            return $value;
+        }
+
+        return substr($value, 0, $length - 3).'...';
+    }
+}

--- a/iznik-batch/app/Console/Commands/ReplayIncomingArchiveCommand.php
+++ b/iznik-batch/app/Console/Commands/ReplayIncomingArchiveCommand.php
@@ -1,0 +1,328 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Services\Mail\Incoming\IncomingMailService;
+use App\Services\Mail\Incoming\MailParserService;
+use App\Services\Mail\Incoming\RoutingResult;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Replay archived incoming emails through the new Laravel code for shadow testing.
+ *
+ * This command processes archive files created by the legacy incoming.php script
+ * and compares the routing results. It runs in dry-run mode by default - no database
+ * changes are made.
+ *
+ * Archive files are expected to be JSON with this structure:
+ * {
+ *   "version": 1,
+ *   "timestamp": "2026-01-28T12:34:56Z",
+ *   "envelope": {
+ *     "from": "sender@example.com",
+ *     "to": "group@groups.ilovefreegle.org"
+ *   },
+ *   "raw_email": "... base64 encoded ...",
+ *   "legacy_result": {
+ *     "routing_outcome": "Approved",
+ *     "message_id": 12345,
+ *     ...
+ *   }
+ * }
+ */
+class ReplayIncomingArchiveCommand extends Command
+{
+    protected $signature = 'mail:replay-archive
+                            {path : Path to archive file or directory}
+                            {--limit=0 : Maximum number of files to process (0 = unlimited)}
+                            {--stop-on-mismatch : Stop processing when a mismatch is found}
+                            {--verbose-match : Show details for matching results too}
+                            {--output=table : Output format: table, json, or summary}';
+
+    protected $description = 'Replay archived incoming emails through new Laravel code for shadow testing';
+
+    /**
+     * Mapping from legacy routing outcomes to new RoutingResult values.
+     */
+    private const LEGACY_TO_NEW_MAP = [
+        'Failure' => RoutingResult::FAILURE,
+        'IncomingSpam' => RoutingResult::INCOMING_SPAM,
+        'Approved' => RoutingResult::APPROVED,
+        'Pending' => RoutingResult::PENDING,
+        'ToUser' => RoutingResult::TO_USER,
+        'ToSystem' => RoutingResult::TO_SYSTEM,
+        'ReadReceipt' => RoutingResult::RECEIPT,
+        'Tryst' => RoutingResult::TRYST,
+        'Dropped' => RoutingResult::DROPPED,
+        'ToVolunteers' => RoutingResult::TO_VOLUNTEERS,
+    ];
+
+    private IncomingMailService $incomingMailService;
+
+    private MailParserService $parserService;
+
+    public function __construct(IncomingMailService $incomingMailService, MailParserService $parserService)
+    {
+        parent::__construct();
+        $this->incomingMailService = $incomingMailService;
+        $this->parserService = $parserService;
+    }
+
+    public function handle(): int
+    {
+        $path = $this->argument('path');
+        $limit = (int) $this->option('limit');
+        $stopOnMismatch = $this->option('stop-on-mismatch');
+        $verboseMatch = $this->option('verbose-match');
+        $outputFormat = $this->option('output');
+
+        // Collect archive files
+        $files = $this->collectArchiveFiles($path);
+
+        if (empty($files)) {
+            $this->error("No archive files found at: $path");
+
+            return 1;
+        }
+
+        $this->info(sprintf('Found %d archive file(s)', count($files)));
+
+        if ($limit > 0) {
+            $files = array_slice($files, 0, $limit);
+            $this->info(sprintf('Processing first %d file(s)', $limit));
+        }
+
+        // Process files and collect results
+        $results = [];
+        $stats = [
+            'total' => 0,
+            'matched' => 0,
+            'mismatched' => 0,
+            'errors' => 0,
+        ];
+
+        $progressBar = $this->output->createProgressBar(count($files));
+        $progressBar->start();
+
+        foreach ($files as $file) {
+            $result = $this->processArchiveFile($file);
+            $results[] = $result;
+
+            $stats['total']++;
+            if ($result['error']) {
+                $stats['errors']++;
+            } elseif ($result['match']) {
+                $stats['matched']++;
+            } else {
+                $stats['mismatched']++;
+
+                if ($stopOnMismatch) {
+                    $progressBar->finish();
+                    $this->newLine();
+                    $this->error('Stopping on first mismatch');
+                    $this->displayMismatch($result);
+
+                    return 1;
+                }
+            }
+
+            $progressBar->advance();
+        }
+
+        $progressBar->finish();
+        $this->newLine(2);
+
+        // Output results
+        $this->outputResults($results, $stats, $outputFormat, $verboseMatch);
+
+        return $stats['mismatched'] > 0 ? 1 : 0;
+    }
+
+    /**
+     * Collect archive files from path (file or directory).
+     */
+    private function collectArchiveFiles(string $path): array
+    {
+        if (is_file($path)) {
+            return [$path];
+        }
+
+        if (is_dir($path)) {
+            $files = [];
+            $iterator = new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator($path, \RecursiveDirectoryIterator::SKIP_DOTS)
+            );
+
+            foreach ($iterator as $file) {
+                if ($file->isFile() && $file->getExtension() === 'json') {
+                    $files[] = $file->getPathname();
+                }
+            }
+
+            sort($files);
+
+            return $files;
+        }
+
+        return [];
+    }
+
+    /**
+     * Process a single archive file.
+     */
+    private function processArchiveFile(string $file): array
+    {
+        $result = [
+            'file' => basename($file),
+            'path' => $file,
+            'match' => false,
+            'error' => null,
+            'legacy_outcome' => null,
+            'new_outcome' => null,
+            'envelope_from' => null,
+            'envelope_to' => null,
+            'subject' => null,
+        ];
+
+        try {
+            // Read and parse archive
+            $content = File::get($file);
+            $archive = json_decode($content, true);
+
+            if (json_last_error() !== JSON_ERROR_NONE) {
+                throw new \RuntimeException('Invalid JSON: '.json_last_error_msg());
+            }
+
+            if (! isset($archive['version']) || $archive['version'] !== 1) {
+                throw new \RuntimeException('Unsupported archive version');
+            }
+
+            // Extract data
+            $rawEmail = base64_decode($archive['raw_email']);
+            $envelopeFrom = $archive['envelope']['from'] ?? '';
+            $envelopeTo = $archive['envelope']['to'] ?? '';
+            $legacyOutcome = $archive['legacy_result']['routing_outcome'] ?? null;
+
+            $result['envelope_from'] = $envelopeFrom;
+            $result['envelope_to'] = $envelopeTo;
+            $result['legacy_outcome'] = $legacyOutcome;
+            $result['subject'] = $archive['legacy_result']['subject'] ?? null;
+
+            // Parse email through new code
+            $parsed = $this->parserService->parse($rawEmail, $envelopeFrom, $envelopeTo);
+
+            // Route through new code in dry-run mode (no DB writes)
+            $newOutcome = $this->incomingMailService->routeDryRun($parsed);
+            $result['new_outcome'] = $newOutcome->value;
+
+            // Compare outcomes
+            $expectedNewOutcome = self::LEGACY_TO_NEW_MAP[$legacyOutcome] ?? null;
+            $result['match'] = ($newOutcome === $expectedNewOutcome);
+
+        } catch (\Throwable $e) {
+            $result['error'] = $e->getMessage();
+            Log::warning('Archive replay error', [
+                'file' => $file,
+                'error' => $e->getMessage(),
+            ]);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Output results based on format.
+     */
+    private function outputResults(array $results, array $stats, string $format, bool $verboseMatch): void
+    {
+        // Summary stats
+        $this->info('=== Summary ===');
+        $this->table(
+            ['Metric', 'Count', 'Percentage'],
+            [
+                ['Total', $stats['total'], '100%'],
+                ['Matched', $stats['matched'], $this->percentage($stats['matched'], $stats['total'])],
+                ['Mismatched', $stats['mismatched'], $this->percentage($stats['mismatched'], $stats['total'])],
+                ['Errors', $stats['errors'], $this->percentage($stats['errors'], $stats['total'])],
+            ]
+        );
+
+        if ($format === 'json') {
+            $this->newLine();
+            $this->line(json_encode([
+                'stats' => $stats,
+                'results' => $results,
+            ], JSON_PRETTY_PRINT));
+
+            return;
+        }
+
+        if ($format === 'summary') {
+            // Just show summary, no details
+            return;
+        }
+
+        // Table format - show mismatches and errors
+        $this->newLine();
+
+        // Show mismatches
+        $mismatches = array_filter($results, fn ($r) => ! $r['match'] && ! $r['error']);
+        if (! empty($mismatches)) {
+            $this->error('=== Mismatches ===');
+            foreach ($mismatches as $mismatch) {
+                $this->displayMismatch($mismatch);
+            }
+        }
+
+        // Show errors
+        $errors = array_filter($results, fn ($r) => $r['error']);
+        if (! empty($errors)) {
+            $this->warn('=== Errors ===');
+            foreach ($errors as $error) {
+                $this->line(sprintf('  %s: %s', $error['file'], $error['error']));
+            }
+        }
+
+        // Show matches if verbose
+        if ($verboseMatch) {
+            $matches = array_filter($results, fn ($r) => $r['match']);
+            if (! empty($matches)) {
+                $this->info('=== Matches ===');
+                $this->table(
+                    ['File', 'Envelope To', 'Outcome'],
+                    array_map(fn ($r) => [$r['file'], $r['envelope_to'], $r['legacy_outcome']], $matches)
+                );
+            }
+        }
+    }
+
+    /**
+     * Display details of a mismatch.
+     */
+    private function displayMismatch(array $result): void
+    {
+        $this->newLine();
+        $this->line(sprintf('  <fg=red>File:</> %s', $result['file']));
+        $this->line(sprintf('  <fg=yellow>From:</> %s', $result['envelope_from']));
+        $this->line(sprintf('  <fg=yellow>To:</> %s', $result['envelope_to']));
+        if ($result['subject']) {
+            $this->line(sprintf('  <fg=yellow>Subject:</> %s', $result['subject']));
+        }
+        $this->line(sprintf('  <fg=green>Legacy:</> %s', $result['legacy_outcome']));
+        $this->line(sprintf('  <fg=red>New:</> %s', $result['new_outcome']));
+    }
+
+    /**
+     * Calculate percentage string.
+     */
+    private function percentage(int $count, int $total): string
+    {
+        if ($total === 0) {
+            return '0%';
+        }
+
+        return sprintf('%.1f%%', ($count / $total) * 100);
+    }
+}

--- a/iznik-batch/app/Http/Controllers/IncomingMailController.php
+++ b/iznik-batch/app/Http/Controllers/IncomingMailController.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\Mail\Incoming\IncomingMailService;
+use App\Services\Mail\Incoming\MailParserService;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Controller for receiving incoming mail from Postfix via HTTP.
+ *
+ * This endpoint is called by the Postfix pipe handler when mail arrives.
+ * The raw email is sent in the request body with envelope info in headers.
+ */
+class IncomingMailController extends Controller
+{
+    public function __construct(
+        private readonly MailParserService $parser,
+        private readonly IncomingMailService $mailService
+    ) {}
+
+    /**
+     * Receive and process an incoming email.
+     *
+     * @return Response
+     */
+    public function receive(Request $request): Response
+    {
+        $sender = $request->header('X-Envelope-From', '');
+        $recipient = $request->header('X-Envelope-To', '');
+        $rawEmail = $request->getContent();
+
+        Log::info('Incoming mail received via HTTP', [
+            'sender' => $sender,
+            'recipient' => $recipient,
+            'size' => strlen($rawEmail),
+        ]);
+
+        // Validate we have content
+        if (empty($rawEmail)) {
+            Log::warning('Empty email content received');
+            return response('Empty content', 400);
+        }
+
+        try {
+            // Parse the email
+            $parsed = $this->parser->parse($rawEmail, $sender, $recipient);
+
+            // Route the email
+            $result = $this->mailService->route($parsed);
+
+            Log::info('Incoming mail processed', [
+                'sender' => $sender,
+                'recipient' => $recipient,
+                'result' => $result->type->value,
+            ]);
+
+            return response('OK', 200);
+
+        } catch (\PDOException $e) {
+            // Database errors - return 503 for Postfix to retry
+            Log::error('Database error processing incoming mail', [
+                'sender' => $sender,
+                'recipient' => $recipient,
+                'error' => $e->getMessage(),
+                'code' => $e->getCode(),
+            ]);
+
+            if ($this->isTransientDatabaseError($e)) {
+                return response('Database temporarily unavailable', 503);
+            }
+
+            // Permanent database error - accept to avoid infinite retries
+            return response('OK', 200);
+
+        } catch (\Throwable $e) {
+            // Other errors - log but accept the message
+            Log::error('Error processing incoming mail', [
+                'sender' => $sender,
+                'recipient' => $recipient,
+                'error' => $e->getMessage(),
+                'trace' => $e->getTraceAsString(),
+            ]);
+
+            // Return 200 to prevent infinite retries for permanent errors
+            return response('OK', 200);
+        }
+    }
+
+    /**
+     * Check if a PDO exception is transient (worth retrying).
+     */
+    private function isTransientDatabaseError(\PDOException $e): bool
+    {
+        $transientCodes = [
+            2002, // Connection refused
+            2003, // Can't connect to MySQL server
+            2006, // MySQL server has gone away
+            1040, // Too many connections
+            1205, // Lock wait timeout
+            1213, // Deadlock found
+        ];
+
+        return in_array((int) $e->getCode(), $transientCodes, true);
+    }
+}

--- a/iznik-batch/app/Services/Mail/Incoming/IncomingMailService.php
+++ b/iznik-batch/app/Services/Mail/Incoming/IncomingMailService.php
@@ -1,0 +1,829 @@
+<?php
+
+namespace App\Services\Mail\Incoming;
+
+use App\Models\ChatMessage;
+use App\Models\ChatRoom;
+use App\Models\Group;
+use App\Models\Membership;
+use App\Models\Message;
+use App\Models\User;
+use App\Models\UserEmail;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Service for routing incoming email messages.
+ *
+ * This is the main entry point for processing incoming emails.
+ * It determines the appropriate handler based on the envelope address
+ * and message content.
+ *
+ * Routing order (matching iznik-server MailRouter.php):
+ * 1. System addresses (digestoff, readreceipt, subscribe, etc.)
+ * 2. Spam detection
+ * 3. Destination-based routing (group, user, volunteers)
+ */
+class IncomingMailService
+{
+    // Maximum age for chat replies (84 days = 12 weeks)
+    private const STALE_CHAT_DAYS = 84;
+
+    // Maximum age for message replies (42 days = 6 weeks)
+    private const EXPIRED_MESSAGE_DAYS = 42;
+
+    public function __construct(
+        private readonly MailParserService $parser
+    ) {}
+
+    /**
+     * Route a parsed email to the appropriate handler.
+     *
+     * @param  ParsedEmail  $email  The parsed email to route
+     * @return RoutingResult The routing outcome
+     */
+    public function route(ParsedEmail $email): RoutingResult
+    {
+        Log::debug('Routing incoming email', [
+            'envelope_from' => $email->envelopeFrom,
+            'envelope_to' => $email->envelopeTo,
+            'subject' => $email->subject,
+        ]);
+
+        // Phase 1: Check for system addresses
+        $systemResult = $this->routeSystemAddress($email);
+        if ($systemResult !== null) {
+            return $systemResult;
+        }
+
+        // Phase 2: Check for bounces (BEFORE auto-reply check)
+        // Bounces have Auto-Submitted header but should be processed, not dropped
+        if ($email->isBounce()) {
+            return $this->handleBounce($email);
+        }
+
+        // Check for known dropped senders (Twitter, etc.)
+        if ($this->shouldDropSender($email)) {
+            return RoutingResult::DROPPED;
+        }
+
+        // Check for auto-replies (OOO, vacation, etc.)
+        if ($email->isAutoReply()) {
+            Log::debug('Dropping auto-reply message');
+
+            return RoutingResult::DROPPED;
+        }
+
+        // Check for self-sent messages
+        if ($this->isSelfSent($email)) {
+            Log::debug('Dropping self-sent message');
+
+            return RoutingResult::DROPPED;
+        }
+
+        // Check if sender is a known spammer
+        if ($this->isKnownSpammer($email)) {
+            Log::debug('Dropping message from known spammer');
+
+            return RoutingResult::DROPPED;
+        }
+
+        // Phase 3: Check for chat/message replies
+        if ($email->isChatNotificationReply()) {
+            return $this->handleChatNotificationReply($email);
+        }
+
+        // Check for replyto- addresses
+        $replyToResult = $this->handleReplyToAddress($email);
+        if ($replyToResult !== null) {
+            return $replyToResult;
+        }
+
+        // Phase 4: Check for volunteer/auto addresses
+        if ($email->isToVolunteers || $email->isToAuto) {
+            return $this->handleVolunteersMessage($email);
+        }
+
+        // Phase 5: Check for group posts
+        if ($email->targetGroupName !== null) {
+            return $this->handleGroupPost($email);
+        }
+
+        // Phase 6: Direct user mail
+        return $this->handleDirectMail($email);
+    }
+
+    /**
+     * Route system addresses (digestoff, readreceipt, subscribe, etc.)
+     */
+    private function routeSystemAddress(ParsedEmail $email): ?RoutingResult
+    {
+        $localPart = explode('@', $email->envelopeTo)[0] ?? '';
+
+        // FBL (Feedback Loop) reports
+        if ($localPart === 'fbl') {
+            return $this->handleFbl($email);
+        }
+
+        // Read receipt
+        if (str_starts_with($localPart, 'readreceipt-')) {
+            return $this->handleReadReceipt($email);
+        }
+
+        // Tryst/handover response
+        if (str_starts_with($localPart, 'handover-')) {
+            return $this->handleTrystResponse($email);
+        }
+
+        // Digest off
+        if ($email->isDigestOffCommand()) {
+            return $this->handleDigestOff($email);
+        }
+
+        // Events off
+        if (str_starts_with($localPart, 'eventsoff-')) {
+            return $this->handleEventsOff($email);
+        }
+
+        // Newsletters off
+        if (str_starts_with($localPart, 'newslettersoff-')) {
+            return $this->handleNewslettersOff($email);
+        }
+
+        // Relevant off
+        if (str_starts_with($localPart, 'relevantoff-')) {
+            return $this->handleRelevantOff($email);
+        }
+
+        // Volunteering off
+        if (str_starts_with($localPart, 'volunteeringoff-')) {
+            return $this->handleVolunteeringOff($email);
+        }
+
+        // Notification mails off
+        if (str_starts_with($localPart, 'notificationmailsoff-')) {
+            return $this->handleNotificationMailsOff($email);
+        }
+
+        // One-click unsubscribe
+        if (str_starts_with($localPart, 'unsubscribe-')) {
+            return $this->handleOneClickUnsubscribe($email);
+        }
+
+        // Subscribe command
+        if ($email->isSubscribeCommand()) {
+            return $this->handleSubscribe($email);
+        }
+
+        // Unsubscribe command
+        if ($email->isUnsubscribeCommand()) {
+            return $this->handleUnsubscribe($email);
+        }
+
+        return null;
+    }
+
+    /**
+     * Check if sender should be dropped (Twitter, etc.)
+     */
+    private function shouldDropSender(ParsedEmail $email): bool
+    {
+        $fromAddress = strtolower($email->fromAddress ?? '');
+
+        // Drop Twitter notifications
+        if ($fromAddress === 'info@twitter.com') {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if this is a self-sent message.
+     */
+    private function isSelfSent(ParsedEmail $email): bool
+    {
+        $fromAddress = strtolower($email->fromAddress ?? '');
+        $envelopeTo = strtolower($email->envelopeTo);
+
+        return $fromAddress === $envelopeTo && ! empty($fromAddress);
+    }
+
+    /**
+     * Check if sender is a known spammer.
+     */
+    private function isKnownSpammer(ParsedEmail $email): bool
+    {
+        $fromAddress = $email->fromAddress;
+        if (empty($fromAddress)) {
+            return false;
+        }
+
+        // Find user by email
+        $userEmail = UserEmail::where('email', $fromAddress)->first();
+        if ($userEmail === null) {
+            return false;
+        }
+
+        // Check spam_users table
+        return DB::table('spam_users')
+            ->where('userid', $userEmail->userid)
+            ->where('collection', 'Spammer')
+            ->exists();
+    }
+
+    /**
+     * Handle FBL (Feedback Loop) reports.
+     */
+    private function handleFbl(ParsedEmail $email): RoutingResult
+    {
+        Log::info('Processing FBL report');
+        // TODO: Implement FBL processing
+
+        return RoutingResult::TO_SYSTEM;
+    }
+
+    /**
+     * Handle read receipts.
+     */
+    private function handleReadReceipt(ParsedEmail $email): RoutingResult
+    {
+        Log::info('Processing read receipt');
+        // TODO: Implement read receipt processing
+
+        return RoutingResult::RECEIPT;
+    }
+
+    /**
+     * Handle tryst/handover calendar responses.
+     */
+    private function handleTrystResponse(ParsedEmail $email): RoutingResult
+    {
+        Log::info('Processing tryst response');
+        // TODO: Implement tryst response processing
+
+        return RoutingResult::TRYST;
+    }
+
+    /**
+     * Handle digest off command.
+     */
+    private function handleDigestOff(ParsedEmail $email): RoutingResult
+    {
+        Log::info('Processing digest off command', [
+            'user_id' => $email->commandUserId,
+            'group_id' => $email->commandGroupId,
+        ]);
+        // TODO: Implement digest off processing
+
+        return RoutingResult::TO_SYSTEM;
+    }
+
+    /**
+     * Handle events off command.
+     */
+    private function handleEventsOff(ParsedEmail $email): RoutingResult
+    {
+        Log::info('Processing events off command');
+        // TODO: Implement events off processing
+
+        return RoutingResult::TO_SYSTEM;
+    }
+
+    /**
+     * Handle newsletters off command.
+     */
+    private function handleNewslettersOff(ParsedEmail $email): RoutingResult
+    {
+        Log::info('Processing newsletters off command');
+        // TODO: Implement newsletters off processing
+
+        return RoutingResult::TO_SYSTEM;
+    }
+
+    /**
+     * Handle relevant off command.
+     */
+    private function handleRelevantOff(ParsedEmail $email): RoutingResult
+    {
+        Log::info('Processing relevant off command');
+        // TODO: Implement relevant off processing
+
+        return RoutingResult::TO_SYSTEM;
+    }
+
+    /**
+     * Handle volunteering off command.
+     */
+    private function handleVolunteeringOff(ParsedEmail $email): RoutingResult
+    {
+        Log::info('Processing volunteering off command');
+        // TODO: Implement volunteering off processing
+
+        return RoutingResult::TO_SYSTEM;
+    }
+
+    /**
+     * Handle notification mails off command.
+     */
+    private function handleNotificationMailsOff(ParsedEmail $email): RoutingResult
+    {
+        Log::info('Processing notification mails off command');
+        // TODO: Implement notification mails off processing
+
+        return RoutingResult::TO_SYSTEM;
+    }
+
+    /**
+     * Handle one-click unsubscribe.
+     */
+    private function handleOneClickUnsubscribe(ParsedEmail $email): RoutingResult
+    {
+        Log::info('Processing one-click unsubscribe');
+        // TODO: Implement one-click unsubscribe processing
+
+        return RoutingResult::TO_SYSTEM;
+    }
+
+    /**
+     * Handle subscribe command.
+     */
+    private function handleSubscribe(ParsedEmail $email): RoutingResult
+    {
+        Log::info('Processing subscribe command', [
+            'group' => $email->targetGroupName,
+        ]);
+        // TODO: Implement subscribe processing
+
+        return RoutingResult::TO_SYSTEM;
+    }
+
+    /**
+     * Handle unsubscribe command.
+     */
+    private function handleUnsubscribe(ParsedEmail $email): RoutingResult
+    {
+        Log::info('Processing unsubscribe command', [
+            'group' => $email->targetGroupName,
+        ]);
+        // TODO: Implement unsubscribe processing
+
+        return RoutingResult::TO_SYSTEM;
+    }
+
+    /**
+     * Handle bounce messages.
+     */
+    private function handleBounce(ParsedEmail $email): RoutingResult
+    {
+        Log::info('Processing bounce', [
+            'recipient' => $email->bounceRecipient,
+            'status' => $email->bounceStatus,
+            'permanent' => $email->isPermanentBounce(),
+        ]);
+
+        // Extract user ID from bounce address if present
+        $localPart = explode('@', $email->envelopeTo)[0] ?? '';
+        if (preg_match('/^bounce-(\d+)-/', $localPart, $matches)) {
+            $userId = (int) $matches[1];
+
+            if ($email->isPermanentBounce() && $email->bounceRecipient) {
+                // Record permanent bounce against user's email
+                $this->recordBounce($userId, $email->bounceRecipient);
+            }
+        }
+
+        return RoutingResult::DROPPED;
+    }
+
+    /**
+     * Record a bounce against a user's email.
+     *
+     * The bounced column stores a timestamp (when the bounce was recorded),
+     * not a count. Setting it marks the email as having bounced.
+     */
+    private function recordBounce(int $userId, string $emailAddress): void
+    {
+        DB::table('users_emails')
+            ->where('userid', $userId)
+            ->where('email', $emailAddress)
+            ->update([
+                'bounced' => now(),
+            ]);
+
+        Log::info('Recorded bounce for user', [
+            'user_id' => $userId,
+            'email' => $emailAddress,
+        ]);
+    }
+
+    /**
+     * Handle reply-to addresses (replyto-{msgid}-{fromid}).
+     */
+    private function handleReplyToAddress(ParsedEmail $email): ?RoutingResult
+    {
+        $localPart = explode('@', $email->envelopeTo)[0] ?? '';
+
+        if (! str_starts_with($localPart, 'replyto-')) {
+            return null;
+        }
+
+        // Parse replyto-{msgid}-{fromid}
+        $parts = explode('-', $localPart);
+        if (count($parts) < 3) {
+            Log::warning('Invalid replyto address format', [
+                'envelope_to' => $email->envelopeTo,
+            ]);
+
+            return RoutingResult::DROPPED;
+        }
+
+        $messageId = (int) $parts[1];
+
+        // Check if message exists and is not expired
+        $message = Message::find($messageId);
+        if ($message === null) {
+            Log::warning('Reply to non-existent message', [
+                'message_id' => $messageId,
+            ]);
+
+            return RoutingResult::DROPPED;
+        }
+
+        // Check if message is expired (>42 days old)
+        $arrival = $message->arrival ?? $message->date;
+        if ($arrival && $arrival->diffInDays(now()) > self::EXPIRED_MESSAGE_DAYS) {
+            Log::info('Dropping reply to expired message', [
+                'message_id' => $messageId,
+                'age_days' => $arrival->diffInDays(now()),
+            ]);
+
+            return RoutingResult::DROPPED;
+        }
+
+        // TODO: Create/get chat and add message
+        Log::info('Processing reply to message', [
+            'message_id' => $messageId,
+        ]);
+
+        return RoutingResult::TO_USER;
+    }
+
+    /**
+     * Handle chat notification replies (notify-{chatid}-{userid}[-{msgid}]).
+     */
+    private function handleChatNotificationReply(ParsedEmail $email): RoutingResult
+    {
+        $chatId = $email->chatId;
+        $userId = $email->chatUserId;
+
+        Log::info('Processing chat notification reply', [
+            'chat_id' => $chatId,
+            'user_id' => $userId,
+            'message_id' => $email->chatMessageId,
+        ]);
+
+        // Validate chat exists
+        $chat = ChatRoom::find($chatId);
+        if ($chat === null) {
+            Log::warning('Reply to non-existent chat', [
+                'chat_id' => $chatId,
+            ]);
+
+            return RoutingResult::DROPPED;
+        }
+
+        // Check if chat is stale and sender email is unfamiliar
+        if ($this->isStaleChatWithUnfamiliarSender($chat, $email)) {
+            Log::info('Dropping reply to stale chat from unfamiliar sender', [
+                'chat_id' => $chatId,
+                'age_days' => $chat->latestmessage?->diffInDays(now()),
+            ]);
+
+            return RoutingResult::DROPPED;
+        }
+
+        // Validate user is part of chat
+        if (! $this->isUserInChat($userId, $chat)) {
+            Log::warning('User not part of chat', [
+                'chat_id' => $chatId,
+                'user_id' => $userId,
+            ]);
+
+            return RoutingResult::DROPPED;
+        }
+
+        // Create chat message
+        $this->createChatMessageFromEmail($chat, $userId, $email);
+
+        return RoutingResult::TO_USER;
+    }
+
+    /**
+     * Check if chat is stale with unfamiliar sender.
+     */
+    private function isStaleChatWithUnfamiliarSender(ChatRoom $chat, ParsedEmail $email): bool
+    {
+        // Check if chat is stale (>84 days old)
+        $latestMessage = $chat->latestmessage;
+        if ($latestMessage === null || $latestMessage->diffInDays(now()) <= self::STALE_CHAT_DAYS) {
+            return false;
+        }
+
+        // Check if sender email is known
+        $fromAddress = $email->fromAddress;
+        if (empty($fromAddress)) {
+            return true;
+        }
+
+        // Check if email belongs to a user in the chat
+        $emailUser = UserEmail::where('email', $fromAddress)->first();
+        if ($emailUser === null) {
+            return true;
+        }
+
+        // Check if email user is part of the chat
+        return ! $this->isUserInChat($emailUser->userid, $chat);
+    }
+
+    /**
+     * Check if user is part of a chat.
+     */
+    private function isUserInChat(int $userId, ChatRoom $chat): bool
+    {
+        if ($chat->chattype === 'User2User') {
+            return $chat->user1 === $userId || $chat->user2 === $userId;
+        }
+
+        // For group chats, check roster
+        return DB::table('chat_roster')
+            ->where('chatid', $chat->id)
+            ->where('userid', $userId)
+            ->exists();
+    }
+
+    /**
+     * Create a chat message from an incoming email.
+     */
+    private function createChatMessageFromEmail(ChatRoom $chat, int $userId, ParsedEmail $email): void
+    {
+        $body = $email->textBody ?? $email->htmlBody ?? '';
+
+        ChatMessage::create([
+            'chatid' => $chat->id,
+            'userid' => $userId,
+            'message' => $body,
+            'type' => ChatMessage::TYPE_DEFAULT,
+            'date' => now(),
+            'platform' => 0, // Email source
+        ]);
+
+        Log::info('Created chat message from email', [
+            'chat_id' => $chat->id,
+            'user_id' => $userId,
+        ]);
+    }
+
+    /**
+     * Handle messages to group volunteers.
+     */
+    private function handleVolunteersMessage(ParsedEmail $email): RoutingResult
+    {
+        Log::info('Processing volunteers message', [
+            'group' => $email->targetGroupName,
+            'is_volunteers' => $email->isToVolunteers,
+            'is_auto' => $email->isToAuto,
+        ]);
+
+        // Find the group
+        $group = $this->findGroup($email->targetGroupName);
+        if ($group === null) {
+            Log::warning('Volunteers message to unknown group', [
+                'group' => $email->targetGroupName,
+            ]);
+
+            return RoutingResult::DROPPED;
+        }
+
+        // Find sender user
+        $user = $this->findUserByEmail($email->fromAddress);
+        if ($user === null) {
+            Log::warning('Volunteers message from unknown user', [
+                'from' => $email->fromAddress,
+            ]);
+
+            return RoutingResult::DROPPED;
+        }
+
+        // TODO: Create/get chat between user and moderators
+        // TODO: Add message to chat
+
+        return RoutingResult::TO_VOLUNTEERS;
+    }
+
+    /**
+     * Handle group posts.
+     */
+    private function handleGroupPost(ParsedEmail $email): RoutingResult
+    {
+        Log::info('Processing group post', [
+            'group' => $email->targetGroupName,
+            'subject' => $email->subject,
+        ]);
+
+        // Find the group
+        $group = $this->findGroup($email->targetGroupName);
+        if ($group === null) {
+            Log::warning('Post to unknown group', [
+                'group' => $email->targetGroupName,
+            ]);
+
+            return RoutingResult::DROPPED;
+        }
+
+        // Find sender user
+        $user = $this->findUserByEmail($email->fromAddress);
+        if ($user === null) {
+            Log::info('Post from unknown user - dropping', [
+                'from' => $email->fromAddress,
+            ]);
+
+            return RoutingResult::DROPPED;
+        }
+
+        // Check membership
+        $membership = Membership::where('userid', $user->id)
+            ->where('groupid', $group->id)
+            ->where('collection', 'Approved')
+            ->first();
+
+        if ($membership === null) {
+            Log::info('Post from non-member - dropping', [
+                'user_id' => $user->id,
+                'group_id' => $group->id,
+            ]);
+
+            return RoutingResult::DROPPED;
+        }
+
+        // Check if Trash Nothing post with valid secret (skip spam check)
+        $skipSpamCheck = $this->shouldSkipSpamCheck($email);
+
+        // Check for spam if not TN
+        if (! $skipSpamCheck && $this->isSpam($email)) {
+            return RoutingResult::INCOMING_SPAM;
+        }
+
+        // Check posting status (column is camelCase: ourPostingStatus)
+        $postingStatus = $membership->ourPostingStatus ?? 'DEFAULT';
+
+        // Check if user is unmapped (no location)
+        if ($user->lastlocation === null) {
+            Log::info('Post from unmapped user - pending', [
+                'user_id' => $user->id,
+            ]);
+
+            return RoutingResult::PENDING;
+        }
+
+        // Check for worry words
+        if ($this->containsWorryWords($email)) {
+            Log::info('Post contains worry words - pending', [
+                'subject' => $email->subject,
+            ]);
+
+            return RoutingResult::PENDING;
+        }
+
+        // Route based on posting status
+        return match ($postingStatus) {
+            'MODERATED' => RoutingResult::PENDING,
+            'PROHIBITED' => RoutingResult::DROPPED,
+            default => RoutingResult::APPROVED,
+        };
+    }
+
+    /**
+     * Check if spam check should be skipped (e.g., for TN with valid secret).
+     */
+    private function shouldSkipSpamCheck(ParsedEmail $email): bool
+    {
+        if (! $email->isFromTrashNothing()) {
+            return false;
+        }
+
+        $secret = $email->getTrashNothingSecret();
+        if ($secret === null) {
+            return false;
+        }
+
+        // TODO: Validate secret against config
+        // For now, any TN secret skips spam check
+        return true;
+    }
+
+    /**
+     * Check if email is spam.
+     */
+    private function isSpam(ParsedEmail $email): bool
+    {
+        $subject = strtolower($email->subject ?? '');
+        $body = strtolower($email->textBody ?? '');
+
+        // Simple spam patterns - TODO: Implement full spam checking
+        $spamPatterns = [
+            'make money fast',
+            'guaranteed returns',
+            'western union',
+            'send money',
+            'lottery winner',
+            'nigerian prince',
+        ];
+
+        foreach ($spamPatterns as $pattern) {
+            if (str_contains($subject, $pattern) || str_contains($body, $pattern)) {
+                Log::info('Spam pattern detected', [
+                    'pattern' => $pattern,
+                ]);
+
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if email contains worry words.
+     */
+    private function containsWorryWords(ParsedEmail $email): bool
+    {
+        $subject = strtolower($email->subject ?? '');
+        $body = strtolower($email->textBody ?? '');
+
+        // Common worry words - TODO: Load from database/config
+        $worryWords = [
+            'kitten',
+            'puppy',
+            'dog',
+            'cat',
+            'pet',
+            'animal',
+            'medication',
+            'medicine',
+            'drugs',
+        ];
+
+        foreach ($worryWords as $word) {
+            if (str_contains($subject, $word) || str_contains($body, $word)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Handle direct mail to users.
+     */
+    private function handleDirectMail(ParsedEmail $email): RoutingResult
+    {
+        Log::info('Processing direct mail', [
+            'from' => $email->fromAddress,
+            'to' => $email->envelopeTo,
+        ]);
+
+        // TODO: Implement direct mail routing
+
+        return RoutingResult::TO_USER;
+    }
+
+    /**
+     * Find a group by name.
+     */
+    private function findGroup(?string $name): ?Group
+    {
+        if (empty($name)) {
+            return null;
+        }
+
+        return Group::where('nameshort', $name)->first();
+    }
+
+    /**
+     * Find a user by email address.
+     */
+    private function findUserByEmail(?string $email): ?User
+    {
+        if (empty($email)) {
+            return null;
+        }
+
+        $userEmail = UserEmail::where('email', $email)->first();
+        if ($userEmail === null) {
+            return null;
+        }
+
+        return User::find($userEmail->userid);
+    }
+}

--- a/iznik-batch/app/Services/Mail/Incoming/IncomingMailService.php
+++ b/iznik-batch/app/Services/Mail/Incoming/IncomingMailService.php
@@ -9,6 +9,7 @@ use App\Models\Membership;
 use App\Models\Message;
 use App\Models\User;
 use App\Models\UserEmail;
+use Carbon\Carbon;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 
@@ -32,9 +33,7 @@ class IncomingMailService
     // Maximum age for message replies (42 days = 6 weeks)
     private const EXPIRED_MESSAGE_DAYS = 42;
 
-    public function __construct(
-        private readonly MailParserService $parser
-    ) {}
+    // No constructor dependencies - parsing is done by the command before routing
 
     /**
      * Route a parsed email to the appropriate handler.
@@ -199,14 +198,17 @@ class IncomingMailService
     }
 
     /**
-     * Check if this is a self-sent message.
+     * Check if this is a self-sent message (envelope-from == envelope-to).
+     *
+     * Sending to yourself isn't a valid path, and is used by spammers.
+     * This compares envelope addresses, not header addresses.
      */
     private function isSelfSent(ParsedEmail $email): bool
     {
-        $fromAddress = strtolower($email->fromAddress ?? '');
+        $envelopeFrom = strtolower($email->envelopeFrom);
         $envelopeTo = strtolower($email->envelopeTo);
 
-        return $fromAddress === $envelopeTo && ! empty($fromAddress);
+        return $envelopeFrom === $envelopeTo && ! empty($envelopeFrom);
     }
 
     /**
@@ -234,139 +236,846 @@ class IncomingMailService
 
     /**
      * Handle FBL (Feedback Loop) reports.
+     *
+     * FBL reports come from email providers when a user marks an email as spam.
+     * We extract the original recipient email address and turn off their emails.
      */
     private function handleFbl(ParsedEmail $email): RoutingResult
     {
         Log::info('Processing FBL report');
-        // TODO: Implement FBL processing
+
+        $rawMessage = $email->rawMessage;
+
+        // Extract original recipient from various FBL headers
+        $recipientEmail = null;
+        if (preg_match('/Original-Rcpt-To:\s*(.+)/i', $rawMessage, $matches)) {
+            $recipientEmail = trim($matches[1]);
+        } elseif (preg_match('/X-Original-To:\s*([^;]+)/i', $rawMessage, $matches)) {
+            $recipientEmail = trim($matches[1]);
+        } elseif (preg_match('/X-HmXmrOriginalRecipient:\s*(.+)/i', $rawMessage, $matches)) {
+            $recipientEmail = trim($matches[1]);
+        }
+
+        if ($recipientEmail) {
+            Log::info('FBL report for email', ['email' => $recipientEmail]);
+
+            // Find the user
+            $userEmail = UserEmail::where('email', $recipientEmail)->first();
+            if ($userEmail) {
+                $user = User::find($userEmail->userid);
+                if ($user) {
+                    // Turn off email digests for all their memberships
+                    DB::table('memberships')
+                        ->where('userid', $user->id)
+                        ->update(['emailfrequency' => 0]);
+
+                    Log::info('Turned off emails due to FBL', [
+                        'user_id' => $user->id,
+                        'email' => $recipientEmail,
+                    ]);
+                }
+            }
+        } else {
+            Log::warning('FBL report could not extract recipient email');
+        }
 
         return RoutingResult::TO_SYSTEM;
     }
 
     /**
      * Handle read receipts.
+     *
+     * Updates the chat roster to indicate the user has seen messages.
+     * Format: readreceipt-{chatid}-{userid}-{msgid}@users.ilovefreegle.org
      */
     private function handleReadReceipt(ParsedEmail $email): RoutingResult
     {
-        Log::info('Processing read receipt');
-        // TODO: Implement read receipt processing
+        $localPart = explode('@', $email->envelopeTo)[0] ?? '';
+
+        // Parse readreceipt-{chatid}-{userid}-{msgid}
+        if (! preg_match('/^readreceipt-(\d+)-(\d+)-(\d+)$/', $localPart, $matches)) {
+            Log::warning('Invalid read receipt address format', [
+                'envelope_to' => $email->envelopeTo,
+            ]);
+
+            return RoutingResult::DROPPED;
+        }
+
+        $chatId = (int) $matches[1];
+        $userId = (int) $matches[2];
+        $msgId = (int) $matches[3];
+
+        Log::info('Processing read receipt', [
+            'chat_id' => $chatId,
+            'user_id' => $userId,
+            'message_id' => $msgId,
+        ]);
+
+        // Update user's last access
+        DB::table('users')
+            ->where('id', $userId)
+            ->update(['lastaccess' => now()]);
+
+        // Check if chat exists
+        $chat = ChatRoom::find($chatId);
+        if ($chat === null) {
+            Log::warning('Read receipt for non-existent chat', [
+                'chat_id' => $chatId,
+            ]);
+
+            return RoutingResult::DROPPED;
+        }
+
+        // Check if user can see the chat
+        if (! $this->isUserInChat($userId, $chat)) {
+            Log::warning('Read receipt from user not in chat', [
+                'chat_id' => $chatId,
+                'user_id' => $userId,
+            ]);
+
+            return RoutingResult::DROPPED;
+        }
+
+        // Update the chat roster to mark messages as seen
+        DB::table('chat_roster')
+            ->updateOrInsert(
+                ['chatid' => $chatId, 'userid' => $userId],
+                ['lastmsgseen' => $msgId, 'lastseen' => now()]
+            );
+
+        // For user-to-user chats, mark message as seen by all
+        if ($chat->chattype === 'User2User') {
+            DB::table('chat_messages')
+                ->where('id', $msgId)
+                ->where('chatid', $chatId)
+                ->update(['seenbyall' => 1]);
+        }
+
+        Log::info('Processed read receipt', [
+            'chat_id' => $chatId,
+            'user_id' => $userId,
+            'message_id' => $msgId,
+        ]);
 
         return RoutingResult::RECEIPT;
     }
 
     /**
      * Handle tryst/handover calendar responses.
+     *
+     * Parses VCALENDAR attachments or subject line to determine accept/decline status.
+     * Format: handover-{trystid}-{userid}@users.ilovefreegle.org
      */
     private function handleTrystResponse(ParsedEmail $email): RoutingResult
     {
-        Log::info('Processing tryst response');
-        // TODO: Implement tryst response processing
+        $localPart = explode('@', $email->envelopeTo)[0] ?? '';
+
+        // Parse handover-{trystid}-{userid}
+        if (! preg_match('/^handover-(\d+)-(\d+)$/', $localPart, $matches)) {
+            Log::warning('Invalid handover address format', [
+                'envelope_to' => $email->envelopeTo,
+            ]);
+
+            return RoutingResult::DROPPED;
+        }
+
+        $trystId = (int) $matches[1];
+        $userId = (int) $matches[2];
+
+        Log::info('Processing tryst response', [
+            'tryst_id' => $trystId,
+            'user_id' => $userId,
+        ]);
+
+        // Update user's last access
+        DB::table('users')
+            ->where('id', $userId)
+            ->update(['lastaccess' => now()]);
+
+        // Check if tryst exists
+        $tryst = DB::table('trysts')->find($trystId);
+        if ($tryst === null) {
+            Log::warning('Tryst response for non-existent tryst', [
+                'tryst_id' => $trystId,
+            ]);
+
+            return RoutingResult::DROPPED;
+        }
+
+        // Determine response from email content
+        $response = $this->parseTrystResponse($email);
+
+        // Update the tryst response
+        DB::table('trysts_responses')
+            ->updateOrInsert(
+                ['trystid' => $trystId, 'userid' => $userId],
+                ['response' => $response, 'date' => now()]
+            );
+
+        Log::info('Processed tryst response', [
+            'tryst_id' => $trystId,
+            'user_id' => $userId,
+            'response' => $response,
+        ]);
 
         return RoutingResult::TRYST;
     }
 
     /**
+     * Parse tryst response from email content.
+     *
+     * Checks VCALENDAR content in body or subject line for accepted/declined.
+     */
+    private function parseTrystResponse(ParsedEmail $email): string
+    {
+        // Check body for VCALENDAR status
+        $body = strtolower($email->textBody ?? '');
+        if (str_contains($body, 'status:confirmed') || str_contains($body, 'status:tentative')) {
+            return 'Accepted';
+        }
+        if (str_contains($body, 'status:cancelled')) {
+            return 'Declined';
+        }
+
+        // Check subject line as fallback
+        $subject = strtolower($email->subject ?? '');
+        if (str_contains($subject, 'accepted')) {
+            return 'Accepted';
+        }
+        if (str_contains($subject, 'declined')) {
+            return 'Declined';
+        }
+
+        // Default to Other
+        return 'Other';
+    }
+
+    /**
      * Handle digest off command.
+     *
+     * Updates the user's membership to turn off email digests (emailfrequency = 0).
+     * Format: digestoff-{userid}-{groupid}@users.ilovefreegle.org
      */
     private function handleDigestOff(ParsedEmail $email): RoutingResult
     {
+        $userId = $email->commandUserId;
+        $groupId = $email->commandGroupId;
+
         Log::info('Processing digest off command', [
-            'user_id' => $email->commandUserId,
-            'group_id' => $email->commandGroupId,
+            'user_id' => $userId,
+            'group_id' => $groupId,
         ]);
-        // TODO: Implement digest off processing
+
+        if (! $userId || ! $groupId) {
+            Log::warning('Invalid digest off command - missing user or group ID');
+
+            return RoutingResult::DROPPED;
+        }
+
+        // Update user's last access
+        DB::table('users')
+            ->where('id', $userId)
+            ->update(['lastaccess' => now()]);
+
+        // Check if user is an approved member of the group
+        $membership = Membership::where('userid', $userId)
+            ->where('groupid', $groupId)
+            ->where('collection', 'Approved')
+            ->first();
+
+        if ($membership === null) {
+            Log::warning('User is not an approved member of group', [
+                'user_id' => $userId,
+                'group_id' => $groupId,
+            ]);
+
+            return RoutingResult::DROPPED;
+        }
+
+        // Set email frequency to 0 (NEVER)
+        $membership->emailfrequency = 0;
+        $membership->save();
+
+        Log::info('Turned off digest for user', [
+            'user_id' => $userId,
+            'group_id' => $groupId,
+        ]);
 
         return RoutingResult::TO_SYSTEM;
     }
 
     /**
      * Handle events off command.
+     *
+     * Updates the user's membership to turn off event emails (eventsallowed = 0).
+     * Format: eventsoff-{userid}-{groupid}@users.ilovefreegle.org
      */
     private function handleEventsOff(ParsedEmail $email): RoutingResult
     {
-        Log::info('Processing events off command');
-        // TODO: Implement events off processing
+        $localPart = explode('@', $email->envelopeTo)[0] ?? '';
+
+        // Parse eventsoff-{userid}-{groupid}
+        if (! preg_match('/^eventsoff-(\d+)-(\d+)$/', $localPart, $matches)) {
+            Log::warning('Invalid events off address format', [
+                'envelope_to' => $email->envelopeTo,
+            ]);
+
+            return RoutingResult::DROPPED;
+        }
+
+        $userId = (int) $matches[1];
+        $groupId = (int) $matches[2];
+
+        Log::info('Processing events off command', [
+            'user_id' => $userId,
+            'group_id' => $groupId,
+        ]);
+
+        // Update user's last access
+        DB::table('users')
+            ->where('id', $userId)
+            ->update(['lastaccess' => now()]);
+
+        // Check if user is an approved member of the group
+        $membership = Membership::where('userid', $userId)
+            ->where('groupid', $groupId)
+            ->where('collection', 'Approved')
+            ->first();
+
+        if ($membership === null) {
+            Log::warning('User is not an approved member of group', [
+                'user_id' => $userId,
+                'group_id' => $groupId,
+            ]);
+
+            return RoutingResult::DROPPED;
+        }
+
+        // Set eventsallowed to 0
+        $membership->eventsallowed = 0;
+        $membership->save();
+
+        Log::info('Turned off events for user', [
+            'user_id' => $userId,
+            'group_id' => $groupId,
+        ]);
 
         return RoutingResult::TO_SYSTEM;
     }
 
     /**
      * Handle newsletters off command.
+     *
+     * Updates the user's settings to turn off newsletters (newslettersallowed = 0).
+     * Format: newslettersoff-{userid}@users.ilovefreegle.org
      */
     private function handleNewslettersOff(ParsedEmail $email): RoutingResult
     {
-        Log::info('Processing newsletters off command');
-        // TODO: Implement newsletters off processing
+        $localPart = explode('@', $email->envelopeTo)[0] ?? '';
+
+        // Parse newslettersoff-{userid}
+        if (! preg_match('/^newslettersoff-(\d+)$/', $localPart, $matches)) {
+            Log::warning('Invalid newsletters off address format', [
+                'envelope_to' => $email->envelopeTo,
+            ]);
+
+            return RoutingResult::DROPPED;
+        }
+
+        $userId = (int) $matches[1];
+
+        Log::info('Processing newsletters off command', [
+            'user_id' => $userId,
+        ]);
+
+        // Update user's last access
+        DB::table('users')
+            ->where('id', $userId)
+            ->update(['lastaccess' => now()]);
+
+        // Check if user exists
+        $user = User::find($userId);
+        if ($user === null) {
+            Log::warning('User not found for newsletters off', [
+                'user_id' => $userId,
+            ]);
+
+            return RoutingResult::DROPPED;
+        }
+
+        // Set newslettersallowed to 0
+        $user->newslettersallowed = 0;
+        $user->save();
+
+        Log::info('Turned off newsletters for user', [
+            'user_id' => $userId,
+        ]);
 
         return RoutingResult::TO_SYSTEM;
     }
 
     /**
      * Handle relevant off command.
+     *
+     * Updates the user's settings to turn off "interested in" emails (relevantallowed = 0).
+     * Format: relevantoff-{userid}@users.ilovefreegle.org
      */
     private function handleRelevantOff(ParsedEmail $email): RoutingResult
     {
-        Log::info('Processing relevant off command');
-        // TODO: Implement relevant off processing
+        $localPart = explode('@', $email->envelopeTo)[0] ?? '';
+
+        // Parse relevantoff-{userid}
+        if (! preg_match('/^relevantoff-(\d+)$/', $localPart, $matches)) {
+            Log::warning('Invalid relevant off address format', [
+                'envelope_to' => $email->envelopeTo,
+            ]);
+
+            return RoutingResult::DROPPED;
+        }
+
+        $userId = (int) $matches[1];
+
+        Log::info('Processing relevant off command', [
+            'user_id' => $userId,
+        ]);
+
+        // Update user's last access
+        DB::table('users')
+            ->where('id', $userId)
+            ->update(['lastaccess' => now()]);
+
+        // Check if user exists
+        $user = User::find($userId);
+        if ($user === null) {
+            Log::warning('User not found for relevant off', [
+                'user_id' => $userId,
+            ]);
+
+            return RoutingResult::DROPPED;
+        }
+
+        // Set relevantallowed to 0
+        $user->relevantallowed = 0;
+        $user->save();
+
+        Log::info('Turned off relevant for user', [
+            'user_id' => $userId,
+        ]);
 
         return RoutingResult::TO_SYSTEM;
     }
 
     /**
      * Handle volunteering off command.
+     *
+     * Updates the user's membership to turn off volunteering emails (volunteeringallowed = 0).
+     * Format: volunteeringoff-{userid}-{groupid}@users.ilovefreegle.org
      */
     private function handleVolunteeringOff(ParsedEmail $email): RoutingResult
     {
-        Log::info('Processing volunteering off command');
-        // TODO: Implement volunteering off processing
+        $localPart = explode('@', $email->envelopeTo)[0] ?? '';
+
+        // Parse volunteeringoff-{userid}-{groupid}
+        if (! preg_match('/^volunteeringoff-(\d+)-(\d+)$/', $localPart, $matches)) {
+            Log::warning('Invalid volunteering off address format', [
+                'envelope_to' => $email->envelopeTo,
+            ]);
+
+            return RoutingResult::DROPPED;
+        }
+
+        $userId = (int) $matches[1];
+        $groupId = (int) $matches[2];
+
+        Log::info('Processing volunteering off command', [
+            'user_id' => $userId,
+            'group_id' => $groupId,
+        ]);
+
+        // Update user's last access
+        DB::table('users')
+            ->where('id', $userId)
+            ->update(['lastaccess' => now()]);
+
+        // Check if user is an approved member of the group
+        $membership = Membership::where('userid', $userId)
+            ->where('groupid', $groupId)
+            ->where('collection', 'Approved')
+            ->first();
+
+        if ($membership === null) {
+            Log::warning('User is not an approved member of group', [
+                'user_id' => $userId,
+                'group_id' => $groupId,
+            ]);
+
+            return RoutingResult::DROPPED;
+        }
+
+        // Set volunteeringallowed to 0
+        $membership->volunteeringallowed = 0;
+        $membership->save();
+
+        Log::info('Turned off volunteering for user', [
+            'user_id' => $userId,
+            'group_id' => $groupId,
+        ]);
 
         return RoutingResult::TO_SYSTEM;
     }
 
     /**
      * Handle notification mails off command.
+     *
+     * Updates the user's settings JSON to turn off notification mails.
+     * Format: notificationmailsoff-{userid}@users.ilovefreegle.org
      */
     private function handleNotificationMailsOff(ParsedEmail $email): RoutingResult
     {
-        Log::info('Processing notification mails off command');
-        // TODO: Implement notification mails off processing
+        $localPart = explode('@', $email->envelopeTo)[0] ?? '';
+
+        // Parse notificationmailsoff-{userid}
+        if (! preg_match('/^notificationmailsoff-(\d+)$/', $localPart, $matches)) {
+            Log::warning('Invalid notification mails off address format', [
+                'envelope_to' => $email->envelopeTo,
+            ]);
+
+            return RoutingResult::DROPPED;
+        }
+
+        $userId = (int) $matches[1];
+
+        Log::info('Processing notification mails off command', [
+            'user_id' => $userId,
+        ]);
+
+        // Update user's last access
+        DB::table('users')
+            ->where('id', $userId)
+            ->update(['lastaccess' => now()]);
+
+        // Check if user exists
+        $user = User::find($userId);
+        if ($user === null) {
+            Log::warning('User not found for notification mails off', [
+                'user_id' => $userId,
+            ]);
+
+            return RoutingResult::DROPPED;
+        }
+
+        // Get current settings JSON
+        $settings = json_decode($user->settings ?? '{}', TRUE) ?: [];
+
+        // Only update if not already off
+        if (($settings['notificationmails'] ?? TRUE) === TRUE) {
+            $settings['notificationmails'] = FALSE;
+            $user->settings = json_encode($settings);
+            $user->save();
+
+            Log::info('Turned off notification mails for user', [
+                'user_id' => $userId,
+            ]);
+        }
 
         return RoutingResult::TO_SYSTEM;
     }
 
     /**
-     * Handle one-click unsubscribe.
+     * Handle one-click unsubscribe (RFC 8058).
+     *
+     * Puts the user into "limbo" (soft delete) which allows them to recover their account.
+     * Format: unsubscribe-{userid}-{key}-{type}@users.ilovefreegle.org
      */
     private function handleOneClickUnsubscribe(ParsedEmail $email): RoutingResult
     {
-        Log::info('Processing one-click unsubscribe');
-        // TODO: Implement one-click unsubscribe processing
+        $localPart = explode('@', $email->envelopeTo)[0] ?? '';
+
+        // Parse unsubscribe-{userid}-{key}-{type}
+        if (! preg_match('/^unsubscribe-(\d+)-([^-]+)-(.+)$/', $localPart, $matches)) {
+            Log::warning('Invalid one-click unsubscribe address format', [
+                'envelope_to' => $email->envelopeTo,
+            ]);
+
+            return RoutingResult::DROPPED;
+        }
+
+        $userId = (int) $matches[1];
+        $key = $matches[2];
+        $type = $matches[3];
+
+        Log::info('Processing one-click unsubscribe', [
+            'user_id' => $userId,
+            'type' => $type,
+        ]);
+
+        // Check if user exists
+        $user = User::find($userId);
+        if ($user === null) {
+            Log::warning('User not found for one-click unsubscribe', [
+                'user_id' => $userId,
+            ]);
+
+            return RoutingResult::DROPPED;
+        }
+
+        // Prevent accidental unsubscription by moderators
+        if ($this->isUserModerator($userId)) {
+            Log::info('Ignoring one-click unsubscribe for moderator', [
+                'user_id' => $userId,
+            ]);
+
+            return RoutingResult::DROPPED;
+        }
+
+        // Validate the key to prevent spoof unsubscribes
+        $storedKey = $this->getUserKey($userId);
+        if (! $storedKey || strcasecmp($storedKey, $key) !== 0) {
+            Log::warning('Invalid key for one-click unsubscribe', [
+                'user_id' => $userId,
+            ]);
+
+            return RoutingResult::DROPPED;
+        }
+
+        // Put user into limbo (soft delete)
+        DB::table('users')
+            ->where('id', $userId)
+            ->update(['deleted' => now()]);
+
+        Log::info('Put user into limbo via one-click unsubscribe', [
+            'user_id' => $userId,
+            'type' => $type,
+        ]);
 
         return RoutingResult::TO_SYSTEM;
+    }
+
+    /**
+     * Check if user is a moderator on any group.
+     */
+    private function isUserModerator(int $userId): bool
+    {
+        return DB::table('memberships')
+            ->where('userid', $userId)
+            ->whereIn('role', ['Moderator', 'Owner'])
+            ->exists();
+    }
+
+    /**
+     * Get the user's stored key for one-click unsubscribe validation.
+     */
+    private function getUserKey(int $userId): ?string
+    {
+        $login = DB::table('users_logins')
+            ->where('userid', $userId)
+            ->where('type', 'Link')
+            ->first();
+
+        return $login?->credentials;
     }
 
     /**
      * Handle subscribe command.
+     *
+     * Adds the user to the group. If the user doesn't exist, creates them.
+     * Format: {groupname}-subscribe@groups.ilovefreegle.org
      */
     private function handleSubscribe(ParsedEmail $email): RoutingResult
     {
+        $localPart = explode('@', $email->envelopeTo)[0] ?? '';
+
+        // Parse {groupname}-subscribe
+        if (! preg_match('/^(.+)-subscribe$/', $localPart, $matches)) {
+            Log::warning('Invalid subscribe address format', [
+                'envelope_to' => $email->envelopeTo,
+            ]);
+
+            return RoutingResult::DROPPED;
+        }
+
+        $groupName = $matches[1];
+
         Log::info('Processing subscribe command', [
-            'group' => $email->targetGroupName,
+            'group' => $groupName,
         ]);
-        // TODO: Implement subscribe processing
+
+        // Find the group
+        $group = Group::where('nameshort', $groupName)->first();
+        if ($group === null) {
+            Log::warning('Subscribe to unknown group', [
+                'group' => $groupName,
+            ]);
+
+            return RoutingResult::DROPPED;
+        }
+
+        // Find or create the user
+        $envFrom = $email->envelopeFrom;
+        $userEmail = UserEmail::where('email', $envFrom)->first();
+
+        if ($userEmail === null) {
+            // Create a new user
+            $user = User::create([
+                'fullname' => $email->fromName,
+                'systemrole' => 'User',
+                'added' => now(),
+                'lastaccess' => now(),
+            ]);
+
+            // Add their email
+            UserEmail::create([
+                'userid' => $user->id,
+                'email' => $envFrom,
+                'preferred' => 1,
+                'added' => now(),
+            ]);
+
+            Log::info('Created new user for subscribe', [
+                'user_id' => $user->id,
+                'email' => $envFrom,
+            ]);
+        } else {
+            $user = User::find($userEmail->userid);
+            if ($user === null) {
+                Log::warning('User email exists but user not found', [
+                    'email' => $envFrom,
+                ]);
+
+                return RoutingResult::DROPPED;
+            }
+
+            // Update last access
+            $user->lastaccess = now();
+            $user->save();
+        }
+
+        // Check if already a member
+        $existingMembership = Membership::where('userid', $user->id)
+            ->where('groupid', $group->id)
+            ->first();
+
+        if ($existingMembership !== null) {
+            Log::info('User is already a member', [
+                'user_id' => $user->id,
+                'group_id' => $group->id,
+            ]);
+
+            return RoutingResult::TO_SYSTEM;
+        }
+
+        // Add membership
+        Membership::create([
+            'userid' => $user->id,
+            'groupid' => $group->id,
+            'role' => 'Member',
+            'collection' => 'Approved',
+            'added' => now(),
+            'emailfrequency' => 24, // Daily digest by default
+        ]);
+
+        Log::info('Added user to group', [
+            'user_id' => $user->id,
+            'group_id' => $group->id,
+            'group_name' => $groupName,
+        ]);
 
         return RoutingResult::TO_SYSTEM;
     }
 
     /**
      * Handle unsubscribe command.
+     *
+     * Removes the user from the group. Moderators/owners are protected from
+     * accidental unsubscription.
+     * Format: {groupname}-unsubscribe@groups.ilovefreegle.org
      */
     private function handleUnsubscribe(ParsedEmail $email): RoutingResult
     {
+        $localPart = explode('@', $email->envelopeTo)[0] ?? '';
+
+        // Parse {groupname}-unsubscribe
+        if (! preg_match('/^(.+)-unsubscribe$/', $localPart, $matches)) {
+            Log::warning('Invalid unsubscribe address format', [
+                'envelope_to' => $email->envelopeTo,
+            ]);
+
+            return RoutingResult::DROPPED;
+        }
+
+        $groupName = $matches[1];
+
         Log::info('Processing unsubscribe command', [
-            'group' => $email->targetGroupName,
+            'group' => $groupName,
         ]);
-        // TODO: Implement unsubscribe processing
+
+        // Find the group
+        $group = Group::where('nameshort', $groupName)->first();
+        if ($group === null) {
+            Log::warning('Unsubscribe from unknown group', [
+                'group' => $groupName,
+            ]);
+
+            return RoutingResult::DROPPED;
+        }
+
+        // Find the user by envelope from
+        $envFrom = $email->envelopeFrom;
+        $userEmail = UserEmail::where('email', $envFrom)->first();
+
+        if ($userEmail === null) {
+            Log::warning('Unsubscribe from unknown user', [
+                'email' => $envFrom,
+            ]);
+
+            return RoutingResult::DROPPED;
+        }
+
+        $user = User::find($userEmail->userid);
+        if ($user === null) {
+            Log::warning('User email exists but user not found', [
+                'email' => $envFrom,
+            ]);
+
+            return RoutingResult::DROPPED;
+        }
+
+        // Update last access
+        $user->lastaccess = now();
+        $user->save();
+
+        // Check if user is a mod or owner of this group - protect them
+        $membership = Membership::where('userid', $user->id)
+            ->where('groupid', $group->id)
+            ->first();
+
+        if ($membership === null) {
+            Log::info('User is not a member of group', [
+                'user_id' => $user->id,
+                'group_id' => $group->id,
+            ]);
+
+            return RoutingResult::DROPPED;
+        }
+
+        if (in_array($membership->role, ['Moderator', 'Owner'])) {
+            Log::info('Ignoring unsubscribe for moderator/owner', [
+                'user_id' => $user->id,
+                'group_id' => $group->id,
+                'role' => $membership->role,
+            ]);
+
+            return RoutingResult::DROPPED;
+        }
+
+        // Remove membership
+        $membership->delete();
+
+        Log::info('Removed user from group', [
+            'user_id' => $user->id,
+            'group_id' => $group->id,
+            'group_name' => $groupName,
+        ]);
 
         return RoutingResult::TO_SYSTEM;
     }
@@ -461,9 +1170,44 @@ class IncomingMailService
             return RoutingResult::DROPPED;
         }
 
-        // TODO: Create/get chat and add message
-        Log::info('Processing reply to message', [
+        // Find the sender user
+        $fromUser = $this->findUserByEmail($email->fromAddress);
+        if ($fromUser === null) {
+            Log::warning('Reply from unknown user', [
+                'from' => $email->fromAddress,
+            ]);
+
+            return RoutingResult::DROPPED;
+        }
+
+        // Get the message owner
+        $messageOwner = $message->fromuser;
+        if ($messageOwner === null) {
+            Log::warning('Message has no owner', [
+                'message_id' => $messageId,
+            ]);
+
+            return RoutingResult::DROPPED;
+        }
+
+        // Get or create User2User chat between the sender and message owner
+        $chat = $this->getOrCreateUserChat($fromUser->id, $messageOwner);
+        if ($chat === null) {
+            Log::warning('Could not create chat for reply', [
+                'from_user' => $fromUser->id,
+                'to_user' => $messageOwner,
+            ]);
+
+            return RoutingResult::DROPPED;
+        }
+
+        // Create the chat message
+        $this->createChatMessageFromEmail($chat, $fromUser->id, $email);
+
+        Log::info('Created chat message from reply-to email', [
             'message_id' => $messageId,
+            'chat_id' => $chat->id,
+            'from_user' => $fromUser->id,
         ]);
 
         return RoutingResult::TO_USER;
@@ -615,8 +1359,25 @@ class IncomingMailService
             return RoutingResult::DROPPED;
         }
 
-        // TODO: Create/get chat between user and moderators
-        // TODO: Add message to chat
+        // Get or create User2Mod chat between user and group moderators
+        $chat = $this->getOrCreateUser2ModChat($user->id, $group->id);
+        if ($chat === null) {
+            Log::warning('Could not create User2Mod chat', [
+                'user_id' => $user->id,
+                'group_id' => $group->id,
+            ]);
+
+            return RoutingResult::DROPPED;
+        }
+
+        // Create the chat message
+        $this->createChatMessageFromEmail($chat, $user->id, $email);
+
+        Log::info('Created volunteers message', [
+            'chat_id' => $chat->id,
+            'user_id' => $user->id,
+            'group_id' => $group->id,
+        ]);
 
         return RoutingResult::TO_VOLUNTEERS;
     }
@@ -717,9 +1478,14 @@ class IncomingMailService
             return false;
         }
 
-        // TODO: Validate secret against config
-        // For now, any TN secret skips spam check
-        return true;
+        // Validate secret against config
+        $configSecret = config('freegle.mail.trashnothing_secret');
+        if (empty($configSecret)) {
+            // If no secret configured, accept any TN email with a secret header
+            return true;
+        }
+
+        return $secret === $configSecret;
     }
 
     /**
@@ -730,7 +1496,9 @@ class IncomingMailService
         $subject = strtolower($email->subject ?? '');
         $body = strtolower($email->textBody ?? '');
 
-        // Simple spam patterns - TODO: Implement full spam checking
+        // Common spam patterns
+        // Note: Full spam checking is handled by Rspamd/SpamAssassin at the MTA level.
+        // These patterns catch obvious spam that might bypass external filters.
         $spamPatterns = [
             'make money fast',
             'guaranteed returns',
@@ -755,36 +1523,93 @@ class IncomingMailService
 
     /**
      * Check if email contains worry words.
+     *
+     * Worry words are stored in the 'worrywords' database table with types:
+     * - Regulated: UK regulated substances
+     * - Reportable: UK reportable substances
+     * - Medicine: Medicines/supplements
+     * - Review: Just needs looking at
+     * - Allowed: Exclusions (removed from text before checking)
      */
     private function containsWorryWords(ParsedEmail $email): bool
     {
-        $subject = strtolower($email->subject ?? '');
-        $body = strtolower($email->textBody ?? '');
+        $subject = $email->subject ?? '';
+        $body = $email->textBody ?? '';
 
-        // Common worry words - TODO: Load from database/config
-        $worryWords = [
-            'kitten',
-            'puppy',
-            'dog',
-            'cat',
-            'pet',
-            'animal',
-            'medication',
-            'medicine',
-            'drugs',
-        ];
+        // Get worry words from database
+        $worryWords = DB::table('worrywords')->get();
 
-        foreach ($worryWords as $word) {
-            if (str_contains($subject, $word) || str_contains($body, $word)) {
-                return true;
+        // Check for pound sign (£) as a special case
+        if (str_contains($subject, '£') || str_contains($body, '£')) {
+            Log::debug('Worry word found: £');
+
+            return TRUE;
+        }
+
+        // First, remove any ALLOWED type words from the text
+        foreach ($worryWords as $worryWord) {
+            if ($worryWord->type === 'Allowed') {
+                $pattern = '/\b'.preg_quote($worryWord->keyword, '/').'\b/i';
+                $subject = preg_replace($pattern, '', $subject);
+                $body = preg_replace($pattern, '', $body);
             }
         }
 
-        return false;
+        // Check for phrases (words containing spaces) with literal matching
+        foreach ($worryWords as $worryWord) {
+            if ($worryWord->type !== 'Allowed' && str_contains($worryWord->keyword, ' ')) {
+                if (stripos($subject, $worryWord->keyword) !== FALSE ||
+                    stripos($body, $worryWord->keyword) !== FALSE) {
+                    Log::debug('Worry word phrase found', [
+                        'keyword' => $worryWord->keyword,
+                        'type' => $worryWord->type,
+                    ]);
+
+                    return TRUE;
+                }
+            }
+        }
+
+        // Check individual words with exact matching (threshold = 1, so exact match only)
+        $subjectWords = preg_split('/\b/', $subject);
+        $bodyWords = preg_split('/\b/', $body);
+        $allWords = array_merge($subjectWords, $bodyWords);
+
+        foreach ($allWords as $word) {
+            $word = trim($word);
+            if (empty($word)) {
+                continue;
+            }
+
+            foreach ($worryWords as $worryWord) {
+                if ($worryWord->type !== 'Allowed' && ! empty($worryWord->keyword)) {
+                    // Check length ratio (0.75 to 1.25)
+                    $ratio = strlen($word) / strlen($worryWord->keyword);
+                    if ($ratio >= 0.75 && $ratio <= 1.25) {
+                        // Exact match only (levenshtein distance < 1)
+                        if (levenshtein(strtolower($worryWord->keyword), strtolower($word)) < 1) {
+                            Log::debug('Worry word found', [
+                                'word' => $word,
+                                'keyword' => $worryWord->keyword,
+                                'type' => $worryWord->type,
+                            ]);
+
+                            return TRUE;
+                        }
+                    }
+                }
+            }
+        }
+
+        return FALSE;
     }
 
     /**
      * Handle direct mail to users.
+     *
+     * Direct mail is sent to {something}@users.ilovefreegle.org where {something}
+     * is a user's email address that can be looked up. This handles replies to
+     * What's New emails and direct user-to-user communication.
      */
     private function handleDirectMail(ParsedEmail $email): RoutingResult
     {
@@ -793,7 +1618,65 @@ class IncomingMailService
             'to' => $email->envelopeTo,
         ]);
 
-        // TODO: Implement direct mail routing
+        // Find the recipient user by looking up the envelope-to address
+        $toAddress = $email->envelopeTo;
+        $recipientEmail = UserEmail::where('email', $toAddress)->first();
+
+        if ($recipientEmail === null) {
+            Log::info('Direct mail to unknown user address', [
+                'to' => $toAddress,
+            ]);
+
+            return RoutingResult::DROPPED;
+        }
+
+        $recipientUser = User::find($recipientEmail->userid);
+        if ($recipientUser === null) {
+            Log::warning('Direct mail to email with no user', [
+                'to' => $toAddress,
+            ]);
+
+            return RoutingResult::DROPPED;
+        }
+
+        // Find the sender user
+        $senderUser = $this->findUserByEmail($email->fromAddress);
+        if ($senderUser === null) {
+            Log::info('Direct mail from unknown user', [
+                'from' => $email->fromAddress,
+            ]);
+
+            return RoutingResult::DROPPED;
+        }
+
+        // Don't create a chat between the same user
+        if ($senderUser->id === $recipientUser->id) {
+            Log::info('Direct mail to self - dropping', [
+                'user_id' => $senderUser->id,
+            ]);
+
+            return RoutingResult::DROPPED;
+        }
+
+        // Get or create chat between sender and recipient
+        $chat = $this->getOrCreateUserChat($senderUser->id, $recipientUser->id);
+        if ($chat === null) {
+            Log::warning('Could not create chat for direct mail', [
+                'from_user' => $senderUser->id,
+                'to_user' => $recipientUser->id,
+            ]);
+
+            return RoutingResult::DROPPED;
+        }
+
+        // Create the chat message
+        $this->createChatMessageFromEmail($chat, $senderUser->id, $email);
+
+        Log::info('Created chat message from direct mail', [
+            'chat_id' => $chat->id,
+            'from_user' => $senderUser->id,
+            'to_user' => $recipientUser->id,
+        ]);
 
         return RoutingResult::TO_USER;
     }
@@ -825,5 +1708,56 @@ class IncomingMailService
         }
 
         return User::find($userEmail->userid);
+    }
+
+    /**
+     * Get or create a User2User chat between two users.
+     */
+    private function getOrCreateUserChat(int $userId1, int $userId2): ?ChatRoom
+    {
+        // Normalize order (smaller ID first)
+        if ($userId1 > $userId2) {
+            [$userId1, $userId2] = [$userId2, $userId1];
+        }
+
+        // Check if chat already exists
+        $chat = ChatRoom::where('chattype', 'User2User')
+            ->where('user1', $userId1)
+            ->where('user2', $userId2)
+            ->first();
+
+        if ($chat !== null) {
+            return $chat;
+        }
+
+        // Create new chat
+        return ChatRoom::create([
+            'chattype' => 'User2User',
+            'user1' => $userId1,
+            'user2' => $userId2,
+        ]);
+    }
+
+    /**
+     * Get or create a User2Mod chat for a user with a group's moderators.
+     */
+    private function getOrCreateUser2ModChat(int $userId, int $groupId): ?ChatRoom
+    {
+        // Check if chat already exists
+        $chat = ChatRoom::where('chattype', 'User2Mod')
+            ->where('user1', $userId)
+            ->where('groupid', $groupId)
+            ->first();
+
+        if ($chat !== null) {
+            return $chat;
+        }
+
+        // Create new chat
+        return ChatRoom::create([
+            'chattype' => 'User2Mod',
+            'user1' => $userId,
+            'groupid' => $groupId,
+        ]);
     }
 }

--- a/iznik-batch/app/Services/Mail/Incoming/IncomingMailService.php
+++ b/iznik-batch/app/Services/Mail/Incoming/IncomingMailService.php
@@ -340,7 +340,7 @@ class IncomingMailService
         DB::table('chat_roster')
             ->updateOrInsert(
                 ['chatid' => $chatId, 'userid' => $userId],
-                ['lastmsgseen' => $msgId, 'lastseen' => now()]
+                ['lastmsgseen' => $msgId, 'date' => now()]
             );
 
         // For user-to-user chats, mark message as seen by all

--- a/iznik-batch/app/Services/Mail/Incoming/MailParserService.php
+++ b/iznik-batch/app/Services/Mail/Incoming/MailParserService.php
@@ -228,8 +228,9 @@ class MailParserService
         $localPart = $parts[0];
         $domain = $parts[1];
 
-        // Only process groups.ilovefreegle.org addresses for group routing
-        if ($domain !== 'groups.ilovefreegle.org') {
+        // Only process group domain addresses for group routing
+        $groupDomain = config('freegle.mail.group_domain');
+        if ($domain !== $groupDomain) {
             return $result;
         }
 
@@ -384,8 +385,9 @@ class MailParserService
         $localPart = $parts[0];
         $domain = $parts[1];
 
-        // Must be users.ilovefreegle.org domain
-        if ($domain !== 'users.ilovefreegle.org') {
+        // Must be user domain
+        $userDomain = config('freegle.mail.user_domain');
+        if ($domain !== $userDomain) {
             return $result;
         }
 
@@ -432,8 +434,9 @@ class MailParserService
         $localPart = $parts[0];
         $domain = $parts[1];
 
-        // Must be users.ilovefreegle.org domain
-        if ($domain !== 'users.ilovefreegle.org') {
+        // Must be user domain
+        $userDomain = config('freegle.mail.user_domain');
+        if ($domain !== $userDomain) {
             return $result;
         }
 

--- a/iznik-batch/app/Services/Mail/Incoming/MailParserService.php
+++ b/iznik-batch/app/Services/Mail/Incoming/MailParserService.php
@@ -1,0 +1,478 @@
+<?php
+
+namespace App\Services\Mail\Incoming;
+
+use Carbon\Carbon;
+use ZBateson\MailMimeParser\Header\AddressHeader;
+use ZBateson\MailMimeParser\Message;
+
+/**
+ * Service for parsing raw email messages into structured ParsedEmail objects.
+ *
+ * This service extracts all relevant information from an incoming email,
+ * including headers, body content, and routing hints derived from the
+ * envelope addresses and message structure.
+ *
+ * Uses zbateson/mail-mime-parser - a pure PHP library with excellent RFC
+ * compliance and no extension dependencies.
+ */
+class MailParserService
+{
+    /**
+     * Parse a raw email message.
+     *
+     * @param  string  $rawMessage  The complete raw email including headers and body
+     * @param  string  $envelopeFrom  The SMTP envelope sender (MAIL FROM)
+     * @param  string  $envelopeTo  The SMTP envelope recipient (RCPT TO)
+     * @return ParsedEmail The parsed email data
+     */
+    public function parse(string $rawMessage, string $envelopeFrom, string $envelopeTo): ParsedEmail
+    {
+        // Parse the message using zbateson/mail-mime-parser
+        $message = Message::from($rawMessage, false);
+
+        // Extract basic headers
+        $subject = $message->getSubject();
+        [$fromAddress, $fromName] = $this->extractFrom($message);
+        $toAddresses = $this->extractToAddresses($message);
+        $messageId = $this->extractMessageId($message);
+        $date = $this->extractDate($message);
+
+        // Extract body content
+        $textBody = $message->getTextContent();
+        $htmlBody = $message->getHtmlContent();
+
+        // Extract all headers (lowercase keys for consistent access)
+        $headers = $this->extractAllHeaders($message);
+
+        // Analyze envelope-to for routing information
+        $routingInfo = $this->analyzeEnvelopeTo($envelopeTo);
+
+        // Check for bounce information
+        $bounceInfo = $this->extractBounceInfo($message, $envelopeFrom, $envelopeTo);
+
+        // Check for chat notification reply
+        $chatInfo = $this->extractChatInfo($envelopeTo);
+
+        // Check for email commands (digestoff, etc.)
+        $commandInfo = $this->extractCommandInfo($envelopeTo);
+
+        // Extract sender IP
+        $senderIp = $this->extractSenderIp($headers);
+
+        return new ParsedEmail(
+            rawMessage: $rawMessage,
+            envelopeFrom: $envelopeFrom,
+            envelopeTo: $envelopeTo,
+            subject: $subject,
+            fromAddress: $fromAddress,
+            fromName: $fromName,
+            toAddresses: $toAddresses,
+            messageId: $messageId,
+            date: $date,
+            textBody: $textBody ?: null,
+            htmlBody: $htmlBody ?: null,
+            headers: $headers,
+            targetGroupName: $routingInfo['groupName'],
+            isToVolunteers: $routingInfo['isVolunteers'],
+            isToAuto: $routingInfo['isAuto'],
+            bounceRecipient: $bounceInfo['recipient'],
+            bounceStatus: $bounceInfo['status'],
+            bounceDiagnostic: $bounceInfo['diagnostic'],
+            chatId: $chatInfo['chatId'],
+            chatUserId: $chatInfo['userId'],
+            chatMessageId: $chatInfo['messageId'],
+            commandUserId: $commandInfo['userId'],
+            commandGroupId: $commandInfo['groupId'],
+            senderIp: $senderIp
+        );
+    }
+
+    /**
+     * Extract from address and name.
+     *
+     * @return array{0: ?string, 1: ?string} [address, name]
+     */
+    private function extractFrom(Message $message): array
+    {
+        $fromHeader = $message->getHeader('From');
+
+        if (! $fromHeader instanceof AddressHeader) {
+            return [null, null];
+        }
+
+        $email = $fromHeader->getEmail();
+        $name = $fromHeader->getPersonName();
+
+        // If display name is same as email or empty, treat as no name
+        if ($name === $email || $name === '') {
+            $name = null;
+        }
+
+        return [$email, $name];
+    }
+
+    /**
+     * Extract all To addresses.
+     *
+     * @return array<string>
+     */
+    private function extractToAddresses(Message $message): array
+    {
+        $toHeader = $message->getHeader('To');
+
+        if (! $toHeader instanceof AddressHeader) {
+            return [];
+        }
+
+        $addresses = [];
+        foreach ($toHeader->getAddresses() as $addr) {
+            $email = $addr->getEmail();
+            if ($email !== null) {
+                $addresses[] = $email;
+            }
+        }
+
+        return $addresses;
+    }
+
+    /**
+     * Extract Message-ID header.
+     */
+    private function extractMessageId(Message $message): ?string
+    {
+        $messageId = $message->getHeaderValue('Message-ID');
+        if ($messageId === null) {
+            return null;
+        }
+
+        // Remove angle brackets if present
+        return trim($messageId, '<>');
+    }
+
+    /**
+     * Extract and parse Date header.
+     */
+    private function extractDate(Message $message): ?Carbon
+    {
+        $dateHeader = $message->getHeader('Date');
+
+        if ($dateHeader === null) {
+            return null;
+        }
+
+        // zbateson provides DateTime parsing via DateHeader
+        if (method_exists($dateHeader, 'getDateTime')) {
+            $dateTime = $dateHeader->getDateTime();
+            if ($dateTime !== null) {
+                return Carbon::instance($dateTime);
+            }
+        }
+
+        // Fallback: try parsing the raw value
+        $dateValue = $message->getHeaderValue('Date');
+        if ($dateValue !== null) {
+            try {
+                return Carbon::parse($dateValue);
+            } catch (\Exception $e) {
+                return null;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Extract all headers as lowercase-keyed array.
+     *
+     * @return array<string, string>
+     */
+    private function extractAllHeaders(Message $message): array
+    {
+        $headers = [];
+
+        foreach ($message->getAllHeaders() as $header) {
+            $name = strtolower($header->getName());
+            $value = $header->getRawValue();
+
+            // If we already have this header, append (for multi-value headers)
+            if (isset($headers[$name])) {
+                $headers[$name] .= ', '.$value;
+            } else {
+                $headers[$name] = $value;
+            }
+        }
+
+        return $headers;
+    }
+
+    /**
+     * Analyze envelope-to address for routing information.
+     *
+     * @return array{groupName: ?string, isVolunteers: bool, isAuto: bool}
+     */
+    private function analyzeEnvelopeTo(string $envelopeTo): array
+    {
+        $result = [
+            'groupName' => null,
+            'isVolunteers' => false,
+            'isAuto' => false,
+        ];
+
+        // Parse the envelope-to address
+        $parts = explode('@', $envelopeTo);
+        if (count($parts) !== 2) {
+            return $result;
+        }
+
+        $localPart = $parts[0];
+        $domain = $parts[1];
+
+        // Only process groups.ilovefreegle.org addresses for group routing
+        if ($domain !== 'groups.ilovefreegle.org') {
+            return $result;
+        }
+
+        // Check for special suffixes
+        if (str_ends_with($localPart, '-volunteers')) {
+            $result['isVolunteers'] = true;
+            $result['groupName'] = substr($localPart, 0, -11); // Remove '-volunteers'
+        } elseif (str_ends_with($localPart, '-auto')) {
+            $result['isAuto'] = true;
+            $result['groupName'] = substr($localPart, 0, -5); // Remove '-auto'
+        } elseif (str_ends_with($localPart, '-subscribe')) {
+            $result['groupName'] = substr($localPart, 0, -10); // Remove '-subscribe'
+        } elseif (str_ends_with($localPart, '-unsubscribe')) {
+            $result['groupName'] = substr($localPart, 0, -12); // Remove '-unsubscribe'
+        } else {
+            // Plain group address
+            $result['groupName'] = $localPart;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Extract bounce/DSN information from the message.
+     *
+     * @return array{recipient: ?string, status: ?string, diagnostic: ?string}
+     */
+    private function extractBounceInfo(Message $message, string $envelopeFrom, string $envelopeTo): array
+    {
+        $result = [
+            'recipient' => null,
+            'status' => null,
+            'diagnostic' => null,
+        ];
+
+        // Check if this looks like a bounce
+        $isFromMailerDaemon = stripos($envelopeFrom, 'mailer-daemon') !== false;
+        $contentType = $message->getHeaderValue('Content-Type') ?? '';
+        $isDeliveryReport = stripos($contentType, 'multipart/report') !== false &&
+            stripos($contentType, 'delivery-status') !== false;
+
+        if (! $isFromMailerDaemon && ! $isDeliveryReport) {
+            return $result;
+        }
+
+        // Look for delivery-status part in the message
+        $childCount = $message->getChildCount();
+        for ($i = 0; $i < $childCount; $i++) {
+            $child = $message->getChild($i);
+            if ($child === null) {
+                continue;
+            }
+
+            $childContentType = $child->getHeaderValue('Content-Type') ?? '';
+            if (stripos($childContentType, 'message/delivery-status') !== false) {
+                $content = $child->getContent();
+                if ($content !== null) {
+                    $result = $this->parseDeliveryStatus($content);
+                    break;
+                }
+            }
+        }
+
+        // If no delivery-status part, try to parse from body
+        if ($result['recipient'] === null) {
+            $textBody = $message->getTextContent();
+            if ($textBody) {
+                $result = $this->extractBounceFromBody($textBody);
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Parse delivery-status content.
+     *
+     * @return array{recipient: ?string, status: ?string, diagnostic: ?string}
+     */
+    private function parseDeliveryStatus(string $content): array
+    {
+        $result = [
+            'recipient' => null,
+            'status' => null,
+            'diagnostic' => null,
+        ];
+
+        // Parse Final-Recipient
+        if (preg_match('/Final-Recipient:\s*(?:rfc822;?\s*)?(\S+)/i', $content, $matches)) {
+            $result['recipient'] = trim($matches[1]);
+        }
+
+        // Parse Status
+        if (preg_match('/Status:\s*(\d\.\d\.\d)/i', $content, $matches)) {
+            $result['status'] = $matches[1];
+        }
+
+        // Parse Diagnostic-Code
+        if (preg_match('/Diagnostic-Code:\s*(?:smtp;?\s*)?(.+?)(?:\r?\n(?!\s)|\z)/is', $content, $matches)) {
+            $result['diagnostic'] = trim($matches[1]);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Try to extract bounce info from plain text body.
+     *
+     * @return array{recipient: ?string, status: ?string, diagnostic: ?string}
+     */
+    private function extractBounceFromBody(string $body): array
+    {
+        $result = [
+            'recipient' => null,
+            'status' => null,
+            'diagnostic' => null,
+        ];
+
+        // Look for email address in angle brackets after common bounce indicators
+        if (preg_match('/<([^>]+@[^>]+)>.*?(\d\d\d\s+.+?)(?:\r?\n|\z)/is', $body, $matches)) {
+            $result['recipient'] = $matches[1];
+            // Extract status code from diagnostic
+            if (preg_match('/(\d\.\d\.\d)/', $matches[2], $statusMatch)) {
+                $result['status'] = $statusMatch[1];
+            }
+            $result['diagnostic'] = trim($matches[2]);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Extract chat notification reply information from envelope-to.
+     *
+     * Format: notify-{chatId}-{userId}[-{messageId}]@users.ilovefreegle.org
+     *
+     * @return array{chatId: ?int, userId: ?int, messageId: ?int}
+     */
+    private function extractChatInfo(string $envelopeTo): array
+    {
+        $result = [
+            'chatId' => null,
+            'userId' => null,
+            'messageId' => null,
+        ];
+
+        $parts = explode('@', $envelopeTo);
+        if (count($parts) !== 2) {
+            return $result;
+        }
+
+        $localPart = $parts[0];
+        $domain = $parts[1];
+
+        // Must be users.ilovefreegle.org domain
+        if ($domain !== 'users.ilovefreegle.org') {
+            return $result;
+        }
+
+        // Check for notify- prefix
+        if (! str_starts_with($localPart, 'notify-')) {
+            return $result;
+        }
+
+        // Parse: notify-{chatId}-{userId}[-{messageId}]
+        $notifyParts = explode('-', substr($localPart, 7)); // Remove 'notify-'
+
+        if (count($notifyParts) >= 2) {
+            $result['chatId'] = is_numeric($notifyParts[0]) ? (int) $notifyParts[0] : null;
+            $result['userId'] = is_numeric($notifyParts[1]) ? (int) $notifyParts[1] : null;
+
+            if (isset($notifyParts[2]) && is_numeric($notifyParts[2])) {
+                $result['messageId'] = (int) $notifyParts[2];
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Extract email command information from envelope-to.
+     *
+     * Supported formats:
+     * - digestoff-{userId}-{groupId}@users.ilovefreegle.org
+     *
+     * @return array{userId: ?int, groupId: ?int}
+     */
+    private function extractCommandInfo(string $envelopeTo): array
+    {
+        $result = [
+            'userId' => null,
+            'groupId' => null,
+        ];
+
+        $parts = explode('@', $envelopeTo);
+        if (count($parts) !== 2) {
+            return $result;
+        }
+
+        $localPart = $parts[0];
+        $domain = $parts[1];
+
+        // Must be users.ilovefreegle.org domain
+        if ($domain !== 'users.ilovefreegle.org') {
+            return $result;
+        }
+
+        // Check for digestoff- prefix
+        if (str_starts_with($localPart, 'digestoff-')) {
+            $commandParts = explode('-', substr($localPart, 10)); // Remove 'digestoff-'
+
+            if (count($commandParts) >= 2) {
+                $result['userId'] = is_numeric($commandParts[0]) ? (int) $commandParts[0] : null;
+                $result['groupId'] = is_numeric($commandParts[1]) ? (int) $commandParts[1] : null;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Extract sender IP address from headers.
+     */
+    private function extractSenderIp(array $headers): ?string
+    {
+        // Check X-Freegle-IP first (our own header)
+        if (isset($headers['x-freegle-ip'])) {
+            return $headers['x-freegle-ip'];
+        }
+
+        // Check X-Originating-IP (common webmail header)
+        if (isset($headers['x-originating-ip'])) {
+            $ip = $headers['x-originating-ip'];
+
+            // Often wrapped in square brackets
+            return trim($ip, '[]');
+        }
+
+        // Check X-Trash-Nothing-User-IP (Trash Nothing posts)
+        if (isset($headers['x-trash-nothing-user-ip'])) {
+            return $headers['x-trash-nothing-user-ip'];
+        }
+
+        return null;
+    }
+}

--- a/iznik-batch/app/Services/Mail/Incoming/ParsedEmail.php
+++ b/iznik-batch/app/Services/Mail/Incoming/ParsedEmail.php
@@ -1,0 +1,386 @@
+<?php
+
+namespace App\Services\Mail\Incoming;
+
+use Carbon\Carbon;
+
+/**
+ * Data Transfer Object for a parsed email message.
+ *
+ * This immutable object holds all extracted data from an incoming email,
+ * including envelope information, headers, body content, and routing hints.
+ */
+class ParsedEmail
+{
+    // ========================================
+    // Core Email Properties
+    // ========================================
+
+    public readonly string $rawMessage;
+
+    public readonly string $envelopeFrom;
+
+    public readonly string $envelopeTo;
+
+    public readonly ?string $subject;
+
+    public readonly ?string $fromAddress;
+
+    public readonly ?string $fromName;
+
+    public readonly array $toAddresses;
+
+    public readonly ?string $messageId;
+
+    public readonly ?Carbon $date;
+
+    public readonly ?string $textBody;
+
+    public readonly ?string $htmlBody;
+
+    // ========================================
+    // Routing Properties
+    // ========================================
+
+    public readonly ?string $targetGroupName;
+
+    public readonly bool $isToVolunteers;
+
+    public readonly bool $isToAuto;
+
+    // ========================================
+    // Bounce Properties
+    // ========================================
+
+    public readonly ?string $bounceRecipient;
+
+    public readonly ?string $bounceStatus;
+
+    public readonly ?string $bounceDiagnostic;
+
+    // ========================================
+    // Chat Reply Properties
+    // ========================================
+
+    public readonly ?int $chatId;
+
+    public readonly ?int $chatUserId;
+
+    public readonly ?int $chatMessageId;
+
+    // ========================================
+    // Email Command Properties
+    // ========================================
+
+    public readonly ?int $commandUserId;
+
+    public readonly ?int $commandGroupId;
+
+    // ========================================
+    // Spam/Security Properties
+    // ========================================
+
+    public readonly ?string $senderIp;
+
+    // ========================================
+    // Internal State
+    // ========================================
+
+    private array $headers;
+
+    private string $envelopeToLocalPart;
+
+    public function __construct(
+        string $rawMessage,
+        string $envelopeFrom,
+        string $envelopeTo,
+        ?string $subject,
+        ?string $fromAddress,
+        ?string $fromName,
+        array $toAddresses,
+        ?string $messageId,
+        ?Carbon $date,
+        ?string $textBody,
+        ?string $htmlBody,
+        array $headers,
+        ?string $targetGroupName,
+        bool $isToVolunteers,
+        bool $isToAuto,
+        ?string $bounceRecipient,
+        ?string $bounceStatus,
+        ?string $bounceDiagnostic,
+        ?int $chatId,
+        ?int $chatUserId,
+        ?int $chatMessageId,
+        ?int $commandUserId,
+        ?int $commandGroupId,
+        ?string $senderIp
+    ) {
+        $this->rawMessage = $rawMessage;
+        $this->envelopeFrom = $envelopeFrom;
+        $this->envelopeTo = $envelopeTo;
+        $this->subject = $subject;
+        $this->fromAddress = $fromAddress;
+        $this->fromName = $fromName;
+        $this->toAddresses = $toAddresses;
+        $this->messageId = $messageId;
+        $this->date = $date;
+        $this->textBody = $textBody;
+        $this->htmlBody = $htmlBody;
+        $this->headers = $headers;
+        $this->targetGroupName = $targetGroupName;
+        $this->isToVolunteers = $isToVolunteers;
+        $this->isToAuto = $isToAuto;
+        $this->bounceRecipient = $bounceRecipient;
+        $this->bounceStatus = $bounceStatus;
+        $this->bounceDiagnostic = $bounceDiagnostic;
+        $this->chatId = $chatId;
+        $this->chatUserId = $chatUserId;
+        $this->chatMessageId = $chatMessageId;
+        $this->commandUserId = $commandUserId;
+        $this->commandGroupId = $commandGroupId;
+        $this->senderIp = $senderIp;
+
+        // Cache envelope-to local part for routing checks
+        $this->envelopeToLocalPart = explode('@', $envelopeTo)[0] ?? '';
+    }
+
+    // ========================================
+    // Header Access
+    // ========================================
+
+    /**
+     * Get a header value by name (case-insensitive).
+     */
+    public function getHeader(string $name): ?string
+    {
+        $name = strtolower($name);
+
+        return $this->headers[$name] ?? null;
+    }
+
+    /**
+     * Get all headers.
+     */
+    public function getHeaders(): array
+    {
+        return $this->headers;
+    }
+
+    // ========================================
+    // Message Type Detection
+    // ========================================
+
+    /**
+     * Check if this is a bounce/DSN message.
+     */
+    public function isBounce(): bool
+    {
+        return $this->bounceRecipient !== null || $this->bounceStatus !== null;
+    }
+
+    /**
+     * Check if this is a permanent bounce (5.x.x status).
+     */
+    public function isPermanentBounce(): bool
+    {
+        if ($this->bounceStatus === null) {
+            return false;
+        }
+
+        return str_starts_with($this->bounceStatus, '5');
+    }
+
+    /**
+     * Check if this is a reply to a chat notification email.
+     */
+    public function isChatNotificationReply(): bool
+    {
+        return $this->chatId !== null;
+    }
+
+    /**
+     * Check if this is an auto-reply (vacation, OOO, etc.).
+     */
+    public function isAutoReply(): bool
+    {
+        $autoSubmitted = $this->getHeader('auto-submitted');
+        if ($autoSubmitted === null) {
+            return false;
+        }
+
+        // RFC 3834: 'no' means manual, anything else is automatic
+        return strtolower($autoSubmitted) !== 'no';
+    }
+
+    /**
+     * Check if this email is addressed to group volunteers.
+     */
+    public function isToVolunteers(): bool
+    {
+        return $this->isToVolunteers;
+    }
+
+    /**
+     * Check if this email is addressed to the group auto address.
+     */
+    public function isToAuto(): bool
+    {
+        return $this->isToAuto;
+    }
+
+    // ========================================
+    // Email Command Detection
+    // ========================================
+
+    /**
+     * Check if this is a subscribe command.
+     */
+    public function isSubscribeCommand(): bool
+    {
+        return str_ends_with($this->envelopeToLocalPart, '-subscribe');
+    }
+
+    /**
+     * Check if this is an unsubscribe command.
+     */
+    public function isUnsubscribeCommand(): bool
+    {
+        return str_ends_with($this->envelopeToLocalPart, '-unsubscribe');
+    }
+
+    /**
+     * Check if this is a digest-off command.
+     */
+    public function isDigestOffCommand(): bool
+    {
+        return str_starts_with($this->envelopeToLocalPart, 'digestoff-');
+    }
+
+    // ========================================
+    // Trash Nothing Detection
+    // ========================================
+
+    /**
+     * Check if this email came from Trash Nothing.
+     */
+    public function isFromTrashNothing(): bool
+    {
+        // Check for TN secret header
+        $tnSecret = $this->getHeader('x-trash-nothing-secret');
+        if ($tnSecret !== null) {
+            return true;
+        }
+
+        // Check for TN-specific domain in envelope-from
+        return str_contains($this->envelopeFrom, 'trashnothing.com');
+    }
+
+    /**
+     * Get Trash Nothing post ID if present.
+     */
+    public function getTrashNothingPostId(): ?string
+    {
+        return $this->getHeader('x-trash-nothing-post-id');
+    }
+
+    /**
+     * Get Trash Nothing user IP if present.
+     */
+    public function getTrashNothingUserIp(): ?string
+    {
+        return $this->getHeader('x-trash-nothing-user-ip');
+    }
+
+    /**
+     * Get Trash Nothing post coordinates if present.
+     */
+    public function getTrashNothingCoordinates(): ?string
+    {
+        return $this->getHeader('x-trash-nothing-post-coordinates');
+    }
+
+    /**
+     * Get Trash Nothing source (Web, App, etc.) if present.
+     */
+    public function getTrashNothingSource(): ?string
+    {
+        return $this->getHeader('x-trash-nothing-source');
+    }
+
+    /**
+     * Get Trash Nothing secret header for authentication.
+     */
+    public function getTrashNothingSecret(): ?string
+    {
+        return $this->getHeader('x-trash-nothing-secret');
+    }
+
+    // ========================================
+    // Serialization for Validation/Comparison
+    // ========================================
+
+    /**
+     * Convert to array for comparison/logging.
+     *
+     * This is useful for the validation test mode where we compare
+     * Laravel parsing results against PHP parsing results.
+     */
+    public function toArray(): array
+    {
+        return [
+            'envelope_from' => $this->envelopeFrom,
+            'envelope_to' => $this->envelopeTo,
+            'subject' => $this->subject,
+            'from_address' => $this->fromAddress,
+            'from_name' => $this->fromName,
+            'to_addresses' => $this->toAddresses,
+            'message_id' => $this->messageId,
+            'date' => $this->date?->toIso8601String(),
+            'has_text_body' => $this->textBody !== null,
+            'has_html_body' => $this->htmlBody !== null,
+            'target_group_name' => $this->targetGroupName,
+            'is_to_volunteers' => $this->isToVolunteers,
+            'is_to_auto' => $this->isToAuto,
+            'is_bounce' => $this->isBounce(),
+            'is_permanent_bounce' => $this->isPermanentBounce(),
+            'bounce_recipient' => $this->bounceRecipient,
+            'bounce_status' => $this->bounceStatus,
+            'is_chat_reply' => $this->isChatNotificationReply(),
+            'chat_id' => $this->chatId,
+            'chat_user_id' => $this->chatUserId,
+            'chat_message_id' => $this->chatMessageId,
+            'is_auto_reply' => $this->isAutoReply(),
+            'is_subscribe_command' => $this->isSubscribeCommand(),
+            'is_unsubscribe_command' => $this->isUnsubscribeCommand(),
+            'is_digestoff_command' => $this->isDigestOffCommand(),
+            'command_user_id' => $this->commandUserId,
+            'command_group_id' => $this->commandGroupId,
+            'sender_ip' => $this->senderIp,
+            'is_from_trash_nothing' => $this->isFromTrashNothing(),
+        ];
+    }
+
+    /**
+     * Get a fingerprint for quick comparison.
+     *
+     * This hash can be used to quickly check if two ParsedEmail objects
+     * have identical routing-relevant properties.
+     */
+    public function getRoutingFingerprint(): string
+    {
+        $data = [
+            $this->envelopeFrom,
+            $this->envelopeTo,
+            $this->targetGroupName,
+            $this->isBounce(),
+            $this->isChatNotificationReply(),
+            $this->isSubscribeCommand(),
+            $this->isUnsubscribeCommand(),
+            $this->isDigestOffCommand(),
+            $this->isAutoReply(),
+        ];
+
+        return md5(json_encode($data));
+    }
+}

--- a/iznik-batch/app/Services/Mail/Incoming/ParsedEmail.php
+++ b/iznik-batch/app/Services/Mail/Incoming/ParsedEmail.php
@@ -273,7 +273,9 @@ class ParsedEmail
         }
 
         // Check for TN-specific domain in envelope-from
-        return str_contains($this->envelopeFrom, 'trashnothing.com');
+        $tnDomain = config('freegle.mail.trashnothing_domain');
+
+        return str_contains($this->envelopeFrom, $tnDomain);
     }
 
     /**

--- a/iznik-batch/app/Services/Mail/Incoming/RoutingResult.php
+++ b/iznik-batch/app/Services/Mail/Incoming/RoutingResult.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Services\Mail\Incoming;
+
+/**
+ * Routing outcomes for incoming email processing.
+ *
+ * These match the outcomes in iznik-server's MailRouter.php.
+ */
+enum RoutingResult: string
+{
+    // Message approved and posted to group
+    case APPROVED = 'Approved';
+
+    // Message held for moderator approval
+    case PENDING = 'Pending';
+
+    // Message marked as spam for review
+    case INCOMING_SPAM = 'IncomingSpam';
+
+    // Message sent to group volunteers via chat
+    case TO_VOLUNTEERS = 'ToVolunteers';
+
+    // Message routed to user (chat reply)
+    case TO_USER = 'ToUser';
+
+    // System message handled (unsubscribe, digest off, etc.)
+    case TO_SYSTEM = 'ToSystem';
+
+    // Read receipt or calendar response
+    case RECEIPT = 'Receipt';
+
+    // Calendar event (tryst) response
+    case TRYST = 'Tryst';
+
+    // Message dropped/discarded
+    case DROPPED = 'Dropped';
+
+    // Routing failed
+    case FAILURE = 'Failure';
+
+    /**
+     * Check if this result indicates the message was saved.
+     */
+    public function isSaved(): bool
+    {
+        return in_array($this, [
+            self::APPROVED,
+            self::PENDING,
+            self::INCOMING_SPAM,
+        ]);
+    }
+
+    /**
+     * Check if this result indicates the message was discarded.
+     */
+    public function isDiscarded(): bool
+    {
+        return in_array($this, [
+            self::DROPPED,
+            self::FAILURE,
+        ]);
+    }
+
+    /**
+     * Get the Postfix exit code for this result.
+     *
+     * EX_OK (0) = success, message handled
+     * EX_TEMPFAIL (75) = temporary failure, retry later
+     */
+    public function getExitCode(): int
+    {
+        return match ($this) {
+            self::FAILURE => 75,  // EX_TEMPFAIL
+            default => 0,         // EX_OK
+        };
+    }
+}

--- a/iznik-batch/composer.json
+++ b/iznik-batch/composer.json
@@ -11,7 +11,8 @@
         "laravel/tinker": "^2.10.1",
         "sentry/sentry-laravel": "^4.20",
         "simple-as-fuck/laravel-lock": "^0.4.0",
-        "spatie/mjml-php": "^1.2"
+        "spatie/mjml-php": "^1.2",
+        "zbateson/mail-mime-parser": "^3.0"
     },
     "require-dev": {
         "brianium/paratest": "^7.8",

--- a/iznik-batch/composer.lock
+++ b/iznik-batch/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "91b2a9164d7e17252489545686f4022a",
+    "content-hash": "3d1faee91390aa71a089262085ff58b5",
     "packages": [
         {
             "name": "brick/math",
@@ -2665,6 +2665,134 @@
             "time": "2024-09-09T07:06:30+00:00"
         },
         {
+            "name": "php-di/invoker",
+            "version": "2.3.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHP-DI/Invoker.git",
+                "reference": "3c1ddfdef181431fbc4be83378f6d036d59e81e1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHP-DI/Invoker/zipball/3c1ddfdef181431fbc4be83378f6d036d59e81e1",
+                "reference": "3c1ddfdef181431fbc4be83378f6d036d59e81e1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "psr/container": "^1.0|^2.0"
+            },
+            "require-dev": {
+                "athletic/athletic": "~0.1.8",
+                "mnapoli/hard-mode": "~0.3.0",
+                "phpunit/phpunit": "^9.0 || ^10 || ^11 || ^12"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Invoker\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Generic and extensible callable invoker",
+            "homepage": "https://github.com/PHP-DI/Invoker",
+            "keywords": [
+                "callable",
+                "dependency",
+                "dependency-injection",
+                "injection",
+                "invoke",
+                "invoker"
+            ],
+            "support": {
+                "issues": "https://github.com/PHP-DI/Invoker/issues",
+                "source": "https://github.com/PHP-DI/Invoker/tree/2.3.7"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/mnapoli",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-30T10:22:22+00:00"
+        },
+        {
+            "name": "php-di/php-di",
+            "version": "7.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHP-DI/PHP-DI.git",
+                "reference": "f88054cc052e40dbe7b383c8817c19442d480352"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHP-DI/PHP-DI/zipball/f88054cc052e40dbe7b383c8817c19442d480352",
+                "reference": "f88054cc052e40dbe7b383c8817c19442d480352",
+                "shasum": ""
+            },
+            "require": {
+                "laravel/serializable-closure": "^1.0 || ^2.0",
+                "php": ">=8.0",
+                "php-di/invoker": "^2.0",
+                "psr/container": "^1.1 || ^2.0"
+            },
+            "provide": {
+                "psr/container-implementation": "^1.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3",
+                "friendsofphp/proxy-manager-lts": "^1",
+                "mnapoli/phpunit-easymock": "^1.3",
+                "phpunit/phpunit": "^9.6 || ^10 || ^11",
+                "vimeo/psalm": "^5|^6"
+            },
+            "suggest": {
+                "friendsofphp/proxy-manager-lts": "Install it if you want to use lazy injection (version ^1)"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "DI\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "The dependency injection container for humans",
+            "homepage": "https://php-di.org/",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interop",
+                "dependency injection",
+                "di",
+                "ioc",
+                "psr11"
+            ],
+            "support": {
+                "issues": "https://github.com/PHP-DI/PHP-DI/issues",
+                "source": "https://github.com/PHP-DI/PHP-DI/tree/7.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/mnapoli",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/php-di/php-di",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-16T11:10:48+00:00"
+        },
+        {
             "name": "phpoption/phpoption",
             "version": "1.9.4",
             "source": {
@@ -4990,6 +5118,90 @@
             "time": "2024-09-09T11:45:10+00:00"
         },
         {
+            "name": "symfony/polyfill-iconv",
+            "version": "v1.33.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-iconv.git",
+                "reference": "5f3b930437ae03ae5dff61269024d8ea1b3774aa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-iconv/zipball/5f3b930437ae03ae5dff61269024d8ea1b3774aa",
+                "reference": "5f3b930437ae03ae5dff61269024d8ea1b3774aa",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-iconv": "*"
+            },
+            "suggest": {
+                "ext-iconv": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Iconv\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Iconv extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "iconv",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-iconv/tree/v1.33.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-17T14:58:18+00:00"
+        },
+        {
             "name": "symfony/polyfill-intl-grapheme",
             "version": "v1.33.0",
             "source": {
@@ -6702,6 +6914,214 @@
                 }
             ],
             "time": "2024-11-21T01:49:47+00:00"
+        },
+        {
+            "name": "zbateson/mail-mime-parser",
+            "version": "3.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zbateson/mail-mime-parser.git",
+                "reference": "ff054c8e05310c445c2028c6128a4319cc9f6aa8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zbateson/mail-mime-parser/zipball/ff054c8e05310c445c2028c6128a4319cc9f6aa8",
+                "reference": "ff054c8e05310c445c2028c6128a4319cc9f6aa8",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/psr7": "^2.5",
+                "php": ">=8.0",
+                "php-di/php-di": "^6.0|^7.0",
+                "psr/log": "^1|^2|^3",
+                "zbateson/mb-wrapper": "^2.0",
+                "zbateson/stream-decorators": "^2.1"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "*",
+                "monolog/monolog": "^2|^3",
+                "phpstan/phpstan": "*",
+                "phpunit/phpunit": "^9.6"
+            },
+            "suggest": {
+                "ext-iconv": "For best support/performance",
+                "ext-mbstring": "For best support/performance"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "ZBateson\\MailMimeParser\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Zaahid Bateson"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/zbateson/mail-mime-parser/graphs/contributors"
+                }
+            ],
+            "description": "MIME email message parser",
+            "homepage": "https://mail-mime-parser.org",
+            "keywords": [
+                "MimeMailParser",
+                "email",
+                "mail",
+                "mailparse",
+                "mime",
+                "mimeparse",
+                "parser",
+                "php-imap"
+            ],
+            "support": {
+                "docs": "https://mail-mime-parser.org/#usage-guide",
+                "issues": "https://github.com/zbateson/mail-mime-parser/issues",
+                "source": "https://github.com/zbateson/mail-mime-parser"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/zbateson",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-12-02T00:29:16+00:00"
+        },
+        {
+            "name": "zbateson/mb-wrapper",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zbateson/mb-wrapper.git",
+                "reference": "50a14c0c9537f978a61cde9fdc192a0267cc9cff"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zbateson/mb-wrapper/zipball/50a14c0c9537f978a61cde9fdc192a0267cc9cff",
+                "reference": "50a14c0c9537f978a61cde9fdc192a0267cc9cff",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0",
+                "symfony/polyfill-iconv": "^1.9",
+                "symfony/polyfill-mbstring": "^1.9"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "*",
+                "phpstan/phpstan": "*",
+                "phpunit/phpunit": "^9.6|^10.0"
+            },
+            "suggest": {
+                "ext-iconv": "For best support/performance",
+                "ext-mbstring": "For best support/performance"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "ZBateson\\MbWrapper\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Zaahid Bateson"
+                }
+            ],
+            "description": "Wrapper for mbstring with fallback to iconv for encoding conversion and string manipulation",
+            "keywords": [
+                "charset",
+                "encoding",
+                "http",
+                "iconv",
+                "mail",
+                "mb",
+                "mb_convert_encoding",
+                "mbstring",
+                "mime",
+                "multibyte",
+                "string"
+            ],
+            "support": {
+                "issues": "https://github.com/zbateson/mb-wrapper/issues",
+                "source": "https://github.com/zbateson/mb-wrapper/tree/2.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/zbateson",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-12-20T22:05:33+00:00"
+        },
+        {
+            "name": "zbateson/stream-decorators",
+            "version": "2.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zbateson/stream-decorators.git",
+                "reference": "32a2a62fb0f26313395c996ebd658d33c3f9c4e5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zbateson/stream-decorators/zipball/32a2a62fb0f26313395c996ebd658d33c3f9c4e5",
+                "reference": "32a2a62fb0f26313395c996ebd658d33c3f9c4e5",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/psr7": "^2.5",
+                "php": ">=8.0",
+                "zbateson/mb-wrapper": "^2.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "*",
+                "phpstan/phpstan": "*",
+                "phpunit/phpunit": "^9.6|^10.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "ZBateson\\StreamDecorators\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Zaahid Bateson"
+                }
+            ],
+            "description": "PHP psr7 stream decorators for mime message part streams",
+            "keywords": [
+                "base64",
+                "charset",
+                "decorators",
+                "mail",
+                "mime",
+                "psr7",
+                "quoted-printable",
+                "stream",
+                "uuencode"
+            ],
+            "support": {
+                "issues": "https://github.com/zbateson/stream-decorators/issues",
+                "source": "https://github.com/zbateson/stream-decorators/tree/2.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/zbateson",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-04-29T21:42:39+00:00"
         }
     ],
     "packages-dev": [

--- a/iznik-batch/config/freegle.php
+++ b/iznik-batch/config/freegle.php
@@ -30,6 +30,7 @@ return [
     'mail' => [
         'noreply_addr' => env('FREEGLE_NOREPLY_ADDR', 'noreply@ilovefreegle.org'),
         'user_domain' => env('FREEGLE_USER_DOMAIN', 'users.ilovefreegle.org'),
+        'group_domain' => env('FREEGLE_GROUP_DOMAIN', 'groups.ilovefreegle.org'),
         // Internal domains that should be excluded when selecting a user's preferred email.
         // These are Freegle-internal addresses that can't receive external mail.
         // Matches iznik-server's Mail::ourDomain() + GROUP_DOMAIN + yahoogroups.
@@ -53,6 +54,10 @@ return [
         'enabled_types' => env('FREEGLE_MAIL_ENABLED_TYPES', ''),
         // GeekAlerts email for system alerts and failure notifications.
         'geek_alerts_addr' => env('FREEGLE_GEEK_ALERTS_ADDR', 'geek-alerts@ilovefreegle.org'),
+        // Trash Nothing domain for incoming mail detection
+        'trashnothing_domain' => env('FREEGLE_TRASHNOTHING_DOMAIN', 'trashnothing.com'),
+        // Trash Nothing shared secret for mail authentication (skips spam check)
+        'trashnothing_secret' => env('FREEGLE_TRASHNOTHING_SECRET', ''),
     ],
 
     'images' => [

--- a/iznik-batch/config/logging.php
+++ b/iznik-batch/config/logging.php
@@ -127,6 +127,15 @@ return [
             'path' => storage_path('logs/laravel.log'),
         ],
 
+        // Incoming mail processing logs
+        // Structured for Loki ingestion
+        'incoming_mail' => [
+            'driver' => 'single',
+            'path' => storage_path('logs/incoming-mail.log'),
+            'level' => env('LOG_LEVEL', 'debug'),
+            'replace_placeholders' => true,
+        ],
+
     ],
 
 ];

--- a/iznik-batch/docker/supervisor.conf
+++ b/iznik-batch/docker/supervisor.conf
@@ -38,3 +38,14 @@ numprocs=1
 redirect_stderr=true
 stdout_logfile=/var/www/html/storage/logs/spooler.log
 stopwaitsecs=60
+
+[program:mail-receiver]
+process_name=%(program_name)s
+command=php -S 0.0.0.0:8080 -t /var/www/html/public /var/www/html/public/index.php
+autostart=true
+autorestart=true
+user=root
+numprocs=1
+redirect_stderr=true
+stdout_logfile=/var/www/html/storage/logs/mail-receiver.log
+stopwaitsecs=10

--- a/iznik-batch/routes/web.php
+++ b/iznik-batch/routes/web.php
@@ -1,7 +1,13 @@
 <?php
 
+use App\Http\Controllers\IncomingMailController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
     return view('welcome');
 });
+
+// Incoming mail endpoint for Postfix pipe delivery
+// This is called by the postfix container via HTTP
+Route::post('/api/mail/incoming', [IncomingMailController::class, 'receive'])
+    ->withoutMiddleware([\Illuminate\Foundation\Http\Middleware\ValidateCsrfToken::class]);

--- a/iznik-batch/tests/Feature/Mail/IncomingMailCommandTest.php
+++ b/iznik-batch/tests/Feature/Mail/IncomingMailCommandTest.php
@@ -291,15 +291,20 @@ class IncomingMailCommandTest extends TestCase
 
     public function test_outputs_routing_result(): void
     {
+        $user = $this->createTestUser(['email_preferred' => $this->uniqueEmail('member')]);
+        $group = $this->createTestGroup();
+        $this->createMembership($user, $group);
+        $userEmail = $user->emails->first()->email;
+
         $rawEmail = $this->createMinimalEmail([
-            'From' => 'user@example.com',
-            'To' => 'digestoff-12345-67890@users.ilovefreegle.org',
+            'From' => $userEmail,
+            'To' => "digestoff-{$user->id}-{$group->id}@users.ilovefreegle.org",
             'Subject' => 'Turn off digest',
         ]);
 
         $this->artisan('mail:incoming', [
-            'sender' => 'user@example.com',
-            'recipient' => 'digestoff-12345-67890@users.ilovefreegle.org',
+            'sender' => $userEmail,
+            'recipient' => "digestoff-{$user->id}-{$group->id}@users.ilovefreegle.org",
             '--stdin-content' => $rawEmail,
         ])->expectsOutput('ToSystem')
             ->assertSuccessful();
@@ -307,15 +312,20 @@ class IncomingMailCommandTest extends TestCase
 
     public function test_verbose_mode_shows_details(): void
     {
+        $user = $this->createTestUser(['email_preferred' => $this->uniqueEmail('member')]);
+        $group = $this->createTestGroup();
+        $this->createMembership($user, $group);
+        $userEmail = $user->emails->first()->email;
+
         $rawEmail = $this->createMinimalEmail([
-            'From' => 'user@example.com',
-            'To' => 'digestoff-12345-67890@users.ilovefreegle.org',
+            'From' => $userEmail,
+            'To' => "digestoff-{$user->id}-{$group->id}@users.ilovefreegle.org",
             'Subject' => 'Turn off digest',
         ]);
 
         $this->artisan('mail:incoming', [
-            'sender' => 'user@example.com',
-            'recipient' => 'digestoff-12345-67890@users.ilovefreegle.org',
+            'sender' => $userEmail,
+            'recipient' => "digestoff-{$user->id}-{$group->id}@users.ilovefreegle.org",
             '--stdin-content' => $rawEmail,
             '-v' => true,
         ])->expectsOutputToContain('Turn off digest')

--- a/iznik-batch/tests/Feature/Mail/IncomingMailCommandTest.php
+++ b/iznik-batch/tests/Feature/Mail/IncomingMailCommandTest.php
@@ -1,0 +1,365 @@
+<?php
+
+namespace Tests\Feature\Mail;
+
+use App\Services\Mail\Incoming\RoutingResult;
+use Illuminate\Support\Facades\DB;
+use Tests\Support\EmailFixtures;
+use Tests\TestCase;
+
+/**
+ * Tests for the mail:incoming Artisan command.
+ *
+ * This command is the entry point for Postfix to deliver incoming emails.
+ * It reads the raw email from stdin and routes it using IncomingMailService.
+ */
+class IncomingMailCommandTest extends TestCase
+{
+    use EmailFixtures;
+
+    // ========================================
+    // Basic Command Execution Tests
+    // ========================================
+
+    public function test_command_exists(): void
+    {
+        $this->artisan('list')
+            ->expectsOutputToContain('mail:incoming');
+    }
+
+    public function test_command_requires_sender_argument(): void
+    {
+        $this->expectException(\Symfony\Component\Console\Exception\RuntimeException::class);
+        $this->expectExceptionMessage('Not enough arguments');
+        $this->artisan('mail:incoming');
+    }
+
+    public function test_command_requires_recipient_argument(): void
+    {
+        $this->expectException(\Symfony\Component\Console\Exception\RuntimeException::class);
+        $this->expectExceptionMessage('Not enough arguments');
+        $this->artisan('mail:incoming', ['sender' => 'test@test.com']);
+    }
+
+    public function test_command_processes_basic_email(): void
+    {
+        $group = $this->createTestGroup();
+        $user = $this->createTestUser(['email_preferred' => $this->uniqueEmail('sender')]);
+        $this->createMembership($user, $group);
+
+        // Set user location
+        DB::table('users')->where('id', $user->id)->update([
+            'lastlocation' => $this->createLocation(51.5, -0.1),
+        ]);
+
+        $userEmail = $user->emails->first()->email;
+
+        $rawEmail = $this->createMinimalEmail([
+            'From' => $userEmail,
+            'To' => $group->nameshort.'@groups.ilovefreegle.org',
+            'Subject' => 'OFFER: Test Item (London)',
+        ], 'Free item available.');
+
+        // Simulate piping email via stdin
+        $this->artisan('mail:incoming', [
+            'sender' => $userEmail,
+            'recipient' => $group->nameshort.'@groups.ilovefreegle.org',
+            '--stdin-content' => $rawEmail,  // Test option to pass content
+        ])->assertSuccessful();
+    }
+
+    // ========================================
+    // Exit Code Tests
+    // ========================================
+
+    public function test_returns_zero_on_successful_routing(): void
+    {
+        $rawEmail = $this->createMinimalEmail([
+            'From' => 'user@example.com',
+            'To' => 'digestoff-12345-67890@users.ilovefreegle.org',
+            'Subject' => 'Turn off digest',
+        ]);
+
+        $this->artisan('mail:incoming', [
+            'sender' => 'user@example.com',
+            'recipient' => 'digestoff-12345-67890@users.ilovefreegle.org',
+            '--stdin-content' => $rawEmail,
+        ])->assertExitCode(0);
+    }
+
+    public function test_returns_zero_for_dropped_messages(): void
+    {
+        // Auto-reply messages should be dropped but return success
+        $rawEmail = $this->createMinimalEmail([
+            'From' => 'user@example.com',
+            'To' => 'someone@users.ilovefreegle.org',
+            'Subject' => 'Out of Office',
+            'Auto-Submitted' => 'auto-replied',
+        ], 'I am out of office.');
+
+        $this->artisan('mail:incoming', [
+            'sender' => 'user@example.com',
+            'recipient' => 'someone@users.ilovefreegle.org',
+            '--stdin-content' => $rawEmail,
+        ])->assertExitCode(0);
+    }
+
+    public function test_returns_success_on_malformed_content(): void
+    {
+        // Even with completely invalid content, command should return success
+        // to prevent Postfix from retrying endlessly. Invalid messages are dropped.
+        $this->artisan('mail:incoming', [
+            'sender' => '',
+            'recipient' => '',
+            '--stdin-content' => '',
+        ])->assertSuccessful();
+    }
+
+    // ========================================
+    // System Address Routing Tests
+    // ========================================
+
+    public function test_routes_digestoff_command(): void
+    {
+        $rawEmail = $this->createMinimalEmail([
+            'From' => 'user@example.com',
+            'To' => 'digestoff-12345-67890@users.ilovefreegle.org',
+            'Subject' => 'Turn off digest',
+        ]);
+
+        $this->artisan('mail:incoming', [
+            'sender' => 'user@example.com',
+            'recipient' => 'digestoff-12345-67890@users.ilovefreegle.org',
+            '--stdin-content' => $rawEmail,
+        ])->assertSuccessful();
+    }
+
+    public function test_routes_subscribe_command(): void
+    {
+        $group = $this->createTestGroup();
+
+        $rawEmail = $this->createMinimalEmail([
+            'From' => 'newuser@example.com',
+            'To' => $group->nameshort.'-subscribe@groups.ilovefreegle.org',
+            'Subject' => 'Subscribe',
+        ]);
+
+        $this->artisan('mail:incoming', [
+            'sender' => 'newuser@example.com',
+            'recipient' => $group->nameshort.'-subscribe@groups.ilovefreegle.org',
+            '--stdin-content' => $rawEmail,
+        ])->assertSuccessful();
+    }
+
+    public function test_routes_unsubscribe_command(): void
+    {
+        $group = $this->createTestGroup();
+
+        $rawEmail = $this->createMinimalEmail([
+            'From' => 'member@example.com',
+            'To' => $group->nameshort.'-unsubscribe@groups.ilovefreegle.org',
+            'Subject' => 'Unsubscribe',
+        ]);
+
+        $this->artisan('mail:incoming', [
+            'sender' => 'member@example.com',
+            'recipient' => $group->nameshort.'-unsubscribe@groups.ilovefreegle.org',
+            '--stdin-content' => $rawEmail,
+        ])->assertSuccessful();
+    }
+
+    // ========================================
+    // Bounce Handling Tests
+    // ========================================
+
+    public function test_routes_bounce_message(): void
+    {
+        $user = $this->createTestUser(['email_preferred' => $this->uniqueEmail('bounced')]);
+        $userEmail = $user->emails->first();
+
+        $rawEmail = $this->createBounceEmail(
+            $userEmail->email,
+            '5.1.1',
+            'User unknown'
+        );
+
+        $this->artisan('mail:incoming', [
+            'sender' => 'MAILER-DAEMON@ilovefreegle.org',
+            'recipient' => 'bounce-'.$user->id.'-12345@users.ilovefreegle.org',
+            '--stdin-content' => $rawEmail,
+        ])->assertSuccessful();
+
+        // Verify the bounce was recorded
+        $userEmail->refresh();
+        $this->assertNotNull($userEmail->bounced);
+    }
+
+    // ========================================
+    // Chat Reply Tests
+    // ========================================
+
+    public function test_routes_chat_notification_reply(): void
+    {
+        $user1 = $this->createTestUser(['email_preferred' => $this->uniqueEmail('user1')]);
+        $user2 = $this->createTestUser(['email_preferred' => $this->uniqueEmail('user2')]);
+        $chat = $this->createTestChatRoom($user1, $user2);
+
+        $user1Email = $user1->emails->first()->email;
+
+        $rawEmail = $this->createMinimalEmail([
+            'From' => $user1Email,
+            'To' => "notify-{$chat->id}-{$user1->id}@users.ilovefreegle.org",
+            'Subject' => 'Re: Item inquiry',
+        ], 'Yes, still available!');
+
+        $initialCount = DB::table('chat_messages')
+            ->where('chatid', $chat->id)
+            ->count();
+
+        $this->artisan('mail:incoming', [
+            'sender' => $user1Email,
+            'recipient' => "notify-{$chat->id}-{$user1->id}@users.ilovefreegle.org",
+            '--stdin-content' => $rawEmail,
+        ])->assertSuccessful();
+
+        $finalCount = DB::table('chat_messages')
+            ->where('chatid', $chat->id)
+            ->count();
+
+        $this->assertEquals($initialCount + 1, $finalCount);
+    }
+
+    // ========================================
+    // Group Post Tests
+    // ========================================
+
+    public function test_routes_approved_member_post(): void
+    {
+        $group = $this->createTestGroup();
+        $user = $this->createTestUser(['email_preferred' => $this->uniqueEmail('member')]);
+        $this->createMembership($user, $group, ['ourPostingStatus' => 'DEFAULT']);
+
+        // Set user location
+        DB::table('users')->where('id', $user->id)->update([
+            'lastlocation' => $this->createLocation(51.5, -0.1),
+        ]);
+
+        $userEmail = $user->emails->first()->email;
+
+        $rawEmail = $this->createMinimalEmail([
+            'From' => $userEmail,
+            'To' => $group->nameshort.'@groups.ilovefreegle.org',
+            'Subject' => 'OFFER: Test Item (London)',
+        ], 'Free item for collection.');
+
+        $this->artisan('mail:incoming', [
+            'sender' => $userEmail,
+            'recipient' => $group->nameshort.'@groups.ilovefreegle.org',
+            '--stdin-content' => $rawEmail,
+        ])->assertSuccessful();
+    }
+
+    public function test_routes_moderated_member_post(): void
+    {
+        $group = $this->createTestGroup();
+        $user = $this->createTestUser(['email_preferred' => $this->uniqueEmail('moderated')]);
+        $this->createMembership($user, $group, ['ourPostingStatus' => 'MODERATED']);
+
+        // Set user location
+        DB::table('users')->where('id', $user->id)->update([
+            'lastlocation' => $this->createLocation(51.5, -0.1),
+        ]);
+
+        $userEmail = $user->emails->first()->email;
+
+        $rawEmail = $this->createMinimalEmail([
+            'From' => $userEmail,
+            'To' => $group->nameshort.'@groups.ilovefreegle.org',
+            'Subject' => 'OFFER: Test Item (London)',
+        ], 'Free item for collection.');
+
+        $this->artisan('mail:incoming', [
+            'sender' => $userEmail,
+            'recipient' => $group->nameshort.'@groups.ilovefreegle.org',
+            '--stdin-content' => $rawEmail,
+        ])->assertSuccessful();
+    }
+
+    // ========================================
+    // Output and Logging Tests
+    // ========================================
+
+    public function test_outputs_routing_result(): void
+    {
+        $rawEmail = $this->createMinimalEmail([
+            'From' => 'user@example.com',
+            'To' => 'digestoff-12345-67890@users.ilovefreegle.org',
+            'Subject' => 'Turn off digest',
+        ]);
+
+        $this->artisan('mail:incoming', [
+            'sender' => 'user@example.com',
+            'recipient' => 'digestoff-12345-67890@users.ilovefreegle.org',
+            '--stdin-content' => $rawEmail,
+        ])->expectsOutput('ToSystem')
+            ->assertSuccessful();
+    }
+
+    public function test_verbose_mode_shows_details(): void
+    {
+        $rawEmail = $this->createMinimalEmail([
+            'From' => 'user@example.com',
+            'To' => 'digestoff-12345-67890@users.ilovefreegle.org',
+            'Subject' => 'Turn off digest',
+        ]);
+
+        $this->artisan('mail:incoming', [
+            'sender' => 'user@example.com',
+            'recipient' => 'digestoff-12345-67890@users.ilovefreegle.org',
+            '--stdin-content' => $rawEmail,
+            '-v' => true,
+        ])->expectsOutputToContain('Turn off digest')
+            ->assertSuccessful();
+    }
+
+    // ========================================
+    // Error Handling Tests
+    // ========================================
+
+    public function test_handles_empty_stdin_gracefully(): void
+    {
+        // Empty email content should not crash
+        $this->artisan('mail:incoming', [
+            'sender' => 'test@test.com',
+            'recipient' => 'test@test.com',
+            '--stdin-content' => '',
+        ])->assertSuccessful();  // Returns 0 even for invalid content (dropped)
+    }
+
+    public function test_handles_malformed_email_gracefully(): void
+    {
+        // Completely malformed content
+        $this->artisan('mail:incoming', [
+            'sender' => 'test@test.com',
+            'recipient' => 'test@test.com',
+            '--stdin-content' => 'This is not a valid email at all',
+        ])->assertSuccessful();  // Returns 0 even for invalid content (dropped)
+    }
+
+    // ========================================
+    // Helper Methods
+    // ========================================
+
+    /**
+     * Create a location for testing.
+     */
+    protected function createLocation(float $lat, float $lng): int
+    {
+        return DB::table('locations')->insertGetId([
+            'name' => 'Test Location '.uniqid(),
+            'type' => 'Polygon',
+            'lat' => $lat,
+            'lng' => $lng,
+        ]);
+    }
+}

--- a/iznik-batch/tests/Support/EmailFixtures.php
+++ b/iznik-batch/tests/Support/EmailFixtures.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace Tests\Support;
+
+/**
+ * Trait for working with email test fixtures.
+ *
+ * Provides helper methods for loading and manipulating test email files.
+ */
+trait EmailFixtures
+{
+    /**
+     * Get the path to the email fixtures directory.
+     */
+    protected function getEmailFixturesPath(): string
+    {
+        return base_path('tests/fixtures/emails');
+    }
+
+    /**
+     * Get the path to a specific email fixture file.
+     */
+    protected function getEmailFixturePath(string $name): string
+    {
+        $path = "{$this->getEmailFixturesPath()}/{$name}.eml";
+
+        if (! file_exists($path)) {
+            throw new \RuntimeException("Email fixture not found: {$path}");
+        }
+
+        return $path;
+    }
+
+    /**
+     * Load the contents of an email fixture file.
+     */
+    protected function loadEmailFixture(string $name): string
+    {
+        return file_get_contents($this->getEmailFixturePath($name));
+    }
+
+    /**
+     * Create a minimal valid email for testing.
+     *
+     * @param  array<string, string>  $headers  Headers to set (From, To, Subject, etc.)
+     * @param  string  $body  The email body
+     * @return string Raw email string
+     */
+    protected function createMinimalEmail(array $headers = [], string $body = ''): string
+    {
+        $defaults = [
+            'From' => 'test@test.com',
+            'To' => 'recipient@test.com',
+            'Subject' => 'Test Subject',
+            'Date' => 'Tue, 27 Jan 2026 10:00:00 +0000',
+            'Message-ID' => '<test-'.uniqid().'@test.com>',
+            'MIME-Version' => '1.0',
+            'Content-Type' => 'text/plain; charset=utf-8',
+        ];
+
+        $merged = array_merge($defaults, $headers);
+
+        $headerLines = [];
+        foreach ($merged as $name => $value) {
+            $headerLines[] = "{$name}: {$value}";
+        }
+
+        return implode("\r\n", $headerLines)."\r\n\r\n".$body;
+    }
+
+    /**
+     * Create a multipart email for testing.
+     *
+     * @param  array<string, string>  $headers  Headers to set
+     * @param  string  $textBody  Plain text body
+     * @param  string  $htmlBody  HTML body
+     * @return string Raw email string
+     */
+    protected function createMultipartEmail(array $headers = [], string $textBody = '', string $htmlBody = ''): string
+    {
+        $boundary = '----=_Part_'.uniqid();
+
+        $defaults = [
+            'From' => 'test@test.com',
+            'To' => 'recipient@test.com',
+            'Subject' => 'Test Subject',
+            'Date' => 'Tue, 27 Jan 2026 10:00:00 +0000',
+            'Message-ID' => '<test-'.uniqid().'@test.com>',
+            'MIME-Version' => '1.0',
+            'Content-Type' => "multipart/alternative;\r\n boundary=\"{$boundary}\"",
+        ];
+
+        $merged = array_merge($defaults, $headers);
+
+        $headerLines = [];
+        foreach ($merged as $name => $value) {
+            $headerLines[] = "{$name}: {$value}";
+        }
+
+        $parts = [];
+
+        if ($textBody) {
+            $parts[] = "Content-Type: text/plain; charset=utf-8\r\n\r\n{$textBody}";
+        }
+
+        if ($htmlBody) {
+            $parts[] = "Content-Type: text/html; charset=utf-8\r\n\r\n{$htmlBody}";
+        }
+
+        $body = "--{$boundary}\r\n".implode("\r\n--{$boundary}\r\n", $parts)."\r\n--{$boundary}--";
+
+        return implode("\r\n", $headerLines)."\r\n\r\n".$body;
+    }
+
+    /**
+     * Create a bounce message for testing.
+     *
+     * @param  string  $originalRecipient  The email that bounced
+     * @param  string  $status  DSN status code (e.g., '5.0.0', '4.2.2')
+     * @param  string  $diagnostic  Diagnostic message
+     * @return string Raw bounce email
+     */
+    protected function createBounceEmail(
+        string $originalRecipient,
+        string $status = '5.0.0',
+        string $diagnostic = 'mailbox unavailable'
+    ): string {
+        $boundary = '----=_Bounce_'.uniqid();
+
+        $headers = [
+            'From' => 'MAILER-DAEMON@ilovefreegle.org',
+            'To' => 'bounce-12345-67890@users.ilovefreegle.org',
+            'Subject' => 'Undelivered Mail Returned to Sender',
+            'Auto-Submitted' => 'auto-replied',
+            'Content-Type' => "multipart/report; report-type=delivery-status;\r\n\tboundary=\"{$boundary}\"",
+        ];
+
+        $headerLines = [];
+        foreach ($headers as $name => $value) {
+            $headerLines[] = "{$name}: {$value}";
+        }
+
+        $notification = "This is the mail system.\r\n\r\n".
+            "Your message could not be delivered.\r\n\r\n".
+            "<{$originalRecipient}>: {$diagnostic}";
+
+        $deliveryStatus = "Reporting-MTA: dns; bulk2.ilovefreegle.org\r\n\r\n".
+            "Final-Recipient: rfc822; {$originalRecipient}\r\n".
+            "Action: failed\r\n".
+            "Status: {$status}\r\n".
+            "Diagnostic-Code: smtp; {$diagnostic}";
+
+        $body = "--{$boundary}\r\n".
+            "Content-Type: text/plain; charset=us-ascii\r\n\r\n".
+            "{$notification}\r\n\r\n".
+            "--{$boundary}\r\n".
+            "Content-Type: message/delivery-status\r\n\r\n".
+            "{$deliveryStatus}\r\n\r\n".
+            "--{$boundary}--";
+
+        return implode("\r\n", $headerLines)."\r\n\r\n".$body;
+    }
+}

--- a/iznik-batch/tests/Unit/Services/Mail/Incoming/IncomingMailServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/Mail/Incoming/IncomingMailServiceTest.php
@@ -1,0 +1,944 @@
+<?php
+
+namespace Tests\Unit\Services\Mail\Incoming;
+
+use App\Services\Mail\Incoming\IncomingMailService;
+use App\Services\Mail\Incoming\MailParserService;
+use App\Services\Mail\Incoming\RoutingResult;
+use Illuminate\Support\Facades\DB;
+use Tests\Support\EmailFixtures;
+use Tests\TestCase;
+
+/**
+ * Tests for IncomingMailService routing logic.
+ *
+ * These tests verify that incoming emails are routed correctly based on
+ * the envelope-to address, message content, and sender status.
+ */
+class IncomingMailServiceTest extends TestCase
+{
+    use EmailFixtures;
+
+    private IncomingMailService $service;
+
+    private MailParserService $parser;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->parser = app(MailParserService::class);
+        $this->service = app(IncomingMailService::class);
+    }
+
+    // ========================================
+    // System Address Routing Tests
+    // ========================================
+
+    public function test_routes_digestoff_to_system(): void
+    {
+        $email = $this->createMinimalEmail([
+            'From' => 'user@example.com',
+            'To' => 'digestoff-12345-67890@users.ilovefreegle.org',
+            'Subject' => 'Turn off digest',
+        ]);
+
+        $parsed = $this->parser->parse(
+            $email,
+            'user@example.com',
+            'digestoff-12345-67890@users.ilovefreegle.org'
+        );
+
+        $result = $this->service->route($parsed);
+
+        $this->assertEquals(RoutingResult::TO_SYSTEM, $result);
+    }
+
+    public function test_routes_readreceipt_to_receipt(): void
+    {
+        $email = $this->createMinimalEmail([
+            'From' => 'user@example.com',
+            'To' => 'readreceipt-111-222-333@users.ilovefreegle.org',
+            'Subject' => 'Read receipt',
+        ]);
+
+        $parsed = $this->parser->parse(
+            $email,
+            'user@example.com',
+            'readreceipt-111-222-333@users.ilovefreegle.org'
+        );
+
+        $result = $this->service->route($parsed);
+
+        $this->assertEquals(RoutingResult::RECEIPT, $result);
+    }
+
+    public function test_routes_subscribe_to_system(): void
+    {
+        $group = $this->createTestGroup();
+
+        $email = $this->createMinimalEmail([
+            'From' => 'newuser@example.com',
+            'To' => $group->nameshort.'-subscribe@groups.ilovefreegle.org',
+            'Subject' => 'Subscribe',
+        ]);
+
+        $parsed = $this->parser->parse(
+            $email,
+            'newuser@example.com',
+            $group->nameshort.'-subscribe@groups.ilovefreegle.org'
+        );
+
+        $result = $this->service->route($parsed);
+
+        $this->assertEquals(RoutingResult::TO_SYSTEM, $result);
+    }
+
+    public function test_routes_unsubscribe_to_system(): void
+    {
+        $group = $this->createTestGroup();
+
+        $email = $this->createMinimalEmail([
+            'From' => 'member@example.com',
+            'To' => $group->nameshort.'-unsubscribe@groups.ilovefreegle.org',
+            'Subject' => 'Unsubscribe',
+        ]);
+
+        $parsed = $this->parser->parse(
+            $email,
+            'member@example.com',
+            $group->nameshort.'-unsubscribe@groups.ilovefreegle.org'
+        );
+
+        $result = $this->service->route($parsed);
+
+        $this->assertEquals(RoutingResult::TO_SYSTEM, $result);
+    }
+
+    public function test_routes_oneclick_unsubscribe_to_system(): void
+    {
+        $email = $this->createMinimalEmail([
+            'From' => 'user@example.com',
+            'To' => 'unsubscribe-12345-abc123-digest@users.ilovefreegle.org',
+            'Subject' => 'One-click unsubscribe',
+        ]);
+
+        $parsed = $this->parser->parse(
+            $email,
+            'user@example.com',
+            'unsubscribe-12345-abc123-digest@users.ilovefreegle.org'
+        );
+
+        $result = $this->service->route($parsed);
+
+        $this->assertEquals(RoutingResult::TO_SYSTEM, $result);
+    }
+
+    public function test_routes_eventsoff_to_system(): void
+    {
+        $email = $this->createMinimalEmail([
+            'From' => 'user@example.com',
+            'To' => 'eventsoff-12345-67890@users.ilovefreegle.org',
+            'Subject' => 'Turn off events',
+        ]);
+
+        $parsed = $this->parser->parse(
+            $email,
+            'user@example.com',
+            'eventsoff-12345-67890@users.ilovefreegle.org'
+        );
+
+        $result = $this->service->route($parsed);
+
+        $this->assertEquals(RoutingResult::TO_SYSTEM, $result);
+    }
+
+    public function test_routes_newslettersoff_to_system(): void
+    {
+        $email = $this->createMinimalEmail([
+            'From' => 'user@example.com',
+            'To' => 'newslettersoff-12345@users.ilovefreegle.org',
+            'Subject' => 'Turn off newsletters',
+        ]);
+
+        $parsed = $this->parser->parse(
+            $email,
+            'user@example.com',
+            'newslettersoff-12345@users.ilovefreegle.org'
+        );
+
+        $result = $this->service->route($parsed);
+
+        $this->assertEquals(RoutingResult::TO_SYSTEM, $result);
+    }
+
+    public function test_routes_relevantoff_to_system(): void
+    {
+        $email = $this->createMinimalEmail([
+            'From' => 'user@example.com',
+            'To' => 'relevantoff-12345@users.ilovefreegle.org',
+            'Subject' => 'Turn off relevant',
+        ]);
+
+        $parsed = $this->parser->parse(
+            $email,
+            'user@example.com',
+            'relevantoff-12345@users.ilovefreegle.org'
+        );
+
+        $result = $this->service->route($parsed);
+
+        $this->assertEquals(RoutingResult::TO_SYSTEM, $result);
+    }
+
+    public function test_routes_volunteeringoff_to_system(): void
+    {
+        $email = $this->createMinimalEmail([
+            'From' => 'user@example.com',
+            'To' => 'volunteeringoff-12345-67890@users.ilovefreegle.org',
+            'Subject' => 'Turn off volunteering',
+        ]);
+
+        $parsed = $this->parser->parse(
+            $email,
+            'user@example.com',
+            'volunteeringoff-12345-67890@users.ilovefreegle.org'
+        );
+
+        $result = $this->service->route($parsed);
+
+        $this->assertEquals(RoutingResult::TO_SYSTEM, $result);
+    }
+
+    public function test_routes_notificationmailsoff_to_system(): void
+    {
+        $email = $this->createMinimalEmail([
+            'From' => 'user@example.com',
+            'To' => 'notificationmailsoff-12345@users.ilovefreegle.org',
+            'Subject' => 'Turn off notification mails',
+        ]);
+
+        $parsed = $this->parser->parse(
+            $email,
+            'user@example.com',
+            'notificationmailsoff-12345@users.ilovefreegle.org'
+        );
+
+        $result = $this->service->route($parsed);
+
+        $this->assertEquals(RoutingResult::TO_SYSTEM, $result);
+    }
+
+    public function test_routes_fbl_to_system(): void
+    {
+        $email = $this->createMinimalEmail([
+            'From' => 'fbl@hotmail.com',
+            'To' => 'fbl@ilovefreegle.org',
+            'Subject' => 'Feedback Loop Report',
+        ]);
+
+        $parsed = $this->parser->parse(
+            $email,
+            'fbl@hotmail.com',
+            'fbl@ilovefreegle.org'
+        );
+
+        $result = $this->service->route($parsed);
+
+        $this->assertEquals(RoutingResult::TO_SYSTEM, $result);
+    }
+
+    // ========================================
+    // Volunteer/Auto Address Routing Tests
+    // ========================================
+
+    public function test_routes_volunteers_address_to_volunteers(): void
+    {
+        $group = $this->createTestGroup();
+        $user = $this->createTestUser(['email_preferred' => $this->uniqueEmail('member')]);
+        $this->createMembership($user, $group);
+
+        $memberEmail = $user->emails->first()->email;
+
+        $email = $this->createMinimalEmail([
+            'From' => $memberEmail,
+            'To' => $group->nameshort.'-volunteers@groups.ilovefreegle.org',
+            'Subject' => 'Question for volunteers',
+        ], 'Hi, I have a question about posting...');
+
+        $parsed = $this->parser->parse(
+            $email,
+            $memberEmail,
+            $group->nameshort.'-volunteers@groups.ilovefreegle.org'
+        );
+
+        $result = $this->service->route($parsed);
+
+        $this->assertEquals(RoutingResult::TO_VOLUNTEERS, $result);
+    }
+
+    public function test_routes_auto_address_to_volunteers(): void
+    {
+        $group = $this->createTestGroup();
+        $user = $this->createTestUser(['email_preferred' => $this->uniqueEmail('member')]);
+        $this->createMembership($user, $group);
+
+        $memberEmail = $user->emails->first()->email;
+
+        $email = $this->createMinimalEmail([
+            'From' => $memberEmail,
+            'To' => $group->nameshort.'-auto@groups.ilovefreegle.org',
+            'Subject' => 'Auto message',
+        ], 'This is an automated message...');
+
+        $parsed = $this->parser->parse(
+            $email,
+            $memberEmail,
+            $group->nameshort.'-auto@groups.ilovefreegle.org'
+        );
+
+        $result = $this->service->route($parsed);
+
+        $this->assertEquals(RoutingResult::TO_VOLUNTEERS, $result);
+    }
+
+    // ========================================
+    // Bounce Handling Tests
+    // ========================================
+
+    public function test_routes_bounce_to_dropped(): void
+    {
+        $bounceEmail = $this->createBounceEmail(
+            'recipient@example.com',
+            '5.1.1',
+            'User unknown'
+        );
+
+        $parsed = $this->parser->parse(
+            $bounceEmail,
+            'MAILER-DAEMON@ilovefreegle.org',
+            'bounce-12345-67890@users.ilovefreegle.org'
+        );
+
+        $result = $this->service->route($parsed);
+
+        // Bounces are processed (user may be suspended) but message is dropped
+        $this->assertEquals(RoutingResult::DROPPED, $result);
+    }
+
+    public function test_permanent_bounce_suspends_user_email(): void
+    {
+        $user = $this->createTestUser(['email_preferred' => $this->uniqueEmail('bounced')]);
+        $userEmail = $user->emails->first();
+
+        $bounceEmail = $this->createBounceEmail(
+            $userEmail->email,
+            '5.1.1',
+            'User unknown'
+        );
+
+        $parsed = $this->parser->parse(
+            $bounceEmail,
+            'MAILER-DAEMON@ilovefreegle.org',
+            'bounce-'.$user->id.'-12345@users.ilovefreegle.org'
+        );
+
+        $this->service->route($parsed);
+
+        // Refresh and check the user's email is now marked as bounced
+        $userEmail->refresh();
+        $this->assertNotNull($userEmail->bounced, 'Email should be marked as bounced');
+    }
+
+    // ========================================
+    // Chat Reply Routing Tests
+    // ========================================
+
+    public function test_routes_chat_notification_reply_to_user(): void
+    {
+        $user1 = $this->createTestUser(['email_preferred' => $this->uniqueEmail('user1')]);
+        $user2 = $this->createTestUser(['email_preferred' => $this->uniqueEmail('user2')]);
+        $chat = $this->createTestChatRoom($user1, $user2);
+
+        $user1Email = $user1->emails->first()->email;
+
+        $email = $this->createMinimalEmail([
+            'From' => $user1Email,
+            'To' => "notify-{$chat->id}-{$user1->id}@users.ilovefreegle.org",
+            'Subject' => 'Re: About the item',
+        ], 'Yes, it is still available!');
+
+        $parsed = $this->parser->parse(
+            $email,
+            $user1Email,
+            "notify-{$chat->id}-{$user1->id}@users.ilovefreegle.org"
+        );
+
+        $result = $this->service->route($parsed);
+
+        $this->assertEquals(RoutingResult::TO_USER, $result);
+    }
+
+    public function test_routes_chat_reply_with_msgid_to_user(): void
+    {
+        $user1 = $this->createTestUser(['email_preferred' => $this->uniqueEmail('user1')]);
+        $user2 = $this->createTestUser(['email_preferred' => $this->uniqueEmail('user2')]);
+        $chat = $this->createTestChatRoom($user1, $user2);
+        $msg = $this->createTestChatMessage($chat, $user2, ['message' => 'Is this available?']);
+
+        $user1Email = $user1->emails->first()->email;
+
+        $email = $this->createMinimalEmail([
+            'From' => $user1Email,
+            'To' => "notify-{$chat->id}-{$user1->id}-{$msg->id}@users.ilovefreegle.org",
+            'Subject' => 'Re: About the item',
+        ], 'Yes, still available!');
+
+        $parsed = $this->parser->parse(
+            $email,
+            $user1Email,
+            "notify-{$chat->id}-{$user1->id}-{$msg->id}@users.ilovefreegle.org"
+        );
+
+        $result = $this->service->route($parsed);
+
+        $this->assertEquals(RoutingResult::TO_USER, $result);
+    }
+
+    public function test_routes_replyto_address_to_user(): void
+    {
+        $poster = $this->createTestUser(['email_preferred' => $this->uniqueEmail('poster')]);
+        $replier = $this->createTestUser(['email_preferred' => $this->uniqueEmail('replier')]);
+        $group = $this->createTestGroup();
+        $this->createMembership($poster, $group);
+        $message = $this->createTestMessage($poster, $group);
+
+        $replierEmail = $replier->emails->first()->email;
+
+        $email = $this->createMinimalEmail([
+            'From' => $replierEmail,
+            'To' => "replyto-{$message->id}-{$replier->id}@users.ilovefreegle.org",
+            'Subject' => 'Re: '.$message->subject,
+        ], 'Is this still available?');
+
+        $parsed = $this->parser->parse(
+            $email,
+            $replierEmail,
+            "replyto-{$message->id}-{$replier->id}@users.ilovefreegle.org"
+        );
+
+        $result = $this->service->route($parsed);
+
+        $this->assertEquals(RoutingResult::TO_USER, $result);
+    }
+
+    public function test_chat_reply_creates_chat_message(): void
+    {
+        $user1 = $this->createTestUser(['email_preferred' => $this->uniqueEmail('user1')]);
+        $user2 = $this->createTestUser(['email_preferred' => $this->uniqueEmail('user2')]);
+        $chat = $this->createTestChatRoom($user1, $user2);
+
+        $user1Email = $user1->emails->first()->email;
+
+        $email = $this->createMinimalEmail([
+            'From' => $user1Email,
+            'To' => "notify-{$chat->id}-{$user1->id}@users.ilovefreegle.org",
+            'Subject' => 'Re: About the item',
+        ], 'The test reply message content');
+
+        $parsed = $this->parser->parse(
+            $email,
+            $user1Email,
+            "notify-{$chat->id}-{$user1->id}@users.ilovefreegle.org"
+        );
+
+        $initialCount = DB::table('chat_messages')
+            ->where('chatid', $chat->id)
+            ->count();
+
+        $this->service->route($parsed);
+
+        $finalCount = DB::table('chat_messages')
+            ->where('chatid', $chat->id)
+            ->count();
+
+        $this->assertEquals($initialCount + 1, $finalCount);
+
+        // Verify the message content
+        $lastMessage = DB::table('chat_messages')
+            ->where('chatid', $chat->id)
+            ->orderBy('id', 'desc')
+            ->first();
+
+        $this->assertStringContainsString('The test reply message content', $lastMessage->message);
+    }
+
+    // ========================================
+    // Auto-Reply Handling Tests
+    // ========================================
+
+    public function test_drops_auto_reply_messages(): void
+    {
+        $email = $this->createMinimalEmail([
+            'From' => 'user@example.com',
+            'To' => 'someone@users.ilovefreegle.org',
+            'Subject' => 'Out of Office: Re: Your message',
+            'Auto-Submitted' => 'auto-replied',
+        ], 'I am out of the office until...');
+
+        $parsed = $this->parser->parse(
+            $email,
+            'user@example.com',
+            'someone@users.ilovefreegle.org'
+        );
+
+        $result = $this->service->route($parsed);
+
+        $this->assertEquals(RoutingResult::DROPPED, $result);
+    }
+
+    public function test_drops_vacation_auto_reply(): void
+    {
+        $email = $this->createMinimalEmail([
+            'From' => 'user@example.com',
+            'To' => 'someone@users.ilovefreegle.org',
+            'Subject' => 'Automatic reply: Your message',
+            'Auto-Submitted' => 'auto-generated',
+            'X-Auto-Response-Suppress' => 'All',
+        ], 'Thank you for your message...');
+
+        $parsed = $this->parser->parse(
+            $email,
+            'user@example.com',
+            'someone@users.ilovefreegle.org'
+        );
+
+        $result = $this->service->route($parsed);
+
+        $this->assertEquals(RoutingResult::DROPPED, $result);
+    }
+
+    // ========================================
+    // Group Post Routing Tests
+    // ========================================
+
+    public function test_routes_approved_member_post_to_approved(): void
+    {
+        $group = $this->createTestGroup();
+        $user = $this->createTestUser(['email_preferred' => $this->uniqueEmail('member')]);
+        $this->createMembership($user, $group, [
+            'ourPostingStatus' => 'DEFAULT',
+        ]);
+        // Set user location
+        DB::table('users')->where('id', $user->id)->update([
+            'lastlocation' => $this->createLocation(51.5, -0.1),
+        ]);
+
+        $userEmail = $user->emails->first()->email;
+
+        $email = $this->createMinimalEmail([
+            'From' => $userEmail,
+            'To' => $group->nameshort.'@groups.ilovefreegle.org',
+            'Subject' => 'OFFER: Test Item (London)',
+        ], 'Free test item, collection only.');
+
+        $parsed = $this->parser->parse(
+            $email,
+            $userEmail,
+            $group->nameshort.'@groups.ilovefreegle.org'
+        );
+
+        $result = $this->service->route($parsed);
+
+        $this->assertEquals(RoutingResult::APPROVED, $result);
+    }
+
+    public function test_routes_moderated_member_post_to_pending(): void
+    {
+        $group = $this->createTestGroup();
+        $user = $this->createTestUser(['email_preferred' => $this->uniqueEmail('moderated')]);
+        $this->createMembership($user, $group, [
+            'ourPostingStatus' => 'MODERATED',
+        ]);
+        // Set user location
+        DB::table('users')->where('id', $user->id)->update([
+            'lastlocation' => $this->createLocation(51.5, -0.1),
+        ]);
+
+        $userEmail = $user->emails->first()->email;
+
+        $email = $this->createMinimalEmail([
+            'From' => $userEmail,
+            'To' => $group->nameshort.'@groups.ilovefreegle.org',
+            'Subject' => 'OFFER: Test Item (London)',
+        ], 'Free test item, collection only.');
+
+        $parsed = $this->parser->parse(
+            $email,
+            $userEmail,
+            $group->nameshort.'@groups.ilovefreegle.org'
+        );
+
+        $result = $this->service->route($parsed);
+
+        $this->assertEquals(RoutingResult::PENDING, $result);
+    }
+
+    public function test_routes_non_member_post_to_dropped(): void
+    {
+        $group = $this->createTestGroup();
+        $user = $this->createTestUser(['email_preferred' => $this->uniqueEmail('nonmember')]);
+        // Don't add user to group
+
+        $userEmail = $user->emails->first()->email;
+
+        $email = $this->createMinimalEmail([
+            'From' => $userEmail,
+            'To' => $group->nameshort.'@groups.ilovefreegle.org',
+            'Subject' => 'OFFER: Test Item (London)',
+        ], 'Free test item, collection only.');
+
+        $parsed = $this->parser->parse(
+            $email,
+            $userEmail,
+            $group->nameshort.'@groups.ilovefreegle.org'
+        );
+
+        $result = $this->service->route($parsed);
+
+        // Non-members get rejection email and message is dropped
+        $this->assertEquals(RoutingResult::DROPPED, $result);
+    }
+
+    public function test_routes_unmapped_user_post_to_pending(): void
+    {
+        $group = $this->createTestGroup();
+        $user = $this->createTestUser(['email_preferred' => $this->uniqueEmail('unmapped')]);
+        $this->createMembership($user, $group, [
+            'ourPostingStatus' => 'DEFAULT',
+        ]);
+        // Don't set location - user is unmapped
+
+        $userEmail = $user->emails->first()->email;
+
+        $email = $this->createMinimalEmail([
+            'From' => $userEmail,
+            'To' => $group->nameshort.'@groups.ilovefreegle.org',
+            'Subject' => 'OFFER: Test Item (London)',
+        ], 'Free test item, collection only.');
+
+        $parsed = $this->parser->parse(
+            $email,
+            $userEmail,
+            $group->nameshort.'@groups.ilovefreegle.org'
+        );
+
+        $result = $this->service->route($parsed);
+
+        $this->assertEquals(RoutingResult::PENDING, $result);
+    }
+
+    public function test_routes_worry_word_post_to_pending(): void
+    {
+        $group = $this->createTestGroup();
+        $user = $this->createTestUser(['email_preferred' => $this->uniqueEmail('member')]);
+        $this->createMembership($user, $group, [
+            'ourPostingStatus' => 'DEFAULT',
+        ]);
+        // Set user location
+        DB::table('users')->where('id', $user->id)->update([
+            'lastlocation' => $this->createLocation(51.5, -0.1),
+        ]);
+
+        $userEmail = $user->emails->first()->email;
+
+        // Use a worry word in the subject (from WorryWords.php)
+        $email = $this->createMinimalEmail([
+            'From' => $userEmail,
+            'To' => $group->nameshort.'@groups.ilovefreegle.org',
+            'Subject' => 'OFFER: Free kitten (London)',
+        ], 'Adorable kitten needs a good home.');
+
+        $parsed = $this->parser->parse(
+            $email,
+            $userEmail,
+            $group->nameshort.'@groups.ilovefreegle.org'
+        );
+
+        $result = $this->service->route($parsed);
+
+        // Worry words cause posts to be held for review
+        $this->assertEquals(RoutingResult::PENDING, $result);
+    }
+
+    // ========================================
+    // Spam Detection Tests
+    // ========================================
+
+    public function test_routes_spam_to_incoming_spam(): void
+    {
+        $group = $this->createTestGroup();
+        $user = $this->createTestUser(['email_preferred' => $this->uniqueEmail('spammer')]);
+        $this->createMembership($user, $group, [
+            'ourPostingStatus' => 'DEFAULT',
+        ]);
+        // Set user location
+        DB::table('users')->where('id', $user->id)->update([
+            'lastlocation' => $this->createLocation(51.5, -0.1),
+        ]);
+
+        $userEmail = $user->emails->first()->email;
+
+        // Use known spam patterns
+        $email = $this->createMinimalEmail([
+            'From' => $userEmail,
+            'To' => $group->nameshort.'@groups.ilovefreegle.org',
+            'Subject' => 'OFFER: Make money fast! (London)',
+        ], 'Send money to this account for guaranteed returns! Western Union accepted.');
+
+        $parsed = $this->parser->parse(
+            $email,
+            $userEmail,
+            $group->nameshort.'@groups.ilovefreegle.org'
+        );
+
+        $result = $this->service->route($parsed);
+
+        $this->assertEquals(RoutingResult::INCOMING_SPAM, $result);
+    }
+
+    public function test_drops_known_spammer(): void
+    {
+        $user = $this->createTestUser(['email_preferred' => $this->uniqueEmail('badactor')]);
+        // Mark user as spammer
+        DB::table('spam_users')->insert([
+            'userid' => $user->id,
+            'collection' => 'Spammer',
+            'reason' => 'Test spammer',
+            'added' => now(),
+        ]);
+        $group = $this->createTestGroup();
+
+        $userEmail = $user->emails->first()->email;
+
+        $email = $this->createMinimalEmail([
+            'From' => $userEmail,
+            'To' => $group->nameshort.'@groups.ilovefreegle.org',
+            'Subject' => 'OFFER: Normal item (London)',
+        ], 'This looks normal but sender is banned.');
+
+        $parsed = $this->parser->parse(
+            $email,
+            $userEmail,
+            $group->nameshort.'@groups.ilovefreegle.org'
+        );
+
+        $result = $this->service->route($parsed);
+
+        $this->assertEquals(RoutingResult::DROPPED, $result);
+    }
+
+    // ========================================
+    // Trash Nothing Routing Tests
+    // ========================================
+
+    public function test_routes_trash_nothing_post(): void
+    {
+        $group = $this->createTestGroup();
+
+        $email = $this->loadEmailFixture('tn_post');
+        // Modify fixture to target our test group
+        $email = str_replace(
+            'testgroup@groups.ilovefreegle.org',
+            $group->nameshort.'@groups.ilovefreegle.org',
+            $email
+        );
+
+        $parsed = $this->parser->parse(
+            $email,
+            'user@trashnothing.com',
+            $group->nameshort.'@groups.ilovefreegle.org'
+        );
+
+        $result = $this->service->route($parsed);
+
+        // TN posts from authenticated source should route to appropriate collection
+        // This test verifies TN secret header is respected
+        $this->assertNotEquals(RoutingResult::INCOMING_SPAM, $result);
+    }
+
+    public function test_skips_spam_check_for_trash_nothing_with_secret(): void
+    {
+        $group = $this->createTestGroup();
+
+        // Create email with TN secret header but spam-like content
+        $email = $this->createMinimalEmail([
+            'From' => 'user@trashnothing.com',
+            'To' => $group->nameshort.'@groups.ilovefreegle.org',
+            'Subject' => 'OFFER: Make money (Bristol)',
+            'X-Trash-Nothing-Secret' => 'valid-secret-here',
+        ], 'Content that might otherwise trigger spam filters.');
+
+        $parsed = $this->parser->parse(
+            $email,
+            'user@trashnothing.com',
+            $group->nameshort.'@groups.ilovefreegle.org'
+        );
+
+        // If secret is valid, spam check should be skipped
+        $result = $this->service->route($parsed);
+
+        $this->assertNotEquals(RoutingResult::INCOMING_SPAM, $result);
+    }
+
+    // ========================================
+    // Tryst (Calendar) Response Tests
+    // ========================================
+
+    public function test_routes_tryst_response_to_tryst(): void
+    {
+        $email = $this->createMinimalEmail([
+            'From' => 'user@example.com',
+            'To' => 'handover-12345-67890@users.ilovefreegle.org',
+            'Subject' => 'Accepted: Pickup at 2pm',
+            'Content-Type' => 'text/calendar; method=REPLY',
+        ], "BEGIN:VCALENDAR\nMETHOD:REPLY\nEND:VCALENDAR");
+
+        $parsed = $this->parser->parse(
+            $email,
+            'user@example.com',
+            'handover-12345-67890@users.ilovefreegle.org'
+        );
+
+        $result = $this->service->route($parsed);
+
+        $this->assertEquals(RoutingResult::TRYST, $result);
+    }
+
+    // ========================================
+    // Edge Case Tests
+    // ========================================
+
+    public function test_drops_twitter_notifications(): void
+    {
+        $group = $this->createTestGroup();
+
+        $email = $this->createMinimalEmail([
+            'From' => 'info@twitter.com',
+            'To' => $group->nameshort.'@groups.ilovefreegle.org',
+            'Subject' => 'You have a new follower!',
+        ], 'Someone followed you on Twitter.');
+
+        $parsed = $this->parser->parse(
+            $email,
+            'info@twitter.com',
+            $group->nameshort.'@groups.ilovefreegle.org'
+        );
+
+        $result = $this->service->route($parsed);
+
+        $this->assertEquals(RoutingResult::DROPPED, $result);
+    }
+
+    public function test_drops_self_sent_messages(): void
+    {
+        $user = $this->createTestUser(['email_preferred' => $this->uniqueEmail('user')]);
+        $userEmail = $user->emails->first()->email;
+
+        $email = $this->createMinimalEmail([
+            'From' => $userEmail,
+            'To' => $userEmail,
+            'Subject' => 'Note to self',
+        ], 'Testing.');
+
+        $parsed = $this->parser->parse(
+            $email,
+            $userEmail,
+            $userEmail
+        );
+
+        $result = $this->service->route($parsed);
+
+        $this->assertEquals(RoutingResult::DROPPED, $result);
+    }
+
+    public function test_drops_chat_reply_to_stale_chat(): void
+    {
+        $user1 = $this->createTestUser(['email_preferred' => $this->uniqueEmail('user1')]);
+        $user2 = $this->createTestUser(['email_preferred' => $this->uniqueEmail('user2')]);
+        $chat = $this->createTestChatRoom($user1, $user2);
+
+        // Make chat stale (90 days old)
+        DB::table('chat_rooms')
+            ->where('id', $chat->id)
+            ->update(['latestmessage' => now()->subDays(90)]);
+
+        // Try to reply from unfamiliar email
+        $email = $this->createMinimalEmail([
+            'From' => 'unknown@otherdomain.com',
+            'To' => "notify-{$chat->id}-{$user1->id}@users.ilovefreegle.org",
+            'Subject' => 'Re: Old conversation',
+        ], 'Reply to very old chat.');
+
+        $parsed = $this->parser->parse(
+            $email,
+            'unknown@otherdomain.com',
+            "notify-{$chat->id}-{$user1->id}@users.ilovefreegle.org"
+        );
+
+        $result = $this->service->route($parsed);
+
+        $this->assertEquals(RoutingResult::DROPPED, $result);
+    }
+
+    public function test_drops_expired_message_reply(): void
+    {
+        $poster = $this->createTestUser(['email_preferred' => $this->uniqueEmail('poster')]);
+        $replier = $this->createTestUser(['email_preferred' => $this->uniqueEmail('replier')]);
+        $group = $this->createTestGroup();
+        $this->createMembership($poster, $group);
+        $message = $this->createTestMessage($poster, $group);
+
+        // Make message expired (45 days old)
+        DB::table('messages')
+            ->where('id', $message->id)
+            ->update([
+                'arrival' => now()->subDays(45),
+                'date' => now()->subDays(45),
+            ]);
+
+        $replierEmail = $replier->emails->first()->email;
+
+        $email = $this->createMinimalEmail([
+            'From' => $replierEmail,
+            'To' => "replyto-{$message->id}-{$replier->id}@users.ilovefreegle.org",
+            'Subject' => 'Re: '.$message->subject,
+        ], 'Is this still available?');
+
+        $parsed = $this->parser->parse(
+            $email,
+            $replierEmail,
+            "replyto-{$message->id}-{$replier->id}@users.ilovefreegle.org"
+        );
+
+        $result = $this->service->route($parsed);
+
+        $this->assertEquals(RoutingResult::DROPPED, $result);
+    }
+
+    // ========================================
+    // Helper Methods
+    // ========================================
+
+    /**
+     * Create a location for testing.
+     */
+    protected function createLocation(float $lat, float $lng): int
+    {
+        return DB::table('locations')->insertGetId([
+            'name' => 'Test Location '.uniqid(),
+            'type' => 'Polygon',
+            'lat' => $lat,
+            'lng' => $lng,
+        ]);
+    }
+}

--- a/iznik-batch/tests/Unit/Services/Mail/Incoming/IncomingMailServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/Mail/Incoming/IncomingMailServiceTest.php
@@ -884,7 +884,6 @@ class IncomingMailServiceTest extends TestCase
         DB::table('worrywords')->insert([
             'keyword' => 'kitten',
             'type' => 'Review',
-            'added' => now(),
         ]);
 
         $userEmail = $user->emails->first()->email;
@@ -1037,11 +1036,14 @@ class IncomingMailServiceTest extends TestCase
         $user = $this->createTestUser(['email_preferred' => $this->uniqueEmail('trystuser')]);
         $userEmail = $user->emails->first()->email;
 
+        // Create a second user for the tryst
+        $user2 = $this->createTestUser(['email_preferred' => $this->uniqueEmail('trystuser2')]);
+
         // Create a tryst record
         $trystId = DB::table('trysts')->insertGetId([
-            'chatid' => 1,  // Doesn't need to be real for this test
-            'date' => now()->addDay(),
-            'added' => now(),
+            'user1' => $user->id,
+            'user2' => $user2->id,
+            'arrangedfor' => now()->addDay(),
         ]);
 
         $email = $this->createMinimalEmail([

--- a/iznik-batch/tests/Unit/Services/Mail/Incoming/MailParserServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/Mail/Incoming/MailParserServiceTest.php
@@ -168,6 +168,16 @@ class MailParserServiceTest extends TestCase
         $this->assertTrue($parsed->isPermanentBounce());
     }
 
+    public function test_dynamic_bounce_extracts_recipient(): void
+    {
+        $expectedEmail = 'bounced-user-'.uniqid().'@example.com';
+        $rawEmail = $this->createBounceEmail($expectedEmail, '5.1.1', 'User unknown');
+
+        $parsed = $this->parser->parse($rawEmail, 'MAILER-DAEMON@test.com', 'bounce-12345@users.ilovefreegle.org');
+
+        $this->assertEquals($expectedEmail, $parsed->bounceRecipient);
+    }
+
     public function test_temporary_bounce_starts_with_4(): void
     {
         $rawEmail = $this->createBounceEmail('test@example.com', '4.2.2', 'Mailbox full');

--- a/iznik-batch/tests/Unit/Services/Mail/Incoming/MailParserServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/Mail/Incoming/MailParserServiceTest.php
@@ -1,0 +1,401 @@
+<?php
+
+namespace Tests\Unit\Services\Mail\Incoming;
+
+use App\Services\Mail\Incoming\MailParserService;
+use App\Services\Mail\Incoming\ParsedEmail;
+use Tests\Support\EmailFixtures;
+use Tests\TestCase;
+
+class MailParserServiceTest extends TestCase
+{
+    use EmailFixtures;
+
+    private MailParserService $parser;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->parser = new MailParserService;
+    }
+
+    // ========================================
+    // Basic Parsing Tests
+    // ========================================
+
+    public function test_parse_extracts_subject(): void
+    {
+        $parsed = $this->parseFixture('basic');
+
+        $this->assertInstanceOf(ParsedEmail::class, $parsed);
+        $this->assertEquals('OFFER: Test item (Test Location)', $parsed->subject);
+    }
+
+    public function test_parse_extracts_from_address(): void
+    {
+        $parsed = $this->parseFixture('basic');
+
+        $this->assertEquals('test@test.com', $parsed->fromAddress);
+        $this->assertEquals('Test User', $parsed->fromName);
+    }
+
+    public function test_parse_extracts_to_addresses(): void
+    {
+        $parsed = $this->parseFixture('basic');
+
+        $this->assertContains('testgroup@groups.ilovefreegle.org', $parsed->toAddresses);
+    }
+
+    public function test_parse_extracts_message_id(): void
+    {
+        $parsed = $this->parseFixture('basic');
+
+        $this->assertEquals('test-message-id-12345@test.com', $parsed->messageId);
+    }
+
+    public function test_parse_extracts_date(): void
+    {
+        $parsed = $this->parseFixture('basic');
+
+        $this->assertNotNull($parsed->date);
+        $this->assertEquals('2026-01-27', $parsed->date->format('Y-m-d'));
+    }
+
+    public function test_parse_extracts_text_body(): void
+    {
+        $parsed = $this->parseFixture('basic');
+
+        $this->assertStringContainsString('test offer message', $parsed->textBody);
+        $this->assertStringContainsString('test item available', $parsed->textBody);
+    }
+
+    public function test_parse_extracts_html_body(): void
+    {
+        $parsed = $this->parseFixture('basic');
+
+        $this->assertStringContainsString('<p>This is a test offer message.</p>', $parsed->htmlBody);
+    }
+
+    public function test_parse_stores_envelope_addresses(): void
+    {
+        $rawEmail = $this->loadEmailFixture('basic');
+
+        $parsed = $this->parser->parse($rawEmail, 'envelope-from@test.com', 'envelope-to@groups.ilovefreegle.org');
+
+        $this->assertEquals('envelope-from@test.com', $parsed->envelopeFrom);
+        $this->assertEquals('envelope-to@groups.ilovefreegle.org', $parsed->envelopeTo);
+    }
+
+    public function test_parse_stores_raw_message(): void
+    {
+        $rawEmail = $this->loadEmailFixture('basic');
+        $parsed = $this->parser->parse($rawEmail, 'test@test.com', 'testgroup@groups.ilovefreegle.org');
+
+        $this->assertEquals($rawEmail, $parsed->rawMessage);
+    }
+
+    // ========================================
+    // Header Extraction Tests
+    // ========================================
+
+    public function test_parse_extracts_arbitrary_headers(): void
+    {
+        $rawEmail = $this->createMinimalEmail([
+            'X-Custom-Header' => 'custom-value',
+            'X-Another-Header' => 'another-value',
+        ], 'Test body');
+
+        $parsed = $this->parser->parse($rawEmail, 'test@test.com', 'recipient@test.com');
+
+        $this->assertEquals('custom-value', $parsed->getHeader('x-custom-header'));
+        $this->assertEquals('another-value', $parsed->getHeader('x-another-header'));
+    }
+
+    public function test_get_header_returns_null_for_missing_header(): void
+    {
+        $parsed = $this->parseFixture('basic');
+
+        $this->assertNull($parsed->getHeader('x-nonexistent-header'));
+    }
+
+    // ========================================
+    // Bounce Detection Tests
+    // ========================================
+
+    public function test_parse_detects_bounce_message(): void
+    {
+        $rawEmail = $this->loadEmailFixture('bounce');
+
+        $parsed = $this->parser->parse($rawEmail, 'MAILER-DAEMON@ilovefreegle.org', 'bounce-3743448-1479334364@users.ilovefreegle.org');
+
+        $this->assertTrue($parsed->isBounce());
+    }
+
+    public function test_parse_extracts_bounce_recipient(): void
+    {
+        $rawEmail = $this->loadEmailFixture('bounce');
+
+        $parsed = $this->parser->parse($rawEmail, 'MAILER-DAEMON@ilovefreegle.org', 'bounce-3743448-1479334364@users.ilovefreegle.org');
+
+        $this->assertEquals('bounced@example.com', $parsed->bounceRecipient);
+    }
+
+    public function test_parse_extracts_bounce_status(): void
+    {
+        $rawEmail = $this->loadEmailFixture('bounce');
+
+        $parsed = $this->parser->parse($rawEmail, 'MAILER-DAEMON@ilovefreegle.org', 'bounce-3743448-1479334364@users.ilovefreegle.org');
+
+        $this->assertEquals('5.0.0', $parsed->bounceStatus);
+        $this->assertTrue($parsed->isPermanentBounce());
+    }
+
+    public function test_parse_extracts_bounce_diagnostic(): void
+    {
+        $rawEmail = $this->loadEmailFixture('bounce');
+
+        $parsed = $this->parser->parse($rawEmail, 'MAILER-DAEMON@ilovefreegle.org', 'bounce-3743448-1479334364@users.ilovefreegle.org');
+
+        $this->assertStringContainsString('mailbox unavailable', $parsed->bounceDiagnostic);
+    }
+
+    public function test_permanent_bounce_starts_with_5(): void
+    {
+        $rawEmail = $this->createBounceEmail('test@example.com', '5.1.1', 'User unknown');
+
+        $parsed = $this->parser->parse($rawEmail, 'MAILER-DAEMON@test.com', 'bounce@users.ilovefreegle.org');
+
+        $this->assertTrue($parsed->isPermanentBounce());
+    }
+
+    public function test_temporary_bounce_starts_with_4(): void
+    {
+        $rawEmail = $this->createBounceEmail('test@example.com', '4.2.2', 'Mailbox full');
+
+        $parsed = $this->parser->parse($rawEmail, 'MAILER-DAEMON@test.com', 'bounce@users.ilovefreegle.org');
+
+        $this->assertTrue($parsed->isBounce());
+        $this->assertFalse($parsed->isPermanentBounce());
+    }
+
+    // ========================================
+    // Chat Reply Detection Tests
+    // ========================================
+
+    public function test_parse_detects_chat_notification_reply(): void
+    {
+        $rawEmail = $this->loadEmailFixture('chat_reply');
+
+        $parsed = $this->parser->parse($rawEmail, 'replier@example.com', 'notify-12345-67890-111@users.ilovefreegle.org');
+
+        $this->assertTrue($parsed->isChatNotificationReply());
+    }
+
+    public function test_parse_extracts_chat_ids_from_notify_address(): void
+    {
+        $rawEmail = $this->loadEmailFixture('chat_reply');
+
+        $parsed = $this->parser->parse($rawEmail, 'replier@example.com', 'notify-12345-67890-111@users.ilovefreegle.org');
+
+        $this->assertEquals(12345, $parsed->chatId);
+        $this->assertEquals(67890, $parsed->chatUserId);
+        $this->assertEquals(111, $parsed->chatMessageId);
+    }
+
+    public function test_chat_notification_reply_without_message_id(): void
+    {
+        $rawEmail = $this->createMinimalEmail([], 'Reply content');
+
+        $parsed = $this->parser->parse($rawEmail, 'replier@example.com', 'notify-12345-67890@users.ilovefreegle.org');
+
+        $this->assertTrue($parsed->isChatNotificationReply());
+        $this->assertEquals(12345, $parsed->chatId);
+        $this->assertEquals(67890, $parsed->chatUserId);
+        $this->assertNull($parsed->chatMessageId);
+    }
+
+    // ========================================
+    // Auto-Reply Detection Tests
+    // ========================================
+
+    public function test_parse_detects_auto_submitted_header(): void
+    {
+        $rawEmail = $this->createMinimalEmail([
+            'Auto-Submitted' => 'auto-replied',
+        ], 'Auto-reply content');
+
+        $parsed = $this->parser->parse($rawEmail, 'autoresponder@test.com', 'recipient@test.com');
+
+        $this->assertTrue($parsed->isAutoReply());
+    }
+
+    public function test_parse_detects_auto_generated_header(): void
+    {
+        $rawEmail = $this->createMinimalEmail([
+            'Auto-Submitted' => 'auto-generated',
+        ], 'Auto-generated content');
+
+        $parsed = $this->parser->parse($rawEmail, 'system@test.com', 'recipient@test.com');
+
+        $this->assertTrue($parsed->isAutoReply());
+    }
+
+    public function test_normal_message_is_not_auto_reply(): void
+    {
+        $parsed = $this->parseFixture('basic');
+
+        $this->assertFalse($parsed->isAutoReply());
+    }
+
+    // ========================================
+    // Group Detection Tests
+    // ========================================
+
+    public function test_parse_extracts_group_name_from_envelope_to(): void
+    {
+        $rawEmail = $this->loadEmailFixture('basic');
+
+        $parsed = $this->parser->parse($rawEmail, 'test@test.com', 'mygroup@groups.ilovefreegle.org');
+
+        $this->assertEquals('mygroup', $parsed->targetGroupName);
+    }
+
+    public function test_parse_detects_volunteers_address(): void
+    {
+        $rawEmail = $this->createMinimalEmail([
+            'To' => 'testgroup-volunteers@groups.ilovefreegle.org',
+        ], 'Message to volunteers');
+
+        $parsed = $this->parser->parse($rawEmail, 'test@test.com', 'testgroup-volunteers@groups.ilovefreegle.org');
+
+        $this->assertTrue($parsed->isToVolunteers());
+        $this->assertEquals('testgroup', $parsed->targetGroupName);
+    }
+
+    public function test_parse_detects_auto_address(): void
+    {
+        $rawEmail = $this->createMinimalEmail([
+            'To' => 'testgroup-auto@groups.ilovefreegle.org',
+        ], 'Automated message');
+
+        $parsed = $this->parser->parse($rawEmail, 'test@test.com', 'testgroup-auto@groups.ilovefreegle.org');
+
+        $this->assertTrue($parsed->isToAuto());
+        $this->assertEquals('testgroup', $parsed->targetGroupName);
+    }
+
+    // ========================================
+    // Email Command Detection Tests
+    // ========================================
+
+    public function test_parse_detects_subscribe_command(): void
+    {
+        $rawEmail = $this->createMinimalEmail([], 'Subscribe me');
+
+        $parsed = $this->parser->parse($rawEmail, 'user@example.com', 'testgroup-subscribe@groups.ilovefreegle.org');
+
+        $this->assertTrue($parsed->isSubscribeCommand());
+        $this->assertEquals('testgroup', $parsed->targetGroupName);
+    }
+
+    public function test_parse_detects_unsubscribe_command(): void
+    {
+        $rawEmail = $this->createMinimalEmail([], 'Unsubscribe me');
+
+        $parsed = $this->parser->parse($rawEmail, 'user@example.com', 'testgroup-unsubscribe@groups.ilovefreegle.org');
+
+        $this->assertTrue($parsed->isUnsubscribeCommand());
+        $this->assertEquals('testgroup', $parsed->targetGroupName);
+    }
+
+    public function test_parse_detects_digestoff_command(): void
+    {
+        $rawEmail = $this->createMinimalEmail([], '');
+
+        $parsed = $this->parser->parse($rawEmail, 'user@example.com', 'digestoff-12345-67890@users.ilovefreegle.org');
+
+        $this->assertTrue($parsed->isDigestOffCommand());
+        $this->assertEquals(12345, $parsed->commandUserId);
+        $this->assertEquals(67890, $parsed->commandGroupId);
+    }
+
+    // ========================================
+    // Error Handling Tests
+    // ========================================
+
+    public function test_parse_handles_malformed_email_gracefully(): void
+    {
+        $rawEmail = 'This is not a valid email';
+
+        $parsed = $this->parser->parse($rawEmail, 'test@test.com', 'test@test.com');
+
+        $this->assertInstanceOf(ParsedEmail::class, $parsed);
+        $this->assertEquals('test@test.com', $parsed->envelopeFrom);
+        $this->assertEquals('test@test.com', $parsed->envelopeTo);
+    }
+
+    public function test_parse_handles_empty_body(): void
+    {
+        $rawEmail = $this->createMinimalEmail(['Subject' => 'Empty Body'], '');
+
+        $parsed = $this->parser->parse($rawEmail, 'test@test.com', 'recipient@test.com');
+
+        $this->assertInstanceOf(ParsedEmail::class, $parsed);
+        $this->assertEquals('Empty Body', $parsed->subject);
+        $this->assertEmpty($parsed->textBody);
+    }
+
+    // ========================================
+    // IP Address Extraction Tests
+    // ========================================
+
+    public function test_parse_extracts_ip_from_x_originating_ip(): void
+    {
+        $rawEmail = $this->createMinimalEmail([
+            'X-Originating-IP' => '[192.0.2.50]',
+        ], 'Test');
+
+        $parsed = $this->parser->parse($rawEmail, 'test@test.com', 'recipient@test.com');
+
+        $this->assertEquals('192.0.2.50', $parsed->senderIp);
+    }
+
+    public function test_parse_extracts_ip_from_x_freegle_ip(): void
+    {
+        $rawEmail = $this->createMinimalEmail([
+            'X-Freegle-IP' => '192.0.2.51',
+        ], 'Test');
+
+        $parsed = $this->parser->parse($rawEmail, 'test@test.com', 'recipient@test.com');
+
+        $this->assertEquals('192.0.2.51', $parsed->senderIp);
+    }
+
+    // ========================================
+    // Helper Methods
+    // ========================================
+
+    /**
+     * Parse a fixture file using default envelope addresses.
+     */
+    private function parseFixture(string $name): ParsedEmail
+    {
+        $rawEmail = $this->loadEmailFixture($name);
+
+        // Use envelope addresses appropriate for the fixture type
+        $envelopeFrom = match ($name) {
+            'bounce' => 'MAILER-DAEMON@ilovefreegle.org',
+            'tn_post' => 'user@trashnothing.com',
+            'chat_reply' => 'replier@example.com',
+            default => 'test@test.com',
+        };
+
+        $envelopeTo = match ($name) {
+            'bounce' => 'bounce-3743448-1479334364@users.ilovefreegle.org',
+            'chat_reply' => 'notify-12345-67890-111@users.ilovefreegle.org',
+            default => 'testgroup@groups.ilovefreegle.org',
+        };
+
+        return $this->parser->parse($rawEmail, $envelopeFrom, $envelopeTo);
+    }
+}

--- a/iznik-batch/tests/fixtures/emails/basic.eml
+++ b/iznik-batch/tests/fixtures/emails/basic.eml
@@ -1,0 +1,29 @@
+Return-Path: <test@test.com>
+From: "Test User" <test@test.com>
+To: testgroup@groups.ilovefreegle.org
+Subject: OFFER: Test item (Test Location)
+Date: Tue, 27 Jan 2026 10:00:00 +0000
+Message-ID: <test-message-id-12345@test.com>
+MIME-Version: 1.0
+Content-Type: multipart/alternative;
+ boundary="----=_Part_12345"
+
+------=_Part_12345
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
+
+This is a test offer message.
+
+I have a test item available for collection.
+
+------=_Part_12345
+Content-Type: text/html; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
+
+<html>
+<body>
+<p>This is a test offer message.</p>
+<p>I have a test item available for collection.</p>
+</body>
+</html>
+------=_Part_12345--

--- a/iznik-batch/tests/fixtures/emails/bounce.eml
+++ b/iznik-batch/tests/fixtures/emails/bounce.eml
@@ -1,0 +1,56 @@
+Received: by bulk2.ilovefreegle.org (Postfix)
+	id 0FCBC402670D; Sun, 20 Nov 2016 13:49:46 +0000 (UTC)
+Date: Sun, 20 Nov 2016 13:49:46 +0000 (UTC)
+From: MAILER-DAEMON@ilovefreegle.org (Mail Delivery System)
+Subject: Undelivered Mail Returned to Sender
+To: bounce-3743448-1479334364@users.ilovefreegle.org
+Auto-Submitted: auto-replied
+MIME-Version: 1.0
+Content-Type: multipart/report; report-type=delivery-status;
+	boundary="6D9B644D9B75.1479649786/bulk2.ilovefreegle.org"
+Message-Id: <20161120134946.0FCBC402670D@bulk2.ilovefreegle.org>
+
+This is a MIME-encapsulated message.
+
+--6D9B644D9B75.1479649786/bulk2.ilovefreegle.org
+Content-Description: Notification
+Content-Type: text/plain; charset=us-ascii
+
+This is the mail system at host bulk2.ilovefreegle.org.
+
+I'm sorry to have to inform you that your message could not
+be delivered to one or more recipients.
+
+                   The mail system
+
+<bounced@example.com>: host mx.example.com[192.0.2.1] said: 550
+    Requested action not taken: mailbox unavailable (in reply to RCPT TO
+    command)
+
+--6D9B644D9B75.1479649786/bulk2.ilovefreegle.org
+Content-Description: Delivery report
+Content-Type: message/delivery-status
+
+Reporting-MTA: dns; bulk2.ilovefreegle.org
+X-Postfix-Queue-ID: 6D9B644D9B75
+X-Postfix-Sender: rfc822; bounce-3743448-1479334364@users.ilovefreegle.org
+Arrival-Date: Wed, 16 Nov 2016 22:13:36 +0000 (UTC)
+
+Final-Recipient: rfc822; bounced@example.com
+Original-Recipient: rfc822;bounced@example.com
+Action: failed
+Status: 5.0.0
+Remote-MTA: dns; mx.example.com
+Diagnostic-Code: smtp; 550 Requested action not taken: mailbox unavailable
+
+--6D9B644D9B75.1479649786/bulk2.ilovefreegle.org
+Content-Description: Undelivered Message
+Content-Type: message/rfc822
+
+From: test@test.com
+To: bounced@example.com
+Subject: Test message that bounced
+
+Original message content here.
+
+--6D9B644D9B75.1479649786/bulk2.ilovefreegle.org--

--- a/iznik-batch/tests/fixtures/emails/chat_reply.eml
+++ b/iznik-batch/tests/fixtures/emails/chat_reply.eml
@@ -1,0 +1,13 @@
+Return-Path: <replier@example.com>
+From: "Jane Doe" <replier@example.com>
+To: notify-12345-67890-111@users.ilovefreegle.org
+Subject: Re: About the chair
+Date: Tue, 27 Jan 2026 14:30:00 +0000
+Message-ID: <chat-reply-67890@example.com>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+
+Hi, is the chair still available? I can collect today.
+
+Thanks,
+Jane

--- a/iznik-batch/tests/fixtures/emails/tn_post.eml
+++ b/iznik-batch/tests/fixtures/emails/tn_post.eml
@@ -1,0 +1,15 @@
+Return-Path: <user@trashnothing.com>
+From: "TN User" <user@user.trashnothing.com>
+To: testgroup@groups.ilovefreegle.org
+Subject: OFFER: Sofa (Bristol BS1)
+Date: Tue, 27 Jan 2026 09:00:00 +0000
+Message-ID: <tn-post-abc123@trashnothing.com>
+X-Trash-Nothing-Secret: test-secret-12345
+X-Trash-Nothing-Post-Id: 98765
+X-Trash-Nothing-Source: Web
+X-Trash-Nothing-User-IP: 192.0.2.100
+X-Trash-Nothing-Post-Coordinates: 51.4545,-2.5879
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+
+Free sofa, good condition. Collection only from Bristol city centre.

--- a/plans/active/incoming-email-to-docker.md
+++ b/plans/active/incoming-email-to-docker.md
@@ -966,6 +966,7 @@ Update MX records to point directly to Postfix. Disable Exim forwarding.
 - [ ] Implement `mail:incoming` command
 - [ ] Implement `MailParserService`
 - [ ] Set up Loki logging channel
+- [ ] Update architecture documentation (see Documentation Updates below)
 
 ### Phase B: Bounce Processing (Week 3-4)
 - [ ] Port `Bounce.php` to Laravel `BounceService`
@@ -1055,6 +1056,31 @@ GROUP_DOMAIN=groups.ilovefreegle.org
 # Mail archiving
 MAILPIT_ARCHIVE_ENABLED=true
 ```
+
+---
+
+## Part 13: Documentation Updates
+
+The following documentation must be updated as part of this migration:
+
+### Architecture Documentation
+- [ ] **`ARCHITECTURE.md`** - Add `postfix-incoming` container to mermaid diagram
+  - Add to "Infrastructure" subgraph
+  - Show data flow: `postfix-incoming → batch → percona`
+  - Add to Container Groups table
+- [ ] **`README.md`** - Add postfix-incoming to services list, update mailpit description
+
+### Configuration Documentation
+- [ ] **`docker-compose.yml`** - Inline comments explaining postfix-incoming configuration
+- [ ] **`.env.example`** - Add new environment variables (MAIL_INCOMING_*, domains)
+
+### Migration Documentation
+- [ ] **`iznik-batch/EMAIL-MIGRATION-GUIDE.md`** - Document incoming mail migration lessons
+- [ ] **`iznik-server/MIGRATIONS.md`** - Note code retirement timeline
+
+### Operational Documentation
+- [ ] **`CLAUDE.md`** - Update session log format, add incoming mail debugging tips
+- [ ] **Yesterday/README.md** - Note incoming mail handling differences
 
 ---
 

--- a/plans/active/incoming-email-to-docker.md
+++ b/plans/active/incoming-email-to-docker.md
@@ -1,0 +1,1092 @@
+# Incoming Email Migration to Docker (Consolidated Plan)
+
+**Status**: Planning
+**Branch**: `feature/incoming-email-migration`
+**Supersedes**: `plans/active/incoming-email-migration-to-laravel.md` (to be archived after implementation)
+
+## Executive Summary
+
+This plan consolidates the incoming email migration strategy, covering:
+1. **Mail reception** - Postfix container in Docker receiving via MX records
+2. **Processing** - Laravel commands in iznik-batch handling routing, spam, bounces
+3. **Monitoring** - ModTools UI for email statistics and queue status
+4. **Archiving** - MailPit-style mail viewer for production debugging
+5. **Switchover** - Phased migration from Exim/iznik-server to Postfix/iznik-batch
+6. **Retirement** - Removing code from iznik-server after stable operation
+
+---
+
+## Part 1: Architecture Decision - Postfix as Buffer
+
+### Current State (Bulk4)
+- **MX records** point to bulk4.ilovefreegle.org
+- **Exim 4** receives mail on port 25
+- **Pipe transport** calls `incoming.php` for each message
+- **Processing** via MailRouter in iznik-server
+
+### Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **A: Direct HTTP endpoint** | Simpler, no MTA | No buffering during outages, need custom SMTP server |
+| **B: Postfix container in Docker** | Battle-tested MTA, queuing, standard protocols | Another service to maintain |
+| **C: External relay (SES, Mailgun)** | Managed, reliable | User requirement to avoid third-party |
+
+### Decision: Option B - Postfix Container
+
+**Rationale:**
+1. **Buffering** - If iznik-batch is restarting or overloaded, Postfix queues mail safely
+2. **Proven** - Postfix is battle-tested for decades
+3. **Standard** - Uses standard SMTP, easy to monitor, well-documented
+4. **Already planned** - The existing plan already proposes this approach
+5. **Mail archiving** - Postfix `always_bcc` easily archives all mail to MailPit
+
+### Single vs Dual Postfix Architecture
+
+**Question**: Should we use a single postfix instance for both incoming and outgoing mail, or separate instances?
+
+#### Traffic Characteristics
+
+| Direction | Volume | Importance | Latency Tolerance |
+|-----------|--------|------------|-------------------|
+| **Outgoing** | High (notifications, digests, 10k+/day) | Medium | Minutes acceptable |
+| **Incoming** | Low (replies, posts, ~1k/day) | **High** (user messages) | Seconds preferred |
+
+#### Analysis: Separate Instances (Recommended)
+
+**Advantages:**
+1. **Incoming prioritization** - Dedicated queue ensures user messages aren't delayed by outgoing batch
+2. **Independent scaling** - Can tune resources separately
+3. **Isolation** - Outgoing delivery issues don't affect incoming reception
+4. **Monitoring clarity** - Separate queue depths for each direction
+5. **Different configurations** - Incoming needs strict spam checks, outgoing needs delivery optimization
+
+**Disadvantages:**
+1. Two services to maintain
+2. Slightly more resource usage
+
+#### Architecture: Dual Postfix
+
+```yaml
+# Incoming mail - receives from internet, pipes to Laravel
+postfix-incoming:
+  ports:
+    - "25:25"      # SMTP from internet
+  environment:
+    - INSTANCE_TYPE=incoming
+  # Receives mail → pipes to artisan mail:incoming
+
+# Outgoing mail - receives from Laravel, delivers to internet
+postfix-outgoing:
+  ports:
+    - "587:587"    # Submission from internal services only (not exposed to internet)
+  environment:
+    - INSTANCE_TYPE=outgoing
+  # Receives mail from Laravel Mail → delivers externally
+```
+
+#### Prioritization Without Dual Postfix
+
+If using single instance, Postfix has limited prioritization options:
+- `defer_transports` can delay certain transports
+- But no true priority queuing
+- Backpressure from outgoing would still delay incoming
+
+**Recommendation: Use dual postfix instances** - the operational clarity and incoming prioritization outweighs the minor complexity increase.
+
+### Postfix Container Design (Incoming)
+
+```yaml
+# docker-compose.yml addition
+postfix-incoming:
+  build:
+    context: ./conf/postfix-incoming
+    dockerfile: Dockerfile
+  container_name: freegle-postfix-incoming
+  hostname: mail.ilovefreegle.org
+  ports:
+    - "25:25"     # SMTP from internet
+  volumes:
+    - postfix-incoming-spool:/var/spool/postfix
+    - ./conf/postfix-incoming/main.cf:/etc/postfix/main.cf:ro
+    - ./conf/postfix-incoming/master.cf:/etc/postfix/master.cf:ro
+    - ./conf/postfix-incoming/transport:/etc/postfix/transport:ro
+  environment:
+    - MAILPIT_HOST=mailpit
+    - BATCH_CONTAINER=batch
+  networks:
+    - default
+  restart: unless-stopped
+  depends_on:
+    - batch
+    - mailpit
+  profiles:
+    - production  # Only runs in production profile
+```
+
+### Key Configuration
+
+**main.cf** (core settings):
+```
+# Domains we accept mail for
+mydestination =
+relay_domains = ilovefreegle.org, groups.ilovefreegle.org, users.ilovefreegle.org, user.trashnothing.com
+
+# Transport to Laravel
+transport_maps = hash:/etc/postfix/transport
+
+# Concurrency limits - max 4 parallel deliveries to Laravel
+freegle_destination_concurrency_limit = 4
+default_process_limit = 50
+
+# Archive all mail to MailPit for debugging
+always_bcc = archive@mailpit
+```
+
+**master.cf** (transport definition):
+```
+# Pipe to Laravel artisan command
+freegle unix - n n - 4 pipe
+  flags=F user=www-data argv=/usr/bin/php /app/artisan mail:incoming ${sender} ${recipient}
+```
+
+**transport** (domain routing):
+```
+groups.ilovefreegle.org    freegle:
+users.ilovefreegle.org     freegle:
+user.trashnothing.com      freegle:
+ilovefreegle.org           freegle:
+```
+
+---
+
+## Part 2: Laravel Command Structure
+
+### Entry Point: `mail:incoming`
+
+```php
+// app/Console/Commands/Mail/IncomingMailCommand.php
+class IncomingMailCommand extends Command
+{
+    protected $signature = 'mail:incoming {sender} {recipient}';
+    protected $description = 'Process incoming email from Postfix';
+
+    public function handle(IncomingMailService $service): int
+    {
+        $sender = $this->argument('sender');
+        $recipient = $this->argument('recipient');
+        $rawEmail = file_get_contents('php://stdin');
+
+        try {
+            $result = $service->process($sender, $recipient, $rawEmail);
+            $this->logToLoki($result);
+            return Command::SUCCESS;
+        } catch (\Exception $e) {
+            Sentry::captureException($e);
+            return Command::FAILURE;
+        }
+    }
+}
+```
+
+### Service Structure
+
+```
+app/Services/Mail/Incoming/
+├── IncomingMailService.php      # Main orchestrator
+├── MailParserService.php        # MIME parsing (php-mime-mail-parser)
+├── MailRouterService.php        # Routing logic (11 outcomes)
+├── BounceService.php            # DSN parsing and processing
+├── FBLService.php               # Feedback loop processing
+├── SpamCheckService.php         # Dual SpamD + custom checks
+├── FreegleSpamService.php       # Freegle-specific spam detection
+├── ContentModerationService.php # Worry words + spam keywords
+├── TrashNothingService.php      # TN header validation
+├── EmailCommandService.php      # Subscribe/unsubscribe commands
+└── AttachmentService.php        # TUSD upload handling
+```
+
+### Dual Spam Detection Approach
+
+Freegle uses two complementary spam detection systems:
+
+#### 1. SpamAssassin (SpamD)
+- External daemon for content-based spam detection
+- Connected via `lib/spamc.php` client library
+- **Threshold**: Score >= 8 triggers spam classification
+- Configuration via `SPAMD_HOST` and `SPAMD_PORT`
+- Only used for content checks when subject not in standard format
+
+#### 2. Custom Freegle Spam Checks (`Spam.php`)
+- IP reputation checks (multiple users/groups from same IP)
+- Subject duplication across groups (threshold: 30 groups)
+- Country blocking (configurable)
+- Greeting spam detection ("hello", "hey", etc. patterns)
+- Domain blacklist (DBL) URL checks
+- Known spam keywords
+- Worry words detection
+- Bulk volunteer mail detection
+- Our domain spoofing detection
+- Same image sent multiple times
+
+#### Laravel Implementation
+
+```php
+class SpamCheckService
+{
+    private const SPAMASSASSIN_THRESHOLD = 8;
+
+    public function __construct(
+        private SpamDClient $spamd,
+        private FreegleSpamService $freegleSpam
+    ) {}
+
+    public function check(ParsedEmail $email, bool $contentCheck = true): SpamResult
+    {
+        // 1. Run Freegle-specific checks first (faster, no network call)
+        $freegleResult = $this->freegleSpam->checkMessage($email);
+        if ($freegleResult->isSpam()) {
+            return $freegleResult;
+        }
+
+        // 2. Run SpamAssassin for content check if enabled
+        if ($contentCheck && !$this->hasStandardSubjectFormat($email)) {
+            $saResult = $this->spamd->check($email->getRawMessage());
+            if ($saResult->score >= self::SPAMASSASSIN_THRESHOLD) {
+                return SpamResult::spam(SpamReason::SPAMASSASSIN, $saResult->score);
+            }
+        }
+
+        return SpamResult::notSpam();
+    }
+}
+
+class FreegleSpamService
+{
+    // Port from Spam.php - all custom checks
+    public function checkMessage(ParsedEmail $email): SpamResult;
+    public function checkIpReputation(string $ip): SpamResult;
+    public function checkSubjectDuplication(string $subject): SpamResult;
+    public function checkCountry(string $ip): SpamResult;
+    public function checkGreetingSpam(string $body): SpamResult;
+    public function checkDbl(array $urls): SpamResult;
+    public function checkSpamKeywords(string $text): SpamResult;
+    public function checkWorryWords(string $text): SpamResult;
+}
+```
+
+#### SpamD Container (Docker)
+
+```yaml
+# docker-compose.yml addition
+spamd:
+  image: instantlinux/spamassassin:latest
+  container_name: freegle-spamd
+  volumes:
+    - spamd-data:/var/lib/spamassassin
+  environment:
+    - SA_UPDATE_CRON=0 4 * * *  # Update rules at 4am
+  networks:
+    - default
+  restart: unless-stopped
+  profiles:
+    - production
+```
+
+### Routing Outcomes (from MailRouter)
+
+| Outcome | Description | Action |
+|---------|-------------|--------|
+| FAILURE | Could not process | Log error, return failure |
+| INCOMING_SPAM | Detected as spam | Log, optionally store for review |
+| APPROVED | Auto-approved for posting | Create message, notify |
+| PENDING | Needs moderation | Create message, notify mods |
+| TO_USER | Chat message | Route to chat system |
+| TO_SYSTEM | System command | Process command |
+| RECEIPT | Read receipt | Update chat message status |
+| TRYST | Calendar response | Process meeting response |
+| DROPPED | Silently dropped | Log only |
+| TO_VOLUNTEERS | To moderators | Route to mod mail |
+
+---
+
+## Part 3: Bounce and FBL Processing
+
+### Current Bounce Flow (VERP-based)
+1. Outgoing mail uses `bounce-{userid}-{timestamp}@users.ilovefreegle.org`
+2. Bounces arrive at that address
+3. `bounce.php` cron extracts userid from address
+4. Records in `bounces_emails` table
+5. `bounce_users.php` suspends users with 3+ permanent bounces
+
+### New Bounce Flow (DSN parsing)
+1. Bounces arrive at `noreply@ilovefreegle.org` (new no-reply address)
+2. `BounceService` detects DSN format or heuristic bounce patterns
+3. Extracts original recipient from DSN `Final-Recipient` or body parsing
+4. Records bounce and marks email as bounced
+5. Scheduled command suspends users with threshold bounces
+
+### BounceService Key Methods
+
+```php
+class BounceService
+{
+    // Detection
+    public function isBounce(ParsedEmail $email): bool;
+    public function isDsnCompliant(ParsedEmail $email): bool;
+
+    // Extraction (cascading strategy)
+    public function extractRecipient(string $rawMessage): ?string;
+    private function extractFromDsn(string $rawMessage): ?string;
+    private function extractHeuristically(string $rawMessage): ?string;
+    private function extractFromOriginalMessage(ParsedEmail $email): ?string;
+
+    // Classification
+    public function isPermanent(?string $diagnosticCode): bool;
+    public function shouldIgnore(?string $diagnosticCode): bool;
+
+    // Processing
+    public function processBounce(ParsedEmail $email): ?BounceResult;
+}
+```
+
+### FBL Processing
+
+FBL reports (when users mark our mail as spam) arrive at `fbl@users.ilovefreegle.org`.
+
+```php
+class FBLService
+{
+    public function isFBL(ParsedEmail $email): bool;
+    public function processFBL(ParsedEmail $email): ?FBLResult;
+}
+```
+
+Action: Set user's `simple_mail = NONE` to stop all email.
+
+---
+
+## Part 4: Spam Review UI in ModTools
+
+### Current Problem
+Currently, incoming mail classified as spam is simply discarded with no ability to review or recover false positives.
+
+### Solution: Spam Review Queue
+
+Store suspected spam for review instead of discarding:
+
+```php
+// Database table for spam queue
+// Migration: create_incoming_spam_queue_table
+Schema::create('incoming_spam_queue', function (Blueprint $table) {
+    $table->id();
+    $table->text('raw_message');          // Full RFC2822 message
+    $table->string('envelope_from');
+    $table->string('envelope_to');
+    $table->string('from_address');
+    $table->string('subject');
+    $table->string('spam_reason');         // SpamAssassin, GreetingSpam, etc.
+    $table->decimal('spam_score', 5, 2)->nullable();
+    $table->json('spam_details')->nullable(); // Additional detection info
+    $table->timestamp('received_at');
+    $table->unsignedBigInteger('reviewed_by')->nullable();
+    $table->enum('status', ['pending', 'approved', 'rejected'])->default('pending');
+    $table->timestamp('reviewed_at')->nullable();
+    $table->timestamps();
+
+    $table->index(['status', 'received_at']);
+    $table->index('envelope_to');
+});
+```
+
+### API Endpoints
+
+```
+GET /api/v2/mail/spam-queue
+    ?status=pending          # Filter by status
+    &page=1                  # Pagination
+    &per_page=20
+
+GET /api/v2/mail/spam-queue/{id}
+    Returns full message details including parsed headers, body preview
+
+POST /api/v2/mail/spam-queue/{id}/approve
+    Releases message from spam queue for delivery
+    Creates whitelist entry if requested
+
+POST /api/v2/mail/spam-queue/{id}/reject
+    Marks as confirmed spam (for training)
+    Optionally adds to blacklist
+
+DELETE /api/v2/mail/spam-queue/purge
+    Removes messages older than N days (default 7)
+```
+
+### ModTools Spam Review Component
+
+```vue
+<!-- modtools/components/ModSpamQueue.vue -->
+<template>
+  <div class="spam-queue">
+    <h4>Incoming Spam Review</h4>
+
+    <!-- Stats summary -->
+    <div class="queue-stats">
+      <span class="stat pending">{{ pendingCount }} pending</span>
+      <span class="stat approved">{{ approvedToday }} approved today</span>
+      <span class="stat rejected">{{ rejectedToday }} rejected today</span>
+    </div>
+
+    <!-- Filter tabs -->
+    <b-tabs v-model="activeTab">
+      <b-tab title="Pending Review" />
+      <b-tab title="Recently Approved" />
+      <b-tab title="Recently Rejected" />
+    </b-tabs>
+
+    <!-- Message list -->
+    <div class="message-list">
+      <div v-for="msg in messages" :key="msg.id" class="spam-item">
+        <div class="spam-header">
+          <span class="from">{{ msg.from_address }}</span>
+          <span class="reason badge" :class="reasonClass(msg.spam_reason)">
+            {{ msg.spam_reason }}
+          </span>
+          <span v-if="msg.spam_score" class="score">
+            Score: {{ msg.spam_score }}
+          </span>
+        </div>
+        <div class="spam-subject">{{ msg.subject }}</div>
+        <div class="spam-preview">{{ msg.body_preview }}</div>
+        <div class="spam-actions">
+          <b-button variant="success" size="sm" @click="approve(msg.id)">
+            Approve & Deliver
+          </b-button>
+          <b-button variant="danger" size="sm" @click="reject(msg.id)">
+            Confirm Spam
+          </b-button>
+          <b-button variant="secondary" size="sm" @click="showDetails(msg)">
+            View Full
+          </b-button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Detail modal -->
+    <b-modal v-model="showDetailModal" size="xl" title="Spam Message Details">
+      <div v-if="selectedMessage">
+        <h5>Headers</h5>
+        <pre class="headers">{{ selectedMessage.headers }}</pre>
+        <h5>Body</h5>
+        <pre class="body">{{ selectedMessage.body }}</pre>
+        <h5>Spam Analysis</h5>
+        <pre class="analysis">{{ JSON.stringify(selectedMessage.spam_details, null, 2) }}</pre>
+      </div>
+    </b-modal>
+  </div>
+</template>
+```
+
+### Whitelist Management
+
+When approving spam, offer to whitelist:
+- **Sender address**: `spam_whitelist_addresses` table
+- **Sender IP**: `spam_whitelist_ips` table
+- **Subject pattern**: `spam_whitelist_subjects` table
+
+### Retention Policy
+
+- **Pending messages**: 7 days, then auto-purge
+- **Approved messages**: Delete immediately after delivery (logged)
+- **Rejected messages**: 30 days for potential blacklist training
+
+### Access Control
+
+- All volunteers (moderators) can view the spam queue
+- Support/Admin users can approve/reject spam
+- All actions logged with user ID and timestamp
+- Sentry alerts for high false positive rates
+
+### UI Placement in ModTools
+
+Add to left sidebar under Messages section:
+- **Menu item**: "Incoming Spam" with blue badge showing pending count
+- **Badge**: Shows pending spam count (blue, like other notification counts)
+- **Purpose**: Shows volunteers the value of spam filtering without requiring action
+- **Retention**: 7 days - auto-purged if not reviewed
+
+```vue
+<!-- In LeftMenu.vue Messages section -->
+<MenuOption
+  v-if="hasModeratorRole"
+  name="Incoming Spam"
+  icon="shield-alt"
+  :badge="spamQueueCount"
+  badge-variant="primary"
+  :to="'/modtools/support/spam'"
+/>
+```
+
+This placement:
+1. Demonstrates the system's value by showing blocked spam
+2. Allows curious moderators to review if they choose
+3. Auto-purges after 7 days so no action required
+4. Blue badge matches existing notification style
+
+---
+
+## Part 5: ModTools Email Statistics
+
+### API Endpoint
+
+`GET /api/v2/mail/stats` (Go API for speed)
+
+**Response:**
+```json
+{
+    "queue": {
+        "size": 12,
+        "checked_at": "2026-01-26T14:30:00Z",
+        "status": "ok"
+    },
+    "incoming": {
+        "last_hour": {
+            "total": 245,
+            "by_outcome": {
+                "approved": 180,
+                "pending": 32,
+                "spam": 28,
+                "dropped": 5
+            },
+            "by_source": {
+                "trashnothing": 162,
+                "direct": 83
+            }
+        },
+        "last_24h": {
+            "total": 4123,
+            "bounces": 47,
+            "fbl_reports": 3
+        }
+    },
+    "processing": {
+        "avg_time_ms": 156,
+        "errors_last_hour": 2
+    }
+}
+```
+
+### ModTools UI Component
+
+Add to Support Tools dashboard:
+
+```vue
+<!-- modtools/components/ModEmailStats.vue -->
+<template>
+  <div class="email-stats">
+    <h4>Incoming Email Status</h4>
+
+    <!-- Queue Status -->
+    <div class="queue-status" :class="queueStatusClass">
+      <span>Mail Queue: {{ stats.queue.size }}</span>
+      <small>Last checked: {{ formatTime(stats.queue.checked_at) }}</small>
+    </div>
+
+    <!-- Hourly Stats -->
+    <div class="hourly-stats">
+      <div class="stat">
+        <span class="value">{{ stats.incoming.last_hour.total }}</span>
+        <span class="label">Last Hour</span>
+      </div>
+      <div class="stat">
+        <span class="value">{{ stats.incoming.last_24h.total }}</span>
+        <span class="label">Last 24h</span>
+      </div>
+      <div class="stat">
+        <span class="value">{{ stats.incoming.last_24h.bounces }}</span>
+        <span class="label">Bounces (24h)</span>
+      </div>
+    </div>
+
+    <!-- Outcome Breakdown -->
+    <div class="outcomes">
+      <div v-for="(count, outcome) in stats.incoming.last_hour.by_outcome"
+           :key="outcome"
+           class="outcome-bar">
+        <span>{{ outcome }}: {{ count }}</span>
+      </div>
+    </div>
+  </div>
+</template>
+```
+
+### Queue Monitoring Command
+
+```php
+// app/Console/Commands/Mail/MonitorMailQueueCommand.php
+class MonitorMailQueueCommand extends Command
+{
+    protected $signature = 'mail:monitor-queue';
+
+    private const WARNING_THRESHOLD = 100;
+    private const CRITICAL_THRESHOLD = 500;
+
+    public function handle(): int
+    {
+        $queueSize = $this->getPostfixQueueSize();
+
+        Cache::put('mail:queue_size', $queueSize, now()->addMinutes(5));
+        Cache::put('mail:queue_checked_at', now(), now()->addMinutes(5));
+
+        if ($queueSize >= self::CRITICAL_THRESHOLD) {
+            Sentry::captureMessage("Critical: Mail queue at {$queueSize}");
+            return Command::FAILURE;
+        }
+
+        if ($queueSize >= self::WARNING_THRESHOLD) {
+            Sentry::captureMessage("Warning: Mail queue at {$queueSize}");
+        }
+
+        return Command::SUCCESS;
+    }
+
+    private function getPostfixQueueSize(): int
+    {
+        // Execute mailq in postfix container
+        $output = shell_exec('docker exec freegle-postfix-incoming mailq 2>/dev/null | grep -c "^[A-F0-9]" || echo 0');
+        return (int) trim($output);
+    }
+}
+```
+
+---
+
+## Part 6: Mail Archiving (MailPit Integration)
+
+### Production Mail Debugging
+
+Use Postfix `always_bcc` to copy all incoming mail to MailPit:
+
+```
+# In postfix main.cf
+always_bcc = archive@mailpit
+```
+
+MailPit provides:
+- Web UI for searching/viewing mail
+- API for programmatic access
+- 7-day retention (configurable)
+- Full MIME viewing
+
+### MailPit Configuration for Production
+
+```yaml
+# In docker-compose.yml - enhance existing mailpit service
+mailpit:
+  image: axllent/mailpit:latest
+  container_name: freegle-mailpit
+  environment:
+    - MP_DATABASE=/data/mailpit.db
+    - MP_MAX_MESSAGES=100000
+    - MP_MAX_AGE=168h  # 7 days
+    - MP_SMTP_AUTH_ACCEPT_ANY=true
+    - MP_WEBROOT=/mailpit
+  volumes:
+    - mailpit-data:/data
+  labels:
+    # Expose via Traefik for Support staff
+    - "traefik.http.routers.mailpit-prod.rule=Host(`mailpit.ilovefreegle.org`)"
+    - "traefik.http.routers.mailpit-prod.middlewares=auth@docker"
+```
+
+### Access Control
+
+MailPit should only be accessible to Support/Admin users:
+- Use Traefik middleware with basic auth or OAuth
+- Or integrate into ModTools with iframe + auth check
+
+### Alternative: Piler (for longer retention)
+
+If 7-day retention is insufficient, consider Piler for enterprise-grade archiving:
+- Full-text search
+- Longer retention periods
+- Compliance features
+
+See `plans/reference/logging-and-email-tracking-research.md` for Piler setup details.
+
+---
+
+## Part 7: Logging Architecture
+
+### Loki for All Incoming Mail Logs
+
+No database tables for logging. All incoming mail events go to Loki:
+
+```php
+// In IncomingMailService
+Log::channel('incoming_mail')->info('Mail processed', [
+    'envelope_from' => $envelope['from'],
+    'envelope_to' => $envelope['to'],
+    'from_address' => $parsed->getFromAddress(),
+    'subject' => $parsed->getSubject(),
+    'message_id' => $parsed->getMessageId(),
+    'source' => $source,  // Email, Platform, TrashNothing
+    'routing_result' => $result->getOutcome(),
+    'rspamd_score' => $rspamdResult?->score,
+    'processing_time_ms' => $duration,
+    'user_id' => $user?->id,
+    'group_id' => $group?->id,
+]);
+```
+
+### Loki Queries for Support
+
+```logql
+# All mail in last hour
+{app="iznik-batch", channel="incoming_mail"} | json
+
+# Filter by outcome
+{app="iznik-batch", channel="incoming_mail"} | json | routing_result="Spam"
+
+# Filter by user
+{app="iznik-batch", channel="incoming_mail"} | json | user_id="12345"
+
+# Bounces
+{app="iznik-batch", channel="incoming_mail"} | json | routing_result="Bounce"
+```
+
+---
+
+## Part 8: Switchover Process
+
+### Phase 0: Preparation (Before any mail migration)
+
+1. **Email template cleanup**
+   - Remove legacy mailto: unsubscribe links from MGML templates
+   - Replace with website settings page links
+   - Ensure List-Unsubscribe uses RFC 8058 one-click format
+
+2. **Infrastructure setup**
+   - Deploy Postfix container (not receiving mail yet)
+   - Deploy/configure MailPit for archiving
+   - Set up Loki logging channel
+
+### Phase 1: Bounces Only (Lowest Risk)
+
+**Duration**: 1-2 weeks
+
+1. **Configure Exim to forward bounces to Postfix**
+   ```
+   # Exim router
+   bounce_to_postfix:
+     driver = manualroute
+     domains = users.ilovefreegle.org
+     local_parts = noreply : bounce-*
+     transport = postfix_smtp
+     route_list = * 127.0.0.1::2525
+   ```
+
+2. **Deploy Laravel BounceService**
+   - Port `Bounce.php` logic to Laravel
+   - Implement DSN parsing for no-reply bounces
+   - Keep VERP support for transition period
+
+3. **Monitor**
+   - Compare bounce counts (old vs new system)
+   - Watch for missed bounces
+   - Verify user suspension working
+
+4. **Success criteria**
+   - 100% bounce detection rate
+   - User suspension logic matches
+
+### Phase 2: FBL Reports (Low Risk)
+
+**Duration**: 1 week
+
+1. **Forward FBL to Postfix**
+   ```
+   fbl_to_postfix:
+     driver = manualroute
+     domains = users.ilovefreegle.org
+     local_parts = fbl
+     transport = postfix_smtp
+     route_list = * 127.0.0.1::2525
+   ```
+
+2. **Deploy Laravel FBLService**
+
+3. **Success criteria**
+   - FBL reports processed correctly
+   - Users unsubscribed as expected
+
+### Phase 3: Trash Nothing Chat Replies (Medium Risk)
+
+**Duration**: 2 weeks
+
+**Why TN first**: 66% of traffic, but validates via header so bypasses spam checks - simpler to test.
+
+1. **Forward TN domain to Postfix**
+   ```
+   tn_to_postfix:
+     driver = manualroute
+     domains = user.trashnothing.com
+     transport = postfix_smtp
+     route_list = * 127.0.0.1::2525
+   ```
+
+2. **Deploy Laravel TrashNothingService**
+   - Port TN header validation
+   - Port chat routing logic
+
+3. **Success criteria**
+   - Chat messages delivered correctly
+   - TN secret validation working
+
+### Phase 4: Native Chat Replies (Medium Risk)
+
+**Duration**: 2 weeks
+
+1. **Forward chat reply addresses**
+   ```
+   chat_to_postfix:
+     driver = manualroute
+     domains = users.ilovefreegle.org
+     local_parts = notify-*
+     transport = postfix_smtp
+     route_list = * 127.0.0.1::2525
+   ```
+
+2. **Deploy full chat routing**
+   - Needs spam/content checks for non-TN mail
+
+3. **Success criteria**
+   - Chat replies work for all sources
+   - Spam detection equivalent to existing
+
+### Phase 5: Group Messages (Higher Risk)
+
+**Duration**: 2-4 weeks
+
+1. **Forward group domain**
+   ```
+   groups_to_postfix:
+     driver = manualroute
+     domains = groups.ilovefreegle.org
+     transport = postfix_smtp
+     route_list = * 127.0.0.1::2525
+   ```
+
+2. **Deploy full MailRouterService**
+   - Complete routing logic (11 outcomes)
+   - All email commands
+   - Full spam/content moderation
+
+3. **Success criteria**
+   - All routing outcomes match existing behavior
+   - Moderator workflows unchanged
+
+### Phase 6: Full Cutover
+
+1. **Update MX records** to point directly to Postfix
+2. **Disable Exim forwarding rules**
+3. **Monitor closely** for 1-2 weeks
+
+### Phase 7: Retire iznik-server Code
+
+**After 4+ weeks of stable operation:**
+
+1. **Remove from crontab**
+   - `bounce.php`
+   - `bounce_users.php`
+   - Any incoming mail related scripts
+
+2. **Archive code** (don't delete immediately)
+   - `scripts/incoming/incoming.php`
+   - `include/mail/MailRouter.php`
+   - `include/mail/Bounce.php`
+
+3. **Update documentation**
+   - Remove references to Exim configuration
+   - Update architecture diagrams
+
+4. **Clean up database**
+   - `bounces` table (temporary storage) can be emptied
+   - `bounces_emails` table continues to be used by Laravel
+
+---
+
+## Part 9: Test Migration Strategy
+
+### Existing Tests (iznik-server)
+
+- `MailRouterTest.php` - 1923 lines, 56+ test cases
+- 77 test email files in `test/ut/php/msgs/`
+
+### Laravel Test Structure
+
+```
+tests/
+├── Unit/Services/Mail/Incoming/
+│   ├── MailParserServiceTest.php
+│   ├── MailRouterServiceTest.php
+│   ├── BounceServiceTest.php
+│   ├── FBLServiceTest.php
+│   ├── SpamCheckServiceTest.php
+│   └── ContentModerationServiceTest.php
+├── Feature/Mail/
+│   ├── IncomingMailCommandTest.php
+│   ├── GroupMessageRoutingTest.php
+│   ├── ChatReplyRoutingTest.php
+│   └── BounceProcessingTest.php
+└── fixtures/emails/
+    ├── bounce/
+    ├── fbl/
+    ├── chat-replies/
+    ├── group-messages/
+    └── spam/
+```
+
+### Test Migration Approach
+
+1. **Convert test files to templates**
+   - Replace hardcoded group names with `{{GROUP_NAME}}`
+   - Replace email addresses with `{{FROM_EMAIL}}`
+
+2. **Port test assertions**
+   - Each PHP test case becomes a Laravel test
+   - Verify same routing outcomes
+
+3. **Use DatabaseTransactions**
+   - Each test isolated
+   - Supports parallel execution
+
+---
+
+## Part 10: Implementation Phases
+
+### Phase A: Foundation (Week 1-2)
+- [ ] Create Postfix container configuration
+- [ ] Implement `mail:incoming` command
+- [ ] Implement `MailParserService`
+- [ ] Set up Loki logging channel for incoming mail
+
+### Phase B: Bounce Processing (Week 3-4)
+- [ ] Port `Bounce.php` to Laravel `BounceService`
+- [ ] Implement DSN parsing
+- [ ] Implement heuristic extraction
+- [ ] Port bounce tests
+- [ ] Implement `mail:process-bounces` scheduled command
+
+### Phase C: FBL Processing (Week 4)
+- [ ] Implement `FBLService`
+- [ ] Port FBL tests
+
+### Phase D: Routing Logic (Week 5-6)
+- [ ] Implement `MailRouterService` with all outcomes
+- [ ] Port email command handling
+- [ ] Implement chat routing
+- [ ] Implement group message routing
+- [ ] Port routing tests
+
+### Phase E: Spam & Content Moderation (Week 7-8)
+- [ ] Implement `SpamCheckService` (dual SpamD + custom checks)
+- [ ] Port SpamAssassin/SpamD integration
+- [ ] Port custom Freegle spam checks from `Spam.php`
+- [ ] Implement `ContentModerationService`
+- [ ] Port worry words and spam keywords
+- [ ] Port spam detection tests
+
+### Phase F: ModTools UI (Week 9-10)
+- [ ] Implement Go API endpoint for mail stats
+- [ ] Create Vue component for email statistics (`ModEmailStats.vue`)
+- [ ] Add to Support Tools dashboard
+- [ ] Create spam queue database table
+- [ ] Implement spam queue API endpoints (Go)
+- [ ] Create spam review Vue component (`ModSpamQueue.vue`)
+- [ ] Implement whitelist management for approved spam
+
+### Phase G: Production Deployment (Week 10-12)
+- [ ] Deploy Postfix container
+- [ ] Phased migration (bounces → FBL → TN → chat → groups)
+- [ ] Monitor and tune
+
+### Phase H: Retirement (Week 13+)
+- [ ] Remove iznik-server incoming mail code from crontab
+- [ ] Archive code
+- [ ] Update documentation
+
+---
+
+## Part 11: Risk Mitigation
+
+### Rollback Strategy
+
+Each phase can be rolled back independently:
+1. **Disable Exim router rule** for that traffic type
+2. Traffic returns to iznik-server processing
+3. No data loss - mail queued in Postfix if needed
+
+### Monitoring
+
+1. **Queue depth** - Alert if > 100 messages
+2. **Processing errors** - Sentry alerts
+3. **Routing outcome comparison** - Log discrepancies
+4. **User complaints** - Support ticket monitoring
+
+### Data Integrity
+
+- Compare routing decisions between old/new during parallel operation
+- Log all discrepancies for investigation
+- Keep iznik-server code available for 4+ weeks after full cutover
+
+---
+
+## Part 12: Configuration
+
+### Environment Variables
+
+```env
+# Incoming mail processing
+MAIL_INCOMING_ENABLED=true
+MAIL_INCOMING_LOG_RAW=true
+
+# Rspamd
+RSPAMD_HOST=rspamd
+RSPAMD_PORT=11333
+RSPAMD_SPAM_THRESHOLD=8.0
+
+# TUSD (attachments)
+TUS_UPLOADER_URL=http://tusd:1080/files
+
+# Trash Nothing
+TN_SECRET=your-secret-here
+
+# Domains
+USER_DOMAIN=ilovefreegle.org
+GROUP_DOMAIN=groups.ilovefreegle.org
+
+# Mail archiving
+MAILPIT_ARCHIVE_ENABLED=true
+```
+
+---
+
+## References
+
+### Internal Documents
+- `plans/active/incoming-email-migration-to-laravel.md` - Original detailed plan (to be superseded)
+- `plans/reference/logging-and-email-tracking-research.md` - Piler/Loki research
+- `iznik-batch/EMAIL-MIGRATION-GUIDE.md` - Migration lessons learned
+
+### External
+- [Postfix Pipe Configuration](https://thecodingmachine.io/triggering-a-php-script-when-your-postfix-server-receives-a-mail)
+- [php-mime-mail-parser](https://github.com/php-mime-mail-parser/php-mime-mail-parser)
+- [RFC 3464](https://datatracker.ietf.org/doc/html/rfc3464) - DSN format
+- [RFC 5965](https://datatracker.ietf.org/doc/html/rfc5965) - FBL/ARF format
+- [MailPit](https://github.com/axllent/mailpit) - Mail testing/archiving
+
+### Source Code
+- `iznik-server/include/mail/MailRouter.php` - Current routing logic
+- `iznik-server/include/mail/Bounce.php` - Current bounce processing
+- `iznik-server/test/ut/php/include/MailRouterTest.php` - Test cases to port

--- a/plans/active/incoming-email-to-docker.md
+++ b/plans/active/incoming-email-to-docker.md
@@ -1,9 +1,25 @@
 # Incoming Email Migration to Docker (Consolidated Plan)
 
-**Status**: Planning
+**Status**: Shadow Mode Validation (Phase A in progress)
 **Branches**:
 - FreegleDocker: `feature/incoming-email-migration` (includes iznik-batch)
-- iznik-server: `feature/incoming-email-migration` (for retirement phase only - code removal happens last)
+- iznik-server: `feature/incoming-email-migration` - archiving deployed to production (PR #48)
+
+## Current Progress (2026-01-28)
+
+### Completed
+1. **Postfix container configuration** - `conf/postfix/` with Dockerfile, main.cf, master.cf, transport maps
+2. **Laravel HTTP endpoint** - `IncomingMailController` receives mail via HTTP from Postfix
+3. **Shadow mode archiving** - Legacy `incoming.php` saves emails to `/var/lib/freegle/incoming-archive/`
+4. **Replay command** - Laravel command to replay archived emails for comparison
+
+### In Progress
+- Deploying archiving to production (iznik-server PR #48 ready for merge)
+- Postfix container ready but not receiving mail (MX records unchanged)
+
+### Not Yet Started
+- MX record switchover (safe to do after validation)
+- Full production traffic through Laravel
 
 ## Executive Summary
 

--- a/plans/active/incoming-email-to-docker.md
+++ b/plans/active/incoming-email-to-docker.md
@@ -1,7 +1,9 @@
 # Incoming Email Migration to Docker (Consolidated Plan)
 
 **Status**: Planning
-**Branch**: `feature/incoming-email-migration`
+**Branches**:
+- FreegleDocker: `feature/incoming-email-migration` (includes iznik-batch)
+- iznik-server: `feature/incoming-email-migration` (for retirement phase only - code removal happens last)
 
 ## Executive Summary
 
@@ -15,7 +17,7 @@ This plan consolidates the incoming email migration strategy, covering:
 
 ---
 
-## Part 1: Architecture - Single Postfix Design
+## Part 1: Architecture - Incoming Postfix Only
 
 ### Current State (Bulk4)
 - **MX records** point to bulk4.ilovefreegle.org
@@ -23,38 +25,42 @@ This plan consolidates the incoming email migration strategy, covering:
 - **Pipe transport** calls `incoming.php` for each message
 - **Processing** via MailRouter in iznik-server
 
-### Architecture Decision: Single Postfix Instance
+### Current Outgoing Mail
+- **Dev/test**: MailPit container captures all mail
+- **Production**: External smarthost via `${MAIL_HOST_IP}` (no change planned)
 
-A single Postfix instance handles both incoming and outgoing mail:
+### Architecture Decision: Add Postfix-Incoming Only
 
-| Function | Port | Notes |
-|----------|------|-------|
-| **Receive from internet** | 25 | Pipe to Laravel for processing |
-| **Send notifications/digests** | 587 | Outgoing via relay |
+We add a dedicated `postfix-incoming` container for receiving mail. Outgoing mail continues via external smarthost.
 
-**Rationale for single instance:**
-- Simpler deployment and maintenance
-- Incoming volume is moderate (many users post via website now)
-- Postfix handles mixed traffic efficiently with proper queue prioritization
-- Existing iznik-batch already uses postfix-outgoing for sending
+| Direction | Method | Notes |
+|-----------|--------|-------|
+| **Incoming** | New `postfix-incoming` container | Port 25, pipes to Laravel |
+| **Outgoing** | External smarthost (unchanged) | Already working, no need to change |
+
+**Rationale:**
+- Outgoing via smarthost already works reliably
+- Only incoming needs to move into Docker
+- Simpler - one new container instead of two
+- Clear separation of concerns
 
 <details>
 <summary><strong>Docker Compose Configuration</strong></summary>
 
 ```yaml
-postfix:
+postfix-incoming:
   build:
-    context: ./conf/postfix
+    context: ./conf/postfix-incoming
     dockerfile: Dockerfile
-  container_name: freegle-postfix
+  container_name: freegle-postfix-incoming
   hostname: mail.ilovefreegle.org
   ports:
     - "25:25"
   volumes:
-    - postfix-spool:/var/spool/postfix
-    - ./conf/postfix/main.cf:/etc/postfix/main.cf:ro
-    - ./conf/postfix/master.cf:/etc/postfix/master.cf:ro
-    - ./conf/postfix/transport:/etc/postfix/transport:ro
+    - postfix-incoming-spool:/var/spool/postfix
+    - ./conf/postfix-incoming/main.cf:/etc/postfix/main.cf:ro
+    - ./conf/postfix-incoming/master.cf:/etc/postfix/master.cf:ro
+    - ./conf/postfix-incoming/transport:/etc/postfix/transport:ro
   environment:
     - BATCH_CONTAINER=batch
   networks:
@@ -81,17 +87,77 @@ transport_maps = hash:/etc/postfix/transport
 freegle_destination_concurrency_limit = 4
 default_process_limit = 50
 
-# Rate limiting for flood protection (see Part 3A)
+# Rate limiting - prevent accepting work faster than we can process
 smtpd_client_connection_rate_limit = 50
 smtpd_client_message_rate_limit = 100
+smtpd_client_connection_count_limit = 10
 anvil_rate_time_unit = 60s
+
+# TLS for incoming SMTP (STARTTLS) - Let's Encrypt certs mounted from host
+smtpd_tls_cert_file = /etc/letsencrypt/live/mail.ilovefreegle.org/fullchain.pem
+smtpd_tls_key_file = /etc/letsencrypt/live/mail.ilovefreegle.org/privkey.pem
+smtpd_tls_security_level = may
+smtpd_tls_loglevel = 1
 ```
+
+**TLS Setup**: Use Let's Encrypt with certbot on the Docker host. Mount certs read-only into container:
+```yaml
+volumes:
+  - /etc/letsencrypt/live/mail.ilovefreegle.org:/etc/letsencrypt/live/mail.ilovefreegle.org:ro
+  - /etc/letsencrypt/archive/mail.ilovefreegle.org:/etc/letsencrypt/archive/mail.ilovefreegle.org:ro
+```
+
+**Why certbot on host (not in container)?**
+- **Security**: Running certbot in a container requires elevated permissions (port 80 for HTTP-01 challenge or DNS API keys for DNS-01)
+- **Simplicity**: The host likely already has certbot for other services; one renewal mechanism is easier to maintain
+- **Best practice**: Certs mounted read-only into containers follows principle of least privilege
+- **No container restarts needed**: Postfix picks up new certs on `postfix reload` (SIGHUP)
+
+**Certificate renewal**:
+- Certbot auto-renews via systemd timer on the host
+- Add post-renewal hook to reload Postfix: `/etc/letsencrypt/renewal-hooks/post/reload-postfix.sh`
+  ```bash
+  #!/bin/bash
+  docker exec freegle-postfix-incoming postfix reload 2>/dev/null || true
+  ```
+
+**Domain for certificate**:
+- Only `mail.ilovefreegle.org` needs a certificate (the SMTP hostname)
+- The other domains (`users.ilovefreegle.org`, `groups.ilovefreegle.org`, `user.trashnothing.com`) are envelope routing domains, not TLS identities
+- Current Exim uses a self-signed cert which is fine for opportunistic TLS; Let's Encrypt improves deliverability with stricter senders
 
 **master.cf** (transport definition):
 ```
 freegle unix - n n - 4 pipe
-  flags=F user=www-data argv=/usr/bin/php /app/artisan mail:incoming ${sender} ${recipient}
+  flags=F user=nobody argv=/usr/local/bin/mail-to-webhook.sh ${sender} ${recipient}
 ```
+
+**mail-to-webhook.sh** (inside postfix container):
+```bash
+#!/bin/bash
+# Pipe email to Laravel via HTTP webhook
+# Exit codes: 0=delivered, 75=defer (Postfix retries)
+curl --fail --silent --max-time 30 --data-binary @- \
+  -H "Content-Type: message/rfc822" \
+  -H "X-Envelope-From: $1" \
+  -H "X-Envelope-To: $2" \
+  "http://batch/api/mail/incoming"
+exit $?
+```
+
+**Why HTTP webhook?** The pipe transport runs inside the Postfix container, which can't directly execute `artisan` in the batch container. HTTP webhook allows:
+- Clean container separation
+- Postfix queues mail if batch is down (curl fails → exit 75 → defer)
+- Standard retry/backoff behavior
+- Easy monitoring via HTTP response codes
+
+**Email domains** (from iznik-server constants):
+| Domain | Defined As | Purpose |
+|--------|------------|---------|
+| `groups.ilovefreegle.org` | `GROUP_DOMAIN` | Group reply addresses (e.g., `12345-reply@groups.ilovefreegle.org`) |
+| `users.ilovefreegle.org` | `USER_DOMAIN` | User notification addresses, email commands |
+| `user.trashnothing.com` | Hardcoded | Trash Nothing user addresses (TN integration) |
+| `ilovefreegle.org` | Base domain | Catch-all for legacy or admin addresses |
 
 **transport** (domain routing):
 ```
@@ -144,7 +210,7 @@ class IncomingMailCommand extends Command
 app/Services/Mail/Incoming/
 ├── IncomingMailService.php      # Main orchestrator
 ├── MailParserService.php        # MIME parsing (php-mime-mail-parser)
-├── MailRouterService.php        # Routing logic (11 outcomes)
+├── MailRouterService.php        # Routing logic (10 outcomes)
 ├── BounceService.php            # DSN parsing and processing
 ├── FBLService.php               # Feedback loop processing
 ├── SpamCheckService.php         # Orchestrates all spam detection
@@ -365,96 +431,28 @@ See `plans/future/spam-and-content-moderation-rethink.md` for planned enhancemen
 
 ---
 
-## Part 3A: Flood and Attack Protection
+## Part 3A: Flood Protection
 
-Email bombing and flood attacks are real threats. Defense requires multiple layers.
-
-### Rate Limiting (Postfix Level)
+Flood protection is handled at the Postfix level via rate limiting configured in `main.cf`:
 
 ```
-# main.cf - Connection and message rate limits
 smtpd_client_connection_rate_limit = 50      # Connections per minute per client
 smtpd_client_message_rate_limit = 100        # Messages per minute per client
-smtpd_client_recipient_rate_limit = 200      # Recipients per minute per client
-anvil_rate_time_unit = 60s
-
-# Reject excessive connections early
 smtpd_client_connection_count_limit = 10     # Concurrent connections per client
+anvil_rate_time_unit = 60s
 ```
 
-### Application-Level Protection
+This prevents Postfix from accepting work faster than we can process it. If Laravel processing is slow or down, Postfix queues mail internally and retries with backoff.
 
-<details>
-<summary><strong>FloodProtectionService</strong></summary>
+### Queue Monitoring
 
-```php
-class FloodProtectionService
-{
-    private const RATE_LIMIT_SENDER = 30;      // Messages per hour per sender
-    private const RATE_LIMIT_SUBJECT = 50;     // Same subject per hour across all senders
-    private const BURST_THRESHOLD = 10;        // Messages in 5 minutes = burst
+Monitor Postfix queue depth via the `mail:monitor-queue` scheduled command. Alert thresholds:
+- **Warning**: Queue > 100 messages
+- **Critical**: Queue > 500 messages → Sentry alert
 
-    public function checkFlood(string $sender, string $subject): FloodResult
-    {
-        // Check sender rate
-        $senderKey = "flood:sender:{$sender}";
-        $senderCount = Cache::increment($senderKey);
-        Cache::expire($senderKey, 3600);
+### Cross-Post Flooding
 
-        if ($senderCount > self::RATE_LIMIT_SENDER) {
-            return FloodResult::blocked('sender_rate', $senderCount);
-        }
-
-        // Check burst (short-term spike)
-        $burstKey = "flood:burst:{$sender}";
-        $burstCount = Cache::increment($burstKey);
-        Cache::expire($burstKey, 300);
-
-        if ($burstCount > self::BURST_THRESHOLD) {
-            $this->alertOps("Burst detected from {$sender}: {$burstCount} in 5 min");
-            return FloodResult::blocked('burst', $burstCount);
-        }
-
-        // Check subject flooding (coordinated attack)
-        $subjectHash = md5(strtolower(trim($subject)));
-        $subjectKey = "flood:subject:{$subjectHash}";
-        $subjectCount = Cache::increment($subjectKey);
-        Cache::expire($subjectKey, 3600);
-
-        if ($subjectCount > self::RATE_LIMIT_SUBJECT) {
-            return FloodResult::blocked('subject_flood', $subjectCount);
-        }
-
-        return FloodResult::allowed();
-    }
-}
-```
-
-</details>
-
-### Attack Pattern Detection
-
-| Pattern | Detection | Response |
-|---------|-----------|----------|
-| **Email bombing** | >10 msgs/5min from same sender | Temporary block, alert ops |
-| **Subscription bombing** | Many different senders, same target | Alert, manual review |
-| **Cross-post flood** | Same subject to 30+ groups | Spam flag, moderator review |
-| **Attachment abuse** | Large attachments, rapid succession | Rate limit, reject oversized |
-
-### Monitoring & Alerts
-
-```logql
-# Loki alert: Flood detection
-{app="iznik-batch", channel="incoming_mail"}
-| json
-| flood_blocked="true"
-| count by (flood_reason) > 10
-```
-
-Alert channels:
-- Sentry for application errors
-- Grafana alerts for rate thresholds
-- Geek-alerts email for ops issues
+The existing Freegle spam check for "same subject to 30+ groups" (Part 3) handles coordinated cross-post attacks at the application level.
 
 ---
 
@@ -764,155 +762,41 @@ Add to ModTools left sidebar under Messages:
 
 </details>
 
-### Queue Monitoring
+### Queue Size Monitoring
 
-<details>
-<summary><strong>MonitorMailQueueCommand</strong></summary>
+The `postfix-incoming` container exposes queue size via a healthcheck script that writes to a shared volume:
 
-```php
-class MonitorMailQueueCommand extends Command
-{
-    protected $signature = 'mail:monitor-queue';
-
-    private const WARNING_THRESHOLD = 100;
-    private const CRITICAL_THRESHOLD = 500;
-
-    public function handle(): int
-    {
-        $queueSize = $this->getPostfixQueueSize();
-
-        Cache::put('mail:queue_size', $queueSize, now()->addMinutes(5));
-        Cache::put('mail:queue_checked_at', now(), now()->addMinutes(5));
-
-        if ($queueSize >= self::CRITICAL_THRESHOLD) {
-            Sentry::captureMessage("Critical: Mail queue at {$queueSize}");
-            return Command::FAILURE;
-        }
-
-        if ($queueSize >= self::WARNING_THRESHOLD) {
-            Sentry::captureMessage("Warning: Mail queue at {$queueSize}");
-        }
-
-        return Command::SUCCESS;
-    }
-
-    private function getPostfixQueueSize(): int
-    {
-        $output = shell_exec('docker exec freegle-postfix-incoming mailq 2>/dev/null | grep -c "^[A-F0-9]" || echo 0');
-        return (int) trim($output);
-    }
-}
+```yaml
+# docker-compose.yml
+postfix-incoming:
+  ...
+  volumes:
+    - postfix-metrics:/var/metrics
+  healthcheck:
+    test: ["CMD", "/usr/local/bin/check-queue.sh"]
+    interval: 60s
 ```
 
-</details>
+```bash
+# check-queue.sh (inside postfix-incoming)
+#!/bin/bash
+QSIZE=$(mailq 2>/dev/null | grep -c "^[A-F0-9]" || echo 0)
+echo $QSIZE > /var/metrics/queue_size
+[ $QSIZE -lt 500 ]  # Exit non-zero if critical
+```
+
+The batch container reads `/var/metrics/queue_size` and alerts to Sentry if thresholds exceeded.
 
 ---
 
-## Part 7: Mail Archiving (Piler)
+## Part 7: Mail Archiving
 
-### Overview
+**Deferred to future issue.** For MVP, incoming mail is stored in the `messages` table with 7-day retention for spam queue.
 
-[Piler](https://www.mailpiler.org/) is used for long-term email archiving with search capabilities. All incoming mail is archived via Postfix's `always_bcc` directive.
-
-### Piler vs MailPit
-
-| Feature | Piler | MailPit |
-|---------|-------|---------|
-| **Purpose** | Production archiving | Development/debugging |
-| **Retention** | Years (compliance) | Days |
-| **Search** | Full-text, advanced | Basic |
-| **Scale** | Enterprise | Small volumes |
-| **Auth** | Custom hooks available | Basic auth |
-
-**Decision**: Use Piler for production archiving; MailPit remains for local dev environments.
-
-### ModTools Integration Options
-
-Piler has a REST API for automation and custom authentication hooks. Integration approaches:
-
-1. **Iframe embed** (simplest)
-   - Embed Piler's web UI in a ModTools modal
-   - Uses Piler's native search interface
-   - Requires SSO via custom auth hook
-
-2. **API integration** (more seamless)
-   - Use Piler REST API to search/retrieve messages
-   - Display results in native ModTools components
-   - More development work but better UX
-
-3. **Deep link** (recommended for MVP)
-   - Link from ModTools to Piler with pre-filled search parameters
-   - User ID, email address, or date range
-   - Opens Piler in new tab with relevant context
-
-<details>
-<summary><strong>Piler Auth Hook for ModTools SSO</strong></summary>
-
-In Piler's `config-site.php`, add custom authentication that validates against ModTools session:
-
-```php
-// config-site.php
-$config['CUSTOM_EMAIL_QUERY_FUNCTION'] = 'freegle_email_query';
-
-function freegle_email_query($username) {
-    // Call ModTools API to get user's accessible emails
-    $apiUrl = 'https://api.ilovefreegle.org/api/user/emails';
-    $response = file_get_contents($apiUrl . '?modtools_session=' . $_COOKIE['modtools_session']);
-    $data = json_decode($response, true);
-
-    if ($data && isset($data['emails'])) {
-        return $data['emails'];  // Array of email addresses this mod can search
-    }
-    return [];
-}
-```
-
-</details>
-
-<details>
-<summary><strong>Docker Compose Configuration (Piler)</strong></summary>
-
-```yaml
-piler:
-  image: sutoj/piler:latest
-  container_name: freegle-piler
-  hostname: piler.ilovefreegle.org
-  environment:
-    - PILER_HOSTNAME=piler.ilovefreegle.org
-    - MYSQL_DATABASE=piler
-    - MYSQL_USER=piler
-    - MYSQL_PASSWORD=${PILER_DB_PASSWORD}
-  volumes:
-    - piler-data:/var/piler/store
-    - piler-sphinx:/var/piler/sphinx
-    - ./conf/piler/config-site.php:/etc/piler/config-site.php:ro
-  labels:
-    - "traefik.http.routers.piler.rule=Host(`piler.ilovefreegle.org`)"
-    - "traefik.http.routers.piler.middlewares=auth@docker"
-  profiles:
-    - production
-  depends_on:
-    - percona
-```
-
-</details>
-
-### Postfix Integration
-
-```
-# main.cf - Archive all mail to Piler
-always_bcc = archive@piler.ilovefreegle.org
-```
-
-### Future: Full ModTools Integration
-
-In the longer term, we could move incoming email out of the `messages` table entirely and use Piler as the primary store. This would:
-- Reduce database size
-- Improve search capabilities
-- Enable longer retention periods
-- Leverage Piler's compliance features
-
-This requires building a ModTools component that wraps Piler's API for a seamless experience.
+Future options to explore separately:
+- [Piler](https://www.mailpiler.org/) for long-term archiving with search
+- MailPit for debugging (already used in dev)
+- Postfix `always_bcc` to archive all incoming mail
 
 ---
 
@@ -1063,7 +947,7 @@ Forward TN domain to Postfix. **Why TN first**: 66% of traffic, validates via he
 Forward chat reply addresses. Needs full spam/content checks.
 
 ### Phase 5: Group Messages (2-4 weeks)
-Forward group domain. Complete routing logic with all 11 outcomes.
+Forward group domain. Complete routing logic with all 10 outcomes.
 
 ### Phase 6: Full Cutover
 Update MX records to point directly to Postfix. Disable Exim forwarding.


### PR DESCRIPTION
## Summary
- Add Postfix container configuration for receiving incoming email
- Add Laravel HTTP endpoint for processing incoming mail from Postfix
- Add shadow mode archiving for validation against legacy code

## Components Added

### Postfix Container (`conf/postfix/`)
- Receives mail on port 25 for Freegle domains
- Routes to Laravel via HTTP endpoint
- Uses 'mail' profile (not started by default)

### Laravel HTTP Endpoint
- `IncomingMailController` receives mail from Postfix
- Returns appropriate HTTP codes for Postfix retry behavior
- Processes via `IncomingMailService`

### Shadow Mode Archiving
- Legacy `incoming.php` archives emails when directory exists
- `mail:incoming:replay` command validates Laravel against legacy

## Deployment Status
- **Postfix container**: Configured but not receiving mail (MX records unchanged)
- **Archiving**: Ready to deploy to production via iznik-server PR #48
- **MX switchover**: Safe to do after validation completes

## Test Plan
1. Deploy archiving to production (create `/var/lib/freegle/incoming-archive`)
2. Collect sample emails for validation
3. Replay through Laravel to compare routing decisions
4. Once validated, update MX records to point to Docker container

Relates to: Incoming email migration plan