### PR TITLE
fix(contentcheck): gate phone-number check on group restrictpersonalinfo (#9766)

### DIFF
--- a/iznik-batch/app/Services/ContentCheckService.php
+++ b/iznik-batch/app/Services/ContentCheckService.php
@@ -130,7 +130,7 @@ class ContentCheckService
         if ($r = $this->checkNotAnItem($subject, $textbody, $itemName)) {
             $reasons[] = $r;
         }
-        if ($r = $this->checkPhoneNumbers($subject, $textbody)) {
+        if ($r = $this->checkPhoneNumbers($subject, $textbody, $groupid)) {
             $reasons[] = $r;
         }
         if ($r = $this->checkPII($subject, $textbody, $groupid)) {
@@ -178,8 +178,9 @@ class ContentCheckService
      * Phone numbers are deliberately NOT checked in chat: sharing a phone
      * number is normal and expected when arranging a handover, so flagging it
      * produced too many false positives. (V1's Spam::checkReview() never
-     * checked phone numbers either.) The checkPhoneNumbers() check still runs
-     * for posts via checkMessage().
+     * checked phone numbers either.) The checkPhoneNumbers() check runs for
+     * posts via checkMessage(), but only when the group's restrictpersonalinfo
+     * rule is set.
      *
      * @return array|null Reason ['check','category','action','detail'] or null.
      */
@@ -826,10 +827,26 @@ class ContentCheckService
     // (0, +44, or 0044) followed by 9–10 digits (with optional spaces/hyphens).
     // This specificity avoids false positives from short numeric strings like
     // flat numbers or times.
+    //
+    // Only flagged when the group's restrictpersonalinfo rule is set — phone
+    // numbers are explicitly called out in that setting's description ("eg
+    // telephone numbers, addresses"). Groups without the rule never see this
+    // flag. (V1 had no universal phone-number check; the setting description
+    // makes the intent clear.)
     // -------------------------------------------------------------------------
 
-    public function checkPhoneNumbers(string $subject, string $textbody): ?array
+    public function checkPhoneNumbers(string $subject, string $textbody, int $groupid): ?array
     {
+        $rulesJson = DB::table('groups')->where('id', $groupid)->value('rules');
+        if ($rulesJson) {
+            $rules = is_string($rulesJson) ? json_decode($rulesJson, true) : $rulesJson;
+            if (empty($rules['restrictpersonalinfo'])) {
+                return null;
+            }
+        } else {
+            return null;
+        }
+
         $haystack = $subject . ' ' . $textbody;
 
         // (?<!\d) / (?!\d) instead of \b — \b doesn't fire before a literal "+"
@@ -847,8 +864,10 @@ class ContentCheckService
     }
 
     // -------------------------------------------------------------------------
-    // PII — external email addresses, only when group rule restrictpersonalinfo
-    // is set. Phone numbers in posts are checked via checkPhoneNumbers().
+    // PII — external email addresses, gated by the group rule restrictpersonalinfo.
+    // Phone numbers are also gated by the same rule via checkPhoneNumbers().
+    // Both checks are described by the setting: "Do you restrict personal info
+    // in posts eg telephone numbers, addresses?"
     // -------------------------------------------------------------------------
 
     public function checkPII(string $subject, string $textbody, int $groupid): ?array

--- a/iznik-batch/tests/Feature/Message/ContentCheckTest.php
+++ b/iznik-batch/tests/Feature/Message/ContentCheckTest.php
@@ -422,29 +422,40 @@ class ContentCheckTest extends TestCase
     }
 
     // -------------------------------------------------------------------------
-    // checkPhoneNumbers — universal UK phone number detection
+    // checkPhoneNumbers — gated by group restrictpersonalinfo rule
     // -------------------------------------------------------------------------
 
-    public function test_phone_number_in_body_returns_reason(): void
+    public function test_phone_number_flagged_when_group_restricts_personalinfo(): void
     {
-        $result = $this->service->checkPhoneNumbers('OFFER: Sofa', 'Call me on 07700 900123');
+        $group = $this->createTestGroup(['rules' => ['restrictpersonalinfo' => true]]);
 
-        $this->assertNotNull($result);
+        $result = $this->service->checkPhoneNumbers('OFFER: Sofa', 'Call me on 07700 900123', $group->id);
+
+        $this->assertNotNull($result, 'Phone number should be flagged when restrictpersonalinfo is set');
         $this->assertEquals('PhoneNumber', $result['check']);
     }
 
-    public function test_phone_number_universal_check_always_flags(): void
+    public function test_phone_number_not_flagged_when_group_has_no_personalinfo_restriction(): void
     {
+        // Discourse #9766: groups without restrictpersonalinfo must not have posts held for phone numbers
         $group = $this->createTestGroup();
 
-        $result = $this->service->checkPhoneNumbers('OFFER: Sofa', 'Call me on 07700 900123');
+        $result = $this->service->checkPhoneNumbers('OFFER: Sofa', 'Call me on 07700 900123', $group->id);
 
-        $this->assertNotNull($result, 'Phone numbers should be flagged universally regardless of group rules');
-        $this->assertEquals('PhoneNumber', $result['check']);
+        $this->assertNull($result, 'Phone number must not be flagged when group has no restrictpersonalinfo rule');
+    }
+
+    public function test_phone_number_not_flagged_when_restrict_rule_is_false(): void
+    {
+        $group = $this->createTestGroup(['rules' => ['restrictpersonalinfo' => false]]);
+
+        $result = $this->service->checkPhoneNumbers('OFFER: Sofa', 'Call me on 07700 900123', $group->id);
+
+        $this->assertNull($result, 'Phone number must not be flagged when restrictpersonalinfo is false');
     }
 
     // -------------------------------------------------------------------------
-    // checkPII — email addresses (phone numbers now checked universally)
+    // checkPII — email addresses, gated by the same restrictpersonalinfo rule
     // -------------------------------------------------------------------------
 
     public function test_no_personal_info_in_body_returns_null(): void

--- a/iznik-batch/tests/Unit/Services/ContentCheckServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/ContentCheckServiceTest.php
@@ -221,13 +221,15 @@ class ContentCheckServiceTest extends TestCase
     }
 
     // =========================================================================
-    // checkPhoneNumbers — public, pure regex
+    // checkPhoneNumbers — gated by group restrictpersonalinfo rule
     // =========================================================================
 
     #[DataProvider('phoneNumberProvider')]
     public function test_check_phone_numbers(string $subject, string $body, bool $expectFlag): void
     {
-        $result = $this->service->checkPhoneNumbers($subject, $body);
+        // Phone number check is gated by restrictpersonalinfo; use a group that has it set.
+        $group = $this->createTestGroup(['rules' => ['restrictpersonalinfo' => true]]);
+        $result = $this->service->checkPhoneNumbers($subject, $body, $group->id);
 
         if ($expectFlag) {
             $this->assertNotNull($result);
@@ -236,6 +238,15 @@ class ContentCheckServiceTest extends TestCase
         } else {
             $this->assertNull($result);
         }
+    }
+
+    public function test_check_phone_numbers_not_flagged_without_group_rule(): void
+    {
+        // Groups without restrictpersonalinfo must not have posts flagged for phone numbers.
+        $group = $this->createTestGroup();
+        $result = $this->service->checkPhoneNumbers('', 'Call 07911 123456 for details', $group->id);
+
+        $this->assertNull($result, 'Phone number must not flag when group has no restrictpersonalinfo rule');
     }
 
     public static function phoneNumberProvider(): array


### PR DESCRIPTION
## Root Cause

`checkPhoneNumbers()` in `ContentCheckService` ran unconditionally for **all groups** — it never consulted the group's `restrictpersonalinfo` rule. This kept posts in Pending with a "PhoneNumber" reason for groups that never opted into PII restrictions.

The `restrictpersonalinfo` group rule explicitly covers telephone numbers (its description: *"Do you restrict personal info in posts eg telephone numbers, addresses?"*). Both `checkPhoneNumbers()` and `checkPII()` (email addresses) must be gated on the same setting.

## What V1 showed

V1 (`iznik-server/`) had **no universal phone-number check at all**. `WorryWords.php` and `Spam.php` contain no phone-number detection. Commit `251838d80` in the Laravel migration deliberately moved the check out of `checkPII()` (which was correctly gated) to make it "universal" — that was the wrong decision.

## Fix

`checkPhoneNumbers(string $subject, string $textbody, int $groupid)` now queries `groups.rules->>restrictpersonalinfo` before running the UK phone-number regex, identical to the existing `checkPII()` gate. Groups without the rule return `null` immediately. The call site in `checkMessage()` passes `$groupid`.

## What changed

- `iznik-batch/app/Services/ContentCheckService.php` — `checkPhoneNumbers()` now accepts `$groupid` and gates on `restrictpersonalinfo`; updated call site and comments
- `iznik-batch/tests/Feature/Message/ContentCheckTest.php` — replaced `test_phone_number_universal_check_always_flags` with three gating tests (with rule → flagged; without rule → null; rule=false → null)
- `iznik-batch/tests/Unit/Services/ContentCheckServiceTest.php` — updated `test_check_phone_numbers` to use a group with the rule; added `test_check_phone_numbers_not_flagged_without_group_rule`

The wording change from the previous version of this PR (PR #677's original commit — now already on master as `adb02fb51`) is retained: the warning now says "This post contains a phone number" rather than "This group restricts personal info in posts".

## Test results

All 333 ContentCheck tests pass (run via status container Laravel suite).

## Discourse

https://discourse.ilovefreegle.org/t/9766/1
