### PR TITLE
fix(reply): crosspost join picks first group not last (Discourse #9733)

### DIFF
--- a/iznik-nuxt3/composables/useReplyStateMachine.js
+++ b/iznik-nuxt3/composables/useReplyStateMachine.js
@@ -799,12 +799,13 @@ export function useReplyStateMachine(messageId) {
         return
       }
 
-      // Check if already a member
+      // Default to first group; overwritten if user is already in a later group.
+      // Without this, the loop left groupToJoin pointing at the last group for
+      // non-members of a crossposted message (Discourse #9733).
       let isMember = false
-      let groupToJoin = null
+      const groupToJoin = msg.groups[0].groupid
 
       for (const messageGroup of msg.groups) {
-        groupToJoin = messageGroup.groupid
         for (const key of Object.keys(myGroups.value || {})) {
           const group = myGroups.value[key]
           if (messageGroup.groupid === group.id) {

--- a/iznik-nuxt3/tests/unit/composables/useReplyStateMachine.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useReplyStateMachine.spec.js
@@ -980,6 +980,27 @@ describe('handleJoinGroup (via submit with logged-in user)', () => {
     expect(mockForceLogin.value).toBe(true)
     expect(result.state.value).toBe(ReplyState.AUTHENTICATING)
   })
+
+  it('crosspost: joins first group when not a member of any (Discourse #9733)', async () => {
+    // Bug: the loop set groupToJoin on every iteration, so a non-member of any group
+    // ended up being joined to the LAST group, not the first (Southwark/Lewisham mix-up).
+    mockMeValue = { id: 10 }
+    mockMyidValue = 10
+    mockMyGroupsValue = {} // not a member of any group
+    mockMessageFetch.mockResolvedValue({
+      id: MSG_ID,
+      groups: [{ groupid: 300 }, { groupid: 400 }], // crossposted to two groups
+    })
+    mockReplyToPostFn.mockResolvedValue(MSG_ID)
+
+    const { result } = mountComposable()
+    result.setRefs({ form: makeFormRef(true), chatButton: makeChatButtonRef() })
+    await doLoggedInSubmit(result)
+
+    // Must join the FIRST group (300), not the last (400)
+    expect(mockAuthStore.joinGroup).toHaveBeenCalledWith(10, 300, false)
+    expect(result.state.value).toBe(ReplyState.COMPLETED)
+  })
 })
 
 describe('handleCreateChat (via submit with logged-in user)', () => {


### PR DESCRIPTION
## Root Cause

In `useReplyStateMachine.js` `handleJoinGroup()`, the loop that selects which group to join when replying set `groupToJoin = messageGroup.groupid` on **every** iteration. For a non-member of a crossposted message (e.g. an offer posted in both Southwark and Lewisham), the loop ran all the way through and left `groupToJoin` pointing at the **last** group in the array. The user was then silently auto-joined to that arbitrary last group rather than the first one.

## Evidence

```
❯ tests/unit/composables/useReplyStateMachine.spec.js
  ✗ crosspost: joins first group when not a member of any (Discourse #9733)
    Expected: joinGroup(10, 300, false)
    Received: joinGroup(10, 400, false)   ← last group, not first
```

Test added in this PR failed against the unpatched code with the exact wrong-group symptom.

## Fix

Initialise `groupToJoin = msg.groups[0].groupid` **before** the loop (and remove the per-iteration assignment). Non-members now join the **first** group deterministically. Users who are already a member of any group in the list hit `isMember = true` and skip `joinGroup` as before.

```js
// Before
let groupToJoin = null
for (const messageGroup of msg.groups) {
  groupToJoin = messageGroup.groupid  // ← overwrites on every iteration
  ...
}

// After
const groupToJoin = msg.groups[0].groupid  // defaults to first group
for (const messageGroup of msg.groups) {
  // membership check only — no assignment
  ...
}
```

## Other Call Sites

`joinGroup` is also called from `GroupHeader.vue` and `pages/explore/join/[[id]].vue` — both are explicit user-initiated join flows with a single group, unaffected.

## Test

**File**: `iznik-nuxt3/tests/unit/composables/useReplyStateMachine.spec.js`
**Command**: `node_modules/.bin/vitest run "tests/unit/composables/useReplyStateMachine"`
**Proves**: fails on buggy code (joins group 400 instead of 300); passes after fix (joins group 300, the first group in the crosspost list).

Full suite: 89/89 pass on fixed code, 12,824/12,828 pass on full unit suite (4 pre-existing skips).

## Discourse

https://discourse.ilovefreegle.org/t/9733/1