### PR TITLE
feat(ai-images): move "don't use AI for this item" suppress control to the AI Images page

### DIFF
--- a/iznik-nuxt3/api/AIImagesAPI.js
+++ b/iznik-nuxt3/api/AIImagesAPI.js
@@ -22,4 +22,8 @@ export default class AIImagesAPI extends BaseAPI {
   keep(id) {
     return this.$postv2(`/admin/ai-images/${id}/keep`, {})
   }
+
+  suppress(id) {
+    return this.$postv2(`/admin/ai-images/${id}/suppress`, {})
+  }
 }

--- a/iznik-nuxt3/modtools/components/ModPhoto.vue
+++ b/iznik-nuxt3/modtools/components/ModPhoto.vue
@@ -14,32 +14,6 @@
       :messageid="messageid"
       :attachmentid="attachmentid"
     />
-    <b-modal
-      ref="aiDeleteModal"
-      title="Remove AI Image"
-      no-stacking
-    >
-      <template #default>
-        <p>This is an AI-generated image. Why are you removing it?</p>
-        <b-button
-          variant="outline-secondary"
-          class="d-block w-100 mb-2"
-          @click="confirmRemove(false)"
-        >
-          Not relevant to this post
-        </b-button>
-        <b-button
-          variant="outline-danger"
-          class="d-block w-100"
-          @click="confirmRemove(true)"
-        >
-          Bad AI image for any post of this item
-        </b-button>
-      </template>
-      <template #footer>
-        <b-button variant="white" @click="hideAiDeleteModal">Cancel</b-button>
-      </template>
-    </b-modal>
   </span>
 </template>
 
@@ -66,8 +40,6 @@ const messageStore = useMessageStore()
 
 const zoom = ref(false)
 const modphotomodal = ref(null)
-const aiDeleteModal = ref(null)
-const pendingRemoveId = ref(null)
 
 const message = computed(() => messageStore.byId(props.messageid))
 
@@ -94,29 +66,11 @@ function showModal() {
   modphotomodal.value?.show()
 }
 
-function hideAiDeleteModal() {
-  aiDeleteModal.value?.hide()
-  pendingRemoveId.value = null
-}
-
+// Removing an AI-generated image is recorded server-side: the V2 message PATCH handler
+// records a review vote and protects this message from the illustrations cron re-adding
+// an image. To stop AI images for an item entirely, use the "Don't use AI for this item"
+// control on the ModTools AI Images page.
 async function removePhoto(id) {
-  if (mods.value?.ai) {
-    pendingRemoveId.value = id
-    aiDeleteModal.value?.show()
-    return
-  }
-
-  await doRemove(id, false)
-}
-
-async function confirmRemove(isBadForAnyPost) {
-  const id = pendingRemoveId.value
-  aiDeleteModal.value?.hide()
-  pendingRemoveId.value = null
-  await doRemove(id, isBadForAnyPost)
-}
-
-async function doRemove(id, isBadForAnyPost) {
   const attachments = []
 
   message.value?.attachments?.forEach((a) => {
@@ -125,12 +79,7 @@ async function doRemove(id, isBadForAnyPost) {
     }
   })
 
-  const patch = { id: props.messageid, attachments }
-  if (isBadForAnyPost) {
-    patch.badAIImages = [id]
-  }
-
-  await messageStore.patch(patch)
+  await messageStore.patch({ id: props.messageid, attachments })
 }
 
 async function updatedPhoto() {

--- a/iznik-nuxt3/modtools/components/ModPhotoModal.vue
+++ b/iznik-nuxt3/modtools/components/ModPhotoModal.vue
@@ -22,37 +22,10 @@
       <b-button variant="white" @click="hide"> Close </b-button>
     </template>
   </b-modal>
-
-  <b-modal
-    ref="aiDeleteModal"
-    title="Remove AI Image"
-    no-stacking
-  >
-    <template #default>
-      <p>This is an AI-generated image. Why are you removing it?</p>
-      <b-button
-        variant="outline-secondary"
-        class="d-block w-100 mb-2"
-        @click="confirmRemove(false)"
-      >
-        Not relevant to this post
-      </b-button>
-      <b-button
-        variant="outline-danger"
-        class="d-block w-100"
-        @click="confirmRemove(true)"
-      >
-        Bad AI image for any post of this item
-      </b-button>
-    </template>
-    <template #footer>
-      <b-button variant="white" @click="hideAiDeleteModal">Cancel</b-button>
-    </template>
-  </b-modal>
 </template>
 
 <script setup>
-import { ref, computed } from 'vue'
+import { computed } from 'vue'
 import { useMessageStore } from '~/stores/message'
 import { useOurModal } from '~/composables/useOurModal'
 
@@ -69,8 +42,6 @@ const props = defineProps({
 
 const { modal, show, hide } = useOurModal()
 const messageStore = useMessageStore()
-const aiDeleteModal = ref(null)
-const pendingRemoveId = ref(null)
 
 const message = computed(() => messageStore.byId(props.messageid))
 
@@ -96,29 +67,11 @@ async function updatedPhoto() {
   await messageStore.patch({ id: props.messageid })
 }
 
-function hideAiDeleteModal() {
-  aiDeleteModal.value?.hide()
-  pendingRemoveId.value = null
-}
-
+// Removing an AI-generated image is recorded server-side: the V2 message PATCH handler
+// records a review vote and protects this message from the illustrations cron re-adding
+// an image. To stop AI images for an item entirely, use the "Don't use AI for this item"
+// control on the ModTools AI Images page.
 async function removePhoto(id) {
-  if (externalmods.value?.ai) {
-    pendingRemoveId.value = id
-    aiDeleteModal.value?.show()
-    return
-  }
-
-  await doRemove(id, false)
-}
-
-async function confirmRemove(isBadForAnyPost) {
-  const id = pendingRemoveId.value
-  aiDeleteModal.value?.hide()
-  pendingRemoveId.value = null
-  await doRemove(id, isBadForAnyPost)
-}
-
-async function doRemove(id, isBadForAnyPost) {
   const attachments = []
 
   message.value?.attachments?.forEach((a) => {
@@ -127,15 +80,10 @@ async function doRemove(id, isBadForAnyPost) {
     }
   })
 
-  const patch = { id: props.messageid, attachments }
-  if (isBadForAnyPost) {
-    patch.badAIImages = [id]
-  }
-
-  await messageStore.patch(patch)
+  await messageStore.patch({ id: props.messageid, attachments })
 }
 
-defineExpose({ show, hide, doRemove, confirmRemove, pendingRemoveId })
+defineExpose({ show, hide })
 </script>
 
 <style scoped>

--- a/iznik-nuxt3/modtools/composables/useAIImages.js
+++ b/iznik-nuxt3/modtools/composables/useAIImages.js
@@ -41,6 +41,10 @@ export function useAIImages() {
     return $api.aiimages.keep(id)
   }
 
+  async function suppress(id) {
+    return $api.aiimages.suppress(id)
+  }
+
   return {
     count: readonly(count),
     images: readonly(images),
@@ -50,5 +54,6 @@ export function useAIImages() {
     regenerate,
     accept,
     keep,
+    suppress,
   }
 }

--- a/iznik-nuxt3/modtools/pages/images/index.vue
+++ b/iznik-nuxt3/modtools/pages/images/index.vue
@@ -29,7 +29,9 @@
         </li>
         <li>
           Some items genuinely can't have a good AI image — if every attempt is wrong, it is fine
-          to leave the current image and move on.
+          to leave the current image and move on with "Keep Current". If an item should never have
+          an AI image at all (e.g. cash, a lift, a voucher), use "Don't use AI for this item" and
+          we won't generate one for it again.
         </li>
       </ul>
     </b-alert>
@@ -149,6 +151,16 @@
 
               <div class="d-flex gap-2">
                 <b-button
+                  data-testid="suppress-btn"
+                  variant="outline-danger"
+                  :disabled="suppressing[img.id]"
+                  @click="handleSuppress(img)"
+                >
+                  <b-spinner v-if="suppressing[img.id]" small class="me-1" />
+                  Don't use AI for this item
+                </b-button>
+
+                <b-button
                   data-testid="keep-btn"
                   variant="secondary"
                   :disabled="keeping[img.id]"
@@ -183,7 +195,8 @@ import { useAIImages } from '~/modtools/composables/useAIImages'
 
 definePageMeta({ layout: 'default' })
 
-const { images, loading, fetchReview, regenerate, accept, keep } = useAIImages()
+const { images, loading, fetchReview, regenerate, accept, keep, suppress } =
+  useAIImages()
 
 const localImages = ref([])
 const notes = ref({})
@@ -191,6 +204,7 @@ const localPreviews = ref({}) // set after clicking Regenerate
 const regenerating = ref({})
 const accepting = ref({})
 const keeping = ref({})
+const suppressing = ref({})
 const errors = ref({})
 
 onMounted(async () => {
@@ -249,6 +263,23 @@ async function handleKeep(img) {
     errors.value[img.id] = 'Failed to keep current image. Please try again.'
   } finally {
     keeping.value[img.id] = false
+  }
+}
+
+// Suppress: terminally mark this item as one that should never have an AI image.
+// The Go API sets ai_images.status = 'suppressed', so the illustrations cron skips
+// the name and message serving masks any existing image for it.
+async function handleSuppress(img) {
+  suppressing.value[img.id] = true
+  errors.value[img.id] = null
+
+  try {
+    await suppress(img.id)
+    localImages.value = localImages.value.filter((i) => i.id !== img.id)
+  } catch (e) {
+    errors.value[img.id] = 'Failed to suppress this item. Please try again.'
+  } finally {
+    suppressing.value[img.id] = false
   }
 }
 </script>

--- a/iznik-nuxt3/tests/unit/components/modtools/ModPhotoModal.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModPhotoModal.spec.js
@@ -526,24 +526,27 @@ describe('ModPhotoModal', () => {
       expect(closeBtn.attributes('data-variant')).toBe('white')
     })
 
-    it('has Close button and AI-delete modal buttons', () => {
+    it('renders only the Close button (AI-delete modal removed)', () => {
       const wrapper = mountComponent()
       const buttons = wrapper.findAll('button')
-      // Close + "Not relevant" + "Bad AI image" + Cancel = 4
-      expect(buttons.length).toBe(4)
+      // The "bad AI image for any post" control moved to the AI Images page, so the
+      // only button left in this modal is Close.
+      expect(buttons.length).toBe(1)
+      expect(buttons[0].text()).toBe('Close')
     })
   })
 
-  describe('AI image deletion modal', () => {
-    it('renders AI-delete choice buttons', () => {
+  describe('AI image removal (no modal)', () => {
+    it('no longer renders the AI-delete choice buttons', () => {
       const wrapper = mountComponent()
-      expect(wrapper.text()).toContain('Not relevant to this post')
-      expect(wrapper.text()).toContain('Bad AI image for any post of this item')
+      expect(wrapper.text()).not.toContain('Not relevant to this post')
+      expect(wrapper.text()).not.toContain(
+        'Bad AI image for any post of this item'
+      )
     })
 
-    it('calls patch without badAIImages for non-AI attachment on removePhoto', async () => {
+    it('removePhoto patches directly for a non-AI attachment', async () => {
       const wrapper = mountComponent()
-      // Default attachment has no ai:true in mods — non-AI path
       await wrapper.vm.removePhoto(123)
       await flushPromises()
 
@@ -553,31 +556,7 @@ describe('ModPhotoModal', () => {
       })
     })
 
-    it('calls patch with badAIImages when doRemove called with isBadForAnyPost=true', async () => {
-      const wrapper = mountComponent()
-      await wrapper.vm.doRemove(123, true)
-      await flushPromises()
-
-      expect(mockMessageStore.patch).toHaveBeenCalledWith({
-        id: 456,
-        attachments: [124, 125],
-        badAIImages: [123],
-      })
-    })
-
-    it('calls patch without badAIImages when doRemove called with isBadForAnyPost=false', async () => {
-      const wrapper = mountComponent()
-      await wrapper.vm.doRemove(123, false)
-      await flushPromises()
-
-      expect(mockMessageStore.patch).toHaveBeenCalledWith({
-        id: 456,
-        attachments: [124, 125],
-      })
-    })
-
-    it('shows AI delete modal for AI attachment on removePhoto', async () => {
-      // Attachment with ai:true externalmods
+    it('removePhoto patches an AI attachment directly without intercepting via a modal', async () => {
       const wrapper = mountComponent({
         attachmentid: 200,
         _messageData: {
@@ -593,57 +572,31 @@ describe('ModPhotoModal', () => {
       await wrapper.vm.removePhoto(200)
       await flushPromises()
 
-      // Should NOT have patched yet (modal intercepts)
-      expect(mockMessageStore.patch).not.toHaveBeenCalled()
-      // pendingRemoveId should be set
-      expect(wrapper.vm.pendingRemoveId).toBe(200)
-    })
-
-    it('calls patch with badAIImages after confirmRemove(true)', async () => {
-      const wrapper = mountComponent({
-        attachmentid: 200,
-        _messageData: {
-          id: 456,
-          subject: 'Test',
-          attachments: [
-            { id: 200, externalmods: JSON.stringify({ ai: true }) },
-            { id: 201 },
-          ],
-        },
-      })
-
-      await wrapper.vm.removePhoto(200)
-      await wrapper.vm.confirmRemove(true)
-      await flushPromises()
-
-      expect(mockMessageStore.patch).toHaveBeenCalledWith({
-        id: 456,
-        attachments: [201],
-        badAIImages: [200],
-      })
-    })
-
-    it('calls patch without badAIImages after confirmRemove(false)', async () => {
-      const wrapper = mountComponent({
-        attachmentid: 200,
-        _messageData: {
-          id: 456,
-          subject: 'Test',
-          attachments: [
-            { id: 200, externalmods: JSON.stringify({ ai: true }) },
-            { id: 201 },
-          ],
-        },
-      })
-
-      await wrapper.vm.removePhoto(200)
-      await wrapper.vm.confirmRemove(false)
-      await flushPromises()
-
+      // Patches immediately — no "why are you removing it?" modal.
       expect(mockMessageStore.patch).toHaveBeenCalledWith({
         id: 456,
         attachments: [201],
       })
+    })
+
+    it('never sends badAIImages in the patch payload', async () => {
+      const wrapper = mountComponent({
+        attachmentid: 200,
+        _messageData: {
+          id: 456,
+          subject: 'Test',
+          attachments: [
+            { id: 200, externalmods: JSON.stringify({ ai: true }) },
+            { id: 201 },
+          ],
+        },
+      })
+
+      await wrapper.vm.removePhoto(200)
+      await flushPromises()
+
+      const payload = mockMessageStore.patch.mock.calls[0][0]
+      expect(payload).not.toHaveProperty('badAIImages')
     })
   })
 })

--- a/iznik-nuxt3/tests/unit/pages/modtools/AIImageReview.spec.js
+++ b/iznik-nuxt3/tests/unit/pages/modtools/AIImageReview.spec.js
@@ -15,6 +15,8 @@ vi.mock('~/composables/useMe', () => ({
 const mockFetchReview = vi.fn()
 const mockRegenerate = vi.fn()
 const mockAccept = vi.fn()
+const mockKeep = vi.fn()
+const mockSuppress = vi.fn()
 const mockImages = ref([])
 const mockLoading = ref(false)
 
@@ -25,6 +27,8 @@ vi.mock('~/modtools/composables/useAIImages', () => ({
     fetchReview: mockFetchReview,
     regenerate: mockRegenerate,
     accept: mockAccept,
+    keep: mockKeep,
+    suppress: mockSuppress,
     count: ref(0),
     fetchCount: vi.fn(),
   }),
@@ -60,6 +64,8 @@ beforeEach(async () => {
   mockFetchReview.mockReset()
   mockRegenerate.mockReset()
   mockAccept.mockReset()
+  mockKeep.mockReset()
+  mockSuppress.mockReset()
 })
 
 describe('Images page', () => {
@@ -406,5 +412,67 @@ describe('AIImageReview error handling', () => {
     // Clean up: resolve the promise
     resolveRegen({})
     await flushPromises()
+  })
+})
+
+describe('AIImageReview suppress ("Don\'t use AI for this item")', () => {
+  beforeEach(() => {
+    mockImages.value = [
+      {
+        id: 42,
+        name: 'Cash',
+        externaluid: 'freegletusd-cash',
+        image_url: 'https://example.com/cash.jpg',
+        status: 'rejected',
+        regeneration_notes: null,
+        pending_externaluid: null,
+        pending_image_url: null,
+        votes: [],
+        reject_count: 5,
+        approve_count: 0,
+      },
+    ]
+  })
+
+  it('renders a suppress button for each image', async () => {
+    const wrapper = mount(ImagesPage, { global: { stubs: stubComponents } })
+    await flushPromises()
+    expect(wrapper.find('[data-testid="suppress-btn"]').exists()).toBe(true)
+  })
+
+  it('calls suppress with the image id when clicked', async () => {
+    mockSuppress.mockResolvedValue({ ret: 0 })
+    const wrapper = mount(ImagesPage, { global: { stubs: stubComponents } })
+    await flushPromises()
+
+    await wrapper.find('[data-testid="suppress-btn"]').trigger('click')
+    await flushPromises()
+
+    expect(mockSuppress).toHaveBeenCalledWith(42)
+  })
+
+  it('removes the image from the list after suppress', async () => {
+    mockSuppress.mockResolvedValue({ ret: 0 })
+    const wrapper = mount(ImagesPage, { global: { stubs: stubComponents } })
+    await flushPromises()
+    expect(wrapper.text()).toContain('Cash')
+
+    await wrapper.find('[data-testid="suppress-btn"]').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.text()).not.toContain('Cash')
+  })
+
+  it('shows an error and keeps the image when suppress throws', async () => {
+    mockSuppress.mockRejectedValue(new Error('Network error'))
+    const wrapper = mount(ImagesPage, { global: { stubs: stubComponents } })
+    await flushPromises()
+
+    await wrapper.find('[data-testid="suppress-btn"]').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Failed to suppress')
+    // Image stays in the list so the moderator can retry.
+    expect(wrapper.text()).toContain('Cash')
   })
 })

--- a/iznik-server-go/aiimage/aiimage.go
+++ b/iznik-server-go/aiimage/aiimage.go
@@ -772,6 +772,50 @@ func KeepCurrent(c *fiber.Ctx) error {
 	return c.JSON(fiber.Map{"ret": 0, "status": "Success"})
 }
 
+// Suppress marks an AI image as 'suppressed' — a TERMINAL state meaning this item name
+// should never have an AI image generated or shown again. It is the moderator equivalent
+// of the volunteer-quorum suppress path (microvolunteering.checkAIImageSuppressQuorum):
+// the Pollinations/illustrations cron skips the name, message serving masks the image
+// (see the ai_images status IN ('rejected','regenerating','suppressed') join), and the
+// regeneration queue ignores it. Clears any pending review state and review votes so the
+// image leaves the queue. Works regardless of the current status (admin override), so a
+// 'regenerating' image can also be suppressed.
+//
+// @Summary Suppress an AI image (never generate one for this item again)
+// @Tags ai-images
+// @Produce json
+// @Security BearerAuth
+// @Param id path int true "AI image ID"
+// @Success 200 {object} map[string]interface{}
+// @Router /admin/ai-images/{id}/suppress [post]
+func Suppress(c *fiber.Ctx) error {
+	myid := user.WhoAmI(c)
+	if myid == 0 {
+		return fiber.NewError(fiber.StatusUnauthorized, "Not logged in")
+	}
+	if !user.IsAdminOrSupport(myid) {
+		return fiber.NewError(fiber.StatusForbidden, "Must be Support or Admin")
+	}
+
+	id, err := strconv.ParseUint(c.Params("id"), 10, 64)
+	if err != nil || id == 0 {
+		return fiber.NewError(fiber.StatusBadRequest, "Invalid image ID")
+	}
+
+	db := database.DBConn
+
+	var existing uint64
+	db.Raw("SELECT id FROM ai_images WHERE id = ?", id).Scan(&existing)
+	if existing == 0 {
+		return fiber.NewError(fiber.StatusNotFound, "AI image not found")
+	}
+
+	db.Exec(`UPDATE ai_images SET status = 'suppressed', pending_externaluid = NULL, regeneration_notes = NULL WHERE id = ?`, id)
+	db.Exec(`DELETE FROM microactions WHERE aiimageid = ? AND actiontype = 'AIImageReview'`, id)
+
+	return c.JSON(fiber.Map{"ret": 0, "status": "Success"})
+}
+
 // Count returns the number of AI images currently needing regeneration (rejected or regenerating).
 // Used by the ModTools nav badge.
 //

--- a/iznik-server-go/router/routes.go
+++ b/iznik-server-go/router/routes.go
@@ -208,6 +208,7 @@ func SetupRoutes(app *fiber.App) {
 		rg.Post("/admin/ai-images/:id/regenerate", aiimage.Regenerate)
 		rg.Post("/admin/ai-images/:id/accept", aiimage.Accept)
 		rg.Post("/admin/ai-images/:id/keep", aiimage.KeepCurrent)
+		rg.Post("/admin/ai-images/:id/suppress", aiimage.Suppress)
 
 		// Authority Search
 		// @Router /authority [get]

--- a/iznik-server-go/test/ai_image_suppress_test.go
+++ b/iznik-server-go/test/ai_image_suppress_test.go
@@ -1,0 +1,112 @@
+package test
+
+import (
+	json2 "encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/freegle/iznik-server-go/microvolunteering"
+	"github.com/stretchr/testify/assert"
+)
+
+// ---------------------------------------------------------------------------
+// POST /api/admin/ai-images/:id/suppress
+//
+// Admin/Support action that marks an AI image as terminally 'suppressed' — the
+// "don't keep asking for an AI image for this item" control. Mirrors the
+// volunteer-quorum suppress path (microvolunteering.checkAIImageSuppressQuorum),
+// but applied directly by a moderator from the AI Images review page.
+// ---------------------------------------------------------------------------
+
+func TestAIImageSuppress_RequiresAuth(t *testing.T) {
+	prefix := uniquePrefix("aisup_noauth")
+	imgID := createTestAIImageWithStatus(t, "suppress-noauth-"+prefix, "freegletusd-supnoauth-"+prefix, "rejected")
+
+	req := httptest.NewRequest("POST", fmt.Sprintf("/api/admin/ai-images/%d/suppress", imgID), nil)
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 401, resp.StatusCode)
+}
+
+func TestAIImageSuppress_RequiresAdminOrSupport(t *testing.T) {
+	prefix := uniquePrefix("aisup_norm")
+	uid := CreateTestUser(t, prefix, "User")
+	_, tok := CreateTestSession(t, uid)
+	imgID := createTestAIImageWithStatus(t, "suppress-norm-"+prefix, "freegletusd-supnorm-"+prefix, "rejected")
+
+	req := httptest.NewRequest("POST", fmt.Sprintf("/api/admin/ai-images/%d/suppress?jwt="+tok, imgID), nil)
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 403, resp.StatusCode)
+}
+
+func TestAIImageSuppress_NotFound(t *testing.T) {
+	prefix := uniquePrefix("aisup_404")
+	supportID := CreateTestUser(t, prefix+"_sup", "Support")
+	_, tok := CreateTestSession(t, supportID)
+
+	req := httptest.NewRequest("POST", "/api/admin/ai-images/999999999/suppress?jwt="+tok, nil)
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 404, resp.StatusCode)
+}
+
+// Suppress sets status='suppressed' (terminal), clears any pending review state, and
+// deletes the review votes so the image leaves the regeneration queue.
+func TestAIImageSuppress_SetsStatusSuppressedAndClearsQueue(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("aisup_set")
+	supportID := CreateTestUser(t, prefix+"_sup", "Support")
+	_, tok := CreateTestSession(t, supportID)
+
+	imgID := createTestAIImageWithStatus(t, "suppress-set-"+prefix, "freegletusd-supset-"+prefix, "rejected")
+
+	// Pre-populate pending state + a review vote — both should be cleared on suppress.
+	db.Exec("UPDATE ai_images SET pending_externaluid = ?, regeneration_notes = ? WHERE id = ?",
+		"freegletusd-pending-"+prefix, "some notes", imgID)
+	voter := CreateTestUser(t, prefix+"_voter", "User")
+	db.Exec("INSERT INTO microactions (actiontype, userid, aiimageid, result, version, score_negative) VALUES (?, ?, ?, 'Reject', 4, 0)",
+		microvolunteering.ChallengeAIImageReview, voter, imgID)
+
+	req := httptest.NewRequest("POST", fmt.Sprintf("/api/admin/ai-images/%d/suppress?jwt="+tok, imgID), nil)
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	// Status should now be the terminal 'suppressed'.
+	var status string
+	db.Raw("SELECT status FROM ai_images WHERE id = ?", imgID).Scan(&status)
+	assert.Equal(t, "suppressed", status, "Status should be 'suppressed' after admin suppress")
+
+	// Pending review state should be cleared.
+	var pendingUID *string
+	db.Raw("SELECT pending_externaluid FROM ai_images WHERE id = ?", imgID).Scan(&pendingUID)
+	assert.Nil(t, pendingUID, "pending_externaluid should be cleared after suppress")
+
+	// Review votes should be deleted so the image leaves the queue.
+	var voteCount int64
+	db.Raw("SELECT COUNT(*) FROM microactions WHERE aiimageid = ? AND actiontype = ?",
+		imgID, microvolunteering.ChallengeAIImageReview).Scan(&voteCount)
+	assert.Equal(t, int64(0), voteCount, "Review votes should be deleted after suppress")
+}
+
+// A 'regenerating' image can also be suppressed (admin override) and must then be
+// excluded from the review list.
+func TestAIImageSuppress_RemovesFromReviewList(t *testing.T) {
+	prefix := uniquePrefix("aisup_list")
+	supportID := CreateTestUser(t, prefix+"_sup", "Support")
+	_, tok := CreateTestSession(t, supportID)
+
+	imgID := createTestAIImageWithStatus(t, "suppress-list-"+prefix, "freegletusd-suplist-"+prefix, "regenerating")
+
+	reqS := httptest.NewRequest("POST", fmt.Sprintf("/api/admin/ai-images/%d/suppress?jwt="+tok, imgID), nil)
+	respS, _ := getApp().Test(reqS)
+	assert.Equal(t, 200, respS.StatusCode)
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/admin/ai-images/review?jwt="+tok, nil))
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result []map[string]interface{}
+	json2.Unmarshal(rsp(resp), &result)
+	for _, item := range result {
+		assert.NotEqual(t, imgID, uint64(item["id"].(float64)), "Suppressed image must not appear in review list")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a per-item **"Don't use AI for this item"** control on the ModTools **AI Images** review page (`/images`) — the moderator equivalent of the volunteer-quorum suppress. It sets `ai_images.status = 'suppressed'` (terminal), so the illustrations cron skips the item name and message serving masks any existing image for it.
- **Moves** that capability out of the photo-removal flow: removed the *"Why are you removing it?"* modal (and its *"Bad AI image for any post of this item"* option) from `ModPhoto.vue` and `ModPhotoModal.vue`, as requested. Removing an AI image now patches directly; the V2 message PATCH handler still records the review vote and protects that message from re-injection.
- New Go endpoint `POST /admin/ai-images/:id/suppress` (Support/Admin only): sets status, clears pending review state, deletes review votes so the image leaves the queue. Works regardless of current status, so a `regenerating` image can also be suppressed.

The backend `badAIImages` / `ForceRejectAIImage` path is **retained** (still a valid API with its own tests); only the frontend stops sending `badAIImages`.

## Files
- `iznik-server-go/aiimage/aiimage.go` — `Suppress` handler
- `iznik-server-go/router/routes.go` — route registration
- `iznik-server-go/test/ai_image_suppress_test.go` — new tests
- `iznik-nuxt3/api/AIImagesAPI.js`, `modtools/composables/useAIImages.js` — `suppress()`
- `iznik-nuxt3/modtools/pages/images/index.vue` — suppress button + handler + tip text
- `iznik-nuxt3/modtools/components/ModPhoto.vue`, `ModPhotoModal.vue` — removed AI-delete modal
- `iznik-nuxt3/tests/unit/...` — suppress tests + updated ModPhotoModal specs

## Code Quality Review
- Suppress handler mirrors the existing `KeepCurrent` shape (auth, existence check, status update, vote cleanup) for consistency.
- `suppressed` is already handled everywhere it matters (message-serving mask join, illustrations cron, regenerate refusal), so only the status change is needed — no new masking logic.
- `ModPhotoModal.vue`: dropped the now-unused `ref` import; `defineExpose` reduced to `show`/`hide`.
- Note: `index.vue` and the touched spec files are **not prettier-clean on `master`** (pre-existing); I kept additions consistent with the surrounding style rather than reformatting unrelated lines into a noisy diff.

## Future Improvements
- A short confirmation could be added before suppress (it's terminal, though admins can reverse via DB), matching the other one-click actions which also don't confirm.

## Test Plan
Run via the worktree status API.
- **Go:** full suite green — **3009 passed, 0 failed**, including 5 new `TestAIImageSuppress_*` (auth, authz, not-found, status+queue clearing, removal from review list).
- **Vitest:** AI Images page **45✓** (incl. new suppress-button tests), ModPhoto/ModPhotoModal **56✓** (modal-removal behaviour), ModMessage consumer specs **472✓**.