### PR TITLE
fix(modtools/stdmsg): editable prose in segmented editor + TN-aware $editlink

### DIFF
--- a/iznik-nuxt3/modtools/components/ModStdMessageModal.vue
+++ b/iznik-nuxt3/modtools/components/ModStdMessageModal.vue
@@ -67,14 +67,19 @@
            have to look back at the template. -->
       <div v-else class="mt-2 segmented-editor border rounded p-3">
         <p class="text-muted small mb-2">
-          Fill in the highlighted boxes and choose Keep or Remove for any optional
-          parts. This is the message the member will receive.
+          Fill in the highlighted boxes and choose Keep or Remove for any
+          optional parts. You can edit any of the rest of the wording too. This
+          is the message the member will receive.
         </p>
         <div class="segmented-body">
           <template v-for="(seg, i) in segments" :key="'seg' + i">
-            <span v-if="seg.type === 'text'" class="seg-text">{{
-              seg.content
-            }}</span>
+            <b-form-textarea
+              v-if="seg.type === 'text'"
+              v-model="seg.content"
+              class="seg-text"
+              rows="1"
+              max-rows="30"
+            />
             <b-form-textarea
               v-else-if="seg.type === 'editthis'"
               v-model="seg.value"
@@ -106,9 +111,11 @@
                   Remove
                 </b-button>
               </span>
-              <span v-else-if="seg.removed === false" class="seg-optional-kept">{{
-                seg.content
-              }}</span>
+              <span
+                v-else-if="seg.removed === false"
+                class="seg-optional-kept"
+                >{{ seg.content }}</span
+              >
               <span v-else class="seg-optional-removed">
                 <s class="text-muted">{{ seg.content }}</s>
                 <b-button
@@ -124,11 +131,7 @@
           </template>
         </div>
       </div>
-      <NoticeMessage
-        v-if="directiveWarning"
-        variant="danger"
-        class="mt-1 mb-1"
-      >
+      <NoticeMessage v-if="directiveWarning" variant="danger" class="mt-1 mb-1">
         {{ directiveWarning }}
       </NoticeMessage>
       <div
@@ -406,6 +409,24 @@ const toEmail = computed(() => {
   return ret
 })
 
+// True when the recipient is a TrashNothing member. They post via TN, so their
+// own posts live on TN's site — identified by a tnuserid (or a trashnothing.com
+// from-address as a fallback when the user record isn't fully loaded).
+const isTnUser = computed(() => {
+  if (user.value?.tnuserid) return true
+  const from = message.value?.fromaddr
+  return !!(from && from.includes('trashnothing.com'))
+})
+
+// Where the member goes to edit/repost their own posts ($editlink). TrashNothing
+// members manage theirs on TN's "Your Posts" page (per TN's help docs), not on
+// ilovefreegle.org, so sending them to /myposts would be a dead end for them.
+const editLink = computed(() =>
+  isTnUser.value
+    ? 'https://trashnothing.com/user/posts'
+    : 'https://www.ilovefreegle.org/myposts'
+)
+
 const processLabel = computed(() => {
   switch (stdmsg.value?.action) {
     case 'Approve':
@@ -679,8 +700,9 @@ async function substitutionStrings(text) {
     text = text.replace(/\$myname/g, me.value.displayname)
     text = text.replace(/\$nummembers/g, group.membercount)
     text = text.replace(/\$nummods/g, group.modcount)
-    // Link the member to where they can edit/repost their own posts.
-    text = text.replace(/\$editlink/g, 'https://www.ilovefreegle.org/myposts')
+    // Link the member to where they can edit/repost their own posts. TrashNothing
+    // members are sent to TN's own posts page (see editLink).
+    text = text.replace(/\$editlink/g, editLink.value)
     if (group.settings && group.settings.reposts) {
       text = text.replace(/\$repostoffer/g, group.settings.reposts.offer)
       text = text.replace(/\$repostwanted/g, group.settings.reposts.wanted)
@@ -1037,8 +1059,29 @@ defineExpose({ fillin, show, modal })
   line-height: 1.7;
   font-size: 1rem;
 }
+/* Fixed prose is editable too (mods often tweak the wording), so render it as an
+   auto-sizing textarea rather than a static span. Styled to read as part of the
+   message — a light border that strengthens on hover/focus signals it's editable,
+   while staying visually quieter than the amber "must fill in" editthis boxes. */
 .seg-text {
-  white-space: pre-wrap;
+  display: block;
+  width: 100%;
+  margin: 4px 0;
+  padding: 4px 8px;
+  border: 1px solid #dee2e6;
+  border-radius: 6px;
+  background-color: #fff;
+  font: inherit;
+  line-height: 1.4;
+}
+.seg-text:hover {
+  border-color: #adb5bd;
+}
+.seg-text:focus,
+.seg-text:focus-visible {
+  outline: none;
+  border-color: #0d6efd;
+  box-shadow: 0 0 0 0.2rem rgba(13, 110, 253, 0.25);
 }
 /* editthis boxes sit on their own full-width line so each editable bit reads as
    a clear fillable field. A placeholder box is highlighted (amber) so outstanding

--- a/iznik-nuxt3/modtools/utils/stdMessageDirectives.js
+++ b/iznik-nuxt3/modtools/utils/stdMessageDirectives.js
@@ -45,9 +45,7 @@ function matchInners(text, re) {
 // final message a recipient sees (after the mod has edited/decided).
 export function stripDirectiveTags(text) {
   if (!text) return text
-  return text
-    .replace(/<\/?editthis>/gi, '')
-    .replace(/<\/?optional>/gi, '')
+  return text.replace(/<\/?editthis>/gi, '').replace(/<\/?optional>/gi, '')
 }
 
 // Replace the Nth (0-based) occurrence of a tag with `replacement(inner)`.
@@ -100,7 +98,11 @@ export function hasUndecidedOptional(text) {
 export function sendBlockers(currentText, originalEditThisInners) {
   const editThis = pendingEditThis(currentText, originalEditThisInners)
   const optional = hasUndecidedOptional(currentText)
-  return { editThis, optionalUndecided: optional, ok: editThis.length === 0 && !optional }
+  return {
+    editThis,
+    optionalUndecided: optional,
+    ok: editThis.length === 0 && !optional,
+  }
 }
 
 // ── Segmented editor model ──────────────────────────────────────────────────
@@ -112,7 +114,7 @@ export function sendBlockers(currentText, originalEditThisInners) {
 // template.
 //
 // Segment shapes:
-//   { type: 'text',     content }                 fixed prose (not editable)
+//   { type: 'text',     content }                 prose; freely editable (content)
 //   { type: 'editthis', content, value, edited }  must-fill; content=placeholder
 //   { type: 'optional', content, removed }        removed: undefined until decided
 const SEGMENT_RE = /<(editthis|optional)>([\s\S]*?)<\/\1>/gi
@@ -124,14 +126,17 @@ export function parseSegments(text) {
   let last = 0
   let m
   while ((m = re.exec(text)) !== null) {
-    if (m.index > last) segments.push({ type: 'text', content: text.slice(last, m.index) })
+    if (m.index > last)
+      segments.push({ type: 'text', content: text.slice(last, m.index) })
     const type = m[1].toLowerCase() // 'editthis' | 'optional'
     const content = m[2]
-    if (type === 'editthis') segments.push({ type, content, value: content, edited: false })
+    if (type === 'editthis')
+      segments.push({ type, content, value: content, edited: false })
     else segments.push({ type, content, removed: undefined })
     last = m.index + m[0].length
   }
-  if (last < text.length) segments.push({ type: 'text', content: text.slice(last) })
+  if (last < text.length)
+    segments.push({ type: 'text', content: text.slice(last) })
   return segments
 }
 
@@ -171,5 +176,9 @@ export function segmentsSendBlockers(segments) {
       undecided.push(i)
     }
   })
-  return { unedited, undecided, ok: unedited.length === 0 && undecided.length === 0 }
+  return {
+    unedited,
+    undecided,
+    ok: unedited.length === 0 && undecided.length === 0,
+  }
 }

--- a/iznik-nuxt3/tests/unit/components/modtools/ModStdMessageModal.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModStdMessageModal.spec.js
@@ -603,4 +603,91 @@ describe('ModStdMessageModal', () => {
       expect(wrapper.vm.body).toBe('')
     })
   })
+
+  describe('segmented editor — editable fixed prose', () => {
+    const directiveStdmsg = () =>
+      createStdmsg({
+        action: 'Approve',
+        body: 'Hello,\n\nThanks for using $groupname.\n\n<editthis>say something specific</editthis>\n\nCheers from the team.',
+        insert: 'Top',
+      })
+
+    it('renders fixed prose as editable textareas, not static spans', async () => {
+      const wrapper = mountComponent({}, { stdmsgData: directiveStdmsg() })
+      await wrapper.vm.fillin()
+      await wrapper.vm.$nextTick()
+
+      expect(wrapper.vm.useSegmentedEditor).toBe(true)
+      // The whole message is editable now: fixed prose renders as a textarea, so
+      // there is no longer a static (read-only) span for it.
+      expect(wrapper.find('span.seg-text').exists()).toBe(false)
+      expect(wrapper.find('textarea.seg-text').exists()).toBe(true)
+    })
+
+    it('includes edits to the fixed prose in the message that is sent', async () => {
+      const wrapper = mountComponent({}, { stdmsgData: directiveStdmsg() })
+      await wrapper.vm.fillin()
+
+      // Personalise the must-fill box and tweak a bit of the surrounding prose.
+      const editthis = wrapper.vm.segments.find((s) => s.type === 'editthis')
+      editthis.value = 'Hope you find what you are looking for soon'
+      const textSeg = wrapper.vm.segments.find((s) => s.type === 'text')
+      textSeg.content += ' EDITED-PROSE-MARKER and a few more words.'
+
+      await wrapper.vm.process()
+
+      expect(mockMessageStore.approve).toHaveBeenCalled()
+      // approve(messageid, groupid, subject, stdmsgid, body) — body is arg 5.
+      const bodyArg = mockMessageStore.approve.mock.calls[0][4]
+      expect(bodyArg).toContain('EDITED-PROSE-MARKER')
+      expect(bodyArg).toContain('Hope you find what you are looking for soon')
+      // Directive tags never reach the recipient.
+      expect(bodyArg).not.toContain('<editthis>')
+    })
+  })
+
+  describe('editLink — TrashNothing awareness', () => {
+    const tnMessage = () =>
+      createMessage({
+        fromuser: {
+          id: 456,
+          displayname: 'TN User',
+          tnuserid: 5555,
+          emails: [],
+        },
+      })
+
+    it('uses the Freegle myposts link for a normal member', () => {
+      const wrapper = mountComponent()
+      expect(wrapper.vm.isTnUser).toBe(false)
+      expect(wrapper.vm.editLink).toBe('https://www.ilovefreegle.org/myposts')
+    })
+
+    it('uses the TrashNothing posts link when the member has a tnuserid', () => {
+      const wrapper = mountComponent({}, { message: tnMessage() })
+      expect(wrapper.vm.isTnUser).toBe(true)
+      expect(wrapper.vm.editLink).toBe('https://trashnothing.com/user/posts')
+    })
+
+    it('detects TrashNothing from a trashnothing.com from-address', () => {
+      const wrapper = mountComponent(
+        {},
+        { message: createMessage({ fromaddr: 'someone@trashnothing.com' }) }
+      )
+      expect(wrapper.vm.isTnUser).toBe(true)
+      expect(wrapper.vm.editLink).toBe('https://trashnothing.com/user/posts')
+    })
+
+    it('substitutes $editlink with the TrashNothing link for a TN member', async () => {
+      const wrapper = mountComponent({}, { message: tnMessage() })
+      const out = await wrapper.vm.substitutionStrings('Edit here: $editlink')
+      expect(out).toBe('Edit here: https://trashnothing.com/user/posts')
+    })
+
+    it('substitutes $editlink with the Freegle link for a normal member', async () => {
+      const wrapper = mountComponent()
+      const out = await wrapper.vm.substitutionStrings('Edit here: $editlink')
+      expect(out).toBe('Edit here: https://www.ilovefreegle.org/myposts')
+    })
+  })
 })

--- a/iznik-nuxt3/tests/unit/modtools/utils/stdMessageDirectives.spec.js
+++ b/iznik-nuxt3/tests/unit/modtools/utils/stdMessageDirectives.spec.js
@@ -17,7 +17,8 @@ import {
 describe('stdMessageDirectives', () => {
   describe('parseEditThis', () => {
     it('returns the inner text of each editthis block', () => {
-      const t = 'Hi <editthis>a clearer title</editthis> and <editthis>why</editthis>.'
+      const t =
+        'Hi <editthis>a clearer title</editthis> and <editthis>why</editthis>.'
       expect(parseEditThis(t)).toEqual(['a clearer title', 'why'])
     })
     it('is case-insensitive and multiline', () => {
@@ -125,20 +126,44 @@ describe('stdMessageDirectives', () => {
 
   describe('parseSegments', () => {
     it('splits a message into ordered text/editthis/optional segments', () => {
-      const t = 'Hi <editthis>name</editthis>, see <optional>browse first</optional> ok'
+      const t =
+        'Hi <editthis>name</editthis>, see <optional>browse first</optional> ok'
       const segs = parseSegments(t)
       expect(segs.map((s) => s.type)).toEqual([
-        'text', 'editthis', 'text', 'optional', 'text',
+        'text',
+        'editthis',
+        'text',
+        'optional',
+        'text',
       ])
       expect(segs[0].content).toBe('Hi ')
-      expect(segs[1]).toMatchObject({ type: 'editthis', content: 'name', value: 'name', edited: false })
-      expect(segs[3]).toMatchObject({ type: 'optional', content: 'browse first', removed: undefined })
+      expect(segs[1]).toMatchObject({
+        type: 'editthis',
+        content: 'name',
+        value: 'name',
+        edited: false,
+      })
+      expect(segs[3]).toMatchObject({
+        type: 'optional',
+        content: 'browse first',
+        removed: undefined,
+      })
       expect(segs[4].content).toBe(' ok')
     })
     it('preserves order with multiple editthis blocks', () => {
-      const segs = parseSegments('a<editthis>1</editthis>b<editthis>2</editthis>c')
-      expect(segs.filter((s) => s.type === 'editthis').map((s) => s.content)).toEqual(['1', '2'])
-      expect(segs.map((s) => s.type)).toEqual(['text', 'editthis', 'text', 'editthis', 'text'])
+      const segs = parseSegments(
+        'a<editthis>1</editthis>b<editthis>2</editthis>c'
+      )
+      expect(
+        segs.filter((s) => s.type === 'editthis').map((s) => s.content)
+      ).toEqual(['1', '2'])
+      expect(segs.map((s) => s.type)).toEqual([
+        'text',
+        'editthis',
+        'text',
+        'editthis',
+        'text',
+      ])
     })
     it('handles a plain message (single text segment) and empty input', () => {
       expect(parseSegments('just text').map((s) => s.type)).toEqual(['text'])
@@ -157,22 +182,36 @@ describe('stdMessageDirectives', () => {
 
   describe('assembleSegments', () => {
     it('builds the final message from edited segments in order', () => {
-      const segs = parseSegments('Hi <editthis>NAME</editthis>.\n\n<optional>browse first</optional>\n\nThanks')
+      const segs = parseSegments(
+        'Hi <editthis>NAME</editthis>.\n\n<optional>browse first</optional>\n\nThanks'
+      )
       segs.find((s) => s.type === 'editthis').value = 'Jo'
       segs.find((s) => s.type === 'optional').removed = false // kept
       expect(assembleSegments(segs)).toBe('Hi Jo.\n\nbrowse first\n\nThanks')
     })
     it('drops a removed optional and tidies the blank lines', () => {
-      const segs = parseSegments('Hi <editthis>NAME</editthis>.\n\n<optional>browse first</optional>\n\nThanks')
+      const segs = parseSegments(
+        'Hi <editthis>NAME</editthis>.\n\n<optional>browse first</optional>\n\nThanks'
+      )
       segs.find((s) => s.type === 'editthis').value = 'Jo'
       segs.find((s) => s.type === 'optional').removed = true
       expect(assembleSegments(segs)).toBe('Hi Jo.\n\nThanks')
+    })
+    it('includes edits made to a fixed text segment', () => {
+      // The mod can edit the surrounding prose, not just the editthis boxes.
+      const segs = parseSegments('Hello <editthis>NAME</editthis>, thanks.')
+      segs.find((s) => s.type === 'editthis').value = 'Jo'
+      const textSeg = segs.find((s) => s.type === 'text')
+      textSeg.content = textSeg.content.replace('Hello', 'Hi there')
+      expect(assembleSegments(segs)).toBe('Hi there Jo, thanks.')
     })
   })
 
   describe('segmentsSendBlockers', () => {
     it('blocks while an editthis is unchanged or an optional undecided', () => {
-      const segs = parseSegments('Hi <editthis>NAME</editthis> <optional>x</optional>')
+      const segs = parseSegments(
+        'Hi <editthis>NAME</editthis> <optional>x</optional>'
+      )
       let r = segmentsSendBlockers(segs)
       expect(r.ok).toBe(false)
       expect(r.unedited.length).toBe(1)


### PR DESCRIPTION
## What & why

Two fixes to the recent ModTools standard-message changes (the segmented "directive" editor from #659).

### 1. The whole reply is editable again, not just the highlighted boxes
The segmented editor rendered the fixed prose (greeting, closing, etc.) as a **read-only `<span>`** — only the amber `<editthis>` boxes could be edited. Mods reported they could no longer tweak the rest of the wording (e.g. personalise the greeting).

Fix: render `text` segments as auto-sizing `<b-form-textarea>`s bound to `seg.content`, styled to read as part of the message (a light border that strengthens on hover/focus) while staying visually quieter than the amber "must fill in" boxes. `assembleSegments` already emits text segments verbatim, so edits flow straight through to what the member receives. Send-gating (must-fill boxes / keep-or-remove optionals) is unchanged.

| Before | After |
|---|---|
| Greeting/closing prose = static span, uneditable | Every part of the message is an editable field; editthis boxes keep their amber highlight |

### 2. `$editlink` is TrashNothing-aware
`$editlink` always resolved to `https://www.ilovefreegle.org/myposts`. For **TrashNothing** members that's a dead end — they manage their posts on TN's own site. Per [TN's help docs](https://help.trashnothing.com/how-do-i-edit-my-post), the edit/repost page is **`https://trashnothing.com/user/posts`** ("Your Posts"). TN members (detected via `tnuserid`, or a `trashnothing.com` from-address as a fallback) now get that link; everyone else is unchanged.

## Tests
- New: editable-prose renders as a textarea (not a span) + edits reach the sent body; `editLink`/`isTnUser` + `$editlink` substitution for TN and non-TN members; `assembleSegments` text-edit case.
- **78 unit tests pass** (`ModStdMessageModal.spec.js` + `stdMessageDirectives.spec.js`) — run in the worktree's modtools dev container (the local status API has no unit-test endpoint).
- ESLint clean on the changed lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
