### PR TITLE
fix(stats): authority autocomplete crash + V2 dashboard parity on :id page

### DIFF
--- a/iznik-nuxt3/composables/useAuthoritySearch.js
+++ b/iznik-nuxt3/composables/useAuthoritySearch.js
@@ -1,0 +1,17 @@
+export function normalizeAuthoritySearch(results, limit = 5) {
+  // V2 Go API returns a bare array; V1 PHP returned { authorities: [...] }.
+  const list = Array.isArray(results)
+    ? results
+    : Array.isArray(results?.authorities)
+      ? results.authorities
+      : []
+
+  const trimmed = list.slice(0, limit)
+  const ret = []
+  for (const authority of trimmed) {
+    if (authority && authority.name) {
+      ret.push(authority)
+    }
+  }
+  return ret
+}

--- a/iznik-nuxt3/composables/useAuthoritySearch.js
+++ b/iznik-nuxt3/composables/useAuthoritySearch.js
@@ -1,3 +1,12 @@
+// Dashboard Outcomes dates arrive as "YYYY-MM" (V1 PHP legacy) or as
+// "YYYY-MM-DDT..." ISO datetimes (V2 Go API). dayjs happily parses both
+// when we normalise to a plain "YYYY-MM-DD" string.
+export function parseOutcomeDate(date) {
+  if (!date || typeof date !== 'string') return ''
+  if (date.length === 7) return date + '-01'
+  return date.slice(0, 10)
+}
+
 export function normalizeAuthoritySearch(results, limit = 5) {
   // V2 Go API returns a bare array; V1 PHP returned { authorities: [...] }.
   const list = Array.isArray(results)

--- a/iznik-nuxt3/pages/stats/authorities.vue
+++ b/iznik-nuxt3/pages/stats/authorities.vue
@@ -32,6 +32,7 @@
 import { ref, useRoute, useRouter, useHead, useRuntimeConfig } from '#imports'
 import AutoComplete from '~/components/AutoComplete.vue'
 import { buildHead } from '~/composables/useBuildHead'
+import { normalizeAuthoritySearch } from '~/composables/useAuthoritySearch'
 
 // Setup stores and route
 const runtimeConfig = useRuntimeConfig()
@@ -54,19 +55,7 @@ useHead(
 
 // Methods
 function process(results) {
-  const authorities =
-    results.authorities.length > 5
-      ? results.authorities.slice(0, 5)
-      : results.authorities
-  const ret = []
-  for (const authority of authorities) {
-    if (authority && authority.name) {
-      ret.push(authority)
-    }
-  }
-
-  results.value = ret
-  return ret
+  return normalizeAuthoritySearch(results, 5)
 }
 
 function select(auth) {

--- a/iznik-nuxt3/pages/stats/authority/[[id]].vue
+++ b/iznik-nuxt3/pages/stats/authority/[[id]].vue
@@ -314,12 +314,12 @@
                 <b-col
                   class="border border-white p-0 bg-white text-center pt-1"
                 >
-                  <H5>WEIGHTS (KG)</H5>
+                  <h5>WEIGHTS (KG)</h5>
                 </b-col>
                 <b-col
                   class="border border-white p-0 bg-white text-center pt-1"
                 >
-                  <H5>MEMBERS</H5>
+                  <h5>MEMBERS</h5>
                 </b-col>
               </b-row>
               <b-row class="m-0">
@@ -412,6 +412,7 @@ import { MAX_MAP_ZOOM } from '~/constants'
 import StatsImpact from '~/components/StatsImpact.vue'
 import { buildHead } from '~/composables/useBuildHead'
 import { useStatsStore } from '~/stores/stats'
+import { parseOutcomeDate } from '~/composables/useAuthoritySearch'
 import {
   getBenefitPerTonne,
   CO2_PER_TONNE,
@@ -550,13 +551,15 @@ const totalGifts = computed(() => {
   for (const groupid in stats.value) {
     const overlapValue = overlap(groupid)
     const stat = stats.value[groupid]
-    const outcomes = stat.OutcomesPerMonth
+    const outcomes = Array.isArray(stat.OutcomesPerMonth)
+      ? stat.OutcomesPerMonth
+      : []
 
     const start = dayjs(startDate.value)
     const end = dayjs(endDate.value)
 
     for (const outcome of outcomes) {
-      const m = dayjs(outcome.date + '-01')
+      const m = dayjs(parseOutcomeDate(outcome.date))
 
       if (!m.isBefore(start) && !m.isAfter(end)) {
         count += outcome.count * overlapValue
@@ -838,14 +841,16 @@ const last3MonthsGiftsTotal = computed(() => {
     for (const groupid in stats.value) {
       const overlapValue = overlap(groupid)
       const stat = stats.value[groupid]
-      const outcomes = stat.OutcomesPerMonth
+      const outcomes = Array.isArray(stat.OutcomesPerMonth)
+        ? stat.OutcomesPerMonth
+        : []
       let thisone = 0
 
       const start = last3Months.value[mon].startOf('month')
       const end = last3Months.value[mon].endOf('month')
 
       for (const outcome of outcomes) {
-        const m = dayjs(outcome.date + '-01')
+        const m = dayjs(parseOutcomeDate(outcome.date))
 
         if (!m.isBefore(start) && !m.isAfter(end)) {
           thisone += outcome.count * overlapValue
@@ -930,12 +935,12 @@ const last3MonthsGroups = computed(() => {
 
 // Initialize date range
 // Default end is last complete month, and start is a year before that, so we cover twelve months.
-endDate.value = dayjs().subtract(1, 'month').endOf('month').format()
+endDate.value = dayjs().subtract(1, 'month').endOf('month').toDate()
 startDate.value = dayjs(endDate.value)
   .subtract(1, 'year')
   .add(1, 'month')
   .startOf('month')
-  .format()
+  .toDate()
 
 // Methods
 function mapPoly(poly, options) {
@@ -993,13 +998,14 @@ async function fetchData(id) {
     await statsStore.fetch({
       group: group.id,
       grouptype: 'Freegle',
+      components: 'Weight,ApprovedMemberCount,Outcomes',
       start,
       end,
       force: true,
     })
 
     const overlapValue = group.overlap
-    const weights = statsStore.Weight
+    const weights = Array.isArray(statsStore.Weight) ? statsStore.Weight : []
 
     let totalWeight = 0
     for (const w of weights) {
@@ -1024,8 +1030,12 @@ async function fetchData(id) {
           avpermonth,
           totalweight: totalWeight,
           Weights: weights,
-          ApprovedMemberCount: statsStore.ApprovedMemberCount,
-          OutcomesPerMonth: statsStore.OutcomesPerMonth,
+          ApprovedMemberCount: Array.isArray(statsStore.ApprovedMemberCount)
+            ? statsStore.ApprovedMemberCount
+            : [],
+          OutcomesPerMonth: Array.isArray(statsStore.Outcomes)
+            ? statsStore.Outcomes
+            : [],
           group,
         }
       }

--- a/iznik-nuxt3/tests/unit/composables/useAuthoritySearch.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useAuthoritySearch.spec.js
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+import { normalizeAuthoritySearch } from '~/composables/useAuthoritySearch'
+
+describe('normalizeAuthoritySearch', () => {
+  const a = (id, name) => ({ id, name, area_code: 'Ward' })
+
+  it('accepts the V2 Go shape (bare array) without crashing', () => {
+    const results = [a(1, 'Essex County'), a(2, 'Wessex Ward')]
+    expect(normalizeAuthoritySearch(results)).toEqual(results)
+  })
+
+  it('accepts the V1 PHP shape ({ authorities: [...] })', () => {
+    const results = { authorities: [a(1, 'Essex County'), a(2, 'Wessex Ward')] }
+    expect(normalizeAuthoritySearch(results)).toEqual(results.authorities)
+  })
+
+  it('caps the number of results at the default limit of 5', () => {
+    const big = Array.from({ length: 12 }, (_, i) => a(i, 'Authority ' + i))
+    expect(normalizeAuthoritySearch(big)).toHaveLength(5)
+  })
+
+  it('honours a custom limit', () => {
+    const big = Array.from({ length: 12 }, (_, i) => a(i, 'Authority ' + i))
+    expect(normalizeAuthoritySearch(big, 3)).toHaveLength(3)
+  })
+
+  it('filters out entries missing a name', () => {
+    const results = [a(1, 'Essex County'), { id: 2 }, null, a(3, 'Wessex Ward')]
+    const ret = normalizeAuthoritySearch(results)
+    expect(ret).toHaveLength(2)
+    expect(ret.map((r) => r.id)).toEqual([1, 3])
+  })
+
+  it('returns an empty array for null/undefined input', () => {
+    expect(normalizeAuthoritySearch(null)).toEqual([])
+    expect(normalizeAuthoritySearch(undefined)).toEqual([])
+  })
+
+  it('returns an empty array for unexpected shapes', () => {
+    expect(normalizeAuthoritySearch({})).toEqual([])
+    expect(normalizeAuthoritySearch({ authorities: null })).toEqual([])
+    expect(normalizeAuthoritySearch('Essex')).toEqual([])
+  })
+
+  it('returns an empty array when the array is empty', () => {
+    expect(normalizeAuthoritySearch([])).toEqual([])
+    expect(normalizeAuthoritySearch({ authorities: [] })).toEqual([])
+  })
+})

--- a/iznik-nuxt3/tests/unit/composables/useAuthoritySearch.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useAuthoritySearch.spec.js
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest'
-import { normalizeAuthoritySearch } from '~/composables/useAuthoritySearch'
+import {
+  normalizeAuthoritySearch,
+  parseOutcomeDate,
+} from '~/composables/useAuthoritySearch'
 
 describe('normalizeAuthoritySearch', () => {
   const a = (id, name) => ({ id, name, area_code: 'Ward' })
@@ -45,5 +48,26 @@ describe('normalizeAuthoritySearch', () => {
   it('returns an empty array when the array is empty', () => {
     expect(normalizeAuthoritySearch([])).toEqual([])
     expect(normalizeAuthoritySearch({ authorities: [] })).toEqual([])
+  })
+})
+
+describe('parseOutcomeDate', () => {
+  it('pins the V1 "YYYY-MM" shape to the first of the month', () => {
+    expect(parseOutcomeDate('2025-04')).toBe('2025-04-01')
+  })
+
+  it('strips the time portion from the V2 ISO datetime shape', () => {
+    expect(parseOutcomeDate('2025-04-15T00:00:00Z')).toBe('2025-04-15')
+    expect(parseOutcomeDate('2025-04-15T23:59:59+01:00')).toBe('2025-04-15')
+  })
+
+  it('passes through a plain "YYYY-MM-DD" unchanged', () => {
+    expect(parseOutcomeDate('2025-04-15')).toBe('2025-04-15')
+  })
+
+  it('returns an empty string for falsy/non-string input', () => {
+    expect(parseOutcomeDate(null)).toBe('')
+    expect(parseOutcomeDate(undefined)).toBe('')
+    expect(parseOutcomeDate(123)).toBe('')
   })
 })


### PR DESCRIPTION
## Summary

The `/stats/authorities` autocomplete crashed as soon as a user typed a
search term: the inline `process()` callback assumed the V1 PHP response
shape (`{ authorities: [...] }`) while the V2 Go API returns a bare
array, so `results.authorities.length` threw.

Once the dropdown worked and a council was selected, the `/stats/authority/:id`
page threw `TypeError: weights is not iterable` and never rendered,
leaving the user stuck on "Crunching the numbers…".

## Changes

**Autocomplete (`pages/stats/authorities.vue` + new composable):**
- New `composables/useAuthoritySearch.js` exporting `normalizeAuthoritySearch()`
  that accepts both V2 bare-array and V1 `{ authorities: [...] }` shapes,
  filters entries missing a name, and caps the list to the requested limit.

**Authority stats page (`pages/stats/authority/[[id]].vue`):**
- Request `Weight,ApprovedMemberCount,Outcomes` explicitly from the V2 dashboard.
  The legacy PHP response shipped them by default; the Go API only returns
  them when requested.
- Guard `Weight`/`ApprovedMemberCount`/`Outcomes` iterations with
  `Array.isArray` fallbacks so an empty or mod-gated component never throws.
- Route Outcomes dates through a new `parseOutcomeDate()` helper that
  handles both the V1 "YYYY-MM" shape and the V2 ISO datetime shape.
- Initialise the date-range refs as `Date` objects so `OurDatePicker`
  stops emitting Vue prop-type warnings.
- Lowercase the two `<H5>` headings — Vue was treating them as unknown
  components.

**Tests (`tests/unit/composables/useAuthoritySearch.spec.js`):**
- 8 cases for `normalizeAuthoritySearch` (V1/V2 shapes, limits, missing
  names, null, unexpected shapes, empty).
- 4 cases for `parseOutcomeDate` (V1 month-only, V2 ISO, plain date, falsy).
- All 12 pass.

## Known follow-ups (separate PRs)

- The V2 Go dashboard gates `ApprovedMemberCount` behind `isMod`, so the
  MEMBERS chart is empty for anonymous visitors. V1's legacy dashboard
  path served aggregate member counts publicly; restoring that parity is
  a backend change.

## Test plan
- [x] Vitest: 12 new tests pass
- [x] Chrome MCP: type "Essex" on `/stats/authorities` → dropdown with 5
  results; click "Essex County" → navigates to `/stats/authority/117233`
- [x] `/stats/authority/117233` renders: 278 tonnes, £283,141 benefit,
  10,817 gifts, 21 groups, WEIGHTS chart with 13 monthly bars
- [x] Console is clean of the old "weights is not iterable", "Failed to
  resolve component: H5", and OurDatePicker prop-type warnings
