### PR TITLE
fix(modtools): include Spam messages in Pending view filter — badge=1/list=0 (#9723)

### DIFF
--- a/iznik-nuxt3/modtools/composables/useModMessages.js
+++ b/iznik-nuxt3/modtools/composables/useModMessages.js
@@ -82,7 +82,7 @@ const messages = computed(() => {
   if (collection.value && REAL_COLLECTIONS.includes(collection.value)) {
     const allowed =
       collection.value === 'Pending'
-        ? ['Pending', 'PendingOther']
+        ? ['Pending', 'PendingOther', 'Spam']
         : [collection.value]
     const contextGid = groupid.value ? parseInt(groupid.value) : null
     messages = messages.filter((m) => {

--- a/iznik-nuxt3/tests/unit/composables/useModMessages.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useModMessages.spec.js
@@ -546,4 +546,28 @@ describe('useModMessages collection filter (approve-race defence)', () => {
 
     expect(messages.value.map((m) => m.id)).toEqual([1])
   })
+
+  it('includes Spam-collection messages when listing Pending (Discourse #9723)', async () => {
+    // Spam messages are shown in the Pending review list (PR #638 / server
+    // query includes Spam collection). But the client-side collection filter
+    // only allowed ['Pending', 'PendingOther'], so spam messages were silently
+    // stripped before rendering — causing badge=1 but list=0.
+    const msgSpam = {
+      id: 1,
+      arrival: '2026-01-05',
+      groups: [{ groupid: 10, arrival: '2026-01-05', collection: 'Spam' }],
+    }
+
+    mockAll.value = [msgSpam]
+    mockFetchMessagesMT.mockResolvedValue([1])
+
+    const { setupModMessages } = await import(
+      '~/modtools/composables/useModMessages'
+    )
+    const { getMessages, collection, messages } = setupModMessages(true)
+    collection.value = 'Pending'
+    await getMessages()
+
+    expect(messages.value.map((m) => m.id)).toContain(1)
+  })
 })


### PR DESCRIPTION
## Summary

- **Bug**: Red badge showed 1 on Pending in ModTools nav, but the Pending list was empty for all groups (Discourse #9723 post 9, screenshot confirms mod is on "All my communities" with badge=1 and zero items)
- **Root cause**: Client-side defensive collection filter in `useModMessages.js` only allowed `['Pending', 'PendingOther']` when `collection='Pending'`. PR #638 added Spam messages to the server-side Pending query; PR #697 added `'spam'` to the nav badge count — but the client-side filter was never updated to allow `'Spam'`, so every spam message was silently stripped before rendering.
- **Fix**: Add `'Spam'` to the allowed list for the Pending view. The approve-race defense (preventing approved messages reappearing after a concurrent refetch) is unchanged.

## Test plan

- [x] Added failing test `includes Spam-collection messages when listing Pending (Discourse #9723)` to `useModMessages.spec.js` — confirms `AssertionError: expected [] to include 1` before fix
- [x] All 21 vitest unit tests pass after fix
- [x] Existing collection-filter tests (including approve-race defense and PendingOther inclusion) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)