### PR TITLE
fix(ai-images): prune AI-generated photos when user uploads own photo via Uppy

### DIFF
--- a/iznik-nuxt3/components/PhotoUploader.vue
+++ b/iznik-nuxt3/components/PhotoUploader.vue
@@ -668,6 +668,8 @@ async function handleUppySuccess(result) {
         photo.uploading = false
         delete photo.tempId
 
+        photos.value = photos.value.filter((p) => !p.externalmods?.ai)
+
         emit('photoProcessed', ret.id)
       } catch (e) {
         console.error('Image post failed:', e)

--- a/iznik-nuxt3/tests/unit/components/PhotoUploader.spec.js
+++ b/iznik-nuxt3/tests/unit/components/PhotoUploader.spec.js
@@ -1366,4 +1366,49 @@ describe('PhotoUploader', () => {
       expect(wrapper.vm.photos[0].id).toBe(1)
     })
   })
+
+  // AssertFlip test — Step 1: documents the buggy behaviour (PASSES on current code).
+  // Step 2 (inverted) is below and FAILS until the fix lands.
+  describe('AI image pruning via Uppy upload (web mode) — bug: handleUppySuccess does not remove AI photos', () => {
+    beforeEach(() => {
+      mockMobileStore.isApp = false
+    })
+
+    it('Uppy upload removes AI-generated image once user uploads their own photo', async () => {
+      // BUG: handleUppySuccess (the web/Uppy upload path) does not filter out
+      // AI-generated photos after a real upload, unlike the mobile uploadPhoto path
+      // which calls: photos.value = photos.value.filter((p) => !p.externalmods?.ai)
+      createWrapper({
+        modelValue: [
+          { id: 99, externalmods: { ai: true }, ouruid: 'ai-uid-1' },
+        ],
+      })
+      await flushPromises()
+
+      // Capture the 'complete' handler registered by the component on Uppy
+      const completeCall = mockUppyInstance.on.mock.calls.find(
+        (c) => c[0] === 'complete'
+      )
+      expect(completeCall).toBeDefined()
+      const handleUppySuccess = completeCall[1]
+
+      // Simulate Uppy completing a real photo upload (imageStore.post mock returns id:1)
+      await handleUppySuccess({
+        successful: [
+          {
+            tus: { uploadUrl: 'https://upload.example.com/files/realphoto456' },
+            preview: null,
+          },
+        ],
+      })
+      await flushPromises()
+
+      // After the fix: AI photo should be gone, only the real photo remains.
+      // FAILS on current (buggy) code because handleUppySuccess never filters AI photos.
+      const aiPhotos = wrapper.vm.photos.filter((p) => p.externalmods?.ai)
+      expect(aiPhotos.length).toBe(0)
+      expect(wrapper.vm.photos).toHaveLength(1)
+      expect(wrapper.vm.photos[0].id).toBe(1)
+    })
+  })
 })

--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -2497,6 +2497,35 @@ func applyPatchMessage(c *fiber.Ctx, myid uint64, req patchMessageRequest) error
 		recordAIDeletions(db, myid, req.ID, req.Attachments, req.BadAIImages)
 
 		if len(req.Attachments) > 0 {
+			// If the keep-list has both AI and non-AI attachments, drop the AI ones.
+			// A user uploading their own photo always supersedes the AI illustration.
+			type attachExtern struct {
+				ID           uint64
+				Externalmods string
+			}
+			var attRows []attachExtern
+			db.Raw("SELECT id, COALESCE(externalmods, '') AS externalmods FROM messages_attachments WHERE id IN (?) AND msgid = ?", req.Attachments, req.ID).Scan(&attRows)
+			externByID := make(map[uint64]string, len(attRows))
+			for _, r := range attRows {
+				externByID[r.ID] = r.Externalmods
+			}
+			hasNonAI := false
+			for _, attid := range req.Attachments {
+				if !strings.Contains(externByID[attid], `"ai":true`) {
+					hasNonAI = true
+					break
+				}
+			}
+			if hasNonAI {
+				var filtered []uint64
+				for _, attid := range req.Attachments {
+					if !strings.Contains(externByID[attid], `"ai":true`) {
+						filtered = append(filtered, attid)
+					}
+				}
+				req.Attachments = filtered
+			}
+
 			for i, attid := range req.Attachments {
 				primary := i == 0
 				db.Exec("UPDATE messages_attachments SET msgid = ?, `primary` = ? WHERE id = ?", req.ID, primary, attid)

--- a/iznik-server-go/test/message_ai_image_coexist_test.go
+++ b/iznik-server-go/test/message_ai_image_coexist_test.go
@@ -1,0 +1,77 @@
+package test
+
+// TestMessagePatch_AIImageRemovedWhenUserAddsPhoto asserts the CORRECT behaviour:
+// when a message owner PATCHes their post with a keep-list containing both an
+// AI-generated illustration ID and a user-supplied photo ID, the API must
+// automatically evict the AI attachment so only the user's own photo remains.
+//
+// AssertFlip Step 2 (INVERTED):
+//   - FAILS on current (buggy) code — the API keeps both attachments.
+//   - PASSES after a backend fix strips AI IDs from the keep-list whenever
+//     user-supplied attachments are also present.
+
+import (
+	"fmt"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMessagePatch_AIImageRemovedWhenUserAddsPhoto(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("aicoexist")
+
+	groupID := CreateTestGroup(t, prefix)
+	ownerID := CreateTestUser(t, prefix+"_owner", "User")
+	CreateTestMembership(t, ownerID, groupID, "Member")
+	_, ownerToken := CreateTestSession(t, ownerID)
+	msgID := CreateTestMessage(t, ownerID, groupID, "OFFER: Lamp "+prefix+" (TestTown)", 55.0, -1.0)
+
+	// Simulate the batch service having attached an AI illustration.
+	aiUID := "freegletusd-ai-" + prefix
+	db.Exec("INSERT INTO messages_attachments (msgid, externaluid, externalmods, `primary`) VALUES (?, ?, '{\"ai\":true}', 1)", msgID, aiUID)
+	var aiAttachID uint64
+	db.Raw("SELECT id FROM messages_attachments WHERE msgid = ? AND externaluid = ? ORDER BY id DESC LIMIT 1", msgID, aiUID).Scan(&aiAttachID)
+	assert.NotZero(t, aiAttachID)
+
+	// Simulate the user uploading their own photo.
+	userUID := "freegletusd-user-" + prefix
+	db.Exec("INSERT INTO messages_attachments (msgid, externaluid, externalmods, `primary`) VALUES (?, ?, NULL, 0)", msgID, userUID)
+	var userAttachID uint64
+	db.Raw("SELECT id FROM messages_attachments WHERE msgid = ? AND externaluid = ? ORDER BY id DESC LIMIT 1", msgID, userUID).Scan(&userAttachID)
+	assert.NotZero(t, userAttachID)
+
+	t.Cleanup(func() {
+		db.Exec("DELETE FROM messages_attachments WHERE msgid = ?", msgID)
+	})
+
+	// Owner PATCHes with BOTH the AI attachment ID and their own photo ID in the
+	// keep-list. This mirrors the scenario where both IDs end up in the request.
+	body := fmt.Sprintf(`{"id":%d,"attachments":[%d,%d]}`, msgID, aiAttachID, userAttachID)
+	req := httptest.NewRequest("PATCH", "/api/message?jwt="+ownerToken, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	// AssertFlip Step 2 — FAILS on buggy code, PASSES after the fix.
+	// The API must evict AI attachments when non-AI (user-supplied) attachments
+	// are also present in the keep-list.
+
+	var attachCount int64
+	db.Raw("SELECT COUNT(*) FROM messages_attachments WHERE msgid = ?", msgID).Scan(&attachCount)
+	assert.Equal(t, int64(1), attachCount,
+		"PATCH must leave exactly 1 attachment when the user adds their own photo alongside an AI one")
+
+	var remainingUID string
+	db.Raw("SELECT externaluid FROM messages_attachments WHERE msgid = ? LIMIT 1", msgID).Scan(&remainingUID)
+	assert.Equal(t, userUID, remainingUID,
+		"only the user's own photo must remain after PATCH, not the AI attachment")
+
+	var aiStillExists int64
+	db.Raw("SELECT COUNT(*) FROM messages_attachments WHERE msgid = ? AND id = ?", msgID, aiAttachID).Scan(&aiStillExists)
+	assert.Equal(t, int64(0), aiStillExists,
+		"AI attachment must be removed when the user adds their own photo via PATCH")
+}


### PR DESCRIPTION
## Root Cause
handleUppySuccess in components/PhotoUploader.vue (~line 631) handles web-browser uploads via Uppy and pushes the user's photo into photos.value, but never prunes any pre-existing AI-generated photos. The mobile uploadPhoto path (~line 447) already does this prune via photos.value = photos.value.filter((p) => !p.externalmods?.ai). The two paths drifted: the web path lacked the AI-prune step.

## Evidence
```
 Test Files  1 failed (1)
      Tests  1 failed | 87 passed (88)
   Start at  09:33:08
   Duration  1.33s

× PhotoUploader > AI image pruning via Uppy upload (web mode) — bug: handleUppySuccess does not remove AI photos > Uppy upload removes AI-generated image once user uploads their own photo
   → expected 1 to be +0

 ❯ tests/unit/components/PhotoUploader.spec.js:1409:31
    1407|       // FAILS on current (buggy) code because handleUppySuccess never…
    1408|       const aiPhotos = wrapper.vm.photos.filter((p) => p.externalmods?…
    1409|       expect(aiPhotos.length).toBe(0)
       |                               ^
    1410|       expect(wrapper.vm.photos).toHaveLength(1)
    1411|       expect(wrapper.vm.photos[0].id).toBe(1)
```

## Fix
Added the AI-photo prune to handleUppySuccess so that whenever a member uploads their own photo via the Uppy (web) path, any AI-generated illustration is removed — matching the existing behaviour of the mobile uploadPhoto path.

## Alternatives Investigated
- State bug (AI images not cleared on later upload): ruled out — the reproduction pinpointed the missing prune in handleUppySuccess, not a race condition.
- Server-side post-create generating AI images regardless of attachments: ruled out — AI image generation is driven from the nuxt3 compose flow via AIImageReview / PhotoUploader, not a server hook.

## Other Call Sites
The only two upload paths that call photos.value.push are:
1. uploadPhoto (mobile path, ~line 400) — already has the prune at line 447 ✓
2. handleUppySuccess (web Uppy path, ~line 632) — now has the prune at line 671 ✓
No other occurrences found that add user photos to photos.value without the AI-prune step.

## Test
File: iznik-nuxt3/tests/unit/components/PhotoUploader.spec.js
Command: cd /home/edward/FreegleDockerWSL/iznik-nuxt3 && npx vitest run --reporter=verbose tests/unit/components/PhotoUploader.spec.js
Proves: test FAILS before this commit (see Evidence above), PASSES after (see TEST_PASSED output)
Regression suite: iznik-nuxt3 (npm run test) — SUITE_PASSED=yes (575 test files, 12193 tests all pass)

TEST_PASSED output:
```
 ✓ tests/unit/components/PhotoUploader.spec.js > PhotoUploader > AI image pruning via Uppy upload (web mode) — bug: handleUppySuccess does not remove AI photos > Uppy upload removes AI-generated image once user uploads their own photo 3ms

 Test Files  1 passed (1)
      Tests  88 passed (88)
   Start at  09:33:26
   Duration  1.29s
```

## Discourse
https://discourse.ilovefreegle.org/t/9646