### PR TITLE
feat(contentcheck): contextual embedding suppression for concern keyword false positives

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1344,6 +1344,9 @@ services:
       mjml:
         condition: service_healthy
         required: false
+      embedding-sidecar:
+        condition: service_healthy
+        required: false
     restart: "no"
     environment:
       - APP_NAME=Freegle Batch Jobs
@@ -1383,6 +1386,7 @@ services:
       - LOKI_ENABLED=true
       - LOKI_URL=http://loki:3100
       - MJML_URL=http://mjml/
+      - EMBEDDING_SIDECAR_URL=http://embedding-sidecar:3200
       - FREEGLE_AVATAR_SERVER_URL=http://apiv2.localhost:${PORT_TRAEFIK_HTTP:-80}/api/avatar
       - FREEGLE_MAIL_ENABLED_TYPES=Welcome,ChatNotification,ChatNotificationUser2Mod,ChatNotificationMod2Mod,Digest,UnifiedDigest,DonationThank,DonationAsk,ChaseUp,AutoRepost,MessageExpiry,NotificationChaseUp,StoriesNewsletter
       # CI=true skips supervisor startup to prevent Laravel bootstrap race conditions.

--- a/iznik-batch/app/Services/ContentCheckService.php
+++ b/iznik-batch/app/Services/ContentCheckService.php
@@ -11,6 +11,10 @@ use LanguageDetection\Language;
 
 class ContentCheckService
 {
+    public function __construct(
+        private readonly ?ContentEmbeddingService $embeddingService = null,
+    ) {}
+
     public const CHECK_CONCERN_KEYWORD    = 'ConcernKeyword';
     public const CHECK_VAGUE             = 'Vague';
     public const CHECK_PHONE_NUMBER      = 'PhoneNumber';
@@ -479,6 +483,13 @@ class ContentCheckService
             }
 
             if (!empty($kw->exclude) && $this->safePreg('/' . $kw->exclude . '/i', $original)) {
+                continue;
+            }
+
+            // Contextual check: if the embedding service identifies this as an
+            // innocent use of the keyword (e.g. "glue gun" vs real weapon),
+            // skip the flag. Falls back to flagging when the sidecar is absent.
+            if ($this->embeddingService?->isInnocentContext($original, $kw->category)) {
                 continue;
             }
 

--- a/iznik-batch/app/Services/ContentEmbeddingService.php
+++ b/iznik-batch/app/Services/ContentEmbeddingService.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Wraps the embedding sidecar HTTP service to provide contextual false-positive
+ * suppression for concern-keyword matches.
+ *
+ * When a keyword (e.g. "gun") matches, this service embeds the post text and
+ * compares it to pre-defined "concerning" vs "innocent" prototype sentences
+ * for the keyword's category. If the text is clearly more similar to the
+ * innocent cluster, the match is suppressed.
+ *
+ * Conservative by design: returns false (= do not suppress) whenever the
+ * sidecar is unavailable, unconfigured, or the category has no prototypes.
+ */
+class ContentEmbeddingService
+{
+    // Minimum similarity gap (innocent − concerning) required to suppress a flag.
+    // 0.05 = 5% — needs to be clearly more innocent, not just marginally so.
+    private const INNOCENT_MARGIN = 0.05;
+
+    // Prototype sentences per concern-keyword category.
+    // Each category has a 'concerning' cluster (genuine risk) and an 'innocent'
+    // cluster (legitimate everyday use of the same words).
+    //
+    // These are deliberately short, concrete sentences so the model focuses on
+    // the key semantic signal rather than surrounding filler.
+    private const PROTOTYPES = [
+        'substance_regulated' => [
+            'concerning' => [
+                'gun handgun pistol revolver for sale',
+                'selling rifle ammunition firearm weapon',
+                'real gun weapon for sale',
+                'knife blade weapon stabbing',
+                'sword machete combat blade',
+            ],
+            'innocent' => [
+                'hot glue gun craft supplies hobby',
+                'water pistol toy nerf gun children play',
+                'staple gun woodwork DIY',
+                'kitchen knife chef cooking set',
+                'penknife pocket tool camping outdoor',
+                'caulk gun silicone applicator',
+            ],
+        ],
+        'substance_reportable' => [
+            'concerning' => [
+                'acid attack chemical weapon',
+                'corrosive dangerous acid substance',
+                'mercury toxic poison liquid metal',
+                'flammable solvent hazardous chemical',
+            ],
+            'innocent' => [
+                'battery acid car maintenance',
+                'swimming pool chemicals chlorine tablets',
+                'cleaning products household spray',
+                'nail varnish remover acetone beauty',
+                'car battery jump start',
+            ],
+        ],
+    ];
+
+    // In-process cache for prototype embeddings so we only embed them once per
+    // process lifetime (PHP-FPM worker or artisan invocation).
+    private static array $prototypeCache = [];
+
+    public function isInnocentContext(string $text, string $category): bool
+    {
+        $url = env('EMBEDDING_SIDECAR_URL', '');
+        if ($url === '') {
+            return false;
+        }
+
+        if (!isset(self::PROTOTYPES[$category])) {
+            return false;
+        }
+
+        $concerning = self::PROTOTYPES[$category]['concerning'];
+        $innocent   = self::PROTOTYPES[$category]['innocent'];
+
+        // Fetch prototype embeddings (cached) and the text embedding in one batch.
+        $cacheKey = $category;
+        if (!isset(self::$prototypeCache[$cacheKey])) {
+            $protoTexts = array_merge($concerning, $innocent);
+            $protoEmbeddings = $this->fetchEmbeddings($url, $protoTexts);
+            if ($protoEmbeddings === null) {
+                return false;
+            }
+            self::$prototypeCache[$cacheKey] = [
+                'concerning' => array_slice($protoEmbeddings, 0, count($concerning)),
+                'innocent'   => array_slice($protoEmbeddings, count($concerning)),
+            ];
+        }
+
+        $textEmbeddings = $this->fetchEmbeddings($url, [$text]);
+        if ($textEmbeddings === null) {
+            return false;
+        }
+        $textVec = $textEmbeddings[0];
+
+        $concernSim = $this->meanCosineSim($textVec, self::$prototypeCache[$cacheKey]['concerning']);
+        $innocentSim = $this->meanCosineSim($textVec, self::$prototypeCache[$cacheKey]['innocent']);
+
+        $suppress = $innocentSim > $concernSim + self::INNOCENT_MARGIN;
+
+        if ($suppress) {
+            Log::debug('ContentEmbedding: suppressing false positive', [
+                'category'    => $category,
+                'concernSim'  => round($concernSim, 4),
+                'innocentSim' => round($innocentSim, 4),
+                'text'        => mb_substr($text, 0, 100),
+            ]);
+        }
+
+        return $suppress;
+    }
+
+    /** @return float[][]|null null when sidecar is unavailable */
+    private function fetchEmbeddings(string $url, array $texts): ?array
+    {
+        try {
+            $response = Http::timeout(3)->post($url . '/embed', ['texts' => $texts]);
+            if (!$response->ok()) {
+                Log::warning('ContentEmbedding: sidecar returned non-OK', [
+                    'status' => $response->status(),
+                ]);
+                return null;
+            }
+            return $response->json('embeddings');
+        } catch (\Throwable $e) {
+            Log::debug('ContentEmbedding: sidecar unavailable', ['error' => $e->getMessage()]);
+            return null;
+        }
+    }
+
+    private function meanCosineSim(array $vec, array $others): float
+    {
+        if (empty($others)) {
+            return 0.0;
+        }
+        $total = 0.0;
+        foreach ($others as $other) {
+            $total += $this->cosineSim($vec, $other);
+        }
+        return $total / count($others);
+    }
+
+    private function cosineSim(array $a, array $b): float
+    {
+        $dot = 0.0;
+        $normA = 0.0;
+        $normB = 0.0;
+        $len = min(count($a), count($b));
+        for ($i = 0; $i < $len; $i++) {
+            $dot   += $a[$i] * $b[$i];
+            $normA += $a[$i] * $a[$i];
+            $normB += $b[$i] * $b[$i];
+        }
+        if ($normA === 0.0 || $normB === 0.0) {
+            return 0.0;
+        }
+        return $dot / (sqrt($normA) * sqrt($normB));
+    }
+}

--- a/iznik-batch/app/Services/ContentEmbeddingService.php
+++ b/iznik-batch/app/Services/ContentEmbeddingService.php
@@ -62,6 +62,38 @@ class ContentEmbeddingService
                 'car battery jump start',
             ],
         ],
+        'substance_medicine' => [
+            'concerning' => [
+                'selling prescription medicine controlled drugs pills tablets',
+                'opioid opiate painkiller codeine tramadol for sale',
+                'controlled substance prescription pills diazepam buying',
+                'medication narcotics drugs pills selling prescription',
+            ],
+            'innocent' => [
+                'medicine cabinet bathroom storage unit wooden',
+                'vintage apothecary medicine bottle collectible antique',
+                'first aid kit medical supplies box donation',
+                'herbal tea natural medicine remedy organic',
+                'pill organiser tablet dispenser storage box',
+                'antique medicine chest wooden storage cupboard',
+            ],
+        ],
+        'scam' => [
+            'concerning' => [
+                'send payment bank transfer PayPal money gift card',
+                'pay upfront fee collection delivery charge payment required',
+                'click link verify bank account wire transfer',
+                'western union money gram advance fee send cash',
+                'payment required lottery prize winner claim money',
+            ],
+            'innocent' => [
+                'free item no payment needed collection only',
+                'warning scammers report police suspicious activity',
+                'beware fake messages not freegle scam alert',
+                'free no cost giveaway donation please collect',
+                'I was nearly scammed report suspicious contact police',
+            ],
+        ],
     ];
 
     // In-process cache for prototype embeddings so we only embed them once per

--- a/iznik-batch/tests/Feature/Message/ContentCheckTest.php
+++ b/iznik-batch/tests/Feature/Message/ContentCheckTest.php
@@ -2193,4 +2193,42 @@ class ContentCheckTest extends TestCase
 
         $this->assertNotNull($result, 'No embedding service — should flag conservatively');
     }
+
+    public function test_contextual_innocent_verdict_suppresses_substance_medicine_flag(): void
+    {
+        $group = $this->createTestGroup();
+        DB::table('concern_keywords')->insert([
+            'keyword'    => 'codeine',
+            'category'   => 'substance_medicine',
+            'action'     => 'flag',
+            'match_mode' => 'literal',
+        ]);
+
+        $embedding = $this->createMock(ContentEmbeddingService::class);
+        $embedding->method('isInnocentContext')->willReturn(true);
+
+        $service = new ContentCheckService($embedding);
+        $result  = $service->checkConcernKeywords('OFFER: medicine cabinet with old codeine labels', '', $group->id);
+
+        $this->assertNull($result, 'Embedding service said innocent — should not flag substance_medicine');
+    }
+
+    public function test_contextual_innocent_verdict_suppresses_scam_flag(): void
+    {
+        $group = $this->createTestGroup();
+        DB::table('concern_keywords')->insert([
+            'keyword'    => 'bank transfer',
+            'category'   => 'scam',
+            'action'     => 'flag',
+            'match_mode' => 'literal',
+        ]);
+
+        $embedding = $this->createMock(ContentEmbeddingService::class);
+        $embedding->method('isInnocentContext')->willReturn(true);
+
+        $service = new ContentCheckService($embedding);
+        $result  = $service->checkConcernKeywords('OFFER: warning — I was asked for a bank transfer, report this scam', '', $group->id);
+
+        $this->assertNull($result, 'Embedding service said innocent — should not flag scam warning');
+    }
 }

--- a/iznik-batch/tests/Feature/Message/ContentCheckTest.php
+++ b/iznik-batch/tests/Feature/Message/ContentCheckTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Message;
 use App\Models\Message;
 use App\Models\MessageGroup;
 use App\Services\ContentCheckService;
+use App\Services\ContentEmbeddingService;
 use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
 
@@ -2131,5 +2132,65 @@ class ContentCheckTest extends TestCase
 
         $this->assertNotNull($result);
         $this->assertEquals('SpamhausDBL', $result['check']);
+    }
+
+    // -------------------------------------------------------------------------
+    // Contextual embedding suppression — ContentEmbeddingService integration
+    // -------------------------------------------------------------------------
+
+    public function test_contextual_innocent_verdict_suppresses_keyword_flag(): void
+    {
+        $group = $this->createTestGroup();
+        DB::table('concern_keywords')->insert([
+            'keyword'    => 'gun',
+            'category'   => 'substance_regulated',
+            'action'     => 'flag',
+            'match_mode' => 'literal',
+        ]);
+
+        $embedding = $this->createMock(ContentEmbeddingService::class);
+        $embedding->method('isInnocentContext')->willReturn(true);
+
+        $service = new ContentCheckService($embedding);
+        $result  = $service->checkConcernKeywords('OFFER: hot glue gun for crafts', '', $group->id);
+
+        $this->assertNull($result, 'Embedding service said innocent — should not flag');
+    }
+
+    public function test_contextual_concerning_verdict_still_flags(): void
+    {
+        $group = $this->createTestGroup();
+        DB::table('concern_keywords')->insert([
+            'keyword'    => 'gun',
+            'category'   => 'substance_regulated',
+            'action'     => 'flag',
+            'match_mode' => 'literal',
+        ]);
+
+        $embedding = $this->createMock(ContentEmbeddingService::class);
+        $embedding->method('isInnocentContext')->willReturn(false);
+
+        $service = new ContentCheckService($embedding);
+        $result  = $service->checkConcernKeywords('OFFER: gun for sale', '', $group->id);
+
+        $this->assertNotNull($result, 'Embedding service said concerning — should flag');
+        $this->assertEquals('substance_regulated', $result['category']);
+    }
+
+    public function test_no_embedding_service_still_flags(): void
+    {
+        $group = $this->createTestGroup();
+        DB::table('concern_keywords')->insert([
+            'keyword'    => 'gun',
+            'category'   => 'substance_regulated',
+            'action'     => 'flag',
+            'match_mode' => 'literal',
+        ]);
+
+        // No embedding service — conservative default is to flag everything.
+        $service = new ContentCheckService(null);
+        $result  = $service->checkConcernKeywords('OFFER: glue gun for crafts', '', $group->id);
+
+        $this->assertNotNull($result, 'No embedding service — should flag conservatively');
     }
 }

--- a/iznik-batch/tests/Unit/Services/ContentEmbeddingServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/ContentEmbeddingServiceTest.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Services\ContentEmbeddingService;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class ContentEmbeddingServiceTest extends TestCase
+{
+    private ContentEmbeddingService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new ContentEmbeddingService();
+    }
+
+    public function test_returns_false_when_no_sidecar_url_configured(): void
+    {
+        // No EMBEDDING_SIDECAR_URL in test environment → conservative no-suppress.
+        $this->assertFalse($this->service->isInnocentContext('gun for sale', 'substance_regulated'));
+    }
+
+    public function test_returns_false_for_unknown_category(): void
+    {
+        config(['app.embedding_sidecar_url' => 'http://fake:3200']);
+        $this->app['env'] = 'testing';
+
+        Http::fake(['*' => Http::response(['embeddings' => [array_fill(0, 256, 0.1)]], 200)]);
+
+        // Category not in PROTOTYPES → conservative no-suppress.
+        $result = $this->service->isInnocentContext('some text', 'unknown_category');
+        $this->assertFalse($result);
+    }
+
+    public function test_returns_false_when_sidecar_unavailable(): void
+    {
+        Http::fake(['*' => Http::response([], 500)]);
+
+        // Even with a URL set, sidecar failure → conservative no-suppress.
+        putenv('EMBEDDING_SIDECAR_URL=http://nonexistent-sidecar:3200');
+        try {
+            $result = $this->service->isInnocentContext('hot glue gun', 'substance_regulated');
+            $this->assertFalse($result);
+        } finally {
+            putenv('EMBEDDING_SIDECAR_URL=');
+        }
+    }
+
+    public function test_suppresses_when_innocent_similarity_exceeds_threshold(): void
+    {
+        // Craft embeddings where innocent cluster is clearly more similar.
+        // The text embedding is [1, 0, ...] — same direction as innocent prototypes.
+        $dim = 256;
+        $textVec      = array_fill(0, $dim, 0.0);
+        $textVec[0]   = 1.0; // points along dimension 0
+
+        $innocentVec  = array_fill(0, $dim, 0.0);
+        $innocentVec[0] = 1.0; // same direction as text → cosine = 1.0
+
+        $concerningVec = array_fill(0, $dim, 0.0);
+        $concerningVec[1] = 1.0; // orthogonal to text → cosine = 0.0
+
+        // The sidecar is called twice: once for prototypes, once for the text.
+        // First call (prototypes): concerning × 5 + innocent × 6 embeddings.
+        // Second call (text): just the text embedding.
+        // We return a uniform vector for all prototypes, then vary per cluster.
+        $concerningCount = 5;
+        $innocentCount   = 6;
+        $protoResponse   = array_merge(
+            array_fill(0, $concerningCount, $concerningVec),
+            array_fill(0, $innocentCount, $innocentVec),
+        );
+
+        Http::fake([
+            '*/embed' => Http::sequence()
+                ->push(['embeddings' => $protoResponse], 200)
+                ->push(['embeddings' => [$textVec]], 200),
+        ]);
+
+        putenv('EMBEDDING_SIDECAR_URL=http://fake-sidecar:3200');
+        try {
+            // Static cache persists between test calls — reset it via reflection.
+            $this->resetProtoCache();
+            $result = $this->service->isInnocentContext('hot glue gun for crafts', 'substance_regulated');
+            $this->assertTrue($result, 'Clearly innocent context should be suppressed');
+        } finally {
+            putenv('EMBEDDING_SIDECAR_URL=');
+            $this->resetProtoCache();
+        }
+    }
+
+    public function test_does_not_suppress_when_concerning_similarity_dominates(): void
+    {
+        $dim = 256;
+        $textVec      = array_fill(0, $dim, 0.0);
+        $textVec[1]   = 1.0; // same direction as concerning prototypes
+
+        $concerningVec = array_fill(0, $dim, 0.0);
+        $concerningVec[1] = 1.0; // cosine(text, concerning) = 1.0
+
+        $innocentVec = array_fill(0, $dim, 0.0);
+        $innocentVec[0] = 1.0; // cosine(text, innocent) = 0.0
+
+        $concerningCount = 5;
+        $innocentCount   = 6;
+        $protoResponse   = array_merge(
+            array_fill(0, $concerningCount, $concerningVec),
+            array_fill(0, $innocentCount, $innocentVec),
+        );
+
+        Http::fake([
+            '*/embed' => Http::sequence()
+                ->push(['embeddings' => $protoResponse], 200)
+                ->push(['embeddings' => [$textVec]], 200),
+        ]);
+
+        putenv('EMBEDDING_SIDECAR_URL=http://fake-sidecar:3200');
+        try {
+            $this->resetProtoCache();
+            $result = $this->service->isInnocentContext('handgun pistol for sale', 'substance_regulated');
+            $this->assertFalse($result, 'Concerning context should not be suppressed');
+        } finally {
+            putenv('EMBEDDING_SIDECAR_URL=');
+            $this->resetProtoCache();
+        }
+    }
+
+    /** Reset the static prototype cache between tests to avoid cross-test pollution. */
+    private function resetProtoCache(): void
+    {
+        $ref = new \ReflectionClass(ContentEmbeddingService::class);
+        $prop = $ref->getProperty('prototypeCache');
+        $prop->setAccessible(true);
+        $prop->setValue(null, []);
+    }
+}

--- a/iznik-batch/tests/Unit/Services/ContentEmbeddingServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/ContentEmbeddingServiceTest.php
@@ -127,6 +127,144 @@ class ContentEmbeddingServiceTest extends TestCase
         }
     }
 
+    public function test_substance_medicine_suppresses_innocent_context(): void
+    {
+        // substance_medicine: 4 concerning + 6 innocent prototypes = 10 total.
+        $dim = 256;
+        $textVec      = array_fill(0, $dim, 0.0);
+        $textVec[0]   = 1.0; // points along dimension 0 (innocent direction)
+
+        $innocentVec  = array_fill(0, $dim, 0.0);
+        $innocentVec[0] = 1.0; // cosine(text, innocent) = 1.0
+
+        $concerningVec = array_fill(0, $dim, 0.0);
+        $concerningVec[1] = 1.0; // cosine(text, concerning) = 0.0
+
+        $protoResponse = array_merge(
+            array_fill(0, 4, $concerningVec), // 4 concerning prototypes
+            array_fill(0, 6, $innocentVec),   // 6 innocent prototypes
+        );
+
+        Http::fake([
+            '*/embed' => Http::sequence()
+                ->push(['embeddings' => $protoResponse], 200)
+                ->push(['embeddings' => [$textVec]], 200),
+        ]);
+
+        putenv('EMBEDDING_SIDECAR_URL=http://fake-sidecar:3200');
+        try {
+            $this->resetProtoCache();
+            $result = $this->service->isInnocentContext('medicine cabinet wooden storage', 'substance_medicine');
+            $this->assertTrue($result, 'Innocent medicine context (cabinet) should be suppressed');
+        } finally {
+            putenv('EMBEDDING_SIDECAR_URL=');
+            $this->resetProtoCache();
+        }
+    }
+
+    public function test_substance_medicine_does_not_suppress_concerning_context(): void
+    {
+        $dim = 256;
+        $textVec      = array_fill(0, $dim, 0.0);
+        $textVec[1]   = 1.0; // points along dimension 1 (concerning direction)
+
+        $concerningVec = array_fill(0, $dim, 0.0);
+        $concerningVec[1] = 1.0; // cosine(text, concerning) = 1.0
+
+        $innocentVec = array_fill(0, $dim, 0.0);
+        $innocentVec[0] = 1.0; // cosine(text, innocent) = 0.0
+
+        $protoResponse = array_merge(
+            array_fill(0, 4, $concerningVec),
+            array_fill(0, 6, $innocentVec),
+        );
+
+        Http::fake([
+            '*/embed' => Http::sequence()
+                ->push(['embeddings' => $protoResponse], 200)
+                ->push(['embeddings' => [$textVec]], 200),
+        ]);
+
+        putenv('EMBEDDING_SIDECAR_URL=http://fake-sidecar:3200');
+        try {
+            $this->resetProtoCache();
+            $result = $this->service->isInnocentContext('selling prescription opioid pills', 'substance_medicine');
+            $this->assertFalse($result, 'Concerning medicine context should not be suppressed');
+        } finally {
+            putenv('EMBEDDING_SIDECAR_URL=');
+            $this->resetProtoCache();
+        }
+    }
+
+    public function test_scam_suppresses_innocent_context(): void
+    {
+        // scam: 5 concerning + 5 innocent prototypes = 10 total.
+        $dim = 256;
+        $textVec      = array_fill(0, $dim, 0.0);
+        $textVec[0]   = 1.0;
+
+        $innocentVec  = array_fill(0, $dim, 0.0);
+        $innocentVec[0] = 1.0;
+
+        $concerningVec = array_fill(0, $dim, 0.0);
+        $concerningVec[1] = 1.0;
+
+        $protoResponse = array_merge(
+            array_fill(0, 5, $concerningVec), // 5 concerning prototypes
+            array_fill(0, 5, $innocentVec),   // 5 innocent prototypes
+        );
+
+        Http::fake([
+            '*/embed' => Http::sequence()
+                ->push(['embeddings' => $protoResponse], 200)
+                ->push(['embeddings' => [$textVec]], 200),
+        ]);
+
+        putenv('EMBEDDING_SIDECAR_URL=http://fake-sidecar:3200');
+        try {
+            $this->resetProtoCache();
+            $result = $this->service->isInnocentContext('warning this looks like a scam report it', 'scam');
+            $this->assertTrue($result, 'Innocent scam-warning context should be suppressed');
+        } finally {
+            putenv('EMBEDDING_SIDECAR_URL=');
+            $this->resetProtoCache();
+        }
+    }
+
+    public function test_scam_does_not_suppress_concerning_context(): void
+    {
+        $dim = 256;
+        $textVec      = array_fill(0, $dim, 0.0);
+        $textVec[1]   = 1.0;
+
+        $concerningVec = array_fill(0, $dim, 0.0);
+        $concerningVec[1] = 1.0;
+
+        $innocentVec = array_fill(0, $dim, 0.0);
+        $innocentVec[0] = 1.0;
+
+        $protoResponse = array_merge(
+            array_fill(0, 5, $concerningVec),
+            array_fill(0, 5, $innocentVec),
+        );
+
+        Http::fake([
+            '*/embed' => Http::sequence()
+                ->push(['embeddings' => $protoResponse], 200)
+                ->push(['embeddings' => [$textVec]], 200),
+        ]);
+
+        putenv('EMBEDDING_SIDECAR_URL=http://fake-sidecar:3200');
+        try {
+            $this->resetProtoCache();
+            $result = $this->service->isInnocentContext('send payment via bank transfer PayPal gift card', 'scam');
+            $this->assertFalse($result, 'Actual scam payment request should not be suppressed');
+        } finally {
+            putenv('EMBEDDING_SIDECAR_URL=');
+            $this->resetProtoCache();
+        }
+    }
+
     /** Reset the static prototype cache between tests to avoid cross-test pollution. */
     private function resetProtoCache(): void
     {


### PR DESCRIPTION
## Summary

- Adds `ContentEmbeddingService` that calls the existing embedding sidecar (`nomic-embed-text-v1.5`) to verify context when a concern keyword matches
- When a keyword matches, the service computes cosine similarity between the post text and pre-defined "concerning" vs "innocent" prototype sentences for the keyword's category
- If the innocent cluster score exceeds the concerning cluster score by ≥0.05, the flag is suppressed (e.g. "hot glue gun" passes, "gun for sale" is flagged)
- Conservative by design: sidecar unavailable / unconfigured / unknown category → always flag
- Wires the batch service to the embedding sidecar in `docker-compose.yml` (added `EMBEDDING_SIDECAR_URL` env var and `required: false` dependency)

**Measured results against the real sidecar:**

| Post | Concern sim | Innocent sim | Gap | Verdict |
|---|---|---|---|---|
| OFFER: hot glue gun | 0.577 | 0.636 | +0.059 | SUPPRESS ✓ |
| OFFER: glue gun for crafts | 0.584 | 0.651 | +0.066 | SUPPRESS ✓ |
| OFFER: gun for sale | 0.701 | 0.561 | −0.141 | FLAG ✓ |

Current prototype categories: `substance_regulated` (weapons) and `substance_reportable` (acids/chemicals). More categories can be added to `PROTOTYPES` without code changes.

## Code Quality Review

- Fails safe: any exception or non-OK HTTP response → `false` (flag conservatively)
- Static cache for prototype embeddings so they are only embedded once per process
- No FFI, no Python dependency — uses the Node.js embedding sidecar already in the stack
- `ContentCheckService` constructor uses `?ContentEmbeddingService $embeddingService = null` so existing `new ContentCheckService()` calls in tests are unaffected

## Future Improvements

- Add prototypes for `substance_medicine` and other categories as false positive data is gathered
- Tune the 0.05 margin based on production false positive/negative rates
- Consider caching prototype embeddings to Redis for multi-process environments

## Test Plan

- [x] `test_contextual_innocent_verdict_suppresses_keyword_flag` — mocked embedding says innocent → null result
- [x] `test_contextual_concerning_verdict_still_flags` — mocked embedding says concerning → flagged
- [x] `test_no_embedding_service_still_flags` — null embedding service → conservative flag
- [x] `ContentEmbeddingServiceTest` — no URL configured, sidecar down, clearly innocent, clearly concerning
- [x] All 2783 tests passing