### PR TITLE
fix(jobs): dedupe FD jobs feed by title+body, not canonical_title (9739)

### DIFF
--- a/iznik-server-go/job/job.go
+++ b/iznik-server-go/job/job.go
@@ -19,20 +19,21 @@ import (
 var categorySanitizer = regexp.MustCompile(`[^a-zA-Z/ ]+`)
 
 type Job struct {
-	ID           uint64  `json:"id" gorm:"primary_key"`
-	Ambit        float64 `json:"ambit"`
-	Dist         float64 `json:"dist"`
-	Area         float64 `json:"area"`
-	Url          string  `json:"url"`
-	Title        string  `json:"title"`
-	Location     string  `json:"location"`
-	Body         string  `json:"body"`
-	Reference    string  `json:"job_reference"`
-	Category     string  `json:"category"`
-	CPC          float64 `json:"cpc"`
-	Clickability float64 `json:"clickability"`
-	Expectation  float64 `json:"expectation"`
-	Image        string  `json:"image,omitempty"`
+	ID               uint64  `json:"id" gorm:"primary_key"`
+	Ambit            float64 `json:"ambit"`
+	Dist             float64 `json:"dist"`
+	Area             float64 `json:"area"`
+	Url              string  `json:"url"`
+	Title            string  `json:"title"`
+	Location         string  `json:"location"`
+	Body             string  `json:"body"`
+	Reference        string  `json:"job_reference"`
+	Category         string  `json:"category"`
+	CPC              float64 `json:"cpc"`
+	Clickability     float64 `json:"clickability"`
+	Expectation      float64 `json:"expectation"`
+	Image            string  `json:"image,omitempty"`
+	CanonicalTitle   string  `json:"-"`
 }
 
 const JOBS_LIMIT = 50
@@ -98,6 +99,7 @@ func GetJobs(c *fiber.Ctx) error {
 			go func(ambit float64) {
 				var nelat, nelng, swlat, swlng float64
 				var these []Job
+				seenCanonicalTitles := make(map[string]bool)
 
 				// Get an exclusive connection.
 				db, err := database.Pool.Conn(timeoutContext)
@@ -129,7 +131,7 @@ func GetJobs(c *fiber.Ctx) error {
 					"ST_Distance(geometry, ST_SRID(POINT(" + lngs + ", " + lats + "), " + srids + ")) AS dist, " +
 					"CASE WHEN ST_Dimension(geometry) < 2 THEN 0 ELSE ST_Area(geometry) END AS area, " +
 					"jobs.id, jobs.url, jobs.title, jobs.location, jobs.body, jobs.job_reference, jobs.category, jobs.cpc, jobs.clickability, jobs.cpc * jobs.clickability AS expectation, " +
-					"ai_images.externaluid " +
+					"jobs.canonical_title, ai_images.externaluid " +
 					"FROM `jobs` " +
 					"LEFT JOIN ai_images ON ai_images.name = jobs.canonical_title " +
 					"WHERE ST_Within(geometry, ST_SRID(POLYGON(LINESTRING(" +
@@ -163,6 +165,7 @@ func GetJobs(c *fiber.Ctx) error {
 					for rows.Next() {
 						var job Job
 						var externaluid sql.NullString
+						var canonicalTitle sql.NullString
 						err = rows.Scan(
 							&job.Ambit,
 							&job.Dist,
@@ -177,10 +180,26 @@ func GetJobs(c *fiber.Ctx) error {
 							&job.CPC,
 							&job.Clickability,
 							&job.Expectation,
+							&canonicalTitle,
 							&externaluid)
 
 						if externaluid.Valid && len(externaluid.String) > 0 {
 							job.Image = misc.GetImageDeliveryUrl(externaluid.String, "")
+						}
+
+						if canonicalTitle.Valid {
+							job.CanonicalTitle = canonicalTitle.String
+						}
+
+						// De-duplicate by canonical_title: skip if we've already seen this canonical_title
+						// (but only if canonical_title is non-empty; rows with empty canonical_title are kept)
+						if job.CanonicalTitle != "" && seenCanonicalTitles[job.CanonicalTitle] {
+							continue
+						}
+
+						// Mark this canonical_title as seen (only if non-empty)
+						if job.CanonicalTitle != "" {
+							seenCanonicalTitles[job.CanonicalTitle] = true
 						}
 
 						these = append(these, job)

--- a/iznik-server-go/job/job.go
+++ b/iznik-server-go/job/job.go
@@ -19,21 +19,21 @@ import (
 var categorySanitizer = regexp.MustCompile(`[^a-zA-Z/ ]+`)
 
 type Job struct {
-	ID               uint64  `json:"id" gorm:"primary_key"`
-	Ambit            float64 `json:"ambit"`
-	Dist             float64 `json:"dist"`
-	Area             float64 `json:"area"`
-	Url              string  `json:"url"`
-	Title            string  `json:"title"`
-	Location         string  `json:"location"`
-	Body             string  `json:"body"`
-	Reference        string  `json:"job_reference"`
-	Category         string  `json:"category"`
-	CPC              float64 `json:"cpc"`
-	Clickability     float64 `json:"clickability"`
-	Expectation      float64 `json:"expectation"`
-	Image            string  `json:"image,omitempty"`
-	CanonicalTitle   string  `json:"-"`
+	ID             uint64  `json:"id" gorm:"primary_key"`
+	Ambit          float64 `json:"ambit"`
+	Dist           float64 `json:"dist"`
+	Area           float64 `json:"area"`
+	Url            string  `json:"url"`
+	Title          string  `json:"title"`
+	Location       string  `json:"location"`
+	Body           string  `json:"body"`
+	Reference      string  `json:"job_reference"`
+	Category       string  `json:"category"`
+	CPC            float64 `json:"cpc"`
+	Clickability   float64 `json:"clickability"`
+	Expectation    float64 `json:"expectation"`
+	Image          string  `json:"image,omitempty"`
+	CanonicalTitle string  `json:"-"`
 }
 
 const JOBS_LIMIT = 50
@@ -99,7 +99,7 @@ func GetJobs(c *fiber.Ctx) error {
 			go func(ambit float64) {
 				var nelat, nelng, swlat, swlng float64
 				var these []Job
-				seenCanonicalTitles := make(map[string]bool)
+				seenJobs := make(map[string]bool)
 
 				// Get an exclusive connection.
 				db, err := database.Pool.Conn(timeoutContext)
@@ -191,16 +191,18 @@ func GetJobs(c *fiber.Ctx) error {
 							job.CanonicalTitle = canonicalTitle.String
 						}
 
-						// De-duplicate by canonical_title: skip if we've already seen this canonical_title
-						// (but only if canonical_title is non-empty; rows with empty canonical_title are kept)
-						if job.CanonicalTitle != "" && seenCanonicalTitles[job.CanonicalTitle] {
+						// De-duplicate genuine duplicates only: the SAME posting (title + body)
+						// indexed for many locations collapses to a single card (Discourse 9739
+						// "every job identical except location"). canonical_title is just the
+						// AI-image category — many unrelated jobs (different employers, different
+						// bodies) share it — so it must NOT be the dedup key, or distinct jobs
+						// would be hidden. Location is intentionally excluded from the key so the
+						// multi-location copies of one posting merge.
+						dedupKey := job.Title + "\x00" + job.Body
+						if seenJobs[dedupKey] {
 							continue
 						}
-
-						// Mark this canonical_title as seen (only if non-empty)
-						if job.CanonicalTitle != "" {
-							seenCanonicalTitles[job.CanonicalTitle] = true
-						}
+						seenJobs[dedupKey] = true
 
 						these = append(these, job)
 					}

--- a/iznik-server-go/test/jobs_test.go
+++ b/iznik-server-go/test/jobs_test.go
@@ -3,10 +3,14 @@ package test
 import (
 	json2 "encoding/json"
 	"fmt"
+	"github.com/freegle/iznik-server-go/database"
 	"github.com/freegle/iznik-server-go/job"
+	"github.com/freegle/iznik-server-go/utils"
 	"github.com/stretchr/testify/assert"
+	"math/rand"
 	"net/http/httptest"
 	"testing"
+	"time"
 )
 
 func TestJobs(t *testing.T) {
@@ -69,4 +73,75 @@ func TestJobClick(t *testing.T) {
 	// Test with missing job ID - still returns success (matches PHP behavior)
 	resp, _ = getApp().Test(httptest.NewRequest("POST", "/api/job", nil))
 	assert.Equal(t, 200, resp.StatusCode)
+}
+
+func TestJobsDedupeByCanonicalTitle(t *testing.T) {
+	// Test data: two jobs with same canonical_title but different locations
+	lat := 52.5833189
+	lng := -2.0455619
+
+	db := database.DBConn
+	defer func() {
+		// Cleanup: delete test jobs
+		db.Exec("DELETE FROM jobs WHERE canonical_title = ? OR canonical_title = ?",
+			"test-role-dedup", "test-role-control")
+	}()
+
+	// Helper to insert a job with specific canonical_title
+	insertJob := func(title, location, canonicalTitle string) {
+		wkt := fmt.Sprintf("POINT(%.7f %.7f)", lng, lat)
+		ref := fmt.Sprintf("test-job-%d-%d", time.Now().UnixNano(), rand.Intn(100000))
+		result := db.Exec(
+			fmt.Sprintf(
+				"INSERT INTO jobs (title, location, url, body, job_reference, category, geometry, cpc, clickability, visible, canonical_title) "+
+					"VALUES (?, ?, 'http://example.com/job', 'Test body', ?, 'General', ST_GeomFromText(?, %d), 0.15, 1, 1, ?)",
+				utils.SRID),
+			title, location, ref, wkt, canonicalTitle)
+
+		if result.Error != nil {
+			t.Fatalf("Failed to insert job: %v", result.Error)
+		}
+	}
+
+	// Insert two jobs with SAME canonical_title but different locations
+	insertJob("Software Engineer - London", "London, UK", "test-role-dedup")
+	insertJob("Software Engineer - Manchester", "Manchester, UK", "test-role-dedup")
+
+	// Insert one job with DIFFERENT canonical_title as control (should still appear)
+	insertJob("DevOps Engineer - Leeds", "Leeds, UK", "test-role-control")
+
+	// Query for jobs
+	resp, _ := getApp().Test(httptest.NewRequest("GET", fmt.Sprintf("/api/job?lat=%f&lng=%f", lat, lng), nil))
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var jobs []job.Job
+	json2.Unmarshal(rsp(resp), &jobs)
+
+	// Count how many jobs with the "test-role-dedup" canonical_title are returned
+	// We can identify them by their titles
+	deducedTitles := map[string]int{
+		"Software Engineer - London":      0,
+		"Software Engineer - Manchester":  0,
+		"DevOps Engineer - Leeds":         0,
+	}
+
+	for _, j := range jobs {
+		for title := range deducedTitles {
+			if j.Title == title {
+				deducedTitles[title]++
+			}
+		}
+	}
+
+	// ASSERT: Only ONE of the duplicated titles should appear (the first one, due to ordering)
+	londonCount := deducedTitles["Software Engineer - London"]
+	manchesterCount := deducedTitles["Software Engineer - Manchester"]
+	controlCount := deducedTitles["DevOps Engineer - Leeds"]
+
+	// Before fix: both London and Manchester appear (2 total)
+	// After fix: only one appears (1 total)
+	totalDedupedJobs := londonCount + manchesterCount
+
+	assert.Equal(t, 1, totalDedupedJobs, "Expected exactly 1 job with canonical_title='test-role-dedup', but got %d", totalDedupedJobs)
+	assert.Greater(t, controlCount, 0, "Expected control job (different canonical_title) to still appear")
 }

--- a/iznik-server-go/test/jobs_test.go
+++ b/iznik-server-go/test/jobs_test.go
@@ -75,77 +75,100 @@ func TestJobClick(t *testing.T) {
 	assert.Equal(t, 200, resp.StatusCode)
 }
 
-func TestJobsDedupeByCanonicalTitle(t *testing.T) {
-	// Test data: two jobs with same canonical_title but different locations
+func TestJobsDedupeByTitleAndBody(t *testing.T) {
+	// The FD jobs feed indexes the SAME posting for many locations, so a single
+	// role can appear dozens of times (Discourse 9739, "every job identical
+	// except location"). We de-duplicate by title+body so those exact copies
+	// collapse to one card — but NOT by canonical_title (the AI-image category),
+	// because unrelated jobs from different employers share a category while
+	// having different bodies, and each must still appear.
 	lat := 52.5833189
 	lng := -2.0455619
 
 	db := database.DBConn
 
-	// Remove any stale rows from a previous crashed run before inserting.
-	// The jobs table has a unique(location, title) constraint, so stale rows
-	// would cause the insert below to fail with a duplicate-key error.
-	db.Exec("DELETE FROM jobs WHERE canonical_title IN (?, ?)", "test-role-dedup", "test-role-control")
-
+	// Clean up by marker (canonical_title) before and after. The jobs table has a
+	// unique(location, title) constraint, so stale rows from a crashed run would
+	// otherwise cause duplicate-key errors on insert.
+	db.Exec("DELETE FROM jobs WHERE canonical_title IN (?, ?, ?)",
+		"test-dedup-A", "test-dedup-B", "test-dedup-ctrl")
 	defer func() {
-		db.Exec("DELETE FROM jobs WHERE canonical_title IN (?, ?)", "test-role-dedup", "test-role-control")
+		db.Exec("DELETE FROM jobs WHERE canonical_title IN (?, ?, ?)",
+			"test-dedup-A", "test-dedup-B", "test-dedup-ctrl")
 	}()
 
-	// Helper to insert a job with specific canonical_title
-	insertJob := func(title, location, canonicalTitle string) {
+	// High expectation (cpc * clickability) so these rank within JOBS_LIMIT.
+	insertJob := func(title, location, body, canonicalTitle string) {
 		wkt := fmt.Sprintf("POINT(%.7f %.7f)", lng, lat)
-		ref := fmt.Sprintf("test-job-%d-%d", time.Now().UnixNano(), rand.Intn(100000))
+		ref := fmt.Sprintf("test-job-%d-%d", time.Now().UnixNano(), rand.Intn(1000000))
 		result := db.Exec(
 			fmt.Sprintf(
 				"INSERT INTO jobs (title, location, url, body, job_reference, category, geometry, cpc, clickability, visible, canonical_title) "+
-					"VALUES (?, ?, 'http://example.com/job', 'Test body', ?, 'General', ST_GeomFromText(?, %d), 0.15, 1, 1, ?)",
+					"VALUES (?, ?, 'http://example.com/job', ?, ?, 'General', ST_GeomFromText(?, %d), 99.0, 1, 1, ?)",
 				utils.SRID),
-			title, location, ref, wkt, canonicalTitle)
+			title, location, body, ref, wkt, canonicalTitle)
 
 		if result.Error != nil {
 			t.Fatalf("Failed to insert job: %v", result.Error)
 		}
 	}
 
-	// Insert two jobs with SAME canonical_title but different locations
-	insertJob("Software Engineer - London", "London, UK", "test-role-dedup")
-	insertJob("Software Engineer - Manchester", "Manchester, UK", "test-role-dedup")
+	// Group A: the SAME posting (identical title + body) indexed for two
+	// locations — must collapse to a single card.
+	sameBody := "Pick and pack orders in a busy warehouse. Immediate start, full training given."
+	insertJob("Warehouse Operative", "London, UK", sameBody, "test-dedup-A")
+	insertJob("Warehouse Operative", "Manchester, UK", sameBody, "test-dedup-A")
 
-	// Insert one job with DIFFERENT canonical_title as control (should still appear)
-	insertJob("DevOps Engineer - Leeds", "Leeds, UK", "test-role-control")
+	// Group B: SAME title and SAME canonical_title but DIFFERENT bodies (two
+	// different employers) — both must still appear. This is the case a
+	// canonical_title- or title-only dedupe wrongly collapsed.
+	bodySunrise := "Sunrise Homes: support residents with daily living in our care home."
+	bodyBrightCare := "BrightCare Ltd: deliver care to clients in their own homes across the city."
+	insertJob("Care Assistant", "Bristol, UK", bodySunrise, "test-dedup-B")
+	insertJob("Care Assistant", "Leeds, UK", bodyBrightCare, "test-dedup-B")
 
-	// Query for jobs
+	// Control: a distinct posting — must appear.
+	insertJob("Delivery Driver", "York, UK", "Drive a van delivering parcels on a fixed local route.", "test-dedup-ctrl")
+
 	resp, _ := getApp().Test(httptest.NewRequest("GET", fmt.Sprintf("/api/job?lat=%f&lng=%f", lat, lng), nil))
 	assert.Equal(t, 200, resp.StatusCode)
 
 	var jobs []job.Job
 	json2.Unmarshal(rsp(resp), &jobs)
 
-	// Count how many jobs with the "test-role-dedup" canonical_title are returned
-	// We can identify them by their titles
-	deducedTitles := map[string]int{
-		"Software Engineer - London":      0,
-		"Software Engineer - Manchester":  0,
-		"DevOps Engineer - Leeds":         0,
-	}
-
-	for _, j := range jobs {
-		for title := range deducedTitles {
+	countTitle := func(title string) int {
+		n := 0
+		for _, j := range jobs {
 			if j.Title == title {
-				deducedTitles[title]++
+				n++
 			}
 		}
+		return n
+	}
+	countTitleBody := func(title, body string) int {
+		n := 0
+		for _, j := range jobs {
+			if j.Title == title && j.Body == body {
+				n++
+			}
+		}
+		return n
 	}
 
-	// ASSERT: Only ONE of the duplicated titles should appear (the first one, due to ordering)
-	londonCount := deducedTitles["Software Engineer - London"]
-	manchesterCount := deducedTitles["Software Engineer - Manchester"]
-	controlCount := deducedTitles["DevOps Engineer - Leeds"]
+	// Group A: identical title+body across locations collapses to exactly one.
+	assert.Equal(t, 1, countTitle("Warehouse Operative"),
+		"an identical posting indexed for multiple locations should collapse to a single card")
 
-	// Before fix: both London and Manchester appear (2 total)
-	// After fix: only one appears (1 total)
-	totalDedupedJobs := londonCount + manchesterCount
+	// Group B: same title, different body -> BOTH appear (not collapsed by
+	// canonical_title or by title alone).
+	assert.Equal(t, 1, countTitleBody("Care Assistant", bodySunrise),
+		"first distinct Care Assistant posting should appear")
+	assert.Equal(t, 1, countTitleBody("Care Assistant", bodyBrightCare),
+		"second distinct Care Assistant posting (different body) must also appear")
+	assert.Equal(t, 2, countTitle("Care Assistant"),
+		"two different employers sharing a job title must both appear; title/canonical_title alone must not collapse them")
 
-	assert.Equal(t, 1, totalDedupedJobs, "Expected exactly 1 job with canonical_title='test-role-dedup', but got %d", totalDedupedJobs)
-	assert.Greater(t, controlCount, 0, "Expected control job (different canonical_title) to still appear")
+	// Control posting still appears.
+	assert.GreaterOrEqual(t, countTitle("Delivery Driver"), 1,
+		"a distinct control posting should still appear")
 }

--- a/iznik-server-go/test/jobs_test.go
+++ b/iznik-server-go/test/jobs_test.go
@@ -81,10 +81,14 @@ func TestJobsDedupeByCanonicalTitle(t *testing.T) {
 	lng := -2.0455619
 
 	db := database.DBConn
+
+	// Remove any stale rows from a previous crashed run before inserting.
+	// The jobs table has a unique(location, title) constraint, so stale rows
+	// would cause the insert below to fail with a duplicate-key error.
+	db.Exec("DELETE FROM jobs WHERE canonical_title IN (?, ?)", "test-role-dedup", "test-role-control")
+
 	defer func() {
-		// Cleanup: delete test jobs
-		db.Exec("DELETE FROM jobs WHERE canonical_title = ? OR canonical_title = ?",
-			"test-role-dedup", "test-role-control")
+		db.Exec("DELETE FROM jobs WHERE canonical_title IN (?, ?)", "test-role-dedup", "test-role-control")
 	}()
 
 	// Helper to insert a job with specific canonical_title

--- a/iznik-server-go/test/session_test.go
+++ b/iznik-server-go/test/session_test.go
@@ -1220,7 +1220,8 @@ func TestForgetPartnerFlow(t *testing.T) {
 	groupID := CreateTestGroup(t, prefix)
 	userID := CreateTestUser(t, prefix, "User")
 	CreateTestMembership(t, userID, groupID, "Member")
-	db.Exec("UPDATE users SET ljuserid = ? WHERE id = ?", uint64(99999), userID)
+	partnerUID := uint64(time.Now().UnixNano())
+	db.Exec("UPDATE users SET ljuserid = ? WHERE id = ?", partnerUID, userID)
 
 	// Seed a message + messages_groups row so we can confirm partner erasure still
 	// blanks content (unlike the self-service grace path).


### PR DESCRIPTION
## Summary

The FD jobs feed (`/api/job`) indexes the **same posting for many locations**, so a single role appears dozens of times in the list (Discourse 9739 — "every job identical except location").

The first attempt deduped by `canonical_title`. That was wrong: `canonical_title` is the **AI-image category** (`ai_images.name = jobs.canonical_title`), so many *unrelated* jobs from different employers — with different bodies — share it, and deduping by it hid genuinely distinct jobs.

This reworks the dedupe to key on **title + body** (location intentionally excluded):
- The same posting copied across many locations collapses to **one** card.
- Two different employers that happen to share a job **title** (but have different bodies) **both** still appear.

## Code Quality Review

- `seenCanonicalTitles` → `seenJobs`, keyed on `job.Title + "\x00" + job.Body`.
- `jobs.body` is already SELECTed and scanned, so the key is fully populated.
- `canonical_title` is retained only for the AI-image JOIN, not for identity.

## Test Plan

`TestJobsDedupeByTitleAndBody` (rewritten):
- Group A — identical title+body at two locations → collapses to 1.
- Group B — same title, **different bodies** (and same `canonical_title`) → both appear (2).
- Control — a distinct posting still appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
