### PR TITLE
fix(test): wait for /browse→/explore redirect via waitForURL before clicking logout

### DIFF
--- a/iznik-nuxt3/tests/e2e/utils/user.js
+++ b/iznik-nuxt3/tests/e2e/utils/user.js
@@ -130,6 +130,34 @@ async function logoutIfLoggedIn(page, navigateToHome = true) {
         .catch(() => {})
     }
 
+    // /browse auto-redirects new users (no group membership) to /explore via JS
+    // AFTER DOMContentLoaded fires. waitForLoadState above resolves immediately
+    // because /browse's DOMContentLoaded has already fired by the time
+    // logoutIfLoggedIn is called, leaving the JS-initiated /browse→/explore
+    // redirect still in flight. Clicking logout while that navigation is
+    // committing causes two simultaneous hard navigations that freeze the V8
+    // renderer for 35+ seconds before freeze-detection closes the page.
+    if (!page.isClosed()) {
+      const currentPath = (() => {
+        try {
+          return new URL(page.url()).pathname
+        } catch {
+          return ''
+        }
+      })()
+      if (currentPath === '/browse') {
+        console.log(
+          '[logoutIfLoggedIn] At /browse — waiting for /browse→/explore redirect to complete'
+        )
+        await page
+          .waitForURL(/\/(explore|myposts)/, { timeout: 3000 })
+          .catch(() => {})
+        await page
+          .waitForLoadState('domcontentloaded', { timeout: 3000 })
+          .catch(() => {})
+      }
+    }
+
     // Clear any lingering modal backdrop from a prior modal (e.g. the login
     // modal that closes via route redirect after signUpViaHomepage). The
     // backdrop node in <div id="teleports"> otherwise intercepts pointer

--- a/iznik-nuxt3/tests/unit/e2e-utils/logoutIfLoggedIn.spec.js
+++ b/iznik-nuxt3/tests/unit/e2e-utils/logoutIfLoggedIn.spec.js
@@ -29,6 +29,7 @@ function makeLocator(visible = false) {
 function makePage(url = 'http://example.com/', overrides = {}) {
   const gotoMock = vi.fn().mockResolvedValue(undefined)
   const waitForLoadStateMock = vi.fn().mockResolvedValue(undefined)
+  const waitForURLMock = vi.fn().mockResolvedValue(undefined)
   return {
     _url: url,
     isClosed: () => false,
@@ -37,6 +38,7 @@ function makePage(url = 'http://example.com/', overrides = {}) {
     },
     goto: gotoMock,
     waitForLoadState: waitForLoadStateMock,
+    waitForURL: waitForURLMock,
     evaluate: vi.fn().mockResolvedValue(undefined),
     context: () => ({ clearCookies: vi.fn().mockResolvedValue(undefined) }),
     locator: vi.fn().mockImplementation((selector) => {
@@ -108,6 +110,22 @@ describe('logoutIfLoggedIn (e2e util)', () => {
     expect(page.waitForLoadState).toHaveBeenCalledWith(
       'domcontentloaded',
       expect.objectContaining({ timeout: 5000 })
+    )
+  })
+
+  it('waits for /browse→/explore redirect via waitForURL when at /browse', async () => {
+    // The production CI failure: /browse auto-redirects new users to /explore via
+    // JS AFTER DOMContentLoaded fires. waitForLoadState('domcontentloaded') resolves
+    // immediately because /browse's DOMContentLoaded has already fired, leaving the
+    // JS-initiated redirect in flight. Clicking logout while /browse→/explore is
+    // committing causes two simultaneous hard navigations that freeze the V8 renderer
+    // for 35+ seconds (observed in production CI job 16194 at sha 83d85abb9).
+    // Fix: explicitly call waitForURL(/explore|myposts/) when the entry URL is /browse.
+    const page = makePage('http://freegle-prod-local.localhost:9080/browse')
+    await logoutIfLoggedIn(page)
+    expect(page.waitForURL).toHaveBeenCalledWith(
+      expect.any(RegExp),
+      expect.objectContaining({ timeout: 3000 })
     )
   })
 })


### PR DESCRIPTION
## Summary

- **Root cause of production CI job 16194** (test 3.2 "can login and reply from Browse Page"): `/browse` auto-redirects new users (no group membership) to `/explore` via JS **after** DOMContentLoaded fires.
- The existing fix (`2028666e2`) added `waitForLoadState('domcontentloaded')` at the start of `logoutIfLoggedIn`, but that call resolves **immediately** when `/browse`'s DOMContentLoaded has already fired — leaving the JS-initiated `/browse→/explore` redirect still in flight.
- Clicking logout while that redirect is committing causes two simultaneous hard navigations that freeze the V8 renderer for 35+ seconds (heartbeat timeout → page closed → test fails).
- **Fix**: when the entry URL is `/browse`, explicitly call `waitForURL(/\/(explore|myposts)/)` to drain the redirect chain before searching for and clicking the logout button.
- Adds a Vitest unit test verifying the `waitForURL` call is made when entry is `/browse`.

## Test plan

- [x] All 7 Vitest unit tests in `logoutIfLoggedIn.spec.js` pass locally
- [x] New test "waits for /browse→/explore redirect via waitForURL when at /browse" passes
- [ ] CI build passes (Playwright test 3.2 should no longer freeze)

🤖 Generated with [Claude Code](https://claude.com/claude-code)