### PR TITLE
feat(batch): migrate message_spatial.php → messages:update-spatial-index

### DIFF
--- a/iznik-batch/tests/Unit/Commands/Message/UpdateSpatialIndexCommandTest.php
+++ b/iznik-batch/tests/Unit/Commands/Message/UpdateSpatialIndexCommandTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Unit\Commands\Message;
+
+use App\Services\MessageSpatialService;
+use Tests\TestCase;
+
+class UpdateSpatialIndexCommandTest extends TestCase
+{
+    public function test_dry_run_returns_success_without_changes(): void
+    {
+        $service = $this->createMock(MessageSpatialService::class);
+        $service->expects($this->never())->method('updateSpatialIndex');
+        $this->app->instance(MessageSpatialService::class, $service);
+
+        $this->artisan('messages:update-spatial-index', ['--dry-run' => true])
+            ->expectsOutputToContain('Dry run')
+            ->assertExitCode(0);
+    }
+
+    public function test_command_runs_service_and_reports_results(): void
+    {
+        $service = $this->createMock(MessageSpatialService::class);
+        $service->method('updateSpatialIndex')->willReturn(42);
+        $this->app->instance(MessageSpatialService::class, $service);
+
+        $this->artisan('messages:update-spatial-index')
+            ->expectsOutputToContain('42 row(s) processed')
+            ->assertExitCode(0);
+    }
+}


### PR DESCRIPTION
## Summary

- Migrates V1 `cron/message_spatial.php` → `Message::updateSpatialIndex()` to Laravel artisan command `messages:update-spatial-index`
- `MessageSpatialService::updateSpatialIndex()` runs 5 steps each invocation:
  1. Upsert recent Approved messages with locations into `messages_spatial` (using `ST_GeomFromText`)
  2. Queue `freebie_alerts_add` background task for newly-indexed messages (replaces V1 beanstalkd push)
  3. Update `successful`/`promised` flags based on `messages_outcomes` and `messages_promises`
  4. Remove stale entries for deleted messages/users
  5. Remove entries for old (>31 days) and non-Approved messages
- `UpdateSpatialIndexCommand` (`messages:update-spatial-index`, `--dry-run` support)
- Scheduled every 5 minutes in `routes/console.php`

## Code Quality Review

- SRID from `config('freegle.srid', 3857)` — no hardcoded value
- Uses `CONCAT('POINT(', lng, ' ', lat, ')')` pattern to avoid SQL injection with coordinate interpolation
- Freebie alert queuing uses `background_tasks` table (same pattern as `CopyAdminsCommand`)
- Mirrors all 5 cleanup passes from V1 exactly

## Test Plan

- [x] 9 unit tests: indexes new message, queues freebie alert, doesn't re-queue existing, skips no-location, skips non-Approved, removes withdrawn, marks taken as successful, removes deleted, removes old
- [x] All 9 tests pass locally