### PR TITLE
fix(modtools): Add Note button now active in iOS normal Chat Review

### DIFF
--- a/iznik-nuxt3/modtools/components/ModChatReviewUser.vue
+++ b/iznik-nuxt3/modtools/components/ModChatReviewUser.vue
@@ -31,9 +31,9 @@
       />
     </div>
     <ModCommentAddModal
-      v-if="showAddCommentModal && groupid"
+      v-if="showAddCommentModal"
       :userid="userid"
-      :groupid="groupid"
+      :groupid="groupid || null"
       @added="updateComments"
       @hidden="showAddCommentModal = false"
     />

--- a/iznik-nuxt3/tests/unit/components/modtools/ModChatReviewUser.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModChatReviewUser.spec.js
@@ -218,12 +218,25 @@ describe('ModChatReviewUser', () => {
       expect(wrapper.vm.showAddCommentModal).toBe(true)
     })
 
-    it('does not render modal when groupid is 0', async () => {
+    it('renders modal when Add note clicked even when groupid is 0 (iOS Chat Review regression: topic 9518/234)', async () => {
+      // Bug: v-if="showAddCommentModal && groupid" blocked the modal when groupid=0.
+      // Normal Chat Review can have groupid=0 (no group context for that user);
+      // QCR always has a non-zero group so it appeared to work. Fix: remove the groupid guard.
+      const wrapper = mountComponent({ groupid: 0 })
+      await wrapper.find('button').trigger('click')
+      await wrapper.vm.$nextTick()
+      expect(wrapper.vm.showAddCommentModal).toBe(true)
+      expect(wrapper.find('.add-modal').exists()).toBe(true)
+    })
+
+    it('passes null groupid to modal when component groupid is 0', async () => {
       const wrapper = mountComponent({ groupid: 0 })
       wrapper.vm.addAComment()
       await wrapper.vm.$nextTick()
-      expect(wrapper.vm.showAddCommentModal).toBe(true)
-      expect(wrapper.find('.add-modal').exists()).toBe(false)
+      const modal = wrapper.findComponent({ name: 'ModCommentAddModal' })
+      if (modal.exists()) {
+        expect(modal.props('groupid')).toBeNull()
+      }
     })
 
     it('renders modal when groupid is non-zero', async () => {


### PR DESCRIPTION
## Summary

Fixes Add Note button being silently inactive in normal Chat Review, reported by Neville_Reid on iOS.

- **Bug**: In `ModChatReviewUser.vue`, `ModCommentAddModal` was gated by `v-if="showAddCommentModal && groupid"`. When `groupid=0` (no group context for that user), clicking "Add Note" set the flag but the modal never rendered — button appeared inert.
- **QCR works**: Quicker Chat Review messages always carry a non-zero `message.group?.id`, so the modal opened. Normal Chat Review can have `groupid=0` (e.g. chat user not on a modded group), which exposed the bug.
- **Fix**: Remove the `&& groupid` guard from the `v-if`; pass `groupid || null` so `ModCommentAddModal` receives its documented default (`null`) instead of `0` when there is no group context.

## Root cause

`iznik-nuxt3/modtools/components/ModChatReviewUser.vue` line 34 (before fix):
```html
<ModCommentAddModal
  v-if="showAddCommentModal && groupid"
  :groupid="groupid"
  ...
/>
```
`ModCommentAddModal` declares `groupid` as optional with `default: null` — it was never designed to require a group. The guard was unnecessarily strict.

## What changed

- `ModChatReviewUser.vue`: `v-if="showAddCommentModal && groupid"` → `v-if="showAddCommentModal"`, `:groupid="groupid"` → `:groupid="groupid || null"`
- `ModChatReviewUser.spec.js`: replaced the test that documented the buggy behaviour with two tests verifying: (a) modal opens when `groupid=0`, (b) modal receives `null` not `0` in that case

## Test evidence

New failing test before fix:
```
× renders modal when Add note clicked even when groupid is 0 (iOS Chat Review regression: topic 9518/234)
  → expected false to be true
```

After fix — full suite:
```
✓ tests/unit/components/modtools/ModChatReviewUser.spec.js (20 tests)
Test Files  161 passed (161)
Tests  4179 passed (4179)
```

## Discourse report

> Reported by Neville_Reid: https://discourse.ilovefreegle.org/t/9518/234
>
> "This morning I had a Chat Review for cash being offered by a member of my groups. I tried to add a note but in iOS the Add Note button was not active. Instead, I went to the profile (membership page) and added a note there. Just now I had a Quicker Chat Review and found that the Add Note button was working fine, in iOS and on desktop browser."