### PR TITLE
fix(compose): block submit when message is empty skeleton on all 4 wizard pages

### DIFF
--- a/iznik-nuxt3/composables/useCompose.js
+++ b/iznik-nuxt3/composables/useCompose.js
@@ -226,6 +226,30 @@ export function setup(type) {
   }
 }
 
+// makeCanSubmit returns a computed that gates the submit button on message validity.
+// Pass the page's own refs so it can be tested without mounting the full component.
+// requirePostcode adds the whereami-style postcode/group checks.
+export function makeCanSubmit({
+  messageValid,
+  loggedIn,
+  emailValid,
+  emailBelongsToSomeoneElse,
+  postcodeValid,
+  closed,
+  noGroups,
+  requirePostcode = false,
+}) {
+  return computed(() => {
+    if (!messageValid.value) return false
+    if (requirePostcode) {
+      if (!postcodeValid.value || closed.value || noGroups.value) return false
+    }
+    if (loggedIn.value) return true
+    if (!emailValid) return false
+    return emailValid.value && !emailBelongsToSomeoneElse.value
+  })
+}
+
 export async function deleteItem(id) {
   const composeStore = useComposeStore()
 

--- a/iznik-nuxt3/pages/find/mobile/whereami.vue
+++ b/iznik-nuxt3/pages/find/mobile/whereami.vue
@@ -124,6 +124,7 @@ import {
   postcodeSelect,
   postcodeClear,
   freegleIt,
+  makeCanSubmit,
 } from '~/composables/useCompose'
 
 const router = useRouter()
@@ -145,6 +146,7 @@ const emailBelongsToSomeoneElse = ref(false)
 // Get setup data from composable
 const {
   initialPostcode,
+  messageValid,
   postcodeValid,
   noGroups,
   closed,
@@ -156,15 +158,15 @@ const {
   wentWrong,
 } = await setup('Wanted')
 
-// Can submit if postcode is valid, group not closed, no group issues, and either logged in or email is valid
-const canSubmit = computed(() => {
-  if (!postcodeValid.value || closed.value || noGroups.value) {
-    return false
-  }
-  if (loggedIn.value) {
-    return true
-  }
-  return emailValid.value && !emailBelongsToSomeoneElse.value
+const canSubmit = makeCanSubmit({
+  messageValid,
+  loggedIn,
+  emailValid,
+  emailBelongsToSomeoneElse,
+  postcodeValid,
+  closed,
+  noGroups,
+  requirePostcode: true,
 })
 
 // Reset email belongs to someone else flag when email changes

--- a/iznik-nuxt3/pages/find/whoami.vue
+++ b/iznik-nuxt3/pages/find/whoami.vue
@@ -114,7 +114,7 @@ import PostLoggedInEmail from '~/components/PostLoggedInEmail.vue'
 import { useComposeStore } from '~/stores/compose'
 import { useUserStore } from '~/stores/user'
 import { useAuthStore } from '~/stores/auth'
-import { setup, freegleIt } from '~/composables/useCompose'
+import { setup, freegleIt, makeCanSubmit } from '~/composables/useCompose'
 import { buildHead } from '~/composables/useBuildHead'
 import { useMe } from '~/composables/useMe'
 
@@ -144,6 +144,7 @@ const emailBelongsToSomeoneElse = ref(false)
 
 // Get setup data from composable
 const {
+  messageValid,
   loggedIn,
   emailIsntOurs,
   submitting,
@@ -152,12 +153,11 @@ const {
   wentWrong,
 } = await setup('Wanted')
 
-// Can submit if logged in, or email is valid and not belonging to someone else
-const canSubmit = computed(() => {
-  if (loggedIn.value) {
-    return true
-  }
-  return emailValid.value && !emailBelongsToSomeoneElse.value
+const canSubmit = makeCanSubmit({
+  messageValid,
+  loggedIn,
+  emailValid,
+  emailBelongsToSomeoneElse,
 })
 
 // Reset email belongs to someone else flag when email changes

--- a/iznik-nuxt3/pages/give/mobile/whereami.vue
+++ b/iznik-nuxt3/pages/give/mobile/whereami.vue
@@ -124,6 +124,7 @@ import {
   postcodeSelect,
   postcodeClear,
   freegleIt,
+  makeCanSubmit,
 } from '~/composables/useCompose'
 
 const router = useRouter()
@@ -145,6 +146,7 @@ const emailBelongsToSomeoneElse = ref(false)
 // Get setup data from composable
 const {
   initialPostcode,
+  messageValid,
   postcodeValid,
   noGroups,
   closed,
@@ -156,15 +158,15 @@ const {
   wentWrong,
 } = await setup('Offer')
 
-// Can submit if postcode is valid, group not closed, no group issues, and either logged in or email is valid
-const canSubmit = computed(() => {
-  if (!postcodeValid.value || closed.value || noGroups.value) {
-    return false
-  }
-  if (loggedIn.value) {
-    return true
-  }
-  return emailValid.value && !emailBelongsToSomeoneElse.value
+const canSubmit = makeCanSubmit({
+  messageValid,
+  loggedIn,
+  emailValid,
+  emailBelongsToSomeoneElse,
+  postcodeValid,
+  closed,
+  noGroups,
+  requirePostcode: true,
 })
 
 // Reset email belongs to someone else flag when email changes

--- a/iznik-nuxt3/pages/give/whoami.vue
+++ b/iznik-nuxt3/pages/give/whoami.vue
@@ -127,7 +127,7 @@ import PostLoggedInEmail from '~/components/PostLoggedInEmail.vue'
 import { useComposeStore } from '~/stores/compose'
 import { useUserStore } from '~/stores/user'
 import { useAuthStore } from '~/stores/auth'
-import { setup, freegleIt } from '~/composables/useCompose'
+import { setup, freegleIt, makeCanSubmit } from '~/composables/useCompose'
 import { buildHead } from '~/composables/useBuildHead'
 import { useMe } from '~/composables/useMe'
 
@@ -167,12 +167,11 @@ const {
   wentWrong,
 } = await setup('Offer')
 
-// Can submit if logged in, or email is valid and not belonging to someone else
-const canSubmit = computed(() => {
-  if (loggedIn.value) {
-    return true
-  }
-  return emailValid.value && !emailBelongsToSomeoneElse.value
+const canSubmit = makeCanSubmit({
+  messageValid,
+  loggedIn,
+  emailValid,
+  emailBelongsToSomeoneElse,
 })
 
 // Reset email belongs to someone else flag when email changes

--- a/iznik-nuxt3/tests/unit/composables/useCompose.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useCompose.spec.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { postcodeSelect } from '~/composables/useCompose.js'
+import { ref } from 'vue'
+import { postcodeSelect, makeCanSubmit } from '~/composables/useCompose.js'
 
 let mockGroup = null
 let mockPostcode = null
@@ -91,5 +92,143 @@ describe('postcodeSelect', () => {
     postcodeSelect(pc)
     expect(mockSetPostcode).not.toHaveBeenCalled()
     expect(mockGroup).toBe(55)
+  })
+})
+
+describe('makeCanSubmit', () => {
+  const makeRefs = (overrides = {}) => ({
+    messageValid: ref(true),
+    loggedIn: ref(false),
+    emailValid: ref(false),
+    emailBelongsToSomeoneElse: ref(false),
+    postcodeValid: ref(null),
+    closed: ref(false),
+    noGroups: ref(false),
+    requirePostcode: false,
+    ...overrides,
+  })
+
+  // ── whoami-style (no postcode requirement) ──────────────────────────────
+
+  it('returns false when logged in but message is empty skeleton (the core bug)', () => {
+    const refs = makeRefs({ loggedIn: ref(true), messageValid: ref(false) })
+    const canSubmit = makeCanSubmit(refs)
+    expect(canSubmit.value).toBe(false)
+  })
+
+  it('returns true when logged in and message is valid', () => {
+    const refs = makeRefs({ loggedIn: ref(true), messageValid: ref(true) })
+    const canSubmit = makeCanSubmit(refs)
+    expect(canSubmit.value).toBe(true)
+  })
+
+  it('returns true when logged out, email valid, not belonging to someone else, and message valid', () => {
+    const refs = makeRefs({
+      loggedIn: ref(false),
+      emailValid: ref(true),
+      emailBelongsToSomeoneElse: ref(false),
+      messageValid: ref(true),
+    })
+    const canSubmit = makeCanSubmit(refs)
+    expect(canSubmit.value).toBe(true)
+  })
+
+  it('returns false when logged out and email belongs to someone else', () => {
+    const refs = makeRefs({
+      loggedIn: ref(false),
+      emailValid: ref(true),
+      emailBelongsToSomeoneElse: ref(true),
+      messageValid: ref(true),
+    })
+    const canSubmit = makeCanSubmit(refs)
+    expect(canSubmit.value).toBe(false)
+  })
+
+  it('returns false when logged out and email is invalid', () => {
+    const refs = makeRefs({
+      loggedIn: ref(false),
+      emailValid: ref(false),
+      messageValid: ref(true),
+    })
+    const canSubmit = makeCanSubmit(refs)
+    expect(canSubmit.value).toBe(false)
+  })
+
+  it('returns false when logged out, valid email, but message is empty', () => {
+    const refs = makeRefs({
+      loggedIn: ref(false),
+      emailValid: ref(true),
+      messageValid: ref(false),
+    })
+    const canSubmit = makeCanSubmit(refs)
+    expect(canSubmit.value).toBe(false)
+  })
+
+  // ── whereami-style (requirePostcode: true) ──────────────────────────────
+
+  it('returns false when postcode required but missing, even with valid message and login', () => {
+    const refs = makeRefs({
+      loggedIn: ref(true),
+      messageValid: ref(true),
+      postcodeValid: ref(null),
+      requirePostcode: true,
+    })
+    const canSubmit = makeCanSubmit(refs)
+    expect(canSubmit.value).toBe(false)
+  })
+
+  it('returns false when group is closed, even with valid postcode, message and login', () => {
+    const refs = makeRefs({
+      loggedIn: ref(true),
+      messageValid: ref(true),
+      postcodeValid: ref('SW1A 1AA'),
+      closed: ref(true),
+      requirePostcode: true,
+    })
+    const canSubmit = makeCanSubmit(refs)
+    expect(canSubmit.value).toBe(false)
+  })
+
+  it('returns false when no groups nearby, even with valid postcode, message and login', () => {
+    const refs = makeRefs({
+      loggedIn: ref(true),
+      messageValid: ref(true),
+      postcodeValid: ref('SW1A 1AA'),
+      noGroups: ref(true),
+      requirePostcode: true,
+    })
+    const canSubmit = makeCanSubmit(refs)
+    expect(canSubmit.value).toBe(false)
+  })
+
+  it('returns true when postcode required, postcode valid, logged in, message valid', () => {
+    const refs = makeRefs({
+      loggedIn: ref(true),
+      messageValid: ref(true),
+      postcodeValid: ref('SW1A 1AA'),
+      requirePostcode: true,
+    })
+    const canSubmit = makeCanSubmit(refs)
+    expect(canSubmit.value).toBe(true)
+  })
+
+  it('returns false when logged in but skeleton message with postcode requirement', () => {
+    const refs = makeRefs({
+      loggedIn: ref(true),
+      messageValid: ref(false),
+      postcodeValid: ref('SW1A 1AA'),
+      requirePostcode: true,
+    })
+    const canSubmit = makeCanSubmit(refs)
+    expect(canSubmit.value).toBe(false)
+  })
+
+  it('is reactive — updates when messageValid changes', () => {
+    const messageValid = ref(false)
+    const refs = makeRefs({ loggedIn: ref(true), messageValid })
+    const canSubmit = makeCanSubmit(refs)
+    expect(canSubmit.value).toBe(false)
+    messageValid.value = true
+    expect(canSubmit.value).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary

- User 42537414 fired 7 empty `PUT /message` + `POST JoinAndPost` cycles in 2.5 minutes because the client never stopped them: after `clearMessages()` each page re-seeds an empty skeleton `{type:'Offer'}`, but the four "Freegle it!" submit buttons only checked login/email/postcode state — `messageValid` was imported in `give/whoami.vue` but never wired into `canSubmit` anywhere
- Adds `makeCanSubmit()` to `useCompose.js`: a pure function over refs, easy to unit test, covering both whoami-style (no postcode) and whereami-style (postcode + group required) pages
- All four pages now use `makeCanSubmit()`: a logged-in user with an empty skeleton can no longer submit

**Pages fixed:**
- `pages/give/whoami.vue`
- `pages/find/whoami.vue` (also needed `messageValid` added to setup destructuring)
- `pages/give/mobile/whereami.vue` (same)
- `pages/find/mobile/whereami.vue` (same)

## Code Quality Review

- `makeCanSubmit` accepts all inputs as explicit refs → no hidden module-level state, fully deterministic
- The `requirePostcode` flag unifies whoami and whereami logic without duplication
- Removing 4 inline `canSubmit` computed blocks eliminates ~12 lines of near-identical duplicated logic
- No changes to templates or store; purely wiring an already-computed value into the guard

## Test Plan

- 12 new unit tests in `tests/unit/composables/useCompose.spec.js` covering:
  - logged in + empty skeleton → false (the core bug)
  - logged in + valid message → true
  - logged out + valid email + valid message → true
  - logged out + email belongs to someone else → false
  - logged out + invalid email → false
  - logged out + valid email + empty message → false
  - requirePostcode: missing postcode → false
  - requirePostcode: group closed → false
  - requirePostcode: no groups → false
  - requirePostcode: all valid → true
  - requirePostcode: valid postcode but empty message → false
  - reactivity: messageValid changing from false → true updates canSubmit
- Full Vitest suite: 12213/12213 pass

This is the client-side half of the fix; the server-side validation (reject empty `item` in `PUT /message`) is in PR #384.