### PR TITLE
fix(auth): return socialSignin status from lostpassword for OAuth-only accounts

### DIFF
--- a/iznik-server-go/session/session.go
+++ b/iznik-server-go/session/session.go
@@ -307,6 +307,29 @@ func handleLostPassword(c *fiber.Ctx, email string) error {
 		})
 	}
 
+	// Check whether the account has a native password. OAuth-only accounts (e.g.
+	// Google/Facebook signups) have no Native row in users_logins; sending them a
+	// password-reset link would be confusing and unhelpful — tell the frontend to
+	// redirect to social sign-in instead.
+	//
+	// Note: users with no login rows at all (email-only, never set a password) are
+	// allowed through — they can use the reset link to set their first password.
+	var nativeCount int64
+	db.Raw("SELECT COUNT(*) FROM users_logins WHERE userid = ? AND type = ?",
+		userID, utils.LOGIN_TYPE_NATIVE).Scan(&nativeCount)
+	if nativeCount == 0 {
+		var socialCount int64
+		db.Raw("SELECT COUNT(*) FROM users_logins WHERE userid = ? AND type IN (?, ?)",
+			userID, utils.LOGIN_TYPE_GOOGLE, utils.LOGIN_TYPE_FACEBOOK).Scan(&socialCount)
+		if socialCount > 0 {
+			return c.JSON(fiber.Map{
+				"ret":          1,
+				"status":       "This account uses social sign-in. Please sign in with Google, Facebook, or Yahoo.",
+				"socialSignin": true,
+			})
+		}
+	}
+
 	// Get or create the auto-login key for this user.
 	key, err := getOrCreateLoginKey(userID)
 	if err != nil {

--- a/iznik-server-go/test/session_lostpassword_oauth_test.go
+++ b/iznik-server-go/test/session_lostpassword_oauth_test.go
@@ -1,0 +1,95 @@
+package test
+
+// AssertFlip failing test for lostpassword blank screen on OAuth-only accounts.
+//
+// Bug: POST /api/session {action:"LostPassword"} with an OAuth-only user
+// (no Native row in users_logins) returns ret=0 with no socialSignin indicator.
+// The frontend cannot show "use social login" because it gets a generic success
+// response with no actionable status — resulting in a blank screen.
+//
+// After the fix: the endpoint returns a non-zero ret code and a socialSignin=true
+// field so the frontend can render the "sign in with Google/Yahoo/Facebook" message.
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/freegle/iznik-server-go/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// postLostPassword sends POST /api/session with action=LostPassword and returns decoded JSON.
+func postLostPassword(t *testing.T, email string) map[string]interface{} {
+	t.Helper()
+	body, err := json.Marshal(map[string]interface{}{
+		"action": "LostPassword",
+		"email":  email,
+	})
+	require.NoError(t, err)
+	req := httptest.NewRequest("POST", "/api/session", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := getApp().Test(req, -1)
+	require.NoError(t, err)
+	var result map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&result)
+	return result
+}
+
+// createOAuthOnlyUser creates a user that has a Google login but no Native password,
+// simulating a moderator account created via OAuth (e.g. Google Sign-In).
+func createOAuthOnlyUser(t *testing.T, prefix string) (uint64, string) {
+	t.Helper()
+	db := database.DBConn
+
+	email := fmt.Sprintf("%s@test.com", prefix)
+	fullname := fmt.Sprintf("OAuth User %s", prefix)
+
+	result := db.Exec("INSERT INTO users (firstname, lastname, fullname, systemrole) VALUES ('OAuth', ?, ?, 'User')",
+		prefix, fullname)
+	require.NoError(t, result.Error)
+
+	var userID uint64
+	db.Raw("SELECT id FROM users WHERE fullname = ? ORDER BY id DESC LIMIT 1", fullname).Scan(&userID)
+	require.NotZero(t, userID)
+
+	db.Exec("INSERT INTO users_emails (userid, email) VALUES (?, ?)", userID, email)
+
+	// Add a Google login to simulate OAuth signup — deliberately no Native login.
+	db.Exec("INSERT INTO users_logins (userid, type, uid, credentials) VALUES (?, ?, ?, ?)",
+		userID, utils.LOGIN_TYPE_GOOGLE, email, "google-oauth-token-test")
+
+	return userID, email
+}
+
+// TestLostPasswordOAuthOnlyUserReturnsNoPasswordStatus is an AssertFlip Step 2 test.
+//
+// This test FAILS on the current (unfixed) code because the endpoint returns
+// ret=0 (generic success) for OAuth-only accounts with no native password.
+// It will PASS after the fix, when the endpoint returns a non-zero ret code
+// and a socialSignin=true field so the frontend can show the correct message.
+func TestLostPasswordOAuthOnlyUserReturnsNoPasswordStatus(t *testing.T) {
+	prefix := uniquePrefix("lostpass_oauth")
+	_, email := createOAuthOnlyUser(t, prefix)
+
+	result := postLostPassword(t, email)
+
+	// After fix: endpoint must NOT return generic success (ret=0) for OAuth-only accounts.
+	// Currently fails: endpoint returns ret=0 regardless of whether a native password exists.
+	assert.NotEqual(t, float64(0), result["ret"],
+		"lostpassword must return a non-zero ret code for OAuth-only accounts so the frontend can show 'use social login'")
+
+	// After fix: response must carry a socialSignin indicator so the frontend renders
+	// the correct message instead of a blank screen.
+	socialSignin, hasSocialSignin := result["socialSignin"]
+	assert.True(t, hasSocialSignin,
+		"response must include a socialSignin field for accounts with no native password")
+	if hasSocialSignin {
+		assert.Equal(t, true, socialSignin,
+			"socialSignin must be true for OAuth-only accounts")
+	}
+}


### PR DESCRIPTION
## Root Cause
The lostpassword endpoint in iznik-server-go silently returns {"ret":0,"status":"Success"} for users with no Native row in users_logins (OAuth-only signups). The frontend has no signal to render a 'use social login' message and shows a blank screen.

## Evidence
```
=== RUN   TestLostPasswordOAuthOnlyUserReturnsNoPasswordStatus
    session_lostpassword_oauth_test.go:83:
        Error: Should not be: 0
        Messages: lostpassword must return a non-zero ret code for OAuth-only accounts so the frontend can show 'use social login'
    session_lostpassword_oauth_test.go:89:
        Error: Should be true
        Messages: response must include a socialSignin field for accounts with no native password
--- FAIL: TestLostPasswordOAuthOnlyUserReturnsNoPasswordStatus (0.03s)
```

## Fix
After finding the user by email, `handleLostPassword` now checks `users_logins` for a Native row. If none exists, it checks for Google/Facebook rows: if any social login is present, it returns `{"ret":1,"socialSignin":true}` so the frontend can show the correct 'sign in with Google/Facebook' message instead of a blank screen. Users with no login rows at all (email-only accounts that have never set a password) are unaffected and continue to receive the reset email.

## Alternatives Investigated
- Generic frontend JS crash on the forgot-password page: ruled out — only one mod affected, and 'no password set' is an account-data-specific condition.
- Email sent but spam-filtered leaving a blank success state: ruled out — a true success path renders a confirmation; blank screen indicates a missing render branch in the frontend handling of an unexpected response shape.

## Other Call Sites
`handleLostPassword` is called from exactly one place (`session/session.go:252`). No other files contain the same pattern.

## Test
File: iznik-server-go/test/session_lostpassword_oauth_test.go
Command: POST http://localhost:8081/api/tests/go {"filter":"TestLostPasswordOAuthOnlyUserReturnsNoPasswordStatus"}
Proves: test FAILS before this commit (see Evidence above), PASSES after (see TEST_PASSED output)
Regression suite: Go API — SUITE_PASSED=yes (2447 tests, 0 failures)

## Discourse
https://discourse.ilovefreegle.org/t/9677