### PR TITLE
fix(modtools): show pending message subject in ModMail log entries (#9518/211)

### DIFF
--- a/iznik-nuxt3/modtools/components/ModLog.vue
+++ b/iznik-nuxt3/modtools/components/ModLog.vue
@@ -77,9 +77,7 @@
               <span
                 v-if="
                   logMessage.groups &&
-                  logMessage.groups.some(
-                    (g) => g.collection === 'Pending'
-                  )
+                  logMessage.groups.some((g) => g.collection === 'Pending')
                 "
                 class="text-warning"
               >
@@ -139,13 +137,11 @@
           </span>
           <span v-else-if="log.subtype === 'Replied'" class="text-danger">
             Modmail sent
+            <ModLogMessage :logid="logid" notext nostdmsg />
             <span v-if="log.text && log.text.length > 0">
               with <em>{{ log.text }} </em>
-              <span v-if="log.stdmsg">
-                using <em>{{ log.stdmsg.title }} </em></span
-              >
-              <span v-else> mail </span>
             </span>
+            <ModLogStdMsg :logid="logid" />
           </span>
           <span v-else-if="log.subtype === 'Deleted'" class="text-danger">
             Deleted <ModLogMessage :logid="logid" />

--- a/iznik-nuxt3/modtools/components/ModLogMessage.vue
+++ b/iznik-nuxt3/modtools/components/ModLogMessage.vue
@@ -11,7 +11,8 @@
       <span v-if="!notext && log.text && log.text.length > 0">
         with <em>{{ log.text }} </em></span
       >
-      <ModLogStdMsg :logid="logid" /> <ModLogGroup :logid="logid" :tag="tag" />
+      <ModLogStdMsg v-if="!nostdmsg" :logid="logid" />
+      <ModLogGroup :logid="logid" :tag="tag" />
     </span>
     <span v-else>
       <v-icon icon="hashtag" class="text-muted" scale="0.75" />{{ log.msgid }}
@@ -30,6 +31,11 @@ const props = defineProps({
     required: true,
   },
   notext: {
+    type: Boolean,
+    required: false,
+    default: false,
+  },
+  nostdmsg: {
     type: Boolean,
     required: false,
     default: false,

--- a/iznik-nuxt3/tests/unit/components/modtools/ModLog.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModLog.spec.js
@@ -62,7 +62,7 @@ describe('ModLog', () => {
           },
           ModLogMessage: {
             template: '<span class="mod-log-message">Message</span>',
-            props: ['logid', 'notext', 'tag'],
+            props: ['logid', 'notext', 'nostdmsg', 'tag'],
           },
           ModLogStdMsg: {
             template: '<span class="mod-log-stdmsg">StdMsg</span>',
@@ -364,6 +364,44 @@ describe('ModLog', () => {
         text: 'Reply text',
       })
       expect(wrapper.text()).toContain('Modmail sent')
+    })
+
+    it('shows ModLogMessage for Message/Replied to identify the pending message', () => {
+      // Regression test: Discourse #9518/211 — modmail logs didn't show which
+      // pending message the modmail was sent about.
+      const wrapper = createWrapper({
+        id: 1,
+        type: 'Message',
+        subtype: 'Replied',
+        msgid: 12345,
+        text: 'Please add a photo',
+      })
+      expect(wrapper.find('.mod-log-message').exists()).toBe(true)
+    })
+
+    it('shows ModLogStdMsg for Message/Replied with standard message but no text', () => {
+      // Regression test: Discourse #9518/211 — stdmsg title ("add a photo") was
+      // hidden inside v-if="log.text", so it never showed when text was absent.
+      const wrapper = createWrapper({
+        id: 1,
+        type: 'Message',
+        subtype: 'Replied',
+        msgid: 12345,
+        stdmsg: { id: 7, title: 'add a photo' },
+      })
+      expect(wrapper.find('.mod-log-stdmsg').exists()).toBe(true)
+    })
+
+    it('shows ModLogStdMsg for Message/Replied even when log.text is empty', () => {
+      const wrapper = createWrapper({
+        id: 1,
+        type: 'Message',
+        subtype: 'Replied',
+        msgid: 12345,
+        text: '',
+        stdmsg: { id: 7, title: 'add a photo' },
+      })
+      expect(wrapper.find('.mod-log-stdmsg').exists()).toBe(true)
     })
 
     it('shows Edited with text content for Message/Edit', () => {

--- a/iznik-nuxt3/tests/unit/components/modtools/ModLogMessage.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModLogMessage.spec.js
@@ -365,6 +365,72 @@ describe('ModLogMessage', () => {
     })
   })
 
+  describe('nostdmsg prop', () => {
+    it('renders ModLogStdMsg when nostdmsg is false (default)', () => {
+      const log = { id: 1, msgid: 1050, message: { subject: 'Test' } }
+      mockLogsStore.list = [log]
+      mockLogsStore.byId.mockImplementation(
+        (id) => mockLogsStore.list.find((l) => l.id === id) || null
+      )
+      const wrapper = mount(ModLogMessage, {
+        props: { logid: 1, nostdmsg: false },
+        global: {
+          stubs: {
+            ModLogStdMsg: {
+              name: 'ModLogStdMsg',
+              template: '<span class="stub-stdmsg"></span>',
+              props: ['logid'],
+            },
+            ModLogGroup: {
+              name: 'ModLogGroup',
+              template: '<span class="stub-group"></span>',
+              props: ['logid', 'tag'],
+            },
+            'v-icon': {
+              name: 'v-icon',
+              template: '<span class="stub-icon"></span>',
+              props: ['icon', 'scale'],
+            },
+          },
+        },
+      })
+      expect(wrapper.find('.stub-stdmsg').exists()).toBe(true)
+    })
+
+    it('suppresses ModLogStdMsg when nostdmsg is true', () => {
+      // Regression test: Discourse #9518/211 — the Replied case needs nostdmsg
+      // so the parent ModLog.vue can show stdmsg once without duplication.
+      const log = { id: 1, msgid: 1055, message: { subject: 'Test' } }
+      mockLogsStore.list = [log]
+      mockLogsStore.byId.mockImplementation(
+        (id) => mockLogsStore.list.find((l) => l.id === id) || null
+      )
+      const wrapper = mount(ModLogMessage, {
+        props: { logid: 1, nostdmsg: true },
+        global: {
+          stubs: {
+            ModLogStdMsg: {
+              name: 'ModLogStdMsg',
+              template: '<span class="stub-stdmsg"></span>',
+              props: ['logid'],
+            },
+            ModLogGroup: {
+              name: 'ModLogGroup',
+              template: '<span class="stub-group"></span>',
+              props: ['logid', 'tag'],
+            },
+            'v-icon': {
+              name: 'v-icon',
+              template: '<span class="stub-icon"></span>',
+              props: ['icon', 'scale'],
+            },
+          },
+        },
+      })
+      expect(wrapper.find('.stub-stdmsg').exists()).toBe(false)
+    })
+  })
+
   describe('child component props', () => {
     it('passes logid to ModLogStdMsg', () => {
       const log = { id: 1, msgid: 1100, message: { subject: 'Test' } }


### PR DESCRIPTION
## Summary

- When a moderator sent ModMail from the pending message view, the `Message/Replied` log entry showed only the email subject/template name but not *which* pending message was involved — reported by Jos in Discourse topic 9518, post 211.
- Added `<ModLogMessage>` to the `Replied` case so the pending message link and subject appear in the log, matching the pattern used by all other message log subtypes.
- Added `nostdmsg` prop to `ModLogMessage` so the parent can render `ModLogStdMsg` directly without duplication.
- Moved `<ModLogStdMsg>` outside the `v-if="log.text"` guard so the template name shows even when the email subject line is empty.

## Test plan

- [x] 5 new Vitest unit tests in `ModLog.spec.js` and `ModLogMessage.spec.js` covering the new behaviour
- [x] All 11906 existing tests continue to pass (1 pre-existing failure in `member.spec.js` unrelated to this change)
- [x] ESLint clean on all 4 changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)