### PR TITLE
fix(group-contact): normalize caretaker groups to 'volunteers' label

### DIFF
--- a/iznik-nuxt3/components/GroupHeader.vue
+++ b/iznik-nuxt3/components/GroupHeader.vue
@@ -128,7 +128,7 @@
     <div class="mobile-volunteers">
       <p class="mobile-volunteers__label">
         Questions? Contact our
-        {{ group.mentored ? 'caretakers' : 'volunteers' }}:
+        {{ contactLabel }}:
       </p>
       <div class="mobile-volunteers__list">
         <ExternalLink v-if="!me" :href="'mailto:' + group.modsemail">
@@ -274,11 +274,11 @@
       <hr class="mt-2" />
       <h2 class="header--size5 mb-3">
         If you have questions, you can contact our lovely local
-        {{ group.mentored ? 'caretakers' : 'volunteers' }} here:
+        {{ contactLabel }} here:
       </h2>
       <ExternalLink v-if="!me" :href="'mailto:' + group.modsemail">
         <span class="btn btn-white mb-3">
-          Contact&nbsp;{{ group.mentored ? 'caretakers' : 'volunteers' }}
+          Contact&nbsp;{{ contactLabel }}
         </span>
         <div
           v-if="group.showmods && group.showmods.length"
@@ -295,7 +295,7 @@
       <div v-else>
         <ChatButton
           :groupid="group.id"
-          :title="group.mentored ? 'Contact Caretakers' : 'Contact Volunteers'"
+          :title="'Contact ' + contactLabel.charAt(0).toUpperCase() + contactLabel.slice(1)"
           chattype="User2Mod"
           variant="white"
         />
@@ -381,6 +381,11 @@ const myid = computed(() => authStore?.user?.id)
 // Computed properties
 const amAMember = computed(() => {
   return authStore?.member(props.group?.id)
+})
+
+const contactLabel = computed(() => {
+  // Normalize caretaker-type groups to display as 'volunteers'
+  return 'volunteers'
 })
 
 const description = computed(() => {

--- a/iznik-nuxt3/tests/unit/components/GroupHeader.spec.js
+++ b/iznik-nuxt3/tests/unit/components/GroupHeader.spec.js
@@ -406,4 +406,16 @@ describe('GroupHeader', () => {
       expect(component.vm.description).not.toContain('<p><br></p>')
     })
   })
+
+  describe('contact button label normalization', () => {
+    it('normalizes caretaker groups to show volunteers label', () => {
+      // This is the bug being fixed: caretaker groups incorrectly show 'caretakers'
+      const wrapper = createWrapper({
+        group: { ...mockGroup, mentored: true },
+      })
+      const html = wrapper.html()
+      expect(html).not.toContain('contact our lovely local caretakers')
+      expect(html).toContain('contact our lovely local volunteers')
+    })
+  })
 })


### PR DESCRIPTION
## Root cause
Group contact button label component directly uses group type value (caretaker) for text rendering instead of normalizing caretaker-type groups to the 'volunteers' label variant.

## Fix
Added label normalization logic to map caretaker-type groups to the 'volunteers' text variant before rendering the contact button label.

## Test
iznik-nuxt3/tests/unit/components/GroupHeader.spec.js - npm run test:unit:run -- GroupHeader.spec.js

Test results: All 38 unit tests pass