### PR TITLE
feat(batch): migrate chat_process.php to chats:process-incoming

### DIFF
--- a/iznik-batch/MIGRATION-STATUS.md
+++ b/iznik-batch/MIGRATION-STATUS.md
@@ -53,6 +53,7 @@ All email-related commands use the `mail:` prefix. Other batch commands use desc
 | `data:classify-app-release` | Classify app release versions |
 | `groups:update-counts` | Update group member/moderator counts |
 | `chats:update-counts` | Update chat message counts, reopen closed User2Mod |
+| `chats:process-incoming` | Process pending chat messages (processingrequired=1): spam check, roster update |
 | `users:update-lastaccess` | Fallback update of user last access timestamps |
 | `users:update-support-roles` | Grant/remove support tools access |
 | `donations:update-ads-target` | Update ads-off donation target |
@@ -203,6 +204,7 @@ These have code implemented but the scheduler entry is commented out in `routes/
 | `message_spatial.php` | `messages:update-spatial-index` | - | Spatial index updates (PR #398) |
 | `message_unindexed.php` | `messages:update-index` | - | Index missing messages (PR #393) |
 | `message_deindex.php` | `messages:deindex` | - | De-index old messages (PR #393) |
+| `chat_process.php` | `chats:process-incoming` | - | Process pending incoming chat messages: spam check, roster update, reopen closed chats |
 | `memberships_processing.php` | `memberships:process` | - | Membership processing: welcome emails, flag mod comments |
 | `exports.php` | `users:process-exports` | - | GDPR data export processing + purge old export data |
 | `engage_update.php` | `users:update-engagement` | - | Update user engagement classifications (New/Occasional/Frequent/Obsessed/Inactive/Dormant) |
@@ -244,7 +246,7 @@ These original scripts need to be migrated to Laravel artisan commands:
 | Script | Frequency | Priority | Description |
 |--------|-----------|----------|-------------|
 | `background.php` | Every 1 min | High | Background job processor — **Covered: `queue:background-tasks` (Go API background tasks)** |
-| `chat_process.php` | Every 1 min | High | Chat message processing |
+| ~~`chat_process.php`~~ | ~~Every 1 min~~ | ~~High~~ | ~~Chat message processing~~ — **Migrated: `chats:process-incoming`** |
 | `admins.php` | Every 1 min | Medium | Admin notifications — **Covered: `mail:admin:copy` + `mail:admin:send` + `mail:admin:chase`** |
 | `tryst.php` | Every 1 min | Medium | Meeting coordination |
 | ~~`memberships_processing.php`~~ | ~~Every 1 min~~ | ~~Medium~~ | ~~Membership processing~~ — **Migrated: `memberships:process`** |

--- a/iznik-batch/app/Console/Commands/Chat/ProcessIncomingChatCommand.php
+++ b/iznik-batch/app/Console/Commands/Chat/ProcessIncomingChatCommand.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Console\Commands\Chat;
+
+use App\Console\Concerns\PreventsOverlapping;
+use App\Services\ChatProcessService;
+use App\Traits\GracefulShutdown;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+
+class ProcessIncomingChatCommand extends Command
+{
+    use PreventsOverlapping;
+    use GracefulShutdown;
+
+    protected $signature = 'chats:process-incoming
+                            {--dry-run : Show what would be processed without making changes}';
+
+    protected $description = 'Process pending chat messages (processingrequired=1) — spam checks, roster update, reopen closed chats';
+
+    public function handle(ChatProcessService $service): int
+    {
+        if (!$this->acquireLock()) {
+            $this->info('Already running, exiting.');
+            return Command::SUCCESS;
+        }
+
+        try {
+            if ($this->option('dry-run')) {
+                $count = \Illuminate\Support\Facades\DB::table('chat_messages')
+                    ->where('processingrequired', 1)
+                    ->count();
+                $this->info("Dry run — {$count} message(s) would be processed.");
+                return Command::SUCCESS;
+            }
+
+            Log::info('Starting chat message processing');
+
+            $count = $service->processIncoming();
+
+            $this->info("{$count} message(s) processed");
+            Log::info('Chat message processing complete', ['count' => $count]);
+
+            return Command::SUCCESS;
+        } finally {
+            $this->releaseLock();
+        }
+    }
+}

--- a/iznik-batch/app/Services/ChatProcessService.php
+++ b/iznik-batch/app/Services/ChatProcessService.php
@@ -1,0 +1,244 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\ChatMessage;
+use App\Models\ChatRoom;
+use App\Models\ChatRoster;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Processes chat messages that arrive via incoming email (processingrequired = 1).
+ *
+ * Mirrors V1 cron/chat_process.php + ChatMessage::process().
+ *
+ * Key responsibilities:
+ * - Spam/ban checks for User2User chats
+ * - Setting processingrequired = 0, processingsuccessful = 1 (or 0 on failure)
+ * - Updating chat_roster for the sender
+ * - Reopening closed chats after new activity
+ */
+class ChatProcessService
+{
+    // V1: ChatMessage::REVIEW_SPAM, REVIEW_FORCE, etc.
+    private const REVIEW_SPAM = 'Spam';
+    private const REVIEW_LAST = 'Last';
+
+    /**
+     * Process all pending chat messages (processingrequired = 1).
+     *
+     * @return int Number of messages processed.
+     */
+    public function processIncoming(): int
+    {
+        $messages = DB::table('chat_messages')
+            ->join('chat_rooms', 'chat_messages.chatid', '=', 'chat_rooms.id')
+            ->where('chat_messages.processingrequired', 1)
+            ->orderBy('chat_messages.id', 'asc')
+            ->select('chat_messages.*', 'chat_rooms.chattype', 'chat_rooms.user1', 'chat_rooms.user2')
+            ->get();
+
+        $count = 0;
+
+        foreach ($messages as $message) {
+            if ($this->processMessage($message)) {
+                $count++;
+            }
+        }
+
+        Log::info("ChatProcess: processed {$count} messages");
+
+        return $count;
+    }
+
+    /**
+     * Process a single pending message.
+     *
+     * @return bool True if the message was processed (success or failure), false if skipped.
+     */
+    private function processMessage(object $message): bool
+    {
+        $id = $message->id;
+        $chatid = $message->chatid;
+        $userid = $message->userid;
+        $chattype = $message->chattype;
+        $platform = (bool) $message->platform;
+
+        // --- Ban check for messages with a refmsgid ---
+        if (!empty($message->refmsgid)) {
+            $banned = DB::table('messages_groups')
+                ->join('users_banned', function ($join) use ($userid) {
+                    $join->on('messages_groups.groupid', '=', 'users_banned.groupid')
+                        ->where('users_banned.userid', '=', $userid);
+                })
+                ->where('messages_groups.msgid', $message->refmsgid)
+                ->exists();
+
+            if ($banned) {
+                $this->processFailed($id);
+                return true;
+            }
+        }
+
+        // --- User2User spam and review checks ---
+        $review = 0;
+        $reviewreason = null;
+        $spam = 0;
+
+        if ($chattype === ChatRoom::TYPE_USER2USER) {
+            // Check if sender is a confirmed or pending spammer.
+            $isSpammer = DB::table('spam_users')
+                ->where('userid', $userid)
+                ->whereIn('collection', ['Spammer', 'PendingAdd'])
+                ->exists();
+
+            if ($isSpammer) {
+                $this->processFailed($id);
+                return true;
+            }
+
+            // Check if sender is banned on all common groups with the other user.
+            $otherId = $message->user1 == $userid ? $message->user2 : $message->user1;
+
+            $bannedInCommon = $this->isBannedInCommonGroups($userid, $otherId);
+
+            if ($bannedInCommon) {
+                $this->processFailed($id);
+                return true;
+            }
+
+            // Check if sender's messages should be held for review.
+            $user = DB::table('users')->where('id', $userid)->first();
+            $chatmodstatus = $user?->chatmodstatus ?? 'Moderated';
+
+            if ($chatmodstatus === 'Fully') {
+                $review = 1;
+                $reviewreason = self::REVIEW_SPAM;
+            }
+
+            // If the previous message in this chat is held for review, hold this one too.
+            if (!$review) {
+                $lastReview = DB::table('chat_messages')
+                    ->where('chatid', $chatid)
+                    ->where('id', '!=', $id)
+                    ->orderByDesc('id')
+                    ->value('reviewrequired');
+
+                if ($lastReview) {
+                    $review = 1;
+                    $reviewreason = self::REVIEW_LAST;
+                }
+            }
+        }
+
+        // Mark the message as processed.
+        DB::table('chat_messages')
+            ->where('id', $id)
+            ->update([
+                'reviewrequired' => $review,
+                'reportreason' => $reviewreason,
+                'reviewrejected' => $spam,
+                'processingrequired' => 0,
+                'processingsuccessful' => 1,
+            ]);
+
+        // Update the sender's roster position.
+        $this->updateSenderRoster($id, $chatid, $userid, $platform);
+
+        // Reopen any CLOSED roster entries for this chat (not BLOCKED).
+        DB::table('chat_roster')
+            ->where('chatid', $chatid)
+            ->where('status', ChatRoster::STATUS_CLOSED)
+            ->update(['status' => ChatRoster::STATUS_OFFLINE]);
+
+        return true;
+    }
+
+    /**
+     * Mark a message as failed processing.
+     */
+    private function processFailed(int $messageId): void
+    {
+        DB::table('chat_messages')
+            ->where('id', $messageId)
+            ->update([
+                'processingrequired' => 0,
+                'processingsuccessful' => 0,
+            ]);
+    }
+
+    /**
+     * Check if $userId is banned on all groups they have in common with $otherId.
+     */
+    private function isBannedInCommonGroups(int $userId, int $otherId): bool
+    {
+        // Get groups both users are members of.
+        $commonGroups = DB::table('memberships as m1')
+            ->join('memberships as m2', function ($join) use ($otherId) {
+                $join->on('m1.groupid', '=', 'm2.groupid')
+                    ->where('m2.userid', '=', $otherId);
+            })
+            ->where('m1.userid', $userId)
+            ->pluck('m1.groupid');
+
+        if ($commonGroups->isEmpty()) {
+            return false;
+        }
+
+        // Check if $userId is banned on ALL common groups.
+        $bannedCount = DB::table('users_banned')
+            ->where('userid', $userId)
+            ->whereIn('groupid', $commonGroups)
+            ->count();
+
+        return $bannedCount >= $commonGroups->count();
+    }
+
+    /**
+     * Update the sender's roster entry after they sent a message.
+     *
+     * V1: If the message came by email (!platform), mark it seen/emailed (since the sender
+     * wrote it, they've "seen" it). For platform messages, same unless they have email-mine on.
+     */
+    private function updateSenderRoster(int $messageId, int $chatid, int $userid, bool $platform): void
+    {
+        if (!$platform) {
+            // Incoming email reply: only update if there are no unseen messages from the other user.
+            $hasUnseen = DB::table('chat_messages as cm')
+                ->leftJoin('chat_roster as cr', function ($join) use ($userid) {
+                    $join->on('cr.chatid', '=', 'cm.chatid')
+                        ->where('cr.userid', '=', $userid);
+                })
+                ->where('cm.chatid', $chatid)
+                ->where('cm.userid', '!=', $userid)
+                ->where('cm.seenbyall', 0)
+                ->where('cm.mailedtoall', 0)
+                ->where(function ($q) {
+                    $q->whereNull('cr.lastmsgseen')
+                        ->orWhereColumn('cr.lastmsgseen', '<', 'cm.id');
+                })
+                ->where(function ($q) {
+                    $q->whereNull('cr.lastmsgemailed')
+                        ->orWhereColumn('cr.lastmsgemailed', '<', 'cm.id');
+                })
+                ->exists();
+
+            if ($hasUnseen) {
+                return;
+            }
+        }
+
+        DB::table('chat_roster')
+            ->where('chatid', $chatid)
+            ->where('userid', $userid)
+            ->where(function ($q) use ($messageId) {
+                $q->whereNull('lastmsgseen')
+                    ->orWhere('lastmsgseen', '<', $messageId);
+            })
+            ->update([
+                'lastmsgseen' => $messageId,
+                'lastmsgemailed' => $messageId,
+            ]);
+    }
+}

--- a/iznik-batch/routes/console.php
+++ b/iznik-batch/routes/console.php
@@ -377,6 +377,16 @@ Schedule::command('mail:admin:chase')
 // NOT YET ENABLED — enable individually after testing
 // =============================================================================
 
+// Process pending chat messages (processingrequired=1): spam check, roster update, reopen closed chats.
+// V1: cron/chat_process.php (continuous daemon, restarted by cron every 2 minutes)
+// IncomingMailService creates messages with processingrequired=1; this makes them visible to notifications.
+// — disabled pending sign-off
+// Schedule::command('chats:process-incoming')
+//     ->everyMinute()
+//     ->withoutOverlapping()
+//     ->sendOutputTo(cronLog('chats:process-incoming'))
+//     ->runInBackground();
+
 // Process pending GDPR data export requests and purge old completed data.
 // V1: cron/exports.php (every 1 minute)
 // — disabled pending sign-off

--- a/iznik-batch/tests/Unit/Services/ChatProcessServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/ChatProcessServiceTest.php
@@ -1,0 +1,267 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Models\ChatMessage;
+use App\Models\ChatRoom;
+use App\Models\ChatRoster;
+use App\Services\ChatProcessService;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class ChatProcessServiceTest extends TestCase
+{
+    protected ChatProcessService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new ChatProcessService();
+    }
+
+    // --- Basic processing ---
+
+    public function test_message_with_processingrequired_gets_marked_processed(): void
+    {
+        $user1 = $this->createTestUser();
+        $user2 = $this->createTestUser();
+        $room = $this->createTestChatRoom($user1, $user2);
+
+        $msg = $this->createTestChatMessage($room, $user1, [
+            'processingrequired' => 1,
+            'processingsuccessful' => 0,
+            'platform' => 1,
+        ]);
+
+        $count = $this->service->processIncoming();
+
+        $updated = DB::table('chat_messages')->where('id', $msg->id)->first();
+        $this->assertEquals(0, $updated->processingrequired);
+        $this->assertEquals(1, $updated->processingsuccessful);
+        $this->assertEquals(0, $updated->reviewrequired);
+        $this->assertGreaterThanOrEqual(1, $count);
+    }
+
+    public function test_already_processed_message_is_not_touched(): void
+    {
+        $user1 = $this->createTestUser();
+        $user2 = $this->createTestUser();
+        $room = $this->createTestChatRoom($user1, $user2);
+
+        $this->createTestChatMessage($room, $user1, [
+            'processingrequired' => 0,
+            'processingsuccessful' => 1,
+        ]);
+
+        $count = $this->service->processIncoming();
+
+        $this->assertEquals(0, $count);
+    }
+
+    public function test_returns_count_of_processed_messages(): void
+    {
+        $user1 = $this->createTestUser();
+        $user2 = $this->createTestUser();
+        $room = $this->createTestChatRoom($user1, $user2);
+
+        $this->createTestChatMessage($room, $user1, ['processingrequired' => 1, 'processingsuccessful' => 0, 'platform' => 1]);
+        $this->createTestChatMessage($room, $user2, ['processingrequired' => 1, 'processingsuccessful' => 0, 'platform' => 1]);
+
+        $count = $this->service->processIncoming();
+
+        $this->assertEquals(2, $count);
+    }
+
+    // --- Spammer checks ---
+
+    public function test_message_from_confirmed_spammer_fails_processing(): void
+    {
+        $user1 = $this->createTestUser();
+        $user2 = $this->createTestUser();
+        $room = $this->createTestChatRoom($user1, $user2);
+
+        DB::table('spam_users')->insert([
+            'userid' => $user1->id,
+            'collection' => 'Spammer',
+            'added' => now(),
+        ]);
+
+        $msg = $this->createTestChatMessage($room, $user1, [
+            'processingrequired' => 1,
+            'processingsuccessful' => 0,
+            'platform' => 1,
+        ]);
+
+        $this->service->processIncoming();
+
+        $updated = DB::table('chat_messages')->where('id', $msg->id)->first();
+        $this->assertEquals(0, $updated->processingrequired);
+        $this->assertEquals(0, $updated->processingsuccessful);
+    }
+
+    public function test_message_from_pending_add_spammer_fails_processing(): void
+    {
+        $user1 = $this->createTestUser();
+        $user2 = $this->createTestUser();
+        $room = $this->createTestChatRoom($user1, $user2);
+
+        DB::table('spam_users')->insert([
+            'userid' => $user1->id,
+            'collection' => 'PendingAdd',
+            'added' => now(),
+        ]);
+
+        $msg = $this->createTestChatMessage($room, $user1, [
+            'processingrequired' => 1,
+            'processingsuccessful' => 0,
+            'platform' => 1,
+        ]);
+
+        $this->service->processIncoming();
+
+        $updated = DB::table('chat_messages')->where('id', $msg->id)->first();
+        $this->assertEquals(0, $updated->processingrequired);
+        $this->assertEquals(0, $updated->processingsuccessful);
+    }
+
+    public function test_message_from_whitelisted_user_processes_normally(): void
+    {
+        $user1 = $this->createTestUser();
+        $user2 = $this->createTestUser();
+        $room = $this->createTestChatRoom($user1, $user2);
+
+        DB::table('spam_users')->insert([
+            'userid' => $user1->id,
+            'collection' => 'Whitelisted',
+            'added' => now(),
+        ]);
+
+        $msg = $this->createTestChatMessage($room, $user1, [
+            'processingrequired' => 1,
+            'processingsuccessful' => 0,
+            'platform' => 1,
+        ]);
+
+        $this->service->processIncoming();
+
+        $updated = DB::table('chat_messages')->where('id', $msg->id)->first();
+        $this->assertEquals(0, $updated->processingrequired);
+        $this->assertEquals(1, $updated->processingsuccessful);
+    }
+
+    // --- Roster update ---
+
+    public function test_email_message_updates_sender_roster(): void
+    {
+        $user1 = $this->createTestUser();
+        $user2 = $this->createTestUser();
+        $room = $this->createTestChatRoom($user1, $user2);
+
+        // Create roster entry for user1 in this room
+        DB::table('chat_roster')->insert([
+            'chatid' => $room->id,
+            'userid' => $user1->id,
+            'status' => ChatRoster::STATUS_OFFLINE,
+            'lastmsgseen' => null,
+            'lastmsgemailed' => null,
+        ]);
+
+        $msg = $this->createTestChatMessage($room, $user1, [
+            'processingrequired' => 1,
+            'processingsuccessful' => 0,
+            'platform' => 0,  // email reply
+        ]);
+
+        $this->service->processIncoming();
+
+        $roster = DB::table('chat_roster')->where('chatid', $room->id)->where('userid', $user1->id)->first();
+        $this->assertEquals($msg->id, $roster->lastmsgseen);
+        $this->assertEquals($msg->id, $roster->lastmsgemailed);
+    }
+
+    // --- Closed chat reopen ---
+
+    public function test_closed_chat_is_reopened_after_processing(): void
+    {
+        $user1 = $this->createTestUser();
+        $user2 = $this->createTestUser();
+        $room = $this->createTestChatRoom($user1, $user2);
+
+        // user2's roster entry is CLOSED
+        DB::table('chat_roster')->insert([
+            'chatid' => $room->id,
+            'userid' => $user2->id,
+            'status' => ChatRoster::STATUS_CLOSED,
+            'lastmsgseen' => null,
+            'lastmsgemailed' => null,
+        ]);
+
+        $this->createTestChatMessage($room, $user1, [
+            'processingrequired' => 1,
+            'processingsuccessful' => 0,
+            'platform' => 1,
+        ]);
+
+        $this->service->processIncoming();
+
+        $roster = DB::table('chat_roster')->where('chatid', $room->id)->where('userid', $user2->id)->first();
+        $this->assertEquals(ChatRoster::STATUS_OFFLINE, $roster->status);
+    }
+
+    public function test_blocked_chat_stays_blocked_after_processing(): void
+    {
+        $user1 = $this->createTestUser();
+        $user2 = $this->createTestUser();
+        $room = $this->createTestChatRoom($user1, $user2);
+
+        // user2's roster entry is BLOCKED
+        DB::table('chat_roster')->insert([
+            'chatid' => $room->id,
+            'userid' => $user2->id,
+            'status' => ChatRoster::STATUS_BLOCKED,
+            'lastmsgseen' => null,
+            'lastmsgemailed' => null,
+        ]);
+
+        $this->createTestChatMessage($room, $user1, [
+            'processingrequired' => 1,
+            'processingsuccessful' => 0,
+            'platform' => 1,
+        ]);
+
+        $this->service->processIncoming();
+
+        $roster = DB::table('chat_roster')->where('chatid', $room->id)->where('userid', $user2->id)->first();
+        $this->assertEquals(ChatRoster::STATUS_BLOCKED, $roster->status);
+    }
+
+    // --- Review cascade ---
+
+    public function test_message_held_when_previous_message_under_review(): void
+    {
+        $user1 = $this->createTestUser();
+        $user2 = $this->createTestUser();
+        $room = $this->createTestChatRoom($user1, $user2);
+
+        // Previous message from user2 is under review
+        $this->createTestChatMessage($room, $user2, [
+            'reviewrequired' => 1,
+            'processingrequired' => 0,
+            'processingsuccessful' => 1,
+        ]);
+
+        // New message from user1 needs processing
+        $msg = $this->createTestChatMessage($room, $user1, [
+            'processingrequired' => 1,
+            'processingsuccessful' => 0,
+            'platform' => 1,
+        ]);
+
+        $this->service->processIncoming();
+
+        $updated = DB::table('chat_messages')->where('id', $msg->id)->first();
+        $this->assertEquals(1, $updated->reviewrequired);
+        $this->assertEquals(0, $updated->processingrequired);
+        $this->assertEquals(1, $updated->processingsuccessful);
+    }
+}


### PR DESCRIPTION
## Summary

- Migrates V1 `cron/chat_process.php` to Laravel batch command `chats:process-incoming`
- `IncomingMailService` creates chat messages with `processingrequired=1` (noting that V1's `chat_process.php` handles visibility, roster, push notifications) — **without this migration those email replies are invisible** to `ChatNotificationService` which filters on `processingrequired=0 AND processingsuccessful=1`
- Scheduler entry commented out pending sign-off

## Key operations per message

- Spam/ban checks for User2User chats: `spam_users` (Spammer/PendingAdd), `users_banned`, `chatmodstatus`
- Review cascade: holds new message if previous message in same chat is under review
- Marks `processingrequired=0, processingsuccessful=1` (or 0 on failure)
- Updates sender's `chat_roster` (lastmsgseen/lastmsgemailed) for email replies
- Reopens CLOSED roster entries (not BLOCKED) after new activity

## Known omissions vs V1

- URL expansion (Shortlink service) — optimization only, not critical for delivery
- `processImageMessage` — image spam detection
- `pokeMembers` / push notifications — handled by `queue:background-tasks`
- `notifyMembers` — handled by `mail:chat:*` commands

## Code Quality Review

- Service mirrors V1 logic faithfully with direct DB queries matching V1 SQL patterns
- No external dependencies beyond what already exists in the batch app
- Command uses `PreventsOverlapping` (flock-based) and `GracefulShutdown` traits

## Test Plan

- [x] `test_message_with_processingrequired_gets_marked_processed`
- [x] `test_already_processed_message_is_not_touched`
- [x] `test_returns_count_of_processed_messages`
- [x] `test_message_from_confirmed_spammer_fails_processing`
- [x] `test_message_from_pending_add_spammer_fails_processing`
- [x] `test_message_from_whitelisted_user_processes_normally`
- [x] `test_email_message_updates_sender_roster`
- [x] `test_closed_chat_is_reopened_after_processing`
- [x] `test_blocked_chat_stays_blocked_after_processing`
- [x] `test_message_held_when_previous_message_under_review`
- [x] Full suite (2012 tests) passing