### PR TITLE
fix(location): use ST_Contains for group membership detection (#9518)

### DIFF
--- a/iznik-server/include/misc/Location.php
+++ b/iznik-server/include/misc/Location.php
@@ -403,6 +403,36 @@ class Location extends Entity
     public function groupsNear($radius = Location::NEARBY, $expand = FALSE, $limit = 10) {
         $limit = intval($limit);
 
+        # If this point lies inside one or more group polygons, those are the correct groups —
+        # polygon containment is authoritative and beats any centre-distance heuristic.
+        # This fixes bug #9518 where a group with a close centre but non-containing polygon
+        # was returned instead of the large group whose polygon actually contains the point.
+        $point = "ST_GeomFromText('POINT({$this->loc['lng']} {$this->loc['lat']})', {$this->dbhr->SRID()})";
+        $containingSql = "SELECT id, nameshort, 0 AS dist,
+            haversine(lat, lng, {$this->loc['lat']}, {$this->loc['lng']}) AS hav,
+            CASE WHEN altlat IS NOT NULL THEN haversine(altlat, altlng, {$this->loc['lat']}, {$this->loc['lng']}) ELSE NULL END AS hav2
+            FROM `groups`
+            WHERE ST_Contains(polyindex, $point) AND publish = 1 AND listable = 1
+            ORDER BY hav ASC, external ASC LIMIT $limit;";
+        $containingGroups = $this->dbhr->preQuery($containingSql);
+
+        if (!empty($containingGroups)) {
+            $ret = [];
+            foreach ($containingGroups as $group) {
+                if ($expand) {
+                    $g = Group::get($this->dbhr, $this->dbhm, $group['id']);
+                    $thisone = $g->getPublic();
+                    $thisone['distance'] = $group['hav'];
+                    $thisone['polydist'] = $group['dist'];
+                    $ret[] = $thisone;
+                } else {
+                    $ret[] = $group['id'];
+                }
+            }
+            return($ret);
+        }
+
+        # No group polygon contains this point; fall back to the radius-stepping search.
         # To make this efficient we want to use the spatial index on polyindex.  But our groups are not evenly
         # distributed, so if we search immediately upto $radius, which is the maximum we need to cover, then we
         # will often have to scan many more groups than we need in order to determine the closest groups

--- a/iznik-server/run-phpunit.sh
+++ b/iznik-server/run-phpunit.sh
@@ -213,6 +213,13 @@ if [[ "$TEST_PATH" == /var/www/iznik/* ]]; then
     echo "Adjusted test path to: $TEST_PATH"
 fi
 
+# --filter requires functional mode (-f) in paratest
+FUNCTIONAL_FLAG=""
+if echo "$TEST_PATH" | grep -q -- "--filter"; then
+    FUNCTIONAL_FLAG="-f"
+    echo "Using functional mode to support --filter"
+fi
+
 cd /var/www/iznik
 export XDEBUG_MODE=coverage
 
@@ -225,6 +232,7 @@ timeout --signal=SIGTERM --kill-after=60s 3000 \
     php -d memory_limit=-1 -d max_execution_time=0 \
     /var/www/iznik/composer/vendor/bin/paratest \
     -p 4 \
+    $FUNCTIONAL_FLAG \
     --verbose \
     --configuration /var/www/iznik/test/ut/php/phpunit.xml \
     --coverage-clover /tmp/phpunit-coverage.xml \

--- a/iznik-server/test/ut/php/include/GroupMembershipDetectionTest.php
+++ b/iznik-server/test/ut/php/include/GroupMembershipDetectionTest.php
@@ -79,7 +79,12 @@ class GroupMembershipDetectionTest extends IznikTestCase {
         $groups = $l->groupsNear(50, FALSE, 1);
 
         // STEP 2 (AssertFlip — must FAIL on buggy code):
-        // Correct behaviour: Group B must NOT appear — the point is not inside its polygon.
+        // Correct behaviour: Group A must appear (point is inside its polygon)
+        // and Group B must NOT appear (point is outside its polygon).
+        $this->assertTrue(
+            in_array($gidA, $groups),
+            'Bug #9518: Group A (containing polygon) must be returned for a point inside it'
+        );
         $this->assertFalse(
             in_array($gidB, $groups),
             'Bug #9518: Group B (close centre, non-containing polygon) must NOT be returned for a point inside Group A'

--- a/iznik-server/test/ut/php/include/GroupMembershipDetectionTest.php
+++ b/iznik-server/test/ut/php/include/GroupMembershipDetectionTest.php
@@ -1,0 +1,88 @@
+<?php
+namespace Freegle\Iznik;
+
+if (!defined('UT_DIR')) {
+    define('UT_DIR', dirname(__FILE__) . '/../..');
+}
+
+require_once(UT_DIR . '/../../include/config.php');
+require_once(UT_DIR . '/../../include/db.php');
+
+/**
+ * @backupGlobals disabled
+ * @backupStaticAttributes disabled
+ */
+class GroupMembershipDetectionTest extends IznikTestCase {
+    private $dbhr, $dbhm;
+
+    protected function setUp() : void {
+        parent::setUp();
+        global $dbhr, $dbhm;
+        $this->dbhr = $dbhr;
+        $this->dbhm = $dbhm;
+    }
+
+    /**
+     * Bug #9518: groupsNear() uses haversine from group centres rather than ST_Contains polygon
+     * containment. A point inside a large group polygon (Group A) but near a small group's
+     * centre (Group B, whose polygon does NOT contain the point) returns Group B instead of A.
+     *
+     * AssertFlip protocol:
+     *   STEP 1 — assertion matches BUGGY behaviour (assertTrue): test PASSES on current code.
+     *   STEP 2 — assertion inverted (assertFalse): test FAILS on current code, PASSES after fix.
+     *
+     * Geometry (Tuvalu-area, no production groups):
+     *   Test point: lng=179.265, lat=8.45
+     *   Group A (large): poly lng 179.0..179.27, lat 8.35..8.55  — centre lng=179.177 (~6 mi away)
+     *   Group B (small): poly lng 179.27..179.30, lat 8.43..8.47 — centre lng=179.285 (~1.4 mi away)
+     *   ST_Contains(A.poly, point) = 1, ST_Contains(B.poly, point) = 0
+     *   At the initial 4-mile search radius, only Group B's centre qualifies; loop exits with B only.
+     */
+    public function testGroupsNearReturnsContainingGroupNotNearestCentre() {
+        $testLat = 8.45;
+        $testLng = 179.265;
+
+        // Group A: large polygon whose centre is ~6 miles from the test point
+        $nameA = 'testGrpALarge_' . rand(100000, 999999);
+        list($gA, $gidA) = $this->createTestGroup($nameA, Group::GROUP_REUSE);
+        $gA->setPrivate('lat', 8.45);
+        $gA->setPrivate('lng', 179.177);
+        $gA->setPrivate('poly', 'POLYGON((179.0 8.35, 179.0 8.55, 179.27 8.55, 179.27 8.35, 179.0 8.35))');
+
+        // Group B: small polygon whose centre is ~1.4 miles from the test point
+        $nameB = 'testGrpBSmall_' . rand(100000, 999999);
+        list($gB, $gidB) = $this->createTestGroup($nameB, Group::GROUP_REUSE);
+        $gB->setPrivate('lat', 8.45);
+        $gB->setPrivate('lng', 179.285);
+        $gB->setPrivate('poly', 'POLYGON((179.27 8.43, 179.27 8.47, 179.30 8.47, 179.30 8.43, 179.27 8.43))');
+
+        // Verify preconditions: point is inside A, outside B
+        $srid = $this->dbhr->SRID();
+        $inA = $this->dbhr->preQuery(
+            "SELECT ST_Contains(polyindex, ST_GeomFromText('POINT($testLng $testLat)', $srid)) AS c FROM `groups` WHERE id = ?",
+            [$gidA]
+        );
+        $inB = $this->dbhr->preQuery(
+            "SELECT ST_Contains(polyindex, ST_GeomFromText('POINT($testLng $testLat)', $srid)) AS c FROM `groups` WHERE id = ?",
+            [$gidB]
+        );
+        $this->assertEquals(1, $inA[0]['c'], 'Precondition: test point must be inside Group A polygon');
+        $this->assertEquals(0, $inB[0]['c'], 'Precondition: test point must NOT be inside Group B polygon');
+
+        // Create location at the test point
+        $locName = 'TuvNearBoundary_' . rand(100000, 999999);
+        list($l, $lid) = $this->createTestLocation(NULL, $locName, 'Road', "POINT($testLng $testLat)");
+
+        // With limit=1, groupsNear iterates from ~4-mile radius upward.
+        // At 4 miles: Group B centre (1.4 mi) qualifies; Group A centre (6 mi) does not.
+        // Loop exits after first iteration returning [gidB]. Group A is never considered.
+        $groups = $l->groupsNear(50, FALSE, 1);
+
+        // STEP 2 (AssertFlip — must FAIL on buggy code):
+        // Correct behaviour: Group B must NOT appear — the point is not inside its polygon.
+        $this->assertFalse(
+            in_array($gidB, $groups),
+            'Bug #9518: Group B (close centre, non-containing polygon) must NOT be returned for a point inside Group A'
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- **Bug**: `groupsNear()` used `haversine(group_centre) < radius` to filter candidates. A group with a close centre but non-containing polygon was returned instead of the large group whose polygon actually contains the point. Real-world case: a Chiltern postcode was flagged as possibly belonging to High Wycombe.
- **Fix**: Run an `ST_Contains(polyindex, POINT)` query first. If the point falls inside any group polygon, return those groups directly — polygon containment is authoritative and skips the radius-stepping fallback entirely.
- **Infrastructure fix**: Added `-f` (functional mode) flag to paratest when `--filter` is passed, since paratest v6 requires functional mode to support per-test filtering.

## Test plan

- [ ] `GroupMembershipDetectionTest::testGroupsNearReturnsContainingGroupNotNearestCentre` passes (verified locally: `OK (1 test, 14 assertions)`)
- [ ] Full PHP test suite via CircleCI

🤖 Generated with [Claude Code](https://claude.com/claude-code)