### PR TITLE
fix(modtools): show info notice for Pending posts with no content issues

### DIFF
--- a/iznik-nuxt3/modtools/components/ModMessage.vue
+++ b/iznik-nuxt3/modtools/components/ModMessage.vue
@@ -356,6 +356,9 @@
                   (g) =>
                     g.contentcheck_reasons &&
                     g.contentcheck_reasons.length
+                ) ||
+                message.groups?.some(
+                  (g) => g.collection === 'Pending' && g.contentcheck_checked_at
                 )
               "
               :messageid="message.id"

--- a/iznik-nuxt3/modtools/components/ModMessageWorry.vue
+++ b/iznik-nuxt3/modtools/components/ModMessageWorry.vue
@@ -36,6 +36,16 @@
       </p>
     </NoticeMessage>
 
+    <!-- Pending post with no content flags: explain it's held by manual-review group setting -->
+    <NoticeMessage
+      v-if="pendingNoIssues"
+      variant="info"
+      class="mb-1"
+    >
+      This post has no content issues. It is in the pending queue because this
+      community requires all posts to be approved manually.
+    </NoticeMessage>
+
     <!-- Content check failure reasons (stored, from batch processing) -->
     <NoticeMessage
       v-for="(reason, i) in contentcheckReasons"
@@ -155,5 +165,18 @@ const contentcheckReasons = computed(() => {
     }
   }
   return []
+})
+
+/* True when the batch content-check has run (contentcheck_checked_at set), the post
+   is still Pending, and neither real-time worry words nor batch reasons flagged it.
+   In this case the post is pending only because the group requires manual approval —
+   show an informational notice so mods know it is safe to approve. */
+const pendingNoIssues = computed(() => {
+  if (!message.value?.groups) return false
+  if (worryMatches.value.length > 0) return false
+  if (contentcheckReasons.value.length > 0) return false
+  return message.value.groups.some(
+    (mg) => mg.collection === 'Pending' && mg.contentcheck_checked_at
+  )
 })
 </script>

--- a/iznik-nuxt3/tests/unit/components/modtools/ModMessage.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModMessage.spec.js
@@ -840,6 +840,36 @@ describe('ModMessage', () => {
       await wrapper.vm.$nextTick()
       expect(wrapper.find('.mod-message-worry').exists()).toBe(true)
     })
+
+    it('shows worry component for Pending post with contentcheck_checked_at set (no worry, no reasons)', async () => {
+      const wrapper = mountComponent({ summary: false }, {
+        worry: null,
+        groups: [{
+          groupid: 789,
+          namedisplay: 'Test Group',
+          collection: 'Pending',
+          contentcheck_checked_at: '2026-06-10T12:00:00Z',
+          contentcheck_reasons: null,
+        }],
+      })
+      await wrapper.vm.$nextTick()
+      expect(wrapper.find('.mod-message-worry').exists()).toBe(true)
+    })
+
+    it('does not show worry component for Pending post when contentcheck_checked_at is null', async () => {
+      const wrapper = mountComponent({ summary: false }, {
+        worry: null,
+        groups: [{
+          groupid: 789,
+          namedisplay: 'Test Group',
+          collection: 'Pending',
+          contentcheck_checked_at: null,
+          contentcheck_reasons: null,
+        }],
+      })
+      await wrapper.vm.$nextTick()
+      expect(wrapper.find('.mod-message-worry').exists()).toBe(false)
+    })
   })
 
   describe('Availability badges', () => {

--- a/iznik-nuxt3/tests/unit/components/modtools/ModMessageWorry.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModMessageWorry.spec.js
@@ -33,6 +33,28 @@ function makeMessage(reasons = [], worry = []) {
   }
 }
 
+function makePendingMessage({ reasons = [], worry = [], checkedAt = null, collection = 'Pending' } = {}) {
+  return {
+    id: 456,
+    worry,
+    groups: [{
+      collection,
+      contentcheck_checked_at: checkedAt,
+      contentcheck_reasons: reasons,
+    }],
+  }
+}
+
+function mountMessage(message) {
+  mockMessageStore.byId.mockImplementation((id) =>
+    id === message.id ? message : null
+  )
+  return mount(ModMessageWorry, {
+    props: { messageid: message.id },
+    global: { stubs: STUBS },
+  })
+}
+
 function mountWithReasons(reasons) {
   const message = makeMessage(reasons)
   mockMessageStore.byId.mockImplementation((id) =>
@@ -395,6 +417,51 @@ describe('ModMessageWorry', () => {
     it('messageid prop is required and used', () => {
       const wrapper = mountWithReasons([])
       expect(wrapper.props('messageid')).toBe(123)
+    })
+  })
+
+  describe('pendingNoIssues — info notice for Pending posts with no flags', () => {
+    it('shows info notice for Pending + checked + no worry + no reasons', () => {
+      const message = makePendingMessage({ checkedAt: '2026-06-10T12:00:00Z' })
+      const wrapper = mountMessage(message)
+      expect(wrapper.find('.notice-message.info').exists()).toBe(true)
+      expect(wrapper.text()).toContain('no content issues')
+    })
+
+    it('info notice text mentions pending queue', () => {
+      const message = makePendingMessage({ checkedAt: '2026-06-10T12:00:00Z' })
+      const wrapper = mountMessage(message)
+      expect(wrapper.text()).toContain('pending queue')
+    })
+
+    it('does not show info notice when worry matches are present', () => {
+      const message = makePendingMessage({
+        checkedAt: '2026-06-10T12:00:00Z',
+        worry: [{ word: 'gun', worryword: { keyword: 'gun', type: 'Review' } }],
+      })
+      const wrapper = mountMessage(message)
+      expect(wrapper.find('.notice-message.info').exists()).toBe(false)
+    })
+
+    it('does not show info notice when contentcheck_reasons are present', () => {
+      const message = makePendingMessage({
+        checkedAt: '2026-06-10T12:00:00Z',
+        reasons: [{ check: 'Vague', category: null, detail: 'too generic' }],
+      })
+      const wrapper = mountMessage(message)
+      expect(wrapper.find('.notice-message.info').exists()).toBe(false)
+    })
+
+    it('does not show info notice when contentcheck_checked_at is null (not yet processed)', () => {
+      const message = makePendingMessage({ checkedAt: null })
+      const wrapper = mountMessage(message)
+      expect(wrapper.find('.notice-message.info').exists()).toBe(false)
+    })
+
+    it('does not show info notice for Approved collection', () => {
+      const message = makePendingMessage({ checkedAt: '2026-06-10T12:00:00Z', collection: 'Approved' })
+      const wrapper = mountMessage(message)
+      expect(wrapper.find('.notice-message.info').exists()).toBe(false)
     })
   })
 })


### PR DESCRIPTION
## Root Cause

`ModMessage.vue` only rendered `ModMessageWorry` when `message.worry?.length` or `contentcheck_reasons` were non-empty. For posts on fully-moderated groups, the batch content-check sets `contentcheck_checked_at` but leaves `contentcheck_reasons` null (no flags) — the post is Pending purely because the group requires manual approval. The component was never rendered for this case, so mods saw an empty worries area and no explanation, causing the "should I leave or approve this?" confusion.

Previous attempt PR #702 added a `pendingNoIssues` notice but its computed only checked `contentcheck_reasons`, ignoring `worryMatches` — a Pending post with worry-word flags but no batch reasons would have incorrectly shown "no content issues."

## Evidence

```
 FAIL  tests/unit/components/modtools/ModMessage.spec.js > ModMessage > ModMessageWorry > shows worry component for Pending post with contentcheck_checked_at set (no worry, no reasons)
 FAIL  tests/unit/components/modtools/ModMessageWorry.spec.js > ModMessageWorry > pendingNoIssues — info notice for Pending posts with no flags > shows info notice for Pending + checked + no worry + no reasons
 FAIL  tests/unit/components/modtools/ModMessageWorry.spec.js > ModMessageWorry > pendingNoIssues — info notice for Pending posts with no flags > info notice text mentions pending queue
 Tests  4 failed | 43 passed (47)
```
After fix: all 47 (ModMessageWorry) + 77 (ModMessage) tests pass.

## Fix

1. **`ModMessage.vue`**: expanded the `v-if` guard on `<ModMessageWorry>` to include a third condition — render also when any group has `collection === 'Pending'` AND `contentcheck_checked_at` set.
2. **`ModMessageWorry.vue`**: added `pendingNoIssues` computed that fires only when `contentcheck_checked_at` is set, collection is Pending, **and** both `worryMatches` and `contentcheckReasons` are empty — ensuring no false "no issues" notice appears when real flags exist.

## Other Call Sites

`ModMessageWorry` is rendered only from `ModMessage.vue` (single call site). No other files use this pattern.

## Test

| File | Command | Proves |
|---|---|---|
| `tests/unit/components/modtools/ModMessageWorry.spec.js` | `vitest run ModMessageWorry` | pendingNoIssues notice shown/suppressed correctly (47 tests pass) |
| `tests/unit/components/modtools/ModMessage.spec.js` | `vitest run ModMessage` | ModMessageWorry rendered for Pending+checked posts (77 tests pass) |

Fail-before: 4 tests fail on unmodified code. Pass-after: all pass with fix.

## Discourse

https://discourse.ilovefreegle.org/t/9481/567