### PR TITLE
fix: reopen closed chats when message is sent (atomic UPDATE)

### DIFF
--- a/.circleci/orb/freegle-tests.yml
+++ b/.circleci/orb/freegle-tests.yml
@@ -1896,6 +1896,14 @@ jobs:
             mkdir -p ~/test-output
             TESTS_KILLED_EARLY=false
 
+            # === INITIALIZE RESULT FILES ===
+            # On self-hosted runner (cleanup_working_directory: false), stale /tmp files
+            # from previous runs persist. Initialize all result files to prevent false results.
+            for f in laravel go php playwright; do
+              echo "pending" > /tmp/${f}-result
+            done
+            rm -f /tmp/watchdog-triggered /tmp/watchdog-pid
+
             # === WATCHDOG TIMEOUT ===
             # Start a watchdog that will force-stop tests after 48 minutes
             # This leaves ~12 minutes for artifact collection before CircleCI's 60-min hard limit
@@ -2317,13 +2325,16 @@ jobs:
             PHP_RESULT=$(cat /tmp/php-result 2>/dev/null || echo "fail")
             PLAYWRIGHT_RESULT=$(cat /tmp/playwright-result 2>/dev/null || echo "fail")
 
-            # Handle killed tests
-            if [ "$TESTS_KILLED_EARLY" = "true" ]; then
-              [ "$LARAVEL_RESULT" = "running" ] && LARAVEL_RESULT="killed"
-              [ "$GO_RESULT" = "running" ] && GO_RESULT="killed"
-              [ "$PHP_RESULT" = "running" ] && PHP_RESULT="killed"
-              [ "$PLAYWRIGHT_RESULT" = "running" ] && PLAYWRIGHT_RESULT="killed"
-            fi
+            # Handle killed or never-started tests
+            for varname in LARAVEL_RESULT GO_RESULT PHP_RESULT PLAYWRIGHT_RESULT; do
+              val="${!varname}"
+              if [ "$TESTS_KILLED_EARLY" = "true" ] && [ "$val" = "running" ]; then
+                eval "$varname=killed"
+              elif [ "$val" = "pending" ]; then
+                echo "⚠️ $varname was never started (still 'pending')"
+                eval "$varname=fail"
+              fi
+            done
 
             echo ""
             echo "=== Parallel Test Results ==="

--- a/iznik-server-go/chat/chatmessage.go
+++ b/iznik-server-go/chat/chatmessage.go
@@ -374,12 +374,13 @@ func CreateChatMessage(c *fiber.Ctx) error {
 
 	// If anyone has closed this chat, reopen it so it reappears in their list.
 	// Blocked chats are left as-is.  Only applies to User2User and User2Mod chats.
-	var roomChattype string
-	db.Raw("SELECT chattype FROM chat_rooms WHERE id = ?", id).Scan(&roomChattype)
+	result := db.Exec("UPDATE chat_roster SET status = ? WHERE chatid = ? AND status = ? "+
+		"AND EXISTS (SELECT 1 FROM chat_rooms WHERE id = ? AND chattype IN (?, ?))",
+		utils.CHAT_STATUS_OFFLINE, id, utils.CHAT_STATUS_CLOSED,
+		id, utils.CHAT_TYPE_USER2USER, utils.CHAT_TYPE_USER2MOD)
 
-	if roomChattype == utils.CHAT_TYPE_USER2USER || roomChattype == utils.CHAT_TYPE_USER2MOD {
-		db.Exec("UPDATE chat_roster SET status = ? WHERE chatid = ? AND status = ?",
-			utils.CHAT_STATUS_OFFLINE, id, utils.CHAT_STATUS_CLOSED)
+	if result.Error != nil {
+		stdlog.Printf("Failed to reopen closed chat roster for chat %d: %v", id, result.Error)
 	}
 
 	ret := struct {

--- a/iznik-server-go/chat/chatmessage.go
+++ b/iznik-server-go/chat/chatmessage.go
@@ -372,6 +372,16 @@ func CreateChatMessage(c *fiber.Ctx) error {
 		db.Exec("UPDATE chat_images SET chatmsgid = ? WHERE id = ?;", newid, *payload.Imageid)
 	}
 
+	// If anyone has closed this chat, reopen it so it reappears in their list.
+	// Blocked chats are left as-is.  Only applies to User2User and User2Mod chats.
+	var roomChattype string
+	db.Raw("SELECT chattype FROM chat_rooms WHERE id = ?", id).Scan(&roomChattype)
+
+	if roomChattype == utils.CHAT_TYPE_USER2USER || roomChattype == utils.CHAT_TYPE_USER2MOD {
+		db.Exec("UPDATE chat_roster SET status = ? WHERE chatid = ? AND status = ?",
+			utils.CHAT_STATUS_OFFLINE, id, utils.CHAT_STATUS_CLOSED)
+	}
+
 	ret := struct {
 		Id int64 `json:"id"`
 	}{}

--- a/iznik-server-go/test/chat_test.go
+++ b/iznik-server-go/test/chat_test.go
@@ -3396,3 +3396,124 @@ func TestUnseenCountExcludesOldMessages(t *testing.T) {
 	db.Exec("DELETE FROM chat_roster WHERE chatid = ?", chatID)
 	db.Exec("DELETE FROM chat_rooms WHERE id = ?", chatID)
 }
+
+func TestCreateChatMessageReopensClosedChat(t *testing.T) {
+	// V1 parity: when a message is sent to a chat where the other user has
+	// status=Closed in chat_roster, the status should be reopened to Offline.
+	// Blocked status should NOT be changed.
+	prefix := uniquePrefix("chatreopn")
+	db := database.DBConn
+
+	user1ID := CreateTestUser(t, prefix+"_u1", "Member")
+	_, user1Token := CreateTestSession(t, user1ID)
+	user2ID := CreateTestUser(t, prefix+"_u2", "Member")
+
+	// Create a User2User chat.
+	chatID := CreateTestChatRoom(t, user1ID, &user2ID, nil, "User2User")
+
+	// User2 closes the chat.
+	db.Exec("INSERT INTO chat_roster (chatid, userid, status, date) VALUES (?, ?, ?, NOW()) "+
+		"ON DUPLICATE KEY UPDATE status = VALUES(status)",
+		chatID, user2ID, utils.CHAT_STATUS_CLOSED)
+
+	// Verify it's closed.
+	var statusBefore string
+	db.Raw("SELECT status FROM chat_roster WHERE chatid = ? AND userid = ?", chatID, user2ID).Scan(&statusBefore)
+	assert.Equal(t, utils.CHAT_STATUS_CLOSED, statusBefore)
+
+	// User1 sends a message — should reopen user2's closed roster entry.
+	var payload chat.ChatMessage
+	payload.Message = "Hello, are you there?"
+	s, _ := json2.Marshal(payload)
+	request := httptest.NewRequest("POST", "/api/chat/"+fmt.Sprint(chatID)+"/message?jwt="+user1Token, bytes.NewBuffer(s))
+	request.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(request)
+	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+
+	// User2's roster status should now be Offline (reopened), not Closed.
+	var statusAfter string
+	db.Raw("SELECT status FROM chat_roster WHERE chatid = ? AND userid = ?", chatID, user2ID).Scan(&statusAfter)
+	assert.Equal(t, utils.CHAT_STATUS_OFFLINE, statusAfter, "Closed chat should be reopened to Offline when a message is sent")
+
+	// Clean up.
+	db.Exec("DELETE FROM chat_messages WHERE chatid = ?", chatID)
+	db.Exec("DELETE FROM chat_roster WHERE chatid = ?", chatID)
+	db.Exec("DELETE FROM chat_rooms WHERE id = ?", chatID)
+}
+
+func TestCreateChatMessageDoesNotReopenBlockedChat(t *testing.T) {
+	// Blocked chats should NOT be reopened when a message is sent.
+	prefix := uniquePrefix("chatblkd")
+	db := database.DBConn
+
+	user1ID := CreateTestUser(t, prefix+"_u1", "Member")
+	_, user1Token := CreateTestSession(t, user1ID)
+	user2ID := CreateTestUser(t, prefix+"_u2", "Member")
+
+	// Create a User2User chat.
+	chatID := CreateTestChatRoom(t, user1ID, &user2ID, nil, "User2User")
+
+	// User2 blocks the chat.
+	db.Exec("INSERT INTO chat_roster (chatid, userid, status, date) VALUES (?, ?, ?, NOW()) "+
+		"ON DUPLICATE KEY UPDATE status = VALUES(status)",
+		chatID, user2ID, utils.CHAT_STATUS_BLOCKED)
+
+	// User1 sends a message.
+	var payload chat.ChatMessage
+	payload.Message = "Hello?"
+	s, _ := json2.Marshal(payload)
+	request := httptest.NewRequest("POST", "/api/chat/"+fmt.Sprint(chatID)+"/message?jwt="+user1Token, bytes.NewBuffer(s))
+	request.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(request)
+	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+
+	// User2's roster status should still be Blocked.
+	var statusAfter string
+	db.Raw("SELECT status FROM chat_roster WHERE chatid = ? AND userid = ?", chatID, user2ID).Scan(&statusAfter)
+	assert.Equal(t, utils.CHAT_STATUS_BLOCKED, statusAfter, "Blocked chat should NOT be reopened")
+
+	// Clean up.
+	db.Exec("DELETE FROM chat_messages WHERE chatid = ?", chatID)
+	db.Exec("DELETE FROM chat_roster WHERE chatid = ?", chatID)
+	db.Exec("DELETE FROM chat_rooms WHERE id = ?", chatID)
+}
+
+func TestCreateChatMessageReopensClosedUser2ModChat(t *testing.T) {
+	// Same reopen behavior should apply to User2Mod chats.
+	prefix := uniquePrefix("chatreomod")
+	db := database.DBConn
+
+	modUserID := CreateTestUser(t, prefix+"_mod", "Moderator")
+	groupID := CreateTestGroup(t, prefix)
+	CreateTestMembership(t, modUserID, groupID, "Moderator")
+	_, modToken := CreateTestSession(t, modUserID)
+
+	userID := CreateTestUser(t, prefix+"_usr", "Member")
+
+	// Create a User2Mod chat.
+	chatID := CreateTestChatRoom(t, userID, nil, &groupID, "User2Mod")
+
+	// User closes the chat.
+	db.Exec("INSERT INTO chat_roster (chatid, userid, status, date) VALUES (?, ?, ?, NOW()) "+
+		"ON DUPLICATE KEY UPDATE status = VALUES(status)",
+		chatID, userID, utils.CHAT_STATUS_CLOSED)
+
+	// Mod sends a message — should reopen user's closed roster entry.
+	var payload chat.ChatMessage
+	payload.Message = "Following up on your query"
+	s, _ := json2.Marshal(payload)
+	request := httptest.NewRequest("POST", "/api/chat/"+fmt.Sprint(chatID)+"/message?jwt="+modToken, bytes.NewBuffer(s))
+	request.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(request)
+	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+
+	// User's roster status should now be Offline (reopened).
+	var statusAfter string
+	db.Raw("SELECT status FROM chat_roster WHERE chatid = ? AND userid = ?", chatID, userID).Scan(&statusAfter)
+	assert.Equal(t, utils.CHAT_STATUS_OFFLINE, statusAfter, "Closed User2Mod chat should be reopened to Offline")
+
+	// Clean up.
+	db.Exec("DELETE FROM chat_messages WHERE chatid = ?", chatID)
+	db.Exec("DELETE FROM chat_roster WHERE chatid = ?", chatID)
+	db.Exec("DELETE FROM chat_rooms WHERE id = ?", chatID)
+}


### PR DESCRIPTION
## Summary

- Replace two-query chat reopen pattern (SELECT chattype + conditional UPDATE) with a single atomic `UPDATE ... WHERE EXISTS` subquery
- Eliminates TOCTOU race condition where chattype could change between queries
- Reduces DB round trips from 2 to 1
- Only reopens User2User and User2Mod chats; blocked chats remain blocked

## Test plan

- [x] Go tests pass locally (1369✓ 0✗)
- [ ] CircleCI green