### PR TITLE
fix(modtools): View Chat empty when moderator clicks from reported message

### DIFF
--- a/iznik-server-go/chat/chatmessage.go
+++ b/iznik-server-go/chat/chatmessage.go
@@ -148,7 +148,9 @@ func FetchChatMessages(chatID, userID uint64, limit int, excludeID uint64, desce
 
 	// Build the query - don't return messages:
 	// - held for review unless we sent them or we have mod access
-	// - for deleted users unless that's us
+	// - for deleted users unless that's us (or we have mod access — mods must
+	//   see all messages including from accounts deleted after the fact, e.g.
+	//   a phisher who deletes their account immediately after sending spam)
 	var reviewFilter string
 	if modAccess {
 		// Mods can see all messages including those held for review.
@@ -157,13 +159,25 @@ func FetchChatMessages(chatID, userID uint64, limit int, excludeID uint64, desce
 		reviewFilter = "(userid = ? OR (reviewrequired = 0 AND reviewrejected = 0 AND processingsuccessful = 1))"
 	}
 
+	// Mods reviewing a chat must see messages from soft-deleted users (V1 parity:
+	// the PHP GetMessages query had no users.deleted filter). Regular users only
+	// see their own messages when the sender has been deleted.
+	var deletedFilter string
+	if !modAccess {
+		deletedFilter = " AND (users.deleted IS NULL OR users.id = ?)"
+	}
+
 	query := "SELECT chat_messages.*, chat_images.archived, chat_images.externaluid AS imageuid, chat_images.externalmods AS imagemods FROM chat_messages " +
 		"LEFT JOIN chat_images ON chat_images.chatmsgid = chat_messages.id " +
 		"INNER JOIN users ON users.id = chat_messages.userid " +
-		"WHERE chatid = ? AND " + reviewFilter + " " +
-		"AND (users.deleted IS NULL OR users.id = ?)"
+		"WHERE chatid = ? AND " + reviewFilter + deletedFilter
 
-	args := []interface{}{chatID, userID, userID}
+	var args []interface{}
+	if modAccess {
+		args = []interface{}{chatID, userID}
+	} else {
+		args = []interface{}{chatID, userID, userID}
+	}
 
 	if excludeID > 0 {
 		query += " AND chat_messages.id != ?"
@@ -765,6 +779,17 @@ func getChatMessagesForRoom(c *fiber.Ctx, myid uint64, roomid uint64) error {
 		reviewFilter = "(chat_messages.reviewrejected = 0 OR chat_messages.userid = ?)"
 	}
 
+	// Mods reviewing a chat must see messages from soft-deleted users.
+	// Participants only see their own messages when the sender is deleted.
+	var deletedFilterRoom string
+	var roomArgs []interface{}
+	if isParticipant {
+		deletedFilterRoom = " AND (users.deleted IS NULL OR users.id = ?)"
+		roomArgs = []interface{}{roomid, myid, myid, limit}
+	} else {
+		roomArgs = []interface{}{roomid, myid, limit}
+	}
+
 	var msgs []msgRow
 	db.Raw("SELECT chat_messages.id, chat_messages.chatid, chat_messages.userid, "+
 		"chat_messages.type, chat_messages.message, chat_messages.date, "+
@@ -772,10 +797,9 @@ func getChatMessagesForRoom(c *fiber.Ctx, myid uint64, roomid uint64) error {
 		"FROM chat_messages "+
 		"INNER JOIN users ON users.id = chat_messages.userid "+
 		"WHERE chat_messages.chatid = ? "+
-		"AND "+reviewFilter+" "+
-		"AND users.deleted IS NULL"+ctxq+
+		"AND "+reviewFilter+deletedFilterRoom+ctxq+
 		" ORDER BY chat_messages.id DESC LIMIT ?",
-		roomid, myid, limit).Scan(&msgs)
+		roomArgs...).Scan(&msgs)
 
 	if msgs == nil {
 		msgs = []msgRow{}

--- a/iznik-server-go/test/chatmessage_tdd_test.go
+++ b/iznik-server-go/test/chatmessage_tdd_test.go
@@ -1,0 +1,74 @@
+package test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestGetChatMessages_ModSeesDeletedUserMessages verifies that a moderator viewing
+// a chat via GET /chat/{id}/message can see messages from soft-deleted users.
+//
+// Scenario: phisher sends a scam message then deletes their account. The moderator
+// must still see the message when clicking "View Chat" in the ModTools review queue.
+// V1 PHP did NOT filter on users.deleted in this path; V2 incorrectly excluded them.
+func TestGetChatMessages_ModSeesDeletedUserMessages(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("modviewdel")
+
+	groupID := CreateTestGroup(t, prefix)
+	modID := CreateTestUser(t, prefix+"_mod", "User")
+	victimID := CreateTestUser(t, prefix+"_victim", "User")
+	phisherID := CreateTestUser(t, prefix+"_phisher", "User")
+
+	CreateTestMembership(t, modID, groupID, "Moderator")
+	CreateTestMembership(t, victimID, groupID, "Member")
+	// phisher has no membership (already unsubscribed)
+
+	// User2User chat: victim initiated, phisher replied with scam
+	chatID := CreateTestChatRoom(t, victimID, &phisherID, nil, "User2User")
+
+	db.Exec(
+		"INSERT INTO chat_messages (chatid, userid, message, date, reviewrequired, reviewrejected, processingsuccessful) "+
+			"VALUES (?, ?, 'Click here for free prize!', NOW(), 1, 0, 1)",
+		chatID, phisherID,
+	)
+	var msgID uint64
+	db.Raw(
+		"SELECT id FROM chat_messages WHERE chatid = ? AND userid = ? ORDER BY id DESC LIMIT 1",
+		chatID, phisherID,
+	).Scan(&msgID)
+	if msgID == 0 {
+		t.Fatal("Failed to create phisher's chat message")
+	}
+
+	// Phisher immediately deletes their account after sending the scam message
+	db.Exec("UPDATE users SET deleted = NOW() WHERE id = ?", phisherID)
+
+	_, modToken := CreateTestSession(t, modID)
+	req := httptest.NewRequest(
+		"GET",
+		fmt.Sprintf("/api/chat/%d/message?jwt=%s", chatID, modToken),
+		nil,
+	)
+	resp, _ := getApp().Test(req, -1)
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var messages []map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&messages)
+
+	// Mod MUST see the phisher's message even though the phisher's account is deleted.
+	// Without the fix, FetchChatMessages filters out messages from deleted users
+	// (AND users.deleted IS NULL) even for mods, returning an empty array.
+	assert.Equal(t, 1, len(messages), "moderator should see the phisher's message even after account deletion")
+	if len(messages) > 0 {
+		id, _ := messages[0]["id"].(float64)
+		assert.Equal(t, float64(msgID), id)
+	}
+}


### PR DESCRIPTION
## Root Cause

`FetchChatMessages` in `iznik-server-go/chat/chatmessage.go` filtered out messages from soft-deleted users with `AND (users.deleted IS NULL OR users.id = ?)`, where `?` is the requesting moderator's ID — not the phisher's ID. So when a phisher deletes their account after sending a scam/phishing message, any moderator clicking **View Chat** on the review item got an empty response (200 OK, zero messages), causing `ModChatModal` to show nothing.

The same filter applied to `getChatMessagesForRoom` (the `GET /chatmessages?roomid=X` path) as an unconditional `AND users.deleted IS NULL`.

V1 PHP (`ChatRoom.php` `getMessages()`) applied no `users.deleted` filter at all, so mods could always see the full chat history for review purposes.

## Evidence (failing test output)

Before fix — test asserts `len(messages) == 1`, current code returns 0:
```
--- FAIL: TestGetChatMessages_ModSeesDeletedUserMessages (0.11s)
    chatmessage_tdd_test.go:68: moderator should see the phisher's message even after account deletion
        Expected :1
        Actual   :0
```

After fix:
```
--- PASS: TestGetChatMessages_ModSeesDeletedUserMessages (0.11s)
```
All 2988 Go tests pass.

## Fix

In `FetchChatMessages` (called by `GET /chat/{id}/message`): when `modAccess=true`, the `users.deleted IS NULL` filter is omitted entirely. `canSeeChatRoom()` already guards access — once a mod is authorised, they must see all messages.

In `getChatMessagesForRoom` (called by `GET /chatmessages?roomid=X`): the deleted-user filter is now conditional on `isParticipant`, not always applied.

## Other Call Sites

- `getReviewQueue` (lines 902, 941): the `INNER JOIN users ... AND users.deleted IS NULL` means the review item itself disappears from the queue if the sender's account is deleted after the message is queued. This is separate from the View Chat bug (the mod may have loaded the review item before the account was deleted). Not changed in this PR — a separate concern.
- All other `users.deleted IS NULL` occurrences in the codebase are in different contexts (email lookup, session, stories, messages) and are unrelated.

## Test

**File:** `iznik-server-go/test/chatmessage_tdd_test.go`  
**Test:** `TestGetChatMessages_ModSeesDeletedUserMessages`  
**Command:** `curl -s -X POST http://localhost:8081/api/tests/go -d '{"filter":"TestGetChatMessages_ModSeesDeletedUserMessages"}'`

**Proves:**
- FAIL before fix: mod sees 0 messages when phisher's account is soft-deleted
- PASS after fix: mod sees the phishing message regardless of account deletion

## Discourse
https://discourse.ilovefreegle.org/t/9744/9