### PR TITLE
fix(modtools): prevent layout shift when toggling hide expired posts

### DIFF
--- a/iznik-nuxt3/modtools/pages/members/feedback.vue
+++ b/iznik-nuxt3/modtools/pages/members/feedback.vue
@@ -10,7 +10,9 @@
               Feedback <span v-if="members.length">({{ members.length }})</span>
             </h4>
           </template>
-          <div class="d-flex justify-content-between flex-wrap gap-2 align-items-center">
+          <div
+            class="d-flex justify-content-between flex-wrap gap-2 align-items-center"
+          >
             <ModGroupSelect
               v-model="groupid"
               modonly
@@ -57,16 +59,18 @@
           <NoticeMessage v-if="!members.length && !busy" class="mt-2">
             There are no items to show at the moment.
           </NoticeMessage>
-          <div
-            v-for="item in visibleItems"
-            :key="'memberlist-' + item.id"
-            class="p-0 mt-2"
-          >
-            <ModMemberHappiness
-              v-if="item.type === 'Member'"
-              :id="item.object.id"
-            />
-          </div>
+          <transition-group name="fade" tag="div" class="feedback-list">
+            <div
+              v-for="item in visibleItems"
+              :key="'memberlist-' + item.id"
+              class="p-0 mt-2"
+            >
+              <ModMemberHappiness
+                v-if="item.type === 'Member'"
+                :id="item.object.id"
+              />
+            </div>
+          </transition-group>
         </b-tab>
 
         <b-tab>
@@ -218,8 +222,11 @@ watch(tabIndex, () => {
 })
 
 watch(showExpired, () => {
-  show.value = 0
-  bump.value++
+  // Don't reset to 0 — adjust based on filtered count to prevent layout shift
+  const visibleCount = sortedItems.value.length
+  if (show.value > visibleCount) {
+    show.value = Math.max(1, visibleCount)
+  }
 })
 
 // Methods
@@ -325,5 +332,19 @@ onMounted(async () => {
 <style scoped>
 select {
   max-width: 300px;
+}
+
+.feedback-list {
+  display: block;
+}
+
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.2s ease;
+}
+
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
 }
 </style>

--- a/iznik-nuxt3/tests/unit/pages/modtools/members/Feedback.spec.js
+++ b/iznik-nuxt3/tests/unit/pages/modtools/members/Feedback.spec.js
@@ -453,6 +453,94 @@ describe('Feedback Page', () => {
     })
   })
 
+  describe('showExpired watcher prevents layout shift', () => {
+    it('adjusts show.value when showExpired changes to prevent layout shift', async () => {
+      mockMembers.value = [
+        {
+          id: 1,
+          timestamp: '2024-01-10T10:00:00Z',
+          happiness: 'Happy',
+          outcome: 'Taken',
+        },
+        {
+          id: 2,
+          timestamp: '2024-01-11T10:00:00Z',
+          happiness: 'Happy',
+          outcome: 'Expired',
+        },
+        {
+          id: 3,
+          timestamp: '2024-01-12T10:00:00Z',
+          happiness: 'Happy',
+          outcome: 'Received',
+        },
+      ]
+      const wrapper = mountComponent()
+      mockFilter.value = ''
+      // Initially showing all 3 items
+      mockShow.value = 3
+      await flushPromises()
+
+      // Turn off showExpired — should only show 2 items (Taken and Received)
+      wrapper.vm.showExpired = false
+      await flushPromises()
+
+      // show.value should adjust to 2, not reset to 0
+      expect(wrapper.vm.show).toBe(2)
+      expect(wrapper.vm.visibleItems).toHaveLength(2)
+    })
+
+    it('keeps show.value as-is when filtering does not reduce visible items', async () => {
+      mockMembers.value = [
+        {
+          id: 1,
+          timestamp: '2024-01-10T10:00:00Z',
+          happiness: 'Happy',
+          outcome: 'Taken',
+        },
+        {
+          id: 2,
+          timestamp: '2024-01-11T10:00:00Z',
+          happiness: 'Happy',
+          outcome: 'Received',
+        },
+      ]
+      const wrapper = mountComponent()
+      mockFilter.value = ''
+      // All items are non-expired, so show.value stays the same
+      mockShow.value = 2
+      await flushPromises()
+
+      wrapper.vm.showExpired = false
+      await flushPromises()
+
+      // show.value should stay 2 since both items pass the filter
+      expect(wrapper.vm.show).toBe(2)
+    })
+
+    it('sets show.value to at least 1 to avoid empty display', async () => {
+      mockMembers.value = [
+        {
+          id: 1,
+          timestamp: '2024-01-10T10:00:00Z',
+          happiness: 'Happy',
+          outcome: 'Expired',
+        },
+      ]
+      const wrapper = mountComponent()
+      mockFilter.value = ''
+      mockShow.value = 1
+      await flushPromises()
+
+      // The only item is expired, so filtering removes it
+      wrapper.vm.showExpired = false
+      await flushPromises()
+
+      // show.value should be 1 (at least 1) even though sortedItems is empty
+      expect(wrapper.vm.show).toBe(1)
+    })
+  })
+
   describe('scroll behaviour: loadMore uses filtered count', () => {
     it('loadMore calls baseLoadMore for initial fetch when members is empty', async () => {
       mockMembers.value = []


### PR DESCRIPTION
## Summary
The 'Show expired' toggle in the ModTools Feedback page caused content jumping and layout shift when toggled. This was due to the component abruptly resetting `show.value` to 0, which cleared all DOM items immediately, then the infinite loader would reload them causing visual jumpiness.

## Root Cause
When the `showExpired` checkbox was toggled, the watcher would reset `show.value = 0`, causing:
- All visible items to disappear from DOM immediately
- Sudden layout reflow with no content
- Items would then reload causing visual jumping

## Solution
1. **Intelligent show.value adjustment**: Instead of resetting to 0, the watcher now intelligently adjusts `show.value` based on the filtered count. This prevents sudden DOM clearing.
2. **Smooth transitions**: Wrapped the items in a `transition-group` with CSS fade transitions. Items fade in/out over 200ms instead of appearing/disappearing instantly, reducing Cumulative Layout Shift (CLS).

## Changes
- Modified `showExpired` watcher to use `Math.max(1, visibleCount)` instead of `show.value = 0`
- Added `<transition-group>` component with fade name
- Added CSS for fade transitions (200ms opacity transition)

## Testing
Added three new test cases to verify:
1. show.value adjusts correctly when filtering reduces visible items
2. show.value stays unchanged when filtering doesn't reduce items
3. show.value is set to at least 1 to avoid empty display edge case

Fixes: Discourse topic 9518, post 230

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>