### PR TITLE
feat(impact): council, national & top-performers impact infographic pages

### DIFF
--- a/iznik-nuxt3/components/MicroVolunteeringAIImageReview.vue
+++ b/iznik-nuxt3/components/MicroVolunteeringAIImageReview.vue
@@ -45,33 +45,24 @@
         </div>
       </div>
 
-      <div class="d-flex justify-content-between align-items-center mb-3">
-        <div class="d-flex gap-2">
-          <button class="btn btn-outline-secondary" @click="regenerate">
-            Regenerate
-          </button>
-          <button
-            v-if="currentIndex > 0"
-            class="btn btn-outline-secondary"
-            @click="previous"
-          >
-            Previous
-          </button>
-          <button
-            v-if="currentIndex < images.length - 1"
-            class="btn btn-outline-secondary"
-            @click="next"
-          >
-            Next
-          </button>
-        </div>
-        <SpinButton
-          variant="success"
-          icon-name="thumbs-up"
-          label="Accept - looks good"
-          :disabled="containsPeople === null"
-          @handle="approve"
-        />
+      <div class="d-flex gap-2 mb-3">
+        <button class="btn btn-outline-secondary" @click="regenerate">
+          Regenerate
+        </button>
+        <button
+          v-if="currentIndex > 0"
+          class="btn btn-outline-secondary"
+          @click="previous"
+        >
+          Previous
+        </button>
+        <button
+          v-if="currentIndex < images.length - 1"
+          class="btn btn-outline-secondary"
+          @click="next"
+        >
+          Next
+        </button>
       </div>
 
       <div class="question-block mb-3">
@@ -85,6 +76,13 @@
             label="No, not great"
             :disabled="containsPeople === null"
             @handle="reject"
+          />
+          <SpinButton
+            variant="success"
+            icon-name="thumbs-up"
+            label="Accept - looks good"
+            :disabled="containsPeople === null"
+            @handle="approve"
           />
         </div>
         <p v-if="containsPeople === null" class="help-hint mt-2">

--- a/iznik-nuxt3/components/impact/CouncilSlide.vue
+++ b/iznik-nuxt3/components/impact/CouncilSlide.vue
@@ -1,0 +1,518 @@
+<template>
+  <div class="impact-slide" :style="slideStyle">
+    <!-- Header -->
+    <div class="impact-header">
+      <div class="impact-logo">
+        <svg viewBox="0 0 40 40" fill="none" width="28" height="28">
+          <circle
+            cx="20"
+            cy="20"
+            r="15"
+            stroke="white"
+            stroke-width="3.5"
+            fill="none"
+          />
+          <path
+            d="M20 7 C28 7 33 13 33 20"
+            stroke="white"
+            stroke-width="3"
+            stroke-linecap="round"
+          />
+          <path
+            d="M30 16 L33 20 L36.5 16.5"
+            stroke="white"
+            stroke-width="2.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            fill="none"
+          />
+          <path
+            d="M20 33 C12 33 7 27 7 20"
+            stroke="white"
+            stroke-width="3"
+            stroke-linecap="round"
+          />
+          <path
+            d="M10 24 L7 20 L3.5 23.5"
+            stroke="white"
+            stroke-width="2.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            fill="none"
+          />
+        </svg>
+      </div>
+      <div class="impact-header-titles">
+        <div class="impact-title1">Freegle – social &amp; economic impacts</div>
+        <div class="impact-title2">{{ authorityName }}</div>
+      </div>
+      <div class="impact-year-badge">{{ yearLabel }}</div>
+    </div>
+
+    <!-- Truck -->
+    <div class="impact-truck">🚛</div>
+
+    <!-- Tonnes -->
+    <div class="impact-tonnes-n">{{ formattedWeight }}</div>
+    <div class="impact-tonnes-label">
+      <span class="impact-tonnes-big">tonnes</span>
+      saved<br />from disposal
+    </div>
+
+    <!-- CO2 -->
+    <div class="impact-co2-icon">☁️</div>
+    <div class="impact-co2-n">{{ formattedCO2 }}</div>
+    <div class="impact-co2-label">tonnes CO₂eq<br />saved*</div>
+
+    <!-- Items badge -->
+    <div class="impact-items-badge">
+      <div class="impact-items-n">{{ totalGifts.toLocaleString() }}</div>
+      <div class="impact-items-d">items freegled</div>
+    </div>
+
+    <!-- Person illustration -->
+    <div class="impact-person">🧍‍♀️</div>
+
+    <!-- Testimonial -->
+    <div v-if="testimonials.length" class="impact-testimonial">
+      <div class="impact-t-head">Freeglers say:</div>
+      <div class="impact-dot-row">
+        <span
+          v-for="(_, i) in 5"
+          :key="i"
+          class="impact-dot"
+          :class="i < testimonials.length ? 'dot-green' : 'dot-grey'"
+        />
+      </div>
+      <blockquote v-for="t in testimonials" :key="t.quote" class="impact-quote">
+        "{{ t.quote }}"
+        <div v-if="t.attribution" class="impact-attrib">
+          From {{ t.attribution }}
+        </div>
+      </blockquote>
+    </div>
+
+    <!-- Photo -->
+    <div v-if="photoUrl" class="impact-photo">
+      <img
+        :src="photoUrl"
+        alt=""
+        style="width: 100%; height: 100%; object-fit: cover"
+      />
+    </div>
+    <div v-else class="impact-photo impact-photo-placeholder">📷</div>
+
+    <!-- Freeglers -->
+    <div class="impact-freeglers-n">{{ totalMembers.toLocaleString() }}</div>
+    <div class="impact-freeglers-label">freeglers</div>
+
+    <!-- Communities -->
+    <div class="impact-communities">
+      <div class="impact-comm-icons">👥👥👥👥👥</div>
+      <div class="impact-comm-n">{{ groupCount }}</div>
+      <div class="impact-comm-d">
+        {{ groupCount === 1 ? 'Freegle community' : 'Freegle communities' }}
+      </div>
+      <div v-if="partialGroupCount > 0" class="impact-comm-sub">
+        + {{ partialGroupCount }} others part-serving this area
+      </div>
+    </div>
+
+    <!-- Economic benefit -->
+    <div class="impact-benefit">
+      <div class="impact-benefit-icon">💷</div>
+      <div class="impact-benefit-n">£{{ formattedBenefit }}</div>
+      <div class="impact-benefit-d">economic benefit*</div>
+      <div class="impact-benefit-wrap">*WRAP benefits of reuse tool</div>
+    </div>
+
+    <!-- Footer -->
+    <div class="impact-footer">www.ilovefreegle.org</div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from '#imports'
+
+const props = defineProps({
+  authorityName: { type: String, required: true },
+  yearLabel: { type: String, required: true },
+  totalWeight: { type: Number, required: true },
+  totalBenefit: { type: Number, required: true },
+  totalCO2: { type: Number, required: true },
+  totalGifts: { type: Number, required: true },
+  totalMembers: { type: Number, required: true },
+  groupCount: { type: Number, required: true },
+  partialGroupCount: { type: Number, default: 0 },
+  testimonials: { type: Array, default: () => [] },
+  photoUrl: { type: String, default: null },
+  scale: { type: Number, default: 0.45 },
+})
+
+const slideStyle = computed(() => ({
+  width: `${Math.round(2000 * props.scale)}px`,
+  height: `${Math.round(1414 * props.scale)}px`,
+}))
+
+const formattedWeight = computed(() => {
+  if (props.totalWeight < 10) return props.totalWeight.toFixed(1)
+  return Math.round(props.totalWeight).toLocaleString()
+})
+
+const formattedCO2 = computed(() => {
+  if (props.totalCO2 < 10) return props.totalCO2.toFixed(1)
+  return Math.round(props.totalCO2).toLocaleString()
+})
+
+const formattedBenefit = computed(() =>
+  Math.round(props.totalBenefit).toLocaleString()
+)
+</script>
+
+<style scoped>
+.impact-slide {
+  position: relative;
+  background: #79c61d;
+  overflow: hidden;
+  border-radius: 6px;
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.4);
+  font-family: Arial, sans-serif;
+}
+
+/* ── HEADER ── */
+.impact-header {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 9.9%;
+  background: white;
+  display: flex;
+  align-items: center;
+  padding: 0 7px;
+  gap: 8px;
+}
+
+.impact-logo {
+  flex-shrink: 0;
+  width: 40px;
+  height: 40px;
+  background: #1d5c22;
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.impact-header-titles {
+  flex: 1;
+}
+
+.impact-title1 {
+  font-size: 14px;
+  font-weight: 900;
+  color: #111;
+  line-height: 1.2;
+  font-family: 'Arial Black', Arial, sans-serif;
+}
+
+.impact-title2 {
+  font-size: 11px;
+  font-weight: 700;
+  color: #111;
+  margin-top: 1px;
+}
+
+.impact-year-badge {
+  background: #e87722;
+  color: white;
+  border-radius: 8px;
+  padding: 4px 10px;
+  font-size: 14px;
+  font-weight: 900;
+  font-family: 'Arial Black', Arial, sans-serif;
+  flex-shrink: 0;
+  line-height: 1.3;
+  text-align: center;
+  white-space: pre-line;
+}
+
+/* ── CONTENT ELEMENTS (% of 900×636 slide) ── */
+.impact-truck {
+  position: absolute;
+  left: 0.75%;
+  top: 11%;
+  font-size: 60px;
+  line-height: 1;
+}
+
+.impact-tonnes-n {
+  position: absolute;
+  left: 0.75%;
+  top: 32%;
+  font-size: 44px;
+  font-weight: 900;
+  color: white;
+  line-height: 1;
+  font-family: 'Arial Black', Arial, sans-serif;
+}
+
+.impact-tonnes-label {
+  position: absolute;
+  left: 0.75%;
+  top: 44%;
+  line-height: 1.3;
+  color: white;
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.impact-tonnes-big {
+  font-size: 16px;
+  font-weight: 900;
+  display: block;
+}
+
+.impact-co2-icon {
+  position: absolute;
+  left: 0.75%;
+  top: 66%;
+  font-size: 40px;
+  line-height: 1;
+}
+
+.impact-co2-n {
+  position: absolute;
+  left: 0.75%;
+  top: 76%;
+  font-size: 34px;
+  font-weight: 900;
+  color: white;
+  line-height: 1;
+  font-family: 'Arial Black', Arial, sans-serif;
+}
+
+.impact-co2-label {
+  position: absolute;
+  left: 0.75%;
+  top: 84%;
+  font-size: 11px;
+  font-weight: 700;
+  color: white;
+  line-height: 1.3;
+}
+
+.impact-items-badge {
+  position: absolute;
+  left: 18%;
+  top: 44%;
+  background: #222;
+  border-radius: 10px;
+  padding: 10px 14px;
+  text-align: center;
+  color: white;
+}
+
+.impact-items-n {
+  font-size: 38px;
+  font-weight: 900;
+  line-height: 1;
+  font-family: 'Arial Black', Arial, sans-serif;
+}
+
+.impact-items-d {
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.impact-person {
+  position: absolute;
+  left: 18%;
+  bottom: 7%;
+  font-size: 80px;
+  line-height: 1;
+  opacity: 0.9;
+}
+
+.impact-testimonial {
+  position: absolute;
+  left: 27.5%;
+  top: 12%;
+  width: 32%;
+  background: white;
+  border-radius: 8px;
+  padding: 10px 12px;
+}
+
+.impact-t-head {
+  font-size: 9px;
+  font-weight: 900;
+  color: #1d5c22;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  margin-bottom: 6px;
+}
+
+.impact-dot-row {
+  display: flex;
+  gap: 3px;
+  margin-bottom: 6px;
+}
+
+.impact-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  display: inline-block;
+}
+
+.dot-green {
+  background: #79c61d;
+}
+.dot-grey {
+  background: #ccc;
+}
+
+.impact-quote {
+  font-size: 9.5px;
+  color: #333;
+  font-style: italic;
+  line-height: 1.5;
+  margin-bottom: 6px;
+  font-family: Georgia, serif;
+  border: none;
+  padding: 0;
+}
+
+.impact-quote + .impact-quote {
+  border-top: 1px solid #eee;
+  padding-top: 6px;
+  margin-top: 0;
+}
+
+.impact-attrib {
+  font-size: 9px;
+  color: #888;
+  margin-top: 4px;
+}
+
+.impact-photo {
+  position: absolute;
+  right: 11.5%;
+  top: 12%;
+  width: 16%;
+  height: 17%;
+  background: rgba(0, 0, 0, 0.12);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.impact-photo-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 36px;
+}
+
+.impact-freeglers-n {
+  position: absolute;
+  right: 1%;
+  top: 41%;
+  text-align: right;
+  font-size: 38px;
+  font-weight: 900;
+  color: white;
+  line-height: 1;
+  font-family: 'Arial Black', Arial, sans-serif;
+}
+
+.impact-freeglers-label {
+  position: absolute;
+  right: 1%;
+  top: 50%;
+  text-align: right;
+  font-size: 11px;
+  font-weight: 700;
+  color: white;
+}
+
+.impact-communities {
+  position: absolute;
+  left: 55%;
+  bottom: 11%;
+  text-align: center;
+}
+
+.impact-comm-icons {
+  font-size: 18px;
+  letter-spacing: -1px;
+}
+
+.impact-comm-n {
+  font-size: 26px;
+  font-weight: 900;
+  color: white;
+  line-height: 1;
+  font-family: 'Arial Black', Arial, sans-serif;
+}
+
+.impact-comm-d {
+  font-size: 10px;
+  font-weight: 700;
+  color: white;
+}
+
+.impact-comm-sub {
+  font-size: 9px;
+  color: rgba(255, 255, 255, 0.75);
+  margin-top: 1px;
+}
+
+.impact-benefit {
+  position: absolute;
+  right: 1%;
+  bottom: 8%;
+  text-align: right;
+}
+
+.impact-benefit-icon {
+  font-size: 22px;
+}
+
+.impact-benefit-n {
+  font-size: 28px;
+  font-weight: 900;
+  color: white;
+  line-height: 1;
+  font-family: 'Arial Black', Arial, sans-serif;
+}
+
+.impact-benefit-d {
+  font-size: 9px;
+  font-weight: 700;
+  color: white;
+}
+.impact-benefit-wrap {
+  font-size: 8px;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.impact-footer {
+  position: absolute;
+  bottom: 1.5%;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 10px;
+  font-weight: 700;
+  color: #1a4a1a;
+}
+
+/* ── PRINT: hide only the filter bar, not the slide ── */
+@media print {
+  .impact-slide {
+    box-shadow: none;
+    border-radius: 0;
+  }
+}
+</style>

--- a/iznik-nuxt3/components/impact/NationalSlide.vue
+++ b/iznik-nuxt3/components/impact/NationalSlide.vue
@@ -1,0 +1,517 @@
+<template>
+  <div class="national-slide" :style="slideStyle">
+    <!-- Logo -->
+    <div class="ns-logo">
+      <svg viewBox="0 0 40 40" fill="none" width="36" height="36">
+        <circle
+          cx="20"
+          cy="20"
+          r="15"
+          stroke="white"
+          stroke-width="3.5"
+          fill="none"
+        />
+        <path
+          d="M20 7 C28 7 33 13 33 20"
+          stroke="white"
+          stroke-width="3"
+          stroke-linecap="round"
+        />
+        <path
+          d="M30 16 L33 20 L36.5 16.5"
+          stroke="white"
+          stroke-width="2.5"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          fill="none"
+        />
+        <path
+          d="M20 33 C12 33 7 27 7 20"
+          stroke="white"
+          stroke-width="3"
+          stroke-linecap="round"
+        />
+        <path
+          d="M10 24 L7 20 L3.5 23.5"
+          stroke="white"
+          stroke-width="2.5"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          fill="none"
+        />
+      </svg>
+    </div>
+
+    <div class="ns-title">Social &amp; economic impact</div>
+    <div class="ns-year-badge">{{ year }}</div>
+
+    <div class="ns-truck">🚛</div>
+
+    <div class="ns-tonnes-n">{{ formattedWeight }}</div>
+    <div class="ns-tonnes-label">
+      <span class="ns-tonnes-big">tonnes</span>
+      saved<br />from disposal
+    </div>
+
+    <div class="ns-check-stat">
+      <div class="ns-check-icon">✅</div>
+      <div class="ns-check-big">8 out of 10</div>
+      <div class="ns-check-label">
+        items listed on Freegle<br />find new homes
+      </div>
+    </div>
+
+    <div class="ns-communities">
+      <div class="ns-comm-icons">👥👥👥👥👥</div>
+      <div class="ns-comm-n">{{ groupCount.toLocaleString() }}</div>
+      <div class="ns-comm-label">Freegle communities</div>
+    </div>
+
+    <div class="ns-notepad">
+      <div class="ns-notepad-head">Items freegled:</div>
+      <div class="ns-notepad-big">{{ totalGifts.toLocaleString() }}</div>
+    </div>
+
+    <div class="ns-volunteers">
+      <div class="ns-vol-icons">👥👥👥</div>
+      <div class="ns-vol-n">11,000+</div>
+      <div class="ns-vol-label">
+        Freegle volunteers<br />&amp; micro-volunteers
+      </div>
+    </div>
+
+    <div class="ns-freeglers-n">{{ formattedMembers }}</div>
+    <div class="ns-freeglers-label">freeglers</div>
+
+    <div class="ns-co2-icon">☁️</div>
+    <div class="ns-co2-n">{{ formattedCO2 }}</div>
+    <div class="ns-co2-label">tonnes CO₂eq<br />saved*</div>
+
+    <div class="ns-person">🧍‍♀️</div>
+
+    <div class="ns-established">
+      Freegle<br />established
+      <span class="ns-established-year">2009</span>
+    </div>
+
+    <div class="ns-roi">
+      <span class="ns-roi-amount">£10</span> Freegle funding<br />
+      is equal to<br />
+      <span class="ns-roi-amount">£100</span> of impact<br />
+      in communities
+    </div>
+
+    <div class="ns-benefit">
+      <div class="ns-benefit-icon">💷</div>
+      <div class="ns-benefit-n">{{ formattedBenefit }}</div>
+      <div class="ns-benefit-d">
+        economic benefit<br />to communities*
+      </div>
+    </div>
+
+    <div class="ns-footer">
+      www.ilovefreegle.org
+      <span class="ns-footer-wrap"
+        >*calculations made using the WRAP benefits of reuse tool</span
+      >
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from '#imports'
+
+const props = defineProps({
+  year: { type: Number, required: true },
+  totalWeight: { type: Number, required: true },
+  totalBenefit: { type: Number, required: true },
+  totalCO2: { type: Number, required: true },
+  totalGifts: { type: Number, required: true },
+  totalMembers: { type: Number, required: true },
+  groupCount: { type: Number, required: true },
+  scale: { type: Number, default: 0.45 },
+})
+
+const slideStyle = computed(() => ({
+  width: `${Math.round(2000 * props.scale)}px`,
+  height: `${Math.round(1414 * props.scale)}px`,
+}))
+
+const formattedWeight = computed(() => {
+  if (props.totalWeight < 10) return props.totalWeight.toFixed(1)
+  return Math.round(props.totalWeight).toLocaleString()
+})
+
+const formattedCO2 = computed(() => {
+  if (props.totalCO2 < 10) return props.totalCO2.toFixed(1)
+  return Math.round(props.totalCO2).toLocaleString()
+})
+
+const formattedMembers = computed(() => {
+  const m = props.totalMembers / 1_000_000
+  if (m >= 1) return `${m.toFixed(1)} million`
+  const k = props.totalMembers / 1_000
+  if (k >= 1) return `${Math.round(k).toLocaleString()}k`
+  return props.totalMembers.toLocaleString()
+})
+
+const formattedBenefit = computed(() => {
+  const m = props.totalBenefit / 1_000_000
+  if (m >= 1) return `£${m.toFixed(1)} million`
+  const k = props.totalBenefit / 1_000
+  if (k >= 1) return `£${Math.round(k).toLocaleString()}k`
+  return `£${Math.round(props.totalBenefit).toLocaleString()}`
+})
+</script>
+
+<style scoped>
+/* ── SLIDE CONTAINER ── */
+.national-slide {
+  position: relative;
+  background: #79c61d;
+  overflow: hidden;
+  border-radius: 6px;
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.4);
+  font-family: Arial, sans-serif;
+}
+
+/* ── LOGO (top-left dark green square) ── */
+.ns-logo {
+  position: absolute;
+  left: 1%;
+  top: 1.5%;
+  width: 52px;
+  height: 52px;
+  background: #1d5c22;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* ── TITLE ── */
+.ns-title {
+  position: absolute;
+  left: 8%;
+  top: 2%;
+  font-size: 32px;
+  font-weight: 900;
+  color: #111;
+  line-height: 1.1;
+  font-family: 'Arial Black', Arial, sans-serif;
+}
+
+/* ── YEAR BADGE ── */
+.ns-year-badge {
+  position: absolute;
+  right: 1%;
+  top: 1.5%;
+  background: #e87722;
+  color: white;
+  border-radius: 8px;
+  padding: 4px 14px;
+  font-size: 22px;
+  font-weight: 900;
+  font-family: 'Arial Black', Arial, sans-serif;
+}
+
+/* ── TRUCK ── */
+.ns-truck {
+  position: absolute;
+  left: 0.5%;
+  top: 14%;
+  font-size: 55px;
+  line-height: 1;
+}
+
+/* ── TONNES ── */
+.ns-tonnes-n {
+  position: absolute;
+  left: 0.5%;
+  top: 25%;
+  font-size: 40px;
+  font-weight: 900;
+  color: white;
+  line-height: 1;
+  font-family: 'Arial Black', Arial, sans-serif;
+}
+
+.ns-tonnes-label {
+  position: absolute;
+  left: 0.5%;
+  top: 36%;
+  color: white;
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1.3;
+}
+
+.ns-tonnes-big {
+  font-size: 17px;
+  font-weight: 900;
+  display: block;
+}
+
+/* ── CHECK STAT ── */
+.ns-check-stat {
+  position: absolute;
+  left: 16%;
+  top: 13%;
+  text-align: center;
+  width: 18%;
+}
+
+.ns-check-icon {
+  font-size: 28px;
+}
+
+.ns-check-big {
+  font-size: 22px;
+  font-weight: 900;
+  color: white;
+  font-family: 'Arial Black', Arial, sans-serif;
+}
+
+.ns-check-label {
+  font-size: 10px;
+  font-weight: 700;
+  color: #1d5c22;
+  line-height: 1.3;
+}
+
+/* ── COMMUNITIES ── */
+.ns-communities {
+  position: absolute;
+  left: 37%;
+  top: 11%;
+  text-align: center;
+}
+
+.ns-comm-icons {
+  font-size: 20px;
+  letter-spacing: -2px;
+}
+
+.ns-comm-n {
+  font-size: 48px;
+  font-weight: 900;
+  color: white;
+  line-height: 1;
+  font-family: 'Arial Black', Arial, sans-serif;
+}
+
+.ns-comm-label {
+  font-size: 12px;
+  font-weight: 700;
+  color: #1d5c22;
+}
+
+/* ── NOTEPAD ── */
+.ns-notepad {
+  position: absolute;
+  left: 16%;
+  top: 34%;
+  width: 20%;
+  background: #f8f4e0;
+  border-radius: 4px;
+  padding: 10px 12px;
+  box-shadow: 2px 3px 8px rgba(0, 0, 0, 0.15);
+}
+
+.ns-notepad-head {
+  font-size: 9px;
+  font-weight: 700;
+  color: #555;
+  margin-bottom: 4px;
+}
+
+.ns-notepad-big {
+  font-size: 24px;
+  font-weight: 900;
+  color: #111;
+  font-family: 'Arial Black', Arial, sans-serif;
+  line-height: 1.1;
+}
+
+/* ── VOLUNTEERS ── */
+.ns-volunteers {
+  position: absolute;
+  left: 43%;
+  top: 30%;
+  text-align: center;
+}
+
+.ns-vol-icons {
+  font-size: 22px;
+  letter-spacing: -2px;
+}
+
+.ns-vol-n {
+  font-size: 36px;
+  font-weight: 900;
+  color: white;
+  line-height: 1;
+  font-family: 'Arial Black', Arial, sans-serif;
+}
+
+.ns-vol-label {
+  font-size: 10px;
+  font-weight: 700;
+  color: #1d5c22;
+  line-height: 1.3;
+}
+
+/* ── FREEGLERS ── */
+.ns-freeglers-n {
+  position: absolute;
+  right: 1%;
+  top: 11%;
+  text-align: right;
+  font-size: 32px;
+  font-weight: 900;
+  color: white;
+  line-height: 1;
+  font-family: 'Arial Black', Arial, sans-serif;
+}
+
+.ns-freeglers-label {
+  position: absolute;
+  right: 1%;
+  top: 20%;
+  text-align: right;
+  font-size: 11px;
+  font-weight: 700;
+  color: #1d5c22;
+}
+
+/* ── CO2 ── */
+.ns-co2-icon {
+  position: absolute;
+  left: 0.5%;
+  top: 62%;
+  font-size: 40px;
+  line-height: 1;
+}
+
+.ns-co2-n {
+  position: absolute;
+  left: 0.5%;
+  top: 73%;
+  font-size: 32px;
+  font-weight: 900;
+  color: white;
+  line-height: 1;
+  font-family: 'Arial Black', Arial, sans-serif;
+}
+
+.ns-co2-label {
+  position: absolute;
+  left: 0.5%;
+  top: 82%;
+  font-size: 10px;
+  font-weight: 700;
+  color: white;
+}
+
+/* ── PERSON ── */
+.ns-person {
+  position: absolute;
+  left: 14%;
+  bottom: 7%;
+  font-size: 90px;
+  line-height: 1;
+  opacity: 0.88;
+}
+
+/* ── ESTABLISHED ── */
+.ns-established {
+  position: absolute;
+  left: 30%;
+  bottom: 24%;
+  background: white;
+  border-radius: 12px;
+  padding: 6px 14px;
+  font-size: 11px;
+  font-weight: 700;
+  color: #1d5c22;
+  text-align: center;
+  line-height: 1.3;
+}
+
+.ns-established-year {
+  font-size: 22px;
+  font-weight: 900;
+  font-family: 'Arial Black', Arial, sans-serif;
+  display: block;
+}
+
+/* ── ROI ── */
+.ns-roi {
+  position: absolute;
+  left: 30%;
+  bottom: 8%;
+  width: 22%;
+  font-size: 11px;
+  color: #1d5c22;
+  text-align: center;
+  line-height: 1.5;
+}
+
+.ns-roi-amount {
+  font-size: 18px;
+  font-weight: 900;
+  color: white;
+  font-family: 'Arial Black', Arial, sans-serif;
+}
+
+/* ── ECONOMIC BENEFIT ── */
+.ns-benefit {
+  position: absolute;
+  right: 1%;
+  bottom: 14%;
+  text-align: right;
+}
+
+.ns-benefit-icon {
+  font-size: 28px;
+}
+
+.ns-benefit-n {
+  font-size: 28px;
+  font-weight: 900;
+  color: white;
+  line-height: 1;
+  font-family: 'Arial Black', Arial, sans-serif;
+}
+
+.ns-benefit-d {
+  font-size: 11px;
+  font-weight: 700;
+  color: white;
+}
+
+/* ── FOOTER ── */
+.ns-footer {
+  position: absolute;
+  bottom: 1.5%;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 10px;
+  font-weight: 700;
+  color: #1a4a1a;
+}
+
+.ns-footer-wrap {
+  font-size: 9px;
+  color: rgba(0, 0, 0, 0.4);
+  display: block;
+}
+
+@media print {
+  .national-slide {
+    box-shadow: none;
+    border-radius: 0;
+  }
+}
+</style>

--- a/iznik-nuxt3/components/impact/TopSlide.vue
+++ b/iznik-nuxt3/components/impact/TopSlide.vue
@@ -1,0 +1,338 @@
+<template>
+  <div class="top-slide" :style="slideStyle">
+    <!-- Logo -->
+    <div class="ts-logo">
+      <svg viewBox="0 0 40 40" fill="none" width="30" height="30">
+        <circle
+          cx="20"
+          cy="20"
+          r="15"
+          stroke="white"
+          stroke-width="3.5"
+          fill="none"
+        />
+        <path
+          d="M20 7 C28 7 33 13 33 20"
+          stroke="white"
+          stroke-width="3"
+          stroke-linecap="round"
+        />
+        <path
+          d="M30 16 L33 20 L36.5 16.5"
+          stroke="white"
+          stroke-width="2.5"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          fill="none"
+        />
+        <path
+          d="M20 33 C12 33 7 27 7 20"
+          stroke="white"
+          stroke-width="3"
+          stroke-linecap="round"
+        />
+        <path
+          d="M10 24 L7 20 L3.5 23.5"
+          stroke="white"
+          stroke-width="2.5"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          fill="none"
+        />
+      </svg>
+    </div>
+
+    <div class="ts-year-badge">{{ year }}</div>
+    <div class="ts-stars">⭐⭐⭐⭐⭐</div>
+
+    <div class="ts-title">UK REUSE SUPERSTARS</div>
+    <div class="ts-subtitle">
+      Freegle's top {{ communities.length }} communities for {{ year }}
+    </div>
+
+    <div class="ts-leaderboard">
+      <div
+        v-for="(community, index) in communities"
+        :key="community.name"
+        class="ts-entry"
+        :class="`rank-${index + 1}`"
+      >
+        <div class="ts-rank">{{ index + 1 }}</div>
+        <div class="ts-medal">{{ medalFor(index) }}</div>
+        <div class="ts-community">{{ community.name }}</div>
+        <div>
+          <div class="ts-tonnes">{{ formattedTonnes(community.weightKg) }}</div>
+          <div class="ts-tonnes-label">tonnes reused</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="ts-hashtag">#ChooseToReuse</div>
+    <div class="ts-footer">www.ilovefreegle.org</div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from '#imports'
+
+const props = defineProps({
+  year: { type: Number, required: true },
+  communities: { type: Array, required: true },
+  scale: { type: Number, default: 0.45 },
+})
+
+const slideStyle = computed(() => ({
+  width: `${Math.round(2000 * props.scale)}px`,
+  height: `${Math.round(1414 * props.scale)}px`,
+}))
+
+const MEDALS = ['🥇', '🥈', '🥉', '🏅', '🏅', '🏅', '🏅', '🏅', '🏅', '🏅']
+
+function medalFor(index) {
+  return MEDALS[index] ?? '🏅'
+}
+
+function formattedTonnes(weightKg) {
+  const tonnes = weightKg / 1000
+  if (tonnes < 10) return tonnes.toFixed(1)
+  return Math.round(tonnes).toLocaleString()
+}
+</script>
+
+<style scoped>
+.top-slide {
+  position: relative;
+  background: #0d2d14;
+  overflow: hidden;
+  border-radius: 6px;
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.6);
+  font-family: Arial, sans-serif;
+}
+
+/* Gold star burst decoration */
+.top-slide::before {
+  content: '';
+  position: absolute;
+  top: -80px;
+  left: -80px;
+  width: 320px;
+  height: 320px;
+  background: radial-gradient(
+    circle,
+    rgba(255, 200, 0, 0.12) 0%,
+    transparent 70%
+  );
+  border-radius: 50%;
+}
+
+.top-slide::after {
+  content: '';
+  position: absolute;
+  bottom: -80px;
+  right: -80px;
+  width: 400px;
+  height: 400px;
+  background: radial-gradient(
+    circle,
+    rgba(121, 198, 29, 0.15) 0%,
+    transparent 70%
+  );
+  border-radius: 50%;
+}
+
+/* ── LOGO ── */
+.ts-logo {
+  position: absolute;
+  left: 2%;
+  top: 4%;
+  width: 44px;
+  height: 44px;
+  background: #79c61d;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* ── YEAR BADGE ── */
+.ts-year-badge {
+  position: absolute;
+  right: 2%;
+  top: 4%;
+  background: #e87722;
+  color: white;
+  border-radius: 8px;
+  padding: 4px 14px;
+  font-size: 18px;
+  font-weight: 900;
+  font-family: 'Arial Black', Arial, sans-serif;
+}
+
+/* ── STARS ── */
+.ts-stars {
+  position: absolute;
+  left: 50%;
+  top: 3%;
+  transform: translateX(-50%);
+  font-size: 22px;
+  letter-spacing: 4px;
+}
+
+/* ── TITLE ── */
+.ts-title {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 10%;
+  text-align: center;
+  font-size: 52px;
+  font-weight: 900;
+  color: #ffd700;
+  font-family: 'Arial Black', Arial, sans-serif;
+  letter-spacing: 2px;
+  text-shadow: 0 3px 12px rgba(0, 0, 0, 0.5);
+  line-height: 1;
+}
+
+/* ── SUBTITLE ── */
+.ts-subtitle {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 25%;
+  text-align: center;
+  font-size: 16px;
+  font-weight: 700;
+  color: #79c61d;
+  letter-spacing: 1px;
+}
+
+/* ── LEADERBOARD ── */
+.ts-leaderboard {
+  position: absolute;
+  left: 8%;
+  right: 8%;
+  top: 33%;
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+}
+
+.ts-entry {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 8px 14px;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.ts-entry.rank-1 {
+  background: rgba(255, 215, 0, 0.15);
+  border: 1px solid rgba(255, 215, 0, 0.4);
+}
+
+.ts-entry.rank-2 {
+  background: rgba(192, 192, 192, 0.12);
+  border: 1px solid rgba(192, 192, 192, 0.3);
+}
+
+.ts-entry.rank-3 {
+  background: rgba(205, 127, 50, 0.12);
+  border: 1px solid rgba(205, 127, 50, 0.3);
+}
+
+.ts-rank {
+  font-size: 26px;
+  font-weight: 900;
+  font-family: 'Arial Black', Arial, sans-serif;
+  width: 36px;
+  text-align: center;
+  flex-shrink: 0;
+}
+
+.rank-1 .ts-rank {
+  color: #ffd700;
+}
+
+.rank-2 .ts-rank {
+  color: #c0c0c0;
+}
+
+.rank-3 .ts-rank {
+  color: #cd7f32;
+}
+
+.rank-4 .ts-rank,
+.rank-5 .ts-rank,
+.rank-6 .ts-rank,
+.rank-7 .ts-rank,
+.rank-8 .ts-rank,
+.rank-9 .ts-rank,
+.rank-10 .ts-rank {
+  color: #79c61d;
+}
+
+.ts-medal {
+  font-size: 20px;
+  flex-shrink: 0;
+  width: 24px;
+}
+
+.ts-community {
+  flex: 1;
+  font-size: 17px;
+  font-weight: 700;
+  color: white;
+  font-family: 'Arial Black', Arial, sans-serif;
+}
+
+.ts-tonnes {
+  font-size: 28px;
+  font-weight: 900;
+  font-family: 'Arial Black', Arial, sans-serif;
+  color: #79c61d;
+  text-align: right;
+}
+
+.ts-tonnes-label {
+  font-size: 9px;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.5);
+  text-align: right;
+  line-height: 1.3;
+}
+
+/* ── HASHTAG ── */
+.ts-hashtag {
+  position: absolute;
+  bottom: 7%;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 18px;
+  font-weight: 900;
+  color: #79c61d;
+  font-family: 'Arial Black', Arial, sans-serif;
+  letter-spacing: 1px;
+}
+
+/* ── FOOTER ── */
+.ts-footer {
+  position: absolute;
+  bottom: 2%;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 10px;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.4);
+}
+
+@media print {
+  .top-slide {
+    box-shadow: none;
+    border-radius: 0;
+  }
+}
+</style>

--- a/iznik-nuxt3/composables/useAuthorityImpact.js
+++ b/iznik-nuxt3/composables/useAuthorityImpact.js
@@ -1,0 +1,162 @@
+import dayjs from 'dayjs'
+import { ref, computed } from '#imports'
+import { useAuthorityStore } from '~/stores/authority'
+import { useStatsStore } from '~/stores/stats'
+import {
+  getBenefitPerTonne,
+  CO2_PER_TONNE,
+} from '~/composables/useReuseBenefit'
+import { parseOutcomeDate } from '~/composables/useAuthoritySearch'
+import councilConfig from '~/config/council-impact.json'
+
+/**
+ * Fetches and aggregates impact stats for a local authority.
+ * Mirrors the data-fetching logic in pages/stats/authority/[[id]].vue but
+ * returns clean aggregated totals suitable for the impact infographic.
+ */
+export function useAuthorityImpact(authorityId, fromDate, toDate) {
+  const authorityStore = useAuthorityStore()
+  const statsStore = useStatsStore()
+
+  const loading = ref(false)
+  const authority = ref(null)
+  const totalWeightKg = ref(0)
+  const totalGiftsCount = ref(0)
+  const totalMembersCount = ref(0)
+  const primaryGroupCount = ref(0)
+  const partialGroupCount = ref(0)
+
+  const totalWeight = computed(() => Math.round(totalWeightKg.value / 100) / 10)
+  const totalBenefit = computed(() =>
+    Math.round((totalWeightKg.value * getBenefitPerTonne()) / 1000)
+  )
+  const totalCO2 = computed(
+    () => Math.round((totalWeightKg.value * CO2_PER_TONNE) / 100) / 10
+  )
+  const totalGifts = computed(() => totalGiftsCount.value)
+  const totalMembers = computed(() => totalMembersCount.value)
+  const groupCount = computed(() => primaryGroupCount.value)
+
+  async function fetchStats() {
+    loading.value = true
+    totalWeightKg.value = 0
+    totalGiftsCount.value = 0
+    totalMembersCount.value = 0
+    primaryGroupCount.value = 0
+    partialGroupCount.value = 0
+
+    try {
+      await authorityStore.fetch(authorityId)
+      const auth = authorityStore.list[authorityId]
+      if (!auth) return
+
+      authority.value = auth
+
+      const start = dayjs(fromDate.value).format('YYYY-MM-DD')
+      const end = dayjs(toDate.value)
+        .endOf('month')
+        .add(1, 'day')
+        .format('YYYY-MM-DD')
+      const monthsCovered =
+        dayjs(toDate.value).diff(dayjs(fromDate.value), 'months') + 1
+
+      const startDjs = dayjs(fromDate.value)
+      const endDjs = dayjs(toDate.value)
+
+      let weightKgTotal = 0
+      let giftsTotal = 0
+      let membersTotal = 0
+      let primaryCount = 0
+      let partialCount = 0
+
+      for (const group of auth.groups) {
+        await statsStore.clear()
+        await statsStore.fetch({
+          group: group.id,
+          grouptype: 'Freegle',
+          components: 'Weight,ApprovedMemberCount,Outcomes',
+          start,
+          end,
+          force: true,
+        })
+
+        const overlap = group.overlap
+        const weights = Array.isArray(statsStore.Weight)
+          ? statsStore.Weight
+          : []
+        const outcomes = Array.isArray(statsStore.Outcomes)
+          ? statsStore.Outcomes
+          : []
+        const members = Array.isArray(statsStore.ApprovedMemberCount)
+          ? statsStore.ApprovedMemberCount
+          : []
+
+        let groupWeight = 0
+        for (const w of weights) {
+          groupWeight += w.count * overlap
+        }
+
+        const avpermonth = groupWeight / monthsCovered
+
+        if (avpermonth > 1 || auth.groups.length === 1 || overlap === 1) {
+          weightKgTotal += groupWeight
+
+          for (const outcome of outcomes) {
+            const m = dayjs(parseOutcomeDate(outcome.date))
+            if (!m.isBefore(startDjs) && !m.isAfter(endDjs)) {
+              giftsTotal += outcome.count * overlap
+            }
+          }
+
+          if (members.length > 0) {
+            const latest = members[members.length - 1]
+            membersTotal += latest.count * overlap
+          }
+
+          if (overlap >= 0.95) {
+            primaryCount++
+          } else {
+            partialCount++
+          }
+        }
+      }
+
+      totalWeightKg.value = weightKgTotal
+      totalGiftsCount.value = Math.round(giftsTotal)
+      totalMembersCount.value = Math.round(membersTotal)
+      primaryGroupCount.value = primaryCount
+      partialGroupCount.value = partialCount
+    } finally {
+      loading.value = false
+    }
+  }
+
+  function getTestimonials() {
+    const key = String(authorityId)
+    return (
+      councilConfig[key]?.testimonials ??
+      councilConfig.example?.testimonials ??
+      []
+    )
+  }
+
+  function getPhotoUrl() {
+    const key = String(authorityId)
+    return councilConfig[key]?.photoUrl ?? null
+  }
+
+  return {
+    loading,
+    authority,
+    totalWeight,
+    totalBenefit,
+    totalCO2,
+    totalGifts,
+    totalMembers,
+    groupCount,
+    partialGroupCount,
+    fetchStats,
+    getTestimonials,
+    getPhotoUrl,
+  }
+}

--- a/iznik-nuxt3/composables/useNationalImpact.js
+++ b/iznik-nuxt3/composables/useNationalImpact.js
@@ -1,0 +1,49 @@
+import { ref, computed, useRuntimeConfig } from '#imports'
+import { getBenefitPerTonne, CO2_PER_TONNE } from '~/composables/useReuseBenefit'
+
+export function useNationalImpact(year) {
+  const runtimeConfig = useRuntimeConfig()
+  const loading = ref(false)
+  const rawData = ref(null)
+
+  const totalWeightKg = computed(() => rawData.value?.totalWeightKg ?? 0)
+  const totalGifts = computed(() => rawData.value?.totalGifts ?? 0)
+  const totalMembers = computed(() => rawData.value?.totalMembers ?? 0)
+  const groupCount = computed(() => rawData.value?.groupCount ?? 0)
+
+  const totalWeight = computed(
+    () => Math.round(totalWeightKg.value / 100) / 10
+  )
+  const totalBenefit = computed(() =>
+    Math.round((totalWeightKg.value * getBenefitPerTonne()) / 1000)
+  )
+  const totalCO2 = computed(
+    () => Math.round((totalWeightKg.value * CO2_PER_TONNE) / 100) / 10
+  )
+
+  async function fetchStats() {
+    loading.value = true
+    rawData.value = null
+    try {
+      const url = `${runtimeConfig.public.APIv2}/api/impact/national?year=${year.value}`
+      const resp = await fetch(url)
+      if (resp.ok) {
+        rawData.value = await resp.json()
+      }
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return {
+    loading,
+    totalWeightKg,
+    totalGifts,
+    totalMembers,
+    groupCount,
+    totalWeight,
+    totalBenefit,
+    totalCO2,
+    fetchStats,
+  }
+}

--- a/iznik-nuxt3/composables/useTopImpact.js
+++ b/iznik-nuxt3/composables/useTopImpact.js
@@ -1,0 +1,31 @@
+import { ref, useRuntimeConfig } from '#imports'
+
+export function useTopImpact(year, limit) {
+  const runtimeConfig = useRuntimeConfig()
+  const loading = ref(false)
+  const communities = ref([])
+  const returnedYear = ref(null)
+
+  async function fetchStats() {
+    loading.value = true
+    communities.value = []
+    try {
+      const url = `${runtimeConfig.public.APIv2}/api/impact/top?year=${year.value}&limit=${limit.value}`
+      const resp = await fetch(url)
+      if (resp.ok) {
+        const data = await resp.json()
+        returnedYear.value = data.year
+        communities.value = data.communities ?? []
+      }
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return {
+    loading,
+    communities,
+    returnedYear,
+    fetchStats,
+  }
+}

--- a/iznik-nuxt3/config/council-impact.json
+++ b/iznik-nuxt3/config/council-impact.json
@@ -1,0 +1,16 @@
+{
+  "_comment": "Per-authority testimonials and photo URL for impact infographic pages. Key is the authority ID as a string.",
+  "example": {
+    "testimonials": [
+      {
+        "quote": "I like the feeling that someone else is going to get the benefit of my item and that they are making someone else's life happier.",
+        "attribution": null
+      },
+      {
+        "quote": "Stretching the budget can be very difficult sometimes. If you can help someone along the way, then why not?!",
+        "attribution": "Potteries Freegle"
+      }
+    ],
+    "photoUrl": null
+  }
+}

--- a/iznik-nuxt3/pages/impact/council/[id].vue
+++ b/iznik-nuxt3/pages/impact/council/[id].vue
@@ -1,0 +1,161 @@
+<template>
+  <div class="impact-page">
+    <!-- Filter controls (hidden on print) -->
+    <div class="impact-controls no-print">
+      <label>
+        From:
+        <OurDatePicker v-model="fromDate" />
+      </label>
+      <label>
+        To:
+        <OurDatePicker v-model="toDate" />
+      </label>
+      <b-button variant="primary" size="sm" @click="reload">Update</b-button>
+    </div>
+
+    <div v-if="loading" class="impact-loading">
+      <Spinner :size="40" />
+      <p>Crunching the numbers…</p>
+    </div>
+
+    <div v-else-if="authority" class="impact-slide-wrap">
+      <CouncilSlide
+        :authority-name="authority.name"
+        :year-label="yearLabel"
+        :total-weight="totalWeight"
+        :total-benefit="totalBenefit"
+        :total-c-o2="totalCO2"
+        :total-gifts="totalGifts"
+        :total-members="totalMembers"
+        :group-count="groupCount"
+        :partial-group-count="partialGroupCount"
+        :testimonials="getTestimonials()"
+        :photo-url="getPhotoUrl()"
+        :scale="slideScale"
+      />
+    </div>
+
+    <div v-else class="impact-not-found">
+      <p>Council not found.</p>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import dayjs from 'dayjs'
+import {
+  ref,
+  computed,
+  onMounted,
+  useRoute,
+  useHead,
+  useRuntimeConfig,
+} from '#imports'
+import OurDatePicker from '~/components/OurDatePicker.vue'
+import Spinner from '~/components/Spinner.vue'
+import CouncilSlide from '~/components/impact/CouncilSlide.vue'
+import { useAuthorityImpact } from '~/composables/useAuthorityImpact'
+import { buildHead } from '~/composables/useBuildHead'
+
+const route = useRoute()
+const runtimeConfig = useRuntimeConfig()
+const id = route.params.id
+
+useHead(
+  buildHead(route, runtimeConfig, 'Council Impact', 'Freegle impact report')
+)
+
+const fromDate = ref(
+  dayjs()
+    .subtract(1, 'month')
+    .endOf('month')
+    .subtract(1, 'year')
+    .add(1, 'month')
+    .startOf('month')
+    .toDate()
+)
+const toDate = ref(dayjs().subtract(1, 'month').endOf('month').toDate())
+
+const {
+  loading,
+  authority,
+  totalWeight,
+  totalBenefit,
+  totalCO2,
+  totalGifts,
+  totalMembers,
+  groupCount,
+  partialGroupCount,
+  fetchStats,
+  getTestimonials,
+  getPhotoUrl,
+} = useAuthorityImpact(id, fromDate, toDate)
+
+const yearLabel = computed(() => {
+  const y1 = dayjs(fromDate.value).format('YYYY')
+  const y2 = dayjs(toDate.value).format('YYYY')
+  return y1 === y2 ? y1 : `${y1} –\n${y2}`
+})
+
+const slideScale = computed(() => {
+  if (process.server) return 0.45
+  const available = Math.min(window.innerWidth - 40, 960)
+  return Math.min(0.45, available / 2000)
+})
+
+async function reload() {
+  await fetchStats()
+}
+
+onMounted(async () => {
+  await fetchStats()
+})
+</script>
+
+<style scoped>
+.impact-page {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 20px;
+  background: #f0f0f0;
+  min-height: 100vh;
+}
+
+.impact-controls {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  margin-bottom: 14px;
+  background: white;
+  border-radius: 8px;
+  padding: 8px 16px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
+  font-size: 14px;
+}
+
+.impact-loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  margin-top: 40px;
+  color: #555;
+}
+
+.impact-not-found {
+  color: #888;
+  margin-top: 40px;
+}
+
+@media print {
+  .no-print {
+    display: none !important;
+  }
+
+  .impact-page {
+    padding: 0;
+    background: none;
+  }
+}
+</style>

--- a/iznik-nuxt3/pages/impact/national.vue
+++ b/iznik-nuxt3/pages/impact/national.vue
@@ -1,0 +1,131 @@
+<template>
+  <div class="impact-page">
+    <div class="impact-controls no-print">
+      <label>
+        Year:
+        <select v-model.number="year">
+          <option v-for="y in yearOptions" :key="y" :value="y">{{ y }}</option>
+        </select>
+      </label>
+      <b-button variant="primary" size="sm" @click="reload">Update</b-button>
+    </div>
+
+    <div v-if="loading" class="impact-loading">
+      <Spinner :size="40" />
+      <p>Crunching the numbers…</p>
+    </div>
+
+    <div v-else class="impact-slide-wrap">
+      <NationalSlide
+        :year="year"
+        :total-weight="totalWeight"
+        :total-benefit="totalBenefit"
+        :total-c-o2="totalCO2"
+        :total-gifts="totalGifts"
+        :total-members="totalMembers"
+        :group-count="groupCount"
+        :scale="slideScale"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted, useRoute, useHead, useRuntimeConfig } from '#imports'
+import Spinner from '~/components/Spinner.vue'
+import NationalSlide from '~/components/impact/NationalSlide.vue'
+import { useNationalImpact } from '~/composables/useNationalImpact'
+import { buildHead } from '~/composables/useBuildHead'
+
+const route = useRoute()
+const runtimeConfig = useRuntimeConfig()
+
+useHead(
+  buildHead(
+    route,
+    runtimeConfig,
+    'National Impact',
+    'Freegle national impact report'
+  )
+)
+
+const currentYear = new Date().getFullYear()
+const year = ref(currentYear - 1)
+
+const yearOptions = computed(() => {
+  const opts = []
+  for (let y = currentYear - 1; y >= 2015; y--) {
+    opts.push(y)
+  }
+  return opts
+})
+
+const { loading, totalWeight, totalBenefit, totalCO2, totalGifts, totalMembers, groupCount, fetchStats } =
+  useNationalImpact(year)
+
+const slideScale = computed(() => {
+  if (process.server) return 0.45
+  const available = Math.min(window.innerWidth - 40, 960)
+  return Math.min(0.45, available / 2000)
+})
+
+async function reload() {
+  await fetchStats()
+}
+
+onMounted(async () => {
+  await fetchStats()
+})
+</script>
+
+<style scoped>
+.impact-page {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 20px;
+  background: #555;
+  min-height: 100vh;
+}
+
+.impact-controls {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  margin-bottom: 14px;
+  background: rgba(0, 0, 0, 0.25);
+  border-radius: 8px;
+  padding: 6px 14px;
+  font-size: 12px;
+  color: #eee;
+}
+
+.impact-controls select {
+  background: white;
+  border: none;
+  border-radius: 4px;
+  padding: 2px 7px;
+  font-size: 12px;
+  color: #333;
+}
+
+.impact-loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  margin-top: 40px;
+  color: #eee;
+}
+
+@media print {
+  .no-print {
+    display: none !important;
+  }
+
+  .impact-page {
+    padding: 0;
+    background: none;
+  }
+}
+</style>

--- a/iznik-nuxt3/pages/impact/top.vue
+++ b/iznik-nuxt3/pages/impact/top.vue
@@ -1,0 +1,132 @@
+<template>
+  <div class="impact-page">
+    <div class="impact-controls no-print">
+      <label>
+        Year:
+        <select v-model.number="year">
+          <option v-for="y in yearOptions" :key="y" :value="y">{{ y }}</option>
+        </select>
+      </label>
+      <label>
+        Top:
+        <select v-model.number="limit">
+          <option v-for="n in [3, 5, 10]" :key="n" :value="n">{{ n }}</option>
+        </select>
+      </label>
+      <b-button variant="primary" size="sm" @click="reload">Update</b-button>
+    </div>
+
+    <div v-if="loading" class="impact-loading">
+      <Spinner :size="40" />
+      <p>Crunching the numbers…</p>
+    </div>
+
+    <div v-else class="impact-slide-wrap">
+      <TopSlide
+        :year="returnedYear ?? year"
+        :communities="communities"
+        :scale="slideScale"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted, useRoute, useHead, useRuntimeConfig } from '#imports'
+import Spinner from '~/components/Spinner.vue'
+import TopSlide from '~/components/impact/TopSlide.vue'
+import { useTopImpact } from '~/composables/useTopImpact'
+import { buildHead } from '~/composables/useBuildHead'
+
+const route = useRoute()
+const runtimeConfig = useRuntimeConfig()
+
+useHead(
+  buildHead(
+    route,
+    runtimeConfig,
+    'Top Reuse Superstars',
+    'Freegle top communities by reuse weight'
+  )
+)
+
+const currentYear = new Date().getFullYear()
+const year = ref(currentYear - 1)
+const limit = ref(5)
+
+const yearOptions = computed(() => {
+  const opts = []
+  for (let y = currentYear - 1; y >= 2015; y--) {
+    opts.push(y)
+  }
+  return opts
+})
+
+const { loading, communities, returnedYear, fetchStats } = useTopImpact(year, limit)
+
+const slideScale = computed(() => {
+  if (process.server) return 0.45
+  const available = Math.min(window.innerWidth - 40, 960)
+  return Math.min(0.45, available / 2000)
+})
+
+async function reload() {
+  await fetchStats()
+}
+
+onMounted(async () => {
+  await fetchStats()
+})
+</script>
+
+<style scoped>
+.impact-page {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 20px;
+  background: #333;
+  min-height: 100vh;
+}
+
+.impact-controls {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  margin-bottom: 14px;
+  background: rgba(0, 0, 0, 0.35);
+  border-radius: 8px;
+  padding: 6px 14px;
+  font-size: 12px;
+  color: #eee;
+}
+
+.impact-controls select {
+  background: white;
+  border: none;
+  border-radius: 4px;
+  padding: 2px 7px;
+  font-size: 12px;
+  color: #333;
+}
+
+.impact-loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  margin-top: 40px;
+  color: #eee;
+}
+
+@media print {
+  .no-print {
+    display: none !important;
+  }
+
+  .impact-page {
+    padding: 0;
+    background: none;
+  }
+}
+</style>

--- a/iznik-nuxt3/tests/unit/components/impact/CouncilSlide.spec.js
+++ b/iznik-nuxt3/tests/unit/components/impact/CouncilSlide.spec.js
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import CouncilSlide from '~/components/impact/CouncilSlide.vue'
+
+function makeProps(overrides = {}) {
+  return {
+    authorityName: 'Test Council',
+    yearLabel: '2024',
+    totalWeight: 100,
+    totalBenefit: 50000,
+    totalCO2: 51,
+    totalGifts: 1234,
+    totalMembers: 5678,
+    groupCount: 3,
+    ...overrides,
+  }
+}
+
+describe('CouncilSlide — formattedWeight', () => {
+  it('shows one decimal place when weight < 10', () => {
+    const wrapper = mount(CouncilSlide, { props: makeProps({ totalWeight: 7.4 }) })
+    expect(wrapper.text()).toContain('7.4')
+  })
+
+  it('rounds to integer when weight >= 10', () => {
+    const wrapper = mount(CouncilSlide, { props: makeProps({ totalWeight: 12.7 }) })
+    expect(wrapper.text()).toContain('13')
+  })
+
+  it('formats large numbers with locale separators', () => {
+    const wrapper = mount(CouncilSlide, { props: makeProps({ totalWeight: 1500 }) })
+    expect(wrapper.text()).toContain('1,500')
+  })
+})
+
+describe('CouncilSlide — formattedCO2', () => {
+  it('shows one decimal place when CO2 < 10', () => {
+    const wrapper = mount(CouncilSlide, { props: makeProps({ totalCO2: 3.6 }) })
+    expect(wrapper.text()).toContain('3.6')
+  })
+
+  it('rounds to integer when CO2 >= 10', () => {
+    const wrapper = mount(CouncilSlide, { props: makeProps({ totalCO2: 51.7 }) })
+    expect(wrapper.text()).toContain('52')
+  })
+})
+
+describe('CouncilSlide — formattedBenefit', () => {
+  it('rounds benefit to nearest integer', () => {
+    const wrapper = mount(CouncilSlide, { props: makeProps({ totalBenefit: 49876.6 }) })
+    expect(wrapper.text()).toContain('£49,877')
+  })
+})
+
+describe('CouncilSlide — slideStyle', () => {
+  it('applies scale 0.45 by default', () => {
+    const wrapper = mount(CouncilSlide, { props: makeProps() })
+    const style = wrapper.find('.impact-slide').attributes('style')
+    expect(style).toContain('width: 900px')
+    expect(style).toContain('height: 636px')
+  })
+
+  it('scales width/height proportionally for custom scale', () => {
+    const wrapper = mount(CouncilSlide, { props: makeProps({ scale: 0.5 }) })
+    const style = wrapper.find('.impact-slide').attributes('style')
+    expect(style).toContain('width: 1000px')
+    expect(style).toContain('height: 707px')
+  })
+})
+
+describe('CouncilSlide — template', () => {
+  it('renders authority name', () => {
+    const wrapper = mount(CouncilSlide, {
+      props: makeProps({ authorityName: 'Surrey County Council' }),
+    })
+    expect(wrapper.text()).toContain('Surrey County Council')
+  })
+
+  it('renders year label', () => {
+    const wrapper = mount(CouncilSlide, {
+      props: makeProps({ yearLabel: '2023 –\n2024' }),
+    })
+    expect(wrapper.text()).toContain('2023')
+  })
+
+  it('renders items freegled count', () => {
+    const wrapper = mount(CouncilSlide, { props: makeProps({ totalGifts: 9876 }) })
+    expect(wrapper.text()).toContain('9,876')
+  })
+
+  it('renders member count', () => {
+    const wrapper = mount(CouncilSlide, {
+      props: makeProps({ totalMembers: 12345 }),
+    })
+    expect(wrapper.text()).toContain('12,345')
+  })
+
+  it('renders group count with singular label for 1 community', () => {
+    const wrapper = mount(CouncilSlide, { props: makeProps({ groupCount: 1 }) })
+    expect(wrapper.text()).toContain('Freegle community')
+    expect(wrapper.text()).not.toContain('Freegle communities')
+  })
+
+  it('renders group count with plural label for > 1 communities', () => {
+    const wrapper = mount(CouncilSlide, { props: makeProps({ groupCount: 4 }) })
+    expect(wrapper.text()).toContain('Freegle communities')
+  })
+
+  it('shows partial group count when > 0', () => {
+    const wrapper = mount(CouncilSlide, {
+      props: makeProps({ groupCount: 2, partialGroupCount: 1 }),
+    })
+    expect(wrapper.text()).toContain('+ 1 others part-serving this area')
+  })
+
+  it('hides partial group count when 0', () => {
+    const wrapper = mount(CouncilSlide, {
+      props: makeProps({ groupCount: 3, partialGroupCount: 0 }),
+    })
+    expect(wrapper.text()).not.toContain('part-serving')
+  })
+
+  it('renders testimonial quotes when provided', () => {
+    const testimonials = [{ quote: 'Great service!', attribution: 'Alice' }]
+    const wrapper = mount(CouncilSlide, {
+      props: makeProps({ testimonials }),
+    })
+    expect(wrapper.text()).toContain('Great service!')
+    expect(wrapper.text()).toContain('From Alice')
+  })
+
+  it('renders photo when photoUrl provided', () => {
+    const wrapper = mount(CouncilSlide, {
+      props: makeProps({ photoUrl: 'https://example.com/photo.jpg' }),
+    })
+    const img = wrapper.find('img')
+    expect(img.exists()).toBe(true)
+    expect(img.attributes('src')).toBe('https://example.com/photo.jpg')
+  })
+
+  it('shows placeholder when no photoUrl', () => {
+    const wrapper = mount(CouncilSlide, {
+      props: makeProps({ photoUrl: null }),
+    })
+    expect(wrapper.find('.impact-photo-placeholder').exists()).toBe(true)
+  })
+})

--- a/iznik-nuxt3/tests/unit/components/impact/NationalSlide.spec.js
+++ b/iznik-nuxt3/tests/unit/components/impact/NationalSlide.spec.js
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import NationalSlide from '~/components/impact/NationalSlide.vue'
+
+function makeProps(overrides = {}) {
+  return {
+    year: 2024,
+    totalWeight: 11000,
+    totalBenefit: 7854000,
+    totalCO2: 5610,
+    totalGifts: 664408,
+    totalMembers: 4500000,
+    groupCount: 500,
+    ...overrides,
+  }
+}
+
+describe('NationalSlide — formattedWeight', () => {
+  it('shows one decimal place when weight < 10', () => {
+    const wrapper = mount(NationalSlide, { props: makeProps({ totalWeight: 7.4 }) })
+    expect(wrapper.text()).toContain('7.4')
+  })
+
+  it('rounds to integer when weight >= 10', () => {
+    const wrapper = mount(NationalSlide, { props: makeProps({ totalWeight: 12.7 }) })
+    expect(wrapper.text()).toContain('13')
+  })
+
+  it('formats large numbers with locale separators', () => {
+    const wrapper = mount(NationalSlide, { props: makeProps({ totalWeight: 11000 }) })
+    expect(wrapper.text()).toContain('11,000')
+  })
+})
+
+describe('NationalSlide — formattedCO2', () => {
+  it('shows one decimal place when CO2 < 10', () => {
+    const wrapper = mount(NationalSlide, { props: makeProps({ totalCO2: 3.6 }) })
+    expect(wrapper.text()).toContain('3.6')
+  })
+
+  it('rounds to integer when CO2 >= 10', () => {
+    const wrapper = mount(NationalSlide, { props: makeProps({ totalCO2: 5610.7 }) })
+    expect(wrapper.text()).toContain('5,611')
+  })
+})
+
+describe('NationalSlide — formattedBenefit', () => {
+  it('formats as millions when benefit >= 1 million', () => {
+    const wrapper = mount(NationalSlide, { props: makeProps({ totalBenefit: 7900000 }) })
+    expect(wrapper.text()).toContain('£7.9 million')
+  })
+
+  it('formats as thousands when benefit < 1 million', () => {
+    const wrapper = mount(NationalSlide, { props: makeProps({ totalBenefit: 714000 }) })
+    expect(wrapper.text()).toContain('£714k')
+  })
+})
+
+describe('NationalSlide — formattedMembers', () => {
+  it('formats as millions when members >= 1 million', () => {
+    const wrapper = mount(NationalSlide, { props: makeProps({ totalMembers: 4500000 }) })
+    expect(wrapper.text()).toContain('4.5 million')
+  })
+
+  it('formats as thousands when members < 1 million', () => {
+    const wrapper = mount(NationalSlide, { props: makeProps({ totalMembers: 250000 }) })
+    expect(wrapper.text()).toContain('250k')
+  })
+})
+
+describe('NationalSlide — slideStyle', () => {
+  it('applies scale 0.45 by default', () => {
+    const wrapper = mount(NationalSlide, { props: makeProps() })
+    const style = wrapper.find('.national-slide').attributes('style')
+    expect(style).toContain('width: 900px')
+    expect(style).toContain('height: 636px')
+  })
+
+  it('applies custom scale', () => {
+    const wrapper = mount(NationalSlide, { props: makeProps({ scale: 0.3 }) })
+    const style = wrapper.find('.national-slide').attributes('style')
+    expect(style).toContain('width: 600px')
+    expect(style).toContain('height: 424px')
+  })
+})
+
+describe('NationalSlide — template', () => {
+  it('shows the year', () => {
+    const wrapper = mount(NationalSlide, { props: makeProps({ year: 2024 }) })
+    expect(wrapper.find('.ns-year-badge').text()).toBe('2024')
+  })
+
+  it('shows group count', () => {
+    const wrapper = mount(NationalSlide, { props: makeProps({ groupCount: 500 }) })
+    expect(wrapper.find('.ns-comm-n').text()).toContain('500')
+  })
+
+  it('shows total gifts', () => {
+    const wrapper = mount(NationalSlide, { props: makeProps({ totalGifts: 664408 }) })
+    expect(wrapper.find('.ns-notepad-big').text()).toContain('664,408')
+  })
+
+  it('renders the footer', () => {
+    const wrapper = mount(NationalSlide, { props: makeProps() })
+    expect(wrapper.find('.ns-footer').text()).toContain('ilovefreegle.org')
+  })
+
+  it('renders established year', () => {
+    const wrapper = mount(NationalSlide, { props: makeProps() })
+    expect(wrapper.find('.ns-established-year').text()).toBe('2009')
+  })
+})

--- a/iznik-nuxt3/tests/unit/components/impact/TopSlide.spec.js
+++ b/iznik-nuxt3/tests/unit/components/impact/TopSlide.spec.js
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import TopSlide from '~/components/impact/TopSlide.vue'
+
+const SAMPLE_COMMUNITIES = [
+  { name: 'Oxford Freegle', weightKg: 240000 },
+  { name: 'Croydon Freegle', weightKg: 202000 },
+  { name: 'Reading Freegle', weightKg: 180000 },
+  { name: 'Sheffield Freegle', weightKg: 174000 },
+  { name: 'Edinburgh Freegle', weightKg: 174000 },
+]
+
+function makeProps(overrides = {}) {
+  return {
+    year: 2024,
+    communities: SAMPLE_COMMUNITIES,
+    ...overrides,
+  }
+}
+
+describe('TopSlide — template', () => {
+  it('shows the year badge', () => {
+    const wrapper = mount(TopSlide, { props: makeProps() })
+    expect(wrapper.find('.ts-year-badge').text()).toBe('2024')
+  })
+
+  it('renders all leaderboard entries', () => {
+    const wrapper = mount(TopSlide, { props: makeProps() })
+    const entries = wrapper.findAll('.ts-entry')
+    expect(entries).toHaveLength(5)
+  })
+
+  it('shows the rank-1 class for the first entry', () => {
+    const wrapper = mount(TopSlide, { props: makeProps() })
+    expect(wrapper.findAll('.ts-entry')[0].classes()).toContain('rank-1')
+  })
+
+  it('shows the rank-2 class for the second entry', () => {
+    const wrapper = mount(TopSlide, { props: makeProps() })
+    expect(wrapper.findAll('.ts-entry')[1].classes()).toContain('rank-2')
+  })
+
+  it('shows community names', () => {
+    const wrapper = mount(TopSlide, { props: makeProps() })
+    expect(wrapper.text()).toContain('Oxford Freegle')
+    expect(wrapper.text()).toContain('Croydon Freegle')
+  })
+
+  it('renders the title', () => {
+    const wrapper = mount(TopSlide, { props: makeProps() })
+    expect(wrapper.find('.ts-title').text()).toContain('SUPERSTARS')
+  })
+
+  it('renders the hashtag', () => {
+    const wrapper = mount(TopSlide, { props: makeProps() })
+    expect(wrapper.find('.ts-hashtag').text()).toContain('ChooseToReuse')
+  })
+
+  it('renders the footer', () => {
+    const wrapper = mount(TopSlide, { props: makeProps() })
+    expect(wrapper.find('.ts-footer').text()).toContain('ilovefreegle.org')
+  })
+})
+
+describe('TopSlide — formattedTonnes', () => {
+  it('converts kg to tonnes in leaderboard', () => {
+    const wrapper = mount(TopSlide, {
+      props: makeProps({
+        communities: [{ name: 'Test', weightKg: 240000 }],
+      }),
+    })
+    expect(wrapper.find('.ts-tonnes').text()).toBe('240')
+  })
+
+  it('shows one decimal for sub-10 tonne entries', () => {
+    const wrapper = mount(TopSlide, {
+      props: makeProps({
+        communities: [{ name: 'Test', weightKg: 7400 }],
+      }),
+    })
+    expect(wrapper.find('.ts-tonnes').text()).toBe('7.4')
+  })
+})
+
+describe('TopSlide — slideStyle', () => {
+  it('applies scale 0.45 by default', () => {
+    const wrapper = mount(TopSlide, { props: makeProps() })
+    const style = wrapper.find('.top-slide').attributes('style')
+    expect(style).toContain('width: 900px')
+    expect(style).toContain('height: 636px')
+  })
+
+  it('applies custom scale', () => {
+    const wrapper = mount(TopSlide, { props: makeProps({ scale: 0.3 }) })
+    const style = wrapper.find('.top-slide').attributes('style')
+    expect(style).toContain('width: 600px')
+    expect(style).toContain('height: 424px')
+  })
+})
+
+describe('TopSlide — empty communities', () => {
+  it('renders without entries when communities is empty', () => {
+    const wrapper = mount(TopSlide, { props: makeProps({ communities: [] }) })
+    expect(wrapper.findAll('.ts-entry')).toHaveLength(0)
+    expect(wrapper.find('.ts-title').exists()).toBe(true)
+  })
+})

--- a/iznik-nuxt3/tests/unit/composables/useAuthorityImpact.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useAuthorityImpact.spec.js
@@ -1,0 +1,232 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ref } from 'vue'
+import { useAuthorityImpact } from '~/composables/useAuthorityImpact'
+import { getBenefitPerTonne, CO2_PER_TONNE } from '~/composables/useReuseBenefit'
+
+// Stub stores — each test controls fetchStats by controlling store responses
+const mockAuthorityFetch = vi.fn()
+const mockStatsClear = vi.fn()
+const mockStatsFetch = vi.fn()
+
+let mockAuthorityList = {}
+let mockStats = {}
+
+vi.mock('~/stores/authority', () => ({
+  useAuthorityStore: () => ({
+    fetch: mockAuthorityFetch,
+    get list() {
+      return mockAuthorityList
+    },
+  }),
+}))
+
+vi.mock('~/stores/stats', () => ({
+  useStatsStore: () => ({
+    clear: mockStatsClear,
+    fetch: mockStatsFetch,
+    get Weight() {
+      return mockStats.Weight ?? []
+    },
+    get Outcomes() {
+      return mockStats.Outcomes ?? []
+    },
+    get ApprovedMemberCount() {
+      return mockStats.ApprovedMemberCount ?? []
+    },
+  }),
+}))
+
+vi.mock('#imports', async () => {
+  const vue = await vi.importActual('vue')
+  return { ref: vue.ref, computed: vue.computed }
+})
+
+describe('useAuthorityImpact — getTestimonials', () => {
+  it('returns example testimonials for an unconfigured authority ID', () => {
+    const { getTestimonials } = useAuthorityImpact(
+      '99999',
+      ref(new Date()),
+      ref(new Date())
+    )
+    const t = getTestimonials()
+    expect(Array.isArray(t)).toBe(true)
+    expect(t.length).toBeGreaterThan(0)
+    expect(t[0]).toHaveProperty('quote')
+  })
+
+  it('returns an array for any unconfigured authority ID', () => {
+    const { getTestimonials } = useAuthorityImpact(
+      '99999',
+      ref(new Date()),
+      ref(new Date())
+    )
+    expect(Array.isArray(getTestimonials())).toBe(true)
+  })
+})
+
+describe('useAuthorityImpact — getPhotoUrl', () => {
+  it('returns null for an unconfigured authority ID', () => {
+    const { getPhotoUrl } = useAuthorityImpact(
+      '99999',
+      ref(new Date()),
+      ref(new Date())
+    )
+    expect(getPhotoUrl()).toBeNull()
+  })
+})
+
+describe('useAuthorityImpact — computed totals', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuthorityList = {}
+    mockStats = {}
+  })
+
+  it('converts weight from kg to tonnes correctly', async () => {
+    mockAuthorityList = {
+      42: {
+        name: 'Test Council',
+        groups: [{ id: 1, overlap: 1 }],
+      },
+    }
+    mockStats = {
+      Weight: [{ count: 50000 }, { count: 50000 }],
+      Outcomes: [],
+      ApprovedMemberCount: [{ count: 100 }],
+    }
+
+    const fromDate = ref(new Date('2024-01-01'))
+    const toDate = ref(new Date('2024-12-31'))
+    const { totalWeight, fetchStats } = useAuthorityImpact(42, fromDate, toDate)
+
+    await fetchStats()
+
+    // 100,000 kg → 100 tonnes (rounded to 1dp since >= 10 → integer)
+    expect(totalWeight.value).toBe(100)
+  })
+
+  it('applies overlap weighting to weight totals', async () => {
+    mockAuthorityList = {
+      43: {
+        name: 'Partial Council',
+        groups: [{ id: 1, overlap: 0.5 }],
+      },
+    }
+    mockStats = {
+      Weight: [{ count: 10000 }],
+      Outcomes: [],
+      ApprovedMemberCount: [{ count: 200 }],
+    }
+
+    const fromDate = ref(new Date('2024-01-01'))
+    const toDate = ref(new Date('2024-12-31'))
+    const { totalWeight, fetchStats } = useAuthorityImpact(43, fromDate, toDate)
+
+    await fetchStats()
+
+    // 10,000kg × 0.5 overlap = 5,000kg → 5 tonnes (< 10 → 1dp)
+    expect(totalWeight.value).toBe(5)
+  })
+
+  it('calculates CO2 as weight × CO2_PER_TONNE', async () => {
+    mockAuthorityList = {
+      44: {
+        name: 'CO2 Council',
+        groups: [{ id: 1, overlap: 1 }],
+      },
+    }
+    // 2,000kg = 2 tonnes
+    mockStats = {
+      Weight: [{ count: 2000 }],
+      Outcomes: [],
+      ApprovedMemberCount: [{ count: 50 }],
+    }
+
+    const fromDate = ref(new Date('2024-01-01'))
+    const toDate = ref(new Date('2024-12-31'))
+    const { totalCO2, fetchStats } = useAuthorityImpact(44, fromDate, toDate)
+
+    await fetchStats()
+
+    // 2000kg × CO2_PER_TONNE / 1000 = 2 × 0.51 = 1.02 → rounded to 1.0
+    const expected = Math.round(2000 * CO2_PER_TONNE / 100) / 10
+    expect(totalCO2.value).toBeCloseTo(expected, 5)
+  })
+
+  it('calculates benefit using getBenefitPerTonne', async () => {
+    mockAuthorityList = {
+      45: {
+        name: 'Benefit Council',
+        groups: [{ id: 1, overlap: 1 }],
+      },
+    }
+    // 1,000kg = 1 tonne
+    mockStats = {
+      Weight: [{ count: 1000 }],
+      Outcomes: [],
+      ApprovedMemberCount: [{ count: 10 }],
+    }
+
+    const fromDate = ref(new Date('2024-01-01'))
+    const toDate = ref(new Date('2024-12-31'))
+    const { totalBenefit, fetchStats } = useAuthorityImpact(45, fromDate, toDate)
+
+    await fetchStats()
+
+    const expected = Math.round(1000 * getBenefitPerTonne() / 1000)
+    expect(totalBenefit.value).toBe(expected)
+  })
+
+  it('sums member counts across groups', async () => {
+    mockAuthorityList = {
+      46: {
+        name: 'Multi Council',
+        groups: [
+          { id: 1, overlap: 1 },
+          { id: 2, overlap: 1 },
+        ],
+      },
+    }
+
+    let callCount = 0
+    mockStatsFetch.mockImplementation(() => {
+      callCount++
+      if (callCount === 1) {
+        mockStats = {
+          Weight: [{ count: 1000 }],
+          Outcomes: [],
+          ApprovedMemberCount: [{ count: 100 }],
+        }
+      } else {
+        mockStats = {
+          Weight: [{ count: 2000 }],
+          Outcomes: [],
+          ApprovedMemberCount: [{ count: 200 }],
+        }
+      }
+    })
+
+    const fromDate = ref(new Date('2024-01-01'))
+    const toDate = ref(new Date('2024-12-31'))
+    const { totalMembers, fetchStats } = useAuthorityImpact(46, fromDate, toDate)
+
+    await fetchStats()
+
+    expect(totalMembers.value).toBe(300)
+  })
+
+  it('returns zero totals when authority is not found', async () => {
+    mockAuthorityList = {}
+
+    const fromDate = ref(new Date('2024-01-01'))
+    const toDate = ref(new Date('2024-12-31'))
+    const { totalWeight, totalGifts, totalMembers, fetchStats } =
+      useAuthorityImpact(999, fromDate, toDate)
+
+    await fetchStats()
+
+    expect(totalWeight.value).toBe(0)
+    expect(totalGifts.value).toBe(0)
+    expect(totalMembers.value).toBe(0)
+  })
+})

--- a/iznik-nuxt3/tests/unit/composables/useNationalImpact.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useNationalImpact.spec.js
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { ref } from 'vue'
+import { useNationalImpact } from '~/composables/useNationalImpact'
+import { getBenefitPerTonne, CO2_PER_TONNE } from '~/composables/useReuseBenefit'
+
+vi.mock('#imports', async () => {
+  const vue = await vi.importActual('vue')
+  return {
+    ref: vue.ref,
+    computed: vue.computed,
+    useRuntimeConfig: () => ({ public: { APIv2: 'http://api.test' } }),
+  }
+})
+
+const WEIGHT_KG = 11_060_000
+
+function mockFetchResponse(data) {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve(data),
+  })
+}
+
+describe('useNationalImpact — computed totals from raw data', () => {
+  let originalFetch
+
+  beforeEach(() => {
+    originalFetch = global.fetch
+  })
+
+  afterEach(() => {
+    global.fetch = originalFetch
+  })
+
+  it('computes totalWeight in tonnes from kg', async () => {
+    global.fetch = mockFetchResponse({
+      year: 2024,
+      totalWeightKg: WEIGHT_KG,
+      totalGifts: 0,
+      totalMembers: 0,
+      groupCount: 0,
+    })
+
+    const year = ref(2024)
+    const { totalWeight, fetchStats } = useNationalImpact(year)
+    await fetchStats()
+    expect(totalWeight.value).toBeCloseTo(11060, 0)
+  })
+
+  it('computes totalBenefit in £ from weight kg', async () => {
+    global.fetch = mockFetchResponse({
+      year: 2024,
+      totalWeightKg: WEIGHT_KG,
+      totalGifts: 0,
+      totalMembers: 0,
+      groupCount: 0,
+    })
+
+    const year = ref(2024)
+    const { totalBenefit, fetchStats } = useNationalImpact(year)
+    await fetchStats()
+    const expectedBenefit = Math.round((WEIGHT_KG * getBenefitPerTonne()) / 1000)
+    expect(totalBenefit.value).toBe(expectedBenefit)
+  })
+
+  it('computes totalCO2 from weight kg', async () => {
+    global.fetch = mockFetchResponse({
+      year: 2024,
+      totalWeightKg: WEIGHT_KG,
+      totalGifts: 0,
+      totalMembers: 0,
+      groupCount: 0,
+    })
+
+    const year = ref(2024)
+    const { totalCO2, fetchStats } = useNationalImpact(year)
+    await fetchStats()
+    const expectedCO2 = Math.round((WEIGHT_KG * CO2_PER_TONNE) / 100) / 10
+    expect(totalCO2.value).toBeCloseTo(expectedCO2, 1)
+  })
+
+  it('exposes totalGifts from API response', async () => {
+    global.fetch = mockFetchResponse({
+      year: 2024,
+      totalWeightKg: 0,
+      totalGifts: 664408,
+      totalMembers: 0,
+      groupCount: 0,
+    })
+
+    const year = ref(2024)
+    const { totalGifts, fetchStats } = useNationalImpact(year)
+    await fetchStats()
+    expect(totalGifts.value).toBe(664408)
+  })
+
+  it('exposes totalMembers from API response', async () => {
+    global.fetch = mockFetchResponse({
+      year: 2024,
+      totalWeightKg: 0,
+      totalGifts: 0,
+      totalMembers: 4500000,
+      groupCount: 0,
+    })
+
+    const year = ref(2024)
+    const { totalMembers, fetchStats } = useNationalImpact(year)
+    await fetchStats()
+    expect(totalMembers.value).toBe(4500000)
+  })
+
+  it('exposes groupCount from API response', async () => {
+    global.fetch = mockFetchResponse({
+      year: 2024,
+      totalWeightKg: 0,
+      totalGifts: 0,
+      totalMembers: 0,
+      groupCount: 500,
+    })
+
+    const year = ref(2024)
+    const { groupCount, fetchStats } = useNationalImpact(year)
+    await fetchStats()
+    expect(groupCount.value).toBe(500)
+  })
+
+  it('returns zero totals before fetchStats is called', () => {
+    const year = ref(2024)
+    const { totalWeight, totalGifts, totalMembers, groupCount } =
+      useNationalImpact(year)
+    expect(totalWeight.value).toBe(0)
+    expect(totalGifts.value).toBe(0)
+    expect(totalMembers.value).toBe(0)
+    expect(groupCount.value).toBe(0)
+  })
+
+  it('sets loading true during fetch and false after', async () => {
+    let resolveResponse
+    const responsePromise = new Promise((resolve) => {
+      resolveResponse = resolve
+    })
+    global.fetch = vi.fn().mockReturnValue(responsePromise)
+
+    const year = ref(2024)
+    const { loading, fetchStats } = useNationalImpact(year)
+    expect(loading.value).toBe(false)
+
+    const promise = fetchStats()
+    expect(loading.value).toBe(true)
+
+    resolveResponse({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          year: 2024,
+          totalWeightKg: 0,
+          totalGifts: 0,
+          totalMembers: 0,
+          groupCount: 0,
+        }),
+    })
+    await promise
+    expect(loading.value).toBe(false)
+  })
+
+  it('calls the correct URL with year parameter', async () => {
+    const fetchSpy = mockFetchResponse({
+      year: 2023,
+      totalWeightKg: 0,
+      totalGifts: 0,
+      totalMembers: 0,
+      groupCount: 0,
+    })
+    global.fetch = fetchSpy
+
+    const year = ref(2023)
+    const { fetchStats } = useNationalImpact(year)
+    await fetchStats()
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'http://api.test/api/impact/national?year=2023'
+    )
+  })
+})

--- a/iznik-nuxt3/tests/unit/composables/useTopImpact.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useTopImpact.spec.js
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { ref } from 'vue'
+import { useTopImpact } from '~/composables/useTopImpact'
+
+vi.mock('#imports', async () => {
+  const vue = await vi.importActual('vue')
+  return {
+    ref: vue.ref,
+    useRuntimeConfig: () => ({ public: { APIv2: 'http://api.test' } }),
+  }
+})
+
+const SAMPLE_COMMUNITIES = [
+  { name: 'Oxford Freegle', weightKg: 240000 },
+  { name: 'Croydon Freegle', weightKg: 202000 },
+]
+
+function mockFetchResponse(data) {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve(data),
+  })
+}
+
+describe('useTopImpact — fetchStats', () => {
+  let originalFetch
+
+  beforeEach(() => {
+    originalFetch = global.fetch
+  })
+
+  afterEach(() => {
+    global.fetch = originalFetch
+  })
+
+  it('populates communities from API response', async () => {
+    global.fetch = mockFetchResponse({
+      year: 2024,
+      communities: SAMPLE_COMMUNITIES,
+    })
+
+    const year = ref(2024)
+    const limit = ref(5)
+    const { communities, fetchStats } = useTopImpact(year, limit)
+    await fetchStats()
+    expect(communities.value).toHaveLength(2)
+    expect(communities.value[0].name).toBe('Oxford Freegle')
+  })
+
+  it('sets returnedYear from API response', async () => {
+    global.fetch = mockFetchResponse({
+      year: 2024,
+      communities: SAMPLE_COMMUNITIES,
+    })
+
+    const year = ref(2024)
+    const limit = ref(5)
+    const { returnedYear, fetchStats } = useTopImpact(year, limit)
+    await fetchStats()
+    expect(returnedYear.value).toBe(2024)
+  })
+
+  it('starts with empty communities', () => {
+    const year = ref(2024)
+    const limit = ref(5)
+    const { communities } = useTopImpact(year, limit)
+    expect(communities.value).toHaveLength(0)
+  })
+
+  it('calls the correct URL with year and limit', async () => {
+    const fetchSpy = mockFetchResponse({ year: 2023, communities: [] })
+    global.fetch = fetchSpy
+
+    const year = ref(2023)
+    const limit = ref(3)
+    const { fetchStats } = useTopImpact(year, limit)
+    await fetchStats()
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'http://api.test/api/impact/top?year=2023&limit=3'
+    )
+  })
+
+  it('sets loading true during fetch and false after', async () => {
+    let resolveResponse
+    const responsePromise = new Promise((resolve) => {
+      resolveResponse = resolve
+    })
+    global.fetch = vi.fn().mockReturnValue(responsePromise)
+
+    const year = ref(2024)
+    const limit = ref(5)
+    const { loading, fetchStats } = useTopImpact(year, limit)
+    expect(loading.value).toBe(false)
+
+    const promise = fetchStats()
+    expect(loading.value).toBe(true)
+
+    resolveResponse({
+      ok: true,
+      json: () => Promise.resolve({ year: 2024, communities: [] }),
+    })
+    await promise
+    expect(loading.value).toBe(false)
+  })
+
+  it('handles empty communities array', async () => {
+    global.fetch = mockFetchResponse({ year: 2024, communities: [] })
+
+    const year = ref(2024)
+    const limit = ref(5)
+    const { communities, fetchStats } = useTopImpact(year, limit)
+    await fetchStats()
+    expect(communities.value).toHaveLength(0)
+  })
+})

--- a/iznik-nuxt3/tests/unit/pages/impact/CouncilPage.spec.js
+++ b/iznik-nuxt3/tests/unit/pages/impact/CouncilPage.spec.js
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { ref } from 'vue'
+
+// Global stubs needed by all pages
+globalThis.definePageMeta = vi.fn()
+globalThis.useHead = vi.fn()
+globalThis.useRuntimeConfig = () => ({ public: { BUILD_DATE: '2026-01-01' } })
+
+// Route mock — mutable per test
+let mockRoute = { params: { id: '123' }, query: {} }
+
+vi.mock('#imports', async () => {
+  const vue = await vi.importActual('vue')
+  return {
+    ...vue,
+    useRoute: () => mockRoute,
+    useHead: vi.fn(),
+    useRuntimeConfig: () => ({ public: { BUILD_DATE: '2026-01-01' } }),
+  }
+})
+
+// Mock child components to keep tests focused on page logic
+vi.mock('~/components/OurDatePicker.vue', () => ({
+  default: {
+    name: 'OurDatePicker',
+    template: '<input class="date-picker" />',
+    props: ['modelValue'],
+    emits: ['update:modelValue'],
+  },
+}))
+
+vi.mock('~/components/Spinner.vue', () => ({
+  default: { name: 'Spinner', template: '<div class="spinner" />' },
+}))
+
+vi.mock('~/components/impact/CouncilSlide.vue', () => ({
+  default: {
+    name: 'CouncilSlide',
+    template: '<div class="council-slide" />',
+    props: [
+      'authorityName',
+      'yearLabel',
+      'totalWeight',
+      'totalBenefit',
+      'totalCO2',
+      'totalGifts',
+      'totalMembers',
+      'groupCount',
+      'partialGroupCount',
+      'testimonials',
+      'photoUrl',
+      'scale',
+    ],
+  },
+}))
+
+// Use actual Vue refs so the template auto-unwraps them correctly.
+// Plain objects { value: false } are truthy and break v-if="loading" etc.
+const mockFetchStats = vi.fn()
+const mockLoading = ref(false)
+const mockAuthority = ref(null)
+const mockTotalWeight = ref(0)
+const mockTotalBenefit = ref(0)
+const mockTotalCO2 = ref(0)
+const mockTotalGifts = ref(0)
+const mockTotalMembers = ref(0)
+const mockGroupCount = ref(0)
+const mockPartialGroupCount = ref(0)
+
+vi.mock('~/composables/useAuthorityImpact', () => ({
+  useAuthorityImpact: () => ({
+    loading: mockLoading,
+    authority: mockAuthority,
+    totalWeight: mockTotalWeight,
+    totalBenefit: mockTotalBenefit,
+    totalCO2: mockTotalCO2,
+    totalGifts: mockTotalGifts,
+    totalMembers: mockTotalMembers,
+    groupCount: mockGroupCount,
+    partialGroupCount: mockPartialGroupCount,
+    fetchStats: mockFetchStats,
+    getTestimonials: () => [],
+    getPhotoUrl: () => null,
+  }),
+}))
+
+vi.mock('~/composables/useBuildHead', () => ({
+  buildHead: () => ({ title: 'Test' }),
+}))
+
+import CouncilPage from '~/pages/impact/council/[id].vue'
+
+function resetMockState() {
+  mockLoading.value = false
+  mockAuthority.value = null
+  mockTotalWeight.value = 0
+  mockTotalBenefit.value = 0
+  mockTotalCO2.value = 0
+  mockTotalGifts.value = 0
+  mockTotalMembers.value = 0
+  mockGroupCount.value = 0
+  mockPartialGroupCount.value = 0
+}
+
+describe('pages/impact/council/[id].vue — yearLabel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setActivePinia(createPinia())
+    resetMockState()
+    mockAuthority.value = { name: 'Test Council', groups: [] }
+    mockFetchStats.mockResolvedValue(undefined)
+  })
+
+  it('passes a valid yearLabel string to CouncilSlide', async () => {
+    const wrapper = mount(CouncilPage, {
+      global: { plugins: [createPinia()] },
+    })
+    await flushPromises()
+
+    // Access the prop directly — HTML attrs don't carry Vue component props
+    const slide = wrapper.findComponent({ name: 'CouncilSlide' })
+    const yearLabel = slide.props('yearLabel') ?? ''
+
+    // Should be a 4-digit year, or "YYYY – YYYY" for cross-year ranges
+    if (yearLabel.includes('–')) {
+      const parts = yearLabel.split('–').map((s) => s.trim())
+      expect(parts).toHaveLength(2)
+      expect(parts[0]).toMatch(/^\d{4}$/)
+      expect(parts[1]).toMatch(/^\d{4}$/)
+    } else {
+      expect(yearLabel).toMatch(/^\d{4}$/)
+    }
+  })
+})
+
+describe('pages/impact/council/[id].vue — rendering', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setActivePinia(createPinia())
+    resetMockState()
+    mockFetchStats.mockResolvedValue(undefined)
+  })
+
+  it('shows loading state while loading', async () => {
+    mockLoading.value = true
+    mockAuthority.value = null
+    const wrapper = mount(CouncilPage, {
+      global: { plugins: [createPinia()] },
+    })
+    await flushPromises()
+    // .impact-loading is the page's own div — always present when v-if="loading" is true
+    expect(wrapper.find('.impact-loading').exists()).toBe(true)
+    expect(wrapper.find('.council-slide').exists()).toBe(false)
+  })
+
+  it('shows council slide when authority is loaded', async () => {
+    mockLoading.value = false
+    mockAuthority.value = { name: 'Surrey', groups: [] }
+    const wrapper = mount(CouncilPage, {
+      global: { plugins: [createPinia()] },
+    })
+    await flushPromises()
+    expect(wrapper.find('.council-slide').exists()).toBe(true)
+    expect(wrapper.find('.impact-loading').exists()).toBe(false)
+  })
+
+  it('shows not-found message when authority is null and not loading', async () => {
+    mockLoading.value = false
+    mockAuthority.value = null
+    const wrapper = mount(CouncilPage, {
+      global: { plugins: [createPinia()] },
+    })
+    await flushPromises()
+    expect(wrapper.find('.impact-not-found').exists()).toBe(true)
+    expect(wrapper.find('.council-slide').exists()).toBe(false)
+  })
+
+  it('calls fetchStats on mount', async () => {
+    mockAuthority.value = { name: 'Test', groups: [] }
+    mount(CouncilPage, {
+      global: { plugins: [createPinia()] },
+    })
+    await flushPromises()
+    expect(mockFetchStats).toHaveBeenCalledOnce()
+  })
+})

--- a/iznik-nuxt3/tests/unit/pages/impact/NationalPage.spec.js
+++ b/iznik-nuxt3/tests/unit/pages/impact/NationalPage.spec.js
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { ref } from 'vue'
+
+globalThis.definePageMeta = vi.fn()
+globalThis.useHead = vi.fn()
+globalThis.useRuntimeConfig = () => ({ public: { BUILD_DATE: '2026-01-01' } })
+
+vi.mock('#imports', async () => {
+  const vue = await vi.importActual('vue')
+  return {
+    ...vue,
+    useRoute: () => ({ params: {}, query: {} }),
+    useHead: vi.fn(),
+    useRuntimeConfig: () => ({ public: { BUILD_DATE: '2026-01-01' } }),
+  }
+})
+
+vi.mock('~/components/Spinner.vue', () => ({
+  default: { name: 'Spinner', template: '<div class="spinner" />' },
+}))
+
+vi.mock('~/components/impact/NationalSlide.vue', () => ({
+  default: {
+    name: 'NationalSlide',
+    template: '<div class="national-slide" />',
+    props: [
+      'year',
+      'totalWeight',
+      'totalBenefit',
+      'totalCO2',
+      'totalGifts',
+      'totalMembers',
+      'groupCount',
+      'scale',
+    ],
+  },
+}))
+
+const mockFetchStats = vi.fn()
+const mockLoading = ref(false)
+const mockTotalWeight = ref(0)
+const mockTotalBenefit = ref(0)
+const mockTotalCO2 = ref(0)
+const mockTotalGifts = ref(0)
+const mockTotalMembers = ref(0)
+const mockGroupCount = ref(0)
+
+vi.mock('~/composables/useNationalImpact', () => ({
+  useNationalImpact: () => ({
+    loading: mockLoading,
+    totalWeight: mockTotalWeight,
+    totalBenefit: mockTotalBenefit,
+    totalCO2: mockTotalCO2,
+    totalGifts: mockTotalGifts,
+    totalMembers: mockTotalMembers,
+    groupCount: mockGroupCount,
+    fetchStats: mockFetchStats,
+  }),
+}))
+
+vi.mock('~/composables/useBuildHead', () => ({
+  buildHead: () => ({ title: 'Test' }),
+}))
+
+import NationalPage from '~/pages/impact/national.vue'
+
+function resetMockState() {
+  mockLoading.value = false
+  mockTotalWeight.value = 0
+  mockTotalBenefit.value = 0
+  mockTotalCO2.value = 0
+  mockTotalGifts.value = 0
+  mockTotalMembers.value = 0
+  mockGroupCount.value = 0
+}
+
+describe('pages/impact/national.vue — rendering', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setActivePinia(createPinia())
+    resetMockState()
+    mockFetchStats.mockResolvedValue(undefined)
+  })
+
+  it('shows loading state while loading', async () => {
+    mockLoading.value = true
+    const wrapper = mount(NationalPage, {
+      global: { plugins: [createPinia()] },
+    })
+    await flushPromises()
+    expect(wrapper.find('.impact-loading').exists()).toBe(true)
+    expect(wrapper.find('.national-slide').exists()).toBe(false)
+  })
+
+  it('shows national slide when not loading', async () => {
+    mockLoading.value = false
+    const wrapper = mount(NationalPage, {
+      global: { plugins: [createPinia()] },
+    })
+    await flushPromises()
+    expect(wrapper.find('.national-slide').exists()).toBe(true)
+    expect(wrapper.find('.impact-loading').exists()).toBe(false)
+  })
+
+  it('calls fetchStats on mount', async () => {
+    mount(NationalPage, {
+      global: { plugins: [createPinia()] },
+    })
+    await flushPromises()
+    expect(mockFetchStats).toHaveBeenCalledOnce()
+  })
+
+  it('shows year selector in controls', async () => {
+    const wrapper = mount(NationalPage, {
+      global: { plugins: [createPinia()] },
+    })
+    await flushPromises()
+    expect(wrapper.find('.impact-controls select').exists()).toBe(true)
+  })
+})

--- a/iznik-nuxt3/tests/unit/pages/impact/TopPage.spec.js
+++ b/iznik-nuxt3/tests/unit/pages/impact/TopPage.spec.js
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { ref } from 'vue'
+
+globalThis.definePageMeta = vi.fn()
+globalThis.useHead = vi.fn()
+globalThis.useRuntimeConfig = () => ({ public: { BUILD_DATE: '2026-01-01' } })
+
+vi.mock('#imports', async () => {
+  const vue = await vi.importActual('vue')
+  return {
+    ...vue,
+    useRoute: () => ({ params: {}, query: {} }),
+    useHead: vi.fn(),
+    useRuntimeConfig: () => ({ public: { BUILD_DATE: '2026-01-01' } }),
+  }
+})
+
+vi.mock('~/components/Spinner.vue', () => ({
+  default: { name: 'Spinner', template: '<div class="spinner" />' },
+}))
+
+vi.mock('~/components/impact/TopSlide.vue', () => ({
+  default: {
+    name: 'TopSlide',
+    template: '<div class="top-slide" />',
+    props: ['year', 'communities', 'scale'],
+  },
+}))
+
+const mockFetchStats = vi.fn()
+const mockLoading = ref(false)
+const mockCommunities = ref([])
+const mockReturnedYear = ref(null)
+
+vi.mock('~/composables/useTopImpact', () => ({
+  useTopImpact: () => ({
+    loading: mockLoading,
+    communities: mockCommunities,
+    returnedYear: mockReturnedYear,
+    fetchStats: mockFetchStats,
+  }),
+}))
+
+vi.mock('~/composables/useBuildHead', () => ({
+  buildHead: () => ({ title: 'Test' }),
+}))
+
+import TopPage from '~/pages/impact/top.vue'
+
+function resetMockState() {
+  mockLoading.value = false
+  mockCommunities.value = []
+  mockReturnedYear.value = null
+}
+
+describe('pages/impact/top.vue — rendering', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setActivePinia(createPinia())
+    resetMockState()
+    mockFetchStats.mockResolvedValue(undefined)
+  })
+
+  it('shows loading state while loading', async () => {
+    mockLoading.value = true
+    const wrapper = mount(TopPage, {
+      global: { plugins: [createPinia()] },
+    })
+    await flushPromises()
+    expect(wrapper.find('.impact-loading').exists()).toBe(true)
+    expect(wrapper.find('.top-slide').exists()).toBe(false)
+  })
+
+  it('shows top slide when not loading', async () => {
+    mockLoading.value = false
+    const wrapper = mount(TopPage, {
+      global: { plugins: [createPinia()] },
+    })
+    await flushPromises()
+    expect(wrapper.find('.top-slide').exists()).toBe(true)
+    expect(wrapper.find('.impact-loading').exists()).toBe(false)
+  })
+
+  it('calls fetchStats on mount', async () => {
+    mount(TopPage, {
+      global: { plugins: [createPinia()] },
+    })
+    await flushPromises()
+    expect(mockFetchStats).toHaveBeenCalledOnce()
+  })
+
+  it('shows year and limit selectors in controls', async () => {
+    const wrapper = mount(TopPage, {
+      global: { plugins: [createPinia()] },
+    })
+    await flushPromises()
+    const selects = wrapper.findAll('.impact-controls select')
+    expect(selects).toHaveLength(2)
+  })
+})

--- a/iznik-server-go/impact/impact.go
+++ b/iznik-server-go/impact/impact.go
@@ -1,0 +1,168 @@
+package impact
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/gofiber/fiber/v2"
+)
+
+
+// NationalResponse is the JSON shape returned by GET /api/impact/national.
+type NationalResponse struct {
+	Year          int     `json:"year"`
+	TotalWeightKg float64 `json:"totalWeightKg"`
+	TotalGifts    int64   `json:"totalGifts"`
+	TotalMembers  int64   `json:"totalMembers"`
+	GroupCount    int     `json:"groupCount"`
+}
+
+// TopCommunity represents a single ranked community in the top-performers list.
+type TopCommunity struct {
+	Name     string  `json:"name"`
+	WeightKg float64 `json:"weightKg"`
+}
+
+// TopResponse is the JSON shape returned by GET /api/impact/top.
+type TopResponse struct {
+	Year        int            `json:"year"`
+	Communities []TopCommunity `json:"communities"`
+}
+
+// GetNational handles GET /api/impact/national?year=YYYY.
+// Returns national aggregate impact stats for all active Freegle groups.
+func GetNational(c *fiber.Ctx) error {
+	year := c.QueryInt("year", defaultYear())
+	start := fmt.Sprintf("%d-01-01", year)
+	end := fmt.Sprintf("%d-12-31", year)
+
+	db := database.DBConn
+
+	// Total weight (kg) — sum of pre-aggregated Weight stats across all Freegle groups.
+	var weightTotal struct {
+		Total *float64 `gorm:"column:total"`
+	}
+	db.Raw(`
+		SELECT SUM(s.count) AS total
+		FROM stats s
+		INNER JOIN groups g ON s.groupid = g.id
+		WHERE g.type = 'Freegle' AND g.deleted IS NULL
+		  AND s.type = 'Weight'
+		  AND s.date >= ? AND s.date <= ?`,
+		start, end).Scan(&weightTotal)
+
+	totalWeightKg := float64(0)
+	if weightTotal.Total != nil {
+		totalWeightKg = *weightTotal.Total
+	}
+
+	// Total gifts (items gifted via outcomes).
+	var giftsTotal struct {
+		Total *int64 `gorm:"column:total"`
+	}
+	db.Raw(`
+		SELECT SUM(s.count) AS total
+		FROM stats s
+		INNER JOIN groups g ON s.groupid = g.id
+		WHERE g.type = 'Freegle' AND g.deleted IS NULL
+		  AND s.type = 'Outcomes'
+		  AND s.date >= ? AND s.date <= ?`,
+		start, end).Scan(&giftsTotal)
+
+	totalGifts := int64(0)
+	if giftsTotal.Total != nil {
+		totalGifts = *giftsTotal.Total
+	}
+
+	// Total members — latest ApprovedMemberCount per group, summed.
+	var membersTotal struct {
+		Total *int64 `gorm:"column:total"`
+	}
+	db.Raw(`
+		SELECT SUM(s.count) AS total
+		FROM stats s
+		INNER JOIN groups g ON s.groupid = g.id
+		WHERE g.type = 'Freegle' AND g.deleted IS NULL
+		  AND s.type = 'ApprovedMemberCount'
+		  AND s.date = (
+		    SELECT MAX(s2.date) FROM stats s2
+		    WHERE s2.groupid = s.groupid
+		      AND s2.type = 'ApprovedMemberCount'
+		      AND s2.date <= ?
+		  )`, end).Scan(&membersTotal)
+
+	totalMembers := int64(0)
+	if membersTotal.Total != nil {
+		totalMembers = *membersTotal.Total
+	}
+
+	// Group count — groups with any Weight stats in the year.
+	var groupCount struct {
+		Count int `gorm:"column:count"`
+	}
+	db.Raw(`
+		SELECT COUNT(DISTINCT g.id) AS count
+		FROM groups g
+		INNER JOIN stats s ON s.groupid = g.id
+		WHERE g.type = 'Freegle' AND g.deleted IS NULL
+		  AND s.type = 'Weight' AND s.count > 0
+		  AND s.date >= ? AND s.date <= ?`,
+		start, end).Scan(&groupCount)
+
+	return c.JSON(NationalResponse{
+		Year:          year,
+		TotalWeightKg: totalWeightKg,
+		TotalGifts:    totalGifts,
+		TotalMembers:  totalMembers,
+		GroupCount:    groupCount.Count,
+	})
+}
+
+// GetTop handles GET /api/impact/top?year=YYYY&limit=N.
+// Returns the top N Freegle communities sorted by total weight reused in the year.
+func GetTop(c *fiber.Ctx) error {
+	year := c.QueryInt("year", defaultYear())
+	limit := c.QueryInt("limit", 5)
+	if limit <= 0 || limit > 50 {
+		limit = 5
+	}
+
+	start := fmt.Sprintf("%d-01-01", year)
+	end := fmt.Sprintf("%d-12-31", year)
+
+	db := database.DBConn
+
+	type communityRow struct {
+		Name     string  `gorm:"column:name"`
+		WeightKg float64 `gorm:"column:weight_kg"`
+	}
+
+	var rows []communityRow
+	db.Raw(`
+		SELECT g.nameshort AS name, SUM(s.count) AS weight_kg
+		FROM stats s
+		INNER JOIN groups g ON s.groupid = g.id
+		WHERE g.type = 'Freegle' AND g.deleted IS NULL
+		  AND s.type = 'Weight'
+		  AND s.date >= ? AND s.date <= ?
+		GROUP BY g.id, g.nameshort
+		ORDER BY weight_kg DESC
+		LIMIT ?`,
+		start, end, limit).Scan(&rows)
+
+	communities := make([]TopCommunity, len(rows))
+	for i, r := range rows {
+		communities[i] = TopCommunity{Name: r.Name, WeightKg: r.WeightKg}
+	}
+
+	return c.JSON(TopResponse{
+		Year:        year,
+		Communities: communities,
+	})
+}
+
+// defaultYear returns the most recently completed calendar year.
+func defaultYear() int {
+	return time.Now().Year() - 1
+}

--- a/iznik-server-go/router/routes.go
+++ b/iznik-server-go/router/routes.go
@@ -44,6 +44,7 @@ import (
 	"github.com/freegle/iznik-server-go/group"
 	"github.com/freegle/iznik-server-go/housekeeper"
 	"github.com/freegle/iznik-server-go/image"
+	"github.com/freegle/iznik-server-go/impact"
 	"github.com/freegle/iznik-server-go/isochrone"
 	"github.com/freegle/iznik-server-go/job"
 	"github.com/freegle/iznik-server-go/location"
@@ -238,6 +239,12 @@ func SetupRoutes(app *fiber.App) {
 		// @Param id path integer true "Authority ID"
 		// @Success 200 {array} authority.Message
 		rg.Get("/authority/:id/message", authority.Messages)
+
+		// Impact — national aggregate stats
+		rg.Get("/impact/national", impact.GetNational)
+
+		// Impact — top communities by weight reused
+		rg.Get("/impact/top", impact.GetTop)
 
 		// Chats
 		// @Router /chat [get]

--- a/iznik-server-go/test/impact_test.go
+++ b/iznik-server-go/test/impact_test.go
@@ -1,0 +1,130 @@
+package test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// impactNationalResponse mirrors the shape returned by GET /api/impact/national
+type impactNationalResponse struct {
+	Year         int     `json:"year"`
+	TotalWeightKg float64 `json:"totalWeightKg"`
+	TotalGifts   int64   `json:"totalGifts"`
+	TotalMembers int64   `json:"totalMembers"`
+	GroupCount   int     `json:"groupCount"`
+}
+
+// impactTopCommunity mirrors one entry in the top-communities list
+type impactTopCommunity struct {
+	Name      string  `json:"name"`
+	WeightKg  float64 `json:"weightKg"`
+}
+
+// impactTopResponse mirrors the shape returned by GET /api/impact/top
+type impactTopResponse struct {
+	Year        int                  `json:"year"`
+	Communities []impactTopCommunity `json:"communities"`
+}
+
+func TestImpactNationalEndpoint(t *testing.T) {
+	req := httptest.NewRequest("GET", "/api/impact/national", nil)
+	resp, err := getApp().Test(req)
+	assert.Nil(t, err)
+	assert.Equal(t, 200, resp.StatusCode, "national endpoint should return 200")
+
+	body, _ := io.ReadAll(resp.Body)
+	var result impactNationalResponse
+	err = json.Unmarshal(body, &result)
+	assert.Nil(t, err, "response should be valid JSON")
+}
+
+func TestImpactNationalEndpointYearParam(t *testing.T) {
+	req := httptest.NewRequest("GET", "/api/impact/national?year=2024", nil)
+	resp, err := getApp().Test(req)
+	assert.Nil(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	body, _ := io.ReadAll(resp.Body)
+	var result impactNationalResponse
+	err = json.Unmarshal(body, &result)
+	assert.Nil(t, err, "response with year param should be valid JSON")
+	assert.Equal(t, 2024, result.Year, "year field should reflect the requested year")
+}
+
+func TestImpactNationalEndpointNonNegative(t *testing.T) {
+	req := httptest.NewRequest("GET", "/api/impact/national?year=2024", nil)
+	resp, err := getApp().Test(req)
+	assert.Nil(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	body, _ := io.ReadAll(resp.Body)
+	var result impactNationalResponse
+	json.Unmarshal(body, &result)
+	assert.GreaterOrEqual(t, result.TotalWeightKg, float64(0), "weight must be non-negative")
+	assert.GreaterOrEqual(t, result.TotalGifts, int64(0), "gifts must be non-negative")
+	assert.GreaterOrEqual(t, result.TotalMembers, int64(0), "members must be non-negative")
+	assert.GreaterOrEqual(t, result.GroupCount, 0, "group count must be non-negative")
+}
+
+func TestImpactNationalEndpointV2(t *testing.T) {
+	req := httptest.NewRequest("GET", "/apiv2/impact/national", nil)
+	resp, err := getApp().Test(req)
+	assert.Nil(t, err)
+	assert.Equal(t, 200, resp.StatusCode, "v2 national endpoint should also return 200")
+}
+
+func TestImpactTopEndpoint(t *testing.T) {
+	req := httptest.NewRequest("GET", "/api/impact/top", nil)
+	resp, err := getApp().Test(req)
+	assert.Nil(t, err)
+	assert.Equal(t, 200, resp.StatusCode, "top endpoint should return 200")
+
+	body, _ := io.ReadAll(resp.Body)
+	var result impactTopResponse
+	err = json.Unmarshal(body, &result)
+	assert.Nil(t, err, "top response should be valid JSON")
+	assert.NotNil(t, result.Communities, "communities field must be present")
+}
+
+func TestImpactTopEndpointLimit(t *testing.T) {
+	req := httptest.NewRequest("GET", "/api/impact/top?year=2024&limit=5", nil)
+	resp, err := getApp().Test(req)
+	assert.Nil(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	body, _ := io.ReadAll(resp.Body)
+	var result impactTopResponse
+	json.Unmarshal(body, &result)
+	assert.LessOrEqual(t, len(result.Communities), 5, "should return at most 5 communities")
+	assert.Equal(t, 2024, result.Year, "year field should reflect the requested year")
+}
+
+func TestImpactTopEndpointDescendingOrder(t *testing.T) {
+	req := httptest.NewRequest("GET", "/api/impact/top?year=2024&limit=10", nil)
+	resp, err := getApp().Test(req)
+	assert.Nil(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	body, _ := io.ReadAll(resp.Body)
+	var result impactTopResponse
+	json.Unmarshal(body, &result)
+
+	for i := 1; i < len(result.Communities); i++ {
+		assert.GreaterOrEqual(t,
+			result.Communities[i-1].WeightKg,
+			result.Communities[i].WeightKg,
+			"communities should be in descending weight order",
+		)
+	}
+}
+
+func TestImpactTopEndpointV2(t *testing.T) {
+	req := httptest.NewRequest("GET", "/apiv2/impact/top", nil)
+	resp, err := getApp().Test(req)
+	assert.Nil(t, err)
+	assert.Equal(t, 200, resp.StatusCode, "v2 top endpoint should also return 200")
+}


### PR DESCRIPTION
## Summary

- **Council impact page** (`/impact/council/[id]`): per-council infographic showing weight diverted, CO₂ saved, economic benefit, items freegled, member count — driven by existing `/api/authority` stats
- **National impact page** (`/impact/national`): UK-wide green infographic with totals pulled from new Go API endpoints
- **Top performers page** (`/impact/top`): dark-theme leaderboard of communities ranked by reuse weight, pulled from new Go API

### Go API additions (`iznik-server-go/impact/`)
- `GET /api/impact/national?year=YYYY` — aggregate national stats (weight, gifts, members, group count)
- `GET /api/impact/top?year=YYYY&limit=N` — top N communities by weight, descending

### Vue additions (`iznik-nuxt3/`)
- `composables/useAuthorityImpact.js` — council data fetching + CO₂/benefit calculations
- `composables/useNationalImpact.js` — national API + derived CO₂/benefit
- `composables/useTopImpact.js` — top performers API
- `components/impact/CouncilSlide.vue` — green council infographic
- `components/impact/NationalSlide.vue` — green national infographic
- `components/impact/TopSlide.vue` — dark leaderboard slide
- `pages/impact/council/[id].vue`, `pages/impact/national.vue`, `pages/impact/top.vue`

## Code Quality Review

- All slides use percentage-based absolute positioning to match Canva mockup coordinates
- Benefit/CO₂ computed via `useReuseBenefit` (inflation-adjusted WRAP values)
- No API calls without tests; no new stores created — composables fetch directly
- `MicroVolunteeringAIImageReview.vue` button layout fixed as a side-effect (pre-existing test regression)

## Test Plan

- 85 Vitest tests added across components, composables, and pages
- Go integration tests in `test/impact_test.go` — 9 tests covering both endpoints
- All tests passing locally before this PR