### PR TITLE
feat(batch): migrate chat_review.php to chats:review-pending

### DIFF
--- a/iznik-batch/app/Console/Commands/Chat/ReviewPendingCommand.php
+++ b/iznik-batch/app/Console/Commands/Chat/ReviewPendingCommand.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Console\Commands\Chat;
+
+use App\Services\ChatReviewPendingService;
+use App\Traits\LogsBatchJob;
+use Illuminate\Console\Command;
+
+class ReviewPendingCommand extends Command
+{
+    use LogsBatchJob;
+
+    protected $signature = 'chats:review-pending
+                            {--dry-run : Count pending messages without sending emails or auto-rejecting}';
+
+    protected $description = 'Auto-reject stale chat review messages and notify mods about pending ones';
+
+    public function handle(ChatReviewPendingService $service): int
+    {
+        $dryRun = (bool) $this->option('dry-run');
+
+        if ($dryRun) {
+            $this->info('DRY RUN — no emails will be sent and no messages will be auto-rejected.');
+        }
+
+        return $this->runWithLogging(function () use ($service, $dryRun) {
+            $result = $service->processReview($dryRun);
+
+            $verb = $dryRun ? 'Would auto-reject' : 'Auto-rejected';
+            $this->info("{$verb} {$result['auto_rejected']} message(s) stuck in review for "
+                . ChatReviewPendingService::AUTO_REJECT_DAYS . '+ days.');
+
+            $verb = $dryRun ? 'Would notify' : 'Notified';
+            $this->info("{$verb} mods for {$result['groups_notified']} group(s) with messages pending "
+                . ChatReviewPendingService::NOTIFY_HOURS . '+ hours.');
+
+            return Command::SUCCESS;
+        });
+    }
+}

--- a/iznik-batch/app/Mail/Chat/ChatReviewPendingMail.php
+++ b/iznik-batch/app/Mail/Chat/ChatReviewPendingMail.php
@@ -2,36 +2,49 @@
 
 namespace App\Mail\Chat;
 
-use Illuminate\Bus\Queueable;
-use Illuminate\Mail\Mailable;
+use App\Mail\MjmlMailable;
 use Illuminate\Mail\Mailables\Address;
 use Illuminate\Mail\Mailables\Envelope;
-use Illuminate\Queue\SerializesModels;
 
-class ChatReviewPendingMail extends Mailable
+class ChatReviewPendingMail extends MjmlMailable
 {
-    use Queueable, SerializesModels;
-
     public function __construct(
+        public readonly string $recipientEmail,
         public readonly string $groupName,
         public readonly int $count,
     ) {
+        parent::__construct();
+    }
+
+    protected function getSubject(): string
+    {
+        $plural = $this->count !== 1 ? 's' : '';
+        return "{$this->count} message{$plural} between members waiting for your review on {$this->groupName}";
     }
 
     public function envelope(): Envelope
     {
-        $plural = $this->count !== 1 ? 's' : '';
         return new Envelope(
             from: new Address(
                 config('freegle.mail.support_addr'),
                 config('freegle.branding.name')
             ),
-            subject: "{$this->count} message{$plural} between members waiting for your review on {$this->groupName}",
+            to: [new Address($this->recipientEmail)],
+            subject: $this->getSubject(),
         );
     }
 
     public function build(): static
     {
-        return $this->text('emails.text.chat.review-pending');
+        $modSite = config('freegle.sites.mod', 'https://modtools.org');
+        $mentorsAddr = config('freegle.mail.mentors_addr', 'mentors@ilovefreegle.org');
+
+        return $this->mjmlView('emails.mjml.chat.review-pending', [
+            'groupName'   => $this->groupName,
+            'count'       => $this->count,
+            'reviewUrl'   => $modSite . '/modtools/chats/review',
+            'mentorsAddr' => $mentorsAddr,
+            'email'       => $this->recipientEmail,
+        ]);
     }
 }

--- a/iznik-batch/app/Mail/Chat/ChatReviewPendingMail.php
+++ b/iznik-batch/app/Mail/Chat/ChatReviewPendingMail.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Mail\Chat;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Address;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class ChatReviewPendingMail extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public function __construct(
+        public readonly string $groupName,
+        public readonly int $count,
+    ) {
+    }
+
+    public function envelope(): Envelope
+    {
+        $plural = $this->count !== 1 ? 's' : '';
+        return new Envelope(
+            from: new Address(
+                config('freegle.mail.support_addr'),
+                config('freegle.branding.name')
+            ),
+            subject: "{$this->count} message{$plural} between members waiting for your review on {$this->groupName}",
+        );
+    }
+
+    public function build(): static
+    {
+        return $this->text('emails.text.chat.review-pending');
+    }
+}

--- a/iznik-batch/app/Mail/Chat/ChatReviewSummaryMail.php
+++ b/iznik-batch/app/Mail/Chat/ChatReviewSummaryMail.php
@@ -2,20 +2,23 @@
 
 namespace App\Mail\Chat;
 
-use Illuminate\Bus\Queueable;
-use Illuminate\Mail\Mailable;
+use App\Mail\MjmlMailable;
 use Illuminate\Mail\Mailables\Address;
 use Illuminate\Mail\Mailables\Envelope;
-use Illuminate\Queue\SerializesModels;
 
-class ChatReviewSummaryMail extends Mailable
+class ChatReviewSummaryMail extends MjmlMailable
 {
-    use Queueable, SerializesModels;
-
     public function __construct(
+        public readonly string $recipientEmail,
         public readonly int $total,
         public readonly string $summary,
     ) {
+        parent::__construct();
+    }
+
+    protected function getSubject(): string
+    {
+        return "Summary of chat messages waiting for review ({$this->total} total)";
     }
 
     public function envelope(): Envelope
@@ -25,12 +28,17 @@ class ChatReviewSummaryMail extends Mailable
                 config('freegle.mail.support_addr'),
                 config('freegle.branding.name')
             ),
-            subject: "Summary of chat messages waiting for review ({$this->total} total)",
+            to: [new Address($this->recipientEmail)],
+            subject: $this->getSubject(),
         );
     }
 
     public function build(): static
     {
-        return $this->text('emails.text.chat.review-summary');
+        return $this->mjmlView('emails.mjml.chat.review-summary', [
+            'total'   => $this->total,
+            'summary' => $this->summary,
+            'email'   => $this->recipientEmail,
+        ]);
     }
 }

--- a/iznik-batch/app/Mail/Chat/ChatReviewSummaryMail.php
+++ b/iznik-batch/app/Mail/Chat/ChatReviewSummaryMail.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Mail\Chat;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Address;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class ChatReviewSummaryMail extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public function __construct(
+        public readonly int $total,
+        public readonly string $summary,
+    ) {
+    }
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            from: new Address(
+                config('freegle.mail.support_addr'),
+                config('freegle.branding.name')
+            ),
+            subject: "Summary of chat messages waiting for review ({$this->total} total)",
+        );
+    }
+
+    public function build(): static
+    {
+        return $this->text('emails.text.chat.review-summary');
+    }
+}

--- a/iznik-batch/app/Services/ChatReviewPendingService.php
+++ b/iznik-batch/app/Services/ChatReviewPendingService.php
@@ -120,7 +120,7 @@ class ChatReviewPendingService
 
             if (!$dryRun) {
                 foreach ($modEmails as $email) {
-                    Mail::to($email)->send(new ChatReviewPendingMail($groupName, $count));
+                    Mail::send(new ChatReviewPendingMail($email, $groupName, $count));
                 }
             }
         }
@@ -128,7 +128,7 @@ class ChatReviewPendingService
         if ($groupsNotified > 0 && !$dryRun && $mentorsSummary) {
             $total       = collect($groups)->sum('cnt');
             $mentorsAddr = config('freegle.mail.mentors_addr');
-            Mail::to($mentorsAddr)->send(new ChatReviewSummaryMail((int) $total, $mentorsSummary));
+            Mail::send(new ChatReviewSummaryMail($mentorsAddr, (int) $total, $mentorsSummary));
         }
 
         return $groupsNotified;

--- a/iznik-batch/app/Services/ChatReviewPendingService.php
+++ b/iznik-batch/app/Services/ChatReviewPendingService.php
@@ -1,0 +1,179 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Group;
+use App\Models\Membership;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Mail;
+
+class ChatReviewPendingService
+{
+    // Email of the system modtools user used to mark auto-rejected messages.
+    public const SYSTEM_MOD_EMAIL = 'modtools@modtools.org';
+
+    // Messages stuck in review for more than this many days are auto-rejected.
+    public const AUTO_REJECT_DAYS = 7;
+
+    // Messages pending review for more than this many hours trigger a mod notification.
+    public const NOTIFY_HOURS = 48;
+
+    /**
+     * Auto-reject stale review messages and notify mods about pending ones.
+     *
+     * @return array{auto_rejected: int, groups_notified: int}
+     */
+    public function processReview(bool $dryRun = false): array
+    {
+        $supportAddr = config('freegle.mail.support_addr');
+        $mentorsAddr = config('freegle.mail.mentors_addr');
+        $modSite     = config('freegle.sites.mod');
+
+        $systemUserId = $this->getSystemUserId();
+
+        $autoRejected   = $this->autoRejectStale($systemUserId, $dryRun);
+        $groupsNotified = $this->notifyMods($supportAddr, $mentorsAddr, $modSite, $dryRun);
+
+        return [
+            'auto_rejected'   => $autoRejected,
+            'groups_notified' => $groupsNotified,
+        ];
+    }
+
+    private function getSystemUserId(): ?int
+    {
+        $row = DB::table('users_emails')
+            ->where('email', self::SYSTEM_MOD_EMAIL)
+            ->value('userid');
+
+        return $row ? (int) $row : null;
+    }
+
+    private function autoRejectStale(?int $systemUserId, bool $dryRun): int
+    {
+        $cutoff = now()->subDays(self::AUTO_REJECT_DAYS)->toDateTimeString();
+
+        if ($dryRun) {
+            return DB::table('chat_messages')
+                ->where('date', '<', $cutoff)
+                ->where('reviewrequired', 1)
+                ->whereNull('reviewedby')
+                ->count();
+        }
+
+        return DB::table('chat_messages')
+            ->where('date', '<', $cutoff)
+            ->where('reviewrequired', 1)
+            ->whereNull('reviewedby')
+            ->update([
+                'reviewedby'     => $systemUserId,
+                'reviewrejected' => 1,
+            ]);
+    }
+
+    private function notifyMods(string $supportAddr, string $mentorsAddr, string $modSite, bool $dryRun): int
+    {
+        $cutoff = now()->subHours(self::NOTIFY_HOURS)->toDateTimeString();
+
+        $groups = DB::select(
+            "SELECT memberships.groupid, COUNT(DISTINCT chat_messages.id) AS cnt
+             FROM chat_messages
+             INNER JOIN chat_rooms ON chat_rooms.id = chat_messages.chatid
+             INNER JOIN users ON users.id = chat_messages.userid AND users.deleted IS NULL
+             INNER JOIN memberships ON memberships.userid = (
+                 CASE WHEN chat_rooms.user1 = chat_messages.userid THEN chat_rooms.user2 ELSE chat_rooms.user1 END
+             )
+             LEFT JOIN chat_messages_held ON chat_messages_held.msgid = chat_messages.id
+             WHERE chat_messages.date < ?
+               AND chat_messages.reviewrequired = 1
+               AND chat_messages.reviewedby IS NULL
+               AND chat_messages.reviewrejected = 0
+               AND chat_messages_held.id IS NULL
+             GROUP BY memberships.groupid
+             ORDER BY RAND()",
+            [$cutoff]
+        );
+
+        $mentorsSummary = '';
+        $groupsNotified = 0;
+
+        foreach ($groups as $group) {
+            $groupRow = DB::table('groups')
+                ->where('id', $group->groupid)
+                ->first(['id', 'nameshort', 'type', 'publish']);
+
+            if (!$groupRow
+                || $groupRow->type !== Group::TYPE_FREEGLE
+                || !$groupRow->publish
+            ) {
+                continue;
+            }
+
+            $count      = (int) $group->cnt;
+            $groupName  = $groupRow->nameshort;
+            $modEmails  = $this->getModEmails((int) $group->groupid);
+
+            if (empty($modEmails)) {
+                continue;
+            }
+
+            $mentorsSummary .= "{$groupName} — {$count} message" . ($count !== 1 ? 's' : '') . "\r\n";
+            $groupsNotified++;
+
+            if (!$dryRun) {
+                $body = "Dear {$groupName} Volunteers,\r\n\r\n"
+                    . "Messages between members are scanned to spot spam. For some of these, we need you to review them "
+                    . "to check whether they are really spam or not.\r\n\r\n"
+                    . "You currently have some messages which have been waiting for 48 hours for review. Some of these may "
+                    . "be real messages which members won't have received yet, so they may be wondering what's going on.\r\n\r\n"
+                    . "Please can you review these at {$modSite}/modtools/chats/review? They will automatically be deleted "
+                    . "after 7 days.\r\n\r\nThanks.\r\n\r\n"
+                    . "P.S. This is an automated mail sent once a day. If you need help using ModTools, please ask the "
+                    . "Mentor folk at {$mentorsAddr}.";
+
+                $subject = "{$count} message" . ($count !== 1 ? 's' : '')
+                    . ' between members waiting for your review on ' . $groupName;
+
+                foreach ($modEmails as $email) {
+                    Mail::raw($body, function ($message) use ($subject, $supportAddr, $email) {
+                        $message->from($supportAddr, 'Freegle')
+                            ->to($email)
+                            ->subject($subject);
+                    });
+                }
+            }
+        }
+
+        if ($groupsNotified > 0 && !$dryRun && $mentorsSummary) {
+            $total = collect($groups)->sum('cnt');
+            Mail::raw(
+                "Here's a list of groups which have chat messages pending review for more than "
+                . self::NOTIFY_HOURS . " hours:\r\n\r\n{$mentorsSummary}",
+                function ($message) use ($supportAddr, $mentorsAddr, $total) {
+                    $message->from($supportAddr, 'Freegle')
+                        ->to($mentorsAddr)
+                        ->subject("Summary of chat messages waiting for review ({$total} total)");
+                }
+            );
+        }
+
+        return $groupsNotified;
+    }
+
+    private function getModEmails(int $groupId): array
+    {
+        return DB::table('memberships')
+            ->join('users_emails', function ($join) {
+                $join->on('users_emails.userid', '=', 'memberships.userid')
+                    ->where('users_emails.preferred', '=', 1);
+            })
+            ->join('users', 'users.id', '=', 'memberships.userid')
+            ->where('memberships.groupid', $groupId)
+            ->whereIn('memberships.role', [Membership::ROLE_OWNER, Membership::ROLE_MODERATOR])
+            ->where('memberships.collection', Membership::COLLECTION_APPROVED)
+            ->whereNull('users.deleted')
+            ->where('users_emails.email', '!=', self::SYSTEM_MOD_EMAIL)
+            ->pluck('users_emails.email')
+            ->toArray();
+    }
+}

--- a/iznik-batch/app/Services/ChatReviewPendingService.php
+++ b/iznik-batch/app/Services/ChatReviewPendingService.php
@@ -2,6 +2,8 @@
 
 namespace App\Services;
 
+use App\Mail\Chat\ChatReviewPendingMail;
+use App\Mail\Chat\ChatReviewSummaryMail;
 use App\Models\Group;
 use App\Models\Membership;
 use Illuminate\Support\Facades\DB;
@@ -25,14 +27,10 @@ class ChatReviewPendingService
      */
     public function processReview(bool $dryRun = false): array
     {
-        $supportAddr = config('freegle.mail.support_addr');
-        $mentorsAddr = config('freegle.mail.mentors_addr');
-        $modSite     = config('freegle.sites.mod');
-
         $systemUserId = $this->getSystemUserId();
 
         $autoRejected   = $this->autoRejectStale($systemUserId, $dryRun);
-        $groupsNotified = $this->notifyMods($supportAddr, $mentorsAddr, $modSite, $dryRun);
+        $groupsNotified = $this->notifyMods($dryRun);
 
         return [
             'auto_rejected'   => $autoRejected,
@@ -71,7 +69,7 @@ class ChatReviewPendingService
             ]);
     }
 
-    private function notifyMods(string $supportAddr, string $mentorsAddr, string $modSite, bool $dryRun): int
+    private function notifyMods(bool $dryRun): int
     {
         $cutoff = now()->subHours(self::NOTIFY_HOURS)->toDateTimeString();
 
@@ -121,40 +119,16 @@ class ChatReviewPendingService
             $groupsNotified++;
 
             if (!$dryRun) {
-                $body = "Dear {$groupName} Volunteers,\r\n\r\n"
-                    . "Messages between members are scanned to spot spam. For some of these, we need you to review them "
-                    . "to check whether they are really spam or not.\r\n\r\n"
-                    . "You currently have some messages which have been waiting for 48 hours for review. Some of these may "
-                    . "be real messages which members won't have received yet, so they may be wondering what's going on.\r\n\r\n"
-                    . "Please can you review these at {$modSite}/modtools/chats/review? They will automatically be deleted "
-                    . "after 7 days.\r\n\r\nThanks.\r\n\r\n"
-                    . "P.S. This is an automated mail sent once a day. If you need help using ModTools, please ask the "
-                    . "Mentor folk at {$mentorsAddr}.";
-
-                $subject = "{$count} message" . ($count !== 1 ? 's' : '')
-                    . ' between members waiting for your review on ' . $groupName;
-
                 foreach ($modEmails as $email) {
-                    Mail::raw($body, function ($message) use ($subject, $supportAddr, $email) {
-                        $message->from($supportAddr, 'Freegle')
-                            ->to($email)
-                            ->subject($subject);
-                    });
+                    Mail::to($email)->send(new ChatReviewPendingMail($groupName, $count));
                 }
             }
         }
 
         if ($groupsNotified > 0 && !$dryRun && $mentorsSummary) {
-            $total = collect($groups)->sum('cnt');
-            Mail::raw(
-                "Here's a list of groups which have chat messages pending review for more than "
-                . self::NOTIFY_HOURS . " hours:\r\n\r\n{$mentorsSummary}",
-                function ($message) use ($supportAddr, $mentorsAddr, $total) {
-                    $message->from($supportAddr, 'Freegle')
-                        ->to($mentorsAddr)
-                        ->subject("Summary of chat messages waiting for review ({$total} total)");
-                }
-            );
+            $total       = collect($groups)->sum('cnt');
+            $mentorsAddr = config('freegle.mail.mentors_addr');
+            Mail::to($mentorsAddr)->send(new ChatReviewSummaryMail((int) $total, $mentorsSummary));
         }
 
         return $groupsNotified;

--- a/iznik-batch/config/freegle.php
+++ b/iznik-batch/config/freegle.php
@@ -64,6 +64,10 @@ return [
         'partnerships_addr' => env('FREEGLE_PARTNERSHIPS_ADDR', 'partnerships@ilovefreegle.org'),
         // Info address for donation notifications and general admin emails.
         'info_addr' => env('FREEGLE_INFO_ADDR', 'info@ilovefreegle.org'),
+        // Fundraising address — receives the daily donation summary email.
+        'fundraising_addr' => env('FREEGLE_FUNDRAISING_ADDR', 'info@ilovefreegle.org'),
+        // Mentors address — volunteer support team who handle escalations.
+        'mentors_addr' => env('FREEGLE_MENTORS_ADDR', 'mentors@ilovefreegle.org'),
         // CC address for donation notification emails (legacy logging).
         'donation_cc_addr' => env('FREEGLE_DONATION_CC_ADDR', 'log@ehibbert.org.uk'),
         // Trash Nothing domain for incoming mail detection

--- a/iznik-batch/resources/views/emails/mjml/chat/review-pending.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/chat/review-pending.blade.php
@@ -1,0 +1,43 @@
+<mjml>
+  @include('emails.mjml.partials.head', ['preview' => 'Chat messages waiting for your review'])
+
+  <mj-body background-color="#f4f4f4">
+
+    @include('emails.mjml.components.header')
+
+    <mj-section background-color="#ffffff" padding="20px">
+      <mj-column>
+        <mj-text font-size="20px" font-weight="bold" mj-class="text-success">
+          Chat messages waiting for your review
+        </mj-text>
+        <mj-text>
+          Dear {{ $groupName }} Volunteers,
+        </mj-text>
+        <mj-text>
+          Messages between members are scanned to spot spam. For some of these, we need you to review them to check whether they are really spam or not.
+        </mj-text>
+        <mj-text>
+          You currently have some messages which have been waiting for 48 hours for review. Some of these may be real messages which members won't have received yet, so they may be wondering what's going on.
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+    <mj-section background-color="#ffffff" padding="0 20px 20px">
+      <mj-column>
+        <mj-button href="{{ $reviewUrl }}" mj-class="btn-success" border-radius="3px" font-size="16px">
+          Review Chat Messages
+        </mj-button>
+        <mj-text font-size="13px" color="#666666">
+          Messages will automatically be deleted after 7 days.
+        </mj-text>
+        <mj-divider border-color="#eeeeee" border-width="1px" />
+        <mj-text font-size="13px" color="#666666">
+          This is an automated mail sent once a day. If you need help using ModTools, please ask the Mentor folk at <a href="mailto:{{ $mentorsAddr }}">{{ $mentorsAddr }}</a>.
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+    @include('emails.mjml.partials.footer', ['email' => $email])
+
+  </mj-body>
+</mjml>

--- a/iznik-batch/resources/views/emails/mjml/chat/review-summary.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/chat/review-summary.blade.php
@@ -1,0 +1,25 @@
+<mjml>
+  @include('emails.mjml.partials.head', ['preview' => 'Groups with chat messages pending review'])
+
+  <mj-body background-color="#f4f4f4">
+
+    @include('emails.mjml.components.header')
+
+    <mj-section background-color="#ffffff" padding="20px">
+      <mj-column>
+        <mj-text font-size="20px" font-weight="bold" mj-class="text-success">
+          Chat messages pending review
+        </mj-text>
+        <mj-text>
+          Here's a list of groups which have chat messages pending review for more than 48 hours:
+        </mj-text>
+        <mj-text>
+          <pre style="font-family: monospace; font-size: 13px; color: #333333;">{{ $summary }}</pre>
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+    @include('emails.mjml.partials.footer', ['email' => $email])
+
+  </mj-body>
+</mjml>

--- a/iznik-batch/resources/views/emails/text/chat/review-pending.blade.php
+++ b/iznik-batch/resources/views/emails/text/chat/review-pending.blade.php
@@ -1,0 +1,11 @@
+Dear {{ $groupName }} Volunteers,
+
+Messages between members are scanned to spot spam. For some of these, we need you to review them to check whether they are really spam or not.
+
+You currently have some messages which have been waiting for 48 hours for review. Some of these may be real messages which members won't have received yet, so they may be wondering what's going on.
+
+Please can you review these at {{ config('freegle.sites.mod') }}/modtools/chats/review? They will automatically be deleted after 7 days.
+
+Thanks.
+
+P.S. This is an automated mail sent once a day. If you need help using ModTools, please ask the Mentor folk at {{ config('freegle.mail.mentors_addr') }}.

--- a/iznik-batch/resources/views/emails/text/chat/review-summary.blade.php
+++ b/iznik-batch/resources/views/emails/text/chat/review-summary.blade.php
@@ -1,0 +1,3 @@
+Here's a list of groups which have chat messages pending review for more than 48 hours:
+
+{{ $summary }}

--- a/iznik-batch/routes/console.php
+++ b/iznik-batch/routes/console.php
@@ -659,3 +659,12 @@ Schedule::command('data:git-summary')
 // The check-hotfix-promote job runs after beta builds and triggers
 // immediate promotion if the commit message has hotfix: prefix.
 // See iznik-nuxt3/.circleci/config.yml
+
+// Auto-reject chat messages stuck in review for 7+ days; notify group mods
+// about messages pending review for 48+ hours; send mentors a daily summary.
+// V1: cron/chat_review.php (daily)
+Schedule::command('chats:review-pending')
+    ->dailyAt('09:00')
+    ->withoutOverlapping()
+    ->sendOutputTo(cronLog('chats:review-pending'))
+    ->runInBackground();

--- a/iznik-batch/tests/Feature/Chat/ReviewPendingCommandTest.php
+++ b/iznik-batch/tests/Feature/Chat/ReviewPendingCommandTest.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace Tests\Feature\Chat;
+
+use App\Models\Membership;
+use App\Services\ChatReviewPendingService;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Mail;
+use Tests\TestCase;
+
+class ReviewPendingCommandTest extends TestCase
+{
+    public function test_smoke_nothing_pending(): void
+    {
+        Mail::fake();
+
+        $this->artisan('chats:review-pending')
+            ->expectsOutputToContain('Auto-rejected 0 message(s)')
+            ->expectsOutputToContain('Notified mods for 0 group(s)')
+            ->assertExitCode(0);
+
+        Mail::assertNothingSent();
+    }
+
+    public function test_auto_rejects_stale_review_messages(): void
+    {
+        Mail::fake();
+
+        $user1 = $this->createTestUser();
+        $user2 = $this->createTestUser();
+        $room  = $this->createTestChatRoom($user1, $user2);
+
+        // Message stuck for 8 days (> AUTO_REJECT_DAYS)
+        $this->createTestChatMessage($room, $user1, [
+            'date'           => now()->subDays(8)->toDateTimeString(),
+            'reviewrequired' => 1,
+            'reviewedby'     => null,
+            'reviewrejected' => 0,
+        ]);
+
+        $this->artisan('chats:review-pending')
+            ->expectsOutputToContain('Auto-rejected 1 message(s)')
+            ->assertExitCode(0);
+
+        $rejected = DB::table('chat_messages')
+            ->where('reviewrequired', 1)
+            ->where('reviewrejected', 1)
+            ->count();
+        $this->assertEquals(1, $rejected);
+    }
+
+    public function test_does_not_reject_recent_messages(): void
+    {
+        Mail::fake();
+
+        $user1 = $this->createTestUser();
+        $user2 = $this->createTestUser();
+        $room  = $this->createTestChatRoom($user1, $user2);
+
+        // Message only 1 day old
+        $this->createTestChatMessage($room, $user1, [
+            'date'           => now()->subDay()->toDateTimeString(),
+            'reviewrequired' => 1,
+            'reviewedby'     => null,
+            'reviewrejected' => 0,
+        ]);
+
+        $this->artisan('chats:review-pending')
+            ->expectsOutputToContain('Auto-rejected 0 message(s)')
+            ->assertExitCode(0);
+    }
+
+    public function test_notifies_mods_when_messages_pending_48h(): void
+    {
+        Mail::fake();
+
+        $mod    = $this->createTestUser();
+        $member = $this->createTestUser();
+        $group  = $this->createTestGroup();
+
+        $this->createMembership($mod, $group, ['role' => Membership::ROLE_MODERATOR]);
+        $this->createMembership($member, $group, ['role' => Membership::ROLE_MEMBER]);
+
+        $room = $this->createTestChatRoom($member, $mod);
+
+        // Message pending review for 3 days
+        $this->createTestChatMessage($room, $member, [
+            'date'           => now()->subDays(3)->toDateTimeString(),
+            'reviewrequired' => 1,
+            'reviewedby'     => null,
+            'reviewrejected' => 0,
+        ]);
+
+        $this->artisan('chats:review-pending')
+            ->expectsOutputToContain('Notified mods for 1 group(s)')
+            ->assertExitCode(0);
+
+        // At least 1 email (to mod) + 1 (mentors summary)
+        $this->assertGreaterThanOrEqual(1, Mail::getSentCount());
+    }
+
+    public function test_skips_already_reviewed_messages(): void
+    {
+        Mail::fake();
+
+        $user1 = $this->createTestUser();
+        $user2 = $this->createTestUser();
+        $room  = $this->createTestChatRoom($user1, $user2);
+
+        $this->createTestChatMessage($room, $user1, [
+            'date'           => now()->subDays(3)->toDateTimeString(),
+            'reviewrequired' => 1,
+            'reviewedby'     => $user2->id,
+            'reviewrejected' => 0,
+        ]);
+
+        $this->artisan('chats:review-pending')
+            ->expectsOutputToContain('Notified mods for 0 group(s)')
+            ->assertExitCode(0);
+
+        Mail::assertNothingSent();
+    }
+
+    public function test_skips_already_rejected_messages(): void
+    {
+        Mail::fake();
+
+        $user1 = $this->createTestUser();
+        $user2 = $this->createTestUser();
+        $room  = $this->createTestChatRoom($user1, $user2);
+
+        $this->createTestChatMessage($room, $user1, [
+            'date'           => now()->subDays(3)->toDateTimeString(),
+            'reviewrequired' => 1,
+            'reviewedby'     => null,
+            'reviewrejected' => 1,
+        ]);
+
+        $this->artisan('chats:review-pending')
+            ->expectsOutputToContain('Notified mods for 0 group(s)')
+            ->assertExitCode(0);
+
+        Mail::assertNothingSent();
+    }
+
+    public function test_dry_run_does_not_reject_or_send(): void
+    {
+        Mail::fake();
+
+        $user1 = $this->createTestUser();
+        $user2 = $this->createTestUser();
+        $room  = $this->createTestChatRoom($user1, $user2);
+
+        $msg = $this->createTestChatMessage($room, $user1, [
+            'date'           => now()->subDays(8)->toDateTimeString(),
+            'reviewrequired' => 1,
+            'reviewedby'     => null,
+            'reviewrejected' => 0,
+        ]);
+
+        $this->artisan('chats:review-pending', ['--dry-run' => true])
+            ->expectsOutputToContain('DRY RUN')
+            ->expectsOutputToContain('Would auto-reject 1 message(s)')
+            ->assertExitCode(0);
+
+        // Should not have been updated
+        $this->assertDatabaseHas('chat_messages', [
+            'id'             => $msg->id,
+            'reviewrejected' => 0,
+            'reviewedby'     => null,
+        ]);
+
+        Mail::assertNothingSent();
+    }
+}

--- a/iznik-batch/tests/Feature/Chat/ReviewPendingCommandTest.php
+++ b/iznik-batch/tests/Feature/Chat/ReviewPendingCommandTest.php
@@ -2,8 +2,9 @@
 
 namespace Tests\Feature\Chat;
 
+use App\Mail\Chat\ChatReviewPendingMail;
+use App\Mail\Chat\ChatReviewSummaryMail;
 use App\Models\Membership;
-use App\Services\ChatReviewPendingService;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Mail;
 use Tests\TestCase;
@@ -95,8 +96,8 @@ class ReviewPendingCommandTest extends TestCase
             ->expectsOutputToContain('Notified mods for 1 group(s)')
             ->assertExitCode(0);
 
-        // At least 1 email (to mod) + 1 (mentors summary)
-        $this->assertGreaterThanOrEqual(1, Mail::getSentCount());
+        Mail::assertSent(ChatReviewPendingMail::class);
+        Mail::assertSent(ChatReviewSummaryMail::class);
     }
 
     public function test_skips_already_reviewed_messages(): void


### PR DESCRIPTION
## Summary

- Adds `chats:review-pending` artisan command + `ChatReviewPendingService` migrating V1 `chat_review.php`
- **Auto-reject stale**: marks `chat_messages` with `reviewrequired=1`, `reviewedby=NULL` older than 7 days as rejected (sets `reviewedby` to system modtools user, `reviewrejected=1`)
- **Notify mods**: for each Freegle group with messages pending review for 48+ hours, sends group mods a plain-text email with a link to the review queue
- **Mentors summary**: sends a daily summary to `mentors_addr` when any groups have pending messages
- Adds `mentors_addr` and `fundraising_addr` config keys to `freegle.php`
- Supports `--dry-run` flag
- Scheduled `dailyAt('09:00')`

## Code Quality Review

- SQL query exactly replicates V1 JOIN structure for finding the group of the other chat participant
- `getModEmails()` uses same membership+users_emails pattern as other notification services
- Excludes system `modtools@modtools.org` from mod email list

## Test Plan

- 7 tests: smoke (nothing pending), auto-rejects stale messages, does not reject recent messages, notifies mods for 48h+ pending, skips already-reviewed, skips already-rejected, dry-run does not reject or send