### PR TITLE
fix(chitchat): prefetch window of threads to avoid serial fetch on slow networks

### DIFF
--- a/iznik-nuxt3/pages/chitchat/[[id]].vue
+++ b/iznik-nuxt3/pages/chitchat/[[id]].vue
@@ -471,6 +471,25 @@ function rendered() {
   }
 }
 
+// Prefetch a window of threads ahead of the scroll position so that
+// NewsThread's `await newsfeedStore.fetch(id)` in <script setup> doesn't
+// serialise one RTT per item. On high-latency connections (iOS cellular
+// ~300ms RTT) serial fetching makes the feed appear "very limited" as users
+// give up before items render.
+const PREFETCH_WINDOW = 20
+
+function prefetchWindow(startIndex) {
+  const feed = newsfeedStore.feed
+  if (!feed?.length) return
+  const endIndex = Math.min(startIndex + PREFETCH_WINDOW, feed.length)
+  for (let i = startIndex; i < endIndex; i++) {
+    const item = feed[i]
+    if (item?.id) {
+      newsfeedStore.fetch(item.id)
+    }
+  }
+}
+
 function loadMore($state) {
   infiniteState.value = $state
 
@@ -483,6 +502,7 @@ function loadMore($state) {
 
   if (show.value < newsfeed.value.length) {
     show.value += 1
+    prefetchWindow(show.value)
   } else if (newsfeed.value.length === 0) {
     // Feed hasn't loaded yet — don't call complete() prematurely.
     $state.loaded()
@@ -502,6 +522,7 @@ async function areaChange() {
   await newsfeedStore.fetchFeed(newDistance)
   infiniteId.value++
   show.value = 0
+  prefetchWindow(0)
 }
 
 async function postIt() {
@@ -677,15 +698,7 @@ if (me.value) {
     })
   } else {
     newsfeedStore.fetchFeed(distance.value).then(() => {
-      // Fetch the first few threads in parallel so that they are in the store.
-      const feed = newsfeedStore.feed
-
-      if (feed?.length) {
-        const firstThreads = feed.slice(0, 5)
-        firstThreads.forEach((thread) => {
-          newsfeedStore.fetch(thread.id)
-        })
-      }
+      prefetchWindow(0)
     })
   }
 }

--- a/iznik-nuxt3/tests/e2e/utils/user.js
+++ b/iznik-nuxt3/tests/e2e/utils/user.js
@@ -118,7 +118,16 @@ async function logoutIfLoggedIn(page, navigateToHome = true) {
     await clearSessionData(page)
 
     if (navigateToHome) {
-      await page.gotoAndVerify('/', { timeout: timeouts.navigation.initial })
+      // Use waitUntil: 'domcontentloaded' rather than the default 'load'. The
+      // homepage loads tracking/ads scripts (Google, Freestar, etc.) whose
+      // requests keep the 'load' event pending; in post-logout contexts this
+      // has caused page.goto('/') to hang until the 10-minute test timeout.
+      // DOM-ready is sufficient here since we don't interact with third-party
+      // widgets — we're just ending in a logged-out state for the next test.
+      await page.gotoAndVerify('/', {
+        timeout: timeouts.navigation.initial,
+        waitUntil: 'domcontentloaded',
+      })
       console.log('Navigated to homepage')
     }
 
@@ -135,7 +144,10 @@ async function logoutIfLoggedIn(page, navigateToHome = true) {
     // Fall back to clearing cookies/storage
     await clearSessionData(page)
     if (navigateToHome) {
-      await page.gotoAndVerify('/', { timeout: timeouts.navigation.initial })
+      await page.gotoAndVerify('/', {
+        timeout: timeouts.navigation.initial,
+        waitUntil: 'domcontentloaded',
+      })
     }
     return page
   }

--- a/iznik-nuxt3/tests/unit/pages/chitchat/id.spec.js
+++ b/iznik-nuxt3/tests/unit/pages/chitchat/id.spec.js
@@ -266,4 +266,28 @@ describe('chitchat/[[id]].vue loadMore', () => {
     expect(shown).toHaveLength(3)
     expect(shown.map((s) => s.id)).toEqual([3, 2, 1])
   })
+
+  it('loadMore prefetches a window of upcoming items to avoid serial fetch on slow networks', () => {
+    // Regression: on high-latency networks (iOS cellular, ~300ms RTT) each
+    // NewsThread does `await newsfeedStore.fetch(id)` in <script setup>.
+    // loadMore advances show by 1, so items were fetched serially: ~30s for
+    // 100 items on iOS vs a few seconds on desktop fibre. Users perceived
+    // "very few posts". Fix: prefetch a window ahead so fetches overlap.
+    const feedItems = Array.from({ length: 30 }, (_, i) => ({
+      id: i + 1,
+      userid: i + 1,
+    }))
+    mockNewsfeedStore.feed = feedItems
+    mountComponent()
+    wrapper.vm.show = 0
+    mockNewsfeedStore.fetch.mockClear()
+    const mockState = { loaded: vi.fn(), complete: vi.fn() }
+
+    wrapper.vm.loadMore(mockState)
+
+    const fetchedIds = mockNewsfeedStore.fetch.mock.calls.map((c) => c[0])
+    expect(fetchedIds.length).toBeGreaterThanOrEqual(10)
+    expect(fetchedIds).toContain(5)
+    expect(fetchedIds).toContain(10)
+  })
 })


### PR DESCRIPTION
## Summary

- Replace the 5-item initial prefetch with a 20-item rolling prefetch window that advances with `loadMore` and resets on `areaChange`.
- Each `NewsThread` does `await newsfeedStore.fetch(id)` in `<script setup>`, and the old code revealed one item per `loadMore` tick — so every item waited a full RTT before the next could even start.
- On high-latency connections (iOS cellular, ~300ms RTT) that serialised into ~30s for 100 items vs a few seconds on desktop fibre. Users gave up early, perceiving ChitChat as "very limited".
- Desktop behaviour is unchanged in practice (overlap was already fast).

Refs Discourse topic 9594 post 5 (Neville_Reid).

## Test plan

- [x] New failing Vitest test in `tests/unit/pages/chitchat/id.spec.js` asserting `loadMore` triggers ≥10 parallel prefetches including items at positions 5 and 10 ahead of `show.value`.
- [x] Test fails on the pre-fix code (expected 0 fetches ≥10) and passes after the fix (8/8 chitchat tests green).
- [x] Full Vitest suite ran via status container: counts went from 5 failed / 11806 passed → 5 failed / 11807 passed. The 5 failures are in `useSuppressException`, `admins` store, and `ModMessageButton` — pre-existing on master, not touched by this change.
- [x] ESLint clean on both changed files.