### PR TITLE
fix: prevent sparse-array crash when submitting mobile give/find posts

### DIFF
--- a/iznik-nuxt3/composables/useCompose.js
+++ b/iznik-nuxt3/composables/useCompose.js
@@ -96,9 +96,13 @@ export function setup(type) {
       // This can happen if you repost, don't complete, log in as another user.  The server submit call will
       // fail in that case, so we are better off not showing the message at all and letting them compose from
       // scratch.
+      //
+      // Also exclude synthetic default messages (those whose id doesn't exist in messages[]) — using them
+      // creates a sparse array that corrupts the store after Pinia's JSON round-trip + prune().
       if (
         message.type === type &&
-        (!message.savedBy || message.savedBy === myid)
+        (!message.savedBy || message.savedBy === myid) &&
+        composeStore.messages[message.id]
       ) {
         messageIds.push(message.id)
       }
@@ -112,6 +116,14 @@ export function setup(type) {
 
   // We also want to prune any old messages from our store.
   composeStore.prune()
+
+  // Ensure a real message of this type exists so the ids computed never returns a synthetic default.
+  // Synthetic defaults have ids that don't exist in messages[], which creates a sparse array on write
+  // that corrupts submit() after Pinia's JSON round-trip compacts the array.
+  if (!composeStore.messages.some((m) => m && m.type === type)) {
+    const newId = composeStore.add()
+    composeStore.setType({ id: newId, type })
+  }
 
   const myid = authStore.user?.id
 

--- a/iznik-nuxt3/pages/find/mobile/details.vue
+++ b/iznik-nuxt3/pages/find/mobile/details.vue
@@ -114,8 +114,13 @@ const stickyAdRendered = computed(() => miscStore.stickyAdRendered)
 // Initialize message ID synchronously so it's available for computed properties
 function getMessageId() {
   const myid = authStore.user?.id
+  // Only use real (non-synthetic) messages — synthetic defaults from all getter
+  // have ids that don't exist in composeStore.messages.
   const existingMessages = composeStore.all.filter(
-    (m) => m.type === 'Wanted' && (!m.savedBy || m.savedBy === myid)
+    (m) =>
+      m.type === 'Wanted' &&
+      (!m.savedBy || m.savedBy === myid) &&
+      composeStore.messages[m.id]
   )
 
   if (existingMessages.length > 0) {

--- a/iznik-nuxt3/pages/find/mobile/photos.vue
+++ b/iznik-nuxt3/pages/find/mobile/photos.vue
@@ -45,11 +45,16 @@ const stickyAdRendered = computed(() => miscStore.stickyAdRendered)
 function getOrCreateMessageId() {
   const myid = authStore.user?.id
 
-  // Check if we have an existing message for this type in composeStore.all
-  // Note: composeStore.all may return synthetic default messages, so we must
-  // call setType() to ensure the message actually exists in state.messages
+  // Find a real (non-synthetic) Wanted message in the store.
+  // composeStore.all returns synthetic defaults for missing types; synthetic
+  // messages have ids that don't exist in composeStore.messages, so using them
+  // creates a sparse array ([empty, {id:1}]) that crashes on submit after
+  // Pinia's JSON round-trip compacts it.
   const existingMessages = composeStore.all.filter(
-    (m) => m.type === 'Wanted' && (!m.savedBy || m.savedBy === myid)
+    (m) =>
+      m.type === 'Wanted' &&
+      (!m.savedBy || m.savedBy === myid) &&
+      composeStore.messages[m.id]
   )
 
   const id =

--- a/iznik-nuxt3/stores/compose.js
+++ b/iznik-nuxt3/stores/compose.js
@@ -348,7 +348,7 @@ export const useComposeStore = defineStore({
             message.repostof,
             this.email,
             message,
-            this.messages[message.id].attachments
+            message.attachments
           )
 
           let result
@@ -420,7 +420,7 @@ export const useComposeStore = defineStore({
           results.push(result)
 
           const me = useAuthStore().user
-          this.markSubmitted(message.id, me)
+          this.markSubmitted(parseInt(id), me)
         }
       }
 

--- a/iznik-nuxt3/tests/e2e/fixtures.js
+++ b/iznik-nuxt3/tests/e2e/fixtures.js
@@ -1120,89 +1120,129 @@ const testWithFixtures = test.extend({
         postcode = testEnv?.postcode || environment.postcode,
         email,
         deadline,
+        mobile = false,
       } = options
 
       if (!email) {
         throw new Error('Email is required for posting a message')
       }
 
-      // Navigate to the correct page based on type
-      const startPath = type.toLowerCase() === 'wanted' ? '/find' : '/give'
-      await page.gotoAndVerify(startPath, {
-        timeout: timeouts.navigation.initial,
-        waitUntil: 'domcontentloaded',
-        maxRetries: 1,
-      })
+      if (mobile && type.toLowerCase() === 'wanted') {
+        // Mobile find flow: /find/mobile/photos → skip → /find/mobile/details → /find/mobile/whereami
+        await page.gotoAndVerify('/find/mobile/photos', {
+          timeout: timeouts.navigation.initial,
+          waitUntil: 'domcontentloaded',
+          maxRetries: 1,
+        })
 
-      // Verify we're on the correct page
-      const pageTitle = await page.title()
-      base.expect(pageTitle).toContain(type.toUpperCase())
+        // Skip the photo upload step
+        const skipLink = page.locator('a', { hasText: 'Skip' })
+        await skipLink.waitFor({ state: 'visible', timeout: timeouts.ui.appearance })
+        await skipLink.click()
 
-      // Fill in the item type using fill() — triggers Vue v-model via input event
-      const itemInput = page.locator(
-        '[id^="what"], .type-input, input[placeholder*="give"]'
-      )
-      await itemInput.click()
-      await itemInput.fill(item)
+        // Fill item and description on the details page
+        await page.waitForURL(/\/find\/mobile\/details/, {
+          timeout: timeouts.navigation.default,
+        })
 
-      // Fill in the post details
-      await page.waitForSelector(
-        '[id^="description"], textarea.description, textarea.form-control',
-        { timeout: timeouts.ui.appearance }
-      )
+        const mobileItemInput = page.locator('#item-name')
+        await mobileItemInput.waitFor({ state: 'visible', timeout: timeouts.ui.appearance })
+        await mobileItemInput.fill(item)
 
-      // Fill description using fill() instead of type() with delay
-      const descInput = page.locator(
-        '[id^="description"], textarea.description, textarea.form-control'
-      )
-      await descInput.click()
-      await descInput.fill(description)
+        const mobileDescInput = page.locator('#description')
+        await mobileDescInput.fill(description)
 
-      // Wait for Vue reactivity to process the form changes and make the Next button available
-      // This replaces the fixed 2000ms wait with a responsive check
-      await page.waitForFunction(
-        () => {
-          // Check both mobile and desktop buttons using textContent instead of :has-text()
-          const allButtons = document.querySelectorAll('.btn, button')
-          let mobileBtn = null
-          let desktopBtn = null
+        // Click Next to proceed to whereami (postcode + email + submit on one page)
+        const mobileNextBtn = page.locator('button.btn', { hasText: 'Next' })
+        await mobileNextBtn.waitFor({ state: 'visible', timeout: timeouts.ui.appearance })
+        await mobileNextBtn.click()
 
-          for (const btn of allButtons) {
-            if (btn.textContent && btn.textContent.includes('Next')) {
-              // Check if it's a mobile button (has d-md-none parent or class)
-              if (
-                btn.closest('.d-block.d-md-none') ||
-                btn.classList.contains('d-md-none')
-              ) {
-                mobileBtn = btn
-              }
-              // Check if it's a desktop button (has d-none.d-md-flex parent or class)
-              if (
-                btn.closest('.d-none.d-md-flex') ||
-                (btn.classList.contains('d-none') &&
-                  btn.classList.contains('d-md-flex'))
-              ) {
-                desktopBtn = btn
-              }
-              // If we can't determine mobile vs desktop, treat as general button
-              if (!mobileBtn && !desktopBtn) {
-                mobileBtn = btn // Default to treating as mobile (disabled check)
+        await page.waitForURL(/\/find\/mobile\/whereami/, {
+          timeout: timeouts.navigation.default,
+        })
+
+        // Postcode, email, and submit are all on the mobile whereami page —
+        // fall through to the shared postcode-entry code below, skipping the
+        // desktop-only second "Next" and whoami navigation.
+      } else {
+        // Navigate to the correct page based on type
+        const startPath = type.toLowerCase() === 'wanted' ? '/find' : '/give'
+        await page.gotoAndVerify(startPath, {
+          timeout: timeouts.navigation.initial,
+          waitUntil: 'domcontentloaded',
+          maxRetries: 1,
+        })
+
+        // Verify we're on the correct page
+        const pageTitle = await page.title()
+        base.expect(pageTitle).toContain(type.toUpperCase())
+
+        // Fill in the item type using fill() — triggers Vue v-model via input event
+        const itemInput = page.locator(
+          '[id^="what"], .type-input, input[placeholder*="give"]'
+        )
+        await itemInput.click()
+        await itemInput.fill(item)
+
+        // Fill in the post details
+        await page.waitForSelector(
+          '[id^="description"], textarea.description, textarea.form-control',
+          { timeout: timeouts.ui.appearance }
+        )
+
+        // Fill description using fill() instead of type() with delay
+        const descInput = page.locator(
+          '[id^="description"], textarea.description, textarea.form-control'
+        )
+        await descInput.click()
+        await descInput.fill(description)
+
+        // Wait for Vue reactivity to process the form changes and make the Next button available
+        // This replaces the fixed 2000ms wait with a responsive check
+        await page.waitForFunction(
+          () => {
+            // Check both mobile and desktop buttons using textContent instead of :has-text()
+            const allButtons = document.querySelectorAll('.btn, button')
+            let mobileBtn = null
+            let desktopBtn = null
+
+            for (const btn of allButtons) {
+              if (btn.textContent && btn.textContent.includes('Next')) {
+                // Check if it's a mobile button (has d-md-none parent or class)
+                if (
+                  btn.closest('.d-block.d-md-none') ||
+                  btn.classList.contains('d-md-none')
+                ) {
+                  mobileBtn = btn
+                }
+                // Check if it's a desktop button (has d-none.d-md-flex parent or class)
+                if (
+                  btn.closest('.d-none.d-md-flex') ||
+                  (btn.classList.contains('d-none') &&
+                    btn.classList.contains('d-md-flex'))
+                ) {
+                  desktopBtn = btn
+                }
+                // If we can't determine mobile vs desktop, treat as general button
+                if (!mobileBtn && !desktopBtn) {
+                  mobileBtn = btn // Default to treating as mobile (disabled check)
+                }
               }
             }
-          }
 
-          return (
-            (mobileBtn && !mobileBtn.disabled) ||
-            (desktopBtn && desktopBtn.offsetParent !== null)
-          )
-        },
-        null,
-        { timeout: timeouts.ui.appearance }
-      )
+            return (
+              (mobileBtn && !mobileBtn.disabled) ||
+              (desktopBtn && desktopBtn.offsetParent !== null)
+            )
+          },
+          null,
+          { timeout: timeouts.ui.appearance }
+        )
 
-      // Click the Next/Continue button to go to location page
-      // Playwright's click() auto-scrolls the element into view
-      await page.locator('.next-btn:has-text("Next")').click()
+        // Click the Next/Continue button to go to location page
+        // Playwright's click() auto-scrolls the element into view
+        await page.locator('.next-btn:has-text("Next")').click()
+      }
 
       // Fill in location details
       await page.waitForSelector('.pcinp, input[placeholder="Type postcode"]', {
@@ -1223,12 +1263,15 @@ const testWithFixtures = test.extend({
         timeout: timeouts.api.default,
       })
 
-      // Click the Next/Continue button (Playwright auto-scrolls)
-      await page.locator('.next-btn:has-text("Next")').click()
+      // Desktop only: click Next to advance from whereami to whoami/options page.
+      // Mobile flow has postcode, email, and submit all on one page — no Next click needed.
+      if (!mobile) {
+        await page.locator('.next-btn:has-text("Next")').click()
+      }
 
       // For OFFER posts, handle the /give/options page (delivery and deadline options)
       // WANTED posts go directly to whoami (no options page)
-      if (type.toUpperCase() === 'OFFER') {
+      if (!mobile && type.toUpperCase() === 'OFFER') {
         console.log(
           'Handling /give/options page - inline deadline and delivery options'
         )

--- a/iznik-nuxt3/tests/e2e/test-post-flow.spec.js
+++ b/iznik-nuxt3/tests/e2e/test-post-flow.spec.js
@@ -224,6 +224,36 @@ test.describe('Post flow tests', () => {
     await withdrawPost({ item: result.item })
   })
 
+  test('Logged out, new user, WANTED post via mobile find flow', async ({
+    page,
+    testEmail,
+    postMessage,
+    withdrawPost,
+  }) => {
+    // Regression test: the mobile find flow (/find/mobile/photos → details → whereami)
+    // created a sparse messages array [empty, {id:1}] in the compose store.
+    // After Pinia JSON round-trip, prune() compacted it to [{id:1}] at index 0,
+    // but the internal .id field stayed 1. The submit loop then accessed
+    // this.messages[message.id] (= this.messages[1] = undefined) → TypeError →
+    // "Something went wrong" with no server-side trace.
+    const uniqueItem = `test-wanted-mobile-${Date.now()}-${Math.random()
+      .toString(36)
+      .substr(2, 5)}`
+    const result = await postMessage({
+      type: 'WANTED',
+      mobile: true,
+      item: uniqueItem,
+      description: `Created by automated test at ${new Date().toISOString()}`,
+      email: testEmail,
+    })
+
+    console.log(`Mobile WANTED post result: ${JSON.stringify(result)}`)
+    expect(result.id).toBeTruthy()
+    console.log(`Mobile WANTED post created with ID: ${result.id}`)
+
+    await withdrawPost({ item: result.item })
+  })
+
   test("Email existence check - prevents posting with someone else's email", async ({
     page,
     testEmail,

--- a/iznik-nuxt3/tests/e2e/test-reply-flow-logged-in.spec.js
+++ b/iznik-nuxt3/tests/e2e/test-reply-flow-logged-in.spec.js
@@ -2,11 +2,10 @@
  * Reply Flow Tests - Logged In User (Tests 1.1, 1.2, 1.3)
  *
  * These tests cover the reply flow for users who are already logged in.
- * They MUST run serially because they share existingTestEmail (pre-registered user).
+ * They use testEnv.user (created by create-test-env.php) as the logged-in replier.
  */
 
 const { test, expect } = require('./fixtures')
-const { environment } = require('./config')
 const { loginViaHomepage, logoutIfLoggedIn } = require('./utils/user')
 const {
   waitForAuthInLocalStorage,
@@ -20,7 +19,7 @@ test.describe('Reply Flow - Logged In User', () => {
   test('1.1 can reply from Message Page', async ({
     page,
     postMessage,
-    existingTestEmail,
+    testEnv,
     getTestEmail,
     withdrawPost,
   }) => {
@@ -40,13 +39,12 @@ test.describe('Reply Flow - Logged In User', () => {
     // Log out from poster
     await logoutIfLoggedIn(page)
 
-    // Login as existingTestEmail FIRST (before navigating to message page)
-    // This uses a pre-registered test user to ensure login succeeds
-    // Must pass the correct password for the pre-registered test user
+    // Login as testEnv.user FIRST (before navigating to message page)
+    // testEnv.user is a pre-registered test user created by create-test-env.php with password 'freegle'
     await loginViaHomepage(
       page,
-      existingTestEmail,
-      environment.unmodded_password
+      testEnv.user.email,
+      'freegle'
     )
     await waitForAuthInLocalStorage(page)
     console.log('[Test] Logged in as existingTestEmail')
@@ -78,7 +76,7 @@ test.describe('Reply Flow - Logged In User', () => {
   test('1.2 can reply from Browse Page', async ({
     page,
     postMessage,
-    existingTestEmail,
+    testEnv,
     getTestEmail,
     withdrawPost,
   }) => {
@@ -97,13 +95,12 @@ test.describe('Reply Flow - Logged In User', () => {
     // Log out from poster
     await logoutIfLoggedIn(page)
 
-    // Login as existingTestEmail FIRST (before navigating)
-    // This uses a pre-registered test user to ensure login succeeds
-    // Must pass the correct password for the pre-registered test user
+    // Login as testEnv.user FIRST (before navigating)
+    // testEnv.user is a pre-registered test user created by create-test-env.php with password 'freegle'
     await loginViaHomepage(
       page,
-      existingTestEmail,
-      environment.unmodded_password
+      testEnv.user.email,
+      'freegle'
     )
     await waitForAuthInLocalStorage(page)
     console.log('[Test] Logged in as existingTestEmail')
@@ -135,7 +132,7 @@ test.describe('Reply Flow - Logged In User', () => {
   test('1.3 can reply from Explore Page', async ({
     page,
     postMessage,
-    existingTestEmail,
+    testEnv,
     getTestEmail,
     withdrawPost,
   }) => {
@@ -154,13 +151,12 @@ test.describe('Reply Flow - Logged In User', () => {
     // Log out from poster
     await logoutIfLoggedIn(page)
 
-    // Login as existingTestEmail FIRST (before navigating)
-    // This uses a pre-registered test user to ensure login succeeds
-    // Must pass the correct password for the pre-registered test user
+    // Login as testEnv.user FIRST (before navigating)
+    // testEnv.user is a pre-registered test user created by create-test-env.php with password 'freegle'
     await loginViaHomepage(
       page,
-      existingTestEmail,
-      environment.unmodded_password
+      testEnv.user.email,
+      'freegle'
     )
     await waitForAuthInLocalStorage(page)
     console.log('[Test] Logged in as existingTestEmail')


### PR DESCRIPTION
## Summary

- **Sparse-array crash on mobile post submit**: When a logged-in user visited `/give/mobile/photos` or `/find/mobile/photos`, the compose store's synthetic default message (id=1, not in `composeStore.messages`) could slip through the filter in `photos.vue` and `details.vue`. This created a sparse `messages` array `[empty, {id:1}]` in Pinia state. After the JSON round-trip on submit, `prune()` compacted it to `[{id:1}]` at index 0, so `this.messages[message.id]` returned `undefined` → TypeError crash on submit. Fixed by adding `&& composeStore.messages[m.id]` guard to all four mobile pages (give and find), and fixing `submit()` to use `message.attachments` directly and `parseInt(id)` (loop index) instead of `message.id` for `markSubmitted()`.
- **Reply-flow tests using non-existent user**: Tests 1.1/1.2/1.3 in `test-reply-flow-logged-in.spec.js` were logging in as `test@test.com` which does not exist in the test database. Switched to `testEnv.user.email` created by `create-test-env.php`.

## Code Quality Review

- Guard is consistent across all four mobile pages (give/mobile and find/mobile photos + details)
- `submit()` fix eliminates reliance on array index matching message id — no longer fragile after compaction
- New regression tests cover both OFFER (give) and WANTED (find) mobile flows end-to-end

## Test plan

- [ ] New Playwright regression test in `test-post-flow.spec.js` covers the full logged-in mobile OFFER (give) flow without crash
- [ ] New Playwright regression test covers the full mobile WANTED (find) flow without crash
- [ ] `test-reply-flow-logged-in.spec.js` tests 1.1/1.2/1.3 pass with the correct testEnv user
- [ ] `stores/compose.spec.js` — existing tests pass