### PR TITLE
fix(test): skip page.goto('/') when logout redirect already at home page

### DIFF
--- a/iznik-nuxt3/tests/e2e/utils/user.js
+++ b/iznik-nuxt3/tests/e2e/utils/user.js
@@ -207,32 +207,57 @@ async function logoutIfLoggedIn(page, navigateToHome = true) {
       //      burn the entire 10-minute test budget.
       //   3. Any page-content errors here are irrelevant to the test being set up;
       //      the test will navigate to its actual target URL straight afterwards.
-      console.log('[logoutIfLoggedIn] Navigating to homepage (try block)')
-      try {
-        await page.goto('/', {
-          timeout: timeouts.navigation.initial,
-          waitUntil: 'domcontentloaded',
-        })
+      //
+      // Skip the explicit navigation if the logout redirect already landed us at '/'.
+      // Calling page.goto('/') while the page is already loading '/' (from the logout
+      // redirect) triggers a double-navigation race: the logout-redirect navigation and
+      // the explicit goto compete, Chromium ends up processing both simultaneously, and
+      // the V8 renderer can hang for 35+ seconds before freeze-detection fires. This
+      // race is most visible when /browse auto-redirects new users to /explore (no group
+      // membership), because logoutIfLoggedIn then runs from /explore — the logout
+      // redirect to '/' is still in flight when goto('/') is called.
+      const currentPathIsHome =
+        !page.isClosed() &&
+        (() => {
+          try {
+            return new URL(page.url()).pathname === '/'
+          } catch {
+            return false
+          }
+        })()
+
+      if (currentPathIsHome) {
         console.log(
-          `[logoutIfLoggedIn] Navigated to homepage (try block) url=${page.url()}`
+          '[logoutIfLoggedIn] Logout redirect already at home page, skipping explicit navigation'
         )
-      } catch (navErr) {
-        // If the page itself was closed (e.g. by freeze-detection heartbeat), propagate
-        // as fatal so the test fails immediately rather than continuing with a dead page.
-        if (
-          page.isClosed() ||
-          navErr.message.includes(
-            'Target page, context or browser has been closed'
+      } else {
+        console.log('[logoutIfLoggedIn] Navigating to homepage (try block)')
+        try {
+          await page.goto('/', {
+            timeout: timeouts.navigation.initial,
+            waitUntil: 'domcontentloaded',
+          })
+          console.log(
+            `[logoutIfLoggedIn] Navigated to homepage (try block) url=${page.url()}`
           )
-        ) {
-          throw navErr
+        } catch (navErr) {
+          // If the page itself was closed (e.g. by freeze-detection heartbeat), propagate
+          // as fatal so the test fails immediately rather than continuing with a dead page.
+          if (
+            page.isClosed() ||
+            navErr.message.includes(
+              'Target page, context or browser has been closed'
+            )
+          ) {
+            throw navErr
+          }
+          console.warn(
+            `[logoutIfLoggedIn] Homepage navigation failed (non-fatal): ${navErr.message.substring(
+              0,
+              200
+            )}`
+          )
         }
-        console.warn(
-          `[logoutIfLoggedIn] Homepage navigation failed (non-fatal): ${navErr.message.substring(
-            0,
-            200
-          )}`
-        )
       }
     }
 

--- a/iznik-nuxt3/tests/unit/e2e-utils/logoutIfLoggedIn.spec.js
+++ b/iznik-nuxt3/tests/unit/e2e-utils/logoutIfLoggedIn.spec.js
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('../../e2e/config.js', () => ({
+  timeouts: { ui: { appearance: 1000, interaction: 1000 }, navigation: { initial: 5000 } },
+  DEFAULT_TEST_PASSWORD: 'x',
+  SCREENSHOTS_DIR: '/tmp',
+}))
+vi.mock('../../e2e/utils/ui.js', () => ({
+  waitForModal: vi.fn(),
+}))
+
+const { logoutIfLoggedIn } = require('../../e2e/utils/user.js')
+
+function makeLocator(visible = false) {
+  return {
+    waitFor: vi.fn().mockResolvedValue(undefined),
+    isVisible: vi.fn().mockResolvedValue(visible),
+    click: vi.fn().mockResolvedValue(undefined),
+    evaluate: vi.fn().mockResolvedValue(undefined),
+    filter: function () {
+      return this
+    },
+  }
+}
+
+function makePage(url = 'http://example.com/', overrides = {}) {
+  const gotoMock = vi.fn().mockResolvedValue(undefined)
+  return {
+    _url: url,
+    isClosed: () => false,
+    url: function () {
+      return this._url
+    },
+    goto: gotoMock,
+    evaluate: vi.fn().mockResolvedValue(undefined),
+    context: () => ({ clearCookies: vi.fn().mockResolvedValue(undefined) }),
+    locator: vi.fn().mockImplementation((selector) => {
+      if (selector === '#menu-option-logout') {
+        return makeLocator(false)
+      }
+      if (selector === 'text=Logout') {
+        return makeLocator(false)
+      }
+      return makeLocator(false)
+    }),
+    addAllowedErrorPattern: vi.fn(),
+    ...overrides,
+  }
+}
+
+describe('logoutIfLoggedIn (e2e util)', () => {
+  it('skips page.goto("/") when logout redirect already landed at home page', async () => {
+    // The bug: after logout redirects to '/', calling page.goto('/') while the
+    // page is still hydrating causes a double-navigation race that freezes the
+    // Chromium renderer. Fix: skip goto('/') if already at '/'.
+    const page = makePage('http://freegle-prod-local.localhost:9080/')
+    await logoutIfLoggedIn(page)
+    expect(page.goto).not.toHaveBeenCalled()
+  })
+
+  it('calls page.goto("/") when logout did not redirect to home page', async () => {
+    // When logout leaves the user on a non-home page, we still need to navigate.
+    const page = makePage('http://freegle-prod-local.localhost:9080/explore')
+    await logoutIfLoggedIn(page)
+    expect(page.goto).toHaveBeenCalledWith(
+      '/',
+      expect.objectContaining({ waitUntil: 'domcontentloaded' })
+    )
+  })
+
+  it('skips page.goto("/") when already at root with query string (e.g. ?t=1)', async () => {
+    const page = makePage('http://freegle-prod-local.localhost:9080/?t=1')
+    await logoutIfLoggedIn(page)
+    expect(page.goto).not.toHaveBeenCalled()
+  })
+
+  it('calls page.goto("/") when at /browse even with trailing slash', async () => {
+    const page = makePage('http://freegle-prod-local.localhost:9080/browse')
+    await logoutIfLoggedIn(page)
+    expect(page.goto).toHaveBeenCalledWith(
+      '/',
+      expect.objectContaining({ waitUntil: 'domcontentloaded' })
+    )
+  })
+})


### PR DESCRIPTION
## Summary

- **Root cause**: `logoutIfLoggedIn` always called `page.goto('/')` after clicking logout, even when the logout redirect already navigated to `/`. This double-navigation races with ongoing page hydration, freezing the Chromium V8 renderer for 35+ seconds until freeze-detection fires.
- **Trigger**: Test 4.1 (`test-reply-flow-social.spec.js`) registers a fresh user with no group membership. The `/browse` page immediately calls `router.push('/explore')` because no location/group is set. By the time `logoutIfLoggedIn` clicks logout, the page is at `/explore`. The logout redirect navigates `/explore → /`, and then the explicit `page.goto('/')` causes the race.
- **Fix**: After `clearSessionData`, check `page.url().pathname`. If it is already `/`, skip the explicit navigation — auth state has been cleared and the next test step navigates to its own target immediately.
- **Unit tests added**: `logoutIfLoggedIn.spec.js` covering skip logic for pages at `/`, `/?t=1`, `/browse`, and `/explore`.

## Reproduces production CI failure

Production CI job #14739 failed: `1 [chromium] › tests/e2e/test-reply-flow-social.spec.js:34:3 › Reply Flow - Social Login Simulation › 4.1 reply state survives loginCount key bump (social login simulation)`.

The same test passed on master CI job #14724 (same code) because the logout click happened faster — before the `/browse → /explore` redirect fired — so no double-navigation race occurred.

## Test plan

- [x] Existing Vitest unit tests (12212) pass
- [ ] New unit tests in `logoutIfLoggedIn.spec.js` pass (validates fix logic)
- [ ] Playwright test 4.1 passes on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)