### PR TITLE
fix: clean up stale Spam review entries after ignore

### DIFF
--- a/iznik-nuxt3/modtools/stores/member.js
+++ b/iznik-nuxt3/modtools/stores/member.js
@@ -160,6 +160,18 @@ export const useMemberStore = defineStore({
             })
           })
           Object.values(byUser).forEach((member) => {
+            // Remove any stale entry for this userid keyed under a different
+            // membership ID (can happen after ReviewIgnore changes which
+            // membership row comes first from the API).
+            const staleKey = Object.keys(this.list).find(
+              (k) =>
+                parseInt(this.list[k].userid) === member.userid &&
+                k !== String(member.id)
+            )
+            if (staleKey) {
+              delete this.list[staleKey]
+            }
+
             member.rawindex = this.rawindex++
             this.list[member.id] = member
           })

--- a/iznik-nuxt3/tests/unit/stores/member.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/member.spec.js
@@ -70,6 +70,49 @@ describe('member store', () => {
     })
   })
 
+  describe('fetchMembers - Spam collection stale entry cleanup', () => {
+    it('removes stale entry when refetch returns same user under different membership ID', async () => {
+      const store = useMemberStore()
+      store.config = {}
+
+      // Simulate existing entry keyed by membership 111 (the Wolves membership).
+      store.list[111] = {
+        id: 111,
+        userid: 456,
+        memberships: [
+          { id: 111, membershipid: 111, groupid: 789 },
+          { id: 222, membershipid: 222, groupid: 999 },
+        ],
+      }
+
+      // After ignore on group 789, refetch returns only the remaining membership.
+      // The API returns it as membership ID 222 (the first remaining row).
+      mockFetchMembers.mockResolvedValue({
+        members: [
+          {
+            id: 222,
+            userid: 456,
+            groupid: 999,
+            reviewrequestedat: '2026-04-13',
+            reviewreason: 'test',
+          },
+        ],
+        context: null,
+        ratings: [],
+      })
+
+      await store.fetchMembers({ collection: 'Spam' })
+
+      // Old entry under key 111 should be gone.
+      expect(store.list[111]).toBeUndefined()
+      // New entry under key 222 should exist with the remaining membership.
+      expect(store.list[222]).toBeTruthy()
+      expect(store.list[222].userid).toBe(456)
+      expect(store.list[222].memberships).toHaveLength(1)
+      expect(store.list[222].memberships[0].groupid).toBe(999)
+    })
+  })
+
   describe('fetchMembers - Related collection', () => {
     it('stores pairs and creates synthetic member entries', async () => {
       mockFetchMembers.mockResolvedValue({


### PR DESCRIPTION
## Summary
- When a mod ignores a spam member on one group, the next refetch may return the same user keyed by a different membership ID (the next remaining row from the API)
- Without cleanup, the old entry persists as a ghost card that keeps reappearing in the review queue
- Adds stale-entry detection in the Spam collection fetch path: removes any prior entry for the same userid before inserting the refreshed one

Fixes Discourse #9518.167 ("Member review keeps coming back after clicking ignore").

## Test plan
- [x] New Vitest test: verifies stale entry under old key is removed when refetch returns same user under new key
- [x] All 11,515 Vitest tests pass locally
- [ ] Manual test: ignore a spam member who is in review on multiple groups, verify they don't reappear after page refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)