### PR TITLE
fix: DELETE /modtools/stdmsg endpoint returns 404

### DIFF
--- a/iznik-server-go/stdmsg/stdmsg.go
+++ b/iznik-server-go/stdmsg/stdmsg.go
@@ -274,15 +274,26 @@ func DeleteStdMsg(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"ret": 1, "status": "Not logged in"})
 	}
 
-	id, _ := strconv.ParseUint(c.Query("id", "0"), 10, 64)
-	if id == 0 {
+	type DeleteRequest struct {
+		ID uint64 `json:"id"`
+	}
+
+	var req DeleteRequest
+	if strings.Contains(c.Get("Content-Type"), "application/json") {
+		c.BodyParser(&req)
+	}
+	if req.ID == 0 {
+		req.ID, _ = strconv.ParseUint(c.Query("id", "0"), 10, 64)
+	}
+
+	if req.ID == 0 {
 		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"ret": 2, "status": "Invalid stdmsg id"})
 	}
 
 	db := database.DBConn
 
 	var configid uint64
-	db.Raw("SELECT configid FROM mod_stdmsgs WHERE id = ?", id).Scan(&configid)
+	db.Raw("SELECT configid FROM mod_stdmsgs WHERE id = ?", req.ID).Scan(&configid)
 	if configid == 0 {
 		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"ret": 2, "status": "Invalid stdmsg id"})
 	}
@@ -291,7 +302,7 @@ func DeleteStdMsg(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusForbidden).JSON(fiber.Map{"ret": 4, "status": "Don't have rights to modify config"})
 	}
 
-	db.Exec("DELETE FROM mod_stdmsgs WHERE id = ?", id)
+	db.Exec("DELETE FROM mod_stdmsgs WHERE id = ?", req.ID)
 
 	return c.JSON(fiber.Map{"ret": 0, "status": "Success"})
 }

--- a/iznik-server-go/test/stdmsg_test.go
+++ b/iznik-server-go/test/stdmsg_test.go
@@ -173,3 +173,30 @@ func TestGetStdMsgV2Path(t *testing.T) {
 	resp, _ := getApp().Test(req)
 	assert.Equal(t, 404, resp.StatusCode)
 }
+
+func TestDeleteStdMsgWithJSONBody(t *testing.T) {
+	prefix := uniquePrefix("StdMsgDelJSON")
+	groupID := CreateTestGroup(t, prefix)
+	modID := CreateTestUser(t, prefix+"_mod", "Moderator")
+	CreateTestMembership(t, modID, groupID, "Owner")
+	_, token := CreateTestSession(t, modID)
+
+	cfgID := createTestModConfig(t, prefix+"_cfg", modID)
+	msgID := createTestStdMsg(t, cfgID, prefix+"_msg")
+
+	// Test DELETE with id in JSON body (the way frontend API sends it)
+	body := fmt.Sprintf(`{"id":%d}`, msgID)
+	req := httptest.NewRequest("DELETE", fmt.Sprintf("/api/modtools/stdmsg?jwt=%s", token), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json2.Unmarshal(rsp(resp), &result)
+	assert.Equal(t, float64(0), result["ret"])
+
+	db := database.DBConn
+	var count int64
+	db.Raw("SELECT COUNT(*) FROM mod_stdmsgs WHERE id = ?", msgID).Scan(&count)
+	assert.Equal(t, int64(0), count)
+}


### PR DESCRIPTION
## Summary
Fixed the DELETE /modtools/stdmsg endpoint that was returning 404 for all deletion requests from ModTools UI.

## Root Cause
- **Frontend (ModTools)**: Sends DELETE requests with parameters in JSON body
- **Backend (Go API)**: Handler only read id from query string
- Result: id defaulted to 0, causing 404 "Invalid stdmsg id"

## Changes
- Updated DeleteStdMsg handler to parse id from JSON request body
- Falls back to query string for backwards compatibility  
- Added test case TestDeleteStdMsgWithJSONBody to validate the fix

## Testing
- All 2298 existing tests pass ✅
- New test validates DELETE with JSON body works correctly ✅
- Backwards compatibility maintained (query string params still work) ✅

## Verification
Once merged, users will be able to delete standard messages from ModTools without receiving 404 errors.

🤖 Generated with Claude Code