### PR TITLE
chore(test): cover useTwem escape/unescape helpers

### DIFF
--- a/iznik-nuxt3/tests/unit/composables/useTwem.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useTwem.spec.js
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import { twem, untwem } from '~/composables/useTwem'
+
+describe('useTwem', () => {
+  describe('twem', () => {
+    it('coerces numeric input to a string', () => {
+      expect(twem(42)).toBe('42')
+    })
+
+    it('leaves a plain string without escape markers unchanged', () => {
+      expect(twem('hello world')).toBe('hello world')
+    })
+
+    it('returns non-string, non-number values unchanged', () => {
+      const arr = [1, 2, 3]
+      expect(twem(arr)).toBe(arr)
+      expect(twem(null)).toBe(null)
+      expect(twem(undefined)).toBe(undefined)
+    })
+
+    it('converts \\u<codepoint>\\u escape sequences to emoji', () => {
+      // U+1F600 = 😀
+      const result = twem('before \\\\u1f600\\\\u after')
+      expect(result).toContain('before ')
+      expect(result).toContain(' after')
+      expect(result).toContain('😀')
+    })
+
+    it('handles multi-codepoint sequences joined with -', () => {
+      // Flag example: U+1F1EC U+1F1E7 = 🇬🇧
+      const result = twem('flag: \\\\u1f1ec-1f1e7\\\\u end')
+      expect(result).toContain('🇬🇧')
+      expect(result).toContain('flag: ')
+      expect(result).toContain(' end')
+    })
+
+    it('round-trips with untwem', () => {
+      const original = 'hello 😀 world'
+      const escaped = untwem(original)
+      const restored = twem(escaped)
+      expect(restored).toContain('😀')
+      expect(restored).toContain('hello')
+      expect(restored).toContain('world')
+    })
+  })
+
+  describe('untwem', () => {
+    it('returns a plain string without emoji unchanged', () => {
+      expect(untwem('no emoji here')).toBe('no emoji here')
+    })
+
+    it('replaces emoji with \\u<codepoint>\\u escape sequences', () => {
+      const result = untwem('hi 😀')
+      expect(result).toMatch(/\\\\u[0-9a-f]+\\\\u/i)
+      expect(result).toContain('hi ')
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Adds unit coverage for twem() and untwem() in composables/useTwem.js
- Covers numeric coercion, plain-string pass-through, escape-to-emoji conversion (single and multi-codepoint flags), emoji-to-escape, and a round-trip
- Non-string/non-number input passes through unchanged (null/undefined/array)

## Code Quality Review
- Pure helper; no store or Vue reactivity dependencies
- Uses real twemoji library (no mocks) to verify codepoint conversion end-to-end
- Follows useSuppressException.spec.js and useReuseBenefit.spec.js patterns

## Future Improvements
- None — these are the only exports of the module

## Test Plan
- [x] Filtered suite on useTwem: 8/8 pass
- [x] Full suite: 11795 pass
