### PR TITLE
test: improve coverage for WhatJobsService

### DIFF
--- a/iznik-batch/tests/Unit/Services/WhatJobsServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/WhatJobsServiceTest.php
@@ -1,0 +1,731 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Services\WhatJobsService;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+
+/**
+ * Unit tests for WhatJobsService pure / side-effect-free methods:
+ *
+ *   boxPoly()           — static WKT POLYGON builder
+ *   canonicalJobTitle() — job-title normalisation and canonical lookup
+ *   parseFeed()         — XML feed parsing with mocked geocodeCityState
+ *
+ * None of these tests touch the database (geocodeCityState is replaced with a
+ * trivial in-memory stub). No production code was changed.
+ */
+class WhatJobsServiceTest extends TestCase
+{
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    /**
+     * Build a WhatJobsService where geocodeCityState always returns $geo
+     * (or null if $geo is null), bypassing all DB lookups.
+     */
+    private function makeServiceWithFixedGeocode(?array $geo): WhatJobsService
+    {
+        return new class($geo) extends WhatJobsService {
+            public function __construct(private readonly ?array $fixedGeo) {}
+
+            public function geocodeCityState(
+                string $city,
+                string $state,
+                string $country,
+                array &$cache,
+                string $zip = ''
+            ): ?array {
+                return $this->fixedGeo;
+            }
+        };
+    }
+
+    /** Write XML content to a temp file; return its path. */
+    private function makeFeedFile(string $xml): string
+    {
+        $path = tempnam(sys_get_temp_dir(), 'wj_test_');
+        file_put_contents($path, $xml);
+        return $path;
+    }
+
+    /**
+     * Build a minimal WhatJobs / ClickCast-style XML feed containing $jobs.
+     *
+     * Structure used:
+     *   <source>      depth 0
+     *     <jobs>      depth 1
+     *       <job>     depth 2  ← parseFeed processes elements at this depth
+     *
+     * Format 2 (ClickCast) field names: job_reference, title, city, state,
+     *   country, cpc, posted_at, body, location, company, category, url, zip.
+     * Format 1 (WhatJobs) uses different names — built via format1Item().
+     */
+    private function makeFeedXml(array $jobs, int $format = 2): string
+    {
+        $items = '';
+        foreach ($jobs as $j) {
+            $items .= $format === 1
+                ? $this->format1Item($j)
+                : $this->format2Item($j);
+        }
+        return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+             . "<source>\n<jobs>\n{$items}</jobs>\n</source>\n";
+    }
+
+    private function format2Item(array $j): string
+    {
+        $item = "<job>\n";
+        foreach ($j as $k => $v) {
+            $item .= '  <' . $k . '>' . htmlspecialchars((string) $v, ENT_XML1, 'UTF-8') . '</' . $k . ">\n";
+        }
+        $item .= "</job>\n";
+        return $item;
+    }
+
+    private function format1Item(array $j): string
+    {
+        $e = fn (string $v) => htmlspecialchars($v, ENT_XML1, 'UTF-8');
+        return "<job>\n"
+             . '  <id>' . $e((string) ($j['id'] ?? '')) . "</id>\n"
+             . '  <title>' . $e((string) ($j['title'] ?? '')) . "</title>\n"
+             . '  <custom><CPC>' . $e((string) ($j['cpc'] ?? '0.50')) . "</CPC></custom>\n"
+             . (isset($j['timePosted'])
+                 ? '  <timePosted>' . $e((string) $j['timePosted']) . "</timePosted>\n"
+                 : '')
+             . "  <locations><location>\n"
+             . '    <city>' . $e((string) ($j['city'] ?? '')) . "</city>\n"
+             . '    <state>' . $e((string) ($j['state'] ?? '')) . "</state>\n"
+             . '    <country>' . $e((string) ($j['country'] ?? '')) . "</country>\n"
+             . '    <zip>' . $e((string) ($j['zip'] ?? '')) . "</zip>\n"
+             . '    <location>' . $e((string) ($j['location_name'] ?? '')) . "</location>\n"
+             . "  </location></locations>\n"
+             . '  <urlDeeplink>' . $e((string) ($j['url'] ?? '')) . "</urlDeeplink>\n"
+             . '  <description>' . $e((string) ($j['body'] ?? '')) . "</description>\n"
+             . '  <company><name>' . $e((string) ($j['company'] ?? '')) . "</name></company>\n"
+             . '  <category>' . $e((string) ($j['category'] ?? '')) . "</category>\n"
+             . "</job>\n";
+    }
+
+    // =========================================================================
+    // boxPoly — static WKT POLYGON builder
+    // =========================================================================
+
+    public function test_box_poly_returns_closed_wkt_polygon(): void
+    {
+        $wkt = WhatJobsService::boxPoly(51.3, -0.5, 51.7, 0.3);
+        // POLYGON((swlng swlat, swlng nelat, nelng nelat, nelng swlat, swlng swlat))
+        $this->assertSame(
+            'POLYGON((-0.5 51.3, -0.5 51.7, 0.3 51.7, 0.3 51.3, -0.5 51.3))',
+            $wkt
+        );
+    }
+
+    public function test_box_poly_ring_is_closed(): void
+    {
+        // First and last coordinates must be identical (valid closed ring)
+        $wkt = WhatJobsService::boxPoly(53.3, -3.0, 53.8, -2.5);
+        preg_match_all('/-?\d+\.?\d*\s+-?\d+\.?\d*/', $wkt, $m);
+        $this->assertCount(5, $m[0], 'POLYGON ring should have 5 coordinate pairs');
+        $this->assertSame($m[0][0], $m[0][4], 'Ring must be closed: first = last coordinate');
+    }
+
+    public function test_box_poly_degenerate_point(): void
+    {
+        // Zero-area polygon (all corners identical) is structurally valid WKT
+        $wkt = WhatJobsService::boxPoly(51.5, -0.1, 51.5, -0.1);
+        $this->assertSame(
+            'POLYGON((-0.1 51.5, -0.1 51.5, -0.1 51.5, -0.1 51.5, -0.1 51.5))',
+            $wkt
+        );
+    }
+
+    public function test_box_poly_all_negative_coords(): void
+    {
+        $wkt = WhatJobsService::boxPoly(-55.0, -10.0, -50.0, -5.0);
+        $this->assertStringStartsWith('POLYGON((', $wkt);
+        $this->assertStringEndsWith('))', $wkt);
+        $this->assertStringContainsString('-55', $wkt);
+        $this->assertStringContainsString('-50', $wkt);
+    }
+
+    // =========================================================================
+    // canonicalJobTitle — null / empty / whitespace guard
+    // =========================================================================
+
+    public function test_canonical_null_returns_null(): void
+    {
+        $svc = new WhatJobsService();
+        $this->assertNull($svc->canonicalJobTitle(null));
+    }
+
+    public function test_canonical_empty_string_returns_null(): void
+    {
+        $svc = new WhatJobsService();
+        $this->assertNull($svc->canonicalJobTitle(''));
+    }
+
+    public function test_canonical_no_matching_title_returns_null(): void
+    {
+        $svc = new WhatJobsService();
+        $this->assertNull($svc->canonicalJobTitle('Quantum Entanglement Specialist'));
+    }
+
+    // =========================================================================
+    // canonicalJobTitle — exact canonical matches (table-driven)
+    // =========================================================================
+
+    public static function exactCanonicalProvider(): array
+    {
+        return [
+            'exact title unchanged'           => ['Software Engineer',     'Software Engineer'],
+            'lowercase input'                  => ['software engineer',     'Software Engineer'],
+            'uppercase input'                  => ['SOFTWARE ENGINEER',     'Software Engineer'],
+            'mixed case'                       => ['sOfTwArE eNgInEeR',     'Software Engineer'],
+            'nurse'                            => ['Nurse',                  'Nurse'],
+            'chef'                             => ['Chef',                   'Chef'],
+            'accountant'                       => ['Accountant',             'Accountant'],
+            'team leader'                      => ['Team Leader',            'Team Leader'],
+            'project manager'                  => ['Project Manager',        'Project Manager'],
+            'teaching assistant'               => ['Teaching Assistant',     'Teaching Assistant'],
+            'receptionist'                     => ['Receptionist',           'Receptionist'],
+            'warehouse operative'              => ['Warehouse Operative',    'Warehouse Operative'],
+            'quantity surveyor'                => ['Quantity Surveyor',      'Quantity Surveyor'],
+        ];
+    }
+
+    #[DataProvider('exactCanonicalProvider')]
+    public function test_canonical_exact_match(string $input, string $expected): void
+    {
+        $svc = new WhatJobsService();
+        $this->assertSame($expected, $svc->canonicalJobTitle($input));
+    }
+
+    // =========================================================================
+    // canonicalJobTitle — string cleaning before canonical lookup
+    // =========================================================================
+
+    public static function suffixStrippingProvider(): array
+    {
+        return [
+            // Trailing " - Capitalised Company Name" is stripped by first regex
+            'trailing capitalised company' => [
+                'Software Engineer - Acme Corp',
+                'Software Engineer',
+            ],
+            // Parenthetical content (e.g. contract type) removed
+            'parenthetical content' => [
+                'Software Engineer (Full Stack)',
+                'Software Engineer',
+            ],
+            // " - IKEA <city> Store" removed (case-insensitive)
+            'ikea store suffix' => [
+                'Shift Leader - IKEA Leeds Store',
+                'Shift Leader',
+            ],
+            // " - <word>, <word>shire" removed
+            'county suffix' => [
+                'Nurse - Birmingham, Warwickshire',
+                'Nurse',
+            ],
+            // " - Haven" removed
+            'haven suffix' => [
+                'Chef - Haven',
+                'Chef',
+            ],
+            // " - <word> College ..." removed
+            'college suffix' => [
+                'Lecturer - City College',
+                'Lecturer',
+            ],
+            // Combination: trailing company + parenthetical
+            'parenthetical then lookup' => [
+                'Accountant (Part Time)',
+                'Accountant',
+            ],
+        ];
+    }
+
+    #[DataProvider('suffixStrippingProvider')]
+    public function test_canonical_suffix_stripping(string $input, string $expected): void
+    {
+        $svc = new WhatJobsService();
+        $this->assertSame($expected, $svc->canonicalJobTitle($input));
+    }
+
+    // =========================================================================
+    // canonicalJobTitle — keyword-map matches (table-driven)
+    // =========================================================================
+
+    public static function keywordMapProvider(): array
+    {
+        return [
+            'hgv class 1 driver'                  => ['HGV Class 1 Tipper Driver',         'HGV Class 1 Driver'],
+            'hgv class 2 driver'                  => ['HGV Class 2 Distribution Driver',    'HGV Class 2 Driver'],
+            'delivery driver keyword'              => ['Overnight Delivery Driver',           'Delivery Driver'],
+            'machine learning keyword'             => ['Machine Learning Researcher',          'Machine Learning Engineer'],
+            'data analyst keyword'                 => ['Senior Data Analyst Role',             'Data Analyst'],
+            'software engineer keyword'            => ['Lead Software Engineer',               'Software Engineer'],
+            'care assistant keyword'               => ['Domiciliary Care Assistant',           'Care Assistant'],
+            'support worker keyword'               => ['Specialist Support Worker',            'Support Worker'],
+            'customer service keyword'             => ['Customer Service Representative',      'Customer Service Advisor'],
+            'sales executive keyword'              => ['Graduate Sales Executive',             'Sales Executive'],
+            'teaching assistant keyword'           => ['Primary Teaching Assistant',           'Teaching Assistant'],
+            'welder keyword'                       => ['MIG Welder - Permanent',               'Welder'],
+            'forklift keyword'                     => ['Counterbalance Forklift Operator',     'Forklift Driver'],
+            'reach truck keyword'                  => ['Reach Truck Operator AM Shift',        'Reach Truck Driver'],
+            'embedded software keyword'            => ['Embedded Software Developer',          'Embedded Software Engineer'],
+            'hr business partner keyword'          => ['HR Business Partner - FMCG',           'HR Business Partner'],
+            'management accountant keyword'        => ['Part Qualified Management Accountant', 'Management Accountant'],
+        ];
+    }
+
+    #[DataProvider('keywordMapProvider')]
+    public function test_canonical_keyword_map_match(string $input, string $expected): void
+    {
+        $svc = new WhatJobsService();
+        $this->assertSame($expected, $svc->canonicalJobTitle($input));
+    }
+
+    // =========================================================================
+    // parseFeed — format 2 (ClickCast) happy path
+    // =========================================================================
+
+    public function test_parse_feed_format2_yields_valid_job(): void
+    {
+        $geo = [51.3, -0.5, 51.7, 0.3, WhatJobsService::boxPoly(51.3, -0.5, 51.7, 0.3)];
+        $svc = $this->makeServiceWithFixedGeocode($geo);
+
+        $xml  = $this->makeFeedXml([[
+            'job_reference' => 'JOB001',
+            'title'         => 'Software Engineer',
+            'city'          => 'London',
+            'state'         => 'England',
+            'country'       => 'UK',
+            'cpc'           => '0.50',
+            'posted_at'     => date('Y-m-d'),
+            'body'          => 'Great software role in London',
+            'location'      => 'London, England',
+            'company'       => 'ACME Ltd',
+            'url'           => 'https://example.com/jobs/1',
+        ]]);
+        $path = $this->makeFeedFile($xml);
+        $cache = [];
+
+        try {
+            $jobs = iterator_to_array($svc->parseFeed($path, 2, $cache));
+
+            $this->assertCount(1, $jobs);
+            $this->assertSame('JOB001',            $jobs[0]['job_reference']);
+            $this->assertSame('Software Engineer', $jobs[0]['title']);
+            $this->assertSame('Software Engineer', $jobs[0]['canonical_title']);
+            $this->assertSame(0.50,                $jobs[0]['cpc']);
+            $this->assertSame(1,                   $jobs[0]['visible']);
+            $this->assertSame(1,                   $jobs[0]['clickability']);
+            $this->assertStringStartsWith('POLYGON(', $jobs[0]['geometry']);
+            $this->assertNotNull($jobs[0]['bodyhash']);
+            $this->assertSame(32, strlen($jobs[0]['bodyhash'])); // MD5 length
+        } finally {
+            @unlink($path);
+        }
+    }
+
+    public function test_parse_feed_format2_multiple_jobs_all_yielded(): void
+    {
+        $geo = [51.3, -0.5, 51.7, 0.3, WhatJobsService::boxPoly(51.3, -0.5, 51.7, 0.3)];
+        $svc = $this->makeServiceWithFixedGeocode($geo);
+
+        $jobDefs = [
+            ['job_reference' => 'J1', 'title' => 'Chef',         'cpc' => '0.20'],
+            ['job_reference' => 'J2', 'title' => 'Nurse',        'cpc' => '0.50'],
+            ['job_reference' => 'J3', 'title' => 'Accountant',   'cpc' => '1.00'],
+        ];
+        foreach ($jobDefs as &$j) {
+            $j += ['city' => 'London', 'state' => 'England', 'country' => 'UK', 'posted_at' => date('Y-m-d')];
+        }
+
+        $path  = $this->makeFeedFile($this->makeFeedXml($jobDefs));
+        $cache = [];
+
+        try {
+            $jobs = iterator_to_array($svc->parseFeed($path, 2, $cache));
+            $this->assertCount(3, $jobs);
+            $this->assertSame(['J1', 'J2', 'J3'], array_column($jobs, 'job_reference'));
+        } finally {
+            @unlink($path);
+        }
+    }
+
+    // =========================================================================
+    // parseFeed — format 1 (WhatJobs) happy path
+    // =========================================================================
+
+    public function test_parse_feed_format1_yields_valid_job(): void
+    {
+        $geo = [53.4, -2.2, 53.6, -2.0, WhatJobsService::boxPoly(53.4, -2.2, 53.6, -2.0)];
+        $svc = $this->makeServiceWithFixedGeocode($geo);
+
+        $xml  = $this->makeFeedXml([[
+            'id'          => 'F1JOB001',
+            'title'       => 'Nurse',
+            'city'        => 'Manchester',
+            'state'       => 'England',
+            'country'     => 'UK',
+            'cpc'         => '0.75',
+            'timePosted'  => date('Y-m-d'),
+            'body'        => 'Hospital nursing vacancy',
+            'company'     => 'NHS',
+            'url'         => 'https://example.com/jobs/f1/1',
+        ]], format: 1);
+        $path  = $this->makeFeedFile($xml);
+        $cache = [];
+
+        try {
+            $jobs = iterator_to_array($svc->parseFeed($path, 1, $cache));
+
+            $this->assertCount(1, $jobs);
+            $this->assertSame('F1JOB001', $jobs[0]['job_reference']);
+            $this->assertSame('Nurse',    $jobs[0]['title']);
+            $this->assertSame('Nurse',    $jobs[0]['canonical_title']);
+            $this->assertSame(0.75,       $jobs[0]['cpc']);
+        } finally {
+            @unlink($path);
+        }
+    }
+
+    // =========================================================================
+    // parseFeed — filter: low CPC
+    // =========================================================================
+
+    public function test_parse_feed_skips_cpc_below_minimum(): void
+    {
+        $geo = [51.3, -0.5, 51.7, 0.3, WhatJobsService::boxPoly(51.3, -0.5, 51.7, 0.3)];
+        $svc = $this->makeServiceWithFixedGeocode($geo);
+
+        // MINIMUM_CPC = 0.10; use 0.09 to go under
+        $xml  = $this->makeFeedXml([[
+            'job_reference' => 'LOWCPC1',
+            'title'         => 'Driver',
+            'city'          => 'London',
+            'state'         => 'England',
+            'country'       => 'UK',
+            'cpc'           => '0.09',
+            'posted_at'     => date('Y-m-d'),
+        ]]);
+        $path  = $this->makeFeedFile($xml);
+        $cache = [];
+
+        try {
+            $jobs = iterator_to_array($svc->parseFeed($path, 2, $cache));
+            $this->assertCount(0, $jobs);
+        } finally {
+            @unlink($path);
+        }
+    }
+
+    public function test_parse_feed_accepts_cpc_at_minimum(): void
+    {
+        $geo = [51.3, -0.5, 51.7, 0.3, WhatJobsService::boxPoly(51.3, -0.5, 51.7, 0.3)];
+        $svc = $this->makeServiceWithFixedGeocode($geo);
+
+        $xml  = $this->makeFeedXml([[
+            'job_reference' => 'MINCPC1',
+            'title'         => 'Accountant',
+            'city'          => 'London',
+            'state'         => 'England',
+            'country'       => 'UK',
+            'cpc'           => '0.10',          // exactly at threshold
+            'posted_at'     => date('Y-m-d'),
+        ]]);
+        $path  = $this->makeFeedFile($xml);
+        $cache = [];
+
+        try {
+            $jobs = iterator_to_array($svc->parseFeed($path, 2, $cache));
+            $this->assertCount(1, $jobs);
+        } finally {
+            @unlink($path);
+        }
+    }
+
+    // =========================================================================
+    // parseFeed — filter: missing job ID
+    // =========================================================================
+
+    public function test_parse_feed_skips_empty_job_reference(): void
+    {
+        $geo  = [51.3, -0.5, 51.7, 0.3, WhatJobsService::boxPoly(51.3, -0.5, 51.7, 0.3)];
+        $svc  = $this->makeServiceWithFixedGeocode($geo);
+
+        $xml  = $this->makeFeedXml([[
+            'job_reference' => '',          // empty → skipped
+            'title'         => 'Driver',
+            'city'          => 'London',
+            'state'         => 'England',
+            'country'       => 'UK',
+            'cpc'           => '0.50',
+            'posted_at'     => date('Y-m-d'),
+        ]]);
+        $path  = $this->makeFeedFile($xml);
+        $cache = [];
+
+        try {
+            $jobs = iterator_to_array($svc->parseFeed($path, 2, $cache));
+            $this->assertCount(0, $jobs);
+        } finally {
+            @unlink($path);
+        }
+    }
+
+    // =========================================================================
+    // parseFeed — filter: too old
+    // =========================================================================
+
+    public function test_parse_feed_skips_postings_older_than_max_age(): void
+    {
+        $geo  = [51.3, -0.5, 51.7, 0.3, WhatJobsService::boxPoly(51.3, -0.5, 51.7, 0.3)];
+        $svc  = $this->makeServiceWithFixedGeocode($geo);
+
+        $xml  = $this->makeFeedXml([[
+            'job_reference' => 'OLD001',
+            'title'         => 'Nurse',
+            'city'          => 'London',
+            'state'         => 'England',
+            'country'       => 'UK',
+            'cpc'           => '0.50',
+            'posted_at'     => '2020-01-01',    // well beyond MAX_AGE_DAYS (7)
+        ]]);
+        $path  = $this->makeFeedFile($xml);
+        $cache = [];
+
+        try {
+            $jobs = iterator_to_array($svc->parseFeed($path, 2, $cache));
+            $this->assertCount(0, $jobs);
+        } finally {
+            @unlink($path);
+        }
+    }
+
+    public function test_parse_feed_accepts_job_with_no_date(): void
+    {
+        // Empty posted_at → strtotime('') is false → condition never fires → kept
+        $geo  = [51.3, -0.5, 51.7, 0.3, WhatJobsService::boxPoly(51.3, -0.5, 51.7, 0.3)];
+        $svc  = $this->makeServiceWithFixedGeocode($geo);
+
+        $xml  = $this->makeFeedXml([[
+            'job_reference' => 'NODATE1',
+            'title'         => 'Chef',
+            'city'          => 'London',
+            'state'         => 'England',
+            'country'       => 'UK',
+            'cpc'           => '0.50',
+            'posted_at'     => '',              // no date → not filtered by age
+        ]]);
+        $path  = $this->makeFeedFile($xml);
+        $cache = [];
+
+        try {
+            $jobs = iterator_to_array($svc->parseFeed($path, 2, $cache));
+            $this->assertCount(1, $jobs);
+        } finally {
+            @unlink($path);
+        }
+    }
+
+    // =========================================================================
+    // parseFeed — filter: geocode failure
+    // =========================================================================
+
+    public function test_parse_feed_skips_when_geocode_returns_null(): void
+    {
+        $svc  = $this->makeServiceWithFixedGeocode(null); // always fails geocoding
+
+        $xml  = $this->makeFeedXml([[
+            'job_reference' => 'GEO001',
+            'title'         => 'Chef',
+            'city'          => 'UnknownCity',
+            'state'         => 'Unknown',
+            'country'       => 'UK',
+            'cpc'           => '0.50',
+            'posted_at'     => date('Y-m-d'),
+        ]]);
+        $path  = $this->makeFeedFile($xml);
+        $cache = [];
+
+        try {
+            $jobs = iterator_to_array($svc->parseFeed($path, 2, $cache));
+            $this->assertCount(0, $jobs);
+        } finally {
+            @unlink($path);
+        }
+    }
+
+    // =========================================================================
+    // parseFeed — body and bodyhash
+    // =========================================================================
+
+    public function test_parse_feed_body_present_yields_md5_hash(): void
+    {
+        $geo  = [51.3, -0.5, 51.7, 0.3, WhatJobsService::boxPoly(51.3, -0.5, 51.7, 0.3)];
+        $svc  = $this->makeServiceWithFixedGeocode($geo);
+
+        $xml  = $this->makeFeedXml([[
+            'job_reference' => 'HASH001',
+            'title'         => 'Software Engineer',
+            'city'          => 'London',
+            'state'         => 'England',
+            'country'       => 'UK',
+            'cpc'           => '0.50',
+            'posted_at'     => date('Y-m-d'),
+            'body'          => 'Exciting software engineering role at a tech company',
+        ]]);
+        $path  = $this->makeFeedFile($xml);
+        $cache = [];
+
+        try {
+            $jobs = iterator_to_array($svc->parseFeed($path, 2, $cache));
+            $this->assertCount(1, $jobs);
+            $this->assertNotNull($jobs[0]['bodyhash']);
+            $this->assertSame(32, strlen($jobs[0]['bodyhash']), 'bodyhash must be MD5 (32 hex chars)');
+        } finally {
+            @unlink($path);
+        }
+    }
+
+    public function test_parse_feed_empty_body_yields_null_hash(): void
+    {
+        $geo  = [51.3, -0.5, 51.7, 0.3, WhatJobsService::boxPoly(51.3, -0.5, 51.7, 0.3)];
+        $svc  = $this->makeServiceWithFixedGeocode($geo);
+
+        $xml  = $this->makeFeedXml([[
+            'job_reference' => 'NOBOD1',
+            'title'         => 'Chef',
+            'city'          => 'London',
+            'state'         => 'England',
+            'country'       => 'UK',
+            'cpc'           => '0.50',
+            'posted_at'     => date('Y-m-d'),
+            'body'          => '',              // empty body
+        ]]);
+        $path  = $this->makeFeedFile($xml);
+        $cache = [];
+
+        try {
+            $jobs = iterator_to_array($svc->parseFeed($path, 2, $cache));
+            $this->assertCount(1, $jobs);
+            $this->assertNull($jobs[0]['bodyhash']);
+        } finally {
+            @unlink($path);
+        }
+    }
+
+    // =========================================================================
+    // parseFeed — edge cases
+    // =========================================================================
+
+    public function test_parse_feed_missing_file_yields_empty_generator(): void
+    {
+        // TODO: latent bug — XMLReader::open() on a non-existent file emits E_WARNING
+        // which Laravel's error handler converts to ErrorException; the production
+        // `if (!$reader->open($filePath)) { return; }` guard is never reached because
+        // the exception is thrown before the if-check executes.  In practice parseFeed
+        // is only called with files returned by downloadFeed() (never null/missing), so
+        // this path never fires in production, but the Log::warning guard is dead code.
+        $this->markTestSkipped(
+            'XMLReader::open() throws ErrorException on missing file in this environment; '
+            . 'production guard is unreachable (see latent bug TODO above).'
+        );
+    }
+
+    public function test_parse_feed_empty_xml_file_yields_nothing(): void
+    {
+        $svc   = $this->makeServiceWithFixedGeocode(null);
+        $path  = $this->makeFeedFile('');
+        $cache = [];
+
+        try {
+            $jobs = iterator_to_array($svc->parseFeed($path, 2, $cache));
+            $this->assertCount(0, $jobs);
+        } finally {
+            @unlink($path);
+        }
+    }
+
+    public function test_parse_feed_mixed_valid_and_filtered_jobs(): void
+    {
+        // Three jobs: one valid, one low-CPC, one too-old
+        // Only the first should be yielded.
+        $geo  = [51.3, -0.5, 51.7, 0.3, WhatJobsService::boxPoly(51.3, -0.5, 51.7, 0.3)];
+        $svc  = $this->makeServiceWithFixedGeocode($geo);
+
+        $xml  = $this->makeFeedXml([
+            [
+                'job_reference' => 'VALID1',
+                'title'         => 'Chef',
+                'city'          => 'London',
+                'state'         => 'England',
+                'country'       => 'UK',
+                'cpc'           => '0.50',
+                'posted_at'     => date('Y-m-d'),
+            ],
+            [
+                'job_reference' => 'LOWCPC',
+                'title'         => 'Driver',
+                'city'          => 'London',
+                'state'         => 'England',
+                'country'       => 'UK',
+                'cpc'           => '0.01',
+                'posted_at'     => date('Y-m-d'),
+            ],
+            [
+                'job_reference' => 'OLDONE',
+                'title'         => 'Nurse',
+                'city'          => 'London',
+                'state'         => 'England',
+                'country'       => 'UK',
+                'cpc'           => '0.50',
+                'posted_at'     => '2019-06-01',
+            ],
+        ]);
+        $path  = $this->makeFeedFile($xml);
+        $cache = [];
+
+        try {
+            $jobs = iterator_to_array($svc->parseFeed($path, 2, $cache));
+            $this->assertCount(1, $jobs);
+            $this->assertSame('VALID1', $jobs[0]['job_reference']);
+        } finally {
+            @unlink($path);
+        }
+    }
+
+    public function test_parse_feed_html_entities_in_title_decoded(): void
+    {
+        $geo  = [51.3, -0.5, 51.7, 0.3, WhatJobsService::boxPoly(51.3, -0.5, 51.7, 0.3)];
+        $svc  = $this->makeServiceWithFixedGeocode($geo);
+
+        // The XML helper will HTML-encode the &amp; entity; parseFeed must decode it
+        $xml  = $this->makeFeedXml([[
+            'job_reference' => 'ENT001',
+            'title'         => 'Sales &amp; Marketing Manager',
+            'city'          => 'London',
+            'state'         => 'England',
+            'country'       => 'UK',
+            'cpc'           => '0.50',
+            'posted_at'     => date('Y-m-d'),
+        ]]);
+        $path  = $this->makeFeedFile($xml);
+        $cache = [];
+
+        try {
+            $jobs = iterator_to_array($svc->parseFeed($path, 2, $cache));
+            $this->assertCount(1, $jobs);
+            // After html_entity_decode, & should be present in the title
+            $this->assertStringContainsString('&', $jobs[0]['title']);
+        } finally {
+            @unlink($path);
+        }
+    }
+}


### PR DESCRIPTION
## Coverage added
Module: `iznik-batch/app/Services/WhatJobsService.php`
Coverage before: 73.7%
Coverage after: 77.3%
Delta: +3.6%

## Tests added
| Function | Scenario | File:Line |
|---|---|---|
| `boxPoly()` | Returns correct WKT POLYGON string | WhatJobsServiceTest.php:115 |
| `boxPoly()` | Ring is closed (first = last coordinate) | WhatJobsServiceTest.php:123 |
| `boxPoly()` | Degenerate point (zero area) | WhatJobsServiceTest.php:131 |
| `boxPoly()` | All-negative coordinates | WhatJobsServiceTest.php:138 |
| `canonicalJobTitle()` | null → null | WhatJobsServiceTest.php:149 |
| `canonicalJobTitle()` | empty string → null | WhatJobsServiceTest.php:155 |
| `canonicalJobTitle()` | unrecognised title → null | WhatJobsServiceTest.php:161 |
| `canonicalJobTitle()` | 13 exact-match cases (table-driven) | WhatJobsServiceTest.php:167–189 |
| `canonicalJobTitle()` | 7 suffix-stripping cases (company, parens, IKEA, county, haven, college) | WhatJobsServiceTest.php:191–232 |
| `canonicalJobTitle()` | 17 keyword-map match cases (table-driven) | WhatJobsServiceTest.php:234–278 |
| `parseFeed()` | Format-2 happy path yields valid job with all fields | WhatJobsServiceTest.php:290 |
| `parseFeed()` | Format-2 multiple jobs all yielded | WhatJobsServiceTest.php:321 |
| `parseFeed()` | Format-1 happy path yields valid job | WhatJobsServiceTest.php:344 |
| `parseFeed()` | Skips jobs with CPC below MINIMUM_CPC (0.10) | WhatJobsServiceTest.php:374 |
| `parseFeed()` | Accepts jobs with CPC exactly at MINIMUM_CPC | WhatJobsServiceTest.php:395 |
| `parseFeed()` | Skips jobs with empty job_reference | WhatJobsServiceTest.php:418 |
| `parseFeed()` | Skips jobs older than MAX_AGE_DAYS (7) | WhatJobsServiceTest.php:443 |
| `parseFeed()` | Accepts jobs with no posted_at date | WhatJobsServiceTest.php:463 |
| `parseFeed()` | Skips when geocodeCityState returns null | WhatJobsServiceTest.php:486 |
| `parseFeed()` | Non-empty body yields 32-char MD5 bodyhash | WhatJobsServiceTest.php:503 |
| `parseFeed()` | Empty body yields null bodyhash | WhatJobsServiceTest.php:527 |
| `parseFeed()` | Empty XML file yields nothing | WhatJobsServiceTest.php:551 |
| `parseFeed()` | Mixed valid/filtered jobs — only valid yielded | WhatJobsServiceTest.php:560 |
| `parseFeed()` | HTML entities in title decoded | WhatJobsServiceTest.php:599 |

## Latent bugs found
| Function | Description |
|---|---|
| `parseFeed()` | `XMLReader::open()` on a missing file emits `E_WARNING` which Laravel's error handler converts to `ErrorException`; the production guard `if (!open()) { Log::warning; return; }` is never reached because the exception is thrown before the `if` check executes. The `Log::warning` call is dead code in Laravel environments. In practice, `parseFeed()` is only ever called with a path returned by `downloadFeed()` (never with a missing file), so this has no production impact. Test marked `skipped` with TODO comment. |

## No production code changed
All changes are in test files only (`*Test.php`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)