### PR TITLE
feat(digest): V1-parity jobs/sponsors everywhere + per-post group labels (#9691)

### DIFF
--- a/iznik-batch/app/Mail/Digest/UnifiedDigest.php
+++ b/iznik-batch/app/Mail/Digest/UnifiedDigest.php
@@ -37,6 +37,9 @@ class UnifiedDigest extends MjmlMailable implements RetryableMailable
 
     protected Collection $preparedPosts;
 
+    /** @var array<int,object> primary group rows (id => {nameshort, namefull}) for post bylines + header list */
+    protected array $groupLookup = [];
+
     protected int $digestNumber;
 
     public function __construct(
@@ -146,11 +149,24 @@ class UnifiedDigest extends MjmlMailable implements RetryableMailable
             return null;
         }
 
+        // Re-derive sponsors so a durable retry still ships sponsor credit
+        // (constructing with an empty Collection dropped it on every retry).
+        // Match the live send-path scope: immediate = the post's single group,
+        // daily = the union across the recipient's groups.
+        $mode = $descriptor['mode'] ?? UnifiedDigestService::MODE_IMMEDIATE;
+        $service = app(UnifiedDigestService::class);
+        if ($mode === UnifiedDigestService::MODE_IMMEDIATE) {
+            $groupId = (int) ($descriptor['posts'][0]['groups'][0] ?? 0);
+            $sponsors = $service->getSponsorsForGroup($groupId);
+        } else {
+            $sponsors = $service->getSponsorsForUser($user);
+        }
+
         return new self(
             $user,
             $posts,
-            $descriptor['mode'] ?? UnifiedDigestService::MODE_IMMEDIATE,
-            new Collection()
+            $mode,
+            $sponsors
         );
     }
 
@@ -218,6 +234,15 @@ class UnifiedDigest extends MjmlMailable implements RetryableMailable
             ? 'immediately'
             : 'daily';
 
+        // Header group list: the distinct groups represented by THIS digest's
+        // posts (not the user's whole membership), each linking to /explore.
+        // Used by the daily multi-group header.
+        $digestGroups = $this->preparedPosts
+            ->filter(fn ($p) => !empty($p['groupName']))
+            ->map(fn ($p) => ['name' => $p['groupName'], 'url' => $p['groupUrl']])
+            ->unique('name')
+            ->values();
+
         $result = $this->mjmlView('emails.mjml.digest.unified', array_merge([
             'user' => $this->user,
             'posts' => $this->preparedPosts,
@@ -233,6 +258,7 @@ class UnifiedDigest extends MjmlMailable implements RetryableMailable
             'donateUrl' => $donateUrl,
             'primaryGroupName' => $primaryGroupName,
             'frequencyText' => $frequencyText,
+            'digestGroups' => $digestGroups,
         ], $this->getTrackingData()), 'emails.text.digest.unified')
             ->to($this->user->email_preferred)
             ->applyLogging('UnifiedDigest');
@@ -311,6 +337,14 @@ class UnifiedDigest extends MjmlMailable implements RetryableMailable
                 'ampPostMeta' => $ampPostMeta,
                 'ampApiUrl' => $ampApiUrl,
                 'ampUserId' => (int) $this->user->id,
+                // Jobs + sponsors reach the AMP body too (V1 parity — the MJML
+                // and text parts already carry these; AMP previously dropped
+                // them). Same data the MJML view above receives.
+                'sponsors' => $this->sponsors,
+                'jobAds' => $jobAds,
+                'jobsUrl' => $jobsUrl,
+                'donateUrl' => $donateUrl,
+                'digestGroups' => $digestGroups,
             ]);
 
             $result->withSymfonyMessage(function ($message) {
@@ -467,15 +501,40 @@ class UnifiedDigest extends MjmlMailable implements RetryableMailable
             }
         }
 
+        // Batch-load the primary group (first in postedToGroups) for every post
+        // so each card can show "on <group>" without an N+1 per post. namefull
+        // is the friendly name; nameshort drives the /explore link.
+        $primaryGroupIds = $this->posts
+            ->map(fn ($p) => $p['postedToGroups'][0] ?? null)
+            ->filter()
+            ->unique()
+            ->values();
+        $this->groupLookup = $primaryGroupIds->isNotEmpty()
+            ? DB::table('groups')->whereIn('id', $primaryGroupIds)
+                ->get(['id', 'nameshort', 'namefull'])->keyBy('id')->all()
+            : [];
+
         return $this->posts->map(function ($post, $index) use ($totalPosts, $userLat, $userLng) {
             $message = $post['message'];
             $postedToGroups = $post['postedToGroups'];
             $isOffer = $message->type === 'Offer';
 
-            // Get group names for "Posted to:" display.
-            $postedToText = count($postedToGroups) > 1
-                ? $this->formatPostedTo($postedToGroups)
-                : null;
+            // Primary group name (friendly full name) + /explore link for the
+            // "Posted by … on <group>" byline.
+            $groupName = null;
+            $groupUrl = null;
+            $primaryGroupId = $postedToGroups[0] ?? null;
+            if ($primaryGroupId && isset($this->groupLookup[$primaryGroupId])) {
+                $g = $this->groupLookup[$primaryGroupId];
+                $groupName = $g->namefull ?: $g->nameshort;
+                if ($g->nameshort) {
+                    $groupUrl = $this->trackedUrl(
+                        $this->userSite . '/explore/' . urlencode($g->nameshort),
+                        "group_{$index}",
+                        'group'
+                    );
+                }
+            }
 
             // Get image URL via delivery service.
             $imageUrl = $this->getMessageImageUrl($message);
@@ -566,7 +625,8 @@ class UnifiedDigest extends MjmlMailable implements RetryableMailable
                 'thumbImageUrl' => $thumbImageUrl,
                 'trackedImageUrl' => $trackedImage,
                 'isPlaceholder' => $imageUrl === null,
-                'postedToText' => $postedToText,
+                'groupName' => $groupName,
+                'groupUrl' => $groupUrl,
                 'type' => $message->type,
                 'subject' => $message->subject,
                 'itemName' => $this->extractItemName($message->subject),

--- a/iznik-batch/app/Services/UnifiedDigestService.php
+++ b/iznik-batch/app/Services/UnifiedDigestService.php
@@ -273,7 +273,12 @@ class UnifiedDigestService
                 }
                 if (!$dryRun) {
                     if ($sponsorsCache === null) {
-                        $sponsorsCache = $this->getSponsorsForUser($user);
+                        // Immediate digest is about THIS group's post only, so
+                        // scope sponsors to the group (V1 parity), not the
+                        // recipient's whole membership union. The whole batch
+                        // is one $groupid, so a single lookup serves every
+                        // recipient in this loop.
+                        $sponsorsCache = $this->getSponsorsForGroup((int) $groupid);
                     }
                     $deduped = collect([
                         ['message' => $message, 'postedToGroups' => [$groupid]],
@@ -676,8 +681,13 @@ class UnifiedDigestService
             return ['status' => 'no_posts', 'count' => 0];
         }
 
-        // Get deduplicated sponsors for the user's groups.
-        $sponsors = $this->getSponsorsForUser($user);
+        // Sponsors. The combined daily digest spans all the user's groups, so
+        // the cross-group union is right; the immediate path scopes per-post to
+        // that post's group below (V1 parity — one group's email, one group's
+        // sponsors).
+        $sponsors = $mode === self::MODE_IMMEDIATE
+            ? collect()
+            : $this->getSponsorsForUser($user);
 
         if ($mode === self::MODE_IMMEDIATE) {
             // One email per post. Advance the tracker after each send so a
@@ -686,8 +696,12 @@ class UnifiedDigestService
             $sent = 0;
             foreach ($deduplicatedPosts as $deduped) {
                 if (!$dryRun) {
+                    // Each immediate email is about one post on one group; carry
+                    // only that group's sponsors.
+                    $postGroupId = (int) ($deduped['postedToGroups'][0] ?? 0);
+                    $postSponsors = $this->getSponsorsForGroup($postGroupId);
                     app(\App\Services\EmailSpoolerService::class)->spool(
-                        new UnifiedDigest($user, collect([$deduped]), $mode, $sponsors),
+                        new UnifiedDigest($user, collect([$deduped]), $mode, $postSponsors),
                         emailType: 'digest_immediate',
                     );
                     $this->advanceImmediateTracker($digestTracker, $deduped['message']);
@@ -1015,6 +1029,31 @@ class UnifiedDigestService
         // appears once. Keep the entry with the highest amount (first
         // in the result set due to ORDER BY amount DESC).
         return $sponsors->unique('name')->values();
+    }
+
+    /**
+     * Active, visible sponsors for a SINGLE group.
+     *
+     * V1 parity for the immediate digest: an immediate email is about one
+     * group's post, so it must carry only that group's sponsors — not the
+     * union across every group the recipient belongs to (which is what
+     * {@see getSponsorsForUser} returns for the combined daily digest). No
+     * name-dedupe here: a single group can't list the same sponsor twice in a
+     * way that needs collapsing, and dropping the dedupe keeps the query cheap.
+     */
+    public function getSponsorsForGroup(int $groupId): Collection
+    {
+        if ($groupId <= 0) {
+            return collect();
+        }
+
+        return DB::table('groups_sponsorship')
+            ->where('groupid', $groupId)
+            ->where('visible', TRUE)
+            ->where('startdate', '<=', now())
+            ->where('enddate', '>=', now()->startOfDay())
+            ->orderByDesc('amount')
+            ->get();
     }
 
 }

--- a/iznik-batch/resources/views/emails/amp/digest/unified.blade.php
+++ b/iznik-batch/resources/views/emails/amp/digest/unified.blade.php
@@ -139,6 +139,10 @@
     .post-byline strong {
       color: #555555;
     }
+    .post-byline .group-link {
+      color: #555555;
+      text-decoration: underline;
+    }
     .post-first-posted {
       font-size: 11px;
       color: #999999;
@@ -335,6 +339,98 @@
       line-height: 1.5;
       margin: 0;
     }
+
+    /* Job listings block (V1 single.html parity — mirrors the MJML jobs block) */
+    .jobs-section {
+      background-color: #F7F6EC;
+      padding: 16px 20px;
+      border-top: 1px solid #e9ecef;
+    }
+    .jobs-title {
+      font-size: 16px;
+      font-weight: bold;
+      color: #333333;
+      text-align: center;
+      margin: 0 0 10px 0;
+    }
+    .job-row {
+      margin: 0 0 8px 0;
+    }
+    .job-thumb {
+      width: 40px;
+      height: 40px;
+      border-radius: 4px;
+      margin-right: 8px;
+      vertical-align: middle;
+    }
+    .job-link {
+      color: #338808;
+      font-weight: bold;
+      text-decoration: none;
+      font-size: 14px;
+      line-height: 1.25;
+    }
+    .job-location {
+      color: #666666;
+      font-size: 12px;
+      line-height: 1.3;
+    }
+    .jobs-note {
+      font-size: 12px;
+      color: #666666;
+      line-height: 1.4;
+      margin: 8px 0 0 0;
+    }
+    .jobs-buttons {
+      margin-top: 12px;
+      text-align: center;
+    }
+    .jobs-button {
+      display: inline-block;
+      background-color: #338808;
+      color: #ffffff;
+      text-decoration: none;
+      font-size: 14px;
+      padding: 10px 25px;
+      border-radius: 5px;
+      margin: 4px;
+    }
+
+    /* Sponsors (V1 parity — mirrors the MJML sponsors block) */
+    .sponsors-section {
+      background-color: #ffffff;
+      padding: 10px 20px;
+    }
+    .sponsors-divider {
+      border-top: 1px solid #eeeeee;
+      margin: 0 0 5px 0;
+    }
+    .sponsors-label {
+      font-size: 12px;
+      color: #888888;
+      font-style: italic;
+      margin: 0 0 8px 0;
+    }
+    .sponsor-row {
+      margin: 0 0 10px 0;
+    }
+    .sponsor-thumb {
+      width: 60px;
+      height: 60px;
+      border-radius: 5px;
+      margin-right: 10px;
+      vertical-align: middle;
+    }
+    .sponsor-name {
+      color: #338808;
+      text-decoration: none;
+      font-weight: bold;
+      font-size: 13px;
+    }
+    .sponsor-tagline {
+      font-size: 11px;
+      color: #666666;
+    }
   </style>
 </head>
 <body>
@@ -433,7 +529,7 @@
              with the bold poster name rather than crowding the time/pin. --}}
         <p class="post-byline">
           <amp-img src="{{ $post['posterAvatarUrl'] }}" width="22" height="22" layout="fixed" alt=""></amp-img>
-          Posted by <strong>{{ \Illuminate\Support\Str::limit($post['posterName'], 30) }}</strong>
+          Posted by <strong>{{ \Illuminate\Support\Str::limit($post['posterName'], 30) }}</strong>@if(!empty($post['groupName'])) on <a href="{{ $post['groupUrl'] }}" class="group-link">{{ $post['groupName'] }}</a>@endif
         </p>
         @if(!empty($post['firstPostedFormatted']))
         {{-- V1 single.html parity: only shown when the message has actually
@@ -470,6 +566,52 @@
       </div>
     </div>
     @endforeach
+
+    {{-- Jobs near you (V1 single.html parity — mirrors the MJML jobs block).
+         AMP4Email needs concrete amp-img dimensions, so the thumb is a fixed
+         40x40. --}}
+    @if(isset($jobAds) && $jobAds->isNotEmpty())
+    <div class="jobs-section">
+      <p class="jobs-title">Jobs near you</p>
+      @foreach($jobAds as $job)
+      <div class="job-row">
+        @if($job->image_url ?? null)
+        <a href="{{ $job->tracked_url }}">
+          <amp-img class="job-thumb" src="{{ $job->image_url }}" width="40" height="40" layout="fixed" alt=""></amp-img>
+        </a>
+        @endif
+        <a href="{{ $job->tracked_url }}" class="job-link">{{ $job->title }}</a>
+        @if($job->location ?? null)
+        <br /><span class="job-location">{{ $job->location }}</span>
+        @endif
+      </div>
+      @endforeach
+      <p class="jobs-note">If you are interested and click, it will raise a little to help keep Freegle running and free to use.</p>
+      <div class="jobs-buttons">
+        <a href="{{ $jobsUrl }}" class="jobs-button">View more jobs</a>
+        <a href="{{ $donateUrl }}" class="jobs-button">Donating helps too!</a>
+      </div>
+    </div>
+    @endif
+
+    {{-- Sponsors (V1 parity — mirrors the MJML sponsors block) --}}
+    @if(isset($sponsors) && $sponsors->isNotEmpty())
+    <div class="sponsors-section">
+      <div class="sponsors-divider"></div>
+      <p class="sponsors-label">Sponsored by:</p>
+      @foreach($sponsors as $sponsor)
+      <div class="sponsor-row">
+        @if($sponsor->imageurl)
+        <a href="{{ $sponsor->linkurl }}">
+          <amp-img class="sponsor-thumb" src="{{ $sponsor->imageurl }}" width="60" height="60" layout="fixed" alt="{{ $sponsor->name }}"></amp-img>
+        </a>
+        @endif
+        @if($sponsor->linkurl)<a href="{{ $sponsor->linkurl }}" class="sponsor-name">{{ $sponsor->name }}</a>@else<strong class="sponsor-name">{{ $sponsor->name }}</strong>@endif
+        @if($sponsor->tagline)<br /><span class="sponsor-tagline">{{ $sponsor->tagline }}</span>@endif
+      </div>
+      @endforeach
+    </div>
+    @endif
 
     {{-- Browse All Posts --}}
     <div class="browse-section">

--- a/iznik-batch/resources/views/emails/mjml/digest/unified.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/digest/unified.blade.php
@@ -94,7 +94,7 @@
                 {{-- Posted by --}}
                 <mj-text font-size="13px" color="#888888" padding="0 0 16px 0">
                     <img src="{{ $post['posterAvatarUrl'] }}" alt="" width="22" height="22" style="display: inline-block; width: 22px; height: 22px; border-radius: 50%; vertical-align: middle; margin-right: 6px;" />
-                    Posted by <strong style="color: #555555;">{{ \Illuminate\Support\Str::limit($post['posterName'], 40) }}</strong>
+                    Posted by <strong style="color: #555555;">{{ \Illuminate\Support\Str::limit($post['posterName'], 40) }}</strong>@if(!empty($post['groupName'])) on <a href="{{ $post['groupUrl'] }}" style="color: #555555; text-decoration: underline;">{{ $post['groupName'] }}</a>@endif
                 </mj-text>
                 {{-- First posted (V1 single.html parity — only shown when the
                      message has actually been reposted to this group). Subtle
@@ -266,6 +266,23 @@
             </mj-column>
         </mj-section>
 
+        {{-- Greeting + the communities represented in this digest. The daily
+             roll-up spans several groups, so name them (each links to /explore)
+             — V1/Neil parity: "each of the groups featured within the email". --}}
+        <mj-section background-color="#ffffff" padding="16px 20px 0 20px">
+            <mj-column>
+                <mj-text font-size="16px" font-weight="bold" color="#333333" padding="0 0 4px 0">
+                    Hi {{ $user->firstname ?? 'there' }},
+                </mj-text>
+                @if(($digestGroups ?? collect())->isNotEmpty())
+                <mj-text font-size="13px" color="#666666" line-height="1.5" padding="0">
+                    New posts from your communities:
+                    @foreach($digestGroups as $dg)@if($dg['url'])<a href="{{ $dg['url'] }}" style="color: #338808; text-decoration: underline;">{{ $dg['name'] }}</a>@else<span>{{ $dg['name'] }}</span>@endif{!! $loop->last ? '' : ' &middot; ' !!}@endforeach
+                </mj-text>
+                @endif
+            </mj-column>
+        </mj-section>
+
         {{-- The "What's New (N posts)" title is carried by the subject line,
              so no in-body heading here. --}}
         @foreach($posts as $index => $post)
@@ -335,7 +352,7 @@
                 {{-- Avatar byline (V1 MultipleDigest parity). --}}
                 <mj-text padding="6px 0 10px 0" font-size="12px" color="#888888">
                     <img src="{{ $post['posterAvatarUrl'] }}" alt="" width="22" height="22" style="display: inline-block; width: 22px; height: 22px; border-radius: 50%; vertical-align: middle; margin-right: 6px;" />
-                    Posted by <strong style="color: #555555;">{{ \Illuminate\Support\Str::limit($post['posterName'], 30) }}</strong>
+                    Posted by <strong style="color: #555555;">{{ \Illuminate\Support\Str::limit($post['posterName'], 30) }}</strong>@if(!empty($post['groupName'])) on <a href="{{ $post['groupUrl'] }}" style="color: #555555; text-decoration: underline;">{{ $post['groupName'] }}</a>@endif
                 </mj-text>
                 {{-- Reply button: stays INSIDE the content column at its
                      bottom edge so it visually pairs with the image's
@@ -367,6 +384,66 @@
             </mj-column>
         </mj-section>
 
+        @endif
+
+        {{-- Jobs near you (daily mode). V1 parity: every digest recipient gets
+             nearby jobs, not just immediate. The immediate (single-post) layout
+             has its own jobs block above; this covers the daily multi-post
+             digest. --}}
+        @if(!$isSingle && isset($jobAds) && $jobAds->isNotEmpty())
+        <mj-section background-color="#F7F6EC" padding="20px 20px 10px 20px" border-top="1px solid #e9ecef">
+            <mj-column>
+                <mj-text font-size="16px" font-weight="bold" color="#333333" align="center" padding-bottom="10px">
+                    Jobs near you
+                </mj-text>
+            </mj-column>
+        </mj-section>
+        <mj-section background-color="#F7F6EC" padding="5px 12px">
+            <mj-column>
+                <mj-table cellpadding="0" cellspacing="0" width="100%">
+                    @foreach($jobAds as $job)
+                    <tr>
+                        @if($job->image_url ?? null)
+                        <td style="width: 44px; padding: 4px 4px 4px 0; vertical-align: middle;">
+                            <a href="{{ $job->tracked_url }}">
+                                <img src="{{ $job->image_url }}" width="40" height="40" alt="" style="border-radius: 4px; display: block;" />
+                            </a>
+                        </td>
+                        <td style="padding: 4px 0; vertical-align: middle;">
+                        @else
+                        <td colspan="2" style="padding: 4px 0; vertical-align: middle;">
+                        @endif
+                            <a href="{{ $job->tracked_url }}" style="color: #338808; font-weight: bold; text-decoration: none; font-size: 14px; line-height: 1.25;">
+                                {{ $job->title }}
+                            </a>
+                            @if($job->location ?? null)
+                            <br/><span style="color: #666666; font-size: 12px; line-height: 1.3;">{{ $job->location }}</span>
+                            @endif
+                        </td>
+                    </tr>
+                    @endforeach
+                </mj-table>
+            </mj-column>
+        </mj-section>
+        <mj-section background-color="#F7F6EC" padding="0 20px 10px 20px">
+            <mj-column>
+                <mj-text font-size="12px" color="#666666" line-height="1.4">
+                    If you are interested and click, it will raise a little to help keep Freegle running and free to use.
+                </mj-text>
+            </mj-column>
+        </mj-section>
+        <mj-section background-color="#F7F6EC" padding="0 20px 20px 20px">
+            <mj-column width="50%">
+                <mj-button href="{{ $jobsUrl }}" background-color="{{ $accentColor }}" color="#ffffff" font-size="14px" inner-padding="10px 25px" border-radius="5px" width="90%">
+                    View more jobs
+                </mj-button>
+            </mj-column>
+            <mj-column width="50%">
+                <mj-button href="{{ $donateUrl }}" background-color="{{ $accentColor }}" color="#ffffff" font-size="14px" inner-padding="10px 25px" border-radius="5px" width="90%">
+                    Donating helps too!
+                </mj-button>
+            </mj-column>
+        </mj-section>
         @endif
 
         {{-- Sponsors (both modes) --}}
@@ -402,6 +479,16 @@
             <mj-column>
                 <mj-text font-size="11px" color="#666666" align="center" line-height="1.5">
                     You're a member of <strong>{{ $primaryGroupName }}</strong> and asked to receive updates <strong>{{ $frequencyText }}</strong>.
+                </mj-text>
+            </mj-column>
+        </mj-section>
+        @elseif(!$isSingle)
+        {{-- Daily roll-up spans several groups, so name the cadence rather than
+             one group. --}}
+        <mj-section background-color="#f5f5f5" padding="10px 20px 0 20px">
+            <mj-column>
+                <mj-text font-size="11px" color="#666666" align="center" line-height="1.5">
+                    You're receiving this <strong>daily</strong> digest of new posts from your Freegle communities.
                 </mj-text>
             </mj-column>
         </mj-section>

--- a/iznik-batch/resources/views/emails/mjml/digest/unified.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/digest/unified.blade.php
@@ -2,7 +2,10 @@
     {{-- An immediate (-1) digest uses the full-width hero single-post layout
          (V1 single.html parity). The multi-post daily digest uses the compact
          multi-post layout below. --}}
-    @php $isSingle = $mode === 'immediate'; @endphp
+    {{-- $accentColor defaults to the Freegle green so the daily layout (which
+         spans many posts/types) has a defined button colour; the immediate
+         single-post branch overrides it with the post's offer/wanted accent. --}}
+    @php $isSingle = $mode === 'immediate'; $accentColor = '#338808'; @endphp
     @if($isSingle)
     @php $post = $posts->first(); $isOffer = $post['type'] === 'Offer'; $accentColor = $isOffer ? '#3c763d' : '#2196A6'; @endphp
     @include('emails.mjml.partials.head', ['preview' => $post['subject']])

--- a/iznik-batch/resources/views/emails/text/digest/unified.blade.php
+++ b/iznik-batch/resources/views/emails/text/digest/unified.blade.php
@@ -22,7 +22,7 @@ Location: {!! $post['locationName'] !!}
 {!! $isSingle ? $post['messageText'] : \Illuminate\Support\Str::limit($post['messageText'], 200) !!}
 @endif
 
-Posted by {!! $post['posterName'] !!}
+Posted by {!! $post['posterName'] !!}@if($post['groupName'] ?? null) on {!! $post['groupName'] !!}@endif
 @if(!empty($post['firstPostedFormatted']))
 First posted {!! $post['firstPostedFormatted'] !!}
 @endif
@@ -32,6 +32,15 @@ Reply: {{ $post['messageUrl'] }}
 ------------------------------------
 
 Browse all posts: {{ $browseUrl }}
+@if(isset($jobAds) && $jobAds->isNotEmpty())
+
+Jobs near you:
+@foreach($jobAds as $job)
+- {!! $job->title !!}{{ ($job->location ?? null) ? ' (' . $job->location . ')' : '' }}: {{ $job->tracked_url }}
+@endforeach
+If you are interested and click, it raises a little to help keep Freegle running and free to use.
+View more jobs: {{ $jobsUrl }}
+@endif
 @if($sponsors->isNotEmpty())
 
 Sponsored by:

--- a/iznik-batch/tests/Unit/Mail/UnifiedDigestRetryTest.php
+++ b/iznik-batch/tests/Unit/Mail/UnifiedDigestRetryTest.php
@@ -56,6 +56,49 @@ class UnifiedDigestRetryTest extends TestCase
         );
     }
 
+    public function test_rebuild_reloads_group_sponsors_for_immediate(): void
+    {
+        // A durable retry used to construct with an empty sponsor Collection,
+        // so retried immediate digests shipped without sponsor credit. The
+        // rebuild must re-derive the post's group sponsors (V1 single-group
+        // scope).
+        $poster = $this->createTestUser();
+        $recipient = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $this->createMembership($recipient, $group);
+        $message = $this->createTestMessage($poster, $group);
+
+        \Illuminate\Support\Facades\DB::table('groups_sponsorship')->insert([
+            'groupid' => $group->id,
+            'name' => 'Retry Sponsor',
+            'linkurl' => 'https://retry.example.com',
+            'imageurl' => 'https://retry.example.com/logo.png',
+            'tagline' => 'Still here on retry',
+            'startdate' => now()->subDay(),
+            'enddate' => now()->addMonth(),
+            'contactname' => 'R',
+            'contactemail' => 'r@example.com',
+            'amount' => 100,
+            'visible' => TRUE,
+        ]);
+
+        $rebuilt = UnifiedDigest::rebuildFromDescriptor([
+            'userid' => $recipient->id,
+            'mode' => UnifiedDigestService::MODE_IMMEDIATE,
+            'posts' => [['msgid' => $message->id, 'groups' => [$group->id]]],
+        ]);
+
+        $this->assertInstanceOf(UnifiedDigest::class, $rebuilt);
+
+        // sponsors is protected — read it via reflection.
+        $ref = new \ReflectionProperty(UnifiedDigest::class, 'sponsors');
+        $ref->setAccessible(true);
+        $sponsors = $ref->getValue($rebuilt);
+
+        $this->assertCount(1, $sponsors);
+        $this->assertEquals('Retry Sponsor', $sponsors->first()->name);
+    }
+
     public function test_rebuild_returns_null_for_unknown_user(): void
     {
         $rebuilt = UnifiedDigest::rebuildFromDescriptor([

--- a/iznik-batch/tests/Unit/Mail/UnifiedDigestTest.php
+++ b/iznik-batch/tests/Unit/Mail/UnifiedDigestTest.php
@@ -153,6 +153,119 @@ class UnifiedDigestTest extends TestCase
         $this->assertEquals('UnifiedDigestDaily', $tracking->email_type);
     }
 
+    /**
+     * Fabricate the minimal data the digest templates need so they can be
+     * rendered standalone (empty posts skips the per-post loop; jobs/sponsors
+     * blocks are gated only on $jobAds / $sponsors).
+     */
+    private function digestTemplateData(array $jobAds, array $sponsors): array
+    {
+        $user = (object) ['email_preferred' => 'r@example.com', 'displayname' => 'Sam'];
+        return [
+            'user' => $user,
+            'posts' => collect(),
+            'postCount' => 0,
+            'mode' => UnifiedDigestService::MODE_DAILY,
+            'isSingle' => false,
+            'sponsors' => collect($sponsors),
+            'jobAds' => collect($jobAds),
+            'jobsUrl' => 'https://example.com/jobs?t=1',
+            'donateUrl' => 'https://example.com/donate?t=1',
+            'browseUrl' => 'https://example.com/browse?t=1',
+            'settingsUrl' => 'https://example.com/settings?t=1',
+            'unsubscribeUrl' => 'https://example.com/unsubscribe?t=1',
+            'userSite' => 'https://example.com',
+            'siteName' => 'Freegle',
+        ];
+    }
+
+    public function test_amp_template_renders_jobs_and_sponsors(): void
+    {
+        $job = (object) [
+            'title' => 'Warehouse Operative',
+            'location' => 'Edinburgh',
+            'tracked_url' => 'https://example.com/job/1?t=1',
+            'image_url' => 'https://example.com/job1.png',
+        ];
+        $sponsor = (object) [
+            'name' => 'Edinburgh Council',
+            'tagline' => 'Backs reuse',
+            'linkurl' => 'https://council.example.com',
+            'imageurl' => 'https://council.example.com/logo.png',
+        ];
+
+        $html = view('emails.amp.digest.unified', $this->digestTemplateData([$job], [$sponsor]))->render();
+
+        // Jobs block (previously absent from AMP entirely).
+        $this->assertStringContainsString('Jobs near you', $html);
+        $this->assertStringContainsString('Warehouse Operative', $html);
+        $this->assertStringContainsString('https://example.com/job/1?t=1', $html);
+        $this->assertStringContainsString('View more jobs', $html);
+        // Sponsors block (previously absent from AMP entirely).
+        $this->assertStringContainsString('Sponsored by', $html);
+        $this->assertStringContainsString('Edinburgh Council', $html);
+    }
+
+    public function test_amp_template_omits_jobs_and_sponsors_when_empty(): void
+    {
+        $html = view('emails.amp.digest.unified', $this->digestTemplateData([], []))->render();
+
+        // Assert on markup-only strings (CSS comments/classes must not contain
+        // these, or the present/omit pair becomes meaningless).
+        $this->assertStringNotContainsString('Jobs near you', $html);
+        $this->assertStringNotContainsString('View more jobs', $html);
+        $this->assertStringNotContainsString('Sponsored by', $html);
+    }
+
+    public function test_text_template_renders_jobs(): void
+    {
+        $job = (object) [
+            'title' => 'Delivery Driver',
+            'location' => 'Leith',
+            'tracked_url' => 'https://example.com/job/2?t=1',
+            'image_url' => null,
+        ];
+
+        $text = view('emails.text.digest.unified', $this->digestTemplateData([$job], []))->render();
+
+        $this->assertStringContainsString('Jobs near you', $text);
+        $this->assertStringContainsString('Delivery Driver', $text);
+        $this->assertStringContainsString('https://example.com/job/2?t=1', $text);
+    }
+
+    public function test_prepared_posts_carry_group_name_and_explore_url(): void
+    {
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $this->createMembership($user, $group);
+        $poster = $this->createTestUser();
+        $this->createMembership($poster, $group);
+        $message = $this->createTestMessage($poster, $group, ['subject' => 'OFFER: Sofa (Town)']);
+
+        $posts = collect([
+            ['message' => $message, 'postedToGroups' => [$group->id]],
+        ]);
+        $mail = new UnifiedDigest($user, $posts, UnifiedDigestService::MODE_DAILY);
+
+        $ref = new \ReflectionProperty(UnifiedDigest::class, 'preparedPosts');
+        $ref->setAccessible(true);
+        $prepared = $ref->getValue($mail);
+        $card = $prepared->first();
+
+        // Friendly full name (not the short name) is the displayed group label.
+        $this->assertSame($group->namefull, $card['groupName']);
+        // The link points at the group's /explore page (keyed on nameshort).
+        // groupUrl is wrapped by the click-tracker (…/e/d/r/TOKEN?url=BASE64),
+        // so decode the inner target before asserting.
+        $this->assertNotNull($card['groupUrl']);
+        $target = $card['groupUrl'];
+        if (preg_match('/[?&]url=([^&]+)/', $card['groupUrl'], $mm)) {
+            $target = base64_decode(urldecode($mm[1])) ?: $target;
+        }
+        $this->assertStringContainsString('/explore/', $target);
+        $this->assertStringContainsString($group->nameshort, $target);
+    }
+
     public function test_cross_post_text_shown_for_multiple_groups(): void
     {
         $user = $this->createTestUser();

--- a/iznik-batch/tests/Unit/Services/UnifiedDigestServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/UnifiedDigestServiceTest.php
@@ -348,6 +348,106 @@ class UnifiedDigestServiceTest extends TestCase
         $this->assertNotNull($localBiz);
     }
 
+    public function test_get_sponsors_for_group_returns_only_that_groups_sponsors(): void
+    {
+        // V1 parity for immediate digests: an email about group A must carry
+        // only group A's sponsors, never the union across the recipient's other
+        // groups (which getSponsorsForUser returns for the daily digest).
+        $groupA = $this->createTestGroup();
+        $groupB = $this->createTestGroup();
+
+        DB::table('groups_sponsorship')->insert([
+            'groupid' => $groupA->id,
+            'name' => 'Group A Sponsor',
+            'linkurl' => 'https://a.example.com',
+            'imageurl' => 'https://a.example.com/logo.png',
+            'tagline' => 'Backs group A',
+            'startdate' => now()->subDay(),
+            'enddate' => now()->addMonth(),
+            'contactname' => 'A',
+            'contactemail' => 'a@example.com',
+            'amount' => 100,
+            'visible' => TRUE,
+        ]);
+        DB::table('groups_sponsorship')->insert([
+            'groupid' => $groupB->id,
+            'name' => 'Group B Sponsor',
+            'linkurl' => 'https://b.example.com',
+            'imageurl' => 'https://b.example.com/logo.png',
+            'tagline' => 'Backs group B',
+            'startdate' => now()->subDay(),
+            'enddate' => now()->addMonth(),
+            'contactname' => 'B',
+            'contactemail' => 'b@example.com',
+            'amount' => 100,
+            'visible' => TRUE,
+        ]);
+
+        $sponsors = $this->service->getSponsorsForGroup($groupA->id);
+
+        $this->assertCount(1, $sponsors);
+        $this->assertEquals('Group A Sponsor', $sponsors->first()->name);
+        $this->assertNull($sponsors->firstWhere('name', 'Group B Sponsor'));
+    }
+
+    public function test_get_sponsors_for_group_excludes_expired_and_invisible(): void
+    {
+        $group = $this->createTestGroup();
+
+        // Expired.
+        DB::table('groups_sponsorship')->insert([
+            'groupid' => $group->id,
+            'name' => 'Expired Sponsor',
+            'linkurl' => 'https://x.example.com',
+            'imageurl' => null,
+            'tagline' => null,
+            'startdate' => now()->subMonths(2),
+            'enddate' => now()->subMonth(),
+            'contactname' => 'X',
+            'contactemail' => 'x@example.com',
+            'amount' => 100,
+            'visible' => TRUE,
+        ]);
+        // Hidden.
+        DB::table('groups_sponsorship')->insert([
+            'groupid' => $group->id,
+            'name' => 'Hidden Sponsor',
+            'linkurl' => 'https://y.example.com',
+            'imageurl' => null,
+            'tagline' => null,
+            'startdate' => now()->subDay(),
+            'enddate' => now()->addMonth(),
+            'contactname' => 'Y',
+            'contactemail' => 'y@example.com',
+            'amount' => 100,
+            'visible' => FALSE,
+        ]);
+        // Active + visible.
+        DB::table('groups_sponsorship')->insert([
+            'groupid' => $group->id,
+            'name' => 'Active Sponsor',
+            'linkurl' => 'https://z.example.com',
+            'imageurl' => null,
+            'tagline' => null,
+            'startdate' => now()->subDay(),
+            'enddate' => now()->addMonth(),
+            'contactname' => 'Z',
+            'contactemail' => 'z@example.com',
+            'amount' => 100,
+            'visible' => TRUE,
+        ]);
+
+        $sponsors = $this->service->getSponsorsForGroup($group->id);
+
+        $this->assertCount(1, $sponsors);
+        $this->assertEquals('Active Sponsor', $sponsors->first()->name);
+    }
+
+    public function test_get_sponsors_for_group_returns_empty_for_zero_group(): void
+    {
+        $this->assertTrue($this->service->getSponsorsForGroup(0)->isEmpty());
+    }
+
     public function test_expired_sponsors_are_excluded(): void
     {
         $user = $this->createTestUser();


### PR DESCRIPTION
## Summary

Brings the unified digest to V1 parity across all three body parts (MJML/AMP/text) and adds the agreed Discourse **#9691** per-post group labelling.

### Jobs + sponsors parity
- **Jobs** now render in **AMP** and **text** (were MJML-only), and in the **daily MJML** layout — jobs were gated to immediate-only, but V1 shows nearby jobs to *every* digest recipient.
- **Sponsors** now render in **AMP** (text/MJML already had them).
- **Immediate digest scopes sponsors to the single posting group** via new `UnifiedDigestService::getSponsorsForGroup()`. Previously it unioned sponsors across every group the recipient belongs to, so an email about group A could carry B/C/D's sponsors. Daily keeps the cross-group union (one combined email).
- `UnifiedDigest::rebuildFromDescriptor()` re-derives sponsors (immediate = the post's group, daily = the user union) so durable retries no longer ship without sponsor credit.

### Group labels (#9691)
- Each post byline shows **"Posted by &lt;name&gt; on &lt;group&gt;"**, where the group is the friendly `namefull` (fallback `nameshort`), underlined, linking to the group's `/explore` page. `preparePosts()` batch-loads the primary group (no N+1).
- Daily header lists the **communities represented by this digest's posts** (each linking to `/explore`), plus a **"Hi &lt;firstname&gt;"** greeting (AMP/text already had one) and a **daily cadence** footer line.
- Removed the dead `postedToText` (computed but never rendered).

## Decisions captured (from product review)
- No combined-vs-per-group opt-out user setting; daily stays combined.
- No cross-post-to-moderation flagging in this PR.
- Subject stays generic; no long-digest cap.
- Daily From is already "Freegle" and already replies to noreply — no change.

## Test Plan
- `UnifiedDigestServiceTest`: `getSponsorsForGroup` single-group scope, expiry/visibility exclusion, zero-group guard.
- `UnifiedDigestRetryTest`: `rebuildFromDescriptor` reloads the group's sponsors.
- `UnifiedDigestTest`: AMP/text render jobs + sponsors (and omit when empty); per-post `groupName`/`groupUrl` resolves friendly name + tracked `/explore` link.
- Full Laravel suite run locally: no regressions from this change (UnifiedDigest suite green).
- Rendered daily + immediate samples with real seeded data (posts, jobs, sponsors, group links) and reviewed visually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
