### PR TITLE
fix(modtools): drop restricted media permissions to pass Google Play review

### DIFF
--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -23,7 +23,7 @@ parameters:
     description: "Forwarded from trigger — true when build_modtools_production was set"
 
 orbs:
-  freegle: freegle/tests@1.1.349
+  freegle: freegle/tests@1.1.350
 
 jobs:
   mark-ci-passed:

--- a/.circleci/orb/freegle-tests.yml
+++ b/.circleci/orb/freegle-tests.yml
@@ -3712,6 +3712,21 @@ jobs:
               fi
               sed -i 's|</manifest>|    <uses-permission android:name="com.google.android.gms.permission.AD_ID" tools:node="remove"/>\n</manifest>|' "$MANIFEST"
             fi
+            # ModTools needs no camera or media access: moderators pick existing
+            # images via the permission-free Android Photo Picker
+            # (Camera.pickImages -> PickVisualMedia). Convert the shared base
+            # manifest's CAMERA declaration into a tools:node="remove" override so
+            # the merged ModTools manifest declares ZERO camera/media permissions
+            # (Freegle keeps CAMERA for in-app capture). The restricted
+            # READ_MEDIA_IMAGES / legacy storage perms were already dropped from the
+            # shared base manifest. In-app "take a photo" still works in ModTools
+            # via the system ACTION_IMAGE_CAPTURE intent, which needs no permission.
+            if grep -q 'android.permission.CAMERA' "$MANIFEST"; then
+              if ! grep -q 'xmlns:tools' "$MANIFEST"; then
+                sed -i 's|<manifest|<manifest xmlns:tools="http://schemas.android.com/tools"|' "$MANIFEST"
+              fi
+              sed -i 's|<uses-permission android:name="android.permission.CAMERA"[[:space:]]*/>|<uses-permission android:name="android.permission.CAMERA" tools:node="remove"/>|' "$MANIFEST"
+            fi
             echo "✅ ModTools identity configured"
       - run:
           name: Set ModTools Launcher Icons
@@ -3937,6 +3952,21 @@ jobs:
                 sed -i 's|<manifest|<manifest xmlns:tools="http://schemas.android.com/tools"|' "$MANIFEST"
               fi
               sed -i 's|</manifest>|    <uses-permission android:name="com.google.android.gms.permission.AD_ID" tools:node="remove"/>\n</manifest>|' "$MANIFEST"
+            fi
+            # ModTools needs no camera or media access: moderators pick existing
+            # images via the permission-free Android Photo Picker
+            # (Camera.pickImages -> PickVisualMedia). Convert the shared base
+            # manifest's CAMERA declaration into a tools:node="remove" override so
+            # the merged ModTools manifest declares ZERO camera/media permissions
+            # (Freegle keeps CAMERA for in-app capture). The restricted
+            # READ_MEDIA_IMAGES / legacy storage perms were already dropped from the
+            # shared base manifest. In-app "take a photo" still works in ModTools
+            # via the system ACTION_IMAGE_CAPTURE intent, which needs no permission.
+            if grep -q 'android.permission.CAMERA' "$MANIFEST"; then
+              if ! grep -q 'xmlns:tools' "$MANIFEST"; then
+                sed -i 's|<manifest|<manifest xmlns:tools="http://schemas.android.com/tools"|' "$MANIFEST"
+              fi
+              sed -i 's|<uses-permission android:name="android.permission.CAMERA"[[:space:]]*/>|<uses-permission android:name="android.permission.CAMERA" tools:node="remove"/>|' "$MANIFEST"
             fi
             echo "✅ ModTools identity configured"
       - run:

--- a/iznik-nuxt3/android/app/src/main/AndroidManifest.xml
+++ b/iznik-nuxt3/android/app/src/main/AndroidManifest.xml
@@ -80,9 +80,14 @@
   <uses-permission android:name="android.permission.INTERNET"/>
   <uses-permission android:name="android.permission.READ_CALENDAR"/>
   <uses-permission android:name="android.permission.WRITE_CALENDAR"/>
-  <uses-permission android:name="android.permission.READ_MEDIA_IMAGES"/>
-  <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
-  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+  <!--
+    Photo upload uses the permission-free Android Photo Picker (Capacitor Camera
+    pickImages / getPhoto source Photos -> PickVisualMedia) and the system camera
+    intent, so none of the restricted media / legacy storage permissions are
+    needed. READ_MEDIA_IMAGES in particular is a Google Play restricted permission
+    that caused a ModTools review rejection ("permission not related to core
+    purpose"). Removed for both Freegle and ModTools.
+  -->
   <uses-permission android:name="android.permission.READ_CONTACTS" />
   <queries>
     <intent>

--- a/iznik-nuxt3/capacitor.config.modtools.js
+++ b/iznik-nuxt3/capacitor.config.modtools.js
@@ -33,6 +33,7 @@ const config = {
       '@capacitor/device',
       '@capacitor/browser',
       '@capacitor/app-launcher',
+      '@capacitor/camera',
     ],
     buildOptions: {
       releaseType: 'APK',
@@ -53,6 +54,7 @@ const config = {
       '@capacitor/device',
       '@capacitor/browser',
       '@capacitor/app-launcher',
+      '@capacitor/camera',
     ],
   },
 

--- a/plans/2026-06-15-modtools-photo-permissions.md
+++ b/plans/2026-06-15-modtools-photo-permissions.md
@@ -1,0 +1,65 @@
+# ModTools Google Play rejection: remove restricted media permissions
+
+**Date:** 2026-06-15
+**Branch:** `fix/modtools-photo-permissions`
+
+## Problem
+
+Google Play rejected the ModTools app (version code 1282): `READ_MEDIA_IMAGES`
+is a *restricted* permission and "Permission use is not directly related to your
+app's core purpose." ModTools only needs occasional photo upload (group IDs,
+post images), which does not qualify for broad media access.
+
+## Root cause
+
+Freegle and ModTools are built from the **same** native Android project
+(`iznik-nuxt3/android`). The shared `AndroidManifest.xml` hard-codes three
+restricted/legacy permissions (`READ_MEDIA_IMAGES`, `READ_EXTERNAL_STORAGE`,
+`WRITE_EXTERNAL_STORAGE`). They are **vestigial** — leftovers from the old
+Cordova camera plugin that predated the Android Photo Picker:
+
+- Gallery selection (`Camera.pickImages` / `getPhoto` source Photos) uses
+  `ActivityResultContracts.PickVisualMedia` — the **Android Photo Picker** —
+  which needs **no** permission (verified in `@capacitor/camera` v7.0.2
+  `CameraPlugin.java`).
+- Taking a photo (`getPhoto` source Camera) needs only `CAMERA` (a *normal*,
+  non-restricted permission) on Android 10+.
+- The storage perms are only requested for `saveToGallery: true` on Android ≤ 9,
+  which the app never sets.
+
+ModTools made the mismatch glaring: it doesn't even bundle `@capacitor/camera`,
+so the restricted permission was declared with zero corresponding functionality.
+
+## Fix
+
+| Permission | Freegle | ModTools |
+|---|---|---|
+| `READ_MEDIA_IMAGES` | removed | removed |
+| `READ_EXTERNAL_STORAGE` | removed | removed |
+| `WRITE_EXTERNAL_STORAGE` | removed | removed |
+| `CAMERA` | kept (in-app capture) | removed |
+
+1. **`iznik-nuxt3/android/app/src/main/AndroidManifest.xml`** — remove the three
+   media/storage permissions from the shared base manifest (neither app uses
+   them; this also future-proofs Freegle against the same rejection).
+2. **`.circleci/orb/freegle-tests.yml`** — in both ModTools build jobs
+   (`build-android-modtools-debug`, `build-android-modtools`), convert the
+   `CAMERA` declaration to `tools:node="remove"` for the ModTools flavour only
+   (mirrors the existing `AD_ID` removal). ModTools ends with **zero**
+   camera/media permissions.
+3. **`iznik-nuxt3/capacitor.config.modtools.js`** — add `@capacitor/camera` to
+   `android`/`ios` `includePlugins` so the "Choose photo" (Photo Picker) and
+   "Add photo" buttons in `OurUploader.vue` work in the ModTools app. The
+   plugin's own manifest does not declare `READ_MEDIA_IMAGES`/`CAMERA`, so it
+   does not re-introduce a restricted permission.
+
+In ModTools, "take a photo" still works via the system `ACTION_IMAGE_CAPTURE`
+intent, which needs no permission even with `CAMERA` removed.
+
+## Out-of-code follow-ups (manual)
+
+- Publish the orb after merge: `circleci orb publish .circleci/orb/freegle-tests.yml freegle/tests@1.x.x`.
+- Bump the ModTools version and resubmit **all** tracks (production + testing) so
+  no live build still declares the restricted permission.
+- The Play Console "Photo and Video Permissions" declaration becomes moot once
+  the permission is gone from every track.


### PR DESCRIPTION
## Why

Google Play **rejected the ModTools app** (version code 1282):

> Permission use is not directly related to your app's core purpose. … Remove the use of `READ_MEDIA_IMAGES`/`READ_MEDIA_VIDEO` … consider using the Android photo picker.

`READ_MEDIA_IMAGES` is a *restricted* permission; ModTools only needs occasional photo upload (group IDs, post images), which doesn't qualify for broad media access.

## Root cause

Freegle and ModTools build from the **same** native Android project, whose shared `AndroidManifest.xml` hard-codes three vestigial permissions left over from the old Cordova camera plugin: `READ_MEDIA_IMAGES`, `READ_EXTERNAL_STORAGE`, `WRITE_EXTERNAL_STORAGE`. **Neither app actually uses them** (verified against `@capacitor/camera` v7.0.2 `CameraPlugin.java`):

- Gallery selection (`Camera.pickImages` / `getPhoto` source Photos) → `ActivityResultContracts.PickVisualMedia`, the **Android Photo Picker** → needs **no** permission.
- Taking a photo (`getPhoto` source Camera) → needs only the *normal* `CAMERA` permission on Android 10+.
- The storage perms are only requested for `saveToGallery: true` on Android ≤ 9, which the app never sets.

ModTools made the mismatch glaring — it didn't even bundle `@capacitor/camera`, so the restricted permission was declared with zero corresponding functionality.

## Changes

| Permission | Freegle | ModTools |
|---|---|---|
| `READ_MEDIA_IMAGES` | removed | removed |
| `READ_EXTERNAL_STORAGE` | removed | removed |
| `WRITE_EXTERNAL_STORAGE` | removed | removed |
| `CAMERA` | kept (in-app capture) | removed |

1. **`AndroidManifest.xml`** — drop the three media/storage permissions from the shared base manifest (fixes ModTools, future-proofs Freegle against the identical policy).
2. **`.circleci/orb/freegle-tests.yml`** — in both ModTools build jobs, convert `CAMERA` → `tools:node="remove"` for the ModTools flavour only (mirrors the existing `AD_ID` removal). ModTools ends with **zero** camera/media permissions; Freegle keeps `CAMERA`. ModTools "take a photo" still works via the system `ACTION_IMAGE_CAPTURE` intent (needs no permission).
3. **`capacitor.config.modtools.js`** — add `@capacitor/camera` so the Photo Picker upload path in `OurUploader.vue` works in the ModTools app. The plugin's manifest declares neither `READ_MEDIA_IMAGES` nor `CAMERA`, so no restricted permission returns.

## Verification

- `AndroidManifest.xml` is well-formed XML; the three permissions are gone, `CAMERA` retained for Freegle.
- **Simulated the orb's full ModTools manifest manipulation** (AD_ID + new CAMERA step) against the edited manifest → valid XML, `CAMERA` correctly converted to `tools:node="remove"`.
- `capacitor.config.modtools.js` parses; `@capacitor/camera` present in both `android` and `ios` plugin lists.
- Orb YAML parses; CAMERA-removal block present in both ModTools jobs.
- Shared iOS `Info.plist` already carries `NSCameraUsageDescription` + photo-library strings, so adding the plugin to ModTools iOS is safe.

## ⚠️ Post-merge steps (manual)

1. **Republish the orb** so the CAMERA-removal step takes effect in CI:
   `circleci orb publish .circleci/orb/freegle-tests.yml freegle/tests@1.x.x`
2. **Bump the ModTools version and resubmit all tracks** (production + testing) — Google requires the permission gone from *every* version code in the submission.
3. The Play Console "Photo and Video Permissions" declaration becomes moot once the permission is gone from all tracks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
