### PR TITLE
fix(modtools): defer Pending-list refresh while a modal is open

### DIFF
--- a/iznik-nuxt3/modtools/composables/useModMessages.js
+++ b/iznik-nuxt3/modtools/composables/useModMessages.js
@@ -8,6 +8,7 @@
 // - which in turn stops useModMessages watch(work) from updating the messages list
 // - until another timed update occurs
 
+import { onScopeDispose, getCurrentScope } from 'vue'
 import { useMessageStore } from '~/stores/message'
 import { useAuthStore } from '@/stores/auth'
 // import { useModGroupStore } from '@/stores/modgroup'
@@ -31,6 +32,22 @@ const memberTerm = ref(null)
 const nextAfterRemoved = ref(null)
 
 const distance = ref(10)
+
+// Holds a workdetail refresh that arrived while a modal was open (e.g. a
+// moderator typing a rejection reason). The list is NOT refreshed while a modal
+// is open — re-rendering would unmount the modal and lose the draft — so the
+// pending refresh is parked here and applied when the modal closes.
+const pendingWorkRefresh = ref(null)
+
+// Bootstrap sets <body> overflow:hidden while a modal is open, so use that as a
+// cross-component "is any modal open?" signal. The typeof guard keeps it
+// SSR-safe (no document on the server).
+function aModalIsOpen() {
+  return (
+    typeof document !== 'undefined' &&
+    document.body?.style?.overflow === 'hidden'
+  )
+}
 
 const summary = computed(() => {
   if (!summarykey.value) return false
@@ -271,12 +288,19 @@ export function setupModMessages(reset) {
     // When the work total INCREASES, genuinely new work has arrived (e.g. a new
     // pending message). The list must refresh to show it - otherwise the count /
     // red alert updates but the message stays invisible until a manual reload
-    // (Discourse #9737). This is NOT modal-specific: refresh regardless of the
-    // deferGetMessages smoothness flag and the body-overflow (beep) guard, which
-    // exist only to avoid jarring reloads on mod actions that do not add work.
+    // (Discourse #9737).
     const newTotal = Number(newVal?.total ?? 0)
     const oldTotal = Number(oldVal?.total ?? 0)
     if (newTotal > oldTotal) {
+      // ...but NOT while a modal is open. Refreshing re-renders the message
+      // list, which unmounts an open modal (e.g. a moderator part-way through
+      // typing a rejection reason) and loses their draft. Park the refresh and
+      // apply it when the modal closes (see the observer below), so the new
+      // message still appears without a manual reload.
+      if (aModalIsOpen()) {
+        pendingWorkRefresh.value = newVal
+        return
+      }
       getMessages(newVal)
       return
     }
@@ -285,10 +309,35 @@ export function setupModMessages(reset) {
     // already handled): keep the existing suppression so the list does not
     // reload under the user's feet.
     if (miscStore.deferGetMessages) return
-    if (document.body.style.overflow !== 'hidden') {
+    if (!aModalIsOpen()) {
       getMessages(newVal)
     }
   })
+
+  // Apply a refresh that was deferred because a modal was open, as soon as the
+  // modal closes. Bootstrap toggles <body> overflow:hidden around modals, so we
+  // observe that attribute; when it clears and a refresh is pending, run it.
+  // This keeps an open rejection modal (and its draft) intact during editing
+  // while still surfacing the new pending message the moment it is dismissed.
+  if (
+    typeof document !== 'undefined' &&
+    typeof MutationObserver !== 'undefined'
+  ) {
+    const bodyOverflowObserver = new MutationObserver(() => {
+      if (pendingWorkRefresh.value && !aModalIsOpen()) {
+        const deferred = pendingWorkRefresh.value
+        pendingWorkRefresh.value = null
+        getMessages(deferred)
+      }
+    })
+    bodyOverflowObserver.observe(document.body, {
+      attributes: true,
+      attributeFilter: ['style'],
+    })
+    if (getCurrentScope()) {
+      onScopeDispose(() => bodyOverflowObserver.disconnect())
+    }
+  }
 
   return {
     busy,

--- a/iznik-nuxt3/tests/unit/composables/useModMessages.pendingAutoRefresh.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useModMessages.pendingAutoRefresh.spec.js
@@ -1,11 +1,11 @@
 /**
  * Tests for the pending-messages auto-refresh behaviour.
  *
- * The Pending messages page must call getMessages() whenever authStore.work
- * changes (new pending messages arrived), even if a modal is open at the time.
- *
- * Discourse #9737: "A red alert appears in Pending messages but no message is
- * visible without a manual page refresh."
+ * When authStore.work increases (new pending messages arrived) the list must
+ * refresh so the message becomes visible without a manual reload (Discourse
+ * #9737) — EXCEPT while a modal is open (e.g. a moderator typing a rejection
+ * reason), where re-rendering would unmount the modal and lose the draft. In
+ * that case the refresh is deferred and applied as soon as the modal closes.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { ref, nextTick } from 'vue'
@@ -92,11 +92,13 @@ describe('useModMessages — pending list auto-refresh', () => {
     expect(mockFetchMessagesMT).toHaveBeenCalled()
   })
 
-  // Regression test for Discourse #9737: the pending list must re-fetch even
-  // when a modal is open (body.style.overflow === 'hidden').  Previously the
-  // overflow check blocked the fetch, leaving the badge count correct but the
-  // list stale until the next manual page refresh.
-  it('calls getMessages when pending count increases even while a modal is open', async () => {
+  // A new pending message arriving while a modal is open (Bootstrap sets <body>
+  // overflow:hidden) must NOT refresh the list immediately — that would unmount
+  // the modal and lose a moderator's part-typed rejection reason. The refresh
+  // is deferred and applied as soon as the modal closes, so the message still
+  // appears without a manual reload (reconciles Discourse #9737 with draft
+  // preservation).
+  it('defers the refresh while a modal is open and applies it on close', async () => {
     const { setupModMessages } = await import(
       '~/modtools/composables/useModMessages'
     )
@@ -108,16 +110,23 @@ describe('useModMessages — pending list auto-refresh', () => {
     await flushPromises()
     vi.clearAllMocks()
 
-    // Simulate any open modal (Bootstrap sets overflow:hidden on <body>)
+    // A modal opens (Bootstrap sets overflow:hidden on <body>).
     document.body.style.overflow = 'hidden'
 
-    // A new pending message arrives while the modal is open
+    // A new pending message arrives while the modal is open.
     mockWork.value = { pending: 1, pendingother: 0, total: 1 }
-
     await nextTick()
     await flushPromises()
 
-    // The list must still be re-fetched regardless of body overflow state
+    // The list must NOT refresh yet — that would lose the open modal's draft.
+    expect(mockFetchMessagesMT).not.toHaveBeenCalled()
+
+    // The modal closes (Bootstrap clears the body overflow style).
+    document.body.style.overflow = ''
+    await nextTick()
+    await flushPromises()
+
+    // Now the deferred refresh is applied so the new message becomes visible.
     expect(mockFetchMessagesMT).toHaveBeenCalled()
   })
 


### PR DESCRIPTION
## Problem

When new moderation work arrives while a moderator has a modal open — e.g. they're part-way through typing a rejection reason — the Pending-list watch refreshes the list. That re-render unmounts the open modal and loses their in-progress draft.

This builds on the #9737 fix (refresh the Pending list when the work total increases) by making that refresh modal-aware.

## Fix

- When the work total increases but a modal is open, the refresh is **parked** in `pendingWorkRefresh` instead of running immediately.
- A `MutationObserver` on `<body>` (Bootstrap toggles `overflow:hidden` around modals) replays the parked refresh the moment the modal closes, so the new pending message still appears without a manual reload.
- The existing `deferGetMessages` / body-overflow suppression for non-work-adding updates is factored into a shared `aModalIsOpen()` helper.
- The observer is disconnected on scope dispose; `typeof document` / `typeof MutationObserver` guards keep it SSR-safe.

## Tests

`iznik-nuxt3/tests/unit/composables/useModMessages.pendingAutoRefresh.spec.js` updated to cover the defer-while-modal-open and replay-on-close behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)