### PR TITLE
fix(eee): serve EEELabel ahead of AIImageReview; make migration Galera-safe

### DIFF
--- a/iznik-batch/database/migrations/2026_05_26_000001_add_eee_label_to_microactions.php
+++ b/iznik-batch/database/migrations/2026_05_26_000001_add_eee_label_to_microactions.php
@@ -12,9 +12,12 @@ return new class extends Migration
             return;
         }
 
-        // Part 1 — INSTANT in MySQL 8.0+: append the EEELabel enum value
-        // and add four new nullable columns at the end of the table.
-        // Both operations skip the row rewrite that ENUM-mid-list edits force.
+        // Single INPLACE + LOCK=NONE ALTER on prod (Percona 8.0 + Galera TOI).
+        // INSTANT can't be used here — Galera TOI doesn't support it for ENUM
+        // extension / multi-clause ALTERs (see FreegleDocker memory
+        // reference_galera_enum_alter). INPLACE is still online, ms-scale
+        // metadata lock only. eee_attachment_id is used (not msgid) so the new
+        // unique key does not clash with the existing (userid,msgid) key.
         if (!Schema::hasColumn('microactions', 'eee_attachment_id')) {
             DB::statement("
                 ALTER TABLE microactions
@@ -27,18 +30,6 @@ return new class extends Migration
                     'ItemSize','ItemWeight','Survey','Survey2','Invite','AIImageReview',
                     'EEELabel'
                   ),
-                  ALGORITHM=INSTANT
-            ");
-        }
-
-        // Part 2 — INPLACE + LOCK=NONE (still online, no table lock).
-        // Index/unique-key adds cannot be INSTANT. Uses eee_attachment_id, not
-        // msgid, so it does not clash with the existing (userid,msgid) unique
-        // key used by CheckMessage.
-        $indexes = DB::select("SHOW INDEX FROM microactions WHERE Key_name IN ('idx_eee_attachment_id','userid_7')");
-        if (empty($indexes)) {
-            DB::statement("
-                ALTER TABLE microactions
                   ADD INDEX idx_eee_attachment_id (eee_attachment_id),
                   ADD UNIQUE KEY userid_7 (userid, eee_attachment_id),
                   ALGORITHM=INPLACE, LOCK=NONE

--- a/iznik-server-go/microvolunteering/microvolunteering.go
+++ b/iznik-server-go/microvolunteering/microvolunteering.go
@@ -205,6 +205,16 @@ func GetChallenge(c *fiber.Ctx) error {
 		}
 	}
 
+	// Try EEELabel first (ahead of AIImageReview/CheckMessage). The EEE
+	// labelling pipeline relies on volunteer labels reaching quorum quickly,
+	// and AIImageReview / CheckMessage have plentiful backlogs that would
+	// otherwise crowd it out entirely.
+	if contains(challengeTypes, ChallengeEEELabel) {
+		if challenge := getEEELabelChallenge(db, userID); challenge != nil {
+			return c.JSON(challenge)
+		}
+	}
+
 	// Randomize between approved message review and AI image review (50/50) so that
 	// AI image review actually gets served — otherwise CheckMessage always has work
 	// and AI image review is never reached.
@@ -233,16 +243,6 @@ func GetChallenge(c *fiber.Ctx) error {
 		}
 	} else if wantAIImage {
 		if challenge := getAIImageReviewChallenge(db, userID); challenge != nil {
-			return c.JSON(challenge)
-		}
-	}
-
-	// Try EEE label challenge — present after AI image review so heavier
-	// existing flows (CheckMessage, AIImageReview) still get served first
-	// when present, but EEELabel runs ahead of PhotoRotate which is rarely
-	// satisfied.
-	if contains(challengeTypes, ChallengeEEELabel) {
-		if challenge := getEEELabelChallenge(db, userID); challenge != nil {
 			return c.JSON(challenge)
 		}
 	}


### PR DESCRIPTION
## Summary
- EEELabel from PR #496 is being served **0 times in 24h** on prod because the priority order put it after the CheckMessage/AIImageReview coinflip; AIImageReview / CheckMessage have plentiful backlogs so EEELabel was never reached. Live last-24h microactions: AIImageReview 125, CheckMessage 120, Invite 63, EEELabel 0. Move EEELabel ahead of the coinflip.
- 2026_05_26 migration uses \`ALGORITHM=INSTANT\` which Galera TOI doesn't support for ENUM extension (see [reference_galera_enum_alter](https://github.com/Freegle/Iznik/blob/master/iznik-batch)). Switched to \`INPLACE, LOCK=NONE\` (still online, ms-scale metadata lock). Collapsed to a single ALTER.

## Prod DDL
Migration won't auto-run on prod (per the standing \`feedback_never_artisan_migrate\` rule). Apply manually:

\`\`\`sql
ALTER TABLE microactions
  ADD COLUMN eee_attachment_id BIGINT UNSIGNED NULL DEFAULT NULL,
  ADD COLUMN eee_condition     VARCHAR(32) NULL DEFAULT NULL,
  ADD COLUMN eee_weight        VARCHAR(32) NULL DEFAULT NULL,
  ADD COLUMN eee_size          VARCHAR(32) NULL DEFAULT NULL,
  MODIFY COLUMN actiontype ENUM(
    'CheckMessage','SearchTerm','Items','FacebookShare','PhotoRotate',
    'ItemSize','ItemWeight','Survey','Survey2','Invite','AIImageReview','EEELabel'
  ),
  ADD INDEX idx_eee_attachment_id (eee_attachment_id),
  ADD UNIQUE KEY userid_7 (userid, eee_attachment_id),
  ALGORITHM=INPLACE, LOCK=NONE;
\`\`\`

## Test plan
- [ ] CI green
- [ ] Apply DDL on prod; verify \`SHOW COLUMNS FROM microactions WHERE Field LIKE 'eee\\_%'\`
- [ ] After ~30 min check \`SELECT actiontype, COUNT(*) FROM microactions WHERE timestamp >= NOW() - INTERVAL 1 HOUR GROUP BY actiontype\` — EEELabel should appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)