### PR TITLE
fix(stats): chart column types + ad CSS binding

### DIFF
--- a/iznik-nuxt3/components/ExternalDa.vue
+++ b/iznik-nuxt3/components/ExternalDa.vue
@@ -373,8 +373,11 @@ function rippleRendered(rendered) {
   }
 }
 
+// v-bind in scoped <style> emits the returned value directly into CSS, so
+// it must be a valid CSS value — not a boolean. `pointer-events: true` is
+// invalid and triggers "Invalid value used for CSS binding" warnings.
 const passClicks = computed(() => {
-  return !adShown.value
+  return adShown.value ? 'none' : 'auto'
 })
 
 onBeforeUnmount(() => {

--- a/iznik-nuxt3/composables/useAuthoritySearch.js
+++ b/iznik-nuxt3/composables/useAuthoritySearch.js
@@ -7,6 +7,19 @@ export function parseOutcomeDate(date) {
   return date.slice(0, 10)
 }
 
+// Header row for Google Charts weight/member series on the authority stats
+// page. Explicit types prevent "axis #0 cannot be of type string" when
+// the data rows are empty (anonymous visitors don't get ApprovedMemberCount).
+export const DASHBOARD_CHART_HEADER = [
+  { type: 'date', label: 'Date' },
+  { type: 'number', label: 'Count' },
+]
+
+// True when the chart has at least one data row beyond the header.
+export function hasChartDataRows(data) {
+  return Array.isArray(data) && data.length > 1
+}
+
 export function normalizeAuthoritySearch(results, limit = 5) {
   // V2 Go API returns a bare array; V1 PHP returned { authorities: [...] }.
   const list = Array.isArray(results)

--- a/iznik-nuxt3/pages/stats/authority/[[id]].vue
+++ b/iznik-nuxt3/pages/stats/authority/[[id]].vue
@@ -332,10 +332,14 @@
                 </b-col>
                 <b-col class="border border-white p-0 bg-white overflow-hidden">
                   <GChart
+                    v-if="hasMemberData"
                     type="LineChart"
                     :data="memberData"
                     :options="memberOptions"
                   />
+                  <div v-else class="text-center text-muted small p-3">
+                    Member counts are only visible to moderators.
+                  </div>
                 </b-col>
               </b-row>
               <b-card variant="white" class="border-white">
@@ -412,7 +416,11 @@ import { MAX_MAP_ZOOM } from '~/constants'
 import StatsImpact from '~/components/StatsImpact.vue'
 import { buildHead } from '~/composables/useBuildHead'
 import { useStatsStore } from '~/stores/stats'
-import { parseOutcomeDate } from '~/composables/useAuthoritySearch'
+import {
+  parseOutcomeDate,
+  DASHBOARD_CHART_HEADER,
+  hasChartDataRows,
+} from '~/composables/useAuthoritySearch'
 import {
   getBenefitPerTonne,
   CO2_PER_TONNE,
@@ -593,7 +601,7 @@ const weightByMonth = computed(() => {
 })
 
 const weightData = computed(() => {
-  const ret = [['Date', 'Count']]
+  const ret = [DASHBOARD_CHART_HEADER]
   for (const mon in weightByMonth.value) {
     ret.push([new Date(mon + '-01'), weightByMonth.value[mon]])
   }
@@ -602,7 +610,7 @@ const weightData = computed(() => {
 })
 
 const memberData = computed(() => {
-  const ret = [['Date', 'Count']]
+  const ret = [DASHBOARD_CHART_HEADER]
   const dates = []
 
   for (const groupid in stats.value) {
@@ -627,6 +635,8 @@ const memberData = computed(() => {
 
   return ret
 })
+
+const hasMemberData = computed(() => hasChartDataRows(memberData.value))
 
 const totalMembers = computed(() => {
   let ret = 0

--- a/iznik-nuxt3/tests/unit/components/ExternalDa.spec.js
+++ b/iznik-nuxt3/tests/unit/components/ExternalDa.spec.js
@@ -330,16 +330,19 @@ describe('ExternalDa', () => {
   })
 
   describe('passClicks computed', () => {
-    it('returns false when adShown is true', () => {
+    // passClicks feeds straight into `pointer-events` via v-bind in <style>,
+    // so it must resolve to a real CSS keyword. Booleans trigger the Vue
+    // "Invalid value used for CSS binding" warning.
+    it("returns 'none' when adShown is true", () => {
       const wrapper = createWrapper()
       wrapper.vm.adShown = true
-      expect(wrapper.vm.passClicks).toBe(false)
+      expect(wrapper.vm.passClicks).toBe('none')
     })
 
-    it('returns true when adShown is false', () => {
+    it("returns 'auto' when adShown is false", () => {
       const wrapper = createWrapper()
       wrapper.vm.adShown = false
-      expect(wrapper.vm.passClicks).toBe(true)
+      expect(wrapper.vm.passClicks).toBe('auto')
     })
   })
 

--- a/iznik-nuxt3/tests/unit/composables/useAuthoritySearch.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useAuthoritySearch.spec.js
@@ -2,6 +2,8 @@ import { describe, it, expect } from 'vitest'
 import {
   normalizeAuthoritySearch,
   parseOutcomeDate,
+  DASHBOARD_CHART_HEADER,
+  hasChartDataRows,
 } from '~/composables/useAuthoritySearch'
 
 describe('normalizeAuthoritySearch', () => {
@@ -69,5 +71,34 @@ describe('parseOutcomeDate', () => {
     expect(parseOutcomeDate(null)).toBe('')
     expect(parseOutcomeDate(undefined)).toBe('')
     expect(parseOutcomeDate(123)).toBe('')
+  })
+})
+
+describe('DASHBOARD_CHART_HEADER', () => {
+  it('types column 0 as date so Google Charts does not infer string', () => {
+    expect(DASHBOARD_CHART_HEADER[0]).toEqual({ type: 'date', label: 'Date' })
+  })
+
+  it('types column 1 as number', () => {
+    expect(DASHBOARD_CHART_HEADER[1]).toEqual({ type: 'number', label: 'Count' })
+  })
+})
+
+describe('hasChartDataRows', () => {
+  it('is false for a header-only dataset', () => {
+    expect(hasChartDataRows([DASHBOARD_CHART_HEADER])).toBe(false)
+  })
+
+  it('is true when at least one data row is present', () => {
+    expect(
+      hasChartDataRows([DASHBOARD_CHART_HEADER, [new Date('2025-04-01'), 42]])
+    ).toBe(true)
+  })
+
+  it('is false for non-array input', () => {
+    expect(hasChartDataRows(null)).toBe(false)
+    expect(hasChartDataRows(undefined)).toBe(false)
+    expect(hasChartDataRows('nope')).toBe(false)
+    expect(hasChartDataRows([])).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary

Two small fixes discovered while verifying the /stats/authority/:id page works end-to-end for anonymous (non-mod) visitors after the V2 migration:

- **MEMBERS chart "axis #0 cannot be of type string"** — Go's V2 dashboard gates `ApprovedMemberCount` behind mod auth, so anonymous visitors got a header-only dataset. Google Charts then inferred the column type from the label row as string. Added `DASHBOARD_CHART_HEADER` with explicit `{type:'date'}` / `{type:'number'}` typing, added `hasChartDataRows()`, and wrapped the MEMBERS chart in `v-if` so it hides entirely with a short "visible to moderators" note when empty.
- **Ad CSS binding warning** — `ExternalDa.vue`'s `passClicks` computed returned a boolean that fed straight into `pointer-events: v-bind(passClicks)` in a scoped `<style>`. Vue flagged "Invalid value used for CSS binding" because `true`/`false` aren't valid `pointer-events` keywords. Returning `'none'`/`'auto'` makes it valid CSS.

## Test plan
- [x] 5 new tests in `useAuthoritySearch.spec.js` covering `DASHBOARD_CHART_HEADER` shape and the `hasChartDataRows` empty/non-empty/non-array paths
- [x] Updated `ExternalDa.spec.js` assertions to the new string return values
- [x] Full Vitest suite: 11,792 / 11,792 pass
- [ ] Verify `/stats/authority/:id` renders for anonymous visitor on the Netlify preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)