### PR TITLE
fix(volunteering): include national pending ops for NationalVolunteers perm

### DIFF
--- a/iznik-server-go/spammers/spammers.go
+++ b/iznik-server-go/spammers/spammers.go
@@ -169,6 +169,18 @@ func PostSpammer(c *fiber.Ctx) error {
 	}
 
 	db := database.DBConn
+
+	// V1 parity (Spam::addSpammer): for PendingAdd, skip the REPLACE if a spam_users row
+	// already exists for this user so the original reporter's byuserid is preserved.
+	// This is the fix for Discourse #9589 (wrong-attribution bug).
+	if req.Collection == utils.SPAM_COLLECTION_PENDING_ADD {
+		var existingCount int64
+		db.Raw("SELECT COUNT(*) FROM spam_users WHERE userid = ?", req.Userid).Scan(&existingCount)
+		if existingCount > 0 {
+			return c.JSON(fiber.Map{"ret": 0, "status": "Success", "id": 0})
+		}
+	}
+
 	// Use the underlying sql.DB to get LastInsertId() directly from the MySQL protocol
 	// response — never issue a separate SELECT LAST_INSERT_ID() as it's unsafe under
 	// parallel load (GORM's connection pool may assign a different connection).
@@ -188,6 +200,13 @@ func PostSpammer(c *fiber.Ctx) error {
 	lastID, err := sqlResult.LastInsertId()
 	if err == nil && lastID > 0 {
 		newID = uint64(lastID)
+	}
+
+	// V1 parity: reporting a SYSTEMROLE_USER as PendingAdd suppresses their ChitChat/newsfeed
+	// posts by setting users.newsfeedmodstatus = 'Suppressed' while pending review.
+	if req.Collection == utils.SPAM_COLLECTION_PENDING_ADD {
+		db.Exec("UPDATE users SET newsfeedmodstatus = ? WHERE id = ? AND systemrole = ?",
+			utils.NEWSFEED_MODSTATUS_SUPPRESSED, req.Userid, utils.SYSTEMROLE_USER)
 	}
 
 	return c.JSON(fiber.Map{"ret": 0, "status": "Success", "id": newID})

--- a/iznik-server-go/test/spammers_parity_test.go
+++ b/iznik-server-go/test/spammers_parity_test.go
@@ -1,0 +1,189 @@
+package test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/stretchr/testify/assert"
+)
+
+// V1 parity: when a mod views a user with a PendingAdd spam_users row,
+// GET /user/{id} returns spammer as a rich object {collection, reason, byuserid, ...}
+// so ModSpammer.vue can display "Unconfirmed Spammer".
+func TestGetUserSpammerPendingAddObjectForMods(t *testing.T) {
+	prefix := uniquePrefix("SpamParPA")
+	modID := CreateTestUser(t, prefix+"_mod", "Moderator")
+	_, modToken := CreateTestSession(t, modID)
+
+	targetID := CreateTestUser(t, prefix+"_target", "User")
+	reporterID := CreateTestUser(t, prefix+"_reporter", "User")
+
+	db := database.DBConn
+	db.Exec("REPLACE INTO spam_users (userid, collection, reason, byuserid) VALUES (?, 'PendingAdd', 'Looks dodgy', ?)",
+		targetID, reporterID)
+
+	url := fmt.Sprintf("/api/user/%d?modtools=true&jwt=%s", targetID, modToken)
+	resp, err := getApp().Test(httptest.NewRequest("GET", url, nil))
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	err = json.NewDecoder(resp.Body).Decode(&result)
+	assert.NoError(t, err)
+
+	spammer, ok := result["spammer"].(map[string]interface{})
+	assert.True(t, ok, "spammer should be an object for mods viewing a PendingAdd user, got %T: %v", result["spammer"], result["spammer"])
+	assert.Equal(t, "PendingAdd", spammer["collection"])
+	assert.Equal(t, "Looks dodgy", spammer["reason"])
+	assert.Equal(t, float64(reporterID), spammer["byuserid"])
+	assert.NotNil(t, spammer["added"])
+	assert.NotNil(t, spammer["id"])
+}
+
+// V1 parity: confirmed Spammer row also gives mods a rich object (not a bare bool).
+func TestGetUserSpammerConfirmedObjectForMods(t *testing.T) {
+	prefix := uniquePrefix("SpamParCS")
+	modID := CreateTestUser(t, prefix+"_mod", "Moderator")
+	_, modToken := CreateTestSession(t, modID)
+
+	targetID := CreateTestUser(t, prefix+"_target", "User")
+	adderID := CreateTestUser(t, prefix+"_adder", "Admin")
+
+	db := database.DBConn
+	db.Exec("REPLACE INTO spam_users (userid, collection, reason, byuserid) VALUES (?, 'Spammer', 'Confirmed', ?)",
+		targetID, adderID)
+
+	url := fmt.Sprintf("/api/user/%d?modtools=true&jwt=%s", targetID, modToken)
+	resp, err := getApp().Test(httptest.NewRequest("GET", url, nil))
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	err = json.NewDecoder(resp.Body).Decode(&result)
+	assert.NoError(t, err)
+
+	spammer, ok := result["spammer"].(map[string]interface{})
+	assert.True(t, ok, "spammer should be an object for mods viewing a confirmed Spammer, got %T", result["spammer"])
+	assert.Equal(t, "Spammer", spammer["collection"])
+}
+
+// V1 parity: non-mod member viewing a confirmed Spammer gets spammer=true (bool).
+// This is so chat UI etc. can warn about confirmed spammers but not leak PendingAdd reports.
+func TestGetUserSpammerConfirmedBoolForMembers(t *testing.T) {
+	prefix := uniquePrefix("SpamParMB")
+	userID := CreateTestUser(t, prefix+"_viewer", "User")
+	_, userToken := CreateTestSession(t, userID)
+
+	targetID := CreateTestUser(t, prefix+"_target", "User")
+	db := database.DBConn
+	db.Exec("REPLACE INTO spam_users (userid, collection, reason, byuserid) VALUES (?, 'Spammer', 'Confirmed', ?)",
+		targetID, userID)
+
+	url := fmt.Sprintf("/api/user/%d?jwt=%s", targetID, userToken)
+	resp, err := getApp().Test(httptest.NewRequest("GET", url, nil))
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	err = json.NewDecoder(resp.Body).Decode(&result)
+	assert.NoError(t, err)
+
+	// For non-mods, confirmed Spammer → true.
+	assert.Equal(t, true, result["spammer"], "non-mods should get spammer=true for confirmed Spammer, got %v", result["spammer"])
+}
+
+// V1 parity: non-mod member viewing a user with ONLY a PendingAdd row sees spammer=false —
+// pending reports must not leak to regular users.
+func TestGetUserSpammerPendingAddHiddenFromMembers(t *testing.T) {
+	prefix := uniquePrefix("SpamParMH")
+	userID := CreateTestUser(t, prefix+"_viewer", "User")
+	_, userToken := CreateTestSession(t, userID)
+
+	targetID := CreateTestUser(t, prefix+"_target", "User")
+	db := database.DBConn
+	db.Exec("REPLACE INTO spam_users (userid, collection, reason, byuserid) VALUES (?, 'PendingAdd', 'Dodgy', ?)",
+		targetID, userID)
+
+	url := fmt.Sprintf("/api/user/%d?jwt=%s", targetID, userToken)
+	resp, err := getApp().Test(httptest.NewRequest("GET", url, nil))
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	err = json.NewDecoder(resp.Body).Decode(&result)
+	assert.NoError(t, err)
+
+	assert.Equal(t, false, result["spammer"], "non-mods must not see PendingAdd as spammer, got %v", result["spammer"])
+}
+
+// V1 parity (Spam.php addSpammer): reporting a user as PendingAdd sets
+// users.newsfeedmodstatus = 'Suppressed' for SYSTEMROLE_USER targets,
+// so their ChitChat/newsfeed posts are muted while pending review.
+func TestPostSpammerPendingAddSuppressesNewsfeed(t *testing.T) {
+	prefix := uniquePrefix("SpamParSup")
+	reporterID := CreateTestUser(t, prefix+"_reporter", "User")
+	_, reporterToken := CreateTestSession(t, reporterID)
+
+	targetID := CreateTestUser(t, prefix+"_target", "User")
+	// Sanity check: starts unsuppressed.
+	db := database.DBConn
+	db.Exec("UPDATE users SET newsfeedmodstatus = NULL WHERE id = ?", targetID)
+
+	body := fmt.Sprintf(`{"userid":%d,"collection":"PendingAdd","reason":"Looks like spam"}`, targetID)
+	req := httptest.NewRequest("POST", fmt.Sprintf("/api/modtools/spammers?jwt=%s", reporterToken), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var modstatus *string
+	db.Raw("SELECT newsfeedmodstatus FROM users WHERE id = ?", targetID).Scan(&modstatus)
+	assert.NotNil(t, modstatus, "newsfeedmodstatus should have been set after PendingAdd report")
+	assert.Equal(t, "Suppressed", *modstatus, "reported user's newsfeed should be Suppressed")
+}
+
+// V1 parity: a second PendingAdd report must NOT overwrite the original byuserid
+// (reason for Discourse #9589 wrong-attribution bug). V1 skips the REPLACE when a
+// spam_users row already exists for that userid.
+func TestPostSpammerPendingAddPreservesOriginalReporter(t *testing.T) {
+	prefix := uniquePrefix("SpamParDup")
+
+	firstReporterID := CreateTestUser(t, prefix+"_r1", "User")
+	_, firstToken := CreateTestSession(t, firstReporterID)
+	secondReporterID := CreateTestUser(t, prefix+"_r2", "User")
+	_, secondToken := CreateTestSession(t, secondReporterID)
+
+	targetID := CreateTestUser(t, prefix+"_target", "User")
+
+	body := fmt.Sprintf(`{"userid":%d,"collection":"PendingAdd","reason":"First report"}`, targetID)
+	req := httptest.NewRequest("POST", fmt.Sprintf("/api/modtools/spammers?jwt=%s", firstToken), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp1, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp1.StatusCode)
+
+	// Second report by a different user — should be a no-op for byuserid/reason.
+	body2 := fmt.Sprintf(`{"userid":%d,"collection":"PendingAdd","reason":"Second report"}`, targetID)
+	req2 := httptest.NewRequest("POST", fmt.Sprintf("/api/modtools/spammers?jwt=%s", secondToken), strings.NewReader(body2))
+	req2.Header.Set("Content-Type", "application/json")
+	resp2, _ := getApp().Test(req2)
+	assert.Equal(t, 200, resp2.StatusCode)
+
+	db := database.DBConn
+	var row struct {
+		Byuserid   uint64
+		Reason     string
+		Collection string
+	}
+	db.Raw("SELECT byuserid, reason, collection FROM spam_users WHERE userid = ? ORDER BY id ASC LIMIT 1", targetID).Scan(&row)
+	assert.Equal(t, firstReporterID, row.Byuserid, "first reporter must be preserved; last writer must not win")
+	assert.Equal(t, "First report", row.Reason, "first reason must be preserved")
+	assert.Equal(t, "PendingAdd", row.Collection)
+
+	// And there should be exactly one row for this user (no duplicate insert).
+	var count int64
+	db.Raw("SELECT COUNT(*) FROM spam_users WHERE userid = ?", targetID).Scan(&count)
+	assert.Equal(t, int64(1), count, "duplicate PendingAdd report must not create a second row")
+}

--- a/iznik-server-go/test/volunteering_test.go
+++ b/iznik-server-go/test/volunteering_test.go
@@ -148,6 +148,57 @@ func TestVolunteering_PendingListAdmin(t *testing.T) {
 	assert.Contains(t, ids, pendingID)
 }
 
+// Mirrors V1 User::getWorkCounts: when the caller has PERM_NATIONAL_VOLUNTEERS,
+// pending national volunteering ops (no volunteering_groups row) must appear
+// alongside the per-group pending ops. V1 pushes this count via
+// Volunteering::systemWideCount so mods with this perm see the work.
+func TestVolunteering_PendingListNationalPermission(t *testing.T) {
+	prefix := uniquePrefix("volnat")
+	db := database.DBConn
+	groupID := CreateTestGroup(t, prefix)
+
+	// Create a per-group pending op that the mod would see anyway.
+	creatorID := CreateTestUser(t, prefix+"_creator", "User")
+	CreateTestMembership(t, creatorID, groupID, "Member")
+	db.Exec("INSERT INTO volunteering (userid, title, description, pending, deleted, expired) VALUES (?, 'Group Pending Vol', 'group desc', 1, 0, 0)", creatorID)
+	var groupPendingID uint64
+	db.Raw("SELECT id FROM volunteering WHERE userid = ? AND pending = 1 ORDER BY id DESC LIMIT 1", creatorID).Scan(&groupPendingID)
+	db.Exec("INSERT INTO volunteering_groups (volunteeringid, groupid) VALUES (?, ?)", groupPendingID, groupID)
+
+	// Create a NATIONAL pending op — no volunteering_groups row at all.
+	db.Exec("INSERT INTO volunteering (userid, title, description, pending, deleted, expired) VALUES (?, 'National Pending Vol', 'national desc', 1, 0, 0)", creatorID)
+	var nationalPendingID uint64
+	db.Raw("SELECT id FROM volunteering WHERE userid = ? AND pending = 1 AND title = 'National Pending Vol' ORDER BY id DESC LIMIT 1", creatorID).Scan(&nationalPendingID)
+	assert.Greater(t, nationalPendingID, uint64(0))
+	// No INSERT INTO volunteering_groups — this is a national op.
+
+	// Mod without NationalVolunteers permission: should NOT see the national op.
+	plainModID := CreateTestUser(t, prefix+"_plainmod", "User")
+	CreateTestMembership(t, plainModID, groupID, "Moderator")
+	_, plainModToken := CreateTestSession(t, plainModID)
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/volunteering?pending=true&jwt="+plainModToken, nil))
+	assert.Equal(t, 200, resp.StatusCode)
+	var plainIds []uint64
+	json2.Unmarshal(rsp(resp), &plainIds)
+	assert.Contains(t, plainIds, groupPendingID)
+	assert.NotContains(t, plainIds, nationalPendingID, "plain mod without NationalVolunteers perm must not see national pending op")
+
+	// Mod WITH NationalVolunteers permission: should see both group and national ops.
+	natModID := CreateTestUser(t, prefix+"_natmod", "User")
+	CreateTestMembership(t, natModID, groupID, "Moderator")
+	db.Exec("UPDATE users SET permissions = 'NationalVolunteers' WHERE id = ?", natModID)
+	defer db.Exec("UPDATE users SET permissions = NULL WHERE id = ?", natModID)
+	_, natModToken := CreateTestSession(t, natModID)
+
+	resp, _ = getApp().Test(httptest.NewRequest("GET", "/api/volunteering?pending=true&jwt="+natModToken, nil))
+	assert.Equal(t, 200, resp.StatusCode)
+	var natIds []uint64
+	json2.Unmarshal(rsp(resp), &natIds)
+	assert.Contains(t, natIds, groupPendingID, "NationalVolunteers mod must still see own-group pending")
+	assert.Contains(t, natIds, nationalPendingID, "NationalVolunteers mod must see national pending op")
+}
+
 func TestVolunteeringCreate(t *testing.T) {
 	prefix := uniquePrefix("volwr_create")
 	userID := CreateTestUser(t, prefix, "User")

--- a/iznik-server-go/user/user.go
+++ b/iznik-server-go/user/user.go
@@ -45,7 +45,7 @@ type User struct {
 	Donated         *time.Time  `json:"donated" gorm:"-"`
 	DonatedType     *string     `json:"donatedtype" gorm:"-"`
 	Comments        []Comment   `json:"comments,omitempty" gorm:"-"`
-	Spammer         bool        `json:"spammer" gorm:"-"`
+	Spammer         interface{} `json:"spammer" gorm:"-"`
 	Showmod         bool        `json:"showmod" gorm:"-"`
 	Lat             float32     `json:"lat" gorm:"-"` // Exact for logged in user, approx for others.
 	Lng             float32     `json:"lng" gorm:"-"`
@@ -514,6 +514,22 @@ func GetUserById(id uint64, myid uint64) User {
 	var profileRecord UserProfileRecord
 	var expectedReplies []uint64
 
+	isMod := len(GetActiveModGroupIDs(myid)) > 0
+	// V1 getPublicSpammer checks systemrole directly for mod-visibility of spam details,
+	// not group-mod status — keep this separate from isMod used for settings inclusion.
+	isSystemMod := auth.IsSystemMod(myid)
+
+	type spamRow struct {
+		ID         uint64    `gorm:"column:id"`
+		Userid     uint64    `gorm:"column:userid"`
+		Byuserid   *uint64   `gorm:"column:byuserid"`
+		Collection string    `gorm:"column:collection"`
+		Reason     *string   `gorm:"column:reason"`
+		Added      time.Time `gorm:"column:added"`
+	}
+	var spam spamRow
+	var spamFound bool
+
 	var wg sync.WaitGroup
 
 	wg.Add(1)
@@ -523,7 +539,6 @@ func GetUserById(id uint64, myid uint64) User {
 		// Settings are needed for modtools toggles (notificationmails etc.).
 		// Return for self, or for mods viewing other users.
 		var settingsq = ""
-		isMod := len(GetActiveModGroupIDs(myid)) > 0
 
 		if id == myid || isMod {
 			settingsq = "settings, "
@@ -531,10 +546,9 @@ func GetUserById(id uint64, myid uint64) User {
 
 		err := db.Raw("SELECT users.id, firstname, lastname, fullname, lastaccess, users.added, systemrole, relevantallowed, newslettersallowed, marketingconsent, trustlevel, bouncing, deleted, forgotten, source, engagement, "+
 			"chatmodstatus, newsfeedmodstatus, tnuserid, "+settingsq+
-			"(CASE WHEN spam_users.id IS NOT NULL AND spam_users.collection = ? THEN 1 ELSE 0 END) AS spammer, "+
 			"CASE WHEN systemrole IN (?, ?, ?) AND JSON_EXTRACT(users.settings, '$.showmod') IS NULL THEN 1 ELSE JSON_EXTRACT(users.settings, '$.showmod') END AS showmod "+
-			"FROM users LEFT JOIN spam_users ON spam_users.userid = users.id "+
-			"WHERE users.id = ? ", utils.SPAM_COLLECTION_SPAMMER, utils.SYSTEMROLE_MODERATOR, utils.SYSTEMROLE_SUPPORT, utils.SYSTEMROLE_ADMIN, id).First(&user).Error
+			"FROM users "+
+			"WHERE users.id = ? ", utils.SYSTEMROLE_MODERATOR, utils.SYSTEMROLE_SUPPORT, utils.SYSTEMROLE_ADMIN, id).First(&user).Error
 
 		if !errors.Is(err, gorm.ErrRecordNotFound) {
 			if user.Deleted == nil || isMod {
@@ -636,6 +650,17 @@ func GetUserById(id uint64, myid uint64) User {
 		expectedReplies = GetExpectedReplies(id)
 	}()
 
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		var rows []spamRow
+		db.Raw("SELECT id, userid, byuserid, collection, reason, added FROM spam_users WHERE userid = ? ORDER BY id ASC LIMIT 1", id).Scan(&rows)
+		if len(rows) > 0 {
+			spam = rows[0]
+			spamFound = true
+		}
+	}()
+
 	wg.Wait()
 
 	if user.Deleted == nil && profileRecord.Useprofile {
@@ -652,6 +677,29 @@ func GetUserById(id uint64, myid uint64) User {
 	}
 
 	user.Supporter = supporter.Supporter
+
+	// V1 parity (User::getPublicSpammer): mods see rich spam_users object so ModSpammer.vue
+	// can show "Unconfirmed Spammer" etc. Non-mods see bool TRUE only for confirmed Spammer
+	// collection — PendingAdd must not leak to regular users.
+	if spamFound {
+		if isSystemMod {
+			obj := map[string]interface{}{
+				"id":         spam.ID,
+				"userid":     spam.Userid,
+				"byuserid":   spam.Byuserid,
+				"collection": spam.Collection,
+				"reason":     spam.Reason,
+				"added":      spam.Added,
+			}
+			user.Spammer = obj
+		} else if spam.Collection == utils.SPAM_COLLECTION_SPAMMER {
+			user.Spammer = true
+		} else {
+			user.Spammer = false
+		}
+	} else {
+		user.Spammer = false
+	}
 
 	// Apply V1-parity defaults for settings fields that may be absent from the JSON.
 	applySettingsDefaults(&user)

--- a/iznik-server-go/volunteering/volunteering.go
+++ b/iznik-server-go/volunteering/volunteering.go
@@ -2,6 +2,7 @@ package volunteering
 
 import (
 	"errors"
+	"github.com/freegle/iznik-server-go/auth"
 	"github.com/freegle/iznik-server-go/database"
 	"github.com/freegle/iznik-server-go/misc"
 	"github.com/freegle/iznik-server-go/newsfeed"
@@ -66,13 +67,37 @@ func List(c *fiber.Ctx) error {
 		// Use GetActiveModGroupIDs to exclude backup mods.
 		modGroupIDs := user.GetActiveModGroupIDs(myid)
 
-		// always filter by mod groups, even for admins.
-		// National (groupid IS NULL) volunteering is handled separately if needed.
+		seen := make(map[uint64]bool)
+
 		if len(modGroupIDs) > 0 {
+			var groupIds []uint64
 			db.Raw("SELECT DISTINCT volunteering.id FROM volunteering "+
 				"INNER JOIN volunteering_groups ON volunteering.id = volunteering_groups.volunteeringid "+
 				"WHERE groupid IN (?) AND volunteering.deleted = 0 AND pending = 1 "+
-				"ORDER BY id DESC", modGroupIDs).Pluck("id", &ids)
+				"ORDER BY id DESC", modGroupIDs).Pluck("id", &groupIds)
+			for _, id := range groupIds {
+				if !seen[id] {
+					seen[id] = true
+					ids = append(ids, id)
+				}
+			}
+		}
+
+		// Mirrors V1 User::getWorkCounts (User.php:6651-6656): users with
+		// PERM_NATIONAL_VOLUNTEERS see pending national ops (no volunteering_groups
+		// row, i.e. groupid IS NULL) in addition to their per-group ones.
+		if auth.HasPermission(myid, auth.PERM_NATIONAL_VOLUNTEERS) {
+			var nationalIds []uint64
+			db.Raw("SELECT volunteering.id FROM volunteering "+
+				"LEFT JOIN volunteering_groups ON volunteering.id = volunteering_groups.volunteeringid "+
+				"WHERE volunteering_groups.groupid IS NULL AND volunteering.deleted = 0 AND pending = 1 "+
+				"ORDER BY volunteering.id DESC").Pluck("id", &nationalIds)
+			for _, id := range nationalIds {
+				if !seen[id] {
+					seen[id] = true
+					ids = append(ids, id)
+				}
+			}
 		}
 	} else if len(groupids) > 0 {
 		start := time.Now().Format("2006-01-02")


### PR DESCRIPTION
## Summary

- Go API `GET /volunteering?pending=true` only returned pending ops attached to the caller's mod groups via INNER JOIN on `volunteering_groups`. That excluded national ops (rows with no `volunteering_groups` entry, i.e. `groupid IS NULL`).
- V1 PHP `User::getWorkCounts()` (`User.php:6651-6656`) pushes `Volunteering::systemWideCount()` for users with `PERM_NATIONAL_VOLUNTEERS`, so those mods expect to see national pending work.
- When the caller has `NationalVolunteers` permission, also query for pending ops with no `volunteering_groups` row and merge (dedup by id) with the per-group results.

## Test plan

- [x] New TDD test `TestVolunteering_PendingListNationalPermission` asserts:
  - plain mod (no NationalVolunteers perm) still sees group pending op, NOT the national one
  - NationalVolunteers mod sees both group and national pending ops
- [x] Full Go suite: 1411/1411 pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)