### PR TITLE
fix(web): make leave-Freegle removal notice prominent, mute the buttons

### DIFF
--- a/iznik-nuxt3/pages/unsubscribe/[[id]].vue
+++ b/iznik-nuxt3/pages/unsubscribe/[[id]].vue
@@ -37,19 +37,32 @@
               />
             </div>
 
-            <NoticeMessage v-if="left" class="mb-3" variant="info">
+            <NoticeMessage
+              v-if="left"
+              class="mb-3 fs-4 fw-bold"
+              variant="success"
+            >
               We've removed you from {{ left }}.
             </NoticeMessage>
 
             <div v-if="!groupid" class="mobile-section">
               <p class="mobile-section__label">Or choose an option:</p>
               <div class="mobile-actions">
-                <NuxtLink to="/settings" class="mobile-btn mobile-btn--primary">
+                <NuxtLink
+                  to="/settings"
+                  :class="[
+                    'mobile-btn',
+                    left ? 'mobile-btn--white' : 'mobile-btn--primary',
+                  ]"
+                >
                   <v-icon icon="cog" class="me-2" />
                   Get fewer emails
                 </NuxtLink>
                 <button
-                  class="mobile-btn mobile-btn--danger"
+                  :class="[
+                    'mobile-btn',
+                    left ? 'mobile-btn--white' : 'mobile-btn--danger',
+                  ]"
                   @click="unsubscribe"
                 >
                   <v-icon icon="trash-alt" class="me-2" />
@@ -150,7 +163,11 @@
                   />
                 </div>
               </div>
-              <NoticeMessage v-if="left" class="mt-2 mb-2" variant="info">
+              <NoticeMessage
+                v-if="left"
+                class="mt-2 mb-3 fs-4 fw-bold"
+                variant="success"
+              >
                 We've removed you from {{ left }}.
               </NoticeMessage>
               <template v-if="!groupid">
@@ -160,14 +177,18 @@
                 </p>
                 <div class="d-flex justify-content-between flex-wrap">
                   <nuxt-link to="/settings" no-prefetch>
-                    <b-button size="lg" variant="primary" class="mb-2 me-2">
+                    <b-button
+                      size="lg"
+                      :variant="left ? 'light' : 'primary'"
+                      class="mb-2 me-2"
+                    >
                       <v-icon icon="cog" />
                       <span class="ms-1"> Get fewer emails </span>
                     </b-button>
                   </nuxt-link>
                   <b-button
                     size="lg"
-                    variant="danger"
+                    :variant="left ? 'light' : 'danger'"
                     class="mb-2"
                     @click="unsubscribe"
                   >


### PR DESCRIPTION
## What

On the unsubscribe / "Want to leave Freegle?" page, the **"We've removed you from X"** confirmation was a small pale-blue *info* notice, while the red **Delete your account** button drew the eye — risking accidental account deletion when the user had already done what they came to do.

## Change

- The removal notice is now **large, bold and success-styled** so it's the focal point.
- While that notice is showing (`left` is set), both action buttons (**Get fewer emails** / **Delete your account**) are **muted to white** instead of green/red.
- Applied to both the **mobile** and **desktop** layouts.

Easy to tweak in review — e.g. if you'd prefer the notice red rather than green, or a bordered (outline) white button rather than `light`. The Netlify deploy preview renders it; the styled state shows after you leave a group from the dropdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)