### PR TITLE
fix(membership): exclude deleted users from member lists

### DIFF
--- a/iznik-server-go/membership/membership.go
+++ b/iznik-server-go/membership/membership.go
@@ -356,7 +356,7 @@ func GetMemberships(c *fiber.Ctx) error {
 			"NULL AS reviewrequestedat, NULL AS reviewedat, NULL AS reviewreason "+
 			"FROM users_banned b "+
 			"JOIN users u ON u.id = b.userid "+
-			"WHERE b.groupid = ? "+
+			"WHERE b.groupid = ? AND u.deleted IS NULL "+
 			"ORDER BY b.date DESC LIMIT ?",
 			groupid, limit).Scan(&members)
 		if members == nil {
@@ -380,7 +380,7 @@ func GetMemberships(c *fiber.Ctx) error {
 			"JOIN users u ON u.id = m.userid "+
 			"LEFT JOIN users_banned b ON b.userid = m.userid AND b.groupid = m.groupid "+
 			"INNER JOIN users_modmails um ON um.userid = m.userid AND um.groupid = m.groupid "+
-			"WHERE m.groupid = ? AND m.collection = ? "+
+			"WHERE m.groupid = ? AND m.collection = ? AND u.deleted IS NULL "+
 			"GROUP BY m.userid "+
 			"ORDER BY lastmodmail DESC LIMIT ?",
 			groupid, collection, limit).Scan(&members)
@@ -430,7 +430,7 @@ func GetMemberships(c *fiber.Ctx) error {
 		if numErr == nil && searchID > 0 {
 			db.Raw("SELECT "+selectCols+" "+
 				fromClause+filterJoin+" "+
-				"WHERE "+groupFilter+" AND m.collection = ?"+filterWhere+
+				"WHERE "+groupFilter+" AND m.collection = ? AND u.deleted IS NULL"+filterWhere+
 				" AND m.userid = ? "+
 				"ORDER BY m.added DESC LIMIT ?",
 				groupArg, collection, searchID, limit).Scan(&members)
@@ -439,7 +439,7 @@ func GetMemberships(c *fiber.Ctx) error {
 			db.Raw("SELECT "+selectCols+" "+
 				fromClause+filterJoin+
 				" LEFT JOIN users_emails ue ON ue.userid = m.userid "+
-				"WHERE "+groupFilter+" AND m.collection = ?"+filterWhere+
+				"WHERE "+groupFilter+" AND m.collection = ? AND u.deleted IS NULL"+filterWhere+
 				" AND (u.fullname LIKE ? OR ue.email LIKE ?) "+
 				"GROUP BY m.id "+
 				"ORDER BY m.added DESC LIMIT ?",
@@ -458,7 +458,7 @@ func GetMemberships(c *fiber.Ctx) error {
 
 		result := db.Raw("SELECT "+selectCols+" "+
 			fromClause+filterJoin+" "+
-			"WHERE m.groupid = ? AND m.collection = ?"+filterWhere+contextWhere+
+			"WHERE m.groupid = ? AND m.collection = ? AND u.deleted IS NULL"+filterWhere+contextWhere+
 			" ORDER BY m.id DESC LIMIT ?",
 			queryArgs...).Scan(&members)
 		if result.Error != nil {
@@ -484,7 +484,7 @@ func GetMemberships(c *fiber.Ctx) error {
 
 		countFrom := "FROM memberships m JOIN users u ON u.id = m.userid"
 		db.Raw("SELECT COUNT(DISTINCT m.userid) "+countFrom+filterJoin+
-			" WHERE m.groupid = ? AND m.collection = ?"+filterWhere,
+			" WHERE m.groupid = ? AND m.collection = ? AND u.deleted IS NULL"+filterWhere,
 			groupid, collection).Scan(&filterCount)
 
 		return c.JSON(fiber.Map{
@@ -579,6 +579,7 @@ func getSpamMembers(c *fiber.Ctx, myid uint64, groupid uint64, limit int) error 
 		fromClause+" "+
 		"WHERE m.groupid IN ? AND m.reviewrequestedat IS NOT NULL "+
 		"AND (m.reviewedat IS NULL OR m.reviewrequestedat > m.reviewedat) "+
+		"AND u.deleted IS NULL "+
 		"ORDER BY m.userid DESC LIMIT ?",
 		modGroupIDs, limit).Scan(&members)
 	if result.Error != nil {

--- a/iznik-server-go/test/membership_test.go
+++ b/iznik-server-go/test/membership_test.go
@@ -3245,3 +3245,46 @@ func TestPatchMembershipsConfigChange(t *testing.T) {
 		modID, groupID).Scan(&configID2)
 	assert.Equal(t, cfgID2, configID2)
 }
+
+func TestGetMembershipsExcludesDeletedUsers(t *testing.T) {
+	// Regression: Deleted users should not appear in member lists even if they have memberships.
+	// This ensures that users in limbo (mark for deletion) don't appear as active members.
+	prefix := uniquePrefix("mem_deleted")
+	db := database.DBConn
+
+	groupID := CreateTestGroup(t, prefix)
+
+	// Create moderator
+	modID := CreateTestUser(t, prefix+"_mod", "User")
+	CreateTestMembership(t, modID, groupID, "Moderator")
+	_, modToken := CreateTestSession(t, modID)
+
+	// Create two members
+	member1ID := CreateTestUser(t, prefix+"_member1", "User")
+	CreateTestMembership(t, member1ID, groupID, "Member")
+
+	member2ID := CreateTestUser(t, prefix+"_member2", "User")
+	CreateTestMembership(t, member2ID, groupID, "Member")
+
+	// Mark one member as deleted (in limbo)
+	db.Exec("UPDATE users SET deleted = NOW() WHERE id = ?", member2ID)
+
+	// Get membership list
+	url := fmt.Sprintf("/api/memberships?jwt=%s&groupid=%d&collection=Approved", modToken, groupID)
+	req := httptest.NewRequest("GET", url, nil)
+	resp, err := getApp().Test(req, -1)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	// Parse response
+	var result map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&result)
+	members := result["members"].([]interface{})
+
+	// Should only contain the non-deleted member
+	assert.Equal(t, 1, len(members), "Should only return non-deleted members")
+
+	// Verify it's the right member
+	member := members[0].(map[string]interface{})
+	assert.Equal(t, float64(member1ID), member["userid"])
+}


### PR DESCRIPTION
## Summary

- Deleted users were appearing in member lists in modtools because GetMemberships didn't filter on `users.deleted IS NULL`
- This caused new members marked as deleted to show as active, creating confusion: "Member is active but account still shows as deleted" (Discourse #9497)
- Added filter to all member list queries across approved, pending, banned, and review collections

## Changes

- Add `AND u.deleted IS NULL` to all member list queries in GetMemberships
- Include filter in search queries, filter-specific queries, and count queries
- Add regression test: TestGetMembershipsExcludesDeletedUsers

## Test Plan

- [x] Write test that verifies deleted users don't appear in member lists
- Run Go test suite to ensure no regressions
- Verify modtools member lists no longer show deleted users

Fixes: Discourse topic 9497 post 63579

🤖 Generated with [Claude Code](https://claude.com/claude-code)