### PR TITLE
fix(stats): restore messages_items links so Weight stats stop halving

### DIFF
--- a/iznik-batch/app/Console/Commands/Message/BackfillItemsCommand.php
+++ b/iznik-batch/app/Console/Commands/Message/BackfillItemsCommand.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace App\Console\Commands\Message;
+
+use App\Models\Message;
+use App\Services\ItemService;
+use App\Services\StatsGenerationService;
+use Carbon\CarbonImmutable;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Backfill the messages_items links that the V2 incoming-mail migration stopped
+ * creating (cutover 2026-02-04). For every OFFER/WANTED message in the date
+ * range that has no item link, parse the item from its subject and create the
+ * catalog row + link (same logic as V1 Message::save()). Optionally regenerate
+ * the affected `stats` rows so the Weight figures recover.
+ *
+ * @see App\Services\ItemService
+ * @see App\Services\StatsGenerationService
+ */
+class BackfillItemsCommand extends Command
+{
+    protected $signature = 'messages:backfill-items
+                            {--from= : Start of inclusive range (YYYY-MM-DD), matched against messages.arrival}
+                            {--to= : End of inclusive range (YYYY-MM-DD), default = today}
+                            {--chunk=1000 : Number of messages to process per batch}
+                            {--stats : After backfilling, regenerate the daily stats for each date in the range}
+                            {--dry-run : Report what would change without writing}';
+
+    protected $description = 'Backfill missing messages_items links (and optionally regenerate stats) for OFFER/WANTED messages';
+
+    public function handle(ItemService $items, StatsGenerationService $stats): int
+    {
+        $from = $this->option('from');
+        if (! $from) {
+            $this->error('--from is required (YYYY-MM-DD).');
+
+            return Command::FAILURE;
+        }
+
+        $start = CarbonImmutable::parse($from)->startOfDay();
+        $end = $this->option('to')
+            ? CarbonImmutable::parse($this->option('to'))->endOfDay()
+            : CarbonImmutable::now()->endOfDay();
+
+        $dryRun = (bool) $this->option('dry-run');
+        $chunk = max(1, (int) $this->option('chunk'));
+
+        $this->info(sprintf(
+            '%s messages_items for OFFER/WANTED messages arriving %s .. %s',
+            $dryRun ? 'Would backfill' : 'Backfilling',
+            $start->toDateString(),
+            $end->toDateString(),
+        ));
+
+        $linked = 0;
+        $noSubject = 0;
+        $scanned = 0;
+
+        DB::table('messages')
+            ->whereIn('type', [Message::TYPE_OFFER, Message::TYPE_WANTED])
+            ->where('arrival', '>=', $start)
+            ->where('arrival', '<=', $end)
+            ->whereNotExists(function ($q) {
+                $q->select(DB::raw(1))
+                    ->from('messages_items')
+                    ->whereColumn('messages_items.msgid', 'messages.id');
+            })
+            ->select('messages.id', 'messages.subject')
+            ->orderBy('messages.id')
+            ->chunkById($chunk, function ($messages) use ($items, $dryRun, &$linked, &$noSubject, &$scanned) {
+                foreach ($messages as $message) {
+                    $scanned++;
+                    $name = $items->extractItemName($message->subject ?? '');
+                    if ($name === null) {
+                        $noSubject++;
+
+                        continue;
+                    }
+
+                    if (! $dryRun) {
+                        $items->recordFromSubject($message->id, $message->subject);
+                    }
+                    $linked++;
+                }
+            }, 'id');
+
+        $this->info(sprintf(
+            'Scanned %d message(s): %d %s linked, %d skipped (no well-formed subject).',
+            $scanned,
+            $linked,
+            $dryRun ? 'would be' : 'were',
+            $noSubject,
+        ));
+
+        if (! $dryRun) {
+            Log::info('messages:backfill-items', [
+                'from' => $start->toDateString(),
+                'to' => $end->toDateString(),
+                'scanned' => $scanned,
+                'linked' => $linked,
+                'no_subject' => $noSubject,
+            ]);
+        }
+
+        if ($this->option('stats')) {
+            $this->regenerateStats($stats, $start, $end, $dryRun);
+        }
+
+        return Command::SUCCESS;
+    }
+
+    private function regenerateStats(StatsGenerationService $stats, CarbonImmutable $start, CarbonImmutable $end, bool $dryRun): void
+    {
+        $startDay = $start->startOfDay();
+        $endDay = $end->startOfDay();
+        $days = $startDay->diffInDays($endDay) + 1;
+
+        $this->info(sprintf(
+            '%s stats for %d date(s) %s .. %s',
+            $dryRun ? 'Would regenerate' : 'Regenerating',
+            $days,
+            $startDay->toDateString(),
+            $endDay->toDateString(),
+        ));
+
+        for ($d = $startDay; $d->lte($endDay); $d = $d->addDay()) {
+            $date = $d->toDateString();
+            $result = $stats->generateForAllGroups($date, $dryRun);
+            $this->line(sprintf(
+                '  %s: %d groups, %d rows %s',
+                $date,
+                $result['groups'],
+                $result['rows_written'],
+                $dryRun ? 'would be written' : 'written',
+            ));
+        }
+    }
+}

--- a/iznik-batch/app/Services/ItemService.php
+++ b/iznik-batch/app/Services/ItemService.php
@@ -1,0 +1,196 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Item catalog helper: find-or-create item rows, link them to messages, and
+ * estimate weights. Ported from V1 iznik-server include/message/Item.php
+ * (create/estimateWeight) and the item-extraction in Message::save().
+ *
+ * Both the incoming-mail path and the messages:backfill-items command use this
+ * so that every OFFER/WANTED message has a messages_items row — without it the
+ * Weight stat's INNER JOIN messages_items silently drops the message.
+ */
+class ItemService
+{
+    /** Matches V1 Item::MAX_ITEM_NAME_LENGTH. */
+    public const MAX_ITEM_NAME_LENGTH = 60;
+
+    /** Memoised standard weights so a batch backfill scans the table once. */
+    private ?array $weights = null;
+
+    /**
+     * Extract the item name from a well-formed "TYPE: item (location)" subject.
+     * Mirrors the regex V1 Message::save() used to decide whether to record an item.
+     */
+    public function extractItemName(string $subject): ?string
+    {
+        if (preg_match('/.*?\:(.*)\(.*\)/', $subject, $matches)) {
+            $name = trim($matches[1]);
+
+            return $name !== '' ? $name : null;
+        }
+
+        return null;
+    }
+
+    /**
+     * Find or create the catalog row for $name, returning its id (null for an
+     * empty name). The `name` unique index is case-insensitive, so the
+     * LAST_INSERT_ID() upsert returns the existing id on a case-only difference
+     * — exactly as V1 Item::create() did. A freshly-created item gets a weight
+     * estimate; existing rows keep their weight.
+     */
+    public function findOrCreate(string $name): ?int
+    {
+        $name = trim($name);
+        if ($name === '') {
+            return null;
+        }
+
+        if (mb_strlen($name) > self::MAX_ITEM_NAME_LENGTH) {
+            $name = mb_substr($name, 0, self::MAX_ITEM_NAME_LENGTH);
+        }
+
+        DB::statement(
+            'INSERT INTO items (name) VALUES (?) ON DUPLICATE KEY UPDATE id = LAST_INSERT_ID(id), name = ?',
+            [$name, $name]
+        );
+        $id = (int) DB::getPdo()->lastInsertId();
+        if ($id <= 0) {
+            return null;
+        }
+
+        // Only estimate when the row has no weight yet (new item, or an old one
+        // we've never weighed). Avoids reweighing established catalog entries.
+        $current = DB::table('items')->where('id', $id)->value('weight');
+        if ($current === null) {
+            $weight = $this->estimateWeight($name);
+            if ($weight !== null) {
+                DB::table('items')->where('id', $id)->update(['weight' => $weight]);
+            }
+        }
+
+        return $id;
+    }
+
+    /**
+     * Link a message to an item. Idempotent (INSERT IGNORE on the composite key),
+     * matching V1 Message::addItem().
+     */
+    public function linkToMessage(int $msgid, int $itemid): void
+    {
+        DB::statement(
+            'INSERT IGNORE INTO messages_items (msgid, itemid) VALUES (?, ?)',
+            [$msgid, $itemid]
+        );
+    }
+
+    /**
+     * Convenience: extract the item from a subject, find/create it, and link it
+     * to the message. Returns the item id, or null if the subject is not a
+     * well-formed OFFER/WANTED subject.
+     */
+    public function recordFromSubject(int $msgid, string $subject): ?int
+    {
+        $name = $this->extractItemName($subject);
+        if ($name === null) {
+            return null;
+        }
+
+        $itemid = $this->findOrCreate($name);
+        if ($itemid === null) {
+            return null;
+        }
+
+        $this->linkToMessage($msgid, $itemid);
+
+        return $itemid;
+    }
+
+    /**
+     * Estimate an item's weight from the standard `weights` table, picking the
+     * entry with the most words in common. Returns null when nothing is a good
+     * enough match (V1 threshold: words-in-common > 10%). Ported from
+     * V1 Item::estimateWeight().
+     */
+    public function estimateWeight(string $name): ?float
+    {
+        $bestWeight = null;
+        $bestWic = null;
+
+        foreach ($this->standardWeights() as $weight) {
+            $wic = $this->wordsInCommon($name, $weight['name']);
+            if ($bestWic === null || $wic > $bestWic) {
+                $bestWic = $wic;
+                $bestWeight = $weight['weight'];
+            }
+        }
+
+        return ($bestWic !== null && $bestWic > 10) ? (float) $bestWeight : null;
+    }
+
+    /**
+     * @return array<int,array{name:string,weight:float}>
+     */
+    private function standardWeights(): array
+    {
+        if ($this->weights === null) {
+            $this->weights = DB::table('weights')
+                ->selectRaw('CASE WHEN simplename IS NOT NULL THEN simplename ELSE name END AS name, weight')
+                ->get()
+                ->map(fn ($row) => ['name' => (string) $row->name, 'weight' => (float) $row->weight])
+                ->all();
+        }
+
+        return $this->weights;
+    }
+
+    // --- Word-similarity helpers, ported verbatim from V1 Utils ---
+
+    private function wordsInCommon(string $sentence1, string $sentence2): float
+    {
+        $words1 = $this->canonSentence($sentence1);
+        $words2 = $this->canonSentence($sentence2);
+
+        $ret = 0;
+        foreach ($words1 as $w1) {
+            foreach ($words2 as $w2) {
+                if ($w1 === $w2) {
+                    $ret++;
+                }
+            }
+        }
+
+        $limit = max(count($words1), count($words2));
+
+        return $limit === 1 ? 0 : (100 * $ret / $limit);
+    }
+
+    /**
+     * @return array<int,string>
+     */
+    private function canonSentence(string $sentence): array
+    {
+        $words = preg_split('/\s+/', $sentence) ?: [];
+        $canon = array_map(fn ($w) => $this->canonWord($w), $words);
+
+        return array_values(array_unique($canon));
+    }
+
+    private function canonWord(string $word): string
+    {
+        $word = strtolower($word);
+        $word = preg_replace('/[^\da-z]/i', '', $word) ?? '';
+
+        if (strlen($word) > 3) {
+            $arr = str_split($word);
+            sort($arr);
+            $word = implode('', $arr);
+        }
+
+        return $word;
+    }
+}

--- a/iznik-batch/app/Services/Mail/Incoming/IncomingMailService.php
+++ b/iznik-batch/app/Services/Mail/Incoming/IncomingMailService.php
@@ -12,6 +12,7 @@ use App\Models\Message;
 use App\Models\MessageGroup;
 use App\Models\User;
 use App\Models\UserEmail;
+use App\Services\ItemService;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
@@ -45,6 +46,8 @@ class IncomingMailService
 
     private BounceService $bounceService;
 
+    private ItemService $itemService;
+
     /**
      * Context from the last routing decision (group name, user id, etc.).
      * Set during route() and read by controllers for logging.
@@ -54,11 +57,13 @@ class IncomingMailService
     public function __construct(
         ?SpamCheckService $spamCheck = null,
         ?StripQuotedService $stripQuoted = null,
-        ?BounceService $bounceService = null
+        ?BounceService $bounceService = null,
+        ?ItemService $itemService = null
     ) {
         $this->spamCheck = $spamCheck ?? app(SpamCheckService::class);
         $this->stripQuoted = $stripQuoted ?? new StripQuotedService;
         $this->bounceService = $bounceService ?? new BounceService;
+        $this->itemService = $itemService ?? new ItemService;
     }
 
     /**
@@ -2719,6 +2724,12 @@ class IncomingMailService
                 'collection' => $collection,
                 'arrival' => now(),
             ]);
+
+            // Record the item from a well-formed "TYPE: item (location)" subject,
+            // exactly as V1 Message::save() did. The messages_items link is what
+            // the Weight stat's INNER JOIN relies on — without it, items given
+            // away via email (e.g. TrashNothing posts) contribute zero weight.
+            $this->itemService->recordFromSubject($message->id, $email->subject ?? '');
 
             // Add to message history for spam checking
             DB::table('messages_history')->insert([

--- a/iznik-batch/docs/weight-stats-item-backfill.md
+++ b/iznik-batch/docs/weight-stats-item-backfill.md
@@ -1,0 +1,87 @@
+# Weight stats drop (Feb 2026) — missing `messages_items` links
+
+## Symptom
+
+The `/stats` page "Weights" chart shows the monthly diverted-weight figure roughly
+halving from **February 2026** onwards (~1,000,000 kg/month → ~450,000 kg/month),
+and continuing to drift down. Item **volume** (the Outcomes figure) is unchanged.
+
+## Root cause
+
+The Weight stat is computed by `StatsGenerationService` (V1: `iznik-server`
+`Stats::generate()`), which sums `items.weight` over the items linked to each
+taken/received message:
+
+```
+messages_outcomes
+  JOIN messages_groups
+  JOIN messages
+  JOIN messages_items      <-- INNER JOIN: a message with no item link is dropped
+  LEFT JOIN items
+WHERE outcome IN ('Taken','Received')
+```
+
+Because that join to `messages_items` is an **inner** join, any taken message
+with no `messages_items` row contributes **0 kg** while still counting as an
+Outcome.
+
+When incoming-email processing was migrated from V1 (`iznik-server`
+`Message::save()`) to V2 (`iznik-batch` `IncomingMailService`), the item-extraction
+step was not ported. V1, after inserting a message, parsed a well-formed
+`TYPE: item (location)` subject, found/created the `items` catalog row and wrote
+a `messages_items` link. `IncomingMailService::createGroupPostMessage()` created
+the message and `messages_groups` row but **never created the item link**.
+
+Posts that arrive by email — chiefly **TrashNothing** posts (`sourceheader`
+`TN-native-app` / `TN-web-app`), which are ~half of all OFFER/WANTED posts — went
+through this path. Posts from the Freegle app/web (`source = Platform`) were
+unaffected and kept ~100% item coverage.
+
+### Evidence (production)
+
+Item-link coverage of taken messages by month:
+
+| Month   | taken msgs | with `messages_items` | %     |
+|---------|-----------:|----------------------:|------:|
+| 2026-01 |     29,371 |                29,364 | 100%  |
+| 2026-02 |     25,020 |                17,015 | 68%   |
+| 2026-05 |     30,783 |                15,337 | 49.8% |
+
+Exact cutover: **2026-02-04** (100% on 2026-02-03 → 65% on 2026-02-04).
+
+## Fix (forward)
+
+`IncomingMailService::createGroupPostMessage()` now calls
+`ItemService::recordFromSubject()` immediately after creating the message and
+`messages_groups` row, restoring V1 parity. `App\Services\ItemService` ports V1's
+`Item::create()` (case-insensitive find-or-create + weight estimate from the
+`weights` table) and `Message::addItem()` (idempotent `messages_items` link).
+
+## Backfill (historical repair)
+
+`messages:backfill-items` rebuilds the missing links for OFFER/WANTED messages in
+a date range (by `messages.arrival`) and can regenerate the affected `stats` rows.
+
+```bash
+# Dry run first — see how many messages would be linked.
+php artisan messages:backfill-items --from=2026-02-04 --dry-run
+
+# Backfill the links, then regenerate the daily stats for the same range.
+php artisan messages:backfill-items --from=2026-02-04 --stats
+```
+
+Notes:
+
+- Only messages with **no** existing `messages_items` row are touched; messages
+  that already have items (e.g. Platform posts) are skipped.
+- Messages whose subject is not a well-formed `TYPE: item (location)` are counted
+  as "skipped (no well-formed subject)" and left alone.
+- `--stats` regenerates **all** stat types for **every group** for each date in
+  the range (mirrors `stats:generate-daily`), so for a multi-month repair it is
+  cheaper to run a month at a time:
+
+  ```bash
+  for m in 2026-02 2026-03 2026-04 2026-05; do
+    php artisan messages:backfill-items --from=${m}-01 --to=${m}-31 --stats
+  done
+  ```

--- a/iznik-batch/tests/Feature/Message/BackfillItemsCommandTest.php
+++ b/iznik-batch/tests/Feature/Message/BackfillItemsCommandTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Tests\Feature\Message;
+
+use App\Models\Message;
+use App\Services\StatsGenerationService;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+/**
+ * The backfill command reconstructs the messages_items links that the V2
+ * incoming-mail migration stopped creating (cutover 2026-02-04), and then
+ * regenerates the affected `stats` rows so the Weight figures recover.
+ */
+class BackfillItemsCommandTest extends TestCase
+{
+    private function seedTakenOfferWithoutItem(string $subject, string $date): Message
+    {
+        $group = $this->createTestGroup();
+        $user = $this->createTestUser();
+        $message = $this->createTestMessage($user, $group, [
+            'type' => Message::TYPE_OFFER,
+            'subject' => $subject,
+            'source' => Message::SOURCE_EMAIL,
+            'sourceheader' => 'TN-native-app',
+            'arrival' => $date.' 09:00:00',
+        ]);
+        DB::table('messages_outcomes')->insert([
+            'msgid' => $message->id,
+            'userid' => $user->id,
+            'outcome' => Message::OUTCOME_TAKEN,
+            'timestamp' => $date.' 12:00:00',
+        ]);
+
+        // No messages_items row — this is the bug state.
+        $this->assertSame(0, DB::table('messages_items')->where('msgid', $message->id)->count());
+
+        return $message;
+    }
+
+    public function test_backfills_missing_messages_items_link(): void
+    {
+        $message = $this->seedTakenOfferWithoutItem('OFFER: Vintage Oak Table (Bristol BS1)', '2026-02-10');
+
+        $this->artisan('messages:backfill-items', [
+            '--from' => '2026-02-01',
+            '--to' => '2026-02-28',
+        ])->assertSuccessful();
+
+        $link = DB::table('messages_items')->where('msgid', $message->id)->first();
+        $this->assertNotNull($link, 'backfill should create the messages_items link');
+        $this->assertSame('Vintage Oak Table', DB::table('items')->where('id', $link->itemid)->value('name'));
+    }
+
+    public function test_dry_run_writes_nothing(): void
+    {
+        $message = $this->seedTakenOfferWithoutItem('OFFER: Dry Run Item (Bristol BS1)', '2026-02-10');
+
+        $this->artisan('messages:backfill-items', [
+            '--from' => '2026-02-01',
+            '--to' => '2026-02-28',
+            '--dry-run' => true,
+        ])->assertSuccessful();
+
+        $this->assertSame(0, DB::table('messages_items')->where('msgid', $message->id)->count());
+    }
+
+    public function test_skips_messages_that_already_have_items(): void
+    {
+        $message = $this->seedTakenOfferWithoutItem('OFFER: Already Linked (Bristol BS1)', '2026-02-10');
+        $itemid = DB::table('items')->insertGetId(['name' => 'Pre Existing Item']);
+        DB::table('messages_items')->insert(['msgid' => $message->id, 'itemid' => $itemid]);
+
+        $this->artisan('messages:backfill-items', [
+            '--from' => '2026-02-01',
+            '--to' => '2026-02-28',
+        ])->assertSuccessful();
+
+        // The original link is untouched; no second item was added from the subject.
+        $items = DB::table('messages_items')->where('msgid', $message->id)->pluck('itemid')->all();
+        $this->assertSame([$itemid], $items);
+    }
+
+    public function test_regenerates_weight_stats_with_stats_flag(): void
+    {
+        DB::table('weights')->insert(['name' => 'table', 'simplename' => null, 'weight' => 30.00]);
+        $message = $this->seedTakenOfferWithoutItem('OFFER: Vintage Oak Table (Bristol BS1)', '2026-02-10');
+        $groupId = DB::table('messages_groups')->where('msgid', $message->id)->value('groupid');
+
+        $this->artisan('messages:backfill-items', [
+            '--from' => '2026-02-01',
+            '--to' => '2026-02-28',
+            '--stats' => true,
+        ])->assertSuccessful();
+
+        $weightRow = DB::table('stats')
+            ->where('date', '2026-02-10')
+            ->where('groupid', $groupId)
+            ->where('type', StatsGenerationService::TYPE_WEIGHT)
+            ->first();
+        $this->assertNotNull($weightRow, 'Weight stat should be regenerated for the affected date');
+        $this->assertEquals(30, $weightRow->count);
+    }
+}

--- a/iznik-batch/tests/Unit/Services/ItemServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/ItemServiceTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Services\ItemService;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+/**
+ * Covers item catalog find-or-create + message linking + weight estimation,
+ * ported from V1 iznik-server Item::create()/estimateWeight() and the
+ * Message::save() item-extraction regex. This is the building block the
+ * incoming-mail path and the backfill command both use to populate
+ * messages_items so the Weight stat can find items moved.
+ */
+class ItemServiceTest extends TestCase
+{
+    private ItemService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new ItemService();
+    }
+
+    public function test_extracts_item_name_from_well_formed_subject(): void
+    {
+        $this->assertSame('Big Red Sofa', $this->service->extractItemName('OFFER: Big Red Sofa (London)'));
+        $this->assertSame('Bike', $this->service->extractItemName('WANTED: Bike (Edinburgh EH1)'));
+    }
+
+    public function test_extracts_item_name_returns_null_for_malformed_subject(): void
+    {
+        $this->assertNull($this->service->extractItemName('Re: a chat reply with no item'));
+        $this->assertNull($this->service->extractItemName('OFFER: no parens here'));
+        $this->assertNull($this->service->extractItemName('OFFER:  (London)'));
+    }
+
+    public function test_find_or_create_returns_null_for_empty_name(): void
+    {
+        $this->assertNull($this->service->findOrCreate(''));
+        $this->assertNull($this->service->findOrCreate('   '));
+    }
+
+    public function test_find_or_create_is_idempotent_and_case_insensitive(): void
+    {
+        $id1 = $this->service->findOrCreate('Wooden Chair');
+        $this->assertNotNull($id1);
+
+        // Same name, different case -> same catalog row (name index is case-insensitive).
+        $id2 = $this->service->findOrCreate('wooden chair');
+        $this->assertSame($id1, $id2);
+
+        $this->assertSame(1, DB::table('items')->where('name', 'Wooden Chair')->count());
+    }
+
+    public function test_find_or_create_truncates_long_names(): void
+    {
+        $long = str_repeat('a', 100);
+        $id = $this->service->findOrCreate($long);
+        $name = DB::table('items')->where('id', $id)->value('name');
+        $this->assertSame(60, strlen($name));
+    }
+
+    public function test_find_or_create_estimates_weight_from_weights_table(): void
+    {
+        DB::table('weights')->insert(['name' => 'sofa', 'simplename' => null, 'weight' => 40.00]);
+
+        $id = $this->service->findOrCreate('Big Comfy Sofa');
+
+        $weight = DB::table('items')->where('id', $id)->value('weight');
+        $this->assertNotNull($weight);
+        $this->assertEquals(40.00, (float) $weight);
+    }
+
+    public function test_find_or_create_leaves_weight_null_when_no_match(): void
+    {
+        DB::table('weights')->insert(['name' => 'sofa', 'simplename' => null, 'weight' => 40.00]);
+
+        $id = $this->service->findOrCreate('Xylophone');
+
+        $this->assertNull(DB::table('items')->where('id', $id)->value('weight'));
+    }
+
+    public function test_link_to_message_is_idempotent(): void
+    {
+        // messages_items has a FK to messages, so we need a real message row.
+        $message = $this->createTestMessage($this->createTestUser(), $this->createTestGroup());
+        $itemid = $this->service->findOrCreate('Lamp');
+
+        $this->service->linkToMessage($message->id, $itemid);
+        $this->service->linkToMessage($message->id, $itemid);
+
+        $this->assertSame(1, DB::table('messages_items')
+            ->where('msgid', $message->id)->where('itemid', $itemid)->count());
+    }
+
+    public function test_record_from_subject_creates_item_and_link(): void
+    {
+        $message = $this->createTestMessage($this->createTestUser(), $this->createTestGroup());
+
+        $itemid = $this->service->recordFromSubject($message->id, 'OFFER: Garden Spade (Leeds LS1)');
+
+        $this->assertNotNull($itemid);
+        $this->assertSame('Garden Spade', DB::table('items')->where('id', $itemid)->value('name'));
+        $this->assertSame(1, DB::table('messages_items')
+            ->where('msgid', $message->id)->where('itemid', $itemid)->count());
+    }
+
+    public function test_record_from_subject_returns_null_for_malformed_subject(): void
+    {
+        $message = $this->createTestMessage($this->createTestUser(), $this->createTestGroup());
+
+        $this->assertNull($this->service->recordFromSubject($message->id, 'just a plain subject'));
+        $this->assertSame(0, DB::table('messages_items')->where('msgid', $message->id)->count());
+    }
+}

--- a/iznik-batch/tests/Unit/Services/Mail/Incoming/IncomingMailItemLinkTest.php
+++ b/iznik-batch/tests/Unit/Services/Mail/Incoming/IncomingMailItemLinkTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Tests\Unit\Services\Mail\Incoming;
+
+use App\Services\Mail\Incoming\IncomingMailService;
+use App\Services\Mail\Incoming\MailParserService;
+use App\Services\Mail\Incoming\RoutingResult;
+use Illuminate\Support\Facades\DB;
+use Tests\Support\EmailFixtures;
+use Tests\TestCase;
+
+/**
+ * Regression test for the weight-stats bug: incoming group posts (e.g. the
+ * TrashNothing posts that arrive by email) must create a messages_items link,
+ * exactly as V1 Message::save() did. Without it, the Weight stat's
+ * INNER JOIN messages_items drops the message and reports zero kg even though
+ * the item was given away.
+ *
+ * @see https://github.com/Freegle/iznik-server include/message/Message.php (item-extraction on save)
+ */
+class IncomingMailItemLinkTest extends TestCase
+{
+    use EmailFixtures;
+
+    private IncomingMailService $service;
+
+    private MailParserService $parser;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->parser = app(MailParserService::class);
+        $this->service = app(IncomingMailService::class);
+    }
+
+    private function createLocation(float $lat, float $lng): int
+    {
+        return DB::table('locations')->insertGetId([
+            'name' => 'Test Location '.uniqid(),
+            'type' => 'Polygon',
+            'lat' => $lat,
+            'lng' => $lng,
+        ]);
+    }
+
+    public function test_group_post_creates_messages_items_link(): void
+    {
+        $group = $this->createTestGroup();
+        $user = $this->createTestUser(['email_preferred' => $this->uniqueEmail('member')]);
+        $this->createMembership($user, $group, ['ourPostingStatus' => 'DEFAULT']);
+        DB::table('users')->where('id', $user->id)->update([
+            'lastlocation' => $this->createLocation(51.5, -0.1),
+        ]);
+
+        $userEmail = $user->emails->first()->email;
+        $to = $group->nameshort.'@groups.ilovefreegle.org';
+
+        $email = $this->createMinimalEmail([
+            'From' => $userEmail,
+            'To' => $to,
+            'Subject' => 'OFFER: Distinctive Velvet Armchair (London)',
+        ], 'Free, collection only.');
+
+        $parsed = $this->parser->parse($email, $userEmail, $to);
+        $result = $this->service->route($parsed);
+
+        $this->assertEquals(RoutingResult::APPROVED, $result);
+
+        $msg = DB::table('messages')
+            ->where('subject', 'OFFER: Distinctive Velvet Armchair (London)')
+            ->orderByDesc('id')
+            ->first();
+        $this->assertNotNull($msg, 'group post message should be created');
+
+        $link = DB::table('messages_items')->where('msgid', $msg->id)->first();
+        $this->assertNotNull($link, 'group post must create a messages_items link for weight stats');
+
+        $itemName = DB::table('items')->where('id', $link->itemid)->value('name');
+        $this->assertSame('Distinctive Velvet Armchair', $itemName);
+    }
+}


### PR DESCRIPTION
## Problem

The `/stats` **Weights** chart roughly halves from **February 2026** onwards (~1,000,000 → ~450,000 kg/month) and keeps drifting down, while item **volume (Outcomes) is unchanged**.

## Root cause (confirmed against live production data)

Not a stats-calculation bug. The Weight stat (`StatsGenerationService`, V1 `Stats::generate()`) sums `items.weight` over each taken/received message via an **`INNER JOIN messages_items`** — so any taken message with no `messages_items` row contributes **0 kg** but still counts as an Outcome.

When incoming-email processing was migrated from V1 (`iznik-server` `Message::save()`) to V2 (`iznik-batch` `IncomingMailService`), the item-extraction step was not ported. V1, after inserting a message, parsed a well-formed `TYPE: item (location)` subject, found/created the `items` row and wrote the `messages_items` link. `IncomingMailService::createGroupPostMessage()` created the message + `messages_groups` row but never created the item link.

Posts arriving by email — chiefly **TrashNothing** (`source=Email`, `sourceheader` `TN-native-app`/`TN-web-app`), ~half of all OFFER/WANTED posts — lost their item links. Freegle app/web posts (`source=Platform`) were unaffected.

### Evidence

Item-link coverage of taken messages by month (production):

| Month   | taken msgs | with `messages_items` | %     |
|---------|-----------:|----------------------:|------:|
| 2026-01 |     29,371 |                29,364 | 100%  |
| 2026-02 |     25,020 |                17,015 | 68%   |
| 2026-05 |     30,783 |                15,337 | 49.8% |

Exact cutover: **2026-02-04** (100% on 02-03 → 65% on 02-04). kg-per-item collapsed 27.0 → 14.6 with item volume flat.

## Changes

- **`app/Services/ItemService.php`** (new) — ports V1 `Item::create`/`addItem`/`estimateWeight`: case-insensitive find-or-create, idempotent `messages_items` link, weight estimate from the `weights` table.
- **`IncomingMailService::createGroupPostMessage()`** — links the item on group-post creation, restoring V1 parity (the forward fix).
- **`messages:backfill-items`** (new command) — rebuilds missing links for OFFER/WANTED messages in a date range and optionally regenerates the affected `stats` rows.
- Unit/Feature tests for all three; runbook in `docs/weight-stats-item-backfill.md`.

## Testing

Full Laravel **Unit+Feature suite: 3922 passed**, 0 failures (run via the worktree status API). 15 new tests cover the service, the incoming-mail link, and the backfill command (links + dry-run + skip-existing + stats regeneration).

## Production repair (after merge)

```bash
php artisan messages:backfill-items --from=2026-02-04 --dry-run   # preview
php artisan messages:backfill-items --from=2026-02-04 --stats     # rebuild links + regenerate stats
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)