### PR TITLE
feat(ai-image): suppress AI images for unsuitable items (9630)

### DIFF
--- a/iznik-batch/database/migrations/2026_06_02_000001_add_suppressed_to_ai_images_status.php
+++ b/iznik-batch/database/migrations/2026_06_02_000001_add_suppressed_to_ai_images_status.php
@@ -1,0 +1,54 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (!Schema::hasTable('ai_images')) {
+            return;
+        }
+
+        // Append 'suppressed' so a reviewer can permanently mark an item NAME as
+        // "should never have an AI image" (e.g. abstract items like cash/lift/voucher
+        // where a generated photo is misleading).
+        //
+        // Unlike 'rejected' — which is part of the reversible rejected -> regenerating
+        // -> active flow ("this image is bad, make a better one") — 'suppressed' is
+        // TERMINAL: the Pollinations generator skips the name and Regenerate refuses.
+        //
+        // End-append keeps the enum at 1 byte of storage. ALGORITHM=INPLACE, LOCK=NONE
+        // is the Galera-safe form for ENUM widening (INSTANT is not supported for ENUM
+        // modification on Percona/Galera — see reference_galera_enum_alter). The DDL is
+        // metadata-only; existing rows are untouched.
+        DB::statement("
+            ALTER TABLE ai_images
+              MODIFY COLUMN status
+                ENUM('active','rejected','regenerating','suppressed')
+                NOT NULL DEFAULT 'active',
+              ALGORITHM=INPLACE, LOCK=NONE
+        ");
+    }
+
+    public function down(): void
+    {
+        if (!Schema::hasTable('ai_images')) {
+            return;
+        }
+
+        // Coerce suppressed rows back to 'rejected' before narrowing, else the ALTER
+        // fails on rows whose value is no longer in the enum.
+        DB::statement("UPDATE ai_images SET status = 'rejected' WHERE status = 'suppressed'");
+
+        DB::statement("
+            ALTER TABLE ai_images
+              MODIFY COLUMN status
+                ENUM('active','rejected','regenerating')
+                NOT NULL DEFAULT 'active',
+              ALGORITHM=INPLACE, LOCK=NONE
+        ");
+    }
+};

--- a/iznik-batch/database/migrations/2026_06_02_000002_add_suppress_to_microactions_result.php
+++ b/iznik-batch/database/migrations/2026_06_02_000002_add_suppress_to_microactions_result.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (!Schema::hasTable('microactions')) {
+            return;
+        }
+
+        // Append 'Suppress' so an AIImageReview micro-volunteering vote can say
+        // "this item should never have an AI image" (distinct from 'Reject', which
+        // means "this generated image is bad"). At quorum the Go API sets the
+        // ai_images row to status='suppressed'. End-append is metadata-only;
+        // INPLACE/LOCK=NONE is the Galera-safe form for ENUM widening.
+        DB::statement("
+            ALTER TABLE microactions
+              MODIFY COLUMN result ENUM('Approve','Reject','Suppress') NOT NULL,
+              ALGORITHM=INPLACE, LOCK=NONE
+        ");
+    }
+
+    public function down(): void
+    {
+        if (!Schema::hasTable('microactions')) {
+            return;
+        }
+
+        DB::statement("UPDATE microactions SET result = 'Reject' WHERE result = 'Suppress'");
+
+        DB::statement("
+            ALTER TABLE microactions
+              MODIFY COLUMN result ENUM('Approve','Reject') NOT NULL,
+              ALGORITHM=INPLACE, LOCK=NONE
+        ");
+    }
+};

--- a/iznik-nuxt3/components/MicroVolunteeringAIImageReview.vue
+++ b/iznik-nuxt3/components/MicroVolunteeringAIImageReview.vue
@@ -91,6 +91,21 @@
           Please answer the question above first
         </p>
       </div>
+
+      <div class="question-block mb-3">
+        <p class="question-label">Not suitable for a picture at all?</p>
+        <SpinButton
+          variant="outline-danger"
+          icon-name="ban"
+          label="This item shouldn't have an AI image"
+          @handle="suppress"
+        />
+        <p class="help-hint mt-2">
+          Use this for things that shouldn't have a generated picture at all
+          (e.g. cash, a lift, a voucher). We won't create an image for this item
+          again.
+        </p>
+      </div>
     </div>
   </div>
 </template>
@@ -155,6 +170,21 @@ async function reject(callback) {
   await microVolunteeringStore.respond({
     aiimageid: props.aiimage.id,
     response: 'Reject',
+    containspeople: containsPeople.value,
+  })
+
+  submitted.value = true
+  callback()
+  emit('next')
+}
+
+// Suppress: the item itself shouldn't have an AI image at all (terminal — once
+// enough reviewers agree, we never generate or show an image for this item again).
+// Distinct from Reject, which just means "this generated image is poor".
+async function suppress(callback) {
+  await microVolunteeringStore.respond({
+    aiimageid: props.aiimage.id,
+    response: 'Suppress',
     containspeople: containsPeople.value,
   })
 

--- a/iznik-nuxt3/tests/unit/components/MicroVolunteeringAIImageReview.spec.js
+++ b/iznik-nuxt3/tests/unit/components/MicroVolunteeringAIImageReview.spec.js
@@ -194,11 +194,54 @@ describe('MicroVolunteeringAIImageReview', () => {
     })
   })
 
+  describe('suppress flow', () => {
+    it('calls store respond with Suppress when the item is unsuitable for any image', async () => {
+      const wrapper = createWrapper()
+
+      // Answer people question — no
+      const buttons = wrapper.findAll('.b-button')
+      await buttons[1].trigger('click')
+
+      const spinButtons = wrapper.findAll('.spin-button')
+      const suppressBtn = spinButtons.find((b) =>
+        b.text().includes("shouldn't have an AI image")
+      )
+      await suppressBtn.trigger('click')
+      await flushPromises()
+
+      expect(mockMicroVolunteeringStore.respond).toHaveBeenCalledWith({
+        aiimageid: 42,
+        response: 'Suppress',
+        containspeople: false,
+      })
+    })
+
+    it('emits next event after suppress', async () => {
+      const wrapper = createWrapper()
+
+      const spinButtons = wrapper.findAll('.spin-button')
+      const suppressBtn = spinButtons.find((b) =>
+        b.text().includes("shouldn't have an AI image")
+      )
+      await suppressBtn.trigger('click')
+      await flushPromises()
+
+      expect(wrapper.emitted('next')).toHaveLength(1)
+    })
+  })
+
   describe('button state', () => {
     it('disables quality buttons until people question answered', () => {
       const wrapper = createWrapper()
-      const spinButtons = wrapper.findAll('.spin-button')
-      spinButtons.forEach((btn) => {
+      // Only the image-judgement buttons (Approve / Reject) are gated on the
+      // people question. The Suppress action ("this item shouldn't have an AI
+      // image") is about the item itself, not this image, so it is intentionally
+      // always available and excluded here.
+      const gated = wrapper
+        .findAll('.spin-button')
+        .filter((btn) => !btn.text().includes("shouldn't have an AI image"))
+      expect(gated.length).toBeGreaterThan(0)
+      gated.forEach((btn) => {
         expect(btn.attributes('disabled')).toBeDefined()
       })
     })

--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -456,7 +456,7 @@ func GetMessagesByIds(myid uint64, ids []string, isPartner bool) []Message {
 				CASE WHEN ai.id IS NOT NULL THEN '' ELSE COALESCE(ma.externaluid, '') END AS externaluid,
 				ma.externalmods
 				FROM messages_attachments ma
-				LEFT JOIN ai_images ai ON ai.externaluid = ma.externaluid AND ai.status IN ('rejected', 'regenerating')
+				LEFT JOIN ai_images ai ON ai.externaluid = ma.externaluid AND ai.status IN ('rejected', 'regenerating', 'suppressed')
 				WHERE ma.msgid = ?
 				ORDER BY ma.`+"`primary`"+` DESC, ma.id ASC`, id).Scan(&messageAttachments)
 			}()

--- a/iznik-server-go/microvolunteering/microvolunteering.go
+++ b/iznik-server-go/microvolunteering/microvolunteering.go
@@ -772,7 +772,7 @@ func PostResponse(c *fiber.Ctx) error {
 		// Response to an AIImageReview challenge.
 		response := *req.Response
 
-		if response == "Approve" || response == "Reject" {
+		if response == "Approve" || response == "Reject" || response == "Suppress" {
 			var containsPeople interface{}
 			if req.ContainsPeople != nil {
 				if *req.ContainsPeople {
@@ -788,7 +788,10 @@ func PostResponse(c *fiber.Ctx) error {
 				ChallengeAIImageReview, myid, req.AIImageID, response, containsPeople, Version,
 				response, containsPeople, Version)
 
-			// After recording the vote, check if reject quorum is reached.
+			// After recording the vote, check the quorums. 'Suppress' ("this item
+			// should never have an AI image") is terminal, so check it first; 'Reject'
+			// ("this image is bad") leaves the name open to regeneration.
+			checkAIImageSuppressQuorum(db, req.AIImageID)
 			checkAIImageRejectQuorum(db, req.AIImageID)
 		}
 
@@ -1000,5 +1003,22 @@ func checkAIImageRejectQuorum(db *gorm.DB, aiImageID uint64) {
 
 	if totalVotes >= int64(AIImageReviewQuorum) && rejectVotes > totalVotes/2 {
 		db.Exec(`UPDATE ai_images SET status = 'rejected' WHERE id = ? AND status = 'active'`, aiImageID)
+	}
+}
+
+// checkAIImageSuppressQuorum checks whether an AI image has reached the suppress
+// quorum (≥ AIImageReviewQuorum votes with a majority being Suppress). If so, sets
+// status='suppressed' — a TERMINAL state meaning this item name should never have an
+// AI image: the Pollinations generator skips the name, the image is never shown, and
+// Regenerate refuses. Suppress overrides a prior 'rejected' state.
+func checkAIImageSuppressQuorum(db *gorm.DB, aiImageID uint64) {
+	var totalVotes, suppressVotes int64
+	db.Raw(`SELECT COUNT(*) FROM microactions WHERE aiimageid = ? AND actiontype = ?`,
+		aiImageID, ChallengeAIImageReview).Scan(&totalVotes)
+	db.Raw(`SELECT COUNT(*) FROM microactions WHERE aiimageid = ? AND actiontype = ? AND result = 'Suppress'`,
+		aiImageID, ChallengeAIImageReview).Scan(&suppressVotes)
+
+	if totalVotes >= int64(AIImageReviewQuorum) && suppressVotes > totalVotes/2 {
+		db.Exec(`UPDATE ai_images SET status = 'suppressed' WHERE id = ? AND status IN ('active','rejected')`, aiImageID)
 	}
 }

--- a/iznik-server-go/test/microvolunteering_ai_image_test.go
+++ b/iznik-server-go/test/microvolunteering_ai_image_test.go
@@ -421,3 +421,71 @@ func TestGetChallenge_SkipsRejectedImages(t *testing.T) {
 	}
 	// If no challenge at all that's also correct — no active images to review.
 }
+
+// TestGetChallenge_SkipsSuppressedImages verifies that AI images with
+// status='suppressed' (the item should never have an AI image) are not served.
+func TestGetChallenge_SkipsSuppressedImages(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("mv_aisuppressed")
+	userID := CreateTestUser(t, prefix, "User")
+	_, token := CreateTestSession(t, userID)
+	blockInviteChallenge(t, userID)
+
+	suppressedUID := "freegletusd-test-suppressed-" + prefix
+	db.Exec("INSERT INTO ai_images (name, externaluid, usage_count, status) VALUES (?, ?, 100, 'suppressed')",
+		"suppressed-"+prefix, suppressedUID)
+	var suppressedID uint64
+	db.Raw("SELECT id FROM ai_images WHERE name = ? ORDER BY id DESC LIMIT 1", "suppressed-"+prefix).Scan(&suppressedID)
+	assert.NotZero(t, suppressedID)
+
+	t.Cleanup(func() {
+		db.Exec("DELETE FROM ai_images WHERE id = ?", suppressedID)
+	})
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET",
+		"/api/microvolunteering?jwt="+token+"&types=AIImageReview", nil))
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json2.Unmarshal(rsp(resp), &result)
+
+	if typ, ok := result["type"]; ok && typ == microvolunteering.ChallengeAIImageReview {
+		aiimage, ok := result["aiimage"].(map[string]interface{})
+		assert.True(t, ok)
+		assert.NotEqual(t, float64(suppressedID), aiimage["id"],
+			"Suppressed AI image must not be served as a challenge")
+	}
+}
+
+// TestAIImageReview_SuppressQuorumReached verifies that a quorum of 'Suppress' votes
+// sets the AI image to status='suppressed' (terminal — never generated/shown again),
+// distinct from 'Reject' which leaves status='rejected'.
+func TestAIImageReview_SuppressQuorumReached(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("mv_aisupq")
+
+	var voterTokens []string
+	for i := 0; i < 5; i++ {
+		uid := CreateTestUser(t, fmt.Sprintf("%s_v%d", prefix, i), "User")
+		_, tok := CreateTestSession(t, uid)
+		voterTokens = append(voterTokens, tok)
+	}
+
+	imgID := createTestAIImage(t, "suppress-quorum-"+prefix, 200)
+	t.Cleanup(func() {
+		db.Exec("DELETE FROM microactions WHERE aiimageid = ? AND actiontype = ?", imgID, microvolunteering.ChallengeAIImageReview)
+		db.Exec("DELETE FROM ai_images WHERE id = ?", imgID)
+	})
+
+	for i := 0; i < 5; i++ {
+		body := fmt.Sprintf(`{"aiimageid":%d,"response":"Suppress","containspeople":false}`, imgID)
+		req := httptest.NewRequest("POST", "/api/microvolunteering?jwt="+voterTokens[i], strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		resp, _ := getApp().Test(req)
+		assert.Equal(t, 200, resp.StatusCode)
+	}
+
+	var status string
+	db.Raw("SELECT status FROM ai_images WHERE id = ?", imgID).Scan(&status)
+	assert.Equal(t, "suppressed", status, "5 Suppress votes should set the image to suppressed")
+}

--- a/iznik-server/scripts/cron/messages_illustrations.php
+++ b/iznik-server/scripts/cron/messages_illustrations.php
@@ -124,7 +124,15 @@ do {
         }
 
         # Check if we already have a cached image for this item name.
-        $cached = $dbhr->preQuery("SELECT externaluid FROM ai_images WHERE name = ?", [$itemName]);
+        $cached = $dbhr->preQuery("SELECT externaluid, status FROM ai_images WHERE name = ?", [$itemName]);
+
+        # Suppressed: this item name has been deliberately marked as unsuitable for an
+        # AI image (quorum of 'Suppress' votes). Never attach one and never regenerate —
+        # the row already exists so it is skipped by the no-row generation path anyway,
+        # but we must not attach its (now-suppressed) cached image.
+        if (count($cached) > 0 && ($cached[0]['status'] ?? '') === 'suppressed') {
+            continue;
+        }
 
         if (count($cached) > 0 && $cached[0]['externaluid']) {
             $cachedMessages[] = [


### PR DESCRIPTION
## Summary

Implements a way for reviewers to say **"this item should never have an AI image"** — the capability that was missing (raised against #364 / Discourse 9630/4). This is distinct from **Reject** ("this generated image is poor"), which leaves the item open to regeneration via the reversible `rejected → regenerating → active` flow.

- **DB** — append a terminal `'suppressed'` to `ai_images.status`, and `'Suppress'` to `microactions.result`. Both are Galera-safe `ALGORITHM=INPLACE, LOCK=NONE` end-appends (INSTANT isn't supported for ENUM).
- **Go** — `AIImageReview` accepts a `'Suppress'` vote; at quorum (`checkAIImageSuppressQuorum`, mirrors reject) the row goes to `status='suppressed'`. Suppressed images are never served as review challenges (`status='active'` gate) and never shown on messages (display JOIN now also hides `'suppressed'`).
- **Generator** (`messages_illustrations.php`) — a suppressed name is never regenerated (the existence check is status-agnostic) and its cached image is never attached.
- **Regenerate** already refuses anything not `rejected`/`regenerating`, so `suppressed` is terminal.
- **UI** (`MicroVolunteeringAIImageReview.vue`) — a separated "This item shouldn't have an AI image" action, visually distinct from Reject to avoid mis-clicks.

## Code Quality Review
- No new columns/tables — reuses the existing status/result enums.
- Suppress mirrors the existing reject quorum exactly (consistency).
- `suppressed` overrides a prior `rejected` (terminal wins).

## Future Improvements
- Optional Support/Admin `ForceSuppressAIImage` (immediate) mirroring `ForceRejectAIImage`.
- A tool to un-suppress if a name is suppressed in error.

## Test Plan
- Go: `TestAIImageReview_SuppressQuorumReached` (5 Suppress votes → `status='suppressed'`); `TestGetChallenge_SkipsSuppressedImages`.
- Vitest: suppress button calls `respond` with `response:'Suppress'` and emits `next`.
- Migrations apply cleanly (enum widen).

## Live schema
`ai_images.status` already widened on live. Still to run (or it lands via the migration on the next Laravel deploy):
```sql
ALTER TABLE microactions MODIFY COLUMN result
  ENUM('Approve','Reject','Suppress') NOT NULL, ALGORITHM=INPLACE, LOCK=NONE;
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
