### PR TITLE
fix(modtools/config): allow group mods to add standard messages to unprotected configs

### DIFF
--- a/iznik-server-go/stdmsg/stdmsg.go
+++ b/iznik-server-go/stdmsg/stdmsg.go
@@ -89,10 +89,6 @@ func PostStdMsg(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"ret": 1, "status": "Not logged in"})
 	}
 
-	if !auth.IsSystemMod(myid) {
-		return c.Status(fiber.StatusForbidden).JSON(fiber.Map{"ret": 4, "status": "Don't have rights to create configs"})
-	}
-
 	type CreateRequest struct {
 		Configid     uint64  `json:"configid"`
 		Title        string  `json:"title"`
@@ -124,6 +120,10 @@ func PostStdMsg(c *fiber.Ctx) error {
 	}
 	if req.Configid == 0 {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"ret": 3, "status": "Must supply configid"})
+	}
+
+	if !canModifyConfig(myid, req.Configid) {
+		return c.Status(fiber.StatusForbidden).JSON(fiber.Map{"ret": 4, "status": "Don't have rights to modify config"})
 	}
 
 	db := database.DBConn

--- a/iznik-server-go/test/stdmsg_test.go
+++ b/iznik-server-go/test/stdmsg_test.go
@@ -200,3 +200,55 @@ func TestDeleteStdMsgWithJSONBody(t *testing.T) {
 	db.Raw("SELECT COUNT(*) FROM mod_stdmsgs WHERE id = ?", msgID).Scan(&count)
 	assert.Equal(t, int64(0), count)
 }
+
+// TestPostStdMsgByGroupMod verifies that a regular group moderator (systemrole="User")
+// can add a standard message to an unprotected config they did not create.
+// Bug: PostStdMsg used IsSystemMod() instead of canModifyConfig(), blocking group mods.
+func TestPostStdMsgByGroupMod(t *testing.T) {
+	prefix := uniquePrefix("StdMsgGrpMod")
+	groupID := CreateTestGroup(t, prefix)
+	// systemrole "User" = regular group mod, not a system-level mod
+	groupModID := CreateTestUser(t, prefix+"_mod", "User")
+	CreateTestMembership(t, groupModID, groupID, "Owner")
+	_, token := CreateTestSession(t, groupModID)
+
+	// Config created by someone else but not protected — any mod can modify it
+	otherID := CreateTestUser(t, prefix+"_other", "User")
+	cfgID := createTestModConfig(t, prefix+"_cfg", otherID)
+
+	body := fmt.Sprintf(`{"configid":%d,"title":"%s_newmsg"}`, cfgID, prefix)
+	req := httptest.NewRequest("POST", fmt.Sprintf("/api/modtools/stdmsg?jwt=%s", token), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json2.Unmarshal(rsp(resp), &result)
+	assert.Equal(t, float64(0), result["ret"])
+	assert.Greater(t, result["id"].(float64), float64(0))
+}
+
+// TestPostStdMsgByGroupModProtectedConfig verifies that a regular group mod
+// cannot add a stdmsg to a protected config they did not create.
+func TestPostStdMsgByGroupModProtectedConfig(t *testing.T) {
+	prefix := uniquePrefix("StdMsgGrpModProt")
+	groupID := CreateTestGroup(t, prefix)
+	groupModID := CreateTestUser(t, prefix+"_mod", "User")
+	CreateTestMembership(t, groupModID, groupID, "Owner")
+	_, token := CreateTestSession(t, groupModID)
+
+	// Config created by someone else AND protected
+	ownerID := CreateTestUser(t, prefix+"_owner", "User")
+	cfgID := createTestModConfig(t, prefix+"_cfg", ownerID)
+	database.DBConn.Exec("UPDATE mod_configs SET protected = 1 WHERE id = ?", cfgID)
+
+	body := fmt.Sprintf(`{"configid":%d,"title":"%s_newmsg"}`, cfgID, prefix)
+	req := httptest.NewRequest("POST", fmt.Sprintf("/api/modtools/stdmsg?jwt=%s", token), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 403, resp.StatusCode)
+
+	var result map[string]interface{}
+	json2.Unmarshal(rsp(resp), &result)
+	assert.Equal(t, float64(4), result["ret"])
+}


### PR DESCRIPTION
## Root Cause

`PostStdMsg` (Go API `/modtools/stdmsg` POST) checked `auth.IsSystemMod(myid)`, which only allows users with a system-level `Moderator`/`Support`/`Admin` systemrole. Regular group moderators have `systemrole = "User"` (they're mods at the group membership level, not the system level), so they received HTTP 403 when trying to add a new standard message button to a config.

`PatchStdMsg` and `DeleteStdMsg` correctly use `canModifyConfig(myid, configid)`, which allows the config creator or any user when the config is unprotected. `PostStdMsg` was inconsistent — it required system-level authority that regular group moderators never have.

## Evidence

`TestPostStdMsgByGroupMod` (with assert 200) **failed** on buggy code:

```
--- FAIL: TestPostStdMsgByGroupMod (0.05s)
    Error: Response status 403 is not equal to 200
FAIL	iznik-server-go/test	132.046s
```

After fix, both new tests pass along with all existing stdmsg tests.

## Fix

Removed the early `IsSystemMod` check from `PostStdMsg`. After parsing `req.Configid`, replaced it with `canModifyConfig(myid, req.Configid)` — the same check already used by PATCH and DELETE. The check runs after input parsing so the configid is available to look up permission.

## Other Call Sites

`auth.IsSystemMod` is used in 10+ other files (alert, admin, microvolunteering, etc.) where system-level access is genuinely required. The only incorrect usage was in `PostStdMsg`.

## Test

File: `iznik-server-go/test/stdmsg_test.go`

Command: `curl -X POST http://localhost:8081/api/tests/go`

- `TestPostStdMsgByGroupMod` — group mod (systemrole="User") can POST to unprotected config → 200 ✓
- `TestPostStdMsgByGroupModProtectedConfig` — group mod cannot POST to a protected config they didn't create → 403 ✓

Proves: fail-before (403 on unprotected), pass-after (200 on unprotected, 403 on protected).

## Discourse

https://discourse.ilovefreegle.org/t/9793/1