### PR TITLE
fix(modtools): consistent avatars for member messages in chat review

### DIFF
--- a/iznik-nuxt3/components/ChatListEntry.vue
+++ b/iznik-nuxt3/components/ChatListEntry.vue
@@ -8,7 +8,7 @@
   >
     <ChatAvatar
       :icon="resolvedIcon"
-      :name="chat.name"
+      :name="avatarName"
       :supporter="chat.supporter"
       :unread-count="chat.unseen"
     />
@@ -62,6 +62,14 @@ const chat = computed(() => {
 // row (ORDER BY id DESC LIMIT 1). No need to fetch the user separately —
 // that caused avatar flicker when the user store returned a different URL (#327).
 const resolvedIcon = computed(() => chat.value?.icon)
+
+// For User2Mod chats viewed by a moderator, chat.name includes a group suffix
+// like "John Smith (Freecycle)". Strip it so the avatar seed matches the
+// member's displayname used in individual chat message avatars (Discourse #9518).
+const avatarName = computed(() => {
+  const name = chat.value?.name || ''
+  return name.replace(/ \([^)]+\)$/, '') || name
+})
 
 const esnippet = computed(() => {
   if (chat.value?.snippet === 'null') {

--- a/iznik-nuxt3/modtools/components/ModChatHeader.vue
+++ b/iznik-nuxt3/modtools/components/ModChatHeader.vue
@@ -20,7 +20,7 @@
               otheruser?.profile?.paththumb ||
               chat.icon
             "
-            :name="chat.name"
+            :name="otheruser?.displayname || chat.name"
             class="pe-1 clickme d-none d-md-flex"
             is-thumbnail
             size="xl"

--- a/iznik-nuxt3/tests/unit/composables/useChatProfileImage.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useChatProfileImage.spec.js
@@ -428,6 +428,48 @@ describe('Profile names', () => {
   })
 })
 
+// --- avatarName — strips group suffix from chat.name for avatar seed ---
+// Production code: components/ChatListEntry.vue avatarName computed
+// Ensures the avatar seed used in the chat list matches the member's displayname
+// used in individual chat message avatars (Discourse #9518).
+function chatListAvatarName(chatName) {
+  const name = chatName || ''
+  return name.replace(/ \([^)]+\)$/, '') || name
+}
+
+describe('avatarName — chat list avatar seed (Discourse #9518)', () => {
+  it('strips group suffix from User2Mod chat name (mod viewing)', () => {
+    // Go API adds " (GroupShortName)" for mod-viewed User2Mod chats.
+    // Avatar seed must match member's displayname used in message avatars.
+    expect(chatListAvatarName('John Smith (Freecycle)')).toBe('John Smith')
+  })
+
+  it('strips group suffix with longer group name', () => {
+    expect(chatListAvatarName('Alice Jones (Chippenham Freecycle)')).toBe(
+      'Alice Jones'
+    )
+  })
+
+  it('leaves User2User name unchanged (no group suffix)', () => {
+    expect(chatListAvatarName('John Smith')).toBe('John Smith')
+  })
+
+  it('leaves Mod2Mod name unchanged', () => {
+    expect(chatListAvatarName('Freecycle Mods')).toBe('Freecycle Mods')
+  })
+
+  it('leaves member-view User2Mod name unchanged (no group suffix pattern)', () => {
+    // Member sees "Groupname Volunteers" — no parenthetical, so unchanged.
+    expect(chatListAvatarName('Freecycle Volunteers')).toBe(
+      'Freecycle Volunteers'
+    )
+  })
+
+  it('handles empty string gracefully', () => {
+    expect(chatListAvatarName('')).toBe('')
+  })
+})
+
 describe('Chat list icon (Go API sets chat.icon per-user)', () => {
   // These document the Go API's icon rules (chatroom.go buildUserIcon).
   // The frontend just displays chat.icon — no frontend logic to test,


### PR DESCRIPTION
## Summary

- **Root cause**: For User2Mod chats in ModTools, the Go API sets `chat.name` to `"John Smith (Freecycle)"` (member name + group suffix) for mod-viewed chats. But individual chat message avatars use the member's `displayname` from the user store (`"John Smith"`). Different strings → different hashes → different avatar colors.
- **Fix 1** (`ChatListEntry.vue`): Added `avatarName` computed that strips the trailing ` (GroupName)` suffix before passing to `ChatAvatar`. The display name shown to users (`{{ chat.name }}`) is unchanged.
- **Fix 2** (`ModChatHeader.vue`): Use `otheruser?.displayname` (already loaded when the chat pane opens) for the header avatar seed, falling back to `chat.name` if not yet loaded.
- **Tests**: Added `chatListAvatarName` unit tests to `useChatProfileImage.spec.js` covering the stripping logic for all chat types.

## Regression history

Commit `239c66604` ("fix: Chat review avatars/alignment") introduced pov-aware `otheruserComputed` which correctly uses `userStore.displayname` for message avatars, but the list/header continued using `chat.name` (which includes the group suffix). This is the source of the mismatch.

## Test plan

- [ ] Open ModTools chat list — any User2Mod chat should show member's avatar (e.g., pink) in the list entry
- [ ] Click into the chat — header avatar for the member should be the same color (pink)
- [ ] Individual messages from the member should show the same avatar color (pink)
- [ ] User2User chats unaffected (no group suffix to strip)
- [ ] Vitest `useChatProfileImage.spec.js` passes

Fixes Discourse #9518 post 206.

🤖 Generated with [Claude Code](https://claude.com/claude-code)