### PR TITLE
fix: Member Review Ignore action has no effect (#9618)

### DIFF
--- a/iznik-nuxt3/modtools/stores/member.js
+++ b/iznik-nuxt3/modtools/stores/member.js
@@ -209,20 +209,14 @@ export const useMemberStore = defineStore({
         params.groupid
       )
 
-      // Remove just the acted-on membership from the member's memberships
-      // array, not the whole entry. If the member is in review on multiple
-      // groups, the mod needs to act on each one (#324).
+      // The backend clears review flags for ALL of the mod's moderated groups at once
+      // (Discourse #9618 fix). Remove the whole user entry from the store so the card
+      // disappears immediately instead of reappearing with another group's Ignore button.
       const key = Object.keys(this.list).find(
         (k) => parseInt(this.list[k].userid) === parseInt(params.userid)
       )
-      if (key && this.list[key].memberships) {
-        this.list[key].memberships = this.list[key].memberships.filter(
-          (m) => parseInt(m.groupid) !== parseInt(params.groupid)
-        )
-        // Remove the whole entry only when no memberships remain.
-        if (this.list[key].memberships.length === 0) {
-          delete this.list[key]
-        }
+      if (key) {
+        delete this.list[key]
       }
     },
 

--- a/iznik-nuxt3/tests/unit/stores/member.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/member.spec.js
@@ -30,7 +30,7 @@ describe('member store', () => {
   })
 
   describe('spamignore', () => {
-    it('removes only the acted-on membership, keeps entry for other groups', async () => {
+    it('removes entire user entry on ignore (backend clears all mod groups at once)', async () => {
       const store = useMemberStore()
       store.config = {}
 
@@ -44,17 +44,15 @@ describe('member store', () => {
         ],
       }
 
-      // Ignore on group 789 only.
+      // Ignore on group 789 — backend now clears ALL mod groups, so the
+      // whole entry should be removed immediately (Discourse #9618 fix).
       await store.spamignore({ userid: 456, groupid: 789 })
 
       expect(mockReviewIgnore).toHaveBeenCalledWith(456, 789)
-      // Entry should still exist with the remaining membership.
-      expect(store.list[123]).toBeTruthy()
-      expect(store.list[123].memberships).toHaveLength(1)
-      expect(store.list[123].memberships[0].groupid).toBe(999)
+      expect(store.list[123]).toBeUndefined()
     })
 
-    it('removes entire entry when last membership is ignored', async () => {
+    it('removes entire entry when single membership is ignored', async () => {
       const store = useMemberStore()
       store.config = {}
 

--- a/iznik-server-go/membership/membership.go
+++ b/iznik-server-go/membership/membership.go
@@ -240,11 +240,17 @@ func PostMemberships(c *fiber.Ctx) error {
 		return c.JSON(fiber.Map{"ret": 0, "status": "Success"})
 
 	case "ReviewIgnore":
-		// ReviewIgnore marks a spam/review member as reviewed so they drop off the Member Review list.
-		// clear reviewrequestedat so the member doesn't reappear in review.
-		// PHP User.php:6805 sets reviewrequestedat = NULL on review completion.
-		db.Exec("UPDATE memberships SET reviewedat = NOW(), reviewrequestedat = NULL, heldby = NULL WHERE userid = ? AND groupid = ?",
-			req.Userid, req.Groupid)
+		// ReviewIgnore clears the Member Review flag for the target user across ALL groups
+		// the calling moderator moderates (not just the one clicked). This prevents the
+		// confusing behaviour reported in Discourse topic 9618 where a mod clicks Ignore
+		// and the member reappears immediately because they are flagged on another of the
+		// mod's groups. PHP User.php:6805 sets reviewrequestedat = NULL on review completion.
+		modGroupIDs := user.GetActiveModGroupIDs(myid)
+		if len(modGroupIDs) > 0 {
+			db.Exec("UPDATE memberships SET reviewedat = NOW(), reviewrequestedat = NULL, heldby = NULL "+
+				"WHERE userid = ? AND groupid IN ?",
+				req.Userid, modGroupIDs)
+		}
 		return c.JSON(fiber.Map{"ret": 0, "status": "Success"})
 
 	case "HappinessReviewed":

--- a/iznik-server-go/test/membership_test.go
+++ b/iznik-server-go/test/membership_test.go
@@ -1327,6 +1327,99 @@ func TestPostMembershipsReviewIgnore(t *testing.T) {
 	assert.False(t, found, "Target should NOT appear in spam members after ignore")
 }
 
+// TestReviewIgnoreMultiGroupMod verifies that clicking Ignore on a member in the Member Review
+// queue clears the review flag for ALL groups the mod moderates — not just the one clicked.
+// Regression test for Discourse topic 9618: "Clicking Ignore on a member stuck in Member Review
+// has no effect — member remains in review queue across multiple attempts."
+func TestReviewIgnoreMultiGroupMod(t *testing.T) {
+	prefix := uniquePrefix("rvign_multi")
+	db := database.DBConn
+
+	group1ID := CreateTestGroup(t, prefix+"_g1")
+	group2ID := CreateTestGroup(t, prefix+"_g2")
+
+	// Mod moderates BOTH groups.
+	modID := CreateTestUser(t, prefix+"_mod", "User")
+	CreateTestMembership(t, modID, group1ID, "Moderator")
+	CreateTestMembership(t, modID, group2ID, "Moderator")
+	_, token := CreateTestSession(t, modID)
+
+	// Target user is a member of both groups.
+	targetID := CreateTestUser(t, prefix+"_target", "User")
+	CreateTestMembership(t, targetID, group1ID, "Member")
+	CreateTestMembership(t, targetID, group2ID, "Member")
+
+	// Both memberships are flagged for review — simulating a month-old cross-group flag
+	// as described in Discourse topic 9618.
+	db.Exec(
+		"UPDATE memberships SET reviewrequestedat = DATE_SUB(NOW(), INTERVAL 40 DAY), reviewreason = 'Note flagged to other groups' WHERE userid = ? AND groupid IN ?",
+		targetID, []uint64{group1ID, group2ID},
+	)
+
+	// Verify target appears for BOTH groups before Ignore.
+	req := httptest.NewRequest("GET", fmt.Sprintf("/api/memberships?collection=Spam&limit=50&jwt=%s", token), nil)
+	resp, err := getApp().Test(req, -1)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+	var membersBefore []map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&membersBefore)
+	foundG1Before, foundG2Before := false, false
+	for _, m := range membersBefore {
+		if uint64(m["userid"].(float64)) == targetID {
+			gid := uint64(m["groupid"].(float64))
+			if gid == group1ID {
+				foundG1Before = true
+			}
+			if gid == group2ID {
+				foundG2Before = true
+			}
+		}
+	}
+	assert.True(t, foundG1Before, "Target should appear on group1 before Ignore")
+	assert.True(t, foundG2Before, "Target should appear on group2 before Ignore")
+
+	// Mod clicks Ignore — sending groupid=group1 (as the UI would for the first card).
+	body := map[string]interface{}{
+		"userid":  targetID,
+		"groupid": group1ID,
+		"action":  "ReviewIgnore",
+	}
+	bodyBytes, _ := json.Marshal(body)
+	url := fmt.Sprintf("/api/memberships?jwt=%s", token)
+	req = httptest.NewRequest("POST", url, bytes.NewBuffer(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err = getApp().Test(req, -1)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+	var result map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&result)
+	assert.Equal(t, float64(0), result["ret"])
+
+	// After Ignore, the target should NOT appear in the Spam list for EITHER group.
+	// The mod has reviewed the member and clicked Ignore — the member should be gone
+	// from ALL of the mod's moderated groups, not just group1.
+	req = httptest.NewRequest("GET", fmt.Sprintf("/api/memberships?collection=Spam&limit=50&jwt=%s", token), nil)
+	resp, err = getApp().Test(req, -1)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+	var membersAfter []map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&membersAfter)
+	foundG1After, foundG2After := false, false
+	for _, m := range membersAfter {
+		if uint64(m["userid"].(float64)) == targetID {
+			gid := uint64(m["groupid"].(float64))
+			if gid == group1ID {
+				foundG1After = true
+			}
+			if gid == group2ID {
+				foundG2After = true
+			}
+		}
+	}
+	assert.False(t, foundG1After, "Target should NOT appear on group1 after Ignore")
+	assert.False(t, foundG2After, "Target should NOT appear on group2 after Ignore — Ignore clears all mod's groups")
+}
+
 func TestPostMembershipsHappinessReviewed(t *testing.T) {
 	prefix := uniquePrefix("mod_happy")
 	db := database.DBConn

--- a/iznik-server/http/api/memberships.php
+++ b/iznik-server/http/api/memberships.php
@@ -311,6 +311,13 @@ function memberships() {
                             $n->notifyGroupMods($groupid);
                             break;
                         }
+                        case 'ReviewIgnore': {
+                            # Mark the member as reviewed so they drop off the Member Review queue.
+                            # Fixes Discourse topic 9618: Ignore had no effect on iOS because this
+                            # action was missing from the PHP V1 API.
+                            $u->memberReview($groupid, FALSE, '');
+                            break;
+                        }
                     }
                 }
 


### PR DESCRIPTION
## Summary

Fixes Discourse bug topic [#9618](https://discourse.ilovefreegle.org/t/9618) reported by Neville_Reid:

> Clicking Ignore on a member stuck in Member Review has no effect — member remains in review queue across multiple attempts on desktop Chrome and iOS app.

Two distinct root causes were found and fixed:

- **iOS (PHP V1 API)**: `memberships.php` POST switch had no `ReviewIgnore` case. iOS Ignore calls returned HTTP 200 with `ret: 0` but never touched the database. Added the missing case calling `$u->memberReview($groupid, FALSE, '')`.

- **Web (Go V2 API)**: `flagOthers()` in `comment.go` sets `reviewrequestedat` on **all other groups** of a user when a flagged note is posted. The `ReviewIgnore` handler only cleared **one** group's flag, so clicking Ignore on group A left the flag on group B — and the member immediately reappeared via group B. Fixed by clearing all groups the calling mod moderates in a single UPDATE using `user.GetActiveModGroupIDs(myid)`.

- **Frontend store**: `spamignore()` in `member.js` kept the user card visible if other group memberships remained. Now removes the whole entry immediately, matching the backend's new all-groups behaviour.

## Test plan

- [x] `TestReviewIgnoreMultiGroupMod` (Go): mod moderates two groups, user flagged on both, Ignore on group 1 → user absent from spam list for **both** groups
- [x] Existing `TestPostMembershipsReviewIgnore` still passes
- [x] Vitest `member.spec.js`: updated to assert entire entry removed (not just one membership) after `spamignore()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
