### PR TITLE
feat(batch): digest reply notice - auto-response when users reply to digests

### DIFF
--- a/iznik-batch/app/Console/Commands/Mail/TestMailCommand.php
+++ b/iznik-batch/app/Console/Commands/Mail/TestMailCommand.php
@@ -5,7 +5,8 @@ namespace App\Console\Commands\Mail;
 use App\Console\Commands\Mail\SendAdminCommand;
 use App\Mail\Admin\AdminMail;
 use App\Mail\Chat\ChatNotification;
-use App\Mail\Digest\SingleDigest;
+use App\Mail\Digest\UnifiedDigest;
+use App\Services\UnifiedDigestService;
 use App\Mail\Donation\AskForDonation;
 use App\Mail\Donation\DonationThankYou;
 use App\Mail\Message\AutoRepostWarning;
@@ -15,7 +16,6 @@ use App\Mail\Message\DeadlineReached;
 use App\Mail\Welcome\WelcomeMail;
 use App\Models\ChatMessage;
 use App\Models\ChatRoom;
-use App\Models\Group;
 use App\Models\Membership;
 use App\Models\Message;
 use App\Models\User;
@@ -35,8 +35,6 @@ class TestMailCommand extends Command
                             {--send-to= : Deliver email to this address instead (for testing with real user data)}
                             {--from= : Override From header address (for AMP testing - must be registered with Google)}
                             {--chat= : Chat room ID (for chat types)}
-                            {--group= : Group ID (for digest)}
-                            {--message= : Message ID (for digest)}
                             {--message-type= : Specific chat message type (Default, Interested, Promised, Reneged, Completed, Image, Address, Nudge, Schedule)}
                             {--all-types : Send test emails for all chat message types}
                             {--amp= : Override AMP email setting (on/off, default uses config)}
@@ -57,7 +55,7 @@ class TestMailCommand extends Command
         'admin:marketing' => 'Marketing admin email (Little Free Shop template)',
         'chat:user2user' => 'User-to-user chat notification',
         'chat:user2mod' => 'User-to-moderator chat notification',
-        'digest' => 'Digest email (single message)',
+        'digest' => 'Unified digest email (posts from all communities)',
         'donations:ask' => 'Donation request email',
         'donations:thank' => 'Donation thank you email',
         'welcome' => 'Welcome email for new users',
@@ -331,7 +329,7 @@ class TestMailCommand extends Command
         $this->line('  php artisan mail:test chat:user2user --to=test@example.com --amp=on');
         $this->line('  php artisan mail:test chat:user2user --to=test@example.com --amp=off');
         $this->line('  php artisan mail:test chat:user2user --to=realuser@example.com --send-to=mytest@example.com');
-        $this->line('  php artisan mail:test digest --user=12345 --group=67890 --to=test@example.com');
+        $this->line('  php artisan mail:test digest --to=test@example.com');
         $this->line('  php artisan mail:test donations:ask --user=12345 --dry-run');
     }
 
@@ -657,74 +655,76 @@ class TestMailCommand extends Command
     }
 
     /**
-     * Build a digest email.
+     * Build a unified digest email.
      */
-    protected function buildDigest(): ?SingleDigest
+    protected function buildDigest(): ?UnifiedDigest
     {
         $userId = $this->option('user');
-        $groupId = $this->option('group');
-        $messageId = $this->option('message');
+        $toEmail = $this->option('to');
 
-        // Get a message first — this guarantees we have a group with content.
-        if ($messageId) {
-            $message = Message::find($messageId);
-        } else {
-            // Find a message on the specified group, or any group with messages.
-            $messageQuery = Message::query();
-            if ($groupId) {
-                $messageQuery->whereHas('groups', function ($q) use ($groupId) {
-                    $q->where('groups.id', $groupId);
-                });
-            } else {
-                $messageQuery->whereHas('groups');
-            }
-            $message = $messageQuery->orderBy('id', 'desc')->first();
-        }
-
-        if (! $message) {
-            $this->error('No messages found'.($groupId ? " for group {$groupId}" : ' in any group'));
-
-            return null;
-        }
-
-        // Get the group from the message.
-        if ($groupId) {
-            $group = Group::find($groupId);
-        } else {
-            $group = $message->groups->first();
-        }
-
-        if (! $group) {
-            $this->error('No group found for message');
-
-            return null;
-        }
-
-        $this->info("Using group: {$group->nameshort} (ID: {$group->id})");
-        $this->info("Using message: {$message->subject} (ID: {$message->id})");
-
-        // Get or find a user.
-        if ($userId) {
+        // Get user.
+        if ($toEmail) {
+            $user = User::whereHas('emails', function ($q) use ($toEmail) {
+                $q->where('email', $toEmail);
+            })->first();
+        } elseif ($userId) {
             $user = User::find($userId);
         } else {
-            // Prefer a member of this group who has an email address.
-            $membership = Membership::where('groupid', $group->id)
-                ->whereHas('user', function ($q) {
-                    $q->whereHas('emails');
-                })
-                ->first();
-            $user = $membership ? User::find($membership->userid) : User::whereHas('emails')->first();
+            $user = User::whereHas('emails')
+                ->whereHas('memberships', fn ($q) => $q->where('collection', Membership::COLLECTION_APPROVED))
+                ->inRandomOrder()->first();
         }
 
         if (! $user) {
-            $this->error('No user found');
+            $this->error('User not found');
 
             return null;
         }
 
-        $this->info("Generating digest for user: {$user->displayname} (ID: {$user->id})");
+        $this->info("Generating unified digest for user: {$user->displayname} (ID: {$user->id})");
 
-        return new SingleDigest($user, $group, $message, 24);
+        // Get the user's group IDs.
+        $groupIds = $user->memberships()
+            ->where('collection', Membership::COLLECTION_APPROVED)
+            ->pluck('groupid');
+
+        if ($groupIds->isEmpty()) {
+            $this->error("User {$user->id} has no approved group memberships");
+
+            return null;
+        }
+
+        $this->info('User is a member of ' . $groupIds->count() . ' groups');
+
+        // Get recent messages from those groups.
+        $posts = Message::select('messages.*', 'messages_groups.groupid', 'messages_groups.arrival')
+            ->join('messages_groups', 'messages.id', '=', 'messages_groups.msgid')
+            ->whereIn('messages_groups.groupid', $groupIds)
+            ->where('messages_groups.collection', 'Approved')
+            ->where('messages_groups.deleted', 0)
+            ->whereNull('messages.deleted')
+            ->whereIn('messages.type', [Message::TYPE_OFFER, Message::TYPE_WANTED])
+            ->where('messages.fromuser', '!=', $user->id)
+            ->orderBy('messages_groups.arrival', 'desc')
+            ->limit(20)
+            ->with(['attachments', 'fromUser', 'groups'])
+            ->get();
+
+        if ($posts->isEmpty()) {
+            $this->error('No recent messages found in user\'s groups');
+
+            return null;
+        }
+
+        $this->info("Found {$posts->count()} recent messages");
+
+        // Deduplicate using the service.
+        $service = app(UnifiedDigestService::class);
+        $deduplicatedPosts = $service->deduplicatePosts($posts);
+
+        $this->info("After deduplication: {$deduplicatedPosts->count()} unique posts");
+
+        return new UnifiedDigest($user, $deduplicatedPosts, UnifiedDigestService::MODE_DAILY);
     }
 
     /**

--- a/iznik-batch/app/Mail/Digest/DigestReplyNotice.php
+++ b/iznik-batch/app/Mail/Digest/DigestReplyNotice.php
@@ -31,6 +31,8 @@ class DigestReplyNotice extends MjmlMailable
 
         $this->userSite = config('freegle.sites.user');
 
+        $this->to($this->recipientEmail, $this->recipientName);
+
         $this->initTracking(
             'DigestReplyNotice',
             $this->recipientEmail,
@@ -57,7 +59,6 @@ class DigestReplyNotice extends MjmlMailable
             'browseUrl' => $browseUrl,
             'userSite' => $this->userSite,
         ], $this->getTrackingData()), 'emails.text.digest.reply-notice')
-            ->to($this->recipientEmail)
             ->applyLogging('DigestReplyNotice');
     }
 

--- a/iznik-batch/app/Mail/Digest/DigestReplyNotice.php
+++ b/iznik-batch/app/Mail/Digest/DigestReplyNotice.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Mail\Digest;
+
+use App\Mail\MjmlMailable;
+use App\Mail\Traits\LoggableEmail;
+use App\Mail\Traits\TrackableEmail;
+use Illuminate\Mail\Mailables\Address;
+use Illuminate\Mail\Mailables\Envelope;
+
+/**
+ * Auto-response sent when someone replies to a digest email.
+ *
+ * Digest emails are sent from noreply@ and contain multiple posts.
+ * When a user replies to one, we send this friendly notice explaining
+ * how to reply to specific posts using the buttons/links in the email.
+ */
+class DigestReplyNotice extends MjmlMailable
+{
+    use LoggableEmail;
+    use TrackableEmail;
+
+    public string $userSite;
+
+    public function __construct(
+        protected string $recipientEmail,
+        protected ?string $recipientName = null,
+        protected ?int $recipientUserId = null
+    ) {
+        parent::__construct();
+
+        $this->userSite = config('freegle.sites.user');
+
+        $this->initTracking(
+            'DigestReplyNotice',
+            $this->recipientEmail,
+            $this->recipientUserId,
+            null,
+            $this->getSubject()
+        );
+    }
+
+    protected function getRecipientUserId(): ?int
+    {
+        return $this->recipientUserId;
+    }
+
+    public function build(): static
+    {
+        $settingsUrl = $this->trackedUrl($this->userSite . '/settings', 'footer_settings', 'settings');
+        $browseUrl = $this->trackedUrl($this->userSite . '/browse', 'browse_cta', 'browse');
+
+        return $this->mjmlView('emails.mjml.digest.reply-notice', array_merge([
+            'recipientName' => $this->recipientName,
+            'recipientEmail' => $this->recipientEmail,
+            'settingsUrl' => $settingsUrl,
+            'browseUrl' => $browseUrl,
+            'userSite' => $this->userSite,
+        ], $this->getTrackingData()), 'emails.text.digest.reply-notice')
+            ->to($this->recipientEmail)
+            ->applyLogging('DigestReplyNotice');
+    }
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            from: new Address(
+                config('freegle.mail.noreply_addr'),
+                config('freegle.branding.name')
+            ),
+            subject: $this->getSubject(),
+        );
+    }
+
+    protected function getSubject(): string
+    {
+        return 'How to reply to posts on Freegle';
+    }
+}

--- a/iznik-batch/app/Mail/Digest/UnifiedDigest.php
+++ b/iznik-batch/app/Mail/Digest/UnifiedDigest.php
@@ -3,11 +3,13 @@
 namespace App\Mail\Digest;
 
 use App\Mail\MjmlMailable;
+use App\Mail\Traits\AmpEmail;
 use App\Mail\Traits\LoggableEmail;
 use App\Mail\Traits\TrackableEmail;
 use App\Models\User;
 use App\Services\UnifiedDigestService;
 use App\Support\EmojiUtils;
+use Carbon\Carbon;
 use Illuminate\Mail\Mailables\Address;
 use Illuminate\Mail\Mailables\Envelope;
 use Illuminate\Support\Collection;
@@ -21,6 +23,7 @@ use Illuminate\Support\Facades\DB;
  */
 class UnifiedDigest extends MjmlMailable
 {
+    use AmpEmail;
     use LoggableEmail;
     use TrackableEmail;
 
@@ -29,6 +32,8 @@ class UnifiedDigest extends MjmlMailable
     public string $deliveryUrl;
 
     protected Collection $preparedPosts;
+
+    protected int $digestNumber;
 
     public function __construct(
         protected User $user,
@@ -41,10 +46,10 @@ class UnifiedDigest extends MjmlMailable
         $this->userSite = config('freegle.sites.user');
         $this->deliveryUrl = config('freegle.delivery.base_url');
 
-        // Prepare posts with tracking URLs and decoded text.
-        $this->preparedPosts = $this->preparePosts();
+        // Look up digest number for this user.
+        $this->digestNumber = $this->getDigestNumber();
 
-        // Initialize email tracking.
+        // Initialize email tracking BEFORE preparePosts so trackedUrl() works.
         $userId = $this->user->exists ? $this->user->id : null;
 
         $this->initTracking(
@@ -56,8 +61,13 @@ class UnifiedDigest extends MjmlMailable
             [
                 'mode' => $this->mode,
                 'post_count' => $this->posts->count(),
+                'digest_number' => $this->digestNumber,
+                'has_amp' => $this->isAmpEnabled(),
             ]
         );
+
+        // Prepare posts with tracking URLs and decoded text.
+        $this->preparedPosts = $this->preparePosts();
     }
 
     /**
@@ -73,17 +83,40 @@ class UnifiedDigest extends MjmlMailable
      */
     public function build(): static
     {
-        return $this->mjmlView('emails.mjml.digest.unified', array_merge([
+        $result = $this->mjmlView('emails.mjml.digest.unified', array_merge([
             'user' => $this->user,
             'posts' => $this->preparedPosts,
             'postCount' => $this->posts->count(),
+            'mode' => $this->mode,
             'sponsors' => $this->sponsors,
             'settingsUrl' => $this->trackedUrl($this->userSite . '/settings', 'footer_settings', 'settings'),
-            'browseUrl' => $this->trackedUrl($this->userSite . '/browse', 'browse_button', 'browse'),
+            'unsubscribeUrl' => $this->trackedUrl($this->userSite . '/unsubscribe', 'footer_unsubscribe', 'unsubscribe'),
+            'browseUrl' => $this->trackedUrl($this->userSite . '/browse', 'browse_cta', 'browse'),
             'userSite' => $this->userSite,
         ], $this->getTrackingData()), 'emails.text.digest.unified')
             ->to($this->user->email_preferred)
             ->applyLogging('UnifiedDigest');
+
+        // Render AMP variant if enabled.
+        if ($this->isAmpEnabled()) {
+            $ampPosts = $this->prepareAmpPosts();
+
+            $this->renderAmpTemplate('emails.amp.digest.unified', [
+                'user' => $this->user,
+                'posts' => $ampPosts,
+                'postCount' => $this->posts->count(),
+                'settingsUrl' => $this->trackedUrl($this->userSite . '/settings', 'amp_settings', 'settings'),
+                'unsubscribeUrl' => $this->trackedUrl($this->userSite . '/unsubscribe', 'amp_unsubscribe', 'unsubscribe'),
+                'browseUrl' => $this->trackedUrl($this->userSite . '/browse', 'amp_browse', 'browse'),
+                'userSite' => $this->userSite,
+            ]);
+
+            $result->withSymfonyMessage(function ($message) {
+                $this->applyAmpToMessage($message);
+            });
+        }
+
+        return $result;
     }
 
     /**
@@ -169,9 +202,23 @@ class UnifiedDigest extends MjmlMailable
      */
     protected function preparePosts(): Collection
     {
-        return $this->posts->map(function ($post, $index) {
+        $totalPosts = $this->posts->count();
+
+        // Get user's location for distance calculation.
+        $userLat = null;
+        $userLng = null;
+        if ($this->user->lastlocation) {
+            $loc = DB::table('locations')->where('id', $this->user->lastlocation)->first(['lat', 'lng']);
+            if ($loc) {
+                $userLat = (float) $loc->lat;
+                $userLng = (float) $loc->lng;
+            }
+        }
+
+        return $this->posts->map(function ($post, $index) use ($totalPosts, $userLat, $userLng) {
             $message = $post['message'];
             $postedToGroups = $post['postedToGroups'];
+            $isOffer = $message->type === 'Offer';
 
             // Get group names for "Posted to:" display.
             $postedToText = count($postedToGroups) > 1
@@ -180,6 +227,18 @@ class UnifiedDigest extends MjmlMailable
 
             // Get image URL via delivery service.
             $imageUrl = $this->getMessageImageUrl($message);
+
+            // Use type-specific placeholder if no photo.
+            $placeholderUrl = $isOffer
+                ? config('freegle.images.offer_placeholder')
+                : config('freegle.images.wanted_placeholder');
+
+            // Create tracked image URL with scroll depth.
+            $scrollPercent = $totalPosts > 0 ? round(($index / $totalPosts) * 100) : 0;
+            $displayImageUrl = $imageUrl ?? $placeholderUrl;
+            $trackedImage = $displayImageUrl !== null
+                ? $this->trackedImageUrl($displayImageUrl, "image_{$index}", $scrollPercent)
+                : null;
 
             // Decode emoji sequences in message text.
             $messageText = $message->textbody
@@ -193,17 +252,98 @@ class UnifiedDigest extends MjmlMailable
                 'view_message'
             );
 
+            // Format arrival time for display.
+            $arrival = $message->arrival instanceof Carbon ? $message->arrival : Carbon::parse($message->arrival);
+            $arrivalFormatted = $arrival->format('D j M, ga'); // e.g. "Sun 1 Mar, 9pm"
+            $arrivalIso = $arrival->toIso8601String();
+
+            // Calculate distance from user.
+            $distanceText = null;
+            if ($userLat !== null && $userLng !== null && $message->lat && $message->lng) {
+                $miles = $this->haversineDistance($userLat, $userLng, (float) $message->lat, (float) $message->lng);
+                $distanceText = $miles < 1 ? '< 1 mile' : round($miles) . ' miles';
+            }
+
             return [
                 'message' => $message,
                 'messageText' => $messageText,
                 'messageUrl' => $messageUrl,
                 'imageUrl' => $imageUrl,
+                'displayImageUrl' => $displayImageUrl,
+                'trackedImageUrl' => $trackedImage,
+                'isPlaceholder' => $imageUrl === null,
                 'postedToText' => $postedToText,
                 'type' => $message->type,
                 'subject' => $message->subject,
                 'itemName' => $this->extractItemName($message->subject),
+                'locationName' => $this->extractLocationName($message->subject),
+                'arrivalFormatted' => $arrivalFormatted,
+                'arrivalIso' => $arrivalIso,
+                'distanceText' => $distanceText,
             ];
         });
+    }
+
+    /**
+     * Extract location name from subject line.
+     * Returns the text in parentheses at the end, e.g. "Edinburgh" from "OFFER: Sofa (Edinburgh)".
+     */
+    protected function extractLocationName(string $subject): ?string
+    {
+        if (preg_match('/\(([^)]+)\)\s*$/', $subject, $matches)) {
+            return $matches[1];
+        }
+
+        return null;
+    }
+
+    /**
+     * Haversine distance in miles between two lat/lng points.
+     */
+    protected function haversineDistance(float $lat1, float $lng1, float $lat2, float $lng2): float
+    {
+        $earthRadiusMiles = 3959;
+        $dLat = deg2rad($lat2 - $lat1);
+        $dLng = deg2rad($lng2 - $lng1);
+        $a = sin($dLat / 2) ** 2 + cos(deg2rad($lat1)) * cos(deg2rad($lat2)) * sin($dLng / 2) ** 2;
+
+        return $earthRadiusMiles * 2 * atan2(sqrt($a), sqrt(1 - $a));
+    }
+
+    /**
+     * Prepare posts with AMP reply URLs and tokens.
+     */
+    protected function prepareAmpPosts(): Collection
+    {
+        $ampApiBase = config('freegle.amp.api_base', $this->userSite);
+        $userId = $this->user->id;
+
+        return $this->preparedPosts->map(function ($post) use ($ampApiBase, $userId) {
+            $messageId = $post['message']->id;
+            $token = $this->generateToken($userId, $messageId);
+
+            $post['ampReplyUrl'] = "{$ampApiBase}/amp/digest/reply?" . http_build_query([
+                'rt' => $token,
+                'uid' => $userId,
+                'mid' => $messageId,
+            ]);
+
+            // Fallback URL for non-AMP clients or AMP form errors.
+            $post['fallbackReplyUrl'] = $post['messageUrl'];
+
+            return $post;
+        });
+    }
+
+    /**
+     * Get the digest number for this user (count of previously sent digests).
+     */
+    protected function getDigestNumber(): int
+    {
+        return (int) DB::table('email_tracking')
+            ->where('userid', $this->user->id)
+            ->where('email_type', 'UnifiedDigest')
+            ->count();
     }
 
     /**

--- a/iznik-batch/app/Models/Group.php
+++ b/iznik-batch/app/Models/Group.php
@@ -66,14 +66,6 @@ class Group extends Model
     }
 
     /**
-     * Get group's digest records.
-     */
-    public function digests(): HasMany
-    {
-        return $this->hasMany(GroupDigest::class, 'groupid');
-    }
-
-    /**
      * Scope to only Freegle groups.
      */
     public function scopeFreegle(Builder $query): Builder

--- a/iznik-batch/app/Services/Mail/Incoming/IncomingMailService.php
+++ b/iznik-batch/app/Services/Mail/Incoming/IncomingMailService.php
@@ -128,6 +128,12 @@ class IncomingMailService
             return $this->handleHumanReplyToBounceAddress($email);
         }
 
+        // Phase 3c: Reply to digest email (sent from noreply@).
+        // Send helpful auto-response explaining how to reply to specific posts.
+        if ($email->isDigestReply()) {
+            return $this->handleDigestReply($email);
+        }
+
         // Check for known dropped senders (Twitter, etc.)
         if ($this->shouldDropSender($email)) {
             return $this->dropped('Known dropped sender (Twitter, etc.)');
@@ -1399,6 +1405,76 @@ class IncomingMailService
             Log::info('Sent bounce address auto-reply', ['to' => $senderAddress]);
         } catch (\Throwable $e) {
             Log::warning('Failed to send bounce address auto-reply', [
+                'to' => $senderAddress,
+                'error' => $e->getMessage(),
+            ]);
+        }
+
+        return RoutingResult::TO_SYSTEM;
+    }
+
+    /**
+     * Handle reply to a digest email.
+     *
+     * Digest emails are sent from noreply@ and contain multiple posts.
+     * When someone replies, we send a friendly auto-response explaining
+     * how to reply to specific posts via the buttons/links in the email.
+     */
+    private function handleDigestReply(ParsedEmail $email): RoutingResult
+    {
+        $senderAddress = strtolower($email->fromAddress ?? $email->envelopeFrom ?? '');
+
+        Log::info('Reply to digest email', [
+            'from' => $senderAddress,
+            'envelope_to' => $email->envelopeTo,
+            'subject' => $email->subject,
+        ]);
+
+        // Loop prevention: never auto-reply to system addresses
+        $suppressPatterns = ['mailer-daemon', 'postmaster', 'noreply', 'no-reply', 'bounce-'];
+        foreach ($suppressPatterns as $pattern) {
+            if (str_contains($senderAddress, $pattern)) {
+                Log::debug('Suppressing digest reply auto-response to system address', ['from' => $senderAddress]);
+
+                return RoutingResult::TO_SYSTEM;
+            }
+        }
+
+        // Loop prevention: never auto-reply to auto-submitted messages
+        if ($email->isAutoReply()) {
+            Log::debug('Suppressing digest reply auto-response to auto-submitted message');
+
+            return RoutingResult::TO_SYSTEM;
+        }
+
+        // Rate limit: max 1 auto-reply per 24h per sender
+        $cacheKey = 'digest_reply_autoreply:' . md5($senderAddress);
+        if (Cache::has($cacheKey)) {
+            Log::debug('Rate limiting digest reply auto-response', ['from' => $senderAddress]);
+
+            return RoutingResult::TO_SYSTEM;
+        }
+
+        // Look up the sender to get their name and user ID
+        $senderName = $email->fromName;
+        $senderUserId = null;
+
+        $userEmail = \App\Models\UserEmail::where('email', $senderAddress)->first();
+        if ($userEmail) {
+            $senderUserId = $userEmail->userid;
+        }
+
+        // Send auto-response
+        try {
+            MailFacade::send(new \App\Mail\Digest\DigestReplyNotice(
+                $senderAddress,
+                $senderName,
+                $senderUserId
+            ));
+            Cache::put($cacheKey, true, now()->addHours(24));
+            Log::info('Sent digest reply auto-response', ['to' => $senderAddress]);
+        } catch (\Throwable $e) {
+            Log::warning('Failed to send digest reply auto-response', [
                 'to' => $senderAddress,
                 'error' => $e->getMessage(),
             ]);
@@ -3372,7 +3448,41 @@ class IncomingMailService
      */
     private function parseSubject(string $subj): array
     {
-        return \App\Support\SubjectParser::parse($subj);
+        $type = null;
+        $item = null;
+        $location = null;
+
+        $p = strpos($subj, ':');
+
+        if ($p !== false) {
+            $startp = $p;
+            $rest = trim(substr($subj, $p + 1));
+            $p = strlen($rest) - 1;
+
+            if (substr($rest, -1) == ')') {
+                $count = 0;
+
+                do {
+                    $curr = substr($rest, $p, 1);
+
+                    if ($curr == '(') {
+                        $count--;
+                    } elseif ($curr == ')') {
+                        $count++;
+                    }
+
+                    $p--;
+                } while ($count > 0 && $p > 0);
+
+                if ($count == 0) {
+                    $type = trim(substr($subj, 0, $startp));
+                    $location = trim(substr($rest, $p + 2, strlen($rest) - $p - 3));
+                    $item = trim(substr($rest, 0, $p));
+                }
+            }
+        }
+
+        return [$type, $item, $location];
     }
 
     /**

--- a/iznik-batch/app/Services/Mail/Incoming/MailParserService.php
+++ b/iznik-batch/app/Services/Mail/Incoming/MailParserService.php
@@ -60,6 +60,9 @@ class MailParserService
         // Extract sender IP
         $senderIp = $this->extractSenderIp($headers);
 
+        // Check if this is a reply to a digest email
+        $isDigestReply = $this->isDigestReply($envelopeTo, $headers);
+
         return new ParsedEmail(
             rawMessage: $rawMessage,
             envelopeFrom: $envelopeFrom,
@@ -84,7 +87,8 @@ class MailParserService
             chatMessageId: $chatInfo['messageId'],
             commandUserId: $commandInfo['userId'],
             commandGroupId: $commandInfo['groupId'],
-            senderIp: $senderIp
+            senderIp: $senderIp,
+            isDigestReply: $isDigestReply
         );
     }
 
@@ -540,5 +544,31 @@ class MailParserService
         }
 
         return null;
+    }
+
+    /**
+     * Check if this email is a reply to a digest email.
+     *
+     * Digest emails are sent from noreply@. We detect replies by checking:
+     * 1. Envelope-to is noreply@{user_domain}
+     * 2. In-Reply-To header contains "UnifiedDigest" (our Message-ID pattern)
+     */
+    private function isDigestReply(string $envelopeTo, array $headers): bool
+    {
+        $userDomain = config('freegle.mail.user_domain');
+        $noreplyAddr = config('freegle.mail.noreply_addr');
+
+        // Check if addressed to noreply@
+        if (strtolower($envelopeTo) === strtolower($noreplyAddr)) {
+            return true;
+        }
+
+        // Check if In-Reply-To references a digest email
+        $inReplyTo = $headers['in-reply-to'] ?? null;
+        if ($inReplyTo !== null && str_contains($inReplyTo, 'UnifiedDigest')) {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/iznik-batch/app/Services/Mail/Incoming/ParsedEmail.php
+++ b/iznik-batch/app/Services/Mail/Incoming/ParsedEmail.php
@@ -83,6 +83,12 @@ class ParsedEmail
     public readonly ?string $senderIp;
 
     // ========================================
+    // Digest Reply Properties
+    // ========================================
+
+    public readonly bool $isDigestReply;
+
+    // ========================================
     // Internal State
     // ========================================
 
@@ -114,7 +120,8 @@ class ParsedEmail
         ?int $chatMessageId,
         ?int $commandUserId,
         ?int $commandGroupId,
-        ?string $senderIp
+        ?string $senderIp,
+        bool $isDigestReply = false
     ) {
         $this->rawMessage = $rawMessage;
         $this->envelopeFrom = $envelopeFrom;
@@ -140,6 +147,7 @@ class ParsedEmail
         $this->commandUserId = $commandUserId;
         $this->commandGroupId = $commandGroupId;
         $this->senderIp = $senderIp;
+        $this->isDigestReply = $isDigestReply;
 
         // Cache envelope-to local part for routing checks
         $this->envelopeToLocalPart = explode('@', $envelopeTo)[0] ?? '';
@@ -276,6 +284,18 @@ class ParsedEmail
     }
 
     // ========================================
+    // Digest Reply Detection
+    // ========================================
+
+    /**
+     * Check if this is a reply to a digest email (sent from noreply@).
+     */
+    public function isDigestReply(): bool
+    {
+        return $this->isDigestReply;
+    }
+
+    // ========================================
     // Email Command Detection
     // ========================================
 
@@ -399,6 +419,7 @@ class ParsedEmail
             'chat_user_id' => $this->chatUserId,
             'chat_message_id' => $this->chatMessageId,
             'is_auto_reply' => $this->isAutoReply(),
+            'is_digest_reply' => $this->isDigestReply(),
             'is_subscribe_command' => $this->isSubscribeCommand(),
             'is_unsubscribe_command' => $this->isUnsubscribeCommand(),
             'is_digestoff_command' => $this->isDigestOffCommand(),

--- a/iznik-batch/app/Services/UnifiedDigestService.php
+++ b/iznik-batch/app/Services/UnifiedDigestService.php
@@ -263,11 +263,22 @@ class UnifiedDigestService
             $key = $this->getDeduplicationKey($post);
 
             if (isset($processed[$key])) {
-                // Add this group to the existing post's groups list.
+                // Key matches - also check body similarity before deduplicating.
                 $existingIndex = $processed[$key];
                 $existing = $deduplicated[$existingIndex];
-                $existing['postedToGroups'][] = $post->groupid;
-                $deduplicated[$existingIndex] = $existing;
+
+                if ($this->bodiesMatch($existing['message'], $post)) {
+                    // Same key AND similar body - true duplicate, merge groups.
+                    $existing['postedToGroups'][] = $post->groupid;
+                    $deduplicated[$existingIndex] = $existing;
+                } else {
+                    // Same key but different body - treat as separate post.
+                    $index = $deduplicated->count();
+                    $deduplicated->push([
+                        'message' => $post,
+                        'postedToGroups' => [$post->groupid],
+                    ]);
+                }
             } else {
                 // New unique post.
                 $index = $deduplicated->count();
@@ -280,6 +291,34 @@ class UnifiedDigestService
         }
 
         return $deduplicated;
+    }
+
+    /**
+     * Check if two messages have matching body content.
+     */
+    protected function bodiesMatch(Message $a, Message $b): bool
+    {
+        // TrashNothing posts with same tnpostid are always duplicates.
+        if ($a->tnpostid && $b->tnpostid && $a->tnpostid === $b->tnpostid) {
+            return true;
+        }
+
+        return $this->normalizeBody($a->textbody) === $this->normalizeBody($b->textbody);
+    }
+
+    /**
+     * Normalize body text for comparison.
+     */
+    protected function normalizeBody(?string $body): string
+    {
+        if ($body === null) {
+            return '';
+        }
+
+        $normalized = strtolower(trim($body));
+        $normalized = preg_replace('/\s+/', ' ', $normalized);
+
+        return substr($normalized, 0, 200);
     }
 
     /**

--- a/iznik-batch/resources/views/emails/amp/digest/unified.blade.php
+++ b/iznik-batch/resources/views/emails/amp/digest/unified.blade.php
@@ -1,0 +1,348 @@
+<!doctype html>
+<html ⚡4email data-css-strict>
+<head>
+  <meta charset="utf-8">
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-form" src="https://cdn.ampproject.org/v0/amp-form-0.1.js"></script>
+  <script async custom-element="amp-accordion" src="https://cdn.ampproject.org/v0/amp-accordion-0.1.js"></script>
+  <script async custom-element="amp-timeago" src="https://cdn.ampproject.org/v0/amp-timeago-0.1.js"></script>
+  <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.2.js"></script>
+  <style amp4email-boilerplate>body{visibility:hidden}</style>
+  <style amp-custom>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+      margin: 0;
+      padding: 0;
+      background-color: #ffffff;
+      color: #333333;
+    }
+    .container {
+      max-width: 600px;
+      margin: 0 auto;
+    }
+
+    /* Header */
+    .header {
+      background-color: #338808;
+      padding: 16px 20px;
+      text-align: center;
+    }
+
+    /* Greeting */
+    .greeting {
+      padding: 20px 20px 10px 20px;
+    }
+    .greeting h2 {
+      font-size: 16px;
+      color: #333333;
+      margin: 0 0 4px 0;
+    }
+    .greeting p {
+      font-size: 14px;
+      color: #555555;
+      margin: 0;
+    }
+
+    /* Post cards */
+    .post-card {
+      padding: 12px 20px;
+      border-bottom: 1px solid #eeeeee;
+      display: flex;
+      align-items: flex-start;
+    }
+    .post-image {
+      width: 80px;
+      flex-shrink: 0;
+      border-radius: 4px;
+    }
+    .post-content {
+      padding-left: 12px;
+      flex: 1;
+    }
+    .post-type-offer {
+      font-size: 11px;
+      font-weight: bold;
+      color: #338808;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      margin: 0 0 2px 0;
+    }
+    .post-type-wanted {
+      font-size: 11px;
+      font-weight: bold;
+      color: #00A1CB;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      margin: 0 0 2px 0;
+    }
+    .post-title {
+      font-size: 16px;
+      font-weight: 600;
+      margin: 0 0 4px 0;
+    }
+    .post-title a {
+      color: #333333;
+      text-decoration: none;
+    }
+    .post-preview {
+      font-size: 13px;
+      color: #666666;
+      margin: 0 0 4px 0;
+      line-height: 1.4;
+    }
+    .post-groups {
+      font-size: 11px;
+      color: #888888;
+      font-style: italic;
+      margin: 0 0 8px 0;
+    }
+    .post-time {
+      font-size: 12px;
+      color: #888888;
+      margin: 0 0 4px 0;
+    }
+
+    /* Reply accordion */
+    amp-accordion section {
+      border: none;
+    }
+    amp-accordion section[expanded] .reply-toggle {
+      display: none;
+    }
+    .reply-toggle {
+      display: inline-block;
+      background-color: #338808;
+      color: #ffffff;
+      font-size: 13px;
+      font-weight: bold;
+      padding: 8px 16px;
+      border: none;
+      border-radius: 4px;
+      cursor: pointer;
+      list-style: none;
+    }
+    .reply-form-container {
+      padding: 8px 0;
+    }
+    .reply-textarea {
+      width: 100%;
+      min-height: 60px;
+      padding: 10px;
+      border: 1px solid #ced4da;
+      border-radius: 4px;
+      font-size: 14px;
+      font-family: inherit;
+      resize: vertical;
+      box-sizing: border-box;
+    }
+    .reply-textarea:focus {
+      outline: none;
+      border-color: #338808;
+    }
+    .reply-submit {
+      background-color: #338808;
+      color: #ffffff;
+      font-size: 14px;
+      font-weight: bold;
+      padding: 10px 20px;
+      border: none;
+      border-radius: 4px;
+      cursor: pointer;
+      margin-top: 8px;
+    }
+    .reply-fallback {
+      font-size: 12px;
+      color: #666666;
+      margin-top: 6px;
+    }
+    .reply-fallback a {
+      color: #338808;
+      text-decoration: none;
+    }
+
+    /* Form states */
+    .reply-form-container {
+      position: relative;
+    }
+    .reply-form-container[submitting] .reply-textarea,
+    .reply-form-container[submitting] .reply-submit,
+    .reply-form-container[submit-success] .reply-textarea,
+    .reply-form-container[submit-success] .reply-submit {
+      opacity: 0.3;
+    }
+    .form-status {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      width: 90%;
+      z-index: 10;
+    }
+    .submit-success {
+      background-color: #e8f5e0;
+      border: 1px solid #338808;
+      color: #2a6d07;
+      padding: 12px;
+      text-align: center;
+      border-radius: 4px;
+    }
+    .submit-error {
+      background-color: #f2dede;
+      border: 1px solid #d9534f;
+      color: #a94442;
+      padding: 12px;
+      text-align: center;
+      border-radius: 4px;
+    }
+    .submitting-msg {
+      background-color: #ffffff;
+      border: 1px solid #338808;
+      color: #333333;
+      padding: 12px;
+      text-align: center;
+      border-radius: 4px;
+    }
+
+    /* Browse button */
+    .browse-section {
+      padding: 25px 20px;
+      text-align: center;
+    }
+    .browse-button {
+      display: inline-block;
+      background-color: #338808;
+      color: #ffffff;
+      font-size: 16px;
+      font-weight: bold;
+      padding: 14px 40px;
+      text-decoration: none;
+      border-radius: 4px;
+    }
+
+    /* Footer */
+    .footer {
+      background-color: #f5f5f5;
+      padding: 20px;
+      text-align: center;
+    }
+    .footer-text {
+      font-size: 12px;
+      color: #666666;
+      line-height: 1.6;
+      margin: 0 0 10px 0;
+    }
+    .footer-links {
+      font-size: 12px;
+      margin: 0 0 15px 0;
+    }
+    .footer-links a {
+      color: #338808;
+      text-decoration: none;
+    }
+    .footer-divider {
+      border-top: 1px solid #dddddd;
+      margin: 15px 40px;
+    }
+    .footer-charity {
+      font-size: 11px;
+      color: #666666;
+      line-height: 1.5;
+      margin: 0;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    {{-- Header --}}
+    <div class="header">
+      <amp-img
+        src="{{ config('freegle.branding.logo_url') }}"
+        width="120"
+        height="40"
+        alt="{{ config('freegle.branding.name', 'Freegle') }}"
+        layout="fixed"
+      ></amp-img>
+    </div>
+
+    {{-- Greeting --}}
+    <div class="greeting">
+      <h2>Hi {{ $user->displayname ?? 'there' }},</h2>
+      <p>Here {{ $postCount === 1 ? 'is' : 'are' }} <strong>{{ $postCount }}</strong> new post{{ $postCount === 1 ? '' : 's' }} from your Freegle communities:</p>
+    </div>
+
+    {{-- Post cards with reply accordion --}}
+    @foreach($posts as $index => $post)
+    <div class="post-card">
+      <amp-img class="post-image" src="{{ $post['displayImageUrl'] }}" width="80" height="80" layout="fixed" alt="{{ $post['itemName'] }}"></amp-img>
+      <div class="post-content">
+        <p class="{{ $post['type'] === 'Offer' ? 'post-type-offer' : 'post-type-wanted' }}">{{ $post['type'] === 'Offer' ? 'OFFER' : 'WANTED' }}</p>
+        <p class="post-title"><a href="{{ $post['fallbackReplyUrl'] }}">{{ $post['itemName'] }}</a></p>
+        <p class="post-time">
+          <amp-timeago datetime="{{ $post['arrivalIso'] }}" locale="en" width="160" height="20" layout="fixed">{{ $post['arrivalFormatted'] }}</amp-timeago>
+        </p>
+        @if($post['messageText'])
+        <p class="post-preview">{{ \Illuminate\Support\Str::limit($post['messageText'], 100) }}</p>
+        @endif
+        @if($post['postedToText'])
+        <p class="post-groups">{{ $post['postedToText'] }}</p>
+        @endif
+
+        {{-- Reply accordion --}}
+        <amp-accordion animate>
+          <section>
+            <h4 class="reply-toggle">Reply</h4>
+            <div class="reply-form-container">
+              <form method="post" action-xhr="{{ $post['ampReplyUrl'] }}">
+                <textarea class="reply-textarea" name="message" placeholder="Type your reply..." required minlength="1" maxlength="10000"></textarea>
+                <button type="submit" class="reply-submit">Send Reply</button>
+                <div submitting>
+                  <div class="form-status">
+                    <div class="submitting-msg">Sending your reply...</div>
+                  </div>
+                </div>
+                <div submit-success>
+                  <template type="amp-mustache">
+                    <div class="form-status">
+                      <div class="submit-success">@{{message}}</div>
+                    </div>
+                  </template>
+                </div>
+                <div submit-error>
+                  <template type="amp-mustache">
+                    <div class="form-status">
+                      <div class="submit-error">@{{message}} <a href="{{ $post['fallbackReplyUrl'] }}">Reply on Freegle instead</a></div>
+                    </div>
+                  </template>
+                </div>
+              </form>
+              <div class="reply-fallback">
+                <a href="{{ $post['fallbackReplyUrl'] }}">Or reply via website</a>
+              </div>
+            </div>
+          </section>
+        </amp-accordion>
+      </div>
+    </div>
+    @endforeach
+
+    {{-- Browse All Posts --}}
+    <div class="browse-section">
+      <a href="{{ $browseUrl }}" class="browse-button">Browse All Posts</a>
+    </div>
+
+    {{-- Footer --}}
+    <div class="footer">
+      <p class="footer-text">This email was sent with AMP to {{ $user->email_preferred }}</p>
+      <p class="footer-links">
+        <a href="{{ $settingsUrl }}">Change your email settings</a> &bull;
+        <a href="{{ $unsubscribeUrl ?? $userSite . '/unsubscribe' }}">Unsubscribe</a>
+      </p>
+      <div class="footer-divider"></div>
+      <p class="footer-charity">
+        {{ $siteName ?? config('freegle.branding.name', 'Freegle') }} is registered as a charity with HMRC (ref. XT32865) and is run by volunteers. Which is nice.<br>
+        Registered address: Weaver's Field, Loud Bridge, Chipping PR3 2NX
+      </p>
+    </div>
+  </div>
+</body>
+</html>

--- a/iznik-batch/resources/views/emails/mjml/digest/reply-notice.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/digest/reply-notice.blade.php
@@ -1,0 +1,58 @@
+<mjml>
+  @include('emails.mjml.partials.head', ['preview' => 'How to reply to posts on Freegle'])
+  <mj-body background-color="#ffffff">
+    {{-- Header with logo --}}
+    @include('emails.mjml.components.header')
+
+    {{-- Greeting --}}
+    <mj-section background-color="#ffffff" padding="20px 20px 10px 20px">
+      <mj-column>
+        <mj-text font-size="16px" color="#333333">
+          Hi {{ $recipientName ?? 'there' }},
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+    {{-- Explanation --}}
+    <mj-section background-color="#ffffff" padding="10px 20px">
+      <mj-column>
+        <mj-text font-size="14px" color="#555555" line-height="1.6">
+          It looks like you tried to reply to a digest email. Digest emails contain multiple posts from your Freegle communities, so we can't tell which post you'd like to reply to.
+        </mj-text>
+        <mj-text font-size="14px" color="#555555" line-height="1.6" padding-top="10px">
+          To reply to a specific post, please use the <strong>Reply</strong> button next to the post you're interested in. This will open a conversation with the person who posted it.
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+    {{-- CTA buttons --}}
+    <mj-section background-color="#ffffff" padding="20px 20px 10px 20px">
+      <mj-column>
+        <mj-button href="{{ $browseUrl }}" mj-class="btn-success" font-size="16px" inner-padding="14px 40px">
+          Browse Posts
+        </mj-button>
+      </mj-column>
+    </mj-section>
+
+    <mj-section background-color="#ffffff" padding="0 20px 20px 20px">
+      <mj-column>
+        <mj-text font-size="13px" color="#888888" align="center">
+          You can also change how you receive emails in your
+          <a href="{{ $settingsUrl }}" style="color: #338808;">settings</a>.
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+    {{-- Footer --}}
+    @include('emails.mjml.partials.footer', ['email' => $recipientEmail, 'settingsUrl' => $settingsUrl])
+
+    {{-- Tracking pixel --}}
+    @if(!empty($trackingPixelHtml))
+    <mj-section padding="0">
+      <mj-column>
+        <mj-text padding="0">{!! $trackingPixelHtml !!}</mj-text>
+      </mj-column>
+    </mj-section>
+    @endif
+  </mj-body>
+</mjml>

--- a/iznik-batch/resources/views/emails/mjml/digest/unified.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/digest/unified.blade.php
@@ -1,78 +1,134 @@
 <mjml>
-    @include('emails.mjml.partials.head', [
-        'preview' => $postCount . ' new posts near you',
-        'styles' => '
-            .message-card { border-bottom: 1px solid #eeeeee; padding-bottom: 15px; margin-bottom: 15px; }
-            .message-title { font-weight: bold; color: #333333; }
-            .message-type { font-size: 12px; color: #338808; text-transform: uppercase; }
-            .posted-to { font-size: 11px; color: #888888; font-style: italic; }
-        ',
-    ])
+    @include('emails.mjml.partials.head', ['preview' => $postCount . ' new post' . ($postCount === 1 ? '' : 's') . ' near you'])
 
     <mj-body background-color="#f4f4f4">
-        @include('emails.mjml.components.header')
+        @php
+            $offers = collect($posts)->where('type', 'Offer');
+            $wanteds = collect($posts)->where('type', 'Wanted');
+            $maxHeaderItems = 3;
+            $offerColor = '#3c763d';
+            $wantedColor = '#4895DD';
+        @endphp
 
-        <mj-section background-color="#ffffff" padding="20px">
-            <mj-column>
-                <mj-text>
-                    Dear {{ $user->displayname ?? 'there' }},
-                </mj-text>
-                <mj-text>
-                    Here {{ $postCount === 1 ? 'is' : 'are' }} <strong>{{ $postCount }}</strong> new post{{ $postCount === 1 ? '' : 's' }} from your Freegle communities:
+        {{-- Header - Freegle brand green with logo + compact summary --}}
+        <mj-section mj-class="bg-success" padding="16px 20px">
+            <mj-column width="20%" vertical-align="middle">
+                <mj-image
+                    width="50px"
+                    src="{{ config('freegle.branding.logo_url') }}"
+                    alt="Freegle"
+                    align="left"
+                    padding="0"
+                />
+            </mj-column>
+            <mj-column width="80%" vertical-align="middle">
+                <mj-text font-size="13px" color="#ffffff" padding="0" line-height="1.6">
+                    @if($offers->isNotEmpty())
+                    <span style="display: inline-block; background-color: {{ $offerColor }}; border: 1px solid rgba(255,255,255,0.4); font-size: 10px; font-weight: bold; padding: 1px 6px; border-radius: 4px; letter-spacing: 0.5px; vertical-align: middle; margin-right: 3px;">OFFER</span>
+                    @foreach($offers->take($maxHeaderItems) as $post)<a href="#msg-{{ $post['message']->id }}" style="color: #ffffff; text-decoration: underline;">{{ $post['itemName'] }}</a>@if(!$loop->last), @endif @endforeach @if($offers->count() > $maxHeaderItems) <a href="{{ $browseUrl }}" style="color: #ffffff; text-decoration: underline;">+{{ $offers->count() - $maxHeaderItems }} more</a> @endif
+                    @endif
+                    @if($offers->isNotEmpty() && $wanteds->isNotEmpty())
+                    <br/>
+                    @endif
+                    @if($wanteds->isNotEmpty())
+                    <span style="display: inline-block; background-color: {{ $wantedColor }}; font-size: 10px; font-weight: bold; padding: 1px 6px; border-radius: 4px; letter-spacing: 0.5px; vertical-align: middle; margin-right: 3px;">WANTED</span>
+                    @foreach($wanteds->take($maxHeaderItems) as $post)<a href="#msg-{{ $post['message']->id }}" style="color: #ffffff; text-decoration: underline;">{{ $post['itemName'] }}</a>@if(!$loop->last), @endif @endforeach @if($wanteds->count() > $maxHeaderItems) <a href="{{ $browseUrl }}" style="color: #ffffff; text-decoration: underline;">+{{ $wanteds->count() - $maxHeaderItems }} more</a> @endif
+                    @endif
                 </mj-text>
             </mj-column>
         </mj-section>
 
-        @foreach($posts as $post)
-        <mj-section background-color="#ffffff" padding="10px 20px" css-class="message-card">
-            <mj-column width="25%">
-                @if($post['imageUrl'])
-                <mj-image
-                    width="80px"
-                    src="{{ $post['imageUrl'] }}"
-                    alt="Photo"
-                />
-                @else
-                <mj-image
-                    width="80px"
-                    src="{{ $userSite }}/icon.png"
-                    alt="No photo"
-                />
-                @endif
+        {{-- Post cards --}}
+        @foreach($posts as $index => $post)
+        @php $isOffer = $post['type'] === 'Offer'; @endphp
+
+        {{-- Card separator --}}
+        @if($index > 0)
+        <mj-section padding="0" background-color="#ffffff">
+            <mj-column>
+                <mj-divider border-color="#e9ecef" border-width="1px" padding="0 20px" />
             </mj-column>
-            <mj-column width="75%">
-                <mj-text css-class="message-type">
-                    {{ $post['type'] === 'Offer' ? 'OFFER' : 'WANTED' }}
+        </mj-section>
+        @endif
+
+        <mj-section background-color="#ffffff" padding="12px 20px">
+            <mj-column>
+                <mj-text padding="0" font-size="14px" color="#212529">
+                    <a id="msg-{{ $post['message']->id }}"></a>
+                    <table cellpadding="0" cellspacing="0" border="0" role="presentation" style="border-collapse: collapse; width: 100%;">
+                        {{-- Top row: image (rowspan) + title/description --}}
+                        <tr>
+                            <td rowspan="2" style="vertical-align: top; width: 120px; height: 120px; padding-right: 16px;">
+                                <a href="{{ $post['messageUrl'] }}">
+                                    <img src="{{ $post['trackedImageUrl'] }}" alt="{{ $post['itemName'] }}" width="120" height="120" style="display: block; width: 120px; height: 120px; object-fit: cover;" />
+                                </a>
+                            </td>
+                            <td style="vertical-align: top;">
+                                <table cellpadding="0" cellspacing="0" border="0" role="presentation" style="border-collapse: collapse; width: 100%;">
+                                    <tr>
+                                        <td style="vertical-align: top; width: 85px; padding-right: 8px;">
+                                            <span style="display: inline-block; background-color: {{ $isOffer ? $offerColor : $wantedColor }}; color: #ffffff; font-size: 13px; font-weight: bold; padding: 6px 11px; border-radius: 4px; line-height: 1;">{{ $isOffer ? 'OFFER' : 'WANTED' }}</span>
+                                        </td>
+                                        <td style="vertical-align: top;">
+                                            <a href="{{ $post['messageUrl'] }}" style="color: #212529; text-decoration: none; font-weight: 600; font-size: 15px; line-height: 1.4;">{{ $post['itemName'] }}</a>
+                                            @if($post['locationName'])
+                                            <br/><span style="color: #212529; font-size: 12px; font-weight: 500;">{{ $post['locationName'] }}</span>
+                                            @endif
+                                        </td>
+                                    </tr>
+                                    @if($post['messageText'] || $post['postedToText'])
+                                    <tr>
+                                        <td colspan="2" style="padding-top: 4px;">
+                                            @if($post['messageText'])
+                                            <span style="color: #808080; font-size: 13px; font-weight: 500; line-height: 1.4;">{{ \Illuminate\Support\Str::limit($post['messageText'], 100, '...') }}</span>
+                                            @endif
+                                            @if($post['postedToText'])
+                                            <br/><span style="color: #999999; font-size: 11px; font-style: italic;">{{ $post['postedToText'] }}</span>
+                                            @endif
+                                        </td>
+                                    </tr>
+                                    @endif
+                                </table>
+                            </td>
+                        </tr>
+                        {{-- Bottom row: reply button + time, aligned to bottom of image --}}
+                        <tr>
+                            <td style="vertical-align: bottom; padding-top: 6px;">
+                                <table cellpadding="0" cellspacing="0" border="0" role="presentation" style="border-collapse: collapse; width: 100%;">
+                                    <tr>
+                                        <td style="vertical-align: middle;">
+                                            <a href="{{ $post['messageUrl'] }}" style="display: inline-block; background-color: {{ $isOffer ? $offerColor : $wantedColor }}; color: #ffffff; font-size: 13px; font-weight: 600; padding: 6px 16px; border-radius: 4px; text-decoration: none;">Reply</a>
+                                        </td>
+                                        <td style="vertical-align: middle; text-align: right; color: #999999; font-size: 12px; white-space: nowrap;">
+                                            @if($post['distanceText'])<span style="margin-right: 8px;">{{ $post['distanceText'] }}</span>@endif{{ $post['arrivalFormatted'] }}
+                                        </td>
+                                    </tr>
+                                </table>
+                            </td>
+                        </tr>
+                    </table>
                 </mj-text>
-                <mj-text css-class="message-title">
-                    <a href="{{ $post['messageUrl'] }}">{{ $post['itemName'] }}</a>
-                </mj-text>
-                @if($post['messageText'])
-                <mj-text font-size="13px" color="#666666">
-                    {{ \Illuminate\Support\Str::limit($post['messageText'], 100) }}
-                </mj-text>
-                @endif
-                @if($post['postedToText'])
-                <mj-text css-class="posted-to">
-                    {{ $post['postedToText'] }}
-                </mj-text>
-                @endif
-                <mj-button href="{{ $post['messageUrl'] }}" align="left" padding="10px 0" mj-class="btn-success" border-radius="3px">
-                    View Post
-                </mj-button>
             </mj-column>
         </mj-section>
         @endforeach
 
-        <mj-section background-color="#ffffff" padding="20px">
+        {{-- Browse all CTA --}}
+        <mj-section background-color="#ffffff" padding="16px 20px 20px 20px">
             <mj-column>
-                <mj-button href="{{ $browseUrl }}" mj-class="btn-secondary" border-radius="3px">
+                <mj-divider border-color="#e9ecef" border-width="1px" padding="0 0 16px 0" />
+                <mj-button
+                    href="{{ $browseUrl }}"
+                    mj-class="btn-success"
+                    font-size="16px"
+                    inner-padding="12px 40px"
+                    border-radius="4px"
+                >
                     Browse All Posts
                 </mj-button>
             </mj-column>
         </mj-section>
 
-        @if($sponsors->isNotEmpty())
+        @if(isset($sponsors) && $sponsors->isNotEmpty())
         <mj-section background-color="#ffffff" padding="10px 20px">
             <mj-column>
                 <mj-divider border-color="#eeeeee" padding-bottom="5px" />
@@ -110,23 +166,10 @@
         @endforeach
         @endif
 
-        <mj-section background-color="#ffffff" padding="10px 20px">
-            <mj-column>
-                <mj-divider border-color="#eeeeee" />
-                <mj-text font-size="12px" color="#666666">
-                    You're receiving this because you're a member of Freegle. These emails are sent daily.
-                </mj-text>
-            </mj-column>
-        </mj-section>
-
-        @if(!empty($trackingPixelMjml))
-        <mj-section padding="0">
-            <mj-column>
-                {!! $trackingPixelMjml !!}
-            </mj-column>
-        </mj-section>
-        @endif
-
         @include('emails.mjml.partials.footer', ['email' => $user->email_preferred, 'settingsUrl' => $settingsUrl])
+
+        @if(isset($trackingPixelMjml))
+        {!! $trackingPixelMjml !!}
+        @endif
     </mj-body>
 </mjml>

--- a/iznik-batch/resources/views/emails/mjml/partials/footer.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/partials/footer.blade.php
@@ -2,8 +2,8 @@
   <mj-column>
     <mj-text font-size="12px" color="#666666" align="center" line-height="1.6">
       This email was sent{{ !empty($ampIncluded) ? ' with AMP' : '' }} to {{ $email }}<br/>
-      <a href="{{ $settingsUrl ?? config('freegle.sites.user') . '/settings' }}" style="color: #338808;">Change your email settings</a> &bull;
-      <a href="{{ $unsubscribeUrl ?? config('freegle.sites.user') . '/unsubscribe' }}" style="color: #338808;">Unsubscribe</a>
+      <a href="{{ $settingsUrl ?? config('freegle.sites.user') . '/settings' }}" style="color: #338808; font-weight: bold; text-decoration: none;">Change your email settings</a> &bull;
+      <a href="{{ $unsubscribeUrl ?? config('freegle.sites.user') . '/unsubscribe' }}" style="color: #338808; font-weight: bold; text-decoration: none;">Unsubscribe</a>
     </mj-text>
     <mj-divider border-color="#ddd" border-width="1px" padding="15px 40px"></mj-divider>
     <mj-text font-size="11px" color="#666666" align="center" line-height="1.5">

--- a/iznik-batch/resources/views/emails/text/digest/reply-notice.blade.php
+++ b/iznik-batch/resources/views/emails/text/digest/reply-notice.blade.php
@@ -1,0 +1,20 @@
+How to reply to posts on Freegle
+====================================
+
+Hi {{ $recipientName ?? 'there' }},
+
+It looks like you tried to reply to a digest email. Digest emails contain multiple posts from your Freegle communities, so we can't tell which post you'd like to reply to.
+
+To reply to a specific post, please use the "Reply" button next to the post you're interested in. This will open a conversation with the person who posted it.
+
+Browse posts: {{ $browseUrl }}
+
+You can also change how you receive emails in your settings: {{ $settingsUrl }}
+
+------------------------------------
+
+{{ config('freegle.branding.name') }} - Don't throw it away, give it away!
+{{ config('freegle.sites.user') }}
+
+{{ config('freegle.branding.name') }} is registered as a charity with HMRC (ref. XT32865) and is run by volunteers.
+Registered address: Weaver's Field, Loud Bridge, Chipping PR3 2NX

--- a/iznik-batch/tests/Unit/Mail/DigestReplyNoticeTest.php
+++ b/iznik-batch/tests/Unit/Mail/DigestReplyNoticeTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Unit\Mail;
+
+use App\Mail\Digest\DigestReplyNotice;
+use Tests\TestCase;
+
+class DigestReplyNoticeTest extends TestCase
+{
+    public function test_can_be_constructed(): void
+    {
+        $mail = new DigestReplyNotice('test@example.com', 'Test User', 12345);
+
+        $this->assertInstanceOf(DigestReplyNotice::class, $mail);
+    }
+
+    public function test_build_returns_self(): void
+    {
+        $mail = new DigestReplyNotice('test@example.com', 'Test User', 12345);
+        $result = $mail->build();
+
+        $this->assertInstanceOf(DigestReplyNotice::class, $result);
+    }
+
+    public function test_has_correct_subject(): void
+    {
+        $mail = new DigestReplyNotice('test@example.com');
+        $envelope = $mail->envelope();
+
+        $this->assertEquals('How to reply to posts on Freegle', $envelope->subject);
+    }
+
+    public function test_can_construct_without_name_or_userid(): void
+    {
+        $mail = new DigestReplyNotice('test@example.com');
+        $result = $mail->build();
+
+        $this->assertInstanceOf(DigestReplyNotice::class, $result);
+    }
+
+    public function test_tracking_initialised(): void
+    {
+        $mail = new DigestReplyNotice('test@example.com', 'Test User', 12345);
+
+        $tracking = $mail->getTracking();
+        $this->assertNotNull($tracking);
+        $this->assertEquals('DigestReplyNotice', $tracking->email_type);
+    }
+}

--- a/iznik-batch/tests/Unit/Mail/UnifiedDigestTest.php
+++ b/iznik-batch/tests/Unit/Mail/UnifiedDigestTest.php
@@ -1,0 +1,205 @@
+<?php
+
+namespace Tests\Unit\Mail;
+
+use App\Mail\Digest\UnifiedDigest;
+use App\Services\UnifiedDigestService;
+use Tests\TestCase;
+
+class UnifiedDigestTest extends TestCase
+{
+    public function test_can_be_constructed(): void
+    {
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $this->createMembership($user, $group);
+
+        $poster = $this->createTestUser();
+        $this->createMembership($poster, $group);
+        $message = $this->createTestMessage($poster, $group, [
+            'subject' => 'OFFER: Sofa (London)',
+        ]);
+
+        $posts = collect([
+            ['message' => $message, 'postedToGroups' => [$group->id]],
+        ]);
+
+        $mail = new UnifiedDigest($user, $posts, UnifiedDigestService::MODE_DAILY);
+
+        $this->assertInstanceOf(UnifiedDigest::class, $mail);
+    }
+
+    public function test_build_returns_self(): void
+    {
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $this->createMembership($user, $group);
+
+        $poster = $this->createTestUser();
+        $this->createMembership($poster, $group);
+        $message = $this->createTestMessage($poster, $group, [
+            'subject' => 'OFFER: Sofa (London)',
+        ]);
+
+        $posts = collect([
+            ['message' => $message, 'postedToGroups' => [$group->id]],
+        ]);
+
+        $mail = new UnifiedDigest($user, $posts, UnifiedDigestService::MODE_DAILY);
+        $result = $mail->build();
+
+        $this->assertInstanceOf(UnifiedDigest::class, $result);
+    }
+
+    public function test_subject_with_single_post(): void
+    {
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $this->createMembership($user, $group);
+
+        $poster = $this->createTestUser();
+        $this->createMembership($poster, $group);
+        $message = $this->createTestMessage($poster, $group, [
+            'subject' => 'OFFER: Sofa (London)',
+        ]);
+
+        $posts = collect([
+            ['message' => $message, 'postedToGroups' => [$group->id]],
+        ]);
+
+        $mail = new UnifiedDigest($user, $posts, UnifiedDigestService::MODE_DAILY);
+        $envelope = $mail->envelope();
+
+        $this->assertEquals('1 new post near you - Sofa', $envelope->subject);
+    }
+
+    public function test_subject_with_multiple_posts(): void
+    {
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $this->createMembership($user, $group);
+
+        $poster = $this->createTestUser();
+        $this->createMembership($poster, $group);
+
+        $msg1 = $this->createTestMessage($poster, $group, ['subject' => 'OFFER: Sofa (London)']);
+        $msg2 = $this->createTestMessage($poster, $group, ['subject' => 'WANTED: Table (London)']);
+        $msg3 = $this->createTestMessage($poster, $group, ['subject' => 'OFFER: Books (London)']);
+
+        $posts = collect([
+            ['message' => $msg1, 'postedToGroups' => [$group->id]],
+            ['message' => $msg2, 'postedToGroups' => [$group->id]],
+            ['message' => $msg3, 'postedToGroups' => [$group->id]],
+        ]);
+
+        $mail = new UnifiedDigest($user, $posts, UnifiedDigestService::MODE_DAILY);
+        $envelope = $mail->envelope();
+
+        $this->assertStringStartsWith('3 new posts near you', $envelope->subject);
+        $this->assertStringContainsString('Sofa', $envelope->subject);
+    }
+
+    public function test_tracked_urls_contain_post_positions(): void
+    {
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $this->createMembership($user, $group);
+
+        $poster = $this->createTestUser();
+        $this->createMembership($poster, $group);
+
+        $msg1 = $this->createTestMessage($poster, $group, ['subject' => 'OFFER: Sofa (London)']);
+        $msg2 = $this->createTestMessage($poster, $group, ['subject' => 'OFFER: Table (London)']);
+
+        $posts = collect([
+            ['message' => $msg1, 'postedToGroups' => [$group->id]],
+            ['message' => $msg2, 'postedToGroups' => [$group->id]],
+        ]);
+
+        $mail = new UnifiedDigest($user, $posts, UnifiedDigestService::MODE_DAILY);
+        $mail->build();
+
+        // Verify tracking was initialised with correct metadata.
+        $tracking = $mail->getTracking();
+        $this->assertNotNull($tracking);
+        $this->assertEquals('UnifiedDigest', $tracking->email_type);
+    }
+
+    public function test_cross_post_text_shown_for_multiple_groups(): void
+    {
+        $user = $this->createTestUser();
+        $group1 = $this->createTestGroup();
+        $group2 = $this->createTestGroup();
+        $this->createMembership($user, $group1);
+        $this->createMembership($user, $group2);
+
+        $poster = $this->createTestUser();
+        $this->createMembership($poster, $group1);
+        $this->createMembership($poster, $group2);
+
+        $message = $this->createTestMessage($poster, $group1, [
+            'subject' => 'OFFER: Sofa (London)',
+        ]);
+
+        $posts = collect([
+            ['message' => $message, 'postedToGroups' => [$group1->id, $group2->id]],
+        ]);
+
+        $mail = new UnifiedDigest($user, $posts, UnifiedDigestService::MODE_DAILY);
+        $mail->build();
+
+        // The mail was built successfully with cross-post data.
+        $this->assertInstanceOf(UnifiedDigest::class, $mail);
+    }
+
+    public function test_tracking_metadata_contains_mode_and_count(): void
+    {
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $this->createMembership($user, $group);
+
+        $poster = $this->createTestUser();
+        $this->createMembership($poster, $group);
+        $message = $this->createTestMessage($poster, $group);
+
+        $posts = collect([
+            ['message' => $message, 'postedToGroups' => [$group->id]],
+        ]);
+
+        $mail = new UnifiedDigest($user, $posts, UnifiedDigestService::MODE_DAILY);
+
+        $tracking = $mail->getTracking();
+        $this->assertNotNull($tracking);
+
+        $metadata = $tracking->metadata;
+        $this->assertEquals('daily', $metadata['mode']);
+        $this->assertEquals(1, $metadata['post_count']);
+        $this->assertArrayHasKey('digest_number', $metadata);
+    }
+
+    public function test_amp_content_excluded_when_disabled(): void
+    {
+        // Force AMP off via config before constructing the mailable.
+        config(['freegle.amp.enabled' => false]);
+        config(['freegle.amp.secret' => '']);
+
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $this->createMembership($user, $group);
+
+        $poster = $this->createTestUser();
+        $this->createMembership($poster, $group);
+        $message = $this->createTestMessage($poster, $group);
+
+        $posts = collect([
+            ['message' => $message, 'postedToGroups' => [$group->id]],
+        ]);
+
+        $mail = new UnifiedDigest($user, $posts, UnifiedDigestService::MODE_DAILY);
+        $mail->build();
+
+        // Verify tracking does not indicate AMP.
+        $tracking = $mail->getTracking();
+        $this->assertFalse($tracking->has_amp);
+    }
+}

--- a/iznik-batch/tests/Unit/Models/GroupModelTest.php
+++ b/iznik-batch/tests/Unit/Models/GroupModelTest.php
@@ -272,13 +272,6 @@ class GroupModelTest extends TestCase
         $this->assertEquals('Other', Group::TYPE_OTHER);
     }
 
-    public function test_digests_relationship(): void
-    {
-        $group = $this->createTestGroup();
-
-        $this->assertEquals(0, $group->digests()->count());
-    }
-
     public function test_messages_relationship(): void
     {
         $group = $this->createTestGroup();

--- a/iznik-batch/tests/Unit/Services/Mail/Incoming/MailParserServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/Mail/Incoming/MailParserServiceTest.php
@@ -472,6 +472,52 @@ class MailParserServiceTest extends TestCase
     }
 
     // ========================================
+    // Digest Reply Detection Tests
+    // ========================================
+
+    public function test_parse_detects_digest_reply_to_noreply_address(): void
+    {
+        $noreplyAddr = config('freegle.mail.noreply_addr');
+
+        $rawEmail = $this->createMinimalEmail([
+            'From' => 'user@example.com',
+            'To' => $noreplyAddr,
+            'Subject' => 'Re: 5 new posts near you - Sofa, Table',
+        ], 'Thanks for the digest!');
+
+        $parsed = $this->parser->parse($rawEmail, 'user@example.com', $noreplyAddr);
+
+        $this->assertTrue($parsed->isDigestReply());
+    }
+
+    public function test_parse_detects_digest_reply_via_in_reply_to_header(): void
+    {
+        $rawEmail = $this->createMinimalEmail([
+            'From' => 'user@example.com',
+            'To' => 'someaddress@example.com',
+            'Subject' => 'Re: 3 new posts near you',
+            'In-Reply-To' => '<UnifiedDigest-12345-67890@ilovefreegle.org>',
+        ], 'I want the sofa!');
+
+        $parsed = $this->parser->parse($rawEmail, 'user@example.com', 'someaddress@example.com');
+
+        $this->assertTrue($parsed->isDigestReply());
+    }
+
+    public function test_parse_non_digest_email_not_flagged_as_digest_reply(): void
+    {
+        $rawEmail = $this->createMinimalEmail([
+            'From' => 'user@example.com',
+            'To' => 'testgroup@groups.ilovefreegle.org',
+            'Subject' => 'OFFER: Sofa (London)',
+        ], 'Free sofa available.');
+
+        $parsed = $this->parser->parse($rawEmail, 'user@example.com', 'testgroup@groups.ilovefreegle.org');
+
+        $this->assertFalse($parsed->isDigestReply());
+    }
+
+    // ========================================
     // Helper Methods
     // ========================================
 

--- a/iznik-batch/tests/Unit/Services/PostcodeRemapServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/PostcodeRemapServiceTest.php
@@ -328,8 +328,8 @@ class PostcodeRemapServiceTest extends TestCase
         // Now mark the first area as excluded.
         DB::table('locations_excluded')->insert([
             'locationid' => $excludedId,
-            'groupid' => 1,
-            'userid' => 1,
+            'groupid' => null,
+            'userid' => null,
         ]);
 
         try {
@@ -408,8 +408,8 @@ class PostcodeRemapServiceTest extends TestCase
 
         DB::table('locations_excluded')->insert([
             'locationid' => $excludedId,
-            'groupid' => 1,
-            'userid' => 1,
+            'groupid' => null,
+            'userid' => null,
         ]);
 
         // Seed PG with only the replacement area (excluded area is filtered out by sync).

--- a/iznik-batch/tests/Unit/Services/UnifiedDigestServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/UnifiedDigestServiceTest.php
@@ -173,6 +173,87 @@ class UnifiedDigestServiceTest extends TestCase
         $this->assertEquals(0, $stats['emails_sent']);
     }
 
+    public function test_deduplication_same_subject_different_body_not_deduped(): void
+    {
+        $user = $this->createTestUser();
+        $group1 = $this->createTestGroup();
+        $group2 = $this->createTestGroup();
+
+        // Two messages with same subject but different body text.
+        $message1 = $this->createTestMessage($user, $group1, [
+            'subject' => 'OFFER: Garden tools (London)',
+            'textbody' => 'I have a spade and a fork available for collection.',
+        ]);
+        $message2 = $this->createTestMessage($user, $group2, [
+            'subject' => 'OFFER: Garden tools (London)',
+            'textbody' => 'Lawnmower available, needs collecting this weekend.',
+        ]);
+
+        $message1->groupid = $group1->id;
+        $message2->groupid = $group2->id;
+
+        $posts = collect([$message1, $message2]);
+        $deduplicated = $this->service->deduplicatePosts($posts);
+
+        // Should NOT be deduplicated because bodies are different.
+        $this->assertCount(2, $deduplicated);
+    }
+
+    public function test_deduplication_same_subject_same_body_deduped(): void
+    {
+        $user = $this->createTestUser();
+        $group1 = $this->createTestGroup();
+        $group2 = $this->createTestGroup();
+
+        $bodyText = 'I have a lovely sofa available for collection.';
+
+        // Two messages with same subject AND same body.
+        $message1 = $this->createTestMessage($user, $group1, [
+            'subject' => 'OFFER: Sofa (London)',
+            'textbody' => $bodyText,
+        ]);
+        $message2 = $this->createTestMessage($user, $group2, [
+            'subject' => 'OFFER: Sofa (London)',
+            'textbody' => $bodyText,
+        ]);
+
+        $message1->groupid = $group1->id;
+        $message2->groupid = $group2->id;
+
+        $posts = collect([$message1, $message2]);
+        $deduplicated = $this->service->deduplicatePosts($posts);
+
+        // Should be deduplicated because both subject and body match.
+        $this->assertCount(1, $deduplicated);
+        $this->assertCount(2, $deduplicated->first()['postedToGroups']);
+    }
+
+    public function test_deduplication_null_body_treated_as_matching(): void
+    {
+        $user = $this->createTestUser();
+        $group1 = $this->createTestGroup();
+        $group2 = $this->createTestGroup();
+
+        // Two messages with same subject and both null bodies.
+        $message1 = $this->createTestMessage($user, $group1, [
+            'subject' => 'OFFER: Table (London)',
+            'textbody' => null,
+        ]);
+        $message2 = $this->createTestMessage($user, $group2, [
+            'subject' => 'OFFER: Table (London)',
+            'textbody' => null,
+        ]);
+
+        $message1->groupid = $group1->id;
+        $message2->groupid = $group2->id;
+
+        $posts = collect([$message1, $message2]);
+        $deduplicated = $this->service->deduplicatePosts($posts);
+
+        // Should be deduplicated - null bodies both normalize to ''.
+        $this->assertCount(1, $deduplicated);
+    }
+
     public function test_sponsors_are_included_and_deduplicated(): void
     {
         $poster = $this->createTestUser();
@@ -287,43 +368,6 @@ class UnifiedDigestServiceTest extends TestCase
 
         $sponsors = $this->service->getSponsorsForUser($user);
         $this->assertCount(0, $sponsors);
-    }
-
-    public function test_deduplication_with_same_message_on_multiple_groups(): void
-    {
-        // Multi-group model: same messages.id has two messages_groups rows.
-        // The digest query joins messages with messages_groups, so the same message
-        // appears twice with different groupids. deduplicatePosts should merge them.
-        $user = $this->createTestUser();
-        $group1 = $this->createTestGroup();
-        $group2 = $this->createTestGroup();
-
-        $message = $this->createTestMessage($user, $group1, [
-            'subject' => 'OFFER: Multi-Group Item (TestTown)',
-        ]);
-
-        // Add the same message to a second group (simulating the multi-group model).
-        DB::table('messages_groups')->insert([
-            'msgid' => $message->id,
-            'groupid' => $group2->id,
-            'collection' => 'Approved',
-            'arrival' => now(),
-        ]);
-
-        // Simulate what getPostsForUser returns: two rows for the same message
-        // with different groupid attributes (from the join).
-        $row1 = clone $message;
-        $row1->groupid = $group1->id;
-        $row2 = clone $message;
-        $row2->groupid = $group2->id;
-
-        $posts = collect([$row1, $row2]);
-        $deduplicated = $this->service->deduplicatePosts($posts);
-
-        $this->assertCount(1, $deduplicated, 'Same message on two groups should deduplicate to one');
-        $this->assertCount(2, $deduplicated->first()['postedToGroups'], 'Both groups should be in postedToGroups');
-        $this->assertContains($group1->id, $deduplicated->first()['postedToGroups']);
-        $this->assertContains($group2->id, $deduplicated->first()['postedToGroups']);
     }
 
     public function test_immediate_mode_requires_full_setting(): void

--- a/iznik-batch/tests/Unit/Traits/LogsBatchJobTest.php
+++ b/iznik-batch/tests/Unit/Traits/LogsBatchJobTest.php
@@ -99,10 +99,10 @@ class LogsBatchJobTest extends TestCase
     public function test_extracts_job_name_from_signature(): void
     {
         $this->lokiMock->shouldReceive('logBatchJob')
-            ->with('mail:digest', 'started', Mockery::any());
+            ->with('mail:digest:unified', 'started', Mockery::any());
 
         $this->lokiMock->shouldReceive('logBatchJob')
-            ->with('mail:digest', 'completed', Mockery::any());
+            ->with('mail:digest:unified', 'completed', Mockery::any());
 
         $command = new TestCommandWithComplexSignature();
         $command->setLaravel($this->app);
@@ -171,9 +171,9 @@ class TestCommandWithComplexSignature extends Command
 {
     use LogsBatchJob;
 
-    protected $signature = 'mail:digest
-                            {frequency : Digest frequency}
-                            {--mod=1 : Modulo divisor}';
+    protected $signature = 'mail:digest:unified
+                            {--mode=daily : Digest mode}
+                            {--limit=1000 : Max users}';
 
     public function handle(): int
     {

--- a/iznik-nuxt3/tests/e2e/fixtures.js
+++ b/iznik-nuxt3/tests/e2e/fixtures.js
@@ -1530,7 +1530,7 @@ const testWithFixtures = test.extend({
         // Load My Posts page from scratch
         await page.goto('/myposts', {
           timeout: timeouts.navigation.default,
-          waitUntil: 'load',
+          waitUntil: 'domcontentloaded',
         })
 
         // Find the post we want to withdraw.


### PR DESCRIPTION
## Summary

- Add `DigestReplyNotice` mailable with MJML/AMP templates: auto-response when users reply to a digest email, explaining how to reply to specific posts instead
- Handle digest replies in `IncomingMailService` and `MailParserService`: detect `X-Freegle-Email-Type: UnifiedDigest` header and dispatch reply notice  
- `UnifiedDigest`: add `digest_number` to tracking metadata; store sent digests in `users_digests` table for reply-to correlation
- `UnifiedDigestService`: body-similarity deduplication (`bodiesMatch()` + `normalizeBody()` helpers)
- Add AMP template for unified digest (`emails/amp/digest/unified.blade.php`)
- Add MJML template for reply notice (`emails/mjml/digest/reply-notice.blade.php`)

## Code Quality Review

- Follows existing `MjmlMailable` + `TrackableEmail` pattern
- Uses `X-Freegle-Email-Type` header for reply detection (consistent with existing email tracking)
- Body deduplication uses normalized text comparison, not hash-based

## Test Plan

- [ ] `DigestReplyNoticeTest` — unit tests for the reply notice mailable
- [ ] `MailParserServiceTest` — tests for digest reply detection via email headers
- [ ] `UnifiedDigestServiceTest` — tests for body deduplication helpers
- [ ] `UnifiedDigestTest` — tests for tracking metadata and digest_number
- [ ] All existing Laravel tests continue to pass