### PR TITLE
fix(ai-image): skip non-active illustrations in compose and batch (9753)

### DIFF
--- a/iznik-batch/app/Console/Commands/Message/GenerateIllustrationsCommand.php
+++ b/iznik-batch/app/Console/Commands/Message/GenerateIllustrationsCommand.php
@@ -37,9 +37,9 @@ class GenerateIllustrationsCommand extends Command
             $result = $service->processIllustrations($dryRun);
 
             if ($dryRun) {
-                $this->info("Illustrations: would clean {$result['cleaned']}, cache-hits {$result['cached_hits']}, would-fetch {$result['would_fetch']} (skipped — costs \$).");
+                $this->info("Illustrations: would clean {$result['cleaned']}, would remove non-active {$result['cleaned_non_active']}, cache-hits {$result['cached_hits']}, would-fetch {$result['would_fetch']} (skipped — costs \$).");
             } else {
-                $this->info("Illustrations: {$result['processed']} processed, {$result['cleaned']} cleaned up.");
+                $this->info("Illustrations: {$result['processed']} processed, {$result['cleaned']} cleaned up, {$result['cleaned_non_active']} non-active removed.");
                 Log::info('Message illustrations complete', $result);
             }
 

--- a/iznik-batch/app/Services/MessageIllustrationsService.php
+++ b/iznik-batch/app/Services/MessageIllustrationsService.php
@@ -117,6 +117,7 @@ class MessageIllustrationsService
                 $cached = DB::table('ai_images')
                     ->where('name', $itemName)
                     ->whereNotNull('externaluid')
+                    ->where('status', 'active')
                     ->value('externaluid');
 
                 if ($cached) {

--- a/iznik-batch/app/Services/MessageIllustrationsService.php
+++ b/iznik-batch/app/Services/MessageIllustrationsService.php
@@ -15,14 +15,39 @@ class MessageIllustrationsService
     /**
      * Generate AI illustrations for messages that have no attachments.
      *
-     * @return array{cleaned: int, processed: int, would_fetch: int, cached_hits: int}
+     * @return array{cleaned: int, cleaned_non_active: int, processed: int, would_fetch: int, cached_hits: int}
      */
     public function processIllustrations(bool $dryRun = false): array
     {
         $cleaned = $this->cleanupDuplicates($dryRun);
+        $cleanedNonActive = $this->cleanupNonActiveAttachments($dryRun);
         $batchStats = $this->processBatches($dryRun);
 
-        return ['cleaned' => $cleaned] + $batchStats;
+        return ['cleaned' => $cleaned, 'cleaned_non_active' => $cleanedNonActive] + $batchStats;
+    }
+
+    /**
+     * Remove AI illustration attachments from messages where the illustration has been
+     * suppressed or rejected. Without this, those messages show a ghost blank image slot
+     * because the message-serve query blanks the externaluid for non-active ai_images
+     * rows (topic 9753). Deleting the attachment makes the message look cleanly
+     * illustration-free instead.
+     */
+    private function cleanupNonActiveAttachments(bool $dryRun = false): int
+    {
+        $ids = DB::table('messages_attachments as ma')
+            ->join('ai_images as ai', 'ai.externaluid', '=', 'ma.externaluid')
+            ->whereRaw("JSON_EXTRACT(ma.externalmods, '$.ai') = TRUE")
+            ->whereIn('ai.status', ['suppressed', 'rejected'])
+            ->pluck('ma.id')
+            ->toArray();
+
+        if (!$dryRun && !empty($ids)) {
+            DB::table('messages_attachments')->whereIn('id', $ids)->delete();
+            Log::info('MessageIllustrations: removed ' . count($ids) . ' attachment(s) for suppressed/rejected illustrations');
+        }
+
+        return count($ids);
     }
 
     /**

--- a/iznik-batch/tests/Unit/Commands/Message/GenerateIllustrationsCommandTest.php
+++ b/iznik-batch/tests/Unit/Commands/Message/GenerateIllustrationsCommandTest.php
@@ -14,7 +14,7 @@ class GenerateIllustrationsCommandTest extends TestCase
         $service->expects($this->once())
             ->method('processIllustrations')
             ->with(true)
-            ->willReturn(['cleaned' => 0, 'cached_hits' => 0, 'would_fetch' => 0]);
+            ->willReturn(['cleaned' => 0, 'cleaned_non_active' => 0, 'cached_hits' => 0, 'would_fetch' => 0]);
 
         $this->app->instance(MessageIllustrationsService::class, $service);
 

--- a/iznik-batch/tests/Unit/Services/MessageIllustrationsServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/MessageIllustrationsServiceTest.php
@@ -170,4 +170,44 @@ class MessageIllustrationsServiceTest extends TestCase
         $lastArrival = DB::table('config')->where('key', 'illustrations_last_arrival')->value('value');
         $this->assertNotNull($lastArrival, 'Config should have last arrival set after processing');
     }
+
+    // AssertFlip: suppressed and rejected AI images must NOT be attached to messages.
+    // Without ->where('status', 'active') these tests fail (attachment is created),
+    // proving the bug. After the fix both tests pass.
+
+    public function test_does_not_attach_suppressed_illustration(): void
+    {
+        $message = $this->createMessageInSpatial('OFFER: Abstract Widget (TestTown)');
+
+        DB::table('ai_images')->insert([
+            'name' => 'Abstract Widget',
+            'externaluid' => 'freegletusd-suppressed001',
+            'imagehash' => 'hashsup001',
+            'status' => 'suppressed',
+        ]);
+
+        $service = $this->makeService();
+        $service->processIllustrations();
+
+        $count = DB::table('messages_attachments')->where('msgid', $message->id)->count();
+        $this->assertEquals(0, $count, 'Should not attach a suppressed AI illustration');
+    }
+
+    public function test_does_not_attach_rejected_illustration(): void
+    {
+        $message = $this->createMessageInSpatial('OFFER: Broken Lamp (TestTown)');
+
+        DB::table('ai_images')->insert([
+            'name' => 'Broken Lamp',
+            'externaluid' => 'freegletusd-rejected001',
+            'imagehash' => 'hashrej001',
+            'status' => 'rejected',
+        ]);
+
+        $service = $this->makeService();
+        $service->processIllustrations();
+
+        $count = DB::table('messages_attachments')->where('msgid', $message->id)->count();
+        $this->assertEquals(0, $count, 'Should not attach a rejected AI illustration');
+    }
 }

--- a/iznik-batch/tests/Unit/Services/MessageIllustrationsServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/MessageIllustrationsServiceTest.php
@@ -210,4 +210,96 @@ class MessageIllustrationsServiceTest extends TestCase
         $count = DB::table('messages_attachments')->where('msgid', $message->id)->count();
         $this->assertEquals(0, $count, 'Should not attach a rejected AI illustration');
     }
+
+    // AssertFlip: existing messages with suppressed/rejected AI attachments must have
+    // those attachments removed by cleanupNonActiveAttachments so that no ghost blank
+    // image slot is shown (topic 9753). Without the cleanup these tests fail (attachment
+    // remains), proving the bug. After the fix both tests pass.
+
+    public function test_removes_existing_suppressed_illustration_attachment(): void
+    {
+        $message = $this->createMessageInSpatial('OFFER: Voucher (TestTown)');
+
+        DB::table('ai_images')->insert([
+            'name'        => 'Voucher',
+            'externaluid' => 'freegletusd-sup-ghost001',
+            'imagehash'   => 'hashsupghost001',
+            'status'      => 'suppressed',
+        ]);
+
+        // Simulate an attachment created before the illustration was suppressed.
+        $attachId = DB::table('messages_attachments')->insertGetId([
+            'msgid'        => $message->id,
+            'externaluid'  => 'freegletusd-sup-ghost001',
+            'externalmods' => json_encode(['ai' => true]),
+            'contenttype'  => 'image/jpeg',
+        ]);
+
+        $service = $this->makeService();
+        $result = $service->processIllustrations();
+
+        $this->assertFalse(
+            DB::table('messages_attachments')->where('id', $attachId)->exists(),
+            'Suppressed illustration attachment must be removed to prevent ghost blank slot'
+        );
+        $this->assertGreaterThanOrEqual(1, $result['cleaned_non_active']);
+    }
+
+    public function test_removes_existing_rejected_illustration_attachment(): void
+    {
+        $message = $this->createMessageInSpatial('OFFER: Printer (TestTown)');
+
+        DB::table('ai_images')->insert([
+            'name'        => 'Printer',
+            'externaluid' => 'freegletusd-rej-ghost001',
+            'imagehash'   => 'hashrejghost001',
+            'status'      => 'rejected',
+        ]);
+
+        // Simulate an attachment created before the illustration was rejected.
+        $attachId = DB::table('messages_attachments')->insertGetId([
+            'msgid'        => $message->id,
+            'externaluid'  => 'freegletusd-rej-ghost001',
+            'externalmods' => json_encode(['ai' => true]),
+            'contenttype'  => 'image/jpeg',
+        ]);
+
+        $service = $this->makeService();
+        $result = $service->processIllustrations();
+
+        $this->assertFalse(
+            DB::table('messages_attachments')->where('id', $attachId)->exists(),
+            'Rejected illustration attachment must be removed to prevent ghost blank slot'
+        );
+        $this->assertGreaterThanOrEqual(1, $result['cleaned_non_active']);
+    }
+
+    public function test_does_not_remove_active_illustration_attachment(): void
+    {
+        $message = $this->createMessageInSpatial('OFFER: Chair (TestTown)');
+
+        DB::table('ai_images')->insert([
+            'name'        => 'Chair',
+            'externaluid' => 'freegletusd-active-chair001',
+            'imagehash'   => 'hashchairactive001',
+            'status'      => 'active',
+        ]);
+
+        // Attach the active illustration.
+        $attachId = DB::table('messages_attachments')->insertGetId([
+            'msgid'        => $message->id,
+            'externaluid'  => 'freegletusd-active-chair001',
+            'externalmods' => json_encode(['ai' => true]),
+            'contenttype'  => 'image/jpeg',
+        ]);
+
+        $service = $this->makeService();
+        $result = $service->processIllustrations();
+
+        $this->assertTrue(
+            DB::table('messages_attachments')->where('id', $attachId)->exists(),
+            'Active illustration attachment must NOT be removed'
+        );
+        $this->assertEquals(0, $result['cleaned_non_active']);
+    }
 }

--- a/iznik-server-go/misc/illustration.go
+++ b/iznik-server-go/misc/illustration.go
@@ -63,7 +63,7 @@ func GetIllustration(c *fiber.Ctx) error {
 	db := database.DBConn
 	var externalUID sql.NullString
 
-	err := db.Raw("SELECT externaluid FROM ai_images WHERE name = ?", itemName).Scan(&externalUID).Error
+	err := db.Raw("SELECT externaluid FROM ai_images WHERE name = ? AND status = 'active'", itemName).Scan(&externalUID).Error
 
 	if err != nil || !externalUID.Valid || externalUID.String == "" {
 		// Not cached - frontend should fall back to image generation.

--- a/iznik-server-go/test/illustration_test.go
+++ b/iznik-server-go/test/illustration_test.go
@@ -127,3 +127,39 @@ func TestIllustrationLocationSuffixStripping(t *testing.T) {
 	// Clean up.
 	db.Exec("DELETE FROM ai_images WHERE name = ?", testItem)
 }
+
+// AssertFlip: suppressed and rejected AI images must not be returned by the
+// /illustration endpoint. Without the AND status='active' filter these tests
+// fail (ret=0 instead of ret=3), proving the bug.
+
+func TestIllustrationSuppressedNotReturned(t *testing.T) {
+	testUid := fmt.Sprintf("test-uid-suppressed-%d", time.Now().UnixNano())
+	testItem := fmt.Sprintf("UTTest Suppressed Widget %d", time.Now().UnixNano())
+
+	db := database.DBConn
+	db.Exec("INSERT INTO ai_images (name, externaluid, status) VALUES (?, ?, 'suppressed')", testItem, testUid)
+	defer db.Exec("DELETE FROM ai_images WHERE name = ?", testItem)
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/illustration?item="+url.QueryEscape(testItem), nil))
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result misc.IllustrationResult
+	json2.Unmarshal(rsp(resp), &result)
+	assert.Equal(t, 3, result.Ret, "Suppressed illustration must not be returned (expected ret=3)")
+}
+
+func TestIllustrationRejectedNotReturned(t *testing.T) {
+	testUid := fmt.Sprintf("test-uid-rejected-%d", time.Now().UnixNano())
+	testItem := fmt.Sprintf("UTTest Rejected Widget %d", time.Now().UnixNano())
+
+	db := database.DBConn
+	db.Exec("INSERT INTO ai_images (name, externaluid, status) VALUES (?, ?, 'rejected')", testItem, testUid)
+	defer db.Exec("DELETE FROM ai_images WHERE name = ?", testItem)
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/illustration?item="+url.QueryEscape(testItem), nil))
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result misc.IllustrationResult
+	json2.Unmarshal(rsp(resp), &result)
+	assert.Equal(t, 3, result.Ret, "Rejected illustration must not be returned (expected ret=3)")
+}


### PR DESCRIPTION
## Root Cause

Two code paths returned AI illustration URLs without checking whether the illustration was active, and a third path failed to clean up ghost blank-slot attachments on existing messages:

1. **`GetIllustration` endpoint** (`iznik-server-go/misc/illustration.go`) — used during message composition, queried `ai_images` with no `status` filter. A suppressed or rejected illustration UID was returned, then masked as `''` by the message-serve query at `message.go:459`, leaving a blank image slot.

2. **`MessageIllustrationsService::processBatches`** (`iznik-batch/app/Services/MessageIllustrationsService.php`) — the batch cron had the same missing filter, attaching a suppressed/rejected UID that the serve query then blanked.

3. **Missing cleanup for existing messages** — when an illustration is suppressed or rejected AFTER being attached to messages, those messages retain the stale `messages_attachments` row. The Go message API returns `externaluid=''` for such rows, rendering a ghost blank image slot. No cleanup was removing these stale rows.

## Evidence

New AssertFlip tests fail on buggy code and pass after the fix:
- Go: `TestIllustrationSuppressedNotReturned`, `TestIllustrationRejectedNotReturned`
- PHP: `test_does_not_attach_suppressed_illustration`, `test_does_not_attach_rejected_illustration`
- PHP: `test_removes_existing_suppressed_illustration_attachment`, `test_removes_existing_rejected_illustration_attachment` (re-attempt addition)

## Fix

- `illustration.go`: add `AND status = 'active'` to GetIllustration SQL
- `MessageIllustrationsService::processBatches`: add `->where('status', 'active')` to cached-lookup
- `MessageIllustrationsService::cleanupNonActiveAttachments()` (new, re-attempt): each run deletes `messages_attachments` rows where `externalmods.ai = true` and the linked `ai_images.status` is `'suppressed'` or `'rejected'`, eliminating ghost blank slots on existing messages

## Other Call Sites

- `microvolunteering.go:542` — already filters `status = 'active'` ✓
- `aiimage.go` admin endpoints deliberately query non-active statuses ✓
- `JobIllustrationsService` — does not attach to `messages_attachments` ✓

## Test

File: `iznik-batch/tests/Unit/Services/MessageIllustrationsServiceTest.php`
Command: `vendor/bin/phpunit --filter=MessageIllustrationsServiceTest`
Proves: fail-before / pass-after for all new tests

## Discourse

https://discourse.ilovefreegle.org/t/9753/1