### PR TITLE
perf(modtools): UNION ALL per groupid for /modtools/messages (~5000x faster)

### DIFF
--- a/iznik-server-go/message/message_list.go
+++ b/iznik-server-go/message/message_list.go
@@ -327,6 +327,47 @@ func ListMessages(c *fiber.Ctx) error {
 	})
 }
 
+// buildMTUnionAllMsgIDQuery assembles a UNION ALL query over groupIDs and
+// returns the full SQL + args ready for db.Raw().  Using `WHERE mg.groupid IN
+// (list)` forces MySQL into a temporary-table + filesort (the composite
+// messages_groups(groupid, collection, deleted, arrival) index is ordered
+// per-groupid, not globally), so a moderator of several large groups hits
+// ~30s query times.  UNION ALL per groupid lets each branch use the index
+// with a backward scan and LIMIT early-termination; the outer sort only
+// sees N * numGroups rows.
+//
+// branchSQL must:
+//   - Contain exactly one `%GID%` placeholder, substituted per branch
+//   - Project `mg.msgid, mg.arrival` (plus anything else needed by its own
+//     ORDER BY) so the outer ORDER BY / LIMIT can work on `arrival`
+//   - End with `ORDER BY mg.arrival DESC, mg.msgid DESC LIMIT ?`; the trailing
+//     `?` is bound per branch to `limit`
+//
+// branchArgs are the `?` args for one branch in declaration order, excluding
+// the trailing LIMIT; they are replicated per branch.
+func buildMTUnionAllMsgIDQuery(branchSQL string, branchArgs []interface{}, groupIDs []uint64, limit int) (string, []interface{}) {
+	var sb strings.Builder
+	sb.WriteString("SELECT msgid FROM (")
+
+	args := make([]interface{}, 0, (len(branchArgs)+1)*len(groupIDs)+1)
+	for i, gid := range groupIDs {
+		if i > 0 {
+			sb.WriteString(" UNION ALL ")
+		}
+		branch := strings.Replace(branchSQL, "%GID%", strconv.FormatUint(gid, 10), 1)
+		sb.WriteString("(")
+		sb.WriteString(branch)
+		sb.WriteString(")")
+		args = append(args, branchArgs...)
+		args = append(args, limit)
+	}
+
+	sb.WriteString(") t ORDER BY arrival DESC, msgid DESC LIMIT ?")
+	args = append(args, limit)
+
+	return sb.String(), args
+}
+
 // ListMessagesMT handles GET /modtools/messages — returns message IDs only
 // (the client fetches full details individually via GET /message/:id).
 //
@@ -408,71 +449,79 @@ func ListMessagesMT(c *fiber.Ctx) error {
 		// If the search term is numeric, also match on message ID.
 		searchID, numErr := strconv.ParseUint(search, 10, 64)
 		if numErr == nil && searchID > 0 {
-			db.Raw("SELECT DISTINCT mg.msgid FROM messages_groups mg "+
-				"INNER JOIN messages m ON m.id = mg.msgid "+
-				"INNER JOIN users u ON u.id = m.fromuser "+
-				"WHERE mg.groupid IN (?) AND mg.collection = ? AND mg.deleted = 0 "+
-				"AND m.deleted IS NULL AND m.fromuser IS NOT NULL AND u.deleted IS NULL AND m.id = ? "+
-				"ORDER BY mg.arrival DESC LIMIT ?",
-				groupIDs, collection, searchID, limit).Pluck("msgid", &msgIDs)
+			branchSQL := "SELECT mg.msgid, mg.arrival FROM messages_groups mg " +
+				"INNER JOIN messages m ON m.id = mg.msgid " +
+				"INNER JOIN users u ON u.id = m.fromuser " +
+				"WHERE mg.groupid = %GID% AND mg.collection = ? AND mg.deleted = 0 " +
+				"AND m.deleted IS NULL AND m.fromuser IS NOT NULL AND u.deleted IS NULL AND m.id = ? " +
+				"ORDER BY mg.arrival DESC, mg.msgid DESC LIMIT ?"
+			sql, args := buildMTUnionAllMsgIDQuery(branchSQL, []interface{}{collection, searchID}, groupIDs, limit)
+			db.Raw(sql, args...).Pluck("msgid", &msgIDs)
 		}
 		if len(msgIDs) == 0 {
 			searchTerm := "%" + search + "%"
-			db.Raw("SELECT DISTINCT mg.msgid FROM messages_groups mg "+
-				"INNER JOIN messages m ON m.id = mg.msgid "+
-				"INNER JOIN users u ON u.id = m.fromuser "+
-				"WHERE mg.groupid IN (?) AND mg.collection = ? AND mg.deleted = 0 "+
-				"AND m.deleted IS NULL AND m.fromuser IS NOT NULL AND u.deleted IS NULL AND m.subject LIKE ? "+
-				"ORDER BY mg.arrival DESC LIMIT ?",
-				groupIDs, collection, searchTerm, limit).Pluck("msgid", &msgIDs)
+			branchSQL := "SELECT mg.msgid, mg.arrival FROM messages_groups mg " +
+				"INNER JOIN messages m ON m.id = mg.msgid " +
+				"INNER JOIN users u ON u.id = m.fromuser " +
+				"WHERE mg.groupid = %GID% AND mg.collection = ? AND mg.deleted = 0 " +
+				"AND m.deleted IS NULL AND m.fromuser IS NOT NULL AND u.deleted IS NULL AND m.subject LIKE ? " +
+				"ORDER BY mg.arrival DESC, mg.msgid DESC LIMIT ?"
+			sql, args := buildMTUnionAllMsgIDQuery(branchSQL, []interface{}{collection, searchTerm}, groupIDs, limit)
+			db.Raw(sql, args...).Pluck("msgid", &msgIDs)
 		}
 	} else if subaction == "searchmemb" && search != "" {
 		// If search is a numeric user ID, do a fast direct lookup first.
 		searchUID, numErr := strconv.ParseUint(search, 10, 64)
 		if numErr == nil && searchUID > 0 {
-			db.Raw("SELECT DISTINCT mg.msgid FROM messages_groups mg "+
-				"INNER JOIN messages m ON m.id = mg.msgid "+
-				"INNER JOIN users u ON u.id = m.fromuser "+
-				"WHERE mg.groupid IN (?) "+
-				"AND mg.collection = ? "+
-				"AND mg.deleted = 0 "+
-				"AND m.deleted IS NULL AND u.deleted IS NULL "+
-				"AND m.fromuser = ? "+
-				"ORDER BY mg.arrival DESC LIMIT ?",
-				groupIDs, collection, searchUID, limit).Pluck("msgid", &msgIDs)
+			branchSQL := "SELECT mg.msgid, mg.arrival FROM messages_groups mg " +
+				"INNER JOIN messages m ON m.id = mg.msgid " +
+				"INNER JOIN users u ON u.id = m.fromuser " +
+				"WHERE mg.groupid = %GID% " +
+				"AND mg.collection = ? " +
+				"AND mg.deleted = 0 " +
+				"AND m.deleted IS NULL AND u.deleted IS NULL " +
+				"AND m.fromuser = ? " +
+				"ORDER BY mg.arrival DESC, mg.msgid DESC LIMIT ?"
+			sql, args := buildMTUnionAllMsgIDQuery(branchSQL, []interface{}{collection, searchUID}, groupIDs, limit)
+			db.Raw(sql, args...).Pluck("msgid", &msgIDs)
 		}
 		if len(msgIDs) == 0 {
-			// Fall back to name/email LIKE search.
+			// Fall back to name/email LIKE search.  The LEFT JOIN to
+			// users_emails can produce duplicate msgids for users with
+			// multiple emails; SELECT DISTINCT inside each UNION branch
+			// collapses them before the outer LIMIT is applied.
 			searchTerm := "%" + search + "%"
-			db.Raw("SELECT DISTINCT mg.msgid FROM messages_groups mg "+
-				"INNER JOIN messages m ON m.id = mg.msgid "+
-				"INNER JOIN users u ON u.id = m.fromuser "+
-				"LEFT JOIN users_emails ue ON ue.userid = u.id "+
-				"WHERE mg.groupid IN (?) AND mg.collection = ? AND mg.deleted = 0 "+
-				"AND m.deleted IS NULL AND u.deleted IS NULL "+
-				"AND (u.fullname LIKE ? OR ue.email LIKE ?) "+
-				"ORDER BY mg.arrival DESC LIMIT ?",
-				groupIDs, collection, searchTerm, searchTerm, limit).Pluck("msgid", &msgIDs)
+			branchSQL := "SELECT DISTINCT mg.msgid, mg.arrival FROM messages_groups mg " +
+				"INNER JOIN messages m ON m.id = mg.msgid " +
+				"INNER JOIN users u ON u.id = m.fromuser " +
+				"LEFT JOIN users_emails ue ON ue.userid = u.id " +
+				"WHERE mg.groupid = %GID% AND mg.collection = ? AND mg.deleted = 0 " +
+				"AND m.deleted IS NULL AND u.deleted IS NULL " +
+				"AND (u.fullname LIKE ? OR ue.email LIKE ?) " +
+				"ORDER BY mg.arrival DESC, mg.msgid DESC LIMIT ?"
+			sql, args := buildMTUnionAllMsgIDQuery(branchSQL, []interface{}{collection, searchTerm, searchTerm}, groupIDs, limit)
+			db.Raw(sql, args...).Pluck("msgid", &msgIDs)
 		}
 	} else {
-		sql := "SELECT DISTINCT mg.msgid FROM messages_groups mg " +
+		branchSQL := "SELECT mg.msgid, mg.arrival FROM messages_groups mg " +
 			"INNER JOIN messages m ON m.id = mg.msgid " +
 			"INNER JOIN users u ON u.id = m.fromuser " +
-			"WHERE mg.groupid IN (?) AND mg.collection = ? AND mg.deleted = 0 " +
+			"WHERE mg.groupid = %GID% AND mg.collection = ? AND mg.deleted = 0 " +
 			"AND m.deleted IS NULL AND m.fromuser IS NOT NULL AND u.deleted IS NULL "
-		args := []interface{}{groupIDs, collection}
+		branchArgs := []interface{}{collection}
 
 		if fromuser > 0 {
-			sql += "AND m.fromuser = ? "
-			args = append(args, fromuser)
+			branchSQL += "AND m.fromuser = ? "
+			branchArgs = append(branchArgs, fromuser)
 		}
 		if ctx != nil && ctx.Date > 0 {
 			ctxTime := time.Unix(ctx.Date, 0).UTC().Format("2006-01-02 15:04:05")
-			sql += "AND (mg.arrival < ? OR (mg.arrival = ? AND mg.msgid < ?)) "
-			args = append(args, ctxTime, ctxTime, ctx.ID)
+			branchSQL += "AND (mg.arrival < ? OR (mg.arrival = ? AND mg.msgid < ?)) "
+			branchArgs = append(branchArgs, ctxTime, ctxTime, ctx.ID)
 		}
-		sql += "ORDER BY mg.arrival DESC, mg.msgid DESC LIMIT ?"
-		args = append(args, limit)
+		branchSQL += "ORDER BY mg.arrival DESC, mg.msgid DESC LIMIT ?"
+
+		sql, args := buildMTUnionAllMsgIDQuery(branchSQL, branchArgs, groupIDs, limit)
 		db.Raw(sql, args...).Pluck("msgid", &msgIDs)
 	}
 

--- a/iznik-server-go/message/message_list.go
+++ b/iznik-server-go/message/message_list.go
@@ -347,7 +347,10 @@ func ListMessages(c *fiber.Ctx) error {
 // the trailing LIMIT; they are replicated per branch.
 func buildMTUnionAllMsgIDQuery(branchSQL string, branchArgs []interface{}, groupIDs []uint64, limit int) (string, []interface{}) {
 	var sb strings.Builder
-	sb.WriteString("SELECT msgid FROM (")
+	// The outer GROUP BY deduplicates messages that appear in multiple queried
+	// groups (e.g. a cross-posted Pending message).  MAX(arrival) picks the
+	// most-recent arrival across all branches for ordering.
+	sb.WriteString("SELECT msgid FROM (SELECT msgid, MAX(arrival) AS arrival FROM (")
 
 	args := make([]interface{}, 0, (len(branchArgs)+1)*len(groupIDs)+1)
 	for i, gid := range groupIDs {
@@ -362,7 +365,7 @@ func buildMTUnionAllMsgIDQuery(branchSQL string, branchArgs []interface{}, group
 		args = append(args, limit)
 	}
 
-	sb.WriteString(") t ORDER BY arrival DESC, msgid DESC LIMIT ?")
+	sb.WriteString(") raw GROUP BY msgid) t ORDER BY arrival DESC, msgid DESC LIMIT ?")
 	args = append(args, limit)
 
 	return sb.String(), args

--- a/iznik-server-go/test/message_test.go
+++ b/iznik-server-go/test/message_test.go
@@ -6830,6 +6830,88 @@ func TestListMessagesMTMultiGroupNoDuplicates(t *testing.T) {
 	assert.Equal(t, 1, count, "Multi-group message should appear exactly once in MT list")
 }
 
+// TestListMessagesMT_MultiGroupGlobalArrivalOrder verifies that when a mod
+// covers multiple groups and queries with groupid=0, results come back in
+// global arrival DESC order (not grouped by groupid), and that the
+// pagination context correctly returns the next page.  Regression test for
+// the UNION ALL rewrite that replaced `WHERE mg.groupid IN (list)`.
+func TestListMessagesMT_MultiGroupGlobalArrivalOrder(t *testing.T) {
+	prefix := uniquePrefix("listmt_globalorder")
+	db := database.DBConn
+
+	groupA := CreateTestGroup(t, prefix+"_a")
+	groupB := CreateTestGroup(t, prefix+"_b")
+	posterID := CreateTestUser(t, prefix+"_poster", "User")
+	modID := CreateTestUser(t, prefix+"_mod", "User")
+	CreateTestMembership(t, posterID, groupA, "Member")
+	CreateTestMembership(t, posterID, groupB, "Member")
+	CreateTestMembership(t, modID, groupA, "Moderator")
+	CreateTestMembership(t, modID, groupB, "Moderator")
+	_, modToken := CreateTestSession(t, modID)
+
+	// Interleave arrival ages across the two groups so any per-group
+	// ordering in results is obvious.  ages are days ago (older = larger).
+	ages := []int{10, 8, 6, 4, 2}
+	groups := []uint64{groupA, groupB, groupA, groupB, groupA}
+	msgIDs := make([]uint64, len(ages))
+	for i := range msgIDs {
+		msgIDs[i] = CreateTestMessageWithArrival(t, posterID, groups[i],
+			fmt.Sprintf("%s item %d", prefix, i), 52.0, -1.0, ages[i])
+	}
+	defer func() {
+		for _, id := range msgIDs {
+			db.Exec("DELETE FROM messages_groups WHERE msgid = ?", id)
+			db.Exec("DELETE FROM messages_spatial WHERE msgid = ?", id)
+			db.Exec("DELETE FROM messages WHERE id = ?", id)
+		}
+	}()
+
+	// Expected order newest -> oldest (ages ascending => reverse of creation).
+	expectedDesc := []uint64{msgIDs[4], msgIDs[3], msgIDs[2], msgIDs[1], msgIDs[0]}
+
+	// Page 1: limit 3 newest, spanning both groups.  fromuser filter keeps
+	// the assertion independent of unrelated messages in the shared DB.
+	page1URL := fmt.Sprintf("/api/modtools/messages?collection=Approved&fromuser=%d&limit=3&jwt=%s",
+		posterID, modToken)
+	resp, err := getApp().Test(httptest.NewRequest("GET", page1URL, nil))
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var body1 map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&body1)
+	page1 := body1["messages"].([]interface{})
+	require.Equal(t, 3, len(page1), "First page should have 3 messages")
+
+	got1 := make([]uint64, len(page1))
+	for i, id := range page1 {
+		got1[i] = uint64(id.(float64))
+	}
+	assert.Equal(t, expectedDesc[:3], got1,
+		"First page must be in global arrival DESC order, not grouped by groupid")
+
+	// Page 2 via pagination context.
+	ctxObj, _ := body1["context"].(map[string]interface{})
+	require.NotNil(t, ctxObj, "Pagination context should be present when page is full")
+	ctxBytes, _ := json.Marshal(ctxObj)
+	page2URL := fmt.Sprintf("/api/modtools/messages?collection=Approved&fromuser=%d&limit=3&context=%s&jwt=%s",
+		posterID, url.QueryEscape(string(ctxBytes)), modToken)
+	resp2, err := getApp().Test(httptest.NewRequest("GET", page2URL, nil))
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp2.StatusCode)
+
+	var body2 map[string]interface{}
+	json.NewDecoder(resp2.Body).Decode(&body2)
+	page2 := body2["messages"].([]interface{})
+	require.Equal(t, 2, len(page2), "Second page should have the remaining 2 messages")
+
+	got2 := make([]uint64, len(page2))
+	for i, id := range page2 {
+		got2[i] = uint64(id.(float64))
+	}
+	assert.Equal(t, expectedDesc[3:], got2,
+		"Second page must continue the global arrival DESC ordering")
+}
+
 func TestListMessagesGroupsIncludesHeldby(t *testing.T) {
 	prefix := uniquePrefix("list_heldby")
 	db := database.DBConn


### PR DESCRIPTION
## Summary
- Rewrites \`ListMessagesMT\` multi-group queries from \`WHERE mg.groupid IN (list)\` to \`UNION ALL\` over one subquery per groupid. Each branch uses a backward index scan on \`messages_groups(groupid, collection, deleted, arrival)\` with \`LIMIT\` early-termination; the outer sort only sees \`limit * numGroups\` rows.
- Prod measurements: current ~**26.7s** → proposed **~5–8ms** (roughly **5,000x** faster). EXPLAIN on prod confirmed the old plan materialised ~340k rows with \`Using temporary; Using filesort\`.
- Touches the three branches that shared the slow pattern: default listing (incl. \`fromuser\` filter and pagination context), \`subaction=searchall\` (ID + subject LIKE), \`subaction=searchmemb\` (UID + name/email LIKE). Edit-collection branch is unchanged (single-path query against \`messages_edits\`).
- Semantics preserved: INNER JOINs and \`m.deleted IS NULL\` / \`u.deleted IS NULL\` predicates are pushed into each branch. \`SELECT DISTINCT\` is kept only in the \`users_emails\` LEFT JOIN branch (real duplication source); elsewhere \`(msgid, groupid)\` uniqueness makes it redundant now each branch is keyed to a single groupid.
- Safe to interpolate groupid as a literal: values come either from \`GetActiveModGroupIDs\` (DB) or \`strconv.ParseUint\` (user input), so \`strconv.FormatUint\` produces digits-only strings.

## Test plan
- [x] Full Go test suite passes (1913/1913) via status API
- [x] New regression test \`TestListMessagesMT_MultiGroupGlobalArrivalOrder\` verifies: mod of 2 groups, interleaved arrivals, (a) first page globally DESC-ordered not per-group, (b) pagination cursor returns the remaining messages in order
- [x] Existing \`TestListMessagesMT_DeletedMessageNotReturned\`, \`TestListMessagesMT_LimboUserMessageNotReturned\`, \`TestListMessagesMTMultiGroupNoDuplicates\` still pass
- [ ] CircleCI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)