### PR TITLE
feat(batch): migrate users_modmails.php to users:update-modmails

### DIFF
--- a/iznik-batch/app/Console/Commands/User/UpdateModMailsCommand.php
+++ b/iznik-batch/app/Console/Commands/User/UpdateModMailsCommand.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Console\Commands\User;
+
+use App\Services\UserModMailsService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+
+class UpdateModMailsCommand extends Command
+{
+    protected $signature = 'users:update-modmails
+                            {--dry-run : Show counts without making changes}';
+
+    protected $description = 'Sync recent mod actions into users_modmails and prune old entries (V1: users_modmails.php)';
+
+    public function handle(UserModMailsService $service): int
+    {
+        $dryRun = $this->option('dry-run');
+
+        if ($dryRun) {
+            $this->info('DRY RUN — no changes will be made.');
+
+            return Command::SUCCESS;
+        }
+
+        $inserted = $service->updateModMails();
+        $deleted = $service->pruneOldEntries();
+
+        $this->info("users:update-modmails complete — inserted: {$inserted}, pruned: {$deleted}");
+        Log::info('users:update-modmails complete', ['inserted' => $inserted, 'pruned' => $deleted]);
+
+        return Command::SUCCESS;
+    }
+}

--- a/iznik-batch/app/Services/UserModMailsService.php
+++ b/iznik-batch/app/Services/UserModMailsService.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Maintains the users_modmails table by scanning recent logs for mod actions.
+ *
+ * Mirrors V1 cron/users_modmails.php:
+ * - Scan logs from the last 10 minutes for mod actions on users (Rejected, Deleted, Replied, Mailed).
+ * - Only records where byuser != user (mod acting on someone else).
+ * - Prune entries older than 30 days.
+ */
+class UserModMailsService
+{
+    private const SCAN_MINUTES = 10;
+
+    private const PRUNE_DAYS = 30;
+
+    private const MOD_ACTION_TYPES = [
+        ['type' => 'Message', 'subtypes' => ['Rejected', 'Deleted', 'Replied']],
+        ['type' => 'User', 'subtypes' => ['Mailed', 'Rejected', 'Deleted']],
+    ];
+
+    /**
+     * Insert recent mod-action log entries into users_modmails.
+     *
+     * @return int Number of new entries inserted
+     */
+    public function updateModMails(): int
+    {
+        $since = now()->subMinutes(self::SCAN_MINUTES);
+        $inserted = 0;
+
+        $logs = DB::table('logs')
+            ->where('timestamp', '>', $since)
+            ->where(function ($q) {
+                foreach (self::MOD_ACTION_TYPES as $group) {
+                    $q->orWhere(function ($inner) use ($group) {
+                        $inner->where('type', $group['type'])
+                            ->whereIn('subtype', $group['subtypes']);
+                    });
+                }
+            })
+            ->whereColumn('byuser', '!=', 'user')
+            ->whereNotNull('byuser')
+            ->whereNotNull('user')
+            ->get();
+
+        foreach ($logs as $log) {
+            $affected = DB::table('users_modmails')->insertOrIgnore([
+                'userid' => $log->user,
+                'logid' => $log->id,
+                'timestamp' => $log->timestamp,
+                'groupid' => $log->groupid ?? 0,
+            ]);
+
+            if ($affected > 0) {
+                $inserted++;
+            }
+        }
+
+        Log::info('users_modmails updated', ['inserted' => $inserted, 'logs_scanned' => count($logs)]);
+
+        return $inserted;
+    }
+
+    /**
+     * Prune users_modmails entries older than 30 days.
+     *
+     * @return int Number of entries deleted
+     */
+    public function pruneOldEntries(): int
+    {
+        $cutoff = now()->subDays(self::PRUNE_DAYS)->startOfDay();
+
+        $deleted = DB::table('users_modmails')
+            ->where('timestamp', '<', $cutoff)
+            ->delete();
+
+        if ($deleted > 0) {
+            Log::info('users_modmails pruned', ['deleted' => $deleted]);
+        }
+
+        return $deleted;
+    }
+}

--- a/iznik-batch/routes/console.php
+++ b/iznik-batch/routes/console.php
@@ -195,6 +195,14 @@ Schedule::command('chats:update-counts')
     ->sendOutputTo(cronLog('chats:update-counts'))
     ->runInBackground();
 
+// Sync recent mod actions into users_modmails and prune old entries.
+// V1: cron/users_modmails.php
+Schedule::command('users:update-modmails')
+    ->everyFiveMinutes()
+    ->withoutOverlapping()
+    ->sendOutputTo(cronLog('users:update-modmails'))
+    ->runInBackground();
+
 // Hourly fallback users.lastaccess update from chat / membership activity.
 // V1: cron/lastaccess.php
 Schedule::command('users:update-lastaccess')

--- a/iznik-batch/tests/Unit/Services/UserModMailsServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/UserModMailsServiceTest.php
@@ -1,0 +1,228 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Services\UserModMailsService;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class UserModMailsServiceTest extends TestCase
+{
+    private UserModMailsService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new UserModMailsService;
+    }
+
+    // ===================================================================
+    // updateModMails
+    // ===================================================================
+
+    private function insertLog(array $attrs): int
+    {
+        return DB::table('logs')->insertGetId(array_merge([
+            'timestamp' => now()->subMinutes(5),
+            'type' => 'Message',
+            'subtype' => 'Rejected',
+            'byuser' => null,
+            'user' => null,
+            'groupid' => null,
+        ], $attrs));
+    }
+
+    public function test_update_records_rejected_message_log(): void
+    {
+        $mod = $this->createTestUser();
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+
+        $this->insertLog([
+            'type' => 'Message',
+            'subtype' => 'Rejected',
+            'byuser' => $mod->id,
+            'user' => $user->id,
+            'groupid' => $group->id,
+        ]);
+
+        $this->service->updateModMails();
+
+        $this->assertEquals(1, DB::table('users_modmails')->where('userid', $user->id)->count());
+    }
+
+    public function test_update_records_deleted_message_log(): void
+    {
+        $mod = $this->createTestUser();
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+
+        $this->insertLog([
+            'type' => 'Message',
+            'subtype' => 'Deleted',
+            'byuser' => $mod->id,
+            'user' => $user->id,
+            'groupid' => $group->id,
+        ]);
+
+        $this->service->updateModMails();
+
+        $this->assertEquals(1, DB::table('users_modmails')->where('userid', $user->id)->count());
+    }
+
+    public function test_update_records_replied_message_log(): void
+    {
+        $mod = $this->createTestUser();
+        $user = $this->createTestUser();
+
+        $this->insertLog([
+            'type' => 'Message',
+            'subtype' => 'Replied',
+            'byuser' => $mod->id,
+            'user' => $user->id,
+        ]);
+
+        $this->service->updateModMails();
+
+        $this->assertEquals(1, DB::table('users_modmails')->where('userid', $user->id)->count());
+    }
+
+    public function test_update_records_user_mailed_log(): void
+    {
+        $mod = $this->createTestUser();
+        $user = $this->createTestUser();
+
+        $this->insertLog([
+            'type' => 'User',
+            'subtype' => 'Mailed',
+            'byuser' => $mod->id,
+            'user' => $user->id,
+        ]);
+
+        $this->service->updateModMails();
+
+        $this->assertEquals(1, DB::table('users_modmails')->where('userid', $user->id)->count());
+    }
+
+    public function test_update_skips_log_where_byuser_equals_user(): void
+    {
+        $user = $this->createTestUser();
+
+        $this->insertLog([
+            'type' => 'Message',
+            'subtype' => 'Rejected',
+            'byuser' => $user->id,
+            'user' => $user->id,
+        ]);
+
+        $this->service->updateModMails();
+
+        // User acted on themselves — should not appear in users_modmails
+        $this->assertEquals(0, DB::table('users_modmails')->where('userid', $user->id)->count());
+    }
+
+    public function test_update_skips_old_log(): void
+    {
+        $mod = $this->createTestUser();
+        $user = $this->createTestUser();
+
+        // Log is 15 minutes old — outside the 10-minute scan window
+        $this->insertLog([
+            'type' => 'Message',
+            'subtype' => 'Rejected',
+            'byuser' => $mod->id,
+            'user' => $user->id,
+            'timestamp' => now()->subMinutes(15),
+        ]);
+
+        $this->service->updateModMails();
+
+        $this->assertEquals(0, DB::table('users_modmails')->where('userid', $user->id)->count());
+    }
+
+    public function test_update_skips_irrelevant_log_subtype(): void
+    {
+        $mod = $this->createTestUser();
+        $user = $this->createTestUser();
+
+        $this->insertLog([
+            'type' => 'Message',
+            'subtype' => 'Approved',  // not a mod-action subtype
+            'byuser' => $mod->id,
+            'user' => $user->id,
+        ]);
+
+        $this->service->updateModMails();
+
+        $this->assertEquals(0, DB::table('users_modmails')->where('userid', $user->id)->count());
+    }
+
+    public function test_update_does_not_insert_duplicate_log(): void
+    {
+        $mod = $this->createTestUser();
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+
+        $logId = $this->insertLog([
+            'type' => 'Message',
+            'subtype' => 'Rejected',
+            'byuser' => $mod->id,
+            'user' => $user->id,
+            'groupid' => $group->id,
+        ]);
+
+        // Pre-insert so second call is a duplicate
+        DB::table('users_modmails')->insert([
+            'userid' => $user->id,
+            'logid' => $logId,
+            'timestamp' => now()->subMinutes(5),
+            'groupid' => $group->id,
+        ]);
+
+        $this->service->updateModMails();
+
+        // Still only one entry (INSERT IGNORE de-duplicates by logid)
+        $this->assertEquals(1, DB::table('users_modmails')->where('userid', $user->id)->count());
+    }
+
+    // ===================================================================
+    // pruneOldEntries
+    // ===================================================================
+
+    public function test_prune_deletes_old_entries(): void
+    {
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $logId = $this->insertLog(['user' => $user->id, 'groupid' => $group->id]);
+
+        DB::table('users_modmails')->insert([
+            'userid' => $user->id,
+            'logid' => $logId,
+            'timestamp' => now()->subDays(31),
+            'groupid' => $group->id,
+        ]);
+
+        $deleted = $this->service->pruneOldEntries();
+
+        $this->assertGreaterThanOrEqual(1, $deleted);
+        $this->assertEquals(0, DB::table('users_modmails')->where('userid', $user->id)->count());
+    }
+
+    public function test_prune_keeps_recent_entries(): void
+    {
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $logId = $this->insertLog(['user' => $user->id, 'groupid' => $group->id]);
+
+        DB::table('users_modmails')->insert([
+            'userid' => $user->id,
+            'logid' => $logId,
+            'timestamp' => now()->subDays(5),
+            'groupid' => $group->id,
+        ]);
+
+        $this->service->pruneOldEntries();
+
+        $this->assertEquals(1, DB::table('users_modmails')->where('userid', $user->id)->count());
+    }
+}


### PR DESCRIPTION
## Summary

- Migrates V1 `cron/users_modmails.php` to `users:update-modmails` artisan command
- `UserModMailsService` scans logs from the last 10 minutes for mod actions (Message/Rejected, Message/Deleted, Message/Replied, User/Mailed, User/Rejected, User/Deleted) where the acting user differs from the affected user
- Inserts qualifying entries into `users_modmails` (INSERT IGNORE on `logid` — idempotent)
- Prunes entries older than 30 days
- Scheduled every 5 minutes in `routes/console.php`
- Also marks `admins.php` as already covered by the existing `mail:admin:*` commands

## Code Quality Review

- Tests are scoped to the specific user's records (not total count) to remain robust against pre-existing test data from other test classes that commits to the `logs` table
- `insertOrIgnore` on `logid` unique key ensures idempotency

## Test Plan

- 10 PHPUnit tests covering: all relevant log subtypes (Rejected, Deleted, Replied, Mailed), duplicate prevention, old-log skipping (> 10 min), irrelevant-subtype skipping, byuser=user skipping, prune (deletes old / keeps recent)
- All 1819 tests pass locally (1819 = master baseline + these 10 new tests)