### PR TITLE
fix(donations): restore IPN user-matching, add backfill, fix thank-prep digest

### DIFF
--- a/.env.background.example
+++ b/.env.background.example
@@ -95,3 +95,17 @@ WHATJOBS_FEED2=https://clickcastfeeds.s3.amazonaws.com/<account-id>/feed.xml.gz
 # all eligible users". Remove this line once the daily-digest cutover is
 # complete and you want to send to everyone.
 # FREEGLE_DIGEST_DAILY_ALLOWLIST=edward@ehibbert.org.uk
+
+# =============================================================================
+# Donation email recipients
+# =============================================================================
+# Two distinct donation emails go to two distinct addresses:
+#   - mail:donations:summary    (hourly status table of donations that landed)
+#                               -> FREEGLE_FUNDRAISING_ADDR
+#   - mail:donations:thank-prep (daily card-per-donation digest for composing
+#                               thank-you replies) -> FREEGLE_THANKS_ADDR
+# IMPORTANT: FREEGLE_THANKS_ADDR falls back to FREEGLE_FUNDRAISING_ADDR when
+# unset (see config/freegle.php). So if you only set the fundraising address,
+# the daily thanks digest ALSO lands there. Set both to route them separately.
+FREEGLE_FUNDRAISING_ADDR=log@ehibbert.org.uk
+FREEGLE_THANKS_ADDR=info@ilovefreegle.org

--- a/iznik-batch/.env.example
+++ b/iznik-batch/.env.example
@@ -59,6 +59,14 @@ MAIL_PASSWORD=null
 MAIL_FROM_ADDRESS="hello@example.com"
 MAIL_FROM_NAME="${APP_NAME}"
 
+# Donation email recipients (see config/freegle.php).
+# mail:donations:summary    (hourly status table) -> FREEGLE_FUNDRAISING_ADDR
+# mail:donations:thank-prep (daily thanks digest)  -> FREEGLE_THANKS_ADDR
+# FREEGLE_THANKS_ADDR falls back to FREEGLE_FUNDRAISING_ADDR when unset, so set
+# both to route the two emails to different addresses.
+FREEGLE_FUNDRAISING_ADDR=info@ilovefreegle.org
+FREEGLE_THANKS_ADDR=info@ilovefreegle.org
+
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 AWS_DEFAULT_REGION=us-east-1

--- a/iznik-batch/app/Console/Commands/Donation/CorrectDonationUserIdsCommand.php
+++ b/iznik-batch/app/Console/Commands/Donation/CorrectDonationUserIdsCommand.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Console\Commands\Donation;
+
+use App\Services\DonationUserIdBackfillService;
+use App\Traits\LogsBatchJob;
+use Illuminate\Console\Command;
+
+/**
+ * One-shot backfill of users_donations.userid for the historical backlog of
+ * unmatched donations. Deliberately NOT scheduled — the PayPal/Stripe IPN
+ * handlers now match at receipt time (email/canon/prior donation); this just
+ * cleans up donations that landed before that logic existed.
+ */
+class CorrectDonationUserIdsCommand extends Command
+{
+    use LogsBatchJob;
+
+    protected $signature = 'donations:correct-userids
+                            {--dry-run : Report what would change without writing}
+                            {--limit= : Only scan this many unmatched donations}';
+
+    protected $description = 'Backfill unmatched donations to accounts by email/canon or a prior donation from the same Payer (one-shot; not scheduled).';
+
+    public function handle(DonationUserIdBackfillService $service): int
+    {
+        $dryRun = (bool) $this->option('dry-run');
+        $limit  = $this->option('limit') !== null ? (int) $this->option('limit') : null;
+
+        if ($dryRun) {
+            $this->info('DRY RUN — no donations will be updated.');
+        }
+
+        return $this->runWithLogging(function () use ($service, $dryRun, $limit) {
+            $r = $service->backfill($dryRun, $limit);
+
+            $verb = $dryRun ? 'Would link' : 'Linked';
+            $this->info(sprintf(
+                '%s %d of %d unmatched donation(s): %d by email/canon, %d by prior donation.',
+                $verb,
+                $r['updated'],
+                $r['scanned'],
+                $r['matched_email'],
+                $r['matched_prior']
+            ));
+
+            if ($r['scanned'] === 0) {
+                $this->info('No unmatched donations found.');
+            }
+
+            return Command::SUCCESS;
+        });
+    }
+}

--- a/iznik-batch/app/Services/DonationThankPrepService.php
+++ b/iznik-batch/app/Services/DonationThankPrepService.php
@@ -80,11 +80,29 @@ class DonationThankPrepService
         $cards  = [];
         $maxId  = $lastId;
         foreach ($donations as $donation) {
-            $total += (float) $donation->GrossAmount;
-            $cards[] = $this->buildDonationCard($donation);
+            // Always advance the high-water mark, even for donations we skip,
+            // so a continuation or sub-threshold gift isn't re-examined every
+            // run and never re-surfaces tomorrow.
             if ((int) $donation->id > $maxId) {
                 $maxId = (int) $donation->id;
             }
+
+            if (!$this->shouldThank($donation)) {
+                continue;
+            }
+
+            $total  += (float) $donation->GrossAmount;
+            $cards[] = $this->buildDonationCard($donation);
+        }
+
+        // Nothing in this batch warranted a thank-you (all continuations,
+        // sub-threshold one-offs, or excluded payers). Advance the mark so the
+        // skipped rows don't return, but send no email.
+        if (empty($cards)) {
+            if (!$dryRun) {
+                $this->setLastSentId($maxId);
+            }
+            return ['donations' => 0, 'total' => 0.0, 'sent' => false, 'last_id' => $maxId];
         }
 
         if (!$dryRun) {
@@ -108,11 +126,74 @@ class DonationThankPrepService
         }
 
         return [
-            'donations' => $donations->count(),
+            'donations' => count($cards),
             'total'     => $total,
             'sent'      => !$dryRun,
             'last_id'   => $maxId,
         ];
+    }
+
+    /**
+     * Should this donation produce a thank-you card? Mirrors V1
+     * donateipn.php's trigger so we don't re-thank established donors:
+     *
+     *   - never for an excluded payer (PayPal Giving Fund / Tipalti);
+     *   - for recurring donations, only the donor's first-ever payment (a new
+     *     sign-up), never the monthly continuations;
+     *   - for one-off donations, only at or above the manual-thanks threshold.
+     */
+    private function shouldThank(object $donation): bool
+    {
+        if ($this->isExcludedPayer((string) ($donation->Payer ?? ''))
+            || (string) $donation->source === 'PayPalGivingFund') {
+            return false;
+        }
+
+        $recurring = in_array((string) $donation->TransactionType, self::RECURRING_TYPES, true);
+
+        if ($recurring) {
+            return $this->isFirstDonation($donation);
+        }
+
+        return (float) $donation->GrossAmount >= (float) config('freegle.donations.manual_thanks', 20);
+    }
+
+    /**
+     * True when there is no earlier donation from the same donor — matched by
+     * userid where known, otherwise by Payer email so a continuation from an
+     * as-yet-unmatched recurring donor is still recognised as not-first.
+     */
+    private function isFirstDonation(object $donation): bool
+    {
+        $query = DB::table('users_donations')->where('id', '<', (int) $donation->id);
+
+        if ($donation->userid) {
+            $query->where('userid', (int) $donation->userid);
+        } else {
+            $query->where('Payer', (string) ($donation->Payer ?? ''));
+        }
+
+        return !$query->exists();
+    }
+
+    private function isExcludedPayer(string $payer): bool
+    {
+        if ($payer === '') {
+            return false;
+        }
+
+        $list = array_filter(array_map(
+            'trim',
+            explode(',', (string) config('freegle.donations.excluded_payers', ''))
+        ));
+
+        foreach ($list as $excluded) {
+            if (strcasecmp($payer, $excluded) === 0) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**
@@ -183,6 +264,7 @@ class DonationThankPrepService
             'modChats'        => [],
             'birthdayHint'    => false,
             'flags'           => [],
+            'candidates'      => [],
             'links'           => $this->buildLinks($donation),
         ];
 
@@ -190,6 +272,7 @@ class DonationThankPrepService
             $card = $this->enrichMatchedDonor((int) $donation->userid, $donation, $card, $recurring);
         } else {
             $card['flags'][] = 'Unmatched donor — needs sleuthing';
+            $card['candidates'] = $this->gatherCandidates($donation);
         }
 
         if ($recurring) {
@@ -410,5 +493,91 @@ class DonationThankPrepService
         }
 
         return $links;
+    }
+
+    /**
+     * For an unmatched donation, surface a few plausible Freegle accounts the
+     * thanker can check — mirroring the manual sleuthing (same email prefix on
+     * a different provider; same display name). These are read-only suggestions
+     * shown on the card; nothing is auto-linked. Capped so the card stays
+     * scannable.
+     *
+     * @return array<int, array{userid:int, name:string, email:?string, reason:string, link:string}>
+     */
+    private function gatherCandidates(object $donation): array
+    {
+        $payer      = (string) ($donation->Payer ?? '');
+        $candidates = [];
+        $seen       = [];
+
+        // 1. Same email local-part on any provider — people reuse the prefix
+        //    across gmail/btinternet/etc. The leading-anchored LIKE uses the
+        //    email index, so this stays cheap.
+        $at = strpos($payer, '@');
+        if ($at > 2) {
+            $local      = substr($payer, 0, $at);
+            $likePrefix = str_replace(['\\', '%', '_'], ['\\\\', '\\%', '\\_'], $local) . '@%';
+
+            $rows = DB::table('users_emails')
+                ->join('users', 'users.id', '=', 'users_emails.userid')
+                ->whereNull('users.deleted')
+                ->whereNotNull('users_emails.userid')
+                ->where('users_emails.email', 'like', $likePrefix)
+                ->where('users_emails.email', '<>', $payer)
+                ->where('users_emails.email', 'not like', '%@users.ilovefreegle.org')
+                ->where('users_emails.email', 'not like', '%@users.trash-nothing.com')
+                ->orderBy('users_emails.userid')
+                ->limit(5)
+                ->get(['users.id as userid', 'users.firstname', 'users.lastname', 'users.fullname', 'users_emails.email']);
+
+            foreach ($rows as $r) {
+                $key = (int) $r->userid;
+                if (isset($seen[$key])) {
+                    continue;
+                }
+                $seen[$key] = true;
+                $candidates[] = $this->candidateRow($r, "same email prefix ({$local}@…)");
+            }
+        }
+
+        // 2. Exact display-name match (PayPal/Stripe give us the payer's name).
+        $name = trim((string) ($donation->PayerDisplayName ?? ''));
+        if ($name !== '' && strpos($name, '@') === false && count($candidates) < 5) {
+            $rows = DB::table('users')
+                ->whereNull('deleted')
+                ->where('fullname', $name)
+                ->orderBy('id')
+                ->limit(5)
+                ->get(['id as userid', 'firstname', 'lastname', 'fullname']);
+
+            foreach ($rows as $r) {
+                $key = (int) $r->userid;
+                if (isset($seen[$key])) {
+                    continue;
+                }
+                $seen[$key] = true;
+                $r->email = null;
+                $candidates[] = $this->candidateRow($r, 'name match');
+            }
+        }
+
+        return array_slice($candidates, 0, 5);
+    }
+
+    private function candidateRow(object $r, string $reason): array
+    {
+        $display = trim(((string) ($r->firstname ?? '')) . ' ' . ((string) ($r->lastname ?? '')));
+        if ($display === '') {
+            $display = (string) ($r->fullname ?? '');
+        }
+        $modBase = rtrim((string) config('freegle.sites.mod', 'https://modtools.org'), '/');
+
+        return [
+            'userid' => (int) $r->userid,
+            'name'   => $display !== '' ? $display : 'Unknown',
+            'email'  => isset($r->email) ? $r->email : null,
+            'reason' => $reason,
+            'link'   => "{$modBase}/support/" . (int) $r->userid,
+        ];
     }
 }

--- a/iznik-batch/app/Services/DonationUserIdBackfillService.php
+++ b/iznik-batch/app/Services/DonationUserIdBackfillService.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * One-shot backfill that re-links unmatched donations (users_donations.userid
+ * IS NULL) to a Freegle account.
+ *
+ * It restores V1 correctUserIdInDonations() parity (exact-email matching) and
+ * adds the same two extra signals now used by the live Go IPN handlers
+ * (donations.MatchUserByEmailOrPriorDonation):
+ *
+ *   1. canonical-email matching (gmail dots/+tags, googlemail, TN variants) via
+ *      the shared App\Models\User::canonMail(); and
+ *   2. a prior donation from the same Payer already linked to a non-deleted
+ *      user — recovering recurring donors whose Freegle email later changed
+ *      while the payment processor keeps billing the original address.
+ *
+ * Going forward the IPN handlers match at receipt time, so this command is NOT
+ * scheduled; it exists to clean up the historical backlog.
+ */
+class DonationUserIdBackfillService
+{
+    /**
+     * @return array{scanned:int, matched_email:int, matched_prior:int, updated:int}
+     */
+    public function backfill(bool $dryRun = false, ?int $limit = null): array
+    {
+        $scanned      = 0;
+        $matchedEmail = 0;
+        $matchedPrior = 0;
+        $updated      = 0;
+
+        // Resolve once per distinct Payer — recurring donors have many unmatched
+        // rows that all resolve to the same account.
+        $resolved = [];
+
+        $query = DB::table('users_donations')
+            ->whereNull('userid')
+            ->whereNotNull('Payer')
+            ->where('Payer', '<>', '')
+            ->orderBy('id');
+
+        $remaining = $limit;
+
+        $query->chunkById(500, function ($rows) use (
+            &$scanned, &$matchedEmail, &$matchedPrior, &$updated, &$resolved, &$remaining, $dryRun, $limit
+        ) {
+            foreach ($rows as $row) {
+                if ($limit !== null && $remaining !== null && $remaining <= 0) {
+                    return false; // stop chunking
+                }
+
+                $scanned++;
+                if ($remaining !== null) {
+                    $remaining--;
+                }
+
+                $payer = (string) $row->Payer;
+                if (!array_key_exists($payer, $resolved)) {
+                    $resolved[$payer] = $this->resolve($payer);
+                }
+                [$uid, $via] = $resolved[$payer];
+
+                if ($uid === null) {
+                    continue;
+                }
+
+                if ($via === 'email') {
+                    $matchedEmail++;
+                } else {
+                    $matchedPrior++;
+                }
+
+                if (!$dryRun) {
+                    DB::table('users_donations')->where('id', $row->id)->update(['userid' => $uid]);
+                }
+                $updated++;
+            }
+
+            return true;
+        });
+
+        return [
+            'scanned'       => $scanned,
+            'matched_email' => $matchedEmail,
+            'matched_prior' => $matchedPrior,
+            'updated'       => $updated,
+        ];
+    }
+
+    /**
+     * Resolve a Payer email to a still-valid user id, mirroring the Go handler's
+     * MatchUserByEmailOrPriorDonation.
+     *
+     * @return array{0:int|null, 1:string} [userid|null, 'email'|'prior'|'']
+     */
+    private function resolve(string $payer): array
+    {
+        $canon = User::canonMail($payer);
+
+        // 1. Registered address (exact or canonical), on a live account.
+        $uid = DB::table('users_emails')
+            ->join('users', 'users.id', '=', 'users_emails.userid')
+            ->whereNull('users.deleted')
+            ->whereNotNull('users_emails.userid')
+            ->where(function ($q) use ($payer, $canon) {
+                $q->where('users_emails.email', $payer)
+                  ->orWhere('users_emails.canon', $canon);
+            })
+            ->value('users_emails.userid');
+
+        if ($uid) {
+            return [(int) $uid, 'email'];
+        }
+
+        // 2. A prior donation from the same Payer, linked to a still-valid user.
+        $uid = DB::table('users_donations')
+            ->join('users', 'users.id', '=', 'users_donations.userid')
+            ->whereNull('users.deleted')
+            ->whereNotNull('users_donations.userid')
+            ->where('users_donations.Payer', $payer)
+            ->orderByDesc('users_donations.timestamp')
+            ->value('users_donations.userid');
+
+        if ($uid) {
+            return [(int) $uid, 'prior'];
+        }
+
+        return [null, ''];
+    }
+}

--- a/iznik-batch/config/freegle.php
+++ b/iznik-batch/config/freegle.php
@@ -23,6 +23,18 @@ return [
 
     'avatar_server_url' => env('FREEGLE_AVATAR_SERVER_URL', 'https://api.ilovefreegle.org/avatar'),
 
+    'donations' => [
+        // One-off donations below this amount (£) don't warrant a manual
+        // thank-you (V1 Donations::MANUAL_THANKS). Recurring donations are
+        // thanked once, on the first payment, regardless of amount.
+        'manual_thanks' => (float) env('FREEGLE_MANUAL_THANKS', 20),
+
+        // Payer emails that must never trigger a thank-you (PayPal Giving Fund,
+        // Tipalti). Comma-separated; mirrors the Go DONATIONS_EXCLUDE so both
+        // sides share one source of truth.
+        'excluded_payers' => env('DONATIONS_EXCLUDE', 'ppgfukpay@paypalgivingfund.org,paypal.msb@tipalti.com'),
+    ],
+
     'branding' => [
         'name' => env('FREEGLE_SITE_NAME', 'Freegle'),
         'logo_url' => env('FREEGLE_LOGO_URL', 'https://www.ilovefreegle.org/icon.png'),

--- a/iznik-batch/resources/views/emails/mjml/donation/thank-prep.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/donation/thank-prep.blade.php
@@ -83,7 +83,7 @@
               <tr>
                 <td style="text-align:left;">
                   <div style="font-size:18px;font-weight:bold;color:#222;">
-                    {{ $amountFmt }} &nbsp;to&nbsp; {{ $name }}
+                    {{ $amountFmt }} &nbsp;from&nbsp; {{ $name }}
                   </div>
                   <div style="font-size:13px;color:#555;margin-top:2px;">
                     at {{ $d['time'] }} &nbsp;via&nbsp; {{ $d['source'] }}@if ($d['transaction']) &nbsp;&middot;&nbsp; ref <span style="font-family:monospace;font-size:12px;">{{ $d['transaction'] }}</span>@endif
@@ -136,6 +136,20 @@
                   <td class="card-label">Member</td>
                   <td><span class="flag-pill flag-pill-warn">Unmatched</span> — sleuthing required (PayPal/Stripe email may differ from Freegle email)</td>
                 </tr>
+                @if (!empty($card['candidates']))
+                  <tr>
+                    <td class="card-label">Possible matches</td>
+                    <td>
+                      @foreach ($card['candidates'] as $cand)
+                        <div style="margin-bottom:3px;">
+                          <a href="{{ $cand['link'] }}">{{ $cand['name'] !== 'Unknown' ? $cand['name'] : ('#' . $cand['userid']) }}</a>
+                          @if ($cand['email'])&nbsp;<span style="color:#555;word-break:break-all;">&lt;{{ $cand['email'] }}&gt;</span>@endif
+                          <span style="color:#888;font-size:12px;">— {{ $cand['reason'] }}</span>
+                        </div>
+                      @endforeach
+                    </td>
+                  </tr>
+                @endif
               @endif
             </table>
           </mj-raw>

--- a/iznik-batch/tests/Feature/Donation/CorrectDonationUserIdsCommandTest.php
+++ b/iznik-batch/tests/Feature/Donation/CorrectDonationUserIdsCommandTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Tests\Feature\Donation;
+
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+/**
+ * Behaviour of `donations:correct-userids` — the one-shot backfill that re-links
+ * unmatched donations using the same logic as the live IPN handlers.
+ */
+class CorrectDonationUserIdsCommandTest extends TestCase
+{
+    private function insertUser(array $attrs = []): int
+    {
+        $row = array_merge([
+            'firstname'  => 'Test',
+            'lastname'   => 'Donor',
+            'fullname'   => 'Test Donor',
+            'systemrole' => 'User',
+            'added'      => now()->subYears(2),
+        ], $attrs);
+        DB::table('users')->insert($row);
+        return (int) DB::getPdo()->lastInsertId();
+    }
+
+    private function insertDonation(array $attrs = []): int
+    {
+        return (int) DB::table('users_donations')->insertGetId([
+            'userid'           => $attrs['userid'] ?? null,
+            'GrossAmount'      => $attrs['GrossAmount'] ?? 5.00,
+            'TransactionType'  => $attrs['TransactionType'] ?? 'subscr_payment',
+            'Payer'            => $attrs['Payer'] ?? 'donor@example.com',
+            'PayerDisplayName' => $attrs['PayerDisplayName'] ?? 'Donor',
+            'type'             => $attrs['type'] ?? 'PayPal',
+            'source'           => $attrs['source'] ?? 'DonateWithPayPal',
+            'timestamp'        => $attrs['timestamp'] ?? now(),
+        ]);
+    }
+
+    public function test_links_unmatched_donation_via_prior_donation_with_valid_user(): void
+    {
+        $uid   = $this->insertUser(['fullname' => 'Prior Match Donor']);
+        $payer = 'prior-paypal-only@external.test'; // not registered on the account
+
+        // Historical matched donation from this Payer.
+        $this->insertDonation(['userid' => $uid, 'Payer' => $payer, 'timestamp' => now()->subMonth()]);
+        // Unmatched continuation that must be re-linked.
+        $newId = $this->insertDonation(['userid' => null, 'Payer' => $payer]);
+
+        $this->artisan('donations:correct-userids')->assertExitCode(0);
+
+        $this->assertEquals($uid, DB::table('users_donations')->where('id', $newId)->value('userid'));
+    }
+
+    public function test_does_not_link_when_prior_user_deleted(): void
+    {
+        $uid   = $this->insertUser(['fullname' => 'Gone Donor', 'deleted' => now()]);
+        $payer = 'deleted-paypal-only@external.test';
+
+        $this->insertDonation(['userid' => $uid, 'Payer' => $payer, 'timestamp' => now()->subMonth()]);
+        $newId = $this->insertDonation(['userid' => null, 'Payer' => $payer]);
+
+        $this->artisan('donations:correct-userids')->assertExitCode(0);
+
+        $this->assertNull(DB::table('users_donations')->where('id', $newId)->value('userid'));
+    }
+
+    public function test_links_by_canon_email(): void
+    {
+        $uid   = $this->insertUser(['fullname' => 'Canon Donor']);
+        $payer = 'jane.canon.donor@gmail.com';
+        $canon = User::canonMail($payer); // janecanondonor@gmailcom
+
+        // Registered email differs from the payer (no exact match) but shares the canon.
+        DB::table('users_emails')->insert([
+            'userid' => $uid,
+            'email'  => 'janecanondonor@gmail.com',
+            'canon'  => $canon,
+        ]);
+
+        $newId = $this->insertDonation(['userid' => null, 'Payer' => $payer]);
+
+        $this->artisan('donations:correct-userids')->assertExitCode(0);
+
+        $this->assertEquals($uid, DB::table('users_donations')->where('id', $newId)->value('userid'));
+    }
+
+    public function test_dry_run_makes_no_changes(): void
+    {
+        $uid   = $this->insertUser(['fullname' => 'Dry Run Donor']);
+        $payer = 'dryrun-paypal-only@external.test';
+
+        $this->insertDonation(['userid' => $uid, 'Payer' => $payer, 'timestamp' => now()->subMonth()]);
+        $newId = $this->insertDonation(['userid' => null, 'Payer' => $payer]);
+
+        $this->artisan('donations:correct-userids', ['--dry-run' => true])->assertExitCode(0);
+
+        $this->assertNull(DB::table('users_donations')->where('id', $newId)->value('userid'));
+    }
+}

--- a/iznik-batch/tests/Feature/Donation/DonationThankPrepCommandTest.php
+++ b/iznik-batch/tests/Feature/Donation/DonationThankPrepCommandTest.php
@@ -89,16 +89,17 @@ class DonationThankPrepCommandTest extends TestCase
     {
         Mail::fake();
 
-        $this->insertDonation(['GrossAmount' => 15.00, 'Payer' => 'alice@example.com']);
+        // Both one-off and at/above the £20 manual-thanks threshold so both qualify.
+        $this->insertDonation(['GrossAmount' => 25.00, 'Payer' => 'alice@example.com']);
         $this->insertDonation(['GrossAmount' => 25.50, 'Payer' => 'bob@example.com']);
 
         $this->artisan('mail:donations:thank-prep')
-            ->expectsOutputToContain('Sent thank-prep digest for 2 donor(s) needing thanks, totalling £40.50')
+            ->expectsOutputToContain('Sent thank-prep digest for 2 donor(s) needing thanks, totalling £50.50')
             ->assertExitCode(0);
 
         Mail::assertSentCount(1);
         Mail::assertSent(DonationThankPrepMail::class, function (DonationThankPrepMail $mail) {
-            return $mail->envelope()->subject === 'Donations needing thanks: 2 donors, £40.50'
+            return $mail->envelope()->subject === 'Donations needing thanks: 2 donors, £50.50'
                 && count($mail->cards) === 2;
         });
     }
@@ -120,8 +121,8 @@ class DonationThankPrepCommandTest extends TestCase
     {
         Mail::fake();
 
-        // First batch.
-        $this->insertDonation(['GrossAmount' => 10.00, 'Payer' => 'first@example.com']);
+        // First batch (both one-off and >= £20 so both qualify).
+        $this->insertDonation(['GrossAmount' => 20.00, 'Payer' => 'first@example.com']);
         $this->insertDonation(['GrossAmount' => 20.00, 'Payer' => 'second@example.com']);
 
         $this->artisan('mail:donations:thank-prep')->assertExitCode(0);
@@ -164,7 +165,7 @@ class DonationThankPrepCommandTest extends TestCase
         $this->assertNotNull($row);
         $this->assertSame((string) $b, $row->value);
 
-        $this->insertDonation(['GrossAmount' => 7.00, 'Payer' => 'after@example.com']);
+        $this->insertDonation(['GrossAmount' => 25.00, 'Payer' => 'after@example.com']);
         $this->artisan('mail:donations:thank-prep')->assertExitCode(0);
         Mail::assertSentCount(1);
     }
@@ -254,12 +255,13 @@ class DonationThankPrepCommandTest extends TestCase
         ]);
         $this->setLastSentId($oldId);
 
-        // Today's new donation.
+        // Today's new donation — a qualifying one-off (>= £20) so a card is
+        // produced; the earlier recurring gift above shows up as history.
         $this->insertDonation([
             'userid'          => $userId,
-            'GrossAmount'     => 10.00,
+            'GrossAmount'     => 25.00,
             'Payer'           => 'elizabeth@example.com',
-            'TransactionType' => 'recurring_payment',
+            'TransactionType' => 'Completed',
             'giftaidconsent'  => 1,
         ]);
 
@@ -277,15 +279,16 @@ class DonationThankPrepCommandTest extends TestCase
                 && $card['giftaid']['postcode'] === 'NR1 1JW'
                 && $card['giftaid']['declined'] === false
                 && count($card['donationHistory']) === 1
-                && (float) $card['donationHistory'][0]['amount'] === 10.0
-                && in_array('Recurring', $card['flags'], true);
+                && (float) $card['donationHistory'][0]['amount'] === 10.0;
         });
     }
 
-    public function test_pgf_donation_flagged_to_avoid_double_claim(): void
+    public function test_pgf_donation_excluded_from_digest(): void
     {
         Mail::fake();
 
+        // PayPal Giving Fund donations are Gift-Aided by PayPal and must never
+        // generate thank-you work — they are excluded entirely.
         $this->insertDonation([
             'GrossAmount' => 5.00,
             'Payer'       => 'anon@paypal.example',
@@ -293,11 +296,11 @@ class DonationThankPrepCommandTest extends TestCase
             'type'        => 'External',
         ]);
 
-        $this->artisan('mail:donations:thank-prep')->assertExitCode(0);
+        $this->artisan('mail:donations:thank-prep')
+            ->expectsOutputToContain('No donations need thanks today')
+            ->assertExitCode(0);
 
-        Mail::assertSent(DonationThankPrepMail::class, function (DonationThankPrepMail $mail) {
-            return in_array('PGF — Gift Aid claimed by PayPal', $mail->cards[0]['flags'], true);
-        });
+        Mail::assertNothingSent();
     }
 
     public function test_declined_giftaid_distinguished_from_no_row(): void
@@ -306,7 +309,7 @@ class DonationThankPrepCommandTest extends TestCase
 
         $userA = $this->insertUser(['firstname' => 'No', 'lastname' => 'GA', 'fullname' => 'No GA']);
         $this->insertDonation([
-            'userid' => $userA, 'GrossAmount' => 10.00,
+            'userid' => $userA, 'GrossAmount' => 20.00,
             'Payer'  => 'noga@example.com', 'PayerDisplayName' => 'No GA',
         ]);
 
@@ -346,7 +349,7 @@ class DonationThankPrepCommandTest extends TestCase
         Mail::fake();
 
         $userId = $this->insertUser(['firstname' => 'Chat', 'lastname' => 'Donor']);
-        $this->insertDonation(['userid' => $userId, 'GrossAmount' => 5.00, 'Payer' => 'chat@example.com']);
+        $this->insertDonation(['userid' => $userId, 'GrossAmount' => 25.00, 'Payer' => 'chat@example.com']);
 
         // Mod note with HTML entity + legacy emoji escape (stored as
         // \\u<hex>\\u per EmojiUtils). Must round-trip cleanly.
@@ -371,6 +374,126 @@ class DonationThankPrepCommandTest extends TestCase
                 && !str_contains($snip, '&amp;')
                 && str_contains($snip, "\u{1F600}")
                 && !str_contains($snip, 'u1f600');
+        });
+    }
+
+    public function test_first_recurring_donation_is_thanked(): void
+    {
+        Mail::fake();
+
+        // A brand-new recurring sign-up (no prior donation from this donor) is
+        // thanked regardless of amount.
+        $this->insertDonation([
+            'GrossAmount'     => 3.00,
+            'Payer'           => 'newrecur@example.com',
+            'TransactionType' => 'subscr_payment',
+        ]);
+
+        $this->artisan('mail:donations:thank-prep')->assertExitCode(0);
+
+        Mail::assertSentCount(1);
+        Mail::assertSent(DonationThankPrepMail::class, function (DonationThankPrepMail $mail) {
+            return count($mail->cards) === 1
+                && $mail->cards[0]['donation']['payer'] === 'newrecur@example.com';
+        });
+    }
+
+    public function test_recurring_continuation_is_not_thanked(): void
+    {
+        Mail::fake();
+
+        // An earlier donation from the same donor exists (below the mark), so
+        // this month's payment is a continuation and must not be re-thanked.
+        $priorId = $this->insertDonation([
+            'GrossAmount'     => 5.00,
+            'Payer'           => 'established@example.com',
+            'TransactionType' => 'subscr_payment',
+            'timestamp'       => now()->subMonth(),
+        ]);
+        $this->setLastSentId($priorId);
+
+        $this->insertDonation([
+            'GrossAmount'     => 5.00,
+            'Payer'           => 'established@example.com',
+            'TransactionType' => 'subscr_payment',
+        ]);
+
+        $this->artisan('mail:donations:thank-prep')
+            ->expectsOutputToContain('No donations need thanks today')
+            ->assertExitCode(0);
+
+        Mail::assertNothingSent();
+    }
+
+    public function test_oneoff_below_threshold_is_not_thanked(): void
+    {
+        Mail::fake();
+
+        $this->insertDonation([
+            'GrossAmount'     => 10.00,
+            'Payer'           => 'smalloneoff@example.com',
+            'TransactionType' => 'Completed',
+        ]);
+
+        $this->artisan('mail:donations:thank-prep')
+            ->expectsOutputToContain('No donations need thanks today')
+            ->assertExitCode(0);
+
+        Mail::assertNothingSent();
+    }
+
+    public function test_excluded_payer_is_not_thanked(): void
+    {
+        Mail::fake();
+
+        // PayPal Giving Fund's payer address is on the default exclusion list,
+        // so even a large one-off must not generate thank-you work.
+        $this->insertDonation([
+            'GrossAmount'     => 50.00,
+            'Payer'           => 'ppgfukpay@paypalgivingfund.org',
+            'TransactionType' => 'Completed',
+        ]);
+
+        $this->artisan('mail:donations:thank-prep')
+            ->expectsOutputToContain('No donations need thanks today')
+            ->assertExitCode(0);
+
+        Mail::assertNothingSent();
+    }
+
+    public function test_unmatched_donor_surfaces_candidate_by_email_prefix(): void
+    {
+        Mail::fake();
+
+        // A user whose registered email shares the payer's local-part but on a
+        // different provider — the manual "search the prefix" technique.
+        $userId = $this->insertUser([
+            'firstname' => 'Lyn', 'lastname' => 'Goswell', 'fullname' => 'Lyn Goswell',
+        ]);
+        DB::table('users_emails')->insert([
+            'userid' => $userId, 'email' => 'lyngoswell@btinternet.com', 'preferred' => 1,
+        ]);
+
+        // Donation from the gmail variant (not registered) → unmatched.
+        $this->insertDonation([
+            'GrossAmount'      => 50.00,
+            'Payer'            => 'lyngoswell@gmail.com',
+            'PayerDisplayName' => 'Lyn Goswell',
+        ]);
+
+        $this->artisan('mail:donations:thank-prep')->assertExitCode(0);
+
+        Mail::assertSent(DonationThankPrepMail::class, function (DonationThankPrepMail $mail) use ($userId) {
+            $card = $mail->cards[0];
+            if ($card['user'] !== null) {
+                return false; // must be the unmatched card
+            }
+            foreach ($card['candidates'] as $cand) {
+                if ($cand['userid'] === $userId) {
+                    return true;
+                }
+            }
+            return false;
         });
     }
 }

--- a/iznik-server-go/donations/donations.go
+++ b/iznik-server-go/donations/donations.go
@@ -68,6 +68,47 @@ func getExcludedPayers() []string {
 	return result
 }
 
+// MatchUserByEmailOrPriorDonation finds a still-valid Freegle user for a payer
+// email, mirroring V1 donateipn.php / User::findByEmail. It tries, in order:
+//
+//  1. an exact or canonical match against a registered address — V1 matched
+//     `email = ? OR canon = ?`, but the Go IPN handlers had dropped the canon
+//     leg, so variant addresses (gmail dots/+tags, googlemail, TN variants)
+//     stopped matching; and
+//  2. a prior donation from the same Payer that is already linked to a
+//     non-deleted user. This catches recurring donors whose Freegle email later
+//     changed or was removed while PayPal keeps billing the original address.
+//     The `users.deleted IS NULL` guard makes it merge-safe: a merged-away
+//     account is marked deleted (and its donations reassigned to the survivor),
+//     so we never re-link to a dead account — we just fall through to unmatched.
+//
+// Returns 0 when there is no confident match.
+func MatchUserByEmailOrPriorDonation(email string) uint64 {
+	email = strings.TrimSpace(email)
+	if email == "" {
+		return 0
+	}
+
+	gdb := database.DBConn
+	var userID uint64
+
+	// 1. Registered address, exact or canonical (reuses the shared util so the
+	//    canon form matches how addresses are stored).
+	canon := user.CanonicalizeEmail(email)
+	gdb.Raw("SELECT userid FROM users_emails WHERE (email = ? OR canon = ?) AND userid IS NOT NULL LIMIT 1",
+		email, canon).Scan(&userID)
+	if userID > 0 {
+		return userID
+	}
+
+	// 2. Prior donation from the same Payer, linked to a still-valid user.
+	gdb.Raw("SELECT ud.userid FROM users_donations ud "+
+		"JOIN users u ON u.id = ud.userid "+
+		"WHERE ud.Payer = ? AND ud.userid IS NOT NULL AND u.deleted IS NULL "+
+		"ORDER BY ud.timestamp DESC LIMIT 1", email).Scan(&userID)
+	return userID
+}
+
 // GetDonations returns donation target and amount raised for the current month
 // @Summary Get donations summary
 // @Description Returns the donation target and amount raised for the current month, optionally filtered by group

--- a/iznik-server-go/donations/paypalipn.go
+++ b/iznik-server-go/donations/paypalipn.go
@@ -78,11 +78,14 @@ func PayPalIPN(c *fiber.Ctx) error {
 		}
 	}
 
-	// Fallback to email lookup.
+	// Fallback: registered address (exact or canonical) or a prior donation from
+	// the same Payer that's linked to a still-valid user. Mirrors V1 findByEmail
+	// and recovers recurring donors whose Freegle email later changed while
+	// PayPal keeps billing the original address.
 	if userID == 0 && payerEmail != "" {
-		gdb.Raw("SELECT userid FROM users_emails WHERE email = ? AND userid IS NOT NULL LIMIT 1", payerEmail).Scan(&userID)
+		userID = MatchUserByEmailOrPriorDonation(payerEmail)
 		if userID > 0 {
-			log.Printf("[PayPalIPN] Matched user %d from payer email %s", userID, payerEmail)
+			log.Printf("[PayPalIPN] Matched user %d for payer email %s (email/canon/prior donation)", userID, payerEmail)
 		}
 	}
 

--- a/iznik-server-go/donations/stripeipn.go
+++ b/iznik-server-go/donations/stripeipn.go
@@ -215,6 +215,21 @@ func matchDonorUser(charge *stripe.Charge) (uint64, string, string) {
 		}
 	}
 
+	// 4. Canonical-email and prior-donation fallbacks (V1 parity), using the
+	//    best available payer email.
+	if userID == 0 {
+		payerEmail := ""
+		if charge.BillingDetails != nil {
+			payerEmail = charge.BillingDetails.Email
+		}
+		if payerEmail != "" {
+			userID = MatchUserByEmailOrPriorDonation(payerEmail)
+			if userID > 0 {
+				log.Printf("[StripeIPN] Matched user %d via email/canon/prior donation for %s", userID, payerEmail)
+			}
+		}
+	}
+
 	// Get user name and email for the matched user.
 	if userID > 0 {
 		gdb.Raw("SELECT email FROM users_emails WHERE userid = ? ORDER BY preferred DESC LIMIT 1", userID).Scan(&userEmail)

--- a/iznik-server-go/test/paypalipn_test.go
+++ b/iznik-server-go/test/paypalipn_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/freegle/iznik-server-go/database"
+	"github.com/freegle/iznik-server-go/user"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -260,6 +261,135 @@ func TestPayPalIPN_OneOffBelowThresholdNoThankYou(t *testing.T) {
 	assert.Equal(t, int64(0), taskCount, "One-off donation below £20 must not queue thank-you")
 
 	db.Exec("DELETE FROM users_donations WHERE TransactionID = ?", txnID)
+}
+
+// TestPayPalIPN_MatchByPriorDonation covers the case where a recurring donor's
+// PayPal payer email is no longer (or never was) on their Freegle account — but
+// a PRIOR donation from the same Payer is already linked to a still-valid user.
+// V1 matched these; the Go port must too. (e.g. donor changed their Freegle
+// email but PayPal keeps billing the old address.)
+func TestPayPalIPN_MatchByPriorDonation(t *testing.T) {
+	prefix := uniquePrefix("paypalprior")
+	db := database.DBConn
+
+	userID := CreateTestUser(t, prefix+"_donor", "User")
+	// PayPal email that is NOT registered on the account.
+	payerEmail := prefix + "_paypal@external.com"
+	priorTxn := "PRIOR_" + prefix
+	newTxn := "PAY_" + prefix
+
+	// A historical donation from this Payer, already linked to the valid user.
+	db.Exec("INSERT INTO users_donations (userid, Payer, GrossAmount, TransactionID, TransactionType, source, type, timestamp) "+
+		"VALUES (?, ?, 5.00, ?, 'subscr_payment', 'DonateWithPayPal', 'PayPal', NOW() - INTERVAL 1 MONTH)",
+		userID, payerEmail, priorTxn)
+
+	body := makePayPalForm(map[string]string{
+		"mc_gross":     "5.00",
+		"payer_email":  payerEmail,
+		"first_name":   "Recurring",
+		"last_name":    "Donor",
+		"txn_id":       newTxn,
+		"txn_type":     "subscr_payment",
+		"payment_date": "2026-01-15 10:30:00",
+	})
+
+	req := httptest.NewRequest("POST", "/donateipn", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := getApp().Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var donorID *uint64
+	db.Raw("SELECT userid FROM users_donations WHERE TransactionID = ?", newTxn).Scan(&donorID)
+	assert.NotNil(t, donorID, "new donation should be matched via prior donation from same Payer")
+	if donorID != nil {
+		assert.Equal(t, userID, *donorID)
+	}
+
+	db.Exec("DELETE FROM users_donations WHERE TransactionID IN (?, ?)", priorTxn, newTxn)
+}
+
+// TestPayPalIPN_PriorDonationDeletedUserNotMatched guards the merge/deletion
+// case: if the only prior-donation link points to a deleted (or merged-away)
+// user, we must NOT reuse it — the donation stays unmatched.
+func TestPayPalIPN_PriorDonationDeletedUserNotMatched(t *testing.T) {
+	prefix := uniquePrefix("paypalpriordel")
+	db := database.DBConn
+
+	deletedID := CreateDeletedTestUser(t, prefix+"_gone")
+	payerEmail := prefix + "_paypal@external.com"
+	priorTxn := "PRIOR_" + prefix
+	newTxn := "PAY_" + prefix
+
+	db.Exec("INSERT INTO users_donations (userid, Payer, GrossAmount, TransactionID, TransactionType, source, type, timestamp) "+
+		"VALUES (?, ?, 5.00, ?, 'subscr_payment', 'DonateWithPayPal', 'PayPal', NOW() - INTERVAL 1 MONTH)",
+		deletedID, payerEmail, priorTxn)
+
+	body := makePayPalForm(map[string]string{
+		"mc_gross":     "5.00",
+		"payer_email":  payerEmail,
+		"first_name":   "Recurring",
+		"last_name":    "Donor",
+		"txn_id":       newTxn,
+		"txn_type":     "subscr_payment",
+		"payment_date": "2026-01-15 10:30:00",
+	})
+
+	req := httptest.NewRequest("POST", "/donateipn", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := getApp().Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var donorID *uint64
+	db.Raw("SELECT userid FROM users_donations WHERE TransactionID = ?", newTxn).Scan(&donorID)
+	assert.Nil(t, donorID, "must not match a prior donation linked to a deleted/merged-away user")
+
+	db.Exec("DELETE FROM users_donations WHERE TransactionID IN (?, ?)", priorTxn, newTxn)
+}
+
+// TestPayPalIPN_MatchByCanon covers V1's `email = ? OR canon = ?` matching: a
+// payer email that differs from the registered address only by canonicalisation
+// (gmail dots, +tag, etc.) must still match. The Go port dropped this.
+func TestPayPalIPN_MatchByCanon(t *testing.T) {
+	prefix := uniquePrefix("paypalcanon")
+	db := database.DBConn
+
+	userID := CreateTestUser(t, prefix+"_donor", "User")
+
+	// Register a canonicalised email; the incoming payer is a dotted variant
+	// that is NOT an exact match but shares the same canon.
+	payerEmail := prefix + ".donor@test.com"
+	canon := user.CanonicalizeEmail(payerEmail)
+	storedEmail := canon // exact-different from payerEmail (no dot), same canon
+	db.Exec("INSERT INTO users_emails (userid, email, canon) VALUES (?, ?, ?)", userID, storedEmail, canon)
+
+	newTxn := "PAY_" + prefix
+	body := makePayPalForm(map[string]string{
+		"mc_gross":     "5.00",
+		"payer_email":  payerEmail,
+		"first_name":   "Canon",
+		"last_name":    "Donor",
+		"txn_id":       newTxn,
+		"txn_type":     "subscr_payment",
+		"payment_date": "2026-01-15 10:30:00",
+	})
+
+	req := httptest.NewRequest("POST", "/donateipn", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := getApp().Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var donorID *uint64
+	db.Raw("SELECT userid FROM users_donations WHERE TransactionID = ?", newTxn).Scan(&donorID)
+	assert.NotNil(t, donorID, "payer email should match registered account via canon")
+	if donorID != nil {
+		assert.Equal(t, userID, *donorID)
+	}
+
+	db.Exec("DELETE FROM users_donations WHERE TransactionID = ?", newTxn)
+	db.Exec("DELETE FROM users_emails WHERE userid = ? AND email = ?", userID, storedEmail)
 }
 
 func TestPayPalIPN_NoMcGross(t *testing.T) {

--- a/iznik-server-go/test/stripeipn_test.go
+++ b/iznik-server-go/test/stripeipn_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/freegle/iznik-server-go/database"
+	"github.com/freegle/iznik-server-go/user"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -249,4 +250,67 @@ func TestStripeIPN_GiftAidNotification(t *testing.T) {
 
 	db.Exec("DELETE FROM users_donations WHERE TransactionID = ?", chargeID)
 	db.Exec("DELETE FROM users_notifications WHERE touser = ? AND type = 'GiftAid'", userID)
+}
+
+// TestStripeIPN_MatchByPriorDonation: a billing email not registered on any
+// account, but a prior donation from the same Payer is linked to a valid user.
+func TestStripeIPN_MatchByPriorDonation(t *testing.T) {
+	prefix := uniquePrefix("stripeprior")
+	db := database.DBConn
+
+	userID := CreateTestUser(t, prefix+"_donor", "User")
+	billingEmail := prefix + "_card@external.com" // not in users_emails
+	priorTxn := "ch_prior_" + prefix
+	chargeID := "ch_test_" + prefix
+
+	db.Exec("INSERT INTO users_donations (userid, Payer, GrossAmount, TransactionID, TransactionType, source, type, timestamp) "+
+		"VALUES (?, ?, 10.00, ?, 'subscr_payment', 'Stripe', 'Stripe', NOW() - INTERVAL 1 MONTH)",
+		userID, billingEmail, priorTxn)
+
+	body := makeChargeEvent(chargeID, 1000, map[string]string{}, billingEmail, "One-time donation")
+	req := httptest.NewRequest("POST", "/api/stripeipn", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := getApp().Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var donorID *uint64
+	db.Raw("SELECT userid FROM users_donations WHERE TransactionID = ?", chargeID).Scan(&donorID)
+	assert.NotNil(t, donorID, "should match via prior donation from same Payer")
+	if donorID != nil {
+		assert.Equal(t, userID, *donorID)
+	}
+
+	db.Exec("DELETE FROM users_donations WHERE TransactionID IN (?, ?)", priorTxn, chargeID)
+}
+
+// TestStripeIPN_MatchByCanon: billing email differs from the registered address
+// only by canonicalisation; must still match (V1 parity).
+func TestStripeIPN_MatchByCanon(t *testing.T) {
+	prefix := uniquePrefix("stripecanon")
+	db := database.DBConn
+
+	userID := CreateTestUser(t, prefix+"_donor", "User")
+	billingEmail := prefix + ".donor@test.com"
+	canon := user.CanonicalizeEmail(billingEmail)
+	storedEmail := canon
+	db.Exec("INSERT INTO users_emails (userid, email, canon) VALUES (?, ?, ?)", userID, storedEmail, canon)
+
+	chargeID := "ch_test_" + prefix
+	body := makeChargeEvent(chargeID, 1000, map[string]string{}, billingEmail, "One-time donation")
+	req := httptest.NewRequest("POST", "/api/stripeipn", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := getApp().Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var donorID *uint64
+	db.Raw("SELECT userid FROM users_donations WHERE TransactionID = ?", chargeID).Scan(&donorID)
+	assert.NotNil(t, donorID, "billing email should match registered account via canon")
+	if donorID != nil {
+		assert.Equal(t, userID, *donorID)
+	}
+
+	db.Exec("DELETE FROM users_donations WHERE TransactionID = ?", chargeID)
+	db.Exec("DELETE FROM users_emails WHERE userid = ? AND email = ?", userID, storedEmail)
 }


### PR DESCRIPTION
## Summary

Triggered by feedback from the thank-you team about unmatched donors and over-thanking. Three donation issues fixed, plus the original `FREEGLE_THANKS_ADDR` routing.

### 1. IPN user-matching regression (Go)
The PayPal/Stripe IPN handlers were migrated PHP→Go but matched the payer email **exactly** only, dropping two V1 behaviours:
- **canon matching** — V1 `User::findByEmail` matched `email = ? OR canon = ?` (gmail dots/+tags, googlemail, TrashNothing variants). Restored using the existing `user.CanonicalizeEmail` (no dup).
- **`correctUserIdInDonations` backfill** — never migrated. Added a **prior-donation → still-valid (non-deleted) user** fallback to both handlers, recovering recurring donors whose Freegle email later changed while the processor keeps billing the old address. `deleted IS NULL` makes it merge-safe (merges reassign donations to the survivor and mark the old account deleted).

Verified read-only against the live DB: ~10%/month of donations are unmatched; the donors flagged were account-deletion / email-change cases, and the canon + backfill gaps were the real V1-parity losses.

### 2. Backfill command
`donations:correct-userids` — one-shot, **not scheduled** (the IPN matches at receipt time). Re-links the historical backlog with the same email/canon + prior-donation logic, reusing `App\Models\User::canonMail`. Supports `--dry-run` / `--limit`.

### 3. Thank-prep digest
- only cards the donor's **first-ever recurring** payment or a **one-off ≥ £20** — stops re-thanking established recurring donors;
- **excludes** PGF/Tipalti payers (new `freegle.donations` config mirroring the Go `DONATIONS_EXCLUDE`);
- card now reads "£X **from** {donor}" (was "to");
- unmatched cards **surface candidate accounts** (same email-prefix / name match) with Modtools links.

### 4. `FREEGLE_THANKS_ADDR`
Documented in both `.env` examples. The daily thanks digest already reads `thanks_addr`; setting `FREEGLE_THANKS_ADDR=info@ilovefreegle.org` on live routes it separately from the fundraising address (currently it falls back there).

## Tests
- 5 new Go IPN tests (canon, prior-donation, deleted-user guard) — full Go suite green (0 failures).
- 4 backfill tests green.
- Thank-prep suite updated to the new trigger spec + new cases — 16 green.

## Live action still needed
Set `FREEGLE_THANKS_ADDR=info@ilovefreegle.org` in `.env.background` and refresh `batch-prod`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
