### PR TITLE
fix(avatar): persist uploaded avatar so the change sticks

### DIFF
--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -23,7 +23,7 @@ parameters:
     description: "Forwarded from trigger — true when build_modtools_production was set"
 
 orbs:
-  freegle: freegle/tests@1.1.337
+  freegle: freegle/tests@1.1.339
 
 jobs:
   mark-ci-passed:

--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -23,7 +23,7 @@ parameters:
     description: "Forwarded from trigger — true when build_modtools_production was set"
 
 orbs:
-  freegle: freegle/tests@1.1.334
+  freegle: freegle/tests@1.1.336
 
 jobs:
   mark-ci-passed:

--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -23,7 +23,7 @@ parameters:
     description: "Forwarded from trigger — true when build_modtools_production was set"
 
 orbs:
-  freegle: freegle/tests@1.1.336
+  freegle: freegle/tests@1.1.337
 
 jobs:
   mark-ci-passed:

--- a/iznik-nuxt3/components/settings/ProfileSection.vue
+++ b/iznik-nuxt3/components/settings/ProfileSection.vue
@@ -268,7 +268,7 @@ watch(
         externaluid: newVal[0].ouruid,
         externalmods: newVal[0].externalmods,
         imgtype: 'User',
-        msgid: me?.value.id,
+        user: me?.value.id,
       }
       await imageStore.post(atts)
     }

--- a/iznik-nuxt3/tests/unit/components/settings_ProfileSection.spec.js
+++ b/iznik-nuxt3/tests/unit/components/settings_ProfileSection.spec.js
@@ -575,6 +575,30 @@ describe('ProfileSection', () => {
 
       expect(wrapper.vm.displayName).toBe('Updated Name')
     })
+
+    describe('currentAtts watcher (avatar upload persistence)', () => {
+      it('posts avatar with user field (not msgid) so it persists against the user', async () => {
+        mockImagePost.mockResolvedValue({ id: 999, uid: 'freegletusd-abc' })
+        const wrapper = createWrapper()
+
+        wrapper.vm.currentAtts = [
+          { ouruid: 'freegletusd-abc', externalmods: {} },
+        ]
+        await wrapper.vm.$nextTick()
+        await new Promise((resolve) => setTimeout(resolve, 0))
+
+        expect(mockImagePost).toHaveBeenCalledWith(
+          expect.objectContaining({
+            externaluid: 'freegletusd-abc',
+            imgtype: 'User',
+            user: 123,
+          })
+        )
+        expect(mockImagePost).not.toHaveBeenCalledWith(
+          expect.objectContaining({ msgid: 123 })
+        )
+      })
+    })
   })
 
   describe('uploader visibility', () => {


### PR DESCRIPTION
## Root Cause
`ProfileSection.vue`'s `currentAtts` watcher called `imageStore.post()` with `msgid: me.value.id` when persisting a new avatar. The Go API `/image` endpoint resolves the parent user ID for `imgtype: 'User'` images from the `user` JSON field (`req.UserID`), not `msgid`. So `users_images.userid` was always `NULL` — the upload was never linked to the user in the database. When `fetchMe(true)` subsequently refreshed the profile, the server returned the old (or no) profile image, causing the brief flash then revert seen by user 43484123.

## Evidence
```
FAIL  tests/unit/components/settings_ProfileSection.spec.js
> ProfileSection > watch > currentAtts watcher > posts avatar with user field (not msgid) so it persists
AssertionError: expected "spy" to be called with arguments: [ ObjectContaining{ user: 123 } ]
Received: { "externaluid": "freegletusd-abc", "imgtype": "User", "msgid": 123 }
```

## Fix
Single-character field name change in `ProfileSection.vue`:
```diff
-        msgid: me?.value.id,
+        user: me?.value.id,
```
The `user` field maps to `req.UserID` in the Go API, which becomes `users_images.userid` — properly linking the uploaded image to the authenticated user.

## Other Call Sites
The only other `imgtype: 'User'` call in `ProfileSection.vue` (line 234) is the rotation handler; it already correctly uses `user: true` as the type flag. No other component posts `imgtype: 'User'` images with a parent-ID field.

## Test
- File: `iznik-nuxt3/tests/unit/components/settings_ProfileSection.spec.js`
- Command: `vitest run tests/unit/components/settings_ProfileSection.spec.js`
- Proves: fails before fix (`msgid` found), passes after fix (`user` found, `msgid` absent)

## Discourse
https://discourse.ilovefreegle.org/t/9679/10