### PR TITLE
fix(spammers): V1 parity — restore Unconfirmed Spammer label, ChitChat muting, preserve reporter

### DIFF
--- a/iznik-server-go/spammers/spammers.go
+++ b/iznik-server-go/spammers/spammers.go
@@ -169,6 +169,18 @@ func PostSpammer(c *fiber.Ctx) error {
 	}
 
 	db := database.DBConn
+
+	// V1 parity (Spam::addSpammer): for PendingAdd, skip the REPLACE if a spam_users row
+	// already exists for this user so the original reporter's byuserid is preserved.
+	// This is the fix for Discourse #9589 (wrong-attribution bug).
+	if req.Collection == utils.SPAM_COLLECTION_PENDING_ADD {
+		var existingCount int64
+		db.Raw("SELECT COUNT(*) FROM spam_users WHERE userid = ?", req.Userid).Scan(&existingCount)
+		if existingCount > 0 {
+			return c.JSON(fiber.Map{"ret": 0, "status": "Success", "id": 0})
+		}
+	}
+
 	// Use the underlying sql.DB to get LastInsertId() directly from the MySQL protocol
 	// response — never issue a separate SELECT LAST_INSERT_ID() as it's unsafe under
 	// parallel load (GORM's connection pool may assign a different connection).
@@ -188,6 +200,13 @@ func PostSpammer(c *fiber.Ctx) error {
 	lastID, err := sqlResult.LastInsertId()
 	if err == nil && lastID > 0 {
 		newID = uint64(lastID)
+	}
+
+	// V1 parity: reporting a SYSTEMROLE_USER as PendingAdd suppresses their ChitChat/newsfeed
+	// posts by setting users.newsfeedmodstatus = 'Suppressed' while pending review.
+	if req.Collection == utils.SPAM_COLLECTION_PENDING_ADD {
+		db.Exec("UPDATE users SET newsfeedmodstatus = ? WHERE id = ? AND systemrole = ?",
+			utils.NEWSFEED_MODSTATUS_SUPPRESSED, req.Userid, utils.SYSTEMROLE_USER)
 	}
 
 	return c.JSON(fiber.Map{"ret": 0, "status": "Success", "id": newID})

--- a/iznik-server-go/test/spammers_parity_test.go
+++ b/iznik-server-go/test/spammers_parity_test.go
@@ -1,0 +1,189 @@
+package test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/stretchr/testify/assert"
+)
+
+// V1 parity: when a mod views a user with a PendingAdd spam_users row,
+// GET /user/{id} returns spammer as a rich object {collection, reason, byuserid, ...}
+// so ModSpammer.vue can display "Unconfirmed Spammer".
+func TestGetUserSpammerPendingAddObjectForMods(t *testing.T) {
+	prefix := uniquePrefix("SpamParPA")
+	modID := CreateTestUser(t, prefix+"_mod", "Moderator")
+	_, modToken := CreateTestSession(t, modID)
+
+	targetID := CreateTestUser(t, prefix+"_target", "User")
+	reporterID := CreateTestUser(t, prefix+"_reporter", "User")
+
+	db := database.DBConn
+	db.Exec("REPLACE INTO spam_users (userid, collection, reason, byuserid) VALUES (?, 'PendingAdd', 'Looks dodgy', ?)",
+		targetID, reporterID)
+
+	url := fmt.Sprintf("/api/user/%d?modtools=true&jwt=%s", targetID, modToken)
+	resp, err := getApp().Test(httptest.NewRequest("GET", url, nil))
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	err = json.NewDecoder(resp.Body).Decode(&result)
+	assert.NoError(t, err)
+
+	spammer, ok := result["spammer"].(map[string]interface{})
+	assert.True(t, ok, "spammer should be an object for mods viewing a PendingAdd user, got %T: %v", result["spammer"], result["spammer"])
+	assert.Equal(t, "PendingAdd", spammer["collection"])
+	assert.Equal(t, "Looks dodgy", spammer["reason"])
+	assert.Equal(t, float64(reporterID), spammer["byuserid"])
+	assert.NotNil(t, spammer["added"])
+	assert.NotNil(t, spammer["id"])
+}
+
+// V1 parity: confirmed Spammer row also gives mods a rich object (not a bare bool).
+func TestGetUserSpammerConfirmedObjectForMods(t *testing.T) {
+	prefix := uniquePrefix("SpamParCS")
+	modID := CreateTestUser(t, prefix+"_mod", "Moderator")
+	_, modToken := CreateTestSession(t, modID)
+
+	targetID := CreateTestUser(t, prefix+"_target", "User")
+	adderID := CreateTestUser(t, prefix+"_adder", "Admin")
+
+	db := database.DBConn
+	db.Exec("REPLACE INTO spam_users (userid, collection, reason, byuserid) VALUES (?, 'Spammer', 'Confirmed', ?)",
+		targetID, adderID)
+
+	url := fmt.Sprintf("/api/user/%d?modtools=true&jwt=%s", targetID, modToken)
+	resp, err := getApp().Test(httptest.NewRequest("GET", url, nil))
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	err = json.NewDecoder(resp.Body).Decode(&result)
+	assert.NoError(t, err)
+
+	spammer, ok := result["spammer"].(map[string]interface{})
+	assert.True(t, ok, "spammer should be an object for mods viewing a confirmed Spammer, got %T", result["spammer"])
+	assert.Equal(t, "Spammer", spammer["collection"])
+}
+
+// V1 parity: non-mod member viewing a confirmed Spammer gets spammer=true (bool).
+// This is so chat UI etc. can warn about confirmed spammers but not leak PendingAdd reports.
+func TestGetUserSpammerConfirmedBoolForMembers(t *testing.T) {
+	prefix := uniquePrefix("SpamParMB")
+	userID := CreateTestUser(t, prefix+"_viewer", "User")
+	_, userToken := CreateTestSession(t, userID)
+
+	targetID := CreateTestUser(t, prefix+"_target", "User")
+	db := database.DBConn
+	db.Exec("REPLACE INTO spam_users (userid, collection, reason, byuserid) VALUES (?, 'Spammer', 'Confirmed', ?)",
+		targetID, userID)
+
+	url := fmt.Sprintf("/api/user/%d?jwt=%s", targetID, userToken)
+	resp, err := getApp().Test(httptest.NewRequest("GET", url, nil))
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	err = json.NewDecoder(resp.Body).Decode(&result)
+	assert.NoError(t, err)
+
+	// For non-mods, confirmed Spammer → true.
+	assert.Equal(t, true, result["spammer"], "non-mods should get spammer=true for confirmed Spammer, got %v", result["spammer"])
+}
+
+// V1 parity: non-mod member viewing a user with ONLY a PendingAdd row sees spammer=false —
+// pending reports must not leak to regular users.
+func TestGetUserSpammerPendingAddHiddenFromMembers(t *testing.T) {
+	prefix := uniquePrefix("SpamParMH")
+	userID := CreateTestUser(t, prefix+"_viewer", "User")
+	_, userToken := CreateTestSession(t, userID)
+
+	targetID := CreateTestUser(t, prefix+"_target", "User")
+	db := database.DBConn
+	db.Exec("REPLACE INTO spam_users (userid, collection, reason, byuserid) VALUES (?, 'PendingAdd', 'Dodgy', ?)",
+		targetID, userID)
+
+	url := fmt.Sprintf("/api/user/%d?jwt=%s", targetID, userToken)
+	resp, err := getApp().Test(httptest.NewRequest("GET", url, nil))
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	err = json.NewDecoder(resp.Body).Decode(&result)
+	assert.NoError(t, err)
+
+	assert.Equal(t, false, result["spammer"], "non-mods must not see PendingAdd as spammer, got %v", result["spammer"])
+}
+
+// V1 parity (Spam.php addSpammer): reporting a user as PendingAdd sets
+// users.newsfeedmodstatus = 'Suppressed' for SYSTEMROLE_USER targets,
+// so their ChitChat/newsfeed posts are muted while pending review.
+func TestPostSpammerPendingAddSuppressesNewsfeed(t *testing.T) {
+	prefix := uniquePrefix("SpamParSup")
+	reporterID := CreateTestUser(t, prefix+"_reporter", "User")
+	_, reporterToken := CreateTestSession(t, reporterID)
+
+	targetID := CreateTestUser(t, prefix+"_target", "User")
+	// Sanity check: starts unsuppressed.
+	db := database.DBConn
+	db.Exec("UPDATE users SET newsfeedmodstatus = NULL WHERE id = ?", targetID)
+
+	body := fmt.Sprintf(`{"userid":%d,"collection":"PendingAdd","reason":"Looks like spam"}`, targetID)
+	req := httptest.NewRequest("POST", fmt.Sprintf("/api/modtools/spammers?jwt=%s", reporterToken), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var modstatus *string
+	db.Raw("SELECT newsfeedmodstatus FROM users WHERE id = ?", targetID).Scan(&modstatus)
+	assert.NotNil(t, modstatus, "newsfeedmodstatus should have been set after PendingAdd report")
+	assert.Equal(t, "Suppressed", *modstatus, "reported user's newsfeed should be Suppressed")
+}
+
+// V1 parity: a second PendingAdd report must NOT overwrite the original byuserid
+// (reason for Discourse #9589 wrong-attribution bug). V1 skips the REPLACE when a
+// spam_users row already exists for that userid.
+func TestPostSpammerPendingAddPreservesOriginalReporter(t *testing.T) {
+	prefix := uniquePrefix("SpamParDup")
+
+	firstReporterID := CreateTestUser(t, prefix+"_r1", "User")
+	_, firstToken := CreateTestSession(t, firstReporterID)
+	secondReporterID := CreateTestUser(t, prefix+"_r2", "User")
+	_, secondToken := CreateTestSession(t, secondReporterID)
+
+	targetID := CreateTestUser(t, prefix+"_target", "User")
+
+	body := fmt.Sprintf(`{"userid":%d,"collection":"PendingAdd","reason":"First report"}`, targetID)
+	req := httptest.NewRequest("POST", fmt.Sprintf("/api/modtools/spammers?jwt=%s", firstToken), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp1, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp1.StatusCode)
+
+	// Second report by a different user — should be a no-op for byuserid/reason.
+	body2 := fmt.Sprintf(`{"userid":%d,"collection":"PendingAdd","reason":"Second report"}`, targetID)
+	req2 := httptest.NewRequest("POST", fmt.Sprintf("/api/modtools/spammers?jwt=%s", secondToken), strings.NewReader(body2))
+	req2.Header.Set("Content-Type", "application/json")
+	resp2, _ := getApp().Test(req2)
+	assert.Equal(t, 200, resp2.StatusCode)
+
+	db := database.DBConn
+	var row struct {
+		Byuserid   uint64
+		Reason     string
+		Collection string
+	}
+	db.Raw("SELECT byuserid, reason, collection FROM spam_users WHERE userid = ? ORDER BY id ASC LIMIT 1", targetID).Scan(&row)
+	assert.Equal(t, firstReporterID, row.Byuserid, "first reporter must be preserved; last writer must not win")
+	assert.Equal(t, "First report", row.Reason, "first reason must be preserved")
+	assert.Equal(t, "PendingAdd", row.Collection)
+
+	// And there should be exactly one row for this user (no duplicate insert).
+	var count int64
+	db.Raw("SELECT COUNT(*) FROM spam_users WHERE userid = ?", targetID).Scan(&count)
+	assert.Equal(t, int64(1), count, "duplicate PendingAdd report must not create a second row")
+}

--- a/iznik-server-go/user/user.go
+++ b/iznik-server-go/user/user.go
@@ -45,7 +45,7 @@ type User struct {
 	Donated         *time.Time  `json:"donated" gorm:"-"`
 	DonatedType     *string     `json:"donatedtype" gorm:"-"`
 	Comments        []Comment   `json:"comments,omitempty" gorm:"-"`
-	Spammer         bool        `json:"spammer" gorm:"-"`
+	Spammer         interface{} `json:"spammer" gorm:"-"`
 	Showmod         bool        `json:"showmod" gorm:"-"`
 	Lat             float32     `json:"lat" gorm:"-"` // Exact for logged in user, approx for others.
 	Lng             float32     `json:"lng" gorm:"-"`
@@ -514,6 +514,22 @@ func GetUserById(id uint64, myid uint64) User {
 	var profileRecord UserProfileRecord
 	var expectedReplies []uint64
 
+	isMod := len(GetActiveModGroupIDs(myid)) > 0
+	// V1 getPublicSpammer checks systemrole directly for mod-visibility of spam details,
+	// not group-mod status — keep this separate from isMod used for settings inclusion.
+	isSystemMod := auth.IsSystemMod(myid)
+
+	type spamRow struct {
+		ID         uint64    `gorm:"column:id"`
+		Userid     uint64    `gorm:"column:userid"`
+		Byuserid   *uint64   `gorm:"column:byuserid"`
+		Collection string    `gorm:"column:collection"`
+		Reason     *string   `gorm:"column:reason"`
+		Added      time.Time `gorm:"column:added"`
+	}
+	var spam spamRow
+	var spamFound bool
+
 	var wg sync.WaitGroup
 
 	wg.Add(1)
@@ -523,7 +539,6 @@ func GetUserById(id uint64, myid uint64) User {
 		// Settings are needed for modtools toggles (notificationmails etc.).
 		// Return for self, or for mods viewing other users.
 		var settingsq = ""
-		isMod := len(GetActiveModGroupIDs(myid)) > 0
 
 		if id == myid || isMod {
 			settingsq = "settings, "
@@ -531,10 +546,9 @@ func GetUserById(id uint64, myid uint64) User {
 
 		err := db.Raw("SELECT users.id, firstname, lastname, fullname, lastaccess, users.added, systemrole, relevantallowed, newslettersallowed, marketingconsent, trustlevel, bouncing, deleted, forgotten, source, engagement, "+
 			"chatmodstatus, newsfeedmodstatus, tnuserid, "+settingsq+
-			"(CASE WHEN spam_users.id IS NOT NULL AND spam_users.collection = ? THEN 1 ELSE 0 END) AS spammer, "+
 			"CASE WHEN systemrole IN (?, ?, ?) AND JSON_EXTRACT(users.settings, '$.showmod') IS NULL THEN 1 ELSE JSON_EXTRACT(users.settings, '$.showmod') END AS showmod "+
-			"FROM users LEFT JOIN spam_users ON spam_users.userid = users.id "+
-			"WHERE users.id = ? ", utils.SPAM_COLLECTION_SPAMMER, utils.SYSTEMROLE_MODERATOR, utils.SYSTEMROLE_SUPPORT, utils.SYSTEMROLE_ADMIN, id).First(&user).Error
+			"FROM users "+
+			"WHERE users.id = ? ", utils.SYSTEMROLE_MODERATOR, utils.SYSTEMROLE_SUPPORT, utils.SYSTEMROLE_ADMIN, id).First(&user).Error
 
 		if !errors.Is(err, gorm.ErrRecordNotFound) {
 			if user.Deleted == nil || isMod {
@@ -636,6 +650,17 @@ func GetUserById(id uint64, myid uint64) User {
 		expectedReplies = GetExpectedReplies(id)
 	}()
 
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		var rows []spamRow
+		db.Raw("SELECT id, userid, byuserid, collection, reason, added FROM spam_users WHERE userid = ? ORDER BY id ASC LIMIT 1", id).Scan(&rows)
+		if len(rows) > 0 {
+			spam = rows[0]
+			spamFound = true
+		}
+	}()
+
 	wg.Wait()
 
 	if user.Deleted == nil && profileRecord.Useprofile {
@@ -652,6 +677,29 @@ func GetUserById(id uint64, myid uint64) User {
 	}
 
 	user.Supporter = supporter.Supporter
+
+	// V1 parity (User::getPublicSpammer): mods see rich spam_users object so ModSpammer.vue
+	// can show "Unconfirmed Spammer" etc. Non-mods see bool TRUE only for confirmed Spammer
+	// collection — PendingAdd must not leak to regular users.
+	if spamFound {
+		if isSystemMod {
+			obj := map[string]interface{}{
+				"id":         spam.ID,
+				"userid":     spam.Userid,
+				"byuserid":   spam.Byuserid,
+				"collection": spam.Collection,
+				"reason":     spam.Reason,
+				"added":      spam.Added,
+			}
+			user.Spammer = obj
+		} else if spam.Collection == utils.SPAM_COLLECTION_SPAMMER {
+			user.Spammer = true
+		} else {
+			user.Spammer = false
+		}
+	} else {
+		user.Spammer = false
+	}
 
 	// Apply V1-parity defaults for settings fields that may be absent from the JSON.
 	applySettingsDefaults(&user)


### PR DESCRIPTION
## Summary

Restores three V1 parity behaviours lost in the V2 Go API migration:

- **Unconfirmed Spammer label** — `GET /user/:id` now returns the spam record as a rich object for mods (collection, reason, byuserid, added, id) so `ModSpammer.vue` can show "Unconfirmed Spammer" / "Confirmed Spammer" / "Disputed Spammer". Non-mods get `spammer: true` only for confirmed `Spammer` collection, matching V1's `User::getPublicSpammer` — pending reports stay hidden from regular users.
- **Reporter attribution (Discourse [#9589](https://discourse.ilovefreegle.org/t/confirmed-spammer/9589))** — `POST /spammers` with a duplicate `PendingAdd` report no longer overwrites the original reporter's `byuserid`. Added a SELECT-first guard matching V1's `Spam::addSpammer`.
- **ChitChat muting** — Reporting a `SYSTEMROLE_USER` as `PendingAdd` now sets `users.newsfeedmodstatus = 'Suppressed'` so their newsfeed/ChitChat posts are muted during review, as V1 did.

Root cause of the label bug: the User struct's `Spammer` field was declared `bool` with `gorm:"-"` and so was never populated — the SELECT alias in the query was discarded. Changed to `interface{}` and populated from a separate `spam_users` lookup after `wg.Wait`.

## Test plan

- [x] 6 new TDD tests in `iznik-server-go/test/spammers_parity_test.go`:
  - `TestGetUserSpammerPendingAddObjectForMods`
  - `TestGetUserSpammerConfirmedObjectForMods`
  - `TestGetUserSpammerConfirmedBoolForMembers`
  - `TestGetUserSpammerPendingAddHiddenFromMembers`
  - `TestPostSpammerPendingAddSuppressesNewsfeed`
  - `TestPostSpammerPendingAddPreservesOriginalReporter`
- [x] Full Go suite: 1409/1409 passing
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)