### PR TITLE
fix(logs): show message subject as it was at the time of each log event

### DIFF
--- a/iznik-batch/database/migrations/2026_04_28_000001_add_msgsubject_to_logs_table.php
+++ b/iznik-batch/database/migrations/2026_04_28_000001_add_msgsubject_to_logs_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('logs', function (Blueprint $table) {
+            // Store the message subject at the time each log event occurs so that
+            // ModTools can show the historical subject rather than the current (possibly
+            // edited) one.  Nullable because existing rows pre-date this column, and
+            // because not every log type has an associated message subject.
+            $table->string('msgsubject', 80)->nullable()->after('msgid');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('logs', function (Blueprint $table) {
+            $table->dropColumn('msgsubject');
+        });
+    }
+};

--- a/iznik-nuxt3/modtools/components/ModLogMessage.vue
+++ b/iznik-nuxt3/modtools/components/ModLogMessage.vue
@@ -1,6 +1,6 @@
 <template>
   <span v-if="log && log.msgid">
-    <span v-if="message">
+    <span v-if="message || log.msgsubject">
       <a
         :href="'https://www.ilovefreegle.org/message/' + log.msgid"
         target="_blank"
@@ -63,12 +63,16 @@ const message = computed(() => {
 })
 
 const messagesubject = computed(() => {
+  // Prefer the subject stored at the time of the log event (historical accuracy).
+  // Falls back to the current message subject for pre-migration log entries.
+  if (log.value?.msgsubject) {
+    return log.value.msgsubject
+  }
   if (message.value) {
     return message.value.subject
       ? message.value.subject
       : '(Blank subject line)'
-  } else {
-    return '(Message now deleted)'
   }
+  return '(Message now deleted)'
 })
 </script>

--- a/iznik-nuxt3/tests/unit/components/modtools/ModLogMessage.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModLogMessage.spec.js
@@ -339,6 +339,48 @@ describe('ModLogMessage', () => {
       })
       expect(wrapper.vm.messagesubject).toBe('(Message now deleted)')
     })
+
+    // Regression tests for Discourse #9518 post 215:
+    // log.msgsubject (historical) must take priority over message.subject (current).
+    it('uses log.msgsubject instead of message.subject when both are present', () => {
+      // Simulates the case where a message was edited after the log event was recorded.
+      // The log.msgsubject holds the subject at the time of the event; message.subject
+      // holds the current (edited) subject.  The log should show the historical value.
+      const wrapper = createWrapper({
+        log: {
+          id: 1,
+          msgid: 905,
+          msgsubject: 'Wanted: Escooter',
+          message: { subject: 'Wanted: Cycle' },
+        },
+      })
+      expect(wrapper.vm.messagesubject).toBe('Wanted: Escooter')
+    })
+
+    it('uses log.msgsubject when message store object is not loaded', () => {
+      // The API now includes msgsubject so the frontend can display the subject
+      // even before the message store is populated.
+      const wrapper = createWrapper({
+        log: {
+          id: 1,
+          msgid: 906,
+          msgsubject: 'Offer: Free table',
+        },
+      })
+      expect(wrapper.vm.messagesubject).toBe('Offer: Free table')
+    })
+
+    it('falls back to message.subject when log.msgsubject is absent', () => {
+      // Pre-migration log entries will not have msgsubject; fall back to current subject.
+      const wrapper = createWrapper({
+        log: {
+          id: 1,
+          msgid: 907,
+          message: { subject: 'OFFER: Old item' },
+        },
+      })
+      expect(wrapper.vm.messagesubject).toBe('OFFER: Old item')
+    })
   })
 
   describe('props', () => {
@@ -494,6 +536,17 @@ describe('ModLogMessage', () => {
       })
       expect(wrapper.find('.stub-stdmsg').exists()).toBe(false)
       expect(wrapper.find('.stub-group').exists()).toBe(false)
+    })
+
+    it('shows link section when message is null but msgsubject is set', () => {
+      // Deleted messages no longer exist in the store but the historical subject
+      // is still available from the API response via log.msgsubject.
+      const wrapper = createWrapper({
+        log: { id: 1, msgid: 2200, msgsubject: 'Offer: Gone item', message: null },
+      })
+      expect(wrapper.find('a').exists()).toBe(true)
+      expect(wrapper.text()).not.toContain('(no info available)')
+      expect(wrapper.find('em').text()).toBe('Offer: Gone item')
     })
   })
 })

--- a/iznik-server-go/logs/logs.go
+++ b/iznik-server-go/logs/logs.go
@@ -181,11 +181,13 @@ func GetLogs(c *fiber.Ctx) error {
 	}
 
 	// Build the query.
-	query := "SELECT logs.* FROM logs "
+	// Always LEFT JOIN messages so we can return the current subject as a fallback
+	// when logs.msgsubject is not stored (pre-migration rows).
+	query := "SELECT logs.*, messages.subject AS msg_subject_current FROM logs " +
+		"LEFT JOIN messages ON messages.id = logs.msgid "
 
 	if search != "" {
-		query += "LEFT JOIN users ON users.id = logs.user " +
-			"LEFT JOIN messages ON messages.id = logs.msgid "
+		query += "LEFT JOIN users ON users.id = logs.user "
 
 		searchLike := "%" + search + "%"
 		where = append(where, "(users.firstname LIKE ? OR users.lastname LIKE ? OR users.fullname LIKE ? "+
@@ -198,17 +200,19 @@ func GetLogs(c *fiber.Ctx) error {
 	args = append(args, limit)
 
 	type LogRow struct {
-		ID        uint64  `json:"id"`
-		Timestamp string  `json:"timestamp"`
-		Type      string  `json:"type"`
-		Subtype   *string `json:"subtype"`
-		Groupid   *uint64 `json:"groupid"`
-		User      *uint64 `json:"user"`
-		Byuser    *uint64 `json:"byuser"`
-		Msgid     *uint64 `json:"msgid"`
-		Configid  *uint64 `json:"configid"`
-		Stdmsgid  *uint64 `json:"stdmsgid"`
-		Text      *string `json:"text"`
+		ID                uint64  `json:"id"`
+		Timestamp         string  `json:"timestamp"`
+		Type              string  `json:"type"`
+		Subtype           *string `json:"subtype"`
+		Groupid           *uint64 `json:"groupid"`
+		User              *uint64 `json:"user"`
+		Byuser            *uint64 `json:"byuser"`
+		Msgid             *uint64 `json:"msgid"`
+		Configid          *uint64 `json:"configid"`
+		Stdmsgid          *uint64 `json:"stdmsgid"`
+		Text              *string `json:"text"`
+		Msgsubject        *string `gorm:"column:msgsubject"`         // stored at log creation time
+		MsgSubjectCurrent *string `gorm:"column:msg_subject_current"` // from messages JOIN (fallback)
 	}
 
 	var rows []LogRow
@@ -252,6 +256,14 @@ func GetLogs(c *fiber.Ctx) error {
 		if r.Subtype != nil && *r.Subtype == log.LOG_SUBTYPE_OUTCOME && r.Text != nil && *r.Text != "" {
 			firstWord := strings.SplitN(*r.Text, " ", 2)[0]
 			entry["text"] = &firstWord
+		}
+
+		// msgsubject: prefer the value stored at log creation time (historical accuracy);
+		// fall back to the current message subject from the JOIN for pre-migration rows.
+		if r.Msgsubject != nil {
+			entry["msgsubject"] = *r.Msgsubject
+		} else if r.MsgSubjectCurrent != nil {
+			entry["msgsubject"] = *r.MsgSubjectCurrent
 		}
 
 		result[i] = entry

--- a/iznik-server-go/test/logs_test.go
+++ b/iznik-server-go/test/logs_test.go
@@ -373,7 +373,71 @@ func TestGetLogsModmailTextIsEmailSubject(t *testing.T) {
 	// log.text must contain the stdmsg-constructed email subject, not just "Re: [post subject]"
 	assert.Equal(t, emailSubject, logEntry["text"], "log.text should contain the stdmsg-constructed email subject")
 
-	// msgsubject must NOT be present — the post title is not exposed separately
-	_, hasMsgSubject := logEntry["msgsubject"]
-	assert.False(t, hasMsgSubject, "msgsubject field must not be in the response")
+	// msgsubject must be the message's own subject (from the messages JOIN), distinct from log.text
+	// which holds the modmail email subject
+	assert.Equal(t, "add a photo", logEntry["msgsubject"], "msgsubject should be the message's own subject")
+}
+
+func TestGetLogsMsgsubjectHistoricalIsPreserved(t *testing.T) {
+	// Regression test for Discourse topic #9518 post 215:
+	// The message log was showing the edited item name retroactively for events that
+	// occurred before the edit.  After this fix, each log event stores and returns the
+	// message subject as it was at the time of that event (logs.msgsubject), taking
+	// precedence over the current (possibly edited) messages.subject.
+	prefix := uniquePrefix("LogsMsgS")
+	groupID := CreateTestGroup(t, prefix)
+	userID := CreateTestUser(t, prefix, "User")
+	CreateTestMembership(t, userID, groupID, "Owner")
+	_, token := CreateTestSession(t, userID)
+
+	db := database.DBConn
+
+	// Check the msgsubject column exists (requires the 2026_04_28_000001 migration).
+	var hasColumn int64
+	db.Raw("SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'logs' AND column_name = 'msgsubject'").Scan(&hasColumn)
+	if hasColumn == 0 {
+		t.Skip("msgsubject column not in schema; run: php artisan migrate")
+	}
+
+	// Create a message with the original subject.
+	db.Exec("INSERT INTO messages (fromuser, type, subject, textbody, arrival, date, source) VALUES (?, 'Offer', 'Offer: Original Item', 'body', NOW(), NOW(), 'Platform')", userID)
+	var msgID uint64
+	db.Raw("SELECT id FROM messages WHERE fromuser = ? ORDER BY id DESC LIMIT 1", userID).Scan(&msgID)
+
+	// Insert a Received log entry that stores the original subject at the time of the event.
+	db.Exec("INSERT INTO logs (type, subtype, groupid, user, msgid, timestamp, msgsubject) VALUES (?, ?, ?, ?, ?, DATE_SUB(NOW(), INTERVAL 1 HOUR), ?)",
+		flog.LOG_TYPE_MESSAGE, flog.LOG_SUBTYPE_RECEIVED, groupID, userID, msgID, "Offer: Original Item")
+
+	// Simulate the message being edited to a new name after the Received event.
+	db.Exec("UPDATE messages SET subject = ? WHERE id = ?", "Offer: Edited Item", msgID)
+
+	// Fetch the message log.
+	req := httptest.NewRequest("GET", fmt.Sprintf("/api/modtools/logs?logtype=messages&groupid=%d&limit=10&jwt=%s", groupID, token), nil)
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json2.Unmarshal(rsp(resp), &result)
+	assert.Equal(t, float64(0), result["ret"])
+
+	logs, ok := result["logs"].([]interface{})
+	assert.True(t, ok, "logs should be an array")
+	assert.Greater(t, len(logs), 0, "should have at least one log entry")
+
+	// Find the Received log entry for our message.
+	var logEntry map[string]interface{}
+	for _, l := range logs {
+		e := l.(map[string]interface{})
+		if subtype, ok := e["subtype"].(string); ok && subtype == flog.LOG_SUBTYPE_RECEIVED {
+			if mid, ok := e["msgid"].(float64); ok && uint64(mid) == msgID {
+				logEntry = e
+				break
+			}
+		}
+	}
+	assert.NotNil(t, logEntry, "should find the Received log entry for the test message")
+
+	// The stored historical msgsubject must take precedence over the current (edited) subject.
+	assert.Equal(t, "Offer: Original Item", logEntry["msgsubject"],
+		"log event should show the subject as it was at the time of the event, not the current edited subject")
 }

--- a/iznik-server/include/message/Message.php
+++ b/iznik-server/include/message/Message.php
@@ -406,6 +406,7 @@ class Message
                 'type' => Log::TYPE_MESSAGE,
                 'subtype' => Log::SUBTYPE_EDIT,
                 'msgid' => $this->id,
+                'msgsubject' => $this->subject,
                 'byuser' => $me ? $me->getId() : NULL,
                 'text' => $text
             ]);
@@ -2790,6 +2791,7 @@ ORDER BY lastdate DESC;";
                     'type' => Log::TYPE_MESSAGE,
                     'subtype' => Log::SUBTYPE_RECEIVED,
                     'msgid' => $this->id,
+                    'msgsubject' => $this->subject,
                     'user' => $this->fromuser,
                     'text' => $this->messageid,
                     'groupid' => $this->groupid
@@ -3032,6 +3034,7 @@ ORDER BY lastdate DESC;";
             'type' => Log::TYPE_MESSAGE,
             'subtype' => $subject ? Log::SUBTYPE_REJECTED : Log::SUBTYPE_DELETED,
             'msgid' => $this->id,
+            'msgsubject' => $this->subject,
             'byuser' => $me ? $me->getId() : NULL,
             'user' => $this->fromuser,
             'groupid' => $groupid,
@@ -3076,6 +3079,7 @@ ORDER BY lastdate DESC;";
             'type' => Log::TYPE_MESSAGE,
             'subtype' => Log::SUBTYPE_APPROVED,
             'msgid' => $this->id,
+            'msgsubject' => $this->subject,
             'user' => $this->fromuser,
             'byuser' => $myid,
             'groupid' => $groupid,
@@ -3164,6 +3168,7 @@ ORDER BY lastdate DESC;";
             'type' => Log::TYPE_MESSAGE,
             'subtype' => Log::SUBTYPE_REPLIED,
             'msgid' => $this->id,
+            'msgsubject' => $this->subject,
             'user' => $this->fromuser,
             'byuser' => $me ? $me->getId() : NULL,
             'groupid' => $groupid,
@@ -3189,6 +3194,7 @@ ORDER BY lastdate DESC;";
                 'type' => Log::TYPE_MESSAGE,
                 'subtype' => Log::SUBTYPE_HOLD,
                 'msgid' => $this->id,
+                'msgsubject' => $this->subject,
                 'byuser' => $me ? $me->getId() : NULL
             ]);
 
@@ -3211,6 +3217,7 @@ ORDER BY lastdate DESC;";
                 'type' => Log::TYPE_MESSAGE,
                 'subtype' => Log::SUBTYPE_RELEASE,
                 'msgid' => $this->id,
+                'msgsubject' => $this->subject,
                 'byuser' => $me ? $me->getId() : NULL
             ]);
 
@@ -3262,6 +3269,7 @@ ORDER BY lastdate DESC;";
                     'type' => Log::TYPE_MESSAGE,
                     'subtype' => Log::SUBTYPE_DELETED,
                     'msgid' => $this->id,
+                    'msgsubject' => $this->subject,
                     'user' => $this->fromuser,
                     'byuser' => $me ? $me->getId() : NULL,
                     'text' => $reason,
@@ -4432,6 +4440,7 @@ ORDER BY lastdate DESC;";
                                 'type' => Log::TYPE_MESSAGE,
                                 'subtype' => Log::SUBTYPE_OUTCOME,
                                 'msgid' => $this->id,
+                                'msgsubject' => $this->subject,
                                 'user' => $this->getFromuser(),
                                 'byuser' => $byuser,
                                 'groupid' => $groupid,
@@ -4531,6 +4540,7 @@ WHERE refmsgid = ? AND chat_messages.type = ? AND reviewrejected = 0 AND message
             'type' => Log::TYPE_MESSAGE,
             'subtype' => Log::SUBTYPE_OUTCOME,
             'msgid' => $this->id,
+            'msgsubject' => $this->subject,
             'user' => $this->getFromuser(),
             'byuser' => $me ? $me->getId() : NULL,
             'text' => $intcomment ? "Withdrawn: $comment" : "Withdrawn"
@@ -5242,6 +5252,7 @@ $mq", [
                 'type' => Log::TYPE_MESSAGE,
                 'subtype' => Log::SUBTYPE_AUTO_REPOSTED,
                 'msgid' => $this->id,
+                'msgsubject' => $this->subject,
                 'groupid' => $groupid,
                 'user' => $this->getFromuser(),
                 'text' => "$reposts / $max"
@@ -5473,6 +5484,7 @@ $mq", [
                                                 'subtype' => Log::SUBTYPE_AUTO_APPROVED,
                                                 'groupid' => $message['groupid'],
                                                 'msgid' => $message['msgid'],
+                                                'msgsubject' => $m->getSubject(),
                                                 'user' => $m->getFromuser()
                                             ]);
 


### PR DESCRIPTION
## Summary

Fixes Discourse topic [#9518 post 215](https://discourse.ilovefreegle.org/t/9518/215) — ModTools message log retroactively showed the edited item name for all historical events when a message subject was changed.

**Root cause**: The `logs` table stored only `msgid`; the frontend fetched the *current* message from the store on each render. When a post was edited (e.g. "Wanted: Escooter" → "Wanted: Cycle"), all historical log events (Received, Approved, etc.) retroactively showed the new name.

**Changes**:

- **Migration** `2026_04_28_000001`: adds `logs.msgsubject VARCHAR(80) NULL` — stores the subject at the time each log event occurs.
- **PHP `Message.php`**: populates `msgsubject` on all `TYPE_MESSAGE` log calls: Received, Approved, Rejected, Deleted, Replied, Hold, Release, Outcome, Auto\_Reposted, Auto\_Approved, Edit.
- **Go API `logs/logs.go`**: always `LEFT JOIN messages`; returns `logs.msgsubject` (stored historical, preferred) or `messages.subject` (current, fallback for pre-migration rows) as `msgsubject` in every log response entry that has a `msgid`.
- **Frontend `ModLogMessage.vue`**: uses `log.msgsubject` when present; falls back to `message.subject` for pre-migration entries; shows subject section even when the message has been deleted but `msgsubject` is available.
- **Tests**: updates `TestGetLogsModmailTextIsEmailSubject`; adds Go regression test `TestGetLogsMsgsubjectHistoricalIsPreserved`; adds three Vitest regression tests verifying `msgsubject` priority.

**Backward compatibility**: pre-migration log entries have `msgsubject = NULL`; those fall back to the current message subject (same behaviour as today). Only new log entries created after migration will carry the historical subject.

## Test plan

- [ ] Run `php artisan migrate` to apply the new column
- [ ] Run Go tests: `curl -X POST http://localhost:8081/api/tests/go` — all existing + new `TestGetLogsMsgsubjectHistoricalIsPreserved` pass
- [ ] Run Vitest tests: `curl -X POST http://localhost:8081/api/tests/vitest` — new `ModLogMessage` tests pass
- [ ] In ModTools: edit a message subject, check the log — earlier events (Received, Approved) now show the original subject, the Edit event shows the new subject

🤖 Generated with [Claude Code](https://claude.com/claude-code)