### PR TITLE
fix(authentication): scope GetSession to the requesting session to fix cross-context logout (#9748/4)

### DIFF
--- a/iznik-server-go/session/session.go
+++ b/iznik-server-go/session/session.go
@@ -835,7 +835,31 @@ func GetSession(c *fiber.Ctx) error {
 	}()
 	go func() {
 		defer wg.Done()
-		db.Raw("SELECT id, series, token FROM sessions WHERE userid = ? LIMIT 1", myid).Scan(&sessionRow)
+		// Use the session that authenticated this specific request so the
+		// returned JWT/persistent carries the correct series for this context.
+		// LIMIT 1 returned an arbitrary (typically oldest) session, so a user
+		// logged into both Freegle and ModTools would receive the wrong series
+		// after GET /session, causing subsequent logout to delete the wrong
+		// app's sessions. Discourse #9748.
+		if _, reqSessionId, _ := user.GetJWTFromRequest(c); reqSessionId > 0 {
+			db.Raw("SELECT id, series, token FROM sessions WHERE id = ? AND userid = ?",
+				reqSessionId, myid).Scan(&sessionRow)
+		}
+		if sessionRow.ID == 0 {
+			// Authorization2 persistent-token fallback: its ID field is the sessions row pk.
+			if pt := c.Get("Authorization2"); pt != "" {
+				var persistentTok auth.PersistentToken
+				if json.Unmarshal([]byte(pt), &persistentTok) == nil && persistentTok.ID > 0 {
+					db.Raw("SELECT id, series, token FROM sessions WHERE id = ? AND userid = ?",
+						persistentTok.ID, myid).Scan(&sessionRow)
+				}
+			}
+		}
+		if sessionRow.ID == 0 {
+			// Last resort: LIMIT 1 covers the case where neither auth method
+			// identifies a specific session row (backward compatibility).
+			db.Raw("SELECT id, series, token FROM sessions WHERE userid = ? LIMIT 1", myid).Scan(&sessionRow)
+		}
 	}()
 	go func() {
 		defer wg.Done()

--- a/iznik-server-go/test/session_test.go
+++ b/iznik-server-go/test/session_test.go
@@ -1079,6 +1079,55 @@ func TestDeleteSessionScopedToCurrentSeries(t *testing.T) {
 	assert.Equal(t, int64(1), count(idC), "other app session (series 2) must remain logged in")
 }
 
+// TestGetSessionReturnsSendersSeries verifies that GET /session returns the
+// persistent/JWT tied to the SESSION that authenticated the request, not an
+// arbitrary first session in the DB.
+//
+// Regression for Discourse #9748 (post 4): DeleteSession already scopes
+// logout to the current login series, but GetSession was still running
+// "SELECT ... FROM sessions WHERE userid = ? LIMIT 1", which returns the
+// oldest session. When a user has two active contexts (e.g. Freegle and
+// ModTools), the second login's GET /session overwrites its auth store with
+// the first login's series. Subsequent logout then deletes the WRONG series,
+// logging the user out of the other app.
+func TestGetSessionReturnsSendersSeries(t *testing.T) {
+	prefix := uniquePrefix("get_sess_series")
+	userID := CreateTestUser(t, prefix, "User")
+	db := database.DBConn
+
+	series1 := userID*1000 + 1
+	series2 := userID*1000 + 2
+
+	mk := func(series uint64) uint64 {
+		db.Exec("INSERT INTO sessions (userid, series, token, date, lastactive) VALUES (?, ?, 1, NOW(), NOW())", userID, series)
+		var id uint64
+		db.Raw("SELECT id FROM sessions WHERE userid = ? ORDER BY id DESC LIMIT 1", userID).Scan(&id)
+		return id
+	}
+	// Create both sessions; idFirst has the lower pk (LIMIT 1 picks this one on bugged code).
+	idFirst := mk(series1)
+	idSecond := mk(series2)
+
+	// Authenticate as the SECOND session.
+	token := GetToken(userID, idSecond)
+	req := httptest.NewRequest("GET", "/api/session?jwt="+token, nil)
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&result)
+	assert.Equal(t, float64(0), result["ret"])
+
+	persistent, _ := result["persistent"].(map[string]interface{})
+	assert.NotNil(t, persistent, "persistent token should be returned")
+	// The persistent token must identify the session that made the request
+	// (idSecond / series2), not the first session in the DB (idFirst / series1).
+	assert.Equal(t, float64(idSecond), persistent["id"],
+		"persistent.id must match the requesting session, not the oldest session (idFirst=%d)", idFirst)
+	assert.Equal(t, fmt.Sprintf("%d", series2), fmt.Sprintf("%v", persistent["series"]),
+		"persistent.series must match the requesting session's series")
+}
+
 // ---------------------------------------------------------------------------
 // POST /session - Forget
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Root cause**: `GetSession` ran `SELECT … FROM sessions WHERE userid = ? LIMIT 1`, returning an arbitrary (typically oldest) session row regardless of which session authenticated the request. When a user is logged into both Freegle and ModTools, the second app's GET /session overwrote its auth store with the first app's series. Subsequent logout then called DELETE with the wrong series, clearing the other app's sessions.
- **Fix**: Extract the session ID from the request's JWT claim (or Authorization2 persistent-token ID) and query `WHERE id = ? AND userid = ?` to return only the authenticating session's row. Falls back to `LIMIT 1` only when neither auth method identifies a specific session (backward compatibility).
- **Existing fix preserved**: DeleteSession's series-based deletion from #611 is unchanged and correct; this fix ensures the series data it relies on is always sourced from the right session.

## Test plan

- [ ] `TestGetSessionReturnsSendersSeries` (new) — creates two sessions with distinct series, calls GET /session authenticated as the newer session, asserts `persistent.id` and `persistent.series` match the authenticating session, not the LIMIT 1 result
- [ ] `TestDeleteSessionScopedToCurrentSeries` (existing) — verifies DELETE /session only removes the caller's series
- [ ] Full Go test suite passes

Discourse: https://discourse.ilovefreegle.org/t/9748/4

🤖 Generated with [Claude Code](https://claude.com/claude-code)