### PR TITLE
config: gate Prebid + GoogleTag init script behind ADS_SCRIPT_ENABLED

### DIFF
--- a/iznik-nuxt3/config.js
+++ b/iznik-nuxt3/config.js
@@ -78,6 +78,13 @@ const CONFIG = {
   PLAYWIRE_PUB_ID: process.env.PLAYWIRE_PUB_ID,
   PLAYWIRE_WEBSITE_ID: process.env.PLAYWIRE_WEBSITE_ID,
 
+  // Inline Prebid + Google Tag init script in app.head.script. Enabled by
+  // default — Freegle relies on this for its ad auction. Set
+  // ADS_SCRIPT_ENABLED=false to omit the ~5 kB inline script (and stop
+  // identifying the page to ad brokers) for builds that don't render ads
+  // (modtools, layered re-skins, embedded views).
+  ADS_SCRIPT_ENABLED: process.env.ADS_SCRIPT_ENABLED !== 'false',
+
   AD_PREBID_CONFIG: [
     {
       code: '/22794232631/freegle_sticky',

--- a/iznik-nuxt3/nuxt.config.ts
+++ b/iznik-nuxt3/nuxt.config.ts
@@ -639,7 +639,14 @@ export default defineNuxtConfig({
         // The order in which we load scripts is excruciatingly and critically important - see below.
         //
         // But we want to reduce LCP, so we defer all this by loading with async.
-        {
+        //
+        // Gated on config.ADS_SCRIPT_ENABLED so deployments that don't run ads
+        // (modtools layer, third-party re-skins) can omit this ~5 kB inline
+        // script and the Prebid auction it triggers. Default true preserves
+        // Freegle's existing behaviour.
+        ...(config.ADS_SCRIPT_ENABLED
+          ? [
+              {
           type: 'text/javascript',
           body: true,
           async: true,
@@ -973,7 +980,9 @@ export default defineNuxtConfig({
           } catch (e) {
             console.error('Error initialising ads and consent:', e.message);
           }`,
-        },
+              },
+            ]
+          : []),
       ],
       meta: [
         { charset: 'utf-8' },


### PR DESCRIPTION
## Summary

- The third entry in `app.head.script` (lines ~642-977 of `nuxt.config.ts`) is a ~5 kB inline `<script>` that registers consent state, initialises Prebid, declares all `freegle_*` ad-slot codes, identifies the page as `26548_Freegle` to ad brokers, and defers ad loading until CookieYes consent.
- Wrap that single entry in a spread guarded by `config.ADS_SCRIPT_ENABLED`. Default true, so Freegle behaviour is unchanged.
- Set `ADS_SCRIPT_ENABLED=false` (env) to omit it.

## Why

The script is essential for Freegle but dead weight for any build that doesn't render ads:
- ModTools — moderators don't see ads
- App-only builds (e.g. embedded webviews)
- Third-party re-skins that consume Freegle as a Nuxt base layer

Today such builds either ship the script anyway (5 kB unused, plus `wrappername: "26548_Freegle"` and ~17 `/22794232631/freegle_*` slot codes visible in every view-source) or maintain a nuxt.config layer module that filters the entry out of `app.head.script` post-hoc — which is what I had to do for our consumer.

A named env flag is the smallest, safest change.

## Test plan

- [ ] Build with no env var; view-source shows the Prebid script as today.
- [ ] Build with `ADS_SCRIPT_ENABLED=false`; the entry is absent; the other two `script:` entries (window.__initSearch capture, globalThis polyfill) are still present.
- [ ] `npm run test` — Playwright e2e suite passes (no test depends on the script being present *or* absent).

## Future work

The `LayoutCommon.vue` sticky-ad `<ExternalDa ad-unit-path="/22794232631/freegle_sticky">` block is *separately* gated on `allowAd` (a per-route computed). When `ADS_SCRIPT_ENABLED=false` and Prebid isn't initialised, those slots will silently fail-to-render — which is the desired behaviour for non-ad builds, but the upstream gating could be unified with this flag in a follow-up.

---
_Re-opened from same-repo branch to enable CircleCI (replaces fork PR #550)._