### PR TITLE
feat(batch): migrate memberships_processing.php to memberships:process

### DIFF
--- a/iznik-batch/MIGRATION-STATUS.md
+++ b/iznik-batch/MIGRATION-STATUS.md
@@ -54,6 +54,7 @@ All email-related commands use the `mail:` prefix. Other batch commands use desc
 | `groups:update-counts` | Update group member/moderator counts |
 | `chats:update-counts` | Update chat message counts, reopen closed User2Mod |
 | `chats:process-incoming` | Process pending chat messages (processingrequired=1): spam check, roster update |
+| `memberships:process` | Process pending membership history: per-group welcome emails, flag reviewed members |
 | `users:update-lastaccess` | Fallback update of user last access timestamps |
 | `users:update-support-roles` | Grant/remove support tools access |
 | `donations:update-ads-target` | Update ads-off donation target |
@@ -205,7 +206,7 @@ These have code implemented but the scheduler entry is commented out in `routes/
 | `message_unindexed.php` | `messages:update-index` | - | Index missing messages (PR #393) |
 | `message_deindex.php` | `messages:deindex` | - | De-index old messages (PR #393) |
 | `chat_process.php` | `chats:process-incoming` | - | Process pending incoming chat messages: spam check, roster update, reopen closed chats |
-| `memberships_processing.php` | `memberships:process` | - | Membership processing: welcome emails, flag mod comments |
+| `memberships_processing.php` | `memberships:process` | - | Process pending membership history: per-group welcome emails, flag reviewed members |
 | `exports.php` | `users:process-exports` | - | GDPR data export processing + purge old export data |
 | `engage_update.php` | `users:update-engagement` | - | Update user engagement classifications (New/Occasional/Frequent/Obsessed/Inactive/Dormant) |
 | `users_remap.php` | `users:remap-locations` | - | Update cached location names in user settings |

--- a/iznik-batch/app/Console/Commands/Membership/ProcessMembershipsCommand.php
+++ b/iznik-batch/app/Console/Commands/Membership/ProcessMembershipsCommand.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Console\Commands\Membership;
+
+use App\Console\Concerns\PreventsOverlapping;
+use App\Services\MembershipsProcessingService;
+use App\Traits\GracefulShutdown;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+class ProcessMembershipsCommand extends Command
+{
+    use PreventsOverlapping;
+    use GracefulShutdown;
+
+    protected $signature = 'memberships:process
+                            {--dry-run : Show what would be processed without making changes}';
+
+    protected $description = 'Process pending membership history entries: send per-group welcome emails, flag reviewed members';
+
+    public function handle(MembershipsProcessingService $service): int
+    {
+        if (!$this->acquireLock()) {
+            $this->info('Already running, exiting.');
+            return Command::SUCCESS;
+        }
+
+        try {
+            if ($this->option('dry-run')) {
+                $count = DB::table('memberships_history')
+                    ->where('processingrequired', 1)
+                    ->count();
+                $this->info("Dry run — {$count} entry/entries would be processed.");
+                return Command::SUCCESS;
+            }
+
+            Log::info('Starting membership processing');
+
+            $count = $service->processAll();
+
+            $this->info("{$count} entry/entries processed");
+            Log::info('Membership processing complete', ['count' => $count]);
+
+            return Command::SUCCESS;
+        } finally {
+            $this->releaseLock();
+        }
+    }
+}

--- a/iznik-batch/app/Mail/Welcome/GroupWelcomeMail.php
+++ b/iznik-batch/app/Mail/Welcome/GroupWelcomeMail.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Mail\Welcome;
+
+use App\Mail\MjmlMailable;
+use App\Mail\Traits\LoggableEmail;
+use App\Models\Group;
+use App\Models\User;
+use Illuminate\Mail\Mailables\Address;
+use Illuminate\Mail\Mailables\Envelope;
+
+/**
+ * Per-group welcome email sent to new approved members.
+ *
+ * V1: Group::sendWelcome() / cron/memberships_processing.php
+ *
+ * Sends the group's custom welcome text (groups.welcomemail) to the
+ * new member, from the group's auto-email address.
+ */
+class GroupWelcomeMail extends MjmlMailable
+{
+    use LoggableEmail;
+
+    /**
+     * @param User $user The new member.
+     * @param Group $group The group they joined.
+     */
+    public function __construct(
+        public User $user,
+        public Group $group
+    ) {
+        parent::__construct();
+    }
+
+    protected function getRecipientUserId(): ?int
+    {
+        return $this->user->id;
+    }
+
+    public function envelope(): Envelope
+    {
+        $groupName = $this->group->namefull ?? $this->group->nameshort ?? config('freegle.branding.name');
+        $autoEmail = $this->group->autoemail ?? config('freegle.mail.noreply_addr');
+        $modsEmail = $this->group->modsemail ?? config('freegle.mail.support');
+
+        return new Envelope(
+            from: new Address($autoEmail, "{$groupName} Volunteers"),
+            replyTo: [new Address($modsEmail, "{$groupName} Volunteers")],
+            subject: $this->getSubject(),
+        );
+    }
+
+    protected function getSubject(): string
+    {
+        $groupName = $this->group->namefull ?? $this->group->nameshort ?? config('freegle.branding.name');
+        return "Welcome to {$groupName}";
+    }
+
+    public function build(): static
+    {
+        $groupName = $this->group->namefull ?? $this->group->nameshort ?? config('freegle.branding.name');
+        $recipientEmail = $this->user->email_preferred;
+        $userSite = config('freegle.sites.user');
+
+        // Convert plain-text line breaks to HTML line breaks for display.
+        $welcomeContent = nl2br(e($this->group->welcomemail));
+
+        return $this->mjmlView(
+            'emails.mjml.welcome.group_welcome',
+            [
+                'groupName' => $groupName,
+                'welcomeContent' => $welcomeContent,
+                'email' => $recipientEmail,
+                'userSite' => $userSite,
+                'settingsUrl' => "{$userSite}/settings",
+                'unsubscribeUrl' => "{$userSite}/unsubscribe",
+            ]
+        )->to($recipientEmail)
+            ->applyLogging('GroupWelcome');
+    }
+}

--- a/iznik-batch/app/Services/MembershipsProcessingService.php
+++ b/iznik-batch/app/Services/MembershipsProcessingService.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace App\Services;
+
+use App\Mail\Welcome\GroupWelcomeMail;
+use App\Models\Group;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Mail;
+
+/**
+ * Process pending membership history entries (processingrequired = 1).
+ *
+ * Mirrors V1 cron/memberships_processing.php + User::processMemberships().
+ *
+ * For each new approved membership:
+ * - Send per-group welcome email if the group has one configured.
+ * - Flag member for review if there are flagged mod comments about them.
+ * - Mark the entry as processed (processingrequired = 0).
+ *
+ * Note: Full spam check (Spam::checkUser) is not implemented here.
+ * The users:remove-spammers command handles spam detection separately.
+ */
+class MembershipsProcessingService
+{
+    /**
+     * Process all pending membership history entries.
+     *
+     * @return int Number of entries processed.
+     */
+    public function processAll(): int
+    {
+        $entries = DB::table('memberships_history')
+            ->where('processingrequired', 1)
+            ->orderBy('id', 'asc')
+            ->get();
+
+        $count = 0;
+
+        foreach ($entries as $entry) {
+            $this->processEntry($entry);
+            $count++;
+        }
+
+        Log::info("MembershipsProcessing: processed {$count} entries");
+
+        return $count;
+    }
+
+    private function processEntry(object $entry): void
+    {
+        $userId = $entry->userid;
+        $groupId = $entry->groupid;
+        $collection = $entry->collection;
+
+        // Send per-group welcome email for newly approved members on groups that have one.
+        if ($collection === 'Approved') {
+            $group = Group::find($groupId);
+
+            if ($group && $group->onhere && !empty($group->welcomemail)) {
+                $user = User::find($userId);
+
+                if ($user && $user->email_preferred) {
+                    try {
+                        Mail::send(new GroupWelcomeMail($user, $group));
+                        Log::info("MembershipsProcessing: sent group welcome", [
+                            'user' => $userId,
+                            'group' => $groupId,
+                        ]);
+                    } catch (\Throwable $e) {
+                        Log::error("MembershipsProcessing: group welcome failed", [
+                            'user' => $userId,
+                            'group' => $groupId,
+                            'error' => $e->getMessage(),
+                        ]);
+                    }
+                }
+            }
+
+            // Check for flagged mod comments not yet covered by a review.
+            // If found, flag the member for review on this group.
+            $this->checkFlaggedComments($userId, $groupId);
+        }
+
+        DB::table('memberships_history')
+            ->where('id', $entry->id)
+            ->update(['processingrequired' => 0]);
+    }
+
+    /**
+     * Check if there are flagged comments about this user that post-date the last review.
+     * If so, flag the membership for review.
+     *
+     * Mirrors V1: User::processMembership() flagged-comment check.
+     */
+    private function checkFlaggedComments(int $userId, int $groupId): void
+    {
+        $count = DB::table('users_comments as uc')
+            ->where('uc.userid', $userId)
+            ->where('uc.flag', 1)
+            ->whereNotExists(function ($q) use ($userId, $groupId) {
+                $q->select(DB::raw(1))
+                    ->from('memberships as m')
+                    ->where('m.userid', $userId)
+                    ->where('m.groupid', $groupId)
+                    ->whereNotNull('m.reviewedat')
+                    ->whereColumn('m.reviewedat', '>=', 'uc.date');
+            })
+            ->count();
+
+        if ($count > 0) {
+            DB::table('memberships')
+                ->where('userid', $userId)
+                ->where('groupid', $groupId)
+                ->update([
+                    'reviewrequestedat' => now(),
+                    'reviewreason' => 'Note flagged to other groups',
+                ]);
+
+            Log::info("MembershipsProcessing: flagged member for review due to mod comments", [
+                'user' => $userId,
+                'group' => $groupId,
+            ]);
+        }
+    }
+}

--- a/iznik-batch/resources/views/emails/mjml/welcome/group_welcome.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/welcome/group_welcome.blade.php
@@ -1,0 +1,51 @@
+<mjml>
+  @include('emails.mjml.partials.head', [
+    'preview' => 'Welcome to ' . $groupName
+  ])
+  <mj-body background-color="#ffffff">
+
+    {{-- Header --}}
+    <mj-section mj-class="bg-success" padding="0">
+      <mj-column width="65%" vertical-align="middle">
+        <mj-text font-size="18px" font-weight="bold" color="#ffffff" padding="10px 25px">
+          Welcome to {{ $groupName }}
+        </mj-text>
+      </mj-column>
+      <mj-column width="35%" vertical-align="middle">
+        <mj-image
+          width="80px"
+          src="{{ config('freegle.logo_url', 'https://www.ilovefreegle.org/icon.png') }}"
+          alt="Freegle"
+          align="right"
+          padding="10px 20px"
+        />
+      </mj-column>
+    </mj-section>
+
+    {{-- Welcome message body --}}
+    <mj-section background-color="#F7F6EC" padding="20px 0">
+      <mj-column>
+        <mj-text font-size="13px" color="#000000" line-height="1.6" padding="10px 25px">
+          {!! $welcomeContent !!}
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+    {{-- CTA --}}
+    <mj-section background-color="#ffffff" padding="20px">
+      <mj-column>
+        <mj-button href="{{ $userSite }}" mj-class="btn-success" font-size="14px" padding="12px 25px">
+          Freegle something!
+        </mj-button>
+      </mj-column>
+    </mj-section>
+
+    {{-- Footer --}}
+    @include('emails.mjml.partials.footer', [
+      'email' => $email,
+      'settingsUrl' => $settingsUrl,
+      'unsubscribeUrl' => $unsubscribeUrl,
+    ])
+
+  </mj-body>
+</mjml>

--- a/iznik-batch/routes/console.php
+++ b/iznik-batch/routes/console.php
@@ -387,6 +387,16 @@ Schedule::command('mail:admin:chase')
 //     ->sendOutputTo(cronLog('chats:process-incoming'))
 //     ->runInBackground();
 
+// Process pending membership history entries: send per-group welcome emails, flag reviewed members.
+// V1: cron/memberships_processing.php (every 1 minute)
+// Go API creates memberships_history with processingrequired=1; this sends welcome emails + review flags.
+// — disabled pending sign-off
+// Schedule::command('memberships:process')
+//     ->everyMinute()
+//     ->withoutOverlapping()
+//     ->sendOutputTo(cronLog('memberships:process'))
+//     ->runInBackground();
+
 // Process pending GDPR data export requests and purge old completed data.
 // V1: cron/exports.php (every 1 minute)
 // — disabled pending sign-off

--- a/iznik-batch/tests/Unit/Services/MembershipsProcessingServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/MembershipsProcessingServiceTest.php
@@ -1,0 +1,216 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Mail\Welcome\GroupWelcomeMail;
+use App\Models\Membership;
+use App\Services\MembershipsProcessingService;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Mail;
+use Tests\TestCase;
+
+class MembershipsProcessingServiceTest extends TestCase
+{
+    protected MembershipsProcessingService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new MembershipsProcessingService();
+        Mail::fake();
+    }
+
+    // --- Basic processing ---
+
+    public function test_marks_history_entry_as_processed(): void
+    {
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+
+        $historyId = DB::table('memberships_history')->insertGetId([
+            'userid' => $user->id,
+            'groupid' => $group->id,
+            'collection' => 'Approved',
+            'processingrequired' => 1,
+        ]);
+
+        $this->service->processAll();
+
+        $entry = DB::table('memberships_history')->where('id', $historyId)->first();
+        $this->assertEquals(0, $entry->processingrequired);
+    }
+
+    public function test_skips_already_processed_entries(): void
+    {
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+
+        DB::table('memberships_history')->insert([
+            'userid' => $user->id,
+            'groupid' => $group->id,
+            'collection' => 'Approved',
+            'processingrequired' => 0,
+        ]);
+
+        $count = $this->service->processAll();
+        $this->assertEquals(0, $count);
+    }
+
+    public function test_returns_count_of_processed_entries(): void
+    {
+        $user1 = $this->createTestUser();
+        $user2 = $this->createTestUser();
+        $group = $this->createTestGroup();
+
+        DB::table('memberships_history')->insert([
+            ['userid' => $user1->id, 'groupid' => $group->id, 'collection' => 'Approved', 'processingrequired' => 1],
+            ['userid' => $user2->id, 'groupid' => $group->id, 'collection' => 'Approved', 'processingrequired' => 1],
+        ]);
+
+        $count = $this->service->processAll();
+        $this->assertEquals(2, $count);
+    }
+
+    // --- Per-group welcome email ---
+
+    public function test_sends_group_welcome_email_for_approved_member_with_welcome_text(): void
+    {
+        $user = $this->createTestUser();
+        $this->createTestUserEmail($user);
+        $group = $this->createTestGroup(['welcomemail' => 'Welcome to our group! Please be nice.']);
+        DB::table('groups')->where('id', $group->id)->update(['onhere' => 1]);
+
+        DB::table('memberships_history')->insert([
+            'userid' => $user->id,
+            'groupid' => $group->id,
+            'collection' => 'Approved',
+            'processingrequired' => 1,
+        ]);
+
+        $this->service->processAll();
+
+        Mail::assertSent(GroupWelcomeMail::class, function ($mail) use ($user) {
+            return $mail->user->id === $user->id;
+        });
+    }
+
+    public function test_does_not_send_group_welcome_email_when_no_welcome_text(): void
+    {
+        $user = $this->createTestUser();
+        $this->createTestUserEmail($user);
+        $group = $this->createTestGroup();
+        DB::table('groups')->where('id', $group->id)->update(['welcomemail' => null, 'onhere' => 1]);
+
+        DB::table('memberships_history')->insert([
+            'userid' => $user->id,
+            'groupid' => $group->id,
+            'collection' => 'Approved',
+            'processingrequired' => 1,
+        ]);
+
+        $this->service->processAll();
+
+        Mail::assertNotSent(GroupWelcomeMail::class);
+    }
+
+    public function test_does_not_send_group_welcome_email_for_pending_membership(): void
+    {
+        $user = $this->createTestUser();
+        $this->createTestUserEmail($user);
+        $group = $this->createTestGroup(['welcomemail' => 'Welcome!']);
+        DB::table('groups')->where('id', $group->id)->update(['onhere' => 1]);
+
+        DB::table('memberships_history')->insert([
+            'userid' => $user->id,
+            'groupid' => $group->id,
+            'collection' => 'Pending',
+            'processingrequired' => 1,
+        ]);
+
+        $this->service->processAll();
+
+        Mail::assertNotSent(GroupWelcomeMail::class);
+    }
+
+    // --- Flagged mod comments ---
+
+    public function test_flags_member_for_review_when_flagged_comment_exists(): void
+    {
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+
+        // Add a flagged comment for this user on another group.
+        $otherGroup = $this->createTestGroup();
+        DB::table('users_comments')->insert([
+            'userid' => $user->id,
+            'byuserid' => $user->id,
+            'groupid' => $otherGroup->id,
+            'date' => now()->subDays(10),
+            'user1' => 'This user seems suspicious',
+            'flag' => 1,
+        ]);
+
+        // Create the membership (needed so we can set reviewrequired)
+        DB::table('memberships')->insertOrIgnore([
+            'userid' => $user->id,
+            'groupid' => $group->id,
+            'collection' => 'Approved',
+        ]);
+
+        DB::table('memberships_history')->insert([
+            'userid' => $user->id,
+            'groupid' => $group->id,
+            'collection' => 'Approved',
+            'processingrequired' => 1,
+        ]);
+
+        $this->service->processAll();
+
+        // Membership should have reviewrequestedat set.
+        $membership = DB::table('memberships')
+            ->where('userid', $user->id)
+            ->where('groupid', $group->id)
+            ->first();
+        $this->assertNotNull($membership->reviewrequestedat);
+    }
+
+    public function test_does_not_flag_member_when_review_already_happened_after_comment(): void
+    {
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+
+        // Flagged comment before the last review.
+        DB::table('users_comments')->insert([
+            'userid' => $user->id,
+            'byuserid' => $user->id,
+            'groupid' => $group->id,
+            'date' => now()->subDays(10),
+            'user1' => 'Old comment',
+            'flag' => 1,
+        ]);
+
+        // Membership was reviewed after the comment.
+        DB::table('memberships')->insertOrIgnore([
+            'userid' => $user->id,
+            'groupid' => $group->id,
+            'collection' => 'Approved',
+            'reviewedat' => now()->subDays(5),  // reviewed AFTER the comment
+        ]);
+
+        DB::table('memberships_history')->insert([
+            'userid' => $user->id,
+            'groupid' => $group->id,
+            'collection' => 'Approved',
+            'processingrequired' => 1,
+        ]);
+
+        $this->service->processAll();
+
+        // Should NOT have reviewrequestedat set since already reviewed.
+        $membership = DB::table('memberships')
+            ->where('userid', $user->id)
+            ->where('groupid', $group->id)
+            ->first();
+        $this->assertNull($membership->reviewrequestedat ?? null);
+    }
+}


### PR DESCRIPTION
## Summary

Migrates V1 `cron/memberships_processing.php` + `User::processMemberships()` to a Laravel artisan command.

- **`MembershipsProcessingService`** — processes `memberships_history` entries with `processingrequired=1`:
  - Sends per-group welcome email (`GroupWelcomeMail`) when group has `welcomemail` set and `onhere=1`
  - Checks flagged mod comments: flags membership for review if any unflagged comments post-date the last review
  - Marks entry as `processingrequired=0`
- **`ProcessMembershipsCommand`** — `memberships:process {--dry-run}` with `PreventsOverlapping` + `GracefulShutdown`
- **`GroupWelcomeMail`** — `MjmlMailable` with MJML template for per-group welcome text
- Scheduler entry commented out pending sign-off (every minute)

Full spam check (`Spam::checkUser`) is handled separately by `users:remove-spammers`.

## Code Quality Review

- Mirrors V1 logic faithfully; `checkFlaggedComments()` uses `whereNotExists` to only flag when no review has happened after the comment
- MJML template uses `nl2br(e($group->welcomemail))` — escaped + line breaks for moderator-written content
- `LoggableEmail` trait applied for trace header tracking

## Test Plan

- 8 unit tests cover: marks processed, skips already-processed, returns count, sends welcome email, skips when no welcome text, skips for Pending, flags for review, does not flag when already reviewed
- All 8 tests pass