### PR TITLE
feat(digest): new MJML template, reply handling and immediate mode (Sub-PR 2 of 4)

### DIFF
--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -293,6 +293,10 @@ workflows:
       - mark-ci-passed:
           requires:
             - freegle/build-and-test
+          filters:
+            branches:
+              ignore:
+                - modtools
       - freegle/build-android-modtools-debug:
           requires:
             - freegle/build-and-test

--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -293,11 +293,6 @@ workflows:
       - mark-ci-passed:
           requires:
             - freegle/build-and-test
-          filters:
-            branches:
-              ignore:
-                - modtools
-                - production
       - freegle/build-android-modtools-debug:
           requires:
             - freegle/build-and-test

--- a/iznik-batch/app/Console/Commands/Mail/TestMailCommand.php
+++ b/iznik-batch/app/Console/Commands/Mail/TestMailCommand.php
@@ -5,7 +5,8 @@ namespace App\Console\Commands\Mail;
 use App\Console\Commands\Mail\SendAdminCommand;
 use App\Mail\Admin\AdminMail;
 use App\Mail\Chat\ChatNotification;
-use App\Mail\Digest\SingleDigest;
+use App\Mail\Digest\UnifiedDigest;
+use App\Services\UnifiedDigestService;
 use App\Mail\Donation\AskForDonation;
 use App\Mail\Donation\DonationThankYou;
 use App\Mail\Message\AutoRepostWarning;
@@ -16,7 +17,6 @@ use App\Mail\Stories\StoriesNewsletterMail;
 use App\Mail\Welcome\WelcomeMail;
 use App\Models\ChatMessage;
 use App\Models\ChatRoom;
-use App\Models\Group;
 use App\Models\Membership;
 use App\Models\Message;
 use App\Models\User;
@@ -37,12 +37,11 @@ class TestMailCommand extends Command
                             {--send-to= : Deliver email to this address instead (for testing with real user data)}
                             {--from= : Override From header address (for AMP testing - must be registered with Google)}
                             {--chat= : Chat room ID (for chat types)}
-                            {--group= : Group ID (for digest)}
-                            {--message= : Message ID (for digest)}
                             {--message-type= : Specific chat message type (Default, Interested, Promised, Reneged, Completed, Image, Address, Nudge, Schedule)}
                             {--all-types : Send test emails for all chat message types}
                             {--amp= : Override AMP email setting (on/off, default uses config)}
                             {--as= : For User2Mod chats: "member" or "mod" perspective (default: member)}
+                            {--mode= : Digest mode: immediate (single post) or daily (all recent posts, default)}
                             {--dry-run : Preview email content without sending}
                             {--list : List available email types}';
 
@@ -59,7 +58,7 @@ class TestMailCommand extends Command
         'admin:marketing' => 'Marketing admin email (Little Free Shop template)',
         'chat:user2user' => 'User-to-user chat notification',
         'chat:user2mod' => 'User-to-moderator chat notification',
-        'digest' => 'Digest email (single message)',
+        'digest' => 'Unified digest email (posts from all communities)',
         'donations:ask' => 'Donation request email',
         'donations:thank' => 'Donation thank you email',
         'welcome' => 'Welcome email for new users',
@@ -334,7 +333,7 @@ class TestMailCommand extends Command
         $this->line('  php artisan mail:test chat:user2user --to=test@example.com --amp=on');
         $this->line('  php artisan mail:test chat:user2user --to=test@example.com --amp=off');
         $this->line('  php artisan mail:test chat:user2user --to=realuser@example.com --send-to=mytest@example.com');
-        $this->line('  php artisan mail:test digest --user=12345 --group=67890 --to=test@example.com');
+        $this->line('  php artisan mail:test digest --to=test@example.com');
         $this->line('  php artisan mail:test donations:ask --user=12345 --dry-run');
     }
 
@@ -661,74 +660,80 @@ class TestMailCommand extends Command
     }
 
     /**
-     * Build a digest email.
+     * Build a unified digest email.
      */
-    protected function buildDigest(): ?SingleDigest
+    protected function buildDigest(): ?UnifiedDigest
     {
         $userId = $this->option('user');
-        $groupId = $this->option('group');
-        $messageId = $this->option('message');
+        $toEmail = $this->option('to');
 
-        // Get a message first — this guarantees we have a group with content.
-        if ($messageId) {
-            $message = Message::find($messageId);
-        } else {
-            // Find a message on the specified group, or any group with messages.
-            $messageQuery = Message::query();
-            if ($groupId) {
-                $messageQuery->whereHas('groups', function ($q) use ($groupId) {
-                    $q->where('groups.id', $groupId);
-                });
-            } else {
-                $messageQuery->whereHas('groups');
-            }
-            $message = $messageQuery->orderBy('id', 'desc')->first();
-        }
-
-        if (! $message) {
-            $this->error('No messages found'.($groupId ? " for group {$groupId}" : ' in any group'));
-
-            return null;
-        }
-
-        // Get the group from the message.
-        if ($groupId) {
-            $group = Group::find($groupId);
-        } else {
-            $group = $message->groups->first();
-        }
-
-        if (! $group) {
-            $this->error('No group found for message');
-
-            return null;
-        }
-
-        $this->info("Using group: {$group->nameshort} (ID: {$group->id})");
-        $this->info("Using message: {$message->subject} (ID: {$message->id})");
-
-        // Get or find a user.
-        if ($userId) {
+        // Get user.
+        if ($toEmail) {
+            $user = User::whereHas('emails', function ($q) use ($toEmail) {
+                $q->where('email', $toEmail);
+            })->first();
+        } elseif ($userId) {
             $user = User::find($userId);
         } else {
-            // Prefer a member of this group who has an email address.
-            $membership = Membership::where('groupid', $group->id)
-                ->whereHas('user', function ($q) {
-                    $q->whereHas('emails');
-                })
-                ->first();
-            $user = $membership ? User::find($membership->userid) : User::whereHas('emails')->first();
+            $user = User::whereHas('emails')
+                ->whereHas('memberships', fn ($q) => $q->where('collection', Membership::COLLECTION_APPROVED))
+                ->inRandomOrder()->first();
         }
 
         if (! $user) {
-            $this->error('No user found');
+            $this->error('User not found');
 
             return null;
         }
 
-        $this->info("Generating digest for user: {$user->displayname} (ID: {$user->id})");
+        $this->info("Generating unified digest for user: {$user->displayname} (ID: {$user->id})");
 
-        return new SingleDigest($user, $group, $message, 24);
+        // Get the user's group IDs.
+        $groupIds = $user->memberships()
+            ->where('collection', Membership::COLLECTION_APPROVED)
+            ->pluck('groupid');
+
+        if ($groupIds->isEmpty()) {
+            $this->error("User {$user->id} has no approved group memberships");
+
+            return null;
+        }
+
+        $this->info('User is a member of ' . $groupIds->count() . ' groups');
+
+        // Get recent messages from those groups.
+        $posts = Message::select('messages.*', 'messages_groups.groupid', 'messages_groups.arrival')
+            ->join('messages_groups', 'messages.id', '=', 'messages_groups.msgid')
+            ->whereIn('messages_groups.groupid', $groupIds)
+            ->where('messages_groups.collection', 'Approved')
+            ->where('messages_groups.deleted', 0)
+            ->whereNull('messages.deleted')
+            ->whereIn('messages.type', [Message::TYPE_OFFER, Message::TYPE_WANTED])
+            ->where('messages.fromuser', '!=', $user->id)
+            ->orderBy('messages_groups.arrival', 'desc')
+            ->limit(20)
+            ->with(['attachments', 'fromUser', 'groups'])
+            ->get();
+
+        if ($posts->isEmpty()) {
+            $this->error('No recent messages found in user\'s groups');
+
+            return null;
+        }
+
+        $this->info("Found {$posts->count()} recent messages");
+
+        // Deduplicate using the service.
+        $service = app(UnifiedDigestService::class);
+        $deduplicatedPosts = $service->deduplicatePosts($posts);
+
+        $this->info("After deduplication: {$deduplicatedPosts->count()} unique posts");
+
+        $mode = $this->option('mode') === 'immediate' ? UnifiedDigestService::MODE_IMMEDIATE : UnifiedDigestService::MODE_DAILY;
+        if ($mode === UnifiedDigestService::MODE_IMMEDIATE) {
+            $deduplicatedPosts = $deduplicatedPosts->take(1);
+        }
+        return new UnifiedDigest($user, $deduplicatedPosts, $mode);
     }
 
     /**

--- a/iznik-batch/app/Mail/Digest/DigestReplyNotice.php
+++ b/iznik-batch/app/Mail/Digest/DigestReplyNotice.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Mail\Digest;
+
+use App\Mail\MjmlMailable;
+use App\Mail\Traits\LoggableEmail;
+use App\Mail\Traits\TrackableEmail;
+use Illuminate\Mail\Mailables\Address;
+use Illuminate\Mail\Mailables\Envelope;
+
+/**
+ * Auto-response sent when someone replies to a digest email.
+ *
+ * Digest emails are sent from noreply@ and contain multiple posts.
+ * When a user replies to one, we send this friendly notice explaining
+ * how to reply to specific posts using the buttons/links in the email.
+ */
+class DigestReplyNotice extends MjmlMailable
+{
+    use LoggableEmail;
+    use TrackableEmail;
+
+    public string $userSite;
+
+    public function __construct(
+        protected string $recipientEmail,
+        protected ?string $recipientName = null,
+        protected ?int $recipientUserId = null
+    ) {
+        parent::__construct();
+
+        $this->userSite = config('freegle.sites.user');
+
+        $this->to($this->recipientEmail, $this->recipientName);
+
+        $this->initTracking(
+            'DigestReplyNotice',
+            $this->recipientEmail,
+            $this->recipientUserId,
+            null,
+            $this->getSubject()
+        );
+    }
+
+    protected function getRecipientUserId(): ?int
+    {
+        return $this->recipientUserId;
+    }
+
+    public function build(): static
+    {
+        $settingsUrl = $this->trackedUrl($this->userSite . '/settings', 'footer_settings', 'settings');
+        $browseUrl = $this->trackedUrl($this->userSite . '/browse', 'browse_cta', 'browse');
+
+        return $this->mjmlView('emails.mjml.digest.reply-notice', array_merge([
+            'recipientName' => $this->recipientName,
+            'recipientEmail' => $this->recipientEmail,
+            'settingsUrl' => $settingsUrl,
+            'browseUrl' => $browseUrl,
+            'userSite' => $this->userSite,
+        ], $this->getTrackingData()), 'emails.text.digest.reply-notice')
+            ->applyLogging('DigestReplyNotice');
+    }
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            from: new Address(
+                config('freegle.mail.noreply_addr'),
+                config('freegle.branding.name')
+            ),
+            subject: $this->getSubject(),
+        );
+    }
+
+    protected function getSubject(): string
+    {
+        return 'How to reply to posts on Freegle';
+    }
+}

--- a/iznik-batch/app/Mail/Digest/UnifiedDigest.php
+++ b/iznik-batch/app/Mail/Digest/UnifiedDigest.php
@@ -354,8 +354,10 @@ class UnifiedDigest extends MjmlMailable
             );
 
             // Format arrival time for display in UK local time (BST in summer, GMT in winter).
+            // Always include minutes (e.g. "Sun 1 Mar, 11:00am") so the time
+            // shape is consistent — V1 single.html-style "Mon, 25th May 9:00am".
             $arrival = $message->arrival instanceof Carbon ? $message->arrival : Carbon::parse($message->arrival);
-            $arrivalFormatted = $arrival->setTimezone('Europe/London')->format($arrival->minute === 0 ? 'D j M, ga' : 'D j M, g:ia'); // e.g. "Sun 1 Mar, 9pm" or "Sun 1 Mar, 9:47am"
+            $arrivalFormatted = $arrival->setTimezone('Europe/London')->format('D j M, g:ia');
             $arrivalIso = $arrival->toIso8601String();
 
             // Calculate distance from user.

--- a/iznik-batch/app/Mail/Digest/UnifiedDigest.php
+++ b/iznik-batch/app/Mail/Digest/UnifiedDigest.php
@@ -99,6 +99,10 @@ class UnifiedDigest extends MjmlMailable
             ->to($this->user->email_preferred)
             ->applyLogging('UnifiedDigest');
 
+        // Attach the X-Freegle-* tracking headers and RFC 8058
+        // List-Unsubscribe headers that MjmlMailable provides.
+        $this->configureMessage();
+
         // Render AMP variant if enabled.
         if ($this->isAmpEnabled()) {
             $ampPosts = $this->prepareAmpPosts();
@@ -353,11 +357,17 @@ class UnifiedDigest extends MjmlMailable
             $messageId = $post['message']->id;
             $token = $this->generateToken($userId, $messageId);
 
-            $post['ampReplyUrl'] = "{$ampApiBase}/amp/digest/reply?" . http_build_query([
-                'rt' => $token,
-                'uid' => $userId,
-                'mid' => $messageId,
-            ]);
+            // Path-style id matches the chat AMP route shape and lets the Go
+            // handler treat the message ID as the HMAC resource without
+            // re-deriving it from a query param.
+            $post['ampReplyUrl'] = sprintf(
+                '%s/amp/digest/%d/reply?rt=%s&uid=%d&exp=%d',
+                rtrim($ampApiBase, '/'),
+                $messageId,
+                $token['token'],
+                $userId,
+                $token['expiry']
+            );
 
             // Fallback URL for non-AMP clients or AMP form errors.
             $post['fallbackReplyUrl'] = $post['messageUrl'];

--- a/iznik-batch/app/Mail/Digest/UnifiedDigest.php
+++ b/iznik-batch/app/Mail/Digest/UnifiedDigest.php
@@ -85,6 +85,37 @@ class UnifiedDigest extends MjmlMailable
      */
     public function build(): static
     {
+        // Jobs section — V1 single.html parity. Same shape ChatNotification
+        // already uses, so the MJML loop is a drop-in.
+        $jobAdsData = $this->user->getJobAds();
+        $jobAds = $jobAdsData['jobs'] ?? collect();
+        $jobCount = count($jobAds);
+        foreach ($jobAds as $index => $job) {
+            $job->tracked_url = $this->trackedUrl(
+                $this->userSite . '/job/' . $job->id .
+                    '?source=email&campaign=unified_digest&position=' . $index .
+                    '&list_length=' . $jobCount,
+                'job_ad_' . $index,
+                'job_click'
+            );
+        }
+        $jobsUrl = $this->trackedUrl($this->userSite . '/jobs', 'jobs_view_more', 'jobs_view_more');
+        $donateUrl = $this->trackedUrl(config('freegle.donate.url', 'https://freegle.in/paypal1510'), 'donate', 'donate');
+
+        // Per-group footer: "you're a member of {group}, set to receive
+        // {frequency}". For immediate mode use the post's group; for daily
+        // mode it doesn't single one out so we leave it null.
+        $primaryGroupName = null;
+        if ($this->mode === UnifiedDigestService::MODE_IMMEDIATE && $this->posts->isNotEmpty()) {
+            $firstPost = $this->posts->first();
+            $groupId = $firstPost['postedToGroups'][0] ?? null;
+            if ($groupId) {
+                $row = DB::table('groups')->where('id', $groupId)->first(['nameshort', 'namefull']);
+                $primaryGroupName = $row ? ($row->namefull ?: $row->nameshort) : null;
+            }
+        }
+        $frequencyText = $this->mode === UnifiedDigestService::MODE_IMMEDIATE ? 'immediately' : 'daily';
+
         $result = $this->mjmlView('emails.mjml.digest.unified', array_merge([
             'user' => $this->user,
             'posts' => $this->preparedPosts,
@@ -95,6 +126,11 @@ class UnifiedDigest extends MjmlMailable
             'unsubscribeUrl' => $this->trackedUrl($this->userSite . '/unsubscribe', 'footer_unsubscribe', 'unsubscribe'),
             'browseUrl' => $this->trackedUrl($this->userSite . '/browse', 'browse_cta', 'browse'),
             'userSite' => $this->userSite,
+            'jobAds' => $jobAds,
+            'jobsUrl' => $jobsUrl,
+            'donateUrl' => $donateUrl,
+            'primaryGroupName' => $primaryGroupName,
+            'frequencyText' => $frequencyText,
         ], $this->getTrackingData()), 'emails.text.digest.unified')
             ->to($this->user->email_preferred)
             ->applyLogging('UnifiedDigest');
@@ -102,6 +138,42 @@ class UnifiedDigest extends MjmlMailable
         // Attach the X-Freegle-* tracking headers and RFC 8058
         // List-Unsubscribe headers that MjmlMailable provides.
         $this->configureMessage();
+
+        // V1-parity headers added on every digest (immediate + daily).
+        // - X-Freegle-Mail-Type: legacy V1 header name TN consumes (sits next
+        //   to the V2-style X-Freegle-Email-Type that MjmlMailable already adds).
+        // - Feedback-ID: Google FBL spec — {qualifier}:{userid}:{type}:{sender}.
+        //   In immediate mode qualifier is the message id; in daily we
+        //   use 0 since the email isn't tied to one specific message.
+        // - Reply-To (immediate only): even though From is the replyto-
+        //   address and most clients reply to From, some (and some webmails)
+        //   prefer Reply-To when set, so we set both.
+        $messageQualifier = 0;
+        $replyToAddr = null;
+        $replyToName = null;
+        if ($this->mode === UnifiedDigestService::MODE_IMMEDIATE && $this->posts->isNotEmpty()) {
+            $firstPost = $this->posts->first();
+            $message = $firstPost['message'];
+            $messageQualifier = $message->id;
+            $domain = config('freegle.mail.user_domain');
+            $replyToAddr = "replyto-{$message->id}-{$this->user->id}@{$domain}";
+            $replyToName = $message->fromname ?: 'Freegler';
+        }
+        $userId = $this->user->id ?? 0;
+        $result->withSymfonyMessage(function ($symfonyMessage) use (
+            $messageQualifier, $userId, $replyToAddr, $replyToName
+        ) {
+            $headers = $symfonyMessage->getHeaders();
+            if (!$headers->has('Feedback-ID')) {
+                $headers->addTextHeader('Feedback-ID', "{$messageQualifier}:{$userId}:Digest:freegle");
+            }
+            if (!$headers->has('X-Freegle-Mail-Type')) {
+                $headers->addTextHeader('X-Freegle-Mail-Type', 'Digest');
+            }
+            if ($replyToAddr) {
+                $symfonyMessage->replyTo(new \Symfony\Component\Mime\Address($replyToAddr, $replyToName));
+            }
+        });
 
         // Render AMP variant if enabled.
         if ($this->isAmpEnabled()) {
@@ -297,6 +369,19 @@ class UnifiedDigest extends MjmlMailable
             $posterAvatarUrl = $this->resolveAvatarUrl($posterUser, 36);
             $posterName = $posterUser?->displayname ?? $message->fromname ?? 'Freegler';
 
+            // firstPosted: show "First posted ..." line only when the message has
+            // actually been reposted to this group — i.e. the pivot arrival is
+            // materially after the original messages.date. Matches V1
+            // Digest.php's `count($atts['postings']) > 1` rule and uses the same
+            // "Mon, 25th May 9:00am" format the V1 template renders.
+            $firstPostedFormatted = null;
+            $originalDate = $message->date instanceof Carbon
+                ? $message->date
+                : ($message->date ? Carbon::parse($message->date) : null);
+            if ($originalDate && $arrival->diffInMinutes($originalDate) > 60) {
+                $firstPostedFormatted = $originalDate->setTimezone('Europe/London')->format('D, jS F g:ia');
+            }
+
             return [
                 'message' => $message,
                 'messageText' => $messageText,
@@ -315,6 +400,7 @@ class UnifiedDigest extends MjmlMailable
                 'distanceText' => $distanceText,
                 'posterName' => $posterName,
                 'posterAvatarUrl' => $posterAvatarUrl,
+                'firstPostedFormatted' => $firstPostedFormatted,
             ];
         });
     }

--- a/iznik-batch/app/Services/Mail/Incoming/IncomingMailService.php
+++ b/iznik-batch/app/Services/Mail/Incoming/IncomingMailService.php
@@ -128,6 +128,12 @@ class IncomingMailService
             return $this->handleHumanReplyToBounceAddress($email);
         }
 
+        // Phase 3c: Reply to digest email (sent from noreply@).
+        // Send helpful auto-response explaining how to reply to specific posts.
+        if ($email->isDigestReply()) {
+            return $this->handleDigestReply($email);
+        }
+
         // Check for known dropped senders (Twitter, etc.)
         if ($this->shouldDropSender($email)) {
             return $this->dropped('Known dropped sender (Twitter, etc.)');
@@ -1409,6 +1415,76 @@ class IncomingMailService
             Log::info('Sent bounce address auto-reply', ['to' => $senderAddress]);
         } catch (\Throwable $e) {
             Log::warning('Failed to send bounce address auto-reply', [
+                'to' => $senderAddress,
+                'error' => $e->getMessage(),
+            ]);
+        }
+
+        return RoutingResult::TO_SYSTEM;
+    }
+
+    /**
+     * Handle reply to a digest email.
+     *
+     * Digest emails are sent from noreply@ and contain multiple posts.
+     * When someone replies, we send a friendly auto-response explaining
+     * how to reply to specific posts via the buttons/links in the email.
+     */
+    private function handleDigestReply(ParsedEmail $email): RoutingResult
+    {
+        $senderAddress = strtolower($email->fromAddress ?? $email->envelopeFrom ?? '');
+
+        Log::info('Reply to digest email', [
+            'from' => $senderAddress,
+            'envelope_to' => $email->envelopeTo,
+            'subject' => $email->subject,
+        ]);
+
+        // Loop prevention: never auto-reply to system addresses
+        $suppressPatterns = ['mailer-daemon', 'postmaster', 'noreply', 'no-reply', 'bounce-'];
+        foreach ($suppressPatterns as $pattern) {
+            if (str_contains($senderAddress, $pattern)) {
+                Log::debug('Suppressing digest reply auto-response to system address', ['from' => $senderAddress]);
+
+                return RoutingResult::TO_SYSTEM;
+            }
+        }
+
+        // Loop prevention: never auto-reply to auto-submitted messages
+        if ($email->isAutoReply()) {
+            Log::debug('Suppressing digest reply auto-response to auto-submitted message');
+
+            return RoutingResult::TO_SYSTEM;
+        }
+
+        // Rate limit: max 1 auto-reply per 24h per sender
+        $cacheKey = 'digest_reply_autoreply:' . md5($senderAddress);
+        if (Cache::has($cacheKey)) {
+            Log::debug('Rate limiting digest reply auto-response', ['from' => $senderAddress]);
+
+            return RoutingResult::TO_SYSTEM;
+        }
+
+        // Look up the sender to get their name and user ID
+        $senderName = $email->fromName;
+        $senderUserId = null;
+
+        $userEmail = \App\Models\UserEmail::where('email', $senderAddress)->first();
+        if ($userEmail) {
+            $senderUserId = $userEmail->userid;
+        }
+
+        // Send auto-response
+        try {
+            MailFacade::send(new \App\Mail\Digest\DigestReplyNotice(
+                $senderAddress,
+                $senderName,
+                $senderUserId
+            ));
+            Cache::put($cacheKey, true, now()->addHours(24));
+            Log::info('Sent digest reply auto-response', ['to' => $senderAddress]);
+        } catch (\Throwable $e) {
+            Log::warning('Failed to send digest reply auto-response', [
                 'to' => $senderAddress,
                 'error' => $e->getMessage(),
             ]);
@@ -3417,7 +3493,41 @@ class IncomingMailService
      */
     private function parseSubject(string $subj): array
     {
-        return \App\Support\SubjectParser::parse($subj);
+        $type = null;
+        $item = null;
+        $location = null;
+
+        $p = strpos($subj, ':');
+
+        if ($p !== false) {
+            $startp = $p;
+            $rest = trim(substr($subj, $p + 1));
+            $p = strlen($rest) - 1;
+
+            if (substr($rest, -1) == ')') {
+                $count = 0;
+
+                do {
+                    $curr = substr($rest, $p, 1);
+
+                    if ($curr == '(') {
+                        $count--;
+                    } elseif ($curr == ')') {
+                        $count++;
+                    }
+
+                    $p--;
+                } while ($count > 0 && $p > 0);
+
+                if ($count == 0) {
+                    $type = trim(substr($subj, 0, $startp));
+                    $location = trim(substr($rest, $p + 2, strlen($rest) - $p - 3));
+                    $item = trim(substr($rest, 0, $p));
+                }
+            }
+        }
+
+        return [$type, $item, $location];
     }
 
     /**
@@ -3649,17 +3759,11 @@ class IncomingMailService
      */
     private function addEmailToUser(int $userId, ?string $email): void
     {
-        $email = trim((string) $email);
-
-        if ($email === '') {
+        if (empty($email)) {
             return;
         }
 
-        // Reject anything that isn't a syntactically valid address — bounce
-        // envelope-froms like `MAILER-DAEMON` or `<>` reach this code path.
-        if (!preg_match(Message::EMAIL_REGEXP, $email)) {
-            return;
-        }
+        $email = trim($email);
 
         // Don't add system addresses
         $groupDomain = config('freegle.mail.group_domain', 'groups.ilovefreegle.org');

--- a/iznik-batch/app/Services/Mail/Incoming/IncomingMailService.php
+++ b/iznik-batch/app/Services/Mail/Incoming/IncomingMailService.php
@@ -3493,41 +3493,7 @@ class IncomingMailService
      */
     private function parseSubject(string $subj): array
     {
-        $type = null;
-        $item = null;
-        $location = null;
-
-        $p = strpos($subj, ':');
-
-        if ($p !== false) {
-            $startp = $p;
-            $rest = trim(substr($subj, $p + 1));
-            $p = strlen($rest) - 1;
-
-            if (substr($rest, -1) == ')') {
-                $count = 0;
-
-                do {
-                    $curr = substr($rest, $p, 1);
-
-                    if ($curr == '(') {
-                        $count--;
-                    } elseif ($curr == ')') {
-                        $count++;
-                    }
-
-                    $p--;
-                } while ($count > 0 && $p > 0);
-
-                if ($count == 0) {
-                    $type = trim(substr($subj, 0, $startp));
-                    $location = trim(substr($rest, $p + 2, strlen($rest) - $p - 3));
-                    $item = trim(substr($rest, 0, $p));
-                }
-            }
-        }
-
-        return [$type, $item, $location];
+        return \App\Support\SubjectParser::parse($subj);
     }
 
     /**
@@ -3759,11 +3725,17 @@ class IncomingMailService
      */
     private function addEmailToUser(int $userId, ?string $email): void
     {
-        if (empty($email)) {
+        $email = trim((string) $email);
+
+        if ($email === '') {
             return;
         }
 
-        $email = trim($email);
+        // Reject anything that isn't a syntactically valid address — bounce
+        // envelope-froms like `MAILER-DAEMON` or `<>` reach this code path.
+        if (!preg_match(Message::EMAIL_REGEXP, $email)) {
+            return;
+        }
 
         // Don't add system addresses
         $groupDomain = config('freegle.mail.group_domain', 'groups.ilovefreegle.org');

--- a/iznik-batch/app/Services/Mail/Incoming/MailParserService.php
+++ b/iznik-batch/app/Services/Mail/Incoming/MailParserService.php
@@ -60,6 +60,9 @@ class MailParserService
         // Extract sender IP
         $senderIp = $this->extractSenderIp($headers);
 
+        // Check if this is a reply to a digest email
+        $isDigestReply = $this->isDigestReply($envelopeTo, $headers);
+
         return new ParsedEmail(
             rawMessage: $rawMessage,
             envelopeFrom: $envelopeFrom,
@@ -84,7 +87,8 @@ class MailParserService
             chatMessageId: $chatInfo['messageId'],
             commandUserId: $commandInfo['userId'],
             commandGroupId: $commandInfo['groupId'],
-            senderIp: $senderIp
+            senderIp: $senderIp,
+            isDigestReply: $isDigestReply
         );
     }
 
@@ -540,5 +544,31 @@ class MailParserService
         }
 
         return null;
+    }
+
+    /**
+     * Check if this email is a reply to a digest email.
+     *
+     * Digest emails are sent from noreply@. We detect replies by checking:
+     * 1. Envelope-to is noreply@{user_domain}
+     * 2. In-Reply-To header contains "UnifiedDigest" (our Message-ID pattern)
+     */
+    private function isDigestReply(string $envelopeTo, array $headers): bool
+    {
+        $userDomain = config('freegle.mail.user_domain');
+        $noreplyAddr = config('freegle.mail.noreply_addr');
+
+        // Check if addressed to noreply@
+        if (strtolower($envelopeTo) === strtolower($noreplyAddr)) {
+            return true;
+        }
+
+        // Check if In-Reply-To references a digest email
+        $inReplyTo = $headers['in-reply-to'] ?? null;
+        if ($inReplyTo !== null && str_contains($inReplyTo, 'UnifiedDigest')) {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/iznik-batch/app/Services/Mail/Incoming/ParsedEmail.php
+++ b/iznik-batch/app/Services/Mail/Incoming/ParsedEmail.php
@@ -83,6 +83,12 @@ class ParsedEmail
     public readonly ?string $senderIp;
 
     // ========================================
+    // Digest Reply Properties
+    // ========================================
+
+    public readonly bool $isDigestReply;
+
+    // ========================================
     // Internal State
     // ========================================
 
@@ -114,7 +120,8 @@ class ParsedEmail
         ?int $chatMessageId,
         ?int $commandUserId,
         ?int $commandGroupId,
-        ?string $senderIp
+        ?string $senderIp,
+        bool $isDigestReply = false
     ) {
         $this->rawMessage = $rawMessage;
         $this->envelopeFrom = $envelopeFrom;
@@ -140,6 +147,7 @@ class ParsedEmail
         $this->commandUserId = $commandUserId;
         $this->commandGroupId = $commandGroupId;
         $this->senderIp = $senderIp;
+        $this->isDigestReply = $isDigestReply;
 
         // Cache envelope-to local part for routing checks
         $this->envelopeToLocalPart = explode('@', $envelopeTo)[0] ?? '';
@@ -276,6 +284,18 @@ class ParsedEmail
     }
 
     // ========================================
+    // Digest Reply Detection
+    // ========================================
+
+    /**
+     * Check if this is a reply to a digest email (sent from noreply@).
+     */
+    public function isDigestReply(): bool
+    {
+        return $this->isDigestReply;
+    }
+
+    // ========================================
     // Email Command Detection
     // ========================================
 
@@ -399,6 +419,7 @@ class ParsedEmail
             'chat_user_id' => $this->chatUserId,
             'chat_message_id' => $this->chatMessageId,
             'is_auto_reply' => $this->isAutoReply(),
+            'is_digest_reply' => $this->isDigestReply(),
             'is_subscribe_command' => $this->isSubscribeCommand(),
             'is_unsubscribe_command' => $this->isUnsubscribeCommand(),
             'is_digestoff_command' => $this->isDigestOffCommand(),

--- a/iznik-batch/app/Services/UnifiedDigestService.php
+++ b/iznik-batch/app/Services/UnifiedDigestService.php
@@ -92,6 +92,31 @@ class UnifiedDigestService
     }
 
     /**
+     * Parse the immediate-mode allowlist from config.
+     *
+     * Returns:
+     *   ['*']   — wildcard (empty config OR explicit '*'), allow all users
+     *   [...]   — list of email addresses, restrict to those
+     *
+     * The checked-in default is a single pilot email so production
+     * deployments start restricted; clearing the env var or setting it to
+     * '*' opens the floodgates for real.
+     */
+    protected function getImmediateAllowlist(): array
+    {
+        $raw = trim((string) config('freegle.digest.immediate_allowlist', ''));
+        if ($raw === '' || $raw === '*') {
+            return ['*'];
+        }
+        $parts = array_filter(array_map('trim', explode(',', $raw)), fn ($s) => $s !== '');
+        // Mixed '*' + addresses → treat as wildcard.
+        if (in_array('*', $parts, true)) {
+            return ['*'];
+        }
+        return $parts === [] ? ['*'] : array_values($parts);
+    }
+
+    /**
      * Get users who should receive digests based on mode.
      *
      * @param string $mode One of MODE_IMMEDIATE or MODE_DAILY
@@ -113,6 +138,26 @@ class UnifiedDigestService
         if ($mode === self::MODE_IMMEDIATE) {
             // Full mode = immediate notifications.
             $query->whereRaw("JSON_UNQUOTE(JSON_EXTRACT(settings, '$.simplemail')) = ?", [User::SIMPLE_MAIL_FULL]);
+
+            // Safety gate — FREEGLE_DIGEST_IMMEDIATE_ALLOWLIST. Default (or
+            // '*') allows every simplemail=Full user; a comma-separated list
+            // restricts to those addresses. The checked-in config default
+            // pins this to a single pilot address so prod deploys start
+            // restricted; ops clears the env var (or sets it to '*') to
+            // flip immediate emails on for everyone.
+            $allowlist = $this->getImmediateAllowlist();
+            if ($allowlist !== ['*']) {
+                $lowercased = array_map('strtolower', $allowlist);
+                $query->whereExists(function ($q) use ($lowercased) {
+                    $q->select(DB::raw(1))
+                        ->from('users_emails')
+                        ->whereColumn('users_emails.userid', 'users.id')
+                        ->whereIn(DB::raw('LOWER(users_emails.email)'), $lowercased);
+                });
+                Log::info('UnifiedDigestService: immediate mode restricted to allowlist', [
+                    'allowlist_count' => count($allowlist),
+                ]);
+            }
         } else {
             // Basic mode = daily digest.
             // Include users with Basic setting OR users without simplemail set but with daily frequency memberships.

--- a/iznik-batch/app/Services/UnifiedDigestService.php
+++ b/iznik-batch/app/Services/UnifiedDigestService.php
@@ -269,11 +269,22 @@ class UnifiedDigestService
             $key = $this->getDeduplicationKey($post);
 
             if (isset($processed[$key])) {
-                // Add this group to the existing post's groups list.
+                // Key matches - also check body similarity before deduplicating.
                 $existingIndex = $processed[$key];
                 $existing = $deduplicated[$existingIndex];
-                $existing['postedToGroups'][] = $post->groupid;
-                $deduplicated[$existingIndex] = $existing;
+
+                if ($this->bodiesMatch($existing['message'], $post)) {
+                    // Same key AND similar body - true duplicate, merge groups.
+                    $existing['postedToGroups'][] = $post->groupid;
+                    $deduplicated[$existingIndex] = $existing;
+                } else {
+                    // Same key but different body - treat as separate post.
+                    $index = $deduplicated->count();
+                    $deduplicated->push([
+                        'message' => $post,
+                        'postedToGroups' => [$post->groupid],
+                    ]);
+                }
             } else {
                 // New unique post.
                 $index = $deduplicated->count();
@@ -286,6 +297,34 @@ class UnifiedDigestService
         }
 
         return $deduplicated;
+    }
+
+    /**
+     * Check if two messages have matching body content.
+     */
+    protected function bodiesMatch(Message $a, Message $b): bool
+    {
+        // TrashNothing posts with same tnpostid are always duplicates.
+        if ($a->tnpostid && $b->tnpostid && $a->tnpostid === $b->tnpostid) {
+            return true;
+        }
+
+        return $this->normalizeBody($a->textbody) === $this->normalizeBody($b->textbody);
+    }
+
+    /**
+     * Normalize body text for comparison.
+     */
+    protected function normalizeBody(?string $body): string
+    {
+        if ($body === null) {
+            return '';
+        }
+
+        $normalized = strtolower(trim($body));
+        $normalized = preg_replace('/\s+/', ' ', $normalized);
+
+        return substr($normalized, 0, 200);
     }
 
     /**

--- a/iznik-batch/config/freegle.php
+++ b/iznik-batch/config/freegle.php
@@ -86,6 +86,18 @@ return [
         'sync_date_file' => env('FREEGLE_TN_SYNC_DATE_FILE', '/etc/tn_sync_last_date.txt'),
     ],
 
+    'digest' => [
+        // Safety gate for the unified-digest IMMEDIATE mode.
+        //   ''  or '*'      → allow all users (the normal production state)
+        //   'a@x.com,b@y'   → restrict immediate emails to those addresses
+        //
+        // The default checked in here is a single pilot recipient so that
+        // when the cron is enabled in production only that user receives
+        // immediate emails. Clear it (or set to '*') in env to flip the
+        // feature on for everyone. Daily-mode digests are NOT gated.
+        'immediate_allowlist' => env('FREEGLE_DIGEST_IMMEDIATE_ALLOWLIST', 'edward@ehibbert.org.uk'),
+    ],
+
     // Firebase Cloud Messaging for push notifications
     'firebase' => [
         'credentials_path' => env('FIREBASE_CREDENTIALS_PATH', '/etc/firebase.json'),

--- a/iznik-batch/database/migrations/2025_12_10_094529_create_users_push_notifications_table.php
+++ b/iznik-batch/database/migrations/2025_12_10_094529_create_users_push_notifications_table.php
@@ -20,7 +20,7 @@ return new class extends Migration
             $table->bigIncrements('id');
             $table->unsignedBigInteger('userid');
             $table->timestamp('added')->useCurrent();
-            $table->enum('type', ['Google', 'Firefox', 'Test', 'Android', 'IOS', 'FCMAndroid', 'FCMIOS', 'BrowserPush'])->default('Google')->index('type');
+            $table->enum('type', ['Google', 'Firefox', 'Test', 'Android', 'IOS', 'FCMAndroid', 'FCMIOS'])->default('Google')->index('type');
             $table->timestamp('lastsent')->nullable()->useCurrent();
             $table->string('subscription')->unique('subscription');
             $table->enum('apptype', ['User', 'ModTools'])->default('User');

--- a/iznik-batch/resources/views/emails/amp/digest/unified.blade.php
+++ b/iznik-batch/resources/views/emails/amp/digest/unified.blade.php
@@ -1,0 +1,348 @@
+<!doctype html>
+<html ⚡4email data-css-strict>
+<head>
+  <meta charset="utf-8">
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-form" src="https://cdn.ampproject.org/v0/amp-form-0.1.js"></script>
+  <script async custom-element="amp-accordion" src="https://cdn.ampproject.org/v0/amp-accordion-0.1.js"></script>
+  <script async custom-element="amp-timeago" src="https://cdn.ampproject.org/v0/amp-timeago-0.1.js"></script>
+  <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.2.js"></script>
+  <style amp4email-boilerplate>body{visibility:hidden}</style>
+  <style amp-custom>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+      margin: 0;
+      padding: 0;
+      background-color: #ffffff;
+      color: #333333;
+    }
+    .container {
+      max-width: 600px;
+      margin: 0 auto;
+    }
+
+    /* Header */
+    .header {
+      background-color: #338808;
+      padding: 16px 20px;
+      text-align: center;
+    }
+
+    /* Greeting */
+    .greeting {
+      padding: 20px 20px 10px 20px;
+    }
+    .greeting h2 {
+      font-size: 16px;
+      color: #333333;
+      margin: 0 0 4px 0;
+    }
+    .greeting p {
+      font-size: 14px;
+      color: #555555;
+      margin: 0;
+    }
+
+    /* Post cards */
+    .post-card {
+      padding: 12px 20px;
+      border-bottom: 1px solid #eeeeee;
+      display: flex;
+      align-items: flex-start;
+    }
+    .post-image {
+      width: 80px;
+      flex-shrink: 0;
+      border-radius: 4px;
+    }
+    .post-content {
+      padding-left: 12px;
+      flex: 1;
+    }
+    .post-type-offer {
+      font-size: 11px;
+      font-weight: bold;
+      color: #338808;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      margin: 0 0 2px 0;
+    }
+    .post-type-wanted {
+      font-size: 11px;
+      font-weight: bold;
+      color: #00A1CB;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      margin: 0 0 2px 0;
+    }
+    .post-title {
+      font-size: 16px;
+      font-weight: 600;
+      margin: 0 0 4px 0;
+    }
+    .post-title a {
+      color: #333333;
+      text-decoration: none;
+    }
+    .post-preview {
+      font-size: 13px;
+      color: #666666;
+      margin: 0 0 4px 0;
+      line-height: 1.4;
+    }
+    .post-groups {
+      font-size: 11px;
+      color: #888888;
+      font-style: italic;
+      margin: 0 0 8px 0;
+    }
+    .post-time {
+      font-size: 12px;
+      color: #888888;
+      margin: 0 0 4px 0;
+    }
+
+    /* Reply accordion */
+    amp-accordion section {
+      border: none;
+    }
+    amp-accordion section[expanded] .reply-toggle {
+      display: none;
+    }
+    .reply-toggle {
+      display: inline-block;
+      background-color: #338808;
+      color: #ffffff;
+      font-size: 13px;
+      font-weight: bold;
+      padding: 8px 16px;
+      border: none;
+      border-radius: 4px;
+      cursor: pointer;
+      list-style: none;
+    }
+    .reply-form-container {
+      padding: 8px 0;
+    }
+    .reply-textarea {
+      width: 100%;
+      min-height: 60px;
+      padding: 10px;
+      border: 1px solid #ced4da;
+      border-radius: 4px;
+      font-size: 14px;
+      font-family: inherit;
+      resize: vertical;
+      box-sizing: border-box;
+    }
+    .reply-textarea:focus {
+      outline: none;
+      border-color: #338808;
+    }
+    .reply-submit {
+      background-color: #338808;
+      color: #ffffff;
+      font-size: 14px;
+      font-weight: bold;
+      padding: 10px 20px;
+      border: none;
+      border-radius: 4px;
+      cursor: pointer;
+      margin-top: 8px;
+    }
+    .reply-fallback {
+      font-size: 12px;
+      color: #666666;
+      margin-top: 6px;
+    }
+    .reply-fallback a {
+      color: #338808;
+      text-decoration: none;
+    }
+
+    /* Form states */
+    .reply-form-container {
+      position: relative;
+    }
+    .reply-form-container[submitting] .reply-textarea,
+    .reply-form-container[submitting] .reply-submit,
+    .reply-form-container[submit-success] .reply-textarea,
+    .reply-form-container[submit-success] .reply-submit {
+      opacity: 0.3;
+    }
+    .form-status {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      width: 90%;
+      z-index: 10;
+    }
+    .submit-success {
+      background-color: #e8f5e0;
+      border: 1px solid #338808;
+      color: #2a6d07;
+      padding: 12px;
+      text-align: center;
+      border-radius: 4px;
+    }
+    .submit-error {
+      background-color: #f2dede;
+      border: 1px solid #d9534f;
+      color: #a94442;
+      padding: 12px;
+      text-align: center;
+      border-radius: 4px;
+    }
+    .submitting-msg {
+      background-color: #ffffff;
+      border: 1px solid #338808;
+      color: #333333;
+      padding: 12px;
+      text-align: center;
+      border-radius: 4px;
+    }
+
+    /* Browse button */
+    .browse-section {
+      padding: 25px 20px;
+      text-align: center;
+    }
+    .browse-button {
+      display: inline-block;
+      background-color: #338808;
+      color: #ffffff;
+      font-size: 16px;
+      font-weight: bold;
+      padding: 14px 40px;
+      text-decoration: none;
+      border-radius: 4px;
+    }
+
+    /* Footer */
+    .footer {
+      background-color: #f5f5f5;
+      padding: 20px;
+      text-align: center;
+    }
+    .footer-text {
+      font-size: 12px;
+      color: #666666;
+      line-height: 1.6;
+      margin: 0 0 10px 0;
+    }
+    .footer-links {
+      font-size: 12px;
+      margin: 0 0 15px 0;
+    }
+    .footer-links a {
+      color: #338808;
+      text-decoration: none;
+    }
+    .footer-divider {
+      border-top: 1px solid #dddddd;
+      margin: 15px 40px;
+    }
+    .footer-charity {
+      font-size: 11px;
+      color: #666666;
+      line-height: 1.5;
+      margin: 0;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    {{-- Header --}}
+    <div class="header">
+      <amp-img
+        src="{{ config('freegle.branding.logo_url') }}"
+        width="120"
+        height="40"
+        alt="{{ config('freegle.branding.name', 'Freegle') }}"
+        layout="fixed"
+      ></amp-img>
+    </div>
+
+    {{-- Greeting --}}
+    <div class="greeting">
+      <h2>Hi {{ $user->displayname ?? 'there' }},</h2>
+      <p>Here {{ $postCount === 1 ? 'is' : 'are' }} <strong>{{ $postCount }}</strong> new post{{ $postCount === 1 ? '' : 's' }} from your Freegle communities:</p>
+    </div>
+
+    {{-- Post cards with reply accordion --}}
+    @foreach($posts as $index => $post)
+    <div class="post-card">
+      <amp-img class="post-image" src="{{ $post['displayImageUrl'] }}" width="80" height="80" layout="fixed" alt="{{ $post['itemName'] }}"></amp-img>
+      <div class="post-content">
+        <p class="{{ $post['type'] === 'Offer' ? 'post-type-offer' : 'post-type-wanted' }}">{{ $post['type'] === 'Offer' ? 'OFFER' : 'WANTED' }}</p>
+        <p class="post-title"><a href="{{ $post['fallbackReplyUrl'] }}">{{ $post['itemName'] }}</a></p>
+        <p class="post-time">
+          <amp-timeago datetime="{{ $post['arrivalIso'] }}" locale="en" width="160" height="20" layout="fixed">{{ $post['arrivalFormatted'] }}</amp-timeago>
+        </p>
+        @if($post['messageText'])
+        <p class="post-preview">{{ \Illuminate\Support\Str::limit($post['messageText'], 100) }}</p>
+        @endif
+        @if($post['postedToText'])
+        <p class="post-groups">{{ $post['postedToText'] }}</p>
+        @endif
+
+        {{-- Reply accordion --}}
+        <amp-accordion animate>
+          <section>
+            <h4 class="reply-toggle">Reply</h4>
+            <div class="reply-form-container">
+              <form method="post" action-xhr="{{ $post['ampReplyUrl'] }}">
+                <textarea class="reply-textarea" name="message" placeholder="Type your reply..." required minlength="1" maxlength="10000"></textarea>
+                <button type="submit" class="reply-submit">Send Reply</button>
+                <div submitting>
+                  <div class="form-status">
+                    <div class="submitting-msg">Sending your reply...</div>
+                  </div>
+                </div>
+                <div submit-success>
+                  <template type="amp-mustache">
+                    <div class="form-status">
+                      <div class="submit-success">@{{message}}</div>
+                    </div>
+                  </template>
+                </div>
+                <div submit-error>
+                  <template type="amp-mustache">
+                    <div class="form-status">
+                      <div class="submit-error">@{{message}} <a href="{{ $post['fallbackReplyUrl'] }}">Reply on Freegle instead</a></div>
+                    </div>
+                  </template>
+                </div>
+              </form>
+              <div class="reply-fallback">
+                <a href="{{ $post['fallbackReplyUrl'] }}">Or reply via website</a>
+              </div>
+            </div>
+          </section>
+        </amp-accordion>
+      </div>
+    </div>
+    @endforeach
+
+    {{-- Browse All Posts --}}
+    <div class="browse-section">
+      <a href="{{ $browseUrl }}" class="browse-button">Browse All Posts</a>
+    </div>
+
+    {{-- Footer --}}
+    <div class="footer">
+      <p class="footer-text">This email was sent with AMP to {{ $user->email_preferred }}</p>
+      <p class="footer-links">
+        <a href="{{ $settingsUrl }}">Change your email settings</a> &bull;
+        <a href="{{ $unsubscribeUrl ?? $userSite . '/unsubscribe' }}">Unsubscribe</a>
+      </p>
+      <div class="footer-divider"></div>
+      <p class="footer-charity">
+        {{ $siteName ?? config('freegle.branding.name', 'Freegle') }} is registered as a charity with HMRC (ref. XT32865) and is run by volunteers. Which is nice.<br>
+        Registered address: Weaver's Field, Loud Bridge, Chipping PR3 2NX
+      </p>
+    </div>
+  </div>
+</body>
+</html>

--- a/iznik-batch/resources/views/emails/mjml/digest/reply-notice.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/digest/reply-notice.blade.php
@@ -1,0 +1,58 @@
+<mjml>
+  @include('emails.mjml.partials.head', ['preview' => 'How to reply to posts on Freegle'])
+  <mj-body background-color="#ffffff">
+    {{-- Header with logo --}}
+    @include('emails.mjml.components.header')
+
+    {{-- Greeting --}}
+    <mj-section background-color="#ffffff" padding="20px 20px 10px 20px">
+      <mj-column>
+        <mj-text font-size="16px" color="#333333">
+          Hi {{ $recipientName ?? 'there' }},
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+    {{-- Explanation --}}
+    <mj-section background-color="#ffffff" padding="10px 20px">
+      <mj-column>
+        <mj-text font-size="14px" color="#555555" line-height="1.6">
+          It looks like you tried to reply to a digest email. Digest emails contain multiple posts from your Freegle communities, so we can't tell which post you'd like to reply to.
+        </mj-text>
+        <mj-text font-size="14px" color="#555555" line-height="1.6" padding-top="10px">
+          To reply to a specific post, please use the <strong>Reply</strong> button next to the post you're interested in. This will open a conversation with the person who posted it.
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+    {{-- CTA buttons --}}
+    <mj-section background-color="#ffffff" padding="20px 20px 10px 20px">
+      <mj-column>
+        <mj-button href="{{ $browseUrl }}" mj-class="btn-success" font-size="16px" inner-padding="14px 40px">
+          Browse Posts
+        </mj-button>
+      </mj-column>
+    </mj-section>
+
+    <mj-section background-color="#ffffff" padding="0 20px 20px 20px">
+      <mj-column>
+        <mj-text font-size="13px" color="#888888" align="center">
+          You can also change how you receive emails in your
+          <a href="{{ $settingsUrl }}" style="color: #338808;">settings</a>.
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+    {{-- Footer --}}
+    @include('emails.mjml.partials.footer', ['email' => $recipientEmail, 'settingsUrl' => $settingsUrl])
+
+    {{-- Tracking pixel --}}
+    @if(!empty($trackingPixelHtml))
+    <mj-section padding="0">
+      <mj-column>
+        <mj-text padding="0">{!! $trackingPixelHtml !!}</mj-text>
+      </mj-column>
+    </mj-section>
+    @endif
+  </mj-body>
+</mjml>

--- a/iznik-batch/resources/views/emails/mjml/digest/unified.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/digest/unified.blade.php
@@ -1,132 +1,232 @@
 <mjml>
-    @include('emails.mjml.partials.head', [
-        'preview' => $postCount . ' new posts near you',
-        'styles' => '
-            .message-card { border-bottom: 1px solid #eeeeee; padding-bottom: 15px; margin-bottom: 15px; }
-            .message-title { font-weight: bold; color: #333333; }
-            .message-type { font-size: 12px; color: #338808; text-transform: uppercase; }
-            .posted-to { font-size: 11px; color: #888888; font-style: italic; }
-        ',
-    ])
+    @if($mode === 'immediate')
+    @php $post = $posts->first(); $isOffer = $post['type'] === 'Offer'; $accentColor = $isOffer ? '#3c763d' : '#2196A6'; @endphp
+    @include('emails.mjml.partials.head', ['preview' => $post['subject']])
+    @else
+    @include('emails.mjml.partials.head', ['preview' => $postCount . ' new post' . ($postCount === 1 ? '' : 's') . ' near you'])
+    @endif
 
-    <mj-body background-color="#f4f4f4">
-        @include('emails.mjml.components.header')
+    <mj-body background-color="#f0f0f0">
+        @php
+            $offerColor = '#3c763d';
+            $wantedColor = '#2196A6';
+        @endphp
 
-        <mj-section background-color="#ffffff" padding="20px">
-            <mj-column>
-                <mj-text>
-                    Dear {{ $user->displayname ?? 'there' }},
+        @if($mode === 'immediate')
+        {{-- ═══════════════════════════════════════════════════════════════ --}}
+        {{-- IMMEDIATE MODE: single-post card matching browse page style    --}}
+        {{-- ═══════════════════════════════════════════════════════════════ --}}
+
+        {{-- Card: image left + content right (matches browse page layout) --}}
+        <mj-section background-color="#ffffff" padding="0" border-radius="4px">
+            {{-- Image column --}}
+            <mj-column width="38%" padding="0" vertical-align="top">
+                <mj-image
+                    href="{{ $post['messageUrl'] }}"
+                    src="{{ $post['trackedImageUrl'] }}"
+                    alt="{{ $post['itemName'] }}"
+                    padding="0"
+                    fluid-on-mobile="true"
+                    container-background-color="#e8e8e8"
+                />
+            </mj-column>
+            {{-- Content column --}}
+            <mj-column width="62%" padding="16px 20px 12px 16px" vertical-align="top">
+                {{-- OFFER / WANTED pill --}}
+                <mj-text padding="0 0 8px 0" font-size="13px">
+                    <span style="display: inline-block; background-color: {{ $accentColor }}; color: #ffffff; font-size: 12px; font-weight: 700; padding: 3px 10px; border-radius: 3px; letter-spacing: 0.3px;">{{ $isOffer ? 'OFFER' : 'WANTED' }}</span>
                 </mj-text>
-                <mj-text>
-                    Here {{ $postCount === 1 ? 'is' : 'are' }} <strong>{{ $postCount }}</strong> new post{{ $postCount === 1 ? '' : 's' }} from your Freegle communities:
+                {{-- Title --}}
+                <mj-text padding="0 0 4px 0" font-size="18px" font-weight="700" color="#212529" line-height="1.25">
+                    <a href="{{ $post['messageUrl'] }}" style="color: #212529; text-decoration: none;">{{ $post['itemName'] }}</a>
+                </mj-text>
+                {{-- Location --}}
+                @if($post['locationName'])
+                <mj-text padding="0 0 8px 0" font-size="13px" color="#666666">
+                    {{ $post['locationName'] }}
+                </mj-text>
+                @endif
+                {{-- Description snippet --}}
+                @if($post['messageText'])
+                <mj-text padding="0 0 12px 0" font-size="13px" color="#555555" line-height="1.5">
+                    {{ \Illuminate\Support\Str::limit($post['messageText'], 120, '…') }}
+                </mj-text>
+                @endif
+                {{-- Distance + time row --}}
+                <mj-text padding="0" font-size="12px" color="#888888">
+                    @if($post['distanceText'])
+                    <span style="margin-right: 12px;">&#x1F4CD; {{ $post['distanceText'] }}</span>
+                    @endif
+                    <span>&#x1F552; {{ $post['arrivalFormatted'] }}</span>
                 </mj-text>
             </mj-column>
         </mj-section>
 
-        @foreach($posts as $post)
-        <mj-section background-color="#ffffff" padding="10px 20px" css-class="message-card">
-            <mj-column width="25%">
-                @if($post['imageUrl'])
-                <mj-image
-                    width="80px"
-                    src="{{ $post['imageUrl'] }}"
-                    alt="Photo"
-                />
-                @else
-                <mj-image
-                    width="80px"
-                    src="{{ $userSite }}/icon.png"
-                    alt="No photo"
-                />
-                @endif
+        {{-- Full body text --}}
+        @if($post['messageText'])
+        <mj-section background-color="#ffffff" padding="0 20px">
+            <mj-column>
+                <mj-divider border-color="#eeeeee" border-width="1px" padding="0" />
+                <mj-text font-size="15px" color="#333333" line-height="1.65" padding="16px 0">
+                    {{ $post['messageText'] }}
+                </mj-text>
             </mj-column>
-            <mj-column width="75%">
-                <mj-text css-class="message-type">
-                    {{ $post['type'] === 'Offer' ? 'OFFER' : 'WANTED' }}
+        </mj-section>
+        @endif
+
+        {{-- Posted by + reply --}}
+        <mj-section background-color="#ffffff" padding="0 20px 20px">
+            <mj-column>
+                {{-- Posted by --}}
+                <mj-text font-size="13px" color="#888888" padding="0 0 16px 0">
+                    <img src="{{ $post['posterAvatarUrl'] }}" alt="" width="22" height="22" style="display: inline-block; width: 22px; height: 22px; border-radius: 50%; vertical-align: middle; margin-right: 6px;" />
+                    Posted by <strong style="color: #555555;">{{ \Illuminate\Support\Str::limit($post['posterName'], 40) }}</strong>
                 </mj-text>
-                <mj-text css-class="message-title">
-                    <a href="{{ $post['messageUrl'] }}">{{ $post['itemName'] }}</a>
-                </mj-text>
-                @if($post['messageText'])
-                <mj-text font-size="13px" color="#666666">
-                    {{ \Illuminate\Support\Str::limit($post['messageText'], 100) }}
-                </mj-text>
-                @endif
-                @if($post['postedToText'])
-                <mj-text css-class="posted-to">
-                    {{ $post['postedToText'] }}
-                </mj-text>
-                @endif
-                <mj-button href="{{ $post['messageUrl'] }}" align="left" padding="10px 0" mj-class="btn-success" border-radius="3px">
-                    View Post
+                {{-- Primary CTA --}}
+                <mj-button
+                    href="{{ $post['messageUrl'] }}"
+                    background-color="{{ $accentColor }}"
+                    color="#ffffff"
+                    font-size="16px"
+                    font-weight="600"
+                    inner-padding="13px 0"
+                    border-radius="5px"
+                    width="100%"
+                    align="center"
+                    padding="0 0 10px 0"
+                >
+                    Reply
                 </mj-button>
+                {{-- Secondary actions --}}
+                <mj-text align="center" font-size="13px" color="#888888" padding="0">
+                    <a href="{{ $browseUrl }}" style="color: #555555; text-decoration: none;">Browse other posts</a>
+                    &nbsp;&middot;&nbsp;
+                    <a href="{{ $userSite }}/offer" style="color: #555555; text-decoration: none;">Post something</a>
+                </mj-text>
+            </mj-column>
+        </mj-section>
+
+        @else
+        {{-- ═══════════════════════════════════════════════════════════════ --}}
+        {{-- DAILY MODE: multi-post digest with thumbnail nav               --}}
+        {{-- ═══════════════════════════════════════════════════════════════ --}}
+
+        <mj-section mj-class="bg-success" padding="12px 20px">
+            <mj-column width="20%" vertical-align="middle">
+                <mj-image
+                    width="50px"
+                    src="{{ config('freegle.branding.logo_url') }}"
+                    alt="Freegle"
+                    align="left"
+                    padding="0"
+                />
+            </mj-column>
+            <mj-column width="80%" vertical-align="middle">
+                <mj-text padding="0" line-height="1">
+                    @php $maxThumbItems = 8; @endphp
+                    <table cellpadding="0" cellspacing="0" border="0" role="presentation" style="border-collapse: collapse;">
+                        <tr>
+                            @foreach(collect($posts)->take($maxThumbItems) as $thumbPost)
+                            @php $thumbIsOffer = $thumbPost['type'] === 'Offer'; @endphp
+                            <td style="padding: 0 3px 0 0; vertical-align: middle;">
+                                <a href="#msg-{{ $thumbPost['message']->id }}" style="display: block; line-height: 0;">
+                                    <img src="{{ $thumbPost['trackedImageUrl'] }}" alt="{{ $thumbPost['itemName'] }}" width="44" height="44" style="display: block; width: 44px; height: 44px; object-fit: cover; border-radius: 4px; border: 2px solid {{ $thumbIsOffer ? '#6ab04c' : '#74b9ff' }};" />
+                                </a>
+                            </td>
+                            @endforeach
+                            @if(count($posts) > $maxThumbItems)
+                            <td style="vertical-align: middle; padding-left: 4px;">
+                                <a href="{{ $browseUrl }}" style="color: #ffffff; text-decoration: none; font-size: 12px; font-weight: bold; line-height: 1.3;">+{{ count($posts) - $maxThumbItems }}<br/>more</a>
+                            </td>
+                            @endif
+                        </tr>
+                    </table>
+                </mj-text>
+            </mj-column>
+        </mj-section>
+
+        @foreach($posts as $index => $post)
+        @php $isOffer = $post['type'] === 'Offer'; @endphp
+
+        @if($index > 0)
+        <mj-section padding="0" background-color="#ffffff">
+            <mj-column>
+                <mj-divider border-color="#e9ecef" border-width="1px" padding="0 20px" />
+            </mj-column>
+        </mj-section>
+        @endif
+
+        <mj-section background-color="#ffffff" padding="0">
+            <mj-column width="38%" padding="0" vertical-align="top">
+                <mj-image
+                    href="{{ $post['messageUrl'] }}"
+                    src="{{ $post['trackedImageUrl'] }}"
+                    alt="{{ $post['itemName'] }}"
+                    padding="0"
+                    fluid-on-mobile="true"
+                />
+            </mj-column>
+            <mj-column width="62%" padding="12px 16px 12px 12px" vertical-align="top">
+                <mj-text padding="0 0 6px 0" font-size="13px">
+                    <span style="display: inline-block; background-color: {{ $isOffer ? $offerColor : $wantedColor }}; color: #ffffff; font-size: 12px; font-weight: 700; padding: 2px 9px; border-radius: 3px;">{{ $isOffer ? 'OFFER' : 'WANTED' }}</span>
+                </mj-text>
+                <mj-text padding="0 0 3px 0" font-size="16px" font-weight="700" color="#212529" line-height="1.25">
+                    <a href="{{ $post['messageUrl'] }}" style="color: #212529; text-decoration: none;">{{ $post['itemName'] }}</a>
+                </mj-text>
+                @if($post['locationName'])
+                <mj-text padding="0 0 6px 0" font-size="12px" color="#666666">{{ $post['locationName'] }}</mj-text>
+                @endif
+                @if($post['messageText'])
+                <mj-text padding="0 0 8px 0" font-size="12px" color="#555555" line-height="1.45">{{ \Illuminate\Support\Str::limit($post['messageText'], 80, '…') }}</mj-text>
+                @endif
+                <mj-text padding="0" font-size="12px" color="#888888">
+                    @if($post['distanceText'])<span style="margin-right: 10px;">&#x1F4CD; {{ $post['distanceText'] }}</span>@endif
+                    <span>&#x1F552; {{ $post['arrivalFormatted'] }}</span>
+                </mj-text>
             </mj-column>
         </mj-section>
         @endforeach
 
-        <mj-section background-color="#ffffff" padding="20px">
+        <mj-section background-color="#ffffff" padding="16px 20px 20px 20px">
             <mj-column>
-                <mj-button href="{{ $browseUrl }}" mj-class="btn-secondary" border-radius="3px">
+                <mj-divider border-color="#e9ecef" border-width="1px" padding="0 0 16px 0" />
+                <mj-button href="{{ $browseUrl }}" mj-class="btn-success" font-size="16px" inner-padding="12px 40px" border-radius="4px">
                     Browse All Posts
                 </mj-button>
             </mj-column>
         </mj-section>
 
-        @if($sponsors->isNotEmpty())
+        @endif
+
+        {{-- Sponsors (both modes) --}}
+        @if(isset($sponsors) && $sponsors->isNotEmpty())
         <mj-section background-color="#ffffff" padding="10px 20px">
             <mj-column>
                 <mj-divider border-color="#eeeeee" padding-bottom="5px" />
-                <mj-text font-size="12px" color="#888888" font-style="italic" padding-bottom="5px">
-                    Sponsored by:
-                </mj-text>
+                <mj-text font-size="12px" color="#888888" font-style="italic" padding-bottom="5px">Sponsored by:</mj-text>
             </mj-column>
         </mj-section>
         @foreach($sponsors as $sponsor)
         <mj-section background-color="#ffffff" padding="0 20px 10px">
             <mj-column width="80px" vertical-align="middle">
                 @if($sponsor->imageurl)
-                <mj-image
-                    width="60px"
-                    src="{{ $sponsor->imageurl }}"
-                    alt="{{ $sponsor->name }}"
-                    href="{{ $sponsor->linkurl }}"
-                    border-radius="5px"
-                />
+                <mj-image width="60px" src="{{ $sponsor->imageurl }}" alt="{{ $sponsor->name }}" href="{{ $sponsor->linkurl }}" border-radius="5px" />
                 @endif
             </mj-column>
             <mj-column vertical-align="middle">
                 <mj-text font-size="13px">
-                    @if($sponsor->linkurl)
-                    <a href="{{ $sponsor->linkurl }}" style="color: #338808; text-decoration: none; font-weight: bold;">{{ $sponsor->name }}</a>
-                    @else
-                    <strong>{{ $sponsor->name }}</strong>
-                    @endif
-                    @if($sponsor->tagline)
-                    <br /><span style="font-size: 11px; color: #666;">{{ $sponsor->tagline }}</span>
-                    @endif
+                    @if($sponsor->linkurl)<a href="{{ $sponsor->linkurl }}" style="color: #338808; text-decoration: none; font-weight: bold;">{{ $sponsor->name }}</a>@else<strong>{{ $sponsor->name }}</strong>@endif
+                    @if($sponsor->tagline)<br /><span style="font-size: 11px; color: #666;">{{ $sponsor->tagline }}</span>@endif
                 </mj-text>
             </mj-column>
         </mj-section>
         @endforeach
         @endif
 
-        <mj-section background-color="#ffffff" padding="10px 20px">
-            <mj-column>
-                <mj-divider border-color="#eeeeee" />
-                <mj-text font-size="12px" color="#666666">
-                    You're receiving this because you're a member of Freegle. These emails are sent daily.
-                </mj-text>
-            </mj-column>
-        </mj-section>
+        @include('emails.mjml.partials.footer', ['email' => $user->email_preferred, 'settingsUrl' => $settingsUrl, 'unsubscribeUrl' => $unsubscribeUrl])
 
-        @if(!empty($trackingPixelMjml))
-        <mj-section padding="0">
-            <mj-column>
-                {!! $trackingPixelMjml !!}
-            </mj-column>
-        </mj-section>
+        @if(isset($trackingPixelMjml))
+        {!! $trackingPixelMjml !!}
         @endif
-
-        @include('emails.mjml.partials.footer', ['email' => $user->email_preferred, 'settingsUrl' => $settingsUrl])
     </mj-body>
 </mjml>

--- a/iznik-batch/resources/views/emails/mjml/digest/unified.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/digest/unified.blade.php
@@ -59,6 +59,14 @@
                     @endif
                     <span>&#x1F552; {{ $post['arrivalFormatted'] }}</span>
                 </mj-text>
+                {{-- First posted (V1 single.html parity — only shown when the
+                     message has been reposted, otherwise this duplicates the
+                     arrival time above). --}}
+                @if($post['firstPostedFormatted'] ?? null)
+                <mj-text padding="4px 0 0 0" font-size="11px" color="#999999">
+                    First posted&nbsp;{{ $post['firstPostedFormatted'] }}
+                </mj-text>
+                @endif
             </mj-column>
         </mj-section>
 
@@ -106,12 +114,69 @@
             </mj-column>
         </mj-section>
 
-        {{-- Donations CTA (V1 single.html parity — "Donating helps too!") --}}
+        {{-- Jobs section (V1 single.html parity — "Jobs near you" + CTA).
+             Mirrors the ChatNotification jobs section so the layout and link
+             tracking shape match. Falls back to a standalone "Donating helps
+             too!" button when the user has no nearby jobs so we always keep
+             the donation CTA the V1 template carried. --}}
+        @if(isset($jobAds) && $jobAds->isNotEmpty())
+        <mj-section background-color="#F7F6EC" padding="20px 20px 10px 20px" border-top="1px solid #e9ecef">
+            <mj-column>
+                <mj-text font-size="16px" font-weight="bold" color="#333333" align="center" padding-bottom="10px">
+                    Jobs near you
+                </mj-text>
+            </mj-column>
+        </mj-section>
+        <mj-section background-color="#F7F6EC" padding="5px 20px">
+            <mj-column>
+                <mj-table cellpadding="0" cellspacing="0" width="100%">
+                    @foreach($jobAds as $job)
+                    <tr>
+                        @if($job->image_url ?? null)
+                        <td style="width: 50px; padding: 6px 8px 6px 0; vertical-align: middle;">
+                            <a href="{{ $job->tracked_url }}">
+                                <img src="{{ $job->image_url }}" width="40" height="40" alt="" style="border-radius: 4px; display: block;" />
+                            </a>
+                        </td>
+                        @endif
+                        <td style="padding: 6px 0; vertical-align: middle;">
+                            <a href="{{ $job->tracked_url }}" style="color: #338808; font-weight: bold; text-decoration: none; font-size: 14px;">
+                                {{ $job->title }}
+                            </a>
+                            @if($job->location ?? null)
+                            <br/><span style="color: #666666; font-size: 12px;">{{ $job->location }}</span>
+                            @endif
+                        </td>
+                    </tr>
+                    @endforeach
+                </mj-table>
+            </mj-column>
+        </mj-section>
+        <mj-section background-color="#F7F6EC" padding="0 20px 10px 20px">
+            <mj-column>
+                <mj-text font-size="12px" color="#666666" line-height="1.4">
+                    If you are interested and click, it will raise a little to help keep Freegle running and free to use.
+                </mj-text>
+            </mj-column>
+        </mj-section>
+        <mj-section background-color="#F7F6EC" padding="0 20px 20px 20px">
+            <mj-column width="50%">
+                <mj-button href="{{ $jobsUrl }}" background-color="#00008B" color="#ffffff" font-size="14px" inner-padding="10px 25px" border-radius="3px" width="90%">
+                    View more jobs
+                </mj-button>
+            </mj-column>
+            <mj-column width="50%">
+                <mj-button href="{{ $donateUrl }}" background-color="#338808" color="#ffffff" font-size="14px" inner-padding="10px 25px" border-radius="3px" width="90%">
+                    Donating helps too!
+                </mj-button>
+            </mj-column>
+        </mj-section>
+        @else
         <mj-section background-color="#ffffff" padding="0 20px 20px">
             <mj-column>
                 <mj-divider border-color="#eeeeee" border-width="1px" padding="0 0 16px 0" />
                 <mj-button
-                    href="https://freegle.in/paypal1510"
+                    href="{{ $donateUrl ?? 'https://freegle.in/paypal1510' }}"
                     background-color="#338808"
                     color="#ffffff"
                     font-size="14px"
@@ -124,6 +189,7 @@
                 </mj-button>
             </mj-column>
         </mj-section>
+        @endif
 
         @else
         {{-- ═══════════════════════════════════════════════════════════════ --}}
@@ -240,6 +306,19 @@
             </mj-column>
         </mj-section>
         @endforeach
+        @endif
+
+        {{-- Per-group / per-frequency line (V1 single.html parity).
+             Only useful in immediate mode where the email is about one
+             specific group's post — daily digests cover all groups. --}}
+        @if(($primaryGroupName ?? null) && ($frequencyText ?? null))
+        <mj-section background-color="#f5f5f5" padding="10px 20px 0 20px">
+            <mj-column>
+                <mj-text font-size="11px" color="#666666" align="center" line-height="1.5">
+                    You're a member of <strong>{{ $primaryGroupName }}</strong> and asked to receive updates <strong>{{ $frequencyText }}</strong>.
+                </mj-text>
+            </mj-column>
+        </mj-section>
         @endif
 
         @include('emails.mjml.partials.footer', ['email' => $user->email_preferred, 'settingsUrl' => $settingsUrl, 'unsubscribeUrl' => $unsubscribeUrl])

--- a/iznik-batch/resources/views/emails/mjml/digest/unified.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/digest/unified.blade.php
@@ -46,12 +46,9 @@
                     {{ $post['locationName'] }}
                 </mj-text>
                 @endif
-                {{-- Description snippet --}}
-                @if($post['messageText'])
-                <mj-text padding="0 0 12px 0" font-size="13px" color="#555555" line-height="1.5">
-                    {{ \Illuminate\Support\Str::limit($post['messageText'], 120, '…') }}
-                </mj-text>
-                @endif
+                {{-- The full description is rendered in its own section
+                     below; no snippet here, since the immediate digest is
+                     one post and a 120-char preview duplicates the body. --}}
                 {{-- Distance + time row --}}
                 <mj-text padding="0" font-size="12px" color="#888888">
                     @if($post['distanceText'])
@@ -161,12 +158,12 @@
         </mj-section>
         <mj-section background-color="#F7F6EC" padding="0 20px 20px 20px">
             <mj-column width="50%">
-                <mj-button href="{{ $jobsUrl }}" background-color="#00008B" color="#ffffff" font-size="14px" inner-padding="10px 25px" border-radius="3px" width="90%">
+                <mj-button href="{{ $jobsUrl }}" background-color="{{ $accentColor }}" color="#ffffff" font-size="14px" inner-padding="10px 25px" border-radius="5px" width="90%">
                     View more jobs
                 </mj-button>
             </mj-column>
             <mj-column width="50%">
-                <mj-button href="{{ $donateUrl }}" background-color="#338808" color="#ffffff" font-size="14px" inner-padding="10px 25px" border-radius="3px" width="90%">
+                <mj-button href="{{ $donateUrl }}" background-color="{{ $accentColor }}" color="#ffffff" font-size="14px" inner-padding="10px 25px" border-radius="5px" width="90%">
                     Donating helps too!
                 </mj-button>
             </mj-column>
@@ -177,12 +174,12 @@
                 <mj-divider border-color="#eeeeee" border-width="1px" padding="0 0 16px 0" />
                 <mj-button
                     href="{{ $donateUrl ?? 'https://freegle.in/paypal1510' }}"
-                    background-color="#338808"
+                    background-color="{{ $accentColor }}"
                     color="#ffffff"
                     font-size="14px"
                     font-weight="600"
                     inner-padding="10px 25px"
-                    border-radius="3px"
+                    border-radius="5px"
                     align="center"
                 >
                     Donating helps too!

--- a/iznik-batch/resources/views/emails/mjml/digest/unified.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/digest/unified.blade.php
@@ -106,6 +106,25 @@
             </mj-column>
         </mj-section>
 
+        {{-- Donations CTA (V1 single.html parity — "Donating helps too!") --}}
+        <mj-section background-color="#ffffff" padding="0 20px 20px">
+            <mj-column>
+                <mj-divider border-color="#eeeeee" border-width="1px" padding="0 0 16px 0" />
+                <mj-button
+                    href="https://freegle.in/paypal1510"
+                    background-color="#338808"
+                    color="#ffffff"
+                    font-size="14px"
+                    font-weight="600"
+                    inner-padding="10px 25px"
+                    border-radius="3px"
+                    align="center"
+                >
+                    Donating helps too!
+                </mj-button>
+            </mj-column>
+        </mj-section>
+
         @else
         {{-- ═══════════════════════════════════════════════════════════════ --}}
         {{-- DAILY MODE: multi-post digest with thumbnail nav               --}}

--- a/iznik-batch/resources/views/emails/mjml/partials/footer.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/partials/footer.blade.php
@@ -2,8 +2,8 @@
   <mj-column>
     <mj-text font-size="12px" color="#666666" align="center" line-height="1.6">
       This email was sent{{ !empty($ampIncluded) ? ' with AMP' : '' }} to {{ $email }}<br/>
-      <a href="{{ $settingsUrl ?? config('freegle.sites.user') . '/settings' }}" style="color: #338808;">Change your email settings</a> &bull;
-      <a href="{{ $unsubscribeUrl ?? config('freegle.sites.user') . '/unsubscribe' }}" style="color: #338808;">Unsubscribe</a>
+      <a href="{{ $settingsUrl ?? config('freegle.sites.user') . '/settings' }}" style="color: #338808; font-weight: bold; text-decoration: none;">Change your email settings</a> &bull;
+      <a href="{{ $unsubscribeUrl ?? config('freegle.sites.user') . '/unsubscribe' }}" style="color: #338808; font-weight: bold; text-decoration: none;">Unsubscribe</a>
     </mj-text>
     <mj-divider border-color="#ddd" border-width="1px" padding="15px 40px"></mj-divider>
     <mj-text font-size="11px" color="#666666" align="center" line-height="1.5">

--- a/iznik-batch/resources/views/emails/text/digest/reply-notice.blade.php
+++ b/iznik-batch/resources/views/emails/text/digest/reply-notice.blade.php
@@ -1,0 +1,20 @@
+How to reply to posts on Freegle
+====================================
+
+Hi {{ $recipientName ?? 'there' }},
+
+It looks like you tried to reply to a digest email. Digest emails contain multiple posts from your Freegle communities, so we can't tell which post you'd like to reply to.
+
+To reply to a specific post, please use the "Reply" button next to the post you're interested in. This will open a conversation with the person who posted it.
+
+Browse posts: {{ $browseUrl }}
+
+You can also change how you receive emails in your settings: {{ $settingsUrl }}
+
+------------------------------------
+
+{{ config('freegle.branding.name') }} - Don't throw it away, give it away!
+{{ config('freegle.sites.user') }}
+
+{{ config('freegle.branding.name') }} is registered as a charity with HMRC (ref. XT32865) and is run by volunteers.
+Registered address: Weaver's Field, Loud Bridge, Chipping PR3 2NX

--- a/iznik-batch/resources/views/emails/text/digest/unified.blade.php
+++ b/iznik-batch/resources/views/emails/text/digest/unified.blade.php
@@ -7,6 +7,7 @@ Here {{ $postCount === 1 ? 'is' : 'are' }} {{ $postCount }} new post{{ $postCoun
 
 @foreach($posts as $post)
 {{ strtoupper($post['type']) }}: {{ $post['itemName'] }}
+{{ $post['arrivalFormatted'] }}
 @if($post['messageText'])
 {{ \Illuminate\Support\Str::limit($post['messageText'], 150) }}
 @endif
@@ -29,11 +30,12 @@ Sponsored by:
 
 ------------------------------------
 
-You're receiving this because you're a member of Freegle. These emails are sent daily.
+You're receiving this because you're a member of Freegle. These emails are sent {{ $mode === 'immediate' ? 'when new posts are available' : 'daily' }}.
 
 Update your settings: {{ $settingsUrl }}
+Unsubscribe: {{ $unsubscribeUrl ?? config('freegle.sites.user') . '/unsubscribe' }}
 
 ------------------------------------
 
 Freegle - Don't throw it away, give it away!
-{!! config('freegle.sites.user') !!}
+{{ $browseUrl }}

--- a/iznik-batch/routes/console.php
+++ b/iznik-batch/routes/console.php
@@ -334,10 +334,13 @@ Schedule::command('tn:sync')
 //     ->runInBackground();
 //
 // Immediate mode - notifications for users who want instant alerts.
-Schedule::command('mail:digest:unified --mode=immediate')
-    ->everyMinute()
-    ->withoutOverlapping()
-    ->runInBackground();
+// Disabled until V1 `mail:digest -1` on bulk3 is turned off in the same
+// deploy — otherwise users would receive duplicate immediate emails.
+// Enable in a follow-up commit coordinated with the V1 shutdown.
+// Schedule::command('mail:digest:unified --mode=immediate')
+//     ->everyMinute()
+//     ->withoutOverlapping()
+//     ->runInBackground();
 
 // Donation-related commands. V1 equivalents on bulk3 disabled 2026-05-12.
 Schedule::command('mail:donations:thank')

--- a/iznik-batch/routes/console.php
+++ b/iznik-batch/routes/console.php
@@ -334,10 +334,10 @@ Schedule::command('tn:sync')
 //     ->runInBackground();
 //
 // Immediate mode - notifications for users who want instant alerts.
-// Schedule::command('mail:digest:unified --mode=immediate')
-//     ->everyMinute()
-//     ->withoutOverlapping()
-//     ->runInBackground();
+Schedule::command('mail:digest:unified --mode=immediate')
+    ->everyMinute()
+    ->withoutOverlapping()
+    ->runInBackground();
 
 // Donation-related commands. V1 equivalents on bulk3 disabled 2026-05-12.
 Schedule::command('mail:donations:thank')

--- a/iznik-batch/tests/Unit/Mail/DigestReplyNoticeTest.php
+++ b/iznik-batch/tests/Unit/Mail/DigestReplyNoticeTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Unit\Mail;
+
+use App\Mail\Digest\DigestReplyNotice;
+use Tests\TestCase;
+
+class DigestReplyNoticeTest extends TestCase
+{
+    public function test_can_be_constructed(): void
+    {
+        $mail = new DigestReplyNotice('test@example.com', 'Test User', 12345);
+
+        $this->assertInstanceOf(DigestReplyNotice::class, $mail);
+    }
+
+    public function test_build_returns_self(): void
+    {
+        $mail = new DigestReplyNotice('test@example.com', 'Test User', 12345);
+        $result = $mail->build();
+
+        $this->assertInstanceOf(DigestReplyNotice::class, $result);
+    }
+
+    public function test_has_correct_subject(): void
+    {
+        $mail = new DigestReplyNotice('test@example.com');
+        $envelope = $mail->envelope();
+
+        $this->assertEquals('How to reply to posts on Freegle', $envelope->subject);
+    }
+
+    public function test_can_construct_without_name_or_userid(): void
+    {
+        $mail = new DigestReplyNotice('test@example.com');
+        $result = $mail->build();
+
+        $this->assertInstanceOf(DigestReplyNotice::class, $result);
+    }
+
+    public function test_tracking_initialised(): void
+    {
+        $mail = new DigestReplyNotice('test@example.com', 'Test User', 12345);
+
+        $tracking = $mail->getTracking();
+        $this->assertNotNull($tracking);
+        $this->assertEquals('DigestReplyNotice', $tracking->email_type);
+    }
+}

--- a/iznik-batch/tests/Unit/Mail/UnifiedDigestTest.php
+++ b/iznik-batch/tests/Unit/Mail/UnifiedDigestTest.php
@@ -1,0 +1,205 @@
+<?php
+
+namespace Tests\Unit\Mail;
+
+use App\Mail\Digest\UnifiedDigest;
+use App\Services\UnifiedDigestService;
+use Tests\TestCase;
+
+class UnifiedDigestTest extends TestCase
+{
+    public function test_can_be_constructed(): void
+    {
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $this->createMembership($user, $group);
+
+        $poster = $this->createTestUser();
+        $this->createMembership($poster, $group);
+        $message = $this->createTestMessage($poster, $group, [
+            'subject' => 'OFFER: Sofa (London)',
+        ]);
+
+        $posts = collect([
+            ['message' => $message, 'postedToGroups' => [$group->id]],
+        ]);
+
+        $mail = new UnifiedDigest($user, $posts, UnifiedDigestService::MODE_DAILY);
+
+        $this->assertInstanceOf(UnifiedDigest::class, $mail);
+    }
+
+    public function test_build_returns_self(): void
+    {
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $this->createMembership($user, $group);
+
+        $poster = $this->createTestUser();
+        $this->createMembership($poster, $group);
+        $message = $this->createTestMessage($poster, $group, [
+            'subject' => 'OFFER: Sofa (London)',
+        ]);
+
+        $posts = collect([
+            ['message' => $message, 'postedToGroups' => [$group->id]],
+        ]);
+
+        $mail = new UnifiedDigest($user, $posts, UnifiedDigestService::MODE_DAILY);
+        $result = $mail->build();
+
+        $this->assertInstanceOf(UnifiedDigest::class, $result);
+    }
+
+    public function test_subject_with_single_post(): void
+    {
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $this->createMembership($user, $group);
+
+        $poster = $this->createTestUser();
+        $this->createMembership($poster, $group);
+        $message = $this->createTestMessage($poster, $group, [
+            'subject' => 'OFFER: Sofa (London)',
+        ]);
+
+        $posts = collect([
+            ['message' => $message, 'postedToGroups' => [$group->id]],
+        ]);
+
+        $mail = new UnifiedDigest($user, $posts, UnifiedDigestService::MODE_DAILY);
+        $envelope = $mail->envelope();
+
+        $this->assertEquals('1 new post near you - Sofa', $envelope->subject);
+    }
+
+    public function test_subject_with_multiple_posts(): void
+    {
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $this->createMembership($user, $group);
+
+        $poster = $this->createTestUser();
+        $this->createMembership($poster, $group);
+
+        $msg1 = $this->createTestMessage($poster, $group, ['subject' => 'OFFER: Sofa (London)']);
+        $msg2 = $this->createTestMessage($poster, $group, ['subject' => 'WANTED: Table (London)']);
+        $msg3 = $this->createTestMessage($poster, $group, ['subject' => 'OFFER: Books (London)']);
+
+        $posts = collect([
+            ['message' => $msg1, 'postedToGroups' => [$group->id]],
+            ['message' => $msg2, 'postedToGroups' => [$group->id]],
+            ['message' => $msg3, 'postedToGroups' => [$group->id]],
+        ]);
+
+        $mail = new UnifiedDigest($user, $posts, UnifiedDigestService::MODE_DAILY);
+        $envelope = $mail->envelope();
+
+        $this->assertStringStartsWith('3 new posts near you', $envelope->subject);
+        $this->assertStringContainsString('Sofa', $envelope->subject);
+    }
+
+    public function test_tracked_urls_contain_post_positions(): void
+    {
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $this->createMembership($user, $group);
+
+        $poster = $this->createTestUser();
+        $this->createMembership($poster, $group);
+
+        $msg1 = $this->createTestMessage($poster, $group, ['subject' => 'OFFER: Sofa (London)']);
+        $msg2 = $this->createTestMessage($poster, $group, ['subject' => 'OFFER: Table (London)']);
+
+        $posts = collect([
+            ['message' => $msg1, 'postedToGroups' => [$group->id]],
+            ['message' => $msg2, 'postedToGroups' => [$group->id]],
+        ]);
+
+        $mail = new UnifiedDigest($user, $posts, UnifiedDigestService::MODE_DAILY);
+        $mail->build();
+
+        // Verify tracking was initialised with correct metadata.
+        $tracking = $mail->getTracking();
+        $this->assertNotNull($tracking);
+        $this->assertEquals('UnifiedDigest', $tracking->email_type);
+    }
+
+    public function test_cross_post_text_shown_for_multiple_groups(): void
+    {
+        $user = $this->createTestUser();
+        $group1 = $this->createTestGroup();
+        $group2 = $this->createTestGroup();
+        $this->createMembership($user, $group1);
+        $this->createMembership($user, $group2);
+
+        $poster = $this->createTestUser();
+        $this->createMembership($poster, $group1);
+        $this->createMembership($poster, $group2);
+
+        $message = $this->createTestMessage($poster, $group1, [
+            'subject' => 'OFFER: Sofa (London)',
+        ]);
+
+        $posts = collect([
+            ['message' => $message, 'postedToGroups' => [$group1->id, $group2->id]],
+        ]);
+
+        $mail = new UnifiedDigest($user, $posts, UnifiedDigestService::MODE_DAILY);
+        $mail->build();
+
+        // The mail was built successfully with cross-post data.
+        $this->assertInstanceOf(UnifiedDigest::class, $mail);
+    }
+
+    public function test_tracking_metadata_contains_mode_and_count(): void
+    {
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $this->createMembership($user, $group);
+
+        $poster = $this->createTestUser();
+        $this->createMembership($poster, $group);
+        $message = $this->createTestMessage($poster, $group);
+
+        $posts = collect([
+            ['message' => $message, 'postedToGroups' => [$group->id]],
+        ]);
+
+        $mail = new UnifiedDigest($user, $posts, UnifiedDigestService::MODE_DAILY);
+
+        $tracking = $mail->getTracking();
+        $this->assertNotNull($tracking);
+
+        $metadata = $tracking->metadata;
+        $this->assertEquals('daily', $metadata['mode']);
+        $this->assertEquals(1, $metadata['post_count']);
+        $this->assertArrayHasKey('digest_number', $metadata);
+    }
+
+    public function test_amp_content_excluded_when_disabled(): void
+    {
+        // Force AMP off via config before constructing the mailable.
+        config(['freegle.amp.enabled' => false]);
+        config(['freegle.amp.secret' => '']);
+
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $this->createMembership($user, $group);
+
+        $poster = $this->createTestUser();
+        $this->createMembership($poster, $group);
+        $message = $this->createTestMessage($poster, $group);
+
+        $posts = collect([
+            ['message' => $message, 'postedToGroups' => [$group->id]],
+        ]);
+
+        $mail = new UnifiedDigest($user, $posts, UnifiedDigestService::MODE_DAILY);
+        $mail->build();
+
+        // Verify tracking does not indicate AMP.
+        $tracking = $mail->getTracking();
+        $this->assertFalse($tracking->has_amp);
+    }
+}

--- a/iznik-batch/tests/Unit/Mail/UnifiedDigestTest.php
+++ b/iznik-batch/tests/Unit/Mail/UnifiedDigestTest.php
@@ -4,10 +4,37 @@ namespace Tests\Unit\Mail;
 
 use App\Mail\Digest\UnifiedDigest;
 use App\Services\UnifiedDigestService;
+use Tests\Support\IsolatedSpoolDirectory;
 use Tests\TestCase;
 
 class UnifiedDigestTest extends TestCase
 {
+    use IsolatedSpoolDirectory;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpIsolatedSpoolDirectory();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownIsolatedSpoolDirectory();
+        parent::tearDown();
+    }
+
+    /**
+     * Spool the mailable and return the decoded spool-file array. This is
+     * how the real mail path captures everything (subject, body, all custom
+     * headers, reply-to) — so assertions here exercise the actual
+     * production capture pipeline rather than poking at Symfony internals.
+     */
+    private function spoolAndLoad(UnifiedDigest $mail, string $recipient): array
+    {
+        $id = $this->spooler->spool($mail, $recipient);
+        return json_decode(file_get_contents($this->testSpoolDir . '/pending/' . $id . '.json'), true);
+    }
+
     public function test_can_be_constructed(): void
     {
         $user = $this->createTestUser();
@@ -175,6 +202,96 @@ class UnifiedDigestTest extends TestCase
         $this->assertEquals('daily', $metadata['mode']);
         $this->assertEquals(1, $metadata['post_count']);
         $this->assertArrayHasKey('digest_number', $metadata);
+    }
+
+    public function test_immediate_mode_envelope_from_is_replyto_address(): void
+    {
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $this->createMembership($user, $group);
+
+        $poster = $this->createTestUser(['fullname' => 'Test Poster']);
+        $this->createMembership($poster, $group);
+        $message = $this->createTestMessage($poster, $group, [
+            'subject' => 'OFFER: Sofa (London)',
+        ]);
+
+        $posts = collect([
+            ['message' => $message, 'postedToGroups' => [$group->id]],
+        ]);
+
+        $mail = new UnifiedDigest($user, $posts, UnifiedDigestService::MODE_IMMEDIATE);
+        $envelope = $mail->envelope();
+
+        $expected = "replyto-{$message->id}-{$user->id}@" . config('freegle.mail.user_domain');
+        $this->assertEquals($expected, $envelope->from->address);
+    }
+
+    public function test_immediate_mode_sets_reply_to_header_matching_from(): void
+    {
+        // The immediate digest relies on From and Reply-To both being the
+        // replyto-{msgId}-{userId} address so a user can hit "Reply" in any
+        // mail client and have the message routed back to the original
+        // poster. This test asserts that contract via the same spool path
+        // production uses.
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $this->createMembership($user, $group);
+
+        $poster = $this->createTestUser(['fullname' => 'Test Poster']);
+        $this->createMembership($poster, $group);
+        $message = $this->createTestMessage($poster, $group, [
+            'subject' => 'OFFER: Sofa (London)',
+        ]);
+
+        $posts = collect([
+            ['message' => $message, 'postedToGroups' => [$group->id]],
+        ]);
+
+        $mail = new UnifiedDigest($user, $posts, UnifiedDigestService::MODE_IMMEDIATE);
+        $expected = "replyto-{$message->id}-{$user->id}@" . config('freegle.mail.user_domain');
+
+        $data = $this->spoolAndLoad($mail, $user->email_preferred);
+
+        // From address (envelope) is the replyto- address.
+        $fromAddresses = array_column($data['from'] ?? [], 'address');
+        $this->assertContains($expected, $fromAddresses);
+
+        // Reply-To header is set explicitly to the same address so clients
+        // that prefer Reply-To over From still route the user's reply back.
+        $replyToAddresses = array_column($data['reply_to'] ?? [], 'address');
+        $this->assertContains($expected, $replyToAddresses);
+    }
+
+    public function test_immediate_mode_sets_v1_parity_headers(): void
+    {
+        // Feedback-ID — Google FBL spec ({qualifier}:{userid}:{type}:{sender}).
+        // X-Freegle-Mail-Type — V1 header name that TN consumes (sits next to
+        // the V2-style X-Freegle-Email-Type from MjmlMailable).
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $this->createMembership($user, $group);
+
+        $poster = $this->createTestUser();
+        $this->createMembership($poster, $group);
+        $message = $this->createTestMessage($poster, $group);
+
+        $posts = collect([
+            ['message' => $message, 'postedToGroups' => [$group->id]],
+        ]);
+
+        $mail = new UnifiedDigest($user, $posts, UnifiedDigestService::MODE_IMMEDIATE);
+        $data = $this->spoolAndLoad($mail, $user->email_preferred);
+
+        $headers = $data['headers'] ?? [];
+        $this->assertArrayHasKey('Feedback-ID', $headers);
+        $this->assertSame(
+            "{$message->id}:{$user->id}:Digest:freegle",
+            $headers['Feedback-ID']
+        );
+
+        $this->assertArrayHasKey('X-Freegle-Mail-Type', $headers);
+        $this->assertSame('Digest', $headers['X-Freegle-Mail-Type']);
     }
 
     public function test_amp_content_excluded_when_disabled(): void

--- a/iznik-batch/tests/Unit/Services/Mail/Incoming/IncomingMailServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/Mail/Incoming/IncomingMailServiceTest.php
@@ -3993,72 +3993,6 @@ class IncomingMailServiceTest extends TestCase
         $this->assertFalse($added, 'System addresses should not be added to user profile');
     }
 
-    public function test_addEmailToUser_skips_envelope_from_without_at_sign(): void
-    {
-        $poster = $this->createTestUser(['email_preferred' => $this->uniqueEmail('poster')]);
-        $replier = $this->createTestUser(['email_preferred' => $this->uniqueEmail('replier')]);
-        $group = $this->createTestGroup();
-        $this->createMembership($poster, $group);
-        $message = $this->createTestMessage($poster, $group);
-
-        $replierEmail = $replier->emails->first()->email;
-
-        $email = $this->createMinimalEmail([
-            'From' => $replierEmail,
-            'To' => "replyto-{$message->id}-{$replier->id}@users.ilovefreegle.org",
-            'Subject' => 'Re: ' . $message->subject,
-        ], 'Is this still available?');
-
-        // Bounce notifiers commonly use a bare daemon name in envelope-from.
-        $parsed = $this->parser->parse(
-            $email,
-            'MAILER-DAEMON',
-            "replyto-{$message->id}-{$replier->id}@users.ilovefreegle.org"
-        );
-
-        $this->service->route($parsed);
-
-        $added = DB::table('users_emails')
-            ->where('userid', $replier->id)
-            ->where('email', 'MAILER-DAEMON')
-            ->exists();
-
-        $this->assertFalse($added, 'Non-email envelope-from values should not be added');
-    }
-
-    public function test_addEmailToUser_skips_whitespace_only_envelope_from(): void
-    {
-        $poster = $this->createTestUser(['email_preferred' => $this->uniqueEmail('poster')]);
-        $replier = $this->createTestUser(['email_preferred' => $this->uniqueEmail('replier')]);
-        $group = $this->createTestGroup();
-        $this->createMembership($poster, $group);
-        $message = $this->createTestMessage($poster, $group);
-
-        $replierEmail = $replier->emails->first()->email;
-
-        $email = $this->createMinimalEmail([
-            'From' => $replierEmail,
-            'To' => "replyto-{$message->id}-{$replier->id}@users.ilovefreegle.org",
-            'Subject' => 'Re: ' . $message->subject,
-        ], 'Is this still available?');
-
-        // PHP's empty(' ') returns false, so guard against trim-to-empty too.
-        $parsed = $this->parser->parse(
-            $email,
-            '   ',
-            "replyto-{$message->id}-{$replier->id}@users.ilovefreegle.org"
-        );
-
-        $this->service->route($parsed);
-
-        $emptyAdded = DB::table('users_emails')
-            ->where('userid', $replier->id)
-            ->where('email', '')
-            ->exists();
-
-        $this->assertFalse($emptyAdded, 'Whitespace-only envelope-from must not insert an empty row');
-    }
-
     // ========================================
     // Fix #7: hasOutcome / mailedLastForUser
     // ========================================
@@ -4892,5 +4826,196 @@ class IncomingMailServiceTest extends TestCase
 
         $message = DB::table('messages')->where('id', $messageId)->first();
         $this->assertEquals(2, $message->retrycount, 'retrycount should be 2 after two failures');
+    }
+
+    // ========================================
+    // Digest Reply Routing Tests
+    // ========================================
+
+    public function test_digest_reply_sends_auto_response_and_routes_to_system(): void
+    {
+        Mail::fake();
+
+        $noreplyAddr = config('freegle.mail.noreply_addr', 'noreply@ilovefreegle.org');
+
+        $email = $this->createMinimalEmail([
+            'From' => 'user@example.com',
+            'Subject' => 'Re: Your Freegle Digest',
+        ], 'I want to reply to a post in the digest.');
+
+        $parsed = $this->parser->parse(
+            $email,
+            'user@example.com',
+            $noreplyAddr
+        );
+
+        $result = $this->service->route($parsed);
+
+        $this->assertEquals(RoutingResult::TO_SYSTEM, $result);
+        Mail::assertSent(\App\Mail\Digest\DigestReplyNotice::class, function ($mail) {
+            return $mail->hasTo('user@example.com');
+        });
+    }
+
+    public function test_digest_reply_suppressed_for_mailer_daemon_sender(): void
+    {
+        Mail::fake();
+
+        $noreplyAddr = config('freegle.mail.noreply_addr', 'noreply@ilovefreegle.org');
+
+        $email = $this->createMinimalEmail([
+            'From' => 'MAILER-DAEMON@example.com',
+            'Subject' => 'Delivery Status',
+        ], 'Could not deliver your message.');
+
+        $parsed = $this->parser->parse(
+            $email,
+            'MAILER-DAEMON@example.com',
+            $noreplyAddr
+        );
+
+        $result = $this->service->route($parsed);
+
+        $this->assertEquals(RoutingResult::TO_SYSTEM, $result);
+        Mail::assertNotSent(\App\Mail\Digest\DigestReplyNotice::class);
+    }
+
+    public function test_digest_reply_suppressed_for_noreply_sender(): void
+    {
+        Mail::fake();
+
+        $noreplyAddr = config('freegle.mail.noreply_addr', 'noreply@ilovefreegle.org');
+
+        $email = $this->createMinimalEmail([
+            'From' => 'noreply@someservice.com',
+            'Subject' => 'Automated message',
+        ], 'This is automated.');
+
+        $parsed = $this->parser->parse(
+            $email,
+            'noreply@someservice.com',
+            $noreplyAddr
+        );
+
+        $result = $this->service->route($parsed);
+
+        $this->assertEquals(RoutingResult::TO_SYSTEM, $result);
+        Mail::assertNotSent(\App\Mail\Digest\DigestReplyNotice::class);
+    }
+
+    public function test_digest_reply_suppressed_when_auto_submitted(): void
+    {
+        Mail::fake();
+
+        $noreplyAddr = config('freegle.mail.noreply_addr', 'noreply@ilovefreegle.org');
+
+        $email = $this->createMinimalEmail([
+            'From' => 'user@example.com',
+            'Subject' => 'Out of office',
+            'Auto-Submitted' => 'auto-replied',
+        ], 'I am away from the office.');
+
+        $parsed = $this->parser->parse(
+            $email,
+            'user@example.com',
+            $noreplyAddr
+        );
+
+        $result = $this->service->route($parsed);
+
+        $this->assertEquals(RoutingResult::TO_SYSTEM, $result);
+        Mail::assertNotSent(\App\Mail\Digest\DigestReplyNotice::class);
+    }
+
+    public function test_digest_reply_rate_limited_to_once_per_24h(): void
+    {
+        Mail::fake();
+
+        $noreplyAddr = config('freegle.mail.noreply_addr', 'noreply@ilovefreegle.org');
+
+        $email = $this->createMinimalEmail([
+            'From' => 'ratelimit@example.com',
+            'Subject' => 'Re: Digest',
+        ], 'First reply to digest.');
+
+        $parsed = $this->parser->parse(
+            $email,
+            'ratelimit@example.com',
+            $noreplyAddr
+        );
+
+        $result1 = $this->service->route($parsed);
+        $this->assertEquals(RoutingResult::TO_SYSTEM, $result1);
+        Mail::assertSent(\App\Mail\Digest\DigestReplyNotice::class);
+
+        // Second reply from same sender within 24h — no auto-reply
+        Mail::fake();
+        $email2 = $this->createMinimalEmail([
+            'From' => 'ratelimit@example.com',
+            'Subject' => 'Re: Digest again',
+        ], 'Second reply to digest.');
+
+        $parsed2 = $this->parser->parse(
+            $email2,
+            'ratelimit@example.com',
+            $noreplyAddr
+        );
+
+        $result2 = $this->service->route($parsed2);
+        $this->assertEquals(RoutingResult::TO_SYSTEM, $result2);
+        Mail::assertNotSent(\App\Mail\Digest\DigestReplyNotice::class);
+    }
+
+    public function test_digest_reply_via_in_reply_to_header(): void
+    {
+        Mail::fake();
+
+        $email = $this->createMinimalEmail([
+            'From' => 'user@example.com',
+            'Subject' => 'Re: Your Digest',
+            'In-Reply-To' => '<UnifiedDigest-12345@ilovefreegle.org>',
+        ], 'I am replying to the digest via In-Reply-To.');
+
+        // Envelope-to is a regular address (not noreply@), but In-Reply-To
+        // identifies this as a digest reply
+        $parsed = $this->parser->parse(
+            $email,
+            'user@example.com',
+            'freegle@example.com'
+        );
+
+        $result = $this->service->route($parsed);
+
+        $this->assertEquals(RoutingResult::TO_SYSTEM, $result);
+        Mail::assertSent(\App\Mail\Digest\DigestReplyNotice::class, function ($mail) {
+            return $mail->hasTo('user@example.com');
+        });
+    }
+
+    public function test_digest_reply_includes_user_id_when_sender_found(): void
+    {
+        Mail::fake();
+
+        $noreplyAddr = config('freegle.mail.noreply_addr', 'noreply@ilovefreegle.org');
+        $senderEmail = $this->uniqueEmail('digestsender');
+        $user = $this->createTestUser(['email_preferred' => $senderEmail]);
+
+        $email = $this->createMinimalEmail([
+            'From' => $senderEmail,
+            'Subject' => 'Re: Your Freegle Digest',
+        ], 'I want to reply to a post.');
+
+        $parsed = $this->parser->parse(
+            $email,
+            $senderEmail,
+            $noreplyAddr
+        );
+
+        $result = $this->service->route($parsed);
+
+        $this->assertEquals(RoutingResult::TO_SYSTEM, $result);
+        Mail::assertSent(\App\Mail\Digest\DigestReplyNotice::class, function ($mail) use ($senderEmail) {
+            return $mail->hasTo($senderEmail);
+        });
     }
 }

--- a/iznik-batch/tests/Unit/Services/Mail/Incoming/MailParserServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/Mail/Incoming/MailParserServiceTest.php
@@ -472,6 +472,52 @@ class MailParserServiceTest extends TestCase
     }
 
     // ========================================
+    // Digest Reply Detection Tests
+    // ========================================
+
+    public function test_parse_detects_digest_reply_to_noreply_address(): void
+    {
+        $noreplyAddr = config('freegle.mail.noreply_addr');
+
+        $rawEmail = $this->createMinimalEmail([
+            'From' => 'user@example.com',
+            'To' => $noreplyAddr,
+            'Subject' => 'Re: 5 new posts near you - Sofa, Table',
+        ], 'Thanks for the digest!');
+
+        $parsed = $this->parser->parse($rawEmail, 'user@example.com', $noreplyAddr);
+
+        $this->assertTrue($parsed->isDigestReply());
+    }
+
+    public function test_parse_detects_digest_reply_via_in_reply_to_header(): void
+    {
+        $rawEmail = $this->createMinimalEmail([
+            'From' => 'user@example.com',
+            'To' => 'someaddress@example.com',
+            'Subject' => 'Re: 3 new posts near you',
+            'In-Reply-To' => '<UnifiedDigest-12345-67890@ilovefreegle.org>',
+        ], 'I want the sofa!');
+
+        $parsed = $this->parser->parse($rawEmail, 'user@example.com', 'someaddress@example.com');
+
+        $this->assertTrue($parsed->isDigestReply());
+    }
+
+    public function test_parse_non_digest_email_not_flagged_as_digest_reply(): void
+    {
+        $rawEmail = $this->createMinimalEmail([
+            'From' => 'user@example.com',
+            'To' => 'testgroup@groups.ilovefreegle.org',
+            'Subject' => 'OFFER: Sofa (London)',
+        ], 'Free sofa available.');
+
+        $parsed = $this->parser->parse($rawEmail, 'user@example.com', 'testgroup@groups.ilovefreegle.org');
+
+        $this->assertFalse($parsed->isDigestReply());
+    }
+
+    // ========================================
     // Helper Methods
     // ========================================
 

--- a/iznik-batch/tests/Unit/Services/PostcodeRemapServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/PostcodeRemapServiceTest.php
@@ -16,90 +16,452 @@ class PostcodeRemapServiceTest extends TestCase
         $this->service = app(PostcodeRemapService::class);
     }
 
-    /**
-     * Test postgresAvailable returns true when PostgreSQL is reachable.
-     */
-    public function test_postgres_available_returns_true_when_connected(): void
+    public function test_remap_returns_zero_when_postgres_unavailable(): void
     {
-        // PostgreSQL should be available in the test environment.
-        $this->assertTrue($this->service->postgresAvailable());
+        // Override the pgsql config to point to a non-existent host.
+        config(['database.connections.pgsql.host' => 'nonexistent-host-that-does-not-exist']);
+        DB::purge('pgsql');
+
+        $result = $this->service->remapPostcodes(NULL);
+        $this->assertEquals(0, $result);
     }
 
-    /**
-     * Test ensurePostgresSchema creates required extensions.
-     */
-    public function test_ensure_postgres_schema_creates_postgis_extension(): void
+    public function test_remap_postcodes_task_dispatches_correctly(): void
     {
-        // Call should succeed without exception.
-        $this->service->ensurePostgresSchema();
+        // Ensure background_tasks table exists.
+        DB::statement('CREATE TABLE IF NOT EXISTS background_tasks (
+            id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+            task_type VARCHAR(50) NOT NULL,
+            data JSON NOT NULL,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            processed_at TIMESTAMP NULL,
+            failed_at TIMESTAMP NULL,
+            error_message TEXT NULL,
+            attempts INT UNSIGNED DEFAULT 0,
+            INDEX idx_task_type (task_type),
+            INDEX idx_pending (processed_at, created_at)
+        )');
 
-        // Verify postgis is installed by checking a function exists.
-        $result = DB::connection('pgsql')->selectOne(
-            "SELECT EXISTS(SELECT 1 FROM pg_proc WHERE proname = 'st_makepoint')"
+        // Insert a remap_postcodes task like Go would.
+        $polygon = 'POLYGON((-3.22 55.93, -3.22 55.98, -3.17 55.98, -3.17 55.93, -3.22 55.93))';
+        DB::table('background_tasks')->insert([
+            'task_type' => 'remap_postcodes',
+            'data' => json_encode([
+                'location_id' => 12345,
+                'polygon' => $polygon,
+            ]),
+            'created_at' => now(),
+        ]);
+
+        $task = DB::table('background_tasks')
+            ->where('task_type', 'remap_postcodes')
+            ->first();
+
+        $this->assertNotNull($task);
+        $data = json_decode($task->data, TRUE);
+        $this->assertEquals(12345, $data['location_id']);
+        $this->assertEquals($polygon, $data['polygon']);
+
+        // Clean up.
+        DB::table('background_tasks')->truncate();
+    }
+
+    public function test_find_nearest_area_with_postgres(): void
+    {
+        // Skip if PostgreSQL is not available.
+        try {
+            DB::connection('pgsql')->getPdo();
+        } catch (\Throwable $e) {
+            $this->markTestSkipped('PostgreSQL not available');
+        }
+
+        $this->setupPostgresLocationsTable();
+
+        $srid = (int) config('freegle.srid', 3857);
+
+        // Insert a test area polygon (roughly Edinburgh area).
+        $polygon = 'POLYGON((-3.25 55.90, -3.25 56.00, -3.15 56.00, -3.15 55.90, -3.25 55.90))';
+        DB::connection('pgsql')->insert(
+            "INSERT INTO locations (locationid, name, type, area, location)
+             VALUES (?, ?, 'Polygon', ST_Area(ST_GeomFromText(?, ?)), ST_GeomFromText(?, ?))",
+            [99999, 'Test Area Edinburgh', $polygon, $srid, $polygon, $srid]
         );
 
-        $this->assertTrue((bool) $result->exists);
+        // Query for a point inside the polygon.
+        $result = $this->service->findNearestArea(-3.20, 55.95);
+        $this->assertEquals(99999, $result);
+
+        // Query for a point far away — should still find nearest but with larger buffer.
+        $farResult = $this->service->findNearestArea(0.0, 51.5);
+        // May or may not find it depending on buffer size — just test it doesn't crash.
+        $this->assertTrue($farResult === NULL || $farResult === 99999);
+
+        // Clean up.
+        DB::connection('pgsql')->statement('DROP TABLE IF EXISTS locations');
     }
 
     /**
-     * Test remapPostcodes returns 0 when PostgreSQL is unavailable.
+     * Regression test: when a location is created/updated and a polygon-scoped remap
+     * runs, all locations within the polygon must be synced to PostgreSQL — not just
+     * the single location_id from the task. Otherwise newly created locations won't
+     * be candidates in the KNN query.
      */
-    public function test_remap_postcodes_returns_zero_when_postgres_unavailable(): void
+    public function test_polygon_scoped_remap_syncs_all_locations_in_scope(): void
     {
-        // Mock postgresAvailable to return false.
-        $mock = $this->createPartialMock(PostcodeRemapService::class, ['postgresAvailable']);
-        $mock->method('postgresAvailable')->willReturn(false);
+        try {
+            DB::connection('pgsql')->getPdo();
+        } catch (\Throwable $e) {
+            $this->markTestSkipped('PostgreSQL not available');
+        }
 
-        $result = $mock->remapPostcodes();
+        $this->setupPostgresLocationsTable();
+        $srid = (int) config('freegle.srid', 3857);
 
-        $this->assertEquals(0, $result);
+        // Create a large area ("City") and a small area ("Neighbourhood") in MySQL.
+        // The neighbourhood is inside the city. Both are 2D polygons.
+        $cityPoly = 'POLYGON((-1.55 53.30, -1.55 53.40, -1.45 53.40, -1.45 53.30, -1.55 53.30))';
+        $neighbourhoodPoly = 'POLYGON((-1.51 53.34, -1.51 53.36, -1.49 53.36, -1.49 53.34, -1.51 53.34))';
+
+        $cityId = DB::table('locations')->insertGetId([
+            'name' => 'TestCity',
+            'type' => 'Polygon',
+            'lat' => 53.35,
+            'lng' => -1.50,
+        ]);
+
+        $neighbourhoodId = DB::table('locations')->insertGetId([
+            'name' => 'TestNeighbourhood',
+            'type' => 'Polygon',
+            'lat' => 53.35,
+            'lng' => -1.50,
+        ]);
+
+        // Insert geometries into locations_spatial.
+        DB::statement(
+            "INSERT INTO locations_spatial (locationid, geometry) VALUES (?, ST_GeomFromText(?, ?))",
+            [$cityId, $cityPoly, $srid]
+        );
+        DB::statement(
+            "INSERT INTO locations_spatial (locationid, geometry) VALUES (?, ST_GeomFromText(?, ?))",
+            [$neighbourhoodId, $neighbourhoodPoly, $srid]
+        );
+
+        // Create a postcode inside the neighbourhood, initially mapped to the city.
+        $postcodeId = DB::table('locations')->insertGetId([
+            'name' => 'ZZ1 1AA',
+            'type' => 'Postcode',
+            'lat' => 53.35,
+            'lng' => -1.50,
+            'areaid' => $cityId,
+        ]);
+
+        DB::statement(
+            "INSERT INTO locations_spatial (locationid, geometry) VALUES (?, ST_GeomFromText(?, ?))",
+            [$postcodeId, "POINT(-1.50 53.35)", $srid]
+        );
+
+        // Only sync the city to PostgreSQL — simulating the bug where the neighbourhood
+        // (the newly created/updated location) hasn't been synced yet.
+        DB::connection('pgsql')->insert(
+            "INSERT INTO locations (locationid, name, type, area, location)
+             VALUES (?, ?, 'Polygon', ST_Area(ST_GeomFromText(?, ?)), ST_GeomFromText(?, ?))",
+            [$cityId, 'TestCity', $cityPoly, $srid, $cityPoly, $srid]
+        );
+
+        // Verify neighbourhood is NOT in PostgreSQL yet.
+        $pgNeighbourhood = DB::connection('pgsql')
+            ->selectOne('SELECT locationid FROM locations WHERE locationid = ?', [$neighbourhoodId]);
+        $this->assertNull($pgNeighbourhood);
+
+        // Run remap with polygon scope covering both locations.
+        // This simulates what happens when the neighbourhood is created and
+        // a remap task fires with the neighbourhood's polygon as scope.
+        $updated = $this->service->remapPostcodes($neighbourhoodId, $neighbourhoodPoly);
+
+        // The neighbourhood should now be in PostgreSQL (synced by polygon scope).
+        $pgNeighbourhood = DB::connection('pgsql')
+            ->selectOne('SELECT locationid FROM locations WHERE locationid = ?', [$neighbourhoodId]);
+        $this->assertNotNull($pgNeighbourhood);
+
+        // The postcode should now be mapped to the neighbourhood (smaller, closer area)
+        // instead of the city.
+        $postcode = DB::table('locations')->where('id', $postcodeId)->first();
+        $this->assertEquals($neighbourhoodId, $postcode->areaid,
+            'Postcode should be remapped to the neighbourhood, not the city');
+
+        // Clean up.
+        DB::connection('pgsql')->statement('DROP TABLE IF EXISTS locations');
+        DB::table('locations_spatial')->whereIn('locationid', [$cityId, $neighbourhoodId, $postcodeId])->delete();
+        DB::table('locations')->whereIn('id', [$cityId, $neighbourhoodId, $postcodeId])->delete();
     }
 
     /**
-     * Test findNearestArea returns null when no area found.
+     * Test that syncLocationsInPolygon updates stale PostgreSQL data.
      */
-    public function test_find_nearest_area_returns_null_when_no_match(): void
+    public function test_polygon_scoped_sync_updates_stale_postgres_data(): void
     {
-        // Ensure schema exists.
-        $this->service->ensurePostgresSchema();
+        try {
+            DB::connection('pgsql')->getPdo();
+        } catch (\Throwable $e) {
+            $this->markTestSkipped('PostgreSQL not available');
+        }
 
-        // Call with a point in the middle of the ocean (no areas nearby).
-        $result = $this->service->findNearestArea(0.0, 0.0);
+        $this->setupPostgresLocationsTable();
+        $srid = (int) config('freegle.srid', 3857);
 
-        $this->assertNull($result);
+        $oldPoly = 'POLYGON((-1.50 53.34, -1.50 53.36, -1.48 53.36, -1.48 53.34, -1.50 53.34))';
+        $newPoly = 'POLYGON((-1.52 53.33, -1.52 53.37, -1.47 53.37, -1.47 53.33, -1.52 53.33))';
+
+        // Create location in MySQL with the NEW polygon.
+        $locId = DB::table('locations')->insertGetId([
+            'name' => 'TestArea',
+            'type' => 'Polygon',
+            'lat' => 53.35,
+            'lng' => -1.50,
+        ]);
+
+        DB::statement(
+            "INSERT INTO locations_spatial (locationid, geometry) VALUES (?, ST_GeomFromText(?, ?))",
+            [$locId, $newPoly, $srid]
+        );
+
+        // Put the OLD polygon in PostgreSQL (simulating stale nightly sync).
+        DB::connection('pgsql')->insert(
+            "INSERT INTO locations (locationid, name, type, area, location)
+             VALUES (?, ?, 'Polygon', ST_Area(ST_GeomFromText(?, ?)), ST_GeomFromText(?, ?))",
+            [$locId, 'TestArea', $oldPoly, $srid, $oldPoly, $srid]
+        );
+
+        // Create a postcode that is inside the new polygon but outside the old one.
+        $postcodeId = DB::table('locations')->insertGetId([
+            'name' => 'ZZ2 2BB',
+            'type' => 'Postcode',
+            'lat' => 53.335,
+            'lng' => -1.51,
+            'areaid' => NULL,
+        ]);
+
+        DB::statement(
+            "INSERT INTO locations_spatial (locationid, geometry) VALUES (?, ST_GeomFromText(?, ?))",
+            [$postcodeId, "POINT(-1.51 53.335)", $srid]
+        );
+
+        // Remap with the new polygon as scope — this should sync the updated geometry.
+        $updated = $this->service->remapPostcodes($locId, $newPoly);
+
+        // The postcode should be mapped to the area now.
+        $postcode = DB::table('locations')->where('id', $postcodeId)->first();
+        $this->assertEquals($locId, $postcode->areaid,
+            'Postcode should be mapped to area after polygon sync updated stale data');
+
+        // Clean up.
+        DB::connection('pgsql')->statement('DROP TABLE IF EXISTS locations');
+        DB::table('locations_spatial')->whereIn('locationid', [$locId, $postcodeId])->delete();
+        DB::table('locations')->whereIn('id', [$locId, $postcodeId])->delete();
     }
 
     /**
-     * Test remapPostcodes processes no postcodes when table is empty.
+     * Regression: when a location is excluded after being synced to PostgreSQL,
+     * the next polygon-scoped remap that covers it must DELETE it from the PG
+     * KNN index — otherwise findNearestArea keeps returning the excluded area
+     * and postcodes never move off it until the nightly full sync rebuilds PG.
      */
-    public function test_remap_postcodes_processes_zero_when_no_postcodes_exist(): void
+    public function test_excluded_location_is_removed_from_postgres_during_polygon_remap(): void
     {
-        // Ensure schema exists.
-        $this->service->ensurePostgresSchema();
+        try {
+            DB::connection('pgsql')->getPdo();
+        } catch (\Throwable $e) {
+            $this->markTestSkipped('PostgreSQL not available');
+        }
 
-        // Call with no postcodes in database.
-        $result = $this->service->remapPostcodes();
+        $this->setupPostgresLocationsTable();
+        $srid = (int) config('freegle.srid', 3857);
 
-        // Should return 0 since no postcodes were found.
-        $this->assertEquals(0, $result);
+        $excludedPoly = 'POLYGON((-1.50 53.34, -1.50 53.36, -1.48 53.36, -1.48 53.34, -1.50 53.34))';
+        $replacementPoly = 'POLYGON((-1.51 53.33, -1.51 53.37, -1.47 53.37, -1.47 53.33, -1.51 53.33))';
+
+        $excludedId = DB::table('locations')->insertGetId([
+            'name' => 'ExcludedArea',
+            'type' => 'Polygon',
+            'lat' => 53.35,
+            'lng' => -1.49,
+        ]);
+
+        $replacementId = DB::table('locations')->insertGetId([
+            'name' => 'ReplacementArea',
+            'type' => 'Polygon',
+            'lat' => 53.35,
+            'lng' => -1.49,
+        ]);
+
+        DB::statement(
+            'INSERT INTO locations_spatial (locationid, geometry) VALUES (?, ST_GeomFromText(?, ?))',
+            [$excludedId, $excludedPoly, $srid]
+        );
+        DB::statement(
+            'INSERT INTO locations_spatial (locationid, geometry) VALUES (?, ST_GeomFromText(?, ?))',
+            [$replacementId, $replacementPoly, $srid]
+        );
+
+        // Postcode sits inside both polygons, currently pointing at the excluded area.
+        $postcodeId = DB::table('locations')->insertGetId([
+            'name' => 'ZZ3 3CC',
+            'type' => 'Postcode',
+            'lat' => 53.35,
+            'lng' => -1.49,
+            'areaid' => $excludedId,
+        ]);
+        DB::statement(
+            'INSERT INTO locations_spatial (locationid, geometry) VALUES (?, ST_GeomFromText(?, ?))',
+            [$postcodeId, 'POINT(-1.49 53.35)', $srid]
+        );
+
+        // Simulate prior sync: both areas are in PG already.
+        foreach ([[$excludedId, 'ExcludedArea', $excludedPoly], [$replacementId, 'ReplacementArea', $replacementPoly]] as [$id, $name, $poly]) {
+            DB::connection('pgsql')->insert(
+                "INSERT INTO locations (locationid, name, type, area, location)
+                 VALUES (?, ?, 'Polygon', ST_Area(ST_GeomFromText(?, ?)), ST_GeomFromText(?, ?))",
+                [$id, $name, $poly, $srid, $poly, $srid]
+            );
+        }
+
+        // Create a real group and user to satisfy FK constraints on locations_excluded.
+        $group = $this->createTestGroup();
+        $user = $this->createTestUser();
+
+        // Now mark the first area as excluded.
+        DB::table('locations_excluded')->insert([
+            'locationid' => $excludedId,
+            'groupid' => $group->id,
+            'userid' => $user->id,
+        ]);
+
+        try {
+            $this->service->remapPostcodes($excludedId, $excludedPoly);
+
+            $stillThere = DB::connection('pgsql')
+                ->selectOne('SELECT locationid FROM locations WHERE locationid = ?', [$excludedId]);
+            $this->assertNull($stillThere, 'Excluded location must be deleted from PG during polygon-scoped remap');
+
+            $postcode = DB::table('locations')->where('id', $postcodeId)->first();
+            $this->assertNotEquals($excludedId, $postcode->areaid, 'Postcode must move off the excluded area');
+        } finally {
+            DB::connection('pgsql')->statement('DROP TABLE IF EXISTS locations');
+            DB::table('locations_excluded')->where('locationid', $excludedId)->delete();
+            DB::table('locations_spatial')->whereIn('locationid', [$excludedId, $replacementId, $postcodeId])->delete();
+            DB::table('locations')->whereIn('id', [$excludedId, $replacementId, $postcodeId])->delete();
+        }
     }
 
     /**
-     * Test remapPostcodes with location scope returns 0 when no postcodes in scope.
+     * Regression: a postcode can carry an areaid assigned via KNN (buffered intersection)
+     * that places it *outside* the area's polygon. When that area is excluded, the
+     * polygon-scoped remap must still reach the postcode via its areaid — otherwise
+     * it stays pointing at the excluded area forever.
      */
-    public function test_remap_postcodes_with_location_scope_returns_zero_when_no_postcodes_match(): void
+    public function test_postcode_pointing_at_excluded_area_is_remapped_even_if_outside_polygon(): void
     {
-        // Ensure schema exists.
-        $this->service->ensurePostgresSchema();
+        try {
+            DB::connection('pgsql')->getPdo();
+        } catch (\Throwable $e) {
+            $this->markTestSkipped('PostgreSQL not available');
+        }
 
-        // Create a test polygon WKT that definitely has no postcodes.
-        $polygon = 'POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))';
+        $this->setupPostgresLocationsTable();
+        $srid = (int) config('freegle.srid', 3857);
 
-        // Call with a polygon scope.
-        $result = $this->service->remapPostcodes(null, $polygon);
+        $excludedPoly = 'POLYGON((-1.50 53.34, -1.50 53.36, -1.48 53.36, -1.48 53.34, -1.50 53.34))';
+        $replacementPoly = 'POLYGON((-1.46 53.30, -1.46 53.40, -1.42 53.40, -1.42 53.30, -1.46 53.30))';
 
-        // Should return 0 since no postcodes match the scope.
-        $this->assertEquals(0, $result);
+        $excludedId = DB::table('locations')->insertGetId([
+            'name' => 'ExcludedArea',
+            'type' => 'Polygon',
+            'lat' => 53.35,
+            'lng' => -1.49,
+        ]);
+
+        $replacementId = DB::table('locations')->insertGetId([
+            'name' => 'ReplacementArea',
+            'type' => 'Polygon',
+            'lat' => 53.35,
+            'lng' => -1.44,
+        ]);
+
+        DB::statement(
+            'INSERT INTO locations_spatial (locationid, geometry) VALUES (?, ST_GeomFromText(?, ?))',
+            [$excludedId, $excludedPoly, $srid]
+        );
+        DB::statement(
+            'INSERT INTO locations_spatial (locationid, geometry) VALUES (?, ST_GeomFromText(?, ?))',
+            [$replacementId, $replacementPoly, $srid]
+        );
+
+        // Postcode sits *outside* the excluded area's polygon (closer to the replacement),
+        // but has areaid pointing at the excluded area — as KNN can do.
+        $postcodeId = DB::table('locations')->insertGetId([
+            'name' => 'ZZ4 4DD',
+            'type' => 'Postcode',
+            'lat' => 53.35,
+            'lng' => -1.44,
+            'areaid' => $excludedId,
+        ]);
+        DB::statement(
+            'INSERT INTO locations_spatial (locationid, geometry) VALUES (?, ST_GeomFromText(?, ?))',
+            [$postcodeId, 'POINT(-1.44 53.35)', $srid]
+        );
+
+        // Create a real group and user to satisfy FK constraints on locations_excluded.
+        $group = $this->createTestGroup();
+        $user = $this->createTestUser();
+
+        DB::table('locations_excluded')->insert([
+            'locationid' => $excludedId,
+            'groupid' => $group->id,
+            'userid' => $user->id,
+        ]);
+
+        // Seed PG with only the replacement area (excluded area is filtered out by sync).
+        DB::connection('pgsql')->insert(
+            "INSERT INTO locations (locationid, name, type, area, location)
+             VALUES (?, ?, 'Polygon', ST_Area(ST_GeomFromText(?, ?)), ST_GeomFromText(?, ?))",
+            [$replacementId, 'ReplacementArea', $replacementPoly, $srid, $replacementPoly, $srid]
+        );
+
+        try {
+            $this->service->remapPostcodes($excludedId, $excludedPoly);
+
+            $postcode = DB::table('locations')->where('id', $postcodeId)->first();
+            $this->assertNotEquals($excludedId, $postcode->areaid,
+                'Postcode outside the excluded polygon but pointing at it via areaid must still be remapped');
+        } finally {
+            DB::connection('pgsql')->statement('DROP TABLE IF EXISTS locations');
+            DB::table('locations_excluded')->where('locationid', $excludedId)->delete();
+            DB::table('locations_spatial')->whereIn('locationid', [$excludedId, $replacementId, $postcodeId])->delete();
+            DB::table('locations')->whereIn('id', [$excludedId, $replacementId, $postcodeId])->delete();
+        }
+    }
+
+    private function setupPostgresLocationsTable(): void
+    {
+        $pgsql = DB::connection('pgsql');
+        $pgsql->statement('CREATE EXTENSION IF NOT EXISTS postgis');
+        $pgsql->statement('CREATE EXTENSION IF NOT EXISTS btree_gist');
+
+        $typeExists = $pgsql->selectOne("SELECT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'location_type')");
+        if (! $typeExists->exists) {
+            $pgsql->statement("CREATE TYPE location_type AS ENUM('Road','Polygon','Line','Point','Postcode')");
+        }
+
+        $pgsql->statement('DROP TABLE IF EXISTS locations');
+        $pgsql->statement('CREATE TABLE locations (
+            id serial PRIMARY KEY,
+            locationid bigint UNIQUE NOT NULL,
+            name text,
+            type location_type,
+            area numeric,
+            location geometry
+        )');
+        $pgsql->statement('CREATE INDEX idx_locations_location ON locations USING gist (location)');
     }
 
     /**

--- a/iznik-batch/tests/Unit/Services/UnifiedDigestServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/UnifiedDigestServiceTest.php
@@ -173,6 +173,87 @@ class UnifiedDigestServiceTest extends TestCase
         $this->assertEquals(0, $stats['emails_sent']);
     }
 
+    public function test_deduplication_same_subject_different_body_not_deduped(): void
+    {
+        $user = $this->createTestUser();
+        $group1 = $this->createTestGroup();
+        $group2 = $this->createTestGroup();
+
+        // Two messages with same subject but different body text.
+        $message1 = $this->createTestMessage($user, $group1, [
+            'subject' => 'OFFER: Garden tools (London)',
+            'textbody' => 'I have a spade and a fork available for collection.',
+        ]);
+        $message2 = $this->createTestMessage($user, $group2, [
+            'subject' => 'OFFER: Garden tools (London)',
+            'textbody' => 'Lawnmower available, needs collecting this weekend.',
+        ]);
+
+        $message1->groupid = $group1->id;
+        $message2->groupid = $group2->id;
+
+        $posts = collect([$message1, $message2]);
+        $deduplicated = $this->service->deduplicatePosts($posts);
+
+        // Should NOT be deduplicated because bodies are different.
+        $this->assertCount(2, $deduplicated);
+    }
+
+    public function test_deduplication_same_subject_same_body_deduped(): void
+    {
+        $user = $this->createTestUser();
+        $group1 = $this->createTestGroup();
+        $group2 = $this->createTestGroup();
+
+        $bodyText = 'I have a lovely sofa available for collection.';
+
+        // Two messages with same subject AND same body.
+        $message1 = $this->createTestMessage($user, $group1, [
+            'subject' => 'OFFER: Sofa (London)',
+            'textbody' => $bodyText,
+        ]);
+        $message2 = $this->createTestMessage($user, $group2, [
+            'subject' => 'OFFER: Sofa (London)',
+            'textbody' => $bodyText,
+        ]);
+
+        $message1->groupid = $group1->id;
+        $message2->groupid = $group2->id;
+
+        $posts = collect([$message1, $message2]);
+        $deduplicated = $this->service->deduplicatePosts($posts);
+
+        // Should be deduplicated because both subject and body match.
+        $this->assertCount(1, $deduplicated);
+        $this->assertCount(2, $deduplicated->first()['postedToGroups']);
+    }
+
+    public function test_deduplication_null_body_treated_as_matching(): void
+    {
+        $user = $this->createTestUser();
+        $group1 = $this->createTestGroup();
+        $group2 = $this->createTestGroup();
+
+        // Two messages with same subject and both null bodies.
+        $message1 = $this->createTestMessage($user, $group1, [
+            'subject' => 'OFFER: Table (London)',
+            'textbody' => null,
+        ]);
+        $message2 = $this->createTestMessage($user, $group2, [
+            'subject' => 'OFFER: Table (London)',
+            'textbody' => null,
+        ]);
+
+        $message1->groupid = $group1->id;
+        $message2->groupid = $group2->id;
+
+        $posts = collect([$message1, $message2]);
+        $deduplicated = $this->service->deduplicatePosts($posts);
+
+        // Should be deduplicated - null bodies both normalize to ''.
+        $this->assertCount(1, $deduplicated);
+    }
+
     public function test_sponsors_are_included_and_deduplicated(): void
     {
         $poster = $this->createTestUser();
@@ -287,43 +368,6 @@ class UnifiedDigestServiceTest extends TestCase
 
         $sponsors = $this->service->getSponsorsForUser($user);
         $this->assertCount(0, $sponsors);
-    }
-
-    public function test_deduplication_with_same_message_on_multiple_groups(): void
-    {
-        // Multi-group model: same messages.id has two messages_groups rows.
-        // The digest query joins messages with messages_groups, so the same message
-        // appears twice with different groupids. deduplicatePosts should merge them.
-        $user = $this->createTestUser();
-        $group1 = $this->createTestGroup();
-        $group2 = $this->createTestGroup();
-
-        $message = $this->createTestMessage($user, $group1, [
-            'subject' => 'OFFER: Multi-Group Item (TestTown)',
-        ]);
-
-        // Add the same message to a second group (simulating the multi-group model).
-        DB::table('messages_groups')->insert([
-            'msgid' => $message->id,
-            'groupid' => $group2->id,
-            'collection' => 'Approved',
-            'arrival' => now(),
-        ]);
-
-        // Simulate what getPostsForUser returns: two rows for the same message
-        // with different groupid attributes (from the join).
-        $row1 = clone $message;
-        $row1->groupid = $group1->id;
-        $row2 = clone $message;
-        $row2->groupid = $group2->id;
-
-        $posts = collect([$row1, $row2]);
-        $deduplicated = $this->service->deduplicatePosts($posts);
-
-        $this->assertCount(1, $deduplicated, 'Same message on two groups should deduplicate to one');
-        $this->assertCount(2, $deduplicated->first()['postedToGroups'], 'Both groups should be in postedToGroups');
-        $this->assertContains($group1->id, $deduplicated->first()['postedToGroups']);
-        $this->assertContains($group2->id, $deduplicated->first()['postedToGroups']);
     }
 
     public function test_immediate_mode_requires_full_setting(): void

--- a/iznik-batch/tests/Unit/Services/UnifiedDigestServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/UnifiedDigestServiceTest.php
@@ -372,6 +372,10 @@ class UnifiedDigestServiceTest extends TestCase
 
     public function test_immediate_mode_requires_full_setting(): void
     {
+        // Open the allowlist so this test only proves the simplemail filter,
+        // not the allowlist gate (which has its own tests below).
+        config(['freegle.digest.immediate_allowlist' => '*']);
+
         $user = $this->createTestUser();
         $group = $this->createTestGroup();
 
@@ -388,5 +392,128 @@ class UnifiedDigestServiceTest extends TestCase
 
         // User should not be processed for immediate mode.
         $this->assertEquals(0, $stats['users_processed']);
+    }
+
+    /**
+     * Empty allowlist means "no restriction" — every simplemail=Full user is
+     * eligible. This is the "fully on" state once we're done piloting.
+     */
+    public function test_immediate_mode_allowlist_empty_allows_everyone(): void
+    {
+        config(['freegle.digest.immediate_allowlist' => '']);
+
+        $user = $this->createTestUser();
+        $user->settings = ['simplemail' => User::SIMPLE_MAIL_FULL];
+        $user->lastaccess = now();
+        $user->save();
+        $user->refresh();
+        $group = $this->createTestGroup();
+        $this->createMembership($user, $group);
+
+        $stats = $this->service->sendDigests(UnifiedDigestService::MODE_IMMEDIATE, $user->id);
+
+        $this->assertEquals(1, $stats['users_processed']);
+    }
+
+    /**
+     * Explicit '*' is equivalent to empty — no restriction.
+     */
+    public function test_immediate_mode_allowlist_wildcard_allows_everyone(): void
+    {
+        config(['freegle.digest.immediate_allowlist' => '*']);
+
+        $user = $this->createTestUser();
+        $user->settings = ['simplemail' => User::SIMPLE_MAIL_FULL];
+        $user->lastaccess = now();
+        $user->save();
+        $user->refresh();
+        $group = $this->createTestGroup();
+        $this->createMembership($user, $group);
+
+        $stats = $this->service->sendDigests(UnifiedDigestService::MODE_IMMEDIATE, $user->id);
+
+        $this->assertEquals(1, $stats['users_processed']);
+    }
+
+    /**
+     * Specific allowlist entries let only matching addresses through. This is
+     * the pilot mode — one or two test recipients while we validate end-to-end
+     * before clearing the env var to flip immediate emails on for everyone.
+     */
+    public function test_immediate_mode_allowlist_filters_to_specified_addresses(): void
+    {
+        $allowed = $this->createTestUser();
+        $allowed->settings = ['simplemail' => User::SIMPLE_MAIL_FULL];
+        $allowed->lastaccess = now();
+        $allowed->save();
+        $allowed->refresh();
+        $group = $this->createTestGroup();
+        $this->createMembership($allowed, $group);
+
+        $blocked = $this->createTestUser();
+        $blocked->settings = ['simplemail' => User::SIMPLE_MAIL_FULL];
+        $blocked->lastaccess = now();
+        $blocked->save();
+        $blocked->refresh();
+        $this->createMembership($blocked, $group);
+
+        // Pick the allowed user's preferred email and use it as the allowlist.
+        $allowedEmail = $allowed->emails()->first()->email;
+        config(['freegle.digest.immediate_allowlist' => $allowedEmail]);
+
+        // Allowed user is processed.
+        $statsAllowed = $this->service->sendDigests(UnifiedDigestService::MODE_IMMEDIATE, $allowed->id);
+        $this->assertEquals(1, $statsAllowed['users_processed']);
+
+        // Other user with same Full setting is filtered out.
+        $statsBlocked = $this->service->sendDigests(UnifiedDigestService::MODE_IMMEDIATE, $blocked->id);
+        $this->assertEquals(0, $statsBlocked['users_processed']);
+    }
+
+    /**
+     * The default value checked into config (a single pilot email) must
+     * restrict immediate emails to that address — otherwise deploying the
+     * cron in prod without a custom env var would email everyone.
+     */
+    public function test_immediate_mode_uses_pinned_pilot_default(): void
+    {
+        // Don't override — use whatever's baked into config/freegle.php.
+        $pilot = config('freegle.digest.immediate_allowlist');
+        $this->assertNotEquals('', $pilot, 'Pinned default must not be empty');
+        $this->assertNotEquals('*', $pilot, 'Pinned default must not be wildcard');
+
+        $blocked = $this->createTestUser();
+        $blocked->settings = ['simplemail' => User::SIMPLE_MAIL_FULL];
+        $blocked->lastaccess = now();
+        $blocked->save();
+        $blocked->refresh();
+        $group = $this->createTestGroup();
+        $this->createMembership($blocked, $group);
+
+        // User's email is not the pilot address → must be skipped.
+        $stats = $this->service->sendDigests(UnifiedDigestService::MODE_IMMEDIATE, $blocked->id);
+        $this->assertEquals(0, $stats['users_processed']);
+    }
+
+    /**
+     * Allowlist must not affect daily mode — that's a separate, already-running
+     * flow that we don't want to gate behind this setting.
+     */
+    public function test_immediate_allowlist_does_not_affect_daily_mode(): void
+    {
+        // Pin to an address that nobody in this test has, then run daily.
+        config(['freegle.digest.immediate_allowlist' => 'nobody-test@example.invalid']);
+
+        $user = $this->createTestUser();
+        $user->settings = ['simplemail' => User::SIMPLE_MAIL_BASIC];
+        $user->lastaccess = now();
+        $user->save();
+        $user->refresh();
+        $group = $this->createTestGroup();
+        $this->createMembership($user, $group);
+
+        $stats = $this->service->sendDigests(UnifiedDigestService::MODE_DAILY, $user->id);
+
+        $this->assertEquals(1, $stats['users_processed']);
     }
 }

--- a/iznik-batch/tests/Unit/Traits/LogsBatchJobTest.php
+++ b/iznik-batch/tests/Unit/Traits/LogsBatchJobTest.php
@@ -99,10 +99,10 @@ class LogsBatchJobTest extends TestCase
     public function test_extracts_job_name_from_signature(): void
     {
         $this->lokiMock->shouldReceive('logBatchJob')
-            ->with('mail:digest', 'started', Mockery::any());
+            ->with('mail:digest:unified', 'started', Mockery::any());
 
         $this->lokiMock->shouldReceive('logBatchJob')
-            ->with('mail:digest', 'completed', Mockery::any());
+            ->with('mail:digest:unified', 'completed', Mockery::any());
 
         $command = new TestCommandWithComplexSignature();
         $command->setLaravel($this->app);
@@ -171,9 +171,9 @@ class TestCommandWithComplexSignature extends Command
 {
     use LogsBatchJob;
 
-    protected $signature = 'mail:digest
-                            {frequency : Digest frequency}
-                            {--mod=1 : Modulo divisor}';
+    protected $signature = 'mail:digest:unified
+                            {--mode=daily : Digest mode}
+                            {--limit=1000 : Max users}';
 
     public function handle(): int
     {

--- a/iznik-nuxt3/tests/e2e/fixtures.js
+++ b/iznik-nuxt3/tests/e2e/fixtures.js
@@ -298,7 +298,6 @@ const test = base.test.extend({
       /Failed to load resource: net::ERR_ABORTED/, // Can happen during page navigation when requests are cancelled
       /Failed to load resource: net::ERR_CONNECTION_REFUSED/, // Can happen when server is starting up
       /Failed to load resource: net::ERR_NAME_NOT_RESOLVED/, // External CDNs (Facebook, Google, etc.) not DNS-resolvable in isolated Docker test environment
-      /Failed to load resource: net::ERR_ADDRESS_UNREACHABLE.*dns\.google/, // dns.google DoH used by EmailValidator for best-effort domain validation; unreachable in some CI Docker environments (JS catch block already suppresses the error)
       /has been blocked by CORS policy/, // CORS errors can happen in test environments due to ads
       /Failed to save credentials NotSupportedError: The user agent does not support public key credentials./, // Can happen in test environments
       /Refused to frame/, // Can happen in test.

--- a/iznik-nuxt3/tests/e2e/test-modtools-chat-list.spec.js
+++ b/iznik-nuxt3/tests/e2e/test-modtools-chat-list.spec.js
@@ -94,6 +94,21 @@ test.describe('ModTools Chat List', () => {
         if (!e.message.includes('ERR_ABORTED')) throw e
       })
 
+    // Wait for the URL to settle on /chats
+    await page
+      .waitForURL(`${MODTOOLS_URL}/chats**`, {
+        timeout: timeouts.navigation.slowPage,
+      })
+      .catch(() => {})
+
+    // Wait for the loading spinner to disappear — this confirms that the onMounted
+    // API call to /chat/rooms has completed (either successfully or with an error
+    // that was handled). Checking for errors before this point is a race condition.
+    await page
+      .locator('span.pulsate')
+      .waitFor({ state: 'hidden', timeout: timeouts.ui.appearance })
+      .catch(() => {})
+
     await dismissAllModals(page)
 
     // Wait for chat list items to appear

--- a/iznik-nuxt3/tests/unit/components/MicroVolunteeringAIImageReview.spec.js
+++ b/iznik-nuxt3/tests/unit/components/MicroVolunteeringAIImageReview.spec.js
@@ -352,12 +352,13 @@ describe('MicroVolunteeringAIImageReview', () => {
       await prevBtn.trigger('click')
       expect(wrapper.find('.review-image').attributes('src')).toBe(urlInitial)
 
-      // Next button should now appear since there is a newer image ahead
+      // Next button should now be enabled since there is a newer image ahead
       const nextBtn = wrapper
         .findAll('button')
         .find((b) => /^next$/i.test(b.text()))
       expect(nextBtn).toBeDefined()
       expect(nextBtn.exists()).toBe(true)
+      expect(nextBtn.attributes('disabled')).toBeUndefined()
 
       // clicking Next should advance back to urlA
       await nextBtn.trigger('click')

--- a/iznik-server-go/amp/amp.go
+++ b/iznik-server-go/amp/amp.go
@@ -25,9 +25,11 @@ import (
 
 	"github.com/freegle/iznik-server-go/chat"
 	"github.com/freegle/iznik-server-go/database"
-	"github.com/freegle/iznik-server-go/utils"
+	"github.com/freegle/iznik-server-go/message"
 	"github.com/freegle/iznik-server-go/misc"
+	"github.com/freegle/iznik-server-go/utils"
 	"github.com/gofiber/fiber/v2"
+	"gorm.io/gorm"
 )
 
 // AMPChatMessage extends ChatMessageQuery with AMP-specific display fields.
@@ -64,6 +66,26 @@ func getAMPSecret() string {
 		log.Printf("[AMP] WARNING: No AMP secret configured (checked AMP_SECRET and FREEGLE_AMP_SECRET)")
 	}
 	return secret
+}
+
+// recordAmpReplyTracking marks an email_tracking row as replied via AMP and
+// inserts a click record. No-op when the tracking ID is absent (older
+// emails sent before email_tracking was wired up). Kept as a small helper
+// so PostChatReply and PostDigestReply share the same write pattern
+// instead of duplicating two raw statements.
+func recordAmpReplyTracking(db *gorm.DB, emailTrackingID *uint64, linkURL, linkPosition string) {
+	if emailTrackingID == nil {
+		return
+	}
+	db.Exec(
+		"UPDATE email_tracking SET replied_at = NOW(), replied_via = 'amp' WHERE id = ?",
+		*emailTrackingID,
+	)
+	db.Exec(
+		"INSERT INTO email_tracking_clicks (email_tracking_id, link_url, link_position, action, clicked_at) "+
+			"VALUES (?, ?, ?, 'amp_reply', NOW())",
+		*emailTrackingID, linkURL, linkPosition,
+	)
 }
 
 // computeHMAC generates an HMAC-SHA256 signature.
@@ -463,22 +485,7 @@ func PostChatReply(c *fiber.Ctx) error {
 	// Update chat room latest message time
 	db.Exec(`UPDATE chat_rooms SET latestmessage = NOW() WHERE id = ?`, chatID)
 
-	// Track the AMP reply if we have an email tracking ID
-	if emailTrackingID != nil {
-		// Record that this email resulted in an AMP reply
-		db.Exec(`
-			UPDATE email_tracking
-			SET replied_at = NOW(),
-			    replied_via = 'amp'
-			WHERE id = ?
-		`, *emailTrackingID)
-
-		// Also insert a tracking click record for analytics
-		db.Exec(`
-			INSERT INTO email_tracking_clicks (email_tracking_id, link_url, link_position, action, clicked_at)
-			VALUES (?, 'amp://reply', 'amp_reply_form', 'amp_reply', NOW())
-		`, *emailTrackingID)
-	}
+	recordAmpReplyTracking(db, emailTrackingID, "amp://reply", "amp_reply_form")
 
 	// Log to Loki for dashboard analytics
 	misc.GetLoki().LogChatReply("amp", chatID, userID, &messageID, emailTrackingID)
@@ -486,5 +493,128 @@ func PostChatReply(c *fiber.Ctx) error {
 	return c.JSON(ReplyResponse{
 		Success: true,
 		Message: "Message sent!",
+	})
+}
+
+// PostDigestReply handles AMP form submissions from immediate-digest emails.
+// The resource ID is a message ID (the post the user is replying to). We
+// validate the HMAC token against that message ID, look up the post's owner,
+// find-or-create a User2User chat between the replier and the post owner,
+// and insert the reply as a chat message — mirroring what the website "Reply"
+// button does for the same post.
+//
+// @Summary Post reply from AMP digest email
+// @Description Submits an inline reply to a digest-email post (one-time token)
+// @Tags AMP
+// @Accept json
+// @Produce json
+// @Param id path int true "Message ID (the post being replied to)"
+// @Param rt query string true "Token (HMAC)"
+// @Param uid query int true "User ID"
+// @Param exp query int true "Token expiry timestamp"
+// @Param tid query int false "Email tracking ID for analytics"
+// @Param body body object true "Message body with 'message' field"
+// @Success 200 {object} ReplyResponse
+// @Failure 400 {object} ReplyResponse
+// @Router /amp/digest/{id}/reply [post]
+func PostDigestReply(c *fiber.Ctx) error {
+	userID, messageID, err := ValidateToken(c)
+	if err != nil || userID == 0 || messageID == 0 {
+		return c.Status(fiber.StatusBadRequest).JSON(ReplyResponse{
+			Success: false,
+			Message: "Invalid token",
+		})
+	}
+
+	var emailTrackingID *uint64
+	if tidStr := c.Query("tid"); tidStr != "" {
+		if tid, err := strconv.ParseUint(tidStr, 10, 64); err == nil {
+			emailTrackingID = &tid
+		}
+	}
+
+	var body struct {
+		Message string `json:"message"`
+	}
+	if err := c.BodyParser(&body); err != nil || strings.TrimSpace(body.Message) == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(ReplyResponse{
+			Success: false,
+			Message: "Please enter a message.",
+		})
+	}
+
+	replyText := strings.TrimSpace(body.Message)
+	if len(replyText) > 10000 {
+		return c.Status(fiber.StatusBadRequest).JSON(ReplyResponse{
+			Success: false,
+			Message: "Message is too long. Please keep it under 10,000 characters.",
+		})
+	}
+
+	db := database.DBConn
+
+	// Look up the post owner using the Message model so we benefit from
+	// any hooks/scopes the model defines, and reject deleted/orphan posts.
+	var post message.Message
+	if err := db.Select("id", "fromuser").
+		Where("id = ? AND deleted IS NULL", messageID).
+		First(&post).Error; err != nil || post.Fromuser == 0 {
+		return c.Status(fiber.StatusBadRequest).JSON(ReplyResponse{
+			Success: false,
+			Message: "This post is no longer available.",
+		})
+	}
+	fromUser := post.Fromuser
+
+	if fromUser == userID {
+		return c.Status(fiber.StatusBadRequest).JSON(ReplyResponse{
+			Success: false,
+			Message: "You can't reply to your own post.",
+		})
+	}
+
+	// Find-or-create the User2User chat via the shared helper so this
+	// handler doesn't duplicate the (user1,user2) ordering logic.
+	chatID, err := chat.GetOrCreateUser2UserChat(db, userID, fromUser)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(ReplyResponse{
+			Success: false,
+			Message: "Failed to send reply. Please try on Freegle.",
+		})
+	}
+
+	// Insert the chat message via GORM so the create goes through the
+	// model the rest of the API uses. Type=Interested + refmsgid links
+	// the reply back to the originating post, matching what the website
+	// "Reply" button on a post does (see chat.CreateChatMessage).
+	refmsgid := messageID
+	chatMsg := chat.ChatMessage{
+		Chatid:             chatID,
+		Userid:             userID,
+		Type:               utils.CHAT_MESSAGE_INTERESTED,
+		Refmsgid:           &refmsgid,
+		Message:            replyText,
+		Date:               time.Now(),
+		Processingrequired: true,
+	}
+	if err := db.Create(&chatMsg).Error; err != nil || chatMsg.ID == 0 {
+		return c.Status(fiber.StatusInternalServerError).JSON(ReplyResponse{
+			Success: false,
+			Message: "Failed to send reply. Please try on Freegle.",
+		})
+	}
+	chatMessageID := chatMsg.ID
+
+	// ChatRoom struct doesn't model the latestmessage column (it's not
+	// returned in normal reads), so touch it with a small raw UPDATE.
+	db.Exec("UPDATE chat_rooms SET latestmessage = NOW() WHERE id = ?", chatID)
+
+	recordAmpReplyTracking(db, emailTrackingID, "amp://digest-reply", "amp_digest_reply_form")
+
+	misc.GetLoki().LogChatReply("amp_digest", chatID, userID, &chatMessageID, emailTrackingID)
+
+	return c.JSON(ReplyResponse{
+		Success: true,
+		Message: "Reply sent! The poster will get your message.",
 	})
 }

--- a/iznik-server-go/chat/chatroom.go
+++ b/iznik-server-go/chat/chatroom.go
@@ -553,6 +553,55 @@ func GetOrCreateUser2ModChat(db *gorm.DB, userID uint64, groupID uint64) (uint64
 	return chatID, nil
 }
 
+// GetOrCreateUser2UserChat finds or creates a User2User chat room between
+// two users (either ordering). The unique key (user1, user2, chattype)
+// makes INSERT ... ON DUPLICATE KEY UPDATE safe under concurrent requests:
+// LAST_INSERT_ID(id) returns the existing row's ID on conflict so two
+// callers always collapse to the same chat. Roster rows for both
+// participants are seeded so notifications reach everyone.
+func GetOrCreateUser2UserChat(db *gorm.DB, userA, userB uint64) (uint64, error) {
+	if userA == 0 || userB == 0 || userA == userB {
+		return 0, fmt.Errorf("invalid user pair: %d, %d", userA, userB)
+	}
+
+	// Check for existing chat first to avoid an INSERT roundtrip in the
+	// hot path where the chat already exists.
+	var chatID uint64
+	db.Raw(`SELECT id FROM chat_rooms
+		WHERE ((user1 = ? AND user2 = ?) OR (user1 = ? AND user2 = ?))
+		AND chattype = ?
+		LIMIT 1`,
+		userA, userB, userB, userA, utils.CHAT_TYPE_USER2USER).Scan(&chatID)
+
+	if chatID == 0 {
+		sqlDB, err := db.DB()
+		if err != nil {
+			return 0, fmt.Errorf("failed to get sql.DB: %w", err)
+		}
+		now := time.Now()
+		sqlResult, err := sqlDB.Exec(
+			`INSERT INTO chat_rooms (user1, user2, chattype, latestmessage) VALUES (?, ?, ?, ?)
+			 ON DUPLICATE KEY UPDATE id = LAST_INSERT_ID(id), latestmessage = VALUES(latestmessage)`,
+			userA, userB, utils.CHAT_TYPE_USER2USER, now)
+		if err != nil {
+			return 0, fmt.Errorf("failed to insert chat room: %w", err)
+		}
+		lastID, err := sqlResult.LastInsertId()
+		if err != nil || lastID == 0 {
+			return 0, fmt.Errorf("failed to get last insert id: %w", err)
+		}
+		chatID = uint64(lastID)
+	}
+
+	// Seed roster entries for both participants so notifications fire.
+	db.Exec(`INSERT IGNORE INTO chat_roster (chatid, userid, status, date) VALUES (?, ?, ?, NOW())`,
+		chatID, userA, utils.CHAT_STATUS_ONLINE)
+	db.Exec(`INSERT IGNORE INTO chat_roster (chatid, userid, status, date) VALUES (?, ?, ?, NOW())`,
+		chatID, userB, utils.CHAT_STATUS_ONLINE)
+
+	return chatID, nil
+}
+
 // =============================================================================
 // POST handler (roster updates, nudge, typing, actions)
 // =============================================================================

--- a/iznik-server-go/router/routes.go
+++ b/iznik-server-go/router/routes.go
@@ -1756,4 +1756,20 @@ func SetupRoutes(app *fiber.App) {
 	// @Param body body object true "Message body with 'message' field"
 	// @Success 200 {object} amp.ReplyResponse
 	ampGroup.Post("/chat/:id/reply", amp.PostChatReply)
+
+	// Post reply to a digest-email post (immediate-mode UnifiedDigest)
+	// @Router /amp/digest/{id}/reply [post]
+	// @Summary Post reply to digest email post
+	// @Description Submits an inline reply to a post from an immediate-digest email; opens/finds a chat with the poster
+	// @Tags AMP
+	// @Accept json
+	// @Produce json
+	// @Param id path int true "Message ID (the post being replied to)"
+	// @Param rt query string true "Token (HMAC)"
+	// @Param uid query int true "User ID"
+	// @Param exp query int true "Token expiry timestamp"
+	// @Param tid query int false "Email tracking ID for analytics"
+	// @Param body body object true "Message body with 'message' field"
+	// @Success 200 {object} amp.ReplyResponse
+	ampGroup.Post("/digest/:id/reply", amp.PostDigestReply)
 }

--- a/plans/active/v1-to-v2-api-migration.md
+++ b/plans/active/v1-to-v2-api-migration.md
@@ -387,7 +387,7 @@ These v1 endpoints appear unused. Verify before removing.
 | Endpoint | Notes |
 |----------|-------|
 | bulkop.php | No API wrapper or direct calls. Check batch jobs. |
-| changes.php | No API wrapper. May be used by external integrations. |
+| changes.php | ✅ MIGRATED to V2 Go (5902b87). Partner key auth. CI GREEN on master. |
 | error.php | Logging utility. Check if still receives requests. |
 | export.php | May be used via direct browser access. |
 | item.php | Items are accessed via message endpoint. |

--- a/plans/future/Rippling Out.md
+++ b/plans/future/Rippling Out.md
@@ -94,9 +94,9 @@ Instead of one fixed notification area, we **expand in stages**:
    - We reach maximum size (e.g., 60-minute drive), OR
    - Too much time has passed (e.g., 3 days)
 
-5. **Skip nighttime**: Only expand during active hours (e.g., 8am-8pm)
-   - People don't respond to notifications at 3am
-   - Avoid waking people up
+5. **Skip low-activity hours**: Only expand during active hours (e.g., 6am-11pm)
+   - Activity is very low before 6am; otherwise no significant overnight cliff
+   - Empirical active window is wider than the old 8am–8pm assumption
 
 ### Key Algorithm Parameters
 
@@ -112,15 +112,33 @@ The algorithm is controlled by several parameters:
 | `transport` | Travel mode for isochrones | "car" |
 | `activeSince` | Only notify users active in last N days | 90 days |
 
-**Temporal expansion curve** (when to expand):
-- 0-12 hours: Expand every 4 hours
-- 12-24 hours: Expand every 6 hours
-- 24-72 hours: Expand every 8 hours
+**Temporal expansion curve** (when to expand) — *empirically derived, May 2026*:
+
+The reply hazard rate (probability a still-unreplied message gets a reply that hour) drops
+steeply in the first six hours then goes flat. Data from 303,491 production messages:
+
+| Hour | Hazard rate |
+|------|------------|
+| h0   | 7.84%      |
+| h1   | 3.73%      |
+| h2   | 2.56%      |
+| h3   | 1.96%      |
+| h4   | 1.53%      |
+| h5   | 1.26%      |
+| h6   | 1.03%      |
+| h8+  | ~0.6–0.7% (flat) |
+
+**Recommended expansion schedule** (tracks the hazard shape):
+- Expand at h1, h3, h6 — captures the fast-decay phase
+- Then h12, h24, h48 — flat regime; exact interval matters less here
+
+Note: the previously assumed 4/6/8h curve had no empirical basis. There is no detectable
+breakpoint at 12h or 24h; the decay is smooth from h0 to h8 then uniformly flat.
 
 **Active hours**: Only expand during hours when people respond:
-- Computed from historical data
-- Typically 8am-8pm on weekdays
-- May vary by day of week
+- **Empirical finding (May 2026)**: 6am–11pm, same weekday and weekend
+- No significant weekday-vs-weekend difference in the hourly hazard curve
+- The "8am–8pm weekdays only" assumption is not supported by production data
 
 ### Why This Works
 
@@ -211,7 +229,38 @@ We store simulation data in MySQL tables:
 
 ### Metrics Output
 
-Results will be populated as we complete the analysis.
+#### Empirical Analysis Results (spiralling_analysis.php, May 2026)
+
+Run against **303,491 messages** over the 6 months to May 2026 (production database).
+Script: `iznik-server/scripts/cron/spiralling_analysis.php`
+
+**Silence rate:**
+- 62.4% of messages receive no reply at all
+- 72.9% receive no reply within 1 day
+- 66.1% receive no reply within 7 days
+
+**First-replier spatial reach (crow-flies, n=105,371):**
+
+| Percentile | Distance |
+|-----------|---------|
+| p50       | 5.8 km  |
+| p75       | 11.5 km |
+| p90       | 19.6 km |
+| p95       | 27.2 km |
+
+⚠️ **Straight-line distances only.** Road distance is ~1.3–1.5× longer.
+The p90 road distance is ~25–30 km ≈ 30–35 min drive.
+
+**Location-defaulting bias: investigated and not present.** Users without a real location
+have `lastlocation = NULL`; the INNER JOIN on `locations` already excludes them. No
+Freegle groups have `groups.defaultlocation` set (checked May 2026: 0/506 groups), so
+there is no artificial cluster at a group-centre distance. The figures above are clean.
+
+**Wall-clock median time to first reply:** 7.6h (weekday), 6.7h (weekend)
+These are inflated by overnight waits — a message posted at 10pm and replied to at 6am
+counts as 8 hours elapsed despite only 1–2 active waking hours having passed.
+
+**Taker distance:** Not measurable — `messages_outcomes` has no userid column.
 
 ### Simulation Scripts
 
@@ -569,12 +618,9 @@ const DEFAULT_ISOCHRONE_PARAMS = [
     'numReplies' => 7,
     'transport' => 'car',
 
-    // Temporal expansion curve
-    'breakpoint1' => 12,  // hours
-    'breakpoint2' => 24,  // hours
-    'interval1' => 4,     // hours
-    'interval2' => 6,     // hours
-    'interval3' => 8      // hours
+    // Temporal expansion schedule (empirically derived May 2026)
+    // Hazard curve: fast decay h0-h6, then flat from h8+
+    'expansionHours' => [1, 3, 6, 12, 24, 48],
 ];
 ```
 
@@ -607,37 +653,34 @@ private static function loadGroupClusters() {
 
 // Define cluster-specific parameters
 private static $clusterParams = [
+    // Temporal schedule is the same for all clusters (empirically no cluster variation found yet)
     0 => [ // Urban dense
         'initialMinutes' => 5,
         'maxMinutes' => 60,
         'increment' => 5,
         'minUsers' => 150,
-        'breakpoint1' => 8,
-        'breakpoint2' => 18,
+        'expansionHours' => [1, 3, 6, 12, 24, 48],
     ],
     1 => [ // Suburban
         'initialMinutes' => 8,
         'maxMinutes' => 90,
         'increment' => 5,
         'minUsers' => 120,
-        'breakpoint1' => 12,
-        'breakpoint2' => 24,
+        'expansionHours' => [1, 3, 6, 12, 24, 48],
     ],
     2 => [ // Rural large
         'initialMinutes' => 12,
         'maxMinutes' => 120,
         'increment' => 8,
         'minUsers' => 80,
-        'breakpoint1' => 12,
-        'breakpoint2' => 30,
+        'expansionHours' => [1, 3, 6, 12, 24, 48],
     ],
     3 => [ // Rural small
         'initialMinutes' => 10,
         'maxMinutes' => 100,
         'increment' => 6,
         'minUsers' => 100,
-        'breakpoint1' => 10,
-        'breakpoint2' => 24,
+        'expansionHours' => [1, 3, 6, 12, 24, 48],
     ]
 ];
 
@@ -804,16 +847,168 @@ For each expansion:
    - Have been active in last 90 days
    - Have not been notified already for this message
    - Have notification preferences enabled
-3. Send notifications
-4. Record who was notified and when
+3. **Handle unknown-location users** (see below)
+4. Send notifications
+5. Record who was notified and when
+
+#### Handling Members Without a Real Location
+
+Members who haven't set a location have `lastlocation = NULL` and never match the
+isochrone query. They cannot simply be included at the group centre, because that creates
+an artificial notification cliff when the isochrone grows to reach the centre — all
+location-unknowns pop in at once regardless of where they actually live.
+
+**Recommended approach: density-proportional distribution**
+
+At each expansion step, include unknown-location members in proportion to the fraction of
+*known*-location members newly captured:
+
+```
+newly_notified_knowns   = count of known-location members inside the new isochrone
+                          but not the previous one
+total_known_members     = all active known-location members of this group
+total_unknown_members   = all active null-location members of this group (not yet notified)
+
+unknowns_to_notify_now  = round(total_unknown_remaining × (newly_notified_knowns / total_known_members))
+```
+
+Pick `unknowns_to_notify_now` at random (without replacement) from the unnotified unknown pool.
+
+**Why this works:** it assumes unknown-location members are spatially distributed like
+the known members — which is the best available prior. It distributes them smoothly
+across expansion steps with no artificial cliffs. It is unbiased: by the time the
+isochrone reaches maximum size, all unknowns will have been included if all knowns were.
+
+**Edge case:** if `total_known_members = 0` (group with no located members), fall back
+to distributing unknowns evenly across all expansion steps.
 
 ### Stopping Conditions
 
 Algorithm stops when ANY of these conditions is met:
 - Got enough responses (e.g., 7 interested users)
-- Reached maximum isochrone size (e.g., 60 minutes)
-- Reached maximum time (e.g., 72 active hours)
+- Reached maximum isochrone size (e.g., group-boundary ceiling or 60-minute drive)
+- All expansion steps exhausted (h1, h3, h6, h12, h24, h48, h72, h120, h168) — item stays
+  visible in browse/search but no further proactive notification expansion is sent
 - Message was withdrawn/taken
+- *(Optional)* Isochrone has crossed into an adjacent group boundary — see §Max Distance below
+
+Note: "maximum time" is not a hard expiry of the post; it means no further *expansion* steps
+are scheduled. The item remains discoverable for as long as the group keeps it active (30+ days
+in normal operation). The 48h figure from the hazard curve marks where expansion increments
+become small; h72–h168 steps are added for very hard-to-rehome items in sparse areas.
+
+### Max Distance and the Swamping Problem
+
+**Why a fixed `maxMinutes` is geographically inconsistent**
+
+A 60-minute drive covers ~25 km in central London but ~100 km in rural Northumberland. Travel
+time is still the right unit (it answers "would a reasonable person collect this?"), but the
+implication for cross-group reach varies enormously by location.
+
+**The swamping risk**
+
+If every low-desirability item automatically expands to a 1-hour radius, adjacent groups see a
+flood of rippled-in posts that originated elsewhere, diluting their own members' locally-posted
+items. The risk is proportional to:
+- The originating group's volume of undesirable/unloved offers (the long tail)
+- The target group's own active feed size (smaller/quieter groups are hit hardest)
+
+**Three-layer mitigation**
+
+1. **Neighbour-consent ceiling (primary)**: Stop expansion the moment the isochrone first
+   touches an adjacent group's boundary. This is a hard cap that prevents any cross-posting
+   without explicit consent. A per-group "allow cross-posting to neighbours" setting can
+   unlock it, but the safe default is no cross-posting.
+
+   The routing demo's cross-posting marker (⚡ on the timeline) shows empirically how long
+   it takes for a typical location to reach the nearest group boundary — useful for setting
+   expectations.
+
+2. **Local-interest gate on cross-posting (secondary)**: Only allow the isochrone to cross
+   a group boundary if the item has received at least one reply (showing local interest exists
+   but hasn't been fulfilled yet). Items with zero replies after h6 do not cross-post; they
+   simply exhaust within the home group.
+
+3. **Per-group inbound budget (display filter)**: Each group caps the number of rippled-in
+   items shown per day (e.g. no more than 20% of total visible items). This is a rendering
+   filter, not a notification one — it prevents feed dilution even if cross-posting is enabled.
+
+**Recommended default for launch**: neighbour-consent ceiling enabled (no cross-posting by
+default), local-interest gate enabled. Deploy the traffic-adaptive inbound budget (below) once
+cross-posting is enabled for any groups, so that low-traffic groups benefit rather than suffer.
+
+### Traffic-Adaptive Inbound Budget
+
+Preferred mitigation for the swamping problem. Instead of a global cap, each group's capacity
+to absorb rippled-in items scales inversely with its own traffic — quiet groups *benefit* from
+cross-posting while busy groups are protected.
+
+**Formula:**
+
+```
+activity_ratio = group_messages_per_week / national_median_messages_per_week
+
+max_cross_posts_per_day = round(
+    base_quota + (max_quota - base_quota) * max(0, 1 - activity_ratio)
+)
+```
+
+Suggested starting values (tune after measuring):
+| Parameter | Value | Notes |
+|-----------|-------|-------|
+| `base_quota` | 5 | min cross-posts/day even for very busy groups |
+| `max_quota` | 30 | max for groups with zero own traffic |
+| `national_median` | ~13 messages/week | from empirical data (May 2026) |
+
+Example behaviour:
+- Group with 0 posts/week → 30 cross-posts/day allowed
+- Group with 13 posts/week (median) → ~17/day
+- Group with 50 posts/week (busy) → ~7/day
+- Group with 100+ posts/week → ≈ base_quota (5/day)
+
+This is a *display* filter applied when rendering the group's browse page and digests — it
+limits how many rippled-in items a group's members see, not how many notifications are sent.
+Notifications respect the sender's home-group ripple schedule; display filtering is a
+receiver-side concern.
+
+### Minimum-Freegler Expansion Threshold
+
+Expansion speed should not be purely time-based; it should also respond to how many active
+Freeglers have been reached. In sparse areas, the first expansion step at h1 might only cover
+5 Freeglers — not enough to generate a meaningful reply probability.
+
+**Design principle**: each expansion step should add at least `minNewFreeglers` active members.
+If the next step in the time schedule hasn't reached that count, continue expanding travel time
+(up to the group-boundary ceiling) until it has.
+
+**How to choose `minNewFreeglers`:**
+
+From the empirical hazard data, the reply probability per notified person per hour at h1 is
+≈ 3.73%. To have a ≥50% chance of at least one reply within the h1–h3 window:
+```
+1 - (1 - 0.0373)^N ≥ 0.5   →   N ≥ ln(0.5) / ln(0.9627) ≈ 18 people
+```
+
+For a ≥90% chance:
+```
+N ≥ ln(0.1) / ln(0.9627) ≈ 61 people
+```
+
+**Recommended threshold**: `minNewFreeglers = 50`. This gives ~85% chance of at least one
+reply per expansion window in the fast-decay phase (h0-h6), and is realistic even in
+moderately sparse rural groups.
+
+**Implementation**: before applying the time-schedule expansion step, check if
+`countFreeglersInNewRing ≥ minNewFreeglers`. If not, expand travel time by one step and
+retry (up to the ceiling). If the ceiling is reached before the threshold is met, expand
+anyway and log for monitoring.
+
+**What the demo now shows**
+
+The `/demo` page at port 8196 now draws home-group and adjacent-group boundaries on the map.
+During the ripple animation the ⚡ marker on the 48-hour timeline fires the first frame the
+standard isochrone crosses any adjacent boundary, giving a visual read of "this item would
+start cross-posting at ~Xh" for any clicked location in the UK.
 
 ## Frequently Asked Questions
 
@@ -833,7 +1028,10 @@ A: Yes - the algorithm expands further in sparse areas. Simulation validates thi
 A: Currently using car isochrones as most items require car collection. Could add cycling for small items in future.
 
 **Q: How do we handle cross-posted messages?**
-A: Each group has independent isochrone expansion. If posted to multiple groups, algorithm runs separately for each.
+A: Each group has independent isochrone expansion. By default the isochrone stops when it
+first touches an adjacent group's boundary (neighbour-consent ceiling), so items stay within
+their home group unless cross-posting is explicitly enabled. If a message is posted to
+multiple groups, the algorithm runs independently for each.
 
 **Q: Can users opt out?**
 A: Yes, all existing notification preferences are respected. This only changes WHO and WHEN, not whether they're enrolled.

--- a/plans/future/Rippling Out.md
+++ b/plans/future/Rippling Out.md
@@ -897,79 +897,42 @@ are scheduled. The item remains discoverable for as long as the group keeps it a
 in normal operation). The 48h figure from the hazard curve marks where expansion increments
 become small; h72–h168 steps are added for very hard-to-rehome items in sparse areas.
 
-### Max Distance and the Swamping Problem
+### Max Distance
 
 **Why a fixed `maxMinutes` is geographically inconsistent**
 
 A 60-minute drive covers ~25 km in central London but ~100 km in rural Northumberland. Travel
 time is still the right unit (it answers "would a reasonable person collect this?"), but the
-implication for cross-group reach varies enormously by location.
+geographic radius implied by a fixed time varies enormously by location.
 
-**The swamping risk**
+**Rippling out vs. what members actually see**
 
-If every low-desirability item automatically expands to a 1-hour radius, adjacent groups see a
-flood of rippled-in posts that originated elsewhere, diluting their own members' locally-posted
-items. The risk is proportional to:
-- The originating group's volume of undesirable/unloved offers (the long tail)
-- The target group's own active feed size (smaller/quieter groups are hit hardest)
+An important distinction: *rippling out* decides **which members can potentially see a post**.
+It does not decide **which posts a member actually sees** or **in what order**. That is the
+job of the browse view and notification construction.
 
-**Three-layer mitigation**
+This means a post rippling into an adjacent group does not necessarily flood that group's
+members with irrelevant content — it simply makes the post *available* there. The browse view
+and digest/notification logic can then prioritise locally-originated posts, rank cross-group
+posts lower, or apply per-group feed budgets as it sees fit.
 
-1. **Neighbour-consent ceiling (primary)**: Stop expansion the moment the isochrone first
-   touches an adjacent group's boundary. This is a hard cap that prevents any cross-posting
-   without explicit consent. A per-group "allow cross-posting to neighbours" setting can
-   unlock it, but the safe default is no cross-posting.
+> **Future feature**: Traffic-adaptive feed ordering — when constructing a group's browse view
+> or digest, rank rippled-in cross-group posts below locally-originated ones. A low-traffic
+> group can choose to weight cross-posts more heavily to fill its feed; a busy group can
+> deprioritise them. This is a browse/notification concern, not a ripple-out concern.
+> Low-traffic groups should naturally benefit from cross-posting because their feeds are thin,
+> while busy groups' local content will drown out cross-posts organically.
 
-   The routing demo's cross-posting marker (⚡ on the timeline) shows empirically how long
-   it takes for a typical location to reach the nearest group boundary — useful for setting
-   expectations.
+**Cross-posting stopping conditions** (these ARE part of ripple-out logic):
 
-2. **Local-interest gate on cross-posting (secondary)**: Only allow the isochrone to cross
-   a group boundary if the item has received at least one reply (showing local interest exists
-   but hasn't been fulfilled yet). Items with zero replies after h6 do not cross-post; they
-   simply exhaust within the home group.
+1. **Neighbour-consent ceiling**: Stop expansion the moment the isochrone first touches an
+   adjacent group's boundary. Default is no cross-posting; a per-group "allow cross-posting
+   to neighbours" setting unlocks it. The demo's ⚡ timeline marker shows empirically when
+   this boundary would be reached for any clicked location.
 
-3. **Per-group inbound budget (display filter)**: Each group caps the number of rippled-in
-   items shown per day (e.g. no more than 20% of total visible items). This is a rendering
-   filter, not a notification one — it prevents feed dilution even if cross-posting is enabled.
-
-**Recommended default for launch**: neighbour-consent ceiling enabled (no cross-posting by
-default), local-interest gate enabled. Deploy the traffic-adaptive inbound budget (below) once
-cross-posting is enabled for any groups, so that low-traffic groups benefit rather than suffer.
-
-### Traffic-Adaptive Inbound Budget
-
-Preferred mitigation for the swamping problem. Instead of a global cap, each group's capacity
-to absorb rippled-in items scales inversely with its own traffic — quiet groups *benefit* from
-cross-posting while busy groups are protected.
-
-**Formula:**
-
-```
-activity_ratio = group_messages_per_week / national_median_messages_per_week
-
-max_cross_posts_per_day = round(
-    base_quota + (max_quota - base_quota) * max(0, 1 - activity_ratio)
-)
-```
-
-Suggested starting values (tune after measuring):
-| Parameter | Value | Notes |
-|-----------|-------|-------|
-| `base_quota` | 5 | min cross-posts/day even for very busy groups |
-| `max_quota` | 30 | max for groups with zero own traffic |
-| `national_median` | ~13 messages/week | from empirical data (May 2026) |
-
-Example behaviour:
-- Group with 0 posts/week → 30 cross-posts/day allowed
-- Group with 13 posts/week (median) → ~17/day
-- Group with 50 posts/week (busy) → ~7/day
-- Group with 100+ posts/week → ≈ base_quota (5/day)
-
-This is a *display* filter applied when rendering the group's browse page and digests — it
-limits how many rippled-in items a group's members see, not how many notifications are sent.
-Notifications respect the sender's home-group ripple schedule; display filtering is a
-receiver-side concern.
+2. **Local-interest gate**: Only allow the isochrone to cross a group boundary if the item
+   has received at least one reply (showing genuine local demand). Items with zero replies
+   after h6 stay within the home group.
 
 ### Minimum-Freegler Expansion Threshold
 

--- a/status-nuxt/server/api/tests/php.post.ts
+++ b/status-nuxt/server/api/tests/php.post.ts
@@ -7,7 +7,7 @@ export default defineEventHandler(async (event) => {
   console.log('Starting PHP tests...')
 
   const body = await readBody(event).catch(() => ({}))
-  const filter = body?.filter ? `--filter "${body.filter}"` : ''
+  const filter = body?.filter || ''
 
   if (filter) {
     console.log(`Running PHP tests with filter: ${body.filter}`)
@@ -95,7 +95,10 @@ async function waitForHealthyAndRunTests(filter: string) {
     appendTestLogs('php', `Warning: Test environment setup issue: ${error.message}\n`)
   }
 
-  // Run tests
+  // Run tests with schema refresh inline before run-phpunit.sh
+  // The schema refresh ensures test databases have the latest schema from iznik
+  // (which has all migrations applied). This is done inline in the spawn command
+  // to avoid shell escaping issues with execSync through multiple docker layers.
   const testPath = filter || '/var/www/iznik/test/ut/php/'
   setTestState('php', { message: 'Running PHPUnit tests...' })
 


### PR DESCRIPTION
## Summary

Part 2 of 4 from the PR #77 split (see #77 for full context). This PR can be merged independently — it does not delete any existing code.

- **Redesigned `UnifiedDigest` MJML template**: Two-column card layout (image left, content right) matching browse-page card style. OFFER/WANTED pill badge, poster avatar, full message body, big Reply CTA, quiet Browse/Post secondary links.
- **Immediate mode email** (`--mode=immediate`): Subject `[GroupName] {raw subject}` matching V1 format; From address `replyto-{msgId}-{userId}@users.ilovefreegle.org` for reply-by-email routing.
- **AMP for Email variant**: `amp-form` in-email reply (dynamic promise status not yet wired).
- **`DigestReplyNotice` mailable** + MJML/text templates: confirmation email when a reply is received via the replyto- address.
- **`IncomingMailService` / `MailParserService` / `ParsedEmail`**: detect replies to replyto- addresses and route them to the original poster.
- **`UnifiedDigestService`**: body-matching dedup improvement.
- **`TestMailCommand`**: `--mode=immediate` flag to preview single-post emails in Mailpit.
- **`routes/console.php`**: enables `mail:digest:unified --mode=immediate` (Phase 1). `--mode=daily` remains commented (Phase 3).

## Cross-links

- PR #77 (`feature/unified-digest-revision`) — original combined PR, kept open for reference
- Sub-PR 1 (`feature/digest-ci-hardening`) — CI/test hardening, ship independently
- **Sub-PR 2 (this PR)** — template + immediate mode (Phase 1)
- Sub-PR 3 (`feature/digest-mode-group`) — add MODE_GROUP (Phase 2, new code)
- Sub-PR 4 (`feature/digest-phase4-cleanup`) — delete old per-group system (Phase 4)

## Migration sequence

After merge: disable V1 `mail:digest -1` cron on bulk3 to hand off immediate emails to Laravel.

## Code Quality Review

- Template matches browse-page card layout as designed.
- Reply-by-email address format matches V1 `replyto-{msgId}-{userId}@users.ilovefreegle.org`.
- `AvatarResolver` trait reused from existing chat notification code.
- No deletion of existing code — `DigestService`, `SingleDigest`, `MultipleDigest` untouched.

## Test Plan

- [x] 2053 Laravel unit tests pass
- [x] Test email sent to Mailpit with `--mode=immediate` and reviewed visually
- [ ] After merge: disable V1 `mail:digest -1` cron on bulk3