### PR TITLE
fix(messages): serialise pagination context for infinite scroll

### DIFF
--- a/iznik-nuxt3/stores/message.js
+++ b/iznik-nuxt3/stores/message.js
@@ -1,4 +1,3 @@
-import cloneDeep from 'lodash.clonedeep'
 import { defineStore } from 'pinia'
 import { nextTick } from 'vue'
 import api from '~/api'
@@ -523,8 +522,10 @@ export const useMessageStore = defineStore({
     },
     async fetchMessagesMT(params) {
       if (params.context) {
-        // Ensure the context is a real object, in case it has been in the store.
-        params.context = cloneDeep(params.context)
+        // Server expects context as a JSON-encoded string; URLSearchParams
+        // would otherwise coerce an object to "[object Object]", the server
+        // silently drops it, and infinite scroll caps at one page (~100).
+        params.context = JSON.stringify(params.context)
       }
       if (!params.context) params.context = null
 

--- a/iznik-nuxt3/tests/unit/stores/message.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/message.spec.js
@@ -336,3 +336,55 @@ describe('message store - searchMT()', () => {
     expect(store.fetchMT).not.toHaveBeenCalled()
   })
 })
+
+describe('message store - fetchMessagesMT() pagination context', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+    mockMiscStore.modtools = false
+  })
+
+  // The Go server expects `context` as a JSON-encoded string
+  // (it calls json.Unmarshal on the query value). If we pass the object
+  // directly URLSearchParams coerces it to "[object Object]" which fails
+  // to parse, so the server silently falls back to page 1 and the infinite
+  // scroll caps at one page (~100 messages) regardless of how far the user
+  // scrolls.
+  it('serialises the pagination context as a JSON string before sending', async () => {
+    useAuthStore.mockReturnValue({ user: { id: 1 } })
+    mockFetchMessages.mockResolvedValue({
+      messages: [1001, 1002],
+      context: { Date: 1700000000, ID: 1001 },
+    })
+
+    const store = useMessageStore()
+    store.fetchMT = vi.fn().mockResolvedValue({ id: 1, subject: 'x' })
+
+    await store.fetchMessagesMT({
+      groupid: 1,
+      collection: 'Approved',
+      context: { Date: 1700001234, ID: 2002 },
+      limit: 30,
+    })
+
+    const sent = mockFetchMessages.mock.calls[0][0]
+    expect(typeof sent.context).toBe('string')
+    expect(JSON.parse(sent.context)).toEqual({ Date: 1700001234, ID: 2002 })
+  })
+
+  it('leaves a null context alone', async () => {
+    useAuthStore.mockReturnValue({ user: { id: 1 } })
+    mockFetchMessages.mockResolvedValue({ messages: [] })
+
+    const store = useMessageStore()
+    store.fetchMT = vi.fn()
+
+    await store.fetchMessagesMT({
+      groupid: 1,
+      collection: 'Approved',
+      context: null,
+    })
+
+    expect(mockFetchMessages.mock.calls[0][0].context).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

Infinite scroll of approved messages capped at exactly 100 posts regardless of how far the user scrolled (Discourse [#9518.179](https://discourse.ilovefreegle.org/t/9518/179)).

### Root cause

`fetchMessagesMT` in `stores/message.js` passed the pagination context (`{ Date, ID }`) as an object to `$getv2`. `URLSearchParams` coerces objects via `toString()` → `"[object Object]"`, which the Go server's `json.Unmarshal` fails on silently. With `ctx = nil`, the server falls back to the newest `limit` messages — capped at 100 by the server's hard limit — so every "load more" returns the same 100 messages.

### Fix

Serialise the context with `JSON.stringify` before handing it to `$getv2`. This matches the server's expectation (the query handler calls `json.Unmarshal` on the string value).

### Tests

Added two unit tests in `tests/unit/stores/message.spec.js` covering:
- Object context is serialised to a JSON string before hitting the API.
- Null context is left as `null`.

## Test plan

- [ ] CI Vitest suite passes
- [ ] Manual verification on ModTools approved messages: scroll past 100 posts without hitting the cap
- [ ] Netlify preview for ModTools (when available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)