### PR TITLE
fix(tn): scrape TN photos synchronously before the edit change signal

### DIFF
--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -138,9 +138,14 @@ func extractTNImageURLsFromPage(pageURL string) []string {
 	return found
 }
 
-// TNPhotoScrapeRunner launches TN photo scraping.  Swappable in tests to run synchronously.
+// TNPhotoScrapeRunner scrapes TN photos and stores them as attachments.  It runs
+// SYNCHRONOUSLY so the photos are fully in place before the caller writes the edit's
+// change signal (the messages_edits row).  TN polls /api/changes — which reports a
+// message as "Edited" via messages_edits — and then fetches the message to read its
+// attachments; if the signal were visible before the photos landed, TN would get a
+// partial photo set.  Swappable in tests.
 var TNPhotoScrapeRunner = func(db *gorm.DB, msgID uint64, picPageURLs []string) {
-	go scrapeTNPhotosToAttachments(db, msgID, picPageURLs)
+	scrapeTNPhotosToAttachments(db, msgID, picPageURLs)
 }
 
 // scrapeTNPhotosToAttachments downloads TN images from pic-page URLs and inserts
@@ -3039,15 +3044,18 @@ func PatchMessageByTN(c *fiber.Ctx) error {
 			}
 		}
 
-		if err := applyPatchMessageCore(c, myid, req); err != nil {
-			return err
-		}
-
-		// TN's textbody is the authoritative photo set for its posts.  Whenever TN
-		// sends a textbody (even an empty one) we delete ALL existing attachments and
-		// then let the scraper add the new set (if pic links were present).
+		// Attachments must reach their final state BEFORE the edit's change signal is
+		// written.  applyPatchMessageCore writes the messages_edits row that /api/changes
+		// reports as "Edited"; TN then fetches the message to read its attachments.  If we
+		// scraped after the signal (or asynchronously), TN could poll in the gap and get a
+		// partial photo set — the "only 1 photo back, all of them on a forced re-fetch" bug.
+		// So we delete the old attachments and synchronously scrape the new ones first, then
+		// call the core.  This matches V1, which scrapes + saves attachments before edit()
+		// (http/api/message.php).
 		//
-		// This fixes two bugs:
+		// TN's textbody is the authoritative photo set for its posts.  Whenever TN sends a
+		// textbody (even an empty one) we delete ALL existing attachments and then let the
+		// scraper add the new set (if pic links were present).  This fixes two further bugs:
 		//   #2 — textbody with no pic links: old non-AI photos were left behind.
 		//   #3 — textbody with new pic links: old non-AI photos coexisted with the new ones.
 		//
@@ -3058,9 +3066,13 @@ func PatchMessageByTN(c *fiber.Ctx) error {
 			db.Exec("DELETE FROM messages_attachments WHERE msgid = ?", msgID)
 		}
 
-		// If TN photos were present, scrape them and store as attachments.
+		// If TN photos were present, scrape them and store as attachments (synchronously).
 		if len(picPageURLs) > 0 {
 			TNPhotoScrapeRunner(db, msgID, picPageURLs)
+		}
+
+		if err := applyPatchMessageCore(c, myid, req); err != nil {
+			return err
 		}
 	}
 	return c.JSON(fiber.Map{"ret": 0, "status": "Success"})

--- a/iznik-server-go/test/message_test.go
+++ b/iznik-server-go/test/message_test.go
@@ -8674,6 +8674,105 @@ func TestPatchMessageByTnPostid_RemovesAIAndScrapesTNPhotosWhenLinksPresent(t *t
 	db.Exec("DELETE FROM messages_attachments WHERE msgid = ?", msgID)
 }
 
+// TestPatchMessageByTN_ChangeSignalNotWrittenUntilPhotosScraped verifies the fix for the
+// TN multi-photo race.  TN polls /api/changes, which reports a message as "Edited" based
+// on the existence of a messages_edits row.  TN then fetches the full message to read its
+// attachments.  If the messages_edits row (the change signal) is written BEFORE the TN
+// photos have been scraped into messages_attachments, TN can fetch in the gap and get a
+// partial photo set — the reported "only 1 photo back, all of them on a forced re-fetch" bug.
+//
+// The fix scrapes TN photos SYNCHRONOUSLY and BEFORE applyPatchMessageCore (which writes
+// messages_edits), matching V1 (http/api/message.php scrapes + saves attachments before
+// calling Message::edit()).  So the change signal only becomes visible once every photo is in.
+//
+// This test deliberately does NOT swap TNPhotoScrapeRunner: it exercises the real production
+// runner, so an asynchronous or wrong-order implementation fails it.
+func TestPatchMessageByTN_ChangeSignalNotWrittenUntilPhotosScraped(t *testing.T) {
+	prefix := uniquePrefix("patchtn_signalorder")
+	db := database.DBConn
+
+	groupID := CreateTestGroup(t, prefix)
+	ownerID := CreateTestUser(t, prefix+"_owner", "User")
+	CreateTestMembership(t, ownerID, groupID, "Member")
+	db.Exec("UPDATE users SET tnuserid = ? WHERE id = ?", 77804, ownerID)
+
+	msgID := CreateTestMessage(t, ownerID, groupID, prefix+" Offer", 55.9533, -3.1883)
+	tnpostid := fmt.Sprintf("tn-signalorder-%d", msgID)
+	db.Exec("UPDATE messages SET tnpostid = ? WHERE id = ?", tnpostid, msgID)
+
+	// Set up a clean slate for the change signal and attachments we assert on.
+	db.Exec("DELETE FROM messages_edits WHERE msgid = ?", msgID)
+	db.Exec("DELETE FROM messages_attachments WHERE msgid = ?", msgID)
+
+	key := insertTestPartnerKeyMsg(t, prefix, "tn.com")
+	defer db.Exec("DELETE FROM partners_keys WHERE partner = ?", prefix+"_partner")
+
+	// Fake the TN fetch chain so no real HTTP happens.
+	fakeImageURL := "https://img.trashnothing.com/fake/signalorder.jpg"
+	origFetcher := message.TNPageFetcher
+	message.TNPageFetcher = func(pageURL string) []string { return []string{fakeImageURL} }
+	defer func() { message.TNPageFetcher = origFetcher }()
+
+	origImageFetcher := message.TNImageFetcher
+	message.TNImageFetcher = func(imageURL string) ([]byte, string, error) {
+		return []byte("fake-image-data"), "image/jpeg", nil
+	}
+	defer func() { message.TNImageFetcher = origImageFetcher }()
+
+	// The uploader runs at the moment a photo is about to be stored.  Capture how many
+	// messages_edits rows (the /api/changes signal) exist AT THAT MOMENT.  With the fix
+	// this must be 0: the signal is only written after every photo is in.
+	fakeExternalUID := fmt.Sprintf("freegletusd-tn-signalorder-%d", msgID)
+	editsAtUploadTime := int64(-1)
+	uploaded := make(chan struct{}, 1)
+	origUploader := aiimage.ImageUploader
+	aiimage.ImageUploader = func(data []byte, mime string) (string, error) {
+		db.Raw("SELECT COUNT(*) FROM messages_edits WHERE msgid = ?", msgID).Scan(&editsAtUploadTime)
+		select {
+		case uploaded <- struct{}{}:
+		default:
+		}
+		return fakeExternalUID, nil
+	}
+	defer func() { aiimage.ImageUploader = origUploader }()
+
+	textbody := "Sofa for collection.\n\nCheck out the pictures at:\nhttps://trashnothing.com/pics/sigorder1\n"
+	bodyBytes, _ := json.Marshal(map[string]interface{}{"textbody": textbody})
+	reqURL := fmt.Sprintf("/api/message/tn/%s?partner=%s&tnuserid=77804&email=%s@tn.com", tnpostid, key, prefix+"_owner")
+	req := httptest.NewRequest("PATCH", reqURL, bytes.NewBuffer(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := getApp().Test(req, -1)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	// Wait for the upload to have happened (covers a still-asynchronous implementation).
+	// The channel receive synchronises with the uploader goroutine, so the subsequent read
+	// of editsAtUploadTime is race-free.
+	select {
+	case <-uploaded:
+	case <-time.After(10 * time.Second):
+		t.Fatal("TN photo was never uploaded/scraped")
+	}
+
+	// Core assertion: the change signal must NOT have existed while the photo was being stored.
+	assert.Equal(t, int64(0), editsAtUploadTime,
+		"messages_edits (the /api/changes signal) must not be written until all TN photos are scraped — otherwise TN can fetch a partial photo set")
+
+	// After the handler completes, both the photo and the change signal must exist.
+	var tnCount int64
+	db.Raw("SELECT COUNT(*) FROM messages_attachments WHERE msgid = ? AND externaluid = ?", msgID, fakeExternalUID).Scan(&tnCount)
+	assert.Equal(t, int64(1), tnCount, "scraped TN photo should be stored as attachment")
+
+	var editsCount int64
+	db.Raw("SELECT COUNT(*) FROM messages_edits WHERE msgid = ?", msgID).Scan(&editsCount)
+	assert.True(t, editsCount >= 1, "an edit (change signal) should be recorded after the photos are in")
+
+	// Cleanup.
+	db.Exec("DELETE FROM messages_edits WHERE msgid = ?", msgID)
+	db.Exec("DELETE FROM messages_attachments WHERE msgid = ?", msgID)
+	db.Exec("DELETE FROM messages_ai_declined WHERE msgid = ?", msgID)
+}
+
 // TestPatchMessageByTnPostid_NonAIAttachmentRemovedOnTextEdit verifies that when a
 // TN user edits a post by sending a textbody (even with no pic links), ALL existing
 // attachments — including non-AI ones — are deleted.  TN's textbody is the authoritative

--- a/status/server.js
+++ b/status/server.js
@@ -22,6 +22,22 @@ function getDockerComposeCommand() {
 const DOCKER_COMPOSE = getDockerComposeCommand();
 console.log(`Using docker compose command: ${DOCKER_COMPOSE}`);
 
+// Container names are prefixed by the compose project name, which differs per instance:
+// "freegle" for the main checkout, "freegle-<name>" for each worktree.  Test runners MUST
+// address this project's own containers (and therefore its own database), not hardcoded
+// "freegle-*" names — otherwise a worktree's test run escapes into the main instance's
+// containers and database.  These resolve to the existing "freegle-*" names on the main
+// checkout, so behaviour there is unchanged.
+const PROJECT = process.env.COMPOSE_PROJECT_NAME || "freegle";
+const APIV1 = `${PROJECT}-apiv1`;
+const APIV2 = `${PROJECT}-apiv2`;
+const APIV1_PHPUNIT = `${PROJECT}-apiv1-phpunit`;
+const BATCH = `${PROJECT}-batch`;
+const PLAYWRIGHT = `${PROJECT}-playwright`;
+const PROD_LOCAL = `${PROJECT}-prod-local`;
+const PERCONA = `${PROJECT}-percona`;
+console.log(`Using container prefix: ${PROJECT}`);
+
 // Status cache for all services
 const statusCache = new Map();
 let lastFullCheck = 0;
@@ -845,7 +861,7 @@ async function runPlaywrightTests(testFile = null, testName = null) {
     try {
       const { execSync } = require("child_process");
       execSync(
-        'docker exec freegle-playwright sh -c "rm -f /app/test-results/test-progress.json /app/playwright-results.json"',
+        `docker exec ${PLAYWRIGHT} sh -c "rm -f /app/test-results/test-progress.json /app/playwright-results.json"`,
         { timeout: 5000 }
       );
       console.log("Cleared stale progress files");
@@ -858,7 +874,7 @@ async function runPlaywrightTests(testFile = null, testName = null) {
 
     // Check that the required containers are running
     const freegleProdCheck = execSync(
-      'docker ps --filter "name=freegle-prod-local" --format "{{.Status}}"',
+      `docker ps --filter "name=${PROD_LOCAL}" --format "{{.Status}}"`,
       {
         encoding: "utf8",
         timeout: 5000,
@@ -878,7 +894,7 @@ async function runPlaywrightTests(testFile = null, testName = null) {
       "Restarting Playwright container to kill existing processes\n";
 
     try {
-      execSync("docker restart freegle-playwright", {
+      execSync(`docker restart ${PLAYWRIGHT}`, {
         encoding: "utf8",
         timeout: 30000,
       });
@@ -896,9 +912,9 @@ async function runPlaywrightTests(testFile = null, testName = null) {
     testStatus.logs += "Setting up test environment (FreeglePlayground group, test users)...\n";
 
     try {
-      // Use freegle-apiv1 (not phpunit container) since Playwright tests run against the main iznik database
+      // Use apiv1 (not phpunit container) since Playwright tests run against the main iznik database
       execSync(
-        'docker exec freegle-apiv1 sh -c "cd /var/www/iznik && php install/testenv.php"',
+        `docker exec ${APIV1} sh -c "cd /var/www/iznik && php install/testenv.php"`,
         {
           encoding: "utf8",
           timeout: 60000,
@@ -937,7 +953,7 @@ async function runPlaywrightTests(testFile = null, testName = null) {
         try {
           // Run curl from Playwright container which has host network access
           const curlResult = execSync(
-            `docker exec freegle-playwright curl -s -o /dev/null -w "%{http_code}" --max-time 10 "${route.url}"`,
+            `docker exec ${PLAYWRIGHT} curl -s -o /dev/null -w "%{http_code}" --max-time 10 "${route.url}"`,
             { encoding: 'utf8', timeout: 15000 }
           ).trim();
 
@@ -996,7 +1012,7 @@ async function runPlaywrightTests(testFile = null, testName = null) {
     }
     // Enable coverage reporter for CI builds
     // Set NODE_PATH to find globally installed @playwright/test module
-    const testCommand = `docker exec freegle-playwright sh -c "
+    const testCommand = `docker exec ${PLAYWRIGHT} sh -c "
       cd /app &&
       export ENABLE_MONOCART_REPORTER=true &&
       export NODE_PATH=/usr/lib/node_modules &&
@@ -1248,7 +1264,7 @@ async function runPlaywrightTests(testFile = null, testName = null) {
         try {
           const { execSync } = require("child_process");
           const progressOutput = execSync(
-            'docker exec freegle-playwright cat /app/test-results/test-progress.json 2>/dev/null || echo "{}"',
+            `docker exec ${PLAYWRIGHT} cat /app/test-results/test-progress.json 2>/dev/null || echo "{}"`,
             { encoding: "utf8", timeout: 5000 }
           );
           const progress = JSON.parse(progressOutput.trim() || "{}");
@@ -1355,9 +1371,9 @@ async function runPlaywrightTests(testFile = null, testName = null) {
         try {
           const copyCommands = [
             // Copy coverage directory if it exists in mounted location
-            'docker exec freegle-playwright sh -c "if [ -d /host-playwright-config/coverage ] && [ "$(ls -A /host-playwright-config/coverage 2>/dev/null)" ]; then cp -r /host-playwright-config/coverage/* /app/coverage/; fi"',
+            `docker exec ${PLAYWRIGHT} sh -c "if [ -d /host-playwright-config/coverage ] && [ "$(ls -A /host-playwright-config/coverage 2>/dev/null)" ]; then cp -r /host-playwright-config/coverage/* /app/coverage/; fi"`,
             // Copy monocart-report if it exists in mounted location
-            'docker exec freegle-playwright sh -c "if [ -d /host-playwright-config/monocart-report ] && [ "$(ls -A /host-playwright-config/monocart-report 2>/dev/null)" ]; then cp -r /host-playwright-config/monocart-report/* /app/monocart-report/; fi"',
+            `docker exec ${PLAYWRIGHT} sh -c "if [ -d /host-playwright-config/monocart-report ] && [ "$(ls -A /host-playwright-config/monocart-report 2>/dev/null)" ]; then cp -r /host-playwright-config/monocart-report/* /app/monocart-report/; fi"`,
           ];
 
           for (const command of copyCommands) {
@@ -1374,7 +1390,7 @@ async function runPlaywrightTests(testFile = null, testName = null) {
         let coverageGenerated = false;
         try {
           const coverageCheckCommand =
-            'docker exec freegle-playwright sh -c "test -f /app/monocart-report/coverage/lcov.info && echo exists"';
+            `docker exec ${PLAYWRIGHT} sh -c "test -f /app/monocart-report/coverage/lcov.info && echo exists"`;
           const coverageResult = execSync(coverageCheckCommand, {
             encoding: "utf8",
             timeout: 5000,
@@ -1422,7 +1438,7 @@ async function runPlaywrightTests(testFile = null, testName = null) {
       try {
         console.log("Starting Playwright report server...");
         const reportServerCommand =
-          'docker exec -d freegle-playwright sh -c "cd /app && nohup npx playwright show-report --host=0.0.0.0 --port=9323 > /tmp/report-server.log 2>&1 &"';
+          `docker exec -d ${PLAYWRIGHT} sh -c "cd /app && nohup npx playwright show-report --host=0.0.0.0 --port=9323 > /tmp/report-server.log 2>&1 &"`;
         execSync(reportServerCommand);
         console.log(
           "Playwright report server started successfully on port 9323"
@@ -1643,7 +1659,7 @@ const httpServer = http.createServer(async (req, res) => {
       // Delete existing test users first to ensure clean recreate
       try {
         execSync(
-          "docker exec freegle-percona mysql -u root -piznik iznik -e \"DELETE FROM users WHERE id IN (SELECT userid FROM (SELECT userid FROM users_emails WHERE email IN ('test@test.com', 'testmod@test.com')) AS subquery)\"",
+          `docker exec ${PERCONA} mysql -u root -piznik iznik -e "DELETE FROM users WHERE id IN (SELECT userid FROM (SELECT userid FROM users_emails WHERE email IN ('test@test.com', 'testmod@test.com')) AS subquery)"`,
           { encoding: "utf8", timeout: 10000 }
         );
         results.push("Deleted existing test users");
@@ -1656,7 +1672,7 @@ const httpServer = http.createServer(async (req, res) => {
       // Recreate test@test.com
       try {
         const testUserResult = execSync(
-          'docker exec freegle-apiv1 php /var/www/iznik/scripts/cli/user_create.php -e test@test.com -n "Test User" -p freegle',
+          `docker exec ${APIV1} php /var/www/iznik/scripts/cli/user_create.php -e test@test.com -n "Test User" -p freegle`,
           { encoding: "utf8", timeout: 30000 }
         );
         results.push(`test@test.com: ${testUserResult.trim()}`);
@@ -1667,7 +1683,7 @@ const httpServer = http.createServer(async (req, res) => {
       // Recreate testmod@test.com
       try {
         const modUserResult = execSync(
-          'docker exec freegle-apiv1 php /var/www/iznik/scripts/cli/user_create.php -e testmod@test.com -n "Test Mod" -p freegle',
+          `docker exec ${APIV1} php /var/www/iznik/scripts/cli/user_create.php -e testmod@test.com -n "Test Mod" -p freegle`,
           { encoding: "utf8", timeout: 30000 }
         );
         results.push(`testmod@test.com: ${modUserResult.trim()}`);
@@ -1848,14 +1864,14 @@ const httpServer = http.createServer(async (req, res) => {
 
         # Copy schema from main iznik database (which batch container has already migrated)
         # This ensures Go tests have the exact same schema as production
-        docker exec freegle-apiv1 sh -c "\\
+        docker exec ${APIV1} sh -c "\\
           mysql -h percona -u root -piznik -e 'DROP DATABASE IF EXISTS iznik_go_test; CREATE DATABASE iznik_go_test;' && \\
           mysqldump -h percona -u root -piznik --no-data --routines --triggers iznik | mysql -h percona -u root -piznik iznik_go_test && \\
           mysql -h percona -u root -piznik -e \\"SET GLOBAL sql_mode = 'NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION'\\" && \\
           mysql -h percona -u root -piznik -e \\"SET GLOBAL sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''));\\"" || echo "Warning: Database setup had issues, continuing..."
 
         echo "Running Go tests against iznik_go_test database..."
-        docker exec -w /app freegle-apiv2 sh -c "${testCmd} 2>&1"
+        docker exec -w /app ${APIV2} sh -c "${testCmd} 2>&1"
       `,
       ],
       { stdio: "pipe" }
@@ -1972,7 +1988,7 @@ const httpServer = http.createServer(async (req, res) => {
 
       // Build the phpunit command - skip coverage when filtering for speed
       const coverageFlag = filter ? "" : " --coverage-clover=/tmp/laravel-coverage.xml";
-      const phpunitCmd = `docker exec -e VIA_STATUS_CONTAINER=1 freegle-batch vendor/bin/phpunit --testsuite=Unit,Feature${filter}${coverageFlag} 2>&1`;
+      const phpunitCmd = `docker exec -e VIA_STATUS_CONTAINER=1 ${BATCH} vendor/bin/phpunit --testsuite=Unit,Feature${filter}${coverageFlag} 2>&1`;
 
       // Run tests asynchronously
       const { spawn } = require("child_process");
@@ -1988,12 +2004,12 @@ const httpServer = http.createServer(async (req, res) => {
           # In CI, supervisor isn't running (CI=true skips it in entrypoint.sh).
           # In local dev, this stops background workers to prevent interference.
           echo "Stopping supervisor workers..."
-          docker exec freegle-batch supervisorctl stop all 2>&1 || true
+          docker exec ${BATCH} supervisorctl stop all 2>&1 || true
 
           # Set up fresh test database
           echo "Setting up fresh test database..."
-          docker exec freegle-batch mysql -h percona -u root -piznik --skip-ssl -e "CREATE DATABASE IF NOT EXISTS iznik_batch_test" 2>&1
-          docker exec -e DB_DATABASE=iznik_batch_test freegle-batch php artisan migrate:fresh --database=mysql --force 2>&1
+          docker exec ${BATCH} mysql -h percona -u root -piznik --skip-ssl -e "CREATE DATABASE IF NOT EXISTS iznik_batch_test" 2>&1
+          docker exec -e DB_DATABASE=iznik_batch_test ${BATCH} php artisan migrate:fresh --database=mysql --force 2>&1
 
           echo "Running Laravel tests${filter ? ' (filtered)' : ' with coverage'}..."
           ${phpunitCmd}
@@ -2084,7 +2100,7 @@ const httpServer = http.createServer(async (req, res) => {
       // Collect the inotify monitoring log for artifacts
       try {
         const inotifyLog = execSync(
-          "docker exec freegle-batch cat /tmp/bootstrap-cache-monitor.log 2>/dev/null || echo 'No inotify events recorded'",
+          `docker exec ${BATCH} cat /tmp/bootstrap-cache-monitor.log 2>/dev/null || echo 'No inotify events recorded'`,
           { encoding: "utf8", timeout: 10000 }
         );
         const inotifyArtifactPath = "/tmp/laravel-bootstrap-cache-monitor.log";
@@ -2106,7 +2122,7 @@ const httpServer = http.createServer(async (req, res) => {
 
       // Restart supervisor workers that were stopped before tests
       try {
-        execSync("docker exec freegle-batch supervisorctl start all 2>&1 || true", {
+        execSync(`docker exec ${BATCH} supervisorctl start all 2>&1 || true`, {
           encoding: "utf8",
           timeout: 30000,
         });
@@ -2182,12 +2198,12 @@ const httpServer = http.createServer(async (req, res) => {
 
         // Start and wait for the apiv1-phpunit container to be healthy
         testStatus.message = "Starting PHPUnit test container...";
-        testStatus.logs += "Starting freegle-apiv1-phpunit container...\n";
+        testStatus.logs += `Starting ${APIV1_PHPUNIT} container...\n`;
 
         try {
           // Start the container if it's stopped (container must be created by docker-compose first)
           // We use 'docker start' because docker-compose from inside the container has path issues
-          execSync("docker start freegle-apiv1-phpunit", {
+          execSync(`docker start ${APIV1_PHPUNIT}`, {
             encoding: "utf8",
             timeout: 60000,
           });
@@ -2202,7 +2218,7 @@ const httpServer = http.createServer(async (req, res) => {
           while (Date.now() - containerStartTime < maxWait) {
             try {
               const health = execSync(
-                'docker inspect --format="{{.State.Health.Status}}" freegle-apiv1-phpunit 2>/dev/null || echo "unknown"',
+                `docker inspect --format="{{.State.Health.Status}}" ${APIV1_PHPUNIT} 2>/dev/null || echo "unknown"`,
                 { encoding: "utf8" }
               ).trim();
 
@@ -2242,7 +2258,7 @@ const httpServer = http.createServer(async (req, res) => {
 
         try {
           execSync(
-            'docker exec freegle-apiv1-phpunit sh -c "cd /var/www/iznik && php install/testenv.php"',
+            `docker exec ${APIV1_PHPUNIT} sh -c "cd /var/www/iznik && php install/testenv.php"`,
             {
               encoding: "utf8",
               timeout: 60000,
@@ -2261,7 +2277,7 @@ const httpServer = http.createServer(async (req, res) => {
 
         // First, clear the output file
         execSync(
-          `docker exec freegle-apiv1-phpunit sh -c "rm -f ${outputFile} && touch ${outputFile}"`
+          `docker exec ${APIV1_PHPUNIT} sh -c "rm -f ${outputFile} && touch ${outputFile}"`
         );
 
         // Don't try to pre-count tests - TeamCity output will give us the correct count
@@ -2282,7 +2298,7 @@ const httpServer = http.createServer(async (req, res) => {
           [
             "-c",
             `
-          docker exec -w /var/www/iznik freegle-apiv1-phpunit sh -c "
+          docker exec -w /var/www/iznik ${APIV1_PHPUNIT} sh -c "
             echo 'Setting up test environment...' | tee ${outputFile} && \\
             php install/testenv.php 2>&1 | tee -a ${outputFile} || echo 'Warning: testenv.php failed but continuing...' | tee -a ${outputFile}; \\
             echo 'Running PHPUnit tests via wrapper script...' | tee -a ${outputFile} && \\
@@ -2307,7 +2323,7 @@ const httpServer = http.createServer(async (req, res) => {
             // This ensures we don't miss tests that run faster than our polling interval
             try {
               const markerCount = execSync(
-                `docker exec freegle-apiv1-phpunit sh -c "grep -c '##PHPUNIT_TEST_STARTED##' ${outputFile} 2>/dev/null || echo '0'"`,
+                `docker exec ${APIV1_PHPUNIT} sh -c "grep -c '##PHPUNIT_TEST_STARTED##' ${outputFile} 2>/dev/null || echo '0'"`,
                 { encoding: "utf8" }
               ).trim();
               const count = parseInt(markerCount) || 0;
@@ -2320,7 +2336,7 @@ const httpServer = http.createServer(async (req, res) => {
 
             // Get the last few lines for status message and other info
             const lastLines = execSync(
-              `docker exec freegle-apiv1-phpunit sh -c "tail -n 10 ${outputFile} 2>/dev/null || echo ''"`,
+              `docker exec ${APIV1_PHPUNIT} sh -c "tail -n 10 ${outputFile} 2>/dev/null || echo ''"`,
               { encoding: "utf8" }
             ).trim();
             if (lastLines) {
@@ -2456,7 +2472,7 @@ const httpServer = http.createServer(async (req, res) => {
           // Get final output
           try {
             const finalOutput = execSync(
-              `docker exec freegle-apiv1-phpunit sh -c "cat ${outputFile} 2>/dev/null || echo ''"`,
+              `docker exec ${APIV1_PHPUNIT} sh -c "cat ${outputFile} 2>/dev/null || echo ''"`,
               { encoding: "utf8", maxBuffer: 50 * 1024 * 1024 }
             ); // 50MB buffer
             testStatus.logs = finalOutput;
@@ -3039,7 +3055,7 @@ const httpServer = http.createServer(async (req, res) => {
     if (!devServerHost) {
       try {
         const ips = execSync(
-          'docker exec freegle-playwright hostname -I 2>/dev/null',
+          `docker exec ${PLAYWRIGHT} hostname -I 2>/dev/null`,
           { encoding: 'utf8', timeout: 3000 }
         ).trim().split(' ');
 


### PR DESCRIPTION
## Problem

When TrashNothing (TN) edits a post and adds multiple photos, TN's later poll of the FD `/api/changes` feed sometimes returns the message with only **1 photo**; a forced re-fetch returns all of them.

### Root cause (race)

TN's edit lands at `PatchMessageByTN`. The old ordering was:

1. `applyPatchMessageCore` — writes the `messages_edits` row. This *is* the change signal: `/api/changes` reports a message as `Edited` when a `messages_edits` row exists for it (`changes/changes.go`).
2. delete old attachments
3. `TNPhotoScrapeRunner` — a **detached goroutine** (`go scrapeTNPhotosToAttachments`) that downloads each TN image, uploads it to TUS, and inserts the `messages_attachments` rows one at a time.

So the change signal was committed **before** any photo was scraped. TN's changes-poller is an independent process; if it polled in the window between step 1 and the goroutine finishing, it saw the message as `Edited` and fetched it while only the first (or no) `messages_attachments` row existed — a partial photo set. A later re-fetch, once the goroutine completed, returned all photos. That's exactly the reported symptom.

## Fix

Run the scrape **synchronously** and move it (with the attachment cleanup) **ahead of** `applyPatchMessageCore`, so the `messages_edits` change signal is only written once every photo is stored. This matches V1, which scrapes + saves attachments before `Message::edit()` (`http/api/message.php`).

- `iznik-server-go/message/message.go`: `TNPhotoScrapeRunner` no longer detaches a goroutine; the delete+scrape now run before the core in `PatchMessageByTN`.

### Test (TDD)

`TestPatchMessageByTN_ChangeSignalNotWrittenUntilPhotosScraped` hooks the image uploader and asserts that **no `messages_edits` row exists while a photo is still uploading**, and that both the photo and the signal exist afterwards. It deliberately does *not* swap the scrape runner, so it exercises the real production path.

- Red (old code): `messages_edits (the /api/changes signal) must not be written until all TN photos are scraped` — `expected: 0, actual: 1`.
- Green (fix): passes. Full Go suite: **3135 passed, 0 failed** (red run was 3134 passed / 1 failed = this test).

## Also: worktree test-runner isolation fix

While validating, I found the status server (`status/server.js`) hardcoded container names (`freegle-apiv2`, `freegle-apiv1`, `freegle-apiv1-phpunit`, `freegle-batch`, `freegle-playwright`, `freegle-prod-local`, `freegle-percona`) in its **test-runner** exec/start/inspect calls. In a worktree the real containers are prefixed (`freegle-<name>-apiv2`), so a worktree's `/api/tests/{go,laravel,php,playwright}` ran inside the **main** instance's containers and against the **main** database — testing the wrong code and breaching worktree isolation.

- Container names are now derived from `COMPOSE_PROJECT_NAME` (defaults to `freegle`, so the **main checkout and CI are unchanged**).
- Scope: test-runner exec paths only. The health-check *display* / connectivity references still use hardcoded names (cascading UI lookups) — left for a follow-up; test execution is now correctly isolated.

This fix is what let me validate the Go change end-to-end against the worktree's own apiv2 + database.

## Validation

Go suite run via the worktree's own status API (now correctly targeting the worktree containers): **3135 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)