### PR TITLE
fix(auth): scope logout to the current login series for MT/FD parity (#9748)

### DIFF
--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -23,7 +23,7 @@ parameters:
     description: "Forwarded from trigger — true when build_modtools_production was set"
 
 orbs:
-  freegle: freegle/tests@1.1.326
+  freegle: freegle/tests@1.1.332
 
 jobs:
   mark-ci-passed:

--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -23,7 +23,7 @@ parameters:
     description: "Forwarded from trigger — true when build_modtools_production was set"
 
 orbs:
-  freegle: freegle/tests@1.1.332
+  freegle: freegle/tests@1.1.334
 
 jobs:
   mark-ci-passed:

--- a/iznik-server-go/session/session.go
+++ b/iznik-server-go/session/session.go
@@ -1780,7 +1780,26 @@ func DeleteSession(c *fiber.Ctx) error {
 
 	if myid > 0 {
 		db := database.DBConn
-		db.Exec("DELETE FROM sessions WHERE userid = ?", myid)
+
+		// Delete only the caller's current session so that other devices/browsers
+		// remain logged in. The JWT carries the session row ID; fall back to the
+		// legacy Authorization2 persistent-token header when no JWT is present.
+		_, sessionId, _ := user.GetJWTFromRequest(c)
+
+		if sessionId == 0 {
+			// Persistent-token path: extract session ID from Authorization2 header.
+			persistent := c.Get("Authorization2")
+			if persistent != "" {
+				var pt auth.PersistentToken
+				if jsonErr := json.Unmarshal([]byte(persistent), &pt); jsonErr == nil {
+					sessionId = pt.ID
+				}
+			}
+		}
+
+		if sessionId > 0 {
+			db.Exec("DELETE FROM sessions WHERE id = ? AND userid = ?", sessionId, myid)
+		}
 	}
 
 	return c.JSON(fiber.Map{

--- a/iznik-server-go/session/session.go
+++ b/iznik-server-go/session/session.go
@@ -1781,24 +1781,34 @@ func DeleteSession(c *fiber.Ctx) error {
 	if myid > 0 {
 		db := database.DBConn
 
-		// Delete only the caller's current session so that other devices/browsers
-		// remain logged in. The JWT carries the session row ID; fall back to the
-		// legacy Authorization2 persistent-token header when no JWT is present.
-		_, sessionId, _ := user.GetJWTFromRequest(c)
+		// V1 parity (Session::destroy($userid, $series)): log out the current
+		// login SERIES, not all the user's sessions and not a single session row.
+		// Freegle and ModTools each get their own series at login, so deleting by
+		// series logs the user out of only the current app and leaves the other
+		// app logged in (Discourse #9748: logout was clearing both at once).
+		var series uint64
 
-		if sessionId == 0 {
-			// Persistent-token path: extract session ID from Authorization2 header.
-			persistent := c.Get("Authorization2")
-			if persistent != "" {
-				var pt auth.PersistentToken
-				if jsonErr := json.Unmarshal([]byte(persistent), &pt); jsonErr == nil {
-					sessionId = pt.ID
-				}
+		// Persistent-token (Authorization2) carries the series directly.
+		if persistent := c.Get("Authorization2"); persistent != "" {
+			var pt auth.PersistentToken
+			if json.Unmarshal([]byte(persistent), &pt) == nil {
+				series = pt.Series
 			}
 		}
 
-		if sessionId > 0 {
-			db.Exec("DELETE FROM sessions WHERE id = ? AND userid = ?", sessionId, myid)
+		// JWT path: resolve the series from the session row the JWT identifies.
+		if series == 0 {
+			if _, sessionId, _ := user.GetJWTFromRequest(c); sessionId > 0 {
+				db.Raw("SELECT series FROM sessions WHERE id = ? AND userid = ?", sessionId, myid).Scan(&series)
+			}
+		}
+
+		if series > 0 {
+			db.Exec("DELETE FROM sessions WHERE userid = ? AND series = ?", myid, series)
+		} else {
+			// Series could not be determined - fall back to V1's null-series path
+			// (clear all the user's sessions) so logout never silently no-ops.
+			db.Exec("DELETE FROM sessions WHERE userid = ?", myid)
 		}
 	}
 

--- a/iznik-server-go/test/session_test.go
+++ b/iznik-server-go/test/session_test.go
@@ -1030,23 +1030,36 @@ func TestDeleteSession(t *testing.T) {
 // invalidates the caller's session, leaving other active sessions (other devices)
 // intact. Regression test for Discourse #9748: logout was deleting all sessions
 // for the user instead of just the current one.
-func TestDeleteSessionScopedToCurrentDevice(t *testing.T) {
-	prefix := uniquePrefix("del_sess_scope")
+// TestDeleteSessionScopedToCurrentSeries verifies V1 parity
+// (Session::destroy with a series): logging out deletes the current login
+// SERIES only, so a separate app's session (a different series - e.g. ModTools
+// while Freegle is logged in) stays active. Regression test for Discourse
+// #9748: logout was deleting ALL of a user's sessions, logging them out of both
+// Freegle and ModTools at once.
+func TestDeleteSessionScopedToCurrentSeries(t *testing.T) {
+	prefix := uniquePrefix("del_sess_series")
 	userID := CreateTestUser(t, prefix, "User")
-
-	// Two sessions simulating two independent devices/browsers.
-	session1ID, token1 := CreateTestSession(t, userID)
-	session2ID, _ := CreateTestSession(t, userID)
-
 	db := database.DBConn
 
-	// Verify both sessions exist before logout.
-	var countBefore int64
-	db.Raw("SELECT COUNT(*) FROM sessions WHERE userid = ?", userID).Scan(&countBefore)
-	assert.Equal(t, int64(2), countBefore, "expected 2 sessions before logout")
+	// Production gives each login a distinct random series; the CreateTestSession
+	// helper hardcodes series=userID, so insert explicit series here. series1 is
+	// the current app login (two tabs); series2 is a separate app login.
+	series1 := userID*1000 + 1
+	series2 := userID*1000 + 2
 
-	// Log out using device 1's JWT.
-	req := httptest.NewRequest("DELETE", "/api/session?jwt="+token1, nil)
+	mk := func(series uint64) uint64 {
+		db.Exec("INSERT INTO sessions (userid, series, token, date, lastactive) VALUES (?, ?, 1, NOW(), NOW())", userID, series)
+		var id uint64
+		db.Raw("SELECT id FROM sessions WHERE userid = ? ORDER BY id DESC LIMIT 1", userID).Scan(&id)
+		return id
+	}
+	idA := mk(series1) // current login (series 1)
+	idB := mk(series1) // same login series, another tab
+	idC := mk(series2) // separate app login (series 2)
+
+	token := GetToken(userID, idA)
+
+	req := httptest.NewRequest("DELETE", "/api/session?jwt="+token, nil)
 	resp, _ := getApp().Test(req)
 	assert.Equal(t, 200, resp.StatusCode)
 
@@ -1054,15 +1067,16 @@ func TestDeleteSessionScopedToCurrentDevice(t *testing.T) {
 	json.NewDecoder(resp.Body).Decode(&result)
 	assert.Equal(t, float64(0), result["ret"])
 
-	// Device 1's session must be destroyed.
-	var session1Count int64
-	db.Raw("SELECT COUNT(*) FROM sessions WHERE id = ?", session1ID).Scan(&session1Count)
-	assert.Equal(t, int64(0), session1Count, "logged-out session should be deleted")
-
-	// Device 2's session must remain active (other device should stay logged in).
-	var session2Count int64
-	db.Raw("SELECT COUNT(*) FROM sessions WHERE id = ?", session2ID).Scan(&session2Count)
-	assert.Equal(t, int64(1), session2Count, "other device session should remain active")
+	count := func(id uint64) int64 {
+		var n int64
+		db.Raw("SELECT COUNT(*) FROM sessions WHERE id = ?", id).Scan(&n)
+		return n
+	}
+	// The whole current series is logged out...
+	assert.Equal(t, int64(0), count(idA), "current session (series 1) should be deleted")
+	assert.Equal(t, int64(0), count(idB), "same-series session should also be deleted")
+	// ...but the other app's series stays logged in.
+	assert.Equal(t, int64(1), count(idC), "other app session (series 2) must remain logged in")
 }
 
 // ---------------------------------------------------------------------------

--- a/iznik-server-go/test/session_test.go
+++ b/iznik-server-go/test/session_test.go
@@ -1026,6 +1026,45 @@ func TestDeleteSession(t *testing.T) {
 	assert.Equal(t, int64(0), countAfter)
 }
 
+// TestDeleteSessionScopedToCurrentDevice verifies that DELETE /session only
+// invalidates the caller's session, leaving other active sessions (other devices)
+// intact. Regression test for Discourse #9748: logout was deleting all sessions
+// for the user instead of just the current one.
+func TestDeleteSessionScopedToCurrentDevice(t *testing.T) {
+	prefix := uniquePrefix("del_sess_scope")
+	userID := CreateTestUser(t, prefix, "User")
+
+	// Two sessions simulating two independent devices/browsers.
+	session1ID, token1 := CreateTestSession(t, userID)
+	session2ID, _ := CreateTestSession(t, userID)
+
+	db := database.DBConn
+
+	// Verify both sessions exist before logout.
+	var countBefore int64
+	db.Raw("SELECT COUNT(*) FROM sessions WHERE userid = ?", userID).Scan(&countBefore)
+	assert.Equal(t, int64(2), countBefore, "expected 2 sessions before logout")
+
+	// Log out using device 1's JWT.
+	req := httptest.NewRequest("DELETE", "/api/session?jwt="+token1, nil)
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&result)
+	assert.Equal(t, float64(0), result["ret"])
+
+	// Device 1's session must be destroyed.
+	var session1Count int64
+	db.Raw("SELECT COUNT(*) FROM sessions WHERE id = ?", session1ID).Scan(&session1Count)
+	assert.Equal(t, int64(0), session1Count, "logged-out session should be deleted")
+
+	// Device 2's session must remain active (other device should stay logged in).
+	var session2Count int64
+	db.Raw("SELECT COUNT(*) FROM sessions WHERE id = ?", session2ID).Scan(&session2Count)
+	assert.Equal(t, int64(1), session2Count, "other device session should remain active")
+}
+
 // ---------------------------------------------------------------------------
 // POST /session - Forget
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Root Cause

`DeleteSession` (the `DELETE /api/session` handler in `iznik-server-go/session/session.go`) executed:

```sql
DELETE FROM sessions WHERE userid = ?
```

This logged the user out of **every** session at once. Freegle (FD) and ModTools (MT) historically had **separate logins** — a moderator could stay logged into ModTools while logging in and out of different Freegle accounts in the same browser. The blanket delete broke that separation (regression, Discourse #9748).

An earlier attempt scoped logout to a single session **row id**. That is not how V1 behaves: V1 (`Session::destroy($userid, $series)`) keys on the login **series**, and FD and MT each get their own series at login. Scoping to one row would log out only a single tab; scoping to the series logs out the current app while leaving the other app logged in.

## Fix — V1 parity (delete by series)

`iznik-server-go/session/session.go` — resolve the current login **series** and delete that series only:

1. From the `Authorization2` persistent-token header (carries the series directly), else
2. From the JWT: `SELECT series FROM sessions WHERE id = ? AND userid = ?` for the JWT's session id.

```sql
DELETE FROM sessions WHERE userid = ? AND series = ?
```

If the series cannot be determined, it falls back to the original all-sessions delete so logout never silently no-ops. `handleForget` (account deletion) still clears all sessions intentionally.

The `sessions` table has a `series` column (unique index `id, series, token`), matching V1.

## Other Call Sites

- `session.go` `handleForget` (self-service account deletion): `DELETE WHERE userid` is **correct** — clear everything on account removal.
- No other `DELETE FROM sessions` exists.

## Test

`iznik-server-go/test/session_test.go` — `TestDeleteSessionScopedToCurrentSeries`:
- inserts three session rows: two in the **current** series (series 1, two tabs) and one in a **separate app's** series (series 2)
- after logout, asserts both series-1 rows are deleted **and** the series-2 row survives

Fails on the buggy code (series-2 row also deleted), passes after the fix.

> Note: post #2 on the Discourse topic is a **separate** bug (a ModTools sub-page opened while logged out shows "Oh dear" instead of a login dialog) and is not addressed here.

## Discourse

https://discourse.ilovefreegle.org/t/9748/1
