### PR TITLE
fix(modtools): reset tab title after mod action even when confirmation modal is open

### DIFF
--- a/iznik-nuxt3/modtools/composables/useModMe.js
+++ b/iznik-nuxt3/modtools/composables/useModMe.js
@@ -77,9 +77,10 @@ export function useModMe() {
       clearTimeout(miscStore.workTimer)
     }
 
-    // Do not check for work and therefore refresh while any modal is open
+    // Skip refresh while modtools editing is in progress; beep is also skipped
+    // when any modal is open (body overflow:hidden) to avoid iOS audio interruption.
     const bodyoverflow = document.body.style.overflow
-    const oktocheck = bodyoverflow !== 'hidden' && !miscStore.modtoolsediting
+    const oktocheck = !miscStore.modtoolsediting
     if (force || oktocheck) {
       // console.log('========================================')
       console.log(
@@ -111,6 +112,7 @@ export function useModMe() {
         work &&
         totalCount > currentTotal &&
         !skipBeep &&
+        bodyoverflow !== 'hidden' &&
         authStore.user &&
         (!authStore.user.settings ||
           !Object.keys(authStore.user.settings).includes('playbeep') ||

--- a/iznik-nuxt3/tests/unit/composables/useModMe.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useModMe.spec.js
@@ -143,3 +143,32 @@ describe('useModMe checkWork beep behavior', () => {
     expect(mockAudioPlay).not.toHaveBeenCalled()
   })
 })
+
+describe('useModMe document.title refresh after mod action', () => {
+  it('clears title count when checkWork is called after mod action while modal is open', async () => {
+    const { useModMe } = await import('~/modtools/composables/useModMe')
+    const { checkWork } = useModMe()
+
+    // Establish initial state: 2 pending items → title becomes "(2) ModTools"
+    mockFetchMe.mockImplementationOnce(async () => {
+      globalThis.__mockAuthStore.work = { total: 2 }
+    })
+    await checkWork(true)
+    expect(global.document.title).toBe('(2) ModTools')
+
+    // Mod action completes: queue clears, but modal is still open (body overflow:hidden).
+    // checkWorkDeferGetMessages() calls checkWork() WITHOUT force.
+    // Guard in checkWork: bodyoverflow==='hidden' && !force → skips the entire update block,
+    // so document.title is never refreshed with the new zero count.
+    global.document.body.style.overflow = 'hidden'
+    mockFetchMe.mockImplementation(async () => {
+      globalThis.__mockAuthStore.work = { total: 0 }
+    })
+    await checkWork() // no force — reproduces checkWorkDeferGetMessages() call path
+
+    // Title must update to 'ModTools' when work queue empties after a mod action.
+    // FAILS on buggy code: guard blocks title refresh when body overflow is 'hidden'
+    // and force is not passed, leaving stale '(2) ModTools' as the tab title.
+    expect(global.document.title).toBe('ModTools')
+  })
+})


### PR DESCRIPTION
## Root Cause
checkWork() in iznik-nuxt3/composables/useModMe.js gates its entire update block — including the document.title reset — behind the oktocheck guard `bodyoverflow !== 'hidden' && !miscStore.modtoolsediting`. After a mod action, checkWorkDeferGetMessages() invokes checkWork() without force=true while the confirmation modal is still open (body.style.overflow === 'hidden'), so the title reset is skipped and '(N) ModTools' stays stuck even after the queue empties.

## Evidence
<Paste the failing test output from the CONFIRMED_FAILING step: this is the proof the bug existed before the fix>

```
 FAIL  tests/unit/composables/useModMe.spec.js > useModMe document.title refresh after mod action > clears title count when checkWork is called after mod action while modal is open
AssertionError: expected '(2) ModTools' to be 'ModTools' // Object.is equality

Expected: "ModTools"
Received: "(2) ModTools"

 ❯ tests/unit/composables/useModMe.spec.js:172:35
```

## Fix
Removed `bodyoverflow !== 'hidden'` from the `oktocheck` guard so the fetch+title update path runs regardless of modal state. The bodyoverflow check is now applied exclusively to the beep condition (where it was always the real concern — preventing iOS audio interruption from Apple Podcasts/BBC Sounds). This means:
- The 30s polling fetch and the post-action `checkWorkDeferGetMessages()` fetch both run even when a modal is open, keeping the title accurate
- The beep is still suppressed while any modal is open, preserving the iOS audio fix from #256

## Alternatives Investigated
- Off-by-one accumulator: ruled out — multi-item drift, not single-step
- Non-reactive title watcher: ruled out — sibling iOS-badge report shows source IS reactive on browser actions; only the refresh-after-action path was broken

## Other Call Sites
`document.title` is only set in `modtools/composables/useModMe.js` — no other files with the stale-title pattern.

`checkWork()` without force is called from:
- `setTimeout(checkWork, 30000)` — 30s polling timer (now correctly updates title when modal is open)
- `setTimeout(checkWork, 0)` in `modtools/layouts/default.vue` — initial load (no modal open then)
- `checkWorkDeferGetMessages()` — the primary bug trigger path (now fixed)
- `modtools/components/ModSocialAction.vue:165` — after social action (correct to update title)

All other callers use `checkWork(true)` (with force) and were unaffected.

## Test
File: iznik-nuxt3/tests/unit/composables/useModMe.spec.js
Command: cd /home/edward/FreegleDockerWSL/iznik-nuxt3 && npx vitest run --reporter=verbose tests/unit/composables/useModMe.spec.js
Proves: test FAILS before this commit (see Evidence above), PASSES after (see TEST_PASSED output)
Regression suite: nuxt — SUITE_PASSED=yes (575 test files, 12194 tests all pass)

```
 ✓ tests/unit/composables/useModMe.spec.js > useModMe checkWork beep behavior > does not play beep on first checkWork even when work arrives (iOS audio safety) 16ms
 ✓ tests/unit/composables/useModMe.spec.js > useModMe checkWork beep behavior > plays beep when work count increases after first check 3ms
 ✓ tests/unit/composables/useModMe.spec.js > useModMe checkWork beep behavior > does not play beep when work count stays the same on subsequent checks 2ms
 ✓ tests/unit/composables/useModMe.spec.js > useModMe checkWork beep behavior > respects playbeep=false user setting on subsequent checks 2ms
 ✓ tests/unit/composables/useModMe.spec.js > useModMe document.title refresh after mod action > clears title count when checkWork is called after mod action while modal is open 2ms

 Test Files  1 passed (1)
      Tests  5 passed (5)
```

## Discourse
https://discourse.ilovefreegle.org/t/9518