### PR TITLE
feat(digests): unify community-event and volunteering roundups per user (with dedup)

### DIFF
--- a/iznik-batch/app/Console/Commands/Mail/SendEventsDigestCommand.php
+++ b/iznik-batch/app/Console/Commands/Mail/SendEventsDigestCommand.php
@@ -27,7 +27,7 @@ class SendEventsDigestCommand extends Command
             $stats = $service->sendEventDigests($dryRun);
 
             $verb = $dryRun ? 'Would send' : 'Sent';
-            $this->info("{$verb} {$stats['sent']} email(s) for {$stats['groups_processed']} group(s).");
+            $this->info("{$verb} {$stats['sent']} email(s) to {$stats['users_processed']} user(s) across {$stats['groups_processed']} group(s).");
 
             return Command::SUCCESS;
         });

--- a/iznik-batch/app/Console/Commands/Mail/SendVolunteeringDigestCommand.php
+++ b/iznik-batch/app/Console/Commands/Mail/SendVolunteeringDigestCommand.php
@@ -27,7 +27,7 @@ class SendVolunteeringDigestCommand extends Command
             $stats = $service->sendVolunteeringDigests($dryRun);
 
             $verb = $dryRun ? 'Would send' : 'Sent';
-            $this->info("{$verb} {$stats['sent']} email(s) for {$stats['groups_processed']} group(s).");
+            $this->info("{$verb} {$stats['sent']} email(s) to {$stats['users_processed']} user(s) across {$stats['groups_processed']} group(s).");
 
             return Command::SUCCESS;
         });

--- a/iznik-batch/app/Mail/Event/EventsDigestMail.php
+++ b/iznik-batch/app/Mail/Event/EventsDigestMail.php
@@ -11,9 +11,13 @@ class EventsDigestMail extends MjmlMailable
 {
     use TrackableEmail;
 
+    /**
+     * @param array $events Deduplicated events across all the recipient's
+     *                      event-enabled groups. Each carries a 'groups' array
+     *                      of the recipient's group names it is shared with.
+     */
     public function __construct(
         public readonly string $recipientEmail,
-        public readonly string $groupName,
         public readonly array $events,
         public readonly string $unsubscribeUrl,
         public readonly ?int $userId = null,
@@ -26,13 +30,13 @@ class EventsDigestMail extends MjmlMailable
             $this->userId,
             null,
             $this->getSubject(),
-            ['group' => $this->groupName, 'event_count' => count($this->events)]
+            ['event_count' => count($this->events)]
         );
     }
 
     protected function getSubject(): string
     {
-        return "[{$this->groupName}] Community Event Roundup";
+        return 'Community events near you';
     }
 
     public function envelope(): Envelope
@@ -40,7 +44,7 @@ class EventsDigestMail extends MjmlMailable
         return new Envelope(
             from: new Address(
                 config('freegle.mail.noreply_addr', 'noreply@ilovefreegle.org'),
-                $this->groupName
+                config('freegle.site_name', 'Freegle')
             ),
             to: [new Address($this->recipientEmail)],
             subject: $this->getSubject(),
@@ -52,7 +56,6 @@ class EventsDigestMail extends MjmlMailable
         $userSite = config('freegle.sites.user');
 
         return $this->mjmlView('emails.mjml.event.events-digest', [
-            'groupName'      => $this->groupName,
             'events'         => $this->events,
             'userSite'       => $userSite,
             'unsubscribeUrl' => $this->unsubscribeUrl,

--- a/iznik-batch/app/Mail/Event/EventsDigestMail.php
+++ b/iznik-batch/app/Mail/Event/EventsDigestMail.php
@@ -14,7 +14,8 @@ class EventsDigestMail extends MjmlMailable
     /**
      * @param array $events Deduplicated events across all the recipient's
      *                      event-enabled groups. Each carries a 'groups' array
-     *                      of the recipient's group names it is shared with.
+     *                      of ['name' => , 'url' => ] pairs for the recipient's
+     *                      groups it was posted on.
      */
     public function __construct(
         public readonly string $recipientEmail,

--- a/iznik-batch/app/Mail/Volunteering/VolunteeringDigestMail.php
+++ b/iznik-batch/app/Mail/Volunteering/VolunteeringDigestMail.php
@@ -11,9 +11,16 @@ use Illuminate\Support\Collection;
 class VolunteeringDigestMail extends MjmlMailable
 {
     use TrackableEmail;
+
+    /**
+     * @param array $volunteerings Deduplicated opportunities across all the
+     *                             recipient's volunteering-enabled groups (plus
+     *                             global opportunities). Each carries a 'groups'
+     *                             array of the recipient's group names it is
+     *                             shared with (empty for global opportunities).
+     */
     public function __construct(
         public readonly string $recipientEmail,
-        public readonly string $groupName,
         public readonly array $volunteerings,
         public readonly string $unsubscribeUrl,
         public readonly Collection $jobAds = new Collection(),
@@ -27,13 +34,13 @@ class VolunteeringDigestMail extends MjmlMailable
             $this->userId,
             null,
             $this->getSubject(),
-            ['group' => $this->groupName, 'vol_count' => count($this->volunteerings)]
+            ['vol_count' => count($this->volunteerings)]
         );
     }
 
     protected function getSubject(): string
     {
-        return "[{$this->groupName}] Volunteer Opportunity Roundup";
+        return 'Volunteer opportunities near you';
     }
 
     public function envelope(): Envelope
@@ -41,7 +48,7 @@ class VolunteeringDigestMail extends MjmlMailable
         return new Envelope(
             from: new Address(
                 config('freegle.mail.noreply_addr', 'noreply@ilovefreegle.org'),
-                $this->groupName
+                config('freegle.site_name', 'Freegle')
             ),
             to: [new Address($this->recipientEmail)],
             subject: $this->getSubject(),
@@ -62,7 +69,6 @@ class VolunteeringDigestMail extends MjmlMailable
         });
 
         return $this->mjmlView('emails.mjml.volunteering.digest', [
-            'groupName'      => $this->groupName,
             'volunteerings'  => $this->volunteerings,
             'userSite'       => $userSite,
             'unsubscribeUrl' => $this->unsubscribeUrl,

--- a/iznik-batch/app/Mail/Volunteering/VolunteeringDigestMail.php
+++ b/iznik-batch/app/Mail/Volunteering/VolunteeringDigestMail.php
@@ -16,8 +16,9 @@ class VolunteeringDigestMail extends MjmlMailable
      * @param array $volunteerings Deduplicated opportunities across all the
      *                             recipient's volunteering-enabled groups (plus
      *                             global opportunities). Each carries a 'groups'
-     *                             array of the recipient's group names it is
-     *                             shared with (empty for global opportunities).
+     *                             array of ['name' => , 'url' => ] pairs for the
+     *                             recipient's groups it was posted on (empty for
+     *                             global opportunities).
      */
     public function __construct(
         public readonly string $recipientEmail,

--- a/iznik-batch/app/Services/Concerns/BuildsUserRoundups.php
+++ b/iznik-batch/app/Services/Concerns/BuildsUserRoundups.php
@@ -25,23 +25,29 @@ trait BuildsUserRoundups
     public const MIN_INTERVAL_DAYS = 3;
 
     /**
-     * Freegle groups eligible for a roundup of the given kind, keyed id => nameshort.
+     * Freegle groups eligible for a roundup of the given kind, keyed by id.
      *
      * Mirrors the per-group eligibility the old per-group services applied:
      * published, on-here Freegle groups that aren't playgrounds, aren't closed,
      * and have the relevant feature setting enabled (default on).
      *
+     * Each value carries the friendly display name plus the /explore link for
+     * the group, so the roundup can show a "Posted on <group>" byline matching
+     * the message digest (UnifiedDigest "Posted by … on <group>").
+     *
      * @param string $settingKey 'communityevents' | 'volunteering'
-     * @return array<int,string>
+     * @return array<int,array{name:string,url:string}>
      */
     protected function eligibleGroups(string $settingKey): array
     {
+        $userSite = config('freegle.sites.user');
+
         $candidates = Group::query()
             ->where('type', Group::TYPE_FREEGLE)
             ->where('publish', 1)
             ->where('onhere', 1)
             ->whereRaw("nameshort NOT LIKE '%playground%'")
-            ->get(['id', 'nameshort', 'settings']);
+            ->get(['id', 'nameshort', 'namefull', 'settings']);
 
         $eligible = [];
         foreach ($candidates as $group) {
@@ -51,7 +57,10 @@ trait BuildsUserRoundups
             if ($group->isClosed()) {
                 continue;
             }
-            $eligible[(int) $group->id] = $group->nameshort;
+            $eligible[(int) $group->id] = [
+                'name' => $group->namefull ?: $group->nameshort,
+                'url'  => $userSite . '/explore/' . rawurlencode($group->nameshort),
+            ];
         }
 
         return $eligible;

--- a/iznik-batch/app/Services/Concerns/BuildsUserRoundups.php
+++ b/iznik-batch/app/Services/Concerns/BuildsUserRoundups.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace App\Services\Concerns;
+
+use App\Models\Group;
+use App\Models\Membership;
+use App\Models\User;
+use App\Models\UserDigest;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\LazyCollection;
+
+/**
+ * Shared plumbing for the user-centric "roundup" digests (community events and
+ * volunteering opportunities).
+ *
+ * Both roundups now send ONE combined email per user covering every group they
+ * belong to — instead of a separate per-group email — with the same item
+ * (cross-posted to several of the user's groups) shown once. The user/group
+ * eligibility, the per-user cadence guard and the "which of my groups is this
+ * shared with" attribution are identical between the two, so they live here.
+ */
+trait BuildsUserRoundups
+{
+    /** Minimum days between roundups of a given kind for one user (V1: DATEDIFF >= 3). */
+    public const MIN_INTERVAL_DAYS = 3;
+
+    /**
+     * Freegle groups eligible for a roundup of the given kind, keyed id => nameshort.
+     *
+     * Mirrors the per-group eligibility the old per-group services applied:
+     * published, on-here Freegle groups that aren't playgrounds, aren't closed,
+     * and have the relevant feature setting enabled (default on).
+     *
+     * @param string $settingKey 'communityevents' | 'volunteering'
+     * @return array<int,string>
+     */
+    protected function eligibleGroups(string $settingKey): array
+    {
+        $candidates = Group::query()
+            ->where('type', Group::TYPE_FREEGLE)
+            ->where('publish', 1)
+            ->where('onhere', 1)
+            ->whereRaw("nameshort NOT LIKE '%playground%'")
+            ->get(['id', 'nameshort', 'settings']);
+
+        $eligible = [];
+        foreach ($candidates as $group) {
+            if (!$group->getSetting($settingKey, true)) {
+                continue;
+            }
+            if ($group->isClosed()) {
+                continue;
+            }
+            $eligible[(int) $group->id] = $group->nameshort;
+        }
+
+        return $eligible;
+    }
+
+    /**
+     * Stream users eligible for a roundup: deliverable (active / not on holiday /
+     * not bouncing / simplemail != None), with at least one approved membership
+     * in an eligible group that has the relevant per-group flag set and a
+     * non-zero email frequency, and not already sent this roundup type within
+     * MIN_INTERVAL_DAYS.
+     *
+     * @param array<int> $groupIds      Eligible group ids.
+     * @param string     $allowedColumn 'eventsallowed' | 'volunteeringallowed'.
+     * @param string     $mode          users_digests.mode ('events' | 'volunteering').
+     */
+    protected function eligibleUsers(array $groupIds, string $allowedColumn, string $mode): LazyCollection
+    {
+        if (empty($groupIds)) {
+            return User::query()->whereRaw('1 = 0')->lazyById(500);
+        }
+
+        return User::query()
+            ->select(['users.id'])
+            ->whereExists(function ($q) use ($groupIds, $allowedColumn) {
+                $q->select(DB::raw(1))
+                    ->from('memberships')
+                    ->whereColumn('memberships.userid', 'users.id')
+                    ->whereIn('memberships.groupid', $groupIds)
+                    ->where('memberships.collection', Membership::COLLECTION_APPROVED)
+                    ->where("memberships.$allowedColumn", 1)
+                    ->where('memberships.emailfrequency', '!=', 0);
+            })
+            ->whereNotExists(function ($q) use ($mode) {
+                $q->select(DB::raw(1))
+                    ->from('users_digests')
+                    ->whereColumn('users_digests.userid', 'users.id')
+                    ->where('users_digests.mode', $mode)
+                    ->where('users_digests.lastsent', '>', now()->subDays(self::MIN_INTERVAL_DAYS));
+            })
+            ->receivingOurMails()
+            ->lazyById(500);
+    }
+
+    /**
+     * The subset of a user's approved memberships (with the relevant flag set and
+     * non-zero frequency) that fall within the eligible group set.
+     *
+     * @param array<int> $eligibleGroupIds
+     * @return array<int>
+     */
+    protected function userGroupIds(int $userId, array $eligibleGroupIds, string $allowedColumn): array
+    {
+        if (empty($eligibleGroupIds)) {
+            return [];
+        }
+
+        return DB::table('memberships')
+            ->where('userid', $userId)
+            ->whereIn('groupid', $eligibleGroupIds)
+            ->where('collection', Membership::COLLECTION_APPROVED)
+            ->where($allowedColumn, 1)
+            ->where('emailfrequency', '!=', 0)
+            ->pluck('groupid')
+            ->map(fn ($id) => (int) $id)
+            ->all();
+    }
+
+    /**
+     * Record that we sent this roundup type to the user, so the next run inside
+     * MIN_INTERVAL_DAYS skips them.
+     */
+    protected function markRoundupSent(int $userId, string $mode, bool $dryRun): void
+    {
+        if ($dryRun) {
+            return;
+        }
+
+        UserDigest::updateOrCreate(
+            ['userid' => $userId, 'mode' => $mode],
+            ['lastsent' => now()]
+        );
+    }
+}

--- a/iznik-batch/app/Services/EventsDigestService.php
+++ b/iznik-batch/app/Services/EventsDigestService.php
@@ -124,7 +124,7 @@ class EventsDigestService
      * @param array<int,array>  $eventsById     eventid => event data (start-ordered)
      * @param array<int,int[]>  $groupsByEvent  eventid => [group ids]
      * @param array<int>        $userGroupIds   the user's eligible group ids
-     * @param array<int,string> $eligibleGroups group id => nameshort
+     * @param array<int,array{name:string,url:string}> $eligibleGroups group id => display name + /explore link
      * @return array<int,array>
      */
     protected function eventsForUser(array $eventsById, array $groupsByEvent, array $userGroupIds, array $eligibleGroups): array

--- a/iznik-batch/app/Services/EventsDigestService.php
+++ b/iznik-batch/app/Services/EventsDigestService.php
@@ -3,211 +3,245 @@
 namespace App\Services;
 
 use App\Mail\Event\EventsDigestMail;
-use App\Models\Group;
-use App\Models\Membership;
 use App\Models\User;
+use App\Services\Concerns\BuildsUserRoundups;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\Mail;
 
+/**
+ * Community-event roundup, unified per user.
+ *
+ * Previously one email per group: a member of several groups received several
+ * roundups, and the same event cross-posted to multiple of their groups
+ * appeared in each one. This now sends ONE email per user covering upcoming
+ * events across ALL their event-enabled groups, with each event shown once
+ * (deduplicated by event id) and annotated with which of the user's groups it
+ * belongs to.
+ */
 class EventsDigestService
 {
-    // Minimum days between roundups per group (V1: DATEDIFF >= 3)
-    public const MIN_INTERVAL_DAYS = 3;
+    use BuildsUserRoundups;
+
+    /** users_digests.mode value used for the per-user cadence guard. */
+    public const DIGEST_MODE = 'events';
+
+    /** Only include events starting within this many days. */
+    public const HORIZON_DAYS = 30;
 
     /**
-     * Send community event roundup emails to members of all eligible groups.
+     * Send unified community-event roundups.
      *
-     * @return array{sent: int, groups_processed: int}
+     * @return array{sent: int, users_processed: int, groups_processed: int}
      */
     public function sendEventDigests(bool $dryRun = false): array
     {
         $userSite = config('freegle.sites.user');
 
         $sent = 0;
-        $groupsProcessed = 0;
+        $usersProcessed = 0;
 
-        // Find Freegle groups due for an event roundup (not sent in last 3 days).
-        $groups = DB::table('groups')
-            ->where('type', Group::TYPE_FREEGLE)
-            ->where('publish', 1)
-            ->where('onhere', 1)
-            ->where(function ($q) {
-                $q->whereNull('lasteventsroundup')
-                    ->orWhereRaw('DATEDIFF(NOW(), lasteventsroundup) >= ?', [self::MIN_INTERVAL_DAYS]);
-            })
-            ->whereRaw("nameshort NOT LIKE '%playground%'")
-            ->select(['id', 'nameshort', 'settings'])
-            ->get();
+        $eligibleGroups = $this->eligibleGroups('communityevents'); // id => nameshort
+        if (empty($eligibleGroups)) {
+            return ['sent' => 0, 'users_processed' => 0, 'groups_processed' => 0];
+        }
+        $groupIds = array_keys($eligibleGroups);
 
-        foreach ($groups as $groupRow) {
-            // Instantiate the Group model to use getSetting().
-            $group = Group::find($groupRow->id);
-            if (!$group) {
+        // Pre-fetch all upcoming events + their group associations + images once,
+        // rather than per user. The working set (events in the next 30 days
+        // across all groups) is small and bounded.
+        [$eventsById, $groupsByEvent] = $this->fetchUpcomingEvents($groupIds, $userSite);
+
+        if (empty($eventsById)) {
+            return ['sent' => 0, 'users_processed' => 0, 'groups_processed' => count($eligibleGroups)];
+        }
+
+        foreach ($this->eligibleUsers($groupIds, 'eventsallowed', self::DIGEST_MODE) as $userRow) {
+            $usersProcessed++;
+
+            $user = User::find($userRow->id);
+            if (!$user) {
                 continue;
             }
 
-            // Skip groups where communityevents setting is disabled (default: enabled).
-            if (!$group->getSetting('communityevents', true)) {
-                if (!$dryRun) {
-                    DB::table('groups')->where('id', $groupRow->id)
-                        ->update(['lasteventsroundup' => now()]);
-                }
+            // V1 parity: pick the user's preferred external email; skip if they
+            // only have internal-alias addresses.
+            $email = $user->email_preferred;
+            if (!$email) {
                 continue;
             }
 
-            // Skip closed groups.
-            if ($group->isClosed()) {
+            $userGroupIds = $this->userGroupIds($user->id, $groupIds, 'eventsallowed');
+            if (empty($userGroupIds)) {
                 continue;
             }
 
-            // Find upcoming community events for this group (starting within the next 30 days).
-            $rawEvents = DB::table('communityevents')
-                ->join('communityevents_groups', function ($join) use ($groupRow) {
-                    $join->on('communityevents_groups.eventid', '=', 'communityevents.id')
-                        ->where('communityevents_groups.groupid', '=', $groupRow->id);
-                })
-                ->join('communityevents_dates', 'communityevents_dates.eventid', '=', 'communityevents.id')
-                ->where('communityevents_dates.start', '>=', now())
-                ->whereRaw('DATEDIFF(communityevents_dates.start, NOW()) <= 30')
-                ->where('communityevents.pending', 0)
-                ->where('communityevents.deleted', 0)
-                ->orderBy('communityevents_dates.start')
-                ->select([
-                    'communityevents.id',
-                    'communityevents.title',
-                    'communityevents.location',
-                    'communityevents.description',
-                    'communityevents.contactname',
-                    'communityevents.contactphone',
-                    'communityevents.contactemail',
-                    'communityevents.contacturl',
-                    'communityevents_dates.start',
-                    'communityevents_dates.end',
-                ])
-                ->get()
-                ->unique('id');
-
-            if ($rawEvents->isEmpty()) {
-                if (!$dryRun) {
-                    DB::table('groups')->where('id', $groupRow->id)
-                        ->update(['lasteventsroundup' => now()]);
-                }
+            $userEvents = $this->eventsForUser($eventsById, $groupsByEvent, $userGroupIds, $eligibleGroups);
+            if (empty($userEvents)) {
                 continue;
-            }
-
-            // Batch-fetch first non-archived image per event.
-            $eventIds = $rawEvents->pluck('id')->all();
-            $images = DB::table('communityevents_images')
-                ->whereIn('eventid', $eventIds)
-                ->where('archived', 0)
-                ->orderBy('eventid')
-                ->orderBy('id')
-                ->get()
-                ->groupBy('eventid')
-                ->map(fn ($imgs) => $imgs->first());
-
-            // Build structured event data for the template.
-            $eventData = $rawEvents->map(function ($event) use ($userSite, $images) {
-                $start = Carbon::parse($event->start)->setTimezone('Europe/London')->format('D, jS F g:ia');
-                $end   = ($event->end && $event->end !== '0000-00-00 00:00:00')
-                    ? Carbon::parse($event->end)->setTimezone('Europe/London')->format('g:ia')
-                    : null;
-
-                $imageUrl = null;
-                if ($images->has($event->id)) {
-                    $img  = $images->get($event->id);
-                    $mods = $img->externalmods ? json_decode($img->externalmods, true) : [];
-                    $imageUrl = $mods['url'] ?? "{$userSite}/communityevent/{$event->id}/image/{$img->id}";
-                }
-
-                // The DB stores HTML-encoded text (e.g. "Soup &amp; Song").
-                // Decode before passing to templates so Blade's {{ }} escaping
-                // produces correct HTML source ("&amp;") rather than the
-                // double-encoded "&amp;amp;" that the email client would render
-                // as the literal string "&amp;" instead of the intended "&".
-                $decode = fn (?string $s): ?string =>
-                    $s !== null ? html_entity_decode($s, ENT_QUOTES | ENT_HTML5, 'UTF-8') : null;
-
-                return [
-                    'id'           => $event->id,
-                    'title'        => $decode($event->title),
-                    'location'     => $decode($event->location),
-                    'description'  => $decode($event->description),
-                    'contactname'  => $decode($event->contactname),
-                    'contactphone' => $event->contactphone,
-                    'contactemail' => $event->contactemail,
-                    'contacturl'   => $event->contacturl,
-                    'start'        => $start,
-                    'end'          => $end,
-                    'imageUrl'     => $imageUrl,
-                    'url'          => "{$userSite}/communityevent/{$event->id}",
-                ];
-            })->values()->all();
-
-            $groupsProcessed++;
-
-            // Find members who have events enabled and are not opted out.
-            // Activity / holiday / bouncing / simplemail filters live on
-            // User::scopeReceivingOurMails so events + volunteering digests +
-            // any future bulk-mail batch job share the same definition of
-            // "deliverable" — V1 events.php enforced these via sendOurMails()
-            // per recipient, and skipping them inflated the V2 dry-run from
-            // ~49k (V1 baseline) to 722k sends.
-            $members = User::query()
-                ->select(['users.id as userId'])
-                ->join('memberships', 'memberships.userid', '=', 'users.id')
-                ->where('memberships.groupid', $groupRow->id)
-                ->where('memberships.collection', Membership::COLLECTION_APPROVED)
-                ->where('memberships.eventsallowed', 1)
-                ->where('memberships.emailfrequency', '!=', 0)
-                ->receivingOurMails()
-                ->get();
-
-            foreach ($members as $member) {
-                // V1 parity: pick the user's preferred external email and skip
-                // when they have none (only internal-alias addresses).
-                $email = User::find($member->userId)?->email_preferred;
-                if (!$email) {
-                    continue;
-                }
-
-                if (!$dryRun) {
-                    $unsubscribeUrl = "{$userSite}/unsubscribe?email=" . urlencode($email);
-                    // spool() builds the message (incl. MJML render) up front and
-                    // only swallows permanent address failures internally; a
-                    // transient render/build error re-throws. Without this catch
-                    // it would escape the per-member foreach and abort the whole
-                    // digest run — the resilience SafeMail::sendMailable used to
-                    // provide. Skip the one recipient and keep the loop going.
-                    try {
-                        app(\App\Services\EmailSpoolerService::class)->spool(new EventsDigestMail(
-                            recipientEmail: $email,
-                            groupName: $groupRow->nameshort,
-                            events: $eventData,
-                            unsubscribeUrl: $unsubscribeUrl,
-                            userId: $member->userId,
-                        ), $email);
-                    } catch (\Throwable $e) {
-                        Log::warning('Skipping events digest for member after spool failure; continuing loop', [
-                            'email' => $email,
-                            'user_id' => $member->userId,
-                            'group' => $groupRow->nameshort,
-                            'error' => $e->getMessage(),
-                        ]);
-                        continue;
-                    }
-                }
-                $sent++;
             }
 
             if (!$dryRun) {
-                DB::table('groups')->where('id', $groupRow->id)
-                    ->update(['lasteventsroundup' => now()]);
+                $unsubscribeUrl = "{$userSite}/unsubscribe?email=" . urlencode($email);
+                // spool() builds the message (incl. MJML render) up front and only
+                // swallows permanent address failures; a transient render/build
+                // error re-throws. Catch it so one bad recipient doesn't abort the
+                // whole run.
+                try {
+                    app(EmailSpoolerService::class)->spool(new EventsDigestMail(
+                        recipientEmail: $email,
+                        events: $userEvents,
+                        unsubscribeUrl: $unsubscribeUrl,
+                        userId: $user->id,
+                    ), $email);
+                } catch (\Throwable $e) {
+                    Log::warning('Skipping events digest for user after spool failure; continuing loop', [
+                        'email' => $email,
+                        'user_id' => $user->id,
+                        'error' => $e->getMessage(),
+                    ]);
+                    continue;
+                }
             }
+
+            $this->markRoundupSent($user->id, self::DIGEST_MODE, $dryRun);
+            $sent++;
         }
 
-        return ['sent' => $sent, 'groups_processed' => $groupsProcessed];
+        return [
+            'sent' => $sent,
+            'users_processed' => $usersProcessed,
+            'groups_processed' => count($eligibleGroups),
+        ];
+    }
+
+    /**
+     * Build the deduplicated, group-attributed event list for one user.
+     *
+     * An event that belongs to several of the user's groups appears once, with
+     * the names of those groups attached.
+     *
+     * @param array<int,array>  $eventsById     eventid => event data (start-ordered)
+     * @param array<int,int[]>  $groupsByEvent  eventid => [group ids]
+     * @param array<int>        $userGroupIds   the user's eligible group ids
+     * @param array<int,string> $eligibleGroups group id => nameshort
+     * @return array<int,array>
+     */
+    protected function eventsForUser(array $eventsById, array $groupsByEvent, array $userGroupIds, array $eligibleGroups): array
+    {
+        $out = [];
+        foreach ($eventsById as $eid => $eventData) {
+            $shared = array_values(array_intersect($groupsByEvent[$eid] ?? [], $userGroupIds));
+            if (empty($shared)) {
+                continue;
+            }
+            $eventData['groups'] = array_values(array_filter(array_map(
+                fn ($gid) => $eligibleGroups[$gid] ?? null,
+                $shared
+            )));
+            $out[] = $eventData;
+        }
+
+        return $out;
+    }
+
+    /**
+     * Fetch all upcoming events for the eligible groups, returning both the
+     * per-event display data (keyed by id, ordered by start) and the map of
+     * event id => the eligible group ids it belongs to.
+     *
+     * @param array<int> $groupIds
+     * @return array{0: array<int,array>, 1: array<int,int[]>}
+     */
+    protected function fetchUpcomingEvents(array $groupIds, string $userSite): array
+    {
+        $rawEvents = DB::table('communityevents')
+            ->join('communityevents_groups', 'communityevents_groups.eventid', '=', 'communityevents.id')
+            ->join('communityevents_dates', 'communityevents_dates.eventid', '=', 'communityevents.id')
+            ->whereIn('communityevents_groups.groupid', $groupIds)
+            ->where('communityevents_dates.start', '>=', now())
+            ->whereRaw('DATEDIFF(communityevents_dates.start, NOW()) <= ?', [self::HORIZON_DAYS])
+            ->where('communityevents.pending', 0)
+            ->where('communityevents.deleted', 0)
+            ->orderBy('communityevents_dates.start')
+            ->select([
+                'communityevents.id',
+                'communityevents.title',
+                'communityevents.location',
+                'communityevents.description',
+                'communityevents.contactname',
+                'communityevents.contactphone',
+                'communityevents.contactemail',
+                'communityevents.contacturl',
+                'communityevents_dates.start',
+                'communityevents_dates.end',
+            ])
+            ->get()
+            ->unique('id'); // earliest upcoming date per event (rows are start-ordered)
+
+        if ($rawEvents->isEmpty()) {
+            return [[], []];
+        }
+
+        $eventIds = $rawEvents->pluck('id')->all();
+
+        // All eligible-group associations per event (for dedup + attribution).
+        $groupsByEvent = [];
+        DB::table('communityevents_groups')
+            ->whereIn('eventid', $eventIds)
+            ->whereIn('groupid', $groupIds)
+            ->get(['eventid', 'groupid'])
+            ->each(function ($row) use (&$groupsByEvent) {
+                $groupsByEvent[(int) $row->eventid][] = (int) $row->groupid;
+            });
+
+        // First non-archived image per event.
+        $images = DB::table('communityevents_images')
+            ->whereIn('eventid', $eventIds)
+            ->where('archived', 0)
+            ->orderBy('eventid')
+            ->orderBy('id')
+            ->get()
+            ->groupBy('eventid')
+            ->map(fn ($imgs) => $imgs->first());
+
+        // The DB stores HTML-encoded text (e.g. "Soup &amp; Song"). Decode before
+        // passing to Blade so {{ }} escaping yields "&amp;" not double-encoded
+        // "&amp;amp;".
+        $decode = fn (?string $s): ?string =>
+            $s !== null ? html_entity_decode($s, ENT_QUOTES | ENT_HTML5, 'UTF-8') : null;
+
+        $eventsById = [];
+        foreach ($rawEvents as $event) {
+            $start = Carbon::parse($event->start)->setTimezone('Europe/London')->format('D, jS F g:ia');
+            $end = ($event->end && $event->end !== '0000-00-00 00:00:00')
+                ? Carbon::parse($event->end)->setTimezone('Europe/London')->format('g:ia')
+                : null;
+
+            $imageUrl = null;
+            if ($images->has($event->id)) {
+                $img = $images->get($event->id);
+                $mods = $img->externalmods ? json_decode($img->externalmods, true) : [];
+                $imageUrl = $mods['url'] ?? "{$userSite}/communityevent/{$event->id}/image/{$img->id}";
+            }
+
+            $eventsById[(int) $event->id] = [
+                'id'           => (int) $event->id,
+                'title'        => $decode($event->title),
+                'location'     => $decode($event->location),
+                'description'  => $decode($event->description),
+                'contactname'  => $decode($event->contactname),
+                'contactphone' => $event->contactphone,
+                'contactemail' => $event->contactemail,
+                'contacturl'   => $event->contacturl,
+                'start'        => $start,
+                'end'          => $end,
+                'imageUrl'     => $imageUrl,
+                'url'          => "{$userSite}/communityevent/{$event->id}",
+                'groups'       => [],
+            ];
+        }
+
+        return [$eventsById, $groupsByEvent];
     }
 }

--- a/iznik-batch/app/Services/VolunteeringDigestService.php
+++ b/iznik-batch/app/Services/VolunteeringDigestService.php
@@ -123,7 +123,7 @@ class VolunteeringDigestService
      * @param array<int,int[]>  $groupsByOpp     opp id => [group ids] (group-specific opps)
      * @param array<int,bool>   $globalOppIds    opp id => true for opps with no specific group
      * @param array<int>        $userGroupIds
-     * @param array<int,string> $eligibleGroups  group id => nameshort
+     * @param array<int,array{name:string,url:string}> $eligibleGroups  group id => display name + /explore link
      * @return array<int,array>
      */
     protected function opportunitiesForUser(array $oppsById, array $groupsByOpp, array $globalOppIds, array $userGroupIds, array $eligibleGroups): array

--- a/iznik-batch/app/Services/VolunteeringDigestService.php
+++ b/iznik-batch/app/Services/VolunteeringDigestService.php
@@ -3,234 +3,261 @@
 namespace App\Services;
 
 use App\Mail\Volunteering\VolunteeringDigestMail;
-use App\Models\Group;
-use App\Models\Membership;
 use App\Models\User;
+use App\Services\Concerns\BuildsUserRoundups;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\Mail;
 
+/**
+ * Volunteering-opportunity roundup, unified per user.
+ *
+ * Previously one email per group: a member of several groups received several
+ * roundups, and the same opportunity cross-posted to multiple of their groups
+ * (or a national/global opportunity with no specific group) appeared in each
+ * one. This now sends ONE email per user covering opportunities across ALL
+ * their volunteering-enabled groups plus global opportunities, with each shown
+ * once (deduplicated by opportunity id) and annotated with which of the user's
+ * groups it belongs to.
+ */
 class VolunteeringDigestService
 {
-    // Minimum days between roundups per group (V1: DATEDIFF >= 3)
-    public const MIN_INTERVAL_DAYS = 3;
+    use BuildsUserRoundups;
+
+    /** users_digests.mode value used for the per-user cadence guard. */
+    public const DIGEST_MODE = 'volunteering';
 
     /**
-     * Send volunteering opportunity roundup emails to members of all eligible groups.
+     * Send unified volunteering-opportunity roundups.
      *
-     * V1: VolunteeringDigest::send() called for each group in volunteering.php
-     *
-     * @return array{sent: int, groups_processed: int}
+     * @return array{sent: int, users_processed: int, groups_processed: int}
      */
     public function sendVolunteeringDigests(bool $dryRun = false): array
     {
         $userSite = config('freegle.sites.user');
 
         $sent = 0;
-        $groupsProcessed = 0;
+        $usersProcessed = 0;
 
-        // Find Freegle groups due for a volunteering roundup (not sent in last 3 days).
-        $groups = DB::table('groups')
-            ->where('type', Group::TYPE_FREEGLE)
-            ->where('publish', 1)
-            ->where('onhere', 1)
-            ->where(function ($q) {
-                $q->whereNull('lastvolunteeringroundup')
-                    ->orWhereRaw('DATEDIFF(NOW(), lastvolunteeringroundup) >= ?', [self::MIN_INTERVAL_DAYS]);
-            })
-            ->whereRaw("nameshort NOT LIKE '%playground%'")
-            ->select(['id', 'nameshort', 'settings'])
-            ->get();
+        $eligibleGroups = $this->eligibleGroups('volunteering'); // id => nameshort
+        if (empty($eligibleGroups)) {
+            return ['sent' => 0, 'users_processed' => 0, 'groups_processed' => 0];
+        }
+        $groupIds = array_keys($eligibleGroups);
 
-        foreach ($groups as $groupRow) {
-            $group = Group::find($groupRow->id);
-            if (!$group) {
-                continue;
-            }
+        // Pre-fetch active opportunities + their group associations once.
+        // $globalOppIds are opportunities with no specific group (shown to all).
+        [$oppsById, $groupsByOpp, $globalOppIds] = $this->fetchActiveOpportunities($userSite);
 
-            // Skip groups where volunteering setting is disabled (default: enabled).
-            if (!$group->getSetting('volunteering', true)) {
-                if (!$dryRun) {
-                    DB::table('groups')->where('id', $groupRow->id)
-                        ->update(['lastvolunteeringroundup' => now()]);
-                }
-                continue;
-            }
-
-            // Skip closed groups.
-            if ($group->isClosed()) {
-                continue;
-            }
-
-            // Find active volunteering opportunities for this group (or with no specific group).
-            // V1 note: filtering groupid in SQL with IS NULL / NOT IN / NOT EXISTS is unreliable
-            // in MySQL with LEFT JOINs. Fetch all with groupid included and filter in PHP instead.
-            $imagesDomain = config('freegle.images.domain', 'https://images.ilovefreegle.org');
-            $volunteerings = DB::table('volunteering')
-                ->leftJoin('volunteering_groups', 'volunteering_groups.volunteeringid', '=', 'volunteering.id')
-                ->leftJoin('volunteering_images', 'volunteering_images.opportunityid', '=', 'volunteering.id')
-                ->leftJoin('volunteering_dates', 'volunteering_dates.volunteeringid', '=', 'volunteering.id')
-                ->where('volunteering.pending', 0)
-                ->where('volunteering.deleted', 0)
-                ->where('volunteering.expired', 0)
-                ->select([
-                    'volunteering.id',
-                    'volunteering.title',
-                    'volunteering.location',
-                    'volunteering.description',
-                    'volunteering.timecommitment',
-                    'volunteering.online',
-                    'volunteering.contactname',
-                    'volunteering.contactphone',
-                    'volunteering.contactemail',
-                    'volunteering.contacturl',
-                    'volunteering_groups.groupid',
-                    DB::raw('volunteering_images.id AS photo_id'),
-                    DB::raw('volunteering_images.externaluid AS photo_externaluid'),
-                    DB::raw('volunteering_images.externalmods AS photo_externalmods'),
-                    DB::raw('volunteering_dates.applyby AS applyby'),
-                ])
-                ->orderByDesc('volunteering.id')
-                ->get()
-                ->filter(fn ($v) => $v->groupid === null || (int) $v->groupid === (int) $groupRow->id)
-                ->unique('id');
-
-            if ($volunteerings->isEmpty()) {
-                if (!$dryRun) {
-                    DB::table('groups')->where('id', $groupRow->id)
-                        ->update(['lastvolunteeringroundup' => now()]);
-                }
-                continue;
-            }
-
-            $groupsProcessed++;
-
-            // Build structured volunteering data for the template.
-            $tusUploader = config('freegle.tus_uploader', 'https://uploads.ilovefreegle.org:8080');
-            $deliveryUrl = config('freegle.delivery.base_url');
-            $volData = $volunteerings->map(function ($v) use ($userSite, $imagesDomain, $tusUploader, $deliveryUrl) {
-                $photoThumb = null;
-                if ($v->photo_id) {
-                    // Prefer externalmods.url (set for Cloudinary/CDN-hosted images)
-                    $mods = $v->photo_externalmods ? json_decode($v->photo_externalmods, true) : [];
-                    if (!empty($mods['url'])) {
-                        $photoThumb = $mods['url'];
-                    } elseif ($v->photo_externaluid) {
-                        $p = strrpos($v->photo_externaluid, 'freegletusd-');
-                        if ($p !== false) {
-                            $fileId = substr($v->photo_externaluid, $p + strlen('freegletusd-'));
-                            $source = $tusUploader . '/' . $fileId;
-                            $photoThumb = $deliveryUrl
-                                ? $deliveryUrl . '?url=' . urlencode($source) . '&w=400'
-                                : $source;
-                        }
-                    } else {
-                        $photoThumb = "{$imagesDomain}/toimg_{$v->photo_id}.jpg";
-                    }
-                }
-
-                $applyby = $v->applyby
-                    ? Carbon::parse($v->applyby)->setTimezone('Europe/London')->format('D, jS F Y')
-                    : null;
-
-                // The DB stores HTML-encoded text (e.g. "Coffee &amp; Cake").
-                // Decode before passing to templates so Blade's {{ }} escaping
-                // produces correct HTML source ("&amp;") rather than the
-                // double-encoded "&amp;amp;" that the email client would render
-                // as the literal string "&amp;" instead of the intended "&".
-                $decode = fn (?string $s): ?string =>
-                    $s !== null ? html_entity_decode($s, ENT_QUOTES | ENT_HTML5, 'UTF-8') : null;
-
-                return [
-                    'id'             => $v->id,
-                    'title'          => $decode($v->title),
-                    'location'       => $decode($v->location),
-                    'description'    => $decode($v->description),
-                    'timecommitment' => $decode($v->timecommitment),
-                    'online'         => (bool) $v->online,
-                    'contactname'    => $decode($v->contactname),
-                    'contactphone'   => $v->contactphone,
-                    'contactemail'   => $v->contactemail,
-                    'contacturl'     => $v->contacturl,
-                    'photo_thumb'    => $photoThumb,
-                    'applyby'        => $applyby,
-                    'url'            => "{$userSite}/volunteering/{$v->id}",
-                ];
-            })->values()->all();
-
-            // Find members who have volunteering enabled and are not opted out.
-            // Activity / holiday / bouncing / simplemail filters come from
-            // User::scopeReceivingOurMails so this query matches the V1
-            // sendOurMails() criteria. Without those, the V2 dry-run was
-            // 1.34× V1's send count (149k vs 111k).
-            $members = User::query()
-                ->select([
-                    'users.id as userId',
-                    'locations.lat',
-                    'locations.lng',
-                ])
-                ->join('memberships', 'memberships.userid', '=', 'users.id')
-                ->leftJoin('locations', 'locations.id', '=', 'users.lastlocation')
-                ->where('memberships.groupid', $groupRow->id)
-                ->where('memberships.collection', Membership::COLLECTION_APPROVED)
-                ->where('memberships.volunteeringallowed', 1)
-                ->where('memberships.emailfrequency', '!=', 0)
-                ->receivingOurMails()
-                ->get();
-
-            foreach ($members as $member) {
-                $user = User::find($member->userId);
-
-                // V1 parity: skip users whose only emails are on our own per-user
-                // alias domains — those loop back through IncomingMailService
-                // and materialise as chat messages from the noreply system user.
-                $email = $user?->email_preferred;
-                if (!$email) {
-                    continue;
-                }
-
-                $jobAds = collect();
-                if ($member->lat && $member->lng && $user) {
-                    $jobAds = $user->getJobAds()['jobs'];
-                }
-
-                if (!$dryRun) {
-                    $unsubscribeUrl = "{$userSite}/unsubscribe?email=" . urlencode($email);
-                    // spool() builds the message (incl. MJML render) up front and
-                    // only swallows permanent address failures internally; a
-                    // transient render/build error re-throws. Without this catch
-                    // it would escape the per-member foreach and abort the whole
-                    // digest run — the resilience SafeMail::sendMailable used to
-                    // provide. Skip the one recipient and keep the loop going.
-                    try {
-                        app(\App\Services\EmailSpoolerService::class)->spool(new VolunteeringDigestMail(
-                            recipientEmail: $email,
-                            groupName: $groupRow->nameshort,
-                            volunteerings: $volData,
-                            unsubscribeUrl: $unsubscribeUrl,
-                            jobAds: $jobAds,
-                            userId: $member->userId,
-                        ), $email);
-                    } catch (\Throwable $e) {
-                        Log::warning('Skipping volunteering digest for member after spool failure; continuing loop', [
-                            'email' => $email,
-                            'user_id' => $member->userId,
-                            'group' => $groupRow->nameshort,
-                            'error' => $e->getMessage(),
-                        ]);
-                        continue;
-                    }
-                }
-                $sent++;
-            }
-
-            if (!$dryRun) {
-                DB::table('groups')->where('id', $groupRow->id)
-                    ->update(['lastvolunteeringroundup' => now()]);
-            }
+        if (empty($oppsById)) {
+            return ['sent' => 0, 'users_processed' => 0, 'groups_processed' => count($eligibleGroups)];
         }
 
-        return ['sent' => $sent, 'groups_processed' => $groupsProcessed];
+        foreach ($this->eligibleUsers($groupIds, 'volunteeringallowed', self::DIGEST_MODE) as $userRow) {
+            $usersProcessed++;
+
+            $user = User::find($userRow->id);
+            if (!$user) {
+                continue;
+            }
+
+            $email = $user->email_preferred;
+            if (!$email) {
+                continue;
+            }
+
+            $userGroupIds = $this->userGroupIds($user->id, $groupIds, 'volunteeringallowed');
+            if (empty($userGroupIds)) {
+                continue;
+            }
+
+            $userOpps = $this->opportunitiesForUser($oppsById, $groupsByOpp, $globalOppIds, $userGroupIds, $eligibleGroups);
+            if (empty($userOpps)) {
+                continue;
+            }
+
+            // Local job ads are personalised by the user's location;
+            // getJobAds() returns an empty collection when no location is set.
+            $jobAds = $user->getJobAds()['jobs'] ?? collect();
+
+            if (!$dryRun) {
+                $unsubscribeUrl = "{$userSite}/unsubscribe?email=" . urlencode($email);
+                // spool() re-throws transient render/build errors (only permanent
+                // address failures are swallowed). Catch so one bad recipient
+                // doesn't abort the whole run.
+                try {
+                    app(EmailSpoolerService::class)->spool(new VolunteeringDigestMail(
+                        recipientEmail: $email,
+                        volunteerings: $userOpps,
+                        unsubscribeUrl: $unsubscribeUrl,
+                        jobAds: $jobAds,
+                        userId: $user->id,
+                    ), $email);
+                } catch (\Throwable $e) {
+                    Log::warning('Skipping volunteering digest for user after spool failure; continuing loop', [
+                        'email' => $email,
+                        'user_id' => $user->id,
+                        'error' => $e->getMessage(),
+                    ]);
+                    continue;
+                }
+            }
+
+            $this->markRoundupSent($user->id, self::DIGEST_MODE, $dryRun);
+            $sent++;
+        }
+
+        return [
+            'sent' => $sent,
+            'users_processed' => $usersProcessed,
+            'groups_processed' => count($eligibleGroups),
+        ];
+    }
+
+    /**
+     * Build the deduplicated, group-attributed opportunity list for one user:
+     * every global opportunity, plus opportunities shared with any of the user's
+     * volunteering-enabled groups, each shown once.
+     *
+     * @param array<int,array>  $oppsById
+     * @param array<int,int[]>  $groupsByOpp     opp id => [group ids] (group-specific opps)
+     * @param array<int,bool>   $globalOppIds    opp id => true for opps with no specific group
+     * @param array<int>        $userGroupIds
+     * @param array<int,string> $eligibleGroups  group id => nameshort
+     * @return array<int,array>
+     */
+    protected function opportunitiesForUser(array $oppsById, array $groupsByOpp, array $globalOppIds, array $userGroupIds, array $eligibleGroups): array
+    {
+        $out = [];
+        foreach ($oppsById as $oid => $oppData) {
+            $isGlobal = isset($globalOppIds[$oid]);
+            $shared = array_values(array_intersect($groupsByOpp[$oid] ?? [], $userGroupIds));
+
+            if (!$isGlobal && empty($shared)) {
+                continue;
+            }
+
+            $oppData['groups'] = array_values(array_filter(array_map(
+                fn ($gid) => $eligibleGroups[$gid] ?? null,
+                $shared
+            )));
+            $out[] = $oppData;
+        }
+
+        return $out;
+    }
+
+    /**
+     * Fetch all active opportunities, returning per-opportunity display data
+     * (keyed by id), the map of opportunity id => its group ids, and the set of
+     * opportunity ids that have no specific group (global / national).
+     *
+     * @return array{0: array<int,array>, 1: array<int,int[]>, 2: array<int,bool>}
+     */
+    protected function fetchActiveOpportunities(string $userSite): array
+    {
+        $imagesDomain = config('freegle.images.domain', 'https://images.ilovefreegle.org');
+        $tusUploader = config('freegle.tus_uploader', 'https://uploads.ilovefreegle.org:8080');
+        $deliveryUrl = config('freegle.delivery.base_url');
+
+        $rawOpps = DB::table('volunteering')
+            ->leftJoin('volunteering_images', 'volunteering_images.opportunityid', '=', 'volunteering.id')
+            ->leftJoin('volunteering_dates', 'volunteering_dates.volunteeringid', '=', 'volunteering.id')
+            ->where('volunteering.pending', 0)
+            ->where('volunteering.deleted', 0)
+            ->where('volunteering.expired', 0)
+            ->select([
+                'volunteering.id',
+                'volunteering.title',
+                'volunteering.location',
+                'volunteering.description',
+                'volunteering.timecommitment',
+                'volunteering.online',
+                'volunteering.contactname',
+                'volunteering.contactphone',
+                'volunteering.contactemail',
+                'volunteering.contacturl',
+                DB::raw('volunteering_images.id AS photo_id'),
+                DB::raw('volunteering_images.externaluid AS photo_externaluid'),
+                DB::raw('volunteering_images.externalmods AS photo_externalmods'),
+                DB::raw('volunteering_dates.applyby AS applyby'),
+            ])
+            ->orderByDesc('volunteering.id')
+            ->get()
+            ->unique('id');
+
+        if ($rawOpps->isEmpty()) {
+            return [[], [], []];
+        }
+
+        $oppIds = $rawOpps->pluck('id')->all();
+
+        // Every group association for these opportunities (used both to decide
+        // globality — an opportunity with no rows at all is global — and for the
+        // "shared with" attribution).
+        $groupsByOpp = [];
+        DB::table('volunteering_groups')
+            ->whereIn('volunteeringid', $oppIds)
+            ->get(['volunteeringid', 'groupid'])
+            ->each(function ($row) use (&$groupsByOpp) {
+                if ($row->groupid !== null) {
+                    $groupsByOpp[(int) $row->volunteeringid][] = (int) $row->groupid;
+                }
+            });
+
+        $decode = fn (?string $s): ?string =>
+            $s !== null ? html_entity_decode($s, ENT_QUOTES | ENT_HTML5, 'UTF-8') : null;
+
+        $oppsById = [];
+        $globalOppIds = [];
+        foreach ($rawOpps as $v) {
+            $id = (int) $v->id;
+
+            if (empty($groupsByOpp[$id])) {
+                $globalOppIds[$id] = true;
+            }
+
+            $photoThumb = null;
+            if ($v->photo_id) {
+                $mods = $v->photo_externalmods ? json_decode($v->photo_externalmods, true) : [];
+                if (!empty($mods['url'])) {
+                    $photoThumb = $mods['url'];
+                } elseif ($v->photo_externaluid) {
+                    $p = strrpos($v->photo_externaluid, 'freegletusd-');
+                    if ($p !== false) {
+                        $fileId = substr($v->photo_externaluid, $p + strlen('freegletusd-'));
+                        $source = $tusUploader . '/' . $fileId;
+                        $photoThumb = $deliveryUrl
+                            ? $deliveryUrl . '?url=' . urlencode($source) . '&w=400'
+                            : $source;
+                    }
+                } else {
+                    $photoThumb = "{$imagesDomain}/toimg_{$v->photo_id}.jpg";
+                }
+            }
+
+            $applyby = $v->applyby
+                ? Carbon::parse($v->applyby)->setTimezone('Europe/London')->format('D, jS F Y')
+                : null;
+
+            $oppsById[$id] = [
+                'id'             => $id,
+                'title'          => $decode($v->title),
+                'location'       => $decode($v->location),
+                'description'    => $decode($v->description),
+                'timecommitment' => $decode($v->timecommitment),
+                'online'         => (bool) $v->online,
+                'contactname'    => $decode($v->contactname),
+                'contactphone'   => $v->contactphone,
+                'contactemail'   => $v->contactemail,
+                'contacturl'     => $v->contacturl,
+                'photo_thumb'    => $photoThumb,
+                'applyby'        => $applyby,
+                'url'            => "{$userSite}/volunteering/{$id}",
+                'groups'         => [],
+            ];
+        }
+
+        return [$oppsById, $groupsByOpp, $globalOppIds];
     }
 }

--- a/iznik-batch/database/migrations/2026_06_11_000001_add_roundup_modes_to_users_digests.php
+++ b/iznik-batch/database/migrations/2026_06_11_000001_add_roundup_modes_to_users_digests.php
@@ -1,0 +1,49 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Extend users_digests.mode to cover the unified community-events and
+ * volunteering-opportunity roundups.
+ *
+ * These roundups become user-centric (one combined email per user across all
+ * their groups, deduplicated) like the message digest, so they need the same
+ * per-user "last sent" tracking the table already provides for digests. We
+ * reuse users_digests rather than the per-group groups.lasteventsroundup /
+ * groups.lastvolunteeringroundup cursors, which no longer map to a per-user
+ * send.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (!Schema::hasTable('users_digests')) {
+            return;
+        }
+
+        DB::statement(
+            "ALTER TABLE users_digests
+             MODIFY COLUMN mode ENUM('immediate','daily','events','volunteering')
+             NOT NULL DEFAULT 'daily' COMMENT 'Digest mode'"
+        );
+    }
+
+    public function down(): void
+    {
+        if (!Schema::hasTable('users_digests')) {
+            return;
+        }
+
+        // Drop any rows using the new modes first so the narrower enum applies
+        // cleanly.
+        DB::table('users_digests')->whereIn('mode', ['events', 'volunteering'])->delete();
+
+        DB::statement(
+            "ALTER TABLE users_digests
+             MODIFY COLUMN mode ENUM('immediate','daily')
+             NOT NULL DEFAULT 'daily' COMMENT 'Digest mode'"
+        );
+    }
+};

--- a/iznik-batch/resources/views/emails/mjml/event/events-digest.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/event/events-digest.blade.php
@@ -1,5 +1,5 @@
 <mjml>
-  @include('emails.mjml.partials.head', ['preview' => 'Community events in ' . $groupName])
+  @include('emails.mjml.partials.head', ['preview' => 'Upcoming community events near you'])
 
   <mj-body background-color="#f4f4f4">
 
@@ -11,7 +11,7 @@
           Community Event Roundup
         </mj-text>
         <mj-text font-size="14px" color="#555555">
-          Here are upcoming community events for {{ $groupName }}.
+          Here are upcoming community events from your Freegle communities.
           If you'd like to add one, <a href="{{ $userSite }}/communityevents">click here</a>.
         </mj-text>
       </mj-column>
@@ -44,6 +44,11 @@
           {{ $event['description'] }}
         </mj-text>
         @endif
+        @if (!empty($event['groups']))
+        <mj-text font-size="11px" color="#999999" padding="0 0 4px">
+          Shared with {{ implode(', ', $event['groups']) }}
+        </mj-text>
+        @endif
       </mj-column>
       <mj-column width="40%">
         <mj-image src="{{ $event['imageUrl'] }}" alt="{{ $event['title'] }}"
@@ -69,6 +74,11 @@
         @if (!empty($event['description']))
         <mj-text font-size="13px" color="#333333" padding="0 0 6px" line-height="1.5">
           {{ $event['description'] }}
+        </mj-text>
+        @endif
+        @if (!empty($event['groups']))
+        <mj-text font-size="11px" color="#999999" padding="0 0 4px">
+          Shared with {{ implode(', ', $event['groups']) }}
         </mj-text>
         @endif
       </mj-column>

--- a/iznik-batch/resources/views/emails/mjml/event/events-digest.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/event/events-digest.blade.php
@@ -45,8 +45,14 @@
         </mj-text>
         @endif
         @if (!empty($event['groups']))
+        @php
+        $groupLinks = array_map(
+            fn ($g) => '<a href="' . e($g['url']) . '" style="color: #999999; text-decoration: underline;">' . e($g['name']) . '</a>',
+            $event['groups']
+        );
+        @endphp
         <mj-text font-size="11px" color="#999999" padding="0 0 4px">
-          Shared with {{ implode(', ', $event['groups']) }}
+          Posted on {!! implode(', ', $groupLinks) !!}
         </mj-text>
         @endif
       </mj-column>
@@ -77,8 +83,14 @@
         </mj-text>
         @endif
         @if (!empty($event['groups']))
+        @php
+        $groupLinks = array_map(
+            fn ($g) => '<a href="' . e($g['url']) . '" style="color: #999999; text-decoration: underline;">' . e($g['name']) . '</a>',
+            $event['groups']
+        );
+        @endphp
         <mj-text font-size="11px" color="#999999" padding="0 0 4px">
-          Shared with {{ implode(', ', $event['groups']) }}
+          Posted on {!! implode(', ', $groupLinks) !!}
         </mj-text>
         @endif
       </mj-column>

--- a/iznik-batch/resources/views/emails/mjml/volunteering/digest.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/volunteering/digest.blade.php
@@ -1,5 +1,5 @@
 <mjml>
-  @include('emails.mjml.partials.head', ['preview' => 'Volunteer opportunities in ' . $groupName])
+  @include('emails.mjml.partials.head', ['preview' => 'Volunteer opportunities near you'])
 
   <mj-body background-color="#f4f4f4">
 
@@ -11,7 +11,7 @@
           Volunteer Opportunity Roundup
         </mj-text>
         <mj-text font-size="14px" color="#555555">
-          Charities, community organisations and good causes in {{ $groupName }} are looking for helpers.
+          Charities, community organisations and good causes near your Freegle communities are looking for helpers.
           If you'd like to add one, <a href="{{ $userSite }}/volunteering">click here</a>.
         </mj-text>
       </mj-column>
@@ -45,6 +45,11 @@
           {!! nl2br(e(mb_strlen($vol['description']) > 300 ? mb_substr($vol['description'], 0, 300) . '…' : $vol['description'])) !!}
         </mj-text>
         @endif
+        @if (!empty($vol['groups']))
+        <mj-text font-size="11px" color="#999999" padding="0 0 4px">
+          Shared with {{ implode(', ', $vol['groups']) }}
+        </mj-text>
+        @endif
       </mj-column>
       <mj-column width="40%">
         <mj-image src="{{ $vol['photo_thumb'] }}" alt="{{ $vol['title'] }}"
@@ -71,6 +76,11 @@
         @if (!empty($vol['description']))
         <mj-text font-size="13px" color="#333333" padding="0 0 6px" line-height="1.5">
           {!! nl2br(e(mb_strlen($vol['description']) > 300 ? mb_substr($vol['description'], 0, 300) . '…' : $vol['description'])) !!}
+        </mj-text>
+        @endif
+        @if (!empty($vol['groups']))
+        <mj-text font-size="11px" color="#999999" padding="0 0 4px">
+          Shared with {{ implode(', ', $vol['groups']) }}
         </mj-text>
         @endif
       </mj-column>

--- a/iznik-batch/resources/views/emails/mjml/volunteering/digest.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/volunteering/digest.blade.php
@@ -46,8 +46,14 @@
         </mj-text>
         @endif
         @if (!empty($vol['groups']))
+        @php
+        $groupLinks = array_map(
+            fn ($g) => '<a href="' . e($g['url']) . '" style="color: #999999; text-decoration: underline;">' . e($g['name']) . '</a>',
+            $vol['groups']
+        );
+        @endphp
         <mj-text font-size="11px" color="#999999" padding="0 0 4px">
-          Shared with {{ implode(', ', $vol['groups']) }}
+          Posted on {!! implode(', ', $groupLinks) !!}
         </mj-text>
         @endif
       </mj-column>
@@ -79,8 +85,14 @@
         </mj-text>
         @endif
         @if (!empty($vol['groups']))
+        @php
+        $groupLinks = array_map(
+            fn ($g) => '<a href="' . e($g['url']) . '" style="color: #999999; text-decoration: underline;">' . e($g['name']) . '</a>',
+            $vol['groups']
+        );
+        @endphp
         <mj-text font-size="11px" color="#999999" padding="0 0 4px">
-          Shared with {{ implode(', ', $vol['groups']) }}
+          Posted on {!! implode(', ', $groupLinks) !!}
         </mj-text>
         @endif
       </mj-column>

--- a/iznik-batch/routes/console.php
+++ b/iznik-batch/routes/console.php
@@ -897,7 +897,10 @@ Schedule::command('messages:update-index')
 //     ->sendOutputTo(cronLog('donations:update-giftaid'))
 //     ->runInBackground();
 
-// Volunteering opportunity roundup — weekly to group members.
+// Volunteering opportunity roundup — weekly, ONE combined email per user
+// covering every volunteering-enabled group they belong to (plus global
+// opportunities), deduplicated. A per-user cadence guard (users_digests
+// mode='volunteering', 3-day minimum) makes a same-week re-run a no-op.
 // V1: cron/volunteering.php (weekly Mon 23:00, two mod-2 shards on bulk3 —
 // disabled there 2026-05-12 when this Laravel command took over).
 Schedule::command('mail:volunteering-digest')
@@ -906,7 +909,11 @@ Schedule::command('mail:volunteering-digest')
     ->sendOutputTo(cronLog('mail:volunteering-digest'))
     ->runInBackground();
 
-// Community events roundup — weekly to group members.
+// Community events roundup — weekly, ONE combined email per user covering
+// every event-enabled group they belong to, deduplicated (an event
+// cross-posted to several of the user's groups appears once). A per-user
+// cadence guard (users_digests mode='events', 3-day minimum) makes a
+// same-week re-run a no-op.
 // V1: cron/events.php (weekly Thu 23:00, two mod-2 shards on bulk3 —
 // disabled there 2026-05-12). Single-threaded here; the streaming /
 // activity-filtered query keeps the working set well below V1's count.

--- a/iznik-batch/tests/Feature/Mail/EventsDigestCommandTest.php
+++ b/iznik-batch/tests/Feature/Mail/EventsDigestCommandTest.php
@@ -4,7 +4,6 @@ namespace Tests\Feature\Mail;
 
 use App\Mail\Event\EventsDigestMail;
 use App\Models\Group;
-use App\Models\Membership;
 use App\Services\EmailSpoolerService;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Mail;
@@ -16,12 +15,13 @@ class EventsDigestCommandTest extends TestCase
     {
         parent::setUp();
 
-        // EventsDigestService queries communityevents globally (no WHERE groupid in SQL).
-        // Rows from parallel test classes can slip through DatabaseTransactions isolation.
-        // Delete inside the current transaction so leaked rows are hidden without affecting
-        // other test classes (the DELETE is rolled back with this test's transaction).
+        // EventsDigestService queries communityevents / groups / users globally.
+        // Rows from parallel test classes can slip through DatabaseTransactions
+        // isolation. Delete inside the current transaction so leaked rows are
+        // hidden without affecting other test classes (the DELETE rolls back with
+        // this test's transaction).
         DB::statement('SET FOREIGN_KEY_CHECKS=0');
-        foreach (['communityevents_images', 'communityevents_dates', 'communityevents_groups', 'communityevents', 'memberships', 'users_emails', 'users', 'groups'] as $table) {
+        foreach (['communityevents_images', 'communityevents_dates', 'communityevents_groups', 'communityevents', 'users_digests', 'memberships', 'users_emails', 'users', 'groups'] as $table) {
             DB::table($table)->delete();
         }
         DB::statement('SET FOREIGN_KEY_CHECKS=1');
@@ -52,6 +52,14 @@ class EventsDigestCommandTest extends TestCase
         return $eventId;
     }
 
+    private function linkEventToGroup(int $eventId, int $groupId): void
+    {
+        DB::table('communityevents_groups')->insert([
+            'eventid' => $eventId,
+            'groupid' => $groupId,
+        ]);
+    }
+
     private function addEventImage(int $eventId, ?string $externalUrl = null): int
     {
         return DB::table('communityevents_images')->insertGetId([
@@ -59,6 +67,15 @@ class EventsDigestCommandTest extends TestCase
             'contenttype' => 'image/jpeg',
             'archived'    => 0,
             'externalmods' => $externalUrl ? json_encode(['url' => $externalUrl]) : null,
+        ]);
+    }
+
+    private function setLastSent(int $userId, \DateTimeInterface|string $when): void
+    {
+        DB::table('users_digests')->insert([
+            'userid'   => $userId,
+            'mode'     => 'events',
+            'lastsent' => $when,
         ]);
     }
 
@@ -86,13 +103,12 @@ class EventsDigestCommandTest extends TestCase
 
         // No events created for the group
 
-        $this->artisan('mail:events-digest')
-            ->assertExitCode(0);
+        $this->artisan('mail:events-digest')->assertExitCode(0);
 
         Mail::assertNothingSent();
     }
 
-    public function test_sends_to_members_with_events_enabled(): void
+    public function test_sends_one_email_per_user_with_events_enabled(): void
     {
         Mail::fake();
 
@@ -100,16 +116,10 @@ class EventsDigestCommandTest extends TestCase
         $this->createEvent($group->id);
 
         $member1 = $this->createTestUser();
-        $this->createMembership($member1, $group, [
-            'eventsallowed' => 1,
-            'emailfrequency' => 24,
-        ]);
+        $this->createMembership($member1, $group, ['eventsallowed' => 1, 'emailfrequency' => 24]);
 
         $member2 = $this->createTestUser();
-        $this->createMembership($member2, $group, [
-            'eventsallowed' => 1,
-            'emailfrequency' => 24,
-        ]);
+        $this->createMembership($member2, $group, ['eventsallowed' => 1, 'emailfrequency' => 24]);
 
         $this->artisan('mail:events-digest')
             ->expectsOutputToContain('Sent 2 email(s)')
@@ -118,26 +128,77 @@ class EventsDigestCommandTest extends TestCase
         Mail::assertSentCount(2);
     }
 
-    public function test_spool_failure_for_one_member_does_not_abort_digest(): void
+    public function test_one_combined_email_covers_all_a_users_groups(): void
     {
-        // The spooler throws on the first recipient (e.g. a transient MJML
-        // render error, which spool() re-throws because it isn't a permanent
-        // address failure). The per-member loop must skip that recipient and
-        // keep going — not let the exception escape and abort the whole run.
+        // A user in two event-enabled groups, each with its own event, gets ONE
+        // email containing BOTH events — not one email per group.
+        Mail::fake();
+
+        $group1 = $this->createTestGroup();
+        $group2 = $this->createTestGroup();
+        $this->createEvent($group1->id, 'Group One Event');
+        $this->createEvent($group2->id, 'Group Two Event');
+
+        $user = $this->createTestUser();
+        $this->createMembership($user, $group1, ['eventsallowed' => 1, 'emailfrequency' => 24]);
+        $this->createMembership($user, $group2, ['eventsallowed' => 1, 'emailfrequency' => 24]);
+
+        $this->artisan('mail:events-digest')
+            ->expectsOutputToContain('Sent 1 email(s)')
+            ->assertExitCode(0);
+
+        Mail::assertSentCount(1);
+        Mail::assertSent(EventsDigestMail::class, function (EventsDigestMail $mail) {
+            return count($mail->events) === 2;
+        });
+    }
+
+    public function test_event_cross_posted_to_several_of_users_groups_appears_once(): void
+    {
+        // The same event shared with two of the user's groups must appear ONCE
+        // (deduplicated by event id), annotated with both group names.
+        Mail::fake();
+
+        $group1 = $this->createTestGroup();
+        $group2 = $this->createTestGroup();
+
+        $user = $this->createTestUser();
+        $this->createMembership($user, $group1, ['eventsallowed' => 1, 'emailfrequency' => 24]);
+        $this->createMembership($user, $group2, ['eventsallowed' => 1, 'emailfrequency' => 24]);
+
+        $eventId = $this->createEvent($group1->id, 'Cross-posted Event');
+        $this->linkEventToGroup($eventId, $group2->id);
+
+        $this->artisan('mail:events-digest')
+            ->expectsOutputToContain('Sent 1 email(s)')
+            ->assertExitCode(0);
+
+        Mail::assertSentCount(1);
+        Mail::assertSent(EventsDigestMail::class, function (EventsDigestMail $mail) use ($group1, $group2) {
+            if (count($mail->events) !== 1) {
+                return false;
+            }
+            $groups = $mail->events[0]['groups'] ?? [];
+            sort($groups);
+            $expected = [$group1->nameshort, $group2->nameshort];
+            sort($expected);
+            return $groups === $expected;
+        });
+    }
+
+    public function test_spool_failure_for_one_user_does_not_abort_digest(): void
+    {
+        // The spooler throws on the first recipient (e.g. a transient MJML render
+        // error, which spool() re-throws). The per-user loop must skip that
+        // recipient and keep going — not let the exception abort the whole run.
         $group = $this->createTestGroup();
         $this->createEvent($group->id);
 
         $member1 = $this->createTestUser();
-        $this->createMembership($member1, $group, [
-            'eventsallowed' => 1,
-            'emailfrequency' => 24,
-        ]);
+        $this->createMembership($member1, $group, ['eventsallowed' => 1, 'emailfrequency' => 24]);
 
         $member2 = $this->createTestUser();
-        $this->createMembership($member2, $group, [
-            'eventsallowed' => 1,
-            'emailfrequency' => 24,
-        ]);
+        $this->createMembership($member2, $group, ['eventsallowed' => 1, 'emailfrequency' => 24]);
 
         $calls = 0;
         $spooler = \Mockery::mock(EmailSpoolerService::class);
@@ -150,13 +211,11 @@ class EventsDigestCommandTest extends TestCase
         });
         $this->app->instance(EmailSpoolerService::class, $spooler);
 
-        // Exits cleanly and reports one successful send (the failed member is
-        // skipped, not counted). Without the try/catch this would throw.
         $this->artisan('mail:events-digest')
             ->expectsOutputToContain('Sent 1 email(s)')
             ->assertExitCode(0);
 
-        $this->assertSame(2, $calls, 'Both members should have been attempted');
+        $this->assertSame(2, $calls, 'Both users should have been attempted');
     }
 
     public function test_skips_members_with_events_disabled(): void
@@ -167,16 +226,10 @@ class EventsDigestCommandTest extends TestCase
         $this->createEvent($group->id);
 
         $memberOptedIn = $this->createTestUser();
-        $this->createMembership($memberOptedIn, $group, [
-            'eventsallowed' => 1,
-            'emailfrequency' => 24,
-        ]);
+        $this->createMembership($memberOptedIn, $group, ['eventsallowed' => 1, 'emailfrequency' => 24]);
 
         $memberOptedOut = $this->createTestUser();
-        $this->createMembership($memberOptedOut, $group, [
-            'eventsallowed' => 0,
-            'emailfrequency' => 24,
-        ]);
+        $this->createMembership($memberOptedOut, $group, ['eventsallowed' => 0, 'emailfrequency' => 24]);
 
         $this->artisan('mail:events-digest')
             ->expectsOutputToContain('Sent 1 email(s)')
@@ -193,16 +246,10 @@ class EventsDigestCommandTest extends TestCase
         $this->createEvent($group->id);
 
         $memberActive = $this->createTestUser();
-        $this->createMembership($memberActive, $group, [
-            'eventsallowed' => 1,
-            'emailfrequency' => 24,
-        ]);
+        $this->createMembership($memberActive, $group, ['eventsallowed' => 1, 'emailfrequency' => 24]);
 
         $memberOptedOut = $this->createTestUser();
-        $this->createMembership($memberOptedOut, $group, [
-            'eventsallowed' => 1,
-            'emailfrequency' => 0,
-        ]);
+        $this->createMembership($memberOptedOut, $group, ['eventsallowed' => 1, 'emailfrequency' => 0]);
 
         $this->artisan('mail:events-digest')
             ->expectsOutputToContain('Sent 1 email(s)')
@@ -219,10 +266,7 @@ class EventsDigestCommandTest extends TestCase
         $this->createEvent($group->id);
 
         $deletedUser = $this->createTestUser(['deleted' => now()]);
-        $this->createMembership($deletedUser, $group, [
-            'eventsallowed' => 1,
-            'emailfrequency' => 24,
-        ]);
+        $this->createMembership($deletedUser, $group, ['eventsallowed' => 1, 'emailfrequency' => 24]);
 
         $this->artisan('mail:events-digest')
             ->expectsOutputToContain('Sent 0 email(s)')
@@ -231,45 +275,36 @@ class EventsDigestCommandTest extends TestCase
         Mail::assertNothingSent();
     }
 
-    public function test_skips_group_recently_sent(): void
+    public function test_skips_user_recently_sent(): void
     {
         Mail::fake();
 
         $group = $this->createTestGroup();
-        // Mark as sent only 1 day ago (< 3 days threshold)
-        DB::table('groups')->where('id', $group->id)
-            ->update(['lasteventsroundup' => now()->subDays(1)]);
-
         $this->createEvent($group->id);
 
         $member = $this->createTestUser();
-        $this->createMembership($member, $group, [
-            'eventsallowed' => 1,
-            'emailfrequency' => 24,
-        ]);
+        $this->createMembership($member, $group, ['eventsallowed' => 1, 'emailfrequency' => 24]);
 
-        $this->artisan('mail:events-digest')
-            ->assertExitCode(0);
+        // Sent only 1 day ago (< 3-day threshold) — must be skipped.
+        $this->setLastSent($member->id, now()->subDays(1));
+
+        $this->artisan('mail:events-digest')->assertExitCode(0);
 
         Mail::assertNothingSent();
     }
 
-    public function test_processes_group_not_sent_in_3_days(): void
+    public function test_processes_user_not_sent_in_3_days(): void
     {
         Mail::fake();
 
         $group = $this->createTestGroup();
-        // Last sent 4 days ago (>= 3 days threshold)
-        DB::table('groups')->where('id', $group->id)
-            ->update(['lasteventsroundup' => now()->subDays(4)]);
-
         $this->createEvent($group->id);
 
         $member = $this->createTestUser();
-        $this->createMembership($member, $group, [
-            'eventsallowed' => 1,
-            'emailfrequency' => 24,
-        ]);
+        $this->createMembership($member, $group, ['eventsallowed' => 1, 'emailfrequency' => 24]);
+
+        // Last sent 4 days ago (>= 3-day threshold) — must be processed.
+        $this->setLastSent($member->id, now()->subDays(4));
 
         $this->artisan('mail:events-digest')
             ->expectsOutputToContain('Sent 1 email(s)')
@@ -278,7 +313,7 @@ class EventsDigestCommandTest extends TestCase
         Mail::assertSentCount(1);
     }
 
-    public function test_updates_lasteventsroundup_after_sending(): void
+    public function test_records_lastsent_per_user_after_sending(): void
     {
         Mail::fake();
 
@@ -286,16 +321,15 @@ class EventsDigestCommandTest extends TestCase
         $this->createEvent($group->id);
 
         $member = $this->createTestUser();
-        $this->createMembership($member, $group, [
-            'eventsallowed' => 1,
-            'emailfrequency' => 24,
-        ]);
+        $this->createMembership($member, $group, ['eventsallowed' => 1, 'emailfrequency' => 24]);
 
-        $this->artisan('mail:events-digest')
-            ->assertExitCode(0);
+        $this->artisan('mail:events-digest')->assertExitCode(0);
 
         $this->assertNotNull(
-            DB::table('groups')->where('id', $group->id)->value('lasteventsroundup')
+            DB::table('users_digests')
+                ->where('userid', $member->id)
+                ->where('mode', 'events')
+                ->value('lastsent')
         );
     }
 
@@ -304,17 +338,12 @@ class EventsDigestCommandTest extends TestCase
         Mail::fake();
 
         $group = $this->createTestGroup();
-        // Event 35 days from now — outside the 30-day window
         $this->createEvent($group->id, 'Far Future Event', 35);
 
         $member = $this->createTestUser();
-        $this->createMembership($member, $group, [
-            'eventsallowed' => 1,
-            'emailfrequency' => 24,
-        ]);
+        $this->createMembership($member, $group, ['eventsallowed' => 1, 'emailfrequency' => 24]);
 
-        $this->artisan('mail:events-digest')
-            ->assertExitCode(0);
+        $this->artisan('mail:events-digest')->assertExitCode(0);
 
         Mail::assertNothingSent();
     }
@@ -324,17 +353,12 @@ class EventsDigestCommandTest extends TestCase
         Mail::fake();
 
         $group = $this->createTestGroup();
-        // Event 1 day in the past — should not be included
         $this->createEvent($group->id, 'Past Event', -1);
 
         $member = $this->createTestUser();
-        $this->createMembership($member, $group, [
-            'eventsallowed' => 1,
-            'emailfrequency' => 24,
-        ]);
+        $this->createMembership($member, $group, ['eventsallowed' => 1, 'emailfrequency' => 24]);
 
-        $this->artisan('mail:events-digest')
-            ->assertExitCode(0);
+        $this->artisan('mail:events-digest')->assertExitCode(0);
 
         Mail::assertNothingSent();
     }
@@ -347,18 +371,14 @@ class EventsDigestCommandTest extends TestCase
         $this->createEvent($group->id);
 
         $member = $this->createTestUser();
-        $this->createMembership($member, $group, [
-            'eventsallowed' => 1,
-            'emailfrequency' => 24,
-        ]);
+        $this->createMembership($member, $group, ['eventsallowed' => 1, 'emailfrequency' => 24]);
 
-        $this->artisan('mail:events-digest')
-            ->assertExitCode(0);
+        $this->artisan('mail:events-digest')->assertExitCode(0);
 
         Mail::assertNothingSent();
     }
 
-    public function test_dry_run_does_not_send_emails(): void
+    public function test_dry_run_does_not_send_or_record(): void
     {
         Mail::fake();
 
@@ -366,10 +386,7 @@ class EventsDigestCommandTest extends TestCase
         $this->createEvent($group->id);
 
         $member = $this->createTestUser();
-        $this->createMembership($member, $group, [
-            'eventsallowed' => 1,
-            'emailfrequency' => 24,
-        ]);
+        $this->createMembership($member, $group, ['eventsallowed' => 1, 'emailfrequency' => 24]);
 
         $this->artisan('mail:events-digest', ['--dry-run' => true])
             ->expectsOutputToContain('DRY RUN')
@@ -378,9 +395,9 @@ class EventsDigestCommandTest extends TestCase
 
         Mail::assertNothingSent();
 
-        // Should not update lasteventsroundup in dry-run
+        // Dry-run must not record a per-user lastsent.
         $this->assertNull(
-            DB::table('groups')->where('id', $group->id)->value('lasteventsroundup')
+            DB::table('users_digests')->where('userid', $member->id)->where('mode', 'events')->value('lastsent')
         );
     }
 
@@ -395,13 +412,9 @@ class EventsDigestCommandTest extends TestCase
         $this->createEvent($group->id);
 
         $member = $this->createTestUser();
-        $this->createMembership($member, $group, [
-            'eventsallowed' => 1,
-            'emailfrequency' => 24,
-        ]);
+        $this->createMembership($member, $group, ['eventsallowed' => 1, 'emailfrequency' => 24]);
 
-        $this->artisan('mail:events-digest')
-            ->assertExitCode(0);
+        $this->artisan('mail:events-digest')->assertExitCode(0);
 
         Mail::assertNothingSent();
     }
@@ -433,7 +446,6 @@ class EventsDigestCommandTest extends TestCase
         $this->createMembership($member, $group, ['eventsallowed' => 1, 'emailfrequency' => 24]);
 
         $this->createEvent($group->id, 'No Photo Event');
-        // No addEventImage call
 
         $this->artisan('mail:events-digest')->assertExitCode(0);
 

--- a/iznik-batch/tests/Feature/Mail/EventsDigestCommandTest.php
+++ b/iznik-batch/tests/Feature/Mail/EventsDigestCommandTest.php
@@ -178,11 +178,21 @@ class EventsDigestCommandTest extends TestCase
             if (count($mail->events) !== 1) {
                 return false;
             }
+            // Each group is a ['name' => , 'url' => ] pair for the "Posted on
+            // <group>" byline: the friendly name plus its /explore link.
             $groups = $mail->events[0]['groups'] ?? [];
-            sort($groups);
-            $expected = [$group1->nameshort, $group2->nameshort];
-            sort($expected);
-            return $groups === $expected;
+            $names = array_column($groups, 'name');
+            sort($names);
+            $expectedNames = [$group1->namefull, $group2->namefull];
+            sort($expectedNames);
+            if ($names !== $expectedNames) {
+                return false;
+            }
+
+            $urls = array_column($groups, 'url');
+            return collect([$group1, $group2])->every(
+                fn ($g) => collect($urls)->contains(fn ($u) => str_contains($u, '/explore/' . $g->nameshort))
+            );
         });
     }
 

--- a/iznik-batch/tests/Feature/Mail/VolunteeringDigestCommandTest.php
+++ b/iznik-batch/tests/Feature/Mail/VolunteeringDigestCommandTest.php
@@ -160,11 +160,21 @@ class VolunteeringDigestCommandTest extends TestCase
             if (count($mail->volunteerings) !== 1) {
                 return false;
             }
+            // Each group is a ['name' => , 'url' => ] pair for the "Posted on
+            // <group>" byline: the friendly name plus its /explore link.
             $groups = $mail->volunteerings[0]['groups'] ?? [];
-            sort($groups);
-            $expected = [$group1->nameshort, $group2->nameshort];
-            sort($expected);
-            return $groups === $expected;
+            $names = array_column($groups, 'name');
+            sort($names);
+            $expectedNames = [$group1->namefull, $group2->namefull];
+            sort($expectedNames);
+            if ($names !== $expectedNames) {
+                return false;
+            }
+
+            $urls = array_column($groups, 'url');
+            return collect([$group1, $group2])->every(
+                fn ($g) => collect($urls)->contains(fn ($u) => str_contains($u, '/explore/' . $g->nameshort))
+            );
         });
     }
 

--- a/iznik-batch/tests/Feature/Mail/VolunteeringDigestCommandTest.php
+++ b/iznik-batch/tests/Feature/Mail/VolunteeringDigestCommandTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Feature\Mail;
 
+use App\Mail\Volunteering\VolunteeringDigestMail;
 use App\Models\Group;
-use App\Models\Membership;
 use App\Services\EmailSpoolerService;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Mail;
@@ -15,18 +15,19 @@ class VolunteeringDigestCommandTest extends TestCase
     {
         parent::setUp();
 
-        // VolunteeringDigestService queries volunteerings globally (no WHERE groupid in SQL).
-        // Rows from parallel test classes can slip through DatabaseTransactions isolation.
-        // Delete inside the current transaction so leaked rows are hidden without affecting
-        // other test classes (the DELETE is rolled back with this test's transaction).
+        // VolunteeringDigestService queries volunteering / groups / users globally.
+        // Rows from parallel test classes can slip through DatabaseTransactions
+        // isolation. Delete inside the current transaction so leaked rows are
+        // hidden without affecting other test classes (the DELETE rolls back with
+        // this test's transaction).
         DB::statement('SET FOREIGN_KEY_CHECKS=0');
-        foreach (['volunteering_dates', 'volunteering_images', 'volunteering_groups', 'volunteering', 'memberships', 'users_emails', 'users', 'groups'] as $table) {
+        foreach (['volunteering_dates', 'volunteering_images', 'volunteering_groups', 'volunteering', 'users_digests', 'memberships', 'users_emails', 'users', 'groups'] as $table) {
             DB::table($table)->delete();
         }
         DB::statement('SET FOREIGN_KEY_CHECKS=1');
     }
 
-    private function createVolunteering(int $groupId = null, string $title = 'Test Volunteering'): int
+    private function createVolunteering(?int $groupId = null, string $title = 'Test Volunteering'): int
     {
         $volId = DB::table('volunteering')->insertGetId([
             'title' => $title,
@@ -48,6 +49,23 @@ class VolunteeringDigestCommandTest extends TestCase
         return $volId;
     }
 
+    private function linkVolunteeringToGroup(int $volId, int $groupId): void
+    {
+        DB::table('volunteering_groups')->insert([
+            'volunteeringid' => $volId,
+            'groupid' => $groupId,
+        ]);
+    }
+
+    private function setLastSent(int $userId, \DateTimeInterface|string $when): void
+    {
+        DB::table('users_digests')->insert([
+            'userid'   => $userId,
+            'mode'     => 'volunteering',
+            'lastsent' => $when,
+        ]);
+    }
+
     public function test_smoke_no_groups(): void
     {
         Mail::fake();
@@ -65,20 +83,14 @@ class VolunteeringDigestCommandTest extends TestCase
 
         $group = $this->createTestGroup();
         $member = $this->createTestUser();
-        $this->createMembership($member, $group, [
-            'volunteeringallowed' => 1,
-            'emailfrequency' => 24,
-        ]);
+        $this->createMembership($member, $group, ['volunteeringallowed' => 1, 'emailfrequency' => 24]);
 
-        // No volunteering created for the group
-
-        $this->artisan('mail:volunteering-digest')
-            ->assertExitCode(0);
+        $this->artisan('mail:volunteering-digest')->assertExitCode(0);
 
         Mail::assertNothingSent();
     }
 
-    public function test_sends_to_members_with_volunteering_enabled(): void
+    public function test_sends_one_email_per_user_with_volunteering_enabled(): void
     {
         Mail::fake();
 
@@ -86,16 +98,10 @@ class VolunteeringDigestCommandTest extends TestCase
         $this->createVolunteering($group->id);
 
         $member1 = $this->createTestUser();
-        $this->createMembership($member1, $group, [
-            'volunteeringallowed' => 1,
-            'emailfrequency' => 24,
-        ]);
+        $this->createMembership($member1, $group, ['volunteeringallowed' => 1, 'emailfrequency' => 24]);
 
         $member2 = $this->createTestUser();
-        $this->createMembership($member2, $group, [
-            'volunteeringallowed' => 1,
-            'emailfrequency' => 24,
-        ]);
+        $this->createMembership($member2, $group, ['volunteeringallowed' => 1, 'emailfrequency' => 24]);
 
         $this->artisan('mail:volunteering-digest')
             ->expectsOutputToContain('Sent 2 email(s)')
@@ -104,26 +110,74 @@ class VolunteeringDigestCommandTest extends TestCase
         Mail::assertSentCount(2);
     }
 
-    public function test_spool_failure_for_one_member_does_not_abort_digest(): void
+    public function test_one_combined_email_covers_all_a_users_groups(): void
     {
-        // The spooler throws on the first recipient (e.g. a transient MJML
-        // render error, which spool() re-throws because it isn't a permanent
-        // address failure). The per-member loop must skip that recipient and
-        // keep going — not let the exception escape and abort the whole run.
+        // A user in two volunteering-enabled groups, each with its own
+        // opportunity, gets ONE email containing BOTH — not one email per group.
+        Mail::fake();
+
+        $group1 = $this->createTestGroup();
+        $group2 = $this->createTestGroup();
+        $this->createVolunteering($group1->id, 'Group One Opp');
+        $this->createVolunteering($group2->id, 'Group Two Opp');
+
+        $user = $this->createTestUser();
+        $this->createMembership($user, $group1, ['volunteeringallowed' => 1, 'emailfrequency' => 24]);
+        $this->createMembership($user, $group2, ['volunteeringallowed' => 1, 'emailfrequency' => 24]);
+
+        $this->artisan('mail:volunteering-digest')
+            ->expectsOutputToContain('Sent 1 email(s)')
+            ->assertExitCode(0);
+
+        Mail::assertSentCount(1);
+        Mail::assertSent(VolunteeringDigestMail::class, function (VolunteeringDigestMail $mail) {
+            return count($mail->volunteerings) === 2;
+        });
+    }
+
+    public function test_opportunity_cross_posted_to_several_of_users_groups_appears_once(): void
+    {
+        // The same opportunity shared with two of the user's groups must appear
+        // ONCE (deduplicated by id), annotated with both group names.
+        Mail::fake();
+
+        $group1 = $this->createTestGroup();
+        $group2 = $this->createTestGroup();
+
+        $user = $this->createTestUser();
+        $this->createMembership($user, $group1, ['volunteeringallowed' => 1, 'emailfrequency' => 24]);
+        $this->createMembership($user, $group2, ['volunteeringallowed' => 1, 'emailfrequency' => 24]);
+
+        $volId = $this->createVolunteering($group1->id, 'Cross-posted Opp');
+        $this->linkVolunteeringToGroup($volId, $group2->id);
+
+        $this->artisan('mail:volunteering-digest')
+            ->expectsOutputToContain('Sent 1 email(s)')
+            ->assertExitCode(0);
+
+        Mail::assertSentCount(1);
+        Mail::assertSent(VolunteeringDigestMail::class, function (VolunteeringDigestMail $mail) use ($group1, $group2) {
+            if (count($mail->volunteerings) !== 1) {
+                return false;
+            }
+            $groups = $mail->volunteerings[0]['groups'] ?? [];
+            sort($groups);
+            $expected = [$group1->nameshort, $group2->nameshort];
+            sort($expected);
+            return $groups === $expected;
+        });
+    }
+
+    public function test_spool_failure_for_one_user_does_not_abort_digest(): void
+    {
         $group = $this->createTestGroup();
         $this->createVolunteering($group->id);
 
         $member1 = $this->createTestUser();
-        $this->createMembership($member1, $group, [
-            'volunteeringallowed' => 1,
-            'emailfrequency' => 24,
-        ]);
+        $this->createMembership($member1, $group, ['volunteeringallowed' => 1, 'emailfrequency' => 24]);
 
         $member2 = $this->createTestUser();
-        $this->createMembership($member2, $group, [
-            'volunteeringallowed' => 1,
-            'emailfrequency' => 24,
-        ]);
+        $this->createMembership($member2, $group, ['volunteeringallowed' => 1, 'emailfrequency' => 24]);
 
         $calls = 0;
         $spooler = \Mockery::mock(EmailSpoolerService::class);
@@ -140,7 +194,7 @@ class VolunteeringDigestCommandTest extends TestCase
             ->expectsOutputToContain('Sent 1 email(s)')
             ->assertExitCode(0);
 
-        $this->assertSame(2, $calls, 'Both members should have been attempted');
+        $this->assertSame(2, $calls, 'Both users should have been attempted');
     }
 
     public function test_skips_members_with_volunteering_disabled(): void
@@ -151,16 +205,10 @@ class VolunteeringDigestCommandTest extends TestCase
         $this->createVolunteering($group->id);
 
         $memberOptedIn = $this->createTestUser();
-        $this->createMembership($memberOptedIn, $group, [
-            'volunteeringallowed' => 1,
-            'emailfrequency' => 24,
-        ]);
+        $this->createMembership($memberOptedIn, $group, ['volunteeringallowed' => 1, 'emailfrequency' => 24]);
 
         $memberOptedOut = $this->createTestUser();
-        $this->createMembership($memberOptedOut, $group, [
-            'volunteeringallowed' => 0,
-            'emailfrequency' => 24,
-        ]);
+        $this->createMembership($memberOptedOut, $group, ['volunteeringallowed' => 0, 'emailfrequency' => 24]);
 
         $this->artisan('mail:volunteering-digest')
             ->expectsOutputToContain('Sent 1 email(s)')
@@ -177,16 +225,10 @@ class VolunteeringDigestCommandTest extends TestCase
         $this->createVolunteering($group->id);
 
         $memberActive = $this->createTestUser();
-        $this->createMembership($memberActive, $group, [
-            'volunteeringallowed' => 1,
-            'emailfrequency' => 24,
-        ]);
+        $this->createMembership($memberActive, $group, ['volunteeringallowed' => 1, 'emailfrequency' => 24]);
 
         $memberNoEmail = $this->createTestUser();
-        $this->createMembership($memberNoEmail, $group, [
-            'volunteeringallowed' => 1,
-            'emailfrequency' => 0,
-        ]);
+        $this->createMembership($memberNoEmail, $group, ['volunteeringallowed' => 1, 'emailfrequency' => 0]);
 
         $this->artisan('mail:volunteering-digest')
             ->expectsOutputToContain('Sent 1 email(s)')
@@ -203,10 +245,7 @@ class VolunteeringDigestCommandTest extends TestCase
         $this->createVolunteering($group->id);
 
         $deletedUser = $this->createTestUser(['deleted' => now()]);
-        $this->createMembership($deletedUser, $group, [
-            'volunteeringallowed' => 1,
-            'emailfrequency' => 24,
-        ]);
+        $this->createMembership($deletedUser, $group, ['volunteeringallowed' => 1, 'emailfrequency' => 24]);
 
         $this->artisan('mail:volunteering-digest')
             ->expectsOutputToContain('Sent 0 email(s)')
@@ -215,43 +254,36 @@ class VolunteeringDigestCommandTest extends TestCase
         Mail::assertNothingSent();
     }
 
-    public function test_skips_group_recently_sent(): void
+    public function test_skips_user_recently_sent(): void
     {
         Mail::fake();
 
         $group = $this->createTestGroup();
-        DB::table('groups')->where('id', $group->id)
-            ->update(['lastvolunteeringroundup' => now()->subDays(1)]);
-
         $this->createVolunteering($group->id);
 
         $member = $this->createTestUser();
-        $this->createMembership($member, $group, [
-            'volunteeringallowed' => 1,
-            'emailfrequency' => 24,
-        ]);
+        $this->createMembership($member, $group, ['volunteeringallowed' => 1, 'emailfrequency' => 24]);
 
-        $this->artisan('mail:volunteering-digest')
-            ->assertExitCode(0);
+        // Sent only 1 day ago (< 3-day threshold) — must be skipped.
+        $this->setLastSent($member->id, now()->subDays(1));
+
+        $this->artisan('mail:volunteering-digest')->assertExitCode(0);
 
         Mail::assertNothingSent();
     }
 
-    public function test_processes_group_not_sent_in_3_days(): void
+    public function test_processes_user_not_sent_in_3_days(): void
     {
         Mail::fake();
 
         $group = $this->createTestGroup();
-        DB::table('groups')->where('id', $group->id)
-            ->update(['lastvolunteeringroundup' => now()->subDays(4)]);
-
         $this->createVolunteering($group->id);
 
         $member = $this->createTestUser();
-        $this->createMembership($member, $group, [
-            'volunteeringallowed' => 1,
-            'emailfrequency' => 24,
-        ]);
+        $this->createMembership($member, $group, ['volunteeringallowed' => 1, 'emailfrequency' => 24]);
+
+        // Last sent 4 days ago (>= 3-day threshold) — must be processed.
+        $this->setLastSent($member->id, now()->subDays(4));
 
         $this->artisan('mail:volunteering-digest')
             ->expectsOutputToContain('Sent 1 email(s)')
@@ -260,7 +292,7 @@ class VolunteeringDigestCommandTest extends TestCase
         Mail::assertSentCount(1);
     }
 
-    public function test_updates_lastvolunteeringroundup_after_sending(): void
+    public function test_records_lastsent_per_user_after_sending(): void
     {
         Mail::fake();
 
@@ -268,16 +300,15 @@ class VolunteeringDigestCommandTest extends TestCase
         $this->createVolunteering($group->id);
 
         $member = $this->createTestUser();
-        $this->createMembership($member, $group, [
-            'volunteeringallowed' => 1,
-            'emailfrequency' => 24,
-        ]);
+        $this->createMembership($member, $group, ['volunteeringallowed' => 1, 'emailfrequency' => 24]);
 
-        $this->artisan('mail:volunteering-digest')
-            ->assertExitCode(0);
+        $this->artisan('mail:volunteering-digest')->assertExitCode(0);
 
         $this->assertNotNull(
-            DB::table('groups')->where('id', $group->id)->value('lastvolunteeringroundup')
+            DB::table('users_digests')
+                ->where('userid', $member->id)
+                ->where('mode', 'volunteering')
+                ->value('lastsent')
         );
     }
 
@@ -286,14 +317,11 @@ class VolunteeringDigestCommandTest extends TestCase
         Mail::fake();
 
         $group = $this->createTestGroup();
-        // Global volunteering — no group assigned
+        // Global opportunity — no group assigned, shown to all eligible users.
         $this->createVolunteering(null, 'Global Opportunity');
 
         $member = $this->createTestUser();
-        $this->createMembership($member, $group, [
-            'volunteeringallowed' => 1,
-            'emailfrequency' => 24,
-        ]);
+        $this->createMembership($member, $group, ['volunteeringallowed' => 1, 'emailfrequency' => 24]);
 
         $this->artisan('mail:volunteering-digest')
             ->expectsOutputToContain('Sent 1 email(s)')
@@ -308,7 +336,6 @@ class VolunteeringDigestCommandTest extends TestCase
 
         $group = $this->createTestGroup();
 
-        // Expired volunteering — should not be included
         $expiredId = DB::table('volunteering')->insertGetId([
             'title' => 'Expired Opportunity',
             'location' => 'Somewhere',
@@ -323,13 +350,9 @@ class VolunteeringDigestCommandTest extends TestCase
         ]);
 
         $member = $this->createTestUser();
-        $this->createMembership($member, $group, [
-            'volunteeringallowed' => 1,
-            'emailfrequency' => 24,
-        ]);
+        $this->createMembership($member, $group, ['volunteeringallowed' => 1, 'emailfrequency' => 24]);
 
-        $this->artisan('mail:volunteering-digest')
-            ->assertExitCode(0);
+        $this->artisan('mail:volunteering-digest')->assertExitCode(0);
 
         Mail::assertNothingSent();
     }
@@ -342,18 +365,14 @@ class VolunteeringDigestCommandTest extends TestCase
         $this->createVolunteering($group->id);
 
         $member = $this->createTestUser();
-        $this->createMembership($member, $group, [
-            'volunteeringallowed' => 1,
-            'emailfrequency' => 24,
-        ]);
+        $this->createMembership($member, $group, ['volunteeringallowed' => 1, 'emailfrequency' => 24]);
 
-        $this->artisan('mail:volunteering-digest')
-            ->assertExitCode(0);
+        $this->artisan('mail:volunteering-digest')->assertExitCode(0);
 
         Mail::assertNothingSent();
     }
 
-    public function test_dry_run_does_not_send_emails(): void
+    public function test_dry_run_does_not_send_or_record(): void
     {
         Mail::fake();
 
@@ -361,10 +380,7 @@ class VolunteeringDigestCommandTest extends TestCase
         $this->createVolunteering($group->id);
 
         $member = $this->createTestUser();
-        $this->createMembership($member, $group, [
-            'volunteeringallowed' => 1,
-            'emailfrequency' => 24,
-        ]);
+        $this->createMembership($member, $group, ['volunteeringallowed' => 1, 'emailfrequency' => 24]);
 
         $this->artisan('mail:volunteering-digest', ['--dry-run' => true])
             ->expectsOutputToContain('DRY RUN')
@@ -374,7 +390,7 @@ class VolunteeringDigestCommandTest extends TestCase
         Mail::assertNothingSent();
 
         $this->assertNull(
-            DB::table('groups')->where('id', $group->id)->value('lastvolunteeringroundup')
+            DB::table('users_digests')->where('userid', $member->id)->where('mode', 'volunteering')->value('lastsent')
         );
     }
 
@@ -389,13 +405,9 @@ class VolunteeringDigestCommandTest extends TestCase
         $this->createVolunteering($group->id);
 
         $member = $this->createTestUser();
-        $this->createMembership($member, $group, [
-            'volunteeringallowed' => 1,
-            'emailfrequency' => 24,
-        ]);
+        $this->createMembership($member, $group, ['volunteeringallowed' => 1, 'emailfrequency' => 24]);
 
-        $this->artisan('mail:volunteering-digest')
-            ->assertExitCode(0);
+        $this->artisan('mail:volunteering-digest')->assertExitCode(0);
 
         Mail::assertNothingSent();
     }
@@ -422,16 +434,15 @@ class VolunteeringDigestCommandTest extends TestCase
         ]);
 
         $member = $this->createTestUser();
-        $this->createMembership($member, $group, [
-            'volunteeringallowed' => 1,
-            'emailfrequency' => 24,
-        ]);
+        $this->createMembership($member, $group, ['volunteeringallowed' => 1, 'emailfrequency' => 24]);
 
         $this->artisan('mail:volunteering-digest')
             ->expectsOutputToContain('Sent 1 email(s)')
             ->assertExitCode(0);
 
-        Mail::assertSentCount(1);
+        Mail::assertSent(VolunteeringDigestMail::class, function (VolunteeringDigestMail $mail) {
+            return $mail->volunteerings[0]['online'] === true;
+        });
     }
 
     public function test_applyby_deadline_is_formatted(): void
@@ -447,16 +458,15 @@ class VolunteeringDigestCommandTest extends TestCase
         ]);
 
         $member = $this->createTestUser();
-        $this->createMembership($member, $group, [
-            'volunteeringallowed' => 1,
-            'emailfrequency' => 24,
-        ]);
+        $this->createMembership($member, $group, ['volunteeringallowed' => 1, 'emailfrequency' => 24]);
 
         $this->artisan('mail:volunteering-digest')
             ->expectsOutputToContain('Sent 1 email(s)')
             ->assertExitCode(0);
 
-        Mail::assertSentCount(1);
+        Mail::assertSent(VolunteeringDigestMail::class, function (VolunteeringDigestMail $mail) {
+            return !empty($mail->volunteerings[0]['applyby']);
+        });
     }
 
     public function test_contact_fields_are_passed_through(): void
@@ -478,19 +488,20 @@ class VolunteeringDigestCommandTest extends TestCase
             'expired' => 0,
             'added' => now(),
         ]);
-        // No volunteering_groups row → global opportunity, shown for all groups
+        // No volunteering_groups row → global opportunity, shown for all users
 
         $member = $this->createTestUser();
-        $this->createMembership($member, $group, [
-            'volunteeringallowed' => 1,
-            'emailfrequency' => 24,
-        ]);
+        $this->createMembership($member, $group, ['volunteeringallowed' => 1, 'emailfrequency' => 24]);
 
         $this->artisan('mail:volunteering-digest')
             ->expectsOutputToContain('Sent 1 email(s)')
             ->assertExitCode(0);
 
-        Mail::assertSentCount(1);
+        Mail::assertSent(VolunteeringDigestMail::class, function (VolunteeringDigestMail $mail) {
+            $v = $mail->volunteerings[0];
+            return $v['contactname'] === 'Jane Smith'
+                && $v['contactemail'] === 'jane@example.org';
+        });
     }
 
     public function test_photo_thumb_from_externalmods_url(): void
@@ -508,15 +519,14 @@ class VolunteeringDigestCommandTest extends TestCase
         ]);
 
         $member = $this->createTestUser();
-        $this->createMembership($member, $group, [
-            'volunteeringallowed' => 1,
-            'emailfrequency' => 24,
-        ]);
+        $this->createMembership($member, $group, ['volunteeringallowed' => 1, 'emailfrequency' => 24]);
 
         $this->artisan('mail:volunteering-digest')
             ->expectsOutputToContain('Sent 1 email(s)')
             ->assertExitCode(0);
 
-        Mail::assertSentCount(1);
+        Mail::assertSent(VolunteeringDigestMail::class, function (VolunteeringDigestMail $mail) {
+            return $mail->volunteerings[0]['photo_thumb'] === 'https://cdn.example.com/image.jpg';
+        });
     }
 }

--- a/iznik-batch/tests/Unit/Mail/AmpersandEncodingTest.php
+++ b/iznik-batch/tests/Unit/Mail/AmpersandEncodingTest.php
@@ -62,7 +62,6 @@ class AmpersandEncodingTest extends TestCase
         // which email clients render as a single "&".
         $mail = new VolunteeringDigestMail(
             recipientEmail: 'test@example.com',
-            groupName:      'Testville Freegle',
             volunteerings:  [$this->makeVolunteeringDecoded()],
             unsubscribeUrl: 'https://example.com/unsubscribe',
         );
@@ -127,7 +126,6 @@ class AmpersandEncodingTest extends TestCase
     {
         $mail = new EventsDigestMail(
             recipientEmail: 'test@example.com',
-            groupName:      'Testville Freegle',
             events:         [$this->makeEventDecoded()],
             unsubscribeUrl: 'https://example.com/unsubscribe',
         );

--- a/iznik-batch/tests/Unit/Mail/EventsDigestMailTest.php
+++ b/iznik-batch/tests/Unit/Mail/EventsDigestMailTest.php
@@ -31,7 +31,6 @@ class EventsDigestMailTest extends TestCase
 
         $mail = new EventsDigestMail(
             recipientEmail: 'test@example.com',
-            groupName:      'Testville Freegle',
             events:         [$this->makeEvent(42)],
             unsubscribeUrl: $userSite . '/unsubscribe?email=' . urlencode('test@example.com'),
         );
@@ -57,7 +56,6 @@ class EventsDigestMailTest extends TestCase
 
         $mail = new EventsDigestMail(
             recipientEmail: 'test@example.com',
-            groupName:      'Testville Freegle',
             events:         [$this->makeEvent()],
             unsubscribeUrl: $unsubscribeUrl,
         );

--- a/iznik-batch/tests/Unit/Mail/VolunteeringDigestMailTest.php
+++ b/iznik-batch/tests/Unit/Mail/VolunteeringDigestMailTest.php
@@ -33,7 +33,6 @@ class VolunteeringDigestMailTest extends TestCase
 
         $mail = new VolunteeringDigestMail(
             recipientEmail: 'test@example.com',
-            groupName:      'Testville Freegle',
             volunteerings:  [$this->makeVolunteering(42)],
             unsubscribeUrl: $userSite . '/unsubscribe?email=' . urlencode('test@example.com'),
         );
@@ -57,7 +56,6 @@ class VolunteeringDigestMailTest extends TestCase
 
         $mail = new VolunteeringDigestMail(
             recipientEmail: 'test@example.com',
-            groupName:      'Testville Freegle',
             volunteerings:  [$this->makeVolunteering()],
             unsubscribeUrl: $unsubscribeUrl,
         );
@@ -119,7 +117,6 @@ class VolunteeringDigestMailTest extends TestCase
 
         $mail = new VolunteeringDigestMail(
             recipientEmail: 'test@example.com',
-            groupName:      'Testville Freegle',
             volunteerings:  [$this->makeVolunteering(1)],
             unsubscribeUrl: "{$userSite}/unsubscribe?email=" . urlencode('test@example.com'),
             jobAds:         collect([$this->makeJobAd(99)]),


### PR DESCRIPTION
## Summary

Following the unified "what's new" message digest, this makes the **community-event** and **volunteering-opportunity** roundups user-centric too.

Previously both were **per-group**: a member of several groups got a separate roundup email from each, and the same event/opportunity cross-posted to multiple of their groups appeared in every email. Now each is **one combined email per user** covering all their event-/volunteering-enabled groups, with:

- **Deduplication** — an event/opportunity shared with several of the user's groups appears **once**, annotated with a *"Shared with Group A, Group B"* line.
- **Global volunteering opportunities** (no specific group) included for every eligible user.
- **Per-user cadence** — `users_digests` gains `events`/`volunteering` modes (3-day minimum between sends), replacing the per-group `groups.lasteventsroundup` / `lastvolunteeringroundup` cursors.

Eligibility (active/holiday/bouncing/simplemail via `receivingOurMails`, per-group `eventsallowed`/`volunteeringallowed`, `emailfrequency != 0`, group feature-setting + open/published Freegle group) is unchanged — it's just applied per user instead of per group.

## Changes

- New `App\Services\Concerns\BuildsUserRoundups` trait — shared eligible-group/eligible-user queries, per-user cadence guard, and group attribution.
- `EventsDigestService` / `VolunteeringDigestService` rewritten to iterate users, pre-fetch + dedup items across their groups, and send one combined email each.
- `EventsDigestMail` / `VolunteeringDigestMail`: drop the single `groupName`; generic subject ("Community events near you" / "Volunteer opportunities near you"); from-name is the site name.
- Templates: generic header + per-item "Shared with …" attribution.
- Migration `2026_06_11_000001` extends `users_digests.mode` enum (additive — existing immediate/daily unaffected).
- Commands report users + groups; weekly schedule unchanged (per-user 3-day guard makes a same-week re-run a no-op).

## Code Quality Review

- Shared logic extracted to one trait (no duplication between the two services).
- Items pre-fetched once per run, not per user (bounded working set); users streamed via `lazyById`.
- Per-recipient spool failures are caught so one bad address can't abort the run (parity with prior behaviour).
- Additive enum migration; no destructive schema change.

## Test Plan

- Full `EventsDigestCommandTest` / `VolunteeringDigestCommandTest` rewritten for the per-user model; new cases: one combined email across a user's groups, cross-posted item deduplicated to a single entry with both group names, global opportunity shown once, per-user cadence (skip <3 days, send >=3 days, records `lastsent`), dry-run records nothing.
- Mailable unit tests + `AmpersandEncodingTest` updated for the new constructors.
- Local (status API) Laravel run of the affected suites: **61 passed, 0 failed**.
- Rendered both digests to **Mailpit** with multi-group/dedup/global sample data and verified the HTML: both items present, cross-group items show "Shared with …", global opportunity has no attribution, ampersands encode correctly, online/apply-by labels render.

## Future Improvements

- Optional pilot allowlist (as the message digest has) if a staged rollout is wanted.
- Plain-text alternative parts (the existing per-group versions had none either).