### PR TITLE
feat(batch): migrate donations_giftaid.php chase-up to Laravel

### DIFF
--- a/iznik-batch/app/Console/Commands/Donation/UpdateGiftAidCommand.php
+++ b/iznik-batch/app/Console/Commands/Donation/UpdateGiftAidCommand.php
@@ -2,12 +2,15 @@
 
 namespace App\Console\Commands\Donation;
 
+use App\Console\Concerns\PreventsOverlapping;
 use App\Services\GiftAidClaimService;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Log;
 
 class UpdateGiftAidCommand extends Command
 {
+    use PreventsOverlapping;
+
     protected $signature = 'donations:update-giftaid
                             {--dry-run : Show counts without making changes or sending emails}';
 
@@ -15,28 +18,36 @@ class UpdateGiftAidCommand extends Command
 
     public function handle(GiftAidClaimService $service): int
     {
-        $dryRun = $this->option('dry-run');
-
-        if ($dryRun) {
-            $this->info('DRY RUN — no changes will be made.');
+        if (! $this->acquireLock()) {
+            $this->info('Already running, exiting.');
 
             return Command::SUCCESS;
         }
 
-        $postcodes = $service->identifyPostcodes();
-        $houses = $service->identifyHouseNumbers();
-        $identified = $service->identifyGiftAidedDonations();
+        try {
+            if ($this->option('dry-run')) {
+                $this->info('DRY RUN — no changes will be made.');
 
-        $sent = $service->sendGiftAidChaseUps();
+                return Command::SUCCESS;
+            }
 
-        $this->info("donations:update-giftaid complete — postcodes: {$postcodes}, houses: {$houses}, identified: {$identified}, chaseups: {$sent}");
-        Log::info('donations:update-giftaid complete', [
-            'postcodes' => $postcodes,
-            'houses' => $houses,
-            'identified' => $identified,
-            'chaseups' => $sent,
-        ]);
+            $postcodes = $service->identifyPostcodes();
+            $houses = $service->identifyHouseNumbers();
+            $identified = $service->identifyGiftAidedDonations();
 
-        return Command::SUCCESS;
+            $sent = $service->sendGiftAidChaseUps();
+
+            $this->info("donations:update-giftaid complete — postcodes: {$postcodes}, houses: {$houses}, identified: {$identified}, chaseups: {$sent}");
+            Log::info('donations:update-giftaid complete', [
+                'postcodes' => $postcodes,
+                'houses' => $houses,
+                'identified' => $identified,
+                'chaseups' => $sent,
+            ]);
+
+            return Command::SUCCESS;
+        } finally {
+            $this->releaseLock();
+        }
     }
 }

--- a/iznik-batch/app/Console/Commands/Donation/UpdateGiftAidCommand.php
+++ b/iznik-batch/app/Console/Commands/Donation/UpdateGiftAidCommand.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Console\Commands\Donation;
+
+use App\Services\GiftAidClaimService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+
+class UpdateGiftAidCommand extends Command
+{
+    protected $signature = 'donations:update-giftaid
+                            {--dry-run : Show counts without making changes or sending emails}';
+
+    protected $description = 'Update gift aid data and send chase-up emails (V1: donations_giftaid.php)';
+
+    public function handle(GiftAidClaimService $service): int
+    {
+        $dryRun = $this->option('dry-run');
+
+        if ($dryRun) {
+            $this->info('DRY RUN — no changes will be made.');
+
+            return Command::SUCCESS;
+        }
+
+        $postcodes = $service->identifyPostcodes();
+        $houses = $service->identifyHouseNumbers();
+        $identified = $service->identifyGiftAidedDonations();
+
+        $sent = $service->sendGiftAidChaseUps();
+
+        $this->info("donations:update-giftaid complete — postcodes: {$postcodes}, houses: {$houses}, identified: {$identified}, chaseups: {$sent}");
+        Log::info('donations:update-giftaid complete', [
+            'postcodes' => $postcodes,
+            'houses' => $houses,
+            'identified' => $identified,
+            'chaseups' => $sent,
+        ]);
+
+        return Command::SUCCESS;
+    }
+}

--- a/iznik-batch/app/Mail/Donation/GiftAidChaseUp.php
+++ b/iznik-batch/app/Mail/Donation/GiftAidChaseUp.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Mail\Donation;
+
+use App\Mail\MjmlMailable;
+use App\Mail\Traits\LoggableEmail;
+use App\Mail\Traits\TrackableEmail;
+use App\Models\User;
+use Illuminate\Mail\Mailables\Address;
+use Illuminate\Mail\Mailables\Envelope;
+
+class GiftAidChaseUp extends MjmlMailable
+{
+    use LoggableEmail;
+    use TrackableEmail;
+
+    public User $user;
+
+    public string $donationDate;
+
+    public string $giftAidUrl;
+
+    public string $settingsUrl;
+
+    public function __construct(User $user, string $donationDate)
+    {
+        parent::__construct();
+
+        $this->user = $user;
+        $this->donationDate = $donationDate;
+        $this->giftAidUrl = config('freegle.sites.user').'/giftaid';
+        $this->settingsUrl = config('freegle.sites.user').'/settings';
+
+        $this->initTracking(
+            'GiftAidChaseUp',
+            $this->user->email_preferred,
+            $this->user->id ?? null,
+            null,
+            $this->getSubject(),
+            ['donation_date' => $donationDate]
+        );
+    }
+
+    protected function getRecipientUserId(): ?int
+    {
+        return $this->user->id ?? null;
+    }
+
+    public function build(): static
+    {
+        return $this->to($this->user->email_preferred, $this->user->displayname)
+            ->subject($this->getSubject())
+            ->mjmlView('emails.mjml.donation.giftaid-chaseup', array_merge([
+                'user' => $this->user,
+                'donationDate' => $this->donationDate,
+                'giftAidUrl' => $this->trackedUrl($this->giftAidUrl, 'giftaid_button', 'giftaid'),
+                'settingsUrl' => $this->trackedUrl($this->settingsUrl, 'footer_settings', 'settings'),
+            ], $this->getTrackingData()), 'emails.text.donation.giftaid-chaseup')
+            ->applyLogging('GiftAidChaseUp');
+    }
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            from: new Address(
+                config('freegle.mail.noreply_addr'),
+                config('freegle.branding.name')
+            ),
+            subject: $this->getSubject(),
+        );
+    }
+
+    protected function getSubject(): string
+    {
+        return 'Could Freegle collect Gift Aid on your donation?';
+    }
+}

--- a/iznik-batch/app/Services/GiftAidClaimService.php
+++ b/iznik-batch/app/Services/GiftAidClaimService.php
@@ -2,9 +2,12 @@
 
 namespace App\Services;
 
+use App\Mail\Donation\GiftAidChaseUp;
 use App\Models\GiftAid;
+use App\Models\User;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Mail;
 
 /**
  * Generates HMRC Gift Aid claim CSVs from reviewed, unclaimed donation records.
@@ -395,6 +398,82 @@ class GiftAidClaimService
         } elseif ($rowCallback !== null) {
             $rowCallback($row);
         }
+    }
+
+    /**
+     * Send one-off gift aid consent chase-up emails to eligible donors.
+     *
+     * Mirrors V1 donations_giftaid.php chase-up loop.
+     * Targets PayPal/Stripe donors (2-30 days ago) with no gift aid consent and
+     * no prior chaseup record. Sends at most one email per user and marks all
+     * their donations with giftaidchaseup = NOW() to prevent re-sending.
+     *
+     * @return int Number of emails sent
+     */
+    public function sendGiftAidChaseUps(): int
+    {
+        $start = now()->subDays(2)->toDateString();
+        $end = now()->subDays(30)->toDateString();
+
+        $donations = DB::table('users_donations')
+            ->leftJoin('giftaid', 'giftaid.userid', '=', 'users_donations.userid')
+            ->where('users_donations.timestamp', '>=', '2016-04-06')
+            ->where('users_donations.timestamp', '>=', $end)
+            ->where('users_donations.timestamp', '<=', $start)
+            ->whereIn('users_donations.source', ['DonateWithPayPal', 'Stripe'])
+            ->where('users_donations.giftaidconsent', 0)
+            ->whereNull('giftaid.userid')
+            ->whereNull('users_donations.giftaidchaseup')
+            ->whereNotNull('users_donations.userid')
+            ->select('users_donations.*')
+            ->get();
+
+        $sent = 0;
+        $sentTo = [];
+
+        foreach ($donations as $donation) {
+            if (isset($sentTo[$donation->userid])) {
+                continue;
+            }
+
+            // Check for any previous chaseup on any of this user's donations
+            $previousChaseUp = DB::table('users_donations')
+                ->where('userid', $donation->userid)
+                ->whereNotNull('giftaidchaseup')
+                ->exists();
+
+            if ($previousChaseUp) {
+                // Fix up pre-existing gap: mark all their donations as chased
+                DB::table('users_donations')
+                    ->where('userid', $donation->userid)
+                    ->update(['giftaidchaseup' => now()]);
+                $sentTo[$donation->userid] = true;
+                continue;
+            }
+
+            $user = User::find($donation->userid);
+            if (! $user || ! $user->email_preferred) {
+                continue;
+            }
+
+            $sentTo[$donation->userid] = true;
+            $donationDate = date('d-M-Y', strtotime($donation->timestamp));
+
+            try {
+                $mailable = new GiftAidChaseUp($user, $donationDate);
+                Mail::queue($mailable);
+
+                DB::table('users_donations')
+                    ->where('userid', $donation->userid)
+                    ->update(['giftaidchaseup' => now()]);
+
+                $sent++;
+            } catch (\Throwable $e) {
+                Log::error('GiftAid chaseup failed', ['userid' => $donation->userid, 'error' => $e->getMessage()]);
+            }
+        }
+
+        return $sent;
     }
 
     /**

--- a/iznik-batch/resources/views/emails/mjml/donation/giftaid-chaseup.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/donation/giftaid-chaseup.blade.php
@@ -1,0 +1,47 @@
+<mjml>
+    @include('emails.mjml.partials.head', ['preview' => 'Could Freegle collect Gift Aid on your donation?'])
+
+    <mj-body background-color="#f4f4f4">
+        @include('emails.mjml.components.header')
+
+        <mj-section background-color="#ffffff" padding="20px">
+            <mj-column>
+                <mj-text>
+                    Dear {{ $user->displayname ?? 'there' }},
+                </mj-text>
+                <mj-text>
+                    You kindly donated to Freegle on {{ $donationDate }}. We can make your kind donation go even further if we can claim Gift Aid on it.
+                </mj-text>
+                <mj-text>
+                    If you're a UK taxpayer, Freegle can claim an extra 25p for every £1 you donate — at no cost to you!
+                </mj-text>
+            </mj-column>
+        </mj-section>
+
+        <mj-section background-color="#ffffff" padding="10px 20px">
+            <mj-column>
+                <mj-button href="{{ $giftAidUrl }}" mj-class="btn-success" border-radius="3px">
+                    Consent to Gift Aid
+                </mj-button>
+            </mj-column>
+        </mj-section>
+
+        <mj-section background-color="#ffffff" padding="10px 20px">
+            <mj-column>
+                <mj-text font-size="13px" color="#666666">
+                    This is a one-off email. You won't be asked again about this donation.
+                </mj-text>
+            </mj-column>
+        </mj-section>
+
+        @if(!empty($trackingPixelMjml))
+        <mj-section padding="0">
+            <mj-column>
+                {!! $trackingPixelMjml !!}
+            </mj-column>
+        </mj-section>
+        @endif
+
+        @include('emails.mjml.partials.footer', ['email' => $user->email_preferred, 'settingsUrl' => $settingsUrl])
+    </mj-body>
+</mjml>

--- a/iznik-batch/resources/views/emails/text/donation/giftaid-chaseup.blade.php
+++ b/iznik-batch/resources/views/emails/text/donation/giftaid-chaseup.blade.php
@@ -1,0 +1,12 @@
+Hi {!! $user->displayname ?? 'there' !!},
+
+You kindly donated to Freegle on {!! $donationDate !!}. We can make your kind donation go even further if we can claim Gift Aid on it.
+
+If you're a UK taxpayer, Freegle can claim an extra 25p for every £1 you donate — at no cost to you!
+
+Consent to Gift Aid: {!! $giftAidUrl !!}
+
+This is a one-off email. You won't be asked again about this donation.
+
+---
+To change your notification settings: {!! $settingsUrl !!}

--- a/iznik-batch/routes/console.php
+++ b/iznik-batch/routes/console.php
@@ -381,6 +381,19 @@ Schedule::command('ai:usage-counts:update')
 
 
 // =============================================================================
+// GIFT AID
+// =============================================================================
+
+// Update gift aid data: identify postcodes, houses, consented donations.
+// Also sends one-off chase-up emails to eligible donors (2-30 days ago, PayPal/Stripe).
+// V1: cron/donations_giftaid.php
+Schedule::command('donations:update-giftaid')
+    ->everyTenMinutes()
+    ->withoutOverlapping()
+    ->sendOutputTo(cronLog('donations:update-giftaid'))
+    ->runInBackground();
+
+// =============================================================================
 // VECTOR SEARCH EMBEDDINGS
 // =============================================================================
 

--- a/iznik-batch/tests/Unit/Services/GiftAidClaimServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/GiftAidClaimServiceTest.php
@@ -555,4 +555,116 @@ class GiftAidClaimServiceTest extends TestCase
         // Cleanup
         DB::delete('DELETE FROM giftaid WHERE userid = ?', [$user->id]);
     }
+
+    // =========================================================================
+    // sendGiftAidChaseUps tests
+    // =========================================================================
+
+    private function insertDonation(int $userId, array $attrs = []): int
+    {
+        return DB::table('users_donations')->insertGetId(array_merge([
+            'userid' => $userId,
+            'source' => 'DonateWithPayPal',
+            'GrossAmount' => '5.00',
+            'timestamp' => now()->subDays(5)->toDateTimeString(),
+            'giftaidconsent' => 0,
+            'giftaidchaseup' => null,
+            'Payer' => 'test@example.com',
+            'PayerDisplayName' => 'Test User',
+            'TransactionID' => uniqid('tx', true),
+        ], $attrs));
+    }
+
+    public function test_chaseup_sends_email_to_eligible_donor(): void
+    {
+        $user = $this->createTestUser();
+        $this->insertDonation($user->id);
+
+        \Illuminate\Support\Facades\Mail::fake();
+
+        $sent = $this->service->sendGiftAidChaseUps();
+
+        $this->assertGreaterThanOrEqual(1, $sent);
+        \Illuminate\Support\Facades\Mail::assertQueued(\App\Mail\Donation\GiftAidChaseUp::class, function ($mail) use ($user) {
+            return $mail->user->id === $user->id;
+        });
+    }
+
+    public function test_chaseup_marks_giftaidchaseup_after_send(): void
+    {
+        $user = $this->createTestUser();
+        $donationId = $this->insertDonation($user->id);
+
+        \Illuminate\Support\Facades\Mail::fake();
+        $this->service->sendGiftAidChaseUps();
+
+        $chaseup = DB::table('users_donations')->where('id', $donationId)->value('giftaidchaseup');
+        $this->assertNotNull($chaseup);
+    }
+
+    public function test_chaseup_skips_donor_already_chased(): void
+    {
+        $user = $this->createTestUser();
+        $this->insertDonation($user->id, ['giftaidchaseup' => now()->subDays(1)->toDateTimeString()]);
+
+        \Illuminate\Support\Facades\Mail::fake();
+        $sent = $this->service->sendGiftAidChaseUps();
+
+        \Illuminate\Support\Facades\Mail::assertNotQueued(\App\Mail\Donation\GiftAidChaseUp::class, function ($mail) use ($user) {
+            return $mail->user->id === $user->id;
+        });
+    }
+
+    public function test_chaseup_skips_donor_with_giftaid_consent(): void
+    {
+        $user = $this->createTestUser();
+        $this->insertDonation($user->id, ['giftaidconsent' => 1]);
+
+        \Illuminate\Support\Facades\Mail::fake();
+        $this->service->sendGiftAidChaseUps();
+
+        \Illuminate\Support\Facades\Mail::assertNotQueued(\App\Mail\Donation\GiftAidChaseUp::class, function ($mail) use ($user) {
+            return $mail->user->id === $user->id;
+        });
+    }
+
+    public function test_chaseup_skips_donation_older_than_30_days(): void
+    {
+        $user = $this->createTestUser();
+        $this->insertDonation($user->id, ['timestamp' => now()->subDays(31)->toDateTimeString()]);
+
+        \Illuminate\Support\Facades\Mail::fake();
+        $this->service->sendGiftAidChaseUps();
+
+        \Illuminate\Support\Facades\Mail::assertNotQueued(\App\Mail\Donation\GiftAidChaseUp::class, function ($mail) use ($user) {
+            return $mail->user->id === $user->id;
+        });
+    }
+
+    public function test_chaseup_skips_donation_less_than_2_days_old(): void
+    {
+        $user = $this->createTestUser();
+        $this->insertDonation($user->id, ['timestamp' => now()->subHours(12)->toDateTimeString()]);
+
+        \Illuminate\Support\Facades\Mail::fake();
+        $this->service->sendGiftAidChaseUps();
+
+        \Illuminate\Support\Facades\Mail::assertNotQueued(\App\Mail\Donation\GiftAidChaseUp::class, function ($mail) use ($user) {
+            return $mail->user->id === $user->id;
+        });
+    }
+
+    public function test_chaseup_sends_only_one_email_per_user(): void
+    {
+        $user = $this->createTestUser();
+        // Two donations from same user
+        $this->insertDonation($user->id);
+        $this->insertDonation($user->id);
+
+        \Illuminate\Support\Facades\Mail::fake();
+        $sent = $this->service->sendGiftAidChaseUps();
+
+        // Only 1 email per user
+        \Illuminate\Support\Facades\Mail::assertQueued(\App\Mail\Donation\GiftAidChaseUp::class, 1);
+    }
 }


### PR DESCRIPTION
## Summary

- Adds `donations:update-giftaid` artisan command (every 10 min), replacing V1 `cron/donations_giftaid.php`
- New `GiftAidChaseUp` mailable with MJML + plain-text templates asking UK taxpayers to consent to Gift Aid
- `GiftAidClaimService::sendGiftAidChaseUps()` targets PayPal/Stripe donors (2–30 days ago) with no consent and no prior chase-up; marks all their donations with `giftaidchaseup = NOW()` after sending
- Command also calls existing `identifyPostcodes()`, `identifyHouseNumbers()`, `identifyGiftAidedDonations()` — full V1 parity

## Code Quality Review

- Business logic matches V1 `donations_giftaid.php` chase-up loop: same date window (2–30 days), same source filter, same deduplication logic
- `Mail::queue()` used (consistent with rest of batch app); tests use `assertQueued()`
- No hardcoded URLs — all via `config('freegle.sites.*')`

## Test Plan

- [x] 7 new unit tests in `GiftAidClaimServiceTest` — all pass (27/27 total)
  - Eligible donor receives email
  - `giftaidchaseup` marked on all user donations after send
  - Already-chased donors skipped
  - Donors with gift aid consent skipped
  - Donations older than 30 days skipped
  - Donations newer than 2 days skipped
  - Only one email per user when multiple eligible donations exist