### PR TITLE
fix(microvolunteering/settings): save microvolunteeringoptions via PATCH and fix null settings crash

### DIFF
--- a/iznik-nuxt3/modtools/components/ModSettingsGroup.vue
+++ b/iznik-nuxt3/modtools/components/ModSettingsGroup.vue
@@ -4,7 +4,7 @@
       <ModGroupSelect v-model="groupid" modonly />
     </div>
     <div v-if="group && group.mysettings" class="mt-2 scrollinplace">
-      <NoticeMessage v-if="group.settings.closed" variant="danger" class="mb-1">
+      <NoticeMessage v-if="group.settings?.closed" variant="danger" class="mb-1">
         Your community is currently closed. You can change this in
         <em>Features for Members</em>.
       </NoticeMessage>

--- a/iznik-server-go/group/group.go
+++ b/iznik-server-go/group/group.go
@@ -676,8 +676,9 @@ type PatchGroupRequest struct {
 	AffiliationConfirmed  *string  `json:"affiliationconfirmed"`
 	Onhere                *int     `json:"onhere"`
 	Publish               *int     `json:"publish"`
-	Microvolunteering     *int     `json:"microvolunteering"`
-	Mentored              *int     `json:"mentored"`
+	Microvolunteering        *int             `json:"microvolunteering"`
+	Microvolunteeringoptions *json.RawMessage `json:"microvolunteeringoptions"`
+	Mentored                 *int             `json:"mentored"`
 	Ontn                  *int     `json:"ontn"`
 	Onlovejunk            *int              `json:"onlovejunk"`
 	Profile               *uint64           `json:"profile"`
@@ -761,6 +762,9 @@ func PatchGroup(c *fiber.Ctx) error {
 	}
 	if req.Microvolunteering != nil {
 		db.Exec("UPDATE `groups` SET microvolunteering = ? WHERE id = ?", *req.Microvolunteering, req.ID)
+	}
+	if req.Microvolunteeringoptions != nil {
+		db.Exec("UPDATE `groups` SET microvolunteeringoptions = ? WHERE id = ?", string(*req.Microvolunteeringoptions), req.ID)
 	}
 	if req.Mentored != nil {
 		db.Exec("UPDATE `groups` SET mentored = ? WHERE id = ?", *req.Mentored, req.ID)

--- a/iznik-server-go/test/group_test.go
+++ b/iznik-server-go/test/group_test.go
@@ -1023,6 +1023,47 @@ func TestPatchGroupSupportCanPatchWithoutMembership(t *testing.T) {
 	assert.Equal(t, "Support set this", tagline)
 }
 
+func TestPatchGroupMicrovolunteeringoptions(t *testing.T) {
+	prefix := uniquePrefix("grpmv_opts")
+	db := database.DBConn
+	groupID := CreateTestGroup(t, prefix)
+	userID := CreateTestUser(t, prefix+"_mod", "User")
+	_, token := CreateTestSession(t, userID)
+	CreateTestMembership(t, userID, groupID, "Moderator")
+
+	opts := map[string]interface{}{
+		"approvedmessages": true,
+		"wordmatch":        true,
+		"photorotate":      false,
+	}
+	body, _ := json.Marshal(map[string]interface{}{
+		"id":                     groupID,
+		"microvolunteeringoptions": opts,
+	})
+	req := httptest.NewRequest("PATCH", fmt.Sprintf("/api/group?jwt=%s", token), bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := getApp().Test(req, 10000)
+	require.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	// Verify microvolunteeringoptions was saved to the DB
+	var stored string
+	db.Raw("SELECT COALESCE(microvolunteeringoptions, '') FROM `groups` WHERE id = ?", groupID).Scan(&stored)
+	assert.NotEmpty(t, stored, "microvolunteeringoptions should be stored after PATCH")
+	assert.Contains(t, stored, "approvedmessages", "stored value should contain approvedmessages key")
+	assert.Contains(t, stored, "wordmatch", "stored value should contain wordmatch key")
+
+	// Verify it is returned correctly in GET response
+	getResp, _ := getApp().Test(httptest.NewRequest("GET", "/api/group/"+fmt.Sprint(groupID), nil))
+	assert.Equal(t, 200, getResp.StatusCode)
+	var raw map[string]interface{}
+	json2.Unmarshal(rsp(getResp), &raw)
+	mvOpts, ok := raw["microvolunteeringoptions"].(map[string]interface{})
+	assert.True(t, ok, "microvolunteeringoptions should be a JSON object in GET response")
+	assert.Equal(t, true, mvOpts["approvedmessages"])
+	assert.Equal(t, true, mvOpts["wordmatch"])
+}
+
 func TestTnKeyInfoJSONShape(t *testing.T) {
 	// Verify that TnKeyInfo serializes as a nested object with "url" and "expires" fields,
 	// matching the TN API response shape that the frontend expects (group.tnkey.url).


### PR DESCRIPTION
## Summary

- **Go API**: `PatchGroupRequest` was missing `Microvolunteeringoptions *json.RawMessage` — the frontend's `microvolunteeringoptions` payload was silently dropped by Fiber's body parser, so the column stayed NULL and settings never persisted.
- **Go API**: Added handler `if req.Microvolunteeringoptions != nil { db.Exec("UPDATE groups SET microvolunteeringoptions = ?...", ...) }` — mirrors the existing `Settings`/`Rules` pattern.
- **Vue**: `ModSettingsGroup.vue` line 7 accessed `group.settings.closed` without null-guarding `group.settings`; when a group has `settings = NULL` in the DB this threw `TypeError: Cannot read properties of null`. Fixed with `group.settings?.closed`.

Fixes [topic 9518, post 294](https://discourse.ilovefreegle.org/t/9518/294) — reporter Matty.

## Test plan

- [ ] New Go test `TestPatchGroupMicrovolunteeringoptions` in `iznik-server-go/test/group_test.go`: PATCHes microvolunteeringoptions as a moderator, verifies DB column and GET response
- [ ] Existing Go group test suite: no regressions
- [ ] Vue: `ModSettingsGroup.vue` renders without crash for groups with `settings = null`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
