### PR TITLE
fix(modtools): reject cross-posted messages on all authorized pending groups

### DIFF
--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -1832,7 +1832,25 @@ func handleReject(c *fiber.Ctx, myid uint64, req PostMessageRequest) error {
 	if req.Groupid != nil {
 		reqGid = *req.Groupid
 	}
-	authorizedGroups, err := resolveAuthorizedGroups(myid, reqGid, ctx.Groupids)
+	// Validate the specified groupid (if any), but reject from ALL groups the caller
+	// is authorised to moderate.  A cross-posted message may be pending on several
+	// groups; limiting the UPDATE to one groupid leaves the others stuck in Pending.
+	if reqGid > 0 {
+		if !auth.IsModOfGroup(myid, reqGid) {
+			return fiber.NewError(fiber.StatusForbidden, "Not a moderator for this group")
+		}
+		onGroup := false
+		for _, gid := range ctx.Groupids {
+			if gid == reqGid {
+				onGroup = true
+				break
+			}
+		}
+		if !onGroup {
+			return fiber.NewError(fiber.StatusNotFound, "Message not on that group")
+		}
+	}
+	authorizedGroups, err := resolveAuthorizedGroups(myid, 0, ctx.Groupids)
 	if err != nil {
 		return err
 	}
@@ -1845,10 +1863,25 @@ func handleReject(c *fiber.Ctx, myid uint64, req PostMessageRequest) error {
 			utils.COLLECTION_REJECTED, req.ID, authorizedGroups, utils.COLLECTION_PENDING); result.Error != nil {
 			log.Printf("Failed to reject message %d: %v", req.ID, result.Error)
 		}
+		// Clear held-by on rejected groups so they no longer appear in held-pending
+		// dashboard counts (mirrors the cleanup handleApprove already does).
+		db.Exec("UPDATE messages_groups SET heldby = NULL WHERE msgid = ? AND groupid IN ?", req.ID, authorizedGroups)
+		var stillHeldCount int64
+		db.Raw("SELECT COUNT(*) FROM messages_groups WHERE msgid = ? AND heldby IS NOT NULL", req.ID).Scan(&stillHeldCount)
+		if stillHeldCount == 0 {
+			db.Exec("UPDATE messages SET heldby = NULL WHERE id = ?", req.ID)
+		}
 	} else {
 		if result := db.Exec("UPDATE messages_groups SET deleted = 1 WHERE msgid = ? AND groupid IN ? AND collection = ?",
 			req.ID, authorizedGroups, utils.COLLECTION_PENDING); result.Error != nil {
 			log.Printf("Failed to delete pending message %d: %v", req.ID, result.Error)
+		}
+		// Clear held-by on deleted groups.
+		db.Exec("UPDATE messages_groups SET heldby = NULL WHERE msgid = ? AND groupid IN ?", req.ID, authorizedGroups)
+		var stillHeldCount int64
+		db.Raw("SELECT COUNT(*) FROM messages_groups WHERE msgid = ? AND heldby IS NOT NULL", req.ID).Scan(&stillHeldCount)
+		if stillHeldCount == 0 {
+			db.Exec("UPDATE messages SET heldby = NULL WHERE id = ?", req.ID)
 		}
 
 		// Cascade soft-delete: if no non-deleted groups remain, mark messages.deleted

--- a/iznik-server-go/test/message_test.go
+++ b/iznik-server-go/test/message_test.go
@@ -1135,6 +1135,101 @@ func TestPostMessageRejectAfterMemberWithdrawsPending(t *testing.T) {
 	assert.Equal(t, 200, rresp.StatusCode, "Mod should be able to reject message after member withdraws it (no 403)")
 }
 
+// TestRejectCrossPostedClearsAllPendingGroups verifies that rejecting a cross-posted
+// message clears the pending state on ALL groups the mod is authorized for, not only
+// the single groupid passed in the request.
+//
+// Discourse 9729: when a mod specified groupid=A but the message was also pending on
+// group B, the UPDATE had AND collection='Pending' AND groupid IN (A), so group B
+// stayed pending — the rejection was silently a no-op for it.
+func TestRejectCrossPostedClearsAllPendingGroups(t *testing.T) {
+	prefix := uniquePrefix("rej_xpost")
+	db := database.DBConn
+
+	groupA := CreateTestGroup(t, prefix+"_A")
+	groupB := CreateTestGroup(t, prefix+"_B")
+	modID := CreateTestUser(t, prefix+"_mod", "User")
+	posterID := CreateTestUser(t, prefix+"_poster", "User")
+	CreateTestMembership(t, modID, groupA, "Moderator")
+	CreateTestMembership(t, modID, groupB, "Moderator")
+	CreateTestMembership(t, posterID, groupA, "Member")
+	CreateTestMembership(t, posterID, groupB, "Member")
+	_, modToken := CreateTestSession(t, modID)
+
+	// Cross-post: message pending on both groups.
+	msgID := createPendingMessage(t, posterID, groupA, prefix)
+	db.Exec("INSERT INTO messages_groups (msgid, groupid, arrival, collection, autoreposts, contentcheck_checked_at) VALUES (?, ?, NOW(), 'Pending', 0, NOW())",
+		msgID, groupB)
+
+	// Reject specifying only group A — the bug left group B in 'Pending'.
+	body := map[string]interface{}{
+		"id":      msgID,
+		"action":  "Reject",
+		"groupid": groupA,
+		"subject": "This is a duplicate post.",
+		"body":    "Please do not cross-post.",
+	}
+	bodyBytes, _ := json.Marshal(body)
+	url := fmt.Sprintf("/api/message?jwt=%s", modToken)
+	req := httptest.NewRequest("POST", url, bytes.NewBuffer(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := getApp().Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var collectionA, collectionB string
+	db.Raw("SELECT collection FROM messages_groups WHERE msgid = ? AND groupid = ?", msgID, groupA).Scan(&collectionA)
+	db.Raw("SELECT collection FROM messages_groups WHERE msgid = ? AND groupid = ?", msgID, groupB).Scan(&collectionB)
+	assert.Equal(t, "Rejected", collectionA, "group A must be Rejected")
+	assert.Equal(t, "Rejected", collectionB, "group B must also be Rejected — cross-post rejection must clear all authorized pending groups")
+}
+
+// TestRejectHeldMessageClearsHeldBy verifies that rejecting a held message clears
+// the heldby field on messages_groups and messages, matching the behaviour of
+// handleApprove which already does this cleanup.
+func TestRejectHeldMessageClearsHeldBy(t *testing.T) {
+	prefix := uniquePrefix("rej_held")
+	db := database.DBConn
+
+	groupID := CreateTestGroup(t, prefix)
+	modID := CreateTestUser(t, prefix+"_mod", "User")
+	posterID := CreateTestUser(t, prefix+"_poster", "User")
+	CreateTestMembership(t, modID, groupID, "Moderator")
+	CreateTestMembership(t, posterID, groupID, "Member")
+	_, modToken := CreateTestSession(t, modID)
+
+	msgID := createPendingMessage(t, posterID, groupID, prefix)
+
+	// Hold the message.
+	db.Exec("UPDATE messages_groups SET heldby = ? WHERE msgid = ? AND groupid = ?", modID, msgID, groupID)
+	db.Exec("UPDATE messages SET heldby = ? WHERE id = ?", modID, msgID)
+
+	// Reject it.
+	body := map[string]interface{}{
+		"id":      msgID,
+		"action":  "Reject",
+		"groupid": groupID,
+		"subject": "Not suitable.",
+		"body":    "Please revise your post.",
+	}
+	bodyBytes, _ := json.Marshal(body)
+	url := fmt.Sprintf("/api/message?jwt=%s", modToken)
+	req := httptest.NewRequest("POST", url, bytes.NewBuffer(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := getApp().Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	// heldby must be cleared on both messages_groups and messages.
+	var mgHeldCount int64
+	db.Raw("SELECT COUNT(*) FROM messages_groups WHERE msgid = ? AND groupid = ? AND heldby IS NOT NULL", msgID, groupID).Scan(&mgHeldCount)
+	assert.Equal(t, int64(0), mgHeldCount, "messages_groups.heldby must be NULL after rejection")
+
+	var msgHeldCount int64
+	db.Raw("SELECT COUNT(*) FROM messages WHERE id = ? AND heldby IS NOT NULL", msgID).Scan(&msgHeldCount)
+	assert.Equal(t, int64(0), msgHeldCount, "messages.heldby must be NULL after rejection")
+}
+
 // --- Test: Delete (mod action) ---
 
 func TestPostMessageDelete(t *testing.T) {


### PR DESCRIPTION
## Root Cause

`handleReject()` called `resolveAuthorizedGroups(myid, reqGid, ctx.Groupids)` with the specific `groupid` supplied by the frontend. This returns exactly one group when a `groupid` is specified, so the `UPDATE … WHERE groupid IN (?) AND collection = 'Pending'` only touched that one row.

For a message cross-posted to multiple groups (both Pending), rejecting via `groupid=A` left group B in `Pending`. On the next frontend fetch, `message.groups[0]` could resolve to the already-Rejected group A (no `ORDER BY` in the DB query), and the retry UPDATE would silently match 0 rows — leaving the message permanently stuck in the mod's pending queue.

Additionally, `handleReject()` never cleared `messages_groups.heldby` / `messages.heldby`, unlike `handleApprove()`. Held-and-then-rejected messages left dangling `heldby` references that inflated the "held pending" dashboard count.

## Evidence

**Failing test (before fix)**:
```
--- FAIL: TestRejectCrossPostedClearsAllPendingGroups
    message_test.go:1175: group B must also be Rejected
    Expected "Rejected", got "Pending"
```

**After fix**: both tests pass in the full suite (2991✓ 0✗).

## Fix

`iznik-server-go/message/message.go` — `handleReject()`:

1. **Validate `reqGid` explicitly** — same 403/404 error semantics as before when an invalid groupid is specified.
2. **Call `resolveAuthorizedGroups(myid, 0, ctx.Groupids)`** — returns all groups the caller moderates, not just the one passed in. The UPDATE still has `AND collection = 'Pending'` so Approved/Spam rows are unaffected.
3. **Clear `heldby` after rejection** — mirrors the cleanup `handleApprove` already does; prevents stale held-pending dashboard counts.

## Other Call Sites

All other handlers (`handleApprove`, `handleDeleteMessage`, `handleSpam`, `handleHold`, `handleRelease`, `handleBackToPending`) use `resolveAuthorizedGroups(myid, reqGid, ...)` unchanged — per-group semantics are correct for those actions.

## Test

| File | Command | Proves |
|---|---|---|
| `iznik-server-go/test/message_test.go` | `TestRejectCrossPostedClearsAllPendingGroups` | cross-post rejection clears both groups — FAIL before fix, PASS after |
| `iznik-server-go/test/message_test.go` | `TestRejectHeldMessageClearsHeldBy` | held rejection clears heldby — FAIL before fix, PASS after |

## Discourse
https://discourse.ilovefreegle.org/t/9729/1