### PR TITLE
feat(batch): migrate check_cgas, visualise, tn_sync + dry-run improvements

### DIFF
--- a/.circleci/orb/freegle-tests.yml
+++ b/.circleci/orb/freegle-tests.yml
@@ -275,7 +275,7 @@ commands:
             for attempt in $(seq 1 $MAX_RETRIES); do
               echo "Build attempt $attempt of $MAX_RETRIES..."
 
-              # Self-hosted runner has persistent Docker layer cache — use it
+              # Self-hosted runner has persistent Docker layer cache — use it for most containers
               CACHE_FLAG="--no-cache"
               if [ "${SELF_HOSTED_RUNNER:-}" = "true" ]; then
                 CACHE_FLAG=""
@@ -285,7 +285,7 @@ commands:
               if docker-compose build $CACHE_FLAG \
                 apiv1 apiv1-phpunit apiv2 \
                 freegle-prod-local modtools-prod-local \
-                playwright status batch; then
+                playwright status; then
                 echo "✅ Build succeeded on attempt $attempt"
                 break
               else
@@ -301,6 +301,17 @@ commands:
                 fi
               fi
             done
+
+            # Build batch with legacy builder to avoid BuildKit WSL2 build context bug
+            # where stale COPY . . layers persist between branches (same bug as status-nuxt).
+            # Legacy builder correctly detects context changes and invalidates the cache.
+            echo "Building batch container..."
+            if [ "${SELF_HOSTED_RUNNER:-}" = "true" ]; then
+              echo "Self-hosted runner: building batch with legacy builder (avoids BuildKit context bug)"
+              DOCKER_BUILDKIT=0 COMPOSE_DOCKER_CLI_BUILD=0 docker-compose build batch 2>&1
+            else
+              docker-compose build --no-cache batch 2>&1
+            fi
 
             # Two-phase startup: databases must exist before application containers start.
             #

--- a/iznik-batch/.dockerignore
+++ b/iznik-batch/.dockerignore
@@ -3,3 +3,4 @@ storage/spool/*
 storage/incoming-archive/*
 node_modules
 .git
+vendor

--- a/iznik-batch/MIGRATION-STATUS.md
+++ b/iznik-batch/MIGRATION-STATUS.md
@@ -268,7 +268,7 @@ These original scripts need to be migrated to Laravel artisan commands:
 | ~~`visualise.php`~~ | ~~Every 5 min~~ | ~~Low~~ | ~~Data visualisation~~ — **Migrated: `messages:update-visualise`** |
 | ~~`microvolunteering.php`~~ | ~~Every 5 min~~ | ~~Low~~ | ~~Micro-volunteering~~ — **Migrated: `microvolunteering:score`** |
 | ~~`newsfeed_link_previews.php`~~ | ~~Every 1 min~~ | ~~Low~~ | ~~Newsfeed link previews~~ — **Covered: `newsfeed:generate-link-previews` (PR #405)** |
-| `tn_sync.php` | Every 1 min | Medium | Trash Nothing sync |
+| ~~`tn_sync.php`~~ | ~~Every 1 min~~ | ~~Medium~~ | ~~Trash Nothing sync~~ — **Migrated: `integrations:sync-trashnothing`** |
 
 ## Medium Frequency Scripts (Every 10-60 min) - Not Started
 

--- a/iznik-batch/MIGRATION-STATUS.md
+++ b/iznik-batch/MIGRATION-STATUS.md
@@ -323,8 +323,8 @@ These original scripts need to be migrated to Laravel artisan commands:
 | ~~`facebook_chaseup.php`~~ | ~~18:00~~ | ~~Low~~ | ~~Facebook chase-up~~ — **Skip: file not found (retired)** |
 | `whatjobs.php` | Hourly 08:00-22:00 | Low | WhatJobs |
 | ~~`microactions_score.php`~~ | ~~23:00~~ | ~~Low~~ | ~~Microactions scoring~~ — **Covered: `microvolunteering:score`** |
-| `restartproject.php` | 23:00 | Low | Restart project |
-| `repaircafewales.php` | 23:00 | Low | Repair Cafe Wales |
+| ~~`restartproject.php`~~ | ~~23:00~~ | ~~Low~~ | ~~Restart project~~ — **Migrated: `integrations:sync-restartproject` (PR #408)** |
+| ~~`repaircafewales.php`~~ | ~~23:00~~ | ~~Low~~ | ~~Repair Cafe Wales~~ — **Migrated: `integrations:sync-repaircafewales` (PR #408)** |
 | ~~`archive_attachments.php`~~ | ~~22:30~~ | ~~Low~~ | ~~Attachment archiving~~ — **Migrated: `cleanup:archive-profile-images` (PR #405)** |
 
 ## Weekly Scripts - Not Started

--- a/iznik-batch/MIGRATION-STATUS.md
+++ b/iznik-batch/MIGRATION-STATUS.md
@@ -256,8 +256,8 @@ These original scripts need to be migrated to Laravel artisan commands:
 | ~~`lovejunk.php`~~ | ~~Every 1 min~~ | ~~Medium~~ | ~~LoveJunk integration~~ — **Migrated: `integrations:sync-lovejunk`** |
 | ~~`exports.php`~~ | ~~Every 1 min~~ | ~~Low~~ | ~~Data exports~~ — **Migrated: `users:process-exports`** |
 | ~~`notification_chaseup.php`~~ | ~~Every 5 min~~ | ~~Medium~~ | ~~Notification reminders~~ — **Migrated: `mail:notifications:chaseup`** |
-| `previews.php` | Every 5 min | Medium | Link preview generation |
-| `check_cgas.php` | Every 5 min | Low | CGA checking |
+| ~~`previews.php`~~ | ~~Every 5 min~~ | ~~Medium~~ | ~~Link preview generation~~ — **Covered: `newsfeed:generate-link-previews`** |
+| ~~`check_cgas.php`~~ | ~~Every 5 min~~ | ~~Low~~ | ~~CGA checking~~ — **Migrated: `groups:check-boundaries`** |
 | ~~`message_spatial.php`~~ | ~~Every 5 min~~ | ~~Medium~~ | ~~Spatial index updates~~ — **Migrated: `messages:update-spatial-index` — PR #398** |
 | ~~`messages_illustrations.php`~~ | ~~Every 1 min~~ | ~~Medium~~ | ~~Message illustrations~~ — **Migrated: `messages:generate-illustrations`** |
 | ~~`messages_remap.php`~~ | ~~Every 5 min~~ | ~~Low~~ | ~~Message remapping~~ — **Migrated: `messages:remap-subjects`** |
@@ -265,9 +265,9 @@ These original scripts need to be migrated to Laravel artisan commands:
 | ~~`chat_spam.php`~~ | ~~Every 5 min~~ | ~~Medium~~ | ~~Chat spam detection~~ — **Migrated: `chats:process-spam` — PR #397** |
 | ~~`check_spammers.php`~~ | ~~Every 5 min~~ | ~~Medium~~ | ~~Spam detection~~ — **Migrated: `users:remove-spammers` — PR #395** |
 | ~~`users_modmails.php`~~ | ~~Every 5 min~~ | ~~Medium~~ | ~~Mod mail processing~~ — **Migrated: `users:update-modmails` — PR #392** |
-| `visualise.php` | Every 5 min | Low | Data visualisation |
-| `microvolunteering.php` | Every 5 min | Low | Micro-volunteering — **Migrated: `microvolunteering:score`** |
-| `newsfeed_link_previews.php` | Every 1 min | Low | Newsfeed link previews |
+| ~~`visualise.php`~~ | ~~Every 5 min~~ | ~~Low~~ | ~~Data visualisation~~ — **Migrated: `messages:update-visualise`** |
+| ~~`microvolunteering.php`~~ | ~~Every 5 min~~ | ~~Low~~ | ~~Micro-volunteering~~ — **Migrated: `microvolunteering:score`** |
+| ~~`newsfeed_link_previews.php`~~ | ~~Every 1 min~~ | ~~Low~~ | ~~Newsfeed link previews~~ — **Covered: `newsfeed:generate-link-previews` (PR #405)** |
 | `tn_sync.php` | Every 1 min | Medium | Trash Nothing sync |
 
 ## Medium Frequency Scripts (Every 10-60 min) - Not Started
@@ -282,7 +282,7 @@ These original scripts need to be migrated to Laravel artisan commands:
 | ~~`jobs_illustrations.php`~~ | ~~Every 30 min~~ | ~~Low~~ | ~~Job illustrations~~ — **Migrated: `jobs:generate-illustrations`** |
 | ~~`message_unindexed.php`~~ | ~~Every 30 min~~ | ~~Low~~ | ~~Unindexed messages~~ — **Migrated: `messages:update-index` — PR #393** |
 | ~~`chat_latestmessage.php`~~ | ~~Every 60 min~~ | ~~Low~~ | ~~Chat latest message~~ — **Migrated: `chats:update-counts`** |
-| `pledge.php` | Every 60 min | Low | Pledges |
+| ~~`pledge.php`~~ | ~~Every 60 min~~ | ~~Low~~ | ~~Pledges~~ — **Skip: retired** |
 | ~~`lastacces.php`~~ | ~~Every 59 min~~ | ~~Low~~ | ~~Last access tracking~~ — **Migrated: `users:update-lastaccess`** |
 | ~~`mod_notifs.php`~~ | ~~Every 60 min~~ | ~~Medium~~ | ~~Moderator notifications~~ — **Migrated: `mail:mod-notifs` — PR #391** |
 | ~~`supporttools.php`~~ | ~~Every 60 min~~ | ~~Low~~ | ~~Support tools~~ — **Migrated: `users:update-support-roles`** |
@@ -313,19 +313,19 @@ These original scripts need to be migrated to Laravel artisan commands:
 | ~~`purge_sessions.php`~~ | ~~03:00~~ | ~~Low~~ | ~~Session purging~~ — **Migrated: `purge:sessions`** |
 | ~~`purge_logs.php`~~ | ~~04:00~~ | ~~Low~~ | ~~Log purging~~ — **Migrated: `purge:logs`** |
 | ~~`email_validate.php`~~ | ~~04:00~~ | ~~Low~~ | ~~Email validation~~ — **Migrated: `emails:validate`** |
-| `messages_popular.php` | 05:00 | Low | Popular messages |
+| ~~`messages_popular.php`~~ | ~~05:00~~ | ~~Low~~ | ~~Popular messages~~ — **Skip: `Group::findPopularMessages()` not implemented in iznik-server** |
 | ~~`users_remap.php`~~ | ~~05:00~~ | ~~Low~~ | ~~User remapping~~ — **Migrated: `users:remap-locations`** |
 | ~~`locations_skewwhiff.php`~~ | ~~05:00~~ | ~~Low~~ | ~~Location fixes~~ — **Migrated: `locations:fix-skewed`** |
 | `nearby.php` | 14:05 | Medium | Nearby items |
 | `chat_review.php` | 11:00 | Medium | Chat review queue |
 | `engage.php` | 16:00 | Medium | User engagement emails |
 | `user_askdonation.php` | 17:00 | Medium | Donation requests |
-| `facebook_chaseup.php` | 18:00 | Low | Facebook chase-up |
+| ~~`facebook_chaseup.php`~~ | ~~18:00~~ | ~~Low~~ | ~~Facebook chase-up~~ — **Skip: file not found (retired)** |
 | `whatjobs.php` | Hourly 08:00-22:00 | Low | WhatJobs |
-| `microactions_score.php` | 23:00 | Low | Microactions scoring |
+| ~~`microactions_score.php`~~ | ~~23:00~~ | ~~Low~~ | ~~Microactions scoring~~ — **Covered: `microvolunteering:score`** |
 | `restartproject.php` | 23:00 | Low | Restart project |
 | `repaircafewales.php` | 23:00 | Low | Repair Cafe Wales |
-| `archive_attachments.php` | 22:30 | Low | Attachment archiving |
+| ~~`archive_attachments.php`~~ | ~~22:30~~ | ~~Low~~ | ~~Attachment archiving~~ — **Migrated: `cleanup:archive-profile-images` (PR #405)** |
 
 ## Weekly Scripts - Not Started
 

--- a/iznik-batch/app/Console/Commands/Group/CheckBoundariesCommand.php
+++ b/iznik-batch/app/Console/Commands/Group/CheckBoundariesCommand.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Console\Commands\Group;
+
+use App\Services\GroupBoundaryService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+
+class CheckBoundariesCommand extends Command
+{
+    protected $signature = 'groups:check-boundaries
+                            {--dry-run : Report how many groups would be checked without running checks}';
+
+    protected $description = 'Validate spatial CGA/DPA boundary geometry for all Freegle groups';
+
+    public function handle(GroupBoundaryService $service): int
+    {
+        $dryRun = (bool) $this->option('dry-run');
+
+        if ($dryRun) {
+            $this->info('DRY RUN — no spatial checks will be executed.');
+        }
+
+        Log::info('Starting group boundary checks', ['dry_run' => $dryRun]);
+
+        $stats = $service->checkBoundaries($dryRun);
+
+        if ($dryRun) {
+            $this->info("[DRY RUN] Would check boundaries for {$stats['total']} group(s).");
+        } else {
+            $this->info("Checked {$stats['total']} group(s), {$stats['errors']} error(s) detected.");
+        }
+
+        Log::info('Group boundary check complete', $stats);
+
+        return Command::SUCCESS;
+    }
+}

--- a/iznik-batch/app/Console/Commands/Integrations/SyncRepairCafeWalesCommand.php
+++ b/iznik-batch/app/Console/Commands/Integrations/SyncRepairCafeWalesCommand.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Console\Commands\Integrations;
+
+use App\Services\RepairCafeWalesService;
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Cache\LockTimeoutException;
+use Illuminate\Support\Facades\Cache;
+
+class SyncRepairCafeWalesCommand extends Command
+{
+    protected $signature = 'integrations:sync-repaircafewales
+                            {--dry-run : Log what would change without writing to the database}';
+
+    protected $description = 'Sync upcoming Repair Cafe Wales events into community events';
+
+    public function handle(RepairCafeWalesService $service): int
+    {
+        $lock = Cache::lock('integrations:sync-repaircafewales', 3600);
+
+        try {
+            $lock->block(0);
+        } catch (LockTimeoutException) {
+            $this->warn('Another instance is already running.');
+            return Command::SUCCESS;
+        }
+
+        try {
+            $dryRun = (bool) $this->option('dry-run');
+            $result = $service->sync($dryRun);
+
+            $prefix = $dryRun ? '[DRY RUN] Would process' : 'Processed';
+            $this->info("{$prefix} {$result['added']} new event(s), {$result['updated']} updated, {$result['deleted']} deleted.");
+        } finally {
+            $lock->release();
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/iznik-batch/app/Console/Commands/Integrations/SyncRestartProjectCommand.php
+++ b/iznik-batch/app/Console/Commands/Integrations/SyncRestartProjectCommand.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Console\Commands\Integrations;
+
+use App\Services\RestartProjectService;
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Cache\LockTimeoutException;
+use Illuminate\Support\Facades\Cache;
+
+class SyncRestartProjectCommand extends Command
+{
+    protected $signature = 'integrations:sync-restartproject
+                            {--dry-run : Log what would change without writing to the database}';
+
+    protected $description = 'Sync upcoming Restart Project repair events into community events';
+
+    public function handle(RestartProjectService $service): int
+    {
+        $lock = Cache::lock('integrations:sync-restartproject', 3600);
+
+        try {
+            $lock->block(0);
+        } catch (LockTimeoutException) {
+            $this->warn('Another instance is already running.');
+            return Command::SUCCESS;
+        }
+
+        try {
+            $dryRun = (bool) $this->option('dry-run');
+            $result = $service->sync($dryRun);
+
+            $prefix = $dryRun ? '[DRY RUN] Would process' : 'Processed';
+            $this->info("{$prefix} {$result['added']} new event(s), {$result['updated']} updated, {$result['deleted']} deleted.");
+        } finally {
+            $lock->release();
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/iznik-batch/app/Console/Commands/Integrations/SyncTrashNothingCommand.php
+++ b/iznik-batch/app/Console/Commands/Integrations/SyncTrashNothingCommand.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Console\Commands\Integrations;
+
+use App\Console\Concerns\PreventsOverlapping;
+use App\Services\TnSyncService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+
+class SyncTrashNothingCommand extends Command
+{
+    use PreventsOverlapping;
+
+    protected $signature = 'integrations:sync-trashnothing
+                            {--dry-run : Log what would change without writing to the database}';
+
+    protected $description = 'Sync ratings and user changes from the TrashNothing API';
+
+    public function handle(TnSyncService $service): int
+    {
+        if (!$this->acquireLock()) {
+            $this->info('Already running, exiting.');
+            return Command::SUCCESS;
+        }
+
+        try {
+            $dryRun = (bool) $this->option('dry-run');
+
+            if ($dryRun) {
+                $this->info('DRY RUN — no database writes will be made.');
+            }
+
+            Log::info('TN sync command starting', ['dry_run' => $dryRun]);
+
+            $result = $service->sync($dryRun);
+
+            $prefix = $dryRun ? '[DRY RUN] Would process' : 'Processed';
+            $this->info("{$prefix} {$result['ratings']} rating(s), {$result['user_changes']} user change(s).");
+
+            Log::info('TN sync command complete', $result + ['dry_run' => $dryRun]);
+
+            return Command::SUCCESS;
+        } finally {
+            $this->releaseLock();
+        }
+    }
+}

--- a/iznik-batch/app/Console/Commands/Membership/ProcessMembershipsCommand.php
+++ b/iznik-batch/app/Console/Commands/Membership/ProcessMembershipsCommand.php
@@ -6,7 +6,6 @@ use App\Console\Concerns\PreventsOverlapping;
 use App\Services\MembershipsProcessingService;
 use App\Traits\GracefulShutdown;
 use Illuminate\Console\Command;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 
 class ProcessMembershipsCommand extends Command
@@ -15,7 +14,7 @@ class ProcessMembershipsCommand extends Command
     use GracefulShutdown;
 
     protected $signature = 'memberships:process
-                            {--dry-run : Show what would be processed without making changes}';
+                            {--dry-run : Log what would be processed without making changes}';
 
     protected $description = 'Process pending membership history entries: send per-group welcome emails, flag reviewed members';
 
@@ -27,20 +26,19 @@ class ProcessMembershipsCommand extends Command
         }
 
         try {
-            if ($this->option('dry-run')) {
-                $count = DB::table('memberships_history')
-                    ->where('processingrequired', 1)
-                    ->count();
-                $this->info("Dry run — {$count} entry/entries would be processed.");
-                return Command::SUCCESS;
+            $dryRun = (bool) $this->option('dry-run');
+
+            if ($dryRun) {
+                $this->info('DRY RUN — no emails will be sent or records updated.');
             }
 
-            Log::info('Starting membership processing');
+            Log::info('Starting membership processing', ['dry_run' => $dryRun]);
 
-            $count = $service->processAll();
+            $count = $service->processAll($dryRun);
 
-            $this->info("{$count} entry/entries processed");
-            Log::info('Membership processing complete', ['count' => $count]);
+            $prefix = $dryRun ? '[DRY RUN] Would process' : 'Processed';
+            $this->info("{$prefix} {$count} entry/entries.");
+            Log::info('Membership processing complete', ['count' => $count, 'dry_run' => $dryRun]);
 
             return Command::SUCCESS;
         } finally {

--- a/iznik-batch/app/Console/Commands/Message/UpdateVisualiseCommand.php
+++ b/iznik-batch/app/Console/Commands/Message/UpdateVisualiseCommand.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Console\Commands\Message;
+
+use App\Services\VisualiseService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+
+class UpdateVisualiseCommand extends Command
+{
+    protected $signature = 'messages:update-visualise
+                            {--ago=30 minutes ago : How far back to scan for taken messages}
+                            {--dry-run : Log what would be inserted without writing to the database}';
+
+    protected $description = 'Scan recent taken OFFER messages and insert visualisation flow records';
+
+    public function handle(VisualiseService $service): int
+    {
+        $dryRun = (bool) $this->option('dry-run');
+        $ago    = $this->option('ago');
+
+        if ($dryRun) {
+            $this->info('DRY RUN — no database writes will be made.');
+        }
+
+        Log::info('Starting visualise scan', ['ago' => $ago, 'dry_run' => $dryRun]);
+
+        $count = $service->scan($ago, $dryRun);
+
+        $prefix = $dryRun ? '[DRY RUN] Would insert' : 'Inserted';
+        $this->info("{$prefix} {$count} visualise record(s).");
+        Log::info('Visualise scan complete', ['count' => $count, 'dry_run' => $dryRun]);
+
+        return Command::SUCCESS;
+    }
+}

--- a/iznik-batch/app/Console/Commands/User/ProcessExportsCommand.php
+++ b/iznik-batch/app/Console/Commands/User/ProcessExportsCommand.php
@@ -14,7 +14,7 @@ class ProcessExportsCommand extends Command
     use GracefulShutdown;
 
     protected $signature = 'users:process-exports
-                            {--dry-run : Show what would be processed without making changes}';
+                            {--dry-run : Log what would be processed without making changes}';
 
     protected $description = 'Process pending GDPR data export requests and purge old completed export data';
 
@@ -26,20 +26,19 @@ class ProcessExportsCommand extends Command
         }
 
         try {
-            if ($this->option('dry-run')) {
-                $count = \Illuminate\Support\Facades\DB::table('users_exports')
-                    ->whereNull('completed')
-                    ->count();
-                $this->info("Dry run — {$count} export(s) would be processed.");
-                return Command::SUCCESS;
+            $dryRun = (bool) $this->option('dry-run');
+
+            if ($dryRun) {
+                $this->info('DRY RUN — no exports will be assembled or data written.');
             }
 
-            Log::info('Starting GDPR export processing');
+            Log::info('Starting GDPR export processing', ['dry_run' => $dryRun]);
 
-            $count = $service->processAll();
+            $count = $service->processAll($dryRun);
 
-            $this->info("{$count} export(s) processed");
-            Log::info('GDPR export processing complete', ['count' => $count]);
+            $prefix = $dryRun ? '[DRY RUN] Would process' : 'Processed';
+            $this->info("{$prefix} {$count} export(s).");
+            Log::info('GDPR export processing complete', ['count' => $count, 'dry_run' => $dryRun]);
 
             return Command::SUCCESS;
         } finally {

--- a/iznik-batch/app/Models/Location.php
+++ b/iznik-batch/app/Models/Location.php
@@ -53,4 +53,26 @@ class Location extends Model
 
         return null;
     }
+
+    public static function findByName(string $name): ?int
+    {
+        $canon = strtolower(preg_replace("/[^A-Za-z0-9]/", '', $name));
+        $loc = DB::table('locations')->where('canon', 'LIKE', $canon)->first();
+        return $loc?->id;
+    }
+
+    public static function groupsNear(float $lat, float $lng, int $radiusMiles = 50, int $limit = 10): array
+    {
+        $rows = DB::select(
+            "SELECT id
+             FROM `groups`
+             WHERE publish = 1 AND listable = 1
+               AND haversine(lat, lng, ?, ?) < ?
+             ORDER BY haversine(lat, lng, ?, ?) ASC
+             LIMIT ?",
+            [$lat, $lng, $radiusMiles, $lat, $lng, $limit]
+        );
+
+        return array_column($rows, 'id');
+    }
 }

--- a/iznik-batch/app/Models/Location.php
+++ b/iznik-batch/app/Models/Location.php
@@ -56,9 +56,13 @@ class Location extends Model
 
     public static function findByName(string $name): ?int
     {
+        return static::getByName($name)?->id;
+    }
+
+    public static function getByName(string $name): ?object
+    {
         $canon = strtolower(preg_replace("/[^A-Za-z0-9]/", '', $name));
-        $loc = DB::table('locations')->where('canon', 'LIKE', $canon)->first();
-        return $loc?->id;
+        return DB::table('locations')->where('canon', 'LIKE', $canon)->first();
     }
 
     public static function groupsNear(float $lat, float $lng, int $radiusMiles = 50, int $limit = 10): array

--- a/iznik-batch/app/Models/Location.php
+++ b/iznik-batch/app/Models/Location.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\DB;
 
 class Location extends Model
 {
@@ -17,4 +18,39 @@ class Location extends Model
         'osm_amenity' => 'boolean',
         'osm_shop' => 'boolean',
     ];
+
+    public static function closestPostcode(float $lat, float $lng): ?object
+    {
+        $srid = config('freegle.srid', 3857);
+        $scan = 0.00001953125;
+
+        do {
+            $swlat = $lat - $scan;
+            $nelat = $lat + $scan;
+            $swlng = $lng - $scan;
+            $nelng = $lng + $scan;
+
+            $poly = "POLYGON(($swlng $swlat, $swlng $nelat, $nelng $nelat, $nelng $swlat, $swlng $swlat))";
+
+            $locs = DB::select(
+                "SELECT locations.id, locations.name, locations.lat, locations.lng
+                 FROM locations_spatial
+                 INNER JOIN locations ON locations.id = locations_spatial.locationid
+                 WHERE MBRContains(ST_Envelope(ST_GeomFromText(?, ?)), locations_spatial.geometry)
+                   AND locations.type = 'Postcode'
+                   AND LOCATE(' ', locations.name) > 0
+                 ORDER BY ST_distance(locations_spatial.geometry, ST_GeomFromText(?, ?)) ASC
+                 LIMIT 1",
+                [$poly, $srid, "POINT($lng $lat)", $srid]
+            );
+
+            if (count($locs) === 1) {
+                return $locs[0];
+            }
+
+            $scan *= 2;
+        } while ($scan <= 0.2);
+
+        return null;
+    }
 }

--- a/iznik-batch/app/Services/CommunityEventService.php
+++ b/iznik-batch/app/Services/CommunityEventService.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\DB;
+
+class CommunityEventService
+{
+    public function findByExternalId(string $externalId): ?object
+    {
+        return DB::table('communityevents')->where('externalid', $externalId)->first();
+    }
+
+    public function createEvent(
+        ?int $userId,
+        string $title,
+        string $location,
+        ?string $contactName,
+        ?string $contactPhone,
+        ?string $contactEmail,
+        ?string $contactUrl,
+        ?string $description,
+        ?string $externalId = null
+    ): int {
+        DB::table('communityevents')->insert([
+            'userid'       => $userId,
+            'pending'      => 1,
+            'title'        => $title,
+            'location'     => $location,
+            'contactname'  => $contactName,
+            'contactphone' => $contactPhone,
+            'contactemail' => $contactEmail,
+            'contacturl'   => $contactUrl,
+            'description'  => $description,
+            'externalid'   => $externalId,
+        ]);
+
+        return (int) DB::getPdo()->lastInsertId();
+    }
+
+    public function updateEvent(int $id, array $attributes): void
+    {
+        DB::table('communityevents')->where('id', $id)->update($attributes);
+    }
+
+    public function addDate(int $eventId, string $start, string $end): void
+    {
+        if (strtotime($end) < strtotime($start)) {
+            $end = date('Y-m-d H:i:s', strtotime($start) + 3600);
+        }
+
+        DB::table('communityevents_dates')->insert([
+            'eventid' => $eventId,
+            'start'   => $start,
+            'end'     => $end,
+        ]);
+    }
+
+    public function removeDates(int $eventId): void
+    {
+        DB::table('communityevents_dates')->where('eventid', $eventId)->delete();
+    }
+
+    public function addGroup(int $eventId, int $groupId): void
+    {
+        DB::table('communityevents_groups')->insertOrIgnore([
+            'eventid' => $eventId,
+            'groupid' => $groupId,
+        ]);
+        // V1 also creates a Newsfeed entry and pushes notifications to group mods here,
+        // but events are pending=1 so they're not visible to users until a mod approves them.
+        // Those side effects are omitted; the mod will see the event in their pending queue.
+    }
+
+    public function markDeleted(int $eventId): void
+    {
+        DB::table('communityevents')->where('id', $eventId)->update(['deleted' => 1]);
+    }
+
+    public function getUpcomingByExternalIdPrefix(string $prefix, string $fromDate): array
+    {
+        return DB::table('communityevents')
+            ->join('communityevents_dates', 'communityevents.id', '=', 'communityevents_dates.eventid')
+            ->where('communityevents.externalid', 'LIKE', $prefix . '%')
+            ->where('communityevents_dates.start', '>=', $fromDate)
+            ->select('communityevents.id', 'communityevents.externalid')
+            ->get()
+            ->toArray();
+    }
+}

--- a/iznik-batch/app/Services/CommunityEventService.php
+++ b/iznik-batch/app/Services/CommunityEventService.php
@@ -87,4 +87,15 @@ class CommunityEventService
             ->get()
             ->toArray();
     }
+
+    public function getUpcomingByExternalIdSubstring(string $substring, string $fromDate): array
+    {
+        return DB::table('communityevents')
+            ->join('communityevents_dates', 'communityevents.id', '=', 'communityevents_dates.eventid')
+            ->where('communityevents.externalid', 'LIKE', '%' . $substring . '%')
+            ->where('communityevents_dates.start', '>=', $fromDate)
+            ->select('communityevents.id', 'communityevents.externalid')
+            ->get()
+            ->toArray();
+    }
 }

--- a/iznik-batch/app/Services/GroupBoundaryService.php
+++ b/iznik-batch/app/Services/GroupBoundaryService.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+class GroupBoundaryService
+{
+    public function checkBoundaries(bool $dryRun = false): array
+    {
+        $srid = config('freegle.srid', 3857);
+
+        $groups = DB::select(
+            "SELECT id, nameshort, poly FROM `groups` WHERE type = 'Freegle' AND publish = 1 AND onmap = 1"
+        );
+
+        $total = count($groups);
+        $errors = 0;
+
+        if ($dryRun) {
+            Log::info('Dry run: would check boundaries for groups', ['total' => $total]);
+            return ['total' => $total, 'errors' => 0];
+        }
+
+        foreach ($groups as $group) {
+            try {
+                DB::select(
+                    "SELECT ST_Intersection(ST_GeomFromText(polyofficial, ?), COALESCE(simplified, polygon))
+                     FROM `groups`
+                     INNER JOIN `authorities` ON type = 'Freegle' AND publish = 1 AND onmap = 1
+                     WHERE authorities.id = 74579 AND groups.id = ?",
+                    [$srid, $group->id]
+                );
+
+                if ($group->poly) {
+                    DB::select(
+                        "SELECT ST_Intersection(ST_GeomFromText(poly, ?), COALESCE(simplified, polygon))
+                         FROM `groups`
+                         INNER JOIN `authorities` ON type = 'Freegle' AND publish = 1 AND onmap = 1
+                         WHERE authorities.id = 74579 AND groups.id = ?",
+                        [$srid, $group->id]
+                    );
+                }
+            } catch (\Throwable $e) {
+                Log::error("Invalid CGA/DPA boundary for group {$group->id} {$group->nameshort}", [
+                    'group_id'   => $group->id,
+                    'nameshort'  => $group->nameshort,
+                    'error'      => $e->getMessage(),
+                ]);
+                $errors++;
+            }
+        }
+
+        return ['total' => $total, 'errors' => $errors];
+    }
+}

--- a/iznik-batch/app/Services/MembershipsProcessingService.php
+++ b/iznik-batch/app/Services/MembershipsProcessingService.php
@@ -24,12 +24,7 @@ use Illuminate\Support\Facades\Mail;
  */
 class MembershipsProcessingService
 {
-    /**
-     * Process all pending membership history entries.
-     *
-     * @return int Number of entries processed.
-     */
-    public function processAll(): int
+    public function processAll(bool $dryRun = false): int
     {
         $entries = DB::table('memberships_history')
             ->where('processingrequired', 1)
@@ -39,64 +34,73 @@ class MembershipsProcessingService
         $count = 0;
 
         foreach ($entries as $entry) {
-            $this->processEntry($entry);
+            $this->processEntry($entry, $dryRun);
             $count++;
         }
 
-        Log::info("MembershipsProcessing: processed {$count} entries");
+        if ($dryRun) {
+            Log::info('MembershipsProcessing: dry run complete', ['would_process' => $count]);
+        } else {
+            Log::info("MembershipsProcessing: processed {$count} entries");
+        }
 
         return $count;
     }
 
-    private function processEntry(object $entry): void
+    private function processEntry(object $entry, bool $dryRun): void
     {
         $userId = $entry->userid;
         $groupId = $entry->groupid;
         $collection = $entry->collection;
 
-        // Send per-group welcome email for newly approved members on groups that have one.
         if ($collection === 'Approved') {
             $group = Group::find($groupId);
+            $hasWelcome = $group && $group->onhere && !empty($group->welcomemail);
+            $user = $hasWelcome ? User::find($userId) : null;
+            $wouldSendWelcome = $hasWelcome && $user && $user->email_preferred;
 
-            if ($group && $group->onhere && !empty($group->welcomemail)) {
-                $user = User::find($userId);
+            $flaggedCount = $this->countFlaggedComments($userId, $groupId);
 
-                if ($user && $user->email_preferred) {
-                    try {
-                        Mail::send(new GroupWelcomeMail($user, $group));
-                        Log::info("MembershipsProcessing: sent group welcome", [
-                            'user' => $userId,
-                            'group' => $groupId,
-                        ]);
-                    } catch (\Throwable $e) {
-                        Log::error("MembershipsProcessing: group welcome failed", [
-                            'user' => $userId,
-                            'group' => $groupId,
-                            'error' => $e->getMessage(),
-                        ]);
-                    }
+            if ($dryRun) {
+                Log::info('MembershipsProcessing: dry run entry', [
+                    'entry_id'           => $entry->id,
+                    'user'               => $userId,
+                    'group'              => $groupId,
+                    'would_send_welcome' => $wouldSendWelcome,
+                    'would_flag_review'  => $flaggedCount > 0,
+                ]);
+                return;
+            }
+
+            if ($wouldSendWelcome) {
+                try {
+                    Mail::send(new GroupWelcomeMail($user, $group));
+                    Log::info("MembershipsProcessing: sent group welcome", [
+                        'user' => $userId,
+                        'group' => $groupId,
+                    ]);
+                } catch (\Throwable $e) {
+                    Log::error("MembershipsProcessing: group welcome failed", [
+                        'user' => $userId,
+                        'group' => $groupId,
+                        'error' => $e->getMessage(),
+                    ]);
                 }
             }
 
-            // Check for flagged mod comments not yet covered by a review.
-            // If found, flag the member for review on this group.
-            $this->checkFlaggedComments($userId, $groupId);
+            $this->applyFlaggedComments($userId, $groupId);
         }
 
-        DB::table('memberships_history')
-            ->where('id', $entry->id)
-            ->update(['processingrequired' => 0]);
+        if (!$dryRun) {
+            DB::table('memberships_history')
+                ->where('id', $entry->id)
+                ->update(['processingrequired' => 0]);
+        }
     }
 
-    /**
-     * Check if there are flagged comments about this user that post-date the last review.
-     * If so, flag the membership for review.
-     *
-     * Mirrors V1: User::processMembership() flagged-comment check.
-     */
-    private function checkFlaggedComments(int $userId, int $groupId): void
+    private function countFlaggedComments(int $userId, int $groupId): int
     {
-        $count = DB::table('users_comments as uc')
+        return DB::table('users_comments as uc')
             ->where('uc.userid', $userId)
             ->where('uc.flag', 1)
             ->whereNotExists(function ($q) use ($userId, $groupId) {
@@ -108,8 +112,11 @@ class MembershipsProcessingService
                     ->whereColumn('m.reviewedat', '>=', 'uc.date');
             })
             ->count();
+    }
 
-        if ($count > 0) {
+    private function applyFlaggedComments(int $userId, int $groupId): void
+    {
+        if ($this->countFlaggedComments($userId, $groupId) > 0) {
             DB::table('memberships')
                 ->where('userid', $userId)
                 ->where('groupid', $groupId)

--- a/iznik-batch/app/Services/RepairCafeWalesService.php
+++ b/iznik-batch/app/Services/RepairCafeWalesService.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Location;
+use App\Models\Group;
+use ICal\ICal;
+use Illuminate\Support\Facades\Log;
+
+class RepairCafeWalesService
+{
+    private const DAYS_AHEAD = 31;
+    private const POSTCODE   = '/([Gg][Ii][Rr] 0[Aa]{2})|((([A-Za-z][0-9]{1,2})|(([A-Za-z][A-Ha-hJ-Yj-y][0-9]{1,2})|(([A-Za-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9][A-Za-z]?))))\s?[0-9][A-Za-z]{2})/mi';
+
+    public function __construct(private CommunityEventService $events) {}
+
+    protected function icalUrl(): string
+    {
+        return 'https://repaircafewales.org/events/list/?ical=1';
+    }
+
+    public function sync(bool $dryRun = false): array
+    {
+        $added         = 0;
+        $updated       = 0;
+        $deleted       = 0;
+        $now           = date('Y-m-d');
+        $rangeEnd      = date('Y-m-d 23:59:59', strtotime('+' . self::DAYS_AHEAD . ' days'));
+        $externalsSeen = [];
+
+        try {
+            $ical = new ICal(options: [
+                'defaultSpan'                 => 2,
+                'defaultTimeZone'             => 'UTC',
+                'disableCharacterReplacement' => false,
+                'filterDaysAfter'             => self::DAYS_AHEAD,
+                'filterDaysBefore'            => 0,
+                'skipRecurrence'              => false,
+            ]);
+            $ical->initUrl($this->icalUrl());
+        } catch (\Exception $e) {
+            Log::error('RepairCafeWales: failed to fetch iCal feed', ['error' => $e->getMessage()]);
+            return ['added' => $added, 'updated' => $updated, 'deleted' => $deleted];
+        }
+
+        $icalEvents = $ical->eventsFromRange($now . ' 00:00:00', $rangeEnd);
+
+        if (empty($icalEvents)) {
+            Log::warning('RepairCafeWales: no events in feed');
+        }
+
+        foreach ($icalEvents as $event) {
+            $externalId            = $event->uid;
+            $externalsSeen[$externalId] = true;
+
+            $title       = $event->summary ?? '';
+            $description = $event->description ?? '';
+            $location    = $event->location ?? '';
+            $url         = $event->url ?? null;
+
+            $start = $ical->iCalDateToDateTime($event->dtstart_array[3])->format('Y-m-d H:i:s');
+            $end   = $ical->iCalDateToDateTime($event->dtend_array[3])->format('Y-m-d H:i:s');
+
+            if (!preg_match(self::POSTCODE, $location, $matches)) {
+                Log::debug('RepairCafeWales: no postcode in location', ['location' => $location]);
+                continue;
+            }
+
+            $postcode = strtoupper(trim($matches[0]));
+            $locRow = Location::getByName($postcode);
+
+            if (!$locRow) {
+                Log::debug('RepairCafeWales: postcode not found', ['postcode' => $postcode]);
+                continue;
+            }
+
+            $groupIds = Location::groupsNear((float) $locRow->lat, (float) $locRow->lng, 15);
+
+            if (empty($groupIds)) {
+                Log::debug('RepairCafeWales: no groups near postcode', ['postcode' => $postcode]);
+                continue;
+            }
+
+            $freegleGroup = Group::find($groupIds[0]);
+            if (!$freegleGroup) {
+                continue;
+            }
+
+            if (!$freegleGroup->getSetting('communityevents', 1)) {
+                Log::debug('RepairCafeWales: communityevents disabled', ['group' => $freegleGroup->nameshort]);
+                continue;
+            }
+
+            $existing = $this->events->findByExternalId($externalId);
+
+            if ($existing) {
+                if ($dryRun) {
+                    Log::debug('RepairCafeWales: dry run — would update', ['external_id' => $externalId]);
+                    $updated++;
+                    continue;
+                }
+
+                $pendingFlag = $existing->title !== $title ||
+                               $existing->location !== $location ||
+                               $existing->description !== $description;
+
+                $updateData = [
+                    'title'       => $title,
+                    'location'    => $location,
+                    'description' => $description,
+                    'contacturl'  => $url,
+                ];
+
+                if ($pendingFlag && !$existing->pending) {
+                    $updateData['pending'] = 1;
+                }
+
+                $this->events->updateEvent($existing->id, $updateData);
+                $this->events->removeDates($existing->id);
+                $this->events->addDate($existing->id, $start, $end);
+                $updated++;
+            } else {
+                if ($dryRun) {
+                    Log::debug('RepairCafeWales: dry run — would create', ['external_id' => $externalId]);
+                    $added++;
+                    continue;
+                }
+
+                $eid = $this->events->createEvent(
+                    null,
+                    $title,
+                    $location,
+                    null,
+                    null,
+                    null,
+                    $url,
+                    $description,
+                    $externalId
+                );
+
+                $this->events->addGroup($eid, $groupIds[0]);
+                $this->events->addDate($eid, $start, $end);
+                $added++;
+            }
+        }
+
+        $existings = $this->events->getUpcomingByExternalIdSubstring('repaircafewales', $now);
+        foreach ($existings as $e) {
+            if (!array_key_exists($e->externalid, $externalsSeen)) {
+                if ($dryRun) {
+                    Log::debug('RepairCafeWales: dry run — would delete', ['external_id' => $e->externalid]);
+                    $deleted++;
+                    continue;
+                }
+                $this->events->markDeleted($e->id);
+                $deleted++;
+            }
+        }
+
+        return ['added' => $added, 'updated' => $updated, 'deleted' => $deleted];
+    }
+}

--- a/iznik-batch/app/Services/RestartProjectService.php
+++ b/iznik-batch/app/Services/RestartProjectService.php
@@ -1,0 +1,202 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Group;
+use App\Models\Location;
+use Html2Text\Html2Text;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+class RestartProjectService
+{
+    private const API_BASE     = 'https://restarters.net/api/v2';
+    private const NEARBY_MILES = 15;
+    private const DAYS_AHEAD   = 31;
+
+    public function __construct(private CommunityEventService $events) {}
+
+    public function sync(bool $dryRun = false): array
+    {
+        $added         = 0;
+        $updated       = 0;
+        $deleted       = 0;
+        $now           = date('Y-m-d');
+        $latest        = date('Y-m-d', strtotime('+' . self::DAYS_AHEAD . ' days'));
+        $externalsSeen = [];
+
+        $groups = $this->apiGet('/groups/names');
+
+        if ($groups === null) {
+            Log::error('Restart: failed to fetch groups list');
+            return ['added' => $added, 'updated' => $updated, 'deleted' => $deleted];
+        }
+
+        foreach ($groups as $group) {
+            if (str_contains($group['name'] ?? '', '[INACTIVE]')) {
+                continue;
+            }
+
+            $details = $this->apiGet("/groups/{$group['id']}");
+            if (!$details) {
+                continue;
+            }
+
+            if (($details['location']['country_code'] ?? '') !== 'GB') {
+                continue;
+            }
+
+            $lat = (float) ($details['location']['lat'] ?? 0);
+            $lng = (float) ($details['location']['lng'] ?? 0);
+            if (!$lat || !$lng) {
+                continue;
+            }
+
+            $groupIds = Location::groupsNear($lat, $lng, self::NEARBY_MILES);
+            if (empty($groupIds)) {
+                Log::debug('Restart: no Freegle groups near', ['group' => $group['name'], 'lat' => $lat, 'lng' => $lng]);
+                continue;
+            }
+
+            $freegleGroup = Group::find($groupIds[0]);
+            if (!$freegleGroup) {
+                continue;
+            }
+
+            if (!$freegleGroup->getSetting('communityevents', 1)) {
+                Log::debug('Restart: communityevents disabled', ['freegle_group' => $freegleGroup->nameshort]);
+                continue;
+            }
+
+            $events = $this->apiGet("/groups/{$group['id']}/events", [
+                'start' => $now,
+                'end'   => $latest,
+            ]);
+            if (!$events) {
+                continue;
+            }
+
+            foreach ($events as $event) {
+                if (!($event['approved'] ?? false)) {
+                    continue;
+                }
+
+                $eventDetails = $this->apiGet("/events/{$event['id']}");
+                if (!$eventDetails) {
+                    continue;
+                }
+
+                $externalId         = "Restart-{$event['id']}";
+                $externalsSeen[$externalId] = true;
+
+                $html        = new Html2Text($eventDetails['description'] ?? '');
+                $description = $html->getText();
+
+                $title = $event['title'];
+                if (!str_contains($title, 'Repair Cafe')) {
+                    $title = "Repair Cafe: $title";
+                }
+
+                $url      = $eventDetails['link'] ?? ($details['website'] ?? null);
+                $email    = $details['email'] ?? null;
+                $location = $event['location'] ?? '';
+
+                $existing = $this->events->findByExternalId($externalId);
+
+                if ($existing) {
+                    if ($dryRun) {
+                        Log::debug('Restart: dry run — would update event', ['external_id' => $externalId]);
+                        $updated++;
+                        continue;
+                    }
+
+                    $pendingFlag = $existing->title !== $title ||
+                                  $existing->location !== $location ||
+                                  $existing->description !== $description;
+
+                    $updateData = [
+                        'title'        => $title,
+                        'location'     => $location,
+                        'description'  => $description,
+                        'contacturl'   => $url,
+                        'contactemail' => $email,
+                    ];
+
+                    if ($pendingFlag && !$existing->pending) {
+                        $updateData['pending'] = 1;
+                    }
+
+                    $this->events->updateEvent($existing->id, $updateData);
+                    $this->events->removeDates($existing->id);
+                    $this->events->addDate($existing->id, $event['start'], $event['end']);
+                    $updated++;
+                } else {
+                    if ($dryRun) {
+                        Log::debug('Restart: dry run — would create event', ['external_id' => $externalId]);
+                        $added++;
+                        continue;
+                    }
+
+                    $contactName = $eventDetails['group']['name'] ?? null;
+
+                    $eid = $this->events->createEvent(
+                        null,
+                        $title,
+                        $location,
+                        $contactName,
+                        null,
+                        $email,
+                        $url,
+                        $description,
+                        $externalId
+                    );
+
+                    $this->events->addGroup($eid, $groupIds[0]);
+                    $this->events->addDate($eid, $event['start'], $event['end']);
+                    $added++;
+                }
+            }
+        }
+
+        $existings = $this->events->getUpcomingByExternalIdPrefix('Restart-', $now);
+        foreach ($existings as $e) {
+            if (!array_key_exists($e->externalid, $externalsSeen)) {
+                if ($dryRun) {
+                    Log::debug('Restart: dry run — would delete old event', ['external_id' => $e->externalid]);
+                    $deleted++;
+                    continue;
+                }
+                $this->events->markDeleted($e->id);
+                $deleted++;
+            }
+        }
+
+        return ['added' => $added, 'updated' => $updated, 'deleted' => $deleted];
+    }
+
+    private function apiGet(string $path, array $params = []): ?array
+    {
+        do {
+            $response  = Http::get(self::API_BASE . $path, $params);
+            $throttled = str_contains($response->body(), 'Too Many Requests');
+
+            if ($throttled) {
+                Log::warning('Restart: API throttled, retrying', ['path' => $path]);
+                sleep(5);
+            }
+        } while ($throttled);
+
+        if (!$response->successful()) {
+            Log::error('Restart: API error', ['path' => $path, 'status' => $response->status()]);
+            return null;
+        }
+
+        $data = $response->json('data');
+
+        if ($data === null) {
+            Log::warning('Restart: no data in response', ['path' => $path]);
+        }
+
+        return $data;
+    }
+}

--- a/iznik-batch/app/Services/TnSyncService.php
+++ b/iznik-batch/app/Services/TnSyncService.php
@@ -1,0 +1,255 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Location;
+use App\Models\User;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+class TnSyncService
+{
+    private const CACHE_KEY      = 'tn_sync_last_date';
+    private const PAGE_SIZE      = 100;
+    private const RATINGS_PATH   = '/fd/api/ratings';
+    private const CHANGES_PATH   = '/fd/api/user-changes';
+
+    private string $apiBase;
+    private string $apiKey;
+
+    public function __construct()
+    {
+        $this->apiBase = config('freegle.trashnothing.api_base', 'https://trashnothing.com');
+        $this->apiKey  = config('freegle.trashnothing.key', '');
+    }
+
+    public function sync(bool $dryRun = false): array
+    {
+        $from = $this->getFromDate();
+        $to   = date('c');
+
+        Log::info('TN sync starting', ['from' => $from, 'to' => $to, 'dry_run' => $dryRun]);
+
+        $ratings     = $this->syncRatings($from, $to, $dryRun);
+        $userChanges = $this->syncUserChanges($from, $to, $dryRun);
+
+        if (!$dryRun && ($ratings > 0 || $userChanges > 0)) {
+            Cache::forever(self::CACHE_KEY, $to);
+        }
+
+        return ['ratings' => $ratings, 'user_changes' => $userChanges];
+    }
+
+    private function getFromDate(): string
+    {
+        $cached = Cache::get(self::CACHE_KEY);
+        if ($cached) {
+            return $cached;
+        }
+
+        $latest = DB::table('ratings')
+            ->whereNotNull('tn_rating_id')
+            ->max('timestamp');
+
+        return $latest ? date('c', strtotime($latest)) : date('c', strtotime('30 days ago'));
+    }
+
+    private function syncRatings(string $from, string $to, bool $dryRun): int
+    {
+        $count = 0;
+        $page  = 1;
+
+        do {
+            $response = Http::get($this->apiBase . self::RATINGS_PATH, [
+                'key'      => $this->apiKey,
+                'page'     => $page,
+                'per_page' => self::PAGE_SIZE,
+                'date_min' => $from,
+                'date_max' => $to,
+            ]);
+
+            if (!$response->successful()) {
+                Log::error('TN sync: ratings API error', ['status' => $response->status()]);
+                break;
+            }
+
+            $ratings = $response->json('ratings', []);
+            $page++;
+
+            foreach ($ratings as $rating) {
+                if (!($rating['ratee_fd_user_id'] ?? null)) {
+                    continue;
+                }
+
+                $rateeId  = $rating['ratee_fd_user_id'];
+                $ratingId = $rating['rating_id'];
+
+                if (!User::find($rateeId)) {
+                    continue;
+                }
+
+                if ($dryRun) {
+                    Log::debug('TN sync: dry run — would sync rating', [
+                        'ratee'     => $rateeId,
+                        'rating_id' => $ratingId,
+                        'rating'    => $rating['rating'] ?? null,
+                    ]);
+                    $count++;
+                    continue;
+                }
+
+                try {
+                    if ($rating['rating'] ?? null) {
+                        DB::statement(
+                            "INSERT INTO ratings (ratee, rating, timestamp, visible, tn_rating_id)
+                             VALUES (?, ?, ?, 1, ?)
+                             ON DUPLICATE KEY UPDATE rating = ?, timestamp = ?",
+                            [
+                                $rateeId,
+                                $rating['rating'],
+                                $rating['date'],
+                                $ratingId,
+                                $rating['rating'],
+                                $rating['date'],
+                            ]
+                        );
+                    } else {
+                        DB::table('ratings')
+                            ->where('ratee', $rateeId)
+                            ->where('tn_rating_id', $ratingId)
+                            ->delete();
+                    }
+                    $count++;
+                } catch (\Throwable $e) {
+                    Log::error('TN sync: rating update failed', [
+                        'ratee'  => $rateeId,
+                        'rating' => $rating,
+                        'error'  => $e->getMessage(),
+                    ]);
+                }
+            }
+        } while (count($ratings) === self::PAGE_SIZE);
+
+        return $count;
+    }
+
+    private function syncUserChanges(string $from, string $to, bool $dryRun): int
+    {
+        $count = 0;
+        $page  = 1;
+
+        do {
+            $response = Http::get($this->apiBase . self::CHANGES_PATH, [
+                'key'      => $this->apiKey,
+                'page'     => $page,
+                'per_page' => self::PAGE_SIZE,
+                'date_min' => $from,
+                'date_max' => $to,
+            ]);
+
+            if (!$response->successful()) {
+                Log::error('TN sync: user-changes API error', ['status' => $response->status()]);
+                break;
+            }
+
+            $changes = $response->json('changes', []);
+            $page++;
+
+            foreach ($changes as $change) {
+                if (!($change['fd_user_id'] ?? null)) {
+                    continue;
+                }
+
+                $userId = $change['fd_user_id'];
+                $user   = User::find($userId);
+
+                if (!$user || !$user->isTN()) {
+                    continue;
+                }
+
+                if ($dryRun) {
+                    Log::debug('TN sync: dry run — would apply user change', [
+                        'user'           => $userId,
+                        'account_removed'=> isset($change['account_removed']),
+                        'has_reply_time' => isset($change['reply_time']),
+                        'has_about_me'   => isset($change['about_me']),
+                        'has_username'   => isset($change['username']),
+                        'has_location'   => isset($change['location']),
+                    ]);
+                    $count++;
+                    continue;
+                }
+
+                try {
+                    if (isset($change['account_removed'])) {
+                        Log::info('TN sync: account removed', ['user' => $userId]);
+                        app(UserManagementService::class)->forgetUser($userId, 'TN account removed');
+                        $count++;
+                        continue;
+                    }
+
+                    if (isset($change['reply_time'])) {
+                        DB::statement(
+                            "REPLACE INTO users_replytime (userid, replytime, timestamp) VALUES (?, ?, ?)",
+                            [$userId, $change['reply_time'], $change['date']]
+                        );
+                    }
+
+                    if (isset($change['about_me'])) {
+                        try {
+                            DB::statement(
+                                "REPLACE INTO users_aboutme (userid, timestamp, text) VALUES (?, ?, ?)",
+                                [$userId, $change['date'], $change['about_me']]
+                            );
+                        } catch (\Throwable $e) {
+                            Log::error('TN sync: about_me update failed', ['user' => $userId, 'error' => $e->getMessage()]);
+                        }
+                    }
+
+                    if (isset($change['username'])) {
+                        $oldName = User::removeTNGroup($user->fullname ?? '');
+                        if ($oldName !== $change['username']) {
+                            Log::info('TN sync: name change', ['user' => $userId, 'from' => $oldName, 'to' => $change['username']]);
+                            DB::table('users')->where('id', $userId)->update(['fullname' => $change['username']]);
+
+                            $this->renameTnEmails($userId, $oldName, $change['username']);
+                        }
+                    }
+
+                    if (isset($change['location']['latitude'], $change['location']['longitude'])) {
+                        $lat = (float) $change['location']['latitude'];
+                        $lng = (float) $change['location']['longitude'];
+
+                        $loc = Location::closestPostcode($lat, $lng);
+
+                        if ($loc && $loc->id !== $user->lastlocation) {
+                            Log::info('TN sync: location updated', ['user' => $userId, 'loc' => $loc->id, 'name' => $loc->name]);
+                            DB::table('users')->where('id', $userId)->update(['lastlocation' => $loc->id]);
+                        }
+                    }
+
+                    $count++;
+                } catch (\Throwable $e) {
+                    Log::error('TN sync: user change failed', ['user' => $userId, 'error' => $e->getMessage()]);
+                }
+            }
+        } while (count($changes) === self::PAGE_SIZE);
+
+        return $count;
+    }
+
+    private function renameTnEmails(int $userId, string $oldName, string $newName): void
+    {
+        $emails = DB::table('users_emails')->where('userid', $userId)->get();
+
+        foreach ($emails as $emailRow) {
+            if (str_contains($emailRow->email, "{$oldName}-")) {
+                $newEmail = str_replace("{$oldName}-", "{$newName}-", $emailRow->email);
+                Log::info('TN sync: rename email', ['user' => $userId, 'from' => $emailRow->email, 'to' => $newEmail]);
+                DB::table('users_emails')->where('id', $emailRow->id)->update(['email' => $newEmail]);
+            }
+        }
+    }
+}

--- a/iznik-batch/app/Services/UserDataExportService.php
+++ b/iznik-batch/app/Services/UserDataExportService.php
@@ -20,9 +20,11 @@ use Illuminate\Support\Facades\Log;
  */
 class UserDataExportService
 {
-    public function processAll(): int
+    public function processAll(bool $dryRun = false): int
     {
-        $this->purgeOldExportData();
+        if (!$dryRun) {
+            $this->purgeOldExportData();
+        }
 
         $exports = DB::table('users_exports')
             ->whereNull('completed')
@@ -32,6 +34,15 @@ class UserDataExportService
         $count = 0;
 
         foreach ($exports as $export) {
+            if ($dryRun) {
+                Log::info('UserDataExport: dry run — would process export', [
+                    'export_id' => $export->id,
+                    'userid'    => $export->userid,
+                ]);
+                $count++;
+                continue;
+            }
+
             try {
                 $this->processExport($export);
                 $count++;
@@ -43,7 +54,11 @@ class UserDataExportService
             }
         }
 
-        Log::info("UserDataExport: processed {$count} exports");
+        if ($dryRun) {
+            Log::info('UserDataExport: dry run complete', ['would_process' => $count]);
+        } else {
+            Log::info("UserDataExport: processed {$count} exports");
+        }
 
         return $count;
     }

--- a/iznik-batch/app/Services/VisualiseService.php
+++ b/iznik-batch/app/Services/VisualiseService.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Message;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+class VisualiseService
+{
+    private const MAX_DISTANCE_METRES = 30000;
+
+    public function scan(string $ago = '30 minutes ago', bool $dryRun = false): int
+    {
+        $since = date('Y-m-d H:i:s', strtotime($ago));
+
+        $rows = DB::select(
+            "SELECT DISTINCT messages.id, a.id AS attid, messages.fromuser, messages_by.userid AS touser,
+                    messages_by.timestamp
+             FROM messages
+             INNER JOIN messages_by ON messages.id = messages_by.msgid
+             INNER JOIN messages_attachments a ON messages.id = a.msgid
+             WHERE messages_by.timestamp > ? AND messages.type = ? AND messages_by.userid IS NOT NULL
+             ORDER BY messages_by.timestamp DESC",
+            [$since, Message::TYPE_OFFER]
+        );
+
+        $count = 0;
+
+        foreach ($rows as $row) {
+            $fromUser = User::find($row->fromuser);
+            $toUser   = User::find($row->touser);
+
+            if (!$fromUser || !$toUser) {
+                continue;
+            }
+
+            if (!$this->allowsProfile($fromUser) || !$this->allowsProfile($toUser)) {
+                continue;
+            }
+
+            [$flat, $flng] = $fromUser->getLatLng();
+            [$tlat, $tlng] = $toUser->getLatLng();
+
+            if (!$flat || !$flng || !$tlat || !$tlng) {
+                continue;
+            }
+
+            $metres = $this->distanceMetres($flat, $flng, $tlat, $tlng);
+
+            if ($metres >= self::MAX_DISTANCE_METRES) {
+                continue;
+            }
+
+            if ($dryRun) {
+                Log::debug('Visualise: dry run — would insert', [
+                    'msgid' => $row->id,
+                    'from' => $row->fromuser,
+                    'to' => $row->touser,
+                    'metres' => $metres,
+                ]);
+                $count++;
+                continue;
+            }
+
+            DB::statement(
+                "INSERT IGNORE INTO visualise (msgid, attid, timestamp, fromuser, touser, fromlat, fromlng, tolat, tolng, distance)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                [$row->id, $row->attid, $row->timestamp, $row->fromuser, $row->touser, $flat, $flng, $tlat, $tlng, $metres]
+            );
+
+            $count++;
+        }
+
+        return $count;
+    }
+
+    private function allowsProfile(User $user): bool
+    {
+        $settings = $user->settings;
+        if (is_array($settings) && array_key_exists('useprofile', $settings)) {
+            return (bool) $settings['useprofile'];
+        }
+        return true;
+    }
+
+    private function distanceMetres(float $lat1, float $lng1, float $lat2, float $lng2): int
+    {
+        $earthRadius = 6371000;
+        $dLat = deg2rad($lat2 - $lat1);
+        $dLng = deg2rad($lng2 - $lng1);
+        $a = sin($dLat / 2) ** 2
+            + cos(deg2rad($lat1)) * cos(deg2rad($lat2)) * sin($dLng / 2) ** 2;
+        return (int) round($earthRadius * 2 * asin(sqrt($a)));
+    }
+}

--- a/iznik-batch/composer.json
+++ b/iznik-batch/composer.json
@@ -8,6 +8,7 @@
     "require": {
         "php": "^8.2",
         "html2text/html2text": "^4.3",
+        "johngrogg/ics-parser": "^3.5",
         "kreait/firebase-php": "^8.1",
         "laravel/framework": "^12.0",
         "laravel/tinker": "^2.10.1",

--- a/iznik-batch/composer.lock
+++ b/iznik-batch/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1b39bea1a5012cfad713a394a322c0b7",
+    "content-hash": "34cdc3116bc48caca86aece85285931e",
     "packages": [
         {
             "name": "beste/clock",
@@ -2025,6 +2025,70 @@
                 "source": "https://github.com/Jean85/pretty-package-versions/tree/2.1.1"
             },
             "time": "2025-03-19T14:43:43+00:00"
+        },
+        {
+            "name": "johngrogg/ics-parser",
+            "version": "v3.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/u01jmg3/ics-parser.git",
+                "reference": "c622b4b29bce99ec63535ec6ad96c8cbea95abf2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/u01jmg3/ics-parser/zipball/c622b4b29bce99ec63535ec6ad96c8cbea95abf2",
+                "reference": "c622b4b29bce99ec63535ec6ad96c8cbea95abf2",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=5.6.40"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5|^9|^10"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "ICal": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jonathan Goode",
+                    "role": "Developer/Owner"
+                },
+                {
+                    "name": "John Grogg",
+                    "email": "john.grogg@gmail.com",
+                    "role": "Developer/Prior Owner"
+                }
+            ],
+            "description": "ICS Parser",
+            "homepage": "https://github.com/u01jmg3/ics-parser",
+            "keywords": [
+                "iCalendar",
+                "ical",
+                "ical-parser",
+                "ics",
+                "ics-parser",
+                "ifb"
+            ],
+            "support": {
+                "issues": "https://github.com/u01jmg3/ics-parser/issues",
+                "source": "https://github.com/u01jmg3/ics-parser/tree/v3.5.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/u01jmg3",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-01-23T13:01:48+00:00"
         },
         {
             "name": "kreait/firebase-php",

--- a/iznik-batch/config/freegle.php
+++ b/iznik-batch/config/freegle.php
@@ -311,4 +311,9 @@ return [
         'api' => env('LOVE_JUNK_API', 'https://elmer.api-lovejunk.com/elmer/v1'),
         'secret' => env('LOVE_JUNK_SECRET', ''),
     ],
+
+    'trashnothing' => [
+        'api_base' => env('TN_API_BASE', 'https://trashnothing.com'),
+        'key'      => env('TN_KEY', ''),
+    ],
 ];

--- a/iznik-batch/docker/Dockerfile
+++ b/iznik-batch/docker/Dockerfile
@@ -62,7 +62,7 @@ WORKDIR /var/www/html
 COPY . .
 
 # Install PHP dependencies including dev dependencies for testing
-RUN composer install --no-interaction --prefer-dist --optimize-autoloader || true
+RUN composer install --no-interaction --prefer-dist --optimize-autoloader
 
 # Create .env file from example for Laravel to find (testing uses phpunit.xml env vars)
 RUN cp .env.example .env || touch .env

--- a/iznik-batch/docker/entrypoint.sh
+++ b/iznik-batch/docker/entrypoint.sh
@@ -17,8 +17,17 @@ rm -f /var/www/html/bootstrap/cache/packages.php
 # (git clean -fd skips gitignored paths, and /vendor is gitignored). Running
 # composer install unconditionally is fast when nothing changed and ensures
 # newly added packages are always present.
+#
+# --no-scripts: skip composer event hooks (pre-package-uninstall, post-autoload-dump etc.)
+# The pre-package-uninstall hook boots the full Laravel application, which fails when the
+# CI runner's persistent workspace has a stale vendor/ with packages that need removing.
+# We handle cache clearing manually above and run package:discover explicitly below.
 echo "Installing/updating PHP dependencies..."
-composer install --no-interaction --prefer-dist --optimize-autoloader
+composer install --no-interaction --prefer-dist --optimize-autoloader --no-scripts
+
+# Run package discovery manually (replaces post-autoload-dump hook skipped above).
+# This writes bootstrap/cache/packages.php so all package service providers are registered.
+php artisan package:discover --ansi || true
 
 # Wait for database server to be ready (connect without specifying database)
 echo "Waiting for database server..."

--- a/iznik-batch/docker/entrypoint.sh
+++ b/iznik-batch/docker/entrypoint.sh
@@ -7,11 +7,18 @@ echo "=== Laravel Batch Container Starting ==="
 # No .env file is needed - APP_KEY and all other config is passed via environment
 echo "Using environment variables for configuration (no .env file needed)"
 
-# Install PHP dependencies (host mount may not have vendor directory)
-if [ ! -f "/var/www/html/vendor/autoload.php" ]; then
-    echo "Installing PHP dependencies..."
-    composer install --no-interaction --prefer-dist --optimize-autoloader
-fi
+# Always clear service/package manifests before any composer/artisan bootstrap.
+# These files can be stale across environments and reference dev-only providers.
+rm -f /var/www/html/bootstrap/cache/services.php
+rm -f /var/www/html/bootstrap/cache/packages.php
+
+# Always run composer install to ensure vendor matches composer.lock.
+# The host bind-mount directory may contain a stale vendor/ from a previous run
+# (git clean -fd skips gitignored paths, and /vendor is gitignored). Running
+# composer install unconditionally is fast when nothing changed and ensures
+# newly added packages are always present.
+echo "Installing/updating PHP dependencies..."
+composer install --no-interaction --prefer-dist --optimize-autoloader
 
 # Wait for database server to be ready (connect without specifying database)
 echo "Waiting for database server..."
@@ -73,7 +80,7 @@ chmod -R 777 /var/www/html/storage /var/www/html/bootstrap/cache 2>/dev/null || 
 
 # Clear environment-specific bootstrap cache files.
 # These contain resolved paths/env values that differ between environments.
-# services.php and packages.php are committed to git and should not be cleared.
+# services.php and packages.php are handled at startup before bootstrap.
 echo "Cleaning environment-specific bootstrap cache..."
 rm -f /var/www/html/bootstrap/cache/config.php
 rm -f /var/www/html/bootstrap/cache/routes-v7.php

--- a/iznik-batch/tests/Feature/Group/CheckBoundariesCommandTest.php
+++ b/iznik-batch/tests/Feature/Group/CheckBoundariesCommandTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests\Feature\Group;
+
+use Tests\TestCase;
+
+class CheckBoundariesCommandTest extends TestCase
+{
+    public function test_runs_cleanly_with_no_groups(): void
+    {
+        $this->artisan('groups:check-boundaries')
+            ->assertExitCode(0);
+    }
+
+    public function test_reports_zero_errors_for_valid_groups(): void
+    {
+        $this->createTestGroup(['publish' => 1, 'onmap' => 1]);
+        $this->createTestGroup(['publish' => 1, 'onmap' => 1]);
+
+        $this->artisan('groups:check-boundaries')
+            ->expectsOutputToContain('0 error(s) detected')
+            ->assertExitCode(0);
+    }
+
+    public function test_dry_run_outputs_dry_run_marker(): void
+    {
+        $this->createTestGroup(['publish' => 1, 'onmap' => 1]);
+
+        $this->artisan('groups:check-boundaries', ['--dry-run' => true])
+            ->expectsOutputToContain('[DRY RUN] Would check boundaries for')
+            ->assertExitCode(0);
+    }
+
+    public function test_dry_run_shows_dry_run_prefix_not_live_summary(): void
+    {
+        // In dry-run mode the command outputs "[DRY RUN]" not "Checked N group(s)".
+        $output = '';
+        $this->artisan('groups:check-boundaries', ['--dry-run' => true])
+            ->expectsOutputToContain('[DRY RUN]')
+            ->assertExitCode(0);
+    }
+}

--- a/iznik-batch/tests/Feature/Integrations/SyncRepairCafeWalesCommandTest.php
+++ b/iznik-batch/tests/Feature/Integrations/SyncRepairCafeWalesCommandTest.php
@@ -1,0 +1,200 @@
+<?php
+
+namespace Tests\Feature\Integrations;
+
+use App\Services\CommunityEventService;
+use App\Services\RepairCafeWalesService;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class SyncRepairCafeWalesCommandTest extends TestCase
+{
+    public function test_runs_cleanly_with_zero_events(): void
+    {
+        $mock = $this->createMock(RepairCafeWalesService::class);
+        $mock->method('sync')->willReturn(['added' => 0, 'updated' => 0, 'deleted' => 0]);
+        $this->app->instance(RepairCafeWalesService::class, $mock);
+
+        $this->artisan('integrations:sync-repaircafewales')
+            ->expectsOutputToContain('Processed 0 new event(s), 0 updated, 0 deleted.')
+            ->assertExitCode(0);
+    }
+
+    public function test_dry_run_outputs_dry_run_prefix(): void
+    {
+        $mock = $this->createMock(RepairCafeWalesService::class);
+        $mock->method('sync')->with(true)->willReturn(['added' => 2, 'updated' => 1, 'deleted' => 0]);
+        $this->app->instance(RepairCafeWalesService::class, $mock);
+
+        $this->artisan('integrations:sync-repaircafewales', ['--dry-run' => true])
+            ->expectsOutputToContain('[DRY RUN] Would process 2 new event(s), 1 updated, 0 deleted.')
+            ->assertExitCode(0);
+    }
+
+    public function test_creates_event_for_nearby_group(): void
+    {
+        $freegleGroup = $this->createTestGroup([
+            'lat'      => 51.4816,
+            'lng'      => -3.1791,
+            'publish'  => 1,
+            'listable' => 1,
+        ]);
+
+        DB::table('locations')->insert([
+            'name'  => 'CF10 1AA',
+            'canon' => 'cf101aa',
+            'type'  => 'Postcode',
+            'lat'   => 51.4816,
+            'lng'   => -3.1791,
+        ]);
+
+        $uid   = 'rcw-test-001@repaircafewales.org';
+        $ical  = $this->buildIcal($uid, 'Community Fix-it Session', 'Cardiff Centre, CF10 1AA',
+            'https://repaircafewales.org/test',
+            now()->addDays(5)->format('Ymd\THis\Z'),
+            now()->addDays(5)->addHours(3)->format('Ymd\THis\Z'));
+
+        $service = $this->serviceWithIcal($ical);
+        $result  = $service->sync(false);
+
+        $this->assertEquals(1, $result['added']);
+        $this->assertEquals(1, DB::table('communityevents')->where('externalid', $uid)->count());
+        $this->assertEquals(
+            1,
+            DB::table('communityevents_groups')
+                ->join('communityevents', 'communityevents.id', '=', 'communityevents_groups.eventid')
+                ->where('communityevents.externalid', $uid)
+                ->where('communityevents_groups.groupid', $freegleGroup->id)
+                ->count()
+        );
+    }
+
+    public function test_updates_existing_event(): void
+    {
+        $this->createTestGroup(['lat' => 51.4816, 'lng' => -3.1791, 'publish' => 1, 'listable' => 1]);
+
+        DB::table('locations')->insert(['name' => 'CF10 1AA', 'canon' => 'cf101aa', 'type' => 'Postcode', 'lat' => 51.4816, 'lng' => -3.1791]);
+
+        $uid = 'rcw-update-001@repaircafewales.org';
+
+        DB::table('communityevents')->insert([
+            'externalid'  => $uid,
+            'title'       => 'Old Title',
+            'location'    => 'Old Location',
+            'description' => 'Old desc',
+            'pending'     => 0,
+        ]);
+        $existingId = (int) DB::getPdo()->lastInsertId();
+        DB::table('communityevents_dates')->insert([
+            'eventid' => $existingId,
+            'start'   => now()->addDays(2)->format('Y-m-d H:i:s'),
+            'end'     => now()->addDays(2)->addHours(2)->format('Y-m-d H:i:s'),
+        ]);
+
+        $ical    = $this->buildIcal($uid, 'New Title', 'Cardiff Centre, CF10 1AA', null,
+            now()->addDays(5)->format('Ymd\THis\Z'),
+            now()->addDays(5)->addHours(3)->format('Ymd\THis\Z'));
+        $service = $this->serviceWithIcal($ical);
+        $result  = $service->sync(false);
+
+        $this->assertEquals(1, $result['updated']);
+        $updated = DB::table('communityevents')->where('externalid', $uid)->first();
+        $this->assertEquals('New Title', $updated->title);
+        $this->assertEquals(1, $updated->pending);
+    }
+
+    public function test_dry_run_does_not_create_event(): void
+    {
+        $this->createTestGroup(['lat' => 51.4816, 'lng' => -3.1791, 'publish' => 1, 'listable' => 1]);
+        DB::table('locations')->insert(['name' => 'CF10 1AA', 'canon' => 'cf101aa', 'type' => 'Postcode', 'lat' => 51.4816, 'lng' => -3.1791]);
+
+        $uid  = 'rcw-dryrun-001@repaircafewales.org';
+        $ical = $this->buildIcal($uid, 'Test Event', 'Place, CF10 1AA', null,
+            now()->addDays(5)->format('Ymd\THis\Z'),
+            now()->addDays(5)->addHours(3)->format('Ymd\THis\Z'));
+
+        $result = $this->serviceWithIcal($ical)->sync(true);
+
+        $this->assertEquals(1, $result['added']);
+        $this->assertEquals(0, DB::table('communityevents')->where('externalid', $uid)->count());
+    }
+
+    public function test_skips_event_without_postcode(): void
+    {
+        $this->createTestGroup(['lat' => 51.4816, 'lng' => -3.1791, 'publish' => 1, 'listable' => 1]);
+
+        $uid  = 'rcw-no-postcode@repaircafewales.org';
+        $ical = $this->buildIcal($uid, 'No Postcode Event', 'Somewhere without a code', null,
+            now()->addDays(5)->format('Ymd\THis\Z'),
+            now()->addDays(5)->addHours(3)->format('Ymd\THis\Z'));
+
+        $result = $this->serviceWithIcal($ical)->sync(false);
+        $this->assertEquals(0, $result['added']);
+    }
+
+    public function test_marks_deleted_when_not_in_feed(): void
+    {
+        DB::table('communityevents')->insert([
+            'externalid'  => 'rcw-old@repaircafewales.org',
+            'title'       => 'Old Event',
+            'location'    => 'Somewhere',
+            'description' => null,
+            'pending'     => 0,
+            'deleted'     => 0,
+        ]);
+        $existingId = (int) DB::getPdo()->lastInsertId();
+        DB::table('communityevents_dates')->insert([
+            'eventid' => $existingId,
+            'start'   => now()->addDays(3)->format('Y-m-d H:i:s'),
+            'end'     => now()->addDays(3)->addHours(2)->format('Y-m-d H:i:s'),
+        ]);
+
+        $emptyIcal = implode("\r\n", ['BEGIN:VCALENDAR', 'VERSION:2.0', 'PRODID:-//T//T//EN', 'END:VCALENDAR', '']);
+        $result    = $this->serviceWithIcal($emptyIcal)->sync(false);
+
+        $this->assertEquals(1, $result['deleted']);
+        $this->assertEquals(1, DB::table('communityevents')->where('externalid', 'rcw-old@repaircafewales.org')->value('deleted'));
+    }
+
+    private function serviceWithIcal(string $icalContent): RepairCafeWalesService
+    {
+        $tmpFile = tempnam(sys_get_temp_dir(), 'rcw_') . '.ics';
+        file_put_contents($tmpFile, $icalContent);
+
+        $events = app(CommunityEventService::class);
+
+        return new class($events, $tmpFile) extends RepairCafeWalesService {
+            public function __construct(CommunityEventService $events, private string $file)
+            {
+                parent::__construct($events);
+            }
+
+            protected function icalUrl(): string
+            {
+                return $this->file;
+            }
+        };
+    }
+
+    private function buildIcal(string $uid, string $summary, string $location, ?string $url, string $dtstart, string $dtend): string
+    {
+        $lines = [
+            'BEGIN:VCALENDAR',
+            'VERSION:2.0',
+            'PRODID:-//Test//Test//EN',
+            'BEGIN:VEVENT',
+            "UID:{$uid}",
+            "SUMMARY:{$summary}",
+            "LOCATION:{$location}",
+            "DTSTART:{$dtstart}",
+            "DTEND:{$dtend}",
+        ];
+        if ($url !== null) {
+            $lines[] = "URL:{$url}";
+        }
+        $lines[] = 'END:VEVENT';
+        $lines[] = 'END:VCALENDAR';
+        $lines[] = '';
+        return implode("\r\n", $lines);
+    }
+}

--- a/iznik-batch/tests/Feature/Integrations/SyncRestartProjectCommandTest.php
+++ b/iznik-batch/tests/Feature/Integrations/SyncRestartProjectCommandTest.php
@@ -1,0 +1,301 @@
+<?php
+
+namespace Tests\Feature\Integrations;
+
+use App\Models\Group;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class SyncRestartProjectCommandTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Http::preventStrayRequests();
+        Cache::flush();
+    }
+
+    private function makeGroup(array $override = []): Group
+    {
+        return $this->createTestGroup(array_merge([
+            'lat'      => 51.5074,
+            'lng'      => -0.1278,
+            'publish'  => 1,
+            'listable' => 1,
+        ], $override));
+    }
+
+    private function restartGroupData(float $lat = 51.5074, float $lng = -0.1278): array
+    {
+        return [
+            'location' => ['country_code' => 'GB', 'lat' => $lat, 'lng' => $lng],
+            'name'     => 'London Restart Group',
+            'website'  => 'https://restarters.net/group/1',
+            'email'    => 'london@restart.org',
+        ];
+    }
+
+    private function restartEvent(int $id, string $title = 'Fix-it session'): array
+    {
+        return [
+            'id'       => $id,
+            'title'    => $title,
+            'approved' => true,
+            'start'    => now()->addDays(7)->format('Y-m-d H:i:s'),
+            'end'      => now()->addDays(7)->addHours(3)->format('Y-m-d H:i:s'),
+            'location' => 'London Community Centre, WC2H 7NA',
+        ];
+    }
+
+    private function restartEventData(int $id): array
+    {
+        return [
+            'id'          => $id,
+            'description' => '<p>Come along and get your items repaired!</p>',
+            'link'        => "https://restarters.net/event/$id",
+            'group'       => ['name' => 'London Restart Group', 'image' => null],
+        ];
+    }
+
+    private function fakeApi(int $groupId, array $groupData, array $events = [], array $eventDetails = []): void
+    {
+        Http::fake(function ($request) use ($groupId, $groupData, $events, $eventDetails) {
+            $url = $request->url();
+
+            if (str_contains($url, '/groups/names')) {
+                return Http::response(['data' => [['id' => $groupId, 'name' => $groupData['name']]]], 200);
+            }
+
+            if (str_contains($url, "/groups/{$groupId}/events")) {
+                return Http::response(['data' => $events], 200);
+            }
+
+            if (str_contains($url, "/groups/{$groupId}")) {
+                return Http::response(['data' => $groupData], 200);
+            }
+
+            foreach ($eventDetails as $id => $detail) {
+                if (str_contains($url, "/events/{$id}")) {
+                    return Http::response(['data' => $detail], 200);
+                }
+            }
+
+            return Http::response(null, 404);
+        });
+    }
+
+    private function fakeEmpty(): void
+    {
+        Http::fake([
+            '*restarters.net/api/v2/groups/names*' => Http::response(['data' => []], 200),
+        ]);
+    }
+
+    public function test_community_event_service_create_works(): void
+    {
+        $service = app(\App\Services\CommunityEventService::class);
+        $id = $service->createEvent(null, 'Test Title', 'Test Location', null, null, null, null, 'desc', 'TEST-EXT-1');
+        $this->assertGreaterThan(0, $id);
+        $this->assertEquals(1, DB::table('communityevents')->where('externalid', 'TEST-EXT-1')->count());
+    }
+
+    public function test_runs_cleanly_with_empty_groups(): void
+    {
+        $this->fakeEmpty();
+
+        $this->artisan('integrations:sync-restartproject')
+            ->expectsOutputToContain('Processed 0 new event(s), 0 updated, 0 deleted.')
+            ->assertExitCode(0);
+    }
+
+    public function test_dry_run_outputs_dry_run_prefix(): void
+    {
+        $this->fakeEmpty();
+
+        $this->artisan('integrations:sync-restartproject', ['--dry-run' => true])
+            ->expectsOutputToContain('[DRY RUN] Would process 0 new event(s), 0 updated, 0 deleted.')
+            ->assertExitCode(0);
+    }
+
+    public function test_skips_inactive_group(): void
+    {
+        Http::fake(function ($request) {
+            if (str_contains($request->url(), '/groups/names')) {
+                return Http::response(['data' => [['id' => 1, 'name' => 'London [INACTIVE]']]], 200);
+            }
+            return Http::response(null, 404);
+        });
+
+        $this->artisan('integrations:sync-restartproject')
+            ->expectsOutputToContain('Processed 0 new event(s)')
+            ->assertExitCode(0);
+    }
+
+    public function test_skips_non_gb_group(): void
+    {
+        $this->fakeApi(2, [
+            'location' => ['country_code' => 'FR', 'lat' => 48.8566, 'lng' => 2.3522],
+            'name'     => 'Paris Restart',
+        ]);
+
+        $this->artisan('integrations:sync-restartproject')
+            ->expectsOutputToContain('Processed 0 new event(s)')
+            ->assertExitCode(0);
+
+        $this->assertEquals(0, DB::table('communityevents')->count());
+    }
+
+    public function test_creates_new_event_for_nearby_gb_group(): void
+    {
+        $freegleGroup = $this->makeGroup();
+        $event        = $this->restartEvent(101);
+
+        Http::fake([
+            '*api/v2/groups/names*'     => Http::response(['data' => [['id' => 10, 'name' => 'London Restart']]], 200),
+            '*api/v2/events/101*'       => Http::response(['data' => $this->restartEventData(101)], 200),
+            '*api/v2/groups/10/events*' => Http::response(['data' => [$event]], 200),
+            '*api/v2/groups/10*'        => Http::response(['data' => $this->restartGroupData()], 200),
+        ]);
+
+        // Verify group is findable
+        $nearby = \App\Models\Location::groupsNear(51.5074, -0.1278, 15);
+        $this->assertContains($freegleGroup->id, $nearby, 'Group must be findable by haversine');
+
+        // Call service directly to isolate from artisan/PendingCommand
+        $service = app(\App\Services\RestartProjectService::class);
+        $result  = $service->sync(false);
+
+        $recorded = Http::recorded();
+        $urls = array_map(fn($pair) => $pair[0]->url(), iterator_to_array($recorded));
+        $this->assertEquals(1, $result['added'], 'Service returned wrong count. Recorded URLs: ' . json_encode($urls));
+        $this->assertEquals(1, DB::table('communityevents')->where('externalid', 'Restart-101')->count());
+        $this->assertEquals(1,
+            DB::table('communityevents_dates')
+                ->join('communityevents', 'communityevents.id', '=', 'communityevents_dates.eventid')
+                ->where('communityevents.externalid', 'Restart-101')
+                ->count()
+        );
+
+        $this->assertEquals(
+            1,
+            DB::table('communityevents_groups')
+                ->join('communityevents', 'communityevents.id', '=', 'communityevents_groups.eventid')
+                ->where('communityevents.externalid', 'Restart-101')
+                ->where('communityevents_groups.groupid', $freegleGroup->id)
+                ->count()
+        );
+    }
+
+    public function test_prefixes_repair_cafe_to_title(): void
+    {
+        $this->makeGroup();
+        $event = $this->restartEvent(102, 'Saturday Session');
+
+        $this->fakeApi(11, $this->restartGroupData(), [$event], [102 => $this->restartEventData(102)]);
+
+        $this->artisan('integrations:sync-restartproject')->assertExitCode(0);
+
+        $this->assertEquals(
+            'Repair Cafe: Saturday Session',
+            DB::table('communityevents')->where('externalid', 'Restart-102')->value('title')
+        );
+    }
+
+    public function test_does_not_prefix_repair_cafe_when_already_in_title(): void
+    {
+        $this->makeGroup();
+        $event = $this->restartEvent(103, 'Repair Cafe Hackney');
+
+        $this->fakeApi(12, $this->restartGroupData(), [$event], [103 => $this->restartEventData(103)]);
+
+        $this->artisan('integrations:sync-restartproject')->assertExitCode(0);
+
+        $this->assertEquals(
+            'Repair Cafe Hackney',
+            DB::table('communityevents')->where('externalid', 'Restart-103')->value('title')
+        );
+    }
+
+    public function test_updates_existing_event(): void
+    {
+        $this->makeGroup();
+
+        DB::table('communityevents')->insert([
+            'externalid'  => 'Restart-200',
+            'title'       => 'Old Title',
+            'location'    => 'Old Location',
+            'description' => 'Old desc',
+            'pending'     => 0,
+        ]);
+        $existingId = (int) DB::getPdo()->lastInsertId();
+        DB::table('communityevents_dates')->insert([
+            'eventid' => $existingId,
+            'start'   => now()->addDays(5)->format('Y-m-d H:i:s'),
+            'end'     => now()->addDays(5)->addHours(2)->format('Y-m-d H:i:s'),
+        ]);
+
+        $event = $this->restartEvent(200, 'New Title');
+        $this->fakeApi(20, $this->restartGroupData(), [$event], [200 => $this->restartEventData(200)]);
+
+        $this->artisan('integrations:sync-restartproject')
+            ->expectsOutputToContain('0 new event(s), 1 updated')
+            ->assertExitCode(0);
+
+        $updated = DB::table('communityevents')->where('externalid', 'Restart-200')->first();
+        $this->assertEquals('Repair Cafe: New Title', $updated->title);
+        $this->assertEquals(1, $updated->pending);
+    }
+
+    public function test_dry_run_does_not_create_event(): void
+    {
+        $this->makeGroup();
+        $event = $this->restartEvent(301);
+
+        $this->fakeApi(30, $this->restartGroupData(), [$event], [301 => $this->restartEventData(301)]);
+
+        $this->artisan('integrations:sync-restartproject', ['--dry-run' => true])
+            ->expectsOutputToContain('[DRY RUN] Would process 1 new event(s)')
+            ->assertExitCode(0);
+
+        $this->assertEquals(0, DB::table('communityevents')->where('externalid', 'Restart-301')->count());
+    }
+
+    public function test_marks_event_deleted_when_not_in_feed(): void
+    {
+        DB::table('communityevents')->insert([
+            'externalid'  => 'Restart-999',
+            'title'       => 'Old Event',
+            'location'    => 'Somewhere',
+            'description' => null,
+            'pending'     => 0,
+            'deleted'     => 0,
+        ]);
+        $existingId = (int) DB::getPdo()->lastInsertId();
+        DB::table('communityevents_dates')->insert([
+            'eventid' => $existingId,
+            'start'   => now()->addDays(3)->format('Y-m-d H:i:s'),
+            'end'     => now()->addDays(3)->addHours(2)->format('Y-m-d H:i:s'),
+        ]);
+
+        $this->fakeEmpty();
+
+        $this->artisan('integrations:sync-restartproject')
+            ->expectsOutputToContain('0 new event(s), 0 updated, 1 deleted.')
+            ->assertExitCode(0);
+
+        $this->assertEquals(1, DB::table('communityevents')->where('externalid', 'Restart-999')->value('deleted'));
+    }
+
+    public function test_skips_group_with_communityevents_disabled(): void
+    {
+        $this->makeGroup(['settings' => json_encode(['communityevents' => 0])]);
+
+        $this->fakeApi(40, $this->restartGroupData());
+
+        $this->artisan('integrations:sync-restartproject')
+            ->expectsOutputToContain('Processed 0 new event(s)')
+            ->assertExitCode(0);
+    }
+}

--- a/iznik-batch/tests/Feature/Integrations/SyncRestartProjectCommandTest.php
+++ b/iznik-batch/tests/Feature/Integrations/SyncRestartProjectCommandTest.php
@@ -17,23 +17,28 @@ class SyncRestartProjectCommandTest extends TestCase
         Cache::flush();
     }
 
+    // Use Leeds coords rather than London defaults to avoid conflicts with other
+    // tests that create groups at createTestGroup()'s default lat=51.5074, lng=-0.1278.
+    private const TEST_LAT = 53.8008;
+    private const TEST_LNG = -1.5491;
+
     private function makeGroup(array $override = []): Group
     {
         return $this->createTestGroup(array_merge([
-            'lat'      => 51.5074,
-            'lng'      => -0.1278,
+            'lat'      => self::TEST_LAT,
+            'lng'      => self::TEST_LNG,
             'publish'  => 1,
             'listable' => 1,
         ], $override));
     }
 
-    private function restartGroupData(float $lat = 51.5074, float $lng = -0.1278): array
+    private function restartGroupData(float $lat = self::TEST_LAT, float $lng = self::TEST_LNG): array
     {
         return [
             'location' => ['country_code' => 'GB', 'lat' => $lat, 'lng' => $lng],
-            'name'     => 'London Restart Group',
+            'name'     => 'Leeds Restart Group',
             'website'  => 'https://restarters.net/group/1',
-            'email'    => 'london@restart.org',
+            'email'    => 'leeds@restart.org',
         ];
     }
 
@@ -153,14 +158,14 @@ class SyncRestartProjectCommandTest extends TestCase
         $event        = $this->restartEvent(101);
 
         Http::fake([
-            '*api/v2/groups/names*'     => Http::response(['data' => [['id' => 10, 'name' => 'London Restart']]], 200),
+            '*api/v2/groups/names*'     => Http::response(['data' => [['id' => 10, 'name' => 'Leeds Restart']]], 200),
             '*api/v2/events/101*'       => Http::response(['data' => $this->restartEventData(101)], 200),
             '*api/v2/groups/10/events*' => Http::response(['data' => [$event]], 200),
             '*api/v2/groups/10*'        => Http::response(['data' => $this->restartGroupData()], 200),
         ]);
 
         // Verify group is findable
-        $nearby = \App\Models\Location::groupsNear(51.5074, -0.1278, 15);
+        $nearby = \App\Models\Location::groupsNear(self::TEST_LAT, self::TEST_LNG, 15);
         $this->assertContains($freegleGroup->id, $nearby, 'Group must be findable by haversine');
 
         // Call service directly to isolate from artisan/PendingCommand

--- a/iznik-batch/tests/Feature/Integrations/SyncTrashNothingCommandTest.php
+++ b/iznik-batch/tests/Feature/Integrations/SyncTrashNothingCommandTest.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace Tests\Feature\Integrations;
+
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class SyncTrashNothingCommandTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Http::preventStrayRequests();
+        Cache::flush();
+    }
+
+    private function fakeEmpty(): void
+    {
+        Http::fake([
+            '*trashnothing.com/fd/api/ratings*'      => Http::response(['ratings' => []], 200),
+            '*trashnothing.com/fd/api/user-changes*' => Http::response(['changes' => []], 200),
+        ]);
+    }
+
+    public function test_runs_cleanly_with_empty_api_responses(): void
+    {
+        $this->fakeEmpty();
+
+        $this->artisan('integrations:sync-trashnothing')
+            ->expectsOutputToContain('Processed 0 rating(s), 0 user change(s)')
+            ->assertExitCode(0);
+    }
+
+    public function test_dry_run_outputs_dry_run_prefix(): void
+    {
+        $this->fakeEmpty();
+
+        $this->artisan('integrations:sync-trashnothing', ['--dry-run' => true])
+            ->expectsOutputToContain('[DRY RUN] Would process 0 rating(s), 0 user change(s)')
+            ->assertExitCode(0);
+    }
+
+    public function test_inserts_new_rating_for_existing_user(): void
+    {
+        $user = $this->createTestUser();
+
+        Http::fake([
+            '*trashnothing.com/fd/api/ratings*' => Http::sequence()
+                ->push(['ratings' => [
+                    [
+                        'ratee_fd_user_id' => $user->id,
+                        'rating_id'        => 42,
+                        'rating'           => 'Positive',
+                        'date'             => '2026-05-01T12:00:00Z',
+                    ],
+                ]])
+                ->push(['ratings' => []]),
+            '*trashnothing.com/fd/api/user-changes*' => Http::response(['changes' => []], 200),
+        ]);
+
+        $this->artisan('integrations:sync-trashnothing')
+            ->expectsOutputToContain('Processed 1 rating(s)')
+            ->assertExitCode(0);
+
+        $this->assertEquals(1, DB::table('ratings')->where('ratee', $user->id)->where('tn_rating_id', 42)->count());
+    }
+
+    public function test_deletes_rating_when_rating_value_is_null(): void
+    {
+        $user = $this->createTestUser();
+
+        DB::table('ratings')->insert([
+            'ratee'        => $user->id,
+            'rating'       => 'Positive',
+            'timestamp'    => now(),
+            'visible'      => 1,
+            'tn_rating_id' => 99,
+        ]);
+
+        Http::fake([
+            '*trashnothing.com/fd/api/ratings*' => Http::sequence()
+                ->push(['ratings' => [
+                    [
+                        'ratee_fd_user_id' => $user->id,
+                        'rating_id'        => 99,
+                        'rating'           => null,
+                        'date'             => '2026-05-01T12:00:00Z',
+                    ],
+                ]])
+                ->push(['ratings' => []]),
+            '*trashnothing.com/fd/api/user-changes*' => Http::response(['changes' => []], 200),
+        ]);
+
+        $this->artisan('integrations:sync-trashnothing')->assertExitCode(0);
+
+        $this->assertEquals(0, DB::table('ratings')->where('ratee', $user->id)->where('tn_rating_id', 99)->count());
+    }
+
+    public function test_dry_run_does_not_insert_rating(): void
+    {
+        $user = $this->createTestUser();
+
+        Http::fake([
+            '*trashnothing.com/fd/api/ratings*' => Http::sequence()
+                ->push(['ratings' => [
+                    [
+                        'ratee_fd_user_id' => $user->id,
+                        'rating_id'        => 55,
+                        'rating'           => 'Positive',
+                        'date'             => '2026-05-01T12:00:00Z',
+                    ],
+                ]])
+                ->push(['ratings' => []]),
+            '*trashnothing.com/fd/api/user-changes*' => Http::response(['changes' => []], 200),
+        ]);
+
+        $this->artisan('integrations:sync-trashnothing', ['--dry-run' => true])
+            ->expectsOutputToContain('[DRY RUN] Would process 1 rating(s)')
+            ->assertExitCode(0);
+
+        $this->assertEquals(0, DB::table('ratings')->where('tn_rating_id', 55)->count());
+    }
+
+    public function test_updates_reply_time_for_tn_user(): void
+    {
+        $user = $this->createTestUser(['email_preferred' => 'alice-g123@user.trashnothing.com']);
+
+        Http::fake([
+            '*trashnothing.com/fd/api/ratings*'      => Http::response(['ratings' => []], 200),
+            '*trashnothing.com/fd/api/user-changes*' => Http::sequence()
+                ->push(['changes' => [
+                    [
+                        'fd_user_id'  => $user->id,
+                        'reply_time'  => 3600,
+                        'date'        => '2026-05-01T12:00:00Z',
+                    ],
+                ]])
+                ->push(['changes' => []]),
+        ]);
+
+        $this->artisan('integrations:sync-trashnothing')->assertExitCode(0);
+
+        $this->assertEquals(1, DB::table('users_replytime')->where('userid', $user->id)->where('replytime', 3600)->count());
+    }
+
+    public function test_skips_non_tn_users_in_user_changes(): void
+    {
+        $user = $this->createTestUser();
+
+        Http::fake([
+            '*trashnothing.com/fd/api/ratings*'      => Http::response(['ratings' => []], 200),
+            '*trashnothing.com/fd/api/user-changes*' => Http::sequence()
+                ->push(['changes' => [
+                    [
+                        'fd_user_id'  => $user->id,
+                        'reply_time'  => 3600,
+                        'date'        => '2026-05-01T12:00:00Z',
+                    ],
+                ]])
+                ->push(['changes' => []]),
+        ]);
+
+        $this->artisan('integrations:sync-trashnothing')
+            ->expectsOutputToContain('Processed 0 rating(s), 0 user change(s)')
+            ->assertExitCode(0);
+
+        $this->assertEquals(0, DB::table('users_replytime')->where('userid', $user->id)->count());
+    }
+}

--- a/iznik-batch/tests/Feature/Message/UpdateVisualiseCommandTest.php
+++ b/iznik-batch/tests/Feature/Message/UpdateVisualiseCommandTest.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace Tests\Feature\Message;
+
+use App\Models\Message;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class UpdateVisualiseCommandTest extends TestCase
+{
+    private function insertLocation(float $lat, float $lng): int
+    {
+        return DB::table('locations')->insertGetId([
+            'name' => 'TestLoc',
+            'type' => 'Postcode',
+            'lat'  => $lat,
+            'lng'  => $lng,
+        ]);
+    }
+
+    private function insertAttachment(int $msgid): int
+    {
+        return DB::table('messages_attachments')->insertGetId([
+            'msgid' => $msgid,
+        ]);
+    }
+
+    private function insertReceivedBy(int $msgid, int $userid): void
+    {
+        DB::table('messages_by')->insert([
+            'msgid'     => $msgid,
+            'userid'    => $userid,
+            'timestamp' => now(),
+        ]);
+    }
+
+    public function test_runs_cleanly_with_no_messages(): void
+    {
+        $this->artisan('messages:update-visualise')
+            ->assertExitCode(0);
+    }
+
+    public function test_inserts_record_for_nearby_taken_offer(): void
+    {
+        $group  = $this->createTestGroup(['publish' => 1, 'onmap' => 1]);
+
+        $locIdA = $this->insertLocation(51.5074, -0.1278);
+        $locIdB = $this->insertLocation(51.5200, -0.1000);
+
+        $giver  = $this->createTestUser(['lastlocation' => $locIdA]);
+        $taker  = $this->createTestUser(['lastlocation' => $locIdB]);
+
+        $msg  = $this->createTestMessage($giver, $group, ['type' => Message::TYPE_OFFER]);
+        $this->insertAttachment($msg->id);
+        $this->insertReceivedBy($msg->id, $taker->id);
+
+        $this->artisan('messages:update-visualise')->assertExitCode(0);
+
+        $this->assertEquals(1, DB::table('visualise')->where('msgid', $msg->id)->count());
+    }
+
+    public function test_skips_message_already_in_visualise_table(): void
+    {
+        $group  = $this->createTestGroup(['publish' => 1, 'onmap' => 1]);
+
+        $locIdA = $this->insertLocation(51.5074, -0.1278);
+        $locIdB = $this->insertLocation(51.5200, -0.1000);
+
+        $giver  = $this->createTestUser(['lastlocation' => $locIdA]);
+        $taker  = $this->createTestUser(['lastlocation' => $locIdB]);
+
+        $msg  = $this->createTestMessage($giver, $group);
+        $attId = $this->insertAttachment($msg->id);
+        $this->insertReceivedBy($msg->id, $taker->id);
+
+        // Pre-insert the record.
+        DB::table('visualise')->insert([
+            'msgid'    => $msg->id,
+            'attid'    => $attId,
+            'fromuser' => $giver->id,
+            'touser'   => $taker->id,
+            'fromlat'  => 51.5074,
+            'fromlng'  => -0.1278,
+            'tolat'    => 51.5200,
+            'tolng'    => -0.1000,
+            'distance' => 2000,
+        ]);
+
+        $this->artisan('messages:update-visualise')
+            ->assertExitCode(0);
+
+        $this->assertEquals(1, DB::table('visualise')->where('msgid', $msg->id)->count());
+    }
+
+    public function test_skips_users_without_location(): void
+    {
+        $group = $this->createTestGroup(['publish' => 1, 'onmap' => 1]);
+
+        $giver = $this->createTestUser(['lastlocation' => null]);
+        $taker = $this->createTestUser(['lastlocation' => null]);
+
+        $msg = $this->createTestMessage($giver, $group);
+        $this->insertAttachment($msg->id);
+        $this->insertReceivedBy($msg->id, $taker->id);
+
+        $this->artisan('messages:update-visualise')
+            ->expectsOutputToContain('Inserted 0 visualise record(s)')
+            ->assertExitCode(0);
+
+        $this->assertEquals(0, DB::table('visualise')->count());
+    }
+
+    public function test_skips_messages_without_attachments(): void
+    {
+        $group = $this->createTestGroup(['publish' => 1, 'onmap' => 1]);
+
+        $locIdA = $this->insertLocation(51.5074, -0.1278);
+        $locIdB = $this->insertLocation(51.5200, -0.1000);
+
+        $giver = $this->createTestUser(['lastlocation' => $locIdA]);
+        $taker = $this->createTestUser(['lastlocation' => $locIdB]);
+
+        $msg = $this->createTestMessage($giver, $group);
+        // No attachment inserted.
+        $this->insertReceivedBy($msg->id, $taker->id);
+
+        $this->artisan('messages:update-visualise')
+            ->expectsOutputToContain('Inserted 0 visualise record(s)')
+            ->assertExitCode(0);
+    }
+
+    public function test_dry_run_does_not_write_to_database(): void
+    {
+        $group  = $this->createTestGroup(['publish' => 1, 'onmap' => 1]);
+
+        $locIdA = $this->insertLocation(51.5074, -0.1278);
+        $locIdB = $this->insertLocation(51.5200, -0.1000);
+
+        $giver  = $this->createTestUser(['lastlocation' => $locIdA]);
+        $taker  = $this->createTestUser(['lastlocation' => $locIdB]);
+
+        $msg = $this->createTestMessage($giver, $group);
+        $this->insertAttachment($msg->id);
+        $this->insertReceivedBy($msg->id, $taker->id);
+
+        $this->artisan('messages:update-visualise', ['--dry-run' => true])
+            ->expectsOutputToContain('[DRY RUN] Would insert 1 visualise record(s)')
+            ->assertExitCode(0);
+
+        $this->assertEquals(0, DB::table('visualise')->count());
+    }
+}

--- a/iznik-batch/tests/Unit/Services/MembershipsProcessingServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/MembershipsProcessingServiceTest.php
@@ -213,4 +213,43 @@ class MembershipsProcessingServiceTest extends TestCase
             ->first();
         $this->assertNull($membership->reviewrequestedat ?? null);
     }
+
+    // --- Dry-run mode ---
+
+    public function test_dry_run_does_not_mark_entries_as_processed(): void
+    {
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+
+        $historyId = DB::table('memberships_history')->insertGetId([
+            'userid' => $user->id,
+            'groupid' => $group->id,
+            'collection' => 'Approved',
+            'processingrequired' => 1,
+        ]);
+
+        $count = $this->service->processAll(dryRun: true);
+
+        $this->assertEquals(1, $count);
+
+        $entry = DB::table('memberships_history')->where('id', $historyId)->first();
+        $this->assertEquals(1, $entry->processingrequired);
+    }
+
+    public function test_dry_run_does_not_send_welcome_email(): void
+    {
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup(['onhere' => 1, 'welcomemail' => 'Welcome!']);
+
+        DB::table('memberships_history')->insert([
+            'userid' => $user->id,
+            'groupid' => $group->id,
+            'collection' => 'Approved',
+            'processingrequired' => 1,
+        ]);
+
+        $this->service->processAll(dryRun: true);
+
+        Mail::assertNothingSent();
+    }
 }

--- a/iznik-batch/tests/Unit/Services/UserDataExportServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/UserDataExportServiceTest.php
@@ -174,4 +174,46 @@ class UserDataExportServiceTest extends TestCase
         $this->assertNotEmpty($json['memberships']);
         $this->assertEquals($group->id, $json['memberships'][0]['groupid']);
     }
+
+    // --- Dry-run mode ---
+
+    public function test_dry_run_does_not_write_export_data(): void
+    {
+        $user = $this->createTestUser();
+        $this->createTestUserEmail($user);
+
+        $exportId = DB::table('users_exports')->insertGetId([
+            'userid' => $user->id,
+            'tag' => 'test-tag',
+            'requested' => now(),
+        ]);
+
+        $count = $this->service->processAll(dryRun: true);
+
+        $this->assertEquals(1, $count);
+
+        $export = DB::table('users_exports')->where('id', $exportId)->first();
+        $this->assertNull($export->started);
+        $this->assertNull($export->completed);
+        $this->assertNull($export->data);
+    }
+
+    public function test_dry_run_does_not_purge_old_exports(): void
+    {
+        $user = $this->createTestUser();
+        $this->createTestUserEmail($user);
+
+        $oldExportId = DB::table('users_exports')->insertGetId([
+            'userid' => $user->id,
+            'tag' => 'old-tag',
+            'requested' => now()->subDays(10),
+            'completed' => now()->subDays(10),
+            'data' => 'old-data',
+        ]);
+
+        $this->service->processAll(dryRun: true);
+
+        $export = DB::table('users_exports')->where('id', $oldExportId)->first();
+        $this->assertEquals('old-data', $export->data);
+    }
 }


### PR DESCRIPTION
## Summary

- **`groups:check-boundaries`** — migrates `check_cgas.php`; runs ST_Intersection spatial checks for all published Freegle groups against authority geometry (id=74579), logs errors per group; `--dry-run` reports count without executing spatial queries
- **`messages:update-visualise`** — migrates `visualise.php`; scans taken OFFER messages with photos, respects user privacy (`settings.useprofile`), calculates haversine distance, writes to `visualise` table with INSERT IGNORE
- **`integrations:sync-trashnothing`** — migrates `tn_sync.php`; paginated sync of ratings and user changes (reply_time, about_me, username rename, location, account_removed) from TrashNothing API using Laravel's `Http` facade; last-sync date stored in Laravel cache
- **Dry-run improvements**: `memberships:process` and `users:process-exports` now pass `$dryRun` through to the service layer — each entry logs what it would do (welcome email, review flag, export path) instead of just returning a count
- **`Location::closestPostcode()`** added to Location model (expanding spatial scan from iznik-server's implementation)
- MIGRATION-STATUS.md: mark `microvolunteering.php`, `newsfeed_link_previews.php`, `archive_attachments.php` as covered/migrated; mark `tn_sync.php` as migrated

## Code Quality Review

- All services accept `bool $dryRun = false` — no early-return stubs, dry-run is threaded through the full call stack
- HTTP calls in `TnSyncService` use Laravel's `Http` facade (mockable in tests via `Http::fake()`)
- `Location::closestPostcode()` is a static method following the same expanding-scan algorithm as V1
- `TnSyncService` intentionally omits the duplicate-TN-user merge from V1 — V1's own comment says it "should no longer happen given locking code in Message::parse"

## Test Plan

- [ ] `groups:check-boundaries` — 4 feature tests (no groups, valid groups, dry-run marker, dry-run prefix)
- [ ] `messages:update-visualise` — 5 feature tests (taken offer, already-in-table skip, no location skip, no attachment skip, dry-run no-write)
- [ ] `integrations:sync-trashnothing` — 7 feature tests (empty API, dry-run prefix, insert rating, delete rating, dry-run no-insert, TN user reply-time, skip non-TN user)
- [ ] `memberships:process` dry-run — 2 unit tests (no DB write, no email)
- [ ] `users:process-exports` dry-run — 2 unit tests (no write, no purge)
- [ ] Full suite: 2050 tests, 0 failures