### PR TITLE
fix(group-profile): group picture not sticking after upload in ModTools

### DIFF
--- a/iznik-server-go/group/group.go
+++ b/iznik-server-go/group/group.go
@@ -638,6 +638,7 @@ type PatchGroupRequest struct {
 	Mentored              *int     `json:"mentored"`
 	Ontn                  *int     `json:"ontn"`
 	Onlovejunk            *int              `json:"onlovejunk"`
+	Profile               *uint64           `json:"profile"`
 	Settings              *json.RawMessage  `json:"settings"`
 	Rules                 *json.RawMessage  `json:"rules"`
 	// Admin/Support only fields
@@ -727,6 +728,10 @@ func PatchGroup(c *fiber.Ctx) error {
 	}
 	if req.Onlovejunk != nil {
 		db.Exec("UPDATE `groups` SET onlovejunk = ? WHERE id = ?", *req.Onlovejunk, req.ID)
+	}
+	if req.Profile != nil {
+		db.Exec("UPDATE `groups` SET profile = ? WHERE id = ?", *req.Profile, req.ID)
+		logGroupEdit(req.ID, myid, "Profile")
 	}
 	if req.Settings != nil {
 		db.Exec("UPDATE `groups` SET settings = ? WHERE id = ?", string(*req.Settings), req.ID)

--- a/iznik-server-go/test/group_test.go
+++ b/iznik-server-go/test/group_test.go
@@ -1052,3 +1052,37 @@ func TestTnKeyInfoOmittedWhenNil(t *testing.T) {
 	_, ok := raw["tnkey"]
 	assert.False(t, ok, "tnkey should be omitted when nil")
 }
+
+// TestPatchGroupProfileImage verifies that PATCH /group persists the profile image ID.
+// Before the fix, PatchGroupRequest had no profile field so the update was silently
+// dropped — the group picture "briefly appeared" (upload succeeded) but never stuck.
+func TestPatchGroupProfileImage(t *testing.T) {
+	prefix := uniquePrefix("grpw_profile")
+	db := database.DBConn
+	groupID := CreateTestGroup(t, prefix)
+	userID := CreateTestUser(t, prefix+"_mod", "User")
+	_, token := CreateTestSession(t, userID)
+	CreateTestMembership(t, userID, groupID, "Moderator")
+
+	// Seed a groups_images row to act as the uploaded profile image.
+	// groups.profile FKs to groups_images.id, not users_images.
+	result := db.Exec("INSERT INTO groups_images (groupid, contenttype, archived) VALUES (?, 'image/jpeg', 0)", groupID)
+	require.NoError(t, result.Error)
+	var imageID uint64
+	db.Raw("SELECT id FROM groups_images WHERE groupid = ? ORDER BY id DESC LIMIT 1", groupID).Scan(&imageID)
+	require.NotZero(t, imageID, "seed image must be created")
+
+	body, _ := json.Marshal(map[string]interface{}{
+		"id":      groupID,
+		"profile": imageID,
+	})
+	req := httptest.NewRequest("PATCH", fmt.Sprintf("/api/group?jwt=%s", token), bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := getApp().Test(req, 10000)
+	require.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var savedProfile uint64
+	db.Raw("SELECT COALESCE(profile, 0) FROM `groups` WHERE id = ?", groupID).Scan(&savedProfile)
+	assert.Equal(t, imageID, savedProfile, "group profile image ID must be persisted after PATCH")
+}


### PR DESCRIPTION
## Root Cause
`PatchGroupRequest` in `iznik-server-go/group/group.go` had no `profile` field.
When `ModSettingsGroup.vue` calls `updateMT({ id, profile: imageID })` after a
successful upload, the Go handler silently dropped the profile field — the group
picture uploaded and briefly appeared (because the frontend updated optimistically)
but was never persisted.

Previous PR #461 fixed the wrong layer (user `ProfileSection.vue`). The actual
bug is in the Go API write path.

## Fix
Add `Profile *uint64 \`json:"profile"\`` to `PatchGroupRequest` and a corresponding
`UPDATE groups SET profile = ? WHERE id = ?` in the handler, with audit log.

## Test
`TestPatchGroupProfileImage` seeds a `groups_images` row, PATCHes with its ID,
and asserts the DB row is updated. Test fails before this commit (FK error proved
the field was ignored), passes after.

## Discourse
https://discourse.ilovefreegle.org/t/9679