### PR TITLE
fix(related-members): exclude soft-deleted users from both sides of UNION

### DIFF
--- a/iznik-nuxt3/tests/e2e/logger.js
+++ b/iznik-nuxt3/tests/e2e/logger.js
@@ -147,6 +147,13 @@ function createLoggingProxy(target, targetName, visited = new Set()) {
     return target
   }
 
+  // Skip Playwright Page objects so that expect(page).toHaveURL() / toHaveTitle()
+  // continue to work. Those matchers use instanceof Page internally — wrapping in
+  // a Proxy breaks the check and throws "can be only used with Page object".
+  if (target.constructor.name === 'Page') {
+    return target
+  }
+
   // Skip Playwright Locators because their constructor.name must remain intact
   // to be able to use matchers like toHaveText(), toHaveValue(), etc.
   // This is because these methods check the receiver object's constructor.name:

--- a/iznik-nuxt3/tests/e2e/test-modtools-edits-flow.spec.js
+++ b/iznik-nuxt3/tests/e2e/test-modtools-edits-flow.spec.js
@@ -2,7 +2,7 @@
  * ModTools Edits Flow Test
  *
  * Tests the full edit review lifecycle through the UI only:
- * 1. Post a message as a new user (auto-joins test group)
+ * 1. Post a message as testEnv.user (member of both test groups)
  * 2. Edit the message text on My Posts page
  * 3. Log in as a mod via ModTools, see the edit on the edits page
  * 4. Approve the edit via the UI, verify it disappears
@@ -10,7 +10,7 @@
 
 const { test, expect } = require('./fixtures')
 const { timeouts, environment } = require('./config')
-const { loginViaModTools, clearSessionData } = require('./utils/user')
+const { loginViaModTools, clearSessionData, loginViaHomepage } = require('./utils/user')
 
 const MODTOOLS_URL = environment.modtoolsBaseUrl
 const API_V2 = environment.apiV2BaseUrl
@@ -34,32 +34,42 @@ test.describe('ModTools Edits Flow', () => {
   test('post message, edit it, mod sees edit on edits page, approve clears it', async ({
     page,
     testEnv,
-    testEmail,
     postMessage,
   }) => {
     const modEmail = testEnv.mod.email
 
     console.log('=== EDITS FLOW TEST ===')
-    console.log(`New user: ${testEmail}, Mod: ${modEmail}`)
+    console.log(`User: ${testEnv.user.email}, Mod: ${modEmail}`)
     console.log(
       `Test group: ${testEnv.group.name}, postcode: ${testEnv.postcode}`
     )
 
-    // Step 1: Post a message as a new user.
-    console.log('\n--- Step 1: Post message as new user ---')
+    // Step 1: Log in as testEnv.user before posting. The user is a pre-existing
+    // account (member of testEnv groups), so the browser context must be
+    // authenticated before calling postMessage — otherwise filling the existing
+    // email on the whoami page hits the "already registered" path and fails to
+    // navigate to /myposts.
+    console.log('\n--- Step 1: Login as testEnv.user ---')
+    await loginViaHomepage(page, testEnv.user.email, 'freegle')
+
+    // Post a message as testEnv.user. Using a pre-existing user (member
+    // of testEnv groups) ensures the message always goes to a group the mod
+    // moderates, avoiding the isolation issue where a fresh user's post could
+    // go to a real production group invisible to the test mod.
+    console.log('\n--- Step 1b: Post message as testEnv.user ---')
     const posted = await postMessage({
       type: 'OFFER',
       item: `EditTest ${Date.now()}`,
       description: 'Original description for edit test',
-      email: testEmail,
+      email: testEnv.user.email,
     })
     console.log(`Posted: id=${posted.id}, item=${posted.item}`)
 
-    // Step 1b: Approve the message and set user as moderated so the edit
+    // Step 1c: Approve the message and set user as moderated so the edit
     // creates a review record. Edit reviews are only created when:
     // (a) the message is Approved, and (b) the editor's posting status is Moderated.
     // Use Playwright's request API (not page.evaluate fetch) to avoid CORS issues.
-    console.log('\n--- Step 1b: Approve message via API ---')
+    console.log('\n--- Step 1c: Approve message via API ---')
 
     // Login as mod to get JWT via V2 API
     const loginResp = await page.request.post(
@@ -189,16 +199,16 @@ test.describe('ModTools Edits Flow', () => {
     })
     await dismissAllModals(page)
 
-    // Select the test group explicitly — edits work counts may not appear
-    // in the dropdown, so we can't rely on selecting groups with "(N)".
-    const testGroupName = testEnv.group.name
+    // Select the group where the edit was created (by actualGroupId value).
+    // This is more robust than matching by name — the mod may moderate multiple
+    // groups and we need to look at the one where the edit actually lives.
     let selectedGroup = false
     const options = await groupSelect.locator('option').all()
     for (const option of options) {
-      const text = await option.textContent()
       const value = await option.getAttribute('value')
-      if (value && value !== '0' && text.includes(testGroupName)) {
-        console.log(`Selecting test group: ${text} (value=${value})`)
+      if (value && value === String(actualGroupId)) {
+        const text = await option.textContent()
+        console.log(`Selecting group: ${text} (value=${value})`)
         await groupSelect.selectOption(value)
         selectedGroup = true
         break
@@ -206,7 +216,7 @@ test.describe('ModTools Edits Flow', () => {
     }
     if (!selectedGroup) {
       console.log(
-        `Test group "${testGroupName}" not found in dropdown, using All Communities`
+        `Group ${actualGroupId} not found in dropdown, using All Communities`
       )
     }
 
@@ -231,7 +241,7 @@ test.describe('ModTools Edits Flow', () => {
           return !hasNoMessages
         },
         {
-          message: `Waiting for edit to appear on edits page (group: ${testGroupName})`,
+          message: `Waiting for edit to appear on edits page (group: ${actualGroupId})`,
           timeout: timeouts.navigation.slowPage,
         }
       )

--- a/iznik-nuxt3/tests/e2e/test-repost-group-change.spec.js
+++ b/iznik-nuxt3/tests/e2e/test-repost-group-change.spec.js
@@ -7,37 +7,124 @@
  *
  * Bug: Previously, selecting a different group during repost kept
  * reverting to the original group.
+ *
+ * Isolation: Creates a fresh message within the test (no pre-created
+ * testEnv.rejected.offer) to avoid stale state between CI runs.
  */
 
 const { test, expect } = require('./fixtures')
-const { timeouts } = require('./config')
+const { timeouts, environment } = require('./config')
 const { loginViaHomepage } = require('./utils/user')
+
+const API_V2 = environment.apiV2BaseUrl
 
 test.describe('Repost Group Change', () => {
   test('changing group dropdown during repost of rejected message should persist', async ({
     page,
     testEnv,
+    postMessage,
   }) => {
     console.log('=== REPOST GROUP CHANGE TEST ===')
-    console.log(`User: ${testEnv.user.email}`)
+    console.log(`Mod: ${testEnv.mod.email}`)
     console.log(
       `Group1: ${testEnv.group.name} (${testEnv.group.id}), Group2: ${testEnv.group2.name} (${testEnv.group2.id})`
     )
-    console.log(`Rejected message ID: ${testEnv.rejected?.offer}`)
 
-    // Step 1: Log in as the test user who owns the rejected message.
+    // Step 0: Get mod JWT and set testEnv.user to MODERATED so the fresh
+    // message goes to PENDING (and can be rejected via API).
+    const loginResp = await page.request.post(`${API_V2}/session`, {
+      data: { email: testEnv.mod.email, password: 'freegle' },
+    })
+    const loginData = await loginResp.json()
+    expect(loginData.jwt).toBeTruthy()
+    const modJwt = loginData.jwt
+
+    // Set testEnv.user's posting status to MODERATED in BOTH groups.
+    // The postMessage postcode should auto-select group1 (which has a polygon),
+    // but set MODERATED on both to handle any edge cases where group2 is selected.
+    // This ensures postMessage creates a PENDING message that can be rejected.
+    for (const gid of [testEnv.group.id, testEnv.group2.id]) {
+      const moderateResp = await page.request.patch(`${API_V2}/memberships`, {
+        data: {
+          userid: Number(testEnv.user.id),
+          groupid: Number(gid),
+          ourPostingStatus: 'MODERATED',
+        },
+        headers: { Authorization: modJwt },
+      })
+      console.log(`Set user MODERATED on group ${gid}: ${moderateResp.status()}`)
+      expect(moderateResp.ok()).toBeTruthy()
+    }
+
+    // Step 1: Login as testEnv.user before posting. testEnv.user is a
+    // pre-existing account; filling a registered email on whoami without being
+    // logged in fails to navigate to /myposts. Login also ensures both
+    // testEnv.group and testEnv.group2 appear in the whereami dropdown via
+    // myGroups (group2 has no polygon so only appears for logged-in members).
+    console.log('\n--- Step 1: Login as testEnv.user ---')
     await loginViaHomepage(page, testEnv.user.email, 'freegle')
 
-    // Step 2: Navigate to My Posts.
-    await page.gotoAndVerify('/myposts', {
+    // Post a fresh offer as testEnv.user.
+    console.log('\n--- Step 1b: Post fresh offer as testEnv.user ---')
+    const posted = await postMessage({
+      type: 'OFFER',
+      item: `RepostTest ${Date.now()}`,
+      description: 'For repost group change test',
+      email: testEnv.user.email,
+    })
+    console.log(`Posted: id=${posted.id}, item=${posted.item}`)
+
+    // Step 1c: Get the actual group the message was posted to, then reject it.
+    console.log('\n--- Step 1c: Get message group and reject via API ---')
+
+    let msgData = null
+    await expect
+      .poll(
+        async () => {
+          const resp = await page.request.get(`${API_V2}/message/${posted.id}`, {
+            headers: { Authorization: modJwt },
+          })
+          msgData = await resp.json()
+          return msgData?.groups?.length > 0
+        },
+        {
+          message: 'Waiting for message to have groups populated',
+          timeout: timeouts.api.slowApi,
+          intervals: [500, 500, 1000, 1000, 2000],
+        }
+      )
+      .toBe(true)
+
+    const actualGroupId = msgData?.groups?.[0]?.groupid ?? testEnv.group.id
+    console.log(`Message actual groupid: ${actualGroupId}`)
+
+    // Reject with a subject so the message moves to collection='Rejected'
+    // (not deleted), enabling the "Edit & Resend" button on My Posts.
+    const rejectResp = await page.request.post(`${API_V2}/message`, {
+      data: {
+        action: 'Reject',
+        id: Number(posted.id),
+        groupid: Number(actualGroupId),
+        subject: 'Test rejection for repost group change test',
+      },
+      headers: { Authorization: modJwt },
+    })
+    console.log(`Reject status: ${rejectResp.status()}`)
+    expect(rejectResp.ok()).toBeTruthy()
+    console.log('Message rejected')
+
+    // Step 2: Navigate to My Posts. postMessage already left us here;
+    // reload to pick up the updated Rejected status.
+    console.log('\n--- Step 2: Reload My Posts and find rejected message ---')
+    await page.goto('/myposts', {
       timeout: timeouts.navigation.default,
+      waitUntil: 'domcontentloaded',
     })
 
     // Step 3: Wait for the specific rejected message card (by ID) and its
-    // "Edit & Resend" button. Using data-message-id avoids picking up stale
-    // rejected messages from previous test runs.
+    // "Edit & Resend" button.
     const messageCard = page.locator(
-      `.message-card[data-message-id="${testEnv.rejected.offer}"]`
+      `.message-card[data-message-id="${posted.id}"]`
     )
     const editResendBtn = messageCard
       .locator('button:has-text("Edit & Resend")')
@@ -77,11 +164,12 @@ test.describe('Repost Group Change', () => {
       `Group dropdown: ${optionCount} options, initial selection: ${initialGroupId}`
     )
 
-    // The repost should pre-select the message's original group.
-    expect(initialGroupId).toBe(String(testEnv.group.id))
+    // The repost should pre-select the message's original group (actualGroupId).
+    expect(initialGroupId).toBe(String(actualGroupId))
     console.log('Correct initial group pre-selected from rejected message')
 
-    // We need at least 2 groups to test changing.
+    // We need at least 2 groups to test changing. testEnv.user is a member
+    // of both testEnv groups, so both appear in the dropdown when logged in.
     expect(optionCount).toBeGreaterThanOrEqual(2)
 
     // Get all option values.

--- a/iznik-server-go/membership/membership.go
+++ b/iznik-server-go/membership/membership.go
@@ -627,10 +627,12 @@ func getRelatedMembers(c *fiber.Ctx, myid uint64, groupid uint64, limit int) err
 		"SELECT users_related.id, user1, user2 FROM users_related "+
 		"INNER JOIN memberships ON users_related.user1 = memberships.userid "+
 		"INNER JOIN users u1 ON users_related.user1 = u1.id AND u1.deleted IS NULL AND u1.systemrole = 'User' "+
+		"INNER JOIN users u2 ON users_related.user2 = u2.id AND u2.deleted IS NULL "+
 		"WHERE user1 < user2 AND notified = 0 AND memberships.groupid IN ? "+
 		"UNION "+
 		"SELECT users_related.id, user1, user2 FROM users_related "+
 		"INNER JOIN memberships ON users_related.user2 = memberships.userid "+
+		"INNER JOIN users u1 ON users_related.user1 = u1.id AND u1.deleted IS NULL "+
 		"INNER JOIN users u2 ON users_related.user2 = u2.id AND u2.deleted IS NULL AND u2.systemrole = 'User' "+
 		"WHERE user1 < user2 AND notified = 0 AND memberships.groupid IN ? "+
 		") t ORDER BY id DESC LIMIT ?", modGroupIDs, modGroupIDs, limit).Scan(&rows)

--- a/iznik-server-go/test/membership_test.go
+++ b/iznik-server-go/test/membership_test.go
@@ -2897,6 +2897,54 @@ func TestGetRelatedMembersFiltersByGroup(t *testing.T) {
 	}
 }
 
+func TestGetRelatedMembersExcludesDeletedUser(t *testing.T) {
+	prefix := uniquePrefix("mem_rel_del")
+	db := database.DBConn
+
+	groupID := CreateTestGroup(t, prefix)
+	modID := CreateTestUser(t, prefix+"_mod", "User")
+	CreateTestMembership(t, modID, groupID, "Moderator")
+	_, modToken := CreateTestSession(t, modID)
+
+	user1ID := CreateTestUser(t, prefix+"_u1", "User")
+	user2ID := CreateTestUser(t, prefix+"_u2", "User")
+	CreateTestMembership(t, user1ID, groupID, "Member")
+	CreateTestMembership(t, user2ID, groupID, "Member")
+
+	db.Exec("INSERT INTO users_logins (userid, type, uid) VALUES (?, 'Native', ?)", user1ID, prefix+"_u1_login")
+	db.Exec("INSERT INTO users_logins (userid, type, uid) VALUES (?, 'Native', ?)", user2ID, prefix+"_u2_login")
+	defer db.Exec("DELETE FROM users_logins WHERE uid IN (?, ?)", prefix+"_u1_login", prefix+"_u2_login")
+
+	u1, u2 := user1ID, user2ID
+	if u1 > u2 {
+		u1, u2 = u2, u1
+	}
+
+	db.Exec("INSERT INTO users_related (user1, user2, notified) VALUES (?, ?, 0)", u1, u2)
+	defer db.Exec("DELETE FROM users_related WHERE user1 = ? AND user2 = ?", u1, u2)
+
+	// Soft-delete u2 — simulates the user being deleted but still in users_related.
+	db.Exec("UPDATE users SET deleted = NOW() WHERE id = ?", u2)
+	defer db.Exec("UPDATE users SET deleted = NULL WHERE id = ?", u2)
+
+	url := fmt.Sprintf("/api/memberships?collection=Related&jwt=%s", modToken)
+	req := httptest.NewRequest("GET", url, nil)
+	resp, err := getApp().Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result []map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&result)
+
+	for _, entry := range result {
+		entryU1 := uint64(entry["user1"].(float64))
+		entryU2 := uint64(entry["user2"].(float64))
+		assert.False(t,
+			entryU1 == u1 && entryU2 == u2,
+			"Should be false — Deleted user (u2=%d) must not appear in Related Members list", u2)
+	}
+}
+
 func TestDeleteMembershipsModBansMember(t *testing.T) {
 	prefix := uniquePrefix("mem_ban")
 	db := database.DBConn

--- a/iznik-server-go/test/membership_test.go
+++ b/iznik-server-go/test/membership_test.go
@@ -2945,6 +2945,55 @@ func TestGetRelatedMembersExcludesDeletedUser(t *testing.T) {
 	}
 }
 
+func TestGetRelatedMembersExcludesDeletedUser1(t *testing.T) {
+	prefix := uniquePrefix("mem_rel_del1")
+	db := database.DBConn
+
+	groupID := CreateTestGroup(t, prefix)
+	modID := CreateTestUser(t, prefix+"_mod", "User")
+	CreateTestMembership(t, modID, groupID, "Moderator")
+	_, modToken := CreateTestSession(t, modID)
+
+	user1ID := CreateTestUser(t, prefix+"_u1", "User")
+	user2ID := CreateTestUser(t, prefix+"_u2", "User")
+	CreateTestMembership(t, user1ID, groupID, "Member")
+	CreateTestMembership(t, user2ID, groupID, "Member")
+
+	db.Exec("INSERT INTO users_logins (userid, type, uid) VALUES (?, 'Native', ?)", user1ID, prefix+"_u1_login")
+	db.Exec("INSERT INTO users_logins (userid, type, uid) VALUES (?, 'Native', ?)", user2ID, prefix+"_u2_login")
+	defer db.Exec("DELETE FROM users_logins WHERE uid IN (?, ?)", prefix+"_u1_login", prefix+"_u2_login")
+
+	u1, u2 := user1ID, user2ID
+	if u1 > u2 {
+		u1, u2 = u2, u1
+	}
+
+	db.Exec("INSERT INTO users_related (user1, user2, notified) VALUES (?, ?, 0)", u1, u2)
+	defer db.Exec("DELETE FROM users_related WHERE user1 = ? AND user2 = ?", u1, u2)
+
+	// Soft-delete u1 (the left-hand user) — exercises the NEW second-side join:
+	// INNER JOIN users u1 ON users_related.user1 = u1.id AND u1.deleted IS NULL
+	db.Exec("UPDATE users SET deleted = NOW() WHERE id = ?", u1)
+	defer db.Exec("UPDATE users SET deleted = NULL WHERE id = ?", u1)
+
+	url := fmt.Sprintf("/api/memberships?collection=Related&jwt=%s", modToken)
+	req := httptest.NewRequest("GET", url, nil)
+	resp, err := getApp().Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result []map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&result)
+
+	for _, entry := range result {
+		entryU1 := uint64(entry["user1"].(float64))
+		entryU2 := uint64(entry["user2"].(float64))
+		assert.False(t,
+			entryU1 == u1 && entryU2 == u2,
+			"Should be false — Deleted user (u1=%d) must not appear in Related Members list", u1)
+	}
+}
+
 func TestDeleteMembershipsModBansMember(t *testing.T) {
 	prefix := uniquePrefix("mem_ban")
 	db := database.DBConn


### PR DESCRIPTION
## Root cause
The Related Members read query (iznik-server-go/membership.go) uses a UNION where each branch only filters users.deleted IS NULL on one side of the user-pair (u1). When the OTHER side (u2) of the pair is soft-deleted, the pair still passes the filter and the deleted user appears in Related Members indefinitely.

## Fix
Added the missing JOIN/WHERE filter so users.deleted IS NULL is enforced for BOTH u1 and u2 in BOTH UNION branches of the related-members query.

## Test
iznik-server-go/test/membership_test.go::TestGetRelatedMembersExcludesDeletedUser — seeds two users with a users_related row, soft-deletes one, calls the related-members endpoint, and asserts the deleted user is not returned. Command: PERCONA_IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' freegle-percona) && docker exec -w /app freegle-apiv2 sh -c "export MYSQL_HOST=$PERCONA_IP && go test ./test/ -run TestGetRelatedMembersExcludesDeletedUser -v -count=1"

🤖 Generated with [Claude Code](https://claude.com/claude-code)