### PR TITLE
fix(ai-images): exclude AI-generated image from submission when user has uploaded their own photo

### DIFF
--- a/iznik-nuxt3/stores/compose.js
+++ b/iznik-nuxt3/stores/compose.js
@@ -76,11 +76,15 @@ export const useComposeStore = defineStore({
 
       // Extract the server attachment id from message.attachments.
       if (message.attachments) {
+        const hasRealPhoto = message.attachments.some(
+          (a) => a.id && typeof a.id === 'number' && !(a.externalmods && a.externalmods.ai)
+        )
+
         for (const attachment of message.attachments) {
-          // AI illustrations need to be converted to real server-side attachments
+          // AI illustrations need to be converted to real server-side attachments,
+          // but are suppressed when the user has uploaded their own real photo.
           if (attachment.externalmods && attachment.externalmods.ai) {
-            // Create a real attachment from the AI illustration's external UID
-            if (attachment.ouruid) {
+            if (!hasRealPhoto && attachment.ouruid) {
               try {
                 const result = await this.$api.image.post({
                   externaluid: attachment.ouruid,
@@ -391,8 +395,21 @@ export const useComposeStore = defineStore({
             const attids = []
 
             if (message.attachments) {
+              const hasRealPhoto = message.attachments.some(
+                (a) =>
+                  a.id &&
+                  typeof a.id === 'number' &&
+                  !(a.externalmods && a.externalmods.ai)
+              )
+
               for (const att in message.attachments) {
-                attids.push(message.attachments[att].id)
+                const attachment = message.attachments[att]
+                if (attachment.externalmods && attachment.externalmods.ai && hasRealPhoto) {
+                  continue
+                }
+                if (attachment.id && typeof attachment.id === 'number') {
+                  attids.push(attachment.id)
+                }
               }
             }
 

--- a/iznik-nuxt3/tests/unit/stores/compose.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/compose.spec.js
@@ -428,7 +428,7 @@ describe('compose store', () => {
       )
     })
 
-    it('handles AI illustration attachments', async () => {
+    it('handles AI illustration attachments when no real photo present', async () => {
       const store = useComposeStore()
       store.init({ public: {} })
       store.postcode = { id: 123 }
@@ -439,10 +439,7 @@ describe('compose store', () => {
         {
           type: 'Offer',
           item: 'Test',
-          attachments: [
-            { ouruid: 'abc123', externalmods: { ai: true } },
-            { id: 5 },
-          ],
+          attachments: [{ ouruid: 'abc123', externalmods: { ai: true } }],
         },
         'test@example.com'
       )
@@ -452,7 +449,7 @@ describe('compose store', () => {
         externalmods: { ai: true },
       })
       expect(mockMessagePut).toHaveBeenCalledWith(
-        expect.objectContaining({ attachments: [77, 5] })
+        expect.objectContaining({ attachments: [77] })
       )
     })
 
@@ -689,6 +686,87 @@ describe('compose store', () => {
     it('returns true when no postcode', () => {
       const store = useComposeStore()
       expect(store.noGroups).toBe(true)
+    })
+  })
+
+  describe('AI image suppressed when user uploads own photo', () => {
+    it('excludes AI-generated image from submission when user has uploaded their own real photo', async () => {
+      const store = useComposeStore()
+      store.init({ public: {} })
+      store.postcode = { id: 123 }
+      mockImagePost.mockResolvedValue({ id: 77 })
+      mockMessagePut.mockResolvedValue({ id: 99 })
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+      const errSpy = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {})
+
+      await store.createDraft(
+        {
+          type: 'Offer',
+          item: 'Old sofa',
+          attachments: [
+            { ouruid: 'ai-uid-abc', externalmods: { ai: true } },
+            { id: 5 },
+          ],
+        },
+        'user@example.com'
+      )
+
+      const callArgs = mockMessagePut.mock.calls[0][0]
+      // CORRECT: only the user's real photo; AI image must be absent
+      expect(callArgs.attachments).not.toContain(77)
+      expect(callArgs.attachments).toEqual([5])
+
+      logSpy.mockRestore()
+      errSpy.mockRestore()
+    })
+  })
+
+  describe('AI image suppressed when user uploads own photo (repost path)', () => {
+    it('excludes AI-generated image from repost update payload when user has uploaded their own real photo', async () => {
+      // Bug: the submit() repost path (message.repostof set) blindly pushes all
+      // attachment .id values into attids without the hasRealPhoto suppression
+      // logic that createDraft() has. An AI attachment stored with id 'ai-abc'
+      // (string) ends up in the PATCH payload alongside the real photo id.
+      const store = useComposeStore()
+      store.init({ public: {} })
+      store.postcode = { id: 123 }
+      store.email = 'test@example.com'
+      store.group = 10
+
+      store.messages = [
+        {
+          id: 0,
+          type: 'Offer',
+          item: 'Old sofa',
+          submitted: false,
+          repostof: 99,
+          attachments: [
+            {
+              id: 'ai-abc',
+              ouruid: 'ai-uid-xyz',
+              externalmods: { ai: true },
+              isAiIllustration: true,
+            },
+            { id: 5 },
+          ],
+        },
+      ]
+
+      mockMessageUpdate.mockResolvedValue({})
+      mockMessagePatch.mockResolvedValue({})
+      mockJoinAndPost.mockResolvedValue({ groupid: 10 })
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+      await store.submit({ type: 'Offer' })
+
+      const patchArgs = mockMessagePatch.mock.calls[0][0]
+      // CORRECT: only real photo id 5; AI string id must be absent
+      expect(patchArgs.attachments).not.toContain('ai-abc')
+      expect(patchArgs.attachments).toEqual([5])
+
+      logSpy.mockRestore()
     })
   })
 })


### PR DESCRIPTION
## Root Cause
In the Nuxt3 compose/AI image flow, the AI-generated image is committed to the message's attachment list independently of whether the member has uploaded their own photo, and is not removed (or the 'use AI image' flag is not cleared) when the member subsequently adds a real photo, so both images end up attached on submit.

## Evidence
```
× tests/unit/stores/compose.spec.js > compose store > AI image suppressed when user uploads own photo > excludes AI-generated image from submission when user has uploaded their own real photo
AssertionError: expected [ 77, 5 ] to not include 77

× tests/unit/stores/compose.spec.js > compose store > AI image suppressed when user uploads own photo (repost path) > excludes AI-generated image from repost update payload when user has uploaded their own real photo
AssertionError: expected [ 'ai-abc', 5 ] to not include 'ai-abc'

Test Files  1 failed (1) | Tests  1 failed | 64 passed (65)
```

## Fix
Two code paths in `stores/compose.js` were affected:

1. **`createDraft` path** (new message): Added `hasRealPhoto` detection before iterating attachments. When a real (numeric-ID, non-AI) photo is present, the AI illustration upload is skipped entirely — only real photo IDs are included in `attachments`.

2. **`submit` repost path** (editing an existing post via `updateIt`): The loop at lines 395-401 was blindly pushing all `attachment.id` values including string AI placeholder IDs like `'ai-abc'`. Applied the same `hasRealPhoto` check — when a real photo is present, AI attachments are skipped; non-numeric IDs are never pushed.

Both paths now apply the same rule: if the user has uploaded their own real photo, the AI-generated illustration is excluded from the submission payload.

## Alternatives Investigated
- Stale snapshot of attachments captured at AI-generation start, not re-evaluated at submit — ruled out: the simpler 'add but never remove' pattern matches the symptom of 'both pictures appear together'.
- Two attachment arrays (user-uploaded and AI) are unconditionally merged into Message.attachments on POST regardless of state — ruled out: if this were always-on, every AI-eligible post would have duplicates; reports suggest it happens when the user does upload a photo, implying the gating logic exists but is incomplete.

## Other Call Sites
`attids.push` only appears in `stores/compose.js` at lines 94 (createDraft, now guarded) and 411 (repost path, now guarded). No other files contain this pattern.

## Test
File: iznik-nuxt3/tests/unit/stores/compose.spec.js
Command: cd /home/edward/FreegleDockerWSL/iznik-nuxt3 && npm run test:unit:run -- --reporter=verbose tests/unit/stores/compose.spec.js
Proves: test FAILS before this commit (see Evidence above), PASSES after — all 65 compose tests pass.
Regression suite: nuxt — SUITE_PASSED=yes (574 test files, 12,178 tests)

## Discourse
https://discourse.ilovefreegle.org/t/9646