### PR TITLE
fix(chat): don't show pov user's photo on the other bubble in mod-viewed User2User chats

### DIFF
--- a/iznik-nuxt3/composables/useChat.js
+++ b/iznik-nuxt3/composables/useChat.js
@@ -265,12 +265,21 @@ export function useChatMessageBase(chatId, messageId, pov = null) {
     if (chatmessage.value?.userid === myidComputed.value) {
       return me.value?.profile?.paththumb
     }
-    // For User2User chats, prefer the other user's profile from the user store.
-    // Fall back to chat.icon (which is the same image from the listing API)
-    // to avoid a blank avatar while the user store is still loading.
-    // In chat review, chat.icon is not populated so this gracefully degrades.
     if (chat.value?.chattype === 'User2User') {
-      return otheruserComputed.value?.profile?.paththumb || chat.value?.icon
+      const otherPaththumb = otheruserComputed.value?.profile?.paththumb
+      // chat.icon for a User2User chat is only correct from one
+      // participant's perspective (the Go API enriches relative to the
+      // requesting user — see iznik-server-go/chat/chatroom.go listChats
+      // icon branch). When a mod views the chat via pov, falling back to
+      // chat.icon for the non-pov user puts the pov user's photo on the
+      // wrong bubble (Discourse #9707). Return the (possibly empty)
+      // paththumb instead so ProfileImage renders a GeneratedAvatar.
+      if (pov) {
+        return otherPaththumb
+      }
+      // Participant view: chat.icon is the other user's image, safe as
+      // a fallback while the user store loads.
+      return otherPaththumb || chat.value?.icon
     }
     // For User2Mod: chat.icon is the group icon (member side) or member
     // profile (mod side). Prefer it over otheruser profile.

--- a/iznik-nuxt3/tests/unit/composables/useChat.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useChat.spec.js
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Integration test that exercises the REAL useChatMessageBase composable
+// (not a mirrored helper). The mirrored-helper pattern in
+// useChatProfileImage.spec.js doesn't catch divergence between the helper
+// and the production computed — this file is the catching layer.
+
+const mockChat = {
+  id: 1,
+  chattype: 'User2User',
+  user1: 11, // BELAL (sender, no profile image)
+  user2: 22, // David (recipient, has profile image)
+  otheruid: 22,
+  icon: '/david.jpg', // Go API enriches as user1 for mod viewers,
+  // so chat.icon is user2's image — only correct for one of the two bubbles.
+}
+
+const mockMessages = {
+  101: { id: 101, chatid: 1, userid: 11 }, // BELAL's message
+  102: { id: 102, chatid: 1, userid: 22 }, // David's message
+}
+
+const mockUsers = {
+  11: { id: 11, displayname: 'BELAL', profile: { paththumb: '' } },
+  22: { id: 22, displayname: 'David', profile: { paththumb: '/david.jpg' } },
+  99: { id: 99, displayname: 'Mod', profile: { paththumb: '/mod.jpg' } },
+}
+
+vi.mock('~/stores/chat', () => ({
+  useChatStore: () => ({
+    byChatId: (id) => (id === mockChat.id ? mockChat : null),
+    messageById: (id) => mockMessages[id] || null,
+    messagesById: (id) => Object.values(mockMessages).filter((m) => m.chatid === id),
+  }),
+}))
+
+vi.mock('~/stores/user', () => ({
+  useUserStore: () => ({
+    byId: (id) => mockUsers[id] || null,
+  }),
+}))
+
+vi.mock('~/stores/auth', () => ({
+  useAuthStore: () => ({
+    user: { id: 99 }, // Viewing mod (not a participant)
+  }),
+}))
+
+vi.mock('~/stores/message', () => ({
+  useMessageStore: () => ({
+    fetch: vi.fn(),
+    byId: () => null,
+  }),
+}))
+
+vi.mock('~/stores/group', () => ({
+  useGroupStore: () => ({ get: () => null }),
+}))
+
+vi.mock('~/composables/useTwem', () => ({
+  twem: (s) => s,
+}))
+
+vi.mock('~/composables/useDistance', () => ({
+  milesAway: () => 0,
+}))
+
+// Imported after mocks are set up
+let useChatMessageBase
+beforeEach(async () => {
+  vi.resetModules()
+  ;({ useChatMessageBase } = await import('~/composables/useChat'))
+})
+
+describe('useChatMessageBase — chatMessageProfileImage (Discourse #9707)', () => {
+  describe('Mod viewing User2User chat modal, sender has no profile image', () => {
+    // Concrete case from Discourse #9707 / chat 20843147:
+    //   user1 = BELAL (11) — no profile image
+    //   user2 = David (22) — has /david.jpg
+    //   pov = 22 (recipient, set by ModChatViewButton)
+    //   chat.icon = /david.jpg (Go API enriches as user1)
+    //
+    // Bug: sender's bubble fell back to chat.icon (David's photo) when
+    // BELAL's paththumb was empty. Fix: don't fall back to chat.icon for
+    // the non-pov user — let ProfileImage render a GeneratedAvatar from
+    // the user's name.
+
+    it("David's own message uses David's profile (matches name)", () => {
+      const { chatMessageProfileImage } = useChatMessageBase(1, 102, 22)
+      expect(chatMessageProfileImage.value).toBe('/david.jpg')
+    })
+
+    it("BELAL's message does NOT fall back to chat.icon (David's photo)", () => {
+      const { chatMessageProfileImage } = useChatMessageBase(1, 101, 22)
+      // The bug: returned '/david.jpg'. Fix: empty so GeneratedAvatar shows.
+      expect(chatMessageProfileImage.value).not.toBe('/david.jpg')
+    })
+
+    it("BELAL's message returns empty paththumb so a generated avatar renders", () => {
+      const { chatMessageProfileImage } = useChatMessageBase(1, 101, 22)
+      expect(chatMessageProfileImage.value).toBeFalsy()
+    })
+
+    it('profile name still reflects the actual sender (BELAL), not the pov user', () => {
+      const { chatMessageProfileName } = useChatMessageBase(1, 101, 22)
+      expect(chatMessageProfileName.value).toBe('BELAL')
+    })
+  })
+
+  describe('Mirror: pov=user1, recipient (user2) has no profile image', () => {
+    // Same bug class, mirrored. If chat.icon would happen to be user1's
+    // image (e.g. on a future API change), the user2 bubble must still
+    // not use it when pov is set.
+
+    it("user2's empty paththumb does not fall back to chat.icon under pov=user1", () => {
+      const originalUser2 = mockUsers[22].profile.paththumb
+      const originalIcon = mockChat.icon
+      mockUsers[22].profile.paththumb = ''
+      mockChat.icon = '/something.jpg' // anything truthy
+
+      try {
+        const { chatMessageProfileImage } = useChatMessageBase(1, 102, 11)
+        expect(chatMessageProfileImage.value).not.toBe('/something.jpg')
+        expect(chatMessageProfileImage.value).toBeFalsy()
+      } finally {
+        mockUsers[22].profile.paththumb = originalUser2
+        mockChat.icon = originalIcon
+      }
+    })
+  })
+})

--- a/iznik-nuxt3/tests/unit/composables/useChatProfileImage.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useChatProfileImage.spec.js
@@ -14,6 +14,7 @@ import { describe, it, expect } from 'vitest'
 function useChatProfileImage({
   messageUserid,
   myid,
+  pov,
   chattype,
   chatIcon,
   meProfile,
@@ -23,7 +24,14 @@ function useChatProfileImage({
     return meProfile
   }
   if (chattype === 'User2User') {
-    // Prefer user store profile; fall back to chat.icon while loading.
+    // When pov is set (mod viewing the chat), chat.icon comes from one
+    // participant's perspective and is wrong for the opposite bubble —
+    // don't fall back to it. See Discourse #9707.
+    if (pov) {
+      return otheruserProfile
+    }
+    // Participant view: chat.icon is the other user's image, safe as a
+    // fallback while the user store loads.
     return otheruserProfile || chatIcon
   }
   // User2Mod: chat.icon is group/member icon, preferred.
@@ -128,7 +136,7 @@ describe('User2User — Freegle site (useChat.js)', () => {
     })
   })
 
-  describe('user store not yet loaded — falls back to chat.icon', () => {
+  describe('user store not yet loaded — falls back to chat.icon (no pov)', () => {
     it('shows chat.icon while otheruser profile is loading', () => {
       expect(
         useChatProfileImage({
@@ -140,6 +148,58 @@ describe('User2User — Freegle site (useChat.js)', () => {
           otheruserProfile: undefined, // not loaded yet
         })
       ).toBe('/chat-icon.jpg')
+    })
+  })
+
+  describe('mod viewing User2User chat modal with pov (Discourse #9707)', () => {
+    // Go API enriches the chat from user1's perspective for non-participant
+    // mods, so chat.icon ends up as user2's image. With pov set to user2,
+    // user1's empty paththumb must NOT fall back to chat.icon (which is
+    // user2's image) — that's the cause of the wrong-avatar bug.
+    const u1Profile = '' // BELAL — no profile image
+    const u2Profile = '/david.jpg'
+    const chatIcon = u2Profile // mirrors what the Go API returns
+
+    it("user2 (David) own message shows user2's profile", () => {
+      expect(
+        useChatProfileImage({
+          messageUserid: 2,
+          myid: 2,
+          pov: 2,
+          chattype: 'User2User',
+          chatIcon,
+          meProfile: u2Profile,
+          otheruserProfile: u1Profile,
+        })
+      ).toBe(u2Profile)
+    })
+
+    it("user1 (BELAL) message does NOT fall back to chat.icon (David's photo)", () => {
+      expect(
+        useChatProfileImage({
+          messageUserid: 1,
+          myid: 2,
+          pov: 2,
+          chattype: 'User2User',
+          chatIcon,
+          meProfile: u2Profile,
+          otheruserProfile: u1Profile,
+        })
+      ).not.toBe(chatIcon)
+    })
+
+    it("user1 (BELAL) message returns empty paththumb so GeneratedAvatar can render", () => {
+      expect(
+        useChatProfileImage({
+          messageUserid: 1,
+          myid: 2,
+          pov: 2,
+          chattype: 'User2User',
+          chatIcon,
+          meProfile: u2Profile,
+          otheruserProfile: u1Profile,
+        })
+      ).toBeFalsy()
     })
   })
 })


### PR DESCRIPTION
Fixes [Discourse #9707](https://discourse.ilovefreegle.org/t/9707) — wrong avatar in ModTools View Chat modal.

## Symptom

In the ModTools View Chat modal (opened from the chat-review queue), a User2User chat showed the wrong person's photo on the other user's bubbles. The name above the bubble was right, the avatar was wrong.

Concrete case (chat 20843147):
- user1 = BELAL #44930705 — no profile image
- user2 = David #2219559 — has imageid 7020530
- pov sent to the modal = user2 (David)
- BELAL's left-aligned bubbles showed David's photo. Name still said BELAL.

## Root cause

Two halves:

1. **Backend perspective**: `iznik-server-go/chat/chatroom.go GetChatRoom` enriches a mod-viewed chat from user1's perspective, so `chat.icon` is built from user2's profile (the icon branch in `listChats` chooses user2 when requester=user1). The result: `chat.icon` is only correct for ONE of the two bubbles.
2. **Frontend fallback**: `composables/useChat.js chatMessageProfileImage` did `otheruserProfile || chat.icon`. When the non-pov user has an empty `paththumb` (BELAL has no `users_images` row → `Useprofile=false` → `ProfileSetPath` not called), the fallback substituted `chat.icon` — which is the OTHER bubble's image.

This only manifests when one of the two participants has no profile image, which is why most chats are unaffected.

## Fix

In `chatMessageProfileImage`, when `pov` is set on a `User2User` chat (mod-viewing context), do NOT fall back to `chat.icon` for the non-pov user. Return the (possibly empty) paththumb — `ProfileImage` will then render a `GeneratedAvatar` from the user's name, which is what should have happened in the first place.

Participant view (no pov) keeps the existing `chat.icon` fallback, because there `chat.icon` IS the other user's image and is a safe fallback while the user store loads.

`useChatMT.js` is dead code (only `setupChatMT` is imported) — not touched, as flagged in the brief.

## Tests

- New integration spec `tests/unit/composables/useChat.spec.js` mocks the stores and calls the REAL `useChatMessageBase` composable, asserting:
  - David's own bubble keeps David's image
  - BELAL's bubble does NOT show `chat.icon` (David's photo)
  - BELAL's bubble returns falsy so `GeneratedAvatar` renders
  - Mirror case with pov=user1
- Updated `tests/unit/composables/useChatProfileImage.spec.js` mirrored helper to take `pov`, plus three new pov-aware test cases.
- Existing no-pov tests (participant view, chat-review, User2Mod) still pass — fallback behavior preserved for those paths.

## Test plan

- [x] `useChat`-filtered unit suite — 66 passing (5 new in `useChat.spec.js`, 3 new in `useChatProfileImage.spec.js`)
- [x] Full unit suite via status API — 12673 passing, 0 failing
- [ ] Manual smoke once deployed: open chat-review queue → click "View" on a User2User chat where one participant has no profile image → confirm sender's bubble shows a generated/initials avatar matching the sender's name, not the recipient's photo

## Note on the brief's "test gap" point

The brief observed that `useChatProfileImage.spec.js` mirrors logic in a helper function so the suite doesn't catch divergence between the helper and production. The new `useChat.spec.js` closes that gap for the avatar path — it imports the real composable and exercises the actual computed.
