### PR TITLE
fix(spammers): preserve reporter + reason on PATCH (V1 parity)

### DIFF
--- a/iznik-nuxt3/tests/unit/composables/useId.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useId.spec.js
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { uid } from '~/composables/useId'
+
+describe('useId', () => {
+  it('prefixes with the supplied type', () => {
+    const result = uid('btn-')
+    expect(result.startsWith('btn-')).toBe(true)
+  })
+
+  it('returns a different id on each call', () => {
+    const a = uid('x')
+    const b = uid('x')
+    expect(a).not.toBe(b)
+  })
+
+  it('monotonically increases the numeric suffix', () => {
+    const a = uid('n')
+    const b = uid('n')
+    const aNum = Number(a.slice(1))
+    const bNum = Number(b.slice(1))
+    expect(bNum).toBe(aNum + 1)
+  })
+
+  it('does not share a counter between prefixes (counter is global)', () => {
+    // Documents existing behaviour — a single module-level counter is shared
+    const a = uid('foo-')
+    const b = uid('bar-')
+    expect(Number(b.slice(4))).toBe(Number(a.slice(4)) + 1)
+  })
+})

--- a/iznik-server-go/spammers/spammers.go
+++ b/iznik-server-go/spammers/spammers.go
@@ -252,8 +252,10 @@ func PatchSpammer(c *fiber.Ctx) error {
 	db := database.DBConn
 	var current struct {
 		Collection string
+		Reason     string
+		Byuserid   *uint64
 	}
-	db.Raw("SELECT collection FROM spam_users WHERE id = ?", req.ID).Scan(&current)
+	db.Raw("SELECT collection, reason, byuserid FROM spam_users WHERE id = ?", req.ID).Scan(&current)
 
 	if current.Collection == "" {
 		return fiber.NewError(fiber.StatusNotFound, "Not found")
@@ -271,12 +273,28 @@ func PatchSpammer(c *fiber.Ctx) error {
 		}
 	}
 
-	// Build update.
+	// Build update. V1 parity (Spam::updateSpammer):
+	//   * Preserve the existing reason when the caller sends an empty one — a Hold
+	//     action carries no reason and must not blank out the reporter's facts.
+	//   * Preserve the existing byuserid (original reporter) except for
+	//     PENDING_REMOVE, where V1 tracks who requested removal by setting byuserid
+	//     to the acting mod. Otherwise holding or confirming a report must not
+	//     reassign the report to the current mod (Discourse #9592).
 	if req.Collection != "" {
+		reason := req.Reason
+		if reason == "" {
+			reason = current.Reason
+		}
+		var byuserid interface{}
+		if req.Collection == utils.SPAM_COLLECTION_PENDING_REMOVE {
+			byuserid = myid
+		} else {
+			byuserid = current.Byuserid
+		}
 		db.Exec("UPDATE spam_users SET collection = ?, reason = ?, byuserid = ?, "+
 			"heldby = ?, heldat = CASE WHEN ? IS NOT NULL THEN NOW() ELSE NULL END "+
 			"WHERE id = ?",
-			req.Collection, req.Reason, myid, req.Heldby, req.Heldby, req.ID)
+			req.Collection, reason, byuserid, req.Heldby, req.Heldby, req.ID)
 	}
 
 	return c.JSON(fiber.Map{"ret": 0, "status": "Success"})

--- a/iznik-server-go/test/spammers_test.go
+++ b/iznik-server-go/test/spammers_test.go
@@ -110,6 +110,77 @@ func TestPatchSpammer(t *testing.T) {
 	assert.Equal(t, float64(0), result["ret"])
 }
 
+func TestPatchSpammerPreservesReporterAndReason(t *testing.T) {
+	// V1 parity (Spam::updateSpammer, Discourse #9592): when a moderator Holds
+	// (or otherwise PATCHes within non-PENDING_REMOVE states) a spam_users row,
+	// the original reporter's byuserid and reason must be preserved. Before the
+	// fix, any PATCH overwrote byuserid = myid and reason = req.Reason (which
+	// was empty for a Hold action), losing the original reporter's evidence.
+	prefix := uniquePrefix("SpamPatchPreserve")
+	adminID := CreateTestUser(t, prefix+"_admin", "Admin")
+	_, token := CreateTestSession(t, adminID)
+
+	reporterID := CreateTestUser(t, prefix+"_reporter", "User")
+	targetID := CreateTestUser(t, prefix+"_target", "User")
+
+	db := database.DBConn
+	db.Exec("REPLACE INTO spam_users (userid, collection, reason, byuserid) VALUES (?, ?, ?, ?)",
+		targetID, "PendingAdd", "Original evidence from reporter", reporterID)
+	var spamID uint64
+	db.Raw("SELECT id FROM spam_users WHERE userid = ? ORDER BY id DESC LIMIT 1", targetID).Scan(&spamID)
+
+	// Hold action: sends collection + heldby, no reason.
+	body := fmt.Sprintf(`{"id":%d,"collection":"PendingAdd","heldby":%d}`, spamID, adminID)
+	req := httptest.NewRequest("PATCH", fmt.Sprintf("/api/modtools/spammers?jwt=%s", token), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var row struct {
+		Byuserid *uint64
+		Reason   string
+		Heldby   *uint64
+	}
+	db.Raw("SELECT byuserid, reason, heldby FROM spam_users WHERE id = ?", spamID).Scan(&row)
+	assert.NotNil(t, row.Byuserid, "byuserid must be preserved, not blanked")
+	assert.Equal(t, reporterID, *row.Byuserid, "byuserid must remain the original reporter, not the holding mod")
+	assert.Equal(t, "Original evidence from reporter", row.Reason, "reason must be preserved when PATCH sends an empty reason")
+	assert.NotNil(t, row.Heldby)
+	assert.Equal(t, adminID, *row.Heldby)
+}
+
+func TestPatchSpammerPendingRemoveTracksRequester(t *testing.T) {
+	// V1 parity: moving a confirmed Spammer to PENDING_REMOVE sets byuserid to
+	// the mod requesting removal, so the audit trail shows who's asking.
+	prefix := uniquePrefix("SpamPatchRemove")
+	adminID := CreateTestUser(t, prefix+"_admin", "Admin")
+	_, token := CreateTestSession(t, adminID)
+
+	originalReporter := CreateTestUser(t, prefix+"_reporter", "User")
+	targetID := CreateTestUser(t, prefix+"_target", "User")
+
+	db := database.DBConn
+	db.Exec("REPLACE INTO spam_users (userid, collection, reason, byuserid) VALUES (?, ?, ?, ?)",
+		targetID, "Spammer", "Confirmed bad", originalReporter)
+	var spamID uint64
+	db.Raw("SELECT id FROM spam_users WHERE userid = ? ORDER BY id DESC LIMIT 1", targetID).Scan(&spamID)
+
+	body := fmt.Sprintf(`{"id":%d,"collection":"PendingRemove","reason":"False positive"}`, spamID)
+	req := httptest.NewRequest("PATCH", fmt.Sprintf("/api/modtools/spammers?jwt=%s", token), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var row struct {
+		Byuserid *uint64
+		Reason   string
+	}
+	db.Raw("SELECT byuserid, reason FROM spam_users WHERE id = ?", spamID).Scan(&row)
+	assert.NotNil(t, row.Byuserid)
+	assert.Equal(t, adminID, *row.Byuserid, "PENDING_REMOVE records the mod requesting removal, not the original reporter")
+	assert.Equal(t, "False positive", row.Reason)
+}
+
 func TestDeleteSpammer(t *testing.T) {
 	prefix := uniquePrefix("SpamDel")
 	adminID := CreateTestUser(t, prefix+"_admin", "Admin")


### PR DESCRIPTION
## Summary
- PATCH /spammers now preserves the original reporter's `byuserid` and `reason` when a moderator Holds or otherwise PATCHes a PendingAdd row. Only `PENDING_REMOVE` updates `byuserid` (to the mod requesting removal), matching V1 `Spam::updateSpammer`.
- Fixes Discourse 9592 (Roger reported that Dee's spammer report for user 44864812 lost its facts and was reattributed to Roger after he clicked Hold).

## Root cause
Go `PatchSpammer` always overwrote `byuserid = myid` and `reason = req.Reason`. A Hold action sends `heldby` with no `reason`, so the DB row ended up with `byuserid` = the holding mod and an empty `reason`. V1 protects both fields — see `iznik-server/include/spam/Spam.php::updateSpammer`:
```php
$reason   = $reason ? $reason : $spammer['reason'];
$byuserid = $collection == PENDING_REMOVE && $me ? $me->getId() : $spammer['byuserid'];
```

## Fix
SELECT the existing `reason` and `byuserid` at the top of `PatchSpammer`, fall back to them when the caller sends empty values, and only assign `byuserid = myid` when the target collection is `PENDING_REMOVE`.

## Test plan
- [x] `TestPatchSpammerPreservesReporterAndReason` — Hold on a PendingAdd row: asserts `byuserid` remains the original reporter, `reason` remains the original evidence, `heldby` = the acting mod.
- [x] `TestPatchSpammerPendingRemoveTracksRequester` — moving Spammer → PendingRemove: asserts `byuserid` = the acting mod (V1 behaviour).
- [x] TDD red→green: pre-fix code fails `TestPatchSpammerPreservesReporterAndReason` with an empty `reason` and the wrong `byuserid`.
- [x] Full Go suite 1415/1415 pass via status container.

## Discourse thread
https://discourse.ilovefreegle.org/t/9592/1

🤖 Generated with [Claude Code](https://claude.com/claude-code)