### PR TITLE
test: add TDD tests for Go

### DIFF
--- a/iznik-server-go/test/abtest_tdd_test.go
+++ b/iznik-server-go/test/abtest_tdd_test.go
@@ -1,0 +1,161 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/freegle/iznik-server-go/abtest"
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestABTest_GetABTest_MissingUID(t *testing.T) {
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/abtest", nil))
+	assert.Equal(t, 400, resp.StatusCode)
+}
+
+func TestABTest_GetABTest_NoVariants(t *testing.T) {
+	uid := uniquePrefix("abtest_no_variants")
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/abtest?uid="+uid, nil))
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json.Unmarshal(rsp(resp), &result)
+	assert.Equal(t, float64(0), result["ret"])
+	assert.Equal(t, "Success", result["status"])
+	assert.Nil(t, result["variant"])
+}
+
+func TestABTest_GetABTest_WithVariants(t *testing.T) {
+	uid := uniquePrefix("abtest_with_variants")
+	db := database.DBConn
+	db.Exec("INSERT INTO abtest (uid, variant, suggest, rate) VALUES (?, 'variant_a', 1, 0.8), (?, 'variant_b', 1, 0.5)",
+		uid, uid)
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/abtest?uid="+uid, nil))
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json.Unmarshal(rsp(resp), &result)
+	assert.Equal(t, float64(0), result["ret"])
+	assert.Equal(t, "Success", result["status"])
+	assert.NotNil(t, result["variant"])
+
+	variant := result["variant"].(map[string]interface{})
+	assert.NotEmpty(t, variant["variant"])
+	assert.Contains(t, []string{"variant_a", "variant_b"}, variant["variant"])
+}
+
+func TestABTest_PostABTest_MissingFields(t *testing.T) {
+	body := `{"uid":"","variant":""}`
+	req := httptest.NewRequest("POST", "/api/abtest", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json.Unmarshal(rsp(resp), &result)
+	assert.Equal(t, float64(0), result["ret"])
+}
+
+func TestABTest_PostABTest_IgnoreAppRequests(t *testing.T) {
+	prefix := uniquePrefix("abtest_app")
+	body := fmt.Sprintf(`{"uid":"%s","variant":"variant_a","shown":true,"app":true}`, prefix)
+	req := httptest.NewRequest("POST", "/api/abtest", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var count int64
+	db := database.DBConn
+	db.Raw("SELECT COUNT(*) FROM abtest WHERE uid = ? AND variant = ?", prefix, "variant_a").Scan(&count)
+	assert.Equal(t, int64(0), count)
+}
+
+func TestABTest_PostABTest_RecordShown(t *testing.T) {
+	prefix := uniquePrefix("abtest_shown")
+	uid := prefix
+	variant := "variant_shown"
+
+	body := fmt.Sprintf(`{"uid":"%s","variant":"%s","shown":true}`, uid, variant)
+	req := httptest.NewRequest("POST", "/api/abtest", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var testVar abtest.ABTestVariant
+	db := database.DBConn
+	db.Raw("SELECT id, uid, variant, shown, action FROM abtest WHERE uid = ? AND variant = ?", uid, variant).Scan(&testVar)
+	assert.Equal(t, uint64(1), testVar.Shown)
+	assert.Equal(t, uint64(0), testVar.Action)
+}
+
+func TestABTest_PostABTest_RecordAction(t *testing.T) {
+	prefix := uniquePrefix("abtest_action")
+	uid := prefix
+	variant := "variant_action"
+
+	body := fmt.Sprintf(`{"uid":"%s","variant":"%s","action":true}`, uid, variant)
+	req := httptest.NewRequest("POST", "/api/abtest", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var testVar abtest.ABTestVariant
+	db := database.DBConn
+	db.Raw("SELECT id, uid, variant, shown, action FROM abtest WHERE uid = ? AND variant = ?", uid, variant).Scan(&testVar)
+	assert.Equal(t, uint64(1), testVar.Action)
+}
+
+func TestABTest_PostABTest_RecordActionWithScore(t *testing.T) {
+	prefix := uniquePrefix("abtest_score")
+	uid := prefix
+	variant := "variant_scored"
+
+	body := fmt.Sprintf(`{"uid":"%s","variant":"%s","action":true,"score":5}`, uid, variant)
+	req := httptest.NewRequest("POST", "/api/abtest", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var testVar abtest.ABTestVariant
+	db := database.DBConn
+	db.Raw("SELECT id, uid, variant, shown, action FROM abtest WHERE uid = ? AND variant = ?", uid, variant).Scan(&testVar)
+	assert.Equal(t, uint64(5), testVar.Action)
+}
+
+func TestABTest_PostABTest_UpdateExistingRecord(t *testing.T) {
+	prefix := uniquePrefix("abtest_accum")
+	uid := prefix
+	variant := "variant_accum"
+
+	db := database.DBConn
+
+	body1 := fmt.Sprintf(`{"uid":"%s","variant":"%s","shown":true}`, uid, variant)
+	req1 := httptest.NewRequest("POST", "/api/abtest", bytes.NewBufferString(body1))
+	req1.Header.Set("Content-Type", "application/json")
+	getApp().Test(req1)
+
+	body2 := fmt.Sprintf(`{"uid":"%s","variant":"%s","shown":true}`, uid, variant)
+	req2 := httptest.NewRequest("POST", "/api/abtest", bytes.NewBufferString(body2))
+	req2.Header.Set("Content-Type", "application/json")
+	getApp().Test(req2)
+
+	body3 := fmt.Sprintf(`{"uid":"%s","variant":"%s","action":true}`, uid, variant)
+	req3 := httptest.NewRequest("POST", "/api/abtest", bytes.NewBufferString(body3))
+	req3.Header.Set("Content-Type", "application/json")
+	getApp().Test(req3)
+
+	var testVar abtest.ABTestVariant
+	db.Raw("SELECT id, uid, variant, shown, action FROM abtest WHERE uid = ? AND variant = ?", uid, variant).Scan(&testVar)
+	assert.Equal(t, uint64(2), testVar.Shown)
+	assert.Equal(t, uint64(1), testVar.Action)
+}

--- a/iznik-server-go/test/alert_tdd_test.go
+++ b/iznik-server-go/test/alert_tdd_test.go
@@ -1,0 +1,214 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/freegle/iznik-server-go/alert"
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAlert_GetAlert_NotFound(t *testing.T) {
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/alert/99999999", nil))
+	assert.Equal(t, 404, resp.StatusCode)
+}
+
+func TestAlert_GetAlert_PublicAccess(t *testing.T) {
+	prefix := uniquePrefix("alert_public")
+	db := database.DBConn
+
+	db.Exec("INSERT INTO alerts (createdby, subject, text, html, `from`, `to`, created) VALUES (?, ?, ?, ?, ?, 'Users', NOW())",
+		1, "Test Alert "+prefix, "Test message", "<p>Test message</p>", "admin@example.com")
+
+	var alertID uint64
+	db.Raw("SELECT id FROM alerts WHERE subject = ? ORDER BY id DESC LIMIT 1", "Test Alert "+prefix).Scan(&alertID)
+	assert.Greater(t, alertID, uint64(0))
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET", fmt.Sprintf("/api/alert/%d", alertID), nil))
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json.Unmarshal(rsp(resp), &result)
+	assert.Equal(t, float64(0), result["ret"])
+	assert.Equal(t, "Success", result["status"])
+	alertObj := result["alert"].(map[string]interface{})
+	assert.Equal(t, float64(alertID), alertObj["id"])
+	assert.Equal(t, "Test Alert"+prefix, alertObj["subject"])
+}
+
+func TestAlert_GetAlert_InvalidID(t *testing.T) {
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/alert/invalid", nil))
+	assert.Equal(t, 400, resp.StatusCode)
+}
+
+func TestAlert_ListAlerts_Unauthorized(t *testing.T) {
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/alert", nil))
+	assert.Equal(t, 401, resp.StatusCode)
+}
+
+func TestAlert_ListAlerts_Forbidden(t *testing.T) {
+	prefix := uniquePrefix("alert_regular_user")
+	userID := CreateTestUser(t, prefix, "User")
+	_, token := CreateTestSession(t, userID)
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET", fmt.Sprintf("/api/alert?jwt=%s", token), nil))
+	assert.Equal(t, 403, resp.StatusCode)
+}
+
+func TestAlert_ListAlerts_AdminAccess(t *testing.T) {
+	prefix := uniquePrefix("alert_admin_list")
+	adminID := CreateTestUser(t, prefix+"_admin", "Support")
+	_, token := CreateTestSession(t, adminID)
+
+	db := database.DBConn
+	db.Exec("INSERT INTO alerts (createdby, subject, text, html, `from`, `to`, created) VALUES (?, ?, ?, ?, ?, 'Users', NOW())",
+		adminID, "Test Alert "+prefix, "Test message", "<p>Test message</p>", "admin@example.com")
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET", fmt.Sprintf("/api/alert?jwt=%s", token), nil))
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json.Unmarshal(rsp(resp), &result)
+	assert.Equal(t, float64(0), result["ret"])
+	assert.Equal(t, "Success", result["status"])
+	alerts := result["alerts"].([]interface{})
+	assert.Greater(t, len(alerts), 0)
+}
+
+func TestAlert_CreateAlert_Unauthorized(t *testing.T) {
+	body := `{"from":"admin@example.com","subject":"Test","text":"Body","html":"<p>Body</p>"}`
+	req := httptest.NewRequest("PUT", "/api/alert", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 401, resp.StatusCode)
+}
+
+func TestAlert_CreateAlert_Forbidden(t *testing.T) {
+	prefix := uniquePrefix("alert_regular_create")
+	userID := CreateTestUser(t, prefix, "User")
+	_, token := CreateTestSession(t, userID)
+
+	body := `{"from":"admin@example.com","subject":"Test","text":"Body","html":"<p>Body</p>"}`
+	req := httptest.NewRequest("PUT", fmt.Sprintf("/api/alert?jwt=%s", token), bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 403, resp.StatusCode)
+}
+
+func TestAlert_CreateAlert_Success(t *testing.T) {
+	prefix := uniquePrefix("alert_create_success")
+	adminID := CreateTestUser(t, prefix+"_admin", "Support")
+	_, token := CreateTestSession(t, adminID)
+
+	body := fmt.Sprintf(`{"from":"admin@example.com","subject":"Test Alert %s","text":"Test body","html":"<p>Test body</p>"}`, prefix)
+	req := httptest.NewRequest("PUT", fmt.Sprintf("/api/alert?jwt=%s", token), bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json.Unmarshal(rsp(resp), &result)
+	assert.Equal(t, float64(0), result["ret"])
+	assert.Equal(t, "Success", result["status"])
+	assert.Greater(t, result["id"], float64(0))
+}
+
+func TestAlert_CreateAlert_DefaultTo(t *testing.T) {
+	prefix := uniquePrefix("alert_default_to")
+	adminID := CreateTestUser(t, prefix+"_admin", "Support")
+	_, token := CreateTestSession(t, adminID)
+
+	body := fmt.Sprintf(`{"from":"admin@example.com","subject":"Test %s","text":"Body"}`, prefix)
+	req := httptest.NewRequest("PUT", fmt.Sprintf("/api/alert?jwt=%s", token), bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json.Unmarshal(rsp(resp), &result)
+	alertID := uint64(result["id"].(float64))
+
+	var createdAlert alert.Alert
+	db := database.DBConn
+	db.Raw("SELECT id, `to` FROM alerts WHERE id = ?", alertID).Scan(&createdAlert)
+	assert.Equal(t, "Mods", createdAlert.To)
+}
+
+func TestAlert_CreateAlert_DefaultHTML(t *testing.T) {
+	prefix := uniquePrefix("alert_default_html")
+	adminID := CreateTestUser(t, prefix+"_admin", "Support")
+	_, token := CreateTestSession(t, adminID)
+
+	textBody := "Line 1\nLine 2\nLine 3"
+	body := fmt.Sprintf(`{"from":"admin@example.com","subject":"Test %s","text":"Line 1\\nLine 2\\nLine 3"}`, prefix)
+	req := httptest.NewRequest("PUT", fmt.Sprintf("/api/alert?jwt=%s", token), bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json.Unmarshal(rsp(resp), &result)
+	alertID := uint64(result["id"].(float64))
+
+	var createdAlert alert.Alert
+	db := database.DBConn
+	db.Raw("SELECT id, html FROM alerts WHERE id = ?", alertID).Scan(&createdAlert)
+	assert.Contains(t, createdAlert.Html, "<br>")
+}
+
+func TestAlert_RecordAlert_InvalidRequest(t *testing.T) {
+	body := `{"action":"invalid"}`
+	req := httptest.NewRequest("POST", "/api/alert", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json.Unmarshal(rsp(resp), &result)
+	assert.Equal(t, float64(0), result["ret"])
+}
+
+func TestAlert_RecordAlert_NoTrackid(t *testing.T) {
+	body := `{"action":"clicked","trackid":0}`
+	req := httptest.NewRequest("POST", "/api/alert", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json.Unmarshal(rsp(resp), &result)
+	assert.Equal(t, float64(0), result["ret"])
+}
+
+func TestAlert_RecordAlert_ValidClick(t *testing.T) {
+	prefix := uniquePrefix("alert_record")
+	db := database.DBConn
+
+	db.Exec("INSERT INTO alerts_tracking (alertid, response) VALUES (1, NULL)")
+	var trackID uint64
+	db.Raw("SELECT id FROM alerts_tracking WHERE alertid = 1 ORDER BY id DESC LIMIT 1").Scan(&trackID)
+
+	if trackID > 0 {
+		body := fmt.Sprintf(`{"action":"clicked","trackid":%d}`, trackID)
+		req := httptest.NewRequest("POST", "/api/alert", bytes.NewBufferString(body))
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, _ := getApp().Test(req)
+		assert.Equal(t, 200, resp.StatusCode)
+
+		var result map[string]interface{}
+		json.Unmarshal(rsp(resp), &result)
+		assert.Equal(t, float64(0), result["ret"])
+	}
+}


### PR DESCRIPTION
## Summary

Add comprehensive TDD test coverage for Go API packages:

- **abtest**: 9 new tests covering variant selection, request recording, and accumulation logic
- **alert**: 12 new tests covering alert creation, retrieval, listing, and tracking

Tests verify:
- Request validation and error handling
- Database state changes
- Authorization checks
- Default value application
- Multi-step state accumulation

All tests follow existing patterns in the test/ directory using Fiber test harness and factory functions for test data isolation.