### PR TITLE
chore(ci): disable iznik-server PHPUnit tests and coverage

### DIFF
--- a/.circleci/orb/freegle-tests.yml
+++ b/.circleci/orb/freegle-tests.yml
@@ -1937,11 +1937,15 @@ jobs:
             SKIP_VITEST=false
             SKIP_PLAYWRIGHT=false
             SKIP_LARAVEL=false
+            # iznik-server (PHP/PHPUnit) tests are permanently disabled: the concern_keywords
+            # migration will break them and iznik-server is not being actively maintained.
+            SKIP_PHP=true
 
             echo "export SKIP_GO=$SKIP_GO" >> "$BASH_ENV"
             echo "export SKIP_VITEST=$SKIP_VITEST" >> "$BASH_ENV"
             echo "export SKIP_PLAYWRIGHT=$SKIP_PLAYWRIGHT" >> "$BASH_ENV"
             echo "export SKIP_LARAVEL=$SKIP_LARAVEL" >> "$BASH_ENV"
+            echo "export SKIP_PHP=$SKIP_PHP" >> "$BASH_ENV"
 
       - setup-dependencies
 
@@ -2121,9 +2125,17 @@ jobs:
             ) > ~/test-output/go.out 2>&1 &
             GO_PID=$!
 
-            # Start iznik-server tests in background (uses separate iznik_phpunit_test database)
-            echo "🧪 Starting iznik-server tests in background..."
+            # iznik-server (PHPUnit) tests are permanently skipped — see SKIP_PHP above.
+            echo "⏭️ Skipping iznik-server PHP tests (disabled — concern_keywords migration will break them)"
             (
+              if [ "${SKIP_PHP:-true}" = "true" ]; then
+                echo "Skipping iznik-server PHP tests (SKIP_PHP=true)"
+                echo "pass" > /tmp/php-result
+                echo "0" > /tmp/php-completed
+                echo "0" > /tmp/php-total
+                exit 0
+              fi
+
               # Restore GeoIP database from cache if available
               if [ -f ~/geoip-cache/GeoLite2-Country.mmdb ]; then
                 echo "📍 Restoring GeoIP database from cache..."
@@ -2665,13 +2677,13 @@ jobs:
             set +o pipefail
             echo "=== Overall Test Results ==="
 
-            # All tests (required)
-            if [ "$LARAVEL_TESTS_PASSED" = "true" ] && [ "$GO_TESTS_PASSED" = "true" ] && [ "$PHP_TESTS_PASSED" = "true" ] && [ "$PLAYWRIGHT_TESTS_PASSED" = "true" ]; then
+            # All tests (required) — iznik-server PHP tests excluded (disabled)
+            if [ "$LARAVEL_TESTS_PASSED" = "true" ] && [ "$GO_TESTS_PASSED" = "true" ] && [ "$PLAYWRIGHT_TESTS_PASSED" = "true" ]; then
               echo "✅ All tests passed successfully!"
               echo "ALL_TESTS_PASSED=true" >> $BASH_ENV
             else
               echo "❌ Tests failed"
-              echo "Laravel: $LARAVEL_TESTS_PASSED, Go: $GO_TESTS_PASSED, PHP: $PHP_TESTS_PASSED, Playwright: $PLAYWRIGHT_TESTS_PASSED"
+              echo "Laravel: $LARAVEL_TESTS_PASSED, Go: $GO_TESTS_PASSED, Playwright: $PLAYWRIGHT_TESTS_PASSED"
               echo ""
 
               # Extract and display failure details from test output files
@@ -2698,17 +2710,6 @@ jobs:
                 else
                   echo "(Showing last 50 lines of output)"
                   tail -50 ~/test-output/go.out
-                fi
-                echo ""
-              fi
-
-              if [ "$PHP_TESTS_PASSED" != "true" ] && [ -f ~/test-output/php.out ]; then
-                echo "=== PHP (iznik-server) Failure Details ==="
-                if grep -q "FAILURES\|There were .* failures" ~/test-output/php.out; then
-                  grep -A 100 "There were .* failures" ~/test-output/php.out | head -80
-                else
-                  echo "(Showing last 50 lines of output)"
-                  tail -50 ~/test-output/php.out
                 fi
                 echo ""
               fi


### PR DESCRIPTION
## Summary

- Permanently disables the `iznik-server` (PHPUnit) test suite in CI
- Sets `SKIP_PHP=true` in the "Determine changed paths" step — same pattern as the existing `SKIP_GO`/`SKIP_LARAVEL` flags
- Guards the iznik-server parallel-test block so it immediately writes `pass` and exits when `SKIP_PHP=true`
- Removes `PHP_TESTS_PASSED` from the "Evaluate overall test results" pass/fail condition
- Removes the PHP failure-detail block from the evaluate step output
- Orb published as `freegle/tests@1.1.242`

**Why:** The upcoming `concern_keywords` migration (merging `worrywords` and `spam_keywords` tables) will break the PHP classes that query those tables directly (`WorryWords.php`, `Spam.php`). Since `iznik-server` is not actively maintained, disabling its CI suite is cleaner than maintaining failing tests.

**Coverage:** PHP/PHPUnit coverage was already absent from the consolidated coverage upload steps in `build-and-test` — no change needed there.

## Test plan

- [ ] CI passes on this branch (iznik-server block reports ⏭️ Skipped immediately)
- [ ] Laravel, Go, Playwright, and Vitest tests still run normally
- [ ] `Evaluate overall test results` step passes without PHP_TESTS_PASSED check