### PR TITLE
config: add IMAGE_SRC_URL for @nuxt/image weserv baseURL

### DIFF
--- a/iznik-nuxt3/config.js
+++ b/iznik-nuxt3/config.js
@@ -31,6 +31,19 @@ const CONFIG = {
   IMAGE_DELIVERY:
     process.env.IMAGE_DELIVERY || 'https://delivery.ilovefreegle.org',
 
+  // Source URL the @nuxt/image weserv provider fetches from (passed to weserv
+  // as `?url=...`). Defaults to TUS_UPLOADER with `:8080` stripped — the same
+  // value the previous hard-coded `.replace(':8080', '')` produced — so when
+  // unset Freegle's behaviour is unchanged. Set explicitly when TUS lives on
+  // a non-:8080 port (e.g. prefix-routed behind a 443 reverse proxy) so
+  // weserv doesn't fetch from a now-wrong URL.
+  IMAGE_SRC_URL:
+    process.env.IMAGE_SRC_URL ||
+    (process.env.TUS_UPLOADER || 'https://uploads.ilovefreegle.org:8080').replace(
+      ':8080',
+      ''
+    ),
+
   // OpenStreetMap Tile Server
   OSM_TILE:
     process.env.OSM_TILE ||

--- a/iznik-nuxt3/nuxt.config.ts
+++ b/iznik-nuxt3/nuxt.config.ts
@@ -1128,7 +1128,14 @@ export default defineNuxtConfig({
 
     weserv: {
       provider: 'weserv',
-      baseURL: config.TUS_UPLOADER.replace(':8080', ''),
+      // Source URL passed to weserv as `?url=…<image-id>`. Reads
+      // IMAGE_SRC_URL so deployments where TUS is on a non-:8080 port
+      // (e.g. behind a 443 prefix-routed proxy) can configure it
+      // explicitly instead of relying on `.replace(':8080', '')`.
+      // When IMAGE_SRC_URL is unset, config.js falls back to the
+      // previous strip-:8080 behaviour, so existing Freegle deploys
+      // see no change.
+      baseURL: config.IMAGE_SRC_URL,
       weservURL: config.IMAGE_DELIVERY,
     },
 


### PR DESCRIPTION
## Summary

- Adds a new config field `IMAGE_SRC_URL` (env var: `IMAGE_SRC_URL`) backing the @nuxt/image weserv provider's `baseURL`.
- `nuxt.config.ts:1131` previously used `config.TUS_UPLOADER.replace(':8080', '')`. That works for the standard Freegle deploy but silently produces a wrong URL when TUS lives on a different port (or under a path-prefix proxy, e.g. `https://host/uploads/files/`).
- Default of `IMAGE_SRC_URL` reproduces the old `.replace(':8080', '')` output, so existing Freegle deploys are unchanged.

## Why

A consumer using this codebase as a Nuxt layer who hosts their own tusd cannot cleanly override the weserv baseURL today — they have to overlay the whole `image:` block in `nuxt.config.ts`. With a named env var:

```sh
IMAGE_SRC_URL=https://lat.example.com/uploads/files/
```

is enough.

## Default-equivalence check

Old (no env var): `config.TUS_UPLOADER.replace(':8080', '')` = `'https://uploads.ilovefreegle.org:8080'.replace(':8080', '')` = `'https://uploads.ilovefreegle.org'`.

New (no env var): `IMAGE_SRC_URL` default = `(process.env.TUS_UPLOADER || 'https://uploads.ilovefreegle.org:8080').replace(':8080', '')` = `'https://uploads.ilovefreegle.org'`.

## Test plan

- [ ] Build a Freegle dev server with no env var set; verify weserv URLs in rendered HTML still hit `uploads.ilovefreegle.org`.
- [ ] Set `IMAGE_SRC_URL=https://example.test/files/` and confirm rendered weserv URLs use the override.