### PR TITLE
chore: add PR template with Sentry investigation checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+## Summary
+
+<!-- 1–3 bullets: what changed and why. -->
+
+## Test plan
+
+<!-- What you ran or will run to verify. -->
+
+---
+
+### Sentry-sourced?
+
+<!-- If this PR addresses a Sentry issue, answer all three. Otherwise delete this section. -->
+
+- **Issue**: <Sentry link>
+- **Breadcrumbs read?** What do the last 5–30s before the crash show? Paste the proximate trigger event (e.g. `console: Reset uploader`, `ui.click`, `navigation`) — not just the exception.
+- **Loki cross-referenced?** State the query + time window you ran (`{source="api"}`, `{source="client"}`, etc.), or explain why Loki is **not applicable** to this class of error. "Not needed because …" is fine; "didn't check" is not.
+- **Integration gap?** Does the failing code path bypass Sentry's fetch/xhr integrations (e.g. `<img>` / `<link>` / `<script>` tag loads, `new Image()`, WebSocket, no-cors fetch)? If yes, name the alternative visibility you used (CDN/weserv/tusd access logs, client-side `console` breadcrumbs) — or flag the gap as unresolved.


### PR DESCRIPTION
## Summary

- Adds `.github/pull_request_template.md` with a Sentry investigation checklist
- Forces PR authors to confirm they've reviewed breadcrumbs, cross-referenced Loki logs, and considered integration gaps when addressing a Sentry issue
- Motivated by recent PRs (#210, #212) that landed on shallow theories from the exception alone without verifying via breadcrumbs or Loki

## Test plan

- [ ] New PRs show the template pre-filled in the description box on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)