### PR TITLE
fix(modtools): show manually-reposted Pending messages in posting history

### DIFF
--- a/iznik-server-go/test/message_test.go
+++ b/iznik-server-go/test/message_test.go
@@ -1986,6 +1986,72 @@ func TestJoinAndPostRejectsEmptyDraft(t *testing.T) {
 	assert.Equal(t, int64(0), msgGroupCount, "Empty draft must not produce a messages_groups row")
 }
 
+// TestManualRepostPendingVisibleInHistory verifies that a user's message appears in
+// their posting history while it is in Pending collection (e.g. after a manual repost).
+// Bug: GetUserMessageHistory filtered to collection='Approved' only, so a manually
+// reposted message was invisible in the Posts history until the content-check batch
+// approved it. Discourse #9481 post 562.
+//
+// FAILS on buggy code (Pending filtered out), PASSES after fix (Pending included).
+func TestManualRepostPendingVisibleInHistory(t *testing.T) {
+	prefix := uniquePrefix("repost_pending_history")
+	db := database.DBConn
+
+	groupID := CreateTestGroup(t, prefix)
+	posterID := CreateTestUser(t, prefix+"_poster", "User")
+	modID := CreateTestUser(t, prefix+"_mod", "User")
+	CreateTestMembership(t, posterID, groupID, "Member")
+	CreateTestMembership(t, modID, groupID, "Moderator")
+	_, modToken := CreateTestSession(t, modID)
+
+	// Simulate a manual repost: message is in Pending collection (content-check not yet run).
+	pendingSubject := prefix + " OFFER pending repost"
+	db.Exec(
+		"INSERT INTO messages (fromuser, subject, textbody, message, type, arrival) "+
+			"VALUES (?, ?, 'body', 'body', 'Offer', NOW())",
+		posterID, pendingSubject)
+	var pendingMsgID uint64
+	db.Raw("SELECT id FROM messages WHERE fromuser = ? AND subject = ? ORDER BY id DESC LIMIT 1",
+		posterID, pendingSubject).Scan(&pendingMsgID)
+	require.NotZero(t, pendingMsgID)
+	db.Exec(
+		"INSERT INTO messages_groups (msgid, groupid, arrival, collection) VALUES (?, ?, NOW(), 'Pending')",
+		pendingMsgID, groupID)
+
+	t.Cleanup(func() {
+		db.Exec("DELETE FROM messages_groups WHERE msgid = ?", pendingMsgID)
+		db.Exec("DELETE FROM messages WHERE id = ?", pendingMsgID)
+	})
+
+	// Fetch the poster as a moderator (modtools=true returns messagehistory).
+	url := fmt.Sprintf("/api/user/%d?modtools=true&jwt=%s", posterID, modToken)
+	resp, err := getApp().Test(httptest.NewRequest("GET", url, nil))
+	require.NoError(t, err)
+	require.Equal(t, 200, resp.StatusCode)
+
+	var raw map[string]interface{}
+	err = json.NewDecoder(resp.Body).Decode(&raw)
+	require.NoError(t, err)
+
+	history, ok := raw["messagehistory"].([]interface{})
+	require.True(t, ok, "messagehistory must be present for modtools fetch")
+
+	pendingFound := false
+	for _, h := range history {
+		entry, _ := h.(map[string]interface{})
+		if uint64(entry["id"].(float64)) == pendingMsgID {
+			pendingFound = true
+			// While we are here verify the collection field is exposed.
+			coll, _ := entry["collection"].(string)
+			assert.Equal(t, "Pending", coll, "messagehistory entry for pending message must carry collection='Pending'")
+		}
+	}
+
+	// FAILS on buggy code: GetUserMessageHistory returns collection='Approved' only.
+	assert.True(t, pendingFound,
+		"Manually reposted Pending message must appear in Posts history (Discourse #9481/562)")
+}
+
 // --- Test: PatchMessage ---
 
 func TestPatchMessage(t *testing.T) {

--- a/iznik-server-go/user/user.go
+++ b/iznik-server-go/user/user.go
@@ -476,6 +476,10 @@ func GetUserMessageHistory(userid uint64) []UserMessageHistory {
 	db := database.DBConn
 
 	var history []UserMessageHistory
+	// Include Pending so that manually-reposted messages (which re-enter Pending
+	// while awaiting content-check) remain visible in the Posts history.
+	// Rejected is excluded: rejected messages should not count as active posts
+	// (e.g. $recentwanted substitution). Discourse #9481/562.
 	db.Raw("SELECT m.id, m.subject, m.type, "+
 		"GREATEST(COALESCE(mp.date, m.arrival), COALESCE(mp.date, m.arrival)) AS arrival, "+
 		"mg.groupid, mg.collection, "+
@@ -483,8 +487,8 @@ func GetUserMessageHistory(userid uint64) []UserMessageHistory {
 		"FROM messages m "+
 		"INNER JOIN messages_groups mg ON m.id = mg.msgid "+
 		"LEFT JOIN messages_postings mp ON mp.msgid = m.id "+
-		"WHERE m.fromuser = ? AND mg.deleted = 0 AND m.deleted IS NULL AND mg.collection = ? "+
-		"ORDER BY arrival DESC", userid, utils.COLLECTION_APPROVED).Scan(&history)
+		"WHERE m.fromuser = ? AND mg.deleted = 0 AND m.deleted IS NULL AND mg.collection IN (?, ?) "+
+		"ORDER BY arrival DESC", userid, utils.COLLECTION_APPROVED, utils.COLLECTION_PENDING).Scan(&history)
 
 	now := time.Now()
 	for ix, h := range history {


### PR DESCRIPTION
## Root Cause

`GetUserMessageHistory` (used by ModPostingHistoryModal via `GET /api/user/:id?modtools=true`) filtered messages to `collection = 'Approved'` only.

When a member manually reposts a message (BackToDraft → edit → JoinAndPost), the message re-enters the content-check pipeline as `Pending`. During that window — until the `messages:contentcheck` batch job promotes it to Approved — the post was invisible in the member's Posts history.

Auto-reposts (`AutoRepostService`) are unaffected because they keep the message in Approved by updating `arrival` in-place rather than moving it through JoinAndPost.

## Fix

Include `Pending` alongside `Approved` in the `GetUserMessageHistory` query:

```go
// Before:
"WHERE m.fromuser = ? AND mg.deleted = 0 AND m.deleted IS NULL AND mg.collection = ?"
// userid, COLLECTION_APPROVED

// After:
"WHERE m.fromuser = ? AND mg.deleted = 0 AND m.deleted IS NULL AND mg.collection IN (?, ?)"
// userid, COLLECTION_APPROVED, COLLECTION_PENDING
```

`Rejected` is intentionally excluded (rejected messages should not count as active posts).

The `UserMessageHistory` struct already carries a `Collection` field, and `ModPostingHistoryModal.vue` already renders `collection === 'Pending'` in red — so no frontend changes are needed.

## Test

Added `TestManualRepostPendingVisibleInHistory` (AssertFlip pattern):
- Inserts a message in `Pending` collection for a user
- Fetches that user with `modtools=true`
- **FAILS** on buggy code (Pending filtered out of messagehistory)
- **PASSES** after fix (Pending included)

The pre-existing `TestRecentWanted_GoAPI_ExcludesNonApproved` continues to pass (Rejected still excluded).

## Discourse

https://discourse.ilovefreegle.org/t/9481/562