### PR TITLE
fix(polyfill): re-add es.array.at to modernPolyfills (correct module name)

### DIFF
--- a/iznik-nuxt3/nuxt.config.ts
+++ b/iznik-nuxt3/nuxt.config.ts
@@ -576,6 +576,7 @@ export default defineNuxtConfig({
           'es.object.from-entries',
           'es.array.flat-map',
           'es.array.flat',
+          'es.array.at',
           'es.string.replace-all',
           'es.promise.any',
         ],

--- a/iznik-nuxt3/tests/unit/config/modernPolyfills.spec.js
+++ b/iznik-nuxt3/tests/unit/config/modernPolyfills.spec.js
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+import { dirname, resolve } from 'path'
+
+/**
+ * Verifies that critical polyfills are listed in nuxt.config.ts modernPolyfills.
+ *
+ * These polyfills are injected into the "modern" Vite bundle on Netlify so
+ * that browsers which support ES modules (and therefore receive the modern
+ * chunk) but are missing newer APIs still work correctly.
+ *
+ * If a Sentry error reports "<method> is not a function" on a browser that
+ * predates that method's introduction, add the corresponding core-js feature
+ * flag here AND in the modernPolyfills array in nuxt.config.ts.
+ *
+ * Note: core-js module names must exactly match files in core-js/modules/.
+ * For example, String.prototype.at is 'es.string.at-alternative' (not 'es.string.at').
+ */
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const configPath = resolve(__dirname, '../../../nuxt.config.ts')
+const config = readFileSync(configPath, 'utf-8')
+
+// Helper: true if the feature string appears inside the modernPolyfills array.
+function hasPolyfill(feature) {
+  return config.includes(`'${feature}'`) || config.includes(`"${feature}"`)
+}
+
+describe('nuxt.config.ts modernPolyfills', () => {
+  it('polyfills es.array.at for Chrome <92 / WebView <92', () => {
+    // Array.prototype.at() — Chrome 92, Safari 15.4, Android WebView 92.
+    // Sentry issue 7493124034: Chrome WebView 90 on Android 11 crashes in Nuxt
+    // Router because it uses .at(-1) to resolve the current route component.
+    expect(hasPolyfill('es.array.at')).toBe(true)
+  })
+
+  it('polyfills es.global-this', () => {
+    expect(hasPolyfill('es.global-this')).toBe(true)
+  })
+
+  it('polyfills es.string.replace-all', () => {
+    expect(hasPolyfill('es.string.replace-all')).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

- Re-adds `es.array.at` to `modernPolyfills` in `nuxt.config.ts` — fixes Sentry issue 7493124034 (Chrome WebView 90 on Android 11 crashing with "is not a function")
- The previous PR (#488, reverted in #497) also added `es.string.at` which is **not a valid core-js 3 module name** — `es.string.at.js` does not exist in core-js (it would be `es.string.at-alternative.js`). This caused the Netlify build to fail on module resolution
- Only `es.array.at` is needed: the Sentry crash is from Nuxt Router calling `.at(-1)` on an Array; Chrome WebView 90 (Android 11) predates `Array.prototype.at` (introduced in Chrome 92)
- Fixes the Vitest spec to use ESM-compatible `fileURLToPath(import.meta.url)` instead of the CJS `__dirname` global

## Root cause of the original failure

`@vitejs/plugin-legacy` resolves `modernPolyfills` strings as:
```
es.array.at  →  core-js/modules/es.array.at.js   ✅ exists
es.string.at →  core-js/modules/es.string.at.js  ❌ does not exist
```

The file `es.string.at-alternative.js` exists for `String.prototype.at`, but that polyfill was not needed for the Sentry issue and has been left out.

## Test Plan

- [x] `es.array.at.js` confirmed present in `node_modules/core-js/modules/`
- [x] `es.string.at.js` confirmed absent (root cause of the original Netlify build failure)
- [x] Vitest spec uses `import.meta.url` for ESM-compatible path resolution
- [x] Vitest spec tests that `es.array.at`, `es.global-this`, and `es.string.replace-all` are in the config
- [ ] CI will verify Vitest passes and Netlify deploy preview builds successfully