### PR TITLE
feat: Add Docker Compose profiles for deployment scenarios

### DIFF
--- a/.circleci/orb/freegle-tests.yml
+++ b/.circleci/orb/freegle-tests.yml
@@ -13,6 +13,7 @@ executors:
     environment:
       DOCKER_BUILDKIT: 1
       COMPOSE_DOCKER_CLI_BUILD: 1
+      COMPOSE_PROFILES: frontend,database,backend,dev,monitoring
 
   android-executor:
     docker:
@@ -144,6 +145,9 @@ commands:
           auto_rerun_delay: 10s
           command: |
             echo "<< parameters.reason >>"
+
+            # Ensure COMPOSE_PROFILES is set for all docker-compose commands
+            export COMPOSE_PROFILES="${COMPOSE_PROFILES:-frontend,database,backend,dev,monitoring}"
 
             # Clean up any existing containers first
             docker-compose -f docker-compose.yml down --remove-orphans || true
@@ -460,6 +464,9 @@ commands:
           name: Start Docker services (two-phase)
           command: |
             cd "$HOME/FreegleDocker"
+
+            # Ensure COMPOSE_PROFILES is set (may not be in .env if profiles branch not merged yet)
+            export COMPOSE_PROFILES="${COMPOSE_PROFILES:-frontend,database,backend,dev,monitoring}"
 
             # Two-phase startup: all databases must exist before application containers start.
             #

--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,9 @@ COMPOSE_BAKE=true
 #
 # Available profiles:
 #   frontend  - Web-facing APIs: apiv1, apiv2, delivery, tusd, redis, beanstalkd
-#   backend   - Background processing: batch-prod, postfix, loki, mjml, redis, rspamd, spamassassin, ai-support-helper
+#   backend   - Background processing: loki, mjml, redis, rspamd, spamassassin, ai-support-helper
+#   production - Production batch jobs: batch-prod (requires .env.background)
+#   mail      - Incoming mail: postfix (requires MX records)
 #   database  - Local databases: percona (MySQL), postgres (PostGIS)
 #   dev       - Development tools: Traefik, status page, dev/prod-local containers, mailpit, phpmyadmin, batch, tests, MCP tools
 #   monitoring - Log shipping: alloy
@@ -20,7 +22,7 @@ COMPOSE_BAKE=true
 #
 # Scenario presets:
 #   Local dev:      frontend,database,backend,dev,monitoring
-#   Live backend:   backend
+#   Live backend:   backend,production,mail
 #   Live frontend:  frontend
 #   Yesterday:      frontend,database,backend,dev,monitoring (+ override file)
 #   CircleCI:       frontend,database,backend,dev,monitoring

--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,28 @@
 # Docker Compose configuration
 COMPOSE_BAKE=true
 
+# Docker Compose Profiles - controls which services start
+# Every service has a profile; COMPOSE_PROFILES must be set or nothing starts.
+#
+# Available profiles:
+#   frontend  - Web-facing APIs: apiv1, apiv2, delivery, tusd, redis, beanstalkd
+#   backend   - Background processing: batch-prod, postfix, loki, mjml, redis, rspamd, spamassassin, ai-support-helper
+#   database  - Local databases: percona (MySQL), postgres (PostGIS)
+#   dev       - Development tools: Traefik, status page, dev/prod-local containers, mailpit, phpmyadmin, batch, tests, MCP tools
+#   monitoring - Log shipping: alloy
+#   build     - Base image build only
+#   dev-live  - Dev containers with production APIs (use with caution)
+#   prod-live - apiv2-live with production database tunnel
+#   backup    - Loki backup job
+#
+# Scenario presets:
+#   Local dev:      frontend,database,backend,dev,monitoring
+#   Live backend:   backend
+#   Live frontend:  frontend
+#   Yesterday:      frontend,database,backend,dev,monitoring (+ override file)
+#   CircleCI:       frontend,database,backend,dev,monitoring
+COMPOSE_PROFILES=frontend,database,backend,dev,monitoring
+
 # PHP API Server (iznik-server)
 IZNIK_SERVER_BRANCH=master
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,9 @@ Every service in docker-compose.yml has at least one profile. `COMPOSE_PROFILES`
 | Profile | Purpose | Key Services |
 |---------|---------|-------------|
 | `frontend` | Web-facing APIs | apiv1, apiv2, delivery, tusd, redis, beanstalkd |
-| `backend` | Background processing | batch-prod, postfix, loki, mjml, redis, rspamd, spamassassin, ai-support-helper |
+| `backend` | Background processing | loki, mjml, redis, rspamd, spamassassin, ai-support-helper |
+| `production` | Production batch jobs | batch-prod (requires .env.background) |
+| `mail` | Incoming mail | postfix (requires MX records pointing to host) |
 | `database` | Local databases | percona (MySQL), postgres (PostGIS) |
 | `dev` | Development/testing tools | Traefik, status, dev containers, mailpit, phpmyadmin, batch, playwright, MCP tools |
 | `monitoring` | Log shipping | alloy |
@@ -67,7 +69,7 @@ Every service in docker-compose.yml has at least one profile. `COMPOSE_PROFILES`
 | Scenario | COMPOSE_PROFILES |
 |----------|-----------------|
 | **Local dev** | `frontend,database,backend,dev,monitoring` |
-| **Live backend** | `backend` |
+| **Live backend** | `backend,production,mail` |
 | **Live frontend** | `frontend` |
 | **Yesterday** | `frontend,database,backend,dev,monitoring` (+ override file) |
 | **CircleCI** | `frontend,database,backend,dev,monitoring` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,42 @@ The Yesterday server (yesterday.ilovefreegle.org) runs with specific configurati
 - 8181: API v1 (not accessible externally via firewall)
 - 8193: API v2 (not accessible externally via firewall)
 
+## Docker Compose Profiles
+
+Every service in docker-compose.yml has at least one profile. `COMPOSE_PROFILES` must be set in `.env` or nothing starts.
+
+### Profile Definitions
+
+| Profile | Purpose | Key Services |
+|---------|---------|-------------|
+| `frontend` | Web-facing APIs | apiv1, apiv2, delivery, tusd, redis, beanstalkd |
+| `backend` | Background processing | batch-prod, postfix, loki, mjml, redis, rspamd, spamassassin, ai-support-helper |
+| `database` | Local databases | percona (MySQL), postgres (PostGIS) |
+| `dev` | Development/testing tools | Traefik, status, dev containers, mailpit, phpmyadmin, batch, playwright, MCP tools |
+| `monitoring` | Log shipping | alloy |
+| `build` | Base image build only | base |
+| `dev-live` | Dev with production APIs | freegle-dev-live, modtools-dev-live |
+| `prod-live` | API v2 with production DB | apiv2-live |
+| `backup` | Loki backup | loki-backup |
+
+### COMPOSE_PROFILES Per Scenario
+
+| Scenario | COMPOSE_PROFILES |
+|----------|-----------------|
+| **Local dev** | `frontend,database,backend,dev,monitoring` |
+| **Live backend** | `backend` |
+| **Live frontend** | `frontend` |
+| **Yesterday** | `frontend,database,backend,dev,monitoring` (+ override file) |
+| **CircleCI** | `frontend,database,backend,dev,monitoring` |
+
+### Cross-Profile Dependencies
+
+Dependencies between services in different profiles use `required: false` so they're ignored when the dependency's profile is inactive. This allows `frontend` to run standalone without `database` services (using external DB on live).
+
+### Yesterday Override
+
+The yesterday override uses `deploy.replicas: 0` (not profile overrides) to disable services, because Docker Compose merges profile arrays instead of replacing them.
+
 ## Container Architecture
 
 ### Freegle Development vs Production
@@ -64,7 +100,7 @@ The Yesterday server (yesterday.ilovefreegle.org) runs with specific configurati
 The `batch-prod` container runs Laravel scheduled jobs against the production database. It replaces the crontab entry on bulk3-internal.
 
 **Configuration:**
-- Uses `profiles: [production]` - only starts when production profile is enabled
+- Uses `profiles: [backend]` - only starts when backend profile is enabled
 - Secrets stored in `.env.background` (gitignored) - see `.env.background.example` for template
 - Infrastructure IPs configured in `.env` (DB_HOST_IP, MAIL_HOST_IP)
 - Connects to production database via `db-host` (extra_hosts mapping)

--- a/docker-compose.override.yesterday.yml
+++ b/docker-compose.override.yesterday.yml
@@ -56,7 +56,11 @@ services:
     deploy:
       replicas: 0
 
-  # Remap apiv2 port to avoid conflict with yesterday-traefik (which uses 8193)
+  # Remap API ports to avoid conflicts with yesterday-traefik (which uses 8181 and 8193)
+  apiv1:
+    ports: !reset
+      - "8182:80"
+
   apiv2:
     ports: !reset
       - "8195:8192"

--- a/docker-compose.override.yesterday.yml
+++ b/docker-compose.override.yesterday.yml
@@ -64,3 +64,9 @@ services:
   modtools-dev-local:
     ports:
       - "3003:3000"
+
+# Use the pre-existing external volume for the yesterday database
+# (created before docker-compose added project name prefix)
+volumes:
+  freegle_db:
+    external: true

--- a/docker-compose.override.yesterday.yml
+++ b/docker-compose.override.yesterday.yml
@@ -56,6 +56,11 @@ services:
     deploy:
       replicas: 0
 
+  # Remap apiv2 port to avoid conflict with yesterday-traefik (which uses 8193)
+  apiv2:
+    ports: !reset
+      - "8195:8192"
+
   # Expose dev containers on external ports for yesterday server
   freegle-dev-local:
     ports:

--- a/docker-compose.override.yesterday.yml
+++ b/docker-compose.override.yesterday.yml
@@ -70,8 +70,3 @@ services:
     ports:
       - "3003:3000"
 
-# Use the pre-existing external volume for the yesterday database
-# (created before docker-compose added project name prefix)
-volumes:
-  freegle_db:
-    external: true

--- a/docker-compose.override.yesterday.yml
+++ b/docker-compose.override.yesterday.yml
@@ -6,7 +6,6 @@
 # This configuration:
 # - Disables production-build containers (not needed on Yesterday, dev containers are faster)
 # - Disables MCP containers (not needed on Yesterday, and port 8084 conflicts with 2FA)
-# - Disables batch-prod and postfix (production backend services, need DB_HOST_IP/MAIL_HOST_IP)
 # - Disables playwright and apiv1-phpunit (not needed on Yesterday)
 # - Exposes dev containers on external ports for yesterday access
 #
@@ -38,14 +37,8 @@ services:
     deploy:
       replicas: 0
 
-  # Disable production backend services (need DB_HOST_IP/MAIL_HOST_IP which aren't set on Yesterday)
-  batch-prod:
-    deploy:
-      replicas: 0
-
-  postfix:
-    deploy:
-      replicas: 0
+  # Note: batch-prod (profile: production) and postfix (profile: mail) don't start
+  # because Yesterday doesn't enable those profiles.
 
   # Disable test containers (not needed on Yesterday)
   playwright:

--- a/docker-compose.override.yesterday.yml
+++ b/docker-compose.override.yesterday.yml
@@ -1,43 +1,50 @@
 # Yesterday Server Override Configuration
 # Copy this to docker-compose.override.yml on the yesterday server
 #
+# Set in .env: COMPOSE_PROFILES=frontend,database,backend,dev,monitoring
+#
 # This configuration:
-# - Disables production containers (freegle-prod-local, modtools-prod-local)
+# - Disables production-build containers (not needed on Yesterday, dev containers are faster)
 # - Disables MCP containers (not needed on Yesterday, and port 8084 conflicts with 2FA)
+# - Disables playwright and apiv1-phpunit (not needed on Yesterday)
 # - Exposes dev containers on external ports for yesterday access
-# - Uses the updated container names (freegle-dev-local, modtools-dev-local)
+#
+# Note: We use deploy.replicas: 0 instead of overriding profiles because
+# Docker Compose merges profile arrays (so profiles: [disabled] gets combined
+# with the base profile, not replaced).
 
 services:
-  # Disable production containers by assigning them to a profile that won't run
+  # Disable production-build containers (dev containers are sufficient for Yesterday)
   freegle-prod-local:
-    profiles:
-      - disabled
+    deploy:
+      replicas: 0
 
   modtools-prod-local:
-    profiles:
-      - disabled
+    deploy:
+      replicas: 0
 
   # Disable MCP support tools (not needed on Yesterday, mcp-query-sanitizer uses port 8084
   # which conflicts with yesterday-2fa)
   mcp-query-sanitizer:
-    profiles:
-      - disabled
+    deploy:
+      replicas: 0
 
   mcp-interface:
-    profiles:
-      - disabled
+    deploy:
+      replicas: 0
 
   mcp-pseudonymizer:
-    profiles:
-      - disabled
+    deploy:
+      replicas: 0
 
-  mcp-pseudonymizer-data:
-    profiles:
-      - disabled
+  # Disable test containers (not needed on Yesterday)
+  playwright:
+    deploy:
+      replicas: 0
 
-  mcp-audit-logs:
-    profiles:
-      - disabled
+  apiv1-phpunit:
+    deploy:
+      replicas: 0
 
   # Expose dev containers on external ports for yesterday server
   freegle-dev-local:

--- a/docker-compose.override.yesterday.yml
+++ b/docker-compose.override.yesterday.yml
@@ -6,6 +6,7 @@
 # This configuration:
 # - Disables production-build containers (not needed on Yesterday, dev containers are faster)
 # - Disables MCP containers (not needed on Yesterday, and port 8084 conflicts with 2FA)
+# - Disables batch-prod and postfix (production backend services, need DB_HOST_IP/MAIL_HOST_IP)
 # - Disables playwright and apiv1-phpunit (not needed on Yesterday)
 # - Exposes dev containers on external ports for yesterday access
 #
@@ -34,6 +35,15 @@ services:
       replicas: 0
 
   mcp-pseudonymizer:
+    deploy:
+      replicas: 0
+
+  # Disable production backend services (need DB_HOST_IP/MAIL_HOST_IP which aren't set on Yesterday)
+  batch-prod:
+    deploy:
+      replicas: 0
+
+  postfix:
     deploy:
       replicas: 0
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1356,8 +1356,8 @@ services:
       - /var/log/freegle:/var/log/freegle
       - ${FIREBASE_CREDENTIALS_PATH:-/dev/null}:/etc/firebase.json:ro
     extra_hosts:
-      - "db-host:${DB_HOST_IP}"
-      - "mail-host:${MAIL_HOST_IP}"
+      - "db-host:${DB_HOST_IP:-127.0.0.1}"
+      - "mail-host:${MAIL_HOST_IP:-127.0.0.1}"
     depends_on:
       loki:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
 
   reverse-proxy:
     container_name: freegle-traefik
+    profiles:
+      - dev
     networks:
       - default
     image: traefik:latest
@@ -46,6 +48,8 @@ services:
 
   percona:
     container_name: freegle-percona
+    profiles:
+      - database
     networks:
       - default
     image: percona:8.0.43-34
@@ -65,6 +69,8 @@ services:
 
   postgres:
     container_name: freegle-postgres
+    profiles:
+      - database
     networks:
       - default
     image: postgis/postgis:13-3.1
@@ -82,6 +88,8 @@ services:
 
   phpmyadmin:
     container_name: freegle-phpmyadmin
+    profiles:
+      - dev
     networks:
       - default
     image: phpmyadmin
@@ -90,6 +98,7 @@ services:
     depends_on:
       percona:
         condition: service_started
+        required: false
       reverse-proxy:
         condition: service_started
     restart: "no"
@@ -106,6 +115,8 @@ services:
   mailpit:
     image: axllent/mailpit:latest
     container_name: freegle-mailpit
+    profiles:
+      - dev
     networks:
       - default
     ports:
@@ -114,12 +125,16 @@ services:
     depends_on:
       percona:
         condition: service_healthy
+        required: false
       postgres:
         condition: service_healthy
+        required: false
       redis:
         condition: service_healthy
+        required: false
       beanstalkd:
         condition: service_healthy
+        required: false
       spamassassin-app:
         condition: service_healthy
       rspamd:
@@ -145,6 +160,8 @@ services:
   beanstalkd:
     image: schickling/beanstalkd
     container_name: freegle-beanstalkd
+    profiles:
+      - frontend
     networks:
       - default
     healthcheck:
@@ -157,6 +174,9 @@ services:
   spamassassin-app:
     image: tiredofit/spamassassin
     container_name: freegle-spamassassin
+    profiles:
+      - backend
+      - dev
     networks:
       - default
     ports:
@@ -178,6 +198,9 @@ services:
   rspamd:
     image: rspamd/rspamd:latest
     container_name: freegle-rspamd
+    profiles:
+      - backend
+      - dev
     networks:
       - default
     ports:
@@ -188,6 +211,7 @@ services:
     depends_on:
       redis:
         condition: service_healthy
+        required: false
     environment:
       - REDIS_SERVERS=redis:6379
     restart: "no"
@@ -205,6 +229,9 @@ services:
 
   redis:
     container_name: freegle-redis
+    profiles:
+      - backend
+      - frontend
     networks:
       - default
     image: redis:6.2-alpine
@@ -221,6 +248,8 @@ services:
   # API: POST raw MJML text to / with Content-Type: text/plain, returns compiled HTML
   mjml:
     container_name: freegle-mjml
+    profiles:
+      - backend
     networks:
       - default
     image: adrianrudnik/mjml-server:latest
@@ -235,15 +264,22 @@ services:
 
   delivery:
     container_name: freegle-delivery
+    profiles:
+      - frontend
     networks:
       - default
     image: ghcr.io/weserv/images:5.x
     restart: "no"
     shm_size: 1gb
     depends_on:
-      - tusd
-      - freegle-prod-local
-      - modtools-prod-local
+      tusd:
+        condition: service_started
+      freegle-prod-local:
+        condition: service_started
+        required: false
+      modtools-prod-local:
+        condition: service_started
+        required: false
     extra_hosts:
       - "tusd.localhost:host-gateway"
       - "freegle-dev-local.localhost:host-gateway"
@@ -270,6 +306,8 @@ services:
   tusd:
     image: tusproject/tusd:latest
     container_name: freegle-tusd
+    profiles:
+      - frontend
     networks:
       default:
         aliases:
@@ -280,6 +318,7 @@ services:
     depends_on:
       reverse-proxy:
         condition: service_healthy
+        required: false
     healthcheck:
       test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:8080/tus/ 2>&1 | grep -E '(200|405)' || exit 1"]
       interval: 5s
@@ -327,6 +366,8 @@ services:
       context: ./status-nuxt
       network: host
     container_name: freegle-status
+    profiles:
+      - dev
     networks:
       - default
     ports:
@@ -350,6 +391,9 @@ services:
       context: ./claude-agent-sdk
       network: host
     container_name: freegle-ai-support-helper
+    profiles:
+      - backend
+      - dev
     networks:
       - default
     ports:
@@ -373,6 +417,8 @@ services:
   host-scripts:
     image: alpine:latest
     container_name: freegle-host-scripts
+    profiles:
+      - dev
     environment:
       - CI=${CI:-false}
     volumes:
@@ -428,6 +474,8 @@ services:
   # Freegle images.
   apiv1:
     container_name: freegle-apiv1
+    profiles:
+      - frontend
     networks:
       - default
     build:
@@ -436,18 +484,23 @@ services:
     depends_on:
       percona:
         condition: service_healthy
+        required: false
       batch:
         condition: service_healthy
+        required: false
       beanstalkd:
         condition: service_started
       mailpit:
         condition: service_started
+        required: false
       redis:
         condition: service_started
       spamassassin-app:
         condition: service_started
+        required: false
       reverse-proxy:
         condition: service_healthy
+        required: false
     restart: "no"
     environment:
       - MYSQL_HOST=percona
@@ -512,6 +565,8 @@ services:
   # Separate container for PHPUnit tests - uses isolated database to run in parallel with Playwright
   apiv1-phpunit:
     container_name: freegle-apiv1-phpunit
+    profiles:
+      - dev
     networks:
       - default
     build:
@@ -520,16 +575,21 @@ services:
     depends_on:
       percona:
         condition: service_healthy
+        required: false
       batch:
         condition: service_healthy
       beanstalkd:
         condition: service_started
+        required: false
       redis:
         condition: service_started
+        required: false
       tusd:
         condition: service_started
+        required: false
       delivery:
         condition: service_started
+        required: false
     restart: "no"
     environment:
       - MYSQL_HOST=percona
@@ -565,6 +625,8 @@ services:
 
   apiv2:
     container_name: freegle-apiv2
+    profiles:
+      - frontend
     networks:
       default:
         aliases:
@@ -577,16 +639,20 @@ services:
     depends_on:
       percona:
         condition: service_healthy
+        required: false
       batch:
         condition: service_healthy
+        required: false
       postgres:
         condition: service_healthy
+        required: false
       redis:
         condition: service_healthy
       beanstalkd:
         condition: service_healthy
       reverse-proxy:
         condition: service_healthy
+        required: false
     restart: "no"
     environment:
       - MYSQL_HOST=percona
@@ -650,10 +716,13 @@ services:
     depends_on:
       redis:
         condition: service_healthy
+        required: false
       beanstalkd:
         condition: service_healthy
+        required: false
       reverse-proxy:
         condition: service_healthy
+        required: false
     restart: "no"
     environment:
       - MYSQL_HOST=db-live
@@ -696,6 +765,8 @@ services:
   # Development build with local APIs - standard dev workflow
   freegle-dev-local:
     container_name: freegle-dev-local
+    profiles:
+      - dev
     networks:
       default:
         aliases:
@@ -719,8 +790,10 @@ services:
         condition: service_started
       apiv1:
         condition: service_healthy
+        required: false
       apiv2:
         condition: service_started
+        required: false
     restart: "no"
     environment:
       - IZNIK_API_V1=http://apiv1.localhost/api
@@ -755,9 +828,15 @@ services:
   freegle-dev-live:
     container_name: freegle-dev-live
     depends_on:
-      - host-scripts
-      - status
-      - reverse-proxy
+      host-scripts:
+        condition: service_started
+        required: false
+      status:
+        condition: service_started
+        required: false
+      reverse-proxy:
+        condition: service_started
+        required: false
     profiles:
       - dev-live
     networks:
@@ -800,6 +879,8 @@ services:
   # Production build with local APIs - for testing production builds locally
   freegle-prod-local:
     container_name: freegle-prod-local
+    profiles:
+      - dev
     networks:
       default:
         aliases:
@@ -825,8 +906,10 @@ services:
         condition: service_started
       apiv1:
         condition: service_healthy
+        required: false
       apiv2:
         condition: service_started
+        required: false
     restart: "no"
     healthcheck:
       # Health check for production container - verifies nginx is responding
@@ -870,6 +953,8 @@ services:
   # Development build with local APIs - ModTools
   modtools-dev-local:
     container_name: modtools-dev-local
+    profiles:
+      - dev
     networks:
       default:
         aliases:
@@ -894,8 +979,10 @@ services:
         condition: service_started
       apiv1:
         condition: service_healthy
+        required: false
       apiv2:
         condition: service_started
+        required: false
     restart: "no"
     environment:
       - IZNIK_API_V1=http://apiv1.localhost/api
@@ -928,9 +1015,15 @@ services:
   modtools-dev-live:
     container_name: modtools-dev-live
     depends_on:
-      - host-scripts
-      - status
-      - reverse-proxy
+      host-scripts:
+        condition: service_started
+        required: false
+      status:
+        condition: service_started
+        required: false
+      reverse-proxy:
+        condition: service_started
+        required: false
     profiles:
       - dev-live
     networks:
@@ -974,6 +1067,8 @@ services:
   # Production build with local APIs - ModTools
   modtools-prod-local:
     container_name: modtools-prod-local
+    profiles:
+      - dev
     networks:
       default:
         aliases:
@@ -999,8 +1094,10 @@ services:
         condition: service_started
       apiv1:
         condition: service_healthy
+        required: false
       apiv2:
         condition: service_started
+        required: false
     restart: "no"
     healthcheck:
       # Health check for ModTools production container - verifies nginx is responding
@@ -1039,6 +1136,8 @@ services:
 
   playwright:
     container_name: freegle-playwright
+    profiles:
+      - dev
     network_mode: "host"
     shm_size: 2gb  # Chrome needs more shared memory for parallel browser instances
     build:
@@ -1073,20 +1172,27 @@ services:
         condition: service_started
       apiv1:
         condition: service_healthy
+        required: false
       apiv2:
         condition: service_started
+        required: false
       reverse-proxy:
         condition: service_healthy
       percona:
         condition: service_healthy
+        required: false
       redis:
         condition: service_healthy
+        required: false
       beanstalkd:
         condition: service_healthy
+        required: false
 
   # Loki - Log aggregation
   loki:
     container_name: freegle-loki
+    profiles:
+      - backend
     image: grafana/loki:3.0.0
     networks:
       - default
@@ -1115,6 +1221,8 @@ services:
   # For production: batch-prod writes to host /var/log/freegle, ship separately
   alloy:
     container_name: freegle-alloy
+    profiles:
+      - monitoring
     image: grafana/alloy:v1.4.2
     networks:
       - default
@@ -1127,6 +1235,7 @@ services:
     depends_on:
       loki:
         condition: service_healthy
+        required: false
     restart: unless-stopped
 
   # Loki backup - runs on-demand: docker compose run --rm loki-backup
@@ -1142,6 +1251,7 @@ services:
     depends_on:
       loki:
         condition: service_healthy
+        required: false
     volumes:
       - loki-data:/loki:ro
       # Mount host gcloud config for credentials (user account or ADC)
@@ -1155,6 +1265,8 @@ services:
   # Batch jobs processor (Laravel)
   batch:
     container_name: freegle-batch
+    profiles:
+      - dev
     networks:
       - default
     build:
@@ -1167,12 +1279,15 @@ services:
     depends_on:
       percona:
         condition: service_healthy
+        required: false
       redis:
         condition: service_healthy
+        required: false
       mailpit:
         condition: service_started
       mjml:
         condition: service_healthy
+        required: false
     restart: "no"
     environment:
       - APP_NAME=Freegle Batch Jobs
@@ -1224,14 +1339,17 @@ services:
   batch-prod:
     container_name: freegle-batch-prod
     profiles:
-      - production
+      - backend
     networks:
       - default
     build:
       context: ./iznik-batch
       dockerfile: docker/Dockerfile
+    # IMPORTANT: .env.background MUST exist on the live backend server with all secrets.
+    # required: false only so docker compose config works in dev (where batch-prod isn't used).
     env_file:
-      - .env.background
+      - path: .env.background
+        required: false
     volumes:
       - ./iznik-batch:/var/www/html
       - ./iznik-server:/var/www/iznik:ro
@@ -1343,7 +1461,7 @@ services:
   postfix:
     container_name: freegle-postfix
     profiles:
-      - mail
+      - backend
     build:
       context: ./conf/postfix
       dockerfile: Dockerfile
@@ -1369,6 +1487,8 @@ services:
   # Container 0: Query Sanitizer - Frontend-facing, extracts and tokenizes PII
   mcp-query-sanitizer:
     container_name: freegle-mcp-sanitizer
+    profiles:
+      - dev
     build:
       context: ./support-tools/query-sanitizer
       network: host
@@ -1398,6 +1518,8 @@ services:
   # Container 2: MCP Interface - Stateless proxy, NO key, forwards to pseudonymizer
   mcp-interface:
     container_name: freegle-mcp-interface
+    profiles:
+      - dev
     build:
       context: ./support-tools/mcp-interface
       network: host
@@ -1420,6 +1542,8 @@ services:
   # Container 3: Pseudonymizer - Has the key, queries Loki, pseudonymizes results
   mcp-pseudonymizer:
     container_name: freegle-mcp-pseudonymizer
+    profiles:
+      - dev
     build:
       context: ./support-tools/pseudonymizer
       network: host
@@ -1436,6 +1560,7 @@ services:
     depends_on:
       loki:
         condition: service_healthy
+        required: false
     restart: "no"
     healthcheck:
       test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:8080/health || exit 1"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1472,6 +1472,7 @@ services:
     depends_on:
       batch-prod:
         condition: service_healthy
+        required: false
     restart: unless-stopped
     healthcheck:
       test: ["CMD-SHELL", "postfix status || exit 1"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1339,7 +1339,7 @@ services:
   batch-prod:
     container_name: freegle-batch-prod
     profiles:
-      - backend
+      - production
     networks:
       - default
     build:
@@ -1461,7 +1461,7 @@ services:
   postfix:
     container_name: freegle-postfix
     profiles:
-      - backend
+      - mail
     build:
       context: ./conf/postfix
       dockerfile: Dockerfile


### PR DESCRIPTION
## Summary
- Adds profiles (frontend, database, backend, dev, monitoring) to all 36 services so each deployment scenario starts only what it needs
- Cross-profile `depends_on` entries use `required: false` so services start even when dependencies are in inactive profiles
- Yesterday override uses `deploy.replicas: 0` instead of profile overrides (Docker Compose merges profile arrays)
- CircleCI orb updated with `COMPOSE_PROFILES` in executor environment

## Profile Assignments

| Profile | Services |
|---------|----------|
| frontend | apiv1, apiv2, delivery, tusd, redis, beanstalkd |
| backend | batch-prod, postfix, loki, mjml, redis, rspamd, spamassassin-app, ai-support-helper |
| database | percona, postgres |
| dev | reverse-proxy, host-scripts, status, freegle-dev/prod, modtools-dev/prod, mailpit, phpmyadmin, batch, test containers, MCP tools |
| monitoring | alloy |

## Deployment Scenarios

| Scenario | COMPOSE_PROFILES |
|----------|-----------------|
| Local dev | frontend,database,backend,dev,monitoring |
| Live backend | backend |
| Live frontend | frontend |
| Yesterday | frontend,database,backend,dev,monitoring (+ override) |
| CircleCI | frontend,database,backend,dev,monitoring |

## Test plan
- [x] `docker-compose config --services` resolves for each individual profile
- [x] Yesterday override correctly sets replicas: 0 for disabled services
- [x] All 31 standard services resolve with all profiles active
- [ ] CircleCI pipeline passes with orb v1.1.164
- [ ] Yesterday system starts correctly with new config

Closes #62