### PR TITLE
fix(modtools): send admin uses boolean pending, not numeric 0

### DIFF
--- a/iznik-nuxt3/modtools/stores/admins.js
+++ b/iznik-nuxt3/modtools/stores/admins.js
@@ -42,9 +42,10 @@ export const useAdminsStore = defineStore({
       }
     },
     async approve(params) {
+      // Go API binds `pending` to *bool; a numeric 0 here yields 400.
       await api(this.config).admins.patch({
         id: params.id,
-        pending: 0,
+        pending: false,
       })
       await this.fetch({ id: params.id })
     },

--- a/iznik-nuxt3/tests/unit/stores/admins.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/admins.spec.js
@@ -84,6 +84,22 @@ describe('admins store', () => {
     })
   })
 
+  it('approve sends pending as boolean false (not numeric 0)', async () => {
+    const store = useAdminsStore()
+    store.config = {}
+    mockFetch.mockResolvedValue({ id: 7, pending: false })
+
+    await store.approve({ id: 7 })
+
+    expect(mockPatch).toHaveBeenCalledWith({
+      id: 7,
+      pending: false,
+    })
+    // Go API decodes `pending` into *bool, so a numeric 0 would 400.
+    const call = mockPatch.mock.calls[0][0]
+    expect(typeof call.pending).toBe('boolean')
+  })
+
   it('delete removes from list', async () => {
     const store = useAdminsStore()
     store.config = {}


### PR DESCRIPTION
## Summary

Moderators reported (Discourse [topic 9597](https://community.ilovefreegle.org/t/9597)) that clicking **Approve and Send** on a pending ADMIN produced:

> Oh dear! Something went wrong…
> `Error was: {"message":"API Error PATCH /modtools/admin?…loggedInAs=… -> status: 400","statusCode":500}`

## Root cause

`modtools/stores/admins.js::approve()` sends:

```js
await api(this.config).admins.patch({ id: params.id, pending: 0 })
```

The Go handler `PatchAdmin` in `iznik-server-go/admin/admin.go` binds the body to:

```go
type PatchAdminRequest struct {
    …
    Pending *bool `json:"pending,omitempty"`
}
```

Go's `encoding/json` rejects a numeric `0` for a `*bool` target, so Fiber's `BodyParser` returns **400 "Invalid request body"** — never reaching the `UPDATE admins SET pending = 0` branch. The `save()` path in `ModAdmin.vue` already sends a real boolean (`pending: true`), so only the approve/send flow was broken.

## Fix

Send `pending: false` from `approve()`, matching the Go struct's boolean type and the existing `save()` convention.

## Test plan

- [x] New Vitest case `approve sends pending as boolean false (not numeric 0)` asserts the payload shape.
- [x] Demonstrated failure before the fix: `expected pending: false, received pending: 0`.
- [x] All 8 `tests/unit/stores/admins.spec.js` cases pass after the fix (via `curl -s -X POST http://localhost:8081/api/tests/vitest` with filter).
- [ ] Manual repro: reviewer can click **Approve and Send** on a pending ADMIN and confirm it now queues for send rather than returning `Oh dear`.

Links: Discourse [topic 9597](https://community.ilovefreegle.org/t/9597).

🤖 Generated with [Claude Code](https://claude.com/claude-code)