### PR TITLE
feat(charity): notify geeks of new Charity Partner signups

### DIFF
--- a/iznik-batch/app/Console/Commands/Charity/NotifySignupsCommand.php
+++ b/iznik-batch/app/Console/Commands/Charity/NotifySignupsCommand.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Console\Commands\Charity;
+
+use App\Services\CharitySignupNotifyService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+
+class NotifySignupsCommand extends Command
+{
+    protected $signature = 'charity:notify-signups
+                            {--dry-run : Show what would be sent without emailing}';
+
+    protected $description = 'Email geeks about new Charity Partner signups in the charities table';
+
+    public function handle(CharitySignupNotifyService $service): int
+    {
+        $dryRun = (bool) $this->option('dry-run');
+
+        if ($dryRun) {
+            $this->info('DRY RUN — no email will be sent.');
+        }
+
+        $stats = $service->process($dryRun);
+
+        $prefix = $dryRun ? '[DRY RUN] ' : '';
+        $this->info("{$prefix}New charity signups notified: {$stats['notified']}");
+
+        Log::info('charity:notify-signups complete', $stats);
+
+        return Command::SUCCESS;
+    }
+}

--- a/iznik-batch/app/Services/CharitySignupNotifyService.php
+++ b/iznik-batch/app/Services/CharitySignupNotifyService.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace App\Services;
+
+use App\Mail\Alert\AlertMail;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Notify the geeks team of new Charity Partner signups.
+ *
+ * Charity signups land in the `charities` table (status Pending) via the Go API,
+ * which emails partnerships@ — but nobody watches them (the one live row has been
+ * Pending since April). This emails geeks@ about any signups not yet reported, so
+ * they get picked up, and marks them notified so each is reported exactly once.
+ */
+class CharitySignupNotifyService
+{
+    /**
+     * @return array{notified:int}
+     */
+    public function process(bool $dryRun = false): array
+    {
+        $stats = ['notified' => 0];
+
+        $new = DB::table('charities')
+            ->where('geeknotified', 0)
+            ->orderBy('id')
+            ->get();
+
+        if ($new->isEmpty()) {
+            return $stats;
+        }
+
+        $count = $new->count();
+        $geeks = config('freegle.mail.geeks_addr') ?: 'geeks@ilovefreegle.org';
+        $subject = $count === 1
+            ? 'New Freegle Charity Partner signup'
+            : "{$count} new Freegle Charity Partner signups";
+
+        [$html, $text] = $this->buildBody($new);
+
+        if (!$dryRun) {
+            app(EmailSpoolerService::class)->spool(new AlertMail(
+                recipientEmail: $geeks,
+                recipientName: 'Freegle Geeks',
+                fromAddress: config('freegle.mail.noreply_addr'),
+                fromName: config('freegle.branding.name'),
+                subjectLine: $subject,
+                htmlBody: $html,
+                textBody: $text,
+            ));
+
+            DB::table('charities')
+                ->whereIn('id', $new->pluck('id')->all())
+                ->update(['geeknotified' => 1]);
+        }
+
+        $stats['notified'] = $count;
+        Log::info("CharitySignupNotify: notified geeks of {$count} new charity signup(s)", ['dry_run' => $dryRun]);
+
+        return $stats;
+    }
+
+    /**
+     * @return array{0:string,1:string} [htmlBody, textBody]
+     */
+    private function buildBody($charities): array
+    {
+        $rows = [];
+        $textLines = [];
+        foreach ($charities as $c) {
+            $type = $c->orgtype === 'registered' ? 'Registered charity' : 'Other organisation';
+            $num = $c->charitynumber ? " (charity no. {$c->charitynumber})" : '';
+            $contactName = $c->contactname ?: '';
+
+            $cell = '<strong>' . e($c->orgname) . '</strong>' . e($num) . '<br>'
+                . e($type) . ' — status ' . e($c->status) . '<br>'
+                . 'Contact: ' . e(trim($contactName . ' <' . $c->contactemail . '>'));
+            if ($c->website) {
+                $cell .= '<br>Website: ' . e($c->website);
+            }
+            if ($c->userid) {
+                $cell .= '<br>User ID: ' . (int) $c->userid;
+            }
+            if ($c->description) {
+                $cell .= '<br>' . e($c->description);
+            }
+            $rows[] = '<tr><td style="padding:6px 10px;border-bottom:1px solid #eee;">' . $cell . '</td></tr>';
+
+            $textLines[] = "- {$c->orgname}{$num} — {$type}, status {$c->status}, contact "
+                . trim($contactName . ' <' . $c->contactemail . '>');
+        }
+
+        $html = '<p>New Charity Partner signup(s) recorded in the <code>charities</code> table — these need reviewing/approving:</p>'
+            . '<table style="border-collapse:collapse;">' . implode('', $rows) . '</table>'
+            . '<p>They remain <strong>Pending</strong> until approved.</p>';
+        $text = "New Charity Partner signup(s) recorded — these need reviewing/approving:\n\n"
+            . implode("\n", $textLines) . "\n\nThey remain Pending until approved.";
+
+        return [$html, $text];
+    }
+}

--- a/iznik-batch/database/migrations/2026_06_04_000003_add_geeknotified_to_charities.php
+++ b/iznik-batch/database/migrations/2026_06_04_000003_add_geeknotified_to_charities.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Track which charity-partner signups have been notified to the geeks team.
+ *
+ * The Go API records signups in `charities` (status Pending) and emails
+ * partnerships@, but nobody is watching them — the one live row has sat Pending
+ * since April. charity:notify-signups emails geeks@ about new entries; this flag
+ * records who has been notified so each signup is reported exactly once.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('charities', function (Blueprint $table) {
+            $table->boolean('geeknotified')->default(false)->after('status');
+            $table->index('geeknotified', 'charities_geeknotified_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('charities', function (Blueprint $table) {
+            $table->dropIndex('charities_geeknotified_idx');
+            $table->dropColumn('geeknotified');
+        });
+    }
+};

--- a/iznik-batch/routes/console.php
+++ b/iznik-batch/routes/console.php
@@ -166,6 +166,14 @@ Schedule::command('mail:bounced')
     ->sendOutputTo(cronLog('mail:bounced'))
     ->runInBackground();
 
+// Charity Partner signup monitor — emails geeks about new entries in the
+// charities table (which would otherwise sit Pending, unwatched).
+Schedule::command('charity:notify-signups')
+    ->hourly()
+    ->withoutOverlapping()
+    ->sendOutputTo(cronLog('charity:notify-signups'))
+    ->runInBackground();
+
 // Moderator work notifications — tells mods about pending messages, events, etc.
 // Only runs 08:00–21:00; deduplicates against last sent summary.
 // V1: cron/mod_notifs.php (hourly)

--- a/iznik-batch/tests/Unit/Commands/Charity/NotifySignupsCommandTest.php
+++ b/iznik-batch/tests/Unit/Commands/Charity/NotifySignupsCommandTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\Unit\Commands\Charity;
+
+use App\Services\CharitySignupNotifyService;
+use Illuminate\Console\Command;
+use Tests\TestCase;
+
+class NotifySignupsCommandTest extends TestCase
+{
+    public function test_reports_notified_count(): void
+    {
+        $service = $this->createMock(CharitySignupNotifyService::class);
+        $service->method('process')->willReturn(['notified' => 3]);
+        $this->app->instance(CharitySignupNotifyService::class, $service);
+
+        $this->artisan('charity:notify-signups')
+            ->expectsOutputToContain('New charity signups notified: 3')
+            ->assertExitCode(Command::SUCCESS);
+    }
+
+    public function test_dry_run_announces_and_passes_flag(): void
+    {
+        $service = $this->createMock(CharitySignupNotifyService::class);
+        $service->expects($this->once())
+            ->method('process')
+            ->with(true)
+            ->willReturn(['notified' => 0]);
+        $this->app->instance(CharitySignupNotifyService::class, $service);
+
+        $this->artisan('charity:notify-signups', ['--dry-run' => true])
+            ->expectsOutputToContain('no email will be sent')
+            ->expectsOutputToContain('[DRY RUN] New charity signups notified: 0')
+            ->assertExitCode(Command::SUCCESS);
+    }
+}

--- a/iznik-batch/tests/Unit/Services/CharitySignupNotifyServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/CharitySignupNotifyServiceTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Mail\Alert\AlertMail;
+use App\Services\CharitySignupNotifyService;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Mail;
+use Tests\TestCase;
+
+class CharitySignupNotifyServiceTest extends TestCase
+{
+    protected CharitySignupNotifyService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new CharitySignupNotifyService();
+    }
+
+    private function makeCharity(array $attrs = []): int
+    {
+        return DB::table('charities')->insertGetId(array_merge([
+            'orgname' => 'Test Charity',
+            'orgtype' => 'registered',
+            'charitynumber' => '123456',
+            'contactemail' => 'contact@example.com',
+            'contactname' => 'Jane Doe',
+            'status' => 'Pending',
+            'geeknotified' => 0,
+        ], $attrs));
+    }
+
+    public function test_notifies_geeks_of_new_signup_and_marks_notified(): void
+    {
+        Mail::fake();
+        $id = $this->makeCharity(['orgname' => 'Acme Reuse']);
+
+        $stats = $this->service->process();
+
+        $this->assertEquals(1, $stats['notified']);
+        Mail::assertSent(AlertMail::class, function ($mail) {
+            return str_contains($mail->subjectLine, 'Charity Partner')
+                && str_contains($mail->recipientEmail, 'geeks');
+        });
+        $this->assertDatabaseHas('charities', ['id' => $id, 'geeknotified' => 1]);
+    }
+
+    public function test_does_not_renotify_already_notified(): void
+    {
+        Mail::fake();
+        $this->makeCharity(['geeknotified' => 1]);
+
+        $stats = $this->service->process();
+
+        $this->assertEquals(0, $stats['notified']);
+        Mail::assertNothingSent();
+    }
+
+    public function test_no_signups_sends_nothing(): void
+    {
+        Mail::fake();
+
+        $stats = $this->service->process();
+
+        $this->assertEquals(0, $stats['notified']);
+        Mail::assertNothingSent();
+    }
+
+    public function test_dry_run_does_not_send_or_mark(): void
+    {
+        Mail::fake();
+        $id = $this->makeCharity();
+
+        $stats = $this->service->process(dryRun: true);
+
+        $this->assertEquals(1, $stats['notified']);
+        Mail::assertNothingSent();
+        $this->assertDatabaseHas('charities', ['id' => $id, 'geeknotified' => 0]);
+    }
+
+    public function test_batches_multiple_into_one_email(): void
+    {
+        Mail::fake();
+        $this->makeCharity(['orgname' => 'A', 'contactemail' => 'a@x.com']);
+        $this->makeCharity(['orgname' => 'B', 'contactemail' => 'b@x.com']);
+
+        $stats = $this->service->process();
+
+        $this->assertEquals(2, $stats['notified']);
+        // One email summarising both signups.
+        Mail::assertSent(AlertMail::class, 1);
+    }
+}


### PR DESCRIPTION
## Summary

Charity Partner signups land in the `charities` table (status `Pending`) via the Go API (`POST /api/charities`), which emails **partnerships@**. But nobody is watching them — the one live row in production has sat `Pending` since **2026‑04‑15** with no action. This adds a scheduled monitor that emails **geeks@** about any new signups so they get picked up.

(Context: this is the missing back‑half of the Charity Partner feature from #140 — the approval + account‑flag + badge‑display half was never built; the badge only renders illustratively on the `/charity` landing page. This PR doesn't build that half — it just makes sure new signups are visible. Surfaced while investigating #140 / closed iznik‑nuxt3#200.)

## What it does

- **Migration**: `charities.geeknotified` flag (so each signup is reported exactly once).
- **`CharitySignupNotifyService`**: finds signups with `geeknotified = 0`, emails geeks@ a summary (org name, type, charity number, contact, status, website, user id, description) — batched into one email — then marks them notified. Reuses the existing internal `AlertMail`.
- **`charity:notify-signups`** command (hourly, `withoutOverlapping`, `--dry-run`).

## Notes

- Complements rather than replaces the existing per‑signup partnerships@ email (different audience; also a safety net if the queued email fails).
- Idempotent: the flag means re‑runs don't re‑notify; missed scheduler runs are caught on the next run.

## Test Plan

- **Laravel** (`CharitySignupNotifyServiceTest`): notifies geeks + marks notified; doesn't re‑notify already‑notified; nothing when there are no new signups; dry‑run sends/marks nothing; multiple signups batch into one email. Plus the command test (count output, dry‑run flag).
