### PR TITLE
fix(merge): guard undefined user.logins (Sentry)

### DIFF
--- a/iznik-nuxt3/composables/useMergeLogins.js
+++ b/iznik-nuxt3/composables/useMergeLogins.js
@@ -1,0 +1,36 @@
+// Build a human-readable summary of how a user has previously signed in,
+// for display on the merge page. Defensively handles users whose `logins`
+// array is missing — the API occasionally returns the field omitted when
+// the user has never logged in, which previously crashed the page
+// (Sentry 7384446789).
+export function formatLogins(user) {
+  const ret = []
+
+  const logins = user?.logins
+  if (!Array.isArray(logins)) {
+    return ''
+  }
+
+  logins.forEach((login) => {
+    switch (login.type) {
+      case 'Native': {
+        ret.push('Email/Password')
+        break
+      }
+      case 'Facebook': {
+        ret.push('Facebook')
+        break
+      }
+      case 'Yahoo': {
+        ret.push('Yahoo')
+        break
+      }
+      case 'Google': {
+        ret.push('Google')
+        break
+      }
+    }
+  })
+
+  return [...new Set(ret)].join(', ')
+}

--- a/iznik-nuxt3/pages/merge.vue
+++ b/iznik-nuxt3/pages/merge.vue
@@ -103,6 +103,7 @@ import SpinButton from '~/components/SpinButton'
 import NoticeMessage from '~/components/NoticeMessage'
 import Api from '~/api'
 import SupportLink from '~/components/SupportLink'
+import { formatLogins } from '~/composables/useMergeLogins'
 
 const ExternalLink = defineAsyncComponent(() =>
   import('~/components/ExternalLink')
@@ -133,40 +134,13 @@ if (!merge.value?.id || !merge.value.user1?.id || !merge.value.user2?.id) {
   invalid.value = true
 }
 
-function logins(user) {
-  const ret = []
+const u1logins = computed(() =>
+  merge.value ? formatLogins(merge.value.user1) : '',
+)
 
-  user.logins.forEach((login) => {
-    switch (login.type) {
-      case 'Native': {
-        ret.push('Email/Password')
-        break
-      }
-      case 'Facebook': {
-        ret.push('Facebook')
-        break
-      }
-      case 'Yahoo': {
-        ret.push('Yahoo')
-        break
-      }
-      case 'Google': {
-        ret.push('Google')
-        break
-      }
-    }
-  })
-
-  return [...new Set(ret)].join(', ')
-}
-
-const u1logins = computed(() => {
-  return merge.value ? logins(merge.value.user1) : ''
-})
-
-const u2logins = computed(() => {
-  return merge.value ? logins(merge.value.user2) : ''
-})
+const u2logins = computed(() =>
+  merge.value ? formatLogins(merge.value.user2) : '',
+)
 
 function mergeit() {
   merging.value = true

--- a/iznik-nuxt3/tests/unit/composables/useMergeLogins.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useMergeLogins.spec.js
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest'
+import { formatLogins } from '~/composables/useMergeLogins'
+
+describe('formatLogins', () => {
+  it('handles a user whose logins array is undefined without throwing (Sentry 7384446789)', () => {
+    // The API sometimes returns a user with no `logins` field at all —
+    // this previously crashed the merge page with
+    // "Cannot read properties of undefined (reading 'forEach')".
+    expect(() => formatLogins({ id: 1 })).not.toThrow()
+    expect(formatLogins({ id: 1 })).toBe('')
+  })
+
+  it('handles a null user without throwing', () => {
+    expect(() => formatLogins(null)).not.toThrow()
+    expect(formatLogins(null)).toBe('')
+  })
+
+  it('handles an empty logins array', () => {
+    expect(formatLogins({ logins: [] })).toBe('')
+  })
+
+  it('maps a single Native login to "Email/Password"', () => {
+    expect(formatLogins({ logins: [{ type: 'Native' }] })).toBe('Email/Password')
+  })
+
+  it('maps each known provider type', () => {
+    const user = {
+      logins: [
+        { type: 'Native' },
+        { type: 'Facebook' },
+        { type: 'Yahoo' },
+        { type: 'Google' },
+      ],
+    }
+    expect(formatLogins(user)).toBe('Email/Password, Facebook, Yahoo, Google')
+  })
+
+  it('deduplicates repeated providers', () => {
+    const user = {
+      logins: [
+        { type: 'Native' },
+        { type: 'Native' },
+        { type: 'Google' },
+        { type: 'Google' },
+      ],
+    }
+    expect(formatLogins(user)).toBe('Email/Password, Google')
+  })
+
+  it('ignores unknown login types silently', () => {
+    const user = {
+      logins: [
+        { type: 'Native' },
+        { type: 'Twitter' },
+        { type: 'Apple' },
+      ],
+    }
+    expect(formatLogins(user)).toBe('Email/Password')
+  })
+
+  it('returns empty string when logins is a non-array truthy value', () => {
+    // Defensive: if the API returns a wrong-shaped value, don't crash.
+    expect(formatLogins({ logins: 'Native' })).toBe('')
+    expect(formatLogins({ logins: { type: 'Native' } })).toBe('')
+  })
+})


### PR DESCRIPTION
## Summary

Fixes Sentry [7384446789](https://freegle.sentry.io/issues/7384446789/) — `TypeError: Cannot read properties of undefined (reading 'forEach')` at `pages/merge.vue`, 4× in the last hour.

When the API returns a user with no `logins` field (can happen for users who've never successfully signed in), the inline `logins(user)` helper on the merge page did `user.logins.forEach(...)` with no guard, crashing the merge UI for support volunteers.

## Changes
- Extract to `composables/useMergeLogins.js` with `Array.isArray` guard → returns `''` when shape is wrong
- `merge.vue` computed refs now call `formatLogins(user)` instead of the local helper
- 8 Vitest tests covering undefined user, null user, empty array, every provider, dedup, unknown types, non-array fallback

## Test plan
- [x] 8 new unit tests pass
- [x] Full Vitest suite still green (11794/11794)
- [ ] CI build-test workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)