### PR TITLE
fix(modtools): include Spam-collection messages in Pending review list (Discourse #9654)

### DIFF
--- a/iznik-server-go/message/message_list.go
+++ b/iznik-server-go/message/message_list.go
@@ -440,13 +440,15 @@ func ListMessagesMT(c *fiber.Ctx) error {
 
 	var msgIDs []uint64
 
-	// Hide messages not yet processed by the content-check batch job.
+	// Hide Pending messages not yet processed by the content-check batch job.
 	// The 30-minute fallback ensures mods always see messages if the batch job is down,
 	// and also makes existing rows (contentcheck_checked_at IS NULL) visible without a
 	// backfill — their arrival times are already in the past.
+	// When the Pending view also shows Spam-collection messages, scope the filter to
+	// Pending rows only (Spam messages have already been reviewed and need no content check).
 	contentcheckFilter := ""
 	if collection == utils.COLLECTION_PENDING {
-		contentcheckFilter = " AND (mg.contentcheck_checked_at IS NOT NULL OR mg.arrival < NOW() - INTERVAL 30 MINUTE)"
+		contentcheckFilter = " AND (mg.collection != 'Pending' OR mg.contentcheck_checked_at IS NOT NULL OR mg.arrival < NOW() - INTERVAL 30 MINUTE)"
 	}
 
 	if collection == "Edit" {
@@ -519,13 +521,23 @@ func ListMessagesMT(c *fiber.Ctx) error {
 			db.Raw(sql, args...).Pluck("msgid", &msgIDs)
 		}
 	} else {
+		// When listing the Pending review queue, also include Spam-collection messages.
+		// The badge work-count (session.workCount.spam) already counts these, so
+		// excluding them from the list creates a spurious "+1 over visible" badge
+		// (Discourse #9654 / V1 parity).
+		collectionFilter := "mg.collection = ?"
+		branchArgs := []interface{}{collection}
+		if collection == utils.COLLECTION_PENDING {
+			collectionFilter = "mg.collection IN (?, ?)"
+			branchArgs = []interface{}{utils.COLLECTION_PENDING, utils.COLLECTION_SPAM}
+		}
+
 		branchSQL := "SELECT mg.msgid, mg.arrival FROM messages_groups mg " +
 			"INNER JOIN messages m ON m.id = mg.msgid " +
 			"INNER JOIN users u ON u.id = m.fromuser " +
-			"WHERE mg.groupid = %GID% AND mg.collection = ? AND mg.deleted = 0 " +
+			"WHERE mg.groupid = %GID% AND " + collectionFilter + " AND mg.deleted = 0 " +
 			"AND m.deleted IS NULL AND m.fromuser IS NOT NULL AND u.deleted IS NULL " +
 			contentcheckFilter + " "
-		branchArgs := []interface{}{collection}
 
 		if fromuser > 0 {
 			branchSQL += "AND m.fromuser = ? "

--- a/iznik-server-go/test/message_test.go
+++ b/iznik-server-go/test/message_test.go
@@ -8648,3 +8648,49 @@ func TestPatchMessageByTnPostid_NonAIAttachmentPreservedOnTextOnlyEdit(t *testin
 	// Cleanup.
 	db.Exec("DELETE FROM messages_attachments WHERE id = ?", realAttachID)
 }
+
+// TestListMessagesMT_SpamInPendingList verifies that Spam-collection messages
+// are returned by the /modtools/messages?collection=Pending endpoint.
+//
+// Root cause (Discourse #9654): the badge work-count includes spam messages
+// but the ModTools Pending review list filtered only mg.collection = 'Pending',
+// so the spam message was counted in the badge but had no visible home in the
+// UI — a spurious "+1 over visible".  V1 parity: V1 included Spam messages in
+// the review queue alongside Pending.
+func TestListMessagesMT_SpamInPendingList(t *testing.T) {
+	prefix := uniquePrefix("lstmt_spam")
+	db := database.DBConn
+
+	groupID := CreateTestGroup(t, prefix)
+	posterID := CreateTestUser(t, prefix+"_poster", "User")
+	modID := CreateTestUser(t, prefix+"_mod", "User")
+	CreateTestMembership(t, posterID, groupID, "Member")
+	CreateTestMembership(t, modID, groupID, "Moderator")
+	_, modToken := CreateTestSession(t, modID)
+
+	// Create a message in the Spam collection (as the spam handler would do).
+	msgID := CreateTestMessage(t, posterID, groupID, prefix+" spam item", 52.0, -1.0)
+	db.Exec("UPDATE messages_groups SET collection = 'Spam' WHERE msgid = ? AND groupid = ?", msgID, groupID)
+
+	// The Pending review endpoint should return the Spam-collection message.
+	resp, err := getApp().Test(httptest.NewRequest("GET",
+		fmt.Sprintf("/api/modtools/messages?groupid=%d&collection=Pending&jwt=%s", groupID, modToken), nil))
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var body map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&body)
+	msgs, _ := body["messages"].([]interface{})
+
+	found := false
+	for _, id := range msgs {
+		if id == float64(msgID) {
+			found = true
+		}
+	}
+	assert.True(t, found, "Spam-collection message should appear in modtools Pending review list (Discourse #9654)")
+
+	// Cleanup.
+	db.Exec("DELETE FROM messages_groups WHERE msgid = ?", msgID)
+	db.Exec("DELETE FROM messages WHERE id = ?", msgID)
+}


### PR DESCRIPTION
## Summary

- The ModTools badge work-count includes `spam`-collection messages (via `session.workCount.spam`) but the Pending review list at `GET /api/modtools/messages?collection=Pending` filtered only `mg.collection = 'Pending'` — so the spam message appeared in the badge with no visible/actionable home, producing a spurious "+1 over visible" red badge
- Fix: expand the collection filter in `ListMessagesMT` to `IN ('Pending', 'Spam')` when the caller requests the Pending view; scope the content-check filter to Pending rows only (Spam messages have already been reviewed and don't need content-check gating)
- V1 parity: V1 included Spam-collection messages in the mod review queue alongside Pending

## Changes

- `iznik-server-go/message/message_list.go`: `ListMessagesMT` main list branch now uses `mg.collection IN ('Pending', 'Spam')` when `collection=Pending`; content-check filter scoped to `mg.collection != 'Pending'` bypass clause
- `iznik-server-go/test/message_test.go`: `TestListMessagesMT_SpamInPendingList` — creates a Spam-collection message, asserts it appears in the Pending review list

## Test plan

- [x] `TestListMessagesMT_SpamInPendingList` — new test, confirmed fail before fix, pass after
- [x] Full Go suite: 3005 tests pass (no regressions)
- [ ] Live verification: apply to `freegle-apiv2-live`, re-impersonate Neville Reid on modtools-dev-live.localhost, confirm Hackney spam message appears in Pending tab (badge now has a visible home)

🤖 Generated with [Claude Code](https://claude.com/claude-code)