### PR TITLE
fix(chat): chaseup-mods email links directly to /chats/ instead of /modtools/chats/

### DIFF
--- a/iznik-batch/app/Services/ChatChaseupModsService.php
+++ b/iznik-batch/app/Services/ChatChaseupModsService.php
@@ -107,7 +107,7 @@ class ChatChaseupModsService
             $textSummary = $messages->map(fn ($m) => $m->message)->implode("\r\n");
 
             $replyTo = "notify-{$room->room_id}-{$memberId}@{$userDomain}";
-            $chatUrl = "{$modSite}/modtools/chats/{$room->room_id}";
+            $chatUrl = "{$modSite}/chats/{$room->room_id}";
 
             // Get all group mods to notify
             $mods = DB::table('memberships')

--- a/iznik-batch/tests/Feature/Chat/ChaseupModsCommandTest.php
+++ b/iznik-batch/tests/Feature/Chat/ChaseupModsCommandTest.php
@@ -390,4 +390,34 @@ class ChaseupModsCommandTest extends TestCase
 
         Mail::assertNothingSent();
     }
+
+    public function test_chat_url_links_directly_to_chats_not_via_modtools_prefix(): void
+    {
+        Mail::fake();
+
+        $member = $this->createTestUser();
+        $mod = $this->createTestUser();
+        $group = $this->createTestGroup();
+
+        $this->createMembership($member, $group, ['role' => Membership::ROLE_MEMBER]);
+        $this->createMembership($mod, $group, [
+            'role' => Membership::ROLE_MODERATOR,
+            'collection' => Membership::COLLECTION_APPROVED,
+        ]);
+
+        $room = $this->createTestChatRoom($member, $mod, [
+            'chattype' => ChatRoom::TYPE_USER2MOD,
+            'groupid' => $group->id,
+        ]);
+
+        $this->createTestChatMessage($room, $member, ['date' => now()->subSeconds(600000)]);
+        $this->createTestChatMessage($room, $member, ['date' => now()->subHours(1)]);
+
+        $this->artisan('chats:chaseup-mods')->assertExitCode(0);
+
+        Mail::assertSent(\App\Mail\Chat\ChaseupModsMail::class, function ($mail) use ($room) {
+            return !str_contains($mail->chatUrl, '/modtools/')
+                && str_contains($mail->chatUrl, '/chats/' . $room->id);
+        });
+    }
 }


### PR DESCRIPTION
## Bug

**Topic 9518, post 329** — Clicking the "View and Reply" button in the volunteer chaseup-mods notification email shows a redirect page ("Redirecting you to…") instead of opening the chat directly. The volunteer has to wait for the redirect or navigate to ModTools separately.

## Root cause

`ChatChaseupModsService` was building the chat URL as `{modSite}/modtools/chats/{id}` — copied verbatim from the V1 PHP migration. V1 served ModTools under `/modtools/`, but V2 Nuxt modtools serves at root `/chats/`. The URL landed on the `/modtools/[...slug].vue` catch-all redirect page instead of `chats/[[id]].vue`.

## Fix

One-line change in `ChatChaseupModsService.php:110`:
```php
// Before
$chatUrl = "{$modSite}/modtools/chats/{$room->room_id}";
// After
$chatUrl = "{$modSite}/chats/{$room->room_id}";
```

`ChatNotification.php` (regular chat emails) already uses the correct `/chats/` path — this brings chaseup-mods into parity.

## Tests

New test `test_chat_url_links_directly_to_chats_not_via_modtools_prefix` in `ChaseupModsCommandTest.php`:
- Confirms URL does not contain `/modtools/` 
- Confirms URL does contain `/chats/{room_id}`
- Failed before the fix, passes after

All 14 `ChaseupModsCommandTest` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)