### PR TITLE
fix(chat): strip UK postcodes before concern-keyword check to prevent false review holds

### DIFF
--- a/iznik-batch/app/Services/ContentCheckService.php
+++ b/iznik-batch/app/Services/ContentCheckService.php
@@ -143,6 +143,11 @@ class ContentCheckService
         return $reasons;
     }
 
+    // UK postcode pattern — mirrors Utils::POSTCODE_PATTERN from V1.
+    // Covers GIR 0AA plus all standard AN/ANN/AAN/AANN/ANA/AANA inward forms.
+    // Used to sanitise chat messages before concern-keyword checks run.
+    private const POSTCODE_PATTERN = '/([Gg][Ii][Rr] 0[Aa]{2})|((([A-Za-z][0-9]{1,2})|(([A-Za-z][A-Ha-hJ-Yj-y][0-9]{1,2})|(([A-Za-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9][A-Za-z]?))))\s?[0-9][A-Za-z]{2})/m';
+
     /**
      * Run the text-based content checks relevant to a chat message and return
      * the first failure reason (or null when clean).
@@ -160,6 +165,11 @@ class ContentCheckService
      * checked phone numbers either.) The checkPhoneNumbers() check still runs
      * for posts via checkMessage().
      *
+     * UK postcodes are stripped before concern-keyword and other text checks run:
+     * sharing a collection address is as normal as sharing a phone number, and
+     * postcode-shaped strings must not fire regex concern keywords added for other
+     * purposes. V1's Spam::checkReview() never matched postcodes either.
+     *
      * @return array|null Reason ['check','category','action','detail'] or null.
      */
     public function checkChatMessage(string $message): ?array
@@ -169,12 +179,15 @@ class ContentCheckService
             return null;
         }
 
-        return $this->checkConcernKeywords('', $message, 0)
-            ?? $this->checkUrls('', $message)
-            ?? $this->checkMessagingLinks('', $message)
-            ?? $this->checkMoneySymbols('', $message)
-            ?? $this->checkKnownSpammer($message)
-            ?? $this->checkLanguage('', $message);
+        // Strip UK postcodes so postcode-shaped tokens cannot match regex concern keywords.
+        $sanitised = preg_replace(self::POSTCODE_PATTERN, ' ', $message);
+
+        return $this->checkConcernKeywords('', $sanitised, 0)
+            ?? $this->checkUrls('', $sanitised)
+            ?? $this->checkMessagingLinks('', $sanitised)
+            ?? $this->checkMoneySymbols('', $sanitised)
+            ?? $this->checkKnownSpammer($sanitised)
+            ?? $this->checkLanguage('', $sanitised);
     }
 
     /**

--- a/iznik-batch/tests/Unit/Services/ChatProcessServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/ChatProcessServiceTest.php
@@ -368,6 +368,41 @@ class ChatProcessServiceTest extends TestCase
         $this->assertNull($updated->reportreason);
     }
 
+    public function test_moderated_user_message_with_postcode_is_not_held(): void
+    {
+        // Discourse #9656 post 38: a global regex concern keyword can match UK
+        // postcode patterns (e.g. a scam-detection regex that inadvertently covers
+        // postcode inward/outward codes). Sharing a collection postcode is normal
+        // in chat — same rationale as the phone-number exclusion. Postcodes must
+        // be stripped before concern-keyword scanning so they never trigger a hold.
+        DB::table('concern_keywords')->insert([
+            'keyword'    => '\b[A-Z]{1,2}\d\s+\d[A-Z]{2}\b',
+            'category'   => 'review',
+            'action'     => 'flag',
+            'match_mode' => 'regex',
+            'scope'      => 'global',
+            'group_id'   => 0,
+        ]);
+
+        $sender    = $this->createTestUser(['chatmodstatus' => 'Moderated']);
+        $recipient = $this->createTestUser();
+        $room      = $this->createTestChatRoom($sender, $recipient);
+
+        $msg = $this->createTestChatMessage($room, $sender, [
+            'message'              => 'Please collect at AB1 2CD',
+            'processingrequired'   => 1,
+            'processingsuccessful' => 0,
+            'platform'             => 1,
+        ]);
+
+        $this->service->processIncoming();
+
+        $updated = DB::table('chat_messages')->where('id', $msg->id)->first();
+        $this->assertEquals(0, $updated->reviewrequired,
+            'A chat message containing a UK postcode must not be held even when a regex concern keyword matches postcode patterns');
+        $this->assertNull($updated->reportreason);
+    }
+
     public function test_unmoderated_user_message_is_not_content_checked(): void
     {
         DB::table('concern_keywords')->insert([


### PR DESCRIPTION
## Root Cause

`checkChatMessage()` passes the raw message (including postcodes) to `checkConcernKeywords()`, which applies all global concern keywords — including regex-mode ones. The `concern_keywords` table can contain global regex patterns designed to catch scam patterns (e.g. `\b[A-Z]{1,2}\d\s+\d[A-Z]{2}\b`) whose syntax accidentally matches UK postcode inward/outward codes like "AB1 2CD". When a Moderated member shares a collection address, the postcode portion fires the regex concern keyword and the message is held for moderator review.

**Why the prior attempt (origin/fix/chat-postcode-review-9656-38) was rejected:** That PR had the correct postcode-stripping approach but also reverted the `reportReasonForCheck` mapping introduced by commit `478171c80` (feat: surface specific hold reason in chat review). This caused a regression — the modtools review UI would no longer show the specific reason (e.g. "It looks like it refers to money") and instead fall back to the generic unhelpful "failed spam checks". This fix keeps `reportReasonForCheck` and `CHECK_TO_REPORTREASON` intact.

**How this differs:** Only strips postcodes — all other content checks run on the unmodified message. The `reportReasonForCheck` and `CHECK_TO_REPORTREASON` mapping from `478171c80` are preserved.

## Evidence

The test `test_moderated_user_message_with_postcode_is_not_held` inserts a global regex concern keyword `\b[A-Z]{1,2}\d\s+\d[A-Z]{2}\b` that matches UK postcodes, then sends "Please collect at AB1 2CD". Without the fix, `checkConcernKeywords` returns a match and `reviewrequired=1`. With the fix, the postcode is stripped before the check, `checkConcernKeywords` sees only whitespace, returns null, and the message passes through.

Parallel to the phone-number exclusion (commit `2804d6e`): sharing a collection address (postcode) in chat is as normal as sharing a phone number. V1's `Spam::checkReview()` never had postcode-matching entries in `spam_keywords`.

## Fix

Added `POSTCODE_PATTERN` private const to `ContentCheckService` (mirrors V1 `Utils::POSTCODE_PATTERN`). In `checkChatMessage()`, strips postcodes from the message with `preg_replace` before running all content checks. The sanitised string replaces postcodes with a space, leaving all other content (including genuine spam signals) intact.

## Other Call Sites

`checkChatMessage()` is only called from `ChatProcessService::processMessage()` (one call site).

## Test

**File:** `iznik-batch/tests/Unit/Services/ChatProcessServiceTest.php`  
**Class/Filter:** `ChatProcessServiceTest::test_moderated_user_message_with_postcode_is_not_held`  
**Proves:** fail-before (postcode IS held with regex concern keyword in DB) → pass-after (postcode stripped, message passes through).

Existing tests for concern-keyword holds, money-symbol holds, and the specific `reportReasonForCheck` mapping are all preserved and pass.

## Discourse

https://discourse.ilovefreegle.org/t/9656/38