### PR TITLE
fix(tests): compare hostnames in modtools-login URL assertion

### DIFF
--- a/iznik-nuxt3/tests/e2e/test-modtools-login.spec.js
+++ b/iznik-nuxt3/tests/e2e/test-modtools-login.spec.js
@@ -25,10 +25,15 @@ test.describe('ModTools login tests', () => {
       timeout: timeouts.ui.appearance,
     })
 
-    // Verify the login modal is displayed and we stayed on the root path
+    // Verify the login modal is displayed and we stayed on the root path.
+    // Compare hostnames because browsers normalise away default ports (:80,
+    // :443) — a raw substring match on modtoolsBaseUrl fails when CI sets
+    // TEST_MODTOOLS_BASE_URL=http://...localhost:80.
     const isModalVisible = await loginModal.first().isVisible()
     expect(isModalVisible).toBe(true)
-    expect(page.url()).toContain(environment.modtoolsBaseUrl)
+    const expected = new URL(environment.modtoolsBaseUrl)
+    const actual = new URL(page.url())
+    expect(actual.hostname).toBe(expected.hostname)
   })
 
   test('login page should display login prompt', async ({


### PR DESCRIPTION
## Summary
- `test-modtools-login.spec.js:10` fails consistently on open PRs (#154, #178, #179, #180, #181) because `expect(page.url()).toContain(environment.modtoolsBaseUrl)` does an exact substring match. CI sets `TEST_MODTOOLS_BASE_URL=http://...localhost:${PORT_TRAEFIK_HTTP:-80}` which renders with an explicit `:80`, but browsers normalise default ports out of `page.url()` — so the substring never matches.
- Switch to URL-hostname comparison, which is immune to port normalisation.

## Why this is unblocking coverage PRs
This single assertion failure is the shared cause of the `ci/circleci: build-and-test` red status on every open coverage PR. Once this merges to master, reruns on those PRs should go green (the one other failure seen, a teardown race in `test-reply-flow-existing-user.spec.js`, appears flaky — it fails on only some of the runs).

## Test plan
- [ ] CI passes on this PR (modtools-login test now passes under both `localhost` and `localhost:80`).
- [ ] Open coverage PRs (#178–#181) pass build-and-test after rebase/rerun on master once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)