### PR TITLE
fix(message): soft-delete pending message on Withdrawn to prevent mod 403

### DIFF
--- a/.circleci/orb/freegle-tests.yml
+++ b/.circleci/orb/freegle-tests.yml
@@ -587,14 +587,14 @@ commands:
               # Also make actual HTTP requests to verify servers are responding
               # This is needed because Docker status is "running" during npm build
               if [ "$freegle_http_ready" = "false" ]; then
-                if curl -s -f -o /dev/null --max-time 5 http://localhost:3012/ 2>/dev/null; then
+                if curl -s -f -o /dev/null --max-time 5 http://localhost:${PORT_FREEGLE_PROD_LOCAL:-3012}/ 2>/dev/null; then
                   freegle_http_ready=true
                   echo "✅ Freegle production container is responding on HTTP"
                 fi
               fi
 
               if [ "$modtools_http_ready" = "false" ]; then
-                if curl -s -f -o /dev/null --max-time 5 http://localhost:3013/ 2>/dev/null; then
+                if curl -s -f -o /dev/null --max-time 5 http://localhost:${PORT_MODTOOLS_PROD_LOCAL:-3013}/ 2>/dev/null; then
                   modtools_http_ready=true
                   echo "✅ ModTools production container is responding on HTTP"
                 fi

--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -3211,13 +3211,22 @@ func handleOutcome(c *fiber.Ctx, myid uint64, req PostMessageRequest) error {
 		return fiber.NewError(fiber.StatusBadRequest, "Received outcome only valid for Wanted messages")
 	}
 
-	// For Withdrawn: if the message is still pending on any group, delete it entirely
-	// instead of recording an outcome.
+	// For Withdrawn: if the message is still pending on any group, soft-delete it
+	// instead of recording an outcome.  We use UPDATE ... SET deleted = NOW() (matching
+	// the rest of the codebase) rather than a hard DELETE so that moderators who loaded
+	// the pending queue before the withdrawal can still reject / delete the message
+	// without getting a spurious 403 from getMessageModContext failing to scan a
+	// now-absent messages row.
 	if req.Outcome == utils.OUTCOME_WITHDRAWN {
 		var pendingCount int64
 		db.Raw("SELECT COUNT(*) FROM messages_groups WHERE msgid = ? AND collection = ?", req.ID, utils.COLLECTION_PENDING).Scan(&pendingCount)
 		if pendingCount > 0 {
-			db.Exec("DELETE FROM messages WHERE id = ?", req.ID)
+			db.Exec("UPDATE messages SET deleted = NOW(), messageid = NULL WHERE id = ?", req.ID)
+			if err := queue.QueueTask(queue.TaskFreebieAlertsRemove, map[string]interface{}{
+				"msgid": req.ID,
+			}); err != nil {
+				log.Printf("Failed to queue freebie alerts remove for withdrawn pending message %d: %v", req.ID, err)
+			}
 			return c.JSON(fiber.Map{"ret": 0, "status": "Success", "deleted": true})
 		}
 	}

--- a/iznik-server-go/test/message_test.go
+++ b/iznik-server-go/test/message_test.go
@@ -1015,6 +1015,70 @@ func TestPostMessageRejectAfterMemberDeletes(t *testing.T) {
 	assert.Equal(t, "Rejected", collection, "Message should be in Rejected collection after mod rejects")
 }
 
+func TestPostMessageRejectAfterMemberWithdrawsPending(t *testing.T) {
+	prefix := uniquePrefix("msgmod_rej_wdraw")
+	db := database.DBConn
+
+	groupID := CreateTestGroup(t, prefix)
+	posterID := CreateTestUser(t, prefix+"_poster", "User")
+	modID := CreateTestUser(t, prefix+"_mod", "User")
+	CreateTestMembership(t, posterID, groupID, "Member")
+	CreateTestMembership(t, modID, groupID, "Moderator")
+	_, posterToken := CreateTestSession(t, posterID)
+	_, modToken := CreateTestSession(t, modID)
+
+	// Create a pending WANTED message
+	var locationID uint64
+	db.Raw("SELECT id FROM locations LIMIT 1").Scan(&locationID)
+	db.Exec("INSERT INTO messages (fromuser, subject, textbody, type, locationid, arrival, date) VALUES (?, ?, 'Test body', 'Wanted', ?, NOW(), NOW())",
+		posterID, prefix+" pending wanted", locationID)
+	var msgID uint64
+	db.Raw("SELECT id FROM messages WHERE fromuser = ? AND subject = ? ORDER BY id DESC LIMIT 1",
+		posterID, prefix+" pending wanted").Scan(&msgID)
+	if msgID == 0 {
+		t.Fatal("Failed to create pending message")
+	}
+	db.Exec("INSERT INTO messages_groups (msgid, groupid, arrival, collection, autoreposts) VALUES (?, ?, NOW(), 'Pending', 0)",
+		msgID, groupID)
+
+	// Member withdraws their pending message via the API
+	withdrawBody := map[string]interface{}{
+		"id":      msgID,
+		"action":  "Outcome",
+		"outcome": "Withdrawn",
+	}
+	withdrawBytes, _ := json.Marshal(withdrawBody)
+	withdrawURL := fmt.Sprintf("/api/message?jwt=%s", posterToken)
+	wreq := httptest.NewRequest("POST", withdrawURL, bytes.NewBuffer(withdrawBytes))
+	wreq.Header.Set("Content-Type", "application/json")
+	wresp, err := getApp().Test(wreq)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, wresp.StatusCode, "Member should be able to withdraw their pending message")
+
+	// Verify the message was marked as deleted (soft delete), not hard deleted
+	var msgDeleted *string
+	db.Raw("SELECT deleted FROM messages WHERE id = ?", msgID).Scan(&msgDeleted)
+	assert.NotNil(t, msgDeleted, "Message should be soft-deleted (deleted IS NOT NULL), not hard-deleted")
+
+	// Mod should still be able to reject the message even though the member withdrew it.
+	// Before fix: handleOutcome hard-deleted messages row, leaving orphaned messages_groups →
+	// isModForMessage returned true (orphaned row) but getMessageModContext scan failed → 403.
+	// After fix: soft delete → getMessageModContext scans successfully → 200.
+	rejectBody := map[string]interface{}{
+		"id":      msgID,
+		"action":  "Reject",
+		"subject": "Duplicate post",
+		"body":    "Please do not post duplicates",
+	}
+	rejectBytes, _ := json.Marshal(rejectBody)
+	rejectURL := fmt.Sprintf("/api/message?jwt=%s", modToken)
+	rreq := httptest.NewRequest("POST", rejectURL, bytes.NewBuffer(rejectBytes))
+	rreq.Header.Set("Content-Type", "application/json")
+	rresp, err := getApp().Test(rreq)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, rresp.StatusCode, "Mod should be able to reject message after member withdraws it (no 403)")
+}
+
 // --- Test: Delete (mod action) ---
 
 func TestPostMessageDelete(t *testing.T) {
@@ -3451,7 +3515,10 @@ func TestPostMessageOutcomeWithdrawnDoesNotMarkSpatialSuccessful(t *testing.T) {
 }
 
 func TestPostMessageWithdrawnPending(t *testing.T) {
-	// H4: Withdrawn on a pending message should delete it entirely.
+	// Withdrawn on a pending message should soft-delete it (V1 parity: Message::delete() uses
+	// UPDATE messages SET deleted = NOW(), not a hard DELETE).  Soft delete allows a moderator
+	// who already loaded the pending queue to still reject the message (see
+	// TestPostMessageRejectAfterMemberWithdrawsPending).
 	prefix := uniquePrefix("msgw_wdr_pnd")
 	db := database.DBConn
 
@@ -3478,12 +3545,12 @@ func TestPostMessageWithdrawnPending(t *testing.T) {
 
 	var result map[string]interface{}
 	json.NewDecoder(resp.Body).Decode(&result)
-	assert.Equal(t, true, result["deleted"], "Pending message should be deleted, not marked")
+	assert.Equal(t, true, result["deleted"], "Pending message should be flagged as deleted in the response")
 
-	// Verify message was deleted.
-	var msgCount int64
-	db.Raw("SELECT COUNT(*) FROM messages WHERE id = ?", msgID).Scan(&msgCount)
-	assert.Equal(t, int64(0), msgCount, "Message should be deleted from messages table")
+	// Verify soft delete: messages row still present but with deleted timestamp.
+	var msgDeleted *string
+	db.Raw("SELECT deleted FROM messages WHERE id = ?", msgID).Scan(&msgDeleted)
+	assert.NotNil(t, msgDeleted, "Message should be soft-deleted (deleted IS NOT NULL), not hard-deleted")
 }
 
 func TestPostMessageWithdrawnApproved(t *testing.T) {


### PR DESCRIPTION
## Summary

- **Bug**: When a member withdraws a WANTED/OFFER still in Pending, the Go API issued `DELETE FROM messages`. This left orphaned `messages_groups` rows — any mod who had already loaded the pending queue would then get a spurious 403 when trying to reject/delete the message.
- **Root cause**: `isModForMessage` found the orphaned `messages_groups` rows and returned `true`, but `getMessageModContext`'s subsequent scan of the now-absent `messages` row failed and returned `nil` → 403 "Not a moderator for this message".
- **V1 parity**: `Message::delete()` never issues a hard `DELETE FROM messages`. It sets `messages_groups.deleted=1` then `UPDATE messages SET deleted=NOW()`. The Go code diverged from this.
- **Fix**: Replace `DELETE FROM messages` with `UPDATE messages SET deleted=NOW(), messageid=NULL` (matching the soft-delete pattern used everywhere else). Also queues `TaskFreebieAlertsRemove` (previously missing for this path).

## Code Quality Review

- Minimal change: 3-line fix in `handleOutcome`, no new helpers.
- V1 parity verified by reading `Message::delete()` in `iznik-server/include/message/Message.php`.
- Two tests updated/added: `TestPostMessageWithdrawnPending` (soft-delete assertion), `TestPostMessageRejectAfterMemberWithdrawsPending` (full regression test).
- All 1916 Go tests pass.

## Test Plan

- [ ] `TestPostMessageWithdrawnPending` — verify Withdrawn-pending response contains `deleted: true`, messages row soft-deleted
- [ ] `TestPostMessageRejectAfterMemberWithdrawsPending` — verify mod can reject after member withdraws (was 403, now 200)
- [ ] `TestPostMessageRejectAfterMemberDeletes` — unchanged, still passes (covers soft-delete via `DELETE /message/:id`)

Fixes: Discourse #9518/194 ("Oh dear" 403 when rejecting member-deleted pending WANTED)