### PR TITLE
fix(search): stop silent keyword fallback when searchmode=vector; log per-call diagnostics

### DIFF
--- a/docker/embedding-sidecar/server.mjs
+++ b/docker/embedding-sidecar/server.mjs
@@ -37,6 +37,7 @@ const server = createServer(async (req, res) => {
     }
   }
 
+  const t0 = process.hrtime.bigint();
   try {
     const { texts } = JSON.parse(body);
     if (!Array.isArray(texts) || texts.length === 0) {
@@ -65,9 +66,34 @@ const server = createServer(async (req, res) => {
 
     res.writeHead(200, { 'Content-Type': 'application/json' });
     res.end(JSON.stringify({ embeddings }));
+
+    const elapsedMs = Number(process.hrtime.bigint() - t0) / 1e6;
+    // Fingerprint first embedding so identical queries across calls can be
+    // cross-checked in Loki — deterministic extractor → identical fp.
+    const fp = embeddings[0]
+      .slice(0, 4)
+      .map(v => v.toFixed(4))
+      .join(',');
+    const sample = texts[0].length > 40 ? texts[0].slice(0, 40) + '...' : texts[0];
+    console.log(JSON.stringify({
+      level: 'info',
+      event: 'embed',
+      count: texts.length,
+      elapsed_ms: Number(elapsedMs.toFixed(2)),
+      first_text_len: texts[0].length,
+      first_text: sample,
+      fp,
+    }));
   } catch (e) {
+    const elapsedMs = Number(process.hrtime.bigint() - t0) / 1e6;
     res.writeHead(500, { 'Content-Type': 'application/json' });
     res.end(JSON.stringify({ error: e.message }));
+    console.log(JSON.stringify({
+      level: 'error',
+      event: 'embed',
+      elapsed_ms: Number(elapsedMs.toFixed(2)),
+      error: e.message,
+    }));
   }
 });
 

--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -1066,18 +1066,27 @@ func Search(c *fiber.Ctx) error {
 			return fiber.NewError(fiber.StatusBadRequest, "No search term")
 		}
 
-		// Try vector search if requested and embeddings are loaded
+		// When searchmode=vector is explicitly requested and vector succeeds,
+		// respect the result (even if empty) instead of falling back to keyword.
+		// Silently switching match models makes repeat queries return different
+		// result sets — the non-determinism Dee reported (Discourse 9594).
 		if searchmode == "vector" && embedding.Global.Count() > 0 {
 			vectorResults, err := VectorSearch(term, SEARCH_LIMIT, groupids, msgtype,
 				float32(nelat), float32(nelng), float32(swlat), float32(swlng))
 			if err != nil {
 				fmt.Printf("Vector search failed, falling back to keyword: %v\n", err)
 			} else {
-				res = vectorResults
+				filtered := []SearchResult{}
+				for _, r := range vectorResults {
+					if r.Msgid != 0 {
+						filtered = append(filtered, r)
+					}
+				}
+				wg.Wait()
+				return c.JSON(filtered)
 			}
 		}
 
-		// Fall back to keyword search if vector returned nothing
 		if len(res) == 0 {
 			words := GetWords(term)
 

--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -1071,8 +1071,12 @@ func Search(c *fiber.Ctx) error {
 		// Silently switching match models makes repeat queries return different
 		// result sets — the non-determinism Dee reported (Discourse 9594).
 		if searchmode == "vector" && embedding.Global.Count() > 0 {
-			vectorResults, err := VectorSearch(term, SEARCH_LIMIT, groupids, msgtype,
+			vectorResults, stats, err := VectorSearch(term, SEARCH_LIMIT, groupids, msgtype,
 				float32(nelat), float32(nelng), float32(swlat), float32(swlng))
+			fallbackTaken := err != nil
+
+			logVectorSearch(term, groupids, msgtype, myid, searchmode, len(vectorResults), fallbackTaken, stats)
+
 			if err != nil {
 				fmt.Printf("Vector search failed, falling back to keyword: %v\n", err)
 			} else {

--- a/iznik-server-go/message/vectorsearch.go
+++ b/iznik-server-go/message/vectorsearch.go
@@ -1,7 +1,13 @@
 package message
 
 import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
 	"github.com/freegle/iznik-server-go/embedding"
+	"github.com/freegle/iznik-server-go/misc"
 	"github.com/freegle/iznik-server-go/utils"
 )
 
@@ -11,6 +17,28 @@ const keywordBoostWeight = 0.3
 // a result. nomic-embed-text-v1.5 normalized dot products: random noise ~0.50,
 // tangential ~0.60, genuine semantic matches 0.70+, exact 0.75+.
 const MinVectorScore = 0.65
+
+// VectorStats captures diagnostic signal about one VectorSearch call, for the
+// handler to emit to Loki. It exists because repeat identical queries for Dee
+// (Discourse 9594) produced different result sets, and the raw response alone
+// didn't reveal *which* stage (sidecar, store, scoring) was behaving
+// differently between calls. With these fields logged per call, the same term
+// called twice will show in Loki whether the embedding, the store size, or the
+// top candidate cosines changed.
+type VectorStats struct {
+	EmbedMs       float64 // duration of the sidecar EmbedQuery call
+	StoreMs       float64 // duration of the brute-force Store.Search call
+	TotalMs       float64 // total VectorSearch duration incl. scoring
+	StoreSize     int     // embedding.Global.Count() at call time
+	Candidates    int     // raw count returned by Store.Search (pre-threshold)
+	SubjectTier   int     // candidates passing MinVectorScore on SubjectCos
+	BodyTier      int     // candidates passing MinVectorScore on BodyCos (and not in subject tier)
+	Dropped       int     // candidates below MinVectorScore on both fields
+	TopSubjectCos float32 // max SubjectCos across the candidates (diagnoses "why empty")
+	TopBodyCos    float32 // max BodyCos across the candidates
+	QueryVecFP    string  // fingerprint of the returned embedding — identical query should yield identical fingerprint
+	Error         string  // populated if EmbedQuery failed (otherwise "")
+}
 
 type scoredResult struct {
 	result SearchResult
@@ -24,17 +52,31 @@ type scoredResult struct {
 // word matches in the subject). This matches what users expect: an item whose
 // subject literally says "table" should surface before one that only mentions
 // "table" buried in the body.
+//
+// Returns VectorStats alongside the results so the caller can emit diagnostic
+// logs — see the type comment for why.
 func VectorSearch(term string, limit int, groupids []uint64, msgtype string,
-	nelat, nelng, swlat, swlng float32) ([]SearchResult, error) {
+	nelat, nelng, swlat, swlng float32) ([]SearchResult, VectorStats, error) {
 
+	stats := VectorStats{StoreSize: embedding.Global.Count()}
+	start := time.Now()
+
+	embedStart := time.Now()
 	queryVec, err := embedding.EmbedQuery(term)
+	stats.EmbedMs = float64(time.Since(embedStart).Microseconds()) / 1000.0
 	if err != nil {
-		return nil, err
+		stats.Error = err.Error()
+		stats.TotalMs = float64(time.Since(start).Microseconds()) / 1000.0
+		return nil, stats, err
 	}
+	stats.QueryVecFP = fingerprintVec(queryVec)
 
 	// Fetch more than needed so we can re-rank with keyword boost.
+	storeStart := time.Now()
 	vecResults := embedding.Global.Search(queryVec, limit*3, msgtype, groupids,
 		swlat, swlng, nelat, nelng)
+	stats.StoreMs = float64(time.Since(storeStart).Microseconds()) / 1000.0
+	stats.Candidates = len(vecResults)
 
 	queryWords := GetWords(term)
 
@@ -42,6 +84,13 @@ func VectorSearch(term string, limit int, groupids []uint64, msgtype string,
 	var bodyTier []scoredResult
 
 	for _, vr := range vecResults {
+		if vr.SubjectCos > stats.TopSubjectCos {
+			stats.TopSubjectCos = vr.SubjectCos
+		}
+		if vr.HasBody && vr.BodyCos > stats.TopBodyCos {
+			stats.TopBodyCos = vr.BodyCos
+		}
+
 		// Keyword boost: literal query-word matches in the subject.
 		// Re-ranks within a tier; doesn't rescue results below threshold.
 		var keywordScore float32
@@ -85,8 +134,12 @@ func VectorSearch(term string, limit int, groupids []uint64, msgtype string,
 				result: sr,
 				score:  vr.BodyCos + keywordScore*keywordBoostWeight,
 			})
+		} else {
+			stats.Dropped++
 		}
 	}
+	stats.SubjectTier = len(subjectTier)
+	stats.BodyTier = len(bodyTier)
 
 	sortByScoreDesc(subjectTier)
 	sortByScoreDesc(bodyTier)
@@ -101,7 +154,68 @@ func VectorSearch(term string, limit int, groupids []uint64, msgtype string,
 		results[i] = s.result
 	}
 
-	return results, nil
+	stats.TotalMs = float64(time.Since(start).Microseconds()) / 1000.0
+	return results, stats, nil
+}
+
+// fingerprintVec returns a short hex-ish string derived from the first 4 values
+// of a vector. Identical inputs to a deterministic embedder must produce
+// identical fingerprints; a fingerprint drift between calls means the sidecar
+// itself is non-deterministic.
+func fingerprintVec(v []float32) string {
+	if len(v) < 4 {
+		return ""
+	}
+	return fmt.Sprintf("%.4f,%.4f,%.4f,%.4f", v[0], v[1], v[2], v[3])
+}
+
+// logVectorSearch emits a structured diagnostic log to Loki summarising one
+// vector search call. Cheap no-op when Loki is disabled.
+func logVectorSearch(term string, groupids []uint64, msgtype string, userID uint64,
+	searchmode string, returned int, fallbackTaken bool, stats VectorStats) {
+
+	l := misc.GetLoki()
+	if l == nil || !l.IsEnabled() {
+		return
+	}
+
+	groupStrs := make([]string, len(groupids))
+	for i, g := range groupids {
+		groupStrs[i] = strconv.FormatUint(g, 10)
+	}
+
+	labels := map[string]string{
+		"searchmode":     searchmode,
+		"fallback_taken": strconv.FormatBool(fallbackTaken),
+		"empty":          strconv.FormatBool(returned == 0),
+	}
+
+	data := map[string]interface{}{
+		"term":            term,
+		"term_len":        len(term),
+		"msgtype":         msgtype,
+		"groupids":        strings.Join(groupStrs, ","),
+		"user_id":         userID,
+		"returned":        returned,
+		"fallback_taken":  fallbackTaken,
+		"embed_ms":        stats.EmbedMs,
+		"store_ms":        stats.StoreMs,
+		"total_ms":        stats.TotalMs,
+		"store_size":      stats.StoreSize,
+		"candidates":      stats.Candidates,
+		"subject_tier":    stats.SubjectTier,
+		"body_tier":       stats.BodyTier,
+		"dropped":         stats.Dropped,
+		"top_subject_cos": stats.TopSubjectCos,
+		"top_body_cos":    stats.TopBodyCos,
+		"query_vec_fp":    stats.QueryVecFP,
+		"min_score":       MinVectorScore,
+	}
+	if stats.Error != "" {
+		data["error"] = stats.Error
+	}
+
+	l.LogCustom("vector_search", labels, data)
 }
 
 // sortByScoreDesc sorts in place by score descending. Selection sort —

--- a/iznik-server-go/message/vectorsearch.go
+++ b/iznik-server-go/message/vectorsearch.go
@@ -38,6 +38,7 @@ type VectorStats struct {
 	TopBodyCos    float32 // max BodyCos across the candidates
 	QueryVecFP    string  // fingerprint of the returned embedding — identical query should yield identical fingerprint
 	Error         string  // populated if EmbedQuery failed (otherwise "")
+	TopK          string  // top-5 candidates serialized as "msgid:subjCos:bodyCos:subject|..." for threshold tuning
 }
 
 type scoredResult struct {
@@ -141,6 +142,26 @@ func VectorSearch(term string, limit int, groupids []uint64, msgtype string,
 	stats.SubjectTier = len(subjectTier)
 	stats.BodyTier = len(bodyTier)
 
+	// Capture top-5 candidates by max(subjectCos,bodyCos) for threshold tuning.
+	// Cheap — vecResults is already the top-K chosen by the store.
+	var topK strings.Builder
+	kMax := 5
+	if len(vecResults) < kMax {
+		kMax = len(vecResults)
+	}
+	for i := 0; i < kMax; i++ {
+		vr := vecResults[i]
+		if i > 0 {
+			topK.WriteString("|")
+		}
+		subj := vr.Subject
+		if len(subj) > 60 {
+			subj = subj[:60]
+		}
+		fmt.Fprintf(&topK, "%d:%.4f:%.4f:%s", vr.Msgid, vr.SubjectCos, vr.BodyCos, subj)
+	}
+	stats.TopK = topK.String()
+
 	sortByScoreDesc(subjectTier)
 	sortByScoreDesc(bodyTier)
 
@@ -210,6 +231,7 @@ func logVectorSearch(term string, groupids []uint64, msgtype string, userID uint
 		"top_body_cos":    stats.TopBodyCos,
 		"query_vec_fp":    stats.QueryVecFP,
 		"min_score":       MinVectorScore,
+		"top_k":           stats.TopK,
 	}
 	if stats.Error != "" {
 		data["error"] = stats.Error

--- a/iznik-server-go/misc/loki.go
+++ b/iznik-server-go/misc/loki.go
@@ -401,6 +401,30 @@ func (l *LokiClient) log(labels map[string]string, logLine string) {
 	}
 }
 
+// LogCustom emits a structured diagnostic log under a caller-chosen source label.
+// Use sparingly — intended for targeted instrumentation (e.g. vector search stats)
+// that doesn't fit the generic API request/response shape.
+func (l *LokiClient) LogCustom(source string, extraLabels map[string]string, data map[string]interface{}) {
+	if !l.enabled {
+		return
+	}
+
+	labels := map[string]string{
+		"app":    "freegle",
+		"source": source,
+	}
+	for k, v := range extraLabels {
+		labels[k] = v
+	}
+
+	if _, ok := data["timestamp"]; !ok {
+		data["timestamp"] = time.Now().Format(time.RFC3339Nano)
+	}
+
+	logLine, _ := json.Marshal(data)
+	l.log(labels, string(logLine))
+}
+
 // LogChatReply logs a chat reply event with source tracking for dashboard analytics.
 // Sources: "amp" (AMP email form), "email" (email reply), "website" (web interface)
 func (l *LokiClient) LogChatReply(source string, chatID, userID uint64, messageID *uint64, emailTrackingID *uint64) {

--- a/iznik-server-go/test/embedding_vectorsearch_test.go
+++ b/iznik-server-go/test/embedding_vectorsearch_test.go
@@ -72,7 +72,7 @@ func TestVectorSearchBasic(t *testing.T) {
 	embedding.SetSidecarURL(server.URL)
 	defer embedding.SetSidecarURL("")
 
-	results, err := message.VectorSearch("sofa", 10, nil, "", 0, 0, 0, 0)
+	results, _, err := message.VectorSearch("sofa", 10, nil, "", 0, 0, 0, 0)
 	require.NoError(t, err)
 	assert.NotEmpty(t, results)
 	assert.Equal(t, uint64(1), results[0].Msgid)
@@ -95,7 +95,7 @@ func TestVectorSearchKeywordBoost(t *testing.T) {
 	embedding.SetSidecarURL(server.URL)
 	defer embedding.SetSidecarURL("")
 
-	results, err := message.VectorSearch("sofa", 10, nil, "", 0, 0, 0, 0)
+	results, _, err := message.VectorSearch("sofa", 10, nil, "", 0, 0, 0, 0)
 	require.NoError(t, err)
 	require.Len(t, results, 2)
 	// Sofa should be boosted to first by keyword match in subject
@@ -116,7 +116,7 @@ func TestVectorSearchWithMsgtypeFilter(t *testing.T) {
 	embedding.SetSidecarURL(server.URL)
 	defer embedding.SetSidecarURL("")
 
-	results, err := message.VectorSearch("sofa", 10, nil, "Offer", 0, 0, 0, 0)
+	results, _, err := message.VectorSearch("sofa", 10, nil, "Offer", 0, 0, 0, 0)
 	require.NoError(t, err)
 	assert.Len(t, results, 1)
 	assert.Equal(t, uint64(20), results[0].Msgid)
@@ -136,7 +136,7 @@ func TestVectorSearchWithGroupFilter(t *testing.T) {
 	embedding.SetSidecarURL(server.URL)
 	defer embedding.SetSidecarURL("")
 
-	results, err := message.VectorSearch("sofa", 10, []uint64{200}, "", 0, 0, 0, 0)
+	results, _, err := message.VectorSearch("sofa", 10, []uint64{200}, "", 0, 0, 0, 0)
 	require.NoError(t, err)
 	assert.Len(t, results, 1)
 	assert.Equal(t, uint64(31), results[0].Msgid)
@@ -159,9 +159,92 @@ func TestVectorSearchLimit(t *testing.T) {
 	embedding.SetSidecarURL(server.URL)
 	defer embedding.SetSidecarURL("")
 
-	results, err := message.VectorSearch("item", 3, nil, "", 0, 0, 0, 0)
+	results, _, err := message.VectorSearch("item", 3, nil, "", 0, 0, 0, 0)
 	require.NoError(t, err)
 	assert.Len(t, results, 3)
+}
+
+// TestVectorSearchStatsDiagnostics pins the diagnostic fields that the handler
+// logs to Loki on every call. These exist so that when a repeat identical
+// query returns a different result set (Dee, Discourse 9594), we can tell from
+// the logs which stage drifted — sidecar embedding, store size, or top
+// candidate cosines. Keep this test honest if you edit VectorStats.
+func TestVectorSearchStatsDiagnostics(t *testing.T) {
+	queryVec := makeTestVec(1.0)
+	strongMatch := makeTestVec(1.001)   // cosine ≈ 1 with queryVec → above threshold
+	antiparallel := makeAntiparallelVec(1.0) // cosine ≈ -1 → below threshold
+
+	embedding.Global.SetEntries([]embedding.Entry{
+		{Msgid: 1, Groupid: 100, Msgtype: "Offer", Subject: "strong", SubjectVec: strongMatch},
+		{Msgid: 2, Groupid: 100, Msgtype: "Offer", Subject: "noise", SubjectVec: antiparallel},
+	})
+	defer embedding.Global.SetEntries(nil)
+
+	server := mockSidecarReturning(t, queryVec[:])
+	defer server.Close()
+	embedding.SetSidecarURL(server.URL)
+	defer embedding.SetSidecarURL("")
+
+	_, stats, err := message.VectorSearch("thing", 10, nil, "", 0, 0, 0, 0)
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, stats.StoreSize, "StoreSize must reflect embedding.Global.Count()")
+	assert.Equal(t, 2, stats.Candidates, "both entries pass pre-filters, so Candidates=2")
+	assert.Equal(t, 1, stats.SubjectTier, "only the strong match should clear MinVectorScore")
+	assert.Equal(t, 1, stats.Dropped, "antiparallel entry is below threshold on both fields")
+	assert.Greater(t, stats.TopSubjectCos, float32(message.MinVectorScore),
+		"TopSubjectCos must capture the strong-match cosine even when most entries fail")
+	assert.Greater(t, stats.EmbedMs, float64(0), "EmbedMs must be populated")
+	assert.Greater(t, stats.TotalMs, float64(0), "TotalMs must be populated")
+	assert.NotEmpty(t, stats.QueryVecFP, "QueryVecFP must fingerprint the sidecar response")
+	assert.Empty(t, stats.Error, "successful call should not set Error")
+}
+
+// TestVectorSearchStatsDeterministicFingerprint confirms the query embedding
+// fingerprint is stable for identical inputs against a deterministic sidecar —
+// the property we rely on to detect sidecar-induced non-determinism in Loki.
+func TestVectorSearchStatsDeterministicFingerprint(t *testing.T) {
+	queryVec := makeTestVec(1.0)
+	embedding.Global.SetEntries([]embedding.Entry{
+		{Msgid: 1, Groupid: 100, Msgtype: "Offer", Subject: "x", SubjectVec: makeTestVec(1.001)},
+	})
+	defer embedding.Global.SetEntries(nil)
+
+	server := mockSidecarReturning(t, queryVec[:])
+	defer server.Close()
+	embedding.SetSidecarURL(server.URL)
+	defer embedding.SetSidecarURL("")
+
+	_, s1, err := message.VectorSearch("thing", 10, nil, "", 0, 0, 0, 0)
+	require.NoError(t, err)
+	_, s2, err := message.VectorSearch("thing", 10, nil, "", 0, 0, 0, 0)
+	require.NoError(t, err)
+	_, s3, err := message.VectorSearch("thing", 10, nil, "", 0, 0, 0, 0)
+	require.NoError(t, err)
+
+	assert.Equal(t, s1.QueryVecFP, s2.QueryVecFP)
+	assert.Equal(t, s2.QueryVecFP, s3.QueryVecFP)
+}
+
+// TestVectorSearchStatsOnEmbedError confirms that when EmbedQuery fails, the
+// stats carry the error text and the handler can emit a diagnostic log
+// regardless of the failure path.
+func TestVectorSearchStatsOnEmbedError(t *testing.T) {
+	embedding.Global.SetEntries([]embedding.Entry{
+		{Msgid: 1, Groupid: 100, Msgtype: "Offer", Subject: "x", SubjectVec: makeTestVec(1.0)},
+	})
+	defer embedding.Global.SetEntries(nil)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	url := server.URL
+	server.Close()
+	embedding.SetSidecarURL(url)
+	defer embedding.SetSidecarURL("")
+
+	_, stats, err := message.VectorSearch("sofa", 10, nil, "", 0, 0, 0, 0)
+	assert.Error(t, err)
+	assert.NotEmpty(t, stats.Error, "stats.Error must be populated when EmbedQuery fails")
+	assert.Equal(t, 1, stats.StoreSize, "StoreSize is known even when embedding fails")
 }
 
 func TestVectorSearchSidecarError(t *testing.T) {
@@ -178,7 +261,7 @@ func TestVectorSearchSidecarError(t *testing.T) {
 	embedding.SetSidecarURL(url)
 	defer embedding.SetSidecarURL("")
 
-	_, err := message.VectorSearch("sofa", 10, nil, "", 0, 0, 0, 0)
+	_, _, err := message.VectorSearch("sofa", 10, nil, "", 0, 0, 0, 0)
 	assert.Error(t, err)
 }
 

--- a/iznik-server-go/test/embedding_vectorsearch_test.go
+++ b/iznik-server-go/test/embedding_vectorsearch_test.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 	"time"
 
@@ -13,6 +14,22 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// makeAntiparallelVec returns a unit vector pointing opposite to makeTestVec,
+// so cosine similarity is ~-1 — reliably below MinVectorScore.
+func makeAntiparallelVec(seed float32) [embedding.EmbeddingDim]float32 {
+	var v [embedding.EmbeddingDim]float32
+	var norm float32
+	for i := 0; i < embedding.EmbeddingDim; i++ {
+		v[i] = -(seed + float32(i)*0.01)
+		norm += v[i] * v[i]
+	}
+	norm = float32(math.Sqrt(float64(norm)))
+	for i := 0; i < embedding.EmbeddingDim; i++ {
+		v[i] /= norm
+	}
+	return v
+}
 
 func makeTestVec(seed float32) [embedding.EmbeddingDim]float32 {
 	var v [embedding.EmbeddingDim]float32
@@ -201,4 +218,139 @@ func TestStoreSetEntriesAndCount(t *testing.T) {
 
 	embedding.Global.SetEntries(nil)
 	assert.Equal(t, 0, embedding.Global.Count())
+}
+
+// TestSearchHandlerVectorModeDoesNotFallBackToKeyword reproduces the
+// non-determinism Dee reported on Discourse 9594: the same query returning
+// wildly different result sets on repeat attempts (flat screens → wood/floor
+// paint → flat screens again). Root cause: when searchmode=vector returned
+// zero matches above MinVectorScore, the handler silently fell back to the
+// keyword index, which has a completely different match model. Flaky network
+// conditions flipping vector between success and timeout produced the
+// observed mode-switching.
+//
+// After the fix, an explicit searchmode=vector request respects the vector
+// result set (even if empty) instead of secretly switching to keyword.
+func TestSearchHandlerVectorModeDoesNotFallBackToKeyword(t *testing.T) {
+	prefix := uniquePrefix("vectornofallback")
+	groupID := CreateTestGroup(t, prefix)
+	userID := CreateTestUser(t, prefix, "User")
+	CreateTestMembership(t, userID, groupID, "Member")
+
+	// Create a message whose indexed words WOULD match a keyword search for
+	// "television" (via exact + prefix word matches on the search index).
+	CreateTestMessage(t, userID, groupID, "television stand oak", 55.9533, -3.1883)
+
+	// Confirm the keyword path actually finds this message — otherwise the
+	// test below would pass trivially and wouldn't prove we avoided fallback.
+	keywordResp, _ := getApp().Test(httptest.NewRequest(
+		"GET",
+		"/api/message/search/television?searchmode=keyword&groupids="+strconv.FormatUint(groupID, 10),
+		nil,
+	), 60000)
+	require.Equal(t, 200, keywordResp.StatusCode)
+	var keywordResults []message.SearchResult
+	json.NewDecoder(keywordResp.Body).Decode(&keywordResults)
+	require.NotEmpty(t, keywordResults, "sanity check: keyword search must find the seeded message")
+
+	// Set up the embedding store with ONE entry whose vector points in the
+	// opposite direction to the query — cosine ≈ -1, far below MinVectorScore
+	// of 0.65. Count() > 0 so the handler enters the vector branch; the
+	// filtered vector result is legitimately empty.
+	queryVec := makeTestVec(1.0)
+	antiparallel := makeAntiparallelVec(1.0)
+	embedding.Global.SetEntries([]embedding.Entry{
+		{
+			Msgid: 999999, Groupid: groupID, Msgtype: "Offer",
+			Lat: 55.9533, Lng: -3.1883,
+			Subject: "totally unrelated noise", Arrival: time.Now(),
+			SubjectVec: antiparallel,
+		},
+	})
+	defer embedding.Global.SetEntries(nil)
+
+	server := mockSidecarReturning(t, queryVec[:])
+	defer server.Close()
+	embedding.SetSidecarURL(server.URL)
+	defer embedding.SetSidecarURL("")
+
+	// Now the same query with searchmode=vector. Vector legitimately returns
+	// nothing above threshold. The handler must NOT silently fall back to the
+	// keyword index (which would surface "television stand oak").
+	vectorResp, _ := getApp().Test(httptest.NewRequest(
+		"GET",
+		"/api/message/search/television?searchmode=vector&groupids="+strconv.FormatUint(groupID, 10),
+		nil,
+	), 60000)
+	require.Equal(t, 200, vectorResp.StatusCode)
+
+	var vectorResults []message.SearchResult
+	json.NewDecoder(vectorResp.Body).Decode(&vectorResults)
+
+	assert.Empty(t, vectorResults,
+		"searchmode=vector with no matches above threshold must return empty, not fall back to keyword")
+
+	// No result should carry a keyword matchedon.Type — fail clearly if the
+	// fallback leaks through.
+	for _, r := range vectorResults {
+		assert.Equal(t, "Vector", r.Matchedon.Type,
+			"non-Vector matchedon.Type (%q) for msgid=%d indicates keyword fallback", r.Matchedon.Type, r.Msgid)
+	}
+}
+
+// TestSearchHandlerVectorModeIsDeterministic confirms the same vector query
+// returns the same result set on repeat calls — directly addresses Dee's
+// "very puzzling" report that identical queries produced different results
+// (Discourse 9594).
+func TestSearchHandlerVectorModeIsDeterministic(t *testing.T) {
+	prefix := uniquePrefix("vectordeterministic")
+	groupID := CreateTestGroup(t, prefix)
+
+	// Two entries: one strong match, one antiparallel (noise).
+	queryVec := makeTestVec(1.0)
+	strongMatch := makeTestVec(1.001)
+	embedding.Global.SetEntries([]embedding.Entry{
+		{
+			Msgid: 11111, Groupid: groupID, Msgtype: "Offer",
+			Lat: 55.9533, Lng: -3.1883,
+			Subject: "television", Arrival: time.Now(), SubjectVec: strongMatch,
+		},
+		{
+			Msgid: 22222, Groupid: groupID, Msgtype: "Offer",
+			Lat: 55.9533, Lng: -3.1883,
+			Subject: "unrelated", Arrival: time.Now(),
+			SubjectVec: makeAntiparallelVec(1.0),
+		},
+	})
+	defer embedding.Global.SetEntries(nil)
+
+	server := mockSidecarReturning(t, queryVec[:])
+	defer server.Close()
+	embedding.SetSidecarURL(server.URL)
+	defer embedding.SetSidecarURL("")
+
+	url := "/api/message/search/television?searchmode=vector&groupids=" + strconv.FormatUint(groupID, 10)
+
+	runOnce := func() []uint64 {
+		resp, _ := getApp().Test(httptest.NewRequest("GET", url, nil), 60000)
+		require.Equal(t, 200, resp.StatusCode)
+		var results []message.SearchResult
+		json.NewDecoder(resp.Body).Decode(&results)
+		ids := make([]uint64, len(results))
+		for i, r := range results {
+			ids[i] = r.Msgid
+		}
+		return ids
+	}
+
+	first := runOnce()
+	for i := 0; i < 3; i++ {
+		assert.Equal(t, first, runOnce(),
+			"repeat #%d returned different ids — vector search must be deterministic for identical inputs", i+1)
+	}
+
+	// Sanity: the strong match should be in the result set; the antiparallel
+	// noise must be filtered by MinVectorScore.
+	assert.Contains(t, first, uint64(11111))
+	assert.NotContains(t, first, uint64(22222))
 }


### PR DESCRIPTION
## Reporter

@Dee, Discourse 9594 / 9585.20 — same query, same group, radically different result sets on repeat calls in quick succession.

## What this PR is (and isn't)

**Is**: (a) remove a silent keyword fallback that masked vector behaviour, (b) add per-call diagnostics so the next recurrence is traceable from Loki alone.

**Isn't**: a fix for the underlying non-determinism. We do **not** fully understand why rapid-succession repeats of Dee's queries returned different result sets. This PR makes the next investigation tractable; it does not explain the flip.

## The silent-fallback bug

Before this PR, the search handler was:

```go
if searchmode == "vector" && embedding.Global.Count() > 0 {
    vectorResults, err := VectorSearch(...)
    if err == nil {
        res = vectorResults // may be empty
    }
}
if len(res) == 0 {
    // keyword search runs even though user asked for vector
}
```

Vector can legitimately return empty (no candidates ≥ `MinVectorScore = 0.65`) without erroring. When that happened, `len(res) == 0` caused the handler to silently run keyword search and return those results as if they were vector results — a completely different match model hidden behind `searchmode=vector`.

Concretely, this is why Dee's "flat screen" result list sometimes contained items marked **Taken** and messages up to six years old: the store excludes `successful=1 OR promised=1`, but the keyword path doesn't. If you saw a Taken/old item in a "semantic" result, you were on the fallback path.

This silent mode-flip was enough on its own to make every vector↔keyword divergence look like non-determinism of the vector path. **Removing it eliminates the mode-flip as a confounder.** Whatever else is going on, at least "vector returned X" now means "vector actually returned X".

The error-path keyword fallback is preserved — a fully-down sidecar still degrades to keyword instead of returning 500.

## Per-call diagnostics (new)

Four changes so the next recurrence is diagnosable from Loki alone:

- **`misc/loki.go`** — `LogCustom(source, labels, data)`: generic structured-log emitter for handlers that don't fit the API request/response shape.
- **`message/vectorsearch.go`** — `VectorSearch` now returns a `VectorStats` struct alongside results:
  - `EmbedMs`, `StoreMs`, `TotalMs` — timing per stage
  - `StoreSize` — `embedding.Global.Count()` at call time (catches refresh-in-flight)
  - `Candidates` — raw count from `Store.Search` pre-threshold
  - `SubjectTier`, `BodyTier`, `Dropped` — how candidates split across the threshold
  - `TopSubjectCos`, `TopBodyCos` — best cosines seen (diagnoses "why empty")
  - `QueryVecFP` — 4-value fingerprint of the returned embedding; identical input to a deterministic embedder must yield identical fingerprint
  - `TopK` — top-5 candidates as `msgid:subjCos:bodyCos:subject|...` for threshold tuning
  - `Error` — populated on `EmbedQuery` failure
- **`message/message.go`** — search handler emits one `vector_search` Loki entry per call with all stats, labelled `searchmode` / `fallback_taken` / `empty`. Queryable e.g. `{source="vector_search", empty="true"}` to see every empty result with its top candidates.
- **`docker/embedding-sidecar/server.mjs`** — per-request JSON log with `elapsed_ms`, `first_text_len`, `first_text` (truncated), and a 4-value fingerprint of the returned embedding.

Next time a reporter says "same query, different results", Loki will show **which stage differed**: embedding fingerprint (sidecar non-determinism), store size (refresh in flight), candidate count (bounding box/group filter changed), or top cosines (store entries appeared/disappeared).

## Known unknowns

- Why Dee's rapid-succession repeats flipped is still not pinned down. The sidecar is stateless and has produced identical fingerprints for identical input in all tests; the store's `Search` is deterministic given identical state. Production runs on Lambda with multiple independent containers, each with its own in-memory store refreshed on an independent 2-minute ticker — concurrent invocations can land on containers in different refresh phases. Whether that fully explains what Dee saw is for the next investigation, with the new logs.
- Relevance tuning (TV → microwaves, threshold calibration, Matryoshka dim) — **deliberately out of scope**. A prior attempt was rejected; this PR does not touch `MinVectorScore` or embedding config.

## Tests

- `TestSearchHandlerVectorModeDoesNotFallBackToKeyword` — pins the handler fix: empty vector result stays empty.
- `TestSearchHandlerVectorModeIsDeterministic` — same vector query four times → identical id lists.
- `TestVectorSearchStatsDiagnostics` — shape of the stats struct.
- `TestVectorSearchStatsDeterministicFingerprint` — identical input → identical fingerprint.
- `TestVectorSearchStatsOnEmbedError` — stats carry the error text on `EmbedQuery` failure.

All Go tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
