### PR TITLE
fix(notifications): exclude orphaned Pending memberships from work-count (Discourse #9654/12)

### DIFF
--- a/iznik-server-go/group/groupWork.go
+++ b/iznik-server-go/group/groupWork.go
@@ -180,13 +180,16 @@ func GetGroupWork(c *fiber.Ctx) error {
 	}()
 
 	// --- Pending members: all groups, no active/inactive split ---
+	// INNER JOIN users excludes orphaned membership rows (user deleted, membership remains)
+	// so the count matches the listing query (Discourse #9654/12, mirrors PR #590 for Spammembers).
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
 		var rows []countRow
-		db.Raw("SELECT groupid, COUNT(*) as count FROM memberships "+
-			"WHERE groupid IN ? AND collection = ? "+
-			"GROUP BY groupid", allGroupIDs, utils.COLLECTION_PENDING).Scan(&rows)
+		db.Raw("SELECT m.groupid, COUNT(*) as count FROM memberships m "+
+			"INNER JOIN users u ON u.id = m.userid AND u.deleted IS NULL "+
+			"WHERE m.groupid IN ? AND m.collection = ? "+
+			"GROUP BY m.groupid", allGroupIDs, utils.COLLECTION_PENDING).Scan(&rows)
 		mapMutex.Lock()
 		for _, r := range rows {
 			if w := workMap[r.Groupid]; w != nil {

--- a/iznik-server-go/session/session.go
+++ b/iznik-server-go/session/session.go
@@ -972,10 +972,14 @@ func GetSession(c *fiber.Ctx) error {
 		}()
 
 		// --- Pending members (all groups, no active/inactive split) ---
+		// INNER JOIN users excludes orphaned membership rows (user deleted, membership remains)
+		// so the count matches the listing query which also INNER-JOINs users (Discourse #9654/12).
 		wg2.Add(1)
 		go func() {
 			defer wg2.Done()
-			db.Raw("SELECT COUNT(*) FROM memberships WHERE groupid IN ? AND collection = ?",
+			db.Raw("SELECT COUNT(*) FROM memberships m "+
+				"INNER JOIN users u ON u.id = m.userid AND u.deleted IS NULL "+
+				"WHERE m.groupid IN ? AND m.collection = ?",
 				modGroupIDs, utils.COLLECTION_PENDING).Scan(&pendingmembers)
 		}()
 

--- a/iznik-server-go/test/member_pending_orphan_test.go
+++ b/iznik-server-go/test/member_pending_orphan_test.go
@@ -1,0 +1,101 @@
+package test
+
+import (
+	json2 "encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/freegle/iznik-server-go/group"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestPendingMembersOrphanCountVsListing is a regression test for the phantom
+// pending-members badge (Discourse #9654/12).
+//
+// When a user whose membership row has collection='Pending' is hard-deleted
+// (user row gone, membership row remains), the pendingmembers count query —
+// which does NOT join the users table — returns 1 while the listing query
+// (which INNER-JOINs users) returns 0. This produces a persistent +1 badge
+// count that the moderator can never clear ("count stays at 1 after doing all tasks").
+//
+// The same pattern was fixed for Spammembers in PR #590. This test covers
+// both the session work total (GET /api/session) and the per-group count
+// (GET /api/group/work).
+func TestPendingMembersOrphanCountVsListing(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("pmorphan")
+
+	groupID := CreateTestGroup(t, prefix)
+	modID := CreateTestUser(t, prefix+"_mod", "User")
+	CreateTestMembership(t, modID, groupID, "Moderator")
+	_, token := CreateTestSession(t, modID)
+
+	// Create a user with a Pending membership, then hard-delete the user row with
+	// FK checks off — leaving an orphaned Pending membership row.
+	// In production this occurs when a user is deleted before FK CASCADE was in place.
+	targetID := CreateTestUser(t, prefix+"_target", "User")
+	db.Exec("INSERT INTO memberships (userid, groupid, role, collection) "+
+		"VALUES (?, ?, 'Member', 'Pending')", targetID, groupID)
+
+	db.Exec("SET FOREIGN_KEY_CHECKS = 0")
+	db.Exec("DELETE FROM users_emails WHERE userid = ?", targetID)
+	db.Exec("DELETE FROM users WHERE id = ?", targetID)
+	db.Exec("SET FOREIGN_KEY_CHECKS = 1")
+
+	t.Cleanup(func() {
+		db.Exec("SET FOREIGN_KEY_CHECKS = 0")
+		db.Exec("DELETE FROM memberships WHERE userid = ? AND groupid = ?", targetID, groupID)
+		db.Exec("SET FOREIGN_KEY_CHECKS = 1")
+	})
+
+	// --- 1. GET /api/group/work: per-group Pendingmembers must be 0 ---
+	workResp, _ := getApp().Test(httptest.NewRequest("GET", "/api/group/work?jwt="+token, nil))
+	assert.Equal(t, 200, workResp.StatusCode)
+
+	var workResult []group.GroupWork
+	json2.Unmarshal(rsp(workResp), &workResult)
+
+	var found *group.GroupWork
+	for i := range workResult {
+		if workResult[i].Groupid == groupID {
+			found = &workResult[i]
+			break
+		}
+	}
+	assert.NotNil(t, found, "Expected group %d in work results", groupID)
+	if found != nil {
+		assert.Equal(t, int64(0), found.Pendingmembers,
+			"group/work Pendingmembers must be 0 when the only pending member's user row is deleted; "+
+				"orphaned membership row must not inflate the count (Discourse #9654/12)")
+	}
+
+	// --- 2. GET /api/session work.pendingmembers must be 0 ---
+	work := getSessionWork(t, token)
+	pendingmembers := work["pendingmembers"].(float64)
+	assert.Equal(t, float64(0), pendingmembers,
+		"session work.pendingmembers must be 0 when the only pending member's user row is deleted; "+
+			"orphaned membership row must not inflate the count (Discourse #9654/12)")
+
+	// --- 3. GET /api/memberships?collection=Pending: listing must return 0 ---
+	listURL := fmt.Sprintf("/api/memberships?collection=Pending&groupid=%d&jwt=%s", groupID, token)
+	listResp, _ := getApp().Test(httptest.NewRequest("GET", listURL, nil))
+	assert.Equal(t, 200, listResp.StatusCode)
+
+	// The listing response is a JSON object with a "members" key (see GetMemberships context
+	// extraction) or a plain array — handle both.
+	var rawList interface{}
+	json2.Unmarshal(rsp(listResp), &rawList)
+	var listLen int
+	switch v := rawList.(type) {
+	case []interface{}:
+		listLen = len(v)
+	case map[string]interface{}:
+		if members, ok := v["members"].([]interface{}); ok {
+			listLen = len(members)
+		}
+	}
+	assert.Equal(t, 0, listLen,
+		"pending-members listing must return 0 rows when the only pending member's user row is deleted")
+}


### PR DESCRIPTION
## Root Cause

The `pendingmembers` count queries in `session.go` (work total badge) and `groupWork.go` (per-group breakdown) tallied memberships **without JOINing to the users table**. Orphaned membership rows — where the user was hard-deleted (before FK CASCADE was in place) but the `memberships` row with `collection='Pending'` was left behind — were counted by the query but returned zero by the listing query (which INNER-JOINs users). This produced a persistent phantom `+1` badge that moderators could never clear.

This is the identical bug pattern fixed for `Spammembers` in PR #590, now fixed for `Pendingmembers`.

## Evidence

```
// BEFORE (buggy):
db.Raw("SELECT COUNT(*) FROM memberships WHERE groupid IN ? AND collection = ?",
    modGroupIDs, utils.COLLECTION_PENDING).Scan(&pendingmembers)
// → returns 1 even when the only pending member's user row is deleted

// AFTER (fixed):
db.Raw("SELECT COUNT(*) FROM memberships m "+
    "INNER JOIN users u ON u.id = m.userid AND u.deleted IS NULL "+
    "WHERE m.groupid IN ? AND m.collection = ?",
    modGroupIDs, utils.COLLECTION_PENDING).Scan(&pendingmembers)
// → returns 0 when user row is deleted (matches listing behaviour)
```

The test `TestPendingMembersOrphanCountVsListing` reproduces the scenario:
- Creates a Pending membership, then hard-deletes the user row with FK checks off
- Asserts `group/work Pendingmembers == 0` (fails on buggy code: returns 1)
- Asserts `session work.pendingmembers == 0` (fails on buggy code: returns 1)
- Asserts `GET /memberships?collection=Pending` returns 0 rows

## Fix

Added `INNER JOIN users u ON u.id = m.userid AND u.deleted IS NULL` to both count queries:
- `session.go` — the work-total badge count
- `groupWork.go` — the per-group breakdown count

Both fixes are identical in structure to PR #590's `Spammembers` fix.

## Other Call Sites

`grep -rn "pendingmembers"` — only the two fixed sites compute this count. The listing queries (`GetMemberships` with `collection=Pending`) already JOIN users and are unaffected.

## Test

**File**: `iznik-server-go/test/member_pending_orphan_test.go`  
**Command**: `go test ./test/... -run TestPendingMembersOrphanCountVsListing -v`  
**Proves**: fails-before (returns 1 when orphan present) / passes-after (returns 0)

## Discourse

https://discourse.ilovefreegle.org/t/9654/12