### PR TITLE
fix(email): replace broken freegle.in/paypal1510 donate URL with /donate across all mailables

### DIFF
--- a/iznik-batch/app/Mail/Chat/ChatNotification.php
+++ b/iznik-batch/app/Mail/Chat/ChatNotification.php
@@ -433,7 +433,7 @@ class ChatNotification extends MjmlMailable implements RetryableMailable
                 ),
                 'jobAds' => $jobAds['jobs'],
                 'jobsUrl' => $this->trackedUrl($this->userSite . '/jobs', 'jobs_link', 'jobs'),
-                'donateUrl' => $this->trackedUrl('https://freegle.in/paypal1510', 'donate_link', 'donate'),
+                'donateUrl' => $this->trackedUrl($this->userSite . '/donate', 'donate_link', 'donate'),
                 'ampIncluded' => $ampIncluded,
                 'isOwnMessage' => $this->isOwnMessage,
                 'otherUserName' => $otherUserName,

--- a/iznik-batch/app/Mail/Digest/UnifiedDigest.php
+++ b/iznik-batch/app/Mail/Digest/UnifiedDigest.php
@@ -214,7 +214,7 @@ class UnifiedDigest extends MjmlMailable implements RetryableMailable
             );
         }
         $jobsUrl = $this->trackedUrl($this->userSite . '/jobs', 'jobs_view_more', 'jobs_view_more');
-        $donateUrl = $this->trackedUrl(config('freegle.donate.url', 'https://freegle.in/paypal1510'), 'donate', 'donate');
+        $donateUrl = $this->trackedUrl($this->userSite . '/donate', 'donate', 'donate');
 
         // Per-group footer heading: "you're a member of {group}, set to
         // receive {frequency}". An immediate digest is about a single

--- a/iznik-batch/app/Mail/Donation/AskForDonation.php
+++ b/iznik-batch/app/Mail/Donation/AskForDonation.php
@@ -35,7 +35,7 @@ class AskForDonation extends MjmlMailable
         $this->itemSubject = $itemSubject;
         $this->userSite = config('freegle.sites.user');
         $this->target = config('freegle.donation.target', 2500);
-        $this->donateUrl = config('freegle.donation.url', 'http://freegle.in/paypal1510');
+        $this->donateUrl = $this->userSite . '/donate';
 
         // Initialize email tracking.
         $userId = $this->user->exists ? $this->user->id : null;

--- a/iznik-batch/app/Mail/Volunteering/VolunteeringDigestMail.php
+++ b/iznik-batch/app/Mail/Volunteering/VolunteeringDigestMail.php
@@ -69,10 +69,7 @@ class VolunteeringDigestMail extends MjmlMailable
             'email'          => $this->recipientEmail,
             'jobAds'         => $jobAds,
             'jobsUrl'        => $this->trackedUrl("{$userSite}/jobs", 'jobs_link', 'jobs'),
-            // Keep the freegle.in PayPal short link — it is whitelisted in the Go
-            // API's isValidRedirectURL (domain allow-list), so the tracked redirect
-            // resolves it correctly. Don't replace the short link with a full URL.
-            'donateUrl'      => $this->trackedUrl('https://freegle.in/paypal1510', 'donate_link', 'donate'),
+            'donateUrl'      => $this->trackedUrl("{$userSite}/donate", 'donate_link', 'donate'),
         ]);
     }
 }

--- a/iznik-batch/resources/views/emails/mjml/digest/unified.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/digest/unified.blade.php
@@ -205,7 +205,7 @@
             <mj-column>
                 <mj-divider border-color="#eeeeee" border-width="1px" padding="0 0 16px 0" />
                 <mj-button
-                    href="{{ $donateUrl ?? 'https://freegle.in/paypal1510' }}"
+                    href="{{ $donateUrl }}"
                     background-color="{{ $accentColor }}"
                     color="#ffffff"
                     font-size="14px"

--- a/iznik-batch/tests/Feature/Mail/EmailDeliveryIntegrationTest.php
+++ b/iznik-batch/tests/Feature/Mail/EmailDeliveryIntegrationTest.php
@@ -255,12 +255,8 @@ class EmailDeliveryIntegrationTest extends TestCase
         // Verify body is non-empty.
         $this->assertNotEmpty($body, 'Email body should not be empty');
 
-        // Verify donate URL is present. The configured URL may vary, but it should be a link.
-        $donateUrl = config('freegle.donation.url', 'http://freegle.in/paypal1510');
-        $donateHost = parse_url($donateUrl, PHP_URL_HOST);
-        // Check for either the direct donate URL or a tracked version of it.
-        $foundDonateLink = $this->extractUrlByPath($body, preg_quote($donateHost, '/'))
-            ?? $this->extractUrlByPath($body, 'donate|paypal');
+        // Verify donate URL is present — donate button links to the user-site /donate page.
+        $foundDonateLink = $this->extractUrlByPath($body, 'donate');
         $this->assertNotNull($foundDonateLink, 'Email should contain a donate URL');
     }
 

--- a/iznik-batch/tests/Unit/Mail/DonateUrlTest.php
+++ b/iznik-batch/tests/Unit/Mail/DonateUrlTest.php
@@ -1,0 +1,201 @@
+<?php
+
+namespace Tests\Unit\Mail;
+
+use App\Mail\Chat\ChatNotification;
+use App\Mail\Digest\UnifiedDigest;
+use App\Mail\Donation\AskForDonation;
+use App\Mail\Volunteering\VolunteeringDigestMail;
+use App\Models\ChatMessage;
+use App\Models\ChatRoom;
+use App\Services\UnifiedDigestService;
+use Tests\TestCase;
+
+/**
+ * The "Donating helps too!" CTA link must point to the user-site /donate page,
+ * not to the old freegle.in/paypal1510 short URL whose destination 403s.
+ *
+ * Correct destination: config('freegle.sites.user') . '/donate'
+ * (same pattern as the working browse, settings, and unsubscribe links).
+ *
+ * Note: email links are wrapped in tracking redirect URLs. The actual destination
+ * is base64-encoded in the `url` query parameter:
+ *   {api_base}/e/d/r/{tracking_id}?url={base64_destination}&p=...&a=...
+ *
+ * So we assert the base64-encoded form of the expected URL appears in the HTML,
+ * and that the base64-encoded form of the old broken URL does NOT appear.
+ */
+class DonateUrlTest extends TestCase
+{
+    private function expectedDonateUrl(): string
+    {
+        return config('freegle.sites.user') . '/donate';
+    }
+
+    /**
+     * Assert the rendered HTML contains a tracking-redirect link whose
+     * destination is the expected donate URL.
+     *
+     * Tracking wraps destination URLs as: ?url=<base64($destinationUrl)>
+     * We check that the HTML contains the base64-encoded expected URL.
+     */
+    private function assertHtmlContainsDonateUrl(string $html, string $context): void
+    {
+        $expectedUrl     = $this->expectedDonateUrl();
+        $encodedExpected = base64_encode($expectedUrl);
+
+        $this->assertStringContainsString(
+            $encodedExpected,
+            $html,
+            "{$context}: rendered HTML must contain a tracking URL whose destination is user_site/donate (encoded as base64 in the ?url= param)"
+        );
+    }
+
+    /**
+     * Assert neither the raw old URL nor its base64-encoded form appears.
+     */
+    private function assertHtmlNotContainsBrokenDonateUrl(string $html, string $context): void
+    {
+        $this->assertStringNotContainsString(
+            'freegle.in/paypal1510',
+            $html,
+            "{$context}: HTML must not contain the raw old freegle.in/paypal1510 URL"
+        );
+
+        $this->assertStringNotContainsString(
+            base64_encode('https://freegle.in/paypal1510'),
+            $html,
+            "{$context}: HTML must not contain the base64-encoded old freegle.in/paypal1510 URL"
+        );
+    }
+
+    /** @test */
+    public function test_unified_digest_donate_url_points_to_user_site_donate_page(): void
+    {
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $this->createMembership($user, $group);
+
+        $poster = $this->createTestUser();
+        $this->createMembership($poster, $group);
+        $message = $this->createTestMessage($poster, $group, ['subject' => 'OFFER: Sofa (London)']);
+
+        $posts = collect([
+            ['message' => $message, 'postedToGroups' => [$group->id]],
+        ]);
+
+        // MODE_IMMEDIATE (single-post "immediate" email) always includes the donate
+        // CTA: when there are no job ads it shows a standalone "Donating helps too!"
+        // button, so the test does not depend on the user having nearby job ads.
+        $mail = new UnifiedDigest($user, $posts, UnifiedDigestService::MODE_IMMEDIATE);
+        $html = $mail->render();
+
+        $this->assertHtmlContainsDonateUrl($html, 'UnifiedDigest');
+        $this->assertHtmlNotContainsBrokenDonateUrl($html, 'UnifiedDigest');
+    }
+
+    /** @test */
+    public function test_chat_notification_donate_url_points_to_user_site_donate_page(): void
+    {
+        $user1 = $this->createTestUser();
+        $user2 = $this->createTestUser();
+        $room = $this->createTestChatRoom($user1, $user2);
+        $chatMessage = $this->createTestChatMessage($room, $user1, [
+            'message' => 'Is the sofa still available?',
+            'type'    => ChatMessage::TYPE_DEFAULT,
+        ]);
+
+        // The donate button in ChatNotification is only rendered when there are
+        // job ads. Mock getJobAds() on the recipient so the jobs section renders
+        // and we can verify the donate URL destination.
+        $fakeJob = (object) [
+            'id'        => 99,
+            'title'     => 'Volunteer Coordinator',
+            'location'  => 'Testville',
+            'image_url' => null,
+        ];
+        $user2 = \Mockery::mock($user2)->makePartial();
+        $user2->shouldReceive('getJobAds')->andReturn(['jobs' => collect([$fakeJob])]);
+
+        $mail = new ChatNotification(
+            $user2,
+            $user1,
+            $room,
+            $chatMessage,
+            ChatRoom::TYPE_USER2USER
+        );
+
+        $html = $mail->render();
+
+        $this->assertHtmlContainsDonateUrl($html, 'ChatNotification');
+        $this->assertHtmlNotContainsBrokenDonateUrl($html, 'ChatNotification');
+    }
+
+    /** @test */
+    public function test_volunteering_digest_donate_url_points_to_user_site_donate_page(): void
+    {
+        $userSite = config('freegle.sites.user');
+
+        // The donate button in the volunteering digest is only shown when job ads
+        // are present (it lives inside the @if($jobAds->isNotEmpty()) block).
+        // Pass a minimal stub object so the section renders and we can verify
+        // the donate link destination.
+        $fakeJob = (object) [
+            'id'        => 99,
+            'title'     => 'Volunteer Coordinator',
+            'location'  => 'Testville',
+            'image_url' => null,
+        ];
+
+        $mail = new VolunteeringDigestMail(
+            recipientEmail: 'test@example.com',
+            groupName:      'Testville Freegle',
+            volunteerings:  [[
+                'id'             => 1,
+                'title'          => 'Help at food bank',
+                'location'       => 'Town Hall',
+                'description'    => 'We need helpers.',
+                'timecommitment' => '2 hours',
+                'online'         => false,
+                'contactname'    => null,
+                'contactphone'   => null,
+                'contactemail'   => null,
+                'contacturl'     => null,
+                'photo_thumb'    => null,
+                'applyby'        => null,
+                'url'            => $userSite . '/volunteering/1',
+            ]],
+            unsubscribeUrl: $userSite . '/unsubscribe?email=test%40example.com',
+            jobAds: collect([$fakeJob]),
+        );
+
+        $html = $mail->render();
+
+        $this->assertHtmlContainsDonateUrl($html, 'VolunteeringDigestMail');
+        $this->assertHtmlNotContainsBrokenDonateUrl($html, 'VolunteeringDigestMail');
+    }
+
+    /** @test */
+    public function test_ask_for_donation_donate_url_points_to_user_site_donate_page(): void
+    {
+        $user = $this->createTestUser();
+        $mail = new AskForDonation($user);
+
+        // Test the property directly (not wrapped by trackedUrl in the mailable).
+        $this->assertStringContainsString(
+            '/donate',
+            $mail->donateUrl,
+            'AskForDonation::$donateUrl must contain /donate'
+        );
+        $this->assertStringNotContainsString(
+            'paypal1510',
+            $mail->donateUrl,
+            'AskForDonation::$donateUrl must not reference paypal1510'
+        );
+
+        $html = $mail->render();
+
+        $this->assertHtmlContainsDonateUrl($html, 'AskForDonation');
+        $this->assertHtmlNotContainsBrokenDonateUrl($html, 'AskForDonation');
+    }
+}

--- a/iznik-batch/tests/Unit/Mail/VolunteeringDigestMailTest.php
+++ b/iznik-batch/tests/Unit/Mail/VolunteeringDigestMailTest.php
@@ -108,13 +108,8 @@ class VolunteeringDigestMailTest extends TestCase
         return null;
     }
 
-    public function test_donate_url_in_job_ads_section_uses_freegle_in_short_link(): void
+    public function test_donate_url_in_job_ads_section_uses_site_donate_page(): void
     {
-        // The "Donating helps too!" button must keep the freegle.in/paypal1510
-        // PayPal short link. freegle.in is whitelisted in the Go API's
-        // isValidRedirectURL allow-list, so the tracked redirect resolves the
-        // short link correctly. The short link must NOT be rewritten to a full
-        // /donate URL — short links are intentional and supported.
         $userSite = config('freegle.sites.user');
 
         $mail = new VolunteeringDigestMail(
@@ -134,8 +129,10 @@ class VolunteeringDigestMailTest extends TestCase
 
         $this->assertNotNull($donateDest,
             '"Donating helps too!" button destination URL not found in rendered email');
-        $this->assertStringContainsString('freegle.in/paypal1510', $donateDest,
-            '"Donating helps too!" must use the freegle.in/paypal1510 PayPal short link (whitelisted in isValidRedirectURL); it must not be replaced with a full URL');
+        $this->assertStringContainsString('/donate', $donateDest,
+            '"Donating helps too!" must link to the site donate page');
+        $this->assertStringNotContainsString('freegle.in/paypal1510', $donateDest,
+            '"Donating helps too!" must not use the old freegle.in/paypal1510 short link');
     }
 
     public function test_service_builds_volunteering_url_without_doubled_https(): void


### PR DESCRIPTION
## Root Cause

Four email mailables hardcoded `freegle.in/paypal1510` as the donate CTA URL. This PayPal short URL returns 403 for recipients, silently breaking donations from every email containing a "Donating helps too!" or "Thanks for freegling!" button.

The affected mailables:
| Mailable | Old donate URL |
|---|---|
| `AskForDonation` | `config('freegle.donation.url', 'http://freegle.in/paypal1510')` |
| `ChatNotification` | `'https://freegle.in/paypal1510'` (hardcoded) |
| `UnifiedDigest` | `config('freegle.donate.url', 'https://freegle.in/paypal1510')` |
| `VolunteeringDigestMail` | `'https://freegle.in/paypal1510'` (hardcoded) |

Also removes the defensive `?? 'https://freegle.in/paypal1510'` fallback in `unified.blade.php` — `$donateUrl` is always set by the PHP mailable layer.

## Evidence

PR #652 partially addressed this: it correctly identified `freegle.in` is in the Go API's `isValidRedirectURL` allow-list (so tracked redirects resolve the domain), but the actual destination URL `freegle.in/paypal1510` still returns 403. Allowing the redirect to forward doesn't fix the 403 at the destination.

## Fix

Replace all four callsites with `$this->userSite . '/donate'` (or `config('freegle.sites.user') . '/donate'`). The user site domain is always in the Go API's allow-list via the `USER_SITE` env var.

## Other Call Sites

All four affected mailables are covered. No remaining `paypal1510` references in app or template code (verified with grep).

## Test

Adds `DonateUrlTest` (4 tests) — one per affected mailable — asserting:
- Rendered HTML contains the base64-encoded `/donate` destination URL in the tracking redirect
- Rendered HTML does NOT contain `freegle.in/paypal1510`

Updates `VolunteeringDigestMailTest::test_donate_url_in_job_ads_section_uses_freegle_in_short_link` (added by PR #652 to assert the wrong behavior) to assert `/donate` is used instead.

Updates `EmailDeliveryIntegrationTest` to use `'donate'` pattern instead of the now-removed `freegle.donation.url` config key.

## Discourse

Found during retesting of https://discourse.ilovefreegle.org/t/9692/12 (ampersand encoding in opportunity titles — the original bug was already fixed by PR #636). The donate URL failures were discovered when running the test suite as part of verification.