### PR TITLE
Speed up ModTools email stats (FORCE INDEX on timeseries/bytype)

### DIFF
--- a/iznik-server-go/emailtracking/emailtracking.go
+++ b/iznik-server-go/emailtracking/emailtracking.go
@@ -909,7 +909,7 @@ func TimeSeries(c *fiber.Ctx) error {
 			SUM(CASE WHEN has_amp = 0 AND opened_at IS NOT NULL THEN 1 ELSE 0 END) as non_amp_opened,
 			SUM(CASE WHEN has_amp = 0 AND clicked_at IS NOT NULL THEN 1 ELSE 0 END) as non_amp_clicked,
 			SUM(CASE WHEN has_amp = 0 AND bounced_at IS NOT NULL THEN 1 ELSE 0 END) as non_amp_linked_bounces
-		FROM email_tracking
+		FROM email_tracking FORCE INDEX (sent_at)
 		LEFT JOIN users ON email_tracking.userid = users.id
 		WHERE users.tnuserid IS NULL AND sent_at BETWEEN ? AND ?
 	`
@@ -1037,7 +1037,7 @@ func StatsByType(c *fiber.Ctx) error {
 			SUM(CASE WHEN opened_at IS NOT NULL THEN 1 ELSE 0 END) as opened,
 			SUM(CASE WHEN clicked_at IS NOT NULL THEN 1 ELSE 0 END) as clicked,
 			SUM(CASE WHEN bounced_at IS NOT NULL THEN 1 ELSE 0 END) as linked_bounces
-		FROM email_tracking
+		FROM email_tracking FORCE INDEX (sent_at)
 		LEFT JOIN users ON email_tracking.userid = users.id
 		WHERE users.tnuserid IS NULL
 	`


### PR DESCRIPTION
## Problem
The ModTools sysadmin outgoing-mail page's `/modtools/email/stats/timeseries` and `.../bytype` endpoints time out (504 after 50s). `email_tracking` is ~6.65M rows and the optimiser **full-scans** it for these date-range aggregations instead of using the `sent_at` index.

## Change
`FORCE INDEX (sent_at)` on the timeseries and bytype queries (the same fix already on `DigestClickPositions`). Measured against the live DB:

| range | full scan (current) | FORCE INDEX |
|---|---|---|
| 1 day | times out | **1.3s** |
| 7 days | times out | **9s** |
| 13 days | 50s → 504 | **17s** |

The optimiser's cost model is simply wrong here — the forced range-scan is far faster than the full scan it chooses.

## Relationship to the purge PR
This is the **immediate** fix (effective on apiv2 redeploy). The **permanent** fix is the `email_tracking` 30-day purge (#743), which shrinks the table to ~1.2M rows so these scans become individually fast.

`stats/` (not changed here) runs ~7 sequential `email_tracking` scans, so the hint can't get it under the timeout on the current table — it's handled by the purge.

Go suite: 3171 ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)