### PR TITLE
Yesterday: LVM-thin fast-switch backups (~1 min day switching)

### DIFF
--- a/yesterday/README.md
+++ b/yesterday/README.md
@@ -23,6 +23,59 @@ The Yesterday environment:
 - Reuses all existing containers (Freegle, ModTools, API v1/v2, Mailhog)
 - Backup selection via web UI with progress tracking
 
+## Fast Switching with LVM-Thin Snapshots
+
+A full restore (download → extract → decompress → `xtrabackup --prepare`) takes
+30–90 minutes, so flipping between backup days used to mean a long wait each
+time. The **LVM-thin fast-switch** system makes switching between recently-loaded
+days take **~1 minute** instead, while keeping disk use small.
+
+**How it works (no production-side backup change):**
+- Backups remain nightly **full** Percona XtraBackup hot backups.
+- The MySQL datadir lives on an **XFS filesystem on an LVM-thin logical volume**
+  (`/mnt/iznik-active`), on a dedicated disk separate from the OS disk.
+- Each day's prepared backup is applied onto the live datadir with
+  `rsync --inplace --no-whole-file`, so the thin pool only copies-on-write the
+  blocks that actually changed.
+- A **read-only thin snapshot per day** (`snap_YYYYMMDD`) is the "datestamped
+  database". Because consecutive days share unchanged blocks, total disk use ≈
+  base (~120 GB) + the sum of daily deltas — *not* N × full size. (Measured:
+  a 50 MB real change costs ~50 MB of snapshot, not a 120 GB copy.)
+- **Switching** creates a fresh writable thin clone of the chosen snapshot,
+  remounts it (with `nouuid` — clones share the origin's XFS UUID), and restarts
+  percona. Browsing writes to the clone are discarded on the next switch.
+
+**Scripts** (in `yesterday/scripts/`):
+
+| Script | When | What it does |
+|--------|------|--------------|
+| `setup-lvm-thin.sh /dev/sdX` | once | Creates the VG, thin pool, `active` + `stage` LVs (XFS), mounts them, fstab. |
+| `prime-backups.sh [N]` | once (background) | Primes the last N daily backups into snapshots, oldest→newest. Runs while percona still serves the old volume — zero downtime. |
+| `cutover-to-lvm.sh` | once | Points percona at `/mnt/iznik-active` (rebinds the `freegle_db` volume) and restarts. Brief downtime. |
+| `switch-backup.sh <YYYYMMDD>` | any time | Fast switch to a snapshotted day (~1 min). `--list` shows available days. |
+| `lib-yesterday-lvm.sh` | — | Shared helpers (sourced by the above). |
+
+**Sizing:** the dedicated pool disk must hold `active` (~120 GB) + `stage`
+(~120 GB, transient during a refresh) + daily snapshot deltas. A **400 GB** disk
+gives comfortable headroom (~70% peak) and lets the prime run in the background.
+
+**Deploy runbook:**
+```bash
+# 1. Attach a dedicated empty disk (e.g. 400GB) to the VM, then on the VM:
+sudo /var/www/FreegleDocker/yesterday/scripts/setup-lvm-thin.sh /dev/sdb
+# 2. Prime the last 7 days (background; percona keeps serving the old DB):
+sudo /var/www/FreegleDocker/yesterday/scripts/prime-backups.sh 7
+# 3. Cut percona over to the LVM datadir (brief restart):
+sudo /var/www/FreegleDocker/yesterday/scripts/cutover-to-lvm.sh
+# 4. Switch between days in ~1 minute:
+sudo /var/www/FreegleDocker/yesterday/scripts/switch-backup.sh --list
+sudo /var/www/FreegleDocker/yesterday/scripts/switch-backup.sh 20260529
+```
+
+> After cutover, the nightly auto-restore should refresh `/mnt/iznik-active` via
+> the same `rsync --inplace` + snapshot path (see `lib-yesterday-lvm.sh`) rather
+> than the old wipe-and-extract in `restore-backup.sh`.
+
 ## Domain Structure
 
 - `yesterday.ilovefreegle.org` - Backup browser and index page

--- a/yesterday/README.md
+++ b/yesterday/README.md
@@ -55,9 +55,14 @@ days take **~1 minute** instead, while keeping disk use small.
 | `switch-backup.sh <YYYYMMDD>` | any time | Fast switch to a snapshotted day (~1 min). `--list` shows available days. |
 | `lib-yesterday-lvm.sh` | — | Shared helpers (sourced by the above). |
 
-**Sizing:** the dedicated pool disk must hold `active` (~120 GB) + `stage`
-(~120 GB, transient during a refresh) + daily snapshot deltas. A **400 GB** disk
-gives comfortable headroom (~70% peak) and lets the prime run in the background.
+**Sizing:** the dedicated pool disk must hold `active` (~140 GB) + `stage`
+(~140 GB) + daily snapshot deltas. In practice the *prepared* datadir is ~140 GB
+and each day's snapshot delta is ~10–20 GB (xtrabackup rewrites page LSNs, so it
+exceeds pure logical churn). Budget **~600 GB** for 7 days with comfortable
+headroom. **Staging must be mounted with `discard`** (setup does this) so its
+freed blocks return to the pool each refresh — otherwise it accumulates and
+exhausts the pool. The pool disk can be grown live if needed:
+`gcloud compute disks resize … && pvresize /dev/sdb && lvextend -l +100%FREE yesterday_vg/thinpool`.
 
 **Deploy runbook:**
 ```bash

--- a/yesterday/api/server.js
+++ b/yesterday/api/server.js
@@ -87,6 +87,14 @@ app.get('/api/backups', async (req, res) => {
     // Get list of backups with size and date
     const { stdout } = await execAsync(`gsutil ls -l "${bucket}/iznik-*.xbstream"`);
 
+    // Dates that have an LVM thin snapshot are instantly switchable (~1 min)
+    // rather than a full restore (~1-2h). The host writes this manifest after
+    // each prime/refresh; absent file => no LVM, everything is a full restore.
+    let instantDates = [];
+    try {
+      instantDates = (JSON.parse(require('fs').readFileSync('/data/lvm-snapshots.json', 'utf8')).dates) || [];
+    } catch (e) { /* no manifest yet */ }
+
     const backups = [];
     const lines = stdout.trim().split('\n');
 
@@ -109,7 +117,8 @@ app.get('/api/backups', async (req, res) => {
             size: size,
             size_human: formatSize(size),
             timestamp: dateStr,
-            loaded: await isBackupLoaded(backupDate)
+            loaded: await isBackupLoaded(backupDate),
+            instant: instantDates.includes(backupDate)
           });
         }
       }

--- a/yesterday/docker-compose.override.yml
+++ b/yesterday/docker-compose.override.yml
@@ -323,9 +323,16 @@ services:
 
 volumes:
   freegle_db:
-    # Mark as external - this volume is populated by the restore script
-    # with production backup data and should not be recreated by Docker
-    external: true
+    # LVM fast-switch: the datadir lives on the XFS thin LV mounted at
+    # /mnt/iznik-active (see yesterday/scripts/setup-lvm-thin.sh). percona's
+    # freegle_db:/var/lib/mysql mapping is unchanged — it now resolves to the
+    # active thin clone, so switch-backup.sh can flip days in seconds.
+    # REQUIRES setup-lvm-thin.sh + cutover-to-lvm.sh to have run on this host.
+    driver: local
+    driver_opts:
+      type: none
+      device: /mnt/iznik-active
+      o: bind
   loki-data:
     # NOT external - Docker creates this automatically if it doesn't exist
     # The restore script will populate it with historical logs if available,

--- a/yesterday/docker-compose.override.yml
+++ b/yesterday/docker-compose.override.yml
@@ -143,6 +143,10 @@ services:
       - ./conf/percona-my.cnf:/etc/my.cnf:ro
 
   phpmyadmin:
+    networks:
+      default:
+        aliases:
+          - freegle-phpmyadmin
     # Accessed via 2FA gateway at /phpmyadmin (Admin only)
     # No direct external access - only through yesterday-2fa gateway
     # Basic auth disabled - authentication handled by 2FA gateway
@@ -165,6 +169,10 @@ services:
       - "traefik.enable=false"
 
   mailpit:
+    networks:
+      default:
+        aliases:
+          - freegle-mailhog
     # Accessed via 2FA gateway at /mailpit (Admin only)
     # No direct external access - only through yesterday-2fa gateway
     # Basic auth disabled - authentication handled by 2FA gateway
@@ -175,6 +183,10 @@ services:
       - "traefik.enable=false"
 
   apiv1:
+    networks:
+      default:
+        aliases:
+          - freegle-apiv1
     # Accessible only through Yesterday 2FA gateway on port 8181
     # Mount MySQL client config with production database password
     # File: ./iznik-server-my.cnf (created by scripts/generate-mysql-configs.sh)
@@ -203,6 +215,10 @@ services:
       - IMAGE_DELIVERY=https://delivery.ilovefreegle.org
 
   apiv2:
+    networks:
+      default:
+        aliases:
+          - freegle-apiv2
     # Accessible only through Yesterday 2FA gateway on port 8193
     ports: !reset []
     labels:
@@ -230,6 +246,10 @@ services:
       - DB_PASSWORD=${MYSQL_PRODUCTION_ROOT_PASSWORD:-iznik}
 
   freegle-dev-local:
+    networks:
+      default:
+        aliases:
+          - freegle-freegle-dev
     # Routed through Traefik for SSL termination on port 3002
     # No direct port binding - Traefik handles HTTPS and proxies to container
     ports: !reset []
@@ -269,6 +289,10 @@ services:
       replicas: 0
 
   modtools-dev-local:
+    networks:
+      default:
+        aliases:
+          - freegle-modtools-dev
     # Routed through Traefik for SSL termination on port 3003
     # No direct port binding - Traefik handles HTTPS and proxies to container
     ports: !reset []

--- a/yesterday/index/index.html
+++ b/yesterday/index/index.html
@@ -191,6 +191,13 @@
       color: #856404;
       border: 1px solid #ffe69c;
     }
+    .badge.restoring {
+      background: #1565c0;
+      color: white;
+    }
+    .backup-row.restoring td {
+      background: #e3f2fd;
+    }
     button.load.instant {
       background: #2e7d32;
     }
@@ -557,17 +564,31 @@
               <tbody>
           `;
 
+          const ri = (typeof restoreInfo !== 'undefined') ? restoreInfo : { inProgress: false, backupDate: null };
           data.backups.forEach(backup => {
             const isCurrent = backup.date === currentBackupDate;
-            const rowClass = isCurrent ? 'backup-row current' : 'backup-row';
-            let badge;
-            if (isCurrent) badge = '<span class="badge current">LOADED</span>';
-            else if (backup.instant) badge = '<span class="badge instant">⚡ Instant · ~1 min</span>';
-            else badge = '<span class="badge fullrestore">Full restore · ~1–2 h</span>';
-            let button;
-            if (isCurrent) button = '<button class="load" disabled>Currently Loaded</button>';
-            else if (backup.instant) button = `<button class="load instant" onclick="loadBackup('${backup.date}', true)">⚡ Switch (~1 min)</button>`;
-            else button = `<button class="load" onclick="loadBackup('${backup.date}', false)">Load (full restore)</button>`;
+            const isRestoringThis = ri.inProgress && backup.date === ri.backupDate;
+            const otherRestore = ri.inProgress && !isRestoringThis;
+            const rowClass = (isCurrent ? 'backup-row current' : 'backup-row') + (isRestoringThis ? ' restoring' : '');
+            let badge, button;
+            if (isRestoringThis) {
+              // This is the one actually being restored — make it unmistakable.
+              badge = '<span class="badge restoring">⏳ Restoring now…</span>';
+              button = '<button class="load" disabled>⏳ Restoring this backup…</button>';
+            } else if (isCurrent) {
+              badge = '<span class="badge current">LOADED</span>';
+              button = '<button class="load" disabled>Currently Loaded</button>';
+            } else if (backup.instant) {
+              badge = '<span class="badge instant">⚡ Instant · ~1 min</span>';
+              button = otherRestore
+                ? '<button class="load" disabled>Locked — restore in progress</button>'
+                : `<button class="load instant" onclick="loadBackup('${backup.date}', true)">⚡ Switch (~1 min)</button>`;
+            } else {
+              badge = '<span class="badge fullrestore">Full restore · ~1–2 h</span>';
+              button = otherRestore
+                ? '<button class="load" disabled>Locked — restore in progress</button>'
+                : `<button class="load" onclick="loadBackup('${backup.date}', false)">Load (full restore)</button>`;
+            }
 
             html += `
               <tr class="${rowClass}">
@@ -885,7 +906,9 @@
       updateStatusCountdown();
     }
 
-    // Check restore status and disable buttons during restore
+    // Track which backup (if any) is currently restoring, so the list can show
+    // it specifically rather than greying out every row with a generic label.
+    let restoreInfo = { inProgress: false, backupDate: null, message: '', status: '' };
     let isRestoreInProgress = false;
     async function checkRestoreStatus() {
       try {
@@ -893,34 +916,22 @@
         const data = await response.json();
 
         const currentBackupSection = document.querySelector('.current-backup');
-
-        if (data.inProgress) {
-          isRestoreInProgress = true;
-
-          // Hide "Currently Loaded Backup" section during restore
-          if (currentBackupSection) {
-            currentBackupSection.style.display = 'none';
-          }
-
-          // Disable all load buttons
-          document.querySelectorAll('button.load').forEach(btn => {
-            btn.disabled = true;
-            btn.textContent = 'Restore In Progress';
-          });
-        } else {
-          isRestoreInProgress = false;
-
-          // Show "Currently Loaded Backup" section
-          if (currentBackupSection) {
-            currentBackupSection.style.display = 'block';
-          }
-
-          // Re-enable load buttons
-          document.querySelectorAll('button.load').forEach(btn => {
-            btn.disabled = false;
-            btn.textContent = 'Load This Backup';
-          });
+        if (currentBackupSection) {
+          currentBackupSection.style.display = data.inProgress ? 'none' : 'block';
         }
+
+        // Re-render the backup list only when the state actually changes, so we
+        // don't clobber the instant/full-restore button labels on every poll.
+        const changed = (!!data.inProgress !== restoreInfo.inProgress) ||
+                        ((data.backupDate || null) !== restoreInfo.backupDate);
+        restoreInfo = {
+          inProgress: !!data.inProgress,
+          backupDate: data.backupDate || null,
+          message: data.message || '',
+          status: data.status || ''
+        };
+        isRestoreInProgress = restoreInfo.inProgress;
+        if (changed) loadBackupList();
       } catch (error) {
         console.error('Failed to check restore status:', error);
       }

--- a/yesterday/index/index.html
+++ b/yesterday/index/index.html
@@ -182,6 +182,18 @@
       background: #e0e0e0;
       color: #666;
     }
+    .badge.instant {
+      background: #2e7d32;
+      color: white;
+    }
+    .badge.fullrestore {
+      background: #fff3cd;
+      color: #856404;
+      border: 1px solid #ffe69c;
+    }
+    button.load.instant {
+      background: #2e7d32;
+    }
     button {
       padding: 8px 16px;
       border: none;
@@ -369,7 +381,7 @@
     <div class="warning-content" id="warning-content">
       <ul>
         <li><strong>Backup Timing:</strong> Backups are created at 4 AM UTC each day, so they include all data from the previous day. The most recent backup is loaded automatically each night at 6 AM UTC.</li>
-        <li><strong>Single Backup Model:</strong> Only one backup can be loaded at a time. Loading a new backup will restart the isolated test environment and replace the database (takes 1-2 hours).</li>
+        <li><strong>Single Backup Model:</strong> Only one backup is active at a time. Recent days marked <span class="badge instant">⚡ Instant · ~1 min</span> are pre-loaded and switch in about a minute (brief restart). Older days marked <span class="badge fullrestore">Full restore · ~1–2 h</span> aren't pre-loaded, so they download and rebuild the whole database first — allow 1-2 hours.</li>
         <li><strong>Isolated Environment:</strong> Runs latest code but with real data from backups. Uses <a href="https://en.wikipedia.org/wiki/Docker_(software)" target="_blank" style="color: #856404; text-decoration: underline;">Docker technology</a> to create a completely isolated copy of the system - changes here don't affect live Freegle.</li>
         <li><strong>Login:</strong> Use your email/password from the live Freegle system. Social logins (Google, Facebook) don't work here since they're configured for production domains only. If you normally use social login, you can reset your password on the live site first.</li>
         <li><strong>Email Testing:</strong> All outbound email is captured in Mailhog (a local email testing tool) - nothing is sent externally, so it's safe to test email functionality. Access Mailhog via the link in the "Currently Loaded Backup" section below.</li>
@@ -430,7 +442,7 @@
 
       <p id="progress-estimate" style="text-align: center; color: #666;">Estimating time...</p>
 
-      <div class="progress-steps">
+      <div class="progress-steps" id="restore-steps">
         <strong>Restoration Steps:</strong>
         <ol>
           <li>Download backup from cloud storage (~30-45 min for 47GB)</li>
@@ -548,12 +560,14 @@
           data.backups.forEach(backup => {
             const isCurrent = backup.date === currentBackupDate;
             const rowClass = isCurrent ? 'backup-row current' : 'backup-row';
-            const badge = isCurrent ?
-              '<span class="badge current">LOADED</span>' :
-              '<span class="badge available">Available</span>';
-            const button = isCurrent ?
-              '<button class="load" disabled>Currently Loaded</button>' :
-              `<button class="load" onclick="loadBackup('${backup.date}')">Load This Backup</button>`;
+            let badge;
+            if (isCurrent) badge = '<span class="badge current">LOADED</span>';
+            else if (backup.instant) badge = '<span class="badge instant">⚡ Instant · ~1 min</span>';
+            else badge = '<span class="badge fullrestore">Full restore · ~1–2 h</span>';
+            let button;
+            if (isCurrent) button = '<button class="load" disabled>Currently Loaded</button>';
+            else if (backup.instant) button = `<button class="load instant" onclick="loadBackup('${backup.date}', true)">⚡ Switch (~1 min)</button>`;
+            else button = `<button class="load" onclick="loadBackup('${backup.date}', false)">Load (full restore)</button>`;
 
             html += `
               <tr class="${rowClass}">
@@ -621,16 +635,23 @@
       return 'just now';
     }
 
-    // Load a backup
-    async function loadBackup(backupDate) {
-      if (confirm(`Load backup from ${formatDate(backupDate)}?\n\nThis will restart the isolated test environment and replace the database. This may take 1-2 hours.`)) {
+    // Load a backup. `instant` = this day already has an LVM snapshot, so it's
+    // a ~1-minute switch rather than a full ~1-2h restore.
+    async function loadBackup(backupDate, instant) {
+      const confirmMsg = instant
+        ? `Switch to the backup from ${formatDate(backupDate)}?\n\nThis day is already prepared, so switching is quick — about a minute, with a brief database restart.`
+        : `Load the backup from ${formatDate(backupDate)}?\n\nThis day is NOT pre-loaded, so it needs a full restore (download + extract + prepare). This can take 1-2 hours.`;
+      if (confirm(confirmMsg)) {
         // Show progress modal
         document.getElementById('progress-modal').classList.add('show');
         document.getElementById('progress-date').textContent = formatDate(backupDate);
         document.getElementById('progress-bar').style.width = '0%';
         document.getElementById('progress-bar').textContent = '0%';
-        document.getElementById('progress-status').textContent = 'Starting restoration...';
-        document.getElementById('progress-estimate').textContent = 'Initializing...';
+        document.getElementById('progress-status').textContent = instant ? 'Switching backup…' : 'Starting restoration...';
+        document.getElementById('progress-estimate').textContent = instant ? '~1 minute (quick switch)' : 'Initializing...';
+        // The long step-by-step breakdown only applies to full restores.
+        var steps = document.getElementById('restore-steps');
+        if (steps) steps.style.display = instant ? 'none' : '';
 
         // Start restoration
         try {

--- a/yesterday/scripts/cutover-to-lvm.sh
+++ b/yesterday/scripts/cutover-to-lvm.sh
@@ -31,37 +31,43 @@ fi
 grep -q "device: $YLVM_ACTIVE_MNT" docker-compose.override.yml \
     || ylvm_die "Override does not bind freegle_db to $YLVM_ACTIVE_MNT — update yesterday/docker-compose.override.yml"
 
-ylvm_log "Stopping percona ..."
-docker compose stop percona || true
+PROJECT="$(ylvm_project_name)"
 
-# Preserve the old volume under a new name (reversible), then drop the freegle_db
-# reference so compose recreates it as the bind mount.
-if docker volume inspect freegle_db >/dev/null 2>&1; then
-    # Is it already the bind? (idempotent re-run)
-    if docker volume inspect freegle_db -f '{{.Options.device}}' 2>/dev/null | grep -q "$YLVM_ACTIVE_MNT"; then
-        ylvm_log "freegle_db already bound to $YLVM_ACTIVE_MNT — skipping rename."
-    else
-        OLD_PATH="$(docker volume inspect freegle_db -f '{{.Mountpoint}}')"
-        ylvm_log "Old freegle_db volume at $OLD_PATH (left on disk; remove later to reclaim ~119GB)."
-        docker volume rm freegle_db >/dev/null \
-            || ylvm_die "Could not remove old freegle_db volume reference (still in use?)."
+# Remove the percona CONTAINER (not just stop) — a stopped container still holds
+# a reference to its volume, which blocks volume removal.
+ylvm_log "Stopping + removing percona container ..."
+docker compose rm -sf percona >/dev/null 2>&1 || true
+
+# Drop any existing freegle_db volume so compose recreates it with the bind opts.
+# The old external volume is literally "freegle_db"; once the override switches it
+# to a managed driver_opts volume it becomes project-prefixed "${PROJECT}_freegle_db".
+# A stale prefixed volume (plain, no bind) would be silently reused otherwise.
+for vol in freegle_db "${PROJECT}_freegle_db"; do
+    if docker volume inspect "$vol" >/dev/null 2>&1; then
+        if docker volume inspect "$vol" -f '{{.Options.device}}' 2>/dev/null | grep -q "$YLVM_ACTIVE_MNT"; then
+            ylvm_log "$vol already bound to $YLVM_ACTIVE_MNT — keeping."
+        else
+            ylvm_log "Removing stale volume $vol (data is redundant — identical to newest snapshot)."
+            docker volume rm "$vol" >/dev/null 2>&1 \
+                || ylvm_die "Could not remove volume $vol (still referenced by a container?)."
+        fi
     fi
-fi
+done
 
-ylvm_log "Recreating containers so freegle_db binds to $YLVM_ACTIVE_MNT ..."
+ylvm_log "Recreating percona so freegle_db binds to $YLVM_ACTIVE_MNT ..."
 docker compose up -d percona
-
-ylvm_log "Waiting for percona health ..."
 for i in $(seq 1 90); do
-    docker compose ps percona 2>/dev/null | grep -q "healthy" && { ylvm_log "✅ percona healthy"; break; }
+    docker compose ps percona 2>/dev/null | grep -q "healthy" && break
     sleep 2
 done
 
 # Verify the bind actually resolved to the LVM datadir.
-BOUND="$(docker volume inspect freegle_db -f '{{.Options.device}}' 2>/dev/null || echo)"
+BOUND="$(docker volume inspect "${PROJECT}_freegle_db" -f '{{.Options.device}}' 2>/dev/null || echo)"
 [ "$BOUND" = "$YLVM_ACTIVE_MNT" ] || ylvm_die "freegle_db bound to '$BOUND', expected $YLVM_ACTIVE_MNT"
 
-PROJECT="$(ylvm_project_name)"
+# The prepared datadir carries the production root password — reset it to the local one.
+ylvm_reset_root_password "${YLVM_DB_PASSWORD:-iznik}"
+
 PW="$(grep '^MYSQL_PRODUCTION_ROOT_PASSWORD=' "$YLVM_COMPOSE_DIR/.env" 2>/dev/null | cut -d= -f2)"; PW="${PW:-iznik}"
 if docker exec "${PROJECT}-percona" mysql -uroot -p"$PW" -e "SHOW DATABASES;" 2>/dev/null | grep -q iznik; then
     ylvm_log "✅ Cutover complete — percona serving the iznik DB from $YLVM_ACTIVE_MNT"

--- a/yesterday/scripts/cutover-to-lvm.sh
+++ b/yesterday/scripts/cutover-to-lvm.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# One-time cutover: point percona at the LVM active datadir (/mnt/iznik-active)
+# instead of the old Docker-managed freegle_db volume. Run AFTER setup-lvm-thin.sh
+# and prime-backups.sh have completed (active holds the newest day, snapshots exist).
+#
+#   sudo ./cutover-to-lvm.sh
+#
+# Brief downtime only (percona restart). The old freegle_db volume is left in
+# place (not deleted) so this is reversible; free it later once confident:
+#   docker volume rm freegle_db_old_backup   (see end of script)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib-yesterday-lvm.sh
+source "$SCRIPT_DIR/lib-yesterday-lvm.sh"
+
+[ "$(id -u)" -eq 0 ] || ylvm_die "Run as root (sudo)."
+cd "$YLVM_COMPOSE_DIR"
+
+# Preconditions
+mountpoint -q "$YLVM_ACTIVE_MNT" || ylvm_die "$YLVM_ACTIVE_MNT not mounted — run setup-lvm-thin.sh"
+[ -f "$YLVM_ACTIVE_MNT/ibdata1" ] || ylvm_die "$YLVM_ACTIVE_MNT has no InnoDB datadir — run prime-backups.sh"
+[ -n "$(ylvm_list_snapshots)" ] || ylvm_die "No dated snapshots found — run prime-backups.sh"
+ylvm_log "Active datadir present; snapshots: $(ylvm_list_snapshots | tr '\n' ' ')"
+
+# Ensure the override (with the freegle_db bind definition) is in place at root.
+if [ -f yesterday/docker-compose.override.yml ]; then
+    cp yesterday/docker-compose.override.yml docker-compose.override.yml
+    ylvm_log "Copied yesterday override to root docker-compose.override.yml"
+fi
+grep -q "device: $YLVM_ACTIVE_MNT" docker-compose.override.yml \
+    || ylvm_die "Override does not bind freegle_db to $YLVM_ACTIVE_MNT — update yesterday/docker-compose.override.yml"
+
+ylvm_log "Stopping percona ..."
+docker compose stop percona || true
+
+# Preserve the old volume under a new name (reversible), then drop the freegle_db
+# reference so compose recreates it as the bind mount.
+if docker volume inspect freegle_db >/dev/null 2>&1; then
+    # Is it already the bind? (idempotent re-run)
+    if docker volume inspect freegle_db -f '{{.Options.device}}' 2>/dev/null | grep -q "$YLVM_ACTIVE_MNT"; then
+        ylvm_log "freegle_db already bound to $YLVM_ACTIVE_MNT — skipping rename."
+    else
+        OLD_PATH="$(docker volume inspect freegle_db -f '{{.Mountpoint}}')"
+        ylvm_log "Old freegle_db volume at $OLD_PATH (left on disk; remove later to reclaim ~119GB)."
+        docker volume rm freegle_db >/dev/null \
+            || ylvm_die "Could not remove old freegle_db volume reference (still in use?)."
+    fi
+fi
+
+ylvm_log "Recreating containers so freegle_db binds to $YLVM_ACTIVE_MNT ..."
+docker compose up -d percona
+
+ylvm_log "Waiting for percona health ..."
+for i in $(seq 1 90); do
+    docker compose ps percona 2>/dev/null | grep -q "healthy" && { ylvm_log "✅ percona healthy"; break; }
+    sleep 2
+done
+
+# Verify the bind actually resolved to the LVM datadir.
+BOUND="$(docker volume inspect freegle_db -f '{{.Options.device}}' 2>/dev/null || echo)"
+[ "$BOUND" = "$YLVM_ACTIVE_MNT" ] || ylvm_die "freegle_db bound to '$BOUND', expected $YLVM_ACTIVE_MNT"
+
+PROJECT="$(ylvm_project_name)"
+PW="$(grep '^MYSQL_PRODUCTION_ROOT_PASSWORD=' "$YLVM_COMPOSE_DIR/.env" 2>/dev/null | cut -d= -f2)"; PW="${PW:-iznik}"
+if docker exec "${PROJECT}-percona" mysql -uroot -p"$PW" -e "SHOW DATABASES;" 2>/dev/null | grep -q iznik; then
+    ylvm_log "✅ Cutover complete — percona serving the iznik DB from $YLVM_ACTIVE_MNT"
+else
+    ylvm_die "DB verification failed after cutover — check: docker logs ${PROJECT}-percona"
+fi
+
+# Bring the rest of the stack back up.
+docker compose up -d
+echo
+ylvm_log "✅ Done. Switch days with:  sudo $SCRIPT_DIR/switch-backup.sh <YYYYMMDD>"
+ylvm_log "    Available: $(ylvm_list_snapshots | tr '\n' ' ')"

--- a/yesterday/scripts/lib-yesterday-lvm.sh
+++ b/yesterday/scripts/lib-yesterday-lvm.sh
@@ -52,6 +52,10 @@ ylvm_prepare_to_stage() {
     mountpoint -q "$YLVM_STAGE_MNT" || ylvm_die "Staging $YLVM_STAGE_MNT not mounted (run setup-lvm-thin.sh)"
     ylvm_log "Clearing staging $YLVM_STAGE_MNT ..."
     rm -rf "${YLVM_STAGE_MNT:?}"/* "${YLVM_STAGE_MNT}"/.[!.]* 2>/dev/null || true
+    # Return the just-freed blocks to the thin pool. Belt-and-braces alongside the
+    # `discard` mount option — without this, staging's pool footprint accumulates
+    # across refreshes (rm on a thin volume doesn't free pool blocks by itself).
+    fstrim "$YLVM_STAGE_MNT" 2>/dev/null || true
 
     ylvm_log "Streaming + extracting to staging ..."
     gsutil cat "$backup_file" | xbstream -x -C "$YLVM_STAGE_MNT"

--- a/yesterday/scripts/lib-yesterday-lvm.sh
+++ b/yesterday/scripts/lib-yesterday-lvm.sh
@@ -142,6 +142,36 @@ ylvm_prune_snapshots() {
     done <<< "$snaps"
 }
 
+# Reset the MySQL root password to the local value the containers expect.
+# Every prepared backup carries the PRODUCTION root password, so after loading
+# any day (switch, nightly refresh, cutover) we must reset it or the apps can't
+# connect. Uses the skip-grant-tables dance (MySQL 8 disables TCP under it, so
+# we talk over the unix socket). Starts percona if it is currently stopped.
+ylvm_reset_root_password() {
+    local pw="${1:-iznik}"
+    local project; project="$(ylvm_project_name)"
+    local cnf="$YLVM_COMPOSE_DIR/conf/percona-my.cnf"
+    cd "$YLVM_COMPOSE_DIR"
+    ylvm_log "Resetting MySQL root password (backup carries the production password)..."
+    docker compose stop percona >/dev/null 2>&1 || true
+    grep -q skip-grant-tables "$cnf" || echo "skip-grant-tables" >> "$cnf"
+    docker compose up -d percona >/dev/null 2>&1 || docker compose start percona >/dev/null 2>&1
+    local ok=
+    for i in $(seq 1 60); do
+        docker exec "${project}-percona" mysqladmin ping --socket=/var/lib/mysql/mysql.sock >/dev/null 2>&1 \
+            && { ok=1; break; }
+        sleep 2
+    done
+    [ -n "$ok" ] || ylvm_die "percona socket not ready for password reset"
+    docker exec "${project}-percona" mysql --socket=/var/lib/mysql/mysql.sock -u root -e \
+        "FLUSH PRIVILEGES; ALTER USER 'root'@'localhost' IDENTIFIED BY '${pw}'; ALTER USER 'root'@'%' IDENTIFIED BY '${pw}'; FLUSH PRIVILEGES;" 2>/dev/null \
+        || ylvm_log "⚠️  password reset query failed"
+    sed -i '/skip-grant-tables/d' "$cnf"
+    docker compose restart percona >/dev/null 2>&1
+    for i in $(seq 1 90); do docker compose ps percona 2>/dev/null | grep -q healthy && break; sleep 2; done
+    ylvm_log "✅ root password reset to local value"
+}
+
 # List available dated snapshots (newest first), as YYYYMMDD.
 ylvm_list_snapshots() {
     lvs --noheadings -o lv_name "$YLVM_VG" 2>/dev/null | tr -d ' ' \

--- a/yesterday/scripts/lib-yesterday-lvm.sh
+++ b/yesterday/scripts/lib-yesterday-lvm.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+# Shared library for Yesterday LVM-thin fast-switch backups.
+# Sourced by setup-lvm-thin.sh, prime-backups.sh, switch-backup.sh and the
+# nightly restore path. Pure helpers — callers own the percona lifecycle.
+#
+# Design (no production-side change): backups remain nightly FULL Percona
+# XtraBackup hot backups. Each day is prepared into a staging volume, then
+# applied onto the live datadir with `rsync --inplace --no-whole-file` so the
+# LVM-thin pool only copies-on-write the blocks that actually changed. A
+# read-only thin snapshot per day is the "datestamped database"; switching is
+# a writable clone of that snapshot + a MySQL restart (seconds).
+
+# ---- Layout (single source of truth) ----------------------------------------
+export YLVM_VG="${YLVM_VG:-yesterday_vg}"
+export YLVM_POOL="${YLVM_POOL:-thinpool}"
+export YLVM_ACTIVE="${YLVM_ACTIVE:-iznik_active}"   # live datadir LV (mounted by percona)
+export YLVM_STAGE="${YLVM_STAGE:-iznik_stage}"      # transient prepare area
+export YLVM_ACTIVE_MNT="${YLVM_ACTIVE_MNT:-/mnt/iznik-active}"
+export YLVM_STAGE_MNT="${YLVM_STAGE_MNT:-/mnt/iznik-stage}"
+export YLVM_SNAP_PREFIX="${YLVM_SNAP_PREFIX:-snap_}"
+export YLVM_KEEP="${YLVM_KEEP:-7}"                  # retain N daily snapshots
+
+export YLVM_BUCKET="${YLVM_BUCKET:-gs://freegle_backup_uk}"
+export YLVM_COMPOSE_DIR="${YLVM_COMPOSE_DIR:-/var/www/FreegleDocker}"
+
+ylvm_log() { echo "[$(date +%H:%M:%S)] $*"; }
+ylvm_die() { echo "❌ $*" >&2; exit 1; }
+
+# Derive the docker compose project name (e.g. "freegledocker").
+ylvm_project_name() {
+    (cd "$YLVM_COMPOSE_DIR" && docker compose config --format json 2>/dev/null \
+        | python3 -c "import sys,json;print(json.load(sys.stdin).get('name','freegledocker'))" 2>/dev/null) \
+        || echo "freegledocker"
+}
+
+# Locate the .xbstream full backup object for a YYYYMMDD date.
+ylvm_find_backup() {
+    local date8="$1"
+    local fmt="${date8:0:4}-${date8:4:2}-${date8:6:2}"
+    gsutil ls "$YLVM_BUCKET/iznik-${fmt}-*.xbstream" 2>/dev/null | head -1
+}
+
+# Prepare a full backup for a date into the staging mount, leaving a clean,
+# crash-recovered InnoDB datadir at $YLVM_STAGE_MNT. Also writes the percona
+# my.cnf (matching restore-backup.sh) so the same image/params are used.
+ylvm_prepare_to_stage() {
+    local date8="$1"
+    local backup_file; backup_file="$(ylvm_find_backup "$date8")"
+    [ -n "$backup_file" ] || ylvm_die "No backup found for $date8 in $YLVM_BUCKET"
+    ylvm_log "Backup: $backup_file"
+
+    mountpoint -q "$YLVM_STAGE_MNT" || ylvm_die "Staging $YLVM_STAGE_MNT not mounted (run setup-lvm-thin.sh)"
+    ylvm_log "Clearing staging $YLVM_STAGE_MNT ..."
+    rm -rf "${YLVM_STAGE_MNT:?}"/* "${YLVM_STAGE_MNT}"/.[!.]* 2>/dev/null || true
+
+    ylvm_log "Streaming + extracting to staging ..."
+    gsutil cat "$backup_file" | xbstream -x -C "$YLVM_STAGE_MNT"
+
+    ylvm_log "Decompressing .zst files (parallel) ..."
+    find "$YLVM_STAGE_MNT" -type f -name "*.zst" -print0 | xargs -0 -P "$(nproc)" -I {} zstd -d --rm {}
+
+    # Percona version + InnoDB params from the backup (mirrors restore-backup.sh)
+    local server_version percona_version mycnf
+    server_version="$(grep '^server_version' "$YLVM_STAGE_MNT/xtrabackup_info" | awk '{print $3}')"
+    percona_version="$(echo "$server_version" | sed 's/\([0-9]\+\.[0-9]\+\.[0-9]\+-[0-9]\+\).*/\1/')"
+    ylvm_log "Backup Percona version: $server_version -> image percona:$percona_version"
+    echo "$percona_version" > "$YLVM_COMPOSE_DIR/yesterday/data/percona-version"
+    mycnf="$YLVM_COMPOSE_DIR/conf/percona-my.cnf"
+    cat > "$mycnf" <<EOF
+[mysqld]
+max_connections = 500
+innodb_data_file_path=$(grep '^innodb_data_file_path' "$YLVM_STAGE_MNT/backup-my.cnf" | cut -d= -f2)
+innodb_page_size=$(grep '^innodb_page_size' "$YLVM_STAGE_MNT/backup-my.cnf" | cut -d= -f2)
+innodb_undo_tablespaces=$(grep '^innodb_undo_tablespaces' "$YLVM_STAGE_MNT/backup-my.cnf" | cut -d= -f2)
+skip-log-bin
+skip-log-slave-updates
+sql_mode=STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION
+EOF
+
+    ylvm_log "Preparing (apply redo) ..."
+    xtrabackup --prepare --apply-log-only --target-dir="$YLVM_STAGE_MNT"
+    ylvm_log "Preparing (final, roll back uncommitted) ..."
+    xtrabackup --prepare --target-dir="$YLVM_STAGE_MNT"
+    rm -f "$YLVM_STAGE_MNT/.extraction_done" 2>/dev/null || true
+    ylvm_log "✅ Staging prepared for $date8"
+}
+
+# Apply the prepared staging datadir onto the live active datadir IN PLACE so
+# the thin pool only allocates changed blocks. Caller MUST ensure percona is
+# NOT using $YLVM_ACTIVE_MNT (stopped, or still on the old volume during prime).
+ylvm_apply_stage_to_active() {
+    local percona_version; percona_version="$(cat "$YLVM_COMPOSE_DIR/yesterday/data/percona-version" 2>/dev/null || echo)"
+    mountpoint -q "$YLVM_ACTIVE_MNT" || ylvm_die "Active $YLVM_ACTIVE_MNT not mounted"
+    ylvm_log "rsync --inplace staging -> active (changed blocks only) ..."
+    rsync -a --inplace --no-whole-file --delete \
+        "$YLVM_STAGE_MNT/" "$YLVM_ACTIVE_MNT/"
+    # Ownership for the in-container mysql user (detected like restore-backup.sh)
+    if [ -n "$percona_version" ]; then
+        local uid gid
+        uid="$(docker run --rm "percona:$percona_version" id -u mysql 2>/dev/null || echo 999)"
+        gid="$(docker run --rm "percona:$percona_version" id -g mysql 2>/dev/null || echo 999)"
+        chown -R "${uid}:${gid}" "$YLVM_ACTIVE_MNT"
+    fi
+    sync
+    ylvm_log "✅ Active updated in place"
+}
+
+# Take a read-only thin snapshot of the active datadir, tagged by date.
+ylvm_snapshot_active() {
+    local date8="$1"
+    local snap="${YLVM_SNAP_PREFIX}${date8}"
+    if lvs "$YLVM_VG/$snap" >/dev/null 2>&1; then
+        ylvm_log "Snapshot $snap exists; removing to refresh"
+        lvremove -fy "$YLVM_VG/$snap"
+    fi
+    # Thin snapshots are block-consistent and lvcreate momentarily suspends the
+    # origin itself, so a flush is enough. Do NOT xfs_freeze first: a frozen XFS
+    # blocks LVM's own origin suspend ("Device or resource busy"). In our flows
+    # the active datadir is quiescent at snapshot time anyway (percona is on the
+    # old volume during prime, and stopped during the nightly refresh).
+    sync
+    lvcreate -s -pr -n "$snap" "$YLVM_VG/$YLVM_ACTIVE"
+    ylvm_log "✅ Snapshot $snap created"
+}
+
+# Keep only the newest $YLVM_KEEP dated snapshots; remove older ones.
+ylvm_prune_snapshots() {
+    local snaps; snaps="$(lvs --noheadings -o lv_name "$YLVM_VG" 2>/dev/null \
+        | tr -d ' ' | grep "^${YLVM_SNAP_PREFIX}" | sort -r)"
+    local i=0
+    while IFS= read -r snap; do
+        [ -z "$snap" ] && continue
+        i=$((i+1))
+        if [ "$i" -gt "$YLVM_KEEP" ]; then
+            ylvm_log "Pruning old snapshot $snap"
+            lvremove -fy "$YLVM_VG/$snap" || true
+        fi
+    done <<< "$snaps"
+}
+
+# List available dated snapshots (newest first), as YYYYMMDD.
+ylvm_list_snapshots() {
+    lvs --noheadings -o lv_name "$YLVM_VG" 2>/dev/null | tr -d ' ' \
+        | grep "^${YLVM_SNAP_PREFIX}" | sed "s/^${YLVM_SNAP_PREFIX}//" | sort -r
+}

--- a/yesterday/scripts/lib-yesterday-lvm.sh
+++ b/yesterday/scripts/lib-yesterday-lvm.sh
@@ -143,6 +143,25 @@ ylvm_prune_snapshots() {
     ylvm_write_snapshot_manifest
 }
 
+# Update the restore-status.json the backup-browser API reads, so the UI shows
+# the right state during/after an LVM operation (and never goes stale). Use a
+# non-terminal status (e.g. "switching") to show in-progress, "completed" when
+# done. Without this, a quick switch would leave the previous status frozen.
+ylvm_set_restore_status() {
+    local status="$1" message="$2" date8="$3"
+    local f="$YLVM_COMPOSE_DIR/yesterday/data/restore-status.json"
+    mkdir -p "$(dirname "$f")"
+    cat > "$f" <<EOF
+{
+  "status": "${status}",
+  "message": "${message}",
+  "backupDate": "${date8}",
+  "filesRemaining": 0,
+  "timestamp": "$(date -Iseconds)"
+}
+EOF
+}
+
 # Write the set of instantly-switchable days to a file the backup-browser API
 # reads (mounted as /data in the yesterday-api container). The UI uses this to
 # show which dates are a ~1-min switch vs a full ~1-2h restore.

--- a/yesterday/scripts/lib-yesterday-lvm.sh
+++ b/yesterday/scripts/lib-yesterday-lvm.sh
@@ -140,6 +140,18 @@ ylvm_prune_snapshots() {
             lvremove -fy "$YLVM_VG/$snap" || true
         fi
     done <<< "$snaps"
+    ylvm_write_snapshot_manifest
+}
+
+# Write the set of instantly-switchable days to a file the backup-browser API
+# reads (mounted as /data in the yesterday-api container). The UI uses this to
+# show which dates are a ~1-min switch vs a full ~1-2h restore.
+ylvm_write_snapshot_manifest() {
+    local out="$YLVM_COMPOSE_DIR/yesterday/data/lvm-snapshots.json"
+    local dates; dates="$(ylvm_list_snapshots | sed 's/^/"/; s/$/"/' | paste -sd, -)"
+    mkdir -p "$(dirname "$out")"
+    printf '{"dates":[%s]}\n' "$dates" > "$out"
+    ylvm_log "Snapshot manifest updated: [${dates}]"
 }
 
 # Reset the MySQL root password to the local value the containers expect.

--- a/yesterday/scripts/nightly-refresh-lvm.sh
+++ b/yesterday/scripts/nightly-refresh-lvm.sh
@@ -42,6 +42,7 @@ mountpoint -q "$YLVM_ACTIVE_MNT" || ylvm_die "$YLVM_ACTIVE_MNT not mounted — r
 mountpoint -q "$YLVM_STAGE_MNT"  || ylvm_die "$YLVM_STAGE_MNT not mounted — run setup-lvm-thin.sh"
 
 ylvm_log "===== Nightly LVM refresh -> $DATE8 (was: ${CURRENT:-none}) ====="
+ylvm_set_restore_status "preparing" "Refreshing to latest backup $DATE8…" "$DATE8"
 
 # 1. Prepare the full backup in staging (percona still serving the current day).
 ylvm_prepare_to_stage "$DATE8"
@@ -62,6 +63,7 @@ ylvm_reset_root_password "${YLVM_DB_PASSWORD:-iznik}"
 # 5. Clear stale cache + record state.
 docker compose exec -T redis redis-cli FLUSHALL >/dev/null 2>&1 || true
 "$SCRIPT_DIR/set-current-backup.sh" "$DATE8" 2>/dev/null || true
+ylvm_set_restore_status "completed" "Refreshed to backup $DATE8" "$DATE8"
 
 # 6. Ensure the rest of the stack is up.
 docker compose up -d

--- a/yesterday/scripts/nightly-refresh-lvm.sh
+++ b/yesterday/scripts/nightly-refresh-lvm.sh
@@ -55,13 +55,9 @@ ylvm_apply_stage_to_active
 ylvm_snapshot_active "$DATE8"
 ylvm_prune_snapshots
 
-# 4. Restart percona on the refreshed datadir.
-ylvm_log "Starting percona ..."
-docker compose up -d percona
-for i in $(seq 1 90); do
-    docker compose ps percona 2>/dev/null | grep -q "healthy" && { ylvm_log "✅ percona healthy"; break; }
-    sleep 2
-done
+# 4. Restart percona on the refreshed datadir, resetting the root password
+#    (the refreshed datadir carries the production password from the backup).
+ylvm_reset_root_password "${YLVM_DB_PASSWORD:-iznik}"
 
 # 5. Clear stale cache + record state.
 docker compose exec -T redis redis-cli FLUSHALL >/dev/null 2>&1 || true

--- a/yesterday/scripts/nightly-refresh-lvm.sh
+++ b/yesterday/scripts/nightly-refresh-lvm.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# Nightly refresh for the LVM fast-switch system. Replaces the old wipe-and-
+# extract path in restore-backup.sh once cutover-to-lvm.sh has run. Applies the
+# latest full backup onto the live datadir IN PLACE (rsync --inplace) and takes
+# a fresh dated snapshot, so day-to-day storage stays small and every recent day
+# remains instantly switchable via switch-backup.sh.
+#
+#   sudo ./nightly-refresh-lvm.sh            # refresh to the latest backup
+#   sudo ./nightly-refresh-lvm.sh 20260530   # refresh to a specific date
+#
+# Unlike the old restore, this does NOT rebuild containers (code is unchanged
+# between days) — it just refreshes the datadir. Brief percona downtime during
+# the rsync + restart (minutes, since only changed blocks are written).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib-yesterday-lvm.sh
+source "$SCRIPT_DIR/lib-yesterday-lvm.sh"
+
+[ "$(id -u)" -eq 0 ] || ylvm_die "Run as root (sudo)."
+cd "$YLVM_COMPOSE_DIR"
+PROJECT="$(ylvm_project_name)"
+STATE_FILE="$YLVM_COMPOSE_DIR/yesterday/data/current-backup.json"
+
+# Determine target date (arg, else newest in bucket).
+DATE8="${1:-}"
+if [ -z "$DATE8" ]; then
+    DATE8="$(gsutil ls "$YLVM_BUCKET/iznik-*.xbstream" 2>/dev/null \
+        | sed -E 's#.*/iznik-([0-9]{4})-([0-9]{2})-([0-9]{2})-.*#\1\2\3#' \
+        | grep -E '^[0-9]{8}$' | sort -u | tail -1)"
+fi
+[ -n "$DATE8" ] || ylvm_die "Could not determine a backup date"
+
+# Skip if already current and snapshot exists.
+CURRENT="$(jq -r '.date // ""' "$STATE_FILE" 2>/dev/null || echo)"
+if [ "$DATE8" = "$CURRENT" ] && lvs "$YLVM_VG/${YLVM_SNAP_PREFIX}${DATE8}" >/dev/null 2>&1; then
+    ylvm_log "Already on latest backup $DATE8 with snapshot present — nothing to do."
+    exit 0
+fi
+
+mountpoint -q "$YLVM_ACTIVE_MNT" || ylvm_die "$YLVM_ACTIVE_MNT not mounted — run setup-lvm-thin.sh"
+mountpoint -q "$YLVM_STAGE_MNT"  || ylvm_die "$YLVM_STAGE_MNT not mounted — run setup-lvm-thin.sh"
+
+ylvm_log "===== Nightly LVM refresh -> $DATE8 (was: ${CURRENT:-none}) ====="
+
+# 1. Prepare the full backup in staging (percona still serving the current day).
+ylvm_prepare_to_stage "$DATE8"
+
+# 2. Stop percona so the active datadir is quiescent for the in-place apply.
+ylvm_log "Stopping percona for in-place apply ..."
+docker compose stop percona || true
+
+# 3. Apply changed blocks onto active, snapshot, prune.
+ylvm_apply_stage_to_active
+ylvm_snapshot_active "$DATE8"
+ylvm_prune_snapshots
+
+# 4. Restart percona on the refreshed datadir.
+ylvm_log "Starting percona ..."
+docker compose up -d percona
+for i in $(seq 1 90); do
+    docker compose ps percona 2>/dev/null | grep -q "healthy" && { ylvm_log "✅ percona healthy"; break; }
+    sleep 2
+done
+
+# 5. Clear stale cache + record state.
+docker compose exec -T redis redis-cli FLUSHALL >/dev/null 2>&1 || true
+"$SCRIPT_DIR/set-current-backup.sh" "$DATE8" 2>/dev/null || true
+
+# 6. Ensure the rest of the stack is up.
+docker compose up -d
+
+echo
+ylvm_log "✅ Nightly refresh complete — now on $DATE8"
+ylvm_log "   Switchable days: $(ylvm_list_snapshots | tr '\n' ' ')"

--- a/yesterday/scripts/prime-backups.sh
+++ b/yesterday/scripts/prime-backups.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Prime the LVM-thin pool with the last N daily full backups, oldest -> newest,
+# building one read-only snapshot per day. Designed to run in the BACKGROUND
+# while percona still serves the current DB on the old volume (zero downtime):
+# nothing here touches percona or the old volume. After it finishes, cut over
+# (see RUNBOOK) and use switch-backup.sh to flip between days.
+#
+#   sudo ./prime-backups.sh [N]      # default N = $YLVM_KEEP (7)
+#
+# Because we rsync --inplace each prepared full onto the SAME active datadir,
+# consecutive days share unchanged blocks, so total pool use ≈ base + sum of
+# daily deltas (validated: ~real-change per day), not N × full size.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib-yesterday-lvm.sh
+source "$SCRIPT_DIR/lib-yesterday-lvm.sh"
+
+[ "$(id -u)" -eq 0 ] || ylvm_die "Run as root (sudo)."
+N="${1:-$YLVM_KEEP}"
+
+mountpoint -q "$YLVM_ACTIVE_MNT" || ylvm_die "Active not mounted — run setup-lvm-thin.sh first"
+mountpoint -q "$YLVM_STAGE_MNT"  || ylvm_die "Staging not mounted — run setup-lvm-thin.sh first"
+
+# Discover the most recent N backup dates available in the bucket (YYYYMMDD).
+ylvm_log "Listing last $N backups in $YLVM_BUCKET ..."
+mapfile -t DATES < <(gsutil ls "$YLVM_BUCKET/iznik-*.xbstream" 2>/dev/null \
+    | sed -E 's#.*/iznik-([0-9]{4})-([0-9]{2})-([0-9]{2})-.*#\1\2\3#' \
+    | grep -E '^[0-9]{8}$' | sort -u | tail -n "$N")
+
+[ "${#DATES[@]}" -gt 0 ] || ylvm_die "No backups found in $YLVM_BUCKET"
+ylvm_log "Will prime ${#DATES[@]} day(s): ${DATES[*]}"
+
+abort_if_pool_low() {
+    # Hard safety: bail before the thin pool fills (corruption risk).
+    local used; used="$(lvs --noheadings -o data_percent "$YLVM_VG/$YLVM_POOL" 2>/dev/null | tr -d ' %' | cut -d. -f1)"
+    [ -n "$used" ] || return 0
+    ylvm_log "Thin pool usage: ${used}%"
+    if [ "$used" -ge 90 ]; then
+        ylvm_die "Thin pool at ${used}% — aborting prime to avoid pool-full. Grow the disk/LV and resume."
+    fi
+}
+
+idx=0
+for date8 in "${DATES[@]}"; do
+    idx=$((idx+1))
+    echo
+    ylvm_log "===== [$idx/${#DATES[@]}] Priming $date8 ====="
+    abort_if_pool_low
+    ylvm_prepare_to_stage "$date8"
+    ylvm_apply_stage_to_active        # percona untouched: active is idle during prime
+    ylvm_snapshot_active "$date8"
+    ylvm_prune_snapshots
+    lvs -o lv_name,lv_size,data_percent,pool_lv "$YLVM_VG" | sed 's/^/    /'
+done
+
+echo
+ylvm_log "✅ Prime complete. Snapshots:"
+ylvm_list_snapshots | sed 's/^/  /'
+echo
+echo "Active datadir currently holds the NEWEST day (${DATES[-1]})."
+echo "Next: cut over percona to $YLVM_ACTIVE_MNT (RUNBOOK), then use switch-backup.sh."

--- a/yesterday/scripts/restore-monitor.sh
+++ b/yesterday/scripts/restore-monitor.sh
@@ -4,7 +4,35 @@
 
 TRIGGER_DIR="/var/www/FreegleDocker/yesterday/data"
 TRIGGER_FILE="$TRIGGER_DIR/restore-trigger"
-RESTORE_SCRIPT="/var/www/FreegleDocker/yesterday/scripts/restore-backup.sh"
+SCRIPTS_DIR="/var/www/FreegleDocker/yesterday/scripts"
+RESTORE_SCRIPT="$SCRIPTS_DIR/restore-backup.sh"            # legacy wipe-and-extract
+SWITCH_SCRIPT="$SCRIPTS_DIR/switch-backup.sh"              # LVM fast switch (seconds)
+REFRESH_SCRIPT="$SCRIPTS_DIR/nightly-refresh-lvm.sh"       # LVM prepare+rsync+snapshot
+
+# Is the LVM fast-switch system live on this host?
+lvm_active() {
+    vgs yesterday_vg >/dev/null 2>&1 && mountpoint -q /mnt/iznik-active 2>/dev/null
+}
+
+# Route a requested date to the right path:
+#   LVM + snapshot exists -> instant switch
+#   LVM, no snapshot      -> LVM refresh (prepare/rsync/snapshot that date)
+#   no LVM                -> legacy full restore
+run_for_date() {
+    local date8="$1"
+    if lvm_active; then
+        if lvs "yesterday_vg/snap_${date8}" >/dev/null 2>&1; then
+            echo "LVM: snapshot snap_${date8} exists — fast switch."
+            "$SWITCH_SCRIPT" "$date8"
+        else
+            echo "LVM: no snapshot for ${date8} — refreshing into a new snapshot."
+            "$REFRESH_SCRIPT" "$date8"
+        fi
+    else
+        echo "LVM not active — legacy full restore."
+        "$RESTORE_SCRIPT" "$date8"
+    fi
+}
 
 echo "Restore monitor started, watching for $TRIGGER_FILE"
 
@@ -22,7 +50,7 @@ while true; do
         # Validate backup date format
         if [[ "$BACKUP_DATE" =~ ^[0-9]{8}$ ]]; then
             echo "Executing restore for backup $BACKUP_DATE..."
-            "$RESTORE_SCRIPT" "$BACKUP_DATE"
+            run_for_date "$BACKUP_DATE"
             EXIT_CODE=$?
 
             if [ $EXIT_CODE -eq 0 ]; then

--- a/yesterday/scripts/setup-lvm-thin.sh
+++ b/yesterday/scripts/setup-lvm-thin.sh
@@ -67,7 +67,10 @@ create_lv() {
 # kernel never serves stale cached data for a duplicate UUID (validated: without
 # nouuid, switches read the previous day's data). Staging is a plain LV — normal.
 create_lv "$YLVM_ACTIVE" "$ACTIVE_VSIZE" "$YLVM_ACTIVE_MNT" "defaults,nofail,nouuid"
-create_lv "$YLVM_STAGE"  "$STAGE_VSIZE"  "$YLVM_STAGE_MNT"  "defaults,nofail"
+# Staging is wiped and re-extracted every refresh. Mount with `discard` so freed
+# blocks are returned to the thin pool (online TRIM) — otherwise stage's pool
+# footprint accumulates across days and eventually exhausts the pool.
+create_lv "$YLVM_STAGE"  "$STAGE_VSIZE"  "$YLVM_STAGE_MNT"  "defaults,nofail,discard"
 
 echo
 ylvm_log "✅ LVM thin pool ready."

--- a/yesterday/scripts/setup-lvm-thin.sh
+++ b/yesterday/scripts/setup-lvm-thin.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# One-time setup of the LVM thin pool for Yesterday fast-switch backups.
+# Run ONCE on the Yesterday VM after attaching a dedicated empty disk.
+#
+#   sudo ./setup-lvm-thin.sh /dev/sdb
+#
+# Creates: PV on the device, VG, a thin pool, an `active` thin LV (the live
+# MySQL datadir) and a `stage` thin LV (transient prepare area), both XFS,
+# mounted at /mnt/iznik-active and /mnt/iznik-stage, with nofail fstab entries.
+# Idempotent: re-running detects existing objects and skips them.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib-yesterday-lvm.sh
+source "$SCRIPT_DIR/lib-yesterday-lvm.sh"
+
+DEVICE="${1:-}"
+ACTIVE_VSIZE="${ACTIVE_VSIZE:-250G}"   # thin virtual size — only used blocks consume the pool
+STAGE_VSIZE="${STAGE_VSIZE:-250G}"
+
+[ "$(id -u)" -eq 0 ] || ylvm_die "Run as root (sudo)."
+[ -n "$DEVICE" ] || ylvm_die "Usage: $0 /dev/sdX  (a dedicated EMPTY disk for the pool)"
+[ -b "$DEVICE" ] || ylvm_die "$DEVICE is not a block device"
+
+# Safety: refuse to wipe a device that already has a signature/partitions.
+if blkid "$DEVICE" >/dev/null 2>&1 || lsblk -no NAME "$DEVICE" | tail -n +2 | grep -q .; then
+    ylvm_die "$DEVICE already has data/partitions ($(blkid "$DEVICE" 2>/dev/null)). Refusing. \
+If this really is the intended empty disk: wipefs -a $DEVICE (DESTRUCTIVE), then re-run."
+fi
+
+mkdir -p "$YLVM_COMPOSE_DIR/yesterday/data"
+
+if vgs "$YLVM_VG" >/dev/null 2>&1; then
+    ylvm_log "VG $YLVM_VG already exists — skipping PV/VG/pool creation."
+else
+    ylvm_log "Creating PV on $DEVICE ..."
+    pvcreate -ff -y "$DEVICE"
+    ylvm_log "Creating VG $YLVM_VG ..."
+    vgcreate "$YLVM_VG" "$DEVICE"
+    ylvm_log "Creating thin pool $YLVM_POOL (95% of VG) ..."
+    lvcreate --type thin-pool -l 95%FREE -n "$YLVM_POOL" "$YLVM_VG"
+fi
+
+# Monitor the pool so dmeventd warns before it fills (we don't auto-extend: the
+# disk is fixed-size, but the warning is the early-abort signal during prime).
+lvchange --monitor y "$YLVM_VG/$YLVM_POOL" 2>/dev/null || true
+
+create_lv() {
+    local lv="$1" vsize="$2" mnt="$3" opts="$4"
+    if lvs "$YLVM_VG/$lv" >/dev/null 2>&1; then
+        ylvm_log "LV $lv exists — skipping create/format."
+    else
+        ylvm_log "Creating thin LV $lv (virtual $vsize) + XFS ..."
+        lvcreate --thin -V "$vsize" -n "$lv" "$YLVM_VG/$YLVM_POOL"
+        mkfs.xfs -q "/dev/$YLVM_VG/$lv"
+    fi
+    mkdir -p "$mnt"
+    if ! grep -q " $mnt " /etc/fstab; then
+        echo "/dev/$YLVM_VG/$lv $mnt xfs $opts 0 0" >> /etc/fstab
+        ylvm_log "Added $mnt to /etc/fstab"
+    fi
+    mountpoint -q "$mnt" || mount "$mnt"
+}
+
+# The active datadir becomes a thin CLONE of a snapshot after the first switch,
+# and all snapshots share the origin's XFS UUID. Mount it with `nouuid` so the
+# kernel never serves stale cached data for a duplicate UUID (validated: without
+# nouuid, switches read the previous day's data). Staging is a plain LV — normal.
+create_lv "$YLVM_ACTIVE" "$ACTIVE_VSIZE" "$YLVM_ACTIVE_MNT" "defaults,nofail,nouuid"
+create_lv "$YLVM_STAGE"  "$STAGE_VSIZE"  "$YLVM_STAGE_MNT"  "defaults,nofail"
+
+echo
+ylvm_log "✅ LVM thin pool ready."
+echo "  Active datadir : $YLVM_ACTIVE_MNT  (LV $YLVM_VG/$YLVM_ACTIVE)"
+echo "  Staging area   : $YLVM_STAGE_MNT  (LV $YLVM_VG/$YLVM_STAGE)"
+echo
+lvs -o lv_name,lv_size,data_percent,pool_lv "$YLVM_VG"
+echo
+echo "Next: prime history with  sudo ./prime-backups.sh 7"
+echo "Then cut over percona to $YLVM_ACTIVE_MNT (see RUNBOOK)."

--- a/yesterday/scripts/switch-backup.sh
+++ b/yesterday/scripts/switch-backup.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# Fast switch between already-snapshotted backup days. Seconds, not hours.
+#
+#   sudo ./switch-backup.sh 20260529
+#   sudo ./switch-backup.sh --list
+#
+# Mechanism: the active datadir is a disposable, writable thin clone of the
+# chosen read-only dated snapshot. Switching = stop percona, replace the active
+# LV with a fresh clone of snap_<date>, remount, start percona, flush redis.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib-yesterday-lvm.sh
+source "$SCRIPT_DIR/lib-yesterday-lvm.sh"
+
+[ "$(id -u)" -eq 0 ] || ylvm_die "Run as root (sudo)."
+
+if [ "${1:-}" = "--list" ] || [ -z "${1:-}" ]; then
+    echo "Available backup days (newest first):"
+    ylvm_list_snapshots | sed 's/^/  /'
+    [ -z "${1:-}" ] && { echo; echo "Usage: $0 YYYYMMDD"; exit 1; }
+    exit 0
+fi
+
+DATE8="$1"
+[[ "$DATE8" =~ ^[0-9]{8}$ ]] || ylvm_die "Usage: $0 YYYYMMDD"
+SNAP="${YLVM_SNAP_PREFIX}${DATE8}"
+lvs "$YLVM_VG/$SNAP" >/dev/null 2>&1 || {
+    echo "No snapshot for $DATE8. Available:"; ylvm_list_snapshots | sed 's/^/  /'; exit 1; }
+
+PROJECT="$(ylvm_project_name)"
+cd "$YLVM_COMPOSE_DIR"
+
+ylvm_log "Switching to backup $DATE8 ..."
+ylvm_log "Stopping percona ..."
+docker compose stop percona || true
+
+if mountpoint -q "$YLVM_ACTIVE_MNT"; then
+    ylvm_log "Unmounting $YLVM_ACTIVE_MNT ..."
+    umount "$YLVM_ACTIVE_MNT"
+fi
+
+ylvm_log "Replacing active LV with a writable clone of $SNAP ..."
+lvremove -fy "$YLVM_VG/$YLVM_ACTIVE" 2>/dev/null || true
+# Writable thin snapshot of the read-only dated snapshot; -kn/-K so it activates.
+lvcreate -s -kn -n "$YLVM_ACTIVE" "$YLVM_VG/$SNAP"
+lvchange -ay -K "$YLVM_VG/$YLVM_ACTIVE"
+
+ylvm_log "Mounting $YLVM_ACTIVE_MNT ..."
+# nouuid: the clone shares the origin's XFS UUID; without it the kernel serves
+# stale cached data from a previous switch (validated).
+mount -o nouuid "/dev/$YLVM_VG/$YLVM_ACTIVE" "$YLVM_ACTIVE_MNT"
+
+ylvm_log "Starting percona ..."
+docker compose start percona
+
+# Wait for health (clean prepared datadir starts fast).
+for i in $(seq 1 60); do
+    if docker compose ps percona 2>/dev/null | grep -q "healthy"; then
+        ylvm_log "✅ percona healthy"; break
+    fi
+    sleep 2
+done
+
+# Stale Redis cache belongs to the previous day — clear it.
+ylvm_log "Flushing Redis cache ..."
+docker compose exec -T redis redis-cli FLUSHALL >/dev/null 2>&1 || true
+
+# Record what's loaded (reuses existing tracker).
+"$SCRIPT_DIR/set-current-backup.sh" "$DATE8" 2>/dev/null || true
+
+echo
+ylvm_log "✅ Switched to backup $DATE8 (project: $PROJECT)"

--- a/yesterday/scripts/switch-backup.sh
+++ b/yesterday/scripts/switch-backup.sh
@@ -51,16 +51,9 @@ ylvm_log "Mounting $YLVM_ACTIVE_MNT ..."
 # stale cached data from a previous switch (validated).
 mount -o nouuid "/dev/$YLVM_VG/$YLVM_ACTIVE" "$YLVM_ACTIVE_MNT"
 
-ylvm_log "Starting percona ..."
-docker compose start percona
-
-# Wait for health (clean prepared datadir starts fast).
-for i in $(seq 1 60); do
-    if docker compose ps percona 2>/dev/null | grep -q "healthy"; then
-        ylvm_log "✅ percona healthy"; break
-    fi
-    sleep 2
-done
+# Start percona and reset the root password (the cloned snapshot carries the
+# production password baked into the backup; the containers expect the local one).
+ylvm_reset_root_password "${YLVM_DB_PASSWORD:-iznik}"
 
 # Stale Redis cache belongs to the previous day — clear it.
 ylvm_log "Flushing Redis cache ..."

--- a/yesterday/scripts/switch-backup.sh
+++ b/yesterday/scripts/switch-backup.sh
@@ -32,6 +32,7 @@ PROJECT="$(ylvm_project_name)"
 cd "$YLVM_COMPOSE_DIR"
 
 ylvm_log "Switching to backup $DATE8 ..."
+ylvm_set_restore_status "switching" "Switching to backup $DATE8 (instant)…" "$DATE8"
 ylvm_log "Stopping percona ..."
 docker compose stop percona || true
 
@@ -61,6 +62,7 @@ docker compose exec -T redis redis-cli FLUSHALL >/dev/null 2>&1 || true
 
 # Record what's loaded (reuses existing tracker).
 "$SCRIPT_DIR/set-current-backup.sh" "$DATE8" 2>/dev/null || true
+ylvm_set_restore_status "completed" "Loaded backup $DATE8 (instant switch)" "$DATE8"
 
 echo
 ylvm_log "✅ Switched to backup $DATE8 (project: $PROJECT)"


### PR DESCRIPTION
## What

Adds an LVM-thin snapshot layer to the **Yesterday** system so switching between recent backup days takes **~1 minute** instead of a full 30–90 min restore, while keeping disk use modest (base + small daily deltas rather than N× full copies).

No production-side backup change: the existing nightly **full** Percona XtraBackup is reused. Each prepared day is applied onto the live datadir with `rsync --inplace --no-whole-file` so the thin pool copies-on-write only changed blocks; a read-only thin snapshot per day is the "datestamped database", and switching is a writable clone of that snapshot + a percona restart.

## Pieces

- `yesterday/scripts/`:
  - `setup-lvm-thin.sh` — one-time pool/LV/XFS setup on a dedicated disk
  - `prime-backups.sh` — prime the last N days into snapshots (background, zero downtime)
  - `cutover-to-lvm.sh` — point percona at the LVM datadir (`/mnt/iznik-active`)
  - `switch-backup.sh` — fast switch between snapshotted days
  - `nightly-refresh-lvm.sh` — nightly: apply latest full in place + snapshot + prune
  - `lib-yesterday-lvm.sh` — shared helpers (prepare/apply/snapshot/prune/reset-password/status/manifest)
  - `restore-monitor.sh` — routes a load request to instant-switch (snapshot exists) / LVM refresh / legacy restore
- `yesterday/docker-compose.override.yml` — `freegle_db` bound to the LVM datadir; `freegle-*` network aliases so the 2FA gateway's hardcoded upstreams resolve under this `freegledocker` project
- `yesterday/api/server.js` + `yesterday/index/index.html` — backup browser shows **⚡ Instant (~1 min)** vs **Full restore (~1–2 h)** per day, names the backup currently restoring, and locks others during a restore
- `yesterday/README.md` — runbook + sizing

## Deployed + verified on the Yesterday VM

- Primed 7 days (20260525–20260531) onto a 600 GB pd-standard pool; cutover done
- Switch verified at **~25 s** (DB content + front-end both reflect the chosen day); Freegle app renders the switched day in-browser
- Two-tier backup browser + "which backup is restoring" verified live
- Nightly path makes the most-recent backup instant automatically (no full restore on the newest day)

> Note: the changes are already live on the VM (deployed directly). Merging makes them durable there (avoids any `git reset --hard origin/master` reverting the override/scripts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)