### PR TITLE
components: use Lazy-prefixed auto-import for ProfileModal/PromiseModal

### DIFF
--- a/iznik-nuxt3/components/ChatFooter.vue
+++ b/iznik-nuxt3/components/ChatFooter.vue
@@ -304,7 +304,7 @@
         />
       </div>
     </div>
-    <PromiseModal
+    <LazyPromiseModal
       v-if="showPromise"
       :messages="ouroffers"
       :selected-message="likelymsg ? likelymsg : 0"
@@ -314,7 +314,7 @@
       @hide="fetchMessages"
       @hidden="showPromise = false"
     />
-    <ProfileModal
+    <LazyProfileModal
       v-if="showProfileModal && otheruser"
       :id="otheruser ? otheruser.id : null"
       @hidden="showProfileModal = false"
@@ -388,12 +388,6 @@ const OurUploader = defineAsyncComponent(() =>
 )
 const UserRatings = defineAsyncComponent(() =>
   import('~/components/UserRatings')
-)
-const PromiseModal = defineAsyncComponent(() =>
-  import('~/components/PromiseModal')
-)
-const ProfileModal = defineAsyncComponent(() =>
-  import('~/components/ProfileModal')
 )
 const AddressModal = defineAsyncComponent(() =>
   import('~/components/AddressModal')

--- a/iznik-nuxt3/components/ChatHeader.vue
+++ b/iznik-nuxt3/components/ChatHeader.vue
@@ -300,7 +300,7 @@
           @confirm="hide"
           @hidden="showChatReport = false"
         />
-        <ProfileModal
+        <LazyProfileModal
           v-if="showProfileModal"
           :id="otheruser.id"
           close-on-message
@@ -345,10 +345,6 @@ const UserRatings = defineAsyncComponent(() =>
 const ChatReportModal = defineAsyncComponent(() =>
   import('~/components/ChatReportModal')
 )
-const ProfileModal = defineAsyncComponent(() =>
-  import('~/components/ProfileModal')
-)
-
 const props = defineProps({
   id: {
     type: Number,

--- a/iznik-nuxt3/components/ChatMessageInterested.vue
+++ b/iznik-nuxt3/components/ChatMessageInterested.vue
@@ -105,7 +105,7 @@
             @outcome="fetchMessage"
             @hidden="showOutcome = false"
           />
-          <PromiseModal
+          <LazyPromiseModal
             v-if="showPromise"
             :messages="[refmsg]"
             :selected-message="refmsg.id"
@@ -243,10 +243,6 @@ import { useMiscStore } from '~/stores/misc'
 const OutcomeModal = defineAsyncComponent(() =>
   import('~/components/OutcomeModal')
 )
-const PromiseModal = defineAsyncComponent(() =>
-  import('~/components/PromiseModal')
-)
-
 const props = defineProps({
   chatid: {
     type: Number,

--- a/iznik-nuxt3/components/ChatMessagePromised.vue
+++ b/iznik-nuxt3/components/ChatMessagePromised.vue
@@ -150,7 +150,7 @@
           >
           <span v-else class="preline forcebreak">{{ emessage }}</span>
         </div>
-        <PromiseModal
+        <LazyPromiseModal
           v-if="showPromise"
           :messages="[refmsg]"
           :selected-message="refmsgid"
@@ -199,10 +199,6 @@ const OutcomeModal = defineAsyncComponent(() =>
 )
 
 const RenegeModal = defineAsyncComponent(() => import('./RenegeModal'))
-const PromiseModal = defineAsyncComponent(() =>
-  import('~/components/PromiseModal')
-)
-
 const props = defineProps({
   chatid: {
     type: Number,

--- a/iznik-nuxt3/components/ChatPane.vue
+++ b/iznik-nuxt3/components/ChatPane.vue
@@ -132,7 +132,7 @@
         @confirm="hide"
         @hidden="showChatReport = false"
       />
-      <ProfileModal
+      <LazyProfileModal
         v-if="showProfileModal"
         :id="otheruser?.id"
         close-on-message
@@ -205,9 +205,6 @@ import { useRouter } from '#imports'
 import { useAuthStore } from '~/stores/auth'
 import { useMe } from '~/composables/useMe'
 
-const ProfileModal = defineAsyncComponent(() =>
-  import('~/components/ProfileModal')
-)
 const ChatBlockModal = defineAsyncComponent(() =>
   import('~/components/ChatBlockModal')
 )

--- a/iznik-nuxt3/components/MessageExpanded.vue
+++ b/iznik-nuxt3/components/MessageExpanded.vue
@@ -571,7 +571,7 @@
     />
 
     <!-- Profile Modal -->
-    <ProfileModal
+    <LazyProfileModal
       v-if="showProfileModal && poster?.id"
       :id="poster.id"
       @hidden="showProfileModal = false"
@@ -613,9 +613,6 @@ const MessagePhotosModal = defineAsyncComponent(() =>
 )
 const MessageShareModal = defineAsyncComponent(() =>
   import('~/components/MessageShareModal')
-)
-const ProfileModal = defineAsyncComponent(() =>
-  import('~/components/ProfileModal')
 )
 const MessageReportModal = defineAsyncComponent(() =>
   import('~/components/MessageReportModal')

--- a/iznik-nuxt3/components/MessageHistoryExpanded.vue
+++ b/iznik-nuxt3/components/MessageHistoryExpanded.vue
@@ -67,7 +67,7 @@
         }}</span>
       </div>
     </div>
-    <ProfileModal
+    <LazyProfileModal
       v-if="showProfile && message && fromuser"
       :id="fromuser.id"
       @hidden="showProfile = false"
@@ -84,10 +84,6 @@ import { useMessageStore } from '~/stores/message'
 import { useGroupStore } from '~/stores/group'
 import { timeago } from '~/composables/useTimeFormat'
 import { useMe } from '~/composables/useMe'
-
-const ProfileModal = defineAsyncComponent(() =>
-  import('~/components/ProfileModal')
-)
 
 const props = defineProps({
   id: {

--- a/iznik-nuxt3/components/MyMessage.vue
+++ b/iznik-nuxt3/components/MyMessage.vue
@@ -500,7 +500,7 @@
         @hidden="showShareModal = false"
       />
       <MessageEditModal v-if="showEditModal" :id="id" @hidden="hidden" />
-      <PromiseModal
+      <LazyPromiseModal
         v-if="showPromiseModal"
         :messages="[message]"
         :selected-message="message.id"
@@ -545,9 +545,6 @@ const MessageShareModal = defineAsyncComponent(() =>
 )
 const NoticeMessage = defineAsyncComponent(() =>
   import('~/components/NoticeMessage')
-)
-const PromiseModal = defineAsyncComponent(() =>
-  import('~/components/PromiseModal')
 )
 const OutcomeModal = defineAsyncComponent(() => import('./OutcomeModal'))
 const MessageEditModal = defineAsyncComponent(() =>

--- a/iznik-nuxt3/components/MyMessagePromisedTo.vue
+++ b/iznik-nuxt3/components/MyMessagePromisedTo.vue
@@ -46,7 +46,7 @@
         </div>
       </b-button>
     </div>
-    <PromiseModal
+    <LazyPromiseModal
       v-if="showPromiseModal"
       :messages="[message]"
       :selected-message="message.id"
@@ -72,9 +72,6 @@ import { useMiscStore } from '~/stores/misc'
 import { useMe } from '~/composables/useMe'
 import AddToCalendar from '~/components/AddToCalendar'
 
-const PromiseModal = defineAsyncComponent(() =>
-  import('~/components/PromiseModal')
-)
 const RenegeModal = defineAsyncComponent(() => import('./RenegeModal'))
 
 const props = defineProps({

--- a/iznik-nuxt3/components/MyMessageReply.vue
+++ b/iznik-nuxt3/components/MyMessageReply.vue
@@ -100,7 +100,7 @@
     </div>
 
     <!-- Modals -->
-    <PromiseModal
+    <LazyPromiseModal
       v-if="replyuser && showPromiseModal"
       :messages="[message]"
       :selected-message="message.id"
@@ -116,7 +116,7 @@
       :selected-user="replyuser?.id"
       @hidden="showRenegeModal = false"
     />
-    <ProfileModal
+    <LazyProfileModal
       v-if="showProfileModal"
       :id="replyuser?.id"
       @hidden="showProfileModal = false"
@@ -139,10 +139,6 @@ const UserRatings = defineAsyncComponent(() =>
 )
 const PromiseModal = defineAsyncComponent(() => import('./PromiseModal'))
 const RenegeModal = defineAsyncComponent(() => import('./RenegeModal'))
-const ProfileModal = defineAsyncComponent(() =>
-  import('~/components/ProfileModal')
-)
-
 const props = defineProps({
   message: {
     type: Object,

--- a/iznik-nuxt3/components/NewsReply.vue
+++ b/iznik-nuxt3/components/NewsReply.vue
@@ -282,7 +282,7 @@
       imgflag="Newsfeed"
       @hidden="showNewsPhotoModal = false"
     />
-    <ProfileModal
+    <LazyProfileModal
       v-if="showProfileModal"
       :id="userid"
       @hidden="showProfileModal = false"
@@ -333,9 +333,6 @@ const NewsPhotoModal = defineAsyncComponent(() =>
 )
 const NewsLovesModal = defineAsyncComponent(() => import('./NewsLovesModal'))
 const NewsEditModal = defineAsyncComponent(() => import('./NewsEditModal'))
-const ProfileModal = defineAsyncComponent(() =>
-  import('~/components/ProfileModal')
-)
 const ConfirmModal = defineAsyncComponent(() =>
   import('~/components/ConfirmModal.vue')
 )

--- a/iznik-nuxt3/components/NewsUserIntro.vue
+++ b/iznik-nuxt3/components/NewsUserIntro.vue
@@ -27,7 +27,7 @@
       their introductions appear automatically on here, and also show to other
       freeglers in chats.)
     </div>
-    <ProfileModal
+    <LazyProfileModal
       v-if="showProfileModal"
       :id="userid"
       @hidden="showProfileModal = false"
@@ -40,10 +40,6 @@ import { timeago, timeagoShort } from '~/composables/useTimeFormat'
 import { useAuthStore } from '~/stores/auth'
 import NewsUserInfo from '~/components/NewsUserInfo'
 import ProfileImage from '~/components/ProfileImage'
-
-const ProfileModal = defineAsyncComponent(() =>
-  import('~/components/ProfileModal')
-)
 
 const props = defineProps({
   userid: {

--- a/iznik-nuxt3/tests/unit/setup.ts
+++ b/iznik-nuxt3/tests/unit/setup.ts
@@ -186,6 +186,24 @@ config.global.stubs = {
   // Stub NuxtLink
   NuxtLink: { template: '<a :href="to"><slot /></a>', props: ['to'] },
 
+  // Stub Lazy-prefixed components — Nuxt's component resolver auto-imports
+  // `LazyXxx` as `defineAsyncComponent(() => import('~/components/Xxx'))`
+  // at build time; in the test runtime the resolver isn't wired, so we stub
+  // the ones used as bare tags in chat / message / news components.
+  // Class names match the non-Lazy stubs existing specs expect, so tests
+  // that assert on `.profile-modal` / `.promise-modal` keep working.
+  LazyProfileModal: {
+    template: '<div class="profile-modal" :data-id="id" />',
+    props: ['id'],
+    methods: { show() {} },
+  },
+  LazyPromiseModal: {
+    template: '<div class="promise-modal" :data-id="id" />',
+    props: ['id', 'group'],
+    emits: ['promised', 'reneged'],
+    methods: { show() {} },
+  },
+
   // Stub Spinner (auto-imported by Nuxt)
   Spinner: {
     template: '<div class="spinner-border" role="status" :style="spinnerStyle" />',


### PR DESCRIPTION
## Summary

- 12 components currently resolve `ProfileModal` / `PromiseModal` via `defineAsyncComponent(() => import('~/components/X'))`. The `~` alias points at the project root and ignores Nuxt's layer override system.
- Replaced the explicit imports with Lazy-prefixed bare tags in templates (`<LazyProfileModal/>`, `<LazyPromiseModal/>`). Nuxt auto-imports + the `Lazy` prefix preserves async / code-split loading AND routes through the component resolver, which honours layers.
- No behaviour change for single-layer (Freegle-only) builds — `LazyXxx` compiles to the same `defineAsyncComponent(() => import(...))` Nuxt would have produced.

## Why

When Freegle is consumed as a base layer (e.g. by a sister site that wants to skin Freegle's chat with a different `ProfileModal`), the layer's `components/ProfileModal.vue` is *not* picked up by callers using `import('~/components/ProfileModal')`. The Lazy-prefixed bare tag fixes this without changing Freegle's bundle behaviour.

## Files touched

`components/`: ChatFooter, ChatHeader, ChatMessageInterested, ChatMessagePromised, ChatPane, MessageExpanded, MessageHistoryExpanded, MyMessage, MyMessagePromisedTo, MyMessageReply, NewsReply, NewsUserIntro.

## Test plan

- [ ] Build the existing Freegle nuxt3 site and verify the chat pane, message expanded view, and news reply UI still open the profile / promise modals.
- [ ] `npm run test` — Playwright e2e suite passes.
- [ ] No new unit-test regressions in `tests/unit/components/{Chat*,Message*,My*,News*}.spec.js`.

## Future work

There are other `defineAsyncComponent(() => import('~/components/X'))` calls in this codebase (ChatBlockModal, MessageMap, OurAtTa, ExternalDa, PostMap, PostItem, ExportPost, ExportChat). Same anti-pattern but those components don't currently have layer overrides upstream, so this PR is scoped to just ProfileModal/PromiseModal. The pattern shown here is the recommended refactor for the remainder.

---
_Re-opened from same-repo branch to enable CircleCI (replaces fork PR #547)._