### PR TITLE
feat(monitor): outcome-based monitoring for scheduled tasks

### DIFF
--- a/iznik-batch/.env.example
+++ b/iznik-batch/.env.example
@@ -106,3 +106,13 @@ FREEGLE_MONITORING_BG_TASKS_MAX_AGE_MIN=10
 FREEGLE_MONITORING_BG_TASKS_BACKLOG=0
 # spam:refresh-mobile-cidrs — alert if no UK-mobile CIDR refresh within N days.
 FREEGLE_MONITORING_MOBILE_CIDRS_MAX_AGE_DAYS=40
+# Per-minute processing queues (contentcheck, chat process-incoming, memberships):
+# a row unprocessed longer than this (minutes) = stuck worker.
+FREEGLE_MONITORING_PROCESSING_BACKLOG_MAX_AGE_MIN=15
+# users:process-exports — heavier work, larger backlog window (minutes).
+FREEGLE_MONITORING_EXPORTS_BACKLOG_MAX_AGE_MIN=30
+# integrations:sync-whatjobs — alert if jobs.seenat older than N hours.
+FREEGLE_MONITORING_WHATJOBS_MAX_AGE_HOURS=24
+# data:git-summary (weekly) / data:update-cpi (monthly) — config-timestamp staleness (days).
+FREEGLE_MONITORING_GIT_SUMMARY_MAX_AGE_DAYS=10
+FREEGLE_MONITORING_CPI_MAX_AGE_DAYS=40

--- a/iznik-batch/.env.example
+++ b/iznik-batch/.env.example
@@ -91,3 +91,18 @@ LETSENCRYPT_CERT_PATH=/etc/letsencrypt/live/ilovefreegle.org
 REACH_VOLUNTEERING_FEED_URL=
 REACH_VOLUNTEERING_USER=
 REACH_VOLUNTEERING_PASSWORD=
+
+# Scheduled-task outcome monitoring (monitor:scheduled-outcomes).
+# Asserts that scheduled jobs actually did their work and alerts Sentry on a
+# breach. See docs/scheduled-outcome-monitoring.md. All have safe defaults.
+# Master kill-switch — set to false to disable the monitor entirely.
+FREEGLE_MONITORING_ENABLED=true
+# stats:generate-daily — min per-group stats rows expected for yesterday.
+FREEGLE_MONITORING_STATS_DAILY_MIN=1
+# mail:digest:unified --mode=daily — min daily-digest sends once the pilot is on.
+FREEGLE_MONITORING_DIGEST_DAILY_MIN=1
+# queue:background-tasks — a pending task older than this (minutes) = stuck worker.
+FREEGLE_MONITORING_BG_TASKS_MAX_AGE_MIN=10
+FREEGLE_MONITORING_BG_TASKS_BACKLOG=0
+# spam:refresh-mobile-cidrs — alert if no UK-mobile CIDR refresh within N days.
+FREEGLE_MONITORING_MOBILE_CIDRS_MAX_AGE_DAYS=40

--- a/iznik-batch/app/Console/Commands/Monitor/MonitorScheduledOutcomesCommand.php
+++ b/iznik-batch/app/Console/Commands/Monitor/MonitorScheduledOutcomesCommand.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\Console\Commands\Monitor;
+
+use App\Monitoring\ScheduledOutcomeRegistry;
+use Carbon\Carbon;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Outcome-based monitoring for scheduled tasks: asserts that jobs actually did
+ * their work (rows written, cursor advanced), not just that the scheduler is
+ * alive. Runs every 10 minutes (itself heartbeated to Sentry Crons).
+ *
+ * For each registered check it prints a line and, on any BREACH, escalates to
+ * Sentry (\Sentry\captureMessage, guarded by function_exists exactly like
+ * EmailHealthCommand/TNSyncCommand) plus Log::warning, then exits non-zero so
+ * the breach shows as a red badge in the cron-jobs sysadmin tab. SKIPPED
+ * results (precondition unmet / outside active window) never fail the command.
+ *
+ * See docs/scheduled-outcome-monitoring.md.
+ */
+class MonitorScheduledOutcomesCommand extends Command
+{
+    protected $signature = 'monitor:scheduled-outcomes {--only= : Evaluate only the check with this slug}';
+
+    protected $description = 'Asserts scheduled tasks did their work; alerts Sentry on outcome breaches';
+
+    public function handle(ScheduledOutcomeRegistry $registry): int
+    {
+        if (! config('freegle.monitoring.enabled', true)) {
+            $this->info('Scheduled-outcome monitoring disabled (freegle.monitoring.enabled=false).');
+
+            return Command::SUCCESS;
+        }
+
+        $now = Carbon::now();
+        $only = $this->option('only');
+
+        $checks = $registry->checks();
+        if ($only !== null && $only !== '') {
+            $checks = array_values(array_filter($checks, fn ($c) => $c->slug() === $only));
+            if (empty($checks)) {
+                $this->error("No scheduled-outcome check with slug '{$only}'.");
+
+                return Command::FAILURE;
+            }
+        }
+
+        $breaches = [];
+
+        foreach ($checks as $check) {
+            $result = $check->evaluate($now);
+            $line = "[{$result->status}] {$check->slug()} — {$result->message}";
+
+            if ($result->isBreach()) {
+                $this->error($line);
+                $breaches[] = $result;
+            } else {
+                $this->info($line);
+            }
+        }
+
+        if (! empty($breaches)) {
+            foreach ($breaches as $breach) {
+                Log::warning("[ScheduledOutcomes] {$breach->slug}: {$breach->message}");
+            }
+
+            // Escalate to Sentry so the team (who actively watch it) are alerted
+            // promptly. Guarded because Sentry's helpers aren't loaded in every
+            // environment (e.g. tests) — same pattern as EmailHealthCommand.
+            if (function_exists('\Sentry\captureMessage')) {
+                foreach ($breaches as $breach) {
+                    \Sentry\captureMessage(
+                        "[ScheduledOutcomes][{$breach->severity}] {$breach->slug}: {$breach->message}"
+                    );
+                }
+            }
+
+            $this->error(count($breaches) . ' scheduled-outcome check(s) breached.');
+
+            return Command::FAILURE;
+        }
+
+        $this->info('All scheduled-outcome checks OK.');
+
+        return Command::SUCCESS;
+    }
+}

--- a/iznik-batch/app/Monitoring/Checks/AbstractOutcomeCheck.php
+++ b/iznik-batch/app/Monitoring/Checks/AbstractOutcomeCheck.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace App\Monitoring\Checks;
+
+use App\Monitoring\OutcomeCheck;
+use App\Monitoring\OutcomeResult;
+use Carbon\CarbonInterface;
+
+/**
+ * Base for outcome checks. Handles the two cross-cutting concerns shared by
+ * every check — an optional enabling precondition and an optional active-hours
+ * window — and delegates the actual assertion to check().
+ *
+ * Both yield SKIPPED (never BREACH) so a deliberately-disabled job, or a job
+ * checked outside its due window, can't raise a false alarm.
+ */
+abstract class AbstractOutcomeCheck implements OutcomeCheck
+{
+    protected string $slug;
+    protected string $description = '';
+    protected string $category = 'general';
+    protected string $severity = 'error';
+
+    /** @var (callable():bool)|null */
+    protected $enabledWhen = null;
+
+    protected ?int $activeFromHour = null;
+    protected ?int $activeToHour = null;
+    protected ?string $timezone = null;
+
+    public function slug(): string
+    {
+        return $this->slug;
+    }
+
+    public function description(): string
+    {
+        return $this->description;
+    }
+
+    public function category(): string
+    {
+        return $this->category;
+    }
+
+    public function severity(): string
+    {
+        return $this->severity;
+    }
+
+    public function describedAs(string $description): static
+    {
+        $this->description = $description;
+
+        return $this;
+    }
+
+    public function inCategory(string $category): static
+    {
+        $this->category = $category;
+
+        return $this;
+    }
+
+    public function withSeverity(string $severity): static
+    {
+        $this->severity = $severity;
+
+        return $this;
+    }
+
+    /** Gate the check on a (usually config-derived) precondition. */
+    public function enabledWhen(callable $callback): static
+    {
+        $this->enabledWhen = $callback;
+
+        return $this;
+    }
+
+    /**
+     * Only evaluate during [$fromHour, $toHour) in the given timezone (default
+     * freegle.timezone). Used to check a daily job after its due time + slack.
+     */
+    public function activeBetween(int $fromHour, int $toHour, ?string $timezone = null): static
+    {
+        $this->activeFromHour = $fromHour;
+        $this->activeToHour = $toHour;
+        $this->timezone = $timezone;
+
+        return $this;
+    }
+
+    protected function isEnabled(): bool
+    {
+        return $this->enabledWhen === null ? true : (bool) ($this->enabledWhen)();
+    }
+
+    protected function isWithinActiveWindow(CarbonInterface $now): bool
+    {
+        if ($this->activeFromHour === null || $this->activeToHour === null) {
+            return true;
+        }
+
+        $tz = $this->timezone ?? config('freegle.timezone', 'Europe/London');
+        $hour = $now->copy()->setTimezone($tz)->hour;
+
+        return $hour >= $this->activeFromHour && $hour < $this->activeToHour;
+    }
+
+    public function evaluate(CarbonInterface $now): OutcomeResult
+    {
+        if (! $this->isEnabled()) {
+            return OutcomeResult::skipped($this->slug, 'disabled by precondition');
+        }
+
+        if (! $this->isWithinActiveWindow($now)) {
+            return OutcomeResult::skipped(
+                $this->slug,
+                "outside active window {$this->activeFromHour}:00-{$this->activeToHour}:00"
+            );
+        }
+
+        return $this->check($now);
+    }
+
+    /** The concrete assertion. Only reached when enabled and in-window. */
+    abstract protected function check(CarbonInterface $now): OutcomeResult;
+}

--- a/iznik-batch/app/Monitoring/Checks/BacklogCheck.php
+++ b/iznik-batch/app/Monitoring/Checks/BacklogCheck.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Monitoring\Checks;
+
+use App\Monitoring\OutcomeResult;
+use Carbon\CarbonInterface;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Breaches when more than $threshold "pending" rows have been waiting longer
+ * than $maxAgeMinutes. Use for CURSOR/QUEUE jobs: the failure mode is a stuck
+ * worker letting work pile up, NOT an empty queue (which is normal and must
+ * never alarm). $pending applies the predicate that defines an unprocessed row.
+ */
+class BacklogCheck extends AbstractOutcomeCheck
+{
+    /**
+     * @param  callable(\Illuminate\Database\Query\Builder):void  $pending
+     */
+    public function __construct(
+        string $slug,
+        protected string $table,
+        protected string $ageColumn,
+        protected int $maxAgeMinutes,
+        protected $pending,
+        protected int $threshold = 0,
+    ) {
+        $this->slug = $slug;
+        $this->category = 'cursor-staleness';
+    }
+
+    protected function check(CarbonInterface $now): OutcomeResult
+    {
+        $cutoff = $now->copy()->subMinutes($this->maxAgeMinutes);
+
+        $query = DB::table($this->table)->where($this->ageColumn, '<', $cutoff);
+        ($this->pending)($query);
+
+        $count = $query->count();
+
+        if ($count > $this->threshold) {
+            return OutcomeResult::breach(
+                $this->slug,
+                "{$this->table}: {$count} pending row(s) older than {$this->maxAgeMinutes} min "
+                    . "(threshold {$this->threshold}) — worker stuck?",
+                $this->severity
+            );
+        }
+
+        return OutcomeResult::ok(
+            $this->slug,
+            "{$this->table}: {$count} pending row(s) older than {$this->maxAgeMinutes} min "
+                . "(threshold {$this->threshold})"
+        );
+    }
+}

--- a/iznik-batch/app/Monitoring/Checks/CallbackCheck.php
+++ b/iznik-batch/app/Monitoring/Checks/CallbackCheck.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Monitoring\Checks;
+
+use App\Monitoring\OutcomeResult;
+use Carbon\CarbonInterface;
+
+/**
+ * Wraps an arbitrary closure returning an OutcomeResult. Use for bespoke
+ * signals the standard primitives can't express — e.g. a timestamp embedded in
+ * a JSON `config` value, or a cross-table comparison. The base class still
+ * applies the enabledWhen / activeBetween gating before the closure runs.
+ */
+class CallbackCheck extends AbstractOutcomeCheck
+{
+    /**
+     * @param  callable(CarbonInterface):OutcomeResult  $callback
+     */
+    public function __construct(
+        string $slug,
+        protected $callback,
+    ) {
+        $this->slug = $slug;
+        $this->category = 'general';
+    }
+
+    protected function check(CarbonInterface $now): OutcomeResult
+    {
+        return ($this->callback)($now);
+    }
+}

--- a/iznik-batch/app/Monitoring/Checks/FreshnessCheck.php
+++ b/iznik-batch/app/Monitoring/Checks/FreshnessCheck.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Monitoring\Checks;
+
+use App\Monitoring\OutcomeResult;
+use Carbon\Carbon;
+use Carbon\CarbonInterface;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Breaches when the freshest side-effect row is older than $maxAgeMinutes (or
+ * there are no rows at all). Use for jobs that should ALWAYS have produced
+ * something recently. For queue/cursor jobs whose table is legitimately empty
+ * during quiet periods, use BacklogCheck instead — a freshness check would
+ * false-alarm overnight.
+ */
+class FreshnessCheck extends AbstractOutcomeCheck
+{
+    /**
+     * @param  (callable(\Illuminate\Database\Query\Builder):void)|null  $where
+     */
+    public function __construct(
+        string $slug,
+        protected string $table,
+        protected string $column,
+        protected int $maxAgeMinutes,
+        protected $where = null,
+    ) {
+        $this->slug = $slug;
+        $this->category = 'cursor-staleness';
+    }
+
+    protected function check(CarbonInterface $now): OutcomeResult
+    {
+        $query = DB::table($this->table);
+        if ($this->where) {
+            ($this->where)($query);
+        }
+
+        $latest = $query->max($this->column);
+
+        if ($latest === null) {
+            return OutcomeResult::breach(
+                $this->slug,
+                "{$this->table}.{$this->column}: no rows at all",
+                $this->severity
+            );
+        }
+
+        $latestAt = Carbon::parse($latest);
+        $ageMinutes = (int) round(($now->getTimestamp() - $latestAt->getTimestamp()) / 60);
+        $threshold = $now->copy()->subMinutes($this->maxAgeMinutes);
+
+        if ($latestAt->lt($threshold)) {
+            return OutcomeResult::breach(
+                $this->slug,
+                "{$this->table}.{$this->column} last advanced {$ageMinutes} min ago (max {$this->maxAgeMinutes})",
+                $this->severity
+            );
+        }
+
+        return OutcomeResult::ok(
+            $this->slug,
+            "{$this->table}.{$this->column} fresh ({$ageMinutes} min ago, max {$this->maxAgeMinutes})"
+        );
+    }
+}

--- a/iznik-batch/app/Monitoring/Checks/ProducedSinceCheck.php
+++ b/iznik-batch/app/Monitoring/Checks/ProducedSinceCheck.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Monitoring\Checks;
+
+use App\Monitoring\OutcomeResult;
+use Carbon\CarbonInterface;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Breaches when fewer than $floor rows were written since the period's window
+ * start. Use for FIRE-ONCE jobs — "did it produce output this period?".
+ *
+ * $windowStart is a closure (CarbonInterface $now): CarbonInterface so the
+ * window can track London-local day boundaries rather than naive UTC days.
+ */
+class ProducedSinceCheck extends AbstractOutcomeCheck
+{
+    /**
+     * @param  callable(CarbonInterface):CarbonInterface  $windowStart
+     * @param  (callable(\Illuminate\Database\Query\Builder):void)|null  $where
+     */
+    public function __construct(
+        string $slug,
+        protected string $table,
+        protected string $column,
+        protected $windowStart,
+        protected int $floor = 1,
+        protected $where = null,
+    ) {
+        $this->slug = $slug;
+        $this->category = 'fire-once-output';
+    }
+
+    protected function check(CarbonInterface $now): OutcomeResult
+    {
+        $start = ($this->windowStart)($now);
+
+        $query = DB::table($this->table)->where($this->column, '>=', $start);
+        if ($this->where) {
+            ($this->where)($query);
+        }
+
+        $count = $query->count();
+        $since = $start->copy()->toDateTimeString();
+
+        if ($count < $this->floor) {
+            return OutcomeResult::breach(
+                $this->slug,
+                "{$this->table}: {$count} row(s) since {$since} (floor {$this->floor}) — did it run?",
+                $this->severity
+            );
+        }
+
+        return OutcomeResult::ok(
+            $this->slug,
+            "{$this->table}: {$count} row(s) since {$since} (floor {$this->floor})"
+        );
+    }
+}

--- a/iznik-batch/app/Monitoring/OutcomeCheck.php
+++ b/iznik-batch/app/Monitoring/OutcomeCheck.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Monitoring;
+
+use Carbon\CarbonInterface;
+
+/**
+ * An outcome assertion for one scheduled task: "did the work actually happen?"
+ *
+ * Implementations live in App\Monitoring\Checks. The registry
+ * (App\Monitoring\ScheduledOutcomeRegistry) wires concrete checks to the
+ * scheduled tasks they monitor; monitor:scheduled-outcomes evaluates them.
+ */
+interface OutcomeCheck
+{
+    /** The scheduled task this check monitors (its console.php command string). */
+    public function slug(): string;
+
+    /** Human-readable description, surfaced in output. */
+    public function description(): string;
+
+    /** Coarse grouping: e.g. 'fire-once-output' or 'cursor-staleness'. */
+    public function category(): string;
+
+    /** Evaluate the check as of $now (the app-clock instant, UTC). */
+    public function evaluate(CarbonInterface $now): OutcomeResult;
+}

--- a/iznik-batch/app/Monitoring/OutcomeResult.php
+++ b/iznik-batch/app/Monitoring/OutcomeResult.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Monitoring;
+
+/**
+ * The result of evaluating a single scheduled-task outcome check.
+ *
+ * Status is one of:
+ *  - OK       — the job's work demonstrably happened.
+ *  - BREACH   — the expected side effect is missing/stale; escalate to Sentry.
+ *  - SKIPPED  — the check did not apply right now (precondition unmet, or
+ *               outside its active window). Never a failure.
+ */
+final class OutcomeResult
+{
+    public const OK = 'ok';
+    public const BREACH = 'breach';
+    public const SKIPPED = 'skipped';
+
+    public function __construct(
+        public readonly string $slug,
+        public readonly string $status,
+        public readonly string $message,
+        public readonly string $severity = 'error',
+    ) {
+    }
+
+    public static function ok(string $slug, string $message): self
+    {
+        return new self($slug, self::OK, $message);
+    }
+
+    public static function breach(string $slug, string $message, string $severity = 'error'): self
+    {
+        return new self($slug, self::BREACH, $message, $severity);
+    }
+
+    public static function skipped(string $slug, string $message): self
+    {
+        return new self($slug, self::SKIPPED, $message);
+    }
+
+    public function isOk(): bool
+    {
+        return $this->status === self::OK;
+    }
+
+    public function isBreach(): bool
+    {
+        return $this->status === self::BREACH;
+    }
+
+    public function isSkipped(): bool
+    {
+        return $this->status === self::SKIPPED;
+    }
+}

--- a/iznik-batch/app/Monitoring/ScheduledOutcomeRegistry.php
+++ b/iznik-batch/app/Monitoring/ScheduledOutcomeRegistry.php
@@ -2,10 +2,14 @@
 
 namespace App\Monitoring;
 
+use App\Models\MessageGroup;
 use App\Monitoring\Checks\BacklogCheck;
+use App\Monitoring\Checks\CallbackCheck;
 use App\Monitoring\Checks\FreshnessCheck;
 use App\Monitoring\Checks\ProducedSinceCheck;
+use Carbon\Carbon;
 use Carbon\CarbonInterface;
+use Illuminate\Support\Facades\DB;
 
 /**
  * Declares which scheduled tasks are monitored, and how. This is the single
@@ -25,8 +29,11 @@ class ScheduledOutcomeRegistry
     public function checks(): array
     {
         $tz = config('freegle.timezone', 'Europe/London');
+        $backlogMin = (int) config('freegle.monitoring.processing_backlog_max_age_minutes', 15);
 
         return [
+            // ---- Fire-once: did it produce output this period? -------------
+
             // stats:generate-daily (daily 02:30) writes one `stats` row per
             // group/type for YESTERDAY. Strong fire-once signal. Only checked
             // from 06:00 so the 02:30 run has comfortably completed.
@@ -58,9 +65,9 @@ class ScheduledOutcomeRegistry
                 ->enabledWhen(fn () => trim((string) config('freegle.digest.daily_allowlist', '')) !== '')
                 ->activeBetween(13, 24, $tz),
 
+            // ---- Cursor/queue: is a worker stuck (backlog piling up)? -------
+
             // queue:background-tasks drains the Go-API -> Laravel task bridge.
-            // The failure mode is a stuck worker letting rows pile up, not an
-            // empty queue — so assert "no pending task waiting too long".
             (new BacklogCheck(
                 'queue:background-tasks',
                 'background_tasks',
@@ -70,6 +77,72 @@ class ScheduledOutcomeRegistry
                 (int) config('freegle.monitoring.background_tasks_backlog_threshold', 0),
             ))
                 ->describedAs('Go-API background task queue not backing up')
+                ->inCategory('cursor-staleness'),
+
+            // messages:contentcheck (every minute) promotes/blocks Pending
+            // posts and always stamps contentcheck_checked_at. A Pending,
+            // un-checked, undeleted post whose message+user are live (mirrors
+            // the worker's exact join) that has sat past $backlogMin = a stalled
+            // moderation pipeline. The joins exclude rows the worker skips
+            // permanently (deleted message / null fromuser) so they don't
+            // false-alarm.
+            (new BacklogCheck(
+                'messages:contentcheck',
+                'messages_groups as mg',
+                'mg.arrival',
+                $backlogMin,
+                fn ($q) => $q
+                    ->join('messages as m', 'm.id', '=', 'mg.msgid')
+                    ->join('users as u', 'u.id', '=', 'm.fromuser')
+                    ->where('mg.collection', MessageGroup::COLLECTION_PENDING)
+                    ->whereNull('mg.contentcheck_checked_at')
+                    ->where('mg.deleted', 0)
+                    ->whereNull('m.deleted')
+                    ->whereNotNull('m.fromuser')
+                    ->whereNull('u.deleted'),
+            ))
+                ->describedAs('Content-check moderation queue not backing up')
+                ->inCategory('cursor-staleness'),
+
+            // chats:process-incoming (every minute) clears processingrequired
+            // on every visited chat message (success or fail). A row still
+            // flagged past $backlogMin = the chat processor is stuck.
+            (new BacklogCheck(
+                'chats:process-incoming',
+                'chat_messages',
+                'date',
+                $backlogMin,
+                fn ($q) => $q->where('processingrequired', 1),
+            ))
+                ->describedAs('Incoming chat-message processing queue not backing up')
+                ->inCategory('cursor-staleness'),
+
+            // memberships:process (every minute) clears processingrequired on
+            // every history row it visits. A row still flagged past $backlogMin
+            // = welcome-mail / review processing is stuck.
+            (new BacklogCheck(
+                'memberships:process',
+                'memberships_history',
+                'added',
+                $backlogMin,
+                fn ($q) => $q->where('processingrequired', 1),
+            ))
+                ->describedAs('Membership-history processing queue not backing up')
+                ->inCategory('cursor-staleness'),
+
+            // users:process-exports (every minute) sets completed when a GDPR
+            // export finishes. An export requested but uncompleted past its
+            // (larger) window = the export worker is stuck. Exports are rare,
+            // so an empty queue is the norm — a backlog check only fires when
+            // one genuinely sits unprocessed.
+            (new BacklogCheck(
+                'users:process-exports',
+                'users_exports',
+                'requested',
+                (int) config('freegle.monitoring.exports_backlog_max_age_minutes', 30),
+                fn ($q) => $q->whereNull('completed'),
+            ))
+                ->describedAs('GDPR data-export queue not backing up')
                 ->inCategory('cursor-staleness'),
 
             // spam:refresh-mobile-cidrs (monthly) upserts spam_whitelist_ips
@@ -84,6 +157,87 @@ class ScheduledOutcomeRegistry
             ))
                 ->describedAs('Monthly UK-mobile CGNAT CIDR refresh')
                 ->inCategory('fire-once-output'),
+
+            // integrations:sync-whatjobs rebuilds the `jobs` table (every 3h,
+            // 08:00-22:00) and stamps jobs.seenat on every row of the run. A
+            // 24h freshness floor tolerates the overnight gap + slow cold runs.
+            // Gated on a feed being configured (no feed = nothing to sync).
+            (new FreshnessCheck(
+                'integrations:sync-whatjobs',
+                'jobs',
+                'seenat',
+                (int) config('freegle.monitoring.whatjobs_max_age_hours', 24) * 60,
+            ))
+                ->describedAs('WhatJobs feed rebuild of the jobs table')
+                ->inCategory('cursor-staleness')
+                ->enabledWhen(fn () => trim((string) config('freegle.whatjobs.feed1', '')) !== ''),
+
+            // ---- Config-value freshness (timestamp embedded in config value) -
+
+            // data:git-summary (weekly Wed 18:00) writes a unix timestamp into
+            // config.value['git_summary_last_run'] after each successful send.
+            $this->configFreshness(
+                'data:git-summary',
+                'git_summary_last_run',
+                (int) config('freegle.monitoring.git_summary_max_age_days', 10) * 24 * 60,
+                fn (string $raw) => is_numeric(trim($raw)) ? Carbon::createFromTimestamp((int) trim($raw)) : null,
+            )
+                ->describedAs('Weekly AI git-summary to Discourse')
+                ->inCategory('fire-once-output'),
+
+            // data:update-cpi (monthly) stores ONS data as JSON in
+            // config.value['cpi_annual_data'] with an ISO-8601 'updated_at'.
+            $this->configFreshness(
+                'data:update-cpi',
+                'cpi_annual_data',
+                (int) config('freegle.monitoring.cpi_max_age_days', 40) * 24 * 60,
+                function (string $raw) {
+                    $decoded = json_decode($raw, true);
+
+                    return is_array($decoded) && !empty($decoded['updated_at'])
+                        ? Carbon::parse($decoded['updated_at'])
+                        : null;
+                },
+            )
+                ->describedAs('Monthly ONS CPI inflation data fetch')
+                ->inCategory('fire-once-output'),
         ];
+    }
+
+    /**
+     * Build a check that reads a timestamp embedded inside a `config` row's
+     * value (the config table has no updated_at column of its own).
+     *
+     * A missing key is SKIPPED, not a breach — on a fresh deploy the job may
+     * simply not have run yet, and we don't want to alarm on that. An
+     * unparseable value IS a breach (the writer is broken).
+     *
+     * @param  callable(string):(CarbonInterface|null)  $extractTimestamp
+     */
+    private function configFreshness(string $slug, string $key, int $maxAgeMinutes, callable $extractTimestamp): CallbackCheck
+    {
+        return new CallbackCheck($slug, function (CarbonInterface $now) use ($slug, $key, $maxAgeMinutes, $extractTimestamp) {
+            $raw = DB::table('config')->where('key', $key)->value('value');
+
+            if ($raw === null) {
+                return OutcomeResult::skipped($slug, "config '{$key}' not set yet (job may not have run since deploy)");
+            }
+
+            $timestamp = $extractTimestamp((string) $raw);
+            if ($timestamp === null) {
+                return OutcomeResult::breach($slug, "config '{$key}' present but its timestamp could not be parsed");
+            }
+
+            $ageMinutes = (int) round(($now->getTimestamp() - $timestamp->getTimestamp()) / 60);
+
+            if ($timestamp->lt($now->copy()->subMinutes($maxAgeMinutes))) {
+                return OutcomeResult::breach(
+                    $slug,
+                    "config '{$key}' last updated {$ageMinutes} min ago (max {$maxAgeMinutes}) — did it run?"
+                );
+            }
+
+            return OutcomeResult::ok($slug, "config '{$key}' fresh ({$ageMinutes} min ago, max {$maxAgeMinutes})");
+        });
     }
 }

--- a/iznik-batch/app/Monitoring/ScheduledOutcomeRegistry.php
+++ b/iznik-batch/app/Monitoring/ScheduledOutcomeRegistry.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\Monitoring;
+
+use App\Monitoring\Checks\BacklogCheck;
+use App\Monitoring\Checks\FreshnessCheck;
+use App\Monitoring\Checks\ProducedSinceCheck;
+use Carbon\CarbonInterface;
+
+/**
+ * Declares which scheduled tasks are monitored, and how. This is the single
+ * place reviewed alongside routes/console.php. See
+ * docs/scheduled-outcome-monitoring.md for the full categorisation of every
+ * task (including those deliberately left unmonitored and why).
+ *
+ * Add an entry only after verifying its table/column against the command's
+ * service code and a migration — ScheduledOutcomeRegistryTest evaluates every
+ * check against the real schema, so a typo fails CI rather than production.
+ */
+class ScheduledOutcomeRegistry
+{
+    /**
+     * @return list<OutcomeCheck>
+     */
+    public function checks(): array
+    {
+        $tz = config('freegle.timezone', 'Europe/London');
+
+        return [
+            // stats:generate-daily (daily 02:30) writes one `stats` row per
+            // group/type for YESTERDAY. Strong fire-once signal. Only checked
+            // from 06:00 so the 02:30 run has comfortably completed.
+            (new ProducedSinceCheck(
+                'stats:generate-daily',
+                'stats',
+                'date',
+                fn (CarbonInterface $now) => $now->copy()->setTimezone($tz)->startOfDay()->subDay(),
+                (int) config('freegle.monitoring.stats_daily_min_expected', 1),
+            ))
+                ->describedAs('Per-group daily stats rows generated for yesterday')
+                ->inCategory('fire-once-output')
+                ->activeBetween(6, 24, $tz),
+
+            // mail:digest:unified --mode=daily (07:00-12:00 London) records a
+            // users_digests.lastsent for mode='daily' on each send. Inert
+            // (skipped) until the daily pilot is enabled via the allowlist.
+            // Checked from 13:00, after the send window + slack.
+            (new ProducedSinceCheck(
+                'mail:digest:unified --mode=daily',
+                'users_digests',
+                'lastsent',
+                fn (CarbonInterface $now) => $now->copy()->setTimezone($tz)->startOfDay()->setTimezone('UTC'),
+                (int) config('freegle.monitoring.digest_daily_min_expected', 1),
+                fn ($q) => $q->where('mode', 'daily'),
+            ))
+                ->describedAs("Daily 'What's New' digest sent today")
+                ->inCategory('fire-once-output')
+                ->enabledWhen(fn () => trim((string) config('freegle.digest.daily_allowlist', '')) !== '')
+                ->activeBetween(13, 24, $tz),
+
+            // queue:background-tasks drains the Go-API -> Laravel task bridge.
+            // The failure mode is a stuck worker letting rows pile up, not an
+            // empty queue — so assert "no pending task waiting too long".
+            (new BacklogCheck(
+                'queue:background-tasks',
+                'background_tasks',
+                'created_at',
+                (int) config('freegle.monitoring.background_tasks_max_age_minutes', 10),
+                fn ($q) => $q->whereNull('processed_at')->whereNull('failed_at')->where('attempts', '<', 3),
+                (int) config('freegle.monitoring.background_tasks_backlog_threshold', 0),
+            ))
+                ->describedAs('Go-API background task queue not backing up')
+                ->inCategory('cursor-staleness'),
+
+            // spam:refresh-mobile-cidrs (monthly) upserts spam_whitelist_ips
+            // rows commented 'UK mobile: ...'. A 40-day staleness floor
+            // tolerates the monthly cadence.
+            (new FreshnessCheck(
+                'spam:refresh-mobile-cidrs',
+                'spam_whitelist_ips',
+                'date',
+                (int) config('freegle.monitoring.mobile_cidrs_max_age_days', 40) * 24 * 60,
+                fn ($q) => $q->where('comment', 'like', 'UK mobile:%'),
+            ))
+                ->describedAs('Monthly UK-mobile CGNAT CIDR refresh')
+                ->inCategory('fire-once-output'),
+        ];
+    }
+}

--- a/iznik-batch/config/freegle.php
+++ b/iznik-batch/config/freegle.php
@@ -404,6 +404,26 @@ return [
         // spam:refresh-mobile-cidrs — alert if the monthly UK-mobile CIDR
         // refresh hasn't written a row within this many days.
         'mobile_cidrs_max_age_days' => (int) env('FREEGLE_MONITORING_MOBILE_CIDRS_MAX_AGE_DAYS', 40),
+
+        // Shared backlog window for the per-minute processing queues
+        // (messages:contentcheck, chats:process-incoming, memberships:process):
+        // a row left unprocessed longer than this signals a stuck worker.
+        'processing_backlog_max_age_minutes' => (int) env('FREEGLE_MONITORING_PROCESSING_BACKLOG_MAX_AGE_MIN', 15),
+
+        // users:process-exports — exports are heavier, so a larger window.
+        'exports_backlog_max_age_minutes' => (int) env('FREEGLE_MONITORING_EXPORTS_BACKLOG_MAX_AGE_MIN', 30),
+
+        // integrations:sync-whatjobs — alert if jobs.seenat hasn't advanced
+        // within this many hours (tolerates the overnight gap + slow cold runs).
+        'whatjobs_max_age_hours' => (int) env('FREEGLE_MONITORING_WHATJOBS_MAX_AGE_HOURS', 24),
+
+        // data:git-summary (weekly) — alert if its config timestamp is older
+        // than this many days.
+        'git_summary_max_age_days' => (int) env('FREEGLE_MONITORING_GIT_SUMMARY_MAX_AGE_DAYS', 10),
+
+        // data:update-cpi (monthly) — alert if its config timestamp is older
+        // than this many days.
+        'cpi_max_age_days' => (int) env('FREEGLE_MONITORING_CPI_MAX_AGE_DAYS', 40),
     ],
 
     'dedup' => [

--- a/iznik-batch/config/freegle.php
+++ b/iznik-batch/config/freegle.php
@@ -372,6 +372,40 @@ return [
         'outgoing_stall_window_hours' => env('FREEGLE_EMAIL_HEALTH_OUTGOING_STALL_WINDOW_HOURS', 1),
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Scheduled-task Outcome Monitoring
+    |--------------------------------------------------------------------------
+    |
+    | Thresholds for the monitor:scheduled-outcomes cron job, which asserts that
+    | scheduled tasks actually did their work (not just that the scheduler is
+    | alive). Breaches escalate to Sentry. See docs/scheduled-outcome-monitoring.md.
+    |
+    */
+
+    'monitoring' => [
+        // Master kill-switch. When false, monitor:scheduled-outcomes no-ops.
+        'enabled' => env('FREEGLE_MONITORING_ENABLED', true),
+
+        // stats:generate-daily — minimum per-group stats rows expected for
+        // yesterday once the day's 02:30 run has had time to complete.
+        'stats_daily_min_expected' => (int) env('FREEGLE_MONITORING_STATS_DAILY_MIN', 1),
+
+        // mail:digest:unified --mode=daily — minimum daily-digest sends expected
+        // once the daily pilot is enabled (FREEGLE_DIGEST_DAILY_ALLOWLIST set).
+        'digest_daily_min_expected' => (int) env('FREEGLE_MONITORING_DIGEST_DAILY_MIN', 1),
+
+        // queue:background-tasks — a pending task (unprocessed, unfailed, under
+        // the retry cap) older than this many minutes signals a stuck worker.
+        'background_tasks_max_age_minutes' => (int) env('FREEGLE_MONITORING_BG_TASKS_MAX_AGE_MIN', 10),
+        // Number of such stale-pending tasks tolerated before breaching.
+        'background_tasks_backlog_threshold' => (int) env('FREEGLE_MONITORING_BG_TASKS_BACKLOG', 0),
+
+        // spam:refresh-mobile-cidrs — alert if the monthly UK-mobile CIDR
+        // refresh hasn't written a row within this many days.
+        'mobile_cidrs_max_age_days' => (int) env('FREEGLE_MONITORING_MOBILE_CIDRS_MAX_AGE_DAYS', 40),
+    ],
+
     'dedup' => [
         // Guard for the dedup:tn artisan command. Defaults to false — the
         // command refuses to run unless this is true, so it's safe to deploy

--- a/iznik-batch/docs/scheduled-outcome-monitoring.md
+++ b/iznik-batch/docs/scheduled-outcome-monitoring.md
@@ -77,12 +77,21 @@ correctness rules learned while populating the registry:
 
 ## Implemented checks
 
+Eleven per-job checks across all four primitives:
+
 | Task | Primitive | Signal | Notes |
 |---|---|---|---|
 | `stats:generate-daily` | `ProducedSinceCheck` | `stats` rows with `date >= yesterday` (London), floor 1 | Active 06:00–24:00 so it isn't checked before the 02:30 run. Strongest fire-once signal in the system (one `REPLACE` per group/type/day). |
 | `mail:digest:unified --mode=daily` | `ProducedSinceCheck` | `users_digests.lastsent` today WHERE `mode='daily'`, floor 1 | Gated `enabledWhen(daily_allowlist != '')` — inert (skipped) until the daily pilot is switched on. Active 13:00–24:00 (after the 07:00–12:00 send window). |
-| `queue:background-tasks` | `BacklogCheck` | `background_tasks` rows `processed_at IS NULL AND failed_at IS NULL AND attempts < 3` older than 10 min | The Go-API → Laravel task bridge; a stuck worker is the failure mode, not an empty queue. |
-| `spam:refresh-mobile-cidrs` | `FreshnessCheck` | `max(spam_whitelist_ips.date)` WHERE `comment LIKE 'UK mobile:%'`, ≤ 40 days | Monthly job; a 40-day staleness floor tolerates the cadence. |
+| `queue:background-tasks` | `BacklogCheck` | `background_tasks` rows `processed_at IS NULL AND failed_at IS NULL AND attempts < 3` older than 10 min | Go-API → Laravel task bridge; a stuck worker is the failure mode, not an empty queue. |
+| `messages:contentcheck` | `BacklogCheck` | `messages_groups` (joined to live `messages`/`users`) `collection='Pending' AND contentcheck_checked_at IS NULL AND deleted=0` older than 15 min | Moderation pipeline. The joins mirror the worker's exact selection so rows it permanently skips (deleted message / null fromuser) don't false-alarm. |
+| `chats:process-incoming` | `BacklogCheck` | `chat_messages` `processingrequired=1` (by `date`) older than 15 min | Worker clears `processingrequired` on every visited row (success or fail). |
+| `memberships:process` | `BacklogCheck` | `memberships_history` `processingrequired=1` (by `added`) older than 15 min | Welcome-mail / review processing queue. |
+| `users:process-exports` | `BacklogCheck` | `users_exports` `completed IS NULL` (by `requested`) older than 30 min | GDPR exports are rare, so an empty queue is normal — only a genuinely-stuck export fires. |
+| `spam:refresh-mobile-cidrs` | `FreshnessCheck` | `max(spam_whitelist_ips.date)` WHERE `comment LIKE 'UK mobile:%'`, ≤ 40 days | Monthly job; the 40-day floor tolerates the cadence. |
+| `integrations:sync-whatjobs` | `FreshnessCheck` | `max(jobs.seenat)`, ≤ 24h | Gated on `freegle.whatjobs.feed1` being set. 24h floor tolerates the 08:00–22:00 window + slow cold runs. |
+| `data:git-summary` | `CallbackCheck` (config) | unix timestamp in `config['git_summary_last_run']`, ≤ 10 days | Weekly. Missing key ⇒ skipped (may not have run since deploy); unparseable ⇒ breach. |
+| `data:update-cpi` | `CallbackCheck` (config) | ISO-8601 `updated_at` in JSON `config['cpi_annual_data']`, ≤ 40 days | Monthly. Same missing/unparseable handling. |
 
 Thresholds are env-overridable under `config('freegle.monitoring.*')` (see
 `.env.example`). A master kill-switch `FREEGLE_MONITORING_ENABLED=false` no-ops
@@ -119,38 +128,35 @@ stories, birthday, noticeboard thanks, alerts, notification chaseup) adds little
 
 ### Fire-once output — deferred (🟡)
 
-These have a clean "produced output this period" signal but were left out of the
-first cut to keep the registry high-confidence (several need a `config`-JSON
-timestamp parsed via `CallbackCheck`, or have a legitimately-empty upstream).
+Not implemented because a strict output floor would **false-alarm**: the output
+is legitimately zero on many periods (eligibility-gated, due-only, or an upstream
+feed that is genuinely empty), or there is no durable timestamp to key on.
 
-| Task | Cadence | Recommended | Signal |
-|---|---|---|---|
-| `data:update-cpi` | monthly | `CallbackCheck` | JSON `updated_at` inside `config` value `cpi_data` |
-| `data:fetch-app-versions` | 6h | `CallbackCheck` | `config` app-version keys (compare value, not count) |
-| `data:git-summary` | weekly | `CallbackCheck` | unix ts in `config` value `git_summary_last_run` |
-| `domains:update-common` | weekly | `FreshnessCheck` | `domains_common` recency (confirm `updated_at`) |
-| `integrations:sync-whatjobs` | 3h 08–22 | `ProducedSinceCheck` | `jobs` table non-empty after the rebuild/swap |
-| `integrations:sync-restartproject` / `-repaircafewales` / `-reachvolunteering` | daily | `FreshnessCheck` | `communityevents`/`volunteering` rows by `externalid` prefix — **upstream feed can be legitimately empty** |
-| `mail:donations:thank-prep` | daily | `CallbackCheck` | `config` high-water-mark `donation_thank_prep_last_id` advances |
-| `mail:volunteering-digest` / `mail:events-digest` | weekly | `ProducedSinceCheck` | `users_digests.lastsent` mode `volunteering`/`events` — 3-day guard + eligibility means zero can be correct |
-| `groups:check-mod-welfare` | weekly | `ProducedSinceCheck` | `groups_mods_welfare.warnedat` |
-| `groups:welcome-review` | daily | `FreshnessCheck` | `groups.welcomereview` |
-| `messages:process-expired` | daily | `ProducedSinceCheck` | `messages_outcomes` `outcome='Expired'` — zero correct when no deadlines lapsed |
+| Task | Why not (yet) |
+|---|---|
+| `data:fetch-app-versions` | The `config` value is just the version string with **no embedded timestamp**, and the store version rarely changes — no freshness signal without adding instrumentation. |
+| `domains:update-common` | `domains_common` has **no timestamp column** (id/domain/count only) — nothing to key freshness on. |
+| `integrations:sync-restartproject` / `-repaircafewales` / `-reachvolunteering` | `communityevents`/`volunteering` by `externalid` prefix — the upstream feed can be **legitimately empty** of upcoming events, so a floor would false-alarm. |
+| `mail:donations:thank-prep` | Dedup is a `config` id high-water-mark with no timestamp, and it only advances when new donations exist — zero is correct on a quiet day. |
+| `mail:volunteering-digest` / `mail:events-digest` | `users_digests.lastsent` mode `volunteering`/`events`, but the 3-day cadence guard + eligibility mean a zero week is correct. |
+| `groups:check-mod-welfare` | `groups_mods_welfare.warnedat` only advances when an inactive mod is found — zero is the healthy case. |
+| `groups:welcome-review` | Processes only groups *due* for review (≤10/run); most days none are due. |
+| `messages:process-expired` | `messages_outcomes outcome='Expired'` is zero when no deadlines lapsed that day. |
+
+Adding any of these would need a per-job "am I expected to have output *this*
+period?" precondition richer than a simple floor.
 
 ### Cursor / queue staleness — deferred (🟡)
 
-Best served by `BacklogCheck` (pending rows older than X), to be added as the
-"stuck worker" failure modes are prioritised:
+The high-value processing queues are now implemented (see above). These remain,
+to be added with `BacklogCheck`/`FreshnessCheck` as the failure modes are
+prioritised (each needs its exact "pending" predicate verified first):
 
-| Task | Backlog signal |
+| Task | Backlog/freshness signal |
 |---|---|
-| `messages:contentcheck` | `messages_groups` unprocessed pending age |
-| `chats:process-incoming` | `chat_messages.processingrequired=1` age |
-| `memberships:process` | `memberships_history.processingrequired=1` age |
-| `users:process-exports` | `users_exports.completed IS NULL` age |
-| `embeddings:generate` | messages awaiting embeddings age |
+| `embeddings:generate` | messages awaiting embeddings (`messages_spatial successful=0 promised=0` minus `messages_embeddings`) — multi-table predicate, verify before adding |
 | `messages:update-spatial-index` / `messages:update-index` | newest indexed vs newest message |
-| `newsfeed:generate-link-previews` | `link_previews.retrieved` recency vs new URLs |
+| `newsfeed:generate-link-previews` | `link_previews.retrieved` recency vs new URLs (quiet-period false-alarm risk) |
 | `microvolunteering:notify`, `chats:update-expected`, `users:update-modmails` | cursor recency |
 
 ### Not worth monitoring (⚪)

--- a/iznik-batch/docs/scheduled-outcome-monitoring.md
+++ b/iznik-batch/docs/scheduled-outcome-monitoring.md
@@ -1,0 +1,181 @@
+# Outcome-based monitoring for scheduled tasks
+
+**Command:** `monitor:scheduled-outcomes` — scheduled every 10 minutes in
+`routes/console.php` and itself heartbeated to Sentry Crons.
+
+## Why
+
+Laravel's scheduler has **no catch-up**: each minute `schedule:run` asks "is
+anything due *this* minute?" and runs it. If the scheduler isn't ticking at a
+job's exact due-minute (container restart, deploy, crash, a long previous tick)
+that job is **silently skipped for the period** — no retry, no error. And a job
+can be alive yet do nothing useful (errored mid-run, wrong config, upstream
+empty).
+
+There are two complementary questions, answered by two mechanisms:
+
+| Question | Mechanism | Status |
+|---|---|---|
+| Did the scheduler *fire* on cadence? | Sentry Crons check-ins (`->sentryMonitor()`) | `scheduler-heartbeat` covers total scheduler death; `monitor:scheduled-outcomes` is itself heartbeated |
+| Did the *work* actually happen? | **Outcome assertions** on each job's side-effect | **This feature** |
+
+Outcome-based monitoring is the only thing that catches "the scheduler was
+alive but this specific job errored / was skipped / produced nothing", and it
+doesn't false-alarm on `withoutOverlapping()` skips the way schedule-based
+monitoring does.
+
+## How it works
+
+A **declarative registry** (`App\Monitoring\ScheduledOutcomeRegistry`) maps a
+scheduled task to an *outcome assertion*. A single evaluator command
+(`monitor:scheduled-outcomes`) runs every check, prints a line per result, and
+on any breach escalates to Sentry (`\Sentry\captureMessage`, guarded by
+`function_exists` exactly like `EmailHealthCommand`/`TNSyncCommand`) and
+`Log::warning`, then exits non-zero (red badge in the cron-jobs sysadmin tab).
+`SKIPPED` results (precondition unmet or outside active window) never fail it.
+
+### Check primitives (`App\Monitoring\Checks`)
+
+Rather than ~100 bespoke commands, four reusable primitives cover the field:
+
+| Primitive | Asserts | Use for |
+|---|---|---|
+| `FreshnessCheck` | `max(timestamp)` on a table is within a max age | jobs that should *always* have produced something recently |
+| `ProducedSinceCheck` | count of rows since a window start meets a floor | **fire-once** jobs ("did it produce output this period?") |
+| `BacklogCheck` | pending rows older than a max age don't pile up | **cursor/queue** jobs (no false-alarm on an empty queue) |
+| `CallbackCheck` | an arbitrary closure result | bespoke signals (e.g. a JSON timestamp inside a `config` value) |
+
+All primitives share, via `AbstractOutcomeCheck`:
+
+- `enabledWhen(fn)` — a config-aware precondition. A job deliberately disabled
+  (e.g. an empty allowlist) is `SKIPPED`, not a failure.
+- `activeBetween(from, to, tz)` — only evaluate during an hour window in a given
+  timezone. This is how a daily job is checked *after* its due time + slack
+  (and a windowed job isn't checked outside its window — the Sentry-Crons gotcha
+  the brief calls out).
+- `withSeverity()` / `inCategory()` / `describedAs()` — metadata surfaced in the
+  output and the Sentry message.
+
+### Choosing a signal
+
+The natural "did it do its work" signal for most jobs is **freshness of a side
+effect** — a `max(timestamp)` (or a count) on the table the job writes. The key
+correctness rules learned while populating the registry:
+
+1. **Cursor/queue jobs must use `BacklogCheck`, not freshness.** A freshness
+   check on a queue table false-alarms whenever the queue is legitimately empty
+   (e.g. no new members overnight). Instead assert "no *pending* row has been
+   waiting longer than X" — which only fires when a worker is genuinely stuck.
+2. **Checks must be config/allowlist-aware.** A digest with an empty
+   `FREEGLE_DIGEST_DAILY_ALLOWLIST` is *deliberately* sending to nobody — zero is
+   correct. Encode that as `enabledWhen()`.
+3. **Boundaries are London-local.** Daily windows use
+   `now($tz)->startOfDay()` (per `freegle.timezone`), matching each job's own
+   period semantics, not naive UTC days.
+4. **Cleanup/purge/in-place-update jobs are usually not monitorable** — zero
+   output is the normal, healthy case (see the table below).
+
+## Implemented checks
+
+| Task | Primitive | Signal | Notes |
+|---|---|---|---|
+| `stats:generate-daily` | `ProducedSinceCheck` | `stats` rows with `date >= yesterday` (London), floor 1 | Active 06:00–24:00 so it isn't checked before the 02:30 run. Strongest fire-once signal in the system (one `REPLACE` per group/type/day). |
+| `mail:digest:unified --mode=daily` | `ProducedSinceCheck` | `users_digests.lastsent` today WHERE `mode='daily'`, floor 1 | Gated `enabledWhen(daily_allowlist != '')` — inert (skipped) until the daily pilot is switched on. Active 13:00–24:00 (after the 07:00–12:00 send window). |
+| `queue:background-tasks` | `BacklogCheck` | `background_tasks` rows `processed_at IS NULL AND failed_at IS NULL AND attempts < 3` older than 10 min | The Go-API → Laravel task bridge; a stuck worker is the failure mode, not an empty queue. |
+| `spam:refresh-mobile-cidrs` | `FreshnessCheck` | `max(spam_whitelist_ips.date)` WHERE `comment LIKE 'UK mobile:%'`, ≤ 40 days | Monthly job; a 40-day staleness floor tolerates the cadence. |
+
+Thresholds are env-overridable under `config('freegle.monitoring.*')` (see
+`.env.example`). A master kill-switch `FREEGLE_MONITORING_ENABLED=false` no-ops
+the whole command.
+
+## Adding a check
+
+Add one entry to `ScheduledOutcomeRegistry::checks()`. Verify the table/column
+against the actual command/service (and a migration) before adding it — a wrong
+column would page the team at 4am. `ScheduledOutcomeRegistryTest` runs every
+registered check against the migrated schema, so a typo fails CI rather than
+production.
+
+## Categorisation of all scheduled tasks
+
+Legend: ✅ implemented · 🔵 already covered elsewhere · 🟡 monitorable, deferred
+(recommended primitive noted) · ⚪ not worth monitoring (zero output is normal).
+
+### Already covered (do not duplicate)
+
+| Task | By |
+|---|---|
+| *(all jobs at once — scheduler death)* | 🔵 `scheduler-heartbeat` Sentry Cron |
+| Aggregate outgoing/incoming email flow | 🔵 `monitor:email-health` (`email_tracking.sent_at` stall + volume floor, 24/7) |
+| `tn:sync` | 🔵 self-alerts via its own `alertIfSyncStale` → Sentry (ratings staleness >12h) |
+| `monitor:scheduled-outcomes` itself | 🔵 `->sentryMonitor()` heartbeat |
+
+Because every email-sending job flows through `email_tracking.sent_at`,
+`monitor:email-health` already catches a smarthost/spooler stall affecting the
+**aggregate** mail pipeline. Individually monitoring sparse per-job mail
+(welcome, chat notifs, mod-notifs, admin mails, donation thanks, engage,
+stories, birthday, noticeboard thanks, alerts, notification chaseup) adds little
+— they are sparse by nature, so a single missed run is invisible and harmless.
+
+### Fire-once output — deferred (🟡)
+
+These have a clean "produced output this period" signal but were left out of the
+first cut to keep the registry high-confidence (several need a `config`-JSON
+timestamp parsed via `CallbackCheck`, or have a legitimately-empty upstream).
+
+| Task | Cadence | Recommended | Signal |
+|---|---|---|---|
+| `data:update-cpi` | monthly | `CallbackCheck` | JSON `updated_at` inside `config` value `cpi_data` |
+| `data:fetch-app-versions` | 6h | `CallbackCheck` | `config` app-version keys (compare value, not count) |
+| `data:git-summary` | weekly | `CallbackCheck` | unix ts in `config` value `git_summary_last_run` |
+| `domains:update-common` | weekly | `FreshnessCheck` | `domains_common` recency (confirm `updated_at`) |
+| `integrations:sync-whatjobs` | 3h 08–22 | `ProducedSinceCheck` | `jobs` table non-empty after the rebuild/swap |
+| `integrations:sync-restartproject` / `-repaircafewales` / `-reachvolunteering` | daily | `FreshnessCheck` | `communityevents`/`volunteering` rows by `externalid` prefix — **upstream feed can be legitimately empty** |
+| `mail:donations:thank-prep` | daily | `CallbackCheck` | `config` high-water-mark `donation_thank_prep_last_id` advances |
+| `mail:volunteering-digest` / `mail:events-digest` | weekly | `ProducedSinceCheck` | `users_digests.lastsent` mode `volunteering`/`events` — 3-day guard + eligibility means zero can be correct |
+| `groups:check-mod-welfare` | weekly | `ProducedSinceCheck` | `groups_mods_welfare.warnedat` |
+| `groups:welcome-review` | daily | `FreshnessCheck` | `groups.welcomereview` |
+| `messages:process-expired` | daily | `ProducedSinceCheck` | `messages_outcomes` `outcome='Expired'` — zero correct when no deadlines lapsed |
+
+### Cursor / queue staleness — deferred (🟡)
+
+Best served by `BacklogCheck` (pending rows older than X), to be added as the
+"stuck worker" failure modes are prioritised:
+
+| Task | Backlog signal |
+|---|---|
+| `messages:contentcheck` | `messages_groups` unprocessed pending age |
+| `chats:process-incoming` | `chat_messages.processingrequired=1` age |
+| `memberships:process` | `memberships_history.processingrequired=1` age |
+| `users:process-exports` | `users_exports.completed IS NULL` age |
+| `embeddings:generate` | messages awaiting embeddings age |
+| `messages:update-spatial-index` / `messages:update-index` | newest indexed vs newest message |
+| `newsfeed:generate-link-previews` | `link_previews.retrieved` recency vs new URLs |
+| `microvolunteering:notify`, `chats:update-expected`, `users:update-modmails` | cursor recency |
+
+### Not worth monitoring (⚪)
+
+Zero output is the normal, healthy case — monitoring a count/freshness here
+would false-alarm constantly:
+
+- **Cleanup / purge / dedup** (delete nothing when there's nothing to delete):
+  `cleanup:search-duplicates`, `cleanup:chat-duplicates`,
+  `cleanup:archive-profile-images`, `cleanup:sessions`, `purge:chats`,
+  `purge:logs`, `purge:messages`, `emails:validate`, `messages:deindex`,
+  `mail:spool:process` (filesystem), `mail:cleanup-archive` (filesystem),
+  `users:remove-spammers`.
+- **In-place recomputes with no advancing timestamp** (UPDATE existing rows):
+  `groups:update-counts`, `chats:update-counts`, `users:update-lastaccess`,
+  `users:update-engagement`, `users:update-kudos`, `users:update-ratings`,
+  `users:update-support-roles`, `ai:usage-counts:update`,
+  `donations:update-ads-target`, `microvolunteering:score`.
+- **Backlog-cleared / sparse maintenance** (legitimately a no-op once caught up):
+  `users:remap-locations`, `users:fix-tn-names`, `messages:remap-subjects`,
+  `locations:fix-skewed`, `locations:sync-pgsql`, `messages:update-visualise`,
+  `jobs:generate-illustrations`, `messages:generate-illustrations`,
+  `groups:check-boundaries` (read-only validation), `donations:update-giftaid`,
+  `deploy:record-commit` (`config` has no timestamp column),
+  `eee:sync-mv-labels` (cursor in cache; remote sink),
+  `integrations:sync-lovejunk`, `mail:admin:chase`.
+- **Email-only "alert when bad"** (zero output = healthy platform):
+  `groups:remind-closed`, `groups:alert-no-messages`.

--- a/iznik-batch/routes/console.php
+++ b/iznik-batch/routes/console.php
@@ -224,6 +224,19 @@ Schedule::command('monitor:email-health')
     ->sendOutputTo(cronLog('monitor:email-health'))
     ->runInBackground();
 
+// Outcome-based monitoring — asserts that scheduled tasks actually DID their
+// work (rows written, cursor advanced), not just that the scheduler is alive.
+// Breaches escalate to Sentry. Runs inline (it's just a few aggregate queries)
+// and is itself heartbeated to Sentry Crons, so a stalled monitor — or a dead
+// scheduler — is visible even when no individual job has breached yet.
+// See docs/scheduled-outcome-monitoring.md.
+Schedule::command('monitor:scheduled-outcomes')
+    ->everyTenMinutes()
+    ->name('scheduled-outcomes-monitor')
+    ->withoutOverlapping()
+    ->sentryMonitor('scheduled-outcomes-monitor', 10)
+    ->sendOutputTo(cronLog('monitor:scheduled-outcomes'));
+
 // Notification chaseup - send emails for unseen, unmailed site notifications.
 // V1: cron/notification_chaseup.php (every 5 minutes)
 Schedule::command('mail:notifications:chaseup')

--- a/iznik-batch/routes/console.php
+++ b/iznik-batch/routes/console.php
@@ -209,12 +209,17 @@ Schedule::command('mail:alerts:send')
 // EVERY scheduled job until it restarts (Laravel's scheduler has no catch-up).
 // This no-op task checks in to Sentry every 5 minutes; if the loop stops,
 // Sentry sees the missed check-in and alerts. Sentry is free for us on the
-// open-source plan, so the check-in volume is a non-issue. checkInMargin=5
-// gives slack for the sleep(60) loop's natural drift before flagging a miss.
+// open-source plan, so the check-in volume is a non-issue. The check-in is
+// deliberately lax to avoid occasional false alarms from the loop's natural
+// drift: checkInMargin=15 gives generous grace before a check-in counts as
+// missed, and failureIssueThreshold=2 means a single sporadic miss won't raise
+// an issue — it takes two consecutive misses — with recoveryThreshold=1
+// clearing it on the next good check-in.
 Schedule::call(fn () => null)
     ->everyFiveMinutes()
     ->name('scheduler-heartbeat')
-    ->sentryMonitor('scheduler-heartbeat', 5);
+    // sentryMonitor(slug, checkInMargin, maxRuntime, updateMonitorConfig, failureIssueThreshold, recoveryThreshold)
+    ->sentryMonitor('scheduler-heartbeat', 15, null, true, 2, 1);
 
 // Email health monitor — alerts if incoming or outgoing email flow drops below
 // configurable thresholds during daytime hours.
@@ -230,11 +235,15 @@ Schedule::command('monitor:email-health')
 // and is itself heartbeated to Sentry Crons, so a stalled monitor — or a dead
 // scheduler — is visible even when no individual job has breached yet.
 // See docs/scheduled-outcome-monitoring.md.
+// Same lax thresholds as the scheduler heartbeat (generous margin + two
+// consecutive misses before an issue) so the monitor's own check-in doesn't
+// false-alarm on occasional scheduler drift.
 Schedule::command('monitor:scheduled-outcomes')
     ->everyTenMinutes()
     ->name('scheduled-outcomes-monitor')
     ->withoutOverlapping()
-    ->sentryMonitor('scheduled-outcomes-monitor', 10)
+    // sentryMonitor(slug, checkInMargin, maxRuntime, updateMonitorConfig, failureIssueThreshold, recoveryThreshold)
+    ->sentryMonitor('scheduled-outcomes-monitor', 20, null, true, 2, 1)
     ->sendOutputTo(cronLog('monitor:scheduled-outcomes'));
 
 // Notification chaseup - send emails for unseen, unmailed site notifications.

--- a/iznik-batch/tests/Feature/Monitor/MonitorScheduledOutcomesCommandTest.php
+++ b/iznik-batch/tests/Feature/Monitor/MonitorScheduledOutcomesCommandTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Tests\Feature\Monitor;
+
+use App\Monitoring\Checks\CallbackCheck;
+use App\Monitoring\OutcomeResult;
+use App\Monitoring\ScheduledOutcomeRegistry;
+use Illuminate\Support\Facades\Log;
+use Tests\TestCase;
+
+/**
+ * Tests for monitor:scheduled-outcomes.
+ *
+ * The command's job is orchestration: run each registered check, print a line
+ * per result, and on any BREACH escalate to Sentry + Log::warning and exit
+ * non-zero. SKIPPED results never fail the command.
+ *
+ * We inject a fake registry (returning controllable CallbackChecks) so these
+ * tests exercise the command logic in isolation from the real registry's
+ * table/column wiring — that wiring is covered by ScheduledOutcomeRegistryTest.
+ *
+ * As in EmailHealthCommandTest, we assert on Log::warning + exit code rather
+ * than the guarded \Sentry\captureMessage (a global not loaded under test).
+ */
+class MonitorScheduledOutcomesCommandTest extends TestCase
+{
+    /**
+     * Bind a registry whose checks() returns the given checks.
+     *
+     * @param  array<int, \App\Monitoring\OutcomeCheck>  $checks
+     */
+    private function fakeRegistry(array $checks): void
+    {
+        $registry = new class($checks) extends ScheduledOutcomeRegistry {
+            public function __construct(private array $fakeChecks)
+            {
+            }
+
+            public function checks(): array
+            {
+                return $this->fakeChecks;
+            }
+        };
+
+        $this->app->instance(ScheduledOutcomeRegistry::class, $registry);
+    }
+
+    public function test_reports_success_when_all_checks_pass(): void
+    {
+        $this->fakeRegistry([
+            new CallbackCheck('job:a', fn ($now) => OutcomeResult::ok('job:a', 'fine')),
+            new CallbackCheck('job:b', fn ($now) => OutcomeResult::ok('job:b', 'fine')),
+        ]);
+
+        Log::spy();
+
+        $this->artisan('monitor:scheduled-outcomes')
+            ->expectsOutputToContain('All scheduled-outcome checks OK.')
+            ->assertExitCode(0);
+
+        Log::shouldNotHaveReceived('warning');
+    }
+
+    public function test_reports_failure_and_logs_when_a_check_breaches(): void
+    {
+        $this->fakeRegistry([
+            new CallbackCheck('job:a', fn ($now) => OutcomeResult::ok('job:a', 'fine')),
+            new CallbackCheck('job:b', fn ($now) => OutcomeResult::breach('job:b', 'did not run today')),
+        ]);
+
+        Log::spy();
+
+        $this->artisan('monitor:scheduled-outcomes')
+            ->assertExitCode(1);
+
+        Log::shouldHaveReceived('warning')
+            ->withArgs(fn ($message, $context = []) =>
+                str_contains((string) $message, 'job:b')
+                && str_contains((string) $message, 'did not run today')
+            );
+    }
+
+    public function test_skipped_checks_do_not_cause_failure(): void
+    {
+        $this->fakeRegistry([
+            new CallbackCheck('job:a', fn ($now) => OutcomeResult::skipped('job:a', 'disabled')),
+            new CallbackCheck('job:b', fn ($now) => OutcomeResult::ok('job:b', 'fine')),
+        ]);
+
+        Log::spy();
+
+        $this->artisan('monitor:scheduled-outcomes')
+            ->assertExitCode(0);
+
+        Log::shouldNotHaveReceived('warning');
+    }
+
+    public function test_only_option_runs_a_single_check(): void
+    {
+        $this->fakeRegistry([
+            new CallbackCheck('job:a', fn ($now) => OutcomeResult::ok('job:a', 'alpha-ran')),
+            new CallbackCheck('job:b', fn ($now) => OutcomeResult::breach('job:b', 'beta-breached')),
+        ]);
+
+        // Only job:a is run, so the breaching job:b is never evaluated → exit 0.
+        $this->artisan('monitor:scheduled-outcomes --only=job:a')
+            ->expectsOutputToContain('alpha-ran')
+            ->doesntExpectOutputToContain('beta-breached')
+            ->assertExitCode(0);
+    }
+
+    public function test_disabled_via_config_noops_even_with_a_breach(): void
+    {
+        config(['freegle.monitoring.enabled' => false]);
+
+        $this->fakeRegistry([
+            new CallbackCheck('job:b', fn ($now) => OutcomeResult::breach('job:b', 'would breach')),
+        ]);
+
+        Log::spy();
+
+        $this->artisan('monitor:scheduled-outcomes')
+            ->expectsOutputToContain('disabled')
+            ->assertExitCode(0);
+
+        Log::shouldNotHaveReceived('warning');
+    }
+}

--- a/iznik-batch/tests/Feature/Monitor/ScheduledOutcomeChecksTest.php
+++ b/iznik-batch/tests/Feature/Monitor/ScheduledOutcomeChecksTest.php
@@ -1,0 +1,251 @@
+<?php
+
+namespace Tests\Feature\Monitor;
+
+use App\Monitoring\Checks\BacklogCheck;
+use App\Monitoring\Checks\CallbackCheck;
+use App\Monitoring\Checks\FreshnessCheck;
+use App\Monitoring\Checks\ProducedSinceCheck;
+use App\Monitoring\OutcomeResult;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+/**
+ * Tests for the outcome-monitoring check primitives.
+ *
+ * Each primitive is exercised against a real (migrated) table so a wrong
+ * table/column name would surface as a query error, not a silent pass:
+ *  - FreshnessCheck       — max(timestamp) must be within a max age.
+ *  - ProducedSinceCheck   — count of rows since a window start must meet a floor.
+ *  - BacklogCheck         — pending rows older than a max age must not pile up.
+ *  - CallbackCheck        — arbitrary closure result.
+ *
+ * Plus the cross-cutting base behaviours: an unmet precondition or a time
+ * outside the active window yields SKIPPED (never a breach).
+ *
+ * FK-free tables (spam_whitelist_ips, background_tasks) are used so the tests
+ * don't depend on seeding parent rows. DatabaseTransactions rolls everything
+ * back; setUp clears the tables so "0 rows" assertions are deterministic.
+ */
+class ScheduledOutcomeChecksTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        DB::table('spam_whitelist_ips')->delete();
+        DB::table('background_tasks')->delete();
+    }
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+        parent::tearDown();
+    }
+
+    private function seedWhitelistIp(string $comment, Carbon $date): void
+    {
+        DB::table('spam_whitelist_ips')->insert([
+            'ip' => '10.' . random_int(0, 255) . '.' . random_int(0, 255) . '.' . random_int(1, 254),
+            'comment' => $comment,
+            'date' => $date,
+        ]);
+    }
+
+    private function seedBackgroundTask(Carbon $createdAt, ?Carbon $processedAt = null, ?Carbon $failedAt = null, int $attempts = 0): void
+    {
+        DB::table('background_tasks')->insert([
+            'task_type' => 'push_notification',
+            'data' => json_encode(['x' => 1]),
+            'created_at' => $createdAt,
+            'processed_at' => $processedAt,
+            'failed_at' => $failedAt,
+            'attempts' => $attempts,
+        ]);
+    }
+
+    // --- FreshnessCheck -----------------------------------------------------
+
+    public function test_freshness_check_ok_when_recent(): void
+    {
+        Carbon::setTestNow(Carbon::create(2026, 6, 12, 10, 0, 0));
+        $this->seedWhitelistIp('UK mobile: EE', Carbon::now()->subDays(2));
+
+        $check = new FreshnessCheck('test:fresh', 'spam_whitelist_ips', 'date', 40 * 24 * 60);
+        $result = $check->evaluate(Carbon::now());
+
+        $this->assertTrue($result->isOk(), $result->message);
+    }
+
+    public function test_freshness_check_breaches_when_stale(): void
+    {
+        Carbon::setTestNow(Carbon::create(2026, 6, 12, 10, 0, 0));
+        $this->seedWhitelistIp('UK mobile: EE', Carbon::now()->subDays(50));
+
+        $check = new FreshnessCheck('test:fresh', 'spam_whitelist_ips', 'date', 40 * 24 * 60);
+        $result = $check->evaluate(Carbon::now());
+
+        $this->assertTrue($result->isBreach(), $result->message);
+    }
+
+    public function test_freshness_check_breaches_when_no_rows(): void
+    {
+        Carbon::setTestNow(Carbon::create(2026, 6, 12, 10, 0, 0));
+
+        $check = new FreshnessCheck('test:fresh', 'spam_whitelist_ips', 'date', 40 * 24 * 60);
+        $result = $check->evaluate(Carbon::now());
+
+        $this->assertTrue($result->isBreach(), $result->message);
+        $this->assertStringContainsString('no rows', $result->message);
+    }
+
+    public function test_freshness_check_honours_where_filter(): void
+    {
+        Carbon::setTestNow(Carbon::create(2026, 6, 12, 10, 0, 0));
+        // A fresh row that does NOT match the filter, and a stale one that does.
+        $this->seedWhitelistIp('Some other entry', Carbon::now()->subDays(1));
+        $this->seedWhitelistIp('UK mobile: EE', Carbon::now()->subDays(50));
+
+        $check = new FreshnessCheck(
+            'test:fresh',
+            'spam_whitelist_ips',
+            'date',
+            40 * 24 * 60,
+            fn ($q) => $q->where('comment', 'like', 'UK mobile:%'),
+        );
+        $result = $check->evaluate(Carbon::now());
+
+        $this->assertTrue($result->isBreach(), $result->message);
+    }
+
+    // --- ProducedSinceCheck -------------------------------------------------
+
+    public function test_produced_since_ok_when_floor_met(): void
+    {
+        Carbon::setTestNow(Carbon::create(2026, 6, 12, 10, 0, 0));
+        $this->seedBackgroundTask(Carbon::now()->subHours(2));
+        $this->seedBackgroundTask(Carbon::now()->subHour());
+
+        $check = new ProducedSinceCheck(
+            'test:produced',
+            'background_tasks',
+            'created_at',
+            fn ($now) => $now->copy()->startOfDay(),
+            1,
+        );
+        $result = $check->evaluate(Carbon::now());
+
+        $this->assertTrue($result->isOk(), $result->message);
+    }
+
+    public function test_produced_since_breaches_when_below_floor(): void
+    {
+        Carbon::setTestNow(Carbon::create(2026, 6, 12, 10, 0, 0));
+        // Only a row from yesterday — before today's window start.
+        $this->seedBackgroundTask(Carbon::now()->subDay());
+
+        $check = new ProducedSinceCheck(
+            'test:produced',
+            'background_tasks',
+            'created_at',
+            fn ($now) => $now->copy()->startOfDay(),
+            1,
+        );
+        $result = $check->evaluate(Carbon::now());
+
+        $this->assertTrue($result->isBreach(), $result->message);
+    }
+
+    // --- BacklogCheck -------------------------------------------------------
+
+    public function test_backlog_check_ok_when_no_stale_pending(): void
+    {
+        Carbon::setTestNow(Carbon::create(2026, 6, 12, 10, 0, 0));
+        // Pending but recent (2 min old) — not yet stale.
+        $this->seedBackgroundTask(Carbon::now()->subMinutes(2));
+        // Old but already processed — must be ignored.
+        $this->seedBackgroundTask(Carbon::now()->subHour(), processedAt: Carbon::now()->subMinutes(30));
+
+        $check = new BacklogCheck(
+            'test:backlog',
+            'background_tasks',
+            'created_at',
+            10,
+            fn ($q) => $q->whereNull('processed_at')->whereNull('failed_at')->where('attempts', '<', 3),
+        );
+        $result = $check->evaluate(Carbon::now());
+
+        $this->assertTrue($result->isOk(), $result->message);
+    }
+
+    public function test_backlog_check_breaches_when_stale_pending(): void
+    {
+        Carbon::setTestNow(Carbon::create(2026, 6, 12, 10, 0, 0));
+        // Pending and old (20 min) — worker appears stuck.
+        $this->seedBackgroundTask(Carbon::now()->subMinutes(20));
+
+        $check = new BacklogCheck(
+            'test:backlog',
+            'background_tasks',
+            'created_at',
+            10,
+            fn ($q) => $q->whereNull('processed_at')->whereNull('failed_at')->where('attempts', '<', 3),
+        );
+        $result = $check->evaluate(Carbon::now());
+
+        $this->assertTrue($result->isBreach(), $result->message);
+    }
+
+    // --- CallbackCheck ------------------------------------------------------
+
+    public function test_callback_check_returns_callback_result(): void
+    {
+        Carbon::setTestNow(Carbon::create(2026, 6, 12, 10, 0, 0));
+
+        $check = new CallbackCheck(
+            'test:callback',
+            fn ($now) => OutcomeResult::breach('test:callback', 'boom'),
+        );
+        $result = $check->evaluate(Carbon::now());
+
+        $this->assertTrue($result->isBreach());
+        $this->assertSame('boom', $result->message);
+    }
+
+    // --- Base behaviours ----------------------------------------------------
+
+    public function test_unmet_precondition_is_skipped_not_breached(): void
+    {
+        Carbon::setTestNow(Carbon::create(2026, 6, 12, 10, 0, 0));
+        // No rows at all would normally breach, but the precondition is false.
+        $check = (new FreshnessCheck('test:fresh', 'spam_whitelist_ips', 'date', 60))
+            ->enabledWhen(fn () => false);
+        $result = $check->evaluate(Carbon::now());
+
+        $this->assertTrue($result->isSkipped(), $result->message);
+    }
+
+    public function test_outside_active_window_is_skipped(): void
+    {
+        // 03:00 UTC — outside a 06:00-12:00 window.
+        Carbon::setTestNow(Carbon::create(2026, 6, 12, 3, 0, 0));
+
+        $check = (new FreshnessCheck('test:fresh', 'spam_whitelist_ips', 'date', 60))
+            ->activeBetween(6, 12, 'UTC');
+        $result = $check->evaluate(Carbon::now());
+
+        $this->assertTrue($result->isSkipped(), $result->message);
+    }
+
+    public function test_inside_active_window_is_evaluated(): void
+    {
+        // 09:00 UTC — inside a 06:00-12:00 window; no rows → breach (evaluated).
+        Carbon::setTestNow(Carbon::create(2026, 6, 12, 9, 0, 0));
+
+        $check = (new FreshnessCheck('test:fresh', 'spam_whitelist_ips', 'date', 60))
+            ->activeBetween(6, 12, 'UTC');
+        $result = $check->evaluate(Carbon::now());
+
+        $this->assertTrue($result->isBreach(), $result->message);
+    }
+}

--- a/iznik-batch/tests/Feature/Monitor/ScheduledOutcomeRegistryTest.php
+++ b/iznik-batch/tests/Feature/Monitor/ScheduledOutcomeRegistryTest.php
@@ -95,4 +95,65 @@ class ScheduledOutcomeRegistryTest extends TestCase
         ]);
         $this->assertTrue($check->evaluate(Carbon::now())->isOk());
     }
+
+    private function check(string $slug): \App\Monitoring\OutcomeCheck
+    {
+        foreach ((new ScheduledOutcomeRegistry())->checks() as $c) {
+            if ($c->slug() === $slug) {
+                return $c;
+            }
+        }
+        $this->fail("check '{$slug}' not found in registry");
+    }
+
+    /**
+     * The config-freshness checks read a timestamp embedded in a config value
+     * (the config table has no updated_at). Verify the parse + compare for both
+     * the unix-timestamp (git-summary) and JSON-updated_at (cpi) formats.
+     */
+    public function test_config_freshness_checks_parse_and_evaluate(): void
+    {
+        Carbon::setTestNow(Carbon::create(2026, 6, 12, 14, 0, 0));
+        DB::table('config')->whereIn('key', ['git_summary_last_run', 'cpi_annual_data'])->delete();
+
+        $git = $this->check('data:git-summary');
+        $cpi = $this->check('data:update-cpi');
+
+        // Missing key -> skipped (no false breach on a fresh deploy).
+        $this->assertTrue($git->evaluate(Carbon::now())->isSkipped());
+
+        // git-summary: fresh unix timestamp -> ok; stale -> breach.
+        DB::table('config')->insert(['key' => 'git_summary_last_run', 'value' => (string) Carbon::now()->subDays(2)->timestamp]);
+        $this->assertTrue($git->evaluate(Carbon::now())->isOk());
+        DB::table('config')->where('key', 'git_summary_last_run')->update(['value' => (string) Carbon::now()->subDays(30)->timestamp]);
+        $this->assertTrue($git->evaluate(Carbon::now())->isBreach());
+
+        // cpi: fresh ISO-8601 updated_at inside JSON -> ok; stale -> breach.
+        DB::table('config')->insert([
+            'key' => 'cpi_annual_data',
+            'value' => json_encode(['data' => [], 'updated_at' => Carbon::now()->subDays(5)->toIso8601String()]),
+        ]);
+        $this->assertTrue($cpi->evaluate(Carbon::now())->isOk());
+        DB::table('config')->where('key', 'cpi_annual_data')->update([
+            'value' => json_encode(['data' => [], 'updated_at' => Carbon::now()->subDays(60)->toIso8601String()]),
+        ]);
+        $this->assertTrue($cpi->evaluate(Carbon::now())->isBreach());
+    }
+
+    /**
+     * The whatjobs check is gated on a feed being configured, so the smoke test
+     * skips it. Enable it and verify it queries jobs.seenat against the real
+     * schema (empty table -> breach, but the query must run without error).
+     */
+    public function test_whatjobs_check_queries_jobs_table_when_enabled(): void
+    {
+        config(['freegle.whatjobs.feed1' => 'https://example.com/feed']);
+        Carbon::setTestNow(Carbon::create(2026, 6, 12, 14, 0, 0));
+        DB::table('jobs')->delete();
+
+        $result = $this->check('integrations:sync-whatjobs')->evaluate(Carbon::now());
+
+        // No rows in jobs -> breach ("no rows"), proving the seenat query ran.
+        $this->assertTrue($result->isBreach(), $result->message);
+    }
 }

--- a/iznik-batch/tests/Feature/Monitor/ScheduledOutcomeRegistryTest.php
+++ b/iznik-batch/tests/Feature/Monitor/ScheduledOutcomeRegistryTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Tests\Feature\Monitor;
+
+use App\Monitoring\OutcomeCheck;
+use App\Monitoring\OutcomeResult;
+use App\Monitoring\ScheduledOutcomeRegistry;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+/**
+ * Smoke tests for the populated registry.
+ *
+ * The most important guarantee here is that every registered check actually
+ * QUERIES THE REAL SCHEMA without error — a typo'd table or column name would
+ * throw a query exception against the migrated test DB and fail this test,
+ * rather than silently false-alarming in production. (Each check legitimately
+ * BREACHES against empty tables; we assert it returns a valid result, not that
+ * it passes.)
+ */
+class ScheduledOutcomeRegistryTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+        parent::tearDown();
+    }
+
+    public function test_registry_returns_checks(): void
+    {
+        $checks = (new ScheduledOutcomeRegistry())->checks();
+
+        $this->assertNotEmpty($checks);
+        foreach ($checks as $check) {
+            $this->assertInstanceOf(OutcomeCheck::class, $check);
+        }
+    }
+
+    public function test_registry_slugs_are_unique(): void
+    {
+        $slugs = array_map(fn (OutcomeCheck $c) => $c->slug(), (new ScheduledOutcomeRegistry())->checks());
+
+        $this->assertSame(
+            array_values(array_unique($slugs)),
+            array_values($slugs),
+            'Registry slugs must be unique'
+        );
+    }
+
+    public function test_every_check_evaluates_against_real_schema_without_error(): void
+    {
+        // Mid-morning so daytime-windowed checks are active and actually run a query.
+        Carbon::setTestNow(Carbon::create(2026, 6, 12, 14, 0, 0));
+
+        foreach ((new ScheduledOutcomeRegistry())->checks() as $check) {
+            $result = $check->evaluate(Carbon::now());
+            $this->assertInstanceOf(
+                OutcomeResult::class,
+                $result,
+                "Check {$check->slug()} did not return an OutcomeResult"
+            );
+        }
+    }
+
+    /**
+     * The daily-digest check is SKIPPED by default (empty allowlist), so the
+     * smoke test above never exercises its users_digests query. Enable it and
+     * seed a row to verify the table/column wiring is correct.
+     */
+    public function test_daily_digest_check_queries_users_digests_when_enabled(): void
+    {
+        config(['freegle.digest.daily_allowlist' => 'pilot@example.com']);
+        // 14:00 UTC = 15:00 London — inside the digest check's 13:00-24:00 window.
+        Carbon::setTestNow(Carbon::create(2026, 6, 12, 14, 0, 0));
+
+        $check = null;
+        foreach ((new ScheduledOutcomeRegistry())->checks() as $c) {
+            if ($c->slug() === 'mail:digest:unified --mode=daily') {
+                $check = $c;
+            }
+        }
+        $this->assertNotNull($check, 'daily digest check not found in registry');
+
+        // No daily send recorded today → breach (query runs against users_digests).
+        DB::table('users_digests')->where('mode', 'daily')->delete();
+        $this->assertTrue($check->evaluate(Carbon::now())->isBreach());
+
+        // A daily send recorded today → OK.
+        $user = $this->createTestUser();
+        DB::table('users_digests')->insert([
+            'userid' => $user->id,
+            'mode' => 'daily',
+            'lastsent' => Carbon::now(),
+        ]);
+        $this->assertTrue($check->evaluate(Carbon::now())->isOk());
+    }
+}


### PR DESCRIPTION
Implements `plans/outcome-based-scheduler-monitoring-2026-06-12.md`.

## Why

Laravel's scheduler has **no catch-up**: a job not ticked at its exact due-minute (container restart, deploy, crash, a long previous tick) is **silently skipped for the period** — no retry, no error. And a job can be alive yet do nothing useful (errored mid-run, misconfigured, empty upstream). The existing `scheduler-heartbeat` Sentry Cron only catches *total* scheduler death; this adds **outcome-based** monitoring that asserts each job actually did its work.

## What

A generic framework instead of ~100 bespoke commands:

- **`App\Monitoring`** — `OutcomeResult` (ok/breach/skipped), `OutcomeCheck`, and `AbstractOutcomeCheck` providing the two cross-cutting concerns the brief calls out: a config-aware `enabledWhen()` precondition and an `activeBetween()` hour-window, **both yielding SKIPPED, never a false breach**.
- **Four reusable primitives**:
  - `FreshnessCheck` — `max(timestamp)` within a max age.
  - `ProducedSinceCheck` — rows since a London-local window meet a floor (fire-once jobs).
  - `BacklogCheck` — no *pending* row older than X (cursor/queue jobs; **no false alarm on a legitimately empty queue**, unlike a naive freshness count).
  - `CallbackCheck` — bespoke signals.
- **`ScheduledOutcomeRegistry`** — the single declarative place, wiring 4 verified checks:

  | Task | Primitive | Signal |
  |---|---|---|
  | `stats:generate-daily` | ProducedSince | `stats.date >= yesterday` (London), active 06–24 |
  | `mail:digest:unified --mode=daily` | ProducedSince | `users_digests.lastsent` today, **gated** on `daily_allowlist` |
  | `queue:background-tasks` | Backlog | pending tasks older than 10 min |
  | `spam:refresh-mobile-cidrs` | Freshness | `spam_whitelist_ips.date` <= 40 days |

- **`monitor:scheduled-outcomes`** — evaluates the registry, escalates breaches to Sentry (guarded `\Sentry\captureMessage`, mirroring `EmailHealthCommand`) + `Log::warning`, exits non-zero. `--only` filter; `FREEGLE_MONITORING_ENABLED` kill-switch. Scheduled every 10 min and itself `sentryMonitor`-heartbeated.
- **Config** (`config/freegle.php` `monitoring` block) + **`.env.example`** knobs.
- **`docs/scheduled-outcome-monitoring.md`** — categorises **all ~100 scheduled tasks** (implemented / already-covered by `monitor:email-health` & the heartbeat / deferred-with-recommended-primitive / **not-worth-monitoring, with reasons** — the cleanup/purge/in-place-update jobs where zero output is the healthy case).

## Testing

- New tests: the four primitives + base gating, command orchestration, and a registry **smoke test that evaluates every check against the real migrated schema** (a wrong table/column fails CI rather than paging on-call).
- Full Laravel suite (worktree status API): **4131 passed, 8348 assertions, 0 failures, 0 errors**.

## Notes

- The brief's prototype assumed `email_tracking.email_type='UnifiedDigestDaily'` (correct), but I keyed the digest check on the cleaner indexed `users_digests.lastsent WHERE mode='daily'` cursor instead — unambiguous and independent of the spool path.
- Additive only; no orb change needed (new files in the existing `Feature` suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)