### PR TITLE
fix(notifications): route ModTools push to dashboard when no pending messages exist

### DIFF
--- a/iznik-batch/app/Services/PushNotificationService.php
+++ b/iznik-batch/app/Services/PushNotificationService.php
@@ -479,8 +479,11 @@ class PushNotificationService
     /**
      * Build the ModTools notification payload.
      *
-     * For ModTools, we send a simple "pending messages" notification.
-     * Matches legacy User::getNotificationPayload(modtools=true).
+     * Routes to /modtools/messages/pending only when there are actual pending
+     * messages — spam-only or volunteering-only work routes to the dashboard
+     * (/modtools) so tapping never lands on an empty pending queue.
+     * Fixes Discourse #9692: notification wrongly labelled "pending" and routing
+     * to /messages/pending when the badge count came from spam/volunteering only.
      */
     private function buildModToolsPayload(int $userId): ?array
     {
@@ -506,7 +509,18 @@ class PushNotificationService
             ];
         }
 
-        $title = "$total message" . ($total > 1 ? 's' : '') . " pending";
+        // Only route to /messages/pending when there are actually pending messages.
+        // The badge count includes spam + volunteering; routing there when only
+        // those exist sends the mod to an empty pending queue (Discourse #9692).
+        $pendingCount = $this->getPendingMessageCount($userId);
+
+        if ($pendingCount > 0) {
+            $title = "$total message" . ($total > 1 ? 's' : '') . " pending";
+            $route = '/modtools/messages/pending';
+        } else {
+            $title = "$total item" . ($total > 1 ? 's' : '') . " to review";
+            $route = '/modtools';
+        }
         $message = "Open ModTools to review";
 
         return [
@@ -521,12 +535,61 @@ class PushNotificationService
             'image' => 'www/images/modtools_logo.png',
             'modtools' => '1',
             'sound' => 'default',
-            'route' => '/modtools/messages/pending',
+            'route' => $route,
             'channel_id' => 'modtools',
             // Fixed notId per user so each new notification replaces the previous one
             // on Android instead of stacking multiple "N pending" badges.
             'notId' => (string) $userId,
         ];
+    }
+
+    /**
+     * Count unheld pending messages in the user's active groups.
+     *
+     * Subset of getBadgeCount() — used by buildModToolsPayload() to decide
+     * whether to route the notification to /messages/pending or the dashboard.
+     */
+    private function getPendingMessageCount(int $userId): int
+    {
+        $memberships = DB::select(
+            "SELECT groupid, settings FROM memberships
+             WHERE userid = ? AND role IN ('Owner', 'Moderator') AND collection = 'Approved'",
+            [$userId]
+        );
+
+        if (empty($memberships)) {
+            return 0;
+        }
+
+        $activeGroupIds = [];
+        foreach ($memberships as $m) {
+            if ($this->isActiveMod($m->settings)) {
+                $activeGroupIds[] = $m->groupid;
+            }
+        }
+
+        if (empty($activeGroupIds)) {
+            return 0;
+        }
+
+        $placeholders = implode(',', array_fill(0, count($activeGroupIds), '?'));
+        $params = array_merge([$userId], $activeGroupIds);
+
+        $pending = DB::selectOne(
+            "SELECT COUNT(*) as cnt FROM messages_groups mg
+             INNER JOIN messages m ON m.id = mg.msgid
+             INNER JOIN memberships mem ON mem.groupid = mg.groupid AND mem.userid = ?
+             WHERE mem.role IN ('Owner', 'Moderator')
+             AND mem.collection = 'Approved'
+             AND mg.collection = 'Pending'
+             AND mg.groupid IN ({$placeholders})
+             AND mg.deleted = 0
+             AND m.fromuser IS NOT NULL
+             AND m.heldby IS NULL",
+            $params
+        );
+
+        return $pending->cnt ?? 0;
     }
 
     /**

--- a/iznik-batch/tests/Unit/Services/PushNotificationServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/PushNotificationServiceTest.php
@@ -496,6 +496,50 @@ class PushNotificationServiceTest extends TestCase
         $this->assertArrayNotHasKey('notification', $cfg);
     }
 
+    /**
+     * Regression for Discourse #9692/10: when only spam (no pending) messages exist,
+     * the notification must route to /modtools (the dashboard) and must NOT say "pending".
+     */
+    public function test_buildModToolsPayload_spam_only_routes_to_dashboard(): void
+    {
+        $mod = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $this->createMembership($mod, $group, ['role' => Membership::ROLE_MODERATOR]);
+
+        $sender = $this->createTestUser();
+        $message = Message::create([
+            'fromuser' => $sender->id,
+            'type' => Message::TYPE_OFFER,
+            'subject' => 'OFFER: Spam Item (Location)',
+            'textbody' => 'Spam',
+            'source' => 'Platform',
+            'date' => now(),
+            'arrival' => now(),
+            'lat' => $group->lat,
+            'lng' => $group->lng,
+            'heldby' => null,
+        ]);
+        MessageGroup::create([
+            'msgid' => $message->id,
+            'groupid' => $group->id,
+            'collection' => MessageGroup::COLLECTION_SPAM,
+            'arrival' => now(),
+            'deleted' => 0,
+        ]);
+
+        $method = new \ReflectionMethod($this->service, 'buildModToolsPayload');
+        $method->setAccessible(true);
+        $payload = $method->invoke($this->service, $mod->id);
+
+        // Badge must still reflect total work items
+        $this->assertSame('1', $payload['badge'], 'Badge must count spam items');
+        // CORRECT: no pending messages → must route to dashboard, not /messages/pending
+        $this->assertSame('/modtools', $payload['route'],
+            'When only spam exists (no pending messages), route must be /modtools not /messages/pending');
+        $this->assertStringNotContainsString('pending', $payload['title'],
+            'When only spam exists, title must not say "pending" — Discourse #9692');
+    }
+
     private function invokeBuildAndroidFcmMessage(string $token, array $payload, bool $forceVisible): array
     {
         $method = new \ReflectionMethod($this->service, 'buildAndroidFcmMessage');


### PR DESCRIPTION
## Root Cause

`getBadgeCount()` counts pending + spam + volunteering items together, but `buildModToolsPayload()` always set:
- `route = '/modtools/messages/pending'`
- `title = "X messages pending"`

…when the total was > 0. If the only work items were spam or pending volunteering (no pending messages), the notification said "messages pending" and tapped through to an empty `/messages/pending` page.

## Evidence

Failing test output (step 3b, before fix):

```
1) Tests\Unit\Services\PushNotificationServiceTest::test_buildModToolsPayload_spam_only_routes_to_dashboard
When only spam exists (no pending messages), route must be /modtools — Discourse #9692
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'/modtools'
+'/modtools/messages/pending'

/var/www/html/tests/Unit/Services/PushNotificationServiceTest.php:520

FAILURES!
Tests: 1, Assertions: 2, Failures: 1
```

## Fix

Added `getPendingMessageCount()` — a targeted query counting only unheld pending messages in the user's active groups. `buildModToolsPayload()` uses it to choose route and label:

- `pendingCount > 0` → `route = /modtools/messages/pending`, title = "X messages pending" (existing behaviour, unchanged)
- `pendingCount == 0` → `route = /modtools` (dashboard), title = "X items to review"

Badge count remains `total` (pending + spam + volunteering) in both cases.

## Other Call Sites

`notifyTest()` always routes to `/modtools` regardless — already correct, no change needed.

No other hardcoded `/modtools/messages/pending` route strings in iznik-batch, iznik-server-go, or iznik-nuxt3.

## Test

**File:** `iznik-batch/tests/Unit/Services/PushNotificationServiceTest::test_buildModToolsPayload_spam_only_routes_to_dashboard`

**Command:** filter=`PushNotificationServiceTest::test_buildModToolsPayload_spam_only_routes_to_dashboard` via status API

**Proves:** spam-only setup → badge=1, route=/modtools, title doesn't say "pending". After fix: Tests: 1, Assertions: 3, OK.
Full `PushNotificationServiceTest` (35 tests) passes with no regressions.

## Discourse
https://discourse.ilovefreegle.org/t/9692/10