### PR TITLE
feat(batch): migrate 15 V1 cron scripts to Laravel; enable 23 batch jobs

### DIFF
--- a/.circleci/orb/freegle-tests.yml
+++ b/.circleci/orb/freegle-tests.yml
@@ -1847,6 +1847,8 @@ jobs:
             checkout_code() {
               if [ -d .git ]; then
                 git fetch --prune origin
+                git reset --hard HEAD
+                git clean -fd
                 git checkout -B "$CIRCLE_BRANCH" "origin/$CIRCLE_BRANCH"
               else
                 # git clone fails when the directory isn't empty (leftover files from

--- a/iznik-batch/MIGRATION-STATUS.md
+++ b/iznik-batch/MIGRATION-STATUS.md
@@ -169,7 +169,7 @@ These have code implemented but the scheduler entry is commented out in `routes/
 |-----------------|-----------------|-------------------|-------|
 | `digest.php` | `mail:digest` | - | Message digests (per-group, legacy) |
 | `digest.php` | `mail:digest:unified` | UnifiedDigest | Unified Freegle digests (user-centric) |
-| `user_askdonation.php` | `mail:donations:ask` | - | Donation ask emails (V1: daily at 17:00, checks 7-day interval) |
+| `donations_email.php` | `mail:donations:ask` | - | Donation reminders |
 | `donations_thank.php` | `mail:donations:thank` | - | Donation thank-you emails |
 | `bounce.php` + `bounce_users.php` | `mail:bounced` | - | Bounced email handling + user suspension (PR #390) |
 | `messages_expired.php` | `messages:process-expired` | - | Deadline expiry handling |
@@ -179,7 +179,7 @@ These have code implemented but the scheduler entry is commented out in `routes/
 | `purge_messages.php` | `purge:messages` | - | Message purging |
 | `purge_chats.php` | `purge:chats` | - | Chat purging |
 | `users_kudos.php` | `users:update-kudos` | - | User kudos |
-| `users_retention.php` | `users:cleanup` | - | GDPR forgets + hard deletes (combines V1 userRetention() + processForgets()) |
+| `users_retention.php` | `users:retention-stats` | - | User retention stats |
 | `membercounts.php` | `groups:update-counts` | - | Group member/mod counts |
 | `chat_latestmessage.php` | `chats:update-counts` | - | Chat message counts + reopen closed User2Mod |
 | `lastaccess.php` | `users:update-lastaccess` | - | Fallback lastaccess update |
@@ -303,7 +303,7 @@ These original scripts need to be migrated to Laravel artisan commands:
 | `nearby.php` | 14:05 | Medium | Nearby items |
 | `chat_review.php` | 11:00 | Medium | Chat review queue |
 | `engage.php` | 16:00 | Medium | User engagement emails |
-| ~~`user_askdonation.php`~~ | ~~17:00~~ | ~~Medium~~ | ~~Donation requests~~ — **Migrated: `mail:donations:ask`** |
+| `user_askdonation.php` | 17:00 | Medium | Donation requests |
 | `facebook_chaseup.php` | 18:00 | Low | Facebook chase-up |
 | `whatjobs.php` | Hourly 08:00-22:00 | Low | WhatJobs |
 | `microactions_score.php` | 23:00 | Low | Microactions scoring |

--- a/iznik-batch/MIGRATION-STATUS.md
+++ b/iznik-batch/MIGRATION-STATUS.md
@@ -169,7 +169,7 @@ These have code implemented but the scheduler entry is commented out in `routes/
 |-----------------|-----------------|-------------------|-------|
 | `digest.php` | `mail:digest` | - | Message digests (per-group, legacy) |
 | `digest.php` | `mail:digest:unified` | UnifiedDigest | Unified Freegle digests (user-centric) |
-| `donations_email.php` | `mail:donations:ask` | - | Donation reminders |
+| `user_askdonation.php` | `mail:donations:ask` | - | Donation ask emails (V1: daily at 17:00, checks 7-day interval) |
 | `donations_thank.php` | `mail:donations:thank` | - | Donation thank-you emails |
 | `bounce.php` + `bounce_users.php` | `mail:bounced` | - | Bounced email handling + user suspension (PR #390) |
 | `messages_expired.php` | `messages:process-expired` | - | Deadline expiry handling |
@@ -179,7 +179,7 @@ These have code implemented but the scheduler entry is commented out in `routes/
 | `purge_messages.php` | `purge:messages` | - | Message purging |
 | `purge_chats.php` | `purge:chats` | - | Chat purging |
 | `users_kudos.php` | `users:update-kudos` | - | User kudos |
-| `users_retention.php` | `users:retention-stats` | - | User retention stats |
+| `users_retention.php` | `users:cleanup` | - | GDPR forgets + hard deletes (combines V1 userRetention() + processForgets()) |
 | `membercounts.php` | `groups:update-counts` | - | Group member/mod counts |
 | `chat_latestmessage.php` | `chats:update-counts` | - | Chat message counts + reopen closed User2Mod |
 | `lastaccess.php` | `users:update-lastaccess` | - | Fallback lastaccess update |
@@ -303,7 +303,7 @@ These original scripts need to be migrated to Laravel artisan commands:
 | `nearby.php` | 14:05 | Medium | Nearby items |
 | `chat_review.php` | 11:00 | Medium | Chat review queue |
 | `engage.php` | 16:00 | Medium | User engagement emails |
-| `user_askdonation.php` | 17:00 | Medium | Donation requests |
+| ~~`user_askdonation.php`~~ | ~~17:00~~ | ~~Medium~~ | ~~Donation requests~~ — **Migrated: `mail:donations:ask`** |
 | `facebook_chaseup.php` | 18:00 | Low | Facebook chase-up |
 | `whatjobs.php` | Hourly 08:00-22:00 | Low | WhatJobs |
 | `microactions_score.php` | 23:00 | Low | Microactions scoring |

--- a/iznik-batch/app/Console/Commands/AI/MicroVolunteeringScoreCommand.php
+++ b/iznik-batch/app/Console/Commands/AI/MicroVolunteeringScoreCommand.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Console\Commands\AI;
+
+use App\Services\MicroVolunteeringScoreService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+
+class MicroVolunteeringScoreCommand extends Command
+{
+    protected $signature = 'microvolunteering:score';
+
+    protected $description = 'Score microvolunteering actions and promote accurate users';
+
+    public function handle(MicroVolunteeringScoreService $service): int
+    {
+        Log::info('Starting microvolunteering score and promote');
+
+        $result = $service->scoreAndPromote();
+
+        $this->info("Promoted {$result['promoted']} users to Moderate trust level.");
+        Log::info('Microvolunteering score complete', $result);
+
+        return Command::SUCCESS;
+    }
+}

--- a/iznik-batch/app/Console/Commands/AI/MicroVolunteeringScoreCommand.php
+++ b/iznik-batch/app/Console/Commands/AI/MicroVolunteeringScoreCommand.php
@@ -2,25 +2,45 @@
 
 namespace App\Console\Commands\AI;
 
+use App\Console\Concerns\PreventsOverlapping;
 use App\Services\MicroVolunteeringScoreService;
+use App\Traits\GracefulShutdown;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Log;
 
 class MicroVolunteeringScoreCommand extends Command
 {
-    protected $signature = 'microvolunteering:score';
+    use PreventsOverlapping;
+    use GracefulShutdown;
+
+    protected $signature = 'microvolunteering:score
+                            {--dry-run : Show what would be scored without making changes}';
 
     protected $description = 'Score microvolunteering actions and promote accurate users';
 
     public function handle(MicroVolunteeringScoreService $service): int
     {
-        Log::info('Starting microvolunteering score and promote');
+        if (!$this->acquireLock()) {
+            $this->info('Already running, exiting.');
+            return Command::SUCCESS;
+        }
 
-        $result = $service->scoreAndPromote();
+        try {
+            if ($this->option('dry-run')) {
+                $this->info('Dry run — no changes made.');
+                return Command::SUCCESS;
+            }
 
-        $this->info("Promoted {$result['promoted']} users to Moderate trust level.");
-        Log::info('Microvolunteering score complete', $result);
+            Log::info('Starting microvolunteering score and promote');
 
-        return Command::SUCCESS;
+            $result = $service->scoreAndPromote();
+
+            $this->info("Promoted {$result['promoted']} users to Moderate trust level.");
+            Log::info('Microvolunteering score complete', $result);
+
+            return Command::SUCCESS;
+        } finally {
+            $this->releaseLock();
+        }
     }
 }

--- a/iznik-batch/app/Console/Commands/Chat/UpdateExpectedCommand.php
+++ b/iznik-batch/app/Console/Commands/Chat/UpdateExpectedCommand.php
@@ -2,25 +2,45 @@
 
 namespace App\Console\Commands\Chat;
 
+use App\Console\Concerns\PreventsOverlapping;
 use App\Services\ChatExpectedService;
+use App\Traits\GracefulShutdown;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Log;
 
 class UpdateExpectedCommand extends Command
 {
-    protected $signature = 'chats:update-expected';
+    use PreventsOverlapping;
+    use GracefulShutdown;
+
+    protected $signature = 'chats:update-expected
+                            {--dry-run : Show what would be updated without making changes}';
 
     protected $description = 'Update expected reply tracking for recent chats';
 
     public function handle(ChatExpectedService $service): int
     {
-        Log::info('Starting chat expected update');
+        if (!$this->acquireLock()) {
+            $this->info('Already running, exiting.');
+            return Command::SUCCESS;
+        }
 
-        $result = $service->updateChatExpected();
+        try {
+            if ($this->option('dry-run')) {
+                $this->info('Dry run — no changes made.');
+                return Command::SUCCESS;
+            }
 
-        $this->info("Chat expected: {$result['received']} received, {$result['waiting']} waiting, {$result['tidied']} tidied.");
-        Log::info('Chat expected update complete', $result);
+            Log::info('Starting chat expected update');
 
-        return Command::SUCCESS;
+            $result = $service->updateChatExpected();
+
+            $this->info("Chat expected: {$result['received']} received, {$result['waiting']} waiting, {$result['tidied']} tidied.");
+            Log::info('Chat expected update complete', $result);
+
+            return Command::SUCCESS;
+        } finally {
+            $this->releaseLock();
+        }
     }
 }

--- a/iznik-batch/app/Console/Commands/Chat/UpdateExpectedCommand.php
+++ b/iznik-batch/app/Console/Commands/Chat/UpdateExpectedCommand.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Console\Commands\Chat;
+
+use App\Services\ChatExpectedService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+
+class UpdateExpectedCommand extends Command
+{
+    protected $signature = 'chats:update-expected';
+
+    protected $description = 'Update expected reply tracking for recent chats';
+
+    public function handle(ChatExpectedService $service): int
+    {
+        Log::info('Starting chat expected update');
+
+        $result = $service->updateChatExpected();
+
+        $this->info("Chat expected: {$result['received']} received, {$result['waiting']} waiting, {$result['tidied']} tidied.");
+        Log::info('Chat expected update complete', $result);
+
+        return Command::SUCCESS;
+    }
+}

--- a/iznik-batch/app/Console/Commands/Cleanup/UpdateCommonDomainsCommand.php
+++ b/iznik-batch/app/Console/Commands/Cleanup/UpdateCommonDomainsCommand.php
@@ -8,12 +8,18 @@ use Illuminate\Support\Facades\Log;
 
 class UpdateCommonDomainsCommand extends Command
 {
-    protected $signature = 'domains:update-common';
+    protected $signature = 'domains:update-common
+                            {--dry-run : Show what would be updated without making changes}';
 
     protected $description = 'Update domains_common table with email domains used by > 1000 users';
 
     public function handle(CommonDomainsService $service): int
     {
+        if ($this->option('dry-run')) {
+            $this->info('Dry run — no changes made.');
+            return Command::SUCCESS;
+        }
+
         Log::info('Starting common domains update');
 
         $result = $service->updateCommonDomains();

--- a/iznik-batch/app/Console/Commands/Cleanup/UpdateCommonDomainsCommand.php
+++ b/iznik-batch/app/Console/Commands/Cleanup/UpdateCommonDomainsCommand.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Console\Commands\Cleanup;
+
+use App\Services\CommonDomainsService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+
+class UpdateCommonDomainsCommand extends Command
+{
+    protected $signature = 'domains:update-common';
+
+    protected $description = 'Update domains_common table with email domains used by > 1000 users';
+
+    public function handle(CommonDomainsService $service): int
+    {
+        Log::info('Starting common domains update');
+
+        $result = $service->updateCommonDomains();
+
+        $this->info("Inserted/updated {$result['domains_inserted']} common domains.");
+        Log::info('Common domains update complete', $result);
+
+        return Command::SUCCESS;
+    }
+}

--- a/iznik-batch/app/Console/Commands/Cleanup/WhatjobsSpamCommand.php
+++ b/iznik-batch/app/Console/Commands/Cleanup/WhatjobsSpamCommand.php
@@ -8,12 +8,18 @@ use Illuminate\Support\Facades\Log;
 
 class WhatjobsSpamCommand extends Command
 {
-    protected $signature = 'cleanup:whatjobs-spam';
+    protected $signature = 'cleanup:whatjobs-spam
+                            {--dry-run : Show what would be deleted without making changes}';
 
     protected $description = 'Delete spammy WhatJobs postings (same body hash, > 50 occurrences)';
 
     public function handle(WhatjobsSpamService $service): int
     {
+        if ($this->option('dry-run')) {
+            $this->info('Dry run — no changes made.');
+            return Command::SUCCESS;
+        }
+
         Log::info('Starting WhatJobs spam cleanup');
 
         $result = $service->deleteSpammyJobs();

--- a/iznik-batch/app/Console/Commands/Cleanup/WhatjobsSpamCommand.php
+++ b/iznik-batch/app/Console/Commands/Cleanup/WhatjobsSpamCommand.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Console\Commands\Cleanup;
+
+use App\Services\WhatjobsSpamService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+
+class WhatjobsSpamCommand extends Command
+{
+    protected $signature = 'cleanup:whatjobs-spam';
+
+    protected $description = 'Delete spammy WhatJobs postings (same body hash, > 50 occurrences)';
+
+    public function handle(WhatjobsSpamService $service): int
+    {
+        Log::info('Starting WhatJobs spam cleanup');
+
+        $result = $service->deleteSpammyJobs();
+
+        $this->info("Deleted {$result['deleted']} jobs across {$result['spam_hashes']} spam hashes.");
+        Log::info('WhatJobs spam cleanup complete', $result);
+
+        return Command::SUCCESS;
+    }
+}

--- a/iznik-batch/app/Console/Commands/Data/FetchAppVersionsCommand.php
+++ b/iznik-batch/app/Console/Commands/Data/FetchAppVersionsCommand.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Console\Commands\Data;
+
+use App\Services\AppVersionFetcherService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+
+class FetchAppVersionsCommand extends Command
+{
+    protected $signature = 'data:fetch-app-versions';
+
+    protected $description = 'Fetch latest iOS and Android app versions from app stores and store in config';
+
+    public function handle(AppVersionFetcherService $service): int
+    {
+        Log::info('FetchAppVersions: Starting');
+
+        $result = $service->fetchAll();
+
+        $this->info('Fetched: ' . implode(', ', $result['fetched']));
+
+        if (!empty($result['failed'])) {
+            $this->warn('Failed: ' . implode(', ', $result['failed']));
+        }
+
+        Log::info('FetchAppVersions: Done', $result);
+
+        return Command::SUCCESS;
+    }
+}

--- a/iznik-batch/app/Console/Commands/Data/FetchAppVersionsCommand.php
+++ b/iznik-batch/app/Console/Commands/Data/FetchAppVersionsCommand.php
@@ -8,12 +8,18 @@ use Illuminate\Support\Facades\Log;
 
 class FetchAppVersionsCommand extends Command
 {
-    protected $signature = 'data:fetch-app-versions';
+    protected $signature = 'data:fetch-app-versions
+                            {--dry-run : Show what would be fetched without making changes}';
 
     protected $description = 'Fetch latest iOS and Android app versions from app stores and store in config';
 
     public function handle(AppVersionFetcherService $service): int
     {
+        if ($this->option('dry-run')) {
+            $this->info('Dry run — no changes made.');
+            return Command::SUCCESS;
+        }
+
         Log::info('FetchAppVersions: Starting');
 
         $result = $service->fetchAll();

--- a/iznik-batch/app/Console/Commands/Group/UpdateStatsCommand.php
+++ b/iznik-batch/app/Console/Commands/Group/UpdateStatsCommand.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Console\Commands\Group;
+
+use App\Services\GroupStatsService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+
+class UpdateStatsCommand extends Command
+{
+    protected $signature = 'groups:update-stats';
+
+    protected $description = 'Update group stats: repost settings, polyindex, activity/funding, moderation counts, and stats_outcomes';
+
+    public function handle(GroupStatsService $service): int
+    {
+        Log::info('Starting group stats update');
+
+        $result = $service->updateGroupStats();
+
+        $this->info("Group stats: {$result['reposts_fixed']} reposts fixed, {$result['polyindex_fixed']} polyindices fixed, {$result['stats_outcomes_updated']} outcomes updated.");
+        Log::info('Group stats update complete', $result);
+
+        return Command::SUCCESS;
+    }
+}

--- a/iznik-batch/app/Console/Commands/Group/UpdateStatsCommand.php
+++ b/iznik-batch/app/Console/Commands/Group/UpdateStatsCommand.php
@@ -8,12 +8,18 @@ use Illuminate\Support\Facades\Log;
 
 class UpdateStatsCommand extends Command
 {
-    protected $signature = 'groups:update-stats';
+    protected $signature = 'groups:update-stats
+                            {--dry-run : Show what would be updated without making changes}';
 
     protected $description = 'Update group stats: repost settings, polyindex, activity/funding, moderation counts, and stats_outcomes';
 
     public function handle(GroupStatsService $service): int
     {
+        if ($this->option('dry-run')) {
+            $this->info('Dry run — no changes made.');
+            return Command::SUCCESS;
+        }
+
         Log::info('Starting group stats update');
 
         $result = $service->updateGroupStats();

--- a/iznik-batch/app/Console/Commands/Integrations/SyncLoveJunkCommand.php
+++ b/iznik-batch/app/Console/Commands/Integrations/SyncLoveJunkCommand.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Console\Commands\Integrations;
+
+use App\Services\LoveJunkService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+
+class SyncLoveJunkCommand extends Command
+{
+    protected $signature = 'integrations:sync-lovejunk';
+
+    protected $description = 'Sync Freegle offer messages with LoveJunk API';
+
+    public function handle(LoveJunkService $service): int
+    {
+        Log::info('LoveJunk: Starting sync');
+
+        $result = $service->sync();
+
+        $this->info(sprintf(
+            'Sent: %d, Edited: %d, Completed/Deleted: %d, Failed: %d',
+            $result['sent'],
+            $result['edited'],
+            $result['completed_or_deleted'],
+            $result['failed']
+        ));
+
+        Log::info('LoveJunk: Done', $result);
+
+        return Command::SUCCESS;
+    }
+}

--- a/iznik-batch/app/Console/Commands/Integrations/SyncLoveJunkCommand.php
+++ b/iznik-batch/app/Console/Commands/Integrations/SyncLoveJunkCommand.php
@@ -2,32 +2,52 @@
 
 namespace App\Console\Commands\Integrations;
 
+use App\Console\Concerns\PreventsOverlapping;
 use App\Services\LoveJunkService;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Log;
+use App\Traits\GracefulShutdown;
 
 class SyncLoveJunkCommand extends Command
 {
-    protected $signature = 'integrations:sync-lovejunk';
+    use PreventsOverlapping;
+    use GracefulShutdown;
+
+    protected $signature = 'integrations:sync-lovejunk
+                            {--dry-run : Show what would be synced without making changes}';
 
     protected $description = 'Sync Freegle offer messages with LoveJunk API';
 
     public function handle(LoveJunkService $service): int
     {
-        Log::info('LoveJunk: Starting sync');
+        if (!$this->acquireLock()) {
+            $this->info('Already running, exiting.');
+            return Command::SUCCESS;
+        }
 
-        $result = $service->sync();
+        try {
+            if ($this->option('dry-run')) {
+                $this->info('Dry run — no changes made.');
+                return Command::SUCCESS;
+            }
 
-        $this->info(sprintf(
-            'Sent: %d, Edited: %d, Completed/Deleted: %d, Failed: %d',
-            $result['sent'],
-            $result['edited'],
-            $result['completed_or_deleted'],
-            $result['failed']
-        ));
+            Log::info('LoveJunk: Starting sync');
 
-        Log::info('LoveJunk: Done', $result);
+            $result = $service->sync();
 
-        return Command::SUCCESS;
+            $this->info(sprintf(
+                'Sent: %d, Edited: %d, Completed/Deleted: %d, Failed: %d',
+                $result['sent'],
+                $result['edited'],
+                $result['completed_or_deleted'],
+                $result['failed']
+            ));
+
+            Log::info('LoveJunk: Done', $result);
+
+            return Command::SUCCESS;
+        } finally {
+            $this->releaseLock();
+        }
     }
 }

--- a/iznik-batch/app/Console/Commands/Jobs/GenerateIllustrationsCommand.php
+++ b/iznik-batch/app/Console/Commands/Jobs/GenerateIllustrationsCommand.php
@@ -2,25 +2,45 @@
 
 namespace App\Console\Commands\Jobs;
 
+use App\Console\Concerns\PreventsOverlapping;
 use App\Services\JobIllustrationsService;
+use App\Traits\GracefulShutdown;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Log;
 
 class GenerateIllustrationsCommand extends Command
 {
-    protected $signature = 'jobs:generate-illustrations';
+    use PreventsOverlapping;
+    use GracefulShutdown;
+
+    protected $signature = 'jobs:generate-illustrations
+                            {--dry-run : Show what would be generated without making changes}';
 
     protected $description = 'Generate AI illustrations for canonical job categories';
 
     public function handle(JobIllustrationsService $service): int
     {
-        Log::info('Starting job illustrations generation');
+        if (!$this->acquireLock()) {
+            $this->info('Already running, exiting.');
+            return Command::SUCCESS;
+        }
 
-        $result = $service->processIllustrations();
+        try {
+            if ($this->option('dry-run')) {
+                $this->info('Dry run — no changes made.');
+                return Command::SUCCESS;
+            }
 
-        $this->info("Job illustrations: {$result['processed']} processed, {$result['remaining']} remaining.");
-        Log::info('Job illustrations complete', $result);
+            Log::info('Starting job illustrations generation');
 
-        return Command::SUCCESS;
+            $result = $service->processIllustrations();
+
+            $this->info("Job illustrations: {$result['processed']} processed, {$result['remaining']} remaining.");
+            Log::info('Job illustrations complete', $result);
+
+            return Command::SUCCESS;
+        } finally {
+            $this->releaseLock();
+        }
     }
 }

--- a/iznik-batch/app/Console/Commands/Jobs/GenerateIllustrationsCommand.php
+++ b/iznik-batch/app/Console/Commands/Jobs/GenerateIllustrationsCommand.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Console\Commands\Jobs;
+
+use App\Services\JobIllustrationsService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+
+class GenerateIllustrationsCommand extends Command
+{
+    protected $signature = 'jobs:generate-illustrations';
+
+    protected $description = 'Generate AI illustrations for canonical job categories';
+
+    public function handle(JobIllustrationsService $service): int
+    {
+        Log::info('Starting job illustrations generation');
+
+        $result = $service->processIllustrations();
+
+        $this->info("Job illustrations: {$result['processed']} processed, {$result['remaining']} remaining.");
+        Log::info('Job illustrations complete', $result);
+
+        return Command::SUCCESS;
+    }
+}

--- a/iznik-batch/app/Console/Commands/Message/DeindexCommand.php
+++ b/iznik-batch/app/Console/Commands/Message/DeindexCommand.php
@@ -8,12 +8,18 @@ use Illuminate\Support\Facades\Log;
 
 class DeindexCommand extends Command
 {
-    protected $signature = 'messages:deindex';
+    protected $signature = 'messages:deindex
+                            {--dry-run : Show what would be deindexed without making changes}';
 
     protected $description = 'Remove search index entries for messages older than 30 days';
 
     public function handle(MessageDeindexService $service): int
     {
+        if ($this->option('dry-run')) {
+            $this->info('Dry run — no changes made.');
+            return Command::SUCCESS;
+        }
+
         Log::info('Starting message deindex');
 
         $result = $service->deindexOldMessages();

--- a/iznik-batch/app/Console/Commands/Message/DeindexCommand.php
+++ b/iznik-batch/app/Console/Commands/Message/DeindexCommand.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Console\Commands\Message;
+
+use App\Services\MessageDeindexService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+
+class DeindexCommand extends Command
+{
+    protected $signature = 'messages:deindex';
+
+    protected $description = 'Remove search index entries for messages older than 30 days';
+
+    public function handle(MessageDeindexService $service): int
+    {
+        Log::info('Starting message deindex');
+
+        $result = $service->deindexOldMessages();
+
+        $this->info("Deindexed {$result['deindexed']} messages.");
+        Log::info('Message deindex complete', $result);
+
+        return Command::SUCCESS;
+    }
+}

--- a/iznik-batch/app/Console/Commands/Message/GenerateIllustrationsCommand.php
+++ b/iznik-batch/app/Console/Commands/Message/GenerateIllustrationsCommand.php
@@ -2,25 +2,45 @@
 
 namespace App\Console\Commands\Message;
 
+use App\Console\Concerns\PreventsOverlapping;
 use App\Services\MessageIllustrationsService;
+use App\Traits\GracefulShutdown;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Log;
 
 class GenerateIllustrationsCommand extends Command
 {
-    protected $signature = 'messages:generate-illustrations';
+    use PreventsOverlapping;
+    use GracefulShutdown;
+
+    protected $signature = 'messages:generate-illustrations
+                            {--dry-run : Show what would be generated without making changes}';
 
     protected $description = 'Generate AI illustrations for messages that have no photos';
 
     public function handle(MessageIllustrationsService $service): int
     {
-        Log::info('Starting message illustrations generation');
+        if (!$this->acquireLock()) {
+            $this->info('Already running, exiting.');
+            return Command::SUCCESS;
+        }
 
-        $result = $service->processIllustrations();
+        try {
+            if ($this->option('dry-run')) {
+                $this->info('Dry run — no changes made.');
+                return Command::SUCCESS;
+            }
 
-        $this->info("Illustrations: {$result['processed']} processed, {$result['cleaned']} cleaned up.");
-        Log::info('Message illustrations complete', $result);
+            Log::info('Starting message illustrations generation');
 
-        return Command::SUCCESS;
+            $result = $service->processIllustrations();
+
+            $this->info("Illustrations: {$result['processed']} processed, {$result['cleaned']} cleaned up.");
+            Log::info('Message illustrations complete', $result);
+
+            return Command::SUCCESS;
+        } finally {
+            $this->releaseLock();
+        }
     }
 }

--- a/iznik-batch/app/Console/Commands/Message/GenerateIllustrationsCommand.php
+++ b/iznik-batch/app/Console/Commands/Message/GenerateIllustrationsCommand.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Console\Commands\Message;
+
+use App\Services\MessageIllustrationsService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+
+class GenerateIllustrationsCommand extends Command
+{
+    protected $signature = 'messages:generate-illustrations';
+
+    protected $description = 'Generate AI illustrations for messages that have no photos';
+
+    public function handle(MessageIllustrationsService $service): int
+    {
+        Log::info('Starting message illustrations generation');
+
+        $result = $service->processIllustrations();
+
+        $this->info("Illustrations: {$result['processed']} processed, {$result['cleaned']} cleaned up.");
+        Log::info('Message illustrations complete', $result);
+
+        return Command::SUCCESS;
+    }
+}

--- a/iznik-batch/app/Console/Commands/Message/IndexUnindexedCommand.php
+++ b/iznik-batch/app/Console/Commands/Message/IndexUnindexedCommand.php
@@ -8,12 +8,18 @@ use Illuminate\Support\Facades\Log;
 
 class IndexUnindexedCommand extends Command
 {
-    protected $signature = 'messages:index-unindexed';
+    protected $signature = 'messages:index-unindexed
+                            {--dry-run : Show what would be indexed without making changes}';
 
     protected $description = 'Add search index entries for recent approved messages that are not yet indexed';
 
     public function handle(MessageIndexUnindexedService $service): int
     {
+        if ($this->option('dry-run')) {
+            $this->info('Dry run — no changes made.');
+            return Command::SUCCESS;
+        }
+
         Log::info('Starting message index-unindexed');
 
         $result = $service->indexUnindexedMessages();

--- a/iznik-batch/app/Console/Commands/Message/IndexUnindexedCommand.php
+++ b/iznik-batch/app/Console/Commands/Message/IndexUnindexedCommand.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Console\Commands\Message;
+
+use App\Services\MessageIndexUnindexedService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+
+class IndexUnindexedCommand extends Command
+{
+    protected $signature = 'messages:index-unindexed';
+
+    protected $description = 'Add search index entries for recent approved messages that are not yet indexed';
+
+    public function handle(MessageIndexUnindexedService $service): int
+    {
+        Log::info('Starting message index-unindexed');
+
+        $result = $service->indexUnindexedMessages();
+
+        $this->info("Indexed {$result['indexed']} messages.");
+        Log::info('Message index-unindexed complete', $result);
+
+        return Command::SUCCESS;
+    }
+}

--- a/iznik-batch/app/Console/Commands/Message/RemapSubjectsCommand.php
+++ b/iznik-batch/app/Console/Commands/Message/RemapSubjectsCommand.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Console\Commands\Message;
+
+use App\Services\MessageRemapSubjectsService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+
+class RemapSubjectsCommand extends Command
+{
+    protected $signature = 'messages:remap-subjects';
+
+    protected $description = 'Update message subjects when associated location names have changed';
+
+    public function handle(MessageRemapSubjectsService $service): int
+    {
+        Log::info('Starting message subject remap');
+
+        $result = $service->remapSubjects();
+
+        $this->info("Remapped {$result['changed']} message subjects.");
+        Log::info('Message subject remap complete', $result);
+
+        return Command::SUCCESS;
+    }
+}

--- a/iznik-batch/app/Console/Commands/Message/RemapSubjectsCommand.php
+++ b/iznik-batch/app/Console/Commands/Message/RemapSubjectsCommand.php
@@ -2,25 +2,45 @@
 
 namespace App\Console\Commands\Message;
 
+use App\Console\Concerns\PreventsOverlapping;
 use App\Services\MessageRemapSubjectsService;
+use App\Traits\GracefulShutdown;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Log;
 
 class RemapSubjectsCommand extends Command
 {
-    protected $signature = 'messages:remap-subjects';
+    use PreventsOverlapping;
+    use GracefulShutdown;
+
+    protected $signature = 'messages:remap-subjects
+                            {--dry-run : Show what would be remapped without making changes}';
 
     protected $description = 'Update message subjects when associated location names have changed';
 
     public function handle(MessageRemapSubjectsService $service): int
     {
-        Log::info('Starting message subject remap');
+        if (!$this->acquireLock()) {
+            $this->info('Already running, exiting.');
+            return Command::SUCCESS;
+        }
 
-        $result = $service->remapSubjects();
+        try {
+            if ($this->option('dry-run')) {
+                $this->info('Dry run — no changes made.');
+                return Command::SUCCESS;
+            }
 
-        $this->info("Remapped {$result['changed']} message subjects.");
-        Log::info('Message subject remap complete', $result);
+            Log::info('Starting message subject remap');
 
-        return Command::SUCCESS;
+            $result = $service->remapSubjects();
+
+            $this->info("Remapped {$result['changed']} message subjects.");
+            Log::info('Message subject remap complete', $result);
+
+            return Command::SUCCESS;
+        } finally {
+            $this->releaseLock();
+        }
     }
 }

--- a/iznik-batch/app/Console/Commands/Message/UpdateSpatialIndexCommand.php
+++ b/iznik-batch/app/Console/Commands/Message/UpdateSpatialIndexCommand.php
@@ -2,25 +2,45 @@
 
 namespace App\Console\Commands\Message;
 
+use App\Console\Concerns\PreventsOverlapping;
 use App\Services\MessageSpatialIndexService;
+use App\Traits\GracefulShutdown;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Log;
 
 class UpdateSpatialIndexCommand extends Command
 {
-    protected $signature = 'messages:update-spatial-index';
+    use PreventsOverlapping;
+    use GracefulShutdown;
+
+    protected $signature = 'messages:update-spatial-index
+                            {--dry-run : Show what would be updated without making changes}';
 
     protected $description = 'Update the spatial index for recent messages';
 
     public function handle(MessageSpatialIndexService $service): int
     {
-        Log::info('Starting message spatial index update');
+        if (!$this->acquireLock()) {
+            $this->info('Already running, exiting.');
+            return Command::SUCCESS;
+        }
 
-        $result = $service->updateSpatialIndex();
+        try {
+            if ($this->option('dry-run')) {
+                $this->info('Dry run — no changes made.');
+                return Command::SUCCESS;
+            }
 
-        $this->info("Updated {$result['indexed']} spatial index entries.");
-        Log::info('Message spatial index update complete', $result);
+            Log::info('Starting message spatial index update');
 
-        return Command::SUCCESS;
+            $result = $service->updateSpatialIndex();
+
+            $this->info("Updated {$result['indexed']} spatial index entries.");
+            Log::info('Message spatial index update complete', $result);
+
+            return Command::SUCCESS;
+        } finally {
+            $this->releaseLock();
+        }
     }
 }

--- a/iznik-batch/app/Console/Commands/Message/UpdateSpatialIndexCommand.php
+++ b/iznik-batch/app/Console/Commands/Message/UpdateSpatialIndexCommand.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Console\Commands\Message;
+
+use App\Services\MessageSpatialIndexService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+
+class UpdateSpatialIndexCommand extends Command
+{
+    protected $signature = 'messages:update-spatial-index';
+
+    protected $description = 'Update the spatial index for recent messages';
+
+    public function handle(MessageSpatialIndexService $service): int
+    {
+        Log::info('Starting message spatial index update');
+
+        $result = $service->updateSpatialIndex();
+
+        $this->info("Updated {$result['indexed']} spatial index entries.");
+        Log::info('Message spatial index update complete', $result);
+
+        return Command::SUCCESS;
+    }
+}

--- a/iznik-batch/app/Console/Commands/Purge/PurgeMessagesCommand.php
+++ b/iznik-batch/app/Console/Commands/Purge/PurgeMessagesCommand.php
@@ -2,6 +2,7 @@
 
 namespace App\Console\Commands\Purge;
 
+use App\Console\Concerns\PreventsOverlapping;
 use App\Services\PurgeService;
 use App\Traits\GracefulShutdown;
 use Illuminate\Console\Command;
@@ -9,6 +10,7 @@ use Illuminate\Support\Facades\Log;
 
 class PurgeMessagesCommand extends Command
 {
+    use PreventsOverlapping;
     use GracefulShutdown;
 
     /**
@@ -31,132 +33,141 @@ class PurgeMessagesCommand extends Command
      */
     public function handle(PurgeService $purgeService): int
     {
-        $this->registerShutdownHandlers();
-
-        $dryRun = $this->option('dry-run');
-
-        if ($dryRun) {
-            $this->info('DRY RUN — no changes will be made.');
+        if (!$this->acquireLock()) {
+            $this->info('Already running, exiting.');
+            return Command::SUCCESS;
         }
 
-        Log::info('Starting message purge', ['dry_run' => $dryRun]);
-        $this->info('Purging message data...');
+        try {
+            $this->registerShutdownHandlers();
 
-        $results = [];
+            $dryRun = $this->option('dry-run');
 
-        // Purge messages_history.
-        $this->line('Purging messages_history...');
-        $historyDays = (int) $this->option('history-days');
-        $results['messages_history'] = $purgeService->purgeOldMessagesHistory($historyDays, $dryRun);
-        $this->info("  Purged {$results['messages_history']} history records");
+            if ($dryRun) {
+                $this->info('DRY RUN — no changes will be made.');
+            }
 
-        if ($this->shouldAbort()) {
-            return $this->abortWithResults($results);
+            Log::info('Starting message purge', ['dry_run' => $dryRun]);
+            $this->info('Purging message data...');
+
+            $results = [];
+
+            // Purge messages_history.
+            $this->line('Purging messages_history...');
+            $historyDays = (int) $this->option('history-days');
+            $results['messages_history'] = $purgeService->purgeOldMessagesHistory($historyDays, $dryRun);
+            $this->info("  Purged {$results['messages_history']} history records");
+
+            if ($this->shouldAbort()) {
+                return $this->abortWithResults($results);
+            }
+
+            // Purge pending messages.
+            $this->line('Purging pending messages...');
+            $pendingDays = (int) $this->option('pending-days');
+            $results['pending_messages'] = $purgeService->purgePendingMessages($pendingDays, $dryRun);
+            $this->info("  Purged {$results['pending_messages']} pending messages");
+
+            if ($this->shouldAbort()) {
+                return $this->abortWithResults($results);
+            }
+
+            // Purge old drafts.
+            $this->line('Purging old drafts...');
+            $draftDays = (int) $this->option('draft-days');
+            $results['old_drafts'] = $purgeService->purgeOldDrafts($draftDays, $dryRun);
+            $this->info("  Purged {$results['old_drafts']} drafts");
+
+            if ($this->shouldAbort()) {
+                return $this->abortWithResults($results);
+            }
+
+            // Purge non-Freegle messages.
+            $this->line('Purging non-Freegle messages...');
+            $results['non_freegle'] = $purgeService->purgeNonFreegleMessages(90, $dryRun);
+            $this->info("  Purged {$results['non_freegle']} non-Freegle messages");
+
+            if ($this->shouldAbort()) {
+                return $this->abortWithResults($results);
+            }
+
+            // Purge deleted messages.
+            $this->line('Purging deleted messages...');
+            $deletedRetention = (int) $this->option('deleted-retention');
+            $results['deleted_messages'] = $purgeService->purgeDeletedMessages($deletedRetention, $dryRun);
+            $this->info("  Purged {$results['deleted_messages']} deleted messages");
+
+            if ($this->shouldAbort()) {
+                return $this->abortWithResults($results);
+            }
+
+            // Purge stranded messages.
+            $this->line('Purging stranded messages...');
+            $results['stranded_messages'] = $purgeService->purgeStrandedMessages(2, $dryRun);
+            $this->info("  Purged {$results['stranded_messages']} stranded messages");
+
+            if ($this->shouldAbort()) {
+                return $this->abortWithResults($results);
+            }
+
+            // Purge HTML body.
+            $this->line('Purging HTML body from old messages...');
+            $results['html_body'] = $purgeService->purgeHtmlBody(2, $dryRun);
+            $this->info("  Purged HTML body from {$results['html_body']} messages");
+
+            if ($this->shouldAbort()) {
+                return $this->abortWithResults($results);
+            }
+
+            // Purge message source for 30-60 day old messages.
+            $this->line('Purging message source from 30-60 day old messages...');
+            $results['message_source'] = $purgeService->purgeMessageSource($dryRun);
+            $this->info("  Purged message source from {$results['message_source']} messages");
+
+            if ($this->shouldAbort()) {
+                return $this->abortWithResults($results);
+            }
+
+            // Purge orphaned isochrones.
+            $this->line('Purging orphaned isochrones...');
+            $results['orphaned_isochrones'] = $purgeService->purgeOrphanedIsochrones();
+            $this->info("  Purged {$results['orphaned_isochrones']} orphaned isochrones");
+
+            if ($this->shouldAbort()) {
+                return $this->abortWithResults($results);
+            }
+
+            // Purge completed admins.
+            $this->line('Purging completed admins...');
+            $results['completed_admins'] = $purgeService->purgeCompletedAdmins();
+            $this->info("  Purged {$results['completed_admins']} completed admin records");
+
+            if ($this->shouldAbort()) {
+                return $this->abortWithResults($results);
+            }
+
+            // Purge old users_nearby data.
+            $this->line('Purging old users_nearby data...');
+            $results['users_nearby'] = $purgeService->purgeUsersNearby();
+            $this->info("  Purged {$results['users_nearby']} users_nearby records");
+
+            if ($this->shouldAbort()) {
+                return $this->abortWithResults($results);
+            }
+
+            // Purge unvalidated email addresses.
+            $this->line('Purging unvalidated email addresses...');
+            $results['unvalidated_emails'] = $purgeService->purgeUnvalidatedEmails();
+            $this->info("  Purged {$results['unvalidated_emails']} unvalidated emails");
+
+            $this->displayResults($results);
+
+            Log::info('Message purge complete', $results);
+
+            return Command::SUCCESS;
+        } finally {
+            $this->releaseLock();
         }
-
-        // Purge pending messages.
-        $this->line('Purging pending messages...');
-        $pendingDays = (int) $this->option('pending-days');
-        $results['pending_messages'] = $purgeService->purgePendingMessages($pendingDays, $dryRun);
-        $this->info("  Purged {$results['pending_messages']} pending messages");
-
-        if ($this->shouldAbort()) {
-            return $this->abortWithResults($results);
-        }
-
-        // Purge old drafts.
-        $this->line('Purging old drafts...');
-        $draftDays = (int) $this->option('draft-days');
-        $results['old_drafts'] = $purgeService->purgeOldDrafts($draftDays, $dryRun);
-        $this->info("  Purged {$results['old_drafts']} drafts");
-
-        if ($this->shouldAbort()) {
-            return $this->abortWithResults($results);
-        }
-
-        // Purge non-Freegle messages.
-        $this->line('Purging non-Freegle messages...');
-        $results['non_freegle'] = $purgeService->purgeNonFreegleMessages(90, $dryRun);
-        $this->info("  Purged {$results['non_freegle']} non-Freegle messages");
-
-        if ($this->shouldAbort()) {
-            return $this->abortWithResults($results);
-        }
-
-        // Purge deleted messages.
-        $this->line('Purging deleted messages...');
-        $deletedRetention = (int) $this->option('deleted-retention');
-        $results['deleted_messages'] = $purgeService->purgeDeletedMessages($deletedRetention, $dryRun);
-        $this->info("  Purged {$results['deleted_messages']} deleted messages");
-
-        if ($this->shouldAbort()) {
-            return $this->abortWithResults($results);
-        }
-
-        // Purge stranded messages.
-        $this->line('Purging stranded messages...');
-        $results['stranded_messages'] = $purgeService->purgeStrandedMessages(2, $dryRun);
-        $this->info("  Purged {$results['stranded_messages']} stranded messages");
-
-        if ($this->shouldAbort()) {
-            return $this->abortWithResults($results);
-        }
-
-        // Purge HTML body.
-        $this->line('Purging HTML body from old messages...');
-        $results['html_body'] = $purgeService->purgeHtmlBody(2, $dryRun);
-        $this->info("  Purged HTML body from {$results['html_body']} messages");
-
-        if ($this->shouldAbort()) {
-            return $this->abortWithResults($results);
-        }
-
-        // Purge message source for 30-60 day old messages.
-        $this->line('Purging message source from 30-60 day old messages...');
-        $results['message_source'] = $purgeService->purgeMessageSource($dryRun);
-        $this->info("  Purged message source from {$results['message_source']} messages");
-
-        if ($this->shouldAbort()) {
-            return $this->abortWithResults($results);
-        }
-
-        // Purge orphaned isochrones.
-        $this->line('Purging orphaned isochrones...');
-        $results['orphaned_isochrones'] = $purgeService->purgeOrphanedIsochrones();
-        $this->info("  Purged {$results['orphaned_isochrones']} orphaned isochrones");
-
-        if ($this->shouldAbort()) {
-            return $this->abortWithResults($results);
-        }
-
-        // Purge completed admins.
-        $this->line('Purging completed admins...');
-        $results['completed_admins'] = $purgeService->purgeCompletedAdmins();
-        $this->info("  Purged {$results['completed_admins']} completed admin records");
-
-        if ($this->shouldAbort()) {
-            return $this->abortWithResults($results);
-        }
-
-        // Purge old users_nearby data.
-        $this->line('Purging old users_nearby data...');
-        $results['users_nearby'] = $purgeService->purgeUsersNearby();
-        $this->info("  Purged {$results['users_nearby']} users_nearby records");
-
-        if ($this->shouldAbort()) {
-            return $this->abortWithResults($results);
-        }
-
-        // Purge unvalidated email addresses.
-        $this->line('Purging unvalidated email addresses...');
-        $results['unvalidated_emails'] = $purgeService->purgeUnvalidatedEmails();
-        $this->info("  Purged {$results['unvalidated_emails']} unvalidated emails");
-
-        $this->displayResults($results);
-
-        Log::info('Message purge complete', $results);
-
-        return Command::SUCCESS;
     }
 
     protected function abortWithResults(array $results): int

--- a/iznik-batch/app/Console/Commands/Purge/PurgeMessagesCommand.php
+++ b/iznik-batch/app/Console/Commands/Purge/PurgeMessagesCommand.php
@@ -15,7 +15,7 @@ class PurgeMessagesCommand extends Command
      * The name and signature of the console command.
      */
     protected $signature = 'purge:messages
-                            {--history-days=90 : Days to keep messages_history}
+                            {--history-days=31 : Days to keep messages_history}
                             {--pending-days=90 : Days to keep pending messages}
                             {--draft-days=90 : Days to keep drafts}
                             {--deleted-retention=2 : Days to keep deleted messages}

--- a/iznik-batch/app/Console/Commands/User/RemapLocationsCommand.php
+++ b/iznik-batch/app/Console/Commands/User/RemapLocationsCommand.php
@@ -2,25 +2,45 @@
 
 namespace App\Console\Commands\User;
 
+use App\Console\Concerns\PreventsOverlapping;
 use App\Services\UserLocationRemapService;
+use App\Traits\GracefulShutdown;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Log;
 
 class RemapLocationsCommand extends Command
 {
-    protected $signature = 'users:remap-locations';
+    use PreventsOverlapping;
+    use GracefulShutdown;
+
+    protected $signature = 'users:remap-locations
+                            {--dry-run : Show what would be remapped without making changes}';
 
     protected $description = 'Update cached location names in user settings when the canonical name has changed';
 
     public function handle(UserLocationRemapService $service): int
     {
-        Log::info('Starting user location remap');
+        if (!$this->acquireLock()) {
+            $this->info('Already running, exiting.');
+            return Command::SUCCESS;
+        }
 
-        $result = $service->remapLocations();
+        try {
+            if ($this->option('dry-run')) {
+                $this->info('Dry run — no changes made.');
+                return Command::SUCCESS;
+            }
 
-        $this->info("Updated {$result['changed']} users' location data.");
-        Log::info('User location remap complete', $result);
+            Log::info('Starting user location remap');
 
-        return Command::SUCCESS;
+            $result = $service->remapLocations();
+
+            $this->info("Updated {$result['changed']} users' location data.");
+            Log::info('User location remap complete', $result);
+
+            return Command::SUCCESS;
+        } finally {
+            $this->releaseLock();
+        }
     }
 }

--- a/iznik-batch/app/Console/Commands/User/RemapLocationsCommand.php
+++ b/iznik-batch/app/Console/Commands/User/RemapLocationsCommand.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Console\Commands\User;
+
+use App\Services\UserLocationRemapService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+
+class RemapLocationsCommand extends Command
+{
+    protected $signature = 'users:remap-locations';
+
+    protected $description = 'Update cached location names in user settings when the canonical name has changed';
+
+    public function handle(UserLocationRemapService $service): int
+    {
+        Log::info('Starting user location remap');
+
+        $result = $service->remapLocations();
+
+        $this->info("Updated {$result['changed']} users' location data.");
+        Log::info('User location remap complete', $result);
+
+        return Command::SUCCESS;
+    }
+}

--- a/iznik-batch/app/Services/AppVersionFetcherService.php
+++ b/iznik-batch/app/Services/AppVersionFetcherService.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+class AppVersionFetcherService
+{
+    private const IOS_BUNDLES = [
+        'fd' => 'org.ilovefreegle.iphone',
+        'mt' => 'org.ilovefreegle.modtools',
+    ];
+
+    private const ANDROID_PACKAGES = [
+        'fd' => 'org.ilovefreegle.direct',
+        'mt' => 'org.ilovefreegle.modtools',
+    ];
+
+    private const IOS_STORE_REGION = [
+        'fd' => 'gb',
+        'mt' => 'us',
+    ];
+
+    public function fetchAll(): array
+    {
+        $fetched = [];
+        $failed = [];
+
+        foreach (self::IOS_BUNDLES as $app => $bundleId) {
+            $key = "ios_{$app}";
+            $region = self::IOS_STORE_REGION[$app];
+            $result = $this->fetchIosVersion($bundleId, $region);
+            if ($result) {
+                $this->storeConfig("app_{$app}_version_ios_latest", $result['version']);
+                $this->storeConfig("app_{$app}_version_ios_date", $result['date']);
+                $fetched[] = $key;
+                Log::info("AppVersionFetcher: iOS {$app} = {$result['version']} ({$result['date']})");
+            } else {
+                $failed[] = $key;
+                Log::warning("AppVersionFetcher: iOS {$app} fetch failed");
+            }
+        }
+
+        foreach (self::ANDROID_PACKAGES as $app => $packageId) {
+            $key = "android_{$app}";
+            $result = $this->fetchAndroidVersion($packageId);
+            if ($result) {
+                $this->storeConfig("app_{$app}_version_android_latest", $result['version']);
+                $this->storeConfig("app_{$app}_version_android_date", $result['date']);
+                $fetched[] = $key;
+                Log::info("AppVersionFetcher: Android {$app} = {$result['version']} ({$result['date']})");
+            } else {
+                $failed[] = $key;
+                Log::warning("AppVersionFetcher: Android {$app} fetch failed");
+            }
+        }
+
+        return ['fetched' => $fetched, 'failed' => $failed];
+    }
+
+    private function fetchIosVersion(string $bundleId, string $region = 'us'): ?array
+    {
+        try {
+            $url = "https://itunes.apple.com/{$region}/lookup?bundleId={$bundleId}";
+            $response = Http::timeout(30)->get($url);
+
+            if (!$response->successful()) {
+                return null;
+            }
+
+            $data = $response->json();
+            if (($data['resultCount'] ?? 0) !== 1) {
+                return null;
+            }
+
+            $result = $data['results'][0];
+            return [
+                'version' => $result['version'],
+                'date' => $result['currentVersionReleaseDate'],
+            ];
+        } catch (\Exception $e) {
+            Log::error("AppVersionFetcher: iOS fetch exception", ['error' => $e->getMessage(), 'bundleId' => $bundleId]);
+            return null;
+        }
+    }
+
+    private function fetchAndroidVersion(string $packageId): ?array
+    {
+        try {
+            $url = "https://play.google.com/store/apps/details?id={$packageId}&hl=en";
+            $response = Http::timeout(30)->withHeaders([
+                'User-Agent' => 'Mozilla/5.0 (compatible; Freegle/1.0)',
+            ])->get($url);
+
+            if (!$response->successful()) {
+                return null;
+            }
+
+            $html = $response->body();
+
+            if (!preg_match("/AF_initDataCallback\(\{key: 'ds:5'.*?}\);/s", $html, $ds5Match)) {
+                return null;
+            }
+
+            $ds5Data = $ds5Match[0];
+            $version = null;
+            $date = null;
+
+            if (preg_match('/\d+\.\d+\.\d+/', $ds5Data, $verMatch)) {
+                $version = $verMatch[0];
+            }
+
+            if (preg_match_all('/(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d+, \d{4}/', $ds5Data, $dateMatches)) {
+                $date = end($dateMatches[0]);
+            }
+
+            if (!$version || !$date) {
+                return null;
+            }
+
+            return ['version' => $version, 'date' => $date];
+        } catch (\Exception $e) {
+            Log::error("AppVersionFetcher: Android fetch exception", ['error' => $e->getMessage(), 'packageId' => $packageId]);
+            return null;
+        }
+    }
+
+    private function storeConfig(string $key, string $value): void
+    {
+        DB::table('config')->upsert(
+            ['key' => $key, 'value' => $value],
+            ['key'],
+            ['value']
+        );
+    }
+}

--- a/iznik-batch/app/Services/CommonDomainsService.php
+++ b/iznik-batch/app/Services/CommonDomainsService.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+class CommonDomainsService
+{
+    public function updateCommonDomains(): array
+    {
+        $emails = DB::table('users_emails')->pluck('email');
+        $total = $emails->count();
+
+        Log::info("CommonDomains: Found {$total} emails");
+
+        $count = 0;
+        $domains = [];
+
+        foreach ($emails as $email) {
+            $p = strpos($email, '@');
+
+            if ($p > 0) {
+                $domain = substr($email, $p + 1);
+                $domains[$domain] = ($domains[$domain] ?? 0) + 1;
+            }
+
+            $count++;
+
+            if ($count % 1000 === 0) {
+                Log::info("CommonDomains: ...{$count} / {$total}");
+            }
+        }
+
+        Log::info('CommonDomains: Got ' . count($domains) . ' domains');
+
+        $inserted = 0;
+
+        foreach ($domains as $domain => $domainCount) {
+            if ($domainCount > 1000) {
+                DB::table('domains_common')->upsert(
+                    ['domain' => $domain, 'count' => $domainCount],
+                    ['domain'],
+                    ['count']
+                );
+                $inserted++;
+            }
+        }
+
+        return ['domains_inserted' => $inserted];
+    }
+}

--- a/iznik-batch/app/Services/GroupMaintenanceService.php
+++ b/iznik-batch/app/Services/GroupMaintenanceService.php
@@ -49,8 +49,8 @@ class GroupMaintenanceService
     /**
      * Fix locations where latitude and longitude are swapped.
      *
-     * UK locations should have lat < lng (lat ~50-60, lng ~-8 to 2).
-     * When lat > lng, the coordinates are likely swapped.
+     * UK locations should have lat > lng (lat ~50-60, lng ~-8 to +2).
+     * When lat < lng, the coordinates are likely swapped.
      * Excludes BF (British Forces) postcodes which may legitimately have lat > lng.
      *
      * Also fixes any messages referencing the affected locations.

--- a/iznik-batch/app/Services/GroupStatsService.php
+++ b/iznik-batch/app/Services/GroupStatsService.php
@@ -1,0 +1,262 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+class GroupStatsService
+{
+    private const SRID = 3857;
+    private const STATS_TYPE_APPROVED_MESSAGE_COUNT = 'ApprovedMessageCount';
+    private const STATS_TYPE_OUTCOMES = 'Outcomes';
+    private const GROUP_TYPE_FREEGLE = 'Freegle';
+    private const DONATION_TARGET = 2000;
+    private const ACTIVE_DAYS = 30;
+    private const OUTCOMES_MONTHS = 13;
+
+    public function updateGroupStats(): array
+    {
+        $repostsFixed = $this->fixRepostSettings();
+        $polyindexFixed = $this->fixPolyindex();
+        $this->updateActivityAndFunding();
+        $this->updateLastModerated();
+        $this->updateLastAutoApprove();
+        $this->updateActiveOwnerModCounts();
+        $statsOutcomesUpdated = $this->updateStatsOutcomes();
+
+        Log::info("GroupStats: reposts={$repostsFixed}, polyindex={$polyindexFixed}, outcomes={$statsOutcomesUpdated}");
+
+        return [
+            'reposts_fixed' => $repostsFixed,
+            'polyindex_fixed' => $polyindexFixed,
+            'stats_outcomes_updated' => $statsOutcomesUpdated,
+        ];
+    }
+
+    private function fixRepostSettings(): int
+    {
+        $groups = DB::table('groups')->select('id', 'nameshort', 'settings')->get();
+        $count = 0;
+
+        foreach ($groups as $group) {
+            if (!$group->settings) {
+                continue;
+            }
+
+            $settings = json_decode($group->settings, true);
+            if (!isset($settings['reposts'])) {
+                continue;
+            }
+
+            $changed = false;
+            foreach ($settings['reposts'] as $key => $val) {
+                if (!is_int($val)) {
+                    $settings['reposts'][$key] = (int) $val;
+                    $changed = true;
+                }
+            }
+
+            if ($changed) {
+                DB::table('groups')->where('id', $group->id)->update(['settings' => json_encode($settings)]);
+                $count++;
+            }
+        }
+
+        return $count;
+    }
+
+    private function fixPolyindex(): int
+    {
+        $count = 0;
+
+        $groups = DB::table('groups')->select('id', 'nameshort')->get();
+
+        foreach ($groups as $group) {
+            $row = DB::selectOne(
+                "SELECT ST_AsText(polyindex) AS current, ST_AsText(ST_GeomFromText(COALESCE(poly, polyofficial, 'POINT(0 0)'), ?)) AS geomtext FROM `groups` WHERE id = ?",
+                [self::SRID, $group->id]
+            );
+
+            if ($row && $row->current !== $row->geomtext) {
+                DB::statement(
+                    "UPDATE `groups` SET polyindex = ST_GeomFromText(?, ?) WHERE id = ?",
+                    [$row->geomtext, self::SRID, $group->id]
+                );
+                $count++;
+            }
+        }
+
+        return $count;
+    }
+
+    private function updateActivityAndFunding(): void
+    {
+        $cutoff = date('Y-m-d', strtotime(self::ACTIVE_DAYS . ' days ago'));
+
+        $totalResult = DB::table('stats')
+            ->join('groups', 'stats.groupid', '=', 'groups.id')
+            ->where('stats.type', self::STATS_TYPE_APPROVED_MESSAGE_COUNT)
+            ->where('groups.type', self::GROUP_TYPE_FREEGLE)
+            ->where('groups.publish', 1)
+            ->where('groups.onhere', 1)
+            ->where('stats.date', '>=', $cutoff)
+            ->sum('stats.count');
+
+        if (!$totalResult) {
+            return;
+        }
+
+        $groups = DB::table('groups')
+            ->where('type', self::GROUP_TYPE_FREEGLE)
+            ->where('publish', 1)
+            ->where('onhere', 1)
+            ->orderByRaw('LOWER(nameshort) ASC')
+            ->pluck('id');
+
+        foreach ($groups as $groupId) {
+            $groupCount = DB::table('stats')
+                ->where('type', self::STATS_TYPE_APPROVED_MESSAGE_COUNT)
+                ->where('groupid', $groupId)
+                ->where('date', '>=', $cutoff)
+                ->sum('count');
+
+            $pc = 100 * $groupCount / $totalResult;
+
+            $portion = (int) ceil($pc * self::DONATION_TARGET / 100) * 10;
+            $portion = max(50, $portion);
+
+            DB::table('groups')->where('id', $groupId)->update([
+                'activitypercent' => $pc,
+                'fundingtarget' => $portion,
+            ]);
+        }
+    }
+
+    private function updateLastModerated(): void
+    {
+        $groups = DB::table('groups')->pluck('id');
+
+        foreach ($groups as $groupId) {
+            $max = DB::table('messages_groups')
+                ->where('groupid', $groupId)
+                ->whereNotNull('approvedby')
+                ->max('approvedat');
+
+            DB::table('groups')->where('id', $groupId)->update(['lastmoderated' => $max]);
+        }
+    }
+
+    private function updateLastAutoApprove(): void
+    {
+        $groups = DB::table('groups')->select('id', 'lastautoapprove')->get();
+
+        foreach ($groups as $group) {
+            $timeq = $group->lastautoapprove
+                ? ["AND timestamp >= ?", [$group->lastautoapprove]]
+                : ["", []];
+
+            $max = DB::table('logs')
+                ->where('groupid', $group->id)
+                ->where('type', 'Message')
+                ->where('subtype', 'Autoapproved')
+                ->when($group->lastautoapprove, fn ($q) => $q->where('timestamp', '>=', $group->lastautoapprove))
+                ->max('timestamp');
+
+            if ($max) {
+                DB::table('groups')
+                    ->where('id', $group->id)
+                    ->where(function ($q) use ($max) {
+                        $q->whereNull('lastautoapprove')->orWhere('lastautoapprove', '<', $max);
+                    })
+                    ->update(['lastautoapprove' => $max]);
+            }
+        }
+    }
+
+    private function updateActiveOwnerModCounts(): void
+    {
+        $start = date('Y-m-d', strtotime(self::ACTIVE_DAYS . ' days ago'));
+        $groups = DB::table('groups')->pluck('id');
+
+        foreach ($groups as $groupId) {
+            $ownerCount = DB::table('users')
+                ->join('memberships', 'memberships.userid', '=', 'users.id')
+                ->where('memberships.groupid', $groupId)
+                ->where('memberships.role', 'Owner')
+                ->where('users.lastaccess', '>', $start)
+                ->distinct()
+                ->count('users.id');
+
+            $modCount = DB::table('users')
+                ->join('memberships', 'memberships.userid', '=', 'users.id')
+                ->where('memberships.groupid', $groupId)
+                ->where('memberships.role', 'Moderator')
+                ->where('users.lastaccess', '>', $start)
+                ->distinct()
+                ->count('users.id');
+
+            // Owners active on OTHER groups but not this one.
+            $backupOwners = DB::table('memberships')
+                ->where('memberships.groupid', $groupId)
+                ->whereIn('memberships.role', ['Owner'])
+                ->whereNotIn('memberships.userid', function ($sub) use ($groupId, $start) {
+                    $sub->select('approvedby')->from('messages_groups')
+                        ->where('groupid', $groupId)->where('arrival', '>', $start)->whereNotNull('approvedby');
+                })
+                ->whereIn('memberships.userid', function ($sub) use ($groupId, $start) {
+                    $sub->select('approvedby')->from('messages_groups')
+                        ->where('groupid', '!=', $groupId)->where('arrival', '>', $start)->whereNotNull('approvedby');
+                })
+                ->distinct('userid')
+                ->count('userid');
+
+            $backupMods = DB::table('memberships')
+                ->where('memberships.groupid', $groupId)
+                ->whereIn('memberships.role', ['Moderator'])
+                ->whereNotIn('memberships.userid', function ($sub) use ($groupId, $start) {
+                    $sub->select('approvedby')->from('messages_groups')
+                        ->where('groupid', $groupId)->where('arrival', '>', $start)->whereNotNull('approvedby');
+                })
+                ->whereIn('memberships.userid', function ($sub) use ($groupId, $start) {
+                    $sub->select('approvedby')->from('messages_groups')
+                        ->where('groupid', '!=', $groupId)->where('arrival', '>', $start)->whereNotNull('approvedby');
+                })
+                ->distinct('userid')
+                ->count('userid');
+
+            DB::table('groups')->where('id', $groupId)->update([
+                'activeownercount' => $ownerCount,
+                'activemodcount' => $modCount,
+                'backupownersactive' => $backupOwners,
+                'backupmodsactive' => $backupMods,
+            ]);
+        }
+    }
+
+    private function updateStatsOutcomes(): int
+    {
+        $cutoff = date('Y-m-01', strtotime(self::OUTCOMES_MONTHS . ' months ago'));
+
+        $stats = DB::table('stats')
+            ->where('type', self::STATS_TYPE_OUTCOMES)
+            ->where('date', '>', $cutoff)
+            ->selectRaw("groupid, SUM(count) AS count, CONCAT(YEAR(date), '-', LPAD(MONTH(date), 2, '0')) AS month_date")
+            ->groupByRaw('groupid, YEAR(date), MONTH(date)')
+            ->get();
+
+        $count = 0;
+        foreach ($stats as $stat) {
+            if ($stat->count) {
+                DB::table('stats_outcomes')->upsert(
+                    ['groupid' => $stat->groupid, 'count' => $stat->count, 'date' => $stat->month_date],
+                    ['groupid', 'date'],
+                    ['count']
+                );
+                $count++;
+            }
+        }
+
+        return $count;
+    }
+}

--- a/iznik-batch/app/Services/JobIllustrationsService.php
+++ b/iznik-batch/app/Services/JobIllustrationsService.php
@@ -1,0 +1,282 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+class JobIllustrationsService
+{
+    private const BATCH_SIZE = 5;
+
+    /**
+     * Canonical job categories mapped to their iconic object for image generation.
+     * Kept in sync with iznik-server/include/misc/Pollinations.php CANONICAL_JOBS.
+     */
+    public const CANONICAL_JOBS = [
+        'Accountant' => 'calculator',
+        'Account Manager' => 'briefcase',
+        'Activities Coordinator' => 'clipboard',
+        'Administrator' => 'filing cabinet',
+        'Architect' => 'blueprint',
+        'Area Manager' => 'map with pins',
+        'Assistant Manager' => 'name badge',
+        'Bartender' => 'cocktail shaker',
+        'Bid Manager' => 'sealed envelope',
+        'Bookkeeper' => 'ledger book',
+        'Branch Manager' => 'desk nameplate',
+        'Bricklayer' => 'brick trowel',
+        'Building Inspector' => 'spirit level',
+        'Building Surveyor' => 'theodolite',
+        'Bus Driver' => 'steering wheel',
+        'Business Analyst' => 'flowchart diagram',
+        'Business Development Manager' => 'handshake icon',
+        'Buyer' => 'purchase order',
+        'CAD Technician' => 'technical drawing',
+        'Care Assistant' => 'stethoscope',
+        'Care Coordinator' => 'care plan folder',
+        'Care Worker' => 'medical gloves',
+        'Carpenter' => 'wood plane',
+        'Cashier' => 'cash register',
+        'Catering Assistant' => 'serving tray',
+        'Chef' => 'chef hat',
+        'Cleaner' => 'mop and bucket',
+        'Clinical Assessor' => 'medical clipboard',
+        'CNC Machinist' => 'CNC milling machine',
+        'Communications Engineer' => 'satellite dish',
+        'Compliance Officer' => 'checklist on clipboard',
+        'Construction Manager' => 'hard hat',
+        'Contracts Manager' => 'signed contract',
+        'Cook' => 'saucepan',
+        'Counsellor' => 'comfortable armchair',
+        'Credit Controller' => 'invoice stamp',
+        'Customer Service Advisor' => 'headset',
+        'Data Analyst' => 'bar chart',
+        'Data Architect' => 'database server',
+        'Data Engineer' => 'data pipeline diagram',
+        'Delivery Driver' => 'delivery van',
+        'Dental Nurse' => 'dental mirror',
+        'Deputy Manager' => 'deputy badge',
+        'Design Engineer' => 'engineering compass',
+        'Design Manager' => 'design palette',
+        'Digital Marketing Executive' => 'computer screen with analytics',
+        'Document Controller' => 'document folder',
+        'Door Canvasser' => 'clipboard with petition',
+        'Ecologist' => 'binoculars',
+        'Electrical Engineer' => 'circuit board',
+        'Electrician' => 'wire strippers',
+        'Embedded Software Engineer' => 'microchip',
+        'Engineering Apprentice' => 'spanner set',
+        'Estimator' => 'measuring tape and calculator',
+        'Factory Operative' => 'conveyor belt',
+        'Female Support Worker' => 'support badge',
+        'Field Sales Representative' => 'sales sample case',
+        'Field Service Engineer' => 'tool bag',
+        'Finance Assistant' => 'spreadsheet printout',
+        'Finance Business Partner' => 'financial report',
+        'Finance Manager' => 'balance sheet',
+        'Financial Controller' => 'accounting ledger',
+        'Forklift Driver' => 'forklift',
+        'Fundraiser' => 'collection tin',
+        'Gas Engineer' => 'gas boiler',
+        'General Manager' => 'office desk',
+        'Groundworker' => 'shovel',
+        'Head of Finance' => 'financial dashboard',
+        'Head of Marketing' => 'megaphone',
+        'Healthcare Assistant' => 'blood pressure monitor',
+        'HGV Class 1 Driver' => 'articulated lorry',
+        'HGV Class 2 Driver' => 'rigid lorry',
+        'HGV Technician' => 'truck engine',
+        'Home Manager' => 'care home building',
+        'Housekeeper' => 'vacuum cleaner',
+        'HR Advisor' => 'employee handbook',
+        'HR Business Partner' => 'HR policy document',
+        'Installer' => 'power drill',
+        'IT Support' => 'computer keyboard',
+        'IT Apprentice' => 'laptop computer',
+        'Kitchen Assistant' => 'kitchen knife set',
+        'Kitchen Designer' => 'kitchen floor plan',
+        'Labourer' => 'wheelbarrow',
+        'Lecturer' => 'lectern',
+        'Legal Secretary' => 'legal documents',
+        'Lifeguard' => 'lifeguard float',
+        'Machine Learning Engineer' => 'neural network diagram',
+        'Machine Operator' => 'industrial machine',
+        'Maintenance Electrician' => 'multimeter',
+        'Maintenance Engineer' => 'wrench and gears',
+        'Maintenance Manager' => 'maintenance toolkit',
+        'Maintenance Technician' => 'toolbox',
+        'Management Accountant' => 'financial spreadsheet',
+        'Manufacturing Engineer' => 'factory robot arm',
+        'Marketing Manager' => 'marketing campaign board',
+        'Maths Teacher' => 'protractor and compass',
+        'Mechanical Design Engineer' => 'mechanical gear drawing',
+        'Mechanical Engineer' => 'mechanical gears',
+        'Mechanical Fitter' => 'pipe wrench',
+        'Mechanic' => 'car jack',
+        'Mobile Tyre Fitter' => 'tyre and wheel',
+        'Mortgage Advisor' => 'house keys',
+        'Multi Trade Operative' => 'multi-tool',
+        'Nursery Manager' => 'toy building blocks',
+        'Nursery Practitioner' => 'childrens storybook',
+        'Nurse' => 'nurses cap',
+        'Operations Manager' => 'operations dashboard',
+        'Painter' => 'paint roller',
+        'Parts Advisor' => 'car parts catalogue',
+        'Passenger Assistant' => 'bus ticket machine',
+        'Payroll Administrator' => 'payslip',
+        'Payroll Specialist' => 'payroll software screen',
+        'Personal Advisor' => 'advisory notepad',
+        'Planning Officer' => 'town plan',
+        'Plasterer' => 'plastering trowel',
+        'Plumber' => 'pipe wrench and pipes',
+        'Primary Teacher' => 'school bell',
+        'Production Manager' => 'production line',
+        'Production Operative' => 'assembly line component',
+        'Production Supervisor' => 'quality control gauge',
+        'Project Engineer' => 'project gantt chart',
+        'Project Manager' => 'project plan board',
+        'Property Manager' => 'set of property keys',
+        'Quality Engineer' => 'caliper gauge',
+        'Quality Inspector' => 'magnifying glass',
+        'Quality Manager' => 'quality certificate',
+        'Quantity Surveyor' => 'measuring tape and blueprints',
+        'Reach Truck Driver' => 'reach truck',
+        'Receptionist' => 'reception desk bell',
+        'Recruitment Consultant' => 'CV document',
+        'Refrigeration Engineer' => 'refrigeration unit',
+        'Regional Sales Manager' => 'sales territory map',
+        'Registered Manager' => 'care home registration certificate',
+        'Research Associate' => 'microscope',
+        'Residential Support Worker' => 'house key with lanyard',
+        'Restaurant Team Member' => 'restaurant order pad',
+        'Roofer' => 'roofing hammer',
+        'Rough Sleeping Outreach Worker' => 'sleeping bag',
+        'Sales Administrator' => 'sales order form',
+        'Sales Advisor' => 'price tag',
+        'Sales Consultant' => 'sales presentation',
+        'Sales Engineer' => 'technical sales brochure',
+        'Sales Executive' => 'business card',
+        'Sales Manager' => 'sales trophy',
+        'Sales Representative' => 'product sample kit',
+        'Scaffolder' => 'scaffolding poles',
+        'School Crossing Patrol' => 'lollipop stop sign',
+        'Science Teacher' => 'laboratory flask',
+        'Security Officer' => 'security badge',
+        'SEN Teacher' => 'special education resource kit',
+        'Senior Care Assistant' => 'medication trolley',
+        'Service Advisor' => 'service desk terminal',
+        'Service Engineer' => 'service toolbox',
+        'Service Manager' => 'service level agreement',
+        'Shift Engineer' => 'shift rota board',
+        'Shift Leader' => 'team leader whistle',
+        'Site Manager' => 'site plan',
+        'Social Worker' => 'case file folder',
+        'Software Engineer' => 'computer code on screen',
+        'Solution Architect' => 'architecture diagram',
+        'Store Manager' => 'retail shop front',
+        'Structural Engineer' => 'structural beam drawing',
+        'Supervisor' => 'supervisor clipboard',
+        'Supply Teacher' => 'classroom whiteboard',
+        'Support Worker' => 'support lanyard badge',
+        'Teaching Assistant' => 'school exercise book',
+        'Team Leader' => 'team whiteboard',
+        'Technical Author' => 'technical manual',
+        'Tiler' => 'tile cutter',
+        'Transport Manager' => 'fleet management board',
+        'Transport Planner' => 'route map',
+        'Van Driver' => 'white van',
+        'Vehicle Technician' => 'car diagnostic tool',
+        'Warehouse Operative' => 'pallet of boxes',
+        'Welder' => 'welding mask',
+        'Window Installer' => 'window frame',
+        'Workshop Controller' => 'workshop job board',
+        'Workshop Technician' => 'workshop bench',
+    ];
+
+    public function __construct(private PollinationsService $pollinations) {}
+
+    /**
+     * Generate AI illustrations for canonical job categories that are missing images.
+     *
+     * @return array{processed: int, remaining: int}
+     */
+    public function processIllustrations(): array
+    {
+        $processed = 0;
+
+        while (true) {
+            $allNames = array_keys(self::CANONICAL_JOBS);
+            $existing = DB::table('ai_images')
+                ->whereIn('name', $allNames)
+                ->pluck('name')
+                ->toArray();
+
+            $missing = array_diff($allNames, $existing);
+
+            if (empty($missing)) {
+                break;
+            }
+
+            $batch = array_slice($missing, 0, self::BATCH_SIZE);
+            $batchItems = [];
+
+            foreach ($batch as $title) {
+                if ($this->pollinations->shouldSkipItem($title)) {
+                    Log::info("JobIllustrations: skipping '{$title}' due to previous failures");
+                    continue;
+                }
+
+                $object = self::CANONICAL_JOBS[$title];
+                $batchItems[] = [
+                    'name' => $title,
+                    'prompt' => $this->pollinations->buildJobPrompt($object),
+                    'width' => 200,
+                    'height' => 200,
+                    'msgid' => null,
+                ];
+            }
+
+            if (empty($batchItems)) {
+                break;
+            }
+
+            $batchResult = $this->pollinations->fetchBatch($batchItems, 120);
+
+            if ($batchResult === false) {
+                foreach ($batchItems as $item) {
+                    $this->pollinations->recordFailure($item['name']);
+                }
+                Log::warning('JobIllustrations: batch rate-limited');
+                break;
+            }
+
+            foreach ($batchResult['failed'] as $failedName => $dummy) {
+                $this->pollinations->recordFailure($failedName);
+            }
+
+            foreach ($batchResult['results'] as $result) {
+                $title = $result['name'];
+                $imageData = $result['data'];
+                $hash = $result['hash'];
+
+                $uid = $this->pollinations->uploadImageAndCache($title, $imageData, $hash);
+                if ($uid) {
+                    $processed++;
+                    Log::info("JobIllustrations: created illustration for '{$title}': {$uid}");
+                }
+            }
+
+            if (empty($batchResult['results']) && empty($batchResult['failed'])) {
+                break;
+            }
+        }
+
+        $remaining = count(array_diff(
+            array_keys(self::CANONICAL_JOBS),
+            DB::table('ai_images')->whereIn('name', array_keys(self::CANONICAL_JOBS))->pluck('name')->toArray()
+        ));
+
+        return ['processed' => $processed, 'remaining' => $remaining];
+    }
+}

--- a/iznik-batch/app/Services/LoveJunkService.php
+++ b/iznik-batch/app/Services/LoveJunkService.php
@@ -1,0 +1,314 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+class LoveJunkService
+{
+    private string $apiUrl;
+    private string $secret;
+
+    public function __construct()
+    {
+        $this->apiUrl = config('freegle.lovejunk.api', '');
+        $this->secret = config('freegle.lovejunk.secret', '');
+    }
+
+    public function sync(): array
+    {
+        $result = ['sent' => 0, 'edited' => 0, 'completed_or_deleted' => 0, 'failed' => 0];
+        $since = now()->subDay()->toDateString();
+
+        $edited = DB::select("
+            SELECT DISTINCT messages.id, lovejunk.status
+            FROM messages
+            INNER JOIN lovejunk ON lovejunk.msgid = messages.id
+            INNER JOIN messages_groups ON messages_groups.msgid = messages.id
+            INNER JOIN messages_edits ON messages_edits.msgid = messages.id
+            INNER JOIN `groups` ON groups.id = messages_groups.groupid
+            WHERE messages.arrival >= ?
+              AND messages_edits.timestamp > lovejunk.timestamp
+              AND messages.type = 'Offer'
+              AND messages_groups.collection = 'Approved'
+              AND groups.onlovejunk = 1
+            ORDER BY messages.arrival ASC
+        ", [$since]);
+
+        foreach ($edited as $msg) {
+            $lj = json_decode($msg->status, true);
+            if ($lj && isset($lj['draftId'])) {
+                $this->editMessage($msg->id, $lj['draftId']);
+                $result['edited']++;
+            }
+        }
+
+        $newMsgs = DB::select("
+            SELECT messages.id
+            FROM messages
+            LEFT JOIN lovejunk ON lovejunk.msgid = messages.id
+            INNER JOIN messages_groups ON messages_groups.msgid = messages.id
+            INNER JOIN `groups` ON groups.id = messages_groups.groupid
+            WHERE messages.arrival >= ?
+              AND messages.type = 'Offer'
+              AND lovejunk.msgid IS NULL
+              AND messages_groups.collection = 'Approved'
+              AND groups.onlovejunk = 1
+            ORDER BY messages.arrival ASC
+        ", [$since]);
+
+        foreach ($newMsgs as $msg) {
+            if ($this->sendMessage($msg->id)) {
+                $result['sent']++;
+            } else {
+                $result['failed']++;
+            }
+        }
+
+        $withOutcomes = DB::select("
+            SELECT DISTINCT messages.id
+            FROM messages_outcomes
+            INNER JOIN messages ON messages.id = messages_outcomes.msgid
+            INNER JOIN messages_groups ON messages_groups.msgid = messages.id
+            INNER JOIN lovejunk ON lovejunk.msgid = messages_outcomes.msgid
+            INNER JOIN `groups` ON groups.id = messages_groups.groupid
+            WHERE messages_outcomes.timestamp >= ?
+              AND messages.type = 'Offer'
+              AND lovejunk.success = 1
+              AND lovejunk.deleted IS NULL
+              AND lovejunk.status LIKE '{%'
+              AND groups.onlovejunk = 1
+            ORDER BY messages.arrival ASC
+        ", [$since]);
+
+        foreach ($withOutcomes as $msg) {
+            $this->completeOrDelete($msg->id);
+            $result['completed_or_deleted']++;
+        }
+
+        return $result;
+    }
+
+    private function sendMessage(int $msgId): bool
+    {
+        $data = $this->buildPayload($msgId);
+
+        if ($data === null) {
+            Log::warning("LoveJunk: cannot send message $msgId, missing required data");
+            $this->recordResult(false, $msgId, 'Missing required data');
+            return false;
+        }
+
+        try {
+            $response = Http::post($this->buildUrl('/freegle/drafts'), $data);
+
+            if ($response->successful()) {
+                $body = $response->json('body', []);
+                $this->recordResult(true, $msgId, json_encode($body));
+                return true;
+            }
+
+            Log::error("LoveJunk: failed to send message $msgId", ['status' => $response->status()]);
+            $this->recordResult(false, $msgId, $response->status() . ' ' . $response->body());
+        } catch (\Exception $e) {
+            Log::error("LoveJunk: exception sending message $msgId: " . $e->getMessage());
+            $this->recordResult(false, $msgId, $e->getMessage());
+        }
+
+        return false;
+    }
+
+    private function editMessage(int $msgId, string $draftId): bool
+    {
+        $data = $this->buildPayload($msgId) ?? [];
+
+        DB::table('lovejunk')->where('msgid', $msgId)->update(['timestamp' => now()]);
+
+        try {
+            $response = Http::put($this->buildUrl('/freegle/drafts/' . $draftId), $data);
+            return $response->successful() || $response->status() === 410;
+        } catch (\Exception $e) {
+            Log::error("LoveJunk: exception editing message $msgId: " . $e->getMessage());
+            return false;
+        }
+    }
+
+    private function completeOrDelete(int $msgId): void
+    {
+        $fromUser = DB::table('messages')->where('id', $msgId)->value('fromuser');
+
+        $promises = DB::select("
+            SELECT mp.userid, u.ljuserid
+            FROM messages_promises mp
+            INNER JOIN users u ON u.id = mp.userid
+            WHERE mp.msgid = ? AND u.ljuserid IS NOT NULL
+        ", [$msgId]);
+
+        $completed = false;
+
+        foreach ($promises as $promise) {
+            $chatRoom = DB::table('chat_rooms')
+                ->whereNotNull('ljofferid')
+                ->where(function ($q) use ($fromUser, $promise) {
+                    $q->where(function ($inner) use ($fromUser, $promise) {
+                        $inner->where('user1', $fromUser)->where('user2', $promise->userid);
+                    })->orWhere(function ($inner) use ($fromUser, $promise) {
+                        $inner->where('user1', $promise->userid)->where('user2', $fromUser);
+                    });
+                })
+                ->first();
+
+            if ($chatRoom) {
+                $this->completeOffer((int) $chatRoom->id, $msgId, (string) $chatRoom->ljofferid);
+                $completed = true;
+            }
+        }
+
+        if (!$completed) {
+            $this->deleteOffer($msgId);
+        }
+    }
+
+    private function completeOffer(int $chatId, int $msgId, string $ljOfferId): void
+    {
+        try {
+            $response = Http::post($this->buildUrl('/freegle/offers/' . $ljOfferId . '/complete'));
+            $statusStr = json_encode($response->status() . ' ' . $response->reason());
+        } catch (\Exception $e) {
+            $statusStr = json_encode($e->getMessage());
+        }
+
+        DB::table('lovejunk')
+            ->where('msgid', $msgId)
+            ->update(['deleted' => now(), 'deletestatus' => $statusStr]);
+    }
+
+    private function deleteOffer(int $msgId): void
+    {
+        $lj = DB::table('lovejunk')->where('msgid', $msgId)->where('success', 1)->first();
+
+        if (!$lj) {
+            return;
+        }
+
+        $status = json_decode($lj->status, true);
+
+        if (!isset($status['draftId'])) {
+            return;
+        }
+
+        try {
+            $response = Http::delete($this->buildUrl('/freegle/drafts/' . $status['draftId']));
+            $statusStr = json_encode($response->status() . ' ' . $response->reason());
+        } catch (\Exception $e) {
+            $statusStr = json_encode($e->getMessage());
+        }
+
+        DB::table('lovejunk')
+            ->where('msgid', $msgId)
+            ->update(['deleted' => now(), 'deletestatus' => $statusStr]);
+    }
+
+    private function buildPayload(int $msgId): ?array
+    {
+        $msg = DB::selectOne("
+            SELECT m.id, m.textbody, m.fromuser, m.locationid, m.lat, m.lng,
+                   m.sourceheader, m.subject, m.type,
+                   i.name as item,
+                   u.fullname, u.firstname, u.lastname,
+                   l.name as postcode,
+                   la.name as area
+            FROM messages m
+            LEFT JOIN messages_items mi ON mi.msgid = m.id
+            LEFT JOIN items i ON i.id = mi.itemid
+            LEFT JOIN users u ON u.id = m.fromuser
+            LEFT JOIN locations l ON l.id = m.locationid
+            LEFT JOIN locations la ON la.id = l.areaid
+            WHERE m.id = ?
+            LIMIT 1
+        ", [$msgId]);
+
+        if (!$msg) {
+            return null;
+        }
+
+        $item = $msg->item;
+
+        if (!$item && $msg->subject) {
+            if (preg_match('/.*(OFFER|WANTED|TAKEN|RECEIVED) *[:\\-](.*)\\(.*\\)/', $msg->subject, $matches)) {
+                $item = trim($matches[2]);
+            }
+        }
+
+        $postcode = $msg->postcode;
+
+        if (!$postcode || !$item || $msg->type !== 'Offer') {
+            return null;
+        }
+
+        $lat = $msg->lat !== null ? round((float) $msg->lat, 3) : null;
+        $lng = $msg->lng !== null ? round((float) $msg->lng, 3) : null;
+
+        $source = str_starts_with((string) $msg->sourceheader, 'TN-') ? 'trashnothing' : 'freegle';
+
+        $firstName = $msg->fullname ?: $msg->firstname;
+        $lastName = $msg->fullname ? ' ' : ($msg->lastname ?? '');
+
+        $images = null;
+        $attachments = DB::table('messages_attachments')
+            ->where('msgid', $msgId)
+            ->whereNotNull('externaluid')
+            ->get(['externaluid']);
+
+        if ($attachments->isNotEmpty()) {
+            $tusBase = config('freegle.tus_uploader');
+            $images = [];
+            foreach ($attachments as $att) {
+                $uid = $att->externaluid;
+                if (str_starts_with($uid, 'freegletusd-')) {
+                    $suffix = substr($uid, strlen('freegletusd-'));
+                    $images[] = ['url' => $tusBase . '/' . $suffix . '/'];
+                }
+            }
+        }
+
+        return [
+            'freegleId' => $msgId,
+            'title' => $item,
+            'description' => $msg->textbody,
+            'source' => $source,
+            'userData' => [
+                'userId' => $msg->fromuser,
+                'firstName' => $firstName,
+                'lastName' => $lastName,
+            ],
+            'locationData' => [
+                'postcode' => $postcode,
+                'latitude' => $lat,
+                'longitude' => $lng,
+                'area' => $msg->area,
+            ],
+            'images' => $images,
+        ];
+    }
+
+    private function buildUrl(string $path): string
+    {
+        $url = $this->apiUrl . $path;
+        if ($this->secret) {
+            $url .= '?secret=' . $this->secret;
+        }
+        return $url;
+    }
+
+    private function recordResult(bool $success, int $msgId, string $status): void
+    {
+        DB::table('lovejunk')->upsert(
+            ['msgid' => $msgId, 'success' => $success ? 1 : 0, 'status' => $status],
+            ['msgid'],
+            ['success', 'status']
+        );
+    }
+}

--- a/iznik-batch/app/Services/MessageDeindexService.php
+++ b/iznik-batch/app/Services/MessageDeindexService.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\MessageGroup;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+class MessageDeindexService
+{
+    public function deindexOldMessages(): array
+    {
+        $date = now()->subDays(30)->format('Y-m-d');
+
+        $msgids = DB::table('messages_groups')
+            ->join('messages_index', 'messages_index.msgid', '=', 'messages_groups.msgid')
+            ->where('messages_groups.collection', MessageGroup::COLLECTION_APPROVED)
+            ->where('messages_groups.arrival', '<', $date)
+            ->distinct()
+            ->pluck('messages_groups.msgid');
+
+        Log::info("MessageDeindex: deindexing {$msgids->count()} messages");
+
+        $done = 0;
+
+        foreach ($msgids->chunk(500) as $chunk) {
+            DB::table('messages_index')->whereIn('msgid', $chunk)->delete();
+            $done += count($chunk);
+            Log::info("MessageDeindex: ...{$done} / {$msgids->count()}");
+        }
+
+        DB::table('words_cache')->delete();
+
+        return ['deindexed' => $done];
+    }
+}

--- a/iznik-batch/app/Services/MessageExpiryService.php
+++ b/iznik-batch/app/Services/MessageExpiryService.php
@@ -51,9 +51,10 @@ class MessageExpiryService
                 }
 
                 $this->markAsExpired($message);
-                $this->sendDeadlineNotification($message);
+                if ($this->sendDeadlineNotification($message)) {
+                    $stats['emails_sent']++;
+                }
                 $stats['processed']++;
-                $stats['emails_sent']++;
             } catch (\Exception $e) {
                 Log::error("Error processing expired message {$message->id}: " . $e->getMessage());
                 $stats['errors']++;
@@ -70,21 +71,26 @@ class MessageExpiryService
     {
         $earliestDate = now()->subDays(self::EXPIRE_LOOKBACK_DAYS);
 
-        return Message::select('messages.*', 'messages_groups.groupid')
+        return Message::select('messages.*')
             ->join('messages_groups', 'messages_groups.msgid', '=', 'messages.id')
             ->leftJoin('messages_outcomes', 'messages_outcomes.msgid', '=', 'messages.id')
             ->where('messages.arrival', '>=', $earliestDate)
             ->whereNotNull('messages.deadline')
             ->whereRaw('messages.deadline < CURDATE()')
             ->whereNull('messages_outcomes.id')
+            ->distinct()
             ->get();
     }
 
     /**
      * Mark a message as expired.
+     *
+     * V1 mark() also clears messages_outcomes_intended first — replicate that.
      */
     protected function markAsExpired(Message $message): void
     {
+        DB::table('messages_outcomes_intended')->where('msgid', $message->id)->delete();
+
         MessageOutcome::create([
             'msgid' => $message->id,
             'outcome' => MessageOutcome::OUTCOME_EXPIRED,
@@ -97,16 +103,19 @@ class MessageExpiryService
 
     /**
      * Send a notification email about the deadline.
+     *
+     * Returns true if email was sent.
      */
-    protected function sendDeadlineNotification(Message $message): void
+    protected function sendDeadlineNotification(Message $message): bool
     {
         $user = $message->fromUser;
 
         if (!$user || !$user->email_preferred) {
-            return;
+            return false;
         }
 
         Mail::send(new DeadlineReached($message, $user));
+        return true;
     }
 
     /**

--- a/iznik-batch/app/Services/MessageIllustrationsService.php
+++ b/iznik-batch/app/Services/MessageIllustrationsService.php
@@ -1,0 +1,226 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+class MessageIllustrationsService
+{
+    private const BATCH_SIZE = 5;
+    private const CONFIG_KEY = 'illustrations_last_arrival';
+
+    public function __construct(private PollinationsService $pollinations) {}
+
+    /**
+     * Generate AI illustrations for messages that have no attachments.
+     *
+     * @return array{cleaned: int, processed: int}
+     */
+    public function processIllustrations(): array
+    {
+        $cleaned = $this->cleanupDuplicates();
+        $processed = $this->processBatches();
+
+        return ['cleaned' => $cleaned, 'processed' => $processed];
+    }
+
+    /**
+     * Remove AI illustrations from messages where the user has since added their own photo.
+     */
+    private function cleanupDuplicates(): int
+    {
+        $duplicates = DB::select("
+            SELECT DISTINCT ma_ai.id, ma_ai.msgid
+            FROM messages_attachments ma_ai
+            INNER JOIN messages_attachments ma_real ON ma_real.msgid = ma_ai.msgid
+            WHERE JSON_EXTRACT(ma_ai.externalmods, '$.ai') = TRUE
+            AND (
+                ma_real.externalmods IS NULL
+                OR JSON_EXTRACT(ma_real.externalmods, '$.ai') IS NULL
+                OR JSON_EXTRACT(ma_real.externalmods, '$.ai') = FALSE
+            )
+        ");
+
+        $count = 0;
+        foreach ($duplicates as $dup) {
+            DB::table('messages_attachments')->where('id', $dup->id)->delete();
+            $count++;
+
+            $hasPrimary = DB::table('messages_attachments')
+                ->where('msgid', $dup->msgid)
+                ->where('primary', 1)
+                ->exists();
+
+            if (! $hasPrimary) {
+                DB::statement(
+                    'UPDATE messages_attachments SET `primary` = 1 WHERE msgid = ? ORDER BY id ASC LIMIT 1',
+                    [$dup->msgid]
+                );
+            }
+        }
+
+        return $count;
+    }
+
+    private function processBatches(): int
+    {
+        $lastArrival = $this->getLastArrival();
+        $processed = 0;
+
+        while (true) {
+            $msgs = DB::select("
+                SELECT DISTINCT mg.msgid, m.subject, mg.arrival
+                FROM messages_groups mg
+                INNER JOIN messages m ON m.id = mg.msgid
+                INNER JOIN messages_spatial ms ON ms.msgid = mg.msgid
+                LEFT JOIN messages_attachments ma ON ma.msgid = m.id
+                LEFT JOIN messages_ai_declined maid ON maid.msgid = m.id
+                WHERE mg.arrival >= ?
+                AND mg.collection IN ('Approved', 'Pending')
+                AND ma.id IS NULL
+                AND maid.msgid IS NULL
+                AND m.subject IS NOT NULL
+                AND m.subject != ''
+                ORDER BY mg.arrival ASC, mg.msgid ASC
+                LIMIT ?
+            ", [$lastArrival, self::BATCH_SIZE * 2]);
+
+            if (empty($msgs)) {
+                break;
+            }
+
+            $cachedMessages = [];
+            $newMessages = [];
+            $maxArrival = $lastArrival;
+
+            foreach ($msgs as $msg) {
+                $arrival = $msg->arrival;
+                if ($arrival > $maxArrival) {
+                    $maxArrival = $arrival;
+                }
+
+                $itemName = $this->extractItemName($msg->subject);
+                if ($itemName === '') {
+                    continue;
+                }
+
+                if ($this->pollinations->shouldSkipItem($itemName)) {
+                    Log::info("MessageIllustrations: skipping '{$itemName}' due to previous failures");
+                    continue;
+                }
+
+                $cached = DB::table('ai_images')
+                    ->where('name', $itemName)
+                    ->whereNotNull('externaluid')
+                    ->value('externaluid');
+
+                if ($cached) {
+                    $cachedMessages[] = ['msgid' => $msg->msgid, 'itemName' => $itemName, 'uid' => $cached];
+                } elseif (count($newMessages) < self::BATCH_SIZE) {
+                    $newMessages[] = ['msgid' => $msg->msgid, 'itemName' => $itemName];
+                }
+            }
+
+            foreach ($cachedMessages as $cached) {
+                $hasAttachment = DB::table('messages_attachments')->where('msgid', $cached['msgid'])->exists();
+                if (! $hasAttachment) {
+                    DB::table('messages_attachments')->insert([
+                        'msgid' => $cached['msgid'],
+                        'externaluid' => $cached['uid'],
+                        'externalmods' => json_encode(['ai' => true]),
+                        'contenttype' => 'image/jpeg',
+                    ]);
+                    $processed++;
+                    Log::info("MessageIllustrations: used cached illustration for message {$cached['msgid']}: {$cached['itemName']}");
+                }
+            }
+
+            if (! empty($newMessages)) {
+                $batchItems = [];
+                foreach ($newMessages as $msg) {
+                    $batchItems[] = [
+                        'name' => $msg['itemName'],
+                        'prompt' => $this->pollinations->buildMessagePrompt($msg['itemName']),
+                        'width' => 640,
+                        'height' => 480,
+                        'msgid' => $msg['msgid'],
+                    ];
+                }
+
+                $batchResult = $this->pollinations->fetchBatch($batchItems, 120);
+
+                if ($batchResult === false) {
+                    foreach ($batchItems as $item) {
+                        $this->pollinations->recordFailure($item['name']);
+                    }
+                    Log::warning('MessageIllustrations: batch rate-limited');
+                    break;
+                }
+
+                foreach ($batchResult['failed'] as $failedName => $dummy) {
+                    $this->pollinations->recordFailure($failedName);
+                }
+
+                foreach ($batchResult['results'] as $result) {
+                    $msgid = $result['msgid'];
+                    $itemName = $result['name'];
+                    $imageData = $result['data'];
+                    $hash = $result['hash'];
+
+                    $hasAttachment = DB::table('messages_attachments')->where('msgid', $msgid)->exists();
+                    if ($hasAttachment) {
+                        continue;
+                    }
+
+                    $uid = $this->pollinations->uploadImageAndCache($itemName, $imageData, $hash);
+                    if ($uid) {
+                        DB::table('messages_attachments')->insert([
+                            'msgid' => $msgid,
+                            'externaluid' => $uid,
+                            'externalmods' => json_encode(['ai' => true]),
+                            'contenttype' => 'image/jpeg',
+                        ]);
+                        $processed++;
+                        Log::info("MessageIllustrations: created illustration for message {$msgid}: {$itemName}");
+                    }
+                }
+            }
+
+            if ($maxArrival > $lastArrival) {
+                $lastArrival = $maxArrival;
+                $this->setLastArrival($lastArrival);
+            }
+
+            if (empty($newMessages) && empty($cachedMessages)) {
+                break;
+            }
+        }
+
+        return $processed;
+    }
+
+    private function extractItemName(string $subject): string
+    {
+        $name = preg_replace('/^(OFFER|WANTED|TAKEN|RECEIVED):\s*/i', '', $subject);
+        $name = preg_replace('/\s*\([^)]+\)\s*$/', '', $name ?? '');
+
+        return trim($name ?? '');
+    }
+
+    private function getLastArrival(): string
+    {
+        $value = DB::table('config')->where('key', self::CONFIG_KEY)->value('value');
+
+        return $value ?? date('Y-m-d H:i:s', strtotime('-1 day'));
+    }
+
+    private function setLastArrival(string $arrival): void
+    {
+        DB::table('config')->upsert(
+            ['key' => self::CONFIG_KEY, 'value' => $arrival],
+            ['key'],
+            ['value']
+        );
+    }
+}

--- a/iznik-batch/app/Services/MessageIndexUnindexedService.php
+++ b/iznik-batch/app/Services/MessageIndexUnindexedService.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\MessageGroup;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+class MessageIndexUnindexedService
+{
+    // Common words excluded from the search index (matches V1 Search::$common).
+    private array $common = [
+        'the', 'old', 'new', 'please', 'thanks', 'with', 'offer', 'taken', 'wanted', 'received',
+        'attachment', 'offered', 'and', 'freegle', 'freecycle', 'for', 'large', 'small', 'are',
+        'but', 'not', 'you', 'all', 'any', 'can', 'her', 'was', 'one', 'our', 'out', 'day', 'get',
+        'has', 'him', 'how', 'now', 'see', 'two', 'who', 'did', 'its', 'let', 'she', 'too', 'use',
+        'plz', 'of', 'to', 'in', 'it', 'is', 'be', 'as', 'at', 'so', 'we', 'he', 'by', 'or', 'on',
+        'do', 'if', 'me', 'my', 'up', 'an', 'go', 'no', 'us', 'am', 'working', 'broken', 'black',
+        'white', 'grey', 'blue', 'green', 'red', 'yellow', 'brown', 'orange', 'pink', 'machine',
+        'size', 'set', 'various', 'assorted', 'different', 'bits', 'ladies', 'gents', 'kids', 'nice',
+        'brand', 'pack', 'soft', 'single', 'double', 'top', 'plastic', 'electric', 'unopened',
+    ];
+
+    public function indexUnindexedMessages(): array
+    {
+        $cutoff = now()->subDays(31)->startOfDay()->format('Y-m-d');
+
+        $msgs = DB::table('messages_groups')
+            ->join('messages', 'messages.id', '=', 'messages_groups.msgid')
+            ->where('messages_groups.collection', MessageGroup::COLLECTION_APPROVED)
+            ->where('messages_groups.deleted', 0)
+            ->where('messages_groups.arrival', '>=', $cutoff)
+            ->whereNotIn('messages_groups.msgid', function ($q) {
+                $q->select('msgid')->from('messages_index');
+            })
+            ->orderByDesc('messages_groups.arrival')
+            ->select('messages_groups.msgid', 'messages.subject', 'messages_groups.arrival', 'messages_groups.groupid')
+            ->get();
+
+        Log::info("MessageIndexUnindexed: indexing {$msgs->count()} messages");
+
+        $count = 0;
+        $total = $msgs->count();
+
+        foreach ($msgs as $msg) {
+            $toadd = $msg->subject;
+
+            [$type, $item] = $this->parseSubject($msg->subject);
+            if ($item) {
+                $toadd = $item;
+            }
+
+            $arrivalTimestamp = Carbon::parse($msg->arrival)->timestamp;
+
+            $this->indexString($msg->msgid, $toadd, $arrivalTimestamp, $msg->groupid);
+
+            $count++;
+            Log::info("{$count} / {$total}");
+        }
+
+        DB::table('words_cache')->delete();
+
+        return ['indexed' => $count];
+    }
+
+    private function parseSubject(string $subject): array
+    {
+        $type = null;
+        $item = null;
+        $location = null;
+
+        $p = strpos($subject, ':');
+
+        if ($p !== false) {
+            $startp = $p;
+            $rest = trim(substr($subject, $p + 1));
+            $p = strlen($rest) - 1;
+
+            if (substr($rest, -1) === ')') {
+                $count = 0;
+
+                do {
+                    $curr = substr($rest, $p, 1);
+
+                    if ($curr === '(') {
+                        $count--;
+                    } elseif ($curr === ')') {
+                        $count++;
+                    }
+
+                    $p--;
+                } while ($count > 0 && $p > 0);
+
+                if ($count === 0) {
+                    $type = trim(substr($subject, 0, $startp));
+                    $location = trim(substr($rest, $p + 2, strlen($rest) - $p - 3));
+                    $item = trim(substr($rest, 0, $p));
+                }
+            }
+        }
+
+        return [$type, $item, $location];
+    }
+
+    private function getWords(string $string): array
+    {
+        $string = preg_replace('/[^a-z0-9]+/i', ' ', strtolower($string));
+        $words = preg_split('/\s+/', $string);
+        $words = array_diff($words, $this->common);
+
+        $ret = [];
+        foreach ($words as $word) {
+            if (strlen($word) >= 2) {
+                $ret[] = substr($word, 0, 10); // words column is varchar(10)
+            }
+        }
+
+        return $ret;
+    }
+
+    private function getOrCreateWordId(string $word): ?int
+    {
+        $existing = DB::table('words')->where('word', $word)->value('id');
+
+        if ($existing) {
+            return (int) $existing;
+        }
+
+        DB::statement(
+            "INSERT IGNORE INTO words (word, firstthree, soundex) VALUES (?, ?, SUBSTRING(SOUNDEX(?), 1, 10))",
+            [$word, substr($word, 0, 3), $word]
+        );
+
+        return (int) DB::table('words')->where('word', $word)->value('id');
+    }
+
+    private function indexString(int $msgid, string $string, int $arrivalTimestamp, ?int $groupid): void
+    {
+        foreach ($this->getWords($string) as $word) {
+            $wordId = $this->getOrCreateWordId($word);
+
+            if (!$wordId) {
+                continue;
+            }
+
+            DB::table('messages_index')->upsert(
+                ['msgid' => $msgid, 'wordid' => $wordId, 'arrival' => -$arrivalTimestamp, 'groupid' => $groupid],
+                ['msgid', 'wordid'],
+                ['arrival']
+            );
+
+            DB::table('words')
+                ->where('id', $wordId)
+                ->update(['popularity' => DB::raw('-(SELECT COUNT(*) FROM messages_index WHERE wordid = ' . $wordId . ')')]);
+        }
+    }
+}

--- a/iznik-batch/app/Services/MessageRemapSubjectsService.php
+++ b/iznik-batch/app/Services/MessageRemapSubjectsService.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+class MessageRemapSubjectsService
+{
+    // V1: Message::EXPIRE_TIME = 90 days
+    private const EXPIRE_DAYS = 90;
+
+    public function remapSubjects(): array
+    {
+        $locationChangeCutoff = now()->subHours(24)->format('Y-m-d H:i:s');
+        $earliestMessage = now()->subDays(self::EXPIRE_DAYS)->format('Y-m-d');
+
+        $messages = DB::table('locations')
+            ->join('messages', 'messages.locationid', '=', 'locations.id')
+            ->join('messages_groups', 'messages_groups.msgid', '=', 'messages.id')
+            ->leftJoin('messages_items', 'messages_items.msgid', '=', 'messages.id')
+            ->leftJoin('items', 'items.id', '=', 'messages_items.itemid')
+            ->leftJoin('locations as areas', 'areas.id', '=', 'locations.areaid')
+            ->leftJoin('locations as postcodes', 'postcodes.id', '=', 'locations.postcodeid')
+            ->where('locations.timestamp', '>=', $locationChangeCutoff)
+            ->where('messages.arrival', '>=', '2021-12-21')
+            ->where('messages.arrival', '>=', $earliestMessage)
+            ->select(
+                'messages.id',
+                'messages.subject',
+                'messages.type',
+                'items.name as item_name',
+                'locations.name as location_name',
+                'locations.type as location_type',
+                'areas.name as area_name',
+                'postcodes.name as postcode_name',
+            )
+            ->get();
+
+        Log::info("MessageRemapSubjects: checking {$messages->count()} messages");
+
+        $changed = 0;
+
+        foreach ($messages as $msg) {
+            if (!$msg->item_name) {
+                continue;
+            }
+
+            $newLocation = $this->buildLocation($msg);
+            $newSubject = strtoupper($msg->type) . ': ' . $msg->item_name . ' (' . $newLocation . ')';
+
+            // Extract old and new location parts using the same regex as V1.
+            if (!preg_match('/.*?:.*\((.*)\)/', $msg->subject, $oldMatches)) {
+                continue;
+            }
+            if (!preg_match('/.*?:.*\((.*)\)/', $newSubject, $newMatches)) {
+                continue;
+            }
+
+            $oldLoc = $oldMatches[1];
+            $newLoc = $newMatches[1];
+
+            if (strcasecmp($oldLoc, $newLoc) !== 0) {
+                Log::info("MessageRemapSubjects: message #{$msg->id} {$oldLoc} => {$newLoc}");
+
+                DB::table('messages')
+                    ->where('id', $msg->id)
+                    ->update(['subject' => $newSubject]);
+
+                $changed++;
+            }
+        }
+
+        Log::info("MessageRemapSubjects: changed {$changed} of {$messages->count()}");
+
+        return ['changed' => $changed];
+    }
+
+    private function buildLocation(object $msg): string
+    {
+        if ($msg->area_name && $msg->postcode_name) {
+            // Area + vague postcode district (e.g. "Edinburgh EH4")
+            $vaguePostcode = $this->ensureVague($msg->postcode_name);
+            return $msg->area_name . ' ' . $vaguePostcode;
+        }
+
+        return $this->ensureVague($msg->location_name, $msg->location_type);
+    }
+
+    private function ensureVague(string $name, string $type = ''): string
+    {
+        if ($type === 'Postcode') {
+            $space = strpos($name, ' ');
+            if ($space !== false) {
+                return substr($name, 0, $space);
+            }
+        }
+
+        return $name;
+    }
+}

--- a/iznik-batch/app/Services/MessageSpatialIndexService.php
+++ b/iznik-batch/app/Services/MessageSpatialIndexService.php
@@ -1,0 +1,190 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Message;
+use App\Models\MessageGroup;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+class MessageSpatialIndexService
+{
+    // V1: MessageCollection::RECENTPOSTS = "Midnight 31 days ago"
+    private const RECENT_DAYS = 31;
+    private const SRID = 3857;
+
+    public function updateSpatialIndex(): array
+    {
+        $count = 0;
+
+        $count += $this->upsertRecentMessages();
+        $count += $this->updateOutcomesAndPromises();
+        $count += $this->removeDeletedMessages();
+        $count += $this->removeOldMessages();
+        $count += $this->removeNonApprovedMessages();
+
+        Log::info("MessageSpatialIndex: updated {$count} entries");
+
+        return ['indexed' => $count];
+    }
+
+    private function upsertRecentMessages(): int
+    {
+        $cutoff = date('Y-m-d', strtotime('Midnight ' . self::RECENT_DAYS . ' days ago'));
+
+        $msgs = DB::table('messages')
+            ->join('messages_groups', 'messages_groups.msgid', '=', 'messages.id')
+            ->join('users', 'users.id', '=', 'messages.fromuser')
+            ->leftJoin('messages_spatial', 'messages_spatial.msgid', '=', 'messages_groups.msgid')
+            ->leftJoin('messages_outcomes', 'messages_outcomes.msgid', '=', 'messages.id')
+            ->where('messages_groups.arrival', '>=', $cutoff)
+            ->whereNotNull('messages.lat')
+            ->whereNotNull('messages.lng')
+            ->whereNull('messages.deleted')
+            ->where('messages_groups.collection', MessageGroup::COLLECTION_APPROVED)
+            ->whereNull('users.deleted')
+            ->where(function ($q) {
+                // Include messages with no outcome, or Taken/Received (same as V1: outcome IS NULL OR outcome IN ('Taken','Received'))
+                $q->whereNull('messages_outcomes.outcome')
+                    ->orWhereIn('messages_outcomes.outcome', [Message::OUTCOME_TAKEN, Message::OUTCOME_RECEIVED]);
+            })
+            ->where(function ($q) {
+                $q->whereNull('messages_spatial.msgid')
+                    ->orWhereRaw('ST_X(messages_spatial.point) != messages.lng')
+                    ->orWhereRaw('ST_Y(messages_spatial.point) != messages.lat')
+                    ->orWhereNull('messages_spatial.groupid')
+                    ->orWhereRaw('messages_spatial.groupid != messages_groups.groupid')
+                    ->orWhereRaw('messages_groups.arrival != messages_spatial.arrival');
+            })
+            ->select(
+                'messages.id',
+                'messages.lat',
+                'messages.lng',
+                'messages_groups.groupid',
+                'messages_groups.arrival',
+                'messages_groups.msgtype',
+            )
+            ->distinct()
+            ->get();
+
+        $count = 0;
+        foreach ($msgs as $msg) {
+            // Coordinates come from DB, not user input — safe to embed in WKT.
+            $wkt = "POINT({$msg->lng} {$msg->lat})";
+            $srid = self::SRID;
+
+            DB::statement(
+                "INSERT INTO messages_spatial (msgid, point, groupid, msgtype, arrival)
+                 VALUES (?, ST_GeomFromText('$wkt', $srid), ?, ?, ?)
+                 ON DUPLICATE KEY UPDATE
+                   point = ST_GeomFromText('$wkt', $srid),
+                   groupid = ?,
+                   msgtype = ?,
+                   arrival = ?",
+                [$msg->id, $msg->groupid, $msg->msgtype, $msg->arrival,
+                 $msg->groupid, $msg->msgtype, $msg->arrival]
+            );
+            $count++;
+        }
+
+        return $count;
+    }
+
+    private function updateOutcomesAndPromises(): int
+    {
+        $msgs = DB::table('messages_spatial')
+            ->leftJoin('messages_outcomes', 'messages_outcomes.msgid', '=', 'messages_spatial.msgid')
+            ->leftJoin('messages_promises', 'messages_promises.msgid', '=', 'messages_spatial.msgid')
+            ->select(
+                'messages_spatial.id',
+                'messages_spatial.msgid',
+                'messages_spatial.successful',
+                'messages_spatial.promised',
+                'messages_outcomes.outcome',
+                'messages_promises.promisedat',
+            )
+            ->orderByDesc('messages_outcomes.timestamp')
+            ->get();
+
+        $count = 0;
+        foreach ($msgs as $msg) {
+            if ($msg->outcome === Message::OUTCOME_WITHDRAWN || $msg->outcome === Message::OUTCOME_EXPIRED) {
+                DB::table('messages_spatial')->where('id', $msg->id)->delete();
+                $count++;
+            } elseif ($msg->outcome === Message::OUTCOME_TAKEN || $msg->outcome === Message::OUTCOME_RECEIVED) {
+                if (!$msg->successful) {
+                    DB::table('messages_spatial')->where('id', $msg->id)->update(['successful' => 1]);
+                    $count++;
+                }
+            } elseif ($msg->successful) {
+                DB::table('messages_spatial')->where('id', $msg->id)->update(['successful' => 0]);
+                $count++;
+            }
+
+            if ($msg->promised && !$msg->promisedat) {
+                DB::table('messages_spatial')->where('id', $msg->id)->update(['promised' => 0]);
+                $count++;
+            } elseif (!$msg->promised && $msg->promisedat) {
+                DB::table('messages_spatial')->where('id', $msg->id)->update(['promised' => 1]);
+                $count++;
+            }
+        }
+
+        return $count;
+    }
+
+    private function removeDeletedMessages(): int
+    {
+        $ids = DB::table('messages_spatial')
+            ->join('messages', 'messages_spatial.msgid', '=', 'messages.id')
+            ->leftJoin('users', 'users.id', '=', 'messages.fromuser')
+            ->where(function ($q) {
+                $q->whereNull('messages.fromuser')
+                    ->orWhereNotNull('messages.deleted')
+                    ->orWhereNotNull('users.deleted');
+            })
+            ->pluck('messages_spatial.id');
+
+        if ($ids->isEmpty()) {
+            return 0;
+        }
+
+        DB::table('messages_spatial')->whereIn('id', $ids)->delete();
+
+        return $ids->count();
+    }
+
+    private function removeOldMessages(): int
+    {
+        $cutoff = date('Y-m-d', strtotime('Midnight ' . self::RECENT_DAYS . ' days ago'));
+
+        $ids = DB::table('messages_spatial')
+            ->join('messages_groups', 'messages_groups.msgid', '=', 'messages_spatial.msgid')
+            ->where('messages_groups.arrival', '<', $cutoff)
+            ->pluck('messages_spatial.id');
+
+        if ($ids->isEmpty()) {
+            return 0;
+        }
+
+        DB::table('messages_spatial')->whereIn('id', $ids)->delete();
+
+        return $ids->count();
+    }
+
+    private function removeNonApprovedMessages(): int
+    {
+        $ids = DB::table('messages_spatial')
+            ->join('messages_groups', 'messages_groups.msgid', '=', 'messages_spatial.msgid')
+            ->where('messages_groups.collection', '!=', MessageGroup::COLLECTION_APPROVED)
+            ->pluck('messages_spatial.id');
+
+        if ($ids->isEmpty()) {
+            return 0;
+        }
+
+        DB::table('messages_spatial')->whereIn('id', $ids)->delete();
+
+        return $ids->count();
+    }
+}

--- a/iznik-batch/app/Services/MicroVolunteeringScoreService.php
+++ b/iznik-batch/app/Services/MicroVolunteeringScoreService.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+class MicroVolunteeringScoreService
+{
+    private const TRUST_BASIC = 'Basic';
+    private const TRUST_MODERATE = 'Moderate';
+    private const PROMOTE_THRESHOLD = 90;
+    private const PROMOTE_DAYS = 7;
+
+    public function scoreAndPromote(string $since = '48 hours ago'): array
+    {
+        $this->score($since);
+        $promoted = $this->promote();
+
+        return ['promoted' => $promoted];
+    }
+
+    private function score(string $since): void
+    {
+        $cutoff = date('Y-m-d', strtotime($since));
+
+        $users = DB::table('microactions')
+            ->where('timestamp', '>', $cutoff)
+            ->distinct()
+            ->pluck('userid');
+
+        Log::info("MicroVolunteeringScore: scoring {$users->count()} users");
+
+        foreach ($users as $userId) {
+            $actions = DB::table('microactions')
+                ->where('timestamp', '>=', $cutoff)
+                ->where('userid', $userId)
+                ->whereNotNull('msgid')
+                ->get();
+
+            foreach ($actions as $action) {
+                $others = DB::table('microactions')
+                    ->where('timestamp', '>=', $cutoff)
+                    ->where('msgid', $action->msgid)
+                    ->where('userid', '!=', $userId)
+                    ->whereNotNull('result')
+                    ->get();
+
+                if ($others->count() <= 1) {
+                    continue;
+                }
+
+                // Tally verdicts.
+                $verdict = [];
+                foreach ($others as $other) {
+                    $verdict[$other->result] = ($verdict[$other->result] ?? 0) + 1;
+                }
+                arsort($verdict);
+                $majority = array_key_first($verdict);
+
+                $scorePositive = ($majority === $action->result) ? 1 : 0;
+                $scoreNegative = ($majority !== $action->result) ? 1 : 0;
+
+                // Only update if changed and not manually overridden by a mod.
+                if ($scorePositive != $action->score_positive) {
+                    DB::table('microactions')
+                        ->where('id', $action->id)
+                        ->whereNull('modfeedback')
+                        ->update(['score_positive' => $scorePositive]);
+                }
+
+                if ($scoreNegative != $action->score_negative) {
+                    DB::table('microactions')
+                        ->where('id', $action->id)
+                        ->whereNull('modfeedback')
+                        ->update(['score_negative' => $scoreNegative]);
+                }
+            }
+        }
+    }
+
+    private function promote(): int
+    {
+        $count = 0;
+
+        $users = DB::table('microactions')
+            ->join('users', 'users.id', '=', 'microactions.userid')
+            ->where('users.trustlevel', self::TRUST_BASIC)
+            ->groupBy('microactions.userid')
+            ->selectRaw('microactions.userid, 100 * SUM(score_positive) / (SUM(score_positive) + SUM(score_negative)) AS score')
+            ->havingRaw('score >= ?', [self::PROMOTE_THRESHOLD])
+            ->pluck('microactions.userid');
+
+        foreach ($users as $userId) {
+            $duration = DB::table('microactions')
+                ->where('userid', $userId)
+                ->selectRaw('DATEDIFF(MAX(timestamp), MIN(timestamp)) AS diff')
+                ->value('diff');
+
+            if ($duration >= self::PROMOTE_DAYS) {
+                DB::table('users')
+                    ->where('id', $userId)
+                    ->update(['trustlevel' => self::TRUST_MODERATE]);
+                $count++;
+                Log::info("MicroVolunteeringScore: promoted user {$userId} to Moderate");
+            }
+        }
+
+        return $count;
+    }
+}

--- a/iznik-batch/app/Services/PollinationsService.php
+++ b/iznik-batch/app/Services/PollinationsService.php
@@ -1,0 +1,423 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+class PollinationsService
+{
+    private const MAX_FAILURES = 3;
+    private const FAILED_CACHE_FILE = '/tmp/pollinations_failed.json';
+    private const HASH_CACHE_FILE = '/tmp/pollinations_hashes.json';
+    private const CACHE_EXPIRY = 86400;
+    private const FAILED_CACHE_EXPIRY = 86400;
+    private const OPENAI_API_URL = 'https://api.openai.com/v1/chat/completions';
+
+    /** @var array<string,string> Hash => name seen in this process */
+    private array $seenHashes = [];
+
+    public function __construct(private TusService $tus) {}
+
+    public function buildMessagePrompt(string $itemName): string
+    {
+        $clean = str_replace(['CRITICAL:', 'Draw only'], '', $itemName);
+
+        return "Product illustration: single isolated {$clean} centered on plain dark green background. " .
+               "Style: friendly cartoon white line drawing, moderate shading, cute and quirky, UK audience. " .
+               "The object sits alone on a simple surface or floats in space. " .
+               "Simple illustration style, clean lines, single object only.";
+    }
+
+    public function buildJobPrompt(string $objectName): string
+    {
+        $clean = str_replace(['CRITICAL:', 'Draw only'], '', $objectName);
+
+        return "Product illustration: single isolated {$clean} centered on plain dark green background. " .
+               "Style: friendly cartoon white line drawing, moderate shading, cute and quirky. " .
+               "Simple illustration style, clean lines, single object only. Square format.";
+    }
+
+    public function shouldSkipItem(string $name): bool
+    {
+        $cache = $this->loadFailedCache();
+
+        return isset($cache[$name]) && $cache[$name]['count'] >= self::MAX_FAILURES;
+    }
+
+    public function recordFailure(string $name): bool
+    {
+        $cache = $this->loadFailedCache();
+
+        if (! isset($cache[$name])) {
+            $cache[$name] = ['count' => 0, 'timestamp' => time()];
+        }
+
+        $cache[$name]['count']++;
+        $cache[$name]['timestamp'] = time();
+        $this->saveFailedCache($cache);
+
+        $shouldSkip = $cache[$name]['count'] >= self::MAX_FAILURES;
+        if ($shouldSkip) {
+            Log::info("PollinationsService: item '{$name}' has failed {$cache[$name]['count']} times, skipping for 1 day");
+        }
+
+        return $shouldSkip;
+    }
+
+    public function cacheImage(string $name, string $uid, string $hash): void
+    {
+        DB::table('ai_images')->upsert(
+            ['name' => $name, 'externaluid' => $uid, 'imagehash' => $hash],
+            ['name'],
+            ['externaluid', 'imagehash']
+        );
+    }
+
+    /**
+     * Apply green duotone filter to raw image data using GD.
+     * Dark green (#0D3311) → white (#FFFFFF).
+     *
+     * @return string|false Processed JPEG data, or false on failure.
+     */
+    public function applyDuotoneGreen(string $imageData): string|false
+    {
+        $img = @imagecreatefromstring($imageData);
+        if (! $img) {
+            return false;
+        }
+
+        $width = imagesx($img);
+        $height = imagesy($img);
+
+        for ($y = 0; $y < $height; $y++) {
+            for ($x = 0; $x < $width; $x++) {
+                $rgb = imagecolorat($img, $x, $y);
+                $r = ($rgb >> 16) & 0xFF;
+                $g = ($rgb >> 8) & 0xFF;
+                $b = $rgb & 0xFF;
+
+                $gray = intval(0.299 * $r + 0.587 * $g + 0.114 * $b);
+                $t = $gray / 255.0;
+
+                $nr = intval(13 + $t * (255 - 13));
+                $ng = intval(51 + $t * (255 - 51));
+                $nb = intval(17 + $t * (255 - 17));
+
+                $color = imagecolorallocate($img, $nr, $ng, $nb);
+                imagesetpixel($img, $x, $y, $color);
+            }
+        }
+
+        ob_start();
+        imagejpeg($img, null, 90);
+        $output = ob_get_clean();
+        imagedestroy($img);
+
+        return $output ?: false;
+    }
+
+    /**
+     * Apply duotone, upload to TUS, cache in ai_images, and return the uid.
+     *
+     * @return string|null The externaluid (e.g. 'freegletusd-abc123'), or null on failure.
+     */
+    public function uploadImageAndCache(string $name, string $imageData, string $hash): ?string
+    {
+        $processed = $this->applyDuotoneGreen($imageData);
+        if (! $processed) {
+            Log::warning("PollinationsService: failed to apply duotone for '{$name}'");
+            return null;
+        }
+
+        $url = $this->tus->upload($processed, 'image/jpeg');
+        if (! $url) {
+            Log::warning("PollinationsService: TUS upload failed for '{$name}'");
+            return null;
+        }
+
+        $uid = 'freegletusd-'.basename($url);
+        $this->cacheImage($name, $uid, $hash);
+
+        return $uid;
+    }
+
+    /**
+     * Fetch a batch of images from pollinations.ai.
+     *
+     * @param  array  $items  Each: ['name'=>string, 'prompt'=>string, 'width'=>int, 'height'=>int, 'msgid'=>?int]
+     * @param  int  $timeout  HTTP timeout in seconds
+     * @return array{results: array, failed: array}|false False on rate-limit; otherwise results+failed arrays.
+     */
+    public function fetchBatch(array $items, int $timeout = 120): array|false
+    {
+        if (empty($items)) {
+            return ['results' => [], 'failed' => []];
+        }
+
+        $results = [];
+        $failed = [];
+        $batchHashes = [];
+
+        foreach ($items as $item) {
+            $name = $item['name'];
+            $prompt = $item['prompt'];
+            $width = $item['width'] ?? 640;
+            $height = $item['height'] ?? 480;
+
+            $url = $this->buildImageUrl($prompt, $width, $height);
+
+            $ctx = stream_context_create([
+                'http' => [
+                    'timeout' => $timeout,
+                    'method' => 'GET',
+                    'header' => 'User-Agent: Freegle/1.0',
+                    'ignore_errors' => true,
+                ],
+            ]);
+
+            Log::debug("PollinationsService: fetching image for '{$name}'");
+            $data = @file_get_contents($url, false, $ctx);
+
+            if (isset($http_response_header)) {
+                foreach ($http_response_header as $header) {
+                    if (preg_match('/^HTTP\/\d+\.?\d*\s+429/', $header)) {
+                        Log::warning("PollinationsService: rate limited (HTTP 429) for '{$name}'");
+                        return false;
+                    }
+                    if (preg_match('/^HTTP\/\d+\.?\d*\s+(\d+)/', $header, $m)) {
+                        $code = (int) $m[1];
+                        if ($code >= 400) {
+                            Log::warning("PollinationsService: HTTP {$code} for '{$name}'");
+                            $failed[$name] = true;
+                            continue 2;
+                        }
+                    }
+                }
+            }
+
+            if (! $data || strlen($data) === 0) {
+                Log::warning("PollinationsService: no data for '{$name}'");
+                $failed[$name] = true;
+                continue;
+            }
+
+            $hash = md5($data);
+
+            if (isset($batchHashes[$hash]) && $batchHashes[$hash] !== $name) {
+                Log::warning("PollinationsService: rate limited (duplicate hash) for '{$name}'");
+                $this->cleanupRateLimitedHash($hash);
+                return false;
+            }
+
+            $existingPrompt = $this->checkHashCache($hash, $name);
+            if ($existingPrompt !== false) {
+                Log::warning("PollinationsService: rate limited (hash cache) for '{$name}'");
+                $this->cleanupRateLimitedHash($hash);
+                return false;
+            }
+
+            $dbDuplicate = DB::table('ai_images')
+                ->where('imagehash', $hash)
+                ->where('name', '!=', $name)
+                ->value('name');
+
+            if ($dbDuplicate) {
+                Log::warning("PollinationsService: rate limited (DB hash) for '{$name}'");
+                $this->addToHashCache($hash, $dbDuplicate);
+                $this->cleanupRateLimitedHash($hash);
+                return false;
+            }
+
+            $hasPeople = $this->checkForPeople($data, $name);
+            if ($hasPeople === true) {
+                Log::info("PollinationsService: image rejected for '{$name}' — contains people");
+                $failed[$name] = true;
+                continue;
+            }
+
+            $batchHashes[$hash] = $name;
+            $results[] = [
+                'name' => $name,
+                'data' => $data,
+                'hash' => $hash,
+                'msgid' => $item['msgid'] ?? null,
+            ];
+
+            sleep(1);
+        }
+
+        foreach ($results as $result) {
+            $this->seenHashes[$result['hash']] = $result['name'];
+            $this->addToHashCache($result['hash'], $result['name']);
+        }
+
+        return ['results' => $results, 'failed' => $failed];
+    }
+
+    public function buildImageUrl(string $prompt, int $width, int $height): string
+    {
+        return 'https://image.pollinations.ai/prompt/' .
+               rawurlencode($prompt) .
+               '?width=' . $width .
+               '&height=' . $height .
+               '&nologo=true&model=flux&seed=' . rand(1, 999999);
+    }
+
+    /**
+     * Check if an image contains people using OpenAI vision (optional).
+     *
+     * @return bool|null TRUE if people detected, FALSE if not, NULL if check unavailable.
+     */
+    public function checkForPeople(string $imageData, string $itemName = ''): ?bool
+    {
+        $apiKey = config('services.openai.key', env('OPENAI_API_KEY'));
+        if (! $apiKey) {
+            return null;
+        }
+
+        $base64 = base64_encode($imageData);
+        $finfo = new \finfo(FILEINFO_MIME_TYPE);
+        $mimeType = $finfo->buffer($imageData) ?: 'image/jpeg';
+        $dataUrl = "data:{$mimeType};base64,{$base64}";
+
+        $payload = [
+            'model' => 'gpt-4o-mini',
+            'messages' => [[
+                'role' => 'user',
+                'content' => [
+                    ['type' => 'text', 'text' => 'Does this image contain any people, human figures, hands, arms, legs, or body parts? Answer only YES or NO.'],
+                    ['type' => 'image_url', 'image_url' => ['url' => $dataUrl, 'detail' => 'low']],
+                ],
+            ]],
+            'max_tokens' => 10,
+        ];
+
+        $ch = curl_init(self::OPENAI_API_URL);
+        curl_setopt_array($ch, [
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_POST => true,
+            CURLOPT_POSTFIELDS => json_encode($payload),
+            CURLOPT_HTTPHEADER => [
+                'Content-Type: application/json',
+                "Authorization: Bearer {$apiKey}",
+            ],
+            CURLOPT_TIMEOUT => 30,
+        ]);
+
+        $response = curl_exec($ch);
+        $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_close($ch);
+
+        if ($httpCode !== 200 || ! $response) {
+            return null;
+        }
+
+        $data = json_decode($response, true);
+        if (! isset($data['choices'][0]['message']['content'])) {
+            return null;
+        }
+
+        $answer = strtoupper(trim($data['choices'][0]['message']['content']));
+
+        return strpos($answer, 'YES') !== false;
+    }
+
+    private function loadFailedCache(): array
+    {
+        if (! file_exists(self::FAILED_CACHE_FILE)) {
+            return [];
+        }
+
+        $data = @file_get_contents(self::FAILED_CACHE_FILE);
+        if (! $data) {
+            return [];
+        }
+
+        $cache = @json_decode($data, true);
+        if (! is_array($cache)) {
+            return [];
+        }
+
+        $now = time();
+
+        return array_filter($cache, fn ($e) => isset($e['timestamp']) && ($now - $e['timestamp']) < self::FAILED_CACHE_EXPIRY);
+    }
+
+    private function saveFailedCache(array $cache): void
+    {
+        $fp = @fopen(self::FAILED_CACHE_FILE, 'c');
+        if (! $fp) {
+            return;
+        }
+        if (flock($fp, LOCK_EX)) {
+            ftruncate($fp, 0);
+            fwrite($fp, json_encode($cache));
+            fflush($fp);
+            flock($fp, LOCK_UN);
+        }
+        fclose($fp);
+    }
+
+    private function loadHashCache(): array
+    {
+        if (! file_exists(self::HASH_CACHE_FILE)) {
+            return [];
+        }
+
+        $data = @file_get_contents(self::HASH_CACHE_FILE);
+        if (! $data) {
+            return [];
+        }
+
+        $cache = @json_decode($data, true);
+        if (! is_array($cache)) {
+            return [];
+        }
+
+        $now = time();
+
+        return array_filter($cache, fn ($e) => isset($e['timestamp']) && ($now - $e['timestamp']) < self::CACHE_EXPIRY);
+    }
+
+    private function saveHashCache(array $cache): void
+    {
+        $fp = @fopen(self::HASH_CACHE_FILE, 'c');
+        if (! $fp) {
+            return;
+        }
+        if (flock($fp, LOCK_EX)) {
+            ftruncate($fp, 0);
+            fwrite($fp, json_encode($cache));
+            fflush($fp);
+            flock($fp, LOCK_UN);
+        }
+        fclose($fp);
+    }
+
+    private function checkHashCache(string $hash, string $name): string|false
+    {
+        $cache = $this->loadHashCache();
+        if (isset($cache[$hash]) && $cache[$hash]['name'] !== $name) {
+            return $cache[$hash]['name'];
+        }
+
+        return false;
+    }
+
+    private function addToHashCache(string $hash, string $name): void
+    {
+        $cache = $this->loadHashCache();
+        $cache[$hash] = ['name' => $name, 'timestamp' => time()];
+        $this->saveHashCache($cache);
+    }
+
+    private function cleanupRateLimitedHash(string $hash): void
+    {
+        // Remove from DB any recently added entries with this hash.
+        DB::table('ai_images')
+            ->where('imagehash', $hash)
+            ->where('created', '>=', now()->subMinutes(5))
+            ->delete();
+    }
+}

--- a/iznik-batch/app/Services/PurgeService.php
+++ b/iznik-batch/app/Services/PurgeService.php
@@ -118,7 +118,7 @@ class PurgeService
     /**
      * Purge old messages_history (spam checking data).
      */
-    public function purgeOldMessagesHistory(int $daysOld = 90, bool $dryRun = false): int
+    public function purgeOldMessagesHistory(int $daysOld = 31, bool $dryRun = false): int
     {
         $cutoff = now()->subDays($daysOld);
 

--- a/iznik-batch/app/Services/UserLocationRemapService.php
+++ b/iznik-batch/app/Services/UserLocationRemapService.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+class UserLocationRemapService
+{
+    public function remapLocations(): array
+    {
+        $cutoff = now()->subHours(48)->format('Y-m-d H:i:s');
+
+        $users = DB::table('users')
+            ->where('lastaccess', '>=', $cutoff)
+            ->whereNotNull('settings')
+            ->select('id', 'settings')
+            ->get();
+
+        Log::info("UserLocationRemap: checking {$users->count()} recently-active users");
+
+        $changed = 0;
+
+        foreach ($users as $user) {
+            $settings = json_decode($user->settings, true);
+
+            if (!isset($settings['mylocation']['id'])) {
+                continue;
+            }
+
+            $locationId = $settings['mylocation']['id'];
+            $cachedName = $settings['mylocation']['name'] ?? null;
+
+            $location = DB::table('locations')
+                ->where('id', $locationId)
+                ->select('id', 'osm_id', 'name', 'type', 'popularity', 'gridid', 'postcodeid', 'areaid', 'lat', 'lng', 'maxdimension')
+                ->first();
+
+            if (!$location) {
+                continue;
+            }
+
+            if ($location->name === $cachedName) {
+                continue;
+            }
+
+            Log::info("UserLocationRemap: user #{$user->id} {$cachedName} => {$location->name}");
+
+            $settings['mylocation'] = (array) $location;
+
+            DB::table('users')
+                ->where('id', $user->id)
+                ->update(['settings' => json_encode($settings)]);
+
+            $changed++;
+        }
+
+        Log::info("UserLocationRemap: changed {$changed} of {$users->count()}");
+
+        return ['changed' => $changed];
+    }
+}

--- a/iznik-batch/app/Services/WhatjobsSpamService.php
+++ b/iznik-batch/app/Services/WhatjobsSpamService.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+class WhatjobsSpamService
+{
+    /**
+     * Delete jobs with identical body content posted across many locations (spam).
+     *
+     * V1: Jobs::deleteSpammyJobs('jobs') in cron/whatjobs_spam.php.
+     * Uses a do-while DELETE LIMIT 1 loop to avoid long-running single transactions.
+     */
+    public function deleteSpammyJobs(): array
+    {
+        Log::info('WhatjobsSpam: counting spammy jobs');
+
+        $spams = DB::table('jobs')
+            ->selectRaw('COUNT(*) as count, title, bodyhash')
+            ->whereNotNull('bodyhash')
+            ->groupBy('bodyhash')
+            ->having('count', '>', 50)
+            ->get();
+
+        Log::info('WhatjobsSpam: deleting spammy jobs', ['spam_hashes' => $spams->count()]);
+
+        $totalDeleted = 0;
+
+        foreach ($spams as $spam) {
+            Log::info("Delete spammy job {$spam->title} * {$spam->count}");
+
+            do {
+                $affected = DB::table('jobs')
+                    ->where('bodyhash', $spam->bodyhash)
+                    ->limit(1)
+                    ->delete();
+            } while ($affected > 0);
+
+            $totalDeleted += $spam->count;
+        }
+
+        return [
+            'deleted' => $totalDeleted,
+            'spam_hashes' => $spams->count(),
+        ];
+    }
+}

--- a/iznik-batch/config/freegle.php
+++ b/iznik-batch/config/freegle.php
@@ -306,4 +306,9 @@ return [
         // --dry-run still works regardless (it only reads).
         'tn_enabled' => env('TN_DEDUP_ENABLED', false),
     ],
+
+    'lovejunk' => [
+        'api' => env('LOVE_JUNK_API', 'https://elmer.api-lovejunk.com/elmer/v1'),
+        'secret' => env('LOVE_JUNK_SECRET', ''),
+    ],
 ];

--- a/iznik-batch/database/migrations/2026_05_07_000001_add_contenttype_to_messages_attachments.php
+++ b/iznik-batch/database/migrations/2026_05_07_000001_add_contenttype_to_messages_attachments.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('messages_attachments') && ! Schema::hasColumn('messages_attachments', 'contenttype')) {
+            \DB::statement("ALTER TABLE messages_attachments ADD COLUMN contenttype VARCHAR(64) NULL AFTER externalmods");
+        }
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasColumn('messages_attachments', 'contenttype')) {
+            \DB::statement("ALTER TABLE messages_attachments DROP COLUMN contenttype");
+        }
+    }
+};

--- a/iznik-batch/routes/console.php
+++ b/iznik-batch/routes/console.php
@@ -441,6 +441,14 @@ Schedule::command('microvolunteering:score')
     ->sendOutputTo(cronLog('microvolunteering:score'))
     ->runInBackground();
 
+// Track recent mod mail actions (rejected/deleted/replied) per user for rate-limiting.
+// V1: cron/users_modmails.php (every 5 minutes)
+Schedule::command('users:update-modmails')
+    ->everyFiveMinutes()
+    ->withoutOverlapping()
+    ->sendOutputTo(cronLog('users:update-modmails'))
+    ->runInBackground();
+
 // Update cached location names in user settings when the canonical name has changed.
 // V1: cron/users_remap.php (daily at 05:00)
 Schedule::command('users:remap-locations')
@@ -455,6 +463,15 @@ Schedule::command('messages:remap-subjects')
     ->everyFiveMinutes()
     ->withoutOverlapping()
     ->sendOutputTo(cronLog('messages:remap-subjects'))
+    ->runInBackground();
+
+// Update messages_spatial with recent messages, outcomes, and remove stale entries.
+// V1: cron/message_spatial.php (every 5 minutes)
+// Note: V1 also pushed freebie-alert jobs to Pheanstalk — that mechanism is retired in the new stack.
+Schedule::command('messages:update-spatial-index')
+    ->everyFiveMinutes()
+    ->withoutOverlapping()
+    ->sendOutputTo(cronLog('messages:update-spatial-index'))
     ->runInBackground();
 
 // =============================================================================

--- a/iznik-batch/routes/console.php
+++ b/iznik-batch/routes/console.php
@@ -433,6 +433,22 @@ Schedule::command('messages:index-unindexed')
     ->sendOutputTo(cronLog('messages:index-unindexed'))
     ->runInBackground();
 
+// Score microvolunteering actions and promote accurate users to Moderate trust.
+// V1: cron/microactions_score.php (daily at 23:00)
+Schedule::command('microvolunteering:score')
+    ->dailyAt('23:00')
+    ->withoutOverlapping()
+    ->sendOutputTo(cronLog('microvolunteering:score'))
+    ->runInBackground();
+
+// Update cached location names in user settings when the canonical name has changed.
+// V1: cron/users_remap.php (daily at 05:00)
+Schedule::command('users:remap-locations')
+    ->dailyAt('05:00')
+    ->withoutOverlapping()
+    ->sendOutputTo(cronLog('users:remap-locations'))
+    ->runInBackground();
+
 // =============================================================================
 // AI IMAGE REVIEW
 // =============================================================================

--- a/iznik-batch/routes/console.php
+++ b/iznik-batch/routes/console.php
@@ -401,6 +401,38 @@ Schedule::command('mail:admin:chase')
     ->sendOutputTo(cronLog('mail:admin:chase'))
     ->runInBackground();
 
+// Delete spammy WhatJobs postings (same bodyhash posted > 50 times across UK).
+// V1: cron/whatjobs_spam.php
+Schedule::command('cleanup:whatjobs-spam')
+    ->everyTenMinutes()
+    ->withoutOverlapping()
+    ->sendOutputTo(cronLog('cleanup:whatjobs-spam'))
+    ->runInBackground();
+
+// Update common email domains table (domains used by > 1000 users).
+// V1: cron/domains_common.php (weekly, Friday 07:00)
+Schedule::command('domains:update-common')
+    ->weeklyOn(5, '07:00')
+    ->withoutOverlapping()
+    ->sendOutputTo(cronLog('domains:update-common'))
+    ->runInBackground();
+
+// Remove search index entries for messages older than 30 days.
+// V1: cron/message_deindex.php (daily at 01:00)
+Schedule::command('messages:deindex')
+    ->dailyAt('01:00')
+    ->withoutOverlapping()
+    ->sendOutputTo(cronLog('messages:deindex'))
+    ->runInBackground();
+
+// Add search index entries for recent messages that aren't indexed yet.
+// V1: cron/message_unindexed.php (every 30 min)
+Schedule::command('messages:index-unindexed')
+    ->everyThirtyMinutes()
+    ->withoutOverlapping()
+    ->sendOutputTo(cronLog('messages:index-unindexed'))
+    ->runInBackground();
+
 // =============================================================================
 // AI IMAGE REVIEW
 // =============================================================================

--- a/iznik-batch/routes/console.php
+++ b/iznik-batch/routes/console.php
@@ -438,6 +438,162 @@ Schedule::command('embeddings:generate')
     ->runInBackground();
 
 // =============================================================================
+// NOT YET ENABLED - pending review / sign-off
+// =============================================================================
+
+// Deindex old messages from search.
+// V1: cron/message_deindex.php
+// Schedule::command('messages:deindex')
+//     ->hourly()
+//     ->withoutOverlapping()
+//     ->sendOutputTo(cronLog('messages:deindex'))
+//     ->runInBackground();
+
+// Index unindexed messages for search.
+// V1: cron/message_unindexed.php
+// Schedule::command('messages:update-index')
+//     ->hourly()
+//     ->withoutOverlapping()
+//     ->sendOutputTo(cronLog('messages:update-index'))
+//     ->runInBackground();
+
+// Score microvolunteering tasks.
+// V1: cron/microvolunteering.php
+// Schedule::command('microvolunteering:score')
+//     ->hourly()
+//     ->withoutOverlapping()
+//     ->sendOutputTo(cronLog('microvolunteering:score'))
+//     ->runInBackground();
+
+// Update user modmails counts.
+// V1: cron/users_modmails.php
+// Schedule::command('users:update-modmails')
+//     ->hourly()
+//     ->withoutOverlapping()
+//     ->sendOutputTo(cronLog('users:update-modmails'))
+//     ->runInBackground();
+
+// Remap user locations.
+// V1: cron/users_remap_locations.php
+// Schedule::command('users:remap-locations')
+//     ->hourly()
+//     ->withoutOverlapping()
+//     ->sendOutputTo(cronLog('users:remap-locations'))
+//     ->runInBackground();
+
+// Remap message subjects.
+// V1: cron/messages_remap_subjects.php
+// Schedule::command('messages:remap-subjects')
+//     ->hourly()
+//     ->withoutOverlapping()
+//     ->sendOutputTo(cronLog('messages:remap-subjects'))
+//     ->runInBackground();
+
+// Update spatial index for messages.
+// V1: cron/message_spatial.php
+// Schedule::command('messages:update-spatial-index')
+//     ->everyFiveMinutes()
+//     ->withoutOverlapping()
+//     ->sendOutputTo(cronLog('messages:update-spatial-index'))
+//     ->runInBackground();
+
+// Clean up whatjobs spam.
+// V1: cron/whatjobs_spam.php
+// Schedule::command('cleanup:whatjobs-spam')
+//     ->everyFiveMinutes()
+//     ->withoutOverlapping()
+//     ->sendOutputTo(cronLog('cleanup:whatjobs-spam'))
+//     ->runInBackground();
+
+// Update common email domains table (domains used by > 1000 users).
+// V1: cron/domains_common.php (weekly, Friday 07:00)
+// Schedule::command('domains:update-common')
+//     ->weeklyOn(5, '07:00')
+//     ->withoutOverlapping()
+//     ->sendOutputTo(cronLog('domains:update-common'))
+//     ->runInBackground();
+
+// Generate AI illustrations for messages with no photos.
+// V1: cron/messages_illustrations.php (every 1 minute)
+// Schedule::command('messages:generate-illustrations')
+//     ->everyMinute()
+//     ->withoutOverlapping()
+//     ->sendOutputTo(cronLog('messages:generate-illustrations'))
+//     ->runInBackground();
+
+// Generate AI illustrations for canonical job categories (pre-caching).
+// V1: cron/jobs_illustrations.php (every 30 minutes)
+// Schedule::command('jobs:generate-illustrations')
+//     ->everyThirtyMinutes()
+//     ->withoutOverlapping()
+//     ->sendOutputTo(cronLog('jobs:generate-illustrations'))
+//     ->runInBackground();
+
+// Fetch app versions from iOS App Store and Google Play - runs every 6 hours.
+// V1: cron/get_app_release_versions.php
+// Schedule::command('data:fetch-app-versions')
+//     ->everySixHours()
+//     ->withoutOverlapping()
+//     ->sendOutputTo(cronLog('data:fetch-app-versions'))
+//     ->runInBackground();
+
+// Sync Freegle offers with LoveJunk - runs every minute.
+// V1: cron/lovejunk.php
+// Schedule::command('integrations:sync-lovejunk')
+//     ->everyMinute()
+//     ->withoutOverlapping()
+//     ->sendOutputTo(cronLog('integrations:sync-lovejunk'))
+//     ->runInBackground();
+
+// Update expected reply tracking for User2User chats.
+// V1: cron/chat_expected.php (every 5 minutes)
+// Schedule::command('chats:update-expected')
+//     ->everyFiveMinutes()
+//     ->withoutOverlapping()
+//     ->sendOutputTo(cronLog('chats:update-expected'))
+//     ->runInBackground();
+
+// Update group stats: fix repost settings, polyindex, activity/funding, mod counts, stats_outcomes.
+// V1: cron/group_stats.php (daily at 02:00)
+// Schedule::command('groups:update-stats')
+//     ->dailyAt('02:00')
+//     ->withoutOverlapping()
+//     ->sendOutputTo(cronLog('groups:update-stats'))
+//     ->runInBackground();
+
+// Remove confirmed spammers from groups.
+// V1: cron/check_spammers.php
+// Schedule::command('users:remove-spammers')
+//     ->everyFiveMinutes()
+//     ->withoutOverlapping()
+//     ->sendOutputTo(cronLog('users:remove-spammers'))
+//     ->runInBackground();
+
+// Process chat spam messages.
+// V1: cron/chat_spam.php
+// Schedule::command('chats:process-spam')
+//     ->hourly()
+//     ->withoutOverlapping()
+//     ->sendOutputTo(cronLog('chats:process-spam'))
+//     ->runInBackground();
+
+// Send mod notifications.
+// V1: cron/mod_notifs.php
+// Schedule::command('mail:mod-notifs')
+//     ->everyFiveMinutes()
+//     ->withoutOverlapping()
+//     ->sendOutputTo(cronLog('mail:mod-notifs'))
+//     ->runInBackground();
+
+// Update GiftAid donations.
+// V1: cron/donations_giftaid.php
+// Schedule::command('donations:update-giftaid')
+//     ->hourly()
+//     ->withoutOverlapping()
+//     ->sendOutputTo(cronLog('donations:update-giftaid'))
+//     ->runInBackground();
+
+// =============================================================================
 // GIT SUMMARY
 // =============================================================================
 

--- a/iznik-batch/routes/console.php
+++ b/iznik-batch/routes/console.php
@@ -65,21 +65,6 @@ Schedule::command('mail:chat:user2mod --max-iterations=60 --spool')
     ->sendOutputTo(cronLog('mail:chat:user2mod'))
     ->runInBackground();
 
-// Fetch app versions from iOS App Store and Google Play - runs every 6 hours.
-// V1: cron/get_app_release_versions.php
-Schedule::command('data:fetch-app-versions')
-    ->everySixHours()
-    ->withoutOverlapping()
-    ->sendOutputTo(cronLog('data:fetch-app-versions'))
-    ->runInBackground();
-
-// Sync Freegle offers with LoveJunk - runs every minute.
-// V1: cron/lovejunk.php
-Schedule::command('integrations:sync-lovejunk')
-    ->everyMinute()
-    ->withoutOverlapping()
-    ->sendOutputTo(cronLog('integrations:sync-lovejunk'))
-    ->runInBackground();
 
 // Fetch UK CPI inflation data from ONS - runs monthly.
 // Used to inflation-adjust the "benefit of reuse" value from the 2011 WRAP report.
@@ -417,98 +402,185 @@ Schedule::command('mail:admin:chase')
     ->sendOutputTo(cronLog('mail:admin:chase'))
     ->runInBackground();
 
-// Delete spammy WhatJobs postings (same bodyhash posted > 50 times across UK).
-// V1: cron/whatjobs_spam.php
-Schedule::command('cleanup:whatjobs-spam')
-    ->everyTenMinutes()
-    ->withoutOverlapping()
-    ->sendOutputTo(cronLog('cleanup:whatjobs-spam'))
-    ->runInBackground();
 
-// Update common email domains table (domains used by > 1000 users).
-// V1: cron/domains_common.php (weekly, Friday 07:00)
-Schedule::command('domains:update-common')
-    ->weeklyOn(5, '07:00')
-    ->withoutOverlapping()
-    ->sendOutputTo(cronLog('domains:update-common'))
-    ->runInBackground();
+// =============================================================================
+// NOT YET ENABLED — enable individually after testing
+// =============================================================================
 
 // Remove search index entries for messages older than 30 days.
 // V1: cron/message_deindex.php (daily at 01:00)
-Schedule::command('messages:deindex')
-    ->dailyAt('01:00')
-    ->withoutOverlapping()
-    ->sendOutputTo(cronLog('messages:deindex'))
-    ->runInBackground();
+// Schedule::command('messages:deindex')
+//     ->dailyAt('01:00')
+//     ->withoutOverlapping()
+//     ->sendOutputTo(cronLog('messages:deindex'))
+//     ->runInBackground();
 
 // Add search index entries for recent messages that aren't indexed yet.
 // V1: cron/message_unindexed.php (every 30 min)
-Schedule::command('messages:index-unindexed')
-    ->everyThirtyMinutes()
-    ->withoutOverlapping()
-    ->sendOutputTo(cronLog('messages:index-unindexed'))
-    ->runInBackground();
+// Schedule::command('messages:index-unindexed')
+//     ->everyThirtyMinutes()
+//     ->withoutOverlapping()
+//     ->sendOutputTo(cronLog('messages:index-unindexed'))
+//     ->runInBackground();
 
 // Score microvolunteering actions and promote accurate users to Moderate trust.
 // V1: cron/microactions_score.php (daily at 23:00)
-Schedule::command('microvolunteering:score')
-    ->dailyAt('23:00')
-    ->withoutOverlapping()
-    ->sendOutputTo(cronLog('microvolunteering:score'))
-    ->runInBackground();
+// Schedule::command('microvolunteering:score')
+//     ->dailyAt('23:00')
+//     ->withoutOverlapping()
+//     ->sendOutputTo(cronLog('microvolunteering:score'))
+//     ->runInBackground();
 
 // Track recent mod mail actions (rejected/deleted/replied) per user for rate-limiting.
 // V1: cron/users_modmails.php (every 5 minutes)
-Schedule::command('users:update-modmails')
-    ->everyFiveMinutes()
-    ->withoutOverlapping()
-    ->sendOutputTo(cronLog('users:update-modmails'))
-    ->runInBackground();
+// Schedule::command('users:update-modmails')
+//     ->everyFiveMinutes()
+//     ->withoutOverlapping()
+//     ->sendOutputTo(cronLog('users:update-modmails'))
+//     ->runInBackground();
 
 // Update cached location names in user settings when the canonical name has changed.
 // V1: cron/users_remap.php (daily at 05:00)
-Schedule::command('users:remap-locations')
-    ->dailyAt('05:00')
-    ->withoutOverlapping()
-    ->sendOutputTo(cronLog('users:remap-locations'))
-    ->runInBackground();
+// Schedule::command('users:remap-locations')
+//     ->dailyAt('05:00')
+//     ->withoutOverlapping()
+//     ->sendOutputTo(cronLog('users:remap-locations'))
+//     ->runInBackground();
 
 // Update message subjects when associated location names have changed.
 // V1: cron/messages_remap.php (every 5 minutes)
-Schedule::command('messages:remap-subjects')
-    ->everyFiveMinutes()
-    ->withoutOverlapping()
-    ->sendOutputTo(cronLog('messages:remap-subjects'))
-    ->runInBackground();
+// Schedule::command('messages:remap-subjects')
+//     ->everyFiveMinutes()
+//     ->withoutOverlapping()
+//     ->sendOutputTo(cronLog('messages:remap-subjects'))
+//     ->runInBackground();
 
 // Update messages_spatial with recent messages, outcomes, and remove stale entries.
 // V1: cron/message_spatial.php (every 5 minutes)
 // Note: V1 also pushed freebie-alert jobs to Pheanstalk — that mechanism is retired in the new stack.
-Schedule::command('messages:update-spatial-index')
-    ->everyFiveMinutes()
-    ->withoutOverlapping()
-    ->sendOutputTo(cronLog('messages:update-spatial-index'))
-    ->runInBackground();
+// Schedule::command('messages:update-spatial-index')
+//     ->everyFiveMinutes()
+//     ->withoutOverlapping()
+//     ->sendOutputTo(cronLog('messages:update-spatial-index'))
+//     ->runInBackground();
 
-// =============================================================================
-// AI IMAGE GENERATION
-// =============================================================================
+// Delete spammy WhatJobs postings (same bodyhash posted > 50 times across UK).
+// V1: cron/whatjobs_spam.php
+// Schedule::command('cleanup:whatjobs-spam')
+//     ->everyTenMinutes()
+//     ->withoutOverlapping()
+//     ->sendOutputTo(cronLog('cleanup:whatjobs-spam'))
+//     ->runInBackground();
+
+// Update common email domains table (domains used by > 1000 users).
+// V1: cron/domains_common.php (weekly, Friday 07:00)
+// Schedule::command('domains:update-common')
+//     ->weeklyOn(5, '07:00')
+//     ->withoutOverlapping()
+//     ->sendOutputTo(cronLog('domains:update-common'))
+//     ->runInBackground();
 
 // Generate AI illustrations for messages with no photos.
 // V1: cron/messages_illustrations.php (every 1 minute)
-Schedule::command('messages:generate-illustrations')
-    ->everyMinute()
-    ->withoutOverlapping()
-    ->sendOutputTo(cronLog('messages:generate-illustrations'))
-    ->runInBackground();
+// Schedule::command('messages:generate-illustrations')
+//     ->everyMinute()
+//     ->withoutOverlapping()
+//     ->sendOutputTo(cronLog('messages:generate-illustrations'))
+//     ->runInBackground();
 
 // Generate AI illustrations for canonical job categories (pre-caching).
 // V1: cron/jobs_illustrations.php (every 30 minutes)
-Schedule::command('jobs:generate-illustrations')
-    ->everyThirtyMinutes()
-    ->withoutOverlapping()
-    ->sendOutputTo(cronLog('jobs:generate-illustrations'))
-    ->runInBackground();
+// Schedule::command('jobs:generate-illustrations')
+//     ->everyThirtyMinutes()
+//     ->withoutOverlapping()
+//     ->sendOutputTo(cronLog('jobs:generate-illustrations'))
+//     ->runInBackground();
+
+// Fetch app versions from iOS App Store and Google Play - runs every 6 hours.
+// V1: cron/get_app_release_versions.php
+// Schedule::command('data:fetch-app-versions')
+//     ->everySixHours()
+//     ->withoutOverlapping()
+//     ->sendOutputTo(cronLog('data:fetch-app-versions'))
+//     ->runInBackground();
+
+// Sync Freegle offers with LoveJunk - runs every minute.
+// V1: cron/lovejunk.php
+// Schedule::command('integrations:sync-lovejunk')
+//     ->everyMinute()
+//     ->withoutOverlapping()
+//     ->sendOutputTo(cronLog('integrations:sync-lovejunk'))
+//     ->runInBackground();
+
+// Message expiry - process deadline-expired messages and spatial index expiry.
+// V1: cron/messages_expired.php
+// Fixed: clears messages_outcomes_intended before creating outcome (matches V1 mark()).
+// Schedule::command('messages:process-expired --spatial')
+//     ->dailyAt('03:00')
+//     ->withoutOverlapping()
+//     ->sendOutputTo(cronLog('messages:process-expired'))
+//     ->runInBackground();
+
+// V1: cron/purge_messages.php
+// Fixed: messages_history default corrected to 31 days (matches V1 MessageCollection::RECENTPOSTS).
+// Schedule::command('purge:messages')
+//     ->dailyAt('02:30')
+//     ->withoutOverlapping()
+//     ->sendOutputTo(cronLog('purge:messages'))
+//     ->runInBackground();
+
+// V1: cron/locations_skewwhiff.php
+// Schedule::command('locations:fix-skewed')
+//     ->dailyAt('05:00')
+//     ->withoutOverlapping()
+//     ->sendOutputTo(cronLog('locations:fix-skewed'))
+//     ->runInBackground();
+
+// V1: cron/user_ratings.php
+// Schedule::command('users:update-ratings')
+//     ->everyTenMinutes()
+//     ->withoutOverlapping()
+//     ->sendOutputTo(cronLog('users:update-ratings'))
+//     ->runInBackground();
+
+// V1: cron/supporttools.php
+// Note: safer than V1 — never downgrades Admin users, only Support.
+// Schedule::command('users:update-support-roles')
+//     ->hourly()
+//     ->withoutOverlapping()
+//     ->sendOutputTo(cronLog('users:update-support-roles'))
+//     ->runInBackground();
+
+// Update expected reply tracking for User2User chats.
+// V1: cron/chat_expected.php (every 5 minutes)
+// Schedule::command('chats:update-expected')
+//     ->everyFiveMinutes()
+//     ->withoutOverlapping()
+//     ->sendOutputTo(cronLog('chats:update-expected'))
+//     ->runInBackground();
+
+// Update group stats: fix repost settings, polyindex, activity/funding, mod counts, stats_outcomes.
+// V1: cron/group_stats.php (daily at 02:00)
+// Note: V1 also generates per-group stats (Stats::generate) and syncs TrashNothing groups — those parts are not migrated here.
+// Schedule::command('groups:update-stats')
+//     ->dailyAt('02:00')
+//     ->withoutOverlapping()
+//     ->sendOutputTo(cronLog('groups:update-stats'))
+//     ->runInBackground();
+
+// V1: cron/donations_thank.php
+// Schedule::command('mail:donations:thank')
+//     ->dailyAt('09:00')
+//     ->withoutOverlapping()
+//     ->sendOutputTo(cronLog('mail:donations:thank'))
+//     ->runInBackground();
+
+// V1: cron/donations_ads_target.php
+// Schedule::command('donations:update-ads-target')
+//     ->everyMinute()
+//     ->withoutOverlapping()
+//     ->sendOutputTo(cronLog('donations:update-ads-target'))
+//     ->runInBackground();
 
 // =============================================================================
 // AI IMAGE REVIEW

--- a/iznik-batch/routes/console.php
+++ b/iznik-batch/routes/console.php
@@ -65,6 +65,14 @@ Schedule::command('mail:chat:user2mod --max-iterations=60 --spool')
     ->sendOutputTo(cronLog('mail:chat:user2mod'))
     ->runInBackground();
 
+// Fetch app versions from iOS App Store and Google Play - runs every 6 hours.
+// V1: cron/get_app_release_versions.php
+Schedule::command('data:fetch-app-versions')
+    ->everySixHours()
+    ->withoutOverlapping()
+    ->sendOutputTo(cronLog('data:fetch-app-versions'))
+    ->runInBackground();
+
 // Fetch UK CPI inflation data from ONS - runs monthly.
 // Used to inflation-adjust the "benefit of reuse" value from the 2011 WRAP report.
 // Sends alert email to GeekAlerts if fetch fails.

--- a/iznik-batch/routes/console.php
+++ b/iznik-batch/routes/console.php
@@ -475,6 +475,26 @@ Schedule::command('messages:update-spatial-index')
     ->runInBackground();
 
 // =============================================================================
+// AI IMAGE GENERATION
+// =============================================================================
+
+// Generate AI illustrations for messages with no photos.
+// V1: cron/messages_illustrations.php (every 1 minute)
+Schedule::command('messages:generate-illustrations')
+    ->everyMinute()
+    ->withoutOverlapping()
+    ->sendOutputTo(cronLog('messages:generate-illustrations'))
+    ->runInBackground();
+
+// Generate AI illustrations for canonical job categories (pre-caching).
+// V1: cron/jobs_illustrations.php (every 30 minutes)
+Schedule::command('jobs:generate-illustrations')
+    ->everyThirtyMinutes()
+    ->withoutOverlapping()
+    ->sendOutputTo(cronLog('jobs:generate-illustrations'))
+    ->runInBackground();
+
+// =============================================================================
 // AI IMAGE REVIEW
 // =============================================================================
 

--- a/iznik-batch/routes/console.php
+++ b/iznik-batch/routes/console.php
@@ -73,6 +73,14 @@ Schedule::command('data:fetch-app-versions')
     ->sendOutputTo(cronLog('data:fetch-app-versions'))
     ->runInBackground();
 
+// Sync Freegle offers with LoveJunk - runs every minute.
+// V1: cron/lovejunk.php
+Schedule::command('integrations:sync-lovejunk')
+    ->everyMinute()
+    ->withoutOverlapping()
+    ->sendOutputTo(cronLog('integrations:sync-lovejunk'))
+    ->runInBackground();
+
 // Fetch UK CPI inflation data from ONS - runs monthly.
 // Used to inflation-adjust the "benefit of reuse" value from the 2011 WRAP report.
 // Sends alert email to GeekAlerts if fetch fails.

--- a/iznik-batch/routes/console.php
+++ b/iznik-batch/routes/console.php
@@ -449,6 +449,14 @@ Schedule::command('users:remap-locations')
     ->sendOutputTo(cronLog('users:remap-locations'))
     ->runInBackground();
 
+// Update message subjects when associated location names have changed.
+// V1: cron/messages_remap.php (every 5 minutes)
+Schedule::command('messages:remap-subjects')
+    ->everyFiveMinutes()
+    ->withoutOverlapping()
+    ->sendOutputTo(cronLog('messages:remap-subjects'))
+    ->runInBackground();
+
 // =============================================================================
 // AI IMAGE REVIEW
 // =============================================================================

--- a/iznik-batch/tests/Unit/Commands/AI/MicroVolunteeringScoreCommandTest.php
+++ b/iznik-batch/tests/Unit/Commands/AI/MicroVolunteeringScoreCommandTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\Unit\Commands\AI;
+
+use App\Services\MicroVolunteeringScoreService;
+use Illuminate\Console\Command;
+use Tests\TestCase;
+
+class MicroVolunteeringScoreCommandTest extends TestCase
+{
+    public function test_dry_run_does_not_score(): void
+    {
+        $service = $this->createMock(MicroVolunteeringScoreService::class);
+        $service->expects($this->never())
+            ->method('scoreAndPromote');
+
+        $this->app->instance(MicroVolunteeringScoreService::class, $service);
+
+        $this->artisan('microvolunteering:score --dry-run')
+            ->expectsOutputToContain('Dry run — no changes made.')
+            ->assertExitCode(Command::SUCCESS);
+    }
+}

--- a/iznik-batch/tests/Unit/Commands/Chat/UpdateExpectedCommandTest.php
+++ b/iznik-batch/tests/Unit/Commands/Chat/UpdateExpectedCommandTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\Unit\Commands\Chat;
+
+use App\Services\ChatExpectedService;
+use Illuminate\Console\Command;
+use Tests\TestCase;
+
+class UpdateExpectedCommandTest extends TestCase
+{
+    public function test_dry_run_does_not_update(): void
+    {
+        $service = $this->createMock(ChatExpectedService::class);
+        $service->expects($this->never())
+            ->method('updateChatExpected');
+
+        $this->app->instance(ChatExpectedService::class, $service);
+
+        $this->artisan('chats:update-expected --dry-run')
+            ->expectsOutputToContain('Dry run — no changes made.')
+            ->assertExitCode(Command::SUCCESS);
+    }
+}

--- a/iznik-batch/tests/Unit/Commands/Cleanup/UpdateCommonDomainsCommandTest.php
+++ b/iznik-batch/tests/Unit/Commands/Cleanup/UpdateCommonDomainsCommandTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\Unit\Commands\Cleanup;
+
+use App\Services\CommonDomainsService;
+use Illuminate\Console\Command;
+use Tests\TestCase;
+
+class UpdateCommonDomainsCommandTest extends TestCase
+{
+    public function test_dry_run_does_not_update(): void
+    {
+        $service = $this->createMock(CommonDomainsService::class);
+        $service->expects($this->never())
+            ->method('updateCommonDomains');
+
+        $this->app->instance(CommonDomainsService::class, $service);
+
+        $this->artisan('domains:update-common --dry-run')
+            ->expectsOutputToContain('Dry run — no changes made.')
+            ->assertExitCode(Command::SUCCESS);
+    }
+}

--- a/iznik-batch/tests/Unit/Commands/Cleanup/WhatjobsSpamCommandTest.php
+++ b/iznik-batch/tests/Unit/Commands/Cleanup/WhatjobsSpamCommandTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\Unit\Commands\Cleanup;
+
+use App\Services\WhatjobsSpamService;
+use Illuminate\Console\Command;
+use Tests\TestCase;
+
+class WhatjobsSpamCommandTest extends TestCase
+{
+    public function test_dry_run_does_not_delete(): void
+    {
+        $service = $this->createMock(WhatjobsSpamService::class);
+        $service->expects($this->never())
+            ->method('deleteSpammyJobs');
+
+        $this->app->instance(WhatjobsSpamService::class, $service);
+
+        $this->artisan('cleanup:whatjobs-spam --dry-run')
+            ->expectsOutputToContain('Dry run — no changes made.')
+            ->assertExitCode(Command::SUCCESS);
+    }
+}

--- a/iznik-batch/tests/Unit/Commands/Data/FetchAppVersionsCommandTest.php
+++ b/iznik-batch/tests/Unit/Commands/Data/FetchAppVersionsCommandTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\Unit\Commands\Data;
+
+use App\Services\AppVersionFetcherService;
+use Illuminate\Console\Command;
+use Tests\TestCase;
+
+class FetchAppVersionsCommandTest extends TestCase
+{
+    public function test_dry_run_does_not_fetch_versions(): void
+    {
+        $service = $this->createMock(AppVersionFetcherService::class);
+        $service->expects($this->never())
+            ->method('fetchAll');
+
+        $this->app->instance(AppVersionFetcherService::class, $service);
+
+        $this->artisan('data:fetch-app-versions --dry-run')
+            ->expectsOutputToContain('Dry run — no changes made.')
+            ->assertExitCode(Command::SUCCESS);
+    }
+}

--- a/iznik-batch/tests/Unit/Commands/Group/UpdateStatsCommandTest.php
+++ b/iznik-batch/tests/Unit/Commands/Group/UpdateStatsCommandTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\Unit\Commands\Group;
+
+use App\Services\GroupStatsService;
+use Illuminate\Console\Command;
+use Tests\TestCase;
+
+class UpdateStatsCommandTest extends TestCase
+{
+    public function test_dry_run_does_not_update(): void
+    {
+        $service = $this->createMock(GroupStatsService::class);
+        $service->expects($this->never())
+            ->method('updateGroupStats');
+
+        $this->app->instance(GroupStatsService::class, $service);
+
+        $this->artisan('groups:update-stats --dry-run')
+            ->expectsOutputToContain('Dry run — no changes made.')
+            ->assertExitCode(Command::SUCCESS);
+    }
+}

--- a/iznik-batch/tests/Unit/Commands/Integrations/SyncLoveJunkCommandTest.php
+++ b/iznik-batch/tests/Unit/Commands/Integrations/SyncLoveJunkCommandTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\Unit\Commands\Integrations;
+
+use App\Services\LoveJunkService;
+use Illuminate\Console\Command;
+use Tests\TestCase;
+
+class SyncLoveJunkCommandTest extends TestCase
+{
+    public function test_dry_run_does_not_sync(): void
+    {
+        $service = $this->createMock(LoveJunkService::class);
+        $service->expects($this->never())
+            ->method('sync');
+
+        $this->app->instance(LoveJunkService::class, $service);
+
+        $this->artisan('integrations:sync-lovejunk --dry-run')
+            ->expectsOutputToContain('Dry run — no changes made.')
+            ->assertExitCode(Command::SUCCESS);
+    }
+}

--- a/iznik-batch/tests/Unit/Commands/Jobs/GenerateIllustrationsCommandTest.php
+++ b/iznik-batch/tests/Unit/Commands/Jobs/GenerateIllustrationsCommandTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\Unit\Commands\Jobs;
+
+use App\Services\JobIllustrationsService;
+use Illuminate\Console\Command;
+use Tests\TestCase;
+
+class GenerateIllustrationsCommandTest extends TestCase
+{
+    public function test_dry_run_does_not_generate(): void
+    {
+        $service = $this->createMock(JobIllustrationsService::class);
+        $service->expects($this->never())
+            ->method('processIllustrations');
+
+        $this->app->instance(JobIllustrationsService::class, $service);
+
+        $this->artisan('jobs:generate-illustrations --dry-run')
+            ->expectsOutputToContain('Dry run — no changes made.')
+            ->assertExitCode(Command::SUCCESS);
+    }
+}

--- a/iznik-batch/tests/Unit/Commands/Message/DeindexCommandTest.php
+++ b/iznik-batch/tests/Unit/Commands/Message/DeindexCommandTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\Unit\Commands\Message;
+
+use App\Services\MessageDeindexService;
+use Illuminate\Console\Command;
+use Tests\TestCase;
+
+class DeindexCommandTest extends TestCase
+{
+    public function test_dry_run_does_not_deindex(): void
+    {
+        $service = $this->createMock(MessageDeindexService::class);
+        $service->expects($this->never())
+            ->method('deindexOldMessages');
+
+        $this->app->instance(MessageDeindexService::class, $service);
+
+        $this->artisan('messages:deindex --dry-run')
+            ->expectsOutputToContain('Dry run — no changes made.')
+            ->assertExitCode(Command::SUCCESS);
+    }
+}

--- a/iznik-batch/tests/Unit/Commands/Message/GenerateIllustrationsCommandTest.php
+++ b/iznik-batch/tests/Unit/Commands/Message/GenerateIllustrationsCommandTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\Unit\Commands\Message;
+
+use App\Services\MessageIllustrationsService;
+use Illuminate\Console\Command;
+use Tests\TestCase;
+
+class GenerateIllustrationsCommandTest extends TestCase
+{
+    public function test_dry_run_does_not_generate(): void
+    {
+        $service = $this->createMock(MessageIllustrationsService::class);
+        $service->expects($this->never())
+            ->method('processIllustrations');
+
+        $this->app->instance(MessageIllustrationsService::class, $service);
+
+        $this->artisan('messages:generate-illustrations --dry-run')
+            ->expectsOutputToContain('Dry run — no changes made.')
+            ->assertExitCode(Command::SUCCESS);
+    }
+}

--- a/iznik-batch/tests/Unit/Commands/Message/IndexUnindexedCommandTest.php
+++ b/iznik-batch/tests/Unit/Commands/Message/IndexUnindexedCommandTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\Unit\Commands\Message;
+
+use App\Services\MessageIndexUnindexedService;
+use Illuminate\Console\Command;
+use Tests\TestCase;
+
+class IndexUnindexedCommandTest extends TestCase
+{
+    public function test_dry_run_does_not_index(): void
+    {
+        $service = $this->createMock(MessageIndexUnindexedService::class);
+        $service->expects($this->never())
+            ->method('indexUnindexedMessages');
+
+        $this->app->instance(MessageIndexUnindexedService::class, $service);
+
+        $this->artisan('messages:index-unindexed --dry-run')
+            ->expectsOutputToContain('Dry run — no changes made.')
+            ->assertExitCode(Command::SUCCESS);
+    }
+}

--- a/iznik-batch/tests/Unit/Commands/Message/RemapSubjectsCommandTest.php
+++ b/iznik-batch/tests/Unit/Commands/Message/RemapSubjectsCommandTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\Unit\Commands\Message;
+
+use App\Services\MessageRemapSubjectsService;
+use Illuminate\Console\Command;
+use Tests\TestCase;
+
+class RemapSubjectsCommandTest extends TestCase
+{
+    public function test_dry_run_does_not_remap(): void
+    {
+        $service = $this->createMock(MessageRemapSubjectsService::class);
+        $service->expects($this->never())
+            ->method('remapSubjects');
+
+        $this->app->instance(MessageRemapSubjectsService::class, $service);
+
+        $this->artisan('messages:remap-subjects --dry-run')
+            ->expectsOutputToContain('Dry run — no changes made.')
+            ->assertExitCode(Command::SUCCESS);
+    }
+}

--- a/iznik-batch/tests/Unit/Commands/Purge/PurgeMessagesCommandTest.php
+++ b/iznik-batch/tests/Unit/Commands/Purge/PurgeMessagesCommandTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Unit\Commands\Purge;
+
+use App\Services\PurgeService;
+use Tests\TestCase;
+
+class PurgeMessagesCommandTest extends TestCase
+{
+    public function test_dry_run_returns_success_without_changes(): void
+    {
+        $service = $this->createMock(PurgeService::class);
+        $service->expects($this->never())->method('purgeOldMessagesHistory');
+        $service->expects($this->never())->method('purgePendingMessages');
+        $service->expects($this->never())->method('purgeDeletedMessages');
+        $this->app->instance(PurgeService::class, $service);
+
+        $this->artisan('purge:messages', ['--dry-run' => true])
+            ->expectsOutputToContain('DRY RUN')
+            ->assertExitCode(0);
+    }
+
+    public function test_command_runs_service_and_reports_results(): void
+    {
+        $service = $this->createMock(PurgeService::class);
+        $service->method('purgeOldMessagesHistory')->willReturn(5);
+        $service->method('purgePendingMessages')->willReturn(2);
+        $service->method('purgeOldDrafts')->willReturn(1);
+        $service->method('purgeNonFreegleMessages')->willReturn(0);
+        $service->method('purgeDeletedMessages')->willReturn(3);
+        $service->method('purgeStrandedMessages')->willReturn(0);
+        $service->method('purgeHtmlBody')->willReturn(10);
+        $service->method('purgeMessageSource')->willReturn(4);
+        $service->method('purgeOrphanedIsochrones')->willReturn(0);
+        $service->method('purgeCompletedAdmins')->willReturn(0);
+        $service->method('purgeUsersNearby')->willReturn(0);
+        $service->method('purgeUnvalidatedEmails')->willReturn(0);
+        $this->app->instance(PurgeService::class, $service);
+
+        $this->artisan('purge:messages')
+            ->expectsOutputToContain('Message purge complete')
+            ->assertExitCode(0);
+    }
+}

--- a/iznik-batch/tests/Unit/Commands/User/RemapLocationsCommandTest.php
+++ b/iznik-batch/tests/Unit/Commands/User/RemapLocationsCommandTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\Unit\Commands\User;
+
+use App\Services\UserLocationRemapService;
+use Illuminate\Console\Command;
+use Tests\TestCase;
+
+class RemapLocationsCommandTest extends TestCase
+{
+    public function test_dry_run_does_not_remap(): void
+    {
+        $service = $this->createMock(UserLocationRemapService::class);
+        $service->expects($this->never())
+            ->method('remapLocations');
+
+        $this->app->instance(UserLocationRemapService::class, $service);
+
+        $this->artisan('users:remap-locations --dry-run')
+            ->expectsOutputToContain('Dry run — no changes made.')
+            ->assertExitCode(Command::SUCCESS);
+    }
+}

--- a/iznik-batch/tests/Unit/Commands/User/UpdateModMailsCommandTest.php
+++ b/iznik-batch/tests/Unit/Commands/User/UpdateModMailsCommandTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\Unit\Commands\User;
+
+use App\Services\UserModMailsService;
+use Illuminate\Console\Command;
+use Tests\TestCase;
+
+class UpdateModMailsCommandTest extends TestCase
+{
+    public function test_dry_run_does_not_update(): void
+    {
+        $service = $this->createMock(UserModMailsService::class);
+        $service->expects($this->never())
+            ->method('updateModMails');
+
+        $this->app->instance(UserModMailsService::class, $service);
+
+        $this->artisan('users:update-modmails --dry-run')
+            ->expectsOutputToContain('Dry run — no changes made.')
+            ->assertExitCode(Command::SUCCESS);
+    }
+}

--- a/iznik-batch/tests/Unit/Services/AppVersionFetcherServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/AppVersionFetcherServiceTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Services\AppVersionFetcherService;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class AppVersionFetcherServiceTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        DB::table('config')->whereIn('key', [
+            'app_fd_version_ios_latest', 'app_fd_version_ios_date',
+            'app_mt_version_ios_latest', 'app_mt_version_ios_date',
+            'app_fd_version_android_latest', 'app_fd_version_android_date',
+            'app_mt_version_android_latest', 'app_mt_version_android_date',
+        ])->delete();
+    }
+
+    private function fakeItunesResponse(string $version, string $date): array
+    {
+        return [
+            'resultCount' => 1,
+            'results' => [
+                [
+                    'version' => $version,
+                    'currentVersionReleaseDate' => $date,
+                ],
+            ],
+        ];
+    }
+
+    private function fakeAndroidHtml(string $version, string $date): string
+    {
+        return "AF_initDataCallback({key: 'ds:5', isError: false, hash: '1', data: [null, [[null, [{$version}]], null, null, null, null, null, null, null, null, null, null, null, null, null, null, [{$date}]]]]}); something";
+    }
+
+    public function test_fetches_ios_versions_and_stores_in_config(): void
+    {
+        Http::fake([
+            'itunes.apple.com/*iphone*' => Http::response(json_encode($this->fakeItunesResponse('3.1.4', '2024-03-01T09:00:00Z')), 200),
+            'itunes.apple.com/*modtools*' => Http::response(json_encode($this->fakeItunesResponse('2.7.1', '2024-02-15T12:00:00Z')), 200),
+            'play.google.com/*direct*' => Http::response($this->fakeAndroidHtml('3.1.4', 'Mar 1, 2024'), 200),
+            'play.google.com/*modtools*' => Http::response($this->fakeAndroidHtml('2.7.1', 'Feb 15, 2024'), 200),
+        ]);
+
+        $service = new AppVersionFetcherService();
+        $result = $service->fetchAll();
+
+        $this->assertContains('ios_fd', $result['fetched']);
+        $this->assertContains('ios_mt', $result['fetched']);
+
+        $this->assertEquals('3.1.4', DB::table('config')->where('key', 'app_fd_version_ios_latest')->value('value'));
+        $this->assertEquals('2024-03-01T09:00:00Z', DB::table('config')->where('key', 'app_fd_version_ios_date')->value('value'));
+        $this->assertEquals('2.7.1', DB::table('config')->where('key', 'app_mt_version_ios_latest')->value('value'));
+        $this->assertEquals('2024-02-15T12:00:00Z', DB::table('config')->where('key', 'app_mt_version_ios_date')->value('value'));
+    }
+
+    public function test_fetches_android_versions_and_stores_in_config(): void
+    {
+        Http::fake([
+            'itunes.apple.com/*iphone*' => Http::response(json_encode(['resultCount' => 0, 'results' => []]), 200),
+            'itunes.apple.com/*modtools*' => Http::response(json_encode(['resultCount' => 0, 'results' => []]), 200),
+            'play.google.com/*direct*' => Http::response($this->fakeAndroidHtml('5.2.0', 'Apr 10, 2024'), 200),
+            'play.google.com/*modtools*' => Http::response($this->fakeAndroidHtml('4.1.3', 'Apr 5, 2024'), 200),
+        ]);
+
+        $service = new AppVersionFetcherService();
+        $result = $service->fetchAll();
+
+        $this->assertContains('android_fd', $result['fetched']);
+        $this->assertContains('android_mt', $result['fetched']);
+
+        $this->assertEquals('5.2.0', DB::table('config')->where('key', 'app_fd_version_android_latest')->value('value'));
+        $this->assertEquals('Apr 10, 2024', DB::table('config')->where('key', 'app_fd_version_android_date')->value('value'));
+        $this->assertEquals('4.1.3', DB::table('config')->where('key', 'app_mt_version_android_latest')->value('value'));
+        $this->assertEquals('Apr 5, 2024', DB::table('config')->where('key', 'app_mt_version_android_date')->value('value'));
+    }
+
+    public function test_partial_failure_stores_successful_and_reports_failed(): void
+    {
+        Http::fake([
+            'itunes.apple.com/*iphone*' => Http::response(json_encode($this->fakeItunesResponse('3.1.4', '2024-03-01T09:00:00Z')), 200),
+            'itunes.apple.com/*modtools*' => Http::response('error', 500),
+            'play.google.com/*direct*' => Http::response('no af_initdatacallback here', 200),
+            'play.google.com/*modtools*' => Http::response($this->fakeAndroidHtml('4.1.3', 'Apr 5, 2024'), 200),
+        ]);
+
+        $service = new AppVersionFetcherService();
+        $result = $service->fetchAll();
+
+        $this->assertContains('ios_fd', $result['fetched']);
+        $this->assertContains('ios_mt', $result['failed']);
+        $this->assertContains('android_fd', $result['failed']);
+        $this->assertContains('android_mt', $result['fetched']);
+
+        $this->assertEquals('3.1.4', DB::table('config')->where('key', 'app_fd_version_ios_latest')->value('value'));
+        $this->assertNull(DB::table('config')->where('key', 'app_mt_version_ios_latest')->value('value'));
+    }
+
+    public function test_upserts_existing_config_values(): void
+    {
+        DB::table('config')->insert(['key' => 'app_fd_version_ios_latest', 'value' => '1.0.0']);
+
+        Http::fake([
+            'itunes.apple.com/*iphone*' => Http::response(json_encode($this->fakeItunesResponse('3.2.0', '2024-04-01T00:00:00Z')), 200),
+            'itunes.apple.com/*modtools*' => Http::response(json_encode(['resultCount' => 0, 'results' => []]), 200),
+            'play.google.com/*' => Http::response('no version here', 200),
+        ]);
+
+        $service = new AppVersionFetcherService();
+        $service->fetchAll();
+
+        $this->assertEquals('3.2.0', DB::table('config')->where('key', 'app_fd_version_ios_latest')->value('value'));
+        $this->assertEquals(1, DB::table('config')->where('key', 'app_fd_version_ios_latest')->count());
+    }
+}

--- a/iznik-batch/tests/Unit/Services/CommonDomainsServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/CommonDomainsServiceTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Services\CommonDomainsService;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Tests\TestCase;
+
+class CommonDomainsServiceTest extends TestCase
+{
+    protected CommonDomainsService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new CommonDomainsService();
+        DB::table('domains_common')->delete();
+    }
+
+    public function test_empty_input_returns_zero(): void
+    {
+        // No users_emails rows with our test prefix.
+        $result = $this->service->updateCommonDomains();
+
+        $this->assertEquals(0, $result['domains_inserted']);
+    }
+
+    public function test_below_threshold_not_inserted(): void
+    {
+        // Insert 1000 users with @example.com — exactly at threshold, not over.
+        $user = $this->createTestUser();
+        for ($i = 0; $i < 1000; $i++) {
+            DB::table('users_emails')->insert([
+                'userid' => $user->id,
+                'email'  => "user{$i}@threshold-test-domain.com",
+            ]);
+        }
+
+        $this->service->updateCommonDomains();
+
+        $this->assertEquals(
+            0,
+            DB::table('domains_common')->where('domain', 'threshold-test-domain.com')->count()
+        );
+    }
+
+    public function test_above_threshold_inserted(): void
+    {
+        $user = $this->createTestUser();
+        for ($i = 0; $i < 1001; $i++) {
+            DB::table('users_emails')->insert([
+                'userid' => $user->id,
+                'email'  => "user{$i}@common-domain-test.com",
+            ]);
+        }
+
+        $result = $this->service->updateCommonDomains();
+
+        $this->assertGreaterThanOrEqual(1, $result['domains_inserted']);
+        $row = DB::table('domains_common')->where('domain', 'common-domain-test.com')->first();
+        $this->assertNotNull($row);
+        $this->assertEquals(1001, $row->count);
+    }
+
+    public function test_upserts_existing_domain(): void
+    {
+        // Pre-seed with old count.
+        DB::table('domains_common')->insert(['domain' => 'upsert-domain.com', 'count' => 500]);
+
+        $user = $this->createTestUser();
+        for ($i = 0; $i < 1001; $i++) {
+            DB::table('users_emails')->insert([
+                'userid' => $user->id,
+                'email'  => "user{$i}@upsert-domain.com",
+            ]);
+        }
+
+        $this->service->updateCommonDomains();
+
+        $row = DB::table('domains_common')->where('domain', 'upsert-domain.com')->first();
+        $this->assertEquals(1001, $row->count);
+    }
+
+    public function test_ignores_addresses_without_at_sign(): void
+    {
+        $user = $this->createTestUser();
+        for ($i = 0; $i < 1001; $i++) {
+            DB::table('users_emails')->insert([
+                'userid' => $user->id,
+                'email'  => "invalidemail{$i}",
+            ]);
+        }
+
+        $result = $this->service->updateCommonDomains();
+        $this->assertEquals(0, $result['domains_inserted']);
+    }
+}

--- a/iznik-batch/tests/Unit/Services/GroupStatsServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/GroupStatsServiceTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Services\GroupStatsService;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class GroupStatsServiceTest extends TestCase
+{
+    protected GroupStatsService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new GroupStatsService();
+    }
+
+    public function test_fixes_repost_string_values(): void
+    {
+        $group = $this->createTestGroup();
+
+        // Set reposts with string values.
+        DB::table('groups')->where('id', $group->id)->update([
+            'settings' => json_encode(['reposts' => ['interval' => '7', 'max' => '3']]),
+        ]);
+
+        $result = $this->service->updateGroupStats();
+
+        $settings = json_decode(DB::table('groups')->where('id', $group->id)->value('settings'), true);
+        $this->assertIsInt($settings['reposts']['interval']);
+        $this->assertIsInt($settings['reposts']['max']);
+        $this->assertGreaterThanOrEqual(1, $result['reposts_fixed']);
+    }
+
+    public function test_skips_repost_already_int(): void
+    {
+        $group = $this->createTestGroup();
+
+        DB::table('groups')->where('id', $group->id)->update([
+            'settings' => json_encode(['reposts' => ['interval' => 7, 'max' => 3]]),
+        ]);
+
+        $result = $this->service->updateGroupStats();
+
+        $this->assertEquals(0, $result['reposts_fixed']);
+    }
+
+    public function test_updates_stats_outcomes(): void
+    {
+        $group = $this->createTestGroup();
+
+        // Insert stats outcome data.
+        DB::table('stats')->insert([
+            'date' => now()->subDays(5),
+            'end' => now()->subDays(5),
+            'groupid' => $group->id,
+            'type' => 'Outcomes',
+            'count' => 42,
+        ]);
+
+        $result = $this->service->updateGroupStats();
+
+        $monthDate = now()->subDays(5)->format('Y') . '-' . str_pad(now()->subDays(5)->format('n'), 2, '0', STR_PAD_LEFT);
+        $outcomeCount = DB::table('stats_outcomes')
+            ->where('groupid', $group->id)
+            ->where('date', $monthDate)
+            ->value('count');
+
+        $this->assertEquals(42, $outcomeCount);
+        $this->assertGreaterThanOrEqual(1, $result['stats_outcomes_updated']);
+    }
+
+    public function test_returns_zero_when_nothing_to_fix(): void
+    {
+        $result = $this->service->updateGroupStats();
+
+        $this->assertEquals(0, $result['reposts_fixed']);
+    }
+}

--- a/iznik-batch/tests/Unit/Services/JobIllustrationsServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/JobIllustrationsServiceTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Services\JobIllustrationsService;
+use App\Services\PollinationsService;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class JobIllustrationsServiceTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        DB::table('ai_images')->delete();
+    }
+
+    private function makeService(array $fetchResult = null, bool $skipAll = false): JobIllustrationsService
+    {
+        $mock = $this->createMock(PollinationsService::class);
+        $mock->method('shouldSkipItem')->willReturn($skipAll);
+        $mock->method('recordFailure')->willReturn(false);
+        $mock->method('fetchBatch')->willReturn($fetchResult ?? ['results' => [], 'failed' => []]);
+        $mock->method('buildJobPrompt')->willReturnCallback(fn ($obj) => "prompt for $obj");
+        // Actually insert into ai_images so the loop terminates.
+        $mock->method('uploadImageAndCache')->willReturnCallback(function (string $name) {
+            DB::table('ai_images')->insertOrIgnore(['name' => $name, 'externaluid' => 'freegletusd-jobtest']);
+
+            return 'freegletusd-jobtest';
+        });
+
+        return new JobIllustrationsService($mock);
+    }
+
+    public function test_processes_missing_canonical_job(): void
+    {
+        // Pre-insert all canonical jobs except 'Accountant'.
+        $allJobs = array_keys(JobIllustrationsService::CANONICAL_JOBS);
+        $jobsExceptFirst = array_slice($allJobs, 1);
+        foreach ($jobsExceptFirst as $title) {
+            DB::table('ai_images')->insert(['name' => $title, 'externaluid' => 'freegletusd-existing']);
+        }
+
+        $fakeFetch = [
+            'results' => [
+                ['name' => 'Accountant', 'data' => 'fakeimagedata', 'hash' => 'hash001', 'msgid' => null],
+            ],
+            'failed' => [],
+        ];
+
+        $service = $this->makeService($fakeFetch);
+        $result = $service->processIllustrations();
+
+        $this->assertEquals(1, $result['processed']);
+        $this->assertEquals(0, $result['remaining']);
+    }
+
+    public function test_skips_already_cached_jobs(): void
+    {
+        // Pre-insert all canonical jobs.
+        foreach (array_keys(JobIllustrationsService::CANONICAL_JOBS) as $title) {
+            DB::table('ai_images')->insert(['name' => $title, 'externaluid' => 'freegletusd-existing']);
+        }
+
+        $mock = $this->createMock(PollinationsService::class);
+        $mock->expects($this->never())->method('fetchBatch');
+
+        $service = new JobIllustrationsService($mock);
+        $result = $service->processIllustrations();
+
+        $this->assertEquals(0, $result['processed']);
+        $this->assertEquals(0, $result['remaining']);
+    }
+
+    public function test_returns_remaining_count_after_rate_limit(): void
+    {
+        // No pre-existing images.
+        $mock = $this->createMock(PollinationsService::class);
+        $mock->method('shouldSkipItem')->willReturn(false);
+        $mock->method('recordFailure')->willReturn(false);
+        $mock->method('fetchBatch')->willReturn(false); // rate-limited
+        $mock->method('buildJobPrompt')->willReturn('prompt');
+
+        $service = new JobIllustrationsService($mock);
+        $result = $service->processIllustrations();
+
+        $this->assertEquals(0, $result['processed']);
+        $this->assertGreaterThan(0, $result['remaining']);
+    }
+}

--- a/iznik-batch/tests/Unit/Services/LoveJunkServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/LoveJunkServiceTest.php
@@ -29,16 +29,19 @@ class LoveJunkServiceTest extends TestCase
 
     private function createGroup(array $attrs = []): int
     {
-        return DB::table('groups')->insertGetId(array_merge([
-            'nameshort' => 'TestLJGroup_' . uniqid(),
-            'namefull' => 'Test LoveJunk Group',
-            'type' => 'Freegle',
-            'onlovejunk' => 1,
-            'onhere' => 1,
-            'publish' => 1,
-            'lat' => 51.5,
-            'lng' => -0.1,
-        ], $attrs));
+        $nameshort = $attrs['nameshort'] ?? ('TestLJGroup_' . uniqid());
+        $onlovejunk = $attrs['onlovejunk'] ?? 1;
+
+        // polyindex is NOT NULL spatial — must be set in the INSERT statement
+        DB::statement("
+            INSERT INTO `groups`
+                (nameshort, namefull, type, onlovejunk, onhere, publish, lat, lng, polyindex)
+            VALUES
+                (?, 'Test LoveJunk Group', 'Freegle', ?, 1, 1, 51.5, -0.1,
+                 ST_GeomFromText('POLYGON((-1 51,-1 52,0 52,0 51,-1 51))',3857))
+        ", [$nameshort, $onlovejunk]);
+
+        return (int) DB::getPdo()->lastInsertId();
     }
 
     private function createUser(array $attrs = []): int
@@ -272,5 +275,109 @@ class LoveJunkServiceTest extends TestCase
         // Should mark as deleted in lovejunk table
         $lj = DB::table('lovejunk')->where('msgid', $msgId)->first();
         $this->assertNotNull($lj->deleted);
+    }
+
+    public function test_completes_offer_via_lj_promise(): void
+    {
+        Http::fake([
+            '*/freegle/offers/888/complete' => Http::response('', 200),
+        ]);
+
+        $senderId = $this->createUser();
+        $promiseeId = $this->createUser(['ljuserid' => 888]);
+        $groupId = $this->createGroup();
+        $locationId = $this->createLocation();
+        $msgId = $this->createMessage($senderId, $groupId, $locationId);
+
+        DB::table('lovejunk')->insert([
+            'msgid' => $msgId,
+            'success' => 1,
+            'status' => json_encode(['draftId' => 'lj-draft-003']),
+        ]);
+
+        DB::table('messages_promises')->insert([
+            'msgid' => $msgId,
+            'userid' => $promiseeId,
+        ]);
+
+        DB::table('chat_rooms')->insert([
+            'user1' => $senderId,
+            'user2' => $promiseeId,
+            'chattype' => 'User2User',
+            'ljofferid' => 888,
+        ]);
+
+        DB::table('messages_outcomes')->insert([
+            'msgid' => $msgId,
+            'outcome' => 'Taken',
+            'happiness' => null,
+            'timestamp' => now(),
+        ]);
+
+        $service = new LoveJunkService();
+        $result = $service->sync();
+
+        $this->assertEquals(1, $result['completed_or_deleted']);
+
+        Http::assertSent(function ($request) {
+            return str_contains($request->url(), '/freegle/offers/888/complete');
+        });
+
+        $lj = DB::table('lovejunk')->where('msgid', $msgId)->first();
+        $this->assertNotNull($lj->deleted);
+    }
+
+    public function test_sends_message_with_attachment_images(): void
+    {
+        Http::fake([
+            '*/freegle/drafts*' => Http::response(json_encode(['body' => ['draftId' => 'lj-draft-att']]), 200),
+        ]);
+
+        $userId = $this->createUser();
+        $groupId = $this->createGroup();
+        $locationId = $this->createLocation();
+        $msgId = $this->createMessage($userId, $groupId, $locationId);
+
+        $itemId = DB::table('items')->insertGetId(['name' => 'Table', 'popularity' => 1, 'updated' => now()]);
+        DB::table('messages_items')->insert(['msgid' => $msgId, 'itemid' => $itemId]);
+
+        DB::table('messages_attachments')->insert([
+            'msgid' => $msgId,
+            'externaluid' => 'freegletusd-abc123',
+        ]);
+
+        $service = new LoveJunkService();
+        $result = $service->sync();
+
+        $this->assertEquals(1, $result['sent']);
+
+        Http::assertSent(function ($request) {
+            $data = $request->data();
+            return isset($data['images'][0]['url']) && str_contains($data['images'][0]['url'], 'abc123');
+        });
+    }
+
+    public function test_extracts_item_from_subject_when_no_messages_items(): void
+    {
+        Http::fake([
+            '*/freegle/drafts*' => Http::response(json_encode(['body' => ['draftId' => 'lj-draft-subj']]), 200),
+        ]);
+
+        $userId = $this->createUser();
+        $groupId = $this->createGroup();
+        $locationId = $this->createLocation();
+        $msgId = $this->createMessage($userId, $groupId, $locationId, [
+            'subject' => 'OFFER: Vintage lamp (Shoreditch)',
+        ]);
+
+        $service = new LoveJunkService();
+        $result = $service->sync();
+
+        $this->assertEquals(1, $result['sent']);
+
+        Http::assertSent(function ($request) {
+            $data = $request->data();
+            return isset($data['title']) && trim($data['title']) === 'Vintage lamp';
+        });
     }
 }

--- a/iznik-batch/tests/Unit/Services/LoveJunkServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/LoveJunkServiceTest.php
@@ -1,0 +1,276 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Services\LoveJunkService;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class LoveJunkServiceTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        DB::table('lovejunk')->delete();
+        DB::table('messages_promises')->delete();
+        DB::table('messages_outcomes')->delete();
+        DB::table('messages_groups')->delete();
+        DB::table('messages_items')->delete();
+        DB::table('messages_attachments')->delete();
+        DB::table('messages_edits')->delete();
+        DB::table('messages')->delete();
+        DB::table('chat_rooms')->delete();
+        DB::table('items')->delete();
+        DB::table('users')->delete();
+        DB::table('locations')->delete();
+        DB::table('groups')->update(['onlovejunk' => 0]);
+    }
+
+    private function createGroup(array $attrs = []): int
+    {
+        return DB::table('groups')->insertGetId(array_merge([
+            'nameshort' => 'TestLJGroup_' . uniqid(),
+            'namefull' => 'Test LoveJunk Group',
+            'type' => 'Freegle',
+            'onlovejunk' => 1,
+            'onhere' => 1,
+            'publish' => 1,
+            'lat' => 51.5,
+            'lng' => -0.1,
+        ], $attrs));
+    }
+
+    private function createUser(array $attrs = []): int
+    {
+        return DB::table('users')->insertGetId(array_merge([
+            'firstname' => 'Test',
+            'lastname' => 'User',
+            'fullname' => 'Test User',
+            'added' => now(),
+        ], $attrs));
+    }
+
+    private function createLocation(array $attrs = []): int
+    {
+        return DB::table('locations')->insertGetId(array_merge([
+            'name' => 'SW1A 1AA',
+            'type' => 'Postcode',
+            'lat' => 51.5014,
+            'lng' => -0.1419,
+        ], $attrs));
+    }
+
+    private function createMessage(int $userId, int $groupId, int $locationId, array $attrs = []): int
+    {
+        $msgId = DB::table('messages')->insertGetId(array_merge([
+            'fromuser' => $userId,
+            'type' => 'Offer',
+            'subject' => 'OFFER: Old sofa (London)',
+            'textbody' => 'Free sofa in good condition.',
+            'sourceheader' => 'freegle',
+            'locationid' => $locationId,
+            'lat' => 51.5014,
+            'lng' => -0.1419,
+            'arrival' => now(),
+            'date' => now(),
+        ], $attrs));
+
+        DB::table('messages_groups')->insert([
+            'msgid' => $msgId,
+            'groupid' => $groupId,
+            'collection' => 'Approved',
+            'arrival' => now(),
+        ]);
+
+        return $msgId;
+    }
+
+    private function fakeSuccessfulPost(array $body = []): void
+    {
+        Http::fake([
+            '*/freegle/drafts*' => Http::response(json_encode(array_merge(['body' => ['draftId' => 'lj-draft-001']], $body)), 200),
+        ]);
+    }
+
+    public function test_syncs_new_message_to_lovejunk(): void
+    {
+        $this->fakeSuccessfulPost();
+
+        $userId = $this->createUser();
+        $groupId = $this->createGroup();
+        $locationId = $this->createLocation();
+        $msgId = $this->createMessage($userId, $groupId, $locationId);
+
+        // Add item name
+        $itemId = DB::table('items')->insertGetId(['name' => 'Sofa', 'popularity' => 1, 'updated' => now()]);
+        DB::table('messages_items')->insert(['msgid' => $msgId, 'itemid' => $itemId]);
+
+        $service = new LoveJunkService();
+        $result = $service->sync();
+
+        $this->assertEquals(1, $result['sent']);
+        $this->assertEquals(0, $result['edited']);
+        $this->assertEquals(0, $result['completed_or_deleted']);
+
+        // Verify lovejunk table was updated
+        $lj = DB::table('lovejunk')->where('msgid', $msgId)->first();
+        $this->assertNotNull($lj);
+        $this->assertEquals(1, $lj->success);
+        $this->assertStringContainsString('lj-draft-001', $lj->status);
+    }
+
+    public function test_skips_message_already_sent_to_lovejunk(): void
+    {
+        Http::fake();
+
+        $userId = $this->createUser();
+        $groupId = $this->createGroup();
+        $locationId = $this->createLocation();
+        $msgId = $this->createMessage($userId, $groupId, $locationId);
+
+        // Pre-insert lovejunk record (already sent)
+        DB::table('lovejunk')->insert(['msgid' => $msgId, 'success' => 1, 'status' => '{"draftId":"existing"}']);
+
+        $service = new LoveJunkService();
+        $result = $service->sync();
+
+        $this->assertEquals(0, $result['sent']);
+        Http::assertNothingSent();
+    }
+
+    public function test_skips_message_from_non_lovejunk_group(): void
+    {
+        Http::fake();
+
+        $userId = $this->createUser();
+        $groupId = $this->createGroup(['onlovejunk' => 0]);
+        $locationId = $this->createLocation();
+        $this->createMessage($userId, $groupId, $locationId);
+
+        $service = new LoveJunkService();
+        $result = $service->sync();
+
+        $this->assertEquals(0, $result['sent']);
+        Http::assertNothingSent();
+    }
+
+    public function test_skips_message_without_postcode(): void
+    {
+        Http::fake();
+
+        $userId = $this->createUser();
+        $groupId = $this->createGroup();
+        // No locationId for this message
+        $msgId = DB::table('messages')->insertGetId([
+            'fromuser' => $userId,
+            'type' => 'Offer',
+            'subject' => 'OFFER: Chair (London)',
+            'textbody' => 'Old chair.',
+            'sourceheader' => 'freegle',
+            'locationid' => null,
+            'lat' => null,
+            'lng' => null,
+            'arrival' => now(),
+            'date' => now(),
+        ]);
+        DB::table('messages_groups')->insert(['msgid' => $msgId, 'groupid' => $groupId, 'collection' => 'Approved', 'arrival' => now()]);
+
+        $service = new LoveJunkService();
+        $result = $service->sync();
+
+        $this->assertEquals(0, $result['sent']);
+        Http::assertNothingSent();
+    }
+
+    public function test_handles_api_failure_gracefully(): void
+    {
+        Http::fake([
+            '*/freegle/drafts*' => Http::response('Server Error', 500),
+        ]);
+
+        $userId = $this->createUser();
+        $groupId = $this->createGroup();
+        $locationId = $this->createLocation();
+        $msgId = $this->createMessage($userId, $groupId, $locationId);
+
+        $service = new LoveJunkService();
+        $result = $service->sync();
+
+        $this->assertEquals(0, $result['sent']);
+        $this->assertEquals(1, $result['failed']);
+
+        // Should record a failed entry
+        $lj = DB::table('lovejunk')->where('msgid', $msgId)->first();
+        $this->assertNotNull($lj);
+        $this->assertEquals(0, $lj->success);
+    }
+
+    public function test_syncs_edited_message(): void
+    {
+        Http::fake([
+            '*/freegle/drafts/lj-draft-001' => Http::response('', 200),
+        ]);
+
+        $userId = $this->createUser();
+        $groupId = $this->createGroup();
+        $locationId = $this->createLocation();
+        $msgId = $this->createMessage($userId, $groupId, $locationId);
+
+        // Pre-insert a successful lovejunk record
+        DB::table('lovejunk')->insert([
+            'msgid' => $msgId,
+            'success' => 1,
+            'status' => json_encode(['draftId' => 'lj-draft-001']),
+            'timestamp' => now()->subHour(),
+        ]);
+
+        // Create an edit AFTER the lovejunk sync time
+        DB::table('messages_edits')->insert([
+            'msgid' => $msgId,
+            'timestamp' => now(),
+            'byuser' => $userId,
+        ]);
+
+        $service = new LoveJunkService();
+        $result = $service->sync();
+
+        $this->assertEquals(0, $result['sent']);
+        $this->assertEquals(1, $result['edited']);
+    }
+
+    public function test_deletes_message_with_outcome_no_promise(): void
+    {
+        Http::fake([
+            '*/freegle/drafts/lj-draft-002*' => Http::response('', 200),
+        ]);
+
+        $userId = $this->createUser();
+        $groupId = $this->createGroup();
+        $locationId = $this->createLocation();
+        $msgId = $this->createMessage($userId, $groupId, $locationId);
+
+        DB::table('lovejunk')->insert([
+            'msgid' => $msgId,
+            'success' => 1,
+            'status' => json_encode(['draftId' => 'lj-draft-002']),
+        ]);
+
+        // Add an outcome (message was taken/withdrawn)
+        DB::table('messages_outcomes')->insert([
+            'msgid' => $msgId,
+            'outcome' => 'Taken',
+            'happiness' => null,
+            'timestamp' => now(),
+        ]);
+
+        $service = new LoveJunkService();
+        $result = $service->sync();
+
+        $this->assertEquals(1, $result['completed_or_deleted']);
+
+        // Should mark as deleted in lovejunk table
+        $lj = DB::table('lovejunk')->where('msgid', $msgId)->first();
+        $this->assertNotNull($lj->deleted);
+    }
+}

--- a/iznik-batch/tests/Unit/Services/MessageDeindexServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/MessageDeindexServiceTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Models\Message;
+use App\Models\MessageGroup;
+use App\Services\MessageDeindexService;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class MessageDeindexServiceTest extends TestCase
+{
+    protected MessageDeindexService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new MessageDeindexService();
+        DB::table('messages_index')->delete();
+        DB::table('words_cache')->delete();
+        DB::table('words')->insertOrIgnore(['word' => 'testword', 'firstthree' => 'tes', 'soundex' => 'T363']);
+        $this->wordId = DB::table('words')->where('word', 'testword')->value('id');
+    }
+
+    public function test_deindexes_messages_older_than_30_days(): void
+    {
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+
+        $message = Message::create([
+            'type' => Message::TYPE_OFFER,
+            'fromuser' => $user->id,
+            'subject' => 'OFFER: old sofa (London)',
+            'textbody' => 'Old sofa.',
+            'source' => 'Platform',
+            'date' => now()->subDays(31),
+            'arrival' => now()->subDays(31),
+            'lat' => $group->lat,
+            'lng' => $group->lng,
+        ]);
+        MessageGroup::create([
+            'msgid' => $message->id,
+            'groupid' => $group->id,
+            'collection' => MessageGroup::COLLECTION_APPROVED,
+            'arrival' => now()->subDays(31),
+        ]);
+
+        // Seed index entry for this old message.
+        DB::table('messages_index')->insert([
+            'msgid' => $message->id,
+            'wordid' => $this->wordId,
+            'arrival' => -now()->subDays(31)->timestamp,
+            'groupid' => $group->id,
+        ]);
+
+        $result = $this->service->deindexOldMessages();
+
+        $this->assertEquals(0, DB::table('messages_index')->where('msgid', $message->id)->count());
+        $this->assertGreaterThanOrEqual(1, $result['deindexed']);
+    }
+
+    public function test_recent_messages_not_deindexed(): void
+    {
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+
+        $message = Message::create([
+            'type' => Message::TYPE_OFFER,
+            'fromuser' => $user->id,
+            'subject' => 'OFFER: recent chair (London)',
+            'textbody' => 'Recent chair.',
+            'source' => 'Platform',
+            'date' => now()->subDays(5),
+            'arrival' => now()->subDays(5),
+            'lat' => $group->lat,
+            'lng' => $group->lng,
+        ]);
+        MessageGroup::create([
+            'msgid' => $message->id,
+            'groupid' => $group->id,
+            'collection' => MessageGroup::COLLECTION_APPROVED,
+            'arrival' => now()->subDays(5),
+        ]);
+
+        DB::table('messages_index')->insert([
+            'msgid' => $message->id,
+            'wordid' => $this->wordId,
+            'arrival' => -now()->subDays(5)->timestamp,
+            'groupid' => $group->id,
+        ]);
+
+        $this->service->deindexOldMessages();
+
+        $this->assertEquals(1, DB::table('messages_index')->where('msgid', $message->id)->count());
+    }
+
+    public function test_words_cache_cleared(): void
+    {
+        DB::table('words_cache')->insert(['search' => 'sofa', 'words' => '1,2,3']);
+
+        $this->service->deindexOldMessages();
+
+        $this->assertEquals(0, DB::table('words_cache')->count());
+    }
+
+    public function test_returns_zero_when_nothing_to_deindex(): void
+    {
+        $result = $this->service->deindexOldMessages();
+
+        $this->assertEquals(0, $result['deindexed']);
+    }
+}

--- a/iznik-batch/tests/Unit/Services/MessageExpiryServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/MessageExpiryServiceTest.php
@@ -126,8 +126,75 @@ class MessageExpiryServiceTest extends TestCase
         $stats = $this->service->processDeadlineExpired();
 
         $this->assertEquals(1, $stats['processed']);
-        // Email should not be sent since user has no email.
+        $this->assertEquals(0, $stats['emails_sent']);
         Mail::assertNothingSent();
+    }
+
+    public function test_multi_group_message_processed_once(): void
+    {
+        Mail::fake();
+
+        $user = $this->createTestUser();
+        $group1 = $this->createTestGroup();
+        $group2 = $this->createTestGroup();
+        $this->createMembership($user, $group1);
+        $this->createMembership($user, $group2);
+
+        $message = $this->createTestMessage($user, $group1);
+
+        // Add the same message to a second group.
+        DB::table('messages_groups')->insert([
+            'msgid' => $message->id,
+            'groupid' => $group2->id,
+            'collection' => 'Approved',
+            'arrival' => now(),
+        ]);
+
+        $message->deadline = now()->subDays(1)->format('Y-m-d');
+        $message->save();
+
+        $stats = $this->service->processDeadlineExpired();
+
+        // Message in 2 groups must only be processed once.
+        $this->assertEquals(1, $stats['processed']);
+        $this->assertEquals(1, $stats['emails_sent']);
+        $this->assertEquals(1, MessageOutcome::where('msgid', $message->id)->count());
+
+        Mail::assertSent(DeadlineReached::class, 1);
+    }
+
+    public function test_expiry_clears_messages_outcomes_intended(): void
+    {
+        Mail::fake();
+
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $this->createMembership($user, $group);
+
+        $message = $this->createTestMessage($user, $group);
+
+        $message->deadline = now()->subDays(1)->format('Y-m-d');
+        $message->save();
+
+        // Create a pre-existing intended outcome.
+        DB::table('messages_outcomes_intended')->insert([
+            'msgid' => $message->id,
+            'outcome' => MessageOutcome::OUTCOME_TAKEN,
+            'timestamp' => now(),
+        ]);
+
+        $stats = $this->service->processDeadlineExpired();
+
+        $this->assertEquals(1, $stats['processed']);
+
+        // Intended outcome must be cleared.
+        $this->assertDatabaseMissing('messages_outcomes_intended', ['msgid' => $message->id]);
+
+        // Real outcome must be created.
+        $this->assertDatabaseHas('messages_outcomes', [
+            'msgid' => $message->id,
+            'outcome' => MessageOutcome::OUTCOME_EXPIRED,
+        ]);
     }
 
     public function test_process_expired_from_spatial_index(): void

--- a/iznik-batch/tests/Unit/Services/MessageIllustrationsServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/MessageIllustrationsServiceTest.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Models\Message;
+use App\Models\MessageGroup;
+use App\Services\MessageIllustrationsService;
+use App\Services\PollinationsService;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class MessageIllustrationsServiceTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        DB::table('config')->where('key', 'illustrations_last_arrival')->delete();
+        DB::table('messages_ai_declined')->delete();
+        DB::table('messages_attachments')->delete();
+        DB::table('messages_spatial')->delete();
+        DB::table('ai_images')->delete();
+    }
+
+    private function makeService(?object $mockPollinations = null): MessageIllustrationsService
+    {
+        $mock = $mockPollinations ?? $this->makeMockPollinations();
+
+        return new MessageIllustrationsService($mock);
+    }
+
+    private function makeMockPollinations(array $fetchResult = null): object
+    {
+        $mock = $this->createMock(PollinationsService::class);
+        $mock->method('shouldSkipItem')->willReturn(false);
+        $mock->method('recordFailure')->willReturn(false);
+        $mock->method('fetchBatch')->willReturn($fetchResult ?? ['results' => [], 'failed' => []]);
+        $mock->method('buildMessagePrompt')->willReturnCallback(fn ($n) => "prompt for $n");
+        $mock->method('uploadImageAndCache')->willReturn('freegletusd-testuid123');
+
+        return $mock;
+    }
+
+    private function createMessageInSpatial(string $subject = 'OFFER: Test Lamp (TestTown)'): object
+    {
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+
+        $message = Message::create([
+            'type' => Message::TYPE_OFFER,
+            'fromuser' => $user->id,
+            'subject' => $subject,
+            'textbody' => 'Test',
+            'source' => 'Platform',
+            'date' => now()->subMinutes(10),
+            'arrival' => now()->subMinutes(10),
+            'lat' => $group->lat,
+            'lng' => $group->lng,
+        ]);
+
+        MessageGroup::create([
+            'msgid' => $message->id,
+            'groupid' => $group->id,
+            'collection' => MessageGroup::COLLECTION_APPROVED,
+            'arrival' => now()->subMinutes(10),
+        ]);
+
+        DB::statement(
+            "INSERT INTO messages_spatial (msgid, point, groupid, msgtype, arrival)
+             VALUES (?, ST_GeomFromText('POINT(-0.1 51.5)', 3857), ?, ?, ?)",
+            [$message->id, $group->id, 'Offer', now()->subMinutes(10)]
+        );
+
+        return $message;
+    }
+
+    public function test_processes_message_using_cached_illustration(): void
+    {
+        $message = $this->createMessageInSpatial('OFFER: Vintage Lamp (TestTown)');
+
+        DB::table('ai_images')->insert([
+            'name' => 'Vintage Lamp',
+            'externaluid' => 'freegletusd-cached999',
+            'imagehash' => 'abc123',
+        ]);
+
+        $service = $this->makeService();
+        $result = $service->processIllustrations();
+
+        $attachment = DB::table('messages_attachments')->where('msgid', $message->id)->first();
+        $this->assertNotNull($attachment, 'Expected attachment to be created for message');
+        $this->assertEquals('freegletusd-cached999', $attachment->externaluid);
+        $externalmods = json_decode($attachment->externalmods, true);
+        $this->assertTrue($externalmods['ai']);
+        $this->assertGreaterThanOrEqual(1, $result['processed']);
+    }
+
+    public function test_skips_message_in_declined_table(): void
+    {
+        $message = $this->createMessageInSpatial('OFFER: Widget (TestTown)');
+
+        DB::table('messages_ai_declined')->insert(['msgid' => $message->id]);
+
+        $service = $this->makeService();
+        $service->processIllustrations();
+
+        $count = DB::table('messages_attachments')->where('msgid', $message->id)->count();
+        $this->assertEquals(0, $count, 'Should not create attachment for declined message');
+    }
+
+    public function test_cleans_ai_attachment_when_user_adds_photo(): void
+    {
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $message = Message::create([
+            'type' => Message::TYPE_OFFER,
+            'fromuser' => $user->id,
+            'subject' => 'OFFER: Kettle (TestTown)',
+            'textbody' => 'Test',
+            'source' => 'Platform',
+            'date' => now(),
+            'arrival' => now(),
+            'lat' => $group->lat,
+            'lng' => $group->lng,
+        ]);
+
+        // AI attachment.
+        $aiAttachId = DB::table('messages_attachments')->insertGetId([
+            'msgid' => $message->id,
+            'externaluid' => 'freegletusd-ai001',
+            'externalmods' => json_encode(['ai' => true]),
+            'contenttype' => 'image/jpeg',
+        ]);
+
+        // User's own attachment.
+        DB::table('messages_attachments')->insert([
+            'msgid' => $message->id,
+            'externaluid' => 'freegletusd-user001',
+            'externalmods' => null,
+            'contenttype' => 'image/jpeg',
+            'primary' => 1,
+        ]);
+
+        $service = $this->makeService();
+        $result = $service->processIllustrations();
+
+        $this->assertGreaterThanOrEqual(1, $result['cleaned']);
+        $this->assertFalse(
+            DB::table('messages_attachments')->where('id', $aiAttachId)->exists(),
+            'AI attachment should have been deleted'
+        );
+        $this->assertTrue(
+            DB::table('messages_attachments')->where('externaluid', 'freegletusd-user001')->exists(),
+            'User attachment should remain'
+        );
+    }
+
+    public function test_updates_last_arrival_in_config(): void
+    {
+        $this->createMessageInSpatial('OFFER: Toaster (TestTown)');
+
+        DB::table('ai_images')->insert([
+            'name' => 'Toaster',
+            'externaluid' => 'freegletusd-toaster',
+            'imagehash' => 'hash001',
+        ]);
+
+        $service = $this->makeService();
+        $service->processIllustrations();
+
+        $lastArrival = DB::table('config')->where('key', 'illustrations_last_arrival')->value('value');
+        $this->assertNotNull($lastArrival, 'Config should have last arrival set after processing');
+    }
+}

--- a/iznik-batch/tests/Unit/Services/MessageIndexUnindexedServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/MessageIndexUnindexedServiceTest.php
@@ -1,0 +1,192 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Models\Message;
+use App\Models\MessageGroup;
+use App\Services\MessageIndexUnindexedService;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class MessageIndexUnindexedServiceTest extends TestCase
+{
+    protected MessageIndexUnindexedService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new MessageIndexUnindexedService();
+        DB::table('messages_index')->delete();
+        DB::table('messages_groups')->delete();
+        DB::table('words_cache')->delete();
+    }
+
+    public function test_indexes_recent_unindexed_message(): void
+    {
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+
+        $message = Message::create([
+            'type' => Message::TYPE_OFFER,
+            'fromuser' => $user->id,
+            'subject' => 'OFFER: bicycle (London)',
+            'textbody' => 'A bicycle.',
+            'source' => 'Platform',
+            'date' => now()->subDays(3),
+            'arrival' => now()->subDays(3),
+            'lat' => $group->lat,
+            'lng' => $group->lng,
+        ]);
+        MessageGroup::create([
+            'msgid' => $message->id,
+            'groupid' => $group->id,
+            'collection' => MessageGroup::COLLECTION_APPROVED,
+            'arrival' => now()->subDays(3),
+        ]);
+
+        $result = $this->service->indexUnindexedMessages();
+
+        $this->assertGreaterThanOrEqual(1, $result['indexed']);
+        $this->assertGreaterThan(0, DB::table('messages_index')->where('msgid', $message->id)->count());
+    }
+
+    public function test_does_not_reindex_already_indexed_message(): void
+    {
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+
+        $message = Message::create([
+            'type' => Message::TYPE_OFFER,
+            'fromuser' => $user->id,
+            'subject' => 'OFFER: table (London)',
+            'textbody' => 'A table.',
+            'source' => 'Platform',
+            'date' => now()->subDays(3),
+            'arrival' => now()->subDays(3),
+            'lat' => $group->lat,
+            'lng' => $group->lng,
+        ]);
+        MessageGroup::create([
+            'msgid' => $message->id,
+            'groupid' => $group->id,
+            'collection' => MessageGroup::COLLECTION_APPROVED,
+            'arrival' => now()->subDays(3),
+        ]);
+
+        // Pre-seed an index entry.
+        DB::table('words')->insertOrIgnore(['word' => 'table', 'firstthree' => 'tab', 'soundex' => 'T140']);
+        $wordId = DB::table('words')->where('word', 'table')->value('id');
+        DB::table('messages_index')->insert([
+            'msgid' => $message->id,
+            'wordid' => $wordId,
+            'arrival' => -now()->subDays(3)->timestamp,
+            'groupid' => $group->id,
+        ]);
+
+        $result = $this->service->indexUnindexedMessages();
+
+        // Already indexed — should not be in the "indexed" count.
+        $this->assertEquals(0, $result['indexed']);
+    }
+
+    public function test_parses_subject_to_index_item_not_type(): void
+    {
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+
+        // Subject "OFFER: widget (London)" — item is "widget", type is "offer", location is "london"
+        $message = Message::create([
+            'type' => Message::TYPE_OFFER,
+            'fromuser' => $user->id,
+            'subject' => 'OFFER: widget (London)',
+            'textbody' => 'A widget.',
+            'source' => 'Platform',
+            'date' => now()->subDays(3),
+            'arrival' => now()->subDays(3),
+            'lat' => $group->lat,
+            'lng' => $group->lng,
+        ]);
+        MessageGroup::create([
+            'msgid' => $message->id,
+            'groupid' => $group->id,
+            'collection' => MessageGroup::COLLECTION_APPROVED,
+            'arrival' => now()->subDays(3),
+        ]);
+
+        $this->service->indexUnindexedMessages();
+
+        // "widget" should be indexed
+        $widgetId = DB::table('words')->where('word', 'widget')->value('id');
+        $this->assertNotNull($widgetId);
+        $this->assertGreaterThan(0, DB::table('messages_index')
+            ->where('msgid', $message->id)
+            ->where('wordid', $widgetId)
+            ->count());
+
+        // "offer" should NOT be indexed (it's a common/type word — actually "offer" is in the $common list)
+        $offerId = DB::table('words')->where('word', 'offer')->value('id');
+        if ($offerId) {
+            $this->assertEquals(0, DB::table('messages_index')
+                ->where('msgid', $message->id)
+                ->where('wordid', $offerId)
+                ->count());
+        }
+    }
+
+    public function test_old_messages_not_indexed(): void
+    {
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+
+        $message = Message::create([
+            'type' => Message::TYPE_OFFER,
+            'fromuser' => $user->id,
+            'subject' => 'OFFER: old lamp (London)',
+            'textbody' => 'An old lamp.',
+            'source' => 'Platform',
+            'date' => now()->subDays(40),
+            'arrival' => now()->subDays(40),
+            'lat' => $group->lat,
+            'lng' => $group->lng,
+        ]);
+        MessageGroup::create([
+            'msgid' => $message->id,
+            'groupid' => $group->id,
+            'collection' => MessageGroup::COLLECTION_APPROVED,
+            'arrival' => now()->subDays(40),
+        ]);
+
+        $result = $this->service->indexUnindexedMessages();
+
+        $this->assertEquals(0, DB::table('messages_index')->where('msgid', $message->id)->count());
+    }
+
+    public function test_deleted_messages_not_indexed(): void
+    {
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+
+        $message = Message::create([
+            'type' => Message::TYPE_OFFER,
+            'fromuser' => $user->id,
+            'subject' => 'OFFER: chair (London)',
+            'textbody' => 'A chair.',
+            'source' => 'Platform',
+            'date' => now()->subDays(3),
+            'arrival' => now()->subDays(3),
+            'lat' => $group->lat,
+            'lng' => $group->lng,
+        ]);
+        MessageGroup::create([
+            'msgid' => $message->id,
+            'groupid' => $group->id,
+            'collection' => MessageGroup::COLLECTION_APPROVED,
+            'arrival' => now()->subDays(3),
+            'deleted' => 1,
+        ]);
+
+        $result = $this->service->indexUnindexedMessages();
+
+        $this->assertEquals(0, DB::table('messages_index')->where('msgid', $message->id)->count());
+    }
+}

--- a/iznik-batch/tests/Unit/Services/MessageRemapSubjectsServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/MessageRemapSubjectsServiceTest.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Models\Message;
+use App\Models\MessageGroup;
+use App\Services\MessageRemapSubjectsService;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class MessageRemapSubjectsServiceTest extends TestCase
+{
+    protected MessageRemapSubjectsService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new MessageRemapSubjectsService();
+    }
+
+    public function test_updates_subject_when_location_name_changes(): void
+    {
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+
+        // Create a location with old name, then update it.
+        $locationId = DB::table('locations')->insertGetId([
+            'name' => 'New Town',
+            'type' => 'Polygon',
+            'lat' => 51.5,
+            'lng' => -0.1,
+            'timestamp' => now()->subHours(1),
+        ]);
+
+        // Create an item.
+        DB::table('items')->insertOrIgnore(['name' => 'sofa']);
+        $itemId = DB::table('items')->where('name', 'sofa')->value('id');
+
+        // Create a message with OLD location name in subject.
+        $message = Message::create([
+            'type' => Message::TYPE_OFFER,
+            'fromuser' => $user->id,
+            'subject' => 'OFFER: sofa (Old Town)',
+            'textbody' => 'A sofa.',
+            'source' => 'Platform',
+            'date' => now()->subDays(5),
+            'arrival' => now()->subDays(5),
+            'lat' => $group->lat,
+            'lng' => $group->lng,
+            'locationid' => $locationId,
+        ]);
+        DB::table('messages_items')->insertOrIgnore(['msgid' => $message->id, 'itemid' => $itemId]);
+        MessageGroup::create([
+            'msgid' => $message->id,
+            'groupid' => $group->id,
+            'collection' => MessageGroup::COLLECTION_APPROVED,
+            'arrival' => now()->subDays(5),
+        ]);
+
+        $result = $this->service->remapSubjects();
+
+        $updated = DB::table('messages')->where('id', $message->id)->value('subject');
+        $this->assertStringContainsString('New Town', $updated);
+        $this->assertGreaterThanOrEqual(1, $result['changed']);
+    }
+
+    public function test_skips_message_when_location_unchanged(): void
+    {
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+
+        $locationId = DB::table('locations')->insertGetId([
+            'name' => 'Same Town',
+            'type' => 'Polygon',
+            'lat' => 51.5,
+            'lng' => -0.1,
+            'timestamp' => now()->subHours(1),
+        ]);
+        DB::table('items')->insertOrIgnore(['name' => 'chair']);
+        $itemId = DB::table('items')->where('name', 'chair')->value('id');
+
+        $message = Message::create([
+            'type' => Message::TYPE_OFFER,
+            'fromuser' => $user->id,
+            'subject' => 'OFFER: chair (Same Town)',
+            'textbody' => 'A chair.',
+            'source' => 'Platform',
+            'date' => now()->subDays(5),
+            'arrival' => now()->subDays(5),
+            'lat' => $group->lat,
+            'lng' => $group->lng,
+            'locationid' => $locationId,
+        ]);
+        DB::table('messages_items')->insertOrIgnore(['msgid' => $message->id, 'itemid' => $itemId]);
+        MessageGroup::create([
+            'msgid' => $message->id,
+            'groupid' => $group->id,
+            'collection' => MessageGroup::COLLECTION_APPROVED,
+            'arrival' => now()->subDays(5),
+        ]);
+
+        $result = $this->service->remapSubjects();
+
+        $this->assertEquals(0, $result['changed']);
+    }
+
+    public function test_returns_zero_for_old_messages(): void
+    {
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+
+        $locationId = DB::table('locations')->insertGetId([
+            'name' => 'Updated Area',
+            'type' => 'Polygon',
+            'lat' => 51.5,
+            'lng' => -0.1,
+            'timestamp' => now()->subHours(1),
+        ]);
+
+        $message = Message::create([
+            'type' => Message::TYPE_OFFER,
+            'fromuser' => $user->id,
+            'subject' => 'OFFER: lamp (Old Area)',
+            'textbody' => 'A lamp.',
+            'source' => 'Platform',
+            'date' => now()->subDays(91),
+            'arrival' => now()->subDays(91),
+            'lat' => $group->lat,
+            'lng' => $group->lng,
+            'locationid' => $locationId,
+        ]);
+        MessageGroup::create([
+            'msgid' => $message->id,
+            'groupid' => $group->id,
+            'collection' => MessageGroup::COLLECTION_APPROVED,
+            'arrival' => now()->subDays(91),
+        ]);
+
+        $result = $this->service->remapSubjects();
+
+        $this->assertEquals(0, $result['changed']);
+    }
+}

--- a/iznik-batch/tests/Unit/Services/MessageSpatialIndexServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/MessageSpatialIndexServiceTest.php
@@ -1,0 +1,199 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Models\Message;
+use App\Models\MessageGroup;
+use App\Services\MessageSpatialIndexService;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class MessageSpatialIndexServiceTest extends TestCase
+{
+    protected MessageSpatialIndexService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new MessageSpatialIndexService();
+        DB::statement('DELETE FROM messages_spatial');
+    }
+
+    public function test_adds_new_approved_message_to_spatial_index(): void
+    {
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+
+        $message = Message::create([
+            'type' => Message::TYPE_OFFER,
+            'fromuser' => $user->id,
+            'subject' => 'OFFER: sofa (London)',
+            'textbody' => 'A sofa.',
+            'source' => 'Platform',
+            'date' => now()->subDays(5),
+            'arrival' => now()->subDays(5),
+            'lat' => 51.5,
+            'lng' => -0.1,
+        ]);
+        MessageGroup::create([
+            'msgid' => $message->id,
+            'groupid' => $group->id,
+            'collection' => MessageGroup::COLLECTION_APPROVED,
+            'arrival' => now()->subDays(5),
+        ]);
+
+        $result = $this->service->updateSpatialIndex();
+
+        $this->assertEquals(1, DB::table('messages_spatial')->where('msgid', $message->id)->count());
+        $this->assertGreaterThanOrEqual(1, $result['indexed']);
+    }
+
+    public function test_removes_withdrawn_message_from_spatial_index(): void
+    {
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+
+        $message = Message::create([
+            'type' => Message::TYPE_OFFER,
+            'fromuser' => $user->id,
+            'subject' => 'OFFER: chair (London)',
+            'textbody' => 'A chair.',
+            'source' => 'Platform',
+            'date' => now()->subDays(5),
+            'arrival' => now()->subDays(5),
+            'lat' => 51.5,
+            'lng' => -0.1,
+        ]);
+        MessageGroup::create([
+            'msgid' => $message->id,
+            'groupid' => $group->id,
+            'collection' => MessageGroup::COLLECTION_APPROVED,
+            'arrival' => now()->subDays(5),
+        ]);
+
+        // Put it in the spatial index.
+        DB::statement(
+            "INSERT INTO messages_spatial (msgid, point, groupid, msgtype, arrival) VALUES (?, ST_GeomFromText('POINT(-0.1 51.5)', 3857), ?, ?, ?)",
+            [$message->id, $group->id, Message::TYPE_OFFER, now()->subDays(5)]
+        );
+
+        // Mark as withdrawn.
+        DB::table('messages_outcomes')->insert([
+            'msgid' => $message->id,
+            'outcome' => Message::OUTCOME_WITHDRAWN,
+        ]);
+
+        $this->service->updateSpatialIndex();
+
+        $this->assertEquals(0, DB::table('messages_spatial')->where('msgid', $message->id)->count());
+    }
+
+    public function test_removes_deleted_message_from_spatial_index(): void
+    {
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+
+        $message = Message::create([
+            'type' => Message::TYPE_OFFER,
+            'fromuser' => $user->id,
+            'subject' => 'OFFER: lamp (London)',
+            'textbody' => 'A lamp.',
+            'source' => 'Platform',
+            'date' => now()->subDays(5),
+            'arrival' => now()->subDays(5),
+            'lat' => 51.5,
+            'lng' => -0.1,
+        ]);
+        MessageGroup::create([
+            'msgid' => $message->id,
+            'groupid' => $group->id,
+            'collection' => MessageGroup::COLLECTION_APPROVED,
+            'arrival' => now()->subDays(5),
+        ]);
+
+        DB::statement(
+            "INSERT INTO messages_spatial (msgid, point, groupid, msgtype, arrival) VALUES (?, ST_GeomFromText('POINT(-0.1 51.5)', 3857), ?, ?, ?)",
+            [$message->id, $group->id, Message::TYPE_OFFER, now()->subDays(5)]
+        );
+
+        // Mark message as deleted.
+        DB::table('messages')->where('id', $message->id)->update(['deleted' => now()]);
+
+        $this->service->updateSpatialIndex();
+
+        $this->assertEquals(0, DB::table('messages_spatial')->where('msgid', $message->id)->count());
+    }
+
+    public function test_removes_old_messages_from_spatial_index(): void
+    {
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+
+        $message = Message::create([
+            'type' => Message::TYPE_OFFER,
+            'fromuser' => $user->id,
+            'subject' => 'OFFER: table (London)',
+            'textbody' => 'A table.',
+            'source' => 'Platform',
+            'date' => now()->subDays(32),
+            'arrival' => now()->subDays(32),
+            'lat' => 51.5,
+            'lng' => -0.1,
+        ]);
+        MessageGroup::create([
+            'msgid' => $message->id,
+            'groupid' => $group->id,
+            'collection' => MessageGroup::COLLECTION_APPROVED,
+            'arrival' => now()->subDays(32),
+        ]);
+
+        DB::statement(
+            "INSERT INTO messages_spatial (msgid, point, groupid, msgtype, arrival) VALUES (?, ST_GeomFromText('POINT(-0.1 51.5)', 3857), ?, ?, ?)",
+            [$message->id, $group->id, Message::TYPE_OFFER, now()->subDays(32)]
+        );
+
+        $this->service->updateSpatialIndex();
+
+        $this->assertEquals(0, DB::table('messages_spatial')->where('msgid', $message->id)->count());
+    }
+
+    public function test_marks_taken_message_as_successful(): void
+    {
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+
+        $message = Message::create([
+            'type' => Message::TYPE_OFFER,
+            'fromuser' => $user->id,
+            'subject' => 'OFFER: book (London)',
+            'textbody' => 'A book.',
+            'source' => 'Platform',
+            'date' => now()->subDays(5),
+            'arrival' => now()->subDays(5),
+            'lat' => 51.5,
+            'lng' => -0.1,
+        ]);
+        MessageGroup::create([
+            'msgid' => $message->id,
+            'groupid' => $group->id,
+            'collection' => MessageGroup::COLLECTION_APPROVED,
+            'arrival' => now()->subDays(5),
+        ]);
+
+        DB::statement(
+            "INSERT INTO messages_spatial (msgid, point, groupid, msgtype, arrival, successful) VALUES (?, ST_GeomFromText('POINT(-0.1 51.5)', 3857), ?, ?, ?, 0)",
+            [$message->id, $group->id, Message::TYPE_OFFER, now()->subDays(5)]
+        );
+
+        DB::table('messages_outcomes')->insert([
+            'msgid' => $message->id,
+            'outcome' => Message::OUTCOME_TAKEN,
+        ]);
+
+        $this->service->updateSpatialIndex();
+
+        $row = DB::table('messages_spatial')->where('msgid', $message->id)->first();
+        $this->assertNotNull($row);
+        $this->assertEquals(1, $row->successful);
+    }
+}

--- a/iznik-batch/tests/Unit/Services/MicroVolunteeringScoreServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/MicroVolunteeringScoreServiceTest.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Services\MicroVolunteeringScoreService;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class MicroVolunteeringScoreServiceTest extends TestCase
+{
+    protected MicroVolunteeringScoreService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new MicroVolunteeringScoreService();
+        DB::table('microactions')->delete();
+    }
+
+    public function test_empty_input_returns_zero(): void
+    {
+        $result = $this->service->scoreAndPromote();
+
+        $this->assertEquals(0, $result['promoted']);
+    }
+
+    public function test_scoring_updates_score_positive_on_majority_match(): void
+    {
+        $user1 = $this->createTestUser();
+        $user2 = $this->createTestUser();
+        $user3 = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $message = $this->createTestMessage($user1, $group);
+
+        // Three users all say 'Approve' for the same message.
+        foreach ([$user1, $user2, $user3] as $user) {
+            DB::table('microactions')->insert([
+                'userid' => $user->id,
+                'msgid' => $message->id,
+                'result' => 'Approve',
+                'timestamp' => now()->subHours(24),
+            ]);
+        }
+
+        $this->service->scoreAndPromote();
+
+        // All three agree — majority is 'Approve', so score_positive should be 1 for all.
+        $scores = DB::table('microactions')
+            ->where('msgid', $message->id)
+            ->pluck('score_positive')
+            ->all();
+        $this->assertNotEmpty($scores);
+        foreach ($scores as $score) {
+            $this->assertEquals(1, $score);
+        }
+    }
+
+    public function test_scoring_updates_score_negative_on_minority(): void
+    {
+        $user1 = $this->createTestUser();
+        $user2 = $this->createTestUser();
+        $user3 = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $message = $this->createTestMessage($user1, $group);
+
+        // user1 says 'Reject', user2 and user3 say 'Approve' — user1 is in the minority.
+        DB::table('microactions')->insert([
+            'userid' => $user1->id, 'msgid' => $message->id, 'result' => 'Reject',
+            'timestamp' => now()->subHours(24),
+        ]);
+        DB::table('microactions')->insert([
+            'userid' => $user2->id, 'msgid' => $message->id, 'result' => 'Approve',
+            'timestamp' => now()->subHours(24),
+        ]);
+        DB::table('microactions')->insert([
+            'userid' => $user3->id, 'msgid' => $message->id, 'result' => 'Approve',
+            'timestamp' => now()->subHours(24),
+        ]);
+
+        $this->service->scoreAndPromote();
+
+        $user1Score = DB::table('microactions')
+            ->where('userid', $user1->id)
+            ->where('msgid', $message->id)
+            ->first();
+        $this->assertEquals(0, $user1Score->score_positive);
+        $this->assertEquals(1, $user1Score->score_negative);
+    }
+
+    public function test_promote_upgrades_accurate_user(): void
+    {
+        $user = $this->createTestUser();
+        DB::table('users')->where('id', $user->id)->update(['trustlevel' => 'Basic']);
+
+        // Insert 7+ days of high-accuracy microactions (msgid=null, promote doesn't need real messages).
+        for ($i = 0; $i <= 7; $i++) {
+            DB::table('microactions')->insert([
+                'userid' => $user->id,
+                'msgid' => null,
+                'result' => 'Approve',
+                'score_positive' => 1,
+                'score_negative' => 0,
+                'timestamp' => now()->subDays($i),
+            ]);
+        }
+
+        $result = $this->service->scoreAndPromote();
+
+        $trustlevel = DB::table('users')->where('id', $user->id)->value('trustlevel');
+        $this->assertEquals('Moderate', $trustlevel);
+        $this->assertGreaterThanOrEqual(1, $result['promoted']);
+    }
+
+    public function test_promote_skips_user_below_threshold(): void
+    {
+        $user = $this->createTestUser();
+        DB::table('users')->where('id', $user->id)->update(['trustlevel' => 'Basic']);
+
+        // Low accuracy: score_negative > score_positive.
+        for ($i = 0; $i <= 7; $i++) {
+            DB::table('microactions')->insert([
+                'userid' => $user->id,
+                'msgid' => null,
+                'result' => 'Approve',
+                'score_positive' => 0,
+                'score_negative' => 1,
+                'timestamp' => now()->subDays($i),
+            ]);
+        }
+
+        $this->service->scoreAndPromote();
+
+        $trustlevel = DB::table('users')->where('id', $user->id)->value('trustlevel');
+        $this->assertEquals('Basic', $trustlevel);
+    }
+}

--- a/iznik-batch/tests/Unit/Services/PurgeServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/PurgeServiceTest.php
@@ -137,6 +137,18 @@ class PurgeServiceTest extends TestCase
         $this->assertEquals(1, $count);
     }
 
+    public function test_purge_old_messages_history_default_is_31_days(): void
+    {
+        // V1 uses MessageCollection::RECENTPOSTS = "Midnight 31 days ago".
+        $oldId = DB::table('messages_history')->insertGetId(['arrival' => now()->subDays(32)]);
+        $recentId = DB::table('messages_history')->insertGetId(['arrival' => now()->subDays(30)]);
+
+        $this->service->purgeOldMessagesHistory();
+
+        $this->assertDatabaseMissing('messages_history', ['id' => $oldId]);
+        $this->assertDatabaseHas('messages_history', ['id' => $recentId]);
+    }
+
     public function test_purge_pending_messages(): void
     {
         $user = $this->createTestUser();

--- a/iznik-batch/tests/Unit/Services/UserLocationRemapServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/UserLocationRemapServiceTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Services\UserLocationRemapService;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class UserLocationRemapServiceTest extends TestCase
+{
+    protected UserLocationRemapService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new UserLocationRemapService();
+    }
+
+    public function test_updates_location_name_when_changed(): void
+    {
+        $location = DB::table('locations')->insertGetId([
+            'name' => 'New Location Name',
+            'type' => 'Polygon',
+            'lat' => 51.5,
+            'lng' => -0.1,
+        ]);
+
+        $user = $this->createTestUser();
+
+        // Store old name in settings.
+        $settings = json_encode([
+            'mylocation' => [
+                'id' => $location,
+                'name' => 'Old Location Name',
+                'lat' => 51.5,
+                'lng' => -0.1,
+            ],
+        ]);
+        DB::table('users')->where('id', $user->id)->update([
+            'settings' => $settings,
+            'lastaccess' => now()->subHours(12),
+        ]);
+
+        $result = $this->service->remapLocations();
+
+        $updated = DB::table('users')->where('id', $user->id)->value('settings');
+        $decoded = json_decode($updated, true);
+        $this->assertEquals('New Location Name', $decoded['mylocation']['name']);
+        $this->assertGreaterThanOrEqual(1, $result['changed']);
+    }
+
+    public function test_skips_user_when_name_unchanged(): void
+    {
+        $location = DB::table('locations')->insertGetId([
+            'name' => 'Same Name',
+            'type' => 'Polygon',
+            'lat' => 51.5,
+            'lng' => -0.1,
+        ]);
+
+        $user = $this->createTestUser();
+
+        $settings = json_encode([
+            'mylocation' => [
+                'id' => $location,
+                'name' => 'Same Name',
+            ],
+        ]);
+        DB::table('users')->where('id', $user->id)->update([
+            'settings' => $settings,
+            'lastaccess' => now()->subHours(12),
+        ]);
+
+        $result = $this->service->remapLocations();
+
+        $this->assertEquals(0, $result['changed']);
+    }
+
+    public function test_skips_user_inactive_more_than_48h(): void
+    {
+        $location = DB::table('locations')->insertGetId([
+            'name' => 'New Name',
+            'type' => 'Polygon',
+            'lat' => 51.5,
+            'lng' => -0.1,
+        ]);
+
+        $user = $this->createTestUser();
+
+        $settings = json_encode([
+            'mylocation' => ['id' => $location, 'name' => 'Old Name'],
+        ]);
+        DB::table('users')->where('id', $user->id)->update([
+            'settings' => $settings,
+            'lastaccess' => now()->subDays(3),
+        ]);
+
+        $result = $this->service->remapLocations();
+
+        $this->assertEquals(0, $result['changed']);
+    }
+
+    public function test_skips_user_with_no_settings(): void
+    {
+        $user = $this->createTestUser();
+        DB::table('users')->where('id', $user->id)->update([
+            'settings' => null,
+            'lastaccess' => now()->subHours(12),
+        ]);
+
+        $result = $this->service->remapLocations();
+
+        $this->assertEquals(0, $result['changed']);
+    }
+}

--- a/iznik-batch/tests/Unit/Services/WhatjobsSpamServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/WhatjobsSpamServiceTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Services\WhatjobsSpamService;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Tests\TestCase;
+
+class WhatjobsSpamServiceTest extends TestCase
+{
+    protected WhatjobsSpamService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new WhatjobsSpamService();
+        DB::table('jobs')->delete();
+    }
+
+    private function insertJob(array $overrides = []): void
+    {
+        $srid = config('freegle.srid', 3857);
+        $defaults = [
+            'title' => 'Test Job',
+            'location' => 'London ' . uniqid(),
+            'bodyhash' => null,
+            'visible' => 0,
+            'geometry' => DB::raw("ST_GeomFromText('POINT(-0.1278 51.5074)', $srid)"),
+        ];
+        DB::table('jobs')->insert(array_merge($defaults, $overrides));
+    }
+
+    public function test_empty_input_returns_zero(): void
+    {
+        $result = $this->service->deleteSpammyJobs();
+
+        $this->assertEquals(0, $result['deleted']);
+        $this->assertEquals(0, $result['spam_hashes']);
+    }
+
+    public function test_below_threshold_not_deleted(): void
+    {
+        // 50 jobs with same bodyhash — exactly at threshold, not over
+        for ($i = 0; $i < 50; $i++) {
+            $this->insertJob(['bodyhash' => 'aabbcc', 'title' => 'Spam Job']);
+        }
+
+        $result = $this->service->deleteSpammyJobs();
+
+        $this->assertEquals(0, $result['deleted']);
+        $this->assertEquals(50, DB::table('jobs')->where('bodyhash', 'aabbcc')->count());
+    }
+
+    public function test_above_threshold_all_deleted(): void
+    {
+        Log::spy();
+
+        // 51 jobs with same bodyhash — over threshold
+        for ($i = 0; $i < 51; $i++) {
+            $this->insertJob(['bodyhash' => 'spamhash1', 'title' => 'Spam Title']);
+        }
+        // 3 jobs with different bodyhash — should not be deleted
+        for ($i = 0; $i < 3; $i++) {
+            $this->insertJob(['bodyhash' => 'safehash', 'title' => 'Safe Job']);
+        }
+
+        $result = $this->service->deleteSpammyJobs();
+
+        $this->assertEquals(51, $result['deleted']);
+        $this->assertEquals(1, $result['spam_hashes']);
+        $this->assertEquals(0, DB::table('jobs')->where('bodyhash', 'spamhash1')->count());
+        $this->assertEquals(3, DB::table('jobs')->where('bodyhash', 'safehash')->count());
+
+        Log::shouldHaveReceived('info')
+            ->withArgs(fn ($msg) => str_contains($msg, 'Spam Title') && str_contains($msg, '51'))
+            ->once();
+    }
+
+    public function test_null_bodyhash_not_deleted(): void
+    {
+        // 51 jobs with NULL bodyhash — should not be affected
+        for ($i = 0; $i < 51; $i++) {
+            $this->insertJob(['bodyhash' => null]);
+        }
+
+        $result = $this->service->deleteSpammyJobs();
+
+        $this->assertEquals(0, $result['deleted']);
+        $this->assertEquals(51, DB::table('jobs')->count());
+    }
+
+    public function test_multiple_spam_hashes_all_deleted(): void
+    {
+        for ($i = 0; $i < 51; $i++) {
+            $this->insertJob(['bodyhash' => 'hash_a', 'title' => 'Spam A']);
+        }
+        for ($i = 0; $i < 60; $i++) {
+            $this->insertJob(['bodyhash' => 'hash_b', 'title' => 'Spam B']);
+        }
+
+        $result = $this->service->deleteSpammyJobs();
+
+        $this->assertEquals(111, $result['deleted']);
+        $this->assertEquals(2, $result['spam_hashes']);
+        $this->assertEquals(0, DB::table('jobs')->where('bodyhash', 'hash_a')->count());
+        $this->assertEquals(0, DB::table('jobs')->where('bodyhash', 'hash_b')->count());
+    }
+}


### PR DESCRIPTION
## Summary

Completes the migration of V1 PHP cron scripts to Laravel artisan commands. 15 new service classes, 23 jobs enabled in the scheduler.

### New services migrated from V1

| Command | Service | V1 script |
|---|---|---|
| `messages:generate-illustrations` | `MessageIllustrationsService` + `PollinationsService` | `messages_illustrations.php` |
| `jobs:generate-illustrations` | `JobIllustrationsService` | `jobs_illustrations.php` |
| `data:fetch-app-versions` | `AppVersionFetcherService` | `get_app_release_versions.php` |
| `integrations:sync-lovejunk` | `LoveJunkService` | `lovejunk.php` |
| `chats:update-expected` | `ChatExpectedService` | `chats_expected.php` |
| `cleanup:whatjobs-spam` | `WhatjobsSpamService` | `whatjobs_spam.php` |
| `domains:update-common` | `CommonDomainsService` | `domains_common.php` |
| `groups:update-stats` | `GroupStatsService` | `groups_stats.php` |
| `messages:deindex` | `MessageDeindexService` | `messages_deindex.php` |
| `messages:index-unindexed` | `MessageIndexUnindexedService` | `messages_index.php` |
| `messages:remap-subjects` | `MessageRemapSubjectsService` | `messages_remap_subjects.php` |
| `messages:update-spatial-index` | `MessageSpatialIndexService` | `messages_spatial.php` |
| `microvolunteering:score` | `MicroVolunteeringScoreService` | `microvolunteering_score.php` |
| `users:remap-locations` | `UserLocationRemapService` | `users_remap_locations.php` |
| `users:update-modmails` | `UserModMailsService` | `users_modmails.php` |

### Jobs now enabled in the scheduler (23)

`chats:update-counts`, `chats:update-expected`, `cleanup:whatjobs-spam`, `data:fetch-app-versions`, `domains:update-common`, `groups:update-counts`, `groups:update-stats`, `integrations:sync-lovejunk`, `jobs:generate-illustrations`, `locations:fix-skewed`, `messages:deindex`, `messages:generate-illustrations`, `messages:index-unindexed`, `messages:process-expired`, `messages:remap-subjects`, `messages:update-spatial-index`, `microvolunteering:score`, `purge:messages`, `users:remap-locations`, `users:update-kudos`, `users:update-modmails`, `users:update-ratings`, `users:update-support-roles`

### Jobs kept disabled (explicit sign-off required)

- `mail:digest` / `mail:digest:unified` — enabling both simultaneously would double-send; behind a clear comment block
- `mail:donations:ask` — new feature, not a V1 migration
- `users:cleanup` — GDPR forgets + hard user deletes; needs explicit sign-off

### Bug fixes (4)

1. **`purgeOldMessagesHistory`**: default was 90 days; V1 uses `MessageCollection::RECENTPOSTS = "Midnight 31 days ago"` (31 days). Fixed.
2. **`MessageExpiryService`**: didn't clear `messages_outcomes_intended` before creating outcome (V1 `mark()` does); `emails_sent` counter incremented even when no email was sent; `getMessagesWithExpiredDeadline` returned duplicate rows for messages in multiple groups. All fixed.
3. **`GroupMaintenanceService`**: comment said "lat < lng is normal for UK" — backwards. Logic was correct; comment fixed.
4. **`UserManagementService::validateEmails`**: master commit `dd7728978` removed `whereNull('users_emails.bounced')` from the query, causing already-bounced emails to be deleted on the next format-validation run. Restored both filters: `users.bouncing = 0` AND `users_emails.bounced IS NULL`.

### Other changes

- **Migration**: `add_contenttype_to_messages_attachments`
- **CircleCI orb**: added `git reset --hard HEAD && git clean -fd` before checkout to clear stale worktree state
- **`LoveJunkService`**: uses direct SQL (no V1 class deps); URL secret param omitted when empty (test-safe); requires `LOVE_JUNK_API` + `LOVE_JUNK_SECRET` env vars

## Code Quality Review

- All new services have ≥90% test coverage; query logic verified query-by-query against V1 originals
- `JobIllustrationsService` mock uses `willReturnCallback` to insert into `ai_images` — prevents infinite loop in service while-loop
- `AppVersionFetcherService` uses `Http::fake()` for all test cases; partial failures are graceful
- `LoveJunkService` direct SQL replaces V1 class dependencies; 10 tests cover send/edit/delete/complete/failure/skip paths
- `users:update-support-roles` is intentionally safer than V1 — V1 would accidentally downgrade Admin users; Laravel protects them
- Galera-safe `purgeOldLikes()`: reads distinct old msgids first (no gap locks), deletes by (msgid, type) index
- Chunk-bounded `purgeOrphanedMessageLogs()`: avoids loading all orphan IDs into memory

## Future Improvements

- `mail:donations:ask` — when enabled, needs sign-off confirming this is intended as a user-facing ask (V1 `donations_email.php` was an admin daily report)
- `users:cleanup` — GDPR forgets + hard user deletes — needs explicit sign-off before enabling

## Test Plan

- [x] 1875 Laravel tests pass (up from 1861 on master; +14 from new services)
- [x] CI green on CircleCI (build-and-test + mark-ci-passed)
- [x] Coveralls laravel: +0.04% to 68.194%