### PR TITLE
feat(monitor): escalate email-health failures to Sentry + 24/7 outgoing-stall check + reclaim orphaned spool files

### DIFF
--- a/iznik-batch/app/Console/Commands/Mail/ProcessSpoolCommand.php
+++ b/iznik-batch/app/Console/Commands/Mail/ProcessSpoolCommand.php
@@ -75,6 +75,20 @@ class ProcessSpoolCommand extends Command
         $this->registerShutdownHandlers();
         $this->info('Running in daemon mode. Press Ctrl+C to stop.');
 
+        // Reclaim any files orphaned in sending/ by a previous process that
+        // died mid-send (supervisor restart / OOM / container restart). The
+        // spooler is single-process (numprocs=1) so nothing is in flight at
+        // startup — this is race-free and lossless. Only done on the daemon
+        // path, never the one-shot path (which could race a running daemon).
+        $reclaimed = $spooler->reclaimOrphanedSending();
+        if ($reclaimed > 0) {
+            $this->line(sprintf(
+                '[%s] Reclaimed %d orphaned spool file(s) from sending/ on startup',
+                now()->toTimeString(),
+                $reclaimed
+            ));
+        }
+
         while (! $this->shouldStop()) {
             $stats = $spooler->processSpool($limit);
 

--- a/iznik-batch/app/Console/Commands/Monitor/EmailHealthCommand.php
+++ b/iznik-batch/app/Console/Commands/Monitor/EmailHealthCommand.php
@@ -10,12 +10,24 @@ use Illuminate\Support\Facades\Log;
 /**
  * Monitors incoming and outgoing email health.
  *
- * Returns FAILURE if:
- * - Zero incoming emails (platform=0 chat messages) in the last N hours during daytime (07:00-22:00)
- * - Fewer than N outgoing emails (email_tracking sent) in the last hour during daytime (07:00-22:00)
+ * Runs 24/7. There are two tiers of check:
  *
- * Thresholds are configurable via .env. Failures show as red badges in the
- * cron jobs sysadmin tab.
+ * - A hard outgoing-STALL check runs at ALL hours: Freegle sends chat
+ *   notifications continuously, so ZERO outgoing across the stall window is a
+ *   near-certain smarthost/spooler stall at any hour. This is what catches a
+ *   night-time smarthost outage that would otherwise go unnoticed until morning.
+ * - The incoming check and the outgoing VOLUME floor stay gated to daytime
+ *   (07:00-22:00) to avoid false alarms from merely-low night-time volume.
+ *
+ * Returns FAILURE if:
+ * - Zero outgoing emails (email_tracking sent) in the stall window (any hour)
+ * - Zero incoming emails (platform=0 chat messages) in the last N hours during daytime
+ * - Fewer than N outgoing emails (email_tracking sent) in the last hour during daytime
+ *
+ * On failure, escalates to Sentry (the team actively watches Sentry) so a
+ * smarthost-down outage is noticed promptly rather than only being buried in
+ * a Log::warning. Thresholds are configurable via .env. Failures also show as
+ * red badges in the cron jobs sysadmin tab.
  */
 class EmailHealthCommand extends Command
 {
@@ -31,47 +43,77 @@ class EmailHealthCommand extends Command
         $dayStart = (int) config('freegle.email_health.daytime_start', 7);
         $dayEnd = (int) config('freegle.email_health.daytime_end', 22);
 
-        // Only check during daytime hours
-        if ($hour < $dayStart || $hour >= $dayEnd) {
-            $this->info("Outside monitoring window ({$dayStart}:00-{$dayEnd}:00). Skipping.");
-
-            return Command::SUCCESS;
-        }
+        // Whether we're inside the daytime window. We DON'T early-return at
+        // night: the hard outgoing-stall check below runs 24/7 so a night-time
+        // smarthost/spooler stall escalates to Sentry immediately.
+        $isDaytime = $hour >= $dayStart && $hour < $dayEnd;
 
         $failures = [];
 
-        // --- Incoming email check ---
-        $incomingWindowHours = (int) config('freegle.email_health.incoming_window_hours', 2);
+        // --- Outgoing STALL check (runs 24/7) ---
+        // Freegle sends chat notifications continuously, so zero outgoing
+        // across the stall window is a near-certain smarthost/spooler stall at
+        // any hour. This is the only check that runs at night, so it never
+        // false-alarms on merely-low night-time volume — it requires ZERO.
+        $stallWindowHours = (int) config('freegle.email_health.outgoing_stall_window_hours', 1);
 
-        $incomingCount = DB::table('chat_messages')
-            ->where('platform', 0)
-            ->where('date', '>=', $now->copy()->subHours($incomingWindowHours))
+        $stallCount = DB::table('email_tracking')
+            ->where('sent_at', '>=', $now->copy()->subHours($stallWindowHours))
             ->count();
 
-        if ($incomingCount === 0) {
-            $failures[] = "INCOMING: 0 emails received in the last {$incomingWindowHours} hours";
+        if ($stallCount === 0) {
+            $failures[] = "OUTGOING STALL: 0 emails sent in the last {$stallWindowHours}h";
         }
 
-        $this->info("Incoming: {$incomingCount} emails in last {$incomingWindowHours}h");
+        $this->info("Outgoing stall window: {$stallCount} emails in last {$stallWindowHours}h");
 
-        // --- Outgoing email check ---
-        $outgoingMinPerHour = (int) config('freegle.email_health.outgoing_min_per_hour', 10);
+        if ($isDaytime) {
+            // --- Incoming email check (daytime only) ---
+            $incomingWindowHours = (int) config('freegle.email_health.incoming_window_hours', 2);
 
-        $outgoingCount = DB::table('email_tracking')
-            ->where('sent_at', '>=', $now->copy()->subHour())
-            ->count();
+            $incomingCount = DB::table('chat_messages')
+                ->where('platform', 0)
+                ->where('date', '>=', $now->copy()->subHours($incomingWindowHours))
+                ->count();
 
-        if ($outgoingCount < $outgoingMinPerHour) {
-            $failures[] = "OUTGOING: {$outgoingCount} emails sent in last hour (threshold: {$outgoingMinPerHour})";
+            if ($incomingCount === 0) {
+                $failures[] = "INCOMING: 0 emails received in the last {$incomingWindowHours} hours";
+            }
+
+            $this->info("Incoming: {$incomingCount} emails in last {$incomingWindowHours}h");
+
+            // --- Outgoing VOLUME floor (daytime only) ---
+            // Gated to daytime so merely-low night-time volume doesn't raise a
+            // false alarm; the 24/7 stall check above still catches a true stall.
+            $outgoingMinPerHour = (int) config('freegle.email_health.outgoing_min_per_hour', 10);
+
+            $outgoingCount = DB::table('email_tracking')
+                ->where('sent_at', '>=', $now->copy()->subHour())
+                ->count();
+
+            if ($outgoingCount < $outgoingMinPerHour) {
+                $failures[] = "OUTGOING: {$outgoingCount} emails sent in last hour (threshold: {$outgoingMinPerHour})";
+            }
+
+            $this->info("Outgoing: {$outgoingCount} emails in last 1h (min: {$outgoingMinPerHour})");
+        } else {
+            $this->info("Outside daytime window ({$dayStart}:00-{$dayEnd}:00); running stall check only.");
         }
-
-        $this->info("Outgoing: {$outgoingCount} emails in last 1h (min: {$outgoingMinPerHour})");
 
         // --- Result ---
         if (! empty($failures)) {
             foreach ($failures as $f) {
                 $this->error($f);
                 Log::warning("[EmailHealth] {$f}");
+            }
+
+            // Escalate to Sentry so the team (who actively watch Sentry) are
+            // alerted promptly — a night-time outage would otherwise only sit
+            // in a Log::warning. function_exists guard matches the codebase
+            // pattern in TNSyncCommand.php (Sentry's helpers aren't loaded in
+            // every environment, e.g. tests).
+            if (function_exists('\Sentry\captureMessage')) {
+                \Sentry\captureMessage('[EmailHealth] ' . implode('; ', $failures));
             }
 
             return Command::FAILURE;

--- a/iznik-batch/app/Services/EmailSpoolerService.php
+++ b/iznik-batch/app/Services/EmailSpoolerService.php
@@ -278,6 +278,36 @@ class EmailSpoolerService
     }
 
     /**
+     * Reclaim files orphaned in sending/ by a previous process that died
+     * mid-send (restart/OOM/crash). Safe to call only when no send is in
+     * flight — i.e. at daemon startup. The spooler runs single-process
+     * (numprocs=1), so at startup nothing is being sent. Files go back to
+     * pending/ for a normal retry; nothing is dead-lettered, so an extended
+     * smarthost outage never loses mail.
+     */
+    public function reclaimOrphanedSending(): int
+    {
+        $reclaimed = 0;
+
+        foreach (glob($this->sendingDir . '/*.json') as $sendingPath) {
+            $filename = basename($sendingPath);
+            if (rename($sendingPath, $this->pendingDir . '/' . $filename)) {
+                $reclaimed++;
+            } else {
+                Log::warning('Could not reclaim orphaned spool file', ['file' => $filename]);
+            }
+        }
+
+        if ($reclaimed > 0) {
+            Log::warning('Reclaimed orphaned spool files from sending/ on startup', [
+                'count' => $reclaimed,
+            ]);
+        }
+
+        return $reclaimed;
+    }
+
+    /**
      * Process pending emails from the spool.
      *
      * Retries indefinitely until the email is sent. Logs an alert if any

--- a/iznik-batch/config/freegle.php
+++ b/iznik-batch/config/freegle.php
@@ -314,6 +314,11 @@ return [
         'outgoing_min_per_hour' => env('FREEGLE_EMAIL_HEALTH_OUTGOING_MIN_PER_HOUR', 10),
         'daytime_start' => env('FREEGLE_EMAIL_HEALTH_DAYTIME_START', 7),
         'daytime_end' => env('FREEGLE_EMAIL_HEALTH_DAYTIME_END', 22),
+        // Hard outgoing-stall check window. Runs 24/7: zero outgoing emails
+        // across this window is a near-certain smarthost/spooler stall at any
+        // hour, so it catches night-time outages the daytime-only volume floor
+        // would miss.
+        'outgoing_stall_window_hours' => env('FREEGLE_EMAIL_HEALTH_OUTGOING_STALL_WINDOW_HOURS', 1),
     ],
 
     'dedup' => [

--- a/iznik-batch/tests/Feature/Monitor/EmailHealthCommandTest.php
+++ b/iznik-batch/tests/Feature/Monitor/EmailHealthCommandTest.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace Tests\Feature\Monitor;
+
+use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Tests\TestCase;
+
+/**
+ * Tests for monitor:email-health.
+ *
+ * The command runs 24/7. A hard outgoing-STALL check (zero emails in the stall
+ * window) runs at all hours so a night-time smarthost/spooler stall escalates
+ * immediately; the incoming check and the outgoing volume floor stay gated to
+ * daytime so merely-low night-time volume doesn't false-alarm.
+ *
+ * We do NOT assert on the actual \Sentry\captureMessage call (it's a global
+ * function that isn't loaded under test, and the command guards it with
+ * function_exists). Instead we assert on the Log::warning lines and the
+ * command exit code, which fully capture the failure behaviour.
+ */
+class EmailHealthCommandTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // DatabaseTransactions rolls these back. Clear so "0 in window"
+        // assertions are deterministic regardless of pre-existing test data.
+        DB::table('email_tracking')->delete();
+        DB::table('chat_messages')->delete();
+    }
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+        parent::tearDown();
+    }
+
+    /**
+     * Insert an email_tracking row sent $minutesAgo minutes before "now".
+     */
+    private function seedOutgoing(int $minutesAgo): void
+    {
+        DB::table('email_tracking')->insert([
+            'tracking_id' => bin2hex(random_bytes(8)),
+            'email_type' => 'ChatNotification',
+            'recipient_email' => 'recipient_' . uniqid('', true) . '@test.com',
+            'sent_at' => Carbon::now()->subMinutes($minutesAgo),
+            'created_at' => Carbon::now()->subMinutes($minutesAgo),
+            'updated_at' => Carbon::now()->subMinutes($minutesAgo),
+        ]);
+    }
+
+    /**
+     * Insert an incoming (platform=0) chat message $minutesAgo before "now".
+     */
+    private function seedIncoming(int $minutesAgo): void
+    {
+        DB::table('chat_messages')->insert([
+            'chatid' => 1,
+            'userid' => 1,
+            'type' => 'Default',
+            'message' => 'Test incoming',
+            'platform' => 0,
+            'date' => Carbon::now()->subMinutes($minutesAgo),
+        ]);
+    }
+
+    public function test_outgoing_stall_at_night_fails_and_logs_warning(): void
+    {
+        // 03:00 — outside the daytime window. No outgoing emails at all.
+        Carbon::setTestNow(Carbon::create(2026, 5, 24, 3, 0, 0));
+
+        Log::spy();
+
+        $this->artisan('monitor:email-health')
+            ->expectsOutputToContain('Outside daytime window')
+            ->assertExitCode(1);
+
+        Log::shouldHaveReceived('warning')
+            ->withArgs(fn ($message, $context = []) =>
+                str_contains((string) $message, 'OUTGOING STALL')
+            );
+    }
+
+    public function test_healthy_outgoing_at_night_succeeds(): void
+    {
+        // 03:00 — at night, only the stall check runs. One recent email means
+        // the stall window is non-empty, so the command should succeed even
+        // though night-time volume is far below the daytime floor.
+        Carbon::setTestNow(Carbon::create(2026, 5, 24, 3, 0, 0));
+
+        $this->seedOutgoing(5);
+
+        Log::spy();
+
+        $this->artisan('monitor:email-health')
+            ->expectsOutputToContain('Outside daytime window')
+            ->expectsOutputToContain('Email health OK.')
+            ->assertExitCode(0);
+
+        Log::shouldNotHaveReceived('warning');
+    }
+
+    public function test_daytime_low_volume_floor_still_fails(): void
+    {
+        // Noon — inside the daytime window. Threshold of 10/hour, but only a
+        // few emails were sent. The stall check passes (window is non-empty)
+        // and incoming is present, so the only failure is the volume floor.
+        Carbon::setTestNow(Carbon::create(2026, 5, 24, 12, 0, 0));
+
+        config(['freegle.email_health.outgoing_min_per_hour' => 10]);
+
+        // 3 outgoing in the last hour — above zero (stall passes) but below 10.
+        $this->seedOutgoing(5);
+        $this->seedOutgoing(10);
+        $this->seedOutgoing(15);
+
+        // Incoming present so the incoming check doesn't also fail.
+        $this->seedIncoming(30);
+
+        Log::spy();
+
+        $this->artisan('monitor:email-health')
+            ->assertExitCode(1);
+
+        // The volume-floor failure must be logged.
+        Log::shouldHaveReceived('warning')
+            ->withArgs(fn ($message, $context = []) =>
+                str_contains((string) $message, 'OUTGOING:')
+                && str_contains((string) $message, 'threshold: 10')
+            );
+    }
+
+    public function test_daytime_all_healthy_succeeds(): void
+    {
+        // Noon, low threshold, plenty of outgoing and incoming → success.
+        Carbon::setTestNow(Carbon::create(2026, 5, 24, 12, 0, 0));
+
+        config(['freegle.email_health.outgoing_min_per_hour' => 2]);
+
+        $this->seedOutgoing(5);
+        $this->seedOutgoing(10);
+        $this->seedOutgoing(15);
+        $this->seedIncoming(30);
+
+        Log::spy();
+
+        $this->artisan('monitor:email-health')
+            ->expectsOutputToContain('Email health OK.')
+            ->assertExitCode(0);
+
+        Log::shouldNotHaveReceived('warning');
+    }
+}

--- a/iznik-batch/tests/Feature/Monitor/EmailHealthCommandTest.php
+++ b/iznik-batch/tests/Feature/Monitor/EmailHealthCommandTest.php
@@ -22,6 +22,9 @@ use Tests\TestCase;
  */
 class EmailHealthCommandTest extends TestCase
 {
+    private int $incomingChatId;
+    private int $incomingUserId;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -30,6 +33,13 @@ class EmailHealthCommandTest extends TestCase
         // assertions are deterministic regardless of pre-existing test data.
         DB::table('email_tracking')->delete();
         DB::table('chat_messages')->delete();
+
+        // Create parent rows needed by seedIncoming().
+        $user1 = $this->createTestUser();
+        $user2 = $this->createTestUser();
+        $room = $this->createTestChatRoom($user1, $user2);
+        $this->incomingChatId = $room->id;
+        $this->incomingUserId = $user1->id;
     }
 
     protected function tearDown(): void
@@ -59,8 +69,8 @@ class EmailHealthCommandTest extends TestCase
     private function seedIncoming(int $minutesAgo): void
     {
         DB::table('chat_messages')->insert([
-            'chatid' => 1,
-            'userid' => 1,
+            'chatid' => $this->incomingChatId,
+            'userid' => $this->incomingUserId,
             'type' => 'Default',
             'message' => 'Test incoming',
             'platform' => 0,

--- a/iznik-batch/tests/Unit/Services/EmailSpoolerServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/EmailSpoolerServiceTest.php
@@ -859,4 +859,67 @@ class EmailSpoolerServiceTest extends TestCase
 
         $this->spooler->spool($mailable, $email);
     }
+
+    /**
+     * Test that a file orphaned in sending/ (left by a process that died
+     * mid-send) is reclaimed back to pending/ on startup.
+     *
+     * The spooler runs single-process (numprocs=1), so at daemon startup
+     * nothing is in flight — reclaiming is race-free and lossless.
+     */
+    public function test_reclaim_orphaned_sending_moves_file_back_to_pending(): void
+    {
+        // Simulate a process that died after moving the file to sending/.
+        $id = 'test_orphan_' . uniqid();
+        $data = [
+            'id' => $id,
+            'to' => [['address' => $this->uniqueEmail('recipient'), 'name' => '']],
+            'from' => [['address' => $this->uniqueEmail('noreply'), 'name' => 'Freegle']],
+            'subject' => 'Orphaned Subject',
+            'html' => '<p>Test</p>',
+            'attempts' => 0,
+            'created_at' => now()->toIso8601String(),
+        ];
+
+        file_put_contents(
+            $this->testSpoolDir . '/sending/' . $id . '.json',
+            json_encode($data)
+        );
+
+        $reclaimed = $this->spooler->reclaimOrphanedSending();
+
+        $this->assertEquals(1, $reclaimed);
+        $this->assertFileDoesNotExist($this->testSpoolDir . '/sending/' . $id . '.json');
+        $this->assertFileExists($this->testSpoolDir . '/pending/' . $id . '.json');
+    }
+
+    /**
+     * Test that reclaim is a no-op (returns 0) when sending/ is empty.
+     */
+    public function test_reclaim_orphaned_sending_noop_when_empty(): void
+    {
+        $reclaimed = $this->spooler->reclaimOrphanedSending();
+
+        $this->assertEquals(0, $reclaimed);
+    }
+
+    /**
+     * Test that reclaim handles multiple orphaned files in one pass.
+     */
+    public function test_reclaim_orphaned_sending_handles_multiple_files(): void
+    {
+        for ($i = 0; $i < 3; $i++) {
+            $id = 'test_orphan_' . $i . '_' . uniqid();
+            file_put_contents(
+                $this->testSpoolDir . '/sending/' . $id . '.json',
+                json_encode(['id' => $id])
+            );
+        }
+
+        $reclaimed = $this->spooler->reclaimOrphanedSending();
+
+        $this->assertEquals(3, $reclaimed);
+        $this->assertCount(0, glob($this->testSpoolDir . '/sending/*.json'));
+        $this->assertCount(3, glob($this->testSpoolDir . '/pending/*.json'));
+    }
 }


### PR DESCRIPTION
## Background

`freegledocker-batch-prod` sends all of Freegle's outgoing email by handing messages to a LOCAL smarthost over SMTP. If that smarthost goes down, outgoing mail stops.

## Problem 1: night-time outages go unnoticed

The previous `monitor:email-health` only ran 07:00–22:00 and only wrote a `Log::warning` on failure. So a smarthost/spooler stall overnight could go unnoticed for hours — nobody is reading logs at 3am, and the check wasn't even running.

### Fix

`monitor:email-health` now runs 24/7 with two tiers:

- **Hard outgoing-STALL check (all hours):** counts `email_tracking` rows with `sent_at` in the last `outgoing_stall_window_hours` (default 1h); fails if the count is **0**. Freegle sends chat notifications continuously, so zero outgoing across the window is a near-certain smarthost/spooler stall at any hour. This is the check that catches the night-time outage.
- **Incoming check + outgoing VOLUME floor (daytime only):** unchanged behaviour, still gated to daytime so merely-low night-time volume doesn't false-alarm.

On any failure the command now **escalates to Sentry** via `\Sentry\captureMessage` (guarded by `function_exists`, matching the `TNSyncCommand` pattern), in addition to the existing per-failure `Log::warning`. The team actively watch Sentry, so this surfaces a smarthost-down outage promptly rather than burying it in a log line.

New config key: `freegle.email_health.outgoing_stall_window_hours` (`FREEGLE_EMAIL_HEALTH_OUTGOING_STALL_WINDOW_HOURS`, default 1).

## Problem 2: mail stranded in `sending/` after a crash

Root cause of stranded mail: in `EmailSpoolerService::processSpool()` a file is `rename()`d from `pending/` to `sending/` **before** the SMTP send. If the process dies in that window (supervisor restart / OOM / container restart) the file is stranded in `sending/` forever with `attempts:0` — nothing ever rescans `sending/`, so the mail is lost. (Two such orphans were found and manually moved in prod.)

### Fix

The spooler runs single-process (`numprocs=1`), so at daemon startup **nothing is in flight** — reclaiming `sending/` back to `pending/` at startup is race-free and lossless. New `EmailSpoolerService::reclaimOrphanedSending()` moves orphaned files back to `pending/` for a normal retry (nothing is dead-lettered, so even an extended smarthost outage never loses mail). It is called **exactly once** at the start of the `--daemon` path in `ProcessSpoolCommand`, and never on the one-shot path (which could race a running daemon).

## Tests

Added (but **not run locally** — CI runs them):

- `tests/Feature/Monitor/EmailHealthCommandTest.php`: outgoing stall at night → FAIL + `OUTGOING STALL` warning; healthy outgoing at night → SUCCESS; daytime low-volume floor → FAIL; daytime all-healthy → SUCCESS. Clock controlled with `Carbon::setTestNow`; rows seeded via the DB facade; assertions use `Log::spy` / `shouldHaveReceived` / `shouldNotHaveReceived`. The actual `\Sentry\captureMessage` is intentionally not asserted (global function, not loaded under test); the `Log::warning` lines and exit code are asserted instead.
- `tests/Unit/Services/EmailSpoolerServiceTest.php`: a file placed in `sending/` is reclaimed to `pending/` and returns count 1; no-op when empty; handles multiple files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
