### PR TITLE
fix(modtools-log-history): discard stale in-flight log fetches on community filter change

### DIFF
--- a/iznik-nuxt3/modtools/stores/logs.js
+++ b/iznik-nuxt3/modtools/stores/logs.js
@@ -12,6 +12,11 @@ export const useLogsStore = defineStore({
     list: [],
     context: null,
     params: null,
+    // Stale-fetch guard: incremented by clear() so any in-flight fetch that
+    // resolves after a clear() can detect it was overtaken and discard its
+    // result. Prevents duplicate/missing/out-of-order entries when the user
+    // changes the community filter mid-flight (Discourse #9672).
+    instance: 1,
   }),
   actions: {
     init(config) {
@@ -20,8 +25,10 @@ export const useLogsStore = defineStore({
     clear() {
       this.list = []
       this.context = null
+      this.instance++
     },
     async fetch(params) {
+      const instance = this.instance
       let ret = null
       delete params.context
       if (this.context?.id) {
@@ -29,6 +36,12 @@ export const useLogsStore = defineStore({
         params.context = this.context.id
       }
       const data = await api(this.config).logs.fetch(params)
+
+      if (this.instance !== instance) {
+        // clear() was called while this fetch was in-flight (user changed
+        // community filter); discard the stale result entirely.
+        return null
+      }
 
       let logs = []
 

--- a/iznik-nuxt3/tests/unit/stores/logs.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/logs.spec.js
@@ -307,4 +307,45 @@ describe('logs store', () => {
     expect(logsForUser10.map((l) => l.id)).toEqual([100, 101])
     expect(logsForUser20.map((l) => l.id)).toEqual([200, 201])
   })
+
+  it('community filter change must not allow stale in-flight fetch to persist — AssertFlip Step 2: stale result is discarded after clear()', async () => {
+    // Reproduces Discourse #9672: when the user changes the community filter,
+    // clear() is called but an in-flight fetch (started for the OLD groupid)
+    // still resolves and pushes its results into the freshly-cleared store.
+    // This produces duplicates, missing entries, and wrong ordering.
+    //
+    // AssertFlip Step 2 (correct behaviour, FAILS before fix, PASSES after):
+    // After clear(), any in-flight fetch that resolves must be silently discarded —
+    // list must remain empty and context must remain null.
+    const store = useLogsStore()
+    store.init({})
+
+    // Arrange: a fetch for groupid=5 is in-flight (hasn't resolved yet).
+    let resolveOldFetch
+    mockLogsFetch.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveOldFetch = resolve
+        })
+    )
+    const staleFetch = store.fetch({ groupid: 5, logtype: 'messages' })
+
+    // User switches to a different community → clear() is called.
+    store.clear()
+
+    // Old fetch resolves with group-5 logs AFTER the clear.
+    resolveOldFetch({
+      logs: [
+        { id: 10, groupid: 5 },
+        { id: 11, groupid: 5 },
+        { id: 12, groupid: 5 },
+      ],
+      context: { id: 10 },
+    })
+    await staleFetch
+
+    // Correct: stale results must be discarded.
+    expect(store.list).toHaveLength(0)
+    expect(store.context).toBeNull()
+  })
 })


### PR DESCRIPTION
## Root Cause

`fetch()` in `modtools/stores/logs.js` had no stale-check. When the user changes the community filter, `clear()` empties the list and resets the context, but any in-flight fetch started for the **previous** community/groupid continues to resolve and pushes its results into the freshly-cleared store. This produces:

- **Duplicates**: logs from the old community pollute the new community's view
- **Missing entries**: the old fetch's context overwrites the correct pagination cursor, causing subsequent pages to skip legitimate entries
- **Wrong order**: IDs from the stale fetch interleave with the new fetch's results breaking the DESC sort

The same bug can also occur when the user clears the filter (groupid → null), in which case a stale in-flight filtered fetch brings back the wrong subset.

Note: the original diagnosis for #9672 post 1 pointed at a backend JOIN fan-out, but the Go API query is correct (1:1 `LEFT JOIN messages ON messages.id = logs.msgid`, no cartesian product). The real fix is frontend-only.

## Evidence

```
× logs store > community filter change must not allow stale in-flight fetch to persist
  — AssertFlip Step 2: stale result is discarded after clear()
  → expected [ { id: 10, groupid: 5 }, …(2) ] to have a length of +0 but got 3
```

This failure occurs on the **unfixed** code: when `clear()` is called mid-flight, `fetch()` has no stale-check, so the old groupid's response still pushes 3 entries into the now-empty list.

## Fix

Added a stale-fetch guard using the same `instance` counter pattern already in use in `modtools/stores/spammer.js`:

- `state`: add `instance: 1`
- `clear()`: increment `this.instance`
- `fetch()`: capture `const instance = this.instance` before the `await`; after the response arrives, if `this.instance !== instance`, return `null` without touching `list` or `context`

## Other Call Sites

- `spammer.js`: already has the correct `instance` guard (increments in `clear()`) — no change needed
- `member.js`: has a non-incrementing version (`this.instance = 1` in `clear()`) that does not actually protect — pre-existing defect, out of scope
- `alert.js`, `admins.js`, `comment.js`: use object dictionaries (key assignment is idempotent — no push race) — no guard needed

## Test

File: `iznik-nuxt3/tests/unit/stores/logs.spec.js`

AssertFlip Step 2: after `clear()`, an in-flight fetch that resolves must be silently discarded — `store.list` remains empty, `store.context` remains `null`.

- **Before fix**: test FAILS (`list` has 3 stale entries)
- **After fix**: test PASSES
- Full Vitest suite: 590 files, 12824 tests passed (2 pre-existing errors in `ModtoolsDefaultLayout.spec.js`, unrelated)

## Discourse
https://discourse.ilovefreegle.org/t/9672/2