### PR TITLE
feat(digest): collapsible "In this digest" summary linking to website posts

### DIFF
--- a/iznik-batch/app/Mail/Digest/DigestStyle.php
+++ b/iznik-batch/app/Mail/Digest/DigestStyle.php
@@ -24,4 +24,15 @@ class DigestStyle
 
     /** Accent for WANTED pills / Reply buttons. */
     public const WANTED_BLUE = '#00A1CB';
+
+    /**
+     * Number of summary ("In this digest") lines shown before the rest are
+     * tucked behind the collapsible "Show N more" control. Three matches the
+     * V1 "What's New" index density and keeps the email short for clients
+     * that can't collapse (the overflow degrades to one line per post).
+     *
+     * Referenced by BOTH the MJML (<details>) and AMP4Email (<amp-accordion>)
+     * renderings so the cut-off can never drift between the two variants.
+     */
+    public const SUMMARY_VISIBLE_LINES = 3;
 }

--- a/iznik-batch/app/Mail/Digest/UnifiedDigest.php
+++ b/iznik-batch/app/Mail/Digest/UnifiedDigest.php
@@ -666,6 +666,18 @@ class UnifiedDigest extends MjmlMailable implements RetryableMailable
                 'view_message'
             );
 
+            // Summary-index link: the top-of-digest "In this digest" list is a
+            // jump-to-post index, so it points at the message's web page WITHOUT
+            // ?reply=1 (we're not asking the reader to reply, just to look) and
+            // carries its own tracking tag so summary clicks are distinguishable
+            // from card clicks. V1's summary used an in-email #anchor that
+            // rendered inconsistently across clients; a real web URL is reliable.
+            $summaryUrl = $this->trackedUrl(
+                $this->userSite . '/message/' . $message->id,
+                "summary_{$index}",
+                'summary_click'
+            );
+
             // Format arrival time for display in UK local time (BST in summer, GMT in winter).
             // Always include minutes (e.g. "Sun 1 Mar, 11:00am") so the time
             // shape is consistent — V1 single.html-style "Mon, 25th May 9:00am".
@@ -719,6 +731,7 @@ class UnifiedDigest extends MjmlMailable implements RetryableMailable
                 'message' => $message,
                 'messageText' => $messageText,
                 'messageUrl' => $messageUrl,
+                'summaryUrl' => $summaryUrl,
                 'imageUrl' => $imageUrl,
                 'displayImageUrl' => $displayImageUrl,
                 'heroImageUrl' => $heroImageUrl,

--- a/iznik-batch/resources/views/emails/amp/digest/unified.blade.php
+++ b/iznik-batch/resources/views/emails/amp/digest/unified.blade.php
@@ -59,6 +59,51 @@
       }
     }
 
+    /* "In this digest" summary index. One line per post linking to the post's
+       web page; any overflow tucks behind a native amp-accordion "Show N more".
+       Mirrors the MJML <details> summary in the HTML MIME part — the visible
+       cut-off comes from DigestStyle so the two can't drift. */
+    .summary-section {
+      padding: 16px 20px 8px;
+      border-bottom: 1px solid #eeeeee;
+    }
+    .summary-head {
+      font-size: 13px;
+      font-weight: 700;
+      color: #212529;
+      text-transform: uppercase;
+      letter-spacing: 0.3px;
+      margin: 0 0 8px 0;
+    }
+    .summary-link {
+      display: block;
+      font-size: 14px;
+      line-height: 1.6;
+      color: {{ \App\Mail\Digest\DigestStyle::OFFER_GREEN }};
+      text-decoration: none;
+      margin: 0 0 4px 0;
+    }
+    .summary-acc { margin-top: 2px; }
+    .summary-acc section { border: none; }
+    /* The amp runtime force-paints the first child of <section>; beat its
+       :where(amp-accordion > section) > :first-child (0,1,0) rule with a
+       0,1,3 selector, the same trick the per-post reply-toggle uses. */
+    amp-accordion.summary-acc > section > h4.summary-toggle {
+      margin: 0;
+      padding: 0;
+      background: transparent;
+      border: 0;
+      cursor: pointer;
+      font-weight: normal;
+    }
+    .summary-more {
+      display: inline-block;
+      color: {{ \App\Mail\Digest\DigestStyle::OFFER_GREEN }};
+      font-weight: 700;
+      font-size: 14px;
+    }
+    .summary-rest { padding-top: 6px; }
+
     /* Greeting */
     .greeting {
       padding: 20px 20px 10px 20px;
@@ -565,6 +610,39 @@
         @endforeach
       </div>
     </div>
+
+    {{-- "In this digest" summary index — one line per post linking to the
+         post's web page (AMP4Email forbids fragment #anchors anyway, so the
+         web URL is the only correct choice). The first SUMMARY_VISIBLE_LINES
+         always show; overflow collapses into a native <amp-accordion> "Show N
+         more". Mirrors the MJML <details> equivalent. (amp-accordion's
+         disable-session-states attribute is AMP-HTML only — the AMP4Email
+         validator rejects it — so it's omitted here.) --}}
+    @php
+        $summaryPosts = collect($posts);
+        $summaryVisible = \App\Mail\Digest\DigestStyle::SUMMARY_VISIBLE_LINES;
+        $summaryHidden = $summaryPosts->slice($summaryVisible);
+    @endphp
+    @if($summaryPosts->count() >= 2)
+    <div class="summary-section">
+      <p class="summary-head">In this digest</p>
+      @foreach($summaryPosts->take($summaryVisible) as $summaryPost)
+      <a class="summary-link" href="{{ $summaryPost['summaryUrl'] }}">{{ $summaryPost['subject'] }}</a>
+      @endforeach
+      @if($summaryHidden->isNotEmpty())
+      <amp-accordion class="summary-acc">
+        <section>
+          <h4 class="summary-toggle"><span class="summary-more">Show {{ $summaryHidden->count() }} more</span></h4>
+          <div class="summary-rest">
+            @foreach($summaryHidden as $summaryPost)
+            <a class="summary-link" href="{{ $summaryPost['summaryUrl'] }}">{{ $summaryPost['subject'] }}</a>
+            @endforeach
+          </div>
+        </section>
+      </amp-accordion>
+      @endif
+    </div>
+    @endif
 
 
     {{-- Shared amp-mustache templates referenced by id from every post's

--- a/iznik-batch/resources/views/emails/mjml/digest/unified.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/digest/unified.blade.php
@@ -302,6 +302,47 @@
         </mj-section>
         @endif
 
+        {{-- ════════════════════════════════════════════════════════════════
+             "In this digest" summary index. One line per post, each linking to
+             the post's page on the website (NOT an in-email #anchor — V1's
+             anchor approach rendered inconsistently across clients). The first
+             DigestStyle::SUMMARY_VISIBLE_LINES lines always show; any overflow
+             collapses into a <details>/<summary> "Show N more" disclosure.
+             Apple Mail and modern webmail render the toggle; clients that ignore
+             <details> show the overflow expanded — but it's one short line per
+             post, so the digest never balloons. AMP clients get the native
+             <amp-accordion> equivalent in the AMP MIME part. --}}
+        @php
+            $summaryPosts = collect($posts);
+            $summaryVisible = \App\Mail\Digest\DigestStyle::SUMMARY_VISIBLE_LINES;
+            $summaryHidden = $summaryPosts->slice($summaryVisible);
+            $summaryLink = 'color: ' . \App\Mail\Digest\DigestStyle::OFFER_GREEN . '; text-decoration: none; display: block; margin-bottom: 4px;';
+        @endphp
+        @if($summaryPosts->count() >= 2)
+        <mj-section background-color="#ffffff" padding="16px 20px 4px">
+            <mj-column>
+                <mj-text font-size="13px" color="#212529" padding="0 0 8px 0">
+                    <strong style="text-transform: uppercase; letter-spacing: 0.3px;">In this digest</strong>
+                </mj-text>
+                <mj-text font-size="14px" color="#212529" line-height="1.6" padding="0">
+                    @foreach($summaryPosts->take($summaryVisible) as $summaryPost)
+                    <a href="{{ $summaryPost['summaryUrl'] }}" style="{{ $summaryLink }}">{{ $summaryPost['subject'] }}</a>
+                    @endforeach
+                    @if($summaryHidden->isNotEmpty())
+                    <details style="margin-top: 2px;">
+                        <summary style="cursor: pointer; color: {{ \App\Mail\Digest\DigestStyle::OFFER_GREEN }}; font-weight: 600;">Show {{ $summaryHidden->count() }} more</summary>
+                        <div style="margin-top: 6px;">
+                            @foreach($summaryHidden as $summaryPost)
+                            <a href="{{ $summaryPost['summaryUrl'] }}" style="{{ $summaryLink }}">{{ $summaryPost['subject'] }}</a>
+                            @endforeach
+                        </div>
+                    </details>
+                    @endif
+                </mj-text>
+            </mj-column>
+        </mj-section>
+        @endif
+
         {{-- Post cards --}}
         @foreach($posts as $index => $post)
         @php $isOffer = $post['type'] === 'Offer'; @endphp

--- a/iznik-batch/resources/views/emails/text/digest/unified.blade.php
+++ b/iznik-batch/resources/views/emails/text/digest/unified.blade.php
@@ -10,6 +10,19 @@
 @unless($isSingle)
 Here are {{ $postCount }} new posts from your Freegle communities:
 
+@php($summaryPosts = collect($posts))
+@php($summaryVisible = \App\Mail\Digest\DigestStyle::SUMMARY_VISIBLE_LINES)
+@php($summaryHidden = $summaryPosts->slice($summaryVisible))
+@if($summaryPosts->count() >= 2)
+In this digest:
+@foreach($summaryPosts->take($summaryVisible) as $summaryPost)
+- {!! $summaryPost['subject'] !!}: {{ $summaryPost['summaryUrl'] }}
+@endforeach
+@if($summaryHidden->isNotEmpty())
+...and {{ $summaryHidden->count() }} more below.
+@endif
+
+@endif
 @endunless
 @foreach($posts as $post)
 {!! strtoupper($post['type']) !!}: {!! $post['itemName'] !!}

--- a/iznik-batch/tests/Unit/Mail/UnifiedDigestCardPhotoTest.php
+++ b/iznik-batch/tests/Unit/Mail/UnifiedDigestCardPhotoTest.php
@@ -90,14 +90,20 @@ class UnifiedDigestCardPhotoTest extends TestCase
         $avatarUrl    = 'https://images.ilovefreegle.org/avatar_' . $id . '.jpg';
         $ampReplyUrl  = 'https://api.ilovefreegle.org/amp/reply/' . $id;
 
+        // Summary index ("In this digest") link: its own tracked URL to the
+        // message page, distinct from messageUrl (which carries ?reply=1).
+        $summaryUrl = 'https://api.ilovefreegle.org/e/d/r/STOKEN' . $id . '?url=' . base64_encode($trackedBase);
+
         return [
             'message'          => (object) ['id' => $id],
             'type'             => $type,
             'itemName'         => 'Test Item ' . $id,
+            'subject'          => strtoupper($type) . ': Test Item ' . $id . ' (Edinburgh)',
             'thumbImageUrl'    => $thumbUrl,
             'heroImageUrl'     => $heroUrl,
             'displayImageUrl'  => $displayUrl,
             'messageUrl'       => $messageUrl,
+            'summaryUrl'       => $summaryUrl,
             'fallbackReplyUrl' => $fallbackUrl,
             'locationName'     => 'Edinburgh',
             'distanceText'     => '1.2 miles',

--- a/iznik-batch/tests/Unit/Mail/UnifiedDigestSummaryTest.php
+++ b/iznik-batch/tests/Unit/Mail/UnifiedDigestSummaryTest.php
@@ -1,0 +1,291 @@
+<?php
+
+namespace Tests\Unit\Mail;
+
+use App\Mail\Digest\DigestStyle;
+use App\Mail\Digest\UnifiedDigest;
+use App\Services\UnifiedDigestService;
+use Illuminate\Mail\Mailable;
+use ReflectionProperty;
+use Tests\Support\IsolatedSpoolDirectory;
+use Tests\TestCase;
+
+/**
+ * The collapsible "In this digest" summary index at the top of the daily
+ * unified digest.
+ *
+ * Behaviour under test (one line per post, linking to the post's page on the
+ * website — never an in-email #anchor):
+ *  - daily digests render a summary index; immediate single-post digests don't;
+ *  - the first DigestStyle::SUMMARY_VISIBLE_LINES lines are always visible and
+ *    the rest are tucked behind a collapsible "Show N more" control;
+ *  - HTML uses <details>/<summary>; AMP uses <amp-accordion>; text falls back
+ *    to "…and N more below";
+ *  - every summary link points at {site}/message/{id}, not "#...".
+ */
+class UnifiedDigestSummaryTest extends TestCase
+{
+    use IsolatedSpoolDirectory;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpIsolatedSpoolDirectory();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownIsolatedSpoolDirectory();
+        parent::tearDown();
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
+    private function spoolAndLoad(Mailable $mailable, string $recipient): array
+    {
+        $id = $this->spooler->spool($mailable, $recipient);
+        $path = $this->testSpoolDir.'/pending/'.$id.'.json';
+
+        return json_decode(file_get_contents($path), true) ?? [];
+    }
+
+    /**
+     * Build a daily/immediate digest with $count real posts whose item names
+     * are distinct words so they can be located in rendered output.
+     *
+     * @return array{0: UnifiedDigest, 1: array<int,\App\Models\Message>}
+     */
+    private function buildDigest(int $count, string $mode): array
+    {
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $this->createMembership($user, $group);
+        $poster = $this->createTestUser();
+        $this->createMembership($poster, $group);
+
+        $words = ['Alpha', 'Bravo', 'Charlie', 'Delta', 'Echo', 'Foxtrot', 'Golf'];
+        $messages = [];
+        $posts = collect();
+        for ($i = 0; $i < $count; $i++) {
+            $m = $this->createTestMessage($poster, $group, [
+                'subject' => 'OFFER: '.$words[$i].' (TestLocation)',
+            ]);
+            $messages[] = $m;
+            $posts->push(['message' => $m, 'postedToGroups' => [$group->id]]);
+        }
+
+        return [new UnifiedDigest($user, $posts, $mode), $messages];
+    }
+
+    /**
+     * @return \Illuminate\Support\Collection<int,array<string,mixed>>
+     */
+    private function preparedPostsOf(UnifiedDigest $mail): \Illuminate\Support\Collection
+    {
+        $ref = new ReflectionProperty(UnifiedDigest::class, 'preparedPosts');
+        $ref->setAccessible(true);
+
+        return $ref->getValue($mail);
+    }
+
+    private static function decodeTrackedTarget(string $url): string
+    {
+        if (preg_match('/[?&]url=([^&]+)/', $url, $m)) {
+            return base64_decode(urldecode($m[1])) ?: $url;
+        }
+
+        return $url;
+    }
+
+    /**
+     * Fabricated template data with $count posts carrying every key the AMP
+     * and text blades reference, so the views can render standalone (the MJML
+     * variant is exercised through the real build+spool path instead).
+     */
+    private function summaryViewData(int $count): array
+    {
+        $words = ['Alpha', 'Bravo', 'Charlie', 'Delta', 'Echo', 'Foxtrot', 'Golf'];
+        $posts = collect();
+        for ($i = 0; $i < $count; $i++) {
+            $posts->push([
+                'message' => (object) ['id' => 1000 + $i],
+                'type' => $i % 2 === 0 ? 'Offer' : 'Wanted',
+                'subject' => 'OFFER: '.$words[$i].' (TestLocation)',
+                'itemName' => $words[$i],
+                'locationName' => 'TestLocation',
+                'messageText' => 'Body text for '.$words[$i],
+                'messageUrl' => 'https://example.com/message/'.(1000 + $i).'?reply=1',
+                'summaryUrl' => 'https://example.com/message/'.(1000 + $i),
+                'fallbackReplyUrl' => 'https://example.com/message/'.(1000 + $i).'?reply=1',
+                'ampReplyUrl' => 'https://api.example.com/amp/digest/'.(1000 + $i).'/reply',
+                'distanceText' => '2 miles',
+                'arrivalFormatted' => 'Mon 1 Jun, 9:00am',
+                'posterName' => 'Sam',
+                'posterAvatarUrl' => 'https://example.com/avatar.png',
+                'groupName' => 'Test Group',
+                'groupUrl' => 'https://example.com/explore/testgroup',
+                'firstPostedFormatted' => null,
+                'thumbImageUrl' => 'https://example.com/thumb.png',
+                'heroImageUrl' => 'https://example.com/hero.png',
+                'displayImageUrl' => 'https://example.com/img.png',
+                'isPlaceholder' => false,
+            ]);
+        }
+
+        return [
+            'user' => (object) ['email_preferred' => 'r@example.com', 'displayname' => 'Sam'],
+            'posts' => $posts,
+            'postCount' => $count,
+            'mode' => UnifiedDigestService::MODE_DAILY,
+            'isSingle' => false,
+            'sponsors' => collect(),
+            'jobAds' => collect(),
+            'completedPosts' => collect(),
+            'jobsUrl' => 'https://example.com/jobs',
+            'donateUrl' => 'https://example.com/donate',
+            'browseUrl' => 'https://example.com/browse',
+            'settingsUrl' => 'https://example.com/settings',
+            'unsubscribeUrl' => 'https://example.com/unsubscribe',
+            'userSite' => 'https://example.com',
+            'siteName' => 'Freegle',
+        ];
+    }
+
+    // ── preparePosts: website summary URL ───────────────────────────────────
+
+    public function test_prepared_posts_carry_summary_url_to_website_message_page(): void
+    {
+        [$mail, $messages] = $this->buildDigest(1, UnifiedDigestService::MODE_DAILY);
+        $card = $this->preparedPostsOf($mail)->first();
+
+        $this->assertArrayHasKey('summaryUrl', $card);
+        $target = self::decodeTrackedTarget($card['summaryUrl']);
+
+        // Points at the post's page on the website…
+        $this->assertStringContainsString('/message/'.$messages[0]->id, $target);
+        // …and is NOT an in-email anchor (the V1 inconsistency we're dropping).
+        $this->assertStringNotContainsString('#', $target);
+        // The summary link is its own jump-to-post link, not the reply CTA.
+        $this->assertStringNotContainsString('reply=1', $target);
+    }
+
+    // ── HTML (MJML → <details>) ─────────────────────────────────────────────
+
+    public function test_html_daily_summary_collapses_beyond_three(): void
+    {
+        [$mail] = $this->buildDigest(5, UnifiedDigestService::MODE_DAILY);
+        $prepared = $this->preparedPostsOf($mail);
+        // Each summary line is the full subject; the first 3 subjects appear
+        // only in the summary index (cards show the bare item name), so they
+        // uniquely locate the summary section.
+        $subjects = $prepared->pluck('subject')->all();
+
+        $html = $this->spoolAndLoad($mail, 'r@example.com')['html'] ?? '';
+
+        $this->assertStringContainsString('In this digest', $html);
+        $this->assertStringContainsString('<details', $html);
+        // 5 posts − 3 visible = 2 hidden.
+        $this->assertStringContainsString('Show 2 more', $html);
+
+        // The summary links are the website summary URLs (Blade escapes & to
+        // &amp; in the href, so compare against the escaped form).
+        $escapedFirstUrl = htmlspecialchars($prepared->first()['summaryUrl'], ENT_QUOTES, 'UTF-8');
+        $this->assertStringContainsString($escapedFirstUrl, $html);
+
+        // Every post's subject is listed in the summary.
+        foreach ($subjects as $s) {
+            $this->assertStringContainsString($s, $html);
+        }
+
+        // First 3 lines sit before the collapse; the remaining 2 inside it.
+        $pos = strpos($html, '<details');
+        $this->assertNotFalse($pos);
+        $this->assertLessThan($pos, strpos($html, $subjects[0]));
+        $this->assertLessThan($pos, strpos($html, $subjects[1]));
+        $this->assertLessThan($pos, strpos($html, $subjects[2]));
+        $this->assertGreaterThan($pos, strpos($html, $subjects[3]));
+        $this->assertGreaterThan($pos, strpos($html, $subjects[4]));
+    }
+
+    public function test_html_daily_three_posts_show_summary_without_collapse(): void
+    {
+        [$mail] = $this->buildDigest(3, UnifiedDigestService::MODE_DAILY);
+        $prepared = $this->preparedPostsOf($mail);
+        $subjects = $prepared->pluck('subject')->all();
+
+        $html = $this->spoolAndLoad($mail, 'r@example.com')['html'] ?? '';
+
+        $this->assertStringContainsString('In this digest', $html);
+        // Summary links use the website summary URL (escaped & → &amp;).
+        $escapedFirstUrl = htmlspecialchars($prepared->first()['summaryUrl'], ENT_QUOTES, 'UTF-8');
+        $this->assertStringContainsString($escapedFirstUrl, $html);
+        foreach ($subjects as $s) {
+            $this->assertStringContainsString($s, $html);
+        }
+        // No overflow → no collapsible control ("Show N more" only ever
+        // appears inside the <details>, so its absence proves no collapse).
+        $this->assertStringNotContainsString('<details', $html);
+    }
+
+    public function test_html_immediate_single_post_has_no_summary_index(): void
+    {
+        [$mail] = $this->buildDigest(1, UnifiedDigestService::MODE_IMMEDIATE);
+
+        $html = $this->spoolAndLoad($mail, 'r@example.com')['html'] ?? '';
+
+        $this->assertStringNotContainsString('In this digest', $html);
+    }
+
+    // ── AMP (<amp-accordion>) ───────────────────────────────────────────────
+
+    public function test_amp_summary_uses_accordion_for_overflow_with_website_links(): void
+    {
+        $html = view('emails.amp.digest.unified', $this->summaryViewData(5))->render();
+
+        $this->assertStringContainsString('In this digest', $html);
+        // Native collapsible: a dedicated summary accordion (the per-post reply
+        // accordion uses class="reply-acc", so this element is unambiguous).
+        $this->assertStringContainsString('<amp-accordion class="summary-acc"', $html);
+        $this->assertStringContainsString('Show 2 more', $html);
+
+        // Each summary link points at the website message page.
+        for ($i = 0; $i < 5; $i++) {
+            $this->assertStringContainsString('https://example.com/message/'.(1000 + $i), $html);
+        }
+        // AMP4Email forbids fragment hrefs; assert we never emit one anywhere.
+        $this->assertStringNotContainsString('href="#"', $html);
+    }
+
+    public function test_amp_summary_no_accordion_when_three_or_fewer(): void
+    {
+        $html = view('emails.amp.digest.unified', $this->summaryViewData(3))->render();
+
+        $this->assertStringContainsString('In this digest', $html);
+        // The summary's own accordion is absent (per-post reply accordions,
+        // which use class="reply-acc", may still render). Check the rendered
+        // "Show N more" span markup, not the literal "Show " (which also
+        // appears in a CSS comment that is not stripped from <style>).
+        $this->assertStringNotContainsString('<amp-accordion class="summary-acc"', $html);
+        $this->assertStringNotContainsString('summary-more">', $html);
+    }
+
+    // ── Text (…and N more below) ────────────────────────────────────────────
+
+    public function test_text_summary_lists_first_three_with_more_note(): void
+    {
+        $text = view('emails.text.digest.unified', $this->summaryViewData(5))->render();
+
+        $this->assertStringContainsString('In this digest', $text);
+        $this->assertStringContainsString('Alpha', $text);
+        $this->assertStringContainsString('Bravo', $text);
+        $this->assertStringContainsString('Charlie', $text);
+        $this->assertStringContainsString('https://example.com/message/1000', $text);
+        // 5 − 3 = 2 more posts below.
+        $this->assertStringContainsString('2 more', $text);
+    }
+
+    public function test_summary_visible_lines_constant_is_three(): void
+    {
+        $this->assertSame(3, DigestStyle::SUMMARY_VISIBLE_LINES);
+    }
+}


### PR DESCRIPTION
## Summary

Adds a collapsible **"In this digest"** summary index at the top of the **daily** unified digest — one line per post, each linking to the post's page on the website.

- **Website links, not in-email anchors.** New `summaryUrl` per post in `UnifiedDigest::preparePosts()` → tracked `{site}/message/{id}` (no `?reply=1`; own `summary_click` tracking tag). V1's summary used `#anchor` links that rendered inconsistently across clients; a real web URL is reliable everywhere.
- **First 3 lines always shown; the rest collapse** behind a "Show N more" control. Cut-off centralised in `DigestStyle::SUMMARY_VISIBLE_LINES` so the MJML and AMP variants can't drift.
- **Three MIME parts, each degrading well:**
  - **AMP** (`text/x-amp-html`): native `<amp-accordion>` — a real collapsible in Gmail/Yahoo/Mail.ru. Validated with `amphtml-validator` (AMP4EMAIL) at 2/3/5/10 posts.
  - **HTML** (`text/html`, MJML): `<details>`/`<summary>` — Apple Mail & modern webmail collapse it; clients that ignore `<details>` show the overflow expanded, but it's one short line per post so the digest never balloons.
  - **Text** (`text/plain`): first 3 lines + "…and N more below" (never long).
- Only renders for multi-post daily digests (`>= 2` posts); the single-post immediate digest is unchanged.

## Code Quality Review

- Shared `SUMMARY_VISIBLE_LINES` constant referenced by both hand-maintained templates (same pattern the repo already uses for `OFFER_GREEN`/`WANTED_BLUE`), so the visible/collapsed boundary stays in lockstep.
- `disable-session-states` on `<amp-accordion>` was dropped — the AMP4Email validator rejects it (it's AMP-HTML only).
- `<details>` survives `mrml` compilation inside `<mj-text>`, so no `<mj-raw>` escape hatch was needed.
- Text template uses inline `@php(...)` (not the `@php`/`@endphp` block) to match the file's existing style — mixing the two breaks Blade's parser there.
- Additive only: the existing card/header/jobs/sponsors layout is untouched.

## Future Improvements

- The daily MJML header thumbnail strip still uses `#msg-{id}` in-email anchors (a separate, pre-existing feature); could be migrated to website links in a follow-up for consistency.

## Test Plan

New `tests/Unit/Mail/UnifiedDigestSummaryTest.php` (TDD — written red first):

- `summaryUrl` decodes to `{site}/message/{id}` — no `#`, no `reply=1`.
- HTML: 5-post digest shows first 3 subjects before `<details>`, last 2 inside, "Show 2 more"; 3-post shows the index with no `<details>`; immediate single-post shows no index.
- AMP: 5-post renders `<amp-accordion class="summary-acc">` + "Show 2 more"; 3-post renders the index with no summary accordion.
- Text: first 3 lines + "…and 2 more below".
- `DigestStyle::SUMMARY_VISIBLE_LINES === 3`.

Verified locally: full Laravel suite green via the worktree status API; AMP validated clean; sample delivered to Mailpit and screenshotted (HTML + AMP, collapsed → expanded).
