### PR TITLE
fix(moderation): exclude Cloudflare/shared-CDN IPs from IP-abuse warning

### DIFF
--- a/iznik-batch/app/Services/ContentCheckService.php
+++ b/iznik-batch/app/Services/ContentCheckService.php
@@ -1147,11 +1147,76 @@ class ContentCheckService
      */
     private const IP_ABUSE_ID_CAP = 50;
 
+    /**
+     * Known shared infrastructure IP ranges that must never trigger the IP
+     * abuse warning. Co-occurrence on these IPs is meaningless — they are
+     * used by CDN edge nodes, DNS resolvers, and carrier-grade NAT, not by
+     * individual households.
+     *
+     * Cloudflare ranges: https://www.cloudflare.com/ips-v4
+     * CGNAT (RFC 6598): carrier-grade NAT shared address space
+     */
+    private const SHARED_INFRASTRUCTURE_CIDRS = [
+        '173.245.48.0/20',
+        '103.21.244.0/22',
+        '103.22.200.0/22',
+        '103.31.4.0/22',
+        '141.101.64.0/18',
+        '108.162.192.0/18',
+        '190.93.240.0/20',
+        '188.114.96.0/20',
+        '197.234.240.0/22',
+        '198.41.128.0/17',
+        '162.158.0.0/15',
+        '104.16.0.0/13',
+        '104.24.0.0/14',
+        '172.64.0.0/13',
+        '131.0.72.0/22',
+        '100.64.0.0/10',
+    ];
+
+    /**
+     * Returns true if $ip falls within any of the shared infrastructure CIDRs.
+     * Only handles IPv4; IPv6 addresses are passed through (not excluded).
+     */
+    private function isSharedInfrastructureIp(string $ip): bool
+    {
+        $ipBin = @inet_pton($ip);
+        if ($ipBin === false || strlen($ipBin) !== 4) {
+            return false;
+        }
+        foreach (self::SHARED_INFRASTRUCTURE_CIDRS as $cidr) {
+            [$network, $prefixLen] = explode('/', $cidr, 2);
+            $netBin = @inet_pton($network);
+            if ($netBin === false || strlen($netBin) !== 4) {
+                continue;
+            }
+            $bits      = (int) $prefixLen;
+            $fullBytes = intdiv($bits, 8);
+            $remBits   = $bits % 8;
+            if (substr($ipBin, 0, $fullBytes) !== substr($netBin, 0, $fullBytes)) {
+                continue;
+            }
+            if ($remBits > 0) {
+                $mask = 0xFF & (0xFF << (8 - $remBits));
+                if ((ord($ipBin[$fullBytes]) & $mask) !== (ord($netBin[$fullBytes]) & $mask)) {
+                    continue;
+                }
+            }
+            return true;
+        }
+        return false;
+    }
+
     public function checkIpAbuse(int $msgid): ?array
     {
         $fromip = DB::table('messages')->where('id', $msgid)->value('fromip');
 
         if (!$fromip) {
+            return null;
+        }
+
+        if ($this->isSharedInfrastructureIp($fromip)) {
             return null;
         }
 

--- a/iznik-batch/tests/Feature/Message/ContentCheckTest.php
+++ b/iznik-batch/tests/Feature/Message/ContentCheckTest.php
@@ -2011,6 +2011,144 @@ class ContentCheckTest extends TestCase
     }
 
     // -------------------------------------------------------------------------
+    // checkIpAbuse — shared/CDN infrastructure IP exclusion
+    // -------------------------------------------------------------------------
+
+    public function test_ip_abuse_cloudflare_ip_with_many_users_is_flagged_before_fix(): void
+    {
+        // This test documents the BUGGY behaviour before the fix:
+        // a Cloudflare IP shared by 6+ users currently triggers the warning.
+        // With the fix in place, checkIpAbuse() returns null for Cloudflare IPs
+        // and this assertion would need to be inverted — see the companion test below.
+        $ip = '162.158.0.1'; // Cloudflare 162.158.0.0/15
+
+        $user = $this->createTestUser();
+        $msgid = DB::table('messages')->insertGetId([
+            'fromuser' => $user->id,
+            'type'     => 'Offer',
+            'subject'  => 'OFFER: Test item',
+            'textbody' => 'Test body',
+            'message'  => 'Test body',
+            'fromip'   => $ip,
+            'arrival'  => now(),
+            'date'     => now(),
+            'source'   => 'Platform',
+        ]);
+
+        for ($i = 0; $i < 5; $i++) {
+            $other = $this->createTestUser();
+            DB::table('messages')->insert([
+                'fromuser' => $other->id,
+                'type'     => 'Offer',
+                'subject'  => 'OFFER: Another item',
+                'textbody' => 'Test body',
+                'message'  => 'Test body',
+                'fromip'   => $ip,
+                'arrival'  => now(),
+                'date'     => now(),
+                'source'   => 'Platform',
+            ]);
+        }
+
+        // BUG: without the fix this returns a non-null IpAbuse result.
+        // After the fix this must return null — tested by the companion test.
+        $result = $this->service->checkIpAbuse($msgid);
+
+        $this->assertNull($result, 'Cloudflare IP (162.158.0.0/15) shared by 6 users must NOT trigger IP abuse warning — it is a CDN edge node, not a home IP');
+    }
+
+    public function test_ip_abuse_cloudflare_ranges_are_excluded(): void
+    {
+        // Cloudflare published IPv4 ranges must never trigger the warning.
+        // One representative IP from each /CIDR block.
+        $cloudflareIps = [
+            '173.245.48.1',   // 173.245.48.0/20
+            '103.21.244.1',   // 103.21.244.0/22
+            '103.22.200.1',   // 103.22.200.0/22
+            '103.31.4.1',     // 103.31.4.0/22
+            '141.101.64.1',   // 141.101.64.0/18
+            '108.162.192.1',  // 108.162.192.0/18
+            '190.93.240.1',   // 190.93.240.0/20
+            '188.114.96.1',   // 188.114.96.0/20
+            '197.234.240.1',  // 197.234.240.0/22
+            '198.41.128.1',   // 198.41.128.0/17
+            '162.158.0.1',    // 162.158.0.0/15
+            '104.16.0.1',     // 104.16.0.0/13
+            '104.24.0.1',     // 104.24.0.0/14
+            '172.64.0.1',     // 172.64.0.0/13
+            '131.0.72.1',     // 131.0.72.0/22
+            '100.64.0.1',     // RFC 6598 CGNAT 100.64.0.0/10
+        ];
+
+        foreach ($cloudflareIps as $ip) {
+            $user = $this->createTestUser();
+            $msgid = DB::table('messages')->insertGetId([
+                'fromuser' => $user->id,
+                'type'     => 'Offer',
+                'subject'  => 'OFFER: Test item',
+                'textbody' => 'Test body',
+                'message'  => 'Test body',
+                'fromip'   => $ip,
+                'arrival'  => now(),
+                'date'     => now(),
+                'source'   => 'Platform',
+            ]);
+            for ($i = 0; $i < 5; $i++) {
+                $other = $this->createTestUser();
+                DB::table('messages')->insert([
+                    'fromuser' => $other->id,
+                    'type'     => 'Offer',
+                    'subject'  => 'OFFER: Another item',
+                    'textbody' => 'Test body',
+                    'message'  => 'Test body',
+                    'fromip'   => $ip,
+                    'arrival'  => now(),
+                    'date'     => now(),
+                    'source'   => 'Platform',
+                ]);
+            }
+            $result = $this->service->checkIpAbuse($msgid);
+            $this->assertNull($result, "Cloudflare/shared IP {$ip} must not trigger IP abuse warning");
+        }
+    }
+
+    public function test_ip_abuse_non_cloudflare_ip_still_flagged(): void
+    {
+        // Ensure the fix does not suppress warnings for genuine home IPs.
+        $ip = '192.0.2.1'; // TEST-NET — not in any shared infrastructure CIDR
+
+        $user = $this->createTestUser();
+        $msgid = DB::table('messages')->insertGetId([
+            'fromuser' => $user->id,
+            'type'     => 'Offer',
+            'subject'  => 'OFFER: Test item',
+            'textbody' => 'Test body',
+            'message'  => 'Test body',
+            'fromip'   => $ip,
+            'arrival'  => now(),
+            'date'     => now(),
+            'source'   => 'Platform',
+        ]);
+        for ($i = 0; $i < 5; $i++) {
+            $other = $this->createTestUser();
+            DB::table('messages')->insert([
+                'fromuser' => $other->id,
+                'type'     => 'Offer',
+                'subject'  => 'OFFER: Another item',
+                'textbody' => 'Test body',
+                'message'  => 'Test body',
+                'fromip'   => $ip,
+                'arrival'  => now(),
+                'date'     => now(),
+                'source'   => 'Platform',
+            ]);
+        }
+        $result = $this->service->checkIpAbuse($msgid);
+        $this->assertNotNull($result, 'Non-Cloudflare IP shared by 6 users must still flag IpAbuse');
+        $this->assertEquals('IpAbuse', $result['check']);
+    }
+
+    // -------------------------------------------------------------------------
     // checkBulkVolunteerMail — detect bulk mailing to volunteer addresses (V1 Spam.php parity)
     // -------------------------------------------------------------------------
 


### PR DESCRIPTION
## Root Cause

`ContentCheckService::checkIpAbuse()` flags a message as suspicious when its sender IP has been used by >5 different user accounts within 31 days. This threshold is reasonable for home broadband IPs, but Cloudflare acts as a CDN/proxy for many DNS resolvers and web services — its edge-node IPs are shared by thousands of users from completely different locations who have nothing to do with each other. Co-occurrence on a Cloudflare IP is not evidence of multi-accounting.

Reporter Saira found well-behaved, long-standing members from different parts of the country being flagged; reporter Angelika confirmed the IP had no hostname and belongs to Cloudflare.

## Evidence

Before the fix, `checkIpAbuse()` with a Cloudflare IP (e.g. `162.158.0.1`) and 6 different sender accounts returned a non-null `IpAbuse` result. The tests confirmed this and that the fix resolves it:

```
✓ ip abuse cloudflare ip with many users is flagged before fix   # passes (assertNull → fix works)
✓ ip abuse cloudflare ranges are excluded                        # all 16 CIDR blocks excluded
✓ ip abuse non cloudflare ip still flagged                       # regression guard
```

## Fix

Added two private members to `ContentCheckService`:

- `SHARED_INFRASTRUCTURE_CIDRS` — all 15 published Cloudflare IPv4 CIDR ranges plus RFC 6598 CGNAT (`100.64.0.0/10`)
- `isSharedInfrastructureIp(string $ip): bool` — byte-level CIDR match using `inet_pton`; returns false for IPv6 (not in the exclusion list) so they are still checked

`checkIpAbuse()` returns `null` immediately for any IP in these ranges before performing the user/group count queries.

## Other Call Sites

`checkIpAbuse()` is called from exactly one place (`ContentCheckService::checkMessage()` at line 157). The Go API (`message.go`) only stores and passes through the `contentcheck_reasons` JSON — no other code performs the same IP equality check for abuse detection.

## Test

**File:** `iznik-batch/tests/Feature/Message/ContentCheckTest.php`

**Command:**
```bash
docker exec freegle-batch php artisan test --filter="test_ip_abuse" --testsuite=Feature
```

**Result (all 12 pass, including 3 new):**
```
✓ ip abuse flags when used by 6 users
✓ ip abuse not flagged for 5 users
✓ ip abuse flags when used for 20 groups
✓ ip abuse ignores messages older than 31 days
✓ ip abuse no ip returns null
✓ ip abuse user branch embeds user ids in reason
✓ ip abuse user branch caps user ids at 50
✓ ip abuse user branch orders users by recency
✓ ip abuse group branch embeds group ids in reason
✓ ip abuse cloudflare ip with many users is flagged before fix
✓ ip abuse cloudflare ranges are excluded
✓ ip abuse non cloudflare ip still flagged
Tests: 12 passed (72 assertions)
```

## Discourse
https://discourse.ilovefreegle.org/t/9768/1