### PR TITLE
fix(batch): retry Reach Volunteering feed on non-JSON upstream errors

### DIFF
--- a/iznik-batch/app/Services/ReachVolunteeringService.php
+++ b/iznik-batch/app/Services/ReachVolunteeringService.php
@@ -30,6 +30,75 @@ class ReachVolunteeringService
         return $response->body();
     }
 
+    /**
+     * Fetch the feed and decode it to an array of opportunities, retrying on
+     * payloads that don't decode to an array.
+     *
+     * Reach's Drupal feed intermittently returns a PHP fatal-error page
+     * ("Maximum execution time of 30 seconds exceeded") with an HTTP 200, so a
+     * successful HTTP status isn't enough — we have to validate the body. The
+     * timeout is load-related, so a later attempt often succeeds.
+     *
+     * On total failure we throw rather than return [] on purpose: returning an
+     * empty set would make the caller treat every Reach opportunity as absent
+     * and mark the lot deleted on a transient outage.
+     */
+    protected function fetchOpportunities(string $feedUrl): array
+    {
+        $attempts = max(1, (int) config('freegle.reach_volunteering.fetch_attempts', 3));
+        $delay    = max(0, (int) config('freegle.reach_volunteering.retry_delay_seconds', 30));
+
+        $body    = '';
+        $decoded = null;
+
+        for ($attempt = 1; $attempt <= $attempts; $attempt++) {
+            $body    = $this->fetchFeedData($feedUrl);
+            $decoded = json_decode($body, true, 512, JSON_INVALID_UTF8_IGNORE);
+
+            if (is_array($decoded)) {
+                return $decoded;
+            }
+
+            Log::warning('ReachVolunteering: feed did not decode to array', [
+                'attempt'      => $attempt,
+                'attempts'     => $attempts,
+                'json_error'   => json_last_error_msg(),
+                'decoded_type' => gettype($decoded),
+                'body_length'  => strlen($body),
+                'body_sample'  => substr($body, 0, 500),
+            ]);
+
+            if ($attempt < $attempts && $delay > 0) {
+                sleep($delay);
+            }
+        }
+
+        // All attempts exhausted — the body still isn't a JSON array. Capture
+        // enough context to triage without a repro (Sentry doesn't record
+        // `$body` as a frame var) and throw to protect the deletion phase.
+        $type    = gettype($decoded);
+        $jsonErr = json_last_error_msg();
+        $bodyLen = strlen($body);
+        $sample  = substr($body, 0, 200);
+
+        Log::error('ReachVolunteering: unexpected feed payload', [
+            'attempts'     => $attempts,
+            'json_error'   => $jsonErr,
+            'decoded_type' => $type,
+            'body_length'  => $bodyLen,
+            'body_sample'  => substr($body, 0, 500),
+        ]);
+
+        throw new \RuntimeException(sprintf(
+            'Reach Volunteering feed: expected JSON array after %d attempt(s), got %s (json_error=%s, body_length=%d, body_sample=%s)',
+            $attempts,
+            $type,
+            $jsonErr,
+            $bodyLen,
+            $sample
+        ));
+    }
+
     public function sync(bool $dryRun = false): array
     {
         $added   = 0;
@@ -37,13 +106,7 @@ class ReachVolunteeringService
         $deleted = 0;
 
         $feedUrl = config('freegle.reach_volunteering.feed_url');
-        $body    = $this->fetchFeedData($feedUrl);
-
-        $opps = json_decode($body, true, 512, JSON_INVALID_UTF8_IGNORE);
-
-        if (!is_array($opps)) {
-            throw new \RuntimeException('Reach Volunteering feed: expected JSON array');
-        }
+        $opps    = $this->fetchOpportunities($feedUrl);
 
         $externalsSeen = [];
         $urlsSeen      = [];

--- a/iznik-batch/config/freegle.php
+++ b/iznik-batch/config/freegle.php
@@ -339,5 +339,10 @@ return [
         'feed_url' => env('REACH_VOLUNTEERING_FEED_URL', ''),
         'username' => env('REACH_VOLUNTEERING_USER', ''),
         'password' => env('REACH_VOLUNTEERING_PASSWORD', ''),
+        // Reach's Drupal feed periodically returns a PHP fatal-error page
+        // (max_execution_time exceeded) with HTTP 200 instead of JSON. Retry
+        // a few times before giving up, since the timeout is load-related.
+        'fetch_attempts'      => (int) env('REACH_VOLUNTEERING_FETCH_ATTEMPTS', 3),
+        'retry_delay_seconds' => (int) env('REACH_VOLUNTEERING_RETRY_DELAY_SECONDS', 30),
     ],
 ];

--- a/iznik-batch/tests/Feature/Integrations/SyncReachVolunteeringCommandTest.php
+++ b/iznik-batch/tests/Feature/Integrations/SyncReachVolunteeringCommandTest.php
@@ -34,16 +34,41 @@ class SyncReachVolunteeringCommandTest extends TestCase
 
     // ── Service tests ─────────────────────────────────────────────────────────
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Don't sleep between retries in tests.
+        config(['freegle.reach_volunteering.retry_delay_seconds' => 0]);
+    }
+
     private function makeService(array $feedData): ReachVolunteeringService
     {
-        $json = json_encode($feedData);
+        return $this->makeServiceFromBody(json_encode($feedData));
+    }
 
-        return new class($json) extends ReachVolunteeringService {
-            public function __construct(private string $feedJson) {}
+    private function makeServiceFromBody(string $body): ReachVolunteeringService
+    {
+        return $this->makeServiceFromBodies([$body]);
+    }
+
+    /**
+     * Build a service that returns each body in sequence on successive feed
+     * fetches (the last body repeats if fetched more times than provided).
+     */
+    private function makeServiceFromBodies(array $bodies): ReachVolunteeringService
+    {
+        return new class($bodies) extends ReachVolunteeringService {
+            private int $call = 0;
+
+            public function __construct(private array $bodies) {}
 
             protected function fetchFeedData(string $feedUrl): string
             {
-                return $this->feedJson;
+                $body = $this->bodies[$this->call] ?? end($this->bodies);
+                $this->call++;
+
+                return $body;
             }
         };
     }
@@ -259,6 +284,80 @@ class SyncReachVolunteeringCommandTest extends TestCase
 
         $this->assertSame(1, $result['deleted']);
         $this->assertSame(0, (int) DB::table('volunteering')->where('externalid', 'reach-99999')->value('deleted'));
+    }
+
+    public function test_throws_with_diagnostic_detail_when_feed_is_not_array(): void
+    {
+        // Mirrors the real failure: Reach's Drupal returns a PHP fatal-error
+        // page with HTTP 200 instead of JSON.
+        $service = $this->makeServiceFromBody(
+            "<br />\n<b>Fatal error</b>:  Maximum execution time of 30 seconds exceeded"
+        );
+
+        try {
+            $service->sync();
+            $this->fail('Expected RuntimeException');
+        } catch (\RuntimeException $e) {
+            $msg = $e->getMessage();
+            $this->assertStringContainsString('expected JSON array', $msg);
+            // The point of the fix: triage info must be in the message.
+            $this->assertStringContainsString('got NULL', $msg);
+            $this->assertStringContainsString('body_length=', $msg);
+            $this->assertStringContainsString('Fatal error', $msg);
+        }
+    }
+
+    public function test_throws_with_diagnostic_detail_when_feed_is_empty(): void
+    {
+        $service = $this->makeServiceFromBody('');
+
+        try {
+            $service->sync();
+            $this->fail('Expected RuntimeException');
+        } catch (\RuntimeException $e) {
+            $msg = $e->getMessage();
+            $this->assertStringContainsString('expected JSON array', $msg);
+            $this->assertStringContainsString('body_length=0', $msg);
+        }
+    }
+
+    public function test_does_not_delete_records_when_feed_fails(): void
+    {
+        // A transient feed failure must NOT cascade into deleting every Reach
+        // opportunity — the throw has to happen before the deletion phase.
+        DB::table('volunteering')->insert([
+            'externalid'  => 'reach-77777',
+            'title'       => 'Live Opportunity',
+            'location'    => 'Somewhere',
+            'description' => 'Active',
+            'contacturl'  => 'https://reachvolunteering.org.uk/vol/77777',
+            'deleted'     => 0,
+        ]);
+
+        try {
+            $this->makeServiceFromBody('<br /><b>Fatal error</b>')->sync();
+            $this->fail('Expected RuntimeException');
+        } catch (\RuntimeException) {
+            // expected
+        }
+
+        $this->assertSame(0, (int) DB::table('volunteering')->where('externalid', 'reach-77777')->value('deleted'));
+    }
+
+    public function test_retries_and_recovers_when_a_later_fetch_succeeds(): void
+    {
+        $this->seedLocationAndGroup('SW1A 1AA', 51.5007, -0.1246);
+
+        // First fetch returns Reach's fatal-error page; the retry returns valid JSON.
+        $service = $this->makeServiceFromBodies([
+            '<br /><b>Fatal error</b>: Maximum execution time of 30 seconds exceeded',
+            json_encode([$this->opportunity()]),
+        ]);
+
+        $result = $service->sync();
+
+        $this->assertSame(1, $result['added']);
+        $this->assertDatabaseHas('volunteering', ['externalid' => 'reach-12345']);
     }
 
     public function test_skips_group_with_volunteering_disabled(): void


### PR DESCRIPTION
## Problem

The daily `integrations:sync-reachvolunteering` job (21:00) failed in Sentry (freegle/batch, BATCH-W) with `RuntimeException: Reach Volunteering feed: expected JSON array`.

A first pass added diagnostic detail to that exception. The next failure then revealed the actual cause — Reach's **Drupal feed returns a PHP fatal-error page with an HTTP 200** instead of JSON:

```
<br /><b>Fatal error</b>: Maximum execution time of 30 seconds exceeded in
/app/web/core/lib/Drupal/Core/Render/Element.php on line 100<br />
```

Their server hit its own 30s `max_execution_time` rendering the feed. `$response->successful()` passes (200), but `json_decode` returns `NULL`. This is upstream and load-related — it recovers on its own.

## Fix

`fetchOpportunities()` validates the decoded body and **retries** before giving up (configurable: `REACH_VOLUNTEERING_FETCH_ATTEMPTS`=3, `REACH_VOLUNTEERING_RETRY_DELAY_SECONDS`=30), since a later attempt usually catches their server less loaded.

On total failure it **throws before the stale-deletion phase** — this is deliberate. Returning `[]` on a bad feed would treat every Reach opportunity as absent and mark the lot deleted on a transient outage. The exception carries `gettype`, `json_last_error_msg`, body length and a body sample (Sentry doesn't capture `$body` as a frame var).

## Tests

- Real Drupal fatal-error payload → throws with diagnostics
- Empty body → throws with `body_length=0`
- Failed feed deletes **nothing** (guards the delete phase)
- Retry-and-recover: bad fetch then good fetch → record created

Retry sleep is forced to 0 in tests. All edited files pass `php -l`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)