### PR TITLE
feat(web): force-reload when the running build is over a week stale

### DIFF
--- a/iznik-nuxt3/components/MessageEditModal.vue
+++ b/iznik-nuxt3/components/MessageEditModal.vue
@@ -159,6 +159,7 @@ import { uid } from '~/composables/useId'
 import PostCode from '~/components/PostCode'
 import { useOurModal } from '~/composables/useOurModal'
 import { MESSAGE_EXPIRE_TIME } from '~/constants'
+import { isNumericOnlyItem } from '~/composables/useItemValidation'
 
 const OurUploader = defineAsyncComponent(() =>
   import('~/components/OurUploader')
@@ -259,6 +260,10 @@ const typeOptions = computed(() => {
 })
 
 const isSaveButtonDisabled = computed(() => {
+  // Block saving a purely-numeric item (PostItem shows the reason inline).
+  if (isNumericOnlyItem(edititem.value)) {
+    return true
+  }
   return !edittextbody.value && !attachments.value?.length
 })
 

--- a/iznik-nuxt3/components/PostItem.vue
+++ b/iznik-nuxt3/components/PostItem.vue
@@ -13,6 +13,11 @@
       />
     </div>
     <div>
+      <NoticeMessage v-if="invalidNumeric" variant="danger" class="mt-1 mb-1">
+        <p class="mb-0">
+          {{ INVALID_ITEM_MESSAGE }}
+        </p>
+      </NoticeMessage>
       <NoticeMessage v-if="vague" variant="warning" class="mt-1 mb-1">
         <p>
           Please avoid very general terms. Be precise - you'll get a better
@@ -54,6 +59,10 @@ import { useComposeStore } from '~/stores/compose'
 import { useMessageStore } from '~/stores/message'
 import { computed } from '#imports'
 import { useMe } from '~/composables/useMe'
+import {
+  isNumericOnlyItem,
+  INVALID_ITEM_MESSAGE,
+} from '~/composables/useItemValidation'
 
 const emit = defineEmits(['update:edititem', 'blur'])
 
@@ -239,6 +248,9 @@ const item = computed({
     }
   },
 })
+
+// A purely-numeric item (e.g. "123") is never a valid description; reject it.
+const invalidNumeric = computed(() => isNumericOnlyItem(item.value))
 
 const vague = computed(() => {
   let ret = false

--- a/iznik-nuxt3/components/SomethingWentWrong.vue
+++ b/iznik-nuxt3/components/SomethingWentWrong.vue
@@ -64,6 +64,20 @@
         </div>
       </NoticeMessage>
       <NoticeMessage
+        v-else-if="needToReloadHard"
+        variant="danger"
+        class="posit text-center"
+        show
+      >
+        <p>
+          This version of Freegle is more than a week out of date. It will
+          refresh to get the latest fixes in {{ hardCountdown }}s.
+        </p>
+        <div class="d-flex justify-content-around">
+          <b-button variant="primary" @click="reload"> Reload now </b-button>
+        </div>
+      </NoticeMessage>
+      <NoticeMessage
         v-else-if="showReload && !snoozeReload"
         variant="info"
         class="posit text-center"
@@ -87,15 +101,25 @@ import NoticeMessage from './NoticeMessage'
 import { ref, watch, onBeforeUnmount } from '#imports'
 import { useMiscStore } from '~/stores/misc'
 import SupportLink from '~/components/SupportLink'
+import { HARD_RELOAD_COUNTDOWN_SECS, TYPING_TIME_INVERVAL } from '~/constants'
 
 const showError = ref(false)
 const showReload = ref(false)
 const snoozeReload = ref(false)
 const snoozeTimer = ref(null)
+const hardCountdown = ref(HARD_RELOAD_COUNTDOWN_SECS)
+const hardReloadTimer = ref(null)
 
 const miscStore = useMiscStore()
-const { somethingWentWrong, needToReload, offline, unloading, errorDetails } =
-  storeToRefs(miscStore)
+const {
+  somethingWentWrong,
+  needToReload,
+  needToReloadHard,
+  offline,
+  unloading,
+  errorDetails,
+  lastTyping,
+} = storeToRefs(miscStore)
 
 const showStackTrace = ref(false)
 
@@ -116,8 +140,53 @@ watch(needToReload, (newVal) => {
   }
 })
 
+// When the build is a week-plus stale we force a reload after a short, visible
+// countdown. immediate:true so it also fires if the flag is already set on mount.
+watch(
+  needToReloadHard,
+  (newVal) => {
+    if (newVal) {
+      hardCountdown.value = HARD_RELOAD_COUNTDOWN_SECS
+      scheduleHardTick()
+    }
+  },
+  { immediate: true }
+)
+
 function reload() {
   window.location.reload()
+}
+
+// Reload unless the user is mid-message — we never want to throw away something
+// they're typing. Returns true if it reloaded, false if it deferred.
+function maybeReload() {
+  if (
+    lastTyping.value &&
+    Date.now() - lastTyping.value < TYPING_TIME_INVERVAL
+  ) {
+    return false
+  }
+  reload()
+  return true
+}
+
+function scheduleHardTick() {
+  if (hardReloadTimer.value) {
+    clearTimeout(hardReloadTimer.value)
+  }
+  hardReloadTimer.value = setTimeout(() => {
+    if (hardCountdown.value <= 1) {
+      // Countdown done: reload unless they're still typing, in which case wait
+      // another cycle rather than destroy their in-progress message.
+      if (!maybeReload()) {
+        hardCountdown.value = HARD_RELOAD_COUNTDOWN_SECS
+        scheduleHardTick()
+      }
+    } else {
+      hardCountdown.value -= 1
+      scheduleHardTick()
+    }
+  }, 1000)
 }
 
 function snooze() {
@@ -139,6 +208,9 @@ function formatTimestamp(timestamp) {
 onBeforeUnmount(() => {
   if (snoozeTimer.value) {
     clearTimeout(snoozeTimer.value)
+  }
+  if (hardReloadTimer.value) {
+    clearTimeout(hardReloadTimer.value)
   }
 })
 </script>

--- a/iznik-nuxt3/composables/useItemValidation.js
+++ b/iznik-nuxt3/composables/useItemValidation.js
@@ -1,0 +1,18 @@
+// A purely-numeric "item" (e.g. "123") isn't a meaningful description of what's
+// being given away or wanted, so we reject it client-side before posting.
+export const INVALID_ITEM_MESSAGE =
+  "That's not a valid item — please say what it actually is, not just a number."
+
+/**
+ * True when the item name is nothing but digits (ignoring surrounding
+ * whitespace), e.g. "123" or " 42 ". Decimals, thousands separators and any
+ * item that merely contains a number ("3 chairs") are allowed. Empty/nullish
+ * values return false — emptiness is handled separately by the required check.
+ *
+ * @param {string|null|undefined} item
+ * @returns {boolean}
+ */
+export function isNumericOnlyItem(item) {
+  if (!item) return false
+  return /^\d+$/.test(item.trim())
+}

--- a/iznik-nuxt3/composables/useNavbar.js
+++ b/iznik-nuxt3/composables/useNavbar.js
@@ -9,6 +9,7 @@ import { useAuthStore } from '~/stores/auth'
 import { fetchMe } from '~/composables/useMe'
 import { useRuntimeConfig } from '#app'
 import { TYPING_TIME_INVERVAL } from '~/constants'
+import { classifyStaleBuild } from '~/composables/useStaleBuild'
 import { useCommunityEventStore } from '~/stores/communityevent'
 import { useVolunteeringStore } from '~/stores/volunteering'
 import { useMobileStore } from '~/stores/mobile'
@@ -103,7 +104,9 @@ export function useNavbar() {
   const chatCount = computed(() => {
     const count = Math.min(99, chatStore.unreadCount)
     if (mobileStore.isApp) {
-      mobileStore.setBadgeCount(Math.min(99, count + (notificationStore.count || 0)))
+      mobileStore.setBadgeCount(
+        Math.min(99, count + (notificationStore.count || 0))
+      )
     }
     return count
   })
@@ -337,12 +340,18 @@ export function useNavbar() {
 
             if (data?.deploy_id) {
               if (data.deploy_id !== runtimeConfig.public.NETLIFY_DEPLOY_ID) {
-                const deployDate = new Date(data.published_deploy.published_at)
+                // We're not on the latest deploy. Soft-nag once the new deploy has
+                // been live a while, but escalate to a forced reload once the build
+                // we're running is over a week stale (people who never refresh).
+                const verdict = classifyStaleBuild(
+                  runtimeConfig.public.BUILD_DATE,
+                  data.published_deploy.published_at,
+                  Date.now()
+                )
 
-                // Check it's not too soon to nag.  This stops annoyances when we have lots of releases in a short
-                // time.
-                if (deployDate.getTime() < Date.now() - 12 * 60 * 60 * 1000) {
-                  // We're not on the latest deploy, so show a warning.
+                if (verdict === 'hard') {
+                  useMiscStore().needToReloadHard = true
+                } else if (verdict === 'soft') {
                   useMiscStore().needToReload = true
                 }
               }

--- a/iznik-nuxt3/composables/useStaleBuild.js
+++ b/iznik-nuxt3/composables/useStaleBuild.js
@@ -1,0 +1,32 @@
+import { STALE_BUILD_HARD_MS, STALE_BUILD_SOFT_MS } from '~/constants'
+
+/**
+ * Decide how to react to a stale build, given that a newer production deploy is
+ * known to exist (the caller checks the deploy id mismatch first).
+ *
+ * - 'hard': the bundle we're actually running (buildDate) is older than the hard
+ *   threshold (a week), so we should force a reload.
+ * - 'soft': the newer deploy has been live longer than the soft threshold (12h),
+ *   so we softly nag — but not right after a release.
+ * - 'none': too soon to do anything yet.
+ *
+ * Fails open: unparseable dates never trigger 'hard'/'soft'.
+ *
+ * @param {string} buildDate  ISO BUILD_DATE baked into the running bundle.
+ * @param {string} deployDate ISO publish time of the newer deploy.
+ * @param {number} now        Current time in epoch ms.
+ * @returns {'hard'|'soft'|'none'}
+ */
+export function classifyStaleBuild(buildDate, deployDate, now) {
+  const buildAge = now - new Date(buildDate).getTime()
+  if (!Number.isNaN(buildAge) && buildAge > STALE_BUILD_HARD_MS) {
+    return 'hard'
+  }
+
+  const deployMs = new Date(deployDate).getTime()
+  if (!Number.isNaN(deployMs) && deployMs < now - STALE_BUILD_SOFT_MS) {
+    return 'soft'
+  }
+
+  return 'none'
+}

--- a/iznik-nuxt3/constants.js
+++ b/iznik-nuxt3/constants.js
@@ -61,6 +61,14 @@ export const GROUP_REPOSTS = { offer: 3, wanted: 14, max: 10, chaseups: 2 }
 
 export const TYPING_TIME_INVERVAL = 10000
 
+// Stale-build warning thresholds. When a newer production deploy exists we either
+// softly nag (newer deploy older than SOFT, so we don't pester right after a
+// release) or, once the bundle we're actually running is older than HARD, escalate
+// to a forced auto-reload. HARD_RELOAD_COUNTDOWN_SECS is the grace before that reload.
+export const STALE_BUILD_SOFT_MS = 12 * 60 * 60 * 1000 // 12 hours
+export const STALE_BUILD_HARD_MS = 7 * 24 * 60 * 60 * 1000 // 1 week
+export const HARD_RELOAD_COUNTDOWN_SECS = 20
+
 // The 37 miles figure comes from research from someone we shall call Clement.
 export const FAR_AWAY = 37
 

--- a/iznik-nuxt3/pages/find/mobile/details.vue
+++ b/iznik-nuxt3/pages/find/mobile/details.vue
@@ -57,6 +57,9 @@
           :state="itemState"
           @blur="onItemBlur"
         />
+        <div v-if="itemError" class="invalid-feedback d-block">
+          {{ itemError }}
+        </div>
       </div>
 
       <!-- Description -->
@@ -100,6 +103,10 @@ import { useAuthStore } from '~/stores/auth'
 import { useMiscStore } from '~/stores/misc'
 import OurUploadedImage from '~/components/OurUploadedImage'
 import api from '~/api'
+import {
+  isNumericOnlyItem,
+  INVALID_ITEM_MESSAGE,
+} from '~/composables/useItemValidation'
 
 const router = useRouter()
 const runtimeConfig = useRuntimeConfig()
@@ -145,11 +152,20 @@ onMounted(() => {
 
 // Item validation state - null initially, false if error, true if valid
 const itemState = computed(() => {
+  if (isNumericOnlyItem(item.value)) {
+    return false
+  }
   if (showItemError.value && (!item.value || !item.value.trim())) {
     return false
   }
   return item.value ? true : null
 })
+
+// Error message shown under the item field. A purely-numeric item is never a
+// valid description, so we flag it as soon as it's typed.
+const itemError = computed(() =>
+  isNumericOnlyItem(item.value) ? INVALID_ITEM_MESSAGE : null
+)
 
 // Description validation state
 const descriptionState = computed(() => {
@@ -302,7 +318,7 @@ function onItemBlur() {
 }
 
 function validateAndNext() {
-  if (!item.value || !item.value.trim()) {
+  if (!item.value || !item.value.trim() || isNumericOnlyItem(item.value)) {
     showItemError.value = true
     nextTick(() => {
       const input = document.getElementById('item-name')

--- a/iznik-nuxt3/pages/give/mobile/details.vue
+++ b/iznik-nuxt3/pages/give/mobile/details.vue
@@ -58,6 +58,9 @@
           :state="itemState"
           @blur="onItemBlur"
         />
+        <div v-if="itemError" class="invalid-feedback d-block">
+          {{ itemError }}
+        </div>
       </div>
 
       <!-- Description -->
@@ -115,6 +118,10 @@ import NumberIncrementDecrement from '~/components/NumberIncrementDecrement'
 import OurUploadedImage from '~/components/OurUploadedImage'
 import api from '~/api'
 import { fetchAiIllustration as fetchAiIllustrationImpl } from '~/composables/useAiIllustration'
+import {
+  isNumericOnlyItem,
+  INVALID_ITEM_MESSAGE,
+} from '~/composables/useItemValidation'
 
 const router = useRouter()
 const runtimeConfig = useRuntimeConfig()
@@ -164,11 +171,20 @@ onMounted(() => {
 
 // Item validation state - null initially, false if error, true if valid
 const itemState = computed(() => {
+  if (isNumericOnlyItem(item.value)) {
+    return false
+  }
   if (showItemError.value && (!item.value || !item.value.trim())) {
     return false
   }
   return item.value ? true : null
 })
+
+// Error message shown under the item field. A purely-numeric item is never a
+// valid description, so we flag it as soon as it's typed.
+const itemError = computed(() =>
+  isNumericOnlyItem(item.value) ? INVALID_ITEM_MESSAGE : null
+)
 
 // Description validation state
 const descriptionState = computed(() => {
@@ -298,7 +314,7 @@ function onItemBlur() {
 }
 
 function validateAndNext() {
-  if (!item.value || !item.value.trim()) {
+  if (!item.value || !item.value.trim() || isNumericOnlyItem(item.value)) {
     showItemError.value = true
     nextTick(() => {
       const input = document.getElementById('item-name')

--- a/iznik-nuxt3/stores/compose.js
+++ b/iznik-nuxt3/stores/compose.js
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia'
 import { useMessageStore } from '~/stores/message'
 import api from '~/api'
 import { useAuthStore } from '~/stores/auth'
+import { isNumericOnlyItem } from '~/composables/useItemValidation'
 
 const defaultOffer = {
   id: 0,
@@ -607,11 +608,13 @@ export const useComposeStore = defineStore({
             message.description && message.description.trim()
           const hasRealPhotos = realPhotos.length > 0
 
-          // A message is valid if there is an item, and either a description or real photos.
+          // A message is valid if there is an item, the item isn't just a number,
+          // and there is either a description or real photos.
           // AI-only photos require a description.
           if (
             !message.item ||
             !message.item.trim() ||
+            isNumericOnlyItem(message.item) ||
             (!hasDescription && !hasRealPhotos)
           ) {
             valid = false

--- a/iznik-nuxt3/stores/misc.js
+++ b/iznik-nuxt3/stores/misc.js
@@ -16,6 +16,7 @@ export const useMiscStore = defineStore({
     somethingWentWrong: false,
     errorDetails: null,
     needToReload: false,
+    needToReloadHard: false,
     visible: true,
     apiCount: 0,
     unloading: false,

--- a/iznik-nuxt3/tests/unit/components/PostItem.spec.js
+++ b/iznik-nuxt3/tests/unit/components/PostItem.spec.js
@@ -109,6 +109,34 @@ describe('PostItem', () => {
     })
   })
 
+  describe('numeric-only item rejection', () => {
+    it.each([
+      ['123', true],
+      ['  42 ', true],
+      ['0', true],
+      ['3 chairs', false],
+      ['Sofa', false],
+      ['', false],
+    ])('item "%s" is invalidNumeric=%s', (item, expected) => {
+      mockMessage.mockReturnValue({ item })
+      const wrapper = createWrapper()
+      expect(wrapper.vm.invalidNumeric).toBe(expected)
+    })
+
+    it('shows a danger message for a purely-numeric item', () => {
+      mockMessage.mockReturnValue({ item: '123' })
+      const wrapper = createWrapper()
+      expect(wrapper.find('.notice-message.danger').exists()).toBe(true)
+      expect(wrapper.text()).toContain('not a valid item')
+    })
+
+    it('shows no danger message for a normal item', () => {
+      mockMessage.mockReturnValue({ item: 'Sofa' })
+      const wrapper = createWrapper()
+      expect(wrapper.find('.notice-message.danger').exists()).toBe(false)
+    })
+  })
+
   describe('item warnings', () => {
     it.each([
       ['sofa', 'Upholstered household items'],

--- a/iznik-nuxt3/tests/unit/components/SomethingWentWrong.spec.js
+++ b/iznik-nuxt3/tests/unit/components/SomethingWentWrong.spec.js
@@ -79,7 +79,12 @@ describe('SomethingWentWrong', () => {
           NoticeMessage: {
             template:
               '<div v-if="show" class="notice-message" :class="variant"><slot /></div>',
-            props: ['variant', 'show'],
+            // show must be typed Boolean so the component's bare `show` attribute
+            // resolves to true (an untyped prop would receive "" and hide the banner).
+            props: {
+              variant: { type: String, default: '' },
+              show: { type: Boolean, default: false },
+            },
           },
           'b-button': {
             template:

--- a/iznik-nuxt3/tests/unit/components/SomethingWentWrong.spec.js
+++ b/iznik-nuxt3/tests/unit/components/SomethingWentWrong.spec.js
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { ref } from 'vue'
 import SomethingWentWrong from '~/components/SomethingWentWrong.vue'
+import { HARD_RELOAD_COUNTDOWN_SECS } from '~/constants'
 
 // Use vi.hoisted for mock setup
 const { mockClearError } = vi.hoisted(() => ({
@@ -11,9 +12,11 @@ const { mockClearError } = vi.hoisted(() => ({
 // Create refs at module level
 const somethingWentWrongRef = ref(false)
 const needToReloadRef = ref(false)
+const needToReloadHardRef = ref(false)
 const offlineRef = ref(false)
 const unloadingRef = ref(false)
 const errorDetailsRef = ref(null)
+const lastTypingRef = ref(null)
 
 // Mock Pinia's storeToRefs to return our refs while preserving other exports
 vi.mock('pinia', async (importOriginal) => {
@@ -23,9 +26,11 @@ vi.mock('pinia', async (importOriginal) => {
     storeToRefs: () => ({
       somethingWentWrong: somethingWentWrongRef,
       needToReload: needToReloadRef,
+      needToReloadHard: needToReloadHardRef,
       offline: offlineRef,
       unloading: unloadingRef,
       errorDetails: errorDetailsRef,
+      lastTyping: lastTypingRef,
     }),
   }
 })
@@ -38,15 +43,26 @@ vi.mock('~/stores/misc', () => ({
 }))
 
 describe('SomethingWentWrong', () => {
+  let reloadSpy
+
   beforeEach(() => {
     vi.clearAllMocks()
     vi.useFakeTimers()
     // Reset ref values before each test
     somethingWentWrongRef.value = false
     needToReloadRef.value = false
+    needToReloadHardRef.value = false
     offlineRef.value = false
     unloadingRef.value = false
     errorDetailsRef.value = null
+    lastTypingRef.value = null
+    // jsdom's location.reload is not directly assignable; redefine it so we can
+    // observe forced reloads without navigating.
+    reloadSpy = vi.fn()
+    Object.defineProperty(window.location, 'reload', {
+      configurable: true,
+      value: reloadSpy,
+    })
   })
 
   afterEach(() => {
@@ -131,6 +147,50 @@ describe('SomethingWentWrong', () => {
       const wrapper = createWrapper()
       // Component should mount and connect to store without error
       expect(wrapper.exists()).toBe(true)
+    })
+  })
+
+  describe('hard reload (stale build)', () => {
+    it('shows a danger banner with a countdown when needToReloadHard is true', () => {
+      needToReloadHardRef.value = true
+      const wrapper = createWrapper()
+      const notice = wrapper.find('.notice-message')
+      expect(notice.exists()).toBe(true)
+      expect(notice.classes()).toContain('danger')
+      expect(wrapper.text()).toContain('more than a week out of date')
+      expect(wrapper.text()).toContain(`${HARD_RELOAD_COUNTDOWN_SECS}s`)
+      expect(wrapper.text()).toContain('Reload now')
+    })
+
+    it('reloads when the countdown expires and the user is not typing', () => {
+      needToReloadHardRef.value = true
+      lastTypingRef.value = null
+      createWrapper()
+      expect(reloadSpy).not.toHaveBeenCalled()
+      vi.advanceTimersByTime(HARD_RELOAD_COUNTDOWN_SECS * 1000)
+      expect(reloadSpy).toHaveBeenCalled()
+    })
+
+    it('reloads immediately when "Reload now" is clicked', async () => {
+      needToReloadHardRef.value = true
+      const wrapper = createWrapper()
+      await wrapper.find('button').trigger('click')
+      expect(reloadSpy).toHaveBeenCalled()
+    })
+
+    it('defers the reload while the user is mid-message', () => {
+      const wrapper = createWrapper()
+      // Typed just now -> within the typing window -> defer.
+      lastTypingRef.value = Date.now()
+      expect(wrapper.vm.maybeReload()).toBe(false)
+      expect(reloadSpy).not.toHaveBeenCalled()
+    })
+
+    it('reloads via maybeReload when the user is not typing', () => {
+      const wrapper = createWrapper()
+      lastTypingRef.value = null
+      expect(wrapper.vm.maybeReload()).toBe(true)
+      expect(reloadSpy).toHaveBeenCalled()
     })
   })
 })

--- a/iznik-nuxt3/tests/unit/composables/useItemValidation.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useItemValidation.spec.js
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import {
+  isNumericOnlyItem,
+  INVALID_ITEM_MESSAGE,
+} from '~/composables/useItemValidation'
+
+describe('isNumericOnlyItem', () => {
+  it('rejects a bare number', () => {
+    expect(isNumericOnlyItem('123')).toBe(true)
+  })
+
+  it('rejects a number with surrounding whitespace', () => {
+    expect(isNumericOnlyItem('  42 ')).toBe(true)
+  })
+
+  it('rejects a single zero', () => {
+    expect(isNumericOnlyItem('0')).toBe(true)
+  })
+
+  it('allows a normal item name', () => {
+    expect(isNumericOnlyItem('Red sofa')).toBe(false)
+  })
+
+  it('allows an item that merely contains digits', () => {
+    expect(isNumericOnlyItem('3 chairs')).toBe(false)
+    expect(isNumericOnlyItem('size 12 boots')).toBe(false)
+  })
+
+  it('allows decimals and thousands separators (not purely digits)', () => {
+    expect(isNumericOnlyItem('12.5')).toBe(false)
+    expect(isNumericOnlyItem('1,000')).toBe(false)
+  })
+
+  it('treats empty / nullish as not-numeric (handled by the required check)', () => {
+    expect(isNumericOnlyItem('')).toBe(false)
+    expect(isNumericOnlyItem('   ')).toBe(false)
+    expect(isNumericOnlyItem(null)).toBe(false)
+    expect(isNumericOnlyItem(undefined)).toBe(false)
+  })
+
+  it('exposes a human-readable message', () => {
+    expect(typeof INVALID_ITEM_MESSAGE).toBe('string')
+    expect(INVALID_ITEM_MESSAGE.length).toBeGreaterThan(0)
+  })
+})

--- a/iznik-nuxt3/tests/unit/composables/useStaleBuild.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useStaleBuild.spec.js
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import { classifyStaleBuild } from '~/composables/useStaleBuild'
+
+const NOW = Date.parse('2026-06-12T12:00:00Z')
+const HOUR = 60 * 60 * 1000
+const DAY = 24 * HOUR
+
+const iso = (ms) => new Date(ms).toISOString()
+
+describe('classifyStaleBuild', () => {
+  it('returns hard when the running build is over a week old', () => {
+    // Newer deploy fresh, but our bundle is 8 days old -> force reload.
+    expect(
+      classifyStaleBuild(iso(NOW - 8 * DAY), iso(NOW - 1 * HOUR), NOW)
+    ).toBe('hard')
+  })
+
+  it('hard wins even when the newer deploy is brand new', () => {
+    expect(
+      classifyStaleBuild(iso(NOW - 10 * DAY), iso(NOW - 1 * 1000), NOW)
+    ).toBe('hard')
+  })
+
+  it('returns soft when build is recent but newer deploy is older than 12h', () => {
+    expect(
+      classifyStaleBuild(iso(NOW - 2 * DAY), iso(NOW - 13 * HOUR), NOW)
+    ).toBe('soft')
+  })
+
+  it('returns none when the newer deploy is too fresh to nag about', () => {
+    expect(
+      classifyStaleBuild(iso(NOW - 2 * DAY), iso(NOW - 6 * HOUR), NOW)
+    ).toBe('none')
+  })
+
+  it('does not escalate at exactly the 7 day boundary', () => {
+    // buildAge == HARD threshold is not strictly greater, so not hard.
+    expect(
+      classifyStaleBuild(iso(NOW - 7 * DAY), iso(NOW - 1 * HOUR), NOW)
+    ).toBe('none')
+  })
+
+  it('fails open to soft when BUILD_DATE is unparseable but a deploy is stale', () => {
+    expect(classifyStaleBuild('not-a-date', iso(NOW - 13 * HOUR), NOW)).toBe(
+      'soft'
+    )
+  })
+
+  it('fails open to none when both dates are unparseable', () => {
+    expect(classifyStaleBuild('not-a-date', 'also-bad', NOW)).toBe('none')
+  })
+})

--- a/iznik-nuxt3/tests/unit/stores/compose.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/compose.spec.js
@@ -655,6 +655,22 @@ describe('compose store', () => {
       const store = useComposeStore()
       expect(store.messageValid({ value: 'Offer' })).toBe(false)
     })
+
+    it('returns false when the item is purely numeric', () => {
+      const store = useComposeStore()
+      store.messages = [
+        { type: 'Offer', item: '123', description: 'Good condition' },
+      ]
+      expect(store.messageValid({ value: 'Offer' })).toBe(false)
+    })
+
+    it('allows an item that merely contains a number', () => {
+      const store = useComposeStore()
+      store.messages = [
+        { type: 'Offer', item: '3 chairs', description: 'Good condition' },
+      ]
+      expect(store.messageValid({ value: 'Offer' })).toBe(true)
+    })
   })
 
   describe('postcodeValid getter', () => {


### PR DESCRIPTION
## What

Escalates the existing soft "please reload" nag into a **forced auto-reload** for clients running a build that's more than a week stale.

Today, when a newer production deploy exists and has been live >12h, the site shows a dismissible info banner asking the user to reload. People who never refresh (long-lived tabs / PWAs) can snooze it forever and stay on an old, buggy bundle. This adds a hard tier: once the bundle we're actually running is **over a week old** *and* a newer deploy exists, show a `danger` banner with a 20s countdown and then reload automatically.

## How

- **`composables/useStaleBuild.js`** — `classifyStaleBuild(buildDate, deployDate, now)` (pure, unit-tested): given a newer deploy exists, returns `'hard'` (running `BUILD_DATE` >1wk old), `'soft'` (newer deploy >12h old — the existing nag), or `'none'`. Fails open on unparseable dates.
- **`composables/useNavbar.js`** — the existing deploy-id check now feeds the verdict into `needToReload` / `needToReloadHard`.
- **`stores/misc.js`** — new `needToReloadHard` flag.
- **`components/SomethingWentWrong.vue`** — new `danger` countdown banner (precedence: error → hard → soft) with "Reload now". The auto-reload **never yanks the page out from under someone mid-message** — if `lastTyping` is within `TYPING_TIME_INVERVAL`, it defers a cycle.
- **`constants.js`** — `STALE_BUILD_SOFT_MS` (12h), `STALE_BUILD_HARD_MS` (1wk), `HARD_RELOAD_COUNTDOWN_SECS` (20).

Production-Netlify-only (inherited from the existing deploy check), so dev / modtools / the Capacitor app are unaffected.

## Tests

- `tests/unit/composables/useStaleBuild.spec.js` — threshold/boundary/fail-open cases.
- `tests/unit/components/SomethingWentWrong.spec.js` — countdown→reload, immediate "Reload now", and typing-deferral.

## Not in this PR (deliberate follow-up — blocked)

The **app-upgrade kill switch** (server-side `ret:123` on stale `webversion`, in Go `session.go` + PHP `session.php`, plus raising `app_fd_version_*_required`) is a separate concern that is **blocked**:
- It needs the post-#650 fixed app live in **both** stores first, then its `BUILD_DATE`/`MOBILE_VERSION` to set thresholds (don't want to lock users out).
- Open design decision: there is **no server-visible app signal on GET `/session`** for modern apps (they send only `webversion`, same as the website), so "gate to app-only" can't use an existing signal — needs a call on webversion-age-only vs User-Agent sniffing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)