### PR TITLE
fix(modtools): add null/undefined check for spammer object before accessing reason property

### DIFF
--- a/iznik-nuxt3/modtools/components/ModSpammer.vue
+++ b/iznik-nuxt3/modtools/components/ModSpammer.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="user">
+  <div v-if="user && user.spammer">
     <NoticeMessage :variant="variant" class="mb-1">
       <div>
         {{ user.displayname }} {{ collname }}: {{ user.spammer.reason }}

--- a/iznik-nuxt3/tests/e2e/test-modtools-member-spammer-crash.spec.js
+++ b/iznik-nuxt3/tests/e2e/test-modtools-member-spammer-crash.spec.js
@@ -1,0 +1,65 @@
+// @ts-check
+/**
+ * Test for ModTools Members filtering crash when spammer object doesn't exist.
+ *
+ * Bug: When filtering Members by 'Approved' status with 'Banned' flag,
+ * ModSpammer component crashes with "Cannot read property 'reason' of undefined"
+ * because the backend returns members without spammer data, and the component
+ * tries to access spammer.reason without checking if spammer exists.
+ */
+
+const { test, expect } = require('./fixtures')
+const { timeouts, environment } = require('./config')
+const { loginViaModTools } = require('./utils/user')
+
+const MODTOOLS_URL = environment.modtoolsBaseUrl
+
+test.describe('ModTools Members Spammer Crash', () => {
+  test('should not crash when filtering members by Approved+Banned with missing spammer data', async ({
+    page,
+    testEnv,
+  }) => {
+    await loginViaModTools(page, testEnv.mod.email)
+
+    // Navigate to members list
+    await page.goto(`${MODTOOLS_URL}/members`, {
+      waitUntil: 'domcontentloaded',
+      timeout: timeouts.navigation.initial,
+    })
+
+    // Wait for the members page to load
+    await expect(page.locator('.members-list, [data-testid="members-list"]')).toBeVisible({
+      timeout: timeouts.navigation.slowPage,
+    })
+
+    // Apply filter for 'Approved' status - look for status filter dropdown or button
+    const statusFilterButton = page.locator(
+      'button:has-text("Approved"), [data-testid="status-filter"], .status-filter'
+    ).first()
+
+    if (await statusFilterButton.isVisible()) {
+      await statusFilterButton.click()
+    }
+
+    // Apply filter for 'Banned' flag - look for banned filter
+    const bannedFilterButton = page.locator(
+      'button:has-text("Banned"), [data-testid="banned-filter"], .banned-filter'
+    ).first()
+
+    if (await bannedFilterButton.isVisible()) {
+      await bannedFilterButton.click()
+    }
+
+    // The test passes if we get here without a 500 error or component crash
+    // Check that the page didn't show an error or HTTP 500
+    const errorMsg = page.locator(
+      'text=/Error|500|Internal Server Error/i'
+    )
+
+    // Wait a moment for any errors to appear
+    await page.waitForTimeout(1000)
+
+    // Assert that we didn't get an error
+    await expect(errorMsg).not.toBeVisible()
+  })
+})

--- a/iznik-nuxt3/tests/unit/components/modtools/ModSpammer.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModSpammer.spec.js
@@ -243,5 +243,64 @@ describe('ModSpammer', () => {
       expect(wrapper.text()).toContain('Minimal User')
       expect(wrapper.text()).toContain('Confirmed Spammer')
     })
+
+    it('handles user without spammer data when filtering by Approved+Banned', () => {
+      const user = {
+        id: 100,
+        displayname: 'User Without Spammer',
+        spammer: null,
+      }
+      const wrapper = mountComponent({ user })
+      // Component should not crash - it should either render nothing or render gracefully
+      expect(wrapper.exists()).toBe(true)
+      // Should not try to access undefined.reason
+      expect(() => wrapper.vm.$forceUpdate()).not.toThrow()
+    })
+
+    it('handles user with undefined spammer', () => {
+      const user = {
+        id: 101,
+        displayname: 'User With Undefined Spammer',
+      }
+      populateUserStore(user)
+      const wrapper = mount(ModSpammer, {
+        props: { userid: user.id },
+        global: {
+          mocks: {
+            timeago: vi.fn(() => '3 days ago'),
+          },
+          stubs: {
+            NoticeMessage: {
+              template:
+                '<div class="notice" :class="\'notice-\' + variant"><slot /></div>',
+              props: ['variant'],
+            },
+            'notice-message': {
+              template:
+                '<div class="notice" :class="\'notice-\' + variant"><slot /></div>',
+              props: ['variant'],
+            },
+            ExternalLink: {
+              template: '<a :href="href"><slot /></a>',
+              props: ['href'],
+            },
+            ModClipboard: {
+              template: '<span class="clipboard" />',
+              props: ['value'],
+            },
+            'nuxt-link': {
+              template: '<a :href="to"><slot /></a>',
+              props: ['to'],
+            },
+            'v-icon': {
+              template: '<span class="icon" />',
+              props: ['icon', 'scale'],
+            },
+          },
+        },
+      })
+      // Component should not crash
+      expect(wrapper.exists()).toBe(true)
+    })
   })
 })


### PR DESCRIPTION
## Root cause
Backend API tries to read spammer.reason without checking if spammer object exists first; member records without spammer data cause undefined object access

## Fix
Added null/undefined check for spammer object in ModSpammer component template to prevent accessing undefined properties. When a member doesn't have spammer data, the component no longer renders, avoiding the crash.

## Test
File: iznik-nuxt3/tests/e2e/test-modtools-member-spammer-crash.spec.js
Command: curl -s -X POST http://localhost:8081/api/tests/playwright