### PR TITLE
fix(calendar/events): prefer polygon containment over centroid distance for group assignment

### DIFF
--- a/iznik-batch/app/Models/Location.php
+++ b/iznik-batch/app/Models/Location.php
@@ -73,6 +73,28 @@ class Location extends Model implements Auditable
 
     public static function groupsNear(float $lat, float $lng, int $radiusMiles = 50, int $limit = 10): array
     {
+        $srid     = config('freegle.srid', 3857);
+        $pointWkt = "POINT($lng $lat)";
+
+        // Polygon-containment check: if the point lies inside one or more group
+        // polyindex polygons, those groups are authoritative and beat the centroid-
+        // distance heuristic (V1 parity; fixes Discourse #9763 where a group with
+        // a close centroid but non-containing polyindex shadowed the correct group).
+        $containing = DB::select(
+            "SELECT id
+             FROM `groups`
+             WHERE publish = 1 AND listable = 1
+               AND ST_Contains(polyindex, ST_GeomFromText(?, ?))
+             ORDER BY haversine(lat, lng, ?, ?) ASC
+             LIMIT ?",
+            [$pointWkt, $srid, $lat, $lng, $limit]
+        );
+
+        if (!empty($containing)) {
+            return array_column($containing, 'id');
+        }
+
+        // No group polygon contains the point; fall back to centroid distance.
         $rows = DB::select(
             "SELECT id
              FROM `groups`

--- a/iznik-batch/tests/Unit/Models/LocationTest.php
+++ b/iznik-batch/tests/Unit/Models/LocationTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Models;
 
+use App\Models\Group;
 use App\Models\Location;
 use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
@@ -64,6 +65,54 @@ class LocationTest extends TestCase
         $result = Location::closestPostcode(30.0, -40.0);
 
         $this->assertNull($result);
+    }
+
+    /**
+     * groupsNear must prefer polygon containment over centroid distance.
+     *
+     * Regression for Discourse #9763 — a Southwark repair-workshop event appeared on
+     * Tower Hamlets Freegle because the implementation used centroid distance only.
+     * When a group's polyindex polygon contains the event location, that group must
+     * win even when another group has a closer centroid.
+     */
+    public function test_groups_near_returns_containing_group_over_closer_centroid(): void
+    {
+        $srid = config('freegle.srid', 3857);
+
+        // Event location: Bermondsey, SE1 (Southwark area)
+        $eventLat = 51.490;
+        $eventLng = -0.090;
+
+        // Group A (Southwark): centroid ~8 km from event, but polyindex POLYGON contains event.
+        $southwark = $this->createTestGroup([
+            'lat'      => 51.450,
+            'lng'      => -0.200,
+            'publish'  => 1,
+            'listable' => 1,
+        ]);
+        // Override the auto-created POINT polyindex with a polygon that covers the event location.
+        // WKT uses the same "lat/lng degree coordinates labeled SRID 3857" convention used
+        // throughout the codebase for polyindex (ST_GeomFromText(poly, 3857) where poly is WGS84).
+        DB::statement(
+            "UPDATE `groups` SET polyindex = ST_GeomFromText(?, ?) WHERE id = ?",
+            ['POLYGON((-0.15 51.46, -0.15 51.52, -0.05 51.52, -0.05 51.46, -0.15 51.46))', $srid, $southwark->id]
+        );
+
+        // Group B (Tower Hamlets): centroid ~140 m from event (very close), but polyindex is
+        // a POINT — ST_Contains(POINT, POINT) returns false for non-identical points.
+        $towerHamlets = $this->createTestGroup([
+            'lat'      => 51.491,
+            'lng'      => -0.089,
+            'publish'  => 1,
+            'listable' => 1,
+        ]);
+
+        $groups = Location::groupsNear($eventLat, $eventLng, 50);
+
+        // Southwark's polygon contains the event: it must be returned.
+        $this->assertContains($southwark->id, $groups, 'Group whose polygon contains the event must be returned');
+        // Tower Hamlets has no containing polygon: it must not shadow the correct group.
+        $this->assertNotContains($towerHamlets->id, $groups, 'Group with no containing polygon must not appear when containment match exists');
     }
 
     public function test_closest_postcode_includes_area_data(): void


### PR DESCRIPTION
## Bug

Discourse #9763 — a Southwark repair-workshop event from Restart Project's API was appearing on Tower Hamlets Freegle.

## Root cause

`Location::groupsNear()` in iznik-batch used **haversine centroid distance only**. The V1 PHP equivalent (`iznik-server/include/misc/Location.php`) uses polygon containment (`ST_Contains(polyindex, point)`) first, falling back to centroid distance only when no polygon contains the point.

Tower Hamlets' centroid was ~140 m from the event (very close), so it ranked first. Southwark's centroid was ~8 km away but its `polyindex` polygon covered the event location — that signal was ignored entirely.

## Fix

Two-phase query in `Location::groupsNear()`:
1. **Containment first**: `ST_Contains(polyindex, point)` — if any group polygon contains the point, those groups are returned (ordered by centroid distance as tiebreaker).
2. **Haversine fallback**: only if no polygon contains the point, fall back to the old centroid-distance query.

This restores V1 parity. Groups without real polygon areas have a `POINT` polyindex (set by `Group::boot()`), which never passes `ST_Contains` for a different point, so the fallback preserves existing behaviour for those groups.

All event-scraping services that call `groupsNear()` benefit: `RestartProjectService`, `RepairCafeWalesService`, `ReachVolunteeringService`.

## Test

`test_groups_near_returns_containing_group_over_closer_centroid` in `LocationTest`:
- Creates Southwark group with polygon covering the event location (centroid ~8 km away)
- Creates Tower Hamlets group with only a POINT polyindex (centroid ~140 m away)
- Asserts Southwark is returned and Tower Hamlets is not

On buggy code Tower Hamlets wins (haversine only); on fixed code Southwark wins (containment).

## Note on local test run

The local test environment was blocked by a concurrent FSM agent repeatedly running `migrate:fresh` against the shared `iznik_batch_test` database, causing bootstrapping failures. The fix and test have been reviewed for correctness; CI will give the authoritative run.