### PR TITLE
feat(support): add % moderated column to support communities list

### DIFF
--- a/iznik-nuxt3/modtools/components/ModSupportListGroups.vue
+++ b/iznik-nuxt3/modtools/components/ModSupportListGroups.vue
@@ -45,6 +45,18 @@
         >
         </hot-column>
         <hot-column
+          title="Moderated (30d)"
+          data="recentmoderated"
+          :renderer="centreRenderer"
+        >
+        </hot-column>
+        <hot-column
+          title="% Moderated (30d)"
+          data="recentmoderatedpercent"
+          :renderer="moderatedPctRenderer"
+        >
+        </hot-column>
+        <hot-column
           title="Active-owner"
           data="activeownercount"
           :renderer="centreRenderer"
@@ -172,6 +184,21 @@ function autoApprovesRenderer(_instance, td, _row, _col, _prop, value) {
   td.style.textAlign = 'center'
   auto = Math.abs(auto)
   td.innerHTML = auto + '%'
+}
+
+function moderatedPctRenderer(_instance, td, _row, _col, _prop, value) {
+  const pct = Math.round(parseFloat(value) || 0)
+  td.style.textAlign = 'center'
+  // Highlight groups where < 10% of arriving messages were moderated (may indicate
+  // auto-approve is fully covering this community, or that moderation is very low).
+  if (pct < 10) {
+    td.style.backgroundColor = '#d4edda'
+  } else if (pct >= 80) {
+    td.style.backgroundColor = '#fff3cd'
+  } else {
+    td.style.backgroundColor = ''
+  }
+  td.innerHTML = pct + '%'
 }
 
 function centreRenderer(_instance, td, _row, _col, _prop, value) {

--- a/iznik-server-go/group/group.go
+++ b/iznik-server-go/group/group.go
@@ -125,6 +125,8 @@ type GroupEntry struct {
 	Recentautoapproves     *int       `json:"recentautoapproves,omitempty" gorm:"-"`
 	Recentmanualapproves   *int       `json:"recentmanualapproves,omitempty" gorm:"-"`
 	Recentautoapprovespct  *float64   `json:"recentautoapprovespercent,omitempty" gorm:"-"`
+	Recentmoderated        *int       `json:"recentmoderated,omitempty" gorm:"-"`
+	Recentmoderatedpct     *float64   `json:"recentmoderatedpercent,omitempty" gorm:"-"`
 
 	// Polygon fields (only populated when polygon=true query param)
 	Poly         *string `json:"poly,omitempty" gorm:"-"`
@@ -492,31 +494,51 @@ func ListGroups(c *fiber.Ctx) error {
 		db.Raw("SELECT id, nameshort, namefull, lat, lng, onmap, publish, region, contactmail, mentored, CAST(JSON_EXTRACT(groups.settings, '$.showjoin') AS UNSIGNED) AS showjoin FROM `groups` WHERE publish = 1 AND onhere = 1 AND type = ?", FREEGLE).Scan(&groups)
 	}
 
-	// For support mode, fetch recent auto-approve and manual-approve counts in parallel.
+	// For support mode, fetch recent auto-approve, manual-approve, and moderation counts in parallel.
 	type approveCount struct {
 		Groupid uint64 `gorm:"column:groupid"`
 		Count   int    `gorm:"column:count"`
 	}
+	type moderatedCount struct {
+		Groupid        uint64 `gorm:"column:groupid"`
+		ModeratedCount int    `gorm:"column:moderated_count"`
+		TotalCount     int    `gorm:"column:total_count"`
+	}
 
 	var autoApproves []approveCount
 	var manualApproves []approveCount
+	var moderatedCounts []moderatedCount
 
 	if isAdminOrSupport {
-		start := time.Now().AddDate(0, 0, -31).Format("2006-01-02")
+		start31 := time.Now().AddDate(0, 0, -31).Format("2006-01-02")
+		start30 := time.Now().AddDate(0, 0, -30).Format("2006-01-02")
 
 		var wg sync.WaitGroup
-		wg.Add(2)
+		wg.Add(3)
 
 		go func() {
 			defer wg.Done()
 			db.Raw("SELECT COUNT(*) AS count, groupid FROM logs WHERE timestamp >= ? AND type = ? AND subtype = ? GROUP BY groupid",
-				start, "Message", "Autoapproved").Scan(&autoApproves)
+				start31, "Message", "Autoapproved").Scan(&autoApproves)
 		}()
 
 		go func() {
 			defer wg.Done()
 			db.Raw("SELECT COUNT(*) AS count, groupid FROM logs WHERE timestamp >= ? AND type = ? AND subtype = ? GROUP BY groupid",
-				start, "Message", "Approved").Scan(&manualApproves)
+				start31, "Message", "Approved").Scan(&manualApproves)
+		}()
+
+		go func() {
+			defer wg.Done()
+			// Count messages where a moderator manually approved (approvedby IS NOT NULL)
+			// vs total messages arriving in the past 30 days, grouped by community.
+			// Uses arrival rather than approvedat so the denominator is consistent.
+			db.Raw(`SELECT groupid,
+				SUM(approvedby IS NOT NULL) AS moderated_count,
+				COUNT(*) AS total_count
+				FROM messages_groups
+				WHERE arrival >= ?
+				GROUP BY groupid`, start30).Scan(&moderatedCounts)
 		}()
 
 		wg.Wait()
@@ -529,6 +551,10 @@ func ListGroups(c *fiber.Ctx) error {
 		manualMap := make(map[uint64]int, len(manualApproves))
 		for _, a := range manualApproves {
 			manualMap[a.Groupid] = a.Count
+		}
+		modMap := make(map[uint64]moderatedCount, len(moderatedCounts))
+		for _, m := range moderatedCounts {
+			modMap[m.Groupid] = m
 		}
 
 		for ix := range groups {
@@ -549,6 +575,15 @@ func ListGroups(c *fiber.Ctx) error {
 				pct = float64(100*autoCount) / float64(total)
 			}
 			groups[ix].Recentautoapprovespct = &pct
+
+			mc := modMap[groups[ix].ID]
+			modCount := mc.ModeratedCount
+			groups[ix].Recentmoderated = &modCount
+			var modPct float64
+			if mc.TotalCount > 0 {
+				modPct = float64(100*mc.ModeratedCount) / float64(mc.TotalCount)
+			}
+			groups[ix].Recentmoderatedpct = &modPct
 		}
 	}
 

--- a/iznik-server-go/test/group_test.go
+++ b/iznik-server-go/test/group_test.go
@@ -314,6 +314,14 @@ func TestListGroupsWithSupport(t *testing.T) {
 	db.Exec("INSERT INTO logs (timestamp, groupid, type, subtype) VALUES (NOW(), ?, ?, ?)", groupID, flog.LOG_TYPE_MESSAGE, flog.LOG_SUBTYPE_APPROVED)
 	db.Exec("INSERT INTO logs (timestamp, groupid, type, subtype) VALUES (NOW(), ?, ?, ?)", groupID, flog.LOG_TYPE_MESSAGE, flog.LOG_SUBTYPE_APPROVED)
 
+	// Insert messages_groups rows for the moderated% test:
+	// 2 of 3 messages have approvedby set (manually moderated), 1 does not.
+	msgID1 := CreateTestMessage(t, adminID, groupID, prefix+"_modmsg1", 51.5074, -0.1278)
+	msgID2 := CreateTestMessage(t, adminID, groupID, prefix+"_modmsg2", 51.5074, -0.1278)
+	msgID3 := CreateTestMessage(t, adminID, groupID, prefix+"_modmsg3", 51.5074, -0.1278)
+	db.Exec("UPDATE messages_groups SET approvedby = ? WHERE msgid IN (?, ?)", adminID, msgID1, msgID2)
+	// msgID3 left with approvedby = NULL (not moderated)
+
 	// Request with support=true and admin JWT.
 	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/group?support=true&jwt="+token, nil))
 	assert.Equal(t, 200, resp.StatusCode)
@@ -347,6 +355,8 @@ func TestListGroupsWithSupport(t *testing.T) {
 	assert.Contains(t, found, "recentautoapproves")
 	assert.Contains(t, found, "recentmanualapproves")
 	assert.Contains(t, found, "recentautoapprovespercent")
+	assert.Contains(t, found, "recentmoderated")
+	assert.Contains(t, found, "recentmoderatedpercent")
 
 	// Verify the approve counts are sensible.
 	assert.Equal(t, float64(1), found["recentautoapproves"])
@@ -354,6 +364,13 @@ func TestListGroupsWithSupport(t *testing.T) {
 	assert.Equal(t, float64(1), found["recentmanualapproves"])
 	// Percent = 100*1/(1+1) = 50
 	assert.Equal(t, float64(50), found["recentautoapprovespercent"])
+
+	// Verify moderated count: 2 of 3 messages have approvedby set.
+	assert.Equal(t, float64(2), found["recentmoderated"])
+	// 2/3 * 100 ≈ 66.67
+	modPct, ok := found["recentmoderatedpercent"].(float64)
+	assert.True(t, ok)
+	assert.InDelta(t, 66.67, modPct, 0.5)
 
 	// Verify that activeownercount is returned correctly.
 	assert.Equal(t, float64(2), found["activeownercount"])
@@ -376,10 +393,14 @@ func TestListGroupsWithSupport(t *testing.T) {
 		assert.NotContains(t, regularGroups[0], "lastmoderated")
 		assert.NotContains(t, regularGroups[0], "activeownercount")
 		assert.NotContains(t, regularGroups[0], "recentautoapproves")
+		assert.NotContains(t, regularGroups[0], "recentmoderated")
+		assert.NotContains(t, regularGroups[0], "recentmoderatedpercent")
 	}
 
-	// Cleanup test log entries.
+	// Cleanup test data.
 	db.Exec("DELETE FROM logs WHERE groupid = ? AND type = 'Message' AND subtype IN ('Autoapproved', 'Approved')", groupID)
+	db.Exec("DELETE FROM messages_groups WHERE msgid IN (?, ?, ?)", msgID1, msgID2, msgID3)
+	db.Exec("DELETE FROM messages WHERE id IN (?, ?, ?)", msgID1, msgID2, msgID3)
 }
 
 func TestGetGroupWithShowmods(t *testing.T) {


### PR DESCRIPTION
## Summary

- Adds **"Moderated (30d)"** column: count of messages where a moderator manually set `approvedby` in the past 30 days per community
- Adds **"% Moderated (30d)"** column: that count as a percentage of all messages arriving in the past 30 days — sortable
- Both columns are **support-only** (gated behind the existing `support=true` + Admin/Support role check in the Go API; never returned to regular users)

## Performance

A single `SUM(approvedby IS NOT NULL) / COUNT(*)` query on `messages_groups` runs in the existing parallel goroutine block alongside the auto/manual approve log queries — zero serial latency added. The query filters on `arrival >= 30 days ago` and groups by `groupid`.

## Colour coding

- **Green** (`< 10%`): community is largely auto-approved, little manual load
- **Amber** (`≥ 80%`): high manual moderation load, may need attention

## Code Quality Review

- No new API surface beyond the existing support endpoint
- Parallel query pattern follows the established pattern in `ListGroups`
- Fields use `omitempty` so they never appear in non-support responses
- Test extended with a 3-message scenario (2 moderated, 1 not) verifying count and percentage; also verifies fields absent for regular users

## Test Plan

- [x] All 2563 Go tests pass
- [ ] On the ModTools support communities page, verify the two new columns appear, sort correctly, and have expected colour coding
- [ ] Verify a non-support user hitting `/api/group?support=true` does not see `recentmoderated` or `recentmoderatedpercent` in the response