### PR TITLE
fix(modtools/members): remove 28-day cap on modmail recipients filter

### DIFF
--- a/iznik-server-go/membership/membership.go
+++ b/iznik-server-go/membership/membership.go
@@ -384,16 +384,23 @@ func GetMemberships(c *fiber.Ctx) error {
 	// ordered by join date (m.added DESC) to match the default listing order.
 	if filter == 6 {
 		var members []GetMembershipsMember
+		// Join logs instead of users_modmails: users_modmails is pruned at 30 days by the
+		// users:update-modmails cron, so an INNER JOIN on it silently drops members whose
+		// only modmails are older than ~30 days.  The logs table is not pruned and is the
+		// authoritative source; criteria match the modmailsonly filter in logs/logs.go.
 		db.Raw("SELECT m.id, m.userid, m.groupid, m.role, m.collection, m.added, m.heldby, "+
 			"u.fullname, u.firstname, u.lastname, m.settings, "+
 			"m.emailfrequency, m.ourPostingStatus, m.eventsallowed, m.volunteeringallowed, "+
 			"b.date AS bandate, b.byuser AS bannedby, "+
 			"m.reviewrequestedat, m.reviewedat, m.reviewreason, u.engagement, "+
-			"MAX(um.timestamp) AS lastmodmail "+
+			"MAX(l.timestamp) AS lastmodmail "+
 			"FROM memberships m "+
 			"JOIN users u ON u.id = m.userid "+
 			"LEFT JOIN users_banned b ON b.userid = m.userid AND b.groupid = m.groupid "+
-			"INNER JOIN users_modmails um ON um.userid = m.userid AND um.groupid = m.groupid "+
+			"INNER JOIN logs l ON l.user = m.userid AND l.groupid = m.groupid "+
+			"AND ((l.type = 'Message' AND l.subtype IN ('Rejected', 'Deleted', 'Replied')) "+
+			"OR (l.type = 'User' AND l.subtype IN ('Mailed', 'Rejected', 'Deleted'))) "+
+			"AND l.byuser != l.user "+
 			"WHERE m.groupid = ? AND m.collection = ? "+
 			"GROUP BY m.userid "+
 			"ORDER BY m.added DESC LIMIT ?",

--- a/iznik-server-go/test/membership_test.go
+++ b/iznik-server-go/test/membership_test.go
@@ -3436,6 +3436,69 @@ func TestGetMembershipsModmailFilterOrderAndLimit(t *testing.T) {
 	}
 }
 
+// TestGetMembershipsFilter6OldModmailPruned is an AssertFlip failing test for issue 9518.
+//
+// Bug: filter=6 (Received mod mails) omits members whose only modmails are older than
+// ~30 days.  The root cause is that users_modmails entries are pruned at 30 days by the
+// users:update-modmails cron, and the filter=6 query uses INNER JOIN users_modmails
+// (no date guard).  Members with no surviving users_modmails row are silently excluded.
+//
+// AssertFlip Step 2 (inverted): asserts the correct behaviour — the member MUST appear —
+// and therefore FAILS on the current buggy code, proving the regression exists.
+//
+// Fix: replace the INNER JOIN users_modmails with a join on the logs table, which is not
+// pruned, using the same type/subtype criteria as UserModMailsService.
+func TestGetMembershipsFilter6OldModmailPruned(t *testing.T) {
+	prefix := uniquePrefix("mf_pruned")
+	db := database.DBConn
+
+	groupID := CreateTestGroup(t, prefix)
+
+	modID := CreateTestUser(t, prefix+"_mod", "User")
+	CreateTestMembership(t, modID, groupID, "Moderator")
+	_, token := CreateTestSession(t, modID)
+
+	memberID := CreateTestUser(t, prefix+"_member", "User")
+	CreateTestMembership(t, memberID, groupID, "Member")
+
+	// Seed a logs entry representing a modmail (User/Mailed) from 35 days ago.
+	// This simulates a real modmail action whose users_modmails entry has since been
+	// pruned by the 30-day cron.  We deliberately do NOT insert into users_modmails.
+	result := db.Exec(
+		"INSERT INTO logs (type, subtype, groupid, user, byuser, timestamp, text) "+
+			"VALUES ('User', 'Mailed', ?, ?, ?, DATE_SUB(NOW(), INTERVAL 35 DAY), 'test modmail')",
+		groupID, memberID, modID,
+	)
+	if result.Error != nil {
+		t.Fatalf("ERROR: Failed to insert logs entry: %v", result.Error)
+	}
+
+	url := fmt.Sprintf("/api/memberships?groupid=%d&filter=6&jwt=%s", groupID, token)
+	req := httptest.NewRequest("GET", url, nil)
+	resp, err := getApp().Test(req, -1)
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var members []map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&members)
+
+	// STEP 2 (inverted — this is the failing assertion that proves the bug):
+	// The member received a modmail 35 days ago.  Even though the users_modmails row
+	// has been pruned, the log entry still exists.  The correct behaviour is for the
+	// member to appear in the filter=6 listing; the current code omits them.
+	found := false
+	for _, m := range members {
+		if uid, ok := m["userid"].(float64); ok && uint64(uid) == memberID {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found,
+		"member with a 35-day-old modmail log entry (users_modmails pruned) must appear in filter=6 results")
+}
+
 // --- Partner auth tests ---
 
 func insertTestPartnerKey(t *testing.T, prefix string, domain string) string {

--- a/iznik-server-go/test/membership_test.go
+++ b/iznik-server-go/test/membership_test.go
@@ -3338,10 +3338,10 @@ func TestGetMembershipsFilterModmails(t *testing.T) {
 	member3ID := CreateTestUser(t, prefix+"_m3", "User")
 	CreateTestMembership(t, member3ID, groupID, "Member")
 
-	// Insert modmail records: member1 older, member2 newer, member3 has none.
-	// logid has a UNIQUE constraint so we need distinct non-zero values.
-	db.Exec("INSERT INTO users_modmails (userid, groupid, timestamp, logid) VALUES (?, ?, '2026-01-01 10:00:00', ?)", member1ID, groupID, member1ID)
-	db.Exec("INSERT INTO users_modmails (userid, groupid, timestamp, logid) VALUES (?, ?, '2026-03-01 10:00:00', ?)", member2ID, groupID, member2ID)
+	// Insert modmail records via logs (the authoritative source; users_modmails is pruned at 30 days).
+	// member3 has no log entry and must be excluded by the filter.
+	db.Exec("INSERT INTO logs (type, subtype, groupid, user, byuser, timestamp, text) VALUES ('User', 'Mailed', ?, ?, ?, '2026-01-01 10:00:00', 'test modmail')", groupID, member1ID, modID)
+	db.Exec("INSERT INTO logs (type, subtype, groupid, user, byuser, timestamp, text) VALUES ('User', 'Mailed', ?, ?, ?, '2026-03-01 10:00:00', 'test modmail')", groupID, member2ID, modID)
 
 	url := fmt.Sprintf("/api/memberships?groupid=%d&filter=6&jwt=%s", groupID, token)
 	req := httptest.NewRequest("GET", url, nil)
@@ -3399,10 +3399,11 @@ func TestGetMembershipsModmailFilterOrderAndLimit(t *testing.T) {
 			joinHoursAgo, membershipID)
 
 		// Anti-correlated modmail: oldest joiner (i=24) gets newest modmail (1h ago).
+		// Insert via logs (the authoritative source; users_modmails is pruned at 30 days).
 		mailHoursAgo := memberCount - i
 		db.Exec(
-			"INSERT INTO users_modmails (userid, groupid, timestamp, logid) VALUES (?, ?, DATE_SUB(NOW(), INTERVAL ? HOUR), ?)",
-			uid, groupID, mailHoursAgo, uid,
+			"INSERT INTO logs (type, subtype, groupid, user, byuser, timestamp, text) VALUES ('User', 'Mailed', ?, ?, ?, DATE_SUB(NOW(), INTERVAL ? HOUR), 'test modmail')",
+			groupID, uid, modID, mailHoursAgo,
 		)
 	}
 


### PR DESCRIPTION
## Root Cause
The backend Go query that lists approved members with the 'received mod mails' filter (filter=6) used `INNER JOIN users_modmails` (`iznik-server-go/membership/membership.go`, line ~396 before this fix). The PHP `users:update-modmails` cron syncs recent mod actions into `users_modmails` but **prunes entries older than 30 days** (`strtotime("Midnight 30 days ago")`). Any member whose only modmails are older than ~30 days has no surviving `users_modmails` row, so the INNER JOIN silently excludes them from the listing.

## Evidence
```
=== RUN   TestGetMembershipsFilter6OldModmailPruned
    membership_test.go:3498: 
        	Error Trace:	/app/test/membership_test.go:3498
        	Error:      	Should be true
        	Test:       	TestGetMembershipsFilter6OldModmailPruned
        	Messages:   	member with a 35-day-old modmail log entry (users_modmails pruned) must appear in filter=6 results
--- FAIL: TestGetMembershipsFilter6OldModmailPruned (0.07s)
```

## Fix
Replaced the `INNER JOIN users_modmails` with `INNER JOIN logs` at `iznik-server-go/membership/membership.go` (filter=6 branch), using the same type/subtype criteria as the PHP `updateModMails` cron and the Go `modmailsonly` filter in `logs/logs.go`:
- `(type='Message' AND subtype IN ('Rejected','Deleted','Replied')) OR (type='User' AND subtype IN ('Mailed','Rejected','Deleted'))`
- `byuser != user` (exclude self-actions)

The `logs` table is authoritative and is never pruned, so all modmail recipients appear regardless of age. Also updated `TestGetMembershipsFilterModmails` and `TestGetMembershipsModmailFilterOrderAndLimit` to insert test data into `logs` instead of `users_modmails`, matching the new query source.

## Alternatives Investigated
- Frontend hardcodes a 28-day `since` parameter — ruled out: filter UI has no date picker; cap matches server-side pruning pattern
- Nightly cleanup purges old modmail rows — ruled out: older modmails remain visible elsewhere in modtools; the `logs` table is not pruned; only `users_modmails` is

## Other Call Sites
No other occurrences of `INTERVAL 28` or `INTERVAL 28 DAY` found across iznik-server-go or iznik-server PHP on modmail-related queries. The PHP `INTERVAL 30 DAY` in `updateModMails` is the intentional pruning cron for `users_modmails` itself — not a query filter.

## Test
File: iznik-server-go/test/membership_test.go
Command: docker exec -w /app freegle-apiv2 sh -c "export MYSQL_HOST=172.19.0.4 && export MYSQL_DBNAME=iznik_go_test && go test -count=1 ./test/... -run TestGetMembershipsFilter6OldModmailPruned -v 2>&1"
Proves: test FAILS before this commit (see Evidence above), PASSES after (see TEST_PASSED output)
Regression suite: go-api full test/... — SUITE_PASSED=yes

## Discourse
https://discourse.ilovefreegle.org/t/9518