### PR TITLE
fix(modtools): Members > Notes — remove duplicates, restore All my communities, fix pagination

### DIFF
--- a/iznik-server-go/membership/membership.go
+++ b/iznik-server-go/membership/membership.go
@@ -420,8 +420,8 @@ func GetMemberships(c *fiber.Ctx) error {
 	filterJoin := ""
 	filterWhere := ""
 	switch filter {
-	case 1: // With comments/notes
-		filterJoin = " INNER JOIN users_comments uc ON uc.userid = m.userid AND uc.groupid = m.groupid"
+	case 1: // With comments/notes — use EXISTS to avoid row multiplication from multi-note members
+		filterWhere = " AND EXISTS (SELECT 1 FROM users_comments uc WHERE uc.userid = m.userid AND uc.groupid = m.groupid)"
 	case 2: // Moderation team
 		filterWhere = " AND m.role IN ('" + utils.ROLE_OWNER + "', '" + utils.ROLE_MODERATOR + "')"
 	case 3: // Bouncing

--- a/iznik-server-go/membership/membership.go
+++ b/iznik-server-go/membership/membership.go
@@ -328,19 +328,19 @@ func GetMemberships(c *fiber.Ctx) error {
 	}
 
 	search := c.Query("search", "")
+	filter := c.QueryInt("filter", 0)
+	contextID := uint64(c.QueryInt("context", 0))
 
 	if groupid == 0 {
-		if search == "" {
-			// No group and no search — return empty list.
+		if search == "" && filter == 0 {
+			// No group, no search, no filter — return empty list.
 			return c.JSON([]GetMembershipsMember{})
 		}
-		// search across all of the mod's groups when no group selected.
-		// Fall through to the search logic with groupid=0 handled below.
+		// filter or search with no specific group — fan out to all of mod's groups.
+		// Fall through.
 	} else if !isModOfGroup(myid, groupid) {
 		return fiber.NewError(fiber.StatusForbidden, "Not a moderator of this group")
 	}
-	filter := c.QueryInt("filter", 0)
-	contextID := uint64(c.QueryInt("context", 0))
 
 	db := database.DBConn
 
@@ -463,7 +463,18 @@ func GetMemberships(c *fiber.Ctx) error {
 		// Cursor-based pagination: m.id is the cursor (auto-increment correlates with join date).
 		// ORDER BY m.id DESC for deterministic per-page slicing consistent with the cursor.
 		contextWhere := ""
-		queryArgs := []interface{}{groupid, collection}
+		var groupCondition string
+		var queryArgs []interface{}
+
+		if groupid == 0 {
+			// All my communities: fan out to every group this mod moderates.
+			groupCondition = "m.groupid IN (SELECT groupid FROM memberships WHERE userid = ? AND role IN ('" + utils.ROLE_MODERATOR + "', '" + utils.ROLE_OWNER + "') AND collection = '" + utils.COLLECTION_APPROVED + "')"
+			queryArgs = []interface{}{myid, collection}
+		} else {
+			groupCondition = "m.groupid = ?"
+			queryArgs = []interface{}{groupid, collection}
+		}
+
 		if contextID > 0 {
 			contextWhere = " AND m.id < ?"
 			queryArgs = append(queryArgs, contextID)
@@ -472,7 +483,7 @@ func GetMemberships(c *fiber.Ctx) error {
 
 		result := db.Raw("SELECT "+selectCols+" "+
 			fromClause+filterJoin+" "+
-			"WHERE m.groupid = ? AND m.collection = ?"+filterWhere+contextWhere+
+			"WHERE "+groupCondition+" AND m.collection = ?"+filterWhere+contextWhere+
 			" ORDER BY m.id DESC LIMIT ?",
 			queryArgs...).Scan(&members)
 		if result.Error != nil {
@@ -493,13 +504,22 @@ func GetMemberships(c *fiber.Ctx) error {
 	}
 
 	// When a filter is active, include the total matching count so the UI can display it.
-	if filter > 0 && groupid > 0 {
+	if filter > 0 {
 		var filterCount int64
 
 		countFrom := "FROM memberships m JOIN users u ON u.id = m.userid"
+		var countCondition string
+		var countArgs []interface{}
+		if groupid == 0 {
+			countCondition = "m.groupid IN (SELECT groupid FROM memberships WHERE userid = ? AND role IN ('" + utils.ROLE_MODERATOR + "', '" + utils.ROLE_OWNER + "') AND collection = '" + utils.COLLECTION_APPROVED + "')"
+			countArgs = []interface{}{myid, collection}
+		} else {
+			countCondition = "m.groupid = ?"
+			countArgs = []interface{}{groupid, collection}
+		}
 		db.Raw("SELECT COUNT(DISTINCT m.userid) "+countFrom+filterJoin+
-			" WHERE m.groupid = ? AND m.collection = ?"+filterWhere,
-			groupid, collection).Scan(&filterCount)
+			" WHERE "+countCondition+" AND m.collection = ?"+filterWhere,
+			countArgs...).Scan(&filterCount)
 
 		return c.JSON(fiber.Map{
 			"members":     members,

--- a/iznik-server-go/test/membership_test.go
+++ b/iznik-server-go/test/membership_test.go
@@ -3594,3 +3594,80 @@ func TestPatchMembershipsConfigChange(t *testing.T) {
 		modID, groupID).Scan(&configID2)
 	assert.Equal(t, cfgID2, configID2)
 }
+
+// TestMembersWithNotesFilterNoDuplicates is an AssertFlip test for the membership filter=1
+// (Members with Notes) regression.
+//
+// Bug: GET /membership?filter=1 uses INNER JOIN users_comments without DISTINCT, so a member
+// with N notes in a group appears N times in the raw API response instead of once.
+// When combined with a LIMIT, this means real members can be "pushed off" the page by
+// duplicate rows for a single heavy-note member -- the consumer deduplicates by membership
+// ID but the LIMIT is consumed before all distinct members are reached.
+//
+// STEP 2 (inverted) -- FAILS on unfixed code, PASSES after fix:
+// Assert that GET /membership?filter=1 returns exactly 1 distinct member entry for a group
+// where only 1 member has notes (even when that member has 6 distinct notes).
+func TestMembersWithNotesFilterNoDuplicates(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("members_notes_filter")
+
+	// Moderator who will view the members list.
+	modID := CreateTestUser(t, prefix+"_mod", "Moderator")
+	_, modToken := CreateTestSession(t, modID)
+
+	// Target member who has 6 notes.
+	targetID := CreateTestUser(t, prefix+"_target", "User")
+
+	groupID := CreateTestGroup(t, prefix)
+
+	// Moderator has role in this group.
+	CreateTestMembership(t, modID, groupID, "Moderator")
+
+	// Target is an approved member of the group.
+	CreateTestMembership(t, targetID, groupID, "Member")
+
+	// Insert 6 distinct notes for the target member in this group.
+	for i := 1; i <= 6; i++ {
+		db.Exec(
+			"INSERT INTO users_comments (userid, groupid, byuserid, user1, date) VALUES (?, ?, ?, ?, NOW())",
+			targetID, groupID, modID, fmt.Sprintf("Note #%d for filter test", i),
+		)
+	}
+
+	// Call the memberships endpoint with filter=1 (Members with Notes).
+	url := fmt.Sprintf("/api/memberships?groupid=%d&collection=Approved&filter=1&limit=20&jwt=%s",
+		groupID, modToken)
+	resp, err := getApp().Test(httptest.NewRequest("GET", url, nil))
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	err = json.NewDecoder(resp.Body).Decode(&result)
+	assert.NoError(t, err)
+
+	members, ok := result["members"].([]interface{})
+	assert.True(t, ok, "response must have a members array")
+
+	// STEP 2 (inverted) -- asserts CORRECT behaviour; FAILS on unfixed code:
+	// Only 1 distinct member should be returned regardless of note count.
+	// BUG: INNER JOIN users_comments without DISTINCT returns 6 rows (one per note),
+	// so len(members) == 6 on unfixed code instead of 1.
+	assert.Equal(t, 1, len(members),
+		"filter=1 must return 1 distinct member entry even when that member has 6 notes "+
+			"(bug: INNER JOIN without DISTINCT returns N rows per N notes, consuming the LIMIT)")
+
+	// Each member ID must be unique (no duplicate membership rows in the response).
+	if len(members) > 0 {
+		seen := make(map[float64]bool)
+		for _, m := range members {
+			mm, isMap := m.(map[string]interface{})
+			if !isMap {
+				continue
+			}
+			mid, _ := mm["id"].(float64)
+			assert.False(t, seen[mid],
+				"duplicate membership ID %.0f in filter=1 response -- INNER JOIN without DISTINCT", mid)
+			seen[mid] = true
+		}
+	}
+}

--- a/iznik-server-go/test/membership_test.go
+++ b/iznik-server-go/test/membership_test.go
@@ -3671,3 +3671,148 @@ func TestMembersWithNotesFilterNoDuplicates(t *testing.T) {
 		}
 	}
 }
+
+// TestNotesFilterAllCommunitiesReturnsMembersWithNotes verifies that GET /memberships?filter=1
+// with groupid=0 (All my communities) returns members who have notes, rather than an empty list.
+//
+// Bug: groupid=0 + no search returns [] immediately before even checking the filter parameter.
+// Members with notes across any of the mod's groups should be returned.
+func TestNotesFilterAllCommunitiesReturnsMembersWithNotes(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("notes_all_communities")
+
+	modID := CreateTestUser(t, prefix+"_mod", "Moderator")
+	_, modToken := CreateTestSession(t, modID)
+
+	memberID := CreateTestUser(t, prefix+"_member", "User")
+
+	groupID := CreateTestGroup(t, prefix)
+
+	CreateTestMembership(t, modID, groupID, "Moderator")
+	CreateTestMembership(t, memberID, groupID, "Member")
+
+	db.Exec(
+		"INSERT INTO users_comments (userid, groupid, byuserid, user1, date) VALUES (?, ?, ?, ?, NOW())",
+		memberID, groupID, modID, "Note from mod",
+	)
+
+	// groupid=0 = All my communities
+	url := fmt.Sprintf("/api/memberships?groupid=0&collection=Approved&filter=1&limit=20&jwt=%s", modToken)
+	resp, err := getApp().Test(httptest.NewRequest("GET", url, nil))
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	err = json.NewDecoder(resp.Body).Decode(&result)
+	assert.NoError(t, err)
+
+	members, ok := result["members"].([]interface{})
+	assert.True(t, ok, "response must have a members array")
+	assert.Equal(t, 1, len(members),
+		"filter=1 with groupid=0 must return members who have notes across all mod groups (got empty list — groupid=0 early-return bug)")
+}
+
+// TestNotesFilterAllCommunitiesExcludesNonModGroups verifies that filter=1 with groupid=0
+// does not return members from groups the requester does not moderate.
+func TestNotesFilterAllCommunitiesExcludesNonModGroups(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("notes_all_excl")
+
+	modID := CreateTestUser(t, prefix+"_mod", "Moderator")
+	_, modToken := CreateTestSession(t, modID)
+
+	// Member in a group the mod moderates — should appear.
+	memberInModGroup := CreateTestUser(t, prefix+"_mine", "User")
+	modGroupID := CreateTestGroup(t, prefix+"_mod_group")
+	CreateTestMembership(t, modID, modGroupID, "Moderator")
+	CreateTestMembership(t, memberInModGroup, modGroupID, "Member")
+	db.Exec(
+		"INSERT INTO users_comments (userid, groupid, byuserid, user1, date) VALUES (?, ?, ?, ?, NOW())",
+		memberInModGroup, modGroupID, modID, "Note in mod group",
+	)
+
+	// Member in a group the mod does NOT moderate — must not appear.
+	otherMod := CreateTestUser(t, prefix+"_othermod", "OtherMod")
+	memberInOtherGroup := CreateTestUser(t, prefix+"_other", "User")
+	otherGroupID := CreateTestGroup(t, prefix+"_other_group")
+	CreateTestMembership(t, otherMod, otherGroupID, "Moderator")
+	CreateTestMembership(t, memberInOtherGroup, otherGroupID, "Member")
+	db.Exec(
+		"INSERT INTO users_comments (userid, groupid, byuserid, user1, date) VALUES (?, ?, ?, ?, NOW())",
+		memberInOtherGroup, otherGroupID, otherMod, "Note in other group",
+	)
+
+	url := fmt.Sprintf("/api/memberships?groupid=0&collection=Approved&filter=1&limit=20&jwt=%s", modToken)
+	resp, err := getApp().Test(httptest.NewRequest("GET", url, nil))
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	err = json.NewDecoder(resp.Body).Decode(&result)
+	assert.NoError(t, err)
+
+	members, ok := result["members"].([]interface{})
+	assert.True(t, ok, "response must have a members array")
+	assert.Equal(t, 1, len(members),
+		"filter=1 with groupid=0 must only return members from groups this mod moderates")
+
+	if len(members) == 1 {
+		mm, _ := members[0].(map[string]interface{})
+		uid, _ := mm["userid"].(float64)
+		assert.Equal(t, float64(memberInModGroup), uid,
+			"returned member must be from the mod's own group, not another group")
+	}
+}
+
+// TestNotesFilterAllCommunitiesPagination verifies that cursor-based pagination works for
+// filter=1 with groupid=0 (All my communities).
+func TestNotesFilterAllCommunitiesPagination(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("notes_all_page")
+
+	modID := CreateTestUser(t, prefix+"_mod", "Moderator")
+	_, modToken := CreateTestSession(t, modID)
+
+	groupID := CreateTestGroup(t, prefix)
+	CreateTestMembership(t, modID, groupID, "Moderator")
+
+	// Create 5 members each with a note.
+	var memberIDs []uint64
+	for i := 0; i < 5; i++ {
+		mid := CreateTestUser(t, fmt.Sprintf("%s_m%d", prefix, i), "User")
+		memberIDs = append(memberIDs, mid)
+		CreateTestMembership(t, mid, groupID, "Member")
+		db.Exec(
+			"INSERT INTO users_comments (userid, groupid, byuserid, user1, date) VALUES (?, ?, ?, ?, NOW())",
+			mid, groupID, modID, fmt.Sprintf("Note %d", i),
+		)
+	}
+
+	// Page 1: limit=3
+	url1 := fmt.Sprintf("/api/memberships?groupid=0&collection=Approved&filter=1&limit=3&jwt=%s", modToken)
+	resp1, err := getApp().Test(httptest.NewRequest("GET", url1, nil))
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp1.StatusCode)
+
+	var page1 map[string]interface{}
+	json.NewDecoder(resp1.Body).Decode(&page1)
+
+	members1, _ := page1["members"].([]interface{})
+	assert.Equal(t, 3, len(members1), "first page must have 3 members")
+
+	cursor, hasCursor := page1["context"]
+	assert.True(t, hasCursor && cursor != nil, "first page must return a pagination cursor")
+
+	// Page 2: use cursor
+	url2 := fmt.Sprintf("/api/memberships?groupid=0&collection=Approved&filter=1&limit=3&context=%.0f&jwt=%s",
+		cursor.(float64), modToken)
+	resp2, err := getApp().Test(httptest.NewRequest("GET", url2, nil))
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp2.StatusCode)
+
+	var page2 map[string]interface{}
+	json.NewDecoder(resp2.Body).Decode(&page2)
+
+	members2, _ := page2["members"].([]interface{})
+	assert.Equal(t, 2, len(members2), "second page must have the remaining 2 members")
+}

--- a/iznik-server-go/test/message_test.go
+++ b/iznik-server-go/test/message_test.go
@@ -6237,10 +6237,9 @@ func TestExpiresatRespectsRepostsOfferKey(t *testing.T) {
 
 	msgID := CreateTestMessage(t, userID, groupID, prefix+" Offer", 55.9533, -3.1883)
 
-	var arrivalStr string
-	db.Raw("SELECT arrival FROM messages_groups WHERE msgid = ? LIMIT 1", msgID).Scan(&arrivalStr)
-	arrival, perr := time.Parse("2006-01-02 15:04:05", arrivalStr)
-	assert.NoError(t, perr)
+	var arrival time.Time
+	db.Raw("SELECT arrival FROM messages_groups WHERE msgid = ? LIMIT 1", msgID).Scan(&arrival)
+	require.False(t, arrival.IsZero(), "arrival must be set")
 
 	url := fmt.Sprintf("/api/message/%d?jwt=%s", msgID, token)
 	req := httptest.NewRequest("GET", url, nil)
@@ -6277,10 +6276,9 @@ func TestExpiresatRespectsRepostsWantedKey(t *testing.T) {
 	db.Exec("UPDATE messages SET type = 'Wanted' WHERE id = ?", msgID)
 	db.Exec("UPDATE messages_groups SET msgtype = 'Wanted' WHERE msgid = ?", msgID)
 
-	var arrivalStr string
-	db.Raw("SELECT arrival FROM messages_groups WHERE msgid = ? LIMIT 1", msgID).Scan(&arrivalStr)
-	arrival, perr := time.Parse("2006-01-02 15:04:05", arrivalStr)
-	assert.NoError(t, perr)
+	var arrival time.Time
+	db.Raw("SELECT arrival FROM messages_groups WHERE msgid = ? LIMIT 1", msgID).Scan(&arrival)
+	require.False(t, arrival.IsZero(), "arrival must be set")
 
 	url := fmt.Sprintf("/api/message/%d?jwt=%s", msgID, token)
 	req := httptest.NewRequest("GET", url, nil)
@@ -6315,10 +6313,9 @@ func TestExpiresatMaxagetoshowWins(t *testing.T) {
 
 	msgID := CreateTestMessage(t, userID, groupID, prefix+" Offer", 55.9533, -3.1883)
 
-	var arrivalStr string
-	db.Raw("SELECT arrival FROM messages_groups WHERE msgid = ? LIMIT 1", msgID).Scan(&arrivalStr)
-	arrival, perr := time.Parse("2006-01-02 15:04:05", arrivalStr)
-	assert.NoError(t, perr)
+	var arrival time.Time
+	db.Raw("SELECT arrival FROM messages_groups WHERE msgid = ? LIMIT 1", msgID).Scan(&arrival)
+	require.False(t, arrival.IsZero(), "arrival must be set")
 
 	url := fmt.Sprintf("/api/message/%d?jwt=%s", msgID, token)
 	req := httptest.NewRequest("GET", url, nil)


### PR DESCRIPTION
## Summary

Fixes three bugs in the **Members › Notes** filter reported at https://discourse.ilovefreegle.org/t/modtools-changes-likely-bugs/9518/251 by Neville Reid.

### Bug 1 — Duplicate rows per member

\`GET /memberships?filter=1\` used \`INNER JOIN users_comments\` without \`DISTINCT\`. A member with N notes in a group produced N rows in the response. With a page limit of 20, a single heavily-annotated member could consume multiple slots, hiding other members.

**Fix:** replaced the \`INNER JOIN\` with \`EXISTS (SELECT 1 FROM users_comments …)\`, which returns at most one row per membership regardless of note count.

### Bug 2 — "All my communities" returned empty list

When \`groupid=0\` (All my communities) and no search term was supplied, the handler returned \`[]\` immediately before checking the \`filter\` parameter. The Notes filter was therefore completely broken for the cross-group view.

**Fix:**
- Read \`filter\` before the \`groupid==0\` guard so the early-return only fires when \`filter==0\` (no filter active) **and** no search term.
- Cursor-based pagination path: when \`groupid==0\`, fan out to all groups the requesting moderator moderates (mirrors the existing search-path behaviour).
- \`filtercount\`: now computed for \`groupid==0\` too (was skipped, hiding the total count from the UI).

### Bug 3 — Time-parsing in existing Go tests

Three \`TestExpiresat*\` tests scanned \`arrival\` as a raw string and parsed with \`time.Parse("2006-01-02 15:04:05", …)\`. GORM scans timestamps as \`time.Time\`, so the parse always failed. Fixed by scanning into \`time.Time\` directly.

## Tests

All changes driven by tests written red-first:

| Test | Covers |
|------|--------|
| \`TestMembersWithNotesFilterNoDuplicates\` | Bug 1: JOIN → EXISTS deduplication |
| \`TestNotesFilterAllCommunitiesReturnsMembersWithNotes\` | Bug 2: groupid=0 returns results |
| \`TestNotesFilterAllCommunitiesExcludesNonModGroups\` | Bug 2: only mod's own groups |
| \`TestNotesFilterAllCommunitiesPagination\` | Bug 2: cursor pagination across groups |

## Not in scope

Neville also requested **infinite scroll** (no hard page limit). The cursor-based pagination mechanism already exists and is now functional for the all-communities view; surfacing it in the Modtools UI is a separate frontend task.

## Test plan

- [ ] Open Modtools › Members › Notes with a specific group selected — each member appears exactly once
- [ ] Switch to "All my communities" — members with notes across all your groups now appear (was empty before)
- [ ] Scroll to the bottom of a long Notes list — cursor pagination loads the next page
- [ ] All 2409 Go tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)