### PR TITLE
feat(mjml): compile-once / substitute-many cache for batch mailables

### DIFF
--- a/iznik-batch/app/Console/Commands/Mail/ChaseAdminCommand.php
+++ b/iznik-batch/app/Console/Commands/Mail/ChaseAdminCommand.php
@@ -202,7 +202,14 @@ class ChaseAdminCommand extends Command
                 );
 
                 if ($bulkCompiler !== null && $mailable instanceof BulkRenderable) {
-                    $mailable->setPrerenderedHtml($bulkCompiler->htmlFor($mailable));
+                    try {
+                        $mailable->setPrerenderedHtml($bulkCompiler->htmlFor($mailable));
+                    } catch (\Throwable $bulkE) {
+                        Log::warning('BulkMjmlCompiler failed; falling back to per-user MJML compile', [
+                            'mod_id' => $mod->id,
+                            'error' => $bulkE->getMessage(),
+                        ]);
+                    }
                 }
 
                 app(\App\Services\EmailSpoolerService::class)->spool($mailable);

--- a/iznik-batch/app/Console/Commands/Mail/ChaseAdminCommand.php
+++ b/iznik-batch/app/Console/Commands/Mail/ChaseAdminCommand.php
@@ -4,13 +4,14 @@ namespace App\Console\Commands\Mail;
 
 use App\Console\Concerns\PreventsOverlapping;
 use App\Mail\Admin\ChaseAdminMail;
+use App\Mail\Concerns\BulkRenderable;
 use App\Models\Group;
 use App\Models\User;
+use App\Services\BulkMail\BulkMjmlCompiler;
 use App\Traits\GracefulShutdown;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\Mail;
 
 class ChaseAdminCommand extends Command
 {
@@ -168,6 +169,12 @@ class ChaseAdminCommand extends Command
 
         $sent = 0;
 
+        // One BulkMjmlCompiler per admin chase: all mods of the group share
+        // the same admin/group/pending data → one MJML compile, N
+        // substitutions for N mods.
+        $bulkEnabled = (bool) config('freegle.bulk_mail.enabled', true);
+        $bulkCompiler = $bulkEnabled ? app(BulkMjmlCompiler::class) : null;
+
         foreach ($moderators as $mod) {
             $email = $mod->email_preferred;
 
@@ -193,6 +200,10 @@ class ChaseAdminCommand extends Command
                     $pendingHours,
                     $admin->id
                 );
+
+                if ($bulkCompiler !== null && $mailable instanceof BulkRenderable) {
+                    $mailable->setPrerenderedHtml($bulkCompiler->htmlFor($mailable));
+                }
 
                 app(\App\Services\EmailSpoolerService::class)->spool($mailable);
 

--- a/iznik-batch/app/Mail/Admin/ChaseAdminMail.php
+++ b/iznik-batch/app/Mail/Admin/ChaseAdminMail.php
@@ -2,6 +2,7 @@
 
 namespace App\Mail\Admin;
 
+use App\Mail\Concerns\BulkRenderable;
 use App\Mail\MjmlMailable;
 use App\Mail\Traits\LoggableEmail;
 use App\Mail\Traits\TrackableEmail;
@@ -9,7 +10,7 @@ use App\Models\User;
 use Illuminate\Mail\Mailables\Address;
 use Illuminate\Mail\Mailables\Envelope;
 
-class ChaseAdminMail extends MjmlMailable
+class ChaseAdminMail extends MjmlMailable implements BulkRenderable
 {
     use TrackableEmail;
     use LoggableEmail;
@@ -103,6 +104,46 @@ class ChaseAdminMail extends MjmlMailable
     protected function getSubject(): string
     {
         return "ADMIN: Action needed - pending suggested admin for {$this->groupName}";
+    }
+
+    /**
+     * All recipients of one admin-chase email share content: same admin, same
+     * group, same pending duration. The only per-mod variation is the greeting
+     * "Dear {first name}" and the tracking pixel URL.
+     */
+    public function shapeKey(): string
+    {
+        return 'chase-admin-'.$this->adminId.'|h='.$this->pendingHours.'|g='.$this->groupName;
+    }
+
+    public function bulkTemplate(): string
+    {
+        return 'emails.mjml.admin.chase';
+    }
+
+    public function bulkData(): array
+    {
+        return array_merge([
+            'adminSubject' => $this->adminSubject,
+            'groupName' => $this->groupName,
+            'pendingHours' => $this->pendingHours,
+            'pendingTimeText' => $this->pendingTimeText,
+            'modToolsUrl' => $this->modToolsUrl,
+            'adminId' => $this->adminId,
+            'userName' => '{{userName}}',
+        ], [
+            'tracking' => $this->tracking,
+            'trackingPixelMjml' => '<mj-image src="{{trackingPixelUrl}}" width="1px" height="1px" alt="" padding="0" />',
+            'trackingPixelHtml' => '',
+        ]);
+    }
+
+    public function mergeVars(): array
+    {
+        return [
+            'userName' => $this->user ? ($this->user->firstname ?: ($this->user->fullname ?: 'there')) : 'there',
+            'trackingPixelUrl' => $this->tracking?->getPixelUrl() ?? '',
+        ];
     }
 
     /**

--- a/iznik-batch/app/Mail/Admin/ChaseAdminMail.php
+++ b/iznik-batch/app/Mail/Admin/ChaseAdminMail.php
@@ -130,10 +130,10 @@ class ChaseAdminMail extends MjmlMailable implements BulkRenderable
             'pendingTimeText' => $this->pendingTimeText,
             'modToolsUrl' => $this->modToolsUrl,
             'adminId' => $this->adminId,
-            'userName' => '{{userName}}',
+            'userName' => $this->ph('userName'),
         ], [
             'tracking' => $this->tracking,
-            'trackingPixelMjml' => '<mj-image src="{{trackingPixelUrl}}" width="1px" height="1px" alt="" padding="0" />',
+            'trackingPixelMjml' => '<mj-image src="'.$this->ph('trackingPixelUrl').'" width="1px" height="1px" alt="" padding="0" />',
             'trackingPixelHtml' => '',
         ]);
     }

--- a/iznik-batch/app/Mail/Concerns/BulkRenderable.php
+++ b/iznik-batch/app/Mail/Concerns/BulkRenderable.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Mail\Concerns;
+
+/**
+ * Opt-in contract for mailables that can share a compiled MJML body across
+ * multiple recipients.
+ *
+ * The trick: per-recipient values are passed to Blade as literal {{name}}
+ * placeholder strings (in bulkData()). Blade's {{ $var }} interpolation does
+ * NOT escape curly braces (htmlspecialchars only touches & " ' < >), so the
+ * placeholders pass through Blade unchanged. MJML compile passes them through
+ * unchanged. After compile, BulkMjmlCompiler::substitute() replaces them with
+ * the recipient's real values from mergeVars().
+ *
+ * The Blade template itself does NOT change. Templates work the same way
+ * whether rendered for bulk (placeholder strings as inputs) or normal sends
+ * (real values as inputs). The mailable controls the mode via which data it
+ * supplies.
+ *
+ * Implementors declare:
+ *   - shapeKey(): identifies recipients that share compiled HTML. Must include
+ *     every structural input that changes the rendered template (@if branches,
+ *     loop bodies, ...). A change in any of these must produce a different key.
+ *   - bulkData(): the data array passed to the Blade template for the SHARED
+ *     compile. Per-recipient fields take literal placeholder strings like
+ *     "{{messageUrl}}"; shared fields take their real values.
+ *   - mergeVars(): per-recipient values keyed by placeholder name. Keys must
+ *     match the placeholders used in bulkData().
+ *
+ * Values are HTML-encoded automatically before substitution (htmlspecialchars
+ * with ENT_QUOTES|ENT_HTML5) — same convention Blade {{ $var }} uses. Pass
+ * URLs with plain & (not &amp;); they become &amp; in the output.
+ */
+interface BulkRenderable
+{
+    /**
+     * Stable identifier for the cache bucket this recipient falls into.
+     */
+    public function shapeKey(): string;
+
+    /**
+     * Blade template path to render for the cached compile (e.g.
+     * 'emails.mjml.digest.unified').
+     */
+    public function bulkTemplate(): string;
+
+    /**
+     * Data array for the SHARED Blade render. Per-recipient fields take
+     * literal "{{name}}" placeholder strings; shared fields take real values.
+     *
+     * Will be merged into the data array set on the mailable for the bulk
+     * compile pass. Subclasses should match the variable names their existing
+     * Blade template expects.
+     *
+     * @return array<string,mixed>
+     */
+    public function bulkData(): array;
+
+    /**
+     * Per-recipient substitutions keyed by placeholder name. Keys must match
+     * the "{{name}}" placeholders that appear in bulkData() and end up in the
+     * compiled MJML output. Values are cast to string and HTML-encoded.
+     *
+     * @return array<string,mixed>
+     */
+    public function mergeVars(): array;
+}

--- a/iznik-batch/app/Mail/Digest/UnifiedDigest.php
+++ b/iznik-batch/app/Mail/Digest/UnifiedDigest.php
@@ -556,7 +556,7 @@ class UnifiedDigest extends MjmlMailable implements RetryableMailable, BulkRende
             return [
                 'message' => $message,
                 'messageText' => $messageText,
-                'messageUrl' => '{{messageUrl}}',
+                'messageUrl' => $this->ph('messageUrl'),
                 'imageUrl' => $imageUrl,
                 'displayImageUrl' => $displayImageUrl,
                 'trackedImageUrl' => null,

--- a/iznik-batch/app/Mail/Digest/UnifiedDigest.php
+++ b/iznik-batch/app/Mail/Digest/UnifiedDigest.php
@@ -527,6 +527,8 @@ class UnifiedDigest extends MjmlMailable implements RetryableMailable, BulkRende
                 ? config('freegle.images.offer_placeholder')
                 : config('freegle.images.wanted_placeholder');
             $displayImageUrl = $imageUrl ?? $placeholderUrl;
+            $heroImageUrl = $this->getMessageImageUrl($message, 600, 400) ?? $placeholderUrl;
+            $thumbImageUrl = $this->getMessageImageUrl($message, 240, 240) ?? $placeholderUrl;
 
             $messageText = $message->textbody
                 ? EmojiUtils::decodeEmojis($message->textbody)
@@ -559,6 +561,8 @@ class UnifiedDigest extends MjmlMailable implements RetryableMailable, BulkRende
                 'messageUrl' => $this->ph('messageUrl'),
                 'imageUrl' => $imageUrl,
                 'displayImageUrl' => $displayImageUrl,
+                'heroImageUrl' => $heroImageUrl,
+                'thumbImageUrl' => $thumbImageUrl,
                 'trackedImageUrl' => null,
                 'isPlaceholder' => $imageUrl === null,
                 'postedToText' => $postedToText,

--- a/iznik-batch/app/Mail/Digest/UnifiedDigest.php
+++ b/iznik-batch/app/Mail/Digest/UnifiedDigest.php
@@ -2,6 +2,7 @@
 
 namespace App\Mail\Digest;
 
+use App\Mail\Concerns\BulkRenderable;
 use App\Mail\Contracts\RetryableMailable;
 use App\Mail\MjmlMailable;
 use App\Mail\Traits\AmpEmail;
@@ -24,7 +25,7 @@ use Illuminate\Support\Facades\DB;
  * Contains posts from all communities the user is a member of,
  * with cross-posted items deduplicated.
  */
-class UnifiedDigest extends MjmlMailable implements RetryableMailable
+class UnifiedDigest extends MjmlMailable implements RetryableMailable, BulkRenderable
 {
     use AmpEmail;
     use AvatarResolver;
@@ -41,6 +42,13 @@ class UnifiedDigest extends MjmlMailable implements RetryableMailable
     protected array $groupLookup = [];
 
     protected int $digestNumber;
+
+    /**
+     * Cached User::getJobAds() result. Avoids running the (cross-table /
+     * spatial) jobs query three times per send for the bulk path (once each
+     * for shapeKey, bulkData, mergeVars).
+     */
+    protected ?Collection $cachedJobAds = null;
 
     public function __construct(
         public User $user,
@@ -201,8 +209,7 @@ class UnifiedDigest extends MjmlMailable implements RetryableMailable
     {
         // Jobs section — V1 single.html parity. Same shape ChatNotification
         // already uses, so the MJML loop is a drop-in.
-        $jobAdsData = $this->user->getJobAds();
-        $jobAds = $jobAdsData['jobs'] ?? collect();
+        $jobAds = $this->getCachedJobAds();
         $jobCount = count($jobAds);
         foreach ($jobAds as $index => $job) {
             $job->tracked_url = $this->trackedUrl(
@@ -245,6 +252,7 @@ class UnifiedDigest extends MjmlMailable implements RetryableMailable
 
         $result = $this->mjmlView('emails.mjml.digest.unified', array_merge([
             'user' => $this->user,
+            'userEmail' => $this->user->email_preferred ?? '',
             'posts' => $this->preparedPosts,
             'postCount' => $this->posts->count(),
             'mode' => $this->mode,
@@ -353,6 +361,253 @@ class UnifiedDigest extends MjmlMailable implements RetryableMailable
         }
 
         return $result;
+    }
+
+    /**
+     * Bucket recipients that share compiled HTML. See BulkRenderable.
+     *
+     * For immediate-mode digests, the structural inputs that change the
+     * rendered template are:
+     *   - the message (drives all the shared content)
+     *   - sponsor set (shared across users in the same group anyway)
+     *   - has_distance: changes the @if branch in the post card
+     *   - has_jobs: when true, the jobs loop has a per-user body (each user
+     *     has their own job set), so users with jobs go solo — unique shape
+     *     per user, no cache sharing. Phase 1 simplification.
+     */
+    public function shapeKey(): string
+    {
+        if ($this->mode !== UnifiedDigestService::MODE_IMMEDIATE) {
+            // Daily digest is per-user (each user has their own union of posts).
+            // Force a unique shape so the bulk path produces correct output
+            // even though there's no sharing benefit. See spec for follow-up
+            // work on per-post fragment sharing.
+            return 'unique-daily-'.$this->user->id;
+        }
+
+        if ($this->getCachedJobAds()->isNotEmpty()) {
+            return 'unique-jobs-'.$this->user->id.'-'.($this->posts->first()['message']->id ?? 0);
+        }
+
+        $messageId = $this->posts->first()['message']->id ?? 0;
+        $sponsorIds = $this->sponsors->pluck('id')->sort()->implode(',');
+
+        // has_distance depends on BOTH the user having a location AND the
+        // message having lat/lng (preparePosts computes the actual text). Use
+        // the rendered distanceText from preparedPosts so the bucket reflects
+        // the same @if branch the template will take. Users-with-location
+        // viewing a message-without-lat-lng land in the same bucket as
+        // users-without-location.
+        $firstPrepared = $this->preparedPosts->first();
+        $hasDistance = ($firstPrepared['distanceText'] ?? null) !== null ? '1' : '0';
+
+        return sha1("immediate|{$messageId}|{$sponsorIds}|{$hasDistance}");
+    }
+
+    /**
+     * Memoised wrapper around $this->user->getJobAds(). Returns the 'jobs'
+     * collection (possibly empty). Cached for the lifetime of this Mailable.
+     */
+    protected function getCachedJobAds(): Collection
+    {
+        if ($this->cachedJobAds === null) {
+            $this->cachedJobAds = $this->user->getJobAds()['jobs'] ?? collect();
+        }
+        return $this->cachedJobAds;
+    }
+
+    public function bulkTemplate(): string
+    {
+        return 'emails.mjml.digest.unified';
+    }
+
+    /**
+     * Data for the SHARED compile pass. Per-recipient fields are literal
+     * "{{name}}" placeholder strings; shared fields are real values.
+     *
+     * Mirrors the data array that build() passes to mjmlView(), but with
+     * placeholder substitutions in place of trackedUrl()-derived values.
+     */
+    public function bulkData(): array
+    {
+        $bulkPosts = $this->preparePostsForBulk();
+        $bulkJobAds = $this->buildBulkJobAds();
+
+        return array_merge([
+            'user' => $this->user,
+            'userEmail' => '{{userEmail}}',
+            'posts' => $bulkPosts,
+            'postCount' => $this->posts->count(),
+            'mode' => $this->mode,
+            'sponsors' => $this->sponsors,
+            'settingsUrl' => '{{settingsUrl}}',
+            'unsubscribeUrl' => '{{unsubscribeUrl}}',
+            'browseUrl' => '{{browseUrl}}',
+            'userSite' => $this->userSite,
+            'jobAds' => $bulkJobAds,
+            'jobsUrl' => '{{jobsUrl}}',
+            'donateUrl' => '{{donateUrl}}',
+            'primaryGroupName' => $this->getPrimaryGroupName(),
+            'frequencyText' => $this->mode === UnifiedDigestService::MODE_IMMEDIATE ? 'immediately' : 'daily',
+        ], [
+            // Overrides for getTrackingData() so the tracking pixel URL is a
+            // merge placeholder instead of the first recipient's real URL.
+            'tracking' => $this->tracking,
+            'trackingPixelMjml' => '<mj-image src="{{trackingPixelUrl}}" width="1px" height="1px" alt="" padding="0" />',
+            'trackingPixelHtml' => '',
+        ]);
+    }
+
+    /**
+     * Per-recipient substitution map. Keys match the literal "{{name}}"
+     * placeholders in bulkData(); values are the real per-recipient strings.
+     */
+    public function mergeVars(): array
+    {
+        $vars = [
+            'userEmail' => $this->user->email_preferred ?? '',
+            'browseUrl' => $this->trackedUrl($this->userSite.'/browse', 'browse_cta', 'browse'),
+            'donateUrl' => $this->trackedUrl(
+                config('freegle.donate.url', 'https://freegle.in/paypal1510'),
+                'donate',
+                'donate'
+            ),
+            'jobsUrl' => $this->trackedUrl($this->userSite.'/jobs', 'jobs_view_more', 'jobs_view_more'),
+            'unsubscribeUrl' => $this->trackedUrl($this->userSite.'/unsubscribe', 'footer_unsubscribe', 'unsubscribe'),
+            'settingsUrl' => $this->trackedUrl($this->userSite.'/settings', 'footer_settings', 'settings'),
+            'messageUrl' => $this->preparedPosts->isNotEmpty()
+                ? $this->preparedPosts->first()['messageUrl']
+                : '',
+            'trackingPixelUrl' => $this->tracking?->getPixelUrl() ?? '',
+        ];
+
+        // distanceText is only emitted by the template when the user has a
+        // location (handled via shape key). Provide the value when present.
+        if ($this->user->lastlocation !== null && $this->preparedPosts->isNotEmpty()) {
+            $first = $this->preparedPosts->first();
+            $vars['distanceText'] = $first['distanceText'] ?? '';
+        }
+
+        // Job slots — same indexing as buildBulkJobAds().
+        $jobAds = $this->getCachedJobAds();
+        $jobCount = count($jobAds);
+        foreach ($jobAds as $idx => $job) {
+            $vars["job_{$idx}_url"] = $this->trackedUrl(
+                $this->userSite.'/job/'.$job->id.
+                    '?source=email&campaign=unified_digest&position='.$idx.
+                    '&list_length='.$jobCount,
+                'job_ad_'.$idx,
+                'job_click'
+            );
+        }
+
+        return $vars;
+    }
+
+    /**
+     * Build a placeholder version of $this->preparedPosts where per-recipient
+     * fields (messageUrl, distanceText) are literal "{{name}}" strings.
+     *
+     * Shared fields (itemName, locationName, posterAvatarUrl, arrival timestamps,
+     * displayImageUrl, etc.) are real values — same as preparePosts().
+     */
+    protected function preparePostsForBulk(): Collection
+    {
+        return $this->posts->map(function ($post) {
+            $message = $post['message'];
+            $postedToGroups = $post['postedToGroups'];
+            $isOffer = $message->type === 'Offer';
+
+            $postedToText = count($postedToGroups) > 1
+                ? $this->formatPostedTo($postedToGroups)
+                : null;
+
+            $imageUrl = $this->getMessageImageUrl($message);
+            $placeholderUrl = $isOffer
+                ? config('freegle.images.offer_placeholder')
+                : config('freegle.images.wanted_placeholder');
+            $displayImageUrl = $imageUrl ?? $placeholderUrl;
+
+            $messageText = $message->textbody
+                ? EmojiUtils::decodeEmojis($message->textbody)
+                : null;
+
+            $arrival = $message->arrival instanceof Carbon ? $message->arrival : Carbon::parse($message->arrival);
+            $arrivalFormatted = $arrival->setTimezone('Europe/London')->format('D j M, g:ia');
+            $arrivalIso = $arrival->toIso8601String();
+
+            // distanceText: truthy placeholder when the user has a location
+            // (the template @if branches on it). Shape key includes
+            // has_distance, so within a shape this is consistent.
+            $distanceText = $this->user->lastlocation !== null ? '{{distanceText}}' : null;
+
+            $posterUser = $message->relationLoaded('fromUser') ? $message->fromUser : null;
+            $posterAvatarUrl = $this->resolveAvatarUrl($posterUser, 36);
+            $posterName = $posterUser?->displayname ?? $message->fromname ?? 'Freegler';
+
+            $firstPostedFormatted = null;
+            $originalDate = $message->date instanceof Carbon
+                ? $message->date
+                : ($message->date ? Carbon::parse($message->date) : null);
+            if ($originalDate && $arrival->diffInMinutes($originalDate) > 60) {
+                $firstPostedFormatted = $originalDate->setTimezone('Europe/London')->format('D, jS F g:ia');
+            }
+
+            return [
+                'message' => $message,
+                'messageText' => $messageText,
+                'messageUrl' => '{{messageUrl}}',
+                'imageUrl' => $imageUrl,
+                'displayImageUrl' => $displayImageUrl,
+                'trackedImageUrl' => null,
+                'isPlaceholder' => $imageUrl === null,
+                'postedToText' => $postedToText,
+                'type' => $message->type,
+                'subject' => $message->subject,
+                'itemName' => $this->extractItemName($message->subject),
+                'locationName' => $this->extractLocationName($message->subject),
+                'arrivalFormatted' => $arrivalFormatted,
+                'arrivalIso' => $arrivalIso,
+                'distanceText' => $distanceText,
+                'posterName' => $posterName,
+                'posterAvatarUrl' => $posterAvatarUrl,
+                'firstPostedFormatted' => $firstPostedFormatted,
+            ];
+        });
+    }
+
+    /**
+     * Build a placeholder version of the user's jobs collection — same shape
+     * and count as the real jobs but with each tracked_url replaced by a
+     * position-indexed "{{job_N_url}}" placeholder.
+     */
+    protected function buildBulkJobAds(): Collection
+    {
+        return $this->getCachedJobAds()->map(function ($job, $idx) {
+            $clone = clone $job;
+            $clone->tracked_url = '{{job_'.$idx.'_url}}';
+            return $clone;
+        });
+    }
+
+    /**
+     * Look up the primary group name (the post's first group) for the per-group
+     * footer line. Shared across all recipients of one message.
+     */
+    protected function getPrimaryGroupName(): ?string
+    {
+        if ($this->mode !== UnifiedDigestService::MODE_IMMEDIATE || $this->posts->isEmpty()) {
+            return null;
+        }
+
+        $firstPost = $this->posts->first();
+        $groupId = $firstPost['postedToGroups'][0] ?? null;
+        if (!$groupId) {
+            return null;
+        }
+
+        $row = DB::table('groups')->where('id', $groupId)->first(['nameshort', 'namefull']);
+        return $row ? ($row->namefull ?: $row->nameshort) : null;
     }
 
     /**

--- a/iznik-batch/app/Mail/Digest/UnifiedDigest.php
+++ b/iznik-batch/app/Mail/Digest/UnifiedDigest.php
@@ -513,14 +513,31 @@ class UnifiedDigest extends MjmlMailable implements RetryableMailable, BulkRende
      */
     protected function preparePostsForBulk(): Collection
     {
-        return $this->posts->map(function ($post) {
+        return $this->posts->map(function ($post, $index) {
             $message = $post['message'];
             $postedToGroups = $post['postedToGroups'];
             $isOffer = $message->type === 'Offer';
 
-            $postedToText = count($postedToGroups) > 1
-                ? $this->formatPostedTo($postedToGroups)
-                : null;
+            // Primary group name + /explore link for the "Posted by … on <group>"
+            // byline — mirrors preparePosts() so the bulk render byte-matches the
+            // non-bulk one. Resolved from $this->groupLookup (populated by
+            // preparePosts() in the constructor). groupUrl is a tracked URL; its
+            // tracking id differs per recipient but is normalised out of the
+            // byte-identity comparison, exactly like messageUrl.
+            $groupName = null;
+            $groupUrl = null;
+            $primaryGroupId = $postedToGroups[0] ?? null;
+            if ($primaryGroupId && isset($this->groupLookup[$primaryGroupId])) {
+                $g = $this->groupLookup[$primaryGroupId];
+                $groupName = $g->namefull ?: $g->nameshort;
+                if ($g->nameshort) {
+                    $groupUrl = $this->trackedUrl(
+                        $this->userSite . '/explore/' . urlencode($g->nameshort),
+                        "group_{$index}",
+                        'group'
+                    );
+                }
+            }
 
             $imageUrl = $this->getMessageImageUrl($message);
             $placeholderUrl = $isOffer
@@ -555,6 +572,10 @@ class UnifiedDigest extends MjmlMailable implements RetryableMailable, BulkRende
                 $firstPostedFormatted = $originalDate->setTimezone('Europe/London')->format('D, jS F g:ia');
             }
 
+            // Decode HTML entities before deriving item/location names so the
+            // output matches preparePosts() (Blade {{ }} re-escapes on render).
+            $subject = html_entity_decode($message->subject ?? '', ENT_QUOTES | ENT_HTML5, 'UTF-8');
+
             return [
                 'message' => $message,
                 'messageText' => $messageText,
@@ -565,11 +586,12 @@ class UnifiedDigest extends MjmlMailable implements RetryableMailable, BulkRende
                 'thumbImageUrl' => $thumbImageUrl,
                 'trackedImageUrl' => null,
                 'isPlaceholder' => $imageUrl === null,
-                'postedToText' => $postedToText,
+                'groupName' => $groupName,
+                'groupUrl' => $groupUrl,
                 'type' => $message->type,
-                'subject' => $message->subject,
-                'itemName' => $this->extractItemName($message->subject),
-                'locationName' => $this->extractLocationName($message->subject),
+                'subject' => $subject,
+                'itemName' => $this->extractItemName($subject),
+                'locationName' => $this->extractLocationName($subject),
                 'arrivalFormatted' => $arrivalFormatted,
                 'arrivalIso' => $arrivalIso,
                 'distanceText' => $distanceText,

--- a/iznik-batch/app/Mail/Digest/UnifiedDigest.php
+++ b/iznik-batch/app/Mail/Digest/UnifiedDigest.php
@@ -435,25 +435,25 @@ class UnifiedDigest extends MjmlMailable implements RetryableMailable, BulkRende
 
         return array_merge([
             'user' => $this->user,
-            'userEmail' => '{{userEmail}}',
+            'userEmail' => $this->ph('userEmail'),
             'posts' => $bulkPosts,
             'postCount' => $this->posts->count(),
             'mode' => $this->mode,
             'sponsors' => $this->sponsors,
-            'settingsUrl' => '{{settingsUrl}}',
-            'unsubscribeUrl' => '{{unsubscribeUrl}}',
-            'browseUrl' => '{{browseUrl}}',
+            'settingsUrl' => $this->ph('settingsUrl'),
+            'unsubscribeUrl' => $this->ph('unsubscribeUrl'),
+            'browseUrl' => $this->ph('browseUrl'),
             'userSite' => $this->userSite,
             'jobAds' => $bulkJobAds,
-            'jobsUrl' => '{{jobsUrl}}',
-            'donateUrl' => '{{donateUrl}}',
+            'jobsUrl' => $this->ph('jobsUrl'),
+            'donateUrl' => $this->ph('donateUrl'),
             'primaryGroupName' => $this->getPrimaryGroupName(),
             'frequencyText' => $this->mode === UnifiedDigestService::MODE_IMMEDIATE ? 'immediately' : 'daily',
         ], [
             // Overrides for getTrackingData() so the tracking pixel URL is a
             // merge placeholder instead of the first recipient's real URL.
             'tracking' => $this->tracking,
-            'trackingPixelMjml' => '<mj-image src="{{trackingPixelUrl}}" width="1px" height="1px" alt="" padding="0" />',
+            'trackingPixelMjml' => '<mj-image src="'.$this->ph('trackingPixelUrl').'" width="1px" height="1px" alt="" padding="0" />',
             'trackingPixelHtml' => '',
         ]);
     }
@@ -539,7 +539,7 @@ class UnifiedDigest extends MjmlMailable implements RetryableMailable, BulkRende
             // distanceText: truthy placeholder when the user has a location
             // (the template @if branches on it). Shape key includes
             // has_distance, so within a shape this is consistent.
-            $distanceText = $this->user->lastlocation !== null ? '{{distanceText}}' : null;
+            $distanceText = $this->user->lastlocation !== null ? $this->ph('distanceText') : null;
 
             $posterUser = $message->relationLoaded('fromUser') ? $message->fromUser : null;
             $posterAvatarUrl = $this->resolveAvatarUrl($posterUser, 36);
@@ -585,7 +585,7 @@ class UnifiedDigest extends MjmlMailable implements RetryableMailable, BulkRende
     {
         return $this->getCachedJobAds()->map(function ($job, $idx) {
             $clone = clone $job;
-            $clone->tracked_url = '{{job_'.$idx.'_url}}';
+            $clone->tracked_url = $this->ph('job_'.$idx.'_url');
             return $clone;
         });
     }

--- a/iznik-batch/app/Mail/Event/EventsDigestMail.php
+++ b/iznik-batch/app/Mail/Event/EventsDigestMail.php
@@ -84,8 +84,8 @@ class EventsDigestMail extends MjmlMailable implements BulkRenderable
             'groupName'      => $this->groupName,
             'events'         => $this->events,
             'userSite'       => config('freegle.sites.user'),
-            'unsubscribeUrl' => '{{unsubscribeUrl}}',
-            'email'          => '{{recipientEmail}}',
+            'unsubscribeUrl' => $this->ph('unsubscribeUrl'),
+            'email'          => $this->ph('recipientEmail'),
         ];
     }
 

--- a/iznik-batch/app/Mail/Event/EventsDigestMail.php
+++ b/iznik-batch/app/Mail/Event/EventsDigestMail.php
@@ -2,12 +2,13 @@
 
 namespace App\Mail\Event;
 
+use App\Mail\Concerns\BulkRenderable;
 use App\Mail\MjmlMailable;
 use App\Mail\Traits\TrackableEmail;
 use Illuminate\Mail\Mailables\Address;
 use Illuminate\Mail\Mailables\Envelope;
 
-class EventsDigestMail extends MjmlMailable
+class EventsDigestMail extends MjmlMailable implements BulkRenderable
 {
     use TrackableEmail;
 
@@ -58,5 +59,41 @@ class EventsDigestMail extends MjmlMailable
             'unsubscribeUrl' => $this->unsubscribeUrl,
             'email'          => $this->recipientEmail,
         ]);
+    }
+
+    /**
+     * All members of one group's events-digest send share the same events list
+     * and group name. Per-recipient body variation: footer email and the
+     * unsubscribe URL (which embeds the recipient's email).
+     */
+    public function shapeKey(): string
+    {
+        return 'events-digest-'.sha1(
+            $this->groupName.'|'.json_encode($this->events, JSON_THROW_ON_ERROR)
+        );
+    }
+
+    public function bulkTemplate(): string
+    {
+        return 'emails.mjml.event.events-digest';
+    }
+
+    public function bulkData(): array
+    {
+        return [
+            'groupName'      => $this->groupName,
+            'events'         => $this->events,
+            'userSite'       => config('freegle.sites.user'),
+            'unsubscribeUrl' => '{{unsubscribeUrl}}',
+            'email'          => '{{recipientEmail}}',
+        ];
+    }
+
+    public function mergeVars(): array
+    {
+        return [
+            'recipientEmail' => $this->recipientEmail,
+            'unsubscribeUrl' => $this->unsubscribeUrl,
+        ];
     }
 }

--- a/iznik-batch/app/Mail/MjmlMailable.php
+++ b/iznik-batch/app/Mail/MjmlMailable.php
@@ -18,6 +18,16 @@ abstract class MjmlMailable extends Mailable
     protected array $mjmlData = [];
 
     /**
+     * Optional pre-rendered HTML body. When set, mjmlView() skips the Blade
+     * render + MJML sidecar compile and uses this string directly. Used by
+     * BulkMjmlCompiler to inject a per-recipient HTML body that was computed
+     * by substituting merge vars into a shape-cached compiled template.
+     *
+     * Null means the standard path runs (Blade + MJML compile per send).
+     */
+    protected ?string $prerenderedHtml = null;
+
+    /**
      * Trace ID for log correlation. Initialized early with default value.
      */
     protected string $traceId = '';
@@ -169,6 +179,19 @@ abstract class MjmlMailable extends Mailable
             throw new \RuntimeException($error);
         }
 
+        // Bulk path short-circuit: if BulkMjmlCompiler already produced a
+        // recipient-specific HTML body via shape caching + merge-var
+        // substitution, use it verbatim. Skip Blade and MJML compile.
+        if ($this->prerenderedHtml !== null) {
+            $this->html($this->prerenderedHtml);
+
+            if ($textTemplate && view()->exists($textTemplate)) {
+                $this->text($textTemplate, $this->mjmlData);
+            }
+
+            return $this;
+        }
+
         // Render the Blade template to get MJML content with retry on empty.
         try {
             $mjmlContent = $this->renderMjmlTemplate();
@@ -195,6 +218,49 @@ abstract class MjmlMailable extends Mailable
         }
 
         return $this;
+    }
+
+    /**
+     * Set the HTML body directly, bypassing the Blade + MJML pipeline on the
+     * next mjmlView() call. Used exclusively by BulkMjmlCompiler.
+     *
+     * Subclasses' build() implementations are unchanged: they still call
+     * mjmlView(...) as usual; mjmlView() now checks $prerenderedHtml first
+     * and short-circuits if set.
+     */
+    public function setPrerenderedHtml(string $html): static
+    {
+        $this->prerenderedHtml = $html;
+
+        return $this;
+    }
+
+    /**
+     * Render the mailable's MJML template + compile to HTML, returning the
+     * body without setting it on the mailable.
+     *
+     * Called by BulkMjmlCompiler once per shape (the first recipient in the
+     * shape). The bulk-data array — supplied by the subclass via
+     * BulkRenderable::bulkData() — passes literal "{{name}}" placeholder
+     * strings for per-recipient fields, so the rendered HTML contains those
+     * placeholders. Subsequent recipients in the shape get this HTML with
+     * their own values substituted in.
+     *
+     * @param string $template     The Blade template path the mailable uses.
+     * @param array  $sharedData   The bulkData() array from the subclass.
+     */
+    public function renderHtmlForBulkCache(string $template, array $sharedData): string
+    {
+        if (!view()->exists($template)) {
+            throw new \RuntimeException("MJML template not found: {$template}");
+        }
+
+        // Stash on the instance so renderMjmlTemplate() can pick them up.
+        $this->mjmlTemplate = $template;
+        $this->mjmlData = array_merge($this->getDefaultData(), $sharedData);
+
+        $mjml = $this->renderMjmlTemplate();
+        return $this->compileMjml($mjml);
     }
 
     /**

--- a/iznik-batch/app/Mail/MjmlMailable.php
+++ b/iznik-batch/app/Mail/MjmlMailable.php
@@ -28,6 +28,16 @@ abstract class MjmlMailable extends Mailable
     protected ?string $prerenderedHtml = null;
 
     /**
+     * Per-compile-instance random token used to namespace bulk-mode
+     * placeholder names — prevents user-controlled content (e.g. a message
+     * subject containing "{{messageUrl}}") from accidentally being treated
+     * as a merge placeholder. Set by BulkMjmlCompiler::htmlFor() before it
+     * calls bulkData()/mergeVars(). Empty string when no bulk render is
+     * active (non-bulk sends never see a placeholder).
+     */
+    protected string $bulkToken = '';
+
+    /**
      * Trace ID for log correlation. Initialized early with default value.
      */
     protected string $traceId = '';
@@ -233,6 +243,40 @@ abstract class MjmlMailable extends Mailable
         $this->prerenderedHtml = $html;
 
         return $this;
+    }
+
+    /**
+     * Hand the mailable a random token to namespace its merge-var
+     * placeholders. Called by BulkMjmlCompiler::htmlFor() once per send;
+     * the mailable then uses ph() in bulkData() to produce placeholders
+     * that user-typed text can't realistically collide with.
+     */
+    public function setBulkToken(string $token): static
+    {
+        $this->bulkToken = $token;
+
+        return $this;
+    }
+
+    /**
+     * Produce a token-namespaced placeholder for a merge var name. Use in
+     * BulkRenderable::bulkData() in place of literal "{{name}}" strings —
+     * the BulkMjmlCompiler substitutes these post-MJML-compile.
+     *
+     * Returns "{{<token>:name}}" — a string a user can't realistically
+     * produce in arbitrary content (32-char random hex prefix).
+     */
+    protected function ph(string $name): string
+    {
+        if ($this->bulkToken === '') {
+            throw new \LogicException(
+                'MjmlMailable::ph() called without a bulk token. '
+                .'BulkMjmlCompiler::htmlFor() must call setBulkToken() before '
+                .'asking the mailable for bulkData().'
+            );
+        }
+
+        return '{{'.$this->bulkToken.':'.$name.'}}';
     }
 
     /**

--- a/iznik-batch/app/Mail/Stories/AskMail.php
+++ b/iznik-batch/app/Mail/Stories/AskMail.php
@@ -64,10 +64,10 @@ class AskMail extends MjmlMailable implements BulkRenderable
     public function bulkData(): array
     {
         return [
-            'name'           => '{{recipientName}}',
+            'name'           => $this->ph('recipientName'),
             'storiesUrl'     => $this->storiesUrl,
             'unsubscribeUrl' => $this->unsubscribeUrl,
-            'email'          => '{{recipientEmail}}',
+            'email'          => $this->ph('recipientEmail'),
         ];
     }
 

--- a/iznik-batch/app/Mail/Stories/AskMail.php
+++ b/iznik-batch/app/Mail/Stories/AskMail.php
@@ -2,11 +2,12 @@
 
 namespace App\Mail\Stories;
 
+use App\Mail\Concerns\BulkRenderable;
 use App\Mail\MjmlMailable;
 use Illuminate\Mail\Mailables\Address;
 use Illuminate\Mail\Mailables\Envelope;
 
-class AskMail extends MjmlMailable
+class AskMail extends MjmlMailable implements BulkRenderable
 {
     public function __construct(
         public readonly string $recipientName,
@@ -42,5 +43,39 @@ class AskMail extends MjmlMailable
             'unsubscribeUrl' => $this->unsubscribeUrl,
             'email'          => $this->recipientEmail,
         ]);
+    }
+
+    /**
+     * The ask template body has only two per-recipient values: the greeting
+     * name and the footer email. Everything else (storiesUrl, unsubscribeUrl)
+     * is constructed from config and is identical for every recipient in a
+     * batch.
+     */
+    public function shapeKey(): string
+    {
+        return 'stories-ask-'.sha1($this->storiesUrl.'|'.$this->unsubscribeUrl);
+    }
+
+    public function bulkTemplate(): string
+    {
+        return 'emails.mjml.stories.ask';
+    }
+
+    public function bulkData(): array
+    {
+        return [
+            'name'           => '{{recipientName}}',
+            'storiesUrl'     => $this->storiesUrl,
+            'unsubscribeUrl' => $this->unsubscribeUrl,
+            'email'          => '{{recipientEmail}}',
+        ];
+    }
+
+    public function mergeVars(): array
+    {
+        return [
+            'recipientName'  => $this->recipientName,
+            'recipientEmail' => $this->recipientEmail,
+        ];
     }
 }

--- a/iznik-batch/app/Mail/Stories/StoriesNewsletterMail.php
+++ b/iznik-batch/app/Mail/Stories/StoriesNewsletterMail.php
@@ -93,7 +93,7 @@ class StoriesNewsletterMail extends MjmlMailable implements BulkRenderable
     {
         return [
             'name'           => $this->recipientName,
-            'email'          => '{{recipientEmail}}',
+            'email'          => $this->ph('recipientEmail'),
             'stories'        => $this->stories,
             'headerImageUrl' => $this->headerImageUrl,
             'tellUrl'        => $this->tellUrl,

--- a/iznik-batch/app/Mail/Stories/StoriesNewsletterMail.php
+++ b/iznik-batch/app/Mail/Stories/StoriesNewsletterMail.php
@@ -2,11 +2,12 @@
 
 namespace App\Mail\Stories;
 
+use App\Mail\Concerns\BulkRenderable;
 use App\Mail\MjmlMailable;
 use Illuminate\Mail\Mailables\Address;
 use Illuminate\Mail\Mailables\Envelope;
 
-class StoriesNewsletterMail extends MjmlMailable
+class StoriesNewsletterMail extends MjmlMailable implements BulkRenderable
 {
     public function __construct(
         public readonly int    $userId,
@@ -60,5 +61,54 @@ class StoriesNewsletterMail extends MjmlMailable
             'unsubscribeUrl' => $this->unsubscribeUrl,
             'settingsUrl'    => $this->settingsUrl,
         ], 'emails.text.stories.newsletter');
+    }
+
+    /**
+     * All recipients of a newsletter run share the same body — same stories,
+     * same hero image, same CTAs, same unsubscribe/settings URLs (constructed
+     * from userSite only). The only thing that differs per-recipient is the
+     * "sent to {email}" line in the footer. Shape on the content hash so two
+     * concurrent send batches with different stories don't share a cache.
+     */
+    public function shapeKey(): string
+    {
+        return 'stories-newsletter-'.sha1(
+            json_encode($this->stories, JSON_THROW_ON_ERROR).'|'
+            .$this->headerImageUrl.'|'
+            .$this->tellUrl.'|'
+            .$this->giveUrl.'|'
+            .$this->findUrl.'|'
+            .$this->previewText.'|'
+            .$this->unsubscribeUrl.'|'
+            .$this->settingsUrl
+        );
+    }
+
+    public function bulkTemplate(): string
+    {
+        return 'emails.mjml.stories.newsletter';
+    }
+
+    public function bulkData(): array
+    {
+        return [
+            'name'           => $this->recipientName,
+            'email'          => '{{recipientEmail}}',
+            'stories'        => $this->stories,
+            'headerImageUrl' => $this->headerImageUrl,
+            'tellUrl'        => $this->tellUrl,
+            'giveUrl'        => $this->giveUrl,
+            'findUrl'        => $this->findUrl,
+            'previewText'    => $this->previewText,
+            'unsubscribeUrl' => $this->unsubscribeUrl,
+            'settingsUrl'    => $this->settingsUrl,
+        ];
+    }
+
+    public function mergeVars(): array
+    {
+        return [
+            'recipientEmail' => $this->recipientEmail,
+        ];
     }
 }

--- a/iznik-batch/app/Mail/Stories/StoriesNewsletterMail.php
+++ b/iznik-batch/app/Mail/Stories/StoriesNewsletterMail.php
@@ -92,7 +92,7 @@ class StoriesNewsletterMail extends MjmlMailable implements BulkRenderable
     public function bulkData(): array
     {
         return [
-            'name'           => $this->recipientName,
+            'name'           => $this->ph('recipientName'),
             'email'          => $this->ph('recipientEmail'),
             'stories'        => $this->stories,
             'headerImageUrl' => $this->headerImageUrl,
@@ -108,6 +108,7 @@ class StoriesNewsletterMail extends MjmlMailable implements BulkRenderable
     public function mergeVars(): array
     {
         return [
+            'recipientName'  => $this->recipientName,
             'recipientEmail' => $this->recipientEmail,
         ];
     }

--- a/iznik-batch/app/Mail/Volunteering/VolunteeringDigestMail.php
+++ b/iznik-batch/app/Mail/Volunteering/VolunteeringDigestMail.php
@@ -108,7 +108,7 @@ class VolunteeringDigestMail extends MjmlMailable implements BulkRenderable
         // regression either, and the shape key keeps that bucket isolated.
         $jobAds = $this->jobAds->map(function ($job, $idx) {
             $clone = clone $job;
-            $clone->tracked_url = '{{job_'.$idx.'_url}}';
+            $clone->tracked_url = $this->ph('job_'.$idx.'_url');
             return $clone;
         });
 
@@ -116,11 +116,11 @@ class VolunteeringDigestMail extends MjmlMailable implements BulkRenderable
             'groupName'      => $this->groupName,
             'volunteerings'  => $this->volunteerings,
             'userSite'       => $userSite,
-            'unsubscribeUrl' => '{{unsubscribeUrl}}',
-            'email'          => '{{recipientEmail}}',
+            'unsubscribeUrl' => $this->ph('unsubscribeUrl'),
+            'email'          => $this->ph('recipientEmail'),
             'jobAds'         => $jobAds,
-            'jobsUrl'        => '{{jobsUrl}}',
-            'donateUrl'      => '{{donateUrl}}',
+            'jobsUrl'        => $this->ph('jobsUrl'),
+            'donateUrl'      => $this->ph('donateUrl'),
         ];
     }
 

--- a/iznik-batch/app/Mail/Volunteering/VolunteeringDigestMail.php
+++ b/iznik-batch/app/Mail/Volunteering/VolunteeringDigestMail.php
@@ -2,13 +2,14 @@
 
 namespace App\Mail\Volunteering;
 
+use App\Mail\Concerns\BulkRenderable;
 use App\Mail\MjmlMailable;
 use App\Mail\Traits\TrackableEmail;
 use Illuminate\Mail\Mailables\Address;
 use Illuminate\Mail\Mailables\Envelope;
 use Illuminate\Support\Collection;
 
-class VolunteeringDigestMail extends MjmlMailable
+class VolunteeringDigestMail extends MjmlMailable implements BulkRenderable
 {
     use TrackableEmail;
     public function __construct(
@@ -74,5 +75,74 @@ class VolunteeringDigestMail extends MjmlMailable
             // resolves it correctly. Don't replace the short link with a full URL.
             'donateUrl'      => $this->trackedUrl('https://freegle.in/paypal1510', 'donate_link', 'donate'),
         ]);
+    }
+
+    /**
+     * Per-group volunteering digest. Members WITHOUT nearby jobs share one
+     * compiled body; members WITH jobs see different job sets per user, so
+     * they fall into a per-user-unique shape (full compile per user, but the
+     * substitute step costs nothing on top of the existing per-send compile).
+     */
+    public function shapeKey(): string
+    {
+        if ($this->jobAds->isNotEmpty()) {
+            return 'unique-vol-'.($this->userId ?? spl_object_id($this));
+        }
+        return 'volunteering-digest-'.sha1(
+            $this->groupName.'|'.json_encode($this->volunteerings, JSON_THROW_ON_ERROR)
+        );
+    }
+
+    public function bulkTemplate(): string
+    {
+        return 'emails.mjml.volunteering.digest';
+    }
+
+    public function bulkData(): array
+    {
+        $userSite = config('freegle.sites.user');
+
+        // Mirror build(): each job gets a placeholder for its per-user tracked
+        // URL. Within a "has-jobs" shape (unique per user), the user's actual
+        // jobs go through bulkData this way too — no extra benefit but no
+        // regression either, and the shape key keeps that bucket isolated.
+        $jobAds = $this->jobAds->map(function ($job, $idx) {
+            $clone = clone $job;
+            $clone->tracked_url = '{{job_'.$idx.'_url}}';
+            return $clone;
+        });
+
+        return [
+            'groupName'      => $this->groupName,
+            'volunteerings'  => $this->volunteerings,
+            'userSite'       => $userSite,
+            'unsubscribeUrl' => '{{unsubscribeUrl}}',
+            'email'          => '{{recipientEmail}}',
+            'jobAds'         => $jobAds,
+            'jobsUrl'        => '{{jobsUrl}}',
+            'donateUrl'      => '{{donateUrl}}',
+        ];
+    }
+
+    public function mergeVars(): array
+    {
+        $userSite = config('freegle.sites.user');
+
+        $vars = [
+            'recipientEmail' => $this->recipientEmail,
+            'unsubscribeUrl' => $this->unsubscribeUrl,
+            'jobsUrl' => $this->trackedUrl("{$userSite}/jobs", 'jobs_link', 'jobs'),
+            'donateUrl' => $this->trackedUrl('https://freegle.in/paypal1510', 'donate_link', 'donate'),
+        ];
+
+        foreach ($this->jobAds as $idx => $job) {
+            $vars["job_{$idx}_url"] = $this->trackedUrl(
+                "{$userSite}/job/{$job->id}",
+                'job_ad',
+                'jobs'
+            );
+        }
+
+        return $vars;
     }
 }

--- a/iznik-batch/app/Services/BulkMail/BulkMjmlCompiler.php
+++ b/iznik-batch/app/Services/BulkMail/BulkMjmlCompiler.php
@@ -39,9 +39,32 @@ class BulkMjmlCompiler
     /** @var int Number of times the sidecar was actually called */
     private int $compileCount = 0;
 
+    /**
+     * Random per-instance token used to namespace placeholder names. Prevents
+     * user-controlled content that happens to contain a literal "{{messageUrl}}"
+     * (e.g. a message subject) from being substituted as if it were one of our
+     * merge vars. The mailable calls $this->ph('messageUrl') and gets back
+     * "{{<token>:messageUrl}}" — a string a user can't realistically produce
+     * by hand. 16-byte hex → 32 random hex chars → collision odds 1/16^32.
+     */
+    private readonly string $batchToken;
+
     public function __construct(
         private readonly MjmlCompilerService $mjml
-    ) {}
+    ) {
+        $this->batchToken = bin2hex(random_bytes(16));
+    }
+
+    /**
+     * Token used in placeholder names for this compiler instance. Mailables
+     * read this via MjmlMailable::setBulkToken() (called by us in htmlFor)
+     * so their bulkData() emits the namespaced placeholders the compiled
+     * HTML carries.
+     */
+    public function batchToken(): string
+    {
+        return $this->batchToken;
+    }
 
     /**
      * Render the recipient's HTML body.
@@ -60,6 +83,12 @@ class BulkMjmlCompiler
      */
     public function htmlFor(MjmlMailable&BulkRenderable $mailable): string
     {
+        // Hand the mailable our batch token before it computes bulkData/
+        // mergeVars/shapeKey, so its placeholders embed the token and can't
+        // collide with user-controlled content like a message subject that
+        // happens to contain "{{messageUrl}}".
+        $mailable->setBulkToken($this->batchToken);
+
         $shape = $mailable->shapeKey();
 
         if (!isset($this->cache[$shape])) {
@@ -95,11 +124,13 @@ class BulkMjmlCompiler
     {
         $replacements = [];
         foreach ($vars as $key => $value) {
-            // Match Blade's e() helper exactly — same flag set Laravel uses
-            // for {{ $var }} interpolation — so the bulk-substituted output
-            // is byte-identical to what Blade would have produced for the
-            // same value.
-            $replacements['{{'.$key.'}}'] = htmlspecialchars(
+            // Placeholder is "{{<token>:<key>}}" — the token namespace makes
+            // it unforgeable from user content. See $batchToken docblock.
+            // Value escaping matches Blade's e() helper exactly so the bulk-
+            // substituted output is byte-identical to what Blade would have
+            // produced for {{ $var }}.
+            $placeholder = '{{'.$this->batchToken.':'.$key.'}}';
+            $replacements[$placeholder] = htmlspecialchars(
                 (string) $value,
                 ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5,
                 'UTF-8'
@@ -108,10 +139,11 @@ class BulkMjmlCompiler
 
         $result = strtr($html, $replacements);
 
-        // Fail-loud on any remaining placeholders. If a placeholder slips
-        // through to a sent email it appears as visible garbage to the
-        // recipient. Better to crash the send loop than ship broken output.
-        if (preg_match_all('/\{\{([a-zA-Z_][a-zA-Z0-9_]*)\}\}/', $result, $matches)) {
+        // Fail-loud on any remaining placeholders carrying our batch token.
+        // Plain "{{varname}}" elsewhere (e.g. a user's message subject) is
+        // ignored — it can't be one of ours because it lacks the token.
+        $pattern = '/\{\{'.preg_quote($this->batchToken, '/').':([a-zA-Z_][a-zA-Z0-9_]*)\}\}/';
+        if (preg_match_all($pattern, $result, $matches)) {
             $unique = array_values(array_unique($matches[1]));
             Log::error('BulkMjmlCompiler: unbound placeholders', [
                 'context' => $context,

--- a/iznik-batch/app/Services/BulkMail/BulkMjmlCompiler.php
+++ b/iznik-batch/app/Services/BulkMail/BulkMjmlCompiler.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace App\Services\BulkMail;
+
+use App\Mail\Concerns\BulkRenderable;
+use App\Mail\MjmlMailable;
+use App\Services\MjmlCompilerService;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Compile-once / substitute-many primitive for batch MJML mailables.
+ *
+ * Caches the compiled HTML body of a mailable's template per "shape" (a bucket
+ * identifier produced by the mailable's BulkRenderable::shapeKey()) for the
+ * lifetime of this service instance. For every recipient that shares a shape,
+ * we make one MJML sidecar call and N cheap string substitutions.
+ *
+ * Cache is process-local. Use clear() between independent send batches if you
+ * want to bound memory; the service is also typically instantiated fresh per
+ * send loop via the container.
+ *
+ * Placeholder convention: literal {{varname}} in the compiled HTML, substituted
+ * via str_replace. Survives MJML compile in text content and href/src/alt
+ * attributes — verified against the live mjml sidecar 2026-05-27. Do not put
+ * placeholders inside <style> blocks or style="" attributes: MJML's CSS inliner
+ * rewrites those.
+ *
+ * Same pattern as AWS SES SendBulkEmail / Postmark Bulk API / Mailchimp merge
+ * tags — see the design doc for references.
+ */
+class BulkMjmlCompiler
+{
+    /** @var array<string,string> shapeKey → compiled HTML with {{vars}} */
+    private array $cache = [];
+
+    /** @var array<string,int> shapeKey → number of recipients served (telemetry only) */
+    private array $hitCount = [];
+
+    /** @var int Number of times the sidecar was actually called */
+    private int $compileCount = 0;
+
+    public function __construct(
+        private readonly MjmlCompilerService $mjml
+    ) {}
+
+    /**
+     * Render the recipient's HTML body.
+     *
+     * On a cache miss for the mailable's shapeKey(), runs the mailable's
+     * template + MJML compile and stores the result. Then substitutes the
+     * mailable's mergeVars() into the cached HTML and returns the final body.
+     *
+     * The caller is expected to call MjmlMailable::setPrerenderedHtml() with
+     * the returned string before Mail::send(), so the mailable's build()
+     * short-circuits and uses this HTML instead of re-running the pipeline.
+     *
+     * @throws UnboundPlaceholderException If the cached HTML contains
+     *         placeholders not covered by the mailable's mergeVars().
+     * @throws \RuntimeException If MJML compilation fails.
+     */
+    public function htmlFor(MjmlMailable&BulkRenderable $mailable): string
+    {
+        $shape = $mailable->shapeKey();
+
+        if (!isset($this->cache[$shape])) {
+            $this->cache[$shape] = $this->renderTemplate($mailable);
+            $this->hitCount[$shape] = 0;
+            $this->compileCount++;
+        }
+
+        $this->hitCount[$shape]++;
+
+        return $this->substitute(
+            $this->cache[$shape],
+            $mailable->mergeVars(),
+            static::class.' (template of '.$mailable::class.')'
+        );
+    }
+
+    /**
+     * Substitute {{name}} placeholders in compiled HTML.
+     *
+     * Values are HTML-escaped (htmlspecialchars with ENT_QUOTES|ENT_HTML5)
+     * to match Blade's {{ $var }} behaviour. Pass URLs with plain & — they
+     * become &amp; in the output, same as Blade would render them.
+     *
+     * For raw HTML or pre-escaped values, pre-encode the value and the escape
+     * will be a no-op for already-encoded chars. (htmlspecialchars without
+     * the double_encode=false flag does double-encode; the cleaner pattern is
+     * to keep merge values as plain-text and let this method encode them.)
+     *
+     * @param array<string,mixed> $vars
+     */
+    public function substitute(string $html, array $vars, string $context = ''): string
+    {
+        $replacements = [];
+        foreach ($vars as $key => $value) {
+            // Match Blade's e() helper exactly — same flag set Laravel uses
+            // for {{ $var }} interpolation — so the bulk-substituted output
+            // is byte-identical to what Blade would have produced for the
+            // same value.
+            $replacements['{{'.$key.'}}'] = htmlspecialchars(
+                (string) $value,
+                ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5,
+                'UTF-8'
+            );
+        }
+
+        $result = strtr($html, $replacements);
+
+        // Fail-loud on any remaining placeholders. If a placeholder slips
+        // through to a sent email it appears as visible garbage to the
+        // recipient. Better to crash the send loop than ship broken output.
+        if (preg_match_all('/\{\{([a-zA-Z_][a-zA-Z0-9_]*)\}\}/', $result, $matches)) {
+            $unique = array_values(array_unique($matches[1]));
+            Log::error('BulkMjmlCompiler: unbound placeholders', [
+                'context' => $context,
+                'missing' => $unique,
+            ]);
+            throw new UnboundPlaceholderException($unique, $context);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Render the mailable's bulk template ONCE, capturing HTML with literal
+     * {{name}} placeholders for per-recipient fields. The mailable supplies
+     * both the template path and the bulk data (with placeholders for
+     * per-recipient values in place of real values).
+     */
+    private function renderTemplate(MjmlMailable&BulkRenderable $mailable): string
+    {
+        return $mailable->renderHtmlForBulkCache(
+            $mailable->bulkTemplate(),
+            $mailable->bulkData()
+        );
+    }
+
+    /**
+     * Clear the cache. Typical use: between independent send batches in a
+     * long-running daemon process, to bound memory.
+     */
+    public function clear(): void
+    {
+        $this->cache = [];
+        $this->hitCount = [];
+        $this->compileCount = 0;
+    }
+
+    /**
+     * Telemetry: number of distinct shapes compiled in this instance's lifetime.
+     */
+    public function compileCount(): int
+    {
+        return $this->compileCount;
+    }
+
+    /**
+     * Telemetry: number of recipients served per shape since last clear().
+     *
+     * @return array<string,int>
+     */
+    public function hitCounts(): array
+    {
+        return $this->hitCount;
+    }
+}

--- a/iznik-batch/app/Services/BulkMail/UnboundPlaceholderException.php
+++ b/iznik-batch/app/Services/BulkMail/UnboundPlaceholderException.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Services\BulkMail;
+
+use RuntimeException;
+
+/**
+ * Thrown when substituted HTML still contains unbound {{var}} placeholders.
+ *
+ * This is fail-loud on purpose: an unsubstituted placeholder in a sent email
+ * would be visible as garbage to the recipient. We'd rather raise during the
+ * send loop and skip the message (or fail the cron tick) than ship broken
+ * output.
+ */
+class UnboundPlaceholderException extends RuntimeException
+{
+    public function __construct(
+        public readonly array $missingKeys,
+        public readonly string $mailableClass = ''
+    ) {
+        $keys = implode(', ', $missingKeys);
+        $cls = $mailableClass !== '' ? " in {$mailableClass}" : '';
+        parent::__construct("Unbound merge placeholders{$cls}: {$keys}");
+    }
+}

--- a/iznik-batch/app/Services/EventsDigestService.php
+++ b/iznik-batch/app/Services/EventsDigestService.php
@@ -2,14 +2,15 @@
 
 namespace App\Services;
 
+use App\Mail\Concerns\BulkRenderable;
 use App\Mail\Event\EventsDigestMail;
+use App\Services\BulkMail\BulkMjmlCompiler;
 use App\Models\Group;
 use App\Models\Membership;
 use App\Models\User;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\Mail;
 
 class EventsDigestService
 {
@@ -165,6 +166,12 @@ class EventsDigestService
                 ->receivingOurMails()
                 ->get();
 
+            // One BulkMjmlCompiler per group: all members of this group share
+            // events + groupName, so one MJML compile feeds every member's
+            // substitution.
+            $bulkEnabled = (bool) config('freegle.bulk_mail.enabled', true);
+            $bulkCompiler = $bulkEnabled ? app(BulkMjmlCompiler::class) : null;
+
             foreach ($members as $member) {
                 // V1 parity: pick the user's preferred external email and skip
                 // when they have none (only internal-alias addresses).
@@ -175,20 +182,25 @@ class EventsDigestService
 
                 if (!$dryRun) {
                     $unsubscribeUrl = "{$userSite}/unsubscribe?email=" . urlencode($email);
+                    $mailable = new EventsDigestMail(
+                        recipientEmail: $email,
+                        groupName: $groupRow->nameshort,
+                        events: $eventData,
+                        unsubscribeUrl: $unsubscribeUrl,
+                        userId: $member->userId,
+                    );
+
+                    if ($bulkCompiler !== null && $mailable instanceof BulkRenderable) {
+                        $mailable->setPrerenderedHtml($bulkCompiler->htmlFor($mailable));
+                    }
+
                     // spool() builds the message (incl. MJML render) up front and
                     // only swallows permanent address failures internally; a
                     // transient render/build error re-throws. Without this catch
                     // it would escape the per-member foreach and abort the whole
-                    // digest run — the resilience SafeMail::sendMailable used to
-                    // provide. Skip the one recipient and keep the loop going.
+                    // digest run. Skip the one recipient and keep the loop going.
                     try {
-                        app(\App\Services\EmailSpoolerService::class)->spool(new EventsDigestMail(
-                            recipientEmail: $email,
-                            groupName: $groupRow->nameshort,
-                            events: $eventData,
-                            unsubscribeUrl: $unsubscribeUrl,
-                            userId: $member->userId,
-                        ), $email);
+                        app(\App\Services\EmailSpoolerService::class)->spool($mailable, $email);
                     } catch (\Throwable $e) {
                         Log::warning('Skipping events digest for member after spool failure; continuing loop', [
                             'email' => $email,

--- a/iznik-batch/app/Services/EventsDigestService.php
+++ b/iznik-batch/app/Services/EventsDigestService.php
@@ -190,16 +190,22 @@ class EventsDigestService
                         userId: $member->userId,
                     );
 
-                    if ($bulkCompiler !== null && $mailable instanceof BulkRenderable) {
-                        $mailable->setPrerenderedHtml($bulkCompiler->htmlFor($mailable));
-                    }
-
                     // spool() builds the message (incl. MJML render) up front and
                     // only swallows permanent address failures internally; a
                     // transient render/build error re-throws. Without this catch
                     // it would escape the per-member foreach and abort the whole
                     // digest run. Skip the one recipient and keep the loop going.
                     try {
+                        if ($bulkCompiler !== null && $mailable instanceof BulkRenderable) {
+                            try {
+                                $mailable->setPrerenderedHtml($bulkCompiler->htmlFor($mailable));
+                            } catch (\Throwable $bulkE) {
+                                Log::warning('BulkMjmlCompiler failed; falling back to per-user MJML compile', [
+                                    'email' => $email,
+                                    'error' => $bulkE->getMessage(),
+                                ]);
+                            }
+                        }
                         app(\App\Services\EmailSpoolerService::class)->spool($mailable, $email);
                     } catch (\Throwable $e) {
                         Log::warning('Skipping events digest for member after spool failure; continuing loop', [

--- a/iznik-batch/app/Services/StoriesAskService.php
+++ b/iznik-batch/app/Services/StoriesAskService.php
@@ -119,7 +119,14 @@ class StoriesAskService
                     );
 
                     if ($bulkCompiler !== null && $mailable instanceof BulkRenderable) {
-                        $mailable->setPrerenderedHtml($bulkCompiler->htmlFor($mailable));
+                        try {
+                            $mailable->setPrerenderedHtml($bulkCompiler->htmlFor($mailable));
+                        } catch (\Throwable $bulkE) {
+                            Log::warning('BulkMjmlCompiler failed; falling back to per-user MJML compile', [
+                                'email' => $email,
+                                'error' => $bulkE->getMessage(),
+                            ]);
+                        }
                     }
 
                     app(\App\Services\EmailSpoolerService::class)->spool($mailable);

--- a/iznik-batch/app/Services/StoriesAskService.php
+++ b/iznik-batch/app/Services/StoriesAskService.php
@@ -2,11 +2,12 @@
 
 namespace App\Services;
 
+use App\Mail\Concerns\BulkRenderable;
 use App\Mail\Stories\AskMail;
 use App\Models\Group;
 use App\Models\Message;
+use App\Services\BulkMail\BulkMjmlCompiler;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Mail;
 
 class StoriesAskService
 {
@@ -26,6 +27,11 @@ class StoriesAskService
      */
     public function askForStories(bool $dryRun = false): array
     {
+        // One BulkMjmlCompiler per ask run: every recipient shares the same
+        // storiesUrl + unsubscribeUrl, so one MJML compile feeds N substitutions.
+        $bulkEnabled = (bool) config('freegle.bulk_mail.enabled', true);
+        $bulkCompiler = $bulkEnabled ? app(BulkMjmlCompiler::class) : null;
+
         $earliest = max(
             strtotime(self::EARLIEST_DATE),
             strtotime('midnight 90 days ago')
@@ -105,12 +111,18 @@ class StoriesAskService
                     ?: 'Freegle User';
 
                 if ($email) {
-                    app(\App\Services\EmailSpoolerService::class)->spool(new AskMail(
+                    $mailable = new AskMail(
                         recipientName: $name,
                         recipientEmail: $email,
                         storiesUrl: config('freegle.sites.user') . '/stories',
                         unsubscribeUrl: config('freegle.sites.user') . '/unsubscribe',
-                    ));
+                    );
+
+                    if ($bulkCompiler !== null && $mailable instanceof BulkRenderable) {
+                        $mailable->setPrerenderedHtml($bulkCompiler->htmlFor($mailable));
+                    }
+
+                    app(\App\Services\EmailSpoolerService::class)->spool($mailable);
                 }
             }
         }

--- a/iznik-batch/app/Services/StoriesNewsletterService.php
+++ b/iznik-batch/app/Services/StoriesNewsletterService.php
@@ -2,12 +2,13 @@
 
 namespace App\Services;
 
+use App\Mail\Concerns\BulkRenderable;
 use App\Mail\Stories\StoriesNewsletterMail;
 use App\Mail\Traits\FeatureFlags;
 use App\Models\Group;
+use App\Services\BulkMail\BulkMjmlCompiler;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\Mail;
 
 class StoriesNewsletterService
 {
@@ -181,6 +182,13 @@ class StoriesNewsletterService
             ->distinct()
             ->select('users.id');
 
+        // One BulkMjmlCompiler for the whole newsletter run. All eligible
+        // recipients share the same content (stories, hero, CTAs) — the only
+        // body variation is the "sent to {email}" footer line. ⇒ exactly one
+        // MJML sidecar call instead of N.
+        $bulkEnabled = (bool) config('freegle.bulk_mail.enabled', true);
+        $bulkCompiler = $bulkEnabled ? app(BulkMjmlCompiler::class) : null;
+
         // Stream eligible members in keyset-paginated chunks; pluck()-ing the entire
         // eligible newsletter userbase (hundreds of thousands of ids) at once exhausts memory.
         foreach ($eligibleMembers->lazyById(1000, 'users.id', 'id') as $member) {
@@ -201,7 +209,7 @@ class StoriesNewsletterService
                 ?? trim(($user->firstname ?? '') . ' ' . ($user->lastname ?? ''))
                 ?: 'Freegle Member';
 
-            app(\App\Services\EmailSpoolerService::class)->spool(new StoriesNewsletterMail(
+            $mailable = new StoriesNewsletterMail(
                 userId: $userId,
                 recipientName: $name,
                 recipientEmail: $email,
@@ -213,9 +221,22 @@ class StoriesNewsletterService
                 previewText: $preview,
                 unsubscribeUrl: "{$userSite}/unsubscribe",
                 settingsUrl: "{$userSite}/settings",
-            ));
+            );
+
+            if ($bulkCompiler !== null && $mailable instanceof BulkRenderable) {
+                $mailable->setPrerenderedHtml($bulkCompiler->htmlFor($mailable));
+            }
+
+            app(\App\Services\EmailSpoolerService::class)->spool($mailable);
 
             $stats['sent']++;
+        }
+
+        if ($bulkCompiler !== null) {
+            Log::info('StoriesNewsletterService: bulk compile stats', [
+                'compiles' => $bulkCompiler->compileCount(),
+                'hits' => $bulkCompiler->hitCounts(),
+            ]);
         }
 
         return $stats;

--- a/iznik-batch/app/Services/StoriesNewsletterService.php
+++ b/iznik-batch/app/Services/StoriesNewsletterService.php
@@ -224,7 +224,14 @@ class StoriesNewsletterService
             );
 
             if ($bulkCompiler !== null && $mailable instanceof BulkRenderable) {
-                $mailable->setPrerenderedHtml($bulkCompiler->htmlFor($mailable));
+                try {
+                    $mailable->setPrerenderedHtml($bulkCompiler->htmlFor($mailable));
+                } catch (\Throwable $bulkE) {
+                    Log::warning('BulkMjmlCompiler failed; falling back to per-user MJML compile', [
+                        'email' => $email,
+                        'error' => $bulkE->getMessage(),
+                    ]);
+                }
             }
 
             app(\App\Services\EmailSpoolerService::class)->spool($mailable);

--- a/iznik-batch/app/Services/UnifiedDigestService.php
+++ b/iznik-batch/app/Services/UnifiedDigestService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Mail\Concerns\BulkRenderable;
 use App\Mail\Digest\UnifiedDigest;
 use App\Mail\Traits\FeatureFlags;
 use App\Models\Membership;
@@ -9,10 +10,10 @@ use App\Models\Message;
 use App\Models\MessageGroup;
 use App\Models\User;
 use App\Models\UserDigest;
+use App\Services\BulkMail\BulkMjmlCompiler;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\Mail;
 
 /**
  * Service for sending unified Freegle digests.
@@ -249,6 +250,12 @@ class UnifiedDigestService
         $lastProcessed = null;
         $deferred = false;
 
+        // Per-message process-local cache of compiled HTML keyed by recipient
+        // shape. Lets us call the MJML sidecar once per shape instead of once
+        // per recipient. Fresh instance per message so memory is bounded —
+        // see BulkMjmlCompiler / docs/superpowers/specs spec for context.
+        $bulkEnabled = (bool) config('freegle.bulk_mail.enabled', true);
+
         foreach ($messages as $message) {
             // Defer messages without a usable attachment so the email
             // doesn't render with a generic placeholder while AI image
@@ -264,6 +271,8 @@ class UnifiedDigestService
             }
 
             $sponsorsCache = null;
+            $bulkCompiler = $bulkEnabled ? app(BulkMjmlCompiler::class) : null;
+
             foreach ($users as $uid => $user) {
                 if ((int) $message->fromuser === (int) $uid) {
                     continue;
@@ -283,6 +292,15 @@ class UnifiedDigestService
                     $deduped = collect([
                         ['message' => $message, 'postedToGroups' => [$groupid]],
                     ]);
+                    $mailable = new UnifiedDigest($user, $deduped, self::MODE_IMMEDIATE, $sponsorsCache);
+
+                    if ($bulkCompiler !== null && $mailable instanceof BulkRenderable) {
+                        // Shape-cached compile: one MJML sidecar call per
+                        // shape bucket, N cheap substitutions for N users.
+                        $html = $bulkCompiler->htmlFor($mailable);
+                        $mailable->setPrerenderedHtml($html);
+                    }
+
                     // Spool through EmailSpoolerService so transient SMTP
                     // failures get retried by the processor rather than
                     // dropping a recipient. Permanent address-rejection
@@ -300,7 +318,7 @@ class UnifiedDigestService
                     // recipient, and let the message still count as processed.
                     try {
                         app(\App\Services\EmailSpoolerService::class)->spool(
-                            new UnifiedDigest($user, $deduped, self::MODE_IMMEDIATE, $sponsorsCache),
+                            $mailable,
                             $user->email_preferred,
                             emailType: 'digest_immediate',
                         );
@@ -316,6 +334,14 @@ class UnifiedDigestService
                 }
                 $emailsSent++;
                 $touched[$uid] = true;
+            }
+
+            if ($bulkCompiler !== null) {
+                Log::debug('UnifiedDigestService: bulk compile stats for message', [
+                    'message_id' => $message->id,
+                    'compiles' => $bulkCompiler->compileCount(),
+                    'hits' => $bulkCompiler->hitCounts(),
+                ]);
             }
 
             $lastProcessed = $message;

--- a/iznik-batch/app/Services/UnifiedDigestService.php
+++ b/iznik-batch/app/Services/UnifiedDigestService.php
@@ -294,13 +294,6 @@ class UnifiedDigestService
                     ]);
                     $mailable = new UnifiedDigest($user, $deduped, self::MODE_IMMEDIATE, $sponsorsCache);
 
-                    if ($bulkCompiler !== null && $mailable instanceof BulkRenderable) {
-                        // Shape-cached compile: one MJML sidecar call per
-                        // shape bucket, N cheap substitutions for N users.
-                        $html = $bulkCompiler->htmlFor($mailable);
-                        $mailable->setPrerenderedHtml($html);
-                    }
-
                     // Spool through EmailSpoolerService so transient SMTP
                     // failures get retried by the processor rather than
                     // dropping a recipient. Permanent address-rejection
@@ -317,6 +310,25 @@ class UnifiedDigestService
                     // copies of the same post in 13 min. Catch it, skip the one
                     // recipient, and let the message still count as processed.
                     try {
+                        if ($bulkCompiler !== null && $mailable instanceof BulkRenderable) {
+                            // Shape-cached compile: one MJML sidecar call per
+                            // shape bucket, N cheap substitutions for N users.
+                            // If the bulk compile fails (sidecar down, template
+                            // error, etc.) fall back to the per-user compile
+                            // path inside spool() — an optimisation failure
+                            // must never drop a recipient.
+                            try {
+                                $mailable->setPrerenderedHtml($bulkCompiler->htmlFor($mailable));
+                            } catch (\Throwable $bulkE) {
+                                Log::warning('BulkMjmlCompiler failed; falling back to per-user MJML compile', [
+                                    'user_id' => $uid,
+                                    'group' => $groupid,
+                                    'msgid' => (int) $message->mg_msgid,
+                                    'error' => $bulkE->getMessage(),
+                                ]);
+                            }
+                        }
+
                         app(\App\Services\EmailSpoolerService::class)->spool(
                             $mailable,
                             $user->email_preferred,

--- a/iznik-batch/app/Services/VolunteeringDigestService.php
+++ b/iznik-batch/app/Services/VolunteeringDigestService.php
@@ -213,16 +213,22 @@ class VolunteeringDigestService
                         userId: $member->userId,
                     );
 
-                    if ($bulkCompiler !== null && $mailable instanceof BulkRenderable) {
-                        $mailable->setPrerenderedHtml($bulkCompiler->htmlFor($mailable));
-                    }
-
                     // spool() builds the message (incl. MJML render) up front and
                     // only swallows permanent address failures internally; a
                     // transient render/build error re-throws. Without this catch
                     // it would escape the per-member foreach and abort the whole
                     // digest run. Skip the one recipient and keep the loop going.
                     try {
+                        if ($bulkCompiler !== null && $mailable instanceof BulkRenderable) {
+                            try {
+                                $mailable->setPrerenderedHtml($bulkCompiler->htmlFor($mailable));
+                            } catch (\Throwable $bulkE) {
+                                Log::warning('BulkMjmlCompiler failed; falling back to per-user MJML compile', [
+                                    'email' => $email,
+                                    'error' => $bulkE->getMessage(),
+                                ]);
+                            }
+                        }
                         app(\App\Services\EmailSpoolerService::class)->spool($mailable, $email);
                     } catch (\Throwable $e) {
                         Log::warning('Skipping volunteering digest for member after spool failure; continuing loop', [

--- a/iznik-batch/app/Services/VolunteeringDigestService.php
+++ b/iznik-batch/app/Services/VolunteeringDigestService.php
@@ -2,14 +2,15 @@
 
 namespace App\Services;
 
+use App\Mail\Concerns\BulkRenderable;
 use App\Mail\Volunteering\VolunteeringDigestMail;
+use App\Services\BulkMail\BulkMjmlCompiler;
 use App\Models\Group;
 use App\Models\Membership;
 use App\Models\User;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\Mail;
 
 class VolunteeringDigestService
 {
@@ -179,6 +180,12 @@ class VolunteeringDigestService
                 ->receivingOurMails()
                 ->get();
 
+            // One BulkMjmlCompiler per group: members without nearby jobs all
+            // share one cached body, so we go from N MJML compiles to ~1.
+            // Members with jobs fall back to per-user compile (jobs differ).
+            $bulkEnabled = (bool) config('freegle.bulk_mail.enabled', true);
+            $bulkCompiler = $bulkEnabled ? app(BulkMjmlCompiler::class) : null;
+
             foreach ($members as $member) {
                 $user = User::find($member->userId);
 
@@ -197,21 +204,26 @@ class VolunteeringDigestService
 
                 if (!$dryRun) {
                     $unsubscribeUrl = "{$userSite}/unsubscribe?email=" . urlencode($email);
+                    $mailable = new VolunteeringDigestMail(
+                        recipientEmail: $email,
+                        groupName: $groupRow->nameshort,
+                        volunteerings: $volData,
+                        unsubscribeUrl: $unsubscribeUrl,
+                        jobAds: $jobAds,
+                        userId: $member->userId,
+                    );
+
+                    if ($bulkCompiler !== null && $mailable instanceof BulkRenderable) {
+                        $mailable->setPrerenderedHtml($bulkCompiler->htmlFor($mailable));
+                    }
+
                     // spool() builds the message (incl. MJML render) up front and
                     // only swallows permanent address failures internally; a
                     // transient render/build error re-throws. Without this catch
                     // it would escape the per-member foreach and abort the whole
-                    // digest run — the resilience SafeMail::sendMailable used to
-                    // provide. Skip the one recipient and keep the loop going.
+                    // digest run. Skip the one recipient and keep the loop going.
                     try {
-                        app(\App\Services\EmailSpoolerService::class)->spool(new VolunteeringDigestMail(
-                            recipientEmail: $email,
-                            groupName: $groupRow->nameshort,
-                            volunteerings: $volData,
-                            unsubscribeUrl: $unsubscribeUrl,
-                            jobAds: $jobAds,
-                            userId: $member->userId,
-                        ), $email);
+                        app(\App\Services\EmailSpoolerService::class)->spool($mailable, $email);
                     } catch (\Throwable $e) {
                         Log::warning('Skipping volunteering digest for member after spool failure; continuing loop', [
                             'email' => $email,

--- a/iznik-batch/config/freegle.php
+++ b/iznik-batch/config/freegle.php
@@ -118,6 +118,17 @@ return [
         'daily_allowlist' => env('FREEGLE_DIGEST_DAILY_ALLOWLIST', ''),
     ],
 
+    // Bulk-send MJML compile cache: when true, mailables that implement
+    // App\Mail\Concerns\BulkRenderable run their template compile once per
+    // recipient SHAPE and substitute per-recipient merge vars into the
+    // cached HTML. Cuts MJML sidecar load on batch sends (immediate digest,
+    // newsletters, donation asks, mod notifications). Flip to false to
+    // fall every send back to the per-recipient compile path (a roll-back
+    // hatch if a regression slips through).
+    'bulk_mail' => [
+        'enabled' => env('FREEGLE_BULK_MAIL_ENABLED', true),
+    ],
+
     // Firebase Cloud Messaging for push notifications
     'firebase' => [
         'credentials_path' => env('FIREBASE_CREDENTIALS_PATH', '/etc/firebase.json'),

--- a/iznik-batch/resources/views/emails/mjml/digest/unified.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/digest/unified.blade.php
@@ -517,7 +517,7 @@
         </mj-section>
         @endif
 
-        @include('emails.mjml.partials.footer', ['email' => $user->email_preferred, 'settingsUrl' => $settingsUrl, 'unsubscribeUrl' => $unsubscribeUrl])
+        @include('emails.mjml.partials.footer', ['email' => $userEmail ?? $user->email_preferred, 'settingsUrl' => $settingsUrl, 'unsubscribeUrl' => $unsubscribeUrl])
 
         @if(isset($trackingPixelMjml))
         {!! $trackingPixelMjml !!}

--- a/iznik-batch/tests/Unit/Mail/BulkRenderableIsolationTest.php
+++ b/iznik-batch/tests/Unit/Mail/BulkRenderableIsolationTest.php
@@ -1,0 +1,496 @@
+<?php
+
+namespace Tests\Unit\Mail;
+
+use App\Mail\Concerns\BulkRenderable;
+use App\Mail\Event\EventsDigestMail;
+use App\Mail\MjmlMailable;
+use App\Mail\Stories\AskMail;
+use App\Mail\Stories\StoriesNewsletterMail;
+use App\Mail\Volunteering\VolunteeringDigestMail;
+use App\Services\BulkMail\BulkMjmlCompiler;
+use App\Services\BulkMail\UnboundPlaceholderException;
+use App\Services\MjmlCompilerService;
+use Illuminate\Mail\Mailables\Envelope;
+use Tests\Support\IsolatedSpoolDirectory;
+use Tests\TestCase;
+
+/**
+ * W2 — Cross-recipient isolation: proves that when two instances of the same
+ *       bulk-capable mailable share the same compiler (same shape bucket), each
+ *       recipient sees only their own per-recipient values and never the other's.
+ *
+ * I6 — Fallback path: proves that when the bulk path is unavailable (compile
+ *       throws, or bulkData/mergeVars is not called), the mailable falls back
+ *       to the standard per-recipient build() path and still produces correct output.
+ */
+class BulkRenderableIsolationTest extends TestCase
+{
+    use IsolatedSpoolDirectory;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpIsolatedSpoolDirectory();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownIsolatedSpoolDirectory();
+        parent::tearDown();
+    }
+
+    // -----------------------------------------------------------------------
+    // W2 — Cross-recipient isolation tests
+    // -----------------------------------------------------------------------
+
+    /**
+     * For StoriesNewsletterMail: two instances (Alice / Bob) run through the
+     * SAME BulkMjmlCompiler. Bob's rendered HTML must contain Bob's email and
+     * name, never Alice's.
+     *
+     * This test would have FAILED before the W1 fix because $name was baked
+     * literally into bulkData() — Alice's name would have appeared in Bob's
+     * compiled template.
+     */
+    public function test_stories_newsletter_cross_recipient_isolation(): void
+    {
+        $stories = [
+            ['headline' => 'A tale', 'username' => 'Carol', 'groupname' => 'London',
+             'story' => 'Got a lamp.', 'profileurl' => '', 'photo' => null],
+        ];
+        $common = [
+            'stories'        => $stories,
+            'headerImageUrl' => 'https://x/header.png',
+            'tellUrl'        => 'https://x/stories',
+            'giveUrl'        => 'https://x/give',
+            'findUrl'        => 'https://x/find',
+            'previewText'    => 'stories',
+            'unsubscribeUrl' => 'https://x/unsubscribe',
+            'settingsUrl'    => 'https://x/settings',
+        ];
+
+        $mailA = new StoriesNewsletterMail(
+            userId: 1,
+            recipientName: 'Alice Smith',
+            recipientEmail: 'alice@example.com',
+            stories: $common['stories'],
+            headerImageUrl: $common['headerImageUrl'],
+            tellUrl: $common['tellUrl'],
+            giveUrl: $common['giveUrl'],
+            findUrl: $common['findUrl'],
+            previewText: $common['previewText'],
+            unsubscribeUrl: $common['unsubscribeUrl'],
+            settingsUrl: $common['settingsUrl'],
+        );
+        $mailB = new StoriesNewsletterMail(
+            userId: 2,
+            recipientName: 'Bob Jones',
+            recipientEmail: 'bob@example.com',
+            stories: $common['stories'],
+            headerImageUrl: $common['headerImageUrl'],
+            tellUrl: $common['tellUrl'],
+            giveUrl: $common['giveUrl'],
+            findUrl: $common['findUrl'],
+            previewText: $common['previewText'],
+            unsubscribeUrl: $common['unsubscribeUrl'],
+            settingsUrl: $common['settingsUrl'],
+        );
+
+        $compiler = app(BulkMjmlCompiler::class);
+
+        $htmlA = $compiler->htmlFor($mailA);
+        $mailA->setPrerenderedHtml($htmlA);
+        $idA = $this->spooler->spool($mailA, 'alice@example.com');
+        $dataA = json_decode(file_get_contents($this->testSpoolDir.'/pending/'.$idA.'.json'), true);
+        $renderedA = $dataA['html'] ?? '';
+
+        $htmlB = $compiler->htmlFor($mailB);
+        $mailB->setPrerenderedHtml($htmlB);
+        $idB = $this->spooler->spool($mailB, 'bob@example.com');
+        $dataB = json_decode(file_get_contents($this->testSpoolDir.'/pending/'.$idB.'.json'), true);
+        $renderedB = $dataB['html'] ?? '';
+
+        // Bob's email should appear in Bob's render.
+        $this->assertStringContainsString(
+            'bob@example.com',
+            $renderedB,
+            'Bob\'s email must appear in Bob\'s rendered HTML'
+        );
+
+        // Alice's email must NOT bleed into Bob's render.
+        $this->assertStringNotContainsString(
+            'alice@example.com',
+            $renderedB,
+            'Alice\'s email must not appear in Bob\'s rendered HTML (cross-recipient bleed)'
+        );
+
+        // Symmetric: Alice's render must not contain Bob's email.
+        $this->assertStringNotContainsString(
+            'bob@example.com',
+            $renderedA,
+            'Bob\'s email must not appear in Alice\'s rendered HTML (cross-recipient bleed)'
+        );
+    }
+
+    /**
+     * For AskMail: two recipients (Alice / Bob) share the same compiler.
+     * Each recipient's name and email must be isolated.
+     */
+    public function test_ask_mail_cross_recipient_isolation(): void
+    {
+        $mailA = new AskMail(
+            recipientName: 'Alice Smith',
+            recipientEmail: 'alice@example.com',
+            storiesUrl: 'https://x/stories',
+            unsubscribeUrl: 'https://x/unsubscribe',
+        );
+        $mailB = new AskMail(
+            recipientName: 'Bob Jones',
+            recipientEmail: 'bob@example.com',
+            storiesUrl: 'https://x/stories',
+            unsubscribeUrl: 'https://x/unsubscribe',
+        );
+
+        $compiler = app(BulkMjmlCompiler::class);
+
+        $htmlA = $compiler->htmlFor($mailA);
+        $mailA->setPrerenderedHtml($htmlA);
+        $idA = $this->spooler->spool($mailA, 'alice@example.com');
+        $dataA = json_decode(file_get_contents($this->testSpoolDir.'/pending/'.$idA.'.json'), true);
+        $renderedA = $dataA['html'] ?? '';
+
+        $htmlB = $compiler->htmlFor($mailB);
+        $mailB->setPrerenderedHtml($htmlB);
+        $idB = $this->spooler->spool($mailB, 'bob@example.com');
+        $dataB = json_decode(file_get_contents($this->testSpoolDir.'/pending/'.$idB.'.json'), true);
+        $renderedB = $dataB['html'] ?? '';
+
+        // Each recipient's name should appear in their own render.
+        $this->assertStringContainsString(
+            'Bob Jones',
+            $renderedB,
+            'Bob\'s name must appear in Bob\'s rendered HTML'
+        );
+        $this->assertStringContainsString(
+            'bob@example.com',
+            $renderedB,
+            'Bob\'s email must appear in Bob\'s rendered HTML'
+        );
+
+        // No cross-contamination.
+        $this->assertStringNotContainsString(
+            'alice@example.com',
+            $renderedB,
+            'Alice\'s email must not appear in Bob\'s rendered HTML'
+        );
+        $this->assertStringNotContainsString(
+            'Alice Smith',
+            $renderedB,
+            'Alice\'s name must not appear in Bob\'s rendered HTML'
+        );
+
+        // Symmetric check.
+        $this->assertStringNotContainsString(
+            'bob@example.com',
+            $renderedA,
+            'Bob\'s email must not appear in Alice\'s rendered HTML'
+        );
+    }
+
+    /**
+     * For EventsDigestMail: two recipients with different emails share the same compiler.
+     * Email must be isolated per recipient.
+     */
+    public function test_events_digest_cross_recipient_isolation(): void
+    {
+        $events = [
+            ['title' => 'Repair Café', 'url' => 'https://x/event/1', 'start' => '2026-06-01 14:00',
+             'end' => '', 'location' => 'Town Hall', 'description' => 'Bring your broken things.', 'imageUrl' => null],
+        ];
+        $common = [
+            'groupName'      => 'Test Group',
+            'events'         => $events,
+            'unsubscribeUrl' => 'https://x/unsubscribe',
+            'userId'         => 42,
+        ];
+
+        $mailA = new EventsDigestMail(
+            recipientEmail: 'alice@example.com',
+            groupName: $common['groupName'],
+            events: $common['events'],
+            unsubscribeUrl: $common['unsubscribeUrl'],
+            userId: $common['userId'],
+        );
+        $mailB = new EventsDigestMail(
+            recipientEmail: 'bob@example.com',
+            groupName: $common['groupName'],
+            events: $common['events'],
+            unsubscribeUrl: $common['unsubscribeUrl'],
+            userId: $common['userId'],
+        );
+
+        $compiler = app(BulkMjmlCompiler::class);
+
+        $htmlA = $compiler->htmlFor($mailA);
+        $mailA->setPrerenderedHtml($htmlA);
+        $idA = $this->spooler->spool($mailA, 'alice@example.com');
+        $dataA = json_decode(file_get_contents($this->testSpoolDir.'/pending/'.$idA.'.json'), true);
+        $renderedA = $dataA['html'] ?? '';
+
+        $htmlB = $compiler->htmlFor($mailB);
+        $mailB->setPrerenderedHtml($htmlB);
+        $idB = $this->spooler->spool($mailB, 'bob@example.com');
+        $dataB = json_decode(file_get_contents($this->testSpoolDir.'/pending/'.$idB.'.json'), true);
+        $renderedB = $dataB['html'] ?? '';
+
+        $this->assertStringContainsString('bob@example.com', $renderedB,
+            'Bob\'s email must appear in Bob\'s rendered HTML');
+        $this->assertStringNotContainsString('alice@example.com', $renderedB,
+            'Alice\'s email must not appear in Bob\'s rendered HTML');
+        $this->assertStringNotContainsString('bob@example.com', $renderedA,
+            'Bob\'s email must not appear in Alice\'s rendered HTML');
+    }
+
+    /**
+     * For VolunteeringDigestMail: same isolation guarantee holds.
+     */
+    public function test_volunteering_digest_cross_recipient_isolation(): void
+    {
+        $vols = [
+            ['title' => 'Garden helper', 'url' => 'https://x/vol/1',
+             'description' => 'Help out.', 'photo_thumb' => null],
+        ];
+        $common = [
+            'groupName'      => 'Test Group',
+            'volunteerings'  => $vols,
+            'unsubscribeUrl' => 'https://x/unsubscribe',
+            'jobAds'         => collect(),
+            'userId'         => 42,
+        ];
+
+        $mailA = new VolunteeringDigestMail(
+            recipientEmail: 'alice@example.com',
+            groupName: $common['groupName'],
+            volunteerings: $common['volunteerings'],
+            unsubscribeUrl: $common['unsubscribeUrl'],
+            jobAds: $common['jobAds'],
+            userId: $common['userId'],
+        );
+        $mailB = new VolunteeringDigestMail(
+            recipientEmail: 'bob@example.com',
+            groupName: $common['groupName'],
+            volunteerings: $common['volunteerings'],
+            unsubscribeUrl: $common['unsubscribeUrl'],
+            jobAds: $common['jobAds'],
+            userId: $common['userId'],
+        );
+
+        $compiler = app(BulkMjmlCompiler::class);
+
+        $htmlA = $compiler->htmlFor($mailA);
+        $mailA->setPrerenderedHtml($htmlA);
+        $idA = $this->spooler->spool($mailA, 'alice@example.com');
+        $dataA = json_decode(file_get_contents($this->testSpoolDir.'/pending/'.$idA.'.json'), true);
+        $renderedA = $dataA['html'] ?? '';
+
+        $htmlB = $compiler->htmlFor($mailB);
+        $mailB->setPrerenderedHtml($htmlB);
+        $idB = $this->spooler->spool($mailB, 'bob@example.com');
+        $dataB = json_decode(file_get_contents($this->testSpoolDir.'/pending/'.$idB.'.json'), true);
+        $renderedB = $dataB['html'] ?? '';
+
+        $this->assertStringContainsString('bob@example.com', $renderedB,
+            'Bob\'s email must appear in Bob\'s rendered HTML');
+        $this->assertStringNotContainsString('alice@example.com', $renderedB,
+            'Alice\'s email must not appear in Bob\'s rendered HTML');
+        $this->assertStringNotContainsString('bob@example.com', $renderedA,
+            'Bob\'s email must not appear in Alice\'s rendered HTML');
+    }
+
+    // -----------------------------------------------------------------------
+    // I6 — Fallback path tests
+    // -----------------------------------------------------------------------
+
+    /**
+     * When setPrerenderedHtml() is never called (i.e. the bulk path was not
+     * used), the mailable's standard build() path runs and produces correct
+     * output containing the recipient's real data.
+     *
+     * This confirms that prerenderedHtml === null triggers the normal Blade +
+     * MJML pipeline, not a blank or broken response.
+     */
+    public function test_stories_newsletter_falls_back_to_per_recipient_build_when_bulk_path_unused(): void
+    {
+        $stories = [
+            ['headline' => 'A tale', 'username' => 'Carol', 'groupname' => 'London',
+             'story' => 'Got a lamp.', 'profileurl' => '', 'photo' => null],
+        ];
+
+        $mail = new StoriesNewsletterMail(
+            userId: 1,
+            recipientName: 'Fallback User',
+            recipientEmail: 'fallback@example.com',
+            stories: $stories,
+            headerImageUrl: 'https://x/header.png',
+            tellUrl: 'https://x/stories',
+            giveUrl: 'https://x/give',
+            findUrl: 'https://x/find',
+            previewText: 'stories',
+            unsubscribeUrl: 'https://x/unsubscribe',
+            settingsUrl: 'https://x/settings',
+        );
+
+        // Do NOT call setPrerenderedHtml — simulate no bulk path.
+        $id = $this->spooler->spool($mail, 'fallback@example.com');
+        $data = json_decode(file_get_contents($this->testSpoolDir.'/pending/'.$id.'.json'), true);
+        $html = $data['html'] ?? '';
+
+        // The standard build() path must produce non-empty HTML with the email in it.
+        $this->assertNotEmpty($html, 'Fallback build must produce non-empty HTML');
+        $this->assertStringContainsString(
+            'fallback@example.com',
+            $html,
+            'Fallback HTML must contain recipient email'
+        );
+    }
+
+    /**
+     * When the bulk compile path throws (compiler returns an error / is stubbed
+     * to fail), the caller can fall back to the standard per-recipient build.
+     * The mailable must still render correctly when prerenderedHtml is not set.
+     *
+     * This verifies the fallback contract: prerenderedHtml === null means
+     * mjmlView() runs the full Blade + MJML pipeline (no short-circuit).
+     */
+    public function test_bulk_compile_failure_allows_fallback_to_normal_build(): void
+    {
+        // Verify the fallback contract: when the BulkMjmlCompiler's renderTemplate()
+        // throws (for any reason), and the caller does NOT call setPrerenderedHtml(),
+        // the mailable's build() runs the standard Blade + MJML pipeline.
+        //
+        // We simulate a bulk-path failure by constructing a throwaway compiler that
+        // always throws from htmlFor(), without touching the container-bound
+        // MjmlCompilerService (the real one is used for the fallback build).
+
+        // Anonymous subclass that overrides htmlFor to always throw.
+        $alwaysFailCompiler = new class(app(MjmlCompilerService::class)) extends BulkMjmlCompiler {
+            public function htmlFor(\App\Mail\MjmlMailable&BulkRenderable $mailable): string
+            {
+                throw new \RuntimeException('Simulated bulk compile failure');
+            }
+        };
+
+        $mail = new AskMail(
+            recipientName: 'Fallback User',
+            recipientEmail: 'fallback@example.com',
+            storiesUrl: 'https://x/stories',
+            unsubscribeUrl: 'https://x/unsubscribe',
+        );
+
+        // The bulk path throws — caller catches and does NOT set prerenderedHtml.
+        $bulkFailed = false;
+        try {
+            $bulkHtml = $alwaysFailCompiler->htmlFor($mail);
+            $mail->setPrerenderedHtml($bulkHtml);
+        } catch (\RuntimeException $e) {
+            $bulkFailed = true;
+        }
+
+        $this->assertTrue($bulkFailed, 'Bulk compile should have thrown');
+
+        // After the failed bulk attempt, prerenderedHtml is still null, so the
+        // standard mjmlView() pipeline runs. Spool via the isolated spooler
+        // (uses real EmailSpoolerService + real MJML container).
+        $id = $this->spooler->spool($mail, 'fallback@example.com');
+        $data = json_decode(file_get_contents($this->testSpoolDir.'/pending/'.$id.'.json'), true);
+        $html = $data['html'] ?? '';
+
+        $this->assertNotEmpty($html, 'Fallback build after bulk failure must produce non-empty HTML');
+        $this->assertStringContainsString(
+            'fallback@example.com',
+            $html,
+            'Fallback HTML must contain recipient email'
+        );
+    }
+
+    /**
+     * When an UnboundPlaceholderException is thrown during substitute() because
+     * a placeholder in the compiled HTML has no matching mergeVar, the caller
+     * can catch it and fall back to the standard build. The mailable must still
+     * render correctly since prerenderedHtml was never set.
+     */
+    public function test_unbound_placeholder_allows_fallback_to_normal_build(): void
+    {
+        // Build a fake compiler whose substitute always fails with unbound placeholders.
+        // We do this by rendering via a pass-through MJML (no real compile needed)
+        // and manually injecting an unbound placeholder into the cached HTML.
+        $passThroughMjml = new class extends MjmlCompilerService {
+            public function __construct() {}
+            public function compile(string $mjml): string { return $mjml; }
+        };
+
+        // Use an anonymous mailable that injects an unbound placeholder.
+        $mail = new class('fallback@example.com') extends MjmlMailable implements BulkRenderable {
+            public function __construct(private string $email) { parent::__construct(); }
+
+            protected function getSubject(): string { return 'Test'; }
+            public function envelope(): Envelope { return new Envelope(subject: 'Test'); }
+
+            public function shapeKey(): string { return 'test-unbound'; }
+            public function bulkTemplate(): string { return 'unused.in.test'; }
+
+            public function bulkData(): array
+            {
+                // Intentionally includes a placeholder but mergeVars won't cover it.
+                return ['email' => $this->ph('email')];
+            }
+
+            public function mergeVars(): array
+            {
+                return ['email' => $this->email];
+                // NOTE: 'unbound_key' is NOT in mergeVars — simulates a bug/mismatch.
+            }
+
+            public function renderHtmlForBulkCache(string $template, array $sharedData): string
+            {
+                // Return HTML that contains an extra placeholder NOT in mergeVars.
+                $token = $this->bulkToken;
+                return '<html><body>'.$this->email.' {{'.$token.':unbound_key}}</body></html>';
+            }
+
+            public function build(): static
+            {
+                // Standard build: renders directly without MJML for this test.
+                $this->html('<html><body>fallback:'.$this->email.'</body></html>');
+                return $this;
+            }
+        };
+
+        $compiler = new BulkMjmlCompiler($passThroughMjml);
+
+        $bulkFailed = false;
+        try {
+            $bulkHtml = $compiler->htmlFor($mail);
+            $mail->setPrerenderedHtml($bulkHtml);
+        } catch (UnboundPlaceholderException $e) {
+            $bulkFailed = true;
+            // prerenderedHtml stays null — standard build will run.
+        }
+
+        $this->assertTrue($bulkFailed, 'UnboundPlaceholderException must have been thrown');
+
+        // Standard build runs because prerenderedHtml is still null.
+        // Verify by calling build() and checking the mailable renders without throwing.
+        // The anonymous mailable's build() sets html directly (no MJML pipeline needed).
+        $exceptionThrown = null;
+        try {
+            $built = $mail->build();
+            $this->assertSame($mail, $built, 'build() must return $this');
+        } catch (\Throwable $e) {
+            $exceptionThrown = $e;
+        }
+        $this->assertNull($exceptionThrown,
+            'build() must not throw after bulk compile failure — fallback path must work');
+    }
+}

--- a/iznik-batch/tests/Unit/Mail/BulkRenderableMailablesParityTest.php
+++ b/iznik-batch/tests/Unit/Mail/BulkRenderableMailablesParityTest.php
@@ -1,0 +1,249 @@
+<?php
+
+namespace Tests\Unit\Mail;
+
+use App\Mail\Admin\ChaseAdminMail;
+use App\Mail\Concerns\BulkRenderable;
+use App\Mail\Event\EventsDigestMail;
+use App\Mail\Stories\AskMail;
+use App\Mail\Stories\StoriesNewsletterMail;
+use App\Mail\Volunteering\VolunteeringDigestMail;
+use App\Services\BulkMail\BulkMjmlCompiler;
+use Tests\Support\IsolatedSpoolDirectory;
+use Tests\TestCase;
+
+/**
+ * Verifies that the bulk path produces byte-identical HTML to the non-bulk
+ * path for each migrated batch-send mailable. Tracking IDs are normalised
+ * out of the comparison (they're per-instance random strings — each Mailable
+ * instance gets a fresh tracking_id when initTracking() runs).
+ */
+class BulkRenderableMailablesParityTest extends TestCase
+{
+    use IsolatedSpoolDirectory;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpIsolatedSpoolDirectory();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownIsolatedSpoolDirectory();
+        parent::tearDown();
+    }
+
+    private function spooledHtml(\Illuminate\Mail\Mailable $mail, string $recipient): string
+    {
+        $id = $this->spooler->spool($mail, $recipient);
+        $data = json_decode(file_get_contents($this->testSpoolDir.'/pending/'.$id.'.json'), true);
+        return $data['html'] ?? '';
+    }
+
+    /**
+     * Normalise out tracking IDs (per-instance random) so two Mailable
+     * instances producing the SAME body via different paths compare equal.
+     */
+    private function normalise(string $html): string
+    {
+        return preg_replace('#/e/d/[a-z]/[A-Za-z0-9\-_]+#', '/e/d/X/NORMALISED', $html);
+    }
+
+    public function test_stories_newsletter_bulk_parity(): void
+    {
+        $stories = [
+            ['headline' => 'A great freegle', 'username' => 'Alice', 'groupname' => 'London', 'story' => 'Saved a sofa from landfill.', 'profileurl' => '', 'photo' => null],
+            ['headline' => 'Another one', 'username' => 'Bob', 'groupname' => 'Bristol', 'story' => 'Found a free bike.', 'profileurl' => '', 'photo' => null],
+        ];
+        $args = [
+            'userId'         => 42,
+            'recipientName'  => 'Test User',
+            'recipientEmail' => 'test@example.com',
+            'stories'        => $stories,
+            'headerImageUrl' => 'https://x/header.png',
+            'tellUrl'        => 'https://x/stories?src=test',
+            'giveUrl'        => 'https://x/give?src=test',
+            'findUrl'        => 'https://x/find?src=test',
+            'previewText'    => 'preview',
+            'unsubscribeUrl' => 'https://x/unsubscribe',
+            'settingsUrl'    => 'https://x/settings',
+        ];
+
+        $nonBulk = new StoriesNewsletterMail(...$args);
+        $nonBulkHtml = $this->spooledHtml($nonBulk, 'test@example.com');
+
+        $bulk = new StoriesNewsletterMail(...$args);
+        $this->assertInstanceOf(BulkRenderable::class, $bulk);
+
+        $compiler = app(BulkMjmlCompiler::class);
+        $bulk->setPrerenderedHtml($compiler->htmlFor($bulk));
+        $bulkHtml = $this->spooledHtml($bulk, 'test@example.com');
+
+        $this->assertSame(
+            $this->normalise($nonBulkHtml),
+            $this->normalise($bulkHtml),
+            'StoriesNewsletter bulk HTML must byte-match non-bulk HTML'
+        );
+    }
+
+    public function test_stories_ask_bulk_parity(): void
+    {
+        $args = [
+            'recipientName'  => 'Charlie Freegler',
+            'recipientEmail' => 'charlie@example.com',
+            'storiesUrl'     => 'https://x/stories',
+            'unsubscribeUrl' => 'https://x/unsubscribe',
+        ];
+
+        $nonBulk = new AskMail(...$args);
+        $nonBulkHtml = $this->spooledHtml($nonBulk, 'charlie@example.com');
+
+        $bulk = new AskMail(...$args);
+        $this->assertInstanceOf(BulkRenderable::class, $bulk);
+
+        $compiler = app(BulkMjmlCompiler::class);
+        $bulk->setPrerenderedHtml($compiler->htmlFor($bulk));
+        $bulkHtml = $this->spooledHtml($bulk, 'charlie@example.com');
+
+        $this->assertSame(
+            $this->normalise($nonBulkHtml),
+            $this->normalise($bulkHtml),
+            'AskMail bulk HTML must byte-match non-bulk HTML'
+        );
+    }
+
+    public function test_chase_admin_bulk_parity(): void
+    {
+        $mod = $this->createTestUser(['firstname' => 'Dana']);
+
+        $args = [
+            $mod,
+            'Pending mod application from someone',
+            'Test Group',
+            48,
+            12345,
+        ];
+
+        $nonBulk = new ChaseAdminMail(...$args);
+        $nonBulkHtml = $this->spooledHtml($nonBulk, $mod->email_preferred);
+
+        $bulk = new ChaseAdminMail(...$args);
+        $this->assertInstanceOf(BulkRenderable::class, $bulk);
+
+        $compiler = app(BulkMjmlCompiler::class);
+        $bulk->setPrerenderedHtml($compiler->htmlFor($bulk));
+        $bulkHtml = $this->spooledHtml($bulk, $mod->email_preferred);
+
+        $this->assertSame(
+            $this->normalise($nonBulkHtml),
+            $this->normalise($bulkHtml),
+            'ChaseAdminMail bulk HTML must byte-match non-bulk HTML'
+        );
+    }
+
+    public function test_chase_admin_shape_groups_by_admin_id(): void
+    {
+        $mod1 = $this->createTestUser(['firstname' => 'Eve']);
+        $mod2 = $this->createTestUser(['firstname' => 'Frank']);
+
+        // Same admin, same group, same pending hours → same shape
+        $m1 = new ChaseAdminMail($mod1, 'Subject', 'Group A', 48, 100);
+        $m2 = new ChaseAdminMail($mod2, 'Subject', 'Group A', 48, 100);
+        $this->assertSame($m1->shapeKey(), $m2->shapeKey());
+
+        // Different admin ID → different shape
+        $m3 = new ChaseAdminMail($mod1, 'Subject', 'Group A', 48, 999);
+        $this->assertNotSame($m1->shapeKey(), $m3->shapeKey());
+    }
+
+    public function test_events_digest_bulk_parity(): void
+    {
+        $events = [
+            ['title' => 'Repair Café', 'url' => 'https://x/event/1', 'start' => '2026-06-01 14:00', 'end' => '', 'location' => 'Town Hall', 'description' => 'Bring your broken things.', 'imageUrl' => null],
+            ['title' => 'Litter Pick', 'url' => 'https://x/event/2', 'start' => '2026-06-08 10:00', 'end' => '', 'location' => 'High Street', 'description' => 'Help clean up.', 'imageUrl' => null],
+        ];
+
+        $args = [
+            'recipientEmail' => 'test@example.com',
+            'groupName' => 'Test Group',
+            'events' => $events,
+            'unsubscribeUrl' => 'https://x/unsubscribe?email=test%40example.com',
+            'userId' => 42,
+        ];
+
+        $nonBulk = new EventsDigestMail(...$args);
+        $nonBulkHtml = $this->spooledHtml($nonBulk, 'test@example.com');
+
+        $bulk = new EventsDigestMail(...$args);
+        $this->assertInstanceOf(BulkRenderable::class, $bulk);
+
+        $compiler = app(BulkMjmlCompiler::class);
+        $bulk->setPrerenderedHtml($compiler->htmlFor($bulk));
+        $bulkHtml = $this->spooledHtml($bulk, 'test@example.com');
+
+        $this->assertSame(
+            $this->normalise($nonBulkHtml),
+            $this->normalise($bulkHtml),
+            'EventsDigest bulk HTML must byte-match non-bulk HTML'
+        );
+    }
+
+    public function test_volunteering_digest_no_jobs_bulk_parity(): void
+    {
+        $vols = [
+            ['title' => 'Garden helper', 'url' => 'https://x/vol/1', 'description' => 'Help out.', 'photo_thumb' => null],
+        ];
+
+        $args = [
+            'recipientEmail' => 'test@example.com',
+            'groupName' => 'Test Group',
+            'volunteerings' => $vols,
+            'unsubscribeUrl' => 'https://x/unsubscribe?email=test%40example.com',
+            'jobAds' => collect(),  // no jobs → shared shape
+            'userId' => 42,
+        ];
+
+        $nonBulk = new VolunteeringDigestMail(...$args);
+        $nonBulkHtml = $this->spooledHtml($nonBulk, 'test@example.com');
+
+        $bulk = new VolunteeringDigestMail(...$args);
+        $this->assertInstanceOf(BulkRenderable::class, $bulk);
+
+        $compiler = app(BulkMjmlCompiler::class);
+        $bulk->setPrerenderedHtml($compiler->htmlFor($bulk));
+        $bulkHtml = $this->spooledHtml($bulk, 'test@example.com');
+
+        $this->assertSame(
+            $this->normalise($nonBulkHtml),
+            $this->normalise($bulkHtml),
+            'VolunteeringDigest (no jobs) bulk HTML must byte-match non-bulk HTML'
+        );
+    }
+
+    public function test_stories_newsletter_shape_groups_by_content_hash(): void
+    {
+        $stories1 = [['headline' => 'S1', 'username' => '', 'groupname' => '', 'story' => 's', 'profileurl' => '', 'photo' => null]];
+        $stories2 = [['headline' => 'S2', 'username' => '', 'groupname' => '', 'story' => 's', 'profileurl' => '', 'photo' => null]];
+
+        $common = [
+            'userId' => 1,
+            'recipientName' => 'A',
+            'recipientEmail' => 'a@example.com',
+            'headerImageUrl' => 'https://x/h.png',
+            'tellUrl' => 'https://x/t',
+            'giveUrl' => 'https://x/g',
+            'findUrl' => 'https://x/f',
+            'previewText' => 'p',
+            'unsubscribeUrl' => 'https://x/u',
+            'settingsUrl' => 'https://x/s',
+        ];
+
+        $m1 = new StoriesNewsletterMail(...['stories' => $stories1] + $common);
+        $m2 = new StoriesNewsletterMail(...['stories' => $stories1] + ['recipientEmail' => 'b@example.com'] + $common);
+        $m3 = new StoriesNewsletterMail(...['stories' => $stories2] + $common);
+
+        $this->assertSame($m1->shapeKey(), $m2->shapeKey(), 'Different recipient, same content → same shape');
+        $this->assertNotSame($m1->shapeKey(), $m3->shapeKey(), 'Different stories → different shape');
+    }
+}

--- a/iznik-batch/tests/Unit/Mail/UnifiedDigestBulkTest.php
+++ b/iznik-batch/tests/Unit/Mail/UnifiedDigestBulkTest.php
@@ -1,0 +1,206 @@
+<?php
+
+namespace Tests\Unit\Mail;
+
+use App\Mail\Concerns\BulkRenderable;
+use App\Mail\Digest\UnifiedDigest;
+use App\Services\BulkMail\BulkMjmlCompiler;
+use App\Services\UnifiedDigestService;
+use Tests\Support\IsolatedSpoolDirectory;
+use Tests\TestCase;
+
+/**
+ * Verifies the BulkRenderable contract on UnifiedDigest for immediate-mode
+ * digests:
+ *  - shapeKey() buckets recipients correctly
+ *  - bulkData() emits placeholder strings for per-recipient fields
+ *  - mergeVars() returns matching real values
+ *  - bulk-path HTML body is byte-identical to the non-bulk path
+ */
+class UnifiedDigestBulkTest extends TestCase
+{
+    use IsolatedSpoolDirectory;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpIsolatedSpoolDirectory();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownIsolatedSpoolDirectory();
+        parent::tearDown();
+    }
+
+    private function spooledHtml(UnifiedDigest $mail, string $recipientEmail): string
+    {
+        $id = $this->spooler->spool($mail, $recipientEmail);
+        $data = json_decode(file_get_contents($this->testSpoolDir.'/pending/'.$id.'.json'), true);
+        return $data['html'] ?? '';
+    }
+
+    private function makeImmediateDigest(\App\Models\User $user, \App\Models\User $poster, \App\Models\Group $group, $message): UnifiedDigest
+    {
+        $posts = collect([
+            ['message' => $message, 'postedToGroups' => [$group->id]],
+        ]);
+
+        return new UnifiedDigest($user, $posts, UnifiedDigestService::MODE_IMMEDIATE);
+    }
+
+    public function test_immediate_digest_is_bulk_renderable(): void
+    {
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $this->createMembership($user, $group);
+        $poster = $this->createTestUser();
+        $this->createMembership($poster, $group);
+        $message = $this->createTestMessage($poster, $group, ['subject' => 'OFFER: Sofa (London)']);
+
+        $mail = $this->makeImmediateDigest($user, $poster, $group, $message);
+
+        $this->assertInstanceOf(BulkRenderable::class, $mail);
+    }
+
+    public function test_shape_key_is_stable_for_same_inputs(): void
+    {
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $this->createMembership($user, $group);
+        $poster = $this->createTestUser();
+        $this->createMembership($poster, $group);
+        $message = $this->createTestMessage($poster, $group, ['subject' => 'OFFER: Sofa (London)']);
+
+        $mail1 = $this->makeImmediateDigest($user, $poster, $group, $message);
+        $mail2 = $this->makeImmediateDigest($user, $poster, $group, $message);
+
+        $this->assertSame($mail1->shapeKey(), $mail2->shapeKey());
+    }
+
+    public function test_shape_key_changes_when_message_changes(): void
+    {
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $this->createMembership($user, $group);
+        $poster = $this->createTestUser();
+        $this->createMembership($poster, $group);
+
+        $msg1 = $this->createTestMessage($poster, $group, ['subject' => 'OFFER: Sofa (London)']);
+        $msg2 = $this->createTestMessage($poster, $group, ['subject' => 'OFFER: Table (London)']);
+
+        $mail1 = $this->makeImmediateDigest($user, $poster, $group, $msg1);
+        $mail2 = $this->makeImmediateDigest($user, $poster, $group, $msg2);
+
+        $this->assertNotSame($mail1->shapeKey(), $mail2->shapeKey());
+    }
+
+    public function test_bulk_data_carries_placeholders_for_per_recipient_fields(): void
+    {
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $this->createMembership($user, $group);
+        $poster = $this->createTestUser();
+        $this->createMembership($poster, $group);
+        $message = $this->createTestMessage($poster, $group, ['subject' => 'OFFER: Sofa (London)']);
+
+        $mail = $this->makeImmediateDigest($user, $poster, $group, $message);
+
+        $data = $mail->bulkData();
+
+        $this->assertSame('{{browseUrl}}', $data['browseUrl']);
+        $this->assertSame('{{donateUrl}}', $data['donateUrl']);
+        $this->assertSame('{{jobsUrl}}', $data['jobsUrl']);
+        $this->assertSame('{{settingsUrl}}', $data['settingsUrl']);
+        $this->assertSame('{{unsubscribeUrl}}', $data['unsubscribeUrl']);
+        $this->assertSame('{{userEmail}}', $data['userEmail']);
+        $this->assertStringContainsString('{{trackingPixelUrl}}', $data['trackingPixelMjml']);
+
+        // Posts collection: per-post messageUrl is a placeholder string.
+        $firstPost = $data['posts']->first();
+        $this->assertSame('{{messageUrl}}', $firstPost['messageUrl']);
+
+        // Shared fields are real values, not placeholders.
+        $this->assertSame('Sofa', $firstPost['itemName']);
+        $this->assertSame('London', $firstPost['locationName']);
+    }
+
+    public function test_merge_vars_keys_match_bulk_data_placeholders(): void
+    {
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $this->createMembership($user, $group);
+        $poster = $this->createTestUser();
+        $this->createMembership($poster, $group);
+        $message = $this->createTestMessage($poster, $group, ['subject' => 'OFFER: Sofa (London)']);
+
+        $mail = $this->makeImmediateDigest($user, $poster, $group, $message);
+
+        $vars = $mail->mergeVars();
+
+        // Every placeholder that bulkData injects MUST have a matching merge var.
+        foreach (['browseUrl', 'donateUrl', 'jobsUrl', 'settingsUrl', 'unsubscribeUrl', 'userEmail', 'messageUrl', 'trackingPixelUrl'] as $key) {
+            $this->assertArrayHasKey($key, $vars, "mergeVars missing key '{$key}'");
+        }
+    }
+
+    public function test_merge_vars_url_values_match_trackedUrl_format(): void
+    {
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $this->createMembership($user, $group);
+        $poster = $this->createTestUser();
+        $this->createMembership($poster, $group);
+        $message = $this->createTestMessage($poster, $group, ['subject' => 'OFFER: Sofa (London)']);
+
+        $mail = $this->makeImmediateDigest($user, $poster, $group, $message);
+
+        $vars = $mail->mergeVars();
+
+        // Tracked URL format: <api_base>/e/d/r/<tracking_id>?url=<base64>...
+        $this->assertStringContainsString('/e/d/r/', $vars['browseUrl']);
+        $this->assertStringContainsString('/e/d/r/', $vars['donateUrl']);
+        $this->assertStringContainsString('/e/d/r/', $vars['messageUrl']);
+    }
+
+    public function test_bulk_path_renders_byte_identical_html_to_non_bulk(): void
+    {
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $this->createMembership($user, $group);
+        $poster = $this->createTestUser();
+        $this->createMembership($poster, $group);
+        $message = $this->createTestMessage($poster, $group, ['subject' => 'OFFER: Sofa (London)']);
+
+        // PATH A: non-bulk — build() runs Blade + MJML with real per-user values.
+        $nonBulkMail = $this->makeImmediateDigest($user, $poster, $group, $message);
+        $nonBulkHtml = $this->spooledHtml($nonBulkMail, $user->email_preferred);
+
+        // PATH B: bulk — compile once with placeholders, substitute per recipient.
+        $bulkMail = $this->makeImmediateDigest($user, $poster, $group, $message);
+        $compiler = app(BulkMjmlCompiler::class);
+        $bulkHtml = $compiler->htmlFor($bulkMail);
+        $bulkMail->setPrerenderedHtml($bulkHtml);
+        $bulkRenderedHtml = $this->spooledHtml($bulkMail, $user->email_preferred);
+
+        // Per-user tracking IDs differ between mailable instances (each
+        // initTracking() creates a fresh record). For a byte-comparable test
+        // we'd need to fix the tracking ID — skip that here and instead diff
+        // ignoring the tracking-id segment. Tracking IDs appear in:
+        //   /e/d/r/<tracking_id>?url=...   (link tracking)
+        //   /e/d/p/<tracking_id>.png       (open pixel)
+        // Replace them with a fixed placeholder for comparison.
+        $normalize = static fn (string $h) => preg_replace(
+            '#/e/d/[a-z]/[A-Za-z0-9\-_]+#',
+            '/e/d/X/NORMALISED',
+            $h
+        );
+
+        $this->assertSame(
+            $normalize($nonBulkHtml),
+            $normalize($bulkRenderedHtml),
+            'Bulk-rendered HTML should byte-match the non-bulk render after normalising tracking IDs. '
+            .'Diff suggests a per-recipient field is not covered by mergeVars or bulkData differs structurally.'
+        );
+    }
+}

--- a/iznik-batch/tests/Unit/Mail/UnifiedDigestBulkTest.php
+++ b/iznik-batch/tests/Unit/Mail/UnifiedDigestBulkTest.php
@@ -127,6 +127,12 @@ class UnifiedDigestBulkTest extends TestCase
         // Shared fields are real values, not placeholders.
         $this->assertSame('Sofa', $firstPost['itemName']);
         $this->assertSame('London', $firstPost['locationName']);
+
+        // Image URL fields required by the template must be present.
+        $this->assertArrayHasKey('heroImageUrl', $firstPost, 'heroImageUrl missing from bulkData posts');
+        $this->assertArrayHasKey('thumbImageUrl', $firstPost, 'thumbImageUrl missing from bulkData posts');
+        $this->assertIsString($firstPost['heroImageUrl']);
+        $this->assertIsString($firstPost['thumbImageUrl']);
     }
 
     public function test_merge_vars_keys_match_bulk_data_placeholders(): void

--- a/iznik-batch/tests/Unit/Mail/UnifiedDigestBulkTest.php
+++ b/iznik-batch/tests/Unit/Mail/UnifiedDigestBulkTest.php
@@ -106,19 +106,23 @@ class UnifiedDigestBulkTest extends TestCase
 
         $mail = $this->makeImmediateDigest($user, $poster, $group, $message);
 
+        // bulkData() requires a bulk token — set one explicitly for the test.
+        // Real sends get the token from BulkMjmlCompiler::htmlFor().
+        $token = 'testtoken123';
+        $mail->setBulkToken($token);
         $data = $mail->bulkData();
 
-        $this->assertSame('{{browseUrl}}', $data['browseUrl']);
-        $this->assertSame('{{donateUrl}}', $data['donateUrl']);
-        $this->assertSame('{{jobsUrl}}', $data['jobsUrl']);
-        $this->assertSame('{{settingsUrl}}', $data['settingsUrl']);
-        $this->assertSame('{{unsubscribeUrl}}', $data['unsubscribeUrl']);
-        $this->assertSame('{{userEmail}}', $data['userEmail']);
-        $this->assertStringContainsString('{{trackingPixelUrl}}', $data['trackingPixelMjml']);
+        $this->assertSame('{{'.$token.':browseUrl}}', $data['browseUrl']);
+        $this->assertSame('{{'.$token.':donateUrl}}', $data['donateUrl']);
+        $this->assertSame('{{'.$token.':jobsUrl}}', $data['jobsUrl']);
+        $this->assertSame('{{'.$token.':settingsUrl}}', $data['settingsUrl']);
+        $this->assertSame('{{'.$token.':unsubscribeUrl}}', $data['unsubscribeUrl']);
+        $this->assertSame('{{'.$token.':userEmail}}', $data['userEmail']);
+        $this->assertStringContainsString('{{'.$token.':trackingPixelUrl}}', $data['trackingPixelMjml']);
 
         // Posts collection: per-post messageUrl is a placeholder string.
         $firstPost = $data['posts']->first();
-        $this->assertSame('{{messageUrl}}', $firstPost['messageUrl']);
+        $this->assertSame('{{'.$token.':messageUrl}}', $firstPost['messageUrl']);
 
         // Shared fields are real values, not placeholders.
         $this->assertSame('Sofa', $firstPost['itemName']);

--- a/iznik-batch/tests/Unit/Services/BulkMail/BulkMjmlCompilerTest.php
+++ b/iznik-batch/tests/Unit/Services/BulkMail/BulkMjmlCompilerTest.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace Tests\Unit\Services\BulkMail;
+
+use App\Mail\Concerns\BulkRenderable;
+use App\Mail\MjmlMailable;
+use App\Services\BulkMail\BulkMjmlCompiler;
+use App\Services\BulkMail\UnboundPlaceholderException;
+use App\Services\MjmlCompilerService;
+use Illuminate\Mail\Mailables\Envelope;
+use Tests\TestCase;
+
+class BulkMjmlCompilerTest extends TestCase
+{
+    public function test_substitute_replaces_simple_placeholders(): void
+    {
+        $compiler = $this->makeCompiler();
+        $html = '<a href="{{url}}">{{label}}</a>';
+        $out = $compiler->substitute($html, ['url' => 'https://example.com', 'label' => 'Click']);
+        $this->assertSame('<a href="https://example.com">Click</a>', $out);
+    }
+
+    public function test_substitute_html_escapes_values(): void
+    {
+        $compiler = $this->makeCompiler();
+        // Quotes and < > & all need encoding for HTML-safe attribute/text content.
+        $out = $compiler->substitute('Hi {{name}}!', ['name' => 'A & B <Co>']);
+        $this->assertSame('Hi A &amp; B &lt;Co&gt;!', $out);
+    }
+
+    public function test_substitute_encodes_ampersand_in_urls(): void
+    {
+        // Matches Blade's {{ $url }} behaviour: caller passes plain &, we encode to &amp;.
+        $compiler = $this->makeCompiler();
+        $out = $compiler->substitute(
+            '<a href="{{url}}">link</a>',
+            ['url' => 'https://x/?a=1&b=2']
+        );
+        $this->assertSame('<a href="https://x/?a=1&amp;b=2">link</a>', $out);
+    }
+
+    public function test_substitute_throws_on_unbound_placeholder(): void
+    {
+        $compiler = $this->makeCompiler();
+        try {
+            $compiler->substitute('Hi {{name}}, {{missing}}!', ['name' => 'x']);
+            $this->fail('Expected UnboundPlaceholderException');
+        } catch (UnboundPlaceholderException $e) {
+            $this->assertSame(['missing'], $e->missingKeys);
+        }
+    }
+
+    public function test_substitute_lists_all_missing_placeholders(): void
+    {
+        $compiler = $this->makeCompiler();
+        try {
+            $compiler->substitute('{{a}} {{b}} {{c}}', []);
+            $this->fail('Expected UnboundPlaceholderException');
+        } catch (UnboundPlaceholderException $e) {
+            $this->assertSame(['a', 'b', 'c'], $e->missingKeys);
+        }
+    }
+
+    public function test_substitute_dedupes_repeated_missing_placeholder(): void
+    {
+        $compiler = $this->makeCompiler();
+        try {
+            $compiler->substitute('{{x}} {{x}} {{x}}', []);
+            $this->fail('Expected UnboundPlaceholderException');
+        } catch (UnboundPlaceholderException $e) {
+            $this->assertSame(['x'], $e->missingKeys);
+        }
+    }
+
+    public function test_substitute_allows_curly_braces_not_matching_placeholder_pattern(): void
+    {
+        // Single braces, braces around invalid chars, etc. should not trip
+        // the validation regex.
+        $compiler = $this->makeCompiler();
+        $out = $compiler->substitute('{name} {{ space }} {{1notavar}} done', []);
+        $this->assertSame('{name} {{ space }} {{1notavar}} done', $out);
+    }
+
+    public function test_html_for_compiles_once_per_shape(): void
+    {
+        $compiler = $this->makeCompiler();
+
+        // Three mailables, two distinct shapes (A used twice, B once). Each
+        // mailable returns its bulkHtml verbatim from renderHtmlForBulkCache(),
+        // so the BulkMjmlCompiler's own counter is what tells us whether the
+        // cache was used.
+        $m1 = $this->makeBulkMailable('shape-A', ['who' => 'alice'], '<root>{{who}}</root>');
+        $m2 = $this->makeBulkMailable('shape-A', ['who' => 'bob'],   '<root>{{who}}</root>');
+        $m3 = $this->makeBulkMailable('shape-B', ['who' => 'carol'], '<root>{{who}} v2</root>');
+
+        $h1 = $compiler->htmlFor($m1);
+        $h2 = $compiler->htmlFor($m2);
+        $h3 = $compiler->htmlFor($m3);
+
+        // Per recipient, the substituted values come through.
+        $this->assertStringContainsString('alice', $h1);
+        $this->assertStringContainsString('bob', $h2);
+        $this->assertStringContainsString('carol', $h3);
+
+        // Two distinct shapes → exactly two cache misses (= 2 compiles).
+        $this->assertSame(2, $compiler->compileCount());
+
+        // Hit counts: shape A served twice, shape B once.
+        $hits = $compiler->hitCounts();
+        $this->assertSame(2, $hits['shape-A']);
+        $this->assertSame(1, $hits['shape-B']);
+    }
+
+    public function test_html_for_caches_first_recipients_html_for_subsequent_recipients(): void
+    {
+        $compiler = $this->makeCompiler();
+
+        // First call seeds the cache with the FIRST mailable's bulkHtml.
+        // A second mailable with the SAME shape but DIFFERENT bulkHtml should
+        // be served the first cached HTML (only its mergeVars differ).
+        $first  = $this->makeBulkMailable('same-shape', ['who' => 'alice'], '<root>{{who}} A</root>');
+        $second = $this->makeBulkMailable('same-shape', ['who' => 'bob'],   '<root>{{who}} B</root>');
+
+        $h1 = $compiler->htmlFor($first);
+        $h2 = $compiler->htmlFor($second);
+
+        // Both recipients see the first-cached body, with their own merge values.
+        $this->assertSame('<root>alice A</root>', $h1);
+        $this->assertSame('<root>bob A</root>', $h2);
+
+        $this->assertSame(1, $compiler->compileCount());
+    }
+
+    public function test_clear_resets_cache(): void
+    {
+        $compiler = $this->makeCompiler();
+
+        $compiler->htmlFor($this->makeBulkMailable('s', ['who' => 'a'], '<r>{{who}}</r>'));
+        $compiler->htmlFor($this->makeBulkMailable('s', ['who' => 'b'], '<r>{{who}}</r>'));
+        $this->assertSame(1, $compiler->compileCount());
+
+        $compiler->clear();
+        $compiler->htmlFor($this->makeBulkMailable('s', ['who' => 'c'], '<r>{{who}}</r>'));
+        $this->assertSame(1, $compiler->compileCount()); // counter reset by clear(), then 1 fresh compile
+    }
+
+    private function makeCompiler(): BulkMjmlCompiler
+    {
+        // For pure substitute() tests, we don't need a working sidecar.
+        $mjml = new class extends MjmlCompilerService {
+            public function __construct() {}
+            public function compile(string $mjml): string { return $mjml; }
+        };
+        return new BulkMjmlCompiler($mjml);
+    }
+
+    /**
+     * Make a tiny test mailable that returns a fixed bulk-cache HTML and
+     * declares the shape + merge vars in its constructor args. Avoids
+     * needing a real Blade template.
+     */
+    private function makeBulkMailable(string $shape, array $vars, string $bulkHtml): MjmlMailable&BulkRenderable
+    {
+        return new class($shape, $vars, $bulkHtml) extends MjmlMailable implements BulkRenderable {
+            public function __construct(
+                private string $shape,
+                private array $vars,
+                private string $bulkHtml
+            ) {
+                parent::__construct();
+            }
+
+            public function shapeKey(): string { return $this->shape; }
+            public function bulkTemplate(): string { return 'unused.in.test'; }
+            public function bulkData(): array { return []; }
+            public function mergeVars(): array { return $this->vars; }
+            public function renderHtmlForBulkCache(string $template, array $sharedData): string
+            {
+                return $this->bulkHtml;
+            }
+
+            protected function getSubject(): string { return 'test'; }
+            public function envelope(): Envelope
+            {
+                return new Envelope(subject: 'test');
+            }
+        };
+    }
+}

--- a/iznik-batch/tests/Unit/Services/BulkMail/BulkMjmlCompilerTest.php
+++ b/iznik-batch/tests/Unit/Services/BulkMail/BulkMjmlCompilerTest.php
@@ -15,7 +15,8 @@ class BulkMjmlCompilerTest extends TestCase
     public function test_substitute_replaces_simple_placeholders(): void
     {
         $compiler = $this->makeCompiler();
-        $html = '<a href="{{url}}">{{label}}</a>';
+        $t = $compiler->batchToken();
+        $html = '<a href="{{'.$t.':url}}">{{'.$t.':label}}</a>';
         $out = $compiler->substitute($html, ['url' => 'https://example.com', 'label' => 'Click']);
         $this->assertSame('<a href="https://example.com">Click</a>', $out);
     }
@@ -23,8 +24,9 @@ class BulkMjmlCompilerTest extends TestCase
     public function test_substitute_html_escapes_values(): void
     {
         $compiler = $this->makeCompiler();
+        $t = $compiler->batchToken();
         // Quotes and < > & all need encoding for HTML-safe attribute/text content.
-        $out = $compiler->substitute('Hi {{name}}!', ['name' => 'A & B <Co>']);
+        $out = $compiler->substitute('Hi {{'.$t.':name}}!', ['name' => 'A & B <Co>']);
         $this->assertSame('Hi A &amp; B &lt;Co&gt;!', $out);
     }
 
@@ -32,8 +34,9 @@ class BulkMjmlCompilerTest extends TestCase
     {
         // Matches Blade's {{ $url }} behaviour: caller passes plain &, we encode to &amp;.
         $compiler = $this->makeCompiler();
+        $t = $compiler->batchToken();
         $out = $compiler->substitute(
-            '<a href="{{url}}">link</a>',
+            '<a href="{{'.$t.':url}}">link</a>',
             ['url' => 'https://x/?a=1&b=2']
         );
         $this->assertSame('<a href="https://x/?a=1&amp;b=2">link</a>', $out);
@@ -42,8 +45,9 @@ class BulkMjmlCompilerTest extends TestCase
     public function test_substitute_throws_on_unbound_placeholder(): void
     {
         $compiler = $this->makeCompiler();
+        $t = $compiler->batchToken();
         try {
-            $compiler->substitute('Hi {{name}}, {{missing}}!', ['name' => 'x']);
+            $compiler->substitute('Hi {{'.$t.':name}}, {{'.$t.':missing}}!', ['name' => 'x']);
             $this->fail('Expected UnboundPlaceholderException');
         } catch (UnboundPlaceholderException $e) {
             $this->assertSame(['missing'], $e->missingKeys);
@@ -53,8 +57,9 @@ class BulkMjmlCompilerTest extends TestCase
     public function test_substitute_lists_all_missing_placeholders(): void
     {
         $compiler = $this->makeCompiler();
+        $t = $compiler->batchToken();
         try {
-            $compiler->substitute('{{a}} {{b}} {{c}}', []);
+            $compiler->substitute('{{'.$t.':a}} {{'.$t.':b}} {{'.$t.':c}}', []);
             $this->fail('Expected UnboundPlaceholderException');
         } catch (UnboundPlaceholderException $e) {
             $this->assertSame(['a', 'b', 'c'], $e->missingKeys);
@@ -64,8 +69,9 @@ class BulkMjmlCompilerTest extends TestCase
     public function test_substitute_dedupes_repeated_missing_placeholder(): void
     {
         $compiler = $this->makeCompiler();
+        $t = $compiler->batchToken();
         try {
-            $compiler->substitute('{{x}} {{x}} {{x}}', []);
+            $compiler->substitute('{{'.$t.':x}} {{'.$t.':x}} {{'.$t.':x}}', []);
             $this->fail('Expected UnboundPlaceholderException');
         } catch (UnboundPlaceholderException $e) {
             $this->assertSame(['x'], $e->missingKeys);
@@ -74,24 +80,46 @@ class BulkMjmlCompilerTest extends TestCase
 
     public function test_substitute_allows_curly_braces_not_matching_placeholder_pattern(): void
     {
-        // Single braces, braces around invalid chars, etc. should not trip
-        // the validation regex.
+        // Plain {{name}} without our batch token is NOT one of our merge
+        // placeholders — it could be user-controlled content. Substitute
+        // must leave it alone.
         $compiler = $this->makeCompiler();
-        $out = $compiler->substitute('{name} {{ space }} {{1notavar}} done', []);
-        $this->assertSame('{name} {{ space }} {{1notavar}} done', $out);
+        $out = $compiler->substitute('{name} {{ space }} {{1notavar}} {{messageUrl}} done', []);
+        $this->assertSame('{name} {{ space }} {{1notavar}} {{messageUrl}} done', $out);
+    }
+
+    public function test_substitute_leaves_unbatched_placeholders_alone(): void
+    {
+        // Security: if user-controlled content happens to contain a literal
+        // "{{messageUrl}}", it MUST NOT be substituted as if it were our
+        // merge var. The batch-token namespacing makes this safe.
+        $compiler = $this->makeCompiler();
+        $t = $compiler->batchToken();
+        $userText = 'A subject containing {{messageUrl}} from a user';
+        $template = $userText.' followed by our real merge: {{'.$t.':messageUrl}}';
+        $out = $compiler->substitute($template, ['messageUrl' => 'https://x']);
+        // Our merge substituted, user text left intact.
+        $this->assertStringContainsString('{{messageUrl}}', $out);
+        $this->assertStringContainsString('https://x', $out);
+        // Crucially the user's "{{messageUrl}}" wasn't substituted.
+        $this->assertSame(
+            'A subject containing {{messageUrl}} from a user followed by our real merge: https://x',
+            $out
+        );
     }
 
     public function test_html_for_compiles_once_per_shape(): void
     {
         $compiler = $this->makeCompiler();
+        $tk = '{{'.$compiler->batchToken().':who}}';
 
         // Three mailables, two distinct shapes (A used twice, B once). Each
         // mailable returns its bulkHtml verbatim from renderHtmlForBulkCache(),
         // so the BulkMjmlCompiler's own counter is what tells us whether the
         // cache was used.
-        $m1 = $this->makeBulkMailable('shape-A', ['who' => 'alice'], '<root>{{who}}</root>');
-        $m2 = $this->makeBulkMailable('shape-A', ['who' => 'bob'],   '<root>{{who}}</root>');
-        $m3 = $this->makeBulkMailable('shape-B', ['who' => 'carol'], '<root>{{who}} v2</root>');
+        $m1 = $this->makeBulkMailable('shape-A', ['who' => 'alice'], '<root>'.$tk.'</root>');
+        $m2 = $this->makeBulkMailable('shape-A', ['who' => 'bob'],   '<root>'.$tk.'</root>');
+        $m3 = $this->makeBulkMailable('shape-B', ['who' => 'carol'], '<root>'.$tk.' v2</root>');
 
         $h1 = $compiler->htmlFor($m1);
         $h2 = $compiler->htmlFor($m2);
@@ -114,12 +142,13 @@ class BulkMjmlCompilerTest extends TestCase
     public function test_html_for_caches_first_recipients_html_for_subsequent_recipients(): void
     {
         $compiler = $this->makeCompiler();
+        $tk = '{{'.$compiler->batchToken().':who}}';
 
         // First call seeds the cache with the FIRST mailable's bulkHtml.
         // A second mailable with the SAME shape but DIFFERENT bulkHtml should
         // be served the first cached HTML (only its mergeVars differ).
-        $first  = $this->makeBulkMailable('same-shape', ['who' => 'alice'], '<root>{{who}} A</root>');
-        $second = $this->makeBulkMailable('same-shape', ['who' => 'bob'],   '<root>{{who}} B</root>');
+        $first  = $this->makeBulkMailable('same-shape', ['who' => 'alice'], '<root>'.$tk.' A</root>');
+        $second = $this->makeBulkMailable('same-shape', ['who' => 'bob'],   '<root>'.$tk.' B</root>');
 
         $h1 = $compiler->htmlFor($first);
         $h2 = $compiler->htmlFor($second);
@@ -134,13 +163,14 @@ class BulkMjmlCompilerTest extends TestCase
     public function test_clear_resets_cache(): void
     {
         $compiler = $this->makeCompiler();
+        $tk = '{{'.$compiler->batchToken().':who}}';
 
-        $compiler->htmlFor($this->makeBulkMailable('s', ['who' => 'a'], '<r>{{who}}</r>'));
-        $compiler->htmlFor($this->makeBulkMailable('s', ['who' => 'b'], '<r>{{who}}</r>'));
+        $compiler->htmlFor($this->makeBulkMailable('s', ['who' => 'a'], '<r>'.$tk.'</r>'));
+        $compiler->htmlFor($this->makeBulkMailable('s', ['who' => 'b'], '<r>'.$tk.'</r>'));
         $this->assertSame(1, $compiler->compileCount());
 
         $compiler->clear();
-        $compiler->htmlFor($this->makeBulkMailable('s', ['who' => 'c'], '<r>{{who}}</r>'));
+        $compiler->htmlFor($this->makeBulkMailable('s', ['who' => 'c'], '<r>'.$tk.'</r>'));
         $this->assertSame(1, $compiler->compileCount()); // counter reset by clear(), then 1 fresh compile
     }
 

--- a/iznik-batch/tests/Unit/Services/UnifiedDigestServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/UnifiedDigestServiceTest.php
@@ -7,6 +7,8 @@ use App\Models\Membership;
 use App\Models\Message;
 use App\Models\User;
 use App\Models\UserDigest;
+use App\Services\BulkMail\BulkMjmlCompiler;
+use App\Services\MjmlCompilerService;
 use App\Services\UnifiedDigestService;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Mail;
@@ -685,6 +687,37 @@ class UnifiedDigestServiceTest extends TestCase
 
         $stats = $this->service->sendDigests(UnifiedDigestService::MODE_IMMEDIATE);
         $this->assertEquals(1, $stats['emails_sent']);
+    }
+
+    /**
+     * When the bulk MJML compile fails (e.g. sidecar unreachable), the
+     * service must still send the email via the per-user compile fallback
+     * path rather than dropping the recipient or crashing the group loop.
+     */
+    public function test_immediate_sends_even_if_bulk_compile_fails(): void
+    {
+        // Bind a BulkMjmlCompiler whose MJML sidecar always throws.
+        $this->app->bind(BulkMjmlCompiler::class, function () {
+            $failingMjml = new class extends MjmlCompilerService {
+                public function __construct() {}
+
+                public function compile(string $mjml): string
+                {
+                    throw new \RuntimeException('Simulated MJML sidecar failure');
+                }
+            };
+            return new BulkMjmlCompiler($failingMjml);
+        });
+
+        [$group, $poster, $recipient] = $this->bootstrapImmediateGroup();
+        $msg = $this->createTestMessage($poster, $group, ['subject' => 'OFFER: Item (TestLocation)']);
+        $this->makeImmediateReady($msg);
+
+        $stats = $this->service->sendDigests(UnifiedDigestService::MODE_IMMEDIATE);
+
+        // Bulk compile failing must not crash the group loop or drop the recipient.
+        $this->assertEquals(1, $stats['emails_sent'], 'Recipient must still be counted even when bulk compile fails');
+        $this->assertEquals(0, $stats['errors'], 'A bulk compile failure must not increment the group error counter');
     }
 
     /**

--- a/plans/2026-05-27-mjml-compile-cache.md
+++ b/plans/2026-05-27-mjml-compile-cache.md
@@ -1,0 +1,251 @@
+# MJML Compile-Once / Substitute-Many for Bulk Mailables
+
+**Date:** 2026-05-27
+**Branch:** `feature/mjml-compile-cache`
+**Goal:** Reduce MJML sidecar load at scale so batch sends (immediate digest, newsletters, donation asks, mod notifications) can ramp without overloading `freegle-mjml`.
+
+---
+
+## Problem
+
+`MjmlMailable::build()` rebuilds the MJML pipeline on every `Mail::send`:
+
+1. Render Blade → MJML string (per-recipient values inlined)
+2. POST MJML to `freegle-mjml` sidecar → HTML
+3. Set HTML on the email
+
+For batch sends, this means **N sidecar compiles for N recipients** even when the
+template body is structurally identical. Confirmed in
+`UnifiedDigestService::processGroupImmediate()` (lines 249–285): one message → all
+group members in immediate mode runs a full `Mail::send(new UnifiedDigest(...))`
+per recipient. `MjmlCompilerService` is wrapped in a `BoundedPool` of 20 with a 30s
+timeout — the team already classifies MJML compile as heavy.
+
+This is the same problem AWS SES, Postmark, and Mailchimp/Mandrill solved via
+their "send bulk templated email" APIs: one compiled body + N small substitution
+maps. SMTP transport (`config/mail.php` → smtp) means we can't outsource it to
+SES; the primitive has to live in our application layer.
+
+## Approach
+
+Adopt the industry-standard placeholder pattern using `{{varname}}` syntax —
+**verified against the live sidecar** (2026-05-27): braces survive MJML
+compilation intact in text content and in `href`/`src`/`alt` attributes. The CSS
+inliner only touches `<style>` and `style=`, so as long as placeholders stay out
+of CSS, they round-trip cleanly.
+
+### Flow
+
+```
+                                 Per cron tick (process-local cache)
+┌──────────────────────────────────────────────────────────────────┐
+│                                                                  │
+│  Mailable::sharedData()    Mailable::recipientVars(User $u)     │
+│        │                          │                              │
+│        ▼                          ▼                              │
+│  Blade render  ───►  MJML w/ {{vars}}  ───sidecar──►  HTML w/ {{vars}}
+│                                                          │       │
+│                            (cached by shape key)         │       │
+│                                                          ▼       │
+│   For each recipient:                            strtr({{var}}→value)
+│   ─ build per-recipient map                              │       │
+│   ─ substitute                                           ▼       │
+│   ─ validate (no unbound {{x}})                  Final HTML      │
+│   ─ hand to Mailable for spool                                   │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+### New components
+
+**`App\Services\BulkMjmlCompiler`** — process-local cache + substitution engine.
+
+```php
+class BulkMjmlCompiler
+{
+    /** @var array<string,string> sha1(mjml) → HTML with {{vars}} */
+    private array $htmlCache = [];
+
+    /** @return string HTML with {{vars}} placeholders intact */
+    public function compileTemplate(string $mjml): string { /* hash + lookup + sidecar */ }
+
+    /** @return string final HTML with placeholders substituted */
+    public function substitute(string $htmlWithVars, array $vars): string
+    {
+        // Pre-encode HTML special chars in values; strtr; then validate no {{x}} left.
+    }
+
+    public function clearCache(): void { /* called between cron runs */ }
+}
+```
+
+**Trait `App\Mail\Concerns\BulkRenderable`** — opt-in contract for mailables.
+
+```php
+trait BulkRenderable
+{
+    /** Stable bucket for recipients that share the same compiled HTML. */
+    abstract public function shapeKey(User $u): string;
+
+    /** Per-recipient placeholder substitutions, keyed by var name. */
+    abstract public function recipientVars(User $u): array;
+
+    /** Render Blade with placeholders intact, compile MJML, cache by shape. */
+    public function renderForRecipient(User $u, BulkMjmlCompiler $compiler): string;
+}
+```
+
+**`App\Mail\Concerns\HasMergeVars`** — Blade helper.
+
+The Blade template uses literal `@{{varname}}` for per-recipient values (Blade's
+documented escape so `{{ }}` is emitted verbatim instead of being interpolated).
+The trait provides helpers for shared mailable code to declare a variable as
+"merge-only", returning the literal `{{varname}}` string at render time.
+
+### Mailable changes (opt-in)
+
+A mailable that opts in declares:
+- `shapeKey(User): string` — typically a hash of (template_path, structural
+  inputs that change template output). For immediate digest:
+  `sha1(message_id|has_jobs|has_amp|sponsor_set_hash)`.
+- `recipientVars(User): array` — map of var name → value. Values are HTML-encoded
+  by the compiler before substitution.
+- The Blade template uses `@{{trackUrl}}`, `@{{distanceText}}` etc. for per-recipient
+  values, and normal `{{ $php }}` for shared values.
+
+Mailables that don't opt in continue to use the existing `MjmlMailable::build()`
+path — no caching, no `{{vars}}` requirement, no behaviour change.
+
+### Sending loop (caller side)
+
+`App\Services\BulkMailDispatcher` wraps the iteration:
+
+```php
+$dispatcher = new BulkMailDispatcher(UnifiedDigest::class, $sharedCtor);
+foreach ($users as $user) {
+    if (...skip rules...) continue;
+    $dispatcher->add($user);
+}
+$dispatcher->dispatch();   // buckets by shape, compiles per shape, substitutes per recipient, spools each
+```
+
+Inside `dispatch()`:
+1. Group recipients by `Mailable::shapeKey($user)`.
+2. For each shape: instantiate the Mailable with the first recipient, call
+   `renderForRecipient()` (which caches the compiled HTML keyed by shape).
+3. For each subsequent recipient in the shape: substitute `recipientVars($user)`
+   into the cached HTML, build the per-recipient envelope/headers, spool.
+4. Validation step rejects unbound `{{[a-zA-Z_][a-zA-Z0-9_]*}}` after substitution.
+
+### Cache lifecycle
+
+- Process-local (PHP array). The digest cron is single-process; cross-process
+  sharing isn't needed.
+- Cleared on dispatcher destruction (one per send batch) so we don't leak.
+- No Redis. 500KB HTML × a few hundred shapes per batch is well within memory.
+
+### Failure modes and safeguards
+
+- **Unbound placeholder leak**: post-substitute regex sweep raises
+  `UnboundPlaceholderException` listing the missing keys. Fail-loud — no email
+  goes out with `{{varname}}` visible to a user.
+- **Placeholder inside CSS**: forbidden by convention. Reviewer checks; lint
+  rule in mailable tests.
+- **Placeholder values containing HTML specials** (`&`, `<`, `>`, `"`):
+  pre-encoded via `htmlspecialchars` before strtr. URL values already use
+  `&amp;` per MJML/XML convention.
+- **Template mismatch between shapes**: shape key includes a hash of structural
+  inputs, so different `@if` branches produce different cache entries.
+- **AMP variant**: AMP rendering uses a separate template path (`emails.amp.*`)
+  and is per-user anyway (AMP enable/disable is a user attribute). For Phase 1,
+  AMP rendering stays on the per-recipient path; the bulk primitive only caches
+  the HTML body. (Future work: parallel cache for AMP.)
+
+## Migration scope
+
+This PR migrates **all batch-send mailables** in iznik-batch where the same
+content fans out to multiple recipients. Per-recipient one-shots (welcome,
+verify-email, forgot-password, etc.) keep using the existing
+`MjmlCompilerService` directly.
+
+| Mailable | Service / call site | Multiplier source |
+|---|---|---|
+| `UnifiedDigest` (immediate) | `UnifiedDigestService::processGroupImmediate` | 1 message → N group members |
+| `StoriesNewsletterMail` | `StoriesNewsletterService` | 1 newsletter → N subscribers |
+| `AskMail` | `StoriesAskService` | 1 ask → N targets |
+| `AskForDonation` | `DonationSummaryService` (ask path) | 1 ask → N donors |
+| `ChaseAdminMail` | `SendAdminCommand` / `ChaseAdminCommand` | 1 chase → N admins of a group |
+| `ModNotifMail` | `SendModNotifsCommand` | 1 notif → N mods of a group |
+| `NewsfeedModNotifMail` | `NewsfeedModNotifService` | 1 notif → N mods of a group |
+| `ChitchatReportMail` | `NewsfeedModNotifService` (chitchat path) | 1 report → N mods |
+| `AlertNoMessagesMail` | `AlertNoMessagesCommand` | 1 alert → N mods of a group |
+| `UnifiedDigest` (daily) | `UnifiedDigestService::sendDailyDigests` | Per-user content, but shared item bodies — investigate |
+
+Out of scope (no multiplier; keep current path):
+- Welcome, verify-email, forgot-password, merge-offer
+- Birthday, engage (per-user content)
+- Chat notifications (per-user)
+- Volunteering and events digests (per-user; investigate later)
+- Donation thank-you, gift-aid chase-up (per-donor)
+- Auto-repost, chase-up promised, deadline-reached, mod-std-message (per-message-per-poster)
+
+## Test strategy
+
+This is correctness-critical work. Tests must prove the new path produces
+**byte-identical** HTML to the old path for every migrated mailable.
+
+1. **Parity tests** (per migrated mailable): given a Mailable instance and a list
+   of users, render via the bulk path; render the same recipients via the
+   old per-send path. Assert byte-identical HTML bodies. Run with realistic
+   variation: with/without jobs, with/without sponsors, with/without AMP.
+
+2. **Cache hit accounting**: assert that for N recipients of the same shape,
+   the sidecar is called exactly once (using a mocked `MjmlCompilerService`
+   that counts compiles).
+
+3. **Validation**: a mailable that forgets to provide a `{{var}}` raises
+   `UnboundPlaceholderException` with the missing key names listed.
+
+4. **HTML encoding**: a `recipientVars` value containing `&`, `<`, `"` is
+   correctly encoded so the resulting HTML validates.
+
+5. **Headers and envelope**: per-recipient headers (`X-Freegle-User-Id`,
+   `List-Unsubscribe`, `Feedback-ID`, reply-to) still come out per-recipient
+   even though the body is shared.
+
+6. **AMP variant**: where the mailable supports AMP, the AMP part is still
+   rendered per-recipient (not cached). Verified via the existing AMP-on
+   integration tests.
+
+7. **Full suite**: Unit + Feature + Integration suites all pass. Mailpit
+   integration test for each migrated mailable confirms end-to-end delivery
+   with correct headers.
+
+## Rollout
+
+- Add a feature flag `freegle.bulk_mail.enabled` defaulting to `true`. If a
+  regression slips through, ops can flip the flag and every mailable falls
+  back to the existing per-send path.
+- For the immediate digest specifically, ops can also keep the existing
+  `FREEGLE_DIGEST_IMMEDIATE_ALLOWLIST` pilot gate — the bulk path doesn't
+  change the allowlist semantics.
+
+## Open question
+
+`UnifiedDigest` daily mode is per-user (each user sees their own union of
+group memberships), but the per-message body content (item name, image,
+description, poster avatar) is shared across users that received the same
+message. There may be sharing opportunities at the **per-post fragment** level
+rather than the whole-email level. This is a separate design question; for
+this PR daily digest goes through `BulkMailDispatcher` but `shapeKey` returns
+a unique value per recipient (so it's effectively the old path — zero
+regression, zero cache hits). A follow-up PR can refine `shapeKey` once we've
+measured.
+
+## What this PR does NOT change
+
+- `MjmlCompilerService` itself. It stays as-is for non-batch sends and is used
+  internally by `BulkMjmlCompiler` for the actual sidecar call.
+- The `freegle-mjml` sidecar. No protocol or container changes.
+- Existing MJML templates outside the migrated set.
+- The spool format or any X-Freegle-* header semantics.
+- The AMP rendering path.

--- a/plans/2026-05-27-mjml-compile-cache.md
+++ b/plans/2026-05-27-mjml-compile-cache.md
@@ -162,31 +162,36 @@ Inside `dispatch()`:
 
 ## Migration scope
 
-This PR migrates **all batch-send mailables** in iznik-batch where the same
-content fans out to multiple recipients. Per-recipient one-shots (welcome,
-verify-email, forgot-password, etc.) keep using the existing
-`MjmlCompilerService` directly.
+This PR migrates batch-send mailables in iznik-batch where the same content
+fans out to multiple recipients AND the per-recipient body variation is
+small enough to fit the merge-var model.
 
-| Mailable | Service / call site | Multiplier source |
-|---|---|---|
-| `UnifiedDigest` (immediate) | `UnifiedDigestService::processGroupImmediate` | 1 message → N group members |
-| `StoriesNewsletterMail` | `StoriesNewsletterService` | 1 newsletter → N subscribers |
-| `AskMail` | `StoriesAskService` | 1 ask → N targets |
-| `AskForDonation` | `DonationSummaryService` (ask path) | 1 ask → N donors |
-| `ChaseAdminMail` | `SendAdminCommand` / `ChaseAdminCommand` | 1 chase → N admins of a group |
-| `ModNotifMail` | `SendModNotifsCommand` | 1 notif → N mods of a group |
-| `NewsfeedModNotifMail` | `NewsfeedModNotifService` | 1 notif → N mods of a group |
-| `ChitchatReportMail` | `NewsfeedModNotifService` (chitchat path) | 1 report → N mods |
-| `AlertNoMessagesMail` | `AlertNoMessagesCommand` | 1 alert → N mods of a group |
-| `UnifiedDigest` (daily) | `UnifiedDigestService::sendDailyDigests` | Per-user content, but shared item bodies — investigate |
+Migrated:
 
-Out of scope (no multiplier; keep current path):
-- Welcome, verify-email, forgot-password, merge-offer
-- Birthday, engage (per-user content)
-- Chat notifications (per-user)
-- Volunteering and events digests (per-user; investigate later)
-- Donation thank-you, gift-aid chase-up (per-donor)
-- Auto-repost, chase-up promised, deadline-reached, mod-std-message (per-message-per-poster)
+| Mailable | Service / call site | Multiplier source | Notes |
+|---|---|---|---|
+| `UnifiedDigest` (immediate) | `UnifiedDigestService::processGroupImmediate` | 1 message → N group members | Users with nearby jobs fall to unique-shape (jobs differ); users without share |
+| `StoriesNewsletterMail` | `StoriesNewsletterService` | 1 newsletter → N subscribers | Single cached body per run — only footer email differs |
+| `AskMail` | `StoriesAskService` | 1 ask → N targets | Two merge vars (name, email) |
+| `ChaseAdminMail` | `ChaseAdminCommand` | 1 chase → N mods of a group | userName + trackingPixelUrl per mod |
+| `EventsDigestMail` | `EventsDigestService` | 1 group's events → N members | Two merge vars (email, unsubscribeUrl) |
+| `VolunteeringDigestMail` | `VolunteeringDigestService` | 1 group's vols → N members | Members without jobs share; with-jobs go solo |
+
+Deliberately skipped — content is per-recipient or audience size is 1, so
+the cache primitive gives no benefit:
+
+| Mailable | Why skipped |
+|---|---|
+| `ModNotifMail` | Each mod's `htmlSummary` is unique → cache hit = 0 |
+| `NewsfeedModNotifMail` | Each mod's `posts` is filtered by their groups → cache hit = 0 |
+| `ChitchatReportMail` | One email to a fixed support address list, not a fan-out |
+| `AlertNoMessagesMail` | Single recipient (mentors address) |
+| `AskForDonation` | Per-user `$itemSubject` + many per-user tracked URLs — viable but complex; deferred |
+| `UnifiedDigest` (daily) | Per-user content; shapeKey returns unique-per-user → cache no-op, no regression |
+
+Truly per-recipient mailables (welcome, verify-email, forgot-password,
+chat-notification, birthday, donation thank-you, etc.) keep using the
+existing per-send compile path. No change.
 
 ## Test strategy
 


### PR DESCRIPTION
## Summary

Adds a compile-once / substitute-many primitive for batch-send MJML
mailables. Cuts MJML sidecar load when the same content fans out to many
recipients with small per-user variation (immediate digest, newsletter,
mod-team chase, per-group event/volunteering digests, story asks).

Same pattern AWS SES `SendBulkEmail`, Postmark Bulk API, and Mailchimp's
merge tags use internally — verified that the `{{varname}}` placeholder
syntax survives MJML sidecar compile in text content and `href`/`src`/`alt`
attributes (the only places we place placeholders).

## Architecture

- `App\Services\BulkMail\BulkMjmlCompiler`: process-local cache + substitute + validate.
- `App\Mail\Concerns\BulkRenderable` interface: opt-in contract for mailables
  (4 methods: `shapeKey`, `bulkTemplate`, `bulkData`, `mergeVars`).
- `App\Mail\MjmlMailable::setPrerenderedHtml()`: lets a caller hand the
  Mailable a pre-rendered HTML body; `mjmlView()` short-circuits the
  Blade+MJML pipeline when one is set.
- Feature flag `freegle.bulk_mail.enabled` (default `true`) — roll-back hatch
  if a regression slips through.
- Fail-loud validation: any unbound `{{var}}` left in the substituted HTML
  raises `UnboundPlaceholderException` (no garbage emails go out).

## Migrated

| Mailable | Service / call site | Multiplier |
|---|---|---|
| `UnifiedDigest` (immediate) | `UnifiedDigestService::processGroupImmediate` | 1 message → N group members |
| `StoriesNewsletterMail` | `StoriesNewsletterService` | 1 newsletter → N subscribers |
| `AskMail` | `StoriesAskService` | 1 ask → N targets |
| `ChaseAdminMail` | `ChaseAdminCommand` | 1 chase → N mods of a group |
| `EventsDigestMail` | `EventsDigestService` | 1 group's events → N members |
| `VolunteeringDigestMail` | `VolunteeringDigestService` | 1 group's vols → N members (no-jobs path) |

Deliberately not migrated (no fan-out OR per-recipient content):
- `ModNotifMail`, `NewsfeedModNotifMail` — per-mod unique content
- `ChitchatReportMail`, `AlertNoMessagesMail` — single-recipient sends
- `AskForDonation`, daily `UnifiedDigest` — see spec for follow-up notes

Truly per-recipient mailables (welcome, verify-email, forgot-password,
chat-notification, birthday, donation thank-you, etc.) keep using the
existing per-send compile path. No change.

## Tests

- `BulkMjmlCompilerTest` (10): substitution, encoding (matches Blade's
  `e()`), unbound-placeholder validation, cache-hit accounting, `clear()`.
- `UnifiedDigestBulkTest` (7): shape stability, merge-var keys match
  placeholders, byte-identical HTML parity (bulk path output == non-bulk
  path output, normalising per-instance tracking IDs).
- `BulkRenderableMailablesParityTest` (7): byte-identical parity tests for
  each migrated mailable plus shape-bucketing assertions.
- All 65 existing `UnifiedDigest` tests still pass.

## Test plan

- [x] BulkMjmlCompilerTest — all 10 pass
- [x] UnifiedDigestBulkTest — all 7 pass including parity
- [x] BulkRenderableMailablesParityTest — all 7 pass including parity
- [x] Full UnifiedDigest test suite — all 65 pass
- [ ] Full Laravel test suite — running, no regressions expected
- [ ] (Ops, post-merge) Watch immediate-digest cron logs for
      `BulkMjmlCompiler: bulk compile stats` lines. Expected pattern:
      compile_count = 1 per message, hits >> 1 per shape.

## Rollback

Flip `FREEGLE_BULK_MAIL_ENABLED=false` in env and restart batch. All
mailables fall back to the per-recipient compile path immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)