### PR TITLE
fix(modtools-ios): prevent audio interruption from Apple Podcasts/BBC Sounds

### DIFF
--- a/iznik-nuxt3/modtools/composables/useModMe.js
+++ b/iznik-nuxt3/modtools/composables/useModMe.js
@@ -4,6 +4,12 @@ import { useMiscStore } from '@/stores/misc'
 import { useModGroupStore } from '@/stores/modgroup'
 import { useMe } from '~/composables/useMe'
 
+// Skip beep on the first checkWork() call after page load. The first call
+// establishes the baseline work count; beeping at that point would interrupt
+// background audio on iOS (podcasts, BBC Sounds) simply because the user opened
+// the app. Beeps fire normally for any increase detected on subsequent calls.
+let isFirstCheckWork = true
+
 async function makebeep() {
   const sound = new Audio('/alert.wav')
   try {
@@ -97,9 +103,14 @@ export function useModMe() {
       const chatcount = chatStore ? Math.min(99, chatStore.unreadCount) : 0
       const work = authStore.work
       const totalCount = work?.total + chatcount
+
+      const skipBeep = isFirstCheckWork
+      isFirstCheckWork = false
+
       if (
         work &&
         totalCount > currentTotal &&
+        !skipBeep &&
         authStore.user &&
         (!authStore.user.settings ||
           !Object.keys(authStore.user.settings).includes('playbeep') ||

--- a/iznik-nuxt3/tests/unit/composables/useModMe.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useModMe.spec.js
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// The vitest config pre-aliases ~/stores/auth → tests/unit/mocks/auth-store.js
+// and ~/stores/chat → tests/unit/mocks/chat-store.js. Those mocks read from
+// globalThis.__mock*Store, so set those instead of re-mocking the modules.
+
+const mockFetchMe = vi.fn()
+const mockGetModGroups = vi.fn()
+const mockMiscStore = {
+  workTimer: null,
+  deferGetMessages: false,
+  modtoolsediting: false,
+}
+
+vi.mock('@/stores/misc', () => ({
+  useMiscStore: () => mockMiscStore,
+}))
+
+vi.mock('@/stores/modgroup', () => ({
+  useModGroupStore: () => ({
+    list: {},
+    get: vi.fn(),
+    getModGroups: mockGetModGroups,
+  }),
+}))
+
+vi.mock('~/composables/useMe', () => ({
+  useMe: () => ({
+    me: { value: null },
+    fetchMe: mockFetchMe,
+  }),
+}))
+
+// --- Audio mock ---
+
+let mockAudioPlay
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  mockAudioPlay = vi.fn().mockResolvedValue(undefined)
+  global.Audio = class MockAudio {
+    constructor(_src) {}
+    play() {
+      return mockAudioPlay()
+    }
+  }
+  global.document = {
+    body: { style: { overflow: '' } },
+    title: '',
+  }
+  // Reset store state via globalThis pattern used by pre-aliased mocks
+  globalThis.__mockAuthStore = {
+    work: null,
+    user: { settings: {} },
+    member: vi.fn(() => null),
+    groups: [],
+  }
+  globalThis.__mockChatStore = {
+    unreadCount: 0,
+  }
+  mockMiscStore.workTimer = null
+  mockMiscStore.deferGetMessages = false
+  mockMiscStore.modtoolsediting = false
+  mockGetModGroups.mockResolvedValue(undefined)
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.clearAllMocks()
+  vi.resetModules()
+  delete globalThis.__mockAuthStore
+  delete globalThis.__mockChatStore
+})
+
+describe('useModMe checkWork beep behavior', () => {
+  it('does not play beep on first checkWork even when work arrives (iOS audio safety)', async () => {
+    // Simulates opening the app with pending work:
+    // - authStore.work is null before fetchMe (nothing loaded yet)
+    // - fetchMe loads 3 pending items → totalCount becomes 3 > currentTotal 0
+    // Without the fix this would immediately beep, interrupting background audio on iOS.
+    mockFetchMe.mockImplementation(async () => {
+      globalThis.__mockAuthStore.work = { total: 3 }
+    })
+
+    const { useModMe } = await import('~/modtools/composables/useModMe')
+    const { checkWork } = useModMe()
+    await checkWork(true)
+
+    expect(mockAudioPlay).not.toHaveBeenCalled()
+  })
+
+  it('plays beep when work count increases after first check', async () => {
+    // First check: establishes baseline of 2 items (no beep)
+    mockFetchMe.mockImplementationOnce(async () => {
+      globalThis.__mockAuthStore.work = { total: 2 }
+    })
+
+    const { useModMe } = await import('~/modtools/composables/useModMe')
+    const { checkWork } = useModMe()
+    await checkWork(true)
+    expect(mockAudioPlay).not.toHaveBeenCalled()
+
+    // Second check: work increases to 5 → beep should fire
+    mockFetchMe.mockImplementationOnce(async () => {
+      globalThis.__mockAuthStore.work = { total: 5 }
+    })
+    await checkWork(true)
+
+    expect(mockAudioPlay).toHaveBeenCalledOnce()
+  })
+
+  it('does not play beep when work count stays the same on subsequent checks', async () => {
+    mockFetchMe.mockImplementation(async () => {
+      globalThis.__mockAuthStore.work = { total: 2 }
+    })
+
+    const { useModMe } = await import('~/modtools/composables/useModMe')
+    const { checkWork } = useModMe()
+
+    await checkWork(true) // baseline
+    await checkWork(true) // same count — no beep
+
+    expect(mockAudioPlay).not.toHaveBeenCalled()
+  })
+
+  it('respects playbeep=false user setting on subsequent checks', async () => {
+    globalThis.__mockAuthStore.user = { settings: { playbeep: false } }
+    // First call: baseline
+    mockFetchMe.mockImplementationOnce(async () => {
+      globalThis.__mockAuthStore.work = { total: 2 }
+    })
+
+    const { useModMe } = await import('~/modtools/composables/useModMe')
+    const { checkWork } = useModMe()
+    await checkWork(true)
+
+    // Work increases but beep is disabled by user setting
+    mockFetchMe.mockImplementationOnce(async () => {
+      globalThis.__mockAuthStore.work = { total: 5 }
+    })
+    await checkWork(true)
+
+    expect(mockAudioPlay).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

- **Root cause**: In `modtools/composables/useModMe.js`, `checkWork()` detects pending work on the first call (since `currentTotal` starts at 0 and `fetchMe` then loads work items), triggering `makebeep()` which plays `/alert.wav` via `new Audio()`. On iOS, this activates `AVAudioSession` with `.soloAmbient` category, immediately interrupting background audio in Apple Podcasts, BBC Sounds, etc.
- **Fix**: Added `isFirstCheckWork` flag (module-level, resets on page load). The first `checkWork()` call is the baseline — it just establishes the current work count. Beeps are only played on subsequent calls when the count actually increases during active use.
- **Test**: 4 new unit tests added. All pass.

Fixes Discourse 9518 post 199

## Test plan

- [x] New unit tests — 4 tests, all passing (run in CI)
- [ ] Manual: Open ModTools on iPhone while playing a podcast — audio should continue uninterrupted
- [ ] Manual: With ModTools open and a new message arriving, the beep should play normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
