### PR TITLE
fix(location-map): do not fall back to group lat/lng when user has no location

### DIFF
--- a/iznik-server-go/test/location_map_9730_test.go
+++ b/iznik-server-go/test/location_map_9730_test.go
@@ -1,0 +1,73 @@
+package test
+
+// Regression test for bug reported in topic 9730:
+// Members with no postcode/location are shown on the map at the group's physical
+// location instead of being shown as having no known location.
+//
+// Root cause: GetLatLng falls back to the most-recently-joined group's lat/lng
+// when a user has no personal location set (no mylocation in settings, no
+// lastlocation, no message location).
+//
+// Fix: GetLatLng should return zero/empty location for such users.
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/freegle/iznik-server-go/database"
+	user2 "github.com/freegle/iznik-server-go/user"
+	"github.com/freegle/iznik-server-go/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetLatLngNoLocationDoesNotFallBackToGroupCoords(t *testing.T) {
+	db := database.DBConn
+
+	prefix := uniquePrefix("latlng9730")
+
+	// Create a group with a distinct known lat/lng (clearly non-zero London coords).
+	groupLat := 51.5074
+	groupLng := -0.1278
+	groupName := fmt.Sprintf("TestGroup_%s", prefix)
+	db.Exec(fmt.Sprintf(
+		"INSERT INTO `groups` (nameshort, namefull, type, onhere, polyindex, lat, lng) "+
+			"VALUES (?, ?, 'Freegle', 1, ST_GeomFromText('POINT(-0.1278 51.5074)', %d), ?, ?)",
+		utils.SRID),
+		groupName, "Test Group "+prefix, groupLat, groupLng)
+
+	var groupID uint64
+	db.Raw("SELECT id FROM `groups` WHERE nameshort = ? ORDER BY id DESC LIMIT 1", groupName).Scan(&groupID)
+	require.NotZero(t, groupID, "test group must be created")
+	defer db.Exec("DELETE FROM `groups` WHERE id = ?", groupID)
+
+	// Create a user with NO personal location: null settings, null lastlocation.
+	fullname := fmt.Sprintf("Test User %s", prefix)
+	db.Exec(
+		"INSERT INTO users (firstname, lastname, fullname, systemrole, lastlocation, settings) "+
+			"VALUES ('Test', ?, ?, 'User', NULL, NULL)",
+		prefix, fullname)
+
+	var userID uint64
+	db.Raw("SELECT id FROM users WHERE fullname = ? ORDER BY id DESC LIMIT 1", fullname).Scan(&userID)
+	require.NotZero(t, userID, "test user must be created")
+	defer db.Exec("DELETE FROM memberships WHERE userid = ?", userID)
+	defer db.Exec("DELETE FROM sessions WHERE userid = ?", userID)
+	defer db.Exec("DELETE FROM users_emails WHERE userid = ?", userID)
+	defer db.Exec("DELETE FROM users WHERE id = ?", userID)
+
+	// Join the user to the group — this is what triggers the buggy group-coord fallback.
+	db.Exec("INSERT INTO memberships (userid, groupid, role, added) VALUES (?, ?, 'Member', NOW())", userID, groupID)
+
+	// Resolve the user's location via the same function used by the members map.
+	latlng := user2.GetLatLng(userID)
+
+	// STEP 2 (INVERTED - AssertFlip): A user who has never set a postcode should have
+	// NO known location (zero coords). The bug causes GetLatLng to return the group's
+	// lat/lng instead, so these assertions FAIL on the current buggy code and will
+	// PASS once the group-location fallback is removed.
+	assert.Equal(t, float32(0), latlng.Lat,
+		"user with no location must return lat=0, not group lat (%.4f)", groupLat)
+	assert.Equal(t, float32(0), latlng.Lng,
+		"user with no location must return lng=0, not group lng (%.4f)", groupLng)
+}

--- a/iznik-server-go/user/user.go
+++ b/iznik-server-go/user/user.go
@@ -879,17 +879,19 @@ func GetLatLng(id uint64) utils.LatLng {
 		Lastlng float32
 	}
 
-	var ul, ulmsg, ulgroups userLoc
+	var ul, ulmsg userLoc
 
 	// We look for the location in the following descending order:
 	// - mylocation in settings, which we need to decode
 	// - lastlocation in user
 	// - last messages posted on a group with a location
-	// - most recently joined group
+	//
+	// We intentionally do NOT fall back to the group's lat/lng — users without a personal
+	// location should return zero coords, not be plotted at the group's physical address.
 	//
 	// Tests show that the first query is fast to fetch, whereas the others are less so.  The first will handle
 	// a user with a known location, so it's a good mainline case to keep fast.
-	// If it doesn't give us what we need them , then fetch the others in parallel.
+	// If it doesn't give us what we need then fetch the message location.
 	db.Raw("SELECT users.id, locations.lat AS lastlat, locations.lng as lastlng, "+
 		"CAST(JSON_EXTRACT(JSON_EXTRACT(settings, '$.mylocation'), '$.lat') AS DECIMAL(10,6)) AS mylat,"+
 		"CAST(JSON_EXTRACT(JSON_EXTRACT(settings, '$.mylocation'), '$.lng') AS DECIMAL(10,6)) as mylng "+
@@ -901,43 +903,18 @@ func GetLatLng(id uint64) utils.LatLng {
 	if ul.Mylng != 0 || ul.Mylat != 0 {
 		ret.Lat = ul.Mylat
 		ret.Lng = ul.Mylng
+	} else if ul.Lastlat != 0 || ul.Lastlng != 0 {
+		ret.Lat = ul.Lastlat
+		ret.Lng = ul.Lastlng
 	} else {
-		var wg sync.WaitGroup
+		db.Raw("SELECT messages.fromuser AS id, locations.lat AS lastlat, locations.lng AS lastlng FROM "+
+			"locations INNER JOIN messages ON messages.locationid = locations.id "+
+			"WHERE messages.fromuser = ? "+
+			"ORDER BY arrival DESC LIMIT 1", id).Scan(&ulmsg)
 
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-		}()
-
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			db.Raw("SELECT messages.fromuser AS id, locations.lat AS lastlat, locations.lng AS lastlng FROM "+
-				"locations INNER JOIN messages ON messages.locationid = locations.id "+
-				"WHERE messages.fromuser = ? "+
-				"ORDER BY arrival DESC LIMIT 1", id).Scan(&ulmsg)
-		}()
-
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			db.Raw("SELECT groups.id, groups.lat AS lastlat, groups.lng AS lastlng FROM  "+
-				"`groups` INNER JOIN memberships ON groups.id = memberships.groupid "+
-				"WHERE memberships.userid = ? "+
-				"ORDER BY added DESC LIMIT 1", id).Scan(&ulgroups)
-		}()
-
-		wg.Wait()
-
-		if ul.Lastlat != 0 || ul.Lastlng != 0 {
-			ret.Lat = ul.Lastlat
-			ret.Lng = ul.Lastlng
-		} else if ulmsg.Lastlat != 0 || ulmsg.Lastlng != 0 {
+		if ulmsg.Lastlat != 0 || ulmsg.Lastlng != 0 {
 			ret.Lat = ulmsg.Lastlat
 			ret.Lng = ulmsg.Lastlng
-		} else if ulgroups.Lastlat != 0 || ulgroups.Lastlng != 0 {
-			ret.Lat = ulgroups.Lastlat
-			ret.Lng = ulgroups.Lastlng
 		}
 	}
 


### PR DESCRIPTION
## Root Cause
In iznik-server-go user.GetLatLng (user/user.go:938-941), when a user has no settings.lat/lng and no lastlocation, the function falls back to returning the group's lat/lng. This causes members without a postcode to be plotted on the members map at the group's physical address.

## Evidence
```
location_map_9730_test.go:69: Not equal: expected: 0, actual: 51.5074
    Messages: user with no location must return lat=0, not group lat (51.5074)
location_map_9730_test.go:71: Not equal: expected: 0, actual: -0.1278
    Messages: user with no location must return lng=0, not group lng (-0.1278)
--- FAIL: TestGetLatLngNoLocationDoesNotFallBackToGroupCoords (0.32s)
```

## Fix
Removed the group-coordinate fallback (`else if ulgroups.Lastlat != 0 || ulgroups.Lastlng != 0`) from `GetLatLng`. The function now returns zero coords when a user has no `mylocation` in settings, no `lastlocation`, and no message-posted location. Callers already handle zero coords correctly (several have explicit `if latlng.Lat != 0` guards; the member map will show no pin for these users).

The parallel goroutine structure in the no-mylocation branch was also simplified: the group-query goroutine was removed (dead code after the fallback was dropped), and the message-location query is now done lazily only when the earlier checks yield nothing.

## Alternatives Investigated
- Frontend label substitution (group name shown instead of user location): ruled out by post 2 (Jeni) reporting the group's geographic position on the map, indicating server-side coord substitution.
- Users auto-joined with group lat/lng copied onto user record: ruled out — would persist permanently rather than appear as an on-the-fly fallback.

## Other Call Sites
```
user/user.go:340:               latlng = GetLatLng(id)         (sets user.Lat/Lng in GET /user response)
user/user.go:669:               latlng := GetLatLng(id)        (has guard: if latlng.Lat != 0)
user/user.go:1014:              latlng := GetLatLng(id)        (GetPublicLocation — passes to ClosestPostcode)
user/user.go:1179:              privatePos = GetLatLng(id)     (mod tools private position)
message/bounds.go:37:           latlng = user.GetLatLng(myid)  (post visibility bounds check)
isochrone/message.go:33:        latlng := user.GetLatLng(myid) (isochrone)
isochrone/message.go:137:       latlng := user.GetLatLng(myid) (isochrone)
newsfeed/newsfeed.go:137:       latlng := user.GetLatLng(uid)  (has guard: if latlng.Lat > 0)
newsfeed/newsfeed.go:316:       latlng := user.GetLatLng(myid) (newsfeed)
newsfeed/newsfeed.go:1158:      latlng := user.GetLatLng(myid) (newsfeed)
newsfeed/newsfeed.go:1322:      latlng := user.GetLatLng(myid) (newsfeed)
```
No other files contain a group-lat/lng fallback pattern (`ulgroups.Lastlat`/`ulgroups.Lastlng` was only in `GetLatLng`). All callers either have `if latlng.Lat != 0` guards or treat 0/0 as "no location" — the same as a user who genuinely has no location set.

## Test
File: iznik-server-go/test/location_map_9730_test.go
Command: `cd iznik-server-go && MYSQL_HOST=... MYSQL_PORT=3306 MYSQL_USER=root MYSQL_PASSWORD=iznik MYSQL_DBNAME=iznik go test ./test/ -run TestGetLatLngNoLocationDoesNotFallBackToGroupCoords -v -count=1`
Proves: test FAILS before this commit (see Evidence above), PASSES after (see TEST_PASSED output)
Regression suite: go-api full suite — SUITE_PASSED=yes

## Discourse
https://discourse.ilovefreegle.org/t/9730