### PR TITLE
fix(ios-push-notifications): re-register APNs token on app resume to recover from OS-invalidated tokens

### DIFF
--- a/iznik-nuxt3/stores/mobile.js
+++ b/iznik-nuxt3/stores/mobile.js
@@ -116,7 +116,7 @@ export const useMobileStore = defineStore({
       this.initDeepLinks(App)
       await this.initPushNotifications(PushNotifications, Badge)
       await this.checkForAppUpdate()
-      this.initWakeUpActions(App)
+      this.initWakeUpActions(App, PushNotifications)
     },
 
     async getDeviceInfo(Device) {
@@ -191,9 +191,9 @@ export const useMobileStore = defineStore({
       return urlParams
     },
 
-    initWakeUpActions(App) {
+    initWakeUpActions(App, PushNotifications) {
       if (process.client) {
-        App.addListener('resume', (event) => {
+        App.addListener('resume', async (event) => {
           try {
             const notificationStore = useNotificationStore()
             notificationStore.fetchCount()
@@ -201,6 +201,20 @@ export const useMobileStore = defineStore({
             const chatStore = useChatStore()
             chatStore.fetchChats(null, false)
           } catch (e) {}
+
+          // Re-register for push notifications on every resume. iOS can invalidate
+          // the APNs device token after an OS upgrade (or other system event).
+          // Calling register() asks the OS for the current token; if it differs
+          // from the stored mobilePushId, the existing onRegistration listener
+          // will POST the fresh token to the backend (no-op when token is unchanged).
+          if (PushNotifications) {
+            try {
+              await PushNotifications.register()
+              dbg()?.info('Push register() called on resume')
+            } catch (e) {
+              dbg()?.warn('Push register() on resume failed', e)
+            }
+          }
         })
       }
     },


### PR DESCRIPTION
## Root Cause
iznik-nuxt3 `stores/mobile.js` calls `PushNotifications.register()` exactly once at app startup (~line 428). The `resume`/lifecycle handler (~lines 196-205) does not re-call `register()`. When iOS invalidates the APNs device token — for example after an iOS major-version upgrade such as iOS 26.5 — the app never asks for a fresh token, so the backend keeps dispatching pushes to a dead token that APNs silently drops. The user only sees the delayed email-fallback notifications.

## Evidence
This bug is hardware-dependent (physical iOS device + APNs) and cannot be reproduced in CI, so it is fixed as a testless change. Code inspection confirmed the diagnosis:
- `stores/mobile.js:428` — one-shot `PushNotifications.register()` at app startup.
- `stores/mobile.js:196-205` — `resume` handler does not re-call `register()`.
- `iznik-server-go/session/session.go:1714` — the `ON DUPLICATE KEY UPDATE` upsert is correct; the backend is not the bug — it is never told about a new token.

## Fix
Re-call `PushNotifications.register()` from the app-resume lifecycle handler in `stores/mobile.js`. The existing `onRegistration` listener already compares the returned token to the stored `mobilePushId` and POSTs to the backend only when they differ, so steady-state resumes are no-ops; only an OS-invalidated token triggers an actual update. After this fix, the next time the user opens the app following an iOS upgrade, the backend's stored token is refreshed and APNs deliveries resume.

## Alternatives Investigated
- Server-side chat-notification dispatch broken for iOS endpoints — ruled out: email fallback fires (pipeline alive) and there are no Android reports.
- User's iOS Focus/Silent settings misconfigured — ruled out: user reports persistent-notification setting is enabled and worked previously.
- APNs production certificate / bundle topic mismatch in build 100.0.365 — ruled out: would affect all iOS users on that build, no widespread reports.

## Other Call Sites
`stores/mobile.js:442` — one-shot `PushNotifications.register()` at startup (inside `initPushNotifications`). No other `PushNotifications.register` calls found in the codebase. `modtools/layouts/default.vue:491` has a separate `resume` listener for modtools-specific work (clear tray notifications, check work items) — it does not and should not manage push tokens, so no change needed there. No `appStateChange` handler exists. Fix adds the sole re-registration point.

## Test
File: n/a (testless)
Command: n/a
Proves: hardware-dependent — requires physical iOS device + APNs sandbox/production. Fix verified by code-read trace of the resume → register → onRegistration → conditional backend POST → upsert path.
Regression suite: not run (no test changes; pure mobile lifecycle code).

## Discourse
https://discourse.ilovefreegle.org/t/9720

🤖 Generated with [Claude Code](https://claude.com/claude-code)