### PR TITLE
fix(message): reactivate deleted users when they post

### DIFF
--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -2866,6 +2866,10 @@ func PutMessage(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusUnauthorized, "Not logged in")
 	}
 
+	// If user is deleted, reactivate them (set deleted = NULL).
+	// This allows deleted users to recover their account by posting a message.
+	db.Exec("UPDATE users SET deleted = NULL WHERE id = ? AND deleted IS NOT NULL", myid)
+
 	if req.Type != "Offer" && req.Type != "Wanted" {
 		return fiber.NewError(fiber.StatusBadRequest, "type must be Offer or Wanted")
 	}

--- a/iznik-server-go/test/message_test.go
+++ b/iznik-server-go/test/message_test.go
@@ -2627,6 +2627,58 @@ func TestPutMessageNewEmailGetsJWT(t *testing.T) {
 	assert.True(t, hasJWT, "Response should contain JWT for new user")
 }
 
+func TestPutMessageReactivatesDeletedUser(t *testing.T) {
+	// When a deleted user posts a message, their account should be reactivated
+	// (deleted flag cleared). This allows deleted users to recover by posting.
+	// Related to Discourse topic 9497, post 62201: deleted account but could still post messages.
+	prefix := uniquePrefix("msgdel_reactivate")
+	db := database.DBConn
+
+	groupID := CreateTestGroup(t, prefix)
+	userID := CreateTestUser(t, prefix+"_user", "User")
+	CreateTestMembership(t, userID, groupID, "Member")
+	_, token := CreateTestSession(t, userID)
+
+	// Soft-delete the user (simulate account deletion).
+	// This sets deleted=NOW() as LimboUser does.
+	db.Exec("UPDATE users SET deleted = NOW() WHERE id = ?", userID)
+
+	// Verify user is deleted before posting.
+	var deletedBefore *string
+	db.Raw("SELECT deleted FROM users WHERE id = ?", userID).Scan(&deletedBefore)
+	assert.NotNil(t, deletedBefore, "user should be marked as deleted before posting")
+
+	// Post a draft message. Deleted users should be able to post drafts.
+	body := map[string]interface{}{
+		"type":     "Wanted",
+		"subject":  prefix + " Test Offer",
+		"textbody": "A deleted user posting",
+		"item":     "Test Item",
+	}
+	bodyBytes, _ := json.Marshal(body)
+	req := httptest.NewRequest("PUT", "/api/message?jwt="+token, bytes.NewBuffer(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := getApp().Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode, "deleted user should be able to post")
+
+	var result map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&result)
+	assert.Equal(t, float64(0), result["ret"])
+	assert.Greater(t, result["id"], float64(0))
+
+	// Verify the message was created.
+	newID := uint64(result["id"].(float64))
+	var subject string
+	db.Raw("SELECT subject FROM messages WHERE id = ?", newID).Scan(&subject)
+	assert.Equal(t, prefix+" Test Offer", subject)
+
+	// Verify user is now reactivated (deleted flag is NULL).
+	var deletedAfter *string
+	db.Raw("SELECT deleted FROM users WHERE id = ?", userID).Scan(&deletedAfter)
+	assert.Nil(t, deletedAfter, "user should be reactivated (deleted set to NULL) after posting")
+}
+
 // --- Test: BackToPending ---
 
 func TestPostMessageBackToPending(t *testing.T) {


### PR DESCRIPTION
## Summary
Fixed a regression where deleted users could post messages but their account remained marked as deleted. The reactivation logic that automatically clears the deleted timestamp when a user posts was missing.

## Changes
- Restore reactivation code in `PutMessage` that sets `deleted = NULL` when a deleted user posts
- Add test `TestPutMessageReactivatesDeletedUser` to verify the behavior

## Test Plan
- [x] New test `TestPutMessageReactivatesDeletedUser` verifies deleted users are reactivated when posting
- Awaiting full test suite completion
- Manual verification: deleted user posts message → deleted timestamp becomes NULL

## References
- Fixes Discourse topic 9497, post 62201 reported by Neville_Reid
- Related to previous fix in commit 5a3336b8d (reactivation behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)