### PR TITLE
fix(vue-mention): null guard prevents querySelector crash on fast navigation

### DIFF
--- a/iznik-nuxt3/patches/vue-mention+2.0.0-alpha.3.patch
+++ b/iznik-nuxt3/patches/vue-mention+2.0.0-alpha.3.patch
@@ -1,0 +1,20 @@
+diff --git a/node_modules/vue-mention/dist/vue-mention.es.js b/node_modules/vue-mention/dist/vue-mention.es.js
+index 08383cd..5cd6ef1 100644
+--- a/node_modules/vue-mention/dist/vue-mention.es.js
++++ b/node_modules/vue-mention/dist/vue-mention.es.js
+@@ -213,6 +213,7 @@ const _sfc_main = defineComponent({
+     let input;
+     const el = ref(null);
+     function getInput() {
++      if (!el.value) return null;
+       var _a, _b;
+       return (_b = (_a = el.value.querySelector("input")) != null ? _a : el.value.querySelector("textarea")) != null ? _b : el.value.querySelector('[contenteditable="true"]');
+     }
+@@ -221,6 +222,7 @@ const _sfc_main = defineComponent({
+       attach();
+     });
+     onUpdated(() => {
++      if (!el.value) return;
+       const newInput = getInput();
+       if (newInput !== input) {
+         detach();

--- a/iznik-nuxt3/tests/unit/components/OurAtTa.spec.js
+++ b/iznik-nuxt3/tests/unit/components/OurAtTa.spec.js
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
 import { mount } from '@vue/test-utils'
 import OurAtTa from '~/components/OurAtTa.vue'
 
@@ -73,6 +74,28 @@ describe('OurAtTa', () => {
     it('members prop is Array type', () => {
       const props = OurAtTa.props
       expect(props.members.type).toBe(Array)
+    })
+  })
+
+  describe('vue-mention null-ref patch', () => {
+    // Regression test for: TypeError: Cannot read properties of null (reading 'querySelector')
+    // vue-mention's Mentionable calls el.value.querySelector() in onMounted/onUpdated.
+    // When the component is destroyed mid-navigation, el.value can be null. patch-package
+    // adds guards; this test verifies those guards are present in the installed dist file.
+    it('vue-mention.es.js has null guard in getInput()', () => {
+      const src = readFileSync(
+        'node_modules/vue-mention/dist/vue-mention.es.js',
+        'utf8'
+      )
+      expect(src).toContain('if (!el.value) return null;')
+    })
+
+    it('vue-mention.es.js has null guard in onUpdated()', () => {
+      const src = readFileSync(
+        'node_modules/vue-mention/dist/vue-mention.es.js',
+        'utf8'
+      )
+      expect(src).toContain('if (!el.value) return;')
     })
   })
 })


### PR DESCRIPTION
## Summary

- vue-mention's `Mentionable` component crashes with `TypeError: Cannot read properties of null (reading 'querySelector')` when navigating away from chat/newsfeed mid-mount
- Root cause: `onMounted`/`onUpdated` call `el.value.querySelector()` but `el.value` can be null if the component is destroyed before those hooks fire (race on fast navigation)
- Fix: patch-package patch adds null guards to `vue-mention@2.0.0-alpha.3` dist
- Regression checks verify the guards are present in the installed package

## Code Quality Review

- Patch is minimal (2 lines) and directly addresses the root cause
- No behaviour change for the normal case where `el.value` is set

## Validation

- [ ] CI vitest suite passes (OurAtTa.spec.js verifies patch is applied)
- [ ] patch-package applies cleanly on `npm install`
- [ ] No querySelector errors on live chat/newsfeed during fast navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
