### PR TITLE
fix(membership): restore V1 Manual/Auto join-method parity in Go API + ModTools

### DIFF
--- a/iznik-nuxt3/modtools/components/ModSupportUser.vue
+++ b/iznik-nuxt3/modtools/components/ModSupportUser.vue
@@ -365,6 +365,12 @@
               timeago(membershiphistory.timestamp || membershiphistory.added)
             }}
           </span>
+          <span
+            v-if="membershiphistory.type === 'Joined' && membershiphistory.text"
+            class="text-muted small ms-1 join-method"
+          >
+            ({{ membershiphistory.text }})
+          </span>
         </div>
         <b-button
           v-if="!showAllMembershipHistories && membershipHistoriesUnshown"

--- a/iznik-nuxt3/tests/unit/components/modtools/ModSupportUser.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModSupportUser.spec.js
@@ -718,4 +718,66 @@ describe('ModSupportUser', () => {
       })
     })
   })
+
+  describe('join-method display', () => {
+    it('shows join-method text in parentheses for a Manual Joined entry', async () => {
+      mockApiFns.fetchMembershipHistory.mockResolvedValueOnce([
+        {
+          type: 'Joined',
+          nameshort: 'TestGroup',
+          timestamp: new Date().toISOString(),
+          text: 'Manual',
+        },
+      ])
+      const wrapper = await mountComponent({ expand: true })
+      await flushPromises()
+      const joinMethod = wrapper.find('.join-method')
+      expect(joinMethod.exists()).toBe(true)
+      expect(joinMethod.text()).toContain('Manual')
+    })
+
+    it('shows join-method text in parentheses for an Auto Joined entry', async () => {
+      mockApiFns.fetchMembershipHistory.mockResolvedValueOnce([
+        {
+          type: 'Joined',
+          nameshort: 'TestGroup',
+          timestamp: new Date().toISOString(),
+          text: 'Auto',
+        },
+      ])
+      const wrapper = await mountComponent({ expand: true })
+      await flushPromises()
+      const joinMethod = wrapper.find('.join-method')
+      expect(joinMethod.exists()).toBe(true)
+      expect(joinMethod.text()).toContain('Auto')
+    })
+
+    it('does not show join-method span when text is empty', async () => {
+      mockApiFns.fetchMembershipHistory.mockResolvedValueOnce([
+        {
+          type: 'Joined',
+          nameshort: 'TestGroup',
+          timestamp: new Date().toISOString(),
+          text: '',
+        },
+      ])
+      const wrapper = await mountComponent({ expand: true })
+      await flushPromises()
+      expect(wrapper.find('.join-method').exists()).toBe(false)
+    })
+
+    it('does not show join-method span for non-Joined entry', async () => {
+      mockApiFns.fetchMembershipHistory.mockResolvedValueOnce([
+        {
+          type: 'Left',
+          nameshort: 'TestGroup',
+          timestamp: new Date().toISOString(),
+          text: 'Manual',
+        },
+      ])
+      const wrapper = await mountComponent({ expand: true })
+      await flushPromises()
+      expect(wrapper.find('.join-method').exists()).toBe(false)
+    })
+  })
 })

--- a/iznik-server-go/membership/membership.go
+++ b/iznik-server-go/membership/membership.go
@@ -1121,7 +1121,7 @@ func PutMemberships(c *fiber.Ctx) error {
 		}
 	}
 
-	return addMemberToGroup(c, db, userid, req.Groupid, myid)
+	return addMemberToGroup(c, db, userid, req.Groupid, myid, req.Manual)
 }
 
 // putMembershipsPartner handles the partner auth path for PUT /memberships.
@@ -1198,7 +1198,8 @@ func putMembershipsPartner(c *fiber.Ctx, db *gorm.DB, partnerKey string) error {
 }
 
 // addMemberToGroup is the shared logic for adding a user to a group (JWT auth paths).
-func addMemberToGroup(c *fiber.Ctx, db *gorm.DB, userid uint64, groupid uint64, byuser uint64) error {
+// manual mirrors V1 User::addMembership: true→"Manual", false→"Auto", nil→"".
+func addMemberToGroup(c *fiber.Ctx, db *gorm.DB, userid uint64, groupid uint64, byuser uint64, manual *bool) error {
 	// Check the group exists.
 	var groupExists int64
 	db.Raw("SELECT COUNT(*) FROM `groups` WHERE id = ?", groupid).Scan(&groupExists)
@@ -1234,7 +1235,18 @@ func addMemberToGroup(c *fiber.Ctx, db *gorm.DB, userid uint64, groupid uint64, 
 		db.Exec("INSERT INTO memberships_history (userid, groupid, collection, processingrequired) VALUES (?, ?, ?, 1)",
 			userid, groupid, utils.COLLECTION_APPROVED)
 
-		logMembershipAction(log.LOG_TYPE_GROUP, log.LOG_SUBTYPE_JOINED, groupid, userid, byuser, "")
+		// V1 parity (User.php:944-957): log text records how the user joined.
+		// manual=true→"Manual" (clicked Join button), false→"Auto" (auto-joined
+		// to reply/post), nil→"" (method not specified).
+		joinText := ""
+		if manual != nil {
+			if *manual {
+				joinText = "Manual"
+			} else {
+				joinText = "Auto"
+			}
+		}
+		logMembershipAction(log.LOG_TYPE_GROUP, log.LOG_SUBTYPE_JOINED, groupid, userid, byuser, joinText)
 	}
 
 	return c.JSON(fiber.Map{"ret": 0, "status": "Success", "addedto": utils.COLLECTION_APPROVED})

--- a/iznik-server-go/test/membership_joinmethod_test.go
+++ b/iznik-server-go/test/membership_joinmethod_test.go
@@ -1,0 +1,171 @@
+package test
+
+// TestJoinMethod* — V1→V2 parity for the membership join-method field.
+//
+// V1 (User.php:944-957): User::addMembership writes the Group/Joined log's
+// text = 'Manual' (manual truthy), 'Auto' (manual === false), or '' (null).
+// V2 was discarding the manual field from PutMembershipsRequest and hard-coding
+// the Joined-log text to "". Additionally GetUserMembershipHistory was not
+// returning l.text so even existing text was invisible to ModTools.
+//
+// These tests pin the corrected behaviour: text must flow end-to-end from the
+// PUT /memberships request body → logs.text → GET /user/:id/membershiphistory response.
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestJoinMethodManual verifies that manual=true records 'Manual' in logs.text.
+func TestJoinMethodManual(t *testing.T) {
+	prefix := uniquePrefix("jm_manual")
+	db := database.DBConn
+
+	userID := CreateTestUser(t, prefix+"_user", "User")
+	_, token := CreateTestSession(t, userID)
+	groupID := CreateTestGroup(t, prefix)
+
+	// self-join with manual=true
+	manualTrue := true
+	body := map[string]interface{}{
+		"groupid": groupID,
+		"manual":  manualTrue,
+	}
+	bodyBytes, _ := json.Marshal(body)
+	url := fmt.Sprintf("/api/memberships?jwt=%s", token)
+	req := httptest.NewRequest("PUT", url, bytes.NewBuffer(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := getApp().Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	// Verify the Joined log has text='Manual'
+	var logText string
+	db.Raw("SELECT COALESCE(text,'') FROM logs WHERE type='Group' AND subtype='Joined' AND user=? AND groupid=? ORDER BY id DESC LIMIT 1",
+		userID, groupID).Scan(&logText)
+	assert.Equal(t, "Manual", logText, "manual=true join must record text='Manual' in the Joined log")
+}
+
+// TestJoinMethodAuto verifies that manual=false records 'Auto' in logs.text.
+func TestJoinMethodAuto(t *testing.T) {
+	prefix := uniquePrefix("jm_auto")
+	db := database.DBConn
+
+	userID := CreateTestUser(t, prefix+"_user", "User")
+	_, token := CreateTestSession(t, userID)
+	groupID := CreateTestGroup(t, prefix)
+
+	// self-join with manual=false
+	manualFalse := false
+	body := map[string]interface{}{
+		"groupid": groupID,
+		"manual":  manualFalse,
+	}
+	bodyBytes, _ := json.Marshal(body)
+	url := fmt.Sprintf("/api/memberships?jwt=%s", token)
+	req := httptest.NewRequest("PUT", url, bytes.NewBuffer(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := getApp().Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	// Verify the Joined log has text='Auto'
+	var logText string
+	db.Raw("SELECT COALESCE(text,'') FROM logs WHERE type='Group' AND subtype='Joined' AND user=? AND groupid=? ORDER BY id DESC LIMIT 1",
+		userID, groupID).Scan(&logText)
+	assert.Equal(t, "Auto", logText, "manual=false join must record text='Auto' in the Joined log")
+}
+
+// TestJoinMethodOmitted verifies that omitting manual records '' (empty) in logs.text.
+func TestJoinMethodOmitted(t *testing.T) {
+	prefix := uniquePrefix("jm_omit")
+	db := database.DBConn
+
+	userID := CreateTestUser(t, prefix+"_user", "User")
+	_, token := CreateTestSession(t, userID)
+	groupID := CreateTestGroup(t, prefix)
+
+	// self-join without manual field
+	body := map[string]interface{}{
+		"groupid": groupID,
+	}
+	bodyBytes, _ := json.Marshal(body)
+	url := fmt.Sprintf("/api/memberships?jwt=%s", token)
+	req := httptest.NewRequest("PUT", url, bytes.NewBuffer(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := getApp().Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	// Verify the Joined log has text='' (empty / NULL)
+	var logText string
+	db.Raw("SELECT COALESCE(text,'') FROM logs WHERE type='Group' AND subtype='Joined' AND user=? AND groupid=? ORDER BY id DESC LIMIT 1",
+		userID, groupID).Scan(&logText)
+	assert.Equal(t, "", logText, "omitting manual must record empty text in the Joined log")
+}
+
+// TestJoinMethodHistoryReturnsText verifies that GET /user/:id/membershiphistory
+// returns the text field (join-method) in each row.
+func TestJoinMethodHistoryReturnsText(t *testing.T) {
+	prefix := uniquePrefix("jm_hist")
+	db := database.DBConn
+
+	// Create a mod who can view membership history.
+	modID := CreateTestUser(t, prefix+"_mod", "User")
+	groupID := CreateTestGroup(t, prefix)
+	CreateTestMembership(t, modID, groupID, "Moderator")
+	_, modToken := CreateTestSession(t, modID)
+
+	// Create target user and join with manual=true.
+	memberID := CreateTestUser(t, prefix+"_member", "User")
+	_, memberToken := CreateTestSession(t, memberID)
+
+	manualTrue := true
+	body := map[string]interface{}{
+		"groupid": groupID,
+		"manual":  manualTrue,
+	}
+	bodyBytes, _ := json.Marshal(body)
+	putURL := fmt.Sprintf("/api/memberships?jwt=%s", memberToken)
+	putReq := httptest.NewRequest("PUT", putURL, bytes.NewBuffer(bodyBytes))
+	putReq.Header.Set("Content-Type", "application/json")
+	putResp, err := getApp().Test(putReq)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, putResp.StatusCode)
+
+	// Confirm the log was written with text='Manual'.
+	var logText string
+	db.Raw("SELECT COALESCE(text,'') FROM logs WHERE type='Group' AND subtype='Joined' AND user=? AND groupid=? ORDER BY id DESC LIMIT 1",
+		memberID, groupID).Scan(&logText)
+	assert.Equal(t, "Manual", logText, "prerequisite: log must have text='Manual'")
+
+	// GET /user/:id/membershiphistory as the mod.
+	histURL := fmt.Sprintf("/api/user/%d/membershiphistory?jwt=%s", memberID, modToken)
+	histReq := httptest.NewRequest("GET", histURL, nil)
+	histResp, err := getApp().Test(histReq)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, histResp.StatusCode)
+
+	var history []map[string]interface{}
+	json.NewDecoder(histResp.Body).Decode(&history)
+	assert.GreaterOrEqual(t, len(history), 1, "history must contain at least one entry")
+
+	// Find the Joined entry and assert it has text='Manual'.
+	found := false
+	for _, row := range history {
+		if rowType, ok := row["type"].(string); ok && rowType == "Joined" {
+			found = true
+			textVal, hasText := row["text"]
+			assert.True(t, hasText, "membershiphistory rows must include a 'text' field")
+			assert.Equal(t, "Manual", textVal, "Joined entry text must be 'Manual' for a manual join")
+			break
+		}
+	}
+	assert.True(t, found, "history must contain a Joined entry")
+}

--- a/iznik-server-go/user/user.go
+++ b/iznik-server-go/user/user.go
@@ -3047,11 +3047,13 @@ func GetUserMembershipHistory(c *fiber.Ctx) error {
 		Nameshort   string     `json:"nameshort"`
 		Namefull    string     `json:"namefull"`
 		Namedisplay string     `json:"namedisplay" gorm:"column:namedisplay"`
+		Text        string     `json:"text"`
 	}
 
 	var history []MembershipHistoryRow
 	db.Raw("SELECT l.timestamp, l.subtype AS type, l.groupid, "+
-		"g.nameshort, COALESCE(g.namefull, '') AS namefull, COALESCE(g.namefull, g.nameshort) AS namedisplay "+
+		"g.nameshort, COALESCE(g.namefull, '') AS namefull, COALESCE(g.namefull, g.nameshort) AS namedisplay, "+
+		"COALESCE(l.text,'') AS text "+
 		"FROM logs l "+
 		"INNER JOIN `groups` g ON g.id = l.groupid "+
 		"WHERE l.user = ? AND l.type = 'Group' "+


### PR DESCRIPTION
## Problem

V1 (`iznik-server`) recorded how a user joined a group in the `Group/Joined` log's `text` field:
- `'Manual'` — user clicked the Join button
- `'Auto'` — auto-joined in order to reply/post
- `''` (empty) — method not specified

V1 also exposed this via `getMembershipHistory()` → `text` → ModTools, so moderators could see the join method.

V2 had two gaps:

1. **Not recorded**: `PutMembershipsRequest` has `Manual *bool json:"manual"` and `PutMemberships` parses it, but the call `addMemberToGroup(c, db, userid, req.Groupid, myid)` dropped the field. `addMemberToGroup` always logged `text=""`.

2. **Not surfaced**: `GetUserMembershipHistory` did not `SELECT l.text`, so even pre-existing text (e.g. `"via partner"`) was invisible to ModTools.

## Fix

### `iznik-server-go/membership/membership.go`
- `addMemberToGroup` gains a `manual *bool` parameter (last param)
- Computes join text: `nil→""`, `true→"Manual"`, `false→"Auto"`
- `PutMemberships` passes `req.Manual`; the one other call site (partner path) uses its own `logMembershipAction` call directly — unchanged
- All other callers pass `nil` (no behaviour change)

### `iznik-server-go/user/user.go`
- `MembershipHistoryRow` gains `Text string \`json:"text"\``
- SQL adds `COALESCE(l.text,'') AS text` — field is always present in the API response

### `iznik-nuxt3/modtools/components/ModSupportUser.vue`
- Full History entries show join-method in parentheses: `(Manual)` / `(Auto)` / other text
- Gated on `type === 'Joined' && text` — only shown when non-empty, only for Joined entries

## Tests

**Go (TDD — wrote tests first, confirmed failing, then implemented):**
- `TestJoinMethodManual` — `manual=true` → `logs.text = 'Manual'`
- `TestJoinMethodAuto` — `manual=false` → `logs.text = 'Auto'`
- `TestJoinMethodOmitted` — `manual` omitted → `logs.text = ''`
- `TestJoinMethodHistoryReturnsText` — GET `/user/:id/membershiphistory` returns `text='Manual'` for a manual join

Full Go suite: **3008 ✓ 0 ✗**

**Vitest (4 new tests in `ModSupportUser.spec.js`):**
- Manual Joined entry shows `.join-method` span containing `'Manual'`
- Auto Joined entry shows `.join-method` span containing `'Auto'`
- Empty text → span does not render
- Non-Joined type → span does not render even if text is set

Full Vitest suite (ModSupportUser): **48 ✓ 0 ✗**

## V1 References

- `http/api/memberships.php:257` — reads `manual` from request
- `include/user/User.php:944-957` — `addMembership` writes log text
- `include/user/User.php:4193` — `getMembershipHistory` returns `text`