### PR TITLE
fix(chitchat): widen the "..." menu gap so it clears post text (#9749)

### DIFF
--- a/iznik-nuxt3/components/NewsThread.vue
+++ b/iznik-nuxt3/components/NewsThread.vue
@@ -667,9 +667,12 @@ async function unmute() {
 }
 
 .thread-menu {
-  /* The "..." menu is floated to the end; give it space so it does not sit
-     right up against the post text (Discourse #9749 - chitchat niggle). */
-  margin-left: 0.5rem;
+  /* The "..." menu is floated to the end; the post text wraps beside it on the
+     first line (and reclaims full width below, so no space is wasted). Give it a
+     clear gap so it does not sit right up against the text — 0.5rem (the first
+     attempt) was too small on inline name+body replies at narrow/iPad widths
+     (Discourse #9749 - chitchat niggle). */
+  margin-left: 1.5rem;
 }
 
 :deep(.strike) {


### PR DESCRIPTION
## Problem
Reported in Discourse #9749 (still jarring per the reporter on Safari/iPad today). The thread "..." options menu floats right; on posts/replies where the **name and body render inline** (e.g. `Muso What I usually do is arrange collection ⋯`), the body's first line wraps right up to the menu, so the "⋯" reads as part of the sentence.

The first attempt (#612) added `.thread-menu { margin-left: 0.5rem }`, but 8px is too small to separate it on those inline replies at narrow / iPad widths.

## Root cause / why padding didn't work
The `.dropdown-toggle` is **fixed-width + `box-sizing: border-box`**, so increasing its `padding-left` just squeezes the icon inside the box — it does **not** move the box edge where text stops. The correct lever is the **float's `margin-left`**, which pushes the wrapping text away from the menu.

## Fix
Bump `.thread-menu { margin-left }` from `0.5rem` to `1.5rem`. Keeping the `float` is deliberate: text still **reclaims full width on the lines below** the menu (no wasted right-hand gutter — a flex column or absolute+padding would waste that space); only the single line beside the menu is shortened.

## Verification
Verified against **live ChitChat data** at a Safari/iPad-width viewport (client-side, before/after): with `1.5rem` the "⋯" sits clearly clear of the wrapping reply text instead of jammed against it. CSS-only change.