### PR TITLE
fix(modtools): fix feedback jumping when toggling expired posts filter

### DIFF
--- a/iznik-nuxt3/modtools/pages/members/feedback.vue
+++ b/iznik-nuxt3/modtools/pages/members/feedback.vue
@@ -218,7 +218,9 @@ watch(tabIndex, () => {
 })
 
 watch(showExpired, () => {
+  context.value = null
   show.value = 0
+  memberStore.clear()
   bump.value++
 })
 

--- a/iznik-nuxt3/tests/unit/pages/modtools/members/Feedback.spec.js
+++ b/iznik-nuxt3/tests/unit/pages/modtools/members/Feedback.spec.js
@@ -653,4 +653,86 @@ describe('Feedback Page', () => {
       ])
     })
   })
+
+  describe('showExpired watcher: state consistency', () => {
+    it('clears memberStore when showExpired changes', async () => {
+      const wrapper = mountComponent()
+      await flushPromises()
+
+      // Simulate having loaded members
+      mockMemberStore.list = {
+        'member-1': { id: 1, happiness: 'Happy', outcome: 'Expired' },
+        'member-2': { id: 2, happiness: 'Happy', outcome: 'Taken' },
+      }
+      mockMembers.value = [
+        { id: 1, happiness: 'Happy', outcome: 'Expired' },
+        { id: 2, happiness: 'Happy', outcome: 'Taken' },
+      ]
+
+      // Sanity check: memberStore has data
+      expect(mockMemberStore.list).toHaveProperty('member-1')
+
+      // Change showExpired
+      wrapper.vm.showExpired = false
+
+      // memberStore should be cleared
+      expect(mockMemberStore.clear).toHaveBeenCalled()
+    })
+
+    it('resets context when showExpired changes', async () => {
+      const wrapper = mountComponent()
+      await flushPromises()
+
+      // Set a context value
+      mockContext.value = 'some-context'
+
+      // Change showExpired
+      wrapper.vm.showExpired = false
+
+      // context should be reset to null
+      expect(mockContext.value).toBeNull()
+    })
+
+    it('resets show and bumps identifier on showExpired change', async () => {
+      const wrapper = mountComponent()
+      await flushPromises()
+
+      mockShow.value = 5
+      const initialBump = wrapper.vm.bump
+
+      // Change showExpired
+      wrapper.vm.showExpired = false
+
+      // show should reset and bump should increment
+      expect(mockShow.value).toBe(0)
+      expect(wrapper.vm.bump).toBe(initialBump + 1)
+    })
+
+    it('showExpired watcher pattern matches filter watcher pattern', async () => {
+      // This test verifies that both watchers do equivalent cleanup
+      // Filter watcher clears: context, show, memberStore, bump
+      // showExpired watcher should do the same
+      const wrapper = mountComponent()
+      await flushPromises()
+
+      // Setup state
+      mockMembers.value = [
+        { id: 1, timestamp: '2024-01-15T10:00:00Z', happiness: 'Happy', outcome: 'Expired' },
+      ]
+      mockShow.value = 1
+      mockContext.value = 'test'
+      mockMemberStore.list = { 'member-1': mockMembers.value[0] }
+
+      const clearCallsBeforeShowExpiredChange = mockMemberStore.clear.mock.calls.length
+
+      // Toggle showExpired
+      wrapper.vm.showExpired = false
+      await flushPromises()
+
+      // Verify cleanup occurred
+      expect(mockMemberStore.clear.mock.calls.length).toBeGreaterThan(clearCallsBeforeShowExpiredChange)
+      expect(mockShow.value).toBe(0)
+      expect(mockContext.value).toBeNull()
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Fixed jumping behavior in ModTools feedback page when toggling the "hide expired posts" filter.

The bug was caused by incomplete state reset in the `showExpired` watcher. While it reset `show.value` and bumped the identifier, it didn't clear the member store or reset context like the `filter` watcher does. This left stale data in the store while the display recalculated filters, causing items to appear momentarily before disappearing (jumping effect).

## Root Cause

When filtering state changes, all related state must reset together:
1. **context**: Clears cached API state
2. **show**: Resets pagination (will reveal items incrementally from start)
3. **memberStore**: Removes old unfiltered data
4. **bump**: Resets the infinite loader identifier

The `showExpired` watcher was only doing #2 and #4.

## Fix

Applied the same cleanup pattern to `showExpired` watcher that was already implemented for the `filter` watcher. This ensures consistent behavior across all filtering operations.

## Test Plan

- Added comprehensive test suite for state consistency when toggling expired posts
- Verifies memberStore is cleared
- Verifies context is reset
- Verifies show/bump are updated
- Confirms the watcher pattern matches the filter watcher pattern

Fixes Discourse topic 9518 post 230.

🤖 Generated with Claude Code