### PR TITLE
fix(batch): chitchat report emails dropped when reporter has no preferred email

### DIFF
--- a/iznik-batch/app/Console/Commands/Queue/ProcessBackgroundTasksCommand.php
+++ b/iznik-batch/app/Console/Commands/Queue/ProcessBackgroundTasksCommand.php
@@ -263,20 +263,20 @@ class ProcessBackgroundTasksCommand extends Command
         EmailSpoolerService $spooler,
         bool $shouldSpool
     ): void {
-        $required = ['user_id', 'user_email', 'newsfeed_id', 'reason'];
+        $required = ['user_id', 'newsfeed_id', 'reason'];
         foreach ($required as $field) {
             if (empty($data[$field])) {
                 throw new \RuntimeException("email_chitchat_report requires {$field}");
             }
         }
 
-        // user_name is cosmetic — reporters identified by id+email; fall back if blank.
+        // user_name and user_email are cosmetic — reporters are identified by user_id.
         $reporterName = !empty($data['user_name']) ? $data['user_name'] : 'A Freegle user';
 
         $mail = new ChitchatReportMail(
             reporterName: $reporterName,
             reporterId: (int) $data['user_id'],
-            reporterEmail: $data['user_email'],
+            reporterEmail: $data['user_email'] ?? '',
             newsfeedId: (int) $data['newsfeed_id'],
             reason: $data['reason'],
         );

--- a/iznik-batch/tests/Unit/Queue/ProcessBackgroundTasksCommandTest.php
+++ b/iznik-batch/tests/Unit/Queue/ProcessBackgroundTasksCommandTest.php
@@ -151,6 +151,42 @@ class ProcessBackgroundTasksCommandTest extends TestCase
         $this->assertNull($task->failed_at);
     }
 
+    public function test_email_chitchat_report_sends_without_user_email(): void
+    {
+        // Regression: reporter with no preferred=1 email queues an empty user_email.
+        // The consumer must still send the report — user_id identifies the reporter.
+        Mail::fake();
+
+        DB::table('background_tasks')->insert([
+            'task_type' => 'email_chitchat_report',
+            'data' => json_encode([
+                'user_id' => 99001,
+                'user_name' => 'No-Email Reporter',
+                'user_email' => '',
+                'newsfeed_id' => 88001,
+                'reason' => 'Spam',
+            ]),
+            'created_at' => now(),
+        ]);
+
+        $this->mock(PushNotificationService::class);
+
+        $this->artisan('queue:background-tasks', [
+            '--max-iterations' => 1,
+            '--sleep' => 0,
+        ])->assertSuccessful();
+
+        Mail::assertSent(ChitchatReportMail::class, function (ChitchatReportMail $mail) {
+            return $mail->reporterId === 99001
+                && $mail->newsfeedId === 88001
+                && $mail->reporterEmail === '';
+        });
+
+        $task = DB::table('background_tasks')->first();
+        $this->assertNotNull($task->processed_at);
+        $this->assertNull($task->failed_at);
+    }
+
     public function test_skips_already_processed_tasks(): void
     {
         DB::table('background_tasks')->insert([

--- a/iznik-server-go/newsfeed/newsfeed.go
+++ b/iznik-server-go/newsfeed/newsfeed.go
@@ -1041,7 +1041,7 @@ func Post(c *fiber.Ctx) error {
 				Email    string
 			}
 			var reporter ReporterInfo
-			db.Raw("SELECT u.fullname, ue.email FROM users u LEFT JOIN users_emails ue ON ue.userid = u.id AND ue.preferred = 1 WHERE u.id = ?", myid).Scan(&reporter)
+			db.Raw("SELECT u.fullname, ue.email FROM users u LEFT JOIN users_emails ue ON ue.userid = u.id WHERE u.id = ? ORDER BY ue.preferred DESC, ue.id ASC LIMIT 1", myid).Scan(&reporter)
 
 			if err := queue.QueueTask(queue.TaskEmailChitchatReport, map[string]interface{}{
 				"user_id":     myid,

--- a/iznik-server-go/test/newsfeed_test.go
+++ b/iznik-server-go/test/newsfeed_test.go
@@ -265,6 +265,39 @@ func TestNewsfeedReport(t *testing.T) {
 	assert.Equal(t, int64(1), taskCount, "Expected email_chitchat_report task to be queued")
 }
 
+func TestNewsfeedReportNoPreferredEmail(t *testing.T) {
+	// Regression: reporter with no preferred=1 email caused user_email to be empty,
+	// silently dropping the ChitChat support notification after 3 failed retries.
+	prefix := uniquePrefix("nfwr_npe")
+	userID := CreateTestUser(t, prefix, "User")
+	_, token := CreateTestSession(t, userID)
+	nfID := CreateTestNewsfeed(t, userID, 52.2, -0.1, "Test report no-preferred "+prefix)
+
+	// Demote the user's email so no row has preferred=1 — this is the bug trigger.
+	db := database.DBConn
+	db.Exec("UPDATE users_emails SET preferred = 0 WHERE userid = ?", userID)
+
+	body := fmt.Sprintf(`{"id":%d,"action":"Report","reason":"Spam"}`, nfID)
+	req := httptest.NewRequest("POST", "/api/newsfeed?jwt="+token, bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	// Task must be queued with a non-empty user_email so the consumer can send it.
+	var taskData string
+	db.Raw(
+		"SELECT data FROM background_tasks WHERE task_type = 'email_chitchat_report' AND processed_at IS NULL AND data LIKE ?",
+		fmt.Sprintf("%%\"newsfeed_id\": %d%%", nfID),
+	).Scan(&taskData)
+	assert.NotEmpty(t, taskData, "Expected email_chitchat_report task to be queued")
+
+	var fields map[string]interface{}
+	if err := json.Unmarshal([]byte(taskData), &fields); err == nil {
+		userEmail, _ := fields["user_email"].(string)
+		assert.NotEmpty(t, userEmail, "Expected user_email to be populated when reporter has a non-preferred email")
+	}
+}
+
 func TestNewsfeedHide(t *testing.T) {
 	prefix := uniquePrefix("nfwr_hide")
 	userID := CreateTestUser(t, prefix, "Admin")


### PR DESCRIPTION
## Summary

- **Go producer** (\`newsfeed.go\`): changed reporter email lookup from \`WHERE preferred=1\` (returns NULL when no preferred email set) to \`ORDER BY preferred DESC, id ASC LIMIT 1\` — picks best available email
- **Laravel consumer** (\`ProcessBackgroundTasksCommand\`): removed \`user_email\` from required fields — \`user_id\` is the meaningful identifier; email is cosmetic context for mods

## Root cause

Sporadic \`email_chitchat_report requires user_email\` failures (Apr 30, May 8, May 21) traced to reporters whose \`users_emails\` rows have \`preferred=0\` or no rows at all. The \`preferred=1\` filter in the LEFT JOIN returned NULL, the consumer hard-failed all 3 retries, and mods never saw the reported post.

## Code Quality Review

- Go query is a minimal change — same LEFT JOIN structure, just removes the ON-clause filter and adds ORDER BY/LIMIT
- No new abstractions, no duplication

## Test Plan

- \`TestNewsfeedReportNoPreferredEmail\` — Go test: reporter with preferred=0 email → asserts task queued with non-empty user_email (was failing before fix)
- \`test_email_chitchat_report_sends_without_user_email\` — Laravel test: consumer processes task with empty user_email without throwing
- Full Laravel suite: 2954✓ 0✗
- Full Go suite: 2646✓ 0✗