### PR TITLE
fix(modtools): show notice for Pending posts with no content issues (group moderation)

### DIFF
--- a/iznik-nuxt3/modtools/components/ModMessageWorry.vue
+++ b/iznik-nuxt3/modtools/components/ModMessageWorry.vue
@@ -1,5 +1,15 @@
 <template>
   <div v-if="message">
+    <!-- Group moderation: post is checked and clean but held by group settings -->
+    <NoticeMessage
+      v-if="pendingNoIssues"
+      variant="info"
+      class="mb-1"
+    >
+      This post has no content issues. It is in the pending queue because this
+      group's settings require all posts to be reviewed manually.
+    </NoticeMessage>
+
     <!-- Worry words flagged by the Go API (real-time, per-request check) -->
     <NoticeMessage
       v-for="(match, i) in worryMatches"
@@ -155,5 +165,19 @@ const contentcheckReasons = computed(() => {
     }
   }
   return []
+})
+
+/* True when the post is Pending, the content-check batch job has run, and no
+   issues were found — meaning it is held only by the group's moderation settings. */
+const pendingNoIssues = computed(() => {
+  if (!message.value?.groups) return false
+  return message.value.groups.some(
+    (mg) =>
+      mg.collection === 'Pending' &&
+      mg.contentcheck_checked_at &&
+      (!mg.contentcheck_reasons ||
+        !Array.isArray(mg.contentcheck_reasons) ||
+        mg.contentcheck_reasons.length === 0)
+  )
 })
 </script>

--- a/iznik-nuxt3/tests/unit/components/modtools/ModMessageWorry.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModMessageWorry.spec.js
@@ -397,4 +397,90 @@ describe('ModMessageWorry', () => {
       expect(wrapper.props('messageid')).toBe(123)
     })
   })
+
+  describe('group moderation notice', () => {
+    it('shows a notice when post is Pending, content-check ran, and no issues found', () => {
+      const message = {
+        id: 123,
+        worry: [],
+        groups: [
+          {
+            collection: 'Pending',
+            contentcheck_checked_at: '2026-01-01T12:00:00Z',
+            contentcheck_reasons: null,
+          },
+        ],
+      }
+      mockMessageStore.byId.mockReturnValue(message)
+      const wrapper = mount(ModMessageWorry, {
+        props: { messageid: 123 },
+        global: { stubs: STUBS },
+      })
+      expect(wrapper.findAll('.notice-message').length).toBe(1)
+      expect(wrapper.text()).toContain('group')
+    })
+
+    it('does NOT show the notice when contentcheck has not run yet', () => {
+      const message = {
+        id: 123,
+        worry: [],
+        groups: [
+          {
+            collection: 'Pending',
+            contentcheck_checked_at: null,
+            contentcheck_reasons: null,
+          },
+        ],
+      }
+      mockMessageStore.byId.mockReturnValue(message)
+      const wrapper = mount(ModMessageWorry, {
+        props: { messageid: 123 },
+        global: { stubs: STUBS },
+      })
+      expect(wrapper.findAll('.notice-message').length).toBe(0)
+    })
+
+    it('does NOT show the notice when contentcheck found issues', () => {
+      const message = {
+        id: 123,
+        worry: [],
+        groups: [
+          {
+            collection: 'Pending',
+            contentcheck_checked_at: '2026-01-01T12:00:00Z',
+            contentcheck_reasons: [
+              { check: 'Vague', category: null, detail: 'too generic' },
+            ],
+          },
+        ],
+      }
+      mockMessageStore.byId.mockReturnValue(message)
+      const wrapper = mount(ModMessageWorry, {
+        props: { messageid: 123 },
+        global: { stubs: STUBS },
+      })
+      expect(wrapper.text()).toContain('Vague post')
+      expect(wrapper.text()).not.toContain('group')
+    })
+
+    it('does NOT show the notice when collection is not Pending', () => {
+      const message = {
+        id: 123,
+        worry: [],
+        groups: [
+          {
+            collection: 'Approved',
+            contentcheck_checked_at: '2026-01-01T12:00:00Z',
+            contentcheck_reasons: null,
+          },
+        ],
+      }
+      mockMessageStore.byId.mockReturnValue(message)
+      const wrapper = mount(ModMessageWorry, {
+        props: { messageid: 123 },
+        global: { stubs: STUBS },
+      })
+      expect(wrapper.findAll('.notice-message').length).toBe(0)
+    })
+  })
 })


### PR DESCRIPTION
## Summary

- Posts on fully-moderated groups land in Pending with `contentcheck_checked_at` set but `contentcheck_reasons` null — the post has no content issues, it's just held by the group's moderation settings.
- Previously `ModMessageWorry.vue` showed nothing for these posts, leaving mods asking "should I leave or approve this?" (Discourse #9481 post 567, reporter: @Matty).
- Adds an informational notice: "This post has no content issues. It is in the pending queue because this group's settings require all posts to be reviewed manually."

## Root cause

`ContentCheckService::processUnprocessed` keeps a post in Pending when `$isModerated = true` (set when either `isGroupModerated()` or `isUserModerated()` is true). For fully-moderated groups, `isGroupModerated()` = true even for DEFAULT members. The batch job sets `contentcheck_checked_at` but leaves `contentcheck_reasons` null — no content flag, just group policy. The UI had no code to explain this case.

## Fix

`ModMessageWorry.vue` gets a new `pendingNoIssues` computed that fires when a message group has `collection === 'Pending'` AND `contentcheck_checked_at` is set AND `contentcheck_reasons` is null/empty. The template renders an `info`-variant `NoticeMessage` in that case.

## Test plan
- [x] New Vitest unit tests in `ModMessageWorry.spec.js` covering: shows notice when Pending + checked + no issues; no notice when not yet checked; no notice when issues exist; no notice when not Pending
- [x] All 45 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes [topic 9481, post 567](https://discourse.ilovefreegle.org/t/9481/567) — original report on Discourse.
