### PR TITLE
feat(batch): migrate tn_names.php to users:fix-tn-names

### DIFF
--- a/iznik-batch/app/Console/Commands/User/FixTNNamesCommand.php
+++ b/iznik-batch/app/Console/Commands/User/FixTNNamesCommand.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Console\Commands\User;
+
+use App\Traits\LogsBatchJob;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+class FixTNNamesCommand extends Command
+{
+    use LogsBatchJob;
+
+    protected $signature = 'users:fix-tn-names
+                            {--dry-run : Show what would be updated without making changes}';
+
+    protected $description = 'Fix display names for Trash Nothing users whose email encodes their name';
+
+    public function handle(): int
+    {
+        $dryRun = $this->option('dry-run');
+
+        if ($dryRun) {
+            $this->info('DRY RUN — no changes will be made.');
+        }
+
+        return $this->runWithLogging(function () use ($dryRun) {
+            Log::info('Starting TN name fix', ['dry_run' => $dryRun]);
+
+            $fixed  = 0;
+            $skipped = 0;
+
+            // TN emails have the format: firstname-groupid@trashnothing.com
+            // The backwards column is the reversed email, so TN emails end with 'moc.gnihtonhsart'
+            $rows = DB::table('users')
+                ->join('users_emails', 'users.id', '=', 'users_emails.userid')
+                ->where('users_emails.backwards', 'LIKE', 'moc.gnihtonhsart%')
+                ->whereNull('users.firstname')
+                ->whereNull('users.lastname')
+                ->where(function ($q) {
+                    $q->whereNull('users.fullname')
+                      ->orWhereRaw("users.fullname LIKE '%-%'");
+                })
+                ->select('users.id', 'users.fullname', 'users_emails.email')
+                ->get();
+
+            foreach ($rows as $row) {
+                if (preg_match('/^(.*)-[^-]+@/', $row->email, $matches)) {
+                    $name = $matches[1];
+
+                    Log::debug("FixTNNames: set fullname for user {$row->id} from {$row->email} => {$name}");
+
+                    if (!$dryRun) {
+                        DB::table('users')
+                            ->where('id', $row->id)
+                            ->update(['fullname' => $name]);
+                    }
+
+                    $fixed++;
+                } else {
+                    $skipped++;
+                }
+            }
+
+            $this->info("Processed " . count($rows) . " TN users: fixed {$fixed}, skipped {$skipped}.");
+            Log::info('TN name fix complete', [
+                'candidates' => count($rows),
+                'fixed'      => $fixed,
+                'skipped'    => $skipped,
+            ]);
+
+            return Command::SUCCESS;
+        });
+    }
+}

--- a/iznik-batch/app/Console/Commands/User/FixTNNamesCommand.php
+++ b/iznik-batch/app/Console/Commands/User/FixTNNamesCommand.php
@@ -30,11 +30,13 @@ class FixTNNamesCommand extends Command
             $fixed  = 0;
             $skipped = 0;
 
-            // TN emails have the format: firstname-groupid@trashnothing.com
-            // The backwards column is the reversed email, so TN emails end with 'moc.gnihtonhsart'
+            // TN emails have the format: firstname-groupid@trashnothing.com.
+            // The backwards column stores strrev(email), so TN rows begin with the reversed domain.
+            $tnBackwardsPrefix = strrev(config('freegle.mail.trashnothing_domain')) . '%';
+
             $rows = DB::table('users')
                 ->join('users_emails', 'users.id', '=', 'users_emails.userid')
-                ->where('users_emails.backwards', 'LIKE', 'moc.gnihtonhsart%')
+                ->where('users_emails.backwards', 'LIKE', $tnBackwardsPrefix)
                 ->whereNull('users.firstname')
                 ->whereNull('users.lastname')
                 ->where(function ($q) {
@@ -62,7 +64,8 @@ class FixTNNamesCommand extends Command
                 }
             }
 
-            $this->info("Processed " . count($rows) . " TN users: fixed {$fixed}, skipped {$skipped}.");
+            $verb = $dryRun ? 'would fix' : 'fixed';
+            $this->info("Processed " . count($rows) . " TN users: {$verb} {$fixed}, skipped {$skipped}.");
             Log::info('TN name fix complete', [
                 'candidates' => count($rows),
                 'fixed'      => $fixed,

--- a/iznik-batch/routes/console.php
+++ b/iznik-batch/routes/console.php
@@ -438,6 +438,13 @@ Schedule::command('users:remap-locations')
     ->sendOutputTo(cronLog('users:remap-locations'))
     ->runInBackground();
 
+// V1: cron/tn_names.php — fix display names for TN users whose email encodes their name.
+Schedule::command('users:fix-tn-names')
+    ->dailyAt('06:30')
+    ->withoutOverlapping()
+    ->sendOutputTo(cronLog('users:fix-tn-names'))
+    ->runInBackground();
+
 // Update message subjects when associated location names have changed.
 // V1: cron/messages_remap.php (every 5 minutes)
 Schedule::command('messages:remap-subjects')

--- a/iznik-batch/tests/Feature/User/FixTNNamesCommandTest.php
+++ b/iznik-batch/tests/Feature/User/FixTNNamesCommandTest.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Tests\Feature\User;
+
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class FixTNNamesCommandTest extends TestCase
+{
+    private function createTNUser(string $namePart, string $groupId = '12345'): int
+    {
+        $userId = DB::table('users')->insertGetId([
+            'firstname' => null,
+            'lastname'  => null,
+            'fullname'  => null,
+            'added'     => now(),
+        ]);
+
+        $email = "{$namePart}-{$groupId}@trashnothing.com";
+
+        DB::table('users_emails')->insert([
+            'userid'    => $userId,
+            'email'     => $email,
+            'backwards' => strrev($email),
+            'preferred' => 1,
+            'added'     => now(),
+        ]);
+
+        return $userId;
+    }
+
+    private function createRegularUser(): int
+    {
+        $userId = DB::table('users')->insertGetId([
+            'firstname' => null,
+            'lastname'  => null,
+            'fullname'  => null,
+            'added'     => now(),
+        ]);
+
+        $email = 'user-' . uniqid() . '@example.com';
+
+        DB::table('users_emails')->insert([
+            'userid'    => $userId,
+            'email'     => $email,
+            'backwards' => strrev($email),
+            'preferred' => 1,
+            'added'     => now(),
+        ]);
+
+        return $userId;
+    }
+
+    public function test_smoke_no_tn_users(): void
+    {
+        $this->artisan('users:fix-tn-names')
+            ->assertExitCode(0);
+    }
+
+    public function test_fixes_tn_user_fullname(): void
+    {
+        $userId = $this->createTNUser('Alice');
+
+        $this->artisan('users:fix-tn-names')
+            ->assertExitCode(0);
+
+        $user = DB::table('users')->where('id', $userId)->first();
+        $this->assertSame('Alice', $user->fullname);
+    }
+
+    public function test_skips_tn_user_with_existing_fullname_without_hyphen(): void
+    {
+        $userId = $this->createTNUser('Bob');
+        DB::table('users')->where('id', $userId)->update(['fullname' => 'Bobby']);
+
+        $this->artisan('users:fix-tn-names')
+            ->assertExitCode(0);
+
+        $user = DB::table('users')->where('id', $userId)->first();
+        $this->assertSame('Bobby', $user->fullname);
+    }
+
+    public function test_fixes_tn_user_with_hyphenated_fullname(): void
+    {
+        $userId = $this->createTNUser('Charlie');
+        // fullname contains a hyphen — previously set from a stale TN sync
+        DB::table('users')->where('id', $userId)->update(['fullname' => 'Charlie-12345']);
+
+        $this->artisan('users:fix-tn-names')
+            ->assertExitCode(0);
+
+        $user = DB::table('users')->where('id', $userId)->first();
+        $this->assertSame('Charlie', $user->fullname);
+    }
+
+    public function test_skips_regular_user(): void
+    {
+        $userId = $this->createRegularUser();
+
+        $this->artisan('users:fix-tn-names')
+            ->assertExitCode(0);
+
+        $user = DB::table('users')->where('id', $userId)->first();
+        $this->assertNull($user->fullname);
+    }
+
+    public function test_dry_run_does_not_update(): void
+    {
+        $userId = $this->createTNUser('Diana');
+
+        $this->artisan('users:fix-tn-names', ['--dry-run' => true])
+            ->assertExitCode(0);
+
+        $user = DB::table('users')->where('id', $userId)->first();
+        $this->assertNull($user->fullname);
+    }
+
+    public function test_handles_multiple_tn_users(): void
+    {
+        $id1 = $this->createTNUser('Eve', '111');
+        $id2 = $this->createTNUser('Frank', '222');
+
+        $this->artisan('users:fix-tn-names')
+            ->assertExitCode(0);
+
+        $this->assertSame('Eve', DB::table('users')->where('id', $id1)->value('fullname'));
+        $this->assertSame('Frank', DB::table('users')->where('id', $id2)->value('fullname'));
+    }
+}


### PR DESCRIPTION
## Summary

- Migrates V1 `cron/tn_names.php` to Laravel artisan command `users:fix-tn-names`
- Trash Nothing emails have the format `firstname-groupid@trashnothing.com` — this command extracts the name part and sets `users.fullname` for TN users who don't have a proper name set
- Targets users where `firstname` and `lastname` are both null AND `fullname` is either null or contains a hyphen (indicating a previous incomplete fix)
- Uses the `backwards` column for efficient TN domain suffix matching
- Scheduled daily at 06:30

## Test Plan

- [x] Smoke test (no TN users) — exits 0
- [x] Fixes TN user's fullname from email
- [x] Skips TN user who already has a fullname without hyphen
- [x] Fixes TN user with hyphenated fullname (stale previous value)
- [x] Skips regular (non-TN) user
- [x] Dry run — exits 0, no updates made
- [x] Handles multiple TN users