### PR TITLE
fix(pending): auto-refresh list when ContentCheck blocks post to Spam (Discourse #9783)

### DIFF
--- a/iznik-nuxt3/modtools/pages/messages/pending/[[id]]/[[term]].vue
+++ b/iznik-nuxt3/modtools/pages/messages/pending/[[id]]/[[term]].vue
@@ -16,7 +16,7 @@
           v-model="groupid"
           all
           modonly
-          :work="['pending', 'pendingother']"
+          :work="['pending', 'pendingother', 'spam']"
           remember="pending"
           :url-override="urlOverride"
         />
@@ -87,7 +87,7 @@ const {
 
 summarykey.value = 'modtoolsMessagesPendingSummary'
 collection.value = 'Pending' // Pending also gets PendingOther
-workType.value = ['pending', 'pendingother']
+workType.value = ['pending', 'pendingother', 'spam']
 
 const { me, myGroups } = useMe()
 

--- a/iznik-nuxt3/tests/unit/composables/useModMessages.pendingAutoRefresh.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useModMessages.pendingAutoRefresh.spec.js
@@ -151,4 +151,61 @@ describe('useModMessages — pending list auto-refresh', () => {
     // No new work → should NOT trigger a re-fetch
     expect(mockFetchMessagesMT).not.toHaveBeenCalled()
   })
+
+  // Regression test for Discourse #9783 — badge/list mismatch when a message is
+  // moved to Spam by ContentCheck (global concern keyword with action='block').
+  // The left-nav red badge counts pending+spam, so work.spam increasing raises
+  // the badge. But workType=['pending','pendingother'] excludes spam from workdetail,
+  // so the watcher's JSON.stringify comparison sees no change and skips getMessages.
+  // Result: red badge with an empty pending list.
+  it('does not refresh when spam increases and workType excludes spam (documents the bug)', async () => {
+    const { setupModMessages } = await import(
+      '~/modtools/composables/useModMessages'
+    )
+    const { workType, collection } = setupModMessages(true)
+    collection.value = 'Pending'
+    workType.value = ['pending', 'pendingother'] // buggy: excludes 'spam'
+
+    await nextTick()
+    await flushPromises()
+    vi.clearAllMocks()
+
+    // A ContentCheck 'block' action moves the message to Spam collection.
+    mockWork.value = { pending: 0, pendingother: 0, spam: 1, total: 1 }
+
+    await nextTick()
+    await flushPromises()
+
+    // workdetail = {pending:0, pendingother:0, total:0} — unchanged because spam
+    // is not in workType → watcher skips → list not refreshed (the bug).
+    expect(mockFetchMessagesMT).not.toHaveBeenCalled()
+  })
+
+  // Fix for Discourse #9783: adding 'spam' to workType ensures workdetail.total
+  // increases when work.spam increases, so the watcher fires and getMessages
+  // refreshes the list (which already shows Spam-collection messages since PR #709).
+  it('calls getMessages when spam count increases and workType includes spam', async () => {
+    mockWork.value = { pending: 0, pendingother: 0, spam: 0, total: 0 }
+
+    const { setupModMessages } = await import(
+      '~/modtools/composables/useModMessages'
+    )
+    const { workType, collection } = setupModMessages(true)
+    collection.value = 'Pending'
+    workType.value = ['pending', 'pendingother', 'spam'] // fixed
+
+    await nextTick()
+    await flushPromises()
+    vi.clearAllMocks()
+
+    // A ContentCheck 'block' action moves the message to Spam collection.
+    mockWork.value = { pending: 0, pendingother: 0, spam: 1, total: 1 }
+
+    await nextTick()
+    await flushPromises()
+
+    // workdetail = {pending:0, pendingother:0, spam:1, total:1} — changed → watcher
+    // fires → getMessages called → list shows the Spam message.
+    expect(mockFetchMessagesMT).toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
## Problem

Discourse #9783 post 6 — moderators see a red pending badge but an empty list when a post is held by a concern keyword.

**Root cause:** When ContentCheck's `processUnprocessed` runs a global concern keyword with `action='block'`, the message moves to the Spam collection. This increments `work.spam`, which the left-nav red badge counts (`pending + spam`). However, the pending page's `workType` was `['pending', 'pendingother']`, so `workdetail.total` excluded spam. The `watch(workdetail)` watcher's `JSON.stringify` comparison saw no change and skipped `getMessages`. Result: badge increases, list does not refresh.

(Note: per-group worry words use `action='flag'` and stay Pending — those already trigger correctly via `work.pending`. Only the `action='block'` path, which moves posts to Spam, was missing.)

## Fix

Two minimal changes in `[[term]].vue`:

1. `workType.value = ['pending', 'pendingother', 'spam']` — so `workdetail.total` rises when `work.spam` rises, firing `getMessages` to refresh the list.
2. `:work="['pending', 'pendingother', 'spam']"` on `ModGroupSelect` — so per-group spam counts appear in the group dropdown (cosmetic; `group.work.spam` is already populated by `groupWork.go`).

The Spam-collection messages are already included in the pending-page list response from the server (see `ListMessagesMT` / `collectionFilter`), and the client-side `allowed` array was fixed to include `'Spam'` in PR #709. This PR provides the missing auto-refresh trigger.

## Tests

Two new unit tests in `useModMessages.pendingAutoRefresh.spec.js`:

- **Documents the bug**: with `workType=['pending','pendingother']`, spam increase → `getMessages` NOT called.
- **Documents the fix**: with `workType=['pending','pendingother','spam']`, spam increase → `getMessages` IS called.

## Test plan

- [ ] CI vitest suite passes (verifies the two new unit tests)
- [ ] CI build-test-katapult passes (overall regression check)
- [ ] Manual: post a message matching a global concern keyword with `action='block'` → check that the pending-page list auto-refreshes when `work.spam` updates (within the session poll interval, ~30s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)