### PR TITLE
fix(chat): append digest-reply label when email reply quotes a digest

### DIFF
--- a/iznik-batch/app/Services/Mail/Incoming/IncomingMailService.php
+++ b/iznik-batch/app/Services/Mail/Incoming/IncomingMailService.php
@@ -1881,12 +1881,30 @@ class IncomingMailService
             $body = $prependSubject . "\r\n\r\n" . $body;
         }
 
+        // Detect digest-reply patterns before stripping so we can append the label after.
+        // V1 parity: MailRouter.php detected "On ... -auto@GROUP_DOMAIN> wrote:" and
+        // "-----Original Message-----" to identify replies that include the full digest,
+        // then stripped the quoted content and appended the label text.
+        $isDigestReply = false;
+        if (! $skipStripQuoted) {
+            $groupDomain = preg_quote(config('freegle.mail.group_domain', 'groups.ilovefreegle.org'), '/');
+            if (preg_match('/^\s*On.*?-auto@' . $groupDomain . '>\s*wrote\s*:/ms', $body) ||
+                preg_match('/-----Original Message-----/', $body)) {
+                $isDigestReply = true;
+            }
+        }
+
         // Strip quoted reply text and signatures before storing.
         // For volunteer messages, the quoted text (conversation transcript, reported post)
         // is the useful content - don't strip it. Matches legacy iznik-server behavior:
         // "Don't strip quoted as it might be useful."
         if (! $skipStripQuoted) {
             $body = $this->stripQuoted->strip($body);
+        }
+
+        // Append digest-reply label so moderators know to check the original email.
+        if ($isDigestReply) {
+            $body = rtrim($body) . "\r\n\r\n(Probably replied to digest - check View original email)";
         }
 
         // Determine if this chat message needs review.

--- a/iznik-batch/tests/Unit/Services/Mail/Incoming/IncomingMailServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/Mail/Incoming/IncomingMailServiceTest.php
@@ -5079,4 +5079,95 @@ class IncomingMailServiceTest extends TestCase
             return $mail->hasTo($senderEmail);
         });
     }
+
+    // ========================================
+    // Digest Reply Label Tests (Issue #9775)
+    // ========================================
+
+    public function test_digest_reply_via_original_message_separator_appends_label(): void
+    {
+        // Regression test for #9775: a user replying to a digest email via a mail
+        // client that quotes it with "-----Original Message-----" should get the
+        // "(Probably replied to digest - check View original email)" label appended
+        // to the chat message body so moderators know to check the original email.
+        $group = $this->createTestGroup();
+        $user = $this->createTestUser(['email_preferred' => $this->uniqueEmail('digestreplier')]);
+        $this->createMembership($user, $group);
+        $memberEmail = $user->emails->first()->email;
+
+        $body = "Hi, I wanted to reply to one of the posts in the digest.\r\n\r\n"
+            . "-----Original Message-----\r\n"
+            . "From: ".$group->nameshort."-auto@groups.ilovefreegle.org\r\n"
+            . "Subject: [".$group->nameshort."] What's New\r\n"
+            . "\r\nHere is all the digest content...";
+
+        $email = $this->createMinimalEmail([
+            'From' => $memberEmail,
+            'To' => $group->nameshort.'-auto@groups.ilovefreegle.org',
+            'Subject' => "Re: [".$group->nameshort."] What's New",
+        ], $body);
+
+        $parsed = $this->parser->parse(
+            $email,
+            $memberEmail,
+            $group->nameshort.'-auto@groups.ilovefreegle.org'
+        );
+
+        $this->service->route($parsed);
+
+        $chatMsg = DB::table('chat_messages')
+            ->where('userid', $user->id)
+            ->orderBy('id', 'desc')
+            ->first();
+
+        $this->assertNotNull($chatMsg, 'Chat message should have been created');
+        $this->assertStringContainsString(
+            '(Probably replied to digest - check View original email)',
+            $chatMsg->message,
+            'Digest reply label should be appended to the chat message body'
+        );
+    }
+
+    public function test_digest_reply_via_auto_address_header_appends_label(): void
+    {
+        // Regression test for #9775: a user replying to a digest email via a mail
+        // client that quotes it with "On ... -auto@groups.ilovefreegle.org> wrote:"
+        // should get the digest label appended to the chat message body.
+        $group = $this->createTestGroup();
+        $user = $this->createTestUser(['email_preferred' => $this->uniqueEmail('digestreplier2')]);
+        $this->createMembership($user, $group);
+        $memberEmail = $user->emails->first()->email;
+
+        $groupDomain = config('freegle.mail.group_domain', 'groups.ilovefreegle.org');
+        $body = "Yes, I am interested in that item!\r\n\r\n"
+            . "On 10 Jun 2026, at 08:00, ".$group->nameshort."-auto@".$groupDomain."> wrote:\r\n"
+            . "\r\n> OFFER: Old sofa (Somewhere)\r\n"
+            . "> Posted by Someone";
+
+        $email = $this->createMinimalEmail([
+            'From' => $memberEmail,
+            'To' => $group->nameshort.'-auto@'.$groupDomain,
+            'Subject' => "Re: [".$group->nameshort."] What's New",
+        ], $body);
+
+        $parsed = $this->parser->parse(
+            $email,
+            $memberEmail,
+            $group->nameshort.'-auto@'.$groupDomain
+        );
+
+        $this->service->route($parsed);
+
+        $chatMsg = DB::table('chat_messages')
+            ->where('userid', $user->id)
+            ->orderBy('id', 'desc')
+            ->first();
+
+        $this->assertNotNull($chatMsg, 'Chat message should have been created');
+        $this->assertStringContainsString(
+            '(Probably replied to digest - check View original email)',
+            $chatMsg->message,
+            'Digest reply label should be appended to the chat message body'
+        );
+    }
 }


### PR DESCRIPTION
## Problem

Chat messages sent by users who replied to the digest email no longer display the 'replied to digest' label. This was present in V1 but regressed in the V2 migration.

Reported by @Jos in [topic 9775, post 1](https://discourse.ilovefreegle.org/t/9775/1).

## Root cause

V1 `MailRouter.php` (lines 704–716) detected when a user's email reply included quoted digest content — either `-----Original Message-----` or `On ... -auto@GROUP_DOMAIN> wrote:` — and appended `(Probably replied to digest - check View original email)` to the chat message body before storing it.

V2 `IncomingMailService::createChatMessageFromEmail()` calls `StripQuotedService::strip()` to remove quoted content, but never added this label. The stripped body was stored without any indication it was a digest reply.

## Fix

In `createChatMessageFromEmail()`, detect the two digest-reply patterns **before** stripping (so we can still see them in the raw body), then **after** stripping append the label if either pattern was found.

The `$skipStripQuoted` guard (used for TN "Reporting…" messages which contain a conversation transcript as useful context) correctly bypasses both detection and appending.

## Tests

Two new regression tests in `IncomingMailServiceTest`:
- `test_digest_reply_via_original_message_separator_appends_label` — covers the `-----Original Message-----` pattern
- `test_digest_reply_via_auto_address_header_appends_label` — covers the `On ... -auto@groups.ilovefreegle.org> wrote:` pattern

All 153 `IncomingMailServiceTest` tests pass.

## Files changed

- `iznik-batch/app/Services/Mail/Incoming/IncomingMailService.php` — detect digest patterns before strip, append label after strip
- `iznik-batch/tests/Unit/Services/Mail/Incoming/IncomingMailServiceTest.php` — two new regression tests