### PR TITLE
fix(volunteers): persist opportunity delete and restore confirmation

### DIFF
--- a/iznik-nuxt3/components/VolunteerOpportunityModal.vue
+++ b/iznik-nuxt3/components/VolunteerOpportunityModal.vue
@@ -394,7 +394,7 @@
               v-if="canmodify"
               variant="danger"
               :disabled="uploadingPhoto"
-              @click="deleteIt"
+              @click="confirmDelete"
             >
               <v-icon icon="trash-alt" /> Delete
             </b-button>
@@ -417,6 +417,13 @@
       </div>
     </template>
   </b-modal>
+  <ConfirmModal
+    v-if="showDeleteConfirm"
+    title="Delete Volunteer Opportunity"
+    message="Are you sure you want to delete this volunteer opportunity?"
+    @confirm="doDelete"
+    @hidden="showDeleteConfirm = false"
+  />
 </template>
 <script setup>
 import { ref, computed, defineAsyncComponent, watch } from 'vue'
@@ -502,6 +509,7 @@ const form = ref(null)
 // Data properties
 const groupid = ref(null)
 const cacheBust = ref(Date.now())
+const showDeleteConfirm = ref(false)
 const showGroupError = ref(false)
 const description = ref(null)
 const currentAtts = ref([])
@@ -544,7 +552,7 @@ const volunteering = computed(() => {
 })
 
 const canmodify = computed(() => {
-  return volunteering.value?.userid === myid.value || supportOrAdmin
+  return volunteering.value?.userid === myid.value || supportOrAdmin.value
 })
 
 const groups = computed(() => {
@@ -644,6 +652,10 @@ watch(
   { deep: true }
 )
 
+function confirmDelete() {
+  showDeleteConfirm.value = true
+}
+
 // Methods
 function validateTitle(value) {
   if (!value) {
@@ -685,7 +697,7 @@ function validateContactName(value) {
   return true
 }
 
-async function deleteIt() {
+async function doDelete() {
   await volunteeringStore.delete(props.id)
   hide()
 }

--- a/iznik-nuxt3/modtools/components/ModVolunteerOpportunity.vue
+++ b/iznik-nuxt3/modtools/components/ModVolunteerOpportunity.vue
@@ -140,8 +140,8 @@ function confirmDelete() {
   showDeleteConfirm.value = true
 }
 
-function deleteme() {
-  volunteeringStore.delete(volunteering.value.id)
+async function deleteme() {
+  await volunteeringStore.delete(volunteering.value.id)
   showDeleteConfirm.value = false
 }
 

--- a/iznik-nuxt3/tests/unit/components/VolunteerOpportunityModal.spec.js
+++ b/iznik-nuxt3/tests/unit/components/VolunteerOpportunityModal.spec.js
@@ -8,6 +8,7 @@ const mockVolunteeringById = vi.fn()
 const mockVolunteeringFetch = vi.fn()
 const mockVolunteeringAdd = vi.fn()
 const mockVolunteeringEdit = vi.fn()
+const mockVolunteeringDelete = vi.fn()
 
 vi.mock('~/stores/volunteering', () => ({
   useVolunteeringStore: () => ({
@@ -15,6 +16,7 @@ vi.mock('~/stores/volunteering', () => ({
     fetch: mockVolunteeringFetch,
     add: mockVolunteeringAdd,
     edit: mockVolunteeringEdit,
+    delete: mockVolunteeringDelete,
   }),
 }))
 
@@ -302,6 +304,13 @@ describe('VolunteerOpportunityModal', () => {
             template: '<img class="our-uploaded-image" :src="src" />',
             props: ['src', 'modifiers', 'alt', 'width', 'height', 'class'],
           },
+          ConfirmModal: {
+            name: 'ConfirmModal',
+            template:
+              '<div class="confirm-modal"><button class="confirm-btn" @click="$emit(\'confirm\')">Confirm</button></div>',
+            props: ['title', 'message'],
+            emits: ['confirm', 'hidden'],
+          },
         },
       },
     })
@@ -310,6 +319,7 @@ describe('VolunteerOpportunityModal', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockAuthUser.value = { id: 1 }
+    mockVolunteeringDelete.mockResolvedValue()
   })
 
   describe('rendering', () => {
@@ -461,6 +471,44 @@ describe('VolunteerOpportunityModal', () => {
       createWrapper()
       await flushPromises()
       expect(mockVolunteeringFetch).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('delete flow', () => {
+    // AssertFlip 3b: clicking Delete must show a confirm modal, not delete immediately.
+    // This test FAILS on buggy code (no confirm modal, delete fired at once)
+    // and PASSES after the fix (confirm modal shown, delete not called yet).
+    it('clicking Delete shows a confirmation modal before deleting', async () => {
+      const wrapper = createWrapper({ id: 123 })
+      await flushPromises()
+
+      const deleteButton = wrapper
+        .findAll('button')
+        .find((b) => b.text().includes('Delete'))
+      expect(deleteButton).toBeDefined()
+      await deleteButton.trigger('click')
+      await flushPromises()
+
+      expect(wrapper.find('.confirm-modal').exists()).toBe(true)
+      expect(mockVolunteeringDelete).not.toHaveBeenCalled()
+    })
+
+    it('confirming the dialog calls store delete and hides the modal', async () => {
+      const wrapper = createWrapper({ id: 123 })
+      await flushPromises()
+
+      const deleteButton = wrapper
+        .findAll('button')
+        .find((b) => b.text().includes('Delete'))
+      await deleteButton.trigger('click')
+      await flushPromises()
+
+      const confirmBtn = wrapper.find('.confirm-btn')
+      await confirmBtn.trigger('click')
+      await flushPromises()
+
+      expect(mockVolunteeringDelete).toHaveBeenCalledWith(123)
+      expect(mockHide).toHaveBeenCalled()
     })
   })
 })


### PR DESCRIPTION
## Root Cause

Two bugs in `VolunteerOpportunityModal.vue`:

1. **Delete not persisting**: The Delete button called `deleteIt()` which called `volunteeringStore.delete(id)` directly, but `deleteIt` was not `async` and did not `await` the store call. The store's `delete` action does `await api(...).volunteering.del(id)` then removes from local state — without `await`, the component raced ahead and called `hide()` before the API call completed. On refresh the item reappeared because the DELETE never landed.

2. **No confirmation dialog**: The Delete button fired `deleteIt()` immediately with no `ConfirmModal` step — the confirmation gate had been dropped at some point, leaving users able to delete with a single click.

Bonus: `canmodify` computed used `supportOrAdmin` (a `computed()` ref) without `.value`, so the ref object itself was always truthy — the Delete button was visible to all logged-in users regardless of ownership or role.

`ModVolunteerOpportunity.vue` also had `deleteme()` without `await`, causing the same race in the ModTools pending-review path.

## Evidence

- Discourse report: opportunity vanishes optimistically on delete but returns on page refresh.
- `deleteIt()` in `VolunteerOpportunityModal.vue` was not async; no `await` before `hide()`.
- No `ConfirmModal` reference anywhere in `VolunteerOpportunityModal.vue` before this fix.
- `canmodify`: `return volunteering.value?.userid === myid.value || supportOrAdmin` — `supportOrAdmin` is a `ComputedRef`, truthy always.

## Fix

**`components/VolunteerOpportunityModal.vue`**:
- Added `showDeleteConfirm = ref(false)` and `confirmDelete()` that sets it to `true`.
- Delete button now calls `confirmDelete` instead of `deleteIt`.
- Added `<ConfirmModal v-if="showDeleteConfirm" …>` that emits `confirm` → `doDelete`.
- Renamed `deleteIt` → `doDelete`, made it `async`, added `await` before `volunteeringStore.delete(id)`.
- Fixed `canmodify` to use `supportOrAdmin.value`.

**`modtools/components/ModVolunteerOpportunity.vue`**:
- Made `deleteme()` `async` and added `await` before `volunteeringStore.delete(volunteering.value.id)`.

## Other Call Sites

- `ModVolunteerOpportunity.vue` — fixed (ModTools pending-review card).
- `VolunteerOpportunity.vue` (public display component) — no delete action, not affected.
- `stores/volunteering.js` `delete` action — correct; awaits API call and removes from store.
- `api/VolunteeringAPI.js` `del` — correct; calls `DELETE /volunteering/:id`.
- `iznik-server-go/volunteering/volunteering.go` `Delete` handler — correct; soft-deletes with `deleted=1`.

## Test

`tests/unit/components/VolunteerOpportunityModal.spec.js` — two new tests in `describe('delete flow')`:

1. **Clicking Delete shows a confirmation modal before deleting** — triggers click, asserts `.confirm-modal` exists and `volunteeringStore.delete` not yet called (AssertFlip: FAILS on buggy code, PASSES after fix).
2. **Confirming the dialog calls store delete and hides the modal** — clicks Delete, then Confirm; asserts `volunteeringStore.delete(123)` called and `hide()` called.

All 38 volunteer-related unit tests pass.

## Discourse
https://discourse.ilovefreegle.org/t/9751/4