### PR TITLE
feat(contentcheck): flag non-physical-item posts (services/rentals/jobs/advice) for review

### DIFF
--- a/iznik-batch/app/Services/ContentCheckService.php
+++ b/iznik-batch/app/Services/ContentCheckService.php
@@ -24,6 +24,7 @@ class ContentCheckService
     public const CHECK_URL               = 'Url';
     public const CHECK_MONEY             = 'Money';
     public const CHECK_LANGUAGE          = 'Language';
+    public const CHECK_NOT_AN_ITEM       = 'NotAnItem';
 
     /**
      * Candidate languages for the content-check language detector. Restricted to
@@ -124,6 +125,9 @@ class ContentCheckService
             $reasons[] = $r;
         }
         if ($r = $this->checkVagueItem($itemName)) {
+            $reasons[] = $r;
+        }
+        if ($r = $this->checkNotAnItem($subject, $textbody, $itemName)) {
             $reasons[] = $r;
         }
         if ($r = $this->checkPhoneNumbers($subject, $textbody)) {
@@ -722,6 +726,98 @@ class ContentCheckService
             }
         }
         return $set;
+    }
+
+    // -------------------------------------------------------------------------
+    // Not-an-item — flag posts that are non-physical requests/offers (services,
+    // accommodation/rentals, jobs/work, help/advice) rather than a physical
+    // object. Freegle is for giving away things, so these are diverted to mods
+    // for review (action=flag, NOT auto-blocked). Keyword design is word-boundary
+    // + exclusion-guarded, validated against the production reject log to avoid
+    // false positives on real items: "vacuum cleaner" is not a cleaner-person,
+    // "removal boxes" is not a removal service, "job lot" is a bundle of goods,
+    // "dinner service" is crockery, and "ladder loan" is borrowing an item
+    // (which Freegle allows).
+    // -------------------------------------------------------------------------
+
+    /** Physical-item phrases that collide with non-item keywords — skip these. */
+    private const NOT_AN_ITEM_EXCLUSIONS = [
+        '/\b(vacuum|patio|window|oven|carpet|drain|fabric|pressure|jet|steam|spot|paint|tile|glass|leather|toilet|kitchen|shower|hoover|floor|wheel|pool|gutter|bbq|grill|mould|mold|nit|comb)\s+cleaner/',
+        '/\b(removal|moving|packing|cardboard|home|house|strong|storage|archive)\s+(box|boxes|crate|crates|bag|bags|paper)/',
+        '/\b(hair|paint|stain|tick|rust|odou?r|live|nit|mole|wart|graffiti|ear\s?wax)\s+removal/',
+        '/\bremoval\s+(box|boxes|cream|kit|tool|tools)/',
+        '/\bjob\s*lot\b/',
+        '/\b(dinner|tea|coffee|table|place|china|dining)\s+service\b/',
+        '/\b(loan|borrow|lend)\b/',
+        '/gardener[\'’]?s\s+world/',
+        '/\bdecorator[\'’]?s?\s+(spare|spares|tool|tools|paint|table|caddy|kit|trestle)/',
+        '/\b(motorway|emergency|bus|train|rail|ferry|postal|customer|council|nhs|social|financial|funeral|armed|secret|support|care|delivery)\s+services?\b/',
+    ];
+
+    /** Non-item trigger patterns, grouped by category; first match wins. */
+    private const NOT_AN_ITEM_PATTERNS = [
+        'accommodation' => [
+            '/\b(room|rooms|flat|house|garage|lock\s?-?\s?up|warehouse|studio|annexe?|bedsit|bedroom|property|driveway|parking\s+space)\b[^.!?\n]{0,30}\b(to|for)\s+(rent|let)\b/',
+            '/\bto let\b/', '/\bfor rent\b/', '/\bto rent\b/', '/\brenting\b/',
+            '/\blodger\b/', '/\bflat\s?share\b/', '/\bhouse\s?share\b/',
+            '/\baccommodation\b/', '/\btenant\b/', '/\broom available\b/',
+        ],
+        'service' => [
+            '/\bman\s+(with|and)\s+a?\s?(van|car)\b/', '/\bman\s*&\s*van\b/',
+            '/\b(cleaner|gardener|plumber|electrician|decorator|builder|tutor|handyman|hairdresser|barber|painter|joiner|locksmith)\s+(wanted|needed|required|available)\b/',
+            '/\b(need(ed)?|looking\s+for|want(ed)?|require[d]?)\s+a\s+(cleaner|gardener|plumber|electrician|decorator|builder|tutor|handyman|babysitter|child\s?minder|dog\s?walker|hairdresser|barber)\b/',
+            '/\b(domestic|house|home|office|end[\s-]of[\s-]tenancy)\s+cleaner\b/',
+            '/\b(cleaning|gardening|ironing|babysitting|child\s?minding|tutoring|decorating|plumbing|catering|delivery|moving)\s+service\b/',
+            '/\bdog\s?walk(er|ing)\b/', '/\bbaby\s?sit(ter|ting)\b/',
+            '/\bchild\s?mind(er|ing)\b/', '/\bhandy\s?man\b/', '/\bmassage\b/',
+            '/\bskill\s?swap\b/', '/\bservices\b/', '/\bservice\s+offered\b/',
+        ],
+        'work' => [
+            '/\bvacanc(y|ies)\b/', '/\bhiring\b/', '/\bwork\s+wanted\b/',
+            '/\b(part|full)[\s-]?time\s+job\b/', '/\bemployment\b/',
+            '/\bjob\s+vacancy\b/', '/\blooking\s+for\s+work\b/', '/\bzero\s+hours?\b/',
+        ],
+        'advice' => [
+            '/\badvice\b/', '/\bany\s+recommendations?\b/',
+            '/\bcan\s+(anyone|someone)\s+recommend\b/',
+            '/\blooking\s+for\s+(advice|recommendations?|someone\s+to)\b/',
+            '/\brecommendations?\s+for\s+a\b/',
+        ],
+    ];
+
+    /**
+     * Flag a post that appears to be a non-physical request/offer rather than an
+     * item. Pure text; returns a flag reason (kept Pending for mod review) or null.
+     */
+    public function checkNotAnItem(string $subject, string $textbody, ?string $itemName = null): ?array
+    {
+        $hay = strtolower(trim($subject . ' ' . $textbody . ' ' . ($itemName ?? '')));
+        if ($hay === '') {
+            return null;
+        }
+
+        // Exclusion guard: physical items that would otherwise match a keyword.
+        foreach (self::NOT_AN_ITEM_EXCLUSIONS as $ex) {
+            if (preg_match($ex, $hay)) {
+                return null;
+            }
+        }
+
+        foreach (self::NOT_AN_ITEM_PATTERNS as $category => $patterns) {
+            foreach ($patterns as $pattern) {
+                if (preg_match($pattern, $hay, $m)) {
+                    $matched = trim($m[0]);
+                    return [
+                        'check'    => self::CHECK_NOT_AN_ITEM,
+                        'category' => $category,
+                        'action'   => 'flag',
+                        'detail'   => "Post may be a non-physical request ({$category}) rather than an item — matched \"{$matched}\"",
+                    ];
+                }
+            }
+        }
+
+        return null;
     }
 
     // -------------------------------------------------------------------------

--- a/iznik-batch/tests/Unit/Services/ContentCheckServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/ContentCheckServiceTest.php
@@ -320,6 +320,66 @@ class ContentCheckServiceTest extends TestCase
     }
 
     // =========================================================================
+    // checkNotAnItem — public, pure (non-physical-item detection)
+    // Positive/negative cases are drawn from the production reject log.
+    // =========================================================================
+
+    #[DataProvider('notAnItemProvider')]
+    public function test_check_not_an_item(string $subject, string $body, ?string $category): void
+    {
+        $result = $this->service->checkNotAnItem($subject, $body);
+
+        if ($category === null) {
+            $this->assertNull($result, "Expected NO flag for: {$subject} {$body}");
+        } else {
+            $this->assertNotNull($result, "Expected a flag for: {$subject} {$body}");
+            $this->assertSame(ContentCheckService::CHECK_NOT_AN_ITEM, $result['check']);
+            $this->assertSame('flag', $result['action']);
+            $this->assertSame($category, $result['category']);
+        }
+    }
+
+    public static function notAnItemProvider(): array
+    {
+        return [
+            // --- positives: flag, with expected category ---
+            'cleaner wanted'      => ['WANTED: Cleaner wanted', '', 'service'],
+            'man with a van'      => ['WANTED: Man with a Van', '', 'service'],
+            'man and car removal' => ['WANTED: man and car removal', '', 'service'],
+            'dog walker'          => ['WANTED: dog walker', '', 'service'],
+            'babysitter needed'   => ['WANTED: babysitter needed', '', 'service'],
+            'gardening service'   => ['OFFER: gardening service available', '', 'service'],
+            'services plural'     => ['OFFER: Services', '', 'service'],
+            'room to rent'        => ['OFFER: Room to rent', '', 'accommodation'],
+            'warehouse to rent'   => ['WANTED: Storage warehouse to rent', '', 'accommodation'],
+            'garage to rent'      => ['WANTED: Lockup garage to rent', '', 'accommodation'],
+            'lodger'              => ['WANTED: lodger wanted', '', 'accommodation'],
+            'job vacancy'         => ['', 'I have a job vacancy to fill', 'work'],
+            'part time job'       => ['WANTED: part time job', '', 'work'],
+            'food advice'         => ['WANTED: Food advice', '', 'advice'],
+
+            // --- negatives: real production items that must NOT trip ---
+            'vacuum cleaner'      => ['OFFER: Shark vacuum cleaner', '', null],
+            'patio cleaner'       => ['OFFER: Patio Cleaner', '', null],
+            'plain vacuum'        => ['WANTED: Vacuum cleaner', '', null],
+            'removal boxes'       => ['WANTED: Removal boxes', '', null],
+            'hair removal cream'  => ['OFFER: Nads hair removal cream', '', null],
+            'job lot'             => ['OFFER: job lot of books', '', null],
+            'dinner service'      => ['OFFER: Dinner service', '', null],
+            'ladder loan'         => ['WANTED: Ladder loan', '', null],
+            'loan camera'         => ['WANTED: Loan IR camera', '', null],
+            'gardeners world'     => ["OFFER: Gardener's World magazines", '', null],
+            'decorator spares'    => ['OFFER: Decorator spares', '', null],
+            'different items'     => ['WANTED: different items', '', null],
+            'lifted turf'         => ['OFFER: Lifted turf', '', null],
+            'guitar tutor'        => ['OFFER: Guitar tutor', '', null],
+            'plain sofa'          => ['WANTED: Sofa', '', null],
+            'garden soil'         => ['OFFER: Garden soil', '', null],
+            'motorway services'   => ['WANTED: footstool', 'Collection near the motorway services', null],
+        ];
+    }
+
+    // =========================================================================
     // checkGreetingSpam — public, pure
     // =========================================================================
 

--- a/iznik-nuxt3/modtools/components/ModMessageWorry.vue
+++ b/iznik-nuxt3/modtools/components/ModMessageWorry.vue
@@ -105,6 +105,11 @@
           Group IDs posted to from this IP: {{ reason.groups.join(', ') }}
         </span>
       </span>
+      <span v-else-if="reason.check === 'NotAnItem'">
+        <strong>Possibly not an item:</strong> {{ reason.detail }}. This may be a
+        service, rental, job, or help/advice request rather than a physical item
+        — please check before approving.
+      </span>
       <span v-else>
         <strong>Flagged:</strong> {{ reason.detail }}
       </span>

--- a/iznik-nuxt3/tests/unit/components/modtools/ModMessageWorry.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModMessageWorry.spec.js
@@ -341,6 +341,29 @@ describe('ModMessageWorry', () => {
     })
   })
 
+  describe('NotAnItem check', () => {
+    it('shows Possibly not an item heading', () => {
+      const wrapper = mountWithReasons([
+        { check: 'NotAnItem', category: 'service', detail: 'Post may be a non-physical request (service) rather than an item — matched "cleaner wanted"' },
+      ])
+      expect(wrapper.text()).toContain('Possibly not an item')
+    })
+
+    it('shows the detail text (matched phrase)', () => {
+      const wrapper = mountWithReasons([
+        { check: 'NotAnItem', category: 'accommodation', detail: 'Post may be a non-physical request (accommodation) rather than an item — matched "to rent"' },
+      ])
+      expect(wrapper.text()).toContain('matched "to rent"')
+    })
+
+    it('explains it may not be a physical item', () => {
+      const wrapper = mountWithReasons([
+        { check: 'NotAnItem', category: 'work', detail: 'Post may be a non-physical request (work) rather than an item — matched "job vacancy"' },
+      ])
+      expect(wrapper.text()).toContain('rather than a physical item')
+    })
+  })
+
   describe('unknown check type', () => {
     it('shows generic Flagged heading', () => {
       const wrapper = mountWithReasons([


### PR DESCRIPTION
## Problem
Freegle is for giving away **physical objects**, but `ContentCheckService` had no check for non-tangible posts — services (cleaner, man-with-a-van), accommodation/rentals ("room to rent"), jobs/work, or help/advice. They reached moderators with no signal. (`checkVagueItem` only catches vague *descriptions*, not non-objects.)

## Fix
New `checkNotAnItem()` in `ContentCheckService`, wired into `checkMessage()`. Returns `action=flag`, so the post stays **Pending for a moderator to review** — it is not auto-blocked. Four categories: `accommodation`, `service`, `work`, `advice`.

## Production evidence (V2 live reject log)
- Rental terms ("to rent/let", lodger, accommodation): **9 rejected / 0 approved** (30d) — very high precision.
- Jobs (vacancy/hiring/work-wanted/employment): **4 / 0**.
- Advice/services (advice, "services", skill-swap): **5 / 1**.
- Service-person words proved noisy, so the design is phrase-based + exclusion-guarded (word boundaries, PCRE).

## False-positive guards (real *approved* items that must NOT flag)
`vacuum`/`patio cleaner` (≠ a cleaner-person), `removal boxes` / `hair removal cream` (≠ removal service), `job lot` (a bundle), `dinner service` (crockery), `ladder loan` / `loan camera` (borrowing an item is allowed), `Gardener's World` magazines, `decorator spares`.

## No schema change
Reasons ride the existing `messages_groups.contentcheck_reasons` JSON column; the Go API already returns it; `ModMessageWorry.vue` renders it (added a labelled **NotAnItem** branch — the generic fallback already displayed it).

## Test
- `ContentCheckServiceTest::test_check_not_an_item` — production-derived positives + false-positive negatives.
- `ModMessageWorry.spec.js` — NotAnItem render cases.
- Verified locally: **Laravel 187/187 ✓, Vitest 38/38 ✓**.