### PR TITLE
fix(api): reject JoinAndPost on drafts with empty subject

### DIFF
--- a/iznik-batch/tests/Unit/Services/Mail/Incoming/IncomingMailServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/Mail/Incoming/IncomingMailServiceTest.php
@@ -3782,7 +3782,12 @@ class IncomingMailServiceTest extends TestCase
         $message = $this->createTestMessage($poster, $group);
 
         $replierEmail = $replier->emails->first()->email;
-        $sharedMessageId = '<race-condition-test@example.com>';
+        // Header form (what the email carries) vs storage form (what
+        // MailParserService normalizes to before writing to `messages`):
+        // the parser strips angle brackets, so the pre-existing row must
+        // store the stripped form for the unique-index race to fire.
+        $headerMessageId = '<race-condition-test@example.com>';
+        $storedMessageId = trim($headerMessageId, '<>');
 
         // Simulate the sibling-process win: a `messages` row with this
         // Message-ID already exists when our handler runs.
@@ -3794,7 +3799,7 @@ class IncomingMailServiceTest extends TestCase
             'envelopefrom' => $replierEmail,
             'envelopeto' => "replyto-{$message->id}-{$replier->id}@users.ilovefreegle.org",
             'subject' => 'Re: '.$message->subject,
-            'messageid' => $sharedMessageId,
+            'messageid' => $storedMessageId,
             'message' => 'pre-existing raw',
             'textbody' => 'pre-existing',
         ]);
@@ -3803,7 +3808,7 @@ class IncomingMailServiceTest extends TestCase
             'From' => $replierEmail,
             'To' => "replyto-{$message->id}-{$replier->id}@users.ilovefreegle.org",
             'Subject' => 'Re: '.$message->subject,
-            'Message-ID' => $sharedMessageId,
+            'Message-ID' => $headerMessageId,
         ], 'second-process body');
 
         $parsed = $this->parser->parse(
@@ -3831,7 +3836,7 @@ class IncomingMailServiceTest extends TestCase
         $this->assertEquals($existingId, $byEmail->msgid);
 
         // No duplicate `messages` row written.
-        $count = DB::table('messages')->where('messageid', $sharedMessageId)->count();
+        $count = DB::table('messages')->where('messageid', $storedMessageId)->count();
         $this->assertEquals(1, $count, 'should not have written a duplicate messages row');
     }
 

--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -2159,6 +2159,15 @@ func handleJoinAndPost(c *fiber.Ctx, myid uint64, req PostMessageRequest) error 
 		}
 	}
 
+	// Refuse to promote a draft that would land in the group with no subject.
+	// This catches pre-validation drafts created before PUT /message required
+	// item, and any other path that leaves subject empty by submit time.
+	var finalSubject string
+	db.Raw("SELECT COALESCE(subject, '') FROM messages WHERE id = ?", req.ID).Scan(&finalSubject)
+	if strings.TrimSpace(finalSubject) == "" {
+		return fiber.NewError(fiber.StatusBadRequest, "Item is required")
+	}
+
 	// Save deadline and deliverypossible if provided.
 	if req.Deadline != nil && *req.Deadline != "" {
 		db.Exec("UPDATE messages SET deadline = ? WHERE id = ?", *req.Deadline, req.ID)

--- a/iznik-server-go/test/message_test.go
+++ b/iznik-server-go/test/message_test.go
@@ -1848,6 +1848,44 @@ func TestJoinAndPostForcePendingFalseDoesNotOverride(t *testing.T) {
 	assert.Equal(t, "Pending", collection, "forcepending=false must not override MODERATED status")
 }
 
+// TestJoinAndPostRejectsEmptyDraft verifies that a draft with no item, no
+// subject and no body — possible for drafts created before PUT /message
+// required item — is rejected at submit time rather than landing in the
+// group as an empty Pending Offer.
+func TestJoinAndPostRejectsEmptyDraft(t *testing.T) {
+	prefix := uniquePrefix("msgmod_jap_empty")
+	db := database.DBConn
+
+	groupID := CreateTestGroup(t, prefix)
+	userID := CreateTestUser(t, prefix+"_user", "User")
+	CreateTestMembership(t, userID, groupID, "Member")
+	_, token := CreateTestSession(t, userID)
+
+	// Simulate a stale pre-validation draft: empty subject, empty textbody,
+	// no row in messages_items, no locationid.
+	db.Exec("INSERT INTO messages (fromuser, type, subject, textbody, message, arrival, date, source) VALUES (?, 'Offer', '', '', '', NOW(), NOW(), 'Platform')", userID)
+	var msgID uint64
+	db.Raw("SELECT id FROM messages WHERE fromuser = ? ORDER BY id DESC LIMIT 1", userID).Scan(&msgID)
+	require.NotZero(t, msgID)
+	db.Exec("INSERT INTO messages_drafts (msgid, groupid, userid) VALUES (?, ?, ?)", msgID, groupID, userID)
+
+	body := map[string]interface{}{
+		"id":     msgID,
+		"action": "JoinAndPost",
+	}
+	bodyBytes, _ := json.Marshal(body)
+	req := httptest.NewRequest("POST", fmt.Sprintf("/api/message?jwt=%s", token), bytes.NewBuffer(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := getApp().Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, 400, resp.StatusCode, "Empty draft must not be promotable")
+
+	// Confirm the draft was NOT routed to the group.
+	var msgGroupCount int64
+	db.Raw("SELECT COUNT(*) FROM messages_groups WHERE msgid = ? AND groupid = ?", msgID, groupID).Scan(&msgGroupCount)
+	assert.Equal(t, int64(0), msgGroupCount, "Empty draft must not produce a messages_groups row")
+}
+
 // --- Test: PatchMessage ---
 
 func TestPatchMessage(t *testing.T) {


### PR DESCRIPTION
## Summary

Three Approved Offers were spotted on prod with empty subject, empty body, no item (e.g. messages `120177637`, `120189994`, `120145984`). They are drafts that pre-date `27c12ac5e` (which added "Item is required" to `PUT /v2/message`), then sat in `messages_drafts` and were later promoted into a group via `JoinAndPost`. `handleJoinAndPost` only rebuilt the subject when both a location and an item row were present, so empty drafts slipped through unchanged.

After the existing optional subject reconstruction in `handleJoinAndPost`, re-read the message and reject with 400 if the final subject is still empty. This closes the door on stale pre-validation drafts and any other path that leaves a draft subjectless at submit time.

## Prod scope (as of 2026-05-16)

- 101 historical messages match `(subject IS NULL OR '') AND (textbody IS NULL OR '') AND no messages_items row`
- 95 already in `messages_groups`, 60 currently Approved & not deleted
- 6 still sitting in `messages_drafts` — these are exactly what this fix blocks at promote time
- 97 of 101 were created before `27c12ac5e` (2026-05-07); newest is 2026-05-09
- Live Approved cleanup is out of scope for this PR

## Test plan
- [ ] CI: new test `TestJoinAndPostRejectsEmptyDraft` runs green
- [ ] CI: existing JoinAndPost tests still green (subject is always non-empty in those)

🤖 Generated with [Claude Code](https://claude.com/claude-code)