### PR TITLE
fix(auth): handle Authorization2 Series as JSON string + GetSession LIMIT 1

### DIFF
--- a/iznik-server-go/auth/auth.go
+++ b/iznik-server-go/auth/auth.go
@@ -39,11 +39,17 @@ func WhoAmI(c *fiber.Ctx) uint64 {
 	persistent := c.Get("Authorization2")
 
 	if id == 0 && len(persistent) > 0 {
-		// parse persistent token
-		var persistentToken PersistentToken
-		_ = json2.Unmarshal([]byte(persistent), &persistentToken)
+		// Use a minimal struct so that old-format tokens whose Series field was
+		// serialised as a JSON string ("12345") don't cause json.Unmarshal to
+		// return a type-error that zeroes out the parsed ID.  id+token is a
+		// sufficient authenticator without Series.
+		var minPT struct {
+			ID    uint64 `json:"id"`
+			Token string `json:"token"`
+		}
+		_ = json2.Unmarshal([]byte(persistent), &minPT)
 
-		if (persistentToken.ID > 0) && (persistentToken.Series > 0) && (persistentToken.Token != "") {
+		if minPT.ID > 0 && minPT.Token != "" {
 			// Verify token against sessions table
 			db := database.DBConn
 
@@ -52,7 +58,7 @@ func WhoAmI(c *fiber.Ctx) uint64 {
 			}
 
 			var userids []Userid
-			db.Raw("SELECT userid FROM sessions WHERE id = ? AND series = ? AND token = ? LIMIT 1;", persistentToken.ID, persistentToken.Series, persistentToken.Token).Scan(&userids)
+			db.Raw("SELECT userid FROM sessions WHERE id = ? AND token = ? LIMIT 1;", minPT.ID, minPT.Token).Scan(&userids)
 
 			if len(userids) > 0 {
 				id = userids[0].Userid

--- a/iznik-server-go/session/session.go
+++ b/iznik-server-go/session/session.go
@@ -795,13 +795,35 @@ func GetSession(c *fiber.Ctx) error {
 
 	type SessionRow struct {
 		ID     uint64 `json:"id"`
-		Series string `json:"series"`
+		Series uint64 `json:"series"`
 		Token  string `json:"token"`
 	}
 
 	type AboutmeRow struct {
 		Text      string    `json:"text"`
 		Timestamp time.Time `json:"timestamp"`
+	}
+
+	// Identify which session authenticated this request so we return its
+	// credentials in the response, not an arbitrary session row.
+	// Without this, "WHERE userid = ? LIMIT 1" returns the oldest session for
+	// the user (InnoDB primary-key order). A user with two active sessions —
+	// one for ModTools, one for ilovefreegle.org — gets the other app's
+	// session credentials back, causing the client to overwrite its stored
+	// JWT/persistent token with the wrong session. (Discourse #9748)
+	var currentSessionID uint64
+	if _, sessID, _ := user.GetJWTFromRequest(c); sessID > 0 {
+		currentSessionID = sessID
+	} else if ptHeader := c.Get("Authorization2"); ptHeader != "" {
+		// Use a minimal struct (no Series field) so that old persistent tokens
+		// whose Series was serialised as a JSON string don't cause Unmarshal to
+		// zero out the parsed ID.
+		var minPT struct {
+			ID uint64 `json:"id"`
+		}
+		if json.Unmarshal([]byte(ptHeader), &minPT) == nil && minPT.ID > 0 {
+			currentSessionID = minPT.ID
+		}
 	}
 
 	var wg sync.WaitGroup
@@ -835,7 +857,11 @@ func GetSession(c *fiber.Ctx) error {
 	}()
 	go func() {
 		defer wg.Done()
-		db.Raw("SELECT id, series, token FROM sessions WHERE userid = ? LIMIT 1", myid).Scan(&sessionRow)
+		if currentSessionID > 0 {
+			db.Raw("SELECT id, series, token FROM sessions WHERE id = ? AND userid = ?", currentSessionID, myid).Scan(&sessionRow)
+		} else {
+			db.Raw("SELECT id, series, token FROM sessions WHERE userid = ? LIMIT 1", myid).Scan(&sessionRow)
+		}
 	}()
 	go func() {
 		defer wg.Done()

--- a/iznik-server-go/test/session_test.go
+++ b/iznik-server-go/test/session_test.go
@@ -498,6 +498,108 @@ func TestGetSessionNotLoggedIn(t *testing.T) {
 	assert.Equal(t, "Not logged in", result["status"])
 }
 
+// TestGetSessionReturnsCurrentSessionCredentials is a regression test for
+// Discourse #9748 post 5. GET /session must return the credentials for the
+// session that made the request, not an arbitrary row returned by LIMIT 1.
+// When two sessions exist for the same user (e.g. ModTools + ilovefreegle.org),
+// the response must carry the JWT and persistent token for the requesting
+// session, not the one with the lowest primary key.
+func TestGetSessionReturnsCurrentSessionCredentials(t *testing.T) {
+	prefix := uniquePrefix("sess_cred")
+	userID := CreateTestUser(t, prefix, "User")
+	db := database.DBConn
+
+	// Insert two sessions. idOther is inserted first so it has the lower PK
+	// and wins the old bare "LIMIT 1" query.
+	seriesOther := userID*1000 + 1
+	seriesCurrent := userID*1000 + 2
+
+	db.Exec("INSERT INTO sessions (userid, series, token, date, lastactive) VALUES (?, ?, 'tokOther', NOW(), NOW())", userID, seriesOther)
+	var idOther uint64
+	db.Raw("SELECT id FROM sessions WHERE userid = ? AND series = ?", userID, seriesOther).Scan(&idOther)
+
+	db.Exec("INSERT INTO sessions (userid, series, token, date, lastactive) VALUES (?, ?, 'tokCurrent', NOW(), NOW())", userID, seriesCurrent)
+	var idCurrent uint64
+	db.Raw("SELECT id FROM sessions WHERE userid = ? AND series = ?", userID, seriesCurrent).Scan(&idCurrent)
+
+	assert.NotZero(t, idOther, "other-app session must be created")
+	assert.NotZero(t, idCurrent, "current session must be created")
+	assert.Less(t, idOther, idCurrent, "other session must have lower id for the LIMIT 1 regression to be deterministic")
+
+	// Authenticate as the CURRENT session (the second one created).
+	tokenCurrent := GetToken(userID, idCurrent)
+	req := httptest.NewRequest("GET", "/api/session?jwt="+tokenCurrent, nil)
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&result)
+	assert.Equal(t, float64(0), result["ret"])
+
+	persistent, ok := result["persistent"].(map[string]interface{})
+	assert.True(t, ok, "response must contain a persistent token map")
+	if ok {
+		gotID := uint64(persistent["id"].(float64))
+		assert.Equal(t, idCurrent, gotID,
+			"persistent.id must match the current session (%d), not the other-app session (%d)",
+			idCurrent, idOther)
+	}
+}
+
+// TestGetSessionReturnsCurrentSessionCredentialsViaAuth2 is a companion to
+// TestGetSessionReturnsCurrentSessionCredentials that exercises the
+// Authorization2 (persistent-token) code path in GetSession.
+//
+// When the JWT has expired the client sends only Authorization2.  This path
+// was broken in two ways: (1) WhoAmI required Series to be non-zero, but
+// old-format tokens sent Series as a JSON string ("12345") which json.Unmarshal
+// coerced to 0; (2) GetSession used LIMIT 1 instead of binding to the session
+// ID from the token.
+func TestGetSessionReturnsCurrentSessionCredentialsViaAuth2(t *testing.T) {
+	prefix := uniquePrefix("sess_auth2")
+	userID := CreateTestUser(t, prefix, "User")
+	db := database.DBConn
+
+	// Insert two sessions. idOther is inserted first so it has a lower PK
+	// and wins the old bare "LIMIT 1" query.
+	seriesOther := userID*2000 + 1
+	seriesCurrent := userID*2000 + 2
+
+	db.Exec("INSERT INTO sessions (userid, series, token, date, lastactive) VALUES (?, ?, 'tokOtherA2', NOW(), NOW())", userID, seriesOther)
+	var idOther uint64
+	db.Raw("SELECT id FROM sessions WHERE userid = ? AND series = ?", userID, seriesOther).Scan(&idOther)
+
+	db.Exec("INSERT INTO sessions (userid, series, token, date, lastactive) VALUES (?, ?, 'tokCurrentA2', NOW(), NOW())", userID, seriesCurrent)
+	var idCurrent uint64
+	db.Raw("SELECT id FROM sessions WHERE userid = ? AND series = ?", userID, seriesCurrent).Scan(&idCurrent)
+
+	assert.NotZero(t, idOther, "other session must exist")
+	assert.NotZero(t, idCurrent, "current session must exist")
+	assert.Less(t, idOther, idCurrent, "other session must have lower id for LIMIT 1 regression to be deterministic")
+
+	// Build a persistent token that mimics what a browser would send.
+	// Use old wire-format: Series as a JSON string ("12345"), not a number.
+	persistentJSON := fmt.Sprintf(`{"id":%d,"series":"%d","token":"tokCurrentA2"}`, idCurrent, seriesCurrent)
+
+	req := httptest.NewRequest("GET", "/api/session", nil)
+	req.Header.Set("Authorization2", persistentJSON)
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&result)
+	assert.Equal(t, float64(0), result["ret"])
+
+	persistent, ok := result["persistent"].(map[string]interface{})
+	assert.True(t, ok, "response must contain a persistent token map")
+	if ok {
+		gotID := uint64(persistent["id"].(float64))
+		assert.Equal(t, idCurrent, gotID,
+			"persistent.id must match the current session (%d), not the other-app session (%d)",
+			idCurrent, idOther)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // POST /session - Email/Password Login
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two related bugs affecting users with old-style persistent tokens and/or multiple concurrent sessions (Discourse #9748):

**Bug 1 — WhoAmI / Authorization2 Series coercion**
- `PersistentToken.Series` is `uint64` but old-format tokens serialise it as a JSON string (`"12345"`)
- `json.Unmarshal` silently leaves `Series=0` on type mismatch, so the `Series > 0` guard always fails → `WhoAmI` returns 0 → 401 Unauthorized
- Fix: use a minimal struct with only `ID`+`Token` (sufficient authenticators), drop `Series` from the `WHERE` clause entirely

**Bug 2 — GetSession LIMIT 1 returns wrong session**
- `WHERE userid = ? LIMIT 1` returns the oldest session (lowest PK), not the requesting session
- For a user logged in on two devices simultaneously (ModTools + ilovefreegle.org), `/session` returns the other device's credentials
- Fix: extract requesting session ID from JWT (preferred) or Authorization2 header before the parallel goroutines, then use `WHERE id = ? AND userid = ?` when available

## Changes

- `iznik-server-go/auth/auth.go`: `WhoAmI` uses minimal struct, drops Series from DB query
- `iznik-server-go/session/session.go`: `GetSession` resolves `currentSessionID` before parallel block, uses targeted query; `SessionRow.Series` corrected from `string` to `uint64`
- `iznik-server-go/test/session_test.go`: Two regression tests added — `TestGetSessionReturnsCurrentSessionCredentials` (JWT path) and `TestGetSessionReturnsCurrentSessionCredentialsViaAuth2` (Authorization2 string-Series path)

## Test plan

- [ ] Go test suite passes (`TestGetSessionReturnsCurrentSessionCredentials`, `TestGetSessionReturnsCurrentSessionCredentialsViaAuth2`)
- [ ] `TestGetSessionNotLoggedIn` and existing session tests still pass
- [ ] No regressions in auth-related tests