### PR TITLE
fix(member-management): Unsubscribe button in Support tools not removing member or logging

### DIFF
--- a/iznik-server-go/test/user_test.go
+++ b/iznik-server-go/test/user_test.go
@@ -1814,6 +1814,79 @@ func TestPostUserUnbounceNotAdmin(t *testing.T) {
 	assert.Equal(t, fiber.StatusForbidden, resp.StatusCode)
 }
 
+// TestPostUserUnsubscribeBySupportRemovesMembership verifies that a Support user clicking
+// "Unsubscribe" in the Support tools removes the target user's memberships and marks their
+// account as deleted (limbo). Regression: POST /user action=Unsubscribe was missing from
+// PostUser's switch, returning "Unknown action" so nothing happened (Discourse #9738 post 1).
+func TestPostUserUnsubscribeBySupportRemovesMembership(t *testing.T) {
+	prefix := uniquePrefix("unsub_support")
+	db := database.DBConn
+
+	supportID := CreateTestUser(t, prefix+"_support", "Support")
+	targetID := CreateTestUser(t, prefix+"_target", "User")
+	groupID := CreateTestGroup(t, prefix)
+	CreateTestMembership(t, targetID, groupID, "Member")
+	_, supportToken := CreateTestSession(t, supportID)
+
+	// Verify member exists before unsubscribe.
+	var memberBefore int64
+	db.Raw("SELECT COUNT(*) FROM memberships WHERE userid = ? AND groupid = ? AND collection = 'Approved'",
+		targetID, groupID).Scan(&memberBefore)
+	assert.Equal(t, int64(1), memberBefore, "setup: target must be a member before unsubscribe")
+
+	payload := map[string]interface{}{
+		"action": "Unsubscribe",
+		"id":     targetID,
+	}
+	s, _ := json.Marshal(payload)
+	request := httptest.NewRequest("POST", "/api/user?jwt="+supportToken, bytes.NewBuffer(s))
+	request.Header.Set("Content-Type", "application/json")
+	resp, err := getApp().Test(request)
+	assert.NoError(t, err)
+	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+
+	var result map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&result)
+	assert.Equal(t, float64(0), result["ret"])
+
+	// Membership must be removed.
+	var memberAfter int64
+	db.Raw("SELECT COUNT(*) FROM memberships WHERE userid = ? AND groupid = ? AND collection = 'Approved'",
+		targetID, groupID).Scan(&memberAfter)
+	assert.Equal(t, int64(0), memberAfter, "Unsubscribe must remove the approved membership")
+
+	// User account must be in limbo (deleted set).
+	var deleted *string
+	db.Raw("SELECT deleted FROM users WHERE id = ?", targetID).Scan(&deleted)
+	assert.NotNil(t, deleted, "Unsubscribe must mark the user account as deleted (limbo)")
+
+	// A log entry must exist for the unsubscribe.
+	var logCount int64
+	db.Raw("SELECT COUNT(*) FROM logs WHERE type = 'User' AND subtype = 'Deleted' AND user = ? AND byuser = ?",
+		targetID, supportID).Scan(&logCount)
+	assert.Equal(t, int64(1), logCount, "Unsubscribe must create a User/Deleted log entry")
+}
+
+// TestPostUserUnsubscribeNonSupportForbidden verifies that a regular user cannot unsubscribe
+// another user via POST /user action=Unsubscribe.
+func TestPostUserUnsubscribeNonSupportForbidden(t *testing.T) {
+	prefix := uniquePrefix("unsub_noperm")
+	callerID := CreateTestUser(t, prefix+"_caller", "User")
+	targetID := CreateTestUser(t, prefix+"_target", "User")
+	_, callerToken := CreateTestSession(t, callerID)
+
+	payload := map[string]interface{}{
+		"action": "Unsubscribe",
+		"id":     targetID,
+	}
+	s, _ := json.Marshal(payload)
+	request := httptest.NewRequest("POST", "/api/user?jwt="+callerToken, bytes.NewBuffer(s))
+	request.Header.Set("Content-Type", "application/json")
+	resp, err := getApp().Test(request)
+	assert.NoError(t, err)
+	assert.Equal(t, fiber.StatusForbidden, resp.StatusCode)
+}
+
 func TestPostUserMerge(t *testing.T) {
 	prefix := uniquePrefix("merge")
 	db := database.DBConn

--- a/iznik-server-go/user/user.go
+++ b/iznik-server-go/user/user.go
@@ -1547,6 +1547,8 @@ func PostUser(c *fiber.Ctx) error {
 		return handleRemoveEmail(c, db, myid, req)
 	case "Unbounce":
 		return handleUnbounce(c, myid, req)
+	case "Unsubscribe":
+		return handleUserUnsubscribe(c, myid, req)
 	case "Merge":
 		return handleMerge(c, myid, req)
 	default:
@@ -2327,6 +2329,35 @@ func handleUnbounce(c *fiber.Ctx, myid uint64, req UserPostRequest) error {
 	}
 
 	db.Exec("UPDATE users SET bouncing = 0 WHERE id = ?", req.ID)
+
+	return c.JSON(fiber.Map{"ret": 0, "status": "Success"})
+}
+
+// handleUserUnsubscribe puts a target user into limbo (14-day soft-delete) and removes their
+// approved memberships. V1 parity: POST /user action=Unsubscribe calls User::limbo() which
+// sets users.deleted (Discourse #9738). Caller must be admin/support or the user themselves.
+func handleUserUnsubscribe(c *fiber.Ctx, myid uint64, req UserPostRequest) error {
+	if req.ID == 0 {
+		return fiber.NewError(fiber.StatusBadRequest, "id is required")
+	}
+
+	targetID := req.ID
+
+	if targetID != myid && !auth.IsAdminOrSupport(myid) {
+		return fiber.NewError(fiber.StatusForbidden, "Only admin/support can unsubscribe other users")
+	}
+
+	db := database.DBConn
+
+	// Remove approved memberships so the user no longer appears in group member lists.
+	db.Exec("DELETE FROM memberships WHERE userid = ? AND collection = ?", targetID, utils.COLLECTION_APPROVED)
+
+	// Mark the account as limbo (soft-deleted, 14-day grace period before permanent erasure).
+	db.Exec("UPDATE users SET deleted = NOW() WHERE id = ?", targetID)
+
+	// Write a log entry so moderator audit views record the removal.
+	db.Exec("INSERT INTO logs (timestamp, type, subtype, user, byuser) VALUES (NOW(), ?, ?, ?, ?)",
+		log2.LOG_TYPE_USER, log2.LOG_SUBTYPE_DELETED, targetID, myid)
 
 	return c.JSON(fiber.Map{"ret": 0, "status": "Success"})
 }

--- a/iznik-server-go/user/user.go
+++ b/iznik-server-go/user/user.go
@@ -2303,14 +2303,8 @@ func LimboUser(c *fiber.Ctx) error {
 		})
 	}
 
-	// Remove memberships so the user no longer appears in group member lists.
-	db.Exec("DELETE FROM memberships WHERE userid = ? AND collection = ?", targetID, utils.COLLECTION_APPROVED)
-
-	db.Exec("UPDATE users SET deleted = NOW() WHERE id = ?", targetID)
-
-	// Log the deletion (type='User', subtype='Deleted').
-	db.Exec("INSERT INTO logs (timestamp, type, subtype, user, byuser) VALUES (NOW(), ?, ?, ?, ?)",
-		log2.LOG_TYPE_USER, log2.LOG_SUBTYPE_DELETED, targetID, myid)
+	// Soft, recoverable limbo (shared with the Unsubscribe action).
+	softLimboUser(db, targetID, myid)
 
 	return c.JSON(fiber.Map{"ret": 0, "status": "Success"})
 }
@@ -2333,9 +2327,27 @@ func handleUnbounce(c *fiber.Ctx, myid uint64, req UserPostRequest) error {
 	return c.JSON(fiber.Map{"ret": 0, "status": "Success"})
 }
 
-// handleUserUnsubscribe puts a target user into limbo (14-day soft-delete) and removes their
-// approved memberships. V1 parity: POST /user action=Unsubscribe calls User::limbo() which
-// sets users.deleted (Discourse #9738). Caller must be admin/support or the user themselves.
+// softLimboUser puts a user into a recoverable "limbo": it removes their approved
+// memberships (so they drop out of group member lists), marks the account deleted
+// (a 14-day grace period before users:cleanup runs forgetUser), and logs a
+// User/Deleted entry. The user can recover by logging back in within the grace
+// period. Shared by self-delete (DELETE /user) and the Support-tools Unsubscribe
+// action (POST /user action=Unsubscribe) so both behave identically. byUser is the
+// actor recorded in the log (the user themselves, or the support volunteer).
+func softLimboUser(db *gorm.DB, targetID uint64, byUser uint64) {
+	db.Exec("DELETE FROM memberships WHERE userid = ? AND collection = ?", targetID, utils.COLLECTION_APPROVED)
+	db.Exec("UPDATE users SET deleted = NOW() WHERE id = ?", targetID)
+	db.Exec("INSERT INTO logs (timestamp, type, subtype, user, byuser) VALUES (NOW(), ?, ?, ?, ?)",
+		log2.LOG_TYPE_USER, log2.LOG_SUBTYPE_DELETED, targetID, byUser)
+}
+
+// handleUserUnsubscribe puts a target user into a recoverable limbo (soft-delete)
+// via the Support-tools "Unsubscribe" action. V1 parity: POST /user action=Unsubscribe
+// maps to a recoverable removal (User::limbo) — NOT the hard GDPR purge that
+// DELETE /user performs for support-on-another-user — so a user who unsubscribed
+// by mistake (e.g. one-click email unsubscribe) can recover by logging back in.
+// A regular user may unsubscribe only themselves; admin/support may unsubscribe
+// anyone. (Discourse #9738.)
 func handleUserUnsubscribe(c *fiber.Ctx, myid uint64, req UserPostRequest) error {
 	if req.ID == 0 {
 		return fiber.NewError(fiber.StatusBadRequest, "id is required")
@@ -2347,17 +2359,7 @@ func handleUserUnsubscribe(c *fiber.Ctx, myid uint64, req UserPostRequest) error
 		return fiber.NewError(fiber.StatusForbidden, "Only admin/support can unsubscribe other users")
 	}
 
-	db := database.DBConn
-
-	// Remove approved memberships so the user no longer appears in group member lists.
-	db.Exec("DELETE FROM memberships WHERE userid = ? AND collection = ?", targetID, utils.COLLECTION_APPROVED)
-
-	// Mark the account as limbo (soft-deleted, 14-day grace period before permanent erasure).
-	db.Exec("UPDATE users SET deleted = NOW() WHERE id = ?", targetID)
-
-	// Write a log entry so moderator audit views record the removal.
-	db.Exec("INSERT INTO logs (timestamp, type, subtype, user, byuser) VALUES (NOW(), ?, ?, ?, ?)",
-		log2.LOG_TYPE_USER, log2.LOG_SUBTYPE_DELETED, targetID, myid)
+	softLimboUser(database.DBConn, targetID, myid)
 
 	return c.JSON(fiber.Map{"ret": 0, "status": "Success"})
 }


### PR DESCRIPTION
## Root Cause

`PostUser` (Go API `user/user.go`) handled actions via a switch statement but had no `\"Unsubscribe\"` case. It fell through to `default: return fiber.NewError(StatusBadRequest, \"Unknown action\")`. Every click of the Support tools Unsubscribe button sent `POST /user {action: \"Unsubscribe\", id: <userid>}`, received a 400 error, and silently did nothing — no membership removal, no log entry, no limbo state set.

## Evidence

- `UserAPI.js:109` calls `POST /user` with `action: 'Unsubscribe'`
- `PostUser` switch (user/user.go) has `Rate`, `RatingReviewed`, `AddEmail`, `RemoveEmail`, `Unbounce`, `Merge` — no `\"Unsubscribe\"` case
- V1 parity: PHP `user.php:327-329` handles action=Unsubscribe by calling `\$u->limbo()` (sets `users.deleted = NOW()`)
- Test confirms: before fix, POST returns 400, membership survives, user.deleted NULL, zero log entries

## Fix

Added `\"Unsubscribe\"` case to `PostUser` dispatching to `handleUserUnsubscribe`:
1. Validates caller is admin/support or the user themselves
2. `DELETE FROM memberships WHERE userid = ? AND collection = 'Approved'` — removes group memberships
3. `UPDATE users SET deleted = NOW()` — marks account as limbo (14-day soft-delete)
4. `INSERT INTO logs (type=User, subtype=Deleted)` — creates audit log entry

## Other Call Sites

- `SessionAPI.js:75` calls `POST /session` with `action: Unsubscribe` (email-based flow) — different endpoint, unaffected
- `UserAPI.js:109` — the only caller of the now-fixed `POST /user action=Unsubscribe`

## Test

`TestPostUserUnsubscribeBySupportRemovesMembership`: Support user calls Unsubscribe on a member; asserts membership removed, account in limbo, log entry written. Failed before fix (400 response), passes after.

`TestPostUserUnsubscribeNonSupportForbidden`: Regular user cannot unsubscribe another. Returns 403.

## Discourse
https://discourse.ilovefreegle.org/t/9738/1