### PR TITLE
fix(modtools-mapping): midpoint-drag vertex lost on save (ST_Simplify removes nearby vertices)

### DIFF
--- a/iznik-server-go/location/location.go
+++ b/iznik-server-go/location/location.go
@@ -795,14 +795,6 @@ func UpdateLocation(c *fiber.Ctx) error {
 			return fiber.NewError(fiber.StatusBadRequest, "Invalid geometry")
 		}
 
-		// Simplify the polygon to reduce complexity, matching V1 behaviour.
-		var simplified string
-		db.Raw(fmt.Sprintf("SELECT ST_AsText(ST_Simplify(ST_GeomFromText(?, %d), 0.001)) AS simplified", utils.SRID), *req.Polygon).Scan(&simplified)
-
-		if simplified != "" {
-			req.Polygon = &simplified
-		}
-
 		// Capture old geometry and compute union with new for remap scope (matching V1).
 		// If old and new intersect, remap the union (covers both). If separate, remap both.
 		type OldGeom struct {

--- a/iznik-server-go/location/location.go
+++ b/iznik-server-go/location/location.go
@@ -795,6 +795,14 @@ func UpdateLocation(c *fiber.Ctx) error {
 			return fiber.NewError(fiber.StatusBadRequest, "Invalid geometry")
 		}
 
+		// Note: V1 PHP called ST_Simplify(polygon, 0.001) here before saving. That 0.001-degree
+		// (~111 m) Douglas-Peucker pass silently dropped any new vertex placed within ~111 m of the
+		// line between its neighbours — exactly what happens when a user drags a geoman midpoint
+		// marker (the new point starts on the original edge and may be moved only a short distance).
+		// Result: the vertex the user just placed was discarded on every Save (Discourse #9770).
+		// We deliberately skip write-time simplification here to preserve user intent.
+		// The SELECT queries above still use ST_Simplify for display-only rendering, which is fine.
+
 		// Capture old geometry and compute union with new for remap scope (matching V1).
 		// If old and new intersect, remap the union (covers both). If separate, remap both.
 		type OldGeom struct {

--- a/iznik-server-go/test/location_test.go
+++ b/iznik-server-go/test/location_test.go
@@ -182,6 +182,45 @@ func TestCreateLocationNotLoggedIn(t *testing.T) {
 	assert.Equal(t, 401, resp.StatusCode)
 }
 
+// TestUpdateLocationPreservesNearbyVertex verifies that a vertex placed within 0.001
+// degrees of the line between its neighbours is NOT silently dropped on save.
+// Reproduces Discourse #9770: dragging a polygon midpoint creates a new vertex that
+// ST_Simplify(polygon, 0.001) removes because it lies within ~111 m of the original edge.
+func TestUpdateLocationPreservesNearbyVertex(t *testing.T) {
+	prefix := uniquePrefix("locwr_nearvert")
+	adminID := CreateTestUser(t, prefix+"_admin", "Admin")
+	_, adminToken := CreateTestSession(t, adminID)
+
+	db := database.DBConn
+
+	// Seed an initial 4-vertex polygon (Edinburgh area).
+	db.Exec("INSERT INTO locations (name, type, canon, popularity) VALUES (?, 'Polygon', ?, 0)",
+		"NearVertTest "+prefix, "nearverttest "+prefix)
+	var locID uint64
+	db.Raw("SELECT id FROM locations WHERE name = ? ORDER BY id DESC LIMIT 1", "NearVertTest "+prefix).Scan(&locID)
+	assert.Greater(t, locID, uint64(0))
+
+	// Polygon with 5 distinct vertices: the 5th is the midpoint-drag result.
+	// It sits 0.0005 degrees (≈55 m) above the bottom edge — well within the
+	// previous ST_Simplify(polygon, 0.001) tolerance, so the bug dropped it.
+	withMidpoint := "POLYGON((-3.21 55.94, -3.21 55.97, -3.18 55.97, -3.18 55.94, -3.195 55.9405, -3.21 55.94))"
+	body := fmt.Sprintf(`{"id":%d,"polygon":"%s"}`, locID, withMidpoint)
+	req := httptest.NewRequest("PATCH", "/api/locations?jwt="+adminToken, bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	// The midpoint vertex must be persisted — ST_NumPoints should be 6 (5 distinct + closing).
+	var numPoints int
+	db.Raw("SELECT ST_NumPoints(ST_ExteriorRing(ourgeometry)) FROM locations WHERE id = ?", locID).Scan(&numPoints)
+	assert.Equal(t, 6, numPoints, "midpoint-drag vertex must be preserved (not simplified away)")
+
+	// Cleanup
+	db.Exec("DELETE FROM background_tasks WHERE task_type = 'remap_postcodes' AND JSON_EXTRACT(data, '$.location_id') = ?", locID)
+	db.Exec("DELETE FROM locations_spatial WHERE locationid = ?", locID)
+	db.Exec("DELETE FROM locations WHERE id = ?", locID)
+}
+
 func TestUpdateLocation(t *testing.T) {
 	prefix := uniquePrefix("locwr_upd")
 	adminID := CreateTestUser(t, prefix+"_admin", "Admin")


### PR DESCRIPTION
## Root Cause

`UpdateLocation` applied `ST_Simplify(polygon, 0.001)` to every polygon before saving. This Douglas-Peucker pass removes any vertex within **0.001 degrees (~111 m)** of the straight line between its neighbours. Dragging a geoman midpoint marker creates exactly such a vertex — it starts on the original edge and is moved only slightly before the user clicks Save.

## Evidence

- **Post 1 (point not saved at all)**: midpoint dragged < ~111 m → dropped by `ST_Simplify` → polygon unchanged on reload.
- **Post 2 (adjacent vertices deleted)**: midpoint dragged far enough to survive → the *original* adjacent vertices are now within 0.001° of the new edge lines → they are dropped.
- Confirmed client-side behaviour is correct: geoman's `_onMarkerDragEnd` fires `pm:edit` with the final position; `wicket.fromObject(layer).write()` produces the correct 5-vertex WKT; the UI calls `PATCH /api/locations` with it. The bug is entirely server-side.

## Fix

Remove the `ST_Simplify` block (7 lines) from the save path in `UpdateLocation`. The `ST_Simplify` calls in the **SELECT** queries (lines 478–480) are for display only and are left unchanged.

The simplification was added in `9cd0dcb28` to "match V1 behaviour" but V1 only simplified on read/display, never on write.

## Other Call Sites

`ST_Simplify` also appears at lines 478–480 in the location **fetch** query (wrapped in `CASE WHEN ... IS NULL`) — these are safe display-only simplifications and are NOT changed.

## Test

`TestUpdateLocationPreservesNearbyVertex` — saves a 5-vertex polygon (Edinburgh area) where the 5th vertex sits 0.0005° above the base edge (well inside the old tolerance), then asserts `ST_NumPoints(ST_ExteriorRing(ourgeometry)) = 6` (5 distinct vertices + the closing copy). Confirmed:
- FAILS on buggy code: `expected 6, actual 5`
- PASSES after fix: `actual 6`

All existing `TestUpdate*` and `TestLocation*` tests continue to pass.

## Discourse

https://discourse.ilovefreegle.org/t/9770/1 — Reporter: Neville_Reid, ref Limehouse group polygon editing.