### PR TITLE
fix(moderation): manual reposts by non-moderated members go to Approved (Discourse #9481)

### DIFF
--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -2372,14 +2372,25 @@ func handleJoinAndPost(c *fiber.Ctx, myid uint64, req PostMessageRequest) error 
 			flog.LOG_TYPE_GROUP, flog.LOG_SUBTYPE_JOINED, groupid, myid, myid)
 	}
 
-	// All messages start Pending — the content check batch job runs content checks
-	// and promotes clean messages from non-moderated users to Approved.
-	collection := utils.COLLECTION_PENDING
+	// Determine collection using V1 postToCollection logic (User::postToCollection line 819):
+	//   NULL / empty / MODERATED / PROHIBITED → Pending
+	//   anything else (e.g. DEFAULT, UNMODERATED) → Approved
+	// This matches the initial-post path and V1 repost() behaviour: a non-moderated
+	// member's manual repost goes straight to Approved, not through the content-check
+	// pipeline. New members (NULL ourPostingStatus) still start in Pending.
 	var ourPostingStatus *string
 	db.Raw("SELECT ourPostingStatus FROM memberships WHERE userid = ? AND groupid = ?", myid, groupid).Scan(&ourPostingStatus)
 
 	if ourPostingStatus != nil && strings.EqualFold(*ourPostingStatus, utils.POSTING_STATUS_PROHIBITED) {
 		return fiber.NewError(fiber.StatusForbidden, "You are not allowed to post on this group")
+	}
+
+	collection := utils.COLLECTION_PENDING
+	if ourPostingStatus != nil &&
+		!strings.EqualFold(*ourPostingStatus, utils.POSTING_STATUS_MODERATED) &&
+		!strings.EqualFold(*ourPostingStatus, utils.POSTING_STATUS_PROHIBITED) &&
+		*ourPostingStatus != "" {
+		collection = utils.COLLECTION_APPROVED
 	}
 
 	// Reconstruct subject with location and group keyword before submitting
@@ -2417,6 +2428,12 @@ func handleJoinAndPost(c *fiber.Ctx, myid uint64, req PostMessageRequest) error 
 	db.Exec("INSERT IGNORE INTO messages_groups (msgid, groupid, collection, arrival) VALUES (?, ?, ?, NOW())",
 		req.ID, groupid, collection)
 
+	// Non-moderated users skip the content-check pipeline (collection=Approved above),
+	// so we must populate the spatial index here rather than waiting for the batch job.
+	if collection == utils.COLLECTION_APPROVED {
+		addApprovedMessageToSpatialIndex(db, req.ID)
+	}
+
 	// Clear any previous outcomes (V1 parity: submit() always deletes outcomes before re-posting).
 	db.Exec("DELETE FROM messages_outcomes WHERE msgid = ?", req.ID)
 	db.Exec("DELETE FROM messages_outcomes_intended WHERE msgid = ?", req.ID)
@@ -2447,13 +2464,11 @@ func handleJoinAndPost(c *fiber.Ctx, myid uint64, req PostMessageRequest) error 
 	// and text=messageid (RFC822 Message-Id header).
 	logMessageReceived(db, groupid, myid, req.ID)
 
-	// Do NOT add to messages_spatial here. Every post starts Pending (see above),
-	// and messages_spatial backs the public browse/map — which is shown to all users,
-	// including logged-out ones (see message.Bounds / message.Groups). So it must only
-	// ever contain Approved messages. The message is added to the spatial index when it
-	// becomes Approved: either the content-check batch job (messages:contentcheck)
-	// auto-promotes it, or a moderator approves it (handleApprove). The poster still
-	// sees their own pending post immediately via the fromuser branch of the browse query.
+	// messages_spatial is only for Approved messages (backs the public browse/map).
+	// Non-moderated users already have collection=Approved and were added to the spatial
+	// index above. For Pending posts the batch job (messages:contentcheck) or a moderator
+	// (handleApprove) will add the row. The poster still sees their own pending post
+	// immediately via the fromuser branch of the browse query.
 
 	// Check if user has a password (to determine if they're a new user).
 	var hasPassword int64

--- a/iznik-server-go/session/session.go
+++ b/iznik-server-go/session/session.go
@@ -589,7 +589,8 @@ func handleForget(c *fiber.Ctx, partner string, targetID uint64) error {
 		// GDPR erasure: partner-deleted accounts have no recovery affordance (the partner
 		// owns the contract), so unlike the self-service flow we blank message content
 		// immediately rather than deferring to the 14-day grace cleanup.
-		db.Exec("UPDATE messages SET fromip = NULL, message = NULL, envelopefrom = NULL, fromname = NULL, fromaddr = NULL, messageid = NULL, textbody = NULL, htmlbody = NULL, deleted = NOW() WHERE fromuser = ?", targetID)
+		// message is NOT NULL in the schema — blank it rather than null it; all other content columns are nullable.
+		db.Exec("UPDATE messages SET fromip = NULL, message = '', envelopefrom = NULL, fromname = NULL, fromaddr = NULL, messageid = NULL, textbody = NULL, htmlbody = NULL, deleted = NOW() WHERE fromuser = ?", targetID)
 		db.Exec("UPDATE messages_groups SET deleted = 1 WHERE msgid IN (SELECT id FROM messages WHERE fromuser = ?)", targetID)
 
 		return c.JSON(fiber.Map{"ret": 0, "status": "Success"})

--- a/iznik-server-go/test/jobs_test.go
+++ b/iznik-server-go/test/jobs_test.go
@@ -100,11 +100,12 @@ func TestJobsDedupeByTitleAndBody(t *testing.T) {
 	// High expectation (cpc * clickability) so these rank within JOBS_LIMIT.
 	insertJob := func(title, location, body, canonicalTitle string) {
 		wkt := fmt.Sprintf("POINT(%.7f %.7f)", lng, lat)
-		ref := fmt.Sprintf("test-job-%d-%d", time.Now().UnixNano(), rand.Intn(1000000))
+		// job_reference is varchar(32) — keep under that limit.
+		ref := fmt.Sprintf("tj%d%04d", time.Now().UnixNano()%10000000000, rand.Intn(10000))
 		result := db.Exec(
 			fmt.Sprintf(
 				"INSERT INTO jobs (title, location, url, body, job_reference, category, geometry, cpc, clickability, visible, canonical_title) "+
-					"VALUES (?, ?, 'http://example.com/job', ?, ?, 'General', ST_GeomFromText(?, %d), 99.0, 1, 1, ?)",
+					"VALUES (?, ?, 'http://example.com/job', ?, ?, 'General', ST_GeomFromText(?, %d), 0.99, 1, 1, ?)",
 				utils.SRID),
 			title, location, body, ref, wkt, canonicalTitle)
 

--- a/iznik-server-go/test/logs_test.go
+++ b/iznik-server-go/test/logs_test.go
@@ -392,7 +392,7 @@ func TestGetLogsMsgsubjectHistoricalIsPreserved(t *testing.T) {
 	db := database.DBConn
 
 	// Create message with original subject "Wanted: Escooter"
-	db.Exec("INSERT INTO messages (fromuser, type, subject, textbody, arrival, date, source) VALUES (?, 'Wanted', 'Wanted: Escooter', 'body', NOW(), NOW(), 'Platform')", userID)
+	db.Exec("INSERT INTO messages (fromuser, type, subject, textbody, message, arrival, date, source) VALUES (?, 'Wanted', 'Wanted: Escooter', 'body', 'body', NOW(), NOW(), 'Platform')", userID)
 	var msgID uint64
 	db.Raw("SELECT id FROM messages WHERE fromuser = ? ORDER BY id DESC LIMIT 1", userID).Scan(&msgID)
 

--- a/iznik-server-go/test/main_test.go
+++ b/iznik-server-go/test/main_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/freegle/iznik-server-go/database"
 	"github.com/freegle/iznik-server-go/router"
@@ -29,8 +30,17 @@ func (a *TestApp) Test(req *http.Request, msTimeout ...int) (*http.Response, err
 var app *TestApp
 
 func init() {
+	// Match production timezone (main.go sets time.Local = UTC). The DB DSN uses loc=Local,
+	// so without this, GORM parses MySQL UTC timestamps as local time, causing 1h skew in BST.
+	loc, _ := time.LoadLocation("UTC")
+	time.Local = loc
+
 	// Set environment variables needed for tests
 	os.Setenv("LOVEJUNK_PARTNER_KEY", "testkey123")
+	// USER_SITE must be set so isValidRedirectURL allows www.ilovefreegle.org (used by email tracking tests).
+	if os.Getenv("USER_SITE") == "" {
+		os.Setenv("USER_SITE", "www.ilovefreegle.org")
+	}
 
 	app = &TestApp{fiber.New()}
 	app.Use(user.NewAuthMiddleware(user.Config{}))

--- a/iznik-server-go/test/membership_test.go
+++ b/iznik-server-go/test/membership_test.go
@@ -4064,7 +4064,7 @@ func TestNotesFilterAllCommunitiesExcludesNonModGroups(t *testing.T) {
 	)
 
 	// Member in a group the mod does NOT moderate — must not appear.
-	otherMod := CreateTestUser(t, prefix+"_othermod", "OtherMod")
+	otherMod := CreateTestUser(t, prefix+"_othermod", "Moderator")
 	memberInOtherGroup := CreateTestUser(t, prefix+"_other", "User")
 	otherGroupID := CreateTestGroup(t, prefix+"_other_group")
 	CreateTestMembership(t, otherMod, otherGroupID, "Moderator")

--- a/iznik-server-go/test/message_test.go
+++ b/iznik-server-go/test/message_test.go
@@ -8377,9 +8377,10 @@ func TestMessagePartnerKeyBypassesBodyMasking(t *testing.T) {
 
 // --- Content check pipeline tests ---
 
-// TestJoinAndPostUnmoderatedUserStartsPending verifies that even a user with
-// an explicit non-moderated posting status starts in Pending (awaiting contentcheck).
-func TestJoinAndPostUnmoderatedUserStartsPending(t *testing.T) {
+// TestJoinAndPostUnmoderatedUserGoesApproved verifies that a user with
+// ourPostingStatus='DEFAULT' (non-moderated) goes straight to Approved on JoinAndPost,
+// matching V1 postToCollection parity. Moderated (NULL/MODERATED) users still go to Pending.
+func TestJoinAndPostUnmoderatedUserGoesApproved(t *testing.T) {
 	prefix := uniquePrefix("msgcc_jap_unmod")
 	db := database.DBConn
 
@@ -8387,7 +8388,7 @@ func TestJoinAndPostUnmoderatedUserStartsPending(t *testing.T) {
 	userID := CreateTestUser(t, prefix+"_user", "User")
 	_, token := CreateTestSession(t, userID)
 
-	// Explicitly non-moderated posting status — previously this caused Approved.
+	// DEFAULT posting status = non-moderated member (V1 postToCollection → Approved).
 	CreateTestMembership(t, userID, groupID, "Member")
 	db.Exec("UPDATE memberships SET ourPostingStatus = 'DEFAULT' WHERE userid = ? AND groupid = ?", userID, groupID)
 
@@ -8405,16 +8406,10 @@ func TestJoinAndPostUnmoderatedUserStartsPending(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 200, resp.StatusCode)
 
-	// Must start Pending — contentcheck batch job promotes to Approved after checking.
+	// Non-moderated member goes to Approved (V1 parity, Discourse #9481/562).
 	var collection string
 	db.Raw("SELECT collection FROM messages_groups WHERE msgid = ? AND groupid = ?", msgID, groupID).Scan(&collection)
-	assert.Equal(t, "Pending", collection, "all submissions must start Pending for content check processing")
-
-	// No push_notify_group_mods task should be queued at submit time.
-	var taskCount int64
-	db.Raw("SELECT COUNT(*) FROM background_tasks WHERE task_type = 'push_notify_group_mods' AND processed_at IS NULL AND data LIKE ?",
-		fmt.Sprintf(`%%"group_id":%d%%`, groupID)).Scan(&taskCount)
-	assert.Equal(t, int64(0), taskCount, "push notification must not be queued at submit time — contentcheck batch job does that")
+	assert.Equal(t, "Approved", collection, "DEFAULT-status member goes to Approved, matching V1 postToCollection")
 }
 
 // TestContentcheckUnprocessedHiddenFromPendingQueue verifies that a message with
@@ -8766,4 +8761,120 @@ func TestListMessagesMT_SpamInPendingList(t *testing.T) {
 	// Cleanup.
 	db.Exec("DELETE FROM messages_groups WHERE msgid = ?", msgID)
 	db.Exec("DELETE FROM messages WHERE id = ?", msgID)
+}
+
+// TestRepostDefaultUserGoesApproved verifies that a non-moderated member (ourPostingStatus=DEFAULT)
+// who manually reposts via RejectToDraft → JoinAndPost gets collection=Approved immediately,
+// matching V1 repost() behaviour and auto-repost behaviour. Discourse #9481 post 562.
+//
+// AssertFlip: FAILS on buggy code (collection=Pending), PASSES after fix (collection=Approved).
+func TestRepostDefaultUserGoesApproved(t *testing.T) {
+	prefix := uniquePrefix("repost_default_approved")
+	db := database.DBConn
+
+	groupID := CreateTestGroup(t, prefix)
+	userID := CreateTestUser(t, prefix+"_user", "User")
+	CreateTestMembership(t, userID, groupID, "Member")
+	// Set to DEFAULT posting status — this is a regular, non-moderated member.
+	db.Exec("UPDATE memberships SET ourPostingStatus = 'DEFAULT' WHERE userid = ? AND groupid = ?", userID, groupID)
+	_, token := CreateTestSession(t, userID)
+
+	// Start with an Approved message (the normal state before reposting).
+	msgID := CreateTestMessage(t, userID, groupID, prefix+" repostable item", 52.5, -1.8)
+
+	// Step 1: RejectToDraft — converts message to a draft.
+	body1, _ := json.Marshal(map[string]interface{}{
+		"id":     msgID,
+		"action": "RejectToDraft",
+	})
+	req := httptest.NewRequest("POST", "/api/message?jwt="+token, bytes.NewBuffer(body1))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := getApp().Test(req)
+	require.NoError(t, err)
+	require.Equal(t, 200, resp.StatusCode)
+
+	// Step 2: JoinAndPost — resubmits the draft.
+	body2, _ := json.Marshal(map[string]interface{}{
+		"id":     msgID,
+		"action": "JoinAndPost",
+	})
+	req = httptest.NewRequest("POST", "/api/message?jwt="+token, bytes.NewBuffer(body2))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err = getApp().Test(req)
+	require.NoError(t, err)
+	require.Equal(t, 200, resp.StatusCode)
+
+	// Non-moderated member's repost must land in Approved, not Pending.
+	var collection string
+	db.Raw("SELECT collection FROM messages_groups WHERE msgid = ? AND groupid = ?", msgID, groupID).Scan(&collection)
+	assert.Equal(t, "Approved", collection, "DEFAULT-status member's manual repost should go to Approved")
+
+	// The message must also be in the spatial index (since collection=Approved).
+	var spatialCount int64
+	db.Raw("SELECT COUNT(*) FROM messages_spatial WHERE msgid = ?", msgID).Scan(&spatialCount)
+	assert.Equal(t, int64(1), spatialCount, "Approved repost must appear in messages_spatial")
+}
+
+// TestManualRepostPendingVisibleInHistory verifies that a message in Pending collection
+// appears in the user's posting history (GetUserMessageHistory).
+// Bug: history was filtered to collection='Approved' only, so a manually reposted message
+// was invisible until the content-check batch approved it. Discourse #9481 post 562.
+//
+// AssertFlip: FAILS on buggy code (Approved-only filter), PASSES after fix (Pending included).
+func TestManualRepostPendingVisibleInHistory(t *testing.T) {
+	prefix := uniquePrefix("repost_pending_history")
+	db := database.DBConn
+
+	groupID := CreateTestGroup(t, prefix)
+	posterID := CreateTestUser(t, prefix+"_poster", "User")
+	modID := CreateTestUser(t, prefix+"_mod", "User")
+	CreateTestMembership(t, posterID, groupID, "Member")
+	CreateTestMembership(t, modID, groupID, "Moderator")
+	_, modToken := CreateTestSession(t, modID)
+
+	// Simulate a moderated member's repost: message is in Pending (content-check not yet run).
+	pendingSubject := prefix + " OFFER pending repost"
+	db.Exec(
+		"INSERT INTO messages (fromuser, subject, textbody, message, type, arrival) "+
+			"VALUES (?, ?, 'body', 'body', 'Offer', NOW())",
+		posterID, pendingSubject)
+	var pendingMsgID uint64
+	db.Raw("SELECT id FROM messages WHERE fromuser = ? AND subject = ? ORDER BY id DESC LIMIT 1",
+		posterID, pendingSubject).Scan(&pendingMsgID)
+	require.NotZero(t, pendingMsgID)
+	db.Exec(
+		"INSERT INTO messages_groups (msgid, groupid, arrival, collection) VALUES (?, ?, NOW(), 'Pending')",
+		pendingMsgID, groupID)
+
+	t.Cleanup(func() {
+		db.Exec("DELETE FROM messages_groups WHERE msgid = ?", pendingMsgID)
+		db.Exec("DELETE FROM messages WHERE id = ?", pendingMsgID)
+	})
+
+	// Fetch the poster via the modtools API (which returns messagehistory).
+	url := fmt.Sprintf("/api/user/%d?modtools=true&jwt=%s", posterID, modToken)
+	resp, err := getApp().Test(httptest.NewRequest("GET", url, nil))
+	require.NoError(t, err)
+	require.Equal(t, 200, resp.StatusCode)
+
+	var raw map[string]interface{}
+	err = json.NewDecoder(resp.Body).Decode(&raw)
+	require.NoError(t, err)
+
+	history, ok := raw["messagehistory"].([]interface{})
+	require.True(t, ok, "messagehistory must be present for modtools fetch")
+
+	pendingFound := false
+	for _, h := range history {
+		entry, ok := h.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if id, ok := entry["id"].(float64); ok && uint64(id) == pendingMsgID {
+			pendingFound = true
+			coll, _ := entry["collection"].(string)
+			assert.Equal(t, "Pending", coll, "history entry should carry the Pending collection")
+		}
+	}
+	assert.True(t, pendingFound, "Pending message must appear in the poster's message history")
 }

--- a/iznik-server-go/user/user.go
+++ b/iznik-server-go/user/user.go
@@ -476,6 +476,9 @@ func GetUserMessageHistory(userid uint64) []UserMessageHistory {
 	db := database.DBConn
 
 	var history []UserMessageHistory
+	// Include Pending so that messages awaiting the content-check batch (e.g. a new
+	// user's first post, or a moderated user's repost) remain visible in the Posts
+	// history. Rejected stays excluded — rejected posts should not count as active.
 	db.Raw("SELECT m.id, m.subject, m.type, "+
 		"GREATEST(COALESCE(mp.date, m.arrival), COALESCE(mp.date, m.arrival)) AS arrival, "+
 		"mg.groupid, mg.collection, "+
@@ -483,8 +486,8 @@ func GetUserMessageHistory(userid uint64) []UserMessageHistory {
 		"FROM messages m "+
 		"INNER JOIN messages_groups mg ON m.id = mg.msgid "+
 		"LEFT JOIN messages_postings mp ON mp.msgid = m.id "+
-		"WHERE m.fromuser = ? AND mg.deleted = 0 AND m.deleted IS NULL AND mg.collection = ? "+
-		"ORDER BY arrival DESC", userid, utils.COLLECTION_APPROVED).Scan(&history)
+		"WHERE m.fromuser = ? AND mg.deleted = 0 AND m.deleted IS NULL AND mg.collection IN (?, ?) "+
+		"ORDER BY arrival DESC", userid, utils.COLLECTION_APPROVED, utils.COLLECTION_PENDING).Scan(&history)
 
 	now := time.Now()
 	for ix, h := range history {


### PR DESCRIPTION
## Summary

Fixes Discourse [topic 9481, post 562](https://discourse.ilovefreegle.org/t/9481/562) (reporter: Neville Reid).

**Bug 1 — Manual reposts always land in Pending:**
`handleJoinAndPost` hardcoded `COLLECTION_PENDING` for every submission. V1's `postToCollection` logic (User.php:819) sends NULL/MODERATED/PROHIBITED members to Pending and everyone else to Approved — the initial-post path and `AutoRepostService` both honour this, but `handleJoinAndPost` did not. After the fix, a member with `ourPostingStatus = 'DEFAULT'` (the typical established member) sees their repost go straight to Approved, matching V1 and auto-repost behaviour.

Also: when `handleJoinAndPost` sets `collection=Approved`, it now immediately calls `addApprovedMessageToSpatialIndex` so the post appears on public browse/map without waiting for the batch job.

**Bug 2 — Original post disappears from Posts list while repost is pending:**
`GetUserMessageHistory` filtered to `collection = Approved` only. A message that is PENDING (whether a new member's first post or a moderated member's repost) vanished from the Posts history until the content-check batch promoted it. Fixed to include both APPROVED and PENDING.

**Pre-existing test fixes (all failing on master before this branch):**
- `test/main_test.go`: set `time.Local = UTC` (matches `main.go`) to fix `TestSessionLastactiveUpdatedWhenOld` 1-hour BST skew; set `USER_SITE` default to fix `TestEmailTrackingClick` URL-whitelist failure.
- `test/jobs_test.go`: `job_reference varchar(32)` overflow → shorter format; `cpc decimal(4,4)` max 0.9999 → changed `99.0` to `0.99`.
- `test/logs_test.go`: `messages.message NOT NULL` → added `message` column to INSERT.
- `test/membership_test.go`: `systemrole SET` type → `'OtherMod'` is invalid → `'Moderator'`.
- `session/session.go`: `messages.message NOT NULL` → GDPR partner-forget erasure now uses `''` not `NULL`.

## Test plan

- [x] `TestRepostDefaultUserGoesApproved` — DEFAULT member's JoinAndPost → Approved + spatial index entry
- [x] `TestManualRepostPendingVisibleInHistory` — PENDING message appears in GetUserMessageHistory
- [x] `TestJoinAndPostUnmoderatedUserGoesApproved` — renamed + corrected from the previous test that was asserting the buggy Pending behaviour
- [x] Full Go test suite passes (0 failures, 109s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)