### PR TITLE
fix(modconfig): V1 parity — return 200+ret instead of 404/403

### DIFF
--- a/iznik-server-go/modconfig/modconfig.go
+++ b/iznik-server-go/modconfig/modconfig.go
@@ -136,12 +136,14 @@ func GetModConfig(c *fiber.Ctx) error {
 	var cfg ModConfig
 	db.Raw("SELECT "+configColumns+" FROM mod_configs WHERE id = ?", id).Scan(&cfg)
 	if cfg.ID == 0 {
-		return fiber.NewError(fiber.StatusNotFound, "Invalid config id")
+		// V1 parity: return 200 with ret:2. The frontend treats
+		// non-200 as a fatal "Settings inaccessible" error (9518.180).
+		return c.JSON(fiber.Map{"ret": 2, "status": "Invalid config id"})
 	}
 
 	// Verify the user can see this config.
 	if !canSee(myid, &cfg) {
-		return fiber.NewError(fiber.StatusForbidden, "Not authorised")
+		return c.JSON(fiber.Map{"ret": 3, "status": "Not authorised"})
 	}
 
 	// Get standard messages.

--- a/iznik-server-go/test/modconfig_test.go
+++ b/iznik-server-go/test/modconfig_test.go
@@ -46,6 +46,25 @@ func TestGetModConfigSingle(t *testing.T) {
 	assert.Contains(t, cfg, "stdmsgs")
 }
 
+// V1 returns HTTP 200 with ret:2 for an invalid / deleted config id. Go
+// previously returned 404, which the frontend surfaced as "Settings
+// inaccessible" (9518.180). Keep V1 parity.
+func TestGetModConfigInvalidID(t *testing.T) {
+	prefix := uniquePrefix("ModCfgBadID")
+	modID := CreateTestUser(t, prefix+"_mod", "User")
+	_, token := CreateTestSession(t, modID)
+
+	// An id that definitely doesn't exist.
+	req := httptest.NewRequest("GET", fmt.Sprintf("/api/modtools/modconfig?id=99999999&jwt=%s", token), nil)
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json2.Unmarshal(rsp(resp), &result)
+	assert.Equal(t, float64(2), result["ret"])
+	assert.Equal(t, "Invalid config id", result["status"])
+}
+
 func TestPostModConfig(t *testing.T) {
 	prefix := uniquePrefix("ModCfgPost")
 	groupID := CreateTestGroup(t, prefix)


### PR DESCRIPTION
## Summary
- Neville (Discourse 9518.180): "Settings inaccessible — 404 on `/modtools/modconfig?id=30307`". The frontend surfaces the 404 as a fatal 500 modal.
- V1 PHP returns HTTP 200 with `{ret:2, status:"Invalid config id"}` when the referenced config id is absent. Go was returning 404.
- Matched V1 for both the invalid-id (ret:2) and canSee-forbidden (ret:3) branches of `GetModConfig`.
- Added `TestGetModConfigInvalidID` (TDD — failing before the change, passing now). Full modconfig suite green (13/13).

## Test plan
- [x] `go test ./test -run ModConfig` passes locally.
- [ ] Neville to retest after deploy — Settings should now load (or gracefully report the stale id).

🤖 Generated with [Claude Code](https://claude.com/claude-code)