### PR TITLE
feat(batch): restore volunteering renewal + expiry maintenance (migrate from V1 cron)

### DIFF
--- a/iznik-batch/app/Console/Commands/Volunteering/MaintainVolunteeringCommand.php
+++ b/iznik-batch/app/Console/Commands/Volunteering/MaintainVolunteeringCommand.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Console\Commands\Volunteering;
+
+use App\Services\VolunteeringMaintenanceService;
+use App\Traits\LogsBatchJob;
+use Illuminate\Console\Command;
+
+class MaintainVolunteeringCommand extends Command
+{
+    use LogsBatchJob;
+
+    protected $signature = 'volunteering:maintain
+                            {--dry-run : Report what would change without emailing or expiring}';
+
+    protected $description = 'Ask owners of dateless volunteering opportunities to renew, and expire stale ones';
+
+    public function handle(VolunteeringMaintenanceService $service): int
+    {
+        $dryRun = (bool) $this->option('dry-run');
+
+        if ($dryRun) {
+            $this->info('DRY RUN — no emails will be sent and nothing will be expired.');
+        }
+
+        return $this->runWithLogging(function () use ($service, $dryRun) {
+            // V1 order (cron/volunteering.php): askRenew() then expire(). The ~7-day
+            // gap between ASK_AGE (24) and EXPIRE_AGE (31) means owners are warned
+            // about a week before an opportunity would expire.
+            $asked = $service->askRenew(null, $dryRun);
+            $expired = $service->expire(null, $dryRun);
+
+            if ($dryRun) {
+                $this->info("Would ask {$asked} owner(s) to renew; would expire {$expired} opportunities.");
+            } else {
+                $this->info("Asked {$asked} owner(s) to renew; expired {$expired} opportunities.");
+            }
+
+            return Command::SUCCESS;
+        });
+    }
+}

--- a/iznik-batch/app/Mail/Volunteering/VolunteeringRenewMail.php
+++ b/iznik-batch/app/Mail/Volunteering/VolunteeringRenewMail.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Mail\Volunteering;
+
+use App\Mail\MjmlMailable;
+use Illuminate\Mail\Mailables\Address;
+use Illuminate\Mail\Mailables\Envelope;
+
+/**
+ * "Is this volunteer opportunity still active?" renewal request.
+ *
+ * Ported from iznik-server mailtemplates/volunteerrenew.php +
+ * Volunteering::askRenew(). Sent to the owner of a dateless opportunity that is
+ * approaching expiry; the "Let us know" button is an auto-login link to
+ * /volunteering/{id} where the owner can renew (Go API sets renewed=NOW(),
+ * expired=0).
+ */
+class VolunteeringRenewMail extends MjmlMailable
+{
+    public function __construct(
+        public readonly string $recipientEmail,
+        public readonly string $title,
+        public readonly string $renewUrl,
+        public readonly string $groupName,
+        public readonly ?int $userId = null,
+    ) {
+        parent::__construct();
+    }
+
+    protected function getSubject(): string
+    {
+        // Matches iznik-server Volunteering::askRenew(): "Regarding: {title}".
+        return 'Regarding: ' . $this->title;
+    }
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            from: new Address(
+                config('freegle.mail.noreply_addr', 'noreply@ilovefreegle.org'),
+                config('freegle.site_name', 'Freegle')
+            ),
+            to: [new Address($this->recipientEmail)],
+            subject: $this->getSubject(),
+        );
+    }
+
+    public function build(): static
+    {
+        // Attach the standard X-Freegle-* tracking and RFC 8058 List-Unsubscribe
+        // headers (the latter keyed off getRecipientUserId() below).
+        $this->configureMessage();
+
+        return $this->mjmlView('emails.mjml.volunteering.renew', [
+            'title'          => $this->title,
+            'renewUrl'       => $this->renewUrl,
+            'groupName'      => $this->groupName,
+            'email'          => $this->recipientEmail,
+            'unsubscribeUrl' => config('freegle.sites.user') . '/unsubscribe',
+        ]);
+    }
+
+    protected function getRecipientUserId(): ?int
+    {
+        return $this->userId;
+    }
+}

--- a/iznik-batch/app/Services/VolunteeringMaintenanceService.php
+++ b/iznik-batch/app/Services/VolunteeringMaintenanceService.php
@@ -1,0 +1,236 @@
+<?php
+
+namespace App\Services;
+
+use App\Mail\Volunteering\VolunteeringRenewMail;
+use App\Models\User;
+use App\Models\Volunteering;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Volunteering opportunity renewal + expiry maintenance.
+ *
+ * Ported from iznik-server Volunteering::askRenew() and Volunteering::expire()
+ * (include/group/Volunteering.php). The V1 weekly cron
+ * (scripts/cron/volunteering.php) ran askRenew() then expire() before emailing
+ * the digest. That cron was disabled ~2026-05-12 when digest emailing moved to
+ * Laravel (mail:volunteering-digest), but the renewal + expiry maintenance was
+ * never migrated — so dateless opportunities stopped being asked-to-renew and
+ * stopped being expired. This service restores that maintenance.
+ *
+ * "Active" = pending=0 AND deleted=0 AND expired=0. A dateless opportunity must
+ * be periodically renewed (owner clicks "still active" → renewed=NOW(),
+ * expired=0, handled in the Go API) to stay live.
+ */
+class VolunteeringMaintenanceService
+{
+    /** Days after which a dateless opportunity expires (iznik-server Volunteering::EXPIRE_AGE). */
+    public const EXPIRE_AGE = 31;
+
+    /**
+     * Days after which a dateless opportunity's owner is asked to renew. V1 used
+     * "Midnight 24 days ago", giving ~7 days' warning before EXPIRE_AGE.
+     */
+    public const ASK_AGE = 24;
+
+    /**
+     * Login-link source tag. V1 askRenew() used User::SRC_VOLUNTEERING_DIGEST
+     * ('voldigest') here — ported exactly. (A dedicated SRC_VOLUNTEERING_RENEWAL
+     * = 'volrenew' constant exists in V1 but askRenew() never used it.)
+     */
+    private const LOGIN_SRC = 'voldigest';
+
+    /**
+     * Email owners of dateless opportunities approaching expiry to ask whether the
+     * opportunity is still active.
+     *
+     * Ports iznik-server Volunteering::askRenew(): for opportunities with no end
+     * date, not deleted, not expired, added more than ASK_AGE days ago and not
+     * renewed within the last ASK_AGE days, email the owner.
+     *
+     * DELIBERATE IMPROVEMENT over V1: we stamp askedtorenew = NOW() after asking
+     * and gate the query on it, so a daily schedule asks ONCE per renewal cycle
+     * rather than re-emailing every run (V1 ran weekly and re-mailed every run
+     * inside the window).
+     *
+     * @param  int|null  $id      Restrict to a single opportunity (tests / manual runs).
+     * @param  bool       $dryRun  Count who would be asked without emailing or stamping.
+     * @return int  Number of renewal asks sent (or, in dry run, that would be sent).
+     */
+    public function askRenew(?int $id = null, bool $dryRun = false): int
+    {
+        $cutoff = Carbon::today()->subDays(self::ASK_AGE);
+
+        $ids = DB::table('volunteering')
+            ->leftJoin('volunteering_dates', 'volunteering.id', '=', 'volunteering_dates.volunteeringid')
+            ->whereNull('volunteering_dates.end')
+            ->where('volunteering.deleted', 0)
+            ->where('volunteering.expired', 0)
+            ->where('volunteering.added', '<', $cutoff)
+            ->where(function ($q) use ($cutoff) {
+                $q->whereNull('volunteering.renewed')
+                    ->orWhere('volunteering.renewed', '<', $cutoff);
+            })
+            // DELIBERATE IMPROVEMENT vs V1: don't re-ask within a renewal cycle.
+            ->where(function ($q) use ($cutoff) {
+                $q->whereNull('volunteering.askedtorenew')
+                    ->orWhere('volunteering.askedtorenew', '<', $cutoff);
+            })
+            ->when($id !== null, fn ($q) => $q->where('volunteering.id', $id))
+            ->distinct()
+            ->pluck('volunteering.id');
+
+        $count = 0;
+
+        foreach ($ids as $volId) {
+            $vol = Volunteering::find($volId);
+            if (!$vol) {
+                continue;
+            }
+
+            // V1 only mails when the owning user still exists and has an address.
+            $user = $vol->userid ? User::find($vol->userid) : null;
+            if (!$user) {
+                continue;
+            }
+
+            $email = $user->email_preferred;
+            if (!$email) {
+                continue;
+            }
+
+            if ($dryRun) {
+                $count++;
+                continue;
+            }
+
+            $url = $user->loginLink('/volunteering/' . $volId, self::LOGIN_SRC);
+
+            try {
+                app(EmailSpoolerService::class)->spool(new VolunteeringRenewMail(
+                    recipientEmail: $email,
+                    title: (string) $vol->title,
+                    renewUrl: $url,
+                    groupName: $this->groupNameFor((int) $volId),
+                    userId: (int) $user->id,
+                ), $email);
+            } catch (\Throwable $e) {
+                // spool() re-throws transient render/build errors; one bad
+                // recipient must not abort the whole run. askedtorenew is left
+                // unstamped so this opportunity is retried next run.
+                Log::warning('Skipping volunteering renewal ask after spool failure; continuing', [
+                    'volunteering_id' => $volId,
+                    'user_id' => $user->id,
+                    'error' => $e->getMessage(),
+                ]);
+                continue;
+            }
+
+            // Eloquent save() (not a bulk UPDATE) so model events fire for Auditing.
+            $vol->askedtorenew = now();
+            $vol->save();
+            $count++;
+        }
+
+        return $count;
+    }
+
+    /**
+     * Expire opportunities that are no longer current.
+     *
+     * Ports iznik-server Volunteering::expire():
+     *  (a) Opportunities WITH dates: expired once no date is still in the future.
+     *  (b) Dateless opportunities: expired once older than EXPIRE_AGE days and not
+     *      renewed within EXPIRE_AGE days.
+     *
+     * @param  int|null  $id      Restrict to a single opportunity (tests / manual runs).
+     * @param  bool       $dryRun  Count what would expire without changing any rows.
+     * @return int  Number of opportunities expired (or, in dry run, that would expire).
+     */
+    public function expire(?int $id = null, bool $dryRun = false): int
+    {
+        $count = 0;
+
+        // (a) Dated opportunities whose dates have all passed.
+        $datedIds = DB::table('volunteering')
+            ->join('volunteering_dates', 'volunteering.id', '=', 'volunteering_dates.volunteeringid')
+            ->where('volunteering_dates.end', '<=', now())
+            ->where('volunteering.expired', 0)
+            ->when($id !== null, fn ($q) => $q->where('volunteering.id', $id))
+            ->distinct()
+            ->pluck('volunteering.id');
+
+        foreach ($datedIds as $volId) {
+            $hasFuture = DB::table('volunteering_dates')
+                ->where('volunteeringid', $volId)
+                ->where('end', '>', now())
+                ->exists();
+
+            if (!$hasFuture && $this->markExpired((int) $volId, $dryRun)) {
+                $count++;
+            }
+        }
+
+        // (b) Dateless opportunities older than EXPIRE_AGE not renewed in EXPIRE_AGE days.
+        $cutoff = Carbon::today()->subDays(self::EXPIRE_AGE);
+
+        $datelessIds = DB::table('volunteering')
+            ->leftJoin('volunteering_dates', 'volunteering.id', '=', 'volunteering_dates.volunteeringid')
+            ->whereNull('volunteering_dates.end')
+            ->where('volunteering.expired', 0)
+            ->where('volunteering.added', '<', $cutoff)
+            ->where(function ($q) use ($cutoff) {
+                $q->whereNull('volunteering.renewed')
+                    ->orWhere('volunteering.renewed', '<', $cutoff);
+            })
+            ->when($id !== null, fn ($q) => $q->where('volunteering.id', $id))
+            ->distinct()
+            ->pluck('volunteering.id');
+
+        foreach ($datelessIds as $volId) {
+            if ($this->markExpired((int) $volId, $dryRun)) {
+                $count++;
+            }
+        }
+
+        return $count;
+    }
+
+    /**
+     * Mark a single opportunity expired via Eloquent (so Auditing fires), unless
+     * this is a dry run. Returns true if the row was (or would be) expired.
+     */
+    private function markExpired(int $volId, bool $dryRun): bool
+    {
+        $vol = Volunteering::find($volId);
+        if (!$vol) {
+            return false;
+        }
+
+        if ($dryRun) {
+            return true;
+        }
+
+        $vol->expired = true;
+        $vol->save();
+
+        return true;
+    }
+
+    /**
+     * Display name of a group the opportunity is posted on, defaulting to the
+     * site name. Mirrors V1's namedisplay (namefull if set, else nameshort).
+     */
+    private function groupNameFor(int $volId): string
+    {
+        $name = DB::table('volunteering_groups')
+            ->join('groups', 'groups.id', '=', 'volunteering_groups.groupid')
+            ->where('volunteering_groups.volunteeringid', $volId)
+            ->selectRaw("COALESCE(NULLIF(groups.namefull, ''), groups.nameshort) AS name")
+            ->value('name');
+
+        return $name ?: config('freegle.site_name', 'Freegle');
+    }
+}

--- a/iznik-batch/resources/views/emails/mjml/volunteering/renew.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/volunteering/renew.blade.php
@@ -1,0 +1,38 @@
+<mjml>
+  @include('emails.mjml.partials.head', ['preview' => 'Is your volunteer opportunity still active?'])
+
+  <mj-body background-color="#f4f4f4">
+
+    @include('emails.mjml.components.header')
+
+    <mj-section background-color="#ffffff" padding="20px 20px 10px">
+      <mj-column>
+        <mj-text font-size="22px" font-weight="bold" mj-class="text-success">
+          Your Volunteer Opportunity on {{ $groupName }}: {{ $title }}
+        </mj-text>
+        <mj-text font-size="14px" color="#555555" line-height="1.5">
+          Please can you let us know whether this volunteer opportunity is still active?
+          If we don't hear from you, we'll stop showing it soon. Don't forget to log in!
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+    <mj-section background-color="#ffffff" padding="0 20px 16px">
+      <mj-column>
+        <mj-button mj-class="btn-success" href="{{ $renewUrl }}" font-size="16px" border-radius="3px" align="left">
+          Let us know
+        </mj-button>
+        <mj-text font-size="12px" color="#999999" padding="8px 0 0">
+          If that's not clickable, copy and paste this into your browser:<br/>
+          <a href="{{ $renewUrl }}" style="color: #999999;">{{ $renewUrl }}</a>
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+    @include('emails.mjml.partials.footer', [
+      'unsubscribeUrl' => $unsubscribeUrl,
+      'email'          => $email,
+    ])
+
+  </mj-body>
+</mjml>

--- a/iznik-batch/routes/console.php
+++ b/iznik-batch/routes/console.php
@@ -995,6 +995,22 @@ Schedule::command('messages:update-index')
 //     ->sendOutputTo(cronLog('donations:update-giftaid'))
 //     ->runInBackground();
 
+// Volunteering opportunity maintenance — daily. Asks owners of dateless
+// opportunities approaching expiry whether they are still active (renewal
+// reminder), then expires opportunities whose dates have all passed or which
+// were never renewed within EXPIRE_AGE (31) days. Runs before the weekly
+// digest below so freshly-expired opportunities drop out of that run.
+// V1: cron/volunteering.php ran askRenew()+expire() weekly before emailing;
+// that cron was disabled 2026-05-12 when Laravel took over the digest, but the
+// renewal+expiry maintenance was never migrated — nothing renewed or expired
+// dateless opportunities since. Daily (vs V1 weekly) is safe because askRenew()
+// now stamps askedtorenew and won't re-ask within a renewal cycle.
+Schedule::command('volunteering:maintain')
+    ->dailyAt('22:00')
+    ->withoutOverlapping()
+    ->sendOutputTo(cronLog('volunteering:maintain'))
+    ->runInBackground();
+
 // Volunteering opportunity roundup — weekly, ONE combined email per user
 // covering every volunteering-enabled group they belong to (plus global
 // opportunities), deduplicated. A per-user cadence guard (users_digests

--- a/iznik-batch/tests/Feature/Volunteering/MaintainVolunteeringCommandTest.php
+++ b/iznik-batch/tests/Feature/Volunteering/MaintainVolunteeringCommandTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Tests\Feature\Volunteering;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Mail;
+use Tests\TestCase;
+
+class MaintainVolunteeringCommandTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        DB::statement('SET FOREIGN_KEY_CHECKS=0');
+        foreach (['volunteering_dates', 'volunteering_images', 'volunteering_groups', 'volunteering', 'memberships', 'users_emails', 'users', 'groups'] as $table) {
+            DB::table($table)->delete();
+        }
+        DB::statement('SET FOREIGN_KEY_CHECKS=1');
+    }
+
+    private function makeOpportunity(array $attrs = []): int
+    {
+        return DB::table('volunteering')->insertGetId(array_merge([
+            'title' => 'Dateless Opportunity',
+            'location' => 'Community Centre',
+            'description' => 'Ongoing help needed.',
+            'pending' => 0,
+            'deleted' => 0,
+            'expired' => 0,
+            'renewed' => null,
+            'askedtorenew' => null,
+            'added' => now()->subDays(25),
+        ], $attrs));
+    }
+
+    public function test_smoke_no_opportunities(): void
+    {
+        Mail::fake();
+
+        $this->artisan('volunteering:maintain')
+            ->expectsOutputToContain('Asked 0')
+            ->assertExitCode(0);
+
+        Mail::assertNothingSent();
+    }
+
+    public function test_command_asks_and_expires_and_reports(): void
+    {
+        Mail::fake();
+        $owner = $this->createTestUser();
+
+        // Dateless, 25 days old → in the renewal-ask window, not yet expirable.
+        $askId = $this->makeOpportunity(['userid' => $owner->id, 'added' => now()->subDays(25)]);
+
+        // Dated, only past dates → expirable, never asked (it has dates).
+        $expireId = $this->makeOpportunity(['userid' => $owner->id, 'title' => 'Past Event', 'added' => now()->subDays(5)]);
+        DB::table('volunteering_dates')->insert([
+            'volunteeringid' => $expireId,
+            'end' => now()->subDays(2)->format('Y-m-d H:i:s'),
+        ]);
+
+        $this->artisan('volunteering:maintain')
+            ->expectsOutputToContain('Asked 1')
+            ->expectsOutputToContain('expired 1')
+            ->assertExitCode(0);
+
+        Mail::assertSentCount(1);
+        $this->assertNotNull(DB::table('volunteering')->where('id', $askId)->value('askedtorenew'));
+        $this->assertSame(1, (int) DB::table('volunteering')->where('id', $expireId)->value('expired'));
+    }
+
+    public function test_command_dry_run_changes_nothing(): void
+    {
+        Mail::fake();
+        $owner = $this->createTestUser();
+        $askId = $this->makeOpportunity(['userid' => $owner->id, 'added' => now()->subDays(25)]);
+
+        $this->artisan('volunteering:maintain', ['--dry-run' => true])
+            ->expectsOutputToContain('DRY RUN')
+            ->assertExitCode(0);
+
+        Mail::assertNothingSent();
+        $this->assertNull(DB::table('volunteering')->where('id', $askId)->value('askedtorenew'));
+    }
+}

--- a/iznik-batch/tests/Feature/Volunteering/MaintainVolunteeringCommandTest.php
+++ b/iznik-batch/tests/Feature/Volunteering/MaintainVolunteeringCommandTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Volunteering;
 
+use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Mail;
 use Tests\TestCase;
@@ -60,11 +61,19 @@ class MaintainVolunteeringCommandTest extends TestCase
             'end' => now()->subDays(2)->format('Y-m-d H:i:s'),
         ]);
 
-        $this->artisan('volunteering:maintain')
-            ->expectsOutputToContain('Asked 1')
-            ->expectsOutputToContain('expired 1')
-            ->assertExitCode(0);
+        // Capture the command output directly rather than chaining two
+        // ->expectsOutputToContain() calls. The command prints ONE summary line
+        // containing both counts; Laravel registers a Mockery doWrite matcher per
+        // expected substring, and a single output line that matches both only
+        // satisfies one matcher — leaving the other reported as "not contained"
+        // (PendingCommand::createABufferedOutputMock). assertStringContainsString
+        // on the captured output has no such limitation.
+        $code = Artisan::call('volunteering:maintain');
+        $output = Artisan::output();
 
+        $this->assertSame(0, $code);
+        $this->assertStringContainsString('Asked 1', $output);
+        $this->assertStringContainsString('expired 1', $output);
         Mail::assertSentCount(1);
         $this->assertNotNull(DB::table('volunteering')->where('id', $askId)->value('askedtorenew'));
         $this->assertSame(1, (int) DB::table('volunteering')->where('id', $expireId)->value('expired'));

--- a/iznik-batch/tests/Feature/Volunteering/VolunteeringMaintenanceServiceTest.php
+++ b/iznik-batch/tests/Feature/Volunteering/VolunteeringMaintenanceServiceTest.php
@@ -1,0 +1,268 @@
+<?php
+
+namespace Tests\Feature\Volunteering;
+
+use App\Mail\Volunteering\VolunteeringRenewMail;
+use App\Services\VolunteeringMaintenanceService;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Mail;
+use Tests\TestCase;
+
+/**
+ * Covers VolunteeringMaintenanceService, ported from iznik-server
+ * Volunteering::askRenew() and Volunteering::expire().
+ */
+class VolunteeringMaintenanceServiceTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // The service queries volunteering / users globally. Hide any rows that
+        // leak from parallel test classes by deleting inside this test's
+        // transaction (rolled back on tearDown). Mirrors VolunteeringDigestCommandTest.
+        DB::statement('SET FOREIGN_KEY_CHECKS=0');
+        foreach (['volunteering_dates', 'volunteering_images', 'volunteering_groups', 'volunteering', 'memberships', 'users_emails', 'users', 'groups'] as $table) {
+            DB::table($table)->delete();
+        }
+        DB::statement('SET FOREIGN_KEY_CHECKS=1');
+    }
+
+    private function service(): VolunteeringMaintenanceService
+    {
+        return app(VolunteeringMaintenanceService::class);
+    }
+
+    /**
+     * Insert a volunteering opportunity. Defaults to a dateless opportunity in
+     * the renewal-ask window (added 25 days ago, never renewed or asked).
+     */
+    private function makeOpportunity(array $attrs = []): int
+    {
+        return DB::table('volunteering')->insertGetId(array_merge([
+            'title' => 'Dateless Opportunity',
+            'location' => 'Community Centre',
+            'description' => 'Ongoing help needed.',
+            'pending' => 0,
+            'deleted' => 0,
+            'expired' => 0,
+            'renewed' => null,
+            'askedtorenew' => null,
+            'added' => now()->subDays(25),
+        ], $attrs));
+    }
+
+    private function addEndDate(int $volId, string $end): void
+    {
+        DB::table('volunteering_dates')->insert([
+            'volunteeringid' => $volId,
+            'end' => $end,
+        ]);
+    }
+
+    // ---- askRenew() -------------------------------------------------------
+
+    public function test_asks_owner_of_dateless_opportunity_past_ask_age(): void
+    {
+        Mail::fake();
+        $owner = $this->createTestUser();
+        $id = $this->makeOpportunity(['userid' => $owner->id, 'added' => now()->subDays(25)]);
+
+        $count = $this->service()->askRenew();
+
+        $this->assertSame(1, $count);
+        Mail::assertSent(VolunteeringRenewMail::class, fn (VolunteeringRenewMail $m) =>
+            $m->recipientEmail === $owner->email_preferred && $m->title === 'Dateless Opportunity');
+        // Intentional improvement over V1: askedtorenew is stamped after asking.
+        $this->assertNotNull(DB::table('volunteering')->where('id', $id)->value('askedtorenew'));
+    }
+
+    public function test_does_not_ask_recent_opportunity(): void
+    {
+        Mail::fake();
+        $owner = $this->createTestUser();
+        $this->makeOpportunity(['userid' => $owner->id, 'added' => now()->subDays(10)]);
+
+        $this->assertSame(0, $this->service()->askRenew());
+        Mail::assertNothingSent();
+    }
+
+    public function test_does_not_ask_opportunity_renewed_recently(): void
+    {
+        Mail::fake();
+        $owner = $this->createTestUser();
+        $this->makeOpportunity(['userid' => $owner->id, 'added' => now()->subDays(40), 'renewed' => now()->subDays(5)]);
+
+        $this->assertSame(0, $this->service()->askRenew());
+        Mail::assertNothingSent();
+    }
+
+    public function test_does_not_ask_dated_opportunity(): void
+    {
+        Mail::fake();
+        $owner = $this->createTestUser();
+        $id = $this->makeOpportunity(['userid' => $owner->id, 'added' => now()->subDays(40)]);
+        // A date with an end makes the opportunity "dated" — renewal does not apply.
+        $this->addEndDate($id, now()->addDays(5)->format('Y-m-d H:i:s'));
+
+        $this->assertSame(0, $this->service()->askRenew());
+        Mail::assertNothingSent();
+    }
+
+    public function test_does_not_reask_when_recently_asked(): void
+    {
+        // Intentional improvement over V1: with askedtorenew set, a daily run must
+        // not re-email an owner who was asked inside the current renewal cycle.
+        Mail::fake();
+        $owner = $this->createTestUser();
+        $this->makeOpportunity(['userid' => $owner->id, 'added' => now()->subDays(25), 'askedtorenew' => now()->subDays(3)]);
+
+        $this->assertSame(0, $this->service()->askRenew());
+        Mail::assertNothingSent();
+    }
+
+    public function test_reasks_when_asked_long_ago(): void
+    {
+        // Once a full ask-cycle (24 days) has elapsed since the last ask, ask again.
+        Mail::fake();
+        $owner = $this->createTestUser();
+        $this->makeOpportunity(['userid' => $owner->id, 'added' => now()->subDays(60), 'askedtorenew' => now()->subDays(30)]);
+
+        $this->assertSame(1, $this->service()->askRenew());
+        Mail::assertSent(VolunteeringRenewMail::class);
+    }
+
+    public function test_skips_deleted_opportunity(): void
+    {
+        Mail::fake();
+        $owner = $this->createTestUser();
+        $this->makeOpportunity(['userid' => $owner->id, 'added' => now()->subDays(25), 'deleted' => 1]);
+
+        $this->assertSame(0, $this->service()->askRenew());
+        Mail::assertNothingSent();
+    }
+
+    public function test_skips_expired_opportunity_for_ask(): void
+    {
+        Mail::fake();
+        $owner = $this->createTestUser();
+        $this->makeOpportunity(['userid' => $owner->id, 'added' => now()->subDays(25), 'expired' => 1]);
+
+        $this->assertSame(0, $this->service()->askRenew());
+        Mail::assertNothingSent();
+    }
+
+    public function test_skips_opportunity_with_no_owner(): void
+    {
+        Mail::fake();
+        $id = $this->makeOpportunity(['userid' => null, 'added' => now()->subDays(25)]);
+
+        $this->assertSame(0, $this->service()->askRenew());
+        Mail::assertNothingSent();
+        // Nothing was emailed, so askedtorenew must remain NULL for a retry next run.
+        $this->assertNull(DB::table('volunteering')->where('id', $id)->value('askedtorenew'));
+    }
+
+    public function test_ask_dry_run_sends_nothing_and_records_nothing(): void
+    {
+        Mail::fake();
+        $owner = $this->createTestUser();
+        $id = $this->makeOpportunity(['userid' => $owner->id, 'added' => now()->subDays(25)]);
+
+        $count = $this->service()->askRenew(null, true);
+
+        $this->assertSame(1, $count, 'Dry run reports who WOULD be asked');
+        Mail::assertNothingSent();
+        $this->assertNull(DB::table('volunteering')->where('id', $id)->value('askedtorenew'));
+    }
+
+    public function test_renewal_email_uses_associated_group_name(): void
+    {
+        Mail::fake();
+        $owner = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $id = $this->makeOpportunity(['userid' => $owner->id, 'added' => now()->subDays(25)]);
+        DB::table('volunteering_groups')->insert(['volunteeringid' => $id, 'groupid' => $group->id]);
+
+        $this->service()->askRenew();
+
+        Mail::assertSent(VolunteeringRenewMail::class, fn (VolunteeringRenewMail $m) =>
+            $m->groupName === $group->namefull);
+    }
+
+    // ---- expire() ---------------------------------------------------------
+
+    public function test_expires_dateless_opportunity_older_than_expire_age(): void
+    {
+        $id = $this->makeOpportunity(['added' => now()->subDays(32), 'renewed' => null]);
+
+        $count = $this->service()->expire();
+
+        $this->assertSame(1, $count);
+        $this->assertSame(1, (int) DB::table('volunteering')->where('id', $id)->value('expired'));
+    }
+
+    public function test_does_not_expire_dateless_recently_renewed(): void
+    {
+        $id = $this->makeOpportunity(['added' => now()->subDays(40), 'renewed' => now()->subDays(5)]);
+
+        $this->assertSame(0, $this->service()->expire());
+        $this->assertSame(0, (int) DB::table('volunteering')->where('id', $id)->value('expired'));
+    }
+
+    public function test_does_not_expire_dateless_younger_than_expire_age(): void
+    {
+        $id = $this->makeOpportunity(['added' => now()->subDays(20)]);
+
+        $this->assertSame(0, $this->service()->expire());
+        $this->assertSame(0, (int) DB::table('volunteering')->where('id', $id)->value('expired'));
+    }
+
+    public function test_expires_dated_opportunity_with_all_dates_past(): void
+    {
+        $id = $this->makeOpportunity(['added' => now()->subDays(5)]);
+        $this->addEndDate($id, now()->subDays(1)->format('Y-m-d H:i:s'));
+
+        $this->assertSame(1, $this->service()->expire());
+        $this->assertSame(1, (int) DB::table('volunteering')->where('id', $id)->value('expired'));
+    }
+
+    public function test_does_not_expire_dated_opportunity_with_a_future_date(): void
+    {
+        $id = $this->makeOpportunity(['added' => now()->subDays(5)]);
+        $this->addEndDate($id, now()->subDays(1)->format('Y-m-d H:i:s'));   // past
+        $this->addEndDate($id, now()->addDays(7)->format('Y-m-d H:i:s'));   // future
+
+        $this->assertSame(0, $this->service()->expire());
+        $this->assertSame(0, (int) DB::table('volunteering')->where('id', $id)->value('expired'));
+    }
+
+    public function test_does_not_reexpire_already_expired_opportunity(): void
+    {
+        $this->makeOpportunity(['added' => now()->subDays(40), 'expired' => 1]);
+
+        $this->assertSame(0, $this->service()->expire());
+    }
+
+    public function test_expire_dry_run_counts_without_changing_rows(): void
+    {
+        $id = $this->makeOpportunity(['added' => now()->subDays(32)]);
+
+        $count = $this->service()->expire(null, true);
+
+        $this->assertSame(1, $count);
+        $this->assertSame(0, (int) DB::table('volunteering')->where('id', $id)->value('expired'));
+    }
+
+    public function test_id_scope_limits_expire_to_one_opportunity(): void
+    {
+        $target = $this->makeOpportunity(['added' => now()->subDays(40)]);
+        $other = $this->makeOpportunity(['added' => now()->subDays(40)]);
+
+        $count = $this->service()->expire($target);
+
+        $this->assertSame(1, $count);
+        $this->assertSame(1, (int) DB::table('volunteering')->where('id', $target)->value('expired'));
+        $this->assertSame(0, (int) DB::table('volunteering')->where('id', $other)->value('expired'));
+    }
+}

--- a/iznik-batch/tests/Unit/Mail/VolunteeringRenewMailTest.php
+++ b/iznik-batch/tests/Unit/Mail/VolunteeringRenewMailTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests\Unit\Mail;
+
+use App\Mail\Volunteering\VolunteeringRenewMail;
+use Tests\TestCase;
+
+class VolunteeringRenewMailTest extends TestCase
+{
+    private function makeMail(string $title = 'Help at the community garden'): VolunteeringRenewMail
+    {
+        $userSite = config('freegle.sites.user');
+
+        return new VolunteeringRenewMail(
+            recipientEmail: 'owner@example.com',
+            title: $title,
+            // A loginLink()-style auto-login URL pointing at the opportunity.
+            renewUrl: $userSite . '/volunteering/42?u=7&k=abcdef&src=voldigest',
+            groupName: 'Freegle Testville',
+            userId: 7,
+        );
+    }
+
+    public function test_subject_is_regarding_the_title(): void
+    {
+        // Mirrors iznik-server Volunteering::askRenew(): "Regarding: {title}".
+        $mail = $this->makeMail('Beach clean-up');
+
+        $this->assertSame('Regarding: Beach clean-up', $mail->envelope()->subject);
+    }
+
+    public function test_rendered_html_contains_title_group_and_renew_link(): void
+    {
+        $mail = $this->makeMail('Help at the community garden');
+
+        $html = $mail->render();
+
+        $this->assertStringContainsString('Help at the community garden', $html,
+            'The opportunity title must appear in the email');
+        $this->assertStringContainsString('Freegle Testville', $html,
+            'The group name must appear in the heading');
+        // Robust against & being escaped to &amp; in the rendered href/text:
+        // assert on the path plus first query param only.
+        $this->assertStringContainsString('/volunteering/42?u=7', $html,
+            'The renewal login link must appear in the email');
+        $this->assertStringContainsString('still active', $html,
+            'The body must ask whether the opportunity is still active');
+        $this->assertStringContainsString('Let us know', $html,
+            'The call-to-action button label must match V1 ("Let us know")');
+    }
+
+    public function test_rendered_html_has_no_doubled_https(): void
+    {
+        $html = $this->makeMail()->render();
+
+        $this->assertStringNotContainsString('https://https://', $html,
+            'Renewal email must not contain doubled https://');
+    }
+}


### PR DESCRIPTION
## Problem

The "is this volunteer opportunity still active?" renewal emails stopped going out around **2026-05-12**, and nothing maintains opportunity expiry any more. Owners of dateless opportunities are never prompted to renew, so they silently drift out of the digests with no warning.

**Why:** the V1 weekly cron `iznik-server/scripts/cron/volunteering.php` ran `$v->askRenew()` then `$v->expire()` before emailing. When digest emailing moved to Laravel (`mail:volunteering-digest`, PR #722) the V1 cron was disabled, but `askRenew()`/`expire()` were never migrated. Confirmed: nothing in `iznik-batch/` called them.

Consequences since mid-May: (1) no renewal-request emails at all; (2) nothing sets `expired=1`; (3) once an opp does expire it gets neither a prompt nor public visibility (both paths filter `expired=0`).

## The fix

Migrate the maintenance into `iznik-batch`, scheduled ahead of the digest. Source of truth is the iznik-server PHP; V1 SQL/constants ported exactly.

- **`App\Services\VolunteeringMaintenanceService`** — `askRenew()` + `expire()` porting the V1 SQL (`EXPIRE_AGE=31`, `ASK_AGE=24`, "Midnight N days ago" cutoffs). Writes go through Eloquent `save()` so Laravel Auditing fires.
- **`App\Mail\Volunteering\VolunteeringRenewMail`** (`MjmlMailable`) + MJML template ported from `mailtemplates/volunteerrenew.php`. Subject `Regarding: {title}`; auto-login "Let us know" link to `/volunteering/{id}`; sent to `email_preferred`; spooled via `EmailSpoolerService`.
- **`volunteering:maintain`** command (`LogsBatchJob`, `--dry-run`) + **daily 22:00** schedule, before the weekly `mail:volunteering-digest`.

### Deliberate change vs V1 (flagged for review)
V1 re-emailed every run inside the renewal window. This version **stamps `askedtorenew=NOW()` after asking and gates the query on it**, so the daily schedule asks **once per renewal cycle** instead of every run. This is the one intentional behavioural change; everything else is a faithful port. No schema change (the columns already exist).

## Tests
- `tests/Feature/Volunteering/VolunteeringMaintenanceServiceTest.php` — ask/expire windows, the no-re-ask gate, dated vs dateless expiry, owner/email guards, dry-run, id-scoping.
- `tests/Feature/Volunteering/MaintainVolunteeringCommandTest.php` — command wiring + reporting.
- `tests/Unit/Mail/VolunteeringRenewMailTest.php` — subject + rendered MJML.

## ⚠️ For geeks@ — data-recovery decision (not done here)
Restoring `askRenew`/`expire` will **not** revive opportunities that already expired during the gap (both ignore `expired=1`). Decide:
- (a) one-off un-expire of opps that expired only because the cron stopped, **or**
- (b) an owner-facing "your expired opportunities → reactivate" path.

Immediate hotfix for the live report (run **one row at a time** — Galera; **not executed in this PR**):
`UPDATE volunteering SET renewed=NOW(), expired=0 WHERE id = 13420;` then `... id = 13423;`

🤖 Generated with [Claude Code](https://claude.com/claude-code)