### PR TITLE
test(e2e): dump DOM + API diagnostics on Edit&Resend button miss

### DIFF
--- a/iznik-nuxt3/tests/e2e/test-repost-group-change.spec.js
+++ b/iznik-nuxt3/tests/e2e/test-repost-group-change.spec.js
@@ -41,7 +41,75 @@ test.describe('Repost Group Change', () => {
         '.message-card:has(.notice--warning) button:has-text("Edit & Resend")'
       )
       .first()
-    await expect(editResendBtn).toBeVisible({ timeout: timeouts.ui.appearance })
+    try {
+      await expect(editResendBtn).toBeVisible({
+        timeout: timeouts.ui.appearance,
+      })
+    } catch (err) {
+      const diag = await page.evaluate((rejectedId) => {
+        const cards = Array.from(document.querySelectorAll('.message-card'))
+        const warning = document.querySelectorAll('.notice--warning')
+        const rejectedCard = document.querySelector(
+          `[data-message-id="${rejectedId}"]`
+        )
+        return {
+          totalCards: cards.length,
+          cardIds: cards
+            .map((c) => c.getAttribute('data-message-id'))
+            .filter(Boolean),
+          noticeWarningCount: warning.length,
+          rejectedCardFound: !!rejectedCard,
+          rejectedCardHTML: rejectedCard
+            ? rejectedCard.innerHTML.slice(0, 2000)
+            : null,
+        }
+      }, testEnv.rejected?.offer)
+      console.log('=== REPOST DIAGNOSTIC ON FAIL ===')
+      console.log(JSON.stringify(diag, null, 2))
+      const apiResp = await page
+        .request.get(
+          `http://apiv2.localhost/api/user/${testEnv.user.id}/message?active=true`
+        )
+        .catch((e) => ({ status: () => 'ERR', json: async () => e.message }))
+      console.log(
+        'api /user/:id/message status:',
+        typeof apiResp.status === 'function' ? apiResp.status() : 'unknown'
+      )
+      if (typeof apiResp.json === 'function') {
+        const body = await apiResp.json().catch(() => null)
+        console.log(
+          'rejected entry in list:',
+          JSON.stringify(
+            (body || []).find(
+              (m) => String(m.id) === String(testEnv.rejected?.offer)
+            ) || null
+          )
+        )
+      }
+      const msgResp = await page
+        .request.get(
+          `http://apiv2.localhost/api/message/${testEnv.rejected?.offer}`
+        )
+        .catch((e) => ({ status: () => 'ERR', json: async () => e.message }))
+      if (typeof msgResp.json === 'function') {
+        const m = await msgResp.json().catch(() => null)
+        if (m) {
+          console.log('/message/:id location present:', !!m.location)
+          console.log('/message/:id item present:', !!m.item)
+          console.log(
+            '/message/:id groups:',
+            JSON.stringify(
+              (m.groups || []).map((g) => ({
+                id: g.groupid,
+                collection: g.collection,
+              }))
+            )
+          )
+        }
+      }
+      console.log('=== END REPOST DIAGNOSTIC ===')
+      throw err
+    }
     console.log('Found rejected message with Edit & Resend button')
     await editResendBtn.click()
     console.log('Clicked Edit & Resend')


### PR DESCRIPTION
## Summary

test-repost-group-change has been the sole failing Playwright test on master's `build-test-cloud` for ~14 consecutive pipelines (since 2026-04-18). The failure signature is `expect(editResendBtn).toBeVisible` timing out at line 44 after 67.5s with "element(s) not found". That message alone doesn't distinguish the two possible root causes:

- **Card missing**: the `/user/:id/message` list didn't return the rejected fixture, so no `.message-card` with `.notice--warning` ever renders — means a Go-API filtering bug.
- **Button missing**: the card renders (`.notice--warning` visible), but the button is gated out by `v-if="message.location && message.item"` in `MyMessage.vue:322/408` — means the per-message detail fetch returned null for one of those fields.

I've traced both paths by reading code (summary below) and can't prove either from the source. This PR adds an on-failure diagnostic block to the test that logs DOM counts, the rejected card's innerHTML, and the `/user/:id/message` and `/message/:id` API responses. The next CI failure will be diagnosable.

### What it logs on timeout
- count + `data-message-id` list of every `.message-card` on page
- count of `.notice--warning` elements
- whether a card with `data-message-id = testEnv.rejected.offer` is present, plus 2KB of its `innerHTML`
- the rejected message's entry in the `/user/:id/message?active=true` response (so we can tell if the list call dropped it)
- `location` / `item` presence + `groups.collection` array from `/message/:id` (so we can tell if the button-gate is failing)

### Code-path ruling-out (for context, from reading code)
- `GetMessagesForUser` (`message.go:735`): HAVING clause `((hasoutcome = 0 AND spatialid IS NOT NULL) OR messages_groups.collection IN ('Pending', 'Rejected'))` — the rejected OR branch means it DOES return rejected messages.
- `applyExpiry` (`message.go:837`): a fresh rejected fixture has arrival ≈ now, not an expiry candidate.
- `GetMessagesByIds` (`message.go:484`): enrichment gated on `Locationid > 0`. Fixture sets `locationid = pcid` which is always non-zero (`create-test-env.php:285-286`).
- `item.FetchForMessage`: returns nil if `messages_items` row missing. `Message.php:2787` inserts one iff the subject regex `/.*?\:(.*)\(.*\)/` matches — the fixture subject `"OFFER: PW_repostgroupchange Rejected Chair (Boultham)"` matches.
- Message owner branch `message.go:549`: `message.Fromuser == myid` → `message.Location = loc`. Owner should get populated location.

Everything that *should* work does work on paper. The diagnostic block will turn the next reproduction into a root-cause.

### Risk
Minimal — if the assertion passes, the catch block never runs; the test behaves identically. If it fails, we get extra console output but still fail the same way.

## Test plan
- [ ] CI reproduces the master failure (expected — this PR doesn't fix it)
- [ ] CI console output includes the `=== REPOST DIAGNOSTIC ON FAIL ===` block
- [ ] Diagnostic output distinguishes card-missing vs button-missing case

🤖 Generated with [Claude Code](https://claude.com/claude-code)