### PR TITLE
chore: add unit tests for modtools stores (admins, alert, comment, stdmsg)

### DIFF
--- a/iznik-nuxt3/tests/unit/stores/admins.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/admins.spec.js
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+const mockFetch = vi.fn()
+const mockAdd = vi.fn().mockResolvedValue(42)
+const mockPatch = vi.fn().mockResolvedValue()
+const mockDel = vi.fn().mockResolvedValue()
+const mockHold = vi.fn().mockResolvedValue()
+const mockRelease = vi.fn().mockResolvedValue()
+
+vi.mock('~/api', () => ({
+  default: () => ({
+    admins: {
+      fetch: mockFetch,
+      add: mockAdd,
+      patch: mockPatch,
+      del: mockDel,
+      hold: mockHold,
+      release: mockRelease,
+    },
+  }),
+}))
+
+describe('admins store', () => {
+  let useAdminsStore
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    setActivePinia(createPinia())
+    const mod = await import('~/modtools/stores/admins')
+    useAdminsStore = mod.useAdminsStore
+  })
+
+  it('stores single admin on fetch with id', async () => {
+    const store = useAdminsStore()
+    store.config = {}
+    mockFetch.mockResolvedValue({ id: 1, subject: 'Test Admin' })
+
+    await store.fetch({ id: 1 })
+
+    expect(store.list[1]).toEqual({ id: 1, subject: 'Test Admin' })
+  })
+
+  it('stores array of admins on list fetch', async () => {
+    const store = useAdminsStore()
+    store.config = {}
+    mockFetch.mockResolvedValue([
+      { id: 1, subject: 'A' },
+      { id: 2, subject: 'B' },
+    ])
+
+    await store.fetch({})
+
+    expect(store.list[1].subject).toBe('A')
+    expect(store.list[2].subject).toBe('B')
+  })
+
+  it('clear empties list', () => {
+    const store = useAdminsStore()
+    store.list = { 1: { id: 1 } }
+    store.clear()
+    expect(store.list).toEqual({})
+  })
+
+  it('clearAdmin removes single entry', () => {
+    const store = useAdminsStore()
+    store.list = { 1: { id: 1 }, 2: { id: 2 } }
+    store.clearAdmin(1)
+    expect(store.list[1]).toBeUndefined()
+    expect(store.list[2]).toBeTruthy()
+  })
+
+  it('add calls patch for template/editprotected', async () => {
+    const store = useAdminsStore()
+    store.config = {}
+
+    await store.add({ template: true, editprotected: 1 })
+
+    expect(mockAdd).toHaveBeenCalled()
+    expect(mockPatch).toHaveBeenCalledWith({
+      id: 42,
+      template: true,
+      editprotected: 1,
+    })
+  })
+
+  it('delete removes from list', async () => {
+    const store = useAdminsStore()
+    store.config = {}
+    store.list = { 5: { id: 5 } }
+
+    await store.delete({ id: 5 })
+
+    expect(mockDel).toHaveBeenCalledWith({ id: 5 })
+    expect(store.list[5]).toBeUndefined()
+  })
+
+  it('get getter returns admin by id', () => {
+    const store = useAdminsStore()
+    store.list = { 3: { id: 3, subject: 'Found' } }
+
+    expect(store.get(3)).toEqual({ id: 3, subject: 'Found' })
+    expect(store.get(999)).toBeNull()
+  })
+})

--- a/iznik-nuxt3/tests/unit/stores/alert.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/alert.spec.js
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+const mockFetch = vi.fn()
+const mockAdd = vi.fn().mockResolvedValue({ id: 10 })
+const mockRecord = vi.fn().mockResolvedValue()
+
+vi.mock('~/api', () => ({
+  default: () => ({
+    alert: {
+      fetch: mockFetch,
+      add: mockAdd,
+      record: mockRecord,
+    },
+  }),
+}))
+
+describe('alert store', () => {
+  let useAlertStore
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    setActivePinia(createPinia())
+    const mod = await import('~/modtools/stores/alert')
+    useAlertStore = mod.useAlertStore
+  })
+
+  it('stores list of alerts from fetch', async () => {
+    const store = useAlertStore()
+    store.config = {}
+    mockFetch.mockResolvedValue({
+      alerts: [
+        { id: 1, subject: 'A' },
+        { id: 2, subject: 'B' },
+      ],
+    })
+
+    await store.fetch({})
+
+    expect(store.list[1].subject).toBe('A')
+    expect(store.list[2].subject).toBe('B')
+  })
+
+  it('stores single alert from fetch', async () => {
+    const store = useAlertStore()
+    store.config = {}
+    mockFetch.mockResolvedValue({ alert: { id: 5, subject: 'Single' } })
+
+    await store.fetch({ id: 5 })
+
+    expect(store.list[5].subject).toBe('Single')
+  })
+
+  it('add creates alert and fetches it', async () => {
+    const store = useAlertStore()
+    store.config = {}
+    mockFetch.mockResolvedValue({ alert: { id: 10, subject: 'New' } })
+
+    const id = await store.add({ subject: 'New' })
+
+    expect(id).toBe(10)
+    expect(mockFetch).toHaveBeenCalledWith({ id: 10 })
+  })
+
+  it('record sends click tracking', async () => {
+    const store = useAlertStore()
+    store.config = {}
+
+    await store.record({ id: 7 })
+
+    expect(mockRecord).toHaveBeenCalledWith({
+      trackid: 7,
+      action: 'clicked',
+    })
+  })
+
+  it('clear empties list', () => {
+    const store = useAlertStore()
+    store.list = { 1: { id: 1 } }
+    store.clear()
+    expect(store.list).toEqual({})
+  })
+
+  it('get getter returns alert by id', () => {
+    const store = useAlertStore()
+    store.list = { 3: { id: 3, subject: 'Found' } }
+
+    expect(store.get(3)).toEqual({ id: 3, subject: 'Found' })
+    expect(store.get(999)).toBeNull()
+  })
+})

--- a/iznik-nuxt3/tests/unit/stores/comment.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/comment.spec.js
@@ -42,12 +42,11 @@ describe('comment store', () => {
       context: { id: 'abc' },
     })
 
-    const ctx = await store.fetch({})
+    await store.fetch({})
 
     expect(store.list[1].body).toBe('First')
     expect(store.list[2].body).toBe('Second')
     expect(store.context).toEqual({ id: 'abc' })
-    expect(ctx).toEqual({ id: 'abc' })
   })
 
   it('stores single comment by id', async () => {

--- a/iznik-nuxt3/tests/unit/stores/comment.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/comment.spec.js
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+const mockFetch = vi.fn()
+
+vi.mock('~/api', () => ({
+  default: () => ({
+    comment: {
+      fetch: mockFetch,
+    },
+  }),
+}))
+
+vi.mock('~/stores/user', () => ({
+  useUserStore: () => ({
+    fetch: vi.fn().mockResolvedValue(),
+    list: {
+      100: { id: 100, displayname: 'Alice' },
+      200: { id: 200, displayname: 'Bob' },
+    },
+  }),
+}))
+
+describe('comment store', () => {
+  let useCommentStore
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    setActivePinia(createPinia())
+    const mod = await import('~/modtools/stores/comment')
+    useCommentStore = mod.useCommentStore
+  })
+
+  it('stores list of comments and sets context', async () => {
+    const store = useCommentStore()
+    store.config = {}
+    mockFetch.mockResolvedValue({
+      comments: [
+        { id: 1, body: 'First', userid: 100 },
+        { id: 2, body: 'Second', byuserid: 200 },
+      ],
+      context: { id: 'abc' },
+    })
+
+    const ctx = await store.fetch({})
+
+    expect(store.list[1].body).toBe('First')
+    expect(store.list[2].body).toBe('Second')
+    expect(store.context).toEqual({ id: 'abc' })
+    expect(ctx).toEqual({ id: 'abc' })
+  })
+
+  it('stores single comment by id', async () => {
+    const store = useCommentStore()
+    store.config = {}
+    mockFetch.mockResolvedValue({ id: 5, body: 'Single', userid: 100 })
+
+    await store.fetch({ id: 5 })
+
+    expect(store.list[5].body).toBe('Single')
+  })
+
+  it('enriches comments with user data', async () => {
+    const store = useCommentStore()
+    store.config = {}
+    mockFetch.mockResolvedValue({
+      comments: [{ id: 1, body: 'Test', userid: 100, byuserid: 200 }],
+      context: null,
+    })
+
+    await store.fetch({})
+
+    expect(store.list[1].user.displayname).toBe('Alice')
+    expect(store.list[1].byuser.displayname).toBe('Bob')
+  })
+
+  it('converts object context to id for V2 API', async () => {
+    const store = useCommentStore()
+    store.config = {}
+    mockFetch.mockResolvedValue({ comments: [], context: null })
+
+    await store.fetch({ context: { id: 'xyz' } })
+
+    expect(mockFetch).toHaveBeenCalledWith({ context: 'xyz' })
+  })
+
+  it('clear resets list and context', () => {
+    const store = useCommentStore()
+    store.list = { 1: { id: 1 } }
+    store.context = { id: 'abc' }
+    store.clear()
+    expect(store.list).toEqual({})
+    expect(store.context).toBeNull()
+  })
+
+  it('sortedList sorts flagged first, then by reviewed date desc', () => {
+    const store = useCommentStore()
+    store.list = {
+      1: { id: 1, flagged: false, reviewed: '2026-01-01' },
+      2: { id: 2, flagged: true, reviewed: '2026-01-01' },
+      3: { id: 3, flagged: false, reviewed: '2026-03-01' },
+    }
+
+    const sorted = store.sortedList
+    expect(sorted[0].id).toBe(2) // flagged first
+    expect(sorted[1].id).toBe(3) // newer date
+    expect(sorted[2].id).toBe(1) // older date
+  })
+
+  it('byId getter returns comment or null', () => {
+    const store = useCommentStore()
+    store.list = { 5: { id: 5, body: 'Found' } }
+
+    expect(store.byId(5)).toEqual({ id: 5, body: 'Found' })
+    expect(store.byId(999)).toBeNull()
+  })
+})

--- a/iznik-nuxt3/tests/unit/stores/stdmsg.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/stdmsg.spec.js
@@ -62,7 +62,7 @@ describe('stdmsg store', () => {
 
   it('delete calls API and refreshes config', async () => {
     const store = useStdmsgStore()
-    store.config = {}
+    store.init({})
 
     await store.delete({ id: 5, configid: 1 })
 
@@ -75,7 +75,7 @@ describe('stdmsg store', () => {
 
   it('update calls API and refreshes config', async () => {
     const store = useStdmsgStore()
-    store.config = {}
+    store.init({})
 
     await store.update({ id: 5, title: 'Updated', configid: 1 })
 
@@ -92,7 +92,7 @@ describe('stdmsg store', () => {
 
   it('add creates stdmsg and refreshes config', async () => {
     const store = useStdmsgStore()
-    store.config = {}
+    store.init({})
 
     const id = await store.add({ title: 'New', configid: 2 })
 

--- a/iznik-nuxt3/tests/unit/stores/stdmsg.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/stdmsg.spec.js
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+const mockFetchStdMsg = vi.fn()
+const mockDeleteStdMsg = vi.fn().mockResolvedValue()
+const mockPatchStdMsg = vi.fn().mockResolvedValue()
+const mockAddStdMsg = vi.fn().mockResolvedValue({ id: 99 })
+const mockFetchConfig = vi.fn().mockResolvedValue()
+
+vi.mock('~/api', () => ({
+  default: () => ({
+    modconfigs: {
+      fetchStdMsg: mockFetchStdMsg,
+      deleteStdMsg: mockDeleteStdMsg,
+      patchStdMsg: mockPatchStdMsg,
+      addStdMsg: mockAddStdMsg,
+    },
+  }),
+}))
+
+vi.mock('~/stores/modconfig', () => ({
+  useModConfigStore: () => ({
+    fetchConfig: mockFetchConfig,
+  }),
+}))
+
+describe('stdmsg store', () => {
+  let useStdmsgStore
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    setActivePinia(createPinia())
+    const mod = await import('~/modtools/stores/stdmsg')
+    useStdmsgStore = mod.useStdmsgStore
+  })
+
+  it('set stores stdmsg by id', () => {
+    const store = useStdmsgStore()
+    store.set({ id: 5, title: 'Welcome' })
+    expect(store.stdmsgs[5]).toEqual({ id: 5, title: 'Welcome' })
+  })
+
+  it('byId and byid return stdmsg or null', () => {
+    const store = useStdmsgStore()
+    store.stdmsgs[5] = { id: 5, title: 'Welcome' }
+
+    expect(store.byId(5)).toEqual({ id: 5, title: 'Welcome' })
+    expect(store.byid(5)).toEqual({ id: 5, title: 'Welcome' })
+    expect(store.byId(999)).toBeNull()
+  })
+
+  it('fetch retrieves and stores stdmsg', async () => {
+    const store = useStdmsgStore()
+    store.config = {}
+    mockFetchStdMsg.mockResolvedValue({ stdmsg: { id: 10, title: 'Reply' } })
+
+    const result = await store.fetch(10)
+
+    expect(result).toEqual({ id: 10, title: 'Reply' })
+    expect(store.stdmsgs[10].title).toBe('Reply')
+  })
+
+  it('delete calls API and refreshes config', async () => {
+    const store = useStdmsgStore()
+    store.config = {}
+
+    await store.delete({ id: 5, configid: 1 })
+
+    expect(mockDeleteStdMsg).toHaveBeenCalledWith({ id: 5, configid: 1 })
+    expect(mockFetchConfig).toHaveBeenCalledWith({
+      id: 1,
+      configuring: true,
+    })
+  })
+
+  it('update calls API and refreshes config', async () => {
+    const store = useStdmsgStore()
+    store.config = {}
+
+    await store.update({ id: 5, title: 'Updated', configid: 1 })
+
+    expect(mockPatchStdMsg).toHaveBeenCalledWith({
+      id: 5,
+      title: 'Updated',
+      configid: 1,
+    })
+    expect(mockFetchConfig).toHaveBeenCalledWith({
+      id: 1,
+      configuring: true,
+    })
+  })
+
+  it('add creates stdmsg and refreshes config', async () => {
+    const store = useStdmsgStore()
+    store.config = {}
+
+    const id = await store.add({ title: 'New', configid: 2 })
+
+    expect(id).toBe(99)
+    expect(mockAddStdMsg).toHaveBeenCalledWith({ title: 'New', configid: 2 })
+    expect(mockFetchConfig).toHaveBeenCalledWith({
+      id: 2,
+      configuring: true,
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Adds unit tests for 4 previously untested modtools Pinia stores
- admins (7 tests): CRUD operations, clear, clearAdmin, getter
- alert (6 tests): list/single fetch, add with re-fetch, click tracking, getter
- comment (7 tests): list/single fetch, user enrichment, V2 context conversion, sortedList getter
- stdmsg (6 tests): set/byId, fetch, delete/update/add with config refresh

## Test plan
- [x] All 11,515 Vitest tests pass (including these 26 new tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)