### PR TITLE
fix(chitchat): space the "..." options menu away from post text (#9749)

### DIFF
--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -23,7 +23,7 @@ parameters:
     description: "Forwarded from trigger — true when build_modtools_production was set"
 
 orbs:
-  freegle: freegle/tests@1.1.326
+  freegle: freegle/tests@1.1.332
 
 jobs:
   mark-ci-passed:

--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -23,7 +23,7 @@ parameters:
     description: "Forwarded from trigger — true when build_modtools_production was set"
 
 orbs:
-  freegle: freegle/tests@1.1.332
+  freegle: freegle/tests@1.1.334
 
 jobs:
   mark-ci-passed:

--- a/iznik-nuxt3/components/ChatListEntry.vue
+++ b/iznik-nuxt3/components/ChatListEntry.vue
@@ -201,7 +201,7 @@ onMounted(() => {
   min-width: 0;
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 6px;
 }
 
 .chat-header {

--- a/iznik-nuxt3/components/ChatListEntry.vue
+++ b/iznik-nuxt3/components/ChatListEntry.vue
@@ -201,7 +201,7 @@ onMounted(() => {
   min-width: 0;
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 2px;
 }
 
 .chat-header {

--- a/iznik-nuxt3/components/NewsThread.vue
+++ b/iznik-nuxt3/components/NewsThread.vue
@@ -666,6 +666,12 @@ async function unmute() {
   z-index: 10000;
 }
 
+.thread-menu {
+  /* The "..." menu is floated to the end; give it space so it does not sit
+     right up against the post text (Discourse #9749 - chitchat niggle). */
+  margin-left: 0.5rem;
+}
+
 :deep(.strike) {
   text-decoration: line-through;
 }


### PR DESCRIPTION
## Root Cause

In the **chitchat / newsfeed** area the "..." options menu (the floated `ellipsis-h` dropdown on a chitchat post) sat too close to the post text — the "silly niggle" reported on Discourse #9749.

An earlier attempt edited `components/ChatListEntry.vue` (the **chat-messaging** list) — wrong area. This is **chitchat, not chat**. That change has been reverted; the fix now targets the chitchat post component.

## Fix

`iznik-nuxt3/components/NewsThread.vue` — give the floated "..." menu left margin so it no longer sits up against the post text:

```css
.thread-menu {
  margin-left: 0.5rem;
}
```

## Other Call Sites

`ChatListEntry.vue` is untouched (the earlier wrong edit was reverted). The chitchat "..." menu lives in `NewsThread.vue` (main post); replies use `NewsReply.vue`, which inherits the same dropdown styling.

## Test

Pure CSS spacing change (a fixed `margin-left` value), which cannot be meaningfully asserted in a jsdom unit test — consistent with how spacing-only changes are handled elsewhere in the repo. The chitchat smoke path is exercised by the Playwright e2e suite in CI.

## Discourse

https://discourse.ilovefreegle.org/t/9749/1
