### PR TITLE
test(email/volunteering): keep freegle.in donate short link (already whitelisted) + regression guard

### DIFF
--- a/iznik-batch/app/Mail/Volunteering/VolunteeringDigestMail.php
+++ b/iznik-batch/app/Mail/Volunteering/VolunteeringDigestMail.php
@@ -69,7 +69,10 @@ class VolunteeringDigestMail extends MjmlMailable
             'email'          => $this->recipientEmail,
             'jobAds'         => $jobAds,
             'jobsUrl'        => $this->trackedUrl("{$userSite}/jobs", 'jobs_link', 'jobs'),
-            'donateUrl'      => $this->trackedUrl("{$userSite}/donate", 'donate_link', 'donate'),
+            // Keep the freegle.in PayPal short link — it is whitelisted in the Go
+            // API's isValidRedirectURL (domain allow-list), so the tracked redirect
+            // resolves it correctly. Don't replace the short link with a full URL.
+            'donateUrl'      => $this->trackedUrl('https://freegle.in/paypal1510', 'donate_link', 'donate'),
         ]);
     }
 }

--- a/iznik-batch/app/Mail/Volunteering/VolunteeringDigestMail.php
+++ b/iznik-batch/app/Mail/Volunteering/VolunteeringDigestMail.php
@@ -69,7 +69,7 @@ class VolunteeringDigestMail extends MjmlMailable
             'email'          => $this->recipientEmail,
             'jobAds'         => $jobAds,
             'jobsUrl'        => $this->trackedUrl("{$userSite}/jobs", 'jobs_link', 'jobs'),
-            'donateUrl'      => $this->trackedUrl('https://freegle.in/paypal1510', 'donate_link', 'donate'),
+            'donateUrl'      => $this->trackedUrl("{$userSite}/donate", 'donate_link', 'donate'),
         ]);
     }
 }

--- a/iznik-batch/tests/Unit/Mail/VolunteeringDigestMailTest.php
+++ b/iznik-batch/tests/Unit/Mail/VolunteeringDigestMailTest.php
@@ -71,6 +71,70 @@ class VolunteeringDigestMailTest extends TestCase
             'Unsubscribe URL must appear correctly in the footer');
     }
 
+    private function makeJobAd(int $id = 1): object
+    {
+        return (object)[
+            'id'        => $id,
+            'title'     => 'Test Volunteer Co-ordinator',
+            'location'  => 'Testville',
+            'image_url' => null,
+        ];
+    }
+
+    /**
+     * Decode the donate button's destination URL from rendered HTML.
+     * The button href is a tracking redirect: /e/d/r/<id>?url=<base64>&p=donate_link
+     * Falls back to a raw href containing /donate if tracking is inactive.
+     */
+    private function extractDonateDestination(string $html): ?string
+    {
+        // Primary: find tracking redirect URL whose p= param is donate_link
+        if (preg_match_all('/href=["\']([^"\']*\/e\/d\/r\/[^"\']*)["\']/', $html, $matches)) {
+            foreach ($matches[1] as $href) {
+                $decoded = html_entity_decode($href);
+                if (str_contains($decoded, 'donate_link') &&
+                    preg_match('/[?&]url=([^&"\']+)/', $decoded, $urlMatch)) {
+                    $dest = base64_decode($urlMatch[1]);
+                    if ($dest !== false) {
+                        return $dest;
+                    }
+                }
+            }
+        }
+        // Fallback: raw /donate href (when tracking is null)
+        if (preg_match('/href=["\']([^"\']*\/donate[^"\']*)["\']/', $html, $match)) {
+            return html_entity_decode($match[1]);
+        }
+        return null;
+    }
+
+    public function test_donate_url_in_job_ads_section_uses_user_site_not_freegle_in(): void
+    {
+        $userSite = config('freegle.sites.user');
+
+        $mail = new VolunteeringDigestMail(
+            recipientEmail: 'test@example.com',
+            groupName:      'Testville Freegle',
+            volunteerings:  [$this->makeVolunteering(1)],
+            unsubscribeUrl: "{$userSite}/unsubscribe?email=" . urlencode('test@example.com'),
+            jobAds:         collect([$this->makeJobAd(99)]),
+        );
+
+        $html = $mail->render();
+
+        $this->assertStringContainsString('Donating helps too!', $html,
+            'Job ads section with Donating helps too! button should be present');
+
+        $donateDest = $this->extractDonateDestination($html);
+
+        $this->assertNotNull($donateDest,
+            '"Donating helps too!" button destination URL not found in rendered email');
+        $this->assertStringNotContainsString('freegle.in', $donateDest,
+            '"Donating helps too!" must not use freegle.in/paypal1510 — that URL fails the Go API isValidRedirectURL check and redirects users to the homepage instead of the donate page');
+        $this->assertStringContainsString('/donate', $donateDest,
+            '"Donating helps too!" must link to the Freegle donate page');
+    }
+
     public function test_service_builds_volunteering_url_without_doubled_https(): void
     {
         // Regression guard: ensure the URL key in the volData array passed to

--- a/iznik-batch/tests/Unit/Mail/VolunteeringDigestMailTest.php
+++ b/iznik-batch/tests/Unit/Mail/VolunteeringDigestMailTest.php
@@ -101,15 +101,20 @@ class VolunteeringDigestMailTest extends TestCase
                 }
             }
         }
-        // Fallback: raw /donate href (when tracking is null)
-        if (preg_match('/href=["\']([^"\']*\/donate[^"\']*)["\']/', $html, $match)) {
+        // Fallback: raw freegle.in short link href (when tracking is null)
+        if (preg_match('/href=["\']([^"\']*freegle\.in[^"\']*)["\']/', $html, $match)) {
             return html_entity_decode($match[1]);
         }
         return null;
     }
 
-    public function test_donate_url_in_job_ads_section_uses_user_site_not_freegle_in(): void
+    public function test_donate_url_in_job_ads_section_uses_freegle_in_short_link(): void
     {
+        // The "Donating helps too!" button must keep the freegle.in/paypal1510
+        // PayPal short link. freegle.in is whitelisted in the Go API's
+        // isValidRedirectURL allow-list, so the tracked redirect resolves the
+        // short link correctly. The short link must NOT be rewritten to a full
+        // /donate URL — short links are intentional and supported.
         $userSite = config('freegle.sites.user');
 
         $mail = new VolunteeringDigestMail(
@@ -129,10 +134,8 @@ class VolunteeringDigestMailTest extends TestCase
 
         $this->assertNotNull($donateDest,
             '"Donating helps too!" button destination URL not found in rendered email');
-        $this->assertStringNotContainsString('freegle.in', $donateDest,
-            '"Donating helps too!" must not use freegle.in/paypal1510 — that URL fails the Go API isValidRedirectURL check and redirects users to the homepage instead of the donate page');
-        $this->assertStringContainsString('/donate', $donateDest,
-            '"Donating helps too!" must link to the Freegle donate page');
+        $this->assertStringContainsString('freegle.in/paypal1510', $donateDest,
+            '"Donating helps too!" must use the freegle.in/paypal1510 PayPal short link (whitelisted in isValidRedirectURL); it must not be replaced with a full URL');
     }
 
     public function test_service_builds_volunteering_url_without_doubled_https(): void


### PR DESCRIPTION
## Summary

The "Donating helps too!" button in volunteering digest emails uses the PayPal short link `https://freegle.in/paypal1510`. That short link already works: `freegle.in` is in the Go API's `isValidRedirectURL` domain allow-list (`iznik-server-go/emailtracking/emailtracking.go`), with a covering test in `emailtracking_coverage_test.go`. So the tracked redirect resolves the short link correctly — it does **not** fall through to the homepage.

This PR keeps the short link and adds a regression guard so it is not replaced with a full URL in future. (An earlier revision of this PR replaced the short link with `www.ilovefreegle.org/donate`; that has been reverted — short links are intentional and supported.)

## Changes

- **`VolunteeringDigestMail.php`** — keep the `freegle.in/paypal1510` donate short link (value unchanged vs master); add a comment noting it is whitelisted in `isValidRedirectURL`.
- **`VolunteeringDigestMailTest.php`** — regression test asserting the "Donating helps too!" button keeps the `freegle.in/paypal1510` short link (rather than being rewritten to a full URL).

## Test Plan

- `VolunteeringDigestMailTest::test_donate_url_in_job_ads_section_uses_freegle_in_short_link` renders the volunteering email with job ads, decodes the donate button's base64 destination from the tracking redirect, and asserts it contains `freegle.in/paypal1510`.

## Discourse

https://discourse.ilovefreegle.org/t/9692/7