### PR TITLE
fix(modtools): message-search shows stale results + Semantic toggle not sticky

### DIFF
--- a/iznik-nuxt3/modtools/pages/messages/approved/[[id]]/[[term]].vue
+++ b/iznik-nuxt3/modtools/pages/messages/approved/[[id]]/[[term]].vue
@@ -64,11 +64,17 @@
 import { ref, computed, watch, onMounted, nextTick } from 'vue'
 import { useRoute, useRouter } from '#imports'
 import { useMessageStore } from '@/stores/message'
+import { useMiscStore } from '@/stores/misc'
 import { setupModMessages } from '@/composables/useModMessages'
 import { useMe } from '~/composables/useMe'
 
+// Persisted (localStorage-backed) key for the semantic-search toggle so it
+// survives group changes, searches and remounts.
+const SEMANTIC_SEARCH_KEY = 'modtoolsSemanticSearch'
+
 // Stores
 const messageStore = useMessageStore()
+const miscStore = useMiscStore()
 
 // Composables
 const modMessages = setupModMessages(true)
@@ -95,8 +101,10 @@ const {
 // Local state (formerly data())
 const chosengroupid = ref(0)
 const bump = ref(0)
-const vectorSearchEnabled = ref(false)
-const searchmode = computed(() => vectorSearchEnabled.value ? 'vector' : 'keyword')
+const vectorSearchEnabled = ref(miscStore.get(SEMANTIC_SEARCH_KEY) ?? false)
+const searchmode = computed(() =>
+  vectorSearchEnabled.value ? 'vector' : 'keyword'
+)
 const urlOverride = ref(false)
 const loaded = ref(false)
 const highlightMsgId = ref(null)
@@ -224,6 +232,8 @@ function searchedMessage(term) {
 }
 
 watch(vectorSearchEnabled, () => {
+  // Persist the choice so it sticks across group changes, searches and remounts.
+  miscStore.set({ key: SEMANTIC_SEARCH_KEY, value: vectorSearchEnabled.value })
   show.value = 0
   context.value = null
   modMessages.listingIds.value = new Set()

--- a/iznik-nuxt3/modtools/pages/messages/approved/[[id]]/[[term]].vue
+++ b/iznik-nuxt3/modtools/pages/messages/approved/[[id]]/[[term]].vue
@@ -201,6 +201,19 @@ function changedMessageTerm(term) {
 function searchedMessage(term) {
   const router = useRouter()
   term = term.trim()
+  // Start a fresh message search from a clean slate.  The store accumulates
+  // messages from other sources (notably a prior "messages from member"
+  // lookup, whose historical posts are not in any search index), and the
+  // listing is filtered by listingIds.  Without resetting here, those leaked
+  // results stay visible during the search — mirrors searchedMember() and the
+  // vectorSearchEnabled watcher, which already reset this state.
+  show.value = 0
+  context.value = null
+  memberTerm.value = null
+  modMessages.listingIds.value = new Set()
+  modMessages.listingIdOrder.value = []
+  messageStore.clear()
+  bump.value++
   if (term.length > 0) {
     router.push('/messages/approved/' + groupid.value + '/' + term)
   } else if (groupid.value) {

--- a/iznik-nuxt3/tests/unit/pages/modtools/messages/approved.spec.js
+++ b/iznik-nuxt3/tests/unit/pages/modtools/messages/approved.spec.js
@@ -415,6 +415,27 @@ describe('messages/approved/[[id]]/[[term]].vue page', () => {
       expect(wrapper.vm.bump).toBeGreaterThan(0)
     })
 
+    it('initialises the semantic search toggle from the misc store (sticky across remounts)', async () => {
+      mockMiscStore.get.mockReturnValue(true)
+      const wrapper = mountComponent()
+      await wrapper.vm.$nextTick()
+      expect(mockMiscStore.get).toHaveBeenCalledWith('modtoolsSemanticSearch')
+      expect(wrapper.vm.vectorSearchEnabled).toBe(true)
+    })
+
+    it('persists the semantic search toggle to the misc store when changed', async () => {
+      mockMiscStore.get.mockReturnValue(false)
+      const wrapper = mountComponent()
+      await wrapper.vm.$nextTick()
+      mockMiscStore.set.mockClear()
+      wrapper.vm.vectorSearchEnabled = true
+      await wrapper.vm.$nextTick()
+      expect(mockMiscStore.set).toHaveBeenCalledWith({
+        key: 'modtoolsSemanticSearch',
+        value: true,
+      })
+    })
+
     describe('loadMore', () => {
       it('calls loaded (not complete) when no user', async () => {
         const wrapper = mountComponent()

--- a/iznik-nuxt3/tests/unit/pages/modtools/messages/approved.spec.js
+++ b/iznik-nuxt3/tests/unit/pages/modtools/messages/approved.spec.js
@@ -395,6 +395,26 @@ describe('messages/approved/[[id]]/[[term]].vue page', () => {
       expect(wrapper.vm.bump).toBeGreaterThan(0)
     })
 
+    it('searchedMessage resets listing state so a prior member lookup does not leak into the search', async () => {
+      mockRouteParams.value = { id: '123', term: undefined }
+      const wrapper = mountComponent()
+      await wrapper.vm.$nextTick()
+      // Simulate a previous "messages from member" lookup having populated the
+      // listing with that member's old approved posts (which are not in any
+      // search index).  They live in listingIds and the store.
+      mockMemberTerm.value = 'theyou@example.com'
+      mockListingIds.value = new Set([25710703, 54673557])
+      mockListingIdOrder.value = [25710703, 54673557]
+      mockMessageStore.clear.mockClear()
+      // Now run a message search.  The member's posts must not survive into it.
+      await wrapper.vm.searchedMessage('sofa')
+      expect(mockListingIds.value.size).toBe(0)
+      expect(mockListingIdOrder.value).toEqual([])
+      expect(mockMemberTerm.value).toBe(null)
+      expect(mockMessageStore.clear).toHaveBeenCalled()
+      expect(wrapper.vm.bump).toBeGreaterThan(0)
+    })
+
     describe('loadMore', () => {
       it('calls loaded (not complete) when no user', async () => {
         const wrapper = mountComponent()


### PR DESCRIPTION
Two related fixes to the ModTools approved-messages search (`modtools/pages/messages/approved/[[id]]/[[term]].vue`).

## 1. Message search showed stale member-lookup results
A moderator running a *message* / *semantic* search could see results left over from an earlier **"messages from member"** lookup — old approved posts by one user that are in **no search index** (not in `messages_spatial`, `messages_embeddings`, or `messages_index`). This looked like semantic search returning ancient, irrelevant junk.

**Cause:** the approved list is filtered by `listingIds`, and the message store accumulates messages from every source (member history, listings, searches). `searchedMember()` and the semantic-search toggle both reset that state; `searchedMessage()` did not — so a prior member lookup's posts stayed in `listingIds`/the store and remained on screen.

**Fix:** `searchedMessage()` now resets `show`/`context`/`memberTerm`/`listingIds`/`listingIdOrder` and clears the store before navigating, mirroring `searchedMember()`.

## 2. "Semantic search" toggle was not sticky
`vectorSearchEnabled` was local component state (`ref(false)`), so it reset on group change, search, and any remount.

**Fix:** back it with the localStorage-persisted misc store (key `modtoolsSemanticSearch`) — initialise the ref from the store and write back in the existing watch — mirroring the Detailed/Summary view toggle.

## Tests
Added unit tests to `tests/unit/pages/modtools/messages/approved.spec.js`:
- `searchedMessage` resets listing state so a prior member lookup does not leak into the search
- initialises the semantic search toggle from the misc store
- persists the semantic search toggle to the misc store when changed

All written test-first (RED → GREEN). Full file: **56 passing, 0 failing**. eslint clean.

> Note: a separate production issue surfaced during diagnosis — the API's query-embedder was unreachable so semantic search silently fell back to keyword-only. That was fixed by deploying the embedding sidecar (infra, not in this PR) and is confirmed working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)