### PR TITLE
fix(ci): skip build-and-test on production branch to prevent Katapult resource contention

### DIFF
--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -83,6 +83,7 @@ workflows:
             branches:
               ignore:
                 - modtools
+                - production
       - mark-ci-passed:
           requires:
             - freegle/build-and-test
@@ -90,6 +91,7 @@ workflows:
             branches:
               ignore:
                 - modtools
+                - production
       - freegle/build-android-dev:
           requires:
             - freegle/build-and-test
@@ -144,6 +146,7 @@ workflows:
             branches:
               ignore:
                 - modtools
+                - production
       - mark-ci-passed:
           requires:
             - freegle/build-and-test
@@ -151,6 +154,7 @@ workflows:
             branches:
               ignore:
                 - modtools
+                - production
       - freegle/build-android-dev:
           requires:
             - freegle/build-and-test


### PR DESCRIPTION
## Summary

- `build-and-test` and `deploy-apps` (iOS/Android Katapult builds) run concurrently on every production push, causing Katapult runner resource contention → `infrastructure_fail`
- Root cause confirmed: both builds #16359 and #16366 on SHA `3da4bf9bc9c0` failed with `infrastructure_fail` during the exact window when iOS/Android builds were running on the same Katapult infrastructure
- `build-and-test` on production is **redundant**: master CI must pass before auto-merge to production happens, so the code has already been tested

## Fix

Add `production` to the `branches: ignore` filter for `freegle/build-and-test` and `mark-ci-passed` in both `build-test-local` and `build-test-cloud` workflows. This eliminates the concurrent resource contention without any loss of test coverage.

## Files changed

- `.circleci/continue-config.yml` — 4 additions: `- production` to ignore lists for `build-and-test` and `mark-ci-passed` in `build-test-local` and `build-test-cloud` workflows

## Test plan

- [ ] Next production push should only trigger `deploy-apps` workflow (no `build-and-test`), eliminating the resource contention
- [ ] Master branch should still run `build-and-test` normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)