### PR TITLE
fix(modmail): reopen acting mod's closed chat so it reappears in ModTools (#9481/541)

### DIFF
--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -23,7 +23,7 @@ parameters:
     description: "Forwarded from trigger — true when build_modtools_production was set"
 
 orbs:
-  freegle: freegle/tests@1.1.337
+  freegle: freegle/tests@1.1.339
 
 jobs:
   mark-ci-passed:

--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -23,7 +23,7 @@ parameters:
     description: "Forwarded from trigger — true when build_modtools_production was set"
 
 orbs:
-  freegle: freegle/tests@1.1.334
+  freegle: freegle/tests@1.1.336
 
 jobs:
   mark-ci-passed:

--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -23,7 +23,7 @@ parameters:
     description: "Forwarded from trigger — true when build_modtools_production was set"
 
 orbs:
-  freegle: freegle/tests@1.1.336
+  freegle: freegle/tests@1.1.337
 
 jobs:
   mark-ci-passed:

--- a/iznik-batch/app/Console/Commands/Queue/ProcessBackgroundTasksCommand.php
+++ b/iznik-batch/app/Console/Commands/Queue/ProcessBackgroundTasksCommand.php
@@ -428,6 +428,22 @@ class ProcessBackgroundTasksCommand extends Command
     }
 
     /**
+     * Reopen any 'Closed' chat rosters for a chat so it reappears in the
+     * recipient's chat list after a new message. The ModTools chat list filters
+     * out rooms whose roster status is 'Closed' (iznik-server-go
+     * chat/chatroom.go), so a mod who had previously closed a User2Mod chat would
+     * not see it again even after sending a modmail to it (Discourse #9481/541).
+     * Mirrors the reopen in V2 CreateChatMessage; 'Blocked' rosters are left as-is.
+     */
+    protected function reopenClosedRosters(int $chatId): void
+    {
+        DB::table('chat_roster')
+            ->where('chatid', $chatId)
+            ->where('status', 'Closed')
+            ->update(['status' => 'Offline']);
+    }
+
+    /**
      * Handle mod standard message emails (approve, reject, reply).
      *
      * Looks up the message poster, group, and mod info, then:
@@ -582,6 +598,13 @@ class ProcessBackgroundTasksCommand extends Command
                     'processingrequired' => 0,
                     'processingsuccessful' => 1,
                 ]);
+
+                // Reopen any closed rosters so the chat reappears in the acting
+                // mod's (and the member's) chat list, mirroring V2 CreateChatMessage
+                // (iznik-server-go chat/chatmessage.go). Without this, a chat the mod
+                // had previously closed stays hidden from their ModTools chats list
+                // even after they send this modmail (Discourse #9481/541).
+                $this->reopenClosedRosters((int) $chatRoom->id);
             }
         }
 
@@ -714,6 +737,10 @@ class ProcessBackgroundTasksCommand extends Command
                     ['chatid', 'userid'],
                     ['lastmsgemailed', 'lastemailed']
                 );
+
+                // Reopen any closed rosters so the chat reappears in the acting
+                // mod's (and the member's) chat list — see reopenClosedRosters().
+                $this->reopenClosedRosters((int) $chatRoom->id);
             }
 
             // Only create the User/Mailed log for email_mod_stdmsg (direct mod message to member).

--- a/iznik-batch/tests/Unit/Queue/ProcessBackgroundTasksCommandTest.php
+++ b/iznik-batch/tests/Unit/Queue/ProcessBackgroundTasksCommandTest.php
@@ -851,6 +851,90 @@ class ProcessBackgroundTasksCommandTest extends TestCase
         $this->assertStringContains('Please repost.', $chatMsg->message);
     }
 
+    public function test_message_rejected_reopens_mods_previously_closed_chat(): void
+    {
+        // Regression (Discourse #9481/541, reporter Derek): a mod actions a member
+        // via a User2Mod chat they had previously CLOSED. The modmail is delivered
+        // and latestmessage is bumped, but the mod's roster stays 'Closed', so the
+        // ModTools chats list (which filters status != 'Closed') hides it — while
+        // the member still sees it. Sending the modmail must reopen the mod's
+        // closed roster so the chat reappears for them.
+        Mail::fake();
+
+        $group = $this->createTestGroup();
+        $poster = $this->createTestUser();
+        $this->createTestUserEmail($poster, ['preferred' => 1]);
+        $mod = $this->createTestUser(['fullname' => 'Closed Roster Mod']);
+
+        $msgId = DB::table('messages')->insertGetId([
+            'fromuser' => $poster->id,
+            'subject' => 'WANTED: Something (Test ZZ1)',
+            'date' => now(),
+        ]);
+        DB::table('messages_groups')->insert([
+            'msgid' => $msgId,
+            'groupid' => $group->id,
+            'collection' => 'Rejected',
+        ]);
+
+        // Pre-existing User2Mod chat that the mod had previously CLOSED, with a
+        // stale latestmessage (as in the real report, an old chat).
+        $chatId = DB::table('chat_rooms')->insertGetId([
+            'user1' => $poster->id,
+            'chattype' => 'User2Mod',
+            'groupid' => $group->id,
+            'latestmessage' => now()->subDays(400),
+        ]);
+        DB::table('chat_roster')->insert([
+            'chatid' => $chatId,
+            'userid' => $mod->id,
+            'status' => 'Closed',
+            'date' => now()->subDays(400),
+        ]);
+
+        DB::table('background_tasks')->insert([
+            'task_type' => 'email_message_rejected',
+            'data' => json_encode([
+                'msgid' => $msgId,
+                'byuser' => $mod->id,
+                'groupid' => $group->id,
+                'subject' => 'Message not approved: WANTED: Something (Test ZZ1)',
+                'body' => 'Please repost with more detail.',
+                'stdmsgid' => 0,
+            ]),
+            'created_at' => now(),
+        ]);
+
+        $mockPush = $this->mock(PushNotificationService::class);
+        $mockPush->shouldReceive('notifyGroupMods')
+            ->once()
+            ->with($group->id)
+            ->andReturn(0);
+
+        $this->artisan('queue:background-tasks', [
+            '--max-iterations' => 1,
+            '--sleep' => 0,
+        ])->assertSuccessful();
+        $this->artisan('mail:spool:process')->assertSuccessful();
+
+        // The modmail must have gone into the pre-existing chat (not a new one).
+        $chatMsg = DB::table('chat_messages')
+            ->where('chatid', $chatId)
+            ->where('userid', $mod->id)
+            ->where('type', 'ModMail')
+            ->first();
+        $this->assertNotNull($chatMsg, 'ModMail should be added to the existing chat');
+
+        // The mod's roster must no longer be 'Closed', so the chat reappears in
+        // their ModTools chats list.
+        $status = DB::table('chat_roster')
+            ->where('chatid', $chatId)
+            ->where('userid', $mod->id)
+            ->value('status');
+        $this->assertNotEquals('Closed', $status, "Mod's previously-closed roster should be reopened after sending modmail");
+        $this->assertEquals('Offline', $status);
+    }
+
     public function test_message_outcome_logs_and_notifies_interested_users(): void
     {
         $group = $this->createTestGroup();

--- a/iznik-batch/tests/Unit/Queue/ProcessBackgroundTasksCommandTest.php
+++ b/iznik-batch/tests/Unit/Queue/ProcessBackgroundTasksCommandTest.php
@@ -935,6 +935,68 @@ class ProcessBackgroundTasksCommandTest extends TestCase
         $this->assertEquals('Offline', $status);
     }
 
+    public function test_mod_stdmsg_to_member_reopens_mods_previously_closed_chat(): void
+    {
+        // Mirrors test_message_rejected_reopens_mods_previously_closed_chat but for the
+        // email_mod_stdmsg (direct mod-to-member message) code path handled by
+        // handleModStdMessageForMember — which also calls reopenClosedRosters().
+        Mail::fake();
+
+        $group = $this->createTestGroup();
+        $member = $this->createTestUser();
+        $this->createTestUserEmail($member, ['preferred' => 1]);
+        $mod = $this->createTestUser(['fullname' => 'Closed Roster Mod 2']);
+
+        // Pre-existing User2Mod chat that the mod had previously CLOSED.
+        $chatId = DB::table('chat_rooms')->insertGetId([
+            'user1' => $member->id,
+            'chattype' => 'User2Mod',
+            'groupid' => $group->id,
+            'latestmessage' => now()->subDays(30),
+        ]);
+        DB::table('chat_roster')->insert([
+            'chatid' => $chatId,
+            'userid' => $mod->id,
+            'status' => 'Closed',
+            'date' => now()->subDays(30),
+        ]);
+
+        DB::table('background_tasks')->insert([
+            'task_type' => 'email_mod_stdmsg',
+            'data' => json_encode([
+                'userid' => $member->id,
+                'byuser' => $mod->id,
+                'groupid' => $group->id,
+                'subject' => 'A note from your moderator',
+                'body' => 'Please read our group rules.',
+                'stdmsgid' => 0,
+            ]),
+            'created_at' => now(),
+        ]);
+
+        $this->artisan('queue:background-tasks', [
+            '--max-iterations' => 1,
+            '--sleep' => 0,
+        ])->assertSuccessful();
+        $this->artisan('mail:spool:process')->assertSuccessful();
+
+        // The modmail must have gone into the pre-existing chat (not a new one).
+        $chatMsg = DB::table('chat_messages')
+            ->where('chatid', $chatId)
+            ->where('userid', $mod->id)
+            ->where('type', 'ModMail')
+            ->first();
+        $this->assertNotNull($chatMsg, 'ModMail should be added to the existing User2Mod chat');
+
+        // The mod's roster must no longer be 'Closed' so the chat reappears.
+        $status = DB::table('chat_roster')
+            ->where('chatid', $chatId)
+            ->where('userid', $mod->id)
+            ->value('status');
+        $this->assertNotEquals('Closed', $status, "Mod's previously-closed roster should be reopened after sending mod stdmsg");
+        $this->assertEquals('Offline', $status);
+    }
+
     public function test_message_outcome_logs_and_notifies_interested_users(): void
     {
         $group = $this->createTestGroup();


### PR DESCRIPTION
## Root Cause (verified against production data)

Discourse #9481/541 (Derek): *"I sent 2 Modmails this morning to 2 different members on 2 different groups but only 1 is showing in the chats list on MT. The one not showing does have the Modmail showing against her name."*

This is **not** a `latestmessage` problem (the earlier version of this PR was wrong). Checked against the live DB, Derek's two chats differed in exactly one field:

| chat | group | latestmessage | mod's `chat_roster.status` | shows in MT? |
|---|---|---|---|---|
| 20871718 | 21414 | current | **Online** | ✅ |
| 13521207 | 21313 | current | **Closed** | ❌ |

Both had a **current** `latestmessage`. The hidden chat was one Derek had **previously closed** (`status='Closed'`, last emailed months earlier). The ModTools chat list query filters `AND (chat_roster.status IS NULL OR chat_roster.status != 'Closed')` (`iznik-server-go/chat/chatroom.go`), so a closed-roster chat stays hidden from the mod — while the member (user1) still sees it.

Mod-action modmails (decline → "Message not approved…", note → "Moderator Note…") are created by `ProcessBackgroundTasksCommand` (`handleModStdMessage` / `handleModStdMessageForMember`). That path creates the `ModMail` chat message and bumps `latestmessage` (via `getOrCreateUser2Mod`) but **never reopens the acting mod's `Closed` roster** — unlike V2 `CreateChatMessage` (`chatmessage.go:391`), which reopens `Closed`→`Offline` on send. So the mod doesn't see the chat reappear.

Across 30 days, 0/2958 User2Mod modmails left `latestmessage` stale, confirming the real differentiator is roster status, not `latestmessage`.

## Fix

`iznik-batch/app/Console/Commands/Queue/ProcessBackgroundTasksCommand.php`: after creating the modmail chat message (both `handleModStdMessage` and `handleModStdMessageForMember`), reopen the chat's `Closed` rosters → `Offline` via a shared `reopenClosedRosters()` helper — mirroring V2 `CreateChatMessage`. `Blocked` rosters are left as-is.

## Test

`tests/Unit/Queue/ProcessBackgroundTasksCommandTest.php` → `test_message_rejected_reopens_mods_previously_closed_chat`: a mod with a `Closed` roster on a pre-existing User2Mod chat actions a rejected message; after processing, the mod's roster is no longer `Closed` (reopened to `Offline`) so the chat reappears. Fails before the fix (roster stays `Closed`), passes after.

## Note

This supersedes the previous (incorrect) version of this PR, which added a `latestmessage` bump in V2 Go `CreateChatMessage` — disproven against live data (latestmessage was already current). That change has been reverted; the fix is now in the actual modmail-creation path.

## Discourse

https://discourse.ilovefreegle.org/t/9481/541
