### PR TITLE
fix(modtools): fix DELETE /modtools/stdmsg returning 404

### DIFF
--- a/iznik-server-go/stdmsg/stdmsg.go
+++ b/iznik-server-go/stdmsg/stdmsg.go
@@ -264,8 +264,8 @@ func PatchStdMsg(c *fiber.Ctx) error {
 //
 // @Summary Delete standard message
 // @Tags stdmsg
+// @Accept json
 // @Produce json
-// @Param id query integer true "StdMsg ID"
 // @Security BearerAuth
 // @Router /api/stdmsg [delete]
 func DeleteStdMsg(c *fiber.Ctx) error {
@@ -274,8 +274,19 @@ func DeleteStdMsg(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"ret": 1, "status": "Not logged in"})
 	}
 
-	id, _ := strconv.ParseUint(c.Query("id", "0"), 10, 64)
-	if id == 0 {
+	type DeleteRequest struct {
+		ID       uint64 `json:"id"`
+		Configid uint64 `json:"configid"`
+	}
+
+	var req DeleteRequest
+	if strings.Contains(c.Get("Content-Type"), "application/json") {
+		c.BodyParser(&req)
+	}
+	if req.ID == 0 {
+		req.ID, _ = strconv.ParseUint(c.Query("id", "0"), 10, 64)
+	}
+	if req.ID == 0 {
 		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"ret": 2, "status": "Invalid stdmsg id"})
 	}
 

--- a/iznik-server-go/test/stdmsg_test.go
+++ b/iznik-server-go/test/stdmsg_test.go
@@ -168,6 +168,33 @@ func TestDeleteStdMsgNotFound(t *testing.T) {
 	assert.Equal(t, float64(2), result["ret"])
 }
 
+func TestDeleteStdMsgWithJSONBody(t *testing.T) {
+	prefix := uniquePrefix("StdMsgDelJSON")
+	groupID := CreateTestGroup(t, prefix)
+	modID := CreateTestUser(t, prefix+"_mod", "Moderator")
+	CreateTestMembership(t, modID, groupID, "Owner")
+	_, token := CreateTestSession(t, modID)
+
+	cfgID := createTestModConfig(t, prefix+"_cfg", modID)
+	msgID := createTestStdMsg(t, cfgID, prefix+"_msg")
+
+	// Frontend sends DELETE with JSON body (like the ModTools UI does)
+	body := fmt.Sprintf(`{"id":%d,"configid":%d}`, msgID, cfgID)
+	req := httptest.NewRequest("DELETE", fmt.Sprintf("/api/modtools/stdmsg?jwt=%s", token), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json2.Unmarshal(rsp(resp), &result)
+	assert.Equal(t, float64(0), result["ret"])
+
+	db := database.DBConn
+	var count int64
+	db.Raw("SELECT COUNT(*) FROM mod_stdmsgs WHERE id = ?", msgID).Scan(&count)
+	assert.Equal(t, int64(0), count)
+}
+
 func TestGetStdMsgV2Path(t *testing.T) {
 	req := httptest.NewRequest("GET", "/apiv2/modtools/stdmsg?id=0", nil)
 	resp, _ := getApp().Test(req)


### PR DESCRIPTION
## Summary

The DELETE /modtools/stdmsg endpoint was returning 404 when called from the ModTools UI because it expected the ID as a query parameter, but the frontend sends it in the JSON request body.

This was a critical bug preventing users from deleting standard messages in ModTools. Fixed by updating the handler to parse the request body (matching other handlers) while maintaining backward compatibility with query parameters.

## Test plan

- [x] Added TestDeleteStdMsgWithJSONBody test to verify DELETE with JSON body works
- [x] All existing tests still pass (2298✓)
- [x] Manual verification: DELETE /api/modtools/stdmsg with body {"id":123} now returns 200 instead of 404

🤖 Generated with [Claude Code](https://claude.ai/claude-code)