### PR TITLE
fix(migration): clean up orphaned Pending rows from PR #248 withdrawal regression

### DIFF
--- a/iznik-batch/database/migrations/2026_04_28_000002_fix_orphaned_pending_messages_groups_deleted.php
+++ b/iznik-batch/database/migrations/2026_04_28_000002_fix_orphaned_pending_messages_groups_deleted.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    // PR #248 (2026-04-23) soft-deleted messages on member withdrawal but did not set
+    // messages_groups.deleted = 1. This left orphaned Pending rows visible in Old ModTools
+    // (V1 query 2 lacks messages.deleted IS NULL filter) but invisible in Live ModTools
+    // (Go API filters m.deleted IS NULL). PR #284 added the messages_groups update for
+    // future withdrawals; this migration cleans up any records created in between.
+    public function up(): void
+    {
+        DB::statement(
+            "UPDATE messages_groups mg
+             INNER JOIN messages m ON m.id = mg.msgid
+             SET mg.deleted = 1
+             WHERE mg.collection = 'Pending'
+               AND mg.deleted = 0
+               AND m.deleted IS NOT NULL"
+        );
+    }
+
+    public function down(): void
+    {
+        // No rollback: we cannot distinguish these rows from legitimately deleted ones.
+    }
+};


### PR DESCRIPTION
## Summary

- Adds a one-shot migration to set `messages_groups.deleted = 1` for any Pending row whose `messages` row is already soft-deleted (`messages.deleted IS NOT NULL`)
- Fixes the 5-day visibility gap between PR #248 (2026-04-23) and PR #284 (2026-04-28) that caused pending messages to be invisible in Live ModTools but visible in Old ModTools

## Root Cause

PR #248 fixed the withdrawal handler to use soft-delete (`UPDATE messages SET deleted=NOW()`) instead of hard-DELETE — preventing the 403 error mods saw when acting on already-withdrawn messages. However, it only updated `messages.deleted` and did **not** also set `messages_groups.deleted = 1`.

This left orphaned rows in a split state:
- `messages.deleted IS NOT NULL` (message is soft-deleted)
- `messages_groups.collection = 'Pending'`, `deleted = 0` (group row still active)

**Go API (Live ModTools)**: filters `AND m.deleted IS NULL` → message **invisible** ✗  
**V1 PHP query 2 (Old ModTools)**: no `messages.deleted` filter → message **visible** ✓

PR #284 (2026-04-28) fixed the code path so future withdrawals set both fields. This migration backfills any records created in the ~5-day window between the two PRs.

## Test plan

- [x] Laravel 1684 tests pass
- [x] Go 553 tests pass (6 pre-existing AIImageRegen failures unrelated to this change)
- Migration SQL is idempotent: running it twice produces the same result
- `down()` left empty as rollback is not meaningful for a data-cleanup migration

Fixes Discourse topic 9622 (pending messages missing from Live ModTools).
🤖 Generated with [Claude Code](https://claude.com/claude-code)