### PR TITLE
test(go): add coverage for message package pure functions

### DIFF
--- a/iznik-server-go/message/message_list_pure_test.go
+++ b/iznik-server-go/message/message_list_pure_test.go
@@ -1,0 +1,202 @@
+package message
+
+// Tests for pure (no-DB) functions in message_list.go.
+// buildMTUnionAllMsgIDQuery is a pure SQL-builder: no database or fiber context needed.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// branchSQL with a single %GID% placeholder, one extra arg, plus the trailing LIMIT arg.
+const testBranchSQL = "SELECT mg.msgid, mg.arrival FROM messages_groups mg WHERE mg.groupid = %GID% AND mg.collection = ? ORDER BY mg.arrival DESC, mg.msgid DESC LIMIT ?"
+
+// TestBuildMTUnionAllMsgIDQuery_SingleGroup verifies the output for a single group ID.
+func TestBuildMTUnionAllMsgIDQuery_SingleGroup(t *testing.T) {
+	branchArgs := []interface{}{"Pending"}
+	groupIDs := []uint64{42}
+	limit := 10
+
+	sql, args := buildMTUnionAllMsgIDQuery(testBranchSQL, branchArgs, groupIDs, limit)
+
+	// Outer structure must wrap a UNION ALL in a subquery.
+	assert.Contains(t, sql, "SELECT msgid FROM (")
+	assert.Contains(t, sql, "GROUP BY msgid")
+	assert.Contains(t, sql, "ORDER BY arrival DESC, msgid DESC LIMIT ?")
+
+	// %GID% must be substituted with the actual group ID.
+	assert.Contains(t, sql, "groupid = 42")
+	assert.NotContains(t, sql, "%GID%")
+
+	// Single group: no UNION ALL needed.
+	assert.NotContains(t, sql, "UNION ALL")
+
+	// Args: branchArgs (1) + limit per branch (1) + outer limit (1) = 3.
+	assert.Len(t, args, 3)
+	assert.Equal(t, "Pending", args[0])
+	assert.Equal(t, limit, args[1])
+	assert.Equal(t, limit, args[2])
+}
+
+// TestBuildMTUnionAllMsgIDQuery_TwoGroups verifies UNION ALL appears once for two groups.
+func TestBuildMTUnionAllMsgIDQuery_TwoGroups(t *testing.T) {
+	branchArgs := []interface{}{"Approved"}
+	groupIDs := []uint64{10, 20}
+	limit := 50
+
+	sql, args := buildMTUnionAllMsgIDQuery(testBranchSQL, branchArgs, groupIDs, limit)
+
+	// Two groups → one UNION ALL.
+	assert.Equal(t, 1, strings.Count(sql, "UNION ALL"))
+
+	// Both group IDs must appear.
+	assert.Contains(t, sql, "groupid = 10")
+	assert.Contains(t, sql, "groupid = 20")
+
+	// Args: 2 * (branchArgs(1) + limit(1)) + outer limit(1) = 5.
+	assert.Len(t, args, 5)
+	assert.Equal(t, limit, args[len(args)-1])
+}
+
+// TestBuildMTUnionAllMsgIDQuery_ThreeGroups verifies two UNION ALLs for three groups.
+func TestBuildMTUnionAllMsgIDQuery_ThreeGroups(t *testing.T) {
+	branchArgs := []interface{}{"Pending"}
+	groupIDs := []uint64{1, 2, 3}
+	limit := 25
+
+	sql, args := buildMTUnionAllMsgIDQuery(testBranchSQL, branchArgs, groupIDs, limit)
+
+	assert.Equal(t, 2, strings.Count(sql, "UNION ALL"))
+	assert.Contains(t, sql, "groupid = 1")
+	assert.Contains(t, sql, "groupid = 2")
+	assert.Contains(t, sql, "groupid = 3")
+
+	// Args: 3 * (1 + 1) + 1 = 7.
+	assert.Len(t, args, 7)
+}
+
+// TestBuildMTUnionAllMsgIDQuery_EmptyGroups returns a degenerate query that won't match anything.
+func TestBuildMTUnionAllMsgIDQuery_EmptyGroups(t *testing.T) {
+	branchArgs := []interface{}{"Approved"}
+	groupIDs := []uint64{}
+	limit := 10
+
+	sql, args := buildMTUnionAllMsgIDQuery(testBranchSQL, branchArgs, groupIDs, limit)
+
+	// No branches → no UNION ALL, no groupid substitution.
+	assert.NotContains(t, sql, "UNION ALL")
+	assert.NotContains(t, sql, "%GID%")
+
+	// Only the outer LIMIT arg is appended.
+	assert.Len(t, args, 1)
+	assert.Equal(t, limit, args[0])
+}
+
+// TestBuildMTUnionAllMsgIDQuery_MultipleBranchArgs verifies multiple per-branch args are replicated.
+func TestBuildMTUnionAllMsgIDQuery_MultipleBranchArgs(t *testing.T) {
+	// Branch SQL with two ? args (before the trailing LIMIT).
+	branchSQL := "SELECT mg.msgid, mg.arrival FROM messages_groups mg WHERE mg.groupid = %GID% AND mg.collection = ? AND mg.deleted = ? ORDER BY mg.arrival DESC, mg.msgid DESC LIMIT ?"
+	branchArgs := []interface{}{"Pending", 0}
+	groupIDs := []uint64{5, 6}
+	limit := 20
+
+	sql, args := buildMTUnionAllMsgIDQuery(branchSQL, branchArgs, groupIDs, limit)
+
+	assert.Equal(t, 1, strings.Count(sql, "UNION ALL"))
+
+	// Args: 2 * (2 + 1) + 1 = 7.
+	assert.Len(t, args, 7)
+	// First branch: "Pending", 0, limit
+	assert.Equal(t, "Pending", args[0])
+	assert.Equal(t, 0, args[1])
+	assert.Equal(t, limit, args[2])
+	// Second branch: same
+	assert.Equal(t, "Pending", args[3])
+	assert.Equal(t, 0, args[4])
+	assert.Equal(t, limit, args[5])
+	// Outer limit.
+	assert.Equal(t, limit, args[6])
+}
+
+// TestBuildMTUnionAllMsgIDQuery_GIDSubstitutionIsExact verifies substitution is exact (not partial).
+func TestBuildMTUnionAllMsgIDQuery_GIDSubstitutionIsExact(t *testing.T) {
+	branchSQL := "SELECT mgid, arr FROM mg WHERE groupid = %GID% LIMIT ?"
+	groupIDs := []uint64{999}
+	limit := 5
+
+	sql, _ := buildMTUnionAllMsgIDQuery(branchSQL, nil, groupIDs, limit)
+
+	assert.Contains(t, sql, "groupid = 999")
+	assert.NotContains(t, sql, "%GID%")
+}
+
+// TestBuildMTUnionAllMsgIDQuery_OuterQueryStructure checks the overall SQL wrapping.
+func TestBuildMTUnionAllMsgIDQuery_OuterQueryStructure(t *testing.T) {
+	branchArgs := []interface{}{}
+	groupIDs := []uint64{7}
+	limit := 30
+
+	branchSQL := "SELECT mg.msgid, mg.arrival FROM messages_groups mg WHERE mg.groupid = %GID% ORDER BY mg.arrival DESC, mg.msgid DESC LIMIT ?"
+	sql, _ := buildMTUnionAllMsgIDQuery(branchSQL, branchArgs, groupIDs, limit)
+
+	// The outermost query selects msgid from the inner.
+	assert.True(t, strings.HasPrefix(sql, "SELECT msgid FROM ("))
+	// Final clause: ORDER BY arrival, then limit placeholder.
+	assert.True(t, strings.HasSuffix(strings.TrimSpace(sql), "LIMIT ?"))
+}
+
+// TestBuildMTUnionAllMsgIDQuery_BranchesParenthesized verifies each branch is wrapped in ().
+func TestBuildMTUnionAllMsgIDQuery_BranchesParenthesized(t *testing.T) {
+	branchSQL := "SELECT mg.msgid, mg.arrival FROM messages_groups mg WHERE mg.groupid = %GID% ORDER BY mg.arrival DESC LIMIT ?"
+	groupIDs := []uint64{1, 2}
+	limit := 10
+
+	sql, _ := buildMTUnionAllMsgIDQuery(branchSQL, nil, groupIDs, limit)
+
+	// Both branches should be wrapped in parentheses.
+	// Check that "( SELECT" or "(SELECT" appears at least twice.
+	openParens := strings.Count(sql, "(SELECT") + strings.Count(sql, "( SELECT")
+	assert.GreaterOrEqual(t, openParens, 2, "each branch must be parenthesized")
+}
+
+// TestBuildMTUnionAllMsgIDQuery_LimitIsLastArg verifies the outer LIMIT arg is the last element.
+func TestBuildMTUnionAllMsgIDQuery_LimitIsLastArg(t *testing.T) {
+	branchArgs := []interface{}{"x"}
+	groupIDs := []uint64{100, 200}
+	limit := 77
+
+	_, args := buildMTUnionAllMsgIDQuery(testBranchSQL, branchArgs, groupIDs, limit)
+
+	assert.Equal(t, limit, args[len(args)-1], "outer LIMIT must be the last arg")
+}
+
+// TestBuildMTUnionAllMsgIDQuery_NilBranchArgs handles nil branchArgs gracefully.
+func TestBuildMTUnionAllMsgIDQuery_NilBranchArgs(t *testing.T) {
+	branchSQL := "SELECT mg.msgid, mg.arrival FROM mg WHERE mg.groupid = %GID% ORDER BY mg.arrival DESC LIMIT ?"
+	groupIDs := []uint64{42}
+	limit := 5
+
+	sql, args := buildMTUnionAllMsgIDQuery(branchSQL, nil, groupIDs, limit)
+
+	assert.Contains(t, sql, "groupid = 42")
+	// Args: nil branchArgs → 0 per branch, plus limit per branch (1) + outer limit (1) = 2.
+	assert.Len(t, args, 2)
+	assert.Equal(t, limit, args[0])
+	assert.Equal(t, limit, args[1])
+}
+
+// TestBuildMTUnionAllMsgIDQuery_ZeroLimitPropagatesToBranches ensures limit=0 propagates correctly.
+func TestBuildMTUnionAllMsgIDQuery_ZeroLimitPropagatesToBranches(t *testing.T) {
+	branchArgs := []interface{}{}
+	groupIDs := []uint64{1}
+	limit := 0
+
+	_, args := buildMTUnionAllMsgIDQuery(testBranchSQL, branchArgs, groupIDs, limit)
+
+	// Per-branch limit arg + outer limit arg.
+	for _, a := range args {
+		assert.Equal(t, 0, a)
+	}
+}

--- a/iznik-server-go/message/message_tablenames_test.go
+++ b/iznik-server-go/message/message_tablenames_test.go
@@ -1,0 +1,244 @@
+package message
+
+// Tests for pure functions that don't require a database connection:
+//   - isTNImageURL  (URL pattern matching)
+//   - TableName() methods on all ORM types
+//   - MessageAttachment.ComputeAI() (JSON-based field population)
+//
+// These tests live in the same package so they can reach unexported helpers.
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// ── TableName() ───────────────────────────────────────────────────────────────
+
+func TestMessageTableName(t *testing.T) {
+	// The ORM table name for Message must exactly match the DB table.
+	assert.Equal(t, "messages", Message{}.TableName())
+}
+
+func TestMessageAttachmentTableName(t *testing.T) {
+	assert.Equal(t, "messages_attachments", MessageAttachment{}.TableName())
+}
+
+func TestMessageGroupTableName(t *testing.T) {
+	assert.Equal(t, "messages_groups", MessageGroup{}.TableName())
+}
+
+func TestMessageOutcomeTableName(t *testing.T) {
+	assert.Equal(t, "messages_outcomes", MessageOutcome{}.TableName())
+}
+
+func TestMessagePromiseTableName(t *testing.T) {
+	assert.Equal(t, "messages_promises", MessagePromise{}.TableName())
+}
+
+func TestMessageReplyTableName(t *testing.T) {
+	// MessageReply rows are stored in the chat_messages table.
+	assert.Equal(t, "chat_messages", MessageReply{}.TableName())
+}
+
+// ── isTNImageURL ─────────────────────────────────────────────────────────────
+
+func TestIsTNImageURL_TrashNothingImgPath(t *testing.T) {
+	// Standard TN CDN path.
+	assert.True(t, isTNImageURL("https://trashnothing.com/img/abc123.jpg"))
+}
+
+func TestIsTNImageURL_ImgTrashNothingDomain(t *testing.T) {
+	// Subdomain CDN.
+	assert.True(t, isTNImageURL("https://img.trashnothing.com/photos/xyz.jpg"))
+}
+
+func TestIsTNImageURL_TNPhotosPath(t *testing.T) {
+	// Local /tn-photos/ path.
+	assert.True(t, isTNImageURL("https://www.example.com/tn-photos/image.jpg"))
+}
+
+func TestIsTNImageURL_PhotosTrashNothingDomain(t *testing.T) {
+	// photos subdomain.
+	assert.True(t, isTNImageURL("https://photos.trashnothing.com/abc/def.jpg"))
+}
+
+func TestIsTNImageURL_NonTNURL(t *testing.T) {
+	// Arbitrary external URL must not match.
+	assert.False(t, isTNImageURL("https://www.ilovefreegle.org/img/photo.jpg"))
+}
+
+func TestIsTNImageURL_EmptyString(t *testing.T) {
+	assert.False(t, isTNImageURL(""))
+}
+
+func TestIsTNImageURL_JustHostname(t *testing.T) {
+	// trashnothing.com without the /img/ path is NOT a TN image URL.
+	assert.False(t, isTNImageURL("https://trashnothing.com/"))
+}
+
+func TestIsTNImageURL_S3OrOtherHost(t *testing.T) {
+	assert.False(t, isTNImageURL("https://s3.amazonaws.com/freegle/images/foo.jpg"))
+}
+
+func TestIsTNImageURL_PartialMatch_TrashNothingInPath(t *testing.T) {
+	// The check is strings.Contains so a URL containing "trashnothing.com/img/" anywhere qualifies.
+	assert.True(t, isTNImageURL("http://cdn.example.com/trashnothing.com/img/pic.jpg"))
+}
+
+func TestIsTNImageURL_TNPhotosSubstring(t *testing.T) {
+	// /tn-photos/ anywhere in the URL triggers the rule.
+	assert.True(t, isTNImageURL("/tn-photos/image.png"))
+}
+
+func TestIsTNImageURL_ImgTNSubdomainWithPath(t *testing.T) {
+	// Deep path on img.trashnothing.com still matches.
+	assert.True(t, isTNImageURL("https://img.trashnothing.com/2024/01/15/photo.jpg"))
+}
+
+func TestIsTNImageURL_CaseVariation(t *testing.T) {
+	// The check is case-sensitive (uses plain Contains).
+	// "TRASHNOTHING.COM/IMG/" must NOT match because only lowercase is in the condition.
+	assert.False(t, isTNImageURL("https://TRASHNOTHING.COM/IMG/abc.jpg"))
+}
+
+// Table-driven — exhaustive coverage of all four isTNImageURL branches.
+
+var isTNImageURLTests = []struct {
+	name string
+	url  string
+	want bool
+}{
+	// Branch 1: trashnothing.com/img/
+	{"tn/img positive", "https://trashnothing.com/img/abc.jpg", true},
+	{"tn/img negative similar", "https://trashnothing.com/image/abc.jpg", false},
+
+	// Branch 2: img.trashnothing.com
+	{"img.tn positive", "https://img.trashnothing.com/x.jpg", true},
+	{"img.tn false friend", "https://img-trashnothing.com/x.jpg", false},
+
+	// Branch 3: /tn-photos/
+	{"tn-photos positive", "/tn-photos/foo.jpg", true},
+	{"tn-photos negative", "/photos/foo.jpg", false},
+
+	// Branch 4: photos.trashnothing.com
+	{"photos.tn positive", "https://photos.trashnothing.com/a/b.jpg", true},
+	{"photos.tn false friend", "https://photo.trashnothing.com/a/b.jpg", false},
+
+	// Empties / edge cases
+	{"empty string", "", false},
+	{"whitespace", "   ", false},
+}
+
+func TestIsTNImageURL_Table(t *testing.T) {
+	for _, tt := range isTNImageURLTests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isTNImageURL(tt.url), "url=%q", tt.url)
+		})
+	}
+}
+
+// ── MessageAttachment.ComputeAI() ────────────────────────────────────────────
+
+func TestComputeAI_BoolTrue(t *testing.T) {
+	a := MessageAttachment{Externalmods: json.RawMessage(`{"ai": true}`)}
+	a.ComputeAI()
+	assert.True(t, a.AI)
+}
+
+func TestComputeAI_BoolFalse(t *testing.T) {
+	a := MessageAttachment{Externalmods: json.RawMessage(`{"ai": false}`)}
+	a.ComputeAI()
+	assert.False(t, a.AI)
+}
+
+func TestComputeAI_Float64Nonzero(t *testing.T) {
+	// JSON number 1 unmarshals to float64; non-zero → true.
+	a := MessageAttachment{Externalmods: json.RawMessage(`{"ai": 1}`)}
+	a.ComputeAI()
+	assert.True(t, a.AI)
+}
+
+func TestComputeAI_Float64Zero(t *testing.T) {
+	// JSON 0 → float64(0) → false.
+	a := MessageAttachment{Externalmods: json.RawMessage(`{"ai": 0}`)}
+	a.ComputeAI()
+	assert.False(t, a.AI)
+}
+
+func TestComputeAI_AIFieldAbsent(t *testing.T) {
+	// No "ai" key → AI remains false.
+	a := MessageAttachment{Externalmods: json.RawMessage(`{"other": "value"}`)}
+	a.ComputeAI()
+	assert.False(t, a.AI)
+}
+
+func TestComputeAI_EmptyJSON(t *testing.T) {
+	a := MessageAttachment{Externalmods: json.RawMessage(`{}`)}
+	a.ComputeAI()
+	assert.False(t, a.AI)
+}
+
+func TestComputeAI_NilExternalmods(t *testing.T) {
+	// Nil slice → early return, no panic.
+	a := MessageAttachment{Externalmods: nil}
+	a.ComputeAI()
+	assert.False(t, a.AI)
+}
+
+func TestComputeAI_EmptyExternalmods(t *testing.T) {
+	a := MessageAttachment{Externalmods: json.RawMessage{}}
+	a.ComputeAI()
+	assert.False(t, a.AI)
+}
+
+func TestComputeAI_InvalidJSON(t *testing.T) {
+	// Malformed JSON → Unmarshal error → no panic, AI stays false.
+	a := MessageAttachment{Externalmods: json.RawMessage(`{not valid json}`)}
+	a.ComputeAI()
+	assert.False(t, a.AI)
+}
+
+func TestComputeAI_AINull(t *testing.T) {
+	// JSON null → interface{} nil → no case matched → AI stays false.
+	a := MessageAttachment{Externalmods: json.RawMessage(`{"ai": null}`)}
+	a.ComputeAI()
+	assert.False(t, a.AI)
+}
+
+func TestComputeAI_AIString(t *testing.T) {
+	// A JSON string is neither bool nor float64, so no case matches → false.
+	a := MessageAttachment{Externalmods: json.RawMessage(`{"ai": "yes"}`)}
+	a.ComputeAI()
+	assert.False(t, a.AI)
+}
+
+func TestComputeAI_ExtraFields(t *testing.T) {
+	// Extra fields must not interfere with the ai field.
+	a := MessageAttachment{Externalmods: json.RawMessage(`{"other":"data","count":3,"ai":true}`)}
+	a.ComputeAI()
+	assert.True(t, a.AI)
+}
+
+func TestComputeAI_CalledTwice(t *testing.T) {
+	// Idempotent: calling ComputeAI twice must not flip the value.
+	a := MessageAttachment{Externalmods: json.RawMessage(`{"ai": true}`)}
+	a.ComputeAI()
+	a.ComputeAI()
+	assert.True(t, a.AI)
+}
+
+func TestComputeAI_LargeFloat64(t *testing.T) {
+	// Any non-zero float64 should yield AI=true.
+	a := MessageAttachment{Externalmods: json.RawMessage(`{"ai": 99}`)}
+	a.ComputeAI()
+	assert.True(t, a.AI)
+}
+
+func TestComputeAI_NegativeFloat64(t *testing.T) {
+	// Negative non-zero float64 should also yield AI=true.
+	a := MessageAttachment{Externalmods: json.RawMessage(`{"ai": -1}`)}
+	a.ComputeAI()
+	assert.True(t, a.AI)
+}


### PR DESCRIPTION
## Coverage added
Module: `iznik-server-go/message`
Coverage before: 5.0%
Coverage after: 6.4%
Delta: +1.4%

## Tests added
| Function | Scenario | File:Line |
|---|---|---|
| `isTNImageURL` | TN CDN paths, img subdomain, tn-photos path, photos subdomain, non-TN URLs, empty string, case sensitivity | `message/message_tablenames_test.go:54` |
| `Message.TableName` | Returns 'messages' | `message/message_tablenames_test.go:19` |
| `MessageAttachment.TableName` | Returns 'messages_attachments' | `message/message_tablenames_test.go:24` |
| `MessageGroup.TableName` | Returns 'messages_groups' | `message/message_tablenames_test.go:28` |
| `MessageOutcome.TableName` | Returns 'messages_outcomes' | `message/message_tablenames_test.go:32` |
| `MessagePromise.TableName` | Returns 'messages_promises' | `message/message_tablenames_test.go:36` |
| `MessageReply.TableName` | Returns 'chat_messages' | `message/message_tablenames_test.go:40` |
| `MessageAttachment.ComputeAI` | bool true/false, float64 nonzero/zero, absent field, nil/empty mods, invalid JSON, null, string, extra fields, idempotency | `message/message_tablenames_test.go:131` |
| `buildMTUnionAllMsgIDQuery` | Single group, two groups, three groups, empty groups, multiple branchArgs, GID substitution, outer structure, branch parenthesization, last arg, nil branchArgs, zero limit | `message/message_list_pure_test.go:22` |

## Coverage ceiling note
The delta (+1.4%) is below the 5% threshold because the message package is very large (~4000 lines) and all remaining untested functions require a live database connection. The pure functions reachable without a DB connection are now fully covered (100% on all targeted functions).

## Latent bugs found
None.

## No production code changed
All changes are in test files only (`*_test.go`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)