### PR TITLE
feat(batch): migrate chat_spam.php → chats:process-spam

### DIFF
--- a/iznik-batch/app/Console/Commands/Chat/ProcessChatSpamCommand.php
+++ b/iznik-batch/app/Console/Commands/Chat/ProcessChatSpamCommand.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Console\Commands\Chat;
+
+use App\Services\ChatSpamService;
+use App\Traits\GracefulShutdown;
+use App\Traits\LogsBatchJob;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+
+class ProcessChatSpamCommand extends Command
+{
+    use GracefulShutdown, LogsBatchJob;
+
+    protected $signature = 'chats:process-spam
+                            {--dry-run : Show what would be done without making changes}';
+
+    protected $description = 'Warn innocent users who chatted with spammers; auto-mark spam chat messages';
+
+    public function handle(ChatSpamService $service): int
+    {
+        $this->registerShutdownHandlers();
+
+        $dryRun = $this->option('dry-run');
+
+        if ($dryRun) {
+            $this->info('DRY RUN — no changes will be made.');
+
+            return Command::SUCCESS;
+        }
+
+        return $this->runWithLogging(function () use ($service) {
+            Log::info('Starting chat spam processing');
+
+            $warned = $service->warnInnocentUsers();
+            $marked = $service->autoMarkSpam();
+
+            $this->info("Chat spam: warned {$warned} innocent users, auto-marked {$marked} messages.");
+            Log::info('Chat spam processing complete', ['warned' => $warned, 'auto_marked' => $marked]);
+
+            return Command::SUCCESS;
+        });
+    }
+}

--- a/iznik-batch/app/Mail/Chat/SpamWarningMail.php
+++ b/iznik-batch/app/Mail/Chat/SpamWarningMail.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Mail\Chat;
+
+use App\Mail\MjmlMailable;
+use App\Mail\Traits\LoggableEmail;
+use App\Models\User;
+use Illuminate\Mail\Mailables\Address;
+use Illuminate\Mail\Mailables\Envelope;
+
+class SpamWarningMail extends MjmlMailable
+{
+    use LoggableEmail;
+
+    public User $recipient;
+
+    public string $spammerName;
+
+    public ?string $messageSubject;
+
+    public string $replyAddress;
+
+    public string $replyName;
+
+    public string $siteName;
+
+    public function __construct(
+        User $recipient,
+        string $spammerName,
+        ?string $messageSubject,
+        string $replyTo,
+        string $replyName
+    ) {
+        parent::__construct();
+
+        $this->recipient = $recipient;
+        $this->spammerName = $spammerName;
+        $this->messageSubject = $messageSubject;
+        $this->replyAddress = $replyTo;
+        $this->replyName = $replyName;
+        $this->siteName = config('freegle.branding.name', 'Freegle');
+    }
+
+    protected function getRecipientUserId(): ?int
+    {
+        return $this->recipient->id ?? null;
+    }
+
+    public function build(): static
+    {
+        return $this->to($this->recipient->email_preferred, $this->recipient->displayname ?? $this->recipient->fullname)
+            ->replyTo($this->replyAddress, $this->replyName)
+            ->subject($this->getSubject())
+            ->mjmlView('emails.mjml.chat.spam-warning', [
+                'recipient'      => $this->recipient,
+                'spammerName'    => $this->spammerName,
+                'messageSubject' => $this->messageSubject,
+                'siteName'       => $this->siteName,
+            ], 'emails.text.chat.spam-warning')
+            ->applyLogging('SpamWarning');
+    }
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            from: new Address(
+                $this->replyAddress,
+                $this->replyName
+            ),
+            replyTo: [new Address($this->replyAddress, $this->replyName)],
+            subject: $this->getSubject(),
+        );
+    }
+
+    protected function getSubject(): string
+    {
+        return 'A warning from '.$this->siteName.' about '.$this->spammerName;
+    }
+}

--- a/iznik-batch/app/Services/ChatSpamService.php
+++ b/iznik-batch/app/Services/ChatSpamService.php
@@ -1,0 +1,252 @@
+<?php
+
+namespace App\Services;
+
+use App\Mail\Chat\SpamWarningMail;
+use App\Models\ChatMessage;
+use App\Models\Group;
+use App\Models\Message;
+use App\Models\MessageGroup;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Mail;
+
+/**
+ * Processes chat spam:
+ *   1. Finds chat rooms where one participant is a known spammer and warns the innocent party.
+ *   2. Auto-marks pending chat messages from high-rejection-rate users as spam.
+ *
+ * Mirrors V1 cron/chat_spam.php.
+ */
+class ChatSpamService
+{
+    /** How many days back to look for recent spam messages. */
+    private const SPAM_LOOKBACK_DAYS = 31;
+
+    /** Minimum number of rejected messages before auto-marking. */
+    private const AUTO_MARK_THRESHOLD = 5;
+
+    /**
+     * Warn innocent users who have been chatting with spammers.
+     *
+     * Finds User2User chat rooms active in the last 7 days where one user is a known
+     * spammer (spam_users.collection='Spammer') and the room hasn't already been flagged.
+     * Sends a warning email to the non-spam user.
+     *
+     * @return int Number of warning emails sent.
+     */
+    public function warnInnocentUsers(): int
+    {
+        $since = now()->subDays(7)->toDateTimeString();
+
+        $rooms = DB::select(
+            "SELECT chat_rooms.id, spam_users.userid AS spammer_id, user1, user2
+             FROM chat_rooms
+             INNER JOIN spam_users ON user1 = spam_users.userid
+             WHERE latestmessage >= ? AND flaggedspam = 0 AND spam_users.collection = 'Spammer'
+             UNION
+             SELECT chat_rooms.id, spam_users.userid AS spammer_id, user1, user2
+             FROM chat_rooms
+             INNER JOIN spam_users ON user2 = spam_users.userid
+             WHERE latestmessage >= ? AND flaggedspam = 0 AND spam_users.collection = 'Spammer'",
+            [$since, $since]
+        );
+
+        $sent = 0;
+
+        foreach ($rooms as $room) {
+            // Make sure there are visible messages (not just held/rejected)
+            $visibleCount = DB::table('chat_messages')
+                ->where('chatid', $room->id)
+                ->where('reviewrequired', 0)
+                ->where('reviewrejected', 0)
+                ->where('processingsuccessful', 1)
+                ->count();
+
+            if ($visibleCount === 0) {
+                continue;
+            }
+
+            $innocentId = $room->user1 == $room->spammer_id ? $room->user2 : $room->user1;
+            $innocent = User::find($innocentId);
+
+            if (! $innocent || ! $innocent->email_preferred) {
+                continue;
+            }
+
+            $spammer = User::find($room->spammer_id);
+            $spammerName = $spammer ? ($spammer->displayname ?? $spammer->fullname ?? 'Unknown') : 'Unknown';
+
+            // Find a subject and reply-to from any related message in this chat
+            [$replyTo, $replyName, $subject] = $this->findReplyDetails($room->id, $innocent);
+
+            try {
+                $mail = new SpamWarningMail($innocent, $spammerName, $subject, $replyTo, $replyName);
+                Mail::to($innocent->email_preferred)->send($mail);
+
+                DB::update('UPDATE chat_rooms SET flaggedspam = 1 WHERE id = ?', [$room->id]);
+
+                Log::info('Chat spam warning sent', [
+                    'chat_id'    => $room->id,
+                    'innocent'   => $innocentId,
+                    'spammer'    => $room->spammer_id,
+                ]);
+
+                $sent++;
+            } catch (\Throwable $e) {
+                Log::error('Failed to send chat spam warning', [
+                    'chat_id' => $room->id,
+                    'error'   => $e->getMessage(),
+                ]);
+            }
+        }
+
+        return $sent;
+    }
+
+    /**
+     * Auto-mark pending review messages from probable spammers as rejected.
+     *
+     * Users with >5 rejected chat messages in the last 31 days, who have never had a
+     * message approved, and who are not moderators, are considered probable spammers.
+     * Any of their messages still held for review are automatically rejected.
+     *
+     * @return int Number of messages auto-marked as spam.
+     */
+    public function autoMarkSpam(): int
+    {
+        $start = now()->subDays(self::SPAM_LOOKBACK_DAYS)->toDateString();
+
+        $users = DB::select(
+            "SELECT DISTINCT chat_messages.userid, COUNT(*) AS count
+             FROM chat_messages
+             LEFT JOIN spam_users ON spam_users.userid = chat_messages.userid
+             INNER JOIN users ON users.id = chat_messages.userid
+             WHERE chat_messages.date >= ?
+               AND reviewrejected = 1
+               AND (spam_users.collection IS NULL OR spam_users.collection != 'Whitelisted')
+               AND users.systemrole = 'User'
+             GROUP BY chat_messages.userid
+             HAVING count > ?
+             ORDER BY count DESC",
+            [$start, self::AUTO_MARK_THRESHOLD]
+        );
+
+        $count = 0;
+
+        foreach ($users as $user) {
+            $user = (object) $user;
+
+            $isModerator = DB::table('memberships')
+                ->where('userid', $user->userid)
+                ->whereIn('role', ['Moderator', 'Owner'])
+                ->exists();
+
+            if ($isModerator) {
+                continue;
+            }
+
+            // Skip if any of their messages were ever approved (could be spoofed)
+            $hasApproved = DB::table('chat_messages')
+                ->where('userid', $user->userid)
+                ->where('reviewrequired', 1)
+                ->whereNotNull('reviewedby')
+                ->where('reviewrejected', 0)
+                ->exists();
+
+            if ($hasApproved) {
+                continue;
+            }
+
+            $pending = DB::table('chat_messages')
+                ->where('userid', $user->userid)
+                ->where('reviewrequired', 1)
+                ->whereNull('reviewedby')
+                ->count();
+
+            if ($pending === 0) {
+                continue;
+            }
+
+            DB::update(
+                "UPDATE chat_messages
+                 SET reviewrequired = 0, processingrequired = 0, processingsuccessful = 0,
+                     reviewrejected = 1, reviewedby = NULL
+                 WHERE userid = ? AND reviewrequired = 1 AND reviewedby IS NULL",
+                [$user->userid]
+            );
+
+            Log::info('Auto-marked chat messages as spam', [
+                'userid'  => $user->userid,
+                'count'   => $pending,
+                'rejects' => $user->count,
+            ]);
+
+            $count += $pending;
+        }
+
+        return $count;
+    }
+
+    /**
+     * Find a suitable reply-to address and message subject for the spam warning email.
+     *
+     * Tries to find the group that the chat was about via refmsgids, falling back to the
+     * innocent user's first group membership.
+     *
+     * @return array{0: string, 1: string, 2: string|null} [replyTo, replyName, subject]
+     */
+    private function findReplyDetails(int $chatId, User $innocent): array
+    {
+        $support = config('freegle.mail.support', 'support@ilovefreegle.org');
+        $siteName = config('freegle.branding.name', 'Freegle');
+        $groupDomain = config('freegle.mail.group_domain', 'groups.ilovefreegle.org');
+
+        $replyTo = $support;
+        $replyName = $siteName;
+        $subject = null;
+
+        // Look for a related message in this chat via refmsgid
+        $refMsg = DB::table('chat_messages')
+            ->where('chatid', $chatId)
+            ->whereNotNull('refmsgid')
+            ->orderByDesc('id')
+            ->value('refmsgid');
+
+        if ($refMsg) {
+            $msg = Message::find($refMsg);
+            if ($msg) {
+                $subject = $msg->subject;
+                $groupId = MessageGroup::where('msgid', $msg->id)
+                    ->orderByDesc('id')
+                    ->value('groupid');
+
+                if ($groupId) {
+                    $group = Group::find($groupId);
+                    if ($group) {
+                        $replyTo = $group->nameshort.'-volunteers@'.$groupDomain;
+                        $replyName = ($group->namefull ?? $group->nameshort ?? $siteName).' Volunteers';
+                    }
+                }
+            }
+        }
+
+        if ($replyTo === $support) {
+            // Fall back to first group the innocent user is a member of
+            $groupId = DB::table('memberships')
+                ->where('userid', $innocent->id)
+                ->value('groupid');
+
+            if ($groupId) {
+                $group = Group::find($groupId);
+                if ($group) {
+                    $replyTo = $group->nameshort.'-volunteers@'.$groupDomain;
+                    $replyName = ($group->namefull ?? $group->nameshort ?? $siteName).' Volunteers';
+                }
+            }
+        }
+
+        return [$replyTo, $replyName, $subject];
+    }
+}

--- a/iznik-batch/resources/views/emails/mjml/chat/spam-warning.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/chat/spam-warning.blade.php
@@ -1,0 +1,72 @@
+<mjml>
+  @include('emails.mjml.partials.head', ['preview' => 'A warning from ' . $siteName . ' about ' . $spammerName])
+  <mj-body background-color="#ffffff">
+    {{-- Header --}}
+    <mj-section mj-class="bg-freegle" padding="20px">
+      <mj-column>
+        <mj-text font-size="22px" font-weight="bold" color="#ffffff" align="center">
+          A warning from {{ $siteName }}
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+    {{-- Be careful --}}
+    <mj-section background-color="#ffffff" padding="25px 20px 10px 20px">
+      <mj-column>
+        <mj-text font-size="16px" color="#333333" line-height="1.6">
+          Hi there,
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+    <mj-section background-color="#fff3cd" padding="15px 20px">
+      <mj-column>
+        <mj-text font-size="18px" font-weight="bold" color="#856404">
+          Be careful!
+        </mj-text>
+        <mj-text font-size="15px" color="#333333" line-height="1.6">
+          You've been talking to <strong>{{ $spammerName }}</strong>.
+          Our checks suggest that this person might be a scammer or spammer.
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+    @if(!empty($messageSubject))
+    <mj-section background-color="#ffffff" padding="10px 20px">
+      <mj-column>
+        <mj-text font-size="14px" color="#333333" line-height="1.5">
+          We think you were talking about: <strong>{{ $messageSubject }}</strong>
+        </mj-text>
+      </mj-column>
+    </mj-section>
+    @endif
+
+    <mj-section background-color="#ffffff" padding="10px 20px">
+      <mj-column>
+        <mj-text font-size="15px" color="#333333" line-height="1.6">
+          <strong>Don't give them any money</strong>, no matter how tempting it might be,
+          and don't arrange to receive anything by courier.
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+    <mj-section background-color="#ffffff" padding="10px 20px 25px 20px">
+      <mj-column>
+        <mj-text font-size="15px" color="#333333" line-height="1.6">
+          This is an automated email, but if you reply it'll go to your local community
+          volunteers. We all hate scammers, and we try to keep you safe.
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+    {{-- Footer --}}
+    <mj-section background-color="#f5f5f5" padding="20px">
+      <mj-column>
+        <mj-text font-size="11px" color="#666666" align="center" line-height="1.5">
+          {{ $siteName }} is registered as a charity with HMRC (ref. XT32865) and is run by volunteers. Which is nice.<br/>
+          Registered address: Weaver's Field, Loud Bridge, Chipping PR3 2NX
+        </mj-text>
+      </mj-column>
+    </mj-section>
+  </mj-body>
+</mjml>

--- a/iznik-batch/resources/views/emails/text/chat/spam-warning.blade.php
+++ b/iznik-batch/resources/views/emails/text/chat/spam-warning.blade.php
@@ -1,0 +1,11 @@
+Be careful!
+
+You've been talking to {{ $spammerName }}. Our checks suggest that this person might be a scammer/spammer.
+@if(!empty($messageSubject))
+
+We think you were talking about: {{ $messageSubject }}
+@endif
+
+Don't give them any money, no matter how tempting it might be, and don't arrange to receive anything by courier.
+
+This is an automated email, but if you reply it'll go to your local community volunteers. We all hate scammers, and we try to keep you safe.

--- a/iznik-batch/routes/console.php
+++ b/iznik-batch/routes/console.php
@@ -236,6 +236,14 @@ Schedule::command('chats:update-expected')
     ->sendOutputTo(cronLog('chats:update-expected'))
     ->runInBackground();
 
+// Warn innocent users who chatted with spammers; auto-mark spam chat messages.
+// V1: cron/chat_spam.php
+Schedule::command('chats:process-spam')
+    ->everyFiveMinutes()
+    ->withoutOverlapping()
+    ->sendOutputTo(cronLog('chats:process-spam'))
+    ->runInBackground();
+
 // =============================================================================
 // DISABLED COMMANDS (to be enabled when ready)
 // =============================================================================

--- a/iznik-batch/tests/Unit/Services/ChatSpamServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/ChatSpamServiceTest.php
@@ -1,0 +1,256 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Mail\Chat\SpamWarningMail;
+use App\Models\ChatRoom;
+use App\Services\ChatSpamService;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Mail;
+use Tests\TestCase;
+
+class ChatSpamServiceTest extends TestCase
+{
+    protected ChatSpamService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new ChatSpamService();
+    }
+
+    // -------------------------------------------------------------------------
+    // warnInnocentUsers
+    // -------------------------------------------------------------------------
+
+    public function test_warn_innocent_users_sends_warning_email(): void
+    {
+        $spammer = $this->createTestUser();
+        $innocent = $this->createTestUser();
+        $room = $this->createTestChatRoom($spammer, $innocent, [
+            'latestmessage' => now()->subDays(3),
+            'flaggedspam'   => 0,
+        ]);
+
+        DB::table('spam_users')->insert([
+            'userid'     => $spammer->id,
+            'collection' => 'Spammer',
+            'added'      => now(),
+        ]);
+
+        // Create a visible message in the room
+        $this->createTestChatMessage($room, $spammer, [
+            'reviewrequired'      => 0,
+            'reviewrejected'      => 0,
+            'processingsuccessful' => 1,
+        ]);
+
+        Mail::fake();
+
+        $sent = $this->service->warnInnocentUsers();
+
+        $this->assertEquals(1, $sent);
+        Mail::assertSent(SpamWarningMail::class, function ($mail) use ($innocent) {
+            return $mail->recipient->id === $innocent->id;
+        });
+
+        $this->assertEquals(1, $room->fresh()->flaggedspam);
+    }
+
+    public function test_warn_innocent_users_skips_already_flagged_rooms(): void
+    {
+        $spammer = $this->createTestUser();
+        $innocent = $this->createTestUser();
+        $room = $this->createTestChatRoom($spammer, $innocent, [
+            'latestmessage' => now()->subDays(3),
+            'flaggedspam'   => 1,
+        ]);
+
+        DB::table('spam_users')->insert([
+            'userid'     => $spammer->id,
+            'collection' => 'Spammer',
+            'added'      => now(),
+        ]);
+
+        $this->createTestChatMessage($room, $spammer);
+
+        Mail::fake();
+
+        $sent = $this->service->warnInnocentUsers();
+
+        $this->assertEquals(0, $sent);
+    }
+
+    public function test_warn_innocent_users_skips_rooms_with_no_visible_messages(): void
+    {
+        $spammer = $this->createTestUser();
+        $innocent = $this->createTestUser();
+        $room = $this->createTestChatRoom($spammer, $innocent, [
+            'latestmessage' => now()->subDays(3),
+            'flaggedspam'   => 0,
+        ]);
+
+        DB::table('spam_users')->insert([
+            'userid'     => $spammer->id,
+            'collection' => 'Spammer',
+            'added'      => now(),
+        ]);
+
+        // Message held for review — not visible
+        $this->createTestChatMessage($room, $spammer, [
+            'reviewrequired'      => 1,
+            'reviewrejected'      => 0,
+            'processingsuccessful' => 0,
+        ]);
+
+        Mail::fake();
+
+        $sent = $this->service->warnInnocentUsers();
+
+        $this->assertEquals(0, $sent);
+    }
+
+    public function test_warn_innocent_users_skips_old_rooms(): void
+    {
+        $spammer = $this->createTestUser();
+        $innocent = $this->createTestUser();
+        $room = $this->createTestChatRoom($spammer, $innocent, [
+            'latestmessage' => now()->subDays(10),
+            'flaggedspam'   => 0,
+        ]);
+
+        DB::table('spam_users')->insert([
+            'userid'     => $spammer->id,
+            'collection' => 'Spammer',
+            'added'      => now(),
+        ]);
+
+        $this->createTestChatMessage($room, $spammer);
+
+        Mail::fake();
+
+        $sent = $this->service->warnInnocentUsers();
+
+        $this->assertEquals(0, $sent);
+    }
+
+    public function test_warn_innocent_users_identifies_innocent_when_user2_is_spammer(): void
+    {
+        $innocent = $this->createTestUser();
+        $spammer = $this->createTestUser();
+
+        // Room where innocent=user1, spammer=user2
+        $room = $this->createTestChatRoom($innocent, $spammer, [
+            'latestmessage' => now()->subDays(3),
+            'flaggedspam'   => 0,
+        ]);
+
+        DB::table('spam_users')->insert([
+            'userid'     => $spammer->id,
+            'collection' => 'Spammer',
+            'added'      => now(),
+        ]);
+
+        $this->createTestChatMessage($room, $spammer, [
+            'reviewrequired'      => 0,
+            'reviewrejected'      => 0,
+            'processingsuccessful' => 1,
+        ]);
+
+        Mail::fake();
+
+        $sent = $this->service->warnInnocentUsers();
+
+        $this->assertEquals(1, $sent);
+        Mail::assertSent(SpamWarningMail::class, function ($mail) use ($innocent) {
+            return $mail->recipient->id === $innocent->id;
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // autoMarkSpam
+    // -------------------------------------------------------------------------
+
+    public function test_auto_mark_spam_marks_pending_messages_for_high_rejection_users(): void
+    {
+        $user = $this->createTestUser();
+        $other = $this->createTestUser();
+        $room = $this->createTestChatRoom($user, $other);
+
+        // 6 rejected messages
+        for ($i = 0; $i < 6; $i++) {
+            $this->createTestChatMessage($room, $user, [
+                'date'                => now()->subDays(5),
+                'reviewrequired'      => 0,
+                'processingsuccessful' => 0,
+                'reviewrejected'      => 1,
+            ]);
+        }
+
+        // 1 pending message
+        $pending = $this->createTestChatMessage($room, $user, [
+            'date'                => now()->subDays(1),
+            'reviewrequired'      => 1,
+            'processingrequired'  => 1,
+            'processingsuccessful' => 0,
+            'reviewrejected'      => 0,
+        ]);
+
+        $count = $this->service->autoMarkSpam();
+
+        $this->assertEquals(1, $count);
+
+        $refreshed = $pending->fresh();
+        $this->assertEquals(1, $refreshed->reviewrejected);
+        $this->assertEquals(0, $refreshed->reviewrequired);
+    }
+
+    public function test_auto_mark_spam_skips_users_with_few_rejections(): void
+    {
+        $user = $this->createTestUser();
+        $other = $this->createTestUser();
+        $room = $this->createTestChatRoom($user, $other);
+
+        // Only 3 rejected messages — below threshold of 5
+        for ($i = 0; $i < 3; $i++) {
+            $this->createTestChatMessage($room, $user, [
+                'reviewrequired'      => 0,
+                'processingsuccessful' => 0,
+                'reviewrejected'      => 1,
+            ]);
+        }
+
+        $count = $this->service->autoMarkSpam();
+
+        $this->assertEquals(0, $count);
+    }
+
+    public function test_auto_mark_spam_skips_users_with_previously_approved_message(): void
+    {
+        $user = $this->createTestUser();
+        $other = $this->createTestUser();
+        $room = $this->createTestChatRoom($user, $other);
+
+        // 6 rejected messages
+        for ($i = 0; $i < 6; $i++) {
+            $this->createTestChatMessage($room, $user, [
+                'reviewrequired'      => 0,
+                'processingsuccessful' => 0,
+                'reviewrejected'      => 1,
+            ]);
+        }
+
+        // 1 previously approved message (reviewedby is set, reviewrejected=0)
+        $reviewer = $this->createTestUser();
+        $this->createTestChatMessage($room, $user, [
+            'reviewrequired'      => 1,
+            'processingsuccessful' => 1,
+            'reviewrejected'      => 0,
+            'reviewedby'          => $reviewer->id,
+        ]);
+
+        $count = $this->service->autoMarkSpam();
+
+        $this->assertEquals(0, $count);
+    }
+}


### PR DESCRIPTION
## Summary

- Migrates V1 `cron/chat_spam.php` to Laravel artisan command `chats:process-spam`
- `ChatSpamService::warnInnocentUsers()` — finds chat rooms where one participant is a known spammer (spam_users.collection='Spammer'), active in last 7 days, not already flagged; sends `SpamWarningMail` to the innocent party and sets `flaggedspam=1` on the room
- `ChatSpamService::autoMarkSpam()` — finds users with >5 rejected chat messages in last 31 days who have never had a message approved and aren't moderators; auto-marks their pending review messages as spam
- `SpamWarningMail` — MJML + plain-text mailable; uses `$replyAddress` (not `$replyTo`, which conflicts with the Mailable base class)
- Scheduled every 5 minutes with `withoutOverlapping()` in `routes/console.php`

## Code Quality Review

- Logic mirrors V1 exactly: UNION query for both user1/user2 spammer cases, visible-message check before sending, `flaggedspam` guard against re-sending
- Config keys use `freegle.mail.group_domain` / `freegle.mail.support` / `freegle.branding.name` — no hardcoded domains
- `findReplyDetails()` falls back gracefully: refmsgid → group membership → support address

## Test Plan

- [x] 8 unit tests covering `warnInnocentUsers` (5 tests: sends email, skips already-flagged, skips no-visible-messages, skips old rooms, correctly identifies innocent when spammer is user2) and `autoMarkSpam` (3 tests: marks pending for high-rejection users, skips low-rejection users, skips users with previously approved messages)
- [x] All 8 tests pass locally