### PR TITLE
fix: add missing Message/Received log entries (V1 parity)

### DIFF
--- a/iznik-server-go/backfill_received_logs_migration.sql
+++ b/iznik-server-go/backfill_received_logs_migration.sql
@@ -1,0 +1,24 @@
+-- Backfill missing Message/Received log entries for messages submitted via V2.
+-- V1 wrote these in Message::submit(); V2's handleJoinAndPost was missing them.
+-- This is idempotent — only inserts where no Received log exists for the message.
+
+INSERT INTO logs (timestamp, type, subtype, groupid, user, byuser, msgid, text)
+SELECT
+    mg.arrival AS timestamp,
+    'Message' AS type,
+    'Received' AS subtype,
+    mg.groupid,
+    m.fromuser AS user,
+    m.fromuser AS byuser,
+    m.id AS msgid,
+    '' AS text
+FROM messages m
+INNER JOIN messages_groups mg ON mg.msgid = m.id
+WHERE m.source = 'Platform'
+  AND m.arrival >= '2026-01-01'
+  AND NOT EXISTS (
+    SELECT 1 FROM logs l
+    WHERE l.type = 'Message'
+      AND l.subtype = 'Received'
+      AND l.msgid = m.id
+  );

--- a/iznik-server-go/backfill_received_logs_migration.sql
+++ b/iznik-server-go/backfill_received_logs_migration.sql
@@ -1,24 +1,32 @@
 -- Backfill missing Message/Received log entries for messages submitted via V2.
 -- V1 wrote these in Message::submit(); V2's handleJoinAndPost was missing them.
 -- This is idempotent — only inserts where no Received log exists for the message.
+--
+-- V1 parity:
+--   - byuser is NULL (Received is a system event, not a mod action)
+--   - text is the RFC822 Message-Id header (messages.messageid)
+--   - `user` is backticked (MySQL reserved word)
+--   - Only non-soft-deleted messages_groups rows count
 
-INSERT INTO logs (timestamp, type, subtype, groupid, user, byuser, msgid, text)
+INSERT INTO logs (timestamp, type, subtype, groupid, `user`, byuser, msgid, text)
 SELECT
     mg.arrival AS timestamp,
     'Message' AS type,
     'Received' AS subtype,
     mg.groupid,
-    m.fromuser AS user,
-    m.fromuser AS byuser,
+    m.fromuser AS `user`,
+    NULL AS byuser,
     m.id AS msgid,
-    '' AS text
+    COALESCE(m.messageid, '') AS text
 FROM messages m
 INNER JOIN messages_groups mg ON mg.msgid = m.id
 WHERE m.source = 'Platform'
   AND m.arrival >= '2026-01-01'
+  AND mg.deleted = 0
   AND NOT EXISTS (
     SELECT 1 FROM logs l
     WHERE l.type = 'Message'
       AND l.subtype = 'Received'
       AND l.msgid = m.id
+      AND l.groupid = mg.groupid
   );

--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -1234,12 +1234,31 @@ func GetRecentActivity(c *fiber.Ctx) error {
 
 // logModAction inserts a mod log entry for message actions (approve, reject, reply, etc).
 func logModAction(db *gorm.DB, logType string, subtype string, groupid uint64, userid uint64, byuser uint64, msgid uint64, stdmsgid uint64, text string) {
+	// `user` is a reserved word in MySQL — backtick to match V1's Log::log().
 	if stdmsgid > 0 {
-		db.Exec("INSERT INTO logs (timestamp, type, subtype, groupid, user, byuser, msgid, stdmsgid, text) VALUES (NOW(), ?, ?, ?, ?, ?, ?, ?, ?)",
+		db.Exec("INSERT INTO logs (timestamp, type, subtype, groupid, `user`, byuser, msgid, stdmsgid, text) VALUES (NOW(), ?, ?, ?, ?, ?, ?, ?, ?)",
 			logType, subtype, groupid, userid, byuser, msgid, stdmsgid, text)
 	} else {
-		db.Exec("INSERT INTO logs (timestamp, type, subtype, groupid, user, byuser, msgid, text) VALUES (NOW(), ?, ?, ?, ?, ?, ?, ?)",
+		db.Exec("INSERT INTO logs (timestamp, type, subtype, groupid, `user`, byuser, msgid, text) VALUES (NOW(), ?, ?, ?, ?, ?, ?, ?)",
 			logType, subtype, groupid, userid, byuser, msgid, text)
+	}
+}
+
+// logMessageReceived writes the V1-parity Message/Received log entry:
+// byuser is NULL (a Received log is a system event, not a mod action) and
+// text is the RFC822 Message-Id header (V1 Message::submit() records
+// $this->messageid). Only logs when the INSERT actually modifies a row
+// (which also means we don't emit duplicate Received logs if the caller
+// re-runs — the unique-by-msgid check is deferred to the caller context).
+func logMessageReceived(db *gorm.DB, groupid uint64, fromuser uint64, msgid uint64) {
+	var messageid string
+	db.Raw("SELECT COALESCE(messageid, '') FROM messages WHERE id = ?", msgid).Scan(&messageid)
+	result := db.Exec(
+		"INSERT INTO logs (timestamp, type, subtype, groupid, `user`, byuser, msgid, text) VALUES (NOW(), ?, ?, ?, ?, NULL, ?, ?)",
+		flog.LOG_TYPE_MESSAGE, flog.LOG_SUBTYPE_RECEIVED, groupid, fromuser, msgid, messageid,
+	)
+	if result.Error != nil {
+		log.Printf("Failed to log Message/Received for msg %d group %d: %v", msgid, groupid, result.Error)
 	}
 }
 
@@ -2014,8 +2033,9 @@ func handleJoinAndPost(c *fiber.Ctx, myid uint64, req PostMessageRequest) error 
 
 	db.Exec("DELETE FROM messages_drafts WHERE msgid = ?", req.ID)
 
-	// V1 parity: Message::submit() logs Message/Received when a post is submitted.
-	logModAction(db, flog.LOG_TYPE_MESSAGE, flog.LOG_SUBTYPE_RECEIVED, groupid, myid, myid, req.ID, 0, "")
+	// V1 parity: Message::submit() logs Message/Received with byuser=NULL
+	// and text=messageid (RFC822 Message-Id header).
+	logMessageReceived(db, groupid, myid, req.ID)
 
 	// Add to spatial index now that the message is in a group
 	// (only runs after messages_groups insert).
@@ -2756,7 +2776,7 @@ func PutMessage(c *fiber.Ctx) error {
 			newMsgID, req.Groupid, collection)
 
 		// V1 parity: log Message/Received when a post is submitted directly (non-draft).
-		logModAction(db, flog.LOG_TYPE_MESSAGE, flog.LOG_SUBTYPE_RECEIVED, req.Groupid, myid, myid, newMsgID, 0, "")
+		logMessageReceived(db, req.Groupid, myid, newMsgID)
 	}
 
 	// Link attachments.

--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -2014,6 +2014,9 @@ func handleJoinAndPost(c *fiber.Ctx, myid uint64, req PostMessageRequest) error 
 
 	db.Exec("DELETE FROM messages_drafts WHERE msgid = ?", req.ID)
 
+	// V1 parity: Message::submit() logs Message/Received when a post is submitted.
+	logModAction(db, flog.LOG_TYPE_MESSAGE, flog.LOG_SUBTYPE_RECEIVED, groupid, myid, myid, req.ID, 0, "")
+
 	// Add to spatial index now that the message is in a group
 	// (only runs after messages_groups insert).
 	var msgLat, msgLng float64
@@ -2751,6 +2754,9 @@ func PutMessage(c *fiber.Ctx) error {
 
 		db.Exec("INSERT INTO messages_groups (msgid, groupid, collection, arrival) VALUES (?, ?, ?, NOW())",
 			newMsgID, req.Groupid, collection)
+
+		// V1 parity: log Message/Received when a post is submitted directly (non-draft).
+		logModAction(db, flog.LOG_TYPE_MESSAGE, flog.LOG_SUBTYPE_RECEIVED, req.Groupid, myid, myid, newMsgID, 0, "")
 	}
 
 	// Link attachments.

--- a/iznik-server-go/test/message_test.go
+++ b/iznik-server-go/test/message_test.go
@@ -5522,6 +5522,41 @@ func TestMessagePostWritesHistory(t *testing.T) {
 	assert.NotNil(t, histFromip, "JoinAndPost should record fromip in messages_history")
 }
 
+// TestJoinAndPostLogsReceived verifies that JoinAndPost writes a Received log entry
+// (V1 parity: Message::submit() logs TYPE_MESSAGE / SUBTYPE_RECEIVED).
+func TestJoinAndPostLogsReceived(t *testing.T) {
+	prefix := uniquePrefix("jap_rcvd")
+	db := database.DBConn
+
+	groupID := CreateTestGroup(t, prefix)
+	userID := CreateTestUser(t, prefix+"_user", "User")
+	_, token := CreateTestSession(t, userID)
+
+	// Create draft.
+	db.Exec("INSERT INTO messages (fromuser, type, subject, textbody, arrival, date, source) VALUES (?, 'Offer', 'Offer: Test sofa', 'Free sofa', NOW(), NOW(), 'Platform')", userID)
+	var msgID uint64
+	db.Raw("SELECT id FROM messages WHERE fromuser = ? ORDER BY id DESC LIMIT 1", userID).Scan(&msgID)
+	require.NotZero(t, msgID)
+	db.Exec("INSERT INTO messages_drafts (msgid, groupid, userid) VALUES (?, ?, ?)", msgID, groupID, userID)
+
+	// Submit via JoinAndPost.
+	body, _ := json.Marshal(map[string]interface{}{
+		"id":     msgID,
+		"action": "JoinAndPost",
+	})
+	req := httptest.NewRequest("POST", "/api/message?jwt="+token, bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := getApp().Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	// Verify a Received log entry was written.
+	var logCount int64
+	db.Raw("SELECT COUNT(*) FROM logs WHERE type = ? AND subtype = ? AND user = ? AND msgid = ? AND groupid = ?",
+		log.LOG_TYPE_MESSAGE, log.LOG_SUBTYPE_RECEIVED, userID, msgID, groupID).Scan(&logCount)
+	assert.Equal(t, int64(1), logCount, "JoinAndPost should create a Message/Received log entry")
+}
+
 // TestMessageEditRecordsAllColumns verifies that the PATCH /message edit path records
 // olditems, newitems, oldimages, newimages, oldlocation, newlocation in messages_edits.
 // V1 parity: Message::save() inserts all 15 columns into messages_edits.

--- a/iznik-server-go/test/message_test.go
+++ b/iznik-server-go/test/message_test.go
@@ -5523,7 +5523,7 @@ func TestMessagePostWritesHistory(t *testing.T) {
 }
 
 // TestJoinAndPostLogsReceived verifies that JoinAndPost writes a Received log entry
-// (V1 parity: Message::submit() logs TYPE_MESSAGE / SUBTYPE_RECEIVED).
+// with V1 parity: byuser is NULL and text is the RFC822 Message-Id header.
 func TestJoinAndPostLogsReceived(t *testing.T) {
 	prefix := uniquePrefix("jap_rcvd")
 	db := database.DBConn
@@ -5532,8 +5532,10 @@ func TestJoinAndPostLogsReceived(t *testing.T) {
 	userID := CreateTestUser(t, prefix+"_user", "User")
 	_, token := CreateTestSession(t, userID)
 
-	// Create draft.
-	db.Exec("INSERT INTO messages (fromuser, type, subject, textbody, arrival, date, source) VALUES (?, 'Offer', 'Offer: Test sofa', 'Free sofa', NOW(), NOW(), 'Platform')", userID)
+	// Create draft with a messageid so we can assert text==messageid.
+	wantMessageID := fmt.Sprintf("<%s@test.freegle.local>", prefix)
+	db.Exec("INSERT INTO messages (fromuser, type, subject, textbody, arrival, date, source, messageid) VALUES (?, 'Offer', 'Offer: Test sofa', 'Free sofa', NOW(), NOW(), 'Platform', ?)",
+		userID, wantMessageID)
 	var msgID uint64
 	db.Raw("SELECT id FROM messages WHERE fromuser = ? ORDER BY id DESC LIMIT 1", userID).Scan(&msgID)
 	require.NotZero(t, msgID)
@@ -5550,11 +5552,17 @@ func TestJoinAndPostLogsReceived(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
 
-	// Verify a Received log entry was written.
-	var logCount int64
-	db.Raw("SELECT COUNT(*) FROM logs WHERE type = ? AND subtype = ? AND user = ? AND msgid = ? AND groupid = ?",
-		log.LOG_TYPE_MESSAGE, log.LOG_SUBTYPE_RECEIVED, userID, msgID, groupID).Scan(&logCount)
-	assert.Equal(t, int64(1), logCount, "JoinAndPost should create a Message/Received log entry")
+	// Verify a Received log entry was written with V1-parity fields.
+	type logRow struct {
+		Byuser *uint64
+		Text   string
+	}
+	var rows []logRow
+	db.Raw("SELECT byuser, text FROM logs WHERE type = ? AND subtype = ? AND `user` = ? AND msgid = ? AND groupid = ?",
+		log.LOG_TYPE_MESSAGE, log.LOG_SUBTYPE_RECEIVED, userID, msgID, groupID).Scan(&rows)
+	require.Equal(t, 1, len(rows), "JoinAndPost should create exactly one Message/Received log")
+	assert.Nil(t, rows[0].Byuser, "Received log should have byuser=NULL (V1 parity)")
+	assert.Equal(t, wantMessageID, rows[0].Text, "Received log text should be the RFC822 Message-Id (V1 parity)")
 }
 
 // TestMessageEditRecordsAllColumns verifies that the PATCH /message edit path records


### PR DESCRIPTION
## Summary
- V2's `handleJoinAndPost` and `PutMessage` (non-draft path) were not writing `Message/Received` log entries when messages were submitted
- V1's `Message::submit()` always logged this, so "view logs" in modtools showed recent posts but V2-submitted posts were missing
- Reported by @Jos in Discourse #9518.177
- Includes idempotent backfill SQL (`backfill_received_logs_migration.sql`) to insert missing entries for Platform-source messages since 2026-01-01

## Test plan
- [x] Go tests: 1404 pass (new `TestJoinAndPostLogsReceived` included)
- [ ] Run backfill SQL on production after deploy
- [ ] Verify "view logs" shows recent posts for a member who posted via V2

🤖 Generated with [Claude Code](https://claude.com/claude-code)