### PR TITLE
fix(monitor-fsm): label opened fix PRs as 'PRs opened' not 'fixed' in iteration summary

### DIFF
--- a/monitor-fsm/src/__tests__/actions.compose_summary.test.ts
+++ b/monitor-fsm/src/__tests__/actions.compose_summary.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { readFileSync, existsSync } from 'node:fs'
+import { resetDbForTests, getDb } from '../db/index.js'
+
+// compose_and_write_summary calls writeFile to /tmp/freegle-monitor/summary.md.
+// Mock the 'node:fs/promises' module so no real file is written.
+vi.mock('node:fs/promises', () => ({
+  writeFile: vi.fn(() => Promise.resolve()),
+  mkdir: vi.fn(() => Promise.resolve()),
+}))
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let composeSummaryHandler: (params: Record<string, unknown>, context: Record<string, unknown>) => Promise<any>
+
+beforeEach(async () => {
+  resetDbForTests()
+  getDb(':memory:')
+  // Re-import so the handler picks up the mocked writeFile
+  vi.resetModules()
+  const { actions } = await import('../actions/index.js')
+  const action = actions.find((a: any) => a.name === 'compose_and_write_summary')
+  composeSummaryHandler = action!.handler
+})
+
+afterEach(() => {
+  resetDbForTests()
+  vi.clearAllMocks()
+})
+
+// Helper: call the handler and capture what was written via the mock
+async function callHandler(context: Record<string, unknown>): Promise<string> {
+  const { writeFile } = await import('node:fs/promises')
+  let capturedContent = ''
+  ;(writeFile as ReturnType<typeof vi.fn>).mockImplementation((_path: unknown, content: unknown) => {
+    capturedContent = content as string
+    return Promise.resolve()
+  })
+  await composeSummaryHandler({}, context)
+  return capturedContent
+}
+
+describe('compose_and_write_summary — section heading accuracy (bug 9778/2)', () => {
+  const bugWithPR = {
+    topic: 9500,
+    post: 3,
+    user: 'reporter_a',
+    summary: 'Widget broken',
+    prNumber: 501,
+    outcome: 'fixed',     // set by VERIFY_FIX when PR opened + adversarial review passed
+  }
+
+  it('STEP 3b — section heading must NOT say "Discourse bugs fixed" for a merely-opened PR', async () => {
+    // "Discourse bugs fixed" is wrong: at this point the PR is just opened and
+    // passed adversarial review. It has not been merged or deployed.
+    const content = await callHandler({ bugsFixed: [bugWithPR] })
+    expect(content).not.toContain('## Discourse bugs fixed')
+  })
+
+  it('STEP 3b — section heading MUST accurately describe open PRs awaiting merge+deploy', async () => {
+    const content = await callHandler({ bugsFixed: [bugWithPR] })
+    // After the fix, the heading should reflect that these are opened PRs, not deployed fixes
+    expect(content).toContain('fix PRs opened')
+  })
+
+  it('STEP 3b — each PR line must surface the "awaiting merge + deploy" qualification', async () => {
+    const content = await callHandler({ bugsFixed: [bugWithPR] })
+    // Moderators reading the bulletin should see that the fix is not live yet
+    expect(content).toContain('awaiting')
+  })
+
+  it('deferred bugs still render under their own section regardless of fix', async () => {
+    const deferredBug = { topic: 9501, post: 1, user: 'reporter_b', outcome: 'deferred', reason: 'V1-only' }
+    const content = await callHandler({ bugsFixed: [bugWithPR, deferredBug] })
+    expect(content).toContain('## Discourse bugs deferred')
+    expect(content).toContain('reporter_b')
+  })
+
+  it('PR number link still appears in the opened-PR section', async () => {
+    const content = await callHandler({ bugsFixed: [bugWithPR] })
+    expect(content).toContain('PR #501')
+  })
+})

--- a/monitor-fsm/src/actions/index.ts
+++ b/monitor-fsm/src/actions/index.ts
@@ -2370,9 +2370,10 @@ ANALYSIS_COMPLETE is for tasks that involve NO code changes (e.g. Discourse tria
       const fixed = bugsFixed.filter(b => b.outcome === 'fixed')
       const deferred = bugsFixed.filter(b => b.outcome === 'deferred')
       if (fixed.length > 0) {
-        lines.push('## Discourse bugs fixed', '')
+        lines.push('## Discourse bugs: fix PRs opened', '')
+        lines.push('_These PRs have passed automated review but are not yet merged or deployed (awaiting merge + deploy)._', '')
         for (const b of fixed) {
-          lines.push(`- ${b.topic}.${b.post} @${b.user ?? 'reporter'}${b.prNumber ? ` → PR #${b.prNumber}` : ''}`)
+          lines.push(`- ${b.topic}.${b.post} @${b.user ?? 'reporter'}${b.prNumber ? ` → PR #${b.prNumber} (awaiting merge + deploy)` : ''}`)
         }
         lines.push('')
       }


### PR DESCRIPTION
## Root Cause

`compose_and_write_summary` in `monitor-fsm/src/actions/index.ts` rendered bugs under `## Discourse bugs fixed` when their `outcome` was `'fixed'` — but `outcome: 'fixed'` is set by `VERIFY_FIX` at the moment a PR is opened **and passes adversarial review**, well before the PR is merged or deployed. The section heading overstated the outcome: the fix was merely proposed, not live.

## Evidence

```
 FAIL  src/__tests__/actions.compose_summary.test.ts > compose_and_write_summary — section heading accuracy (bug 9778/2) > STEP 3b — section heading must NOT say "Discourse bugs fixed" for a merely-opened PR
AssertionError: expected '# Freegle Monitor — iteration summary…' to not contain string '## Discourse bugs fixed'

 FAIL  … > STEP 3b — section heading MUST accurately describe open PRs awaiting merge+deploy
AssertionError: expected '…## Discourse bugs fixed…' to contain 'fix PRs opened'

 FAIL  … > STEP 3b — each PR line must surface the "awaiting merge + deploy" qualification
AssertionError: expected '…' to contain 'awaiting'
```

## Fix

**`monitor-fsm/src/actions/index.ts`** — in the `compose_and_write_summary` handler:
- Renamed `## Discourse bugs fixed` → `## Discourse bugs: fix PRs opened`
- Added an explanatory note: `_These PRs have passed automated review but are not yet merged or deployed (awaiting merge + deploy)._`
- Appended `(awaiting merge + deploy)` to each PR line

This accurately reflects that at iteration-summary time, only a PR has been opened; merge and deployment come later.

## Other Call Sites

`outcome === 'fixed'` is consumed only in `compose_and_write_summary` (actions/index.ts:2189). No other rendering path uses this label. `compose_and_write_summary.description` in workflow.json references the file but contains no rendered text — no change needed.

## Test

**File:** `monitor-fsm/src/__tests__/actions.compose_summary.test.ts`

**Command:** `cd monitor-fsm && npm test -- actions.compose_summary`

**Proves:**
- `## Discourse bugs fixed` no longer appears (fail-before, pass-after)
- `fix PRs opened` heading appears (fail-before, pass-after)
- Each PR line contains `awaiting` qualification (fail-before, pass-after)
- Deferred section still renders correctly (always passes)
- PR number link still appears (always passes)

## Discourse
https://discourse.ilovefreegle.org/t/9778/2