### PR TITLE
fix(modtools): legible edit fields for approved messages in Summary expanded view

### DIFF
--- a/iznik-nuxt3/modtools/components/ModMessage.vue
+++ b/iznik-nuxt3/modtools/components/ModMessage.vue
@@ -170,7 +170,8 @@
           <div class="d-flex flex-shrink-0">
             <div
               v-if="summary && message && fromUser"
-              class="text-info fw-bold me-2"
+              class="text-info fw-bold me-2 text-truncate d-inline-block"
+              style="max-width: 8rem"
             >
               {{ fromUser.displayname }}
               <span v-if="fromUser.deleted" class="badge bg-danger ms-1">
@@ -205,10 +206,10 @@
                   class="mt-2"
                   variant="white"
                   icon-name="reply"
-                  label="Back to Pending"
                   confirm
                   @handle="backToPending"
-                />
+                  ><span class="d-none d-sm-inline">Back to Pending</span></SpinButton
+                >
               </div>
               <div class="ms-2">
                 <b-button

--- a/iznik-nuxt3/tests/unit/components/modtools/ModMessage.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModMessage.spec.js
@@ -1247,4 +1247,34 @@ describe('ModMessage', () => {
       expect(wrapper.text()).not.toContain('Also on')
     })
   })
+
+  describe('Summary view responsive layout (Discourse 9481)', () => {
+    it('username in summary header has text-truncate and max-width to prevent squeezing edit fields', () => {
+      mockUserStore.byId.mockReturnValue({
+        id: 456,
+        displayname: 'AVeryLongUsernameThatWouldSqueezeEditFields',
+        memberships: [{ id: 789, groupid: 789 }],
+      })
+      const wrapper = mountComponent({ summary: true })
+      const usernameEl = wrapper.find('.text-truncate.d-inline-block')
+      expect(usernameEl.exists()).toBe(true)
+      expect(usernameEl.text()).toContain('AVeryLongUsernameThatWouldSqueezeEditFields')
+      expect(usernameEl.attributes('style')).toContain('max-width: 8rem')
+    })
+
+    it('Back to Pending button uses slot for label so text can be hidden on xs', async () => {
+      const wrapper = mountComponent(
+        { summary: false, contextGroupid: 789 },
+        {
+          groups: [{ groupid: 789, collection: 'Approved' }],
+        }
+      )
+      await wrapper.vm.$nextTick()
+      const spinButton = wrapper.find('.spin-button')
+      expect(spinButton.exists()).toBe(true)
+      const labelSpan = spinButton.find('span.d-none.d-sm-inline')
+      expect(labelSpan.exists()).toBe(true)
+      expect(labelSpan.text()).toBe('Back to Pending')
+    })
+  })
 })


### PR DESCRIPTION
## Summary

- **Root cause**: In ModTools approved messages, Summary view + expanded + editing state on mobile (xs), the right-side header had `flex-shrink-0` so it never shrank. The 'Back to Pending' button always showed its full label text while Edit and View Email Source already hide their text on xs with `d-none d-sm-inline`. Combined with a long username, this consumed all available horizontal space leaving no room for the edit fields (type select, item name input, group select).

- **Fix 1**: Changed 'Back to Pending' SpinButton to use slot content instead of `label` prop, wrapping the text in `<span class="d-none d-sm-inline">` — icon-only on xs (≤576px), full label on sm+. Consistent with Edit and View Email Source buttons.

- **Fix 2**: Added `text-truncate d-inline-block` and `style="max-width: 8rem"` to the summary-mode username div, preventing a long displayname from consuming the remaining horizontal space.

- **Tests**: Two new unit tests verify the username truncation/max-width and that the Back to Pending slot text has `d-none d-sm-inline`.

## Test plan

- [ ] Open ModTools approved messages page
- [ ] Switch to Summary view (toggle top-right)
- [ ] Expand an approved message (click caret)
- [ ] Click Edit — verify edit fields (type, item name, postcode) are visible at iPhone widths (≤576px)
- [ ] Verify 'Back to Pending' shows icon only on xs, full label on sm+
- [ ] Verify long usernames are truncated in summary header
- [ ] Verify Detailed view is unchanged

Fixes Discourse 9481 post 497 (reported by Neville_Reid).

🤖 Generated with [Claude Code](https://claude.com/claude-code)