### PR TITLE
fix(go-api): persist groupid to messages_drafts in PatchMessage

### DIFF
--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -2446,6 +2446,19 @@ func PatchMessage(c *fiber.Ctx) error {
 		db.Exec("UPDATE messages SET "+strings.Join(setClauses, ", ")+" WHERE id = ?", args...)
 	}
 
+	// PHP parity (message.php:371-372): when a groupid is supplied, persist it to
+	// messages_drafts so the subsequent JoinAndPost reads the user's chosen group
+	// rather than the original one from RejectToDraft.  Without this, the group
+	// change is silently dropped and the message is reposted to the wrong community.
+	// The UPDATE is a no-op when the message is not in draft state (0 rows affected).
+	if req.Groupid != nil && *req.Groupid > 0 {
+		var groupExists int64
+		db.Raw("SELECT COUNT(*) FROM `groups` WHERE id = ?", *req.Groupid).Scan(&groupExists)
+		if groupExists > 0 {
+			db.Exec("UPDATE messages_drafts SET groupid = ? WHERE msgid = ?", *req.Groupid, req.ID)
+		}
+	}
+
 	// If the user is setting a future deadline, clear any Expired outcome so the post
 	// becomes active again (batch job marks posts Expired when deadline passes; extending
 	// the deadline should move the post back out of "Old Posts").

--- a/iznik-server-go/test/message_test.go
+++ b/iznik-server-go/test/message_test.go
@@ -7350,3 +7350,72 @@ func TestMessagePostingsVisibleUnauthenticated(t *testing.T) {
 	json.NewDecoder(resp.Body).Decode(&msg)
 	assert.NotEmpty(t, msg.Postings, "postings should be visible to unauthenticated callers (V1 parity)")
 }
+
+// TestPatchMessageGroupidUpdatesDraft verifies the repost flow bug:
+// PATCH /message with groupid must persist the new group to messages_drafts
+// so that the subsequent JoinAndPost (which reads messages_drafts.groupid)
+// posts to the user's chosen group, not the original one.
+//
+// PHP parity: message.php:371-372 does this explicitly after every PATCH.
+// The Go handler accepted groupid in PatchMessageRequest but never wrote it.
+func TestPatchMessageGroupidUpdatesDraft(t *testing.T) {
+	prefix := uniquePrefix("patch_groupid_draft")
+	db := database.DBConn
+
+	group1ID := CreateTestGroup(t, prefix+"_g1")
+	group2ID := CreateTestGroup(t, prefix+"_g2")
+	userID := CreateTestUser(t, prefix+"_user", "User")
+	CreateTestMembership(t, userID, group1ID, "Member")
+	_, token := CreateTestSession(t, userID)
+
+	// Create message on group1, then move to draft (simulating user pressing "Repost").
+	msgID := createPendingMessage(t, userID, group1ID, prefix)
+
+	rejectBody := map[string]interface{}{"id": msgID, "action": "RejectToDraft"}
+	rejectBytes, _ := json.Marshal(rejectBody)
+	req := httptest.NewRequest("POST", "/api/message?jwt="+token, bytes.NewBuffer(rejectBytes))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := getApp().Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	// Baseline: draft should record the original group.
+	var draftGroupid uint64
+	db.Raw("SELECT groupid FROM messages_drafts WHERE msgid = ?", msgID).Scan(&draftGroupid)
+	assert.Equal(t, group1ID, draftGroupid, "draft should initially record the original group")
+
+	// User changes group selection via PATCH.
+	patchBody := map[string]interface{}{"id": msgID, "groupid": group2ID}
+	patchBytes, _ := json.Marshal(patchBody)
+	req2 := httptest.NewRequest("PATCH", "/api/message?jwt="+token, bytes.NewBuffer(patchBytes))
+	req2.Header.Set("Content-Type", "application/json")
+	resp2, err := getApp().Test(req2)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp2.StatusCode)
+
+	// messages_drafts.groupid must be updated — this is the key assertion.
+	db.Raw("SELECT groupid FROM messages_drafts WHERE msgid = ?", msgID).Scan(&draftGroupid)
+	assert.Equal(t, group2ID, draftGroupid, "PATCH with groupid must update messages_drafts.groupid")
+
+	// JoinAndPost without explicit groupid — must read from messages_drafts and land on group2.
+	joinBody := map[string]interface{}{"id": msgID, "action": "JoinAndPost"}
+	joinBytes, _ := json.Marshal(joinBody)
+	req3 := httptest.NewRequest("POST", "/api/message?jwt="+token, bytes.NewBuffer(joinBytes))
+	req3.Header.Set("Content-Type", "application/json")
+	resp3, err := getApp().Test(req3)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp3.StatusCode)
+
+	var joinResult map[string]interface{}
+	json.NewDecoder(resp3.Body).Decode(&joinResult)
+	assert.Equal(t, float64(group2ID), joinResult["groupid"], "JoinAndPost should use the new group, not the original")
+
+	// Message must be in group2 only.
+	var mgCount1 int64
+	db.Raw("SELECT COUNT(*) FROM messages_groups WHERE msgid = ? AND groupid = ?", msgID, group1ID).Scan(&mgCount1)
+	assert.Equal(t, int64(0), mgCount1, "message must not land on original group1")
+
+	var mgCount2 int64
+	db.Raw("SELECT COUNT(*) FROM messages_groups WHERE msgid = ? AND groupid = ?", msgID, group2ID).Scan(&mgCount2)
+	assert.Equal(t, int64(1), mgCount2, "message must land on the user-selected group2")
+}


### PR DESCRIPTION
## Summary

- **Bug**: When a user reposted a message to a different group using the `RejectToDraft → PATCH → JoinAndPost` flow, the group change was silently dropped and the message landed on the original community instead of the selected one.
- **Root cause**: `PatchMessage` accepted `Groupid` in `PatchMessageRequest` but the UPDATE builder (message.go:2401-2447) never wrote it anywhere. `messages_drafts.groupid` stayed at the value set by `RejectToDraft` (the original group via `getPrimaryGroupForMessage`). `JoinAndPost` then read that stale value and posted to the wrong group.
- **PHP parity**: `message.php:371-372` performed an explicit `UPDATE messages_drafts SET groupid = ? WHERE msgid = ?` on every PATCH. The Go port omitted this.
- **Fix**: After the main `messages` UPDATE, persist `req.Groupid` to `messages_drafts` when supplied, with a group existence guard to prevent storing a phantom id. The UPDATE is a no-op when the message is not in draft state.
- **Scope**: Only affects the repost flow (`RejectToDraft → PATCH → JoinAndPost`). New posts route the chosen group through `createDraft → PUT /message` which already writes `messages_drafts.groupid` correctly.

## Code Quality Review

- Authorization: `PatchMessage` already gates on `isOwner || isMod` before reaching this code — no additional auth needed to match PHP parity.
- The group existence check prevents storing a nonexistent groupid that would silently corrupt `JoinAndPost` downstream.
- If the message is not a draft (no `messages_drafts` row), the UPDATE affects 0 rows — safe and no-op.
- No new dependencies, no schema changes.

## Test Plan

- `TestPatchMessageGroupidUpdatesDraft`: end-to-end test of the full repost flow — `RejectToDraft` → `PATCH` with new groupid → `JoinAndPost` without explicit groupid. Verifies:
  1. `messages_drafts.groupid` is updated by PATCH (the key assertion that was failing before this fix).
  2. `JoinAndPost` reads the updated groupid and posts to the new group.
  3. Message is in the new group only (not the original).
- Confirmed test **fails** on original code, **passes** with fix.
- Full Go test suite run to check for regressions.