### PR TITLE
app: derive navbar SSR-fallback image URLs from runtime config

### DIFF
--- a/iznik-nuxt3/app.vue
+++ b/iznik-nuxt3/app.vue
@@ -55,20 +55,14 @@
                   ><source
                     type="image/webp"
                     sizes="58px"
-                    srcset="
-                      https://delivery.ilovefreegle.org/?filename=icon.png&we&w=58&output=png&fit=inside&url=https://www.ilovefreegle.org/icon.png   58w,
-                      https://delivery.ilovefreegle.org/?filename=icon.png&we&w=116&output=png&fit=inside&url=https://www.ilovefreegle.org/icon.png 116w
-                    " />
+                    :srcset="navbarFallbackImage.srcset" />
                   <img
                     alt="Home"
                     loading="eager"
                     data-nuxt-pic=""
-                    src="https://61ddd294bd3a390019c6.ucr.io//-/format/png/-/resize/116x//https://www.ilovefreegle.org/icon.png"
+                    :src="navbarFallbackImage.src"
                     sizes="58px"
-                    srcset="
-                      https://delivery.ilovefreegle.org/?filename=icon.png&we&w=58&output=png&fit=inside&url=https://www.ilovefreegle.org/icon.png   58w,
-                      https://delivery.ilovefreegle.org/?filename=icon.png&we&w=116&output=png&fit=inside&url=https://www.ilovefreegle.org/icon.png 116w
-                    " /></picture></a
+                    :srcset="navbarFallbackImage.srcset" /></picture></a
               ><!----><!---->
               <div data-v-454188a5="" class="navbar-nav ms-auto">
                 <div data-v-454188a5="" class="nav-item" no-prefetch="">
@@ -174,6 +168,37 @@ const runtimeConfig = JSON.parse(
     app: useRuntimeConfig().app,
   })
 )
+
+// Navbar SSR-fallback image URLs.
+//
+// Pre-hydration the <client-only fallback> renders a stand-in navbar so the
+// page layout doesn't jump when the real <NavbarDesktop/> mounts. Previously
+// the <img>/<source> srcsets in that fallback hard-coded Freegle's CDN and
+// site URLs verbatim, which meant any consumer that uses this codebase as a
+// Nuxt layer (e.g. a sister site re-skinning Freegle) saw Freegle's icon
+// flash for ~100 ms before hydration.
+//
+// Derive the URLs from runtime config so a layer or env override changes
+// what's shown without forking app.vue.
+const navbarFallbackImage = (() => {
+  const userSite = runtimeConfig.public.USER_SITE || ''
+  const delivery = runtimeConfig.public.IMAGE_DELIVERY || ''
+  const source = `${userSite}/icon.png`
+  const widths = [58, 116]
+  // Same URL shape upstream used; just parameterised. The `output=png` is
+  // intentional even on the <source type="image/webp"> — historically the
+  // delivery proxy was set up to deliver PNG here.
+  const srcset = widths
+    .map(
+      (w) =>
+        `${delivery}/?filename=icon.png&we&w=${w}&output=png&fit=inside&url=${source} ${w}w`
+    )
+    .join(', ')
+  // Fallback <img src> used when the <source> set doesn't match: same
+  // delivery proxy at the largest width.
+  const src = `${delivery}/?filename=icon.png&we&w=116&output=png&fit=inside&url=${source}`
+  return { source, src, srcset }
+})()
 
 const miscStore = useMiscStore()
 const groupStore = useGroupStore()


### PR DESCRIPTION
## Summary

- `<client-only fallback>` in `app.vue` hard-codes the navbar logo's `<source srcset>` and `<img src>` to `delivery.ilovefreegle.org` / `www.ilovefreegle.org` / `61ddd294bd3a390019c6.ucr.io`.
- Replaced with `:srcset` / `:src` bindings driven by the existing `USER_SITE` and `IMAGE_DELIVERY` runtime config values.
- Default config values reproduce the exact URLs the template previously embedded, so Freegle's SSR fallback output is byte-equivalent.

## Why

Any consumer using this codebase as a Nuxt base layer (Freegle's own modtools/lat siblings, or third-party re-skins) currently sees Freegle's icon flash for ~100 ms before hydration replaces the navbar. They can't override it without forking `app.vue` wholesale.

After this change a `USER_SITE` / `IMAGE_DELIVERY` override (via env or a `runtimeConfig.public` block in the layer) is sufficient to point the SSR fallback at the layer's own assets.

## Bytes-equivalent check

With default env (no `USER_SITE`/`IMAGE_DELIVERY` set):
- `USER_SITE` default = `https://www.ilovefreegle.org` (from `config.js`)
- `IMAGE_DELIVERY` default = `https://delivery.ilovefreegle.org` (from `config.js`)

Computed `srcset` becomes:
```
https://delivery.ilovefreegle.org/?filename=icon.png&we&w=58&output=png&fit=inside&url=https://www.ilovefreegle.org/icon.png 58w, https://delivery.ilovefreegle.org/?filename=icon.png&we&w=116&output=png&fit=inside&url=https://www.ilovefreegle.org/icon.png 116w
```

Computed `src` becomes:
```
https://delivery.ilovefreegle.org/?filename=icon.png&we&w=116&output=png&fit=inside&url=https://www.ilovefreegle.org/icon.png
```

The only behaviour-different bit is the Uploadcare CDN URL that the old `<img src>` used (`61ddd294bd3a390019c6.ucr.io//-/format/png/-/resize/116x//…`). That CDN's job — proxy/resize the same `icon.png` — is what `IMAGE_DELIVERY` already does, so the new code just reuses `IMAGE_DELIVERY` instead of routing through a second proxy.

## Test plan

- [ ] Disable JS in the browser and load any Freegle page; the navbar logo still appears (served via the new `:src`/`:srcset`).
- [ ] View-source confirms the rendered fallback `<source>` and `<img>` URLs match the old hard-coded strings.