### PR TITLE
ci(build): retry transient npm network failures in container builds

### DIFF
--- a/docker/embedding-sidecar/Dockerfile
+++ b/docker/embedding-sidecar/Dockerfile
@@ -2,7 +2,7 @@ FROM node:20-slim
 RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY package.json .
-RUN npm install
+RUN npm install --fetch-retries=5 --fetch-retry-mintimeout=20000 --fetch-retry-maxtimeout=120000
 COPY server.mjs .
 # Pre-download model on build so startup is fast
 RUN echo "import {pipeline,env} from '@huggingface/transformers'; env.cacheDir='/app/model-cache'; await pipeline('feature-extraction','nomic-ai/nomic-embed-text-v1.5',{quantized:true}); console.log('Model cached.');" > /app/prebuild.mjs && node /app/prebuild.mjs && rm /app/prebuild.mjs

--- a/iznik-nuxt3/Dockerfile
+++ b/iznik-nuxt3/Dockerfile
@@ -7,7 +7,7 @@ ENV IZNIK_API_V1=http://freegle-apiv1:80/api \
 
 COPY package*.json setup-hooks.* ./
 COPY patches/ ./patches/
-RUN npm install --legacy-peer-deps
+RUN npm install --legacy-peer-deps --fetch-retries=5 --fetch-retry-mintimeout=20000 --fetch-retry-maxtimeout=120000
 
 COPY . .
 

--- a/iznik-nuxt3/Dockerfile.playwright
+++ b/iznik-nuxt3/Dockerfile.playwright
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Install Playwright and related packages
 # Version should match iznik-nuxt3/package.json
-RUN npm install -g @playwright/test@1.52.0 monocart-reporter coveralls
+RUN npm install -g @playwright/test@1.52.0 monocart-reporter coveralls --fetch-retries=5 --fetch-retry-mintimeout=20000 --fetch-retry-maxtimeout=120000
 
 # Install Playwright browsers and dependencies
 RUN npx playwright install chromium && npx playwright install-deps

--- a/iznik-nuxt3/modtools/Dockerfile
+++ b/iznik-nuxt3/modtools/Dockerfile
@@ -9,13 +9,13 @@ ENV IZNIK_API_V1=http://freegle-apiv1:80/api \
 COPY iznik-nuxt3 .
 
 # Install dependencies in parent directory and generate .nuxt
-RUN npm install --legacy-peer-deps && npx nuxi prepare
+RUN npm install --legacy-peer-deps --fetch-retries=5 --fetch-retry-mintimeout=20000 --fetch-retry-maxtimeout=120000 && npx nuxi prepare
 
 # Change to modtools directory
 WORKDIR /app/modtools
 
 # Install modtools specific dependencies
-RUN npm install --legacy-peer-deps
+RUN npm install --legacy-peer-deps --fetch-retries=5 --fetch-retry-mintimeout=20000 --fetch-retry-maxtimeout=120000
 
 EXPOSE 3000
 

--- a/iznik-nuxt3/modtools/Dockerfile.prod
+++ b/iznik-nuxt3/modtools/Dockerfile.prod
@@ -10,13 +10,13 @@ ENV IZNIK_API_V1=http://freegle-apiv1:80/api \
 COPY . .
 
 # Install dependencies in parent directory and generate .nuxt
-RUN npm install --legacy-peer-deps && npx nuxi prepare
+RUN npm install --legacy-peer-deps --fetch-retries=5 --fetch-retry-mintimeout=20000 --fetch-retry-maxtimeout=120000 && npx nuxi prepare
 
 # Change to modtools directory
 WORKDIR /app/modtools
 
 # Install modtools specific dependencies
-RUN npm install --legacy-peer-deps
+RUN npm install --legacy-peer-deps --fetch-retries=5 --fetch-retry-mintimeout=20000 --fetch-retry-maxtimeout=120000
 
 EXPOSE 3001
 

--- a/status-nuxt/Dockerfile
+++ b/status-nuxt/Dockerfile
@@ -14,7 +14,7 @@ ENV DOCKER_API_VERSION=1.44
 COPY package*.json ./
 
 # Install dependencies (using npm install since we don't have package-lock.json yet)
-RUN npm install
+RUN npm install --fetch-retries=5 --fetch-retry-mintimeout=20000 --fetch-retry-maxtimeout=120000
 
 # Copy source code
 COPY . .

--- a/status/Dockerfile
+++ b/status/Dockerfile
@@ -3,7 +3,7 @@ FROM ghcr.io/freegle/freegle-base:latest
 WORKDIR /app
 
 COPY package.json ./
-RUN npm install
+RUN npm install --fetch-retries=5 --fetch-retry-mintimeout=20000 --fetch-retry-maxtimeout=120000
 
 COPY . .
 

--- a/support-tools/mcp-interface/Dockerfile
+++ b/support-tools/mcp-interface/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /app
 COPY package.json ./
 
 # Install dependencies
-RUN npm install --production
+RUN npm install --production --fetch-retries=5 --fetch-retry-mintimeout=20000 --fetch-retry-maxtimeout=120000
 
 # Copy application code
 COPY server.js ./

--- a/support-tools/pseudonymizer/Dockerfile
+++ b/support-tools/pseudonymizer/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /app
 COPY package.json ./
 
 # Install dependencies
-RUN npm install --production
+RUN npm install --production --fetch-retries=5 --fetch-retry-mintimeout=20000 --fetch-retry-maxtimeout=120000
 
 # Copy application code
 COPY server.js db-query.js ./

--- a/support-tools/query-sanitizer/Dockerfile
+++ b/support-tools/query-sanitizer/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /app
 COPY package.json ./
 
 # Install dependencies
-RUN npm install --production
+RUN npm install --production --fetch-retries=5 --fetch-retry-mintimeout=20000 --fetch-retry-maxtimeout=120000
 
 # Copy application code
 COPY server.js ./


### PR DESCRIPTION
## Why
The CI **Build containers** step intermittently fails on `RUN npm install` with `ECONNRESET` — a transient registry/network drop, not a real dependency problem. It hit `embedding-sidecar`'s `[5/7] RUN npm install` on PR #752's first run and needed a manual pipeline re-trigger (which then passed unchanged).

## What
npm's default `fetch-retries` is only **2**. This bumps every `npm install` the CI build runs to `--fetch-retries=5` with longer backoff (`--fetch-retry-mintimeout=20000 --fetch-retry-maxtimeout=120000`), so a transient blip self-heals instead of failing the pipeline.

Covers: `iznik-nuxt3` (freegle + modtools, dev + prod), `status`, `status-nuxt`, `embedding-sidecar`, the Playwright global install, and the three `support-tools` services — 12 `npm install` invocations across 10 Dockerfiles. No logic change; CI validates the builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)