### PR TITLE
fix(content-check): skip IP abuse flag for mobile carrier IPs

### DIFF
--- a/iznik-batch/app/Services/ContentCheckService.php
+++ b/iznik-batch/app/Services/ContentCheckService.php
@@ -890,11 +890,75 @@ class ContentCheckService
      */
     private const IP_ABUSE_ID_CAP = 50;
 
+    /** ASN organization name keywords that identify mobile carrier networks. */
+    private const MOBILE_ASN_KEYWORDS = [
+        'mobile',
+        'mobility',
+        'wireless',
+        'cellular',
+        'mvno',
+    ];
+
+    /**
+     * Look up the ASN organization name for an IP via the GeoLite2-ASN database.
+     *
+     * Returns null if the database is unavailable or the lookup fails.
+     * Override in tests to inject a known ASN org name without a real database.
+     */
+    protected function lookupAsnOrganization(string $ip): ?string
+    {
+        $path = config('freegle.geoip.asn_mmdb_path', '/usr/share/GeoIP/GeoLite2-ASN.mmdb');
+        if (!file_exists($path)) {
+            return null;
+        }
+
+        try {
+            $reader = new \GeoIp2\Database\Reader($path);
+            $org    = $reader->asn($ip)->autonomousSystemOrganization;
+            $reader->close();
+
+            return $org ?: null;
+        } catch (\Exception $e) {
+            Log::debug('GeoIP ASN lookup failed', ['ip' => $ip, 'error' => $e->getMessage()]);
+
+            return null;
+        }
+    }
+
+    /**
+     * Return true if the IP belongs to a mobile carrier network.
+     *
+     * Mobile CGNAT pools are shared by thousands of legitimate users, so
+     * IP-abuse checks would generate constant false positives for them.
+     */
+    public function isMobileCarrierIp(string $ip): bool
+    {
+        $org = $this->lookupAsnOrganization($ip);
+        if ($org === null) {
+            return false;
+        }
+
+        $lower = strtolower($org);
+        foreach (self::MOBILE_ASN_KEYWORDS as $keyword) {
+            if (str_contains($lower, $keyword)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     public function checkIpAbuse(int $msgid): ?array
     {
         $fromip = DB::table('messages')->where('id', $msgid)->value('fromip');
 
         if (!$fromip) {
+            return null;
+        }
+
+        // Mobile carrier CGNAT pools are shared by thousands of legitimate users.
+        // Skip the IP-abuse check entirely to avoid false positives.
+        if ($this->isMobileCarrierIp($fromip)) {
             return null;
         }
 

--- a/iznik-batch/app/Services/ContentCheckService.php
+++ b/iznik-batch/app/Services/ContentCheckService.php
@@ -890,64 +890,6 @@ class ContentCheckService
      */
     private const IP_ABUSE_ID_CAP = 50;
 
-    /** ASN organization name keywords that identify mobile carrier networks. */
-    private const MOBILE_ASN_KEYWORDS = [
-        'mobile',
-        'mobility',
-        'wireless',
-        'cellular',
-        'mvno',
-    ];
-
-    /**
-     * Look up the ASN organization name for an IP via the GeoLite2-ASN database.
-     *
-     * Returns null if the database is unavailable or the lookup fails.
-     * Override in tests to inject a known ASN org name without a real database.
-     */
-    protected function lookupAsnOrganization(string $ip): ?string
-    {
-        $path = config('freegle.geoip.asn_mmdb_path', '/usr/share/GeoIP/GeoLite2-ASN.mmdb');
-        if (!file_exists($path)) {
-            return null;
-        }
-
-        try {
-            $reader = new \GeoIp2\Database\Reader($path);
-            $org    = $reader->asn($ip)->autonomousSystemOrganization;
-            $reader->close();
-
-            return $org ?: null;
-        } catch (\Exception $e) {
-            Log::debug('GeoIP ASN lookup failed', ['ip' => $ip, 'error' => $e->getMessage()]);
-
-            return null;
-        }
-    }
-
-    /**
-     * Return true if the IP belongs to a mobile carrier network.
-     *
-     * Mobile CGNAT pools are shared by thousands of legitimate users, so
-     * IP-abuse checks would generate constant false positives for them.
-     */
-    public function isMobileCarrierIp(string $ip): bool
-    {
-        $org = $this->lookupAsnOrganization($ip);
-        if ($org === null) {
-            return false;
-        }
-
-        $lower = strtolower($org);
-        foreach (self::MOBILE_ASN_KEYWORDS as $keyword) {
-            if (str_contains($lower, $keyword)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
     public function checkIpAbuse(int $msgid): ?array
     {
         $fromip = DB::table('messages')->where('id', $msgid)->value('fromip');
@@ -956,15 +898,15 @@ class ContentCheckService
             return null;
         }
 
-        // Mobile carrier CGNAT pools are shared by thousands of legitimate users.
-        // Skip the IP-abuse check entirely to avoid false positives.
-        if ($this->isMobileCarrierIp($fromip)) {
-            return null;
-        }
+        // Match v1 behaviour: only look at the last 31 days.
+        // V1 queries `messages_history` which is pruned to 31 days by purge_messages.php.
+        // Without a window, CGNAT mobile IPs accumulate years of users and always trigger.
+        $window = now()->subDays(31);
 
         // IP used by 5+ different users
         $userCount = DB::table('messages')
             ->where('fromip', $fromip)
+            ->where('arrival', '>=', $window)
             ->whereNotNull('fromuser')
             ->distinct('fromuser')
             ->count();
@@ -972,6 +914,7 @@ class ContentCheckService
         if ($userCount > 5) {
             $users = DB::table('messages')
                 ->where('fromip', $fromip)
+                ->where('arrival', '>=', $window)
                 ->whereNotNull('fromuser')
                 ->select('fromuser')
                 ->groupBy('fromuser')
@@ -995,6 +938,7 @@ class ContentCheckService
         $groupCount = DB::table('messages_groups')
             ->join('messages', 'messages.id', '=', 'messages_groups.msgid')
             ->where('messages.fromip', $fromip)
+            ->where('messages.arrival', '>=', $window)
             ->distinct('messages_groups.groupid')
             ->count();
 
@@ -1002,6 +946,7 @@ class ContentCheckService
             $groups = DB::table('messages_groups')
                 ->join('messages', 'messages.id', '=', 'messages_groups.msgid')
                 ->where('messages.fromip', $fromip)
+                ->where('messages.arrival', '>=', $window)
                 ->select('messages_groups.groupid')
                 ->groupBy('messages_groups.groupid')
                 ->orderByRaw('MAX(messages_groups.arrival) DESC')

--- a/iznik-batch/config/freegle.php
+++ b/iznik-batch/config/freegle.php
@@ -117,7 +117,8 @@ return [
 
     // GeoIP database for IP country lookups
     'geoip' => [
-        'mmdb_path' => env('GEOIP_MMDB_PATH', '/usr/share/GeoIP/GeoLite2-Country.mmdb'),
+        'mmdb_path'     => env('GEOIP_MMDB_PATH', '/usr/share/GeoIP/GeoLite2-Country.mmdb'),
+        'asn_mmdb_path' => env('GEOIP_ASN_MMDB_PATH', '/usr/share/GeoIP/GeoLite2-ASN.mmdb'),
     ],
 
     // TUS uploader for AI-generated images

--- a/iznik-batch/config/freegle.php
+++ b/iznik-batch/config/freegle.php
@@ -117,8 +117,7 @@ return [
 
     // GeoIP database for IP country lookups
     'geoip' => [
-        'mmdb_path'     => env('GEOIP_MMDB_PATH', '/usr/share/GeoIP/GeoLite2-Country.mmdb'),
-        'asn_mmdb_path' => env('GEOIP_ASN_MMDB_PATH', '/usr/share/GeoIP/GeoLite2-ASN.mmdb'),
+        'mmdb_path' => env('GEOIP_MMDB_PATH', '/usr/share/GeoIP/GeoLite2-Country.mmdb'),
     ],
 
     // TUS uploader for AI-generated images

--- a/iznik-batch/tests/Feature/Message/ContentCheckTest.php
+++ b/iznik-batch/tests/Feature/Message/ContentCheckTest.php
@@ -1882,6 +1882,187 @@ class ContentCheckTest extends TestCase
     }
 
     // -------------------------------------------------------------------------
+    // checkIpAbuse — mobile carrier detection (CGNAT false-positive suppression)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Create a ContentCheckService whose ASN lookup returns a fixed org name,
+     * so tests can exercise mobile-carrier detection without a real database.
+     */
+    private function makeServiceWithAsn(?string $asnOrg): ContentCheckService
+    {
+        return new class($asnOrg) extends ContentCheckService {
+            public function __construct(private readonly ?string $asnOrg) {}
+
+            protected function lookupAsnOrganization(string $ip): ?string
+            {
+                return $this->asnOrg;
+            }
+        };
+    }
+
+    public function test_ip_abuse_skipped_for_mobile_carrier_ip_by_user_count(): void
+    {
+        $ip = '172.16.' . rand(0, 255) . '.' . rand(0, 255);
+
+        $user = $this->createTestUser();
+        $msgid = DB::table('messages')->insertGetId([
+            'fromuser' => $user->id,
+            'type'     => 'Offer',
+            'subject'  => 'OFFER: Test item',
+            'textbody' => 'Test body',
+            'message'  => 'Test body',
+            'fromip'   => $ip,
+            'arrival'  => now(),
+            'date'     => now(),
+            'source'   => 'Platform',
+        ]);
+
+        // 5 more users on the same IP — would normally trigger the user-count check
+        for ($i = 0; $i < 5; $i++) {
+            $otherUser = $this->createTestUser();
+            DB::table('messages')->insert([
+                'fromuser' => $otherUser->id,
+                'type'     => 'Offer',
+                'subject'  => 'OFFER: Another item',
+                'textbody' => 'Test body',
+                'message'  => 'Test body',
+                'fromip'   => $ip,
+                'arrival'  => now(),
+                'date'     => now(),
+                'source'   => 'Platform',
+            ]);
+        }
+
+        $service = $this->makeServiceWithAsn('EE Mobile');
+        $result  = $service->checkIpAbuse($msgid);
+
+        $this->assertNull($result, 'IP abuse check must be skipped for mobile carrier IPs');
+    }
+
+    public function test_ip_abuse_skipped_for_mobile_carrier_ip_by_group_count(): void
+    {
+        $ip = '172.16.' . rand(0, 255) . '.' . rand(0, 255);
+        $user = $this->createTestUser();
+
+        $msgid = DB::table('messages')->insertGetId([
+            'fromuser' => $user->id,
+            'type'     => 'Offer',
+            'subject'  => 'OFFER: Test item',
+            'textbody' => 'Test body',
+            'message'  => 'Test body',
+            'fromip'   => $ip,
+            'arrival'  => now(),
+            'date'     => now(),
+            'source'   => 'Platform',
+        ]);
+
+        // Post to 20 groups — would normally trigger the group-count check
+        for ($i = 0; $i < 20; $i++) {
+            $group = $this->createTestGroup();
+            DB::table('messages_groups')->insert([
+                'msgid'      => $msgid,
+                'groupid'    => $group->id,
+                'collection' => 'Pending',
+                'arrival'    => now(),
+                'deleted'    => 0,
+            ]);
+        }
+
+        $service = $this->makeServiceWithAsn('Vodafone UK Mobile');
+        $result  = $service->checkIpAbuse($msgid);
+
+        $this->assertNull($result, 'IP abuse check must be skipped for mobile carrier IPs');
+    }
+
+    public function test_ip_abuse_not_skipped_for_non_mobile_asn(): void
+    {
+        $ip = '10.' . rand(0, 255) . '.' . rand(0, 255) . '.' . rand(0, 255);
+
+        $user = $this->createTestUser();
+        $msgid = DB::table('messages')->insertGetId([
+            'fromuser' => $user->id,
+            'type'     => 'Offer',
+            'subject'  => 'OFFER: Test item',
+            'textbody' => 'Test body',
+            'message'  => 'Test body',
+            'fromip'   => $ip,
+            'arrival'  => now(),
+            'date'     => now(),
+            'source'   => 'Platform',
+        ]);
+
+        for ($i = 0; $i < 5; $i++) {
+            $otherUser = $this->createTestUser();
+            DB::table('messages')->insert([
+                'fromuser' => $otherUser->id,
+                'type'     => 'Offer',
+                'subject'  => 'OFFER: Another item',
+                'textbody' => 'Test body',
+                'message'  => 'Test body',
+                'fromip'   => $ip,
+                'arrival'  => now(),
+                'date'     => now(),
+                'source'   => 'Platform',
+            ]);
+        }
+
+        $service = $this->makeServiceWithAsn('BT Business Broadband');
+        $result  = $service->checkIpAbuse($msgid);
+
+        $this->assertNotNull($result, 'Non-mobile ASN must still trigger IP abuse check');
+        $this->assertEquals('IpAbuse', $result['check']);
+    }
+
+    /** @dataProvider mobileAsnProvider */
+    public function test_mobile_asn_names_are_detected(string $asnOrg): void
+    {
+        $service = $this->makeServiceWithAsn($asnOrg);
+        $this->assertTrue(
+            $service->isMobileCarrierIp('1.2.3.4'),
+            "ASN org '{$asnOrg}' should be detected as a mobile carrier"
+        );
+    }
+
+    public static function mobileAsnProvider(): array
+    {
+        return [
+            'EE Mobile'          => ['EE Mobile'],
+            'O2 UK Mobile'       => ['O2 (UK) Mobile'],
+            'Vodafone UK Mobile' => ['Vodafone UK Mobile'],
+            'Three UK'           => ['Three UK Wireless'],
+            'T-Mobile US'        => ['T-Mobile USA, Inc.'],
+            'Verizon Wireless'   => ['Verizon Wireless'],
+            'AT&T Mobility'      => ['AT&T Mobility LLC'],
+            'generic mobile'     => ['Some Mobile Network ISP'],
+            'generic wireless'   => ['Regional Wireless Co'],
+            'generic cellular'   => ['Cellular One Inc'],
+        ];
+    }
+
+    /** @dataProvider nonMobileAsnProvider */
+    public function test_non_mobile_asn_names_are_not_detected(?string $asnOrg): void
+    {
+        $service = $this->makeServiceWithAsn($asnOrg);
+        $this->assertFalse(
+            $service->isMobileCarrierIp('1.2.3.4'),
+            "ASN org " . var_export($asnOrg, true) . " should NOT be detected as a mobile carrier"
+        );
+    }
+
+    public static function nonMobileAsnProvider(): array
+    {
+        return [
+            'BT Business'   => ['BT Business Broadband'],
+            'Virgin Media'  => ['Virgin Media'],
+            'Sky Broadband' => ['Sky UK Limited'],
+            'AWS'           => ['Amazon.com, Inc.'],
+            'Cloudflare'    => ['Cloudflare, Inc.'],
+            'null ASN'      => [null],
+        ];
+    }
+
+    // -------------------------------------------------------------------------
     // checkBulkVolunteerMail — detect bulk mailing to volunteer addresses (V1 Spam.php parity)
     // -------------------------------------------------------------------------
 

--- a/iznik-batch/tests/Feature/Message/ContentCheckTest.php
+++ b/iznik-batch/tests/Feature/Message/ContentCheckTest.php
@@ -1671,6 +1671,48 @@ class ContentCheckTest extends TestCase
         $this->assertStringContainsString('20', $result['detail']);
     }
 
+    public function test_ip_abuse_ignores_messages_older_than_31_days(): void
+    {
+        // V1 queries messages_history which is pruned to 31 days.
+        // Messages outside the window must not count toward the abuse threshold.
+        $ip = '192.168.' . rand(0, 255) . '.' . rand(0, 255);
+        $old = now()->subDays(32);
+
+        $user = $this->createTestUser();
+        $msgid = DB::table('messages')->insertGetId([
+            'fromuser' => $user->id,
+            'type'     => 'Offer',
+            'subject'  => 'OFFER: Test item',
+            'textbody' => 'Test body',
+            'message'  => 'Test body',
+            'fromip'   => $ip,
+            'arrival'  => now(),
+            'date'     => now(),
+            'source'   => 'Platform',
+        ]);
+
+        // Add 5 more users — all with arrival > 31 days ago
+        for ($i = 0; $i < 5; $i++) {
+            $otherUser = $this->createTestUser();
+            DB::table('messages')->insert([
+                'fromuser' => $otherUser->id,
+                'type'     => 'Offer',
+                'subject'  => 'OFFER: Old item',
+                'textbody' => 'Test body',
+                'message'  => 'Test body',
+                'fromip'   => $ip,
+                'arrival'  => $old,
+                'date'     => $old,
+                'source'   => 'Platform',
+            ]);
+        }
+
+        // Only 1 user within the window — must NOT flag
+        $result = $this->service->checkIpAbuse($msgid);
+
+        $this->assertNull($result, 'IP abuse check should ignore messages older than 31 days');
+    }
+
     public function test_ip_abuse_no_ip_returns_null(): void
     {
         $user = $this->createTestUser();
@@ -1879,187 +1921,6 @@ class ContentCheckTest extends TestCase
             $this->assertIsInt($id, 'group ID must be int, not string');
         }
         $this->assertArrayNotHasKey('users', $result, 'group branch must not include a users array');
-    }
-
-    // -------------------------------------------------------------------------
-    // checkIpAbuse — mobile carrier detection (CGNAT false-positive suppression)
-    // -------------------------------------------------------------------------
-
-    /**
-     * Create a ContentCheckService whose ASN lookup returns a fixed org name,
-     * so tests can exercise mobile-carrier detection without a real database.
-     */
-    private function makeServiceWithAsn(?string $asnOrg): ContentCheckService
-    {
-        return new class($asnOrg) extends ContentCheckService {
-            public function __construct(private readonly ?string $asnOrg) {}
-
-            protected function lookupAsnOrganization(string $ip): ?string
-            {
-                return $this->asnOrg;
-            }
-        };
-    }
-
-    public function test_ip_abuse_skipped_for_mobile_carrier_ip_by_user_count(): void
-    {
-        $ip = '172.16.' . rand(0, 255) . '.' . rand(0, 255);
-
-        $user = $this->createTestUser();
-        $msgid = DB::table('messages')->insertGetId([
-            'fromuser' => $user->id,
-            'type'     => 'Offer',
-            'subject'  => 'OFFER: Test item',
-            'textbody' => 'Test body',
-            'message'  => 'Test body',
-            'fromip'   => $ip,
-            'arrival'  => now(),
-            'date'     => now(),
-            'source'   => 'Platform',
-        ]);
-
-        // 5 more users on the same IP — would normally trigger the user-count check
-        for ($i = 0; $i < 5; $i++) {
-            $otherUser = $this->createTestUser();
-            DB::table('messages')->insert([
-                'fromuser' => $otherUser->id,
-                'type'     => 'Offer',
-                'subject'  => 'OFFER: Another item',
-                'textbody' => 'Test body',
-                'message'  => 'Test body',
-                'fromip'   => $ip,
-                'arrival'  => now(),
-                'date'     => now(),
-                'source'   => 'Platform',
-            ]);
-        }
-
-        $service = $this->makeServiceWithAsn('EE Mobile');
-        $result  = $service->checkIpAbuse($msgid);
-
-        $this->assertNull($result, 'IP abuse check must be skipped for mobile carrier IPs');
-    }
-
-    public function test_ip_abuse_skipped_for_mobile_carrier_ip_by_group_count(): void
-    {
-        $ip = '172.16.' . rand(0, 255) . '.' . rand(0, 255);
-        $user = $this->createTestUser();
-
-        $msgid = DB::table('messages')->insertGetId([
-            'fromuser' => $user->id,
-            'type'     => 'Offer',
-            'subject'  => 'OFFER: Test item',
-            'textbody' => 'Test body',
-            'message'  => 'Test body',
-            'fromip'   => $ip,
-            'arrival'  => now(),
-            'date'     => now(),
-            'source'   => 'Platform',
-        ]);
-
-        // Post to 20 groups — would normally trigger the group-count check
-        for ($i = 0; $i < 20; $i++) {
-            $group = $this->createTestGroup();
-            DB::table('messages_groups')->insert([
-                'msgid'      => $msgid,
-                'groupid'    => $group->id,
-                'collection' => 'Pending',
-                'arrival'    => now(),
-                'deleted'    => 0,
-            ]);
-        }
-
-        $service = $this->makeServiceWithAsn('Vodafone UK Mobile');
-        $result  = $service->checkIpAbuse($msgid);
-
-        $this->assertNull($result, 'IP abuse check must be skipped for mobile carrier IPs');
-    }
-
-    public function test_ip_abuse_not_skipped_for_non_mobile_asn(): void
-    {
-        $ip = '10.' . rand(0, 255) . '.' . rand(0, 255) . '.' . rand(0, 255);
-
-        $user = $this->createTestUser();
-        $msgid = DB::table('messages')->insertGetId([
-            'fromuser' => $user->id,
-            'type'     => 'Offer',
-            'subject'  => 'OFFER: Test item',
-            'textbody' => 'Test body',
-            'message'  => 'Test body',
-            'fromip'   => $ip,
-            'arrival'  => now(),
-            'date'     => now(),
-            'source'   => 'Platform',
-        ]);
-
-        for ($i = 0; $i < 5; $i++) {
-            $otherUser = $this->createTestUser();
-            DB::table('messages')->insert([
-                'fromuser' => $otherUser->id,
-                'type'     => 'Offer',
-                'subject'  => 'OFFER: Another item',
-                'textbody' => 'Test body',
-                'message'  => 'Test body',
-                'fromip'   => $ip,
-                'arrival'  => now(),
-                'date'     => now(),
-                'source'   => 'Platform',
-            ]);
-        }
-
-        $service = $this->makeServiceWithAsn('BT Business Broadband');
-        $result  = $service->checkIpAbuse($msgid);
-
-        $this->assertNotNull($result, 'Non-mobile ASN must still trigger IP abuse check');
-        $this->assertEquals('IpAbuse', $result['check']);
-    }
-
-    /** @dataProvider mobileAsnProvider */
-    public function test_mobile_asn_names_are_detected(string $asnOrg): void
-    {
-        $service = $this->makeServiceWithAsn($asnOrg);
-        $this->assertTrue(
-            $service->isMobileCarrierIp('1.2.3.4'),
-            "ASN org '{$asnOrg}' should be detected as a mobile carrier"
-        );
-    }
-
-    public static function mobileAsnProvider(): array
-    {
-        return [
-            'EE Mobile'          => ['EE Mobile'],
-            'O2 UK Mobile'       => ['O2 (UK) Mobile'],
-            'Vodafone UK Mobile' => ['Vodafone UK Mobile'],
-            'Three UK'           => ['Three UK Wireless'],
-            'T-Mobile US'        => ['T-Mobile USA, Inc.'],
-            'Verizon Wireless'   => ['Verizon Wireless'],
-            'AT&T Mobility'      => ['AT&T Mobility LLC'],
-            'generic mobile'     => ['Some Mobile Network ISP'],
-            'generic wireless'   => ['Regional Wireless Co'],
-            'generic cellular'   => ['Cellular One Inc'],
-        ];
-    }
-
-    /** @dataProvider nonMobileAsnProvider */
-    public function test_non_mobile_asn_names_are_not_detected(?string $asnOrg): void
-    {
-        $service = $this->makeServiceWithAsn($asnOrg);
-        $this->assertFalse(
-            $service->isMobileCarrierIp('1.2.3.4'),
-            "ASN org " . var_export($asnOrg, true) . " should NOT be detected as a mobile carrier"
-        );
-    }
-
-    public static function nonMobileAsnProvider(): array
-    {
-        return [
-            'BT Business'   => ['BT Business Broadband'],
-            'Virgin Media'  => ['Virgin Media'],
-            'Sky Broadband' => ['Sky UK Limited'],
-            'AWS'           => ['Amazon.com, Inc.'],
-            'Cloudflare'    => ['Cloudflare, Inc.'],
-            'null ASN'      => [null],
-        ];
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Mobile networks use CGNAT, so thousands of users share the same exit IP
- The existing IP abuse check (5+ users or 20+ groups from one IP) produces false positives for mobile users
- The root cause: V1 queries \`messages_history\` which is pruned to 31 days by \`purge_messages.php\`, so CGNAT IPs only accumulate ~31 days of users. Our original code queried \`messages\` with no time window, accumulating years of users.
- Fix: add a 31-day time window (\`->where('arrival', '>=', now()->subDays(31))\`) to both the user-count and group-count queries in \`checkIpAbuse()\` — matching V1 behaviour exactly
- GeoLite2-ASN approach was abandoned: the database is never downloaded in production (Dockerfile.base only fetches GeoLite2-Country, and the batch container doesn't mount the geoip volume)

## Code Quality Review

- Time window matches V1: \`MessageCollection::RECENTPOSTS = \"Midnight 31 days ago\"\` in \`purge_messages.php\`
- No new dependencies or config keys needed — the fix is purely a query constraint
- All mobile ASN code (MOBILE_ASN_KEYWORDS, lookupAsnOrganization, isMobileCarrierIp) and corresponding config removed to keep the codebase clean

## Test Plan

- [x] \`test_ip_abuse_flags_when_ip_used_by_many_users\` — 6 users on same IP → flagged
- [x] \`test_ip_abuse_flags_when_ip_posts_to_many_groups\` — 20 groups from same IP → flagged
- [x] \`test_ip_abuse_ignores_messages_older_than_31_days\` — 5 old users (>31 days) + 1 recent → not flagged
- [x] All 9 IP abuse tests pass