### PR TITLE
test(utils): exhaust TidyName coverage — double/triple TN suffix paths

### DIFF
--- a/iznik-server-go/utils/utils_extra_test.go
+++ b/iznik-server-go/utils/utils_extra_test.go
@@ -1,0 +1,62 @@
+package utils
+
+// ---------------------------------------------------------------------------
+// Additional coverage for TidyName uncovered branches
+// ---------------------------------------------------------------------------
+//
+// Two branches in TidyName were unreachable by the existing tests:
+//
+//  1. tnOnlyRegexp branch: fires when the second tnRegexp.ReplaceAllString
+//     produces a string matching ^-g[0-9]+$  (e.g. "-g123").
+//     Trigger: triple TN suffix with no preceding name, e.g. "-g1-g2-g3".
+//       first  tnRegexp("-g1-g2-g3")  → "-g1-g2"  (non-empty, skips first guard)
+//       second tnRegexp("-g1-g2")     → "-g1"      (matches tnOnlyRegexp)
+//
+//  2. Final len(name)==0 guard: fires when the second tnRegexp produces ""
+//     and tnOnlyRegexp does NOT match (because "" doesn't match ^-g[0-9]+$).
+//     Trigger: double TN suffix with no preceding name, e.g. "-g1-g2".
+//       first  tnRegexp("-g1-g2") → "-g1"   (non-empty, skips first guard)
+//       second tnRegexp("-g1")    → ""       (not matched by tnOnlyRegexp)
+//       final  len==0 guard fires → "A freegler"
+//
+// Note on RandomUint64: the `v = 1` guard (zero-protection after 53-bit mask)
+// has P(hit) ≈ 1/2^53 and cannot be exercised without replacing crypto/rand —
+// which would require changing production code. That branch is left at its
+// current 83.3% coverage intentionally.
+
+import "testing"
+
+func TestTidyName_TripleTNSuffixNoPrecedingNameHitsTNOnlyRegexp(t *testing.T) {
+	// Three consecutive TN suffixes with no preceding name.
+	// Path: first tnRegexp → "-g1-g2" (non-empty), second tnRegexp → "-g1"
+	// which matches tnOnlyRegexp → "A freegler".
+	got := TidyName("-g1-g2-g3")
+	if got != "A freegler" {
+		t.Errorf("TidyName(%q) = %q; want %q", "-g1-g2-g3", got, "A freegler")
+	}
+}
+
+func TestTidyName_DoubleTNSuffixNoPrecedingNameHitsFinalGuard(t *testing.T) {
+	// Two consecutive TN suffixes with no preceding name.
+	// Path: first tnRegexp → "-g1" (non-empty), second tnRegexp → ""
+	// ("" does not match tnOnlyRegexp), final len==0 guard fires → "A freegler".
+	got := TidyName("-g1-g2")
+	if got != "A freegler" {
+		t.Errorf("TidyName(%q) = %q; want %q", "-g1-g2", got, "A freegler")
+	}
+}
+
+func TestTidyName_MultiDigitDoubleTNSuffix(t *testing.T) {
+	// Same path as above but with realistic multi-digit TN suffix numbers.
+	got := TidyName("-g123456-g789012")
+	if got != "A freegler" {
+		t.Errorf("TidyName(%q) = %q; want %q", "-g123456-g789012", got, "A freegler")
+	}
+}
+
+func TestTidyName_MultiDigitTripleTNSuffix(t *testing.T) {
+	got := TidyName("-g123456-g789012-g345678")
+	if got != "A freegler" {
+		t.Errorf("TidyName(%q) = %q; want %q", "-g123456-g789012-g345678", got, "A freegler")
+	}
+}


### PR DESCRIPTION
## Coverage added
Module: `iznik-server-go/utils/utils.go`
Coverage before: 95.8%
Coverage after: 97.0%
Delta: +1.2%

(TidyName function specifically: 91.3% → 100%)

## Tests added
| Function | Scenario | File:Line |
|---|---|---|
| `TidyName` | Triple TN suffix with no preceding name (`-g1-g2-g3`) — hits `tnOnlyRegexp` branch | `utils_extra_test.go:36` |
| `TidyName` | Double TN suffix with no preceding name (`-g1-g2`) — hits final `len(name)==0` guard | `utils_extra_test.go:44` |
| `TidyName` | Multi-digit double TN suffix (`-g123456-g789012`) — same final guard path | `utils_extra_test.go:52` |
| `TidyName` | Multi-digit triple TN suffix (`-g123456-g789012-g345678`) — same tnOnlyRegexp path | `utils_extra_test.go:58` |

## Why these two branches were missed

`TidyName` applies `tnRegexp` **twice**. The first pass strips the trailing `-gNNNN` suffix; the second pass is a second-stage strip for names that survive the first.

- **`tnOnlyRegexp` branch** fires when the *second* tnRegexp produces a string matching `^-g[0-9]+$`. Requires a *triple* TN suffix with no preceding name (e.g. `-g1-g2-g3`): first pass yields `-g1-g2`, second pass yields `-g1` which matches `tnOnlyRegexp`.
- **Final `len(name)==0` guard** fires when the second tnRegexp produces `""` and `tnOnlyRegexp` does **not** match `""`. Requires a *double* TN suffix with no preceding name (e.g. `-g1-g2`): first pass yields `-g1`, second pass yields `""`.

Existing tests used either a single suffix (`-g123456`) — caught by the *first* guard — or a suffix with a preceding name (`Name-g123-g456`) — which never reduces to an empty or tnOnly-matching result.

## Latent bugs found
None. All new tests pass against current production code.

## Remaining coverage gap (3%)
| Function | Branch | Why uncoverable |
|---|---|---|
| `RandomUint64` | `v = 1` zero-protection | P(hit) ≈ 1/2^53; requires mocking `crypto/rand` — would need production code change |
| `weightedRandFromSlice` | `return len(weights) - 1` fallback | Mathematically unreachable (int64 arithmetic, total = sum of weights) |
| `weightedRandFromMap` | `for k := range weights { return k }` fallback | Same — unreachable defensive code |

## No production code changed
All changes are in test files only (`*_test.go`).

```
$ go test ./utils/... -coverprofile=/tmp/coverage.out
ok   iznik-server-go/utils   0.008s   coverage: 97.0% of statements
$ go tool cover -func=/tmp/coverage.out | grep utils.go
utils.go:346:   TidyName   100.0%
```