### PR TITLE
Purge email_tracking to 30 days in the daily log purge

### DIFF
--- a/iznik-batch/app/Services/PurgeService.php
+++ b/iznik-batch/app/Services/PurgeService.php
@@ -526,8 +526,15 @@ class PurgeService
      *
      * Deletes tracking records older than the specified retention period.
      * Associated clicks and images are deleted via cascade.
+     *
+     * Retention is 30 days: the only consumer of historical email_tracking is the
+     * ModTools outgoing-mail stats dashboard (which itself defaults to <=30-day
+     * windows); bounce/open/click/AMP-reply processing all operate on recently-sent
+     * emails. Left unpurged the table grows unbounded (it had reached ~6.65M rows /
+     * 6 months) and the stats endpoints full-scan it and time out (504). Run daily
+     * from purgeAllLogs() (purge:logs).
      */
-    public function purgeEmailTracking(int $daysOld = 90, bool $dryRun = false): int
+    public function purgeEmailTracking(int $daysOld = 30, bool $dryRun = false): int
     {
         $cutoff = now()->subDays($daysOld);
 
@@ -1008,6 +1015,9 @@ class PurgeService
         $results['bounce_logs'] = $this->purgeBounceLogs(dryRun: $dryRun);
         $results['old_bounce_emails'] = $this->purgeOldBounceEmails(dryRun: $dryRun);
         $results['email_logs'] = $this->purgeEmailLogs(dryRun: $dryRun);
+        // email_tracking is log-like and was previously only purged by the
+        // unscheduled purge:all, so it grew unbounded. Purge it daily here.
+        $results['email_tracking'] = $this->purgeEmailTracking(dryRun: $dryRun);
         $results['non_freegle_group_logs'] = $this->purgeNonFreegleGroupLogs(dryRun: $dryRun);
         $results['orphaned_message_logs'] = $this->purgeOrphanedMessageLogs(dryRun: $dryRun);
         $results['src_logs'] = $this->purgeSrcLogs(dryRun: $dryRun);

--- a/iznik-batch/tests/Unit/Services/PurgeServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/PurgeServiceTest.php
@@ -333,6 +333,32 @@ class PurgeServiceTest extends TestCase
         $this->assertDatabaseHas('email_tracking', ['id' => $recentTracking->id]);
     }
 
+    public function test_purge_all_logs_purges_email_tracking_at_30_days(): void
+    {
+        // email_tracking is now purged by the daily log purge (purge:logs ->
+        // purgeAllLogs). Previously it was only in the unscheduled purge:all, so
+        // the table grew unbounded and the stats endpoints timed out. Retention
+        // is 30 days.
+        $old = EmailTracking::create([
+            'tracking_id' => EmailTracking::generateTrackingId(),
+            'email_type' => 'Test',
+            'recipient_email' => $this->uniqueEmail('alog-old'),
+            'sent_at' => now()->subDays(35),
+        ]);
+        $recent = EmailTracking::create([
+            'tracking_id' => EmailTracking::generateTrackingId(),
+            'email_type' => 'Test',
+            'recipient_email' => $this->uniqueEmail('alog-recent'),
+            'sent_at' => now()->subDays(25),
+        ]);
+
+        $results = $this->service->purgeAllLogs();
+
+        $this->assertArrayHasKey('email_tracking', $results);
+        $this->assertDatabaseMissing('email_tracking', ['id' => $old->id]);
+        $this->assertDatabaseHas('email_tracking', ['id' => $recent->id]);
+    }
+
     public function test_purge_html_body(): void
     {
         $user = $this->createTestUser();


### PR DESCRIPTION
## Problem
The ModTools sysadmin **outgoing-mail stats** endpoints (`/modtools/email/stats`, `.../timeseries`, `.../bytype`) time out (504 after 50s). Root cause: **`email_tracking` is never purged in production** — it had grown to **~6.65M rows over ~6 months**, so the stats queries full-scan it.

`purgeEmailTracking()` existed (90-day default) but was only wired into `runAll()` (`purge:all`), which is **not scheduled**. The daily `purge:logs` (`purgeAllLogs()`) skipped it entirely.

## Change
- **Retention → 30 days.** The only consumer of *historical* `email_tracking` is the stats dashboard, which itself defaults to ≤30-day windows. Bounce / open / click / AMP-reply processing all operate on recently-sent emails, so 30-day retention is safe.
- **Add `purgeEmailTracking()` to `purgeAllLogs()`** so the existing daily `purge:logs` (03:30) keeps it bounded. Deletes are chunked (1000/loop) on the indexed `sent_at`; clicks/images cascade.
- Test asserting the daily log purge removes 35-day-old rows and keeps 25-day-old ones.

## Effect
After deploy, the first nightly purge drops the table to ~30 days (~1.2M rows) and the stats endpoints get fast on their own — a permanent fix rather than just an index hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)