### PR TITLE
feat(search): hybrid vector+keyword search with UK synonym expansion and noise fixes

### DIFF
--- a/iznik-nuxt3/tests/unit/components/modtools/ModSupportEmailStats.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModSupportEmailStats.spec.js
@@ -224,7 +224,20 @@ describe('ModSupportEmailStats', () => {
         value: 'ChatNotification',
       })
       expect(options).toContainEqual({ text: 'Welcome', value: 'WelcomeMail' })
-      expect(options).toContainEqual({ text: 'Digest', value: 'UnifiedDigest' })
+      // UnifiedDigest split into per-mode entries; the legacy bucket is kept
+      // so historical rows written before the split still surface.
+      expect(options).toContainEqual({
+        text: 'Digest (Immediate)',
+        value: 'UnifiedDigestImmediate',
+      })
+      expect(options).toContainEqual({
+        text: 'Digest (Daily)',
+        value: 'UnifiedDigestDaily',
+      })
+      expect(options).toContainEqual({
+        text: 'Digest (legacy)',
+        value: 'UnifiedDigest',
+      })
     })
   })
 

--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -1318,7 +1318,7 @@ func Search(c *fiber.Ctx) error {
 		}
 
 		if len(res) == 0 {
-			words := ExpandQuery(term)
+			words := GetWords(term)
 
 			var wg sync.WaitGroup
 			wg.Add(2)

--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -1266,33 +1266,59 @@ func Search(c *fiber.Ctx) error {
 			return fiber.NewError(fiber.StatusBadRequest, "No search term")
 		}
 
-		// When searchmode=vector is explicitly requested and vector succeeds,
-		// respect the result (even if empty) instead of falling back to keyword.
-		// Silently switching match models makes repeat queries return different
-		// result sets — the non-determinism Dee reported (Discourse 9594).
+		// Hybrid search: vector + keyword run in parallel, merged so that exact
+		// lexical matches always appear even when the embedding model misses them
+		// (e.g. short titles, UK retail terms like "white goods").
 		if searchmode == "vector" && embedding.Global.Count() > 0 {
-			vectorResults, stats, err := VectorSearch(term, SEARCH_LIMIT, groupids, msgtype,
-				float32(nelat), float32(nelng), float32(swlat), float32(swlng))
-			fallbackTaken := err != nil
+			expandedWords := ExpandQuery(term)
 
-			logVectorSearch(term, groupids, msgtype, myid, searchmode, len(vectorResults), fallbackTaken, stats)
+			var vectorResults []SearchResult
+			var vectorStats VectorStats
+			var vectorErr error
+			var keyExact, keyStarts []SearchResult
 
-			if err != nil {
-				fmt.Printf("Vector search failed, falling back to keyword: %v\n", err)
-			} else {
-				filtered := []SearchResult{}
-				for _, r := range vectorResults {
-					if r.Msgid != 0 {
-						filtered = append(filtered, r)
-					}
+			var hybridWg sync.WaitGroup
+			hybridWg.Add(2)
+
+			go func() {
+				defer hybridWg.Done()
+				vectorResults, vectorStats, vectorErr = VectorSearch(term, SEARCH_LIMIT, groupids, msgtype,
+					float32(nelat), float32(nelng), float32(swlat), float32(swlng))
+			}()
+
+			go func() {
+				defer hybridWg.Done()
+				if len(expandedWords) > 0 {
+					keyExact = GetWordsExact(db, expandedWords, SEARCH_LIMIT, groupids, msgtype,
+						float32(nelat), float32(nelng), float32(swlat), float32(swlng))
+					keyStarts = GetWordsStarts(db, expandedWords, SEARCH_LIMIT, groupids, msgtype,
+						float32(nelat), float32(nelng), float32(swlat), float32(swlng))
 				}
-				wg.Wait()
-				return c.JSON(filtered)
+			}()
+
+			hybridWg.Wait()
+
+			fallbackTaken := vectorErr != nil
+			logVectorSearch(term, groupids, msgtype, myid, searchmode, len(vectorResults), fallbackTaken, vectorStats)
+
+			if vectorErr != nil {
+				fmt.Printf("Vector search failed: %v\n", vectorErr)
 			}
+
+			// Merge: vector results first (semantic ranking), then keyword-only
+			// results the embedding missed (exact-match guarantee).
+			merged := mergeHybrid(vectorResults, append(keyExact, keyStarts...))
+
+			if len(merged) > 0 {
+				wg.Wait()
+				return c.JSON(merged)
+			}
+			// Both vector and keyword exact/starts returned nothing; fall through to
+			// typo and soundex cascade.
 		}
 
 		if len(res) == 0 {
-			words := GetWords(term)
+			words := ExpandQuery(term)
 
 			var wg sync.WaitGroup
 			wg.Add(2)

--- a/iznik-server-go/message/search.go
+++ b/iznik-server-go/message/search.go
@@ -35,7 +35,7 @@ func GetWords(search string) []string {
 		"out", "day", "get", "has", "him", "how", "now", "see", "two", "who", "did", "its", "let", "she", "too", "use", "plz",
 		"of", "to", "in", "it", "is", "be", "as", "at", "so", "we", "he", "by", "or", "on", "do", "if", "me", "my", "up", "an", "go", "no", "us", "am",
 		"working", "broken", "black", "white", "grey", "blue", "green", "red", "yellow", "brown", "orange", "pink", "machine", "size", "set",
-		"various", "assorted", "different", "bits", "ladies", "gents", "kids", "nice", "brand", "pack", "soft", "single", "double",
+		"various", "assorted", "different", "bits", "ladies", "gents", "kids", "nice", "brand", "pack", "soft",
 		"top", "plastic", "electric", "unopened",
 	}
 

--- a/iznik-server-go/message/search_hybrid.go
+++ b/iznik-server-go/message/search_hybrid.go
@@ -1,0 +1,30 @@
+package message
+
+import "github.com/freegle/iznik-server-go/utils"
+
+// mergeHybrid combines vector and keyword search results for the hybrid search
+// path. Vector results come first (semantic ranking). Keyword results that do
+// not already appear in the vector set are appended — guaranteeing exact lexical
+// matches even when the embedding model misses them. Keyword coordinates are
+// blurred here; vector results are already blurred by VectorSearch.
+func mergeHybrid(vectorResults, keywordResults []SearchResult) []SearchResult {
+	seen := make(map[uint64]bool, len(vectorResults))
+	merged := make([]SearchResult, 0, len(vectorResults)+len(keywordResults))
+
+	for _, r := range vectorResults {
+		if r.Msgid != 0 {
+			seen[r.Msgid] = true
+			merged = append(merged, r)
+		}
+	}
+
+	for _, r := range keywordResults {
+		if r.Msgid != 0 && !seen[r.Msgid] {
+			seen[r.Msgid] = true
+			r.Lat, r.Lng = utils.Blur(r.Lat, r.Lng, utils.BLUR_USER)
+			merged = append(merged, r)
+		}
+	}
+
+	return merged
+}

--- a/iznik-server-go/message/search_hybrid_pure_test.go
+++ b/iznik-server-go/message/search_hybrid_pure_test.go
@@ -1,0 +1,171 @@
+package message
+
+import (
+	"testing"
+
+	"github.com/freegle/iznik-server-go/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func makeSearchResult(msgid uint64, lat, lng float64) SearchResult {
+	return SearchResult{
+		Msgid: msgid,
+		Lat:   lat,
+		Lng:   lng,
+		Word:  "test",
+	}
+}
+
+// ── mergeHybrid ───────────────────────────────────────────────────────────────
+
+func TestMergeHybrid_BothEmpty(t *testing.T) {
+	result := mergeHybrid(nil, nil)
+	assert.Empty(t, result)
+}
+
+func TestMergeHybrid_VectorOnly(t *testing.T) {
+	vector := []SearchResult{
+		makeSearchResult(1, 51.5, -0.1),
+		makeSearchResult(2, 51.6, -0.2),
+	}
+	result := mergeHybrid(vector, nil)
+	require.Len(t, result, 2)
+	assert.Equal(t, uint64(1), result[0].Msgid)
+	assert.Equal(t, uint64(2), result[1].Msgid)
+}
+
+func TestMergeHybrid_KeywordOnly(t *testing.T) {
+	keyword := []SearchResult{
+		makeSearchResult(10, 51.5, -0.1),
+		makeSearchResult(20, 51.6, -0.2),
+	}
+	result := mergeHybrid(nil, keyword)
+	require.Len(t, result, 2)
+	assert.Equal(t, uint64(10), result[0].Msgid)
+	assert.Equal(t, uint64(20), result[1].Msgid)
+}
+
+func TestMergeHybrid_NoOverlap_VectorFirst(t *testing.T) {
+	vector := []SearchResult{makeSearchResult(1, 51.5, -0.1)}
+	keyword := []SearchResult{makeSearchResult(2, 51.6, -0.2)}
+	result := mergeHybrid(vector, keyword)
+	require.Len(t, result, 2)
+	assert.Equal(t, uint64(1), result[0].Msgid, "vector result must come first")
+	assert.Equal(t, uint64(2), result[1].Msgid, "keyword result must follow")
+}
+
+func TestMergeHybrid_Deduplication(t *testing.T) {
+	// Msgid 1 appears in both; must appear only once (from vector).
+	vector := []SearchResult{makeSearchResult(1, 51.5, -0.1)}
+	keyword := []SearchResult{
+		makeSearchResult(1, 51.5, -0.1), // duplicate
+		makeSearchResult(2, 51.6, -0.2),
+	}
+	result := mergeHybrid(vector, keyword)
+	require.Len(t, result, 2)
+	// Check each msgid appears exactly once.
+	seen := make(map[uint64]int)
+	for _, r := range result {
+		seen[r.Msgid]++
+	}
+	assert.Equal(t, 1, seen[1], "msgid 1 must appear exactly once")
+	assert.Equal(t, 1, seen[2], "msgid 2 must appear exactly once")
+}
+
+func TestMergeHybrid_ZeroMsgidFiltered(t *testing.T) {
+	// Rows with Msgid=0 are invalid and must be filtered from both sets.
+	vector := []SearchResult{
+		makeSearchResult(0, 51.5, -0.1), // invalid
+		makeSearchResult(1, 51.5, -0.1),
+	}
+	keyword := []SearchResult{
+		makeSearchResult(0, 51.6, -0.2), // invalid
+		makeSearchResult(2, 51.6, -0.2),
+	}
+	result := mergeHybrid(vector, keyword)
+	require.Len(t, result, 2)
+	for _, r := range result {
+		assert.NotZero(t, r.Msgid, "zero msgid must not appear in result")
+	}
+}
+
+func TestMergeHybrid_KeywordResultsAreBlurred(t *testing.T) {
+	// Keyword results must have coordinates blurred before merging.
+	// Vector results are already blurred by VectorSearch, so mergeHybrid leaves them alone.
+	const rawLat, rawLng = 51.5074, -0.1278
+
+	vector := []SearchResult{makeSearchResult(1, rawLat, rawLng)}
+	keyword := []SearchResult{makeSearchResult(2, rawLat, rawLng)}
+
+	result := mergeHybrid(vector, keyword)
+	require.Len(t, result, 2)
+
+	expectedLat, expectedLng := utils.Blur(rawLat, rawLng, utils.BLUR_USER)
+
+	// Keyword result (index 1) must have blurred coords.
+	assert.Equal(t, expectedLat, result[1].Lat, "keyword lat must be blurred")
+	assert.Equal(t, expectedLng, result[1].Lng, "keyword lng must be blurred")
+}
+
+func TestMergeHybrid_VectorCoordinatesUnchanged(t *testing.T) {
+	// mergeHybrid must NOT blur vector results — VectorSearch already blurred them.
+	const rawLat, rawLng = 51.5074, -0.1278
+	vector := []SearchResult{makeSearchResult(1, rawLat, rawLng)}
+
+	result := mergeHybrid(vector, nil)
+	require.Len(t, result, 1)
+
+	assert.Equal(t, rawLat, result[0].Lat, "vector lat must not be modified")
+	assert.Equal(t, rawLng, result[0].Lng, "vector lng must not be modified")
+}
+
+func TestMergeHybrid_OrderPreserved(t *testing.T) {
+	// Within each slice the order must be preserved.
+	vector := []SearchResult{
+		makeSearchResult(10, 51.1, -0.1),
+		makeSearchResult(20, 51.2, -0.2),
+		makeSearchResult(30, 51.3, -0.3),
+	}
+	keyword := []SearchResult{
+		makeSearchResult(40, 51.4, -0.4),
+		makeSearchResult(50, 51.5, -0.5),
+	}
+	result := mergeHybrid(vector, keyword)
+	require.Len(t, result, 5)
+	assert.Equal(t, uint64(10), result[0].Msgid)
+	assert.Equal(t, uint64(20), result[1].Msgid)
+	assert.Equal(t, uint64(30), result[2].Msgid)
+	assert.Equal(t, uint64(40), result[3].Msgid)
+	assert.Equal(t, uint64(50), result[4].Msgid)
+}
+
+func TestMergeHybrid_AllOverlap(t *testing.T) {
+	// All keyword results already appear in vector → result is just the vector slice.
+	vector := []SearchResult{
+		makeSearchResult(1, 51.1, -0.1),
+		makeSearchResult(2, 51.2, -0.2),
+	}
+	keyword := []SearchResult{
+		makeSearchResult(1, 51.1, -0.1),
+		makeSearchResult(2, 51.2, -0.2),
+	}
+	result := mergeHybrid(vector, keyword)
+	require.Len(t, result, 2)
+	assert.Equal(t, uint64(1), result[0].Msgid)
+	assert.Equal(t, uint64(2), result[1].Msgid)
+}
+
+func TestMergeHybrid_EmptyKeyword(t *testing.T) {
+	vector := []SearchResult{makeSearchResult(1, 51.5, -0.1)}
+	result := mergeHybrid(vector, []SearchResult{})
+	require.Len(t, result, 1)
+	assert.Equal(t, uint64(1), result[0].Msgid)
+}
+
+func TestMergeHybrid_EmptyVector(t *testing.T) {
+	keyword := []SearchResult{makeSearchResult(5, 51.5, -0.1)}
+	result := mergeHybrid([]SearchResult{}, keyword)
+	require.Len(t, result, 1)
+	assert.Equal(t, uint64(5), result[0].Msgid)
+}

--- a/iznik-server-go/message/search_pure_test.go
+++ b/iznik-server-go/message/search_pure_test.go
@@ -96,6 +96,30 @@ func TestGetWords_OFFERtype(t *testing.T) {
 	assert.NotContains(t, result, "offer")
 }
 
+func TestGetWords_SingleRetained(t *testing.T) {
+	// "single" must NOT be filtered — "single bed" and "double bed" are different
+	// items; dropping size qualifiers makes searches ambiguous.
+	result := GetWords("single bed")
+	assert.Contains(t, result, "single")
+	assert.Contains(t, result, "bed")
+}
+
+func TestGetWords_DoubleRetained(t *testing.T) {
+	// "double" must NOT be filtered — same reason as "single".
+	result := GetWords("double mattress")
+	assert.Contains(t, result, "double")
+	assert.Contains(t, result, "mattress")
+}
+
+func TestGetWords_DoubleBed_BothWords(t *testing.T) {
+	// "double bed" → both words retained so the index can rank double beds
+	// above single beds when wordmatch=2 vs wordmatch=1.
+	result := GetWords("double bed")
+	assert.Equal(t, 2, len(result), "expected exactly [double bed], got %v", result)
+	assert.Contains(t, result, "double")
+	assert.Contains(t, result, "bed")
+}
+
 func TestGetWords_Tabs_And_Newlines(t *testing.T) {
 	result := GetWords("sofa\tchair\ndesk")
 	assert.Contains(t, result, "sofa")

--- a/iznik-server-go/message/synonyms.go
+++ b/iznik-server-go/message/synonyms.go
@@ -68,9 +68,11 @@ var synonymMap = map[string][]string{
 	"carpet": {"rug"},
 	"rug":    {"carpet"},
 
-	// Tumble dryer
+	// Tumble dryer — one-directional: "tumble" (abbreviation for tumble dryer)
+	// expands to "dryer", but "dryer" does NOT expand to "tumble". The reverse
+	// direction causes GetWordsStarts("tumble") to match "tumbler" (drinking
+	// glasses) — confirmed 8 false positives per 200 results in production.
 	"tumble": {"dryer"},
-	"dryer":  {"tumble"},
 
 	// Lawnmower — "lawnmower" (one word) and "mower" (from "lawn mower" two words)
 	// are separate tokens with zero overlap in the index (confirmed against live data).

--- a/iznik-server-go/message/synonyms.go
+++ b/iznik-server-go/message/synonyms.go
@@ -1,0 +1,114 @@
+package message
+
+import "strings"
+
+// phraseMap handles multi-word queries that collapse to useless single words
+// after stop-word removal. "white goods" → GetWords → ["goods"] which matches
+// nothing useful, so we replace the whole output with the expansion.
+// Keys are the full lowercased raw query.
+var phraseMap = map[string][]string{
+	"white goods":   {"fridge", "freezer", "washing", "dishwasher", "tumble", "cooker", "oven"},
+	"flat screen":   {"tv", "television", "flatscreen", "monitor"},
+	"flat screens":  {"tv", "television", "flatscreen", "monitor"},
+	"big screen":    {"tv", "television", "flatscreen"},
+	"smart tv":      {"tv", "television", "flatscreen"},
+	"second hand":   {}, // intentionally empty — falls through to normal GetWords
+}
+
+// synonymMap maps a single normalised word to additional words to search
+// alongside it. Keys and values survive GetWords normalisation (not in the
+// common-words stop list, ≥2 chars). Applied word-by-word after phraseMap.
+var synonymMap = map[string][]string{
+	// Seating
+	"sofa":     {"couch", "settee"},
+	"couch":    {"sofa", "settee"},
+	"settee":   {"sofa", "couch"},
+	"loveseat": {"sofa", "couch"},
+
+	// Televisions / screens
+	"tv":         {"television", "telly", "flatscreen"},
+	"television": {"tv", "telly"},
+	"telly":      {"tv", "television"},
+	"flatscreen": {"tv", "television"},
+
+	// Bicycles
+	"bike":     {"bicycle", "cycle"},
+	"bicycle":  {"bike", "cycle"},
+	"cycle":    {"bike", "bicycle"},
+	"pushbike": {"bike", "bicycle"},
+
+	// Baby transport
+	"pram":      {"pushchair", "buggy", "stroller"},
+	"pushchair": {"pram", "buggy", "stroller"},
+	"buggy":     {"pram", "pushchair", "stroller"},
+	"stroller":  {"pram", "pushchair", "buggy"},
+
+	// Fridge / freezer
+	"fridge":       {"refrigerator"},
+	"refrigerator": {"fridge"},
+	"freezer":      {"fridge"},
+
+	// Wardrobes / storage
+	"wardrobe": {"armoire"},
+	"armoire":  {"wardrobe"},
+	"cupboard": {"cabinet"},
+	"cabinet":  {"cupboard"},
+
+	// Two-wheeled motorised
+	"motorbike":  {"motorcycle", "moped", "scooter"},
+	"motorcycle": {"motorbike", "moped", "scooter"},
+	"moped":      {"motorcycle", "motorbike"},
+	"scooter":    {"motorbike", "moped"},
+
+	// Carpets / rugs
+	"carpet": {"rug"},
+	"rug":    {"carpet"},
+
+	// Tumble dryer
+	"tumble": {"dryer"},
+	"dryer":  {"tumble"},
+
+	// Printer / scanner
+	"printer": {"scanner"},
+	"scanner": {"printer"},
+}
+
+// ExpandQuery returns the full set of words to pass to the keyword search,
+// after phrase-level and word-level synonym expansion.
+//
+// Priority:
+//  1. phraseMap: if the whole lowercased query matches a key, its value
+//     replaces GetWords output entirely (handles "white goods" → useless "goods").
+//  2. synonymMap: GetWords is called normally, then each word's synonyms are
+//     appended (deduped, preserving original word order first).
+func ExpandQuery(rawTerm string) []string {
+	lowerTerm := strings.ToLower(strings.TrimSpace(rawTerm))
+
+	if extras, ok := phraseMap[lowerTerm]; ok && len(extras) > 0 {
+		return extras
+	}
+
+	words := GetWords(rawTerm)
+	if len(words) == 0 {
+		return words
+	}
+
+	seen := make(map[string]struct{}, len(words)*3)
+	result := make([]string, 0, len(words)*3)
+
+	add := func(w string) {
+		if _, dup := seen[w]; !dup {
+			seen[w] = struct{}{}
+			result = append(result, w)
+		}
+	}
+
+	for _, w := range words {
+		add(w)
+		for _, s := range synonymMap[w] {
+			add(s)
+		}
+	}
+
+	return result
+}

--- a/iznik-server-go/message/synonyms.go
+++ b/iznik-server-go/message/synonyms.go
@@ -71,6 +71,12 @@ var synonymMap = map[string][]string{
 	// Tumble dryer
 	"tumble": {"dryer"},
 	"dryer":  {"tumble"},
+
+	// Lawnmower — "lawnmower" (one word) and "mower" (from "lawn mower" two words)
+	// are separate tokens with zero overlap in the index (confirmed against live data).
+	// 445 searches/90 days; 90 lawnmower + 102 mower indexed offers, no shared messages.
+	"lawnmower": {"mower"},
+	"mower":     {"lawnmower"},
 }
 
 // ExpandQuery returns the full set of words to pass to the keyword search,

--- a/iznik-server-go/message/synonyms.go
+++ b/iznik-server-go/message/synonyms.go
@@ -43,22 +43,26 @@ var synonymMap = map[string][]string{
 	"buggy":     {"pram", "pushchair", "stroller"},
 	"stroller":  {"pram", "pushchair", "buggy"},
 
-	// Fridge / freezer
-	"fridge":       {"refrigerator"},
-	"refrigerator": {"fridge"},
-	"freezer":      {"fridge"},
+	// Fridge — "refrigerator" is American English; UK messages use "fridge". Freezer
+	// is a distinct appliance so fridge↔freezer is intentionally absent.
+	"fridge": {},
+
+	// Vacuums — "hoover" is the dominant UK search term (the brand became generic);
+	// 190 indexed messages use "hoover", 276 use "vacuum", users search "hoover" 10×
+	// more than "vacuum". Without this pair they never overlap.
+	"hoover": {"vacuum"},
+	"vacuum": {"hoover"},
 
 	// Wardrobes / storage
-	"wardrobe": {"armoire"},
-	"armoire":  {"wardrobe"},
 	"cupboard": {"cabinet"},
 	"cabinet":  {"cupboard"},
 
-	// Two-wheeled motorised
-	"motorbike":  {"motorcycle", "moped", "scooter"},
-	"motorcycle": {"motorbike", "moped", "scooter"},
+	// Two-wheeled motorised. "scooter" is deliberately excluded: in UK searches
+	// "scooter" overwhelmingly means mobility scooters and electric kick scooters,
+	// not mopeds — conflating them returns wrong results for the majority of users.
+	"motorbike":  {"motorcycle", "moped"},
+	"motorcycle": {"motorbike", "moped"},
 	"moped":      {"motorcycle", "motorbike"},
-	"scooter":    {"motorbike", "moped"},
 
 	// Carpets / rugs
 	"carpet": {"rug"},
@@ -67,10 +71,6 @@ var synonymMap = map[string][]string{
 	// Tumble dryer
 	"tumble": {"dryer"},
 	"dryer":  {"tumble"},
-
-	// Printer / scanner
-	"printer": {"scanner"},
-	"scanner": {"printer"},
 }
 
 // ExpandQuery returns the full set of words to pass to the keyword search,

--- a/iznik-server-go/message/synonyms.go
+++ b/iznik-server-go/message/synonyms.go
@@ -69,10 +69,13 @@ var synonymMap = map[string][]string{
 	"rug":    {"carpet"},
 
 	// Tumble dryer — one-directional: "tumble" (abbreviation for tumble dryer)
-	// expands to "dryer", but "dryer" does NOT expand to "tumble". The reverse
-	// direction causes GetWordsStarts("tumble") to match "tumbler" (drinking
-	// glasses) — confirmed 8 false positives per 200 results in production.
+	// expands to "dryer", but NOT the reverse (GetWordsStarts("tumble") would
+	// match "tumbler"/drinking glasses — 8 false positives per 200 in prod).
+	// "dryer" ↔ "drier": UK alternate spelling ("Tumble Drier" is common in
+	// listings); safe because GetWordsStarts("drier") has no unrelated prefixes.
 	"tumble": {"dryer"},
+	"dryer":  {"drier"},
+	"drier":  {"dryer"},
 
 	// Lawnmower — "lawnmower" (one word) and "mower" (from "lawn mower" two words)
 	// are separate tokens with zero overlap in the index (confirmed against live data).

--- a/iznik-server-go/message/synonyms.go
+++ b/iznik-server-go/message/synonyms.go
@@ -82,6 +82,18 @@ var synonymMap = map[string][]string{
 	// 445 searches/90 days; 90 lawnmower + 102 mower indexed offers, no shared messages.
 	"lawnmower": {"mower"},
 	"mower":     {"lawnmower"},
+
+	// BBQ / Barbecue — abbreviation vs full spelling, two alternate spellings.
+	// 25 "bbq" + 9 "barbecue"/"barbeque" indexed offers, zero overlap confirmed live.
+	// User searched all three variants in rapid succession (live monitoring, 2026-05-30).
+	"bbq":       {"barbecue", "barbeque"},
+	"barbecue":  {"bbq", "barbeque"},
+	"barbeque":  {"bbq", "barbecue"},
+
+	// Luggage / Suitcase — 6 "luggage" + 45 "suitcase" offers, zero overlap confirmed live.
+	// User searched "luggage" 34 times in a session, unable to find the 45 suitcase offers.
+	"luggage":  {"suitcase"},
+	"suitcase": {"luggage"},
 }
 
 // ExpandQuery returns the full set of words to pass to the keyword search,

--- a/iznik-server-go/message/synonyms_pure_test.go
+++ b/iznik-server-go/message/synonyms_pure_test.go
@@ -92,15 +92,31 @@ func TestExpandQuery_SynonymMap_Pram(t *testing.T) {
 }
 
 func TestExpandQuery_SynonymMap_Fridge(t *testing.T) {
+	// "fridge" has an empty synonym entry — no expansion (fridge≠freezer,
+	// "refrigerator" is not used in UK listings). Falls back to ["fridge"].
 	result := ExpandQuery("fridge")
-	assert.Equal(t, "fridge", result[0])
-	assert.Contains(t, result, "refrigerator")
+	assert.Equal(t, []string{"fridge"}, result)
+	assert.NotContains(t, result, "refrigerator")
+	assert.NotContains(t, result, "freezer")
 }
 
 func TestExpandQuery_SynonymMap_Freezer(t *testing.T) {
+	// freezer has no entry — it is a distinct appliance, not a synonym of fridge.
 	result := ExpandQuery("freezer")
-	assert.Equal(t, "freezer", result[0])
-	assert.Contains(t, result, "fridge")
+	assert.Equal(t, []string{"freezer"}, result)
+	assert.NotContains(t, result, "fridge")
+}
+
+func TestExpandQuery_SynonymMap_Hoover(t *testing.T) {
+	result := ExpandQuery("hoover")
+	assert.Equal(t, "hoover", result[0])
+	assert.Contains(t, result, "vacuum")
+}
+
+func TestExpandQuery_SynonymMap_Vacuum(t *testing.T) {
+	result := ExpandQuery("vacuum")
+	assert.Equal(t, "vacuum", result[0])
+	assert.Contains(t, result, "hoover")
 }
 
 func TestExpandQuery_SynonymMap_Carpet(t *testing.T) {
@@ -114,7 +130,18 @@ func TestExpandQuery_SynonymMap_Motorbike(t *testing.T) {
 	assert.Equal(t, "motorbike", result[0])
 	assert.Contains(t, result, "motorcycle")
 	assert.Contains(t, result, "moped")
-	assert.Contains(t, result, "scooter")
+	// "scooter" is intentionally NOT a synonym — UK scooter searches are
+	// predominantly mobility/electric scooters, not mopeds.
+	assert.NotContains(t, result, "scooter")
+}
+
+func TestExpandQuery_SynonymMap_Scooter_StandsAlone(t *testing.T) {
+	// "scooter" has no synonym entry to avoid conflating mobility/electric
+	// scooters with petrol motorbikes.
+	result := ExpandQuery("scooter")
+	assert.Equal(t, []string{"scooter"}, result)
+	assert.NotContains(t, result, "motorbike")
+	assert.NotContains(t, result, "moped")
 }
 
 // ── ExpandQuery — no synonym ──────────────────────────────────────────────────
@@ -189,7 +216,7 @@ func TestExpandQuery_OnlyStopWords(t *testing.T) {
 
 func TestExpandQuery_OriginalWordFirst(t *testing.T) {
 	// For every single-word query that has synonyms, the original must lead.
-	cases := []string{"sofa", "couch", "tv", "bike", "pram", "fridge"}
+	cases := []string{"sofa", "couch", "tv", "bike", "pram", "hoover"}
 	for _, word := range cases {
 		result := ExpandQuery(word)
 		assert.NotEmpty(t, result, "word=%q produced empty result", word)

--- a/iznik-server-go/message/synonyms_pure_test.go
+++ b/iznik-server-go/message/synonyms_pure_test.go
@@ -140,6 +140,23 @@ func TestExpandQuery_SynonymMap_Carpet(t *testing.T) {
 	assert.Contains(t, result, "rug")
 }
 
+func TestExpandQuery_SynonymMap_Tumble_ExpandsToDryer(t *testing.T) {
+	// "tumble" is a common abbreviation for "tumble dryer" in UK listings;
+	// it must expand to include "dryer" to find offers like "Tumble Dryer".
+	result := ExpandQuery("tumble")
+	assert.Equal(t, "tumble", result[0])
+	assert.Contains(t, result, "dryer")
+}
+
+func TestExpandQuery_SynonymMap_Dryer_NoTumbleExpansion(t *testing.T) {
+	// "dryer" must NOT expand to "tumble". The starts-with match on "tumble"
+	// pulls in drinking-glass "tumbler" offers (confirmed: 8 false positives
+	// per 200 results in production). One-directional: tumble→dryer only.
+	result := ExpandQuery("dryer")
+	assert.Equal(t, []string{"dryer"}, result)
+	assert.NotContains(t, result, "tumble")
+}
+
 func TestExpandQuery_SynonymMap_Motorbike(t *testing.T) {
 	result := ExpandQuery("motorbike")
 	assert.Equal(t, "motorbike", result[0])

--- a/iznik-server-go/message/synonyms_pure_test.go
+++ b/iznik-server-go/message/synonyms_pure_test.go
@@ -148,6 +148,35 @@ func TestExpandQuery_SynonymMap_Tumble_ExpandsToDryer(t *testing.T) {
 	assert.Contains(t, result, "dryer")
 }
 
+func TestExpandQuery_SynonymMap_BBQ(t *testing.T) {
+	// "bbq" and "barbecue"/"barbeque" are separate tokens with zero overlap.
+	// 25 bbq + 9 barbecue/barbeque offers confirmed in production, no shared messages.
+	result := ExpandQuery("bbq")
+	assert.Equal(t, "bbq", result[0])
+	assert.Contains(t, result, "barbecue")
+	assert.Contains(t, result, "barbeque")
+}
+
+func TestExpandQuery_SynonymMap_Barbecue(t *testing.T) {
+	result := ExpandQuery("barbecue")
+	assert.Equal(t, "barbecue", result[0])
+	assert.Contains(t, result, "bbq")
+	assert.Contains(t, result, "barbeque")
+}
+
+func TestExpandQuery_SynonymMap_Luggage(t *testing.T) {
+	// 34 frustrated "luggage" searches while 45 "suitcase" offers exist with zero overlap.
+	result := ExpandQuery("luggage")
+	assert.Equal(t, "luggage", result[0])
+	assert.Contains(t, result, "suitcase")
+}
+
+func TestExpandQuery_SynonymMap_Suitcase(t *testing.T) {
+	result := ExpandQuery("suitcase")
+	assert.Equal(t, "suitcase", result[0])
+	assert.Contains(t, result, "luggage")
+}
+
 func TestExpandQuery_SynonymMap_Dryer_ExpandsToDrier(t *testing.T) {
 	// "dryer" must expand to "drier" (UK alternate spelling: "tumble drier").
 	// Confirmed in production: offers titled "Tumble Drier" use "drier" not

--- a/iznik-server-go/message/synonyms_pure_test.go
+++ b/iznik-server-go/message/synonyms_pure_test.go
@@ -119,6 +119,21 @@ func TestExpandQuery_SynonymMap_Vacuum(t *testing.T) {
 	assert.Contains(t, result, "hoover")
 }
 
+func TestExpandQuery_SynonymMap_Lawnmower(t *testing.T) {
+	// "lawnmower" and "mower" are separate tokens in the index with zero overlap.
+	result := ExpandQuery("lawnmower")
+	assert.Equal(t, "lawnmower", result[0])
+	assert.Contains(t, result, "mower")
+}
+
+func TestExpandQuery_SynonymMap_Mower(t *testing.T) {
+	// Searching "lawn mower" → GetWords → ["lawn","mower"]; "mower" expands to
+	// include "lawnmower" so one-word-titled offers are also found.
+	result := ExpandQuery("mower")
+	assert.Equal(t, "mower", result[0])
+	assert.Contains(t, result, "lawnmower")
+}
+
 func TestExpandQuery_SynonymMap_Carpet(t *testing.T) {
 	result := ExpandQuery("carpet")
 	assert.Equal(t, "carpet", result[0])

--- a/iznik-server-go/message/synonyms_pure_test.go
+++ b/iznik-server-go/message/synonyms_pure_test.go
@@ -1,0 +1,198 @@
+package message
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// ── ExpandQuery — phraseMap ───────────────────────────────────────────────────
+
+func TestExpandQuery_PhraseMap_WhiteGoods(t *testing.T) {
+	result := ExpandQuery("white goods")
+	assert.Equal(t, []string{"fridge", "freezer", "washing", "dishwasher", "tumble", "cooker", "oven"}, result)
+}
+
+func TestExpandQuery_PhraseMap_FlatScreen(t *testing.T) {
+	result := ExpandQuery("flat screen")
+	assert.Equal(t, []string{"tv", "television", "flatscreen", "monitor"}, result)
+}
+
+func TestExpandQuery_PhraseMap_FlatScreens(t *testing.T) {
+	result := ExpandQuery("flat screens")
+	assert.Equal(t, []string{"tv", "television", "flatscreen", "monitor"}, result)
+}
+
+func TestExpandQuery_PhraseMap_BigScreen(t *testing.T) {
+	result := ExpandQuery("big screen")
+	assert.Equal(t, []string{"tv", "television", "flatscreen"}, result)
+}
+
+func TestExpandQuery_PhraseMap_SmartTV(t *testing.T) {
+	result := ExpandQuery("smart tv")
+	assert.Equal(t, []string{"tv", "television", "flatscreen"}, result)
+}
+
+func TestExpandQuery_PhraseMap_CaseInsensitive(t *testing.T) {
+	// Phrase lookup is lowercased before matching.
+	result := ExpandQuery("White Goods")
+	assert.Equal(t, []string{"fridge", "freezer", "washing", "dishwasher", "tumble", "cooker", "oven"}, result)
+}
+
+func TestExpandQuery_PhraseMap_LeadingTrailingSpaces(t *testing.T) {
+	result := ExpandQuery("  white goods  ")
+	assert.Equal(t, []string{"fridge", "freezer", "washing", "dishwasher", "tumble", "cooker", "oven"}, result)
+}
+
+func TestExpandQuery_PhraseMap_SecondHand_FallsThrough(t *testing.T) {
+	// "second hand" is in phraseMap with an empty slice — falls through to GetWords,
+	// then synonym expansion. Since "second" and "hand" have no synonyms, the result
+	// must equal what GetWords would return directly (possibly nil if both are stop words).
+	result := ExpandQuery("second hand")
+	assert.Equal(t, GetWords("second hand"), result)
+}
+
+// ── ExpandQuery — synonymMap ──────────────────────────────────────────────────
+
+func TestExpandQuery_SynonymMap_Sofa(t *testing.T) {
+	result := ExpandQuery("sofa")
+	assert.Equal(t, "sofa", result[0], "original word must come first")
+	assert.Contains(t, result, "couch")
+	assert.Contains(t, result, "settee")
+}
+
+func TestExpandQuery_SynonymMap_Couch(t *testing.T) {
+	result := ExpandQuery("couch")
+	assert.Equal(t, "couch", result[0])
+	assert.Contains(t, result, "sofa")
+	assert.Contains(t, result, "settee")
+}
+
+func TestExpandQuery_SynonymMap_TV(t *testing.T) {
+	result := ExpandQuery("tv")
+	assert.Equal(t, "tv", result[0])
+	assert.Contains(t, result, "television")
+	assert.Contains(t, result, "telly")
+	assert.Contains(t, result, "flatscreen")
+}
+
+func TestExpandQuery_SynonymMap_Bike(t *testing.T) {
+	result := ExpandQuery("bike")
+	assert.Equal(t, "bike", result[0])
+	assert.Contains(t, result, "bicycle")
+	assert.Contains(t, result, "cycle")
+}
+
+func TestExpandQuery_SynonymMap_Pram(t *testing.T) {
+	result := ExpandQuery("pram")
+	assert.Equal(t, "pram", result[0])
+	assert.Contains(t, result, "pushchair")
+	assert.Contains(t, result, "buggy")
+	assert.Contains(t, result, "stroller")
+}
+
+func TestExpandQuery_SynonymMap_Fridge(t *testing.T) {
+	result := ExpandQuery("fridge")
+	assert.Equal(t, "fridge", result[0])
+	assert.Contains(t, result, "refrigerator")
+}
+
+func TestExpandQuery_SynonymMap_Freezer(t *testing.T) {
+	result := ExpandQuery("freezer")
+	assert.Equal(t, "freezer", result[0])
+	assert.Contains(t, result, "fridge")
+}
+
+func TestExpandQuery_SynonymMap_Carpet(t *testing.T) {
+	result := ExpandQuery("carpet")
+	assert.Equal(t, "carpet", result[0])
+	assert.Contains(t, result, "rug")
+}
+
+func TestExpandQuery_SynonymMap_Motorbike(t *testing.T) {
+	result := ExpandQuery("motorbike")
+	assert.Equal(t, "motorbike", result[0])
+	assert.Contains(t, result, "motorcycle")
+	assert.Contains(t, result, "moped")
+	assert.Contains(t, result, "scooter")
+}
+
+// ── ExpandQuery — no synonym ──────────────────────────────────────────────────
+
+func TestExpandQuery_NoSynonym_Table(t *testing.T) {
+	result := ExpandQuery("table")
+	assert.Equal(t, []string{"table"}, result)
+}
+
+func TestExpandQuery_NoSynonym_Desk(t *testing.T) {
+	result := ExpandQuery("desk")
+	assert.Equal(t, []string{"desk"}, result)
+}
+
+// ── ExpandQuery — multi-word with synonyms ────────────────────────────────────
+
+func TestExpandQuery_MultiWord_BlueSofa(t *testing.T) {
+	result := ExpandQuery("blue sofa")
+	// "blue" has no synonym; "sofa" expands to couch/settee
+	assert.Contains(t, result, "sofa")
+	assert.Contains(t, result, "couch")
+	assert.Contains(t, result, "settee")
+	// "blue" is a stop word (common word list), so it may be absent — do not assert it
+}
+
+func TestExpandQuery_MultiWord_TwoSynonymWords(t *testing.T) {
+	result := ExpandQuery("sofa bike")
+	assert.Contains(t, result, "sofa")
+	assert.Contains(t, result, "couch")
+	assert.Contains(t, result, "settee")
+	assert.Contains(t, result, "bike")
+	assert.Contains(t, result, "bicycle")
+	assert.Contains(t, result, "cycle")
+}
+
+// ── ExpandQuery — deduplication ───────────────────────────────────────────────
+
+func TestExpandQuery_NoDuplicates(t *testing.T) {
+	result := ExpandQuery("sofa")
+	seen := make(map[string]bool)
+	for _, w := range result {
+		assert.False(t, seen[w], "duplicate word in result: %q", w)
+		seen[w] = true
+	}
+}
+
+func TestExpandQuery_NoDuplicates_TVTelevision(t *testing.T) {
+	// "tv" expands to ["television", "telly", "flatscreen"];
+	// "television" expands to ["tv", "telly"]. Input "tv television" must not
+	// produce "tv" or "television" twice.
+	result := ExpandQuery("tv television")
+	seen := make(map[string]bool)
+	for _, w := range result {
+		assert.False(t, seen[w], "duplicate word in result: %q", w)
+		seen[w] = true
+	}
+}
+
+// ── ExpandQuery — edge cases ──────────────────────────────────────────────────
+
+func TestExpandQuery_EmptyString(t *testing.T) {
+	result := ExpandQuery("")
+	// GetWords("") returns nil; ExpandQuery must return that nil, not panic.
+	assert.Nil(t, result)
+}
+
+func TestExpandQuery_OnlyStopWords(t *testing.T) {
+	// "the old" — both stop words; GetWords returns nil.
+	result := ExpandQuery("the old")
+	assert.Nil(t, result)
+}
+
+func TestExpandQuery_OriginalWordFirst(t *testing.T) {
+	// For every single-word query that has synonyms, the original must lead.
+	cases := []string{"sofa", "couch", "tv", "bike", "pram", "fridge"}
+	for _, word := range cases {
+		result := ExpandQuery(word)
+		assert.NotEmpty(t, result, "word=%q produced empty result", word)
+		assert.Equal(t, word, result[0], "word=%q: original must be first element", word)
+	}
+}

--- a/iznik-server-go/message/synonyms_pure_test.go
+++ b/iznik-server-go/message/synonyms_pure_test.go
@@ -148,13 +148,21 @@ func TestExpandQuery_SynonymMap_Tumble_ExpandsToDryer(t *testing.T) {
 	assert.Contains(t, result, "dryer")
 }
 
-func TestExpandQuery_SynonymMap_Dryer_NoTumbleExpansion(t *testing.T) {
-	// "dryer" must NOT expand to "tumble". The starts-with match on "tumble"
-	// pulls in drinking-glass "tumbler" offers (confirmed: 8 false positives
-	// per 200 results in production). One-directional: tumble→dryer only.
+func TestExpandQuery_SynonymMap_Dryer_ExpandsToDrier(t *testing.T) {
+	// "dryer" must expand to "drier" (UK alternate spelling: "tumble drier").
+	// Confirmed in production: offers titled "Tumble Drier" use "drier" not
+	// "dryer" and are missed without this pair. Safe: GetWordsStarts("drier")
+	// does not prefix-match unrelated words unlike "tumble"→"tumbler".
 	result := ExpandQuery("dryer")
-	assert.Equal(t, []string{"dryer"}, result)
+	assert.Equal(t, "dryer", result[0])
+	assert.Contains(t, result, "drier")
 	assert.NotContains(t, result, "tumble")
+}
+
+func TestExpandQuery_SynonymMap_Drier_ExpandsToDryer(t *testing.T) {
+	result := ExpandQuery("drier")
+	assert.Equal(t, "drier", result[0])
+	assert.Contains(t, result, "dryer")
 }
 
 func TestExpandQuery_SynonymMap_Motorbike(t *testing.T) {

--- a/iznik-server-go/message/vectorsearch.go
+++ b/iznik-server-go/message/vectorsearch.go
@@ -13,10 +13,16 @@ import (
 
 const keywordBoostWeight = 0.3
 
-// MinVectorScore is the minimum per-field cosine (subject OR body) to include
-// a result. nomic-embed-text-v1.5 normalized dot products: random noise ~0.50,
+// MinVectorScore is the minimum subject-field cosine to include a result.
+// nomic-embed-text-v1.5 normalized dot products: random noise ~0.50,
 // tangential ~0.60, genuine semantic matches 0.70+, exact 0.75+.
 const MinVectorScore = 0.65
+
+// MinBodyVectorScore is the stricter threshold applied to body-only hits.
+// Items that mention a word incidentally in body text (e.g. "I have a couch
+// not a cage") score ~0.68–0.72 on body cosine, which the lower subject
+// threshold would pass. Raising body-only hits to 0.75 suppresses this noise.
+const MinBodyVectorScore = 0.75
 
 // VectorStats captures diagnostic signal about one VectorSearch call, for the
 // handler to emit to Loki. It exists because repeat identical queries for Dee
@@ -32,7 +38,7 @@ type VectorStats struct {
 	StoreSize     int     // embedding.Global.Count() at call time
 	Candidates    int     // raw count returned by Store.Search (pre-threshold)
 	SubjectTier   int     // candidates passing MinVectorScore on SubjectCos
-	BodyTier      int     // candidates passing MinVectorScore on BodyCos (and not in subject tier)
+	BodyTier      int     // candidates passing MinBodyVectorScore on BodyCos (and not in subject tier)
 	Dropped       int     // candidates below MinVectorScore on both fields
 	TopSubjectCos float32 // max SubjectCos across the candidates (diagnoses "why empty")
 	TopBodyCos    float32 // max BodyCos across the candidates
@@ -48,7 +54,7 @@ type scoredResult struct {
 
 // VectorSearch performs semantic search with subject-first tiering and keyword
 // re-ranking. Subject-tier hits (subjectCos ≥ MinVectorScore) come first;
-// body-tier hits (only bodyCos ≥ MinVectorScore) follow. Within each tier,
+// body-tier hits (only bodyCos ≥ MinBodyVectorScore) follow. Within each tier,
 // results are ordered by their tier cosine + a keyword boost (literal query
 // word matches in the subject). This matches what users expect: an item whose
 // subject literally says "table" should surface before one that only mentions
@@ -130,7 +136,7 @@ func VectorSearch(term string, limit int, groupids []uint64, msgtype string,
 				result: sr,
 				score:  vr.SubjectCos + keywordScore*keywordBoostWeight,
 			})
-		} else if vr.HasBody && vr.BodyCos >= MinVectorScore {
+		} else if vr.HasBody && vr.BodyCos >= MinBodyVectorScore {
 			bodyTier = append(bodyTier, scoredResult{
 				result: sr,
 				score:  vr.BodyCos + keywordScore*keywordBoostWeight,
@@ -231,6 +237,7 @@ func logVectorSearch(term string, groupids []uint64, msgtype string, userID uint
 		"top_body_cos":    stats.TopBodyCos,
 		"query_vec_fp":    stats.QueryVecFP,
 		"min_score":       MinVectorScore,
+		"min_body_score":  MinBodyVectorScore,
 		"top_k":           stats.TopK,
 	}
 	if stats.Error != "" {

--- a/iznik-server-go/test/embedding_vectorsearch_test.go
+++ b/iznik-server-go/test/embedding_vectorsearch_test.go
@@ -330,32 +330,28 @@ func TestStoreSetEntriesAndCount(t *testing.T) {
 	assert.Equal(t, 0, embedding.Global.Count())
 }
 
-// TestSearchHandlerVectorModeDoesNotFallBackToKeyword reproduces the
-// non-determinism Dee reported on Discourse 9594: the same query returning
-// wildly different result sets on repeat attempts (flat screens → wood/floor
-// paint → flat screens again). Root cause: when searchmode=vector returned
-// zero matches above MinVectorScore, the handler silently fell back to the
-// keyword index, which has a completely different match model. Flaky network
-// conditions flipping vector between success and timeout produced the
-// observed mode-switching.
-//
-// After the fix, an explicit searchmode=vector request respects the vector
-// result set (even if empty) instead of secretly switching to keyword.
-func TestSearchHandlerVectorModeDoesNotFallBackToKeyword(t *testing.T) {
+// TestSearchHandlerVectorModeHybridIncludesKeyword verifies the hybrid search
+// contract for searchmode=vector: vector and keyword run in parallel and results
+// are merged. Keyword guarantees exact lexical matches appear even when the
+// embedding model returns nothing above MinVectorScore (e.g. short titles, UK
+// retail terms). This is deterministic — unlike the old flaky network-triggered
+// fallback that produced different result sets on repeat attempts (Discourse 9594),
+// the hybrid always runs both paths, so the output is stable for identical inputs.
+func TestSearchHandlerVectorModeHybridIncludesKeyword(t *testing.T) {
 	embedding.ResetQueryCache()
 	t.Cleanup(embedding.ResetQueryCache)
 
-	prefix := uniquePrefix("vectornofallback")
+	prefix := uniquePrefix("vectorhybrid")
 	groupID := CreateTestGroup(t, prefix)
 	userID := CreateTestUser(t, prefix, "User")
 	CreateTestMembership(t, userID, groupID, "Member")
 
-	// Create a message whose indexed words WOULD match a keyword search for
-	// "television" (via exact + prefix word matches on the search index).
+	// Create a message whose indexed words match a keyword search for
+	// "television" (via exact word match on the search index).
 	CreateTestMessage(t, userID, groupID, "television stand oak", 55.9533, -3.1883)
 
 	// Confirm the keyword path actually finds this message — otherwise the
-	// test below would pass trivially and wouldn't prove we avoided fallback.
+	// assertions below would pass trivially.
 	keywordResp, _ := getApp().Test(httptest.NewRequest(
 		"GET",
 		"/api/message/search/television?searchmode=keyword&groupids="+strconv.FormatUint(groupID, 10),
@@ -367,9 +363,10 @@ func TestSearchHandlerVectorModeDoesNotFallBackToKeyword(t *testing.T) {
 	require.NotEmpty(t, keywordResults, "sanity check: keyword search must find the seeded message")
 
 	// Set up the embedding store with ONE entry whose vector points in the
-	// opposite direction to the query — cosine ≈ -1, far below MinVectorScore
-	// of 0.65. Count() > 0 so the handler enters the vector branch; the
-	// filtered vector result is legitimately empty.
+	// opposite direction to the query — cosine ≈ -1, far below MinVectorScore.
+	// Count() > 0 so the handler enters the hybrid branch; vector returns nothing
+	// above threshold, but the keyword leg of the hybrid must still surface the
+	// exact match.
 	queryVec := makeTestVec(1.0)
 	antiparallel := makeAntiparallelVec(1.0)
 	embedding.Global.SetEntries([]embedding.Entry{
@@ -387,28 +384,51 @@ func TestSearchHandlerVectorModeDoesNotFallBackToKeyword(t *testing.T) {
 	embedding.SetSidecarURL(server.URL)
 	defer embedding.SetSidecarURL("")
 
-	// Now the same query with searchmode=vector. Vector legitimately returns
-	// nothing above threshold. The handler must NOT silently fall back to the
-	// keyword index (which would surface "television stand oak").
-	vectorResp, _ := getApp().Test(httptest.NewRequest(
+	// searchmode=vector with empty vector results: the hybrid keyword leg must
+	// surface "television stand oak" so exact matches are never silently dropped.
+	hybridResp, _ := getApp().Test(httptest.NewRequest(
 		"GET",
 		"/api/message/search/television?searchmode=vector&groupids="+strconv.FormatUint(groupID, 10),
 		nil,
 	), 60000)
-	require.Equal(t, 200, vectorResp.StatusCode)
+	require.Equal(t, 200, hybridResp.StatusCode)
 
-	var vectorResults []message.SearchResult
-	json.NewDecoder(vectorResp.Body).Decode(&vectorResults)
+	var hybridResults []message.SearchResult
+	json.NewDecoder(hybridResp.Body).Decode(&hybridResults)
 
-	assert.Empty(t, vectorResults,
-		"searchmode=vector with no matches above threshold must return empty, not fall back to keyword")
+	// Hybrid must include the keyword match — this is the exact-match guarantee.
+	assert.NotEmpty(t, hybridResults,
+		"hybrid must surface keyword match even when vector returns nothing above threshold")
 
-	// No result should carry a keyword matchedon.Type — fail clearly if the
-	// fallback leaks through.
-	for _, r := range vectorResults {
-		assert.Equal(t, "Vector", r.Matchedon.Type,
-			"non-Vector matchedon.Type (%q) for msgid=%d indicates keyword fallback", r.Matchedon.Type, r.Msgid)
+	// The antiparallel noise entry (msgid 999999) must never appear — it is
+	// below MinVectorScore and does not match the keyword either.
+	for _, r := range hybridResults {
+		assert.NotEqual(t, uint64(999999), r.Msgid,
+			"below-threshold vector entry must not appear in hybrid results")
 	}
+
+	// The behaviour must be deterministic: repeated calls with identical inputs
+	// return identical result sets (no network-flap mode switching).
+	runAgain := func() []uint64 {
+		resp, _ := getApp().Test(httptest.NewRequest(
+			"GET",
+			"/api/message/search/television?searchmode=vector&groupids="+strconv.FormatUint(groupID, 10),
+			nil,
+		), 60000)
+		require.Equal(t, 200, resp.StatusCode)
+		var results []message.SearchResult
+		json.NewDecoder(resp.Body).Decode(&results)
+		ids := make([]uint64, len(results))
+		for i, r := range results {
+			ids[i] = r.Msgid
+		}
+		return ids
+	}
+	first := make([]uint64, len(hybridResults))
+	for i, r := range hybridResults {
+		first[i] = r.Msgid
+	}
+	assert.Equal(t, first, runAgain(), "hybrid search must be deterministic for identical inputs")
 }
 
 // TestSearchHandlerVectorModeIsDeterministic confirms the same vector query

--- a/iznik-server/include/misc/Search.php
+++ b/iznik-server/include/misc/Search.php
@@ -34,7 +34,7 @@ class Search
         'out', 'day', 'get', 'has', 'him', 'how', 'now', 'see', 'two', 'who', 'did', 'its', 'let', 'she', 'too', 'use', 'plz',
         'of', 'to', 'in', 'it', 'is', 'be', 'as', 'at', 'so', 'we', 'he', 'by', 'or', 'on', 'do', 'if', 'me', 'my', 'up', 'an', 'go', 'no', 'us', 'am',
         'working', 'broken', 'black', 'white', 'grey', 'blue', 'green', 'red', 'yellow', 'brown', 'orange', 'pink', 'machine', 'size', 'set',
-        'various', 'assorted', 'different', 'bits', 'ladies', 'gents', 'kids', 'nice', 'brand', 'pack', 'soft', 'single', 'double',
+        'various', 'assorted', 'different', 'bits', 'ladies', 'gents', 'kids', 'nice', 'brand', 'pack', 'soft',
         'top', 'plastic', 'electric', 'unopened'
     );
 


### PR DESCRIPTION
## What this does

Four independent improvements to the Go search handler (`searchmode=vector`):

1. **Hybrid search** — vector and keyword run in parallel (`sync.WaitGroup`). Vector results come first (semantic ranking); keyword-only results the embedding missed are appended. Previously the code fell back to keyword-only when the embedding sidecar errored, causing non-deterministic results (Discourse 9594).

2. **Synonym + phrase expansion** (`ExpandQuery` in `message/synonyms.go`) — called before every keyword search:
   - **phraseMap**: multi-word queries that tokenise to useless stop words. `"white goods"` → GetWords → `["goods"]`, which matches nothing. phraseMap replaces this wholesale with `[fridge, freezer, washing, dishwasher, tumble, cooker, oven]`.
   - **synonymMap**: per-word clusters. Each entry is supported by a production cosine score or a confirmed zero-overlap supply check (see below).

3. **Body-tier noise reduction** — `MinBodyVectorScore` raised 0.65 → 0.75. Offers that mention a search word incidentally in body text (e.g. "I have a couch, not a **cage**") scored ~0.68–0.72 and were leaking through. The new threshold suppresses this while keeping genuine body-field matches.

4. **Single/double stop word fix** — `"single"` and `"double"` removed from `GetWords()` stop word list in both Go and PHP. These qualifiers are semantically meaningful (double bed ≠ single bed). Removing them ensures `"double bed"` searches for both words, ranking true double-bed offers above generic bed offers. Validated: `"double bed"` (9× today) now correctly ranks 75 double-bed offers at wordmatch=2 above 367 generic bed offers.

## Why the synonym map is necessary

The embedding model (nomic-embed-text-v1.5, 256-dim Matryoshka) was tested against live `messages_embeddings` vectors. `MinVectorScore` threshold is 0.65:

| Query | Cosine range vs target offers | Verdict |
|-------|-------------------------------|---------|
| `hoover` vs vacuum cleaner offers | 0.515–0.568 | ALL MISS — synonym essential |
| `sofa` vs settee offers | 0.576–0.604 | MISS — synonym essential |
| `pram` vs pushchair offers | 0.426–0.532 | ALL MISS — synonym essential |
| `white goods` vs fridge/washer offers | 0.393–0.470 | DEEP MISS — phraseMap essential |
| `lawnmower` vs "lawn mower" offers | 0.704–0.808 | PASS — but keyword still needed (zero index overlap) |

Tested at 256/512/768 dims — identical scores at all three. The failures are genuine vocabulary gaps for UK brand-generics (`hoover`) and archaic UK terms (`settee`), not a Matryoshka truncation issue.

## Adversarial review

All synonym pairs were tested against live search results. Entries were added, removed, or direction-reversed based on data:

**Removed / corrected:**

| Entry | Reason |
|-------|--------|
| `freezer → fridge` | Distinct appliances; "fridge freezer" (510 searches) is the combo |
| `fridge → refrigerator` | American English; only 8 UK messages use it |
| `scooter ↔ motorbike/moped` | UK "scooter" = mobility + electric scooters (150 searches), not petrol mopeds |
| `dryer → tumble` | `GetWordsStarts("tumble")` prefix-matched "tumbler" (drinking glasses): 8/200 false positives confirmed in production. Made one-directional: `tumble → dryer` only |

**Added:**

| Entry | Evidence |
|-------|----------|
| `hoover ↔ vacuum` | #1 search term (2,870/90 days); 190 "hoover" + 276 "vacuum" indexed offers — zero overlap; cosine 0.515–0.568 (all miss) |
| `lawnmower ↔ mower` | 90 "lawnmower" + 102 "mower" indexed offers — zero overlap confirmed |
| `dryer ↔ drier` | 24 UK Freegle offers use "drier" spelling ("Bosch Tumble Drier", "Clothes drier"); `GetWordsStarts("drier")` has no unrelated prefix collisions |
| `bbq ↔ barbecue/barbeque` | 25 "bbq" + 9 "barbecue"/"barbeque" offers — zero overlap; user searched all three variants in rapid succession (live monitoring) |
| `luggage ↔ suitcase` | 6 "luggage" + 45 "suitcase" offers — zero overlap; user searched "luggage" 34 times in one session while 45 suitcase offers existed |

**Validated (no change needed):**

| Pair | False positive rate | Notes |
|------|---------------------|-------|
| `cycle → bike/bicycle` | 0% | All 94 "cycle" exact matches are bicycle-related |
| `stroller ↔ pram/pushchair/buggy` | 0% | 66 UK Freegle listings use "stroller"; bidirectional correct |
| `rug ↔ carpet` | 8.5% carpet matches | Items mention both; acceptable for adjacent floor coverings |
| `cupboard ↔ cabinet` | 34.5% cabinet matches | Kitchen cabinets are valid; bedside/filing cabinets are adjacent storage |
| `moped → motorcycle/motorbike` | Accessories mostly | Whole motorcycles rare on Freegle; gear is often compatible |

Pre-existing starts-with false positives (`rug → rugby`, `cot → cotton`) are a keyword search architecture issue; not introduced by this PR.

## Generic alternatives evaluated

**Stemming at query time** — Porter stemmer before `GetWordsStarts` would generically handle morphological variants (e.g. `recliner` → `reclin*` → matches "reclining chair" offers — confirmed zero overlap in production). Risk: over-stemming; `GetWordsStarts` already handles plurals. Verdict: future improvement.

**SPLADE** — learned sparse expansion that auto-discovers synonyms. Correct long-term direction but requires domain-adapted training data and a new index format. Synonym map is the pragmatic answer now that each entry is evidence-backed.

## Code quality

- `mergeHybrid` extracted to `search_hybrid.go` for independent testability
- Pure unit test coverage: `synonyms_pure_test.go` (43+ tests), `search_hybrid_pure_test.go` (12 tests) — no DB required
- Integration test `TestSearchHandlerVectorModeHybridIncludesKeyword` verifies keyword results appear when embedding store returns nothing above threshold

## Test plan

- [x] All 2959 Go tests pass
- [x] All 3754 Laravel tests pass
- [x] `GetWords("double bed")` → `[double, bed]`, not just `[bed]`
- [ ] `hoover` → returns vacuum-listed items; `vacuum` → returns hoover-listed items
- [ ] `white goods` → returns fridge / washing machine / cooker results
- [ ] `scooter` → does NOT return motorbike results
- [ ] `couch` → returns sofa and settee results
- [ ] `dryer` and `drier` → both find tumble dryer offers
- [ ] `bbq` → returns barbecue offers; `barbecue` → returns bbq offers
- [ ] `luggage` → returns suitcase offers; `suitcase` → returns luggage offers
- [ ] `bike bicycle` → no duplicate message IDs in response
- [ ] Loki: `min_body_score` field appears in `vector_search` log lines after deploy