### PR TITLE
fix(modtools-notifications): include spam in Pending badge so total matches visible items (#9654)

### DIFF
--- a/iznik-nuxt3/modtools/layouts/default.vue
+++ b/iznik-nuxt3/modtools/layouts/default.vue
@@ -87,7 +87,7 @@
         <ModMenuItemLeft
           link="/messages/pending"
           name="Pending"
-          :count="['pending']"
+          :count="['pending', 'spam']"
           :othercount="['pendingother']"
           indent
           @mobilehidemenu="mobilehidemenu"

--- a/iznik-nuxt3/tests/unit/components/modtools/ModtoolsDefaultLayout.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModtoolsDefaultLayout.spec.js
@@ -232,6 +232,53 @@ describe('modtools default layout — leftmenu CLS prevention', () => {
   })
 })
 
+describe('modtools default layout — pending badge includes spam', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockCheckWork.mockReset()
+    mockResetCheckWork.mockReset()
+    mockAuthStore.user = { id: 1, displayname: 'Test Mod' }
+    mockAuthStore.loginStateKnown = true
+    mockAuthStore.work = { pending: 0, spam: 1, total: 1 }
+  })
+
+  afterEach(() => {
+    mockAuthStore.user = null
+    mockAuthStore.loginStateKnown = false
+    mockAuthStore.work = null
+  })
+
+  it('Pending menu badge includes spam so work.total matches visible badge sum (Discourse #9654)', async () => {
+    // spam messages appear in the Pending review list (PR #638),
+    // so the Pending nav badge must count ['pending', 'spam'] — not just ['pending'].
+    // Otherwise a mod with 1 spam message sees total=1 in the hamburger but 0 in the
+    // Pending item, giving a spurious "+1 persisting all day" (Discourse #9654).
+    const capturedItems = []
+    const CapturingModMenuItemLeft = {
+      template: '<div />',
+      props: ['link', 'name', 'count', 'othercount', 'indent', 'countVariant', 'directcount'],
+      setup(props) {
+        capturedItems.push({
+          link: props.link,
+          name: props.name,
+          count: props.count ? [...props.count] : null,
+        })
+      },
+    }
+
+    const wrapper = mountLayout({ ModMenuItemLeft: CapturingModMenuItemLeft })
+    await flushPromises()
+    await nextTick()
+
+    const pendingItem = capturedItems.find((item) => item.link === '/messages/pending')
+    expect(pendingItem, 'Pending menu item must be rendered').toBeDefined()
+
+    // Fails on buggy code (count=['pending'], spam not present).
+    // Passes after fix (count=['pending','spam']).
+    expect(pendingItem.count).toContain('spam')
+  })
+})
+
 describe('modtools default layout — re-login group refresh', () => {
   beforeEach(() => {
     vi.clearAllMocks()


### PR DESCRIPTION
## Root Cause

`work.spam` (spam-collection messages) is included in `work.total` — the value that drives the red hamburger badge — but the left-nav **Pending** menu item only counted `['pending']`. Since PR #638 (merged 2026-06-04) made spam-collection messages visible in the Pending review list, a mod with even one spam message sees `work.total = 1` in the hamburger while every per-item left-nav badge shows 0. That mismatch is the "spurious +1 persisting all day" reported in Discourse #9654.

The repo owner confirmed the root cause on PR #632:
> "e.g. Hackney currently has 1 spam message, which is exactly the '+1 over visible' in post #9."

## Evidence

Failing test on buggy code:
```
 FAIL  tests/unit/components/modtools/ModtoolsDefaultLayout.spec.js
  ❯ modtools default layout — pending badge includes spam
    → expected [ 'pending' ] to include 'spam'
```

## Fix

One-line change in `modtools/layouts/default.vue`: the Pending nav item's `:count` prop changes from `['pending']` to `['pending', 'spam']`. Spam messages now have a visible home in the Pending badge, so the sum of all left-nav badges equals `work.total`.

## Other Call Sites

No other code re-sums work fields into a total. `groupWork.go` returns raw per-group counts (no total field). The `menuCount` computed property consumes `work.total` directly without re-summing individual fields.

## Test

- File: `iznik-nuxt3/tests/unit/components/modtools/ModtoolsDefaultLayout.spec.js`
- Suite: `modtools default layout — pending badge includes spam`
- Proves: FAIL before fix (`count=['pending']`, spam absent), PASS after fix (`count=['pending','spam']`)
- Full Vitest suite: 603 files / 12938 tests — all pass (no regressions)

## Discourse
https://discourse.ilovefreegle.org/t/9654/9