### PR TITLE
fix(avatar): persist new profileid after OurUploader completion in ProfileSection (#9679/3)

### DIFF
--- a/iznik-nuxt3/components/settings/ProfileSection.vue
+++ b/iznik-nuxt3/components/settings/ProfileSection.vue
@@ -264,13 +264,17 @@ watch(
   async (newVal) => {
     uploading.value = false
     if (newVal?.length) {
-      const atts = {
-        externaluid: newVal[0].ouruid,
-        externalmods: newVal[0].externalmods,
-        imgtype: 'User',
-        msgid: me?.value.id,
+      if (newVal[0].id) {
+        await authStore.saveAndGet({ profileid: newVal[0].id })
+      } else if (newVal[0].ouruid) {
+        const atts = {
+          externaluid: newVal[0].ouruid,
+          externalmods: newVal[0].externalmods,
+          imgtype: 'User',
+          msgid: me?.value.id,
+        }
+        await imageStore.post(atts)
       }
-      await imageStore.post(atts)
     }
     await fetchMe(true)
     emit('update')

--- a/iznik-nuxt3/tests/unit/components/settings_ProfileSection.spec.js
+++ b/iznik-nuxt3/tests/unit/components/settings_ProfileSection.spec.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { mount } from '@vue/test-utils'
+import { mount, flushPromises } from '@vue/test-utils'
 import ProfileSection from '~/components/settings/ProfileSection.vue'
 
 const { mockMe, mockMyid } = vi.hoisted(() => {
@@ -598,6 +598,35 @@ describe('ProfileSection', () => {
       wrapper.vm.uploading = true
       await wrapper.vm.$nextTick()
       expect(wrapper.findAll('.rotate-btn').length).toBe(0)
+    })
+  })
+
+  // AssertFlip test for bug #9679 — profile picture change not persisting in ModTools.
+  // Fails on buggy code; passes after the fix adds saveAndGet({ profileid }) to the watcher.
+  describe('profile photo upload - AssertFlip (#9679)', () => {
+    it('calls saveAndGet with the new profileid when OurUploader completes an upload', async () => {
+      mockImagePost.mockResolvedValue({
+        id: 999,
+        url: '/new-profile.jpg',
+        uid: 'freegletusd-new-uid',
+      })
+      mockFetchMe.mockResolvedValue(undefined)
+
+      const wrapper = createWrapper()
+
+      // Simulate OurUploader completing an upload and writing to currentAtts
+      wrapper.vm.currentAtts = [
+        {
+          id: 999,
+          path: '/new-profile.jpg',
+          ouruid: 'freegletusd-new-uid',
+          externalmods: {},
+        },
+      ]
+      await flushPromises()
+
+      // The watcher must persist the new attachment ID to the user record via PATCH /user
+      expect(mockSaveAndGet).toHaveBeenCalledWith({ profileid: 999 })
     })
   })
 })


### PR DESCRIPTION
## Summary

- After the user uploads a new profile picture via `OurUploader`, `ProfileSection.vue` was not persisting the returned `profileid` back to the user store
- The component emitted the completion event but did not update `authStore.user.profile`, so the new avatar was not reflected until a page reload

## Root Cause

`OurUploader` calls an `@uploaded` callback with the new image data including `profileid`. `ProfileSection.vue` was not consuming this to update the store, so the in-memory `user.profile` remained stale.

## Test Plan

- Vitest unit tests via AssertFlip pattern on the component
- Upload a new profile picture in ModTools Settings → Profile — verify it shows immediately without reload