### PR TITLE
fix(modtools/stdmsg): 3-line minimum height for segment edit boxes

### DIFF
--- a/iznik-nuxt3/modtools/components/ModStdMessageModal.vue
+++ b/iznik-nuxt3/modtools/components/ModStdMessageModal.vue
@@ -77,15 +77,15 @@
               v-if="seg.type === 'text'"
               v-model="seg.content"
               class="seg-text"
-              rows="1"
+              rows="3"
               max-rows="30"
             />
             <b-form-textarea
               v-else-if="seg.type === 'editthis'"
               v-model="seg.value"
               :class="['seg-editthis', { 'seg-todo': !segEdited(seg) }]"
-              rows="1"
-              max-rows="8"
+              rows="3"
+              max-rows="12"
               :placeholder="seg.content"
             />
             <span v-else-if="seg.type === 'optional'" class="seg-optional">


### PR DESCRIPTION
The segmented standard-message editor (added in #750) rendered each editable box as a 1-row auto-growing textarea, so empty/short segments showed as a single cramped line (see ModTools std-message reply modal).

Sets `rows=3` (minimum 3 lines) on both editable segment types — prose `text` segments and `editthis` fill-ins — keeping the adaptive growth (`max-rows` 30 / 12). The modal scrolls when the content is tall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)