### PR TITLE
feat(batch): migrate notification_chaseup.php to Laravel

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -255,6 +255,27 @@ services:
 
   # MJML email template compilation server (used by batch for worker pool back pressure)
   # API: POST raw MJML text to / with Content-Type: text/plain, returns compiled HTML
+  avatar:
+    container_name: ${COMPOSE_PROJECT_NAME:-freegle}-avatar
+    build:
+      context: ./services/avatar-server
+    profiles:
+      - backend
+    networks:
+      - default
+    restart: "no"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.avatar.rule=Host(`avatar.localhost`)"
+      - "traefik.http.routers.avatar.entrypoints=web"
+      - "traefik.http.services.avatar.loadbalancer.server.port=3000"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O- http://localhost:3000/health || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
   mjml:
     container_name: ${COMPOSE_PROJECT_NAME:-freegle}-mjml
     profiles:
@@ -1380,6 +1401,7 @@ services:
       - LOKI_ENABLED=true
       - LOKI_URL=http://loki:3100
       - MJML_URL=http://mjml/
+      - FREEGLE_AVATAR_SERVER_URL=http://avatar.localhost:${PORT_TRAEFIK_HTTP:-80}
       - FREEGLE_MAIL_ENABLED_TYPES=Welcome,ChatNotification,ChatNotificationUser2Mod,ChatNotificationMod2Mod,Digest,UnifiedDigest,DonationThank,DonationAsk,ChaseUp,AutoRepost,MessageExpiry,NotificationChaseUp
       # CI=true skips supervisor startup to prevent Laravel bootstrap race conditions.
       # Multiple supervisor workers bootstrapping Laravel simultaneously can corrupt services.php.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1380,7 +1380,7 @@ services:
       - LOKI_ENABLED=true
       - LOKI_URL=http://loki:3100
       - MJML_URL=http://mjml/
-      - FREEGLE_MAIL_ENABLED_TYPES=Welcome,ChatNotification,ChatNotificationUser2Mod,ChatNotificationMod2Mod,Digest,UnifiedDigest,DonationThank,DonationAsk,ChaseUp,AutoRepost,MessageExpiry
+      - FREEGLE_MAIL_ENABLED_TYPES=Welcome,ChatNotification,ChatNotificationUser2Mod,ChatNotificationMod2Mod,Digest,UnifiedDigest,DonationThank,DonationAsk,ChaseUp,AutoRepost,MessageExpiry,NotificationChaseUp
       # CI=true skips supervisor startup to prevent Laravel bootstrap race conditions.
       # Multiple supervisor workers bootstrapping Laravel simultaneously can corrupt services.php.
       - CI=${CI:-false}

--- a/iznik-batch/.env.testing
+++ b/iznik-batch/.env.testing
@@ -60,7 +60,7 @@ FREEGLE_MESSAGE_EXPIRE_DAYS=31
 FREEGLE_CHUNK_SIZE=1000
 
 # Enable all email types for testing
-FREEGLE_MAIL_ENABLED_TYPES=Welcome,ChatNotification,ChatNotificationUser2Mod,ChatNotificationMod2Mod,Digest,UnifiedDigest,DonationThank,DonationAsk,ChaseUp,AutoRepost,MessageExpiry
+FREEGLE_MAIL_ENABLED_TYPES=Welcome,ChatNotification,ChatNotificationUser2Mod,ChatNotificationMod2Mod,Digest,UnifiedDigest,DonationThank,DonationAsk,ChaseUp,AutoRepost,MessageExpiry,NotificationChaseUp
 
 # AMP email settings for testing
 AMP_SECRET=test-secret-for-testing-only

--- a/iznik-batch/MIGRATION-STATUS.md
+++ b/iznik-batch/MIGRATION-STATUS.md
@@ -230,7 +230,7 @@ These original scripts need to be migrated to Laravel artisan commands:
 | `user_exhort.php` | Every 1 min | Medium | User encouragement |
 | `lovejunk.php` | Every 1 min | Medium | LoveJunk integration |
 | `exports.php` | Every 1 min | Low | Data exports |
-| `notification_chaseup.php` | Every 5 min | Medium | Notification reminders |
+| ~~`notification_chaseup.php`~~ | ~~Every 5 min~~ | ~~Medium~~ | ~~Notification reminders~~ — **Migrated: `mail:notifications:chaseup`** |
 | `previews.php` | Every 5 min | Medium | Link preview generation |
 | `check_cgas.php` | Every 5 min | Low | CGA checking |
 | `message_spatial.php` | Every 5 min | Medium | Spatial index updates |

--- a/iznik-batch/app/Console/Commands/Mail/SendAdminCommand.php
+++ b/iznik-batch/app/Console/Commands/Mail/SendAdminCommand.php
@@ -4,6 +4,7 @@ namespace App\Console\Commands\Mail;
 
 use App\Console\Concerns\PreventsOverlapping;
 use App\Mail\Admin\AdminMail;
+use App\Mail\Traits\AvatarResolver;
 use App\Mail\Traits\FeatureFlags;
 use App\Models\Group;
 use App\Models\User;
@@ -16,6 +17,7 @@ use Illuminate\Support\Facades\Mail;
 
 class SendAdminCommand extends Command
 {
+    use AvatarResolver;
     use FeatureFlags;
     use GracefulShutdown;
     use PreventsOverlapping;
@@ -169,9 +171,8 @@ class SendAdminCommand extends Command
      */
     public static function getLocalVolunteers(int $groupId): array
     {
-        $oneYearAgo = now()->subYear();
-        $imagesDomain = config('freegle.images.domain', 'https://images.ilovefreegle.org');
-        $defaultProfileUrl = $imagesDomain . '/defaultprofile.png';
+        $oneYearAgo  = now()->subYear();
+        $avatarBase  = rtrim(config('freegle.avatar_server_url', ''), '/');
 
         $mods = User::select('users.id', 'users.fullname')
             ->join('memberships', 'memberships.userid', '=', 'users.id')
@@ -188,11 +189,13 @@ class SendAdminCommand extends Command
         foreach ($mods as $mod) {
             $firstName = explode(' ', $mod->fullname ?? '')[0];
             if ($firstName) {
+                $profileUrl = $mod->getProfileImageUrl()
+                    ?? ($avatarBase . '/' . rawurlencode($mod->fullname ?: 'user') . '.png');
                 $volunteers[] = [
                     'id' => $mod->id,
                     'displayname' => $mod->fullname,
                     'firstname' => $firstName,
-                    'profileurl' => $mod->getProfileImageUrl() ?? $defaultProfileUrl,
+                    'profileurl' => $profileUrl,
                 ];
             }
         }

--- a/iznik-batch/app/Console/Commands/Notification/ChaseUpNotificationsCommand.php
+++ b/iznik-batch/app/Console/Commands/Notification/ChaseUpNotificationsCommand.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Console\Commands\Notification;
+
+use App\Services\NotificationChaseUpService;
+use Illuminate\Console\Command;
+
+/**
+ * Send chaseup emails for unseen, unmailed site notifications (comments, loves, etc.).
+ *
+ * Migrated from V1 notification_chaseup.php → Notifications::sendEmails().
+ * Runs every 5 minutes in production (see routes/console.php).
+ */
+class ChaseUpNotificationsCommand extends Command
+{
+    protected $signature = 'mail:notifications:chaseup
+        {--user= : Only process this user ID}
+        {--before=5 : Minimum age of notification in minutes before sending}
+        {--since=24 : Maximum age of notification in hours}
+        {--dry-run : Show what would be sent without sending}';
+
+    protected $description = 'Send chaseup emails for unseen site notifications (comments, loves, etc.)';
+
+    public function handle(NotificationChaseUpService $service): int
+    {
+        $userId        = $this->option('user') ? (int) $this->option('user') : null;
+        $beforeMinutes = (int) $this->option('before');
+        $sinceHours    = (int) $this->option('since');
+        $dryRun        = (bool) $this->option('dry-run');
+
+        if ($dryRun) {
+            $this->info('Dry run — no emails will be sent.');
+        }
+
+        $count = $service->sendEmails(
+            userId:        $userId,
+            beforeMinutes: $beforeMinutes,
+            sinceHours:    $sinceHours,
+            dryRun:        $dryRun
+        );
+
+        $this->info("Sent {$count} notification chaseup email(s).");
+
+        return Command::SUCCESS;
+    }
+}

--- a/iznik-batch/app/Mail/Chat/ChatNotification.php
+++ b/iznik-batch/app/Mail/Chat/ChatNotification.php
@@ -4,6 +4,7 @@ namespace App\Mail\Chat;
 
 use App\Mail\MjmlMailable;
 use App\Mail\Traits\AmpEmail;
+use App\Mail\Traits\AvatarResolver;
 use App\Mail\Traits\LoggableEmail;
 use App\Mail\Traits\TrackableEmail;
 use App\Models\ChatMessage;
@@ -20,6 +21,7 @@ use Symfony\Component\Mime\Email;
 
 class ChatNotification extends MjmlMailable
 {
+    use AvatarResolver;
     use TrackableEmail;
     use LoggableEmail;
     use AmpEmail;
@@ -919,26 +921,16 @@ class ChatNotification extends MjmlMailable
         // Check both for a user ID and that the user exists in the database.
         // Mock/test users may have IDs but exists=false.
         if (!$user || !$user->id || !$user->exists) {
-            return $this->getDefaultProfileUrl($width);
+            return $this->resolveAvatarUrl(null, $width);
         }
 
         // Get the user's profile image URL from their users_images record.
         $sourceUrl = $user->getProfileImageUrl(TRUE);
 
         if (!$sourceUrl) {
-            return $this->getDefaultProfileUrl($width);
+            return $this->resolveAvatarUrl($user, $width);
         }
 
-        return $this->getDeliveryUrl($sourceUrl, $width);
-    }
-
-    /**
-     * Get default profile image URL via delivery service.
-     */
-    protected function getDefaultProfileUrl(int $width = 40): string
-    {
-        $imagesDomain = config('freegle.images.domain', 'https://images.ilovefreegle.org');
-        $sourceUrl = $imagesDomain . '/defaultprofile.png';
         return $this->getDeliveryUrl($sourceUrl, $width);
     }
 
@@ -954,7 +946,10 @@ class ChatNotification extends MjmlMailable
         $group = $this->chatRoom->group;
 
         if (!$group || !$group->profile) {
-            return $this->getDefaultProfileUrl($width);
+            // No group image — generate a boring-avatar using the group name.
+            $name    = $group?->nameshort ?? 'group';
+            $baseUrl = rtrim(config('freegle.avatar_server_url', ''), '/');
+            return $baseUrl . '/' . rawurlencode($name) . '.png' . ($width !== 48 ? "?size={$width}" : '');
         }
 
         $imagesDomain = config('freegle.images.domain', 'https://images.ilovefreegle.org');

--- a/iznik-batch/app/Mail/Notification/ChaseUpMail.php
+++ b/iznik-batch/app/Mail/Notification/ChaseUpMail.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace App\Mail\Notification;
+
+use App\Mail\MjmlMailable;
+use App\Mail\Traits\LoggableEmail;
+use App\Mail\Traits\TrackableEmail;
+use App\Models\User;
+use Illuminate\Mail\Mailables\Address;
+use Illuminate\Mail\Mailables\Envelope;
+
+/**
+ * Email sent when a user has unseen, unmailed notifications on Freegle
+ * (comments on posts, loves, etc.). Migrated from V1 Notifications::sendEmails()
+ * via notification_chaseup.php.
+ */
+class ChaseUpMail extends MjmlMailable
+{
+    use LoggableEmail;
+    use TrackableEmail;
+
+    public User $recipient;
+
+    /** @var array<int, array<string, mixed>> Prepared notification rows from NotificationChaseUpService */
+    public array $notifications;
+
+    public string $userSite;
+
+    public string $chitchatUrl;
+
+    private string $subjectLine;
+
+    /**
+     * @param User $recipient        Recipient user
+     * @param array $notifications   Prepared notification data (from NotificationChaseUpService)
+     * @param string $subject        Pre-computed subject line
+     */
+    public function __construct(User $recipient, array $notifications, string $subject)
+    {
+        parent::__construct();
+
+        $this->recipient     = $recipient;
+        $this->notifications = $notifications;
+        $this->subjectLine   = $subject;
+        $this->userSite      = config('freegle.sites.user');
+        $this->chitchatUrl   = $this->userSite . '/chitchat';
+
+        $userId = $this->recipient->exists ? $this->recipient->id : null;
+
+        $this->initTracking(
+            'NotificationChaseUp',
+            $this->recipient->email_preferred,
+            $userId,
+            null,
+            $this->subjectLine
+        );
+    }
+
+    protected function getRecipientUserId(): ?int
+    {
+        return $this->recipient->id ?? null;
+    }
+
+    protected function getSubject(): string
+    {
+        return $this->subjectLine;
+    }
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            from: new Address(
+                config('freegle.mail.noreply_addr'),
+                config('freegle.branding.name', 'Freegle')
+            ),
+            subject: $this->getSubject(),
+        );
+    }
+
+    public function build(): static
+    {
+        $count       = count($this->notifications);
+        $settingsUrl = $this->trackedUrl($this->userSite . '/settings', 'footer_settings', 'settings');
+        $unsubUrl    = $this->trackedUrl($this->userSite . '/unsubscribe', 'footer_unsubscribe', 'unsubscribe');
+
+        // Build tracked URLs per notification — mutate public property so text view sees them too.
+        $this->notifications = array_map(function ($notif) {
+            $url = ($notif['type'] === 'Exhort' && $notif['url'])
+                ? $this->userSite . $notif['url']
+                : ($notif['newsfeed'] ? $this->userSite . '/chitchat/' . $notif['newsfeed']['id'] : $this->chitchatUrl);
+
+            $notif['trackedUrl'] = $this->trackedUrl($url, 'notification_' . $notif['id'], 'view');
+
+            return $notif;
+        }, $this->notifications);
+
+        return $this->to($this->recipient->email_preferred, $this->recipient->displayname)
+            ->subject($this->getSubject())
+            ->mjmlView(
+                'emails.mjml.notification.chaseup',
+                array_merge([
+                    'recipient'     => $this->recipient,
+                    'notifications' => $this->notifications,
+                    'count'         => $count,
+                    'userSite'      => $this->userSite,
+                    'chitchatUrl'   => $this->trackedUrl($this->chitchatUrl, 'header_chitchat', 'view'),
+                    'settingsUrl'   => $settingsUrl,
+                    'unsubscribeUrl' => $unsubUrl,
+                    'email'          => $this->recipient->email_preferred,
+                ], $this->getTrackingData()),
+                'emails.text.notification.chaseup'
+            )
+            ->applyLogging('NotificationChaseUp');
+    }
+}

--- a/iznik-batch/app/Mail/Traits/AvatarResolver.php
+++ b/iznik-batch/app/Mail/Traits/AvatarResolver.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Mail\Traits;
+
+use App\Models\User;
+
+trait AvatarResolver
+{
+    /**
+     * Return a hosted avatar URL for the given user.
+     *
+     * Uses the user's uploaded profile image when available, otherwise falls
+     * back to the boring-avatars server which generates the same geometric
+     * avatar the frontend shows (never the grey default silhouette).
+     *
+     * @param int|null $size Pixel size hint for the avatar server (default 48)
+     */
+    protected function resolveAvatarUrl(?User $user, int $size = 48): string
+    {
+        if ($user) {
+            $uploaded = $user->getProfileImageUrl(thumbnail: true);
+            if ($uploaded) {
+                return $uploaded;
+            }
+        }
+
+        $name    = $user?->fullname ?: 'user';
+        $baseUrl = rtrim(config('freegle.avatar_server_url', ''), '/');
+
+        return $baseUrl . '/' . rawurlencode($name) . '.png' . ($size !== 48 ? "?size={$size}" : '');
+    }
+}

--- a/iznik-batch/app/Services/NotificationChaseUpService.php
+++ b/iznik-batch/app/Services/NotificationChaseUpService.php
@@ -268,7 +268,9 @@ class NotificationChaseUpService
                 'title'    => $notif->title,
                 'text'     => $notif->text,
                 'url'      => $notif->url,
-                'timestamp' => $notif->timestamp,
+                'timestamp' => \Carbon\Carbon::parse($notif->timestamp, 'UTC')
+                                   ->setTimezone('Europe/London')
+                                   ->format('D, jS F g:ia'),
                 'seen'     => $notif->seen,
                 'newsfeed' => $newsfeed ? [
                     'id'      => $newsfeed->id,

--- a/iznik-batch/app/Services/NotificationChaseUpService.php
+++ b/iznik-batch/app/Services/NotificationChaseUpService.php
@@ -1,0 +1,376 @@
+<?php
+
+namespace App\Services;
+
+use App\Mail\Notification\ChaseUpMail;
+use App\Mail\Traits\FeatureFlags;
+use App\Models\Notification;
+use App\Models\User;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Mail;
+
+class NotificationChaseUpService
+{
+    use FeatureFlags;
+
+    public const EMAIL_TYPE = 'NotificationChaseUp';
+
+    /**
+     * How far back to look for notifications (oldest that qualify).
+     */
+    public const DEFAULT_SINCE_HOURS = 24;
+
+    /**
+     * Minimum age before sending — gives the user time to see the notification first.
+     */
+    public const DEFAULT_BEFORE_MINUTES = 5;
+
+    /**
+     * How long before a user is considered inactive (6 months).
+     */
+    private const INACTIVE_DAYS = 183;
+
+    /**
+     * Notification types that are never included in chaseup emails (mirrors V1).
+     */
+    public const EXCLUDED_TYPES = ['TryFeed', 'AboutMe', 'GiftAid', 'OpenPosts'];
+
+    /**
+     * Spam-user collection types — notifications from these users are excluded.
+     */
+    private const SPAM_COLLECTIONS = ['Spammer', 'PendingAdd'];
+
+    /**
+     * Send chaseup emails for unmailed, unseen notifications.
+     *
+     * Mirrors V1 Notifications::sendEmails() called from notification_chaseup.php.
+     */
+    public function sendEmails(
+        ?int $userId = null,
+        int $beforeMinutes = self::DEFAULT_BEFORE_MINUTES,
+        int $sinceHours = self::DEFAULT_SINCE_HOURS,
+        bool $dryRun = false
+    ): int {
+        if (! self::isEmailTypeEnabled(self::EMAIL_TYPE)) {
+            Log::info('NotificationChaseUp emails disabled via FREEGLE_MAIL_ENABLED_TYPES');
+            return 0;
+        }
+
+        $users = $this->getUsersWithPendingNotifications($userId, $beforeMinutes, $sinceHours);
+
+        $total = 0;
+
+        foreach ($users as $user) {
+            $total += $this->processUser($user, $dryRun);
+        }
+
+        return $total;
+    }
+
+    /**
+     * Find users with unmailed, unseen notifications in the given time window,
+     * excluding spammers (from-user check, same as V1 SQL JOIN).
+     */
+    private function getUsersWithPendingNotifications(
+        ?int $userId,
+        int $beforeMinutes,
+        int $sinceHours
+    ): Collection {
+        $before = now()->subMinutes($beforeMinutes);
+        $since  = now()->subHours($sinceHours);
+
+        $query = DB::table('users_notifications')
+            ->leftJoin('spam_users', function ($join) {
+                $join->on('spam_users.userid', '=', 'users_notifications.fromuser')
+                    ->whereIn('spam_users.collection', self::SPAM_COLLECTIONS);
+            })
+            ->join('users', 'users.id', '=', 'users_notifications.touser')
+            ->where('users_notifications.timestamp', '<=', $before)
+            ->where('users_notifications.timestamp', '>=', $since)
+            ->where('users_notifications.seen', 0)
+            ->where('users_notifications.mailed', 0)
+            ->whereNotIn('users_notifications.type', self::EXCLUDED_TYPES)
+            ->whereNull('spam_users.userid')
+            ->whereNull('users.deleted')
+            ->select('users_notifications.touser')
+            ->distinct();
+
+        if ($userId !== null) {
+            $query->where('users_notifications.touser', $userId);
+        }
+
+        $userIds = $query->pluck('touser');
+
+        return User::whereIn('id', $userIds)->get();
+    }
+
+    /**
+     * Process a single user: check eligibility, prepare notifications, send email.
+     */
+    private function processUser(User $user, bool $dryRun): int
+    {
+        if (! $this->isUserEligible($user)) {
+            return 0;
+        }
+
+        if (! $this->wantsNotificationEmails($user)) {
+            return 0;
+        }
+
+        $notifications = $this->getUserNotifications($user->id);
+        if ($notifications->isEmpty()) {
+            return 0;
+        }
+
+        $notifData = $this->prepareNotifications($notifications);
+        if (empty($notifData)) {
+            return 0;
+        }
+
+        $subject = $this->getNotifTitle($notifData);
+        if (! $subject) {
+            return 0;
+        }
+
+        $email = $user->email_preferred;
+        if (! $email) {
+            return 0;
+        }
+
+        if (! $dryRun) {
+            // Mark as mailed before sending (like V1).
+            $notifIds = array_column($notifData, 'id');
+            DB::table('users_notifications')
+                ->whereIn('id', $notifIds)
+                ->update(['mailed' => 1]);
+
+            Mail::to($email)->send(new ChaseUpMail($user, $notifData, $subject));
+        }
+
+        return count($notifData);
+    }
+
+    /**
+     * Check whether the user should receive emails at all.
+     * Mirrors V1 User::sendOurMails() checks.
+     */
+    private function isUserEligible(User $user): bool
+    {
+        if ($user->deleted) {
+            return false;
+        }
+
+        if ($user->getSimpleMail() === User::SIMPLE_MAIL_NONE) {
+            return false;
+        }
+
+        // Must have been active in the last ~6 months.
+        if (! $user->lastaccess || $user->lastaccess->diffInDays(now()) > self::INACTIVE_DAYS) {
+            return false;
+        }
+
+        // Not on holiday.
+        if ($user->onholidaytill && now()->lt($user->onholidaytill)) {
+            return false;
+        }
+
+        // Not bouncing.
+        if ($user->bouncing) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Check the user's notification-mail preference (V1 settings.notificationmails, default true).
+     */
+    private function wantsNotificationEmails(User $user): bool
+    {
+        $settings = $user->settings ?? [];
+        return (bool) ($settings['notificationmails'] ?? true);
+    }
+
+    /**
+     * Fetch the latest unseen notifications for this user (mirrors V1 Notifications::get()).
+     */
+    private function getUserNotifications(int $userId): Collection
+    {
+        return Notification::where('touser', $userId)
+            ->where('seen', 0)
+            ->orderByDesc('id')
+            ->limit(10)
+            ->get();
+    }
+
+    /**
+     * Enrich notification rows with from-user display names and newsfeed content.
+     * Skips deleted items. Returns array suitable for template rendering.
+     */
+    private function prepareNotifications(Collection $notifications): array
+    {
+        // Bulk-load from-users.
+        $fromUserIds = $notifications->pluck('fromuser')->filter()->unique()->values()->toArray();
+        $fromUsers = User::whereIn('id', $fromUserIds)->select('id', 'fullname')->get()->keyBy('id');
+
+        // Bulk-load newsfeed items and their reply-tos.
+        $newsfeedIds = $notifications->pluck('newsfeedid')->filter()->unique()->values()->toArray();
+        $newsfeeds = [];
+
+        if (! empty($newsfeedIds)) {
+            $rows = DB::table('newsfeed')->whereIn('id', $newsfeedIds)->get();
+
+            foreach ($rows as $row) {
+                $newsfeeds[$row->id] = $row;
+            }
+
+            $replytoIds = $rows->pluck('replyto')->filter()->unique()->values()->toArray();
+
+            if (! empty($replytoIds)) {
+                $replyRows = DB::table('newsfeed')->whereIn('id', $replytoIds)->get();
+                foreach ($replyRows as $row) {
+                    $newsfeeds[$row->id] = $row;
+                }
+            }
+        }
+
+        $result = [];
+
+        foreach ($notifications as $notif) {
+            if (in_array($notif->type, self::EXCLUDED_TYPES, true)) {
+                continue;
+            }
+
+            $newsfeed = $notif->newsfeedid ? ($newsfeeds[$notif->newsfeedid] ?? null) : null;
+
+            // Skip if the newsfeed item has been deleted.
+            if ($newsfeed && $newsfeed->deleted) {
+                continue;
+            }
+
+            // Skip if the thread being replied to has been deleted.
+            $replyto = null;
+            if ($newsfeed && $newsfeed->replyto) {
+                $replyto = $newsfeeds[$newsfeed->replyto] ?? null;
+                if ($replyto && $replyto->deleted) {
+                    continue;
+                }
+            }
+
+            $fromUser = isset($fromUsers[$notif->fromuser]) ? $fromUsers[$notif->fromuser] : null;
+
+            $result[] = [
+                'id'       => $notif->id,
+                'type'     => $notif->type,
+                'fromname' => $fromUser ? $fromUser->fullname : 'Someone',
+                'title'    => $notif->title,
+                'text'     => $notif->text,
+                'url'      => $notif->url,
+                'timestamp' => $notif->timestamp,
+                'seen'     => $notif->seen,
+                'newsfeed' => $newsfeed ? [
+                    'id'      => $newsfeed->id,
+                    'type'    => $newsfeed->type ?? 'Message',
+                    'message' => $this->snip($newsfeed->message),
+                    'replyto' => $replyto ? [
+                        'id'      => $replyto->id,
+                        'message' => $this->snip($replyto->message),
+                    ] : null,
+                ] : null,
+            ];
+        }
+
+        return $result;
+    }
+
+    /**
+     * Generate the email subject line. Mirrors V1 Notifications::getNotifTitle().
+     *
+     * Priority: CommentOnCommented > CommentOnYourPost > LovedPost/LovedComment > Exhort.
+     * If multiple notifications, appends "+ N more...".
+     */
+    public function getNotifTitle(array $notifs): string
+    {
+        $title = '';
+        $count = 0;
+
+        foreach ($notifs as $notif) {
+            if ($notif['type'] === 'TryFeed') {
+                continue;
+            }
+
+            $fromname = $notif['fromname'];
+            $shortmsg = null;
+
+            if (
+                ! empty($notif['newsfeed']['message']) &&
+                ($notif['newsfeed']['type'] ?? '') !== 'Noticeboard'
+            ) {
+                $msg      = $notif['newsfeed']['message'];
+                $shortmsg = strlen($msg) > 30 ? (substr($msg, 0, 30) . '...') : $msg;
+            }
+
+            switch ($notif['type']) {
+                case 'CommentOnCommented':
+                    $title = "{$fromname} replied: {$shortmsg}";
+                    $count++;
+                    break;
+                case 'CommentOnYourPost':
+                    $title = "{$fromname} commented: {$shortmsg}";
+                    $count++;
+                    break;
+                case 'LovedPost':
+                    if (! $title) {
+                        $title = "{$fromname} loved your post" . ($shortmsg ? " '{$shortmsg}'" : '');
+                    }
+                    $count++;
+                    break;
+                case 'LovedComment':
+                    if (! $title) {
+                        $title = "{$fromname} loved your comment" . ($shortmsg ? " '{$shortmsg}'" : '');
+                    }
+                    $count++;
+                    break;
+                case 'AboutMe':
+                    if (! $title) {
+                        $title = "Why not introduce yourself to other freeglers? You'll get a better response.";
+                    }
+                    $count++;
+                    break;
+                case 'Exhort':
+                    if (! $title) {
+                        $title = $notif['title'] ?? '';
+                    }
+                    $count++;
+                    break;
+            }
+        }
+
+        if ($count > 1) {
+            $title = $title . ' +' . ($count - 1) . ' more...';
+        }
+
+        return $title;
+    }
+
+    /**
+     * Truncate a message to ~57 chars at a word boundary, matching V1 Notifications::snip().
+     */
+    private function snip(?string $msg): ?string
+    {
+        if (! $msg) {
+            return $msg;
+        }
+
+        if (strlen($msg) > 57) {
+            $msg = wordwrap($msg, 60);
+            $p   = strpos($msg, "\n");
+            $msg = ($p !== false) ? substr($msg, 0, $p) : $msg;
+            $msg .= '...';
+        }
+
+        return $msg;
+    }
+}

--- a/iznik-batch/app/Services/NotificationChaseUpService.php
+++ b/iznik-batch/app/Services/NotificationChaseUpService.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use App\Mail\Notification\ChaseUpMail;
+use App\Mail\Traits\AvatarResolver;
 use App\Mail\Traits\FeatureFlags;
 use App\Models\Notification;
 use App\Models\User;
@@ -13,6 +14,7 @@ use Illuminate\Support\Facades\Mail;
 
 class NotificationChaseUpService
 {
+    use AvatarResolver;
     use FeatureFlags;
 
     public const EMAIL_TYPE = 'NotificationChaseUp';
@@ -149,7 +151,7 @@ class NotificationChaseUpService
             Mail::to($email)->send(new ChaseUpMail($user, $notifData, $subject));
         }
 
-        return count($notifData);
+        return 1;
     }
 
     /**
@@ -262,9 +264,10 @@ class NotificationChaseUpService
             $fromUser = isset($fromUsers[$notif->fromuser]) ? $fromUsers[$notif->fromuser] : null;
 
             $result[] = [
-                'id'       => $notif->id,
-                'type'     => $notif->type,
-                'fromname' => $fromUser ? $fromUser->fullname : 'Someone',
+                'id'        => $notif->id,
+                'type'      => $notif->type,
+                'fromname'  => $fromUser ? $fromUser->fullname : 'Someone',
+                'fromimage' => $this->resolveAvatarUrl($fromUser),
                 'title'    => $notif->title,
                 'text'     => $notif->text,
                 'url'      => $notif->url,
@@ -344,6 +347,24 @@ class NotificationChaseUpService
                 case 'Exhort':
                     if (! $title) {
                         $title = $notif['title'] ?? '';
+                    }
+                    $count++;
+                    break;
+                case 'MembershipPending':
+                    if (! $title) {
+                        $title = "Your application to {$notif['url']} requires approval";
+                    }
+                    $count++;
+                    break;
+                case 'MembershipApproved':
+                    if (! $title) {
+                        $title = "Your application to {$notif['url']} has been approved!";
+                    }
+                    $count++;
+                    break;
+                case 'MembershipRejected':
+                    if (! $title) {
+                        $title = "Sorry, your application to {$notif['url']} was rejected";
                     }
                     $count++;
                     break;

--- a/iznik-batch/config/freegle.php
+++ b/iznik-batch/config/freegle.php
@@ -77,6 +77,10 @@ return [
         'credentials_path' => env('FIREBASE_CREDENTIALS_PATH', '/etc/firebase.json'),
     ],
 
+    // Avatar server — generates boring-avatars PNGs matching the frontend's GeneratedAvatar component.
+    // In production this must be a publicly accessible URL so email clients can fetch the images.
+    'avatar_server_url' => env('FREEGLE_AVATAR_SERVER_URL', 'https://www.ilovefreegle.org/api/avatar'),
+
     'images' => [
         // Image domain for user profile images
         'domain' => env('FREEGLE_IMAGES_DOMAIN', 'https://images.ilovefreegle.org'),

--- a/iznik-batch/phpunit.xml
+++ b/iznik-batch/phpunit.xml
@@ -47,7 +47,7 @@
         <env name="PULSE_ENABLED" value="false"/>
         <env name="TELESCOPE_ENABLED" value="false"/>
         <env name="NIGHTWATCH_ENABLED" value="false"/>
-        <env name="FREEGLE_MAIL_ENABLED_TYPES" value="Welcome,ChatNotification,ChatNotificationUser2Mod,ChatNotificationMod2Mod,Digest,UnifiedDigest,DonationThank,DonationAsk,ChaseUp,AutoRepost,MessageExpiry" force="true"/>
+        <env name="FREEGLE_MAIL_ENABLED_TYPES" value="Welcome,ChatNotification,ChatNotificationUser2Mod,ChatNotificationMod2Mod,Digest,UnifiedDigest,DonationThank,DonationAsk,ChaseUp,AutoRepost,MessageExpiry,NotificationChaseUp" force="true"/>
         <env name="VIEW_CHECK_TIMESTAMPS" value="false" force="true"/>
     </php>
 </phpunit>

--- a/iznik-batch/resources/views/emails/mjml/notification/chaseup.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/notification/chaseup.blade.php
@@ -1,0 +1,126 @@
+<mjml>
+  @include('emails.mjml.partials.head', [
+    'preview' => 'You have ' . $count . ' notification' . ($count === 1 ? '' : 's') . ' on Freegle'
+  ])
+  <mj-body background-color="#ffffff">
+
+    {{-- Header --}}
+    <mj-section mj-class="bg-success" padding="0">
+      <mj-column width="65%">
+        <mj-text font-size="18px" font-weight="bold" color="#ffffff" padding="10px 25px">
+          You have {{ $count }} notification{{ $count === 1 ? '' : 's' }}
+        </mj-text>
+      </mj-column>
+      <mj-column width="35%">
+        <mj-image
+          width="80px"
+          src="{{ config('freegle.logo_url', 'https://www.ilovefreegle.org/icon.png') }}"
+          alt="Freegle"
+          align="right"
+          padding="10px 20px"
+        />
+      </mj-column>
+    </mj-section>
+
+    {{-- Notification rows --}}
+    @foreach ($notifications as $notif)
+    <mj-section background-color="#F7F6EC" padding="20px 0 0 0">
+      <mj-column>
+
+        {{-- Notification text --}}
+        @if ($notif['type'] === 'CommentOnCommented')
+        <mj-text font-size="13px" padding="10px 25px 2px">
+          <strong>{{ $notif['fromname'] }}</strong>
+          <span style="color: grey;"> commented on &ldquo;{{ $notif['newsfeed']['replyto']['message'] ?? '' }}&rdquo;:</span>
+          <br/><br/><em>{{ $notif['newsfeed']['message'] ?? '' }}</em>
+        </mj-text>
+
+        @elseif ($notif['type'] === 'CommentOnYourPost')
+        <mj-text font-size="13px" padding="10px 25px 2px">
+          <strong>{{ $notif['fromname'] }}</strong>
+          <span style="color: grey;"> commented on your post:</span>
+          <br/><br/><em>{{ $notif['newsfeed']['message'] ?? '' }}</em>
+        </mj-text>
+
+        @elseif ($notif['type'] === 'LovedPost')
+        <mj-text font-size="13px" padding="10px 25px 2px">
+          <strong>{{ $notif['fromname'] }}</strong>
+          @if (($notif['newsfeed']['type'] ?? '') === 'Noticeboard')
+          <span style="color: grey;"> loved your noticeboard post</span>
+          @else
+          <span style="color: grey;"> loved your post:</span>
+          <br/><br/><em>{{ $notif['newsfeed']['message'] ?? '' }}</em>
+          @endif
+        </mj-text>
+
+        @elseif ($notif['type'] === 'LovedComment')
+        <mj-text font-size="13px" padding="10px 25px 2px">
+          <strong>{{ $notif['fromname'] }}</strong>
+          <span style="color: grey;"> loved your comment:</span>
+          <br/><br/><em>{{ $notif['newsfeed']['message'] ?? '' }}</em>
+        </mj-text>
+
+        @elseif ($notif['type'] === 'Exhort')
+        <mj-text font-size="13px" padding="10px 25px 2px">
+          <strong>{{ $notif['title'] ?? '' }}</strong>
+          @if ($notif['text'])
+          <br/><br/><em>{{ $notif['text'] }}</em>
+          @endif
+        </mj-text>
+
+        @elseif ($notif['type'] === 'MembershipPending')
+        <mj-text font-size="13px" padding="10px 25px 2px">
+          <strong>Your application to {{ $notif['url'] ?? '' }} requires approval. We&rsquo;ll let you know soon.</strong>
+        </mj-text>
+
+        @elseif ($notif['type'] === 'MembershipApproved')
+        <mj-text font-size="13px" padding="10px 25px 2px">
+          <strong>Your application to {{ $notif['url'] ?? '' }} has been approved!</strong>
+        </mj-text>
+
+        @elseif ($notif['type'] === 'MembershipRejected')
+        <mj-text font-size="13px" padding="10px 25px 2px">
+          <strong>Sorry, your application to {{ $notif['url'] ?? '' }} was rejected</strong>
+        </mj-text>
+        @endif
+
+        {{-- Timestamp --}}
+        <mj-text font-size="11px" color="#707070" padding="0 25px 10px">
+          {{ $notif['timestamp'] }}
+        </mj-text>
+
+      </mj-column>
+
+      {{-- CTA button --}}
+      <mj-column>
+        <mj-button
+          mj-class="btn-success"
+          href="{{ $notif['trackedUrl'] }}"
+          align="right"
+          padding="10px 25px"
+        >
+          @if ($notif['type'] === 'Exhort')
+          Click here!
+          @else
+          View thread
+          @endif
+        </mj-button>
+      </mj-column>
+    </mj-section>
+
+    <mj-section padding="0">
+      <mj-column>
+        <mj-divider border-color="#e0e0e0" border-width="1px" padding="0" />
+      </mj-column>
+    </mj-section>
+    @endforeach
+
+    {{-- Footer --}}
+    @include('emails.mjml.partials.footer', [
+      'settingsUrl'    => $settingsUrl,
+      'unsubscribeUrl' => $unsubscribeUrl,
+      'email' => $email,
+    ])
+
+  </mj-body>
+</mjml>

--- a/iznik-batch/resources/views/emails/mjml/notification/chaseup.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/notification/chaseup.blade.php
@@ -6,12 +6,12 @@
 
     {{-- Header --}}
     <mj-section mj-class="bg-success" padding="0">
-      <mj-column width="65%">
+      <mj-column width="65%" vertical-align="middle">
         <mj-text font-size="18px" font-weight="bold" color="#ffffff" padding="10px 25px">
           You have {{ $count }} notification{{ $count === 1 ? '' : 's' }}
         </mj-text>
       </mj-column>
-      <mj-column width="35%">
+      <mj-column width="35%" vertical-align="middle">
         <mj-image
           width="80px"
           src="{{ config('freegle.logo_url', 'https://www.ilovefreegle.org/icon.png') }}"
@@ -25,25 +25,40 @@
     {{-- Notification rows --}}
     @foreach ($notifications as $notif)
     <mj-section background-color="#F7F6EC" padding="20px 0 0 0">
-      <mj-column>
+
+      {{-- Avatar: uploaded photo or server-generated boring-avatar matching the frontend --}}
+      <mj-column width="60px" vertical-align="middle">
+        <mj-image
+          width="48px"
+          height="48px"
+          src="{{ $notif['fromimage'] }}"
+          alt="{{ $notif['fromname'] }}"
+          border-radius="50%"
+          align="center"
+          padding="0 0 0 15px"
+          container-background-color="#F7F6EC"
+        />
+      </mj-column>
+
+      <mj-column vertical-align="middle">
 
         {{-- Notification text --}}
         @if ($notif['type'] === 'CommentOnCommented')
-        <mj-text font-size="13px" padding="10px 25px 2px">
+        <mj-text font-size="13px" padding="10px 10px 2px">
           <strong>{{ $notif['fromname'] }}</strong>
           <span style="color: grey;"> commented on &ldquo;{{ $notif['newsfeed']['replyto']['message'] ?? '' }}&rdquo;:</span>
           <br/><br/><em>{{ $notif['newsfeed']['message'] ?? '' }}</em>
         </mj-text>
 
         @elseif ($notif['type'] === 'CommentOnYourPost')
-        <mj-text font-size="13px" padding="10px 25px 2px">
+        <mj-text font-size="13px" padding="10px 10px 2px">
           <strong>{{ $notif['fromname'] }}</strong>
           <span style="color: grey;"> commented on your post:</span>
           <br/><br/><em>{{ $notif['newsfeed']['message'] ?? '' }}</em>
         </mj-text>
 
         @elseif ($notif['type'] === 'LovedPost')
-        <mj-text font-size="13px" padding="10px 25px 2px">
+        <mj-text font-size="13px" padding="10px 10px 2px">
           <strong>{{ $notif['fromname'] }}</strong>
           @if (($notif['newsfeed']['type'] ?? '') === 'Noticeboard')
           <span style="color: grey;"> loved your noticeboard post</span>
@@ -54,14 +69,14 @@
         </mj-text>
 
         @elseif ($notif['type'] === 'LovedComment')
-        <mj-text font-size="13px" padding="10px 25px 2px">
+        <mj-text font-size="13px" padding="10px 10px 2px">
           <strong>{{ $notif['fromname'] }}</strong>
           <span style="color: grey;"> loved your comment:</span>
           <br/><br/><em>{{ $notif['newsfeed']['message'] ?? '' }}</em>
         </mj-text>
 
         @elseif ($notif['type'] === 'Exhort')
-        <mj-text font-size="13px" padding="10px 25px 2px">
+        <mj-text font-size="13px" padding="10px 10px 2px">
           <strong>{{ $notif['title'] ?? '' }}</strong>
           @if ($notif['text'])
           <br/><br/><em>{{ $notif['text'] }}</em>
@@ -69,35 +84,35 @@
         </mj-text>
 
         @elseif ($notif['type'] === 'MembershipPending')
-        <mj-text font-size="13px" padding="10px 25px 2px">
+        <mj-text font-size="13px" padding="10px 10px 2px">
           <strong>Your application to {{ $notif['url'] ?? '' }} requires approval. We&rsquo;ll let you know soon.</strong>
         </mj-text>
 
         @elseif ($notif['type'] === 'MembershipApproved')
-        <mj-text font-size="13px" padding="10px 25px 2px">
+        <mj-text font-size="13px" padding="10px 10px 2px">
           <strong>Your application to {{ $notif['url'] ?? '' }} has been approved!</strong>
         </mj-text>
 
         @elseif ($notif['type'] === 'MembershipRejected')
-        <mj-text font-size="13px" padding="10px 25px 2px">
+        <mj-text font-size="13px" padding="10px 10px 2px">
           <strong>Sorry, your application to {{ $notif['url'] ?? '' }} was rejected</strong>
         </mj-text>
         @endif
 
         {{-- Timestamp --}}
-        <mj-text font-size="11px" color="#707070" padding="0 25px 10px">
+        <mj-text font-size="11px" color="#707070" padding="0 10px 10px">
           {{ $notif['timestamp'] }}
         </mj-text>
 
       </mj-column>
 
       {{-- CTA button --}}
-      <mj-column>
+      <mj-column width="130px" vertical-align="middle">
         <mj-button
           mj-class="btn-success"
           href="{{ $notif['trackedUrl'] }}"
-          align="right"
-          padding="10px 25px"
+          align="center"
+          padding="10px 10px"
         >
           @if ($notif['type'] === 'Exhort')
           Click here!

--- a/iznik-batch/resources/views/emails/text/notification/chaseup.blade.php
+++ b/iznik-batch/resources/views/emails/text/notification/chaseup.blade.php
@@ -1,0 +1,46 @@
+You have {!! $count !!} notification{!! $count === 1 ? '' : 's' !!} on Freegle.
+
+@foreach ($notifications as $notif)
+---
+@if ($notif['type'] === 'CommentOnCommented')
+{!! $notif['fromname'] !!} commented on "{!! $notif['newsfeed']['replyto']['message'] ?? '' !!}":
+
+{!! $notif['newsfeed']['message'] ?? '' !!}
+@elseif ($notif['type'] === 'CommentOnYourPost')
+{!! $notif['fromname'] !!} commented on your post:
+
+{!! $notif['newsfeed']['message'] ?? '' !!}
+@elseif ($notif['type'] === 'LovedPost')
+@if (($notif['newsfeed']['type'] ?? '') === 'Noticeboard')
+{!! $notif['fromname'] !!} loved your noticeboard post
+@else
+{!! $notif['fromname'] !!} loved your post:
+
+{!! $notif['newsfeed']['message'] ?? '' !!}
+@endif
+@elseif ($notif['type'] === 'LovedComment')
+{!! $notif['fromname'] !!} loved your comment:
+
+{!! $notif['newsfeed']['message'] ?? '' !!}
+@elseif ($notif['type'] === 'Exhort')
+{!! $notif['title'] ?? '' !!}
+
+{!! $notif['text'] ?? '' !!}
+@elseif ($notif['type'] === 'MembershipPending')
+Your application to {!! $notif['url'] ?? '' !!} requires approval. We'll let you know soon.
+@elseif ($notif['type'] === 'MembershipApproved')
+Your application to {!! $notif['url'] ?? '' !!} has been approved!
+@elseif ($notif['type'] === 'MembershipRejected')
+Sorry, your application to {!! $notif['url'] ?? '' !!} was rejected.
+@endif
+
+View on Freegle: {!! $notif['trackedUrl'] !!}
+@endforeach
+
+---
+This email was sent to {!! $email !!}
+Change your email settings: {!! $settingsUrl !!}
+Unsubscribe: {!! $unsubscribeUrl !!}
+
+Freegle is registered as a charity with HMRC (ref. XT32865) and is run by volunteers.
+Registered address: 64a North Road, Ormesby, Great Yarmouth, Norfolk NR29 3LE

--- a/iznik-batch/routes/console.php
+++ b/iznik-batch/routes/console.php
@@ -138,6 +138,15 @@ Schedule::command('monitor:email-health')
     ->sendOutputTo(cronLog('monitor:email-health'))
     ->runInBackground();
 
+// Notification chaseup - send emails for unseen, unmailed site notifications.
+// V1: cron/notification_chaseup.php (every 5 minutes)
+// Disabled until parallel run verified. Enable by removing the comments.
+// Schedule::command('mail:notifications:chaseup')
+//     ->everyFiveMinutes()
+//     ->withoutOverlapping()
+//     ->sendOutputTo(cronLog('mail:notifications:chaseup'))
+//     ->runInBackground();
+
 // =============================================================================
 // DISABLED COMMANDS (to be enabled when ready)
 // =============================================================================

--- a/iznik-batch/tests/Unit/Services/NotificationChaseUpServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/NotificationChaseUpServiceTest.php
@@ -459,6 +459,123 @@ class NotificationChaseUpServiceTest extends TestCase
         $this->assertStringContainsString('Tell us your story!', $subject);
     }
 
+    public function test_subject_for_loved_comment(): void
+    {
+        $subject = $this->service->getNotifTitle([[
+            'type'     => 'LovedComment',
+            'fromname' => 'Dave',
+            'newsfeed' => ['type' => 'Message', 'message' => 'Great comment'],
+            'title'    => null,
+            'seen'     => false,
+        ]]);
+
+        $this->assertStringContainsString('Dave', $subject);
+        $this->assertStringContainsString('loved', $subject);
+    }
+
+    public function test_subject_for_membership_pending(): void
+    {
+        $subject = $this->service->getNotifTitle([[
+            'type'     => 'MembershipPending',
+            'fromname' => '',
+            'newsfeed' => null,
+            'title'    => null,
+            'url'      => 'Freegle Bristol',
+            'seen'     => false,
+        ]]);
+
+        $this->assertStringContainsString('Freegle Bristol', $subject);
+        $this->assertStringContainsString('approval', $subject);
+    }
+
+    public function test_subject_for_membership_approved(): void
+    {
+        $subject = $this->service->getNotifTitle([[
+            'type'     => 'MembershipApproved',
+            'fromname' => '',
+            'newsfeed' => null,
+            'title'    => null,
+            'url'      => 'Freegle Bristol',
+            'seen'     => false,
+        ]]);
+
+        $this->assertStringContainsString('Freegle Bristol', $subject);
+        $this->assertStringContainsString('approved', $subject);
+    }
+
+    public function test_subject_for_membership_rejected(): void
+    {
+        $subject = $this->service->getNotifTitle([[
+            'type'     => 'MembershipRejected',
+            'fromname' => '',
+            'newsfeed' => null,
+            'title'    => null,
+            'url'      => 'Freegle Bristol',
+            'seen'     => false,
+        ]]);
+
+        $this->assertStringContainsString('Freegle Bristol', $subject);
+        $this->assertStringContainsString('rejected', $subject);
+    }
+
+    // -----------------------------------------------------------------------
+    // Membership notification types
+    // -----------------------------------------------------------------------
+
+    public function test_sends_email_for_membership_pending_notification(): void
+    {
+        $user   = $this->createTestUser(['lastaccess' => now()]);
+        $sender = $this->createTestUser();
+
+        $this->createNotification($user, $sender, [
+            'type' => 'MembershipPending',
+            'url'  => 'Freegle Bristol',
+        ]);
+
+        $count = $this->service->sendEmails();
+
+        $this->assertEquals(1, $count);
+        Mail::assertSent(ChaseUpMail::class, function ($mail) use ($user) {
+            return $mail->hasTo($user->email_preferred);
+        });
+    }
+
+    public function test_sends_email_for_membership_approved_notification(): void
+    {
+        $user   = $this->createTestUser(['lastaccess' => now()]);
+        $sender = $this->createTestUser();
+
+        $this->createNotification($user, $sender, [
+            'type' => 'MembershipApproved',
+            'url'  => 'Freegle Bristol',
+        ]);
+
+        $count = $this->service->sendEmails();
+
+        $this->assertEquals(1, $count);
+        Mail::assertSent(ChaseUpMail::class, function ($mail) use ($user) {
+            return $mail->hasTo($user->email_preferred);
+        });
+    }
+
+    public function test_sends_email_for_membership_rejected_notification(): void
+    {
+        $user   = $this->createTestUser(['lastaccess' => now()]);
+        $sender = $this->createTestUser();
+
+        $this->createNotification($user, $sender, [
+            'type' => 'MembershipRejected',
+            'url'  => 'Freegle Bristol',
+        ]);
+
+        $count = $this->service->sendEmails();
+
+        $this->assertEquals(1, $count);
+        Mail::assertSent(ChaseUpMail::class, function ($mail) use ($user) {
+            return $mail->hasTo($user->email_preferred);
+        });
+    }
+
     // -----------------------------------------------------------------------
     // User-specific filtering
     // -----------------------------------------------------------------------

--- a/iznik-batch/tests/Unit/Services/NotificationChaseUpServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/NotificationChaseUpServiceTest.php
@@ -1,0 +1,486 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Mail\Notification\ChaseUpMail;
+use App\Models\Notification;
+use App\Models\User;
+use App\Services\NotificationChaseUpService;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Mail;
+use Tests\TestCase;
+
+class NotificationChaseUpServiceTest extends TestCase
+{
+    protected NotificationChaseUpService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new NotificationChaseUpService();
+        Mail::fake();
+        // Reset feature flags before each test — config() changes persist across tests.
+        config(['freegle.mail.enabled_types' => 'NotificationChaseUp']);
+    }
+
+    // -----------------------------------------------------------------------
+    // Helper: create a users_notifications row
+    // -----------------------------------------------------------------------
+
+    private function createNotification(User $toUser, User $fromUser, array $attributes = []): object
+    {
+        $id = DB::table('users_notifications')->insertGetId(array_merge([
+            'fromuser'   => $fromUser->id,
+            'touser'     => $toUser->id,
+            'type'       => 'CommentOnYourPost',
+            'newsfeedid' => null,
+            'url'        => null,
+            'title'      => null,
+            'text'       => null,
+            'timestamp'  => now()->subMinutes(10), // old enough (> 5 min)
+            'seen'       => 0,
+            'mailed'     => 0,
+        ], $attributes));
+
+        return DB::table('users_notifications')->where('id', $id)->first();
+    }
+
+    private function createNewsfeedItem(array $attributes = []): object
+    {
+        $id = DB::table('newsfeed')->insertGetId(array_merge([
+            'userid'    => null,
+            'type'      => 'Message',
+            'message'   => 'Test newsfeed message',
+            'timestamp' => now(),
+            'deleted'   => null,
+            'replyto'   => null,
+            'position'  => DB::raw("ST_GeomFromText('POINT(0 0)', 3857)"),
+        ], $attributes));
+
+        return DB::table('newsfeed')->where('id', $id)->first();
+    }
+
+    // -----------------------------------------------------------------------
+    // Feature flag tests
+    // -----------------------------------------------------------------------
+
+    public function test_returns_zero_when_email_type_disabled(): void
+    {
+        // Disable the email type
+        config(['freegle.mail.enabled_types' => '']);
+
+        $user = $this->createTestUser();
+        $sender = $this->createTestUser();
+        $this->createNotification($user, $sender);
+
+        $count = $this->service->sendEmails();
+
+        $this->assertEquals(0, $count);
+        Mail::assertNothingSent();
+    }
+
+    // -----------------------------------------------------------------------
+    // No pending notifications
+    // -----------------------------------------------------------------------
+
+    public function test_sends_no_emails_when_no_pending_notifications(): void
+    {
+        $count = $this->service->sendEmails();
+
+        $this->assertEquals(0, $count);
+        Mail::assertNothingSent();
+    }
+
+    // -----------------------------------------------------------------------
+    // Happy path: sends email for pending notification
+    // -----------------------------------------------------------------------
+
+    public function test_sends_email_for_user_with_pending_comment_notification(): void
+    {
+        $user = $this->createTestUser(['lastaccess' => now()]);
+        $sender = $this->createTestUser();
+
+        $newsfeed = $this->createNewsfeedItem(['message' => 'Hello world post']);
+        $this->createNotification($user, $sender, [
+            'type'       => 'CommentOnYourPost',
+            'newsfeedid' => $newsfeed->id,
+            'timestamp'  => now()->subMinutes(10),
+        ]);
+
+        $count = $this->service->sendEmails();
+
+        $this->assertEquals(1, $count);
+        Mail::assertSent(ChaseUpMail::class, function ($mail) use ($user) {
+            return $mail->hasTo($user->email_preferred);
+        });
+    }
+
+    // -----------------------------------------------------------------------
+    // Time window filtering
+    // -----------------------------------------------------------------------
+
+    public function test_does_not_send_for_too_recent_notifications(): void
+    {
+        $user = $this->createTestUser();
+        $sender = $this->createTestUser();
+
+        // Only 2 minutes old — too recent (V1 default: 5 minutes)
+        $this->createNotification($user, $sender, [
+            'timestamp' => now()->subMinutes(2),
+        ]);
+
+        $count = $this->service->sendEmails();
+
+        $this->assertEquals(0, $count);
+        Mail::assertNothingSent();
+    }
+
+    public function test_does_not_send_for_too_old_notifications(): void
+    {
+        $user = $this->createTestUser();
+        $sender = $this->createTestUser();
+
+        // 25 hours old — outside the 24-hour window
+        $this->createNotification($user, $sender, [
+            'timestamp' => now()->subHours(25),
+        ]);
+
+        $count = $this->service->sendEmails();
+
+        $this->assertEquals(0, $count);
+        Mail::assertNothingSent();
+    }
+
+    // -----------------------------------------------------------------------
+    // Already mailed / already seen
+    // -----------------------------------------------------------------------
+
+    public function test_does_not_send_already_mailed_notifications(): void
+    {
+        $user = $this->createTestUser();
+        $sender = $this->createTestUser();
+
+        $this->createNotification($user, $sender, ['mailed' => 1]);
+
+        $count = $this->service->sendEmails();
+
+        $this->assertEquals(0, $count);
+        Mail::assertNothingSent();
+    }
+
+    // -----------------------------------------------------------------------
+    // Excluded notification types
+    // -----------------------------------------------------------------------
+
+    public function test_excludes_try_feed_notifications(): void
+    {
+        $user = $this->createTestUser();
+        $sender = $this->createTestUser();
+
+        $this->createNotification($user, $sender, ['type' => 'TryFeed']);
+
+        $count = $this->service->sendEmails();
+
+        $this->assertEquals(0, $count);
+        Mail::assertNothingSent();
+    }
+
+    public function test_excludes_about_me_notifications(): void
+    {
+        $user = $this->createTestUser();
+        $sender = $this->createTestUser();
+
+        $this->createNotification($user, $sender, ['type' => 'AboutMe']);
+
+        $count = $this->service->sendEmails();
+
+        $this->assertEquals(0, $count);
+        Mail::assertNothingSent();
+    }
+
+    public function test_excludes_gift_aid_notifications(): void
+    {
+        $user = $this->createTestUser();
+        $sender = $this->createTestUser();
+
+        $this->createNotification($user, $sender, ['type' => 'GiftAid']);
+
+        $count = $this->service->sendEmails();
+
+        $this->assertEquals(0, $count);
+        Mail::assertNothingSent();
+    }
+
+    public function test_excludes_open_posts_notifications(): void
+    {
+        $user = $this->createTestUser();
+        $sender = $this->createTestUser();
+
+        $this->createNotification($user, $sender, ['type' => 'OpenPosts']);
+
+        $count = $this->service->sendEmails();
+
+        $this->assertEquals(0, $count);
+        Mail::assertNothingSent();
+    }
+
+    // -----------------------------------------------------------------------
+    // User eligibility checks
+    // -----------------------------------------------------------------------
+
+    public function test_does_not_send_to_deleted_users(): void
+    {
+        $user = $this->createTestUser(['deleted' => now()]);
+        $sender = $this->createTestUser();
+
+        $this->createNotification($user, $sender);
+
+        $count = $this->service->sendEmails();
+
+        $this->assertEquals(0, $count);
+        Mail::assertNothingSent();
+    }
+
+    public function test_does_not_send_when_simplemail_is_none(): void
+    {
+        $user = $this->createTestUser([
+            'settings' => ['simplemail' => 'None'],
+        ]);
+        $sender = $this->createTestUser();
+
+        $this->createNotification($user, $sender);
+
+        $count = $this->service->sendEmails();
+
+        $this->assertEquals(0, $count);
+        Mail::assertNothingSent();
+    }
+
+    public function test_does_not_send_when_notificationmails_is_false(): void
+    {
+        $user = $this->createTestUser([
+            'settings' => ['notificationmails' => false],
+        ]);
+        $sender = $this->createTestUser();
+
+        $this->createNotification($user, $sender);
+
+        $count = $this->service->sendEmails();
+
+        $this->assertEquals(0, $count);
+        Mail::assertNothingSent();
+    }
+
+    public function test_does_not_send_to_bouncing_users(): void
+    {
+        $user = $this->createTestUser(['bouncing' => 1]);
+        $sender = $this->createTestUser();
+
+        $this->createNotification($user, $sender);
+
+        $count = $this->service->sendEmails();
+
+        $this->assertEquals(0, $count);
+        Mail::assertNothingSent();
+    }
+
+    public function test_does_not_send_to_user_on_holiday(): void
+    {
+        $user = $this->createTestUser(['onholidaytill' => now()->addDays(3)]);
+        $sender = $this->createTestUser();
+
+        $this->createNotification($user, $sender);
+
+        $count = $this->service->sendEmails();
+
+        $this->assertEquals(0, $count);
+        Mail::assertNothingSent();
+    }
+
+    public function test_does_not_send_to_inactive_user(): void
+    {
+        // Last active > 182 days ago
+        $user = $this->createTestUser(['lastaccess' => now()->subDays(200)]);
+        $sender = $this->createTestUser();
+
+        $this->createNotification($user, $sender);
+
+        $count = $this->service->sendEmails();
+
+        $this->assertEquals(0, $count);
+        Mail::assertNothingSent();
+    }
+
+    // -----------------------------------------------------------------------
+    // Spam filtering
+    // -----------------------------------------------------------------------
+
+    public function test_excludes_notifications_from_spammers(): void
+    {
+        $user = $this->createTestUser();
+        $spammer = $this->createTestUser();
+
+        // Mark the from-user as a spammer
+        DB::table('spam_users')->insert([
+            'userid'     => $spammer->id,
+            'byuserid'   => $user->id,
+            'collection' => 'Spammer',
+        ]);
+
+        $this->createNotification($user, $spammer);
+
+        $count = $this->service->sendEmails();
+
+        $this->assertEquals(0, $count);
+        Mail::assertNothingSent();
+    }
+
+    // -----------------------------------------------------------------------
+    // Marks notifications as mailed
+    // -----------------------------------------------------------------------
+
+    public function test_marks_notifications_as_mailed_after_sending(): void
+    {
+        $user = $this->createTestUser(['lastaccess' => now()]);
+        $sender = $this->createTestUser();
+
+        $notif = $this->createNotification($user, $sender);
+
+        $this->service->sendEmails();
+
+        $updated = DB::table('users_notifications')->where('id', $notif->id)->first();
+        $this->assertEquals(1, $updated->mailed);
+    }
+
+    public function test_does_not_send_to_already_mailed_users(): void
+    {
+        $user = $this->createTestUser(['lastaccess' => now()]);
+        $sender = $this->createTestUser();
+
+        // Create notification, run service (marks as mailed)
+        $this->createNotification($user, $sender);
+        $this->service->sendEmails();
+        Mail::assertSent(ChaseUpMail::class, 1);
+
+        // Run again — should NOT resend
+        $this->service->sendEmails();
+        Mail::assertSent(ChaseUpMail::class, 1); // still only 1 sent total
+    }
+
+    // -----------------------------------------------------------------------
+    // Dry run
+    // -----------------------------------------------------------------------
+
+    public function test_dry_run_does_not_send_emails(): void
+    {
+        $user = $this->createTestUser(['lastaccess' => now()]);
+        $sender = $this->createTestUser();
+
+        $notif = $this->createNotification($user, $sender);
+
+        $count = $this->service->sendEmails(dryRun: true);
+
+        $this->assertGreaterThan(0, $count);
+        Mail::assertNothingSent();
+
+        // Should NOT have marked as mailed
+        $updated = DB::table('users_notifications')->where('id', $notif->id)->first();
+        $this->assertEquals(0, $updated->mailed);
+    }
+
+    // -----------------------------------------------------------------------
+    // Subject line generation
+    // -----------------------------------------------------------------------
+
+    public function test_subject_for_comment_on_your_post(): void
+    {
+        $subject = $this->service->getNotifTitle([[
+            'type'     => 'CommentOnYourPost',
+            'fromname' => 'Alice',
+            'newsfeed' => ['type' => 'Message', 'message' => 'Hello world'],
+            'title'    => null,
+            'seen'     => false,
+        ]]);
+
+        $this->assertStringContainsString('Alice', $subject);
+        $this->assertStringContainsString('commented', $subject);
+    }
+
+    public function test_subject_for_comment_on_comment(): void
+    {
+        $subject = $this->service->getNotifTitle([[
+            'type'     => 'CommentOnCommented',
+            'fromname' => 'Bob',
+            'newsfeed' => ['type' => 'Message', 'message' => 'Reply text'],
+            'title'    => null,
+            'seen'     => false,
+        ]]);
+
+        $this->assertStringContainsString('Bob', $subject);
+        $this->assertStringContainsString('replied', $subject);
+    }
+
+    public function test_subject_for_loved_post(): void
+    {
+        $subject = $this->service->getNotifTitle([[
+            'type'     => 'LovedPost',
+            'fromname' => 'Carol',
+            'newsfeed' => ['type' => 'Message', 'message' => 'Nice item'],
+            'title'    => null,
+            'seen'     => false,
+        ]]);
+
+        $this->assertStringContainsString('Carol', $subject);
+        $this->assertStringContainsString('loved', $subject);
+    }
+
+    public function test_subject_for_multiple_notifications_appends_count(): void
+    {
+        $subject = $this->service->getNotifTitle([
+            ['type' => 'CommentOnYourPost', 'fromname' => 'Alice', 'newsfeed' => ['type' => 'Message', 'message' => 'Post 1'], 'title' => null, 'seen' => false],
+            ['type' => 'CommentOnYourPost', 'fromname' => 'Bob', 'newsfeed' => ['type' => 'Message', 'message' => 'Post 2'], 'title' => null, 'seen' => false],
+            ['type' => 'LovedPost', 'fromname' => 'Carol', 'newsfeed' => ['type' => 'Message', 'message' => 'Post 3'], 'title' => null, 'seen' => false],
+        ]);
+
+        $this->assertStringContainsString('+', $subject);
+        $this->assertStringContainsString('more', $subject);
+    }
+
+    public function test_subject_for_exhort_uses_title(): void
+    {
+        $subject = $this->service->getNotifTitle([[
+            'type'     => 'Exhort',
+            'fromname' => 'Freegle',
+            'newsfeed' => null,
+            'title'    => 'Tell us your story!',
+            'seen'     => false,
+        ]]);
+
+        $this->assertStringContainsString('Tell us your story!', $subject);
+    }
+
+    // -----------------------------------------------------------------------
+    // User-specific filtering
+    // -----------------------------------------------------------------------
+
+    public function test_can_filter_by_specific_user_id(): void
+    {
+        $user1 = $this->createTestUser(['lastaccess' => now()]);
+        $user2 = $this->createTestUser(['lastaccess' => now()]);
+        $sender = $this->createTestUser();
+
+        $this->createNotification($user1, $sender);
+        $this->createNotification($user2, $sender);
+
+        // Only process user1
+        $count = $this->service->sendEmails(userId: $user1->id);
+
+        $this->assertEquals(1, $count);
+        Mail::assertSent(ChaseUpMail::class, function ($mail) use ($user1) {
+            return $mail->hasTo($user1->email_preferred);
+        });
+        Mail::assertNotSent(ChaseUpMail::class, function ($mail) use ($user2) {
+            return $mail->hasTo($user2->email_preferred);
+        });
+    }
+}

--- a/iznik-nuxt3/components/MicroVolunteeringAIImageReview.vue
+++ b/iznik-nuxt3/components/MicroVolunteeringAIImageReview.vue
@@ -45,7 +45,7 @@
         </div>
       </div>
 
-      <div class="mb-3">
+      <div class="d-flex justify-content-between align-items-center mb-3">
         <div class="d-flex gap-2">
           <button class="btn btn-outline-secondary" @click="regenerate">
             Regenerate
@@ -65,6 +65,13 @@
             Next
           </button>
         </div>
+        <SpinButton
+          variant="success"
+          icon-name="thumbs-up"
+          label="Accept - looks good"
+          :disabled="containsPeople === null"
+          @handle="approve"
+        />
       </div>
 
       <div class="question-block mb-3">
@@ -78,13 +85,6 @@
             label="No, not great"
             :disabled="containsPeople === null"
             @handle="reject"
-          />
-          <SpinButton
-            variant="success"
-            icon-name="thumbs-up"
-            label="Accept - looks good"
-            :disabled="containsPeople === null"
-            @handle="approve"
           />
         </div>
         <p v-if="containsPeople === null" class="help-hint mt-2">

--- a/iznik-nuxt3/components/MicroVolunteeringAIImageReview.vue
+++ b/iznik-nuxt3/components/MicroVolunteeringAIImageReview.vue
@@ -45,7 +45,7 @@
         </div>
       </div>
 
-      <div class="d-flex justify-content-between align-items-center mb-3">
+      <div class="mb-3">
         <div class="d-flex gap-2">
           <button class="btn btn-outline-secondary" @click="regenerate">
             Regenerate
@@ -65,13 +65,6 @@
             Next
           </button>
         </div>
-        <SpinButton
-          variant="success"
-          icon-name="thumbs-up"
-          label="Accept - looks good"
-          :disabled="containsPeople === null"
-          @handle="approve"
-        />
       </div>
 
       <div class="question-block mb-3">
@@ -85,6 +78,13 @@
             label="No, not great"
             :disabled="containsPeople === null"
             @handle="reject"
+          />
+          <SpinButton
+            variant="success"
+            icon-name="thumbs-up"
+            label="Accept - looks good"
+            :disabled="containsPeople === null"
+            @handle="approve"
           />
         </div>
         <p v-if="containsPeople === null" class="help-hint mt-2">

--- a/iznik-nuxt3/components/MicroVolunteeringAIImageReview.vue
+++ b/iznik-nuxt3/components/MicroVolunteeringAIImageReview.vue
@@ -51,14 +51,14 @@
             Regenerate
           </button>
           <button
-            v-if="currentIndex > 0"
+            v-show="currentIndex > 0"
             class="btn btn-outline-secondary"
             @click="previous"
           >
             Previous
           </button>
           <button
-            v-if="currentIndex < images.length - 1"
+            v-show="currentIndex < images.length - 1"
             class="btn btn-outline-secondary"
             @click="next"
           >

--- a/iznik-nuxt3/tests/e2e/fixtures.js
+++ b/iznik-nuxt3/tests/e2e/fixtures.js
@@ -299,6 +299,7 @@ const test = base.test.extend({
       /Failed to load resource: net::ERR_ABORTED/, // Can happen during page navigation when requests are cancelled
       /Failed to load resource: net::ERR_CONNECTION_REFUSED/, // Can happen when server is starting up
       /Failed to load resource: net::ERR_NAME_NOT_RESOLVED/, // External CDNs (Facebook, Google, etc.) not DNS-resolvable in isolated Docker test environment
+      /Failed to load resource: net::ERR_ADDRESS_UNREACHABLE.*dns\.google/, // dns.google DoH used by EmailValidator for best-effort domain validation; unreachable in some CI Docker environments (JS catch block already suppresses the error)
       /has been blocked by CORS policy/, // CORS errors can happen in test environments due to ads
       /Failed to save credentials NotSupportedError: The user agent does not support public key credentials./, // Can happen in test environments
       /Refused to frame/, // Can happen in test.

--- a/iznik-server-go/queue/queue_test.go
+++ b/iznik-server-go/queue/queue_test.go
@@ -1,0 +1,33 @@
+package queue
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTaskTypeConstants(t *testing.T) {
+	// Verify task type string values — iznik-batch Laravel code expects these
+	// exact strings; a rename would silently break the hand-off between Go and PHP.
+	assert.Equal(t, "push_notify_group_mods", TaskPushNotifyGroupMods)
+	assert.Equal(t, "email_chitchat_report", TaskEmailChitchatReport)
+	assert.Equal(t, "email_charity_signup", TaskEmailCharitySignup)
+	assert.Equal(t, "email_donate_external", TaskEmailDonateExternal)
+	assert.Equal(t, "email_forgot_password", TaskEmailForgotPassword)
+	assert.Equal(t, "email_unsubscribe", TaskEmailUnsubscribe)
+	assert.Equal(t, "email_merge", TaskEmailMerge)
+	assert.Equal(t, "email_verify", TaskEmailVerify)
+	assert.Equal(t, "freebie_alerts_add", TaskFreebieAlertsAdd)
+	assert.Equal(t, "freebie_alerts_remove", TaskFreebieAlertsRemove)
+	assert.Equal(t, "remap_postcodes", TaskRemapPostcodes)
+	assert.Equal(t, "user_forget", TaskUserForget)
+}
+
+func TestQueueTaskMarshalError(t *testing.T) {
+	// Channels are not JSON-serializable; QueueTask must return an error before
+	// reaching the database — safe to run without a DB connection.
+	err := QueueTask("test", map[string]interface{}{
+		"bad": make(chan int),
+	})
+	assert.Error(t, err)
+}

--- a/services/avatar-server/Dockerfile
+++ b/services/avatar-server/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:20-alpine
+RUN apk add --no-cache librsvg vips
+WORKDIR /app
+COPY package.json ./
+RUN npm install
+COPY server.js ./
+EXPOSE 3000
+CMD ["node", "server.js"]

--- a/services/avatar-server/package.json
+++ b/services/avatar-server/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "freegle-avatar-server",
+  "version": "1.0.0",
+  "dependencies": {
+    "boring-avatars": "^1.11.2",
+    "express": "^4.18.2",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "sharp": "^0.33.0"
+  }
+}

--- a/services/avatar-server/server.js
+++ b/services/avatar-server/server.js
@@ -1,0 +1,107 @@
+'use strict'
+
+const express = require('express')
+const React = require('react')
+const { renderToStaticMarkup } = require('react-dom/server')
+const boringAvatars = require('boring-avatars')
+const sharp = require('sharp')
+
+// boring-avatars may export default as .default (CJS interop)
+const Avatar = boringAvatars.default || boringAvatars
+
+const app = express()
+
+// Must exactly match GeneratedAvatar.client.vue
+const boringVariants = ['pixel', 'beam', 'bauhaus', 'ring']
+const customVariants = ['spots', 'tiles']
+const allVariants = [...boringVariants, ...customVariants]
+
+const colorPalettes = [
+  ['#2E7D32', '#4CAF50', '#81C784', '#A5D6A7', '#C8E6C9'],
+  ['#1565C0', '#42A5F5', '#90CAF9', '#4DB6AC', '#80CBC4'],
+  ['#7B1FA2', '#BA68C8', '#E1BEE7', '#F48FB1', '#F8BBD9'],
+  ['#E65100', '#FF9800', '#FFB74D', '#FFCC80', '#FFE0B2'],
+  ['#00695C', '#26A69A', '#80CBC4', '#4DD0E1', '#80DEEA'],
+  ['#5D4037', '#8D6E63', '#BCAAA4', '#A1887F', '#D7CCC8'],
+  ['#C62828', '#EF5350', '#FFCDD2', '#FF8A65', '#FFAB91'],
+  ['#AD1457', '#EC407A', '#F48FB1', '#CE93D8', '#E1BEE7'],
+  ['#1A237E', '#3949AB', '#7986CB', '#9FA8DA', '#C5CAE9'],
+  ['#004D40', '#00796B', '#4DB6AC', '#80CBC4', '#B2DFDB'],
+]
+
+function hashString(str) {
+  let hash = 0
+  for (let i = 0; i < str.length; i++) {
+    const char = str.charCodeAt(i)
+    hash = (hash << 5) - hash + char
+    hash = hash & hash
+  }
+  return Math.abs(hash)
+}
+
+function getAvatarParams(name) {
+  const hash = hashString(name || 'user')
+  const variant = allVariants[hash % allVariants.length]
+  const colorIndex = Math.floor(hash / allVariants.length) % colorPalettes.length
+  return { hash, variant, colors: colorPalettes[colorIndex] }
+}
+
+function buildCustomSvg(variant, hash, colors, size) {
+  if (variant === 'spots') {
+    const spots = [
+      { x: 25 + (hash % 15),           y: 25 + ((hash >> 2) % 15),   r: 20 + (hash % 10) },
+      { x: 70 + ((hash >> 3) % 15),    y: 30 + ((hash >> 5) % 15),   r: 18 + ((hash >> 4) % 12) },
+      { x: 30 + ((hash >> 6) % 20),    y: 70 + ((hash >> 7) % 15),   r: 22 + ((hash >> 8) % 10) },
+      { x: 75 + ((hash >> 9) % 15),    y: 72 + ((hash >> 10) % 15),  r: 16 + ((hash >> 11) % 10) },
+      { x: 50 + ((hash >> 12) % 20) - 10, y: 50 + ((hash >> 13) % 20) - 10, r: 15 + ((hash >> 14) % 8) },
+    ]
+    const circles = spots.map((s, i) => `<circle cx="${s.x}" cy="${s.y}" r="${s.r}" fill="${colors[(i % 4) + 1]}"/>`).join('')
+    return `<svg xmlns="http://www.w3.org/2000/svg" width="${size}" height="${size}" viewBox="0 0 100 100"><rect width="100" height="100" fill="${colors[0]}"/>${circles}</svg>`
+  }
+  // tiles
+  const tiles = [
+    { x: 0,                         y: 0,                         w: 45 + (hash % 15),         h: 45 + ((hash >> 2) % 15) },
+    { x: 50 + ((hash >> 3) % 10),   y: 5,                         w: 40 + ((hash >> 4) % 15),  h: 35 + ((hash >> 5) % 15) },
+    { x: 5,                         y: 55 + ((hash >> 6) % 10),   w: 35 + ((hash >> 7) % 15),  h: 38 + ((hash >> 8) % 12) },
+    { x: 45 + ((hash >> 9) % 10),   y: 45 + ((hash >> 10) % 10), w: 50,                        h: 50 },
+  ]
+  const rects = tiles.map((t, i) => `<rect x="${t.x}" y="${t.y}" width="${t.w}" height="${t.h}" fill="${colors[(i % 4) + 1]}"/>`).join('')
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${size}" height="${size}" viewBox="0 0 100 100"><rect width="100" height="100" fill="${colors[0]}"/>${rects}</svg>`
+}
+
+app.get('/:name', async (req, res) => {
+  try {
+    const name = decodeURIComponent(req.params.name.replace(/\.png$/, ''))
+    const size = Math.min(parseInt(req.query.size || '48', 10), 256)
+    const { hash, variant, colors } = getAvatarParams(name)
+
+    let svgString
+    if (customVariants.includes(variant)) {
+      svgString = buildCustomSvg(variant, hash, colors, size)
+    } else {
+      svgString = renderToStaticMarkup(
+        React.createElement(Avatar, { name, size, variant, colors })
+      )
+      if (!svgString.includes('xmlns')) {
+        svgString = svgString.replace('<svg ', '<svg xmlns="http://www.w3.org/2000/svg" ')
+      }
+    }
+
+    const png = await sharp(Buffer.from(svgString))
+      .resize(size, size)
+      .png()
+      .toBuffer()
+
+    res.set('Content-Type', 'image/png')
+    res.set('Cache-Control', 'public, max-age=86400')
+    res.send(png)
+  } catch (err) {
+    console.error('Avatar error:', err)
+    res.status(500).send('Avatar generation failed')
+  }
+})
+
+app.get('/health', (_req, res) => res.send('ok'))
+
+const port = process.env.PORT || 3000
+app.listen(port, () => console.log(`Avatar server on :${port}`))


### PR DESCRIPTION
## Summary

- Migrates V1 `notification_chaseup.php` cron job to a Laravel `NotificationChaseUpService` + `ChaseUpMail`
- Sends one digest email per user listing their unseen, unmailed notifications (comments, loves, exhorts, membership events) using MJML with the standard green header/footer
- Each notification row shows a **boring-avatar** matching the frontend (never the grey default silhouette)
- Artisan command: `mail:notifications:chaseup` (scheduled every 5 min, matching V1)

## Behaviour matches V1

- 5-min minimum / 24-hour maximum age window for notifications
- Excludes: `TryFeed`, `AboutMe`, `GiftAid`, `OpenPosts` notification types
- Skips deleted, bouncing, on-holiday, inactive (>182 days), and `notificationmails=false` users
- Filters notifications from `spam_users`
- Marks `users_notifications.mailed=1` after sending; dry-run mode available
- Subject line mirrors V1 logic (single: "Alice commented: …"; multiple: "Alice commented: … +2 more")
- MembershipPending/Approved/Rejected now produce subject lines (was silently dropped before)

## Avatars

An `AvatarResolver` trait (shared by `NotificationChaseUpService`, `ChatNotification`, and `SendAdminCommand`) resolves avatar URLs. User profile images are used when available; otherwise the boring-avatar server is called. Avatar URL is configured via `FREEGLE_AVATAR_SERVER_URL` (default: `https://www.ilovefreegle.org/api/avatar` — served by the Go API in production).

## Code Quality Review

- Service, Mailable, Command, and Blade templates follow existing patterns
- `AvatarResolver` trait eliminates all `defaultprofile.png` references across the codebase
- All 1791 unit tests pass (up from 1784 — 7 new tests added for Membership types and LovedComment)

## Test Plan

- [x] 1791 tests, 0 failures
- [x] All 10 V1 notification types in a single email visually verified in Mailpit (avatars rendering correctly)
- [x] BST-aware timestamps verified
- [x] Membership type subject lines: MembershipPending, MembershipApproved, MembershipRejected