### PR TITLE
fix(modtools/related-members): clear stale entries before computing remainingPairs in fetchMembers

### DIFF
--- a/iznik-nuxt3/modtools/stores/member.js
+++ b/iznik-nuxt3/modtools/stores/member.js
@@ -112,6 +112,16 @@ export const useMemberStore = defineStore({
         received += members.length
 
         if (params.collection === 'Related') {
+          // Clear stale Related entries from a previous page visit before processing
+          // the current API response. Without this, remainingPairs is inflated by
+          // entries that were never cleared via store.clear() on navigation, causing
+          // the counter to stay stuck at 1 even when the server returns no pairs.
+          Object.keys(this.list).forEach((key) => {
+            if (this.list[key].collection === 'Related') {
+              delete this.list[key]
+            }
+          })
+
           // V2 API returns {id, user1, user2} pairs.  Store each pair keyed
           // by its id, and create synthetic member entries for each user so
           // that ModMember can look them up.

--- a/iznik-nuxt3/stores/compose.js
+++ b/iznik-nuxt3/stores/compose.js
@@ -76,11 +76,15 @@ export const useComposeStore = defineStore({
 
       // Extract the server attachment id from message.attachments.
       if (message.attachments) {
+        const hasRealPhoto = message.attachments.some(
+          (a) => a.id && typeof a.id === 'number' && !(a.externalmods && a.externalmods.ai)
+        )
+
         for (const attachment of message.attachments) {
-          // AI illustrations need to be converted to real server-side attachments
+          // AI illustrations need to be converted to real server-side attachments,
+          // but are suppressed when the user has uploaded their own real photo.
           if (attachment.externalmods && attachment.externalmods.ai) {
-            // Create a real attachment from the AI illustration's external UID
-            if (attachment.ouruid) {
+            if (!hasRealPhoto && attachment.ouruid) {
               try {
                 const result = await this.$api.image.post({
                   externaluid: attachment.ouruid,

--- a/iznik-nuxt3/tests/unit/stores/compose.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/compose.spec.js
@@ -428,7 +428,7 @@ describe('compose store', () => {
       )
     })
 
-    it('handles AI illustration attachments', async () => {
+    it('handles AI illustration attachments when no real photo present', async () => {
       const store = useComposeStore()
       store.init({ public: {} })
       store.postcode = { id: 123 }
@@ -439,10 +439,7 @@ describe('compose store', () => {
         {
           type: 'Offer',
           item: 'Test',
-          attachments: [
-            { ouruid: 'abc123', externalmods: { ai: true } },
-            { id: 5 },
-          ],
+          attachments: [{ ouruid: 'abc123', externalmods: { ai: true } }],
         },
         'test@example.com'
       )
@@ -452,7 +449,7 @@ describe('compose store', () => {
         externalmods: { ai: true },
       })
       expect(mockMessagePut).toHaveBeenCalledWith(
-        expect.objectContaining({ attachments: [77, 5] })
+        expect.objectContaining({ attachments: [77] })
       )
     })
 
@@ -689,6 +686,40 @@ describe('compose store', () => {
     it('returns true when no postcode', () => {
       const store = useComposeStore()
       expect(store.noGroups).toBe(true)
+    })
+  })
+
+  describe('AI image suppressed when user uploads own photo', () => {
+    it('excludes AI-generated image from submission when user has uploaded their own real photo', async () => {
+      const store = useComposeStore()
+      store.init({ public: {} })
+      store.postcode = { id: 123 }
+      mockImagePost.mockResolvedValue({ id: 77 })
+      mockMessagePut.mockResolvedValue({ id: 99 })
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+      const errSpy = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {})
+
+      await store.createDraft(
+        {
+          type: 'Offer',
+          item: 'Old sofa',
+          attachments: [
+            { ouruid: 'ai-uid-abc', externalmods: { ai: true } },
+            { id: 5 },
+          ],
+        },
+        'user@example.com'
+      )
+
+      const callArgs = mockMessagePut.mock.calls[0][0]
+      // CORRECT: only the user's real photo; AI image must be absent
+      expect(callArgs.attachments).not.toContain(77)
+      expect(callArgs.attachments).toEqual([5])
+
+      logSpy.mockRestore()
+      errSpy.mockRestore()
     })
   })
 })

--- a/iznik-nuxt3/tests/unit/stores/member.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/member.spec.js
@@ -160,6 +160,58 @@ describe('member store', () => {
     })
   })
 
+  describe('fetchMembers — stale-entry counter bug (regression #9631 posts 19-20)', () => {
+    // Bug confirmed still spreading (Susan post 20) after PR #369 was closed without merging.
+    // The existing fix (commit 2604e75) resets relatedmembers when remainingPairs === 0, but
+    // it computes remainingPairs from this.list, which is never cleared between page navigations.
+    // Any stale Related pair entry left over from a previous visit makes remainingPairs > 0,
+    // preventing the reset — so the nav badge stays stuck at 1 even though the server returned
+    // no actionable pairs.
+
+    it('counter resets to 0 when API returns empty — even with stale Related pair in store', async () => {
+      // Simulate: user visited Related page, pair was fetched, user navigated away without
+      // store.clear() being called.  Server auto-resolved the pair, so the next visit returns [].
+      // Bug: remainingPairs = 1 (stale entry) → reset does NOT fire → counter stuck at 1.
+      mockFetchMembers.mockResolvedValue({ members: [], context: null, ratings: [] })
+      mockAuthWork.relatedmembers = 1
+
+      const store = useMemberStore()
+      store.config = {}
+      store.list[10] = { id: 10, user1: 100, user2: 200, collection: 'Related' }
+
+      await store.fetchMembers({ collection: 'Related', groupid: 0 })
+
+      expect(mockAuthWork.relatedmembers).toBe(0)
+    })
+
+    it('non-synthetic Related member entry is not double-counted in the pair tally (N pairs → count equals N)', async () => {
+      // When the store holds a stale Related pair from a previous page visit alongside N
+      // newly-returned pairs, remainingPairs = N + stale.  For N=1 this means the stale entry
+      // inflates the tally to 2.  The tally should equal the number of pairs the API actually
+      // returned (1), not the accumulated total across navigations.
+      mockFetchMembers.mockResolvedValue({
+        members: [{ id: 10, user1: 100, user2: 200 }],
+        context: null,
+        ratings: [],
+      })
+      mockAuthWork.relatedmembers = 1
+
+      const store = useMemberStore()
+      store.config = {}
+      // Stale pair 99 (processed on a previous visit; store was not cleared on navigation).
+      store.list[99] = { id: 99, user1: 500, user2: 600, collection: 'Related' }
+
+      await store.fetchMembers({ collection: 'Related', groupid: 0 })
+
+      // After fetchMembers the store should hold exactly N=1 non-synthetic Related pair.
+      // Bug: remainingPairs = 2 (stale pair 99 + new pair 10) → count is off by one.
+      const pairCount = Object.values(store.list).filter(
+        (m) => m.collection === 'Related' && !m._syntheticRelated
+      ).length
+      expect(pairCount).toBe(1)
+    })
+  })
+
   describe('fetchMembers - pagination context', () => {
     it('stores the integer context returned by the API', async () => {
       mockFetchMembers.mockResolvedValue({


### PR DESCRIPTION
## Root cause
In iznik-nuxt3/modtools/stores/member.js, fetchMembers computes remainingPairs from this.list without clearing stale entries first. Any Related pair from a previous page visit (store never gets clear() called between navigations) makes remainingPairs > 0, so the reset to 0 never fires even when the server returns no actionable pairs. Stale entries also inflate the pairCount tally so N pairs appear as N+1.

## Fix
At the start of the `params.collection === 'Related'` branch in `fetchMembers`, all existing entries where `collection === 'Related'` are deleted from `this.list` before processing the new API response. This covers both real pair entries and synthetic member entries from prior visits. After the clear, `remainingPairs` reflects only what the API just returned, so the counter resets correctly to 0 when the server returns no pairs.

A second commit on this branch also fixes a related bug in `stores/compose.js` where an AI-generated illustration was included in the draft submission even when the user had uploaded their own real photo. The fix checks for the presence of a real photo before uploading the AI image; if a real photo exists, the AI image is suppressed.

## Test
iznik-nuxt3/tests/unit/stores/member.spec.js — `cd /home/edward/FreegleDockerWSL/iznik-nuxt3 && npx vitest run --reporter=verbose tests/unit/stores/member.spec.js`

Two new tests were added under `fetchMembers — stale-entry counter bug (regression #9631 posts 19-20)`:
- `counter resets to 0 when API returns empty — even with stale Related pair in store`
- `non-synthetic Related member entry is not double-counted in the pair tally (N pairs → count equals N)`

Both tests confirmed failing before the fix and passing after. Full vitest suite (574 files, 12177 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)