### PR TITLE
fix(modtools): show action buttons for Spam-collection messages in Pending view (#9518)

### DIFF
--- a/iznik-nuxt3/modtools/components/ModMessageButtons.vue
+++ b/iznik-nuxt3/modtools/components/ModMessageButtons.vue
@@ -135,6 +135,33 @@
         @handle="outcome($event, 'Withdrawn')"
       />
     </div>
+    <div v-else-if="spam" class="d-inline">
+      <ModMessageButton
+        v-if="!cantpost"
+        :messageid="message.id"
+        :groupid="groupid"
+        variant="primary"
+        icon="check"
+        approve
+        label="Approve"
+      />
+      <ModMessageButton
+        :messageid="message.id"
+        :groupid="groupid"
+        variant="warning"
+        icon="times"
+        reject
+        label="Reject"
+      />
+      <ModMessageButton
+        :messageid="message.id"
+        :groupid="groupid"
+        variant="danger"
+        icon="ban"
+        spam
+        label="Delete as Spam"
+      />
+    </div>
     <div v-if="!editreview" class="d-lg-inline">
       <ModMessageButton
         v-for="stdmsg in filtered"
@@ -252,6 +279,10 @@ const approved = computed(() => {
   return hasCollection('Approved')
 })
 
+const spam = computed(() => {
+  return hasCollection('Spam')
+})
+
 const validActions = computed(() => {
   // The standard messages we show depend on the valid ones for this type of message.
   if (pending.value) {
@@ -262,6 +293,12 @@ const validActions = computed(() => {
     return ret
   } else if (approved.value) {
     return ['Leave Approved Message', 'Delete Approved Message', 'Edit']
+  } else if (spam.value) {
+    const ret = ['Reject', 'Leave', 'Delete', 'Edit']
+    if (!props.cantpost) {
+      ret.push('Approve')
+    }
+    return ret
   }
 
   return []

--- a/iznik-nuxt3/tests/unit/components/modtools/ModMessageButtons.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModMessageButtons.spec.js
@@ -380,6 +380,56 @@ describe('ModMessageButtons', () => {
     })
   })
 
+  describe('spam message buttons', () => {
+    it('shows approve button for spam messages appearing in pending view', () => {
+      const wrapper = mountComponent(
+        {},
+        { groups: [{ groupid: 456, collection: 'Spam' }] }
+      )
+      expect(wrapper.find('.mod-message-button.approve').exists()).toBe(true)
+    })
+
+    it('shows reject button for spam messages appearing in pending view', () => {
+      const wrapper = mountComponent(
+        {},
+        { groups: [{ groupid: 456, collection: 'Spam' }] }
+      )
+      expect(wrapper.find('.mod-message-button.reject').exists()).toBe(true)
+    })
+
+    it('shows Delete as Spam button for spam messages appearing in pending view', () => {
+      const wrapper = mountComponent(
+        {},
+        { groups: [{ groupid: 456, collection: 'Spam' }] }
+      )
+      expect(wrapper.find('.mod-message-button.spam').exists()).toBe(true)
+    })
+
+    it('hides approve button for spam messages when cantpost is true', () => {
+      const wrapper = mountComponent(
+        { cantpost: true },
+        { groups: [{ groupid: 456, collection: 'Spam' }] }
+      )
+      expect(wrapper.find('.mod-message-button.approve').exists()).toBe(false)
+    })
+
+    it('spam computed is true when message has Spam collection', () => {
+      const wrapper = mountComponent(
+        {},
+        { groups: [{ groupid: 456, collection: 'Spam' }] }
+      )
+      expect(wrapper.vm.spam).toBe(true)
+    })
+
+    it('spam computed is false when message has Pending collection', () => {
+      const wrapper = mountComponent(
+        {},
+        { groups: [{ groupid: 456, collection: 'Pending' }] }
+      )
+      expect(wrapper.vm.spam).toBe(false)
+    })
+  })
+
   describe('hasCollection helper', () => {
     it('returns true when message has Pending collection', () => {
       const wrapper = mountComponent(


### PR DESCRIPTION
## Root Cause

PR #638 (2026-06-04) made the server-side Pending listing return both `Pending` AND `Spam`-collection messages. PR #709 (2026-06-11 03:44) added `'Spam'` to the client-side allowed-collection filter so those messages are now visible. However `ModMessageButtons.vue` only had `v-if`/`v-else-if` branches for `pending` (`hasCollection('Pending')`) and `approved` (`hasCollection('Approved')`). A `Spam`-collection message shown in the Pending view hit none of those conditions, so **no action buttons were rendered**.

## Evidence

Discourse #9518 post 330 — Derek: *"A couple of 'historic' posts have arrived in Pending overnight but I have no way to process them as there are no buttons. First one is 20 days old, second one is 5 years old."*

Filed 2026-06-11 06:13 — approximately 2.5 hours after PR #709 merged at 03:44, confirming the Spam-in-Pending visibility was the trigger.

## Fix

**`modtools/components/ModMessageButtons.vue`**
- Added `const spam = computed(() => hasCollection('Spam'))`
- Added `v-else-if="spam"` section with **Approve** (false positive), **Reject**, and **Delete as Spam** buttons — the standard triage set for a message auto-classified as spam
- Extended `validActions` to include the spam case so configured standard messages (e.g. rejection templates) are also available

## Other Call Sites

`ModMessage.vue` passes the message through to `ModMessageButtons`; no additional changes required there.

## Test

New Vitest tests in `ModMessageButtons.spec.js`:
- `spam message buttons > shows approve button for spam messages appearing in pending view` ✓
- `spam message buttons > shows reject button for spam messages appearing in pending view` ✓
- `spam message buttons > shows Delete as Spam button for spam messages appearing in pending view` ✓
- `spam message buttons > hides approve button for spam messages when cantpost is true` ✓
- `spam message buttons > spam computed is true when message has Spam collection` ✓
- `spam message buttons > spam computed is false when message has Pending collection` ✓

Full suite: 49 tests passed (49).

## Discourse

Fixes Discourse #9518 / post 330

🤖 Generated with [Claude Code](https://claude.com/claude-code)