### PR TITLE
fix(modtools): DELETE endpoints support JSON body parameters

### DIFF
--- a/iznik-server-go/modconfig/modconfig.go
+++ b/iznik-server-go/modconfig/modconfig.go
@@ -585,14 +585,26 @@ func DeleteModConfig(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusUnauthorized, "Not logged in")
 	}
 
-	id, _ := strconv.ParseUint(c.Query("id", "0"), 10, 64)
-	if id == 0 {
+	type DeleteRequest struct {
+		ID uint64 `json:"id"`
+	}
+
+	var req DeleteRequest
+	c.BodyParser(&req)
+
+	// Fall back to query parameter if not in body (for backward compatibility)
+	if req.ID == 0 {
+		id, _ := strconv.ParseUint(c.Query("id", "0"), 10, 64)
+		req.ID = id
+	}
+
+	if req.ID == 0 {
 		return fiber.NewError(fiber.StatusBadRequest, "Invalid config id")
 	}
 
 	db := database.DBConn
 	var cfg ModConfig
-	db.Raw("SELECT "+configColumns+" FROM mod_configs WHERE id = ?", id).Scan(&cfg)
+	db.Raw("SELECT "+configColumns+" FROM mod_configs WHERE id = ?", req.ID).Scan(&cfg)
 	if cfg.ID == 0 {
 		return fiber.NewError(fiber.StatusNotFound, "Invalid config id")
 	}
@@ -603,15 +615,15 @@ func DeleteModConfig(c *fiber.Ctx) error {
 
 	// Check if still in use.
 	var inUse int64
-	db.Raw("SELECT COUNT(*) FROM memberships WHERE configid = ? AND role IN (?, ?)", id, utils.ROLE_MODERATOR, utils.ROLE_OWNER).Scan(&inUse)
+	db.Raw("SELECT COUNT(*) FROM memberships WHERE configid = ? AND role IN (?, ?)", req.ID, utils.ROLE_MODERATOR, utils.ROLE_OWNER).Scan(&inUse)
 	if inUse > 0 {
 		return c.Status(fiber.StatusConflict).JSON(fiber.Map{"ret": 5, "status": "Config still in use"})
 	}
 
-	db.Exec("DELETE FROM mod_configs WHERE id = ?", id)
+	db.Exec("DELETE FROM mod_configs WHERE id = ?", req.ID)
 
 	// Log the deletion.
-	db.Exec("INSERT INTO logs (timestamp, type, subtype, byuser, configid) VALUES (NOW(), ?, ?, ?, ?)", log.LOG_TYPE_CONFIG, log.LOG_SUBTYPE_DELETED, myid, id)
+	db.Exec("INSERT INTO logs (timestamp, type, subtype, byuser, configid) VALUES (NOW(), ?, ?, ?, ?)", log.LOG_TYPE_CONFIG, log.LOG_SUBTYPE_DELETED, myid, req.ID)
 
 	return c.JSON(fiber.Map{"ret": 0, "status": "Success"})
 }

--- a/iznik-server-go/stdmsg/stdmsg.go
+++ b/iznik-server-go/stdmsg/stdmsg.go
@@ -264,8 +264,9 @@ func PatchStdMsg(c *fiber.Ctx) error {
 //
 // @Summary Delete standard message
 // @Tags stdmsg
+// @Accept json
 // @Produce json
-// @Param id query integer true "StdMsg ID"
+// @Param id query integer false "StdMsg ID (legacy - prefer body)"
 // @Security BearerAuth
 // @Router /api/stdmsg [delete]
 func DeleteStdMsg(c *fiber.Ctx) error {
@@ -274,15 +275,27 @@ func DeleteStdMsg(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"ret": 1, "status": "Not logged in"})
 	}
 
-	id, _ := strconv.ParseUint(c.Query("id", "0"), 10, 64)
-	if id == 0 {
+	type DeleteRequest struct {
+		ID uint64 `json:"id"`
+	}
+
+	var req DeleteRequest
+	c.BodyParser(&req)
+
+	// Fall back to query parameter if not in body (for backward compatibility)
+	if req.ID == 0 {
+		id, _ := strconv.ParseUint(c.Query("id", "0"), 10, 64)
+		req.ID = id
+	}
+
+	if req.ID == 0 {
 		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"ret": 2, "status": "Invalid stdmsg id"})
 	}
 
 	db := database.DBConn
 
 	var configid uint64
-	db.Raw("SELECT configid FROM mod_stdmsgs WHERE id = ?", id).Scan(&configid)
+	db.Raw("SELECT configid FROM mod_stdmsgs WHERE id = ?", req.ID).Scan(&configid)
 	if configid == 0 {
 		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"ret": 2, "status": "Invalid stdmsg id"})
 	}
@@ -291,7 +304,7 @@ func DeleteStdMsg(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusForbidden).JSON(fiber.Map{"ret": 4, "status": "Don't have rights to modify config"})
 	}
 
-	db.Exec("DELETE FROM mod_stdmsgs WHERE id = ?", id)
+	db.Exec("DELETE FROM mod_stdmsgs WHERE id = ?", req.ID)
 
 	return c.JSON(fiber.Map{"ret": 0, "status": "Success"})
 }

--- a/iznik-server-go/test/stdmsg_test.go
+++ b/iznik-server-go/test/stdmsg_test.go
@@ -173,3 +173,32 @@ func TestGetStdMsgV2Path(t *testing.T) {
 	resp, _ := getApp().Test(req)
 	assert.Equal(t, 404, resp.StatusCode)
 }
+
+func TestDeleteStdMsgWithBodyParams(t *testing.T) {
+	// Test that DELETE request works when parameters are in JSON body (as sent by frontend)
+	prefix := uniquePrefix("StdMsgDelBody")
+	groupID := CreateTestGroup(t, prefix)
+	modID := CreateTestUser(t, prefix+"_mod", "Moderator")
+	CreateTestMembership(t, modID, groupID, "Owner")
+	_, token := CreateTestSession(t, modID)
+
+	cfgID := createTestModConfig(t, prefix+"_cfg", modID)
+	msgID := createTestStdMsg(t, cfgID, prefix+"_msg")
+
+	// Send DELETE with parameters in JSON body (like the frontend does via $delv2)
+	body := fmt.Sprintf(`{"id":%d,"configid":%d}`, msgID, cfgID)
+	req := httptest.NewRequest("DELETE", fmt.Sprintf("/api/modtools/stdmsg?jwt=%s", token), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode, "DELETE with body params should succeed")
+
+	var result map[string]interface{}
+	json2.Unmarshal(rsp(resp), &result)
+	assert.Equal(t, float64(0), result["ret"])
+
+	// Verify the message was actually deleted
+	db := database.DBConn
+	var count int64
+	db.Raw("SELECT COUNT(*) FROM mod_stdmsgs WHERE id = ?", msgID).Scan(&count)
+	assert.Equal(t, int64(0), count)
+}


### PR DESCRIPTION
## Summary

- Fix DELETE /modtools/stdmsg to accept parameters from JSON request body
- Fix DELETE /modtools/modconfig to accept parameters from JSON request body  
- Both endpoints maintain backward compatibility with query parameter format

## Problem

Frontend's BaseAPI.$delv2 sends DELETE request parameters in the JSON request body (following HTTP semantics for DELETE with data). However, the Go API endpoints were only reading parameters from the query string, causing them to return 404 when parameters weren't present in the URL.

## Solution

Both DeleteStdMsg and DeleteModConfig now:
1. First attempt to parse parameters from JSON request body
2. Fall back to query parameters if not in body (backward compatibility)
3. Use the first non-zero ID found

Pattern matches existing DeleteAdmin and DeleteSpammer which already support both.

## Test Coverage

Added TestDeleteStdMsgWithBodyParams to verify DELETE works with parameters in JSON body, matching frontend behavior.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>