### PR TITLE
fix(monitor-fsm): auto-cancel pending drafts when bug is dismissed

### DIFF
--- a/monitor-fsm/src/__tests__/actions.persist_classifications.test.ts
+++ b/monitor-fsm/src/__tests__/actions.persist_classifications.test.ts
@@ -236,7 +236,8 @@ describe('regression detection in persist_classifications', () => {
   })
 
   it('does NOT flag regression when new bug symptom_tags have ZERO overlap with fixed bug tags', async () => {
-    // 9518/238 scenario: prior fix was for iOS add-note bug; new bug is a 500-error on Banned filter
+    // Prior fix was for iOS add-note bug; new bug is a completely unrelated symptom.
+    // Use synthetic keywords that won't match any real git commits.
     upsertDiscourseBug(db, {
       topic: 304, post: 1, state: 'fixed', prNumber: 350,
       symptomTags: ['ios', 'add-note', 'chat-review', 'button-disabled'],
@@ -244,8 +245,8 @@ describe('regression detection in persist_classifications', () => {
     await persistClassificationsHandler({}, {
       classifications: [{
         topic: 304, post: 5, type: 'bug', user: 'reporter',
-        symptom_tags: ['500-error', 'banned-filter', 'spammer-undefined'],
-        summary: 'Members > Approved filtered by Banned causes 500',
+        symptom_tags: ['zythian-quorblax', 'frambulated', 'xyloquartz-defrobler'],
+        summary: 'Zythian quorblax frambulated xyloquartz defrobler',
       }],
     })
     const bug = getDiscourseBug(db, 304, 5)

--- a/monitor-fsm/src/__tests__/db.helpers.test.ts
+++ b/monitor-fsm/src/__tests__/db.helpers.test.ts
@@ -9,6 +9,7 @@ import {
   getDiscourseBug,
   queueDiscourseDraft,
   listPendingDrafts,
+  cancelDraftsForBug,
   reopenBugAfterRejection,
   markDiscourseBugFixed,
 } from '../db/index'
@@ -215,6 +216,48 @@ describe('Database Helpers', () => {
       expect(id2).not.toBe(id1)
       const pendingCount = (testDb.prepare('SELECT COUNT(*) AS c FROM discourse_draft WHERE posted_at IS NULL AND rejected_at IS NULL').get() as { c: number }).c
       expect(pendingCount).toBe(1)
+    })
+  })
+
+  describe('cancelDraftsForBug', () => {
+    it('should cancel pending drafts for a bug', () => {
+      queueDiscourseDraft(testDb, { topic: 700, post: 1, username: 'edward', quote: 'q', body: 'draft 1' })
+      queueDiscourseDraft(testDb, { topic: 700, post: 2, username: 'edward', quote: 'q', body: 'draft 2' })
+
+      const count = cancelDraftsForBug(testDb, 700, 1, 'Bug dismissed as off-topic')
+      expect(count).toBe(1)
+
+      const pending = listPendingDrafts(testDb)
+      expect(pending.length).toBe(1)
+      expect(pending[0].post).toBe(2)
+
+      const cancelled = testDb.prepare('SELECT * FROM discourse_draft WHERE topic = 700 AND post = 1').get() as { rejected_at: string | null; rejection_reason: string | null }
+      expect(cancelled.rejected_at).not.toBeNull()
+      expect(cancelled.rejection_reason).toBe('Bug dismissed as off-topic')
+    })
+
+    it('should not cancel already-posted drafts', () => {
+      const id = queueDiscourseDraft(testDb, { topic: 701, post: 1, username: 'edward', quote: 'q', body: 'posted draft' })
+      testDb.prepare(`UPDATE discourse_draft SET posted_at = datetime('now') WHERE id = ?`).run(id)
+
+      const count = cancelDraftsForBug(testDb, 701, 1, 'too late')
+      expect(count).toBe(0)
+    })
+
+    it('should return 0 when no pending drafts exist', () => {
+      const count = cancelDraftsForBug(testDb, 999, 1, 'nothing here')
+      expect(count).toBe(0)
+    })
+
+    it('should not cancel already-rejected drafts', () => {
+      const id = queueDiscourseDraft(testDb, { topic: 702, post: 1, username: 'edward', quote: 'q', body: 'rejected draft' })
+      testDb.prepare(`UPDATE discourse_draft SET rejected_at = datetime('now'), rejection_reason = 'old reason' WHERE id = ?`).run(id)
+
+      const count = cancelDraftsForBug(testDb, 702, 1, 'new reason')
+      expect(count).toBe(0)
+
+      const row = testDb.prepare('SELECT rejection_reason FROM discourse_draft WHERE id = ?').get(id) as { rejection_reason: string }
+      expect(row.rejection_reason).toBe('old reason')
     })
   })
 

--- a/monitor-fsm/src/actions/index.ts
+++ b/monitor-fsm/src/actions/index.ts
@@ -13,6 +13,7 @@ import {
   kvGet,
   kvSet,
   queueDiscourseDraft,
+  cancelDraftsForBug,
   insertReviewerFeedback,
   listUnprocessedFeedback,
   upsertDiscourseBug,
@@ -441,6 +442,8 @@ print(json.dumps({'confirmations': results, 'edwardUpdates': edward_updates}))
           db.prepare(
             "UPDATE discourse_bug SET state='off-topic', reason=? WHERE topic=? AND post=?"
           ).run(`Edward (post ${u.postNumber}): "${u.text.slice(0, 120)}"`, u.topic, u.post)
+          const cancelled = cancelDraftsForBug(db, u.topic, u.post, 'Bug dismissed as off-topic')
+          if (cancelled > 0) out(`check_bug_feedback: cancelled ${cancelled} pending draft(s) for off-topic bug ${u.topic}/${u.post}`)
           markedOffTopic.push({ topic: u.topic, post: u.post, reason: u.text.slice(0, 80) })
           out(`check_bug_feedback: marked ${u.topic}/${u.post} off-topic — Edward explained expected behaviour`)
         } else if (u.action === 'investigating') {
@@ -2162,6 +2165,8 @@ ANALYSIS_COMPLETE is for tasks that involve NO code changes (e.g. Discourse tria
               featureArea: c.featureArea ?? undefined, symptomTags, codeArea: codeArea ?? undefined,
               reason: `Duplicate of topic ${tagDup.topic}/${tagDup.post} (tag overlap)`,
             })
+            const cancelled = cancelDraftsForBug(db, Number(c.topic), Number(c.post), `Bug marked duplicate of topic ${tagDup.topic}/${tagDup.post}`)
+            if (cancelled > 0) out(`persist_classifications: cancelled ${cancelled} pending draft(s) for duplicate bug ${c.topic}/${c.post}`)
             out(`persist_classifications: topic ${c.topic}/${c.post} marked duplicate of ${tagDup.topic}/${tagDup.post} (tag similarity)`)
             upserted++
             continue

--- a/monitor-fsm/src/db/index.ts
+++ b/monitor-fsm/src/db/index.ts
@@ -410,6 +410,22 @@ export function listPendingDrafts(db: DB): DiscourseDraftRow[] {
   `).all() as DiscourseDraftRow[]
 }
 
+/**
+ * Cancel all pending (unposted, unrejected) drafts for a bug.
+ * Called when a bug is dismissed (off-topic, duplicate) so stale
+ * replies don't accumulate in the dashboard queue.
+ * Returns the number of drafts cancelled.
+ */
+export function cancelDraftsForBug(db: DB, topic: number, post: number, reason: string): number {
+  const info = db.prepare(`
+    UPDATE discourse_draft
+    SET rejected_at = datetime('now'), rejection_reason = ?
+    WHERE topic = ? AND post = ?
+      AND posted_at IS NULL AND rejected_at IS NULL
+  `).run(reason, topic, post)
+  return info.changes as number
+}
+
 // -------- Reviewer feedback --------
 
 export interface ReviewerFeedbackRow {


### PR DESCRIPTION
## Summary

- Adds `cancelDraftsForBug` to `monitor-fsm/src/db/index.ts` — marks all pending (unposted, unrejected) drafts for a bug as rejected when called
- Wires it into `check_bug_feedback` (off-topic transition) and `persist_classifications` (duplicate transition) so pending Discourse reply drafts are cleaned up automatically when a bug is dismissed
- Fixes a test data issue in `actions.persist_classifications.test.ts` where `checkGitAlreadyFixed` was finding a real commit matching the "banned-filter" test keywords, causing a spurious `fixed` state

## Test Plan

- [ ] `npm test` in `monitor-fsm/` — 161 tests pass
- [ ] New `cancelDraftsForBug` tests cover: cancels pending drafts, skips posted drafts, returns 0 for already-rejected, returns 0 when none exist
- [ ] Existing pending drafts in `monitor.db` cleared manually (bugs already handled)