### PR TITLE
fix: duplicate message links always pointed to approved page

### DIFF
--- a/iznik-nuxt3/modtools/components/ModMessageDuplicate.vue
+++ b/iznik-nuxt3/modtools/components/ModMessageDuplicate.vue
@@ -62,10 +62,8 @@ const groupid = computed(() => {
 })
 
 const isPending = computed(() => {
-  return (
-    message.value?.collection === 'Pending' ||
-    message.value?.collection === 'PendingOther'
-  )
+  const collection = message.value?.groups?.[0]?.collection
+  return collection === 'Pending' || collection === 'PendingOther'
 })
 
 const duplicateLink = computed(() => {

--- a/iznik-nuxt3/modtools/pages/messages/approved/[[id]]/[[term]].vue
+++ b/iznik-nuxt3/modtools/pages/messages/approved/[[id]]/[[term]].vue
@@ -177,6 +177,7 @@ onMounted(() => {
   }
   if (route?.params && 'term' in route.params && route.params.term) {
     messageTerm.value = route.params.term
+    highlightMsgId.value = parseInt(route.params.term)
   }
   if (route.query.searchmode) {
     vectorSearchEnabled.value = route.query.searchmode === 'vector'

--- a/iznik-nuxt3/tests/unit/components/modtools/ModMessageDuplicate.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModMessageDuplicate.spec.js
@@ -15,13 +15,13 @@ vi.mock('~/stores/message', () => ({
 }))
 
 describe('ModMessageDuplicate', () => {
+  // Data shape must match Go API: collection is inside groups[], not top-level.
   const createTestMessage = (overrides = {}) => ({
     id: 123,
     subject: 'Free sofa',
     arrival: '2024-01-15T10:00:00Z',
-    collection: 'Approved',
     outcome: null,
-    groups: [{ groupid: 456 }],
+    groups: [{ groupid: 456, collection: 'Approved' }],
     ...overrides,
   })
 
@@ -103,17 +103,17 @@ describe('ModMessageDuplicate', () => {
 
   describe('pending indicator', () => {
     it('shows "(pending)" for Pending collection', () => {
-      const wrapper = mountComponent({}, { collection: 'Pending' })
+      const wrapper = mountComponent({}, { groups: [{ groupid: 456, collection: 'Pending' }] })
       expect(wrapper.text()).toContain('(pending)')
     })
 
     it('shows "(pending)" for PendingOther collection', () => {
-      const wrapper = mountComponent({}, { collection: 'PendingOther' })
+      const wrapper = mountComponent({}, { groups: [{ groupid: 456, collection: 'PendingOther' }] })
       expect(wrapper.text()).toContain('(pending)')
     })
 
     it('does not show "(pending)" for Approved collection', () => {
-      const wrapper = mountComponent({}, { collection: 'Approved' })
+      const wrapper = mountComponent({}, { groups: [{ groupid: 456, collection: 'Approved' }] })
       expect(wrapper.text()).not.toContain('(pending)')
     })
   })
@@ -166,22 +166,22 @@ describe('ModMessageDuplicate', () => {
 
     describe('isPending', () => {
       it('returns true for Pending collection', () => {
-        const wrapper = mountComponent({}, { collection: 'Pending' })
+        const wrapper = mountComponent({}, { groups: [{ groupid: 456, collection: 'Pending' }] })
         expect(wrapper.vm.isPending).toBe(true)
       })
 
       it('returns true for PendingOther collection', () => {
-        const wrapper = mountComponent({}, { collection: 'PendingOther' })
+        const wrapper = mountComponent({}, { groups: [{ groupid: 456, collection: 'PendingOther' }] })
         expect(wrapper.vm.isPending).toBe(true)
       })
 
       it('returns false for Approved collection', () => {
-        const wrapper = mountComponent({}, { collection: 'Approved' })
+        const wrapper = mountComponent({}, { groups: [{ groupid: 456, collection: 'Approved' }] })
         expect(wrapper.vm.isPending).toBe(false)
       })
 
       it('returns false for other collections', () => {
-        const wrapper = mountComponent({}, { collection: 'Spam' })
+        const wrapper = mountComponent({}, { groups: [{ groupid: 456, collection: 'Spam' }] })
         expect(wrapper.vm.isPending).toBe(false)
       })
     })
@@ -191,8 +191,7 @@ describe('ModMessageDuplicate', () => {
         const wrapper = mountComponent(
           {},
           {
-            collection: 'Pending',
-            groups: [{ groupid: 456 }],
+            groups: [{ groupid: 456, collection: 'Pending' }],
           }
         )
         expect(wrapper.vm.duplicateLink).toBe(
@@ -204,8 +203,7 @@ describe('ModMessageDuplicate', () => {
         const wrapper = mountComponent(
           {},
           {
-            collection: 'Approved',
-            groups: [{ groupid: 456 }],
+            groups: [{ groupid: 456, collection: 'Approved' }],
           }
         )
         expect(wrapper.vm.duplicateLink).toBe(
@@ -218,8 +216,7 @@ describe('ModMessageDuplicate', () => {
           { messageid: 999 },
           {
             id: 999,
-            collection: 'Pending',
-            groups: [{ groupid: 111 }],
+            groups: [{ groupid: 111, collection: 'Pending' }],
           }
         )
         expect(wrapper.vm.duplicateLink).toBe(
@@ -234,8 +231,7 @@ describe('ModMessageDuplicate', () => {
       const wrapper = mountComponent(
         {},
         {
-          collection: 'Pending',
-          groups: [{ groupid: 456 }],
+          groups: [{ groupid: 456, collection: 'Pending' }],
         }
       )
       const link = wrapper.find('a')
@@ -248,8 +244,7 @@ describe('ModMessageDuplicate', () => {
       const wrapper = mountComponent(
         {},
         {
-          collection: 'Approved',
-          groups: [{ groupid: 456 }],
+          groups: [{ groupid: 456, collection: 'Approved' }],
         }
       )
       const link = wrapper.find('a')
@@ -278,7 +273,7 @@ describe('ModMessageDuplicate', () => {
     })
 
     it('has text-muted class on pending indicator', () => {
-      const wrapper = mountComponent({}, { collection: 'Pending' })
+      const wrapper = mountComponent({}, { groups: [{ groupid: 456, collection: 'Pending' }] })
       expect(wrapper.find('span.text-muted').exists()).toBe(true)
     })
   })


### PR DESCRIPTION
## Summary
- `ModMessageDuplicate.vue` read `message.collection` (top-level) but Go API returns `collection` inside `groups[0].collection` — `isPending` was always false, so all duplicate links went to `/messages/approved` even for pending messages
- Fixed `isPending` to read `message.groups?.[0]?.collection`
- Added `highlightMsgId` assignment on the approved page so navigating from a duplicate link scrolls to the target message (matching pending page behaviour)
- Updated all Vitest tests to use correct API data shape (`collection` inside `groups` array, not top-level)

## Test plan
- [x] Vitest: 11705/11705 pass (0 regressions), all 30 ModMessageDuplicate tests green
- [x] TDD: tests updated to correct data shape first (8 failures confirmed), then component fixed (all pass)
- [ ] Manual: duplicate link from approved message to pending message navigates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)