### PR TITLE
fix(ads): allow clicks on Jobs and static ads once ad renders

### DIFF
--- a/iznik-nuxt3/components/ExternalDa.vue
+++ b/iznik-nuxt3/components/ExternalDa.vue
@@ -373,11 +373,13 @@ function rippleRendered(rendered) {
   }
 }
 
-// v-bind in scoped <style> emits the returned value directly into CSS, so
-// it must be a valid CSS value — not a boolean. `pointer-events: true` is
-// invalid and triggers "Invalid value used for CSS binding" warnings.
+// When the ad (or its fallback — Jobs list, donate banner) is rendered we
+// must allow pointer events so the link/ad is clickable. When the slot is
+// still an empty placeholder (adShown=false) we set `none` so clicks pass
+// through to any content behind. The previous mapping was inverted, which
+// blocked clicks on Jobs links and footer ads once an ad resolved.
 const passClicks = computed(() => {
-  return adShown.value ? 'none' : 'auto'
+  return adShown.value ? 'auto' : 'none'
 })
 
 onBeforeUnmount(() => {

--- a/iznik-nuxt3/tests/unit/components/ExternalDa.spec.js
+++ b/iznik-nuxt3/tests/unit/components/ExternalDa.spec.js
@@ -331,18 +331,19 @@ describe('ExternalDa', () => {
 
   describe('passClicks computed', () => {
     // passClicks feeds straight into `pointer-events` via v-bind in <style>,
-    // so it must resolve to a real CSS keyword. Booleans trigger the Vue
-    // "Invalid value used for CSS binding" warning.
-    it("returns 'none' when adShown is true", () => {
+    // so it must resolve to a real CSS keyword. When an ad or fallback is
+    // rendered we need `auto` so the link is clickable — the previous
+    // mapping was inverted and broke Jobs/footer ad clicks (#9481 post 492/493).
+    it("returns 'auto' when adShown is true so the ad is clickable", () => {
       const wrapper = createWrapper()
       wrapper.vm.adShown = true
-      expect(wrapper.vm.passClicks).toBe('none')
+      expect(wrapper.vm.passClicks).toBe('auto')
     })
 
-    it("returns 'auto' when adShown is false", () => {
+    it("returns 'none' when adShown is false so clicks pass through the empty placeholder", () => {
       const wrapper = createWrapper()
       wrapper.vm.adShown = false
-      expect(wrapper.vm.passClicks).toBe('auto')
+      expect(wrapper.vm.passClicks).toBe('none')
     })
   })
 


### PR DESCRIPTION
## Summary

- `ExternalDa.vue` applied `pointer-events: none` to its container once an ad or fallback (Jobs list, donate banner) rendered, blocking clicks on the very content that was supposed to be clickable.
- Video ads were unaffected because they float above the container; every other static link was silently dead.
- The regression came in with `ba725baeb`, which swapped a silently-invalid boolean binding (`pointer-events: true` → browser fell back to `auto`) for valid `'none'`/`'auto'` values without flipping the ternary.

## Fix

- Invert `passClicks`: `'auto'` when the slot has content, `'none'` when it's still an empty placeholder so clicks pass through to anything behind.
- Update the two `passClicks` unit specs to codify the corrected mapping and reference the Discourse report.

## Verification

- [x] All 28 `ExternalDa.spec.js` cases pass (via status container vitest, filter `ExternalDa`).
- [ ] On deploy preview: confirm Jobs links and footer banners (Utility Warehouse / Temu / local restaurant) are clickable on Freegle Direct in desktop Firefox; video ads unaffected.

Reported on Discourse https://discourse.ilovefreegle.org/t/9481/492 and https://discourse.ilovefreegle.org/t/9481/493.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
