### PR TITLE
fix(modtools/message-action): include LOG_SUBTYPE_HOLD in messages-logtype filter

### DIFF
--- a/iznik-server-go/logs/logs.go
+++ b/iznik-server-go/logs/logs.go
@@ -91,7 +91,7 @@ func GetLogs(c *fiber.Ctx) error {
 		if logsubtype != "" {
 			subtypes = []string{logsubtype}
 		} else {
-			subtypes = []string{log.LOG_SUBTYPE_RECEIVED, log.LOG_SUBTYPE_APPROVED, log.LOG_SUBTYPE_REJECTED, log.LOG_SUBTYPE_DELETED, log.LOG_SUBTYPE_AUTO_REPOSTED, log.LOG_SUBTYPE_AUTO_APPROVED, log.LOG_SUBTYPE_OUTCOME}
+			subtypes = []string{log.LOG_SUBTYPE_RECEIVED, log.LOG_SUBTYPE_APPROVED, log.LOG_SUBTYPE_REJECTED, log.LOG_SUBTYPE_DELETED, log.LOG_SUBTYPE_AUTO_REPOSTED, log.LOG_SUBTYPE_AUTO_APPROVED, log.LOG_SUBTYPE_OUTCOME, log.LOG_SUBTYPE_HOLD}
 		}
 	case "memberships":
 		types = []string{log.LOG_TYPE_GROUP, log.LOG_TYPE_USER}

--- a/iznik-server-go/test/hold_log_audit_test.go
+++ b/iznik-server-go/test/hold_log_audit_test.go
@@ -1,0 +1,102 @@
+package test
+
+// AssertFlip test for bug: Message/Hold log entries are absent from the
+// messages logtype audit log that moderators see in the Messages-log tab.
+//
+// Symptom: After performing the 'Hold' action on a pending message, the
+// moderator cannot find any record of the action in the Messages audit log.
+// The Hold log entry is silently dropped because SUBTYPE_HOLD is not included
+// in the default subtype filter for logtype=messages in logs.go (line 94):
+//
+//   subtypes = []string{LOG_SUBTYPE_RECEIVED, LOG_SUBTYPE_APPROVED,
+//       LOG_SUBTYPE_REJECTED, LOG_SUBTYPE_DELETED, LOG_SUBTYPE_AUTO_REPOSTED,
+//       LOG_SUBTYPE_AUTO_APPROVED, LOG_SUBTYPE_OUTCOME}
+//
+// LOG_SUBTYPE_HOLD is missing from the list above.
+//
+// AssertFlip Step 1 — BUGGY behaviour (PASSES on current code, not committed):
+//   holdFound := false
+//   assert.False(t, holdFound, "BUG: Hold log absent from messages log")
+//   → Passes because Hold entry is absent (it's not in the filter).
+//
+// AssertFlip Step 2 — CORRECT behaviour (FAILS on current code, committed here):
+//   assert.True(t, holdFound, "Hold log must appear in messages log")
+//   → Fails because the filter omits SUBTYPE_HOLD.
+
+import (
+	jenc "encoding/json"
+	"bytes"
+	"fmt"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHoldLogAppearsInMessagesLog(t *testing.T) {
+	prefix := uniquePrefix("HoldMsgAudit")
+
+	groupID := CreateTestGroup(t, prefix)
+	posterID := CreateTestUser(t, prefix+"_poster", "User")
+	modID := CreateTestUser(t, prefix+"_mod", "User")
+	CreateTestMembership(t, posterID, groupID, "Member")
+	CreateTestMembership(t, modID, groupID, "Moderator")
+	_, modToken := CreateTestSession(t, modID)
+
+	msgID := createPendingMessage(t, posterID, groupID, prefix)
+
+	// Perform the Hold action via the API.
+	holdBody := map[string]interface{}{
+		"id":     msgID,
+		"action": "Hold",
+	}
+	holdBytes, _ := jenc.Marshal(holdBody)
+	holdReq := httptest.NewRequest("POST",
+		fmt.Sprintf("/api/message?jwt=%s", modToken),
+		bytes.NewBuffer(holdBytes))
+	holdReq.Header.Set("Content-Type", "application/json")
+	holdResp, err := getApp().Test(holdReq)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, holdResp.StatusCode)
+
+	// Fetch the messages log for this group (logtype=messages is what the
+	// ModTools Messages-log tab uses to review message audit history).
+	logsReq := httptest.NewRequest("GET",
+		fmt.Sprintf("/api/modtools/logs?logtype=messages&groupid=%d&jwt=%s",
+			groupID, modToken),
+		nil)
+	logsResp, err := getApp().Test(logsReq)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, logsResp.StatusCode)
+
+	var result map[string]interface{}
+	jenc.Unmarshal(rsp(logsResp), &result)
+	assert.Equal(t, float64(0), result["ret"])
+
+	logs, _ := result["logs"].([]interface{})
+
+	// Scan for a Hold log entry for this specific message.
+	holdFound := false
+	for _, entry := range logs {
+		e, ok := entry.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if e["type"] != "Message" {
+			continue
+		}
+		subtype, _ := e["subtype"].(string)
+		msgidFloat, _ := e["msgid"].(float64)
+		if subtype == "Hold" && uint64(msgidFloat) == msgID {
+			holdFound = true
+			break
+		}
+	}
+
+	// Step 2 (AssertFlip): assert CORRECT behaviour — FAILS on current buggy code.
+	// Fix: add LOG_SUBTYPE_HOLD to the messages logtype subtype filter in logs.go.
+	assert.True(t, holdFound,
+		"Hold log entry must appear in the messages log (logtype=messages) "+
+			"after performing a Hold action — currently FAILS because "+
+			"LOG_SUBTYPE_HOLD is absent from the messages-logtype subtype filter in logs.go")
+}


### PR DESCRIPTION
## Root Cause
LOG_SUBTYPE_HOLD was absent from the messages-logtype subtype filter in iznik-server-go/logs/logs.go. When a moderator performed the Hold action, the audit log row was written correctly to the DB, but the logs API filtered it out of the messages log response — leaving only SpamReport-style entries visible in ModTools, which the moderator (Jeni) perceived as "Hold misidentified as Spam report".

## Evidence

Failing test (before this fix): `TestHoldLogAppearsInMessagesLog` in `iznik-server-go/test/hold_log_audit_test.go:98`

```
assert.True(t, holdFound,
    "Hold log entry must appear in the messages log (logtype=messages) "+
    "after performing a Hold action — currently FAILS because "+
    "LOG_SUBTYPE_HOLD is absent from the messages-logtype subtype filter in logs.go")
```

The test performs a Hold action on a pending message, fetches the messages log (`logtype=messages`), and scans for a log entry with `type=Message, subtype=Hold`. Before this fix `holdFound` is always `false` because the subtype filter on logs.go:94 drops Hold rows.

## Fix
Added `log.LOG_SUBTYPE_HOLD` to the messages-logtype subtype filter in `iznik-server-go/logs/logs.go:94` so Hold audit entries are returned by the logs API and rendered correctly in ModTools.

```go
// Before:
subtypes = []string{log.LOG_SUBTYPE_RECEIVED, log.LOG_SUBTYPE_APPROVED, log.LOG_SUBTYPE_REJECTED, log.LOG_SUBTYPE_DELETED, log.LOG_SUBTYPE_AUTO_REPOSTED, log.LOG_SUBTYPE_AUTO_APPROVED, log.LOG_SUBTYPE_OUTCOME}

// After:
subtypes = []string{log.LOG_SUBTYPE_RECEIVED, log.LOG_SUBTYPE_APPROVED, log.LOG_SUBTYPE_REJECTED, log.LOG_SUBTYPE_DELETED, log.LOG_SUBTYPE_AUTO_REPOSTED, log.LOG_SUBTYPE_AUTO_APPROVED, log.LOG_SUBTYPE_OUTCOME, log.LOG_SUBTYPE_HOLD}
```

## Alternatives Investigated
- PHP/Go logs API serialiser conflates SUBTYPE_HOLD with SUBTYPE_SPAMREPORT — ruled out: failing test shows the Hold row is missing entirely (filter exclusion), not relabelled.
- Post-Hold notification/email/Discourse template mistitles the action — ruled out: symptom is in ModTools UI, not email copy.
- Member Review summary panel aggregates Hold and Spam counters — ruled out: failing test isolates the per-entry log query, not a counter.
- Dispatcher fall-through routes Hold into Spam handler — ruled out in previous reproduction (PHP message.php:443 explicit break; Go message.go:3180 separate return; messages_spamham untouched by Hold).

## Other Call Sites
`iznik-server/http/api/logs.php:34-41` (PHP v1 API) has the identical messages logtype subtype filter also missing `Log::SUBTYPE_HOLD`. That parallel bug is not fixed here (separate repo, out of scope for this PR), but should be addressed in a follow-up.

## Test
File: `iznik-server-go/test/hold_log_audit_test.go`
Command: `cd /home/edward/FreegleDockerWSL/iznik-server-go && go test ./test/... -run TestHoldLogAppearsInMessagesLog -v -count=1`
Proves: test FAILS before this commit (Hold log absent from messages logtype filter), PASSES after (Hold subtype included).
Regression suite: `go test ./...` — no existing test asserts Hold's absence from the messages log; the fix is purely additive.

## Discourse
https://discourse.ilovefreegle.org/t/9518