### PR TITLE
fix(moderation): refresh Pending list when the work total increases (#9737)

### DIFF
--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -23,7 +23,7 @@ parameters:
     description: "Forwarded from trigger — true when build_modtools_production was set"
 
 orbs:
-  freegle: freegle/tests@1.1.326
+  freegle: freegle/tests@1.1.332
 
 jobs:
   mark-ci-passed:

--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -23,7 +23,7 @@ parameters:
     description: "Forwarded from trigger — true when build_modtools_production was set"
 
 orbs:
-  freegle: freegle/tests@1.1.332
+  freegle: freegle/tests@1.1.334
 
 jobs:
   mark-ci-passed:

--- a/iznik-nuxt3/modtools/composables/useModMessages.js
+++ b/iznik-nuxt3/modtools/composables/useModMessages.js
@@ -264,20 +264,30 @@ export function setupModMessages(reset) {
   })
 
   watch(workdetail, (newVal, oldVal) => {
-    // console.log('<<<<useModMessages watch workdetail. oldVal:', oldVal, 'newVal:', newVal)
     if (JSON.stringify(oldVal) === JSON.stringify(newVal)) return // Not actually changed
 
     const miscStore = useMiscStore()
-    // console.log('uMM getMessages',miscStore.deferGetMessages)
-    if (miscStore.deferGetMessages) return
 
-    // Refresh the list whenever the pending count changes.  The
-    // overflow:hidden guard was previously here to avoid audio interruption
-    // on iOS, but that concern belongs only in the beep logic (checkWork).
-    // Blocking the data fetch meant the list stayed stale whenever any
-    // modal was open at the time a new message arrived (Discourse #9737).
-    // console.log('uMM watch workdetail getmessages', newVal)
-    getMessages(newVal)
+    // When the work total INCREASES, genuinely new work has arrived (e.g. a new
+    // pending message). The list must refresh to show it - otherwise the count /
+    // red alert updates but the message stays invisible until a manual reload
+    // (Discourse #9737). This is NOT modal-specific: refresh regardless of the
+    // deferGetMessages smoothness flag and the body-overflow (beep) guard, which
+    // exist only to avoid jarring reloads on mod actions that do not add work.
+    const newTotal = Number(newVal?.total ?? 0)
+    const oldTotal = Number(oldVal?.total ?? 0)
+    if (newTotal > oldTotal) {
+      getMessages(newVal)
+      return
+    }
+
+    // No new work (count unchanged or decreased by a mod action the component
+    // already handled): keep the existing suppression so the list does not
+    // reload under the user's feet.
+    if (miscStore.deferGetMessages) return
+    if (document.body.style.overflow !== 'hidden') {
+      getMessages(newVal)
+    }
   })
 
   return {

--- a/iznik-nuxt3/modtools/composables/useModMessages.js
+++ b/iznik-nuxt3/modtools/composables/useModMessages.js
@@ -266,38 +266,18 @@ export function setupModMessages(reset) {
   watch(workdetail, (newVal, oldVal) => {
     // console.log('<<<<useModMessages watch workdetail. oldVal:', oldVal, 'newVal:', newVal)
     if (JSON.stringify(oldVal) === JSON.stringify(newVal)) return // Not actually changed
-    // if( collection.value!=='Pending') return
-    let doFetch = false
 
     const miscStore = useMiscStore()
     // console.log('uMM getMessages',miscStore.deferGetMessages)
     if (miscStore.deferGetMessages) return
 
-    const bodyoverflow = document.body.style.overflow
-    if (bodyoverflow !== 'hidden') {
-      if (newVal !== oldVal) {
-        // There's new stuff to fetch.
-        // console.log('Fetch')
-        doFetch = true
-      } else {
-        /* In Nuxt 2 miscStore visible was set if we are visible
-        const visible = miscStore.get('visible')
-        //console.log('Visible', visible)
-
-        if (!visible) {
-          // If we're not visible, then clear what we have in the store.  We don't want to do that under our own
-          // feet, but if we do this then we will pick up changes from other people and avoid confusion.
-          console.log('Clear')
-          await messageStore.clear()
-          doFetch = true
-        } */
-      }
-
-      if (doFetch) {
-        // console.log('uMM watch workdetail getmessages', newVal)
-        getMessages(newVal)
-      }
-    }
+    // Refresh the list whenever the pending count changes.  The
+    // overflow:hidden guard was previously here to avoid audio interruption
+    // on iOS, but that concern belongs only in the beep logic (checkWork).
+    // Blocking the data fetch meant the list stayed stale whenever any
+    // modal was open at the time a new message arrived (Discourse #9737).
+    // console.log('uMM watch workdetail getmessages', newVal)
+    getMessages(newVal)
   })
 
   return {

--- a/iznik-nuxt3/tests/unit/composables/useModMessages.pendingAutoRefresh.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useModMessages.pendingAutoRefresh.spec.js
@@ -1,0 +1,145 @@
+/**
+ * Tests for the pending-messages auto-refresh behaviour.
+ *
+ * The Pending messages page must call getMessages() whenever authStore.work
+ * changes (new pending messages arrived), even if a modal is open at the time.
+ *
+ * Discourse #9737: "A red alert appears in Pending messages but no message is
+ * visible without a manual page refresh."
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { ref, nextTick } from 'vue'
+import { flushPromises } from '@vue/test-utils'
+
+// ── Reactive auth-store mock ──────────────────────────────────────────────────
+// The watch(workdetail, …) inside setupModMessages tracks authStore.work via
+// Vue's reactivity.  A plain variable assignment is NOT reactive and would
+// never trigger the watcher.  Using a getter over a ref lets Vue track the
+// dependency correctly.
+const mockWork = ref({ pending: 0, pendingother: 0, total: 0 })
+
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: () => ({
+    // getter so Vue's computed(workdetail) can track the ref dependency
+    get work() {
+      return mockWork.value
+    },
+  }),
+}))
+
+// ── Message store mock ────────────────────────────────────────────────────────
+const mockFetchMessagesMT = vi.fn()
+vi.mock('~/stores/message', () => ({
+  useMessageStore: () => ({
+    clearContext: vi.fn(),
+    clear: vi.fn(),
+    fetchMessagesMT: mockFetchMessagesMT,
+    get all() {
+      return []
+    },
+    getByGroup: vi.fn(() => []),
+    get context() {
+      return null
+    },
+    list: {},
+  }),
+}))
+
+// ── Misc store mock (deferGetMessages = false → no suppression) ───────────────
+vi.mock('@/stores/misc', () => ({
+  useMiscStore: () => ({
+    deferGetMessages: false,
+    get: vi.fn(() => undefined),
+  }),
+}))
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('useModMessages — pending list auto-refresh', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.resetModules()
+    mockWork.value = { pending: 0, pendingother: 0, total: 0 }
+    mockFetchMessagesMT.mockResolvedValue([])
+    // Ensure body overflow is clear between tests
+    document.body.style.overflow = ''
+  })
+
+  afterEach(() => {
+    vi.resetModules()
+    document.body.style.overflow = ''
+  })
+
+  it('calls getMessages when pending count increases with no modal open', async () => {
+    const { setupModMessages } = await import(
+      '~/modtools/composables/useModMessages'
+    )
+    const { workType, collection } = setupModMessages(true)
+    collection.value = 'Pending'
+    workType.value = ['pending', 'pendingother']
+
+    // Allow the initial watch trigger (workType change) to settle
+    await nextTick()
+    await flushPromises()
+    vi.clearAllMocks()
+
+    // A new pending message arrives
+    mockWork.value = { pending: 1, pendingother: 0, total: 1 }
+
+    await nextTick()
+    await flushPromises()
+
+    expect(mockFetchMessagesMT).toHaveBeenCalled()
+  })
+
+  // Regression test for Discourse #9737: the pending list must re-fetch even
+  // when a modal is open (body.style.overflow === 'hidden').  Previously the
+  // overflow check blocked the fetch, leaving the badge count correct but the
+  // list stale until the next manual page refresh.
+  it('calls getMessages when pending count increases even while a modal is open', async () => {
+    const { setupModMessages } = await import(
+      '~/modtools/composables/useModMessages'
+    )
+    const { workType, collection } = setupModMessages(true)
+    collection.value = 'Pending'
+    workType.value = ['pending', 'pendingother']
+
+    await nextTick()
+    await flushPromises()
+    vi.clearAllMocks()
+
+    // Simulate any open modal (Bootstrap sets overflow:hidden on <body>)
+    document.body.style.overflow = 'hidden'
+
+    // A new pending message arrives while the modal is open
+    mockWork.value = { pending: 1, pendingother: 0, total: 1 }
+
+    await nextTick()
+    await flushPromises()
+
+    // The list must still be re-fetched regardless of body overflow state
+    expect(mockFetchMessagesMT).toHaveBeenCalled()
+  })
+
+  it('does not call getMessages when pending count is unchanged', async () => {
+    const { setupModMessages } = await import(
+      '~/modtools/composables/useModMessages'
+    )
+    const { workType, collection } = setupModMessages(true)
+    collection.value = 'Pending'
+    workType.value = ['pending', 'pendingother']
+
+    await nextTick()
+    await flushPromises()
+    vi.clearAllMocks()
+
+    // Count does not change — same values, new object (what a real fetchUser returns)
+    mockWork.value = { pending: 0, pendingother: 0, total: 0 }
+
+    await nextTick()
+    await flushPromises()
+
+    // No new work → should NOT trigger a re-fetch
+    expect(mockFetchMessagesMT).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Root Cause

When a new pending message arrives in ModTools, the badge count / red alert updates correctly (it reads `authStore.work` directly) but the **Pending list itself stays stale** until a manual page refresh (Discourse #9737, reported by Bunny, Vee and Derek).

The `watch(workdetail, …)` callback in `modtools/composables/useModMessages.js` only called `getMessages()` when neither the `deferGetMessages` smoothness flag nor the body-overflow (`'hidden'`) guard was set. Those guards exist to avoid jarring reloads during mod actions — but they were also suppressing the refresh when **genuinely new work** arrived, so the list never re-fetched.

An earlier attempt diagnosed this as **modal-specific** and removed the overflow guard outright. That was the wrong root cause: nothing in the report involves modals — it is a general auto-refresh gap between the count path and the list-fetch path.

## Fix

`iznik-nuxt3/modtools/composables/useModMessages.js` — when the work **total increases** (genuinely new work), call `getMessages()` unconditionally and return:

```js
const newTotal = Number(newVal?.total ?? 0)
const oldTotal = Number(oldVal?.total ?? 0)
if (newTotal > oldTotal) {
  getMessages(newVal)
  return
}
// count unchanged or decreased (a mod action the component already handled):
// keep the existing suppression so the list does not reload under the user.
if (miscStore.deferGetMessages) return
if (document.body.style.overflow !== 'hidden') {
  getMessages(newVal)
}
```

The `deferGetMessages` and overflow guards are **preserved** for the unchanged / decreased case, so the list still does not reload under the user's feet during their own mod actions.

## Other Call Sites

- `useModMe.js` — `bodyoverflow` check is in the beep path only (correct, untouched).
- `chats/review.vue` — has a similar overflow pattern in a separate watcher; out of scope here.

## Test

`iznik-nuxt3/tests/unit/composables/useModMessages.pendingAutoRefresh.spec.js`:
- calls `getMessages` when the pending count increases with no modal open
- calls `getMessages` when the pending count increases **even while a modal is open** (`body.style.overflow = 'hidden'`) — the regression case
- does **not** call `getMessages` when the count is unchanged

Fails on the buggy code (no fetch while overflow hidden), passes after the fix.

## Discourse

https://discourse.ilovefreegle.org/t/9737/13
