### PR TITLE
Idle worktree stack sweeper + WSL diagnostic scripts

### DIFF
--- a/scripts/idle-stack-sweeper/README.md
+++ b/scripts/idle-stack-sweeper/README.md
@@ -1,0 +1,92 @@
+# Idle worktree stack sweeper
+
+Stops the Docker Compose stack of any FreegleDocker **worktree** that is no longer
+being worked on, so idle stacks don't accumulate and fill the WSL VM's memory.
+
+## Why this exists
+
+On a busy dev host we run several worktree environments in parallel (one per
+PR/feature). Each full stack holds several GB. When enough of them pile up, the
+WSL2 VM (capped at ~50% of host RAM) fills, the Linux **global OOM killer** fires,
+kills a process in the WSL session cgroup (`/init.scope`), and the **entire VM
+reboots** — losing all in-flight work. (See `finding_wsl_stops_host_bugcheck` in
+the project memory.)
+
+Raising the memory cap or adding an OOM killer just treats the symptom. The real
+problem is accumulation: worktree stacks that nobody is using any more. This sweeper
+reclaims them.
+
+## What it does
+
+A **systemd system timer** runs every 30 minutes (`freegle-stack-sweeper.timer` →
+`freegle-stack-sweeper.service`, as user `edward`). It runs `freegle-stack-sweeper.sh`,
+which for each worktree **except the main repo** (`/home/edward/FreegleDockerWSL`):
+
+1. Works out when it was last *actually worked on*.
+2. If that was more than `FREEGLE_SWEEP_IDLE_SECS` (default **3600s / 1h**) ago and
+   it has running containers, it `docker stop`s that stack (`stop`, not `down`, so
+   restart is seconds and no data is lost).
+
+The **main repo stack is never stopped.** An actively-edited worktree is never
+stopped, because its activity timestamp keeps refreshing.
+
+### How "last worked on" is measured
+
+Only from signals a developer/Claude produces, never the containers:
+
+- git bookkeeping mtimes: `HEAD`, `ORIG_HEAD`, `FETCH_HEAD`, `logs/HEAD`
+- mtimes of the worktree's changed / untracked-not-ignored files
+  (`git --no-optional-locks status --porcelain`)
+
+It deliberately does **not** use `.git/index` — `git status` (ours, or your shell
+prompt / editor) rewrites it, which would make every worktree look freshly active.
+Container-written churn (logs, `.nuxt`, caches) is ignored because only git-tracked
+or git-recognised paths are counted.
+
+### Notification
+
+When the sweeper stops a stack it drops a marker in `~/.claude/stack-stopped/<project>`.
+The `freegle-stack-notice-hook.sh` **UserPromptSubmit** hook (wired into
+`~/.claude/settings.json`) then tells the Claude session bound to that worktree —
+the next time you type — that its containers were stopped, with the restart command,
+and clears the marker. It is a no-op (near-instant) when nothing has been stopped.
+
+The session→worktree mapping uses the escape-guard state file
+`<CLAUDE_PROJECT_DIR>/.claude/active-worktree.<session_id>` (the `claude` process
+cwd is the *main* repo even while working in a worktree, so cwd alone is unreliable).
+
+## Install / re-install (after a WSL rebuild)
+
+```bash
+scripts/idle-stack-sweeper/install.sh
+```
+
+Idempotent; needs sudo for the systemd parts.
+
+## Tune
+
+- Idle threshold: edit `Environment=FREEGLE_SWEEP_IDLE_SECS=...` in the `.service`
+  (re-run install or `sudo systemctl daemon-reload`).
+- Cadence: edit `OnUnitActiveSec=` in the `.timer`.
+- Dry run (log only, stop nothing): `FREEGLE_SWEEP_DRYRUN=1 ~/.claude/freegle-stack-sweeper.sh`
+- Log: `~/.claude/freegle-stack-sweeper.log`
+
+## Uninstall
+
+```bash
+sudo systemctl disable --now freegle-stack-sweeper.timer
+sudo rm /etc/systemd/system/freegle-stack-sweeper.{service,timer}
+sudo systemctl daemon-reload
+# then remove the UserPromptSubmit hook from ~/.claude/settings.json
+```
+
+## Restart a stack the sweeper stopped
+
+```bash
+cd <worktree> && docker compose start
+```
+
+## Note
+
+The `.service` unit hardcodes `User=edward` and `/home/edward`. On a host with a
+different username, edit the unit before installing.

--- a/scripts/idle-stack-sweeper/freegle-stack-notice-hook.sh
+++ b/scripts/idle-stack-sweeper/freegle-stack-notice-hook.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Claude Code UserPromptSubmit hook.
+#
+# If the idle-stack sweeper (freegle-stack-sweeper.sh) stopped the Docker Compose
+# containers for the worktree THIS session is working in, surface a one-time
+# message to the user AND to Claude (stdout from a UserPromptSubmit hook is added
+# to the conversation), so they know — and can restart the stack if they need it.
+#
+# Always exits 0. Near-instant on the common path (no stacks stopped -> no-op).
+
+set -uo pipefail
+
+NOTICE_DIR="${HOME:-/home/edward}/.claude/stack-stopped"
+
+# Fast path: nothing has been stopped -> do nothing at all.
+[ -d "$NOTICE_DIR" ] || exit 0
+[ -n "$(ls -A "$NOTICE_DIR" 2>/dev/null)" ] || exit 0
+
+payload="$(cat 2>/dev/null)"
+get() { printf '%s' "$payload" | python3 -c "import sys,json;print(json.load(sys.stdin).get('$1',''))" 2>/dev/null; }
+sid="$(get session_id)"
+cwd="$(get cwd)"
+base="${CLAUDE_PROJECT_DIR:-/home/edward/FreegleDockerWSL}"
+
+# Which worktree is this session bound to? The escape-guard state file written by
+# `./freegle switch` is the reliable mapping (the claude process cwd is the main
+# repo even while working in a worktree). Fall back to cwd.
+wt=""
+[ -n "$sid" ] && [ -f "$base/.claude/active-worktree.$sid" ] && wt="$(cat "$base/.claude/active-worktree.$sid" 2>/dev/null)"
+[ -n "$wt" ] || wt="$cwd"
+[ -n "$wt" ] && [ -f "$wt/.env" ] || exit 0
+
+proj="$(grep -E '^COMPOSE_PROJECT_NAME=' "$wt/.env" 2>/dev/null | cut -d= -f2)"
+[ -n "$proj" ] || exit 0
+
+marker="$NOTICE_DIR/$proj"
+[ -f "$marker" ] || exit 0
+
+# If the stack is already running again, the marker is stale — clear it silently.
+running="$(docker ps -q --filter "label=com.docker.compose.project=$proj" 2>/dev/null | grep -c .)"
+if [ "${running:-0}" -gt 0 ]; then
+  rm -f "$marker"
+  exit 0
+fi
+
+# Tell the user + Claude, then clear the marker so it shows only once.
+echo "[idle-stack sweeper] Heads up: this worktree's containers (project '$proj') are stopped."
+sed 's/^/  /' "$marker" 2>/dev/null
+echo "  To bring them back for this work, restart with:  ( cd $wt && docker compose start )"
+rm -f "$marker"
+exit 0

--- a/scripts/idle-stack-sweeper/freegle-stack-sweeper.service
+++ b/scripts/idle-stack-sweeper/freegle-stack-sweeper.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Freegle: stop idle worktree Docker Compose stacks to free RAM
+After=docker.service
+Wants=docker.service
+
+[Service]
+Type=oneshot
+User=edward
+Group=edward
+SupplementaryGroups=docker
+Environment=HOME=/home/edward
+ExecStart=/home/edward/.claude/freegle-stack-sweeper.sh

--- a/scripts/idle-stack-sweeper/freegle-stack-sweeper.sh
+++ b/scripts/idle-stack-sweeper/freegle-stack-sweeper.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Freegle idle-worktree stack sweeper.
+#
+# Stops the Docker Compose stack of any FreegleDocker *worktree* that has not
+# been worked on for FREEGLE_SWEEP_IDLE_SECS, to free RAM and stop the 62GB WSL
+# VM from filling up and OOM-rebooting. The MAIN repo stack is never touched.
+#
+# "Worked on" is measured only from signals a developer/Claude produces — git
+# bookkeeping (commit/stage/rebase/fetch) and the mtimes of files git considers
+# changed/untracked-not-ignored. Container-written churn (logs, .nuxt, caches)
+# is deliberately ignored, so a stack running an idle app still counts as idle.
+#
+# Run by the freegle-stack-sweeper.timer systemd timer (as user edward).
+# Env: FREEGLE_SWEEP_IDLE_SECS (default 3600), FREEGLE_SWEEP_DRYRUN=1 (log only).
+
+set -uo pipefail
+
+MAIN_REPO="/home/edward/FreegleDockerWSL"
+IDLE_SECS="${FREEGLE_SWEEP_IDLE_SECS:-3600}"
+DRYRUN="${FREEGLE_SWEEP_DRYRUN:-0}"
+LOG="${HOME:-/home/edward}/.claude/freegle-stack-sweeper.log"
+NOTICE_DIR="${HOME:-/home/edward}/.claude/stack-stopped"
+now="$(date +%s)"
+
+log() { printf '%s %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$*" >>"$LOG" 2>/dev/null; }
+
+# newest mtime (epoch) among the given paths that exist; 0 if none
+newest_mtime() {
+  local f t max=0
+  for f in "$@"; do
+    [ -e "$f" ] || continue
+    t="$(stat -c %Y "$f" 2>/dev/null)" || continue
+    (( t > max )) && max="$t"
+  done
+  printf '%s' "$max"
+}
+
+# epoch of the most recent developer/Claude activity in a worktree (0 if unknown)
+worktree_last_activity() {
+  local wt="$1" gitdir best t rel
+  gitdir="$(git --no-optional-locks -C "$wt" rev-parse --git-dir 2>/dev/null)" || { printf 0; return; }
+  case "$gitdir" in /*) ;; *) gitdir="$wt/$gitdir" ;; esac
+  # NB: deliberately NOT using .git/index — `git status` (ours or any editor/shell
+  # prompt) opportunistically rewrites it, which would make every worktree look
+  # freshly-active on the next sweep. Staging is covered by changed-file mtimes.
+  best="$(newest_mtime \
+    "$gitdir/HEAD" "$gitdir/ORIG_HEAD" \
+    "$gitdir/FETCH_HEAD" "$gitdir/logs/HEAD")"
+  # mtimes of changed + untracked-not-ignored files (real edits, not container junk).
+  # --no-optional-locks so this read never mutates the index.
+  while IFS= read -r rel; do
+    [ -n "$rel" ] || continue
+    t="$(stat -c %Y "$wt/$rel" 2>/dev/null)" || continue
+    (( t > best )) && best="$t"
+  done < <(
+    git --no-optional-locks -C "$wt" status --porcelain --no-renames 2>/dev/null \
+      | sed 's/^...//'
+  )
+  printf '%s' "$best"
+}
+
+stopped=0 considered=0
+while IFS= read -r wt; do
+  [ -n "$wt" ] || continue
+  [ "$wt" = "$MAIN_REPO" ] && continue            # never the main stack
+  [ -f "$wt/.env" ] || continue
+  proj="$(grep -E '^COMPOSE_PROJECT_NAME=' "$wt/.env" 2>/dev/null | cut -d= -f2)"
+  [ -n "$proj" ] || continue
+
+  ids="$(docker ps -q --filter "label=com.docker.compose.project=$proj" 2>/dev/null)"
+  [ -n "$ids" ] || continue                        # nothing running -> nothing to stop
+  running="$(printf '%s\n' "$ids" | grep -c .)"
+  considered=$((considered + 1))
+
+  last="$(worktree_last_activity "$wt")"
+  if [ "$last" -le 0 ] 2>/dev/null; then
+    log "SKIP $proj — activity unknown, leaving ${running} containers up"
+    continue
+  fi
+  idle=$((now - last))
+  if (( idle < IDLE_SECS )); then
+    continue                                       # active recently -> leave it
+  fi
+
+  if [ "$DRYRUN" = "1" ]; then
+    log "DRYRUN would STOP $proj ($wt) — idle ${idle}s >= ${IDLE_SECS}s, ${running} containers"
+  else
+    log "STOP $proj ($wt) — idle ${idle}s >= ${IDLE_SECS}s, ${running} containers"
+    if docker stop $ids >/dev/null 2>&1; then
+      log "STOPPED $proj OK (${running} containers)"
+      stopped=$((stopped + 1))
+      # Leave a marker so the Claude session bound to this worktree is told (via
+      # the UserPromptSubmit hook) that its containers were stopped — and can
+      # restart them if needed.
+      mkdir -p "$NOTICE_DIR" 2>/dev/null \
+        && printf 'Stopped %s by the idle-stack sweeper after ~%dh idle (%s containers).\n' \
+             "$(date '+%Y-%m-%d %H:%M:%S')" "$(( idle / 3600 ))" "$running" \
+             >"$NOTICE_DIR/$proj" 2>/dev/null
+    else
+      log "STOP $proj FAILED"
+    fi
+  fi
+done < <(git -C "$MAIN_REPO" worktree list --porcelain 2>/dev/null | awk '/^worktree /{print $2}')
+
+log "sweep done — considered ${considered} running worktree stack(s), stopped ${stopped} (idle>=${IDLE_SECS}s, dryrun=${DRYRUN})"

--- a/scripts/idle-stack-sweeper/freegle-stack-sweeper.timer
+++ b/scripts/idle-stack-sweeper/freegle-stack-sweeper.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Freegle idle worktree stack sweep (every 30 min)
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=30min
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/scripts/idle-stack-sweeper/install.sh
+++ b/scripts/idle-stack-sweeper/install.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Install the Freegle idle-worktree-stack sweeper on a WSL dev host.
+#
+# This is host tooling — it is NOT wired in automatically (a WSL rebuild loses
+# the installed copies under ~/.claude and /etc/systemd). Run this once after a
+# rebuild to restore it. Safe to re-run (idempotent). Needs sudo for the systemd
+# unit install + reload.
+#
+# See README.md for what it does and why.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEST="${HOME}/.claude"
+mkdir -p "$DEST"
+
+echo "==> Installing sweeper + notice hook into $DEST"
+install -m 0755 "$HERE/freegle-stack-sweeper.sh"     "$DEST/freegle-stack-sweeper.sh"
+install -m 0755 "$HERE/freegle-stack-notice-hook.sh" "$DEST/freegle-stack-notice-hook.sh"
+
+echo "==> Installing systemd system timer (needs sudo)"
+sudo install -m 0644 "$HERE/freegle-stack-sweeper.service" /etc/systemd/system/freegle-stack-sweeper.service
+sudo install -m 0644 "$HERE/freegle-stack-sweeper.timer"   /etc/systemd/system/freegle-stack-sweeper.timer
+sudo systemctl daemon-reload
+sudo systemctl enable --now freegle-stack-sweeper.timer
+systemctl list-timers freegle-stack-sweeper.timer --no-pager || true
+
+echo "==> Wiring the UserPromptSubmit notice hook into $DEST/settings.json"
+python3 - "$DEST/settings.json" "$DEST/freegle-stack-notice-hook.sh" <<'PY'
+import json, os, sys
+path, cmd = sys.argv[1], sys.argv[2]
+data = {}
+if os.path.exists(path):
+    with open(path) as f:
+        data = json.load(f)
+ups = data.setdefault("hooks", {}).setdefault("UserPromptSubmit", [])
+present = any(h.get("command") == cmd for e in ups for h in e.get("hooks", []))
+if present:
+    print("  hook already present")
+else:
+    ups.append({"matcher": "", "hooks": [{"type": "command", "command": cmd}]})
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2); f.write("\n")
+    print("  hook added")
+PY
+
+echo "==> Done."
+echo "    Idle worktree stacks (no dev/git activity for >60 min) are now stopped"
+echo "    every 30 min to free RAM. The main repo stack is never touched."
+echo "    Log: $DEST/freegle-stack-sweeper.log"

--- a/scripts/wsl/arm-wsl-capture.ps1
+++ b/scripts/wsl/arm-wsl-capture.ps1
@@ -1,0 +1,41 @@
+# Arms a Windows-side capture so the NEXT WSL VM teardown records its cause.
+# Must run ELEVATED. Reversible with disarm-wsl-capture.ps1.
+$ErrorActionPreference = 'Stop'
+$cap = 'C:\wsl-stop-capture'
+New-Item $cap -ItemType Directory -Force | Out-Null
+$log = "$cap\armed.txt"
+"=== Arming WSL stop-capture $(Get-Date) ===" | Out-File $log
+
+try {
+  # 1. Include full command line in process-creation (4688) events
+  $k = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\Audit'
+  if (-not (Test-Path $k)) { New-Item $k -Force | Out-Null }
+  New-ItemProperty $k -Name 'ProcessCreationIncludeCmdLine_Enabled' -PropertyType DWord -Value 1 -Force | Out-Null
+  "[ok] cmdline-in-4688 registry set" | Out-File $log -Append
+
+  # 2. Enable Audit Process Creation (success) so wsl.exe launches + parent get logged
+  & auditpol /set /subcategory:"Process Creation" /success:enable | Out-Null
+  "[ok] auditpol Process Creation success enabled" | Out-File $log -Append
+
+  # 3. Grow logs so records survive days until the next stop
+  & wevtutil sl Security /ms:268435456                                   # 256 MB
+  & wevtutil sl System   /ms:134217728                                   # 128 MB
+  & wevtutil sl Microsoft-Windows-Hyper-V-VmSwitch-Operational /ms:67108864  # 64 MB (teardown timing)
+  "[ok] grew Security/System/VmSwitch logs" | Out-File $log -Append
+
+  # 4. Enable Task Scheduler operational log (catch any task that calls wsl)
+  & wevtutil sl Microsoft-Windows-TaskScheduler/Operational /e:true /ms:33554432
+  "[ok] TaskScheduler/Operational enabled" | Out-File $log -Append
+
+  # ---- verification readback ----
+  "" | Out-File $log -Append
+  "--- VERIFY auditpol ---" | Out-File $log -Append
+  (& auditpol /get /subcategory:"Process Creation") | Out-File $log -Append
+  "--- VERIFY registry ---" | Out-File $log -Append
+  (Get-ItemProperty $k -Name 'ProcessCreationIncludeCmdLine_Enabled').ProcessCreationIncludeCmdLine_Enabled | Out-File $log -Append
+  "--- VERIFY log sizes ---" | Out-File $log -Append
+  & wevtutil gl Security | Select-String maxSize | Out-File $log -Append
+  "ARMED_OK" | Out-File $log -Append
+} catch {
+  "ARMED_FAIL: $_" | Out-File $log -Append
+}

--- a/scripts/wsl/diag-wsl-recent.ps1
+++ b/scripts/wsl/diag-wsl-recent.ps1
@@ -1,0 +1,49 @@
+# Deep-dive on the most recent (unexpected) WSL VM teardown: 2026-06-02 ~23:24:48, boot 23:35:55.
+# RUN ELEVATED. Writes full output to C:\Users\edwar\wsl-diag2-out.txt.
+$ErrorActionPreference = 'SilentlyContinue'
+$out = 'C:\Users\edwar\wsl-diag2-out.txt'
+Start-Transcript -Path $out -Force | Out-Null
+
+$tear = Get-Date '2026-06-02 23:24:48'
+Write-Output ("Probe window centered on teardown " + $tear + "    Generated: " + (Get-Date))
+
+Write-Output "`n================ [1] ALL process-creation (4688) 23:22:00 - 23:27:00 ================"
+$sec = Get-WinEvent -FilterHashtable @{LogName='Security'; Id=4688; StartTime=(Get-Date '2026-06-02 23:22:00'); EndTime=(Get-Date '2026-06-02 23:27:00')} 2>&1
+if ($sec -is [System.Management.Automation.ErrorRecord]) { Write-Output ("Security read failed: " + $sec.Exception.Message) }
+elseif (-not $sec) { Write-Output "0 process-creation events in window => teardown was INTERNAL (idle/memory), not a process/command." }
+else {
+  Write-Output ("Total 4688 in window: " + $sec.Count)
+  $sec | Sort-Object TimeCreated | ForEach-Object {
+    $x=[xml]$_.ToXml()
+    $np=($x.Event.EventData.Data | Where-Object {$_.Name -eq 'NewProcessName'}).'#text'
+    $pp=($x.Event.EventData.Data | Where-Object {$_.Name -eq 'ParentProcessName'}).'#text'
+    $cl=($x.Event.EventData.Data | Where-Object {$_.Name -eq 'CommandLine'}).'#text'
+    Write-Output ("{0}  NEW={1}  PARENT={2}  CMD={3}" -f $_.TimeCreated,$np,$pp,$cl)
+  }
+}
+
+Write-Output "`n================ [2] MEMORY EXHAUSTION (Resource-Exhaustion-Detector, last 4 days) ================"
+Write-Output "Event 2004 = Windows critically low on memory; its message names the top RAM consumers (look for vmmem)."
+$re = Get-WinEvent -FilterHashtable @{LogName='System'; ProviderName='Microsoft-Windows-Resource-Exhaustion-Detector'; StartTime=(Get-Date).AddDays(-4)} -MaxEvents 10
+if (-not $re) { Write-Output "NONE - no memory-exhaustion events (so the host did not hit a hard commit limit)." }
+else { $re | Sort-Object TimeCreated | ForEach-Object { Write-Output ("---- " + $_.TimeCreated + "  Id=" + $_.Id + " ----"); Write-Output ($_.Message) } }
+
+Write-Output "`n================ [3] Hyper-V-Worker VM lifecycle 23:18 - 23:36 ================"
+foreach ($ln in 'Microsoft-Windows-Hyper-V-Worker-Admin','Microsoft-Windows-Hyper-V-Worker-Operational','Microsoft-Windows-Hyper-V-Compute-Operational','Microsoft-Windows-Hyper-V-Compute-Admin') {
+  $ev = Get-WinEvent -FilterHashtable @{LogName=$ln; StartTime=(Get-Date '2026-06-02 23:18:00'); EndTime=(Get-Date '2026-06-02 23:36:30')}
+  if ($ev) {
+    Write-Output ("--- " + $ln + " ---")
+    $ev | Sort-Object TimeCreated | Select-Object TimeCreated, Id, @{n='Msg';e={($_.Message -replace "`r`n",' ')}} | Format-Table -Auto -Wrap
+  }
+}
+
+Write-Output "`n================ [4] System log 23:22 - 23:30 (full provider list) ================"
+Get-WinEvent -FilterHashtable @{LogName='System'; StartTime=(Get-Date '2026-06-02 23:22:00'); EndTime=(Get-Date '2026-06-02 23:30:00')} |
+  Sort-Object TimeCreated | Select-Object TimeCreated, Id, ProviderName, @{n='Msg';e={($_.Message -replace "`r`n",' ').Substring(0,[Math]::Min(120,($_.Message -replace "`r`n",' ').Length))}} |
+  Format-Table -Auto -Wrap
+
+Write-Output "`n================ [5] .wslconfig (idle-timeout / memory cap?) ================"
+$wc = "$env:USERPROFILE\.wslconfig"; if (Test-Path $wc) { Get-Content $wc } else { Write-Output "no .wslconfig" }
+
+Stop-Transcript | Out-Null
+Write-Output ("Wrote full output to " + $out)

--- a/scripts/wsl/diag-wsl-restart.ps1
+++ b/scripts/wsl/diag-wsl-restart.ps1
@@ -1,0 +1,68 @@
+# Diagnose recent WSL VM teardowns/restarts and find what caused them.
+# RUN ELEVATED (Administrator). Writes full output to C:\Users\edwar\wsl-diag-out.txt.
+$ErrorActionPreference = 'SilentlyContinue'
+$out = 'C:\Users\edwar\wsl-diag-out.txt'
+Start-Transcript -Path $out -Force | Out-Null
+
+$id = [System.Security.Principal.WindowsIdentity]::GetCurrent()
+$pr = New-Object System.Security.Principal.WindowsPrincipal($id)
+$elev = $pr.IsInRole([System.Security.Principal.WindowsBuiltInRole]::Administrator)
+Write-Output ("Elevated (admin): " + $elev + "   Generated: " + (Get-Date))
+if (-not $elev) { Write-Output "*** NOT ELEVATED - 4688 section will be empty. Re-run as Administrator. ***" }
+
+Write-Output "`n================ Armed state ================"
+if (Test-Path 'C:\wsl-stop-capture\armed.txt') { Get-Content 'C:\wsl-stop-capture\armed.txt' | Select-Object -Last 2 }
+
+Write-Output "`n================ Host crash check (Kernel-Power 41 / 6008, last 7 days) ================"
+$c = Get-WinEvent -FilterHashtable @{LogName='System'; Id=41,6008; StartTime=(Get-Date).AddDays(-7)} -MaxEvents 10
+if ($c) { $c | Select-Object TimeCreated, Id, ProviderName | Format-Table -Auto } else { Write-Output "NONE - no host crash in last 7 days." }
+
+# --- Teardowns: filter by StartTime (NOT MaxEvents) so we don't miss older Deletes ---
+Write-Output "`n================ WSL VM teardowns (VmSwitch 'Delete succeeded', last 7 days) ================"
+$tds = Get-WinEvent -FilterHashtable @{LogName='Microsoft-Windows-Hyper-V-VmSwitch-Operational'; Id=233; StartTime=(Get-Date).AddDays(-7)} |
+       Where-Object { $_.Message -match "'Delete' succeeded" } | Sort-Object TimeCreated -Descending
+if (-not $tds) { Write-Output "No 'Delete succeeded' teardown events found in last 7 days." }
+else { $tds | Select-Object -First 12 | Select-Object TimeCreated, @{n='Nic';e={ if ($_.Message -match 'on nic ([0-9A-F-]+)') { $matches[1].Substring(0,13) } }} | Format-Table -Auto }
+
+# --- For the most recent teardown, dump 4688 process-creation in a +/-3 min window ---
+$t = if ($tds) { $tds[0].TimeCreated } else { (Get-Date).AddMinutes(-3) }
+Write-Output ("`n================ Process-creation (4688) around most recent teardown: " + $t + " ================")
+$start = $t.AddMinutes(-3); $end = $t.AddMinutes(3)
+$sec = Get-WinEvent -FilterHashtable @{LogName='Security'; Id=4688; StartTime=$start; EndTime=$end} 2>&1
+if ($sec -is [System.Management.Automation.ErrorRecord]) { Write-Output ("Security read failed: " + $sec.Exception.Message) }
+elseif (-not $sec) { Write-Output "0 process-creation events in window (teardown was internal/idle with no process spawn, OR not elevated)." }
+else {
+  Write-Output ("Total 4688 in +/-3min window: " + $sec.Count)
+  $rel = $sec | Sort-Object TimeCreated | Where-Object {
+    $x=[xml]$_.ToXml()
+    $np=($x.Event.EventData.Data | Where-Object {$_.Name -eq 'NewProcessName'}).'#text'
+    $cl=($x.Event.EventData.Data | Where-Object {$_.Name -eq 'CommandLine'}).'#text'
+    ($np -match 'wsl|vmcompute|vmwp|hcs|vmmem|LxssManager|conhost|cmd\.exe|powershell|pwsh|WindowsTerminal|Code') -or ($cl -match 'wsl|--shutdown|--terminate')
+  }
+  if (-not $rel) { Write-Output "(no wsl/vm/shell-related process creations in window)" }
+  $rel | ForEach-Object {
+    $x=[xml]$_.ToXml()
+    $np=($x.Event.EventData.Data | Where-Object {$_.Name -eq 'NewProcessName'}).'#text'
+    $pp=($x.Event.EventData.Data | Where-Object {$_.Name -eq 'ParentProcessName'}).'#text'
+    $cl=($x.Event.EventData.Data | Where-Object {$_.Name -eq 'CommandLine'}).'#text'
+    Write-Output ("{0}  NEW={1}  PARENT={2}  CMD={3}" -f $_.TimeCreated,$np,$pp,$cl)
+  }
+}
+
+# --- Broad sweep: any wsl --shutdown / --terminate command in the last 7 days (since arming) ---
+Write-Output "`n================ Any 'wsl --shutdown/--terminate' command, last 7 days (this names the culprit) ================"
+$sd = Get-WinEvent -FilterHashtable @{LogName='Security'; Id=4688; StartTime=(Get-Date).AddDays(-7)} 2>&1
+if ($sd -is [System.Management.Automation.ErrorRecord]) { Write-Output ("Security read failed: " + $sd.Exception.Message) }
+elseif (-not $sd) { Write-Output "0 events (not elevated, or log empty)." }
+else {
+  $hit = $sd | Where-Object { $_.Message -match 'shutdown|terminate' -and $_.Message -match 'wsl' }
+  if (-not $hit) { Write-Output "No 'wsl --shutdown/--terminate' command found in 4688 in last 7 days." }
+  $hit | Sort-Object TimeCreated | ForEach-Object {
+    $x=[xml]$_.ToXml()
+    $pp=($x.Event.EventData.Data | Where-Object {$_.Name -eq 'ParentProcessName'}).'#text'
+    $cl=($x.Event.EventData.Data | Where-Object {$_.Name -eq 'CommandLine'}).'#text'
+    Write-Output ("{0}  PARENT={1}  CMD={2}" -f $_.TimeCreated,$pp,$cl)
+  }
+}
+Stop-Transcript | Out-Null
+Write-Output ("Wrote full output to " + $out)

--- a/scripts/wsl/diag-wsl-stop.ps1
+++ b/scripts/wsl/diag-wsl-stop.ps1
@@ -1,0 +1,35 @@
+$ErrorActionPreference = 'SilentlyContinue'
+$start = (Get-Date '2026-06-01 07:30:00')
+$end   = (Get-Date '2026-06-01 07:50:00')
+
+Write-Output "================ AUDIT STATE ================"
+& auditpol /get /subcategory:"Process Creation"
+$k = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\Audit'
+Write-Output ("ProcessCreationIncludeCmdLine = " + (Get-ItemProperty $k -Name 'ProcessCreationIncludeCmdLine_Enabled' -ErrorAction SilentlyContinue).ProcessCreationIncludeCmdLine_Enabled)
+Write-Output "armed.txt exists = $(Test-Path 'C:\wsl-stop-capture\armed.txt')"
+
+Write-Output "`n================ HOST CRASH CHECK (Kernel-Power 41 / 6008 last 3 days) ================"
+Get-WinEvent -FilterHashtable @{LogName='System'; Id=41,6008; StartTime=(Get-Date).AddDays(-3)} -MaxEvents 10 |
+  Select-Object TimeCreated, Id, ProviderName | Format-Table -Auto
+
+Write-Output "`n================ VmSwitch teardown (Hyper-V-VmSwitch around 07:30-07:50) ================"
+Get-WinEvent -FilterHashtable @{LogName='Microsoft-Windows-Hyper-V-VmSwitch-Operational'; StartTime=$start; EndTime=$end} |
+  Sort-Object TimeCreated | Select-Object TimeCreated, Id, @{n='Msg';e={$_.Message -replace "`r`n",' ' }} | Format-List
+
+Write-Output "`n================ Security 4688 mentioning wsl/vmcompute/wslservice (07:30-07:50) ================"
+Get-WinEvent -FilterHashtable @{LogName='Security'; Id=4688; StartTime=$start; EndTime=$end} |
+  Where-Object { $_.Message -match 'wsl|vmcompute|vmwp|LxssManager|hcs' } |
+  Sort-Object TimeCreated |
+  ForEach-Object {
+    $x = [xml]$_.ToXml()
+    $newproc = ($x.Event.EventData.Data | Where-Object {$_.Name -eq 'NewProcessName'}).'#text'
+    $parent  = ($x.Event.EventData.Data | Where-Object {$_.Name -eq 'ParentProcessName'}).'#text'
+    $cmd     = ($x.Event.EventData.Data | Where-Object {$_.Name -eq 'CommandLine'}).'#text'
+    Write-Output ("{0}  NEW={1}  PARENT={2}  CMD={3}" -f $_.TimeCreated, $newproc, $parent, $cmd)
+  }
+
+Write-Output "`n================ System log around teardown (07:30-07:50) ================"
+Get-WinEvent -FilterHashtable @{LogName='System'; StartTime=$start; EndTime=$end} |
+  Sort-Object TimeCreated |
+  Select-Object TimeCreated, Id, ProviderName, @{n='Msg';e={($_.Message -replace "`r`n",' ').Substring(0,[Math]::Min(140,($_.Message -replace "`r`n",' ').Length))}} |
+  Format-Table -Auto -Wrap

--- a/scripts/wsl/disarm-wsl-capture.ps1
+++ b/scripts/wsl/disarm-wsl-capture.ps1
@@ -1,0 +1,10 @@
+# Reverts everything arm-wsl-capture.ps1 did. Run ELEVATED.
+$ErrorActionPreference = 'Continue'
+$k = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\Audit'
+Remove-ItemProperty $k -Name 'ProcessCreationIncludeCmdLine_Enabled' -ErrorAction SilentlyContinue
+& auditpol /set /subcategory:"Process Creation" /success:disable | Out-Null
+# Restore default-ish log sizes
+& wevtutil sl Security /ms:20971520
+& wevtutil sl System   /ms:20971520
+& wevtutil sl Microsoft-Windows-Hyper-V-VmSwitch-Operational /ms:1052672
+"Disarmed $(Get-Date)" | Write-Output


### PR DESCRIPTION
## Why
On this dev host several worktree Docker Compose stacks run in parallel. When enough pile up, the WSL2 VM (capped at ~50% of host RAM) fills, the Linux global OOM killer fires inside the guest, kills a process in the WSL session cgroup (`/init.scope`), and **the whole VM reboots** — losing in-flight work. See `finding_wsl_stops_host_bugcheck` in project memory. Raising the RAM cap / adding an OOM killer just treats the symptom; the real problem is idle stacks accumulating.

## What
**`scripts/idle-stack-sweeper/`** — a systemd **system** timer (every 30 min) that `docker stop`s any worktree stack with no developer/git activity for >60 min. Never touches the main repo stack. Notifies the bound Claude session (UserPromptSubmit hook) that it stopped the stack, with the restart command. Activity is measured from git bookkeeping + changed-file mtimes (not `.git/index`, which `git status` rewrites), ignoring container churn.

Host tooling — not wired in automatically. Install/re-install (e.g. after a WSL rebuild):
```
scripts/idle-stack-sweeper/install.sh
```

**`scripts/wsl/*-wsl-*.ps1`** — the Windows-side WSL-stability diagnostic/capture scripts used to investigate the recurring restarts; previously only on the host, so a rebuild would lose them.

## Notes
- This is dev-host tooling; nothing in the running app changes.
- The `.service` unit hardcodes `User=edward` / `/home/edward`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)