### PR TITLE
fix(modtools-notes): keyset pagination so all notes load + clickthrough to member (#9779)

### DIFF
--- a/iznik-nuxt3/modtools/components/ModCommentUser.vue
+++ b/iznik-nuxt3/modtools/components/ModCommentUser.vue
@@ -6,14 +6,17 @@
         <v-icon icon="envelope" /> <ExternalLink :href="'mailto:' + email">{{ email }}</ExternalLink>
       </div>
       <div>
-        <ProfileImage
-          :image="comment.user.profile?.turl || comment.user.profile?.paththumb"
-          :name="comment.user.displayname"
-          class="ms-1 mb-1 inline"
-          is-thumbnail
-          size="sm"
-        />
-        {{ comment.user.displayname }}
+        <!-- eslint-disable-next-line -->
+        <nuxt-link :to="'/members/approved/' + (comment.groupid || 0) + '/' + comment.userid">
+          <ProfileImage
+            :image="comment.user.profile?.turl || comment.user.profile?.paththumb"
+            :name="comment.user.displayname"
+            class="ms-1 mb-1 inline"
+            is-thumbnail
+            size="sm"
+          />
+          {{ comment.user.displayname }}
+        </nuxt-link>
       </div>
       <div v-if="comment.user.lastaccess">
         <v-icon icon="calendar-alt" /> Active

--- a/iznik-nuxt3/tests/unit/components/modtools/ModCommentUser.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModCommentUser.spec.js
@@ -13,6 +13,7 @@ const defaultComment = {
   id: 100,
   user1: 'Test comment',
   userid: 123,
+  groupid: 456,
   user: {
     id: 123,
     displayname: 'Test User',
@@ -70,6 +71,10 @@ describe('ModCommentUser', () => {
             template: '<div class="mod-comment" />',
             props: ['commentid', 'userid'],
           },
+          'nuxt-link': {
+            template: '<a :href="to"><slot /></a>',
+            props: ['to'],
+          },
         },
         mocks: {
           datetimeshort: (date) => `formatted: ${date}`,
@@ -121,6 +126,22 @@ describe('ModCommentUser', () => {
     it('renders ModComment component', () => {
       const wrapper = mountComponent()
       expect(wrapper.find('.mod-comment').exists()).toBe(true)
+    })
+
+    it('renders member name as a link to the member profile page', () => {
+      const wrapper = mountComponent()
+      // The nuxt-link stub renders as <a href="/members/approved/<groupid>/<userid>">
+      const link = wrapper.find(
+        'a[href="/members/approved/456/123"]'
+      )
+      expect(link.exists()).toBe(true)
+      expect(link.text()).toContain('Test User')
+    })
+
+    it('uses groupid 0 in link when comment has no groupid', () => {
+      const wrapper = mountComponent({}, { groupid: null })
+      const link = wrapper.find('a[href="/members/approved/0/123"]')
+      expect(link.exists()).toBe(true)
     })
   })
 

--- a/iznik-server-go/comment/comment.go
+++ b/iznik-server-go/comment/comment.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/freegle/iznik-server-go/auth"
 	"github.com/freegle/iznik-server-go/database"
-	"github.com/freegle/iznik-server-go/utils"
 	"github.com/freegle/iznik-server-go/user"
+	"github.com/freegle/iznik-server-go/utils"
 	"github.com/gofiber/fiber/v2"
 )
 
@@ -53,7 +53,7 @@ func Get(c *fiber.Ctx) error {
 
 	// List comments for moderated groups.
 	groupid, _ := strconv.ParseUint(c.Query("groupid", "0"), 10, 64)
-	contextReviewed := c.Query("context[reviewed]", "")
+	contextID, _ := strconv.ParseUint(c.Query("context", "0"), 10, 64)
 
 	// Get groups where user is moderator + admin/support check in parallel.
 	var wg sync.WaitGroup
@@ -78,7 +78,7 @@ func Get(c *fiber.Ctx) error {
 		})
 	}
 
-	// Build query.
+	// Build query using keyset pagination on id (never null, unique).
 	query := "SELECT * FROM users_comments WHERE "
 	var args []interface{}
 
@@ -87,9 +87,9 @@ func Get(c *fiber.Ctx) error {
 		args = append(args, groupid)
 	}
 
-	if contextReviewed != "" {
-		query += "users_comments.reviewed < ? AND "
-		args = append(args, contextReviewed)
+	if contextID > 0 {
+		query += "users_comments.id < ? AND "
+		args = append(args, contextID)
 	}
 
 	if isAdmin {
@@ -99,7 +99,7 @@ func Get(c *fiber.Ctx) error {
 		args = append(args, modGroupIDs, myid)
 	}
 
-	query += "1=1 ORDER BY reviewed DESC LIMIT 10"
+	query += "1=1 ORDER BY users_comments.id DESC LIMIT 10"
 
 	var rows []CommentItem
 	db.Raw(query, args...).Scan(&rows)
@@ -116,11 +116,9 @@ func Get(c *fiber.Ctx) error {
 		rows[i].Flagged = rows[i].Flag
 	}
 
-	var ctx interface{}
-	lastReviewed := rows[len(rows)-1].Reviewed
-	if lastReviewed != nil {
-		ctx = fiber.Map{"reviewed": lastReviewed.Format(time.RFC3339)}
-	}
+	// Context is the ID of the last row; always set when rows are non-empty
+	// so the frontend can request the next page. Returns nil only when zero rows.
+	ctx := fiber.Map{"id": rows[len(rows)-1].ID}
 
 	return c.JSON(fiber.Map{
 		"comments": rows,

--- a/iznik-server-go/test/comment_test.go
+++ b/iznik-server-go/test/comment_test.go
@@ -105,8 +105,10 @@ func TestCommentGetList(t *testing.T) {
 	assert.Nil(t, firstComment["user"])   // No nested user
 	assert.Nil(t, firstComment["byuser"]) // No nested byuser
 
-	// Context should be present for pagination
+	// Context should be present for pagination and contain an id field
 	assert.NotNil(t, result["context"])
+	ctx := result["context"].(map[string]interface{})
+	assert.NotNil(t, ctx["id"])
 
 	// Cleanup
 	db.Exec("DELETE FROM users_comments WHERE groupid = ?", groupID)
@@ -458,6 +460,78 @@ func TestCommentEditWithFlagOthers(t *testing.T) {
 	// Cleanup
 	db.Exec("DELETE FROM users_comments WHERE id = ?", commentID)
 	db.Exec("UPDATE memberships SET reviewreason = NULL, reviewrequestedat = NULL WHERE userid = ?", targetID)
+}
+
+// TestCommentGetListPagination verifies that keyset pagination on `id` works:
+// page 1 (no context) returns 10 rows and a non-null context; page 2
+// (context = page-1's last id) returns the next distinct rows, not a repeat.
+func TestCommentGetListPagination(t *testing.T) {
+	prefix := uniquePrefix("cmget_page")
+	modID := CreateTestUser(t, prefix+"_mod", "User")
+	targetID := CreateTestUser(t, prefix+"_target", "User")
+	groupID := CreateTestGroup(t, prefix)
+	CreateTestMembership(t, modID, groupID, "Moderator")
+	CreateTestMembership(t, targetID, groupID, "Member")
+	_, modToken := CreateTestSession(t, modID)
+
+	// Insert 15 comments — some with reviewed=NULL (common for unreviewed notes)
+	// to confirm the id-based cursor handles NULLs correctly.
+	db := database.DBConn
+	for i := 0; i < 15; i++ {
+		if i%3 == 0 {
+			db.Exec("INSERT INTO users_comments (userid, groupid, byuserid, user1, flag) VALUES (?, ?, ?, ?, 0)",
+				targetID, groupID, modID, fmt.Sprintf("Note %d", i))
+		} else {
+			db.Exec("INSERT INTO users_comments (userid, groupid, byuserid, user1, flag, reviewed) VALUES (?, ?, ?, ?, 0, NOW())",
+				targetID, groupID, modID, fmt.Sprintf("Note %d", i))
+		}
+	}
+
+	// --- Page 1: no context ---
+	req1 := httptest.NewRequest("GET", fmt.Sprintf("/api/comment?groupid=%d&jwt=%s", groupID, modToken), nil)
+	resp1, _ := getApp().Test(req1)
+	assert.Equal(t, 200, resp1.StatusCode)
+
+	var page1 map[string]interface{}
+	json2.Unmarshal(rsp(resp1), &page1)
+
+	page1Comments := page1["comments"].([]interface{})
+	assert.Equal(t, 10, len(page1Comments), "page 1 should return exactly 10 comments")
+
+	// Context must be non-null and contain an id
+	assert.NotNil(t, page1["context"], "page 1 context must be non-null")
+	page1Ctx := page1["context"].(map[string]interface{})
+	assert.NotNil(t, page1Ctx["id"], "page 1 context must have an id field")
+
+	// Collect page-1 ids
+	page1IDs := make(map[float64]bool)
+	for _, c := range page1Comments {
+		cm := c.(map[string]interface{})
+		page1IDs[cm["id"].(float64)] = true
+	}
+
+	// --- Page 2: use context id from page 1 ---
+	contextID := page1Ctx["id"].(float64)
+	req2 := httptest.NewRequest("GET", fmt.Sprintf("/api/comment?groupid=%d&context=%d&jwt=%s", groupID, int(contextID), modToken), nil)
+	resp2, _ := getApp().Test(req2)
+	assert.Equal(t, 200, resp2.StatusCode)
+
+	var page2 map[string]interface{}
+	json2.Unmarshal(rsp(resp2), &page2)
+
+	page2Comments := page2["comments"].([]interface{})
+	assert.GreaterOrEqual(t, len(page2Comments), 1, "page 2 should return remaining comments")
+	assert.LessOrEqual(t, len(page2Comments), 10, "page 2 should return at most 10 comments")
+
+	// Page 2 must not repeat any id from page 1
+	for _, c := range page2Comments {
+		cm := c.(map[string]interface{})
+		id := cm["id"].(float64)
+		assert.False(t, page1IDs[id], "page 2 must not repeat ids from page 1 (got id %v)", id)
+	}
+
+	// Cleanup
+	db.Exec("DELETE FROM users_comments WHERE groupid = ?", groupID)
 }
 
 func TestCommentDeleteByAdmin(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes two bugs reported in [Discourse #9779](https://discourse.ilovefreegle.org/t/9779/1):

- **Only 10 notes shown**: The comment list was paginating on the `reviewed` column which is nullable. When the 10th row had `reviewed IS NULL` (common — not every note gets reviewed), the server returned `context: null`. The frontend re-fetched with no context, got the same first page, detected no new rows, and called `$state.complete()` — stuck at 10 notes.

- **No clickthrough to member**: The member's display name in `ModCommentUser.vue` was plain text with no link.

## Root causes and fixes

**Bug 1 — Go `comment/comment.go`**: Switched from `ORDER BY reviewed DESC` keyset pagination to `ORDER BY id DESC` keyset pagination. The `id` column is always non-null and unique, so the context is always set when rows are non-empty. The frontend store already transforms `{id: N}` → bare `N` before serialising to `context=N` in the query string; the Go handler reads `c.Query("context", "")` and applies `id < ?`.

**Bug 2 — `ModCommentUser.vue`**: Wrapped the ProfileImage and display name in a `<nuxt-link :to="'/members/approved/' + (comment.groupid || 0) + '/' + comment.userid">`, matching the pattern used in `ModMemberRating.vue`.

## Tests

- **Go** (`comment_test.go`): New `TestCommentGetListPagination` creates 15 comments (some with `reviewed=NULL`), asserts page 1 returns exactly 10 with a non-null `context.id`, and page 2 returns distinct rows not seen in page 1. Updated `TestCommentGetList` to also assert `context.id` is present.
- **Vitest** (`ModCommentUser.spec.js`): Two new assertions — member name renders as a `<nuxt-link>` to `/members/approved/<groupid>/<userid>`, and falls back to `groupid=0` when comment has no groupid.

## Frontend store

No changes required. The store (`modtools/stores/comment.js`) already converts `{id: N}` context objects to bare `N` before the API call, and the `BaseAPI` `$getv2` serialises it as `context=N` via URLSearchParams — which is exactly what the updated Go handler reads.

Discourse: https://discourse.ilovefreegle.org/t/9779/1

🤖 Generated with [Claude Code](https://claude.com/claude-code)