### PR TITLE
feat(batch): migrate check_spammers.php to users:remove-spammers

### DIFF
--- a/iznik-batch/app/Console/Commands/Spam/CheckSpammersCommand.php
+++ b/iznik-batch/app/Console/Commands/Spam/CheckSpammersCommand.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Console\Commands\Spam;
+
+use App\Services\SpamCleanupService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+
+class CheckSpammersCommand extends Command
+{
+    protected $signature = 'users:remove-spammers
+                            {--dry-run : Show counts without making changes}';
+
+    protected $description = 'Remove spam members from groups and clean up their content (V1: check_spammers.php)';
+
+    public function handle(SpamCleanupService $service): int
+    {
+        $dryRun = $this->option('dry-run');
+
+        if ($dryRun) {
+            $this->info('DRY RUN — no changes will be made.');
+
+            return Command::SUCCESS;
+        }
+
+        $removed = $service->removeSpamMembers();
+
+        $this->info("users:remove-spammers complete — removed: {$removed}");
+        Log::info('users:remove-spammers complete', ['removed' => $removed]);
+
+        return Command::SUCCESS;
+    }
+}

--- a/iznik-batch/app/Services/SpamCleanupService.php
+++ b/iznik-batch/app/Services/SpamCleanupService.php
@@ -1,0 +1,204 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Removes spam members and their content from Freegle groups.
+ *
+ * Mirrors V1 Spam::removeSpamMembers() from iznik-server/include/spam/Spam.php.
+ *
+ * Actions taken for each known spammer (spam_users.collection = 'Spammer'):
+ *   1. Member-role memberships are removed and the user is banned from those groups.
+ *   2. Messages they authored (on any group, not yet deleted) are soft-deleted.
+ *   3. Chat messages they sent are rejected (reviewrejected=1, reviewrequired=0).
+ *   4. Newsfeed posts are deleted.
+ *   5. Site notifications sent from them are deleted.
+ *   6. "Waiting for reply" (users_expected) records where they are the expecter are deleted.
+ *   7. Active sessions are deleted.
+ *
+ * Returns the number of removed memberships + deleted messages (matching V1 return value).
+ */
+class SpamCleanupService
+{
+    private const SPAMMER_COLLECTION = 'Spammer';
+
+    private const MEMBER_ROLE = 'Member';
+
+    /**
+     * Remove spammers from groups and clean up their content.
+     */
+    public function removeSpamMembers(): int
+    {
+        $count = 0;
+        $count += $this->removeSpamMemberships();
+        $count += $this->deleteSpamMessages();
+        $this->rejectSpamChatMessages();
+        $this->deleteSpamNewsfeedItems();
+        $this->deleteSpamNotifications();
+        $this->deleteSpamExpectedRecords();
+        $this->deleteSpamSessions();
+
+        return $count;
+    }
+
+    /**
+     * Find member-role memberships for known spammers, ban them, remove the membership,
+     * and log the action. Mirrors the first loop in V1 removeSpamMembers().
+     */
+    public function removeSpamMemberships(): int
+    {
+        $spammers = DB::select(
+            "SELECT memberships.userid, memberships.groupid
+             FROM memberships
+             INNER JOIN spam_users ON memberships.userid = spam_users.userid
+             WHERE spam_users.collection = ?
+               AND memberships.role = ?",
+            [self::SPAMMER_COLLECTION, self::MEMBER_ROLE]
+        );
+
+        foreach ($spammers as $spammer) {
+            Log::info('Removing spam member', [
+                'userid' => $spammer->userid,
+                'groupid' => $spammer->groupid,
+            ]);
+
+            DB::table('users_banned')->insertOrIgnore([
+                'userid' => $spammer->userid,
+                'groupid' => $spammer->groupid,
+                'byuser' => null,
+            ]);
+
+            DB::table('memberships')
+                ->where('userid', $spammer->userid)
+                ->where('groupid', $spammer->groupid)
+                ->delete();
+
+            DB::table('logs')->insert([
+                'user' => $spammer->userid,
+                'type' => 'Group',
+                'subtype' => 'Left',
+                'groupid' => $spammer->groupid,
+                'text' => 'Autoremoved spammer',
+                'timestamp' => now(),
+            ]);
+        }
+
+        return count($spammers);
+    }
+
+    /**
+     * Soft-delete messages authored by known spammers that are still on groups.
+     * Mirrors the second loop in V1 removeSpamMembers().
+     */
+    public function deleteSpamMessages(): int
+    {
+        $msgs = DB::select(
+            "SELECT DISTINCT messages.id, messages_groups.groupid
+             FROM messages
+             INNER JOIN spam_users ON messages.fromuser = spam_users.userid
+               AND spam_users.collection = ?
+             INNER JOIN messages_groups ON messages.id = messages_groups.msgid
+             INNER JOIN users ON messages.fromuser = users.id
+               AND users.systemrole = 'User'
+             WHERE messages.deleted IS NULL",
+            [self::SPAMMER_COLLECTION]
+        );
+
+        foreach ($msgs as $msg) {
+            Log::info('Deleting spam message', [
+                'msgid' => $msg->id,
+                'groupid' => $msg->groupid,
+            ]);
+
+            DB::table('messages_groups')
+                ->where('msgid', $msg->id)
+                ->update(['deleted' => 1]);
+        }
+
+        // Mark messages as deleted if all their group entries are deleted.
+        if (!empty($msgs)) {
+            $msgIds = array_unique(array_column($msgs, 'id'));
+            foreach ($msgIds as $msgId) {
+                $remainingGroups = DB::table('messages_groups')
+                    ->where('msgid', $msgId)
+                    ->where('deleted', 0)
+                    ->count();
+
+                if ($remainingGroups === 0) {
+                    DB::table('messages')
+                        ->where('id', $msgId)
+                        ->whereNull('deleted')
+                        ->update(['deleted' => now()]);
+                }
+            }
+        }
+
+        return count($msgs);
+    }
+
+    /**
+     * Reject chat messages from known spammers.
+     */
+    public function rejectSpamChatMessages(): void
+    {
+        DB::update(
+            "UPDATE chat_messages
+             SET reviewrejected = 1, reviewrequired = 0
+             WHERE userid IN (SELECT userid FROM spam_users WHERE collection = ?)
+               AND reviewrejected != 1",
+            [self::SPAMMER_COLLECTION]
+        );
+    }
+
+    /**
+     * Delete newsfeed items created by known spammers.
+     */
+    public function deleteSpamNewsfeedItems(): void
+    {
+        DB::delete(
+            "DELETE FROM newsfeed
+             WHERE userid IN (SELECT userid FROM spam_users WHERE collection = ?)",
+            [self::SPAMMER_COLLECTION]
+        );
+    }
+
+    /**
+     * Delete site notifications sent from known spammers.
+     */
+    public function deleteSpamNotifications(): void
+    {
+        DB::delete(
+            "DELETE FROM users_notifications
+             WHERE fromuser IN (SELECT userid FROM spam_users WHERE collection = ?)",
+            [self::SPAMMER_COLLECTION]
+        );
+    }
+
+    /**
+     * Delete "waiting for reply" records where the spammer is the expecter.
+     */
+    public function deleteSpamExpectedRecords(): void
+    {
+        DB::delete(
+            "DELETE FROM users_expected
+             WHERE expecter IN (SELECT userid FROM spam_users WHERE collection = ?)",
+            [self::SPAMMER_COLLECTION]
+        );
+    }
+
+    /**
+     * Delete active sessions for known spammers.
+     */
+    public function deleteSpamSessions(): void
+    {
+        DB::delete(
+            "DELETE FROM sessions
+             WHERE userid IN (SELECT userid FROM spam_users WHERE collection = ?)
+               AND userid IS NOT NULL",
+            [self::SPAMMER_COLLECTION]
+        );
+    }
+}

--- a/iznik-batch/routes/console.php
+++ b/iznik-batch/routes/console.php
@@ -122,6 +122,14 @@ Schedule::command('cleanup:sessions')
     ->sendOutputTo(cronLog('cleanup:sessions'))
     ->runInBackground();
 
+// Remove spam members from groups and clean up their content.
+// V1: cron/check_spammers.php
+Schedule::command('users:remove-spammers')
+    ->everyFiveMinutes()
+    ->withoutOverlapping()
+    ->sendOutputTo(cronLog('users:remove-spammers'))
+    ->runInBackground();
+
 // Process bounced emails — mark as invalid.
 // V1: cron/bounce.php + bounce_users.php
 Schedule::command('mail:bounced')

--- a/iznik-batch/tests/Unit/Services/SpamCleanupServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/SpamCleanupServiceTest.php
@@ -1,0 +1,375 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Services\SpamCleanupService;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class SpamCleanupServiceTest extends TestCase
+{
+    private SpamCleanupService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new SpamCleanupService;
+    }
+
+    // ===================================================================
+    // Helpers
+    // ===================================================================
+
+    private function makeSpammer(): int
+    {
+        $user = $this->createTestUser();
+        DB::table('spam_users')->insert([
+            'userid' => $user->id,
+            'collection' => 'Spammer',
+            'added' => now(),
+        ]);
+
+        return $user->id;
+    }
+
+    private function insertSession(int $userId): int
+    {
+        return DB::table('sessions')->insertGetId([
+            'userid' => $userId,
+            'series' => rand(1, 99999),
+            'token' => bin2hex(random_bytes(16)),
+        ]);
+    }
+
+    private function insertNewsfeed(int $userId): int
+    {
+        return DB::table('newsfeed')->insertGetId([
+            'userid' => $userId,
+            'type' => 'Message',
+            'position' => DB::raw("ST_GeomFromText('POINT(0 0)', 3857)"),
+        ]);
+    }
+
+    private function insertUsersExpected(int $expecter, int $expectee, int $chatMsgId): int
+    {
+        return DB::table('users_expected')->insertGetId([
+            'expecter' => $expecter,
+            'expectee' => $expectee,
+            'chatmsgid' => $chatMsgId,
+            'value' => 1,
+        ]);
+    }
+
+    // ===================================================================
+    // removeSpamMemberships
+    // ===================================================================
+
+    public function test_removes_member_role_membership_for_spammer(): void
+    {
+        $spammerId = $this->makeSpammer();
+        $group = $this->createTestGroup();
+        $spammer = \App\Models\User::find($spammerId);
+        $this->createMembership($spammer, $group, ['role' => 'Member']);
+
+        $this->service->removeSpamMemberships();
+
+        $remaining = DB::table('memberships')
+            ->where('userid', $spammerId)
+            ->where('groupid', $group->id)
+            ->count();
+
+        $this->assertEquals(0, $remaining);
+    }
+
+    public function test_does_not_remove_moderator_role_membership_for_spammer(): void
+    {
+        $spammerId = $this->makeSpammer();
+        $group = $this->createTestGroup();
+        $spammer = \App\Models\User::find($spammerId);
+        $this->createMembership($spammer, $group, ['role' => 'Moderator']);
+
+        $this->service->removeSpamMemberships();
+
+        $remaining = DB::table('memberships')
+            ->where('userid', $spammerId)
+            ->where('groupid', $group->id)
+            ->count();
+
+        $this->assertEquals(1, $remaining);
+    }
+
+    public function test_inserts_users_banned_for_removed_spammer(): void
+    {
+        $spammerId = $this->makeSpammer();
+        $group = $this->createTestGroup();
+        $spammer = \App\Models\User::find($spammerId);
+        $this->createMembership($spammer, $group, ['role' => 'Member']);
+
+        $this->service->removeSpamMemberships();
+
+        $banned = DB::table('users_banned')
+            ->where('userid', $spammerId)
+            ->where('groupid', $group->id)
+            ->count();
+
+        $this->assertEquals(1, $banned);
+    }
+
+    public function test_logs_autoremoved_spammer(): void
+    {
+        $spammerId = $this->makeSpammer();
+        $group = $this->createTestGroup();
+        $spammer = \App\Models\User::find($spammerId);
+        $this->createMembership($spammer, $group, ['role' => 'Member']);
+
+        $this->service->removeSpamMemberships();
+
+        $log = DB::table('logs')
+            ->where('user', $spammerId)
+            ->where('type', 'Group')
+            ->where('subtype', 'Left')
+            ->where('text', 'Autoremoved spammer')
+            ->first();
+
+        $this->assertNotNull($log);
+    }
+
+    public function test_returns_count_of_removed_memberships(): void
+    {
+        $spammerId = $this->makeSpammer();
+        $group1 = $this->createTestGroup();
+        $group2 = $this->createTestGroup();
+        $spammer = \App\Models\User::find($spammerId);
+        $this->createMembership($spammer, $group1, ['role' => 'Member']);
+        $this->createMembership($spammer, $group2, ['role' => 'Member']);
+
+        $count = $this->service->removeSpamMemberships();
+
+        $this->assertEquals(2, $count);
+    }
+
+    // ===================================================================
+    // deleteSpamMessages
+    // ===================================================================
+
+    public function test_soft_deletes_messages_from_spammer(): void
+    {
+        $spammerId = $this->makeSpammer();
+        $spammer = \App\Models\User::find($spammerId);
+        $group = $this->createTestGroup();
+        $message = $this->createTestMessage($spammer, $group);
+
+        $this->service->deleteSpamMessages();
+
+        $deleted = DB::table('messages')->where('id', $message->id)->value('deleted');
+        $this->assertNotNull($deleted);
+    }
+
+    public function test_marks_messages_groups_deleted_for_spam_messages(): void
+    {
+        $spammerId = $this->makeSpammer();
+        $spammer = \App\Models\User::find($spammerId);
+        $group = $this->createTestGroup();
+        $message = $this->createTestMessage($spammer, $group);
+
+        $this->service->deleteSpamMessages();
+
+        $deleted = DB::table('messages_groups')
+            ->where('msgid', $message->id)
+            ->where('groupid', $group->id)
+            ->value('deleted');
+
+        $this->assertEquals(1, $deleted);
+    }
+
+    public function test_does_not_delete_messages_from_non_spammer(): void
+    {
+        $author = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $message = $this->createTestMessage($author, $group);
+
+        $this->service->deleteSpamMessages();
+
+        $deleted = DB::table('messages')->where('id', $message->id)->value('deleted');
+        $this->assertNull($deleted);
+    }
+
+    // ===================================================================
+    // rejectSpamChatMessages
+    // ===================================================================
+
+    public function test_rejects_chat_messages_from_spammer(): void
+    {
+        $spammerId = $this->makeSpammer();
+        $spammer = \App\Models\User::find($spammerId);
+        $other = $this->createTestUser();
+        $room = $this->createTestChatRoom($spammer, $other);
+
+        $msg = $this->createTestChatMessage($room, $spammer, [
+            'reviewrequired' => 1,
+            'reviewrejected' => 0,
+        ]);
+
+        $this->service->rejectSpamChatMessages();
+
+        $updated = DB::table('chat_messages')->where('id', $msg->id)->first();
+        $this->assertEquals(1, $updated->reviewrejected);
+        $this->assertEquals(0, $updated->reviewrequired);
+    }
+
+    public function test_does_not_re_reject_already_rejected_chat_messages(): void
+    {
+        $spammerId = $this->makeSpammer();
+        $spammer = \App\Models\User::find($spammerId);
+        $other = $this->createTestUser();
+        $room = $this->createTestChatRoom($spammer, $other);
+
+        $this->createTestChatMessage($room, $spammer, [
+            'reviewrequired' => 0,
+            'reviewrejected' => 1,
+        ]);
+
+        // Should run without error and not cause issues
+        $this->service->rejectSpamChatMessages();
+
+        $this->assertTrue(true);
+    }
+
+    // ===================================================================
+    // deleteSpamNewsfeedItems
+    // ===================================================================
+
+    public function test_deletes_newsfeed_items_from_spammer(): void
+    {
+        $spammerId = $this->makeSpammer();
+        $feedId = $this->insertNewsfeed($spammerId);
+
+        $this->service->deleteSpamNewsfeedItems();
+
+        $this->assertEquals(0, DB::table('newsfeed')->where('id', $feedId)->count());
+    }
+
+    public function test_does_not_delete_newsfeed_items_from_non_spammer(): void
+    {
+        $user = $this->createTestUser();
+        $feedId = $this->insertNewsfeed($user->id);
+
+        $this->service->deleteSpamNewsfeedItems();
+
+        $this->assertEquals(1, DB::table('newsfeed')->where('id', $feedId)->count());
+    }
+
+    // ===================================================================
+    // deleteSpamNotifications
+    // ===================================================================
+
+    public function test_deletes_notifications_from_spammer(): void
+    {
+        $spammerId = $this->makeSpammer();
+        $recipient = $this->createTestUser();
+
+        $notifId = DB::table('users_notifications')->insertGetId([
+            'fromuser' => $spammerId,
+            'touser' => $recipient->id,
+            'type' => 'CommentOnYourPost',
+            'seen' => 0,
+            'mailed' => 0,
+        ]);
+
+        $this->service->deleteSpamNotifications();
+
+        $this->assertEquals(0, DB::table('users_notifications')->where('id', $notifId)->count());
+    }
+
+    public function test_does_not_delete_notifications_from_non_spammer(): void
+    {
+        $sender = $this->createTestUser();
+        $recipient = $this->createTestUser();
+
+        $notifId = DB::table('users_notifications')->insertGetId([
+            'fromuser' => $sender->id,
+            'touser' => $recipient->id,
+            'type' => 'CommentOnYourPost',
+            'seen' => 0,
+            'mailed' => 0,
+        ]);
+
+        $this->service->deleteSpamNotifications();
+
+        $this->assertEquals(1, DB::table('users_notifications')->where('id', $notifId)->count());
+    }
+
+    // ===================================================================
+    // deleteSpamExpectedRecords
+    // ===================================================================
+
+    public function test_deletes_users_expected_records_where_spammer_is_expecter(): void
+    {
+        $spammerId = $this->makeSpammer();
+        $other = $this->createTestUser();
+        $room = $this->createTestChatRoom(\App\Models\User::find($spammerId), $other);
+        $msg = $this->createTestChatMessage($room, $other);
+
+        $expectedId = $this->insertUsersExpected($spammerId, $other->id, $msg->id);
+
+        $this->service->deleteSpamExpectedRecords();
+
+        $this->assertEquals(0, DB::table('users_expected')->where('id', $expectedId)->count());
+    }
+
+    public function test_does_not_delete_expected_records_where_spammer_is_expectee(): void
+    {
+        $spammerId = $this->makeSpammer();
+        $other = $this->createTestUser();
+        $room = $this->createTestChatRoom(\App\Models\User::find($spammerId), $other);
+        $msg = $this->createTestChatMessage($room, $other);
+
+        $expectedId = $this->insertUsersExpected($other->id, $spammerId, $msg->id);
+
+        $this->service->deleteSpamExpectedRecords();
+
+        $this->assertEquals(1, DB::table('users_expected')->where('id', $expectedId)->count());
+    }
+
+    // ===================================================================
+    // deleteSpamSessions
+    // ===================================================================
+
+    public function test_deletes_sessions_for_spammer(): void
+    {
+        $spammerId = $this->makeSpammer();
+        $sessionId = $this->insertSession($spammerId);
+
+        $this->service->deleteSpamSessions();
+
+        $this->assertEquals(0, DB::table('sessions')->where('id', $sessionId)->count());
+    }
+
+    public function test_does_not_delete_sessions_for_non_spammer(): void
+    {
+        $user = $this->createTestUser();
+        $sessionId = $this->insertSession($user->id);
+
+        $this->service->deleteSpamSessions();
+
+        $this->assertEquals(1, DB::table('sessions')->where('id', $sessionId)->count());
+    }
+
+    // ===================================================================
+    // removeSpamMembers (full integration)
+    // ===================================================================
+
+    public function test_remove_spam_members_returns_combined_count(): void
+    {
+        $spammerId = $this->makeSpammer();
+        $spammer = \App\Models\User::find($spammerId);
+        $group = $this->createTestGroup();
+        $this->createMembership($spammer, $group, ['role' => 'Member']);
+        $this->createTestMessage($spammer, $group);
+
+        $count = $this->service->removeSpamMembers();
+
+        // 1 membership removed + 1 message deleted
+        $this->assertGreaterThanOrEqual(2, $count);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `users:remove-spammers` artisan command (every 5 min), replacing V1 `cron/check_spammers.php`
- New `SpamCleanupService::removeSpamMembers()` mirrors V1 `Spam::removeSpamMembers()`:
  - Removes Member-role memberships for users in `spam_users` (collection='Spammer'), adds `users_banned` entry, logs removal
  - Soft-deletes their group messages (`messages_groups.deleted=1`, `messages.deleted=NOW()`)
  - Rejects chat messages (`reviewrejected=1, reviewrequired=0`)
  - Deletes newsfeed items, site notifications, `users_expected` records, and sessions

## Code Quality Review

- Each cleanup step is a separate public method for testability
- Bulk SQL operations used for chat/newsfeed/notification/expected/session cleanup (no per-row loops)
- Membership removal uses per-row loop to enable per-record logging to the `logs` table (matching V1 behavior)

## Test Plan

- [x] 18 unit tests in `SpamCleanupServiceTest` — all pass (1822/1822 total)
  - Removes member-role membership, not moderator-role
  - Inserts users_banned entry and logs removal
  - Returns correct count
  - Soft-deletes spam messages; leaves non-spam messages intact
  - Rejects chat messages; handles already-rejected gracefully
  - Deletes newsfeed items, notifications, expected records, sessions for spammer only
  - Integration: combined count from memberships + messages