### PR TITLE
fix(image-upload): mark aborted TUS upload as error to prevent stuck uploading state

### DIFF
--- a/iznik-nuxt3/components/PhotoUploader.vue
+++ b/iznik-nuxt3/components/PhotoUploader.vue
@@ -254,6 +254,7 @@ const pendingPhoto = ref(null)
 // Always show first photo as the featured/primary one
 const selectedIndex = ref(0)
 let uploadInstance = null
+let uploadingPhoto = null // Photo associated with the current in-progress TUS upload
 let tempIdCounter = 0
 
 // Computed property for the selected photo
@@ -405,8 +406,16 @@ async function uploadPhoto(photo, webPath) {
     await new Promise((resolve, reject) => {
       if (uploadInstance) {
         uploadInstance.abort()
+        // tus.abort() never fires onError/onSuccess, so the Promise we wrapped
+        // around the previous upload would hang forever. Mark that photo as
+        // errored immediately so the user gets feedback and can retry.
+        if (uploadingPhoto && uploadingPhoto.uploading) {
+          uploadingPhoto.error = true
+          uploadingPhoto.uploading = false
+        }
       }
 
+      uploadingPhoto = photo
       uploadInstance = new tus.Upload(file, {
         endpoint: runtimeConfig.public.TUS_UPLOADER,
         retryDelays: [0, 3000, 5000, 10000, 20000],

--- a/iznik-nuxt3/tests/unit/components/PhotoUploader.spec.js
+++ b/iznik-nuxt3/tests/unit/components/PhotoUploader.spec.js
@@ -1411,4 +1411,30 @@ describe('PhotoUploader', () => {
       expect(wrapper.vm.photos[0].id).toBe(1)
     })
   })
+
+  // Bug: concurrent uploadPhoto calls abort the previous TUS upload but tus.abort()
+  // never calls onError/onSuccess, so the aborted photo's Promise hangs forever
+  // (uploading stays true, error stays false — user sees a permanent spinner with no retry).
+  // Fix: track the photo associated with the in-progress upload and mark it errored on abort.
+  describe('concurrent upload abort (9764-1)', () => {
+    it('when second upload starts while first is in-progress, aborted photo should be marked error not stuck uploading', async () => {
+      createWrapper()
+      await flushPromises()
+
+      // Start two uploads without awaiting — simulates user quickly adding photos
+      // while a previous upload is still in-flight on a slow mobile connection.
+      wrapper.vm.processPhoto('blob://photo1.jpg')
+      wrapper.vm.processPhoto('blob://photo2.jpg')
+      await flushPromises()
+
+      // photo1's TUS upload was aborted by photo2's upload start.
+      // After the fix: photo1 must be marked as errored (not stuck in uploading=true).
+      const photo1 = wrapper.vm.photos.find(
+        (p) => p.preview === 'blob://photo1.jpg'
+      )
+      expect(photo1).toBeDefined()
+      expect(photo1.uploading).toBe(false) // FAILS on buggy code (stuck uploading=true)
+      expect(photo1.error).toBe(true) // FAILS on buggy code (error never set)
+    })
+  })
 })


### PR DESCRIPTION
## Root cause

`PhotoUploader.vue` keeps a single `uploadInstance` variable for the in-progress TUS upload. When a new upload starts while one is already in-flight, it calls `uploadInstance.abort()`. The TUS library's `abort()` never fires `onError` or `onSuccess`, so the `Promise` wrapping the first upload hangs forever, leaving `photo.uploading` stuck at `true` with no error shown. On slow mobile connections (Samsung Android) users add several photos in quick succession — each new photo aborts the previous one — and every aborted photo ends up permanently stuck in a spinner state. After 6–7 uploads the component appears broken.

## Fix

Track the in-progress photo alongside `uploadInstance` in a new `uploadingPhoto` variable. On abort, immediately mark that photo `error = true` / `uploading = false` so the user gets feedback and can retry, rather than being silently blocked.

```diff
+let uploadingPhoto = null // Photo associated with the current in-progress TUS upload

 if (uploadInstance) {
   uploadInstance.abort()
+  if (uploadingPhoto && uploadingPhoto.uploading) {
+    uploadingPhoto.error = true
+    uploadingPhoto.uploading = false
+  }
 }

+uploadingPhoto = photo
 uploadInstance = new tus.Upload(file, { ... })
```

## Evidence

- Discourse topic 9764 post 1: "Member on Samsung Android cannot upload images after 6-7 attempts."
- The abort path is the only code path that can leave `photo.uploading = true` permanently — `onError` and `onSuccess` always clear it; `abort()` does not.

## Test

New unit test in `PhotoUploader.spec.js` (suite `concurrent upload abort (9764-1)`):
- Calls `processPhoto` twice without `await` to simulate rapid mobile photo selection
- Verifies the aborted first photo ends up with `uploading = false` and `error = true`
- **Fails on unfixed code** ("expected true to be false"); **passes after fix** (89/89 tests passing)

## Donation error (second symptom from 9764)

The report also mentioned "donation via PayPal card payment shows an error message." After reviewing `StripeDonate.vue`, `DonationButton.vue`, and `donate.vue`: no Freegle-owned code defect was identified. The error originates inside the Stripe/PayPal payment processor iframe. Would need a reproduction with browser devtools to investigate further.

## Discourse link

https://discourse.ilovefreegle.org/t/9764

🤖 Generated with [Claude Code](https://claude.com/claude-code)