### PR TITLE
fix(notification): fix broken avatar and header alignment in chaseup email

### DIFF
--- a/iznik-batch/app/Services/NotificationChaseUpService.php
+++ b/iznik-batch/app/Services/NotificationChaseUpService.php
@@ -276,8 +276,10 @@ class NotificationChaseUpService
             $result[] = [
                 'id'        => $notif->id,
                 'type'      => $notif->type,
-                'fromname'  => $fromUser ? $fromUser->fullname : 'Someone',
-                'fromimage' => $this->resolveAvatarUrl($fromUser),
+                'fromname'  => $fromUser ? $fromUser->fullname : 'Freegle',
+                'fromimage' => $fromUser
+                    ? $this->resolveAvatarUrl($fromUser)
+                    : config('freegle.logo_url', 'https://www.ilovefreegle.org/icon.png'),
                 'title'    => $notif->title,
                 'text'     => $notif->text,
                 'url'      => $notif->url,

--- a/iznik-batch/resources/views/emails/mjml/notification/chaseup.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/notification/chaseup.blade.php
@@ -5,9 +5,9 @@
   <mj-body background-color="#ffffff">
 
     {{-- Header --}}
-    <mj-section mj-class="bg-success" padding="0">
+    <mj-section mj-class="bg-success" padding="20px 0">
       <mj-column width="65%" vertical-align="middle">
-        <mj-text font-size="18px" font-weight="bold" color="#ffffff" padding="10px 25px">
+        <mj-text font-size="18px" font-weight="bold" color="#ffffff" padding="0 0 0 25px">
           You have {{ $count }} notification{{ $count === 1 ? '' : 's' }}
         </mj-text>
       </mj-column>
@@ -17,7 +17,7 @@
           src="{{ config('freegle.logo_url', 'https://www.ilovefreegle.org/icon.png') }}"
           alt="Freegle"
           align="right"
-          padding="10px 20px"
+          padding="0 20px"
         />
       </mj-column>
     </mj-section>


### PR DESCRIPTION
## Summary

- **Broken avatar for system notifications**: `Exhort`, `MembershipPending` and similar notification types have no `fromuser`. `resolveAvatarUrl(null)` was generating a relative `/user.png` URL that breaks in email clients, showing a broken image icon. The sender was labelled "Someone". Fixed by falling back to the Freegle logo URL and the name "Freegle" when there is no from-user.

- **Header text vertical alignment**: The text "You have N notifications" was top-aligned in the green header banner despite `vertical-align="middle"` on the MJML column. The root cause was `padding="0"` on the section with `padding="10px 25px"` on the text — the top padding from the text content was fighting the table-cell centering. Fixed by moving vertical spacing to the section level (`padding="20px 0"`) and removing top/bottom padding from both the text and the logo so MJML's `vertical-align: middle` can centre them correctly.

## Test plan

- [ ] Send a test notification chaseup that includes an `Exhort` type notification — avatar should show Freegle logo, name should show "Freegle"
- [ ] Check header renders with text vertically centred beside the logo on mobile and desktop
- [ ] Existing user-sourced notifications (CommentOnYourPost, LovedPost etc.) still show correct user avatar