### PR TITLE
fix(email): replace broken freegle.in/paypal1510 donate link with /donate

### DIFF
--- a/iznik-batch/app/Mail/Chat/ChatNotification.php
+++ b/iznik-batch/app/Mail/Chat/ChatNotification.php
@@ -433,7 +433,7 @@ class ChatNotification extends MjmlMailable implements RetryableMailable
                 ),
                 'jobAds' => $jobAds['jobs'],
                 'jobsUrl' => $this->trackedUrl($this->userSite . '/jobs', 'jobs_link', 'jobs'),
-                'donateUrl' => $this->trackedUrl('https://freegle.in/paypal1510', 'donate_link', 'donate'),
+                'donateUrl' => $this->trackedUrl($this->userSite . '/donate', 'donate_link', 'donate'),
                 'ampIncluded' => $ampIncluded,
                 'isOwnMessage' => $this->isOwnMessage,
                 'otherUserName' => $otherUserName,

--- a/iznik-batch/app/Mail/Digest/UnifiedDigest.php
+++ b/iznik-batch/app/Mail/Digest/UnifiedDigest.php
@@ -214,7 +214,7 @@ class UnifiedDigest extends MjmlMailable implements RetryableMailable
             );
         }
         $jobsUrl = $this->trackedUrl($this->userSite . '/jobs', 'jobs_view_more', 'jobs_view_more');
-        $donateUrl = $this->trackedUrl(config('freegle.donate.url', 'https://freegle.in/paypal1510'), 'donate', 'donate');
+        $donateUrl = $this->trackedUrl($this->userSite . '/donate', 'donate', 'donate');
 
         // Per-group footer heading: "you're a member of {group}, set to
         // receive {frequency}". An immediate digest is about a single

--- a/iznik-batch/app/Mail/Donation/AskForDonation.php
+++ b/iznik-batch/app/Mail/Donation/AskForDonation.php
@@ -35,7 +35,7 @@ class AskForDonation extends MjmlMailable
         $this->itemSubject = $itemSubject;
         $this->userSite = config('freegle.sites.user');
         $this->target = config('freegle.donation.target', 2500);
-        $this->donateUrl = config('freegle.donation.url', 'http://freegle.in/paypal1510');
+        $this->donateUrl = $this->userSite . '/donate';
 
         // Initialize email tracking.
         $userId = $this->user->exists ? $this->user->id : null;

--- a/iznik-batch/app/Mail/Volunteering/VolunteeringDigestMail.php
+++ b/iznik-batch/app/Mail/Volunteering/VolunteeringDigestMail.php
@@ -69,10 +69,7 @@ class VolunteeringDigestMail extends MjmlMailable
             'email'          => $this->recipientEmail,
             'jobAds'         => $jobAds,
             'jobsUrl'        => $this->trackedUrl("{$userSite}/jobs", 'jobs_link', 'jobs'),
-            // Keep the freegle.in PayPal short link — it is whitelisted in the Go
-            // API's isValidRedirectURL (domain allow-list), so the tracked redirect
-            // resolves it correctly. Don't replace the short link with a full URL.
-            'donateUrl'      => $this->trackedUrl('https://freegle.in/paypal1510', 'donate_link', 'donate'),
+            'donateUrl'      => $this->trackedUrl("{$userSite}/donate", 'donate_link', 'donate'),
         ]);
     }
 }

--- a/iznik-batch/resources/views/emails/mjml/digest/unified.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/digest/unified.blade.php
@@ -205,7 +205,7 @@
             <mj-column>
                 <mj-divider border-color="#eeeeee" border-width="1px" padding="0 0 16px 0" />
                 <mj-button
-                    href="{{ $donateUrl ?? 'https://freegle.in/paypal1510' }}"
+                    href="{{ $donateUrl ?? ($userSite . '/donate') }}"
                     background-color="{{ $accentColor }}"
                     color="#ffffff"
                     font-size="14px"

--- a/iznik-batch/tests/Unit/Mail/DonateUrlTest.php
+++ b/iznik-batch/tests/Unit/Mail/DonateUrlTest.php
@@ -1,0 +1,201 @@
+<?php
+
+namespace Tests\Unit\Mail;
+
+use App\Mail\Chat\ChatNotification;
+use App\Mail\Digest\UnifiedDigest;
+use App\Mail\Donation\AskForDonation;
+use App\Mail\Volunteering\VolunteeringDigestMail;
+use App\Models\ChatMessage;
+use App\Models\ChatRoom;
+use App\Services\UnifiedDigestService;
+use Tests\TestCase;
+
+/**
+ * The "Donating helps too!" CTA link must point to the user-site /donate page,
+ * not to the old freegle.in/paypal1510 short URL whose destination 403s.
+ *
+ * Correct destination: config('freegle.sites.user') . '/donate'
+ * (same pattern as the working browse, settings, and unsubscribe links).
+ *
+ * Note: email links are wrapped in tracking redirect URLs. The actual destination
+ * is base64-encoded in the `url` query parameter:
+ *   {api_base}/e/d/r/{tracking_id}?url={base64_destination}&p=...&a=...
+ *
+ * So we assert the base64-encoded form of the expected URL appears in the HTML,
+ * and that the base64-encoded form of the old broken URL does NOT appear.
+ */
+class DonateUrlTest extends TestCase
+{
+    private function expectedDonateUrl(): string
+    {
+        return config('freegle.sites.user') . '/donate';
+    }
+
+    /**
+     * Assert the rendered HTML contains a tracking-redirect link whose
+     * destination is the expected donate URL.
+     *
+     * Tracking wraps destination URLs as: ?url=<base64($destinationUrl)>
+     * We check that the HTML contains the base64-encoded expected URL.
+     */
+    private function assertHtmlContainsDonateUrl(string $html, string $context): void
+    {
+        $expectedUrl     = $this->expectedDonateUrl();
+        $encodedExpected = base64_encode($expectedUrl);
+
+        $this->assertStringContainsString(
+            $encodedExpected,
+            $html,
+            "{$context}: rendered HTML must contain a tracking URL whose destination is user_site/donate (encoded as base64 in the ?url= param)"
+        );
+    }
+
+    /**
+     * Assert neither the raw old URL nor its base64-encoded form appears.
+     */
+    private function assertHtmlNotContainsBrokenDonateUrl(string $html, string $context): void
+    {
+        $this->assertStringNotContainsString(
+            'freegle.in/paypal1510',
+            $html,
+            "{$context}: HTML must not contain the raw old freegle.in/paypal1510 URL"
+        );
+
+        $this->assertStringNotContainsString(
+            base64_encode('https://freegle.in/paypal1510'),
+            $html,
+            "{$context}: HTML must not contain the base64-encoded old freegle.in/paypal1510 URL"
+        );
+    }
+
+    /** @test */
+    public function test_unified_digest_donate_url_points_to_user_site_donate_page(): void
+    {
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $this->createMembership($user, $group);
+
+        $poster = $this->createTestUser();
+        $this->createMembership($poster, $group);
+        $message = $this->createTestMessage($poster, $group, ['subject' => 'OFFER: Sofa (London)']);
+
+        $posts = collect([
+            ['message' => $message, 'postedToGroups' => [$group->id]],
+        ]);
+
+        // MODE_IMMEDIATE (single-post "immediate" email) always includes the donate
+        // CTA: when there are no job ads it shows a standalone "Donating helps too!"
+        // button, so the test does not depend on the user having nearby job ads.
+        $mail = new UnifiedDigest($user, $posts, UnifiedDigestService::MODE_IMMEDIATE);
+        $html = $mail->render();
+
+        $this->assertHtmlContainsDonateUrl($html, 'UnifiedDigest');
+        $this->assertHtmlNotContainsBrokenDonateUrl($html, 'UnifiedDigest');
+    }
+
+    /** @test */
+    public function test_chat_notification_donate_url_points_to_user_site_donate_page(): void
+    {
+        $user1 = $this->createTestUser();
+        $user2 = $this->createTestUser();
+        $room = $this->createTestChatRoom($user1, $user2);
+        $chatMessage = $this->createTestChatMessage($room, $user1, [
+            'message' => 'Is the sofa still available?',
+            'type'    => ChatMessage::TYPE_DEFAULT,
+        ]);
+
+        // The donate button in ChatNotification is only rendered when there are
+        // job ads. Mock getJobAds() on the recipient so the jobs section renders
+        // and we can verify the donate URL destination.
+        $fakeJob = (object) [
+            'id'        => 99,
+            'title'     => 'Volunteer Coordinator',
+            'location'  => 'Testville',
+            'image_url' => null,
+        ];
+        $user2 = \Mockery::mock($user2)->makePartial();
+        $user2->shouldReceive('getJobAds')->andReturn(['jobs' => collect([$fakeJob])]);
+
+        $mail = new ChatNotification(
+            $user2,
+            $user1,
+            $room,
+            $chatMessage,
+            ChatRoom::TYPE_USER2USER
+        );
+
+        $html = $mail->render();
+
+        $this->assertHtmlContainsDonateUrl($html, 'ChatNotification');
+        $this->assertHtmlNotContainsBrokenDonateUrl($html, 'ChatNotification');
+    }
+
+    /** @test */
+    public function test_volunteering_digest_donate_url_points_to_user_site_donate_page(): void
+    {
+        $userSite = config('freegle.sites.user');
+
+        // The donate button in the volunteering digest is only shown when job ads
+        // are present (it lives inside the @if($jobAds->isNotEmpty()) block).
+        // Pass a minimal stub object so the section renders and we can verify
+        // the donate link destination.
+        $fakeJob = (object) [
+            'id'        => 99,
+            'title'     => 'Volunteer Coordinator',
+            'location'  => 'Testville',
+            'image_url' => null,
+        ];
+
+        $mail = new VolunteeringDigestMail(
+            recipientEmail: 'test@example.com',
+            groupName:      'Testville Freegle',
+            volunteerings:  [[
+                'id'             => 1,
+                'title'          => 'Help at food bank',
+                'location'       => 'Town Hall',
+                'description'    => 'We need helpers.',
+                'timecommitment' => '2 hours',
+                'online'         => false,
+                'contactname'    => null,
+                'contactphone'   => null,
+                'contactemail'   => null,
+                'contacturl'     => null,
+                'photo_thumb'    => null,
+                'applyby'        => null,
+                'url'            => $userSite . '/volunteering/1',
+            ]],
+            unsubscribeUrl: $userSite . '/unsubscribe?email=test%40example.com',
+            jobAds: collect([$fakeJob]),
+        );
+
+        $html = $mail->render();
+
+        $this->assertHtmlContainsDonateUrl($html, 'VolunteeringDigestMail');
+        $this->assertHtmlNotContainsBrokenDonateUrl($html, 'VolunteeringDigestMail');
+    }
+
+    /** @test */
+    public function test_ask_for_donation_donate_url_points_to_user_site_donate_page(): void
+    {
+        $user = $this->createTestUser();
+        $mail = new AskForDonation($user);
+
+        // Test the property directly (not wrapped by trackedUrl in the mailable).
+        $this->assertStringContainsString(
+            '/donate',
+            $mail->donateUrl,
+            'AskForDonation::$donateUrl must contain /donate'
+        );
+        $this->assertStringNotContainsString(
+            'paypal1510',
+            $mail->donateUrl,
+            'AskForDonation::$donateUrl must not reference paypal1510'
+        );
+
+        $html = $mail->render();
+
+        $this->assertHtmlContainsDonateUrl($html, 'AskForDonation');
+        $this->assertHtmlNotContainsBrokenDonateUrl($html, 'AskForDonation');
+    }
+}

--- a/iznik-batch/tests/Unit/Mail/VolunteeringDigestMailTest.php
+++ b/iznik-batch/tests/Unit/Mail/VolunteeringDigestMailTest.php
@@ -101,20 +101,15 @@ class VolunteeringDigestMailTest extends TestCase
                 }
             }
         }
-        // Fallback: raw freegle.in short link href (when tracking is null)
-        if (preg_match('/href=["\']([^"\']*freegle\.in[^"\']*)["\']/', $html, $match)) {
+        // Fallback: raw href containing /donate (when tracking is null)
+        if (preg_match('/href=["\']([^"\']*\/donate[^"\']*)["\']/', $html, $match)) {
             return html_entity_decode($match[1]);
         }
         return null;
     }
 
-    public function test_donate_url_in_job_ads_section_uses_freegle_in_short_link(): void
+    public function test_donate_url_in_job_ads_section_uses_user_site_donate_page(): void
     {
-        // The "Donating helps too!" button must keep the freegle.in/paypal1510
-        // PayPal short link. freegle.in is whitelisted in the Go API's
-        // isValidRedirectURL allow-list, so the tracked redirect resolves the
-        // short link correctly. The short link must NOT be rewritten to a full
-        // /donate URL — short links are intentional and supported.
         $userSite = config('freegle.sites.user');
 
         $mail = new VolunteeringDigestMail(
@@ -134,8 +129,10 @@ class VolunteeringDigestMailTest extends TestCase
 
         $this->assertNotNull($donateDest,
             '"Donating helps too!" button destination URL not found in rendered email');
-        $this->assertStringContainsString('freegle.in/paypal1510', $donateDest,
-            '"Donating helps too!" must use the freegle.in/paypal1510 PayPal short link (whitelisted in isValidRedirectURL); it must not be replaced with a full URL');
+        $this->assertStringContainsString('/donate', $donateDest,
+            '"Donating helps too!" must link to the user-site /donate page');
+        $this->assertStringNotContainsString('freegle.in', $donateDest,
+            '"Donating helps too!" must not use the broken freegle.in/paypal1510 short link');
     }
 
     public function test_service_builds_volunteering_url_without_doubled_https(): void


### PR DESCRIPTION
## Root Cause

The 'Donating helps too!' CTA in four email types (VolunteeringDigest, ChatNotification, UnifiedDigest, AskForDonation) used `https://freegle.in/paypal1510` as the donate destination. This short link returns a 403 — users clicking it see an error rather than the donate page.

The tracking redirect at `api.ilovefreegle.org/e/d/r/...` correctly resolves (PR #635 added `freegle.in` to the allowlist), but the short link destination itself fails with HTTP 403.

## Evidence

All four `DonateUrlTest` assertions fail against the current code — confirming the bug is live:

```
1) Tests\Unit\Mail\DonateUrlTest::test_unified_digest_donate_url_points_to_user_site_donate_page
2) Tests\Unit\Mail\DonateUrlTest::test_chat_notification_donate_url_points_to_user_site_donate_page
3) Tests\Unit\Mail\DonateUrlTest::test_volunteering_digest_donate_url_points_to_user_site_donate_page
4) Tests\Unit\Mail\DonateUrlTest::test_ask_for_donation_donate_url_points_to_user_site_donate_page
FAILURES!
```

## Fix

Replace the broken short link with `{$userSite}/donate` (`www.ilovefreegle.org/donate`) in all four mailables and in the `unified.blade.php` fallback. This is a first-party URL that always passes the Go API's `isValidRedirectURL` check.

## Other Call Sites

All four mailables with "Donating helps too!" CTAs are fixed:
- `VolunteeringDigestMail.php` (primary bug: topic 9692/11)
- `ChatNotification.php` (same pattern)
- `UnifiedDigest.php` (same pattern, was using `config('freegle.donate.url', ...)` with broken fallback)
- `AskForDonation.php` (same pattern)
- `unified.blade.php` fallback also updated

## Test

`DonateUrlTest.php` (new, 4 tests) covers all four mailables — each asserting:
1. HTML contains `base64_encode(userSite . '/donate')` in the tracking URL  
2. HTML does **not** contain `freegle.in/paypal1510` (raw or base64-encoded)

`VolunteeringDigestMailTest.php` updated: `test_donate_url_in_job_ads_section_uses_user_site_donate_page` now asserts `/donate` instead of `freegle.in/paypal1510`.

## Discourse
https://discourse.ilovefreegle.org/t/9692/11

🤖 Generated with [Claude Code](https://claude.com/claude-code)