### PR TITLE
test(sso): expand Discourse SSO coverage 29% → 59%

### DIFF
--- a/iznik-server-go/sso/discourse_test.go
+++ b/iznik-server-go/sso/discourse_test.go
@@ -2,12 +2,34 @@ package sso
 
 import (
 	"encoding/base64"
+	"net/http/httptest"
 	"net/url"
+	"os"
 	"strings"
 	"testing"
 
+	"github.com/gofiber/fiber/v2"
 	"github.com/stretchr/testify/assert"
 )
+
+// ---------------------------------------------------------------------------
+// Helpers for DiscourseSSO endpoint tests
+// ---------------------------------------------------------------------------
+
+func newDiscourseSSOApp() *fiber.App {
+	app := fiber.New()
+	app.Get("/discourse_sso", DiscourseSSO)
+	return app
+}
+
+// makeValidSSOParams builds a base64-encoded SSO payload with a nonce and returns
+// the sso param and the HMAC-SHA256 sig, both already URL-encoded for query use.
+func makeValidSSOParams(secret string) (ssoParam, sigParam string) {
+	raw := "nonce=testnonce&return_sso_url=https%3A%2F%2Fdiscourse.ilovefreegle.org%2Fsession%2Fsso_login"
+	encoded := base64.StdEncoding.EncodeToString([]byte(raw))
+	sig := computeHMAC(encoded, secret)
+	return url.QueryEscape(encoded), url.QueryEscape(sig)
+}
 
 func TestComputeHMACKnownVector(t *testing.T) {
 	// HMAC-SHA256("hello", "key") — standard reference vector.
@@ -123,4 +145,171 @@ func TestBuildSSOResponseRoundTripsViaHMAC(t *testing.T) {
 	encoded := base64.StdEncoding.EncodeToString([]byte(payload))
 	sig := computeHMAC(encoded, secret)
 	assert.True(t, validateHMAC(encoded, sig, secret))
+}
+
+// ---------------------------------------------------------------------------
+// extractNonce — missing url.ParseQuery error branch (10% gap)
+// ---------------------------------------------------------------------------
+
+func TestExtractNonce_InvalidQueryString(t *testing.T) {
+	// base64 of a string containing an invalid percent-encoded sequence.
+	// url.ParseQuery returns an error for malformed escape sequences like %zz.
+	raw := "nonce=abc&bad=%zz"
+	payload := base64.StdEncoding.EncodeToString([]byte(raw))
+	_, err := extractNonce(payload)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "query parse")
+}
+
+// ---------------------------------------------------------------------------
+// DiscourseSSO — DB-free paths (function is at 0% coverage)
+// ---------------------------------------------------------------------------
+
+func TestDiscourseSSO_NoSecret(t *testing.T) {
+	// When DISCOURSE_SECRET is not set, the handler returns 500 before touching DB.
+	os.Unsetenv("DISCOURSE_SECRET")
+	app := newDiscourseSSOApp()
+	req := httptest.NewRequest("GET", "/discourse_sso?sso=anything&sig=anysig", nil)
+	resp, err := app.Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, fiber.StatusInternalServerError, resp.StatusCode)
+}
+
+func TestDiscourseSSO_InvalidSignature(t *testing.T) {
+	// When HMAC check fails, handler returns 403 before touching DB.
+	os.Setenv("DISCOURSE_SECRET", "correct-secret")
+	defer os.Unsetenv("DISCOURSE_SECRET")
+	app := newDiscourseSSOApp()
+	// Use a valid base64 payload but a wrong sig.
+	payload := base64.StdEncoding.EncodeToString([]byte("nonce=x"))
+	req := httptest.NewRequest("GET", "/discourse_sso?sso="+url.QueryEscape(payload)+"&sig=badsig", nil)
+	resp, err := app.Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, fiber.StatusForbidden, resp.StatusCode)
+}
+
+func TestDiscourseSSO_ValidSig_NoCookie(t *testing.T) {
+	// Valid HMAC but no cookie → redirects to modtools.org (no DB call).
+	secret := "sso-secret"
+	os.Setenv("DISCOURSE_SECRET", secret)
+	defer os.Unsetenv("DISCOURSE_SECRET")
+	ssoP, sigP := makeValidSSOParams(secret)
+	app := newDiscourseSSOApp()
+	req := httptest.NewRequest("GET", "/discourse_sso?sso="+ssoP+"&sig="+sigP, nil)
+	resp, err := app.Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, fiber.StatusFound, resp.StatusCode)
+	assert.Contains(t, resp.Header.Get("Location"), "modtools.org/discourse")
+}
+
+func TestDiscourseSSO_ValidSig_InvalidCookieJSON(t *testing.T) {
+	// Valid HMAC and a cookie that is not valid JSON → validateDiscourseSession
+	// returns an error without hitting the DB → redirects to modtools.
+	secret := "sso-secret"
+	os.Setenv("DISCOURSE_SECRET", secret)
+	defer os.Unsetenv("DISCOURSE_SECRET")
+	ssoP, sigP := makeValidSSOParams(secret)
+	app := newDiscourseSSOApp()
+	req := httptest.NewRequest("GET", "/discourse_sso?sso="+ssoP+"&sig="+sigP, nil)
+	req.Header.Set("Cookie", "Iznik-Discourse-SSO=notjson{{}}")
+	resp, err := app.Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, fiber.StatusFound, resp.StatusCode)
+	assert.Contains(t, resp.Header.Get("Location"), "modtools.org/discourse")
+}
+
+func TestDiscourseSSO_ValidSig_URLEncodedCookie_InvalidJSON(t *testing.T) {
+	// Cookie is URL-encoded; after QueryUnescape it still isn't valid JSON →
+	// validateDiscourseSession returns error → redirect to modtools.
+	secret := "sso-secret"
+	os.Setenv("DISCOURSE_SECRET", secret)
+	defer os.Unsetenv("DISCOURSE_SECRET")
+	ssoP, sigP := makeValidSSOParams(secret)
+	app := newDiscourseSSOApp()
+	req := httptest.NewRequest("GET", "/discourse_sso?sso="+ssoP+"&sig="+sigP, nil)
+	// URL-encode something that decodes to invalid JSON.
+	req.Header.Set("Cookie", "Iznik-Discourse-SSO="+url.QueryEscape("broken{json"))
+	resp, err := app.Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, fiber.StatusFound, resp.StatusCode)
+	assert.Contains(t, resp.Header.Get("Location"), "modtools.org/discourse")
+}
+
+func TestDiscourseSSO_ValidSig_IncompleteCookieData(t *testing.T) {
+	// Cookie is valid JSON but fields are zero/empty → validateDiscourseSession
+	// returns "incomplete cookie data" error without touching the DB.
+	secret := "sso-secret"
+	os.Setenv("DISCOURSE_SECRET", secret)
+	defer os.Unsetenv("DISCOURSE_SECRET")
+	ssoP, sigP := makeValidSSOParams(secret)
+	app := newDiscourseSSOApp()
+	req := httptest.NewRequest("GET", "/discourse_sso?sso="+ssoP+"&sig="+sigP, nil)
+	// id=0, series and token present — triggers the incomplete-data check.
+	req.Header.Set("Cookie", `Iznik-Discourse-SSO=`+url.QueryEscape(`{"id":0,"series":"s","token":"t"}`))
+	resp, err := app.Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, fiber.StatusFound, resp.StatusCode)
+	assert.Contains(t, resp.Header.Get("Location"), "modtools.org/discourse")
+}
+
+// ---------------------------------------------------------------------------
+// validateDiscourseSession — pre-DB error paths (currently 0% coverage)
+// ---------------------------------------------------------------------------
+
+func TestValidateDiscourseSession_InvalidJSON(t *testing.T) {
+	_, err := validateDiscourseSession("}{not json")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid cookie JSON")
+}
+
+func TestValidateDiscourseSession_ZeroID(t *testing.T) {
+	_, err := validateDiscourseSession(`{"id":0,"series":"abc","token":"def"}`)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "incomplete cookie data")
+}
+
+func TestValidateDiscourseSession_EmptySeries(t *testing.T) {
+	_, err := validateDiscourseSession(`{"id":42,"series":"","token":"def"}`)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "incomplete cookie data")
+}
+
+func TestValidateDiscourseSession_EmptyToken(t *testing.T) {
+	_, err := validateDiscourseSession(`{"id":42,"series":"abc","token":""}`)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "incomplete cookie data")
+}
+
+func TestValidateDiscourseSession_AllFieldsMissing(t *testing.T) {
+	// Empty JSON object — all fields are zero values.
+	_, err := validateDiscourseSession(`{}`)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "incomplete cookie data")
+}
+
+// ---------------------------------------------------------------------------
+// DiscourseSSO table-driven — parameter validation
+// ---------------------------------------------------------------------------
+
+func TestDiscourseSSO_NoSecretAlwaysReturns500(t *testing.T) {
+	// Regardless of payload/sig values, missing secret = 500.
+	os.Unsetenv("DISCOURSE_SECRET")
+	app := newDiscourseSSOApp()
+	cases := []struct {
+		name string
+		url  string
+	}{
+		{"both empty", "/discourse_sso"},
+		{"sso only", "/discourse_sso?sso=abc"},
+		{"sig only", "/discourse_sso?sig=abc"},
+		{"both present", "/discourse_sso?sso=abc&sig=def"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", tc.url, nil)
+			resp, err := app.Test(req)
+			assert.NoError(t, err)
+			assert.Equal(t, fiber.StatusInternalServerError, resp.StatusCode)
+		})
+	}
 }


### PR DESCRIPTION
## Coverage added
Module: `iznik-server-go/sso`
Coverage before: 29.0%
Coverage after: 59.0%
Delta: +30%

## Tests added
| Function | Scenario | File:Line |
|---|---|---|
| `DiscourseSSO` | No `DISCOURSE_SECRET` env var → 500 | discourse_test.go |
| `DiscourseSSO` | Invalid HMAC signature → 403 | discourse_test.go |
| `DiscourseSSO` | Valid sig, no cookie → 302 to modtools | discourse_test.go |
| `DiscourseSSO` | Valid sig, cookie is bad JSON → 302 | discourse_test.go |
| `DiscourseSSO` | Valid sig, URL-encoded cookie decodes to bad JSON → 302 | discourse_test.go |
| `DiscourseSSO` | Valid sig, incomplete cookie data (id=0) → 302 | discourse_test.go |
| `DiscourseSSO` | Table-driven: no secret with 4 param variations → all 500 | discourse_test.go |
| `validateDiscourseSession` | Invalid JSON cookie → error | discourse_test.go |
| `validateDiscourseSession` | Cookie with id=0 → "incomplete cookie data" | discourse_test.go |
| `validateDiscourseSession` | Cookie with empty series → "incomplete cookie data" | discourse_test.go |
| `validateDiscourseSession` | Cookie with empty token → "incomplete cookie data" | discourse_test.go |
| `validateDiscourseSession` | Empty JSON object → "incomplete cookie data" | discourse_test.go |
| `extractNonce` | base64 of `%zz` sequence → url.ParseQuery error | discourse_test.go |

## Function coverage delta
| Function | Before | After |
|---|---|---|
| `DiscourseSSO` | 0% | 74.2% |
| `validateDiscourseSession` | 0% | 21.4% |
| `extractNonce` | 90% | 100% |
| `getModGroupList` | 0% | 0% (entirely DB-dependent) |

## Latent bugs found
None.

## No production code changed
All changes are in test files only (`*_test.go`).

The remaining uncovered paths in `DiscourseSSO` (session → response building) and `validateDiscourseSession` (DB queries, user lookup, mod group check) and `getModGroupList` require a real database connection and cannot be exercised in pure unit tests.