### PR TITLE
fix(modtools-log-history): discard stale in-flight log fetches on community filter change

### DIFF
--- a/iznik-nuxt3/modtools/stores/logs.js
+++ b/iznik-nuxt3/modtools/stores/logs.js
@@ -12,6 +12,7 @@ export const useLogsStore = defineStore({
     list: [],
     context: null,
     params: null,
+    _fetchGeneration: 0,
   }),
   actions: {
     init(config) {
@@ -20,8 +21,10 @@ export const useLogsStore = defineStore({
     clear() {
       this.list = []
       this.context = null
+      this._fetchGeneration++
     },
     async fetch(params) {
+      const generation = this._fetchGeneration
       let ret = null
       delete params.context
       if (this.context?.id) {
@@ -29,6 +32,12 @@ export const useLogsStore = defineStore({
         params.context = this.context.id
       }
       const data = await api(this.config).logs.fetch(params)
+
+      // Discard result if clear() was called while this fetch was in-flight
+      // (e.g. user changed the community/groupid filter).
+      if (this._fetchGeneration !== generation) {
+        return null
+      }
 
       let logs = []
 

--- a/iznik-nuxt3/tests/unit/stores/logs.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/logs.spec.js
@@ -307,4 +307,91 @@ describe('logs store', () => {
     expect(logsForUser10.map((l) => l.id)).toEqual([100, 101])
     expect(logsForUser20.map((l) => l.id)).toEqual([200, 201])
   })
+
+  // ---------------------------------------------------------------------------
+  // AssertFlip: stale in-flight fetch after community filter change
+  //
+  // Symptom (issue #9672): when the community (groupid) filter is changed while
+  // a fetch is still in progress from the previous group, the in-flight fetch
+  // resolves AFTER clear() has been called. Because fetch() has no stale-check,
+  // it pushes the old group's entries into the freshly-emptied list, producing
+  // duplicated/cross-group entries in the log history view.
+  //
+  // Root cause: logs.js fetch() does not check whether clear() was called while
+  // the API request was in-flight. The existingIds dedup only guards against
+  // concurrent same-page fetches, not against cross-group pollution after a clear.
+  // ---------------------------------------------------------------------------
+
+  it('stale in-flight fetch pollutes cleared list — AssertFlip Step 1 (buggy)', async () => {
+    // STEP 1: assert the WRONG / buggy behaviour.
+    // This test PASSES on the current (buggy) code.
+    // If it fails here, the bug is already fixed and the diagnosis is wrong.
+    const store = useLogsStore()
+    store.init({})
+
+    // Create a deferred promise to control when the "old groupid" fetch resolves.
+    let resolveOldFetch
+    const oldFetchPromise = new Promise((resolve) => {
+      resolveOldFetch = resolve
+    })
+    mockLogsFetch.mockReturnValueOnce(oldFetchPromise)
+
+    // Start an inflight fetch for groupid=5 (won't complete until we resolve it).
+    const oldFetchDone = store.fetch({ groupid: 5 })
+
+    // User switches community filter → caller clears the store.
+    store.clear()
+    expect(store.list).toHaveLength(0) // list is empty immediately after clear
+
+    // Resolve the OLD group-5 fetch. On buggy code fetch() has no stale-check
+    // so it pushes group-5 entries straight into the now-empty list.
+    resolveOldFetch({
+      logs: [
+        { id: 10, groupid: 5 },
+        { id: 11, groupid: 5 },
+        { id: 12, groupid: 5 },
+      ],
+      context: { id: 10 },
+    })
+    await oldFetchDone
+
+    // BUGGY assertion: stale group-5 data leaked into the cleared list.
+    expect(store.list.length).toBeGreaterThan(0)
+  })
+
+  it('community filter change must not allow stale in-flight fetch to persist — AssertFlip Step 2', async () => {
+    // STEP 2 (inverted): these assertions FAIL on buggy code, PASS after fix.
+    // The fix must discard any in-flight fetch result that arrives after clear().
+    const store = useLogsStore()
+    store.init({})
+
+    let resolveOldFetch
+    const oldFetchPromise = new Promise((resolve) => {
+      resolveOldFetch = resolve
+    })
+    mockLogsFetch.mockReturnValueOnce(oldFetchPromise)
+
+    // Inflight fetch for old groupid=5.
+    const oldFetchDone = store.fetch({ groupid: 5 })
+
+    // User switches filter: clear the store.
+    store.clear()
+
+    // Old group-5 fetch returns with 3 seeded entries.
+    resolveOldFetch({
+      logs: [
+        { id: 10, groupid: 5 },
+        { id: 11, groupid: 5 },
+        { id: 12, groupid: 5 },
+      ],
+      context: { id: 10 },
+    })
+    await oldFetchDone
+
+    // CORRECT assertion: after clear(), stale results must NOT appear in the list.
+    expect(store.list).toHaveLength(0)
+
+    // CORRECT assertion: context must remain null (not set by the stale fetch).
+    expect(store.context).toBeNull()
+  })
 })

--- a/iznik-nuxt3/tests/unit/stores/logs.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/logs.spec.js
@@ -322,43 +322,6 @@ describe('logs store', () => {
   // concurrent same-page fetches, not against cross-group pollution after a clear.
   // ---------------------------------------------------------------------------
 
-  it('stale in-flight fetch pollutes cleared list — AssertFlip Step 1 (buggy)', async () => {
-    // STEP 1: assert the WRONG / buggy behaviour.
-    // This test PASSES on the current (buggy) code.
-    // If it fails here, the bug is already fixed and the diagnosis is wrong.
-    const store = useLogsStore()
-    store.init({})
-
-    // Create a deferred promise to control when the "old groupid" fetch resolves.
-    let resolveOldFetch
-    const oldFetchPromise = new Promise((resolve) => {
-      resolveOldFetch = resolve
-    })
-    mockLogsFetch.mockReturnValueOnce(oldFetchPromise)
-
-    // Start an inflight fetch for groupid=5 (won't complete until we resolve it).
-    const oldFetchDone = store.fetch({ groupid: 5 })
-
-    // User switches community filter → caller clears the store.
-    store.clear()
-    expect(store.list).toHaveLength(0) // list is empty immediately after clear
-
-    // Resolve the OLD group-5 fetch. On buggy code fetch() has no stale-check
-    // so it pushes group-5 entries straight into the now-empty list.
-    resolveOldFetch({
-      logs: [
-        { id: 10, groupid: 5 },
-        { id: 11, groupid: 5 },
-        { id: 12, groupid: 5 },
-      ],
-      context: { id: 10 },
-    })
-    await oldFetchDone
-
-    // BUGGY assertion: stale group-5 data leaked into the cleared list.
-    expect(store.list.length).toBeGreaterThan(0)
-  })
-
   it('community filter change must not allow stale in-flight fetch to persist — AssertFlip Step 2', async () => {
     // STEP 2 (inverted): these assertions FAIL on buggy code, PASS after fix.
     // The fix must discard any in-flight fetch result that arrives after clear().


### PR DESCRIPTION
## Root Cause
iznik-nuxt3/modtools/stores/logs.js fetch() has no stale-check. When the community filter changes, clear() empties the store, but in-flight fetches started with the previous groupid resolve afterwards and push their results into the freshly-cleared list. The injected stale rows appear as duplicates of the new view, displace legitimate entries (causing the incomplete list), and disrupt date ordering.

Note: the original diagnosis pointed at a backend JOIN-cartesian bug, but a DB integration test against iznik-server-go/logs/logs.go confirmed the backend query is correct (1:1 LEFT JOIN messages ON messages.id = logs.msgid, proper ORDER BY). The real fix is frontend-only.

## Evidence
```
× logs store > community filter change must not allow stale in-flight fetch to persist — AssertFlip Step 2: expected [ { id: 10, groupid: 5 }, …(2) ] to have a length of +0 but got 3 (tests/unit/stores/logs.spec.js:392:24)
```
This failure occurs before the fix because `fetch()` has no stale-check: when clear() is called mid-flight, the old groupid's response still resolves and pushes 3 entries into the now-empty list.

## Fix
Added a `_fetchGeneration` counter to the store state (initialized at 0). `clear()` increments this counter. `fetch()` captures the generation value at the start of the call (`const generation = this._fetchGeneration`). After the API response resolves, before writing anything to `list` or `context`, fetch checks `if (this._fetchGeneration !== generation) { return null }`. If the generation has changed (because `clear()` was called mid-flight), the result is discarded entirely — neither `list` nor `context` are updated.

This mirrors the existing `this.instance` guard already present in `modtools/stores/member.js` and `modtools/stores/spammer.js` for the same class of race.

## Alternatives Investigated
- Backend JOIN-cartesian bug in logs endpoint: ruled out — DB integration test against iznik-server-go/logs/logs.go showed correct 1:1 join and proper ordering.
- Frontend store merge-on-filter-change (without stale-fetch detail): subsumed — the stale in-flight fetch IS the merge mechanism.
- Pagination cursor not reset on filter change: ruled out — would not affect intra-page ordering, only inter-page alignment.

## Other Call Sites
`member.js` and `spammer.js` already protect their fetch+push pattern with a `this.instance` guard. `alert.js`, `admins.js`, and `comment.js` use dictionaries (key assignment is idempotent — no push race). No other unprotected occurrences found.

## Test
File: iznik-nuxt3/tests/unit/stores/logs.spec.js
Command: `cd /home/edward/FreegleDockerWSL/iznik-nuxt3 && npx vitest run tests/unit/stores/logs.spec.js -t "community filter change must not allow stale in-flight fetch"`
Proves: test FAILS before this commit (see Evidence above), PASSES after (see TEST_PASSED output)
Regression suite: iznik-nuxt3 — SUITE_PASSED=yes (589 test files, 12787 tests passed)

## Discourse
https://discourse.ilovefreegle.org/t/9672