### PR TITLE
test(misc): first tests for imagedelivery + loki helpers

### DIFF
--- a/iznik-server-go/misc/imagedelivery_test.go
+++ b/iznik-server-go/misc/imagedelivery_test.go
@@ -1,0 +1,112 @@
+package misc
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildChatImageUrlLiveDomain(t *testing.T) {
+	// No imageuid, archived=0 → live IMAGE_DOMAIN with mimg_/tmimg_ prefixes.
+	orig := os.Getenv("IMAGE_DOMAIN")
+	os.Setenv("IMAGE_DOMAIN", "images.example.com")
+	defer os.Setenv("IMAGE_DOMAIN", orig)
+
+	full, thumb := BuildChatImageUrl(42, "", "", 0)
+	assert.Equal(t, "https://images.example.com/mimg_42.jpg", full)
+	assert.Equal(t, "https://images.example.com/tmimg_42.jpg", thumb)
+}
+
+func TestBuildChatImageUrlArchivedDomain(t *testing.T) {
+	// archived > 0 → IMAGE_ARCHIVED_DOMAIN instead of IMAGE_DOMAIN.
+	orig := os.Getenv("IMAGE_ARCHIVED_DOMAIN")
+	os.Setenv("IMAGE_ARCHIVED_DOMAIN", "archive.example.com")
+	defer os.Setenv("IMAGE_ARCHIVED_DOMAIN", orig)
+
+	full, thumb := BuildChatImageUrl(99, "", "", 1)
+	assert.Equal(t, "https://archive.example.com/mimg_99.jpg", full)
+	assert.Equal(t, "https://archive.example.com/tmimg_99.jpg", thumb)
+}
+
+func TestBuildChatImageUrlExternalDelivery(t *testing.T) {
+	// Non-empty imageuid → external delivery URL for both full and thumb
+	// (same URL is returned twice — wsrv/caching proxy decides the size).
+	full, thumb := BuildChatImageUrl(0, "freegletusd-abc123", "", 0)
+	assert.Equal(t, full, thumb)
+	assert.Contains(t, full, "abc123")
+	// Must NOT contain the "freegletusd-" prefix — it's stripped.
+	assert.NotContains(t, full, "freegletusd-")
+}
+
+func TestGetImageDeliveryUrlDefaultEnv(t *testing.T) {
+	// With DELIVERY and UPLOADS unset, fall back to the hard-coded defaults.
+	origDelivery := os.Getenv("IMAGE_DELIVERY")
+	origUploads := os.Getenv("UPLOADS")
+	os.Unsetenv("IMAGE_DELIVERY")
+	os.Unsetenv("UPLOADS")
+	defer os.Setenv("IMAGE_DELIVERY", origDelivery)
+	defer os.Setenv("UPLOADS", origUploads)
+
+	url := GetImageDeliveryUrl("freegletusd-abcdef", "")
+	assert.True(t, strings.HasPrefix(url, "https://delivery.ilovefreegle.org?url="))
+	assert.Contains(t, url, "https://uploads.ilovefreegle.org:8080/abcdef")
+}
+
+func TestGetImageDeliveryUrlCustomEnv(t *testing.T) {
+	os.Setenv("IMAGE_DELIVERY", "https://delivery.test")
+	os.Setenv("UPLOADS", "https://uploads.test/")
+	defer os.Unsetenv("IMAGE_DELIVERY")
+	defer os.Unsetenv("UPLOADS")
+
+	url := GetImageDeliveryUrl("freegletusd-xyz", "")
+	assert.Contains(t, url, "https://delivery.test?url=https://uploads.test/xyz")
+}
+
+func TestGetImageDeliveryUrlDeliverySuffixStripped(t *testing.T) {
+	// Backward-compat: IMAGE_DELIVERY may already include "?url=" suffix.
+	// It must be stripped to avoid double ?url=.
+	os.Setenv("IMAGE_DELIVERY", "https://delivery.test?url=")
+	os.Setenv("UPLOADS", "https://uploads.test/")
+	defer os.Unsetenv("IMAGE_DELIVERY")
+	defer os.Unsetenv("UPLOADS")
+
+	url := GetImageDeliveryUrl("freegletusd-xyz", "")
+	// Exactly one "?url=".
+	assert.Equal(t, 1, strings.Count(url, "?url="))
+}
+
+func TestGetImageDeliveryUrlShortUIDNotTrimmed(t *testing.T) {
+	// UIDs of length <= 12 are kept as-is (no prefix stripping).
+	os.Setenv("IMAGE_DELIVERY", "https://delivery.test")
+	os.Setenv("UPLOADS", "https://uploads.test/")
+	defer os.Unsetenv("IMAGE_DELIVERY")
+	defer os.Unsetenv("UPLOADS")
+
+	short := "short"
+	url := GetImageDeliveryUrl(short, "")
+	assert.Contains(t, url, "https://uploads.test/"+short)
+}
+
+func TestGetImageDeliveryUrlWithRotateMods(t *testing.T) {
+	os.Setenv("IMAGE_DELIVERY", "https://delivery.test")
+	os.Setenv("UPLOADS", "https://uploads.test/")
+	defer os.Unsetenv("IMAGE_DELIVERY")
+	defer os.Unsetenv("UPLOADS")
+
+	url := GetImageDeliveryUrl("freegletusd-xyz", `{"rotate":90}`)
+	assert.Contains(t, url, "&ro=90")
+}
+
+func TestGetImageDeliveryUrlBadModsIgnored(t *testing.T) {
+	// Malformed mods JSON must NOT panic or produce a broken URL —
+	// the mods are silently dropped.
+	os.Setenv("IMAGE_DELIVERY", "https://delivery.test")
+	os.Setenv("UPLOADS", "https://uploads.test/")
+	defer os.Unsetenv("IMAGE_DELIVERY")
+	defer os.Unsetenv("UPLOADS")
+
+	url := GetImageDeliveryUrl("freegletusd-xyz", `not json`)
+	assert.NotContains(t, url, "&ro=")
+}

--- a/iznik-server-go/misc/loki_test.go
+++ b/iznik-server-go/misc/loki_test.go
@@ -1,0 +1,124 @@
+package misc
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTruncateStringShort(t *testing.T) {
+	// Strings at or below maxStringLength are returned unchanged.
+	s := strings.Repeat("a", maxStringLength)
+	assert.Equal(t, s, truncateString(s))
+	assert.Equal(t, "hello", truncateString("hello"))
+	assert.Equal(t, "", truncateString(""))
+}
+
+func TestTruncateStringLong(t *testing.T) {
+	// Over-length strings are truncated to maxStringLength + "..." suffix.
+	s := strings.Repeat("a", maxStringLength+10)
+	out := truncateString(s)
+	assert.True(t, strings.HasSuffix(out, "..."))
+	assert.Equal(t, maxStringLength+3, len(out))
+}
+
+func TestTruncateValueString(t *testing.T) {
+	out := truncateValue(strings.Repeat("x", 100))
+	s, ok := out.(string)
+	assert.True(t, ok)
+	assert.True(t, strings.HasSuffix(s, "..."))
+}
+
+func TestTruncateValueNonString(t *testing.T) {
+	// Non-string scalars pass through unchanged.
+	assert.Equal(t, 42, truncateValue(42))
+	assert.Equal(t, true, truncateValue(true))
+	assert.Equal(t, 3.14, truncateValue(3.14))
+	assert.Nil(t, truncateValue(nil))
+}
+
+func TestTruncateValueSlice(t *testing.T) {
+	// Slices of strings have their elements truncated recursively.
+	long := strings.Repeat("a", 100)
+	out := truncateValue([]interface{}{"short", long, 42})
+	slice, ok := out.([]interface{})
+	assert.True(t, ok)
+	assert.Len(t, slice, 3)
+	assert.Equal(t, "short", slice[0])
+	s, _ := slice[1].(string)
+	assert.True(t, strings.HasSuffix(s, "..."))
+	assert.Equal(t, 42, slice[2])
+}
+
+func TestTruncateMapRecursive(t *testing.T) {
+	long := strings.Repeat("q", 100)
+	input := map[string]interface{}{
+		"short": "ok",
+		"long":  long,
+		"nested": map[string]interface{}{
+			"inner": long,
+		},
+	}
+	out := truncateMap(input)
+
+	assert.Equal(t, "ok", out["short"])
+	s, _ := out["long"].(string)
+	assert.True(t, strings.HasSuffix(s, "..."))
+
+	nested, _ := out["nested"].(map[string]interface{})
+	assert.NotNil(t, nested)
+	ns, _ := nested["inner"].(string)
+	assert.True(t, strings.HasSuffix(ns, "..."))
+
+	// The original input must not be mutated — truncateMap returns a new map.
+	assert.Equal(t, long, input["long"])
+}
+
+func TestFilterHeadersResponseKeepsNonSensitive(t *testing.T) {
+	// Response headers (useAllowlist=false) include everything except
+	// sensitive patterns.
+	headers := map[string]string{
+		"Content-Type":  "application/json",
+		"X-Custom":      "yes",
+		"Authorization": "Bearer secret",
+		"Set-Cookie":    "session=abc",
+	}
+	out := filterHeaders(headers, false)
+	assert.Equal(t, "application/json", out["Content-Type"])
+	assert.Equal(t, "yes", out["X-Custom"])
+	_, hasAuth := out["Authorization"]
+	assert.False(t, hasAuth, "Authorization must be filtered")
+	_, hasCookie := out["Set-Cookie"]
+	assert.False(t, hasCookie, "Set-Cookie must be filtered")
+}
+
+func TestFilterHeadersRequestUsesAllowlist(t *testing.T) {
+	// Request headers (useAllowlist=true) keep only the allowlisted set.
+	headers := map[string]string{
+		"User-Agent":        "test/1.0",
+		"Content-Type":      "application/json",
+		"X-Random":          "nope",
+		"Cookie":            "whatever",
+		"X-Freegle-Session": "sess-1",
+	}
+	out := filterHeaders(headers, true)
+	assert.Equal(t, "test/1.0", out["User-Agent"])
+	assert.Equal(t, "application/json", out["Content-Type"])
+	assert.Equal(t, "sess-1", out["X-Freegle-Session"])
+	_, hasRandom := out["X-Random"]
+	assert.False(t, hasRandom, "X-Random is not on the allowlist")
+	_, hasCookie := out["Cookie"]
+	assert.False(t, hasCookie, "Cookie must be filtered")
+}
+
+func TestFilterHeadersSensitiveCaseInsensitive(t *testing.T) {
+	// The sensitive-pattern match is case-insensitive.
+	headers := map[string]string{
+		"AUTHORIZATION": "Bearer secret",
+		"cookie":        "session=abc",
+		"X-API-Key":     "topsecret",
+	}
+	out := filterHeaders(headers, false)
+	assert.Empty(t, out, "all three should be filtered regardless of case")
+}


### PR DESCRIPTION
## Summary
- Adds the first tests for the `misc` package (0% → 21.0%).
- `imagedelivery_test.go`: covers `BuildChatImageUrl` (live/archived domain, external delivery URL) and `GetImageDeliveryUrl` (default env, custom env, `?url=` suffix strip, short-UID path, rotate mods, malformed JSON).
- `loki_test.go`: covers `truncateString`, `truncateValue` (scalar/slice/map recursion), `filterHeaders` (response blocklist, request allowlist, case-insensitive sensitive match).
- Per-function coverage after: `BuildChatImageUrl`, `GetImageDeliveryUrl`, `truncateString`, `truncateValue`, `truncateMap`, `filterHeaders` all 100%.

Idle-iteration coverage work from `/loop freegle-monitor` (iteration 7).

## Test plan
- [x] Suite runs green in the apiv2 container.
- [x] New tests pass individually.
- [x] Package coverage increases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)