### PR TITLE
fix(modtools): $recentwanted uses original arrival time and excludes non-approved messages

### DIFF
--- a/iznik-server-go/test/user_test.go
+++ b/iznik-server-go/test/user_test.go
@@ -4117,3 +4117,110 @@ func TestGetUserInvalidPartnerSeesNoEmail(t *testing.T) {
 	assert.Equal(t, targetID, result.ID)
 	assert.Empty(t, result.Email, "invalid partner key should not expose any email")
 }
+
+// TestRecentWanted_GoAPI_ExcludesNonApproved is an AssertFlip STEP-1 test for the
+// $recentwanted bug (Discourse #9655):
+//
+// Bug: GetUserMessageHistory has no collection='Approved' filter, so Rejected and
+// Pending/Held messages appear in messagehistory and therefore in $recentwanted
+// substitution. The history entries also lack a 'postdate' field; the Go API returns
+// the computed date as 'arrival'. The frontend (ModStdMessageModal.vue) uses
+// msg.postdate, so dayjs(undefined) = current time → wrong rejection timestamp shown.
+//
+// STEP 1 asserts the BUGGY (current) behaviour — this MUST pass on unfixed code.
+// After confirming this passes, the assertions are inverted for STEP 2.
+func TestRecentWanted_GoAPI_ExcludesNonApproved(t *testing.T) {
+	prefix := uniquePrefix("recentwanted_coll")
+	db := database.DBConn
+
+	groupID := CreateTestGroup(t, prefix)
+	posterID := CreateTestUser(t, prefix+"_poster", "User")
+	modID := CreateTestUser(t, prefix+"_mod", "User")
+	CreateTestMembership(t, posterID, groupID, "Member")
+	CreateTestMembership(t, modID, groupID, "Moderator")
+	_, modToken := CreateTestSession(t, modID)
+
+	// Approved WANTED — 10 days old, within the 31-day $recentwanted window.
+	approvedSubject := prefix + " WANTED approved item"
+	db.Exec(
+		"INSERT INTO messages (fromuser, subject, textbody, message, type, arrival) "+
+			"VALUES (?, ?, 'body', 'body', 'Wanted', DATE_SUB(NOW(), INTERVAL 10 DAY))",
+		posterID, approvedSubject)
+	var approvedMsgID uint64
+	db.Raw("SELECT id FROM messages WHERE fromuser = ? AND subject = ? ORDER BY id DESC LIMIT 1",
+		posterID, approvedSubject).Scan(&approvedMsgID)
+	require.NotZero(t, approvedMsgID, "approved message must be created")
+	db.Exec(
+		"INSERT INTO messages_groups (msgid, groupid, arrival, collection) "+
+			"VALUES (?, ?, DATE_SUB(NOW(), INTERVAL 10 DAY), 'Approved')",
+		approvedMsgID, groupID)
+
+	// Rejected WANTED — 7 days old, also within the window.
+	rejectedSubject := prefix + " WANTED rejected item"
+	db.Exec(
+		"INSERT INTO messages (fromuser, subject, textbody, message, type, arrival) "+
+			"VALUES (?, ?, 'body', 'body', 'Wanted', DATE_SUB(NOW(), INTERVAL 7 DAY))",
+		posterID, rejectedSubject)
+	var rejectedMsgID uint64
+	db.Raw("SELECT id FROM messages WHERE fromuser = ? AND subject = ? ORDER BY id DESC LIMIT 1",
+		posterID, rejectedSubject).Scan(&rejectedMsgID)
+	require.NotZero(t, rejectedMsgID, "rejected message must be created")
+	db.Exec(
+		"INSERT INTO messages_groups (msgid, groupid, arrival, collection) "+
+			"VALUES (?, ?, DATE_SUB(NOW(), INTERVAL 7 DAY), 'Rejected')",
+		rejectedMsgID, groupID)
+
+	t.Cleanup(func() {
+		db.Exec("DELETE FROM messages_groups WHERE msgid IN (?, ?)", approvedMsgID, rejectedMsgID)
+		db.Exec("DELETE FROM messages WHERE id IN (?, ?)", approvedMsgID, rejectedMsgID)
+	})
+
+	// Fetch the poster as a moderator — must include messagehistory.
+	url := fmt.Sprintf("/api/user/%d?modtools=true&jwt=%s", posterID, modToken)
+	resp, err := getApp().Test(httptest.NewRequest("GET", url, nil))
+	require.NoError(t, err)
+	require.Equal(t, 200, resp.StatusCode)
+
+	var raw map[string]interface{}
+	err = json.NewDecoder(resp.Body).Decode(&raw)
+	require.NoError(t, err)
+
+	history, ok := raw["messagehistory"].([]interface{})
+	require.True(t, ok, "messagehistory must be present for modtools fetch")
+
+	approvedFound := false
+	rejectedFound := false
+	var postdateFieldExists bool
+
+	for _, h := range history {
+		entry, _ := h.(map[string]interface{})
+		id := uint64(entry["id"].(float64))
+		if id == approvedMsgID {
+			approvedFound = true
+		}
+		if id == rejectedMsgID {
+			rejectedFound = true
+		}
+		// Check whether the 'postdate' field exists in any entry.
+		if _, hasPD := entry["postdate"]; hasPD {
+			postdateFieldExists = true
+		}
+	}
+
+	// STEP 2 (inverted) — asserts CORRECT behaviour; FAILS on unfixed code:
+	// (a) Approved WANTED must appear in history (sanity check — passes before and after fix).
+	assert.True(t, approvedFound,
+		"Approved WANTED must appear in messagehistory for $recentwanted")
+	// (b) Rejected WANTED must NOT appear in history.
+	//     FAILS on current code: GetUserMessageHistory has no collection='Approved' filter,
+	//     so Rejected messages leak into $recentwanted substitution.
+	assert.False(t, rejectedFound,
+		"Rejected WANTED must NOT appear in messagehistory (bug: GetUserMessageHistory lacks collection='Approved' filter)")
+	// (c) Each history entry must have a 'postdate' field (the computed best-date the
+	//     frontend's ModStdMessageModal.vue reads as msg.postdate for $recentwanted).
+	//     FAILS on current code: Go API returns the date as 'arrival' only; msg.postdate is
+	//     undefined in the frontend → dayjs(undefined) = NOW = rejection timestamp shown.
+	assert.True(t, postdateFieldExists,
+		"messagehistory entries must include 'postdate' field (bug: Go API returns 'arrival' only; "+
+			"frontend uses msg.postdate → dayjs(undefined) = current time instead of original arrival)")
+}

--- a/iznik-server-go/user/user.go
+++ b/iznik-server-go/user/user.go
@@ -161,6 +161,7 @@ type UserMessageHistory struct {
 	Subject    string    `json:"subject"`
 	Type       string    `json:"type"`
 	Arrival    time.Time `json:"arrival"`
+	Postdate   time.Time `json:"postdate"` // V1-parity: frontend reads msg.postdate for $recentwanted
 	Groupid    uint64    `json:"groupid"`
 	Collection string    `json:"collection"`
 	Daysago    int       `json:"daysago"`
@@ -482,12 +483,13 @@ func GetUserMessageHistory(userid uint64) []UserMessageHistory {
 		"FROM messages m "+
 		"INNER JOIN messages_groups mg ON m.id = mg.msgid "+
 		"LEFT JOIN messages_postings mp ON mp.msgid = m.id "+
-		"WHERE m.fromuser = ? AND mg.deleted = 0 AND m.deleted IS NULL "+
-		"ORDER BY arrival DESC", userid).Scan(&history)
+		"WHERE m.fromuser = ? AND mg.deleted = 0 AND m.deleted IS NULL AND mg.collection = ? "+
+		"ORDER BY arrival DESC", userid, utils.COLLECTION_APPROVED).Scan(&history)
 
 	now := time.Now()
 	for ix, h := range history {
 		history[ix].Daysago = int(now.Sub(h.Arrival).Hours() / 24)
+		history[ix].Postdate = h.Arrival
 	}
 
 	return history


### PR DESCRIPTION
## Root Cause
Go API GetUserMessageHistory (1) did not filter by collection='Approved', so rejected/held messages appeared in the recent-wanteds list used to expand the $recentwanted macro; and (2) returned only an 'arrival' field, but the frontend reads 'postdate'. With postdate undefined, dayjs(undefined) returned the current time — making rejected/stock-replied posts appear to be timestamped at the rejection moment instead of their original arrival.

## Evidence
```
--- FAIL: TestRecentWanted_GoAPI_ExcludesNonApproved (0.09s)
    user_test.go:4217: Rejected WANTED must NOT appear in messagehistory (bug: GetUserMessageHistory lacks collection='Approved' filter)
    user_test.go:4223: messagehistory entries must include 'postdate' field (bug: Go API returns 'arrival' only; frontend uses msg.postdate → dayjs(undefined) = current time instead of original arrival)
FAIL
```

## Fix
(a) Added `AND mg.collection = ?` with `utils.COLLECTION_APPROVED` to the SQL WHERE clause in `GetUserMessageHistory` — matches V1 PHP behaviour where `getPublicHistory` hardcodes `MessageCollection::APPROVED`.

(b) Added `Postdate time.Time \`json:"postdate"\`` field to `UserMessageHistory` struct, populated as `history[ix].Postdate = h.Arrival` in the post-scan loop. Keeps `arrival` for back-compat. The frontend's `ModStdMessageModal.vue` reads `msg.postdate` to render the $recentwanted date; without this field `dayjs(undefined)` returned the current time (the rejection moment).

## Alternatives Investigated
- Client-side macro substitution using new Date(): ruled out — substitution is data-driven from the Go API messagehistory response.
- PHP StockMessage::substitute / Plugin.php using time(): ruled out — reproduction test fails in the Go API layer.

## Other Call Sites
`GetUserMessageHistory` is the only messagehistory query in the Go codebase. Other Go structs with `arrival` fields (message/message_list/search) are for different endpoints and do not feed the $recentwanted macro. No other occurrences found.

## Test
File: iznik-server-go/test/user_test.go
Command: docker exec -w /app freegle-apiv2 sh -c "export MYSQL_DBNAME=iznik_go_test && /usr/local/go/bin/go test ./test -run TestRecentWanted_GoAPI_ExcludesNonApproved -v"
Proves: test FAILS before this commit (see Evidence above), PASSES after (--- PASS: TestRecentWanted_GoAPI_ExcludesNonApproved (0.17s))
Regression suite: Adjacent tests TestGetUserFetchMT_MessageHistoryForMod and TestGetUserFetchMT_MessageHistoryOutcome — PASS. Full go test ./... — 2 pre-existing failures (TestMessagePatch_AIImageRemovedWhenUserAddsPhoto and TestHoldActionMisidentifiedAsSpamReport_BugAssert) from other parallel worktree tasks; test files not present in this branch.

## Discourse
https://discourse.ilovefreegle.org/t/9655