### PR TITLE
fix: add fire wood worry word for wood-related safety

### DIFF
--- a/iznik-batch/database/migrations/2026_05_01_162400_add_firewood_worry_words.php
+++ b/iznik-batch/database/migrations/2026_05_01_162400_add_firewood_worry_words.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // Add "fire wood" (two words) as a worry word - catches unsafe painted/treated wood for burning
+        DB::table('worrywords')->updateOrInsert(
+            ['keyword' => 'fire wood'],
+            [
+                'type' => 'Review',
+                'substance' => 'Painted/treated wood hazard'
+            ]
+        );
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        DB::table('worrywords')->where('keyword', 'fire wood')->delete();
+    }
+};

--- a/iznik-server/test/ut/php/include/WorryWordsTest.php
+++ b/iznik-server/test/ut/php/include/WorryWordsTest.php
@@ -114,6 +114,60 @@ class WorryWordsTest extends IznikTestCase
         $this->assertNotNull($w->checkMessage($m->getID(), $m->getFromuser(), $m->getSubject(), $m->getTextbody()));
     }
 
+    public function testFirewoodSingleWord()
+    {
+        $this->dbhm->preExec("INSERT IGNORE INTO worrywords (keyword, type) VALUES (?, ?);", [
+            'Firewood',
+            WorryWords::TYPE_REVIEW
+        ]);
+
+        $w = new WorryWords($this->dbhr, $this->dbhm);
+
+        $m = new Message($this->dbhr, $this->dbhm);
+        $mid = $m->createDraft();
+        $m = new Message($this->dbhr, $this->dbhm, $mid);
+        $m->setPrivate('subject', 'OFFER: Firewood (Somewhere)');
+        $m->setPrivate('textbody', 'Free firewood');
+        $result = $w->checkMessage($m->getID(), $m->getFromuser(), $m->getSubject(), $m->getTextbody());
+        $this->assertNotNull($result, 'Should flag "Firewood" as worry word');
+    }
+
+    public function testFirewoodTwoWords()
+    {
+        $this->dbhm->preExec("INSERT IGNORE INTO worrywords (keyword, type) VALUES (?, ?);", [
+            'fire wood',
+            WorryWords::TYPE_REVIEW
+        ]);
+
+        $w = new WorryWords($this->dbhr, $this->dbhm);
+
+        $m = new Message($this->dbhr, $this->dbhm);
+        $mid = $m->createDraft();
+        $m = new Message($this->dbhr, $this->dbhm, $mid);
+        $m->setPrivate('subject', 'OFFER: fire wood (Somewhere)');
+        $m->setPrivate('textbody', 'Some free fire wood here');
+        $result = $w->checkMessage($m->getID(), $m->getFromuser(), $m->getSubject(), $m->getTextbody());
+        $this->assertNotNull($result, 'Should flag "fire wood" (two words) as worry word');
+    }
+
+    public function testFirewoodCaseInsensitive()
+    {
+        $this->dbhm->preExec("INSERT IGNORE INTO worrywords (keyword, type) VALUES (?, ?);", [
+            'fire wood',
+            WorryWords::TYPE_REVIEW
+        ]);
+
+        $w = new WorryWords($this->dbhr, $this->dbhm);
+
+        $m = new Message($this->dbhr, $this->dbhm);
+        $mid = $m->createDraft();
+        $m = new Message($this->dbhr, $this->dbhm, $mid);
+        $m->setPrivate('subject', 'OFFER: FIRE WOOD (Somewhere)');
+        $m->setPrivate('textbody', 'Free Fire Wood');
+        $result = $w->checkMessage($m->getID(), $m->getFromuser(), $m->getSubject(), $m->getTextbody());
+        $this->assertNotNull($result, 'Should flag "FIRE WOOD" with case insensitivity');
+    }
+
 //
 //    public function testEH()
 //    {


### PR DESCRIPTION
## Summary

Adds 'fire wood' as a worry word to catch posts offering unsafe burning materials. The existing 'Firewood' worry word only caught the single-word variant, allowing 'fire wood' (two words) to slip past moderation holds.

## Problem

Posts offering painted or chemically-treated wood for burning were not being flagged for review when written as 'fire wood' instead of 'firewood'. This poses a safety risk as burning treated wood releases toxic fumes.

## Solution

- Added 'fire wood' (two-word phrase) as a Review-type worry word via migration
- Verified phrase matching in WorryWords system is case-insensitive via `stripos()`
- Added comprehensive unit tests for wood-related worry word matching

## Technical Details

The worry word system has two matching strategies:
1. **Phrase matching** (lines 72-104 in WorryWords.php): Case-insensitive substring search for multi-word worry words
2. **Fuzzy matching**: Levenshtein distance for single-word variants

## Test Coverage

Added three new test methods to WorryWordsTest.php:
- `testFirewoodSingleWord()`: Verifies 'Firewood' single-word variant is caught ✓
- `testFirewoodTwoWords()`: Verifies 'fire wood' two-word variant is caught ✓  
- `testFirewoodCaseInsensitive()`: Verifies case-insensitive matching (FIRE WOOD, Fire Wood, etc.) ✓

All tests passing, including messageAPI worry word integration test.

## Changes

- `iznik-server/test/ut/php/include/WorryWordsTest.php`: Added 3 new test methods
- `iznik-batch/database/migrations/2026_05_01_162400_add_firewood_worry_words.php`: Migration to add 'fire wood' worry word

## Notes

- Migration uses `updateOrInsert()` to avoid duplicate key errors if worry word already exists
- 'fire wood' classified as 'Review' type like other safety-related worry words
- Backward compatible: existing 'Firewood' word continues to work