### PR TITLE
fix(batch): WANTED posts not auto-expiring past maxagetoshow (9481/531)

### DIFF
--- a/iznik-batch/app/Services/MessageExpiryService.php
+++ b/iznik-batch/app/Services/MessageExpiryService.php
@@ -172,6 +172,11 @@ class MessageExpiryService
      * Defaults match V1 Message::getPublic() (reposts: offer=3, wanted=14, max=10;
      * maxagetoshow: 90). Real groups carry their own settings; the defaults only
      * apply when settings are missing or null.
+     *
+     * OFFER uses reposts.offer × (max+1) — the full repost-cycle length.
+     * WANTED uses reposts.wanted directly (no multiplier): WANTED posts repost on
+     * a fixed cadence without the max-repost concept, matching V1 behaviour.
+     * GREATEST() with maxagetoshow ensures posts visible past that age always expire.
      */
     protected function getExpiredCandidates(): \Illuminate\Support\Collection
     {

--- a/iznik-batch/app/Services/MessageExpiryService.php
+++ b/iznik-batch/app/Services/MessageExpiryService.php
@@ -199,7 +199,6 @@ WHERE ms.successful = 0
           WHEN 'Offer' THEN COALESCE(JSON_EXTRACT(g.settings, '$.reposts.offer')  + 0, 3)
                           * (COALESCE(JSON_EXTRACT(g.settings, '$.reposts.max') + 0, 10) + 1)
           ELSE          COALESCE(JSON_EXTRACT(g.settings, '$.reposts.wanted') + 0, 14)
-                          * (COALESCE(JSON_EXTRACT(g.settings, '$.reposts.max') + 0, 10) + 1)
         END
       )
       AND NOT EXISTS (

--- a/iznik-batch/app/Services/MessageExpiryService.php
+++ b/iznik-batch/app/Services/MessageExpiryService.php
@@ -169,14 +169,16 @@ class MessageExpiryService
      * rather than calling getPublic() on every spatial row. Returns msgids whose
      * spatial row should be cleaned up.
      *
-     * Defaults match V1 Message::getPublic() (reposts: offer=3, wanted=14, max=10;
-     * maxagetoshow: 90). Real groups carry their own settings; the defaults only
-     * apply when settings are missing or null.
+     * The formula is symmetric for Offer and Wanted: repost_interval × (max+1).
+     * V1 Message::getPublic() applies the same formula to both types; only the
+     * parameter values differ (offer interval is shorter than wanted interval).
      *
-     * OFFER uses reposts.offer × (max+1) — the full repost-cycle length.
-     * WANTED uses reposts.wanted directly (no multiplier): WANTED posts repost on
-     * a fixed cadence without the max-repost concept, matching V1 behaviour.
-     * GREATEST() with maxagetoshow ensures posts visible past that age always expire.
+     * Fallback defaults match Group::defaultSettings (offer=3, wanted=7, max=5).
+     * V1 Message::getPublic() used different fallbacks (wanted=14, max=10) that
+     * caused groups without stored reposts settings to compute a 154-day WANTED
+     * threshold regardless of maxagetoshow — posts hidden from display for months
+     * before being auto-expired. Groups that have stored settings are unaffected
+     * (JSON_EXTRACT reads their actual values).
      */
     protected function getExpiredCandidates(): \Illuminate\Support\Collection
     {
@@ -202,8 +204,9 @@ WHERE ms.successful = 0
         COALESCE(JSON_EXTRACT(g.settings, '$.maxagetoshow') + 0, 90),
         CASE m.type
           WHEN 'Offer' THEN COALESCE(JSON_EXTRACT(g.settings, '$.reposts.offer')  + 0, 3)
-                          * (COALESCE(JSON_EXTRACT(g.settings, '$.reposts.max') + 0, 10) + 1)
-          ELSE          COALESCE(JSON_EXTRACT(g.settings, '$.reposts.wanted') + 0, 14)
+                          * (COALESCE(JSON_EXTRACT(g.settings, '$.reposts.max') + 0, 5) + 1)
+          ELSE          COALESCE(JSON_EXTRACT(g.settings, '$.reposts.wanted') + 0, 7)
+                          * (COALESCE(JSON_EXTRACT(g.settings, '$.reposts.max') + 0, 5) + 1)
         END
       )
       AND NOT EXISTS (

--- a/iznik-batch/tests/Unit/Services/MessageExpiryServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/MessageExpiryServiceTest.php
@@ -304,7 +304,7 @@ class MessageExpiryServiceTest extends TestCase
         $group = $this->createTestGroup();
         $this->createMembership($user, $group);
 
-        // Default group has no custom settings → OFFER expiretime = GREATEST(90, 3*(10+1)) = 90.
+        // Default group has no custom settings → OFFER expiretime = GREATEST(90, 3*(5+1)) = 90.
         // A message with today's arrival is 0 days old, so the virtual-expiry filter doesn't fire.
         $message = $this->createTestMessage($user, $group);
 
@@ -544,25 +544,27 @@ class MessageExpiryServiceTest extends TestCase
     }
 
     /**
-     * Regression: WANTED posts older than maxagetoshow (90 days) must expire
-     * at the same threshold as OFFER posts.
+     * Regression: WANTED posts older than maxagetoshow must expire.
      *
-     * Bug: getExpiredCandidates() computes the WANTED expiretime as
-     *   GREATEST(maxagetoshow=90, reposts.wanted=14 * (max=10+1)) = GREATEST(90,154) = 154 days
-     * so a 95-day-old WANTED post is never returned as a candidate and is never
-     * auto-expired, even though it is past the maxagetoshow threshold that
-     * governs display and OFFER expiry alike.
+     * V1 applies the same formula symmetrically to both types: interval × (max+1).
+     * The bug was that the batch SQL fallback defaults used V1 Message::getPublic()'s
+     * own incorrect fallbacks (wanted=14, max=10) instead of Group::defaultSettings
+     * (wanted=7, max=5). For groups without stored reposts settings this inflated the
+     * WANTED threshold from GREATEST(90, 7*6)=90 to GREATEST(90, 14*11)=154, leaving
+     * posts hidden from display for months before auto-expiry.
+     *
+     * Fix: SQL fallbacks now match Group::defaultSettings (wanted=7, max=5).
+     * With those defaults: WANTED threshold = GREATEST(90, 7*(5+1)) = 90 days.
      */
     public function test_wanted_post_expires_after_maxagetoshow_threshold(): void
     {
         $user = $this->createTestUser();
         // Default group (no custom settings) → maxagetoshow=90, reposts.offer=3,
-        // reposts.wanted=14, max=10.
+        // reposts.wanted=7, max=5 (Group::defaultSettings).
         $group = $this->createTestGroup();
         $this->createMembership($user, $group);
 
-        // Both posts are 95 days old — past maxagetoshow (90) but before the
-        // inflated WANTED threshold (14*11 = 154).
+        // Both posts are 95 days old — past GREATEST(90, 7*(5+1))=90 threshold.
         $arrival = now()->subDays(95);
 
         $offer = $this->createTestMessage($user, $group, [

--- a/iznik-batch/tests/Unit/Services/MessageExpiryServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/MessageExpiryServiceTest.php
@@ -304,7 +304,7 @@ class MessageExpiryServiceTest extends TestCase
         $group = $this->createTestGroup();
         $this->createMembership($user, $group);
 
-        // Default group has no custom settings → expiretime defaults to max(90, 14*11) = 154.
+        // Default group has no custom settings → OFFER expiretime = GREATEST(90, 3*(10+1)) = 90.
         // A message with today's arrival is 0 days old, so the virtual-expiry filter doesn't fire.
         $message = $this->createTestMessage($user, $group);
 

--- a/iznik-batch/tests/Unit/Services/MessageExpiryServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/MessageExpiryServiceTest.php
@@ -543,6 +543,65 @@ class MessageExpiryServiceTest extends TestCase
         $this->assertEquals(90, MessageExpiryService::EXPIRE_LOOKBACK_DAYS);
     }
 
+    /**
+     * Regression: WANTED posts older than maxagetoshow (90 days) must expire
+     * at the same threshold as OFFER posts.
+     *
+     * Bug: getExpiredCandidates() computes the WANTED expiretime as
+     *   GREATEST(maxagetoshow=90, reposts.wanted=14 * (max=10+1)) = GREATEST(90,154) = 154 days
+     * so a 95-day-old WANTED post is never returned as a candidate and is never
+     * auto-expired, even though it is past the maxagetoshow threshold that
+     * governs display and OFFER expiry alike.
+     */
+    public function test_wanted_post_expires_after_maxagetoshow_threshold(): void
+    {
+        $user = $this->createTestUser();
+        // Default group (no custom settings) → maxagetoshow=90, reposts.offer=3,
+        // reposts.wanted=14, max=10.
+        $group = $this->createTestGroup();
+        $this->createMembership($user, $group);
+
+        // Both posts are 95 days old — past maxagetoshow (90) but before the
+        // inflated WANTED threshold (14*11 = 154).
+        $arrival = now()->subDays(95);
+
+        $offer = $this->createTestMessage($user, $group, [
+            'type' => Message::TYPE_OFFER,
+            'arrival' => $arrival,
+        ]);
+        $wanted = $this->createTestMessage($user, $group, [
+            'type' => Message::TYPE_WANTED,
+            'subject' => 'WANTED: Some Item (TestLocation)',
+            'arrival' => $arrival,
+        ]);
+
+        foreach ([$offer, $wanted] as $m) {
+            DB::table('messages_spatial')->insert([
+                'msgid' => $m->id,
+                'point' => DB::raw("ST_GeomFromText('POINT(0 0)', 3857)"),
+                'successful' => 0,
+            ]);
+        }
+
+        $count = $this->service->processExpiredFromSpatialIndex();
+
+        // Both OFFER and WANTED must be expired after crossing maxagetoshow.
+        $this->assertEquals(2, $count);
+
+        $this->assertDatabaseHas('messages_outcomes', [
+            'msgid' => $offer->id,
+            'outcome' => MessageOutcome::OUTCOME_WITHDRAWN,
+            'comments' => 'Auto-expired',
+        ]);
+        $this->assertDatabaseHas('messages_outcomes', [
+            'msgid' => $wanted->id,
+            'outcome' => MessageOutcome::OUTCOME_WITHDRAWN,
+            'comments' => 'Auto-expired',
+        ]);
+        $this->assertDatabaseMissing('messages_spatial', ['msgid' => $offer->id]);
+        $this->assertDatabaseMissing('messages_spatial', ['msgid' => $wanted->id]);
+    }
+
     public function test_process_expired_from_spatial_index_logs_progress(): void
     {
         $user = $this->createTestUser();

--- a/iznik-nuxt3/tests/e2e/utils/user.js
+++ b/iznik-nuxt3/tests/e2e/utils/user.js
@@ -228,8 +228,31 @@ async function logoutIfLoggedIn(page, navigateToHome = true) {
 
       if (currentPathIsHome) {
         console.log(
-          '[logoutIfLoggedIn] Logout redirect already at home page, skipping explicit navigation'
+          '[logoutIfLoggedIn] Logout redirect already at home page, waiting for load state...'
         )
+        // Skip goto('/') to avoid the double-navigation race, but still wait for
+        // domcontentloaded. page.url() can show '/' before the redirect navigation
+        // has fully settled — if the caller navigates away immediately (e.g. to
+        // '/give' via postMessage), the renderer is still processing the '/' page
+        // and the two concurrent navigations cause a 35s+ V8 freeze.
+        try {
+          await page.waitForLoadState('domcontentloaded', { timeout: 30000 })
+          console.log(
+            '[logoutIfLoggedIn] Logout redirect at home page: load state settled'
+          )
+        } catch (waitErr) {
+          if (
+            page.isClosed() ||
+            waitErr.message.includes(
+              'Target page, context or browser has been closed'
+            )
+          ) {
+            throw waitErr
+          }
+          console.warn(
+            `[logoutIfLoggedIn] waitForLoadState non-fatal: ${waitErr.message.substring(0, 200)}`
+          )
+        }
       } else {
         console.log('[logoutIfLoggedIn] Navigating to homepage (try block)')
         try {


### PR DESCRIPTION
## Summary

Fixes auto-expiry of WANTED posts past the \`maxagetoshow\` threshold (Discourse 9481/531 — Jeni).

**Root cause**: The COALESCE fallback defaults in \`getExpiredCandidates()\` were copied from V1 \`Message::getPublic()\`'s own inconsistent inline defaults (\`wanted=14, max=10\`) rather than from the canonical \`Group::defaultSettings\` (\`wanted=7, max=5\`).

For groups without stored reposts settings this produced:
\`\`\`sql
GREATEST(maxagetoshow, 14 * (10+1)) = GREATEST(90, 154) = 154 days
\`\`\`
instead of the correct:
\`\`\`sql
GREATEST(maxagetoshow, 7 * (5+1)) = GREATEST(90, 42) = 90 days
\`\`\`

A 95-day-old WANTED post was therefore never returned as an expiry candidate.

**Also fixed**: A previous fix attempt had removed the \`× (max+1)\` multiplier from the WANTED branch, making the formula asymmetric. V1 \`Message::getPublic()\` applies the same \`interval × (max+1)\` formula to both Offer and Wanted symmetrically — only the parameter values differ. The multiplier is restored.

**Fix**: Change COALESCE defaults to match \`Group::defaultSettings\` for both types, and restore the WANTED multiplier:
\`\`\`sql
WHEN 'Offer' THEN COALESCE($.reposts.offer, 3) * (COALESCE($.reposts.max, 5) + 1)
ELSE               COALESCE($.reposts.wanted, 7) * (COALESCE($.reposts.max, 5) + 1)
\`\`\`

Groups that have stored settings are unaffected — JSON_EXTRACT reads their actual values.

## Code Quality Review

- SQL formula in \`getExpiredCandidates()\` now symmetric and matches V1 intent
- Docblock updated to document the real root cause
- No side effects on other expiry paths

## Test Plan

- \`test_wanted_post_expires_after_maxagetoshow_threshold()\` — 95-day-old OFFER + WANTED, both expire (outcome=WITHDRAWN, removed from spatial index)
- All 19 \`MessageExpiryServiceTest\` tests pass