### PR TITLE
fix(auth): prevent deleted users from remaining authenticated

### DIFF
--- a/iznik-server-go/auth/auth.go
+++ b/iznik-server-go/auth/auth.go
@@ -60,7 +60,16 @@ func WhoAmI(c *fiber.Ctx) uint64 {
 		}
 	}
 
+	// Verify that the user is not deleted - deleted users cannot remain authenticated
 	if id > 0 {
+		db := database.DBConn
+		var deleted *time.Time
+		db.Raw("SELECT deleted FROM users WHERE id = ?", id).Scan(&deleted)
+		if deleted != nil {
+			// User is deleted, return 0 (not logged in)
+			return 0
+		}
+
 		// Signal to the auth middleware that this handler used auth — if the JWT
 		// turns out to be stale the middleware should return 401.
 		c.Locals("authUsed", true)

--- a/iznik-server/http/discourse_sso.php
+++ b/iznik-server/http/discourse_sso.php
@@ -46,6 +46,12 @@ if (($sso->validatePayload($payload,$signature))) {
             foreach ($sessions as &$session) {
                 $u = new User($dbhr, $dbhm, $session['userid']);
 
+                if ($u->getPrivate('deleted')) {
+                    error_log('discourse_sso - User is deleted: '.$u->getEmailPreferred());
+                    echo "Your account has been deleted. You cannot access Discourse.";
+                    exit(0);
+                }
+
                 if ($u->isModerator()) {
                     $atts = $u->getPublic(NULL, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, MessageCollection::APPROVED, FALSE);
 

--- a/iznik-server/include/session/Session.php
+++ b/iznik-server/include/session/Session.php
@@ -180,8 +180,11 @@ class Session {
             $r = User::get($dbhr, $dbhm, $id);
 
             if ($r->getId() == $id) {
-                #error_log("Return cached user $id");
-                $ret = $r;
+                # Check if user is deleted - deleted users cannot remain authenticated
+                if (!$r->getPrivate('deleted')) {
+                    #error_log("Return cached user $id");
+                    $ret = $r;
+                }
             }
             #error_log("Found " . $ret->getId() . " role " . $ret->isModerator());
         }

--- a/iznik-server/test/ut/php/api/sessionTest.php
+++ b/iznik-server/test/ut/php/api/sessionTest.php
@@ -1043,4 +1043,23 @@ class sessionTest extends IznikAPITestCase
 //        $this->assertEquals(0, $ret['ret']);
 //        $this->assertEquals(User::SYSTEMROLE_SUPPORT, $ret['me']['systemrole']);
 //    }
+
+    public function testDeletedUserCannotAuthenticate()
+    {
+        // Create and login a test user
+        list($u, $uid) = $this->createTestUserAndLogin('Test Delete User', 'testdel@test.com', 'testpw');
+
+        // Verify the user is logged in
+        $ret = $this->call('session', 'GET', []);
+        $this->assertEquals(0, $ret['ret']);
+        $this->assertNotNull($ret['user']);
+
+        // Mark the user as deleted
+        $this->dbhm->preExec("UPDATE users SET deleted = NOW() WHERE id = ?;", [$uid]);
+
+        // Session should now return NULL for deleted user
+        $ret = $this->call('session', 'GET', []);
+        $this->assertEquals(1, $ret['ret']);  // Not logged in
+        $this->assertNull($ret['user'] ?? NULL);
+    }
 }


### PR DESCRIPTION
## Summary

Fixed a state inconsistency where deleted users could remain logged in and continue to post messages. The `deleted` flag was not being validated during session authentication.

## Changes

1. **Session validation in PHP v1 API**: `Session::whoAmI()` now checks if the user is deleted and returns NULL if they are
2. **Session validation in Go v2 API**: `auth.WhoAmI()` now checks if the user is deleted and returns 0 if they are  
3. **Discourse SSO protection**: Added explicit deleted flag check to prevent deleted moderators from accessing Discourse
4. **Test coverage**: Added `testDeletedUserCannotAuthenticate()` to verify deleted users cannot authenticate

## Test Results

- Existing session tests continue to pass (including `testForget` which explicitly tests deletion flow)
- New test validates deleted users cannot authenticate
- Full test suite run: 28 tests, 318 assertions, 2 pre-existing failures (unrelated)

## Root Cause

The authentication layer was not checking the `deleted` timestamp field when validating logged-in users. A deleted user's session remained valid and allowed them to continue posting messages and accessing moderator features.

🤖 Generated with [Claude Code](https://claude.com/claude-code)