### PR TITLE
fix(ai-image): exclude suppressed/non-active images from /illustration endpoint

### DIFF
--- a/iznik-server-go/misc/illustration.go
+++ b/iznik-server-go/misc/illustration.go
@@ -63,7 +63,10 @@ func GetIllustration(c *fiber.Ctx) error {
 	db := database.DBConn
 	var externalUID sql.NullString
 
-	err := db.Raw("SELECT externaluid FROM ai_images WHERE name = ?", itemName).Scan(&externalUID).Error
+	// Only serve active illustrations — suppressed/rejected/regenerating images are
+	// hidden by the message API, so returning them here causes a blank photo slot
+	// after the user attaches the image and submits their post (topic 9753).
+	err := db.Raw("SELECT externaluid FROM ai_images WHERE name = ? AND status = 'active'", itemName).Scan(&externalUID).Error
 
 	if err != nil || !externalUID.Valid || externalUID.String == "" {
 		// Not cached - frontend should fall back to image generation.

--- a/iznik-server-go/test/illustration_test.go
+++ b/iznik-server-go/test/illustration_test.go
@@ -127,3 +127,60 @@ func TestIllustrationLocationSuffixStripping(t *testing.T) {
 	// Clean up.
 	db.Exec("DELETE FROM ai_images WHERE name = ?", testItem)
 }
+
+// TestIllustrationSuppressedNotReturned verifies that a suppressed AI image
+// is NOT returned by the illustration endpoint (AssertFlip: FAILS on buggy code,
+// PASSES once illustration.go filters by status = 'active').
+//
+// Root cause: before the fix, GetIllustration queried ai_images without a
+// status filter, so suppressed images were returned during compose and then
+// silently blanked by the message API — the user saw their attachment disappear.
+func TestIllustrationSuppressedNotReturned(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("illust_suppress")
+	suppUID := "freegletusd-suppressed-" + prefix
+	itemName := "drawing-" + prefix
+
+	// Insert a suppressed AI image (as set by checkAIImageSuppressQuorum).
+	db.Exec("INSERT INTO ai_images (name, externaluid, usage_count, status) VALUES (?, ?, 10, 'suppressed')",
+		itemName, suppUID)
+	t.Cleanup(func() {
+		db.Exec("DELETE FROM ai_images WHERE name = ?", itemName)
+	})
+
+	// AssertFlip Step 3b (inverted): should return ret=3 (not cached / don't show),
+	// not ret=0 with the suppressed image. FAILS on buggy code.
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/illustration?item="+url.QueryEscape(itemName), nil))
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result misc.IllustrationResult
+	json2.Unmarshal(rsp(resp), &result)
+	assert.Equal(t, 3, result.Ret,
+		"suppressed AI image must not be returned by /illustration — it would be blanked on view, looking like spam suppression")
+	assert.Nil(t, result.Illustration,
+		"illustration field must be nil for a suppressed image")
+}
+
+// TestIllustrationActiveStillReturned ensures the fix doesn't break the happy
+// path: active illustrations must still be returned.
+func TestIllustrationActiveStillReturned(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("illust_active")
+	activeUID := "freegletusd-active-" + prefix
+	itemName := "sofa-" + prefix
+
+	db.Exec("INSERT INTO ai_images (name, externaluid, usage_count, status) VALUES (?, ?, 50, 'active')",
+		itemName, activeUID)
+	t.Cleanup(func() {
+		db.Exec("DELETE FROM ai_images WHERE name = ?", itemName)
+	})
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/illustration?item="+url.QueryEscape(itemName), nil))
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result misc.IllustrationResult
+	json2.Unmarshal(rsp(resp), &result)
+	assert.Equal(t, 0, result.Ret, "active illustration must still be returned")
+	assert.NotNil(t, result.Illustration)
+	assert.Equal(t, activeUID, result.Illustration.ExternalUID)
+}


### PR DESCRIPTION
## Root Cause

`GetIllustration` (`iznik-server-go/misc/illustration.go:66`) queried `ai_images` with no `status` filter:

```sql
SELECT externaluid FROM ai_images WHERE name = ?
```

This meant suppressed (and rejected/regenerating) AI images were still returned during compose. The user saw the illustration, attached it, submitted their post — but then `GET /api/message/:id`'s LEFT JOIN blanked the `externaluid` for non-active `ai_images` rows. The result was a ghost photo slot that looked like spam suppression (topic 9753).

The `feat(ai-image): suppress AI images for unsuitable items (topic 9630)` commit updated the message display query and the PHP batch generator to respect `status = 'suppressed'`, but missed updating the compose-time `/illustration` endpoint.

## Evidence

```
TestIllustrationSuppressedNotReturned (illustration_test.go)
  FAILS on buggy code: GetIllustration returns ret=0 with the suppressed image externaluid
  PASSES after fix:    GetIllustration returns ret=3 (not cached / don't show)
```

## Fix

Add `AND status = 'active'` to the `GetIllustration` query so only approved illustrations are offered via the compose preview. Suppressed/rejected/regenerating images return `ret=3`; the frontend's `getIllustration()` returns `null`, so no illustration is added to the compose attachments.

## Other Call Sites

- `microvolunteering.go:542` — already filters `status = 'active'` for challenges ✓
- `aiimage.go:502,618` — admin review/regen endpoints deliberately query `status IN ('rejected','regenerating')` ✓
- `message.go:4054` — `recordAIDeletions` looks up AI image by externaluid for deletion tracking; no status filter needed ✓

## Test

**File**: `iznik-server-go/test/illustration_test.go`
**Added**: `TestIllustrationSuppressedNotReturned`, `TestIllustrationActiveStillReturned`
**Command**: `go test ./... -run TestIllustration -v`
**Proves**: suppressed image returns ret=3 after fix; active image still returns ret=0

## Discourse

https://discourse.ilovefreegle.org/t/9753/1