### PR TITLE
fix(public-location): suppress display when user has no real location source

### DIFF
--- a/iznik-server-go/test/user_test.go
+++ b/iznik-server-go/test/user_test.go
@@ -3215,44 +3215,87 @@ func TestPublicLocation_ResponseStructure(t *testing.T) {
 	assert.True(t, hasGroupname, "Response should have 'groupname' field")
 }
 
-func TestPublicLocation_MostRecentMembership(t *testing.T) {
-	// V1 parity: public location uses the most recently added membership,
-	// regardless of role. Moderators commonly moderate their own local group.
-	prefix := uniquePrefix("publocrecent")
+// TestPublicLocation_UserWithNoRealLocation reproduces Discourse 9730:
+// a member who has joined a group but never set a postcode was being
+// displayed (in modtools and the public location endpoint) with their
+// group's centroid coords resolved to "[area], [groupname]" — looking like
+// the member's home address. The fix returns empty Display when the user has
+// no real location source (settings.mylocation / lastlocation / message
+// location), regardless of group membership. Group-coord fallback in
+// GetLatLng is still correct for map-pin placement.
+func TestPublicLocation_UserWithNoRealLocation(t *testing.T) {
+	prefix := uniquePrefix("publocnolocation")
 	db := database.DBConn
 
-	// Create a moderator user who will view the target user's profile.
+	// Create a user with NO mylocation in settings and NO lastlocation —
+	// the CreateTestUser helper always sets mylocation, so build directly.
+	fullname := "Locationless " + prefix
+	db.Exec("INSERT INTO users (firstname, lastname, fullname, systemrole, lastlocation, settings) "+
+		"VALUES ('Locationless', ?, ?, 'User', NULL, NULL)",
+		prefix, fullname)
+	var userID uint64
+	db.Raw("SELECT id FROM users WHERE fullname = ? ORDER BY id DESC LIMIT 1", fullname).Scan(&userID)
+	if userID == 0 {
+		t.Fatalf("failed to create locationless user")
+	}
+	defer db.Exec("DELETE FROM users WHERE id = ?", userID)
+
+	// Join them to a group so GetLatLng has a group fallback to return.
+	groupID := CreateTestGroup(t, prefix)
+	CreateTestMembership(t, userID, groupID, "Member")
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET",
+		fmt.Sprintf("/api/user/%d/publiclocation", userID), nil))
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result user.Publiclocation
+	json2.Unmarshal(rsp(resp), &result)
+
+	// Empty display + empty location because the user has no real source.
+	// Before the fix, Display would be "[area], [groupname]" derived from the
+	// group's centroid — misleading the moderator into thinking the user has
+	// an address in the group's area.
+	assert.Equal(t, "", result.Display,
+		"user with no real location must not have a public-location Display "+
+			"(was misleadingly showing group centroid area + group name)")
+	assert.Equal(t, "", result.Location,
+		"user with no real location must not have a public-location Location")
+	assert.Equal(t, uint64(0), result.Groupid,
+		"user with no real location must not surface a fallback groupid")
+}
+
+func TestPublicLocation_NoGroupNameFallback(t *testing.T) {
+	// Discourse 9730: previously the public-location (modtools view) fell
+	// back to the user's most-recently-added group's display name when the
+	// user had no real location. Moderators reported this as a bug — it
+	// looked like the member's address but was actually just the group name,
+	// causing confusion ("Freegle Hertford" appeared in members' location
+	// fields).
+	//
+	// Correct behaviour: when the user has no real location source
+	// (settings.mylocation / lastlocation / message location), the
+	// publiclocation should be absent/empty rather than borrowing the group
+	// name. The group-coord fallback in GetLatLng is still correct for
+	// map-pin placement and distance calculations.
+	prefix := uniquePrefix("publocnogrp")
+	db := database.DBConn
+
 	modUserID := CreateTestUser(t, prefix+"_mod", "User")
 
-	// Create the target user with no mylocation setting and no lastlocation.
+	// Target user with NO mylocation, NO lastlocation, NO message location.
 	db.Exec("INSERT INTO users (firstname, lastname, fullname, systemrole, lastlocation, settings) "+
 		"VALUES ('Test', ?, ?, 'User', NULL, NULL)", prefix, "Test User "+prefix)
 	var targetUserID uint64
 	db.Raw("SELECT id FROM users WHERE fullname = ? ORDER BY id DESC LIMIT 1", "Test User "+prefix).Scan(&targetUserID)
 	require.Greater(t, targetUserID, uint64(0))
+	defer db.Exec("DELETE FROM users WHERE id = ?", targetUserID)
 
-	// Create two groups.
-	olderGroupID := CreateTestGroup(t, prefix+"_older")
-	newerGroupID := CreateTestGroup(t, prefix+"_newer")
+	groupID := CreateTestGroup(t, prefix+"_grp")
+	db.Exec("UPDATE `groups` SET namefull = ? WHERE id = ?", "Freegle Bugville", groupID)
 
-	// Set distinct full names so we can tell which is returned.
-	db.Exec("UPDATE `groups` SET namefull = ? WHERE id = ?", "Older Town Freegle", olderGroupID)
-	db.Exec("UPDATE `groups` SET namefull = ? WHERE id = ?", "Newer Town Freegle", newerGroupID)
+	CreateTestMembership(t, modUserID, groupID, "Moderator")
+	CreateTestMembership(t, targetUserID, groupID, "Member")
 
-	// Make the viewing user a moderator of both groups so they have permission.
-	CreateTestMembership(t, modUserID, olderGroupID, "Moderator")
-	CreateTestMembership(t, modUserID, newerGroupID, "Moderator")
-
-	// Add target user to the older group first, then the newer group.
-	// Explicitly set `added` timestamps 1 second apart because MySQL TIMESTAMP
-	// has only second precision — both inserts in the same second would make
-	// ORDER BY m.added DESC non-deterministic.
-	CreateTestMembership(t, targetUserID, olderGroupID, "Member")
-	CreateTestMembership(t, targetUserID, newerGroupID, "Moderator")
-	db.Exec("UPDATE memberships SET added = DATE_SUB(added, INTERVAL 1 SECOND) WHERE userid = ? AND groupid = ?",
-		targetUserID, olderGroupID)
-
-	// Fetch the target user via modtools endpoint.
 	_, token := CreateTestSession(t, modUserID)
 	resp, _ := getApp().Test(httptest.NewRequest("GET",
 		fmt.Sprintf("/api/user/%d?modtools=true&jwt=%s", targetUserID, token), nil))
@@ -3261,13 +3304,20 @@ func TestPublicLocation_MostRecentMembership(t *testing.T) {
 	var result map[string]interface{}
 	json2.Unmarshal(rsp(resp), &result)
 
-	// The publiclocation is nested under info.publiclocation.
 	info, ok := result["info"].(map[string]interface{})
 	require.True(t, ok, "Expected info in modtools user response")
-	pubLoc, ok := info["publiclocation"].(map[string]interface{})
-	require.True(t, ok, "Expected publiclocation in info")
-	assert.Equal(t, "Newer Town Freegle", pubLoc["groupname"],
-		"Public location should use the most recently added membership")
+
+	// publiclocation should be absent / nil for a user with no real location.
+	// Before the fix, info.publiclocation.groupname was "Freegle Bugville".
+	pubLocRaw, hasPubLoc := info["publiclocation"]
+	if hasPubLoc && pubLocRaw != nil {
+		pubLoc, _ := pubLocRaw.(map[string]interface{})
+		assert.Equal(t, "", pubLoc["groupname"],
+			"publiclocation.groupname must be empty for users with no real location "+
+				"— the group name was previously leaking out as a faux address (Discourse 9730)")
+		assert.Equal(t, "", pubLoc["display"],
+			"publiclocation.display must be empty for users with no real location")
+	}
 }
 
 // =============================================================================

--- a/iznik-server-go/user/user.go
+++ b/iznik-server-go/user/user.go
@@ -1022,6 +1022,37 @@ func DeleteUserSearch(c *fiber.Ctx) error {
 	return c.JSON(fiber.Map{"ret": 0, "status": "Success"})
 }
 
+// hasRealLocation returns true when the user has any of:
+//   - settings.mylocation (postcode chosen on signup or in settings)
+//   - lastlocation (postcode geocoded from a posted address)
+//   - at least one message with a location attached
+//
+// When all three are absent, GetLatLng falls back to the user's most-recent
+// group centroid — fine for distance calculations but NOT a real address, so
+// callers that render location TEXT should suppress display for those users.
+func hasRealLocation(id uint64) bool {
+	db := database.DBConn
+
+	var hasMyLocation int
+	db.Raw("SELECT COUNT(*) FROM users "+
+		"WHERE id = ? "+
+		"AND JSON_EXTRACT(settings, '$.mylocation.lat') IS NOT NULL "+
+		"AND JSON_EXTRACT(settings, '$.mylocation.lat') != CAST('null' AS JSON)", id).Scan(&hasMyLocation)
+	if hasMyLocation > 0 {
+		return true
+	}
+
+	var hasLastLocation int
+	db.Raw("SELECT COUNT(*) FROM users WHERE id = ? AND lastlocation IS NOT NULL", id).Scan(&hasLastLocation)
+	if hasLastLocation > 0 {
+		return true
+	}
+
+	var hasMessageLocation int
+	db.Raw("SELECT COUNT(*) FROM messages WHERE fromuser = ? AND locationid IS NOT NULL LIMIT 1", id).Scan(&hasMessageLocation)
+	return hasMessageLocation > 0
+}
+
 func GetPublicLocation(c *fiber.Ctx) error {
 	var ret Publiclocation
 	var groupname string
@@ -1032,6 +1063,18 @@ func GetPublicLocation(c *fiber.Ctx) error {
 		id, err := strconv.ParseUint(c.Params("id"), 10, 64)
 
 		if err == nil {
+			// Only emit a public-location display when the user has a real
+			// location source (mylocation / lastlocation / message-posted
+			// location). Otherwise GetLatLng falls back to group centroid
+			// coords, and ClosestPostcode + ClosestSingleGroup on those coords
+			// produce a misleading "[area], [groupname]" string that looks
+			// like the user's address (Discourse 9730). The fallback coords
+			// are still fine for map-pin placement and distance calculations
+			// — we just suppress the display text here.
+			if !hasRealLocation(id) {
+				return c.JSON(ret)
+			}
+
 			var wg sync.WaitGroup
 
 			latlng := GetLatLng(id)

--- a/iznik-server-go/user/userInfo.go
+++ b/iznik-server-go/user/userInfo.go
@@ -292,26 +292,13 @@ func GetPublicLocationForUser(userid uint64) *Publiclocation {
 		}
 	}
 
-	// Fall back to most recent group membership.
-	var groupLoc struct {
-		Groupid   uint64
-		Groupname string
-	}
-	db.Raw("SELECT m.groupid, COALESCE(g.namefull, g.nameshort) AS groupname "+
-		"FROM memberships m "+
-		"INNER JOIN `groups` g ON g.id = m.groupid "+
-		"WHERE m.userid = ? AND m.collection = ? "+
-		"ORDER BY m.added DESC LIMIT 1",
-		userid, utils.COLLECTION_APPROVED).Scan(&groupLoc)
-
-	if groupLoc.Groupid > 0 {
-		return &Publiclocation{
-			Display:   groupLoc.Groupname,
-			Location:  groupLoc.Groupname,
-			Groupid:   groupLoc.Groupid,
-			Groupname: groupLoc.Groupname,
-		}
-	}
-
+	// No real location source — return nil so the UI shows "no location"
+	// rather than misleading the moderator into thinking the user is at the
+	// group centroid. Mods were reporting (Discourse 9730) that members with
+	// no postcode were appearing on maps and in lists showing the group's
+	// own name (e.g. "Freegle Hertford") as if it were the member's address.
+	// The group-coord fallback in GetLatLng is still correct for map-pin
+	// placement and distance calculations — this only suppresses the
+	// public-location TEXT for those users.
 	return nil
 }


### PR DESCRIPTION
## Root Cause

Discourse 9730 — mods reported that some members were showing the **group's name** as their location ("Freegle Hertford" appearing in the member's address slot on the modtools members map/list).

Verified against live data for the specific example (member #44932706, Medway Freegle):

- `users.lastlocation = NULL`, `users.settings.mylocation` absent → no real location source
- `GetLatLng` (correctly, for map-pin placement) falls back to the user's most-recent group centroid → returns `(51.405, 0.565)` which matches Medway Freegle's `(51.407659, 0.560547)`
- **`GetPublicLocationForUser`** (modtools view, `user/userInfo.go:295-314`) had its own explicit fallback that returned the group's `namefull` as the public `Display`
- **`GetPublicLocation`** (public endpoint, `user/user.go:1025`) ran `ClosestPostcode` + `ClosestSingleGroup` on the fallback coords and concatenated them: `"[area], [groupname]"`

Both paths produced misleading "[area], [groupname]" or just "[groupname]" strings that read like the member's address but were actually just the group's own location.

## Fix

The group-coord fallback in `GetLatLng` itself is **correct** — needed for map-pin placement and distance/visibility calculations. The bug was only in display-text generation.

1. New `hasRealLocation(id)` helper checks for `settings.mylocation`, `lastlocation`, or any message-attached location.
2. `GetPublicLocation` early-returns an empty `Publiclocation` when the user has no real source.
3. `GetPublicLocationForUser` (modtools) drops its "fall back to most recent group membership" branch entirely — returns `nil`. Frontend (`ModMember.vue`) already gates on `user.info.publiclocation` truthy, so the line is skipped cleanly.

## Alternatives Investigated

- **Remove the group-coord fallback in `GetLatLng`** — this is what closed PR #581 attempted. Per @edwh, that's the wrong layer: the fallback is correct for map placement, just not for display text.
- **Add an `IsFallback` flag to `GetLatLng`'s return** — would touch all 11 call sites of `GetLatLng`. Rejected as bigger change than needed; the display paths can detect "no real source" directly.

## Test

- `TestPublicLocation_UserWithNoRealLocation` — reproduces the public-endpoint bug; asserts empty `Display` for a user with no `mylocation` / `lastlocation` / message location.
- `TestPublicLocation_NoGroupNameFallback` (renamed from `TestPublicLocation_MostRecentMembership`) — flips the previous assertion. The original test codified the buggy "V1 parity" behaviour; that's exactly the behaviour mods complained about, so the test was wrong.

## Discourse
https://discourse.ilovefreegle.org/t/strange-location/9730
