### PR TITLE
fix(api): restore V1 membership audit-trail parity on self-delete and signup (Nimmy940)

### DIFF
--- a/.circleci/orb/freegle-tests.yml
+++ b/.circleci/orb/freegle-tests.yml
@@ -70,15 +70,14 @@ executors:
       COMPOSE_PROFILES: frontend,database,backend,dev,monitoring
       COMPOSE_PROJECT_NAME: freegle-ci
       SELF_HOSTED_RUNNER: "true"
-      # PW_WORKERS halved 11 -> 6 to stop build-test-katapult CPU-heartbeat
-      # starvation in the parallel test phase. RAM/swap are fine (20G swapfile),
-      # but 11 Chromium workers + Laravel + Go + Vitest saturated all 16 cores,
-      # so the CircleCI agent couldn't heartbeat and the job was killed
-      # (infrastructure_fail) ~6 min into the test step. nice-demoting the test
-      # runners alone (orb 1.1.338) did NOT hold, so we also cut Playwright
-      # concurrency. If it still starves, lower further or split Playwright onto
-      # its own Katapult job (task #37).
-      PW_WORKERS: 6
+      # PW_WORKERS reduced 11 -> 6 (orb 1.1.339) then 6 -> 4 (orb 1.1.340) to
+      # stop build-test-katapult CPU-heartbeat starvation in the parallel test
+      # phase. RAM/swap are fine (20G swapfile), but Chromium workers + Laravel +
+      # Go + Vitest saturated all 16 cores so the CircleCI agent couldn't
+      # heartbeat and the job was killed (infrastructure_fail). nice-demoting the
+      # test runners (orb 1.1.338) did NOT hold alone. 4 matches the stable
+      # machine-executor-large value.
+      PW_WORKERS: 4
       VITEST_MAX_WORKERS: 4
       PORT_TRAEFIK_HTTP: 9080
       PORT_TRAEFIK_API: 17192

--- a/iznik-server-go/session/session.go
+++ b/iznik-server-go/session/session.go
@@ -573,7 +573,10 @@ func handleForget(c *fiber.Ctx, partner string, targetID uint64) error {
 		}
 
 		// V1 parity (User::delete): drop approved memberships so the user immediately
-		// disappears from group member lists.
+		// disappears from group member lists. Emit the per-group (Group, Left) audit
+		// log first (byuser NULL — no acting Freegle user in the partner flow), since
+		// the eager delete leaves nothing for the later cleanup cron to log.
+		user.LogGroupLeftForApprovedMemberships(db, targetID, 0)
 		db.Exec("DELETE FROM memberships WHERE userid = ? AND collection = ?", targetID, utils.COLLECTION_APPROVED)
 
 		db.Exec("UPDATE users SET deleted = NOW() WHERE id = ?", targetID)
@@ -624,7 +627,10 @@ func handleForget(c *fiber.Ctx, partner string, targetID uint64) error {
 	c.Locals("skipPostAuthCheck", true)
 
 	// V1 parity (User::delete): drop approved memberships so the user no longer appears
-	// in group member lists during the grace period.
+	// in group member lists during the grace period. Emit the per-group (Group, Left)
+	// audit log first (byuser = the user themselves), since the eager delete leaves
+	// nothing for the later cleanup cron to log.
+	user.LogGroupLeftForApprovedMemberships(db, myid, myid)
 	db.Exec("DELETE FROM memberships WHERE userid = ? AND collection = ?", myid, utils.COLLECTION_APPROVED)
 
 	// Soft-delete: user can recover by logging back in within ~14 days.

--- a/iznik-server-go/test/membership_audit_parity_test.go
+++ b/iznik-server-go/test/membership_audit_parity_test.go
@@ -1,0 +1,115 @@
+package test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/stretchr/testify/assert"
+)
+
+// Gap 1: per-group (Group, Left) audit log on self-delete.
+//
+// V1 writes one Group/Left log per group when the user actually leaves: at
+// grace-period expiry the processForgets cron calls removeMembership() per group
+// (User.php:1087-1095). V2 bulk-deletes approved memberships eagerly at delete
+// time, so the Left logs must be emitted at that point — otherwise the audit
+// trail V1 produced is lost entirely (the later cleanup cron finds no memberships
+// to iterate). Matches the Nimmy940 report: membership vanished with only a
+// User/Deleted log written.
+
+// TestForgetWritesGroupLeftLog covers the session "Forget" self-delete path
+// (POST /session action=Forget -> session.handleForget).
+func TestForgetWritesGroupLeftLog(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("forget-left")
+	userID := CreateTestUser(t, prefix, "User")
+	groupID := CreateTestGroup(t, prefix)
+	db.Exec("INSERT INTO memberships (userid, groupid, role, collection) VALUES (?, ?, 'Member', 'Approved')", userID, groupID)
+
+	token := getToken(t, userID)
+	req := httptest.NewRequest("POST", "/api/session?jwt="+token, strings.NewReader(`{"action":"Forget"}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := getApp().Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var leftCount int64
+	db.Raw("SELECT COUNT(*) FROM logs WHERE type = 'Group' AND subtype = 'Left' AND user = ? AND groupid = ?",
+		userID, groupID).Scan(&leftCount)
+	assert.Equal(t, int64(1), leftCount, "expected one Group/Left log for the user's group on self-delete")
+
+	// The membership should be gone (V2 eager delete) and the User/Deleted log
+	// present (existing parity must be preserved).
+	var memberCount, deletedCount int64
+	db.Raw("SELECT COUNT(*) FROM memberships WHERE userid = ? AND groupid = ?", userID, groupID).Scan(&memberCount)
+	assert.Equal(t, int64(0), memberCount)
+	db.Raw("SELECT COUNT(*) FROM logs WHERE type = 'User' AND subtype = 'Deleted' AND user = ?", userID).Scan(&deletedCount)
+	assert.Equal(t, int64(1), deletedCount)
+}
+
+// TestLimboUserWritesGroupLeftLogPerGroup covers the DELETE /user self-delete
+// path (user.LimboUser -> softLimboUser, shared with the Unsubscribe action) and
+// asserts the Left log is written for EACH group the user belonged to.
+func TestLimboUserWritesGroupLeftLogPerGroup(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("limbo-left")
+	userID := CreateTestUser(t, prefix, "User")
+	group1 := CreateTestGroup(t, prefix+"a")
+	group2 := CreateTestGroup(t, prefix+"b")
+	db.Exec("INSERT INTO memberships (userid, groupid, role, collection) VALUES (?, ?, 'Member', 'Approved')", userID, group1)
+	db.Exec("INSERT INTO memberships (userid, groupid, role, collection) VALUES (?, ?, 'Member', 'Approved')", userID, group2)
+
+	token := getToken(t, userID)
+	req := httptest.NewRequest("DELETE", "/api/user?jwt="+token, nil)
+	resp, err := getApp().Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var left1, left2 int64
+	db.Raw("SELECT COUNT(*) FROM logs WHERE type = 'Group' AND subtype = 'Left' AND user = ? AND groupid = ?", userID, group1).Scan(&left1)
+	db.Raw("SELECT COUNT(*) FROM logs WHERE type = 'Group' AND subtype = 'Left' AND user = ? AND groupid = ?", userID, group2).Scan(&left2)
+	assert.Equal(t, int64(1), left1, "expected a Group/Left log for group1")
+	assert.Equal(t, int64(1), left2, "expected a Group/Left log for group2")
+}
+
+// Gap 2: memberships_history row on website signup.
+//
+// V1 addMembership() unconditionally writes memberships_history with
+// processingrequired=1 (User.php:911-916), which the memberships:process consumer
+// uses to subject brand-new joiners to welcome / abuse-detection / member-review
+// scrutiny. V2's PutUser website-signup path inserts the membership inline and
+// never calls AddMembership() (where the e041eded2 fix lives), so no history row
+// was written and the new member bypassed that scrutiny. Matches Nimmy940: joined
+// via the signup form, empty memberships_history.
+func TestPutUserWithGroupWritesMembershipsHistory(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("puthist")
+	groupID := CreateTestGroup(t, prefix)
+
+	payload := map[string]interface{}{
+		"email":     fmt.Sprintf("%s@test.com", prefix),
+		"firstname": "Hist",
+		"lastname":  "Joiner",
+		"groupid":   groupID,
+	}
+	s, _ := json.Marshal(payload)
+	req := httptest.NewRequest("PUT", "/api/user", strings.NewReader(string(s)))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := getApp().Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&result)
+	assert.Equal(t, float64(0), result["ret"])
+	userID := uint64(result["id"].(float64))
+
+	var histCount int64
+	db.Raw("SELECT COUNT(*) FROM memberships_history WHERE userid = ? AND groupid = ? AND collection = 'Approved' AND processingrequired = 1",
+		userID, groupID).Scan(&histCount)
+	assert.Equal(t, int64(1), histCount, "expected a memberships_history row with processingrequired=1 for the signup join")
+}

--- a/iznik-server-go/user/user.go
+++ b/iznik-server-go/user/user.go
@@ -1907,6 +1907,15 @@ func PutUser(c *fiber.Ctx) error {
 		if result.RowsAffected > 0 {
 			db.Exec("INSERT INTO logs (timestamp, type, subtype, groupid, user, byuser) VALUES (NOW(), ?, ?, ?, ?, ?)",
 				log2.LOG_TYPE_GROUP, log2.LOG_SUBTYPE_JOINED, req.GroupID, newUserID, newUserID)
+
+			// V1 parity (User::addMembership, User.php:911-916): record the join in
+			// memberships_history with processingrequired=1 so the background
+			// member-review / welcome / abuse-detection consumer (memberships:process)
+			// treats this as a brand-new joiner. AddMembership() writes this row, but
+			// the website-signup path inserts the membership inline and never calls it,
+			// so without this the new member bypasses new-joiner scrutiny.
+			db.Exec("INSERT INTO memberships_history (userid, groupid, collection, processingrequired, added) VALUES (?, ?, ?, 1, NOW())",
+				newUserID, req.GroupID, utils.COLLECTION_APPROVED)
 		}
 	}
 
@@ -2327,6 +2336,32 @@ func handleUnbounce(c *fiber.Ctx, myid uint64, req UserPostRequest) error {
 	return c.JSON(fiber.Map{"ret": 0, "status": "Success"})
 }
 
+// LogGroupLeftForApprovedMemberships writes a per-group (Group, Left) audit log
+// for every Approved membership the user currently holds. V1 emits one such log
+// per group when the user actually leaves: at grace-period expiry the
+// processForgets cron calls User::forget(), which iterates the memberships and
+// calls User::removeMembership() per group, each writing a Left log
+// (User.php:1087-1095). V2 instead bulk-deletes approved memberships eagerly at
+// delete time, so by the time the cleanup cron runs there is nothing left to
+// iterate and the Left logs would never be written — at any point. We therefore
+// emit them here, immediately before the bulk delete. byUser is the actor recorded
+// in the log; pass 0 to record byuser as NULL (e.g. the partner flow, which has no
+// acting Freegle user).
+func LogGroupLeftForApprovedMemberships(db *gorm.DB, targetID uint64, byUser uint64) {
+	var groupids []uint64
+	db.Raw("SELECT groupid FROM memberships WHERE userid = ? AND collection = ?",
+		targetID, utils.COLLECTION_APPROVED).Scan(&groupids)
+	for _, groupid := range groupids {
+		if byUser == 0 {
+			db.Exec("INSERT INTO logs (timestamp, type, subtype, user, byuser, groupid) VALUES (NOW(), ?, ?, ?, NULL, ?)",
+				log2.LOG_TYPE_GROUP, log2.LOG_SUBTYPE_LEFT, targetID, groupid)
+		} else {
+			db.Exec("INSERT INTO logs (timestamp, type, subtype, user, byuser, groupid) VALUES (NOW(), ?, ?, ?, ?, ?)",
+				log2.LOG_TYPE_GROUP, log2.LOG_SUBTYPE_LEFT, targetID, byUser, groupid)
+		}
+	}
+}
+
 // softLimboUser puts a user into a recoverable "limbo": it removes their approved
 // memberships (so they drop out of group member lists), marks the account deleted
 // (a 14-day grace period before users:cleanup runs forgetUser), and logs a
@@ -2335,6 +2370,9 @@ func handleUnbounce(c *fiber.Ctx, myid uint64, req UserPostRequest) error {
 // action (POST /user action=Unsubscribe) so both behave identically. byUser is the
 // actor recorded in the log (the user themselves, or the support volunteer).
 func softLimboUser(db *gorm.DB, targetID uint64, byUser uint64) {
+	// V1 parity: record a per-group (Group, Left) audit log before the eager bulk
+	// delete drops the memberships (see LogGroupLeftForApprovedMemberships).
+	LogGroupLeftForApprovedMemberships(db, targetID, byUser)
 	db.Exec("DELETE FROM memberships WHERE userid = ? AND collection = ?", targetID, utils.COLLECTION_APPROVED)
 	db.Exec("UPDATE users SET deleted = NOW() WHERE id = ?", targetID)
 	db.Exec("INSERT INTO logs (timestamp, type, subtype, user, byuser) VALUES (NOW(), ?, ?, ?, ?)",


### PR DESCRIPTION
## Summary

Two V1→V2 parity gaps in the Go API membership lifecycle, both matching the **Nimmy940** report (membership vanished with only a `User/Deleted` log; joined via signup with empty `memberships_history`).

### Gap 1 — per-group `(Group, Left)` audit log on self-delete
V1 emits one `Group/Left` log **per group** when a user leaves: at grace expiry the `processForgets` cron calls `removeMembership()` per group (`User.php:1087-1095`). V2 **bulk-deletes** approved memberships eagerly at delete time, so by the time the cleanup cron runs there's nothing left to iterate — the `Left` logs were never written, at any point.

Fix: emit the per-group `Group/Left` log immediately before each eager delete, via a new shared helper `user.LogGroupLeftForApprovedMemberships`. Applied to all three paths:
- `session.handleForget` self-delete (`byuser` = the user)
- `session.handleForget` partner flow (`byuser` NULL — no acting Freegle user)
- `user.softLimboUser` — shared by `DELETE /user` self-delete and the Support-tools `Unsubscribe` action

### Gap 2 — `memberships_history` row on website signup
V1 `addMembership()` always writes `memberships_history(collection='Approved', processingrequired=1)` (`User.php:911-916`) so the `memberships:process` consumer treats the user as a brand-new joiner (welcome / abuse-detection / member-review). V2's `PutUser` website-signup path inserts the membership **inline** and never calls `AddMembership()` (where the earlier `e041eded2` fix lives), so the history row was missing and new members bypassed that scrutiny.

Fix: `PutUser` now writes the `memberships_history` row (collection Approved, processingrequired=1) alongside the inline membership insert.

## Code Quality
- Shared helper avoids duplicating the per-group log across three call sites; matches the existing `softLimboUser` style and reuses `utils.COLLECTION_APPROVED` / `log2` constants.
- Single-column `Raw().Scan(&[]uint64)` follows existing precedent (e.g. `message.go` `getAllGroupsForMessage`).

## Test Plan
New `iznik-server-go/test/membership_audit_parity_test.go`, run via the worktree status API (`/api/tests/go`) on a clean `origin/master` base — **3008 pass / 0 fail**:
- `TestForgetWritesGroupLeftLog` — session Forget self path writes the `Group/Left` log and still writes `User/Deleted`; membership removed.
- `TestLimboUserWritesGroupLeftLogPerGroup` — `DELETE /user` writes a `Left` log for **each** of the user's groups.
- `TestPutUserWithGroupWritesMembershipsHistory` — signup with a group writes a `memberships_history` row with `processingrequired=1`.
