### PR TITLE
fix(modtools): remove duplicate log row on moderator message delete

### DIFF
--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -1705,12 +1705,6 @@ func handleDeleteMessage(c *fiber.Ctx, myid uint64, req PostMessageRequest) erro
 		stdmsgid = *req.Stdmsgid
 	}
 
-	// Write audit-log entry for each group this deletion affected.
-	for _, gid := range authorizedGroups {
-		ctx.Groupid = gid
-		logAndNotifyMods(db, flog.LOG_SUBTYPE_DELETED, ctx, myid, req.ID, 0, "")
-	}
-
 	// Queue email+log+push via background task for each authorized group.
 	// The batch processor will create the mod log entry and notify group moderators.
 	for _, gid := range authorizedGroups {

--- a/iznik-server-go/test/message_test.go
+++ b/iznik-server-go/test/message_test.go
@@ -1127,6 +1127,50 @@ func TestPostMessageDelete(t *testing.T) {
 	assert.Contains(t, taskData, "\"action\": \"Delete Approved Message\"", "Delete should include action field for BCC lookup")
 }
 
+// TestPostMessageDeleteNoDuplicateLog asserts that POST /message?action=Delete does NOT
+// synchronously write a Message/Deleted row to the logs table.  The batch processor
+// (ProcessBackgroundTasksCommand) is the sole writer: it inserts the row when it picks up
+// the email_message_rejected background task.  Adding a second synchronous write in the Go
+// handler creates an identical duplicate in production (one from Go, one from PHP).
+//
+// AssertFlip step 1 (BUGGY behaviour — count == 1): PASSES on current code because the
+// recent fix added logAndNotifyMods() to handleDeleteMessage.
+// AssertFlip step 2 (CORRECT behaviour — count == 0): asserted here; FAILS on buggy code.
+func TestPostMessageDeleteNoDuplicateLog(t *testing.T) {
+	prefix := uniquePrefix("msgmod_del_duplog")
+	db := database.DBConn
+
+	groupID := CreateTestGroup(t, prefix)
+	posterID := CreateTestUser(t, prefix+"_poster", "User")
+	modID := CreateTestUser(t, prefix+"_mod", "User")
+	CreateTestMembership(t, posterID, groupID, "Member")
+	CreateTestMembership(t, modID, groupID, "Moderator")
+	_, modToken := CreateTestSession(t, modID)
+
+	msgID := CreateTestMessage(t, posterID, groupID, prefix+" offer item", 52.5, -1.8)
+
+	body := map[string]interface{}{
+		"id":     msgID,
+		"action": "Delete",
+	}
+	bodyBytes, _ := json.Marshal(body)
+	url := fmt.Sprintf("/api/message?jwt=%s", modToken)
+	req := httptest.NewRequest("POST", url, bytes.NewBuffer(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := getApp().Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	// The Go handler must NOT write a Message/Deleted log entry directly.
+	// The batch processor writes it when processing the email_message_rejected task.
+	// A sync write here produces a duplicate in production (Go + PHP = 2 identical rows).
+	var logCount int64
+	db.Raw("SELECT COUNT(*) FROM logs WHERE type = ? AND subtype = ? AND msgid = ?",
+		log.LOG_TYPE_MESSAGE, log.LOG_SUBTYPE_DELETED, msgID).Scan(&logCount)
+	assert.Equal(t, int64(0), logCount,
+		"handleDeleteMessage must not sync-write a logs row: count expected 0, batch processor is the sole writer")
+}
+
 // --- Test: Spam ---
 
 func TestPostMessageSpam(t *testing.T) {

--- a/iznik-server-go/test/message_test.go
+++ b/iznik-server-go/test/message_test.go
@@ -1133,9 +1133,8 @@ func TestPostMessageDelete(t *testing.T) {
 // the email_message_rejected background task.  Adding a second synchronous write in the Go
 // handler creates an identical duplicate in production (one from Go, one from PHP).
 //
-// AssertFlip step 1 (BUGGY behaviour — count == 1): PASSES on current code because the
-// recent fix added logAndNotifyMods() to handleDeleteMessage.
-// AssertFlip step 2 (CORRECT behaviour — count == 0): asserted here; FAILS on buggy code.
+// handleDeleteMessage was temporarily broken to add a logAndNotifyMods() call (bug: duplicate
+// logs).  The fix removed that call; this test guards against regression by asserting count==0.
 func TestPostMessageDeleteNoDuplicateLog(t *testing.T) {
 	prefix := uniquePrefix("msgmod_del_duplog")
 	db := database.DBConn


### PR DESCRIPTION
## Root Cause
The recent fix that made message deletion appear in the audit log added a synchronous INSERT into the logs table inside the Go handler, but the existing batch log processor was already writing the same row asynchronously. Result: every moderator delete produces TWO identical logs rows. The batch processor is the intended sole writer for audit logs.

## Evidence
```
=== RUN   TestPostMessageDeleteNoDuplicateLog
    message_test.go:1170: 
        	Error Trace:	/app/test/message_test.go:1170
        	Error:      	Not equal: 
        	            	expected: 0
        	            	actual  : 1
        	Test:       	TestPostMessageDeleteNoDuplicateLog
        	Messages:   	handleDeleteMessage must not sync-write a logs row: count expected 0, batch processor is the sole writer
--- FAIL: TestPostMessageDeleteNoDuplicateLog (0.15s)
FAIL
Cleaned up 1 test groups
FAIL	iznik-server-go/test	0.182s
FAIL
```

## Fix
Removed the synchronous logs INSERT from the Go delete handler so the batch processor becomes the sole writer for the deletion log row. The original 'deletion not logged' fix is preserved because the batch processor still emits exactly one row per delete.

## Alternatives Investigated
- Two separate endpoints firing on one delete: ruled out — reporter saw only one mod-mail entry, implying one HTTP call.
- Frontend double-submit: ruled out for the same reason.

## Other Call Sites
No other occurrences found. `handleApprove` and `handleReject` already use the batch-only pattern. `handleHold`/`handleRelease` use `logAndNotifyMods` without a batch duplicate (no `email_message_rejected` task — correct pattern for those). `DeleteMessageEndpoint` (DELETE verb) has a sync-only `logModAction` with no batch duplicate — also correct.

## Test
File: iznik-server-go/test/message_test.go
Command: curl -s -X POST http://localhost:8081/api/tests/go -H 'Content-Type: application/json' -d '{"run":"TestPostMessageDeleteNoDuplicateLog"}'
Proves: test FAILS before this commit (count=1 sync row, see Evidence above), PASSES after (count=0 sync rows; batch processor still emits the single intended row).
Regression suite: iznik-server-go full go test suite — SUITE_PASSED=yes

## Discourse
https://discourse.ilovefreegle.org/t/9685