### PR TITLE
fix(chat): clear stuck unread badge via server-side AllSeen

### DIFF
--- a/iznik-nuxt3/api/ChatAPI.js
+++ b/iznik-nuxt3/api/ChatAPI.js
@@ -13,6 +13,10 @@ export default class ChatAPI extends BaseAPI {
     return count
   }
 
+  allSeen() {
+    return this.$postv2('/chatrooms', { action: 'AllSeen' })
+  }
+
   async fetchReviewChatsMT(params) {
     return await this.$getv2(`/chatmessages`, params)
   }

--- a/iznik-nuxt3/modtools/pages/chats/[[id]].vue
+++ b/iznik-nuxt3/modtools/pages/chats/[[id]].vue
@@ -234,16 +234,8 @@ function loadMore($state) {
 }
 
 async function markAllRead() {
-  console.log('markAllRead A')
   loading.value = true
-  for (const chat of filteredChats.value) {
-    if (chat.unseen) {
-      console.log('markAllRead B', chat.unseen, chat.lastmsg)
-      await chatStore.markRead(chat.id)
-    }
-  }
-  console.log('markAllRead C')
-
+  await chatStore.markAllReadMT()
   chatStore.clear()
   await listChats()
   loading.value = false

--- a/iznik-nuxt3/pages/chats/[[id]].vue
+++ b/iznik-nuxt3/pages/chats/[[id]].vue
@@ -598,12 +598,7 @@ function loadMore($state) {
 }
 
 async function markAllRead() {
-  for (const chat of filteredChats.value) {
-    if (chat.unseen) {
-      await chatStore.markRead(chat.id)
-    }
-  }
-
+  await chatStore.markAllRead()
   chatStore.fetchChats()
 }
 

--- a/iznik-nuxt3/stores/chat.js
+++ b/iznik-nuxt3/stores/chat.js
@@ -288,6 +288,12 @@ export const useChatStore = defineStore({
       await api(this.config).chat.allSeen()
       this.currentCountMT = 0
     },
+    async markAllRead() {
+      await api(this.config).chat.allSeen()
+      Object.keys(this.listByChatId).forEach((id) => {
+        this.listByChatId[id].unseen = 0
+      })
+    },
     async markRead(id) {
       const chat = this.listByChatId[id]
 

--- a/iznik-nuxt3/stores/chat.js
+++ b/iznik-nuxt3/stores/chat.js
@@ -284,6 +284,10 @@ export const useChatStore = defineStore({
 
       return messages
     },
+    async markAllReadMT() {
+      await api(this.config).chat.allSeen()
+      this.currentCountMT = 0
+    },
     async markRead(id) {
       const chat = this.listByChatId[id]
 

--- a/iznik-nuxt3/tests/unit/pages/chats/id.spec.js
+++ b/iznik-nuxt3/tests/unit/pages/chats/id.spec.js
@@ -57,6 +57,7 @@ const mockChatStore = {
   fetchChats: vi.fn().mockResolvedValue([]),
   fetchChat: vi.fn().mockResolvedValue({}),
   markRead: vi.fn().mockResolvedValue({}),
+  markAllRead: vi.fn().mockResolvedValue(),
   byChatId: vi.fn().mockReturnValue(null),
   clear: vi.fn(),
   unseenCount: 0,
@@ -254,5 +255,18 @@ describe('chats/[[id]].vue loadMore', () => {
     page.vm.loadMore(mockState)
 
     expect(mockState.complete).toHaveBeenCalled()
+  })
+
+  it('markAllRead calls chatStore.markAllRead and then fetchChats', async () => {
+    const wrapper = mountComponent()
+    await flushPromises()
+    await nextTick()
+    const page = wrapper.findComponent(ChatsPage)
+
+    await page.vm.markAllRead()
+
+    expect(mockChatStore.markAllRead).toHaveBeenCalledOnce()
+    expect(mockChatStore.fetchChats).toHaveBeenCalled()
+    expect(mockChatStore.markRead).not.toHaveBeenCalled()
   })
 })

--- a/iznik-nuxt3/tests/unit/pages/modtools/chats.spec.js
+++ b/iznik-nuxt3/tests/unit/pages/modtools/chats.spec.js
@@ -18,6 +18,7 @@ const mockChatStore = {
   searchSince: null,
   listChatsMT: vi.fn().mockResolvedValue([]),
   markRead: vi.fn().mockResolvedValue({}),
+  markAllReadMT: vi.fn().mockResolvedValue({}),
   clear: vi.fn(),
 }
 
@@ -208,7 +209,7 @@ describe('chats/[[id]].vue page', () => {
       mockChatStore.list = [{ id: 1, unseen: 5 }]
       const wrapper = mountComponent()
       await wrapper.vm.markAllRead()
-      expect(mockChatStore.markRead).toHaveBeenCalledWith(1)
+      expect(mockChatStore.markAllReadMT).toHaveBeenCalled()
       expect(mockChatStore.clear).toHaveBeenCalled()
     })
 

--- a/iznik-nuxt3/tests/unit/stores/chat.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/chat.spec.js
@@ -183,6 +183,42 @@ describe('chat store', () => {
     })
   })
 
+  describe('markAllRead', () => {
+    it('calls allSeen API', async () => {
+      const store = useChatStore()
+      store.config = {}
+      store.listByChatId[1] = { id: 1, unseen: 3, status: 'Online' }
+
+      await store.markAllRead()
+
+      expect(mockAllSeen).toHaveBeenCalledOnce()
+    })
+
+    it('resets unseen to 0 for all chats in listByChatId', async () => {
+      const store = useChatStore()
+      store.config = {}
+      store.listByChatId[1] = { id: 1, unseen: 3, status: 'Online' }
+      store.listByChatId[2] = { id: 2, unseen: 5, status: 'Online' }
+      store.listByChatId[3] = { id: 3, unseen: 2, status: 'Closed' }
+
+      await store.markAllRead()
+
+      expect(store.listByChatId[1].unseen).toBe(0)
+      expect(store.listByChatId[2].unseen).toBe(0)
+      expect(store.listByChatId[3].unseen).toBe(0)
+    })
+
+    it('does not call per-chat markRead', async () => {
+      const store = useChatStore()
+      store.config = {}
+      store.listByChatId[1] = { id: 1, unseen: 3, status: 'Online' }
+
+      await store.markAllRead()
+
+      expect(mockMarkRead).not.toHaveBeenCalled()
+    })
+  })
+
   describe('send', () => {
     it('updates snippet in listByChatId immediately after sending', async () => {
       const store = useChatStore()

--- a/iznik-nuxt3/tests/unit/stores/chat.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/chat.spec.js
@@ -16,6 +16,7 @@ const mockTyping = vi.fn().mockResolvedValue()
 const mockOpenChat = vi.fn().mockResolvedValue({ id: 42 })
 const mockSendMT = vi.fn().mockResolvedValue()
 const mockUnseenCountMT = vi.fn().mockResolvedValue(0)
+const mockAllSeen = vi.fn().mockResolvedValue()
 const mockRsvp = vi.fn().mockResolvedValue()
 const mockFetchReviewChatsMT = vi
   .fn()
@@ -39,6 +40,7 @@ vi.mock('~/api', () => ({
       openChat: mockOpenChat,
       sendMT: mockSendMT,
       unseenCountMT: mockUnseenCountMT,
+      allSeen: mockAllSeen,
       fetchReviewChatsMT: mockFetchReviewChatsMT,
       rsvp: mockRsvp,
     },
@@ -154,6 +156,30 @@ describe('chat store', () => {
       await store.markRead(5)
 
       expect(mockMarkRead).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('markAllReadMT', () => {
+    it('calls allSeen API and resets currentCountMT to 0', async () => {
+      const store = useChatStore()
+      store.config = {}
+      store.currentCountMT = 7
+
+      await store.markAllReadMT()
+
+      expect(mockAllSeen).toHaveBeenCalledOnce()
+      expect(store.currentCountMT).toBe(0)
+    })
+
+    it('resets badge even when currentCountMT was already 0', async () => {
+      const store = useChatStore()
+      store.config = {}
+      store.currentCountMT = 0
+
+      await store.markAllReadMT()
+
+      expect(mockAllSeen).toHaveBeenCalledOnce()
+      expect(store.currentCountMT).toBe(0)
     })
   })
 

--- a/iznik-server-go/test/chat_test.go
+++ b/iznik-server-go/test/chat_test.go
@@ -4213,3 +4213,76 @@ func TestGetChats_EdgeCases(t *testing.T) {
 	db.Exec("DELETE FROM chat_rooms WHERE id = ?", chatID)
 	db.Exec("UPDATE users SET deleted = NULL WHERE id = ?", user2ID)
 }
+
+// TestAllSeenOnlyAffectsCallerRoster is an adversarial test that verifies AllSeen
+// only modifies the CALLER's own roster entries — never the other party's.
+// This covers the risk of accidentally clearing another user's unseen counter.
+func TestAllSeenOnlyAffectsCallerRoster(t *testing.T) {
+	prefix := uniquePrefix("allseen_iso")
+	db := database.DBConn
+	user1ID := CreateTestUser(t, prefix+"_u1", "User")
+	user2ID := CreateTestUser(t, prefix+"_u2", "User")
+	_, tokenU1 := CreateTestSession(t, user1ID)
+
+	chatID := CreateTestChatRoom(t, user1ID, &user2ID, nil, "User2User")
+	msg1ID := CreateTestChatMessage(t, chatID, user1ID, "msg from user1")
+	_ = msg1ID
+	msg2ID := CreateTestChatMessage(t, chatID, user1ID, "msg2 from user1")
+
+	// Give user2 a known, non-zero lastmsgseen so we can detect any unwanted change.
+	const user2KnownSeen = uint64(1)
+	db.Exec("INSERT INTO chat_roster (chatid, userid, status, lastmsgseen, date) VALUES (?, ?, 'Online', ?, NOW()) ON DUPLICATE KEY UPDATE lastmsgseen = ?",
+		chatID, user2ID, user2KnownSeen, user2KnownSeen)
+	db.Exec("INSERT INTO chat_roster (chatid, userid, status, lastmsgseen, date) VALUES (?, ?, 'Online', 0, NOW()) ON DUPLICATE KEY UPDATE lastmsgseen = 0",
+		chatID, user1ID)
+
+	// user1 calls AllSeen.
+	payload := map[string]interface{}{"action": "AllSeen"}
+	body, _ := json2.Marshal(payload)
+	req := httptest.NewRequest("POST", "/api/chatrooms?jwt="+tokenU1, bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+
+	// user1's lastmsgseen must advance to the latest message.
+	var u1Seen uint64
+	db.Raw("SELECT lastmsgseen FROM chat_roster WHERE chatid = ? AND userid = ?", chatID, user1ID).Scan(&u1Seen)
+	assert.Equal(t, msg2ID, u1Seen, "user1's lastmsgseen should advance to latest message")
+
+	// user2's lastmsgseen must be EXACTLY what it was before — AllSeen must not touch it.
+	var u2Seen uint64
+	db.Raw("SELECT lastmsgseen FROM chat_roster WHERE chatid = ? AND userid = ?", chatID, user2ID).Scan(&u2Seen)
+	assert.Equal(t, user2KnownSeen, u2Seen, "AllSeen must not modify the other party's lastmsgseen")
+}
+
+// TestAllSeenIsolatedAcrossUsers verifies that user B calling AllSeen has zero
+// effect on user A's roster entries in shared chats.
+func TestAllSeenIsolatedAcrossUsers(t *testing.T) {
+	prefix := uniquePrefix("allseen_xuser")
+	db := database.DBConn
+	userAID := CreateTestUser(t, prefix+"_a", "User")
+	userBID := CreateTestUser(t, prefix+"_b", "User")
+	_, tokenB := CreateTestSession(t, userBID)
+
+	chatID := CreateTestChatRoom(t, userAID, &userBID, nil, "User2User")
+	CreateTestChatMessage(t, chatID, userBID, "hello")
+	CreateTestChatMessage(t, chatID, userBID, "world")
+
+	// Give userA a specific, non-trivial lastmsgseen.
+	const userAKnownSeen = uint64(999)
+	db.Exec("INSERT INTO chat_roster (chatid, userid, status, lastmsgseen, date) VALUES (?, ?, 'Online', ?, NOW()) ON DUPLICATE KEY UPDATE lastmsgseen = ?",
+		chatID, userAID, userAKnownSeen, userAKnownSeen)
+
+	// userB calls AllSeen.
+	payload := map[string]interface{}{"action": "AllSeen"}
+	body, _ := json2.Marshal(payload)
+	req := httptest.NewRequest("POST", "/api/chatrooms?jwt="+tokenB, bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+
+	// userA's lastmsgseen must remain exactly userAKnownSeen regardless.
+	var aSeenAfter uint64
+	db.Raw("SELECT lastmsgseen FROM chat_roster WHERE chatid = ? AND userid = ?", chatID, userAID).Scan(&aSeenAfter)
+	assert.Equal(t, userAKnownSeen, aSeenAfter, "AllSeen for userB must not modify userA's lastmsgseen")
+}


### PR DESCRIPTION
## Summary

- Fixes ModTools chat unread badge that won't clear after "Mark all read" (Discourse topic 9518)
- Root cause: \`markAllRead()\` iterated visible chats per-chat, calling \`markRead(chat.id)\` for each. This silently failed when \`chat.lastmsg\` was 0, leaving the badge stuck.
- Fix (MT): \`chatStore.markAllReadMT()\` calls server-side \`AllSeen\` atomically, resets \`currentCountMT = 0\`.
- Fix (FD): \`chatStore.markAllRead()\` now also calls \`AllSeen\` (one HTTP call instead of N) and resets all \`unseen\` counts optimistically.
- Adversarial Go tests (\`TestAllSeenOnlyAffectsCallerRoster\`, \`TestAllSeenIsolatedAcrossUsers\`) prove WHERE clause scopes changes only to the calling user.

## Code Quality Review

- Server-side: \`handleAllSeen\` uses \`WHERE userid = ?\` with JWT-derived \`myid\` — cannot be manipulated by caller.
- Both MT and FD paths now use a single \`allSeen()\` API call instead of N \`markRead\` calls.
- TDD: store tests verify contract; page test verifies delegation; Go tests verify server isolation.

## Test Plan

- [x] Go tests: 2185 pass (includes 2 new adversarial isolation tests)
- [x] Vitest: 12,045 pass (includes 3 new store tests + 1 new page test)
- [ ] CI: waiting