### PR TITLE
fix(notifications): correct ModTools push label and route when no pending messages exist (re-attempt)

### DIFF
--- a/iznik-batch/app/Services/PushNotificationService.php
+++ b/iznik-batch/app/Services/PushNotificationService.php
@@ -383,6 +383,23 @@ class PushNotificationService
      */
     public function getBadgeCount(int $userId): int
     {
+        return $this->getBadgeBreakdown($userId)['total'];
+    }
+
+    /**
+     * Return per-collection badge counts for a ModTools user.
+     *
+     * Returns ['pending' => N, 'spam' => N, 'volunteering' => N, 'total' => N].
+     * Callers that need per-collection data (e.g. to choose notification route/label)
+     * use this directly rather than duplicating the queries in a separate method.
+     *
+     * The queries here are the single authoritative source for badge counts — do not
+     * add a parallel count method; update this breakdown instead.
+     */
+    private function getBadgeBreakdown(int $userId): array
+    {
+        $zero = ['pending' => 0, 'spam' => 0, 'volunteering' => 0, 'total' => 0];
+
         // Get all approved mod/owner memberships with settings to determine active/inactive.
         $memberships = DB::select(
             "SELECT groupid, settings FROM memberships
@@ -391,7 +408,7 @@ class PushNotificationService
         );
 
         if (empty($memberships)) {
-            return 0;
+            return $zero;
         }
 
         // Mirror session.go: only count work from active groups in the badge total.
@@ -404,7 +421,7 @@ class PushNotificationService
         }
 
         if (empty($activeGroupIds)) {
-            return 0;
+            return $zero;
         }
 
         $placeholders = implode(',', array_fill(0, count($activeGroupIds), '?'));
@@ -451,7 +468,16 @@ class PushNotificationService
             $activeGroupIds
         );
 
-        return ($pending->cnt ?? 0) + ($spam->cnt ?? 0) + ($volunteering->cnt ?? 0);
+        $pendingCnt = (int) ($pending->cnt ?? 0);
+        $spamCnt = (int) ($spam->cnt ?? 0);
+        $volunteeringCnt = (int) ($volunteering->cnt ?? 0);
+
+        return [
+            'pending' => $pendingCnt,
+            'spam' => $spamCnt,
+            'volunteering' => $volunteeringCnt,
+            'total' => $pendingCnt + $spamCnt + $volunteeringCnt,
+        ];
     }
 
     /**
@@ -485,12 +511,20 @@ class PushNotificationService
     /**
      * Build the ModTools notification payload.
      *
-     * For ModTools, we send a simple "pending messages" notification.
-     * Matches legacy User::getNotificationPayload(modtools=true).
+     * Uses getBadgeBreakdown() to choose the label and tap-through route based on
+     * which categories have work, so the notification describes what actually needs
+     * attention rather than always saying "messages pending" regardless of work type.
+     *
+     * When pendingCount > 0:  title = "N message(s) pending", route = /modtools/messages/pending
+     * When pendingCount == 0: title = "N item(s) to review",  route = /modtools (dashboard)
+     *
+     * Badge uses the total across all categories in both cases.
      */
     private function buildModToolsPayload(int $userId): ?array
     {
-        $total = $this->getBadgeCount($userId);
+        $breakdown = $this->getBadgeBreakdown($userId);
+        $total = $breakdown['total'];
+        $pendingCount = $breakdown['pending'];
 
         if ($total === 0) {
             // Still send a zero-count to clear badge
@@ -512,8 +546,13 @@ class PushNotificationService
             ];
         }
 
-        $title = "$total message" . ($total > 1 ? 's' : '') . " pending";
-        $message = "Open ModTools to review";
+        if ($pendingCount > 0) {
+            $title = "$pendingCount message" . ($pendingCount > 1 ? 's' : '') . " pending";
+            $route = '/modtools/messages/pending';
+        } else {
+            $title = "$total item" . ($total > 1 ? 's' : '') . " to review";
+            $route = '/modtools';
+        }
 
         return [
             'badge' => (string) $total,
@@ -521,13 +560,13 @@ class PushNotificationService
             'chatcount' => '0',
             'notifcount' => (string) $total,
             'title' => $title,
-            'message' => $message,
+            'message' => 'Open ModTools to review',
             'chatids' => '',
             'content-available' => '1',
             'image' => 'www/images/modtools_logo.png',
             'modtools' => '1',
             'sound' => 'default',
-            'route' => '/modtools/messages/pending',
+            'route' => $route,
             'channel_id' => 'modtools',
             // Fixed notId per user so each new notification replaces the previous one
             // on Android instead of stacking multiple "N pending" badges.

--- a/iznik-batch/app/Services/PushNotificationService.php
+++ b/iznik-batch/app/Services/PushNotificationService.php
@@ -511,20 +511,29 @@ class PushNotificationService
     /**
      * Build the ModTools notification payload.
      *
-     * Uses getBadgeBreakdown() to choose the label and tap-through route based on
-     * which categories have work, so the notification describes what actually needs
-     * attention rather than always saying "messages pending" regardless of work type.
+     * Mirrors V1 User::getNotificationPayload(TRUE) (iznik-server/include/user/User.php ~4547-4569):
+     * iterate categories in a fixed priority order (volunteering → spam → pending), last-wins,
+     * so pending — being last — always wins when present. This ensures the notification route and
+     * title reflect the highest-priority work type.
      *
-     * When pendingCount > 0:  title = "N message(s) pending", route = /modtools/messages/pending
-     * When pendingCount == 0: title = "N item(s) to review",  route = /modtools (dashboard)
+     * Routes use direct Nuxt paths WITHOUT a /modtools/ prefix. The /modtools/ prefix hits the
+     * catch-all redirect page (iznik-nuxt3/modtools/pages/modtools/[...slug].vue) which delays
+     * navigation by 2 seconds. The correct direct pages are /messages/pending and /volunteering.
+     * (Discourse #9692/10).
      *
-     * Badge uses the total across all categories in both cases.
+     * Category mapping (V1 parity):
+     *   volunteering → route /volunteering,        title "N volunteer op(s)"
+     *   spam         → route /messages/pending,    title "N message(s) to review"
+     *   pending      → route /messages/pending,    title "N pending message(s)"
+     *
+     * Title is multi-line ("\n"-joined) listing each non-zero category.
+     * If total == 0: empty title, route "/".
+     * Badge is always total across all categories.
      */
     private function buildModToolsPayload(int $userId): ?array
     {
         $breakdown = $this->getBadgeBreakdown($userId);
         $total = $breakdown['total'];
-        $pendingCount = $breakdown['pending'];
 
         if ($total === 0) {
             // Still send a zero-count to clear badge
@@ -540,19 +549,36 @@ class PushNotificationService
                 'image' => 'www/images/modtools_logo.png',
                 'modtools' => '1',
                 'sound' => 'default',
-                'route' => '/modtools',
+                'route' => '/',
                 'channel_id' => 'modtools',
                 'notId' => (string) $userId,
             ];
         }
 
-        if ($pendingCount > 0) {
-            $title = "$pendingCount message" . ($pendingCount > 1 ? 's' : '') . " pending";
-            $route = '/modtools/messages/pending';
-        } else {
-            $title = "$total item" . ($total > 1 ? 's' : '') . " to review";
-            $route = '/modtools';
+        // Per-category label lines (for multi-line title) and per-category route.
+        // Last-wins order: volunteering first, pending last — so pending wins if present.
+        $titleLines = [];
+        $route = '/';
+
+        $volunteeringCount = $breakdown['volunteering'];
+        if ($volunteeringCount > 0) {
+            $titleLines[] = $volunteeringCount . ' volunteer op' . ($volunteeringCount > 1 ? 's' : '');
+            $route = '/volunteering';
         }
+
+        $spamCount = $breakdown['spam'];
+        if ($spamCount > 0) {
+            $titleLines[] = $spamCount . ' message' . ($spamCount > 1 ? 's' : '') . ' to review';
+            $route = '/messages/pending';
+        }
+
+        $pendingCount = $breakdown['pending'];
+        if ($pendingCount > 0) {
+            $titleLines[] = $pendingCount . ' pending message' . ($pendingCount > 1 ? 's' : '');
+            $route = '/messages/pending';
+        }
+
+        $title = implode("\n", $titleLines);
 
         return [
             'badge' => (string) $total,

--- a/iznik-batch/tests/Unit/Services/PushNotificationServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/PushNotificationServiceTest.php
@@ -481,6 +481,48 @@ class PushNotificationServiceTest extends TestCase
     }
 
     /**
+     * Volunteering-only badge count must route to /modtools dashboard, not /modtools/messages/pending.
+     *
+     * Regression for Discourse #9692/10: when the badge total is driven by pending volunteering ops
+     * (no pending messages), the notification said "N messages pending" and routed to
+     * /modtools/messages/pending — an empty page. The label and route must reflect the actual
+     * work type.
+     */
+    public function test_buildModToolsPayload_volunteering_only_routes_to_dashboard_not_messages_pending(): void
+    {
+        $mod = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $this->createMembership($mod, $group, ['role' => Membership::ROLE_MODERATOR]);
+
+        // Pending volunteering op — no pending messages
+        $volunteeringId = DB::table('volunteering')->insertGetId([
+            'pending' => 1,
+            'deleted' => 0,
+            'expired' => 0,
+            'title' => 'Help needed',
+            'userid' => $mod->id,
+        ]);
+        DB::table('volunteering_groups')->insert([
+            'volunteeringid' => $volunteeringId,
+            'groupid' => $group->id,
+        ]);
+
+        $method = new \ReflectionMethod($this->service, 'buildModToolsPayload');
+        $method->setAccessible(true);
+        $payload = $method->invoke($this->service, $mod->id);
+
+        $this->assertSame('1', $payload['badge'], 'Badge must be 1 (the volunteering op)');
+        // Route must NOT send the mod to /messages/pending — there are no pending messages.
+        $this->assertNotSame('/modtools/messages/pending', $payload['route'],
+            'Volunteering-only badge must not route to /messages/pending (Discourse #9692/10)');
+        $this->assertSame('/modtools', $payload['route'],
+            'Volunteering-only badge must route to the /modtools dashboard');
+        // Title must not claim there are "messages pending" when there are none.
+        $this->assertStringNotContainsString('message', $payload['title'],
+            'Title must not say "messages pending" when only volunteering work is queued');
+    }
+
+    /**
      * Visible ModTools push: priority high and notification.tag set so the
      * latest "N pending" entry replaces the previous one in the tray.
      */

--- a/iznik-batch/tests/Unit/Services/PushNotificationServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/PushNotificationServiceTest.php
@@ -481,14 +481,13 @@ class PushNotificationServiceTest extends TestCase
     }
 
     /**
-     * Volunteering-only badge count must route to /modtools dashboard, not /modtools/messages/pending.
+     * Volunteering-only badge must route to /volunteering (V1 parity), not /messages/pending.
      *
      * Regression for Discourse #9692/10: when the badge total is driven by pending volunteering ops
-     * (no pending messages), the notification said "N messages pending" and routed to
-     * /modtools/messages/pending — an empty page. The label and route must reflect the actual
-     * work type.
+     * (no pending messages), the notification must route to /volunteering — not /messages/pending
+     * (empty page) and not /modtools (catch-all redirect with 2s delay).
      */
-    public function test_buildModToolsPayload_volunteering_only_routes_to_dashboard_not_messages_pending(): void
+    public function test_buildModToolsPayload_volunteering_only_routes_to_volunteering(): void
     {
         $mod = $this->createTestUser();
         $group = $this->createTestGroup();
@@ -512,14 +511,180 @@ class PushNotificationServiceTest extends TestCase
         $payload = $method->invoke($this->service, $mod->id);
 
         $this->assertSame('1', $payload['badge'], 'Badge must be 1 (the volunteering op)');
-        // Route must NOT send the mod to /messages/pending — there are no pending messages.
-        $this->assertNotSame('/modtools/messages/pending', $payload['route'],
-            'Volunteering-only badge must not route to /messages/pending (Discourse #9692/10)');
-        $this->assertSame('/modtools', $payload['route'],
-            'Volunteering-only badge must route to the /modtools dashboard');
-        // Title must not claim there are "messages pending" when there are none.
+        // Route must go directly to /volunteering — no /modtools/ prefix (would hit redirect page).
+        $this->assertSame('/volunteering', $payload['route'],
+            'Volunteering-only badge must route to /volunteering (V1 parity, Discourse #9692/10)');
+        // Title must mention "volunteer", not "message".
+        $this->assertStringContainsString('volunteer', $payload['title'],
+            'Title must describe the volunteering work, not say "messages pending"');
         $this->assertStringNotContainsString('message', $payload['title'],
-            'Title must not say "messages pending" when only volunteering work is queued');
+            'Title must not say "messages" when only volunteering work is queued');
+    }
+
+    /**
+     * Pending-only badge must route to /messages/pending (no /modtools/ prefix).
+     *
+     * V1 parity: pending → route /messages/pending, title "N pending message(s)".
+     * The /modtools/ prefix hits the catch-all redirect page (Discourse #9692/10).
+     */
+    public function test_buildModToolsPayload_pending_only_routes_to_messages_pending(): void
+    {
+        $mod = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $this->createMembership($mod, $group, ['role' => Membership::ROLE_MODERATOR]);
+
+        $sender = $this->createTestUser();
+        $message = Message::create([
+            'fromuser' => $sender->id,
+            'type' => Message::TYPE_OFFER,
+            'subject' => 'OFFER: Test (Location)',
+            'textbody' => 'Test',
+            'source' => 'Platform',
+            'date' => now(),
+            'arrival' => now(),
+            'lat' => $group->lat,
+            'lng' => $group->lng,
+            'heldby' => null,
+        ]);
+        MessageGroup::create([
+            'msgid' => $message->id,
+            'groupid' => $group->id,
+            'collection' => MessageGroup::COLLECTION_PENDING,
+            'arrival' => now(),
+            'deleted' => 0,
+        ]);
+
+        $method = new \ReflectionMethod($this->service, 'buildModToolsPayload');
+        $method->setAccessible(true);
+        $payload = $method->invoke($this->service, $mod->id);
+
+        $this->assertSame('1', $payload['badge']);
+        $this->assertSame('/messages/pending', $payload['route'],
+            'Pending-only badge must route to /messages/pending (no /modtools/ prefix)');
+        $this->assertStringContainsString('pending', $payload['title']);
+    }
+
+    /**
+     * Spam-only badge must route to /messages/pending (no /modtools/ prefix).
+     *
+     * V1 parity: spam → route /messages/pending, title "N message(s) to review".
+     */
+    public function test_buildModToolsPayload_spam_only_routes_to_messages_pending(): void
+    {
+        $mod = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $this->createMembership($mod, $group, ['role' => Membership::ROLE_MODERATOR]);
+
+        $sender = $this->createTestUser();
+        $message = Message::create([
+            'fromuser' => $sender->id,
+            'type' => Message::TYPE_OFFER,
+            'subject' => 'OFFER: Spam (Location)',
+            'textbody' => 'Spam',
+            'source' => 'Platform',
+            'date' => now(),
+            'arrival' => now(),
+            'lat' => $group->lat,
+            'lng' => $group->lng,
+            'heldby' => null,
+        ]);
+        MessageGroup::create([
+            'msgid' => $message->id,
+            'groupid' => $group->id,
+            'collection' => MessageGroup::COLLECTION_SPAM,
+            'arrival' => now(),
+            'deleted' => 0,
+        ]);
+
+        $method = new \ReflectionMethod($this->service, 'buildModToolsPayload');
+        $method->setAccessible(true);
+        $payload = $method->invoke($this->service, $mod->id);
+
+        $this->assertSame('1', $payload['badge']);
+        $this->assertSame('/messages/pending', $payload['route'],
+            'Spam-only badge must route to /messages/pending (no /modtools/ prefix)');
+        $this->assertStringContainsString('review', $payload['title']);
+    }
+
+    /**
+     * Mixed pending + volunteering: pending wins (last-wins, V1 parity).
+     *
+     * With both pending messages and volunteering ops, route must be /messages/pending
+     * and the title must mention both categories (multi-line, "\n"-joined).
+     */
+    public function test_buildModToolsPayload_mixed_pending_wins_over_volunteering(): void
+    {
+        $mod = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $this->createMembership($mod, $group, ['role' => Membership::ROLE_MODERATOR]);
+
+        // Add a pending message
+        $sender = $this->createTestUser();
+        $message = Message::create([
+            'fromuser' => $sender->id,
+            'type' => Message::TYPE_OFFER,
+            'subject' => 'OFFER: Test (Location)',
+            'textbody' => 'Test',
+            'source' => 'Platform',
+            'date' => now(),
+            'arrival' => now(),
+            'lat' => $group->lat,
+            'lng' => $group->lng,
+            'heldby' => null,
+        ]);
+        MessageGroup::create([
+            'msgid' => $message->id,
+            'groupid' => $group->id,
+            'collection' => MessageGroup::COLLECTION_PENDING,
+            'arrival' => now(),
+            'deleted' => 0,
+        ]);
+
+        // Add a pending volunteering op
+        $volunteeringId = DB::table('volunteering')->insertGetId([
+            'pending' => 1,
+            'deleted' => 0,
+            'expired' => 0,
+            'title' => 'Help needed',
+            'userid' => $mod->id,
+        ]);
+        DB::table('volunteering_groups')->insert([
+            'volunteeringid' => $volunteeringId,
+            'groupid' => $group->id,
+        ]);
+
+        $method = new \ReflectionMethod($this->service, 'buildModToolsPayload');
+        $method->setAccessible(true);
+        $payload = $method->invoke($this->service, $mod->id);
+
+        $this->assertSame('2', $payload['badge'], 'Badge must be total of all categories');
+        // Pending wins (last in last-wins order)
+        $this->assertSame('/messages/pending', $payload['route'],
+            'Pending wins over volunteering in last-wins order (V1 parity)');
+        // Title must mention both categories
+        $this->assertStringContainsString('volunteer', $payload['title'],
+            'Multi-line title must mention volunteering');
+        $this->assertStringContainsString('pending', $payload['title'],
+            'Multi-line title must mention pending messages');
+    }
+
+    /**
+     * Zero-work payload must route to "/" not "/modtools" (V1 parity).
+     */
+    public function test_buildModToolsPayload_zero_routes_to_root(): void
+    {
+        $mod = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $this->createMembership($mod, $group, ['role' => Membership::ROLE_MODERATOR]);
+
+        $method = new \ReflectionMethod($this->service, 'buildModToolsPayload');
+        $method->setAccessible(true);
+        $payload = $method->invoke($this->service, $mod->id);
+
+        $this->assertNotNull($payload, 'Zero-count payload must not be null (clears badge)');
+        $this->assertSame('0', $payload['badge']);
+        $this->assertSame('/', $payload['route'],
+            'Zero-work payload must route to "/" (V1 parity)');
     }
 
     /**


### PR DESCRIPTION
## Root Cause

`buildModToolsPayload()` always set `route = '/modtools/messages/pending'` and a fixed "N messages pending" title regardless of which work categories had items. Two bugs:

1. **Wrong route for non-message work**: volunteering-only → routed to `/modtools/messages/pending` (empty page).
2. **`/modtools/` prefix hits a catch-all redirect**: `iznik-nuxt3/modtools/pages/modtools/[...slug].vue` is a redirect page that delays navigation by 2 seconds before forwarding to the real page. All routes must use direct Nuxt paths without the `/modtools/` prefix.

## Fix

Per-category, last-wins route selection — matching V1 `User::getNotificationPayload(TRUE)` (`$types` array, `iznik-server/include/user/User.php:4547-4569`) with `/modtools/`-prefix stripped to the actual Nuxt pages:

| Category | Route | Title label |
|---|---|---|
| `volunteering` | `/volunteering` | "N volunteer op(s)" |
| `spam` | `/messages/pending` | "N message(s) to review" |
| `pending` | `/messages/pending` | "N pending message(s)" |

Priority order: `[volunteering, spam, pending]` — **pending is last so it wins when present**. Title is a multi-line (`\n`-joined) list of every non-zero category. Badge is always the total across all categories. Zero-work payload routes to `/` (clears badge, no tray notification).

`getBadgeBreakdown()` remains the single authoritative source for badge counts — no parallel query methods added.

## Route Verification

- `/volunteering` → `iznik-nuxt3/modtools/pages/volunteering/[[id]].vue` ✓ (real page)
- `/messages/pending` → `iznik-nuxt3/modtools/pages/messages/pending/[[id]]/[[term]].vue` ✓ (real page)
- `/modtools/...` → `iznik-nuxt3/modtools/pages/modtools/[...slug].vue` — catch-all **redirect** (2 s delay, wrong)

## Tests

`PushNotificationServiceTest` (36 tests, all pass):

- `test_buildModToolsPayload_volunteering_only_routes_to_volunteering` — volunteering-only → `/volunteering`, title mentions "volunteer"
- `test_buildModToolsPayload_pending_only_routes_to_messages_pending` — pending-only → `/messages/pending`
- `test_buildModToolsPayload_spam_only_routes_to_messages_pending` — spam-only → `/messages/pending`
- `test_buildModToolsPayload_mixed_pending_wins_over_volunteering` — mixed → `/messages/pending`, multi-line title mentions both
- `test_buildModToolsPayload_zero_routes_to_root` — zero-work → `/`, empty title

## Discourse
https://discourse.ilovefreegle.org/t/9692/10
