### PR TITLE
fix(chat): hold-for-review chain follows the previous message, not the newest (#9656)

### DIFF
--- a/iznik-batch/app/Services/ChatProcessService.php
+++ b/iznik-batch/app/Services/ChatProcessService.php
@@ -173,11 +173,20 @@ class ChatProcessService
                 }
             }
 
-            // If the previous message in this chat is held for review, hold this one too.
+            // If the PREVIOUS message in this chat is held for review, hold this
+            // one too. Use id < $id, not id != $id: V1's chat_process.php was a
+            // continuous daemon that processed each message as it arrived, so the
+            // newest other row WAS the previous one. This service processes in
+            // batches (processIncoming orders by id asc), so when a burst of
+            // messages is pending, "newest other row" is a LATER, not-yet-processed
+            // message (reviewrequired defaults to 0) and the hold chain silently
+            // breaks — subsequent messages from a member already under review get
+            // delivered (Discourse #9656). Looking strictly backwards at the
+            // immediately preceding (already-processed) message restores the chain.
             if (!$review) {
                 $lastReview = DB::table('chat_messages')
                     ->where('chatid', $chatid)
-                    ->where('id', '!=', $id)
+                    ->where('id', '<', $id)
                     ->orderByDesc('id')
                     ->value('reviewrequired');
 

--- a/iznik-batch/tests/Unit/Services/ChatProcessServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/ChatProcessServiceTest.php
@@ -265,6 +265,51 @@ class ChatProcessServiceTest extends TestCase
         $this->assertEquals(1, $updated->processingsuccessful);
     }
 
+    // Regression: Discourse #9656. Once a member has a message held for review,
+    // EVERY subsequent message must also be held until a mod clears them. V1's
+    // chat_process daemon processed one message at a time, so the hold chain
+    // propagated naturally. This service processes a whole burst at once, and the
+    // chain query previously looked at the newest OTHER row (id != $id) — which,
+    // mid-batch, is a later not-yet-processed message with reviewrequired = 0, so
+    // the chain broke and innocuous messages between worry-word ones were
+    // delivered. The chain must follow the immediately preceding message.
+    public function test_hold_chain_propagates_across_a_burst_of_messages(): void
+    {
+        $user1 = $this->createTestUser();
+        $user2 = $this->createTestUser();
+        $room = $this->createTestChatRoom($user1, $user2);
+
+        // An earlier message from user1 is already held for review.
+        $this->createTestChatMessage($room, $user1, [
+            'reviewrequired' => 1,
+            'processingrequired' => 0,
+            'processingsuccessful' => 1,
+        ]);
+
+        // Two further innocuous messages arrive in the SAME batch (both pending).
+        // The second has the higher id, so under the old id != $id query it is the
+        // "newest other row" seen while processing the first.
+        $first = $this->createTestChatMessage($room, $user1, [
+            'message' => 'innocuous one',
+            'processingrequired' => 1,
+            'processingsuccessful' => 0,
+            'platform' => 1,
+        ]);
+        $second = $this->createTestChatMessage($room, $user1, [
+            'message' => 'innocuous two',
+            'processingrequired' => 1,
+            'processingsuccessful' => 0,
+            'platform' => 1,
+        ]);
+
+        $this->service->processIncoming();
+
+        $u1 = DB::table('chat_messages')->where('id', $first->id)->first();
+        $u2 = DB::table('chat_messages')->where('id', $second->id)->first();
+        $this->assertEquals(1, $u1->reviewrequired, 'message after a held one must also be held');
+        $this->assertEquals(1, $u2->reviewrequired, 'hold chain must continue through the whole burst');
+    }
+
     // --- Content checks for Moderated members (regression: Discourse #9706) ---
     //
     // V1 ChatMessage::process() ran Spam::checkReview() on Moderated members'


### PR DESCRIPTION
## Summary

Discourse [#9656](https://discourse.ilovefreegle.org/t/chat-reviews/9656/48): once a member has a chat message held for review, **every subsequent message** should also be held until a moderator clears them. Neville reported that only the worry-word messages were held while innocuous messages in between were delivered ("massage 8 held but not message 7").

## Verified against live data

Production chat `20881499` (the reporter's test): the worry-word messages were held (`reviewrequired=1`, later mod-rejected → `reviewrejected=1, reviewedby=420`), but the innocuous messages between them were delivered (`reviewrequired=0`). Confirms the report.

## Root cause

The hold-chain query selected the **newest other** row in the chat:

```php
->where('id', '!=', $id)->orderByDesc('id')->value('reviewrequired')
```

V1's `chat_process.php` was a **continuous daemon** that processed each message as it arrived, so the newest other row genuinely was the *previous* message. This service processes pending messages in a **batch** (`processIncoming` orders by `id asc`). Mid-burst, the newest other row is a **later, not-yet-processed** message whose `reviewrequired` still defaults to `0`, so the chain read `0` and broke — every message after the first in a burst escaped the hold.

## Fix

Look strictly backwards at the immediately preceding (already-processed) message:

```php
->where('id', '<', $id)->orderByDesc('id')
```

This restores the daemon-era chain behaviour under batch processing. In a daemon both queries are equivalent; in a batch only `id < $id` is correct.

## Test

`test_hold_chain_propagates_across_a_burst_of_messages`: a held message plus two pending messages processed in one batch — both must end up held. Fails on `id != $id` (the first sees the later unprocessed message → 0), passes on `id < $id`. Existing `test_message_held_when_previous_message_under_review` still passes.

## Discourse

https://discourse.ilovefreegle.org/t/chat-reviews/9656/48