### PR TITLE
fix(session): accept integer/string marketingconsent in PATCH /session (FlexBool)

### DIFF
--- a/iznik-server-go/session/session.go
+++ b/iznik-server-go/session/session.go
@@ -1544,7 +1544,7 @@ func PatchSession(c *fiber.Ctx) error {
 		Email              *string             `json:"email,omitempty"`
 		Source             *string             `json:"source,omitempty"`
 		Deleted            json.RawMessage     `json:"deleted,omitempty"`
-		Marketingconsent   *bool               `json:"marketingconsent,omitempty"`
+		Marketingconsent   *FlexBool           `json:"marketingconsent,omitempty"`
 		Key                *string             `json:"key,omitempty"`
 		Modtools           FlexBool            `json:"modtools,omitempty"`
 	}
@@ -1684,7 +1684,7 @@ func PatchSession(c *fiber.Ctx) error {
 
 	if req.Marketingconsent != nil {
 		mc := 0
-		if *req.Marketingconsent {
+		if req.Marketingconsent.Bool() {
 			mc = 1
 		}
 		setClauses = append(setClauses, "marketingconsent = ?")

--- a/iznik-server-go/test/session_patch_flexint_test.go
+++ b/iznik-server-go/test/session_patch_flexint_test.go
@@ -251,6 +251,63 @@ func TestPatchSessionMarketingconsentFalse(t *testing.T) {
 	assert.Equal(t, 0, val)
 }
 
+// marketingconsent sent as a JSON integer (1/0). The micro-volunteering
+// "accept invite" flow hardcodes `marketingconsent: 1`, which a plain *bool
+// could not unmarshal — the whole PATCH was rejected with a 400 and consent
+// was never recorded (Discourse/Loki: 285 such requests, all failing).
+// FlexBool must accept the integer form.
+func TestPatchSessionMarketingconsentNumberOne(t *testing.T) {
+	prefix := uniquePrefix("sess_mknum1")
+	userID := CreateTestUser(t, prefix, "User")
+	_, token := CreateTestSession(t, userID)
+
+	result := patchSession(t, token, map[string]interface{}{
+		"marketingconsent": 1,
+	})
+	assert.Equal(t, float64(0), result["ret"])
+
+	db := database.DBConn
+	var val int
+	db.Raw("SELECT marketingconsent FROM users WHERE id = ?", userID).Scan(&val)
+	assert.Equal(t, 1, val)
+}
+
+func TestPatchSessionMarketingconsentNumberZero(t *testing.T) {
+	prefix := uniquePrefix("sess_mknum0")
+	userID := CreateTestUser(t, prefix, "User")
+	_, token := CreateTestSession(t, userID)
+
+	// Set to true first, then clear via numeric 0.
+	patchSession(t, token, map[string]interface{}{"marketingconsent": true})
+
+	result := patchSession(t, token, map[string]interface{}{
+		"marketingconsent": 0,
+	})
+	assert.Equal(t, float64(0), result["ret"])
+
+	db := database.DBConn
+	var val int
+	db.Raw("SELECT marketingconsent FROM users WHERE id = ?", userID).Scan(&val)
+	assert.Equal(t, 0, val)
+}
+
+// marketingconsent sent as a string ("1") — HTML form / select robustness.
+func TestPatchSessionMarketingconsentStringOne(t *testing.T) {
+	prefix := uniquePrefix("sess_mkstr1")
+	userID := CreateTestUser(t, prefix, "User")
+	_, token := CreateTestSession(t, userID)
+
+	result := patchSession(t, token, map[string]interface{}{
+		"marketingconsent": "1",
+	})
+	assert.Equal(t, float64(0), result["ret"])
+
+	db := database.DBConn
+	var val int
+	db.Raw("SELECT marketingconsent FROM users WHERE id = ?", userID).Scan(&val)
+	assert.Equal(t, 1, val)
+}
+
 // ---------------------------------------------------------------------------
 // aboutme
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem
`PATCH /apiv2/session` declared `marketingconsent` as `*bool`. Go's `encoding/json` (via Fiber's `BodyParser`) **cannot unmarshal a JSON number into a `*bool`**, so when a client sent `{"marketingconsent": 1}` the **entire body parse failed** → `fiber.NewError(400, "Invalid request body")` → the whole PATCH was rejected before any field was applied. Marketing consent (and anything else in that body) was silently dropped.

## Scope (Loki, 7 days)
| body value | requests | succeeded |
|---|---|---|
| `marketingconsent: 1` (int) | 285 | **0** |
| `marketingconsent: true` (bool) | ~5000 | ~all |

The micro-volunteering "accept invite" flow hardcodes the integer form (`MicroVolunteering.vue`, `pages/microvolunteering/index.client.vue` → `saveAndGet({ marketingconsent: 1 })`), so consent from that flow was **never recorded**.

## Root cause
`marketingconsent` was the lone `*bool` in `PatchRequest`. Its neighbours already tolerate int/string: `modtools` is `FlexBool`; `relevantallowed`/`newslettersallowed` are `*utils.FlexInt`.

## Fix
Type the field as **`FlexBool`** (the existing helper — accepts JSON bool, int `0/1`, and string `"true"/"false"/"0"/"1"`) and read it via `.Bool()`. This is the server-side, client-agnostic fix: it protects *any* caller sending `1/0`, not just the two known call sites. No schema/DB change.

```
-Marketingconsent *bool
+Marketingconsent *FlexBool
...
-if *req.Marketingconsent {
+if req.Marketingconsent.Bool() {
```

## Test (TDD)
Added to `session_patch_flexint_test.go`: `TestPatchSessionMarketingconsentNumberOne` / `…NumberZero` (the int case that fails in production) and `…StringOne`, alongside the existing bool tests. With `*bool` these fail (`BodyParser` → 400, the 200 assert trips); with `FlexBool` they pass. **Full Go suite green** (`iznik-server-go/test` ok).