### PR TITLE
fix: postcode edit reverts + iPhone UI fixes for ModMessage

### DIFF
--- a/iznik-nuxt3/modtools/components/ModMessage.vue
+++ b/iznik-nuxt3/modtools/components/ModMessage.vue
@@ -44,7 +44,7 @@
                 <b-form-input
                   v-model="editmessage.item.name"
                   size="lg"
-                  class="me-1 flex-grow-1"
+                  class="me-1 flex-grow-1 item-name-input"
                 />
               </div>
               <div v-if="editmessage.item && editmessage.location">
@@ -1391,6 +1391,12 @@ function spamReport() {
 
 .location {
   max-width: 250px;
+}
+
+.item-name-input {
+  /* Cap growth on wide desktop so the field doesn't stretch the whole row.
+     flex-grow-1 keeps it filling available space up to this cap. */
+  max-width: 500px;
 }
 
 .fullsubject {

--- a/iznik-nuxt3/modtools/components/ModMessage.vue
+++ b/iznik-nuxt3/modtools/components/ModMessage.vue
@@ -4,7 +4,7 @@
     <b-card bg-variant="white" no-body>
       <b-card-header class="p-1 p-md-2">
         <div class="d-flex justify-content-between">
-          <div class="flex-grow-1">
+          <div class="flex-grow-1" style="min-width: 0">
             <NoticeMessage
               v-if="editing && !message.lat && !message.lng"
               variant="danger"
@@ -33,7 +33,7 @@
               />
               <div
                 v-if="editmessage.item && editmessage.location"
-                class="d-flex justify-content-start"
+                class="d-flex flex-wrap flex-grow-1"
               >
                 <b-form-select
                   v-model="editmessage.type"
@@ -44,7 +44,7 @@
                 <b-form-input
                   v-model="editmessage.item.name"
                   size="lg"
-                  class="me-1"
+                  class="me-1 flex-grow-1"
                 />
               </div>
               <div v-if="editmessage.item && editmessage.location">
@@ -157,7 +157,7 @@
               />
             </div>
           </div>
-          <div class="d-flex">
+          <div class="d-flex flex-shrink-0">
             <div
               v-if="summary && message && fromUser"
               class="text-info fw-bold me-2"
@@ -1153,7 +1153,11 @@ function hasCollection(coll) {
 }
 
 function postcodeSelect(pc) {
-  message.value.location = pc
+  if (editing.value && editmessage.value) {
+    editmessage.value.location = pc
+  } else {
+    message.value.location = pc
+  }
 }
 
 function startEdit() {

--- a/iznik-nuxt3/tests/unit/components/modtools/ModMessage.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModMessage.spec.js
@@ -629,11 +629,37 @@ describe('ModMessage', () => {
   })
 
   describe('postcodeSelect', () => {
-    it('updates message location', () => {
-      const wrapper = mountComponent()
+    it('updates editmessage location when editing', () => {
+      const wrapper = mountComponent(
+        {},
+        {
+          item: { name: 'Test Item' },
+          location: { name: 'SW1A 1AA' },
+        }
+      )
+      wrapper.vm.startEdit()
       const pc = { name: 'SW1A 2AA', lat: 51.6, lng: -0.2 }
       wrapper.vm.postcodeSelect(pc)
-      expect(wrapper.vm.message.location).toEqual(pc)
+      expect(wrapper.vm.editmessage.location).toEqual(pc)
+    })
+
+    it('save sends updated postcode after postcodeSelect during edit', async () => {
+      const wrapper = mountComponent(
+        {},
+        {
+          item: { name: 'Test Item' },
+          location: { name: 'LA23 2JH' },
+        }
+      )
+      wrapper.vm.startEdit()
+      wrapper.vm.postcodeSelect({ name: 'LA3 3QJ', lat: 54.1, lng: -2.9 })
+      await wrapper.vm.save()
+
+      expect(mockMessageStore.patch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          location: 'LA3 3QJ',
+        })
+      )
     })
   })
 


### PR DESCRIPTION
## Summary
- **Postcode edit revert** (Discourse #9481.480): `postcodeSelect()` was updating `message.location` instead of `editmessage.location` during editing, so `save()` always sent the original postcode back to the API
- **Collapse arrow off-screen on iPhone** (Discourse #9481.481): Added `min-width: 0` on flex content container and `flex-shrink-0` on button container to prevent overflow
- **Narrow edit field on iPhone** (Discourse #9481.482): Added `flex-grow-1` to item name input and `flex-wrap` to the approved message edit container

## Test plan
- [x] Vitest: 11695 tests pass
- [ ] Verify postcode edit saves correctly on a transferred message
- [ ] Verify collapse arrow visible on iPhone-width viewport
- [ ] Verify item name field has usable width on iPhone-width viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)