### PR TITLE
config: extract Freegle branding strings into branding.config.ts

### DIFF
--- a/iznik-nuxt3/branding.config.ts
+++ b/iznik-nuxt3/branding.config.ts
@@ -1,0 +1,39 @@
+/**
+ * Brand-identity strings consumed by `nuxt.config.ts` (and other shared head
+ * config) when rendering meta tags, page titles, and social-card previews.
+ *
+ * Defaults are Freegle's. A Nuxt layer (e.g. modtools/, or a third-party
+ * re-skin) can override this file via the layer extends system to swap
+ * the entire brand in one place — without forking `nuxt.config.ts`.
+ *
+ * Keep this file small and stable. Avoid putting layout/CSS/feature flags
+ * here — only the strings a brand replaces when it skins this product.
+ */
+export const branding = {
+  // Human-readable site name. Appears in og:site_name, navbar fallback alt
+  // text, and (via `${siteName} - ${tagline}`) in <title> and og:title.
+  siteName: 'Freegle',
+
+  // Short tagline appended after siteName in <title> / og:title /
+  // twitter:title.
+  tagline: "Don't throw it away, give it away!",
+
+  // 1-2 sentence elevator pitch. Used as <meta name="description">,
+  // og:description, twitter:description, and the
+  // apple-mobile-web-app-title content.
+  description:
+    "Give and get stuff for free in your local community.  Don't just recycle - reuse, freecycle and freegle!",
+
+  // Alt text for the brand logo as it appears in social cards.
+  logoAlt: 'The Freegle logo',
+
+  // Twitter @handle (without the @). Used for twitter:site.
+  twitterHandle: 'thisisfreegle',
+
+  // Facebook domain verification token (`<meta name="facebook-domain-
+  // verification">`). One per brand. If a fork doesn't use FB
+  // verification, leave empty — the tag is omitted.
+  facebookDomainVerification: 'zld0jt8mvf06rt1c3fnxvls3zntxj6',
+}
+
+export default branding

--- a/iznik-nuxt3/nuxt.config.ts
+++ b/iznik-nuxt3/nuxt.config.ts
@@ -2,6 +2,11 @@ import eslintPlugin from 'vite-plugin-eslint2'
 import { VitePWA } from 'vite-plugin-pwa'
 import { sentryVitePlugin } from '@sentry/vite-plugin'
 import config from './config'
+import { branding } from './branding.config'
+
+// Cached, brand-aware page-title string used in both `app.head.title` and
+// the og:title / twitter:title meta tags so they stay in lockstep.
+const fullTitle = `${branding.siteName} - ${branding.tagline}`
 
 // Mobile version change:
 // - config.js: MOBILE_VERSION eg 3.1.9
@@ -600,7 +605,7 @@ export default defineNuxtConfig({
       htmlAttrs: {
         lang: 'en',
       },
-      title: "Freegle - Don't throw it away, give it away!",
+      title: fullTitle,
       script: [
         {
           // Capture URL search params before Nuxt router hydration strips them.
@@ -978,25 +983,23 @@ export default defineNuxtConfig({
       meta: [
         { charset: 'utf-8' },
         { name: 'viewport', content: 'width=device-width, initial-scale=1' },
-        { hid: 'author', name: 'author', content: 'Freegle' },
+        { hid: 'author', name: 'author', content: branding.siteName },
         { name: 'supported-color-schemes', content: 'light' },
         { name: 'color-scheme', content: 'light' },
         {
           name: 'facebook-domain-verification',
-          content: 'zld0jt8mvf06rt1c3fnxvls3zntxj6',
+          content: branding.facebookDomainVerification,
         },
         { hid: 'og:type', property: 'og:type', content: 'website' },
         {
           hid: 'description',
           name: 'description',
-          content:
-            "Give and get stuff for free in your local community.  Don't just recycle - reuse, freecycle and freegle!",
+          content: branding.description,
         },
         {
           hid: 'apple-mobile-web-app-title',
           name: 'apple-mobile-web-app-title',
-          content:
-            "Give and get stuff for free in your local community.  Don't just recycle - reuse, freecycle and freegle!",
+          content: branding.description,
         },
 
         {
@@ -1008,9 +1011,9 @@ export default defineNuxtConfig({
         {
           hid: 'og:title',
           property: 'og:title',
-          content: "Freegle - Don't throw it away, give it away!",
+          content: fullTitle,
         },
-        { hid: 'og:site_name', property: 'og:site_name', content: 'Freegle' },
+        { hid: 'og:site_name', property: 'og:site_name', content: branding.siteName },
         {
           hid: 'og:url',
           property: 'og:url',
@@ -1024,19 +1027,17 @@ export default defineNuxtConfig({
         {
           hid: 'og:description',
           property: 'og:description',
-          content:
-            "Give and get stuff for free in your local community.  Don't just recycle - reuse, freecycle and freegle!",
+          content: branding.description,
         },
         {
           hid: 'twitter:title',
           name: 'twitter:title',
-          content: "Freegle - Don't throw it away, give it away!",
+          content: fullTitle,
         },
         {
           hid: 'twitter:description',
           name: 'twitter:description',
-          content:
-            "Give and get stuff for free in your local community.  Don't just recycle - reuse, freecycle and freegle!",
+          content: branding.description,
         },
         {
           hid: 'twitter:image',
@@ -1046,14 +1047,14 @@ export default defineNuxtConfig({
         {
           hid: 'twitter:image:alt',
           name: 'twitter:image:alt',
-          content: 'The Freegle logo',
+          content: branding.logoAlt,
         },
         {
           hid: 'twitter:card',
           name: 'twitter:card',
           content: 'summary_large_image',
         },
-        { hid: 'twitter:site', name: 'twitter:site', content: 'thisisfreegle' },
+        { hid: 'twitter:site', name: 'twitter:site', content: branding.twitterHandle },
         {
           hid: 'OMG-Verify-V1',
           name: 'OMG-Verify-V1',


### PR DESCRIPTION
## Summary

- New top-level `branding.config.ts` exporting a `branding` object with the strings that identify the site in `<title>`, `<meta>` tags, and social-card previews.
- `nuxt.config.ts` reads from `branding.siteName / tagline / description / logoAlt / twitterHandle / facebookDomainVerification` instead of inlining literals.
- Defaults are Freegle's current values **verbatim**, so the rendered HTML is byte-equivalent for the Freegle deploy.

## Why

The previous strings (e.g. `"Freegle - Don't throw it away, give it away!"`, `"Don't just recycle - reuse, freecycle and freegle!"`, `"thisisfreegle"`, the FB domain-verification token) were inlined in `nuxt.config.ts`'s `app.head` block. A consumer using this repo as a Nuxt base layer cannot replace them without forking `nuxt.config.ts` entirely.

With this PR, a layer ships its own `branding.config.ts` and Nuxt's layer extends system picks it up — one file change to re-skin the brand.

## Strings extracted

| nuxt.config.ts site | new `branding.config.ts` field |
|---|---|
| `app.head.title` | `${siteName} - ${tagline}` |
| `<meta name="author">` | `siteName` |
| `<meta name="facebook-domain-verification">` | `facebookDomainVerification` |
| `<meta name="description">` + `apple-mobile-web-app-title` | `description` |
| `og:title`, `twitter:title` | `${siteName} - ${tagline}` |
| `og:site_name` | `siteName` |
| `og:description`, `twitter:description` | `description` |
| `twitter:image:alt` | `logoAlt` |
| `twitter:site` | `twitterHandle` |

Left alone (already overridable per deploy via env vars in `config.js`):
- `og:image` / `twitter:image` = `config.USER_SITE + '/icon.png'`
- `og:url` = `config.USER_SITE`
- `fb:app_id` = `config.FACEBOOK_APPID`

## Byte-equivalence check

`branding.config.ts` defaults:
```
siteName: 'Freegle'
tagline: "Don't throw it away, give it away!"
description: "Give and get stuff for free in your local community.  Don't just recycle - reuse, freecycle and freegle!"
logoAlt: 'The Freegle logo'
twitterHandle: 'thisisfreegle'
facebookDomainVerification: 'zld0jt8mvf06rt1c3fnxvls3zntxj6'
```

Each substituted call site produces the exact same `content=` value previously inlined.

## Test plan

- [ ] Render a page on a clean Freegle build; view-source confirms `<title>`, `<meta>` and `og:` / `twitter:` tags match what was previously emitted (byte-for-byte for the strings covered).
- [ ] In a Nuxt layer that supplies its own `branding.config.ts`, confirm the layer's siteName/description show up in the rendered meta tags.