### PR TITLE
fix: prevent layout shift in ModTools post list UI on message load

### DIFF
--- a/iznik-nuxt3/modtools/pages/messages/pending/[[id]]/[[term]].vue
+++ b/iznik-nuxt3/modtools/pages/messages/pending/[[id]]/[[term]].vue
@@ -34,17 +34,19 @@
       >
         There are no messages at the moment. This will refresh automatically.
       </NoticeMessage>
-      <div v-if="groupsreceived">
+      <div v-if="groupsreceived" class="messages-container">
         <ModMessages />
-        <infinite-loading
-          direction="top"
-          :identifier="bump"
-          @infinite="loadMore"
-        >
-          <template #spinner>
-            <Spinner :size="50" />
-          </template>
-        </infinite-loading>
+        <div class="infinite-loading-wrapper">
+          <infinite-loading
+            direction="top"
+            :identifier="bump"
+            @infinite="loadMore"
+          >
+            <template #spinner>
+              <Spinner :size="50" />
+            </template>
+          </infinite-loading>
+        </div>
       </div>
       <NoticeMessage v-else class="mt-2"> Please wait... </NoticeMessage>
 
@@ -331,3 +333,19 @@ defineExpose({
   loadMore,
 })
 </script>
+
+<style scoped>
+/* Reserve space for the infinite-loading spinner to prevent layout shift (CLS) */
+.infinite-loading-wrapper {
+  /* Ensure minimum height to accommodate spinner: 50px spinner + 20px padding */
+  min-height: 70px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+/* Prevent layout shift by maintaining container stability */
+.messages-container {
+  position: relative;
+}
+</style>

--- a/iznik-nuxt3/tests/e2e/test-modtools-pending-messages.spec.js
+++ b/iznik-nuxt3/tests/e2e/test-modtools-pending-messages.spec.js
@@ -197,4 +197,71 @@ test.describe('ModTools Pending Messages', () => {
 
     await assertNoErrors(page)
   })
+
+  test('post list does not jump or scroll unexpectedly on load', async ({
+    page,
+    testEnv,
+    testEmail,
+    postMessage,
+    withdrawPost,
+  }) => {
+    // Regression test: post list UI should not jump/scroll when messages load
+    // This verifies that layout shift is prevented through stable height reservation
+    const item = `test-pending-jump-${Date.now()}`
+    const posted = await postMessage({
+      type: 'OFFER',
+      item,
+      description: 'Test item for layout stability check',
+      email: testEmail,
+    })
+    expect(posted.id).toBeTruthy()
+
+    await loginViaModTools(page, testEnv.mod.email)
+
+    await page.goto(`${MODTOOLS_URL}/messages/pending`, {
+      timeout: timeouts.navigation.initial,
+    })
+
+    const groupSelect = page.locator('#communitieslist')
+    await expect(groupSelect).toBeVisible({
+      timeout: timeouts.navigation.slowPage,
+    })
+
+    await dismissAllModals(page)
+
+    // Get initial scroll position before selecting group
+    const initialScrollY = await page.evaluate(() => window.scrollY)
+
+    // Select a group with pending messages (this triggers message loading)
+    await selectGroupWithPendingMessages(page, groupSelect)
+
+    // Wait for message cards to load
+    const messageCards = page.locator('.card')
+    await expect(messageCards.first()).toBeVisible({
+      timeout: timeouts.navigation.slowPage,
+    })
+
+    // Measure scroll position after messages load
+    const scrollAfterLoad = await page.evaluate(() => window.scrollY)
+
+    // The scroll position should not jump significantly (allow small variance for rendering)
+    // A jump would be > 100px, so we allow a small tolerance
+    const scrollDelta = Math.abs(scrollAfterLoad - initialScrollY)
+    expect(scrollDelta).toBeLessThan(100)
+
+    // Verify the infinite-loading wrapper has reserved height
+    const infiniteLoadingWrapper = page.locator('.infinite-loading-wrapper')
+    if (
+      await infiniteLoadingWrapper
+        .isVisible({ timeout: timeouts.ui.appearance })
+        .catch(() => false)
+    ) {
+      const boundingBox = await infiniteLoadingWrapper.boundingBox()
+      expect(boundingBox).toBeTruthy()
+      expect(boundingBox.height).toBeGreaterThanOrEqual(70)
+    }
+
+    // Cleanup
+    await withdrawPost({ item: posted.item })
+  })
 })


### PR DESCRIPTION
## Summary
Fixed the ModTools pending messages post list jumping/scrolling issue caused by layout shift when the infinite-loading spinner appears/disappears.

**Root Cause**: The infinite-loading component had no reserved space, causing cumulative layout shift (CLS) when new messages loaded via infinite-scroll.

**Solution**:
- Wrapped infinite-loading in a container with min-height (70px) to reserve space
- Added flex layout to properly center and stabilize the spinner
- Added position: relative to parent container for layout context

## Test Plan
✅ Added regression test: "post list does not jump or scroll unexpectedly on load"
  - Verifies scroll position doesn't jump > 100px when messages load
  - Confirms infinite-loading wrapper has reserved height >= 70px
✅ Eslint verification passed
✅ Code changes follow existing patterns in the codebase

## Files Changed
- `modtools/pages/messages/pending/[[id]]/[[term]].vue`: Added wrapper + CSS styling
- `tests/e2e/test-modtools-pending-messages.spec.js`: Added regression test

## Notes
The fix prevents cumulative layout shift (CLS) which improves Core Web Vitals metrics and provides a better user experience when loading pending messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)