### PR TITLE
fix(chat): fix deep-link route resolution for chat reply notifications

### DIFF
--- a/iznik-nuxt3/stores/mobile.js
+++ b/iznik-nuxt3/stores/mobile.js
@@ -211,8 +211,10 @@ export const useMobileStore = defineStore({
           console.log('appUrlOpen', event.url)
           const lookfor = 'ilovefreegle.org'
           const ilfpos = event.url.indexOf(lookfor)
-          if (ilfpos !== false) {
-            const route = event.url.substring(ilfpos + lookfor.length)
+          if (ilfpos !== -1) {
+            const route = event.url
+              .substring(ilfpos + lookfor.length)
+              .replace('/chat/', '/chats/')
             console.log('appUrlOpen route', route)
             const router = useRouter()
             if (route.includes('src=forgotpass')) {
@@ -593,7 +595,7 @@ export const useMobileStore = defineStore({
         if (this.route && okToMove) {
           this.route = this.route.replace('/chat/', '/chats/')
           console.log('router.currentRoute', router.currentRoute)
-          if (router.currentRoute.path !== this.route) {
+          if (router.currentRoute.value.path !== this.route) {
             console.log('GO TO ', this.route)
             router.push(this.route)
           }

--- a/iznik-nuxt3/tests/unit/stores/mobile.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/mobile.spec.js
@@ -75,7 +75,7 @@ vi.stubGlobal('useRuntimeConfig', () => ({
 const mockRouterPush = vi.fn()
 vi.stubGlobal('useRouter', () => ({
   push: mockRouterPush,
-  currentRoute: { path: '/' },
+  currentRoute: { value: { path: '/' } },
 }))
 
 describe('mobile store', () => {
@@ -591,6 +591,112 @@ describe('mobile store', () => {
       await store.getDeviceInfo(mockDevice)
 
       expect(store.deviceuserinfo).toBe('android 13')
+      logSpy.mockRestore()
+    })
+  })
+
+  describe('initDeepLinks', () => {
+    let store
+    let capturedListener
+    let mockApp
+
+    beforeEach(() => {
+      store = useMobileStore()
+      capturedListener = null
+      mockApp = {
+        addListener: vi.fn().mockImplementation((event, fn) => {
+          if (event === 'appUrlOpen') capturedListener = fn
+        }),
+      }
+      // initDeepLinks guards with `if (process.client)`; enable it for tests.
+      process.client = true
+    })
+
+    afterEach(() => {
+      delete process.client
+    })
+
+    async function triggerDeepLink(url) {
+      vi.useFakeTimers()
+      store.initDeepLinks(mockApp)
+      expect(capturedListener).not.toBeNull()
+      await capturedListener({ url })
+      vi.runAllTimers()
+    }
+
+    it('navigates to /chats/:id for a current-format chat deep link', async () => {
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+      await triggerDeepLink('https://www.ilovefreegle.org/chats/12345')
+
+      expect(mockRouterPush).toHaveBeenCalledWith('/chats/12345')
+      logSpy.mockRestore()
+    })
+
+    it('rewrites old /chat/:id deep link to /chats/:id', async () => {
+      // AssertFlip: before the fix initDeepLinks has no /chat/ → /chats/ replacement,
+      // so push is called with '/chat/12345' (wrong). After fix it is '/chats/12345'.
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+      await triggerDeepLink('https://www.ilovefreegle.org/chat/12345')
+
+      expect(mockRouterPush).toHaveBeenCalledWith('/chats/12345')
+      logSpy.mockRestore()
+    })
+
+    it('does not navigate for a URL that does not contain ilovefreegle.org', async () => {
+      // AssertFlip: before the fix `ilfpos !== false` is always true (indexOf never
+      // returns false), so a freegle:// URL navigates to substring(15) = '/12345'.
+      // After fix `ilfpos !== -1` correctly skips non-ilovefreegle.org URLs.
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+      await triggerDeepLink('freegle://chats/12345')
+
+      expect(mockRouterPush).not.toHaveBeenCalled()
+      logSpy.mockRestore()
+    })
+  })
+
+  describe('handleNotification duplicate-navigation guard', () => {
+    it('skips router.push when already on the target chat route', async () => {
+      // AssertFlip: before the fix, router.currentRoute.path is accessed directly
+      // on the Vue Router 4 Ref — which is undefined — so the guard never fires
+      // and push is always called. After fix, router.currentRoute.value.path is
+      // used and the guard correctly prevents redundant navigation.
+      vi.stubGlobal('useRouter', () => ({
+        push: mockRouterPush,
+        currentRoute: { value: { path: '/chats/12345' } },
+      }))
+
+      vi.mock('@capacitor/app', () => ({
+        App: { getState: () => Promise.resolve({ isActive: false }) },
+      }))
+
+      const store = useMobileStore()
+      store.config = { public: {} }
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+      await store.handleNotification(
+        {
+          okToMove: true,
+          data: {
+            channel_id: 'chat_messages',
+            badge: '0',
+            modtools: '0',
+            route: '/chats/12345',
+          },
+        },
+        { removeAllDeliveredNotifications: vi.fn() },
+        { set: vi.fn() }
+      )
+
+      expect(mockRouterPush).not.toHaveBeenCalled()
+
+      // Restore default mock for subsequent tests.
+      vi.stubGlobal('useRouter', () => ({
+        push: mockRouterPush,
+        currentRoute: { value: { path: '/' } },
+      }))
       logSpy.mockRestore()
     })
   })


### PR DESCRIPTION
## Root Cause

Three bugs in `iznik-nuxt3/stores/mobile.js` that together cause a 'sorry' / error page when tapping the reply button in a chat notification email/push on Android:

**Bug 1 — `initDeepLinks`: `ilfpos !== false` (line 214)**  
`String.indexOf()` never returns `false`; it returns `-1` when not found. The condition was always true, so every `appUrlOpen` event was processed regardless of whether the URL contained `ilovefreegle.org`. A `freegle://chats/12345` URL would compute `substring(15) = '/12345'` and navigate there → 404 error page.

**Bug 2 — `initDeepLinks`: missing `/chat/` → `/chats/` replacement**  
`handleNotification` (push notification path) already normalises old-format `/chat/{id}` URLs to `/chats/{id}`. The deep-link path (`appUrlOpen`, fired when tapping email reply button on Android) had no such replacement — old-format chat email links silently navigated to a non-existent route → 404.

**Bug 3 — `handleNotification`: `router.currentRoute.path` instead of `router.currentRoute.value.path`**  
In Vue Router 4, `currentRoute` is a `Ref`, so `.path` on the ref object is `undefined`. The duplicate-navigation guard (`if (currentRoute.path !== this.route)`) was never firing — always `undefined !== '/chats/123'` → always navigated even when already on the target page.

## Evidence

**Failing tests (before fix):**
```
FAIL  initDeepLinks > rewrites old /chat/:id deep link to /chats/:id
  Expected: "/chats/12345"
  Received: "/chat/12345"

FAIL  initDeepLinks > does not navigate for a URL that does not contain ilovefreegle.org
  Expected: not called
  Called with: "/12345"   ← substring(15) of freegle://chats/12345

FAIL  handleNotification duplicate-navigation guard > skips router.push when already on target
  Expected: not called
  Called with: "/chats/12345"   ← guard never fired (undefined !== path)
```

**After fix:** 44/44 tests pass, 594 test files / 12853 tests zero regressions.

## Fix

In `initDeepLinks`:
- `ilfpos !== false` → `ilfpos !== -1`
- Added `.replace('/chat/', '/chats/')` to extracted route (matches `handleNotification`)

In `handleNotification`:
- `router.currentRoute.path` → `router.currentRoute.value.path`

Also corrected the `useRouter` mock in `mobile.spec.js` to use Vue Router 4 Ref structure (`currentRoute: { value: { path: '/' } }`).

## Other Call Sites

Only these two functions reference `currentRoute` or extract routes from URLs. No other call sites.

## Test

File: `iznik-nuxt3/tests/unit/stores/mobile.spec.js`  
Command: `npx vitest run tests/unit/stores/mobile.spec.js`  
Proves: fail-before / pass-after for all three bugs (AssertFlip pattern).

## Discourse
https://discourse.ilovefreegle.org/t/9481/542