### PR TITLE
test(compose): AssertFlip test — AI image excluded when user uploads own photo

### DIFF
--- a/iznik-nuxt3/stores/compose.js
+++ b/iznik-nuxt3/stores/compose.js
@@ -76,11 +76,15 @@ export const useComposeStore = defineStore({
 
       // Extract the server attachment id from message.attachments.
       if (message.attachments) {
+        const hasRealPhoto = message.attachments.some(
+          (a) => a.id && typeof a.id === 'number' && !(a.externalmods && a.externalmods.ai)
+        )
+
         for (const attachment of message.attachments) {
-          // AI illustrations need to be converted to real server-side attachments
+          // AI illustrations need to be converted to real server-side attachments,
+          // but are suppressed when the user has uploaded their own real photo.
           if (attachment.externalmods && attachment.externalmods.ai) {
-            // Create a real attachment from the AI illustration's external UID
-            if (attachment.ouruid) {
+            if (!hasRealPhoto && attachment.ouruid) {
               try {
                 const result = await this.$api.image.post({
                   externaluid: attachment.ouruid,

--- a/iznik-nuxt3/tests/unit/stores/compose.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/compose.spec.js
@@ -691,4 +691,79 @@ describe('compose store', () => {
       expect(store.noGroups).toBe(true)
     })
   })
+
+  // AssertFlip: reproduces bug where AI image is included in submission even when
+  // user has uploaded their own real photo. Step 1 asserts the BUGGY behaviour
+  // (both images submitted); Step 2 (below) inverts the assertion so the test
+  // fails on buggy code and will pass once the bug is fixed.
+  describe('AI image suppressed when user uploads own photo', () => {
+    // STEP 1 — documents the bug: both AI image and user photo survive to submit.
+    // This test PASSES on the current (buggy) code.
+    it('BUGGY: includes AI-generated image in submission even when user has uploaded their own real photo', async () => {
+      const store = useComposeStore()
+      store.init({ public: {} })
+      store.postcode = { id: 123 }
+      mockImagePost.mockResolvedValue({ id: 77 })
+      mockMessagePut.mockResolvedValue({ id: 99 })
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+      const errSpy = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {})
+
+      await store.createDraft(
+        {
+          type: 'Offer',
+          item: 'Old sofa',
+          attachments: [
+            { ouruid: 'ai-uid-abc', externalmods: { ai: true } },
+            { id: 5 },
+          ],
+        },
+        'user@example.com'
+      )
+
+      const callArgs = mockMessagePut.mock.calls[0][0]
+      // BUG: AI image (id 77) is present alongside user's real photo (id 5)
+      expect(callArgs.attachments).toContain(77)
+      expect(callArgs.attachments).toContain(5)
+      expect(callArgs.attachments).toHaveLength(2)
+
+      logSpy.mockRestore()
+      errSpy.mockRestore()
+    })
+
+    // STEP 2 — inverted assertion: AI image must NOT appear when user has a real photo.
+    // This test FAILS on the current (buggy) code and will PASS once the bug is fixed.
+    it('excludes AI-generated image from submission when user has uploaded their own real photo', async () => {
+      const store = useComposeStore()
+      store.init({ public: {} })
+      store.postcode = { id: 123 }
+      mockImagePost.mockResolvedValue({ id: 77 })
+      mockMessagePut.mockResolvedValue({ id: 99 })
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+      const errSpy = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {})
+
+      await store.createDraft(
+        {
+          type: 'Offer',
+          item: 'Old sofa',
+          attachments: [
+            { ouruid: 'ai-uid-abc', externalmods: { ai: true } },
+            { id: 5 },
+          ],
+        },
+        'user@example.com'
+      )
+
+      const callArgs = mockMessagePut.mock.calls[0][0]
+      // CORRECT: only the user's real photo; AI image must be absent
+      expect(callArgs.attachments).not.toContain(77)
+      expect(callArgs.attachments).toEqual([5])
+
+      logSpy.mockRestore()
+      errSpy.mockRestore()
+    })
+  })
 })

--- a/iznik-nuxt3/tests/unit/stores/compose.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/compose.spec.js
@@ -428,7 +428,7 @@ describe('compose store', () => {
       )
     })
 
-    it('handles AI illustration attachments', async () => {
+    it('handles AI illustration attachments when no real photo present', async () => {
       const store = useComposeStore()
       store.init({ public: {} })
       store.postcode = { id: 123 }
@@ -439,10 +439,7 @@ describe('compose store', () => {
         {
           type: 'Offer',
           item: 'Test',
-          attachments: [
-            { ouruid: 'abc123', externalmods: { ai: true } },
-            { id: 5 },
-          ],
+          attachments: [{ ouruid: 'abc123', externalmods: { ai: true } }],
         },
         'test@example.com'
       )
@@ -452,7 +449,7 @@ describe('compose store', () => {
         externalmods: { ai: true },
       })
       expect(mockMessagePut).toHaveBeenCalledWith(
-        expect.objectContaining({ attachments: [77, 5] })
+        expect.objectContaining({ attachments: [77] })
       )
     })
 
@@ -692,48 +689,7 @@ describe('compose store', () => {
     })
   })
 
-  // AssertFlip: reproduces bug where AI image is included in submission even when
-  // user has uploaded their own real photo. Step 1 asserts the BUGGY behaviour
-  // (both images submitted); Step 2 (below) inverts the assertion so the test
-  // fails on buggy code and will pass once the bug is fixed.
   describe('AI image suppressed when user uploads own photo', () => {
-    // STEP 1 — documents the bug: both AI image and user photo survive to submit.
-    // This test PASSES on the current (buggy) code.
-    it('BUGGY: includes AI-generated image in submission even when user has uploaded their own real photo', async () => {
-      const store = useComposeStore()
-      store.init({ public: {} })
-      store.postcode = { id: 123 }
-      mockImagePost.mockResolvedValue({ id: 77 })
-      mockMessagePut.mockResolvedValue({ id: 99 })
-      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-      const errSpy = vi
-        .spyOn(console, 'error')
-        .mockImplementation(() => {})
-
-      await store.createDraft(
-        {
-          type: 'Offer',
-          item: 'Old sofa',
-          attachments: [
-            { ouruid: 'ai-uid-abc', externalmods: { ai: true } },
-            { id: 5 },
-          ],
-        },
-        'user@example.com'
-      )
-
-      const callArgs = mockMessagePut.mock.calls[0][0]
-      // BUG: AI image (id 77) is present alongside user's real photo (id 5)
-      expect(callArgs.attachments).toContain(77)
-      expect(callArgs.attachments).toContain(5)
-      expect(callArgs.attachments).toHaveLength(2)
-
-      logSpy.mockRestore()
-      errSpy.mockRestore()
-    })
-
-    // STEP 2 — inverted assertion: AI image must NOT appear when user has a real photo.
-    // This test FAILS on the current (buggy) code and will PASS once the bug is fixed.
     it('excludes AI-generated image from submission when user has uploaded their own real photo', async () => {
       const store = useComposeStore()
       store.init({ public: {} })


### PR DESCRIPTION
## Root Cause
In the Nuxt3 compose/AI image flow, the AI-generated image is committed to the message's attachment list independently of whether the member has uploaded their own photo. When the member adds a real photo, the AI image is not removed, so both images end up attached on submit.

## Evidence
```
× compose store > AI image suppressed when user uploads own photo > excludes AI-generated image from submission when user has uploaded their own real photo
AssertionError: expected [ 77, 5 ] to not include 77
 ❯ tests/unit/stores/compose.spec.js:762:40
Test Files  1 failed (1) | Tests  1 failed | 64 passed (65)
```

## Fix
In `stores/compose.js → createDraft()`: compute `hasRealPhoto` before the attachment loop, then gate AI image upload behind `!hasRealPhoto`. When the user has a real photo, the AI illustration is skipped rather than uploaded and appended to `attids`.

Also updated `tests/unit/stores/compose.spec.js`:
- Renamed 'handles AI illustration attachments' → '...when no real photo present' and removed real photo from fixture.
- Removed the BUGGY documentation sentinel test.
- Kept 'excludes AI-generated image...' as the regression guard.

## Other Call Sites
`PhotoUploader.vue:447` already filters AI images from the UI photos array when a real photo is uploaded, but this is a UI-layer filter only. No other file builds the server-submission `attids` array — fix is in the only relevant call site.

## Test
File: iznik-nuxt3/tests/unit/stores/compose.spec.js
Command: cd /home/edward/FreegleDockerWSL/iznik-nuxt3 && npm run test:unit:run -- --reporter=verbose tests/unit/stores/compose.spec.js
TEST_PASSED=64 passed (64)
Regression suite: SUITE_PASSED=yes (574 files, 12177 tests)

## Discourse
https://discourse.ilovefreegle.org/t/9646