### PR TITLE
fix(message): return item for rejected message regardless of locationid

### DIFF
--- a/iznik-nuxt3/components/MyMessage.vue
+++ b/iznik-nuxt3/components/MyMessage.vue
@@ -933,7 +933,7 @@ const repost = async (e) => {
     me
   )
 
-  if (msg.location) {
+  if (msg.location?.name) {
     const locs = await locationStore.typeahead(msg.location.name)
     composeStore.postcode = locs[0]
   }

--- a/iznik-nuxt3/tests/e2e/test-repost-group-change.spec.js
+++ b/iznik-nuxt3/tests/e2e/test-repost-group-change.spec.js
@@ -64,6 +64,30 @@ test.describe('Repost Group Change', () => {
     })
     console.log('On whereami page')
 
+    // Dump compose-store + DOM state for diagnostics (helps find why
+    // the group dropdown sometimes fails to render on CI).
+    const whereamiState = await page.evaluate(() => {
+      const pinia = window.$nuxt?.$pinia || window.$pinia
+      const state = pinia?.state?.value
+      const compose = state?.compose
+      return {
+        href: window.location.href,
+        bodyText: document.body.innerText.slice(0, 500),
+        hasSelectElement: !!document.querySelector('select'),
+        hasComposeGroup: !!document.querySelector('.community-section'),
+        composePostcode: compose?.postcode
+          ? {
+              id: compose.postcode.id,
+              name: compose.postcode.name,
+              groupsnearCount: compose.postcode.groupsnear?.length ?? 0,
+              groupsnearIds: compose.postcode.groupsnear?.map((g) => g.id),
+            }
+          : null,
+        composeGroup: compose?.group,
+      }
+    })
+    console.log('WHEREAMI DIAG:', JSON.stringify(whereamiState, null, 2))
+
     // Wait for the group dropdown to appear.
     const groupDropdown = page.locator('select').first()
     await expect(groupDropdown).toBeVisible({ timeout: timeouts.ui.appearance })

--- a/iznik-nuxt3/tests/e2e/test-repost-group-change.spec.js
+++ b/iznik-nuxt3/tests/e2e/test-repost-group-change.spec.js
@@ -64,30 +64,6 @@ test.describe('Repost Group Change', () => {
     })
     console.log('On whereami page')
 
-    // Dump compose-store + DOM state for diagnostics (helps find why
-    // the group dropdown sometimes fails to render on CI).
-    const whereamiState = await page.evaluate(() => {
-      const pinia = window.$nuxt?.$pinia || window.$pinia
-      const state = pinia?.state?.value
-      const compose = state?.compose
-      return {
-        href: window.location.href,
-        bodyText: document.body.innerText.slice(0, 500),
-        hasSelectElement: !!document.querySelector('select'),
-        hasComposeGroup: !!document.querySelector('.community-section'),
-        composePostcode: compose?.postcode
-          ? {
-              id: compose.postcode.id,
-              name: compose.postcode.name,
-              groupsnearCount: compose.postcode.groupsnear?.length ?? 0,
-              groupsnearIds: compose.postcode.groupsnear?.map((g) => g.id),
-            }
-          : null,
-        composeGroup: compose?.group,
-      }
-    })
-    console.log('WHEREAMI DIAG:', JSON.stringify(whereamiState, null, 2))
-
     // Wait for the group dropdown to appear.
     const groupDropdown = page.locator('select').first()
     await expect(groupDropdown).toBeVisible({ timeout: timeouts.ui.appearance })

--- a/iznik-nuxt3/tests/unit/components/MyMessage.spec.js
+++ b/iznik-nuxt3/tests/unit/components/MyMessage.spec.js
@@ -479,6 +479,21 @@ describe('MyMessage', () => {
       const takenBtn = actionBtns.filter((btn) => btn.text().includes('TAKEN'))
       expect(takenBtn.length).toBe(0)
     })
+
+    it('repost skips typeahead when location has no name (locationid=0 fallback)', async () => {
+      mockData.message.groups = [{ groupid: 1, collection: 'Rejected' }]
+      mockData.message.item = { name: 'Test item' }
+      mockData.message.location = { name: '' }
+      const wrapper = await createWrapper()
+      const editResend = wrapper
+        .findAll('.action-btn')
+        .find((btn) => btn.text().includes('Edit & Resend'))
+      expect(editResend).toBeTruthy()
+      await editResend.trigger('click')
+      await flushPromises()
+      expect(mockLocationStore.typeahead).not.toHaveBeenCalled()
+      expect(mockRouterPush).toHaveBeenCalledWith('/give')
+    })
   })
 
   describe('Action Buttons', () => {

--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -478,77 +478,90 @@ func GetMessagesByIds(myid uint64, ids []string) []Message {
 					message.Refchatids = refchatids
 				}
 
-				// Fetch item and location for any viewer with locationid.
-				// Item is always public. Location (precise postcode) is only
-				// for mods and the message owner.
+				// Fetch item, location, and repost info in parallel.
+				// Item is always public and lives in messages_items, so it
+				// must be fetched regardless of locationid — a rejected
+				// message can have a valid item but no locationid.
+				// Location is for mods and the message owner only: prefer
+				// the precise postcode from locationid, else fall back to
+				// lat/lng (mirrors the mod path above).
+				// Repost eligibility needs the message's group settings,
+				// not location.
+				var wgExtra sync.WaitGroup
+
+				var loc *location.Location
+				var i *item.Item
+				var repostAt *time.Time
+				var canRepost bool
+
+				wgExtra.Add(1)
+				go func() {
+					defer wgExtra.Done()
+					i = item.FetchForMessage(message.ID)
+				}()
+
 				if message.Locationid > 0 {
-					var wgExtra sync.WaitGroup
-
-					var loc *location.Location
-					var i *item.Item
-					var repostAt *time.Time
-					var canRepost bool
-
 					wgExtra.Add(1)
 					go func() {
 						defer wgExtra.Done()
 						loc = location.FetchSingle(message.Locationid)
 					}()
-
+				} else if message.Lat != 0 && message.Lng != 0 {
 					wgExtra.Add(1)
 					go func() {
 						defer wgExtra.Done()
-						i = item.FetchForMessage(message.ID)
+						l := &location.Location{}
+						l.GroupsNear = location.ClosestGroups(float64(message.Lat), float64(message.Lng), location.NEARBY, 10)
+						loc = l
 					}()
+				}
 
-					wgExtra.Add(1)
-					go func() {
-						defer wgExtra.Done()
-						var repostStr []string
-						db.Raw("SELECT CASE WHEN JSON_EXTRACT(settings, '$.reposts') IS NULL THEN '{''offer'' => 3, ''wanted'' => 7, ''max'' => 5, ''chaseups'' => 5}' ELSE JSON_EXTRACT(settings, '$.reposts') END AS reposts FROM `groups` INNER JOIN messages_groups ON messages_groups.groupid = groups.id WHERE msgid = ?", message.ID).Pluck("reposts", &repostStr)
+				wgExtra.Add(1)
+				go func() {
+					defer wgExtra.Done()
+					var repostStr []string
+					db.Raw("SELECT CASE WHEN JSON_EXTRACT(settings, '$.reposts') IS NULL THEN '{''offer'' => 3, ''wanted'' => 7, ''max'' => 5, ''chaseups'' => 5}' ELSE JSON_EXTRACT(settings, '$.reposts') END AS reposts FROM `groups` INNER JOIN messages_groups ON messages_groups.groupid = groups.id WHERE msgid = ?", message.ID).Pluck("reposts", &repostStr)
 
-						var reposts []group.RepostSettings
+					var reposts []group.RepostSettings
 
-						for _, r := range repostStr {
-							var rs group.RepostSettings
-							json.Unmarshal([]byte(r), &rs)
-							reposts = append(reposts, rs)
+					for _, r := range repostStr {
+						var rs group.RepostSettings
+						json.Unmarshal([]byte(r), &rs)
+						reposts = append(reposts, rs)
+					}
+
+					for _, r := range reposts {
+						var interval int
+
+						if message.Type == utils.OFFER {
+							interval = r.Offer
+						} else {
+							interval = r.Wanted
 						}
 
-						for _, r := range reposts {
-							var interval int
+						if interval < 365 {
+							if len(message.MessageGroups) > 0 {
+								ra := message.MessageGroups[0].Arrival.AddDate(0, 0, interval)
+								repostAt = &ra
 
-							if message.Type == utils.OFFER {
-								interval = r.Offer
-							} else {
-								interval = r.Wanted
-							}
-
-							if interval < 365 {
-								if len(message.MessageGroups) > 0 {
-									ra := message.MessageGroups[0].Arrival.AddDate(0, 0, interval)
-									repostAt = &ra
-
-									if repostAt.Before(time.Now()) {
-										canRepost = true
-									}
+								if repostAt.Before(time.Now()) {
+									canRepost = true
 								}
 							}
 						}
-					}()
-
-					wgExtra.Wait()
-
-					// Item is always public.
-					message.Item = i
-					message.Repostat = repostAt
-					message.Canrepost = canRepost
-
-					// Precise location only for mods and message owner.
-					// Other viewers get blurred lat/lng (handled elsewhere).
-					if message.Fromuser == myid || isModForMessage(db, myid, message.ID) {
-						message.Location = loc
 					}
+				}()
+
+				wgExtra.Wait()
+
+				message.Item = i
+				message.Repostat = repostAt
+				message.Canrepost = canRepost
+
+				// Precise location only for mods and message owner.
+				// Other viewers get blurred lat/lng (handled elsewhere).
+				if message.Fromuser == myid || isModForMessage(db, myid, message.ID) {
+					message.Location = loc
 				}
 
 				mu.Lock()

--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -409,9 +409,9 @@ func GetMessagesByIds(myid uint64, ids []string) []Message {
 							message.Location = loc
 						}
 					} else if message.Lat != 0 && message.Lng != 0 {
-						loc := &location.Location{}
-						loc.GroupsNear = location.ClosestGroups(float64(message.Lat), float64(message.Lng), location.NEARBY, 10)
-						message.Location = loc
+						l := location.ClosestPostcode(float32(message.Lat), float32(message.Lng))
+						l.GroupsNear = location.ClosestGroups(float64(message.Lat), float64(message.Lng), location.NEARBY, 10)
+						message.Location = &l
 					}
 				}
 
@@ -510,9 +510,9 @@ func GetMessagesByIds(myid uint64, ids []string) []Message {
 					wgExtra.Add(1)
 					go func() {
 						defer wgExtra.Done()
-						l := &location.Location{}
+						l := location.ClosestPostcode(float32(message.Lat), float32(message.Lng))
 						l.GroupsNear = location.ClosestGroups(float64(message.Lat), float64(message.Lng), location.NEARBY, 10)
-						loc = l
+						loc = &l
 					}()
 				}
 

--- a/iznik-server-go/test/message_test.go
+++ b/iznik-server-go/test/message_test.go
@@ -382,8 +382,14 @@ func TestRejectedMessageWithoutLocationidReturnsItemAndLocation(t *testing.T) {
 	// Create a message with a real locationid, then clear it to simulate the
 	// failure mode where the fixture / MailRouter leaves locationid=0.
 	// Lat/lng remain set (as they normally would be for a routed message).
+	// Use FOREIGN_KEY_CHECKS=0 because messages.locationid has a FK to
+	// locations.id; we're simulating the DB state directly.
 	msgID := CreateTestMessage(t, userID, groupID, "OFFER: Rejected NoLoc Chair", 55.9533, -3.1883)
-	db.Exec("UPDATE messages SET locationid = 0 WHERE id = ?", msgID)
+	// CreateTestMessage doesn't populate messages.lat/lng, only the spatial
+	// index — set them explicitly so Go falls into the lat/lng-fallback path.
+	db.Exec("SET FOREIGN_KEY_CHECKS = 0")
+	db.Exec("UPDATE messages SET locationid = 0, lat = ?, lng = ? WHERE id = ?", 55.9533, -3.1883, msgID)
+	db.Exec("SET FOREIGN_KEY_CHECKS = 1")
 	db.Exec("UPDATE messages_groups SET collection = 'Rejected' WHERE msgid = ?", msgID)
 	db.Exec("DELETE FROM messages_spatial WHERE msgid = ?", msgID)
 
@@ -401,6 +407,11 @@ func TestRejectedMessageWithoutLocationidReturnsItemAndLocation(t *testing.T) {
 	assert.Equal(t, msgID, msg.ID)
 	assert.NotNil(t, msg.Item, "Owner must get item on rejected message without locationid (Edit & Resend requires it)")
 	assert.NotNil(t, msg.Location, "Owner must get a location (from lat/lng fallback) on rejected message without locationid (Edit & Resend requires it)")
+	// Repost flow needs msg.location.name — MyMessage.repost() calls
+	// locationStore.typeahead(msg.location.name). If Name is empty the
+	// compose store's postcode is never set and the /give/whereami
+	// group dropdown fails to render.
+	assert.NotEmpty(t, msg.Location.Name, "Location must carry a Name so the repost flow can set composeStore.postcode via typeahead")
 }
 
 func TestCount(t *testing.T) {

--- a/iznik-server-go/test/message_test.go
+++ b/iznik-server-go/test/message_test.go
@@ -363,6 +363,46 @@ func TestRejectedMessageInActiveQuery(t *testing.T) {
 	assert.True(t, found, "Rejected message should appear in active query for own user")
 }
 
+// A rejected message may end up in the DB with locationid=0 (e.g. if the
+// MailRouter never resolved a location before the message was rejected).
+// The owner still needs to see both `item` and `location` on GET /message/:id
+// so the frontend can render the "Edit & Resend" button (v-if="location && item").
+// Regression: prior to the fix in message.go, item and location were both
+// gated on `locationid > 0`, so a rejected message with locationid=0 came
+// back with item=null AND location=null, hiding Edit & Resend entirely.
+func TestRejectedMessageWithoutLocationidReturnsItemAndLocation(t *testing.T) {
+	prefix := uniquePrefix("rjctnoloc")
+	groupID := CreateTestGroup(t, prefix)
+	userID := CreateTestUser(t, prefix, "User")
+	CreateTestMembership(t, userID, groupID, "Member")
+	_, token := CreateTestSession(t, userID)
+
+	db := database.DBConn
+
+	// Create a message with a real locationid, then clear it to simulate the
+	// failure mode where the fixture / MailRouter leaves locationid=0.
+	// Lat/lng remain set (as they normally would be for a routed message).
+	msgID := CreateTestMessage(t, userID, groupID, "OFFER: Rejected NoLoc Chair", 55.9533, -3.1883)
+	db.Exec("UPDATE messages SET locationid = 0 WHERE id = ?", msgID)
+	db.Exec("UPDATE messages_groups SET collection = 'Rejected' WHERE msgid = ?", msgID)
+	db.Exec("DELETE FROM messages_spatial WHERE msgid = ?", msgID)
+
+	// Give the message an item (lives in messages_items, independent of location).
+	itemID := CreateTestItem(t, prefix+" Chair")
+	CreateTestMessageItem(t, msgID, itemID)
+
+	// Owner fetches the message detail.
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/message/"+fmt.Sprint(msgID)+"?jwt="+token, nil))
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var msg message.Message
+	json2.Unmarshal(rsp(resp), &msg)
+
+	assert.Equal(t, msgID, msg.ID)
+	assert.NotNil(t, msg.Item, "Owner must get item on rejected message without locationid (Edit & Resend requires it)")
+	assert.NotNil(t, msg.Location, "Owner must get a location (from lat/lng fallback) on rejected message without locationid (Edit & Resend requires it)")
+}
+
 func TestCount(t *testing.T) {
 	// Create a full test user for count endpoint
 	prefix := uniquePrefix("count")


### PR DESCRIPTION
## Summary

- `GetMessagesByIds` gated Item, Location, and repost fetches behind `if message.Locationid > 0`. Items live in `messages_items` (msgid-keyed, location-independent). A rejected message with locationid=0 came back with `item=null, location=null`.
- The mod path already had a lat/lng-based Location fallback for locationid=0; the owner/non-mod path didn't. Now it does, mirroring the mod path.
- Repost eligibility (read from `groups.settings.reposts`) doesn't depend on location; hoisted out of the gate.

## Why this matters

On `/myposts`, the "Edit & Resend" button on a rejected card is gated `v-if="message.location && message.item"` in `MyMessage.vue`. With both null, the button never rendered and the repost flow was unreachable.

PR #224 instrumented `test-repost-group-change.spec.js` to dump DOM + API state on failure. Pipeline 5231 captured the smoking gun:

```
=== REPOST DIAGNOSTIC ON FAIL ===
rejectedCardFound: true   (card renders — groups present)
/message/:id location present: false
/message/:id item present: false
/message/:id groups: [{"id":55,"collection":"Rejected"}]
```

The card renders (groups come back) but the button's extra gate fails because item/location are null.

This test has been failing on every master build-and-test for ~3 days (pipelines 3424–3494, plus the 5231 instrumented run). Master is currently red on this test.

## Test plan

- [x] Go: new `TestRejectedMessageWithoutLocationidReturnsItemAndLocation` — creates a message, clears `locationid` to 0, asserts owner's `GET /message/:id` returns non-nil `item` AND `location` (via lat/lng fallback).
- [x] Existing Go suite: 1784 tests pass locally (via status API).
- [ ] CircleCI `build-and-test` green.
- [ ] The previously-failing `test-repost-group-change.spec.js` Playwright test passes on this branch.
- [ ] PR #224 (diagnostic-only) will be closed after this merges.

## Notes

Branch is off fresh `origin/master` — does NOT depend on PR #224.

🤖 Generated with [Claude Code](https://claude.com/claude-code)