### PR TITLE
feat(api): server-side kill switch for out-of-date builds (webversion-age) [BLOCKED]

### DIFF
--- a/iznik-server-go/session/appversion.go
+++ b/iznik-server-go/session/appversion.go
@@ -1,0 +1,31 @@
+package session
+
+import "time"
+
+// webversionOlderThan reports whether an ISO-8601 webversion (the BUILD_DATE that
+// every client sends on GET /session) is strictly older than minVersion, the
+// configured app_min_webversion threshold.
+//
+// It is the comparison behind the server-side "app is out of date" kill switch.
+// It fails open (returns false) whenever either value is empty or is not a
+// parseable RFC3339/ISO-8601 timestamp:
+//   - the threshold is empty until an operator arms it, so an unset config blocks
+//     nobody;
+//   - legacy clients send non-ISO webversions, which must never be blocked.
+func webversionOlderThan(webversion, minVersion string) bool {
+	if webversion == "" || minVersion == "" {
+		return false
+	}
+
+	clientTime, err := time.Parse(time.RFC3339, webversion)
+	if err != nil {
+		return false
+	}
+
+	thresholdTime, err := time.Parse(time.RFC3339, minVersion)
+	if err != nil {
+		return false
+	}
+
+	return clientTime.Before(thresholdTime)
+}

--- a/iznik-server-go/session/appversion_pure_test.go
+++ b/iznik-server-go/session/appversion_pure_test.go
@@ -1,0 +1,29 @@
+package session
+
+import "testing"
+
+// Pure tests for the kill-switch comparison. No DB needed.
+func TestWebversionOlderThan(t *testing.T) {
+	cases := []struct {
+		name string
+		web  string
+		min  string
+		want bool
+	}{
+		{"older than threshold", "2026-06-01T00:00:00Z", "2026-06-10T00:00:00Z", true},
+		{"newer than threshold", "2026-06-15T00:00:00Z", "2026-06-10T00:00:00Z", false},
+		{"exactly equal is not older", "2026-06-10T00:00:00Z", "2026-06-10T00:00:00Z", false},
+		{"older with tz offset", "2026-06-10T00:00:00+01:00", "2026-06-10T00:00:00Z", true},
+		{"empty webversion fails open", "", "2026-06-10T00:00:00Z", false},
+		{"unset threshold fails open", "2026-06-01T00:00:00Z", "", false},
+		{"both empty", "", "", false},
+		{"legacy non-ISO webversion fails open", "3.2.5", "2026-06-10T00:00:00Z", false},
+		{"non-ISO threshold fails open", "2026-06-01T00:00:00Z", "not-a-date", false},
+		{"date-only (non-RFC3339) webversion fails open", "2026-06-01", "2026-06-10T00:00:00Z", false},
+	}
+	for _, c := range cases {
+		if got := webversionOlderThan(c.web, c.min); got != c.want {
+			t.Errorf("%s: webversionOlderThan(%q, %q) = %v, want %v", c.name, c.web, c.min, got, c.want)
+		}
+	}
+}

--- a/iznik-server-go/session/session.go
+++ b/iznik-server-go/session/session.go
@@ -779,6 +779,21 @@ func GetSession(c *fiber.Ctx) error {
 		})
 	}
 
+	// Kill switch: reject any build older than the configured minimum web build.
+	// webversion (BUILD_DATE) is sent on every GET /session and needs no client
+	// cooperation, so failing the session makes an out-of-date client non-functional
+	// until updated. Gated purely on build age (no app/web distinction): website
+	// bundles are always fresh and self-heal on reload. Fails open — blocks nobody
+	// unless an operator sets app_min_webversion to an ISO date (see PR notes).
+	var minWebversion string
+	database.DBConn.Raw("SELECT value FROM config WHERE `key` = 'app_min_webversion'").Scan(&minWebversion)
+	if webversionOlderThan(c.Query("webversion"), minWebversion) {
+		return c.JSON(fiber.Map{
+			"ret":    123,
+			"status": "App is out of date",
+		})
+	}
+
 	myid := user.WhoAmI(c)
 	if myid == 0 {
 		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{

--- a/iznik-server/http/api/session.php
+++ b/iznik-server/http/api/session.php
@@ -42,8 +42,20 @@ function session() {
 
             # Mobile app can send its version number, which we can use to determine if it is out of date.
             $appversion = Utils::presdef('appversion', $_REQUEST, NULL);
+            $webversion = Utils::presdef('webversion', $_REQUEST, NULL);
 
-            if ($appversion && substr($appversion, 0, 1) == '2') {
+            # Kill switch: reject any build older than the configured minimum web build
+            # (app_min_webversion). webversion (BUILD_DATE) is sent on every GET, so
+            # failing the session makes an out-of-date client non-functional until it
+            # updates. Fails open - blocks nobody unless the config key is set (see PR).
+            $minWebversion = NULL;
+            $cfg = $dbhr->preQuery("SELECT value FROM config WHERE `key` = 'app_min_webversion'");
+            if (count($cfg) > 0) {
+                $minWebversion = $cfg[0]['value'];
+            }
+
+            if (($appversion && substr($appversion, 0, 1) == '2') ||
+                Utils::webversionTooOld($webversion, $minWebversion)) {
                 $ret = array('ret' => 123, 'status' => 'App is out of date');
             } else {
                 if (Utils::pres('id', $_SESSION) && $me) {

--- a/iznik-server/include/misc/Utils.php
+++ b/iznik-server/include/misc/Utils.php
@@ -708,4 +708,33 @@ class Utils {
         // Fall back to REMOTE_ADDR.
         return Utils::presdef('REMOTE_ADDR', $_SERVER, '');
     }
+
+    /**
+     * Kill-switch comparison: is a client's webversion (the BUILD_DATE it sends on
+     * GET /session) older than the configured minimum web build ($minVersion =
+     * app_min_webversion)?
+     *
+     * Fails open (returns FALSE) on empty/unset/non-ISO values: the threshold is
+     * unset until an operator arms it, and legacy clients send non-ISO webversions
+     * which must never be blocked. Only the ISO-8601 form (e.g. 2026-06-10T12:00:00Z)
+     * is acted on. Mirror of webversionOlderThan() in the Go API.
+     */
+    public static function webversionTooOld($webversion, $minVersion) {
+        if (!$webversion || !$minVersion) {
+            return FALSE;
+        }
+
+        $iso = '/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/';
+        if (!preg_match($iso, $webversion) || !preg_match($iso, $minVersion)) {
+            return FALSE;
+        }
+
+        $wt = strtotime($webversion);
+        $mt = strtotime($minVersion);
+        if ($wt === FALSE || $mt === FALSE) {
+            return FALSE;
+        }
+
+        return $wt < $mt;
+    }
 }

--- a/iznik-server/test/ut/php/include/UtilsTest.php
+++ b/iznik-server/test/ut/php/include/UtilsTest.php
@@ -34,6 +34,19 @@ class UtilsTest extends IznikTestCase {
         $this->assertEquals(2, Utils::calculate_median([1, 2, 2, 3]));
     }
 
+    public function testWebversionTooOld() {
+        # Older ISO build than the threshold -> out of date.
+        $this->assertTrue(Utils::webversionTooOld('2026-06-01T00:00:00Z', '2026-06-10T00:00:00Z'));
+        # Newer or equal -> fine.
+        $this->assertFalse(Utils::webversionTooOld('2026-06-15T00:00:00Z', '2026-06-10T00:00:00Z'));
+        $this->assertFalse(Utils::webversionTooOld('2026-06-10T00:00:00Z', '2026-06-10T00:00:00Z'));
+        # Fail open: unset threshold, missing webversion, legacy non-ISO values.
+        $this->assertFalse(Utils::webversionTooOld('2026-06-01T00:00:00Z', NULL));
+        $this->assertFalse(Utils::webversionTooOld(NULL, '2026-06-10T00:00:00Z'));
+        $this->assertFalse(Utils::webversionTooOld('3.2.5', '2026-06-10T00:00:00Z'));
+        $this->assertFalse(Utils::webversionTooOld('2026-06-01', '2026-06-10T00:00:00Z'));
+    }
+
     public function testlockScript() {
         $lockh = Utils::lockScript('ut');
         $this->assertNotNull($lockh);


### PR DESCRIPTION
## ⛔ BLOCKED — do not merge / do not arm yet

This is the **enforcement half** of forcing app upgrades (Sentry CAPACITOR-44Z context). It ships **inert** and must not be armed until the prerequisites below are met.

## What it does
`webversion` (the `BUILD_DATE` every client sends on `GET /session`) is compared against a configurable `app_min_webversion` threshold. When the client's build is **older**, the session is failed with `{ "ret": 123, "status": "App is out of date" }`, making an out-of-date client non-functional until it updates. No client cooperation needed.

**Gate = webversion-age only (Option A).** There is no server-visible app/web signal on `GET /session` (modern apps send only `webversion`, same as the website), so a date-only gate is used. Website bundles are always fresh and self-heal on reload, so they aren't meaningfully affected; the companion web auto-reload (#729) handles stale web tabs.

## How
- **Go (V2)** — `session.GetSession` reads `app_min_webversion` and rejects older builds. The ISO-8601 comparison is `webversionOlderThan()` in `session/appversion.go` (pure, unit-tested).
- **PHP (V1)** — `session.php` mirrors it via `Utils::webversionTooOld()` (parity).
- **Both FAIL OPEN**: an unset config key, a missing `webversion`, or a legacy non-ISO value never blocks anyone. With the config unset (the default), this PR blocks **nobody**.

## 🔒 Before this can be merged AND armed
1. A **post-#650 fixed app** is live in **both** the App Store and Play Store (so there's a fixed version to force users onto — allow for iOS review time).
2. Set config `app_min_webversion` = that build's `BUILD_DATE` (**B_DATE**). Setting it earlier would **lock users out**.
3. Raise `app_fd_version_ios_required` / `app_fd_version_android_required` from the current `3.2.5` to that build's `MOBILE_VERSION` (**B_VER**) — the non-blocking in-app nudge (`stores/mobile.js` `versionOutOfDate`). These are config **data** changes, set post-publish; **not in this PR**. Each must be ≤ the version actually live in its store.

## Tests
- `iznik-server-go/session/appversion_pure_test.go` — Go threshold/fail-open cases (no DB).
- `UtilsTest::testWebversionTooOld` — PHP parity cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)