### PR TITLE
fix(message): remove AI attachment and scrape TN photos when TN user edits post

### DIFF
--- a/iznik-nuxt3/tests/e2e/fixtures.js
+++ b/iznik-nuxt3/tests/e2e/fixtures.js
@@ -336,6 +336,7 @@ const test = base.test.extend({
       /net::ERR_SOCKET_NOT_CONNECTED.*delivery\.ilovefreegle\.org/, // External CDN not accessible in local/Docker test environments
       /Failed to load resource.*delivery\.ilovefreegle\.org/, // External CDN not accessible in local/Docker test environments
       /Your focus-trap must have at least one container/, // Bootstrap Vue focus-trap error during modal transitions (transient, non-critical)
+      /Failed to load resource.*adtrafficquality\.google.*sodar/, // Google CSE script internally calls sodar (ad traffic quality) — external service, not our code
     ]
 
     // Initialize the working copy of allowed error patterns

--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -34,6 +34,10 @@ import (
 var emailRegexp = regexp.MustCompile(utils.EMAIL_REGEXP)
 var phoneRegexp = regexp.MustCompile(utils.PHONE_REGEXP)
 var tnRegexp = regexp.MustCompile(utils.TN_REGEXP)
+// tnPhotoLinkRegexp matches the "Check out the pictures" photo-link block that TN
+// appends to textbody when a post has photos.  Absence of this pattern in an
+// updated textbody means the TN user intentionally removed all their photos.
+var tnPhotoLinkRegexp = regexp.MustCompile(`https://trashnothing\.com/pics/`)
 
 // Declaring the table name seems to help with a race seen in testing.
 func (Message) TableName() string {
@@ -2791,6 +2795,22 @@ func PatchMessageByTN(c *fiber.Ctx) error {
 		req.ID = msgID
 		if err := applyPatchMessageCore(c, myid, req); err != nil {
 			return err
+		}
+
+		// TN never sends an explicit attachments array — photo removal is signalled
+		// by the absence of a trashnothing.com/pics/ link in the updated textbody.
+		// When we see a textbody update with no photo links, treat any remaining AI
+		// attachment as implicitly removed: record the deletion (sets messages_ai_declined
+		// to block cron re-injection) and delete the attachment row.
+		if req.Textbody != nil && !tnPhotoLinkRegexp.MatchString(*req.Textbody) {
+			var aiCount int64
+			db.Raw("SELECT COUNT(*) FROM messages_attachments WHERE msgid = ? AND externalmods LIKE ?",
+				msgID, `%"ai":true%`).Scan(&aiCount)
+			if aiCount > 0 {
+				recordAIDeletions(db, myid, msgID, []uint64{}, nil)
+				db.Exec("DELETE FROM messages_attachments WHERE msgid = ? AND externalmods LIKE ?",
+					msgID, `%"ai":true%`)
+			}
 		}
 	}
 	return c.JSON(fiber.Map{"ret": 0, "status": "Success"})

--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -4,7 +4,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log"
+	"net/http"
 	"net/url"
 	"os"
 	"regexp"
@@ -13,6 +15,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/freegle/iznik-server-go/aiimage"
 	"github.com/freegle/iznik-server-go/auth"
 	"github.com/freegle/iznik-server-go/database"
 	"github.com/freegle/iznik-server-go/embedding"
@@ -27,6 +30,7 @@ import (
 	"github.com/freegle/iznik-server-go/utils"
 	"github.com/gofiber/fiber/v2"
 	"github.com/golang-jwt/jwt/v4"
+	"golang.org/x/net/html"
 	"gorm.io/gorm"
 )
 
@@ -34,10 +38,150 @@ import (
 var emailRegexp = regexp.MustCompile(utils.EMAIL_REGEXP)
 var phoneRegexp = regexp.MustCompile(utils.PHONE_REGEXP)
 var tnRegexp = regexp.MustCompile(utils.TN_REGEXP)
-// tnPhotoLinkRegexp matches the "Check out the pictures" photo-link block that TN
-// appends to textbody when a post has photos.  Absence of this pattern in an
-// updated textbody means the TN user intentionally removed all their photos.
-var tnPhotoLinkRegexp = regexp.MustCompile(`https://trashnothing\.com/pics/`)
+// tnPicPageURLRegexp finds each TN "pics" page link embedded in a textbody.
+var tnPicPageURLRegexp = regexp.MustCompile(`(?m)https://trashnothing\.com/pics/\S+`)
+// tnPicHeaderRegexp strips the "Check out the pictures…" intro line.
+var tnPicHeaderRegexp = regexp.MustCompile(`(?m)^Check out the pictures[^\n]*\n?`)
+// tnPicURLLineRegexp strips individual trashnothing.com/pics/ URL lines.
+var tnPicURLLineRegexp = regexp.MustCompile(`(?m)^https://trashnothing\.com/pics/[^\n]*\n?`)
+
+// TNPageFetcher fetches a TN /pics/ page and returns direct image URLs.
+// Swappable in tests.
+var TNPageFetcher = extractTNImageURLsFromPage
+
+// TNImageFetcher downloads a TN image and returns (data, mime, error).
+// Swappable in tests.
+var TNImageFetcher = downloadTNImage
+
+func downloadTNImage(imageURL string) ([]byte, string, error) {
+	client := &http.Client{Timeout: 60 * time.Second}
+	resp, err := client.Get(imageURL)
+	if err != nil {
+		return nil, "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, "", fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, "", err
+	}
+	mime := resp.Header.Get("Content-Type")
+	if mime == "" {
+		mime = "image/jpeg"
+	}
+	return data, mime, nil
+}
+
+// isTNImageURL returns true for direct TN image URLs (not the /pics/ page links).
+func isTNImageURL(u string) bool {
+	return strings.Contains(u, "trashnothing.com/img/") ||
+		strings.Contains(u, "img.trashnothing.com") ||
+		strings.Contains(u, "/tn-photos/") ||
+		strings.Contains(u, "photos.trashnothing.com")
+}
+
+// extractTNImageURLsFromPage fetches a TN /pics/ page and returns direct image URLs.
+func extractTNImageURLsFromPage(pageURL string) []string {
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Get(pageURL)
+	if err != nil || resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		if err == nil {
+			resp.Body.Close()
+		}
+		return nil
+	}
+	defer resp.Body.Close()
+
+	doc, err := html.Parse(resp.Body)
+	if err != nil {
+		return nil
+	}
+
+	var found []string
+	var walk func(*html.Node)
+	walk = func(n *html.Node) {
+		if n.Type == html.ElementNode && n.Data == "a" {
+			for _, attr := range n.Attr {
+				if attr.Key == "href" && isTNImageURL(attr.Val) {
+					found = append(found, attr.Val)
+					break
+				}
+			}
+		}
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			walk(c)
+		}
+	}
+	walk(doc)
+
+	// Fall back to img src if no anchor hrefs found.
+	if len(found) == 0 {
+		var walkImgs func(*html.Node)
+		walkImgs = func(n *html.Node) {
+			if n.Type == html.ElementNode && n.Data == "img" {
+				for _, attr := range n.Attr {
+					if attr.Key == "src" && isTNImageURL(attr.Val) {
+						found = append(found, attr.Val)
+						break
+					}
+				}
+			}
+			for c := n.FirstChild; c != nil; c = c.NextSibling {
+				walkImgs(c)
+			}
+		}
+		walkImgs(doc)
+	}
+
+	return found
+}
+
+// TNPhotoScrapeRunner launches TN photo scraping.  Swappable in tests to run synchronously.
+var TNPhotoScrapeRunner = func(db *gorm.DB, msgID uint64, picPageURLs []string) {
+	go scrapeTNPhotosToAttachments(db, msgID, picPageURLs)
+}
+
+// scrapeTNPhotosToAttachments downloads TN images from pic-page URLs and inserts
+// them as messages_attachments rows.  Errors are logged only.
+// Exported as ScrapeTNPhotosSync for test use.
+func scrapeTNPhotosToAttachments(db *gorm.DB, msgID uint64, picPageURLs []string) {
+	isPrimary := true
+	seen := map[string]bool{}
+	for _, pageURL := range picPageURLs {
+		imageURLs := TNPageFetcher(pageURL)
+		for _, imageURL := range imageURLs {
+			if seen[imageURL] {
+				continue
+			}
+			seen[imageURL] = true
+
+			data, mime, err := TNImageFetcher(imageURL)
+			if err != nil {
+				log.Printf("scrapeTNPhotos: failed to download %s: %v", imageURL, err)
+				continue
+			}
+
+			externaluid, err := aiimage.ImageUploader(data, mime)
+			if err != nil {
+				log.Printf("scrapeTNPhotos: TUS upload failed for %s: %v", imageURL, err)
+				continue
+			}
+
+			primary := 0
+			if isPrimary {
+				primary = 1
+				isPrimary = false
+			}
+			db.Exec("INSERT IGNORE INTO messages_attachments (msgid, externaluid, `primary`) VALUES (?, ?, ?)",
+				msgID, externaluid, primary)
+		}
+	}
+}
+
+// ScrapeTNPhotosSync is the synchronous variant of scrapeTNPhotosToAttachments, exposed for tests.
+var ScrapeTNPhotosSync = scrapeTNPhotosToAttachments
 
 // Declaring the table name seems to help with a race seen in testing.
 func (Message) TableName() string {
@@ -2793,16 +2937,31 @@ func PatchMessageByTN(c *fiber.Ctx) error {
 
 	for _, msgID := range msgIDs {
 		req.ID = msgID
+
+		// TN never sends an explicit attachments array.  We detect photo changes
+		// through the textbody:
+		//   • No trashnothing.com/pics/ links → user removed all photos → remove AI.
+		//   • Links present → scrape+store TN photos AND remove AI (TN photos replace it).
+		// In both cases the AI attachment must go; in the second case we also strip the
+		// "Check out the pictures…" block from the stored textbody and kick off scraping.
+		var picPageURLs []string
+		if req.Textbody != nil {
+			picPageURLs = tnPicPageURLRegexp.FindAllString(*req.Textbody, -1)
+			if len(picPageURLs) > 0 {
+				// Strip the photo-link block before persisting the textbody.
+				stripped := tnPicHeaderRegexp.ReplaceAllString(*req.Textbody, "")
+				stripped = tnPicURLLineRegexp.ReplaceAllString(stripped, "")
+				stripped = strings.TrimSpace(stripped)
+				req.Textbody = &stripped
+			}
+		}
+
 		if err := applyPatchMessageCore(c, myid, req); err != nil {
 			return err
 		}
 
-		// TN never sends an explicit attachments array — photo removal is signalled
-		// by the absence of a trashnothing.com/pics/ link in the updated textbody.
-		// When we see a textbody update with no photo links, treat any remaining AI
-		// attachment as implicitly removed: record the deletion (sets messages_ai_declined
-		// to block cron re-injection) and delete the attachment row.
-		if req.Textbody != nil && !tnPhotoLinkRegexp.MatchString(*req.Textbody) {
+		// Remove any AI attachment whenever textbody is updated (both cases).
+		if req.Textbody != nil {
 			var aiCount int64
 			db.Raw("SELECT COUNT(*) FROM messages_attachments WHERE msgid = ? AND externalmods LIKE ?",
 				msgID, `%"ai":true%`).Scan(&aiCount)
@@ -2811,6 +2970,11 @@ func PatchMessageByTN(c *fiber.Ctx) error {
 				db.Exec("DELETE FROM messages_attachments WHERE msgid = ? AND externalmods LIKE ?",
 					msgID, `%"ai":true%`)
 			}
+		}
+
+		// If TN photos were present, scrape them and store as attachments.
+		if len(picPageURLs) > 0 {
+			TNPhotoScrapeRunner(db, msgID, picPageURLs)
 		}
 	}
 	return c.JSON(fiber.Map{"ret": 0, "status": "Success"})

--- a/iznik-server-go/test/message_test.go
+++ b/iznik-server-go/test/message_test.go
@@ -8492,3 +8492,51 @@ func TestPatchMessageByTnPostid_RemovesAIAndScrapesTNPhotosWhenLinksPresent(t *t
 	db.Exec("DELETE FROM messages_ai_declined WHERE msgid = ?", msgID)
 	db.Exec("DELETE FROM messages_attachments WHERE msgid = ?", msgID)
 }
+
+// TestPatchMessageByTnPostid_NonAIAttachmentPreservedOnTextOnlyEdit verifies that when a
+// TN user edits only the text of their post (no photo links in textbody) and there is no
+// AI attachment, any existing real attachment is left untouched.
+func TestPatchMessageByTnPostid_NonAIAttachmentPreservedOnTextOnlyEdit(t *testing.T) {
+	prefix := uniquePrefix("patchtn_noai")
+	db := database.DBConn
+
+	groupID := CreateTestGroup(t, prefix)
+	ownerID := CreateTestUser(t, prefix+"_owner", "User")
+	CreateTestMembership(t, ownerID, groupID, "Member")
+	db.Exec("UPDATE users SET tnuserid = ? WHERE id = ?", 77803, ownerID)
+
+	msgID := CreateTestMessage(t, ownerID, groupID, prefix+" Offer", 55.9533, -3.1883)
+	tnpostid := fmt.Sprintf("tn-noai-%d", msgID)
+	db.Exec("UPDATE messages SET tnpostid = ? WHERE id = ?", tnpostid, msgID)
+
+	// Insert a regular (non-AI) attachment.
+	realAttachID := CreateTestAttachment(t, msgID)
+
+	key := insertTestPartnerKeyMsg(t, prefix, "tn.com")
+	defer db.Exec("DELETE FROM partners_keys WHERE partner = ?", prefix+"_partner")
+
+	// PATCH with a textbody containing no TN photo links — pure text edit.
+	body := map[string]interface{}{
+		"textbody": "Updated description with no photos.",
+	}
+	bodyBytes, _ := json.Marshal(body)
+	url := fmt.Sprintf("/api/message/tn/%s?partner=%s&tnuserid=77803&email=%s@tn.com", tnpostid, key, prefix+"_owner")
+	req := httptest.NewRequest("PATCH", url, bytes.NewBuffer(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := getApp().Test(req, -1)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	// Real attachment must still exist.
+	var attachCount int64
+	db.Raw("SELECT COUNT(*) FROM messages_attachments WHERE id = ?", realAttachID).Scan(&attachCount)
+	assert.Equal(t, int64(1), attachCount, "non-AI attachment must not be deleted on a text-only TN edit")
+
+	// No AI declined flag should be set (no AI attachment was present).
+	var declinedCount int64
+	db.Raw("SELECT COUNT(*) FROM messages_ai_declined WHERE msgid = ?", msgID).Scan(&declinedCount)
+	assert.Equal(t, int64(0), declinedCount, "messages_ai_declined must not be set when no AI attachment existed")
+
+	// Cleanup.
+	db.Exec("DELETE FROM messages_attachments WHERE id = ?", realAttachID)
+}

--- a/iznik-server-go/test/message_test.go
+++ b/iznik-server-go/test/message_test.go
@@ -8345,3 +8345,55 @@ func TestContentcheckFallbackVisibleAfter30Minutes(t *testing.T) {
 	}
 	assert.True(t, found, "unprocessed message older than 30 minutes must appear in pending queue as safety fallback")
 }
+
+// TestPatchMessageByTnPostid_RemovesAIPhotoWhenTextbodyHasNoPhotoLinks verifies that
+// when a TN user edits their post to remove all photos (textbody has no TN photo links),
+// the AI-generated attachment is deleted and the message is flagged as AI-declined so the
+// illustrations cron cannot re-inject it.
+func TestPatchMessageByTnPostid_RemovesAIPhotoWhenTextbodyHasNoPhotoLinks(t *testing.T) {
+	prefix := uniquePrefix("patchtn_ai_photo")
+	db := database.DBConn
+
+	groupID := CreateTestGroup(t, prefix)
+	ownerID := CreateTestUser(t, prefix+"_owner", "User")
+	CreateTestMembership(t, ownerID, groupID, "Member")
+	db.Exec("UPDATE users SET tnuserid = ? WHERE id = ?", 77801, ownerID)
+
+	msgID := CreateTestMessage(t, ownerID, groupID, prefix+" Offer", 55.9533, -3.1883)
+	tnpostid := fmt.Sprintf("tn-ai-%d", msgID)
+	db.Exec("UPDATE messages SET tnpostid = ? WHERE id = ?", tnpostid, msgID)
+
+	// Insert an AI-generated attachment on the message.
+	externalUID := fmt.Sprintf("ai-uid-%d", msgID)
+	db.Exec("INSERT INTO messages_attachments (msgid, externaluid, externalmods, `primary`) VALUES (?, ?, ?, 1)",
+		msgID, externalUID, `{"ai":true}`)
+
+	key := insertTestPartnerKeyMsg(t, prefix, "tn.com")
+	defer db.Exec("DELETE FROM partners_keys WHERE partner = ?", prefix+"_partner")
+
+	// PATCH with a textbody that contains no TN photo links — simulates TN user deleting their photo.
+	body := map[string]interface{}{
+		"textbody": "I have a sofa to give away. No photos.",
+	}
+	bodyBytes, _ := json.Marshal(body)
+	url := fmt.Sprintf("/api/message/tn/%s?partner=%s&tnuserid=77801&email=%s@tn.com", tnpostid, key, prefix+"_owner")
+	req := httptest.NewRequest("PATCH", url, bytes.NewBuffer(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := getApp().Test(req, -1)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	// AI attachment must be gone.
+	var aiCount int64
+	db.Raw("SELECT COUNT(*) FROM messages_attachments WHERE msgid = ? AND externalmods LIKE ?", msgID, `%"ai":true%`).Scan(&aiCount)
+	assert.Equal(t, int64(0), aiCount, "AI attachment should be removed when TN textbody has no photo links")
+
+	// messages_ai_declined must be set so the cron cannot re-inject.
+	var declinedCount int64
+	db.Raw("SELECT COUNT(*) FROM messages_ai_declined WHERE msgid = ?", msgID).Scan(&declinedCount)
+	assert.Equal(t, int64(1), declinedCount, "messages_ai_declined must be set to prevent cron re-injection")
+
+	// Cleanup.
+	db.Exec("DELETE FROM messages_ai_declined WHERE msgid = ?", msgID)
+	db.Exec("DELETE FROM messages_attachments WHERE msgid = ?", msgID)
+}

--- a/iznik-server-go/test/message_test.go
+++ b/iznik-server-go/test/message_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/freegle/iznik-server-go/aiimage"
 	"github.com/freegle/iznik-server-go/database"
 	"github.com/freegle/iznik-server-go/log"
 	"github.com/freegle/iznik-server-go/message"
@@ -8392,6 +8393,100 @@ func TestPatchMessageByTnPostid_RemovesAIPhotoWhenTextbodyHasNoPhotoLinks(t *tes
 	var declinedCount int64
 	db.Raw("SELECT COUNT(*) FROM messages_ai_declined WHERE msgid = ?", msgID).Scan(&declinedCount)
 	assert.Equal(t, int64(1), declinedCount, "messages_ai_declined must be set to prevent cron re-injection")
+
+	// Cleanup.
+	db.Exec("DELETE FROM messages_ai_declined WHERE msgid = ?", msgID)
+	db.Exec("DELETE FROM messages_attachments WHERE msgid = ?", msgID)
+}
+
+// TestPatchMessageByTnPostid_RemovesAIAndScrapesTNPhotosWhenLinksPresent verifies that
+// when a TN user edits their post and the textbody contains trashnothing.com/pics/ links:
+//   - The AI-generated attachment is removed and messages_ai_declined is set
+//   - The pic-link block is stripped from the stored textbody
+//   - The TN page fetcher is invoked and its returned image URLs are stored as attachments
+func TestPatchMessageByTnPostid_RemovesAIAndScrapesTNPhotosWhenLinksPresent(t *testing.T) {
+	prefix := uniquePrefix("patchtn_scrape")
+	db := database.DBConn
+
+	groupID := CreateTestGroup(t, prefix)
+	ownerID := CreateTestUser(t, prefix+"_owner", "User")
+	CreateTestMembership(t, ownerID, groupID, "Member")
+	db.Exec("UPDATE users SET tnuserid = ? WHERE id = ?", 77802, ownerID)
+
+	msgID := CreateTestMessage(t, ownerID, groupID, prefix+" Offer", 55.9533, -3.1883)
+	tnpostid := fmt.Sprintf("tn-scrape-%d", msgID)
+	db.Exec("UPDATE messages SET tnpostid = ? WHERE id = ?", tnpostid, msgID)
+
+	// Insert an AI-generated attachment.
+	aiExternalUID := fmt.Sprintf("ai-uid-scrape-%d", msgID)
+	db.Exec("INSERT INTO messages_attachments (msgid, externaluid, externalmods, `primary`) VALUES (?, ?, ?, 1)",
+		msgID, aiExternalUID, `{"ai":true}`)
+
+	key := insertTestPartnerKeyMsg(t, prefix, "tn.com")
+	defer db.Exec("DELETE FROM partners_keys WHERE partner = ?", prefix+"_partner")
+
+	// Inject a fake TNPageFetcher that returns a stable image URL without real HTTP.
+	fakeImageURL := "https://img.trashnothing.com/fake/photo.jpg"
+	origFetcher := message.TNPageFetcher
+	message.TNPageFetcher = func(pageURL string) []string {
+		return []string{fakeImageURL}
+	}
+	defer func() { message.TNPageFetcher = origFetcher }()
+
+	// Inject a fake TNImageFetcher that returns stub image data without real HTTP.
+	origImageFetcher := message.TNImageFetcher
+	message.TNImageFetcher = func(imageURL string) ([]byte, string, error) {
+		return []byte("fake-image-data"), "image/jpeg", nil
+	}
+	defer func() { message.TNImageFetcher = origImageFetcher }()
+
+	// Inject a fake ImageUploader that returns a stable externaluid without real TUS.
+	fakeExternalUID := fmt.Sprintf("freegletusd-tn-fake-%d", msgID)
+	origUploader := aiimage.ImageUploader
+	aiimage.ImageUploader = func(data []byte, mime string) (string, error) {
+		return fakeExternalUID, nil
+	}
+	defer func() { aiimage.ImageUploader = origUploader }()
+
+	// Run scraping synchronously so the test doesn't need to sleep.
+	origScrapeRunner := message.TNPhotoScrapeRunner
+	message.TNPhotoScrapeRunner = message.ScrapeTNPhotosSync
+	defer func() { message.TNPhotoScrapeRunner = origScrapeRunner }()
+
+	// PATCH with a textbody containing a TN photo link block.
+	textbody := "I have a sofa to give away.\n\nCheck out the pictures at:\nhttps://trashnothing.com/pics/abc123\n"
+	body := map[string]interface{}{
+		"textbody": textbody,
+	}
+	bodyBytes, _ := json.Marshal(body)
+	url := fmt.Sprintf("/api/message/tn/%s?partner=%s&tnuserid=77802&email=%s@tn.com", tnpostid, key, prefix+"_owner")
+	req := httptest.NewRequest("PATCH", url, bytes.NewBuffer(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := getApp().Test(req, -1)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	// AI attachment must be gone.
+	var aiCount int64
+	db.Raw("SELECT COUNT(*) FROM messages_attachments WHERE msgid = ? AND externalmods LIKE ?", msgID, `%"ai":true%`).Scan(&aiCount)
+	assert.Equal(t, int64(0), aiCount, "AI attachment should be removed when TN textbody has photo links")
+
+	// messages_ai_declined must be set.
+	var declinedCount int64
+	db.Raw("SELECT COUNT(*) FROM messages_ai_declined WHERE msgid = ?", msgID).Scan(&declinedCount)
+	assert.Equal(t, int64(1), declinedCount, "messages_ai_declined must be set to prevent cron re-injection")
+
+	// The pic-link block should be stripped from the stored textbody.
+	var storedTextbody string
+	db.Raw("SELECT textbody FROM messages WHERE id = ?", msgID).Scan(&storedTextbody)
+	assert.NotContains(t, storedTextbody, "trashnothing.com/pics/", "pic links should be stripped from stored textbody")
+	assert.NotContains(t, storedTextbody, "Check out the pictures", "pic block header should be stripped from stored textbody")
+	assert.Contains(t, storedTextbody, "sofa", "non-photo content should be preserved in textbody")
+
+	// Verify the scraped TN photo was stored as an attachment.
+	var tnCount int64
+	db.Raw("SELECT COUNT(*) FROM messages_attachments WHERE msgid = ? AND externaluid = ?", msgID, fakeExternalUID).Scan(&tnCount)
+	assert.Equal(t, int64(1), tnCount, "scraped TN photo should be stored as attachment")
 
 	// Cleanup.
 	db.Exec("DELETE FROM messages_ai_declined WHERE msgid = ?", msgID)


### PR DESCRIPTION
## Summary

- When a TN user edits their post via the TN app, TN sends `PATCH /message/tn/:tnpostid` with an updated textbody
- Previously, AI attachments were only removed when the client sent an explicit `attachments: []` array — which TN never does; the illustrations cron could re-inject the AI photo even after the user deleted it
- **Case 1 — No TN photos**: if the updated textbody contains no `trashnothing.com/pics/` links, treat any AI attachment as implicitly removed: call `recordAIDeletions()` and delete the attachment row
- **Case 2 — TN photos present**: if the updated textbody contains `trashnothing.com/pics/` links, ALSO remove the AI attachment AND scrape the TN /pics/ pages for direct image URLs, download and upload them to TUS, store as `messages_attachments` rows, and strip the "Check out the pictures…" block from the stored textbody
- In both cases `messages_ai_declined` is set to block cron re-injection
- Non-AI attachments are never touched by the TN edit path

## Code Quality Review

- No duplication — reuses `recordAIDeletions()` helper; `aiimage.ImageUploader` shared with the illustration pipeline
- Regexps compiled once at package level
- `TNPageFetcher`, `TNImageFetcher`, `TNPhotoScrapeRunner`, `ScrapeTNPhotosSync` are injectable vars; tests use stubs with no real HTTP or TUS calls
- Scraping runs via `TNPhotoScrapeRunner` (goroutine in production, synchronous in tests) so the PATCH response is not delayed by photo downloads
- Textbody stripping happens before `applyPatchMessageCore` so the DB always stores clean text

## Test Plan

- `TestPatchMessageByTnPostid_RemovesAIPhotoWhenTextbodyHasNoPhotoLinks`: PATCH with no photo links → AI removed + `messages_ai_declined` set
- `TestPatchMessageByTnPostid_RemovesAIAndScrapesTNPhotosWhenLinksPresent`: PATCH with TN pic links → AI removed + textbody stripped + scraped photo stored as attachment
- `TestPatchMessageByTnPostid_NonAIAttachmentPreservedOnTextOnlyEdit`: text-only PATCH with no AI attachment → real attachment untouched, no `messages_ai_declined` set
- Playwright: allowed Google sodar 500 errors from CSE script on /stories/summary (external Google service, not our code)
- Full suite: 2648 Go tests pass, CI green