### PR TITLE
fix: remove hybrid score cap that negated keyword boost

### DIFF
--- a/iznik-server-go/message/vectorsearch.go
+++ b/iznik-server-go/message/vectorsearch.go
@@ -55,9 +55,6 @@ func VectorSearch(term string, limit int, groupids []uint64, msgtype string,
 		}
 
 		hybridScore := vr.Score + keywordScore*keywordBoostWeight
-		if hybridScore > 1.0 {
-			hybridScore = 1.0
-		}
 
 		lat, lng := utils.Blur(vr.Lat, vr.Lng, utils.BLUR_USER)
 


### PR DESCRIPTION
## Summary
- Removes the `hybridScore > 1.0` cap in `VectorSearch` that was silently destroying keyword boost for high-similarity vectors
- Root cause: `makeTestVec(1.0)` and `makeTestVec(1.001)` produce cosine similarity of exactly 1.0 in float32 precision, so the boost (1.0 + 0.3 = 1.3) gets capped back to 1.0 — identical to the unboosted score
- The hybrid score is only used for ranking, never displayed, so capping serves no purpose

## Test plan
- [x] `TestVectorSearchKeywordBoost` now passes (was failing on CI)
- [x] All 1401 Go tests pass locally
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)