### PR TITLE
feat(modtools-support): add Unsubscribe button alongside Purge with confirm modals and tooltips

### DIFF
--- a/iznik-nuxt3/api/UserAPI.js
+++ b/iznik-nuxt3/api/UserAPI.js
@@ -103,6 +103,12 @@ export default class UserAPI extends BaseAPI {
     return this.$postv2('/user', { id, action: 'Unbounce' })
   }
 
+  unsubscribe(id) {
+    // Puts the user into limbo — account hidden immediately, all data
+    // permanently deleted after a 14-day grace period (User::limbo()).
+    return this.$postv2('/user', { id, action: 'Unsubscribe' })
+  }
+
   addEmail(id, email, primary) {
     return this.$postv2('/user', { id, action: 'AddEmail', email, primary })
   }

--- a/iznik-nuxt3/modtools/components/ModSupportUser.vue
+++ b/iznik-nuxt3/modtools/components/ModSupportUser.vue
@@ -56,8 +56,23 @@
         <b-button variant="white" class="me-2 mb-1" @click="spamReport">
           <v-icon icon="ban" /> Spammer
         </b-button>
-        <b-button variant="white" class="me-2 mb-1" @click="purge">
+        <b-button
+          v-b-tooltip.hover
+          variant="white"
+          class="me-2 mb-1"
+          title="Immediately and completely delete all data for this user. Cannot be undone."
+          @click="purge"
+        >
           <v-icon icon="trash-alt" /> Purge
+        </b-button>
+        <b-button
+          v-b-tooltip.hover
+          variant="white"
+          class="me-2 mb-1"
+          title="Put this user into the 14-day limbo state — account hidden immediately; data is permanently deleted after 14 days unless they log back in."
+          @click="unsubscribe"
+        >
+          <v-icon icon="user-times" /> Unsubscribe
         </b-button>
         <b-button
           variant="white"
@@ -548,8 +563,17 @@
       :title="
         'Purge ' + user.displayname + ' ' + user.email + ' from the system?'
       "
-      message="<p><strong>This can't be undone.</strong></p><p>Are you completely sure you want to do this?</p>"
+      message="<p><strong>This will immediately and completely delete all data for this user.</strong></p><p>This can't be undone. Are you completely sure you want to do this?</p>"
       @confirm="purgeConfirmed"
+    />
+    <ConfirmModal
+      v-if="unsubscribeConfirm"
+      ref="unsubscribeConfirmRef"
+      :title="
+        'Unsubscribe ' + user.displayname + ' ' + user.email + '?'
+      "
+      message="<p><strong>This will put them into the 14-day limbo state.</strong></p><p>Their account is hidden immediately. If they don't log back in within 14 days their data is permanently deleted. If they do, the account is restored intact.</p>"
+      @confirm="unsubscribeConfirmed"
     />
     <ConfirmModal
       v-if="showPasswordConfirm"
@@ -605,6 +629,7 @@ const userStore = useUserStore()
 const user = computed(() => userStore.byId(props.id))
 const expanded = ref(true)
 const purgeConfirm = ref(false)
+const unsubscribeConfirm = ref(false)
 const showAllMemberships = ref(false)
 const showAllMembershipHistories = ref(false)
 const showAllMessageHistories = ref(false)
@@ -631,6 +656,7 @@ const showProfile = ref(false)
 const logs = ref(null)
 const profileRef = ref(null)
 const purgeConfirmRef = ref(null)
+const unsubscribeConfirmRef = ref(null)
 const spamConfirm = ref(null)
 const showPasswordConfirm = ref(false)
 const passwordConfirmRef = ref(null)
@@ -856,6 +882,15 @@ function purgeConfirmed() {
 function purge() {
   purgeConfirm.value = true
   purgeConfirmRef.value?.show()
+}
+
+function unsubscribeConfirmed() {
+  userStore.unsubscribe(props.id)
+}
+
+function unsubscribe() {
+  unsubscribeConfirm.value = true
+  unsubscribeConfirmRef.value?.show()
 }
 
 function spamReport() {

--- a/iznik-nuxt3/stores/user.js
+++ b/iznik-nuxt3/stores/user.js
@@ -281,6 +281,9 @@ export const useUserStore = defineStore({
     async purge(id) {
       await api(this.config).user.purge(id)
     },
+    async unsubscribe(id) {
+      await api(this.config).user.unsubscribe(id)
+    },
     async ratingReviewed(params) {
       await api(this.config).user.ratingReviewed(params.id)
     },

--- a/iznik-nuxt3/tests/unit/components/modtools/ModSupportUser.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModSupportUser.spec.js
@@ -25,6 +25,7 @@ const mockFetchMT = vi.fn()
 const mockFetch = vi.fn()
 const mockEdit = vi.fn()
 const mockPurge = vi.fn()
+const mockUnsubscribe = vi.fn()
 const mockAddEmail = vi.fn()
 const mockById = vi.fn()
 
@@ -35,6 +36,7 @@ vi.mock('~/stores/user', () => ({
     fetch: mockFetch,
     edit: mockEdit,
     purge: mockPurge,
+    unsubscribe: mockUnsubscribe,
     addEmail: mockAddEmail,
     config: {},
   }),
@@ -96,6 +98,16 @@ describe('ModSupportUser', () => {
       },
       global: {
         plugins: [createPinia()],
+        directives: {
+          // bootstrap-vue-next's tooltip directive isn't registered in tests.
+          // A no-op directive keeps mount silent while leaving the `title`
+          // attribute on the element (tooltip text is verified separately).
+          'b-tooltip': {
+            mounted() {},
+            updated() {},
+            unmounted() {},
+          },
+        },
         stubs: {
           'b-card': {
             template: '<div class="card"><slot /><slot name="header" /></div>',
@@ -233,6 +245,7 @@ describe('ModSupportUser', () => {
     mockFetch.mockResolvedValue()
     mockEdit.mockResolvedValue()
     mockPurge.mockResolvedValue()
+    mockUnsubscribe.mockResolvedValue()
     mockAddEmail.mockResolvedValue()
 
     // Re-establish default API mock implementations cleared by clearAllMocks.
@@ -469,6 +482,18 @@ describe('ModSupportUser', () => {
       const wrapper = await mountComponent()
       wrapper.vm.purgeConfirmed()
       expect(mockPurge).toHaveBeenCalledWith(123)
+    })
+
+    it('unsubscribe sets unsubscribeConfirm to true', async () => {
+      const wrapper = await mountComponent()
+      wrapper.vm.unsubscribe()
+      expect(wrapper.vm.unsubscribeConfirm).toBe(true)
+    })
+
+    it('unsubscribeConfirmed calls store unsubscribe', async () => {
+      const wrapper = await mountComponent()
+      wrapper.vm.unsubscribeConfirmed()
+      expect(mockUnsubscribe).toHaveBeenCalledWith(123)
     })
 
     it('spamReport sets showSpamModal to true', async () => {


### PR DESCRIPTION
## Summary

Adds an **Unsubscribe** action to ModTools support tools (`ModSupportUser`), sitting next to the existing **Purge** button. Both buttons now have hover tooltips and confirm-modal copy that spell out exactly what they do.

| Button | Tooltip | Confirm modal text | Underlying call |
|--------|--------|--------------------|-----------------|
| Purge | Immediately and completely delete all data for this user. Cannot be undone. | "This will immediately and completely delete all data for this user. This can't be undone. Are you completely sure you want to do this?" | `DELETE /apiv2/user { id }` |
| Unsubscribe (new) | Put this user into the 14-day limbo state — account hidden immediately; data is permanently deleted after 14 days unless they log back in. | "This will put them into the 14-day limbo state. Their account is hidden immediately. If they don't log back in within 14 days their data is permanently deleted. If they do, the account is restored intact." | `POST /user { id, action: 'Unsubscribe' }` → V1 `User::limbo()` |

## V1 parity

The 14-day limbo period comes from `iznik-server/include/user/User.php:5863` (text of the email V1 sends on `User::limbo()`):

> _"Your personal data has been marked for deletion and will be completely removed from our systems within 14 days."_

V1 endpoint we're hitting: `POST /user action=Unsubscribe` in `iznik-server/http/api/user.php:322` — admin/support-gated, calls `$u->limbo()`. So the new button delegates to the same code that's already used by the user-facing unsubscribe flow and by `facebook_unsubscribe.php`.

## Files

- `iznik-nuxt3/api/UserAPI.js` — new `unsubscribe(id)` method
- `iznik-nuxt3/stores/user.js` — `unsubscribe()` action
- `iznik-nuxt3/modtools/components/ModSupportUser.vue` — new button, confirm modal, tooltip; Purge confirm wording strengthened
- `iznik-nuxt3/tests/unit/components/modtools/ModSupportUser.spec.js` — 2 new tests; no-op `v-b-tooltip` directive registered so test environment stays Vue-warning-free

## Test plan

- [x] `ModSupportUser.spec.js` — all 44 tests pass (2 new for Unsubscribe)
- [ ] Manual smoke in ModTools support tools: search a test user → click Unsubscribe → confirm → verify user is in limbo (`users.unsubscribed` flag set, all memberships removed, email sent)
- [ ] Manual hover on Purge / Unsubscribe to confirm tooltip text renders
