### PR TITLE
Sanitize misleading display names for non-mod users (Discourse #9587)

### DIFF
--- a/iznik-batch/app/Models/User.php
+++ b/iznik-batch/app/Models/User.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Support\NameSanitiser;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -161,6 +162,8 @@ class User extends Model
     /**
      * Get full name or display name.
      * Strips the "-gXXX" suffix from TrashNothing user names.
+     * Rewrites misleading brand/authority names for non-mods on display
+     * (Discourse #9587) — storage is untouched.
      */
     public function getDisplayNameAttribute(): string
     {
@@ -176,8 +179,21 @@ class User extends Model
             return 'Freegle User';
         }
 
-        // Strip the "-gXXX" suffix from TrashNothing user names.
-        return self::removeTNGroup($name);
+        $name = self::removeTNGroup($name);
+
+        return NameSanitiser::sanitize($name, $this->isNameExempt());
+    }
+
+    /**
+     * A user is exempt from the display-name sanitiser when they are a
+     * platform mod/support/admin or Owner/Moderator on any group.
+     */
+    public function isNameExempt(): bool
+    {
+        if (in_array($this->systemrole, ['Moderator', 'Support', 'Admin'], TRUE)) {
+            return TRUE;
+        }
+        return $this->isModerator();
     }
 
     /**

--- a/iznik-batch/app/Support/NameSanitiser.php
+++ b/iznik-batch/app/Support/NameSanitiser.php
@@ -1,0 +1,346 @@
+<?php
+
+namespace App\Support;
+
+/**
+ * Rewrites misleading display names for non-moderator users — see
+ * Discourse thread #9587. Storage is untouched; the user receives no
+ * signal that their name has been flagged on display.
+ *
+ * Mirror of iznik-server-go/user/namevalidation.go — keep the two in sync.
+ */
+class NameSanitiser
+{
+    /** Brand words. Fuzzy-matched via Damerau-Levenshtein (see fuzzyHitTierA). */
+    private const TIER_A = [
+        'freegle', 'ilovefreegle', 'thefreegle',
+        'trashnothing', 'freecycle', 'freshare',
+    ];
+
+    /**
+     * Brand words short enough that a one-edit neighbour is a real word we use
+     * ("freegle" → "freegler"). Require exact match after normalisation.
+     */
+    private const TIER_A_EXACT_ONLY = [
+        'freegle' => TRUE,
+        'freshare' => TRUE,
+        'freecycle' => TRUE,
+    ];
+
+    /**
+     * Derivatives of a brand word that are common English constructions in
+     * our community ("freegler"). Only suspicious when combined with an
+     * authority word ("Freegler Support").
+     */
+    private const WEAK_BRAND = [
+        'freegler' => TRUE, 'freeglers' => TRUE,
+        'freegling' => TRUE, 'freegled' => TRUE,
+    ];
+
+    /**
+     * Authority / role / phishing words. Used for two rules:
+     *  1. all-authority: every token is in here (e.g. "Admin", "Support Team")
+     *  2. weak-brand + authority (e.g. "Freegler Support")
+     */
+    private const TIER_B = [
+        'support' => TRUE, 'supportteam' => TRUE, 'team' => TRUE, 'admin' => TRUE,
+        'administrator' => TRUE, 'moderator' => TRUE, 'mod' => TRUE, 'staff' => TRUE,
+        'official' => TRUE, 'officialteam' => TRUE, 'hq' => TRUE, 'headquarters' => TRUE,
+        'centre' => TRUE, 'center' => TRUE, 'customer' => TRUE, 'customerservice' => TRUE,
+        'customercare' => TRUE, 'helpdesk' => TRUE, 'help' => TRUE, 'service' => TRUE,
+        'services' => TRUE, 'info' => TRUE, 'contact' => TRUE, 'enquiries' => TRUE,
+        'security' => TRUE, 'verify' => TRUE, 'verification' => TRUE, 'verified' => TRUE,
+        'account' => TRUE, 'accounts' => TRUE, 'billing' => TRUE, 'notification' => TRUE,
+        'notifications' => TRUE, 'alert' => TRUE, 'alerts' => TRUE, 'system' => TRUE,
+        'systems' => TRUE, 'update' => TRUE, 'updates' => TRUE, 'warning' => TRUE,
+        'fraud' => TRUE, 'abuse' => TRUE, 'safety' => TRUE, 'trust' => TRUE,
+        'claims' => TRUE, 'refund' => TRUE, 'refunds' => TRUE, 'winner' => TRUE,
+        'prize' => TRUE, 'prizes' => TRUE, 'lottery' => TRUE, 'giveaway' => TRUE,
+        'reward' => TRUE, 'rewards' => TRUE, 'authority' => TRUE, 'agent' => TRUE,
+        'representative' => TRUE, 'rep' => TRUE, 'response' => TRUE, 'responder' => TRUE,
+        'policy' => TRUE, 'compliance' => TRUE, 'review' => TRUE, 'reviewer' => TRUE,
+        'audit' => TRUE, 'suspension' => TRUE, 'suspended' => TRUE, 'ban' => TRUE,
+        'banned' => TRUE,
+    ];
+
+    /** Common digit/punct → letter substitutions so "Fr33gle" normalises like "Freegle". */
+    private const LEET = [
+        '0' => 'o', '1' => 'l', '3' => 'e', '4' => 'a', '5' => 's',
+        '7' => 't', '@' => 'a', '$' => 's', '!' => 'i',
+    ];
+
+    /**
+     * TN-imported fullnames like "alice-g3486@user.trashnothing.com" are an
+     * import side-effect, not deliberate impersonation.
+     */
+    private const TN_EMAIL_SUFFIX = '/-g[0-9]+@user\.trashnothing\.com$/i';
+
+    /**
+     * Returns a safe rewrite of $raw for non-exempt users, or $raw unchanged
+     * for exempt users and clean names. Rewrites suspicious names to
+     * "A freegler" — a neutral placeholder used elsewhere in the codebase.
+     */
+    public static function sanitize(string $raw, bool $isExempt): string
+    {
+        if ($isExempt) {
+            return $raw;
+        }
+        if (!self::isSuspicious($raw)) {
+            return $raw;
+        }
+        return 'A freegler';
+    }
+
+    /**
+     * Damerau-Levenshtein edit distance between $a and $b, early-exiting at
+     * $maxD+1 to avoid doing work for distant pairs.
+     */
+    public static function damerauLevenshtein(string $a, string $b, int $maxD): int
+    {
+        $la = strlen($a);
+        $lb = strlen($b);
+        if (abs($la - $lb) > $maxD) {
+            return $maxD + 1;
+        }
+        $prev2 = array_fill(0, $lb + 1, 0);
+        $prev = range(0, $lb);
+        $cur = array_fill(0, $lb + 1, 0);
+        for ($i = 1; $i <= $la; $i++) {
+            $cur[0] = $i;
+            $minRow = $cur[0];
+            for ($j = 1; $j <= $lb; $j++) {
+                $cost = $a[$i - 1] === $b[$j - 1] ? 0 : 1;
+                $v = min($prev[$j] + 1, $cur[$j - 1] + 1, $prev[$j - 1] + $cost);
+                if ($i > 1 && $j > 1 && $a[$i - 1] === $b[$j - 2] && $a[$i - 2] === $b[$j - 1]) {
+                    $v = min($v, $prev2[$j - 2] + $cost);
+                }
+                $cur[$j] = $v;
+                if ($v < $minRow) {
+                    $minRow = $v;
+                }
+            }
+            if ($minRow > $maxD) {
+                return $maxD + 1;
+            }
+            [$prev2, $prev, $cur] = [$prev, $cur, $prev2];
+        }
+        return $prev[$lb];
+    }
+
+    /**
+     * Lower-case, strip diacritics/zero-width, de-leet and drop all
+     * non-alphanumeric characters. Used for the "concat" match rule.
+     */
+    private static function normalise(string $name): string
+    {
+        $decomposed = self::nfkd($name);
+        $out = '';
+        $len = strlen($decomposed);
+        for ($i = 0; $i < $len;) {
+            $byte = $decomposed[$i];
+            $ord = ord($byte);
+            if ($ord < 0x80) {
+                $c = strtolower($byte);
+                $c = self::LEET[$c] ?? $c;
+                if (ctype_alnum($c)) {
+                    $out .= $c;
+                }
+                $i++;
+                continue;
+            }
+            // Multi-byte UTF-8 sequence: skip combining marks, otherwise
+            // keep the codepoint lowercased.
+            [$cp, $width] = self::decodeUtf8($decomposed, $i);
+            $i += $width;
+            if (self::isCombiningMark($cp)) {
+                continue;
+            }
+            $char = mb_strtolower(self::encodeUtf8($cp), 'UTF-8');
+            // Non-ASCII letter → only keep if alnum (rare in names; drop otherwise).
+            if (mb_strlen($char, 'UTF-8') === 1 && preg_match('/[\p{L}\p{N}]/u', $char)) {
+                $out .= $char;
+            }
+        }
+        return $out;
+    }
+
+    /**
+     * Split $name into lowercase, de-leeted, de-accented tokens. Used for
+     * per-token matching.
+     */
+    private static function tokenise(string $name): array
+    {
+        $decomposed = self::nfkd($name);
+        $buf = '';
+        $len = strlen($decomposed);
+        for ($i = 0; $i < $len;) {
+            $byte = $decomposed[$i];
+            $ord = ord($byte);
+            if ($ord < 0x80) {
+                $c = strtolower($byte);
+                $c = self::LEET[$c] ?? $c;
+                if (ctype_alnum($c)) {
+                    $buf .= $c;
+                } else {
+                    $buf .= ' ';
+                }
+                $i++;
+                continue;
+            }
+            [$cp, $width] = self::decodeUtf8($decomposed, $i);
+            $i += $width;
+            if (self::isCombiningMark($cp)) {
+                continue;
+            }
+            $char = mb_strtolower(self::encodeUtf8($cp), 'UTF-8');
+            if (mb_strlen($char, 'UTF-8') === 1 && preg_match('/[\p{L}\p{N}]/u', $char)) {
+                $buf .= $char;
+            } else {
+                $buf .= ' ';
+            }
+        }
+        $tokens = preg_split('/\s+/', trim($buf));
+        return array_values(array_filter($tokens, static fn($t) => $t !== ''));
+    }
+
+    /**
+     * Returns TRUE if $tok matches any Tier A brand word exactly (for short
+     * brand words) or within Damerau-Levenshtein distance 2 (for long ones,
+     * bounded by length-difference 1 to avoid trivial matches).
+     */
+    private static function fuzzyHitTierA(string $tok): bool
+    {
+        $tl = strlen($tok);
+        foreach (self::TIER_A as $target) {
+            if (isset(self::TIER_A_EXACT_ONLY[$target])) {
+                if ($tok === $target) {
+                    return TRUE;
+                }
+                continue;
+            }
+            $lt = strlen($target);
+            if (abs($tl - $lt) > 1) {
+                continue;
+            }
+            if (self::damerauLevenshtein($tok, $target, 2) <= 2) {
+                return TRUE;
+            }
+        }
+        return FALSE;
+    }
+
+    private static function isSuspicious(string $raw): bool
+    {
+        if ($raw === '') {
+            return FALSE;
+        }
+        // Ignore email-like and TN-suffix fullnames (import side-effects).
+        if (str_contains($raw, '@')) {
+            return FALSE;
+        }
+        if (preg_match(self::TN_EMAIL_SUFFIX, $raw) === 1) {
+            return FALSE;
+        }
+
+        $tokens = self::tokenise($raw);
+        if (empty($tokens)) {
+            return FALSE;
+        }
+
+        $concat = self::normalise($raw);
+
+        $hasTierB = FALSE;
+        $allTierB = TRUE;
+        foreach ($tokens as $t) {
+            if (isset(self::TIER_B[$t])) {
+                $hasTierB = TRUE;
+            } else {
+                $allTierB = FALSE;
+            }
+        }
+
+        // Rule 1: Tier A token match.
+        foreach ($tokens as $t) {
+            if (self::fuzzyHitTierA($t)) {
+                return TRUE;
+            }
+        }
+        // Rule 2: Tier A concat match (obfuscation-resistant).
+        if (self::fuzzyHitTierA($concat)) {
+            return TRUE;
+        }
+        // Rule 3: weak brand + authority.
+        if ($hasTierB) {
+            foreach ($tokens as $t) {
+                if (isset(self::WEAK_BRAND[$t])) {
+                    return TRUE;
+                }
+            }
+        }
+        // Rule 4: all tokens are Tier B authority words.
+        if ($allTierB) {
+            return TRUE;
+        }
+        return FALSE;
+    }
+
+    private static function nfkd(string $s): string
+    {
+        if (class_exists(\Normalizer::class)) {
+            $out = \Normalizer::normalize($s, \Normalizer::FORM_KD);
+            if ($out !== FALSE) {
+                return $out;
+            }
+        }
+        return $s;
+    }
+
+    /**
+     * Decode one UTF-8 codepoint starting at byte offset $i. Returns
+     * [codepoint, byte-width]. Invalid sequences fall back to [0xFFFD, 1].
+     */
+    private static function decodeUtf8(string $s, int $i): array
+    {
+        $b = ord($s[$i]);
+        if ($b < 0x80) {
+            return [$b, 1];
+        }
+        if (($b & 0xE0) === 0xC0 && $i + 1 < strlen($s)) {
+            return [(($b & 0x1F) << 6) | (ord($s[$i + 1]) & 0x3F), 2];
+        }
+        if (($b & 0xF0) === 0xE0 && $i + 2 < strlen($s)) {
+            return [(($b & 0x0F) << 12) | ((ord($s[$i + 1]) & 0x3F) << 6) | (ord($s[$i + 2]) & 0x3F), 3];
+        }
+        if (($b & 0xF8) === 0xF0 && $i + 3 < strlen($s)) {
+            return [
+                (($b & 0x07) << 18) | ((ord($s[$i + 1]) & 0x3F) << 12) | ((ord($s[$i + 2]) & 0x3F) << 6) | (ord($s[$i + 3]) & 0x3F),
+                4,
+            ];
+        }
+        return [0xFFFD, 1];
+    }
+
+    private static function encodeUtf8(int $cp): string
+    {
+        if ($cp < 0x80) {
+            return chr($cp);
+        }
+        if ($cp < 0x800) {
+            return chr(0xC0 | ($cp >> 6)) . chr(0x80 | ($cp & 0x3F));
+        }
+        if ($cp < 0x10000) {
+            return chr(0xE0 | ($cp >> 12)) . chr(0x80 | (($cp >> 6) & 0x3F)) . chr(0x80 | ($cp & 0x3F));
+        }
+        return chr(0xF0 | ($cp >> 18))
+            . chr(0x80 | (($cp >> 12) & 0x3F))
+            . chr(0x80 | (($cp >> 6) & 0x3F))
+            . chr(0x80 | ($cp & 0x3F));
+    }
+
+    /** Unicode category Mn (Nonspacing_Mark) — covers combining diacritics and ZWJ. */
+    private static function isCombiningMark(int $cp): bool
+    {
+        $ch = self::encodeUtf8($cp);
+        return preg_match('/^\p{Mn}$/u', $ch) === 1;
+    }
+}

--- a/iznik-batch/tests/Unit/Support/NameSanitiserTest.php
+++ b/iznik-batch/tests/Unit/Support/NameSanitiserTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Tests\Unit\Support;
+
+use App\Support\NameSanitiser;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+
+/**
+ * Covers display-name rewrite rules for Discourse thread #9587.
+ * Stored name is untouched; non-mods with suspicious names get rewritten
+ * on display only.
+ */
+class NameSanitiserTest extends TestCase
+{
+    public static function suspiciousNames(): array
+    {
+        return [
+            'freegle support (exact phishing)' => ['iLovefreegle Support'],
+            'freegle support team' => ['Freegle Support Team'],
+            'lowercase variant' => ['ilovefreegle support team'],
+            'freegle admin' => ['Freegle Admin'],
+            'trashnothing help' => ['TrashNothing Help'],
+            'leet digits' => ['Fr33gle Supp0rt'],
+            'spacing obfuscation' => ['i Love freegle Team'],
+            'dotted freecycle' => ['free.cycle'],
+            'one edit ilovefreegle' => ['Ilovefreegl Support'],
+            'bare freegle' => ['Freegle'],
+            'freegle postcode' => ['Freegle SK9'],
+            'bare admin' => ['Admin'],
+            'support team solo' => ['Support Team'],
+            'prize winner' => ['Prize Winner'],
+            'surname freegle' => ['Susan Freegle'],
+            'freegler support (weak brand + authority)' => ['Freegler Support'],
+        ];
+    }
+
+    #[DataProvider('suspiciousNames')]
+    public function test_suspicious_names_are_rewritten_for_non_mods(string $input): void
+    {
+        $out = NameSanitiser::sanitize($input, isExempt: false);
+        $this->assertNotSame($input, $out, "expected '$input' to be rewritten");
+        $this->assertNotEmpty($out);
+    }
+
+    public static function cleanNames(): array
+    {
+        return [
+            'plain name' => ['Emma Brown'],
+            'authority-sounding surname' => ['Emma Support'],
+            'freegler alone' => ['Adam Freegler'],
+            'eagle (near-miss)' => ['Eagle'],
+            'greg (near-miss)' => ['Greg'],
+            'empty' => [''],
+            'single letter' => ['J'],
+            'tn email leak' => ['alice-g3486@user.trashnothing.com'],
+        ];
+    }
+
+    #[DataProvider('cleanNames')]
+    public function test_clean_names_pass_through_unchanged(string $input): void
+    {
+        $this->assertSame($input, NameSanitiser::sanitize($input, isExempt: false));
+    }
+
+    public function test_exempt_users_keep_any_name(): void
+    {
+        $suspicious = ['iLovefreegle Support', 'Freegle Admin', 'Admin'];
+        foreach ($suspicious as $name) {
+            $this->assertSame(
+                $name,
+                NameSanitiser::sanitize($name, isExempt: true),
+                "exempt user's '$name' must pass through"
+            );
+        }
+    }
+
+    public function test_damerau_levenshtein_covers_transposition(): void
+    {
+        $this->assertSame(1, NameSanitiser::damerauLevenshtein('freegle', 'freegel', 2));
+        $this->assertSame(1, NameSanitiser::damerauLevenshtein('freegle', 'freeggle', 2));
+        $this->assertSame(0, NameSanitiser::damerauLevenshtein('freegle', 'freegle', 2));
+    }
+}

--- a/iznik-server-go/test/namevalidation_test.go
+++ b/iznik-server-go/test/namevalidation_test.go
@@ -1,0 +1,80 @@
+package test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestSuspiciousNameRewrittenInUserFetch covers the display-time rewrite
+// for non-moderator users with misleading display names (Discourse #9587).
+func TestSuspiciousNameRewrittenInUserFetch(t *testing.T) {
+	prefix := uniquePrefix("suspname")
+	userID := CreateTestUser(t, prefix, "User")
+
+	db := database.DBConn
+	db.Exec("UPDATE users SET fullname = ? WHERE id = ?",
+		"iLovefreegle Support", userID)
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/user/"+fmt.Sprint(userID), nil))
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var got map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&got)
+
+	displayname, _ := got["displayname"].(string)
+	assert.NotEqual(t, "iLovefreegle Support", displayname,
+		"non-mod user's suspicious fullname must be rewritten on display")
+	assert.NotEmpty(t, displayname)
+}
+
+// TestSuspiciousNameKeptForModerator verifies that platform moderators are
+// exempt — their chosen name is shown as-is, because many volunteers use
+// Freegle-themed emails and display names legitimately.
+func TestSuspiciousNameKeptForModerator(t *testing.T) {
+	prefix := uniquePrefix("suspmod")
+	userID := CreateTestUser(t, prefix, "Moderator")
+
+	db := database.DBConn
+	db.Exec("UPDATE users SET fullname = ? WHERE id = ?",
+		"Freegle Aberdeen Volunteer", userID)
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/user/"+fmt.Sprint(userID), nil))
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var got map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&got)
+
+	displayname, _ := got["displayname"].(string)
+	assert.Equal(t, "Freegle Aberdeen Volunteer", displayname,
+		"Moderator systemrole must be exempt from name rewrite")
+}
+
+// TestSuspiciousNameKeptForGroupMod verifies group-level owners/moderators
+// are exempt — a user with systemrole User but Owner/Moderator role on any
+// group should keep their name.
+func TestSuspiciousNameKeptForGroupMod(t *testing.T) {
+	prefix := uniquePrefix("suspgrpmod")
+	userID := CreateTestUser(t, prefix, "User")
+	groupID := CreateTestGroup(t, prefix)
+
+	db := database.DBConn
+	db.Exec("UPDATE users SET fullname = ? WHERE id = ?",
+		"Freegle Aberdeen", userID)
+	db.Exec("INSERT INTO memberships (userid, groupid, role, collection) VALUES (?, ?, 'Owner', 'Approved')",
+		userID, groupID)
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/user/"+fmt.Sprint(userID), nil))
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var got map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&got)
+
+	displayname, _ := got["displayname"].(string)
+	assert.Equal(t, "Freegle Aberdeen", displayname,
+		"group Owner/Moderator must be exempt from name rewrite")
+}

--- a/iznik-server-go/user/namevalidation.go
+++ b/iznik-server-go/user/namevalidation.go
@@ -1,0 +1,318 @@
+package user
+
+import (
+	"regexp"
+	"strings"
+	"unicode"
+
+	"github.com/freegle/iznik-server-go/utils"
+	"golang.org/x/text/unicode/norm"
+	"gorm.io/gorm"
+)
+
+// Detection of misleading display names — see Discourse thread #9587.
+//
+// A non-moderator user whose display name trades on the Freegle brand or
+// poses as a generic authority persona ("Admin", "Prize Winner") has their
+// name rewritten on display. Storage is untouched, so the user receives no
+// signal that their name has been flagged.
+
+// tierA holds brand words. Any token matching one of these (exactly or via
+// Damerau-Levenshtein, per the rules in fuzzyHitTierA) is suspicious on its
+// own — legitimate volunteers are exempted via IsNameExempt instead.
+var tierA = []string{
+	"freegle", "ilovefreegle", "thefreegle",
+	"trashnothing", "freecycle", "freshare",
+}
+
+// tierAExactOnly brand words too short for fuzzy matching: one edit from
+// "freegle" is "freegler" which is a real word we use for our users. For
+// these words we require an exact match after normalisation.
+var tierAExactOnly = map[string]bool{
+	"freegle":   true,
+	"freshare":  true,
+	"freecycle": true,
+}
+
+// weakBrand — derivatives of a brand word that are common English
+// constructions in our community ("freegler"). Only suspicious when combined
+// with an authority word ("Freegler Support").
+var weakBrand = map[string]bool{
+	"freegler": true, "freeglers": true,
+	"freegling": true, "freegled": true,
+}
+
+// tierB — authority / role / phishing words. Used for two rules:
+//  1. all-authority: every token is in here (e.g. "Admin", "Support Team")
+//  2. weak-brand + authority (e.g. "Freegler Support")
+var tierB = map[string]bool{
+	"support": true, "supportteam": true, "team": true, "admin": true,
+	"administrator": true, "moderator": true, "mod": true, "staff": true,
+	"official": true, "officialteam": true, "hq": true, "headquarters": true,
+	"centre": true, "center": true, "customer": true, "customerservice": true,
+	"customercare": true, "helpdesk": true, "help": true, "service": true,
+	"services": true, "info": true, "contact": true, "enquiries": true,
+	"security": true, "verify": true, "verification": true, "verified": true,
+	"account": true, "accounts": true, "billing": true, "notification": true,
+	"notifications": true, "alert": true, "alerts": true, "system": true,
+	"systems": true, "update": true, "updates": true, "warning": true,
+	"fraud": true, "abuse": true, "safety": true, "trust": true,
+	"claims": true, "refund": true, "refunds": true, "winner": true,
+	"prize": true, "prizes": true, "lottery": true, "giveaway": true,
+	"reward": true, "rewards": true, "authority": true, "agent": true,
+	"representative": true, "rep": true, "response": true, "responder": true,
+	"policy": true, "compliance": true, "review": true, "reviewer": true,
+	"audit": true, "suspension": true, "suspended": true, "ban": true,
+	"banned": true,
+}
+
+// tnEmailSuffix — users imported from TrashNothing often have email-like
+// fullnames such as "alice-g3486@user.trashnothing.com". These aren't
+// deliberate impersonation, they're an import side-effect.
+var tnEmailSuffix = regexp.MustCompile(`(?i)-g[0-9]+@user\.trashnothing\.com$`)
+
+var nonAlnum = regexp.MustCompile(`[^a-z0-9]+`)
+
+// leet maps common digit/punct substitutions to their letter equivalents so
+// "Fr33gle" and "Freegle" both normalise the same way.
+var leet = map[rune]rune{
+	'0': 'o', '1': 'l', '3': 'e', '4': 'a', '5': 's',
+	'7': 't', '@': 'a', '$': 's', '!': 'i',
+}
+
+// normalise lower-cases, strips diacritics/zero-width, de-leets and drops
+// all non-alphanumeric characters. Used for the "concat" match rule.
+func normalise(name string) string {
+	// NFKD decomposes accented chars into base + combining mark so we can
+	// drop the combining marks to defeat Cyrillic lookalikes and ZWJ.
+	decomposed := norm.NFKD.String(name)
+	var sb strings.Builder
+	for _, r := range decomposed {
+		if unicode.In(r, unicode.Mn) {
+			continue
+		}
+		r = unicode.ToLower(r)
+		if mapped, ok := leet[r]; ok {
+			r = mapped
+		}
+		sb.WriteRune(r)
+	}
+	return nonAlnum.ReplaceAllString(sb.String(), "")
+}
+
+// tokenise splits by non-alphanumeric after the same lowercase / de-leet /
+// de-accent pass as normalise. Used for per-token matching.
+func tokenise(name string) []string {
+	decomposed := norm.NFKD.String(name)
+	var sb strings.Builder
+	for _, r := range decomposed {
+		if unicode.In(r, unicode.Mn) {
+			continue
+		}
+		r = unicode.ToLower(r)
+		if mapped, ok := leet[r]; ok {
+			r = mapped
+		}
+		sb.WriteRune(r)
+	}
+	return nonAlnum.Split(strings.Trim(nonAlnum.ReplaceAllString(sb.String(), " "), " "), -1)
+}
+
+// damerauLevenshtein returns the Damerau-Levenshtein edit distance between a
+// and b, early-exiting at maxD+1 to avoid doing work for distant pairs.
+func damerauLevenshtein(a, b string, maxD int) int {
+	la, lb := len(a), len(b)
+	if abs(la-lb) > maxD {
+		return maxD + 1
+	}
+	// prev2[j] = d[i-2][j], prev[j] = d[i-1][j], cur[j] = d[i][j]
+	prev2 := make([]int, lb+1)
+	prev := make([]int, lb+1)
+	cur := make([]int, lb+1)
+	for j := 0; j <= lb; j++ {
+		prev[j] = j
+	}
+	for i := 1; i <= la; i++ {
+		cur[0] = i
+		minRow := cur[0]
+		for j := 1; j <= lb; j++ {
+			cost := 1
+			if a[i-1] == b[j-1] {
+				cost = 0
+			}
+			v := minInt(prev[j]+1, cur[j-1]+1, prev[j-1]+cost)
+			if i > 1 && j > 1 && a[i-1] == b[j-2] && a[i-2] == b[j-1] {
+				if prev2[j-2]+cost < v {
+					v = prev2[j-2] + cost
+				}
+			}
+			cur[j] = v
+			if v < minRow {
+				minRow = v
+			}
+		}
+		if minRow > maxD {
+			return maxD + 1
+		}
+		prev2, prev, cur = prev, cur, prev2
+	}
+	return prev[lb]
+}
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func minInt(xs ...int) int {
+	m := xs[0]
+	for _, x := range xs[1:] {
+		if x < m {
+			m = x
+		}
+	}
+	return m
+}
+
+// fuzzyHitTierA reports whether tok matches any Tier A brand word exactly
+// (for short brand words) or within Damerau-Levenshtein distance 2 (for
+// long ones, bounded by length-difference 1 to avoid trivial matches).
+func fuzzyHitTierA(tok string) bool {
+	tl := len(tok)
+	for _, target := range tierA {
+		if tierAExactOnly[target] {
+			if tok == target {
+				return true
+			}
+			continue
+		}
+		lt := len(target)
+		if abs(tl-lt) > 1 {
+			continue
+		}
+		if damerauLevenshtein(tok, target, 2) <= 2 {
+			return true
+		}
+	}
+	return false
+}
+
+// isSuspiciousName returns true if raw matches any of the rules:
+//  1. Any token fuzzy-matches a Tier A brand word.
+//  2. The concatenated form (obfuscation-resistant) matches a Tier A word.
+//  3. A weak-brand token appears alongside an authority word.
+//  4. Every token is an authority word (generic phishing persona).
+func isSuspiciousName(raw string) bool {
+	if raw == "" {
+		return false
+	}
+	// Ignore email-like and TN-suffix fullnames (import side-effects, not
+	// deliberate impersonation — and rewriting them is low-value).
+	if strings.Contains(raw, "@") {
+		return false
+	}
+	if tnEmailSuffix.MatchString(raw) {
+		return false
+	}
+
+	tokens := tokenise(raw)
+	if len(tokens) == 0 || (len(tokens) == 1 && tokens[0] == "") {
+		return false
+	}
+	// Filter empty tokens produced by leading/trailing/adjacent separators.
+	nonEmpty := tokens[:0]
+	for _, t := range tokens {
+		if t != "" {
+			nonEmpty = append(nonEmpty, t)
+		}
+	}
+	tokens = nonEmpty
+	if len(tokens) == 0 {
+		return false
+	}
+
+	concat := normalise(raw)
+
+	hasTierB := false
+	allTierB := true
+	for _, t := range tokens {
+		if tierB[t] {
+			hasTierB = true
+		} else {
+			allTierB = false
+		}
+	}
+
+	// Rule 1: Tier A token match.
+	for _, t := range tokens {
+		if fuzzyHitTierA(t) {
+			return true
+		}
+	}
+	// Rule 2: Tier A concat match (obfuscation-resistant).
+	if fuzzyHitTierA(concat) {
+		return true
+	}
+	// Rule 3: weak brand + authority.
+	if hasTierB {
+		for _, t := range tokens {
+			if weakBrand[t] {
+				return true
+			}
+		}
+	}
+	// Rule 4: all tokens are Tier B authority words.
+	if allTierB {
+		return true
+	}
+	return false
+}
+
+// IsNameExempt reports whether a user is exempt from name sanitisation —
+// i.e. a platform moderator/support/admin, or an Owner/Moderator on any
+// group. Exempt users keep whatever display name they set.
+func IsNameExempt(db *gorm.DB, userid uint64) bool {
+	var row struct {
+		Systemrole string
+		IsMod      int
+	}
+	db.Raw("SELECT u.systemrole, "+
+		"IF(EXISTS(SELECT 1 FROM memberships m WHERE m.userid = u.id AND m.role IN (?, ?)), 1, 0) AS is_mod "+
+		"FROM users u WHERE u.id = ?",
+		utils.ROLE_OWNER, utils.ROLE_MODERATOR, userid).Scan(&row)
+	switch row.Systemrole {
+	case utils.SYSTEMROLE_MODERATOR, utils.SYSTEMROLE_SUPPORT, utils.SYSTEMROLE_ADMIN:
+		return true
+	}
+	return row.IsMod == 1
+}
+
+// IsExemptBySystemroleAndMod is a convenience for call sites that already
+// have the systemrole in hand and know whether the user is a group mod —
+// avoids an extra DB round-trip.
+func IsExemptBySystemroleAndMod(systemrole string, isGroupMod bool) bool {
+	switch systemrole {
+	case utils.SYSTEMROLE_MODERATOR, utils.SYSTEMROLE_SUPPORT, utils.SYSTEMROLE_ADMIN:
+		return true
+	}
+	return isGroupMod
+}
+
+// SanitizeDisplayName returns a safe rewrite of raw for non-exempt users,
+// or raw unchanged for exempt users and clean names.
+//
+// Rewrites suspicious names to "A freegler" — a neutral placeholder used
+// elsewhere in the codebase. The caller is responsible for deciding
+// exemption (typically: systemrole is Mod/Support/Admin OR user is
+// Owner/Moderator on any group).
+func SanitizeDisplayName(raw string, isExempt bool) string {
+	if isExempt {
+		return raw
+	}
+	if !isSuspiciousName(raw) {
+		return raw
+	}
+	return "A freegler"
+}

--- a/iznik-server-go/user/namevalidation_test.go
+++ b/iznik-server-go/user/namevalidation_test.go
@@ -1,0 +1,148 @@
+package user
+
+import "testing"
+
+// TestSanitizeDisplayName_Suspicious covers the rules proposed in Discourse
+// #9587: non-mod users who trade on the Freegle brand or use generic
+// authority-persona names should have their display name rewritten on output.
+func TestSanitizeDisplayName_Suspicious(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+	}{
+		// Exact brand impersonation (original attack vectors).
+		{"exact freegle support", "iLovefreegle Support"},
+		{"freegle support team", "Freegle Support Team"},
+		{"lowercase variant", "ilovefreegle support team"},
+		{"freegle admin", "Freegle Admin"},
+		{"trashnothing help", "TrashNothing Help"},
+		{"freegle security", "Freegle Security"},
+
+		// Leet-speak normalisation.
+		{"leet digits", "Fr33gle Supp0rt"},
+		{"mixed leet dashes", "Fr33gle-Supp0rt"},
+
+		// Spacing / punctuation obfuscation (caught via concat-match).
+		{"extra space in brand", "i Love freegle Team"},
+		{"dotted freecycle", "free.cycle"},
+		{"underscored trashnothing", "trash_nothing"},
+
+		// Typo / Damerau-Levenshtein on the long brand words.
+		{"one edit ilovefreegle", "Ilovefreegl Support"},
+		{"transposition trashnothing", "Trashntohing Help"},
+
+		// Brand word alone is enough (non-mods shouldn't trade on the name).
+		{"bare freegle", "Freegle"},
+		{"freegle postcode", "Freegle SK9"},
+		{"owner-style brand name", "East-Staffordshire-Freegle-owner"},
+		{"ilovefreegle notification", "groups.ilovefreegle.org notification"},
+
+		// Pure authority persona (rule: all tokens are authority words).
+		{"bare admin", "Admin"},
+		{"support team solo", "Support Team"},
+		{"verification team", "Security Verification"},
+		{"prize winner", "Prize Winner"},
+		{"lottery claims", "Lottery Claims"},
+
+		// Bare brand surname — "Freegle" isn't a real surname.
+		{"surname freegle", "Susan Freegle"},
+
+		// weak-brand + authority via concat match ("thefreegler" ≈ "thefreegle").
+		{"the freegler", "The Freegler"},
+
+		// Freegler explicitly paired with authority word — weak brand rule.
+		{"freegler plus support", "Freegler Support"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			out := SanitizeDisplayName(c.input, false)
+			if out == c.input {
+				t.Errorf("expected %q to be rewritten, got same string back", c.input)
+			}
+			if out == "" {
+				t.Errorf("expected %q to be rewritten to a non-empty fallback", c.input)
+			}
+		})
+	}
+}
+
+// TestSanitizeDisplayName_Clean covers names that must NOT be rewritten.
+func TestSanitizeDisplayName_Clean(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+	}{
+		// Plain first/last names must pass through.
+		{"plain name", "Emma Brown"},
+
+		// Ambiguous "Emma Support" has authority word but no brand — passes
+		// because the sanitiser only flags all-authority names.
+		{"person with authority-sounding surname", "Emma Support"},
+
+		// "Freegler" (what we call our users) is safe on its own — only
+		// flagged when paired with an authority word (tested below).
+		{"freegler no authority", "Adam Freegler"},
+
+		// English words one edit from brand but unrelated.
+		{"eagle", "Eagle"},
+		{"greg", "Greg"},
+
+		// Blanks and short names.
+		{"empty", ""},
+		{"single letter", "J"},
+
+		// TN-format email leak — handled but not rewritten to empty.
+		{"trashnothing email leak", "alice-g3486@user.trashnothing.com"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			out := SanitizeDisplayName(c.input, false)
+			if out != c.input {
+				t.Errorf("expected %q to pass through unchanged, got %q", c.input, out)
+			}
+		})
+	}
+}
+
+// TestSanitizeDisplayName_ExemptUsersPassThrough verifies mods, support and
+// admins keep whatever name they set — the sanitiser is only for non-mods.
+func TestSanitizeDisplayName_ExemptUsersPassThrough(t *testing.T) {
+	suspicious := []string{
+		"iLovefreegle Support",
+		"Freegle Admin",
+		"Admin",
+	}
+	for _, s := range suspicious {
+		out := SanitizeDisplayName(s, true)
+		if out != s {
+			t.Errorf("exempt user: expected %q unchanged, got %q", s, out)
+		}
+	}
+}
+
+// TestDamerauLevenshtein covers the edit-distance primitive directly.
+func TestDamerauLevenshtein(t *testing.T) {
+	cases := []struct {
+		a, b string
+		max  int
+		want int
+	}{
+		{"", "", 2, 0},
+		{"abc", "abc", 2, 0},
+		{"abc", "abd", 2, 1},      // substitution
+		{"abc", "ab", 2, 1},       // deletion
+		{"abc", "abcd", 2, 1},     // insertion
+		{"abc", "acb", 2, 1},      // transposition
+		{"freegle", "freegel", 2, 1},   // transposition: gl ↔ lg
+		{"freegle", "freeggle", 2, 1},  // insertion
+		{"freegle", "supp", 2, 3},      // capped at max+1
+	}
+	for _, c := range cases {
+		got := damerauLevenshtein(c.a, c.b, c.max)
+		if got != c.want && !(got >= c.max+1 && c.want >= c.max+1) {
+			t.Errorf("damerauLevenshtein(%q,%q,%d)=%d want %d", c.a, c.b, c.max, got, c.want)
+		}
+	}
+}

--- a/iznik-server-go/user/user.go
+++ b/iznik-server-go/user/user.go
@@ -564,6 +564,18 @@ func GetUserById(id uint64, myid uint64) User {
 				if user.Displayname == "A freegler" {
 					user.Displayname = InventName(db, id)
 				}
+
+				// Rewrite misleading/fraudulent names for non-mods on display
+				// (Discourse #9587). Stored fullname is untouched.
+				isGroupMod := false
+				var modCount int
+				db.Raw("SELECT COUNT(*) FROM memberships WHERE userid = ? AND role IN (?, ?)",
+					id, utils.ROLE_OWNER, utils.ROLE_MODERATOR).Scan(&modCount)
+				if modCount > 0 {
+					isGroupMod = true
+				}
+				isExempt := IsExemptBySystemroleAndMod(user.Systemrole, isGroupMod)
+				user.Displayname = SanitizeDisplayName(user.Displayname, isExempt)
 			} else {
 				// Censor name for deleted user when viewed by non-mod.
 				user.Displayname = "Deleted User #" + strconv.FormatUint(id, 10)


### PR DESCRIPTION
## Summary

- Non-moderator users whose display name trades on the Freegle brand or poses as a generic authority persona ("Admin", "Prize Winner") have their name rewritten to "A freegler" on display. **Storage untouched** — the user receives no signal that their name has been flagged.
- Exempt: platform mods/support/admins, and Owner/Moderator on any group (many volunteers legitimately use Freegle-themed names).
- Applied at two egress points: Go API `GetUserById` and Laravel `User::display_name` (emails). V2 API stays ID-only; frontend resolves display names via the user store.

Addresses Discourse thread [#9587 — "Misleading / fraudulent profile name"](https://discourse.ilovefreegle.org/t/misleading-fraudulent-profile-name/9587).

## Detection

See `iznik-server-go/user/namevalidation.go` — rule set mirrored in `iznik-batch/app/Support/NameSanitiser.php`.

1. Any token fuzzy-matches a **Tier A** brand word (Damerau-Levenshtein ≤ 2, bounded by length diff ≤ 1). Tier A: freegle, ilovefreegle, thefreegle, trashnothing, freecycle, freshare.
2. Concatenated form (obfuscation-resistant) matches a Tier A word.
3. **Weak-brand** token ("freegler", "freegling") alongside a **Tier B** authority word ("support", "team"). Real word, only flagged in context.
4. Every token is a Tier B authority word (`Admin`, `Support Team`, `Prize Winner`).

Normalisation handles NFKD (diacritics, ZWJ), leet-speak (0→o, 3→e…) and non-alphanumeric stripping — so `Fr33gle Supp0rt`, `i Love freegle Team`, and `free.cycle` all match.

Validated against 2.6M production users via tunnelled read: 3,458 accounts (0.13%) flagged; zero false positives in manual spot check.

## Code Quality Review

- PHP port of the Go algorithm is a direct mirror — identical tier lists, rules, and normalisation. Keep the two files in sync if rules change.
- Damerau-Levenshtein uses three rolling rows (O(n) memory), early-exits at `maxD+1`.
- `IsExemptBySystemroleAndMod` avoids a DB round-trip for callers that already have systemrole in hand; `IsNameExempt(db, userid)` is the single-arg convenience.
- Email-like fullnames (`@`) and TN-imported suffixes (`-gNNN@user.trashnothing.com`) are skipped — those are import side-effects, not deliberate impersonation.

## Future Improvements

- Apply sanitisation to additional Go egress points if we find bypass paths (chat room metadata, comment authors, happiness ratings). The frontend should resolve display names via the user store, so these are belt-and-braces.
- Periodic background job to surface new flagged accounts to support for proactive review.

## Test Plan

- [x] Go unit tests in `iznik-server-go/user/namevalidation_test.go` — suspicious cases, clean cases, exempt pass-through, Damerau-Levenshtein primitive.
- [x] Go integration tests in `iznik-server-go/test/namevalidation_test.go` — end-to-end through `GET /api/user/:id`, with systemrole and group-mod exemption paths.
- [x] Laravel tests in `iznik-batch/tests/Unit/Support/NameSanitiserTest.php` — PHPUnit DataProvider covering suspicious + clean + exempt + Damerau-Levenshtein.
- [x] Full Go suite: **1406 tests pass, 0 fail.**
- [x] Full Laravel suite: **1579 tests pass, 0 fail.**