### PR TITLE
test(utils): add unit tests for RandomHex, Nil helpers, Haversine, CountryName, Flex* JSON

### DIFF
--- a/iznik-server-go/test/utils_test.go
+++ b/iznik-server-go/test/utils_test.go
@@ -1,9 +1,12 @@
 package test
 
 import (
+	"encoding/hex"
+	"encoding/json"
 	"github.com/freegle/iznik-server-go/utils"
 	"github.com/stretchr/testify/assert"
 	"math"
+	"regexp"
 	"testing"
 )
 
@@ -80,4 +83,195 @@ func TestOurDomainFalse(t *testing.T) {
 func TestOurDomainPartialMatch(t *testing.T) {
 	// Should match if domain appears anywhere in email.
 	assert.Equal(t, 1, utils.OurDomain("something-users.ilovefreegle.org@proxy.com"))
+}
+
+func TestRandomHexLength(t *testing.T) {
+	// RandomHex(n) must produce 2n lowercase hex characters.
+	for _, n := range []int{0, 1, 4, 8, 16, 32} {
+		out := utils.RandomHex(n)
+		assert.Len(t, out, n*2)
+		// Round-trip: result must decode back to n bytes.
+		decoded, err := hex.DecodeString(out)
+		assert.NoError(t, err)
+		assert.Len(t, decoded, n)
+	}
+}
+
+func TestRandomHexDistinct(t *testing.T) {
+	// Two calls should almost never return the same 16-byte value.
+	a := utils.RandomHex(16)
+	b := utils.RandomHex(16)
+	assert.NotEqual(t, a, b)
+}
+
+func TestNilIfEmpty(t *testing.T) {
+	assert.Nil(t, utils.NilIfEmpty(""))
+	assert.Equal(t, "hello", utils.NilIfEmpty("hello"))
+	// A single space is not empty — must pass through.
+	assert.Equal(t, " ", utils.NilIfEmpty(" "))
+}
+
+func TestNilIfZero(t *testing.T) {
+	assert.Nil(t, utils.NilIfZero(0))
+	assert.Equal(t, uint64(1), utils.NilIfZero(1))
+	assert.Equal(t, uint64(999999), utils.NilIfZero(999999))
+}
+
+func TestHaversineSamePoint(t *testing.T) {
+	// Distance from a point to itself is zero.
+	d := utils.Haversine(51.5074, -0.1278, 51.5074, -0.1278)
+	assert.InDelta(t, 0, d, 0.001)
+}
+
+func TestHaversineKnownDistance(t *testing.T) {
+	// London (51.5074, -0.1278) to Paris (48.8566, 2.3522) is ~213 miles.
+	d := utils.Haversine(51.5074, -0.1278, 48.8566, 2.3522)
+	assert.InDelta(t, 213, d, 5)
+}
+
+func TestHaversineSymmetric(t *testing.T) {
+	// Haversine must be symmetric: d(A,B) == d(B,A).
+	a := utils.Haversine(51.5074, -0.1278, 55.9533, -3.1883) // London → Edinburgh
+	b := utils.Haversine(55.9533, -3.1883, 51.5074, -0.1278)
+	assert.InDelta(t, a, b, 0.001)
+}
+
+func TestCountryNameKnown(t *testing.T) {
+	name, ok := utils.CountryName("GB")
+	assert.True(t, ok)
+	assert.Equal(t, "United Kingdom", name)
+
+	name, ok = utils.CountryName("FR")
+	assert.True(t, ok)
+	assert.Equal(t, "France", name)
+}
+
+func TestCountryNameLowercase(t *testing.T) {
+	// Lookup must be case-insensitive.
+	name, ok := utils.CountryName("gb")
+	assert.True(t, ok)
+	assert.Equal(t, "United Kingdom", name)
+}
+
+func TestCountryNameUnknown(t *testing.T) {
+	name, ok := utils.CountryName("ZZ")
+	assert.False(t, ok)
+	assert.Equal(t, "", name)
+
+	// Empty string is not a valid code.
+	name, ok = utils.CountryName("")
+	assert.False(t, ok)
+	assert.Equal(t, "", name)
+}
+
+func TestFlexUint64FromNumber(t *testing.T) {
+	var v utils.FlexUint64
+	assert.NoError(t, json.Unmarshal([]byte("42"), &v))
+	assert.Equal(t, utils.FlexUint64(42), v)
+}
+
+func TestFlexUint64FromString(t *testing.T) {
+	// Clients that serialise IDs as strings must still be accepted.
+	var v utils.FlexUint64
+	assert.NoError(t, json.Unmarshal([]byte(`"42"`), &v))
+	assert.Equal(t, utils.FlexUint64(42), v)
+}
+
+func TestFlexUint64FromEmptyAndNull(t *testing.T) {
+	var v utils.FlexUint64 = 99
+	assert.NoError(t, json.Unmarshal([]byte(`""`), &v))
+	assert.Equal(t, utils.FlexUint64(0), v)
+
+	v = 99
+	assert.NoError(t, json.Unmarshal([]byte("null"), &v))
+	assert.Equal(t, utils.FlexUint64(0), v)
+}
+
+func TestFlexUint64FromInvalid(t *testing.T) {
+	var v utils.FlexUint64
+	assert.Error(t, json.Unmarshal([]byte(`"not-a-number"`), &v))
+}
+
+func TestFlexIntFromNumberAndString(t *testing.T) {
+	var v utils.FlexInt
+	assert.NoError(t, json.Unmarshal([]byte("-7"), &v))
+	assert.Equal(t, utils.FlexInt(-7), v)
+
+	assert.NoError(t, json.Unmarshal([]byte(`"24"`), &v))
+	assert.Equal(t, utils.FlexInt(24), v)
+}
+
+func TestFlexIntFromEmptyAndNull(t *testing.T) {
+	var v utils.FlexInt = 99
+	assert.NoError(t, json.Unmarshal([]byte(`""`), &v))
+	assert.Equal(t, utils.FlexInt(0), v)
+
+	v = 99
+	assert.NoError(t, json.Unmarshal([]byte("null"), &v))
+	assert.Equal(t, utils.FlexInt(0), v)
+}
+
+func TestFlexIntFromInvalid(t *testing.T) {
+	var v utils.FlexInt
+	assert.Error(t, json.Unmarshal([]byte(`"abc"`), &v))
+}
+
+func TestFlexFloat64FromNumberAndString(t *testing.T) {
+	var v utils.FlexFloat64
+	assert.NoError(t, json.Unmarshal([]byte("3.14"), &v))
+	assert.InDelta(t, 3.14, float64(v), 0.0001)
+
+	assert.NoError(t, json.Unmarshal([]byte(`"2.5"`), &v))
+	assert.InDelta(t, 2.5, float64(v), 0.0001)
+}
+
+func TestFlexFloat64FromEmptyAndNull(t *testing.T) {
+	var v utils.FlexFloat64 = 9.9
+	assert.NoError(t, json.Unmarshal([]byte(`""`), &v))
+	assert.Equal(t, utils.FlexFloat64(0), v)
+
+	v = 9.9
+	assert.NoError(t, json.Unmarshal([]byte("null"), &v))
+	assert.Equal(t, utils.FlexFloat64(0), v)
+}
+
+func TestFlexFloat64FromInvalid(t *testing.T) {
+	var v utils.FlexFloat64
+	assert.Error(t, json.Unmarshal([]byte(`"not-a-float"`), &v))
+}
+
+func TestTidyNameYahooHexID(t *testing.T) {
+	// 32-char hex-like Yahoo IDs are rewritten to the "A freegler" fallback
+	// because the regex matches strings with both letters and digits.
+	assert.Equal(t, "A freegler", utils.TidyName("abcdef0123456789abcdef0123456789"))
+}
+
+func TestTidyNamePureAlphaNotYahoo(t *testing.T) {
+	// 32 chars all-letters doesn't match the Yahoo-ID regex, so TidyName
+	// keeps it (and does not append "...").
+	allAlpha := "abcdefghijklmnopqrstuvwxyzabcdef"
+	assert.Len(t, allAlpha, 32)
+	assert.Equal(t, allAlpha, utils.TidyName(allAlpha))
+}
+
+func TestTidyNameTNSuffixStripped(t *testing.T) {
+	// -gNN TrashNothing suffix is hidden.
+	assert.Equal(t, "alice", utils.TidyName("alice-g12345"))
+}
+
+func TestGenerateNameValid(t *testing.T) {
+	// GenerateName must return a non-empty lowercase alphabetic string.
+	alpha := regexp.MustCompile(`^[a-z]+$`)
+	for i := 0; i < 50; i++ {
+		name := utils.GenerateName()
+		if !assert.NotEmpty(t, name) {
+			return
+		}
+		// Either a generated word or the "A freegler" fallback.
+		if name == "A freegler" {
+			continue
+		}
+		assert.True(t, alpha.MatchString(name), "expected lowercase alpha, got %q", name)
+		assert.LessOrEqual(t, len(name), 10)
+	}
 }


### PR DESCRIPTION
## Summary

Adds 24 unit tests for previously-untested pure-Go utility functions in `iznik-server-go/utils/`.

Coverage for `./utils/` rises from **22.9% → 93.1%**.

## What's covered

| Function | Cases |
|----------|-------|
| `RandomHex(n)` | length, hex-validity, distinctness across calls |
| `NilIfEmpty` / `NilIfZero` | nil and passthrough branches |
| `Haversine` | zero-distance, known London↔Paris value, symmetry |
| `CountryName` | known code, lowercase (case-insensitivity), unknown, empty |
| `FlexUint64` / `FlexInt` / `FlexFloat64` JSON unmarshal | bare number, quoted-string, empty/null → 0, invalid-string → error |
| `TidyName` | Yahoo-ID hex stripping, 32-char all-alpha passthrough, `-gNN` suffix removal |
| `GenerateName` | non-empty, bounded length ≤10, lowercase alpha |

All tests are pure unit tests (no DB, no network).

## Test plan
- [x] All 30 utils tests pass locally in the apiv2 container
- [x] Utils package coverage measured at 93.1% (up from 22.9%)
- [ ] CI pipeline green

🤖 Generated with [Claude Code](https://claude.com/claude-code)