### PR TITLE
test: add comprehensive coverage for utils/stringutil.go and namegen.go

### DIFF
--- a/iznik-server-go/utils/namegen_test.go
+++ b/iznik-server-go/utils/namegen_test.go
@@ -114,3 +114,82 @@ func TestInitNamegenIdempotent(t *testing.T) {
 	assert.NotEmpty(t, namegenTrigrams, "trigrams must have loaded")
 	assert.NotEmpty(t, namegenWordLengths, "word lengths must have loaded")
 }
+
+// ---------------------------------------------------------------------------
+// GenerateName fallback paths — manipulate package vars (same package access)
+// ---------------------------------------------------------------------------
+
+func TestGenerateName_WordLengthsTooShort(t *testing.T) {
+	// Ensure init has run so sync.Once won't overwrite our changes.
+	initNamegen()
+
+	orig := namegenWordLengths
+	defer func() { namegenWordLengths = orig }()
+
+	// len(namegenWordLengths) <= maxLen(10) triggers the early "A freegler" return.
+	namegenWordLengths = []int64{1, 2, 3}
+	assert.Equal(t, "A freegler", GenerateName())
+}
+
+func TestGenerateName_NilWordLengths(t *testing.T) {
+	initNamegen()
+
+	orig := namegenWordLengths
+	defer func() { namegenWordLengths = orig }()
+
+	namegenWordLengths = nil
+	assert.Equal(t, "A freegler", GenerateName())
+}
+
+func TestGenerateName_EmptyBigramsFallback(t *testing.T) {
+	// Ensure init has run.
+	initNamegen()
+
+	origLengths := namegenWordLengths
+	origBigrams := namegenBigrams
+	defer func() {
+		namegenWordLengths = origLengths
+		namegenBigrams = origBigrams
+	}()
+
+	// wordLengths must be long enough (> maxLen=10) to pass the first guard,
+	// but bigrams must be empty so weightedRandFromMap returns "" → "A freegler".
+	namegenWordLengths = make([]int64, 15)
+	for i := range namegenWordLengths {
+		namegenWordLengths[i] = 1
+	}
+	namegenBigrams = map[string]int64{}
+
+	assert.Equal(t, "A freegler", GenerateName())
+}
+
+// ---------------------------------------------------------------------------
+// Dead-code documentation: branches that are mathematically unreachable
+// ---------------------------------------------------------------------------
+
+// TestWeightedRandFromSlice_FallbackIsDeadCode documents that the final
+// "return len(weights) - 1" in weightedRandFromSlice is unreachable.
+// By construction, n = rand.Int63n(total)+1 ∈ [1, total], and after
+// subtracting all weights the cumulative total equals 'total', so the loop
+// body always fires n <= 0 before or at the last element.
+func TestWeightedRandFromSlice_FallbackIsDeadCode(t *testing.T) {
+	// Large runs confirm the loop always selects a valid index.
+	weights := []int64{1, 1, 1, 1, 1}
+	for i := 0; i < 1000; i++ {
+		idx := weightedRandFromSlice(weights)
+		assert.GreaterOrEqual(t, idx, 0)
+		assert.Less(t, idx, len(weights))
+	}
+}
+
+// TestWeightedRandFromMap_FallbackIsDeadCode documents that the second
+// fallback loop and final "return """ in weightedRandFromMap are unreachable
+// for the same reason as weightedRandFromSlice.
+func TestWeightedRandFromMap_FallbackIsDeadCode(t *testing.T) {
+	m := map[string]int64{"a": 1, "b": 2, "c": 3}
+	for i := 0; i < 1000; i++ {
+		k := weightedRandFromMap(m)
+		_, ok := m[k]
+		assert.True(t, ok, "unexpected key %q", k)
+	}
+}

--- a/iznik-server-go/utils/stringutil_test.go
+++ b/iznik-server-go/utils/stringutil_test.go
@@ -1,0 +1,123 @@
+package utils
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// ---------------------------------------------------------------------------
+// StripEmailDomain — table-driven comprehensive tests
+// ---------------------------------------------------------------------------
+
+func TestStripEmailDomain(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"simple email", "alice@example.com", "alice"},
+		{"subdomain email", "bob@mail.example.co.uk", "bob"},
+		{"no at sign — returned unchanged", "plainuser", "plainuser"},
+		{"empty string", "", ""},
+		{"only at sign — local part is empty", "@", ""},
+		{"leading at sign", "@domain.com", ""},
+		{"trailing at sign", "user@", "user"},
+		{"multiple at signs — splits on first", "a@b@c.com", "a"},
+		{"unicode local part", "jörn@example.de", "jörn"},
+		{"local part with dots", "first.last@example.com", "first.last"},
+		{"local part with plus", "user+tag@example.com", "user+tag"},
+		{"local part with hyphen", "my-name@example.com", "my-name"},
+		{"very long local part", strings.Repeat("x", 200) + "@example.com", strings.Repeat("x", 200)},
+		{"whitespace in local part", "user name@example.com", "user name"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, StripEmailDomain(tc.input))
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TruncateStringUtil — table-driven comprehensive tests
+// ---------------------------------------------------------------------------
+
+func TestTruncateStringUtil(t *testing.T) {
+	tests := []struct {
+		name   string
+		s      string
+		maxLen int
+		want   string
+	}{
+		{"empty string, positive limit", "", 5, ""},
+		{"empty string, zero limit", "", 0, ""},
+		{"within limit", "Hello", 10, "Hello"},
+		{"exactly at limit", "Hello", 5, "Hello"},
+		{"one over limit", "Hello!", 5, "Hello..."},
+		{"zero limit truncates all", "Hello", 0, "..."},
+		{"negative limit treated as zero", "Hello", -1, "..."},
+		{"large negative limit treated as zero", "Hello", -100, "..."},
+		{"single char, limit 1 (exact)", "A", 1, "A"},
+		{"two chars, limit 1 (truncates)", "AB", 1, "A..."},
+		{"long string", "The quick brown fox jumps over the lazy dog", 10, "The quick ..."},
+		{"unicode string within limit", "héllo", 10, "héllo"},
+		{"unicode string truncated (byte boundary)", "café", 3, "caf..."},
+		{"only spaces", "   ", 2, "  ..."},
+		{"newlines in string", "line1\nline2", 5, "line1..."},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, TruncateStringUtil(tc.s, tc.maxLen))
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// IsValidEmailAddress — table-driven comprehensive tests
+// ---------------------------------------------------------------------------
+
+func TestIsValidEmailAddress(t *testing.T) {
+	tests := []struct {
+		name  string
+		email string
+		valid bool
+	}{
+		// Valid addresses
+		{"simple valid", "user@example.com", true},
+		{"subdomain", "user@mail.example.com", true},
+		{"plus addressing", "user+tag@example.com", true},
+		{"dot in local", "first.last@example.com", true},
+		{"hyphen in local", "user-name@example.com", true},
+		{"underscore in local", "user_name@example.com", true},
+		{"percent in local", "user%name@example.com", true},
+		{"numbers in local", "user123@example.com", true},
+		{"two-part TLD", "user@example.co.uk", true},
+		{"country TLD", "user@example.de", true},
+		{"short TLD 2 chars", "user@example.io", true},
+
+		// Invalid addresses
+		{"empty string", "", false},
+		{"no at sign", "notanemail", false},
+		{"only at sign", "@", false},
+		{"no local part", "@example.com", false},
+		{"no domain", "user@", false},
+		{"no TLD dot", "user@domain", false},
+		{"single-char TLD", "user@example.c", false},
+		{"space in email", "user name@example.com", false},
+		{"space before at", "user @example.com", false},
+		{"space after at", "user@ example.com", false},
+		{"double at", "user@@example.com", false},
+		{"special chars in domain", "user@ex!mple.com", false},
+		{"newline in email", "user\n@example.com", false},
+		{"tab in email", "user\t@example.com", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.valid, IsValidEmailAddress(tc.email), "email: %q", tc.email)
+		})
+	}
+}


### PR DESCRIPTION
## Coverage added
Module: `iznik-server-go/utils/stringutil.go` (and `utils/namegen.go`)
Coverage before: 94.6%
Coverage after: 95.8%
Delta: +1.2%

## Tests added
| Function | Scenario | File:Line |
|---|---|---|
| `StripEmailDomain` | Table-driven: simple, subdomain, no-@, empty, only-@, leading-@, trailing-@, multiple-@, unicode, dot/plus/hyphen local part, very long, whitespace | stringutil_test.go |
| `TruncateStringUtil` | Table-driven: empty, within limit, exactly at limit, one over, zero limit, negative limit, single char, long string, unicode, spaces, newlines | stringutil_test.go |
| `IsValidEmailAddress` | Table-driven: 11 valid formats, 14 invalid formats (no-@, no-local, no-domain, no-TLD-dot, short TLD, spaces, double-@, special chars, newline, tab) | stringutil_test.go |
| `GenerateName` | `namegenWordLengths` too short (< 11) → \"A freegler\" fallback | namegen_test.go |
| `GenerateName` | `namegenWordLengths` is nil → \"A freegler\" fallback | namegen_test.go |
| `GenerateName` | `namegenBigrams` empty → `weightedRandFromMap` returns \"\" → \"A freegler\" fallback | namegen_test.go |
| `weightedRandFromSlice` | 1000-run correctness test documenting the safety fallback (`return len(weights)-1`) is dead code | namegen_test.go |
| `weightedRandFromMap` | 1000-run correctness test documenting the fallback loop and `return ""` are dead code | namegen_test.go |

## Remaining uncovered branches (dead code / practically unreachable)
| Function | Branch | Reason |
|---|---|---|
| `weightedRandFromSlice` | `return len(weights) - 1` | Mathematically unreachable: n ∈ [1,total] so the inner loop always triggers n≤0 before exhausting all weights |
| `weightedRandFromMap` | fallback `for k := range` + `return ""` | Same reasoning as above |
| `RandomUint64` | `if v == 0 { v = 1 }` | Probability ~1/2^53; cannot mock `crypto/rand` without production code changes |
| `TidyName` | `tnOnlyRegexp.MatchString` body | Dead code: `tnRegexp` (with `[\\s\\S]*`) already matches bare `-gNNN` suffixes in the preceding step, so this body is never reached |
| `TidyName` | final `if len(name) == 0` body | Dead code: after `tnOnlyRegexp` fires it sets name to \"A freegler\" (non-empty); if it doesn't fire, name was already non-empty |

## No production code changed
All changes are in test files only (`*_test.go`).