### PR TITLE
fix: Add SPF verification, rspamd fuzzy hashing, drop deleted user mail

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 !/conf/alloy/
 !/conf/logrotate/
 !/conf/postfix/
+!/conf/rspamd/
 /.claude/settings.local.json
 /logs/
 /.idea/prettier.xml

--- a/conf/postfix/Dockerfile
+++ b/conf/postfix/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.19
 
-RUN apk add --no-cache postfix postfix-pcre bash curl openssl
+RUN apk add --no-cache postfix postfix-pcre bash curl openssl postfix-policyd-spf-perl
 
 # Generate self-signed TLS cert for opportunistic STARTTLS
 RUN openssl req -x509 -newkey rsa:2048 \

--- a/conf/postfix/main.cf
+++ b/conf/postfix/main.cf
@@ -44,6 +44,17 @@ smtpd_tls_loglevel = 1
 # Relay restrictions - only accept mail for our domains
 smtpd_relay_restrictions = permit_mynetworks, reject_unauth_destination
 
+# SPF verification on incoming mail
+# Rejects mail that FAILS SPF (domain has SPF record with -all, sending IP not authorized)
+# Accepts mail with no SPF record (SPF NONE) - many legitimate domains don't use SPF
+# Accepts SPF SOFTFAIL with Received-SPF header (domains using ~all, including Freegle's own)
+# The Received-SPF header is used by rspamd for spam scoring
+smtpd_recipient_restrictions =
+    permit_mynetworks,
+    reject_unauth_destination,
+    check_policy_service unix:private/policyd-spf
+policyd-spf_time_limit = 3600
+
 # Queue settings
 maximal_queue_lifetime = 1d
 bounce_queue_lifetime = 1d

--- a/conf/postfix/master.cf
+++ b/conf/postfix/master.cf
@@ -46,5 +46,20 @@ postlog   unix-dgram n  -       n       -       1       postlogd
 # Alternative: Use HTTP endpoint instead of pipe (see comments below)
 # ==========================================================================
 
+# ==========================================================================
+# SPF policy daemon - checks sender SPF records
+# ==========================================================================
+# Rejects SPF FAIL (spoofed sender), accepts SPF NONE (no record),
+# accepts SPF SOFTFAIL with Received-SPF header added.
+#
+# Note: Freegle's own SPF records use ~all (softfail) not -all (hard fail).
+# SPF softfail adds a Received-SPF header which rspamd uses for scoring,
+# but does not reject at SMTP level. To get hard rejection of spoofed
+# Freegle emails, change the DNS SPF record to use -all.
+# ==========================================================================
+
+policyd-spf  unix  -       n       n       -       0       spawn
+  user=nobody argv=/usr/bin/postfix-policyd-spf-perl
+
 freegle   unix  -       n       n       -       4       pipe
   flags=F user=mail-handler argv=/usr/local/bin/freegle-mail-handler ${sender} ${recipient}

--- a/conf/rspamd/local.d/fuzzy_check.conf
+++ b/conf/rspamd/local.d/fuzzy_check.conf
@@ -1,0 +1,51 @@
+# Freegle local fuzzy hash storage
+#
+# Uses rspamd's built-in fuzzy storage worker (localhost:11335, Redis backend).
+# Hashes expire after 90 days (configured in the fuzzy worker default).
+#
+# This enables detection of similar messages sent to multiple groups,
+# even when the content is slightly mutated (e.g. different group names).
+# The shingles algorithm matches if >50% of text shingles overlap.
+#
+# Learning: use rspamc to teach the fuzzy storage:
+#   rspamc -f 1 -w 10 fuzzy_add <message>   # Flag 1 = denied (spam)
+#   rspamc -f 2 -w 5  fuzzy_add <message>   # Flag 2 = probable spam
+#   rspamc -f 1 fuzzy_del <message>          # Remove from denied
+#
+# The default rspamd.com rule (read-only) is preserved for global intelligence.
+# This local rule adds our own learning capability.
+
+rule "local" {
+    # Point to the built-in fuzzy storage worker
+    servers = "localhost:11335";
+    algorithm = "mumhash";
+
+    # Allow both reading and writing (learning)
+    read_only = false;
+
+    # Minimum message size to hash (bytes) - skip tiny messages
+    min_bytes = 300;
+
+    # Short text direct hash for small messages that can't generate shingles
+    short_text_direct_hash = true;
+    min_length = 32;
+
+    # Fuzzy flag definitions
+    fuzzy_map {
+        # Flag 1: Known spam/phishing - high weight rejection
+        LOCAL_FUZZY_DENIED {
+            max_score = 20.0;
+            flag = 1;
+        }
+        # Flag 2: Probable spam - moderate weight
+        LOCAL_FUZZY_PROB {
+            max_score = 10.0;
+            flag = 2;
+        }
+        # Flag 3: Known good - whitelist
+        LOCAL_FUZZY_WHITE {
+            max_score = 2.0;
+            flag = 3;
+        }
+    }
+}

--- a/conf/rspamd/local.d/fuzzy_group.conf
+++ b/conf/rspamd/local.d/fuzzy_group.conf
@@ -1,0 +1,19 @@
+# Local fuzzy hash symbol scores
+#
+# These scores are for our local fuzzy storage (taught by moderators).
+# The default rspamd.com fuzzy symbols (FUZZY_DENIED etc.) keep their defaults.
+
+symbols {
+    "LOCAL_FUZZY_DENIED" {
+        weight = 12.0;
+        description = "Matches locally learned spam/phishing pattern";
+    }
+    "LOCAL_FUZZY_PROB" {
+        weight = 5.0;
+        description = "Matches locally learned probable spam pattern";
+    }
+    "LOCAL_FUZZY_WHITE" {
+        weight = -3.0;
+        description = "Matches locally learned good content pattern";
+    }
+}

--- a/conf/rspamd/local.d/policies_group.conf
+++ b/conf/rspamd/local.d/policies_group.conf
@@ -1,0 +1,28 @@
+# Override SPF symbol weights
+#
+# Defaults are too lenient: R_SPF_FAIL=1.0, R_SPF_SOFTFAIL=0.0
+# Increase penalties since SPF failures on domains that HAVE SPF records
+# are a strong signal of spoofing.
+
+symbols {
+    "R_SPF_FAIL" {
+        weight = 6.0;
+        description = "SPF verification failed (sender IP not authorized, domain uses -all)";
+    }
+    "R_SPF_SOFTFAIL" {
+        weight = 3.0;
+        description = "SPF verification soft-failed (sender IP not authorized, domain uses ~all)";
+    }
+    "R_SPF_NEUTRAL" {
+        weight = 0.0;
+        description = "SPF policy is neutral";
+    }
+    "R_SPF_ALLOW" {
+        weight = -0.5;
+        description = "SPF verification allows sending";
+    }
+    "R_SPF_DNSFAIL" {
+        weight = 1.0;
+        description = "SPF DNS lookup failed";
+    }
+}

--- a/conf/rspamd/local.d/settings.conf
+++ b/conf/rspamd/local.d/settings.conf
@@ -1,0 +1,13 @@
+# Rspamd settings - per-sender/recipient scan overrides
+#
+# TrashNothing legitimately cross-posts the same message to multiple
+# Freegle groups. Exempt TN messages from local fuzzy hash matching
+# to avoid false positives on legitimate cross-posts.
+
+trashnothing {
+    priority = 10;
+    from = "@user.trashnothing.com";
+    apply {
+        groups_disabled = ["fuzzy"];
+    }
+}

--- a/iznik-batch/app/Services/Mail/Incoming/IncomingMailService.php
+++ b/iznik-batch/app/Services/Mail/Incoming/IncomingMailService.php
@@ -2103,6 +2103,17 @@ class IncomingMailService
             return $this->dropped("Volunteers message from unknown user");
         }
 
+        // Drop messages from deleted users - their account no longer exists
+        if ($user->deleted !== null) {
+            Log::warning('Volunteers message from deleted user', [
+                'from' => $email->fromAddress,
+                'user_id' => $user->id,
+                'deleted' => $user->deleted,
+            ]);
+
+            return $this->dropped("Volunteers message from deleted user");
+        }
+
         // Filter auto-replies for -auto@ addresses (only -volunteers@ allows auto-replies through)
         if (! $email->isToVolunteers && $email->isAutoReply()) {
             Log::debug('Dropping auto-reply to auto address');

--- a/iznik-batch/tests/Unit/Services/Mail/Incoming/IncomingMailServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/Mail/Incoming/IncomingMailServiceTest.php
@@ -2504,6 +2504,44 @@ class IncomingMailServiceTest extends TestCase
         $this->assertEquals(RoutingResult::DROPPED, $result);
     }
 
+    public function test_volunteers_message_from_deleted_user_is_dropped(): void
+    {
+        $group = $this->createTestGroup();
+        $user = $this->createTestUser(['email_preferred' => $this->uniqueEmail('vol-deleted')]);
+        $this->createMembership($user, $group);
+
+        // Mark user as deleted (soft delete with timestamp)
+        $user->update(['deleted' => now()]);
+
+        $userEmail = $user->emails->first()->email;
+        $groupName = $group->nameshort;
+
+        $email = $this->createMinimalEmail([
+            'From' => $userEmail,
+            'To' => "{$groupName}-volunteers@groups.ilovefreegle.org",
+            'Subject' => 'Help please',
+        ], 'I need help with my item.');
+
+        $parsed = $this->parser->parse(
+            $email,
+            $userEmail,
+            "{$groupName}-volunteers@groups.ilovefreegle.org"
+        );
+
+        $result = $this->service->route($parsed);
+
+        // Deleted users should be dropped - their account no longer exists
+        $this->assertEquals(RoutingResult::DROPPED, $result);
+
+        // Verify no chat message was created
+        $chatMessage = DB::table('chat_messages')
+            ->where('userid', $user->id)
+            ->orderBy('id', 'desc')
+            ->first();
+
+        $this->assertNull($chatMessage, 'No chat message should be created for a deleted user');
+    }
+
     public function test_volunteers_spam_keyword_flagged_for_review(): void
     {
         $group = $this->createTestGroup();


### PR DESCRIPTION
## Summary
- SPF verification in postfix (reject hard fail, header for softfail)
- Rspamd fuzzy hashing with local storage (exempt TrashNothing)
- Drop volunteer messages from deleted users
- Responds to phishing attack with spoofed emails

## Test plan
- [ ] CI passes (PHPUnit test for deleted user mail)
- [ ] Postfix container builds with SPF support