### PR TITLE
fix(embedding): tier subject-match results above body-match in vector search

### DIFF
--- a/iznik-server-go/embedding/store.go
+++ b/iznik-server-go/embedding/store.go
@@ -13,16 +13,6 @@ import (
 // EmbeddingDim is 256-dim Matryoshka truncation of nomic-embed-text-v1.5.
 const EmbeddingDim = 256
 
-// SubjectWeight and BodyWeight combine the two per-message cosine scores into
-// the final ranking score. Subject dominates because the subject line is the
-// high-signal "what is this item" field; the body disambiguates but is noisy
-// (boilerplate, location text, tags). When body is absent we fall back to the
-// pure subject cosine (not 0.7×subject) so the scoring scale stays consistent.
-const (
-	SubjectWeight float32 = 0.7
-	BodyWeight    float32 = 0.3
-)
-
 // Entry holds one message's subject (and optional body) embedding plus metadata.
 type Entry struct {
 	Msgid      uint64
@@ -149,22 +139,28 @@ func decodeFloats(raw []byte, dst []float32) {
 	}
 }
 
-// VectorSearchResult from vector search.
+// VectorSearchResult from vector search. SubjectCos and BodyCos are the pure
+// per-field cosines; HasBody distinguishes "body exists but cosine is 0" from
+// "no body embedding" (BodyCos is 0 in both cases). The caller decides how to
+// tier/order results — this struct carries the raw signal.
 type VectorSearchResult struct {
-	Msgid   uint64    `json:"id"`
-	Groupid uint64    `json:"groupid"`
-	Msgtype string    `json:"type"`
-	Lat     float64   `json:"lat"`
-	Lng     float64   `json:"lng"`
-	Score   float32   `json:"score"`
-	Subject string    `json:"-"` // Used for hybrid keyword scoring, not serialized
-	Arrival time.Time `json:"-"`
+	Msgid      uint64    `json:"id"`
+	Groupid    uint64    `json:"groupid"`
+	Msgtype    string    `json:"type"`
+	Lat        float64   `json:"lat"`
+	Lng        float64   `json:"lng"`
+	SubjectCos float32   `json:"subjectCos"`
+	BodyCos    float32   `json:"bodyCos"`
+	HasBody    bool      `json:"hasBody"`
+	Subject    string    `json:"-"` // Used for hybrid keyword scoring, not serialized
+	Arrival    time.Time `json:"-"`
 }
 
-// Search performs brute-force cosine similarity. Each entry contributes a
-// subject cosine; if a body embedding is present the final score is the
-// weighted combination 0.7*subject + 0.3*body. Bodyless entries keep their
-// pure subject cosine so the scale matches.
+// Search performs brute-force cosine similarity on every entry and returns the
+// top-K by max(subjectCos, bodyCos). Returning both cosines separately lets the
+// caller order subject-matches ahead of body-matches (what users expect:
+// a literal "table" in the subject should come before a message that only
+// mentions "table" in the body).
 func (s *Store) Search(query []float32, limit int, msgtype string, groupids []uint64,
 	swlat, swlng, nelat, nelng float32) []VectorSearchResult {
 
@@ -179,8 +175,11 @@ func (s *Store) Search(query []float32, limit int, msgtype string, groupids []ui
 	hasBoxFilter := nelat != 0 || nelng != 0 || swlat != 0 || swlng != 0
 
 	type scored struct {
-		idx   int
-		score float32
+		idx        int
+		subjectCos float32
+		bodyCos    float32
+		hasBody    bool
+		rankScore  float32 // max(subjectCos, bodyCos) — used only for top-K selection
 	}
 
 	results := make([]scored, 0, len(s.entries))
@@ -210,19 +209,27 @@ func (s *Store) Search(query []float32, limit int, msgtype string, groupids []ui
 			subjectCos += query[j] * e.SubjectVec[j]
 		}
 
-		score := subjectCos
-		if e.BodyVec != nil {
-			var bodyCos float32
+		rankScore := subjectCos
+		var bodyCos float32
+		hasBody := e.BodyVec != nil
+		if hasBody {
 			for j := 0; j < EmbeddingDim; j++ {
 				bodyCos += query[j] * e.BodyVec[j]
 			}
-			score = SubjectWeight*subjectCos + BodyWeight*bodyCos
+			if bodyCos > rankScore {
+				rankScore = bodyCos
+			}
 		}
 
-		results = append(results, scored{idx: i, score: score})
+		results = append(results, scored{
+			idx: i, subjectCos: subjectCos, bodyCos: bodyCos,
+			hasBody: hasBody, rankScore: rankScore,
+		})
 	}
 
-	// Sort top-K by score descending (selection sort — fine for N < 1000)
+	// Top-K by rankScore descending (selection sort — fine for N < 1000).
+	// Caller re-orders into subject/body tiers; this step only bounds the
+	// working set of candidates that are strong on at least one field.
 	n := len(results)
 	if n > limit {
 		n = limit
@@ -230,7 +237,7 @@ func (s *Store) Search(query []float32, limit int, msgtype string, groupids []ui
 	for i := 0; i < n; i++ {
 		maxIdx := i
 		for j := i + 1; j < len(results); j++ {
-			if results[j].score > results[maxIdx].score {
+			if results[j].rankScore > results[maxIdx].rankScore {
 				maxIdx = j
 			}
 		}
@@ -244,14 +251,16 @@ func (s *Store) Search(query []float32, limit int, msgtype string, groupids []ui
 	for i, r := range results {
 		e := &s.entries[r.idx]
 		out[i] = VectorSearchResult{
-			Msgid:   e.Msgid,
-			Groupid: e.Groupid,
-			Msgtype: e.Msgtype,
-			Lat:     e.Lat,
-			Lng:     e.Lng,
-			Score:   r.score,
-			Subject: e.Subject,
-			Arrival: e.Arrival,
+			Msgid:      e.Msgid,
+			Groupid:    e.Groupid,
+			Msgtype:    e.Msgtype,
+			Lat:        e.Lat,
+			Lng:        e.Lng,
+			SubjectCos: r.subjectCos,
+			BodyCos:    r.bodyCos,
+			HasBody:    r.hasBody,
+			Subject:    e.Subject,
+			Arrival:    e.Arrival,
 		}
 	}
 

--- a/iznik-server-go/embedding/store_test.go
+++ b/iznik-server-go/embedding/store_test.go
@@ -101,9 +101,9 @@ func TestStoreSearchSortOrder(t *testing.T) {
 	assert.Equal(t, uint64(2), results[1].Msgid)
 	// Different (msgid 1) should be last
 	assert.Equal(t, uint64(1), results[2].Msgid)
-	// Scores should be descending
-	assert.Greater(t, results[0].Score, results[1].Score)
-	assert.Greater(t, results[1].Score, results[2].Score)
+	// SubjectCos should be descending
+	assert.Greater(t, results[0].SubjectCos, results[1].SubjectCos)
+	assert.Greater(t, results[1].SubjectCos, results[2].SubjectCos)
 }
 
 func TestStoreCount(t *testing.T) {
@@ -202,33 +202,79 @@ func TestVecToBytes(t *testing.T) {
 	}
 }
 
-// --- Hybrid subject+body vector search ---
+// --- Subject + body cosines returned separately for tiering ---
 
-func TestStoreSearchCombinesSubjectAndBodyWithWeights(t *testing.T) {
-	// Query perfectly matches subjectA, and body vector happens to match query
-	// exactly too. Combined score should be ~1.0 (= w_s*1 + w_b*1).
-	// Another entry has subject=query exactly but body=noise. Combined should
-	// be lower than the first.
+// makeOrthogonalTo returns a unit vector orthogonal to ref. makeVec patterns
+// all collapse near the all-ones direction (dot ≈0.97 between any two),
+// making them useless as "noise" — we have to Gram-Schmidt against the
+// specific reference to get a genuinely zero-cosine vector.
+func makeOrthogonalTo(ref [EmbeddingDim]float32) [EmbeddingDim]float32 {
+	var v [EmbeddingDim]float32
+	for i := 0; i < EmbeddingDim; i++ {
+		if i%2 == 0 {
+			v[i] = 1.0
+		} else {
+			v[i] = -1.0
+		}
+	}
+	var dot float32
+	for i := 0; i < EmbeddingDim; i++ {
+		dot += v[i] * ref[i]
+	}
+	for i := 0; i < EmbeddingDim; i++ {
+		v[i] -= dot * ref[i]
+	}
+	var norm float32
+	for i := 0; i < EmbeddingDim; i++ {
+		norm += v[i] * v[i]
+	}
+	norm = float32(math.Sqrt(float64(norm)))
+	for i := 0; i < EmbeddingDim; i++ {
+		v[i] /= norm
+	}
+	return v
+}
+
+func TestStoreSearchReturnsBothCosinesSeparately(t *testing.T) {
+	// Store exposes subjectCos and bodyCos independently so the caller can
+	// tier (subject-matches first, body-matches later) instead of blending.
 	s := &Store{}
 	query := makeVec(1.0)
-	noise := makeVec(10.0)
+	noise := makeOrthogonalTo(query)
 
 	s.entries = []Entry{
-		{Msgid: 1, Msgtype: "Offer", Subject: "match with helpful body",
+		{Msgid: 1, Msgtype: "Offer", Subject: "subject match + body match",
 			SubjectVec: query, BodyVec: vecPtr(query)},
-		{Msgid: 2, Msgtype: "Offer", Subject: "match with noisy body",
+		{Msgid: 2, Msgtype: "Offer", Subject: "subject match + noisy body",
 			SubjectVec: query, BodyVec: vecPtr(noise)},
+		{Msgid: 3, Msgtype: "Offer", Subject: "noisy subject + body match",
+			SubjectVec: noise, BodyVec: vecPtr(query)},
 	}
 
 	results := s.Search(query[:], 10, "", nil, 0, 0, 0, 0)
-	assert.Len(t, results, 2)
-	assert.Equal(t, uint64(1), results[0].Msgid, "helpful body should outrank noisy body")
-	assert.Greater(t, results[0].Score, results[1].Score)
+	assert.Len(t, results, 3)
+
+	byId := make(map[uint64]VectorSearchResult)
+	for _, r := range results {
+		byId[r.Msgid] = r
+	}
+
+	assert.InDelta(t, float32(1.0), byId[1].SubjectCos, 1e-5)
+	assert.InDelta(t, float32(1.0), byId[1].BodyCos, 1e-5)
+	assert.True(t, byId[1].HasBody)
+
+	assert.InDelta(t, float32(1.0), byId[2].SubjectCos, 1e-5)
+	assert.InDelta(t, float32(0), byId[2].BodyCos, 1e-5,
+		"msg 2 body is orthogonal — bodyCos must be near zero")
+
+	assert.InDelta(t, float32(0), byId[3].SubjectCos, 1e-5,
+		"msg 3 subject is orthogonal — subjectCos must be near zero")
+	assert.InDelta(t, float32(1.0), byId[3].BodyCos, 1e-5)
 }
 
-func TestStoreSearchUsesSubjectOnlyWhenBodyAbsent(t *testing.T) {
-	// Body absent → score should equal the pure subject cosine, not get
-	// penalised by the BodyWeight coefficient.
+func TestStoreSearchMarksBodyAbsent(t *testing.T) {
+	// A bodyless entry must report HasBody=false and BodyCos=0 so the caller
+	// never tries to rescue it on body similarity.
 	s := &Store{}
 	query := makeVec(1.0)
 
@@ -238,42 +284,38 @@ func TestStoreSearchUsesSubjectOnlyWhenBodyAbsent(t *testing.T) {
 
 	results := s.Search(query[:], 10, "", nil, 0, 0, 0, 0)
 	assert.Len(t, results, 1)
-	// Dot product of normalised vector with itself = 1.0
-	assert.InDelta(t, float32(1.0), results[0].Score, 1e-5,
-		"subject-only entry must score at the pure subject cosine (no weight penalty)")
+	assert.InDelta(t, float32(1.0), results[0].SubjectCos, 1e-5)
+	assert.False(t, results[0].HasBody)
+	assert.Equal(t, float32(0), results[0].BodyCos)
 }
 
-func TestStoreSearchBodyBoostsWeakSubjectMatch(t *testing.T) {
-	// Subject cosine is weak (0.6) but body matches the query exactly (1.0).
-	// Combined = 0.7*0.6 + 0.3*1.0 = 0.72 → above MinVectorScore threshold.
-	// A subject-only entry with the same 0.6 would score 0.6 and be cut by the
-	// threshold in vectorsearch.go. This is the whole point of the hybrid.
+func TestStoreSearchTopKUsesMaxOfCosines(t *testing.T) {
+	// Top-K candidate selection uses max(subjectCos, bodyCos) so that an
+	// entry strong on only one field still reaches the caller, where it can
+	// be tiered appropriately.
 	s := &Store{}
-
-	// Build a subject vector that gives dot(query)=0.6 approximately.
-	// Mix of query direction and orthogonal noise.
 	query := makeVec(1.0)
-	orthogonal := makeVec(100.0)
-	var weakSubject [EmbeddingDim]float32
-	var norm float32
-	for i := 0; i < EmbeddingDim; i++ {
-		weakSubject[i] = 0.6*query[i] + 0.8*orthogonal[i]
-		norm += weakSubject[i] * weakSubject[i]
-	}
-	norm = float32(math.Sqrt(float64(norm)))
-	for i := 0; i < EmbeddingDim; i++ {
-		weakSubject[i] /= norm
-	}
+	noise := makeOrthogonalTo(query)
 
 	s.entries = []Entry{
-		{Msgid: 1, Msgtype: "Offer", SubjectVec: weakSubject, BodyVec: vecPtr(query)},
-		{Msgid: 2, Msgtype: "Offer", SubjectVec: weakSubject, BodyVec: nil},
+		// weak subject, no body — should NOT make top-2
+		{Msgid: 1, Msgtype: "Offer", SubjectVec: noise, BodyVec: nil},
+		// strong subject, no body — makes top-2
+		{Msgid: 2, Msgtype: "Offer", SubjectVec: query, BodyVec: nil},
+		// weak subject, strong body — makes top-2 via body
+		{Msgid: 3, Msgtype: "Offer", SubjectVec: noise, BodyVec: vecPtr(query)},
 	}
 
-	results := s.Search(query[:], 10, "", nil, 0, 0, 0, 0)
+	results := s.Search(query[:], 2, "", nil, 0, 0, 0, 0)
 	assert.Len(t, results, 2)
-	assert.Equal(t, uint64(1), results[0].Msgid, "body match should boost entry 1 above entry 2")
-	assert.Greater(t, results[0].Score, results[1].Score)
+
+	ids := map[uint64]bool{}
+	for _, r := range results {
+		ids[r.Msgid] = true
+	}
+	assert.True(t, ids[2], "strong-subject entry should be in top-2")
+	assert.True(t, ids[3], "strong-body entry should be in top-2")
+	assert.False(t, ids[1], "weak-on-both entry should be dropped")
 }
 
 func TestStoreLoadReadsSubjectAndBodyColumns(t *testing.T) {

--- a/iznik-server-go/message/vectorsearch.go
+++ b/iznik-server-go/message/vectorsearch.go
@@ -7,12 +7,23 @@ import (
 
 const keywordBoostWeight = 0.3
 
-// MinVectorScore is the minimum combined (subject+body) cosine score to
-// include a result. nomic-embed-text-v1.5 normalized dot products: random
-// noise ~0.50, tangential ~0.60, genuine semantic matches 0.70+, exact 0.75+.
+// MinVectorScore is the minimum per-field cosine (subject OR body) to include
+// a result. nomic-embed-text-v1.5 normalized dot products: random noise ~0.50,
+// tangential ~0.60, genuine semantic matches 0.70+, exact 0.75+.
 const MinVectorScore = 0.65
 
-// VectorSearch performs semantic search with hybrid keyword scoring.
+type scoredResult struct {
+	result SearchResult
+	score  float32
+}
+
+// VectorSearch performs semantic search with subject-first tiering and keyword
+// re-ranking. Subject-tier hits (subjectCos ≥ MinVectorScore) come first;
+// body-tier hits (only bodyCos ≥ MinVectorScore) follow. Within each tier,
+// results are ordered by their tier cosine + a keyword boost (literal query
+// word matches in the subject). This matches what users expect: an item whose
+// subject literally says "table" should surface before one that only mentions
+// "table" buried in the body.
 func VectorSearch(term string, limit int, groupids []uint64, msgtype string,
 	nelat, nelng, swlat, swlng float32) ([]SearchResult, error) {
 
@@ -27,30 +38,19 @@ func VectorSearch(term string, limit int, groupids []uint64, msgtype string,
 
 	queryWords := GetWords(term)
 
-	type scoredResult struct {
-		result SearchResult
-		score  float32
-	}
-
-	scored := make([]scoredResult, 0, len(vecResults))
+	var subjectTier []scoredResult
+	var bodyTier []scoredResult
 
 	for _, vr := range vecResults {
-		// Combined score below threshold → drop. Keyword boost doesn't
-		// rescue results below the semantic floor; it only re-orders.
-		if vr.Score < MinVectorScore {
-			continue
-		}
-
+		// Keyword boost: literal query-word matches in the subject.
+		// Re-ranks within a tier; doesn't rescue results below threshold.
 		var keywordScore float32
 		if len(queryWords) > 0 {
-			// Whole-word match: tokenise the subject with the same rules
-			// GetWords uses for the query so "table" ≠ "portable".
 			subjectWords := GetWords(vr.Subject)
 			subjectSet := make(map[string]struct{}, len(subjectWords))
 			for _, w := range subjectWords {
 				subjectSet[w] = struct{}{}
 			}
-
 			matched := 0
 			for _, w := range queryWords {
 				if _, ok := subjectSet[w]; ok {
@@ -60,10 +60,7 @@ func VectorSearch(term string, limit int, groupids []uint64, msgtype string,
 			keywordScore = float32(matched) / float32(len(queryWords))
 		}
 
-		hybridScore := vr.Score + keywordScore*keywordBoostWeight
-
 		lat, lng := utils.Blur(vr.Lat, vr.Lng, utils.BLUR_USER)
-
 		sr := SearchResult{
 			Msgid:   vr.Msgid,
 			Arrival: vr.Arrival,
@@ -78,26 +75,43 @@ func VectorSearch(term string, limit int, groupids []uint64, msgtype string,
 			},
 		}
 
-		scored = append(scored, scoredResult{result: sr, score: hybridScore})
-	}
-
-	// Sort by hybrid score descending.
-	for i := 0; i < len(scored)-1; i++ {
-		for j := i + 1; j < len(scored); j++ {
-			if scored[j].score > scored[i].score {
-				scored[i], scored[j] = scored[j], scored[i]
-			}
+		if vr.SubjectCos >= MinVectorScore {
+			subjectTier = append(subjectTier, scoredResult{
+				result: sr,
+				score:  vr.SubjectCos + keywordScore*keywordBoostWeight,
+			})
+		} else if vr.HasBody && vr.BodyCos >= MinVectorScore {
+			bodyTier = append(bodyTier, scoredResult{
+				result: sr,
+				score:  vr.BodyCos + keywordScore*keywordBoostWeight,
+			})
 		}
 	}
 
-	if len(scored) > limit {
-		scored = scored[:limit]
+	sortByScoreDesc(subjectTier)
+	sortByScoreDesc(bodyTier)
+
+	combined := append(subjectTier, bodyTier...)
+	if len(combined) > limit {
+		combined = combined[:limit]
 	}
 
-	results := make([]SearchResult, len(scored))
-	for i, s := range scored {
+	results := make([]SearchResult, len(combined))
+	for i, s := range combined {
 		results[i] = s.result
 	}
 
 	return results, nil
+}
+
+// sortByScoreDesc sorts in place by score descending. Selection sort —
+// tier sizes are well under 1000, constant factors beat heap/quick overhead.
+func sortByScoreDesc(s []scoredResult) {
+	for i := 0; i < len(s)-1; i++ {
+		for j := i + 1; j < len(s); j++ {
+			if s[j].score > s[i].score {
+				s[i], s[j] = s[j], s[i]
+			}
+		}
+	}
 }


### PR DESCRIPTION
## Summary
- Return subject and body cosines separately from `Store.Search` instead of blending them with weighted cosine
- `VectorSearch` now splits hits into a subject tier (`subjectCos ≥ 0.65`) and a body tier (only `bodyCos ≥ 0.65`), concatenated subject-first
- Within each tier, hits order by that tier's cosine plus a literal keyword-in-subject boost

## Why
Previous approach blended `0.7*subject + 0.3*body` into a single score. This lost the distinction users expect: a message whose subject literally says "table" should surface above one that only mentions "table" in the body. Reported against modtools vector search.

## Test plan
- [x] Unit: `embedding/store_test.go` covers both cosines returned separately, body-absent case, top-K via max(subject, body)
- [x] `TestStoreSearchReturnsBothCosinesSeparately` — true Gram-Schmidt orthogonal noise (was incorrectly assuming +1/-1 alternating is orthogonal to any positive-entry vector)
- [x] Full Go suite green via status container API

🤖 Generated with [Claude Code](https://claude.com/claude-code)