### PR TITLE
refactor(index): replace top-level await with onServerPrefetch for deterministic coverage

### DIFF
--- a/iznik-nuxt3/pages/index.vue
+++ b/iznik-nuxt3/pages/index.vue
@@ -116,6 +116,7 @@ import {
   ref,
   onMounted,
   onBeforeUnmount,
+  onServerPrefetch,
   nextTick,
   useHead,
   useRuntimeConfig,
@@ -153,28 +154,32 @@ const head = buildHead(
 
 useHead(head)
 
-await groupStore.fetch()
+// SSR data prefetch — onServerPrefetch keeps the setup function synchronous,
+// which produces a stable V8-coverage source map between builds.
+onServerPrefetch(async () => {
+  await groupStore.fetch()
 
-try {
-  const list = await messageStore.fetchInBounds(
-    49.45,
-    -9,
-    61,
-    2,
-    null,
-    50,
-    true
-  )
-  const offers = list.filter((item) => item.type === 'Offer')
+  try {
+    const list = await messageStore.fetchInBounds(
+      49.45,
+      -9,
+      61,
+      2,
+      null,
+      50,
+      true
+    )
+    const offers = list.filter((item) => item.type === 'Offer')
 
-  const preloadPromises = []
-  for (const offer of offers.slice(0, 12)) {
-    preloadPromises.push(messageStore.fetch(offer.id))
+    const preloadPromises = []
+    for (const offer of offers.slice(0, 12)) {
+      preloadPromises.push(messageStore.fetch(offer.id))
+    }
+    await Promise.all(preloadPromises)
+  } catch (e) {
+    console.log('SSR: Failed to prefetch messages', e)
   }
-  await Promise.all(preloadPromises)
-} catch (e) {
-  console.log('SSR: Failed to prefetch messages', e)
-}
+})
 
 // Computed properties
 const me = computed(() => {


### PR DESCRIPTION
## Summary

Moves the two SSR data-fetch blocks in `pages/index.vue` from top-level `await` in `<script setup>` to `onServerPrefetch`.

## Context

This is the anonymous landing page (`v-if="!me"`). Logged-in users — including all mobile-app users — are redirected away in `onMounted` by `goHome()` before they see any of this content, so the data fetch is irrelevant to the mobile logged-in flow.

The sample offers grid below the hero (`LazyMobileVisualiseList`) uses `hydrate-on-visible` lazy hydration and fetches its own data when it mounts. The parent-level prefetch is an optimisation that pre-populates the store before the child hydrates, avoiding a flash of empty content on the initial SSR response.

## Behaviour change

`onServerPrefetch` is **server-only**. The original top-level `await` ran on both SSR *and* client-side navigation. After this change, a logged-out user navigating to `/` via client-side routing will not get the store pre-populated — `LazyMobileVisualiseList` will hydrate and fetch its own data instead (showing the shimmer skeleton briefly). This is acceptable because the prefetch was always optional (the catch block logs `'SSR: Failed to prefetch messages'`).

## Why this fixes non-deterministic coverage

Top-level `await` makes the setup function async. V8 instruments async functions with synthetic continuation points (microtask-scheduling machinery) that appear in coverage byte-range data. These synthetic points map back to source lines via the source map, but since they are compiler-generated the mapping is unstable between builds — producing 25 vs 31 `relevant lines` for this file between otherwise identical CI runs.

`onServerPrefetch` keeps setup synchronous. V8 instruments synchronous functions without the extra continuation points, so the source lines annotated as executable are stable across builds.

## Test plan

- [ ] Landing page (`/`) loads correctly with Give/Find buttons and the photo grid for a logged-out user
- [ ] Sample offers load (may show shimmer briefly on client-side nav, then populate)
- [ ] App download badges visible on non-app browsers (`v-if="!isApp"`)
- [ ] Logged-in user navigating to `/` is redirected by `goHome()` as before
- [ ] `test-pages.spec.js` `/` test passes (title check)
- [ ] Coverage count for `pages/index.vue` is stable between CI runs