### PR TITLE
fix(modtools/related-members): derive related-members counter from array length so new pairs increment after zeroing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,8 +92,16 @@ jobs:
                 "https://runner.circleci.com/api/v3/runner?resource-class=freegle/circleci-docker-runner" 2>/dev/null) || true
 
               if [ -n "$RESPONSE" ]; then
-                ONLINE_COUNT=$(echo "$RESPONSE" | jq '[.items[] | select(.resource_class=="freegle/circleci-docker-runner")] | length' 2>/dev/null) || ONLINE_COUNT=0
-                echo "Found ${ONLINE_COUNT} runner(s)"
+                # Check for runners that were connected in the last 5 minutes
+                # A runner is only usable if it's recently connected (last_connected within 5 min)
+                FIVE_MIN_AGO=$(date -u -d '5 minutes ago' '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || echo "")
+                if [ -n "$FIVE_MIN_AGO" ]; then
+                  ONLINE_COUNT=$(echo "$RESPONSE" | jq --arg cutoff "$FIVE_MIN_AGO" '[.items[] | select(.resource_class=="freegle/circleci-docker-runner" and (.last_connected > $cutoff))] | length' 2>/dev/null) || ONLINE_COUNT=0
+                else
+                  # Fallback if date command doesn't support -d (some systems)
+                  ONLINE_COUNT=$(echo "$RESPONSE" | jq '[.items[] | select(.resource_class=="freegle/circleci-docker-runner")] | length' 2>/dev/null) || ONLINE_COUNT=0
+                fi
+                echo "Found ${ONLINE_COUNT} recently-connected runner(s)"
                 if [ "$ONLINE_COUNT" -gt "0" ]; then
                   RUNNER_AVAILABLE=true
                 fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,9 @@ jobs:
                 # A runner is only usable if it's recently connected (last_connected within 5 min)
                 FIVE_MIN_AGO=$(date -u -d '5 minutes ago' '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || echo "")
                 if [ -n "$FIVE_MIN_AGO" ]; then
-                  ONLINE_COUNT=$(echo "$RESPONSE" | jq --arg cutoff "$FIVE_MIN_AGO" '[.items[] | select(.resource_class=="freegle/circleci-docker-runner" and (.last_connected > $cutoff))] | length' 2>/dev/null) || ONLINE_COUNT=0
+                  # Normalize timestamps by removing microseconds, then compare
+                  # String comparison works for ISO 8601 when precision is uniform
+                  ONLINE_COUNT=$(echo "$RESPONSE" | jq --arg cutoff "$FIVE_MIN_AGO" '[.items[] | select(.resource_class=="freegle/circleci-docker-runner" and ((.last_connected | split(".")[0] + "Z") >= $cutoff))] | length' 2>/dev/null) || ONLINE_COUNT=0
                 else
                   # Fallback if date command doesn't support -d (some systems)
                   ONLINE_COUNT=$(echo "$RESPONSE" | jq '[.items[] | select(.resource_class=="freegle/circleci-docker-runner")] | length' 2>/dev/null) || ONLINE_COUNT=0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,8 @@ jobs:
                 if [ -n "$FIVE_MIN_AGO" ]; then
                   # Normalize timestamps by removing microseconds, then compare
                   # String comparison works for ISO 8601 when precision is uniform
-                  ONLINE_COUNT=$(echo "$RESPONSE" | jq --arg cutoff "$FIVE_MIN_AGO" '[.items[] | select(.resource_class=="freegle/circleci-docker-runner" and ((.last_connected | split(".")[0] + "Z") >= $cutoff))] | length' 2>/dev/null) || ONLINE_COUNT=0
+                  # Use try-catch to gracefully handle missing or malformed last_connected
+                  ONLINE_COUNT=$(echo "$RESPONSE" | jq --arg cutoff "$FIVE_MIN_AGO" '[.items[] | select(.resource_class=="freegle/circleci-docker-runner" and (try ((.last_connected | split(".")[0] + "Z") >= $cutoff) catch false))] | length' 2>/dev/null) || ONLINE_COUNT=0
                 else
                   # Fallback if date command doesn't support -d (some systems)
                   ONLINE_COUNT=$(echo "$RESPONSE" | jq '[.items[] | select(.resource_class=="freegle/circleci-docker-runner")] | length' 2>/dev/null) || ONLINE_COUNT=0

--- a/iznik-batch/tests/Unit/Services/SpamCheck/SpamCheckServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/SpamCheck/SpamCheckServiceTest.php
@@ -3,6 +3,8 @@
 namespace Tests\Unit\Services\SpamCheck;
 
 use App\Services\SpamCheck\SpamCheckService;
+use App\Services\SpamCheck\SpamResult;
+use Illuminate\Support\Facades\Http;
 use Tests\TestCase;
 
 class SpamCheckServiceTest extends TestCase
@@ -12,26 +14,85 @@ class SpamCheckServiceTest extends TestCase
         $this->assertTrue(class_exists(SpamCheckService::class));
     }
 
-    public function test_has_check_rspamd_method(): void
-    {
-        $service = new SpamCheckService();
-        $this->assertTrue(method_exists($service, 'checkRspamd'));
-    }
-
-    public function test_has_check_all_method(): void
-    {
-        $service = new SpamCheckService();
-        $this->assertTrue(method_exists($service, 'checkAll'));
-    }
-
-    public function test_has_check_spamassassin_method(): void
-    {
-        $service = new SpamCheckService();
-        $this->assertTrue(method_exists($service, 'checkSpamAssassin'));
-    }
-
     public function test_is_disabled_by_default(): void
     {
         $this->assertFalse(SpamCheckService::isEnabled());
+    }
+
+    public function test_check_rspamd_returns_spam_result_on_success(): void
+    {
+        Http::fake([
+            '*' => Http::response([
+                'score' => 2.5,
+                'action' => 'no action',
+                'symbols' => [
+                    'DKIM_SIGNED' => ['score' => 0.1],
+                ],
+            ], 200),
+        ]);
+
+        $service = new SpamCheckService();
+        $result = $service->checkRspamd("From: test@example.com\r\nSubject: Test\r\n\r\nBody");
+
+        $this->assertInstanceOf(SpamResult::class, $result);
+        $this->assertNull($result->error);
+        $this->assertFalse($result->isSpam);
+        $this->assertEquals(2.5, $result->score);
+    }
+
+    public function test_check_rspamd_returns_error_on_http_failure(): void
+    {
+        Http::fake([
+            '*' => Http::response('Server Error', 500),
+        ]);
+
+        $service = new SpamCheckService();
+        $result = $service->checkRspamd('test email');
+
+        $this->assertInstanceOf(SpamResult::class, $result);
+        $this->assertNotNull($result->error);
+        $this->assertStringContainsString('HTTP 500', $result->error);
+    }
+
+    public function test_check_rspamd_returns_error_on_empty_json(): void
+    {
+        Http::fake([
+            '*' => Http::response('', 200),
+        ]);
+
+        $service = new SpamCheckService();
+        $result = $service->checkRspamd('test email');
+
+        $this->assertInstanceOf(SpamResult::class, $result);
+        $this->assertNotNull($result->error);
+    }
+
+    public function test_check_spamassassin_returns_spam_result(): void
+    {
+        $service = new SpamCheckService();
+        $result = $service->checkSpamAssassin("From: test@example.com\r\nSubject: Test\r\n\r\nTest body");
+
+        $this->assertInstanceOf(SpamResult::class, $result);
+        $this->assertEquals('SpamAssassin', $result->engine);
+    }
+
+    public function test_check_all_returns_keyed_array(): void
+    {
+        Http::fake([
+            '*' => Http::response([
+                'score' => 0.1,
+                'action' => 'no action',
+                'symbols' => [],
+            ], 200),
+        ]);
+
+        $service = new SpamCheckService();
+        $results = $service->checkAll('test email');
+
+        $this->assertIsArray($results);
+        $this->assertArrayHasKey('spamassassin', $results);
+        $this->assertArrayHasKey('rspamd', $results);
+        $this->assertInstanceOf(SpamResult::class, $results['spamassassin']);
+        $this->assertInstanceOf(SpamResult::class, $results['rspamd']);
     }
 }

--- a/iznik-batch/tests/Unit/Services/SpamCheck/SpamCheckServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/SpamCheck/SpamCheckServiceTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\Unit\Services\SpamCheck;
+
+use App\Services\SpamCheck\SpamCheckService;
+use Tests\TestCase;
+
+class SpamCheckServiceTest extends TestCase
+{
+    public function test_class_exists(): void
+    {
+        $this->assertTrue(class_exists(SpamCheckService::class));
+    }
+
+    public function test_has_check_rspamd_method(): void
+    {
+        $service = new SpamCheckService();
+        $this->assertTrue(method_exists($service, 'checkRspamd'));
+    }
+
+    public function test_has_check_all_method(): void
+    {
+        $service = new SpamCheckService();
+        $this->assertTrue(method_exists($service, 'checkAll'));
+    }
+
+    public function test_has_check_spamassassin_method(): void
+    {
+        $service = new SpamCheckService();
+        $this->assertTrue(method_exists($service, 'checkSpamAssassin'));
+    }
+
+    public function test_is_disabled_by_default(): void
+    {
+        $this->assertFalse(SpamCheckService::isEnabled());
+    }
+}

--- a/iznik-nuxt3/modtools/stores/member.js
+++ b/iznik-nuxt3/modtools/stores/member.js
@@ -134,17 +134,15 @@ export const useMemberStore = defineStore({
             }
           })
 
-          // If the backend returned no actionable pairs, the work counter must
-          // reflect reality — the backend may have auto-resolved pairs without
-          // going through askMerge/ignoreMerge (e.g. one user had no login history).
+          // Derive the counter from the actual pair count so it stays correct
+          // regardless of how pairs were added or removed (askMerge/ignoreMerge,
+          // backend auto-resolve, or new pairs arriving after the counter was zeroed).
           const remainingPairs = Object.values(this.list).filter(
             (m) => m.collection === 'Related' && !m._syntheticRelated
           ).length
-          if (remainingPairs === 0) {
-            const authStore = useAuthStore()
-            if (authStore.work && typeof authStore.work.relatedmembers === 'number') {
-              authStore.work.relatedmembers = 0
-            }
+          const authStore = useAuthStore()
+          if (authStore.work && typeof authStore.work.relatedmembers === 'number') {
+            authStore.work.relatedmembers = remainingPairs
           }
         } else if (params.collection === 'Spam') {
           // V2 API returns one row per membership. V1 grouped by userid and

--- a/iznik-nuxt3/tests/unit/stores/member.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/member.spec.js
@@ -5,12 +5,18 @@ const mockReviewIgnore = vi.fn().mockResolvedValue()
 const mockFetchMembers = vi.fn()
 const mockMergeAsk = vi.fn().mockResolvedValue()
 const mockMergeIgnore = vi.fn().mockResolvedValue()
+const mockReviewRelease = vi.fn().mockResolvedValue()
+const mockReviewHold = vi.fn().mockResolvedValue()
+const mockDelete = vi.fn().mockResolvedValue()
 
 vi.mock('~/api', () => ({
   default: () => ({
     memberships: {
       reviewIgnore: mockReviewIgnore,
       fetchMembers: mockFetchMembers,
+      reviewRelease: mockReviewRelease,
+      reviewHold: mockReviewHold,
+      delete: mockDelete,
     },
     merge: {
       ask: mockMergeAsk,
@@ -36,6 +42,34 @@ describe('member store', () => {
     setActivePinia(createPinia())
     const mod = await import('~/modtools/stores/member')
     useMemberStore = mod.useMemberStore
+  })
+
+  describe('delete', () => {
+    it('removes membership by matching userid and groupid', async () => {
+      const store = useMemberStore()
+      store.config = {}
+      store.list[111] = {
+        id: 111,
+        userid: 456,
+        groupid: 789,
+      }
+      store.list[222] = {
+        id: 222,
+        userid: 999,
+        groupid: 111,
+      }
+
+      await store.delete({
+        id: 456,
+        groupid: 789,
+        subject: 'test',
+        stdmsgid: 1,
+        body: 'test body',
+      })
+
+      expect(store.list[111]).toBeUndefined()
+      expect(store.list[222]).toBeTruthy()
+    })
   })
 
   describe('spamignore', () => {
@@ -420,6 +454,30 @@ describe('member store', () => {
     })
   })
 
+  describe('reviewHold', () => {
+    it('updates heldby with current user on the matching member', async () => {
+      const store = useMemberStore()
+      store.config = {}
+      store.list[42] = { membershipid: 42, heldby: null }
+
+      await store.reviewHold({ userid: 123, groupid: 456, membershipid: 42 })
+
+      expect(store.list[42].heldby).toEqual({ id: 999 }) // 999 is the mocked user id
+    })
+  })
+
+  describe('reviewRelease', () => {
+    it('updates heldby to null on the matching member', async () => {
+      const store = useMemberStore()
+      store.config = {}
+      store.list[42] = { membershipid: 42, heldby: { id: 5 } }
+
+      await store.reviewRelease({ userid: 123, groupid: 456, membershipid: 42 })
+
+      expect(store.list[42].heldby).toBeNull()
+    })
+  })
+
   describe('getters', () => {
     it('getByGroup returns members matching a groupid', () => {
       const store = useMemberStore()
@@ -442,6 +500,15 @@ describe('member store', () => {
       const result = store.get(5)
 
       expect(result).toMatchObject({ id: 5, userid: 100 })
+    })
+
+    it('get returns undefined when member not found', () => {
+      const store = useMemberStore()
+      store.list[5] = { id: 5, userid: 100 }
+
+      const result = store.get(999)
+
+      expect(result).toBeUndefined()
     })
 
     it('ratingById returns the matching rating', () => {

--- a/iznik-nuxt3/tests/unit/stores/member.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/member.spec.js
@@ -377,4 +377,83 @@ describe('member store', () => {
       expect(store.list[200]._syntheticRelated).toBe(true)
     })
   })
+
+  describe('clear', () => {
+    it('resets all state to initial values', () => {
+      const store = useMemberStore()
+      store.list = { 1: { id: 1 } }
+      store.context = 99
+      store.instance = 5
+      store.ratings = [{ id: 1 }]
+      store.rawindex = 10
+      store.filtercount = 20
+
+      store.clear()
+
+      expect(store.list).toEqual({})
+      expect(store.context).toBeNull()
+      expect(store.instance).toBe(1)
+      expect(store.ratings).toEqual([])
+      expect(store.rawindex).toBe(0)
+      expect(store.filtercount).toBeNull()
+    })
+  })
+
+  describe('reviewHeld', () => {
+    it('updates heldby on the matching member', () => {
+      const store = useMemberStore()
+      store.list[42] = { membershipid: 42, heldby: null }
+
+      store.reviewHeld({ membershipid: 42, heldby: { id: 5 } })
+
+      expect(store.list[42].heldby).toEqual({ id: 5 })
+    })
+
+    it('does not affect non-matching members', () => {
+      const store = useMemberStore()
+      store.list[42] = { membershipid: 42, heldby: null }
+      store.list[99] = { membershipid: 99, heldby: { id: 3 } }
+
+      store.reviewHeld({ membershipid: 42, heldby: { id: 5 } })
+
+      expect(store.list[99].heldby).toEqual({ id: 3 })
+    })
+  })
+
+  describe('getters', () => {
+    it('getByGroup returns members matching a groupid', () => {
+      const store = useMemberStore()
+      store.list[1] = { id: 1, groupid: 10 }
+      store.list[2] = { id: 2, groupid: 20 }
+      store.list[3] = { id: 3, groupid: 10 }
+
+      const result = store.getByGroup(10)
+
+      expect(result).toHaveLength(2)
+      expect(result.map((m) => m.id)).toContain(1)
+      expect(result.map((m) => m.id)).toContain(3)
+    })
+
+    it('get returns a member by id', () => {
+      const store = useMemberStore()
+      store.list[5] = { id: 5, userid: 100 }
+      store.list[6] = { id: 6, userid: 200 }
+
+      const result = store.get(5)
+
+      expect(result).toMatchObject({ id: 5, userid: 100 })
+    })
+
+    it('ratingById returns the matching rating', () => {
+      const store = useMemberStore()
+      store.ratings = [
+        { id: 1, value: 'Up' },
+        { id: 2, value: 'Down' },
+      ]
+
+      expect(store.ratingById(1)).toMatchObject({ id: 1, value: 'Up' })
+      expect(store.ratingById(2)).toMatchObject({ id: 2, value: 'Down' })
+      expect(store.ratingById(99)).toBeUndefined()
+    })
+  })
 })

--- a/iznik-nuxt3/tests/unit/stores/member.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/member.spec.js
@@ -158,6 +158,54 @@ describe('member store', () => {
       // The counter must reflect reality and reset to 0.
       expect(mockAuthWork.relatedmembers).toBe(0)
     })
+
+    it('fetchMembers for Related returning new pairs after counter was zeroed via askMerge/ignoreMerge → counter reflects new pair count (regression: no increment path)', async () => {
+      // Regression (Discourse topic 9631): after PR#347 the counter is only updated by
+      // decrementing in askMerge/ignoreMerge and resetting to 0 when fetchMembers returns
+      // an empty list.  There is no INCREMENT path: when fetchMembers returns new Related
+      // pairs after the counter has already been driven to 0, the counter stays at 0
+      // even though the store now contains 1 actionable pair.
+      //
+      // Scenario:
+      //   1. Start: 2 pairs, counter = 2
+      //   2. askMerge pair A → counter = 1, pair A removed
+      //   3. ignoreMerge pair B → counter = 0, pair B removed
+      //   4. fetchMembers returns new pair C → store has 1 pair, counter MUST become 1
+      //
+      // Expected: counter == 1 (derived from actual pair count in the store)
+      // Actual:   counter stays 0 because fetchMembers only resets-to-0, it never increments
+
+      const store = useMemberStore()
+      store.config = {}
+
+      // Step 1: 2 pairs, counter = 2
+      store.list[10] = { id: 10, user1: 100, user2: 200, collection: 'Related' }
+      store.list[11] = { id: 11, user1: 300, user2: 400, collection: 'Related' }
+      mockAuthWork.relatedmembers = 2
+
+      // Step 2: process pair A
+      await store.askMerge(10, { user1: 100, user2: 200 })
+      expect(mockAuthWork.relatedmembers).toBe(1)
+
+      // Step 3: process pair B
+      await store.ignoreMerge(11, { user1: 300, user2: 400 })
+      expect(mockAuthWork.relatedmembers).toBe(0)
+
+      // Step 4: fetch returns a fresh pair — the backend found a new related-member pair
+      mockFetchMembers.mockResolvedValue({
+        members: [{ id: 20, user1: 500, user2: 600 }],
+        context: null,
+        ratings: [],
+      })
+
+      await store.fetchMembers({ collection: 'Related', groupid: 0 })
+
+      // The store now holds 1 actionable Related pair; the counter must reflect that.
+      // This assertion FAILS on the current code because fetchMembers has no increment
+      // path — it only resets the counter to 0 when the list is empty, never updates it
+      // upward when new pairs arrive.
+      expect(mockAuthWork.relatedmembers).toBe(1)
+    })
   })
 
   describe('fetchMembers - pagination context', () => {


### PR DESCRIPTION
## Problem

The Related Members badge in modtools could show the wrong count — most critically, it could drop to zero and stay there even when new duplicate-account pairs arrived for moderators to review. This meant moderators would see no work to do when there actually was.

The badge is a counter in the auth store, previously only updated by decrementing when a moderator acted (merge/ignore). It had no increment path and was never re-derived from the actual list, so anything outside those two actions — backend auto-resolution, or new pairs arriving after the counter reached zero — left it desynced.

## Fix

`fetchMembers` now always sets the counter directly from the length of the returned pairs array, replacing the old `if (remainingPairs === 0)` guard. The badge always reflects what the server currently says, regardless of how the list changed.

## Tests

New unit tests in `iznik-nuxt3/tests/unit/stores/member.spec.js` cover: initial load, decrement on merge/ignore, and the previously broken case where new pairs arrive after the counter was zeroed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)