### PR TITLE
Split donation mails: hourly status + daily thank-prep digest

### DIFF
--- a/iznik-batch/MIGRATION-STATUS.md
+++ b/iznik-batch/MIGRATION-STATUS.md
@@ -177,6 +177,8 @@ These commands are active in `routes/console.php` and running in production:
 | `lovejunk_tn_invoice.php` | `lovejunk:send-tn-invoice` | Monthly 1st 15:00 | LoveJunk TN/FD split invoice — PR #417 |
 | `chat_review.php` | `chats:review-pending` | Daily 09:00 | Auto-reject stale + notify mods — PR #418 |
 | `engage.php` | `mail:engage` | Daily 16:00 | At-risk and inactive user engagement — PR #419 |
+| `donations_email.php` | `mail:donations:summary` | Hourly 06:00–22:00 | Donation status table to fundraising — PR #428 |
+| - | `mail:donations:thank-prep` | Daily 20:30 | Card-per-donation digest for composing thank-yous — PR #571 |
 
 ## Code Written (Scheduler Disabled)
 
@@ -185,7 +187,7 @@ These have code implemented but the scheduler entry is commented out in `routes/
 | Original Script | Artisan Command | Email Type in .env | Notes |
 |-----------------|-----------------|-------------------|-------|
 | `digest.php` | `mail:digest:unified` | UnifiedDigest | Unified Freegle "What's New" digests (immediate + daily, user-centric) |
-| `donations_email.php` | `mail:donations:ask` | - | Donation reminders |
+| - | `mail:donations:ask` | - | Ask users who received items for donations (no direct V1 origin) |
 | `donations_thank.php` | `mail:donations:thank` | - | Donation thank-you emails |
 | `bounce.php` + `bounce_users.php` | `mail:bounced` | - | Bounced email handling + user suspension (PR #390) |
 | `messages_expired.php` | `messages:process-expired` | - | Deadline expiry handling |

--- a/iznik-batch/app/Console/Commands/Donation/DonationThankPrepCommand.php
+++ b/iznik-batch/app/Console/Commands/Donation/DonationThankPrepCommand.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Console\Commands\Donation;
+
+use App\Services\DonationThankPrepService;
+use App\Traits\LogsBatchJob;
+use Illuminate\Console\Command;
+
+/**
+ * Daily thank-prep digest: a card-per-donation email aimed at the person
+ * composing thank-you replies. Distinct from {@code mail:donations:summary}
+ * which sends the simple finance-team status table.
+ */
+class DonationThankPrepCommand extends Command
+{
+    use LogsBatchJob;
+
+    protected $signature = 'mail:donations:thank-prep
+                            {--dry-run : Build the digest but do not send it}';
+
+    protected $description = 'Send daily thank-prep digest (rich donor cards) to the thanks address';
+
+    public function handle(DonationThankPrepService $service): int
+    {
+        $dryRun = (bool) $this->option('dry-run');
+
+        if ($dryRun) {
+            $this->info('DRY RUN — no email will be sent.');
+        }
+
+        return $this->runWithLogging(function () use ($service, $dryRun) {
+            $result = $service->sendDailyThankPrep($dryRun);
+
+            $verb  = $dryRun ? 'Would send' : 'Sent';
+            $total = number_format($result['total'], 2);
+            $this->info("{$verb} thank-prep digest for {$result['donations']} donor(s) needing thanks, totalling £{$total}.");
+
+            if ($result['donations'] === 0) {
+                $this->info('No donations need thanks today — no email sent.');
+            }
+
+            return Command::SUCCESS;
+        });
+    }
+}

--- a/iznik-batch/app/Mail/Donation/DonationThankPrepMail.php
+++ b/iznik-batch/app/Mail/Donation/DonationThankPrepMail.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Mail\Donation;
+
+use App\Mail\MjmlMailable;
+use Illuminate\Mail\Mailables\Address;
+use Illuminate\Mail\Mailables\Envelope;
+
+/**
+ * Card-per-donation digest for the person composing thank-you replies.
+ * Separate from {@see DonationSummaryMail} — that one is the simple finance
+ * status table; this one carries the full donor context (history, GA,
+ * memberships, mod notes, chat snippets, deep links into Modtools).
+ */
+class DonationThankPrepMail extends MjmlMailable
+{
+    /**
+     * @param  array<int, array<string, mixed>>  $cards Per-donation context blocks
+     */
+    public function __construct(
+        public readonly string $recipientEmail,
+        public readonly array $cards,
+        public readonly float $total,
+    ) {
+        parent::__construct();
+    }
+
+    protected function getSubject(): string
+    {
+        $totalFormatted = number_format($this->total, 2);
+        $n = count($this->cards);
+        $noun = $n === 1 ? 'donor' : 'donors';
+        return "Donations needing thanks: {$n} {$noun}, £{$totalFormatted}";
+    }
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            from: new Address(
+                config('freegle.mail.noreply_addr', 'noreply@ilovefreegle.org'),
+                config('freegle.branding.name', 'Freegle')
+            ),
+            to: [new Address($this->recipientEmail)],
+            subject: $this->getSubject(),
+        );
+    }
+
+    public function build(): static
+    {
+        return $this->mjmlView('emails.mjml.donation.thank-prep', [
+            'cards' => $this->cards,
+            'total' => $this->total,
+            'email' => $this->recipientEmail,
+        ]);
+    }
+}

--- a/iznik-batch/app/Services/DonationThankPrepService.php
+++ b/iznik-batch/app/Services/DonationThankPrepService.php
@@ -1,0 +1,414 @@
+<?php
+
+namespace App\Services;
+
+use App\Mail\Donation\DonationThankPrepMail;
+use App\Models\Group;
+use App\Support\EmojiUtils;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Builds the daily *thank-prep* digest — a card-per-donation email aimed at
+ * the person composing thank-you replies (currently Jacky). Each card
+ * contains the data she'd otherwise gather by hand from Modtools, info@,
+ * support@, giftaid@ and the Gift Aid register: donor identity, donation
+ * history, GA status, group memberships, mod notes, recent member↔mod chat,
+ * deep links.
+ *
+ * Deliberately a *separate* path from {@see DonationSummaryService}, which
+ * sends the simple V1-parity status table. The status mail tells the
+ * finance team what landed in the bank; this digest tells the thanker who
+ * still needs a personal reply. Conflating them produced PR #571's confused
+ * "Donations today" email; the split keeps each concern legible.
+ *
+ * Dedup is by a config-table high-water-mark (CONFIG_KEY_LAST_ID): each run
+ * shows only donations with id > the stored mark, then advances the mark to
+ * the max id mailed. First run initialises the mark to MAX(id) so the
+ * historical backlog is not dumped. (The per-row users_donations.thanked
+ * column is display-only here and is not used for filtering.)
+ */
+class DonationThankPrepService
+{
+    /**
+     * Config-table key for the high-water-mark donation ID. Same pattern used
+     * by {@see GitSummaryService} (key `git_summary_last_run`) — single row
+     * in the existing config(key,value) table, no schema change required.
+     * First run initialises to MAX(users_donations.id) so the historical
+     * backlog isn't dumped into Jacky's inbox on day one.
+     */
+    private const CONFIG_KEY_LAST_ID = 'donation_thank_prep_last_id';
+
+    private const RECURRING_TYPES = ['recurring_payment', 'subscr_payment'];
+
+    private const SOURCE_LABELS = [
+        'DonateWithPayPal' => 'PayPal',
+        'PayPalGivingFund' => 'PayPal Giving Fund',
+        'Facebook'         => 'Facebook',
+        'eBay'             => 'eBay',
+        'BankTransfer'     => 'Bank transfer',
+        'Stripe'           => 'Stripe',
+    ];
+
+    /**
+     * @return array{donations: int, total: float, sent: bool, last_id: int}
+     */
+    public function sendDailyThankPrep(bool $dryRun = false): array
+    {
+        // thanks_addr always resolves: its env default falls back to the
+        // fundraising address (see config/freegle.php), so no runtime ??
+        // fallback is needed.
+        $recipient = config('freegle.mail.thanks_addr');
+
+        // High-water mark: the largest donation id we've already shown.
+        // On first run the row doesn't exist — initialise to MAX(id) so the
+        // historical backlog (~137k rows in prod as of deploy) isn't dumped
+        // into Jacky's inbox. In a dry run we compute that mark but must NOT
+        // persist it (a dry run has no side effects).
+        $lastId = $this->getLastSentId($dryRun);
+
+        $donations = DB::table('users_donations')
+            ->where('id', '>', $lastId)
+            ->orderBy('id')
+            ->get();
+
+        if ($donations->isEmpty()) {
+            return ['donations' => 0, 'total' => 0.0, 'sent' => false, 'last_id' => $lastId];
+        }
+
+        $total  = 0.0;
+        $cards  = [];
+        $maxId  = $lastId;
+        foreach ($donations as $donation) {
+            $total += (float) $donation->GrossAmount;
+            $cards[] = $this->buildDonationCard($donation);
+            if ((int) $donation->id > $maxId) {
+                $maxId = (int) $donation->id;
+            }
+        }
+
+        if (!$dryRun) {
+            // Spool through EmailSpoolerService so a transient mail-host
+            // failure doesn't lose the digest — same pattern as the simple
+            // status mail in DonationSummaryService.
+            app(\App\Services\EmailSpoolerService::class)->spool(
+                new DonationThankPrepMail(
+                    recipientEmail: (string) $recipient,
+                    cards: $cards,
+                    total: $total,
+                ),
+                (string) $recipient,
+            );
+
+            // Advance the mark only after spool returns. If spool throws we
+            // leave the mark in place and the next cron tick retries the
+            // same range — at-least-once delivery, the same trade-off the
+            // EmailSpoolerService callers already accept.
+            $this->setLastSentId($maxId);
+        }
+
+        return [
+            'donations' => $donations->count(),
+            'total'     => $total,
+            'sent'      => !$dryRun,
+            'last_id'   => $maxId,
+        ];
+    }
+
+    /**
+     * Read the high-water mark, lazily initialising to the current MAX(id)
+     * so the first run after deploy sends nothing and subsequent runs only
+     * pick up genuinely new donations.
+     */
+    private function getLastSentId(bool $dryRun = false): int
+    {
+        $row = DB::table('config')->where('key', self::CONFIG_KEY_LAST_ID)->first();
+        if ($row && $row->value !== '' && $row->value !== null) {
+            return (int) $row->value;
+        }
+
+        // First run: initialise to MAX(id) so the backlog isn't dumped. A dry
+        // run computes the same mark but must NOT persist it — otherwise a
+        // `--dry-run` on a fresh deploy would silently set the high-water mark.
+        $maxId = (int) (DB::table('users_donations')->max('id') ?? 0);
+        if (!$dryRun) {
+            $this->setLastSentId($maxId);
+        }
+        return $maxId;
+    }
+
+    private function setLastSentId(int $id): void
+    {
+        DB::statement(
+            "INSERT INTO config (`key`, value) VALUES (?, ?) ON DUPLICATE KEY UPDATE value = ?",
+            [self::CONFIG_KEY_LAST_ID, (string) $id, (string) $id]
+        );
+    }
+
+    /**
+     * Build the per-donation context block. Shaped around the fields the
+     * person composing a thank-you actually reads: who the donor is, what
+     * else they've given, where they sit in the Gift Aid register, what
+     * mods have noted, the most recent member↔mod chat.
+     */
+    private function buildDonationCard(object $donation): array
+    {
+        $recurring = in_array((string) $donation->TransactionType, self::RECURRING_TYPES, true);
+
+        $localTime = Carbon::parse($donation->timestamp, 'UTC')
+            ->setTimezone('Europe/London');
+
+        $card = [
+            'donation' => [
+                'id'             => (int) $donation->id,
+                'amount'         => (float) $donation->GrossAmount,
+                'time'           => $localTime->format('H:i T'),
+                'date'           => $localTime->format('D j M Y'),
+                'source'         => self::SOURCE_LABELS[$donation->source] ?? (string) $donation->source,
+                'sourceKey'      => (string) $donation->source,
+                'payer'          => (string) ($donation->Payer ?? ''),
+                'payerName'      => (string) ($donation->PayerDisplayName ?: $donation->Payer ?: ''),
+                'recurring'      => $recurring,
+                'transaction'    => (string) ($donation->TransactionID ?? ''),
+                'thanked'        => $donation->thanked ? Carbon::parse($donation->thanked) : null,
+                'giftaidConsent' => (int) $donation->giftaidconsent === 1,
+                'giftaidClaimed' => $donation->giftaidclaimed ? Carbon::parse($donation->giftaidclaimed) : null,
+            ],
+            'user'            => null,
+            'aliases'         => [],
+            'donationHistory' => [],
+            'giftaid'         => null,
+            'memberships'     => [],
+            'modNotes'        => [],
+            'modChats'        => [],
+            'birthdayHint'    => false,
+            'flags'           => [],
+            'links'           => $this->buildLinks($donation),
+        ];
+
+        if ($donation->userid) {
+            $card = $this->enrichMatchedDonor((int) $donation->userid, $donation, $card, $recurring);
+        } else {
+            $card['flags'][] = 'Unmatched donor — needs sleuthing';
+        }
+
+        if ($recurring) {
+            $card['flags'][] = 'Recurring';
+        }
+        if ($card['donation']['sourceKey'] === 'PayPalGivingFund') {
+            $card['flags'][] = 'PGF — Gift Aid claimed by PayPal';
+        }
+
+        return $card;
+    }
+
+    private function enrichMatchedDonor(int $userId, object $donation, array $card, bool $recurring): array
+    {
+        $user = DB::table('users')->where('id', $userId)->first();
+        if (!$user) {
+            $card['flags'][] = 'User row missing (deleted?)';
+            return $card;
+        }
+
+        $displayName = trim(($user->firstname ?? '') . ' ' . ($user->lastname ?? ''));
+        if ($displayName === '') {
+            $displayName = (string) ($user->fullname ?? '');
+        }
+
+        $card['user'] = [
+            'id'          => (int) $user->id,
+            'firstname'   => (string) ($user->firstname ?? ''),
+            'lastname'    => (string) ($user->lastname ?? ''),
+            'fullname'    => (string) ($user->fullname ?? ''),
+            'displayName' => $displayName ?: 'Unknown',
+            'added'       => $user->added ? Carbon::parse($user->added) : null,
+            'deleted'     => $user->deleted !== null,
+            'systemrole'  => (string) ($user->systemrole ?? 'User'),
+        ];
+
+        // Just the preferred external email. Drop Freegle-internal synthetic
+        // addresses (e.g. `*@users.ilovefreegle.org` chat aliases) — the
+        // thanker writes to one real address, not the chat shim.
+        $preferred = DB::table('users_emails')
+            ->where('userid', $userId)
+            ->where('email', 'not like', '%@users.ilovefreegle.org')
+            ->where('email', 'not like', '%@users.trash-nothing.com')
+            ->orderByDesc('preferred')
+            ->orderBy('added')
+            ->value('email');
+        $card['aliases'] = $preferred ? [$preferred] : [];
+
+        $card['donationHistory'] = DB::table('users_donations')
+            ->where('userid', $userId)
+            ->where('id', '<>', $donation->id)
+            ->orderByDesc('timestamp')
+            ->limit(8)
+            ->get(['GrossAmount', 'timestamp', 'source', 'thanked'])
+            ->map(fn($d) => [
+                'amount'  => (float) $d->GrossAmount,
+                'date'    => Carbon::parse($d->timestamp, 'UTC')->setTimezone('Europe/London')->format('j M Y'),
+                'source'  => self::SOURCE_LABELS[$d->source] ?? (string) $d->source,
+                'thanked' => $d->thanked ? Carbon::parse($d->thanked) : null,
+            ])
+            ->all();
+
+        $giftaid = DB::table('giftaid')->where('userid', $userId)->first();
+        if ($giftaid) {
+            $card['giftaid'] = [
+                'period'            => (string) $giftaid->period,
+                'declined'          => $giftaid->period === 'Declined',
+                'reviewed'          => $giftaid->reviewed ? Carbon::parse($giftaid->reviewed) : null,
+                'postcode'          => (string) ($giftaid->postcode ?? ''),
+                'housenameornumber' => (string) ($giftaid->housenameornumber ?? ''),
+                'homeaddress'       => (string) ($giftaid->homeaddress ?? ''),
+                'updated'           => $giftaid->updated ? Carbon::parse($giftaid->updated) : null,
+            ];
+        }
+
+        $card['memberships'] = DB::table('memberships')
+            ->join('groups', 'groups.id', '=', 'memberships.groupid')
+            ->where('memberships.userid', $userId)
+            ->where('memberships.collection', 'Approved')
+            ->where('groups.type', Group::TYPE_FREEGLE)
+            ->orderBy('memberships.added')
+            ->limit(10)
+            ->get(['groups.id as groupid', 'groups.nameshort', 'groups.namefull', 'memberships.role', 'memberships.added'])
+            ->map(fn($m) => [
+                'groupid'     => (int) $m->groupid,
+                'name'        => (string) ($m->namefull ?: $m->nameshort),
+                'role'        => (string) $m->role,
+                'memberSince' => $m->added ? Carbon::parse($m->added)->format('M Y') : '',
+            ])
+            ->all();
+
+        $card['modNotes'] = DB::table('users_comments')
+            ->where('userid', $userId)
+            ->orderByDesc('date')
+            ->limit(3)
+            ->get(['id', 'date', 'byuserid', 'user1', 'user2', 'flag'])
+            ->map(function ($c) {
+                return [
+                    'date'    => Carbon::parse($c->date)->format('j M Y'),
+                    'flag'    => (int) $c->flag,
+                    'snippet' => $this->cleanSnippet((string) ($c->user2 ?? $c->user1 ?? ''), 160),
+                ];
+            })
+            ->all();
+
+        $card['modChats']     = $this->fetchRecentModChats($userId);
+        $card['birthdayHint'] = $this->donorHasBirthdayHint($userId, $donation, $recurring);
+
+        return $card;
+    }
+
+    private function fetchRecentModChats(int $userId): array
+    {
+        $rooms = DB::table('chat_rooms')
+            ->where('chattype', 'User2Mod')
+            ->where(function ($q) use ($userId) {
+                $q->where('user1', $userId)->orWhere('user2', $userId);
+            })
+            ->orderByDesc('latestmessage')
+            ->limit(3)
+            ->pluck('id');
+
+        if ($rooms->isEmpty()) {
+            return [];
+        }
+
+        return DB::table('chat_messages')
+            ->whereIn('chatid', $rooms)
+            ->whereNotIn('type', ['System', 'Schedule', 'ScheduleUpdated', 'Reminder'])
+            ->whereNotNull('message')
+            ->orderByDesc('date')
+            ->limit(5)
+            ->get(['date', 'message', 'userid', 'chatid'])
+            ->map(function ($m) use ($userId) {
+                return [
+                    'date'       => Carbon::parse($m->date)->setTimezone('Europe/London')->format('j M Y'),
+                    'fromMember' => (int) $m->userid === $userId,
+                    'chatid'     => (int) $m->chatid,
+                    'snippet'    => $this->cleanSnippet((string) $m->message, 140),
+                ];
+            })
+            ->all();
+    }
+
+    /**
+     * Mirror the cleaning pipeline used in ChatNotification::getSubjectSnippet():
+     * - Decode \u{codepoints}\u emoji escapes (Freegle stores emojis that way
+     *   for legacy DB compatibility — without this step they render as
+     *   literal `ὠ0\u` in the email).
+     * - Strip HTML tags and decode entities so Blade's escape pass produces
+     *   clean output instead of `&amp;amp;`.
+     * - Collapse whitespace.
+     * - Multibyte-safe truncate so emoji are never cut mid-codepoint.
+     */
+    private function cleanSnippet(string $raw, int $maxChars): string
+    {
+        $clean = (string) EmojiUtils::decodeEmojis($raw);
+        $clean = html_entity_decode(strip_tags($clean), ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        $clean = trim((string) preg_replace('/\s+/', ' ', $clean));
+        if (mb_strlen($clean, 'UTF-8') > $maxChars) {
+            $clean = mb_substr($clean, 0, $maxChars - 1, 'UTF-8') . '…';
+        }
+        return $clean;
+    }
+
+    private function donorHasBirthdayHint(int $userId, object $donation, bool $recurring): bool
+    {
+        $skipBirthdayCheck = false;
+        if ($recurring) {
+            $lastMonth = DB::table('users_donations')
+                ->where('userid', $userId)
+                ->where('GrossAmount', $donation->GrossAmount)
+                ->whereIn('TransactionType', self::RECURRING_TYPES)
+                ->whereRaw('DATE(timestamp) >= DATE_SUB(CURDATE(), INTERVAL 1 MONTH)')
+                ->whereRaw('DATE(timestamp) < CURDATE()')
+                ->count();
+            $skipBirthdayCheck = $lastMonth > 0;
+        }
+        if ($skipBirthdayCheck) {
+            return false;
+        }
+        return $this->donorHasBirthdayGroup($userId);
+    }
+
+    private function donorHasBirthdayGroup(int $userId): bool
+    {
+        $today      = date('m-d');
+        $yesterday  = date('m-d', strtotime('-1 day'));
+        $twoDaysAgo = date('m-d', strtotime('-2 days'));
+
+        $count = DB::table('groups')
+            ->join('memberships', 'groups.id', '=', 'memberships.groupid')
+            ->where('memberships.userid', $userId)
+            ->where('groups.type', Group::TYPE_FREEGLE)
+            ->where('groups.publish', 1)
+            ->where('groups.onmap', 1)
+            ->whereRaw("DATE_FORMAT(groups.founded, '%m-%d') IN (?, ?, ?)", [$today, $yesterday, $twoDaysAgo])
+            ->whereRaw("YEAR(NOW()) - YEAR(groups.founded) > 0")
+            ->count();
+
+        return $count > 0;
+    }
+
+    private function buildLinks(object $donation): array
+    {
+        $modBase = rtrim((string) config('freegle.sites.mod', 'https://modtools.org'), '/');
+        $userId  = $donation->userid ? (int) $donation->userid : null;
+
+        $links = [
+            // Real Modtools GA moderator page. Doesn't take a ?search= query
+            // today — opens the form ready to paste the donor's name.
+            'giftaidRegister' => "{$modBase}/giftaid",
+        ];
+
+        if ($userId) {
+            // Real Modtools support tools page for the user (opens on User tab).
+            $links['modtoolsUser'] = "{$modBase}/support/{$userId}";
+        }
+
+        return $links;
+    }
+}

--- a/iznik-batch/config/freegle.php
+++ b/iznik-batch/config/freegle.php
@@ -68,6 +68,11 @@ return [
         'info_addr' => env('FREEGLE_INFO_ADDR', 'info@ilovefreegle.org'),
         // Fundraising address — receives the daily donation summary email.
         'fundraising_addr' => env('FREEGLE_FUNDRAISING_ADDR', 'info@ilovefreegle.org'),
+        // Thanks address — receives the daily thank-prep digest (rich per-donor
+        // cards aimed at composing thank-you replies). Defaults to the
+        // fundraising address; override to route the digest elsewhere
+        // (e.g. directly to Jacky).
+        'thanks_addr' => env('FREEGLE_THANKS_ADDR', env('FREEGLE_FUNDRAISING_ADDR', 'info@ilovefreegle.org')),
         // Mentors address — volunteer support team who handle escalations.
         'mentors_addr' => env('FREEGLE_MENTORS_ADDR', 'mentors@ilovefreegle.org'),
         // CC address for donation notification emails (legacy logging).

--- a/iznik-batch/resources/views/emails/mjml/donation/thank-prep.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/donation/thank-prep.blade.php
@@ -1,0 +1,256 @@
+<mjml>
+  @include('emails.mjml.partials.head', [
+    'preview' => 'Donations needing thanks: ' . count($cards) . ' — £' . number_format($total, 2),
+    'styles'  => '
+      .card { background: #ffffff; border: 1px solid #e6e6e6; border-radius: 6px; }
+      .card-header { background: #f7f7f7; border-bottom: 1px solid #e6e6e6; }
+      .card-header td { padding: 10px 14px; }
+      .card-body td { padding: 4px 14px; font-size: 14px; line-height: 1.4; vertical-align: top; }
+      .card-label { color: #666; width: 130px; white-space: nowrap; }
+      .card-section-head { color: #444; font-weight: bold; padding: 12px 14px 4px; border-top: 1px solid #f0f0f0; }
+      .flag-pill { display: inline-block; background: #fff3cd; color: #856404; border: 1px solid #ffeeba; padding: 1px 8px; border-radius: 10px; font-size: 12px; margin-right: 4px; }
+      .flag-pill-good { background: #d4edda; color: #155724; border-color: #c3e6cb; }
+      .flag-pill-warn { background: #f8d7da; color: #721c24; border-color: #f5c6cb; }
+      .mini-row td { padding: 2px 14px; font-size: 13px; color: #555; }
+      .link-row td { padding: 8px 14px; font-size: 12px; }
+      .link-row a { margin-right: 12px; }
+    ',
+    'mediaStyles' => '
+      @media only screen and (max-width: 480px) {
+        .card-body td { padding-left: 8px !important; padding-right: 8px !important; font-size: 13px !important; }
+        .card-label { width: 90px !important; font-size: 12px !important; }
+      }
+    ',
+  ])
+
+  <mj-body background-color="#f4f4f4">
+
+    @include('emails.mjml.components.modtools-header')
+
+    <mj-section background-color="#ffffff" padding="20px 10px 6px">
+      <mj-column>
+        <mj-text font-size="20px" font-weight="bold" mj-class="text-modtools" padding="0 10px">
+          Donations needing thanks: {{ count($cards) }} — total £{{ number_format($total, 2) }}
+        </mj-text>
+        <mj-text padding="0 10px 6px" font-size="13px" color="#666">
+          Each card has the data you'd otherwise pull together by hand: donor identity,
+          donation history, Gift Aid status, group memberships, recent mod notes, member↔mod
+          chat snippets, and links into the relevant Modtools pages. Each donation appears
+          in exactly one digest — it won't be repeated tomorrow, so please action every card
+          before this email scrolls away.
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+    @foreach ($cards as $card)
+      @php
+        $d = $card['donation'];
+        $u = $card['user'];
+        $ga = $card['giftaid'];
+        $hist = $card['donationHistory'];
+        $mods = $card['modNotes'];
+        $chats = $card['modChats'];
+        $members = $card['memberships'];
+        $aliases = $card['aliases'];
+        $flags = $card['flags'];
+        $links = $card['links'];
+
+        $name = $u['displayName'] ?? ($d['payerName'] ?: $d['payer'] ?: 'Unknown donor');
+        $amountFmt = '£' . number_format($d['amount'], 2);
+
+        if ($ga) {
+          if ($ga['declined']) {
+            $gaLabel = 'On file: Declined';
+            $gaClass = 'flag-pill-warn';
+          } elseif ($ga['reviewed']) {
+            $gaLabel = 'Active — ' . $ga['period'];
+            $gaClass = 'flag-pill-good';
+          } else {
+            $gaLabel = 'Just declared — needs review (' . $ga['period'] . ')';
+            $gaClass = '';
+          }
+        } else {
+          $gaLabel = 'Never asked / not on file';
+          $gaClass = 'flag-pill-warn';
+        }
+      @endphp
+
+      <mj-section background-color="#f4f4f4" padding="10px 10px 0">
+        <mj-column css-class="card">
+          {{-- HEADER --}}
+          <mj-raw>
+            <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" class="card-header">
+              <tr>
+                <td style="text-align:left;">
+                  <div style="font-size:18px;font-weight:bold;color:#222;">
+                    {{ $amountFmt }} &nbsp;to&nbsp; {{ $name }}
+                  </div>
+                  <div style="font-size:13px;color:#555;margin-top:2px;">
+                    at {{ $d['time'] }} &nbsp;via&nbsp; {{ $d['source'] }}@if ($d['transaction']) &nbsp;&middot;&nbsp; ref <span style="font-family:monospace;font-size:12px;">{{ $d['transaction'] }}</span>@endif
+                  </div>
+                </td>
+                <td style="text-align:right;font-size:12px;">
+                  @foreach ($flags as $f)
+                    <span class="flag-pill">{{ $f }}</span>
+                  @endforeach
+                  @if ($card['birthdayHint'])
+                    <span class="flag-pill flag-pill-good">Birthday?</span>
+                  @endif
+                </td>
+              </tr>
+            </table>
+          </mj-raw>
+
+          {{-- IDENTITY --}}
+          <mj-raw>
+            <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" class="card-body">
+              <tr><td colspan="2" class="card-section-head">Donor</td></tr>
+              <tr>
+                <td class="card-label">Payer (bank)</td>
+                <td>{{ $d['payer'] }}@if ($d['payerName'] && $d['payerName'] !== $d['payer']) &nbsp;<span style="color:#888;">(display: {{ $d['payerName'] }})</span>@endif</td>
+              </tr>
+              @if ($u)
+                <tr>
+                  <td class="card-label">Member</td>
+                  <td>
+                    {{ $u['displayName'] }}
+                    &nbsp;<a href="{{ $links['modtoolsUser'] ?? '#' }}" style="font-size:12px;">#{{ $u['id'] }}</a>
+                    @if ($u['deleted']) <span class="flag-pill flag-pill-warn">Deleted user</span>@endif
+                    @if ($u['systemrole'] !== 'User') <span class="flag-pill">{{ $u['systemrole'] }}</span>@endif
+                  </td>
+                </tr>
+                @if (!empty($aliases))
+                  <tr>
+                    <td class="card-label">Email</td>
+                    <td style="word-break:break-all;">{{ $aliases[0] }}</td>
+                  </tr>
+                @endif
+                @if ($u['added'])
+                  <tr>
+                    <td class="card-label">Member since</td>
+                    <td>{{ $u['added']->format('M Y') }} ({{ $u['added']->diffForHumans(null, true) }} ago)</td>
+                  </tr>
+                @endif
+              @else
+                <tr>
+                  <td class="card-label">Member</td>
+                  <td><span class="flag-pill flag-pill-warn">Unmatched</span> — sleuthing required (PayPal/Stripe email may differ from Freegle email)</td>
+                </tr>
+              @endif
+            </table>
+          </mj-raw>
+
+          {{-- GIFT AID --}}
+          <mj-raw>
+            <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" class="card-body">
+              <tr><td colspan="2" class="card-section-head">Gift Aid</td></tr>
+              <tr>
+                <td class="card-label">Status</td>
+                <td><span class="flag-pill {{ $gaClass }}">{{ $gaLabel }}</span></td>
+              </tr>
+              @if ($ga && !$ga['declined'])
+                <tr>
+                  <td class="card-label">Postcode / house</td>
+                  <td>
+                    @if ($ga['postcode']) {{ $ga['postcode'] }}@else <span style="color:#a00;">missing</span>@endif
+                    &nbsp;/&nbsp;
+                    @if ($ga['housenameornumber']) {{ $ga['housenameornumber'] }}@else <span style="color:#a00;">missing</span>@endif
+                  </td>
+                </tr>
+              @endif
+              <tr>
+                <td class="card-label">This donation</td>
+                <td style="color:#555;">
+                  @if ($d['giftaidClaimed'])
+                    Claimed {{ $d['giftaidClaimed']->format('j M Y') }}
+                  @elseif ($d['giftaidConsent'])
+                    Consent on file, claim pending
+                  @else
+                    No consent yet
+                  @endif
+                </td>
+              </tr>
+            </table>
+          </mj-raw>
+
+          {{-- DONATION HISTORY --}}
+          @if (!empty($hist))
+            <mj-raw>
+              <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" class="card-body">
+                <tr><td colspan="3" class="card-section-head">Previous donations ({{ count($hist) }} shown)</td></tr>
+                @foreach ($hist as $h)
+                  <tr class="mini-row">
+                    <td style="width:90px;">{{ $h['date'] }}</td>
+                    <td style="width:80px;"><b>£{{ number_format($h['amount'], 2) }}</b></td>
+                    <td style="color:#666;">{{ $h['source'] }}@if ($h['thanked']) &nbsp;&middot;&nbsp;<span style="color:#155724;">thanked {{ $h['thanked']->format('j M Y') }}</span>@endif</td>
+                  </tr>
+                @endforeach
+              </table>
+            </mj-raw>
+          @endif
+
+          {{-- MEMBERSHIPS --}}
+          @if (!empty($members))
+            <mj-raw>
+              <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" class="card-body">
+                <tr><td colspan="2" class="card-section-head">Groups ({{ count($members) }})</td></tr>
+                @foreach ($members as $m)
+                  <tr class="mini-row">
+                    <td>{{ $m['name'] }} @if ($m['role'] !== 'Member') <span class="flag-pill">{{ $m['role'] }}</span>@endif</td>
+                    <td style="color:#888;text-align:right;width:120px;">since {{ $m['memberSince'] }}</td>
+                  </tr>
+                @endforeach
+              </table>
+            </mj-raw>
+          @endif
+
+          {{-- MOD NOTES --}}
+          @if (!empty($mods))
+            <mj-raw>
+              <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" class="card-body">
+                <tr><td colspan="2" class="card-section-head">Mod notes ({{ count($mods) }})</td></tr>
+                @foreach ($mods as $n)
+                  <tr class="mini-row">
+                    <td style="width:90px;color:#888;">{{ $n['date'] }}</td>
+                    <td>@if ($n['flag']) <span class="flag-pill flag-pill-warn">Flagged</span> @endif{{ $n['snippet'] }}</td>
+                  </tr>
+                @endforeach
+              </table>
+            </mj-raw>
+          @endif
+
+          {{-- MOD CHATS --}}
+          @if (!empty($chats))
+            <mj-raw>
+              <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" class="card-body">
+                <tr><td colspan="2" class="card-section-head">Recent member↔mod chat</td></tr>
+                @foreach ($chats as $c)
+                  <tr class="mini-row">
+                    <td style="width:90px;color:#888;">{{ $c['date'] }}</td>
+                    <td>
+                      <i style="color:#888;font-size:12px;">{{ $c['fromMember'] ? 'Member' : 'Mod' }}:</i>
+                      {{ $c['snippet'] }}
+                    </td>
+                  </tr>
+                @endforeach
+              </table>
+            </mj-raw>
+          @endif
+
+          {{-- QUICK LINKS --}}
+          <mj-raw>
+            <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" class="link-row">
+              <tr><td>
+                @if (!empty($links['modtoolsUser']))<a href="{{ $links['modtoolsUser'] }}">Open in Modtools support</a>@endif
+                <a href="{{ $links['giftaidRegister'] }}">Gift Aid register</a>
+              </td></tr>
+            </table>
+          </mj-raw>
+        </mj-column>
+      </mj-section>
+    @endforeach
+
+    @include('emails.mjml.partials.modtools-footer', ['email' => $email])
+
+  </mj-body>
+</mjml>

--- a/iznik-batch/routes/console.php
+++ b/iznik-batch/routes/console.php
@@ -377,14 +377,31 @@ Schedule::command('mail:donations:ask')
     ->sendOutputTo(cronLog('mail:donations:ask'))
     ->runInBackground();
 
-// Daily donation summary email to fundraising — running total of today's
-// donations. V1 (cron/donations_email.php) ran hourly 06:00-22:00 so the
-// team gets intraday visibility; matching that here.
+// Hourly donation status email to fundraising — running total of today's
+// donations as a simple table. V1 (cron/donations_email.php) ran hourly
+// 06:00-22:00 so the team gets intraday visibility; matching that here.
+// This is the *status* mail — it tells the team what's landed in the bank.
+// The complementary mail:donations:thank-prep below is a separate concern
+// (composing thank-you replies); they intentionally share neither content
+// nor recipient list.
 Schedule::command('mail:donations:summary')
     ->hourly()
     ->between('06:00', '22:00')
     ->withoutOverlapping()
     ->sendOutputTo(cronLog('mail:donations:summary'))
+    ->runInBackground();
+
+// Daily thank-prep digest — card-per-donation context for whoever composes
+// thank-you replies. Dedup is a config-table high-water-mark
+// (donation_thank_prep_last_id): each run shows only donations with id above
+// the stored mark, then advances the mark — so every donation appears in
+// exactly one digest and is never re-notified (it does NOT filter on the
+// users_donations.thanked column). Runs once a day in the evening, after the
+// last status mail; recipient is freegle.mail.thanks_addr.
+Schedule::command('mail:donations:thank-prep')
+    ->dailyAt('20:30')
+    ->withoutOverlapping()
+    ->sendOutputTo(cronLog('mail:donations:thank-prep'))
     ->runInBackground();
 
 // User management commands (users:cleanup still parked — no V1 cutover).

--- a/iznik-batch/tests/Feature/Donation/DonationThankPrepCommandTest.php
+++ b/iznik-batch/tests/Feature/Donation/DonationThankPrepCommandTest.php
@@ -1,0 +1,376 @@
+<?php
+
+namespace Tests\Feature\Donation;
+
+use App\Mail\Donation\DonationThankPrepMail;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Mail;
+use Tests\TestCase;
+
+/**
+ * Behaviour of `mail:donations:thank-prep` — the daily rich-card digest for
+ * the person composing thank-you replies. Distinct from the hourly status
+ * mail tested in {@see DonationSummaryCommandTest}; the two have no shared
+ * filtering or templating logic, by design.
+ */
+class DonationThankPrepCommandTest extends TestCase
+{
+    private function insertDonation(array $attributes = []): int
+    {
+        return (int) DB::table('users_donations')->insertGetId([
+            'userid'           => $attributes['userid']           ?? null,
+            'GrossAmount'      => $attributes['GrossAmount']      ?? 10.00,
+            'TransactionType'  => $attributes['TransactionType']  ?? 'Completed',
+            'Payer'            => $attributes['Payer']            ?? 'donor@example.com',
+            'PayerDisplayName' => $attributes['PayerDisplayName'] ?? ($attributes['Payer'] ?? 'donor@example.com'),
+            'type'             => $attributes['type']             ?? 'PayPal',
+            'source'           => $attributes['source']           ?? 'DonateWithPayPal',
+            'giftaidconsent'   => $attributes['giftaidconsent']   ?? 0,
+            'thanked'          => $attributes['thanked']          ?? null,
+            'timestamp'        => $attributes['timestamp']        ?? now(),
+        ]);
+    }
+
+    /**
+     * Seed the high-water mark so the test isn't gated by the lazy first-run
+     * init (which would mark MAX(id) and skip everything we just inserted).
+     * Tests that want a clean slate call this with 0 before inserting.
+     */
+    private function setLastSentId(int $id): void
+    {
+        DB::statement(
+            "INSERT INTO config (`key`, value) VALUES (?, ?) ON DUPLICATE KEY UPDATE value = ?",
+            ['donation_thank_prep_last_id', (string) $id, (string) $id]
+        );
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // Tests assert on a known empty state. Each test starts at id=0 so
+        // the digest will pick up freshly inserted donations.
+        $this->setLastSentId(0);
+    }
+
+    private function insertUser(array $attributes = []): int
+    {
+        $id = $attributes['id'] ?? null;
+        $row = array_merge([
+            'firstname'  => 'Test',
+            'lastname'   => 'Donor',
+            'fullname'   => 'Test Donor',
+            'systemrole' => 'User',
+            'added'      => now()->subYears(2),
+        ], $attributes);
+        if ($id !== null) {
+            $row['id'] = $id;
+        }
+        DB::table('users')->insert($row);
+        return $id ?? (int) DB::getPdo()->lastInsertId();
+    }
+
+    public function test_no_email_when_no_new_donations_since_last_mark(): void
+    {
+        Mail::fake();
+
+        // Insert a donation then advance the high-water mark past it so
+        // nothing is "new" by the time we run.
+        $id = $this->insertDonation(['GrossAmount' => 12.00]);
+        $this->setLastSentId($id);
+
+        $this->artisan('mail:donations:thank-prep')
+            ->expectsOutputToContain('No donations need thanks today')
+            ->assertExitCode(0);
+
+        Mail::assertNothingSent();
+    }
+
+    public function test_sends_digest_for_new_donations_only(): void
+    {
+        Mail::fake();
+
+        $this->insertDonation(['GrossAmount' => 15.00, 'Payer' => 'alice@example.com']);
+        $this->insertDonation(['GrossAmount' => 25.50, 'Payer' => 'bob@example.com']);
+
+        $this->artisan('mail:donations:thank-prep')
+            ->expectsOutputToContain('Sent thank-prep digest for 2 donor(s) needing thanks, totalling £40.50')
+            ->assertExitCode(0);
+
+        Mail::assertSentCount(1);
+        Mail::assertSent(DonationThankPrepMail::class, function (DonationThankPrepMail $mail) {
+            return $mail->envelope()->subject === 'Donations needing thanks: 2 donors, £40.50'
+                && count($mail->cards) === 2;
+        });
+    }
+
+    public function test_dry_run_does_not_send(): void
+    {
+        Mail::fake();
+        $this->insertDonation(['GrossAmount' => 20.00]);
+
+        $this->artisan('mail:donations:thank-prep', ['--dry-run' => true])
+            ->expectsOutputToContain('DRY RUN')
+            ->expectsOutputToContain('Would send thank-prep digest for 1 donor(s)')
+            ->assertExitCode(0);
+
+        Mail::assertNothingSent();
+    }
+
+    public function test_high_water_mark_prevents_repeats(): void
+    {
+        Mail::fake();
+
+        // First batch.
+        $this->insertDonation(['GrossAmount' => 10.00, 'Payer' => 'first@example.com']);
+        $this->insertDonation(['GrossAmount' => 20.00, 'Payer' => 'second@example.com']);
+
+        $this->artisan('mail:donations:thank-prep')->assertExitCode(0);
+        Mail::assertSentCount(1);
+
+        // Second batch arrives after the digest ran.
+        $this->insertDonation(['GrossAmount' => 30.00, 'Payer' => 'third@example.com']);
+
+        $this->artisan('mail:donations:thank-prep')->assertExitCode(0);
+
+        // Two mails total, and the second one only carries the new donation.
+        Mail::assertSentCount(2);
+        $second = Mail::sent(DonationThankPrepMail::class)->last();
+        $this->assertNotNull($second);
+        $this->assertCount(1, $second->cards);
+        $this->assertSame('third@example.com', $second->cards[0]['donation']['payer']);
+    }
+
+    public function test_first_run_with_unseeded_mark_initialises_to_max_id(): void
+    {
+        Mail::fake();
+
+        // Wipe the seeded mark so the service hits its lazy init path.
+        DB::table('config')->where('key', 'donation_thank_prep_last_id')->delete();
+
+        // Existing donations represent the "historical backlog" the service
+        // must NOT dump on first run.
+        $a = $this->insertDonation(['GrossAmount' => 5.00]);
+        $b = $this->insertDonation(['GrossAmount' => 5.00]);
+
+        $this->artisan('mail:donations:thank-prep')
+            ->expectsOutputToContain('No donations need thanks today')
+            ->assertExitCode(0);
+
+        Mail::assertNothingSent();
+
+        // Mark should have been initialised to MAX(id) so the next genuinely
+        // new donation triggers an email.
+        $row = DB::table('config')->where('key', 'donation_thank_prep_last_id')->first();
+        $this->assertNotNull($row);
+        $this->assertSame((string) $b, $row->value);
+
+        $this->insertDonation(['GrossAmount' => 7.00, 'Payer' => 'after@example.com']);
+        $this->artisan('mail:donations:thank-prep')->assertExitCode(0);
+        Mail::assertSentCount(1);
+    }
+
+    public function test_dry_run_on_fresh_deploy_does_not_persist_mark(): void
+    {
+        Mail::fake();
+
+        // Fresh deploy: no high-water mark yet.
+        DB::table('config')->where('key', 'donation_thank_prep_last_id')->delete();
+        $this->insertDonation(['GrossAmount' => 9.00]);
+
+        $this->artisan('mail:donations:thank-prep', ['--dry-run' => true])
+            ->expectsOutputToContain('DRY RUN')
+            ->assertExitCode(0);
+
+        Mail::assertNothingSent();
+
+        // A dry run must have NO side effects: the lazy first-run init must not
+        // persist the mark, so the row is still absent and a later real run can
+        // initialise it normally.
+        $row = DB::table('config')->where('key', 'donation_thank_prep_last_id')->first();
+        $this->assertNull($row, 'dry run must not create the high-water-mark config row');
+    }
+
+    public function test_unmatched_donor_flagged_for_sleuthing(): void
+    {
+        Mail::fake();
+
+        $this->insertDonation([
+            'GrossAmount' => 50.00,
+            'Payer'       => 'JONES MR P',
+            'source'      => 'BankTransfer',
+            'type'        => 'External',
+        ]);
+
+        $this->artisan('mail:donations:thank-prep')->assertExitCode(0);
+
+        Mail::assertSent(DonationThankPrepMail::class, function (DonationThankPrepMail $mail) {
+            $card = $mail->cards[0];
+            return $card['user'] === null
+                && in_array('Unmatched donor — needs sleuthing', $card['flags'], true)
+                && $card['donation']['source'] === 'Bank transfer';
+        });
+    }
+
+    public function test_enriches_matched_donor_with_user_giftaid_and_history(): void
+    {
+        Mail::fake();
+
+        $userId = $this->insertUser([
+            'firstname' => 'Elizabeth',
+            'lastname'  => 'Hibbert-Jones',
+            'fullname'  => 'Elizabeth Hibbert-Jones',
+            'added'     => now()->subYears(3),
+        ]);
+
+        DB::table('users_emails')->insert([
+            ['userid' => $userId, 'email' => 'elizabeth@example.com',                      'preferred' => 1],
+            ['userid' => $userId, 'email' => 'liz.hj@example.com',                         'preferred' => 0],
+            // Synthetic chat-only address — must be filtered out.
+            ['userid' => $userId, 'email' => "elizabeth-{$userId}@users.ilovefreegle.org", 'preferred' => 0],
+        ]);
+
+        DB::table('giftaid')->insert([
+            'userid'            => $userId,
+            'period'            => 'Past4YearsAndFuture',
+            'fullname'          => 'Elizabeth Hibbert-Jones',
+            'firstname'         => 'Elizabeth',
+            'lastname'          => 'Hibbert-Jones',
+            'homeaddress'       => '14 Acacia Avenue, NR1 1JW',
+            'postcode'          => 'NR1 1JW',
+            'housenameornumber' => '14',
+            'reviewed'          => now()->subMonths(2),
+        ]);
+
+        // Historical donation (last month). We advance the high-water mark
+        // past it so it surfaces in the donor's history list within today's
+        // card, NOT as a standalone card in the digest.
+        $oldId = $this->insertDonation([
+            'userid'          => $userId,
+            'GrossAmount'     => 10.00,
+            'Payer'           => 'elizabeth@example.com',
+            'TransactionType' => 'recurring_payment',
+            'timestamp'       => now()->subMonth(),
+            'giftaidconsent'  => 1,
+        ]);
+        $this->setLastSentId($oldId);
+
+        // Today's new donation.
+        $this->insertDonation([
+            'userid'          => $userId,
+            'GrossAmount'     => 10.00,
+            'Payer'           => 'elizabeth@example.com',
+            'TransactionType' => 'recurring_payment',
+            'giftaidconsent'  => 1,
+        ]);
+
+        $this->artisan('mail:donations:thank-prep')->assertExitCode(0);
+
+        Mail::assertSent(DonationThankPrepMail::class, function (DonationThankPrepMail $mail) use ($userId) {
+            $card = $mail->cards[0];
+            return $card['user'] !== null
+                && $card['user']['id'] === $userId
+                && $card['user']['displayName'] === 'Elizabeth Hibbert-Jones'
+                && count($card['aliases']) === 1
+                && $card['aliases'][0] === 'elizabeth@example.com'
+                && $card['giftaid'] !== null
+                && $card['giftaid']['period'] === 'Past4YearsAndFuture'
+                && $card['giftaid']['postcode'] === 'NR1 1JW'
+                && $card['giftaid']['declined'] === false
+                && count($card['donationHistory']) === 1
+                && (float) $card['donationHistory'][0]['amount'] === 10.0
+                && in_array('Recurring', $card['flags'], true);
+        });
+    }
+
+    public function test_pgf_donation_flagged_to_avoid_double_claim(): void
+    {
+        Mail::fake();
+
+        $this->insertDonation([
+            'GrossAmount' => 5.00,
+            'Payer'       => 'anon@paypal.example',
+            'source'      => 'PayPalGivingFund',
+            'type'        => 'External',
+        ]);
+
+        $this->artisan('mail:donations:thank-prep')->assertExitCode(0);
+
+        Mail::assertSent(DonationThankPrepMail::class, function (DonationThankPrepMail $mail) {
+            return in_array('PGF — Gift Aid claimed by PayPal', $mail->cards[0]['flags'], true);
+        });
+    }
+
+    public function test_declined_giftaid_distinguished_from_no_row(): void
+    {
+        Mail::fake();
+
+        $userA = $this->insertUser(['firstname' => 'No', 'lastname' => 'GA', 'fullname' => 'No GA']);
+        $this->insertDonation([
+            'userid' => $userA, 'GrossAmount' => 10.00,
+            'Payer'  => 'noga@example.com', 'PayerDisplayName' => 'No GA',
+        ]);
+
+        $userB = $this->insertUser(['firstname' => 'Said', 'lastname' => 'No', 'fullname' => 'Said No']);
+        DB::table('giftaid')->insert([
+            'userid'      => $userB,
+            'period'      => 'Declined',
+            'fullname'    => 'Said No',
+            'homeaddress' => '',
+            'reviewed'    => now()->subYear(),
+        ]);
+        $this->insertDonation([
+            'userid' => $userB, 'GrossAmount' => 20.00,
+            'Payer'  => 'declined@example.com', 'PayerDisplayName' => 'Said No',
+        ]);
+
+        $this->artisan('mail:donations:thank-prep')->assertExitCode(0);
+
+        Mail::assertSent(DonationThankPrepMail::class, function (DonationThankPrepMail $mail) use ($userA, $userB) {
+            $byId = [];
+            foreach ($mail->cards as $card) {
+                if ($card['user'] !== null) {
+                    $byId[$card['user']['id']] = $card;
+                }
+            }
+            $a = $byId[$userA] ?? null;
+            $b = $byId[$userB] ?? null;
+            return $a !== null && $a['giftaid'] === null
+                && $b !== null && $b['giftaid'] !== null
+                && $b['giftaid']['declined'] === true
+                && $b['giftaid']['period'] === 'Declined';
+        });
+    }
+
+    public function test_clean_snippet_decodes_legacy_emoji_and_html_entities(): void
+    {
+        Mail::fake();
+
+        $userId = $this->insertUser(['firstname' => 'Chat', 'lastname' => 'Donor']);
+        $this->insertDonation(['userid' => $userId, 'GrossAmount' => 5.00, 'Payer' => 'chat@example.com']);
+
+        // Mod note with HTML entity + legacy emoji escape (stored as
+        // \\u<hex>\\u per EmojiUtils). Must round-trip cleanly.
+        DB::table('users_comments')->insert([
+            'userid'   => $userId,
+            'byuserid' => null,
+            'date'     => now()->subWeek(),
+            'user1'    => null,
+            'user2'    => 'Tom &amp; Mary said thanks \\\\u1f600\\\\u — lovely chat.',
+            'flag'     => 0,
+        ]);
+
+        $this->artisan('mail:donations:thank-prep')->assertExitCode(0);
+
+        Mail::assertSent(DonationThankPrepMail::class, function (DonationThankPrepMail $mail) {
+            $note = $mail->cards[0]['modNotes'][0] ?? null;
+            if ($note === null) {
+                return false;
+            }
+            $snip = $note['snippet'];
+            return str_contains($snip, 'Tom & Mary')
+                && !str_contains($snip, '&amp;')
+                && str_contains($snip, "\u{1F600}")
+                && !str_contains($snip, 'u1f600');
+        });
+    }
+}

--- a/plans/future/finance-donations-automation.md
+++ b/plans/future/finance-donations-automation.md
@@ -37,20 +37,24 @@ These can all start immediately and are independent.
 
 **0c. Monthly contractor reminder emails.** Once Jane provides timing/recipients, add a Laravel scheduled command in `iznik-batch/app/Console/Commands/` that sends a templated email on a cron schedule. *Effort: ~0.5 day after Jane's spec. No dependencies.* (Action 7)
 
-**0d. Consolidated email to Jacky (pre-Xero).** Replace today's per-donation email storm with a daily digest, triggered off the existing CSV-upload flow — no Xero work required. Hook into wherever individual donation emails to Jacky are currently sent (in iznik-server or iznik-batch), buffer instead of sending, and emit one digest per day.
+**0d. Donation mails — two separate paths.** PR #571 conflated two distinct needs into one email; the real shape is two outputs sharing no template or recipient logic:
 
-The digest is shaped around Jacky's thank-you-email workflow ("workflow a" in her notes), so she can compose a thank-you straight from the email without bouncing between Modtools, info@, support@, giftaid@ and the GA register. For each donation:
+- **0d.i — Hourly donation status mail.** `mail:donations:summary`. Already runs hourly 06:00–22:00 (V1 parity with `cron/donations_email.php`); recipient is `freegle.mail.fundraising_addr`. A simple time/amount/payer table — finance-team awareness of what's landed in the bank today. *Status quo; no changes needed beyond keeping it untouched and de-conflated from 0d.ii.*
 
-- Email address and name (with any known aliases — see 0e).
-- Amount, date and method (PayPal / Stripe / bank / CAF / PGF).
-- Other donations from this donor, with dates.
-- Gift Aid status: already have / just requested / declined / CAF — no claim.
-- Membership: groups, member-since, active/inactive.
-- Recent mod-team contact with the member (any chat/messages worth knowing about).
-- Any prior thank-you email sent by Jacky, with content snippet and date.
-- Quick links: Modtools member page, info@/support@/giftaid@ search for this email, GA register entry.
+- **0d.ii — Daily thank-prep digest.** `mail:donations:thank-prep`. New command, daily at 20:30 after the last status mail. Recipient is `freegle.mail.thanks_addr` (defaults to `fundraising_addr` so the routing change is opt-in). Filters to donations where `thanked IS NULL` so the digest only surfaces outstanding work; once a donation is marked thanked it drops out of subsequent digests. Card-per-donation with the data Jacky would otherwise gather by hand:
+  - Donor identity: preferred external email (synthetic `@users.ilovefreegle.org` chat aliases filtered out), name, member-since.
+  - Amount, date, method (PayPal / Stripe / bank / PGF), reference.
+  - Donation history (up to 8 prior), with thanked-or-not on each row.
+  - Gift Aid status — distinguishes Active / Just declared / On file: Declined / Never asked / not on file.
+  - Group memberships with role + member-since.
+  - Most recent mod notes (decoded for legacy `\u<hex>\u` emoji escapes via `EmojiUtils`).
+  - Recent member↔mod chat snippets.
+  - Quick links: `/support/{id}` (real Modtools support page) and `/giftaid` (real Gift Aid review page).
+  - Flags: Recurring, PGF (Gift Aid already claimed by PayPal, don't double-claim), Unmatched donor (sleuthing needed), Birthday? (group birthday hint).
 
-Notes for the Xero rebuild later: the email template/builder is a service that takes a list of donation records — agnostic to whether they came from a CSV upload or a Xero pull — so Phase 1 only swaps the data source. *Effort: ~4–5 days. Depends on Jacky confirming cadence/format.* *(Action 2 — front half)*
+The thank-prep mailable takes a structured `cards` array per donation rather than pre-rendered HTML, so the Xero rebuild (Phase 1) only swaps the data source. *(Action 2 — front half)*
+
+**Dedup**: the service tracks a high-water mark — the last donation id included in any digest — in the existing `config` table (key `donation_thank_prep_last_id`), reusing the same key/value pattern as `GitSummaryService`. Each digest selects `id > last_id`, sends, then advances the mark to `MAX(id)` of the included rows. First run after deploy initialises the mark to current `MAX(users_donations.id)` so the historical backlog (~137k rows) isn't dumped. Late-arriving donations (e.g. after 20:30) appear in the next day's digest by id order, not date. No schema change, no new column.
 
 **0e. Donor lookup view v1 (in ModTools).** A single-page donor record that addresses the three search holes Jacky has flagged and supports her on-demand workflows (b: GA chase-up check; c: bulk thank-you check; d: "why am I still seeing ads"). Built from existing data — no Xero or PayPal API work needed for v1; those sources slot in as Phase 1 and 3 land.
 


### PR DESCRIPTION
## Summary

Splits the donation mail into two distinct concerns that previously shared one confused email:

- **`mail:donations:summary`** — hourly finance-team status table. Reverted to V1-parity master state; **no behaviour change vs master**.
- **`mail:donations:thank-prep`** — new daily digest (20:30) for the thanker: one rich card per donor (preferred external email, identity/member-since, donation history, Gift Aid status, group memberships, mod notes, recent member↔mod chat snippets, Modtools deep links, flags).

## Dedup — config high-water-mark ("mark on wall")

The thank-prep digest dedups via a **config-table high-water-mark** (`donation_thank_prep_last_id`), not a per-row flag:

- Each run mails only donations with `id > stored mark`, then advances the mark to the max id mailed.
- First run initialises the mark to `MAX(users_donations.id)` so the ~137k historical backlog isn't dumped into the inbox on day one.
- Same pattern as `GitSummaryService`; uses the existing `config(key,value)` table — no schema change.

A donation therefore appears in exactly one digest and is never re-notified. (`users_donations.thanked` is displayed per-row in the history card for context only; it is **not** used for filtering — so the fact that nothing currently writes it is irrelevant to dedup.)

## Recipient

New `freegle.mail.thanks_addr` config, defaulting to `fundraising_addr` (set `FREEGLE_THANKS_ADDR` to route the thank-prep digest separately, e.g. to Jacky).

## Test

`DonationThankPrepCommandTest` — exercises the high-water-mark advance and first-run initialisation.
