### PR TITLE
fix(auth): logout never deletes all sessions; scope by server-resolved series (#9748)

### DIFF
--- a/iznik-server-go/session/session.go
+++ b/iznik-server-go/session/session.go
@@ -1787,35 +1787,51 @@ func DeleteSession(c *fiber.Ctx) error {
 	if myid > 0 {
 		db := database.DBConn
 
-		// V1 parity (Session::destroy($userid, $series)): log out the current
-		// login SERIES, not all the user's sessions and not a single session row.
-		// Freegle and ModTools each get their own series at login, so deleting by
-		// series logs the user out of only the current app and leaves the other
-		// app logged in (Discourse #9748: logout was clearing both at once).
-		var series uint64
+		// Log out the current login SERIES only (Discourse #9748: logout was
+		// clearing every session, so logging out of Freegle also logged you out
+		// of ModTools and every other device). Freegle and ModTools each get
+		// their own random series at login, so deleting by series closes only the
+		// current app and leaves the other app logged in.
+		//
+		// Identify the current session ROW authoritatively, then resolve its
+		// series SERVER-SIDE. Do NOT trust a series value supplied by the client:
+		// a persistent token minted before the 53-bit series mask (or otherwise
+		// stale) can carry a 0 / wrong series, which previously dropped logout
+		// into a "delete everything" fallback — the actual cause of #9748 still
+		// failing. The session row id, by contrast, is a small stable integer
+		// that survives a JSON round-trip through the browser intact.
+		var sessionId uint64
 
-		// Persistent-token (Authorization2) carries the series directly.
-		if persistent := c.Get("Authorization2"); persistent != "" {
-			var pt auth.PersistentToken
-			if json.Unmarshal([]byte(persistent), &pt) == nil {
-				series = pt.Series
+		// Prefer the JWT (server-verified). It carries the session row id.
+		if _, sid, _ := user.GetJWTFromRequest(c); sid > 0 {
+			sessionId = sid
+		}
+
+		// Fall back to the persistent token's id (NOT its series).
+		if sessionId == 0 {
+			if persistent := c.Get("Authorization2"); persistent != "" {
+				var pt auth.PersistentToken
+				if json.Unmarshal([]byte(persistent), &pt) == nil {
+					sessionId = pt.ID
+				}
 			}
 		}
 
-		// JWT path: resolve the series from the session row the JWT identifies.
-		if series == 0 {
-			if _, sessionId, _ := user.GetJWTFromRequest(c); sessionId > 0 {
-				db.Raw("SELECT series FROM sessions WHERE id = ? AND userid = ?", sessionId, myid).Scan(&series)
-			}
+		var series uint64
+		if sessionId > 0 {
+			db.Raw("SELECT series FROM sessions WHERE id = ? AND userid = ?", sessionId, myid).Scan(&series)
 		}
 
 		if series > 0 {
+			// Close the whole current login series (all its tabs/token rotations).
 			db.Exec("DELETE FROM sessions WHERE userid = ? AND series = ?", myid, series)
-		} else {
-			// Series could not be determined - fall back to V1's null-series path
-			// (clear all the user's sessions) so logout never silently no-ops.
-			db.Exec("DELETE FROM sessions WHERE userid = ?", myid)
+		} else if sessionId > 0 {
+			// Series unavailable but the row is known — delete just that row.
+			db.Exec("DELETE FROM sessions WHERE id = ? AND userid = ?", sessionId, myid)
 		}
+		// If the current session cannot be identified at all, do NOT delete every
+		// session for the user. A logout that can't scope itself must no-op rather
+		// than evict the user from every device and app (Discourse #9748).
 	}
 
 	return c.JSON(fiber.Map{

--- a/iznik-server-go/test/session_test.go
+++ b/iznik-server-go/test/session_test.go
@@ -1079,6 +1079,48 @@ func TestDeleteSessionScopedToCurrentSeries(t *testing.T) {
 	assert.Equal(t, int64(1), count(idC), "other app session (series 2) must remain logged in")
 }
 
+// TestDeleteSessionNeverDeletesAllWhenSeriesUnresolvable is the regression test
+// for Discourse #9748 *still failing* after the first fix. When the current
+// session's series cannot be resolved to a non-zero value (e.g. a legacy/edge
+// session row stored with series 0, or a stale client token), the previous code
+// fell back to DELETE FROM sessions WHERE userid = ? — logging the user out of
+// EVERY app and device ("logging out of either Freegle or ModTools logs me out
+// of both everywhere"). Logout must instead scope to the current session row and
+// never evict the user's other logins.
+func TestDeleteSessionNeverDeletesAllWhenSeriesUnresolvable(t *testing.T) {
+	prefix := uniquePrefix("del_sess_zero")
+	userID := CreateTestUser(t, prefix, "User")
+	db := database.DBConn
+
+	mk := func(series uint64) uint64 {
+		db.Exec("INSERT INTO sessions (userid, series, token, date, lastactive) VALUES (?, ?, 1, NOW(), NOW())", userID, series)
+		var id uint64
+		db.Raw("SELECT id FROM sessions WHERE userid = ? ORDER BY id DESC LIMIT 1", userID).Scan(&id)
+		return id
+	}
+	// Current login's row has series 0 (series unresolvable); a separate app/device
+	// login has a normal series and must survive this logout.
+	idCurrent := mk(0)
+	idOther := mk(userID*1000 + 7)
+
+	token := GetToken(userID, idCurrent)
+	req := httptest.NewRequest("DELETE", "/api/session?jwt="+token, nil)
+	resp, err := getApp().Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	count := func(id uint64) int64 {
+		var n int64
+		db.Raw("SELECT COUNT(*) FROM sessions WHERE id = ?", id).Scan(&n)
+		return n
+	}
+	// The current session is logged out (by row id when its series is 0)...
+	assert.Equal(t, int64(0), count(idCurrent), "current session must be deleted")
+	// ...but the user's other login must NOT be cleared. The old delete-all
+	// fallback deleted this too — that was #9748 "logged out everywhere".
+	assert.Equal(t, int64(1), count(idOther), "other login must survive when current series is unresolvable")
+}
+
 // ---------------------------------------------------------------------------
 // POST /session - Forget
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Discourse #9748 ("Logging me out everywhere") was reported **still failing** after #611: *"logging out of either Freegle or ModTools in a browser logs me out of both everywhere."*

## Root cause

`DeleteSession` resolved the logout scope from a **client-supplied** series (the `Authorization2` persistent token) and, when it couldn't determine a series, fell back to:

```go
db.Exec("DELETE FROM sessions WHERE userid = ?", myid)   // deletes EVERY session
```

That fallback **is** the "logged out everywhere" behaviour. The series comes back unresolved in real conditions:
- a persistent token minted before the 53-bit series mask carries a stale/0 series;
- a session row stored with `series = 0`;
- the request arrives with only the persistent token and no JWT.

There is **no FD/MT flag** in the `sessions` table — the only per-login distinguisher is the random `series` — so once the series is lost, the old code had nothing to scope by and nuked everything.

## Fix

Identify the current session **row** authoritatively (JWT `sessionid`, else the persistent token's `id` — both stable small integers that survive a JSON round-trip), resolve its `series` **server-side**, then:

- `series > 0` → delete that login series only (Freegle vs ModTools stay separate)
- series unresolvable but row known → delete just that one row
- session cannot be identified at all → **no-op** (never delete every session)

This removes the delete-all fallback entirely, so logout can **never** evict the user from all devices/apps regardless of what the client sends — structurally preventing the #9748 symptom.

## Test

`TestDeleteSessionNeverDeletesAllWhenSeriesUnresolvable`: a user with a current session whose `series` is 0 plus a separate login. After logout, the current session is gone but the other login **survives**. Fails on the old delete-all fallback; passes now. (Existing `TestDeleteSessionScopedToCurrentSeries` still passes.)

## Discourse

https://discourse.ilovefreegle.org/t/9748