### PR TITLE
fix(avatar): persist new profileid after OurUploader completion in ProfileSection (#9679)

### DIFF
--- a/iznik-nuxt3/components/settings/ProfileSection.vue
+++ b/iznik-nuxt3/components/settings/ProfileSection.vue
@@ -264,13 +264,17 @@ watch(
   async (newVal) => {
     uploading.value = false
     if (newVal?.length) {
-      const atts = {
-        externaluid: newVal[0].ouruid,
-        externalmods: newVal[0].externalmods,
-        imgtype: 'User',
-        msgid: me?.value.id,
+      if (newVal[0].id) {
+        await authStore.saveAndGet({ profileid: newVal[0].id })
+      } else if (newVal[0].ouruid) {
+        const atts = {
+          externaluid: newVal[0].ouruid,
+          externalmods: newVal[0].externalmods,
+          imgtype: 'User',
+          msgid: me?.value.id,
+        }
+        await imageStore.post(atts)
       }
-      await imageStore.post(atts)
     }
     await fetchMe(true)
     emit('update')

--- a/iznik-nuxt3/tests/unit/components/settings_ProfileSection.spec.js
+++ b/iznik-nuxt3/tests/unit/components/settings_ProfileSection.spec.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { mount } from '@vue/test-utils'
+import { mount, flushPromises } from '@vue/test-utils'
 import ProfileSection from '~/components/settings/ProfileSection.vue'
 
 const { mockMe, mockMyid } = vi.hoisted(() => {
@@ -598,6 +598,35 @@ describe('ProfileSection', () => {
       wrapper.vm.uploading = true
       await wrapper.vm.$nextTick()
       expect(wrapper.findAll('.rotate-btn').length).toBe(0)
+    })
+  })
+
+  // AssertFlip test for bug #9679 — profile picture change not persisting in ModTools.
+  // Fails on buggy code; passes after the fix adds saveAndGet({ profileid }) to the watcher.
+  describe('profile photo upload - AssertFlip (#9679)', () => {
+    it('calls saveAndGet with the new profileid when OurUploader completes an upload', async () => {
+      mockImagePost.mockResolvedValue({
+        id: 999,
+        url: '/new-profile.jpg',
+        uid: 'freegletusd-new-uid',
+      })
+      mockFetchMe.mockResolvedValue(undefined)
+
+      const wrapper = createWrapper()
+
+      // Simulate OurUploader completing an upload and writing to currentAtts
+      wrapper.vm.currentAtts = [
+        {
+          id: 999,
+          path: '/new-profile.jpg',
+          ouruid: 'freegletusd-new-uid',
+          externalmods: {},
+        },
+      ]
+      await flushPromises()
+
+      // The watcher must persist the new attachment ID to the user record via PATCH /user
+      expect(mockSaveAndGet).toHaveBeenCalledWith({ profileid: 999 })
     })
   })
 })


### PR DESCRIPTION
## Root Cause
The profile image change flow in iznik-nuxt3 ProfileSection uploads the image and updates the local user store optimistically, but the follow-up user-update API call that links the new attachment ID to the user's profileid either fails silently, omits the profileid field, or its response is not merged back into the store, so the next reactive read returns the old image. Reported in Discourse topic 9679 by Derek (ModTools) and reproduced equivalently in iznik-nuxt3 ProfileSection.

## Evidence
Failing test output before the fix:
```
× tests/unit/components/settings_ProfileSection.spec.js > ProfileSection > profile photo upload - AssertFlip (#9679) > calls saveAndGet with the new profileid when OurUploader completes an upload
  → expected "spy" to be called with arguments: [ { profileid: 999 } ]
  Number of calls: 0
 Test Files  1 failed (1)
      Tests  1 failed | 65 passed (66)
```

## Fix
The `watch(currentAtts, ...)` handler in `ProfileSection.vue` was calling `imageStore.post` with `externaluid` (for social/external profile images) but never called `authStore.saveAndGet({ profileid: id })` for direct file uploads. When a user uploads a photo from their device, OurUploader resolves the upload and writes an attachment object with an `id` to `currentAtts`. The watcher now checks `newVal[0].id` first and calls `authStore.saveAndGet({ profileid: newVal[0].id })` to durably link the new attachment to the user record via PATCH /user. The existing `imageStore.post` path (for social images with `ouruid`/`externaluid`) is preserved in an `else if` branch.

## Alternatives Investigated
- Upload endpoint response shape change (client reading wrong key, sending null profileid): low confidence — the 'briefly appears' symptom indicates the upload itself succeeds, so the regression is in the persistence step, not the upload response parsing.
- Auth/CORS issue in the wrapper app preventing the user PATCH: ruled out — Derek reports the issue persists across days and other ModTools writes work for him, so it's not a session-wide auth failure.

## Other Call Sites
Grep result for `OurUploader` in `components/` and `pages/`:
- `components/PostMessage.vue` — message attachments, not profile images
- `components/NewsThread.vue` — news thread attachments
- `components/VolunteerOpportunityModal.vue` — volunteer opportunity attachments
- `components/StoryAddModal.vue` — story attachments
- `components/NewsReply.vue` — news reply attachments
- `components/CommunityEventModal.vue` — event attachments
- `components/PosterModal.vue` — poster attachments
- `components/MessageEditModal.vue` — message edit attachments
- `components/ChatFooter.vue` — chat attachments
- `pages/chitchat/[[id]].vue` — chitchat attachments
- `components/settings/ProfileSection.vue` — **only profile image usage with `type="User"`** (this file — fixed here)

No other component has the same `profileid` persistence pattern. The bug is isolated to ProfileSection.

## Test
File: iznik-nuxt3/tests/unit/components/settings_ProfileSection.spec.js
Command: cd /home/edward/FreegleDockerWSL/iznik-nuxt3 && npm run test:unit:run -- --reporter=verbose settings_ProfileSection
Proves: test FAILS before this commit (see Evidence above), PASSES after
Regression suite: iznik-nuxt3 full unit suite — SUITE_PASSED=yes (576 test files, 12210 tests)

## Discourse
https://discourse.ilovefreegle.org/t/9679