### PR TITLE
fix(modtools-editing): show and preserve neighbourhood name when editing posts

### DIFF
--- a/iznik-nuxt3/modtools/components/ModMessage.vue
+++ b/iznik-nuxt3/modtools/components/ModMessage.vue
@@ -49,6 +49,12 @@
               </div>
               <div v-if="editmessage.item && editmessage.location">
                 <b-input-group>
+                  <b-form-input
+                    v-model="editmessage.location.areaname"
+                    size="lg"
+                    class="me-1 areaname-input"
+                    placeholder="Neighbourhood"
+                  />
                   <PostCode
                     :value="editmessage.location.name"
                     :find="false"
@@ -1236,6 +1242,7 @@ async function save() {
         msgtype: editmessage.value.type,
         item: editmessage.value.item.name,
         location: editmessage.value.location.name,
+        areaname: editmessage.value.location.areaname,
         attachments: attids,
         textbody: editmessage.value.textbody,
       })
@@ -1444,6 +1451,10 @@ function spamReport() {
   /* Cap growth on wide desktop so the field doesn't stretch the whole row.
      flex-grow-1 keeps it filling available space up to this cap. */
   max-width: 500px;
+}
+
+.areaname-input {
+  max-width: 160px;
 }
 
 .fullsubject {

--- a/iznik-nuxt3/tests/unit/components/modtools/ModMessage.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModMessage.spec.js
@@ -1316,4 +1316,47 @@ describe('ModMessage', () => {
       expect(labelSpan.text()).toBe('Back to Pending')
     })
   })
+
+  // Regression tests for Discourse #9769/1 — location (neighbourhood) name
+  // must be shown and preserved when a mod edits a post.
+  describe('location areaname editing (Discourse #9769/1)', () => {
+    it('save sends areaname from message location', async () => {
+      // The mod should not need to change anything for the area name to be preserved.
+      const wrapper = mountComponent(
+        {},
+        {
+          item: { name: 'Kitchen Table' },
+          location: { name: 'E1 1AA', areaname: 'Stepney' },
+        }
+      )
+      wrapper.vm.startEdit()
+      await wrapper.vm.save()
+
+      expect(mockMessageStore.patch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          areaname: 'Stepney',
+        })
+      )
+    })
+
+    it('save preserves a custom area name without overwriting with postcode default', async () => {
+      // If the stored area name differs from the Mapping default (e.g. "Whitechapel"
+      // vs the postcode default "Stepney"), the custom name must survive a no-op save.
+      const wrapper = mountComponent(
+        {},
+        {
+          item: { name: 'Kitchen Table' },
+          location: { name: 'E1 1AA', areaname: 'Whitechapel' },
+        }
+      )
+      wrapper.vm.startEdit()
+      await wrapper.vm.save()
+
+      expect(mockMessageStore.patch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          areaname: 'Whitechapel',
+        })
+      )
+    })
+  })
 })

--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -1527,6 +1527,32 @@ func getAllGroupsForMessage(db *gorm.DB, msgid uint64) []uint64 {
 	return groupids
 }
 
+// buildLocStrFromInfo is the pure, database-free core of the location string builder.
+// locName is the raw location record name (e.g. "E1 1AA" for a postcode),
+// locType is the location type ("Postcode" or any other value),
+// dbAreaName is the area name looked up from the DB mapping (used when customArea is empty),
+// customArea is an optional mod-supplied override — when non-empty it replaces dbAreaName.
+func buildLocStrFromInfo(locName, locType, dbAreaName, customArea string) string {
+	areaToUse := dbAreaName
+	if customArea != "" {
+		areaToUse = customArea
+	}
+	if locType == "Postcode" {
+		vaguePC := locName
+		if idx := strings.Index(vaguePC, " "); idx > 0 {
+			vaguePC = vaguePC[:idx]
+		}
+		if areaToUse != "" {
+			return areaToUse + " " + vaguePC
+		}
+		return vaguePC
+	}
+	if customArea != "" {
+		return customArea
+	}
+	return locName
+}
+
 // constructLocationString builds a location string for a message's subject,
 // using the area name + vague postcode format.
 // The vague postcode is the outward code only (e.g., "CB22" from "CB22 3AA").
@@ -2496,6 +2522,7 @@ type patchMessageRequest struct {
 	Lng          *float64 `json:"lng"`
 	Location     *string  `json:"location"`
 	Locationid   *uint64  `json:"locationid"`
+	Areaname     *string  `json:"areaname"`
 	Groupid      *uint64  `json:"groupid"`
 	Attachments  []uint64 `json:"attachments"`
 	BadAIImages  []uint64 `json:"badAIImages"`
@@ -2709,9 +2736,8 @@ func applyPatchMessageCore(c *fiber.Ctx, myid uint64, req patchMessageRequest) e
 		}
 	}
 
-	// Reconstruct subject from type + item + location when item/type/location changed
-	//.
-	if req.Item != nil || req.Type != nil || req.Location != nil || req.Locationid != nil {
+	// Reconstruct subject from type + item + location when item/type/location changed.
+	if req.Item != nil || req.Type != nil || req.Location != nil || req.Locationid != nil || req.Areaname != nil {
 		var msgType string
 		var itemName *string
 		db.Raw("SELECT type FROM messages WHERE id = ?", req.ID).Scan(&msgType)
@@ -2723,8 +2749,23 @@ func applyPatchMessageCore(c *fiber.Ctx, myid uint64, req patchMessageRequest) e
 			db.Raw("SELECT i.name FROM items i INNER JOIN messages_items mi ON mi.itemid = i.id WHERE mi.msgid = ? LIMIT 1", req.ID).Scan(&itemName)
 		}
 
-		// Build the location string using area + vague postcode.
-		locStr := constructLocationString(db, req.ID)
+		// Build the location string, using a mod-supplied area name when provided so
+		// the stored neighbourhood spelling is preserved rather than being silently
+		// overwritten by the postcode-mapping default (Discourse #9769/1).
+		var locStr string
+		if req.Areaname != nil && *req.Areaname != "" {
+			type locInfo struct {
+				Name   string
+				Type   string
+				Areaid uint64
+			}
+			var loc locInfo
+			db.Raw("SELECT l.name, l.type, COALESCE(l.areaid, 0) as areaid FROM locations l "+
+				"INNER JOIN messages m ON m.locationid = l.id WHERE m.id = ?", req.ID).Scan(&loc)
+			locStr = buildLocStrFromInfo(loc.Name, loc.Type, "", *req.Areaname)
+		} else {
+			locStr = constructLocationString(db, req.ID)
+		}
 
 		if itemName != nil && locStr != "" {
 			// Use the group keyword for the type (V1: group settings, defaults to uppercase).

--- a/iznik-server-go/message/message_pure_test.go
+++ b/iznik-server-go/message/message_pure_test.go
@@ -461,3 +461,56 @@ func TestIsAIAttachment_WhitespaceJSON(t *testing.T) {
 	mods := []byte(`  {  "ai" : true  }  `)
 	assert.True(t, isAIAttachment(mods))
 }
+
+// ── buildLocStrFromInfo ───────────────────────────────────────────────────────
+// Regression tests for the ModTools location-name-overwrite bug (Discourse #9769/1).
+// When a mod edits a message, the area name shown in the subject (e.g. "Stepney")
+// must be preserved — it must not be silently replaced with the postcode-mapping default.
+
+func TestBuildLocStrFromInfo_PostcodeWithDBArea(t *testing.T) {
+	// Standard case: postcode has a mapped area.
+	result := buildLocStrFromInfo("E1 1AA", "Postcode", "Stepney", "")
+	assert.Equal(t, "Stepney E1", result)
+}
+
+func TestBuildLocStrFromInfo_PostcodeCustomAreaOverridesDB(t *testing.T) {
+	// When a mod supplies a custom area name it must override the DB-derived one.
+	result := buildLocStrFromInfo("E1 1AA", "Postcode", "Stepney", "Whitechapel")
+	assert.Equal(t, "Whitechapel E1", result)
+}
+
+func TestBuildLocStrFromInfo_PostcodeNoArea(t *testing.T) {
+	// Postcode with no area: return only the outward code.
+	result := buildLocStrFromInfo("CB22 3AA", "Postcode", "", "")
+	assert.Equal(t, "CB22", result)
+}
+
+func TestBuildLocStrFromInfo_PostcodeCustomAreaNoDBArea(t *testing.T) {
+	// Custom area + postcode with no DB mapping.
+	result := buildLocStrFromInfo("CB22 3AA", "Postcode", "", "Teversham")
+	assert.Equal(t, "Teversham CB22", result)
+}
+
+func TestBuildLocStrFromInfo_NonPostcodeNoCustom(t *testing.T) {
+	// Non-postcode location: return the name as-is.
+	result := buildLocStrFromInfo("Stepney", "Area", "", "")
+	assert.Equal(t, "Stepney", result)
+}
+
+func TestBuildLocStrFromInfo_NonPostcodeCustomArea(t *testing.T) {
+	// Non-postcode location: custom area overrides the name.
+	result := buildLocStrFromInfo("Stepney", "Area", "", "Whitechapel")
+	assert.Equal(t, "Whitechapel", result)
+}
+
+func TestBuildLocStrFromInfo_EmptyCustomAreaFallsBackToDBArea(t *testing.T) {
+	// Empty custom area string must not suppress the DB area name.
+	result := buildLocStrFromInfo("E1 1AA", "Postcode", "Stepney", "")
+	assert.Equal(t, "Stepney E1", result)
+}
+
+func TestBuildLocStrFromInfo_PostcodeNoSpaceInName(t *testing.T) {
+	// Edge case: postcode with no space (malformed) — name used as vaguePC.
+	result := buildLocStrFromInfo("E1", "Postcode", "Stepney", "")
+	assert.Equal(t, "Stepney E1", result)
+}


### PR DESCRIPTION
## Root Cause

`ModMessage.vue` only displayed and transmitted the raw postcode string (e.g. `E1 1AA`) in its edit form — the neighbourhood/area name (e.g. `Stepney`) stored in `message.location.areaname` was never shown or included in the `messageStore.patch()` call.

On every save the Go API's `constructLocationString` re-derived the area name from the DB postcode mapping, permanently overwriting any custom area name the original moderator had set.  The PostCode field therefore acted as a one-way reset button.

## Evidence

```
// ModMessage.vue save() before fix — areaname never sent
await messageStore.patch({
  id: ..., msgtype: ..., item: ..., location: editmessage.value.location.name,
  //   ^^^ only raw postcode, no areaname
})
```

## Fix

**Frontend (`ModMessage.vue`)**
- Added editable `<b-form-input>` for `editmessage.location.areaname` alongside the PostCode field so the neighbourhood name is visible and editable.
- Added `areaname: editmessage.value.location.areaname` to `messageStore.patch()`.

**Go API (`message/message.go`)**
- Added `Areaname *string` to `patchMessageRequest`.
- Extracted new pure helper `buildLocStrFromInfo(locName, locType, dbAreaName, customArea string)` — testable without a DB.
- PATCH subject-rebuild path: when `req.Areaname` is non-empty, uses the custom area instead of the DB-derived default; falls back to `constructLocationString` when no area is supplied (existing behaviour unchanged).

## Other Call Sites

`constructLocationString` has three call sites:
- `message.go:2414` — POST create path; no moderator override needed; unchanged.
- `message.go:2767` — PATCH edit path; patched (uses custom area when supplied).
- `message.go:3433` — Draft subject rebuild on submission; no override needed; unchanged.

## Test

**Go pure tests** (`message_pure_test.go`): 8 new cases for `buildLocStrFromInfo` covering postcode + DB area, postcode + custom area override, postcode no area, non-postcode types.

**Vue unit tests** (`ModMessage.spec.js`): 2 regression tests confirming `messageStore.patch` receives the `areaname` field with both default and custom values.

Full suite: 596/597 files pass — the single failing file (`settings_ProfileSection.spec.js`) is pre-existing and unrelated (reproduces on master HEAD).

## Discourse

https://discourse.ilovefreegle.org/t/9769/1

🤖 Generated with [Claude Code](https://claude.com/claude-code)