### PR TITLE
fix(monitor-fsm): gate bulletin 'fixed' label on confirmed deployment, not just merge

### DIFF
--- a/monitor-fsm/src/__tests__/discourse-status.bulletins.test.ts
+++ b/monitor-fsm/src/__tests__/discourse-status.bulletins.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Tests that the Discourse status post and iteration summary accurately label
+ * fix outcomes rather than calling them "done" before they are deployed.
+ *
+ * Bug: topic 9778/2 — bulletins overstate outcomes by labelling:
+ *   - attempted-but-failed fixes (PR opened, not yet merged) as "Discourse bugs fixed"
+ *   - not-yet-live fixes (PR merged, not yet deployed) as "Fixed in the last 7 days"
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import Database from 'better-sqlite3'
+import { SCHEMA_SQL, MIGRATION_V2_SQL, MIGRATION_V3_SQL, MIGRATION_V4_SQL, MIGRATION_V5_SQL } from '../db/schema'
+import { upsertDiscourseBug, upsertPr } from '../db/index'
+import { renderStatusPostBody } from '../db/discourse-status'
+
+function makeTestDb(): Database.Database {
+  const db = new Database(':memory:')
+  db.pragma('foreign_keys = ON')
+  db.exec(SCHEMA_SQL)
+  db.exec(MIGRATION_V2_SQL)
+  for (const stmt of MIGRATION_V3_SQL.trim().split('\n').filter(s => s.trim())) {
+    try { db.exec(stmt) } catch { /* column exists */ }
+  }
+  try { db.exec(MIGRATION_V4_SQL) } catch { /* already ok */ }
+  try { db.exec(MIGRATION_V5_SQL) } catch { /* already ok */ }
+  return db
+}
+
+describe('Discourse status post — bulletin accuracy', () => {
+  let db: Database.Database
+
+  beforeEach(() => {
+    db = makeTestDb()
+  })
+
+  describe('not-yet-deployed merged fix should not appear as "fixed"', () => {
+    beforeEach(() => {
+      // Bug has a PR that is MERGED but not yet deployed (deploy_state = NULL)
+      upsertPr(db, { number: 501, title: 'Fix widget overflow', state: 'MERGED', deployState: undefined })
+      upsertDiscourseBug(db, {
+        topic: 9700, post: 3, reporter: 'TestReporter',
+        excerpt: 'Widget overflow on mobile',
+        state: 'fix-queued', prNumber: 501,
+      })
+    })
+
+    it('MERGED-but-undeployed bug stays in "Bugs being fixed", not "Fixed in the last 7 days"', () => {
+      const { raw } = renderStatusPostBody(db)
+      // The reporter should still be listed (in "Bugs being fixed")
+      expect(raw).toContain('Bugs being fixed')
+      expect(raw).toContain('TestReporter')
+      // But NOT in the "Fixed in the last 7 days" section
+      const fixedSectionIdx = raw.indexOf('Fixed in the last 7 days')
+      const reporterIdx = raw.indexOf('TestReporter')
+      // Either the section is absent, or the reporter appears BEFORE it
+      // (i.e. in "Bugs being fixed" not in "Fixed")
+      if (fixedSectionIdx === -1) {
+        // Section absent entirely — acceptable, reporter must still be shown
+        expect(raw).toContain('TestReporter')
+      } else {
+        expect(reporterIdx).toBeLessThan(fixedSectionIdx)
+      }
+    })
+  })
+
+  describe('deployed fix correctly appears as "fixed"', () => {
+    it('CORRECT: deployed fix moves to "Fixed in the last 7 days"', () => {
+      upsertPr(db, { number: 502, title: 'Fix search ranking', state: 'MERGED', deployState: 'deployed' })
+      upsertDiscourseBug(db, {
+        topic: 9701, post: 5, reporter: 'AnotherReporter',
+        excerpt: 'Search returns wrong results',
+        state: 'fix-queued', prNumber: 502,
+      })
+
+      const { raw } = renderStatusPostBody(db)
+      // After the fix, a DEPLOYED merge should move the bug to "Fixed"
+      expect(raw).toContain('Fixed in the last 7 days')
+      expect(raw).toMatch(/Fixed in the last 7 days[\s\S]*AnotherReporter/)
+    })
+  })
+})

--- a/monitor-fsm/src/actions/index.ts
+++ b/monitor-fsm/src/actions/index.ts
@@ -705,7 +705,7 @@ print(json.dumps({'confirmations': results, 'edwardUpdates': edward_updates}))
 
   {
     name: 'sync_pr_states',
-    description: 'Sync PR states from GitHub for all PRs referenced in discourse_bug.pr_number. Updates the pr table, moves fix-queued bugs to fixed on merge, and reopens bugs whose PRs were closed (rejected) by the reviewer — tracking rejection count so escalation logic can fire. Returns {synced, updated, reopened: [{topic, post, prNumber, rejections}]}.',
+    description: 'Sync PR states from GitHub for all PRs referenced in discourse_bug.pr_number. Updates the pr table (sets deploy_state=pending_deploy on MERGE), and reopens bugs whose PRs were closed (rejected) by the reviewer — tracking rejection count so escalation logic can fire. Bug → fixed promotion happens in reconcileBugStates (discourse-status.ts) only once deploy_state=deployed is confirmed. Returns {synced, updated, reopened: [{topic, post, prNumber, rejections}]}.',
     handler: async () => {
       const db = getDb()
       const bugPRs = db.prepare(
@@ -2370,9 +2370,9 @@ ANALYSIS_COMPLETE is for tasks that involve NO code changes (e.g. Discourse tria
       const fixed = bugsFixed.filter(b => b.outcome === 'fixed')
       const deferred = bugsFixed.filter(b => b.outcome === 'deferred')
       if (fixed.length > 0) {
-        lines.push('## Discourse bugs fixed', '')
+        lines.push('## Discourse bugs: fix PRs opened', '')
         for (const b of fixed) {
-          lines.push(`- ${b.topic}.${b.post} @${b.user ?? 'reporter'}${b.prNumber ? ` → PR #${b.prNumber}` : ''}`)
+          lines.push(`- ${b.topic}.${b.post} @${b.user ?? 'reporter'}${b.prNumber ? ` → PR #${b.prNumber} (awaiting merge + deploy)` : ''}`)
         }
         lines.push('')
       }

--- a/monitor-fsm/src/db/discourse-status.ts
+++ b/monitor-fsm/src/db/discourse-status.ts
@@ -26,21 +26,21 @@ export interface StatusRenderResult {
 }
 
 // Reconcile bug state against PR state before rendering. A bug sits in
-// 'fix-queued' from the moment a draft reply is queued (PR opened). It should
-// only move to 'fixed' once the PR is MERGED and live. Nothing in the rest of
-// the pipeline was calling markDiscourseBugFixed, so bugs accumulated forever
-// in "working on" with the misleading label "fixed". Do the transition here,
-// on every render, based on the pr table.
+// 'fix-queued' from the moment a draft reply is queued (PR opened). It moves
+// to 'fixed' only once the PR is both MERGED and confirmed deployed — so that
+// the "Fixed in the last 7 days" section only lists fixes that are actually
+// live, not fixes that are merely merged but still pending deployment.
+// queue_deployed_reply_drafts (called on every LOAD_STATE) sets deploy_state
+// to 'deployed' once the build commit is confirmed live.
 function reconcileBugStates(db: DB): void {
   const rows = db.prepare(`
-    SELECT b.topic, b.post, b.pr_number, p.state AS pr_state, p.deploy_state
+    SELECT b.topic, b.post, b.pr_number
     FROM discourse_bug b
     JOIN pr p ON p.number = b.pr_number
     WHERE b.state = 'fix-queued'
       AND b.pr_number IS NOT NULL
       AND p.state = 'MERGED'
-      -- deploy_state is rarely populated; Freegle auto-deploys on merge to
-      -- production, so MERGED is sufficient to consider a fix live.
+      AND p.deploy_state IN ('deployed', 'live')
   `).all() as Array<{ topic: number; post: number; pr_number: number }>
   for (const r of rows) {
     markDiscourseBugFixed(db, r.topic, r.post, r.pr_number)


### PR DESCRIPTION
## Root Cause

`reconcileBugStates` in `discourse-status.ts` promoted a bug from `fix-queued` to `fixed` as soon as its PR reached `MERGED` state — without checking whether the fix was actually deployed. This caused the Discourse status post to list bugs under **"Fixed in the last 7 days"** with a contradictory ":hammer_and_wrench: Pending" status while the fix was still deploying.

Separately, `compose_and_write_summary` labelled bugs as **"Discourse bugs fixed"** in the iteration summary at the point a fix PR was opened (and passed adversarial review) — well before any merge or deployment.

## Evidence

```
 FAIL  discourse-status.bulletins.test.ts > ... > MERGED-but-undeployed bug stays in "Bugs being fixed", not "Fixed in the last 7 days"
AssertionError: expected '...' to contain 'Bugs being fixed'

Received:
## Fixed in the last 7 days
| ... | [@TestReporter](...) | Widget overflow on mobile | [#501](...) | :hammer_and_wrench: Pending |
```

## Fix

1. **`reconcileBugStates`** (`discourse-status.ts`): added `AND p.deploy_state IN ('deployed', 'live')` to the SQL query. Bugs with MERGED PRs now stay in `fix-queued` (shown under "Bugs being fixed" with `:hourglass: Deploying`) until `queue_deployed_reply_drafts` confirms the build commit is live and sets `deploy_state='deployed'`.

2. **`compose_and_write_summary`** (`actions/index.ts`): renamed the section from `## Discourse bugs fixed` to `## Discourse bugs: fix PRs opened` and appended `(awaiting merge + deploy)` to each PR line, since at that point only a PR has been opened — not merged or deployed.

3. **`sync_pr_states` description**: corrected the stale "moves fix-queued bugs to fixed on merge" claim in the action description — that transition now happens only in `reconcileBugStates` after deployment is confirmed.

## Other Call Sites

- `check_bug_feedback` (`actions/index.ts:560`): sets `state='fixed'` when the reporter confirms the fix — intentional, unaffected.
- `persist_classifications` (`actions/index.ts:2482`): sets `state='fixed'` when `checkGitAlreadyFixed` finds the bug fixed on master — intentional, unaffected.

## Test

**File:** `monitor-fsm/src/__tests__/discourse-status.bulletins.test.ts`

**Command:** `cd monitor-fsm && npm test -- discourse-status.bulletins`

**Proves:**
- A `fix-queued` bug with a MERGED but non-deployed PR stays in "Bugs being fixed", NOT "Fixed in the last 7 days" (fail-before, pass-after)
- A `fix-queued` bug with a MERGED + `deploy_state='deployed'` PR correctly moves to "Fixed in the last 7 days" (always passes)

## Discourse

https://discourse.ilovefreegle.org/t/9778/2