### PR TITLE
test(go/changes): unit coverage for formatISO and struct JSON marshaling

### DIFF
--- a/iznik-server-go/changes/changes_test.go
+++ b/iznik-server-go/changes/changes_test.go
@@ -1,0 +1,125 @@
+package changes
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// ---------------------------------------------------------------------------
+// formatISO
+// ---------------------------------------------------------------------------
+
+func TestFormatISO_ValidMySQLDatetime(t *testing.T) {
+	// Standard MySQL datetime format must convert to RFC3339 (UTC "Z" suffix).
+	got := formatISO("2026-03-15 14:30:00")
+	assert.Equal(t, "2026-03-15T14:30:00Z", got)
+}
+
+func TestFormatISO_MidnightDatetime(t *testing.T) {
+	// Midnight boundary — ensures zero-padded time is handled correctly.
+	got := formatISO("2026-01-01 00:00:00")
+	assert.Equal(t, "2026-01-01T00:00:00Z", got)
+}
+
+func TestFormatISO_EndOfDay(t *testing.T) {
+	// Last second of day.
+	got := formatISO("2026-12-31 23:59:59")
+	assert.Equal(t, "2026-12-31T23:59:59Z", got)
+}
+
+func TestFormatISO_InvalidStringReturnedAsIs(t *testing.T) {
+	// Garbage input: time.Parse fails, so the original string is returned unchanged.
+	got := formatISO("not-a-date")
+	assert.Equal(t, "not-a-date", got)
+}
+
+func TestFormatISO_EmptyStringReturnedAsIs(t *testing.T) {
+	// Empty string: Parse fails, returns empty.
+	got := formatISO("")
+	assert.Equal(t, "", got)
+}
+
+func TestFormatISO_AlreadyISO8601ReturnedAsIs(t *testing.T) {
+	// A string already in RFC3339 format can't be parsed as MySQL datetime
+	// ("2006-01-02T15:04:05Z" doesn't match "2006-01-02 15:04:05"), so it is
+	// passed through unchanged.
+	iso := "2026-03-15T14:30:00Z"
+	got := formatISO(iso)
+	assert.Equal(t, iso, got)
+}
+
+// ---------------------------------------------------------------------------
+// UserChange JSON marshaling
+// ---------------------------------------------------------------------------
+
+func TestUserChange_NilLastUpdatedMarshal(t *testing.T) {
+	// A UserChange with nil LastUpdated must serialise to {"id":1,"lastupdated":null}.
+	uc := UserChange{ID: 1, LastUpdated: nil}
+	b, err := json.Marshal(uc)
+	assert.NoError(t, err)
+
+	var m map[string]interface{}
+	assert.NoError(t, json.Unmarshal(b, &m))
+	assert.Equal(t, float64(1), m["id"])
+	assert.Nil(t, m["lastupdated"], "nil pointer should serialise to JSON null")
+}
+
+func TestUserChange_NonNilLastUpdatedMarshal(t *testing.T) {
+	// A UserChange with a set LastUpdated must include the string value.
+	val := "2026-03-15T14:30:00Z"
+	uc := UserChange{ID: 42, LastUpdated: &val}
+	b, err := json.Marshal(uc)
+	assert.NoError(t, err)
+
+	var m map[string]interface{}
+	assert.NoError(t, json.Unmarshal(b, &m))
+	assert.Equal(t, val, m["lastupdated"])
+}
+
+// ---------------------------------------------------------------------------
+// Rating JSON marshaling
+// ---------------------------------------------------------------------------
+
+func TestRating_NilTnRatingIDMarshal(t *testing.T) {
+	// TnRatingID is a *uint64 — nil must serialise as JSON null, not omitted.
+	r := Rating{ID: 10, Rater: 1, Ratee: 2, Rating: "Up", Timestamp: "2026-03-15T14:30:00Z", Visible: 1, TnRatingID: nil}
+	b, err := json.Marshal(r)
+	assert.NoError(t, err)
+
+	var m map[string]interface{}
+	assert.NoError(t, json.Unmarshal(b, &m))
+	_, present := m["tn_rating_id"]
+	assert.True(t, present, "tn_rating_id key must always be present in the JSON object")
+	assert.Nil(t, m["tn_rating_id"], "nil *uint64 must serialise to JSON null")
+}
+
+func TestRating_NonNilTnRatingIDMarshal(t *testing.T) {
+	// When TnRatingID is set it must appear as the correct numeric value.
+	var tnID uint64 = 12345
+	r := Rating{ID: 20, Rater: 3, Ratee: 4, Rating: "Down", TnRatingID: &tnID}
+	b, err := json.Marshal(r)
+	assert.NoError(t, err)
+
+	var m map[string]interface{}
+	assert.NoError(t, json.Unmarshal(b, &m))
+	assert.Equal(t, float64(12345), m["tn_rating_id"])
+}
+
+// ---------------------------------------------------------------------------
+// MessageChange JSON marshaling
+// ---------------------------------------------------------------------------
+
+func TestMessageChange_FieldRoundTrip(t *testing.T) {
+	// All three fields (id, timestamp, type) must survive a JSON round-trip.
+	mc := MessageChange{ID: 99, Timestamp: "2026-06-01T10:00:00Z", Type: "Taken"}
+	b, err := json.Marshal(mc)
+	assert.NoError(t, err)
+
+	var mc2 MessageChange
+	assert.NoError(t, json.Unmarshal(b, &mc2))
+	assert.Equal(t, mc.ID, mc2.ID)
+	assert.Equal(t, mc.Timestamp, mc2.Timestamp)
+	assert.Equal(t, mc.Type, mc2.Type)
+}


### PR DESCRIPTION
## Summary

- Adds `iznik-server-go/changes/changes_test.go` (125 lines, 11 new tests)
- No production code changed — tests only

## What's tested

**`formatISO` (previously untested directly):** 6 unit tests covering:
- Valid MySQL datetime `"YYYY-MM-DD HH:MM:SS"` → RFC3339 `"YYYY-MM-DDTHH:MM:SSZ"`
- Midnight boundary
- Last-second-of-day boundary
- Garbage/empty input → returned as-is (parse error path)
- Already-ISO8601 input → returned as-is (won't parse as MySQL format)

**Struct JSON marshaling (previously tested only via HTTP integration):** 5 tests covering:
- `UserChange.LastUpdated` is `*string` with no `omitempty` — nil must serialise to `null`, not be omitted
- Non-nil `*string` carries its value through
- `Rating.TnRatingID` is `*uint64` with no `omitempty` — nil → `null`, set → correct number
- `MessageChange` fields survive a JSON round-trip

## Why these were untested

`formatISO` is a package-private helper in `changes/changes.go`. It was only reachable via the HTTP integration tests in `test/changes_test.go`, which test it indirectly through the full `/api/changes` endpoint. Adding a `changes/changes_test.go` with `package changes` lets the test file reach the unexported function directly.

## Coverage delta

`formatISO`: 0% direct → 100% direct (both branches: parse success and parse failure).  
Struct marshaling: previously covered only by integration; now also covered by fast unit tests.

## Test scenarios

| Test | Scenario |
|------|----------|
| `TestFormatISO_ValidMySQLDatetime` | Happy path: MySQL → RFC3339 |
| `TestFormatISO_MidnightDatetime` | Boundary: midnight |
| `TestFormatISO_EndOfDay` | Boundary: 23:59:59 |
| `TestFormatISO_InvalidStringReturnedAsIs` | Error path: garbage input |
| `TestFormatISO_EmptyStringReturnedAsIs` | Error path: empty string |
| `TestFormatISO_AlreadyISO8601ReturnedAsIs` | Error path: already-ISO string |
| `TestUserChange_NilLastUpdatedMarshal` | *string nil → JSON null |
| `TestUserChange_NonNilLastUpdatedMarshal` | *string set → correct value |
| `TestRating_NilTnRatingIDMarshal` | *uint64 nil → JSON null |
| `TestRating_NonNilTnRatingIDMarshal` | *uint64 set → correct number |
| `TestMessageChange_FieldRoundTrip` | All fields survive marshal/unmarshal |

🤖 Generated with [Claude Code](https://claude.com/claude-code)