### PR TITLE
chore(test): raise embedding package coverage 57.4% -> 69.0%

### DIFF
--- a/iznik-server-go/embedding/sidecar_test.go
+++ b/iznik-server-go/embedding/sidecar_test.go
@@ -106,3 +106,114 @@ func TestEmbedQueryBadJSON(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "unmarshal")
 }
+
+func TestSetSidecarURL(t *testing.T) {
+	origURL := sidecarURL
+	defer func() { sidecarURL = origURL }()
+
+	// Explicit URL is used as-is.
+	SetSidecarURL("http://custom-sidecar:1234")
+	assert.Equal(t, "http://custom-sidecar:1234", sidecarURL)
+
+	// Empty string falls back to the default.
+	SetSidecarURL("")
+	assert.Equal(t, "http://embedding-sidecar:3200", sidecarURL)
+}
+
+func TestEmbedBatchEmptyInput(t *testing.T) {
+	// Zero texts must short-circuit — no HTTP call, nil result, no error.
+	// Using an invalid URL proves no request was made.
+	origURL := sidecarURL
+	sidecarURL = "http://127.0.0.1:1"
+	defer func() { sidecarURL = origURL }()
+
+	result, err := EmbedBatch(nil)
+	assert.NoError(t, err)
+	assert.Nil(t, result)
+
+	result, err = EmbedBatch([]string{})
+	assert.NoError(t, err)
+	assert.Nil(t, result)
+}
+
+func TestEmbedBatchSuccess(t *testing.T) {
+	vec1 := make([]float32, EmbeddingDim)
+	vec2 := make([]float32, EmbeddingDim)
+	for i := range vec1 {
+		vec1[i] = float32(i) * 0.001
+		vec2[i] = float32(i) * 0.002
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/embed", r.URL.Path)
+		assert.Equal(t, "POST", r.Method)
+
+		var req embedRequest
+		err := json.NewDecoder(r.Body).Decode(&req)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"sofa", "chair"}, req.Texts)
+
+		resp := embedResponse{Embeddings: [][]float32{vec1, vec2}}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	origURL := sidecarURL
+	sidecarURL = server.URL
+	defer func() { sidecarURL = origURL }()
+
+	result, err := EmbedBatch([]string{"sofa", "chair"})
+	require.NoError(t, err)
+	assert.Len(t, result, 2)
+	assert.Len(t, result[0], EmbeddingDim)
+	assert.Len(t, result[1], EmbeddingDim)
+	assert.InDelta(t, 0.002, result[1][1], 1e-6)
+}
+
+func TestEmbedBatchServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(503)
+		w.Write([]byte(`{"error":"overloaded"}`))
+	}))
+	defer server.Close()
+
+	origURL := sidecarURL
+	sidecarURL = server.URL
+	defer func() { sidecarURL = origURL }()
+
+	_, err := EmbedBatch([]string{"sofa"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "sidecar returned 503")
+}
+
+func TestEmbedBatchConnectionError(t *testing.T) {
+	// Start and immediately close to get a guaranteed-refused port.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	url := server.URL
+	server.Close()
+
+	origURL := sidecarURL
+	sidecarURL = url
+	defer func() { sidecarURL = origURL }()
+
+	_, err := EmbedBatch([]string{"sofa"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "sidecar request")
+}
+
+func TestEmbedBatchBadJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`<html>oops</html>`))
+	}))
+	defer server.Close()
+
+	origURL := sidecarURL
+	sidecarURL = server.URL
+	defer func() { sidecarURL = origURL }()
+
+	_, err := EmbedBatch([]string{"sofa"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unmarshal")
+}

--- a/iznik-server-go/embedding/store_test.go
+++ b/iznik-server-go/embedding/store_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/freegle/iznik-server-go/database"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -106,6 +107,80 @@ func TestStoreCount(t *testing.T) {
 
 	s.entries = make([]Entry, 5)
 	assert.Equal(t, 5, s.Count())
+}
+
+func TestStoreSetEntries(t *testing.T) {
+	s := &Store{}
+	assert.Equal(t, 0, s.Count())
+
+	entries := []Entry{
+		{Msgid: 10, Groupid: 1, Msgtype: "Offer", Subject: "a"},
+		{Msgid: 11, Groupid: 2, Msgtype: "Wanted", Subject: "b"},
+	}
+	s.SetEntries(entries)
+	assert.Equal(t, 2, s.Count())
+
+	// Overwrite with an empty slice — Count must drop back to zero.
+	s.SetEntries([]Entry{})
+	assert.Equal(t, 0, s.Count())
+}
+
+func TestStoreLoadWithoutDB(t *testing.T) {
+	// When database.DBConn is nil, Load must fail fast with a clear error
+	// rather than panicking. This is the path taken before InitDatabase runs
+	// (e.g. in tests that never initialise the DB).
+	orig := database.DBConn
+	database.DBConn = nil
+	defer func() { database.DBConn = orig }()
+
+	s := &Store{}
+	err := s.Load()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "database not initialized")
+}
+
+func TestStoreSearchMsgtypeAllReturnsAll(t *testing.T) {
+	// An empty msgtype filter ("" — i.e. "any") must NOT filter out anything.
+	s := &Store{}
+	v := makeVec(1.0)
+	s.entries = []Entry{
+		{Msgid: 1, Groupid: 100, Msgtype: "Offer", Vec: v},
+		{Msgid: 2, Groupid: 100, Msgtype: "Wanted", Vec: v},
+		{Msgid: 3, Groupid: 100, Msgtype: "Taken", Vec: v},
+	}
+
+	results := s.Search(v[:], 10, "", nil, 0, 0, 0, 0)
+	assert.Len(t, results, 3)
+}
+
+func TestStoreSearchBoundingBoxTolerance(t *testing.T) {
+	// The box filter allows 0.02 degrees of slack on each edge — points just
+	// outside the requested box must still come back.
+	s := &Store{}
+	v := makeVec(1.0)
+	s.entries = []Entry{
+		{Msgid: 1, Msgtype: "Offer", Lat: 51.515, Lng: -0.105, Vec: v}, // 0.015 outside
+		{Msgid: 2, Msgtype: "Offer", Lat: 51.55, Lng: -0.1, Vec: v},    // inside
+		{Msgid: 3, Msgtype: "Offer", Lat: 51.6, Lng: 0.1, Vec: v},      // well outside (>0.02)
+	}
+
+	// Request box: swlat=51.52 swlng=-0.10 nelat=51.58 nelng=0.00
+	results := s.Search(v[:], 10, "", nil, 51.52, -0.10, 51.58, 0.00)
+	ids := make(map[uint64]bool, len(results))
+	for _, r := range results {
+		ids[r.Msgid] = true
+	}
+	assert.True(t, ids[1], "msgid 1 should be within 0.02 slack")
+	assert.True(t, ids[2], "msgid 2 is inside the box")
+	assert.False(t, ids[3], "msgid 3 is well outside the slack")
+}
+
+func TestStoreSearchEmptyStore(t *testing.T) {
+	// Searching an empty store must return an empty slice, not panic.
+	s := &Store{}
+	v := makeVec(1.0)
+	results := s.Search(v[:], 10, "", nil, 0, 0, 0, 0)
+	assert.Empty(t, results)
 }
 
 func TestVecToBytes(t *testing.T) {


### PR DESCRIPTION
## Summary

Idle-iteration coverage work from the freegle-monitor loop. Previously `iznik-server-go/embedding` had large uncovered sections: `EmbedBatch`, `SetSidecarURL`, `Store.SetEntries`, and `Store.Load` all at 0%.

## Changes

- `EmbedBatch`: empty-input short-circuit, success path with two-text batch, HTTP error, connection refused, bad JSON
- `SetSidecarURL`: explicit URL override, empty-string fallback to the default
- `Store.SetEntries`: populate + overwrite with empty slice
- `Store.Load`: nil-DB guard returns a clear error rather than panicking
- `Store.Search`: empty-msgtype filter returns all rows, bounding-box 0.02 slack, empty-store short-circuit

## Coverage

- Before: 57.4%
- After:  69.0%

Per-function: `SetSidecarURL` 0 -> 100, `EmbedBatch` 0 -> 88.9, `SetEntries` 0 -> 100, `Load` 0 -> 10.3 (only the guard; the rest needs a live DB).

## Test plan

- [x] All 20 tests pass locally in the apiv2 container
- [x] Worktree build clean, no regressions in the rest of the embedding suite