### PR TITLE
fix(ci): add missing branch filters to build-test-katapult workflow

### DIFF
--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -260,7 +260,9 @@ workflows:
               only:
                 - production
 
-  # Katapult cloud runner test — triggered manually with use_katapult: true
+  # Katapult cloud runner test — the default CI path (use_katapult=true is set by check-runner
+  # for all normal pushes). Branch filters here must match build-test-local/build-test-cloud
+  # so production and modtools are skipped (they use deploy-apps and have no tests to run).
   build-test-katapult:
     when: << pipeline.parameters.use_katapult >>
     jobs:
@@ -283,9 +285,19 @@ workflows:
                     -d '{"labels":["CI: Failed"]}' \
                     "https://api.github.com/repos/$REPO/issues/$PR_NUMBER/labels" 2>/dev/null || true
                   echo "Labelled PR #$PR_NUMBER as CI: Failed"
+          filters:
+            branches:
+              ignore:
+                - modtools
+                - production
       - mark-ci-passed:
           requires:
             - freegle/build-and-test
+          filters:
+            branches:
+              ignore:
+                - modtools
+                - production
       - freegle/build-android-modtools-debug:
           requires:
             - freegle/build-and-test


### PR DESCRIPTION
## Summary

- `build-test-katapult` is now the **default CI path** — `check-runner` sets `use_katapult=true` for all normal pushes, so this workflow runs on every branch push
- But `build-test-katapult` was missing the `ignore: production` and `ignore: modtools` branch filters that `build-test-local` and `build-test-cloud` already have
- This caused `freegle/build-and-test` to run on the production branch via a Katapult VM, generating `infrastructure_fail` (heartbeat timeout during the parallel test execution step)
- PR #525 fixed `build-test-local` and `build-test-cloud` but missed `build-test-katapult`

## Root cause

`build-test-katapult` comment said "triggered manually" but it has become the default path since `check-runner` now always routes to Katapult. Without branch filters, it runs on `production` and `modtools` which are deployment-only branches with no need to run the test suite.

## Fix

Added `filters.branches.ignore: [modtools, production]` to `freegle/build-and-test` and `mark-ci-passed` jobs in `build-test-katapult`, matching the pattern already established in `build-test-local` and `build-test-cloud`.

## Files changed
- `.circleci/continue-config.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)