### PR TITLE
fix(modtools/member-audit-log): write Group/Left audit log with correct byuser on all leave paths

### DIFF
--- a/iznik-server-go/test/membership_test.go
+++ b/iznik-server-go/test/membership_test.go
@@ -368,6 +368,87 @@ func TestDeleteMembershipsModRemovesMember(t *testing.T) {
 	assert.NotNil(t, leftLog, "Mod removing member must also log Group/Left for audit parity with V1")
 }
 
+// TestMemberAuditLogLeaveGroupByuser — AssertFlip regression guard.
+//
+// The diagnosis for issue #9678: Group/Left log entries written by the Go API
+// leave path were missing the byuser field (who performed the removal).
+// Mod-tools audit views display the leaver's name via the byuser column, so a
+// nil byuser makes leavers appear anonymous even after commit 0d342ced6 ensured
+// the row is written at all.
+//
+// AssertFlip protocol (fix already in master via 0d342ced6):
+//   Step 1 — Assert CORRECT behaviour (passes on fixed master):
+//     Group/Left log exists AND byuser is non-nil AND byuser equals the acting user.
+//   Step 2 — Invert (would fail on fixed master, proves assertion is meaningful):
+//     assert byuser IS nil — fails because fix sets it.
+//
+// Self-leave: byuser must equal the leaving user's own ID.
+// Mod-removes: byuser must equal the moderator's ID (not the removed member's).
+func TestMemberAuditLogLeaveGroupByuser(t *testing.T) {
+	t.Run("self-leave sets byuser to own ID", func(t *testing.T) {
+		prefix := uniquePrefix("audit_byuser_self")
+		db := database.DBConn
+
+		userID := CreateTestUser(t, prefix+"_user", "User")
+		_, token := CreateTestSession(t, userID)
+		groupID := CreateTestGroup(t, prefix)
+		CreateTestMembership(t, userID, groupID, "Member")
+
+		body := map[string]interface{}{"userid": userID, "groupid": groupID}
+		bodyBytes, _ := json.Marshal(body)
+		url := fmt.Sprintf("/api/memberships?jwt=%s", token)
+		req := httptest.NewRequest("DELETE", url, bytes.NewBuffer(bodyBytes))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := getApp().Test(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, resp.StatusCode)
+
+		// Step 2 (correct-behaviour assertion — FAILS on pre-fix code, PASSES after fix):
+		// The Group/Left log must exist and byuser must be the leaving user's own ID.
+		// Without this, mod-tools audit views show an anonymous leaver.
+		leftLog := findLog(db, "Group", "Left", userID)
+		assert.NotNil(t, leftLog, "self-leave must write Group/Left log")
+		if leftLog != nil {
+			assert.NotNil(t, leftLog.Byuser, "Group/Left byuser must not be nil for self-leave")
+			if leftLog.Byuser != nil {
+				assert.Equal(t, userID, *leftLog.Byuser, "Group/Left byuser must be the leaving user's own ID")
+			}
+		}
+	})
+
+	t.Run("mod-removes sets byuser to mod ID", func(t *testing.T) {
+		prefix := uniquePrefix("audit_byuser_mod")
+		db := database.DBConn
+
+		modID := CreateTestUser(t, prefix+"_mod", "User")
+		memberID := CreateTestUser(t, prefix+"_member", "User")
+		_, modToken := CreateTestSession(t, modID)
+		groupID := CreateTestGroup(t, prefix)
+		CreateTestMembership(t, modID, groupID, "Owner")
+		CreateTestMembership(t, memberID, groupID, "Member")
+
+		body := map[string]interface{}{"userid": memberID, "groupid": groupID}
+		bodyBytes, _ := json.Marshal(body)
+		url := fmt.Sprintf("/api/memberships?jwt=%s", modToken)
+		req := httptest.NewRequest("DELETE", url, bytes.NewBuffer(bodyBytes))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := getApp().Test(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, resp.StatusCode)
+
+		// Step 2 (correct-behaviour assertion — FAILS on pre-fix code, PASSES after fix):
+		// byuser must be the moderator's ID so the audit log shows who removed the member.
+		leftLog := findLog(db, "Group", "Left", memberID)
+		assert.NotNil(t, leftLog, "mod-removes must write Group/Left log for the removed member")
+		if leftLog != nil {
+			assert.NotNil(t, leftLog.Byuser, "Group/Left byuser must not be nil for mod-removes")
+			if leftLog.Byuser != nil {
+				assert.Equal(t, modID, *leftLog.Byuser, "Group/Left byuser must be the moderator's ID, not the removed member's")
+			}
+		}
+	})
+}
+
 func TestPatchMembershipsNotLoggedIn(t *testing.T) {
 	body := map[string]interface{}{"groupid": 1}
 	bodyBytes, _ := json.Marshal(body)


### PR DESCRIPTION
## Root Cause
The Go API leave/removal handler did not write a complete Group/Left audit-log row (or wrote one with byuser unpopulated) on every leave path — self-leave and mod-remove. Commit 0d342ced6 partially addressed log existence but did not lock in byuser correctness on all subpaths.

## Evidence
```
=== RUN   TestMemberAuditLogLeaveGroupByuser
=== RUN   TestMemberAuditLogLeaveGroupByuser/self-leave_sets_byuser_to_own_ID
    membership_test.go:410:
        	Error Trace:	/app/test/membership_test.go:410
        	Error:      	Expected value not to be nil.
        	Test:       	TestMemberAuditLogLeaveGroupByuser/self-leave_sets_byuser_to_own_ID
        	Messages:   	self-leave must write Group/Left log
=== RUN   TestMemberAuditLogLeaveGroupByuser/mod-removes_sets_byuser_to_mod_ID
    membership_test.go:442:
        	Error Trace:	/app/test/membership_test.go:442
        	Error:      	Expected value not to be nil.
        	Test:       	TestMemberAuditLogLeaveGroupByuser/mod-removes_sets_byuser_to_mod_ID
        	Messages:   	mod-removes must write Group/Left log for the removed member
--- FAIL: TestMemberAuditLogLeaveGroupByuser (0.12s)
    --- FAIL: TestMemberAuditLogLeaveGroupByuser/self-leave_sets_byuser_to_own_ID (0.04s)
    --- FAIL: TestMemberAuditLogLeaveGroupByuser/mod-removes_sets_byuser_to_mod_ID (0.08s)
FAIL	iznik-server-go/test	0.142s
```
(Run against the container's pre-fix code, which was stale from before commit 0d342ced6 was synced.)

## Fix
Commit 0d342ced6 (`fix(api): log Group/Left on Go API leave paths for audit parity with V1`) is the production fix already merged into master. It adds a `logMembershipAction(LOG_TYPE_GROUP, LOG_SUBTYPE_LEFT, req.Groupid, userid, myid, "")` call in `DeleteMemberships` (membership/membership.go) whenever `result.RowsAffected > 0`, covering both:
- **Self-leave**: `byuser = myid` (== userid for self-leave) — correct
- **Mod-removes-other**: `byuser = myid` (the moderator, not the removed member) — correct

This PR adds the AssertFlip regression test (`be6b7e081`) that validates both subtests pass with the fixed code, proving byuser is correctly populated in all leave paths.

## Alternatives Investigated
- byuser null due to system/self-delete context — ruled out as primary cause: doesn't explain entries entirely missing
- Front-end filter hiding null-name leaves — ruled out: would hide all or none, not the mixed pattern reported

## Other Call Sites
Grepped for all `DELETE FROM memberships` patterns in the Go API:
- `session/session.go:1538`: bulk-delete all memberships for a user during mail processing — account lifecycle, no Group/Left log needed
- `membership/membership.go:185`: rejects pending memberships — not a voluntary leave path
- `membership/membership.go:213-219`: ban path — already has `logMembershipAction(LOG_TYPE_GROUP, LOG_SUBTYPE_LEFT, ..., "via ban")` ✓
- `membership/membership.go:1356-1363`: partner unsubscribe — already has `logMembershipAction` added by 0d342ced6 ✓
- `user/user.go:2305,2458,2462,2646`: merge and account-delete operations — not Group/Left scenarios

No other files have the same missing-log pattern on the voluntary leave or mod-removes path.

## Test
File: iznik-server-go/test/membership_test.go
Command: cd /home/edward/FreegleDockerWSL/iznik-server-go && MYSQL_HOST=$(docker inspect freegle-percona -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}') go test ./test/... -run TestMemberAuditLogLeaveGroupByuser -v -count=1
Proves: test FAILS before fix (see Evidence above), PASSES after (see below)
```
=== RUN   TestMemberAuditLogLeaveGroupByuser
=== RUN   TestMemberAuditLogLeaveGroupByuser/self-leave_sets_byuser_to_own_ID
=== RUN   TestMemberAuditLogLeaveGroupByuser/mod-removes_sets_byuser_to_mod_ID
--- PASS: TestMemberAuditLogLeaveGroupByuser (0.17s)
    --- PASS: TestMemberAuditLogLeaveGroupByuser/self-leave_sets_byuser_to_own_ID (0.09s)
    --- PASS: TestMemberAuditLogLeaveGroupByuser/mod-removes_sets_byuser_to_mod_ID (0.08s)
PASS
ok  	iznik-server-go/test	0.196s
```
Regression suite: go-api full suite — SUITE_PASSED=yes

## Discourse
https://discourse.ilovefreegle.org/t/9678