### PR TITLE
fix: respect user-initiated group changes during repost

### DIFF
--- a/iznik-nuxt3/components/ComposeGroup.vue
+++ b/iznik-nuxt3/components/ComposeGroup.vue
@@ -136,20 +136,28 @@ onMounted(async () => {
     }
   }
 
+  // Save the group after the first restoration but before fetchUser.
+  // This captures either: (1) the user's choice if they changed it, or (2) savedGroup.
+  // We use this to distinguish user choices from cascade resets in the final guard.
+  const userChoice = composeStore.group
+
   await authStore.fetchUser()
 
   // Final guard: b-form-select may have reset composeStore.group during the
   // async fetchUser wait (options re-evaluated while the saved group wasn't in
-  // groupsnear yet). Restore savedGroup if it is still valid — i.e. present in
+  // groupsnear yet). Restore userChoice if it is still valid — i.e. present in
   // groupsnear or among the user's group memberships.
-  if (savedGroup && composeStore.group !== savedGroup) {
+  //
+  // We restore userChoice instead of savedGroup to respect any user-initiated
+  // group changes that happened during the earlier mount phase.
+  if (userChoice && composeStore.group !== userChoice) {
     const groupsNear = postcode.value?.groupsnear || []
-    const savedGroupValid =
-      groupsNear.some((g) => parseInt(g.id) === parseInt(savedGroup)) ||
-      myGroups.value.some((g) => parseInt(g.groupid) === parseInt(savedGroup))
+    const userChoiceValid =
+      groupsNear.some((g) => parseInt(g.id) === parseInt(userChoice)) ||
+      myGroups.value.some((g) => parseInt(g.groupid) === parseInt(userChoice))
 
-    if (savedGroupValid) {
-      composeStore.group = savedGroup
+    if (userChoiceValid) {
+      composeStore.group = userChoice
     }
   }
 

--- a/iznik-nuxt3/tests/unit/components/ComposeGroup.spec.js
+++ b/iznik-nuxt3/tests/unit/components/ComposeGroup.spec.js
@@ -295,6 +295,41 @@ describe('ComposeGroup', () => {
       // Group 99 is invalid, so the override (1) should stand
       expect(mockComposeStore.group).toBe(1)
     })
+
+    it('respects user-initiated group change during repost (should not revert after fetchUser)', async () => {
+      // BUG: When user changes group from repost default during the mount flow,
+      // the final guard was incorrectly reverting to the original repost group.
+      // Simulate repost flow: group 55 is pre-set from repost
+      mockComposeStore.group = 55
+      mockAuthStore.groups = [
+        { groupid: 1, namedisplay: 'London Central', nameshort: 'london' },
+        { groupid: 55, namedisplay: 'Repost Group', nameshort: 'repost' },
+      ]
+
+      // Mock fetchUser to simulate a cascade reset to groupsnear[0] (group 1)
+      // during the async operation, then the user changes it back.
+      let groupWasChangedDuringFetch = false
+      mockAuthStore.fetchUser = vi.fn().mockImplementation(async () => {
+        // Simulate: during fetchUser, b-form-select might reset to first available group
+        mockComposeStore.group = 1
+        groupWasChangedDuringFetch = true
+      })
+
+      const wrapper = createWrapper()
+
+      // At this point, onMounted has started but fetchUser hasn't completed yet.
+      // User manually changes the group to group 1 (same as cascade default, but user's choice).
+      const select = wrapper.find('.form-select')
+      await select.setValue('1')
+
+      // Now let all promises complete (fetchUser, etc.)
+      await flushPromises()
+
+      // The user's choice (group 1) should be respected, NOT reverted to savedGroup (55)
+      // even though fetchUser might have reset it.
+      expect(groupWasChangedDuringFetch).toBe(true)
+      expect(mockComposeStore.group).toBe('1')
+    })
   })
 
   describe('error handling', () => {


### PR DESCRIPTION
## Summary
Fixed bug where group selection dropdown was being overridden after user manually changed it during the repost flow. When a user selected a different group while the component was initializing (during typeahead/fetchUser), the group would revert to the original repost default instead of respecting the user's choice.

## Root Cause
ComposeGroup.vue's `onMounted` hook had a final guard that attempted to restore the original `savedGroup` after `fetchUser()` completed. However, it didn't distinguish between:
1. Group being reset by b-form-select cascade (should restore)
2. Group being changed by user (should respect)

Result: user's deliberate selection was overwritten.

## Solution
- Introduced `userChoice` variable that captures the group value after the first restoration phase but before `fetchUser()` completes
- This captures both: (1) the original repost group if user didn't change it, or (2) the user's new selection if they did
- Final guard now restores `userChoice` instead of `savedGroup`, preventing unwanted reversions

## Test Coverage
Added unit test: `respects user-initiated group change during repost (should not revert after fetchUser)`
- Simulates repost with group 55 pre-selected
- User changes to group 1 during mount lifecycle
- Verifies group remains 1 after fetchUser completes (not reverted to 55)

All 24 existing tests continue to pass.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>