### PR TITLE
test(member-management): regression tests for Group/Left log on account deletion (Discourse #9678 post 2)

### DIFF
--- a/iznik-server-go/test/user_test.go
+++ b/iznik-server-go/test/user_test.go
@@ -1867,6 +1867,56 @@ func TestPostUserUnsubscribeBySupportRemovesMembership(t *testing.T) {
 	assert.Equal(t, int64(1), logCount, "Unsubscribe must create a User/Deleted log entry")
 }
 
+// TestLimboUserLogsGroupLeft verifies that self-deleting an account (DELETE /user)
+// writes a Group/Left log entry for each group the user belonged to.
+// Regression guard for Discourse #9678 post 2: V1 parity requires per-group Left logs.
+func TestLimboUserLogsGroupLeft(t *testing.T) {
+	prefix := uniquePrefix("limbo_grplft")
+	db := database.DBConn
+
+	userID := CreateTestUser(t, prefix+"_user", "User")
+	_, token := CreateTestSession(t, userID)
+	groupID := CreateTestGroup(t, prefix)
+	CreateTestMembership(t, userID, groupID, "Member")
+
+	req := httptest.NewRequest("DELETE", "/api/user?jwt="+token, nil)
+	resp, err := getApp().Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var logCount int64
+	db.Raw("SELECT COUNT(*) FROM logs WHERE type = 'Group' AND subtype = 'Left' AND user = ? AND groupid = ?",
+		userID, groupID).Scan(&logCount)
+	assert.Equal(t, int64(1), logCount, "account deletion must log Group/Left for each group the user belonged to (V1 parity)")
+}
+
+// TestUnsubscribeLogsGroupLeft verifies that the Support-tools Unsubscribe action
+// also writes a Group/Left log entry per group (same softLimboUser path).
+// Regression guard for Discourse #9678 post 2.
+func TestUnsubscribeLogsGroupLeft(t *testing.T) {
+	prefix := uniquePrefix("unsub_grplft")
+	db := database.DBConn
+
+	supportID := CreateTestUser(t, prefix+"_support", "Support")
+	targetID := CreateTestUser(t, prefix+"_target", "User")
+	groupID := CreateTestGroup(t, prefix)
+	CreateTestMembership(t, targetID, groupID, "Member")
+	_, supportToken := CreateTestSession(t, supportID)
+
+	payload := map[string]interface{}{"action": "Unsubscribe", "id": targetID}
+	s, _ := json.Marshal(payload)
+	req := httptest.NewRequest("POST", "/api/user?jwt="+supportToken, bytes.NewBuffer(s))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := getApp().Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var logCount int64
+	db.Raw("SELECT COUNT(*) FROM logs WHERE type = 'Group' AND subtype = 'Left' AND user = ? AND groupid = ?",
+		targetID, groupID).Scan(&logCount)
+	assert.Equal(t, int64(1), logCount, "Unsubscribe must log Group/Left for each group the user belonged to (V1 parity)")
+}
+
 // TestPostUserUnsubscribeNonSupportForbidden verifies that a regular user cannot unsubscribe
 // another user via POST /user action=Unsubscribe.
 func TestPostUserUnsubscribeNonSupportForbidden(t *testing.T) {


### PR DESCRIPTION
## Summary

- Adds two regression tests to `user_test.go` verifying that `Group/Left` audit log entries are written for every group a user belonged to when their account is deleted or they are unsubscribed by Support
- These guard against regression of the fix introduced in PR #630 (`LogGroupLeftForApprovedMemberships`)

## Context

Discourse topic #9678 post 2 reported that a member who joined Newham, posted a Wanted, then left/deleted had the JOIN logged but not the DEPARTURE. The production fix (`softLimboUser` now calls `LogGroupLeftForApprovedMemberships` before the bulk membership delete) was shipped in PR #630. These tests add complementary regression guards in `user_test.go` covering:

1. **`TestLimboUserLogsGroupLeft`** — self-delete via `DELETE /user` writes `Group/Left` per group
2. **`TestUnsubscribeLogsGroupLeft`** — Support Unsubscribe via `POST /user action=Unsubscribe` writes `Group/Left` per group

Both were confirmed to **fail** on unfixed code and **pass** on fixed code (AssertFlip protocol). They complement `TestLimboUserWritesGroupLeftLogPerGroup` in `membership_audit_parity_test.go` with tests anchored to the original user delete flow.

## Test plan

- [x] `TestLimboUserLogsGroupLeft` — PASS
- [x] `TestUnsubscribeLogsGroupLeft` — PASS
- [x] `TestLimboUserWritesGroupLeftLogPerGroup` (existing) — PASS
- [x] Full Go test suite — 3049✓ 0✗

🤖 Generated with [Claude Code](https://claude.com/claude-code)