### PR TITLE
fix(chat): do not hold chat messages for review for containing a postcode

### DIFF
--- a/iznik-batch/app/Services/ContentCheckService.php
+++ b/iznik-batch/app/Services/ContentCheckService.php
@@ -160,6 +160,12 @@ class ContentCheckService
      * checked phone numbers either.) The checkPhoneNumbers() check still runs
      * for posts via checkMessage().
      *
+     * UK postcodes are stripped from the message before concern-keyword and
+     * other text checks run: sharing a collection address is as legitimate as
+     * sharing a phone number, and a postcode-shaped string must not trigger a
+     * regex concern keyword added for other purposes. (V1 parity: Spam::checkReview()
+     * never checked postcodes either.)
+     *
      * @return array|null Reason ['check','category','action','detail'] or null.
      */
     public function checkChatMessage(string $message): ?array
@@ -169,12 +175,16 @@ class ContentCheckService
             return null;
         }
 
-        return $this->checkConcernKeywords('', $message, 0)
-            ?? $this->checkUrls('', $message)
-            ?? $this->checkMessagingLinks('', $message)
-            ?? $this->checkMoneySymbols('', $message)
-            ?? $this->checkKnownSpammer($message)
-            ?? $this->checkLanguage('', $message);
+        // Strip UK postcodes so a postcode-shaped token cannot fire a regex
+        // concern keyword.  Sharing a collection postcode is normal in chat.
+        $sanitised = preg_replace(self::POSTCODE_PATTERN, ' ', $message);
+
+        return $this->checkConcernKeywords('', $sanitised, 0)
+            ?? $this->checkUrls('', $sanitised)
+            ?? $this->checkMessagingLinks('', $sanitised)
+            ?? $this->checkMoneySymbols('', $sanitised)
+            ?? $this->checkKnownSpammer($sanitised)
+            ?? $this->checkLanguage('', $sanitised);
     }
 
     /**
@@ -732,6 +742,15 @@ class ContentCheckService
 
         return null;
     }
+
+    // -------------------------------------------------------------------------
+    // UK postcode pattern — used to strip postcodes from chat messages before
+    // concern-keyword checks run.  Sharing a collection postcode is normal in
+    // chat (same rationale as the phone-number exclusion).  Matches the V1
+    // Utils::POSTCODE_PATTERN covering GIR 0AA plus all AN/ANN/AAN/AANN forms.
+    // -------------------------------------------------------------------------
+
+    private const POSTCODE_PATTERN = '/([Gg][Ii][Rr] 0[Aa]{2})|((([A-Za-z][0-9]{1,2})|(([A-Za-z][A-Ha-hJ-Yj-y][0-9]{1,2})|(([A-Za-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9][A-Za-z]?))))\s?[0-9][A-Za-z]{2})/m';
 
     // -------------------------------------------------------------------------
     // PII — external email addresses, only when group rule restrictpersonalinfo

--- a/iznik-batch/tests/Unit/Services/ChatProcessServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/ChatProcessServiceTest.php
@@ -321,6 +321,47 @@ class ChatProcessServiceTest extends TestCase
         $this->assertNull($updated->reportreason);
     }
 
+    // --- Postcode hold (Discourse #9656 post 38) ---
+    //
+    // Regex concern keywords can match UK postcode patterns (e.g. a scam-detection
+    // regex that inadvertently covers postcode inward/outward codes). Sharing a
+    // collection address is as legitimate as sharing a phone number, so postcodes
+    // must be stripped before concern-keyword scanning in chat — same rationale as
+    // the phone-number exclusion.
+
+    public function test_moderated_user_message_with_postcode_is_not_held(): void
+    {
+        // A message containing only a UK postcode must NOT be held for review even
+        // when a global regex concern keyword matches postcode patterns — sharing a
+        // collection address is normal in chat.
+        DB::table('concern_keywords')->insert([
+            'keyword'    => '\b[A-Z]{1,2}\d\s+\d[A-Z]{2}\b',
+            'category'   => 'review',
+            'action'     => 'flag',
+            'match_mode' => 'regex',
+            'scope'      => 'global',
+            'group_id'   => 0,
+        ]);
+
+        $sender    = $this->createTestUser(['chatmodstatus' => 'Moderated']);
+        $recipient = $this->createTestUser();
+        $room      = $this->createTestChatRoom($sender, $recipient);
+
+        $msg = $this->createTestChatMessage($room, $sender, [
+            'message'              => 'Please collect at AB1 2CD',
+            'processingrequired'   => 1,
+            'processingsuccessful' => 0,
+            'platform'             => 1,
+        ]);
+
+        $this->service->processIncoming();
+
+        $updated = DB::table('chat_messages')->where('id', $msg->id)->first();
+        $this->assertEquals(0, $updated->reviewrequired,
+            'A message containing a UK postcode should NOT be held for review in chat');
+        $this->assertNull($updated->reportreason);
+    }
+
     public function test_moderated_user_message_with_phone_number_is_not_held(): void
     {
         // Sharing a phone number to arrange a handover is normal, so chat


### PR DESCRIPTION
## Root Cause

`ContentCheckService::checkChatMessage()` passes the raw message text directly to `checkConcernKeywords()`. When the `concern_keywords` table contains a regex entry whose pattern coincidentally matches UK postcode shapes (e.g. a scam-detection rule covering `\b[A-Z]{1,2}\d\s+\d[A-Z]{2}\b`), any chat message sharing a collection address is incorrectly held for moderator review.

## Evidence

Discourse report: https://discourse.ilovefreegle.org/t/9656/38 (post 38, reporter Neville_Reid).

A message like `"Please collect at AB1 2CD"` was flagged as `reviewrequired=1` because the postcode matched a globally-scoped regex concern keyword. The phone-number exemption (commit 2804d6e, "stop phone-number checking on chat messages") addressed the same class of problem for phone numbers but left postcodes unprotected.

## Fix

Strip UK postcodes from the chat message text **before** running any text checks in `checkChatMessage()`. Uses the standard Royal Mail postcode regex (matching V1 `Utils::POSTCODE_PATTERN`) as a `private const POSTCODE_PATTERN`. All other spam content in the same message is still caught — the sanitised string is passed through the full check chain.

V1 parity: `Spam::checkReview()` never checked postcodes either.

## Other Call Sites

`checkChatMessage()` is only called in one place:
- `ChatProcessService::processMessage()` (line 136) — the only consumer of this check

`POSTCODE_PATTERN` is `private const`, used only within `ContentCheckService::checkChatMessage()`.

## Test

`ChatProcessServiceTest::test_moderated_user_message_with_postcode_is_not_held()`:
- Seeds a global regex concern keyword matching simplified UK postcodes (`\b[A-Z]{1,2}\d\s+\d[A-Z]{2}\b`)
- Sends a message `"Please collect at AB1 2CD"` from a Moderated user
- Asserts `reviewrequired = 0` (not held) and `reportreason = null`
- Without the fix, `reviewrequired` was `1` (AssertFlip confirmed)

## Discourse

https://discourse.ilovefreegle.org/t/9656/38