### PR TITLE
fix(modtools): wire up chat-review Delete All to actually reject messages

### DIFF
--- a/iznik-nuxt3/modtools/pages/chats/review.vue
+++ b/iznik-nuxt3/modtools/pages/chats/review.vue
@@ -157,8 +157,7 @@ function deleteAll(callback) {
 function deleteConfirmed() {
   visibleMessages.value.forEach((m) => {
     if (!m.widerchatreview) {
-      // TODO: This needs to use the store properly
-      // chatStore.reject({ id: m.id, chatid: null })
+      chatStore.reject({ id: m.id, chatid: null })
     }
   })
 }

--- a/iznik-nuxt3/tests/unit/pages/modtools/chats/review.spec.js
+++ b/iznik-nuxt3/tests/unit/pages/modtools/chats/review.spec.js
@@ -7,6 +7,7 @@ const mockChatStore = {
   clear: vi.fn().mockResolvedValue({}),
   fetchReviewChatsMT: vi.fn().mockResolvedValue({}),
   messagesById: vi.fn().mockReturnValue([]),
+  reject: vi.fn().mockResolvedValue({}),
 }
 
 const mockAuthStore = {
@@ -193,6 +194,45 @@ describe('chats/review.vue page', () => {
 
       expect(wrapper.vm.showDeleteModal).toBe(true)
       expect(callback).toHaveBeenCalled()
+    })
+
+    it('deleteConfirmed rejects each visible message via the chat store', async () => {
+      // Regression: clicking "Delete All" → confirming the modal was a no-op
+      // because deleteConfirmed had its chatStore.reject() call commented out.
+      mockChatStore.messagesById.mockReturnValue([
+        { id: 1, chatid: 100, widerchatreview: false },
+        { id: 2, chatid: 200, widerchatreview: false },
+      ])
+      const wrapper = mountComponent()
+      await flushPromises()
+      wrapper.vm.show = 10
+      await wrapper.vm.$nextTick()
+      vi.clearAllMocks()
+
+      wrapper.vm.deleteConfirmed()
+      await flushPromises()
+
+      expect(mockChatStore.reject).toHaveBeenCalledTimes(2)
+      expect(mockChatStore.reject).toHaveBeenCalledWith({ id: 1, chatid: null })
+      expect(mockChatStore.reject).toHaveBeenCalledWith({ id: 2, chatid: null })
+    })
+
+    it('deleteConfirmed skips wider-chat-review messages (mod-only entries)', async () => {
+      mockChatStore.messagesById.mockReturnValue([
+        { id: 1, chatid: 100, widerchatreview: true },
+        { id: 2, chatid: 200, widerchatreview: false },
+      ])
+      const wrapper = mountComponent()
+      await flushPromises()
+      wrapper.vm.show = 10
+      await wrapper.vm.$nextTick()
+      vi.clearAllMocks()
+
+      wrapper.vm.deleteConfirmed()
+      await flushPromises()
+
+      expect(mockChatStore.reject).toHaveBeenCalledTimes(1)
+      expect(mockChatStore.reject).toHaveBeenCalledWith({ id: 2, chatid: null })
     })
   })
 


### PR DESCRIPTION
## Summary
- `deleteConfirmed` in `modtools/pages/chats/review.vue` had its `chatStore.reject()` call commented out behind a `// TODO: This needs to use the store properly`. As a result, clicking "Delete All" in the chat review screen, then confirming the modal, was a silent no-op — the modal closed and nothing got rejected.
- Uncommented the call so each non-`widerchatreview` message in `visibleMessages` is rejected via the chat store.
- Added two TDD regression tests in `tests/unit/pages/modtools/chats/review.spec.js`:
  - asserts `chatStore.reject({ id, chatid: null })` is called once per visible message
  - asserts wider-chat-review (mod-only) entries are skipped

## Test plan
- [x] Unit suite for the review page — both new tests pass, 16 tests in file green
- [x] Full unit suite via status API — 277 passed, 0 failed
- [ ] Manual smoke in modtools chat review once deployed: load review queue with >1 message, click Delete All, confirm, verify entries disappear
