### PR TITLE
fix(modtools): pending message link uses /pending/ URL for Spam-collection posts

### DIFF
--- a/iznik-nuxt3/components/MessageHistory.vue
+++ b/iznik-nuxt3/components/MessageHistory.vue
@@ -26,7 +26,7 @@
           :to="
             modinfo && group.groupid
               ? '/messages/' +
-                (group.collection || 'approved').toLowerCase() +
+                (['Pending', 'PendingOther', 'Spam'].includes(group.collection) ? 'pending' : 'approved') +
                 '/' +
                 group.groupid +
                 '/' +

--- a/iznik-nuxt3/tests/unit/components/MessageHistory.spec.js
+++ b/iznik-nuxt3/tests/unit/components/MessageHistory.spec.js
@@ -312,4 +312,45 @@ describe('MessageHistory', () => {
       expect(wrapper.find('a').exists()).toBe(false)
     })
   })
+
+  describe('message ID link URL for collection types', () => {
+    function wrapperWithCollection(collection) {
+      mockMessageStore.byId.mockReturnValue({
+        ...mockMessage,
+        groups: [{ groupid: 100, arrival: '2024-01-15T10:00:00Z', collection }],
+      })
+      return createWrapper({ modinfo: true })
+    }
+
+    it('uses /pending/ URL for Pending collection', () => {
+      const wrapper = wrapperWithCollection('Pending')
+      const btn = wrapper.find('.b-button')
+      expect(btn.attributes('to')).toContain('/messages/pending/')
+    })
+
+    it('uses /pending/ URL for PendingOther collection', () => {
+      const wrapper = wrapperWithCollection('PendingOther')
+      const btn = wrapper.find('.b-button')
+      expect(btn.attributes('to')).toContain('/messages/pending/')
+    })
+
+    it('uses /pending/ URL for Spam collection (not /messages/spam/)', () => {
+      const wrapper = wrapperWithCollection('Spam')
+      const btn = wrapper.find('.b-button')
+      expect(btn.attributes('to')).toContain('/messages/pending/')
+      expect(btn.attributes('to')).not.toContain('/messages/spam/')
+    })
+
+    it('uses /approved/ URL for Approved collection', () => {
+      const wrapper = wrapperWithCollection('Approved')
+      const btn = wrapper.find('.b-button')
+      expect(btn.attributes('to')).toContain('/messages/approved/')
+    })
+
+    it('uses /approved/ URL when collection is null', () => {
+      const wrapper = wrapperWithCollection(null)
+      const btn = wrapper.find('.b-button')
+      expect(btn.attributes('to')).toContain('/messages/approved/')
+    })
+  })
 })


### PR DESCRIPTION
## Summary

- `MessageHistory.vue` generated `/messages/spam/<groupid>/<msgid>` URLs when a post's collection was `Spam` (set by `ContentCheckService` for keyword-blocked posts). That path doesn't exist in ModTools — the `/messages/pending` page handles all three collections: `Pending`, `PendingOther`, and `Spam`.
- The fix maps those three collections to `'pending'` in the URL. The `approved` path is used for everything else (same as before for `null`/`Approved`).
- This was reported via Discourse #9786 by Neville_Reid: a keyword-flagged post ("acid") appeared in the Pending list with a broken link pointing to `/messages/spam/` — confirmed by `default.vue` which already routes both `pending` and `spam` work counts to `/messages/pending`.

## Test plan

- [x] Added 5 new unit tests in `MessageHistory.spec.js` covering: `Pending`, `PendingOther`, and `Spam` collections map to `/pending/`; `Approved` and `null` map to `/approved/`
- [ ] Run vitest suite via CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)