### PR TITLE
fix: false-positive UK phone-number chat warning (#9518)

### DIFF
--- a/iznik-nuxt3/components/ChatMessage.vue
+++ b/iznik-nuxt3/components/ChatMessage.vue
@@ -202,7 +202,10 @@ const phoneNumber = computed(() => {
   let ret = false
 
   if (chatmessage.value?.message) {
-    const re = /\+(\d\d)[^:]/gm
+    // Require at least 8 digits total after '+' to avoid false positives on
+    // things like "+12 more items" or "+30 minutes". Real international numbers
+    // have a country code (1-3 digits) plus a subscriber number (6-14 digits).
+    const re = /\+(\d\d)\d{6,}/gm
     const matches = re.exec(chatmessage.value.message)
 
     if (matches && matches.length > 1) {

--- a/iznik-nuxt3/tests/unit/components/ChatMessage.spec.js
+++ b/iznik-nuxt3/tests/unit/components/ChatMessage.spec.js
@@ -346,4 +346,76 @@ describe('ChatMessage', () => {
       expect(wrapper.text()).toContain('Delete')
     })
   })
+
+  describe('phone number warning', () => {
+    it('does not show warning for message with no phone number', async () => {
+      const { setupChat } = await import('~/composables/useChat')
+      setupChat.mockResolvedValueOnce({
+        chat: ref(mockChat),
+        otheruser: ref(mockOtherUser),
+        chatmessage: ref({
+          ...mockChatMessage,
+          message: 'Hello, can I come and collect this afternoon?',
+        }),
+      })
+      const wrapper = await createWrapper()
+      expect(wrapper.find('.chat-message-warning').exists()).toBe(false)
+    })
+
+    it('does not show warning for text containing + followed by two non-44 digits but no full phone number (false positive fix)', async () => {
+      const { setupChat } = await import('~/composables/useChat')
+      setupChat.mockResolvedValueOnce({
+        chat: ref(mockChat),
+        otheruser: ref(mockOtherUser),
+        chatmessage: ref({
+          ...mockChatMessage,
+          message: 'I have +12 more items to give away if you need them.',
+        }),
+      })
+      const wrapper = await createWrapper()
+      expect(wrapper.find('.chat-message-warning').exists()).toBe(false)
+    })
+
+    it('does not show warning for text with + and small number like "+30 minutes"', async () => {
+      const { setupChat } = await import('~/composables/useChat')
+      setupChat.mockResolvedValueOnce({
+        chat: ref(mockChat),
+        otheruser: ref(mockOtherUser),
+        chatmessage: ref({
+          ...mockChatMessage,
+          message: 'I can be there in +30 minutes',
+        }),
+      })
+      const wrapper = await createWrapper()
+      expect(wrapper.find('.chat-message-warning').exists()).toBe(false)
+    })
+
+    it('shows warning for message containing a real non-UK international phone number', async () => {
+      const { setupChat } = await import('~/composables/useChat')
+      setupChat.mockResolvedValueOnce({
+        chat: ref(mockChat),
+        otheruser: ref(mockOtherUser),
+        chatmessage: ref({
+          ...mockChatMessage,
+          message: 'Please call +12025551234 to arrange pickup.',
+        }),
+      })
+      const wrapper = await createWrapper()
+      expect(wrapper.find('.chat-message-warning').exists()).toBe(true)
+    })
+
+    it('does not show warning for a UK phone number (+44)', async () => {
+      const { setupChat } = await import('~/composables/useChat')
+      setupChat.mockResolvedValueOnce({
+        chat: ref(mockChat),
+        otheruser: ref(mockOtherUser),
+        chatmessage: ref({
+          ...mockChatMessage,
+          message: 'My number is +447911123456',
+        }),
+      })
+      const wrapper = await createWrapper()
+      expect(wrapper.find('.chat-message-warning').exists()).toBe(false)
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Fixes a false-positive 'phone number outside the UK' warning appearing in chat messages that contain no phone numbers — reported in Discourse topic 9518.

**Root cause:** The phone-number detection regex `/\+(\d\d)[^:]/gm` in `ChatMessage.vue` was too loose. It fired on _any_ message containing a `+` followed by two non-UK (`!= 44`) digits followed by any non-colon character. Common text like `"+12 more items"` or `"+30 minutes"` would trigger the warning even though there is no phone number.

**Reporter's original post (Discourse topic 9518):**
> Not sure if this is relevant to this list - but I have just had a chat with a member re his post and I see the chat has this message added in red "This message may contain a phone number outside the UK, which costs more to call." None of the chats have any telephone numbers or indeed any other numbers in them which might be mistaken for one. The member concerned is #43690466

**Fix:** Changed the regex to `/\+(\d\d)\d{6,}/gm` — requiring at least 6 further consecutive digits after the 2-digit country-code capture, giving a minimum of 8 digits total. This is the minimum length for a real international subscriber number. Genuine numbers like `+12025551234` (US) still trigger the warning; short patterns like `+12 more items` do not.

## Files changed

- `iznik-nuxt3/components/ChatMessage.vue` — regex fix (1 line)
- `iznik-nuxt3/tests/unit/components/ChatMessage.spec.js` — 5 new tests

## Test plan

New unit tests added to `ChatMessage.spec.js > phone number warning`:
- [x] Plain text with no phone number → no warning
- [x] `"+12 more items"` (false-positive class) → no warning  
- [x] `"+30 minutes"` (false-positive class) → no warning
- [x] Real non-UK number `+12025551234` → warning shown
- [x] UK number `+447911123456` → no warning

Full Vitest suite: **11900 ✓ 0 ✗** (11895 baseline + 5 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)