### PR TITLE
fix(sentry): suppress ftUtils.js getInnerDimensions null errors (NUXT3-D2H)

### DIFF
--- a/iznik-nuxt3/composables/useSuppressException.js
+++ b/iznik-nuxt3/composables/useSuppressException.js
@@ -26,14 +26,17 @@ export function suppressException(err) {
     return true
   }
 
-  // Freestar (third-party ad provider) ftUtils.js: getPlacementPosition reads
-  // (this.isPlacementXdom?t:t.parent).document with t.parent=null in cross-origin
-  // iframes. Sentry issue NUXT3-CES (~11k events). Match on the Freestar signature
-  // (ftUtils.js or getPlacementPosition in stack) rather than the generic message
-  // so we don't mask real bugs in our own code.
+  // Freestar (third-party ad provider) ftUtils.js throws a range of null-property
+  // TypeErrors from cross-origin iframes — getPlacementPosition reads
+  // (this.isPlacementXdom?t:t.parent).document with t.parent=null (NUXT3-CES),
+  // getInnerDimensions reads t.display with t=null (NUXT3-D2H). Match on the
+  // Freestar signature (ftUtils.js filename or known Freestar function names in
+  // the stack) rather than the generic message, so we don't mask real bugs in
+  // our own code.
   if (
     err.stack?.includes('ftUtils.js') ||
-    err.stack?.includes('getPlacementPosition')
+    err.stack?.includes('getPlacementPosition') ||
+    err.stack?.includes('getInnerDimensions')
   ) {
     console.log('Freestar ftUtils - suppress exception')
     return true

--- a/iznik-nuxt3/plugins/sentry.client.ts
+++ b/iznik-nuxt3/plugins/sentry.client.ts
@@ -86,9 +86,11 @@ export default defineNuxtPlugin(async (nuxtApp) => {
           'TypeError: Unable to preload',
           'Window closed',
 
-          // Freestar third-party ad JS (ftUtils.js getPlacementPosition).
-          // Belt-and-braces: also dropped by suppressException via beforeSend.
+          // Freestar third-party ad JS (ftUtils.js getPlacementPosition,
+          // getInnerDimensions). Belt-and-braces: also dropped by
+          // suppressException via beforeSend.
           'getPlacementPosition',
+          'getInnerDimensions',
         ],
         integrations: [
           new Integrations.BrowserTracing({

--- a/iznik-nuxt3/tests/unit/composables/useSuppressException.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useSuppressException.spec.js
@@ -93,6 +93,48 @@ describe('suppressException', () => {
     ).toBe(true)
   })
 
+  it('suppresses Freestar ftUtils.js getInnerDimensions null errors (Firefox phrasing, NUXT3-D2H)', () => {
+    // Sentry issue NUXT3-D2H (7372854976): 337 events / 119 users.
+    // Firefox surfaces null-property TypeErrors as:
+    //   "can't access property \"display\", t is null"
+    // Culprit: getInnerDimensions(ftUtils) in /ftUtils.js.
+    expect(
+      suppressException({
+        name: 'TypeError',
+        message: 'can\'t access property "display", t is null',
+        stack:
+          'TypeError: can\'t access property "display", t is null\n' +
+          '    at getInnerDimensions (https://a.pub.network/.../ftUtils.js:1:4567)',
+      })
+    ).toBe(true)
+  })
+
+  it('suppresses Freestar ftUtils.js getInnerDimensions null errors (Chrome phrasing, NUXT3-D2H)', () => {
+    // Chrome phrasing of the same Freestar ftUtils.js getInnerDimensions crash.
+    expect(
+      suppressException({
+        name: 'TypeError',
+        message: "Cannot read properties of null (reading 'display')",
+        stack:
+          "TypeError: Cannot read properties of null (reading 'display')\n" +
+          '    at Object.getInnerDimensions (https://a.pub.network/.../ftUtils.js:1:4567)',
+      })
+    ).toBe(true)
+  })
+
+  it('suppresses Freestar errors identified by getInnerDimensions alone in stack', () => {
+    // If the filename has been stripped (e.g. due to SourceMap rewriting or
+    // bundler renaming), the getInnerDimensions function name in the stack is
+    // still a Freestar-specific signature.
+    expect(
+      suppressException({
+        name: 'TypeError',
+        message: 'can\'t access property "display", t is null',
+        stack: '    at getInnerDimensions (something.js:1:1)',
+      })
+    ).toBe(true)
+  })
+
   it('does not suppress unrelated null-document TypeErrors from our code', () => {
     expect(
       suppressException({


### PR DESCRIPTION
## Summary

Suppresses Sentry issue [NUXT3-D2H](https://freegle.sentry.io/issues/7372854976/) — `TypeError: can't access property "display", t is null` from `getInnerDimensions` in the third-party Freestar ad script `/ftUtils.js` (337 events / 119 users).

## Root cause

Third-party Freestar ad JS (`ftUtils.js`) throws null-property TypeErrors from cross-origin iframes. `getInnerDimensions` reads `t.display` when `t` is `null`. We do not control Freestar's code, and this is the same class of crash as NUXT3-CES which we already suppress.

## Prior art

We already suppress other Freestar `ftUtils.js` crashes:
- #206 / f5d8604d — suppress Freestar `ftUtils.js` null-document errors (`getPlacementPosition`)
- 4f729610e — earlier iteration of the same suppression
- 6579683231 — initial null-document TypeError handler

This PR extends the same pattern to the `getInnerDimensions` variant.

## Changes

- `composables/useSuppressException.js` — add `getInnerDimensions` to the Freestar stack-match list (kept alongside `ftUtils.js` filename match and `getPlacementPosition`). Updated comment to reference NUXT3-D2H.
- `plugins/sentry.client.ts` — add `getInnerDimensions` to `ignoreErrors` as a belt-and-braces filter.

## Tests added

- Firefox phrasing: `can't access property "display", t is null` with `getInnerDimensions` in `ftUtils.js` stack → suppressed.
- Chrome phrasing: `Cannot read properties of null (reading 'display')` with `Object.getInnerDimensions` in `ftUtils.js` stack → suppressed.
- Stack-only match via `getInnerDimensions` signature (e.g. if filename rewritten) → suppressed.
- Existing ftUtils/NotReadableError/leaflet/chart suppression tests unchanged and still passing (20/20).

## Test plan

- [x] Targeted unit test run — 20/20 pass locally inside the modtools dev container.
- [ ] CI green.