### PR TITLE
fix(modtools): restore Back to Pending button on multi-group Approved messages

### DIFF
--- a/iznik-nuxt3/modtools/components/ModMessage.vue
+++ b/iznik-nuxt3/modtools/components/ModMessage.vue
@@ -202,7 +202,7 @@
                   >
                 </b-button>
                 <SpinButton
-                  v-if="contextGroup?.collection === 'Approved'"
+                  v-if="hasCollection('Approved')"
                   class="mt-2"
                   variant="white"
                   icon-name="reply"

--- a/iznik-nuxt3/tests/unit/components/modtools/ModMessage.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModMessage.spec.js
@@ -908,6 +908,22 @@ describe('ModMessage', () => {
       )
       expect(backToPendingButton.length).toBe(0)
     })
+
+    it('shows for multi-group messages when any group is Approved (All Groups view)', async () => {
+      // Regression: contextGroup fell back to groups[0] (Pending) when contextGroupid=null,
+      // hiding the button even though groups[1] was Approved.
+      const wrapper = mountComponent(
+        { summary: false, contextGroupid: null },
+        {
+          groups: [
+            { groupid: 100, collection: 'Pending' },
+            { groupid: 789, collection: 'Approved' },
+          ],
+        }
+      )
+      await wrapper.vm.$nextTick()
+      expect(wrapper.text()).toContain('Back to Pending')
+    })
   })
 
   describe('ModMessageButtons', () => {


### PR DESCRIPTION
## Root Cause

`ModMessage.vue` conditioned the **Back to Pending** header button on `contextGroup?.collection === 'Approved'`. When `contextGroupid` is `null` (All Groups view), `contextGroup` fell back to `message.groups[0]`. For multi-group messages where the first group in the DB result (lower `groupid`) had collection `Pending`, `contextGroup.collection` was `'Pending'` and the button was hidden — even though the message was Approved for another group and was correctly visible in the Approved list.

## Evidence

- `ModMessageButtons.vue` uses `hasCollection('Approved')` (checks *any* group) to decide whether to show approved-mode footer buttons (Delete, Spam, etc.). The header Back to Pending button used a stricter check that diverged from this.
- The messages composable already filters the Approved page by `m.groups.some(g => g.collection === 'Approved')`, so messages on the list are guaranteed to have at least one Approved group.
- New failing test in `ModMessage.spec.js`: groups `[{100, Pending}, {789, Approved}]` with `contextGroupid=null` — button was absent before fix, present after.

## Fix

`v-if="contextGroup?.collection === 'Approved'"` → `v-if="hasCollection('Approved')"`

`hasCollection` already exists in `ModMessage.vue` (line 1188) and checks `message.value.groups` for any group with the given collection — the same pattern used by `ModMessageButtons.vue`.

## Other Call Sites

`contextGroup?.collection === 'Approved'` also appears at line 574 (the `review`-mode info alert "Post now in Approved"), which is a post-action status indicator, not a button condition — left unchanged.

## Test

New vitest in `ModMessage > Back to pending button`:
- Message with `groups: [{groupid:100, Pending}, {groupid:789, Approved}]`, `contextGroupid: null`
- Asserts `wrapper.text()` contains `'Back to Pending'`
- Failed before fix, passes after. All 4117 modtools unit tests pass.

## Discourse

https://discourse.ilovefreegle.org/t/9777

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes [topic 9777, post 1](https://discourse.ilovefreegle.org/t/9777/1) — original report on Discourse.
