### PR TITLE
fix(offer-repost): preserve user-selected group during async operations

### DIFF
--- a/iznik-nuxt3/components/ComposeGroup.vue
+++ b/iznik-nuxt3/components/ComposeGroup.vue
@@ -6,7 +6,7 @@
   />
 </template>
 <script setup>
-import { computed, nextTick, onMounted } from 'vue'
+import { computed, nextTick, onMounted, ref } from 'vue'
 import { useComposeStore } from '~/stores/compose'
 import { useAuthStore } from '~/stores/auth'
 import { useGroupStore } from '~/stores/group'
@@ -25,6 +25,10 @@ const composeStore = useComposeStore()
 const authStore = useAuthStore()
 const groupStore = useGroupStore()
 const runtimeConfig = useRuntimeConfig()
+
+// Track the last group value the user explicitly set via the dropdown.
+// This lets us distinguish between user-chosen values and component-driven resets.
+const lastUserSelectedGroup = ref(null)
 
 const postcode = computed(() => {
   return composeStore?.postcode
@@ -48,6 +52,8 @@ const group = computed({
     return ret
   },
   set(newVal) {
+    // Track user-initiated changes so the final guard doesn't overwrite them
+    lastUserSelectedGroup.value = newVal
     composeStore.group = newVal
   },
 })
@@ -142,13 +148,15 @@ onMounted(async () => {
   // async fetchUser wait (options re-evaluated while the saved group wasn't in
   // groupsnear yet). Restore savedGroup if it is still valid — i.e. present in
   // groupsnear or among the user's group memberships.
+  // However, respect if the user explicitly selected a different group (don't override user choice).
   if (savedGroup && composeStore.group !== savedGroup) {
     const groupsNear = postcode.value?.groupsnear || []
     const savedGroupValid =
       groupsNear.some((g) => parseInt(g.id) === parseInt(savedGroup)) ||
       myGroups.value.some((g) => parseInt(g.groupid) === parseInt(savedGroup))
 
-    if (savedGroupValid) {
+    // Only restore savedGroup if the user hasn't explicitly chosen a different one
+    if (savedGroupValid && lastUserSelectedGroup.value === null) {
       composeStore.group = savedGroup
     }
   }

--- a/iznik-nuxt3/tests/unit/components/ComposeGroup.spec.js
+++ b/iznik-nuxt3/tests/unit/components/ComposeGroup.spec.js
@@ -311,4 +311,46 @@ describe('ComposeGroup', () => {
       consoleSpy.mockRestore()
     })
   })
+
+  describe('user-initiated group change during repost', () => {
+    it('should preserve user-chosen group even when savedGroup is still valid', async () => {
+      // Simulate repost scenario: original group 1, but user wants group 2
+      mockComposeStore.group = 1 // Initial group from repost
+      mockComposeStore.postcode = {
+        name: 'SW1A 1AA',
+        groupsnear: [
+          { id: 1, namedisplay: 'London Central', nameshort: 'london-central' },
+          { id: 2, namedisplay: 'Westminster', nameshort: 'westminster' },
+        ],
+      }
+
+      mockApi.location.typeahead.mockResolvedValueOnce([
+        {
+          name: 'SW1A 1AA',
+          groupsnear: [
+            { id: 1, namedisplay: 'London Central', nameshort: 'london-central' },
+            { id: 2, namedisplay: 'Westminster', nameshort: 'westminster' },
+          ],
+        },
+      ])
+
+      mockAuthStore.groups = [
+        { groupid: 1, namedisplay: 'London Central', nameshort: 'london' },
+        { groupid: 2, namedisplay: 'Westminster', nameshort: 'westminster' },
+      ]
+
+      const wrapper = createWrapper()
+
+      // User changes group to 2 after mount but before async operations complete
+      const select = wrapper.find('.form-select')
+      await select.setValue('2')
+      expect(mockComposeStore.group).toBe('2')
+
+      // Let async operations complete
+      await flushPromises()
+
+      // The group should remain 2 (user's choice), NOT revert to 1 (savedGroup)
+      expect(mockComposeStore.group).toBe('2')
+    })
+  })
 })


### PR DESCRIPTION
## Summary

When a user reposts an offer and attempts to change the destination group, the component would incorrectly restore the original group if it was still valid, overwriting the user's explicit selection.

## Root Cause

The ComposeGroup.vue component has a 'final guard' in onMounted that protects against unintended group resets during async operations (typeahead fetch, fetchUser). However, this guard didn't distinguish between:
- Component-driven resets (which should be restored)
- User-initiated changes (which should be preserved)

When async operations completed, the guard would check if the current group differed from the pre-async savedGroup, and if the savedGroup was still valid (in groupsnear or user's memberships), it would restore it—even if the user had explicitly changed the dropdown.

## Solution

Track user-initiated dropdown changes via a new `lastUserSelectedGroup` ref. The final guard now only restores the original group if the user hasn't explicitly selected a different one.

## Changes

- **ComposeGroup.vue**: Added `lastUserSelectedGroup` ref and updated the group computed setter to track user changes
- **ComposeGroup.spec.js**: Added test case verifying user group selection persists during repost

## Test Plan

- Existing E2E test: test-repost-group-change.spec.js validates that group selection persists through navigation
- New unit test: Verifies user-chosen group is not overwritten by the final guard
- Manual test: Repost offer from group A, select group B, verify it completes in group B

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)