### PR TITLE
fix(calendar): reactive error derivation + base64url encoding for tryst calendar links

### DIFF
--- a/iznik-batch/app/Services/TrystService.php
+++ b/iznik-batch/app/Services/TrystService.php
@@ -171,7 +171,7 @@ class TrystService
             'location' => '',
         ];
 
-        return $userSite . '/calendar?data=' . base64_encode(json_encode($eventData));
+        return $userSite . '/calendar?data=' . rtrim(strtr(base64_encode(json_encode($eventData)), '+/', '-_'), '=');
     }
 
     /**

--- a/iznik-batch/tests/Feature/Chat/TrystCommandTest.php
+++ b/iznik-batch/tests/Feature/Chat/TrystCommandTest.php
@@ -247,4 +247,63 @@ class TrystCommandTest extends TestCase
 
         $this->assertNotNull(DB::table('trysts')->where('id', $trystId)->value('remindersent'));
     }
+
+    /**
+     * The calendar link's ?data= param must be base64url (url-safe alphabet: no + or /).
+     * Standard base64 can emit '+' (decoded to space in a query string) and '/' which
+     * are both URL-unsafe. The fix switches to rtrim(strtr(base64_encode(...), '+/', '-_'), '=').
+     */
+    public function test_calendar_link_data_param_is_base64url_safe(): void
+    {
+        $user1 = $this->createTestUser();
+        $user2 = $this->createTestUser();
+
+        $this->createTryst($user1, $user2, [
+            'arrangedfor' => now()->addDays(2)->setTime(14, 0)->format('Y-m-d H:i:s'),
+            'icssent' => 0,
+        ]);
+
+        (new TrystService())->sendCalendarsDue(false);
+
+        // Capture the calendarLink from one of the two sent mails
+        $capturedLink = null;
+        Mail::assertSent(TrystCalendarInviteMail::class, function (TrystCalendarInviteMail $mail) use (&$capturedLink) {
+            $capturedLink = $mail->calendarLink;
+            return true;
+        });
+
+        $this->assertNotNull($capturedLink, 'calendarLink was not set on the sent mail');
+
+        // Extract the ?data= parameter
+        $parsed = parse_url($capturedLink);
+        parse_str($parsed['query'] ?? '', $queryParams);
+        $dataParam = $queryParams['data'] ?? null;
+
+        $this->assertNotNull($dataParam, 'No ?data= param in calendar link: ' . $capturedLink);
+
+        // Must not contain standard base64 URL-unsafe characters
+        $this->assertStringNotContainsString('+', $dataParam, 'data param contains + (URL-unsafe): ' . $dataParam);
+        $this->assertStringNotContainsString('/', $dataParam, 'data param contains / (URL-unsafe): ' . $dataParam);
+
+        // Must be valid base64url (only A-Z a-z 0-9 - _)
+        $this->assertMatchesRegularExpression('/^[A-Za-z0-9\-_]+$/', $dataParam, 'data param is not valid base64url: ' . $dataParam);
+
+        // Must round-trip to JSON with the expected event fields
+        // base64url → standard base64 → decode → JSON
+        $padded = $dataParam . str_repeat('=', (4 - strlen($dataParam) % 4) % 4);
+        $standard = strtr($padded, '-_', '+/');
+        $decoded  = base64_decode($standard, strict: true);
+
+        $this->assertNotFalse($decoded, 'base64url decode failed for: ' . $dataParam);
+
+        $event = json_decode($decoded, associative: true);
+
+        $this->assertNotNull($event, 'JSON decode failed: ' . $decoded);
+        $this->assertArrayHasKey('name', $event);
+        $this->assertArrayHasKey('startDate', $event);
+        $this->assertArrayHasKey('startTime', $event);
+        $this->assertArrayHasKey('endTime', $event);
+        $this->assertArrayHasKey('timeZone', $event);
+        $this->assertStringStartsWith('Handover:', $event['name']);
+    }
 }

--- a/iznik-nuxt3/pages/calendar.client.vue
+++ b/iznik-nuxt3/pages/calendar.client.vue
@@ -39,29 +39,93 @@
 </template>
 
 <script setup>
-import { ref, computed } from 'vue'
+import { computed, onMounted } from 'vue'
 import { useRoute } from '#imports'
 import { buildHead } from '~/composables/useBuildHead'
 
 const route = useRoute()
 const runtimeConfig = useRuntimeConfig()
 
-// Import the component only on client-side, before any rendering
-if (process.client) {
-  await import('add-to-calendar-button')
-}
-
-const eventData = ref({
-  name: '',
-  description: '',
-  startDate: '',
-  startTime: '',
-  endTime: '',
-  timeZone: 'Europe/London',
-  location: '',
+// Load the web component non-blockingly so setup never awaits on it.
+// The button is only rendered when eventData has a name (v-if="eventData.name"),
+// so it will be available by the time it needs to render.
+onMounted(() => {
+  import('add-to-calendar-button').catch(() => {})
 })
 
-const error = ref(null)
+/**
+ * Decode a base64 or base64url string.
+ * base64url uses '-' instead of '+' and '_' instead of '/'.
+ * A '+' in a query string is decoded to a space by URL parsers, so we
+ * must handle both alphabets.  Standard base64 strings contain no '-' or '_'
+ * so the replace is harmless for them.
+ */
+function b64decode(s) {
+  const t = s.replace(/-/g, '+').replace(/_/g, '/')
+  const pad = t.length % 4 ? '='.repeat(4 - (t.length % 4)) : ''
+  return atob(t + pad)
+}
+
+/**
+ * Reactively derive the raw base64 string from the route query.
+ * Falls back to window.location.search for the transient instant when
+ * Nuxt's router has not yet propagated the query (e.g. immediately after
+ * Netlify's trailing-slash 301 redirect).
+ */
+const rawData = computed(() => {
+  const q = route?.query?.data
+  if (q) return Array.isArray(q) ? q[0] : q
+  if (process.client && typeof window !== 'undefined') {
+    return new URLSearchParams(window.location.search).get('data')
+  }
+  return null
+})
+
+/**
+ * Single reactive derivation that returns { error, event }.
+ * Because this is a computed, it re-evaluates whenever rawData changes —
+ * so a stale "no data" error is automatically cleared when the query arrives.
+ */
+const parsed = computed(() => {
+  if (!rawData.value) {
+    return { error: 'No calendar event data provided', event: null }
+  }
+  try {
+    const eventObj = JSON.parse(b64decode(rawData.value))
+    if (!eventObj.name || !eventObj.startDate || !eventObj.startTime) {
+      return { error: 'Missing required event information', event: null }
+    }
+    return { error: null, event: eventObj }
+  } catch (e) {
+    return { error: 'Unable to load calendar event: ' + e.message, event: null }
+  }
+})
+
+const error = computed(() => parsed.value.error)
+
+const eventData = computed(() => {
+  const ev = parsed.value.event
+  if (ev) {
+    return {
+      name: ev.name || '',
+      description: ev.description || '',
+      startDate: ev.startDate || '',
+      startTime: ev.startTime || '',
+      endTime: ev.endTime || '',
+      timeZone: ev.timeZone || 'Europe/London',
+      location: ev.location || '',
+    }
+  }
+  return {
+    name: '',
+    description: '',
+    startDate: '',
+    startTime: '',
+    endTime: '',
+    timeZone: 'Europe/London',
+    location: '',
+  }
+})
 
 const descriptionWithLinks = computed(() => {
   if (!eventData.value.description) return ''
@@ -70,34 +134,6 @@ const descriptionWithLinks = computed(() => {
     '<a href="$1" target="_blank">$1</a>'
   )
 })
-
-try {
-  const data = route.query.data
-
-  if (!data) {
-    throw new Error('No calendar event data provided')
-  }
-
-  const decoded = atob(data)
-  const parsed = JSON.parse(decoded)
-
-  if (!parsed.name || !parsed.startDate || !parsed.startTime) {
-    throw new Error('Missing required event information')
-  }
-
-  eventData.value = {
-    name: parsed.name || '',
-    description: parsed.description || '',
-    startDate: parsed.startDate || '',
-    startTime: parsed.startTime || '',
-    endTime: parsed.endTime || '',
-    timeZone: parsed.timeZone || 'Europe/London',
-    location: parsed.location || '',
-  }
-} catch (e) {
-  console.error('Error in calendar page setup:', e)
-  error.value = 'Unable to load calendar event: ' + e.message
-}
 
 useHead({
   ...buildHead(

--- a/iznik-nuxt3/tests/unit/pages/calendar.spec.js
+++ b/iznik-nuxt3/tests/unit/pages/calendar.spec.js
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { defineComponent, Suspense, h, reactive } from 'vue'
+
+// ============================================================
+// calendar.client.vue — unit tests (TDD)
+//
+// The bug: the page used a plain try/catch in <script setup>
+// that set error.value once, permanently. Netlify's trailing-slash
+// 301 (/calendar?data → /calendar/?data) plus Nuxt's no-slash
+// canonical causes a transient bare-/calendar render (route.query
+// stripped → error cached) followed immediately by the real render
+// with ?data= on the same route instance. Since setup never re-runs
+// the cached error stayed on screen.
+//
+// The fix: derive everything from a `computed` so when route.query
+// changes the error clears automatically.
+// ============================================================
+
+// ---- mock add-to-calendar-button (web component, not needed in jsdom)
+vi.mock('add-to-calendar-button', () => ({}))
+
+// ---- reactive mock route so computed properties respond to query changes
+// (Nuxt's real useRoute() returns a reactive proxy; we replicate that here)
+const mockRoute = reactive({
+  params: {},
+  query: {},
+  path: '/calendar',
+  name: 'calendar',
+  fullPath: '/calendar',
+})
+
+vi.mock('#imports', async () => {
+  const actual = await vi.importActual('#imports')
+  return {
+    ...actual,
+    useRoute: () => mockRoute,
+  }
+})
+
+globalThis.__testUseRoute = () => mockRoute
+globalThis.useHead = vi.fn()
+globalThis.definePageMeta = vi.fn()
+
+// ---- helpers -------------------------------------------------
+
+function b64encode(obj) {
+  return btoa(JSON.stringify(obj))
+}
+
+function b64urlEncode(obj) {
+  const s = btoa(JSON.stringify(obj))
+  return s.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+const validEvent = {
+  name: 'Handover: Alice and Bob',
+  description: 'Please add to your calendar.',
+  startDate: '2026-07-01',
+  startTime: '14:00',
+  endTime: '14:15',
+  timeZone: 'Europe/London',
+  location: '',
+}
+
+async function mountCalendarPage() {
+  const CalendarPage = (await import('~/pages/calendar.client.vue')).default
+  const Wrapper = defineComponent({
+    setup() {
+      return () => h(Suspense, null, { default: () => h(CalendarPage) })
+    },
+  })
+  return mount(Wrapper, {
+    global: {
+      stubs: {
+        'client-only': { template: '<div><slot /></div>' },
+        'b-row': { template: '<div><slot /></div>' },
+        'b-col': { template: '<div><slot /></div>' },
+        'add-to-calendar-button': { template: '<div class="atcb"><slot /></div>' },
+      },
+    },
+  })
+}
+
+describe('pages/calendar.client.vue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Reset to a bare /calendar with NO query data (simulates transient
+    // Netlify trailing-slash render — route.query is stripped)
+    mockRoute.query = {}
+    mockRoute.path = '/calendar'
+    mockRoute.name = 'calendar'
+    mockRoute.fullPath = '/calendar'
+    // Ensure the global hook also reflects the current route
+    globalThis.__testUseRoute = () => mockRoute
+    vi.resetModules()
+  })
+
+  // -----------------------------------------------------------
+  // (a) No data → shows "No calendar event data provided"
+  // -----------------------------------------------------------
+  it('shows "No calendar event data provided" error when route.query.data is absent', async () => {
+    const wrapper = await mountCalendarPage()
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('No calendar event data provided')
+  })
+
+  // -----------------------------------------------------------
+  // (b) THE REGRESSION TEST: when route.query.data becomes
+  // available reactively, the error CLEARS and the event renders.
+  //
+  // This proves the cached-error bug is fixed: if error were a plain
+  // ref set in setup, it would persist after the route updates.
+  // With the computed-based fix, the error re-derives as null when
+  // rawData becomes available.
+  // -----------------------------------------------------------
+  it('clears the error and renders event name when route.query.data arrives reactively', async () => {
+    // Step 1: mount with no data (transient bare render)
+    const wrapper = await mountCalendarPage()
+    await flushPromises()
+
+    // Confirm the error state is showing initially
+    expect(wrapper.text()).toContain('No calendar event data provided')
+
+    // Step 2: simulate query arriving (Nuxt reuses component; route object
+    // is mutated in place — we do the same with our reactive mock)
+    mockRoute.query = { data: b64encode(validEvent) }
+
+    await flushPromises()
+    await wrapper.vm.$nextTick()
+
+    // The error should be gone and the event name visible
+    expect(wrapper.text()).not.toContain('No calendar event data provided')
+    expect(wrapper.text()).toContain(validEvent.name)
+  })
+
+  // -----------------------------------------------------------
+  // (c) base64url payload (url-safe alphabet) decodes correctly
+  // -----------------------------------------------------------
+  it('decodes a base64url-encoded payload (url-safe -_ alphabet) correctly', async () => {
+    // Start with data already present in the query
+    mockRoute.query = { data: b64urlEncode(validEvent) }
+
+    const wrapper = await mountCalendarPage()
+    await flushPromises()
+
+    expect(wrapper.text()).not.toContain('Error')
+    expect(wrapper.text()).toContain(validEvent.name)
+  })
+
+  // -----------------------------------------------------------
+  // (d) Missing required fields → correct error message
+  // -----------------------------------------------------------
+  it('shows "Missing required event information" when name/startDate/startTime absent', async () => {
+    const incomplete = { description: 'No required fields here' }
+    mockRoute.query = { data: b64encode(incomplete) }
+
+    const wrapper = await mountCalendarPage()
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Missing required event information')
+  })
+})


### PR DESCRIPTION
## Problem

Users intermittently saw **"Error — Unable to load calendar event: No calendar event data provided"** when clicking the "Add to Calendar" button in the tryst (handover) reminder email.

Root cause (two interacting bugs):

1. **Cached error in calendar.client.vue**: The page used a plain `ref` + `try/catch` in `<script setup>` to parse the `?data=` query. Netlify's trailing-slash redirect (`/calendar?data=X` → `/calendar/?data=X`) combined with Nuxt's no-slash canonical produces a transient bare `/calendar` render where `route.query` is empty. Setup ran once, threw, and set `error.value` permanently. When the real `?data=` query arrived on the same component instance (same route name → Nuxt reuses the component, setup never re-runs), the cached error stayed on screen.

2. **Standard base64 in TrystService.php**: `base64_encode` can emit `+` and `/`, both URL-unsafe. A `+` in a query string is decoded to a space by URL parsers, corrupting the payload before it reaches the frontend decoder.

## Fix

**Frontend (`iznik-nuxt3/pages/calendar.client.vue`)**:
- Replace the imperative try/catch with reactive `computed` derivation. `error` and `eventData` are now computed properties that re-derive automatically whenever `route.query.data` changes — so a transient no-data state does not get cached.
- Added a `window.location.search` fallback in `rawData` for the transient instant when Nuxt's router has not yet propagated the query (covers the redirect race).
- Implemented a base64url-tolerant decoder (`b64decode`) that handles both standard base64 (existing links) and url-safe base64url (`-_` alphabet, new links). Re-pads as needed.
- Moved the `add-to-calendar-button` dynamic import to `onMounted` so `<script setup>` is never blocked awaiting it.

**Backend (`iznik-batch/app/Services/TrystService.php`)**:
- Changed `base64_encode(...)` to `rtrim(strtr(base64_encode(...), '+/', '-_'), '=')` (base64url). The frontend decoder is backward-compatible: old standard-base64 links (no `-_` characters) still decode correctly.

## Tests

**Vitest** (`iznik-nuxt3/tests/unit/pages/calendar.spec.js` — new file):
- (a) No `route.query.data` → error message shown
- (b) **Regression**: error clears and event name renders when `route.query.data` arrives reactively (uses a reactive mock route to replicate Nuxt's behaviour; would have failed on the old `ref`-based code)
- (c) base64url payload (`-_` alphabet) decodes correctly
- (d) Missing required fields → correct error message

All 4 new + 9 pre-existing `AddToCalendar.spec.js` tests pass (13✓ 0✗).

**Laravel** (`iznik-batch/tests/Feature/Chat/TrystCommandTest.php` — new test appended):
- `test_calendar_link_data_param_is_base64url_safe`: verifies the built calendar link's `?data=` param contains only `[A-Za-z0-9-_]` characters, and round-trips to JSON with all expected event fields.

All 14 `TrystCommandTest` tests pass (13 existing + 1 new, 0✗).