### PR TITLE
fix(browse): drop phantom empty ad band in centered desktop message modal

### DIFF
--- a/iznik-nuxt3/components/MessageExpanded.vue
+++ b/iznik-nuxt3/components/MessageExpanded.vue
@@ -2139,6 +2139,19 @@ onUnmounted(() => {
       padding-bottom: calc(1rem + $sticky-banner-height-desktop-tall);
     }
   }
+
+  /* In the centered desktop modal (xl+, where b-modal is NOT fullscreen) the
+     dialog floats with margin around it and the fixed sticky ad sits on the
+     page below it - they don't overlap, so reserving a full ad-height of
+     clearance just leaves a large empty band inside the modal that reads as a
+     second, blank ad slot. Drop it back to normal padding there. The clearance
+     is still needed for the fullscreen modal (lg-down) and the mobile
+     fullscreen-overlay, where the buttons genuinely sit over the fixed ad. */
+  .in-modal &.stickyAdRendered {
+    @media (min-width: 1200px) {
+      padding-bottom: 1rem;
+    }
+  }
 }
 
 .footer-buttons {


### PR DESCRIPTION
## Problem

On `/browse`, opening a message in the **centered desktop modal** (xl+) shows what looks like **two ad slots**: the real sticky footer ad at the bottom of the screen, plus a large empty white band inside the modal above/below the action buttons. At smaller sizes only one ad shows.

That in-modal "ad slot" is **not an ad** — there is no ad component inside `MessageModal`/`MessageExpanded`. It's reserved padding: `.app-footer.stickyAdRendered` adds `padding-bottom: calc(1rem + $sticky-banner-height-desktop-tall)` (~273px on tall desktop) so the action buttons clear the fixed sticky ad.

That clearance is genuinely needed for the **fullscreen** modal (`lg-down`) and the **mobile fullscreen-overlay**, where the buttons sit flush against the bottom of the viewport over the fixed ad. But in the centered `xl+` `b-modal` the dialog floats with margin around it and the sticky ad sits on the page *below* it — they don't overlap — so the reserved space is just dead white space that reads as a second, blank ad slot.

## Fix

Scope the clearance so it's dropped back to normal padding in the centered desktop modal only:

```scss
.in-modal &.stickyAdRendered {
  @media (min-width: 1200px) {   /* xl+ = b-modal is NOT fullscreen */
    padding-bottom: 1rem;
  }
}
```

- `lg-down` (fullscreen modal) and the mobile fullscreen-overlay keep the full clearance.
- No new SCSS variables, so no risk of the "undefined var breaks page load" failure.
- Higher specificity than the original rule, so it wins the cascade where both media queries match.

## Verification

- `eslint`/SCSS compiles cleanly in the dev container (only pre-existing Bootstrap `red()/green()` deprecation warnings).
- Please confirm visually on the Netlify deploy preview: open a message on `/browse` at desktop width — the empty band below the buttons should be gone, leaving the single sticky footer ad. Mobile/overlay and the narrower fullscreen modal should be unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)