### PR TITLE
feat: Migrate purge_sessions, searchdups, chatdups to Laravel

### DIFF
--- a/iznik-batch/MIGRATION-STATUS.md
+++ b/iznik-batch/MIGRATION-STATUS.md
@@ -44,6 +44,9 @@ All email-related commands use the `mail:` prefix. Other batch commands use desc
 | `users:retention-stats` | Generate retention statistics |
 | `data:update-cpi` | Update CPI data |
 | `data:git-summary` | Generate git summary |
+| `purge:sessions` | Purge old sessions and login links |
+| `cleanup:search-duplicates` | Remove duplicate consecutive searches |
+| `cleanup:chat-duplicates` | Remove duplicate consecutive chat messages |
 | `data:classify-app-release` | Classify app release versions |
 | `groups:update-counts` | Update group member/moderator counts |
 | `chats:update-counts` | Update chat message counts, reopen closed User2Mod |

--- a/iznik-batch/routes/console.php
+++ b/iznik-batch/routes/console.php
@@ -121,7 +121,6 @@ Schedule::command('purge:logs')
     ->dailyAt('04:00')
     ->withoutOverlapping()
     ->runInBackground();
-
 Schedule::command('cleanup:search-duplicates')
     ->hourly()
     ->withoutOverlapping()


### PR DESCRIPTION
## Summary
- Migrates 3 V1 PHP cron scripts to Laravel artisan commands:
  - `purge:sessions` — purges old sessions and expired login links (replaces `purge_sessions.php`)
  - `cleanup:search-duplicates` — removes consecutive duplicate search entries (replaces `searchdups.php`)
  - `cleanup:chat-duplicates` — removes consecutive duplicate chat messages (replaces `chatdups.php`)
- Adds 4 methods to `PurgeService` and wires them into `runAll()`
- Scheduler entries added (currently disabled, matching other pending commands)
- Updates `MIGRATION-STATUS.md` to track progress

## Test plan
- [x] 11 unit tests for PurgeService methods (sessions, login links, search dedup, chat dedup)
- [x] 15 feature tests for artisan commands (run, output, options, data verification)
- [x] All 26 tests pass locally via status container