### PR TITLE
fix(modtools): chat review — member box visibility, correct From: group, User2Mod To: label, self-talking

### DIFF
--- a/iznik-nuxt3/modtools/components/ModChatModal.vue
+++ b/iznik-nuxt3/modtools/components/ModChatModal.vue
@@ -195,6 +195,8 @@ const user2 = computed(() => {
   if (!chat2.value) return null
   const u1id = resolveUserId(chat2.value.user1)
   const u2id = resolveUserId(chat2.value.user2)
+  // User2Mod: user2=0/null in DB — no real second participant on the right.
+  if (!u2id) return null
   // Show the pov user on the right; if pov matches neither participant, show u2 (not u1,
   // which would make both sides show the same person as user1 computed).
   const id = u2id === props.pov ? u2id : u1id === props.pov ? u1id : u2id

--- a/iznik-nuxt3/modtools/components/ModChatModal.vue
+++ b/iznik-nuxt3/modtools/components/ModChatModal.vue
@@ -195,10 +195,9 @@ const user2 = computed(() => {
   if (!chat2.value) return null
   const u1id = resolveUserId(chat2.value.user1)
   const u2id = resolveUserId(chat2.value.user2)
-  // User2Mod: user2=0 in DB (no real second participant) — show nothing on the right
-  if (!u2id) return null
-  // Show the pov user on the right
-  const id = u2id === props.pov ? u2id : u1id
+  // Show the pov user on the right; if pov matches neither participant, show u2 (not u1,
+  // which would make both sides show the same person as user1 computed).
+  const id = u2id === props.pov ? u2id : u1id === props.pov ? u1id : u2id
   return id ? userStore.byId(id) : null
 })
 

--- a/iznik-nuxt3/modtools/components/ModChatReview.vue
+++ b/iznik-nuxt3/modtools/components/ModChatReview.vue
@@ -25,7 +25,7 @@
               class="mt-1 text-info"
             />
             <ModChatReviewUser
-              v-if="message.touserid != null || message.touser"
+              v-if="message.touserid || message.touser"
               :userid="message.touserid || message.touser?.id"
               class="ms-2"
               tag="To: "

--- a/iznik-nuxt3/modtools/components/ModChatReview.vue
+++ b/iznik-nuxt3/modtools/components/ModChatReview.vue
@@ -25,7 +25,7 @@
               class="mt-1 text-info"
             />
             <ModChatReviewUser
-              v-if="message.touserid || message.touser"
+              v-if="message.touserid != null || message.touser"
               :userid="message.touserid || message.touser?.id"
               class="ms-2"
               tag="To: "

--- a/iznik-nuxt3/modtools/components/ModChatReview.vue
+++ b/iznik-nuxt3/modtools/components/ModChatReview.vue
@@ -11,10 +11,10 @@
               class="me-2"
               tag="From: "
               :groupid="
-                message.groupid ||
-                message.group?.id ||
                 message.groupidfrom ||
                 message.groupfrom?.id ||
+                message.groupid ||
+                message.group?.id ||
                 0
               "
               @reload="reload"
@@ -38,6 +38,13 @@
               "
               @reload="reload"
             />
+            <span
+              v-else-if="chatroomName"
+              class="ms-2 align-self-center"
+              data-testid="user2mod-to"
+            >
+              <strong>To: </strong>{{ chatroomName }} Volunteers
+            </span>
           </div>
           <div v-if="message.bymailid || message.msgid">
             <b-button variant="white" class="ms-2" @click="showOriginal = true">
@@ -265,12 +272,24 @@ const authStore = useAuthStore()
 
 const message = computed(() => chatStore.messageById(props.messageid))
 
+// Use a consistent pov based on the chatroom's user2, not the per-message touser.
+// This ensures messages from user1 always appear on the left and user2 on the right,
+// regardless of which direction the reviewed message was sent.
+// For User2Mod chats (user2=NULL in DB, touserid=0), show the chatroom's group name in the To: position.
+// The chatroom name for User2Mod is the mod group's short name (set by Go API).
+const chatroomName = computed(() => {
+  const chatroom = chatStore.byChatId(message.value?.chatid)
+  if (!chatroom || chatroom.chattype !== 'User2Mod') return null
+  return chatroom.name || null
+})
+
 // Use touserid (the recipient of the reviewed message) as pov so the sender always
-// appears on the left. Falling back to chat.user2 was wrong when the sender IS user2.
+// appears on the left in View Chat. chat.user2 was wrong when the sender IS user2 —
+// it placed the suspicious sender on the right as "self", masking who sent the message.
 const chatPov = computed(() => {
   const touserid = message.value?.touserid
   if (touserid) return touserid
-  // touserid=0 or absent (e.g. User2Mod with no specific recipient) — fall back to
+  // touserid=0 or absent (User2Mod with no specific recipient) — fall back to
   // chat.user2, which is also 0 for User2Mod and becomes null via ||.
   const chat = chatStore.byChatId(message.value?.chatid)
   if (chat) return chat.user2 || null

--- a/iznik-nuxt3/modtools/components/ModChatReviewUser.vue
+++ b/iznik-nuxt3/modtools/components/ModChatReviewUser.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="user" class="bg-white rounded border border-info p-2">
+  <div v-if="userid" class="bg-white rounded border border-info p-2">
     <div>
       {{ tag }}<strong>{{ user ? user.displayname : '#' + userid }}</strong>
       <span class="small">

--- a/iznik-nuxt3/tests/unit/components/modtools/ModChatModal.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModChatModal.spec.js
@@ -672,6 +672,28 @@ describe('ModChatModal', () => {
       expect(component.vm.user2).toEqual(user2)
     })
 
+    it('when pov is touserid (recipient), sender appears on left and recipient on right', async () => {
+      // Symptom 2 (Carol1 #219): chatPov used chat.user2 (sender) placing the suspicious
+      // sender on the right as "self". Fixed chatPov now uses touserid (recipient) as pov,
+      // so this modal receives pov=recipient → sender appears on the left (correct view).
+      const sender = createUser({ id: 200, displayname: 'Sender' })
+      const recipient = createUser({ id: 100, displayname: 'Recipient' })
+      registerUsers(sender, recipient)
+      // DB: user1=100 (recipient), user2=200 (sender of suspicious message)
+      const chat = createChat({ user1: 100, user2: 200 })
+      mockChatStore.byChatId.mockReturnValue(chat)
+
+      const wrapper = await mountComponent({ id: 123, pov: 100 }) // pov = recipient
+      const component = getModChatModal(wrapper)
+      component.vm.chat2 = chat
+      await nextTick()
+
+      // user1 (left slot): u1id(100) === pov(100) → swap → id=u2id=200 → sender on left ✓
+      expect(component.vm.user1).toEqual(sender)
+      // user2 (right/self slot): u2id(200)===pov(100)? No → u1id(100)===pov(100)? Yes → id=100 → recipient ✓
+      expect(component.vm.user2).toEqual(recipient)
+    })
+
     it('handles empty chat messages array', async () => {
       const chat = createChat()
       mockChatStore.byChatId.mockReturnValue(chat)

--- a/iznik-nuxt3/tests/unit/components/modtools/ModChatModal.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModChatModal.spec.js
@@ -635,7 +635,7 @@ describe('ModChatModal', () => {
       expect(component.vm.user1).toBe(null)
     })
 
-    it('returns null for user2 when user2 is null (User2Mod: no second participant)', async () => {
+    it('handles chat with null user2 by falling back to user1 when pov matches user1', async () => {
       const onlyUser = createUser({ id: 456, displayname: 'Only User' })
       registerUsers(onlyUser)
       const chat = createChat({ user1: 456, user2: null })
@@ -646,7 +646,30 @@ describe('ModChatModal', () => {
       component.vm.chat2 = chat
       await nextTick()
 
-      expect(component.vm.user2).toBe(null)
+      // When pov matches u1id and user2 is null (u2id=0), falls back to u1id (pov user on right)
+      expect(component.vm.user2).toEqual(onlyUser)
+    })
+
+    it('returns u2id (not u1id) when pov matches neither participant, preventing self-talking', async () => {
+      // Bug C: when pov doesn't match u2id, the old code fell back to u1id unconditionally.
+      // If pov also doesn't match u1id, both user1 and user2 computed resolve to u1id — self-talking.
+      const user1 = createUser({ id: 456, displayname: 'User One' })
+      const user2 = createUser({ id: 789, displayname: 'User Two' })
+      registerUsers(user1, user2)
+      // pov=999 matches neither participant (edge case: stale pov after store update)
+      const chat = createChat({ user1: 456, user2: 789 })
+      mockChatStore.byChatId.mockReturnValue(chat)
+
+      const wrapper = await mountComponent({ id: 123, pov: 999 })
+      const component = getModChatModal(wrapper)
+      component.vm.chat2 = chat
+      await nextTick()
+
+      // user1 computed: u1id(456) !== pov(999) → id=456 → User One
+      expect(component.vm.user1).toEqual(user1)
+      // user2 computed (fixed): should fall back to u2id(789), not u1id(456)
+      // Old code: u2id(789) !== pov(999) → fell back to u1id(456) → same as user1 (self-talking)
+      expect(component.vm.user2).toEqual(user2)
     })
 
     it('handles empty chat messages array', async () => {

--- a/iznik-nuxt3/tests/unit/components/modtools/ModChatModal.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModChatModal.spec.js
@@ -635,7 +635,7 @@ describe('ModChatModal', () => {
       expect(component.vm.user1).toBe(null)
     })
 
-    it('handles chat with null user2 by falling back to user1 when pov matches user1', async () => {
+    it('returns null for user2 when user2 is null (User2Mod: no second participant)', async () => {
       const onlyUser = createUser({ id: 456, displayname: 'Only User' })
       registerUsers(onlyUser)
       const chat = createChat({ user1: 456, user2: null })
@@ -646,8 +646,7 @@ describe('ModChatModal', () => {
       component.vm.chat2 = chat
       await nextTick()
 
-      // When pov matches u1id and user2 is null (u2id=0), falls back to u1id (pov user on right)
-      expect(component.vm.user2).toEqual(onlyUser)
+      expect(component.vm.user2).toBe(null)
     })
 
     it('returns u2id (not u1id) when pov matches neither participant, preventing self-talking', async () => {

--- a/iznik-nuxt3/tests/unit/components/modtools/ModChatReview.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModChatReview.spec.js
@@ -80,6 +80,7 @@ describe('ModChatReview', () => {
             props: ['icon', 'scale'],
           },
           ModChatReviewUser: {
+            name: 'ModChatReviewUser',
             template: '<div class="chat-review-user" />',
             props: ['userid', 'tag', 'groupid'],
             emits: ['reload'],
@@ -589,35 +590,98 @@ describe('ModChatReview', () => {
     })
   })
 
-  describe('groupid fallback to groupidfrom', () => {
-    it('passes groupidfrom to ModChatReviewUser when groupid is 0', () => {
-      const wrapper = mountComponent({
-        groupid: 0,
-        group: null,
-        groupidfrom: 555,
-        groupfrom: { id: 555, namedisplay: 'Sender Group' },
-      })
-      const reviewUsers = wrapper.findAllComponents({
-        name: 'ModChatReviewUser',
-      })
-      reviewUsers.forEach((u) => {
-        expect(u.props('groupid')).toBe(555)
-      })
-    })
-
-    it('prefers groupid over groupidfrom when both are set', () => {
+  describe('groupid priority: From uses groupidfrom (sender), To uses groupid (recipient)', () => {
+    it('From: panel gets groupidfrom and To: panel gets groupid when both are set', () => {
+      // Bug A: From: was incorrectly prioritising groupid (recipient group) over groupidfrom (sender group).
       const wrapper = mountComponent({
         groupid: 789,
         group: { id: 789, namedisplay: 'Recipient Group' },
         groupidfrom: 555,
         groupfrom: { id: 555, namedisplay: 'Sender Group' },
+        touserid: 200,
+        touser: { id: 200, displayname: 'To User', spammer: false },
       })
-      const reviewUsers = wrapper.findAllComponents({
-        name: 'ModChatReviewUser',
+      const reviewUsers = wrapper.findAllComponents({ name: 'ModChatReviewUser' })
+      // First = From:, gets sender's group (groupidfrom)
+      expect(reviewUsers[0].props('groupid')).toBe(555)
+      // Second = To:, gets recipient's group (groupid)
+      expect(reviewUsers[1].props('groupid')).toBe(789)
+    })
+
+    it('both panels fall back to groupidfrom when groupid is 0', () => {
+      const wrapper = mountComponent({
+        groupid: 0,
+        group: null,
+        groupidfrom: 555,
+        groupfrom: { id: 555, namedisplay: 'Sender Group' },
+        touserid: 200,
+        touser: { id: 200, displayname: 'To User', spammer: false },
       })
+      const reviewUsers = wrapper.findAllComponents({ name: 'ModChatReviewUser' })
       reviewUsers.forEach((u) => {
-        expect(u.props('groupid')).toBe(789)
+        expect(u.props('groupid')).toBe(555)
       })
+    })
+  })
+
+  describe('User2Mod: To: position shows chatroom name', () => {
+    beforeEach(() => {
+      // Override byChatId to return a User2Mod chatroom with a name
+      globalThis.__mockChatStore.byChatId = vi.fn(() => ({
+        user1: 100,
+        user2: 0,
+        chattype: 'User2Mod',
+        name: 'TestGroup',
+        groupid: 555,
+      }))
+    })
+
+    it('shows chatroom name in To: position when touserid is 0 (User2Mod)', () => {
+      // Bug B: To: ModChatReviewUser was hidden entirely for User2Mod (touserid=0).
+      const wrapper = mountComponent({
+        touserid: 0,
+        touser: null,
+      })
+      // No ModChatReviewUser for To: (userid=0 is not a real user)
+      const reviewUsers = wrapper.findAllComponents({ name: 'ModChatReviewUser' })
+      expect(reviewUsers.length).toBe(1) // only From:
+      // But the chatroom name should appear as the To: label
+      expect(wrapper.find('[data-testid="user2mod-to"]').exists()).toBe(true)
+      expect(wrapper.text()).toContain('To:')
+      expect(wrapper.text()).toContain('TestGroup Volunteers')
+    })
+
+    it('does not show chatroom name when touserid is set (User2User chat)', () => {
+      globalThis.__mockChatStore.byChatId = vi.fn(() => ({
+        user1: 100,
+        user2: 200,
+        chattype: 'User2User',
+        name: 'SomeChat',
+        groupid: 0,
+      }))
+      const wrapper = mountComponent({
+        touserid: 200,
+        touser: { id: 200, displayname: 'To User', spammer: false },
+      })
+      expect(wrapper.find('[data-testid="user2mod-to"]').exists()).toBe(false)
+      const reviewUsers = wrapper.findAllComponents({ name: 'ModChatReviewUser' })
+      expect(reviewUsers.length).toBe(2) // From: and To:
+    })
+
+    it('chatroomName computed returns null for User2User chattype', () => {
+      globalThis.__mockChatStore.byChatId = vi.fn(() => ({
+        user1: 100,
+        user2: 200,
+        chattype: 'User2User',
+        name: 'SomeChat',
+      }))
+      const wrapper = mountComponent({ touserid: 0, touser: null })
+      expect(wrapper.vm.chatroomName).toBeNull()
+    })
+
+    it('chatroomName computed returns name for User2Mod chattype', () => {
+      const wrapper = mountComponent({ touserid: 0, touser: null })
+      expect(wrapper.vm.chatroomName).toBe('TestGroup')
     })
   })
 

--- a/iznik-nuxt3/tests/unit/components/modtools/ModChatReview.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModChatReview.spec.js
@@ -557,24 +557,33 @@ describe('ModChatReview', () => {
       expect(wrapper.vm.chatPov).toBeNull()
     })
 
-    it('uses touserid (recipient) as pov for User2Mod chat when touserid is valid', () => {
-      // Bug: chatPov was returning null (chat.user2=0→null) even when touserid was a real recipient
-      // Fix: always prefer touserid so the sender appears on the left
+    it('prefers touserid (recipient) as pov even when chat is loaded', () => {
+      // Symptom 2 fix: chatPov used to return chat.user2 when the chat was loaded,
+      // ignoring touserid. This placed the sender on the right as "self" in View Chat.
+      // Fix: always prefer touserid so the sender appears on the LEFT (correct reviewer POV).
       globalThis.__mockChatStore.byChatId = vi.fn(() => ({
         user1: 100,
         user2: 0,
         chattype: 'User2Mod',
       }))
       const wrapper = mountComponent({ touserid: 999 })
-      expect(wrapper.find('.chat-view-button').exists()).toBe(true)
+      const viewButton = wrapper.find('.chat-view-button')
+      // touserid present → use it (not chat.user2=0→null)
+      expect(viewButton.exists()).toBe(true)
       expect(wrapper.vm.chatPov).toBe(999)
     })
 
-    it('uses touserid (recipient) as pov even when chat is loaded, so sender stays on left', () => {
-      // Bug: when sender=user2 (789), chatPov=chat.user2=789 puts the sender on the right
-      // Fix: always prefer touserid (the recipient) so the sender appears on the left
-      const wrapper = mountComponent({ touserid: 200 })
-      expect(wrapper.vm.chatPov).toBe(200)
+    it('uses touserid (recipient) as pov for User2User so sender appears on left in View Chat', () => {
+      // Symptom 2 (Carol1 #219): chatPov=chat.user2 (sender) put the suspicious sender
+      // on the right as "self". Fix: chatPov=touserid (recipient) puts sender on the left.
+      globalThis.__mockChatStore.byChatId = vi.fn(() => ({
+        user1: 100,
+        user2: 200,
+        chattype: 'User2User',
+      }))
+      const wrapper = mountComponent({ touserid: 100 })
+      // pov = recipient (100), so sender (200) appears on the left in View Chat
+      expect(wrapper.vm.chatPov).toBe(100)
     })
 
     it('falls back to message.touserid when chat not found', () => {

--- a/iznik-nuxt3/tests/unit/components/modtools/ModChatReviewUser.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModChatReviewUser.spec.js
@@ -70,6 +70,31 @@ describe('ModChatReviewUser', () => {
   })
 
   describe('rendering', () => {
+    it('renders the box when userid is provided but user data not yet in store', () => {
+      // Symptom 1 (Carol1 #219): box was gated by v-if="user" — hidden entirely until
+      // the user API fetch completed, causing member info to be missing on initial render.
+      // Fix: v-if="userid" renders the box immediately, showing '#<id>' as fallback.
+      mockUserStore.byId.mockReturnValue(null) // user not yet fetched
+      const wrapper = mount(ModChatReviewUser, {
+        props: { userid: 123, groupid: 456 },
+        global: {
+          stubs: {
+            'b-button': { template: '<button><slot /></button>' },
+            'v-icon': { template: '<span />', props: ['icon', 'scale'] },
+            ExternalLink: { template: '<a><slot /></a>', props: ['href'] },
+            ModClipboard: { template: '<span />', props: ['value'] },
+            ModComment: { template: '<div />', props: ['commentid', 'userid'] },
+            ModCommentAddModal: {
+              template: '<div class="add-modal" />',
+              props: ['userid', 'groupid'],
+            },
+          },
+        },
+      })
+      expect(wrapper.find('.bg-white.rounded').exists()).toBe(true)
+      expect(wrapper.text()).toContain('#123')
+    })
+
     it('renders user id', () => {
       const wrapper = mountComponent()
       expect(wrapper.text()).toContain('123')

--- a/iznik-nuxt3/tests/unit/pages/modtools/AIImageReview.spec.js
+++ b/iznik-nuxt3/tests/unit/pages/modtools/AIImageReview.spec.js
@@ -2,9 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import { ref } from 'vue'
-
-// definePageMeta is a Nuxt compiler macro not available in Vitest
-globalThis.definePageMeta = vi.fn()
+import ImagesPage from '~/modtools/pages/images/index.vue'
 
 // Mock useMe composable
 vi.mock('~/composables/useMe', () => ({
@@ -55,8 +53,6 @@ const stubComponents = {
   'b-alert': { template: '<div class="alert"><slot /></div>' },
 }
 
-let ImagesPage
-
 beforeEach(async () => {
   setActivePinia(createPinia())
   mockImages.value = []
@@ -64,11 +60,6 @@ beforeEach(async () => {
   mockFetchReview.mockReset()
   mockRegenerate.mockReset()
   mockAccept.mockReset()
-  // Dynamic import so mocks are applied first.
-  // Vite's import-analysis doesn't support dynamic imports with ~ alias.
-  // Using a relative path from the vitest working directory.
-  const mod = await import('./../../../../modtools/pages/images/index.vue')
-  ImagesPage = mod.default
 })
 
 describe('Images page', () => {

--- a/iznik-nuxt3/tests/unit/pages/modtools/AIImageReview.spec.js
+++ b/iznik-nuxt3/tests/unit/pages/modtools/AIImageReview.spec.js
@@ -65,7 +65,9 @@ beforeEach(async () => {
   mockRegenerate.mockReset()
   mockAccept.mockReset()
   // Dynamic import so mocks are applied first.
-  const mod = await import('~/modtools/pages/images/index.vue')
+  // Vite's import-analysis doesn't support dynamic imports with ~ alias.
+  // Using a relative path from the vitest working directory.
+  const mod = await import('./../../../../modtools/pages/images/index.vue')
   ImagesPage = mod.default
 })
 

--- a/iznik-nuxt3/tests/unit/setup.ts
+++ b/iznik-nuxt3/tests/unit/setup.ts
@@ -132,6 +132,9 @@ const mockNuxtApp = {
 // Mock defineNuxtPlugin (auto-imported by Nuxt, returns the plugin function as-is)
 ;(globalThis as Record<string, unknown>).defineNuxtPlugin = (plugin: unknown) => plugin
 
+// Mock definePageMeta (Nuxt compiler macro, no-op in tests)
+;(globalThis as Record<string, unknown>).definePageMeta = () => {}
+
 // Mock useCookie
 ;(globalThis as Record<string, unknown>).useCookie = () => ref(null)
 


### PR DESCRIPTION
## Summary

Follow-up to #312. Fixes bugs in ModTools chat review (Discourse topic 9518 / Carol1 report #219):

- **Member box invisible until user data loads** (`ModChatReviewUser`): `v-if="user"` hid the box entirely until the store had fetched the user. Changed to `v-if="userid"` so the box renders immediately (showing `#<id>` as fallback).
- **From: showed wrong group** (`ModChatReview`): `groupid` (recipient's group) was checked before `groupidfrom` (sender's group). Swapped priority so From: correctly shows the sender's group.
- **User2Mod To: showed nothing** (`ModChatReview`): When reviewing a User2Mod message (`touserid=0`), the To: slot was empty. Now shows "To: GroupName Volunteers" using the chatroom name from the store.
- **"Talking to themselves"** (`ModChatModal`): `user2` computed fell back to `u1id` unconditionally when pov matched neither participant, making both sides show the same person. Fixed to fall back to `u2id` instead.

## Adversarial review findings (commit 79ac5399d)

Three regressions introduced by commit 682c36ee1 (`handle touserid=0`) were caught in adversarial review and fixed:

1. **`ModChatReview.vue` v-if flip**: `v-if="message.touserid != null || message.touser"` evaluated true when `touserid=0` (JS: `0 != null` is `true`), blocking `v-else-if="chatroomName"` from ever firing. Reverted to `v-if="message.touserid || message.touser"` (treats 0 as falsy, same as original).

2. **`ModChatModal.vue` User2Mod guard removed**: The `if (!u2id) return null` guard in `user2` computed was deleted. Without it, User2Mod chats (u2id=0→null) fell through to the pov-matching logic and returned the sender on the right side (self-talking). Restored the guard.

3. **`ModChatModal.spec.js` inconsistent expectation**: One User2Mod test at line 638 was updated to expect `onlyUser` instead of `null`, while the identical test at line 447 still expected `null`. Reverted line 638 back to `null` for consistency.

## Test plan

- [ ] Vitest: `ModChatReview.spec.js`, `ModChatModal.spec.js`, `ModChatReviewUser.spec.js` all pass
- [ ] Open a User2Mod message in ModTools chat review — To: should show "GroupName Volunteers"
- [ ] From: should show the sender's group, not the recipient's
- [ ] Member boxes should be visible immediately on open, not after a delay