### PR TITLE
message: keep viewer's own promise row, drop other people's

### DIFF
--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -640,14 +640,23 @@ func GetMessagesByIds(myid uint64, ids []string, isPartner bool) []Message {
 				}
 
 				if message.Fromuser != myid {
-					// Shouldn't see promise details, but should see if it's promised to them.
-					for i := range message.MessagePromises {
-						if message.MessagePromises[i].Userid == myid {
+					// Privacy: a non-owner viewer shouldn't see *other people's*
+					// promise rows. But they CAN see their own row if they're a
+					// promisee — that row records terms they are themselves a
+					// party to (e.g. agreement details they're being asked to
+					// accept), so hiding it from them is unhelpful.
+					//
+					// Filter the slice in place: keep only rows where
+					// Userid == myid, drop the rest. PromisedToYou is set as a
+					// side effect for clients that don't read the slice.
+					filtered := message.MessagePromises[:0]
+					for _, p := range message.MessagePromises {
+						if p.Userid == myid {
+							filtered = append(filtered, p)
 							message.PromisedToYou = true
 						}
 					}
-
-					message.MessagePromises = nil
+					message.MessagePromises = filtered
 				} else {
 					message.Refchatids = refchatids
 				}


### PR DESCRIPTION
## Summary

`GET /message/{id}` previously wiped the entire `MessagePromises` slice for any viewer who isn't the message owner:

```go
if message.Fromuser != myid {
    for i := range message.MessagePromises {
        if message.MessagePromises[i].Userid == myid {
            message.PromisedToYou = true
        }
    }
    message.MessagePromises = nil
}
```

That correctly protects *other people's* promise rows. But it also hides the **viewer's own row** from the viewer, even though that row records terms the viewer is party to.

Replace with an in-place filter that keeps only rows where `Userid == myid`. `PromisedToYou` still flips for clients that don't read the slice.

## Why

Promise rows can carry meaningful terms (conditions, proposed-at / accepted-at timestamps, the other party's id). When a user is a promisee, the API tells them "you've been promised" via `PromisedToYou: true`, but won't tell them the details of the promise they're a party to. The current Freegle UI may not surface this gap, but any client that wants to render the agreement to the promisee (so they can confirm / decline / discuss it) currently can't, because the payload is `nil`.

## Privacy invariant

Before: viewer sees zero rows when they aren't the owner.
After: viewer sees zero rows where they aren't the owner.

Other people's rows continue to be invisible. The only behavioural change is that the viewer's own row — the one they already know about via `PromisedToYou` — now arrives with its details.

## Test plan

- [ ] Test that a non-owner viewer who is not a promisee gets `MessagePromises: []` (was `nil`).
- [ ] Test that a non-owner viewer who *is* a promisee gets exactly one row, with `Userid == viewer`.
- [ ] Test that the message owner gets all rows, as before.
- [ ] No new test should pass *additional* fields to non-owners that weren't theirs.

---
_Re-opened from same-repo branch to enable CircleCI (replaces fork PR #551)._