### PR TITLE
fix(repost): preserve user group selection in repost form

### DIFF
--- a/iznik-nuxt3/components/ComposeGroup.vue
+++ b/iznik-nuxt3/components/ComposeGroup.vue
@@ -138,11 +138,12 @@ onMounted(async () => {
 
   await authStore.fetchUser()
 
-  // Final guard: b-form-select may have reset composeStore.group during the
+  // Final guard: b-form-select may have cleared composeStore.group during the
   // async fetchUser wait (options re-evaluated while the saved group wasn't in
   // groupsnear yet). Restore savedGroup if it is still valid — i.e. present in
   // groupsnear or among the user's group memberships.
-  if (savedGroup && composeStore.group !== savedGroup) {
+  // Only restore if the group was cleared, NOT if the user selected a different one.
+  if (savedGroup && !composeStore.group) {
     const groupsNear = postcode.value?.groupsnear || []
     const savedGroupValid =
       groupsNear.some((g) => parseInt(g.id) === parseInt(savedGroup)) ||

--- a/iznik-nuxt3/tests/unit/components/ComposeGroup.spec.js
+++ b/iznik-nuxt3/tests/unit/components/ComposeGroup.spec.js
@@ -297,6 +297,58 @@ describe('ComposeGroup', () => {
     })
   })
 
+  describe('user group selection after mount', () => {
+    it('preserves user selection when group changed after mount but before fetchUser completes', async () => {
+      // Simulate repost flow: group 1 is pre-set (original group)
+      mockComposeStore.group = 1
+      mockAuthStore.groups = [
+        { groupid: 1, namedisplay: 'Original Group', nameshort: 'original' },
+        { groupid: 2, namedisplay: 'New Group', nameshort: 'new' },
+      ]
+
+      // fetchUser will be called but we want to simulate it happening after user changes selection
+      let fetchUserCalled = false
+      mockAuthStore.fetchUser = vi.fn().mockImplementation(async () => {
+        // Simulate that user changed group to 2 while fetch was in progress
+        // The group should stay as 2, not be restored to 1
+        fetchUserCalled = true
+      })
+
+      const wrapper = createWrapper()
+
+      // User changes group selection to 2
+      await wrapper.find('.form-select').setValue('2')
+      expect(mockComposeStore.group).toBe('2')
+
+      // Wait for lifecycle to complete
+      await flushPromises()
+      expect(fetchUserCalled).toBe(true)
+
+      // The group should still be 2 (user's selection), not restored to 1
+      // Because we only restore if group was cleared (falsy), not if it changed
+      expect(mockComposeStore.group).toBe('2')
+    })
+
+    it('restores savedGroup if it was cleared (falsy) but is still valid', async () => {
+      // Simulate repost flow: group 1 is pre-set
+      mockComposeStore.group = 1
+      mockAuthStore.groups = [
+        { groupid: 1, namedisplay: 'Original Group', nameshort: 'original' },
+      ]
+
+      // Simulate b-form-select clearing the group during fetchUser
+      mockAuthStore.fetchUser = vi.fn().mockImplementation(async () => {
+        mockComposeStore.group = null // Group was cleared by b-form-select
+      })
+
+      createWrapper()
+      await flushPromises()
+
+      // The final guard should restore 1 because it was cleared (falsy) and is valid
+      expect(mockComposeStore.group).toBe(1)
+    })
+  })
+
   describe('error handling', () => {
     it('handles postcode fetch error gracefully', async () => {
       const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})


### PR DESCRIPTION
## Summary
When reposting an offer to a different group, the group selection dropdown was being ignored and the offer was reposted to the original group instead. The user's selection was not persisted.

## Root Cause
The `ComposeGroup.vue` component's `onMounted` hook had a "final guard" (lines 145-153) that unconditionally restored the `savedGroup` (the original group when the component mounted) if it differed from `composeStore.group`, even if the user had intentionally changed the selection.

**Bug sequence:**
1. User clicks "Repost" on an offer in group A → `composeStore.group = A`
2. User navigates to the "Where is it?" page
3. User opens the group dropdown and selects group B ✓
4. During the async `fetchUser()` wait in `ComposeGroup.onMounted`:
5. The final guard checks: if `savedGroup && composeStore.group !== savedGroup` → TRUE
6. Restores: `composeStore.group = savedGroup` ✗ (overwrites user's selection!)

## Solution
Changed the guard condition from checking inequality to checking if the group was **cleared** (falsy):
- **Before:** `if (savedGroup && composeStore.group !== savedGroup)`
- **After:** `if (savedGroup && !composeStore.group)`

This preserves the user's intentional selection while still protecting against `b-form-select` accidentally clearing the group during reactive updates.

## Changes
- **ComposeGroup.vue**: Fixed final guard logic to only restore when group is falsy
- **ComposeGroup.spec.js**: Added unit tests for this specific scenario:
  - Test that user's group selection is preserved when changed after mount
  - Test that group is restored only when it was cleared, not when user selected a different one

## Testing
The e2e test `test-repost-group-change.spec.js` already validates this flow. The test changes the group dropdown and polls to verify it persists through async operations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)