### PR TITLE
fix(batch): chitchat email link points to user site, not modtools

### DIFF
--- a/iznik-batch/app/Mail/Newsfeed/NewsfeedModNotifMail.php
+++ b/iznik-batch/app/Mail/Newsfeed/NewsfeedModNotifMail.php
@@ -36,12 +36,12 @@ class NewsfeedModNotifMail extends MjmlMailable
 
     public function build(): static
     {
-        $modSite = config('freegle.sites.mod', 'https://modtools.org');
+        $userSite = config('freegle.sites.user', 'https://www.ilovefreegle.org');
 
         return $this->mjmlView('emails.mjml.newsfeed.mod-notif', [
             'posts'       => $this->posts,
             'count'       => count($this->posts),
-            'chitchatUrl' => "{$modSite}/chitchat",
+            'chitchatUrl' => "{$userSite}/chitchat",
             'email'       => $this->recipientEmail,
         ]);
     }

--- a/iznik-batch/app/Mail/Newsfeed/NewsfeedModNotifMail.php
+++ b/iznik-batch/app/Mail/Newsfeed/NewsfeedModNotifMail.php
@@ -39,10 +39,10 @@ class NewsfeedModNotifMail extends MjmlMailable
         $userSite = config('freegle.sites.user', 'https://www.ilovefreegle.org');
 
         return $this->mjmlView('emails.mjml.newsfeed.mod-notif', [
-            'posts'       => $this->posts,
-            'count'       => count($this->posts),
-            'chitchatUrl' => "{$userSite}/chitchat",
-            'email'       => $this->recipientEmail,
+            'posts'    => $this->posts,
+            'count'    => count($this->posts),
+            'userSite' => $userSite,
+            'email'    => $this->recipientEmail,
         ]);
     }
 }

--- a/iznik-batch/app/Services/NewsfeedModNotifService.php
+++ b/iznik-batch/app/Services/NewsfeedModNotifService.php
@@ -153,6 +153,7 @@ class NewsfeedModNotifService
                 }
 
                 $postsData[] = [
+                    'id'      => $post->id,
                     'label'   => $label,
                     'preview' => $preview,
                     'added'   => $post->added,

--- a/iznik-batch/resources/views/emails/mjml/newsfeed/mod-notif.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/newsfeed/mod-notif.blade.php
@@ -30,7 +30,7 @@
         </mj-text>
       </mj-column>
       <mj-column width="110px" vertical-align="middle">
-        <mj-button mj-class="btn-modtools" href="{{ $chitchatUrl }}" font-size="13px" inner-padding="8px 14px">
+        <mj-button mj-class="btn-modtools" href="{{ $userSite }}/chitchat/{{ $post['id'] }}" font-size="13px" inner-padding="8px 14px">
           View
         </mj-button>
       </mj-column>
@@ -44,7 +44,7 @@
 
     <mj-section background-color="#ffffff" padding="10px 20px 20px">
       <mj-column>
-        <mj-button href="{{ $chitchatUrl }}" mj-class="btn-modtools" border-radius="3px" font-size="16px">
+        <mj-button href="{{ $userSite }}/chitchat" mj-class="btn-modtools" border-radius="3px" font-size="16px">
           View all chitchat
         </mj-button>
       </mj-column>

--- a/iznik-batch/tests/Unit/Mail/Newsfeed/NewsfeedModNotifMailTest.php
+++ b/iznik-batch/tests/Unit/Mail/Newsfeed/NewsfeedModNotifMailTest.php
@@ -6,19 +6,15 @@ use App\Mail\Newsfeed\NewsfeedModNotifMail;
 use Tests\TestCase;
 
 /**
- * AssertFlip failing test for the broken chitchat link in NewsfeedModNotifMail.
+ * Tests for NewsfeedModNotifMail link correctness (V1 parity).
  *
  * Bug (topic 9676): the "View" and "View all chitchat" buttons in the moderator
  * chitchat notification email link to https://modtools.org/chitchat, but the
  * Modtools application has no /chitchat route — clicking the link produces a 404.
  *
- * The legacy iznik-server code correctly linked to https://www.ilovefreegle.org/chitchat
- * (the user site), where the /chitchat page exists. The batch migration accidentally
- * changed the destination to the mod site, which has no such page.
- *
- * AssertFlip Step 2 — inverted assertions that FAIL on buggy code, PASS after the fix.
- * The fix: change chitchatUrl to use config('freegle.sites.user') instead of
- * config('freegle.sites.mod').
+ * V1 parity: iznik-server Newsfeed.php links to /chitchat/{id} (specific post),
+ * not just /chitchat. Each per-post "View" button must use the post ID so mods
+ * land directly on the reported post rather than the general chitchat listing.
  */
 class NewsfeedModNotifMailTest extends TestCase
 {
@@ -26,6 +22,7 @@ class NewsfeedModNotifMailTest extends TestCase
     {
         return [
             [
+                'id'      => 42,
                 'label'   => 'Post',
                 'preview' => 'Anyone know a good plumber nearby?',
                 'added'   => '2026-05-22 10:30:00',
@@ -45,8 +42,6 @@ class NewsfeedModNotifMailTest extends TestCase
         $modSite  = config('freegle.sites.mod');   // https://modtools.org
         $userSite = config('freegle.sites.user');  // https://www.ilovefreegle.org
 
-        // The Modtools app has no /chitchat route: clicking the link returns a 404.
-        // After the fix, the button must link to the user site where /chitchat exists.
         $this->assertStringNotContainsString(
             $modSite . '/chitchat',
             $html,
@@ -60,7 +55,7 @@ class NewsfeedModNotifMailTest extends TestCase
         );
     }
 
-    public function test_view_all_chitchat_button_uses_user_site(): void
+    public function test_per_post_view_button_links_to_specific_post(): void
     {
         $mail = new NewsfeedModNotifMail(
             recipientEmail: 'mod@example.com',
@@ -71,8 +66,27 @@ class NewsfeedModNotifMailTest extends TestCase
 
         $userSite = config('freegle.sites.user');
 
-        // Both the per-post "View" buttons and the "View all chitchat" button
-        // must link to the user site — the only place where /chitchat exists.
+        // V1 parity: each "View" button must link to /chitchat/{id} so mods
+        // land on the specific post, not the general listing.
+        $this->assertStringContainsString(
+            $userSite . '/chitchat/42',
+            $html,
+            'Per-post "View" button must link to /chitchat/{id} matching V1 behaviour'
+        );
+    }
+
+    public function test_view_all_chitchat_button_links_to_general_listing(): void
+    {
+        $mail = new NewsfeedModNotifMail(
+            recipientEmail: 'mod@example.com',
+            posts: $this->makePosts(),
+        );
+
+        $html = $mail->render();
+
+        $userSite = config('freegle.sites.user');
+
+        // The "View all chitchat" footer button goes to the general listing.
         $this->assertStringContainsString(
             $userSite . '/chitchat',
             $html,

--- a/iznik-batch/tests/Unit/Mail/Newsfeed/NewsfeedModNotifMailTest.php
+++ b/iznik-batch/tests/Unit/Mail/Newsfeed/NewsfeedModNotifMailTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Tests\Unit\Mail\Newsfeed;
+
+use App\Mail\Newsfeed\NewsfeedModNotifMail;
+use Tests\TestCase;
+
+/**
+ * AssertFlip failing test for the broken chitchat link in NewsfeedModNotifMail.
+ *
+ * Bug (topic 9676): the "View" and "View all chitchat" buttons in the moderator
+ * chitchat notification email link to https://modtools.org/chitchat, but the
+ * Modtools application has no /chitchat route — clicking the link produces a 404.
+ *
+ * The legacy iznik-server code correctly linked to https://www.ilovefreegle.org/chitchat
+ * (the user site), where the /chitchat page exists. The batch migration accidentally
+ * changed the destination to the mod site, which has no such page.
+ *
+ * AssertFlip Step 2 — inverted assertions that FAIL on buggy code, PASS after the fix.
+ * The fix: change chitchatUrl to use config('freegle.sites.user') instead of
+ * config('freegle.sites.mod').
+ */
+class NewsfeedModNotifMailTest extends TestCase
+{
+    private function makePosts(): array
+    {
+        return [
+            [
+                'label'   => 'Post',
+                'preview' => 'Anyone know a good plumber nearby?',
+                'added'   => '2026-05-22 10:30:00',
+            ],
+        ];
+    }
+
+    public function test_chitchat_link_goes_to_user_site_not_modtools(): void
+    {
+        $mail = new NewsfeedModNotifMail(
+            recipientEmail: 'mod@example.com',
+            posts: $this->makePosts(),
+        );
+
+        $html = $mail->render();
+
+        $modSite  = config('freegle.sites.mod');   // https://modtools.org
+        $userSite = config('freegle.sites.user');  // https://www.ilovefreegle.org
+
+        // The Modtools app has no /chitchat route: clicking the link returns a 404.
+        // After the fix, the button must link to the user site where /chitchat exists.
+        $this->assertStringNotContainsString(
+            $modSite . '/chitchat',
+            $html,
+            'Chitchat link must not go to ' . $modSite . '/chitchat — that route does not exist in the Modtools app'
+        );
+
+        $this->assertStringContainsString(
+            $userSite . '/chitchat',
+            $html,
+            'Chitchat link must go to ' . $userSite . '/chitchat where the page actually exists'
+        );
+    }
+
+    public function test_view_all_chitchat_button_uses_user_site(): void
+    {
+        $mail = new NewsfeedModNotifMail(
+            recipientEmail: 'mod@example.com',
+            posts: $this->makePosts(),
+        );
+
+        $html = $mail->render();
+
+        $userSite = config('freegle.sites.user');
+
+        // Both the per-post "View" buttons and the "View all chitchat" button
+        // must link to the user site — the only place where /chitchat exists.
+        $this->assertStringContainsString(
+            $userSite . '/chitchat',
+            $html,
+            '"View all chitchat" button must link to ' . $userSite . '/chitchat'
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Fixes two issues with the mod chitchat notification email (topic 9676):

1. **Wrong site**: The \"View\" and \"View all chitchat\" buttons linked to \`modtools.org/chitchat\` (404) instead of \`ilovefreegle.org/chitchat\`
2. **Missing post ID (V1 parity)**: The original iznik-server code linked to \`/chitchat/{id}\` so mods land directly on the specific post. This fix restores that behaviour — each \"View\" button now links to the specific post, while \"View all chitchat\" links to the general listing.

### Changes
- \`NewsfeedModNotifService\`: adds post \`id\` to each entry in \`\$postsData\`
- \`NewsfeedModNotifMail::build()\`: passes \`\$userSite\` to template (instead of pre-built \`\$chitchatUrl\`) so template can construct per-post URLs
- \`mod-notif.blade.php\`: per-post \"View\" buttons use \`{{ \$userSite }}/chitchat/{{ \$post['id'] }}\`; \"View all chitchat\" button uses \`{{ \$userSite }}/chitchat\`

## Test plan
- [ ] All 3 unit tests pass: site-not-modtools, per-post link, view-all link
- [ ] CI passes