### PR TITLE
test(NameSanitiser): expand unit coverage from ~70% to 96.5%

### DIFF
--- a/iznik-batch/tests/Unit/Support/NameSanitiserTest.php
+++ b/iznik-batch/tests/Unit/Support/NameSanitiserTest.php
@@ -32,6 +32,30 @@ class NameSanitiserTest extends TestCase
             'prize winner' => ['Prize Winner'],
             'surname freegle' => ['Susan Freegle'],
             'freegler support (weak brand + authority)' => ['Freegler Support'],
+            // Tier A concat match — brand name with no spaces or token boundary
+            'ilovefreegle concat no spaces' => ['ilovefreegle'],
+            // Leet speak normalised to an exact-only brand word
+            'leet freegle full word' => ['Fr33gl3'],
+            // Diacritics decomposed away to reveal brand word
+            'accented e yields freegle' => ["Fr\u{00EB}egle"],
+            // Freshare is TIER_A_EXACT_ONLY: exact token match triggers
+            'freshare exact' => ['Freshare'],
+            'freshare with authority' => ['Freshare Support'],
+            // thefreegle is TIER_A (not exact-only): fuzzy match at distance 0
+            'thefreegle exact' => ['TheFreegle'],
+            // One Damerau-Levenshtein edit off a non-exact-only brand word
+            'one edit thefreegle' => ['TheFregle'],
+            // All-Tier-B authority words (Rule 4)
+            'all tier b helpdesk' => ['HelpDesk'],
+            'all tier b lottery winner' => ['Lottery Winner'],
+            'all tier b verified account' => ['Verified Account'],
+            'all tier b security alert' => ['Security Alert'],
+            'all tier b suspended banned' => ['Suspended Banned'],
+            // Weak-brand + authority (Rule 3)
+            'freegling with support' => ['Freegling Support'],
+            'freeglers with admin' => ['Freeglers Admin'],
+            'freegled with team' => ['Freegled Team'],
+            'freeglers banned' => ['Freeglers Banned'],
         ];
     }
 
@@ -54,6 +78,26 @@ class NameSanitiserTest extends TestCase
             'empty' => [''],
             'single letter' => ['J'],
             'tn email leak' => ['alice-g3486@user.trashnothing.com'],
+            // @ in name bypasses suspicious check entirely
+            'arbitrary email address' => ['admin@example.com'],
+            'freegle.com domain' => ['user@freegle.com'],
+            // Weak-brand words alone (no authority partner) are clean
+            'freegler alone no authority' => ['Freegler'],
+            'freeglers alone' => ['Freeglers'],
+            'freegling alone' => ['Freegling'],
+            'freegled alone' => ['Freegled'],
+            // Near-miss of TIER_A_EXACT_ONLY: one edit but exact-only rule blocks fuzzy
+            'freecycle one edit blocked by exact-only' => ['freecyclx'],
+            'freshare one edit blocked by exact-only' => ['fresharx'],
+            // Punctuation/symbols-only: tokenises to empty → not suspicious
+            'hash symbols only' => ['###'],
+            'punctuation mix' => ['!@#$%'],
+            // Multi-token with one authority word but also normal tokens (allTierB=false, no brand)
+            'normal name with authority token' => ['Admin Johnson'],
+            // Numbers alone do not match any brand
+            'numbers only' => ['12345'],
+            // Long string far from any brand word
+            'completely unrelated name' => ['Freedom Eagle'],
         ];
     }
 
@@ -80,5 +124,119 @@ class NameSanitiserTest extends TestCase
         $this->assertSame(1, NameSanitiser::damerauLevenshtein('freegle', 'freegel', 2));
         $this->assertSame(1, NameSanitiser::damerauLevenshtein('freegle', 'freeggle', 2));
         $this->assertSame(0, NameSanitiser::damerauLevenshtein('freegle', 'freegle', 2));
+    }
+
+    public static function levenshteinCases(): array
+    {
+        return [
+            // Exact matches always return 0
+            'identical empty strings' => ['', '', 0, 0],
+            'identical single char' => ['a', 'a', 0, 0],
+            'identical word' => ['hello', 'hello', 5, 0],
+            // Basic single-edit operations
+            'one insertion at end' => ['abc', 'abcd', 5, 1],
+            'one deletion at end' => ['abcd', 'abc', 5, 1],
+            'one substitution' => ['abc', 'axc', 5, 1],
+            // Transpositions (Damerau extension over plain Levenshtein)
+            'adjacent transposition two chars' => ['ab', 'ba', 5, 1],
+            'transposition in middle' => ['abcde', 'abdce', 5, 1],
+            // Well-known multi-edit example
+            'kitten to sitting' => ['kitten', 'sitting', 10, 3],
+            // Early-exit via length difference: abs(la-lb) > maxD → returns maxD+1
+            'length diff 2 exceeds maxD 1' => ['a', 'abc', 1, 2],
+            'length diff 3 exceeds maxD 0' => ['', 'abc', 0, 1],
+            // Length diff equal to maxD is allowed (does NOT trigger early exit)
+            'length diff equals maxD proceeds normally' => ['ab', 'abc', 1, 1],
+            // maxD=0 exact match still succeeds
+            'maxD zero with identical strings' => ['foo', 'foo', 0, 0],
+        ];
+    }
+
+    #[DataProvider('levenshteinCases')]
+    public function test_damerau_levenshtein_table(string $a, string $b, int $maxD, int $expected): void
+    {
+        $this->assertSame($expected, NameSanitiser::damerauLevenshtein($a, $b, $maxD));
+    }
+
+    public function test_damerau_levenshtein_is_symmetric(): void
+    {
+        $pairs = [
+            ['freegle', 'freegel', 2],
+            ['kitten', 'sitting', 10],
+            ['abc', 'abcd', 5],
+            ['', 'hello', 5],
+        ];
+        foreach ($pairs as [$a, $b, $maxD]) {
+            $this->assertSame(
+                NameSanitiser::damerauLevenshtein($a, $b, $maxD),
+                NameSanitiser::damerauLevenshtein($b, $a, $maxD),
+                "damerauLevenshtein('$a','$b') should equal damerauLevenshtein('$b','$a')"
+            );
+        }
+    }
+
+    public function test_rewrite_result_is_always_a_freegler(): void
+    {
+        $suspicious = ['Freegle Admin', 'Admin', 'iLovefreegle Support'];
+        foreach ($suspicious as $name) {
+            $this->assertSame('A freegler', NameSanitiser::sanitize($name, isExempt: false));
+        }
+    }
+
+    public function test_case_insensitive_for_authority_words(): void
+    {
+        // TIER_B matching is case-insensitive via tokenise lowercasing
+        $this->assertSame('A freegler', NameSanitiser::sanitize('SUPPORT TEAM', isExempt: false));
+        $this->assertSame('A freegler', NameSanitiser::sanitize('support team', isExempt: false));
+        $this->assertSame('A freegler', NameSanitiser::sanitize('Support Team', isExempt: false));
+    }
+
+    public function test_leet_speak_normalisation(): void
+    {
+        // 3→e, 0→o in various brand-word patterns
+        $this->assertSame('A freegler', NameSanitiser::sanitize('Fr33gle', isExempt: false));
+        $this->assertSame('A freegler', NameSanitiser::sanitize('Fr33gl3', isExempt: false));
+        // Supp0rt (0→o) alone is a Tier B word
+        $this->assertSame('A freegler', NameSanitiser::sanitize('Supp0rt', isExempt: false));
+    }
+
+    public function test_non_ascii_letter_in_name_passes_through(): void
+    {
+        // Greek capital Alpha (U+0391, 2-byte UTF-8) is a non-combining-mark letter.
+        // In normalise() it exercises the multi-byte non-combining letter branch (lines ~158-161)
+        // and in tokenise() the equivalent branch (~195-197).
+        // 'Αdmin' normalises token 'αdmin' which is not in any Tier, so the name is clean.
+        $this->assertSame("Αdmin", NameSanitiser::sanitize("Αdmin", isExempt: false));
+
+        // Combined: Greek letter + authority word. Only 'support' is Tier B; 'αdmin' is not,
+        // so allTierB=false and none of the suspicious rules fire.
+        $this->assertSame("Αdmin Support", NameSanitiser::sanitize("Αdmin Support", isExempt: false));
+    }
+
+    public function test_non_alnum_multibyte_symbol_acts_as_token_separator(): void
+    {
+        // Bullet U+2022 (3-byte UTF-8, category Po) is not alphanumeric.
+        // In tokenise() it hits the multi-byte non-letter/non-number branch (~line 199) and is
+        // treated as a word separator. decodeUtf8 exercises the 3-byte path (~lines 311-312)
+        // and encodeUtf8 exercises the 3-byte path (~lines 331-332).
+        //
+        // 'Admin • Moderator' → tokens ['admin', 'moderator'] → all Tier B → suspicious.
+        $this->assertSame('A freegler', NameSanitiser::sanitize("Admin \u{2022} Moderator", isExempt: false));
+
+        // 'Emma • Smith' → tokens ['emma', 'smith'] → not suspicious → unchanged.
+        $this->assertSame("Emma \u{2022} Smith", NameSanitiser::sanitize("Emma \u{2022} Smith", isExempt: false));
+    }
+
+    public function test_emoji_acts_as_token_separator(): void
+    {
+        // Gift-box emoji U+1F381 (4-byte UTF-8, category So) is not a letter/number.
+        // decodeUtf8 exercises the 4-byte codepoint path (~lines 314-318) and encodeUtf8
+        // exercises the 4-byte path (~lines 334-337).
+        //
+        // '🎁 Admin Support' → emoji is separator → tokens ['admin', 'support'] → all Tier B.
+        $this->assertSame('A freegler', NameSanitiser::sanitize("🎁 Admin Support", isExempt: false));
+
+        // 'Emma 🎁 Jones' → tokens ['emma', 'jones'] → not suspicious → unchanged.
+        $this->assertSame("Emma 🎁 Jones", NameSanitiser::sanitize("Emma 🎁 Jones", isExempt: false));
     }
 }


### PR DESCRIPTION
## Coverage added
Module: `iznik-batch/app/Support/NameSanitiser.php`
Coverage before: ~70% (26 tests — original baseline)
Coverage after: 96.5% (137/142 statements)
Delta: +~26%

## Tests added
| Function | Scenario | File:Line |
|---|---|---|
| `sanitize` | Email address with `@` bypasses suspicious check | NameSanitiserTest.php |
| `sanitize` | Punctuation-only name produces empty tokens → clean | NameSanitiserTest.php |
| `sanitize` | Leet-speak normalisation: Fr33gl3 → freegle | NameSanitiserTest.php |
| `sanitize` | Diacritic stripping: Frëegle → freegle | NameSanitiserTest.php |
| `sanitize` | Concat obfuscation: ilovefreegle (no spaces) | NameSanitiserTest.php |
| `sanitize` | TIER_A_EXACT_ONLY: Freshare / Freshare Support | NameSanitiserTest.php |
| `sanitize` | TheFreegle / one-edit TheFregle (fuzzy Tier A) | NameSanitiserTest.php |
| `sanitize` | All-Tier-B authority words: HelpDesk, Lottery Winner, Verified Account, Security Alert | NameSanitiserTest.php |
| `sanitize` | Weak-brand + authority: Freegling Support, Freeglers Admin, Freegled Team | NameSanitiserTest.php |
| `sanitize` | Weak-brand alone (no authority): Freegler, Freegling, Freegled → clean | NameSanitiserTest.php |
| `sanitize` | Case-insensitive Tier B: SUPPORT TEAM / support team / Support Team | NameSanitiserTest.php |
| `sanitize` | Greek letter (2-byte non-combining): exercises normalise/tokenise multi-byte letter path | NameSanitiserTest.php |
| `sanitize` | Bullet U+2022 (3-byte non-alnum): acts as token separator, exercises 3-byte decodeUtf8/encodeUtf8 | NameSanitiserTest.php |
| `sanitize` | Emoji U+1F381 (4-byte): acts as separator, exercises 4-byte decodeUtf8/encodeUtf8 | NameSanitiserTest.php |
| `damerauLevenshtein` | Empty strings, length-diff early-exit sentinel, symmetric property | NameSanitiserTest.php |
| `damerauLevenshtein` | Classic kitten→sitting = 3, one-insertion, one-deletion, one-substitution | NameSanitiserTest.php |

## Latent bugs found (if any)
| Function | Description |
|---|---|
| `isSuspicious` | Line 242: The `TN_EMAIL_SUFFIX` regex check is dead code — any string matching that pattern (e.g. `alice-g3486@user.trashnothing.com`) also contains `@` and is caught at line 238 by the preceding `str_contains` guard. The dead branch can never be reached. No fix in this PR (test-only). |

## No production code changed
All changes are in test files only (`*Test.php`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)