### PR TITLE
fix(modtools): exclude deleted-user messages from the push badge count (#9654/12)

### DIFF
--- a/iznik-batch/app/Services/PushNotificationService.php
+++ b/iznik-batch/app/Services/PushNotificationService.php
@@ -363,10 +363,16 @@ class PushNotificationService
      * - Only ACTIVE groups (membership settings.active != 0 and settings.showmessages != 0)
      * - Only unheld pending messages (heldby IS NULL)
      * - Only spam collection messages (not spamtype in Pending)
-     * - Excludes deleted (mg.deleted = 0) and system messages (fromuser IS NOT NULL)
+     * - Excludes deleted messages (mg.deleted = 0)
+     * - INNER JOINs users with u.deleted IS NULL, so system messages (null fromuser)
+     *   AND messages whose author has been deleted are both excluded — matching the
+     *   app menu (session.go), which filters them too. Without this a pending message
+     *   from a deleted user is counted in the badge but hidden from the menu, leaving
+     *   a phantom +1 the mod can never clear (Discourse #9654/12).
      *
-     * This prevents phantom badges caused by held messages, deleted messages, or
-     * work from inactive groups inflating the count while the app shows nothing.
+     * This prevents phantom badges caused by held messages, deleted messages,
+     * deleted-user messages, or work from inactive groups inflating the count while
+     * the app shows nothing.
      *
      * Note: currently covers only pending + spam (2 of 14 session.go work categories).
      * Omitted categories: pendingmembers, spammembers, pendingevents, pendingadmins,
@@ -408,13 +414,13 @@ class PushNotificationService
         $pending = DB::selectOne(
             "SELECT COUNT(*) as cnt FROM messages_groups mg
              INNER JOIN messages m ON m.id = mg.msgid
+             INNER JOIN users u ON u.id = m.fromuser AND u.deleted IS NULL
              INNER JOIN memberships mem ON mem.groupid = mg.groupid AND mem.userid = ?
              WHERE mem.role IN ('Owner', 'Moderator')
              AND mem.collection = 'Approved'
              AND mg.collection = 'Pending'
              AND mg.groupid IN ({$placeholders})
              AND mg.deleted = 0
-             AND m.fromuser IS NOT NULL
              AND m.heldby IS NULL",
             $pendingParams
         );
@@ -424,13 +430,13 @@ class PushNotificationService
         $spam = DB::selectOne(
             "SELECT COUNT(*) as cnt FROM messages_groups mg
              INNER JOIN messages m ON m.id = mg.msgid
+             INNER JOIN users u ON u.id = m.fromuser AND u.deleted IS NULL
              INNER JOIN memberships mem ON mem.groupid = mg.groupid AND mem.userid = ?
              WHERE mem.role IN ('Owner', 'Moderator')
              AND mem.collection = 'Approved'
              AND mg.collection = 'Spam'
              AND mg.groupid IN ({$placeholders})
-             AND mg.deleted = 0
-             AND m.fromuser IS NOT NULL",
+             AND mg.deleted = 0",
             $spamParams
         );
 

--- a/iznik-batch/tests/Unit/Services/PushNotificationServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/PushNotificationServiceTest.php
@@ -209,6 +209,49 @@ class PushNotificationServiceTest extends TestCase
     }
 
     /**
+     * Pending messages from DELETED users must NOT count towards the badge.
+     *
+     * Regression for Discourse #9654/12: mods reported the ModTools badge stuck at
+     * +1 after clearing all visible tasks. Root cause: getBadgeCount() counted
+     * pending messages whose author had been deleted (fromuser set, but
+     * users.deleted IS NOT NULL), while the app menu (session.go) filters them via
+     * INNER JOIN users ... u.deleted IS NULL. The phantom message is in the badge
+     * but not the menu, so the mod can never clear it. Live data at diagnosis time:
+     * 32 such messages across 24 groups.
+     */
+    public function test_pending_message_from_deleted_user_does_not_count_towards_badge(): void
+    {
+        $mod = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $this->createMembership($mod, $group, ['role' => Membership::ROLE_MODERATOR]);
+
+        $sender = $this->createTestUser(['deleted' => now()]);  // author deleted
+        $message = Message::create([
+            'fromuser' => $sender->id,
+            'type' => Message::TYPE_OFFER,
+            'subject' => 'OFFER: Test (Location)',
+            'textbody' => 'Test',
+            'source' => 'Platform',
+            'date' => now(),
+            'arrival' => now(),
+            'lat' => $group->lat,
+            'lng' => $group->lng,
+            'heldby' => null,  // not held — would count if author were live
+        ]);
+        MessageGroup::create([
+            'msgid' => $message->id,
+            'groupid' => $group->id,
+            'collection' => MessageGroup::COLLECTION_PENDING,
+            'arrival' => now(),
+            'deleted' => 0,
+        ]);
+
+        $count = $this->service->getBadgeCount($mod->id);
+
+        $this->assertEquals(0, $count, 'Pending messages from deleted users must not inflate badge count (Discourse #9654/12)');
+    }
+
+    /**
      * Pending messages in inactive groups must NOT count towards the badge.
      *
      * Session.go excludes inactive group work from `total` (it goes to pendingother/blue).


### PR DESCRIPTION
## Root Cause
The ModTools iOS/Android push badge (`PushNotificationService::getBadgeCount`) counted pending/spam messages whose author had been **deleted** — its queries only checked `m.fromuser IS NOT NULL`, missing `u.deleted IS NULL`. The app menu (session.go) *does* filter those, so such a message is counted in the badge but hidden from the menu: a phantom **+1 the moderator can never clear** by actioning visible work. (Discourse #9654/12: "count stuck at 1 after completing all tasks; iOS banner +1".)

## Evidence
- Live production at diagnosis: **32 phantom pending messages across 24 groups** (0 spam) — counted in badge, hidden in menu.
- Test fails before the fix (badge returns 1), passes after (0). Full `PushNotificationServiceTest` class green (35 tests).

## Fix
Add `INNER JOIN users u ON u.id = m.fromuser AND u.deleted IS NULL` to the pending and spam queries in `getBadgeCount`, mirroring session.go. The now-redundant `m.fromuser IS NOT NULL` is dropped (the join subsumes it; the existing null-fromuser test still passes).

## Test
`iznik-batch` `PushNotificationServiceTest::test_pending_message_from_deleted_user_does_not_count_towards_badge` — fail-before / pass-after; full class green.

## Follow-up (not in this PR)
Root cause is upstream: these users were deleted via a path that does **not** mark their pending messages deleted (all 32 have `m.deleted IS NULL`; the forget path `User.php:5932-5936` does mark them). `purge_messages.php` only sweeps very old Pending rows (a long cycle, which is acceptable). A separate fix should ensure all user-deletion paths clean up pending messages, correcting the menu/data at source.

## Discourse
https://discourse.ilovefreegle.org/t/9654/12