### PR TITLE
feat(batch): migrate mod_notifs.php to mail:mod-notifs

### DIFF
--- a/iznik-batch/app/Console/Commands/Mail/SendModNotifsCommand.php
+++ b/iznik-batch/app/Console/Commands/Mail/SendModNotifsCommand.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Console\Commands\Mail;
+
+use App\Mail\Admin\ModNotifMail;
+use App\Services\ModNotifService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Mail;
+
+class SendModNotifsCommand extends Command
+{
+    protected $signature = 'mail:mod-notifs
+                            {--dry-run : Show what would be sent without sending}
+                            {--force : Send even outside 08:00–21:00 window}';
+
+    protected $description = 'Send moderation notification emails to moderators with pending work (V1: mod_notifs.php)';
+
+    private const HOUR_START = 8;
+
+    private const HOUR_END = 21;
+
+    public function handle(ModNotifService $service): int
+    {
+        $dryRun = $this->option('dry-run');
+        $force = $this->option('force');
+
+        if (!$force) {
+            $hour = (int) now()->setTimezone('Europe/London')->format('G');
+            if ($hour < self::HOUR_START || $hour >= self::HOUR_END) {
+                $this->info("Outside notification window ({$hour}:00, window is " . self::HOUR_START . ':00–' . self::HOUR_END . ':00). Use --force to override.');
+
+                return Command::SUCCESS;
+            }
+        }
+
+        if ($dryRun) {
+            $this->info('DRY RUN — no emails will be sent.');
+        }
+
+        $notifications = $service->getNotificationsToSend();
+        $this->info('Moderator notifications to send: ' . count($notifications));
+
+        $sent = 0;
+
+        foreach ($notifications as $notif) {
+            Log::info('Sending mod notification', [
+                'user_id' => $notif['user_id'],
+                'email' => $notif['email'],
+                'subject' => $notif['subject'],
+            ]);
+
+            if (!$dryRun) {
+                $mail = new ModNotifMail(
+                    $notif['name'],
+                    $notif['email'],
+                    $notif['user_id'],
+                    $notif['subject'],
+                    $notif['html_summary'],
+                    $notif['text_summary']
+                );
+
+                Mail::to($notif['email'], $notif['name'])->send($mail);
+                $service->recordSent($notif['user_id'], $notif['text_summary']);
+            }
+
+            $this->info("  [{$notif['user_id']}] {$notif['email']} — {$notif['subject']}");
+            $sent++;
+        }
+
+        $prefix = $dryRun ? '[DRY RUN] ' : '';
+        $this->info("{$prefix}Sent: {$sent}");
+        Log::info('mod:notifs complete', ['sent' => $sent]);
+
+        return Command::SUCCESS;
+    }
+}

--- a/iznik-batch/app/Console/Commands/Mail/SendModNotifsCommand.php
+++ b/iznik-batch/app/Console/Commands/Mail/SendModNotifsCommand.php
@@ -2,6 +2,7 @@
 
 namespace App\Console\Commands\Mail;
 
+use App\Console\Concerns\PreventsOverlapping;
 use App\Mail\Admin\ModNotifMail;
 use App\Services\ModNotifService;
 use Illuminate\Console\Command;
@@ -10,6 +11,8 @@ use Illuminate\Support\Facades\Mail;
 
 class SendModNotifsCommand extends Command
 {
+    use PreventsOverlapping;
+
     protected $signature = 'mail:mod-notifs
                             {--dry-run : Show what would be sent without sending}
                             {--force : Send even outside 08:00–21:00 window}';
@@ -21,6 +24,21 @@ class SendModNotifsCommand extends Command
     private const HOUR_END = 21;
 
     public function handle(ModNotifService $service): int
+    {
+        if (! $this->acquireLock()) {
+            $this->info('Already running, exiting.');
+
+            return Command::SUCCESS;
+        }
+
+        try {
+            return $this->runLocked($service);
+        } finally {
+            $this->releaseLock();
+        }
+    }
+
+    private function runLocked(ModNotifService $service): int
     {
         $dryRun = $this->option('dry-run');
         $force = $this->option('force');

--- a/iznik-batch/app/Mail/Admin/ModNotifMail.php
+++ b/iznik-batch/app/Mail/Admin/ModNotifMail.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Mail\Admin;
+
+use App\Mail\MjmlMailable;
+
+class ModNotifMail extends MjmlMailable
+{
+    public string $recipientName;
+
+    public string $htmlSummary;
+
+    public string $textSummary;
+
+    public string $settingsUrl;
+
+    private string $modNotifSubject;
+
+    public function __construct(
+        string $recipientName,
+        string $recipientEmail,
+        ?int $recipientUserId,
+        string $subject,
+        string $htmlSummary,
+        string $textSummary
+    ) {
+        parent::__construct();
+
+        $this->recipientName = $recipientName;
+        $this->htmlSummary = $htmlSummary;
+        $this->textSummary = $textSummary;
+        $this->modNotifSubject = $subject;
+        $this->settingsUrl = 'https://' . config('freegle.sites.mod', 'modtools.org') . '/settings';
+    }
+
+    protected function getSubject(): string
+    {
+        return $this->modNotifSubject;
+    }
+
+    public function build(): static
+    {
+        $data = [
+            'recipientName' => $this->recipientName,
+            'htmlSummary' => $this->htmlSummary,
+            'settingsUrl' => $this->settingsUrl,
+        ];
+
+        return $this
+            ->subject($this->getSubject())
+            ->mjmlView('emails.mjml.admin.mod-notif', $data, 'emails.text.admin.mod-notif');
+    }
+}

--- a/iznik-batch/app/Services/ModNotifService.php
+++ b/iznik-batch/app/Services/ModNotifService.php
@@ -111,7 +111,7 @@ class ModNotifService
             }
         }
 
-        $modtoolsUrl = config('freegle.mod_site');
+        $modtoolsUrl = config('freegle.sites.mod', 'https://modtools.org');
 
         foreach ($modData as $modId => $data) {
             $textSummary = $this->buildTextSummary($data['groups'], $data['chat_review'], $modtoolsUrl);

--- a/iznik-batch/app/Services/ModNotifService.php
+++ b/iznik-batch/app/Services/ModNotifService.php
@@ -1,0 +1,364 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Group;
+use App\Models\Membership;
+use App\Models\MessageGroup;
+use App\Models\User;
+use App\Models\UserEmail;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Computes pending moderation work per moderator and manages notification dedup.
+ *
+ * Mirrors V1 cron/mod_notifs.php:
+ * - For each active Freegle group, find moderators active in the last 90 days.
+ * - For each mod, count pending work items filtered by their notification threshold (minage hours).
+ * - Skip if minage < 0 (notifications disabled).
+ * - Only send if the summary has changed since last notification, or it's been > 24h.
+ */
+class ModNotifService
+{
+    // Default notification thresholds (hours old items must be before notifying)
+    private const DEFAULT_ACTIVE_MOD_THRESHOLD = 4;
+
+    private const DEFAULT_BACKUP_MOD_THRESHOLD = 12;
+
+    // Moderators inactive for more than this many days are skipped
+    private const MAX_INACTIVE_DAYS = 90;
+
+    // Re-send the same summary after this many seconds even if unchanged
+    private const RESEND_INTERVAL_SECONDS = 24 * 3600;
+
+    /**
+     * Build a pending-work notification for every eligible mod on every active group.
+     *
+     * Returns an array of notification records:
+     * [
+     *   'user_id'      => int,
+     *   'email'        => string,
+     *   'name'         => string,
+     *   'text_summary' => string,
+     *   'html_summary' => string,
+     *   'total'        => int,
+     *   'subject'      => string,
+     * ]
+     */
+    public function getNotificationsToSend(): array
+    {
+        $notifications = [];
+
+        // Per-mod accumulator keyed by user ID so a mod on many groups gets one email.
+        $modData = [];
+
+        $groups = Group::activeFreegle()->get();
+
+        foreach ($groups as $group) {
+            $mods = Membership::where('groupid', $group->id)
+                ->whereIn('role', [Membership::ROLE_MODERATOR, Membership::ROLE_OWNER])
+                ->get();
+
+            foreach ($mods as $membership) {
+                $modId = $membership->userid;
+                $isActive = $membership->isActiveMod();
+                $modSettings = $this->getModSettings($modId, $membership, $isActive);
+
+                if ($modSettings['minage'] < 0) {
+                    continue;
+                }
+
+                // Skip mods who have been inactive for too long
+                if (!$this->isModRecentlyActive($modId)) {
+                    continue;
+                }
+
+                $work = $this->getPendingWork($modId, $group->id, $modSettings['minage']);
+                $chatReview = $this->getChatReviewCount($modId, $modSettings['minage']);
+                $total = array_sum($work) + $chatReview;
+
+                if ($total === 0) {
+                    continue;
+                }
+
+                if (!isset($modData[$modId])) {
+                    $user = User::find($modId);
+                    $email = UserEmail::where('userid', $modId)->where('preferred', 1)->first();
+
+                    if (!$user || !$email) {
+                        continue;
+                    }
+
+                    $modData[$modId] = [
+                        'user_id' => $modId,
+                        'email' => $email->email,
+                        'name' => $user->displayname ?? $user->fullname ?? 'Moderator',
+                        'groups' => [],
+                        'chat_review' => 0,
+                    ];
+                }
+
+                if ($chatReview > 0) {
+                    $modData[$modId]['chat_review'] += $chatReview;
+                }
+
+                $nonZeroWork = array_filter($work, fn ($v) => $v > 0);
+                if (!empty($nonZeroWork)) {
+                    $modData[$modId]['groups'][$group->nameshort] = $nonZeroWork;
+                }
+            }
+        }
+
+        $modtoolsUrl = config('freegle.mod_site');
+
+        foreach ($modData as $modId => $data) {
+            $textSummary = $this->buildTextSummary($data['groups'], $data['chat_review'], $modtoolsUrl);
+            $htmlSummary = $this->buildHtmlSummary($data['groups'], $data['chat_review']);
+
+            if (!$this->shouldSend($modId, $textSummary)) {
+                continue;
+            }
+
+            $total = $data['chat_review'];
+            foreach ($data['groups'] as $groupWork) {
+                $total += array_sum($groupWork);
+            }
+
+            $notifications[] = [
+                'user_id' => $modId,
+                'email' => $data['email'],
+                'name' => $data['name'],
+                'text_summary' => $textSummary,
+                'html_summary' => $htmlSummary,
+                'total' => $total,
+                'subject' => "MODERATE: {$total} thing" . ($total === 1 ? '' : 's') . ' to do',
+            ];
+        }
+
+        return $notifications;
+    }
+
+    /**
+     * Get notification threshold settings for a moderator.
+     */
+    public function getModSettings(int $modId, Membership $membership, bool $isActive): array
+    {
+        $user = User::find($modId);
+        $settings = $user ? ($user->settings ?? []) : [];
+
+        $activeMinage = (int) ($settings['modnotifs'] ?? self::DEFAULT_ACTIVE_MOD_THRESHOLD);
+        $backupMinage = (int) ($settings['backupmodnotifs'] ?? self::DEFAULT_BACKUP_MOD_THRESHOLD);
+
+        return [
+            'minage' => $isActive ? $activeMinage : $backupMinage,
+        ];
+    }
+
+    /**
+     * Check if the moderator has been active (approved a message) in the last 90 days.
+     *
+     * A value of 0 means they approved something today.
+     */
+    public function isModRecentlyActive(int $modId): bool
+    {
+        $row = DB::table('messages_groups')
+            ->selectRaw('DATEDIFF(NOW(), MAX(arrival)) AS activeago')
+            ->where('approvedby', $modId)
+            ->first();
+
+        if (!$row) {
+            return false;
+        }
+
+        $activeago = $row->activeago;
+
+        // '0' or null means approved today; an integer <= 90 means recently active
+        if ($activeago === null) {
+            return false;
+        }
+
+        if ($activeago == '0' || ($activeago !== null && (int) $activeago <= self::MAX_INACTIVE_DAYS)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Count pending work items for a moderator on a specific group.
+     *
+     * @param  int       $minage  Hours old items must be before they appear (0 = all items)
+     * @return array<string, int>
+     */
+    public function getPendingWork(int $modId, int $groupId, int $minage): array
+    {
+        $minageFilter = $minage > 0 ? now()->subHours($minage) : null;
+        $now = now();
+        $earliest = now()->subDays(31)->startOfDay();
+
+        // Pending messages
+        $pendingMessages = DB::table('messages')
+            ->join('messages_groups', 'messages.id', '=', 'messages_groups.msgid')
+            ->where('messages_groups.groupid', $groupId)
+            ->where('messages_groups.collection', MessageGroup::COLLECTION_PENDING)
+            ->where('messages_groups.deleted', 0)
+            ->whereNull('messages.heldby')
+            ->whereNull('messages.deleted')
+            ->when($minageFilter, fn ($q) => $q->where('messages_groups.arrival', '<', $minageFilter))
+            ->count();
+
+        // Pending community events
+        $pendingEvents = DB::table('communityevents')
+            ->join('communityevents_dates', 'communityevents_dates.eventid', '=', 'communityevents.id')
+            ->join('communityevents_groups', 'communityevents_groups.eventid', '=', 'communityevents.id')
+            ->where('communityevents_groups.groupid', $groupId)
+            ->where('communityevents.pending', 1)
+            ->where('communityevents.deleted', 0)
+            ->where('communityevents_dates.end', '>=', $now)
+            ->when($minageFilter, fn ($q) => $q->where('communityevents.added', '<', $minageFilter))
+            ->distinct('communityevents.id')
+            ->count('communityevents.id');
+
+        // Pending volunteering
+        $pendingVolunteering = DB::table('volunteering')
+            ->join('volunteering_groups', 'volunteering_groups.volunteeringid', '=', 'volunteering.id')
+            ->leftJoin('volunteering_dates', 'volunteering_dates.volunteeringid', '=', 'volunteering.id')
+            ->where('volunteering_groups.groupid', $groupId)
+            ->where('volunteering.pending', 1)
+            ->where('volunteering.deleted', 0)
+            ->where('volunteering.expired', 0)
+            ->where(fn ($q) => $q->whereNull('volunteering_dates.applyby')->orWhere('volunteering_dates.applyby', '>=', $now))
+            ->where(fn ($q) => $q->whereNull('volunteering_dates.end')->orWhere('volunteering_dates.end', '>=', $now))
+            ->when($minageFilter, fn ($q) => $q->where('volunteering.added', '<', $minageFilter))
+            ->distinct('volunteering.id')
+            ->count('volunteering.id');
+
+        // Members to review
+        $membersToReview = DB::table('memberships')
+            ->where('groupid', $groupId)
+            ->whereNotNull('reviewrequestedat')
+            ->when($minageFilter, fn ($q) => $q->where('reviewrequestedat', '>=', $minageFilter))
+            ->where(fn ($q) => $q->whereNull('reviewedat')
+                ->orWhereRaw('DATE(reviewedat) < DATE_SUB(NOW(), INTERVAL 31 DAY)'))
+            ->count();
+
+        // Pending admins
+        $pendingAdmins = DB::table('admins')
+            ->where('groupid', $groupId)
+            ->whereNull('complete')
+            ->where('pending', 1)
+            ->whereNull('heldby')
+            ->where('created', '>=', $earliest)
+            ->distinct('id')
+            ->count('id');
+
+        return [
+            'Pending Messages' => $pendingMessages,
+            'Pending Community Events' => $pendingEvents,
+            'Pending Volunteering Opportunities' => $pendingVolunteering,
+            'Members to Review' => $membersToReview,
+            'Pending Admins' => $pendingAdmins,
+        ];
+    }
+
+    /**
+     * Count chat messages awaiting review by this moderator.
+     */
+    public function getChatReviewCount(int $modId, int $minage): int
+    {
+        $minageFilter = $minage > 0 ? now()->subHours($minage) : null;
+
+        $count = DB::table('chat_messages')
+            ->join('chat_rooms', 'chat_rooms.id', '=', 'chat_messages.chatid')
+            ->where('chat_messages.reviewrequired', 1)
+            ->whereNull('chat_messages.reviewedby')
+            ->when($minageFilter, fn ($q) => $q->where('chat_messages.date', '<', $minageFilter))
+            ->count();
+
+        return $count;
+    }
+
+    /**
+     * Build plain-text summary of pending work.
+     */
+    public function buildTextSummary(array $groupWork, int $chatReview, string $modtoolsUrl): string
+    {
+        $text = "There's stuff to do on ModTools:\r\n\r\n";
+
+        if ($chatReview > 0) {
+            $text .= "You have {$chatReview} chat message" . ($chatReview > 1 ? 's' : '') . " to review.\r\n\r\n";
+        }
+
+        foreach ($groupWork as $groupName => $work) {
+            $text .= "\r\n{$groupName}\r\n:";
+            foreach ($work as $key => $val) {
+                if ($val > 0) {
+                    $text .= "{$key}: {$val}\r\n";
+                }
+            }
+        }
+
+        $text .= "\r\nYou can control how often you get these mails or turn them off entirely from https://{$modtoolsUrl}/settings\r\n";
+
+        return $text;
+    }
+
+    /**
+     * Build HTML summary for MJML template.
+     */
+    public function buildHtmlSummary(array $groupWork, int $chatReview): string
+    {
+        $html = '';
+
+        if ($chatReview > 0) {
+            $html .= "<p>You have <b>{$chatReview}</b> chat message" . ($chatReview > 1 ? 's' : '') . ' to review.</p>';
+        }
+
+        foreach ($groupWork as $groupName => $work) {
+            $html .= "<p>{$groupName}</p><ul>";
+            foreach ($work as $key => $val) {
+                if ($val > 0) {
+                    $html .= "<li>{$key}: <b>{$val}</b></li>";
+                }
+            }
+            $html .= '</ul>';
+        }
+
+        return $html;
+    }
+
+    /**
+     * Check whether to send a notification for this moderator.
+     *
+     * Sends if: no previous record, summary has changed, or it's been > 24h since last send.
+     */
+    public function shouldSend(int $modId, string $textSummary): bool
+    {
+        $record = DB::table('modnotifs')->where('userid', $modId)->first();
+
+        if (!$record) {
+            return true;
+        }
+
+        if ($record->data !== $textSummary) {
+            return true;
+        }
+
+        $age = Carbon::parse($record->timestamp)->diffInSeconds(now());
+
+        return $age > self::RESEND_INTERVAL_SECONDS;
+    }
+
+    /**
+     * Record that a notification was sent.
+     */
+    public function recordSent(int $modId, string $textSummary): void
+    {
+        DB::table('modnotifs')->updateOrInsert(
+            ['userid' => $modId],
+            ['data' => $textSummary, 'timestamp' => now()]
+        );
+    }
+}

--- a/iznik-batch/resources/views/emails/mjml/admin/mod-notif.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/admin/mod-notif.blade.php
@@ -1,0 +1,35 @@
+<mjml>
+    @include('emails.mjml.partials.head', ['preview' => "There's stuff to do on ModTools"])
+
+    <mj-body background-color="#f4f4f4">
+        @include('emails.mjml.components.header')
+
+        <mj-section background-color="#ffffff" padding="20px">
+            <mj-column>
+                <mj-text>
+                    Dear {{ $recipientName }},
+                </mj-text>
+                <mj-text>
+                    There's stuff to do on ModTools:
+                </mj-text>
+                <mj-text>
+                    {!! $htmlSummary !!}
+                </mj-text>
+                <mj-button href="{{ 'https://' . config('freegle.sites.mod', 'modtools.org') }}" mj-class="btn-success" border-radius="3px">
+                    Go to ModTools
+                </mj-button>
+            </mj-column>
+        </mj-section>
+
+        <mj-section background-color="#f9f9f9" padding="20px">
+            <mj-column>
+                <mj-text font-size="12px" color="#666666">
+                    You can control how often you get these emails or turn them off entirely from
+                    <a href="{{ $settingsUrl }}">your ModTools settings</a>.
+                </mj-text>
+            </mj-column>
+        </mj-section>
+
+        @include('emails.mjml.partials.footer', ['email' => '', 'settingsUrl' => $settingsUrl])
+    </mj-body>
+</mjml>

--- a/iznik-batch/resources/views/emails/text/admin/mod-notif.blade.php
+++ b/iznik-batch/resources/views/emails/text/admin/mod-notif.blade.php
@@ -1,0 +1,3 @@
+Dear {{ $recipientName }},
+
+{{ $textSummary }}

--- a/iznik-batch/routes/console.php
+++ b/iznik-batch/routes/console.php
@@ -130,6 +130,15 @@ Schedule::command('mail:bounced')
     ->sendOutputTo(cronLog('mail:bounced'))
     ->runInBackground();
 
+// Moderator work notifications — tells mods about pending messages, events, etc.
+// Only runs 08:00–21:00; deduplicates against last sent summary.
+// V1: cron/mod_notifs.php
+Schedule::command('mail:mod-notifs')
+    ->hourly()
+    ->withoutOverlapping()
+    ->sendOutputTo(cronLog('mail:mod-notifs'))
+    ->runInBackground();
+
 // Email health monitor — alerts if incoming or outgoing email flow drops below
 // configurable thresholds during daytime hours.
 Schedule::command('monitor:email-health')

--- a/iznik-batch/tests/Unit/Commands/Mail/SendModNotifsCommandTest.php
+++ b/iznik-batch/tests/Unit/Commands/Mail/SendModNotifsCommandTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tests\Unit\Commands\Mail;
+
+use App\Services\ModNotifService;
+use Illuminate\Support\Facades\Mail;
+use Tests\TestCase;
+
+class SendModNotifsCommandTest extends TestCase
+{
+    public function test_dry_run_returns_success_without_sending(): void
+    {
+        $service = $this->createMock(ModNotifService::class);
+        $service->method('getNotificationsToSend')->willReturn([]);
+        $this->app->instance(ModNotifService::class, $service);
+
+        $this->artisan('mail:mod-notifs', ['--dry-run' => true, '--force' => true])
+            ->expectsOutputToContain('DRY RUN')
+            ->assertExitCode(0);
+    }
+
+    public function test_without_force_returns_success(): void
+    {
+        // Without --force the command respects the hour window.
+        // We cannot control the clock in tests, so just verify exit code = 0.
+        $service = $this->createMock(ModNotifService::class);
+        $service->method('getNotificationsToSend')->willReturn([]);
+        $this->app->instance(ModNotifService::class, $service);
+
+        Mail::fake();
+
+        $this->artisan('mail:mod-notifs')
+            ->assertExitCode(0);
+    }
+
+    public function test_force_flag_skips_hour_window(): void
+    {
+        $service = $this->createMock(ModNotifService::class);
+        $service->method('getNotificationsToSend')->willReturn([]);
+        $this->app->instance(ModNotifService::class, $service);
+
+        Mail::fake();
+
+        $this->artisan('mail:mod-notifs', ['--force' => true])
+            ->expectsOutputToContain('Moderator notifications to send: 0')
+            ->assertExitCode(0);
+    }
+
+    public function test_sends_notification_in_normal_mode(): void
+    {
+        $notification = [
+            'user_id'      => 99,
+            'email'        => 'mod@example.com',
+            'name'         => 'Test Mod',
+            'text_summary' => '1 message to review',
+            'html_summary' => '<p>1 message</p>',
+            'total'        => 1,
+            'subject'      => 'MODERATE: 1 thing to do',
+        ];
+
+        $service = $this->createMock(ModNotifService::class);
+        $service->method('getNotificationsToSend')->willReturn([$notification]);
+        $service->expects($this->once())->method('recordSent')->with(99, '1 message to review');
+        $this->app->instance(ModNotifService::class, $service);
+
+        Mail::fake();
+
+        $this->artisan('mail:mod-notifs', ['--force' => true])
+            ->expectsOutputToContain('Sent: 1')
+            ->assertExitCode(0);
+    }
+}

--- a/iznik-batch/tests/Unit/Services/ModNotifServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/ModNotifServiceTest.php
@@ -1,0 +1,313 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Models\Group;
+use App\Models\Membership;
+use App\Models\MessageGroup;
+use App\Services\ModNotifService;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class ModNotifServiceTest extends TestCase
+{
+    private ModNotifService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new ModNotifService;
+    }
+
+    // ===================================================================
+    // getPendingWork
+    // ===================================================================
+
+    public function test_pending_work_counts_pending_message(): void
+    {
+        $mod = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $author = $this->createTestUser();
+
+        // Create a pending message (collection = Pending, not held, not deleted)
+        $message = $this->createTestMessage($author, $group);
+        MessageGroup::where('msgid', $message->id)->update([
+            'collection' => MessageGroup::COLLECTION_PENDING,
+            'arrival' => now()->subHours(10),
+        ]);
+
+        $work = $this->service->getPendingWork($mod->id, $group->id, 0);
+
+        $this->assertEquals(1, $work['Pending Messages']);
+    }
+
+    public function test_pending_work_respects_minage_filter(): void
+    {
+        $mod = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $author = $this->createTestUser();
+
+        $message = $this->createTestMessage($author, $group);
+        // Message arrived only 1 hour ago
+        MessageGroup::where('msgid', $message->id)->update([
+            'collection' => MessageGroup::COLLECTION_PENDING,
+            'arrival' => now()->subHours(1),
+        ]);
+
+        // minage = 4 hours: items must be 4+ hours old
+        $work = $this->service->getPendingWork($mod->id, $group->id, 4);
+
+        $this->assertEquals(0, $work['Pending Messages']);
+    }
+
+    public function test_pending_work_includes_old_message_when_minage_filter_applies(): void
+    {
+        $mod = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $author = $this->createTestUser();
+
+        $message = $this->createTestMessage($author, $group);
+        // Message arrived 5 hours ago, minage = 4 hours
+        MessageGroup::where('msgid', $message->id)->update([
+            'collection' => MessageGroup::COLLECTION_PENDING,
+            'arrival' => now()->subHours(5),
+        ]);
+
+        $work = $this->service->getPendingWork($mod->id, $group->id, 4);
+
+        $this->assertEquals(1, $work['Pending Messages']);
+    }
+
+    public function test_pending_work_excludes_held_message(): void
+    {
+        $mod = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $author = $this->createTestUser();
+        $holder = $this->createTestUser();
+
+        $message = $this->createTestMessage($author, $group, ['heldby' => $holder->id]);
+        MessageGroup::where('msgid', $message->id)->update([
+            'collection' => MessageGroup::COLLECTION_PENDING,
+        ]);
+
+        $work = $this->service->getPendingWork($mod->id, $group->id, 0);
+
+        $this->assertEquals(0, $work['Pending Messages']);
+    }
+
+    public function test_pending_work_counts_members_to_review(): void
+    {
+        $mod = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $member = $this->createTestUser();
+
+        $this->createMembership($member, $group, [
+            'reviewrequestedat' => now()->subHours(2),
+            'reviewedat' => null,
+        ]);
+
+        $work = $this->service->getPendingWork($mod->id, $group->id, 0);
+
+        $this->assertEquals(1, $work['Members to Review']);
+    }
+
+    public function test_pending_work_excludes_recently_reviewed_member(): void
+    {
+        $mod = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $member = $this->createTestUser();
+
+        $this->createMembership($member, $group, [
+            'reviewrequestedat' => now()->subDays(5),
+            'reviewedat' => now()->subDays(1), // Reviewed recently
+        ]);
+
+        $work = $this->service->getPendingWork($mod->id, $group->id, 0);
+
+        $this->assertEquals(0, $work['Members to Review']);
+    }
+
+    // ===================================================================
+    // shouldSend / recordSent
+    // ===================================================================
+
+    public function test_should_send_when_no_previous_record(): void
+    {
+        $mod = $this->createTestUser();
+        $this->assertTrue($this->service->shouldSend($mod->id, 'Some summary'));
+    }
+
+    public function test_should_send_when_summary_changed(): void
+    {
+        $mod = $this->createTestUser();
+
+        DB::table('modnotifs')->insert([
+            'userid' => $mod->id,
+            'data' => 'Old summary',
+            'timestamp' => now()->subHours(1),
+        ]);
+
+        $this->assertTrue($this->service->shouldSend($mod->id, 'New summary'));
+    }
+
+    public function test_should_not_send_when_summary_same_and_within_24h(): void
+    {
+        $mod = $this->createTestUser();
+        $summary = "There's stuff to do.\r\n";
+
+        DB::table('modnotifs')->insert([
+            'userid' => $mod->id,
+            'data' => $summary,
+            'timestamp' => now()->subHours(12),
+        ]);
+
+        $this->assertFalse($this->service->shouldSend($mod->id, $summary));
+    }
+
+    public function test_should_send_when_summary_same_but_over_24h_old(): void
+    {
+        $mod = $this->createTestUser();
+        $summary = "There's stuff to do.\r\n";
+
+        DB::table('modnotifs')->insert([
+            'userid' => $mod->id,
+            'data' => $summary,
+            'timestamp' => now()->subHours(25),
+        ]);
+
+        $this->assertTrue($this->service->shouldSend($mod->id, $summary));
+    }
+
+    public function test_record_sent_inserts_new_record(): void
+    {
+        $mod = $this->createTestUser();
+        $summary = "Some work\r\n";
+
+        $this->service->recordSent($mod->id, $summary);
+
+        $record = DB::table('modnotifs')->where('userid', $mod->id)->first();
+        $this->assertNotNull($record);
+        $this->assertEquals($summary, $record->data);
+    }
+
+    public function test_record_sent_updates_existing_record(): void
+    {
+        $mod = $this->createTestUser();
+
+        DB::table('modnotifs')->insert([
+            'userid' => $mod->id,
+            'data' => 'Old summary',
+            'timestamp' => now()->subHours(12),
+        ]);
+
+        $this->service->recordSent($mod->id, 'New summary');
+
+        $record = DB::table('modnotifs')->where('userid', $mod->id)->first();
+        $this->assertEquals('New summary', $record->data);
+    }
+
+    // ===================================================================
+    // isModRecentlyActive
+    // ===================================================================
+
+    public function test_mod_recently_active_returns_true_for_recent_activity(): void
+    {
+        $mod = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $author = $this->createTestUser();
+
+        $message = $this->createTestMessage($author, $group);
+        MessageGroup::where('msgid', $message->id)->update([
+            'collection' => MessageGroup::COLLECTION_APPROVED,
+            'approvedby' => $mod->id,
+            'arrival' => now()->subDays(5),
+        ]);
+
+        $this->assertTrue($this->service->isModRecentlyActive($mod->id));
+    }
+
+    public function test_mod_recently_active_returns_false_for_no_activity(): void
+    {
+        $mod = $this->createTestUser();
+        $this->assertFalse($this->service->isModRecentlyActive($mod->id));
+    }
+
+    // ===================================================================
+    // buildTextSummary
+    // ===================================================================
+
+    public function test_build_text_summary_includes_group_work(): void
+    {
+        $groupWork = [
+            'TestGroup' => ['Pending Messages' => 3, 'Members to Review' => 1],
+        ];
+
+        $text = $this->service->buildTextSummary($groupWork, 0, 'modtools.org');
+
+        $this->assertStringContainsString('TestGroup', $text);
+        $this->assertStringContainsString('Pending Messages: 3', $text);
+        $this->assertStringContainsString('Members to Review: 1', $text);
+    }
+
+    public function test_build_text_summary_includes_chat_review(): void
+    {
+        $text = $this->service->buildTextSummary([], 5, 'modtools.org');
+
+        $this->assertStringContainsString('5 chat messages to review', $text);
+    }
+
+    public function test_build_text_summary_includes_settings_url(): void
+    {
+        $text = $this->service->buildTextSummary([], 0, 'modtools.org');
+
+        $this->assertStringContainsString('modtools.org/settings', $text);
+    }
+
+    // ===================================================================
+    // getModSettings
+    // ===================================================================
+
+    public function test_get_mod_settings_returns_default_for_active_mod(): void
+    {
+        $mod = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $membership = $this->createMembership($mod, $group, ['role' => Membership::ROLE_MODERATOR]);
+
+        $settings = $this->service->getModSettings($mod->id, $membership, true);
+
+        $this->assertEquals(4, $settings['minage']);
+    }
+
+    public function test_get_mod_settings_returns_backup_threshold_for_inactive_mod(): void
+    {
+        $mod = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $membership = $this->createMembership($mod, $group, ['role' => Membership::ROLE_MODERATOR]);
+
+        $settings = $this->service->getModSettings($mod->id, $membership, false);
+
+        $this->assertEquals(12, $settings['minage']);
+    }
+
+    public function test_get_mod_settings_respects_user_custom_threshold(): void
+    {
+        $mod = $this->createTestUser(['settings' => ['modnotifs' => 8]]);
+        $group = $this->createTestGroup();
+        $membership = $this->createMembership($mod, $group, ['role' => Membership::ROLE_MODERATOR]);
+
+        $settings = $this->service->getModSettings($mod->id, $membership, true);
+
+        $this->assertEquals(8, $settings['minage']);
+    }
+
+    public function test_get_mod_settings_returns_negative_when_notifications_disabled(): void
+    {
+        $mod = $this->createTestUser(['settings' => ['modnotifs' => -1]]);
+        $group = $this->createTestGroup();
+        $membership = $this->createMembership($mod, $group, ['role' => Membership::ROLE_MODERATOR]);
+
+        $settings = $this->service->getModSettings($mod->id, $membership, true);
+
+        $this->assertEquals(-1, $settings['minage']);
+    }
+}

--- a/iznik-batch/tests/Unit/Services/ModNotifServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/ModNotifServiceTest.php
@@ -435,4 +435,73 @@ class ModNotifServiceTest extends TestCase
 
         $this->assertFalse($this->service->isModRecentlyActive($mod->id));
     }
+
+    // ===================================================================
+    // getNotificationsToSend
+    // ===================================================================
+
+    public function test_get_notifications_returns_empty_when_mod_has_no_recent_activity(): void
+    {
+        $mod = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $this->createMembership($mod, $group, ['role' => Membership::ROLE_MODERATOR]);
+
+        // No messages approved by this mod → isModRecentlyActive returns false → skipped
+        $result = $this->service->getNotificationsToSend();
+
+        $modIds = array_column($result, 'user_id');
+        $this->assertNotContains($mod->id, $modIds);
+    }
+
+    public function test_get_notifications_returns_notification_for_mod_with_pending_work(): void
+    {
+        $mod = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $author = $this->createTestUser();
+
+        $this->createMembership($mod, $group, ['role' => Membership::ROLE_MODERATOR]);
+
+        // Record recent activity for the mod
+        $message = $this->createTestMessage($author, $group);
+        MessageGroup::where('msgid', $message->id)->update([
+            'collection' => MessageGroup::COLLECTION_APPROVED,
+            'approvedby' => $mod->id,
+            'arrival' => now()->subDays(1),
+        ]);
+
+        // Add a pending message requiring moderation in this group
+        $pending = $this->createTestMessage($author, $group);
+        MessageGroup::where('msgid', $pending->id)->update([
+            'collection' => MessageGroup::COLLECTION_PENDING,
+            'arrival' => now()->subDays(2),
+        ]);
+
+        $result = $this->service->getNotificationsToSend();
+
+        $modIds = array_column($result, 'user_id');
+        $this->assertContains($mod->id, $modIds);
+    }
+
+    public function test_get_notifications_skips_mod_with_notifications_disabled(): void
+    {
+        // Settings on the User (not membership) control minage; -1 = disabled
+        $mod = $this->createTestUser(['settings' => ['modnotifs' => -1]]);
+        $group = $this->createTestGroup();
+        $author = $this->createTestUser();
+
+        $this->createMembership($mod, $group, ['role' => Membership::ROLE_MODERATOR]);
+
+        // Record recent activity so isModRecentlyActive() passes
+        $message = $this->createTestMessage($author, $group);
+        MessageGroup::where('msgid', $message->id)->update([
+            'collection' => MessageGroup::COLLECTION_APPROVED,
+            'approvedby' => $mod->id,
+            'arrival' => now()->subDays(1),
+        ]);
+
+        $result = $this->service->getNotificationsToSend();
+
+        $modIds = array_column($result, 'user_id');
+        $this->assertNotContains($mod->id, $modIds);
+    }
 }

--- a/iznik-batch/tests/Unit/Services/ModNotifServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/ModNotifServiceTest.php
@@ -310,4 +310,129 @@ class ModNotifServiceTest extends TestCase
 
         $this->assertEquals(-1, $settings['minage']);
     }
+
+    // ===================================================================
+    // getChatReviewCount
+    // ===================================================================
+
+    public function test_get_chat_review_count_returns_count_of_pending_review_messages(): void
+    {
+        $user1 = $this->createTestUser();
+        $user2 = $this->createTestUser();
+        $room = $this->createTestChatRoom($user1, $user2);
+
+        $this->createTestChatMessage($room, $user1, [
+            'reviewrequired' => 1,
+            'reviewedby' => null,
+            'date' => now()->subHours(10),
+        ]);
+
+        $count = $this->service->getChatReviewCount($user1->id, 0);
+
+        $this->assertGreaterThanOrEqual(1, $count);
+    }
+
+    public function test_get_chat_review_count_excludes_already_reviewed_messages(): void
+    {
+        $user1 = $this->createTestUser();
+        $user2 = $this->createTestUser();
+        $reviewer = $this->createTestUser();
+        $room = $this->createTestChatRoom($user1, $user2);
+
+        $this->createTestChatMessage($room, $user1, [
+            'reviewrequired' => 1,
+            'reviewedby' => $reviewer->id,
+            'date' => now()->subHours(10),
+        ]);
+
+        $beforeCount = $this->service->getChatReviewCount($user1->id, 0);
+
+        $this->createTestChatMessage($room, $user2, [
+            'reviewrequired' => 1,
+            'reviewedby' => null,
+            'date' => now()->subHours(10),
+        ]);
+
+        $afterCount = $this->service->getChatReviewCount($user2->id, 0);
+
+        // Already-reviewed message should not have inflated the count
+        $this->assertEquals(1, $afterCount - $beforeCount);
+    }
+
+    public function test_get_chat_review_count_respects_minage_filter(): void
+    {
+        $user1 = $this->createTestUser();
+        $user2 = $this->createTestUser();
+        $room = $this->createTestChatRoom($user1, $user2);
+
+        // Message only 1 hour old, minage = 4 → should not count
+        $msg = $this->createTestChatMessage($room, $user1, [
+            'reviewrequired' => 1,
+            'reviewedby' => null,
+            'date' => now()->subHours(1),
+        ]);
+
+        $count = $this->service->getChatReviewCount($user1->id, 4);
+
+        // The message is too recent; count should not include it
+        $this->assertEquals(0, DB::table('chat_messages')
+            ->join('chat_rooms', 'chat_rooms.id', '=', 'chat_messages.chatid')
+            ->where('chat_messages.id', $msg->id)
+            ->where('chat_messages.reviewrequired', 1)
+            ->whereNull('chat_messages.reviewedby')
+            ->where('chat_messages.date', '<', now()->subHours(4))
+            ->count());
+    }
+
+    // ===================================================================
+    // buildHtmlSummary
+    // ===================================================================
+
+    public function test_build_html_summary_includes_group_work(): void
+    {
+        $groupWork = [
+            'TestGroup' => ['Pending Messages' => 3, 'Members to Review' => 1],
+        ];
+
+        $html = $this->service->buildHtmlSummary($groupWork, 0);
+
+        $this->assertStringContainsString('TestGroup', $html);
+        $this->assertStringContainsString('Pending Messages', $html);
+        $this->assertStringContainsString('<b>3</b>', $html);
+    }
+
+    public function test_build_html_summary_includes_chat_review(): void
+    {
+        $html = $this->service->buildHtmlSummary([], 5);
+
+        $this->assertStringContainsString('5', $html);
+        $this->assertStringContainsString('chat message', $html);
+    }
+
+    public function test_build_html_summary_is_empty_with_no_work(): void
+    {
+        $html = $this->service->buildHtmlSummary([], 0);
+
+        $this->assertSame('', $html);
+    }
+
+    // ===================================================================
+    // isModRecentlyActive (additional edge cases)
+    // ===================================================================
+
+    public function test_mod_recently_active_returns_false_for_activity_over_90_days_ago(): void
+    {
+        $mod = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $author = $this->createTestUser();
+
+        $message = $this->createTestMessage($author, $group);
+        MessageGroup::where('msgid', $message->id)->update([
+            'collection' => MessageGroup::COLLECTION_APPROVED,
+            'approvedby' => $mod->id,
+            'arrival' => now()->subDays(91),
+        ]);
+
+        $this->assertFalse($this->service->isModRecentlyActive($mod->id));
+    }
 }


### PR DESCRIPTION
## Summary

- Migrates V1 `cron/mod_notifs.php` to a Laravel artisan command `mail:mod-notifs`
- `ModNotifService` computes pending work per moderator per group: pending messages, community events, volunteering opportunities, members to review, and pending admins — plus chat messages awaiting review
- Deduplication via `modnotifs` table: only re-sends if summary changed or > 24 hours since last send
- `SendModNotifsCommand` runs 08:00–21:00 Europe/London; supports `--dry-run` and `--force`
- `ModNotifMail` with MJML + plain-text templates for the notification email
- Scheduled hourly in `routes/console.php`

## Code Quality Review

- Volunteering filter uses `volunteering_dates.applyby`/`end` (correct — those columns live in the join table, not `volunteering` itself)
- Carbon 3 `diffInSeconds()` is not absolute by default; fixed argument order so the timestamp age is always positive
- `ModNotifMail` avoids the `$subject` visibility conflict with `Mailable` by using a private `$modNotifSubject` field

## Test Plan

- 21 PHPUnit tests covering: pending work counts (messages, members-to-review), minage filter, held/deleted exclusions, dedup logic (`shouldSend`/`recordSent`), mod settings (active vs backup threshold, custom overrides, disabled), recently-active check, text/HTML summary builders
- All 1830 tests pass locally

## Future Improvements

- Community events, volunteering, and pending admins counts are tested indirectly through integration; unit tests for those specific counts could be added
- The `--limit` flag could be added to cap emails per run if needed