### PR TITLE
test(email/volunteering): regression guard for HTML-encoded ampersand in email title (9692/12)

### DIFF
--- a/iznik-batch/tests/Feature/Mail/VolunteeringDigestCommandTest.php
+++ b/iznik-batch/tests/Feature/Mail/VolunteeringDigestCommandTest.php
@@ -378,6 +378,66 @@ class VolunteeringDigestCommandTest extends TestCase
         );
     }
 
+    /**
+     * Regression test for Discourse topic 9692 post 12.
+     *
+     * The DB stores volunteering titles HTML-encoded (e.g. "Coffee &amp; Cake").
+     * VolunteeringDigestService must call html_entity_decode() before passing the
+     * title to the mailable so Blade's {{ }} produces a single &amp; in the HTML
+     * source (which email clients render as "&"). Without the decode, {{ }} double-
+     * encodes to &amp;amp;, which email clients render as the literal string "&amp;".
+     */
+    public function test_html_encoded_title_in_db_is_decoded_in_rendered_email(): void
+    {
+        $group = $this->createTestGroup();
+
+        // Insert volunteering with HTML-encoded title, exactly as production DB stores it.
+        $volId = DB::table('volunteering')->insertGetId([
+            'title'       => 'Coffee &amp; Cake Stall',
+            'location'    => 'Tea &amp; Coffee Room',
+            'description' => 'Bring friends &amp; family.',
+            'pending'     => 0,
+            'deleted'     => 0,
+            'expired'     => 0,
+            'added'       => now(),
+        ]);
+        DB::table('volunteering_groups')->insert([
+            'volunteeringid' => $volId,
+            'groupid'        => $group->id,
+        ]);
+
+        $member = $this->createTestUser();
+        $this->createMembership($member, $group, [
+            'volunteeringallowed' => 1,
+            'emailfrequency'      => 24,
+        ]);
+
+        // Capture the VolunteeringDigestMail before it reaches the spooler.
+        $capturedMail = null;
+        $spooler = \Mockery::mock(EmailSpoolerService::class);
+        $spooler->shouldReceive('spool')->andReturnUsing(function ($mailable) use (&$capturedMail) {
+            $capturedMail = $mailable;
+            return 'spooled-id';
+        });
+        $this->app->instance(EmailSpoolerService::class, $spooler);
+
+        $this->artisan('mail:volunteering-digest')
+            ->expectsOutputToContain('Sent 1 email(s)')
+            ->assertExitCode(0);
+
+        $this->assertNotNull($capturedMail, 'A VolunteeringDigestMail should have been created');
+
+        $html = $capturedMail->render();
+
+        // Correct: single &amp; in HTML source → email client displays "&"
+        $this->assertStringContainsString('Coffee &amp; Cake Stall', $html,
+            'Title must appear as single-encoded "&amp;" so email clients render "&"');
+
+        // Wrong: double-encoded &amp;amp; → email client displays the literal "&amp;"
+        $this->assertStringNotContainsString('Coffee &amp;amp; Cake Stall', $html,
+            'Title must not be double-encoded (regression guard for 9692/12)');
+    }
+
     public function test_skips_group_with_volunteering_setting_disabled(): void
     {
         Mail::fake();


### PR DESCRIPTION
## Root Cause

The DB stores volunteering titles HTML-encoded (e.g. `Coffee &amp; Cake`). `VolunteeringDigestService` was passing the raw DB value directly to the Blade template where `{{ }}` auto-escaped `&amp;` → `&amp;amp;`, which email clients rendered as the literal string `&amp;` instead of `&`.

The fix (`html_entity_decode()` at the data-preparation layer) was applied in PR #636 (merged 2026-06-03). This PR adds a missing integration-level regression guard.

## Evidence

```
// Without fix (buggy): DB → service → template renders as:
Coffee &amp;amp; Cake Stall  ← email client shows: Coffee &amp; Cake Stall (WRONG)

// With fix: DB → html_entity_decode → template renders as:
Coffee &amp; Cake Stall       ← email client shows: Coffee & Cake Stall (CORRECT)
```

AssertFlip verified analytically:
- **Buggy code** (no decode): `assertNotContains('Coffee &amp;amp; Cake Stall')` → FAILS ✓
- **Fixed code** (with decode): `assertNotContains('Coffee &amp;amp; Cake Stall')` → PASSES ✓

## Fix

No production code changes. The underlying fix is already in PR #636.

This PR adds `test_html_encoded_title_in_db_is_decoded_in_rendered_email` to `VolunteeringDigestCommandTest`:
- Inserts volunteering row with `&amp;`-encoded title (as stored in production DB)
- Captures the rendered `VolunteeringDigestMail` via a mock spooler
- Asserts: HTML source contains `&amp;` (single encode, correct) and NOT `&amp;amp;` (double encode, regression)

## Other Call Sites

`{{ $vol['title'] }}` appears at lines 32, 50, 60 in `resources/views/emails/mjml/volunteering/digest.blade.php`. All are covered by the service decode applied before the mailable is constructed.

Existing `AmpersandEncodingTest::test_volunteering_mjml_renders_ampersand_correctly_after_service_decode()` tests the template layer with decoded input. This test adds the DB→service→email integration layer.

## Test

**File:** `iznik-batch/tests/Feature/Mail/VolunteeringDigestCommandTest::test_html_encoded_title_in_db_is_decoded_in_rendered_email`

**Command:** `php artisan test --filter=test_html_encoded_title_in_db_is_decoded_in_rendered_email`

**Proves:** fail-before (without decode) / pass-after (with decode in VolunteeringDigestService)

## Discourse
https://discourse.ilovefreegle.org/t/9692/12