### PR TITLE
fix(modtools-notifications): exclude pending member applications from work.total

### DIFF
--- a/iznik-server-go/session/session.go
+++ b/iznik-server-go/session/session.go
@@ -1291,8 +1291,16 @@ func GetSession(c *fiber.Ctx) error {
 		wg2.Wait()
 
 		// Total only includes actionable work items (primary/red badge counts),
-		// not informational ones (other/blue badge counts like chatreviewother, happiness, giftaid, pendingother).
-		total := pending + spam + pendingmembers + spammembers + pendingevents +
+		// not informational ones (other/blue badge counts like chatreviewother, happiness, giftaid,
+		// pendingother, pendingmembers).
+		//
+		// pendingmembers (membership applications in the Pending collection) is excluded because:
+		//   1. V1 PHP never counted it — Group::getWorkCounts() initialised it to 0 and never populated it.
+		//   2. No ModTools UI exists to action pending member applications (no Pending filter on the
+		//      Members > Approved page and no dedicated Members > Pending menu item).
+		//   3. Large historical backlogs (e.g. 466 on Hackney, 793 on Newham) caused a spurious red
+		//      badge flood for newly-promoted moderators with "no red tasks in the menu" (Discourse #9654).
+		total := pending + spam + spammembers + pendingevents +
 			pendingadmins + editreview + pendingvolunteering + stories +
 			spammerpendingadd + spammerpendingremove +
 			chatreview + newsletterstories + relatedmembers + housekeeping + cronjobs +

--- a/iznik-server-go/test/session_test.go
+++ b/iznik-server-go/test/session_test.go
@@ -1932,16 +1932,19 @@ func TestWorkCountTotalExcludesInformational(t *testing.T) {
 	total := work["total"].(float64)
 
 	// Total should include actionable items but NOT informational ones
-	// (chatreviewother, happiness, giftaid, pendingother).
+	// (chatreviewother, happiness, giftaid, pendingother, pendingmembers).
+	// pendingmembers (pending member applications) is excluded from total:
+	//   - V1 PHP never counted it (always 0 in getWorkCounts)
+	//   - No ModTools UI exists to action pending member applications
+	//   - Discourse bug 9654/10: new mods see hundreds of spurious counts
 	chatreviewother := work["chatreviewother"].(float64)
 	happiness := work["happiness"].(float64)
 	giftaid := work["giftaid"].(float64)
 
 	// Compute expected total from all actionable fields.
-	// giftaid is excluded from total to match PHP API behaviour (commit df11b11).
+	// giftaid and pendingmembers are excluded from total to match PHP API behaviour.
 	actionable := work["pending"].(float64) +
 		work["spam"].(float64) +
-		work["pendingmembers"].(float64) +
 		work["spammembers"].(float64) +
 		work["pendingevents"].(float64) +
 		work["pendingadmins"].(float64) +
@@ -1958,6 +1961,53 @@ func TestWorkCountTotalExcludesInformational(t *testing.T) {
 	_ = chatreviewother
 	_ = happiness
 	_ = giftaid
+}
+
+// ---------------------------------------------------------------------------
+// Work Counts: Pending member applications excluded from total (Discourse #9654)
+// ---------------------------------------------------------------------------
+
+// TestNewModPendingMembersNotInWorkTotal verifies that pending member
+// applications do not inflate work.total for a newly-promoted moderator.
+//
+// Root cause (Discourse topic 9654, post 10): V1 PHP never counted
+// pendingmembers in the work total (it was initialised to 0 and never
+// populated in Group::getWorkCounts). V2 correctly counts the DB rows
+// but there is no ModTools UI to action them, so large historical backlogs
+// (e.g. 466 on Hackney, 793 on Newham) caused a spurious red badge for
+// new mods with "no red tasks in the menu".
+func TestNewModPendingMembersNotInWorkTotal(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("newmod_pendmem")
+
+	groupID := CreateTestGroup(t, prefix)
+	modID := CreateTestUser(t, prefix+"_mod", "User")
+	CreateTestMembership(t, modID, groupID, "Moderator")
+	_, token := CreateTestSession(t, modID)
+
+	// Baseline: a freshly-promoted mod with no pending work.
+	workBefore := getSessionWork(t, token)
+	totalBefore := workBefore["total"].(float64)
+
+	// Create a pending member application in the mod's group.
+	// This simulates the historical backlog that causes the spurious count.
+	pendingUserID := CreateTestUser(t, prefix+"_pending", "User")
+	db.Exec("INSERT INTO memberships (userid, groupid, role, collection) VALUES (?, ?, 'Member', 'Pending')",
+		pendingUserID, groupID)
+	defer db.Exec("DELETE FROM memberships WHERE userid = ? AND groupid = ?", pendingUserID, groupID)
+
+	workAfter := getSessionWork(t, token)
+	pendingmembers := workAfter["pendingmembers"].(float64)
+	totalAfter := workAfter["total"].(float64)
+
+	// 3a: pendingmembers IS returned in the work object (informational data).
+	assert.Greater(t, pendingmembers, float64(0),
+		"pendingmembers should be returned as informational data (>0 after adding pending member)")
+
+	// 3b (FAILS on buggy code): total must not change when only pendingmembers increases.
+	// A new mod with only pending member applications should see total=0 (no actionable UI for them).
+	assert.Equal(t, totalBefore, totalAfter,
+		"work.total must not include pendingmembers — no ModTools UI exists to action them (Discourse #9654)")
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Root Cause

`pendingmembers` (membership applications in the `Pending` collection) was included in `work.total`, the value that drives the red badge on the ModTools hamburger menu button.

**V1 parity failure**: V1 PHP (`Group::getWorkCounts`) always initialised `pendingmembers` to 0 and never populated it from the database, so it never contributed to the work badge. V2 correctly queries the count but introduced new behaviour without a matching UI.

**No actionable UI**: ModTools has no UI to action pending member applications — there is no "Pending" filter on the Members › Approved page and no dedicated Members › Pending menu item. So a large historical backlog causes an inflated red badge with nothing visible in the menu to explain it ("no red tasks in the menu").

## Evidence

Failing test on buggy code:
\`\`\`
=== RUN   TestNewModPendingMembersNotInWorkTotal
    session_test.go:3228:
        Error:      Not equal:
                    expected: 0
                    actual  : 1
        Messages:   work.total must not include pendingmembers — no ModTools UI exists to action them (Discourse #9654)
--- FAIL: TestNewModPendingMembersNotInWorkTotal (0.10s)
\`\`\`

## Fix

Removed `pendingmembers` from the `total` arithmetic in `session.go`. The value is still computed and returned in the work object as informational data (it was informational in V1 too — always 0 but present in the response schema). The per-group `/api/group/work` endpoint is unchanged.

Updated `TestWorkCountTotalExcludesInformational` to match (removed `pendingmembers` from the expected-actionable sum).

Added `TestNewModPendingMembersNotInWorkTotal` which:
- 3a: asserts `pendingmembers > 0` after inserting a pending member (verifies the count IS returned)
- 3b: asserts `work.total` does not increase (fails on buggy code, passes after fix)

## Other Call Sites

`pendingmembers` in `group/groupWork.go` is a struct field returned by `/api/group/work`. It is not used in any total calculation there — informational only. No change needed.

## Test

- File: `iznik-server-go/test/session_test.go`
- Run: `go test ./test/... -run TestNewModPendingMembersNotInWorkTotal -v`
- Proves: FAIL before fix (total increases by 1 when pending member added), PASS after fix (total unchanged)

## Discourse
https://discourse.ilovefreegle.org/t/9654/10