### PR TITLE
fix(sentry): suppress ftUtils.js getPlacementPosition null errors (NUXT3-CES)

### DIFF
--- a/iznik-nuxt3/composables/useSuppressException.js
+++ b/iznik-nuxt3/composables/useSuppressException.js
@@ -1,3 +1,35 @@
+// Robust suppression for Freestar ftUtils.js null-property errors
+// (NUXT3-CES getPlacementPosition, NUXT3-D2H getInnerDimensions) operating on
+// Sentry's parsed event frames. suppressException() below already matches on
+// err.stack string contents, but some events reach Sentry with a stack that
+// doesn't string-match (e.g. framework-wrapped TypeErrors where the original
+// exception is reconstructed before beforeSend sees it). A frame whose filename
+// is ftUtils.js AND whose function is one of Freestar's known null-property
+// sites is a narrow Freestar signature — won't mask real bugs in our own code.
+export function suppressSentryEvent(event) {
+  if (!event?.exception?.values) {
+    return false
+  }
+  for (const ex of event.exception.values) {
+    const frames = ex.stacktrace?.frames || []
+    for (const frame of frames) {
+      const isFtUtilsFrame =
+        frame.filename?.includes('/ftUtils.js') ||
+        frame.abs_path?.includes('/ftUtils.js')
+      const fn = frame.function || ''
+      const isFreestarFn =
+        fn === 'getPlacementPosition' ||
+        fn === 'Object.getPlacementPosition' ||
+        fn === 'getInnerDimensions' ||
+        fn === 'Object.getInnerDimensions'
+      if (isFtUtilsFrame && isFreestarFn) {
+        return true
+      }
+    }
+  }
+  return false
+}
+
 export function suppressException(err) {
   if (!err) {
     return false

--- a/iznik-nuxt3/plugins/sentry.client.ts
+++ b/iznik-nuxt3/plugins/sentry.client.ts
@@ -9,7 +9,10 @@ import { defineNuxtPlugin, useRuntimeConfig } from '#app'
 import { useRouter } from '#imports'
 import { useMiscStore } from '~/stores/misc'
 import { useAuthStore } from '~/stores/auth'
-import { suppressException } from '~/composables/useSuppressException'
+import {
+  suppressException,
+  suppressSentryEvent,
+} from '~/composables/useSuppressException'
 import { onTraceChange, getTraceId, getSessionId } from '~/composables/useTrace'
 import { useClientLog } from '~/composables/useClientLog'
 
@@ -109,6 +112,16 @@ export default defineNuxtPlugin(async (nuxtApp) => {
           if (useMiscStore()?.unloading) {
             // All network requests are aborted during unload, and so we'll get spurious errors.  Ignore them.
             console.log('Ignore error in unload')
+            return null
+          }
+
+          // Freestar ftUtils.js null-property errors (NUXT3-CES
+          // getPlacementPosition, NUXT3-D2H getInnerDimensions). The stack-based
+          // match in suppressException() below misses events where the original
+          // exception is reconstructed/wrapped by the time beforeSend sees it,
+          // so also check the parsed event frames directly.
+          if (suppressSentryEvent(event)) {
+            console.log('Freestar ftUtils frame - suppress event')
             return null
           }
 

--- a/iznik-nuxt3/tests/unit/composables/useSuppressException.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useSuppressException.spec.js
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { suppressException } from '~/composables/useSuppressException'
+import {
+  suppressException,
+  suppressSentryEvent,
+} from '~/composables/useSuppressException'
 
 describe('suppressException', () => {
   let logSpy
@@ -182,5 +185,151 @@ describe('suppressException', () => {
         message: "Cannot read properties of undefined (reading 'foo')",
       })
     ).toBe(false)
+  })
+})
+
+describe('suppressSentryEvent', () => {
+  it('returns false for falsy input', () => {
+    expect(suppressSentryEvent(null)).toBe(false)
+    expect(suppressSentryEvent(undefined)).toBe(false)
+    expect(suppressSentryEvent({})).toBe(false)
+  })
+
+  it('returns false when exception has no values', () => {
+    expect(suppressSentryEvent({ exception: {} })).toBe(false)
+    expect(suppressSentryEvent({ exception: { values: [] } })).toBe(false)
+  })
+
+  it('suppresses NUXT3-CES: ftUtils.js getPlacementPosition frame', () => {
+    // Synthetic Sentry event matching the NUXT3-CES signature (issue 6579683231):
+    // TypeError: Cannot read properties of null (reading 'document')
+    //   at Object.getPlacementPosition (.../ftUtils.js)
+    const event = {
+      exception: {
+        values: [
+          {
+            type: 'TypeError',
+            value: "Cannot read properties of null (reading 'document')",
+            stacktrace: {
+              frames: [
+                {
+                  function: 'Object.getPlacementPosition',
+                  filename: 'https://a.pub.network/freegle.org/ftUtils.js',
+                  abs_path: 'https://a.pub.network/freegle.org/ftUtils.js',
+                },
+              ],
+            },
+          },
+        ],
+      },
+    }
+    expect(suppressSentryEvent(event)).toBe(true)
+  })
+
+  it('suppresses NUXT3-D2H: ftUtils.js getInnerDimensions frame', () => {
+    const event = {
+      exception: {
+        values: [
+          {
+            type: 'TypeError',
+            value: "Cannot read properties of null (reading 'display')",
+            stacktrace: {
+              frames: [
+                {
+                  function: 'getInnerDimensions',
+                  filename: 'https://a.pub.network/freegle.org/ftUtils.js',
+                },
+              ],
+            },
+          },
+        ],
+      },
+    }
+    expect(suppressSentryEvent(event)).toBe(true)
+  })
+
+  it('matches when Freestar frame is not the top frame', () => {
+    const event = {
+      exception: {
+        values: [
+          {
+            stacktrace: {
+              frames: [
+                { function: 'userCode', filename: '/app.js' },
+                {
+                  function: 'getPlacementPosition',
+                  filename: '/ftUtils.js',
+                },
+                { function: 'innerWrapper', filename: '/lib.js' },
+              ],
+            },
+          },
+        ],
+      },
+    }
+    expect(suppressSentryEvent(event)).toBe(true)
+  })
+
+  it('does not suppress ftUtils.js frames with unknown function names', () => {
+    // Narrow match: a new bug in ftUtils.js with a different function should
+    // still be reported so we notice it rather than masking it.
+    const event = {
+      exception: {
+        values: [
+          {
+            stacktrace: {
+              frames: [
+                {
+                  function: 'someNewFunction',
+                  filename: 'https://a.pub.network/freegle.org/ftUtils.js',
+                },
+              ],
+            },
+          },
+        ],
+      },
+    }
+    expect(suppressSentryEvent(event)).toBe(false)
+  })
+
+  it('does not suppress getPlacementPosition in a non-ftUtils file', () => {
+    // Narrow match: another script happening to define a function called
+    // getPlacementPosition shouldn't be silently dropped.
+    const event = {
+      exception: {
+        values: [
+          {
+            stacktrace: {
+              frames: [
+                {
+                  function: 'getPlacementPosition',
+                  filename: '/app/MyComponent.vue',
+                },
+              ],
+            },
+          },
+        ],
+      },
+    }
+    expect(suppressSentryEvent(event)).toBe(false)
+  })
+
+  it('does not suppress unrelated events', () => {
+    const event = {
+      exception: {
+        values: [
+          {
+            type: 'TypeError',
+            value: "Cannot read properties of null (reading 'foo')",
+            stacktrace: {
+              frames: [
+                { function: 'myHandler', filename: '/app/MyComponent.vue' },
+              ],
+            },
+          },
+        ],
+      },
+    }
+    expect(suppressSentryEvent(event)).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary

Sentry issue **NUXT3-CES** (issue 6579683231, ~13.8k events, 1208 users):

> TypeError: Cannot read properties of null (reading 'document')
>     at Object.getPlacementPosition (ftUtils.js)

This is the third-party **Freestar** ad script (`ftUtils.js`), which we do not control — same class of error as NUXT3-D2H (`getInnerDimensions`) that PR #216 / commit 4d99e72d1 already handled.

The existing string-based suppression in `suppressException()` (PR #206) matches on `hint.originalException.stack` contents, but events have continued to arrive — evidently the stack that reaches Sentry isn't always string-searchable for `ftUtils.js` / `getPlacementPosition` (framework-wrapped exceptions, Vue error handler re-raising, etc.). This PR adds a second, more robust filter operating on the **parsed Sentry event frames** directly.

## Change

- `composables/useSuppressException.js`: new `suppressSentryEvent(event)` helper that walks `event.exception.values[].stacktrace.frames[]` looking for a frame where `filename` (or `abs_path`) contains `/ftUtils.js` AND `function` is one of Freestar's known null-property sites (`getPlacementPosition`, `Object.getPlacementPosition`, `getInnerDimensions`, `Object.getInnerDimensions`).
- `plugins/sentry.client.ts`: import and invoke `suppressSentryEvent` early in `beforeSend`, before the existing hint-based checks.
- `tests/unit/composables/useSuppressException.spec.js`: 7 new tests.

## Narrow match criteria

Deliberately narrow so we don't mask real bugs in our own code:

- A new/different bug in `ftUtils.js` (different function name) still reports.
- Any other script that happens to have a `getPlacementPosition` function still reports.
- Only the specific `ftUtils.js` + known Freestar function pair is suppressed.

## Test plan

- [x] New unit tests cover the NUXT3-CES `getPlacementPosition` signature, the NUXT3-D2H `getInnerDimensions` signature, non-top-frame matches, and narrow negatives (unknown function in ftUtils.js, getPlacementPosition in a non-ftUtils file, unrelated events, falsy inputs).
- [x] `useSuppressException.spec.js` passes locally (28/28 tests).
- [ ] Monitor Sentry NUXT3-CES event count post-deploy — should stop accumulating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)