### PR TITLE
fix(ModTools): exclude pre-content-check pending messages from work count

### DIFF
--- a/iznik-server-go/session/session.go
+++ b/iznik-server-go/session/session.go
@@ -924,6 +924,11 @@ func GetSession(c *fiber.Ctx) error {
 		var wg2 sync.WaitGroup
 
 		// --- Pending messages: active groups split by held, inactive all → pendingother ---
+		// Only count messages where contentcheck_checked_at IS NOT NULL: the content
+		// check has run and left the message pending (moderated user/group or flagged
+		// content). Messages that have not yet been content-checked may still be
+		// auto-approved and must not trigger a phantom notification or inflate the
+		// badge count. Discourse #9481 post 563.
 		wg2.Add(1)
 		go func() {
 			defer wg2.Done()
@@ -933,7 +938,8 @@ func GetSession(c *fiber.Ctx) error {
 					"INNER JOIN messages m ON m.id = mg.msgid "+
 					"INNER JOIN users u ON u.id = m.fromuser "+
 					"WHERE mg.groupid IN ? AND mg.collection = ? AND mg.deleted = 0 "+
-					"AND m.deleted IS NULL AND u.deleted IS NULL AND m.heldby IS NULL",
+					"AND m.deleted IS NULL AND u.deleted IS NULL AND m.heldby IS NULL "+
+					"AND mg.contentcheck_checked_at IS NOT NULL",
 					activeGroupIDs, utils.COLLECTION_PENDING).Scan(&pending)
 				// Held pending in active groups → pendingother (blue).
 				var heldActive int64
@@ -941,7 +947,8 @@ func GetSession(c *fiber.Ctx) error {
 					"INNER JOIN messages m ON m.id = mg.msgid "+
 					"INNER JOIN users u ON u.id = m.fromuser "+
 					"WHERE mg.groupid IN ? AND mg.collection = ? AND mg.deleted = 0 "+
-					"AND m.deleted IS NULL AND u.deleted IS NULL AND m.heldby IS NOT NULL",
+					"AND m.deleted IS NULL AND u.deleted IS NULL AND m.heldby IS NOT NULL "+
+					"AND mg.contentcheck_checked_at IS NOT NULL",
 					activeGroupIDs, utils.COLLECTION_PENDING).Scan(&heldActive)
 				pendingother += heldActive
 			}
@@ -952,7 +959,8 @@ func GetSession(c *fiber.Ctx) error {
 					"INNER JOIN messages m ON m.id = mg.msgid "+
 					"INNER JOIN users u ON u.id = m.fromuser "+
 					"WHERE mg.groupid IN ? AND mg.collection = ? AND mg.deleted = 0 "+
-					"AND m.deleted IS NULL AND u.deleted IS NULL",
+					"AND m.deleted IS NULL AND u.deleted IS NULL "+
+					"AND mg.contentcheck_checked_at IS NOT NULL",
 					inactiveGroupIDs, utils.COLLECTION_PENDING).Scan(&inact)
 				pendingother += inact
 			}

--- a/iznik-server-go/test/session_test.go
+++ b/iznik-server-go/test/session_test.go
@@ -1771,8 +1771,8 @@ func TestWorkCountPendingMessages(t *testing.T) {
 		"VALUES (?, 'OFFER: Pending item', 'Test body', 'Test body', 'Offer', ?, NOW())", memberID, locationID)
 	var msgID uint64
 	db.Raw("SELECT id FROM messages WHERE fromuser = ? ORDER BY id DESC LIMIT 1", memberID).Scan(&msgID)
-	db.Exec("INSERT INTO messages_groups (msgid, groupid, arrival, collection, autoreposts) "+
-		"VALUES (?, ?, NOW(), 'Pending', 0)", msgID, groupID)
+	db.Exec("INSERT INTO messages_groups (msgid, groupid, arrival, collection, autoreposts, contentcheck_checked_at) "+
+		"VALUES (?, ?, NOW(), 'Pending', 0, NOW())", msgID, groupID)
 	defer func() {
 		db.Exec("DELETE FROM messages_groups WHERE msgid = ?", msgID)
 		db.Exec("DELETE FROM messages WHERE id = ?", msgID)
@@ -1780,7 +1780,7 @@ func TestWorkCountPendingMessages(t *testing.T) {
 
 	work := getSessionWork(t, token)
 	pending := work["pending"].(float64)
-	assert.GreaterOrEqual(t, pending, float64(1), "Should count pending message")
+	assert.GreaterOrEqual(t, pending, float64(1), "Should count content-checked pending message")
 }
 
 // ---------------------------------------------------------------------------
@@ -1940,7 +1940,8 @@ func TestWorkCountPendingExcludesDeletedUsers(t *testing.T) {
 
 	// Create a pending message from this member.
 	msgID := CreateTestMessage(t, memberID, groupID, "OFFER: Limbo pending", 55.9533, -3.1883)
-	db.Exec("UPDATE messages_groups SET collection = 'Pending' WHERE msgid = ?", msgID)
+	// Set collection = 'Pending' and contentcheck_checked_at so the fix counts it.
+	db.Exec("UPDATE messages_groups SET collection = 'Pending', contentcheck_checked_at = NOW() WHERE msgid = ?", msgID)
 
 	// Baseline: message should be counted.
 	workBefore := getSessionWork(t, token)
@@ -1955,6 +1956,65 @@ func TestWorkCountPendingExcludesDeletedUsers(t *testing.T) {
 	pendingAfter := workAfter["pending"].(float64) + workAfter["pendingother"].(float64)
 
 	assert.Less(t, pendingAfter, pendingBefore, "Pending count must exclude messages from deleted users")
+}
+
+// ---------------------------------------------------------------------------
+// Work Counts: Unchecked pending messages excluded (phantom-notification fix)
+// Discourse #9481 post 563: a pending message with contentcheck_checked_at IS
+// NULL has not yet been processed by the content check and may still be
+// auto-approved. Counting it fires a phantom beep that vanishes when the mod
+// opens Pending. Only messages that content check has processed and left
+// pending (contentcheck_checked_at IS NOT NULL) should be counted.
+// ---------------------------------------------------------------------------
+
+func TestWorkCountPendingExcludesUnchecked(t *testing.T) {
+	prefix := uniquePrefix("wc_unchk")
+	db := database.DBConn
+	groupID := CreateTestGroup(t, prefix)
+	modID := CreateTestUser(t, prefix+"_mod", "User")
+	CreateTestMembership(t, modID, groupID, "Moderator")
+	_, token := CreateTestSession(t, modID)
+
+	memberID := CreateTestUser(t, prefix+"_member", "User")
+	CreateTestMembership(t, memberID, groupID, "Member")
+
+	workBefore := getSessionWork(t, token)
+	pendingBefore := workBefore["pending"].(float64)
+	pendingotherBefore := workBefore["pendingother"].(float64)
+
+	// Simulate a just-arrived post: contentcheck_checked_at IS NULL (not yet processed).
+	var locationID uint64
+	db.Raw("SELECT id FROM locations LIMIT 1").Scan(&locationID)
+	db.Exec("INSERT INTO messages (fromuser, subject, textbody, message, type, locationid, arrival) "+
+		"VALUES (?, 'OFFER: Auto-approvable item', 'Test body', 'Test body', 'Offer', ?, NOW())",
+		memberID, locationID)
+	var msgID uint64
+	db.Raw("SELECT id FROM messages WHERE fromuser = ? ORDER BY id DESC LIMIT 1", memberID).Scan(&msgID)
+	db.Exec("INSERT INTO messages_groups (msgid, groupid, arrival, collection, autoreposts) "+
+		"VALUES (?, ?, NOW(), 'Pending', 0)", msgID, groupID)
+	defer func() {
+		db.Exec("DELETE FROM messages_groups WHERE msgid = ?", msgID)
+		db.Exec("DELETE FROM messages WHERE id = ?", msgID)
+	}()
+
+	workUnchecked := getSessionWork(t, token)
+	pendingUnchecked := workUnchecked["pending"].(float64)
+	pendingotherUnchecked := workUnchecked["pendingother"].(float64)
+
+	// Unchecked message must NOT inflate the count — phantom notification bug.
+	assert.Equal(t, pendingBefore, pendingUnchecked,
+		"Unchecked pending message must not appear in pending count before content check runs")
+	assert.Equal(t, pendingotherBefore, pendingotherUnchecked,
+		"Unchecked pending message must not appear in pendingother before content check runs")
+
+	// Once content check marks the message (contentcheck_checked_at IS NOT NULL),
+	// it must appear in the count — real pending items need mod attention.
+	db.Exec("UPDATE messages_groups SET contentcheck_checked_at = NOW() WHERE msgid = ? AND groupid = ?",
+		msgID, groupID)
+	workChecked := getSessionWork(t, token)
+	pendingChecked := workChecked["pending"].(float64)
+	assert.Greater(t, pendingChecked, pendingBefore,
+		"Content-checked pending message must appear in count once content check has run")
 }
 
 // ---------------------------------------------------------------------------
@@ -2245,8 +2305,8 @@ func TestWorkCountInactiveModPendingGoesToOther(t *testing.T) {
 		"VALUES (?, 'OFFER: Inactive pending', 'Test body', 'Test body', 'Offer', ?, NOW())", memberID, locationID)
 	var msgID uint64
 	db.Raw("SELECT id FROM messages WHERE fromuser = ? ORDER BY id DESC LIMIT 1", memberID).Scan(&msgID)
-	db.Exec("INSERT INTO messages_groups (msgid, groupid, arrival, collection, autoreposts) "+
-		"VALUES (?, ?, NOW(), 'Pending', 0)", msgID, groupID)
+	db.Exec("INSERT INTO messages_groups (msgid, groupid, arrival, collection, autoreposts, contentcheck_checked_at) "+
+		"VALUES (?, ?, NOW(), 'Pending', 0, NOW())", msgID, groupID)
 	defer func() {
 		db.Exec("DELETE FROM messages_groups WHERE msgid = ?", msgID)
 		db.Exec("DELETE FROM messages WHERE id = ?", msgID)
@@ -2278,8 +2338,8 @@ func TestWorkCountActiveModPendingGoesToPrimary(t *testing.T) {
 		"VALUES (?, 'OFFER: Active pending', 'Test body', 'Test body', 'Offer', ?, NOW())", memberID, locationID)
 	var msgID uint64
 	db.Raw("SELECT id FROM messages WHERE fromuser = ? ORDER BY id DESC LIMIT 1", memberID).Scan(&msgID)
-	db.Exec("INSERT INTO messages_groups (msgid, groupid, arrival, collection, autoreposts) "+
-		"VALUES (?, ?, NOW(), 'Pending', 0)", msgID, groupID)
+	db.Exec("INSERT INTO messages_groups (msgid, groupid, arrival, collection, autoreposts, contentcheck_checked_at) "+
+		"VALUES (?, ?, NOW(), 'Pending', 0, NOW())", msgID, groupID)
 	defer func() {
 		db.Exec("DELETE FROM messages_groups WHERE msgid = ?", msgID)
 		db.Exec("DELETE FROM messages WHERE id = ?", msgID)


### PR DESCRIPTION
## Problem

Discourse #9481 post 563 reports two related ModTools symptoms:
1. A phantom notification sound (beep) fires when a group-settings member's post arrives, even though by the time the volunteer opens the Pending tab, the post is already gone (auto-approved).
2. The attention badge count shows inflated numbers (e.g. 4 needing attention when only 1 is on Hold).

## Root cause

Posts arrive into `COLLECTION_PENDING` with `contentcheck_checked_at IS NULL`. Within ~1 minute `ContentCheckService` either:
- auto-approves the post (unmoderated user + clean content) → removed from Pending, or
- leaves it pending and stamps `contentcheck_checked_at = NOW()` + sends a push notification.

During that 0–60 second window the three pending-count queries in `session/session.go` counted the unchecked post. `useModMe.js::checkWork()` polls every 30 s, sees `work.total` increase by 1, plays the beep — then on the next poll the post is gone and the count drops back. Volunteers hear the beep, open Pending, find nothing there.

## Fix

Add `AND mg.contentcheck_checked_at IS NOT NULL` to all three pending-count goroutine queries in `session.go`:
- unheld pending in active groups → `pending` (red)
- held pending in active groups → `pendingother` (blue)
- all pending in inactive groups → `pendingother` (blue)

A post only appears in the badge count once ContentCheck has reviewed it and decided to leave it for a moderator.

## Tests

- **`TestWorkCountPendingExcludesUnchecked`** (new): inserts a pending message with `contentcheck_checked_at IS NULL`, asserts it does NOT inflate `pending` or `pendingother`; then stamps the column and asserts the count DOES increase.
- Updated four existing pending-count tests to set `contentcheck_checked_at = NOW()` in their INSERT/UPDATE so they continue to verify that real pending items are counted after the fix.
- Full Go suite green: **3059 passed, 0 failed** (`POST /api/tests/go`). (An earlier local run showed 6 NOT NULL failures — `TestJobsDedupeByTitleAndBody`, `TestGetLogsMsgsubjectHistoricalIsPreserved`, `TestNotesFilterAllCommunitiesExcludesNonModGroups`, `TestSubmitMessageLinksExistingAttachment`, `TestModerationStats_CountsAutoApprovedAndSample`, `TestForgetPartnerFlow` — caused by the `iznik_go_test` schema being cloned while `freegle-apiv1` was down; restarting apiv1 and rebuilding the test DB cleared all six.)

## Discourse

https://discourse.ilovefreegle.org/t/9481/563
