### PR TITLE
fix(modtools): show all chat review items instead of capping at 5

### DIFF
--- a/iznik-nuxt3/modtools/pages/chats/review.vue
+++ b/iznik-nuxt3/modtools/pages/chats/review.vue
@@ -65,11 +65,7 @@ const chatStore = useChatStore()
 // Reactive state (was data())
 // eslint-disable-next-line no-unused-vars
 const context = ref(null)
-// We fetch less stuff at once for MT.  This is because for slow devices and networks the time to fetch and
-// render is significant, and each of these consumes a lot of screen space.  So by fetching and rendering less,
-// we increase how fast it feels.
 const distance = ref(1000)
-const limit = ref(5)
 const show = ref(0)
 const bump = ref(0)
 const showDeleteModal = ref(false)
@@ -141,9 +137,7 @@ async function clearAndLoad() {
   // We don't want to pick up any real chat messages.
   await chatStore.clear()
 
-  await chatStore.fetchReviewChatsMT(REVIEWCHAT, {
-    limit: limit.value,
-  })
+  await chatStore.fetchReviewChatsMT(REVIEWCHAT, {})
 
   loading.value = false
   bump.value++

--- a/iznik-nuxt3/tests/unit/pages/modtools/chats/review.spec.js
+++ b/iznik-nuxt3/tests/unit/pages/modtools/chats/review.spec.js
@@ -169,9 +169,24 @@ describe('chats/review.vue page', () => {
       await wrapper.vm.clearAndLoad()
 
       expect(mockChatStore.clear).toHaveBeenCalled()
-      expect(mockChatStore.fetchReviewChatsMT).toHaveBeenCalledWith(null, {
-        limit: 5,
-      })
+      expect(mockChatStore.fetchReviewChatsMT).toHaveBeenCalledWith(null, {})
+    })
+
+    it('clearAndLoad fetches without a hard 5-item limit so all pending items are reachable', async () => {
+      // Regression: clearAndLoad was passing limit: 5 to fetchReviewChatsMT,
+      // so the server returned at most 5 messages even when the badge showed more.
+      // loadMore would call $state.complete() after the 5, making further items
+      // unreachable. Fix: remove the hard limit so the server default (100) applies.
+      const wrapper = mountComponent()
+      await flushPromises()
+      vi.clearAllMocks()
+
+      await wrapper.vm.clearAndLoad()
+
+      // Must NOT pass limit: 5 — that was capping the review list
+      const calls = mockChatStore.fetchReviewChatsMT.mock.calls
+      expect(calls.length).toBe(1)
+      expect(calls[0][1]?.limit).not.toBe(5)
     })
 
     it('clearAndLoad increments bump', async () => {


### PR DESCRIPTION
## Root Cause

`clearAndLoad()` in `modtools/pages/chats/review.vue` was passing `limit: 5` to `fetchReviewChatsMT`, so the Go API returned at most 5 messages. Once those 5 were rendered, `loadMore` called `$state.complete()`, marking the infinite scroll as exhausted. Any pending review items beyond the first 5 were permanently unreachable — the badge could show 12 but only 5 could be acted on.

## Evidence

```
FAIL tests/unit/pages/modtools/chats/review.spec.js > clearAndLoad fetches without a hard 5-item limit...
AssertionError: expected 5 not to be 5
  at expect(calls[0][1]?.limit).not.toBe(5)
```

Two tests fail on the buggy code:
1. `clearAndLoad clears store and fetches review chats` — expected `{}` params but got `{ limit: 5 }`
2. `clearAndLoad fetches without a hard 5-item limit` — `limit` was 5, must not be 5

## Fix

Removed `const limit = ref(5)` and the `limit: limit.value` argument from `clearAndLoad`. The server's default of 100 now applies, returning all pending review items. `loadMore` still reveals them progressively via the `show` counter, so there's no rendering regression.

## Other Call Sites

`useModMembers.js` and `ModLogs.vue` also use `limit: limit.value` but with proper pagination increment (`limit.value += distance.value`) — no issue there.

## Test

File: `iznik-nuxt3/tests/unit/pages/modtools/chats/review.spec.js`

Command: `npx vitest run tests/unit/pages/modtools/chats/review.spec.js`

Proves: fails before fix (limit is 5), passes after fix (limit is not 5). Full suite: 596 test files, 12862 tests — all pass.

## Discourse

https://discourse.ilovefreegle.org/t/9656/43