### PR TITLE
fix(mobile-give): stop AI illustration string id causing HTTP 400 on post submit

### DIFF
--- a/iznik-nuxt3/composables/useAiIllustration.js
+++ b/iznik-nuxt3/composables/useAiIllustration.js
@@ -1,0 +1,104 @@
+/**
+ * useAiIllustration — composable for fetching and storing an AI illustration
+ * for a give/mobile post when the member has not uploaded their own photo.
+ *
+ * Extracted from pages/give/mobile/details.vue so the fetch+store logic can
+ * be unit-tested independently of Nuxt's component runtime.
+ */
+
+/**
+ * Fetch an AI illustration for `itemName` (if one is cached on the server),
+ * immediately materialise it as a real server-side attachment via POST /image,
+ * and write the result into the compose store.
+ *
+ * @param {object} opts
+ * @param {object}   opts.api            – result of api(runtimeConfig)
+ * @param {object}   opts.composeStore   – Pinia compose store instance
+ * @param {number}   opts.messageId      – compose store message id
+ * @param {string}   opts.itemName       – item name to fetch illustration for
+ * @param {object[]} opts.attachments    – current attachments for the message
+ * @param {import('vue').Ref<boolean>}  opts.fetchingIllustration – reactive flag
+ * @param {import('vue').Ref<string|null>} opts.lastFetchedItem   – last fetched item name
+ * @returns {Promise<void>}
+ */
+export async function fetchAiIllustration({
+  api,
+  composeStore,
+  messageId,
+  itemName,
+  attachments,
+  fetchingIllustration,
+  lastFetchedItem,
+}) {
+  if (!itemName || !itemName.trim()) return
+
+  const trimmedItem = itemName.trim()
+
+  // Only fetch if there are no real photos, we haven't already fetched for
+  // this item name, and we're not currently fetching.
+  const realPhotos = attachments.filter(
+    (a) => !a.externalmods || a.externalmods.ai !== true
+  )
+
+  if (
+    realPhotos.length > 0 ||
+    fetchingIllustration.value ||
+    lastFetchedItem.value === trimmedItem
+  ) {
+    return
+  }
+
+  fetchingIllustration.value = true
+  lastFetchedItem.value = trimmedItem
+
+  try {
+    const illustration = await api.message.getIllustration(trimmedItem)
+
+    if (illustration && illustration.externaluid) {
+      // Check again that no real photos were added while we were fetching.
+      const currentRealPhotos = attachments.filter(
+        (a) => !a.externalmods || a.externalmods.ai !== true
+      )
+
+      if (currentRealPhotos.length === 0) {
+        // Remove any existing AI illustration first.
+        const filteredAtts = attachments.filter(
+          (a) => !a.externalmods || a.externalmods.ai !== true
+        )
+
+        // Materialise as a real server-side attachment immediately so the id
+        // stored in the compose store is always a numeric uint64.  If this
+        // POST fails we fall back to no id (null); createDraft will retry via
+        // its own image.post() call using ouruid as a safety net.
+        let realId = null
+        try {
+          const result = await api.image.post({
+            externaluid: illustration.externaluid,
+            externalmods: { ai: true },
+          })
+          if (result && typeof result.id === 'number') {
+            realId = result.id
+          }
+        } catch (e) {
+          console.error('Failed to pre-create AI illustration attachment:', e)
+        }
+
+        composeStore.setAttachmentsForMessage(messageId, [
+          ...filteredAtts,
+          {
+            id: realId, // numeric (or null if POST failed — createDraft handles this)
+            path: illustration.url,
+            paththumb: illustration.url,
+            ouruid: illustration.externaluid,
+            externalmods: { ai: true },
+            isAiIllustration: true,
+          },
+        ])
+      }
+    }
+  } catch (e) {
+    console.log('Failed to fetch AI illustration:', e.message)
+  } finally {
+    fetchingIllustration.value = false
+  }
+}

--- a/iznik-nuxt3/pages/give/mobile/details.vue
+++ b/iznik-nuxt3/pages/give/mobile/details.vue
@@ -114,6 +114,7 @@ import { useMiscStore } from '~/stores/misc'
 import NumberIncrementDecrement from '~/components/NumberIncrementDecrement'
 import OurUploadedImage from '~/components/OurUploadedImage'
 import api from '~/api'
+import { fetchAiIllustration as fetchAiIllustrationImpl } from '~/composables/useAiIllustration'
 
 const router = useRouter()
 const runtimeConfig = useRuntimeConfig()
@@ -253,66 +254,19 @@ function editPhotos() {
 const fetchingIllustration = ref(false)
 const lastFetchedItem = ref(null)
 
-// Watch item changes to fetch AI illustration when field loses focus
-// We track the last item we fetched for to avoid refetching
+// Fetch AI illustration when the item name is available and no real photo exists.
+// Delegates to the testable useAiIllustration composable which immediately calls
+// POST /image to obtain a real numeric server-side id — never a synthetic string.
 async function fetchAiIllustration(itemName) {
-  if (!itemName || !itemName.trim()) return
-
-  const trimmedItem = itemName.trim()
-
-  // Only fetch if:
-  // 1. There are no real photos (excluding AI illustrations)
-  // 2. We haven't already fetched for this item name
-  // 3. We're not currently fetching
-  const realPhotos = attachments.value.filter(
-    (a) => !a.externalmods || a.externalmods.ai !== true
-  )
-
-  if (
-    realPhotos.length > 0 ||
-    fetchingIllustration.value ||
-    lastFetchedItem.value === trimmedItem
-  ) {
-    return
-  }
-
-  fetchingIllustration.value = true
-  lastFetchedItem.value = trimmedItem
-
-  try {
-    const illustration = await $api.message.getIllustration(trimmedItem)
-
-    if (illustration && illustration.externaluid) {
-      // Check again that no real photos were added while we were fetching
-      const currentRealPhotos = attachments.value.filter(
-        (a) => !a.externalmods || a.externalmods.ai !== true
-      )
-
-      if (currentRealPhotos.length === 0) {
-        // Remove any existing AI illustration first
-        const filteredAtts = attachments.value.filter(
-          (a) => !a.externalmods || a.externalmods.ai !== true
-        )
-
-        // Add the AI illustration
-        composeStore.setAttachmentsForMessage(messageId.value, [
-          ...filteredAtts,
-          {
-            id: 'ai-' + Date.now(),
-            path: illustration.url,
-            paththumb: illustration.url,
-            ouruid: illustration.externaluid,
-            externalmods: { ai: true },
-            isAiIllustration: true,
-          },
-        ])
-      }
-    }
-  } catch (e) {
-    console.log('Failed to fetch AI illustration:', e.message)
-  } finally {
-    fetchingIllustration.value = false
-  }
+  await fetchAiIllustrationImpl({
+    api: $api,
+    composeStore,
+    messageId: messageId.value,
+    itemName,
+    attachments: attachments.value,
+    fetchingIllustration,
+    lastFetchedItem,
+  })
 }
 
 // Watch for attachment removal to track AI declined

--- a/iznik-nuxt3/stores/compose.js
+++ b/iznik-nuxt3/stores/compose.js
@@ -77,24 +77,38 @@ export const useComposeStore = defineStore({
       // Extract the server attachment id from message.attachments.
       if (message.attachments) {
         const hasRealPhoto = message.attachments.some(
-          (a) => a.id && typeof a.id === 'number' && !(a.externalmods && a.externalmods.ai)
+          (a) =>
+            a.id &&
+            typeof a.id === 'number' &&
+            !(a.externalmods && a.externalmods.ai)
         )
 
         for (const attachment of message.attachments) {
-          // AI illustrations need to be converted to real server-side attachments,
+          // AI illustrations need to be included as real server-side attachments,
           // but are suppressed when the user has uploaded their own real photo.
           if (attachment.externalmods && attachment.externalmods.ai) {
-            if (!hasRealPhoto && attachment.ouruid) {
-              try {
-                const result = await this.$api.image.post({
-                  externaluid: attachment.ouruid,
-                  externalmods: { ai: true },
-                })
-                if (result.id) {
-                  attids.push(result.id)
+            if (!hasRealPhoto) {
+              if (typeof attachment.id === 'number') {
+                // details.vue already called POST /image to get a real numeric id.
+                // Use it directly — don't call image.post() again.
+                attids.push(attachment.id)
+              } else if (attachment.ouruid) {
+                // Fallback: materialise the attachment now (e.g. POST /image failed
+                // earlier, or an older client stored ouruid without a real id).
+                try {
+                  const result = await this.$api.image.post({
+                    externaluid: attachment.ouruid,
+                    externalmods: { ai: true },
+                  })
+                  if (result.id) {
+                    attids.push(result.id)
+                  }
+                } catch (e) {
+                  console.error(
+                    'Failed to create AI illustration attachment:',
+                    e
+                  )
                 }
-              } catch (e) {
-                console.error('Failed to create AI illustration attachment:', e)
               }
             }
             continue
@@ -404,7 +418,31 @@ export const useComposeStore = defineStore({
 
               for (const att in message.attachments) {
                 const attachment = message.attachments[att]
-                if (attachment.externalmods && attachment.externalmods.ai && hasRealPhoto) {
+                if (attachment.externalmods && attachment.externalmods.ai) {
+                  // AI illustrations: include only when there is no real user photo.
+                  if (!hasRealPhoto) {
+                    if (typeof attachment.id === 'number') {
+                      // Already a real server-side id — use it directly.
+                      attids.push(attachment.id)
+                    } else if (attachment.ouruid) {
+                      // Materialise the attachment via POST /image so the PATCH
+                      // receives a valid uint64 id (never a synthetic 'ai-...' string).
+                      try {
+                        const result = await this.$api.image.post({
+                          externaluid: attachment.ouruid,
+                          externalmods: { ai: true },
+                        })
+                        if (result.id) {
+                          attids.push(result.id)
+                        }
+                      } catch (e) {
+                        console.error(
+                          'Failed to create AI illustration attachment:',
+                          e
+                        )
+                      }
+                    }
+                  }
                   continue
                 }
                 if (attachment.id && typeof attachment.id === 'number') {

--- a/iznik-nuxt3/tests/unit/composables/useAiIllustration.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useAiIllustration.spec.js
@@ -1,0 +1,209 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ref } from 'vue'
+import { fetchAiIllustration } from '~/composables/useAiIllustration'
+
+// ---------------------------------------------------------------------------
+// Regression: give/mobile/details.vue used to store AI illustrations with a
+// synthetic string id ('ai-' + Date.now()).  The Go API declares
+// Attachments []uint64, so any string in that array causes HTTP 400 and
+// traps the user in a permanent retry loop.
+//
+// Fix: fetchAiIllustration now calls POST /image immediately to get a real
+// numeric server-side id, and stores that numeric id on the attachment.
+// createDraft in compose.js uses the numeric id directly (no second POST).
+// ---------------------------------------------------------------------------
+
+const mockGetIllustration = vi.fn()
+const mockImagePost = vi.fn()
+const mockSetAttachmentsForMessage = vi.fn()
+
+const fakeApi = {
+  message: { getIllustration: mockGetIllustration },
+  image: { post: mockImagePost },
+}
+
+const fakeComposeStore = {
+  setAttachmentsForMessage: mockSetAttachmentsForMessage,
+}
+
+function makeRefs() {
+  return {
+    fetchingIllustration: ref(false),
+    lastFetchedItem: ref(null),
+  }
+}
+
+describe('fetchAiIllustration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('calls image.post() to get a real numeric id and stores it on the attachment', async () => {
+    mockGetIllustration.mockResolvedValue({
+      externaluid: 'uid-abc-123',
+      url: 'https://images.example.com/uid-abc-123',
+    })
+    mockImagePost.mockResolvedValue({ id: 42 })
+
+    const { fetchingIllustration, lastFetchedItem } = makeRefs()
+    await fetchAiIllustration({
+      api: fakeApi,
+      composeStore: fakeComposeStore,
+      messageId: 0,
+      itemName: 'sofa',
+      attachments: [],
+      fetchingIllustration,
+      lastFetchedItem,
+    })
+
+    // image.post() must be called with the externaluid from the illustration
+    expect(mockImagePost).toHaveBeenCalledWith({
+      externaluid: 'uid-abc-123',
+      externalmods: { ai: true },
+    })
+
+    // The attachment stored in the compose store must have a real numeric id
+    expect(mockSetAttachmentsForMessage).toHaveBeenCalledOnce()
+    const [, storedAtts] = mockSetAttachmentsForMessage.mock.calls[0]
+    expect(storedAtts).toHaveLength(1)
+    const att = storedAtts[0]
+    expect(att.id).toBe(42)
+    expect(typeof att.id).toBe('number')
+    expect(att.ouruid).toBe('uid-abc-123')
+    expect(att.externalmods).toEqual({ ai: true })
+    expect(att.isAiIllustration).toBe(true)
+  })
+
+  it('stores null id (not a synthetic string) when image.post() fails, so createDraft can retry', async () => {
+    mockGetIllustration.mockResolvedValue({
+      externaluid: 'uid-abc-123',
+      url: 'https://images.example.com/uid-abc-123',
+    })
+    mockImagePost.mockRejectedValue(new Error('network error'))
+
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { fetchingIllustration, lastFetchedItem } = makeRefs()
+
+    await fetchAiIllustration({
+      api: fakeApi,
+      composeStore: fakeComposeStore,
+      messageId: 0,
+      itemName: 'sofa',
+      attachments: [],
+      fetchingIllustration,
+      lastFetchedItem,
+    })
+
+    // The attachment is still stored (so createDraft can retry via ouruid)
+    expect(mockSetAttachmentsForMessage).toHaveBeenCalledOnce()
+    const [, storedAtts] = mockSetAttachmentsForMessage.mock.calls[0]
+    const att = storedAtts[0]
+
+    // id must be null — never a synthetic 'ai-...' string
+    expect(att.id).toBeNull()
+    // ouruid is preserved so createDraft can fall back to image.post()
+    expect(att.ouruid).toBe('uid-abc-123')
+
+    errSpy.mockRestore()
+  })
+
+  it('does not store a synthetic ai- string id under any circumstance', async () => {
+    mockGetIllustration.mockResolvedValue({
+      externaluid: 'uid-xyz',
+      url: 'https://images.example.com/uid-xyz',
+    })
+    mockImagePost.mockResolvedValue({ id: 77 })
+
+    const { fetchingIllustration, lastFetchedItem } = makeRefs()
+    await fetchAiIllustration({
+      api: fakeApi,
+      composeStore: fakeComposeStore,
+      messageId: 0,
+      itemName: 'table',
+      attachments: [],
+      fetchingIllustration,
+      lastFetchedItem,
+    })
+
+    const [, storedAtts] = mockSetAttachmentsForMessage.mock.calls[0]
+    storedAtts.forEach((att) => {
+      // id must never be a string (the Go API only accepts uint64)
+      if (att.id !== null && att.id !== undefined) {
+        expect(typeof att.id).toBe('number')
+      }
+      // Specifically, no 'ai-...' prefix strings
+      expect(typeof att.id === 'string' && att.id.startsWith('ai-')).toBe(false)
+    })
+  })
+
+  it('does not fetch when a real photo is already present', async () => {
+    const { fetchingIllustration, lastFetchedItem } = makeRefs()
+    await fetchAiIllustration({
+      api: fakeApi,
+      composeStore: fakeComposeStore,
+      messageId: 0,
+      itemName: 'sofa',
+      attachments: [{ id: 10, path: 'photo.jpg' }], // real photo present
+      fetchingIllustration,
+      lastFetchedItem,
+    })
+
+    expect(mockGetIllustration).not.toHaveBeenCalled()
+    expect(mockSetAttachmentsForMessage).not.toHaveBeenCalled()
+  })
+
+  it('does not fetch when already fetching', async () => {
+    const { fetchingIllustration, lastFetchedItem } = makeRefs()
+    fetchingIllustration.value = true
+
+    await fetchAiIllustration({
+      api: fakeApi,
+      composeStore: fakeComposeStore,
+      messageId: 0,
+      itemName: 'sofa',
+      attachments: [],
+      fetchingIllustration,
+      lastFetchedItem,
+    })
+
+    expect(mockGetIllustration).not.toHaveBeenCalled()
+  })
+
+  it('does not re-fetch when the same item was already fetched', async () => {
+    const { fetchingIllustration, lastFetchedItem } = makeRefs()
+    lastFetchedItem.value = 'sofa'
+
+    await fetchAiIllustration({
+      api: fakeApi,
+      composeStore: fakeComposeStore,
+      messageId: 0,
+      itemName: 'sofa',
+      attachments: [],
+      fetchingIllustration,
+      lastFetchedItem,
+    })
+
+    expect(mockGetIllustration).not.toHaveBeenCalled()
+  })
+
+  it('resets fetchingIllustration to false after completion', async () => {
+    mockGetIllustration.mockResolvedValue({
+      externaluid: 'uid-abc',
+      url: 'https://images.example.com/uid-abc',
+    })
+    mockImagePost.mockResolvedValue({ id: 1 })
+
+    const { fetchingIllustration, lastFetchedItem } = makeRefs()
+    await fetchAiIllustration({
+      api: fakeApi,
+      composeStore: fakeComposeStore,
+      messageId: 0,
+      itemName: 'sofa',
+      attachments: [],
+      fetchingIllustration,
+      lastFetchedItem,
+    })
+
+    expect(fetchingIllustration.value).toBe(false)
+  })
+})

--- a/iznik-nuxt3/tests/unit/stores/compose.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/compose.spec.js
@@ -697,9 +697,7 @@ describe('compose store', () => {
       mockImagePost.mockResolvedValue({ id: 77 })
       mockMessagePut.mockResolvedValue({ id: 99 })
       const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-      const errSpy = vi
-        .spyOn(console, 'error')
-        .mockImplementation(() => {})
+      const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
       await store.createDraft(
         {
@@ -767,6 +765,94 @@ describe('compose store', () => {
       expect(patchArgs.attachments).toEqual([5])
 
       logSpy.mockRestore()
+    })
+  })
+
+  describe('AI illustration preserved in repost path (no real photo)', () => {
+    it('converts AI illustration to real attachment via image.post() when reposting with no real photo', async () => {
+      // Regression: repost path (message.repostof set) silently drops AI illustrations
+      // when there is no real user photo. The PATCH payload ends up with no attachments,
+      // so the AI image is permanently lost. The fix: call image.post(ouruid) in the
+      // repost path, just as createDraft already does.
+      const store = useComposeStore()
+      store.init({ public: {} })
+      store.postcode = { id: 123 }
+      store.email = 'test@example.com'
+      store.group = 10
+
+      store.messages = [
+        {
+          id: 0,
+          type: 'Offer',
+          item: 'Old sofa',
+          submitted: false,
+          repostof: 99,
+          attachments: [
+            {
+              id: null,
+              ouruid: 'ai-uid-xyz',
+              externalmods: { ai: true },
+              isAiIllustration: true,
+            },
+          ],
+        },
+      ]
+
+      mockImagePost.mockResolvedValue({ id: 88 })
+      mockMessageUpdate.mockResolvedValue({})
+      mockMessagePatch.mockResolvedValue({})
+      mockJoinAndPost.mockResolvedValue({ groupid: 10 })
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+      await store.submit({ type: 'Offer' })
+
+      // image.post() must be called to create a real server-side attachment
+      expect(mockImagePost).toHaveBeenCalledWith({
+        externaluid: 'ai-uid-xyz',
+        externalmods: { ai: true },
+      })
+      // The resulting real numeric id must appear in the PATCH payload
+      const patchArgs = mockMessagePatch.mock.calls[0][0]
+      expect(patchArgs.attachments).toContain(88)
+      // No non-numeric strings in attachments
+      patchArgs.attachments.forEach((id) => {
+        expect(typeof id).toBe('number')
+      })
+
+      logSpy.mockRestore()
+    })
+
+    it('uses pre-created numeric id directly when AI attachment already has one (no double image.post())', async () => {
+      // When details.vue calls image.post() eagerly and stores the real numeric id,
+      // createDraft should use that id directly without calling image.post() again.
+      const store = useComposeStore()
+      store.init({ public: {} })
+      store.postcode = { id: 123 }
+      store.group = 10
+      mockMessagePut.mockResolvedValue({ id: 99 })
+
+      await store.createDraft(
+        {
+          type: 'Offer',
+          item: 'Test',
+          attachments: [
+            {
+              id: 55, // real numeric id already created by details.vue
+              ouruid: 'abc123',
+              externalmods: { ai: true },
+              isAiIllustration: true,
+            },
+          ],
+        },
+        'test@example.com'
+      )
+
+      // image.post() must NOT be called again (would double-create the attachment)
+      expect(mockImagePost).not.toHaveBeenCalled()
+      // The existing numeric id must be in the PUT payload
+      expect(mockMessagePut).toHaveBeenCalledWith(
+        expect.objectContaining({ attachments: [55] })
+      )
     })
   })
 })


### PR DESCRIPTION
## Summary

- **Root cause**: When a member posted without a photo, the mobile give flow auto-fetched an AI illustration and stored it with a synthetic string id (`'ai-' + Date.now()`). The Go API declares `Attachments []uint64`; `BodyParser` rejects any non-numeric string → HTTP 400 → permanent retry loop trapping the member.
- **Fix (primary)**: `composables/useAiIllustration.js` (new) calls `POST /image` immediately on AI illustration fetch, storing a real numeric server-side id on the attachment. A synthetic string id is never written.
- **Fix (secondary)**: `compose.js` `createDraft` — when an AI attachment already has a numeric id from the pre-fetch, use it directly with no second `POST /image` call.
- **Fix (tertiary)**: `compose.js` repost path — was silently dropping AI-only attachments (no `image.post()` call). Now materialises them the same way as `createDraft`.
- **Refactor**: `details.vue` delegates AI illustration logic to the new composable (testable without Nuxt component runtime).

## Code Quality Review

- No synthetic ids are ever written to the compose store; the Go API will always see `uint64` values.
- `image.post()` failure is handled: id falls back to `null`, and `createDraft` retries via `ouruid`. The user is not blocked.
- No changes to the Go API (`Attachments []uint64` is unchanged).
- Existing ESLint + vitest pass (595 files, 12 857 tests).

## Future Improvements

- The `null`-id fallback path in `createDraft` could surface a UI spinner/error if `image.post()` fails a second time, rather than silently skipping the AI illustration. Low priority.

## Test Plan

- [x] 7 new unit tests in `tests/unit/composables/useAiIllustration.spec.js` — cover numeric id stored, `null` stored on POST failure (never synthetic string), early-return guards, `fetchingIllustration` reset.
- [x] 2 new unit tests in `tests/unit/stores/compose.spec.js` — repost path preserves AI illustration via `image.post()`; pre-created numeric id is used directly (no double POST).
- [x] All 595 vitest test files pass (12 857 tests).
- [ ] Manual: post on mobile give flow with no photo → confirm post succeeds and AI illustration appears in the posted message.
