### PR TITLE
feat(message): partner key auth for POST /message actions + PATCH /message/tn/:tnpostid

### DIFF
--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -2686,17 +2686,7 @@ func PatchMessage(c *fiber.Ctx) error {
 	return applyPatchMessage(c, myid, req)
 }
 
-// PatchMessageByTN updates a message identified by its Trash Nothing post ID
-// (PATCH /message/tn/:tnpostid). Intended for partner integrations where the
-// Freegle message ID is not yet known (e.g. post held for moderation).
-//
-// @Summary Update a message by TN post ID
-// @Tags message
-// @Accept json
-// @Produce json
-// @Param tnpostid path string true "Trash Nothing post ID"
-// @Success 200 {object} map[string]interface{}
-// @Router /api/message/tn/{tnpostid} [patch]
+// PatchMessageByTN updates a message by TN post ID (PATCH /message/tn/:tnpostid).
 func PatchMessageByTN(c *fiber.Ctx) error {
 	myid := user.WhoAmI(c)
 

--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -2226,91 +2226,60 @@ func handleJoinAndPost(c *fiber.Ctx, myid uint64, req PostMessageRequest) error 
 	return c.JSON(resp)
 }
 
-// PatchMessage updates a message (PATCH /message).
-//
-// @Summary Update a message
-// @Tags message
-// @Accept json
-// @Produce json
-// @Success 200 {object} map[string]interface{}
-// @Router /api/message [patch]
-func PatchMessage(c *fiber.Ctx) error {
-	myid := user.WhoAmI(c)
+// patchMessageRequest is the body for PATCH /message and PATCH /message/tn/:tnpostid.
+type patchMessageRequest struct {
+	ID           uint64   `json:"id"`
+	Subject      *string  `json:"subject"`
+	Textbody     *string  `json:"textbody"`
+	Type         *string  `json:"type"`
+	Msgtype      *string  `json:"msgtype"`
+	Messagetype  *string  `json:"messagetype"`
+	Item         *string  `json:"item"`
+	Availablenow *int     `json:"availablenow"`
+	Lat          *float64 `json:"lat"`
+	Lng          *float64 `json:"lng"`
+	Location     *string  `json:"location"`
+	Locationid   *uint64  `json:"locationid"`
+	Groupid      *uint64  `json:"groupid"`
+	Attachments  []uint64 `json:"attachments"`
+	BadAIImages  []uint64 `json:"badAIImages"`
+	Deadline     *string  `json:"deadline"`
+}
 
-	// Partner auth: if partner query param is present, authenticate via partner key
-	// instead of JWT. The partner acts on behalf of the identified user.
-	partnerKey := c.Query("partner")
-	if partnerKey != "" {
-		db := database.DBConn
-		_, _, domain, err := user.ValidatePartnerKey(db, partnerKey)
-		if err != nil {
-			return fiber.NewError(fiber.StatusForbidden, "Invalid partner key")
-		}
+// resolvePartnerAuth reads a ?partner= query param and resolves the acting user ID.
+// Returns the resolved user ID (0 on failure) and an error to return to the client.
+func resolvePartnerAuth(c *fiber.Ctx) (uint64, error) {
+	db := database.DBConn
+	_, _, domain, err := user.ValidatePartnerKey(db, c.Query("partner"))
+	if err != nil {
+		return 0, fiber.NewError(fiber.StatusForbidden, "Invalid partner key")
+	}
 
-		email := c.Query("email")
-		tnuseridStr := c.Query("tnuserid")
-		var tnuserid uint64
-		if tnuseridStr != "" {
-			if v, err := strconv.ParseUint(tnuseridStr, 10, 64); err == nil {
-				tnuserid = v
-			}
-		}
-
-		// Validate email domain matches partner domain.
-		if email != "" {
-			parts := strings.SplitN(email, "@", 2)
-			if len(parts) != 2 || parts[1] != domain {
-				return fiber.NewError(fiber.StatusForbidden, "Email domain does not match partner domain")
-			}
-		}
-
-		myid = user.FindByTNIdOrEmail(db, tnuserid, email)
-		if myid == 0 {
-			return fiber.NewError(fiber.StatusForbidden, "User not found for partner")
+	email := c.Query("email")
+	tnuseridStr := c.Query("tnuserid")
+	var tnuserid uint64
+	if tnuseridStr != "" {
+		if v, err := strconv.ParseUint(tnuseridStr, 10, 64); err == nil {
+			tnuserid = v
 		}
 	}
 
+	if email != "" {
+		parts := strings.SplitN(email, "@", 2)
+		if len(parts) != 2 || parts[1] != domain {
+			return 0, fiber.NewError(fiber.StatusForbidden, "Email domain does not match partner domain")
+		}
+	}
+
+	myid := user.FindByTNIdOrEmail(db, tnuserid, email)
 	if myid == 0 {
-		return fiber.NewError(fiber.StatusUnauthorized, "Not logged in")
+		return 0, fiber.NewError(fiber.StatusForbidden, "User not found for partner")
 	}
+	return myid, nil
+}
 
-	type PatchMessageRequest struct {
-		ID           uint64   `json:"id"`
-		Subject      *string  `json:"subject"`
-		Textbody     *string  `json:"textbody"`
-		Type         *string  `json:"type"`
-		Msgtype      *string  `json:"msgtype"`
-		Messagetype  *string  `json:"messagetype"`
-		Item         *string  `json:"item"`
-		Availablenow *int     `json:"availablenow"`
-		Lat          *float64 `json:"lat"`
-		Lng          *float64 `json:"lng"`
-		Location     *string  `json:"location"`
-		Locationid   *uint64  `json:"locationid"`
-		Groupid      *uint64  `json:"groupid"`
-		Attachments  []uint64 `json:"attachments"`
-		BadAIImages  []uint64 `json:"badAIImages"`
-		Deadline     *string  `json:"deadline"`
-	}
-
-	var req PatchMessageRequest
-	if err := c.BodyParser(&req); err != nil {
-		return fiber.NewError(fiber.StatusBadRequest, "Invalid request body")
-	}
-
-	// Frontend sends "msgtype" (ModMessage.vue) or "messagetype" (compose store),
-	// accept all three aliases.
-	if req.Type == nil && req.Msgtype != nil {
-		req.Type = req.Msgtype
-	}
-	if req.Type == nil && req.Messagetype != nil {
-		req.Type = req.Messagetype
-	}
-
-	if req.ID == 0 {
-		return fiber.NewError(fiber.StatusBadRequest, "id is required")
-	}
-
+// applyPatchMessage performs the edit on a message after auth and ID are resolved.
+func applyPatchMessage(c *fiber.Ctx, myid uint64, req patchMessageRequest) error {
 	db := database.DBConn
 
 	// Check ownership or mod permission.
@@ -2675,6 +2644,102 @@ func PatchMessage(c *fiber.Ctx) error {
 	return c.JSON(fiber.Map{"ret": 0, "status": "Success"})
 }
 
+// PatchMessage updates a message (PATCH /message).
+//
+// @Summary Update a message
+// @Tags message
+// @Accept json
+// @Produce json
+// @Success 200 {object} map[string]interface{}
+// @Router /api/message [patch]
+func PatchMessage(c *fiber.Ctx) error {
+	myid := user.WhoAmI(c)
+
+	if c.Query("partner") != "" {
+		var err error
+		myid, err = resolvePartnerAuth(c)
+		if err != nil {
+			return err
+		}
+	}
+
+	if myid == 0 {
+		return fiber.NewError(fiber.StatusUnauthorized, "Not logged in")
+	}
+
+	var req patchMessageRequest
+	if err := c.BodyParser(&req); err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, "Invalid request body")
+	}
+
+	if req.Type == nil && req.Msgtype != nil {
+		req.Type = req.Msgtype
+	}
+	if req.Type == nil && req.Messagetype != nil {
+		req.Type = req.Messagetype
+	}
+
+	if req.ID == 0 {
+		return fiber.NewError(fiber.StatusBadRequest, "id is required")
+	}
+
+	return applyPatchMessage(c, myid, req)
+}
+
+// PatchMessageByTN updates a message identified by its Trash Nothing post ID
+// (PATCH /message/tn/:tnpostid). Intended for partner integrations where the
+// Freegle message ID is not yet known (e.g. post held for moderation).
+//
+// @Summary Update a message by TN post ID
+// @Tags message
+// @Accept json
+// @Produce json
+// @Param tnpostid path string true "Trash Nothing post ID"
+// @Success 200 {object} map[string]interface{}
+// @Router /api/message/tn/{tnpostid} [patch]
+func PatchMessageByTN(c *fiber.Ctx) error {
+	myid := user.WhoAmI(c)
+
+	if c.Query("partner") != "" {
+		var err error
+		myid, err = resolvePartnerAuth(c)
+		if err != nil {
+			return err
+		}
+	}
+
+	if myid == 0 {
+		return fiber.NewError(fiber.StatusUnauthorized, "Not logged in")
+	}
+
+	tnpostid := c.Params("tnpostid")
+	if tnpostid == "" {
+		return fiber.NewError(fiber.StatusBadRequest, "tnpostid is required")
+	}
+
+	db := database.DBConn
+	var msgID uint64
+	db.Raw("SELECT id FROM messages WHERE tnpostid = ? LIMIT 1", tnpostid).Scan(&msgID)
+	if msgID == 0 {
+		return fiber.NewError(fiber.StatusNotFound, "Message not found for that TN post ID")
+	}
+
+	var req patchMessageRequest
+	if err := c.BodyParser(&req); err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, "Invalid request body")
+	}
+
+	if req.Type == nil && req.Msgtype != nil {
+		req.Type = req.Msgtype
+	}
+	if req.Type == nil && req.Messagetype != nil {
+		req.Type = req.Messagetype
+	}
+
+	req.ID = msgID
+	return applyPatchMessage(c, myid, req)
+}
+
 // DeleteMessageEndpoint handles DELETE /message/:id.
 //
 // @Summary Delete a message
@@ -3037,11 +3102,45 @@ type PostMessageRequest struct {
 	Deadline         *string `json:"deadline"`
 	Deliverypossible *bool   `json:"deliverypossible"`
 	ForcePending     *bool   `json:"forcepending"`
+	Tnpostid         *string `json:"tnpostid"`
 }
 
 // PostMessage dispatches POST /message actions.
 func PostMessage(c *fiber.Ctx) error {
 	myid := user.WhoAmI(c)
+
+	// Partner auth: if partner query param is present, authenticate via partner key
+	// instead of JWT. The partner acts on behalf of the identified user.
+	partnerKey := c.Query("partner")
+	if partnerKey != "" {
+		db := database.DBConn
+		_, _, domain, err := user.ValidatePartnerKey(db, partnerKey)
+		if err != nil {
+			return fiber.NewError(fiber.StatusForbidden, "Invalid partner key")
+		}
+
+		email := c.Query("email")
+		tnuseridStr := c.Query("tnuserid")
+		var tnuserid uint64
+		if tnuseridStr != "" {
+			if v, err := strconv.ParseUint(tnuseridStr, 10, 64); err == nil {
+				tnuserid = v
+			}
+		}
+
+		if email != "" {
+			parts := strings.SplitN(email, "@", 2)
+			if len(parts) != 2 || parts[1] != domain {
+				return fiber.NewError(fiber.StatusForbidden, "Email domain does not match partner domain")
+			}
+		}
+
+		myid = user.FindByTNIdOrEmail(db, tnuserid, email)
+		if myid == 0 {
+			return fiber.NewError(fiber.StatusForbidden, "User not found for partner")
+		}
+	}
+
 	if myid == 0 {
 		return fiber.NewError(fiber.StatusUnauthorized, "Not logged in")
 	}
@@ -3049,6 +3148,12 @@ func PostMessage(c *fiber.Ctx) error {
 	var req PostMessageRequest
 	if err := c.BodyParser(&req); err != nil {
 		return fiber.NewError(fiber.StatusBadRequest, "Invalid request body")
+	}
+
+	// Resolve message ID from tnpostid when id is absent.
+	if req.ID == 0 && req.Tnpostid != nil && *req.Tnpostid != "" {
+		db := database.DBConn
+		db.Raw("SELECT id FROM messages WHERE tnpostid = ? LIMIT 1", *req.Tnpostid).Scan(&req.ID)
 	}
 
 	if req.ID == 0 {

--- a/iznik-server-go/router/routes.go
+++ b/iznik-server-go/router/routes.go
@@ -902,6 +902,7 @@ func SetupRoutes(app *fiber.App) {
 		// @Success 200 {object} map[string]interface{}
 		rg.Post("/message", message.PostMessage)
 		rg.Patch("/message", message.PatchMessage)
+		rg.Patch("/message/tn/:tnpostid", message.PatchMessageByTN)
 		rg.Put("/message", message.PutMessage)
 		rg.Delete("/message/:id", message.DeleteMessageEndpoint)
 

--- a/iznik-server-go/router/routes.go
+++ b/iznik-server-go/router/routes.go
@@ -902,6 +902,15 @@ func SetupRoutes(app *fiber.App) {
 		// @Success 200 {object} map[string]interface{}
 		rg.Post("/message", message.PostMessage)
 		rg.Patch("/message", message.PatchMessage)
+
+		// @Router /message/tn/{tnpostid} [patch]
+		// @Summary Update a message by TN post ID
+		// @Description Edit a message using its Trash Nothing post ID. For partner integrations when the Freegle message ID is unknown.
+		// @Tags message
+		// @Accept json
+		// @Produce json
+		// @Param tnpostid path string true "Trash Nothing post ID"
+		// @Success 200 {object} map[string]interface{}
 		rg.Patch("/message/tn/:tnpostid", message.PatchMessageByTN)
 		rg.Put("/message", message.PutMessage)
 		rg.Delete("/message/:id", message.DeleteMessageEndpoint)

--- a/iznik-server-go/swagger/swagger.go
+++ b/iznik-server-go/swagger/swagger.go
@@ -2542,6 +2542,45 @@ type messagesResponse struct {
 //	401: errorResponse
 //	403: errorResponse
 
+// swagger:route PATCH /message/tn/{tnpostid} message patchMessageByTN
+// Update message by TN post ID
+//
+// Updates a message using its Trash Nothing post ID. For partner integrations
+// where the Freegle message ID is not yet known (e.g. post held for moderation).
+//
+// Parameters:
+//   + name: tnpostid
+//     in: path
+//     description: Trash Nothing post ID
+//     required: true
+//     type: string
+//   + name: partner
+//     in: query
+//     description: Partner API key (alternative to JWT auth)
+//     required: false
+//     type: string
+//   + name: tnuserid
+//     in: query
+//     description: Trash Nothing user ID (partner auth only)
+//     required: false
+//     type: integer
+//   + name: email
+//     in: query
+//     description: User email (partner auth only, domain must match partner domain)
+//     required: false
+//     type: string
+//
+// security:
+// - BearerAuth: []
+//
+// Responses:
+//
+//	200: successResponse
+//	400: errorResponse
+//	401: errorResponse
+//	403: errorResponse
+//	404: errorResponse
+
 // swagger:route PUT /message message putMessage
 // Create message
 //

--- a/iznik-server-go/swagger/swagger.json
+++ b/iznik-server-go/swagger/swagger.json
@@ -2966,6 +2966,67 @@
         }
       }
     },
+    "/message/tn/{tnpostid}": {
+      "patch": {
+        "security": [
+          {
+            "BearerAuth": [
+              "[]"
+            ]
+          }
+        ],
+        "description": "Updates a message using its Trash Nothing post ID. For partner integrations\nwhere the Freegle message ID is not yet known (e.g. post held for moderation).",
+        "tags": [
+          "message"
+        ],
+        "summary": "Update message by TN post ID",
+        "operationId": "patchMessageByTN",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Trash Nothing post ID",
+            "name": "tnpostid",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Partner API key (alternative to JWT auth)",
+            "name": "partner",
+            "in": "query"
+          },
+          {
+            "type": "integer",
+            "description": "Trash Nothing user ID (partner auth only)",
+            "name": "tnuserid",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "User email (partner auth only, domain must match partner domain)",
+            "name": "email",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/successResponse"
+          },
+          "400": {
+            "$ref": "#/responses/errorResponse"
+          },
+          "401": {
+            "$ref": "#/responses/errorResponse"
+          },
+          "403": {
+            "$ref": "#/responses/errorResponse"
+          },
+          "404": {
+            "$ref": "#/responses/errorResponse"
+          }
+        }
+      }
+    },
     "/message/{ids}": {
       "get": {
         "description": "Returns messages by ID (comma separated)",
@@ -8500,10 +8561,23 @@
           "format": "uint64",
           "x-go-name": "Groupid"
         },
+        "heldby": {
+          "type": "integer",
+          "format": "uint64",
+          "x-go-name": "Heldby"
+        },
         "msgid": {
           "type": "integer",
           "format": "uint64",
           "x-go-name": "Msgid"
+        },
+        "spamreason": {
+          "type": "string",
+          "x-go-name": "Spamreason"
+        },
+        "spamtype": {
+          "type": "string",
+          "x-go-name": "Spamtype"
         }
       },
       "x-go-package": "iznik-server-go/message"
@@ -8524,6 +8598,11 @@
           "type": "integer",
           "format": "uint64",
           "x-go-name": "Groupid"
+        },
+        "heldby": {
+          "type": "integer",
+          "format": "uint64",
+          "x-go-name": "Heldby"
         }
       },
       "x-go-package": "github.com/freegle/iznik-server-go/message"
@@ -9396,6 +9475,10 @@
     "Rating": {
       "type": "object",
       "properties": {
+        "comment": {
+          "type": "string",
+          "x-go-name": "Comment"
+        },
         "id": {
           "type": "integer",
           "format": "uint64",
@@ -9415,6 +9498,10 @@
           "type": "string",
           "x-go-name": "Rating"
         },
+        "reason": {
+          "type": "string",
+          "x-go-name": "Reason"
+        },
         "timestamp": {
           "type": "string",
           "x-go-name": "Timestamp"
@@ -9422,8 +9509,7 @@
         "tn_rating_id": {
           "type": "integer",
           "format": "uint64",
-          "x-go-name": "TnRatingID",
-          "x-nullable": true
+          "x-go-name": "TnRatingID"
         },
         "visible": {
           "type": "integer",
@@ -9965,6 +10051,7 @@
           "x-go-name": "Lat"
         },
         "ljuserid": {
+          "description": "No gorm:\"-\u003e\" — user/auth.go GetLoveJunkUser writes this column via\ndb.Create(\u0026ljuser) when first creating an LJ-linked user; making it\nread-only would silently drop the value and cause a fresh user to be\ncreated on every LJ call (TestCreateChatMessageLoveJunk regression).",
           "type": "integer",
           "format": "uint64",
           "x-go-name": "Ljuserid"
@@ -10032,7 +10119,6 @@
           "x-go-name": "Source"
         },
         "spammer": {
-          "type": "boolean",
           "x-go-name": "Spammer"
         },
         "supporter": {
@@ -10069,8 +10155,7 @@
         },
         "lastupdated": {
           "type": "string",
-          "x-go-name": "LastUpdated",
-          "x-nullable": true
+          "x-go-name": "LastUpdated"
         }
       },
       "x-go-package": "github.com/freegle/iznik-server-go/changes"

--- a/iznik-server-go/test/message_test.go
+++ b/iznik-server-go/test/message_test.go
@@ -7459,3 +7459,139 @@ func TestPatchMessageGroupidUpdatesDraft(t *testing.T) {
 	db.Raw("SELECT COUNT(*) FROM messages_groups WHERE msgid = ? AND groupid = ?", msgID, group2ID).Scan(&mgCount2)
 	assert.Equal(t, int64(1), mgCount2, "message must land on the user-selected group2")
 }
+
+// --- Partner key auth for POST /message (actions) ---
+
+func TestPostMessagePartnerAuthPromise(t *testing.T) {
+	prefix := uniquePrefix("msg_postpartner")
+	db := database.DBConn
+
+	groupID := CreateTestGroup(t, prefix)
+	ownerID := CreateTestUser(t, prefix+"_owner", "User")
+	CreateTestMembership(t, ownerID, groupID, "Member")
+	db.Exec("UPDATE users SET tnuserid = ? WHERE id = ?", 77701, ownerID)
+
+	msgID := CreateTestMessage(t, ownerID, groupID, prefix+" Offer", 55.9533, -3.1883)
+	key := insertTestPartnerKeyMsg(t, prefix, "tn.com")
+	defer db.Exec("DELETE FROM partners_keys WHERE partner = ?", prefix+"_partner")
+
+	body := map[string]interface{}{
+		"id":     msgID,
+		"action": "Promise",
+	}
+	bodyBytes, _ := json.Marshal(body)
+	url := fmt.Sprintf("/api/message?partner=%s&tnuserid=77701&email=%s@tn.com", key, prefix+"_owner")
+	req := httptest.NewRequest("POST", url, bytes.NewBuffer(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := getApp().Test(req, -1)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+}
+
+func TestPostMessagePartnerAuthByTnPostid(t *testing.T) {
+	prefix := uniquePrefix("msg_postpartnertn")
+	db := database.DBConn
+
+	groupID := CreateTestGroup(t, prefix)
+	ownerID := CreateTestUser(t, prefix+"_owner", "User")
+	CreateTestMembership(t, ownerID, groupID, "Member")
+	db.Exec("UPDATE users SET tnuserid = ? WHERE id = ?", 77702, ownerID)
+
+	msgID := CreateTestMessage(t, ownerID, groupID, prefix+" Offer", 55.9533, -3.1883)
+	tnpostid := fmt.Sprintf("tn-%d", msgID)
+	db.Exec("UPDATE messages SET tnpostid = ? WHERE id = ?", tnpostid, msgID)
+
+	key := insertTestPartnerKeyMsg(t, prefix, "tn.com")
+	defer db.Exec("DELETE FROM partners_keys WHERE partner = ?", prefix+"_partner")
+
+	// Send action with tnpostid instead of id.
+	body := map[string]interface{}{
+		"tnpostid": tnpostid,
+		"action":   "Promise",
+	}
+	bodyBytes, _ := json.Marshal(body)
+	url := fmt.Sprintf("/api/message?partner=%s&tnuserid=77702&email=%s@tn.com", key, prefix+"_owner")
+	req := httptest.NewRequest("POST", url, bytes.NewBuffer(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := getApp().Test(req, -1)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+}
+
+func TestPostMessagePartnerInvalidKey(t *testing.T) {
+	prefix := uniquePrefix("msg_postpartbad")
+
+	groupID := CreateTestGroup(t, prefix)
+	ownerID := CreateTestUser(t, prefix+"_owner", "User")
+	CreateTestMembership(t, ownerID, groupID, "Member")
+	msgID := CreateTestMessage(t, ownerID, groupID, prefix+" Offer", 55.9533, -3.1883)
+
+	body := map[string]interface{}{
+		"id":     msgID,
+		"action": "Promise",
+	}
+	bodyBytes, _ := json.Marshal(body)
+	req := httptest.NewRequest("POST", "/api/message?partner=bad_key&tnuserid=1&email=x@tn.com", bytes.NewBuffer(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := getApp().Test(req, -1)
+	assert.NoError(t, err)
+	assert.Equal(t, 403, resp.StatusCode)
+}
+
+// --- PATCH /message/tn/:tnpostid (edit by TN post ID) ---
+
+func TestPatchMessageByTnPostid(t *testing.T) {
+	prefix := uniquePrefix("msg_patchtn")
+	db := database.DBConn
+
+	groupID := CreateTestGroup(t, prefix)
+	ownerID := CreateTestUser(t, prefix+"_owner", "User")
+	CreateTestMembership(t, ownerID, groupID, "Member")
+	db.Exec("UPDATE users SET tnuserid = ? WHERE id = ?", 77703, ownerID)
+
+	msgID := CreateTestMessage(t, ownerID, groupID, prefix+" Offer", 55.9533, -3.1883)
+	tnpostid := fmt.Sprintf("tn-%d", msgID)
+	db.Exec("UPDATE messages SET tnpostid = ? WHERE id = ?", tnpostid, msgID)
+
+	key := insertTestPartnerKeyMsg(t, prefix, "tn.com")
+	defer db.Exec("DELETE FROM partners_keys WHERE partner = ?", prefix+"_partner")
+
+	body := map[string]interface{}{
+		"subject": "TN Updated Subject",
+	}
+	bodyBytes, _ := json.Marshal(body)
+	url := fmt.Sprintf("/api/message/tn/%s?partner=%s&tnuserid=77703&email=%s@tn.com", tnpostid, key, prefix+"_owner")
+	req := httptest.NewRequest("PATCH", url, bytes.NewBuffer(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := getApp().Test(req, -1)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var subject string
+	db.Raw("SELECT subject FROM messages WHERE id = ?", msgID).Scan(&subject)
+	assert.Equal(t, "TN Updated Subject", subject)
+}
+
+func TestPatchMessageByTnPostidNotFound(t *testing.T) {
+	prefix := uniquePrefix("msg_patchtn404")
+	db := database.DBConn
+
+	groupID := CreateTestGroup(t, prefix)
+	ownerID := CreateTestUser(t, prefix+"_owner", "User")
+	CreateTestMembership(t, ownerID, groupID, "Member")
+	db.Exec("UPDATE users SET tnuserid = ? WHERE id = ?", 77704, ownerID)
+
+	key := insertTestPartnerKeyMsg(t, prefix, "tn.com")
+	defer db.Exec("DELETE FROM partners_keys WHERE partner = ?", prefix+"_partner")
+
+	body := map[string]interface{}{
+		"subject": "Should Not Work",
+	}
+	bodyBytes, _ := json.Marshal(body)
+	url := fmt.Sprintf("/api/message/tn/nonexistent-tn-id?partner=%s&tnuserid=77704&email=%s@tn.com", key, prefix+"_owner")
+	req := httptest.NewRequest("PATCH", url, bytes.NewBuffer(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := getApp().Test(req, -1)
+	assert.NoError(t, err)
+	assert.Equal(t, 404, resp.StatusCode)
+}


### PR DESCRIPTION
## Summary

- **Partner key auth for actions**: `POST /message` (actions: Promise, Outcome, Renege, etc.) now accepts `?partner=KEY&tnuserid=N&email=user@domain.com` query params for partner authentication, using the same mechanism as `PATCH /message`. Previously these returned 401 when called with a partner key.
- **Resolve action target by TN post ID**: When `POST /message` is called with `tnpostid` in the body and no `id`, the Freegle message ID is looked up from `messages.tnpostid`. This lets TN send actions before it receives the Freegle message ID.
- **New endpoint `PATCH /message/tn/:tnpostid`**: Edits a message identified by its Trash Nothing post ID rather than the Freegle ID. Intended for cases where the post is held for moderation and TN doesn't yet have the Freegle ID. Uses the same edit logic as `PATCH /message` — no code duplication.
- **Shared helpers**: `patchMessageRequest` moved to package scope; `resolvePartnerAuth` and `applyPatchMessage` extracted so both `PatchMessage` and `PatchMessageByTN` share the logic.

## Code Quality Review

- `resolvePartnerAuth` and `applyPatchMessage` extracted to eliminate duplication between the two PATCH endpoints
- Partner auth in `PostMessage` is an exact structural copy of the pattern in `PatchMessage` — consistent across the API
- `PatchMessageByTN` returns 404 (not 400) when the TN post ID is unknown — correct HTTP semantics
- Route `/message/tn/:tnpostid` is registered before `/message/:ids` in the router so Fiber's path matching resolves it correctly

## Test Plan

- [x] `TestPostMessagePartnerAuthPromise` — partner key → Promise action succeeds
- [x] `TestPostMessagePartnerAuthByTnPostid` — tnpostid in body resolves to message ID, action succeeds
- [x] `TestPostMessagePartnerInvalidKey` — bad partner key → 403
- [x] `TestPatchMessageByTnPostid` — edit message by tnpostid via partner key → 200, subject updated
- [x] `TestPatchMessageByTnPostidNotFound` — unknown tnpostid → 404
- [x] All 2371 existing tests still pass