### PR TITLE
feat(emailtracking): sysadmin digest click-position click-through-rate stats

### DIFF
--- a/iznik-nuxt3/api/EmailTrackingAPI.js
+++ b/iznik-nuxt3/api/EmailTrackingAPI.js
@@ -62,4 +62,15 @@ export default class EmailTrackingAPI extends BaseAPI {
   async fetchTopClickedLinks(params = {}) {
     return await this.$getv2('/modtools/email/stats/clicks', params)
   }
+
+  /**
+   * Fetch digest click-through rate by post position.
+   * @param {Object} params - Query parameters
+   * @param {string} [params.start] - Start date (YYYY-MM-DD)
+   * @param {string} [params.end] - End date (YYYY-MM-DD)
+   * @param {string} [params.type] - Email type filter (default: all UnifiedDigest* types)
+   */
+  async fetchDigestPositions(params = {}) {
+    return await this.$getv2('/modtools/email/stats/digestpositions', params)
+  }
 }

--- a/iznik-nuxt3/modtools/components/ModSysAdminDigestClicks.vue
+++ b/iznik-nuxt3/modtools/components/ModSysAdminDigestClicks.vue
@@ -1,0 +1,237 @@
+<template>
+  <div class="digest-clicks">
+    <p class="text-muted">
+      How far down the unified digest do people click? Each post in a digest is
+      tracked with its position (1 = top). This shows the
+      <strong>click-through rate</strong> — the percentage of digests displaying
+      a post at each position where the recipient clicked that post — so you can
+      see how a post's position affects engagement.
+    </p>
+
+    <!-- Date Range + digest type filter -->
+    <ModEmailDateFilter
+      :loading="emailTrackingStore.digestPositionsLoading"
+      fetch-label="Fetch"
+      default-preset="30days"
+      @fetch="onFilterFetch"
+    >
+      <template #extra-filters>
+        <label class="filter-label">Digest:</label>
+        <b-form-select
+          v-model="digestType"
+          :options="digestTypeOptions"
+          size="sm"
+          style="width: 150px"
+          @change="onTypeChange"
+        />
+      </template>
+    </ModEmailDateFilter>
+
+    <!-- Error -->
+    <NoticeMessage
+      v-if="emailTrackingStore.digestPositionsError"
+      variant="danger"
+      class="mb-3"
+    >
+      {{ emailTrackingStore.digestPositionsError }}
+    </NoticeMessage>
+
+    <!-- Loading -->
+    <div
+      v-if="emailTrackingStore.digestPositionsLoading"
+      class="text-center py-4"
+    >
+      <b-spinner small class="me-2" />
+      Loading digest click positions...
+    </div>
+
+    <!-- Results -->
+    <template v-else-if="emailTrackingStore.hasDigestPositions">
+      <!-- Headline insight -->
+      <NoticeMessage v-if="insight" variant="info" class="mb-3">
+        {{ insight }}
+      </NoticeMessage>
+
+      <!-- Chart -->
+      <div class="chart-container mb-4">
+        <GChart
+          type="ComboChart"
+          :data="emailTrackingStore.digestPositionsChartData"
+          :options="getPositionChartOptions()"
+          class="chart"
+        />
+      </div>
+
+      <!-- Detail table -->
+      <b-table
+        :items="tableRows"
+        :fields="tableFields"
+        striped
+        hover
+        responsive
+        small
+      />
+      <p class="text-muted small">
+        <strong>Emails shown</strong> is the number of digests that displayed a
+        post at that position (the click-through denominator).
+        <strong>Clicked</strong> counts the distinct digests where the recipient
+        clicked the post at that position.
+      </p>
+    </template>
+
+    <!-- Empty -->
+    <div
+      v-else-if="!emailTrackingStore.digestPositionsError"
+      class="text-muted text-center py-4"
+    >
+      <p>No digest click data available for the selected period.</p>
+      <p class="small">
+        Try widening the date range or selecting a different digest type.
+      </p>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed } from 'vue'
+import { GChart } from 'vue-google-charts'
+import { useEmailTrackingStore } from '~/modtools/stores/emailtracking'
+import ModEmailDateFilter from '~/modtools/components/ModEmailDateFilter.vue'
+
+const emailTrackingStore = useEmailTrackingStore()
+
+const startDate = ref('')
+const endDate = ref('')
+const digestType = ref('')
+
+// The unified digest is sent in two modes; allow filtering to each.
+const digestTypeOptions = [
+  { text: 'All digests', value: '' },
+  { text: 'Immediate', value: 'UnifiedDigestImmediate' },
+  { text: 'Daily', value: 'UnifiedDigestDaily' },
+]
+
+const tableFields = [
+  { key: 'position', label: 'Position', sortable: true },
+  { key: 'shown', label: 'Emails shown', sortable: true },
+  { key: 'clicks', label: 'Total clicks', sortable: true },
+  { key: 'emails_clicked', label: 'Clicked', sortable: true },
+  { key: 'ctr', label: 'Click-through rate', sortable: true },
+]
+
+const tableRows = computed(() =>
+  (emailTrackingStore.digestPositions || []).map((p) => ({
+    position: (p.position ?? 0) + 1,
+    shown: (p.shown || 0).toLocaleString(),
+    clicks: (p.clicks || 0).toLocaleString(),
+    emails_clicked: (p.emails_clicked || 0).toLocaleString(),
+    ctr: `${(p.ctr || 0).toFixed(1)}%`,
+  }))
+)
+
+// A plain-English takeaway comparing the top position to the rest.
+const insight = computed(() => {
+  const rows = emailTrackingStore.digestPositions || []
+  if (rows.length < 2) return null
+  const first = rows[0]
+  const last = rows[rows.length - 1]
+  if (!first.ctr) return null
+  const drop = first.ctr - last.ctr
+  if (drop <= 0) return null
+  const pct = Math.round((drop / first.ctr) * 100)
+  return (
+    `The top post is clicked ${first.ctr.toFixed(1)}% of the time, ` +
+    `falling to ${last.ctr.toFixed(1)}% by position ${last.position + 1} — ` +
+    `${pct}% lower. Posts further down the digest get fewer clicks.`
+  )
+})
+
+function fetchData() {
+  emailTrackingStore.setFilters({
+    type: digestType.value,
+    start: startDate.value,
+    end: endDate.value,
+  })
+  emailTrackingStore.fetchDigestPositions()
+}
+
+function onFilterFetch({ start, end }) {
+  startDate.value = start
+  endDate.value = end
+  fetchData()
+}
+
+function onTypeChange() {
+  // Re-fetch with the existing date range when the digest type changes.
+  if (startDate.value && endDate.value) {
+    fetchData()
+  }
+}
+
+function getPositionChartOptions() {
+  return {
+    title: 'Click-through rate by position in the digest',
+    seriesType: 'bars',
+    legend: { position: 'bottom' },
+    chartArea: { width: '80%', height: '70%' },
+    hAxis: {
+      title: 'Position in digest (1 = top)',
+    },
+    vAxes: {
+      0: {
+        title: 'Click-through rate (%)',
+        viewWindow: { min: 0 },
+        format: '#.#',
+      },
+      1: {
+        title: 'Emails shown',
+        viewWindow: { min: 0 },
+      },
+    },
+    series: {
+      0: { type: 'bars', targetAxisIndex: 0, color: '#17a2b8' },
+      1: {
+        type: 'line',
+        targetAxisIndex: 1,
+        color: '#adb5bd',
+        lineDashStyle: [4, 4],
+        pointSize: 3,
+      },
+    },
+    animation: { startup: true, duration: 500, easing: 'out' },
+  }
+}
+
+// Exposed for unit testing.
+defineExpose({
+  digestType,
+  digestTypeOptions,
+  tableFields,
+  tableRows,
+  insight,
+  fetchData,
+  onFilterFetch,
+  onTypeChange,
+  getPositionChartOptions,
+})
+</script>
+
+<style scoped lang="scss">
+.digest-clicks {
+  .filter-label {
+    font-size: 0.85rem;
+    font-weight: 600;
+    margin: 0;
+  }
+
+  .chart-container {
+    width: 100%;
+    min-height: 380px;
+  }
+
+  .chart {
+    width: 100%;
+    height: 380px;
+  }
+}
+</style>

--- a/iznik-nuxt3/modtools/pages/sysadmin/index.vue
+++ b/iznik-nuxt3/modtools/pages/sysadmin/index.vue
@@ -53,6 +53,17 @@
           />
         </b-tab>
 
+        <!-- Digest Clicks Tab -->
+        <b-tab @click="onDigestClicksTab">
+          <template #title>
+            <h2 class="ms-2 me-2">Digest Clicks</h2>
+          </template>
+          <ModSysAdminDigestClicks
+            v-if="showDigestClicks"
+            :key="'digestclicks-' + digestClicksBump"
+          />
+        </b-tab>
+
         <!-- Incoming Email Tab -->
         <b-tab @click="onIncomingEmailTab">
           <template #title>
@@ -93,6 +104,8 @@ const showCronJobs = ref(false)
 const cronJobsBump = ref(0)
 const showEmailStats = ref(false)
 const emailStatsBump = ref(0)
+const showDigestClicks = ref(false)
+const digestClicksBump = ref(0)
 const showIncomingEmail = ref(false)
 const incomingEmailBump = ref(0)
 
@@ -100,7 +113,8 @@ const topTabMap = {
   housekeeping: 0,
   cronjobs: 1,
   outgoing: 2,
-  incoming: 3,
+  digest: 3,
+  incoming: 4,
 }
 
 function onHousekeepingTab() {
@@ -118,6 +132,11 @@ function onEmailStatsTab() {
   emailStatsBump.value = Date.now()
 }
 
+function onDigestClicksTab() {
+  showDigestClicks.value = true
+  digestClicksBump.value = Date.now()
+}
+
 function onIncomingEmailTab() {
   showIncomingEmail.value = true
   incomingEmailBump.value = Date.now()
@@ -131,6 +150,7 @@ onMounted(() => {
     if (tab === 'housekeeping') onHousekeepingTab()
     else if (tab === 'cronjobs') onCronJobsTab()
     else if (tab === 'outgoing') onEmailStatsTab()
+    else if (tab === 'digest') onDigestClicksTab()
     else if (tab === 'incoming') onIncomingEmailTab()
   } else {
     // Default to showing housekeeping

--- a/iznik-nuxt3/modtools/stores/emailtracking.js
+++ b/iznik-nuxt3/modtools/stores/emailtracking.js
@@ -68,6 +68,11 @@ export const useEmailTrackingStore = defineStore({
     bounceEntries: [],
     bounceLoading: false,
     bounceError: null,
+
+    // Digest click-through rate by post position.
+    digestPositions: [],
+    digestPositionsLoading: false,
+    digestPositionsError: null,
   }),
   actions: {
     init(config) {
@@ -87,6 +92,8 @@ export const useEmailTrackingStore = defineStore({
       this.clickedLinksError = null
       this.showAllClickedLinks = false
       this.aggregateClickedLinks = true
+      this.digestPositions = []
+      this.digestPositionsError = null
       this.userEmails = []
       this.userEmailsTotal = 0
       this.userEmailsError = null
@@ -192,6 +199,35 @@ export const useEmailTrackingStore = defineStore({
         console.error('Stats by type fetch error:', e)
       } finally {
         this.statsByTypeLoading = false
+      }
+    },
+
+    async fetchDigestPositions() {
+      this.digestPositionsLoading = true
+      this.digestPositionsError = null
+
+      try {
+        const params = {}
+        if (this.filters.type) {
+          params.type = this.filters.type
+        }
+        if (this.filters.start) {
+          params.start = this.filters.start
+        }
+        if (this.filters.end) {
+          params.end = this.filters.end
+        }
+
+        const response = await api(
+          this.config
+        ).emailtracking.fetchDigestPositions(params)
+        this.digestPositions = response.data || []
+      } catch (e) {
+        this.digestPositionsError =
+          e.message || 'Failed to fetch digest position stats'
+        console.error('Digest positions fetch error:', e)
+      } finally {
+        this.digestPositionsLoading = false
       }
     },
 
@@ -685,6 +721,26 @@ export const useEmailTrackingStore = defineStore({
       state.timeSeries.forEach((day) => {
         const date = new Date(day.date)
         data.push([date, day.sent])
+      })
+
+      return data
+    },
+
+    hasDigestPositions: (state) => state.digestPositions.length > 0,
+
+    // Digest position data formatted for Google Charts (ComboChart). Bars show
+    // the click-through rate at each position; the line shows the sample size
+    // (how many digests displayed a post at that position) for context.
+    digestPositionsChartData: (state) => {
+      if (!state.digestPositions.length) return null
+
+      const data = [['Position', 'Click-through rate (%)', 'Emails shown']]
+
+      state.digestPositions.forEach((p) => {
+        // Positions are zero-based internally; show a 1-based label to humans.
+        const label = String((p.position ?? 0) + 1)
+        const ctr = Math.round((p.ctr || 0) * 10) / 10
+        data.push([label, ctr, p.shown || 0])
       })
 
       return data

--- a/iznik-nuxt3/tests/unit/components/modtools/ModSysAdminDigestClicks.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModSysAdminDigestClicks.spec.js
@@ -1,0 +1,220 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+
+import ModSysAdminDigestClicks from '~/modtools/components/ModSysAdminDigestClicks.vue'
+
+// Mock email tracking store (only the bits this component touches).
+const mockEmailTrackingStore = {
+  digestPositions: [],
+  digestPositionsLoading: false,
+  digestPositionsError: null,
+  hasDigestPositions: false,
+  digestPositionsChartData: null,
+  setFilters: vi.fn(),
+  fetchDigestPositions: vi.fn().mockResolvedValue({}),
+}
+
+vi.mock('~/modtools/stores/emailtracking', () => ({
+  useEmailTrackingStore: () => mockEmailTrackingStore,
+}))
+
+vi.mock('#app', () => ({
+  useRuntimeConfig: () => ({ public: { apiUrl: 'http://test' } }),
+}))
+
+vi.mock('vue-google-charts', () => ({
+  GChart: {
+    template: '<div class="gchart" :data-type="type" />',
+    props: ['type', 'data', 'options'],
+  },
+}))
+
+describe('ModSysAdminDigestClicks', () => {
+  function mountComponent() {
+    return mount(ModSysAdminDigestClicks, {
+      global: {
+        stubs: {
+          NoticeMessage: {
+            template:
+              '<div class="notice-message" :class="variant"><slot /></div>',
+            props: ['variant'],
+          },
+          'b-form-select': {
+            template:
+              '<select :value="modelValue" @change="$emit(\'update:modelValue\', $event.target.value); $emit(\'change\', $event.target.value)"><slot /></select>',
+            props: ['modelValue', 'options', 'size'],
+          },
+          'b-spinner': { template: '<span class="spinner" />' },
+          'b-table': {
+            template: '<table class="table"><slot /></table>',
+            props: [
+              'items',
+              'fields',
+              'striped',
+              'hover',
+              'responsive',
+              'small',
+            ],
+          },
+          GChart: {
+            template: '<div class="gchart" :data-type="type" />',
+            props: ['type', 'data', 'options'],
+          },
+          ModEmailDateFilter: {
+            template: '<div class="date-filter" />',
+            props: ['loading', 'fetchLabel', 'defaultPreset'],
+          },
+        },
+      },
+    })
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockEmailTrackingStore.digestPositions = []
+    mockEmailTrackingStore.digestPositionsLoading = false
+    mockEmailTrackingStore.digestPositionsError = null
+    mockEmailTrackingStore.hasDigestPositions = false
+    mockEmailTrackingStore.digestPositionsChartData = null
+  })
+
+  describe('rendering', () => {
+    it('explains the click-through metric', () => {
+      const wrapper = mountComponent()
+      expect(wrapper.text()).toContain('click-through rate')
+    })
+
+    it('renders the date filter', () => {
+      const wrapper = mountComponent()
+      expect(wrapper.find('.date-filter').exists()).toBe(true)
+    })
+
+    it('shows the empty message when there is no data', () => {
+      const wrapper = mountComponent()
+      expect(wrapper.text()).toContain('No digest click data available')
+    })
+
+    it('shows the chart when data is present', async () => {
+      mockEmailTrackingStore.hasDigestPositions = true
+      mockEmailTrackingStore.digestPositionsChartData = [
+        ['Position', 'Click-through rate (%)', 'Emails shown'],
+        ['1', 50, 100],
+      ]
+      const wrapper = mountComponent()
+      await wrapper.vm.$nextTick()
+      expect(wrapper.find('.gchart').exists()).toBe(true)
+      expect(wrapper.find('.gchart').attributes('data-type')).toBe('ComboChart')
+    })
+
+    it('shows an error message when the store has an error', async () => {
+      mockEmailTrackingStore.digestPositionsError = 'boom'
+      const wrapper = mountComponent()
+      await wrapper.vm.$nextTick()
+      expect(wrapper.text()).toContain('boom')
+    })
+  })
+
+  describe('digest type options', () => {
+    it('offers All / Immediate / Daily', () => {
+      const wrapper = mountComponent()
+      const options = wrapper.vm.digestTypeOptions
+      expect(options).toContainEqual({ text: 'All digests', value: '' })
+      expect(options).toContainEqual({
+        text: 'Immediate',
+        value: 'UnifiedDigestImmediate',
+      })
+      expect(options).toContainEqual({
+        text: 'Daily',
+        value: 'UnifiedDigestDaily',
+      })
+    })
+  })
+
+  describe('tableRows', () => {
+    it('formats positions as 1-based and CTR as a percentage', () => {
+      mockEmailTrackingStore.digestPositions = [
+        { position: 0, shown: 1000, clicks: 520, emails_clicked: 500, ctr: 50 },
+        { position: 1, shown: 1000, clicks: 260, emails_clicked: 250, ctr: 25 },
+      ]
+      const wrapper = mountComponent()
+      const rows = wrapper.vm.tableRows
+      expect(rows[0].position).toBe(1)
+      expect(rows[0].ctr).toBe('50.0%')
+      expect(rows[0].shown).toBe('1,000')
+      expect(rows[1].position).toBe(2)
+      expect(rows[1].ctr).toBe('25.0%')
+    })
+  })
+
+  describe('insight', () => {
+    it('is null with fewer than two positions', () => {
+      mockEmailTrackingStore.digestPositions = [
+        { position: 0, shown: 10, clicks: 5, emails_clicked: 5, ctr: 50 },
+      ]
+      const wrapper = mountComponent()
+      expect(wrapper.vm.insight).toBeNull()
+    })
+
+    it('describes the drop from the top position to the last', () => {
+      mockEmailTrackingStore.digestPositions = [
+        { position: 0, shown: 100, clicks: 80, emails_clicked: 80, ctr: 80 },
+        { position: 2, shown: 100, clicks: 20, emails_clicked: 20, ctr: 20 },
+      ]
+      const wrapper = mountComponent()
+      const text = wrapper.vm.insight
+      expect(text).toContain('80.0%')
+      expect(text).toContain('20.0%')
+      expect(text).toContain('position 3')
+      expect(text).toContain('75% lower')
+    })
+
+    it('is null when there is no drop (flat or rising)', () => {
+      mockEmailTrackingStore.digestPositions = [
+        { position: 0, shown: 100, clicks: 20, emails_clicked: 20, ctr: 20 },
+        { position: 1, shown: 100, clicks: 30, emails_clicked: 30, ctr: 30 },
+      ]
+      const wrapper = mountComponent()
+      expect(wrapper.vm.insight).toBeNull()
+    })
+  })
+
+  describe('chart options', () => {
+    it('returns a ComboChart configuration with two axes', () => {
+      const wrapper = mountComponent()
+      const options = wrapper.vm.getPositionChartOptions()
+      expect(options.seriesType).toBe('bars')
+      expect(options.vAxes[0].title).toBe('Click-through rate (%)')
+      expect(options.vAxes[1].title).toBe('Emails shown')
+      expect(options.series[1].type).toBe('line')
+    })
+  })
+
+  describe('fetching', () => {
+    it('onFilterFetch records the dates and fetches via the store', () => {
+      const wrapper = mountComponent()
+      wrapper.vm.onFilterFetch({ start: '2026-01-01', end: '2026-01-31' })
+
+      expect(mockEmailTrackingStore.setFilters).toHaveBeenCalledWith({
+        type: '',
+        start: '2026-01-01',
+        end: '2026-01-31',
+      })
+      expect(mockEmailTrackingStore.fetchDigestPositions).toHaveBeenCalled()
+    })
+
+    it('onTypeChange refetches only once dates are known', () => {
+      const wrapper = mountComponent()
+
+      // No dates yet → should not fetch.
+      wrapper.vm.onTypeChange()
+      expect(mockEmailTrackingStore.fetchDigestPositions).not.toHaveBeenCalled()
+
+      // After a fetch sets the dates → type change refetches.
+      wrapper.vm.onFilterFetch({ start: '2026-01-01', end: '2026-01-31' })
+      mockEmailTrackingStore.fetchDigestPositions.mockClear()
+      wrapper.vm.digestType = 'UnifiedDigestDaily'
+      wrapper.vm.onTypeChange()
+      expect(mockEmailTrackingStore.fetchDigestPositions).toHaveBeenCalled()
+    })
+  })
+})

--- a/iznik-nuxt3/tests/unit/stores/emailtracking-digestpositions.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/emailtracking-digestpositions.spec.js
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+// Mock the API factory used by the store. api(config).emailtracking.fetchDigestPositions(params)
+const fetchDigestPositions = vi.fn()
+vi.mock('~/api', () => ({
+  default: () => ({
+    emailtracking: { fetchDigestPositions },
+  }),
+}))
+
+describe('emailtracking store — digest positions', () => {
+  let useEmailTrackingStore
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    setActivePinia(createPinia())
+    const mod = await import('~/modtools/stores/emailtracking')
+    useEmailTrackingStore = mod.useEmailTrackingStore
+  })
+
+  describe('digestPositionsChartData getter', () => {
+    it('returns null when there are no positions', () => {
+      const store = useEmailTrackingStore()
+      expect(store.digestPositionsChartData).toBeNull()
+    })
+
+    it('builds a ComboChart 2D array with 1-based labels and rounded CTR', () => {
+      const store = useEmailTrackingStore()
+      store.digestPositions = [
+        { position: 0, shown: 1000, clicks: 520, emails_clicked: 500, ctr: 50 },
+        {
+          position: 1,
+          shown: 1000,
+          clicks: 260,
+          emails_clicked: 250,
+          ctr: 25.04,
+        },
+      ]
+
+      expect(store.digestPositionsChartData).toEqual([
+        ['Position', 'Click-through rate (%)', 'Emails shown'],
+        ['1', 50, 1000],
+        ['2', 25, 1000],
+      ])
+    })
+  })
+
+  describe('hasDigestPositions getter', () => {
+    it('is false when empty and true when populated', () => {
+      const store = useEmailTrackingStore()
+      expect(store.hasDigestPositions).toBe(false)
+      store.digestPositions = [
+        { position: 0, shown: 1, clicks: 1, emails_clicked: 1, ctr: 100 },
+      ]
+      expect(store.hasDigestPositions).toBe(true)
+    })
+  })
+
+  describe('fetchDigestPositions action', () => {
+    it('stores the response data and clears the loading flag', async () => {
+      const rows = [
+        { position: 0, shown: 10, clicks: 5, emails_clicked: 5, ctr: 50 },
+      ]
+      fetchDigestPositions.mockResolvedValueOnce({ data: rows })
+
+      const store = useEmailTrackingStore()
+      store.setFilters({ type: 'UnifiedDigestDaily', start: 'a', end: 'b' })
+      await store.fetchDigestPositions()
+
+      expect(fetchDigestPositions).toHaveBeenCalledWith({
+        type: 'UnifiedDigestDaily',
+        start: 'a',
+        end: 'b',
+      })
+      expect(store.digestPositions).toEqual(rows)
+      expect(store.digestPositionsLoading).toBe(false)
+      expect(store.digestPositionsError).toBeNull()
+    })
+
+    it('records an error when the API rejects', async () => {
+      fetchDigestPositions.mockRejectedValueOnce(new Error('nope'))
+
+      const store = useEmailTrackingStore()
+      await store.fetchDigestPositions()
+
+      expect(store.digestPositionsError).toBe('nope')
+      expect(store.digestPositionsLoading).toBe(false)
+    })
+  })
+})

--- a/iznik-server-go/emailtracking/emailtracking.go
+++ b/iznik-server-go/emailtracking/emailtracking.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -1336,4 +1337,190 @@ func isValidRedirectURL(url string) bool {
 
 	// Reject URLs not matching our domains
 	return false
+}
+
+// DigestPositionStat represents the click-through rate for a single post
+// position within unified digest emails.
+type DigestPositionStat struct {
+	// Position is the zero-based ordinal of the post within the digest (0 = top).
+	Position int `json:"position"`
+	// Shown is the number of digest emails that displayed a post at this position.
+	Shown int64 `json:"shown"`
+	// EmailsClicked is the number of distinct digest emails with at least one
+	// click at this position (the click-through numerator).
+	EmailsClicked int64 `json:"emails_clicked"`
+	// Clicks is the total number of clicks recorded at this position.
+	Clicks int64 `json:"clicks"`
+	// CTR is the click-through rate (EmailsClicked / Shown) as a percentage.
+	CTR float64 `json:"ctr"`
+}
+
+// DigestClickPositions returns the click-through rate by post position within
+// unified digest emails. This shows how a post's vertical position in the
+// digest affects whether recipients click it.
+//
+// The metric is derived entirely from existing tracking data:
+//   - The denominator ("shown") comes from email_tracking.metadata.post_msgids,
+//     an ordered array of the msgids rendered in each digest. A digest with K
+//     posts shows positions 0..K-1, so position N was shown by every digest with
+//     more than N posts.
+//   - The numerator comes from email_tracking_clicks.link_position labels of the
+//     form "post_N", counting the distinct digest emails that registered a click
+//     at each position.
+//
+// Both sides are restricted to the same cohort (digests sent in the period, with
+// metadata, excluding Trash Nothing recipients) so the CTR never exceeds 100%.
+//
+// @Router /email/stats/digestpositions [get]
+// @Summary Get digest click-through rate by post position
+// @Description Returns click-through rate per post position within unified digests, for analysing how position affects engagement (Support/Admin only)
+// @Tags emailtracking
+// @Produce json
+// @Security BearerAuth
+// @Param start query string false "Start date (YYYY-MM-DD)"
+// @Param end query string false "End date (YYYY-MM-DD)"
+// @Param type query string false "Email type filter (default: all UnifiedDigest* types)"
+// @Success 200 {object} map[string]interface{}
+// @Failure 401 {object} fiber.Error "Unauthorized"
+// @Failure 403 {object} fiber.Error "Forbidden"
+func DigestClickPositions(c *fiber.Ctx) error {
+	db := database.DBConn
+
+	myid := user.WhoAmI(c)
+	if myid == 0 {
+		return fiber.NewError(fiber.StatusUnauthorized, "Not logged in")
+	}
+
+	// Check if user has support/admin role
+	if !auth.IsAdminOrSupport(myid) {
+		return fiber.NewError(fiber.StatusForbidden, "Support or Admin role required")
+	}
+
+	startDate := c.Query("start", "")
+	endDate := c.Query("end", "")
+
+	// Default to the last 30 days when no range is supplied.
+	if startDate == "" || endDate == "" {
+		now := time.Now()
+		endDate = now.Format("2006-01-02")
+		startDate = now.AddDate(0, 0, -30).Format("2006-01-02")
+	}
+
+	// If endDate doesn't include a time component, extend it to end of day.
+	endDateTime := endDate
+	if !strings.Contains(endDate, " ") && !strings.Contains(endDate, "T") {
+		endDateTime = endDate + " 23:59:59"
+	}
+
+	// By default consider all unified digest types; allow an exact-type override.
+	emailType := c.Query("type", "")
+	typeClause := "e.email_type LIKE 'UnifiedDigest%'"
+	var typeArgs []interface{}
+	if emailType != "" {
+		typeClause = "e.email_type = ?"
+		typeArgs = append(typeArgs, emailType)
+	}
+
+	// Conditions shared by both queries to keep the cohort consistent.
+	cohort := typeClause + `
+		AND u.tnuserid IS NULL
+		AND e.metadata IS NOT NULL
+		AND JSON_LENGTH(e.metadata, '$.post_msgids') > 0
+		AND e.sent_at BETWEEN ? AND ?`
+
+	// 1. Denominator: distribution of digest sizes. A digest with `num_posts`
+	//    posts displayed positions 0..num_posts-1.
+	denomQuery := `
+		SELECT JSON_LENGTH(e.metadata, '$.post_msgids') AS num_posts, COUNT(*) AS cnt
+		FROM email_tracking e
+		LEFT JOIN users u ON e.userid = u.id
+		WHERE ` + cohort + `
+		GROUP BY num_posts`
+	denomArgs := append(append([]interface{}{}, typeArgs...), startDate, endDateTime)
+
+	var sizeRows []struct {
+		NumPosts int   `gorm:"column:num_posts"`
+		Cnt      int64 `gorm:"column:cnt"`
+	}
+	db.Raw(denomQuery, denomArgs...).Scan(&sizeRows)
+
+	maxPosts := 0
+	for _, r := range sizeRows {
+		if r.NumPosts > maxPosts {
+			maxPosts = r.NumPosts
+		}
+	}
+
+	// shown[n] = number of digests whose size was greater than n (i.e. displayed
+	// a post at position n). sizeRows is small (one row per distinct digest size).
+	shown := make([]int64, maxPosts)
+	for _, r := range sizeRows {
+		for n := 0; n < r.NumPosts && n < maxPosts; n++ {
+			shown[n] += r.Cnt
+		}
+	}
+
+	// 2. Numerator: clicks on post_N links, grouped by position label.
+	clickQuery := `
+		SELECT c.link_position AS link_position,
+		       COUNT(DISTINCT c.email_tracking_id) AS emails_clicked,
+		       COUNT(*) AS clicks
+		FROM email_tracking_clicks c
+		JOIN email_tracking e ON c.email_tracking_id = e.id
+		LEFT JOIN users u ON e.userid = u.id
+		WHERE ` + cohort + `
+		  AND c.link_position REGEXP '^post_[0-9]+$'
+		GROUP BY c.link_position`
+	clickArgs := append(append([]interface{}{}, typeArgs...), startDate, endDateTime)
+
+	var clickRows []struct {
+		LinkPosition  string `gorm:"column:link_position"`
+		EmailsClicked int64  `gorm:"column:emails_clicked"`
+		Clicks        int64  `gorm:"column:clicks"`
+	}
+	db.Raw(clickQuery, clickArgs...).Scan(&clickRows)
+
+	emailsClickedByPos := make(map[int]int64)
+	clicksByPos := make(map[int]int64)
+	for _, r := range clickRows {
+		// link_position is "post_N"; extract the integer position.
+		idx := strings.LastIndex(r.LinkPosition, "_")
+		if idx < 0 || idx+1 >= len(r.LinkPosition) {
+			continue
+		}
+		n, err := strconv.Atoi(r.LinkPosition[idx+1:])
+		if err != nil || n < 0 {
+			continue
+		}
+		emailsClickedByPos[n] += r.EmailsClicked
+		clicksByPos[n] += r.Clicks
+	}
+
+	// 3. Build the per-position result, ascending, skipping positions never shown.
+	data := make([]DigestPositionStat, 0, maxPosts)
+	for n := 0; n < maxPosts; n++ {
+		if shown[n] <= 0 {
+			continue
+		}
+		var ctr float64
+		if shown[n] > 0 {
+			ctr = float64(emailsClickedByPos[n]) / float64(shown[n]) * 100
+		}
+		data = append(data, DigestPositionStat{
+			Position:      n,
+			Shown:         shown[n],
+			EmailsClicked: emailsClickedByPos[n],
+			Clicks:        clicksByPos[n],
+			CTR:           ctr,
+		})
+	}
+
+	return c.JSON(fiber.Map{
+		"data": data,
+		"period": fiber.Map{
+			"start": startDate,
+			"end":   endDate,
+			"type":  emailType,
+		},
+	})
 }

--- a/iznik-server-go/router/routes.go
+++ b/iznik-server-go/router/routes.go
@@ -1264,6 +1264,21 @@ func SetupRoutes(app *fiber.App) {
 		// @Failure 403 {object} fiber.Error "Forbidden"
 		rg.Get("/modtools/email/stats/clicks", emailtracking.TopClickedLinks)
 
+		// Digest Click Positions (authenticated, admin only)
+		// @Router /email/stats/digestpositions [get]
+		// @Summary Get digest click-through rate by post position
+		// @Description Returns click-through rate per post position within unified digests, for analysing how position affects engagement
+		// @Tags emailtracking
+		// @Produce json
+		// @Security BearerAuth
+		// @Param start query string false "Start date (YYYY-MM-DD)"
+		// @Param end query string false "End date (YYYY-MM-DD)"
+		// @Param type query string false "Email type filter (default: all UnifiedDigest* types)"
+		// @Success 200 {object} map[string]interface{}
+		// @Failure 401 {object} fiber.Error "Unauthorized"
+		// @Failure 403 {object} fiber.Error "Forbidden"
+		rg.Get("/modtools/email/stats/digestpositions", emailtracking.DigestClickPositions)
+
 		// Email Tracking for specific user (authenticated, admin only)
 		// @Router /email/user/{id} [get]
 		// @Summary Get email tracking for a user

--- a/iznik-server-go/test/emailtracking_digestpositions_test.go
+++ b/iznik-server-go/test/emailtracking_digestpositions_test.go
@@ -1,0 +1,204 @@
+package test
+
+import (
+	json2 "encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/freegle/iznik-server-go/emailtracking"
+	"github.com/stretchr/testify/assert"
+)
+
+// =============================================================================
+// Helpers for digest click-position tests
+// =============================================================================
+
+// dpSeq keeps generated tracking_id values unique within a test run.
+var dpSeq int
+
+// createDigestTrackingRecord creates a digest email_tracking row whose metadata
+// records `numPosts` ordered post msgids (positions 0..numPosts-1 were shown).
+func createDigestTrackingRecord(t *testing.T, emailType string, sentAt time.Time, numPosts int) uint64 {
+	db := database.DBConn
+
+	dpSeq++
+	shortID := fmt.Sprintf("dp%d-%d", dpSeq, time.Now().UnixNano())
+	if len(shortID) > 32 {
+		shortID = shortID[:32]
+	}
+
+	// Build a post_msgids array of the requested length; the values are
+	// irrelevant — only the length (== number of positions shown) matters.
+	msgids := make([]string, numPosts)
+	for i := range msgids {
+		msgids[i] = fmt.Sprintf("%d", i+1)
+	}
+	meta := fmt.Sprintf(`{"post_msgids":[%s],"digest_number":1}`, strings.Join(msgids, ","))
+
+	tracking := &emailtracking.EmailTracking{
+		TrackingID:     shortID,
+		EmailType:      emailType,
+		RecipientEmail: "dp@example.com",
+		SentAt:         &sentAt,
+		Metadata:       &meta,
+	}
+	result := db.Create(tracking)
+	assert.NoError(t, result.Error)
+	return tracking.ID
+}
+
+// createPositionClick records a click at a specific link_position label.
+func createPositionClick(t *testing.T, trackingID uint64, position string, clickedAt time.Time) {
+	db := database.DBConn
+	pos := position
+	click := &emailtracking.EmailTrackingClick{
+		EmailTrackingID: trackingID,
+		LinkURL:         "https://example.com/message/1",
+		LinkPosition:    &pos,
+		ClickedAt:       clickedAt,
+	}
+	result := db.Create(click)
+	assert.NoError(t, result.Error)
+}
+
+// uniqueDigestType returns an email_type unique to this test run so the
+// computed counts are isolated from any other digest data in the test DB.
+func uniqueDigestType() string {
+	dpSeq++
+	return fmt.Sprintf("UDPT%d%d", dpSeq, time.Now().UnixNano()%1000000)
+}
+
+// =============================================================================
+// Tests for GET /api/modtools/email/stats/digestpositions
+// =============================================================================
+
+func TestDigestPositions_Unauthorized(t *testing.T) {
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/modtools/email/stats/digestpositions", nil))
+	assert.Equal(t, 401, resp.StatusCode)
+}
+
+func TestDigestPositions_ForbiddenForRegularUser(t *testing.T) {
+	prefix := uniquePrefix("dpforbid")
+	userID := CreateTestUser(t, prefix, "User")
+	_, token := CreateTestSession(t, userID)
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/modtools/email/stats/digestpositions?jwt="+token, nil))
+	assert.Equal(t, 403, resp.StatusCode)
+}
+
+func TestDigestPositions_SupportUserAccess(t *testing.T) {
+	prefix := uniquePrefix("dpsupport")
+	userID := CreateTestUser(t, prefix, "Support")
+	_, token := CreateTestSession(t, userID)
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/modtools/email/stats/digestpositions?jwt="+token, nil))
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json2.Unmarshal(rsp(resp), &result)
+	assert.NotNil(t, result["data"])
+	assert.NotNil(t, result["period"])
+}
+
+// TestDigestPositions_CTRByPosition verifies the core metric: click-through rate
+// per post position, with a non-post (summary) click correctly ignored.
+func TestDigestPositions_CTRByPosition(t *testing.T) {
+	prefix := uniquePrefix("dpctr")
+	userID := CreateTestUser(t, prefix, "Support")
+	_, token := CreateTestSession(t, userID)
+
+	now := time.Now()
+	etype := uniqueDigestType()
+
+	// Four digests, each showing three posts (positions 0,1,2 → shown = 4 each).
+	idA := createDigestTrackingRecord(t, etype, now, 3)
+	idB := createDigestTrackingRecord(t, etype, now, 3)
+	idC := createDigestTrackingRecord(t, etype, now, 3)
+	idD := createDigestTrackingRecord(t, etype, now, 3)
+	defer cleanupTestTrackingByID([]uint64{idA, idB, idC, idD})
+
+	// post_0 clicked in A and B; post_1 clicked in C; D only has a summary click.
+	createPositionClick(t, idA, "post_0", now)
+	createPositionClick(t, idB, "post_0", now)
+	createPositionClick(t, idC, "post_1", now)
+	createPositionClick(t, idD, "summary_0", now) // must NOT count towards post_0
+
+	start := now.AddDate(0, 0, -1).Format("2006-01-02")
+	end := now.AddDate(0, 0, 1).Format("2006-01-02")
+
+	url := "/api/modtools/email/stats/digestpositions?jwt=" + token + "&type=" + etype + "&start=" + start + "&end=" + end
+	resp, _ := getApp().Test(httptest.NewRequest("GET", url, nil))
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json2.Unmarshal(rsp(resp), &result)
+	data, ok := result["data"].([]interface{})
+	assert.True(t, ok)
+	assert.Equal(t, 3, len(data)) // positions 0, 1, 2
+
+	p0 := data[0].(map[string]interface{})
+	assert.Equal(t, float64(0), p0["position"])
+	assert.Equal(t, float64(4), p0["shown"])
+	assert.Equal(t, float64(2), p0["emails_clicked"])
+	assert.InDelta(t, 50.0, p0["ctr"].(float64), 0.01)
+
+	p1 := data[1].(map[string]interface{})
+	assert.Equal(t, float64(1), p1["position"])
+	assert.Equal(t, float64(4), p1["shown"])
+	assert.Equal(t, float64(1), p1["emails_clicked"])
+	assert.InDelta(t, 25.0, p1["ctr"].(float64), 0.01)
+
+	p2 := data[2].(map[string]interface{})
+	assert.Equal(t, float64(2), p2["position"])
+	assert.Equal(t, float64(4), p2["shown"])
+	assert.Equal(t, float64(0), p2["emails_clicked"])
+	assert.InDelta(t, 0.0, p2["ctr"].(float64), 0.01)
+}
+
+// TestDigestPositions_CumulativeShownAcrossSizes verifies that the "shown"
+// denominator is cumulative: a digest with K posts contributes to positions 0..K-1.
+func TestDigestPositions_CumulativeShownAcrossSizes(t *testing.T) {
+	prefix := uniquePrefix("dpcum")
+	userID := CreateTestUser(t, prefix, "Support")
+	_, token := CreateTestSession(t, userID)
+
+	now := time.Now()
+	etype := uniqueDigestType()
+
+	// One digest with 2 posts, one with 4 posts.
+	// shown[0]=2, shown[1]=2, shown[2]=1, shown[3]=1.
+	idSmall := createDigestTrackingRecord(t, etype, now, 2)
+	idBig := createDigestTrackingRecord(t, etype, now, 4)
+	defer cleanupTestTrackingByID([]uint64{idSmall, idBig})
+
+	// Click at the deepest position (post_3), only present in the big digest.
+	createPositionClick(t, idBig, "post_3", now)
+
+	start := now.AddDate(0, 0, -1).Format("2006-01-02")
+	end := now.AddDate(0, 0, 1).Format("2006-01-02")
+
+	url := "/api/modtools/email/stats/digestpositions?jwt=" + token + "&type=" + etype + "&start=" + start + "&end=" + end
+	resp, _ := getApp().Test(httptest.NewRequest("GET", url, nil))
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json2.Unmarshal(rsp(resp), &result)
+	data := result["data"].([]interface{})
+	assert.Equal(t, 4, len(data)) // positions 0..3
+
+	p0 := data[0].(map[string]interface{})
+	assert.Equal(t, float64(2), p0["shown"])
+
+	p2 := data[2].(map[string]interface{})
+	assert.Equal(t, float64(1), p2["shown"])
+
+	p3 := data[3].(map[string]interface{})
+	assert.Equal(t, float64(3), p3["position"])
+	assert.Equal(t, float64(1), p3["shown"])
+	assert.Equal(t, float64(1), p3["emails_clicked"])
+	assert.InDelta(t, 100.0, p3["ctr"].(float64), 0.01)
+}


### PR DESCRIPTION
## Summary

- Adds a new **Digest Clicks** sysadmin tab that visualises **click-through rate by post position** within the unified digest — answering "how far down the digest do people actually click?".
- The digest already records per-link positions (`email_tracking_clicks.link_position = post_N`) and the ordered list of posts shown (`email_tracking.metadata.post_msgids`); this surfaces that data as a graph for the first time.
- **Backend (Go):** new `GET /api/modtools/email/stats/digestpositions` (Support/Admin only).
  - `CTR[N] = (distinct digests with a click at post_N) / (digests that displayed a post at position N)`.
  - Denominator is derived from the `post_msgids` array length: a digest with K posts displayed positions `0..K-1`, so `shown[N]` is the count of digests with more than N posts (cumulative).
  - Numerator counts distinct digest emails with a `post_N` click (`link_position REGEXP '^post_[0-9]+$'`).
  - Both sides share the same cohort (digests sent in range, with metadata, excluding Trash Nothing recipients), so CTR never exceeds 100%.
- **Frontend:** `EmailTrackingAPI.fetchDigestPositions` → `useEmailTrackingStore` action + getter → `ModSysAdminDigestClicks.vue`:
  - A Google **ComboChart**: bars = click-through rate per position, dashed line = "emails shown" (sample size) on a secondary axis for context.
  - A detail table (position, emails shown, total clicks, clicked, CTR) and a plain-English insight summarising the drop from top to bottom.
  - Reuses the existing `ModEmailDateFilter` (period + Immediate/Daily digest type).

## Validation

- Verified end-to-end against the running Go API with seeded data: CTR falls from ~43% at the top toward low single digits deeper down, and "emails shown" correctly decreases for deeper positions (fewer digests are that long). Screenshot shared with the team.

## Code Quality Review

- New endpoint mirrors the existing `email/stats/*` handlers (auth via `WhoAmI` + `IsAdminOrSupport`, raw SQL, `fiber.Map` response with `period` echo). No changes to existing handlers.
- Frontend additions are purely additive: new store state/action/getter, new API method, new component, one new sysadmin tab. The only existing spec touching this store (`ModSupportEmailStats.spec.js`) mocks the store and is unaffected.
- No new dependencies. SCSS in the new component is plain nested rules (no variables/mixins).
- Position is parsed from the `post_N` label defensively (`strconv.Atoi` with bounds checks); non-`post_` links (summary/group) are excluded.

## Future Improvements

- Optionally expose `summary_N` (top-of-digest index links) and image scroll positions (`email_tracking_images`) as additional position views.
- The endpoint could accept a `position_type` param to compare card clicks vs summary clicks.

## Test Plan

- **Go (5 new integration tests, full suite 3167 passed / 0 failed):** exact CTR math (50%/25%/0% with a summary click correctly ignored), cumulative `shown` denominator across mixed digest sizes, Support access, 401 unauthorized, 403 for non-admins.
- **Vitest (18 new; broader modtools suite 4539 passed / 0 failed):** component rendering (chart/empty/error states, type options, table formatting, insight, fetch wiring) and store getter/action.
- **Lint:** eslint clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
