### PR TITLE
fix(modtools-editing): show and preserve neighbourhood name when editing posts

### DIFF
--- a/iznik-nuxt3/modtools/components/ModMessage.vue
+++ b/iznik-nuxt3/modtools/components/ModMessage.vue
@@ -49,6 +49,12 @@
               </div>
               <div v-if="editmessage.item && editmessage.location">
                 <b-input-group>
+                  <b-form-input
+                    v-model="editmessage.location.areaname"
+                    size="lg"
+                    class="me-1 areaname-input"
+                    placeholder="Neighbourhood"
+                  />
                   <PostCode
                     :value="editmessage.location.name"
                     :find="false"
@@ -1236,6 +1242,7 @@ async function save() {
         msgtype: editmessage.value.type,
         item: editmessage.value.item.name,
         location: editmessage.value.location.name,
+        areaname: editmessage.value.location.areaname,
         attachments: attids,
         textbody: editmessage.value.textbody,
       })
@@ -1444,6 +1451,10 @@ function spamReport() {
   /* Cap growth on wide desktop so the field doesn't stretch the whole row.
      flex-grow-1 keeps it filling available space up to this cap. */
   max-width: 500px;
+}
+
+.areaname-input {
+  max-width: 160px;
 }
 
 .fullsubject {

--- a/iznik-nuxt3/tests/unit/components/modtools/ModMessage.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModMessage.spec.js
@@ -565,6 +565,39 @@ describe('ModMessage', () => {
         textbody: 'This is the message body',
       })
     })
+
+    // Regression tests for Discourse #9769/1 — neighbourhood name must be sent on save.
+    it('includes areaname in patch when location has areaname (Discourse #9769/1)', async () => {
+      const wrapper = mountComponent(
+        {},
+        {
+          item: { name: 'Kitchen Table' },
+          location: { name: 'E1 1AA', areaname: 'Stepney' },
+        }
+      )
+      wrapper.vm.startEdit()
+      await wrapper.vm.save()
+
+      expect(mockMessageStore.patch).toHaveBeenCalledWith(
+        expect.objectContaining({ areaname: 'Stepney' })
+      )
+    })
+
+    it('preserves custom areaname spelling over mapping default (Discourse #9769/1)', async () => {
+      const wrapper = mountComponent(
+        {},
+        {
+          item: { name: 'Kitchen Table' },
+          location: { name: 'E1 1AA', areaname: 'Whitechapel' },
+        }
+      )
+      wrapper.vm.startEdit()
+      await wrapper.vm.save()
+
+      expect(mockMessageStore.patch).toHaveBeenCalledWith(
+        expect.objectContaining({ areaname: 'Whitechapel' })
+      )
+    })
   })
 
   describe('backToPending', () => {

--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -1530,7 +1530,14 @@ func getAllGroupsForMessage(db *gorm.DB, msgid uint64) []uint64 {
 // constructLocationString builds a location string for a message's subject,
 // using the area name + vague postcode format.
 // The vague postcode is the outward code only (e.g., "CB22" from "CB22 3AA").
-func constructLocationString(db *gorm.DB, msgid uint64) string {
+// Pass an optional overrideAreaName to use a mod-supplied area name instead of
+// the DB-derived mapping default (Discourse #9769/1 — area name not preserved on save).
+func constructLocationString(db *gorm.DB, msgid uint64, overrideAreaName ...string) string {
+	customArea := ""
+	if len(overrideAreaName) > 0 {
+		customArea = overrideAreaName[0]
+	}
+
 	type locInfo struct {
 		Name   string
 		Type   string
@@ -1544,26 +1551,27 @@ func constructLocationString(db *gorm.DB, msgid uint64) string {
 		return ""
 	}
 
-	if loc.Type == "Postcode" && loc.Areaid > 0 {
-		// Get the area name.
-		var areaName string
-		db.Raw("SELECT name FROM locations WHERE id = ?", loc.Areaid).Scan(&areaName)
-
+	if loc.Type == "Postcode" {
 		// Vague postcode: take only the outward code (before the space).
 		vaguePC := loc.Name
 		if idx := strings.Index(vaguePC, " "); idx > 0 {
 			vaguePC = vaguePC[:idx]
 		}
 
-		return areaName + " " + vaguePC
+		// Prefer the mod-supplied name; fall back to the DB mapping area name.
+		areaName := customArea
+		if areaName == "" && loc.Areaid > 0 {
+			db.Raw("SELECT name FROM locations WHERE id = ?", loc.Areaid).Scan(&areaName)
+		}
+
+		if areaName != "" {
+			return areaName + " " + vaguePC
+		}
+		return vaguePC
 	}
 
-	// Not a postcode with area — use the location name as-is,
-	// but ensure vague (strip inward code if it looks like a postcode).
-	if loc.Type == "Postcode" {
-		if idx := strings.Index(loc.Name, " "); idx > 0 {
-			return loc.Name[:idx]
-		}
+	if customArea != "" {
+		return customArea
 	}
 	return loc.Name
 }
@@ -2496,6 +2504,7 @@ type patchMessageRequest struct {
 	Lng          *float64 `json:"lng"`
 	Location     *string  `json:"location"`
 	Locationid   *uint64  `json:"locationid"`
+	Areaname     *string  `json:"areaname"`
 	Groupid      *uint64  `json:"groupid"`
 	Attachments  []uint64 `json:"attachments"`
 	BadAIImages  []uint64 `json:"badAIImages"`
@@ -2709,9 +2718,8 @@ func applyPatchMessageCore(c *fiber.Ctx, myid uint64, req patchMessageRequest) e
 		}
 	}
 
-	// Reconstruct subject from type + item + location when item/type/location changed
-	//.
-	if req.Item != nil || req.Type != nil || req.Location != nil || req.Locationid != nil {
+	// Reconstruct subject from type + item + location when item/type/location/areaname changed.
+	if req.Item != nil || req.Type != nil || req.Location != nil || req.Locationid != nil || req.Areaname != nil {
 		var msgType string
 		var itemName *string
 		db.Raw("SELECT type FROM messages WHERE id = ?", req.ID).Scan(&msgType)
@@ -2723,8 +2731,15 @@ func applyPatchMessageCore(c *fiber.Ctx, myid uint64, req patchMessageRequest) e
 			db.Raw("SELECT i.name FROM items i INNER JOIN messages_items mi ON mi.itemid = i.id WHERE mi.msgid = ? LIMIT 1", req.ID).Scan(&itemName)
 		}
 
-		// Build the location string using area + vague postcode.
-		locStr := constructLocationString(db, req.ID)
+		// Build the location string. When the mod supplied an areaname, pass it as
+		// an override so the spelling they chose is used rather than the mapping default
+		// (Discourse #9769/1 — area name reset to mapping default on save).
+		var locStr string
+		if req.Areaname != nil && *req.Areaname != "" {
+			locStr = constructLocationString(db, req.ID, *req.Areaname)
+		} else {
+			locStr = constructLocationString(db, req.ID)
+		}
 
 		if itemName != nil && locStr != "" {
 			// Use the group keyword for the type (V1: group settings, defaults to uppercase).

--- a/iznik-server-go/test/message_test.go
+++ b/iznik-server-go/test/message_test.go
@@ -5215,6 +5215,113 @@ func TestPatchMessageReconstructsSubjectFromItemLocation(t *testing.T) {
 	assert.NotContains(t, subject, "3AA")
 }
 
+// TestPatchMessageAreanameOverride — Discourse #9769/1
+// When a mod PATCHes a message and supplies an areaname, the subject must use
+// that spelling instead of the DB-derived mapping default.
+func TestPatchMessageAreanameOverride(t *testing.T) {
+	prefix := uniquePrefix("msgpatch_area")
+	db := database.DBConn
+
+	groupID := CreateTestGroup(t, prefix)
+	modID := CreateTestUser(t, prefix+"_mod", "User")
+	posterID := CreateTestUser(t, prefix+"_poster", "User")
+	CreateTestMembership(t, modID, groupID, "Moderator")
+	CreateTestMembership(t, posterID, groupID, "Member")
+	_, modToken := CreateTestSession(t, modID)
+
+	// Create area location ("Mapping default") and a postcode linked to it.
+	db.Exec("INSERT INTO locations (name, type, lat, lng) VALUES (?, 'Point', 52.5, -1.8)", prefix+"_MappingDefault")
+	var areaID uint64
+	db.Raw("SELECT id FROM locations WHERE name = ? ORDER BY id DESC LIMIT 1", prefix+"_MappingDefault").Scan(&areaID)
+	require.NotZero(t, areaID)
+
+	db.Exec("INSERT INTO locations (name, type, lat, lng, areaid) VALUES (?, 'Postcode', 52.5, -1.8, ?)", prefix+"_E1 1AA", areaID)
+	var pcID uint64
+	db.Raw("SELECT id FROM locations WHERE name = ? ORDER BY id DESC LIMIT 1", prefix+"_E1 1AA").Scan(&pcID)
+	require.NotZero(t, pcID)
+
+	msgID := CreateTestMessage(t, posterID, groupID, prefix+" Test Item", 52.5, -1.8)
+	db.Exec("UPDATE messages SET locationid = ? WHERE id = ?", pcID, msgID)
+
+	db.Exec("INSERT INTO items (name) VALUES (?)", prefix+"_Chair")
+	var itemID uint64
+	db.Raw("SELECT id FROM items WHERE name = ? ORDER BY id DESC LIMIT 1", prefix+"_Chair").Scan(&itemID)
+	require.NotZero(t, itemID)
+	db.Exec("DELETE FROM messages_items WHERE msgid = ?", msgID)
+	db.Exec("INSERT INTO messages_items (msgid, itemid) VALUES (?, ?)", msgID, itemID)
+
+	// PATCH with a custom area name that differs from the DB mapping default.
+	body, _ := json.Marshal(map[string]interface{}{
+		"id":       msgID,
+		"areaname": prefix + "_CustomSpelling",
+	})
+	req := httptest.NewRequest("PATCH", "/api/message?jwt="+modToken, bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := getApp().Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var subject string
+	db.Raw("SELECT subject FROM messages WHERE id = ?", msgID).Scan(&subject)
+
+	// Subject must use the mod-supplied spelling, not the DB mapping default.
+	assert.Contains(t, subject, prefix+"_CustomSpelling", "subject should contain mod-supplied area name")
+	assert.NotContains(t, subject, prefix+"_MappingDefault", "subject must NOT use DB mapping default when areaname override is supplied")
+	// Vague postcode (outward code only) should still be present.
+	assert.Contains(t, subject, prefix+"_E1", "subject should contain vague postcode outward code")
+}
+
+// TestPatchMessageAreanameOmittedKeepsDBDefault — Discourse #9769/1 (non-regression)
+// When areaname is not sent, the existing behaviour (DB-derived area name) must be unchanged.
+func TestPatchMessageAreanameOmittedKeepsDBDefault(t *testing.T) {
+	prefix := uniquePrefix("msgpatch_areakp")
+	db := database.DBConn
+
+	groupID := CreateTestGroup(t, prefix)
+	modID := CreateTestUser(t, prefix+"_mod", "User")
+	posterID := CreateTestUser(t, prefix+"_poster", "User")
+	CreateTestMembership(t, modID, groupID, "Moderator")
+	CreateTestMembership(t, posterID, groupID, "Member")
+	_, modToken := CreateTestSession(t, modID)
+
+	db.Exec("INSERT INTO locations (name, type, lat, lng) VALUES (?, 'Point', 52.5, -1.8)", prefix+"_DBArea")
+	var areaID uint64
+	db.Raw("SELECT id FROM locations WHERE name = ? ORDER BY id DESC LIMIT 1", prefix+"_DBArea").Scan(&areaID)
+	require.NotZero(t, areaID)
+
+	db.Exec("INSERT INTO locations (name, type, lat, lng, areaid) VALUES (?, 'Postcode', 52.5, -1.8, ?)", prefix+"_SW1 1AA", areaID)
+	var pcID uint64
+	db.Raw("SELECT id FROM locations WHERE name = ? ORDER BY id DESC LIMIT 1", prefix+"_SW1 1AA").Scan(&pcID)
+	require.NotZero(t, pcID)
+
+	msgID := CreateTestMessage(t, posterID, groupID, prefix+" item", 52.5, -1.8)
+	db.Exec("UPDATE messages SET locationid = ? WHERE id = ?", pcID, msgID)
+
+	db.Exec("INSERT INTO items (name) VALUES (?)", prefix+"_Table")
+	var itemID uint64
+	db.Raw("SELECT id FROM items WHERE name = ? ORDER BY id DESC LIMIT 1", prefix+"_Table").Scan(&itemID)
+	require.NotZero(t, itemID)
+	db.Exec("DELETE FROM messages_items WHERE msgid = ?", msgID)
+	db.Exec("INSERT INTO messages_items (msgid, itemid) VALUES (?, ?)", msgID, itemID)
+
+	// PATCH with item only — no areaname field.
+	body, _ := json.Marshal(map[string]interface{}{
+		"id":   msgID,
+		"item": prefix + "_Table",
+	})
+	req := httptest.NewRequest("PATCH", "/api/message?jwt="+modToken, bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := getApp().Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var subject string
+	db.Raw("SELECT subject FROM messages WHERE id = ?", msgID).Scan(&subject)
+
+	// Without an areaname override, subject must still use the DB-derived area name.
+	assert.Contains(t, subject, prefix+"_DBArea", "subject should contain DB-derived area name when no override is supplied")
+}
+
 func TestPatchMessageItemCaseCorrection(t *testing.T) {
 	// Bug: Discourse #9518 post #18 — "Correct Case" standard message lowercases the
 	// subject visually but the Go API finds the existing item via case-insensitive MySQL


### PR DESCRIPTION
## Root Cause

The ModTools edit form showed only the raw postcode (e.g. `E1 1AA`) via the PostCode component. The area/neighbourhood name (`areaname`, e.g. `Stepney`) was never displayed or sent to the API. On every save, `constructLocationString` re-derived the area name from the DB postcode mapping, silently overwriting any custom spelling the moderator had set.

## Evidence

```
// ModMessage.vue save() before fix — areaname never sent
await messageStore.patch({
  id: ..., location: editmessage.value.location.name,
  //   ^^^ only raw postcode, areaname omitted
})

// constructLocationString always queries DB area, ignores any mod input
locStr := constructLocationString(db, req.ID)  // returns DB-derived "Stepney E1"
```

## Fix vs Rejected #673

**PR #673 was rejected for two reasons — both fixed here:**

1. **No duplicate helper** — #673 added `buildLocStrFromInfo` which reimplemented `constructLocationString`'s logic. This re-attempt folds the area-override into `constructLocationString` itself via an optional variadic parameter (`overrideAreaName ...string`), so there is exactly one function handling all callers. Existing call sites pass no override and behaviour is unchanged.

2. **Integration test coverage** — #673 only tested the pure helper, leaving `applyPatchMessageCore`'s PATCH path with zero coverage. This re-attempt adds two integration tests in `message_test.go` that exercise the actual `PATCH /message` endpoint:
   - `TestPatchMessageAreanameOverride` — confirms mod-supplied areaname appears in the rebuilt subject instead of the DB default
   - `TestPatchMessageAreanameOmittedKeepsDBDefault` — confirms existing DB-default behaviour is unchanged when no areaname is supplied

## Other Call Sites

`constructLocationString` has three call sites:
- `message.go:2396` — POST create path; no moderator override needed; unchanged (no variadic arg passed).
- `message.go:2739/2741` — PATCH edit path; patched to pass `*req.Areaname` when provided.
- `message.go:3407` — Draft subject rebuild on submission; no override needed; unchanged.

## Test

| File | Command | Proves |
|---|---|---|
| `iznik-server-go/test/message_test.go` | `TestPatchMessageAreanameOverride` | PATCH with areaname uses custom spelling in subject, not DB default |
| `iznik-server-go/test/message_test.go` | `TestPatchMessageAreanameOmittedKeepsDBDefault` | PATCH without areaname preserves DB-derived area (non-regression) |

## Discourse
https://discourse.ilovefreegle.org/t/9769/1

🤖 Generated with [Claude Code](https://claude.com/claude-code)