### PR TITLE
fix(chat/unread-count): handleAllSeen now clears unread for chats without a roster entry

### DIFF
--- a/iznik-server-go/chat/chatroom.go
+++ b/iznik-server-go/chat/chatroom.go
@@ -1427,6 +1427,21 @@ func handleAllSeen(c *fiber.Ctx, db *gorm.DB, myid uint64) error {
 		)
 		WHERE userid = ?`, myid)
 
+	// countUnseenMT uses LEFT JOIN chat_roster with COALESCE(lastmsgseen, 0), so
+	// moderator-visible chats without a roster row are treated as fully unread.
+	// When a moderator joins new groups, those groups' chats have no roster entry for
+	// the mod yet. Insert a seen pointer for any such chats so they are cleared.
+	modChatIDs := getModeratorChatIDs(db, myid, []string{utils.CHAT_TYPE_USER2MOD, utils.CHAT_TYPE_MOD2MOD}, "", 0)
+	if len(modChatIDs) > 0 {
+		idlist := joinIDs(modChatIDs)
+		db.Exec(`INSERT INTO chat_roster (chatid, userid, lastmsgseen, date)
+			SELECT cr.id, ?, COALESCE((SELECT MAX(id) FROM chat_messages WHERE chatid = cr.id), 0), NOW()
+			FROM chat_rooms cr
+			WHERE cr.id IN (`+idlist+`)
+			AND NOT EXISTS (SELECT 1 FROM chat_roster r2 WHERE r2.chatid = cr.id AND r2.userid = ?)`,
+			myid, myid)
+	}
+
 	return c.JSON(fiber.Map{"ret": 0, "status": "Success"})
 }
 

--- a/iznik-server-go/test/chat_test.go
+++ b/iznik-server-go/test/chat_test.go
@@ -4294,3 +4294,100 @@ func TestAllSeenIsolatedAcrossUsers(t *testing.T) {
 	db.Raw("SELECT lastmsgseen FROM chat_roster WHERE chatid = ? AND userid = ?", chatID, userAID).Scan(&aSeenAfter)
 	assert.Equal(t, userAKnownSeen, aSeenAfter, "AllSeen for userB must not modify userA's lastmsgseen")
 }
+
+// TestModeratorUnreadCountClearedByMarkAllRead is an AssertFlip test for bug 9675:
+// a moderator's unread badge is stuck at 99+ after joining new groups.
+//
+// Root cause: handleAllSeen only updates existing chat_roster rows (UPDATE … WHERE userid = ?).
+// countUnseenMT counts all moderator-visible chats via a LEFT JOIN; for chats where the
+// moderator has no roster entry, COALESCE(lastmsgseen, 0) = 0 so every message in those
+// chats is perpetually unread.  Newly-joined groups' chats have no roster entry for the
+// moderator, so handleAllSeen cannot clear them and the count stays > 0.
+//
+// AssertFlip Step 2 (inverted): assert count == 0 after markAllRead.
+// This FAILS on current code because handleAllSeen skips chats with no roster entry.
+func TestModeratorUnreadCountClearedByMarkAllRead(t *testing.T) {
+	prefix := uniquePrefix("unread9675")
+	db := database.DBConn
+
+	// Create a fresh moderator with no pre-existing memberships.
+	modID := CreateTestUser(t, prefix+"_mod", "Moderator")
+	_, modToken := CreateTestSession(t, modID)
+	// Member who will post messages into the mod's visible chats.
+	memberID := CreateTestUser(t, prefix+"_mbr", "User")
+
+	// Create 100 groups and User2Mod chats that the moderator can see (via membership)
+	// but for which the moderator has NO chat_roster entry — simulating chats that
+	// pre-existed before the mod joined the group (or were never explicitly opened).
+	numChats := 100
+	var chatIDs []uint64
+	for i := 0; i < numChats; i++ {
+		groupID := CreateTestGroup(t, fmt.Sprintf("%s_g%d", prefix, i))
+		CreateTestMembership(t, modID, groupID, "Moderator")
+		CreateTestMembership(t, memberID, groupID, "Member")
+
+		// Insert the chat room without a roster entry for the moderator.
+		db.Exec(
+			"INSERT INTO chat_rooms (user1, groupid, chattype, latestmessage) VALUES (?, ?, ?, NOW())",
+			memberID, groupID, utils.CHAT_TYPE_USER2MOD,
+		)
+		var chatID uint64
+		db.Raw("SELECT id FROM chat_rooms WHERE user1 = ? AND groupid = ? ORDER BY id DESC LIMIT 1",
+			memberID, groupID).Scan(&chatID)
+		chatIDs = append(chatIDs, chatID)
+
+		// Add a message from the member that countUnseenMT will pick up.
+		db.Exec(
+			"INSERT INTO chat_messages (chatid, userid, message, type, date, reviewrequired, reviewrejected, processingrequired, processingsuccessful) VALUES (?, ?, ?, 'Default', NOW(), 0, 0, 0, 1)",
+			chatID, memberID, fmt.Sprintf("unread msg %d", i),
+		)
+		db.Exec("UPDATE chat_rooms SET latestmessage = NOW() WHERE id = ?", chatID)
+
+		// Add member to roster so the chat is fully set up — but NOT the moderator.
+		db.Exec("INSERT IGNORE INTO chat_roster (chatid, userid) VALUES (?, ?)", chatID, memberID)
+	}
+
+	t.Cleanup(func() {
+		for _, chatID := range chatIDs {
+			db.Exec("DELETE FROM chat_messages WHERE chatid = ?", chatID)
+			db.Exec("DELETE FROM chat_roster WHERE chatid = ?", chatID)
+			db.Exec("DELETE FROM chat_rooms WHERE id = ?", chatID)
+		}
+		db.Exec("DELETE FROM memberships WHERE userid IN (?, ?)", modID, memberID)
+		db.Exec("DELETE FROM users WHERE id IN (?, ?)", modID, memberID)
+	})
+
+	// Verify unread count > 0 before mark-all-read.
+	req := httptest.NewRequest("GET",
+		fmt.Sprintf("/api/chatrooms?count=true&chattypes=User2Mod&jwt=%s", modToken), nil)
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+	var beforeResult map[string]interface{}
+	json2.Unmarshal(rsp(resp), &beforeResult)
+	countBefore := int64(beforeResult["count"].(float64))
+	assert.GreaterOrEqual(t, countBefore, int64(numChats),
+		"should have at least %d unread messages before markAllRead", numChats)
+
+	// Call mark-all-read (POST /chatrooms with action=AllSeen).
+	payload := map[string]interface{}{"action": "AllSeen"}
+	s, _ := json2.Marshal(payload)
+	req2 := httptest.NewRequest("POST", "/api/chatrooms?jwt="+modToken, bytes.NewBuffer(s))
+	req2.Header.Set("Content-Type", "application/json")
+	resp2, _ := getApp().Test(req2)
+	assert.Equal(t, fiber.StatusOK, resp2.StatusCode)
+
+	// AssertFlip Step 2 (inverted — FAILS on buggy code):
+	// After markAllRead the unread count must be 0.  The bug: handleAllSeen only runs
+	// UPDATE chat_roster … WHERE userid = ?, so chats with no roster entry for the mod
+	// are never touched, and countUnseenMT still sees them as fully unread.
+	req3 := httptest.NewRequest("GET",
+		fmt.Sprintf("/api/chatrooms?count=true&chattypes=User2Mod&jwt=%s", modToken), nil)
+	resp3, _ := getApp().Test(req3)
+	assert.Equal(t, 200, resp3.StatusCode)
+	var afterResult map[string]interface{}
+	json2.Unmarshal(rsp(resp3), &afterResult)
+	countAfter := int64(afterResult["count"].(float64))
+
+	assert.Equal(t, int64(0), countAfter,
+		"after markAllRead, unread count must be 0 (got %d: handleAllSeen skips chats with no roster entry)", countAfter)
+}


### PR DESCRIPTION
## Root Cause
handleAllSeen in iznik-server-go iterates only chatrooms where the current user has an existing chat_roster entry. When a moderator joins additional groups, the new modtools chatrooms are visible to the unread aggregator but lack a roster row for that user, so mark-all-read leaves them perpetually unread. The visible unread count then stays pinned at the cap (99 in production, 100 in the seeded test).

## Evidence
Failing test output before the fix (from CONFIRMED_FAILING step):
\`\`\`
=== RUN   TestModeratorUnreadCountClearedByMarkAllRead
    chat_test.go:4391:
        	Error:      Not equal:
        	            expected: 0
        	            actual  : 100
        	Messages:   after markAllRead, unread count must be 0 (got 100: handleAllSeen skips chats with no roster entry)
--- FAIL: TestModeratorUnreadCountClearedByMarkAllRead (6.04s)
FAIL	iznik-server-go/test	6.069s
\`\`\`

## Fix
After the existing UPDATE (which advances lastmsgseen for already-rostered chats), the fix calls `getModeratorChatIDs` to retrieve all User2Mod and Mod2Mod chats visible to this moderator, then INSERTs a chat_roster row (with lastmsgseen = max message ID) for any chat lacking one. This means subsequent calls to countUnseenMT find `COALESCE(lastmsgseen, max_msg_id)` > 0 rather than `COALESCE(NULL, 0) = 0`, so those chats are no longer counted as unread. The INSERT uses `NOT EXISTS` to skip chats already covered by the UPDATE.

## Alternatives Investigated
- Hard LIMIT 99 in unread SQL: ruled out — the failing assertion points specifically at handleAllSeen.
- Frontend stale chat list cache: ruled out — reproduction is server-side.
- Missing last_seen pointer: same underlying cause; addressed by this fix.

## Other Call Sites
`handleRosterUpdate` (single-chat mark-read) already uses INSERT ... ON DUPLICATE KEY UPDATE before updating lastmsgseen, so it always creates a roster entry first — no same-exclusion bug there. The read paths (`countUnseenMT`, chat list) use LEFT JOIN intentionally. No other occurrences of the roster-UPDATE-without-INSERT pattern found.

## Test
File: iznik-server-go/test/chat_test.go (TestModeratorUnreadCountClearedByMarkAllRead)
Command: docker exec -e MYSQL_DBNAME=iznik_go_test freegle-apiv2 /usr/local/go/bin/go test ./test/ -run TestModeratorUnreadCountClearedByMarkAllRead -v -count=1 -timeout 120s
Proves: test FAILS before this commit (see Evidence above), PASSES after (see TEST_PASSED output).
Regression suite: go-api — SUITE_PASSED=yes

## Discourse
https://discourse.ilovefreegle.org/t/9675