### PR TITLE
feat(freegle): `switch` to point the worktree-escape guard at an existing worktree

### DIFF
--- a/.claude/check-worktree-escape.sh
+++ b/.claude/check-worktree-escape.sh
@@ -14,7 +14,28 @@ if [ -z "$CMD" ]; then
     exit 0
 fi
 
+# Allow the sanctioned worktree-management CLI (./freegle). It is the designated
+# tool for creating, switching, and removing sibling worktrees, so it may
+# legitimately reference their paths. Only exempt a *bare* freegle invocation:
+# refuse if the command chains anything else (;, &, |, backticks, $()), so a
+# path escape can't be smuggled alongside it.
+if [[ "$CMD" =~ ^[[:space:]]*(\./|[^[:space:]]*/)?freegle([[:space:]]|$) ]] \
+   && [[ "$CMD" != *';'* && "$CMD" != *'&'* && "$CMD" != *'|'* && "$CMD" != *'`'* && "$CMD" != *'$('* ]]; then
+    exit 0
+fi
+
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+
+# If the session has switched into a pre-existing worktree via `freegle switch`,
+# treat that worktree as an additional allowed root. The state file lives under
+# the launch project's .claude dir, since that is the hook the harness runs
+# regardless of the current working directory.
+ACTIVE_WT=""
+ACTIVE_WT_FILE="$PROJECT_DIR/.claude/active-worktree"
+if [[ -f "$ACTIVE_WT_FILE" ]]; then
+    ACTIVE_WT=$(head -n1 "$ACTIVE_WT_FILE" | tr -d '\r\n')
+fi
+
 PARENT_DIR=$(dirname "$PROJECT_DIR")
 
 # Don't restrict if parent is a root or common temp directory (too broad)
@@ -32,10 +53,19 @@ while IFS= read -r match; do
     if [[ "$match" == "$PROJECT_DIR"* ]]; then
         continue
     fi
+    # ...or inside the worktree the session has switched into via `freegle switch`.
+    if [[ -n "$ACTIVE_WT" && "$match" == "$ACTIVE_WT"* ]]; then
+        continue
+    fi
     echo "BLOCKED: command references '$match' which is outside the current worktree." >&2
     echo "" >&2
     echo "  Current worktree: $PROJECT_DIR" >&2
-    echo "  Stay within:      $PROJECT_DIR" >&2
+    if [[ -n "$ACTIVE_WT" ]]; then
+        echo "  Switched into:    $ACTIVE_WT" >&2
+    fi
+    echo "" >&2
+    echo "  To work in a pre-existing worktree, run: ./freegle switch <name>" >&2
+    echo "  (then cd into it — the guard will allow that worktree going forwards)." >&2
     exit 2
 done < <(echo "$CMD" | grep -oE "${ESCAPED_PARENT}/[^[:space:]'\"\\;|&>]+" 2>/dev/null || true)
 

--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,6 @@ freegle-mobile/
 # Local Claude session log (not committed — updates here don't make PRs go BEHIND)
 .claude-session.md
 monitor.db
+
+# freegle switch: runtime state for the worktree-escape guard
+.claude/active-worktree

--- a/freegle
+++ b/freegle
@@ -6,6 +6,7 @@
 #
 # Usage:
 #   freegle status                Show all worktrees + container counts
+#   freegle switch <n>            Point Claude's escape guard at an existing worktree
 #   freegle worktree create <n>   Create a worktree with isolated compose env
 #   freegle worktree list         List worktrees with compose status
 #   freegle worktree remove <n>   Stop compose, remove volumes and worktree
@@ -60,6 +61,44 @@ resolve_worktree() {
         fi
     done
     return 1
+}
+
+# Switch the active worktree for the running Claude session.
+#
+# Claude's worktree-escape guard (.claude/check-worktree-escape.sh) normally
+# blocks any command that touches a sibling worktree. This records a pre-existing
+# worktree as the "active" one in a state file the guard reads, so the session
+# can cd into it and keep working there. The Bash tool persists cwd across calls,
+# so once switched + cd'd, subsequent commands run in the new worktree.
+cmd_switch() {
+    local name="${1:-}"
+    # The guard reads $CLAUDE_PROJECT_DIR/.claude/active-worktree (the launch
+    # project's hook runs regardless of cwd), so write the state file there.
+    local base="${CLAUDE_PROJECT_DIR:-$(get_main_repo)}"
+    local state_file="$base/.claude/active-worktree"
+
+    if [[ -z "$name" || "$name" == "--clear" || "$name" == "off" ]]; then
+        rm -f "$state_file"
+        echo -e "${GREEN}Cleared active worktree.${NC}"
+        echo "The escape guard now allows only: $base"
+        echo "Move back with:  cd $base"
+        return 0
+    fi
+
+    local dir
+    if ! dir=$(resolve_worktree "$name"); then
+        echo -e "${RED}No worktree matches '$name'.${NC}" >&2
+        echo "Existing worktrees:" >&2
+        get_worktrees | sed 's/^/  /' >&2
+        return 1
+    fi
+
+    mkdir -p "$(dirname "$state_file")"
+    printf '%s\n' "$dir" > "$state_file"
+    echo -e "${GREEN}Switched active worktree to:${NC} $dir"
+    echo "The escape guard will now treat that folder as the working root."
+    echo "Move there with (cwd persists across commands):"
+    echo -e "  ${BLUE}cd $dir${NC}"
 }
 
 cmd_status() {
@@ -299,6 +338,10 @@ case "${1:-help}" in
     status)
         cmd_status
         ;;
+    switch)
+        shift
+        cmd_switch "$@"
+        ;;
     worktree)
         case "${2:-help}" in
             create)
@@ -324,6 +367,8 @@ case "${1:-help}" in
         echo ""
         echo "Commands:"
         echo "  status                  Show all worktrees, containers, and URLs"
+        echo "  switch <name>           Make Claude's escape guard treat <name>'s worktree as the working root"
+        echo "  switch --clear          Revert to the launch worktree"
         echo "  worktree create <name>  Create isolated worktree (unique ports, starts containers)"
         echo "  worktree list           List all worktrees"
         echo "  worktree remove <name>  Stop and remove a worktree"


### PR DESCRIPTION
## Summary

Resuming a Claude session in — or working across — a sibling git worktree is blocked by the worktree-escape guard (`.claude/check-worktree-escape.sh`). The guard only ever allows paths under `CLAUDE_PROJECT_DIR`, and a subprocess can't change the running session's project dir, so there was no way to point an existing session at a pre-existing worktree.

This adds a sanctioned way to do exactly that.

## Changes

- **`freegle switch <name>`** records a pre-existing worktree in `.claude/active-worktree`; **`freegle switch --clear`** reverts to the launch worktree. Resolves by name/basename/suffix like the other `freegle` subcommands.
- **`.claude/check-worktree-escape.sh`** now:
  - exempts a *bare* `./freegle` invocation (the designated worktree tool) — but refuses if the command chains anything else (`;`, `&`, `|`, backticks, `$()`), so a path escape can't be smuggled alongside it;
  - reads `.claude/active-worktree` and allows paths under that worktree in addition to `CLAUDE_PROJECT_DIR`;
  - points at `./freegle switch <name>` in its block message.
- **`.gitignore`** ignores the runtime `.claude/active-worktree` state file.

Because the Bash tool persists `cwd` across calls, once switched the session can `cd` into the worktree and keep working there.

## Origin

Came out of the **PR #459** adversarial-review session: applying a review cleanup on the PR branch (checked out in a sibling worktree) was blocked by the guard, which surfaced the gap.

## Verification

- Guard **blocked** a command referencing the sibling worktree path before switch.
- After `./freegle switch <name>`, the guard **allowed** `cd` into that worktree (state file set, path now permitted).
- `bash -n` clean on both scripts; `freegle help` lists the new subcommand.

## Notes

- Loosens isolation only to the explicitly-switched worktree; all other siblings stay blocked.
- The guard is read from `CLAUDE_PROJECT_DIR`, so the feature is active wherever the session was launched once this lands on `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)