### PR TITLE
fix(MyMessage): repost null crash when message not in store (Sentry 7421179445)

### DIFF
--- a/iznik-nuxt3/components/MyMessage.vue
+++ b/iznik-nuxt3/components/MyMessage.vue
@@ -887,36 +887,42 @@ const repost = async (e) => {
     e.stopPropagation()
   }
 
+  // Repost may be triggered via ?action=repost before the store has loaded
+  // the message (e.g. direct link from an email). Sentry 7421179445 caught
+  // message.value.id crashing here — fetch if missing.
+  const msg = message.value || (await messageStore.fetch(props.id, true))
+  if (!msg) return
+
   await composeStore.clearMessages()
 
   await composeStore.setMessage(
     0,
     {
-      id: message.value.id,
-      savedBy: message.value.fromuser,
-      item: message.value.item?.name.trim(),
-      description: message.value.textbody?.trim() || null,
-      availablenow: message.value.availablenow,
-      type: message.value.type,
+      id: msg.id,
+      savedBy: msg.fromuser,
+      item: msg.item?.name.trim(),
+      description: msg.textbody?.trim() || null,
+      availablenow: msg.availablenow,
+      type: msg.type,
       repostof: props.id,
       deadline: null,
     },
     me
   )
 
-  if (message.value.location) {
-    const locs = await locationStore.typeahead(message.value.location.name)
+  if (msg.location) {
+    const locs = await locationStore.typeahead(msg.location.name)
     composeStore.postcode = locs[0]
   }
 
   // Set the group from the original message so the dropdown shows the correct
   // group rather than falling back to groupsnear[0] or a stale localStorage value.
-  if (message.value.groups?.length > 0) {
-    composeStore.group = message.value.groups[0].groupid
+  if (msg.groups?.length > 0) {
+    composeStore.group = msg.groups[0].groupid
   }
 
-  await composeStore.setAttachmentsForMessage(0, message.value.attachments)
-  router.push(message.value.type === 'Offer' ? '/give' : '/find')
+  await composeStore.setAttachmentsForMessage(0, msg.attachments)
+  router.push(msg.type === 'Offer' ? '/give' : '/find')
 }
 
 const hidden = () => {

--- a/iznik-nuxt3/tests/unit/components/MyMessage.spec.js
+++ b/iznik-nuxt3/tests/unit/components/MyMessage.spec.js
@@ -1031,6 +1031,34 @@ describe('MyMessage', () => {
       expect(mockComposeStore.setMessage).toHaveBeenCalled()
     })
 
+    it('fetches message before repost when not yet in store (Sentry 7421179445)', async () => {
+      // Simulate the Sentry case: message not yet in store at mount time.
+      // The useMessageDisplay mock returns ref(mockData.message), so setting
+      // mockData.message = null makes message.value null in the component.
+      const fetchedMessage = {
+        id: 999,
+        type: 'Offer',
+        fromuser: 1,
+        groups: [{ groupid: 1 }],
+        canrepost: true,
+        location: { name: 'AB1 2CD' },
+        item: { name: 'Test item' },
+        attachments: [],
+        availablenow: 1,
+        textbody: 'body',
+      }
+      mockData.message = null
+      mockMessageStore.fetch.mockResolvedValue(fetchedMessage)
+      await createWrapper({ action: 'repost', id: 999 })
+      // Without the fix, message.value.id throws (null.id) and setMessage is
+      // never called with the fetched id.
+      expect(mockComposeStore.setMessage).toHaveBeenCalledWith(
+        0,
+        expect.objectContaining({ id: 999 }),
+        expect.anything()
+      )
+    })
+
     it('redirects to /myposts when outcome modal closes for withdraw action', async () => {
       const wrapper = await createWrapper({ action: 'withdraw' })
       wrapper.vm.onOutcomeHidden()


### PR DESCRIPTION
## Summary
- Sentry 7421179445: `MyMessage.repost()` crashes with `TypeError: Cannot read properties of null (reading 'id')` when triggered via `?action=repost` before the messageStore has loaded the message (e.g. tapping a repost link from an email before Nuxt hydration populates the store).
- Fix: fall back to `messageStore.fetch(props.id, true)` inside `repost()` when `message.value` is null — same pattern already used on the `completed` path (line 969 in MyMessage.vue).

## Code Quality Review
- Minimal change: only the `repost()` function is touched.
- Mirrors existing fallback pattern in `onMounted` for `completed` action.
- No silent catch — if `fetch` also fails to produce a message, `repost()` returns cleanly.

## Future Improvements
- Consider a composable `ensureMessage(id)` helper so the `await message.value || fetch(…)` pattern isn't duplicated across `repost`, `completed`, `edit`, etc.

## Test Plan
- [x] Unit test `fetches message before repost when not yet in store (Sentry 7421179445)`:
  - Simulates Sentry conditions: `mockData.message = null`, `fetch` resolves to a different message with `id: 999`.
  - **Before fix**: fails with `TypeError: Cannot read properties of null (reading 'id')` — matches Sentry stack.
  - **After fix**: passes — `setMessage` called with `id: 999` from fetched message.
- [x] All 167 existing MyMessage tests still pass.