### PR TITLE
fix(chitchat): cap image height to prevent jarring portrait photos on Safari/iPad

### DIFF
--- a/iznik-nuxt3/components/NewsMessage.vue
+++ b/iznik-nuxt3/components/NewsMessage.vue
@@ -160,6 +160,7 @@ function share() {
 .imgthumb,
 :deep(.imgthumb img) {
   width: 100%;
+  max-height: 400px;
   object-fit: cover;
 
   @include media-breakpoint-up(md) {


### PR DESCRIPTION
## Root Cause

`NewsMessage.vue` renders chitchat post images with `.imgthumb` CSS that set `width: 100%` (mobile) / `400px` (desktop) and `object-fit: cover`, but had **no `max-height`**. Without an explicit height constraint, `object-fit: cover` has no cropping effect — the `<img>` renders at its full natural aspect-ratio height. A tall portrait image (e.g. phone photo taken vertically) could render at 600–1000+px height, dominating the viewport and jarring the scroll experience.

Safari on iPad was specifically reported because it does not apply any platform-level image size clamping; the image renders at whatever the CSS dictates.

## Evidence

Testless: pure CSS defect. No JS logic is involved — the issue is solely that `max-height` was absent from the SCSS rule.

**Before** (`NewsMessage.vue` `.imgthumb` / `:deep(.imgthumb img)`):
```scss
width: 100%;
object-fit: cover;   /* no effect without a height constraint */
```

**After:**
```scss
width: 100%;
max-height: 400px;   /* caps portrait images */
object-fit: cover;   /* center-crops images taller than 400px */
```

Safari/iPad reasoning: `max-height` on `<img>` is well-supported in Safari (iOS 10+ / iPadOS). With `max-height: 400px` the `<img>` box is constrained; `object-fit: cover` then center-crops the image content within that box — matching the intended layout used for the `NuxtPicture` path which already passed `:height="400"` as an intrinsic hint.

## Fix

Added `max-height: 400px` to the `.imgthumb, :deep(.imgthumb img)` rule in `NewsMessage.vue`. One line change.

- Landscape photos: natural height < 400px → `max-height` does not fire, renders normally
- Portrait photos: natural height > 400px → capped at 400px, `object-fit: cover` center-crops ✓

## Other Call Sites

- `NewsAlert.vue` has `.imgthumb` with the same missing `max-height` — out of scope for this chitchat-specific bug report
- `NewsReply.vue` `.replyphoto` is fixed at 150px wide — too small to cause jarring
- `NewsStory.vue` `.story-image` floats at 200px — not a full-width chitchat image

## Test

Testless: pure CSS, no JS logic path. Rationale above.

Before: a portrait image in a chitchat post rendered at `width: 100%; height: auto` (e.g. ~800px tall on iPad viewport), causing jarring scroll experience.
After: same image capped at 400px height, center-cropped via `object-fit: cover`.

## Discourse
https://discourse.ilovefreegle.org/t/9749/3