### PR TITLE
Migrate final V1 crons to Laravel + register in MT cron table

### DIFF
--- a/.env.background.example
+++ b/.env.background.example
@@ -61,6 +61,24 @@ GOOGLE_GEMINI_API_KEY=your_gemini_api_key_here
 # Discourse email address for posting summaries (email-to-forum)
 FREEGLE_DISCOURSE_TECH_EMAIL=tech-updates@discourse.ilovefreegle.org
 
+# Discourse REST API — required by discourse:check-users / discourse:not-signed-up.
+# Both commands skip silently if DISCOURSE_APIKEY is blank.
+DISCOURSE_URL=https://discourse.ilovefreegle.org
+DISCOURSE_APIKEY=
+DISCOURSE_API_USERNAME=system
+DISCOURSE_ANNOUNCEMENTS_ID=7
+
+# PayPal NVP API — required by the donations:paypal-download fallback. Skips if blank.
+PAYPAL_USERNAME=
+PAYPAL_PASSWORD=
+PAYPAL_SIGNATURE=
+PAYPAL_NVP_ENDPOINT=https://api-3t.paypal.com/nvp
+PAYPAL_DOWNLOAD_DAYS=30
+
+# Central mods / Volunteer Support address — receives the Discourse reports.
+FREEGLE_CENTRALMODS_ADDR=volunteers@ilovefreegle.org
+
+
 # =============================================================================
 # Cloudflare Workers AI (Flux Schnell image generation)
 # =============================================================================

--- a/.env.background.example
+++ b/.env.background.example
@@ -76,7 +76,7 @@ PAYPAL_NVP_ENDPOINT=https://api-3t.paypal.com/nvp
 PAYPAL_DOWNLOAD_DAYS=30
 
 # Central mods / Volunteer Support address — receives the Discourse reports.
-FREEGLE_CENTRALMODS_ADDR=volunteers@ilovefreegle.org
+FREEGLE_CENTRALMODS_ADDR=volunteersupport@ilovefreegle.org
 
 
 # =============================================================================

--- a/iznik-batch/.env.example
+++ b/iznik-batch/.env.example
@@ -91,3 +91,24 @@ LETSENCRYPT_CERT_PATH=/etc/letsencrypt/live/ilovefreegle.org
 REACH_VOLUNTEERING_FEED_URL=
 REACH_VOLUNTEERING_USER=
 REACH_VOLUNTEERING_PASSWORD=
+
+# Discourse forum REST API (discourse:check-users, discourse:not-signed-up).
+# Leave DISCOURSE_APIKEY blank to disable both Discourse cron commands.
+DISCOURSE_URL=https://discourse.ilovefreegle.org
+DISCOURSE_APIKEY=
+DISCOURSE_API_USERNAME=system
+DISCOURSE_ANNOUNCEMENTS_ID=7
+
+# PayPal NVP API (donations:paypal-download fallback). Leave PAYPAL_USERNAME
+# blank to disable. Live endpoint shown; sandbox is api-3t.sandbox.paypal.com.
+PAYPAL_USERNAME=
+PAYPAL_PASSWORD=
+PAYPAL_SIGNATURE=
+PAYPAL_NVP_ENDPOINT=https://api-3t.paypal.com/nvp
+PAYPAL_DOWNLOAD_DAYS=30
+
+# Doogal UK postcode dataset (locations:update-postcodes).
+DOOGAL_ZIP_URL=https://www.doogal.co.uk/files/postcodes.zip
+
+# Central mods / Volunteer Support address — receives Discourse reports.
+FREEGLE_CENTRALMODS_ADDR=volunteers@ilovefreegle.org

--- a/iznik-batch/.env.example
+++ b/iznik-batch/.env.example
@@ -111,4 +111,4 @@ PAYPAL_DOWNLOAD_DAYS=30
 DOOGAL_ZIP_URL=https://www.doogal.co.uk/files/postcodes.zip
 
 # Central mods / Volunteer Support address — receives Discourse reports.
-FREEGLE_CENTRALMODS_ADDR=volunteers@ilovefreegle.org
+FREEGLE_CENTRALMODS_ADDR=volunteersupport@ilovefreegle.org

--- a/iznik-batch/app/Console/Commands/Discourse/CheckUsersCommand.php
+++ b/iznik-batch/app/Console/Commands/Discourse/CheckUsersCommand.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Console\Commands\Discourse;
+
+use App\Services\DiscourseCheckUsersService;
+use Illuminate\Console\Command;
+
+/**
+ * Daily Discourse user audit (V1 cron/discourse_checkusers.php): verifies mods,
+ * keeps bios/announcements watching in sync, reports bounces and mail settings.
+ */
+class CheckUsersCommand extends Command
+{
+    protected $signature = 'discourse:check-users';
+
+    protected $description = 'Audit Discourse users against MT mods; fix watching/bios; email a report (V1 discourse_checkusers.php)';
+
+    public function handle(DiscourseCheckUsersService $service): int
+    {
+        $result = $service->run();
+
+        if ($result['skipped'] ?? false) {
+            $this->warn('Discourse API key not configured — skipped.');
+
+            return self::SUCCESS;
+        }
+
+        $this->info(sprintf(
+            'Done. mods=%d, notmod=%d, notuser=%d, announcements-added=%d, bios-updated=%d.',
+            $result['ismod'], $result['notmod'], $result['notuser'],
+            $result['notonannouncements'], $result['bioupdatedcount']
+        ));
+
+        return self::SUCCESS;
+    }
+}

--- a/iznik-batch/app/Console/Commands/Discourse/NotSignedUpCommand.php
+++ b/iznik-batch/app/Console/Commands/Discourse/NotSignedUpCommand.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Console\Commands\Discourse;
+
+use App\Services\DiscourseNotSignedUpService;
+use Illuminate\Console\Command;
+
+/**
+ * Daily check for Freegle groups not represented by an active mod on Discourse,
+ * active mods not signed up, and mods with TN preferred emails (V1
+ * cron/discourse_not_signed_up.php).
+ */
+class NotSignedUpCommand extends Command
+{
+    protected $signature = 'discourse:not-signed-up';
+
+    protected $description = 'Report Freegle groups with no active mod on Discourse + mods not signed up (V1 discourse_not_signed_up.php)';
+
+    public function handle(DiscourseNotSignedUpService $service): int
+    {
+        $result = $service->run();
+
+        if ($result['skipped'] ?? false) {
+            $this->warn('Discourse API key not configured — skipped.');
+
+            return self::SUCCESS;
+        }
+
+        $this->info(sprintf(
+            'Done. groups not represented=%d, volunteers not signed up=%d, TN preferred emails=%d.',
+            $result['notrepresented'], $result['notondiscourse'], $result['tnpreferred']
+        ));
+
+        return self::SUCCESS;
+    }
+}

--- a/iznik-batch/app/Console/Commands/Donation/PaypalDownloadCommand.php
+++ b/iznik-batch/app/Console/Commands/Donation/PaypalDownloadCommand.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Console\Commands\Donation;
+
+use App\Services\PaypalDownloadService;
+use Illuminate\Console\Command;
+
+/**
+ * Fallback PayPal donation downloader (V1 cron/paypal_download.php). The IPN
+ * catches donations normally; this backfills any it missed over the last N days.
+ */
+class PaypalDownloadCommand extends Command
+{
+    protected $signature = 'donations:paypal-download';
+
+    protected $description = 'Fallback: download recent PayPal donations the IPN missed into users_donations (V1 paypal_download.php)';
+
+    public function handle(PaypalDownloadService $service): int
+    {
+        $result = $service->download(function (string $date, int $found, int $upserted) {
+            $this->line("  {$date}: {$found} found, {$upserted} upserted so far");
+        });
+
+        if ($result['skipped']) {
+            $this->warn('PayPal credentials not configured — skipped.');
+
+            return self::SUCCESS;
+        }
+
+        $this->info(
+            "Scanned {$result['days']} day(s): {$result['found']} donation(s) found, {$result['upserted']} upserted."
+        );
+
+        return self::SUCCESS;
+    }
+}

--- a/iznik-batch/app/Console/Commands/Location/UpdatePostcodesCommand.php
+++ b/iznik-batch/app/Console/Commands/Location/UpdatePostcodesCommand.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Console\Commands\Location;
+
+use App\Services\DoogalService;
+use Illuminate\Console\Command;
+
+/**
+ * Add new UK postcodes and refresh changed lat/lng from the Doogal Code-Point
+ * dataset. Faithful migration of V1 scripts/cli/doogal.php and the cron/doogal
+ * wrapper (which downloaded + unzipped the CSV before running it).
+ */
+class UpdatePostcodesCommand extends Command
+{
+    protected $signature = 'locations:update-postcodes
+                            {--file= : Path to an already-extracted Code-Point/Doogal CSV (skips download)}
+                            {--url= : Override the postcodes.zip download URL}
+                            {--keep : Keep the downloaded/extracted temp files}';
+
+    protected $description = 'Add new UK postcodes and refresh changed lat/lng from the Doogal dataset (V1 cli/doogal.php)';
+
+    public function handle(DoogalService $service): int
+    {
+        $file = $this->option('file');
+        $downloaded = false;
+
+        if (!$file) {
+            $this->info('Downloading postcode dataset...');
+            try {
+                $file = $service->fetchCsv($this->option('url'));
+                $downloaded = true;
+            } catch (\Throwable $e) {
+                $this->error('Download failed: '.$e->getMessage());
+
+                return self::FAILURE;
+            }
+        }
+
+        if (!is_file($file)) {
+            $this->error("CSV file not found: {$file}");
+
+            return self::FAILURE;
+        }
+
+        $this->info("Processing postcodes from: {$file}");
+
+        try {
+            $result = $service->process($file, function (int $processed, int $added, int $updated) {
+                $this->line("  ...{$processed} processed ({$added} added, {$updated} updated)");
+            });
+        } catch (\Throwable $e) {
+            $this->error($e->getMessage());
+
+            return self::FAILURE;
+        } finally {
+            if ($downloaded && !$this->option('keep')) {
+                @unlink($file);
+                @rmdir(dirname($file));
+            }
+        }
+
+        $this->info(
+            "Done. Processed {$result['processed']}, added {$result['added']}, "
+            ."updated {$result['updated']}, failed {$result['failed']}."
+        );
+
+        return self::SUCCESS;
+    }
+}

--- a/iznik-batch/app/Mail/Housekeeper/DiscourseReportMail.php
+++ b/iznik-batch/app/Mail/Housekeeper/DiscourseReportMail.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Mail\Housekeeper;
+
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Address;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+
+/**
+ * Plain-text report email for the Discourse housekeeping crons
+ * (discourse:check-users, discourse:not-signed-up). V1 sent these as plain
+ * text via Swift_Message; we wrap the body in a <pre> so the layout survives.
+ */
+class DiscourseReportMail extends Mailable
+{
+    public function __construct(
+        public readonly string $recipientEmail,
+        public readonly string $recipientName,
+        public readonly string $fromEmail,
+        public readonly string $emailSubject,
+        public readonly string $body,
+    ) {}
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            from: new Address($this->fromEmail, 'Freegle Geeks'),
+            to: [new Address($this->recipientEmail, $this->recipientName)],
+            subject: $this->emailSubject,
+        );
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            htmlString: '<pre style="font-family:monospace;white-space:pre-wrap">'.e($this->body).'</pre>',
+        );
+    }
+}

--- a/iznik-batch/app/Services/DiscourseCheckUsersService.php
+++ b/iznik-batch/app/Services/DiscourseCheckUsersService.php
@@ -1,0 +1,306 @@
+<?php
+
+namespace App\Services;
+
+use App\Mail\Housekeeper\DiscourseReportMail;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Daily Discourse user audit. Faithful migration of V1
+ * scripts/cron/discourse_checkusers.php.
+ *
+ * Walks every Discourse user and, for those linked to an MT account
+ * (single_sign_on_record.external_id), checks they still moderate a group,
+ * ensures they watch the Announcements category, keeps their bio in sync with
+ * the groups they moderate, and reports bounces / mail settings. A summary is
+ * emailed to geeks daily and to central mods when there's something to check
+ * (or on Saturdays).
+ */
+class DiscourseCheckUsersService
+{
+    private const SYSTEM_USERNAME = 'freeglegeeks';
+
+    public function __construct(private DiscourseClient $client)
+    {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function run(): array
+    {
+        if (!$this->client->isConfigured()) {
+            Log::warning('DiscourseCheckUsersService: Discourse API key not configured — skipping.');
+
+            return ['skipped' => true];
+        }
+
+        $announcementsId = (int) config('freegle.discourse.announcements_category_id', 7);
+        $throttleUs = (int) config('freegle.discourse.throttle_us', 250000);
+
+        $allusers = $this->client->getAllUsers();
+        $now = Carbon::now();
+
+        $c = array_fill_keys([
+            'ismod', 'notmod', 'notuser', 'system', 'everposted', 'postedinlastweek',
+            'everseen', 'seeninlastweek', 'evermailed', 'mailedinlastweek', 'anybounces',
+            'bouncestopped', 'mailinglistmode', 'watchingcount', 'email_digests',
+            'notonannouncements', 'notreceivingmail', 'bioupdatedcount',
+        ], 0);
+        $anybouncers = '';
+        $bouncestoppers = '';
+        $report = 'Total Discourse users: '.count($allusers)."\n";
+
+        foreach ($allusers as $duser) {
+            $username = (string) ($duser['username'] ?? '');
+
+            if ($username === self::SYSTEM_USERNAME) {
+                $c['system']++;
+                continue;
+            }
+
+            $this->throttle($throttleUs);
+
+            if (!empty($duser['last_posted_at'])) {
+                $c['everposted']++;
+                if ($this->daysSince($duser['last_posted_at'], $now) < 8) {
+                    $c['postedinlastweek']++;
+                }
+            }
+            if (!empty($duser['last_seen_at'])) {
+                $c['everseen']++;
+                if ($this->daysSince($duser['last_seen_at'], $now) < 8) {
+                    $c['seeninlastweek']++;
+                }
+            }
+
+            $fulluser = $this->client->getUser((int) $duser['id'], $username);
+
+            $bounceScore = (float) ($fulluser['bounce_score'] ?? 0);
+            if ($bounceScore >= 400) {
+                $c['bouncestopped']++;
+                $bouncestoppers .= $username.'-'.$bounceScore.', ';
+            } elseif ($bounceScore > 0) {
+                $c['anybounces']++;
+                $anybouncers .= $username.'-'.$bounceScore.', ';
+            }
+
+            $externalId = null;
+            if (isset($fulluser['single_sign_on_record']) && is_array($fulluser['single_sign_on_record'])) {
+                $externalId = $fulluser['single_sign_on_record']['external_id'] ?? null;
+            }
+
+            if (!empty($fulluser['last_emailed_at'])) {
+                $c['evermailed']++;
+                if ($this->daysSince($fulluser['last_emailed_at'], $now) < 8) {
+                    $c['mailedinlastweek']++;
+                }
+            }
+
+            if (!$externalId) {
+                continue;
+            }
+
+            $externalId = (int) $externalId;
+            $useremail = $this->client->getUserEmail($username);
+            $mtUserExists = DB::table('users')->where('id', $externalId)->exists();
+            $modUserId = $this->resolveModUserId($externalId, $useremail);
+
+            if (!$mtUserExists) {
+                // V1 intended this "NOT EVEN A USER" branch but its `new User()`
+                // was always truthy, making it dead code; we honour the intent.
+                $c['notuser']++;
+                $report .= 'Not a MT user: Discourse username: '.$username.', email: '.$useremail."\n";
+            } elseif ($modUserId !== null) {
+                $c['ismod']++;
+            } else {
+                $c['notmod']++;
+                $report .= 'NOT A MOD. MT id: '.$externalId.', Discourse username: '.$username.', email: '.$useremail."\n";
+            }
+
+            // What mail are they getting?
+            $this->throttle($throttleUs);
+            $public = $this->client->getUserPublic($username);
+
+            $watched = (array) ($public['watched_category_ids'] ?? []);
+            $watchedFirst = (array) ($public['watched_first_post_category_ids'] ?? []);
+            $tracked = (array) ($public['tracked_category_ids'] ?? []);
+
+            $gettingAnyMails = (count($watched) + count($watchedFirst) + count($tracked)) > 0;
+            if ($gettingAnyMails) {
+                $c['watchingcount']++;
+            }
+
+            $mlm = false;
+            if (isset($public['user_option']) && is_array($public['user_option'])) {
+                if (!empty($public['user_option']['mailing_list_mode'])) {
+                    $mlm = true;
+                    $c['mailinglistmode']++;
+                    $gettingAnyMails = true;
+                }
+                if (!empty($public['user_option']['email_digests'])) {
+                    $c['email_digests']++;
+                    $gettingAnyMails = true;
+                }
+            }
+
+            if (!$gettingAnyMails) {
+                $report .= 'Not getting any mails: Discourse username: '.$username.', email: '.$useremail."\n";
+                $c['notreceivingmail']++;
+            } elseif (!$mlm) {
+                if (!in_array($announcementsId, $watched) &&
+                    !in_array($announcementsId, $watchedFirst) &&
+                    !in_array($announcementsId, $tracked)) {
+                    $c['notonannouncements']++;
+                    $this->client->setWatchCategory($username, $watched, $announcementsId);
+                    $report .= 'Was not on Announcements: Discourse username: '.$username."\n";
+                }
+            }
+
+            // Keep the bio in sync with the groups they moderate.
+            if ($mtUserExists) {
+                $bio = $useremail.' is a mod on '.$this->modGroupList($externalId);
+                if ($bio !== ($public['bio_raw'] ?? null)) {
+                    $this->client->setBio($username, $bio);
+                    $c['bioupdatedcount']++;
+                }
+            }
+        }
+
+        $report .= $this->summary($c, $anybouncers, $bouncestoppers);
+        $report .= "\ndiscourse:check-users — migrated from V1 discourse_checkusers.php\n";
+
+        $this->sendReports($c, $report);
+
+        return array_merge(['skipped' => false], $c);
+    }
+
+    /**
+     * Resolve the MT user id (the user themselves or a merged main account)
+     * that moderates a group, or null if none. Mirrors V1's email-based merge
+     * fallback.
+     */
+    private function resolveModUserId(int $externalId, string $useremail): ?int
+    {
+        if ($this->isModerator($externalId)) {
+            return $externalId;
+        }
+
+        if ($useremail !== '') {
+            $actualId = (int) DB::table('users_emails')
+                ->where('email', $useremail)
+                ->orderByDesc('id')
+                ->value('userid');
+
+            if ($actualId !== 0 && $actualId !== $externalId && $this->isModerator($actualId)) {
+                return $actualId;
+            }
+        }
+
+        return null;
+    }
+
+    private function isModerator(int $uid): bool
+    {
+        return DB::table('memberships')
+            ->where('userid', $uid)
+            ->whereIn('role', ['Moderator', 'Owner'])
+            ->exists();
+    }
+
+    private function modGroupList(int $uid): string
+    {
+        $names = DB::table('memberships')
+            ->join('groups', 'groups.id', '=', 'memberships.groupid')
+            ->where('memberships.userid', $uid)
+            ->whereIn('memberships.role', ['Moderator', 'Owner'])
+            ->orderBy('groups.nameshort')
+            ->selectRaw('COALESCE(groups.namefull, groups.nameshort) AS nm')
+            ->pluck('nm')
+            ->all();
+
+        return substr(implode(', ', $names), 0, 1000);
+    }
+
+    private function summary(array $c, string $anybouncers, string $bouncestoppers): string
+    {
+        $s = "\n";
+        $s .= "ismod: {$c['ismod']}\n";
+        $s .= "notmod: {$c['notmod']}\n";
+        $s .= "notuser: {$c['notuser']}\n";
+        $s .= "system: {$c['system']}\n\n";
+        $s .= "everposted: {$c['everposted']}\n";
+        $s .= "postedinlastweek: {$c['postedinlastweek']}\n\n";
+        $s .= "everseen: {$c['everseen']}\n";
+        $s .= "seeninlastweek: {$c['seeninlastweek']}\n\n";
+        $s .= "evermailed: {$c['evermailed']}\n";
+        $s .= "mailedinlastweek: {$c['mailedinlastweek']}\n\n";
+        $s .= "anybounces: {$c['anybounces']} ({$anybouncers})\n";
+        $s .= "bouncestopped: {$c['bouncestopped']} ({$bouncestoppers})\n";
+        if ($c['bouncestopped'] > 0) {
+            $s .= "Check users with stopped mails here: https://discourse.ilovefreegle.org/admin/logs/staff_action_logs - action 'revoke email'\n";
+        }
+        $s .= "\n";
+        $s .= "mailinglistmode: ({$c['mailinglistmode']})\n";
+        $s .= "watchingcount: ({$c['watchingcount']})\n";
+        $s .= "email_digests: ({$c['email_digests']})\n";
+        $s .= "notonannouncements: ({$c['notonannouncements']})";
+        $s .= $c['notonannouncements'] > 0 ? " but hopefully now are\n" : "\n";
+        $s .= "notreceivingmail: ({$c['notreceivingmail']})\n";
+        $s .= "bioupdatedcount: ({$c['bioupdatedcount']})\n";
+
+        return $s;
+    }
+
+    private function sendReports(array $c, string $report): void
+    {
+        $from = (string) config('freegle.mail.geeks_addr', 'geeks@ilovefreegle.org');
+        $geeks = (string) config('freegle.mail.geek_alerts_addr', 'geek-alerts@ilovefreegle.org');
+        $centralmods = (string) config('freegle.mail.centralmods_addr');
+
+        $subject = 'Discourse checkuser OK';
+        $mailedCentral = false;
+
+        if ($c['notmod'] || $c['notuser']) {
+            $subject = 'Discourse checkuser USERS TO CHECK';
+            $this->send($centralmods, 'Volunteer Support', $from, $subject, $report);
+            $mailedCentral = true;
+        }
+
+        // V1 also mailed central mods on Saturdays even with nothing to check.
+        if (!$mailedCentral && Carbon::now()->dayOfWeek === Carbon::SATURDAY) {
+            $this->send($centralmods, 'Volunteer Support', $from, $subject, $report);
+        }
+
+        $this->send($geeks, 'Geeks Alerts', $from, $subject, $report);
+    }
+
+    private function send(string $to, string $toName, string $from, string $subject, string $body): void
+    {
+        if ($to === '') {
+            return;
+        }
+
+        try {
+            app(EmailSpoolerService::class)->spool(
+                new DiscourseReportMail($to, $toName, $from, $subject, $body)
+            );
+        } catch (\Throwable $e) {
+            Log::error('DiscourseCheckUsersService: mail failed', ['to' => $to, 'error' => $e->getMessage()]);
+        }
+    }
+
+    private function daysSince(string $iso, Carbon $now): float
+    {
+        return abs(Carbon::parse($iso)->diffInDays($now));
+    }
+
+    private function throttle(int $us): void
+    {
+        if ($us > 0) {
+            usleep($us);
+        }
+    }
+}

--- a/iznik-batch/app/Services/DiscourseClient.php
+++ b/iznik-batch/app/Services/DiscourseClient.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Facades\Http;
+
+/**
+ * Thin client for the Discourse REST API, authenticated with the system
+ * Api-Key/Api-Username headers (V1 used the same headers in
+ * discourse_checkusers.php / discourse_not_signed_up.php).
+ *
+ * All methods return associative arrays (Discourse JSON). Callers are expected
+ * to check {@see isConfigured()} first; when the API key is unset the cron
+ * commands skip rather than firing unauthenticated requests.
+ */
+class DiscourseClient
+{
+    private string $baseUrl;
+
+    private string $apiKey;
+
+    private string $apiUsername;
+
+    public function __construct()
+    {
+        $this->baseUrl = rtrim((string) config('freegle.discourse.url'), '/');
+        $this->apiKey = (string) config('freegle.discourse.api_key');
+        $this->apiUsername = (string) config('freegle.discourse.api_username', 'system');
+    }
+
+    public function isConfigured(): bool
+    {
+        return $this->apiKey !== '';
+    }
+
+    private function request(): PendingRequest
+    {
+        return Http::withHeaders([
+            'Api-Key' => $this->apiKey,
+            'Api-Username' => $this->apiUsername,
+            'User-Agent' => 'Freegle',
+        ])->timeout(60);
+    }
+
+    /**
+     * All trust_level_0 members (effectively every user), first 1000 — overrides
+     * Discourse's default page size of 20.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function getAllUsers(): array
+    {
+        $resp = $this->request()->get($this->baseUrl.'/groups/trust_level_0/members.json', [
+            'limit' => 1000,
+            'offset' => 0,
+        ]);
+        $data = $resp->json();
+
+        if (!is_array($data) || !isset($data['members'])) {
+            $err = is_array($data) && isset($data['errors']) ? implode(', ', (array) $data['errors']) : 'unexpected response';
+            throw new \RuntimeException('Discourse getAllUsers: '.$err);
+        }
+
+        return $data['members'];
+    }
+
+    /**
+     * Admin view of a user — includes bounce_score, single_sign_on_record
+     * (external_id) and last_emailed_at.
+     *
+     * @return array<string, mixed>
+     */
+    public function getUser(int $id, string $username): array
+    {
+        return (array) $this->request()->get($this->baseUrl."/admin/users/{$id}/{$username}.json")->json();
+    }
+
+    /**
+     * Public profile of a user — includes watched/tracked category ids,
+     * user_option (mailing_list_mode, email_digests) and bio_raw.
+     *
+     * @return array<string, mixed>
+     */
+    public function getUserPublic(string $username): array
+    {
+        $data = $this->request()->get($this->baseUrl."/u/{$username}.json")->json();
+
+        return is_array($data) && isset($data['user']) ? (array) $data['user'] : [];
+    }
+
+    /** The user's primary email address. */
+    public function getUserEmail(string $username): string
+    {
+        $data = $this->request()->get($this->baseUrl."/users/{$username}/emails.json")->json();
+
+        return is_array($data) ? (string) ($data['email'] ?? '') : '';
+    }
+
+    /**
+     * Add a watched category to the user, preserving the ones they already
+     * watch (V1 SetWatchCategory).
+     *
+     * @param  array<int, int>  $alreadyWatching
+     */
+    public function setWatchCategory(string $username, array $alreadyWatching, int $categoryId): void
+    {
+        $watch = array_values($alreadyWatching);
+        $watch[] = $categoryId;
+
+        $this->request()->asForm()->put($this->baseUrl."/users/{$username}.json", [
+            'watched_category_ids' => $watch,
+        ]);
+    }
+
+    /** Set the user's bio (V1 SetBio). */
+    public function setBio(string $username, string $bio): void
+    {
+        $this->request()->asForm()->put($this->baseUrl."/users/{$username}.json", [
+            'bio_raw' => $bio,
+        ]);
+    }
+}

--- a/iznik-batch/app/Services/DiscourseNotSignedUpService.php
+++ b/iznik-batch/app/Services/DiscourseNotSignedUpService.php
@@ -1,0 +1,229 @@
+<?php
+
+namespace App\Services;
+
+use App\Mail\Housekeeper\DiscourseReportMail;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Daily check for Freegle groups not represented by an active moderator on
+ * Discourse, plus active mods who haven't signed up and mods whose preferred
+ * email is a TrashNothing address. Faithful migration of V1
+ * scripts/cron/discourse_not_signed_up.php.
+ *
+ * "Active" mod = Owner/Moderator on a Freegle group with users.lastaccess in
+ * the last 6 months. Reports daily to geeks (and central mods) on Saturdays or
+ * whenever a group is unrepresented.
+ */
+class DiscourseNotSignedUpService
+{
+    public function __construct(private DiscourseClient $client)
+    {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function run(): array
+    {
+        if (!$this->client->isConfigured()) {
+            Log::warning('DiscourseNotSignedUpService: Discourse API key not configured — skipping.');
+
+            return ['skipped' => true];
+        }
+
+        $throttleUs = (int) config('freegle.discourse.throttle_us', 250000);
+
+        $allDusers = $this->client->getAllUsers();
+
+        // Published groups, all initially "not represented".
+        $allGroups = DB::table('groups')
+            ->where('publish', 1)
+            ->orderBy('nameshort')
+            ->get(['id', 'nameshort']);
+        $represented = [];
+        foreach ($allGroups as $g) {
+            $represented[$g->id] = false;
+        }
+
+        // Active mods (one row per user+group they moderate), ordered by user id.
+        $sixMonthsAgo = Carbon::now()->subMonths(6);
+        $activeModsGroups = DB::table('users')
+            ->join('memberships', 'users.id', '=', 'memberships.userid')
+            ->join('groups', 'groups.id', '=', 'memberships.groupid')
+            ->whereIn('memberships.role', ['Owner', 'Moderator'])
+            ->where('groups.type', 'Freegle')
+            ->where('users.lastaccess', '>', $sixMonthsAgo)
+            ->orderBy('users.id')
+            ->get([
+                'users.id as id',
+                'users.fullname as fullname',
+                'users.lastaccess as lastaccess',
+                'groups.id as groupid',
+                'memberships.settings as settings',
+            ]);
+
+        $distinctActiveMods = $activeModsGroups->pluck('id')->unique()->count();
+
+        $reportTop = 'Total Discourse users: '.count($allDusers)."\n";
+        $reportTop .= 'Published groups: '.count($allGroups)."\n";
+        $reportTop .= 'Total active mods: '.$distinctActiveMods." (in last 6 months)\n";
+        $reportMid = "\nList of these volunteers not on Discourse:\n";
+
+        $activeModIds = $activeModsGroups->pluck('id')->map(fn ($v) => (int) $v)->unique()->all();
+
+        // Resolve every Discourse user's MT external_id and flag TN preferred mails.
+        $discourseExternalIds = [];
+        $modswithTNpreferredemails = 0;
+
+        foreach ($allDusers as $duser) {
+            $this->throttle($throttleUs);
+
+            $username = (string) ($duser['username'] ?? '');
+            $fulluser = $this->client->getUser((int) ($duser['id'] ?? 0), $username);
+
+            $externalId = null;
+            if (isset($fulluser['single_sign_on_record']) && is_array($fulluser['single_sign_on_record'])) {
+                $externalId = $fulluser['single_sign_on_record']['external_id'] ?? null;
+            }
+
+            if ($externalId === null || $externalId === false || $externalId === '') {
+                continue;
+            }
+            $externalId = (int) $externalId;
+
+            // If the SSO external_id isn't a current active mod (e.g. stale after
+            // a merge), fall back to resolving by the Discourse email.
+            if (!in_array($externalId, $activeModIds, true)) {
+                $demail = $this->client->getUserEmail($username);
+                if ($demail !== '') {
+                    $byEmail = DB::table('users_emails')->where('email', $demail)->value('userid');
+                    if ($byEmail) {
+                        $externalId = (int) $byEmail;
+                    }
+                }
+            }
+
+            $discourseExternalIds[$externalId] = true;
+
+            // Mods whose preferred email is a TrashNothing address.
+            $tn = DB::table('users_emails')
+                ->where('userid', $externalId)
+                ->where('preferred', 1)
+                ->where('email', 'LIKE', '%@user.trashnothing.com')
+                ->value('email');
+            if ($tn) {
+                $reportTop .= 'MOD HAS TN preferred email: '.$externalId.' - '.$tn."\n";
+                $modswithTNpreferredemails++;
+            }
+        }
+
+        // Active mods not on Discourse, and which groups are represented.
+        $notondiscourse = 0;
+        $lastmodid = 0;
+        foreach ($activeModsGroups as $mod) {
+            $modId = (int) $mod->id;
+            $modfirstseen = $lastmodid !== $modId;
+            $lastmodid = $modId;
+
+            $found = isset($discourseExternalIds[$modId]);
+
+            if ($modfirstseen && !$found) {
+                $reportMid .= '* '.$modId.': '.$mod->fullname.' - '.$mod->lastaccess."\n";
+                $notondiscourse++;
+            }
+
+            if ($found) {
+                // A mod with this group muted (active:0) doesn't count as cover.
+                if ($mod->settings && str_contains($mod->settings, '"active":0')) {
+                    continue;
+                }
+                $represented[$mod->groupid] = true;
+            }
+        }
+
+        $reportMid .= "\nActive volunteers not on discourse: $notondiscourse\n\n";
+
+        // Groups with no active mod represented on Discourse.
+        $notrepresentedcount = 0;
+        foreach ($allGroups as $group) {
+            if (!empty($represented[$group->id])) {
+                continue;
+            }
+
+            $reportTop .= 'NOT REPRESENTED '.$group->id.' - '.$group->nameshort."\n";
+            foreach ($activeModsGroups as $mod) {
+                if ((int) $mod->groupid === (int) $group->id) {
+                    $reportTop .= '* Moderator: '.$mod->id.' - '.$mod->fullname."\n";
+                }
+            }
+            $notrepresentedcount++;
+        }
+
+        $reportTop .= "\nGroups without active volunteers on Discourse: $notrepresentedcount\n";
+        $reportTop .= "Mods with TN preferred emails: $modswithTNpreferredemails\n\n";
+
+        $report = $reportTop.$reportMid;
+        $report .= "\ndiscourse:not-signed-up — migrated from V1 discourse_not_signed_up.php\n";
+
+        $this->sendReports($notrepresentedcount, $notondiscourse, $report);
+
+        return [
+            'skipped' => false,
+            'notrepresented' => $notrepresentedcount,
+            'notondiscourse' => $notondiscourse,
+            'tnpreferred' => $modswithTNpreferredemails,
+        ];
+    }
+
+    private function sendReports(int $notrepresented, int $notondiscourse, string $report): void
+    {
+        $from = (string) config('freegle.mail.geeks_addr', 'geeks@ilovefreegle.org');
+        $geeks = (string) config('freegle.mail.geek_alerts_addr', 'geek-alerts@ilovefreegle.org');
+        $centralmods = (string) config('freegle.mail.centralmods_addr');
+
+        $subject = 'Discourse: ';
+        if ($notrepresented === 0) {
+            $subject .= 'All groups represented. ';
+        } else {
+            $subject .= "$notrepresented groups not represented. ";
+        }
+        if ($notondiscourse > 0) {
+            $subject .= "$notondiscourse volunteers not signed up. ";
+        }
+        if ($notrepresented === 0 && $notondiscourse === 0) {
+            $subject .= 'all active volunteers on here';
+        }
+
+        $weeklySendToday = Carbon::now()->dayOfWeek === Carbon::SATURDAY;
+
+        if ($weeklySendToday || $notrepresented > 0) {
+            $this->send($centralmods, 'Volunteer Support', $from, $subject, $report);
+            $this->send($geeks, 'Geeks Alerts', $from, $subject, $report);
+        }
+    }
+
+    private function send(string $to, string $toName, string $from, string $subject, string $body): void
+    {
+        if ($to === '') {
+            return;
+        }
+
+        try {
+            app(EmailSpoolerService::class)->spool(
+                new DiscourseReportMail($to, $toName, $from, $subject, $body)
+            );
+        } catch (\Throwable $e) {
+            Log::error('DiscourseNotSignedUpService: mail failed', ['to' => $to, 'error' => $e->getMessage()]);
+        }
+    }
+
+    private function throttle(int $us): void
+    {
+        if ($us > 0) {
+            usleep($us);
+        }
+    }
+}

--- a/iznik-batch/app/Services/DoogalService.php
+++ b/iznik-batch/app/Services/DoogalService.php
@@ -1,0 +1,277 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Maintains the UK postcode rows in the `locations` table from the Doogal
+ * Code-Point Open dataset (https://www.doogal.co.uk/files/postcodes.zip).
+ *
+ * Faithful migration of V1 scripts/cli/doogal.php (+ the cron/doogal wrapper
+ * that downloaded and unzipped the CSV). For each "in use" postcode it either
+ * refreshes the lat/lng of an existing location (when it has drifted by more
+ * than 2 decimal places) or creates a new Postcode location with a spatial
+ * index entry and centroid lat/lng.
+ *
+ * Mapping new postcodes onto Freegle group areas is deliberately NOT done here:
+ * V1's Location::create() called remapPostcodes() inline, but in Laravel that
+ * work is owned by the scheduled `locations:sync-pgsql` job
+ * ({@see PostcodeRemapService}) — the same "background cron job to save us" that
+ * V1 relied on for the PostGIS copy.
+ */
+class DoogalService
+{
+    private int $srid;
+
+    public function __construct()
+    {
+        $this->srid = (int) config('freegle.srid', 3857);
+    }
+
+    /**
+     * Download the postcodes ZIP, extract it, and return the path to the CSV
+     * inside. Caller is responsible for removing the returned file (and its
+     * containing directory) when done.
+     */
+    public function fetchCsv(?string $url = null): string
+    {
+        $url = $url ?: config('freegle.doogal.zip_url');
+
+        $dir = sys_get_temp_dir().'/doogal_'.uniqid('', true);
+        if (!mkdir($dir) && !is_dir($dir)) {
+            throw new \RuntimeException("Could not create temp dir: {$dir}");
+        }
+
+        $zipPath = $dir.'/postcodes.zip';
+        $response = Http::timeout(600)->get($url);
+        if (!$response->successful()) {
+            throw new \RuntimeException("Failed to download {$url}: HTTP {$response->status()}");
+        }
+        file_put_contents($zipPath, $response->body());
+
+        $zip = new \ZipArchive();
+        if ($zip->open($zipPath) !== true) {
+            throw new \RuntimeException("Could not open ZIP: {$zipPath}");
+        }
+        $csvName = null;
+        for ($i = 0; $i < $zip->numFiles; $i++) {
+            $name = $zip->getNameIndex($i);
+            if (str_ends_with(strtolower((string) $name), '.csv')) {
+                $csvName = $name;
+                break;
+            }
+        }
+        if ($csvName === null) {
+            $zip->close();
+            throw new \RuntimeException("No CSV found inside {$zipPath}");
+        }
+        $zip->extractTo($dir, $csvName);
+        $zip->close();
+
+        return $dir.'/'.$csvName;
+    }
+
+    /**
+     * Process a Code-Point/Doogal CSV, adding new postcodes and refreshing
+     * changed lat/lng. Returns counts: [processed, added, updated, failed].
+     *
+     * @param  callable|null  $progress  fn(int $processed, int $added, int $updated)
+     * @return array{processed:int, added:int, updated:int, failed:int}
+     */
+    public function process(string $csvPath, ?callable $progress = null): array
+    {
+        // Build an in-memory index of existing locations whose name contains a
+        // space (i.e. full postcodes), keyed by the space-stripped lowercase
+        // name — matching V1's $locIndex.
+        $locIndex = [];
+        DB::table('locations')
+            ->select('id', 'name', 'lat', 'lng', 'type')
+            ->whereRaw("LOCATE(' ', name) > 0")
+            ->orderBy('id')
+            ->chunk(10000, function ($locs) use (&$locIndex) {
+                foreach ($locs as $loc) {
+                    $canon = strtolower(str_replace(' ', '', $loc->name));
+                    $locIndex[$canon] = $loc;
+                }
+            });
+
+        $fh = fopen($csvPath, 'r');
+        if ($fh === false) {
+            throw new \RuntimeException("Could not open CSV: {$csvPath}");
+        }
+
+        $processed = 0;
+        $added = 0;
+        $updated = 0;
+        $failed = 0;
+
+        while (($fields = fgetcsv($fh)) !== false) {
+            $processed++;
+
+            if ($progress && $processed % 1000 === 0) {
+                ($progress)($processed, $added, $updated);
+            }
+
+            // Column layout: Postcode, In Use?, Latitude, Longitude, ...
+            if (($fields[1] ?? '') !== 'Yes') {
+                continue;
+            }
+
+            $pc = $fields[0] ?? '';
+            $lat = $fields[2] ?? null;
+            $lng = $fields[3] ?? null;
+
+            if ($pc === '' || (!$lat && !$lng)) {
+                continue;
+            }
+
+            $canon = strtolower(str_replace(' ', '', $pc));
+
+            if (isset($locIndex[$canon])) {
+                // Existing postcode: refresh only if lat/lng changed at 2dp, or
+                // if the location wasn't previously typed as a Postcode. Smaller
+                // differences happen constantly and aren't worth a write.
+                $old = $locIndex[$canon];
+                $newlat = round((float) $lat, 2);
+                $newlng = round((float) $lng, 2);
+                $oldlat = round((float) $old->lat, 2);
+                $oldlng = round((float) $old->lng, 2);
+
+                if ($newlat != $oldlat || $newlng != $oldlng || $old->type !== 'Postcode') {
+                    $this->updatePostcode((int) $old->id, (float) $lat, (float) $lng);
+                    $updated++;
+                }
+            } else {
+                $id = $this->createPostcode($pc, (float) $lng, (float) $lat);
+                if ($id) {
+                    $added++;
+                } else {
+                    $failed++;
+                }
+            }
+        }
+
+        fclose($fh);
+
+        $this->fixSpatialIndex();
+
+        Log::info('DoogalService: processed postcode CSV', compact('processed', 'added', 'updated', 'failed'));
+
+        return compact('processed', 'added', 'updated', 'failed');
+    }
+
+    /**
+     * Create a new Postcode location plus its spatial-index row and centroid
+     * lat/lng, mirroring the Postcode path of V1 Location::create().
+     */
+    private function createPostcode(string $name, float $lng, float $lat): ?int
+    {
+        $point = "POINT($lng $lat)";
+
+        DB::insert(
+            'INSERT INTO locations (osm_id, name, type, geometry, canon, osm_place, maxdimension) '
+            .'VALUES (NULL, ?, ?, ST_GeomFromText(?, ?), ?, 0, GetMaxDimension(ST_GeomFromText(?, ?)))',
+            [$name, 'Postcode', $point, $this->srid, $this->canon($name), $point, $this->srid]
+        );
+        $id = (int) DB::getPdo()->lastInsertId();
+        if (!$id) {
+            return null;
+        }
+
+        DB::insert(
+            'INSERT INTO locations_spatial (locationid, geometry) VALUES (?, ST_GeomFromText(?, ?))',
+            [$id, $point, $this->srid]
+        );
+
+        // Cache lat/lng from the geometry centroid (speeds up later queries).
+        DB::update(
+            'UPDATE locations SET lng = ST_X(ST_Centroid(geometry)), lat = ST_Y(ST_Centroid(geometry)) WHERE id = ?',
+            [$id]
+        );
+
+        // Assign the containing grid square, if any.
+        $grid = DB::selectOne(
+            'SELECT locations_grids.id AS gridid FROM locations '
+            .'INNER JOIN locations_grids ON locations.id = ? AND MBRIntersects(locations.geometry, locations_grids.box) LIMIT 1',
+            [$id]
+        );
+        if ($grid && $grid->gridid) {
+            DB::update('UPDATE locations SET gridid = ? WHERE id = ?', [$grid->gridid, $id]);
+        }
+
+        // Link a full postcode (e.g. "AB1 2CD") to its parent district ("AB1").
+        $sp = strpos($name, ' ');
+        if ($sp !== false) {
+            $parent = DB::selectOne(
+                "SELECT id FROM locations WHERE name = ? AND type = 'Postcode' LIMIT 1",
+                [substr($name, 0, $sp)]
+            );
+            if ($parent) {
+                DB::update('UPDATE locations SET postcodeid = ? WHERE id = ?', [$parent->id, $id]);
+            }
+        }
+
+        return $id;
+    }
+
+    /**
+     * Refresh an existing location's lat/lng and geometry to the new postcode
+     * position, re-typing it as a Postcode. Mirrors V1's UPDATE + REPLACE.
+     */
+    private function updatePostcode(int $id, float $lat, float $lng): void
+    {
+        $point = "POINT($lng $lat)";
+
+        DB::update(
+            'UPDATE locations SET lat = ?, lng = ?, type = ?, geometry = ST_GeomFromText(?, ?), ourgeometry = NULL WHERE id = ?',
+            [$lat, $lng, 'Postcode', $point, $this->srid, $id]
+        );
+
+        DB::statement(
+            'REPLACE INTO locations_spatial (locationid, geometry) VALUES (?, ST_GeomFromText(?, ?))',
+            [$id, $point, $this->srid]
+        );
+    }
+
+    /**
+     * Re-sync any locations_spatial rows whose geometry has drifted from the
+     * canonical location geometry (V1's closing "Check loc index" pass).
+     */
+    private function fixSpatialIndex(): void
+    {
+        $badlocs = DB::select(
+            'SELECT locations.id, ST_AsText(CASE WHEN ourgeometry IS NOT NULL THEN ourgeometry ELSE locations.geometry END) AS g '
+            .'FROM locations INNER JOIN locations_spatial ON locations_spatial.locationid = locations.id '
+            .'WHERE CASE WHEN ourgeometry IS NOT NULL THEN ourgeometry ELSE locations.geometry END != locations_spatial.geometry'
+        );
+
+        foreach ($badlocs as $bad) {
+            DB::update(
+                'UPDATE locations_spatial SET geometry = ST_GeomFromText(?, ?) WHERE locationid = ?',
+                [$bad->g, $this->srid, $bad->id]
+            );
+        }
+    }
+
+    /**
+     * Canonicalise a location name for the `canon` column. Mirrors V1
+     * Location::canon() (common abbreviation expansion + strip non-alphanumerics).
+     */
+    private function canon(string $str): string
+    {
+        $str = preg_replace('/^St\b/', 'Saint', $str);
+        $str = preg_replace('/\bSt\b/', 'Street', $str);
+        $str = preg_replace('/\bRd\b/', 'Road', $str);
+        $str = preg_replace('/\bAvenue\b/', 'Av', $str);
+        $str = preg_replace('/\bDr\b/', 'Drive', $str);
+        $str = preg_replace('/\bLn\b/', 'Lane', $str);
+        $str = preg_replace('/\bPl\b/', 'Place', $str);
+        $str = preg_replace('/\bSq\b/', 'Square', $str);
+        $str = preg_replace('/\bCls\b/', 'Close', $str);
+
+        return strtolower(preg_replace('/[^A-Za-z0-9]/', '', $str));
+    }
+}

--- a/iznik-batch/app/Services/EmailSpoolerService.php
+++ b/iznik-batch/app/Services/EmailSpoolerService.php
@@ -419,8 +419,13 @@ class EmailSpoolerService
             $filename = basename($pendingPath);
             $sendingPath = $this->sendingDir . '/' . $filename;
 
-            // Move to sending directory.
-            if (!rename($pendingPath, $sendingPath)) {
+            // Move to sending directory. Another processor (a second
+            // mail:spool:process run or a supervisor worker) may claim this file
+            // between the glob() above and here, in which case rename() fails on
+            // a now-missing source. Suppress the warning so the source-missing
+            // case takes this graceful skip instead of bubbling up as an
+            // ErrorException via Laravel's error handler.
+            if (!@rename($pendingPath, $sendingPath)) {
                 Log::warning('Could not move spool file to sending', ['file' => $filename]);
                 continue;
             }

--- a/iznik-batch/app/Services/PaypalDownloadService.php
+++ b/iznik-batch/app/Services/PaypalDownloadService.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Fallback downloader for PayPal donations the IPN missed. Faithful migration
+ * of V1 scripts/cron/paypal_download.php.
+ *
+ * Scans the last N days one day at a time via the PayPal NVP TransactionSearch
+ * API and upserts each qualifying payment into users_donations (keyed on the
+ * unique TransactionID). The donate IPN catches donations normally; this only
+ * backfills gaps, so it deliberately tolerates per-day failures and carries on.
+ */
+class PaypalDownloadService
+{
+    /**
+     * @param  callable|null  $progress  fn(string $date, int $found, int $upserted)
+     * @return array{skipped:bool, days:int, found:int, upserted:int}
+     */
+    public function download(?callable $progress = null): array
+    {
+        $username = (string) config('freegle.paypal.username');
+        if ($username === '') {
+            Log::warning('PaypalDownloadService: PAYPAL_USERNAME not configured — skipping.');
+
+            return ['skipped' => true, 'days' => 0, 'found' => 0, 'upserted' => 0];
+        }
+
+        $days = (int) config('freegle.paypal.download_days', 30);
+        $tz = config('freegle.timezone', 'Europe/London');
+
+        $start = Carbon::today($tz);
+        $end = Carbon::tomorrow($tz);
+        $limit = Carbon::today($tz)->subDays($days);
+
+        $found = 0;
+        $upserted = 0;
+        $daysScanned = 0;
+
+        do {
+            $daysScanned++;
+
+            if ($progress) {
+                ($progress)($start->toDateString(), $found, $upserted);
+            }
+
+            try {
+                foreach ($this->searchTransactions($start, $end) as $t) {
+                    // Skip non-payments, refunds/zero amounts, and PayPal Giving
+                    // Fund donations (processed separately).
+                    if ($t['email'] === '' || $t['amount'] <= 0 || $t['name'] === 'PayPal Giving Fund UK') {
+                        continue;
+                    }
+
+                    $found++;
+                    if ($this->upsertDonation($t)) {
+                        $upserted++;
+                    }
+                }
+            } catch (\Throwable $e) {
+                Log::error('PaypalDownloadService: search failed', [
+                    'date' => $start->toDateString(),
+                    'error' => $e->getMessage(),
+                ]);
+                report($e);
+            }
+
+            $start = $start->copy()->subDay();
+            $end = $end->copy()->subDay();
+        } while ($start->greaterThan($limit));
+
+        Log::info('PaypalDownloadService: done', [
+            'days' => $daysScanned,
+            'found' => $found,
+            'upserted' => $upserted,
+        ]);
+
+        return ['skipped' => false, 'days' => $daysScanned, 'found' => $found, 'upserted' => $upserted];
+    }
+
+    /**
+     * Call PayPal NVP TransactionSearch for a [start, end) window and return a
+     * normalised list of transactions.
+     *
+     * @return array<int, array{email:string, name:string, timestamp:string, transactionid:string, amount:float}>
+     */
+    private function searchTransactions(Carbon $start, Carbon $end): array
+    {
+        $response = Http::asForm()
+            ->timeout(120)
+            ->post(config('freegle.paypal.nvp_endpoint'), [
+                'USER' => config('freegle.paypal.username'),
+                'PWD' => config('freegle.paypal.password'),
+                'SIGNATURE' => config('freegle.paypal.signature'),
+                'METHOD' => 'TransactionSearch',
+                'VERSION' => '204.0',
+                'STARTDATE' => $start->toIso8601String(),
+                'ENDDATE' => $end->toIso8601String(),
+            ]);
+
+        if (!$response->successful()) {
+            throw new \RuntimeException('PayPal NVP HTTP '.$response->status());
+        }
+
+        parse_str($response->body(), $parsed);
+
+        $ack = $parsed['ACK'] ?? '';
+        if (stripos((string) $ack, 'Success') === false) {
+            $err = $parsed['L_LONGMESSAGE0'] ?? 'unknown error';
+            throw new \RuntimeException("PayPal NVP ACK={$ack}: {$err}");
+        }
+
+        $txns = [];
+        for ($i = 0; isset($parsed["L_TRANSACTIONID{$i}"]); $i++) {
+            $txns[] = [
+                'email' => (string) ($parsed["L_EMAIL{$i}"] ?? ''),
+                'name' => (string) ($parsed["L_NAME{$i}"] ?? ''),
+                'timestamp' => (string) ($parsed["L_TIMESTAMP{$i}"] ?? ''),
+                'transactionid' => (string) $parsed["L_TRANSACTIONID{$i}"],
+                'amount' => (float) ($parsed["L_AMT{$i}"] ?? 0),
+            ];
+        }
+
+        return $txns;
+    }
+
+    /**
+     * Upsert a transaction into users_donations keyed on the unique
+     * TransactionID, matching the donor to an account by email/canon. Mirrors
+     * V1's INSERT ... ON DUPLICATE KEY UPDATE userid, timestamp.
+     */
+    private function upsertDonation(array $t): bool
+    {
+        $userid = $this->findUserByEmail($t['email']);
+        $timestamp = $t['timestamp'] !== ''
+            ? date('Y-m-d H:i:s', strtotime($t['timestamp']))
+            : now()->format('Y-m-d H:i:s');
+
+        return DB::insert(
+            'INSERT INTO users_donations (userid, Payer, PayerDisplayName, timestamp, TransactionID, GrossAmount) '
+            .'VALUES (?, ?, ?, ?, ?, ?) ON DUPLICATE KEY UPDATE userid = ?, timestamp = ?',
+            [$userid, $t['email'], $t['name'], $timestamp, $t['transactionid'], $t['amount'], $userid, $timestamp]
+        );
+    }
+
+    /**
+     * Resolve a payer email to a Freegle user id, matching V1
+     * User::findByEmail (exact address or canonical form).
+     */
+    private function findUserByEmail(string $email): ?int
+    {
+        $canon = User::canonMail($email);
+
+        $uid = DB::table('users_emails')
+            ->where(function ($q) use ($email, $canon) {
+                $q->where('email', $email)->orWhere('canon', $canon);
+            })
+            ->whereNotNull('canon')
+            ->whereRaw('LENGTH(canon) > 0')
+            ->value('userid');
+
+        return $uid ? (int) $uid : null;
+    }
+}

--- a/iznik-batch/config/freegle.php
+++ b/iznik-batch/config/freegle.php
@@ -94,6 +94,9 @@ return [
         'thanks_addr' => env('FREEGLE_THANKS_ADDR', env('FREEGLE_FUNDRAISING_ADDR', 'info@ilovefreegle.org')),
         // Mentors address — volunteer support team who handle escalations.
         'mentors_addr' => env('FREEGLE_MENTORS_ADDR', 'mentors@ilovefreegle.org'),
+        // Central mods / Volunteer Support address — receives the Discourse
+        // checkuser / not-signed-up reports (V1 CENTRALMODS_ADDR).
+        'centralmods_addr' => env('FREEGLE_CENTRALMODS_ADDR', 'volunteers@ilovefreegle.org'),
         // CC address for donation notification emails (legacy logging).
         'donation_cc_addr' => env('FREEGLE_DONATION_CC_ADDR', 'log@ehibbert.org.uk'),
         // Modbot email — the automated moderator account; excluded from mod-welfare checks.
@@ -108,6 +111,33 @@ return [
         'api_key' => env('FREEGLE_TN_API_KEY', ''),
         'api_base_url' => env('FREEGLE_TN_API_BASE_URL', 'https://trashnothing.com/fd/api'),
         'sync_date_file' => env('FREEGLE_TN_SYNC_DATE_FILE', '/etc/tn_sync_last_date.txt'),
+    ],
+
+    // Discourse forum REST API (V1 discourse_checkusers.php / discourse_not_signed_up.php).
+    // When api_key is empty the Discourse cron commands skip with a warning.
+    'discourse' => [
+        'url' => env('DISCOURSE_URL', 'https://discourse.ilovefreegle.org'),
+        'api_key' => env('DISCOURSE_APIKEY', ''),
+        'api_username' => env('DISCOURSE_API_USERNAME', 'system'),
+        // Discourse category id members are auto-watched onto (V1 ANNOUNCEMENTS_ID).
+        'announcements_category_id' => (int) env('DISCOURSE_ANNOUNCEMENTS_ID', 7),
+    ],
+
+    // PayPal NVP/SOAP API (V1 paypal_download.php fallback transaction downloader).
+    // When username is empty the donations:paypal-download command skips with a warning.
+    'paypal' => [
+        'username' => env('PAYPAL_USERNAME', ''),
+        'password' => env('PAYPAL_PASSWORD', ''),
+        'signature' => env('PAYPAL_SIGNATURE', ''),
+        // Live NVP endpoint; sandbox is https://api-3t.sandbox.paypal.com/nvp
+        'nvp_endpoint' => env('PAYPAL_NVP_ENDPOINT', 'https://api-3t.paypal.com/nvp'),
+        // How many days back to scan for missed transactions.
+        'download_days' => (int) env('PAYPAL_DOWNLOAD_DAYS', 30),
+    ],
+
+    // Doogal UK postcode dataset (V1 cli/doogal.php + cron/doogal wrapper).
+    'doogal' => [
+        'zip_url' => env('DOOGAL_ZIP_URL', 'https://www.doogal.co.uk/files/postcodes.zip'),
     ],
 
     'digest' => [

--- a/iznik-batch/config/freegle.php
+++ b/iznik-batch/config/freegle.php
@@ -96,7 +96,7 @@ return [
         'mentors_addr' => env('FREEGLE_MENTORS_ADDR', 'mentors@ilovefreegle.org'),
         // Central mods / Volunteer Support address — receives the Discourse
         // checkuser / not-signed-up reports (V1 CENTRALMODS_ADDR).
-        'centralmods_addr' => env('FREEGLE_CENTRALMODS_ADDR', 'volunteers@ilovefreegle.org'),
+        'centralmods_addr' => env('FREEGLE_CENTRALMODS_ADDR', 'volunteersupport@ilovefreegle.org'),
         // CC address for donation notification emails (legacy logging).
         'donation_cc_addr' => env('FREEGLE_DONATION_CC_ADDR', 'log@ehibbert.org.uk'),
         // Modbot email — the automated moderator account; excluded from mod-welfare checks.

--- a/iznik-batch/routes/console.php
+++ b/iznik-batch/routes/console.php
@@ -630,6 +630,48 @@ Schedule::command('microvolunteering:notify')
     ->sendOutputTo(cronLog('microvolunteering:notify'))
     ->runInBackground();
 
+// Exhort recently-active established users with an on-site notification nudge
+// (default: "Tell us your Freegle story!"). The 90-day per-user cooldown means
+// running every minute over a 5-minute active window simply dedupes; matches V1.
+// V1: cron/user_exhort.php (every minute).
+Schedule::command('notifications:exhort')
+    ->everyMinute()
+    ->withoutOverlapping()
+    ->sendOutputTo(cronLog('notifications:exhort'))
+    ->runInBackground();
+
+// Refresh UK postcodes (add new, update moved lat/lng) from the Doogal dataset.
+// Downloads + unzips the CSV itself. V1: cron/doogal wrapper (daily at 03:00).
+Schedule::command('locations:update-postcodes')
+    ->dailyAt('03:00')
+    ->withoutOverlapping()
+    ->sendOutputTo(cronLog('locations:update-postcodes'))
+    ->runInBackground();
+
+// Fallback downloader for PayPal donations the IPN missed (last 30 days).
+// V1: cron/paypal_download.php (every 4 hours at :30). Skips if PayPal creds unset.
+Schedule::command('donations:paypal-download')
+    ->cron('30 */4 * * *')
+    ->withoutOverlapping()
+    ->sendOutputTo(cronLog('donations:paypal-download'))
+    ->runInBackground();
+
+// Audit Discourse users against MT mods (watching/bios/bounces) and email a report.
+// V1: cron/discourse_checkusers.php (daily at 03:08). Skips if Discourse API key unset.
+Schedule::command('discourse:check-users')
+    ->dailyAt('03:08')
+    ->withoutOverlapping()
+    ->sendOutputTo(cronLog('discourse:check-users'))
+    ->runInBackground();
+
+// Report Freegle groups not represented by an active mod on Discourse + mods not
+// signed up. V1: cron/discourse_not_signed_up.php (daily at 03:23). Skips if key unset.
+Schedule::command('discourse:not-signed-up')
+    ->dailyAt('03:23')
+    ->withoutOverlapping()
+    ->sendOutputTo(cronLog('discourse:not-signed-up'))
+    ->runInBackground();
+
 // Update cached location names in user settings when the canonical name has changed.
 // V1: cron/users_remap.php (daily at 05:00)
 Schedule::command('users:remap-locations')

--- a/iznik-batch/tests/Unit/Services/DiscourseCheckUsersServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/DiscourseCheckUsersServiceTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Mail\Housekeeper\DiscourseReportMail;
+use App\Services\DiscourseCheckUsersService;
+use App\Services\DiscourseClient;
+use Illuminate\Support\Facades\Mail;
+use Mockery;
+use Tests\TestCase;
+
+/**
+ * Behaviour of {@see DiscourseCheckUsersService} (V1 discourse_checkusers.php).
+ * The Discourse REST client is mocked; the focus is mod detection, the
+ * announcements-watch fix, bio updates, and the report email routing.
+ */
+class DiscourseCheckUsersServiceTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config([
+            'freegle.discourse.throttle_us' => 0,
+            'freegle.discourse.announcements_category_id' => 7,
+            'freegle.mail.centralmods_addr' => 'central@example.com',
+            'freegle.mail.geek_alerts_addr' => 'geeks@example.com',
+            'freegle.mail.geeks_addr' => 'from@example.com',
+        ]);
+    }
+
+    public function test_skips_when_not_configured(): void
+    {
+        $client = Mockery::mock(DiscourseClient::class);
+        $client->shouldReceive('isConfigured')->andReturn(false);
+        $client->shouldNotReceive('getAllUsers');
+
+        $result = (new DiscourseCheckUsersService($client))->run();
+
+        $this->assertTrue($result['skipped']);
+    }
+
+    public function test_audits_users_fixes_watching_and_emails_when_non_mod_found(): void
+    {
+        Mail::fake();
+
+        $group = $this->createTestGroup();
+        $modUser = $this->createTestUser();
+        $this->createMembership($modUser, $group, ['role' => 'Owner']);
+        $plainUser = $this->createTestUser(); // exists but moderates nothing
+
+        $client = Mockery::mock(DiscourseClient::class);
+        $client->shouldReceive('isConfigured')->andReturn(true);
+        $client->shouldReceive('getAllUsers')->andReturn([
+            ['id' => 101, 'username' => 'moduser', 'last_posted_at' => null, 'last_seen_at' => null],
+            ['id' => 102, 'username' => 'notmoduser', 'last_posted_at' => null, 'last_seen_at' => null],
+            ['id' => 1, 'username' => 'freeglegeeks'],
+        ]);
+        $client->shouldReceive('getUser')->andReturnUsing(function ($id, $username) use ($modUser, $plainUser) {
+            return [
+                'bounce_score' => 0,
+                'last_emailed_at' => null,
+                'single_sign_on_record' => [
+                    'external_id' => $username === 'moduser' ? $modUser->id : $plainUser->id,
+                ],
+            ];
+        });
+        $client->shouldReceive('getUserEmail')->andReturnUsing(fn ($u) => $u.'@example.com');
+        $client->shouldReceive('getUserPublic')->andReturn([
+            'watched_category_ids' => [],
+            'watched_first_post_category_ids' => [],
+            'tracked_category_ids' => [5],
+            'user_option' => ['mailing_list_mode' => false, 'email_digests' => true],
+            'bio_raw' => '',
+        ]);
+        // Both users are missing the announcements category → should be added.
+        $client->shouldReceive('setWatchCategory')->twice();
+        // Both users' bios differ from '' → should be set.
+        $client->shouldReceive('setBio')->twice();
+
+        $result = (new DiscourseCheckUsersService($client))->run();
+
+        $this->assertFalse($result['skipped']);
+        $this->assertSame(1, $result['system']);
+        $this->assertSame(1, $result['ismod']);
+        $this->assertSame(1, $result['notmod']);
+        $this->assertSame(0, $result['notuser']);
+        $this->assertSame(2, $result['notonannouncements']);
+        $this->assertSame(2, $result['bioupdatedcount']);
+
+        // A non-mod was found → central mods + geeks both emailed.
+        Mail::assertSent(DiscourseReportMail::class, fn ($m) => $m->recipientEmail === 'central@example.com'
+            && $m->emailSubject === 'Discourse checkuser USERS TO CHECK');
+        Mail::assertSent(DiscourseReportMail::class, fn ($m) => $m->recipientEmail === 'geeks@example.com');
+        Mail::assertSentCount(2);
+    }
+}

--- a/iznik-batch/tests/Unit/Services/DiscourseNotSignedUpServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/DiscourseNotSignedUpServiceTest.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Mail\Housekeeper\DiscourseReportMail;
+use App\Services\DiscourseClient;
+use App\Services\DiscourseNotSignedUpService;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Mail;
+use Mockery;
+use Tests\TestCase;
+
+/**
+ * Behaviour of {@see DiscourseNotSignedUpService} (V1 discourse_not_signed_up.php).
+ * The Discourse REST client is mocked. "Now" is frozen to a Wednesday so the
+ * Saturday weekly-send branch doesn't make email assertions day-dependent.
+ */
+class DiscourseNotSignedUpServiceTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // 2026-06-10 is a Wednesday (not the Saturday weekly-send day).
+        Carbon::setTestNow(Carbon::parse('2026-06-10 12:00:00'));
+        config([
+            'freegle.discourse.throttle_us' => 0,
+            'freegle.mail.centralmods_addr' => 'central@example.com',
+            'freegle.mail.geek_alerts_addr' => 'geeks@example.com',
+            'freegle.mail.geeks_addr' => 'from@example.com',
+        ]);
+
+        // The service reads the WHOLE database (every published Freegle group and
+        // every active mod), so the test must control that global state — other
+        // suites may have committed groups/mods. Unpublish all groups and age out
+        // every existing Freegle mod so only the entities each test creates count.
+        // (Rolled back by DatabaseTransactions; this is setup, not cleanup.)
+        DB::table('groups')->where('publish', 1)->update(['publish' => 0]);
+        DB::table('users')
+            ->whereIn('id', function ($q) {
+                $q->select('memberships.userid')
+                    ->from('memberships')
+                    ->join('groups', 'groups.id', '=', 'memberships.groupid')
+                    ->whereIn('memberships.role', ['Owner', 'Moderator'])
+                    ->where('groups.type', 'Freegle');
+            })
+            ->update(['lastaccess' => Carbon::now()->subYears(2)]);
+    }
+
+    private function mockClient(array $allUsers, callable $getUser, ?callable $getUserEmail = null): DiscourseClient
+    {
+        $client = Mockery::mock(DiscourseClient::class);
+        $client->shouldReceive('isConfigured')->andReturn(true);
+        $client->shouldReceive('getAllUsers')->andReturn($allUsers);
+        $client->shouldReceive('getUser')->andReturnUsing($getUser);
+        $client->shouldReceive('getUserEmail')->andReturnUsing($getUserEmail ?? fn ($u) => $u.'@example.com');
+
+        return $client;
+    }
+
+    public function test_skips_when_not_configured(): void
+    {
+        $client = Mockery::mock(DiscourseClient::class);
+        $client->shouldReceive('isConfigured')->andReturn(false);
+        $client->shouldNotReceive('getAllUsers');
+
+        $result = (new DiscourseNotSignedUpService($client))->run();
+
+        $this->assertTrue($result['skipped']);
+    }
+
+    public function test_reports_and_emails_when_group_unrepresented(): void
+    {
+        Mail::fake();
+
+        $group = $this->createTestGroup();
+        $mod = $this->createTestUser();
+        $this->createMembership($mod, $group, ['role' => 'Owner']);
+
+        // No users on Discourse at all → the mod isn't signed up and the group
+        // has no active representation.
+        $client = $this->mockClient([], fn ($id, $u) => []);
+
+        $result = (new DiscourseNotSignedUpService($client))->run();
+
+        $this->assertFalse($result['skipped']);
+        $this->assertSame(1, $result['notrepresented']);
+        $this->assertSame(1, $result['notondiscourse']);
+
+        Mail::assertSent(DiscourseReportMail::class, fn ($m) => $m->recipientEmail === 'central@example.com');
+        Mail::assertSent(DiscourseReportMail::class, fn ($m) => $m->recipientEmail === 'geeks@example.com');
+        Mail::assertSentCount(2);
+    }
+
+    public function test_group_represented_when_active_mod_on_discourse(): void
+    {
+        Mail::fake();
+
+        $group = $this->createTestGroup();
+        $mod = $this->createTestUser();
+        $this->createMembership($mod, $group, ['role' => 'Owner']);
+
+        $client = $this->mockClient(
+            [['id' => 200, 'username' => 'themod']],
+            fn ($id, $u) => ['single_sign_on_record' => ['external_id' => $mod->id]],
+        );
+
+        $result = (new DiscourseNotSignedUpService($client))->run();
+
+        $this->assertSame(0, $result['notrepresented']);
+        $this->assertSame(0, $result['notondiscourse']);
+
+        // Wednesday + nothing unrepresented → no email.
+        Mail::assertNothingSent();
+    }
+
+    public function test_flags_mod_with_tn_preferred_email(): void
+    {
+        Mail::fake();
+
+        $group = $this->createTestGroup();
+        $mod = $this->createTestUser();
+        $this->createMembership($mod, $group, ['role' => 'Owner']);
+        DB::table('users_emails')->insert([
+            'userid' => $mod->id,
+            'email' => 'someone@user.trashnothing.com',
+            'preferred' => 1,
+        ]);
+
+        $client = $this->mockClient(
+            [['id' => 201, 'username' => 'tnmod']],
+            fn ($id, $u) => ['single_sign_on_record' => ['external_id' => $mod->id]],
+        );
+
+        $result = (new DiscourseNotSignedUpService($client))->run();
+
+        $this->assertSame(1, $result['tnpreferred']);
+        $this->assertSame(0, $result['notrepresented']);
+    }
+}

--- a/iznik-batch/tests/Unit/Services/DoogalServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/DoogalServiceTest.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Services\DoogalService;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+/**
+ * Behaviour of {@see DoogalService} — the postcode importer migrated from V1
+ * cli/doogal.php. Exercises create / update / skip decisions and the spatial
+ * index against the real test database (geometry + stored functions).
+ */
+class DoogalServiceTest extends TestCase
+{
+    private DoogalService $service;
+
+    private int $srid;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new DoogalService();
+        $this->srid = (int) config('freegle.srid', 3857);
+    }
+
+    /** Write a Code-Point/Doogal style CSV (no header) and return its path. */
+    private function writeCsv(array $rows): string
+    {
+        $path = tempnam(sys_get_temp_dir(), 'doogaltest');
+        $fh = fopen($path, 'w');
+        foreach ($rows as $row) {
+            fputcsv($fh, $row);
+        }
+        fclose($fh);
+
+        return $path;
+    }
+
+    /** A single CSV row: Postcode, In Use?, Latitude, Longitude, ...padding. */
+    private function row(string $pc, string $inUse, $lat, $lng): array
+    {
+        return [$pc, $inUse, $lat, $lng, '', '', '', '', '', '', '', '', 'England'];
+    }
+
+    private function insertPostcode(string $name, ?float $lat = null, ?float $lng = null): int
+    {
+        $id = DB::table('locations')->insertGetId([
+            'name' => $name,
+            'type' => 'Postcode',
+            'osm_place' => 0,
+            'lat' => $lat,
+            'lng' => $lng,
+        ]);
+
+        if ($lat !== null && $lng !== null) {
+            $point = "POINT($lng $lat)";
+            DB::statement('UPDATE locations SET geometry = ST_GeomFromText(?, ?) WHERE id = ?', [$point, $this->srid, $id]);
+            DB::statement('INSERT INTO locations_spatial (locationid, geometry) VALUES (?, ST_GeomFromText(?, ?))', [$id, $point, $this->srid]);
+        }
+
+        return (int) $id;
+    }
+
+    public function test_creates_new_postcode_with_spatial_centroid_and_parent_link(): void
+    {
+        $parentId = $this->insertPostcode('AB1');
+
+        $csv = $this->writeCsv([$this->row('AB1 2CD', 'Yes', 55.10, -3.20)]);
+        $result = $this->service->process($csv);
+        @unlink($csv);
+
+        $this->assertSame(1, $result['added']);
+        $this->assertSame(0, $result['updated']);
+
+        $loc = DB::table('locations')->where('name', 'AB1 2CD')->first();
+        $this->assertNotNull($loc);
+        $this->assertSame('Postcode', $loc->type);
+        $this->assertEqualsWithDelta(55.10, (float) $loc->lat, 0.001);
+        $this->assertEqualsWithDelta(-3.20, (float) $loc->lng, 0.001);
+        $this->assertSame($parentId, (int) $loc->postcodeid);
+        $this->assertSame('ab12cd', $loc->canon);
+
+        $this->assertDatabaseHas('locations_spatial', ['locationid' => $loc->id]);
+    }
+
+    public function test_updates_existing_postcode_when_latlng_moved_more_than_2dp(): void
+    {
+        $id = $this->insertPostcode('CB2 3EF', 52.20, 0.10);
+
+        // Latitude moves from 52.20 to 52.25 (> 0.01 at 2dp).
+        $csv = $this->writeCsv([$this->row('CB2 3EF', 'Yes', 52.25, 0.10)]);
+        $result = $this->service->process($csv);
+        @unlink($csv);
+
+        $this->assertSame(1, $result['updated']);
+        $this->assertSame(0, $result['added']);
+
+        $loc = DB::table('locations')->where('id', $id)->first();
+        $this->assertEqualsWithDelta(52.25, (float) $loc->lat, 0.001);
+    }
+
+    public function test_skips_postcode_not_in_use(): void
+    {
+        $csv = $this->writeCsv([$this->row('ZZ9 9ZZ', 'No', 50.0, -1.0)]);
+        $result = $this->service->process($csv);
+        @unlink($csv);
+
+        $this->assertSame(0, $result['added']);
+        $this->assertSame(0, $result['updated']);
+        $this->assertDatabaseMissing('locations', ['name' => 'ZZ9 9ZZ']);
+    }
+
+    public function test_skips_unchanged_postcode_within_2dp(): void
+    {
+        $id = $this->insertPostcode('DE1 4GH', 52.90, -1.47);
+
+        // 52.901 / -1.473 both round to the stored 2dp values → no write.
+        $csv = $this->writeCsv([$this->row('DE1 4GH', 'Yes', 52.901, -1.473)]);
+        $result = $this->service->process($csv);
+        @unlink($csv);
+
+        $this->assertSame(0, $result['updated']);
+        $this->assertSame(0, $result['added']);
+    }
+
+    public function test_fetch_csv_downloads_and_extracts_zip(): void
+    {
+        // Build a small in-memory zip containing a CSV, and fake the HTTP fetch.
+        $zipPath = tempnam(sys_get_temp_dir(), 'doogalzip');
+        $zip = new \ZipArchive();
+        $zip->open($zipPath, \ZipArchive::OVERWRITE);
+        $zip->addFromString('postcodes.csv', "Postcode,In Use?,Latitude,Longitude\nAB1 2CD,Yes,55.1,-3.2\n");
+        $zip->close();
+        $zipBytes = file_get_contents($zipPath);
+        @unlink($zipPath);
+
+        Http::fake(['*' => Http::response($zipBytes, 200)]);
+
+        $csvPath = $this->service->fetchCsv('https://example.test/postcodes.zip');
+        $this->assertFileExists($csvPath);
+        $this->assertStringContainsString('AB1 2CD', file_get_contents($csvPath));
+
+        @unlink($csvPath);
+        @rmdir(dirname($csvPath));
+    }
+}

--- a/iznik-batch/tests/Unit/Services/EmailSpoolerProcessSpoolRaceTest.php
+++ b/iznik-batch/tests/Unit/Services/EmailSpoolerProcessSpoolRaceTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use Tests\Support\IsolatedSpoolDirectory;
+use Tests\TestCase;
+
+/**
+ * Regression test for the rename race in EmailSpoolerService::processSpool().
+ *
+ * processSpool() globs the pending directory then rename()s each file into
+ * sending/. When a second processor (another mail:spool:process run or a
+ * supervisor worker) claims a file first, rename() fails on a now-missing path.
+ * The code intends to skip such files (`if (!rename(...)) { warn; continue; }`),
+ * but an un-suppressed rename() warning is promoted to an ErrorException by
+ * Laravel's handler, crashing the whole run. The fix suppresses the warning so
+ * the graceful skip actually runs.
+ */
+class EmailSpoolerProcessSpoolRaceTest extends TestCase
+{
+    use IsolatedSpoolDirectory;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpIsolatedSpoolDirectory();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownIsolatedSpoolDirectory();
+        parent::tearDown();
+    }
+
+    public function test_process_spool_skips_unmovable_file_without_crashing(): void
+    {
+        $pending = $this->testSpoolDir.'/pending/mail_race.json';
+        file_put_contents($pending, json_encode(['to' => [], 'subject' => 'race']));
+
+        // Simulate the file being claimed concurrently: remove the sending
+        // directory so rename() fails (the same warning the real race produces).
+        $sending = $this->testSpoolDir.'/sending';
+        array_map('unlink', glob($sending.'/*') ?: []);
+        rmdir($sending);
+
+        // Pre-fix this threw ErrorException; it must now skip gracefully.
+        $stats = $this->spooler->processSpool();
+
+        $this->assertIsArray($stats);
+        $this->assertSame(0, $stats['processed']);
+        // The unmovable file is left in pending for another processor to handle.
+        $this->assertFileExists($pending);
+    }
+}

--- a/iznik-batch/tests/Unit/Services/PaypalDownloadServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/PaypalDownloadServiceTest.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Models\User;
+use App\Services\PaypalDownloadService;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+/**
+ * Behaviour of {@see PaypalDownloadService} — the fallback PayPal donation
+ * downloader migrated from V1 cron/paypal_download.php. The NVP API is faked;
+ * the focus is response parsing, donor matching, exclusions and upsert.
+ */
+class PaypalDownloadServiceTest extends TestCase
+{
+    private PaypalDownloadService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new PaypalDownloadService();
+
+        // Configure credentials and a single-day scan window for determinism.
+        config([
+            'freegle.paypal.username' => 'api-user',
+            'freegle.paypal.password' => 'api-pass',
+            'freegle.paypal.signature' => 'api-sig',
+            'freegle.paypal.nvp_endpoint' => 'https://nvp.test/nvp',
+            'freegle.paypal.download_days' => 1,
+        ]);
+    }
+
+    /** Build a URL-encoded NVP TransactionSearch response body. */
+    private function nvpBody(array $transactions, string $ack = 'Success'): string
+    {
+        $fields = ['ACK' => $ack];
+        foreach ($transactions as $i => $t) {
+            $fields["L_TRANSACTIONID{$i}"] = $t['txn'];
+            $fields["L_EMAIL{$i}"] = $t['email'] ?? '';
+            $fields["L_NAME{$i}"] = $t['name'] ?? '';
+            $fields["L_TIMESTAMP{$i}"] = $t['timestamp'] ?? '2024-01-01T12:00:00Z';
+            $fields["L_AMT{$i}"] = $t['amount'] ?? '0.00';
+        }
+
+        return http_build_query($fields);
+    }
+
+    private function fakeNvp(string $body): void
+    {
+        Http::fake(['nvp.test/*' => Http::response($body, 200)]);
+    }
+
+    public function test_skips_when_credentials_missing(): void
+    {
+        config(['freegle.paypal.username' => '']);
+
+        $result = $this->service->download();
+
+        $this->assertTrue($result['skipped']);
+        $this->assertSame(0, $result['upserted']);
+    }
+
+    public function test_inserts_matched_donation_and_excludes_ppgf_and_zero(): void
+    {
+        $user = $this->createTestUser();
+        DB::table('users_emails')->insert([
+            'userid' => $user->id,
+            'email' => 'donor@example.com',
+            'canon' => User::canonMail('donor@example.com'),
+            'preferred' => 1,
+        ]);
+
+        $this->fakeNvp($this->nvpBody([
+            ['txn' => 'TXN-MATCH', 'email' => 'donor@example.com', 'name' => 'Real Donor', 'amount' => '12.50'],
+            ['txn' => 'TXN-PPGF', 'email' => 'fund@paypal.com', 'name' => 'PayPal Giving Fund UK', 'amount' => '99.00'],
+            ['txn' => 'TXN-ZERO', 'email' => 'someone@example.com', 'name' => 'Zero', 'amount' => '0.00'],
+        ]));
+
+        $result = $this->service->download();
+
+        $this->assertFalse($result['skipped']);
+        // PPGF and zero excluded; only the real donation counts.
+        $this->assertSame(1, $result['found']);
+        $this->assertSame(1, $result['upserted']);
+
+        $this->assertDatabaseHas('users_donations', [
+            'TransactionID' => 'TXN-MATCH',
+            'userid' => $user->id,
+            'Payer' => 'donor@example.com',
+            'PayerDisplayName' => 'Real Donor',
+            'GrossAmount' => 12.50,
+        ]);
+        $this->assertDatabaseMissing('users_donations', ['TransactionID' => 'TXN-PPGF']);
+        $this->assertDatabaseMissing('users_donations', ['TransactionID' => 'TXN-ZERO']);
+    }
+
+    public function test_records_donation_with_null_userid_when_unmatched(): void
+    {
+        $this->fakeNvp($this->nvpBody([
+            ['txn' => 'TXN-UNKNOWN', 'email' => 'nobody@nowhere.test', 'name' => 'Stranger', 'amount' => '5.00'],
+        ]));
+
+        $this->service->download();
+
+        $row = DB::table('users_donations')->where('TransactionID', 'TXN-UNKNOWN')->first();
+        $this->assertNotNull($row);
+        $this->assertNull($row->userid);
+    }
+
+    public function test_upserts_existing_transaction_without_duplicating(): void
+    {
+        $user = $this->createTestUser();
+        DB::table('users_emails')->insert([
+            'userid' => $user->id,
+            'email' => 'donor@example.com',
+            'canon' => User::canonMail('donor@example.com'),
+            'preferred' => 1,
+        ]);
+
+        // Pre-existing row with no userid (e.g. an IPN insert that didn't match).
+        DB::table('users_donations')->insert([
+            'TransactionID' => 'TXN-DUP',
+            'Payer' => 'donor@example.com',
+            'PayerDisplayName' => 'Real Donor',
+            'GrossAmount' => 8.00,
+            'timestamp' => '2020-01-01 00:00:00',
+            'userid' => null,
+        ]);
+
+        $this->fakeNvp($this->nvpBody([
+            ['txn' => 'TXN-DUP', 'email' => 'donor@example.com', 'name' => 'Real Donor', 'amount' => '8.00'],
+        ]));
+
+        $this->service->download();
+
+        // Still exactly one row, now matched to the user.
+        $this->assertSame(1, DB::table('users_donations')->where('TransactionID', 'TXN-DUP')->count());
+        $this->assertSame(
+            $user->id,
+            (int) DB::table('users_donations')->where('TransactionID', 'TXN-DUP')->value('userid')
+        );
+    }
+}

--- a/iznik-server-go/housekeeper/housekeeper.go
+++ b/iznik-server-go/housekeeper/housekeeper.go
@@ -394,6 +394,13 @@ var cronJobs = []CronJob{
 
 	// Data & Integrations additions
 	{Command: "donations:update-giftaid", Name: "Gift Aid Update", Description: "Identifies postcodes/house numbers on giftaid records, marks eligible donations as giftaidconsent, and sends one-off chase-up emails to donors 2-30 days post-donation", Schedule: "Every 10 minutes", IntervalMinutes: 10, Category: "Data", Active: true},
+
+	// Final V1 crontab migrations
+	{Command: "notifications:exhort", Name: "Exhort Active Users", Description: "On-site notification nudge (default \"Tell us your Freegle story!\") to recently-active established users; 90-day per-user cooldown", Schedule: "Every minute", IntervalMinutes: 1, Category: "Email — Engagement", Active: true},
+	{Command: "locations:update-postcodes", Name: "Postcode Refresh", Description: "Downloads the Doogal UK postcode dataset and adds new postcodes / refreshes moved lat/lng in the locations table", Schedule: "Daily at 3am", IntervalMinutes: 1440, Category: "Locations", Active: true},
+	{Command: "donations:paypal-download", Name: "PayPal Download (fallback)", Description: "Fallback: scans the last 30 days of PayPal NVP TransactionSearch results and upserts donations the IPN missed", Schedule: "Every 4 hours (:30)", IntervalMinutes: 240, Category: "Data", Active: true},
+	{Command: "discourse:check-users", Name: "Discourse User Audit", Description: "Audits Discourse users against MT mods, fixes Announcements watching + bios, reports bounces/mail settings; emails geeks daily and central mods on issues/Saturdays", Schedule: "Daily at 3:08am", IntervalMinutes: 1440, Category: "Discourse", Active: true},
+	{Command: "discourse:not-signed-up", Name: "Discourse Coverage Check", Description: "Reports Freegle groups with no active mod on Discourse, active mods not signed up, and mods with TrashNothing preferred emails", Schedule: "Daily at 3:23am", IntervalMinutes: 1440, Category: "Discourse", Active: true},
 }
 
 // ActiveCronJobCount returns the number of active cron jobs in the static registry.

--- a/iznik-server-go/test/housekeeper_test.go
+++ b/iznik-server-go/test/housekeeper_test.go
@@ -463,3 +463,44 @@ func TestDeployWatchIsInactive(t *testing.T) {
 		}
 	}
 }
+
+// TestFinalV1CronMigrationsRegistered verifies the last batch of V1 crontab
+// migrations appear in the SysAdmin cron registry as active jobs.
+func TestFinalV1CronMigrationsRegistered(t *testing.T) {
+	prefix := uniquePrefix("v1cron")
+	userID := CreateTestUser(t, prefix+"_admin", "Admin")
+	groupID := CreateTestGroup(t, prefix)
+	CreateTestMembership(t, userID, groupID, "Moderator")
+	_, token := CreateTestSession(t, userID)
+
+	req := httptest.NewRequest("GET", "/api/housekeeper/cronjobs?jwt="+token, nil)
+	resp, err := getApp().Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	respBody, _ := io.ReadAll(resp.Body)
+	var jobs []map[string]interface{}
+	err = json.Unmarshal(respBody, &jobs)
+	assert.NoError(t, err)
+
+	expected := map[string]bool{
+		"notifications:exhort":       false,
+		"locations:update-postcodes": false,
+		"donations:paypal-download":  false,
+		"discourse:check-users":      false,
+		"discourse:not-signed-up":    false,
+	}
+
+	for _, job := range jobs {
+		cmd, _ := job["command"].(string)
+		if _, ok := expected[cmd]; ok {
+			expected[cmd] = true
+			active, _ := job["active"].(bool)
+			assert.True(t, active, cmd+" should be active in the registry")
+		}
+	}
+
+	for cmd, found := range expected {
+		assert.True(t, found, cmd+" should be present in the cron registry")
+	}
+}


### PR DESCRIPTION
## Summary

Migrates the last V1 `scripts/cron` / `scripts/cli` jobs into `iznik-batch`, schedules them to match the V1 crontab, and registers them in the MT SysAdmin cron table (the Go static registry in `housekeeper.go`).

| V1 script | Schedule | New Laravel command |
|---|---|---|
| `user_exhort.php` | every minute | `notifications:exhort` (command/service already existed — this **wires it into the scheduler + registry**; it was dormant) |
| `cron/doogal` (+ `cli/doogal.php`) | daily 03:00 | `locations:update-postcodes` → `DoogalService` |
| `paypal_download.php` | every 4h at :30 | `donations:paypal-download` → `PaypalDownloadService` (PayPal NVP `TransactionSearch`) |
| `discourse_checkusers.php` | daily 03:08 | `discourse:check-users` → `DiscourseClient` + `DiscourseCheckUsersService` |
| `discourse_not_signed_up.php` | daily 03:23 | `discourse:not-signed-up` → `DiscourseNotSignedUpService` |

- `DoogalService` downloads + unzips the doogal.co.uk postcode CSV, adds new postcodes and refreshes moved lat/lng, mirroring V1 `Location::create` (geometry, spatial index, centroid lat/lng, parent-postcode link). Area→group remap is left to the existing `locations:sync-pgsql` job, as V1 relied on a background cron for it.
- `PaypalDownloadService` is the fallback for donations the IPN missed: it scans the last 30 days a day at a time and upserts `users_donations` on the unique `TransactionID`, matching the donor by email/`canonMail`. Excludes PayPal Giving Fund and zero/refund rows, like V1.
- The two Discourse jobs share a `DiscourseClient` (system Api-Key/Api-Username headers) and email plain-text reports to geeks / central mods via `DiscourseReportMail`.
- All 5 commands are added to the Go cron registry (`housekeeper.go`) so they appear in the SysAdmin "Cron Jobs" tab.

The PayPal and Discourse jobs **skip with a log line when their credentials are unset**, so scheduling them is safe until the prod env vars are added (documented in `iznik-batch/.env.example` and `.env.background.example`).

### Incidental fix
`EmailSpoolerService::processSpool` crashed when a spool file was claimed by a concurrent processor: it intends to skip such a file (`if (!rename(...)) { warn; continue; }`), but an un-suppressed `rename()` warning was promoted to an `ErrorException` by Laravel's handler before the false-check. Fixed with `@rename(...)` so the existing skip path runs. (Surfaced as a flaky failure during the full-suite run.)

## Code Quality Review

- Credentials read from config (no hardcoding); all SQL uses bound params.
- Shared `DiscourseClient` between the two Discourse services — no duplication.
- Faithful to V1 semantics (queries, exclusions, email-trigger conditions, schedules). The `discourse_checkusers` "not a MT user" branch — dead code in V1 because `new User()` was always truthy — is implemented to its documented intent (an explicit existence check).
- Throttling between Discourse calls preserved (configurable; disabled in tests).

## Future Improvements

- `FREEGLE_CENTRALMODS_ADDR` is set to `volunteersupport@ilovefreegle.org` (confirmed value for the V1 `CENTRALMODS_ADDR`).
- `DiscourseClient::setWatchCategory` sends `watched_category_ids` as an indexed array (Rails accepts it); V1 used the `[]` form.

## Test Plan

- **Laravel:** full suite green — 4122 tests, 8353 assertions, 0 errors, 0 failures (16 new tests: Doogal 5, PayPal 4, Discourse check-users 2, Discourse not-signed-up 4, spool race 1). PayPal/Discourse/doogal external calls are HTTP-faked or client-mocked.
- **Go:** full suite green — 3134 passed, 0 failed; new `TestFinalV1CronMigrationsRegistered` asserts the 5 commands are registered and active.
- Run via the status-container API (Go suite picked up the `housekeeper.go` change after `docker cp` into the worktree apiv2, since its `/app` is baked).