### PR TITLE
style(modtools/stdmsg): make the segmented-editor instruction red

### DIFF
--- a/iznik-nuxt3/modtools/components/ModStdMessageModal.vue
+++ b/iznik-nuxt3/modtools/components/ModStdMessageModal.vue
@@ -66,7 +66,7 @@
            and a keep/remove control per <optional>, filled in order so you never
            have to look back at the template. -->
       <div v-else class="mt-2 segmented-editor border rounded p-3">
-        <p class="text-muted small mb-2">
+        <p class="text-danger small mb-2">
           Fill in the highlighted boxes and choose Keep or Remove for any
           optional parts. You can edit any of the rest of the wording too. This
           is the message the member will receive.


### PR DESCRIPTION
Follow-up to #750 (which merged before this change landed). Renders the "Fill in the highlighted boxes…" guidance in **red** (`text-danger`) instead of muted grey so mods notice it. One-line class change; 78 unit tests pass, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)