### PR TITLE
fix: posting group selection — member groups selectable + containing-group parity

### DIFF
--- a/iznik-nuxt3/components/ComposeGroup.vue
+++ b/iznik-nuxt3/components/ComposeGroup.vue
@@ -70,11 +70,22 @@ const groupOptions = computed(() => {
   }
 
   // Add any other groups we are a member of and might want to select.
+  // The V2 /session endpoint returns membership stubs that carry only groupid
+  // (no nameshort/namedisplay) — the group names live in the group store,
+  // populated by fetchUser() -> groupStore.fetchBatch(). So resolve the label
+  // from the store when the membership object itself has no name; otherwise the
+  // option renders blank and the member group can't be selected.
   for (const group of myGroups.value) {
     if (!ids[group.groupid]) {
+      const cached = groupStore.get(group.groupid)
       ret.push({
         value: group.groupid,
-        text: group.namedisplay ? group.namedisplay : group.nameshort,
+        text:
+          group.namedisplay ||
+          group.nameshort ||
+          cached?.namedisplay ||
+          cached?.nameshort ||
+          String(group.groupid),
       })
 
       ids[group.groupid] = true

--- a/iznik-nuxt3/tests/unit/components/ComposeGroup.spec.js
+++ b/iznik-nuxt3/tests/unit/components/ComposeGroup.spec.js
@@ -199,6 +199,40 @@ describe('ComposeGroup', () => {
       expect(options[0].element.value).toBe('55')
       expect(options[0].text()).toBe('Repost Group')
     })
+
+    it('resolves member group names from the group store when the membership stub has no name (V2 session)', () => {
+      // The V2 /session endpoint returns membership stubs that carry only groupid
+      // (+ role etc.) — the group names live in the group store, populated by
+      // fetchUser -> groupStore.fetchBatch. Reading namedisplay/nameshort straight
+      // off the membership object therefore yields undefined, rendering the member
+      // group as a blank, unselectable option. This is the regression behind the
+      // "can't select my group when posting" report: members saw only the
+      // postcode-derived groups, none of their own.
+      mockComposeStore.postcode = null
+      mockAuthStore.groups = [{ groupid: 42 }]
+      mockGroupStore.get.mockImplementation((id) =>
+        parseInt(id) === 42
+          ? { namedisplay: 'Freshers', nameshort: 'freshers' }
+          : null
+      )
+      const wrapper = createWrapper()
+      const options = wrapper.findAll('option')
+      expect(options).toHaveLength(1)
+      expect(options[0].element.value).toBe('42')
+      expect(options[0].text()).toBe('Freshers')
+    })
+
+    it('falls back to the group id as label only when the store has no entry either', () => {
+      mockComposeStore.postcode = null
+      mockAuthStore.groups = [{ groupid: 77 }]
+      mockGroupStore.get.mockReturnValue(null)
+      const wrapper = createWrapper()
+      const options = wrapper.findAll('option')
+      expect(options).toHaveLength(1)
+      expect(options[0].element.value).toBe('77')
+      // A bare id is ugly but at least keeps the option selectable rather than blank.
+      expect(options[0].text()).toBe('77')
+    })
   })
 
   describe('group computed (v-model)', () => {

--- a/iznik-server-go/location/location.go
+++ b/iznik-server-go/location/location.go
@@ -134,6 +134,35 @@ func ClosestGroups(lat float64, lng float64, radius float64, limit int) []Closes
 	// This reduces latency significantly, even though it's a bit mean to the database server.
 	db := database.DBConn
 
+	// If this point lies inside one or more group polygons, those are the correct groups —
+	// polygon containment is authoritative and beats any centre-distance heuristic.  This
+	// matches the V1 PHP groupsNear() behaviour and fixes bug #9518, where a group with a
+	// close centre but non-containing polygon was returned instead of the large group whose
+	// polygon actually contains the point.  The radius-stepping search below filters on the
+	// group centre distance (HAVING hav < currradius), so a containing group whose centre is
+	// far away would otherwise be dropped entirely.
+	containing := []ClosestGroup{}
+	db.Raw("SELECT id, nameshort, namefull, ontn, settings, 0 AS dist, "+
+		"haversine(lat, lng, ?, ?) AS hav, "+
+		"CASE WHEN altlat IS NOT NULL THEN haversine(altlat, altlng, ?, ?) ELSE NULL END AS hav2 "+
+		"FROM `groups` WHERE ST_Contains(polyindex, ST_SRID(POINT(?, ?), ?)) "+
+		"AND publish = 1 AND listable = 1 ORDER BY hav ASC, external ASC LIMIT ?;",
+		lat, lng,
+		lat, lng,
+		lng, lat, utils.SRID,
+		limit).Scan(&containing)
+
+	if len(containing) > 0 {
+		for i, r := range containing {
+			if len(r.Namefull) > 0 {
+				containing[i].Namedisplay = r.Namefull
+			} else {
+				containing[i].Namedisplay = r.Nameshort
+			}
+		}
+		return containing
+	}
+
 	var currradius = math.Round(float64(radius)/16.0 + 0.5)
 	results := []ClosestGroup{}
 	var wg sync.WaitGroup

--- a/iznik-server-go/test/location_test.go
+++ b/iznik-server-go/test/location_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/freegle/iznik-server-go/database"
 	"github.com/freegle/iznik-server-go/location"
+	"github.com/freegle/iznik-server-go/utils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -948,4 +949,68 @@ func TestLocationTaskRemapIntegrationWithPostgresSync(t *testing.T) {
 	db.Exec("DELETE FROM background_tasks WHERE task_type = 'remap_postcodes' AND JSON_EXTRACT(data, '$.location_id') = ?", locID)
 	db.Exec("DELETE FROM locations_spatial WHERE locationid = ?", locID)
 	db.Exec("DELETE FROM locations WHERE id = ?", locID)
+}
+
+// TestClosestGroupsContainingPolygonIsAuthoritative reproduces bug #9518: when a
+// location point lies inside a group's polygon, that group is the correct answer
+// even if its centre (lat/lng) is far away — polygon containment must beat the
+// centre-distance heuristic. The V1 PHP groupsNear() does this with an ST_Contains
+// check; the Go ClosestGroups() previously omitted it and so returned only the
+// group with the closest centre, dropping the containing group whose centre lies
+// beyond the search radius (it gets filtered out by the HAVING hav < radius clause).
+//
+// We seed two groups in an empty region (Gulf of Guinea — no real Freegle groups
+// there) so only our test groups are candidates:
+//   - Group A: a large polygon that CONTAINS the point, but whose centre is ~230
+//     miles away (so it is excluded by the centre-distance HAVING clause).
+//   - Group B: a small polygon that does NOT contain the point, but whose centre
+//     is ~5 miles away (so it passes the centre-distance filter).
+// The containing group A must be returned.
+func TestClosestGroupsContainingPolygonIsAuthoritative(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("closest_contain")
+
+	pointLat := 0.5
+	pointLng := 0.5
+
+	// Group A: large containing polygon, distant centre, NULL alt centre.
+	nameA := "ContainA_" + prefix
+	db.Exec(fmt.Sprintf(
+		"INSERT INTO `groups` (nameshort, namefull, type, onhere, publish, listable, lat, lng, altlat, altlng, polyindex) "+
+			"VALUES (?, ?, 'Freegle', 1, 1, 1, 2.9, 2.9, NULL, NULL, ST_GeomFromText('POLYGON((-2 -2, -2 3, 3 3, 3 -2, -2 -2))', %d))",
+		utils.SRID), nameA, "Containing Group A")
+	var groupA uint64
+	db.Raw("SELECT id FROM `groups` WHERE nameshort = ? ORDER BY id DESC LIMIT 1", nameA).Scan(&groupA)
+	assert.Greater(t, groupA, uint64(0))
+
+	// Group B: small non-containing polygon near the point, close centre.
+	nameB := "ContainB_" + prefix
+	db.Exec(fmt.Sprintf(
+		"INSERT INTO `groups` (nameshort, namefull, type, onhere, publish, listable, lat, lng, altlat, altlng, polyindex) "+
+			"VALUES (?, ?, 'Freegle', 1, 1, 1, 0.55, 0.55, NULL, NULL, ST_GeomFromText('POLYGON((0.6 0.6, 0.6 0.7, 0.7 0.7, 0.7 0.6, 0.6 0.6))', %d))",
+		utils.SRID), nameB, "Near Group B")
+	var groupB uint64
+	db.Raw("SELECT id FROM `groups` WHERE nameshort = ? ORDER BY id DESC LIMIT 1", nameB).Scan(&groupB)
+	assert.Greater(t, groupB, uint64(0))
+
+	defer func() {
+		db.Exec("DELETE FROM `groups` WHERE id IN (?, ?)", groupA, groupB)
+	}()
+
+	groups := location.ClosestGroups(pointLat, pointLng, float64(location.NEARBY), 10)
+
+	assert.Greater(t, len(groups), 0, "should find the containing group")
+	if len(groups) > 0 {
+		assert.Equal(t, groupA, groups[0].ID,
+			"the group whose polygon contains the point must be returned, even though its centre is far away")
+		assert.Equal(t, "Containing Group A", groups[0].Namedisplay,
+			"namedisplay should be populated for the containing group")
+	}
+
+	// The containing-groups path is authoritative: a non-containing group with a
+	// closer centre must not be returned ahead of (or instead of) the containing one.
+	for _, g := range groups {
+		assert.NotEqual(t, groupB, g.ID,
+			"non-containing group B must not appear when a containing group exists")
+	}
 }


### PR DESCRIPTION
## Problem

Reported on Discourse: [Can't select group when posting (#9741)](https://discourse.ilovefreegle.org/t/cant-select-group-when-posting/9741). A member of ~70 groups could only select the group nearest their home postcode when posting — none of their own groups were offered (and even 2 groups they weren't a member of appeared).

Investigation found **two distinct issues**, both introduced/exposed by the V1→V2 migration:

### 1. Member groups render as blank options (the reported symptom)

`ComposeGroup.vue` builds the dropdown from the postcode's nearby groups **plus every group you belong to**. The member-group options read `namedisplay`/`nameshort` straight off the membership object — but the V2 `/session` endpoint (`session.go` `MembershipRow`) returns membership **stubs** carrying only `groupid`; the names live in the group store (populated by `fetchUser()` → `groupStore.fetchBatch()`). V1's session embedded the names on each membership (`User.php` ~L2296), so this worked before.

Result: every member group rendered with an `undefined` label — a blank, effectively unselectable option. **Fix:** resolve the label from `groupStore.get(groupid)` when the membership stub has no name, mirroring the existing pre-selected-group handling.

### 2. Polygon containment not authoritative in `ClosestGroups` (related parity gap)

`location.go` `ClosestGroups()` only does the radius-stepping search, which filters on **centre** distance (`HAVING hav < currradius`). A large group whose polygon *contains* the point but whose centre is far away gets dropped, and a closer-centred non-containing group is returned instead. V1's `Location.php` `groupsNear()` runs an `ST_Contains` check first that is authoritative (added to fix bug #9518). **Fix:** port that block to Go.

## Tests (TDD)

- `ComposeGroup.spec.js`: new test with a **V2-realistic** membership stub (only `groupid`, name only in the store) asserting the option label resolves to the group name, not a blank. The pre-existing tests mocked names onto memberships, which is why they never caught this.
- `location_test.go`: `TestClosestGroupsContainingPolygonIsAuthoritative` seeds a containing group with a distant centre + a non-containing group with a close centre (in an empty region) and asserts the containing group is returned.

## Verification note

Local container test execution was unavailable in this worktree (host-port exhaustion across parallel worktrees prevented bringing the stack up), so these run in CI. Both suites + lint run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)