### PR TITLE
fix(chat): preserve review fields in ModChatReview after per-room message fetch

### DIFF
--- a/iznik-nuxt3/stores/chat.js
+++ b/iznik-nuxt3/stores/chat.js
@@ -267,7 +267,13 @@ export const useChatStore = defineStore({
         this.messages[id] = messages
 
         messages.forEach((m) => {
-          this.listByChatMessageId[m.id] = m
+          // Merge rather than overwrite — preserves review-context fields
+          // (touserid, fromuserid, etc.) written by fetchReviewChatsMT when
+          // per-room fetchMessages runs for the same message afterwards.
+          this.listByChatMessageId[m.id] = {
+            ...this.listByChatMessageId[m.id],
+            ...m,
+          }
         })
       }
 

--- a/iznik-nuxt3/tests/unit/stores/chat.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/chat.spec.js
@@ -542,6 +542,49 @@ describe('chat store', () => {
     })
   })
 
+  describe('fetchReviewChatsMT + fetchMessages merge', () => {
+    it('preserves review fields in listByChatMessageId after a per-room fetchMessages', async () => {
+      // Seed the store with a rich review-queue message via fetchReviewChatsMT.
+      // fetchMessages for the same room then returns only the slim per-room shape.
+      // The review fields (touserid, fromuserid) must survive the overwrite.
+      const store = useChatStore()
+      store.config = {}
+
+      const richMsg = {
+        id: 500,
+        chatid: 10,
+        userid: 1,
+        type: 'Chat',
+        message: 'hello',
+        date: '2026-01-01',
+        fromuserid: 1,
+        touserid: 2,
+        chatroom: { id: 10, chattype: 'User2User' },
+      }
+      mockFetchReviewChatsMT.mockResolvedValueOnce({ chatmessages: [richMsg] })
+      await store.fetchReviewChatsMT(10, {})
+
+      // Confirm the rich shape is stored
+      expect(store.messageById(500).touserid).toBe(2)
+
+      // Now fetchMessages returns the slim per-room shape (no touserid)
+      const slimMsg = {
+        id: 500,
+        chatid: 10,
+        userid: 1,
+        type: 'Chat',
+        message: 'hello',
+        date: '2026-01-01',
+      }
+      mockFetchMessages.mockResolvedValueOnce([slimMsg])
+      // Use force=true so the update() path definitely runs
+      await store.fetchMessages(10, true)
+
+      // touserid must still be present — merge, not replace
+      expect(store.messageById(500).touserid).toBe(2)
+    })
+  })
+
   describe('deleteMessage', () => {
     it('calls API and refetches messages', async () => {
       const store = useChatStore()


### PR DESCRIPTION
## Summary

- `listByChatMessageId` is written by two different code paths with different message shapes: `fetchReviewChatsMT` (rich review row with `touserid`, `fromuserid`, `fromuser`, `touser`, etc.) and `fetchMessages` (slim per-room row from Go's `getChatMessagesForRoom` which only selects `id`, `chatid`, `userid`, `type`, `message`, `date`, `refmsgid`, `reportreason`)
- When a moderator clicked **View Chat** in the review queue, `ModChatModal` called `fetchMessages`, which overwrote the rich shape with the slim one via a direct `this.listByChatMessageId[m.id] = m`
- `ModChatReview` is reactive on `messageById(props.messageid)` — after the overwrite it saw `touserid === undefined` and rendered nothing for the To: user (only From: survived because `userid` is present in both shapes)
- Fix: **merge instead of replace** — `this.listByChatMessageId[m.id] = { ...this.listByChatMessageId[m.id], ...m }` — the same pattern already used for `listByChatId` for the same reason (comment references #327)

## Code Quality Review

- One-line change at the site of the bug; no logic moved or restructured
- Follows the existing, commented merge pattern already present five lines above in the same file
- No new abstractions introduced

## Test Plan

- New unit test in `chat.spec.js`: seeds store via `fetchReviewChatsMT` with a rich message (includes `touserid`), then calls `fetchMessages(force=true)` for the same room with a slim shape, asserts `messageById(id).touserid` is still set
- Test confirmed passing locally (44/44 chat store tests ✓)
- The 23 failing tests in `ModMessageWorry.spec.js` on master are pre-existing — the component is being developed in PR #409 and those failures will resolve when that PR merges