### PR TITLE
fix(group-profile): GET ignores groups.profile — load correct profile image by ID

### DIFF
--- a/iznik-nuxt3/modtools/components/ModSettingsGroup.vue
+++ b/iznik-nuxt3/modtools/components/ModSettingsGroup.vue
@@ -197,6 +197,7 @@
                 v-if="uploadingProfile"
                 v-model="profileAtts"
                 type="Group"
+                :groupid="groupid"
               />
             </b-form-group>
             <ModGroupSetting

--- a/iznik-server-go/group/group.go
+++ b/iznik-server-go/group/group.go
@@ -45,8 +45,9 @@ type Group struct {
 	Lng                  float32          `json:"lng"`
 	Altlat               float32          `json:"altlat"`
 	Altlng               float32          `json:"altlng"`
-	GroupProfile         GroupProfile     `gorm:"ForeignKey:groupid" json:"-"`
-	GroupProfileStr      string           `json:"profile"`
+	GroupProfile         GroupProfile     `gorm:"-" json:"-"`
+	Profile              uint64           `gorm:"column:profile" json:"-"`
+	GroupProfileStr      string           `json:"profile" gorm:"-"`
 	Onmap                int              `json:"onmap"`
 	Tagline              string           `json:"tagline"`
 	Description          string           `json:"description"`
@@ -196,7 +197,7 @@ func GetGroup(c *fiber.Ctx) error {
 
 		// Return the group even if publish = 0 or onhere = 0 because they have the actual id, so they must really
 		// want it.  This can happen if a user has a message on a group that is then set to publish = 0, for example.
-		q := db.Preload("GroupProfile")
+		q := db.Session(&gorm.Session{})
 
 		if !wantFilteredSponsors && wantSponsors {
 			// Load all sponsors via GORM Preload (no date/visible filtering) - backward compatible default.
@@ -207,8 +208,11 @@ func GetGroup(c *fiber.Ctx) error {
 		found = !errors.Is(err, gorm.ErrRecordNotFound)
 
 		if found {
-			if group.GroupProfile.ID > 0 {
-				group.GroupProfileStr = "https://" + os.Getenv("IMAGE_DOMAIN") + "/gimg_" + strconv.FormatUint(group.GroupProfile.ID, 10) + ".jpg"
+			if group.Profile > 0 {
+				db.Where("id = ?", group.Profile).First(&group.GroupProfile)
+				if group.GroupProfile.ID > 0 {
+					group.GroupProfileStr = "https://" + os.Getenv("IMAGE_DOMAIN") + "/gimg_" + strconv.FormatUint(group.GroupProfile.ID, 10) + ".jpg"
+				}
 			}
 
 			if len(group.Namefull) > 0 {
@@ -368,7 +372,7 @@ func getMultipleGroups(c *fiber.Ctx, idParam string) error {
 			defer wg.Done()
 
 			var g Group
-			err := db.Preload("GroupProfile").Preload("GroupSponsors").
+			err := db.Preload("GroupSponsors").
 				Raw("SELECT `groups`.*, CAST(JSON_EXTRACT(groups.settings, '$.showjoin') AS UNSIGNED) AS showjoin, ST_AsText(ST_ENVELOPE(polyindex)) AS bbox FROM `groups` WHERE id = ?", gid).
 				First(&g).Error
 
@@ -376,8 +380,11 @@ func getMultipleGroups(c *fiber.Ctx, idParam string) error {
 				return
 			}
 
-			if g.GroupProfile.ID > 0 {
-				g.GroupProfileStr = "https://" + os.Getenv("IMAGE_DOMAIN") + "/gimg_" + strconv.FormatUint(g.GroupProfile.ID, 10) + ".jpg"
+			if g.Profile > 0 {
+				db.Where("id = ?", g.Profile).First(&g.GroupProfile)
+				if g.GroupProfile.ID > 0 {
+					g.GroupProfileStr = "https://" + os.Getenv("IMAGE_DOMAIN") + "/gimg_" + strconv.FormatUint(g.GroupProfile.ID, 10) + ".jpg"
+				}
 			}
 
 			if len(g.Namefull) > 0 {

--- a/iznik-server-go/test/group_test.go
+++ b/iznik-server-go/test/group_test.go
@@ -1053,9 +1053,12 @@ func TestTnKeyInfoOmittedWhenNil(t *testing.T) {
 	assert.False(t, ok, "tnkey should be omitted when nil")
 }
 
-// TestPatchGroupProfileImage verifies that PATCH /group persists the profile image ID.
+// TestPatchGroupProfileImage verifies that PATCH /group persists the profile image ID,
+// and that GET /group returns the correct profile URL using groups.profile (not groupid join).
 // Before the fix, PatchGroupRequest had no profile field so the update was silently
 // dropped — the group picture "briefly appeared" (upload succeeded) but never stuck.
+// A second bug: GET used Preload("GroupProfile") joining on groupid, ignoring groups.profile,
+// so even after fixing PATCH the correct image was not returned on GET.
 func TestPatchGroupProfileImage(t *testing.T) {
 	prefix := uniquePrefix("grpw_profile")
 	db := database.DBConn
@@ -1064,12 +1067,12 @@ func TestPatchGroupProfileImage(t *testing.T) {
 	_, token := CreateTestSession(t, userID)
 	CreateTestMembership(t, userID, groupID, "Moderator")
 
-	// Seed a groups_images row to act as the uploaded profile image.
-	// groups.profile FKs to groups_images.id, not users_images.
-	result := db.Exec("INSERT INTO groups_images (groupid, contenttype, archived) VALUES (?, 'image/jpeg', 0)", groupID)
+	// Seed a groups_images row with groupid=NULL (simulating OurUploader without groupid prop).
+	// groups.profile stores the groups_images.id directly; GET must resolve by id not by groupid.
+	result := db.Exec("INSERT INTO groups_images (groupid, contenttype, archived) VALUES (NULL, 'image/jpeg', 0)")
 	require.NoError(t, result.Error)
 	var imageID uint64
-	db.Raw("SELECT id FROM groups_images WHERE groupid = ? ORDER BY id DESC LIMIT 1", groupID).Scan(&imageID)
+	db.Raw("SELECT LAST_INSERT_ID()").Scan(&imageID)
 	require.NotZero(t, imageID, "seed image must be created")
 
 	body, _ := json.Marshal(map[string]interface{}{
@@ -1085,4 +1088,15 @@ func TestPatchGroupProfileImage(t *testing.T) {
 	var savedProfile uint64
 	db.Raw("SELECT COALESCE(profile, 0) FROM `groups` WHERE id = ?", groupID).Scan(&savedProfile)
 	assert.Equal(t, imageID, savedProfile, "group profile image ID must be persisted after PATCH")
+
+	// Verify GET /group returns the profile URL derived from groups.profile (not groupid join).
+	getReq := httptest.NewRequest("GET", fmt.Sprintf("/api/group/%d?jwt=%s", groupID, token), nil)
+	getResp, err := getApp().Test(getReq, 10000)
+	require.NoError(t, err)
+	assert.Equal(t, 200, getResp.StatusCode)
+
+	var getBody map[string]interface{}
+	json.NewDecoder(getResp.Body).Decode(&getBody)
+	profileStr, _ := getBody["profile"].(string)
+	assert.Contains(t, profileStr, fmt.Sprintf("gimg_%d", imageID), "GET must return profile URL for the specific image ID stored in groups.profile")
 }


### PR DESCRIPTION
## Root Cause

PR #464 fixed PATCH /group to persist `groups.profile = imageID`, but the GET endpoint still used `Preload("GroupProfile")` joining `groups_images` by `groupid` — completely ignoring the stored image ID.

Two bugs combined to make the profile never stick:

**Bug 1 (frontend):** `OurUploader` in `ModSettingsGroup.vue` was not passed a `groupid` prop, so uploaded images were inserted into `groups_images` with `groupid = NULL`. The Preload filtered by `groupid = groups.id`, so it could never find those images.

**Bug 2 (backend):** Even when `groupid` was correct, GORM's `Preload("GroupProfile")` returned the first row by primary key — not necessarily the one referenced by `groups.profile`. The `groups.profile` column was only ever written, never read on GET.

## Fix

- **`group/group.go`**: Add `Profile uint64` field to the `Group` struct mapped to `groups.profile`. Remove `Preload("GroupProfile")` from both the single and multi-group GET handlers. After loading the group, if `Profile > 0`, load the specific `groups_images` record by `WHERE id = Profile`. This matches V1 PHP individual-GET behaviour (which also uses `groups.profile` as the image ID directly).
- **`ModSettingsGroup.vue`**: Pass `:groupid="groupid"` to `OurUploader` so new uploads are stored with the correct `groupid` association in `groups_images`.

## Test

Extended `TestPatchGroupProfileImage` to:
1. Seed a `groups_images` row with `groupid = NULL` (simulating the OurUploader bug before this fix)
2. PATCH with `profile: imageID`
3. Assert GET /group returns a profile URL containing `gimg_<imageID>` — proving the GET uses `groups.profile` to select the image, not the groupid join

## Code Quality Review

- No N+1 added for the common case (single group GET); multi-group handler already runs per-group goroutines
- No behaviour change for groups with no profile set (`Profile == 0` skips the lookup)
- Consistent with V1 PHP behaviour for individual group GET

Fixes discourse.ilovefreegle.org/t/9679 (follow-up to #464)