### PR TITLE
fix(member-status-persistence): prevent deleted users from taking message actions

### DIFF
--- a/iznik-server-go/chat/chatmessage.go
+++ b/iznik-server-go/chat/chatmessage.go
@@ -300,6 +300,13 @@ func CreateChatMessage(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusUnauthorized, "Not logged in")
 	}
 
+	// Check if user is deleted (in limbo).
+	var deleted *time.Time
+	db.Raw("SELECT deleted FROM users WHERE id = ?", myid).Scan(&deleted)
+	if deleted != nil {
+		return fiber.NewError(fiber.StatusForbidden, "Account has been deleted")
+	}
+
 	var payload ChatMessage
 	err = c.BodyParser(&payload)
 
@@ -410,6 +417,13 @@ func CreateChatMessageLoveJunk(c *fiber.Ctx) error {
 	}
 
 	db := database.DBConn
+
+	// Check if user is deleted (in limbo).
+	var deleted *time.Time
+	db.Raw("SELECT deleted FROM users WHERE id = ?", myid).Scan(&deleted)
+	if deleted != nil {
+		return fiber.NewError(fiber.StatusForbidden, "Account has been deleted")
+	}
 
 	// Find the user who sent the message we are replying to.
 	type msgInfo struct {

--- a/iznik-server-go/message/markseen.go
+++ b/iznik-server-go/message/markseen.go
@@ -1,6 +1,8 @@
 package message
 
 import (
+	"time"
+
 	"github.com/freegle/iznik-server-go/database"
 	"github.com/freegle/iznik-server-go/utils"
 	"github.com/freegle/iznik-server-go/user"
@@ -30,6 +32,14 @@ func MarkSeen(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusUnauthorized, "Not logged in")
 	}
 
+	// Check if user is deleted (in limbo).
+	db := database.DBConn
+	var deleted *time.Time
+	db.Raw("SELECT deleted FROM users WHERE id = ?", myid).Scan(&deleted)
+	if deleted != nil {
+		return fiber.NewError(fiber.StatusForbidden, "Account has been deleted")
+	}
+
 	var req MarkSeenRequest
 	if err := c.BodyParser(&req); err != nil {
 		return fiber.NewError(fiber.StatusBadRequest, "Invalid request body")
@@ -38,8 +48,6 @@ func MarkSeen(c *fiber.Ctx) error {
 	if len(req.IDs) == 0 {
 		return fiber.NewError(fiber.StatusBadRequest, "Message IDs required")
 	}
-
-	db := database.DBConn
 
 	// Insert a View record for each message. ON DUPLICATE KEY UPDATE
 	// increments the count and updates the timestamp.

--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -3042,6 +3042,14 @@ func PostMessage(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusUnauthorized, "Not logged in")
 	}
 
+	// Check if user is deleted (in limbo).
+	db := database.DBConn
+	var deleted *time.Time
+	db.Raw("SELECT deleted FROM users WHERE id = ?", myid).Scan(&deleted)
+	if deleted != nil {
+		return fiber.NewError(fiber.StatusForbidden, "Account has been deleted")
+	}
+
 	var req PostMessageRequest
 	if err := c.BodyParser(&req); err != nil {
 		return fiber.NewError(fiber.StatusBadRequest, "Invalid request body")

--- a/iznik-server-go/test/message_test.go
+++ b/iznik-server-go/test/message_test.go
@@ -7338,3 +7338,35 @@ func TestMessagePostingsVisibleUnauthenticated(t *testing.T) {
 	json.NewDecoder(resp.Body).Decode(&msg)
 	assert.NotEmpty(t, msg.Postings, "postings should be visible to unauthenticated callers (V1 parity)")
 }
+
+func TestDeletedUserCannotTakeAction(t *testing.T) {
+	// Regression test for member-status-persistence: user marked as deleted should not be able
+	// to take actions on messages (promise, reply, etc). Topic 9497, Post 62201.
+	db := database.DBConn
+	prefix := uniquePrefix("deluser")
+
+	userID := CreateTestUser(t, prefix, "User")
+	groupID := CreateTestGroup(t, prefix)
+	CreateTestMembership(t, userID, groupID, "Member")
+	_, token := CreateTestSession(t, userID)
+
+	msgID := CreateTestMessage(t, userID, groupID, "OFFER: Test Item", 55.9533, -3.1883)
+
+	// Mark user as deleted
+	db.Exec("UPDATE users SET deleted = NOW() WHERE id = ?", userID)
+
+	// Try to take an action (Promise) on the message
+	reqBody := []byte(fmt.Sprintf(`{"id": %d, "action": "Promise"}`, msgID))
+	req := httptest.NewRequest("POST", "/api/message?jwt="+token, bytes.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := getApp().Test(req)
+	assert.NoError(t, err)
+	// Should return 403 Forbidden or 401 Unauthorized, not 200 Success
+	assert.Greater(t, resp.StatusCode, 299, "Deleted user should not be able to take action on messages")
+
+	// Verify the promise was not recorded
+	var promiseCount int64
+	db.Raw("SELECT COUNT(*) FROM messages_promises WHERE msgid = ? AND userid = ?", msgID, userID).Scan(&promiseCount)
+	assert.Equal(t, int64(0), promiseCount, "Promise should not be recorded for deleted user")
+}


### PR DESCRIPTION
## Summary

Fixes a bug where members marked as deleted could still post messages, send chat messages, and take other actions on the platform. The issue was that the API endpoints didn't validate whether a user's account was in limbo (soft-deleted) before allowing actions.

## Root Cause

When a user deletes their account, it's placed in "limbo" with `users.deleted` set to a timestamp. This allows recovery within ~14 days. However, the message and chat APIs didn't check this flag before allowing actions, so deleted users could still:
- Take actions on messages (Promise, Renege, Outcome, Reply, etc.)
- Send and receive chat messages  
- Mark messages as seen

## Changes

Added deleted user validation to all message action endpoints:
- `POST /message` - Message actions (promise, reply, etc.)
- `POST /chat/:id/message` - Chat message creation
- `POST /chat/lovejunk` - Love/junk chat messages
- `POST /messages/markseen` - Message view tracking

Returns `403 Forbidden` with "Account has been deleted" if user is in limbo.

## Test

Added regression test `TestDeletedUserCannotTakeAction` that:
1. Creates a user and message
2. Marks the user as deleted
3. Attempts to take an action (Promise) on the message
4. Verifies the action is rejected with 4xx status
5. Verifies no promise record was created

Addresses Topic 9497, Post 62201 reported by Neville_Reid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)