### PR TITLE
test(utils): add complementary TidyName double/triple TN suffix tests

### DIFF
--- a/iznik-server-go/utils/utils_test.go
+++ b/iznik-server-go/utils/utils_test.go
@@ -798,6 +798,20 @@ func TestTidyName_TNSuffixMultiple(t *testing.T) {
 	assert.Equal(t, "Name", TidyName("Name-g123-g456"))
 }
 
+func TestTidyName_DoubleTNOnlyBecomesFreegler(t *testing.T) {
+	// A name that is only double TN suffixes (no real prefix): first tnRegexp strips
+	// the outer suffix leaving "-g123"; second tnRegexp strips that leaving ""; the
+	// final len==0 fallback kicks in. Covers the last-resort "A freegler" branch.
+	assert.Equal(t, "A freegler", TidyName("-g123-g456"))
+}
+
+func TestTidyName_TripleTNOnlyBecomesFreegler(t *testing.T) {
+	// A name that is only triple TN suffixes: first tnRegexp strips the outermost
+	// suffix leaving "-g123-g456"; second tnRegexp strips that leaving "-g123";
+	// tnOnlyRegexp matches "-g123" directly. Covers the tnOnlyRegexp "A freegler" branch.
+	assert.Equal(t, "A freegler", TidyName("-g123-g456-g789"))
+}
+
 func TestTidyName_ComplexChain(t *testing.T) {
 	// Email with TN suffix and long name.
 	// Strip email suffix → "verylongnamethatexceedsthirtytwocharacters-g123" (47 chars)


### PR DESCRIPTION
## Coverage added
Module: `iznik-server-go/utils`
Coverage before: 97.0% (all reachable paths were already covered by PRs #683 and #684 merged to master today)
Coverage after: 97.0%
Delta: +0.0%

> Coverage was already high. All reachable code paths in the `utils` package are covered. The remaining 3.0% is dead code (safety-valve fallbacks in `namegen.go` that can never be reached with valid non-negative weights) and the `RandomUint64` `v==0` guard (probability ~1/2^53 per call, documented in utils_gaps_test.go as untestable without mocking `crypto/rand`).

## Tests added
| Function | Scenario | File:Line |
|---|---|---|
| `TidyName` | Double TN-only suffix (`-g123-g456`) with no real prefix — exercises final `len(name)==0` guard | `iznik-server-go/utils/utils_test.go:801` |
| `TidyName` | Triple TN-only suffix (`-g123-g456-g789`) with no real prefix — exercises `tnOnlyRegexp` → "A freegler" path | `iznik-server-go/utils/utils_test.go:808` |

These tests use multi-digit TN suffix numbers and complement the single-digit tests already present in `utils_extra_test.go` (from #684).

## Latent bugs found
None.

## No production code changed
All changes are in test files only (`*_test.go`).

### Remaining coverage gaps (all dead code / untestable)
| Function | Branch | Reason untestable |
|---|---|---|
| `weightedRandFromSlice` | `return len(weights) - 1` | Mathematically unreachable: loop always triggers `n<=0` before exhausting the slice |
| `weightedRandFromMap` | `for k := range weights { return k }` + `return ""` | Same reasoning as above |
| `RandomUint64` | `v = 1` zero-protection | P≈1/2^53 per call; requires mocking `crypto/rand` which would mean changing production code |