### PR TITLE
fix(compose): preserve user-selected group during repost

### DIFF
--- a/iznik-nuxt3/components/ComposeGroup.vue
+++ b/iznik-nuxt3/components/ComposeGroup.vue
@@ -140,17 +140,19 @@ onMounted(async () => {
 
   // Final guard: b-form-select may have reset composeStore.group during the
   // async fetchUser wait (options re-evaluated while the saved group wasn't in
-  // groupsnear yet). Restore savedGroup if it is still valid — i.e. present in
-  // groupsnear or among the user's group memberships.
+  // groupsnear yet). If the user changed the group, verify their selection is
+  // valid; if not, fall back to the original group.
   if (savedGroup && composeStore.group !== savedGroup) {
     const groupsNear = postcode.value?.groupsnear || []
-    const savedGroupValid =
-      groupsNear.some((g) => parseInt(g.id) === parseInt(savedGroup)) ||
-      myGroups.value.some((g) => parseInt(g.groupid) === parseInt(savedGroup))
+    const userSelectedGroupValid =
+      groupsNear.some((g) => parseInt(g.id) === parseInt(composeStore.group)) ||
+      myGroups.value.some((g) => parseInt(g.groupid) === parseInt(composeStore.group))
 
-    if (savedGroupValid) {
+    if (!userSelectedGroupValid) {
+      // User selected a group that's not in the available lists; fall back to original
       composeStore.group = savedGroup
     }
+    // else: keep the user's selection since it's valid
   }
 
   // If we have a postcode with groups but no group selected, auto-select the first one.

--- a/iznik-nuxt3/tests/unit/components/ComposeGroup.spec.js
+++ b/iznik-nuxt3/tests/unit/components/ComposeGroup.spec.js
@@ -295,6 +295,31 @@ describe('ComposeGroup', () => {
       // Group 99 is invalid, so the override (1) should stand
       expect(mockComposeStore.group).toBe(1)
     })
+
+    it('preserves user-selected group during repost when new group is valid', async () => {
+      // Bug fix: when user selects a different group during repost, preserve it if valid
+      // Initial state: group 1 (Bicester) is pre-set from repost
+      mockComposeStore.group = 1
+      // User is member of both group 1 and group 2 (Oxford)
+      mockAuthStore.groups = [
+        { groupid: 1, namedisplay: 'Bicester', nameshort: 'bicester' },
+        { groupid: 2, namedisplay: 'Oxford', nameshort: 'oxford' },
+      ]
+      // Simulate fetchUser not changing the group immediately
+      mockAuthStore.fetchUser = vi.fn().mockResolvedValue(undefined)
+
+      const wrapper = createWrapper()
+
+      // User selects Oxford before fetchUser completes
+      await wrapper.find('.form-select').setValue('2')
+      expect(mockComposeStore.group).toBe('2')
+
+      // Wait for fetchUser and final guard logic
+      await flushPromises()
+
+      // Group should remain 2 (Oxford) because it's valid (user is member)
+      expect(mockComposeStore.group).toBe('2')
+    })
   })
 
   describe('error handling', () => {


### PR DESCRIPTION
## Summary
- Fixed bug where repost group selection dropdown was ignored
- User selects different group (e.g., Oxford instead of Bicester) → correctly preserves selection
- Previous behavior: reverted to original group after async operations

## Root Cause
ComposeGroup.vue's final guard logic (lines 145-154) had inverted validation:
- Saved original group before async operations
- When user selected different group, checked if ORIGINAL was valid
- If original was valid, RESTORED it (erasing user's choice)

Should have checked: is USER'S selection valid? Keep it if yes, fallback to original if no.

## Changes
- `iznik-nuxt3/components/ComposeGroup.vue`: Fixed validation logic in final guard
- `iznik-nuxt3/tests/unit/components/ComposeGroup.spec.js`: Added test case verifying user selection is preserved

## Code Quality Review
- ✓ Logic corrected: now validates user-selected group, not original group
- ✓ Comments updated to reflect correct behavior
- ✓ Preserves fallback to original group if user's selection is invalid
- ✓ No new dependencies or complexity introduced
- ✓ Follows existing code patterns in ComposeGroup

## Test Plan
**Unit tests:**
- New test: "preserves user-selected group during repost when new group is valid"
- Existing tests continue to pass

**E2E tests:**
- Existing test: `tests/e2e/test-repost-group-change.spec.js`
  - Tests the exact scenario: repost from Bicester to Oxford
  - Verifies group persists through async operations and navigation
  - Should now PASS with this fix (was failing before)

**Manual testing:**
1. Create offer in one group (e.g., Bicester)
2. Repost it
3. Select different group from dropdown (e.g., Oxford)
4. Verify it reposts to selected group, not original

## Notes
- Only affects the compose/repost flow when user changes group selection
- Does not affect other group selection scenarios
- Fixes Discourse topic 9635 report by user John1