### PR TITLE
fix(app): re-register push notifications on app resume

### DIFF
--- a/iznik-nuxt3/stores/mobile.js
+++ b/iznik-nuxt3/stores/mobile.js
@@ -45,6 +45,7 @@ export const useMobileStore = defineStore({
     inlineReply: false,
     chatid: false,
     pushed: false,
+    pushPlugin: null,
     route: false,
     apprequiredversion: false,
     appupdaterequired: false,
@@ -200,8 +201,38 @@ export const useMobileStore = defineStore({
 
             const chatStore = useChatStore()
             chatStore.fetchChats(null, false)
+
+            // Re-trigger push registration on resume so that a missed/failed
+            // initial registration or a rotated FCM/APNs token recovers. The
+            // existing 'registration' listener re-fires with the current token
+            // and savePushId() is a no-op unless something actually changed.
+            this.reRegisterPush()
           } catch (e) {}
         })
+      }
+    },
+
+    // Re-register for push on the native app. Safe to call repeatedly: it only
+    // calls register() (which re-fires the existing 'registration' listener);
+    // it does NOT re-add listeners, re-create channels or re-request
+    // permissions. No-op on web or before push has been initialised.
+    async reRegisterPush() {
+      if (!process.client || !this.isApp || !this.pushPlugin) {
+        return
+      }
+
+      try {
+        const permStatus = await this.pushPlugin.checkPermissions()
+        if (permStatus?.receive === 'granted') {
+          dbg()?.info('Re-registering push on resume')
+          await this.pushPlugin.register()
+        } else {
+          dbg()?.info('Skipping push re-register; permission not granted', {
+            receive: permStatus?.receive,
+          })
+        }
+      } catch (e) {
+        dbg()?.warn('Push re-register on resume failed', e?.message)
       }
     },
 
@@ -259,6 +290,11 @@ export const useMobileStore = defineStore({
 
     async initPushNotifications(PushNotifications, Badge) {
       dbg()?.info('initPushNotifications started', { isiOS: this.isiOS })
+
+      // Keep a reference to the plugin so we can re-register on app resume
+      // (see reRegisterPush()) without re-adding listeners or re-requesting
+      // permissions.
+      this.pushPlugin = PushNotifications
 
       if (!this.isiOS) {
         // Delete old channels

--- a/iznik-nuxt3/tests/unit/stores/mobile.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/mobile.spec.js
@@ -657,6 +657,131 @@ describe('mobile store', () => {
     })
   })
 
+  describe('reRegisterPush', () => {
+    function makePushPlugin(receive = 'granted') {
+      return {
+        checkPermissions: vi.fn().mockResolvedValue({ receive }),
+        register: vi.fn().mockResolvedValue(undefined),
+      }
+    }
+
+    it('calls register() on a native app with a stored plugin and granted permission', async () => {
+      const store = useMobileStore()
+      store.isApp = true
+      const plugin = makePushPlugin('granted')
+      store.pushPlugin = plugin
+
+      await store.reRegisterPush()
+
+      expect(plugin.checkPermissions).toHaveBeenCalled()
+      expect(plugin.register).toHaveBeenCalled()
+    })
+
+    it('does NOT call register() when not on the app', async () => {
+      const store = useMobileStore()
+      store.isApp = false
+      const plugin = makePushPlugin('granted')
+      store.pushPlugin = plugin
+
+      await store.reRegisterPush()
+
+      expect(plugin.register).not.toHaveBeenCalled()
+    })
+
+    it('does NOT call register() when no plugin reference is stored', async () => {
+      const store = useMobileStore()
+      store.isApp = true
+      store.pushPlugin = null
+
+      // Should simply no-op without throwing.
+      await expect(store.reRegisterPush()).resolves.toBeUndefined()
+    })
+
+    it('does NOT call register() when permission is not granted', async () => {
+      const store = useMobileStore()
+      store.isApp = true
+      const plugin = makePushPlugin('denied')
+      store.pushPlugin = plugin
+
+      await store.reRegisterPush()
+
+      expect(plugin.checkPermissions).toHaveBeenCalled()
+      expect(plugin.register).not.toHaveBeenCalled()
+    })
+
+    it('swallows errors thrown during re-registration', async () => {
+      const store = useMobileStore()
+      store.isApp = true
+      const plugin = {
+        checkPermissions: vi.fn().mockResolvedValue({ receive: 'granted' }),
+        register: vi.fn().mockRejectedValue(new Error('boom')),
+      }
+      store.pushPlugin = plugin
+
+      await expect(store.reRegisterPush()).resolves.toBeUndefined()
+    })
+  })
+
+  describe('initWakeUpActions resume handler', () => {
+    let store
+    let capturedListener
+    let mockApp
+
+    beforeEach(() => {
+      store = useMobileStore()
+      capturedListener = null
+      mockApp = {
+        addListener: vi.fn().mockImplementation((event, fn) => {
+          if (event === 'resume') capturedListener = fn
+        }),
+      }
+      process.client = true
+    })
+
+    afterEach(() => {
+      delete process.client
+    })
+
+    it('re-registers push on resume when on a native app', async () => {
+      store.isApp = true
+      const plugin = {
+        checkPermissions: vi.fn().mockResolvedValue({ receive: 'granted' }),
+        register: vi.fn().mockResolvedValue(undefined),
+      }
+      store.pushPlugin = plugin
+
+      store.initWakeUpActions(mockApp)
+      expect(capturedListener).not.toBeNull()
+
+      await capturedListener({})
+      // Allow the async reRegisterPush() to settle.
+      await Promise.resolve()
+      await Promise.resolve()
+
+      expect(mockFetchChats).toHaveBeenCalledWith(null, false)
+      expect(plugin.register).toHaveBeenCalled()
+    })
+
+    it('does not re-register push on resume when not on the app', async () => {
+      store.isApp = false
+      const plugin = {
+        checkPermissions: vi.fn().mockResolvedValue({ receive: 'granted' }),
+        register: vi.fn().mockResolvedValue(undefined),
+      }
+      store.pushPlugin = plugin
+
+      store.initWakeUpActions(mockApp)
+      await capturedListener({})
+      await Promise.resolve()
+      await Promise.resolve()
+
+      // Existing resume behaviour still runs.
+      expect(mockFetchChats).toHaveBeenCalledWith(null, false)
+      // But registration is not re-triggered off-app.
+      expect(plugin.register).not.toHaveBeenCalled()
+    })
+  })
+
   describe('handleNotification duplicate-navigation guard', () => {
     it('skips router.push when already on the target chat route', async () => {
       // AssertFlip: before the fix, router.currentRoute.path is accessed directly


### PR DESCRIPTION
## Problem

Push-notification registration only runs on a **cold start** of the native Capacitor app (`initPushNotifications` via `mobile.js init()`). The `resume` handler (`initWakeUpActions`, `stores/mobile.js`) only refetched counts/chats — it never re-triggered registration. And even on cold start, `savePushId` only re-sends to the server when the token *changed* (`acceptedMobilePushId` guard).

Consequence: if the initial registration failed, or the FCM/APNs token rotated, there was **no recovery path**. iOS keeps the app warm and fires `resume` (not a cold start) for long periods, so a device could silently stop receiving push indefinitely.

This was diagnosed from a real case: a moderator who actively uses the app had **no `apptype='User'` push registration** at all, while his ModTools-app token (registered the same day) was healthy — consistent with a missed/rotated FD registration that never recovered.

## Fix

- Store the `PushNotifications` plugin reference during `initPushNotifications` (`this.pushPlugin`).
- Add `reRegisterPush()`: no-op unless `process.client && isApp && pushPlugin`; checks permission is `granted`, then calls `register()` again. This re-fires the existing `registration` listener → `savePushId()`, which is a no-op unless the token actually changed or a prior save failed. It does **not** re-add listeners, recreate channels, or re-request permissions.
- Call `reRegisterPush()` from the `resume` handler alongside the existing fetches.

## Tests

Added unit tests in `tests/unit/stores/mobile.spec.js` covering `reRegisterPush()` (called when native + granted; skipped when not-app / no-plugin / denied; errors swallowed) and the resume handler (re-registers on resume when native, not otherwise).

> Note: tests were written but not run in this environment (project deps not installed); CI will exercise them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)