### PR TITLE
fix(go): queue postcode remap when a location is excluded from a group

### DIFF
--- a/iznik-server-go/location/location.go
+++ b/iznik-server-go/location/location.go
@@ -874,6 +874,8 @@ func ExcludeLocation(c *fiber.Ctx) error {
 	db.Exec("INSERT IGNORE INTO locations_excluded (locationid, groupid, userid) VALUES (?, ?, ?)",
 		req.ID, req.GroupID, myid)
 
+	queueExcludeRemap(req.ID)
+
 	// If byname, also exclude all locations with the same name.
 	if req.Byname {
 		var name string
@@ -884,11 +886,27 @@ func ExcludeLocation(c *fiber.Ctx) error {
 			for _, otherID := range otherIDs {
 				db.Exec("INSERT IGNORE INTO locations_excluded (locationid, groupid, userid) VALUES (?, ?, ?)",
 					otherID, req.GroupID, myid)
+				queueExcludeRemap(otherID)
 			}
 		}
 	}
 
 	return c.JSON(fiber.Map{"success": true})
+}
+
+func queueExcludeRemap(locationID uint64) {
+	var wkt string
+	database.DBConn.Raw(
+		"SELECT ST_AsText(COALESCE(ourgeometry, geometry)) FROM locations WHERE id = ?",
+		locationID,
+	).Scan(&wkt)
+	if wkt == "" {
+		return
+	}
+	go queue.QueueTask(queue.TaskRemapPostcodes, map[string]interface{}{
+		"location_id": locationID,
+		"polygon":     wkt,
+	})
 }
 
 // --- KML to WKT conversion ---

--- a/iznik-server-go/test/location_test.go
+++ b/iznik-server-go/test/location_test.go
@@ -315,6 +315,54 @@ func TestExcludeLocation(t *testing.T) {
 	db.Exec("DELETE FROM locations WHERE id = ?", locID)
 }
 
+func TestExcludeLocationQueuesRemapTask(t *testing.T) {
+	prefix := uniquePrefix("locwr_exclrmp")
+	modID := CreateTestUser(t, prefix+"_mod", "User")
+	groupID := CreateTestGroup(t, prefix)
+	CreateTestMembership(t, modID, groupID, "Moderator")
+	_, modToken := CreateTestSession(t, modID)
+
+	// Create a test location with a polygon. The remap task needs the
+	// excluded location's geometry so PostcodeRemapService can re-run KNN
+	// over the postcodes that were previously inside it.
+	db := database.DBConn
+	polygon := "POLYGON((-3.21 55.94, -3.21 55.97, -3.18 55.97, -3.18 55.94, -3.21 55.94))"
+	db.Exec(fmt.Sprintf(
+		"INSERT INTO locations (name, type, canon, popularity, ourgeometry) VALUES (?, 'Polygon', ?, 0, ST_GeomFromText(?, %d))",
+		3857), // utils.SRID == 3857
+		"ExclRemap "+prefix, "exclremap "+prefix, polygon)
+	var locID uint64
+	db.Raw("SELECT id FROM locations WHERE name = ? ORDER BY id DESC LIMIT 1", "ExclRemap "+prefix).Scan(&locID)
+	assert.Greater(t, locID, uint64(0))
+
+	// Make sure there is no stale task from a prior run.
+	db.Exec("DELETE FROM background_tasks WHERE task_type = 'remap_postcodes' AND JSON_EXTRACT(data, '$.location_id') = ?", locID)
+
+	body := fmt.Sprintf(`{"id":%d,"groupid":%d,"action":"Exclude"}`, locID, groupID)
+	req := httptest.NewRequest("POST", "/api/locations?jwt="+modToken, bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	// Verify exclusion was created.
+	var count int64
+	db.Raw("SELECT COUNT(*) FROM locations_excluded WHERE locationid = ? AND groupid = ?", locID, groupID).Scan(&count)
+	assert.Equal(t, int64(1), count)
+
+	// Verify a remap_postcodes task was queued — exclusion changes which
+	// area postcodes inside this polygon should belong to, so KNN must be
+	// re-run. Async via goroutine, so brief wait.
+	time.Sleep(100 * time.Millisecond)
+	var taskCount int64
+	db.Raw("SELECT COUNT(*) FROM background_tasks WHERE task_type = 'remap_postcodes' AND JSON_EXTRACT(data, '$.location_id') = ?", locID).Scan(&taskCount)
+	assert.Greater(t, taskCount, int64(0), "remap_postcodes task should be queued after location exclude")
+
+	// Cleanup
+	db.Exec("DELETE FROM background_tasks WHERE task_type = 'remap_postcodes' AND JSON_EXTRACT(data, '$.location_id') = ?", locID)
+	db.Exec("DELETE FROM locations_excluded WHERE locationid = ? AND groupid = ?", locID, groupID)
+	db.Exec("DELETE FROM locations WHERE id = ?", locID)
+}
+
 func TestExcludeLocationNotMod(t *testing.T) {
 	prefix := uniquePrefix("locwr_exclnm")
 	userID := CreateTestUser(t, prefix, "User")


### PR DESCRIPTION
## Summary

- `ExcludeLocation` inserted into `locations_excluded` but never queued a postcode remap, so postcodes previously mapped to the excluded area stayed pointing at it (e.g. HD9 6NA remained on an excluded polygon).
- Added `queueExcludeRemap()`: fetches the excluded location's `ST_AsText(COALESCE(ourgeometry, geometry))` and queues `TaskRemapPostcodes` so `PostcodeRemapService` re-runs KNN and reassigns those postcodes to the next nearest non-excluded area.
- For `byname` excludes, one remap task is queued per additional location that gets excluded, so each polygon is re-run.

## Why this is the right shape

`PostcodeRemapService` already joins `locations_excluded` in its inside/outside/KNN queries — the data-model fix only needs a trigger. `UpdateLocation` already uses the same pattern (queue a `TaskRemapPostcodes` with the polygon as WKT); this brings `ExcludeLocation` in line.

V1 parity: `Location::delete()` in PHP doesn't remap either, so `DeleteLocation` in Go is intentionally not changed.

## Test plan

- [x] New `TestExcludeLocationQueuesRemapTask`: creates a polygon location, POSTs Exclude, asserts a `remap_postcodes` row appears in `background_tasks` with the right `location_id`.
- [x] Full Go suite green locally via status container: 1795✓ 0✗ (was 1794✓ 1✗ with the new test red before the fix).
- [ ] CI: build-and-test on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)