### PR TITLE
fix(share): add direct item URL link to MessageShareModal for iOS fallback

### DIFF
--- a/iznik-nuxt3/components/MessageShareModal.vue
+++ b/iznik-nuxt3/components/MessageShareModal.vue
@@ -5,6 +5,9 @@
         <h3>
           {{ message.subject }}
         </h3>
+        <p>
+          <a target="_blank" :href="message.url">{{ message.url }}</a>
+        </p>
         <NoticeMessage variant="info">
           <p>
             Please share - you might get a response from people you know, or a

--- a/iznik-nuxt3/tests/unit/components/MessageShareModal.spec.js
+++ b/iznik-nuxt3/tests/unit/components/MessageShareModal.spec.js
@@ -241,6 +241,22 @@ describe('MessageShareModal', () => {
     })
   })
 
+  describe('direct URL link', () => {
+    it('shows a direct link to the item URL for iOS/mobile fallback', async () => {
+      const wrapper = createWrapper()
+      await flushPromises()
+      const link = wrapper.find('a[href="https://freegle.org/message/1"]')
+      expect(link.exists()).toBe(true)
+      expect(link.attributes('target')).toBe('_blank')
+    })
+
+    it('displays the item URL as link text', async () => {
+      const wrapper = createWrapper()
+      await flushPromises()
+      expect(wrapper.text()).toContain('https://freegle.org/message/1')
+    })
+  })
+
   describe('message fetch', () => {
     it('fetches message on mount', async () => {
       createWrapper()


### PR DESCRIPTION
## Root Cause

`MessageShareModal.vue` was missing the direct `<a target="_blank" :href="message.url">{{ message.url }}</a>` link that both `NewsShareModal.vue` and `StoryShareModal.vue` provide. On iOS (Safari), the `vue-social-sharing` library's popup approach (`window.open()` with named window and features) can be silently blocked by iOS's popup blocker. When that happens the Facebook share button does nothing and there is no fallback — the user can't reach or share the item URL at all.

## Evidence

```
FAIL  tests/unit/components/MessageShareModal.spec.js
  ✗ direct URL link > shows a direct link to the item URL for iOS/mobile fallback
    AssertionError: expected false to be true (link.exists())
  ✗ direct URL link > displays the item URL as link text
    AssertionError: expected text to contain 'https://freegle.org/message/1'
```

Both tests fail on the un-patched component; both pass after the fix.

## Fix

Added the item URL as a direct `<a target="_blank">` link at the top of the message section in `MessageShareModal.vue`, matching the identical pattern already used in `NewsShareModal.vue` (line 12) and `StoryShareModal.vue` (line 12).

## Other Call Sites

`NewsShareModal.vue` and `StoryShareModal.vue` already have this link. No other share-modal-like components are missing it.

## Test

File: `iznik-nuxt3/tests/unit/components/MessageShareModal.spec.js`  
Command: `vitest run tests/unit/components/MessageShareModal.spec.js`  
Proves: test **fails** before fix (link absent), **passes** after (link present with correct href and target="_blank"). Full 590-file unit suite passes with no regressions.

## Discourse

https://discourse.ilovefreegle.org/t/9732/2