### PR TITLE
fix(pending/listings): reject Received/Taken outcomes on pending Wanted posts

### DIFF
--- a/iznik-batch/app/Services/ChaseUpService.php
+++ b/iznik-batch/app/Services/ChaseUpService.php
@@ -139,6 +139,20 @@ class ChaseUpService
                 continue;
             }
 
+            // Skip Taken/Received on pending posts: the post has not been approved yet,
+            // so recording a successful outcome would mark it as done prematurely.
+            // Discourse: https://discourse.ilovefreegle.org/t/9788/7
+            if (in_array($intended->outcome, ['Taken', 'Received'])) {
+                $isPending = DB::table('messages_groups')
+                    ->where('msgid', $intended->msgid)
+                    ->where('collection', MessageGroup::COLLECTION_PENDING)
+                    ->exists();
+
+                if ($isPending) {
+                    continue;
+                }
+            }
+
             if ($dryRun) {
                 Log::info("Dry run: would process intended outcome '{$intended->outcome}' for message #{$intended->msgid}");
                 $count++;

--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -3693,6 +3693,17 @@ func handleOutcomeIntended(c *fiber.Ctx, myid uint64, req PostMessageRequest) er
 		return fiber.NewError(fiber.StatusForbidden, "Not allowed to modify this message")
 	}
 
+	// Reject Taken/Received intended outcomes for pending posts: the batch job
+	// (ChaseUpService::processIntendedOutcomes) would otherwise apply the outcome
+	// 30 minutes later with no pending-state guard.
+	if req.Outcome == utils.OUTCOME_TAKEN || req.Outcome == utils.OUTCOME_RECEIVED {
+		var pendingCount int64
+		db.Raw("SELECT COUNT(*) FROM messages_groups WHERE msgid = ? AND collection = ?", req.ID, utils.COLLECTION_PENDING).Scan(&pendingCount)
+		if pendingCount > 0 {
+			return fiber.NewError(fiber.StatusBadRequest, "Cannot record intended outcome on a pending post")
+		}
+	}
+
 	// Simple insert-or-update.
 	db.Exec("INSERT INTO messages_outcomes_intended (msgid, outcome) VALUES (?, ?) ON DUPLICATE KEY UPDATE outcome = VALUES(outcome)",
 		req.ID, req.Outcome)
@@ -3776,6 +3787,19 @@ func handleOutcome(c *fiber.Ctx, myid uint64, req PostMessageRequest) error {
 			return c.JSON(fiber.Map{"ret": 0, "status": "Success", "deleted": true})
 		}
 	}
+
+	// For Taken/Received: reject if the message is still pending on any group.
+	// A pending post has not been approved yet, so recording a successful outcome
+	// on it prematurely removes it from listings. Withdrawn is handled above
+	// (soft-delete). Discourse: https://discourse.ilovefreegle.org/t/9788/7
+	if req.Outcome == utils.OUTCOME_TAKEN || req.Outcome == utils.OUTCOME_RECEIVED {
+		var pendingCount int64
+		db.Raw("SELECT COUNT(*) FROM messages_groups WHERE msgid = ? AND collection = ?", req.ID, utils.COLLECTION_PENDING).Scan(&pendingCount)
+		if pendingCount > 0 {
+			return fiber.NewError(fiber.StatusBadRequest, "Cannot mark a pending post as "+req.Outcome)
+		}
+	}
+
 
 	// Check for existing outcome. System-generated expiry markers are
 	// overwriteable; anything user-recorded is a real conflict.

--- a/iznik-server-go/test/message_test.go
+++ b/iznik-server-go/test/message_test.go
@@ -9240,3 +9240,47 @@ func TestPostMessagePromisePartnerWrongDomain(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 403, resp.StatusCode, "Partner Promise should fail if fromaddr not in partner domain")
 }
+
+// TestPostMessageReceivedOnPendingWanted asserts that marking a pending WANTED post as
+// Received is rejected by the API. Pending posts have not been approved yet; recording a
+// Received outcome on them prematurely removes them from listings.
+// Discourse: https://discourse.ilovefreegle.org/t/9788/7
+func TestPostMessageReceivedOnPendingWanted(t *testing.T) {
+	prefix := uniquePrefix("msgpend_rcv")
+	db := database.DBConn
+
+	groupID := CreateTestGroup(t, prefix)
+	posterID := CreateTestUser(t, prefix+"_poster", "User")
+	CreateTestMembership(t, posterID, groupID, "Member")
+	_, posterToken := CreateTestSession(t, posterID)
+
+	var locationID uint64
+	db.Raw("SELECT id FROM locations LIMIT 1").Scan(&locationID)
+	db.Exec("INSERT INTO messages (fromuser, subject, textbody, message, type, locationid, arrival, date) VALUES (?, ?, 'Test body', 'Test body', 'Wanted', ?, NOW(), NOW())",
+		posterID, prefix+" pending wanted", locationID)
+	var msgID uint64
+	db.Raw("SELECT id FROM messages WHERE fromuser = ? AND subject = ? ORDER BY id DESC LIMIT 1",
+		posterID, prefix+" pending wanted").Scan(&msgID)
+	if msgID == 0 {
+		t.Fatal("Failed to create pending message")
+	}
+	db.Exec("INSERT INTO messages_groups (msgid, groupid, arrival, collection, autoreposts) VALUES (?, ?, NOW(), 'Pending', 0)",
+		msgID, groupID)
+
+	body := map[string]interface{}{
+		"id":      msgID,
+		"action":  "Outcome",
+		"outcome": "Received",
+	}
+	bodyBytes, _ := json.Marshal(body)
+	url := fmt.Sprintf("/api/message?jwt=%s", posterToken)
+	req := httptest.NewRequest("POST", url, bytes.NewBuffer(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := getApp().Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 400, resp.StatusCode, "Received outcome must be rejected on a pending Wanted post")
+
+	var outcomeCount int64
+	db.Raw("SELECT COUNT(*) FROM messages_outcomes WHERE msgid = ?", msgID).Scan(&outcomeCount)
+	assert.Equal(t, int64(0), outcomeCount, "No outcome should be recorded for a pending Wanted post")
+}


### PR DESCRIPTION
## Root Cause

The V2 Go API intentionally shows pending posts to their owner (unlike V1 which only showed Approved posts). The `handleOutcome` function in `iznik-server-go/message/message.go` already guarded `Withdrawn` on pending posts but had no equivalent guard for `Taken` or `Received`. This meant a user could visit "My Posts", see their still-pending WANTED, and click "Received" — which would immediately record an outcome and remove the post from listings before it had been approved by a moderator.

The `ChaseUpService::processIntendedOutcomes` PHP batch job (runs every minute, applies intended outcomes after 30 min) also had no pending check, so a race existed: record an intended outcome, then have the post go back to pending — and the batch job would apply it anyway.

## Evidence

**Before fix** — `TestPostMessageReceivedOnPendingWanted` fails:
```
FAIL: expected 400, got 200
FAIL: expected outcomeCount=0, got 1
```

**After fix** — test passes:
```
PASS: TestPostMessageReceivedOnPendingWanted (400 returned, outcomeCount=0)
Full suite: 3176 passed, 2 failed (both pre-existing, unrelated to this change)
```

## Fix

Three changes:

1. **`iznik-server-go/message/message.go` — `handleOutcome`** (primary guard): After the existing `Withdrawn`-on-pending guard (~line 3779), added an identical check for `Taken`/`Received` that returns HTTP 400 if `messages_groups` has any row with `collection = 'Pending'` for the message.

2. **`iznik-server-go/message/message.go` — `handleOutcomeIntended`** (~line 3695): Added the same pending check before recording an intended `Taken`/`Received` outcome, so the batch job never gets a chance to race.

3. **`iznik-batch/app/Services/ChaseUpService.php` — `processIntendedOutcomes`**: Defence-in-depth — before applying any `Taken`/`Received` intended outcome from `messages_outcomes_intended`, skip if the message is still in `Pending` collection. Handles the edge case where an intended was recorded before the post went pending.

All three guards mirror the same pattern already used for `Withdrawn` on pending posts.

## Other Call Sites

Grepped for other places that insert into `messages_outcomes` directly — all go through `handleOutcome`, which now has the guard. No other direct callers.

## Test

**File:** `iznik-server-go/test/message_test.go` — `TestPostMessageReceivedOnPendingWanted`

**Command:** `POST /api/message {action:"Outcome", outcome:"Received"}` as the post owner, where the post has `messages_groups.collection = 'Pending'`

**Proves:**
- Before fix: returns 200, `messages_outcomes` row created (bug)
- After fix: returns 400, no `messages_outcomes` row created

## Discourse
https://discourse.ilovefreegle.org/t/9788/7