### PR TITLE
fix(app): disable entryImportMap for Capacitor build so old iOS WebViews boot

### DIFF
--- a/iznik-nuxt3/nuxt.config.ts
+++ b/iznik-nuxt3/nuxt.config.ts
@@ -264,6 +264,17 @@ export default defineNuxtConfig({
     // During prerendering with cdnURL configured, the crawler tries to access these from the CDN
     // path before they exist, causing 404 errors. See: https://github.com/nuxt/nuxt/discussions/27624
     appManifest: false,
+
+    // For the Capacitor app build only, disable the entry import map.
+    // Nuxt 3.21's entryImportMap (default true) rewrites the entry chunk to the
+    // bare specifier `#entry` and injects a <script type="importmap"> to resolve
+    // it at runtime. Import maps are only supported in WKWebView from iOS 16.4+,
+    // so on older iPhones (the app's floor is iOS 14.0 — see ios/App/Podfile)
+    // the app throws "Module specifier '#entry' does not start with..." and
+    // white-screens on launch. Disabling it makes the entry resolve to a normal
+    // relative ./_nuxt/*.js import at build time. The web build keeps the
+    // feature (its browsers are modern and it's served via Netlify).
+    entryImportMap: !config.ISAPP,
   },
 
   webpack: {


### PR DESCRIPTION
## Symptom

The iOS app **white-screens on launch** on iPhones running **iOS < 16.4**, showing the "Oh dear! Something went wrong" page with:

> `Module specifier, '#entry' does not start with "/", "./", or "../". Referenced from capacitor://localhost/_nuxt/<hash>.js`

The app binary is up to date; the constraint is the device's WebView engine, not the app version.

## Root cause

Nuxt 3.21's `experimental.entryImportMap` (default `true`) rewrites the entry chunk to the **bare specifier `#entry`** and injects a `<script type="importmap">` tag to resolve it at runtime. **Import maps are only supported in WKWebView from iOS 16.4+** (March 2023).

The app's deployment floor is **iOS 14.0** (`ios/App/Podfile`: `platform :ios, '14.0'`), so on iOS 14.0–16.3 module resolution throws before the app can boot.

This became load-bearing with the **Vite 8 + rolldown upgrade** (`0ad69379b`, 2026-05-11). Before that, the entry was resolved at build time and survived old WebViews even though the app build doesn't run the `nuxt-vite-legacy` down-level pass (that's gated to Netlify).

## Fix

Set `experimental.entryImportMap: false` **for the app build only** (`config.ISAPP`). The entry then resolves to a normal relative `./_nuxt/*.js` import at build time — no import map, works on every WebView the app targets. The web build is unchanged (modern browsers / served via Netlify).

> Note: setting `vite.build.target` to an old target instead does **not** work — esbuild refuses to lower destructuring because Vite force-pins `import-meta`/`dynamic-import` support (`"safari14" + 2 overrides ... is not supported yet`). Disabling the experimental feature is the correct lever.

## Verification

Local production app build (`IZNIK_NUXT3_IS_APP=true APP_ENV=production npm run generate`):

| | `#entry` chunks | `<script type="importmap">` tags | entry tag |
|---|---|---|---|
| **before** | 173 | 3 (index/200/404.html) | via `#entry` alias |
| **after** | 0 | 0 | `<script type="module" src="/_nuxt/<hash>.js">` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)