### PR TITLE
fix(eee): force MV labels onto the same items the classifier saw

### DIFF
--- a/iznik-batch/app/Console/Commands/Eee/EeeBackfillClassifiedTableCommand.php
+++ b/iznik-batch/app/Console/Commands/Eee/EeeBackfillClassifiedTableCommand.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Console\Commands\Eee;
+
+use App\Services\EeeSqliteService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * One-shot backfill: copy every distinct (messageid, attid) the EEE
+ * classifier has ever processed from the iznik-batch SQLite into the new
+ * MySQL `eee_classified_attachments` pointer table.
+ *
+ * Once the new pointer table is populated, the Go micro-volunteering API
+ * joins against it so volunteers label items the model has classified —
+ * which is what the Condition/Weight/Size accuracy scoring relies on.
+ */
+class EeeBackfillClassifiedTableCommand extends Command
+{
+    protected $signature = 'eee:backfill-classified-table
+                            {--batch-size=1000 : Rows per INSERT batch}
+                            {--dry-run         : Show what would be inserted without writing}';
+
+    protected $description = 'Backfill eee_classified_attachments from the SQLite eee_classifications history';
+
+    public function __construct(protected EeeSqliteService $sqlite)
+    {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $pdo = $this->sqlite->getPdo();
+
+        // Distinct image classifications only — text-only rows have attid IS NULL.
+        $rows = $pdo->query("SELECT DISTINCT messageid, attid FROM eee_classifications WHERE attid IS NOT NULL")->fetchAll(\PDO::FETCH_ASSOC);
+        $total = count($rows);
+        $this->info("SQLite has $total distinct (messageid, attid) image classifications.");
+
+        if ($this->option('dry-run')) {
+            $this->line('First 5:');
+            foreach (array_slice($rows, 0, 5) as $r) {
+                $this->line('  ' . json_encode($r));
+            }
+            return self::SUCCESS;
+        }
+
+        // Existing rows on the MySQL side (so we can report new vs already-present).
+        $existing = DB::table('eee_classified_attachments')->count();
+        $this->info("MySQL has $existing rows before backfill.");
+
+        $batchSize = max(1, (int) $this->option('batch-size'));
+        $batches   = array_chunk($rows, $batchSize);
+        $inserted  = 0;
+
+        foreach ($batches as $i => $batch) {
+            $values = [];
+            $params = [];
+            foreach ($batch as $r) {
+                $values[] = '(?, ?)';
+                $params[] = (int) $r['messageid'];
+                $params[] = (int) $r['attid'];
+            }
+            $sql = 'INSERT IGNORE INTO eee_classified_attachments (messageid, attid) VALUES ' . implode(', ', $values);
+            DB::statement($sql, $params);
+            $inserted += count($batch);
+            $this->line("  batch " . ($i + 1) . "/" . count($batches) . ": " . count($batch) . " upserted");
+        }
+
+        $after = DB::table('eee_classified_attachments')->count();
+        $this->info("Done. MySQL now has $after rows (added " . ($after - $existing) . " new pointers).");
+
+        return self::SUCCESS;
+    }
+}

--- a/iznik-batch/app/Services/EeeClassificationService.php
+++ b/iznik-batch/app/Services/EeeClassificationService.php
@@ -305,6 +305,7 @@ class EeeClassificationService
         ];
 
         $this->sqlite->insertClassification($data);
+        $this->recordClassifiedAttachment((int) $message->id, (int) $att->attid);
         return $data;
     }
 
@@ -493,6 +494,7 @@ class EeeClassificationService
         ];
 
         $this->sqlite->insertClassification($data);
+        $this->recordClassifiedAttachment((int) $message->id, $attid);
         return $data;
     }
 
@@ -522,6 +524,30 @@ class EeeClassificationService
     // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------
+
+    /**
+     * Add (messageid, attid) to the MySQL `eee_classified_attachments` pointer
+     * table so the Go micro-volunteering API can serve volunteers the same
+     * items the model classified.
+     *
+     * INSERT IGNORE: re-classifying the same attachment with a newer model or
+     * prompt is fine — the pointer already exists. The detailed classification
+     * data lives in the iznik-batch SQLite.
+     */
+    protected function recordClassifiedAttachment(int $messageid, int $attid): void
+    {
+        if ($attid <= 0) return;
+        try {
+            DB::statement('INSERT IGNORE INTO eee_classified_attachments (messageid, attid) VALUES (?, ?)', [$messageid, $attid]);
+        } catch (\Throwable $e) {
+            // Table may not exist yet on first deploy — log and continue.
+            // The classifier's own write to SQLite is what matters; this is
+            // only an index for downstream MV serving.
+            \Illuminate\Support\Facades\Log::warning('eee_classified_attachments upsert failed', [
+                'messageid' => $messageid, 'attid' => $attid, 'error' => $e->getMessage(),
+            ]);
+        }
+    }
 
     protected function computeConsensus(array $results): array
     {

--- a/iznik-batch/database/migrations/2026_05_30_000001_create_eee_classified_attachments.php
+++ b/iznik-batch/database/migrations/2026_05_30_000001_create_eee_classified_attachments.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * `eee_classified_attachments` — pointer set of (messageid, attid) pairs that
+ * the EEE classifier has processed, so micro-volunteering can serve volunteers
+ * the SAME attachments the model classified, not arbitrary recent OFFERs.
+ *
+ * Without this table, getEEELabelChallenge picked any recent OFFER with a
+ * photo. That meant volunteers laboured on items the model never classified,
+ * so Condition/Weight/Size labels could not be scored against any model
+ * accuracy. (Confirmed on 2026-05-30: 161 MV-labelled msgids ∩
+ * eee_classifications = 0.)
+ *
+ * The detailed classification data still lives in the iznik-batch SQLite
+ * (eee_classifications) — this is only a pointer index for the MySQL-side
+ * Go API to JOIN against.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('eee_classified_attachments')) {
+            return;
+        }
+
+        Schema::create('eee_classified_attachments', function ($table) {
+            $table->comment('Pointer set of (messageid, attid) pairs the EEE classifier has processed. Joined by micro-volunteering to serve volunteers the same items the model saw.');
+            $table->unsignedBigInteger('messageid');
+            $table->unsignedBigInteger('attid');
+            $table->timestamp('classified_at')->useCurrent();
+            $table->primary(['messageid', 'attid']);
+            $table->index('attid', 'idx_attid');
+            $table->index('classified_at', 'idx_classified_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('eee_classified_attachments');
+    }
+};

--- a/iznik-server-go/microvolunteering/microvolunteering.go
+++ b/iznik-server-go/microvolunteering/microvolunteering.go
@@ -562,23 +562,23 @@ func getAIImageReviewChallenge(db *gorm.DB, userID uint64) *Challenge {
 }
 
 // getEEELabelChallenge returns a Freegle attachment for the user to label
-// for EEE (Electrical / Electronic Equipment) classification. Picks the most
-// recent OFFER attachments that the user has not yet labelled and that have
-// not yet reached EEELabelQuorum.
+// for EEE (Electrical / Electronic Equipment) classification. Restricts to
+// attachments the model classifier has already processed (joined via the
+// `eee_classified_attachments` pointer table), so volunteer labels can be
+// scored directly against model output.
 //
-// Per-message dedup: a message with multiple photos must only contribute
-// ONE attachment per challenge, otherwise the same item gets re-labelled
-// once per photo and the labels can't be joined back to the model's
-// classifications (the EEE classifier processes one attachment per message).
-// The chosen attachment uses the same canonical rule as message_list.go:255
-// — `primary` DESC, id ASC — so volunteers see the same photo that other
-// surfaces show.
+// Previously this picked any recent OFFER with a photo, which produced lots
+// of "wasted" labels on items the classifier never saw (confirmed
+// 2026-05-30: 161 MV-labelled msgids ∩ eee_classifications = 0). Now the
+// candidate set is the intersection of recent OFFER attachments and the
+// classifier's pointer set, so every label can be paired with a model
+// prediction.
 //
-// Performance: the query is driven off `messages.arrival` (index `arrival_2`)
-// with a 30-day window, so the planner does a backward range scan over ~100k
-// recent messages instead of a full scan of `messages_attachments` (8.6M
-// rows). The original join-from-attachments form took 20s+ on prod and tripped
-// the 5s API timeout — see commit message for full EXPLAIN comparison.
+// Performance: drives off `eee_classified_attachments` PRIMARY KEY by
+// joining each pointer to its messages_attachments row. The pointer set
+// is bounded (currently ~5k rows) so the join is cheap, no full scan of
+// messages_attachments. Ordering by classified_at DESC surfaces the most
+// recently classified items first.
 func getEEELabelChallenge(db *gorm.DB, userID uint64) *Challenge {
 	type AttachmentResult struct {
 		Attid       uint64 `json:"attid"`
@@ -591,18 +591,12 @@ func getEEELabelChallenge(db *gorm.DB, userID uint64) *Challenge {
 
 	err := db.Raw(`
 		SELECT ma_att.id AS attid, m.id AS msgid, ma_att.externaluid, m.subject
-		FROM messages m
-		INNER JOIN messages_attachments ma_att ON ma_att.id = (
-			SELECT id FROM messages_attachments
-			WHERE msgid = m.id
-			  AND externaluid IS NOT NULL
-			  AND externaluid != ''
-			ORDER BY `+"`primary`"+` DESC, id ASC
-			LIMIT 1
-		)
-		WHERE m.arrival > DATE_SUB(NOW(), INTERVAL 30 DAY)
-			AND m.type = 'Offer'
-			AND m.deleted IS NULL
+		FROM eee_classified_attachments ec
+		INNER JOIN messages_attachments ma_att ON ma_att.id = ec.attid
+		INNER JOIN messages m ON m.id = ec.messageid
+		WHERE m.deleted IS NULL
+			AND ma_att.externaluid IS NOT NULL
+			AND ma_att.externaluid != ''
 			AND NOT EXISTS (
 				SELECT 1 FROM microactions ma
 				WHERE ma.eee_attachment_id = ma_att.id
@@ -610,7 +604,7 @@ func getEEELabelChallenge(db *gorm.DB, userID uint64) *Challenge {
 				  AND ma.actiontype = ?
 			)
 			AND (SELECT COUNT(*) FROM microactions WHERE eee_attachment_id = ma_att.id AND actiontype = ?) < ?
-		ORDER BY m.arrival DESC
+		ORDER BY ec.classified_at DESC
 		LIMIT 1
 	`, userID, ChallengeEEELabel, ChallengeEEELabel, EEELabelQuorum).Scan(&att).Error
 

--- a/iznik-server-go/test/microvolunteering_test.go
+++ b/iznik-server-go/test/microvolunteering_test.go
@@ -651,70 +651,77 @@ func TestListMicroActions(t *testing.T) {
 	db.Exec("DELETE FROM microactions WHERE id = ?", actionID)
 }
 
-// TestGetMicrovolunteering_EEELabel_DedupesByMessage exercises the
-// per-message dedup rule in getEEELabelChallenge: a message with multiple
-// photos must only ever be served once per challenge, picking the canonical
-// primary photo (`primary` DESC, id ASC) — the same rule
-// message_list.go:255 uses to display a thumbnail.
+// TestGetMicrovolunteering_EEELabel_RestrictsToClassifiedItems exercises
+// the rule that EEELabel only serves attachments the model classifier has
+// already processed (i.e. present in `eee_classified_attachments`). Without
+// this rule, MV labels accumulate on items the model never saw, so the
+// Condition/Weight/Size accuracy column on the eee-browser dashboard is
+// permanently empty.
 //
-// Without the fix this regressed: every photo of the same item generated a
-// separate EEELabel challenge, so the same fridge was labelled twice by the
-// same volunteer (see commit message for the prod incident).
-func TestGetMicrovolunteering_EEELabel_DedupesByMessage(t *testing.T) {
+// Set-up: insert one OFFER attachment that IS in eee_classified_attachments
+// and one that isn't. Asserts EEELabel may serve the classified one but
+// never the unclassified one.
+func TestGetMicrovolunteering_EEELabel_RestrictsToClassifiedItems(t *testing.T) {
 	db := database.DBConn
-	prefix := uniquePrefix("mv_eee_dedup")
+	prefix := uniquePrefix("mv_eee_classified")
 
 	groupID := CreateTestGroup(t, prefix)
 	userID := CreateTestUser(t, prefix+"_user", "User")
 	CreateTestMembership(t, userID, groupID, "Member")
 	_, token := CreateTestSession(t, userID)
 
-	// Suppress Invite challenge for this user so EEELabel can win the dispatch.
+	// Suppress Invite challenge so EEELabel can win the dispatch.
 	db.Exec("INSERT INTO microactions (actiontype, userid, version, timestamp, score_negative) VALUES (?, ?, 4, NOW(), 0)",
 		microvolunteering.ChallengeInvite, userID)
 	defer db.Exec("DELETE FROM microactions WHERE userid = ?", userID)
 
-	// Recent OFFER message + two attachments. Neither marked primary,
-	// so the canonical rule should resolve to the lower-id attachment.
-	var msgID uint64
+	// Two OFFER messages, each with one attachment. The first is in
+	// eee_classified_attachments, the second is not.
+	var msgClassified, msgUnclassified uint64
 	db.Exec(`INSERT INTO messages (fromuser, subject, textbody, message, type, arrival, deleted)
 		VALUES (?, ?, 'test', 'test', 'Offer', NOW(), NULL)`,
-		userID, prefix+" two-photo offer")
-	db.Raw("SELECT LAST_INSERT_ID()").Scan(&msgID)
-	defer db.Exec("DELETE FROM messages WHERE id = ?", msgID)
+		userID, prefix+" classified item")
+	db.Raw("SELECT LAST_INSERT_ID()").Scan(&msgClassified)
+	defer db.Exec("DELETE FROM messages WHERE id = ?", msgClassified)
 
-	var attLow, attHigh uint64
-	db.Exec("INSERT INTO messages_attachments (msgid, archived, externaluid, `primary`) VALUES (?, 0, ?, 0)",
-		msgID, prefix+"-photo-A")
-	db.Raw("SELECT LAST_INSERT_ID()").Scan(&attLow)
-	db.Exec("INSERT INTO messages_attachments (msgid, archived, externaluid, `primary`) VALUES (?, 0, ?, 0)",
-		msgID, prefix+"-photo-B")
-	db.Raw("SELECT LAST_INSERT_ID()").Scan(&attHigh)
-	defer db.Exec("DELETE FROM messages_attachments WHERE msgid = ?", msgID)
+	db.Exec(`INSERT INTO messages (fromuser, subject, textbody, message, type, arrival, deleted)
+		VALUES (?, ?, 'test', 'test', 'Offer', NOW(), NULL)`,
+		userID, prefix+" unclassified item")
+	db.Raw("SELECT LAST_INSERT_ID()").Scan(&msgUnclassified)
+	defer db.Exec("DELETE FROM messages WHERE id = ?", msgUnclassified)
 
-	// Scope to EEELabel so other challenge sources don't mask the assertion.
-	req := httptest.NewRequest("GET", "/api/microvolunteering?jwt="+token+"&types=EEELabel", nil)
-	resp, _ := getApp().Test(req)
-	assert.Equal(t, 200, resp.StatusCode)
+	var attClassified, attUnclassified uint64
+	db.Exec("INSERT INTO messages_attachments (msgid, archived, externaluid, `primary`) VALUES (?, 0, ?, 1)",
+		msgClassified, prefix+"-photo-classified")
+	db.Raw("SELECT LAST_INSERT_ID()").Scan(&attClassified)
+	defer db.Exec("DELETE FROM messages_attachments WHERE msgid = ?", msgClassified)
 
-	var result microvolunteering.Challenge
-	json2.Unmarshal(rsp(resp), &result)
+	db.Exec("INSERT INTO messages_attachments (msgid, archived, externaluid, `primary`) VALUES (?, 0, ?, 1)",
+		msgUnclassified, prefix+"-photo-unclassified")
+	db.Raw("SELECT LAST_INSERT_ID()").Scan(&attUnclassified)
+	defer db.Exec("DELETE FROM messages_attachments WHERE msgid = ?", msgUnclassified)
 
-	// The challenge MAY be for our test message (if it's the most recent OFFER
-	// in the test DB at the moment the test runs) or for some other OFFER.
-	// Either way: when the served attachment IS for our two-photo message it
-	// must be the lower-id one — never the higher-id one.
-	if result.EEELabel != nil && result.EEELabel.Messageid == msgID {
-		assert.Equal(t, attLow, result.EEELabel.Attid,
-			"two-photo message must serve the canonical primary (lower id when both primary=0), never the higher-id attachment")
-		assert.NotEqual(t, attHigh, result.EEELabel.Attid,
-			"the higher-id attachment must never be served while the lower-id one exists")
+	// Pointer in MySQL says only the first attachment has been classified.
+	db.Exec("INSERT IGNORE INTO eee_classified_attachments (messageid, attid) VALUES (?, ?)",
+		msgClassified, attClassified)
+	defer db.Exec("DELETE FROM eee_classified_attachments WHERE messageid IN (?, ?)", msgClassified, msgUnclassified)
+
+	// Make many EEELabel requests as this user. None should ever resolve to
+	// the unclassified attachment, even though it's an otherwise-eligible
+	// recent OFFER with a photo.
+	for i := 0; i < 5; i++ {
+		req := httptest.NewRequest("GET", "/api/microvolunteering?jwt="+token+"&types=EEELabel", nil)
+		resp, _ := getApp().Test(req)
+		assert.Equal(t, 200, resp.StatusCode)
+
+		var result microvolunteering.Challenge
+		json2.Unmarshal(rsp(resp), &result)
+
+		if result.EEELabel != nil {
+			assert.NotEqual(t, attUnclassified, result.EEELabel.Attid,
+				"EEELabel must never serve an attachment that is not in eee_classified_attachments")
+			assert.NotEqual(t, msgUnclassified, result.EEELabel.Messageid,
+				"EEELabel must never serve a message whose attachments are not in eee_classified_attachments")
+		}
 	}
-
-	// Independent check: directly verify the canonical primary on this message
-	// matches the lower id (defends the rule against silent regressions in
-	// other places that also pick primaries).
-	var canonicalPrimary uint64
-	db.Raw("SELECT id FROM messages_attachments WHERE msgid = ? AND externaluid IS NOT NULL ORDER BY `primary` DESC, id ASC LIMIT 1", msgID).Scan(&canonicalPrimary)
-	assert.Equal(t, attLow, canonicalPrimary, "canonical primary rule should pick the lower-id attachment when both primary=0")
 }


### PR DESCRIPTION
## Summary

EEELabel micro-volunteering was serving any recent OFFER with a photo, regardless of whether the classifier had ever classified that item. Result: of the first 161 msgids volunteers labelled, **zero were in `eee_classifications`** — so the Condition/Weight/Size accuracy columns on the eee-browser dashboard stayed permanently empty.

This PR restricts the EEELabel candidate set to attachments the classifier has already processed.

## What changed

- **New MySQL pointer table `eee_classified_attachments`** — lists every `(messageid, attid)` the classifier has touched. The full classification data still lives in iznik-batch's SQLite; this table only mirrors the keys so the Go API can JOIN against it.
- **`EeeClassificationService`** now upserts the pointer from every image-bearing classification path (`classifyMessageWithDriver`, `storeImageResult`). Text-only classifications skipped (no attid).
- **`eee:backfill-classified-table`** artisan command copies the existing ~4,829 SQLite rows into MySQL once after deploy.
- **`getEEELabelChallenge`** Go query rewritten to JOIN the pointer table instead of scanning recent OFFER attachments. Drops the 30-day arrival window and the canonical-primary correlated subquery — both no longer needed because the pointer table already contains the attids the classifier picked. Orders by `classified_at DESC` so freshly classified items surface first.
- **Go test rewritten** — previously asserted multi-photo dedup; now asserts an OFFER whose attachment is NOT in `eee_classified_attachments` is never served, even when it would otherwise be the most recent eligible item.

## Deploy steps

1. Run the migration (creates an empty table — INSTANT, safe under writes).
2. Run `php artisan eee:backfill-classified-table` once (~5k rows in one batch, sub-second).
3. Deploy iznik-server-go. Until step 2 completes the API returns empty challenges — correct behaviour ("no candidate classified items yet").

Once both sides are deployed, every new model classification self-populates the pointer table, so volunteer labels and model output stay on the same item set going forward.

## Test Plan

- [ ] CircleCI passes the new Go test `TestGetMicrovolunteering_EEELabel_RestrictsToClassifiedItems`.
- [ ] After deploy + backfill, `curl /api/microvolunteering?types=EEELabel&jwt=...` returns an item where `msgid` exists in `eee_classified_attachments`.
- [ ] After one volunteer round, `https://freegle-eee-browser.fly.dev/api/review/stats` starts showing model accuracy for Condition/Weight/Size (previously stuck at 0).