### PR TITLE
ci(spatial): run spatial-go tests serially after the Go API tests

### DIFF
--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -23,7 +23,7 @@ parameters:
     description: "Forwarded from trigger — true when build_modtools_production was set"
 
 orbs:
-  freegle: freegle/tests@1.1.350
+  freegle: freegle/tests@1.1.351
 
 jobs:
   mark-ci-passed:

--- a/.circleci/orb/freegle-tests.yml
+++ b/.circleci/orb/freegle-tests.yml
@@ -3012,6 +3012,38 @@ jobs:
           no_output_timeout: 50m
 
       - run:
+          name: Run spatial-go tests
+          command: |
+            # iznik-spatial-go (KNN) tests run via the status container, which
+            # docker-execs `go test ./...` in the spatial-knn container (frontend
+            # profile, already up). Serial gate that runs AFTER the Go API tests
+            # (the parallel block above); a failure here fails the job.
+            echo "🧪 Spatial-go tests (iznik-spatial-go)..."
+            response=$(curl -s -w "%{http_code}" -X POST -H "Content-Type: application/json" "http://localhost:${PORT_STATUS:-8081}/api/tests/spatial")
+            http_code="${response: -3}"
+            if [ "$http_code" != "200" ] && [ "$http_code" != "409" ]; then
+              echo "❌ Failed to trigger spatial tests (HTTP $http_code)"
+              exit 1
+            fi
+            while true; do
+              sleep 5
+              status_response=$(curl -s "http://localhost:${PORT_STATUS:-8081}/api/tests/spatial/status" || echo '{"status":"error"}')
+              status=$(echo "$status_response" | jq -r '.status // "unknown"')
+              if [ "$status" = "completed" ]; then
+                echo "$status_response" | jq -r '.logs // ""' | tail -30
+                if [ "$(echo "$status_response" | jq -r '.success // false')" = "true" ]; then
+                  echo "✅ Spatial tests passed"; break
+                else
+                  echo "❌ Spatial tests failed"; exit 1
+                fi
+              elif [ "$status" = "failed" ] || [ "$status" = "error" ]; then
+                echo "$status_response" | jq -r '.logs // ""' | tail -30
+                echo "❌ Spatial tests failed"; exit 1
+              fi
+            done
+          no_output_timeout: 10m
+
+      - run:
           name: Run routing-go tests
           command: |
             # iznik-routing-go tests run via the status container, which docker-execs


### PR DESCRIPTION
Companion to #761 (status UI + Yesterday). This is the CI half.

## What
Adds a **Run spatial-go tests** orb step that runs **serially after the Go API tests**, immediately before the existing routing-go step. Execution order becomes:

`[parallel: go-api, laravel, playwright, vitest] → spatial → routing`

It triggers `POST /api/tests/spatial` on the status container, which runs the `iznik-spatial-go` suite inside the `spatial-knn` container. `spatial-knn` is in the `frontend` profile (already up in CI) and is single-stage from `freegle-base`, so the Go toolchain + sources are present (same as the routing container). A failure fails the job.

- **Go API suite name unchanged** — stays `go`, per request (no rename).
- Bumps the orb `freegle/tests@1.1.350 → @1.1.351`, **already published**, so this branch's CI resolves it.

## Notes
- Rebased onto current master (post-#760), so the diff is just the spatial step + the orb-version bump.
- `routing` already ran serially after the parallel block; this places `spatial` right before it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
