### PR TITLE
fix(tests): correct Group settings encoding and IncomingMail message-ID lookup

### DIFF
--- a/iznik-batch/tests/Feature/Mail/IncomingMailCommandTest.php
+++ b/iznik-batch/tests/Feature/Mail/IncomingMailCommandTest.php
@@ -465,20 +465,22 @@ class IncomingMailCommandTest extends TestCase
     {
         $group = $this->createTestGroup();
         $user = $this->createTestUser(['email_preferred' => $this->uniqueEmail('logtest')]);
-        $this->createMembership($user, $group);
+        $this->createMembership($user, $group, ['ourPostingStatus' => 'DEFAULT']);
 
         DB::table('users')->where('id', $user->id)->update([
             'lastlocation' => $this->createLocation(51.5, -0.1),
         ]);
 
         $userEmail = $user->emails->first()->email;
-        $msgId = '<test-log-'.uniqid().'@example.com>';
+        // Bare message ID without angle brackets (parser strips them; service appends group ID)
+        $msgId = 'test-log-'.uniqid().'@example.com';
+        $storedMsgId = $msgId.'-'.$group->id;
 
         $rawEmail = $this->createMinimalEmail([
             'From' => $userEmail,
             'To' => $group->nameshort.'@groups.ilovefreegle.org',
             'Subject' => 'OFFER: Test log item (London)',
-            'Message-Id' => $msgId,
+            'Message-Id' => '<'.$msgId.'>',
         ], 'Test body for log.');
 
         $this->artisan('mail:incoming', [
@@ -487,7 +489,7 @@ class IncomingMailCommandTest extends TestCase
             '--stdin-content' => $rawEmail,
         ])->assertSuccessful();
 
-        $message = DB::table('messages')->where('messageid', $msgId)->first();
+        $message = DB::table('messages')->where('messageid', $storedMsgId)->first();
         $this->assertNotNull($message, 'Message should have been created');
 
         $log = DB::table('logs')
@@ -499,7 +501,7 @@ class IncomingMailCommandTest extends TestCase
         $this->assertNotNull($log, 'Message/Received log entry should be written');
         $this->assertEquals($group->id, $log->groupid);
         $this->assertEquals($user->id, $log->user);
-        $this->assertEquals($msgId, $log->text);
+        $this->assertEquals($storedMsgId, $log->text);
     }
 
     // ========================================

--- a/iznik-batch/tests/Feature/Mail/IncomingMailCommandTest.php
+++ b/iznik-batch/tests/Feature/Mail/IncomingMailCommandTest.php
@@ -480,7 +480,7 @@ class IncomingMailCommandTest extends TestCase
             'From' => $userEmail,
             'To' => $group->nameshort.'@groups.ilovefreegle.org',
             'Subject' => 'OFFER: Test log item (London)',
-            'Message-Id' => '<'.$msgId.'>',
+            'Message-ID' => '<'.$msgId.'>',
         ], 'Test body for log.');
 
         $this->artisan('mail:incoming', [

--- a/iznik-batch/tests/Unit/Services/MessageExpiryServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/MessageExpiryServiceTest.php
@@ -474,7 +474,7 @@ class MessageExpiryServiceTest extends TestCase
         DB::table('messages_promises')->insert([
             'msgid' => $message->id,
             'userid' => $other->id,
-            'timestamp' => now(),
+            'promisedat' => now(),
         ]);
 
         $count = $this->service->processExpiredFromSpatialIndex();

--- a/iznik-batch/tests/Unit/Services/MessageExpiryServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/MessageExpiryServiceTest.php
@@ -331,10 +331,10 @@ class MessageExpiryServiceTest extends TestCase
 
         // Group with maxagetoshow=30 and reposts that yield 3*(5+1)=18 → expiretime = 30.
         $group = $this->createTestGroup([
-            'settings' => json_encode([
+            'settings' => [
                 'maxagetoshow' => 30,
                 'reposts' => ['offer' => 3, 'wanted' => 7, 'max' => 5, 'chaseups' => 5],
-            ]),
+            ],
         ]);
         $this->createMembership($user, $group);
 
@@ -373,10 +373,10 @@ class MessageExpiryServiceTest extends TestCase
 
         // maxagetoshow=0 means reposts-based expiry alone: 4*(5+1) = 24 days for Offer.
         $group = $this->createTestGroup([
-            'settings' => json_encode([
+            'settings' => [
                 'maxagetoshow' => 0,
                 'reposts' => ['offer' => 4, 'wanted' => 7, 'max' => 5, 'chaseups' => 5],
-            ]),
+            ],
         ]);
         $this->createMembership($user, $group);
 
@@ -413,10 +413,10 @@ class MessageExpiryServiceTest extends TestCase
         $user = $this->createTestUser();
         $other = $this->createTestUser();
         $group = $this->createTestGroup([
-            'settings' => json_encode([
+            'settings' => [
                 'maxagetoshow' => 30,
                 'reposts' => ['offer' => 3, 'wanted' => 7, 'max' => 5, 'chaseups' => 5],
-            ]),
+            ],
         ]);
         $this->createMembership($user, $group);
 
@@ -456,10 +456,10 @@ class MessageExpiryServiceTest extends TestCase
         $user = $this->createTestUser();
         $other = $this->createTestUser();
         $group = $this->createTestGroup([
-            'settings' => json_encode([
+            'settings' => [
                 'maxagetoshow' => 30,
                 'reposts' => ['offer' => 3, 'wanted' => 7, 'max' => 5, 'chaseups' => 5],
-            ]),
+            ],
         ]);
         $this->createMembership($user, $group);
 
@@ -488,10 +488,10 @@ class MessageExpiryServiceTest extends TestCase
     {
         $user = $this->createTestUser();
         $group = $this->createTestGroup([
-            'settings' => json_encode([
+            'settings' => [
                 'maxagetoshow' => 30,
                 'reposts' => ['offer' => 3, 'wanted' => 7, 'max' => 5, 'chaseups' => 5],
-            ]),
+            ],
         ]);
         $this->createMembership($user, $group);
 

--- a/iznik-nuxt3/tests/e2e/test-modtools-hold-release.spec.js
+++ b/iznik-nuxt3/tests/e2e/test-modtools-hold-release.spec.js
@@ -98,9 +98,14 @@ test.describe('ModTools hold and release message', () => {
     const firstCard = messageCards.first()
 
     // Ensure clean state: if message was left held by a previous run, release it.
-    const existingRelease = firstCard.locator('button:has-text("Release")')
-    if (await existingRelease.isVisible({ timeout: 2000 }).catch(() => false)) {
-      await existingRelease.click()
+    // A held message shows 2 "Release" buttons (one warning notice, one action button),
+    // so use count() to avoid strict-mode errors when both are present.
+    const existingReleaseCount = await firstCard
+      .locator('button:has-text("Release")')
+      .count()
+      .catch(() => 0)
+    if (existingReleaseCount > 0) {
+      await firstCard.locator('button:has-text("Release")').first().click()
       // Wait for Hold button to reappear after release
       await firstCard
         .locator('button:has-text("Hold")')
@@ -128,8 +133,10 @@ test.describe('ModTools hold and release message', () => {
       // No confirmation needed
     }
 
-    // Step 4: After holding, the Release button should appear within the first card
-    const releaseButton = firstCard.locator('button:has-text("Release")')
+    // Step 4: After holding, the Release button should appear within the first card.
+    // A held message shows 2 "Release" buttons (warning notice + action button), so
+    // use .first() to pick one deterministically and avoid strict-mode violations.
+    const releaseButton = firstCard.locator('button:has-text("Release")').first()
     await expect(releaseButton).toBeVisible({
       timeout: timeouts.ui.appearance,
     })


### PR DESCRIPTION
## Summary

- **MessageExpiryServiceTest (3 failures)**: `Group` model has `settings` cast as `'array'`, so passing `json_encode([...])` to `createTestGroup()` double-encodes it. MySQL's `JSON_EXTRACT` then sees a JSON *string* not an object, returns `null`, and `maxagetoshow`/`reposts` look like their defaults (90 days). Tests expecting expiry at 30 days never fired. Fix: pass settings as a plain PHP array.

- **IncomingMailCommandTest (1 failure)**: `MailParserService` strips angle brackets from `Message-Id` headers (`trim('<>')`), and `createGroupPostMessage` appends `'-{groupId}'` for per-group uniqueness. Test was looking up `where('messageid', '<raw-id>')` — wrong on both counts. Also missing `ourPostingStatus=DEFAULT`, so post went to PENDING. Fix: build the stored ID correctly, add posting status.

## Test plan
- [ ] CI passes on this branch
- [ ] All 4 previously-failing tests now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)