### PR TITLE
fix(ModLogsModal): dedupe logs on push (9518.181)

### DIFF
--- a/iznik-nuxt3/modtools/stores/logs.js
+++ b/iznik-nuxt3/modtools/stores/logs.js
@@ -34,14 +34,19 @@ export const useLogsStore = defineStore({
 
       if (params && params.id) {
         logs = data.log || []
-        this.list.push(...logs)
       } else {
         logs = data.logs || []
-        this.list.push(...logs)
         this.context = data.context
 
         ret = data.context
       }
+
+      // Dedupe by id. Concurrent fetchChunk calls from rapid re-opens of
+      // ModLogsModal can both see context=null and return the same page,
+      // pushing duplicate rows into the shared store list (9518.181).
+      const existingIds = new Set(this.list.map((l) => l.id))
+      const newLogs = logs.filter((l) => !existingIds.has(l.id))
+      this.list.push(...newLogs)
 
       // V2 pattern: API returns IDs only. Fetch related entities from stores
       // and attach them so components can access log.user, log.message, etc.

--- a/iznik-nuxt3/tests/unit/stores/logs.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/logs.spec.js
@@ -152,6 +152,46 @@ describe('logs store', () => {
     expect(store.list).toHaveLength(2)
   })
 
+  it('dedupes logs across concurrent fetches returning same page', async () => {
+    // Reproduces Discourse 9518.181: rapid repeated opens of ModLogsModal
+    // ran fetchChunk concurrently. Both saw context=null and returned page 1,
+    // pushing identical rows into the shared store list.
+    const store = useLogsStore()
+    store.init({})
+    mockLogsFetch.mockResolvedValue({
+      logs: [
+        { id: 10, type: 'Message' },
+        { id: 11, type: 'Message' },
+        { id: 12, type: 'Message' },
+      ],
+      context: { id: 12 },
+    })
+
+    await Promise.all([store.fetch({}), store.fetch({}), store.fetch({})])
+
+    expect(store.list).toHaveLength(3)
+    expect(store.list.map((l) => l.id).sort()).toEqual([10, 11, 12])
+  })
+
+  it('dedupes logs when sequential fetch returns overlapping rows', async () => {
+    const store = useLogsStore()
+    store.init({})
+    mockLogsFetch.mockResolvedValueOnce({
+      logs: [{ id: 1 }, { id: 2 }],
+      context: { id: 2 },
+    })
+    mockLogsFetch.mockResolvedValueOnce({
+      logs: [{ id: 2 }, { id: 3 }],
+      context: { id: 3 },
+    })
+
+    await store.fetch({})
+    await store.fetch({})
+
+    expect(store.list).toHaveLength(3)
+    expect(store.list.map((l) => l.id)).toEqual([1, 2, 3])
+  })
+
   it('setParams stores params', () => {
     const store = useLogsStore()
     store.setParams({ groupid: 5 })


### PR DESCRIPTION
## Summary

Fixes Discourse [9518.181](https://discourse.ilovefreegle.org/t/9518/181) — @Neville_Reid reported the ModLogsModal on the Pending Message page showed the same four-row block repeated three times.

## Root cause (client-side, not server)

The V2 Go query is `SELECT logs.* FROM logs WHERE ... ORDER BY logs.id DESC LIMIT ?` — no amplifying JOIN, pagination is exclusive (`logs.id < ?`). A single call cannot return the same log row twice. Verified against V1 PHP (`Log.php:121,145`) which uses the identical pattern.

The duplication happens client-side:

- Multiple `ModLogsModal` / `ModPostingHistory` instances on the same page share one global Pinia `useLogsStore`.
- Rapid re-opens can run `fetchChunk` concurrently. Both in-flight fetches see `this.context === null`, both request page 1, both push identical rows into the shared `list`.
- The block-3 modmail text variant in the screenshot (`using blank letter — Leave`) is consistent with 3 separate fetches where Posted/Held/Joined repeat but the Modmail row differs because another modmail was sent between opens.

## Fix

Dedupe by `id` on push in `modtools/stores/logs.js`. Minimal behaviour change — prevents accumulation regardless of how many concurrent or sequential fetches run over overlapping pages.

## Test plan

- [x] New Vitest test — concurrent fetches returning the same page produce 3 rows not 9.
- [x] New Vitest test — sequential overlapping pages dedup correctly.
- [x] Full Vitest suite 11794/11794 pass.
- [ ] Volunteer retest via Netlify preview (frontend-only fix).

## Follow-up — not addressed here

@Neville_Reid also reports log entries out of order on the Member page (Posted row with timestamp 00:52 above rows with 08:28/08:30). Both V1 and V2 `ORDER BY id DESC`, so the rendered order is deterministic by insertion id. That suggests the underlying `logs` row for the Received event has a higher id than the Hold/Modmail rows — a data artefact (possibly a re-insertion path in PHP `Message::create`), not a V2 regression. Worth a separate investigation with live-DB access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)