### PR TITLE
fix(search): improve search relevance for plural/singular queries and recency weighting

### DIFF
--- a/iznik-server-go/message/search.go
+++ b/iznik-server-go/message/search.go
@@ -34,7 +34,7 @@ func GetWords(search string) []string {
 		"freegle", "freecycle", "for", "large", "small", "are", "but", "not", "you", "all", "any", "can", "her", "was", "one", "our",
 		"out", "day", "get", "has", "him", "how", "now", "see", "two", "who", "did", "its", "let", "she", "too", "use", "plz",
 		"of", "to", "in", "it", "is", "be", "as", "at", "so", "we", "he", "by", "or", "on", "do", "if", "me", "my", "up", "an", "go", "no", "us", "am",
-		"working", "broken", "black", "white", "grey", "blue", "green", "red", "yellow", "brown", "orange", "pink", "machine", "size", "set",
+		"working", "broken", "black", "machine", "size", "set",
 		"various", "assorted", "different", "bits", "ladies", "gents", "kids", "nice", "brand", "pack", "soft", "single", "double",
 		"top", "plastic", "electric", "unopened",
 	}
@@ -157,7 +157,7 @@ func GetWordsExact(db *gorm.DB, words []string, limit int64, groupids []uint64, 
 	sql += ") " +
 		groupFilter(groupids) +
 		typeFilter(msgtype) +
-		"GROUP BY msgid HAVING wordmatch > 0 ORDER BY wordmatch DESC, popularity DESC LIMIT ?;"
+		"GROUP BY msgid HAVING wordmatch > 0 ORDER BY wordmatch DESC, messages_spatial.arrival DESC, popularity DESC LIMIT ?;"
 
 	args = append(args, limit)
 
@@ -197,7 +197,7 @@ func GetWordsTypo(db *gorm.DB, words []string, limit int64, groupids []uint64, m
 
 		sql += ")" + groupFilter(groupids) +
 			typeFilter(msgtype) +
-			" GROUP BY msgid HAVING wordmatch > 0 ORDER BY wordmatch DESC, popularity DESC LIMIT ?"
+			" GROUP BY msgid HAVING wordmatch > 0 ORDER BY wordmatch DESC, messages_spatial.arrival DESC, popularity DESC LIMIT ?"
 
 		args = append(args, limit)
 
@@ -239,7 +239,7 @@ func GetWordsStarts(db *gorm.DB, words []string, limit int64, groupids []uint64,
 
 		sql += ") " + groupFilter(groupids) +
 			typeFilter(msgtype) +
-			" GROUP BY msgid HAVING wordmatch > 0 ORDER BY wordmatch DESC, popularity DESC LIMIT ?"
+			" GROUP BY msgid HAVING wordmatch > 0 ORDER BY wordmatch DESC, messages_spatial.arrival DESC, popularity DESC LIMIT ?"
 
 		args = append(args, limit)
 
@@ -279,7 +279,7 @@ func GetWordsSounds(db *gorm.DB, words []string, limit int64, groupids []uint64,
 
 		sql += ") " + groupFilter(groupids) +
 			typeFilter(msgtype) +
-			" GROUP BY msgid HAVING wordmatch > 0 ORDER BY wordmatch DESC, popularity DESC LIMIT ?"
+			" GROUP BY msgid HAVING wordmatch > 0 ORDER BY wordmatch DESC, messages_spatial.arrival DESC, popularity DESC LIMIT ?"
 
 		args = append(args, limit)
 

--- a/iznik-server-go/test/search_test.go
+++ b/iznik-server-go/test/search_test.go
@@ -135,3 +135,35 @@ func TestAPISearch_V2Path(t *testing.T) {
 	resp, _ := getApp().Test(httptest.NewRequest("GET", "/apiv2/message/search/chair", nil), 60000)
 	assert.Equal(t, 200, resp.StatusCode)
 }
+
+func TestSearchWhiteGoods(t *testing.T) {
+	// Regression test for issue #9585: "white goods" and "white good" search
+	// Create messages with color + product terms
+	prefix := uniquePrefix("whitegoods")
+	groupID := CreateTestGroup(t, prefix)
+	userID := CreateTestUser(t, prefix, "User")
+	CreateTestMembership(t, userID, groupID, "Member")
+
+	// Create recent message with "white goods" in subject
+	CreateTestMessage(t, userID, groupID, "White Goods Fridge Freezer - Free", 55.9533, -3.1883)
+	CreateTestMessage(t, userID, groupID, "White Washing Machine available", 55.9533, -3.1883)
+	CreateTestMessage(t, userID, groupID, "White Microwave oven", 55.9533, -3.1883)
+	CreateTestMessage(t, userID, groupID, "White Cabinet for storage", 55.9533, -3.1883)
+
+	// Test plural form "white goods"
+	words := message.GetWords("white goods")
+	assert.Greater(t, len(words), 0, "should extract at least one word from 'white goods'")
+	assert.Contains(t, words, "goods", "'goods' should not be filtered as stopword")
+	assert.Contains(t, words, "white", "'white' should not be filtered as stopword for color-based searches")
+
+	resultsPlural := message.GetWordsExact(database.DBConn, words, 100, []uint64{groupID}, "All", 0, 0, 0, 0)
+	assert.Greater(t, len(resultsPlural), 0, "should find recent messages matching 'white goods'")
+
+	// Test singular form "white good"
+	words2 := message.GetWords("white good")
+	assert.Greater(t, len(words2), 0, "should extract at least one word from 'white good'")
+	assert.Contains(t, words2, "white", "'white' should not be filtered")
+
+	resultsSingular := message.GetWordsExact(database.DBConn, words2, 100, []uint64{groupID}, "All", 0, 0, 0, 0)
+	assert.Greater(t, len(resultsSingular), 0, "should find messages matching 'white good'")
+}


### PR DESCRIPTION
## Summary

Fixes Discourse topic 9585: 'White goods' search only returned one old item while missing 4 recent live items; 'white good' returned nothing.

### Root Cause

Color words (white, grey, blue, green, red, yellow, brown, orange, pink) were included in the stopword filter for search queries. This caused:
- **'white goods'** → filters out "white" → only searches for "goods" → fewer results
- **'white good'** → filters out both → empty search → no results

### Changes

1. **Remove colors from stopwords** (`search.go:37`): Colors are essential search terms in a marketplace context, especially "white goods" which is a specific product category.

2. **Add recency weighting** (`search.go:160, 200, 242, 282`): Modified all search functions' ORDER BY clauses to include `messages_spatial.arrival DESC`, so recent matches appear before older ones when word match count is equal.

### Testing

- Added regression test `TestSearchWhiteGoods` verifying both plural and singular form searches work correctly
- Searches on: "white goods", "white good"
- Verifies recent messages with these terms are found in results

### Relevant Discourse Topic

[Discourse 9585 - Better Search](https://discourse.freegle.in/t/better-search/4483/18)