### PR TITLE
feat(app): share an image into Freegle to start an Offer (Android)

### DIFF
--- a/iznik-nuxt3/android/app/src/main/AndroidManifest.xml
+++ b/iznik-nuxt3/android/app/src/main/AndroidManifest.xml
@@ -29,6 +29,19 @@
         <data android:host=" " />
         <data android:pathPrefix="/" />
       </intent-filter>
+      <!-- Share an image into Freegle from another app ("Share" -> Freegle) to
+           start an OFFER with the photo pre-attached. Handled natively in
+           MainActivity (ACTION_SEND / ACTION_SEND_MULTIPLE). -->
+      <intent-filter>
+        <action android:name="android.intent.action.SEND" />
+        <category android:name="android.intent.category.DEFAULT" />
+        <data android:mimeType="image/*" />
+      </intent-filter>
+      <intent-filter>
+        <action android:name="android.intent.action.SEND_MULTIPLE" />
+        <category android:name="android.intent.category.DEFAULT" />
+        <data android:mimeType="image/*" />
+      </intent-filter>
     </activity>
     <activity android:name="com.facebook.FacebookActivity"
         android:configChanges="keyboard|keyboardHidden|screenLayout|screenSize|orientation"

--- a/iznik-nuxt3/android/app/src/main/java/org/ilovefreegle/direct/MainActivity.java
+++ b/iznik-nuxt3/android/app/src/main/java/org/ilovefreegle/direct/MainActivity.java
@@ -2,6 +2,7 @@ package org.ilovefreegle.direct;
 
 import android.util.Log;
 import android.webkit.WebView;
+import android.webkit.JavascriptInterface;
 import com.getcapacitor.BridgeActivity;
 import android.os.Bundle;
 import ee.forgr.capacitor.social.login.GoogleProvider;
@@ -10,8 +11,20 @@ import ee.forgr.capacitor.social.login.ModifiedMainActivityForSocialLoginPlugin;
 import com.getcapacitor.PluginHandle;
 import com.getcapacitor.Plugin;
 import android.content.Intent;
+import android.net.Uri;
+import org.json.JSONArray;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.ArrayList;
 
 public class MainActivity extends BridgeActivity implements ModifiedMainActivityForSocialLoginPlugin {
+
+  // Absolute paths of images shared into the app (ACTION_SEND) but not yet handed
+  // to the WebView. The web layer pulls them via window.FreegleShare.consume() on
+  // startup and on every resume, then starts an OFFER with them pre-attached.
+  private final ArrayList<String> pendingSharedImages = new ArrayList<>();
 
   public void onCreate(Bundle savedInstanceState) {
     //Log.e("PHDCC","org.ilovefreegle.direct onCreate A");
@@ -21,6 +34,89 @@ public class MainActivity extends BridgeActivity implements ModifiedMainActivity
     if ((getApplicationInfo().flags & android.content.pm.ApplicationInfo.FLAG_DEBUGGABLE) != 0) {
       WebView.setWebContentsDebuggingEnabled(true);
       Log.d("MainActivity", "WebView debugging enabled for chrome://inspect");
+    }
+
+    // Expose a tiny bridge so the WebView can pull images shared into the app.
+    // The WebView only ever loads our own bundle, so a named interface is safe.
+    WebView webView = getBridge() != null ? getBridge().getWebView() : null;
+    if (webView != null) {
+      webView.addJavascriptInterface(new ShareIntentBridge(), "FreegleShare");
+    }
+
+    handleSendIntent(getIntent());
+  }
+
+  @Override
+  protected void onNewIntent(Intent intent) {
+    super.onNewIntent(intent);
+    // Keep getIntent() current so a later cold-start path sees the right intent.
+    setIntent(intent);
+    handleSendIntent(intent);
+  }
+
+  // Capture an image (or images) shared into Freegle from another app. We copy
+  // each one into our cache because the content:// read permission is scoped to
+  // this intent; the cache file is then readable by the WebView later via
+  // Capacitor.convertFileSrc().
+  private void handleSendIntent(Intent intent) {
+    if (intent == null) return;
+    String action = intent.getAction();
+    String type = intent.getType();
+    if (action == null || type == null || !type.startsWith("image/")) return;
+
+    try {
+      if (Intent.ACTION_SEND.equals(action)) {
+        Uri uri = intent.getParcelableExtra(Intent.EXTRA_STREAM);
+        if (uri != null) copySharedImage(uri);
+      } else if (Intent.ACTION_SEND_MULTIPLE.equals(action)) {
+        ArrayList<Uri> uris = intent.getParcelableArrayListExtra(Intent.EXTRA_STREAM);
+        if (uris != null) {
+          for (Uri uri : uris) {
+            if (uri != null) copySharedImage(uri);
+          }
+        }
+      }
+    } catch (Exception e) {
+      Log.e("MainActivity", "Failed to handle shared image", e);
+    }
+  }
+
+  private void copySharedImage(Uri uri) {
+    try {
+      File dir = new File(getCacheDir(), "shared");
+      if (!dir.exists()) dir.mkdirs();
+      File out;
+      synchronized (pendingSharedImages) {
+        out = new File(dir, "share-" + System.currentTimeMillis() + "-" + pendingSharedImages.size() + ".jpg");
+      }
+      try (InputStream in = getContentResolver().openInputStream(uri);
+           OutputStream os = new FileOutputStream(out)) {
+        if (in == null) return;
+        byte[] buf = new byte[8192];
+        int n;
+        while ((n = in.read(buf)) > 0) os.write(buf, 0, n);
+      }
+      synchronized (pendingSharedImages) {
+        pendingSharedImages.add(out.getAbsolutePath());
+      }
+      Log.d("MainActivity", "Stored shared image " + out.getAbsolutePath());
+    } catch (Exception e) {
+      Log.e("MainActivity", "Failed to copy shared image", e);
+    }
+  }
+
+  // window.FreegleShare.consume() returns a JSON array of absolute file paths for
+  // images shared into the app and clears the queue. The web layer converts each
+  // with Capacitor.convertFileSrc() and feeds it into the give-flow uploader.
+  public class ShareIntentBridge {
+    @JavascriptInterface
+    public String consume() {
+      JSONArray arr = new JSONArray();
+      synchronized (pendingSharedImages) {
+        for (String p : pendingSharedImages) arr.put(p);
+        pendingSharedImages.clear();
+      }
+      return arr.toString();
     }
   }
 

--- a/iznik-nuxt3/components/PhotoUploader.vue
+++ b/iznik-nuxt3/components/PhotoUploader.vue
@@ -723,6 +723,11 @@ onBeforeUnmount(() => {
     uppy.value = null
   }
 })
+
+// Allow a parent (e.g. the give-flow photos page handling a shared image) to
+// push a photo in programmatically. processPhoto runs the same quality check +
+// upload path as the camera/gallery flows; webPath must be fetch()-able.
+defineExpose({ processPhoto })
 </script>
 
 <style scoped lang="scss">

--- a/iznik-nuxt3/pages/give/mobile/photos.vue
+++ b/iznik-nuxt3/pages/give/mobile/photos.vue
@@ -3,6 +3,7 @@
     <!-- Main content -->
     <div class="app-content">
       <PhotoUploader
+        ref="photoUploader"
         v-model="attachments"
         type="Message"
         :recognise="attachments.length === 0"
@@ -25,16 +26,21 @@
 </template>
 
 <script setup>
-import { ref, computed } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { useRouter } from '#imports'
 import { useComposeStore } from '~/stores/compose'
 import { useAuthStore } from '~/stores/auth'
 import { useMiscStore } from '~/stores/misc'
+import { useMobileStore } from '~/stores/mobile'
 
 const router = useRouter()
 const composeStore = useComposeStore()
 const authStore = useAuthStore()
 const miscStore = useMiscStore()
+const mobileStore = useMobileStore()
+
+// Ref to the PhotoUploader so a shared image (Share -> Freegle) can be fed in.
+const photoUploader = ref(null)
 
 // Check if sticky ad is rendered
 const stickyAdRendered = computed(() => miscStore.stickyAdRendered)
@@ -90,6 +96,23 @@ function onPhotoProcessed() {
 function goNext() {
   router.push('/give/mobile/details')
 }
+
+// If the user reached this page by sharing an image into Freegle from another
+// app, attach the shared photo(s) to this OFFER. The native layer populates
+// mobileStore.pendingSharedImages and routes us here (see stores/mobile.js).
+onMounted(async () => {
+  const shared = mobileStore.pendingSharedImages
+  if (!shared || shared.length === 0) return
+  // Clear first so a later resume/navigation doesn't re-add the same photos.
+  mobileStore.pendingSharedImages = []
+  for (const webPath of shared) {
+    try {
+      await photoUploader.value?.processPhoto(webPath)
+    } catch (e) {
+      console.log('Failed to attach shared image', e?.message)
+    }
+  }
+})
 </script>
 
 <style scoped lang="scss">

--- a/iznik-nuxt3/stores/mobile.js
+++ b/iznik-nuxt3/stores/mobile.js
@@ -49,6 +49,9 @@ export const useMobileStore = defineStore({
     route: false,
     apprequiredversion: false,
     appupdaterequired: false,
+    // URLs (Capacitor.convertFileSrc) of images shared into the app from another
+    // app, waiting to be attached to a new OFFER by the give-flow photos page.
+    pendingSharedImages: [],
   }),
   actions: {
     init(config) {
@@ -115,6 +118,7 @@ export const useMobileStore = defineStore({
       await this.getDeviceInfo(Device)
       this.fixWindowOpen(AppLauncher)
       this.initDeepLinks(App)
+      this.initShareIntent(App)
       await this.initPushNotifications(PushNotifications, Badge)
       await this.checkForAppUpdate()
       this.initWakeUpActions(App)
@@ -285,6 +289,44 @@ export const useMobileStore = defineStore({
             }, 500)
           }
         })
+      }
+    },
+
+    // "Share an image into Freegle" (Android ACTION_SEND). The native layer
+    // (MainActivity) copies the shared image(s) to its cache and exposes them via
+    // the window.FreegleShare JS bridge. We pull them at startup (cold share) and
+    // on every resume (warm share), then route into the give flow with the photos
+    // pre-attached. No-op unless the native bridge is present.
+    initShareIntent(App) {
+      if (process.client) {
+        this.checkSharedIntent()
+        App.addListener('resume', () => {
+          this.checkSharedIntent()
+        })
+      }
+    },
+
+    checkSharedIntent() {
+      if (!process.client || !this.isApp) return
+      try {
+        const bridge = window.FreegleShare
+        if (!bridge || typeof bridge.consume !== 'function') return
+        const raw = bridge.consume()
+        if (!raw) return
+        let paths
+        try {
+          paths = JSON.parse(raw)
+        } catch (e) {
+          return
+        }
+        if (!Array.isArray(paths) || paths.length === 0) return
+        // Convert native cache-file paths into URLs the WebView can fetch().
+        this.pendingSharedImages = paths.map((p) => Capacitor.convertFileSrc(p))
+        console.log('Shared images received', this.pendingSharedImages.length)
+        const router = useRouter()
+        router.push('/give/mobile/photos')
+      } catch (e) {
+        console.log('checkSharedIntent failed', e?.message)
       }
     },
 


### PR DESCRIPTION
## What

Adds an Android **"Share → Freegle"** target. From the gallery, camera, or any
other app's share sheet, the user can send a photo straight into a new **OFFER**
with the image already attached — no need to open the app and re-pick it.

This is the Android half of the *Share-into-Freegle* feature. The iOS Share
Extension follows in a separate PR (it needs an App Group + provisioning-profile
changes, so it's staged on its own to avoid touching production signing here).

## How

- **AndroidManifest** — `ACTION_SEND` / `ACTION_SEND_MULTIPLE` `image/*`
  intent-filters on `MainActivity`.
- **MainActivity.java** — on `onCreate`/`onNewIntent`, copies the shared
  image(s) from the intent-scoped `content://` Uri into the app cache (the Uri
  permission doesn't outlive the intent) and exposes them to the WebView via a
  tiny `window.FreegleShare` JS bridge (`consume()` returns the file paths and
  clears the queue).
- **stores/mobile.js** — `initShareIntent` pulls shared images at startup (cold
  share) and on `resume` (warm share), converts the cache paths with
  `Capacitor.convertFileSrc`, queues them in `pendingSharedImages`, and routes
  to `/give/mobile/photos`.
- **PhotoUploader.vue** — `defineExpose({ processPhoto })` so a shared photo
  runs the *same* quality-check + tus-upload path as the camera/gallery flows.
- **give/mobile/photos.vue** — on mount, attaches any queued shared image(s),
  then clears the queue.

## Risk / testing

- Pure-additive: web behaviour and existing camera/gallery flows are unchanged
  unless the native `FreegleShare` bridge is present (Android app only).
- Native (manifest + Java) can't be built locally; verified via CI Android build
  and on-device share test.
- No new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)