### PR TITLE
fix(member-review): exclude orphaned memberships from work-count so count matches listing

### DIFF
--- a/iznik-server-go/group/groupWork.go
+++ b/iznik-server-go/group/groupWork.go
@@ -201,10 +201,11 @@ func GetGroupWork(c *fiber.Ctx) error {
 	go func() {
 		defer wg.Done()
 		var rows []heldCountRow
-		db.Raw("SELECT groupid, COUNT(*) as count, (heldby IS NOT NULL) as held FROM memberships "+
-			"WHERE groupid IN ? AND reviewrequestedat IS NOT NULL "+
-			"AND (reviewedat IS NULL OR reviewrequestedat > reviewedat) "+
-			"GROUP BY groupid, held", allGroupIDs).Scan(&rows)
+		db.Raw("SELECT m.groupid, COUNT(*) as count, (m.heldby IS NOT NULL) as held FROM memberships m "+
+			"INNER JOIN users u ON u.id = m.userid "+
+			"WHERE m.groupid IN ? AND m.reviewrequestedat IS NOT NULL "+
+			"AND (m.reviewedat IS NULL OR m.reviewrequestedat > m.reviewedat) "+
+			"GROUP BY m.groupid, held", allGroupIDs).Scan(&rows)
 		mapMutex.Lock()
 		for _, r := range rows {
 			w := workMap[r.Groupid]

--- a/iznik-server-go/test/member_review_orphan_test.go
+++ b/iznik-server-go/test/member_review_orphan_test.go
@@ -1,0 +1,78 @@
+package test
+
+import (
+	json2 "encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/freegle/iznik-server-go/group"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMemberReviewOrphanCountVsListing(t *testing.T) {
+	// Regression: the Spammembers work-count query tallied membership rows without
+	// JOINing to the users table, so orphaned memberships (user row deleted,
+	// membership row remains) inflated the badge count to 1 while the listing
+	// query (which INNER-JOINs users) returned 0 members.
+	db := database.DBConn
+	prefix := uniquePrefix("mrorph")
+
+	groupID := CreateTestGroup(t, prefix)
+	modID := CreateTestUser(t, prefix+"_mod", "User")
+	CreateTestMembership(t, modID, groupID, "Moderator")
+	_, token := CreateTestSession(t, modID)
+
+	// Create a user, flag their membership for review, then hard-delete the
+	// user row with FK checks disabled — leaving an orphaned membership row.
+	// In production this can occur when a user is deleted from the users table
+	// without cascading (e.g. before FK CASCADE was in place) while a
+	// reviewrequestedat flag remains on their membership row.
+	targetID := CreateTestUser(t, prefix+"_target", "User")
+	db.Exec("INSERT INTO memberships (userid, groupid, role, collection, reviewrequestedat) "+
+		"VALUES (?, ?, 'Member', 'Approved', NOW())", targetID, groupID)
+
+	db.Exec("SET FOREIGN_KEY_CHECKS = 0")
+	db.Exec("DELETE FROM users_emails WHERE userid = ?", targetID)
+	db.Exec("DELETE FROM users WHERE id = ?", targetID)
+	db.Exec("SET FOREIGN_KEY_CHECKS = 1")
+
+	t.Cleanup(func() {
+		db.Exec("SET FOREIGN_KEY_CHECKS = 0")
+		db.Exec("DELETE FROM memberships WHERE userid = ? AND groupid = ?", targetID, groupID)
+		db.Exec("SET FOREIGN_KEY_CHECKS = 1")
+	})
+
+	// Work-count call.
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/group/work?jwt="+token, nil))
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var workResult []group.GroupWork
+	json2.Unmarshal(rsp(resp), &workResult)
+
+	var found *group.GroupWork
+	for i := range workResult {
+		if workResult[i].Groupid == groupID {
+			found = &workResult[i]
+			break
+		}
+	}
+	assert.NotNil(t, found, "Expected group %d in work results", groupID)
+	if found == nil {
+		return
+	}
+
+	// Listing call.
+	spamURL := fmt.Sprintf("/api/memberships?collection=Spam&groupid=%d&jwt=%s", groupID, token)
+	spamResp, _ := getApp().Test(httptest.NewRequest("GET", spamURL, nil))
+	assert.Equal(t, 200, spamResp.StatusCode)
+
+	var spamMembers []map[string]interface{}
+	json2.Unmarshal(rsp(spamResp), &spamMembers)
+
+	assert.Equal(t, int64(len(spamMembers)), found.Spammembers,
+		"work-count Spammembers (%d) must equal members returned by listing (%d); "+
+			"orphaned membership (user deleted, membership row remains) inflates the count",
+		found.Spammembers, len(spamMembers))
+}


### PR DESCRIPTION
## Root Cause
The related-members / member-review work-count query tallies review/membership rows that reference deleted users or removed memberships, while the detail/listing query INNER-JOINs to live user/membership rows and excludes those orphans. So the count returns 1 while the listing returns 0 — a persistent phantom red card.

## Evidence
```
=== RUN   TestMemberReviewOrphanCountVsListing
    member_review_orphan_test.go:74:
        	Error Trace:	iznik-server-go/test/member_review_orphan_test.go:74
        	Error:      	Not equal:
        	            	expected: 0
        	            	actual  : 1
        	Test:       	TestMemberReviewOrphanCountVsListing
        	Messages:   	work-count Spammembers (1) must equal members returned by listing (0); orphaned membership (user deleted, membership row remains) inflates the count
--- FAIL: TestMemberReviewOrphanCountVsListing (0.09s)
```

## Fix
The Spammembers count query in `group/groupWork.go` now adds `INNER JOIN users u ON u.id = m.userid`, identical to the JOIN already present in `getSpamMembers()` (the listing query). Orphaned membership rows — where the user row no longer exists in the users table — no longer satisfy the JOIN, so they are excluded from the badge count exactly as they are excluded from the listing.

## Alternatives Investigated
- Pure WHERE-clause mismatch (no orphan): subsumed by the orphan mechanism; deleted-user precedent in topic 9656 post 37 points to orphaned rows.
- Client-side stale count: ruled out — phantom persists across browser and full PC restart, so the source is server-side.

## Other Call Sites
The only `reviewrequestedat`-based count query without a user JOIN was the Spammembers query in `groupWork.go`. The `Pendingmembers` count at line 187 queries `memberships` without a user JOIN but uses `collection = 'Pending'` (not `reviewrequestedat`) — a separate badge with lower orphan risk given FK CASCADE on membership deletion. No other files contain the same orphan-inflation pattern for review counts.

## Test
File: iznik-server-go/test/member_review_orphan_test.go
Command: `cd iznik-server-go && go test ./test/ -run TestMemberReviewOrphanCountVsListing -v -count=1`
Proves: test FAILS before this commit (see Evidence above), PASSES after (see below)
```
=== RUN   TestMemberReviewOrphanCountVsListing
--- PASS: TestMemberReviewOrphanCountVsListing (0.11s)
PASS
ok  	iznik-server-go/test	0.262s
```
Regression suite: go-api (`go test ./...`) — SUITE_PASSED=yes (3 pre-existing failures on master: AMP_SECRET env var not set, DST timezone, changes_test — all confirmed failing on master before this change)

## Discourse
https://discourse.ilovefreegle.org/t/9631/18