### PR TITLE
fix(settings): add bottom padding so mobile navbar doesn't cover last button

### DIFF
--- a/iznik-nuxt3/pages/settings/index.vue
+++ b/iznik-nuxt3/pages/settings/index.vue
@@ -124,10 +124,12 @@ const ProfileModal = defineAsyncComponent(() =>
 
 <style scoped lang="scss">
 @import 'assets/css/_color-vars.scss';
+@import 'assets/css/navbar.scss';
 
 .settings-page {
   min-height: 100vh;
   background: $color-gray--lighter;
+  padding-bottom: $page-bottom-padding;
 }
 
 .settings-content {


### PR DESCRIPTION
## Root Cause

The fixed bottom navigation bar (`NavbarMobile` `.navbar-bottom`, `position: fixed; bottom: 0; height: 67px`, shown on `d-xl-none` screens) was obscuring the last toggle/button in the Settings page. The `.settings-page` only had `padding: 1rem` (16px) via `.settings-content`, which is insufficient to scroll content past the 67px navbar.

## Evidence

Pure CSS layout issue — the `$page-bottom-padding` variable (`calc(67px + 24px + 10px) = 101px`) from `navbar.scss` already exists for exactly this purpose. Pages like `chitchat`, `volunteerings`, and `communityevents` apply it; `settings` was missing it. The reporter described the symptom: last button hidden behind the footer, briefly visible on scroll up/down.

## Fix

Added `@import 'assets/css/navbar.scss'` and `padding-bottom: $page-bottom-padding` to `.settings-page` in `pages/settings/index.vue`. This matches the pattern in `chitchat/[[id]].vue`, `volunteerings/[[groupid]].vue`, and `communityevents/[[groupid]].vue`.

## Other Call Sites

`chitchat/[[id]].vue`, `volunteerings/[[groupid]].vue`, `communityevents/[[groupid]].vue` — all already have the correct padding. No other settings components were affected.

## Test

Pure CSS fix — testless (no JavaScript logic changed). Existing settings unit tests (`settings_OtherSettingsSection.spec.js` etc.) are unaffected.

File: `iznik-nuxt3/pages/settings/index.vue`

## Discourse

https://discourse.ilovefreegle.org/t/9481/575