### PR TITLE
fix: Require explicit from address in MjmlMailable envelope

### DIFF
--- a/iznik-batch/app/Mail/Digest/MultipleDigest.php
+++ b/iznik-batch/app/Mail/Digest/MultipleDigest.php
@@ -8,6 +8,8 @@ use App\Mail\Traits\TrackableEmail;
 use App\Models\Group;
 use App\Models\User;
 use App\Support\EmojiUtils;
+use Illuminate\Mail\Mailables\Address;
+use Illuminate\Mail\Mailables\Envelope;
 use Illuminate\Support\Collection;
 
 class MultipleDigest extends MjmlMailable
@@ -79,6 +81,17 @@ class MultipleDigest extends MjmlMailable
     /**
      * Get the subject line.
      */
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            from: new Address(
+                config('freegle.mail.noreply_addr'),
+                config('freegle.branding.name')
+            ),
+            subject: $this->getSubject(),
+        );
+    }
+
     protected function getSubject(): string
     {
         $count = $this->messages->count();

--- a/iznik-batch/app/Mail/Digest/SingleDigest.php
+++ b/iznik-batch/app/Mail/Digest/SingleDigest.php
@@ -9,6 +9,8 @@ use App\Models\Group;
 use App\Models\Message;
 use App\Models\User;
 use App\Support\EmojiUtils;
+use Illuminate\Mail\Mailables\Address;
+use Illuminate\Mail\Mailables\Envelope;
 
 class SingleDigest extends MjmlMailable
 {
@@ -85,6 +87,17 @@ class SingleDigest extends MjmlMailable
     /**
      * Get the subject line.
      */
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            from: new Address(
+                config('freegle.mail.noreply_addr'),
+                config('freegle.branding.name')
+            ),
+            subject: $this->getSubject(),
+        );
+    }
+
     protected function getSubject(): string
     {
         return $this->message->subject;

--- a/iznik-batch/app/Mail/Digest/UnifiedDigest.php
+++ b/iznik-batch/app/Mail/Digest/UnifiedDigest.php
@@ -8,6 +8,8 @@ use App\Mail\Traits\TrackableEmail;
 use App\Models\User;
 use App\Services\UnifiedDigestService;
 use App\Support\EmojiUtils;
+use Illuminate\Mail\Mailables\Address;
+use Illuminate\Mail\Mailables\Envelope;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 
@@ -87,6 +89,17 @@ class UnifiedDigest extends MjmlMailable
      *
      * Format: "5 new posts near you - Sofa, Coffee table, Books..."
      */
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            from: new Address(
+                config('freegle.mail.noreply_addr'),
+                config('freegle.branding.name')
+            ),
+            subject: $this->getSubject(),
+        );
+    }
+
     protected function getSubject(): string
     {
         $count = $this->posts->count();

--- a/iznik-batch/app/Mail/Donation/AskForDonation.php
+++ b/iznik-batch/app/Mail/Donation/AskForDonation.php
@@ -6,6 +6,8 @@ use App\Mail\MjmlMailable;
 use App\Mail\Traits\LoggableEmail;
 use App\Mail\Traits\TrackableEmail;
 use App\Models\User;
+use Illuminate\Mail\Mailables\Address;
+use Illuminate\Mail\Mailables\Envelope;
 
 class AskForDonation extends MjmlMailable
 {
@@ -80,6 +82,17 @@ class AskForDonation extends MjmlMailable
     /**
      * Get the subject line.
      */
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            from: new Address(
+                config('freegle.mail.noreply_addr'),
+                config('freegle.branding.name')
+            ),
+            subject: $this->getSubject(),
+        );
+    }
+
     protected function getSubject(): string
     {
         return $this->itemSubject

--- a/iznik-batch/app/Mail/Donation/DonationThankYou.php
+++ b/iznik-batch/app/Mail/Donation/DonationThankYou.php
@@ -6,6 +6,8 @@ use App\Mail\MjmlMailable;
 use App\Mail\Traits\LoggableEmail;
 use App\Mail\Traits\TrackableEmail;
 use App\Models\User;
+use Illuminate\Mail\Mailables\Address;
+use Illuminate\Mail\Mailables\Envelope;
 
 class DonationThankYou extends MjmlMailable
 {
@@ -65,6 +67,17 @@ class DonationThankYou extends MjmlMailable
     /**
      * Get the subject line.
      */
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            from: new Address(
+                config('freegle.mail.noreply_addr'),
+                config('freegle.branding.name')
+            ),
+            subject: $this->getSubject(),
+        );
+    }
+
     protected function getSubject(): string
     {
         return 'Thank you for your donation to Freegle!';

--- a/iznik-batch/app/Mail/Message/DeadlineReached.php
+++ b/iznik-batch/app/Mail/Message/DeadlineReached.php
@@ -7,6 +7,8 @@ use App\Mail\Traits\LoggableEmail;
 use App\Models\Group;
 use App\Models\Message;
 use App\Models\User;
+use Illuminate\Mail\Mailables\Address;
+use Illuminate\Mail\Mailables\Envelope;
 
 class DeadlineReached extends MjmlMailable
 {
@@ -70,6 +72,17 @@ class DeadlineReached extends MjmlMailable
                 'groupName' => $groupName,
             ])
             ->applyLogging('DeadlineReached');
+    }
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            from: new Address(
+                config('freegle.mail.noreply_addr'),
+                config('freegle.branding.name')
+            ),
+            subject: $this->getSubject(),
+        );
     }
 
     /**

--- a/iznik-batch/app/Mail/MjmlMailable.php
+++ b/iznik-batch/app/Mail/MjmlMailable.php
@@ -205,8 +205,9 @@ abstract class MjmlMailable extends Mailable
      */
     public function envelope(): Envelope
     {
-        return new Envelope(
-            subject: $this->getSubject(),
+        throw new \LogicException(
+            static::class . ' must override envelope() and set an explicit from address. '
+            . 'Do not rely on a default - different emails use different sender addresses.'
         );
     }
 

--- a/iznik-batch/tests/Unit/Mail/MjmlMailableTest.php
+++ b/iznik-batch/tests/Unit/Mail/MjmlMailableTest.php
@@ -85,12 +85,36 @@ class MjmlMailableTest extends TestCase
             {
                 return 'My Custom Subject';
             }
+
+            public function envelope(): Envelope
+            {
+                return new Envelope(
+                    from: new \Illuminate\Mail\Mailables\Address(
+                        config('freegle.mail.noreply_addr'),
+                        config('freegle.branding.name')
+                    ),
+                    subject: $this->getSubject(),
+                );
+            }
         };
 
         $envelope = $mailable->envelope();
 
         $this->assertInstanceOf(Envelope::class, $envelope);
         $this->assertEquals('My Custom Subject', $envelope->subject);
+    }
+
+    public function test_envelope_throws_if_not_overridden(): void
+    {
+        $mailable = new class extends MjmlMailable {
+            protected function getSubject(): string
+            {
+                return 'Test Subject';
+            }
+        };
+
+        $this->expectException(\LogicException::class);
+        $mailable->envelope();
     }
 
     public function test_attachments_returns_empty_array_by_default(): void


### PR DESCRIPTION
## Summary
- Base class envelope() throws LogicException instead of silently omitting from address
- Prevents mailables being sent without a sender (spooler doesn't inherit alwaysFrom config)

## Test plan
- [ ] CI passes (PHPUnit)