### PR TITLE
fix(modtools): reword misleading personal-info pending warning

### DIFF
--- a/iznik-nuxt3/modtools/components/ModMessageWorry.vue
+++ b/iznik-nuxt3/modtools/components/ModMessageWorry.vue
@@ -48,12 +48,12 @@
         to describe the item more specifically.
       </span>
       <span v-else-if="reason.check === 'PhoneNumber'">
-        <strong>Phone number:</strong> This group restricts personal info in
-        posts. Please ask the member to remove their phone number.
+        <strong>Phone number:</strong> This post contains a phone number.
+        Please ask the member to remove it.
       </span>
       <span v-else-if="reason.check === 'EmailAddress'">
-        <strong>Email address:</strong> This group restricts personal info in
-        posts. Please ask the member to remove their email address.
+        <strong>Email address:</strong> This post contains an email address.
+        Please ask the member to remove it.
       </span>
       <span v-else-if="reason.check === 'MessagingLink'">
         <strong>Messaging app link:</strong> {{ reason.detail }}. Please ask

--- a/iznik-nuxt3/tests/unit/components/modtools/ModMessageWorry.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModMessageWorry.spec.js
@@ -204,11 +204,19 @@ describe('ModMessageWorry', () => {
       expect(wrapper.text()).toContain('Phone number')
     })
 
+    it('describes the post content, not a group restriction', () => {
+      const wrapper = mountWithReasons([
+        { check: 'PhoneNumber', category: null, detail: 'Post contains what looks like a phone number' },
+      ])
+      expect(wrapper.text()).not.toContain('This group restricts personal info')
+      expect(wrapper.text()).toContain('This post contains a phone number')
+    })
+
     it('asks mod to request phone number removal', () => {
       const wrapper = mountWithReasons([
         { check: 'PhoneNumber', category: null, detail: 'Post contains what looks like a phone number' },
       ])
-      expect(wrapper.text()).toContain('remove their phone number')
+      expect(wrapper.text()).toContain('remove it')
     })
   })
 
@@ -220,11 +228,19 @@ describe('ModMessageWorry', () => {
       expect(wrapper.text()).toContain('Email address')
     })
 
+    it('describes the post content, not a group restriction', () => {
+      const wrapper = mountWithReasons([
+        { check: 'EmailAddress', category: null, detail: 'Post contains an external email address' },
+      ])
+      expect(wrapper.text()).not.toContain('This group restricts personal info')
+      expect(wrapper.text()).toContain('This post contains an email address')
+    })
+
     it('asks mod to request email removal', () => {
       const wrapper = mountWithReasons([
         { check: 'EmailAddress', category: null, detail: 'Post contains an external email address' },
       ])
-      expect(wrapper.text()).toContain('remove their email address')
+      expect(wrapper.text()).toContain('remove it')
     })
   })
 


### PR DESCRIPTION
## Summary

- The `PhoneNumber` and `EmailAddress` contentcheck warnings in `ModMessageWorry.vue` said *"This group restricts personal info in posts"*, implying an automated enforcement that does not happen — the check only **flags** the post for manual review (`action: flag`).
- The `PhoneNumber` check also runs **regardless** of the group's `restrictpersonalinfo` setting, making the group attribution doubly wrong.
- Reworded both messages to describe **what the post contains** rather than implying an automated restriction. Per reporter suggestion (Discourse #9766, post 8).

## Code Quality Review

- Wording-only change to two moderator-facing warning strings; no logic/behaviour change.
- Spec updated to assert the new wording.

## Test Plan

- `ModMessageWorry.spec.js` updated and asserts the reworded PhoneNumber/EmailAddress messages.
- Merges cleanly onto current master (the touched files are unchanged on master since the commit's base).