### PR TITLE
feat(spatial): routing suite in status UI + start spatial servers on Yesterday

### DIFF
--- a/docker-compose.override.yesterday.yml
+++ b/docker-compose.override.yesterday.yml
@@ -69,6 +69,18 @@ services:
     deploy:
       replicas: 0
 
+  # Spatial servers (iznik-spatial-go / iznik-routing-go, added in #459). Both are
+  # in the `frontend` profile, so they start on Yesterday. The KNN server
+  # (spatial-knn) only needs the DB (percona) and comes up as-is. The routing
+  # server (spatial) depends on spatial-knn being healthy AND defaults to the full
+  # UK OSM graph (/data/uk-latest.osm.pbf), which isn't downloaded on Yesterday —
+  # so point it at the committed Bristol extract baked into the image (same as CI)
+  # so it starts and serves the Bristol area instead of exiting on the missing file.
+  spatial:
+    environment:
+      - OSM_PBF_PATH=/app/testdata/bristol.osm.pbf
+      - DEPRIVATION_CSV=/app/testdata/bristol_lsoa.csv
+
   # Expose dev containers on external ports for yesterday server
   freegle-dev-local:
     ports:

--- a/status-nuxt/pages/testing.vue
+++ b/status-nuxt/pages/testing.vue
@@ -4,7 +4,7 @@ import { useTestStore } from '~/stores/tests'
 
 const testStore = useTestStore()
 
-const testTypes: TestType[] = ['go', 'spatial', 'php', 'laravel', 'vitest', 'playwright']
+const testTypes: TestType[] = ['go', 'spatial', 'routing', 'php', 'laravel', 'vitest', 'playwright']
 
 onMounted(() => {
   // Refresh test statuses on mount

--- a/status-nuxt/types/test.ts
+++ b/status-nuxt/types/test.ts
@@ -1,4 +1,4 @@
-export type TestType = 'go' | 'spatial' | 'php' | 'laravel' | 'vitest' | 'playwright'
+export type TestType = 'go' | 'spatial' | 'routing' | 'php' | 'laravel' | 'vitest' | 'playwright'
 
 export type TestStatus = 'idle' | 'running' | 'completed' | 'failed'
 
@@ -44,6 +44,13 @@ export const testConfigs: Record<TestType, TestConfig> = {
     name: 'Spatial Server Tests',
     description: 'Tests for the spatial KNN server (iznik-spatial-go)',
     filterPlaceholder: 'Filter tests (e.g., TestDeleteByExtID)',
+    hasReport: false,
+  },
+  routing: {
+    type: 'routing',
+    name: 'Routing Server Tests',
+    description: 'Tests for the isochrone/routing server (iznik-routing-go)',
+    filterPlaceholder: 'Filter tests (e.g., TestIsochrone)',
     hasReport: false,
   },
   php: {


### PR DESCRIPTION
The orb-independent parts of the spatial-test work (the CI orb change is held — see below).

## What
- **Status webpage** — adds the **Routing Server Tests** suite (`iznik-routing-go`) to `status-nuxt/types/test.ts` + `pages/testing.vue`, so it's runnable from the status page. The `/api/tests/routing` endpoint already existed; **Spatial Server Tests** and **Vitest Unit Tests** were already present.
- **Yesterday** — points the routing server (compose service `spatial`, `iznik-routing-go`) at the committed Bristol OSM extract (`/app/testdata/bristol.osm.pbf`) so it **starts on Yesterday** instead of exiting on the absent 2.5 GB UK graph. `spatial-knn` already starts there (needs only the DB); both are in the `frontend` profile and not disabled.

## Held back: the CI orb change
The "run spatial/routing go tests serially after the Go API tests" change is an **orb** edit, and the published orb is already at `freegle/tests@1.1.350` = **PR #760's** ModTools permission fix (not yet on master). Publishing `1.1.351` for the spatial step would fold #760's unmerged orb changes into this branch, so it's staged locally (`feat/spatial-routing-ci-yesterday`) pending the merge-order decision on #760.

🤖 Generated with [Claude Code](https://claude.com/claude-code)