### PR TITLE
feat(email): ModTools header/footer components for mod-facing emails

### DIFF
--- a/iznik-batch/config/freegle.php
+++ b/iznik-batch/config/freegle.php
@@ -25,6 +25,7 @@ return [
         'name' => env('FREEGLE_SITE_NAME', 'Freegle'),
         'logo_url' => env('FREEGLE_LOGO_URL', 'https://www.ilovefreegle.org/icon.png'),
         'wallpaper_url' => env('FREEGLE_WALLPAPER_URL', 'https://www.ilovefreegle.org/wallpaper.png'),
+        'modtools_logo_url' => env('MODTOOLS_LOGO_URL', 'https://modtools.org/icon.png'),
     ],
 
     'mail' => [

--- a/iznik-batch/resources/views/emails/mjml/chat/review-pending.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/chat/review-pending.blade.php
@@ -3,11 +3,11 @@
 
   <mj-body background-color="#f4f4f4">
 
-    @include('emails.mjml.components.header')
+    @include('emails.mjml.components.modtools-header')
 
     <mj-section background-color="#ffffff" padding="20px">
       <mj-column>
-        <mj-text font-size="20px" font-weight="bold" mj-class="text-success">
+        <mj-text font-size="20px" font-weight="bold" mj-class="text-modtools">
           Chat messages waiting for your review
         </mj-text>
         <mj-text>
@@ -24,7 +24,7 @@
 
     <mj-section background-color="#ffffff" padding="0 20px 20px">
       <mj-column>
-        <mj-button href="{{ $reviewUrl }}" mj-class="btn-success" border-radius="3px" font-size="16px">
+        <mj-button href="{{ $reviewUrl }}" mj-class="btn-modtools" border-radius="3px" font-size="16px">
           Review Chat Messages
         </mj-button>
         <mj-text font-size="13px" color="#666666">
@@ -37,7 +37,7 @@
       </mj-column>
     </mj-section>
 
-    @include('emails.mjml.partials.footer', ['email' => $email])
+    @include('emails.mjml.partials.modtools-footer', ['email' => $email])
 
   </mj-body>
 </mjml>

--- a/iznik-batch/resources/views/emails/mjml/chat/review-summary.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/chat/review-summary.blade.php
@@ -3,11 +3,11 @@
 
   <mj-body background-color="#f4f4f4">
 
-    @include('emails.mjml.components.header')
+    @include('emails.mjml.components.modtools-header')
 
     <mj-section background-color="#ffffff" padding="20px">
       <mj-column>
-        <mj-text font-size="20px" font-weight="bold" mj-class="text-success">
+        <mj-text font-size="20px" font-weight="bold" mj-class="text-modtools">
           Chat messages pending review
         </mj-text>
         <mj-text>
@@ -19,7 +19,7 @@
       </mj-column>
     </mj-section>
 
-    @include('emails.mjml.partials.footer', ['email' => $email])
+    @include('emails.mjml.partials.modtools-footer', ['email' => $email])
 
   </mj-body>
 </mjml>

--- a/iznik-batch/resources/views/emails/mjml/components/modtools-header.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/components/modtools-header.blade.php
@@ -1,0 +1,9 @@
+<mj-section mj-class="bg-modtools" padding="20px">
+    <mj-column>
+        <mj-image
+            width="120px"
+            src="{{ config('freegle.branding.modtools_logo_url') }}"
+            alt="ModTools"
+        />
+    </mj-column>
+</mj-section>

--- a/iznik-batch/resources/views/emails/mjml/group/closed-reminder.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/group/closed-reminder.blade.php
@@ -3,11 +3,11 @@
 
   <mj-body background-color="#f4f4f4">
 
-    @include('emails.mjml.components.header')
+    @include('emails.mjml.components.modtools-header')
 
     <mj-section background-color="#ffffff" padding="20px">
       <mj-column>
-        <mj-text font-size="20px" font-weight="bold" mj-class="text-success">
+        <mj-text font-size="20px" font-weight="bold" mj-class="text-modtools">
           Your Freegle group is currently closed
         </mj-text>
         <mj-text>
@@ -21,7 +21,7 @@
 
     <mj-section background-color="#ffffff" padding="0 20px 20px">
       <mj-column>
-        <mj-button href="{{ $modSite }}/modtools" mj-class="btn-success" border-radius="3px" font-size="16px">
+        <mj-button href="{{ $modSite }}/modtools" mj-class="btn-modtools" border-radius="3px" font-size="16px">
           Go to ModTools
         </mj-button>
         <mj-divider border-color="#eeeeee" border-width="1px" />
@@ -31,7 +31,7 @@
       </mj-column>
     </mj-section>
 
-    @include('emails.mjml.partials.footer', ['email' => $email])
+    @include('emails.mjml.partials.modtools-footer', ['email' => $email])
 
   </mj-body>
 </mjml>

--- a/iznik-batch/resources/views/emails/mjml/partials/modtools-footer.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/partials/modtools-footer.blade.php
@@ -1,0 +1,13 @@
+<mj-section background-color="#f5f5f5" padding="20px">
+  <mj-column>
+    <mj-text font-size="12px" color="#666666" align="center" line-height="1.6">
+      This email was sent to {{ $email }}<br/>
+      <a href="{{ $settingsUrl ?? config('freegle.sites.mod') . '/modtools/settings' }}" style="color: #396aa3;">Change your ModTools email settings</a>
+    </mj-text>
+    <mj-divider border-color="#ddd" border-width="1px" padding="15px 40px"></mj-divider>
+    <mj-text font-size="11px" color="#666666" align="center" line-height="1.5">
+      {{ config('freegle.branding.name') }} is registered as a charity with HMRC (ref. XT32865) and is run by volunteers. Which is nice.<br/>
+      Registered address: 64a North Road, Ormesby, Great Yarmouth, Norfolk NR29 3LE
+    </mj-text>
+  </mj-column>
+</mj-section>


### PR DESCRIPTION
## Summary
- Adds `modtools-header` and `modtools-footer` MJML partials using the #396aa3 ModTools blue colour scheme
- Adds `modtools_logo_url` to `config/freegle.php` (env: `MODTOOLS_LOGO_URL`)
- Updates `ChatReviewPendingMail`, `ChatReviewSummaryMail`, and `ClosedGroupReminderMail` templates to use ModTools branding instead of Freegle consumer branding

## Test plan
- [ ] Send test emails to Mailpit and verify blue ModTools header appears
- [ ] Verify "Change your ModTools email settings" link in footer