### PR TITLE
fix(ModTools Images badge count): decrement count after accept/keep/suppress

### DIFF
--- a/iznik-nuxt3/modtools/composables/useAIImages.js
+++ b/iznik-nuxt3/modtools/composables/useAIImages.js
@@ -34,15 +34,21 @@ export function useAIImages() {
   }
 
   async function accept(id, pendingExternaluid) {
-    return $api.aiimages.accept(id, pendingExternaluid)
+    const result = await $api.aiimages.accept(id, pendingExternaluid)
+    count.value = Math.max(0, count.value - 1)
+    return result
   }
 
   async function keep(id) {
-    return $api.aiimages.keep(id)
+    const result = await $api.aiimages.keep(id)
+    count.value = Math.max(0, count.value - 1)
+    return result
   }
 
   async function suppress(id) {
-    return $api.aiimages.suppress(id)
+    const result = await $api.aiimages.suppress(id)
+    count.value = Math.max(0, count.value - 1)
+    return result
   }
 
   return {

--- a/iznik-nuxt3/tests/unit/composables/useAIImages.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useAIImages.spec.js
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// useAIImages calls useNuxtApp() as a Nuxt auto-import (no explicit import).
+// Wire it globally so the composable finds it in scope at call time.
+let mockAiimages
+
+beforeEach(() => {
+  mockAiimages = {
+    count: vi.fn().mockResolvedValue({ count: 0 }),
+    review: vi.fn().mockResolvedValue([]),
+    accept: vi.fn().mockResolvedValue({}),
+    keep: vi.fn().mockResolvedValue({}),
+    suppress: vi.fn().mockResolvedValue({}),
+    regenerate: vi.fn().mockResolvedValue({}),
+  }
+  globalThis.useNuxtApp = () => ({ $api: { aiimages: mockAiimages } })
+})
+
+afterEach(() => {
+  vi.resetModules()
+})
+
+// Fresh import after resetModules so module-level refs start from zero.
+async function freshComposable() {
+  vi.resetModules()
+  const { useAIImages } = await import('~/modtools/composables/useAIImages')
+  return useAIImages()
+}
+
+describe('useAIImages badge count', () => {
+  it('count is set by fetchReview()', async () => {
+    mockAiimages.review.mockResolvedValue([{ id: 1 }, { id: 2 }, { id: 3 }])
+    const { count, fetchReview } = await freshComposable()
+    await fetchReview()
+    expect(count.value).toBe(3)
+  })
+
+  it('count decrements after accept()', async () => {
+    mockAiimages.review.mockResolvedValue([{ id: 1 }, { id: 2 }, { id: 3 }])
+    mockAiimages.accept.mockResolvedValue({})
+    const { count, fetchReview, accept } = await freshComposable()
+    await fetchReview()
+    expect(count.value).toBe(3)
+
+    await accept(1, '')
+    // Badge must clear as images are processed — not stay stale until navigate-away.
+    expect(count.value).toBe(2)
+  })
+
+  it('count decrements after keep()', async () => {
+    mockAiimages.review.mockResolvedValue([{ id: 1 }, { id: 2 }])
+    mockAiimages.keep.mockResolvedValue({})
+    const { count, fetchReview, keep } = await freshComposable()
+    await fetchReview()
+    expect(count.value).toBe(2)
+
+    await keep(1)
+    expect(count.value).toBe(1)
+  })
+
+  it('count decrements after suppress()', async () => {
+    mockAiimages.review.mockResolvedValue([{ id: 1 }])
+    mockAiimages.suppress.mockResolvedValue({})
+    const { count, fetchReview, suppress } = await freshComposable()
+    await fetchReview()
+    expect(count.value).toBe(1)
+
+    await suppress(1)
+    expect(count.value).toBe(0)
+  })
+
+  it('count does not go below zero', async () => {
+    mockAiimages.accept.mockResolvedValue({})
+    const { count, accept } = await freshComposable()
+    // count starts at 0 — a defensive call must not go negative
+    await accept(99, '')
+    expect(count.value).toBe(0)
+  })
+
+  it('count is not decremented when accept() throws', async () => {
+    mockAiimages.review.mockResolvedValue([{ id: 1 }, { id: 2 }])
+    mockAiimages.accept.mockRejectedValue(new Error('network'))
+    const { count, fetchReview, accept } = await freshComposable()
+    await fetchReview()
+    expect(count.value).toBe(2)
+
+    await expect(accept(1, '')).rejects.toThrow('network')
+    // Failed action — count must stay unchanged
+    expect(count.value).toBe(2)
+  })
+})


### PR DESCRIPTION
## Root Cause

`useAIImages.js` holds a module-level `count` ref that drives the left-nav Images badge via `:directcount`. `fetchReview()` sets `count.value = images.length` on page load, but `accept()`, `keep()`, and `suppress()` each fired the API call and returned without touching `count.value`. So the badge stayed stale until the user navigated away (re-mounting the layout and re-calling `fetchCount()`).

## Evidence

Failing tests before fix (buggy behaviour confirmed):
```
× count decrements after accept() → expected 3 to be 2
× count decrements after keep()   → expected 2 to be 1
× count decrements after suppress() → expected 1 to be 0
```
All 6 tests pass after fix.

## Fix

In `modtools/composables/useAIImages.js`, `accept()`, `keep()`, and `suppress()` now await the API call and then do `count.value = Math.max(0, count.value - 1)` on success. If the call throws, `count` is not decremented (error path leaves count unchanged). `regenerate()` is deliberately excluded — it generates a preview, not removes an image from the queue.

## Other Call Sites

`regenerate()` in the same composable — intentionally excluded (does not finalise/remove an image). No other callers of `accept/keep/suppress`.

## Test

File: `iznik-nuxt3/tests/unit/composables/useAIImages.spec.js`

Command: `POST /api/tests/vitest {"filter":"useAIImages"}`

Proves:
- fail-before: count stays at 3/2/1 after accept/keep/suppress (was the bug)
- pass-after: count decrements correctly; also covers floor-at-zero and no-decrement-on-throw

## Discourse

https://discourse.ilovefreegle.org/t/9630/44