### PR TITLE
fix(session): prefer settings.mylocation over lastlocation for me.lat/me.lng

### DIFF
--- a/iznik-server-go/session/session.go
+++ b/iznik-server-go/session/session.go
@@ -1265,9 +1265,30 @@ func GetSession(c *fiber.Ctx) error {
 	// Wait for discourse fetch to complete.
 	discourseWg.Wait()
 
-	// Fetch location if available (depends on userRow).
+	// Fetch location for me.lat/me.lng — V1 parity: prefer settings.mylocation, fall back to lastlocation.
+	// V1 User::getLatLngs() uses settings.mylocation.lat/lng as primary (the postcode the user typed in
+	// their settings) and only falls back to lastlocation when mylocation is absent. lastlocation is
+	// updated by every draft post, so without this preference a draft on a remote group would shift
+	// me.lat/me.lng (and therefore chat distances) to that group's location.
 	var loc *LocationRow
-	if userRow.Lastlocation != nil && *userRow.Lastlocation > 0 {
+	if len(userRow.Settings) > 0 {
+		var parsed struct {
+			Mylocation *struct {
+				Lat  float64 `json:"lat"`
+				Lng  float64 `json:"lng"`
+				Name string  `json:"name"`
+			} `json:"mylocation"`
+		}
+		if json.Unmarshal(userRow.Settings, &parsed) == nil && parsed.Mylocation != nil &&
+			(parsed.Mylocation.Lat != 0 || parsed.Mylocation.Lng != 0) {
+			loc = &LocationRow{
+				Lat:  parsed.Mylocation.Lat,
+				Lng:  parsed.Mylocation.Lng,
+				Name: parsed.Mylocation.Name,
+			}
+		}
+	}
+	if loc == nil && userRow.Lastlocation != nil && *userRow.Lastlocation > 0 {
 		var locRow LocationRow
 		db.Raw("SELECT name, lat, lng FROM locations WHERE id = ?", *userRow.Lastlocation).Scan(&locRow)
 		if locRow.Name != "" {

--- a/iznik-server-go/test/session_test.go
+++ b/iznik-server-go/test/session_test.go
@@ -418,6 +418,46 @@ func TestGetSessionAppliesSettingsDefaults(t *testing.T) {
 	assert.Equal(t, 200, resp3.StatusCode)
 }
 
+// TestGetSessionLatLngPrefersMyLocation verifies V1/V2 parity for me.lat/me.lng:
+// when settings.mylocation has lat/lng, those must be used in preference to
+// lastlocation (which is updated by posting a draft on a remote group).
+// V1 User::getLatLngs() always preferred settings.mylocation; V2 was only reading
+// lastlocation, causing the distance shown in chat to jump to the draft's location.
+func TestGetSessionLatLngPrefersMyLocation(t *testing.T) {
+	prefix := uniquePrefix("sess_latlng")
+	db := database.DBConn
+	userID := CreateTestUser(t, prefix, "User")
+	_, token := CreateTestSession(t, userID)
+
+	// Create two distinct locations: the user's home postcode and a remote location.
+	db.Exec("INSERT INTO locations (name, type, lat, lng) VALUES (?, 'Postcode', 56.2, -3.2)", prefix+"_home")
+	db.Exec("INSERT INTO locations (name, type, lat, lng) VALUES (?, 'Postcode', 57.9, -6.8)", prefix+"_remote")
+	var homeLocID, remoteLocID uint64
+	db.Raw("SELECT id FROM locations WHERE name = ? LIMIT 1", prefix+"_home").Scan(&homeLocID)
+	db.Raw("SELECT id FROM locations WHERE name = ? LIMIT 1", prefix+"_remote").Scan(&remoteLocID)
+	if homeLocID == 0 || remoteLocID == 0 {
+		t.Skip("Could not create test locations")
+	}
+	defer db.Exec("DELETE FROM locations WHERE id IN (?, ?)", homeLocID, remoteLocID)
+
+	// settings.mylocation points to home; lastlocation points to the remote draft location.
+	homeSettings := fmt.Sprintf(`{"mylocation":{"id":%d,"name":"%s_home","lat":56.2,"lng":-3.2}}`, homeLocID, prefix)
+	db.Exec("UPDATE users SET settings = ?, lastlocation = ? WHERE id = ?", homeSettings, remoteLocID, userID)
+
+	req := httptest.NewRequest("GET", "/api/session?jwt="+token, nil)
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&result)
+	me, ok := result["me"].(map[string]interface{})
+	assert.True(t, ok, "me should be a map")
+
+	// Must use settings.mylocation (home), NOT lastlocation (remote draft).
+	assert.InDelta(t, 56.2, me["lat"], 0.001, "me.lat should come from settings.mylocation, not lastlocation")
+	assert.InDelta(t, -3.2, me["lng"], 0.001, "me.lng should come from settings.mylocation, not lastlocation")
+}
+
 func TestGetSessionNotLoggedIn(t *testing.T) {
 	req := httptest.NewRequest("GET", "/api/session", nil)
 	resp, _ := getApp().Test(req)


### PR DESCRIPTION
## Summary

- **Root cause**: V2 `/apiv2/session` built `me.lat`/`me.lng` solely from `users.lastlocation`, which is updated whenever a user posts a draft on any group. Posting a draft on a remote group (e.g. Outer Hebrides HS8) silently shifted `me.lat`/`me.lng` to that group's location for all subsequent API calls.
- **V1 parity**: `User::getLatLngs()` in PHP prefers `settings.mylocation.lat/lng` (the postcode the user typed in their settings panel) and only falls back to `lastlocation` when `settings.mylocation` is absent. V2 now does the same.
- **Symptom**: Chat "miles away" counter showed 303 miles for a Kirkcaldy user talking to a local Kirkcaldy member, because their draft had updated `lastlocation` to HS8.
- **Fix**: In `session/session.go`, attempt to parse `settings.mylocation` from the user's JSON settings before the `lastlocation` lookup; use it when `lat`/`lng` are present.

## Code Quality Review

- No duplication introduced — the parse is a localised anonymous struct, not a new exported type.
- No security concerns — the settings JSON is read from the DB (trusted internal source).
- Fallback preserved: users with no `settings.mylocation` continue to get `lastlocation` as before.
- `city` name also taken from `settings.mylocation.name` when using that path, consistent with the `lastlocation` path.

## Test Plan

- New test `TestGetSessionLatLngPrefersMyLocation`: sets `settings.mylocation` to home coords and `lastlocation` to a different remote location, then asserts `me.lat`/`me.lng` from `GET /session` match home, not remote.
- Test confirmed failing before the fix (returned remote coords) and passing after.