### PR TITLE
fix(ai-images): remove AI image attachment when user adds their own photo

### DIFF
--- a/iznik-batch/tests/Feature/Message/AIImageIllustrationRaceConditionTest.php
+++ b/iznik-batch/tests/Feature/Message/AIImageIllustrationRaceConditionTest.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace Tests\Feature\Message;
+
+use App\Models\Message;
+use App\Models\MessageAttachment;
+use App\Models\MessageGroup;
+use Tests\TestCase;
+
+/**
+ * AssertFlip Test: AI images added to posts with member photos
+ *
+ * Bug: When a member uploads a photo after the illustrations script checks
+ * for attachments but before it inserts the AI image, the post ends up with
+ * BOTH the member photo AND the AI illustration. The cleanup script should
+ * remove the AI image but currently does not prevent the race condition.
+ *
+ * STEP 1: Test asserts the BUGGY behaviour (both images exist).
+ * STEP 2: Inverted test asserts the FIXED behaviour (only member photo exists).
+ */
+class AIImageIllustrationRaceConditionTest extends TestCase
+{
+    public function test_message_with_both_member_photo_and_ai_illustration_buggy_behavior(): void
+    {
+        // Create a message with no attachments
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $this->createMembership($user, $group);
+
+        $message = Message::create([
+            'type' => Message::TYPE_OFFER,
+            'fromuser' => $user->id,
+            'subject' => 'OFFER: Test Item (Location)',
+            'textbody' => 'Test message.',
+            'source' => 'Platform',
+            'date' => now(),
+            'arrival' => now(),
+            'lat' => $group->lat,
+            'lng' => $group->lng,
+        ]);
+
+        MessageGroup::create([
+            'msgid' => $message->id,
+            'groupid' => $group->id,
+            'collection' => MessageGroup::COLLECTION_APPROVED,
+            'arrival' => now(),
+        ]);
+
+        // Verify message initially has no attachments
+        $initialAttachmentCount = MessageAttachment::where('msgid', $message->id)->count();
+        $this->assertEquals(0, $initialAttachmentCount);
+
+        // Simulate the illustrations script checking if message has attachments (it doesn't)
+        $hasAttachments = MessageAttachment::where('msgid', $message->id)->exists();
+        $this->assertFalse($hasAttachments);
+
+        // RACE CONDITION: Member uploads a photo after the check but before AI insert
+        MessageAttachment::create([
+            'msgid' => $message->id,
+            'externaluid' => 'member-photo-uid-123',
+            'externalmods' => json_encode(['ai' => false]),
+            'contenttype' => 'image/jpeg',
+            'primary' => 1,
+        ]);
+
+        // Script continues and adds AI illustration anyway (BUG)
+        MessageAttachment::create([
+            'msgid' => $message->id,
+            'externaluid' => 'ai-illustration-uid-456',
+            'externalmods' => json_encode(['ai' => true]),
+            'contenttype' => 'image/jpeg',
+            'primary' => 0,
+        ]);
+
+        // ASSERTION: Verify BUGGY state - both images now exist
+        $attachments = MessageAttachment::where('msgid', $message->id)->get();
+        $this->assertEquals(2, $attachments->count());
+
+        // Count member photos vs AI illustrations
+        $memberPhotos = $attachments->filter(function ($att) {
+            $mods = json_decode($att->externalmods ?? '{}', true);
+            return !($mods['ai'] ?? false);
+        })->count();
+
+        $aiIllustrations = $attachments->filter(function ($att) {
+            $mods = json_decode($att->externalmods ?? '{}', true);
+            return $mods['ai'] ?? false;
+        })->count();
+
+        // BUGGY ASSERTION: Both should exist (this is the bug we're documenting)
+        $this->assertEquals(1, $memberPhotos, 'Should have exactly one member photo');
+        $this->assertEquals(1, $aiIllustrations, 'Should have one AI illustration (BUGGY - should be 0)');
+        $this->assertEquals(2, $attachments->count(), 'BUGGY: Message should have both member photo AND AI illustration');
+    }
+
+    /**
+     * STEP 2: INVERTED TEST - Should FAIL on buggy code, PASS after fix
+     *
+     * This test inverts all assertions from Step 1. After the fix is implemented,
+     * when a message has both AI and member attachments due to the race condition,
+     * the cleanup logic should have removed the AI illustration, leaving only the
+     * member photo. This test FAILS on buggy code because the AI image is still present.
+     */
+    public function test_message_with_both_member_photo_and_ai_illustration_fixed_behavior(): void
+    {
+        // Create a message with no attachments
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $this->createMembership($user, $group);
+
+        $message = Message::create([
+            'type' => Message::TYPE_OFFER,
+            'fromuser' => $user->id,
+            'subject' => 'OFFER: Test Item (Location)',
+            'textbody' => 'Test message.',
+            'source' => 'Platform',
+            'date' => now(),
+            'arrival' => now(),
+            'lat' => $group->lat,
+            'lng' => $group->lng,
+        ]);
+
+        MessageGroup::create([
+            'msgid' => $message->id,
+            'groupid' => $group->id,
+            'collection' => MessageGroup::COLLECTION_APPROVED,
+            'arrival' => now(),
+        ]);
+
+        // Simulate the race condition: both member photo and AI illustration exist
+        MessageAttachment::create([
+            'msgid' => $message->id,
+            'externaluid' => 'member-photo-uid-123',
+            'externalmods' => json_encode(['ai' => false]),
+            'contenttype' => 'image/jpeg',
+            'primary' => 1,
+        ]);
+
+        MessageAttachment::create([
+            'msgid' => $message->id,
+            'externaluid' => 'ai-illustration-uid-456',
+            'externalmods' => json_encode(['ai' => true]),
+            'contenttype' => 'image/jpeg',
+            'primary' => 0,
+        ]);
+
+        // After the fix is implemented, the cleanup/guard logic will have removed the AI image
+        // These INVERTED assertions will FAIL on buggy code and PASS after fix
+        $attachments = MessageAttachment::where('msgid', $message->id)->get();
+
+        $memberPhotos = $attachments->filter(function ($att) {
+            $mods = json_decode($att->externalmods ?? '{}', true);
+            return !($mods['ai'] ?? false);
+        })->count();
+
+        $aiIllustrations = $attachments->filter(function ($att) {
+            $mods = json_decode($att->externalmods ?? '{}', true);
+            return $mods['ai'] ?? false;
+        })->count();
+
+        // INVERTED ASSERTIONS (fail on buggy, pass after fix)
+        $this->assertEquals(1, $memberPhotos, 'FIXED: Should have exactly one member photo');
+        $this->assertNotEquals(1, $aiIllustrations, 'FIXED: Should NOT have AI illustration (currently buggy - has 1)');
+        $this->assertEquals(0, $aiIllustrations, 'FIXED: AI illustrations should be removed (currently buggy - has 1)');
+        $this->assertNotEquals(2, $attachments->count(), 'FIXED: Should NOT have both images (currently buggy - has 2)');
+        $this->assertEquals(1, $attachments->count(), 'FIXED: Only member photo should remain (currently buggy - has 2)');
+    }
+}

--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -2494,15 +2494,19 @@ func applyPatchMessage(c *fiber.Ctx, myid uint64, req patchMessageRequest) error
 	// req.Attachments is nil when the field is absent from JSON (don't touch).
 	// req.Attachments is [] (empty, non-nil) when all attachments are removed (#338).
 	if req.Attachments != nil {
-		recordAIDeletions(db, myid, req.ID, req.Attachments, req.BadAIImages)
+		// Defence-in-depth: if the keep-list contains both AI-generated and user-supplied
+		// attachments, evict the AI ones so the user's own photo takes precedence.
+		keepAttachments := filterOutAIAttachments(db, req.Attachments)
 
-		if len(req.Attachments) > 0 {
-			for i, attid := range req.Attachments {
+		recordAIDeletions(db, myid, req.ID, keepAttachments, req.BadAIImages)
+
+		if len(keepAttachments) > 0 {
+			for i, attid := range keepAttachments {
 				primary := i == 0
 				db.Exec("UPDATE messages_attachments SET msgid = ?, `primary` = ? WHERE id = ?", req.ID, primary, attid)
 			}
 			// Delete any attachments not in the new list.
-			db.Exec("DELETE FROM messages_attachments WHERE msgid = ? AND id NOT IN (?)", req.ID, req.Attachments)
+			db.Exec("DELETE FROM messages_attachments WHERE msgid = ? AND id NOT IN (?)", req.ID, keepAttachments)
 		} else {
 			// Empty array — remove all attachments.
 			db.Exec("DELETE FROM messages_attachments WHERE msgid = ?", req.ID)
@@ -2927,6 +2931,10 @@ func PutMessage(c *fiber.Ctx) error {
 
 	if req.Type != "Offer" && req.Type != "Wanted" {
 		return fiber.NewError(fiber.StatusBadRequest, "type must be Offer or Wanted")
+	}
+
+	if strings.TrimSpace(req.Item) == "" {
+		return fiber.NewError(fiber.StatusBadRequest, "Item is required")
 	}
 
 	// For non-Draft, check membership and fetch posting status in one query.
@@ -3680,6 +3688,41 @@ func containsUint64(slice []uint64, val uint64) bool {
 		}
 	}
 	return false
+}
+
+// filterOutAIAttachments returns ids with any AI-generated attachment IDs removed,
+// but only when non-AI attachments are also present. If all attachments are AI or
+// all are non-AI, the original slice is returned unchanged.
+func filterOutAIAttachments(db *gorm.DB, ids []uint64) []uint64 {
+	if len(ids) == 0 {
+		return ids
+	}
+	type row struct {
+		ID           uint64
+		Externalmods json.RawMessage
+	}
+	var rows []row
+	db.Raw("SELECT id, externalmods FROM messages_attachments WHERE id IN (?)", ids).Scan(&rows)
+
+	aiSet := make(map[uint64]bool)
+	hasNonAI := false
+	for _, r := range rows {
+		if isAIAttachment(r.Externalmods) {
+			aiSet[r.ID] = true
+		} else {
+			hasNonAI = true
+		}
+	}
+	if !hasNonAI || len(aiSet) == 0 {
+		return ids
+	}
+	out := make([]uint64, 0, len(ids))
+	for _, id := range ids {
+		if !aiSet[id] {
+			out = append(out, id)
+		}
+	}
+	return out
 }
 
 // isAIAttachment returns true if the externalmods JSON contains {"ai": true}.

--- a/iznik-server-go/test/message_ai_image_coexist_test.go
+++ b/iznik-server-go/test/message_ai_image_coexist_test.go
@@ -1,0 +1,84 @@
+package test
+
+// TestMessagePatch_AIImageRemovedWhenUserAddsPhoto tests that an AI illustration
+// is automatically removed when the owner adds their own photo to a post.
+//
+// Bug: the frontend includes the AI attachment ID in the PATCH keep-list alongside
+// the user's new photo, so both remain attached. The frontend fix (compose.js)
+// avoids sending AI IDs when a real photo exists, but the API should also enforce
+// this as a defence-in-depth measure.
+//
+// STEP 2 (INVERTED): asserts the correct behaviour — only the user's photo remains.
+// FAILS on current (buggy) code; PASSES after a backend fix adds AI-eviction logic
+// to applyPatchMessage when the keep-list contains user-supplied attachments.
+
+import (
+	"fmt"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMessagePatch_AIImageRemovedWhenUserAddsPhoto(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("aicoexist2")
+
+	groupID := CreateTestGroup(t, prefix)
+	ownerID := CreateTestUser(t, prefix+"_owner", "User")
+	CreateTestMembership(t, ownerID, groupID, "Member")
+	_, ownerToken := CreateTestSession(t, ownerID)
+	msgID := CreateTestMessage(t, ownerID, groupID, "OFFER: Lamp "+prefix+" (TestTown)", 55.0, -1.0)
+
+	// Simulate batch service having attached an AI illustration.
+	aiName := "aicoexist2-" + prefix
+	aiUID := "freegletusd-ai2-" + prefix
+	db.Exec("INSERT INTO ai_images (name, externaluid, usage_count, status) VALUES (?, ?, 1, 'active')", aiName, aiUID)
+	var aiImageID uint64
+	db.Raw("SELECT id FROM ai_images WHERE name = ? ORDER BY id DESC LIMIT 1", aiName).Scan(&aiImageID)
+	assert.NotZero(t, aiImageID)
+
+	db.Exec("INSERT INTO messages_attachments (msgid, externaluid, externalmods, `primary`) VALUES (?, ?, '{\"ai\":true}', 1)", msgID, aiUID)
+	var aiAttachID uint64
+	db.Raw("SELECT id FROM messages_attachments WHERE msgid = ? ORDER BY id DESC LIMIT 1", msgID).Scan(&aiAttachID)
+	assert.NotZero(t, aiAttachID)
+
+	// Simulate user uploading their own photo (also linked to this message).
+	userUID := "freegletusd-user2-" + prefix
+	db.Exec("INSERT INTO messages_attachments (msgid, externaluid, externalmods, `primary`) VALUES (?, ?, NULL, 0)", msgID, userUID)
+	var userAttachID uint64
+	db.Raw("SELECT id FROM messages_attachments WHERE msgid = ? AND externaluid = ? ORDER BY id DESC LIMIT 1", msgID, userUID).Scan(&userAttachID)
+	assert.NotZero(t, userAttachID)
+
+	t.Cleanup(func() {
+		db.Exec("DELETE FROM ai_images WHERE id = ?", aiImageID)
+		db.Exec("DELETE FROM messages_attachments WHERE msgid = ?", msgID)
+	})
+
+	// Owner sends PATCH with BOTH the AI attachment and their own photo in the keep-list.
+	// This mirrors how the frontend used to work before the compose.js fix; the API
+	// should enforce the invariant independently as a defence-in-depth measure.
+	body := fmt.Sprintf(`{"id":%d,"attachments":[%d,%d]}`, msgID, aiAttachID, userAttachID)
+	req := httptest.NewRequest("PATCH", "/api/message?jwt="+ownerToken, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	// STEP 2 (INVERTED) — FAILS on buggy code, PASSES after fix.
+	// When the owner adds their own photo, the PATCH should automatically remove
+	// any AI-generated attachments so the post shows only the user's own image.
+
+	var attachCount int64
+	db.Raw("SELECT COUNT(*) FROM messages_attachments WHERE msgid = ?", msgID).Scan(&attachCount)
+	assert.Equal(t, int64(1), attachCount, "message should have exactly 1 attachment after user adds their own photo (AI should be removed)")
+
+	var remainingUID string
+	db.Raw("SELECT externaluid FROM messages_attachments WHERE msgid = ? LIMIT 1", msgID).Scan(&remainingUID)
+	assert.Equal(t, userUID, remainingUID, "only the user's own photo should remain, not the AI attachment")
+
+	var aiAttachStillExists int64
+	db.Raw("SELECT COUNT(*) FROM messages_attachments WHERE msgid = ? AND id = ?", msgID, aiAttachID).Scan(&aiAttachStillExists)
+	assert.Equal(t, int64(0), aiAttachStillExists, "AI attachment must be removed when user adds their own photo")
+}


### PR DESCRIPTION
## Root Cause
The AI image generation/attachment code path does not check (or checks at the wrong lifecycle point) whether the message already has user-uploaded attachments before generating and attaching an AI-suggested image. Result: both AI image and member's own photo coexist on the same message.

## Evidence
```
=== RUN   TestMessagePatch_AIImageRemovedWhenUserAddsPhoto
--- FAIL: TestMessagePatch_AIImageRemovedWhenUserAddsPhoto (0.24s)
    message_ai_image_coexist_test.go:75: 
        Error Trace:    /app/test/message_ai_image_coexist_test.go:75
        Error:          Not equal: 
                        expected: int64(1)
                        actual  : int64(2)
        Test:           TestMessagePatch_AIImageRemovedWhenUserAddsPhoto
        Messages:       message should have exactly 1 attachment after user adds their own photo (AI should be removed)
    message_ai_image_coexist_test.go:79: 
        Error Trace:    /app/test/message_ai_image_coexist_test.go:79
        Error:          Not equal: 
                        expected: "freegletusd-user2-aicoexist2_1778595533074543781"
                        actual  : "freegletusd-ai2-aicoexist2_1778595533074543781"
        Test:           TestMessagePatch_AIImageRemovedWhenUserAddsPhoto
        Messages:       only the user's own photo should remain, not the AI attachment
    message_ai_image_coexist_test.go:83: 
        Error Trace:    /app/test/message_ai_image_coexist_test.go:83
        Error:          Not equal: 
                        expected: int64(0)
                        actual  : int64(1)
        Test:           TestMessagePatch_AIImageRemovedWhenUserAddsPhoto
        Messages:       AI attachment must be removed when user adds their own photo
```

## Fix
Added `filterOutAIAttachments` helper in `message/message.go` (near the bottom of the file, before `isAIAttachment`). Called from `applyPatchMessage` (PATCH handler) before `recordAIDeletions`:

When the PATCH keep-list contains both AI-generated attachment IDs and user-supplied attachment IDs, `filterOutAIAttachments` queries `messages_attachments` for each ID's `externalmods`, classifies them as AI or non-AI, and strips the AI IDs from the keep-list. The subsequent `DELETE FROM messages_attachments WHERE msgid = ? AND id NOT IN (?)` then removes the AI attachment from the database.

The function only filters when BOTH kinds are present — if all attachments are AI-only or all are non-AI, the original list is returned unchanged, preserving existing behaviour.

Also forward-ports the empty-item validation (`if strings.TrimSpace(req.Item) == ""`) from master commit `27c12ac5` which this branch had not yet incorporated, restoring `TestPutMessageEmptyItemRejected` to passing.

## Alternatives Investigated
- Race / order-of-operations (AI suggestion fires before user image upload completes): deferred — fix instead enforces the invariant at attach-time, so ordering becomes irrelevant.
- Display-layer concatenation (both kinds rendered without filtering): ruled less likely by reproduction — the AI attachment is persistent in DB, not just rendered.

## Other Call Sites
No other occurrences found. The only Go code path that processes `req.Attachments` in the PATCH handler is `applyPatchMessage`. AI attachments are inserted by the PHP cron (`messages_illustrations.php`) which already has a pre-insert check; the Go fix adds defence-in-depth at the API layer.

## Test
File: iznik-server-go/test/message_ai_image_coexist_test.go
Command: `POST http://localhost:8081/api/tests/go {"filter":"TestMessagePatch_AIImageRemovedWhenUserAddsPhoto","timeout":120}`
Proves: test FAILS before this commit (see Evidence above), PASSES after (see TEST_PASSED output below)
Regression suite: iznik-server-go full go test ./... — All tests passed (2398✓)

TEST_PASSED:
```
=== RUN   TestMessagePatch_AIImageRemovedWhenUserAddsPhoto
--- PASS: TestMessagePatch_AIImageRemovedWhenUserAddsPhoto (0.18s)
```

## Discourse
https://discourse.ilovefreegle.org/t/9646