### PR TITLE
Update registered name "Freegle Limited" → "Freegle"

### DIFF
--- a/iznik-batch/resources/views/emails/mjml/lovejunk/tn-invoice.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/lovejunk/tn-invoice.blade.php
@@ -11,7 +11,7 @@
           LoveJunk Invoice Request
         </mj-text>
         <mj-text>
-          Please raise an invoice on Freegle Ltd for your share of the LoveJunk advertising income.
+          Please raise an invoice on Freegle for your share of the LoveJunk advertising income.
         </mj-text>
         <mj-divider border-color="#eeeeee" border-width="1px" />
         <mj-text>

--- a/iznik-batch/tests/Feature/LoveJunk/LoveJunkTnInvoiceTest.php
+++ b/iznik-batch/tests/Feature/LoveJunk/LoveJunkTnInvoiceTest.php
@@ -44,6 +44,24 @@ class LoveJunkTnInvoiceTest extends TestCase
             ->assertExitCode(0);
     }
 
+    public function test_invoice_email_uses_current_registered_name(): void
+    {
+        // Our registered name is "Freegle" (formerly "Freegle Limited"/"Freegle Ltd").
+        // The invoice template must use the current name.
+        $html = view('emails.mjml.lovejunk.tn-invoice', [
+            'tnAmount'      => '250.00',
+            'start'         => '2020-01-01',
+            'end'           => '2020-02-01',
+            'tnPercent'     => 50,
+            'treasurerAddr' => 'treasurer@example.com',
+            'email'         => 'partner@example.com',
+        ])->render();
+
+        $this->assertStringContainsString('raise an invoice on Freegle for', $html);
+        $this->assertStringNotContainsString('Freegle Ltd', $html);
+        $this->assertStringNotContainsString('Freegle Limited', $html);
+    }
+
     public function test_dry_run_does_not_send_email(): void
     {
         $msgId = $this->insertMessage('TN-abc123', '2020-01-15 12:00:00');

--- a/iznik-nuxt3/pages/about.vue
+++ b/iznik-nuxt3/pages/about.vue
@@ -281,12 +281,12 @@
                   </ul>
                   <p>
                     Each Freegle local group is run independently and is
-                    affiliated to Freegle Ltd, which provides central services
+                    affiliated to Freegle, which provides central services
                     (such as this website) to these groups and their volunteers.
-                    Freegle Ltd is a registered society under the Co-operative
+                    Freegle is a registered society under the Co-operative
                     and Community Benefit Societies Act 2014 (previously known
                     as an Industrial and Provident Society for Community
-                    Benefit). Freegle Ltd is owned and governed by its members.
+                    Benefit). Freegle is owned and governed by its members.
                     Local and national volunteers are eligible for membership.
                   </p>
                   <p>

--- a/iznik-nuxt3/pages/donate.vue
+++ b/iznik-nuxt3/pages/donate.vue
@@ -105,7 +105,7 @@
               <p>
                 Sort code: <strong>60-83-01</strong><br />
                 Account: <strong>20339094</strong><br />
-                Name: Freegle Limited (Unity Trust Bank)
+                Name: Freegle (Unity Trust Bank)
               </p>
               <p class="reference-note">
                 Reference:
@@ -118,7 +118,7 @@
             <div class="donate-option">
               <h3><v-icon icon="envelope" /> By Cheque</h3>
               <p>
-                Payable to <strong>Freegle Limited</strong><br />
+                Payable to <strong>Freegle</strong><br />
                 Send to: 64A North Road, Ormesby, Great Yarmouth NR29 3LE
               </p>
               <p class="reference-note">


### PR DESCRIPTION
## What

Our registered name changed from **"Freegle Limited"** to **"Freegle"**. This updates all user-facing and document references to the new name (excluding iznik-server V1 per instruction).

## Changes

| File | Change |
|------|--------|
| `iznik-nuxt3/pages/donate.vue` | Bank account name and cheque payee: `Freegle Limited` → `Freegle` |
| `iznik-nuxt3/pages/about.vue` | Registered-society description: `Freegle Ltd` → `Freegle` (3 occurrences) |
| `iznik-batch/resources/views/emails/mjml/lovejunk/tn-invoice.blade.php` | Invoice request text: `Freegle Ltd` → `Freegle` |
| `iznik-batch/tests/Feature/LoveJunk/LoveJunkTnInvoiceTest.php` | New regression test rendering the invoice template, asserting the current name is used and the old names are absent |

## Deliberately left unchanged

- `iznik-nuxt3/README-APP.md` — the Android keystore alias example `"Freegle Ltd Chris"` is the **literal alias baked into the existing signing keystore**, a fixed cryptographic identifier rather than a legal-name reference. Changing the doc would make it no longer match the real keystore, breaking CI signing docs.
- `iznik-server` (V1) — excluded per instruction.

## Testing (run locally via status API)

- **Laravel** (`--filter=LoveJunkTnInvoiceTest`): **12/12 passed** ✓ (includes the new regression test)
- **Vitest** (full unit suite): **12,821 passed, 0 failed** ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)