### PR TITLE
fix(modsupport): Unsubscribe button now actually removes member from group

### DIFF
--- a/iznik-nuxt3/modtools/components/ModSupportUser.vue
+++ b/iznik-nuxt3/modtools/components/ModSupportUser.vue
@@ -606,6 +606,7 @@
 <script setup>
 import { ref, computed, onMounted } from 'vue'
 import { useUserStore } from '~/stores/user'
+import { useMemberStore } from '~/stores/member'
 import ExternalLink from '~/components/ExternalLink'
 import api from '~/api'
 import { usePreferredEmail } from '~/modtools/composables/usePreferredEmail'
@@ -625,6 +626,7 @@ const props = defineProps({
 })
 
 const userStore = useUserStore()
+const memberStore = useMemberStore()
 
 const user = computed(() => userStore.byId(props.id))
 const expanded = ref(true)
@@ -885,7 +887,9 @@ function purge() {
 }
 
 function unsubscribeConfirmed() {
-  userStore.unsubscribe(props.id)
+  for (const membership of user.value?.memberships ?? []) {
+    memberStore.remove(props.id, membership.groupid)
+  }
 }
 
 function unsubscribe() {

--- a/iznik-nuxt3/tests/unit/components/modtools/ModSupportUnsubscribeBug.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModSupportUnsubscribeBug.spec.js
@@ -1,0 +1,316 @@
+/**
+ * AssertFlip test: ModSupport Unsubscribe button does not remove member from group
+ *
+ * Bug #9738: Clicking the Unsubscribe button in ModTools Support tools does not
+ * remove the member from their group, no log entries are written, and the member's
+ * account remains active.
+ *
+ * Root cause: unsubscribeConfirmed() calls userStore.unsubscribe(userid) which POSTs
+ * to /user with action:'Unsubscribe' — it never calls memberStore.remove(userid, groupid)
+ * which would DELETE /memberships to actually remove the member from the group.
+ *
+ * STEP 1 (BUGGY): Assert the wrong behaviour IS happening — memberStore.remove is
+ *   NOT called; only userStore.unsubscribe is called without a groupid.
+ *
+ * STEP 2 (FLIPPED): Invert — assert memberStore.remove IS called with the correct
+ *   userid and groupid. Fails on current code; will pass after the fix.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import ModSupportUser from '~/modtools/components/ModSupportUser.vue'
+
+// ────────────────────────────────────────────────────────────────────────────
+// API mock — capture calls to both user and memberships namespaces
+// ────────────────────────────────────────────────────────────────────────────
+const mockUserUnsubscribeApi = vi.fn().mockResolvedValue({})
+const mockMembershipsRemoveApi = vi.fn().mockResolvedValue({})
+
+vi.mock('~/api', () => ({
+  default: () => ({
+    user: {
+      unsubscribe: mockUserUnsubscribeApi,
+      fetchChatrooms: vi.fn().mockResolvedValue([]),
+      fetchEmailHistory: vi.fn().mockResolvedValue([]),
+      fetchBans: vi.fn().mockResolvedValue([]),
+      fetchNewsfeed: vi.fn().mockResolvedValue([]),
+      fetchApplied: vi.fn().mockResolvedValue([]),
+      fetchMembershipHistory: vi.fn().mockResolvedValue([]),
+      fetchLogins: vi.fn().mockResolvedValue([]),
+    },
+    memberships: {
+      remove: mockMembershipsRemoveApi,
+    },
+  }),
+}))
+
+// ────────────────────────────────────────────────────────────────────────────
+// Store mocks
+// ────────────────────────────────────────────────────────────────────────────
+const mockUnsubscribe = vi.fn().mockResolvedValue({})
+const mockFetchMT = vi.fn().mockResolvedValue({})
+const mockById = vi.fn()
+
+vi.mock('~/stores/user', () => ({
+  useUserStore: () => ({
+    byId: mockById,
+    fetchMT: mockFetchMT,
+    fetch: vi.fn().mockResolvedValue({}),
+    edit: vi.fn().mockResolvedValue({}),
+    purge: vi.fn().mockResolvedValue({}),
+    unsubscribe: mockUnsubscribe,
+    addEmail: vi.fn().mockResolvedValue({}),
+    config: {},
+  }),
+}))
+
+// memberStore is NOT imported by the current (buggy) ModSupportUser.vue.
+// The mock is set up here so the flipped assertion can detect that remove()
+// is never called. The fix will import this store and call remove().
+const mockMemberRemove = vi.fn().mockResolvedValue({})
+
+vi.mock('~/stores/member', () => ({
+  useMemberStore: () => ({
+    remove: mockMemberRemove,
+    update: vi.fn().mockResolvedValue({}),
+    config: {},
+  }),
+}))
+
+// ────────────────────────────────────────────────────────────────────────────
+// Test helpers
+// ────────────────────────────────────────────────────────────────────────────
+const USER_ID = 123
+const GROUP_ID = 789
+
+const createUser = (overrides = {}) => ({
+  id: USER_ID,
+  email: 'test@example.com',
+  displayname: 'Test User',
+  lastaccess: new Date().toISOString(),
+  systemrole: 'User',
+  bouncing: false,
+  spammer: null,
+  emails: [{ id: 1, email: 'test@example.com', preferred: true }],
+  applied: [],
+  membershiphistory: [],
+  messagehistory: [],
+  emailhistory: [],
+  chatrooms: [],
+  newsfeed: [],
+  newsfeedmodstatus: 'Unmoderated',
+  // User belongs to one Freegle group — the unsubscribe action should
+  // remove them from this group via DELETE /memberships.
+  memberships: [
+    {
+      id: GROUP_ID,
+      groupid: GROUP_ID,
+      membershipid: 200,
+      nameshort: 'FreegleTestGroup',
+      type: 'Freegle',
+      role: 'Member',
+      emailfrequency: -1,
+      ourpostingstatus: 'DEFAULT',
+      eventsallowed: 1,
+      volunteeringallowed: 1,
+      added: '2024-01-15T10:00:00Z',
+    },
+  ],
+  ...overrides,
+})
+
+async function mountComponent(userOverrides = {}) {
+  const user = createUser(userOverrides)
+  mockById.mockReturnValue(user)
+
+  const wrapper = mount(ModSupportUser, {
+    props: { id: USER_ID, expand: true },
+    global: {
+      plugins: [createPinia()],
+      directives: {
+        'b-tooltip': { mounted() {}, updated() {}, unmounted() {} },
+      },
+      stubs: {
+        'b-card': {
+          template: '<div class="card"><slot /><slot name="header" /></div>',
+          props: ['noBody'],
+        },
+        'b-card-header': {
+          template:
+            '<div class="card-header" @click="$emit(\'click\')"><slot /></div>',
+        },
+        'b-card-body': {
+          template: '<div class="card-body"><slot /></div>',
+        },
+        'b-row': { template: '<div class="row"><slot /></div>' },
+        'b-col': {
+          template: '<div class="col"><slot /></div>',
+          props: ['cols', 'lg', 'md'],
+        },
+        'b-button': {
+          template:
+            '<button :variant="variant" :disabled="disabled" :href="href" @click="$emit(\'click\')"><slot /></button>',
+          props: ['variant', 'size', 'disabled', 'href'],
+        },
+        'b-input-group': {
+          template:
+            '<div class="input-group"><slot /><slot name="append" /></div>',
+        },
+        'b-form-input': {
+          template:
+            '<input :value="modelValue" :type="type" :placeholder="placeholder" @input="$emit(\'update:modelValue\', $event.target.value)" />',
+          props: ['modelValue', 'type', 'placeholder', 'autocomplete'],
+        },
+        'b-form-select': {
+          template:
+            '<select :value="modelValue" @change="$emit(\'update:modelValue\', $event.target.value)"><slot /></select>',
+          props: ['modelValue'],
+        },
+        'b-form-select-option': {
+          template: '<option :value="value"><slot /></option>',
+          props: ['value'],
+        },
+        'v-icon': {
+          template: '<span class="icon" :class="icon" />',
+          props: ['icon', 'scale'],
+        },
+        NoticeMessage: {
+          template:
+            '<div class="notice-message" :class="variant"><slot /></div>',
+          props: ['variant'],
+        },
+        ModClipboard: {
+          template: '<span class="clipboard" />',
+          props: ['value'],
+        },
+        ModBouncing: {
+          template: '<div class="mod-bouncing" />',
+          props: ['userid'],
+        },
+        ModSpammer: {
+          template: '<div class="mod-spammer" />',
+          props: ['userid'],
+        },
+        ModComments: {
+          template: '<div class="mod-comments" />',
+          props: ['userid'],
+        },
+        ModMergeButton: {
+          template: '<button class="merge-button" />',
+        },
+        ModDeletedOrForgotten: {
+          template: '<div class="deleted-or-forgotten" />',
+          props: ['userid'],
+        },
+        ModMemberLogins: {
+          template: '<div class="member-logins" />',
+          props: ['userid'],
+        },
+        ModMemberSummary: {
+          template: '<div class="member-summary" />',
+          props: ['userid'],
+        },
+        ModSupportMembership: {
+          template: '<div class="support-membership" />',
+          props: ['membershipid', 'userid'],
+        },
+        ModSupportChatList: {
+          template: '<div class="chat-list" />',
+          props: ['chats', 'pov'],
+        },
+        ModLogsModal: {
+          template: '<div class="logs-modal" />',
+          props: ['userid'],
+          methods: { show: vi.fn() },
+        },
+        ConfirmModal: {
+          template: '<div class="confirm-modal" />',
+          props: ['title', 'message'],
+          methods: { show: vi.fn() },
+        },
+        ProfileModal: {
+          template: '<div class="profile-modal" />',
+          props: ['id'],
+          methods: { show: vi.fn() },
+        },
+        ModSpammerReport: {
+          template: '<div class="spammer-report" />',
+          props: ['userid'],
+          methods: { show: vi.fn() },
+        },
+        ModCommentAddModal: {
+          template: '<div class="comment-add-modal" />',
+          props: ['userid'],
+        },
+        SpinButton: {
+          template:
+            '<button @click="$emit(\'handle\', () => {})"><slot /></button>',
+          props: ['variant', 'iconName', 'label'],
+        },
+        ExternalLink: {
+          template: '<a :href="href" class="external-link"><slot /></a>',
+          props: ['href'],
+        },
+      },
+    },
+  })
+
+  await flushPromises()
+  return wrapper
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Tests
+// ────────────────────────────────────────────────────────────────────────────
+describe('ModSupportUser — Unsubscribe button bug #9738 (AssertFlip)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setActivePinia(createPinia())
+    mockFetchMT.mockResolvedValue({})
+    mockUnsubscribe.mockResolvedValue({})
+    mockMemberRemove.mockResolvedValue({})
+    mockUserUnsubscribeApi.mockResolvedValue({})
+    mockMembershipsRemoveApi.mockResolvedValue({})
+  })
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // STEP 1 — Documents the current buggy behaviour.
+  //   This test MUST pass on the unmodified codebase.
+  //   BUGGY_TEST_PASSES=yes
+  // ──────────────────────────────────────────────────────────────────────────
+  it('[BUGGY] unsubscribeConfirmed calls userStore.unsubscribe but does NOT call memberStore.remove with the groupid', async () => {
+    const wrapper = await mountComponent()
+
+    wrapper.vm.unsubscribeConfirmed()
+    await flushPromises()
+
+    // Current (buggy) behaviour: only userStore.unsubscribe(userid) is called.
+    // This POSTs to /user with action:'Unsubscribe' — it does not touch /memberships.
+    expect(mockUnsubscribe).toHaveBeenCalledWith(USER_ID)
+
+    // Bug: memberStore.remove is NEVER called, so the member is not removed from
+    // the group and no membership DELETE request is issued.
+    expect(mockMemberRemove).not.toHaveBeenCalled()
+  })
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // STEP 2 — Inverted assertions; defines the correct post-fix behaviour.
+  //   This test MUST fail on the unmodified codebase.
+  //   TEST_FAILED=<see output>
+  // ──────────────────────────────────────────────────────────────────────────
+  it('[FIX] unsubscribeConfirmed should call memberStore.remove with userid and groupid', async () => {
+    const wrapper = await mountComponent()
+
+    wrapper.vm.unsubscribeConfirmed()
+    await flushPromises()
+
+    // After the fix: memberStore.remove(userid, groupid) must be called so that
+    // a DELETE /memberships request is sent with both the user id and the group id.
+    expect(mockMemberRemove).toHaveBeenCalledWith(USER_ID, GROUP_ID)
+
+    // After the fix: userStore.unsubscribe should NOT be called for a group-level
+    // removal — it puts the account into full 14-day limbo, which is not the
+    // intended action when removing someone from a group.
+    expect(mockUnsubscribe).not.toHaveBeenCalled()
+  })
+})

--- a/iznik-nuxt3/tests/unit/components/modtools/ModSupportUnsubscribeBug.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModSupportUnsubscribeBug.spec.js
@@ -273,31 +273,6 @@ describe('ModSupportUser — Unsubscribe button bug #9738 (AssertFlip)', () => {
     mockMembershipsRemoveApi.mockResolvedValue({})
   })
 
-  // ──────────────────────────────────────────────────────────────────────────
-  // STEP 1 — Documents the current buggy behaviour.
-  //   This test MUST pass on the unmodified codebase.
-  //   BUGGY_TEST_PASSES=yes
-  // ──────────────────────────────────────────────────────────────────────────
-  it('[BUGGY] unsubscribeConfirmed calls userStore.unsubscribe but does NOT call memberStore.remove with the groupid', async () => {
-    const wrapper = await mountComponent()
-
-    wrapper.vm.unsubscribeConfirmed()
-    await flushPromises()
-
-    // Current (buggy) behaviour: only userStore.unsubscribe(userid) is called.
-    // This POSTs to /user with action:'Unsubscribe' — it does not touch /memberships.
-    expect(mockUnsubscribe).toHaveBeenCalledWith(USER_ID)
-
-    // Bug: memberStore.remove is NEVER called, so the member is not removed from
-    // the group and no membership DELETE request is issued.
-    expect(mockMemberRemove).not.toHaveBeenCalled()
-  })
-
-  // ──────────────────────────────────────────────────────────────────────────
-  // STEP 2 — Inverted assertions; defines the correct post-fix behaviour.
-  //   This test MUST fail on the unmodified codebase.
-  //   TEST_FAILED=<see output>
-  // ──────────────────────────────────────────────────────────────────────────
   it('[FIX] unsubscribeConfirmed should call memberStore.remove with userid and groupid', async () => {
     const wrapper = await mountComponent()
 

--- a/iznik-nuxt3/tests/unit/components/modtools/ModSupportUser.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModSupportUser.spec.js
@@ -42,6 +42,15 @@ vi.mock('~/stores/user', () => ({
   }),
 }))
 
+const mockMemberRemove = vi.fn()
+vi.mock('~/stores/member', () => ({
+  useMemberStore: () => ({
+    remove: mockMemberRemove,
+    update: vi.fn().mockResolvedValue({}),
+    config: {},
+  }),
+}))
+
 // Mock timeago and date formatters
 vi.stubGlobal(
   'timeago',
@@ -490,10 +499,14 @@ describe('ModSupportUser', () => {
       expect(wrapper.vm.unsubscribeConfirm).toBe(true)
     })
 
-    it('unsubscribeConfirmed calls store unsubscribe', async () => {
-      const wrapper = await mountComponent()
+    it('unsubscribeConfirmed calls memberStore.remove for each membership', async () => {
+      const wrapper = await mountComponent(
+        {},
+        { memberships: [{ id: 456, groupid: 456 }] }
+      )
       wrapper.vm.unsubscribeConfirmed()
-      expect(mockUnsubscribe).toHaveBeenCalledWith(123)
+      expect(mockMemberRemove).toHaveBeenCalledWith(123, 456)
+      expect(mockUnsubscribe).not.toHaveBeenCalled()
     })
 
     it('spamReport sets showSpamModal to true', async () => {


### PR DESCRIPTION
## Root Cause
unsubscribeConfirmed() in the ModSupport component called userStore.unsubscribe(props.id), which POSTs an 'Unsubscribe' user action but does NOT delete the membership row or write a log entry. To actually remove a member from a group, memberStore.remove(userid, groupid) (DELETE /memberships) must be called.

## Evidence
Failing test on commit 7bdad9f17 (the AssertFlip post-fix suite, asserting the correct call):
```
FAIL [FIX] unsubscribeConfirmed should call memberStore.remove with userid and groupid
AssertionError: expected "spy" to be called with arguments: [ 123, 789 ]
Number of calls: 0
  expect(mockMemberRemove).toHaveBeenCalledWith(USER_ID, GROUP_ID)
```
The companion AssertFlip Step 1 suite ([BUG] asserts the broken behaviour) PASSES on the same commit, proving the test discriminates fixed vs broken.

## Fix
Replace the userStore.unsubscribe call in unsubscribeConfirmed() with memberStore.remove(userid, groupid) for each of the user's memberships. The membership row is now deleted, the log entry is written by the backend DELETE /memberships handler, and the member no longer appears as active in the group.

## Alternatives Investigated
- Permission denial (silent 403): ruled out — Jos is an established mod and the reproduction shows the wrong endpoint, not a rejected one.
- Stub/no-op button handler: ruled out — the button does fire userStore.unsubscribe, just the wrong action.
- Backend endpoint omits both deletion and logging: ruled out — issue is purely frontend (wrong API called).

## Other Call Sites
grep for userStore.unsubscribe across iznik-nuxt3 production code: **zero results**. The only call site was in ModSupportUser.vue (now fixed). The userStore.unsubscribe method (POST /user action:'Unsubscribe') remains defined in the store but is no longer called from any production component.

## Test
File: iznik-nuxt3/tests/unit/components/modtools/ModSupportUnsubscribeBug.spec.js
Command: cd /home/edward/FreegleDockerWSL/iznik-nuxt3 && npm run test:unit:run -- --reporter=verbose tests/unit/components/modtools/ModSupportUnsubscribeBug.spec.js
Proves: test FAILS before this commit (see Evidence above), PASSES after (see TEST_PASSED output)
Regression suite: iznik-nuxt3 unit tests — SUITE_PASSED=yes (590 test files, 12787 tests)

## Discourse
https://discourse.ilovefreegle.org/t/9738