### PR TITLE
spatial: nearest-neighbour lookups via spatial server; drop grid

### DIFF
--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -23,7 +23,7 @@ parameters:
     description: "Forwarded from trigger — true when build_modtools_production was set"
 
 orbs:
-  freegle: freegle/tests@1.1.351
+  freegle: freegle/tests@1.1.352
 
 jobs:
   mark-ci-passed:

--- a/.circleci/orb/freegle-tests.yml
+++ b/.circleci/orb/freegle-tests.yml
@@ -601,6 +601,14 @@ commands:
                 echo '    build:'
                 echo '      cache_from:'
                 echo '        - 185.44.254.6:5002/ci/status:latest'
+                echo '  spatial-knn:'
+                echo '    build:'
+                echo '      cache_from:'
+                echo '        - 185.44.254.6:5002/ci/spatial-knn:latest'
+                echo '  spatial:'
+                echo '    build:'
+                echo '      cache_from:'
+                echo '        - 185.44.254.6:5002/ci/spatial:latest'
               } > /tmp/docker-compose.cache.yml
 
               export COMPOSE_FILE="${COMPOSE_FILE}:/tmp/docker-compose.cache.yml"
@@ -648,8 +656,14 @@ commands:
               ) > "$NUXT_LOG" 2>&1 &
               NUXT_PID=$!
 
-              # Playwright + status (lightweight, finishes quickly)
-              docker-compose build $INLINE_CACHE_FLAG playwright status > "$OTHER_LOG" 2>&1 &
+              # Playwright + status + the two custom Go servers (spatial-knn / spatial).
+              # spatial-knn and spatial are NOT brought up from a registry image — they
+              # build from local source. They must be built explicitly here: otherwise
+              # `docker-compose up` reuses whatever image already exists on a pooled
+              # Katapult VM, which can be a stale build from before a source change (e.g.
+              # missing the admin /v1/:dataset/upsert route → integration-seed tests 404).
+              # The Dockerfile's COPY busts on source change, so cache_from keeps this fast.
+              docker-compose build $INLINE_CACHE_FLAG playwright status spatial-knn spatial > "$OTHER_LOG" 2>&1 &
               OTHER_PID=$!
 
               BUILD_FAILED=0
@@ -683,7 +697,7 @@ commands:
                 if docker-compose build $CACHE_FLAG \
                   apiv1 apiv1-phpunit apiv2 \
                   freegle-prod-local modtools-prod-local \
-                  playwright status; then
+                  playwright status spatial-knn spatial; then
                   echo "✅ Build succeeded on attempt $attempt"
                   break
                 else
@@ -726,6 +740,8 @@ commands:
                   ["playwright"]="${PROJECT}-playwright"
                   ["batch"]="${PROJECT}-batch"
                   ["status"]="${PROJECT}-status"
+                  ["spatial-knn"]="${PROJECT}-spatial-knn"
+                  ["spatial"]="${PROJECT}-spatial"
                 )
                 for svc in "${!SVC_IMAGES[@]}"; do
                   img="${SVC_IMAGES[$svc]}"

--- a/iznik-batch/app/Models/Job.php
+++ b/iznik-batch/app/Models/Job.php
@@ -55,11 +55,13 @@ class Job extends Model
             return collect();
         }
 
-        $results = static::select('id', 'title', 'canonical_title', 'location', 'company', 'city', 'url', 'cpc')
+        $results = static::select('id', 'title', 'canonical_title', 'location', 'company', 'city', 'url', 'cpc', 'clickability')
             ->whereIn('id', $ids)
             ->whereRaw('cpc >= ?', [self::MINIMUM_CPC])
             ->where('visible', 1)
-            ->orderByDesc('cpc')
+            // Rank by expected value (cpc * clickability), matching the public
+            // jobs page (Go job.GetJobs) so digest and web agree on ordering.
+            ->orderByRaw('cpc * clickability DESC, id ASC')
             ->get();
 
         // Randomize the candidate pool so consecutive immediate-mode digests

--- a/iznik-batch/app/Models/Job.php
+++ b/iznik-batch/app/Models/Job.php
@@ -19,9 +19,11 @@ class Job extends Model
     ];
 
     /**
-     * Minimum CPC (cost per click) to show a job ad.
+     * Minimum CPC (cost per click) to show a job ad. Matches the spatial
+     * server's "jobs" dataset floor and the public jobs page, so digest job
+     * ads are drawn from the same eligible pool as everything else.
      */
-    public const MINIMUM_CPC = 0.02;
+    public const MINIMUM_CPC = 0.10;
 
     /**
      * Candidate-pool multiplier used to break the "same N jobs forever"
@@ -33,7 +35,7 @@ class Job extends Model
     public const VARIETY_POOL_MULTIPLIER = 3;
 
     /**
-     * Query jobs near a location using bounding box search.
+     * Query jobs near a location via the spatial server's "jobs" KNN dataset.
      *
      * @param float $lat Latitude
      * @param float $lng Longitude
@@ -41,45 +43,24 @@ class Job extends Model
      */
     public static function nearLocation(float $lat, float $lng, int $limit = 4): Collection
     {
-        // Use same bounding box approach as iznik-server for efficient spatial index usage.
-        // Expand the box iteratively until we find enough jobs. Fetch a
-        // larger candidate pool so the random selection below has room to
-        // vary the picks across consecutive sends.
-        $step = 0.02;
-        $ambit = $step;
-        $srid = config('freegle.srid', 3857);
-
+        // Fetch a larger candidate pool so the random selection below has room
+        // to vary the picks across consecutive sends.
         $candidatePool = $limit * self::VARIETY_POOL_MULTIPLIER;
 
-        $results = collect();
-        $gotIds = [];
-
-        while ($results->count() < $candidatePool && $ambit < 1) {
-            $swlat = $lat - $ambit;
-            $nelat = $lat + $ambit;
-            $swlng = $lng - $ambit;
-            $nelng = $lng + $ambit;
-
-            $poly = "POLYGON(($swlng $swlat, $swlng $nelat, $nelng $nelat, $nelng $swlat, $swlng $swlat))";
-
-            $jobs = static::select('id', 'title', 'canonical_title', 'location', 'company', 'city', 'url', 'cpc')
-                ->whereRaw("ST_Within(geometry, ST_GeomFromText(?, ?))", [$poly, $srid])
-                ->whereRaw("cpc >= ?", [self::MINIMUM_CPC])
-                ->where('visible', 1)
-                ->when(count($gotIds) > 0, function ($query) use ($gotIds) {
-                    $query->whereNotIn('id', $gotIds);
-                })
-                ->orderByDesc('cpc')
-                ->limit($candidatePool - $results->count())
-                ->get();
-
-            foreach ($jobs as $job) {
-                $gotIds[] = $job->id;
-                $results->push($job);
-            }
-
-            $ambit += $step;
+        // The spatial server's "jobs" dataset is the source of truth for which
+        // jobs are eligible (visible, cpc >= floor) and where they are: ask it
+        // for the nearest candidate ids, then enrich + re-check from MySQL.
+        $ids = (new \App\Services\SpatialQueryService())->nearestIds('jobs', $lat, $lng, $candidatePool);
+        if (empty($ids)) {
+            return collect();
         }
+
+        $results = static::select('id', 'title', 'canonical_title', 'location', 'company', 'city', 'url', 'cpc')
+            ->whereIn('id', $ids)
+            ->whereRaw('cpc >= ?', [self::MINIMUM_CPC])
+            ->where('visible', 1)
+            ->orderByDesc('cpc')
+            ->get();
 
         // Randomize the candidate pool so consecutive immediate-mode digests
         // (or chat notifications) to the same user don't show identical job

--- a/iznik-batch/app/Models/Location.php
+++ b/iznik-batch/app/Models/Location.php
@@ -2,10 +2,9 @@
 
 namespace App\Models;
 
+use App\Services\SpatialQueryService;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Http;
-use Illuminate\Support\Facades\Log;
 use OwenIt\Auditing\Contracts\Auditable;
 
 class Location extends Model implements Auditable
@@ -13,7 +12,7 @@ class Location extends Model implements Auditable
     use \OwenIt\Auditing\Auditable;
 
     // Fields exposed by getPublic() - mirrors iznik-server Location::$publicatts.
-    private const PUBLIC_ATTS = ['id', 'osm_id', 'name', 'type', 'popularity', 'gridid', 'postcodeid', 'areaid', 'lat', 'lng', 'maxdimension'];
+    private const PUBLIC_ATTS = ['id', 'osm_id', 'name', 'type', 'popularity', 'postcodeid', 'areaid', 'lat', 'lng', 'maxdimension'];
 
     protected $table = 'locations';
     protected $guarded = ['id'];
@@ -27,65 +26,21 @@ class Location extends Model implements Auditable
         'osm_shop' => 'boolean',
     ];
 
+    /**
+     * Nearest full postcode to a point, via the spatial server's KNN index
+     * (the "postcodes" point dataset). Returns null if the spatial server has
+     * nothing nearby or is unreachable.
+     */
     public static function closestPostcode(float $lat, float $lng): ?object
     {
-        $spatialUrl = config('freegle.spatial_server_url', 'http://localhost:8194');
-
-        try {
-            $response = Http::timeout(3)->get("{$spatialUrl}/v1/locations/knn", [
-                'lat'   => $lat,
-                'lng'   => $lng,
-                'limit' => 1,
-                'type'  => 'Postcode',
-            ]);
-
-            if ($response->successful()) {
-                $results = $response->json('results', []);
-                if (!empty($results)) {
-                    $id = $results[0]['id'];
-                    return DB::table('locations')->where('id', $id)
-                        ->select('id', 'name', 'lat', 'lng')
-                        ->first();
-                }
-            }
-        } catch (\Throwable $e) {
-            Log::warning('closestPostcode spatial server unavailable, falling back to MySQL', [
-                'error' => $e->getMessage(),
-            ]);
+        $ids = (new SpatialQueryService())->nearestIds('postcodes', $lat, $lng, 1);
+        if (empty($ids)) {
+            return null;
         }
 
-        // Fallback: expanding BBox on locations_spatial.
-        $srid = config('freegle.srid', 3857);
-        $scan = 0.00001953125;
-
-        do {
-            $swlat = $lat - $scan;
-            $nelat = $lat + $scan;
-            $swlng = $lng - $scan;
-            $nelng = $lng + $scan;
-
-            $poly = "POLYGON(($swlng $swlat, $swlng $nelat, $nelng $nelat, $nelng $swlat, $swlng $swlat))";
-
-            $locs = DB::select(
-                "SELECT locations.id, locations.name, locations.lat, locations.lng
-                 FROM locations_spatial
-                 INNER JOIN locations ON locations.id = locations_spatial.locationid
-                 WHERE MBRContains(ST_Envelope(ST_GeomFromText(?, ?)), locations_spatial.geometry)
-                   AND locations.type = 'Postcode'
-                   AND LOCATE(' ', locations.name) > 0
-                 ORDER BY ST_distance(locations_spatial.geometry, ST_GeomFromText(?, ?)) ASC
-                 LIMIT 1",
-                [$poly, $srid, "POINT($lng $lat)", $srid]
-            );
-
-            if (count($locs) === 1) {
-                return $locs[0];
-            }
-
-            $scan *= 2;
-        } while ($scan <= 0.2);
-
-        return null;
+        return DB::table('locations')->where('id', $ids[0])
+            ->select('id', 'name', 'lat', 'lng')
+            ->first();
     }
 
     public static function findByName(string $name): ?int

--- a/iznik-batch/app/Services/DoogalService.php
+++ b/iznik-batch/app/Services/DoogalService.php
@@ -216,16 +216,6 @@ class DoogalService
             [$id]
         );
 
-        // Assign the containing grid square, if any.
-        $grid = DB::selectOne(
-            'SELECT locations_grids.id AS gridid FROM locations '
-            .'INNER JOIN locations_grids ON locations.id = ? AND MBRIntersects(locations.geometry, locations_grids.box) LIMIT 1',
-            [$id]
-        );
-        if ($grid && $grid->gridid) {
-            DB::update('UPDATE locations SET gridid = ? WHERE id = ?', [$grid->gridid, $id]);
-        }
-
         // Link a full postcode (e.g. "AB1 2CD") to its parent district ("AB1").
         $sp = strpos($name, ' ');
         if ($sp !== false) {

--- a/iznik-batch/app/Services/Mail/Incoming/IncomingMailService.php
+++ b/iznik-batch/app/Services/Mail/Incoming/IncomingMailService.php
@@ -13,6 +13,7 @@ use App\Models\MessageGroup;
 use App\Models\User;
 use App\Models\UserEmail;
 use App\Services\ItemService;
+use App\Services\SpatialQueryService;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
@@ -3463,41 +3464,9 @@ class IncomingMailService
      */
     private function findClosestPostcodeId(float $lat, float $lng): ?int
     {
-        $srid = config('freegle.srid', 3857);
+        $ids = (new SpatialQueryService())->nearestIds('postcodes', $lat, $lng, 1);
 
-        // Start with a small search radius and expand if needed
-        $scan = 0.00001953125;
-
-        while ($scan <= 0.2) {
-            $swlat = $lat - $scan;
-            $nelat = $lat + $scan;
-            $swlng = $lng - $scan;
-            $nelng = $lng + $scan;
-
-            $poly = "POLYGON(($swlng $swlat, $swlng $nelat, $nelng $nelat, $nelng $swlat, $swlng $swlat))";
-
-            $sql = "SELECT locations.id,
-                           ST_distance(locations_spatial.geometry, ST_GeomFromText('POINT($lng $lat)', $srid)) AS dist
-                    FROM locations_spatial
-                    INNER JOIN locations ON locations.id = locations_spatial.locationid
-                    WHERE MBRContains(ST_Envelope(ST_GeomFromText('$poly', $srid)), locations_spatial.geometry)
-                      AND locations.type = 'Postcode'
-                      AND LOCATE(' ', locations.name) > 0
-                    ORDER BY dist ASC,
-                             CASE WHEN ST_Dimension(locations_spatial.geometry) < 2 THEN 0
-                                  ELSE ST_AREA(locations_spatial.geometry) END ASC
-                    LIMIT 1";
-
-            $result = DB::selectOne($sql);
-
-            if ($result) {
-                return (int) $result->id;
-            }
-
-            $scan *= 2;
-        }
-
-        return null;
+        return $ids[0] ?? null;
     }
 
     /**

--- a/iznik-batch/app/Services/NewsfeedDigestService.php
+++ b/iznik-batch/app/Services/NewsfeedDigestService.php
@@ -6,7 +6,7 @@ use App\Mail\Newsfeed\NewsfeedDigestMail;
 use App\Models\Group;
 use App\Models\Membership;
 use App\Models\User;
-use App\Support\GreatCircle;
+use App\Services\SpatialQueryService;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 
@@ -48,10 +48,13 @@ class NewsfeedDigestService
     /** Posts must be at least this many hours old (V1 digest $minhourage=12). */
     private const MIN_HOUR_AGE = 12;
 
-    /** getNearbyDistance: start radius (m), target poster count, cap (m). V1 800 / 10 / 32187. */
-    private const NEARBY_START_METRES = 800;
-    private const NEARBY_TARGET_POSTERS = 10;
-    private const NEARBY_MAX_METRES = 32187;
+    /**
+     * How many nearest newsfeed posts to pull from the spatial server before
+     * applying the digest filters (type/window/seen/min-age) in MySQL. Large
+     * enough to reach far in sparse areas (the old radius cap was ~20 miles),
+     * while staying well under the spatial server's 1000-result limit.
+     */
+    private const NEARBY_CANDIDATES = 500;
 
     /**
      * Process all eligible groups/members.
@@ -138,17 +141,24 @@ class NewsfeedDigestService
 
         $lastSeen = (int) (DB::table('newsfeed_users')->where('userid', $userId)->value('newsfeedid') ?? 0);
 
-        // V1 getNearbyDistance: grow the radius until ~10 recent posters are in
-        // range (or we hit the cap), then select the latest posts within that box.
-        $dist = $this->getNearbyDistance($lat, $lng);
-        $box = $this->boxSql($lat, $lng, $dist);
+        // Nearest recent chitchat posts via the spatial server's "newsfeed"
+        // dataset, then apply the digest filters in MySQL. Replaces the V1
+        // grow-the-radius-until-10-posters box; like the Go API's nearby
+        // newsfeed, this uses nearest-N (the final ORDER BY timestamp + the
+        // MAX_ITEMS/window filters keep the same "latest nearby posts" result).
+        $ids = (new SpatialQueryService())->nearestIds('newsfeed', $lat, $lng, self::NEARBY_CANDIDATES);
+        if (empty($ids)) {
+            return 0;
+        }
+
         $oldest = now()->subDays(self::WINDOW_DAYS)->toDateTimeString();
         $typePlaceholders = implode(',', array_fill(0, count(self::FEED_TYPES), '?'));
+        $idPlaceholders = implode(',', array_fill(0, count($ids), '?'));
 
         $posts = DB::select(
             "SELECT newsfeed.id, newsfeed.type, newsfeed.userid, newsfeed.message, newsfeed.timestamp
              FROM newsfeed
-             WHERE MBRContains({$box}, newsfeed.position)
+             WHERE newsfeed.id IN ({$idPlaceholders})
                AND newsfeed.replyto IS NULL
                AND newsfeed.deleted IS NULL
                AND newsfeed.hidden IS NULL
@@ -158,7 +168,7 @@ class NewsfeedDigestService
                AND TIMESTAMPDIFF(HOUR, newsfeed.timestamp, NOW()) >= ?
              ORDER BY newsfeed.pinned DESC, newsfeed.timestamp DESC
              LIMIT " . self::MAX_ITEMS,
-            array_merge([$userId], self::FEED_TYPES, [$oldest, self::MIN_HOUR_AGE])
+            array_merge($ids, [$userId], self::FEED_TYPES, [$oldest, self::MIN_HOUR_AGE])
         );
 
         if (empty($posts)) {
@@ -244,55 +254,6 @@ class NewsfeedDigestService
         return [$lat, $lng];
     }
 
-    /**
-     * V1 Newsfeed::getNearbyDistance: start at 800m and double until at least 10
-     * distinct people have posted (non-reply, non-Alert, last 30 days) within the
-     * box, or we reach the cap (~20 miles).
-     */
-    private function getNearbyDistance(float $lat, float $lng): int
-    {
-        $dist = self::NEARBY_START_METRES;
-        $since = now()->subDays(30)->toDateTimeString();
-
-        do {
-            $dist *= 2;
-            $box = $this->boxSql($lat, $lng, $dist);
-
-            $others = DB::select(
-                "SELECT DISTINCT userid FROM newsfeed
-                 WHERE MBRContains({$box}, position)
-                   AND replyto IS NULL
-                   AND type <> 'Alert'
-                   AND timestamp >= ?
-                 LIMIT " . self::NEARBY_TARGET_POSTERS,
-                [$since]
-            );
-        } while ($dist < self::NEARBY_MAX_METRES && count($others) < self::NEARBY_TARGET_POSTERS);
-
-        return $dist;
-    }
-
-    /**
-     * Build the ST_GeomFromText POLYGON box SQL for a given centre + distance,
-     * matching V1 (NE corner at bearing 45°, SW at 225°).
-     */
-    private function boxSql(float $lat, float $lng, int $dist): string
-    {
-        $ne = GreatCircle::getPositionByDistance($dist, 45, $lat, $lng);
-        $sw = GreatCircle::getPositionByDistance($dist, 225, $lat, $lng);
-        $srid = (int) config('freegle.srid', 3857);
-
-        $poly = sprintf(
-            'POLYGON((%F %F, %F %F, %F %F, %F %F, %F %F))',
-            $sw['lng'], $sw['lat'],
-            $sw['lng'], $ne['lat'],
-            $ne['lng'], $ne['lat'],
-            $ne['lng'], $sw['lat'],
-            $sw['lng'], $sw['lat']
-        );
-
-        return "ST_GeomFromText('{$poly}', {$srid})";
-    }
 
     /**
      * The poster's public location name with the group suffix stripped (V1

--- a/iznik-batch/app/Services/SpatialQueryService.php
+++ b/iznik-batch/app/Services/SpatialQueryService.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Read-side client for the iznik-spatial-go "finder" service.
+ *
+ * Replaces the per-table expanding-bounding-box MySQL nearest-neighbour loops
+ * with a single call to the spatial server's R-tree KNN, which is exact and
+ * needs one round-trip instead of up to a dozen MySQL queries.
+ *
+ * @see SpatialAdminService for the write/remove side.
+ */
+class SpatialQueryService
+{
+    private string $url;
+
+    public function __construct()
+    {
+        $this->url = rtrim(config('freegle.spatial_server_url', 'http://localhost:8194'), '/');
+    }
+
+    /**
+     * Return the external IDs of the nearest records in $dataset to (lat, lng),
+     * nearest first, up to $limit. Returns [] if the spatial server errors or is
+     * unreachable (logged) — callers treat that as "nothing nearby".
+     *
+     * @return int[]
+     */
+    public function nearestIds(string $dataset, float $lat, float $lng, int $limit = 1, ?string $type = null): array
+    {
+        $params = ['lat' => $lat, 'lng' => $lng, 'limit' => $limit];
+        if ($type !== null) {
+            $params['type'] = $type;
+        }
+
+        try {
+            $response = Http::timeout(5)->get("{$this->url}/v1/{$dataset}/knn", $params);
+
+            if ($response->successful()) {
+                return array_map(
+                    static fn ($r) => (int) $r['id'],
+                    $response->json('results', []) ?? []
+                );
+            }
+
+            Log::warning("SpatialQuery: {$dataset} knn HTTP {$response->status()}", [
+                'lat' => $lat,
+                'lng' => $lng,
+            ]);
+        } catch (\Throwable $e) {
+            Log::warning("SpatialQuery: {$dataset} knn failed: {$e->getMessage()}", [
+                'lat' => $lat,
+                'lng' => $lng,
+            ]);
+        }
+
+        return [];
+    }
+}

--- a/iznik-batch/app/Services/UserLocationRemapService.php
+++ b/iznik-batch/app/Services/UserLocationRemapService.php
@@ -34,7 +34,7 @@ class UserLocationRemapService
 
             $location = DB::table('locations')
                 ->where('id', $locationId)
-                ->select('id', 'osm_id', 'name', 'type', 'popularity', 'gridid', 'postcodeid', 'areaid', 'lat', 'lng', 'maxdimension')
+                ->select('id', 'osm_id', 'name', 'type', 'popularity', 'postcodeid', 'areaid', 'lat', 'lng', 'maxdimension')
                 ->first();
 
             if (!$location) {

--- a/iznik-batch/config/freegle.php
+++ b/iznik-batch/config/freegle.php
@@ -235,8 +235,18 @@ return [
 
     'srid' => env('FREEGLE_SRID', 3857),
 
-    'spatial_server_url' => env('SPATIAL_SERVER_URL', 'http://localhost:8194'),
-    'spatial_admin_url' => env('SPATIAL_ADMIN_URL', 'http://localhost:8195'),
+    // The spatial-knn "finder" service (iznik-spatial-go). SPATIAL_KNN_URL is the
+    // canonical name (also used by the Go client). NB: SPATIAL_SERVER_URL is taken
+    // by the routing/isochrone server elsewhere, so it must NOT be relied on here —
+    // it's only a last-resort legacy fallback. The admin (rebuild/remove/upsert)
+    // API is the same host on the next port; derive it from SPATIAL_KNN_URL so any
+    // container that sets SPATIAL_KNN_URL gets a working admin URL for free.
+    'spatial_server_url' => env('SPATIAL_KNN_URL', env('SPATIAL_SERVER_URL', 'http://localhost:8194')),
+    'spatial_admin_url' => env('SPATIAL_KNN_ADMIN_URL', env('SPATIAL_ADMIN_URL', str_replace(
+        ':8194',
+        ':8195',
+        env('SPATIAL_KNN_URL', 'http://localhost:8194')
+    ))),
     'spatial_data_dir' => env('SPATIAL_DATA_DIR', '/data'),
 
     /*

--- a/iznik-batch/tests/Feature/Newsfeed/SendDigestCommandTest.php
+++ b/iznik-batch/tests/Feature/Newsfeed/SendDigestCommandTest.php
@@ -8,6 +8,7 @@ use App\Models\Membership;
 use App\Models\User;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Mail;
+use Tests\Support\SeedsSpatialIndex;
 use Tests\TestCase;
 
 /**
@@ -18,7 +19,21 @@ use Tests\TestCase;
  */
 class SendDigestCommandTest extends TestCase
 {
+    use SeedsSpatialIndex;
+
     private const LONG_MESSAGE = 'This is a chitchat post that is definitely long enough to pass the filter.';
+
+    /** @var int[] newsfeed ids seeded into the spatial index, removed in tearDown. */
+    private array $seededNewsfeedIds = [];
+
+    protected function tearDown(): void
+    {
+        if ($this->seededNewsfeedIds) {
+            $this->removeSpatial('newsfeed', $this->seededNewsfeedIds);
+            $this->seededNewsfeedIds = [];
+        }
+        parent::tearDown();
+    }
 
     private function makeLocation(): int
     {
@@ -48,7 +63,7 @@ class SendDigestCommandTest extends TestCase
     private function createPost(int $userId, int $groupId, array $attributes = []): int
     {
         // Default 1 day old: older than the 12h minhourage floor, within 14 days.
-        return DB::table('newsfeed')->insertGetId(array_merge([
+        $id = DB::table('newsfeed')->insertGetId(array_merge([
             'userid' => $userId,
             'groupid' => $groupId,
             'type' => 'Message',
@@ -57,6 +72,13 @@ class SendDigestCommandTest extends TestCase
             'timestamp' => now()->subDay(),
             'position' => DB::raw("ST_GeomFromText('POINT(-0.1278 51.5074)', 3857)"),
         ], $attributes));
+
+        // The digest now selects nearby posts via the spatial 'newsfeed' index
+        // (KNN), so seed this post there at the default London position above.
+        $this->seedSpatialPoint('newsfeed', $id, 51.5074, -0.1278);
+        $this->seededNewsfeedIds[] = $id;
+
+        return $id;
     }
 
     private function makeLocationNamed(string $name): int

--- a/iznik-batch/tests/Feature/TrashNothing/TNSyncCommandTest.php
+++ b/iznik-batch/tests/Feature/TrashNothing/TNSyncCommandTest.php
@@ -481,39 +481,44 @@ class TNSyncCommandTest extends TestCase
     public function test_sync_location_change_updates_lastlocation(): void
     {
 
-        // Only run if we have location data in the test DB.
-        if (!DB::table('locations')->where('type', 'Postcode')->whereRaw("LOCATE(' ', name) > 0")->exists()) {
-            $this->markTestSkipped('No postcode data in test database');
-        }
-
         $user = $this->createTNUser();
 
-        // Find a valid postcode location to use as expected result.
-        $existingLoc = DB::table('locations')
-            ->where('type', 'Postcode')
-            ->whereRaw("LOCATE(' ', name) > 0")
-            ->whereNotNull('lat')
-            ->whereNotNull('lng')
-            ->first();
-
-        Http::fake([
-            '*/ratings*' => Http::response(['ratings' => []], 200),
-            '*/user-changes*' => Http::response([
-                'changes' => [[
-                    'fd_user_id' => $user->id,
-                    'location' => [
-                        'latitude' => (float) $existingLoc->lat,
-                        'longitude' => (float) $existingLoc->lng,
-                    ],
-                    'date' => self::DATE_SYNC,
-                ]],
-            ], 200),
+        // Seed a known postcode row; closestPostcode resolves the user's coords
+        // to it. tn:sync mocks HTTP via Http::fake, which also intercepts the
+        // spatial-server call, so we fake the postcodes KNN response here rather
+        // than seeding the live index.
+        $pcId = 99000201;
+        $lat = 55.9533;
+        $lng = -3.1883;
+        $srid = (int) config('freegle.srid', 3857);
+        DB::table('locations')->updateOrInsert(['id' => $pcId], [
+            'name' => 'EH1 1AA',
+            'type' => 'Postcode',
+            'lat' => $lat,
+            'lng' => $lng,
+            'geometry' => DB::raw(sprintf("ST_GeomFromText('POINT(%F %F)', %d)", $lng, $lat, $srid)),
         ]);
 
-        $this->artisan('tn:sync')->assertExitCode(0);
+        try {
+            Http::fake([
+                '*/ratings*' => Http::response(['ratings' => []], 200),
+                '*/user-changes*' => Http::response([
+                    'changes' => [[
+                        'fd_user_id' => $user->id,
+                        'location' => ['latitude' => $lat, 'longitude' => $lng],
+                        'date' => self::DATE_SYNC,
+                    ]],
+                ], 200),
+                '*/v1/postcodes/knn*' => Http::response(['results' => [['id' => $pcId, 'distance' => 0]]], 200),
+            ]);
 
-        $lastlocation = DB::table('users')->where('id', $user->id)->value('lastlocation');
-        $this->assertNotNull($lastlocation);
+            $this->artisan('tn:sync')->assertExitCode(0);
+
+            $lastlocation = DB::table('users')->where('id', $user->id)->value('lastlocation');
+            $this->assertNotNull($lastlocation);
+        } finally {
+            DB::table('locations')->where('id', $pcId)->delete();
+        }
     }
 
     // =========================================================================

--- a/iznik-batch/tests/Support/SeedsSpatialIndex.php
+++ b/iznik-batch/tests/Support/SeedsSpatialIndex.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\Support;
+
+use Illuminate\Support\Facades\Http;
+
+/**
+ * Helpers for integration tests that exercise the spatial server (closestPostcode,
+ * Job::nearLocation, NewsfeedDigest, …).
+ *
+ * The spatial server keeps its own R-tree index (built from MySQL), so a row
+ * inserted into the test DB is NOT automatically in the index. These helpers
+ * push a known geometry straight into the live index via the admin upsert
+ * endpoint, so a test can: insert the row in the test DB (for the by-id enrich),
+ * seed the index here, call the code under test, assert, then removeSpatial() in
+ * teardown. Decoupled from which DB the server normally indexes.
+ */
+trait SeedsSpatialIndex
+{
+    private function spatialAdminUrl(): string
+    {
+        return rtrim(config('freegle.spatial_admin_url', 'http://localhost:8195'), '/');
+    }
+
+    /**
+     * Upsert one geometry (WKT) into a dataset's live index.
+     */
+    protected function seedSpatial(string $dataset, int $id, string $wkt): void
+    {
+        Http::timeout(5)
+            ->post("{$this->spatialAdminUrl()}/v1/{$dataset}/upsert", [
+                'items' => [['id' => $id, 'wkt' => $wkt]],
+            ])
+            ->throw();
+    }
+
+    /**
+     * Upsert a point into a point dataset (postcodes, newsfeed, …).
+     */
+    protected function seedSpatialPoint(string $dataset, int $id, float $lat, float $lng): void
+    {
+        $this->seedSpatial($dataset, $id, sprintf('POINT(%F %F)', $lng, $lat));
+    }
+
+    /**
+     * Remove seeded ids from a dataset's live index (teardown).
+     */
+    protected function removeSpatial(string $dataset, array $ids): void
+    {
+        Http::timeout(5)->post(
+            "{$this->spatialAdminUrl()}/v1/{$dataset}/remove",
+            ['ids' => array_values($ids)]
+        );
+    }
+}

--- a/iznik-batch/tests/Unit/Commands/Spatial/UpdateSpatialDataCommandTest.php
+++ b/iznik-batch/tests/Unit/Commands/Spatial/UpdateSpatialDataCommandTest.php
@@ -20,6 +20,11 @@ class UpdateSpatialDataCommandTest extends TestCase
             mkdir($this->dataDir, 0755, true);
         }
         config(['freegle.spatial_data_dir' => $this->dataDir]);
+        // Pin the admin URL the reload signal targets so the test is deterministic
+        // regardless of the container's SPATIAL_KNN_URL env (from which
+        // spatial_admin_url is otherwise derived). The Http::fake() stubs and the
+        // reload-URL assertion below both expect localhost:8195.
+        config(['freegle.spatial_admin_url' => 'http://localhost:8195']);
     }
 
     protected function tearDown(): void

--- a/iznik-batch/tests/Unit/Models/JobModelTest.php
+++ b/iznik-batch/tests/Unit/Models/JobModelTest.php
@@ -4,10 +4,60 @@ namespace Tests\Unit\Models;
 
 use App\Models\Job;
 use Illuminate\Support\Facades\DB;
+use Tests\Support\SeedsSpatialIndex;
 use Tests\TestCase;
 
 class JobModelTest extends TestCase
 {
+    use SeedsSpatialIndex;
+
+    /** @var int[] job ids seeded into the spatial index, removed in tearDown. */
+    private array $seededJobIds = [];
+
+    protected function tearDown(): void
+    {
+        if ($this->seededJobIds) {
+            $this->removeSpatial('jobs', $this->seededJobIds);
+            $this->seededJobIds = [];
+        }
+        parent::tearDown();
+    }
+
+    /**
+     * Insert a job row AND seed it into the spatial "jobs" index so KNN returns
+     * it. Jobs are polygons in the index (FindNearestPolygon skips nil-WKB
+     * points), so we seed a small box around the point. Defaults to the standard
+     * London test coords and a cpc above the floor; override via $attrs.
+     */
+    private function seedJob(array $attrs = [], float $lat = 51.5074, float $lng = -0.1278): int
+    {
+        $srid = (int) config('freegle.srid', 3857);
+        $attrs += [
+            'location' => 'London',
+            'company' => 'Test',
+            'city' => 'London',
+            'url' => 'https://example.com',
+            'cpc' => 0.20,
+            'visible' => 1,
+        ];
+        $attrs['geometry'] = DB::raw(sprintf("ST_GeomFromText('POINT(%F %F)', %d)", $lng, $lat, $srid));
+
+        $id = DB::table('jobs')->insertGetId($attrs);
+
+        $d = 0.0005;
+        $this->seedSpatial('jobs', $id, sprintf(
+            'POLYGON((%F %F, %F %F, %F %F, %F %F, %F %F))',
+            $lng - $d, $lat - $d,
+            $lng + $d, $lat - $d,
+            $lng + $d, $lat + $d,
+            $lng - $d, $lat + $d,
+            $lng - $d, $lat - $d
+        ));
+        $this->seededJobIds[] = $id;
+
+        return $id;
+    }
+
     public function test_job_model_has_correct_table(): void
     {
         $job = new Job();
@@ -35,7 +85,8 @@ class JobModelTest extends TestCase
 
     public function test_minimum_cpc_constant(): void
     {
-        $this->assertEquals(0.02, Job::MINIMUM_CPC);
+        // Matches the spatial "jobs" dataset floor and the public jobs page.
+        $this->assertEquals(0.10, Job::MINIMUM_CPC);
     }
 
     public function test_job_model_is_not_guarded_except_id(): void
@@ -46,7 +97,7 @@ class JobModelTest extends TestCase
 
     public function test_near_location_returns_collection(): void
     {
-        // Test that nearLocation returns a collection even with no jobs.
+        // Returns a collection even with nothing seeded for this location.
         $result = Job::nearLocation(51.5074, -0.1278);
 
         $this->assertInstanceOf(\Illuminate\Support\Collection::class, $result);
@@ -54,9 +105,10 @@ class JobModelTest extends TestCase
 
     public function test_near_location_returns_empty_for_no_jobs(): void
     {
-        // Ensure table is empty for this test.
         DB::table('jobs')->delete();
 
+        // Nothing in the test DB, so even if the index returns ids the by-id
+        // enrich finds nothing.
         $result = Job::nearLocation(51.5074, -0.1278);
 
         $this->assertTrue($result->isEmpty());
@@ -65,25 +117,12 @@ class JobModelTest extends TestCase
     public function test_near_location_respects_limit(): void
     {
         DB::table('jobs')->delete();
-        $srid = config('freegle.srid', 3857);
 
-        // Insert 5 visible jobs with good CPC near London.
+        // Five eligible jobs at the search point.
         for ($i = 0; $i < 5; $i++) {
-            $lat = 51.5074 + ($i * 0.001);
-            $lng = -0.1278 + ($i * 0.001);
-            DB::table('jobs')->insert([
-                'title' => 'Test Job ' . $i,
-                'location' => 'London',
-                'company' => 'Test Company',
-                'city' => 'London',
-                'url' => 'https://example.com/job/' . $i,
-                'cpc' => 0.05,
-                'visible' => 1,
-                'geometry' => DB::raw("ST_GeomFromText('POINT($lng $lat)', $srid)"),
-            ]);
+            $this->seedJob(['title' => 'Test Job ' . $i]);
         }
 
-        // Request 3 jobs - should get 3.
         $result = Job::nearLocation(51.5074, -0.1278, 3);
 
         $this->assertCount(3, $result);
@@ -92,37 +131,12 @@ class JobModelTest extends TestCase
     public function test_near_location_filters_by_minimum_cpc(): void
     {
         DB::table('jobs')->delete();
-        $srid = config('freegle.srid', 3857);
-        $lat = 51.5074;
-        $lng = -0.1278;
 
-        // Insert job with CPC below minimum.
-        DB::table('jobs')->insert([
-            'title' => 'Low CPC Job',
-            'location' => 'London',
-            'company' => 'Test Company',
-            'city' => 'London',
-            'url' => 'https://example.com/job/low',
-            'cpc' => 0.01,  // Below MINIMUM_CPC of 0.02.
-            'visible' => 1,
-            'geometry' => DB::raw("ST_GeomFromText('POINT($lng $lat)', $srid)"),
-        ]);
+        $this->seedJob(['title' => 'Low CPC Job', 'cpc' => 0.05]);  // below 0.10
+        $this->seedJob(['title' => 'Good CPC Job', 'cpc' => 0.20]);
 
-        // Insert job with CPC at minimum.
-        DB::table('jobs')->insert([
-            'title' => 'Good CPC Job',
-            'location' => 'London',
-            'company' => 'Test Company',
-            'city' => 'London',
-            'url' => 'https://example.com/job/good',
-            'cpc' => 0.02,  // At MINIMUM_CPC.
-            'visible' => 1,
-            'geometry' => DB::raw("ST_GeomFromText('POINT($lng $lat)', $srid)"),
-        ]);
+        $result = Job::nearLocation(51.5074, -0.1278);
 
-        $result = Job::nearLocation($lat, $lng);
-
-        // Should only get the one with good CPC.
         $this->assertCount(1, $result);
         $this->assertEquals('Good CPC Job', $result->first()->title);
     }
@@ -130,98 +144,41 @@ class JobModelTest extends TestCase
     public function test_near_location_filters_by_visibility(): void
     {
         DB::table('jobs')->delete();
-        $srid = config('freegle.srid', 3857);
-        $lat = 51.5074;
-        $lng = -0.1278;
 
-        // Insert visible job.
-        DB::table('jobs')->insert([
-            'title' => 'Visible Job',
-            'location' => 'London',
-            'company' => 'Test Company',
-            'city' => 'London',
-            'url' => 'https://example.com/job/visible',
-            'cpc' => 0.05,
-            'visible' => 1,
-            'geometry' => DB::raw("ST_GeomFromText('POINT($lng $lat)', $srid)"),
-        ]);
+        $this->seedJob(['title' => 'Visible Job', 'visible' => 1]);
+        $this->seedJob(['title' => 'Hidden Job', 'visible' => 0]);
 
-        // Insert hidden job.
-        DB::table('jobs')->insert([
-            'title' => 'Hidden Job',
-            'location' => 'London',
-            'company' => 'Test Company',
-            'city' => 'London',
-            'url' => 'https://example.com/job/hidden',
-            'cpc' => 0.05,
-            'visible' => 0,
-            'geometry' => DB::raw("ST_GeomFromText('POINT($lng $lat)', $srid)"),
-        ]);
+        $result = Job::nearLocation(51.5074, -0.1278);
 
-        $result = Job::nearLocation($lat, $lng);
-
-        // Should only get the visible one.
         $this->assertCount(1, $result);
         $this->assertEquals('Visible Job', $result->first()->title);
     }
 
-    public function test_near_location_varies_picks_from_top_cpc_pool(): void
+    public function test_near_location_varies_picks_within_pool(): void
     {
-        // When there are more jobs available than the limit, nearLocation
-        // shuffles within a candidate pool sized to limit * VARIETY_POOL_MULTIPLIER
-        // so consecutive immediate-mode digests don't always show the same
-        // ads. Verify (a) the result size stays at limit and (b) every
-        // returned job comes from the top (limit*M) by CPC — anything
-        // below that pool size must never be picked.
+        // With more eligible jobs than the limit, nearLocation shuffles within a
+        // candidate pool (limit * VARIETY_POOL_MULTIPLIER) so consecutive sends
+        // don't always show the same ads. The pool is now the nearest jobs
+        // (matching the web view's KNN selection), not the top-CPC ones, so we
+        // assert the variety invariants only: every result is the right size,
+        // and repeated calls surface more than `limit` distinct jobs.
         DB::table('jobs')->delete();
-        $srid = config('freegle.srid', 3857);
-        $lat = 51.5074;
-        $lng = -0.1278;
 
         $limit = 4;
-        $poolSize = $limit * Job::VARIETY_POOL_MULTIPLIER; // 12
-        $totalJobs = $poolSize + 5; // 17 — five jobs below the pool that must never appear.
-
-        // CPCs strictly descending so we know exactly which IDs belong in
-        // the eligible top-12 pool versus the always-excluded tail.
-        $insertedIdsByRank = [];
-        for ($i = 0; $i < $totalJobs; $i++) {
-            $cpc = round(1.00 - ($i * 0.01), 4); // 1.00, 0.99, ... well above MINIMUM_CPC.
-            DB::table('jobs')->insert([
-                'title' => 'Job rank ' . $i,
-                'location' => 'London',
-                'company' => 'Test',
-                'city' => 'London',
-                'url' => 'https://example.com/job/' . $i,
-                'cpc' => $cpc,
-                'visible' => 1,
-                'geometry' => DB::raw("ST_GeomFromText('POINT($lng $lat)', $srid)"),
-            ]);
-            $insertedIdsByRank[] = DB::getPdo()->lastInsertId();
+        $total = $limit * Job::VARIETY_POOL_MULTIPLIER + 3; // 15
+        for ($i = 0; $i < $total; $i++) {
+            $this->seedJob(['title' => 'Job rank ' . $i, 'cpc' => round(1.00 - ($i * 0.01), 4)]);
         }
 
-        $eligibleIds = array_slice($insertedIdsByRank, 0, $poolSize);
-        $excludedIds = array_slice($insertedIdsByRank, $poolSize);
-
-        // Run the query several times; track which IDs ever appear.
         $allSeen = [];
         for ($call = 0; $call < 8; $call++) {
-            $result = Job::nearLocation($lat, $lng, $limit);
+            $result = Job::nearLocation(51.5074, -0.1278, $limit);
             $this->assertCount($limit, $result, 'Result count must always equal limit');
             foreach ($result as $job) {
-                $this->assertNotContains(
-                    (string) $job->id,
-                    $excludedIds,
-                    'No job below the variety pool may ever be selected'
-                );
                 $allSeen[$job->id] = true;
             }
         }
 
-        // With limit=4 picked from a pool of 12 the probability of seeing
-        // only 4 IDs across 8 calls is vanishingly small (~1 in 1e6), so
-        // requiring strictly more than $limit unique IDs proves the
-        // shuffle is actually doing something.
         $this->assertGreaterThan(
             $limit,
             count($allSeen),
@@ -232,47 +189,15 @@ class JobModelTest extends TestCase
     public function test_near_location_orders_by_cpc_desc(): void
     {
         DB::table('jobs')->delete();
-        $srid = config('freegle.srid', 3857);
-        $lat = 51.5074;
-        $lng = -0.1278;
 
-        // Insert jobs with different CPCs.
-        DB::table('jobs')->insert([
-            'title' => 'Low CPC',
-            'location' => 'London',
-            'company' => 'Test',
-            'city' => 'London',
-            'url' => 'https://example.com/1',
-            'cpc' => 0.03,
-            'visible' => 1,
-            'geometry' => DB::raw("ST_GeomFromText('POINT($lng $lat)', $srid)"),
-        ]);
+        // All above the 0.10 floor; fewer than the default limit so there is no
+        // variety shuffle and the CPC-desc order is preserved.
+        $this->seedJob(['title' => 'Low CPC', 'cpc' => 0.10]);
+        $this->seedJob(['title' => 'High CPC', 'cpc' => 0.30]);
+        $this->seedJob(['title' => 'Medium CPC', 'cpc' => 0.20]);
 
-        DB::table('jobs')->insert([
-            'title' => 'High CPC',
-            'location' => 'London',
-            'company' => 'Test',
-            'city' => 'London',
-            'url' => 'https://example.com/2',
-            'cpc' => 0.10,
-            'visible' => 1,
-            'geometry' => DB::raw("ST_GeomFromText('POINT($lng $lat)', $srid)"),
-        ]);
+        $result = Job::nearLocation(51.5074, -0.1278);
 
-        DB::table('jobs')->insert([
-            'title' => 'Medium CPC',
-            'location' => 'London',
-            'company' => 'Test',
-            'city' => 'London',
-            'url' => 'https://example.com/3',
-            'cpc' => 0.05,
-            'visible' => 1,
-            'geometry' => DB::raw("ST_GeomFromText('POINT($lng $lat)', $srid)"),
-        ]);
-
-        $result = Job::nearLocation($lat, $lng);
-
-        // Should be ordered high to low CPC.
         $this->assertEquals('High CPC', $result[0]->title);
         $this->assertEquals('Medium CPC', $result[1]->title);
         $this->assertEquals('Low CPC', $result[2]->title);
@@ -280,27 +205,13 @@ class JobModelTest extends TestCase
 
     public function test_near_location_title_cases_lowercase_location(): void
     {
-        // The jobs feed stores location names lowercase ("manchester",
-        // "stoke-on-trent"). nearLocation should title-case them so emails
-        // read naturally instead of "Senior Manager manchester".
+        // The jobs feed stores location names lowercase ("stoke-on-trent");
+        // nearLocation title-cases them so emails read naturally.
         DB::table('jobs')->delete();
-        DB::table('ai_images')->delete();
-        $srid = config('freegle.srid', 3857);
-        $lat = 51.5074;
-        $lng = -0.1278;
 
-        DB::table('jobs')->insert([
-            'title' => 'Test Job',
-            'location' => 'stoke-on-trent',
-            'company' => 'Test',
-            'city' => 'London',
-            'url' => 'https://example.com',
-            'cpc' => 0.05,
-            'visible' => 1,
-            'geometry' => DB::raw("ST_GeomFromText('POINT($lng $lat)', $srid)"),
-        ]);
+        $this->seedJob(['title' => 'Test Job', 'location' => 'stoke-on-trent']);
 
-        $result = Job::nearLocation($lat, $lng);
+        $result = Job::nearLocation(51.5074, -0.1278);
 
         $this->assertCount(1, $result);
         $this->assertEquals('Stoke-On-Trent', $result->first()->location);
@@ -308,28 +219,13 @@ class JobModelTest extends TestCase
 
     public function test_near_location_adds_placeholder_image_for_jobs_without_ai_images(): void
     {
-        // When a job has no matching ai_images row, image_url falls back to
-        // briefcase.png — a friendly cartoon briefcase rendered in the same
-        // AI-image house style as the per-title illustrations so rows look
-        // consistent alongside ones with a real AI image.
+        // With no matching ai_images row, image_url falls back to briefcase.png.
         DB::table('jobs')->delete();
         DB::table('ai_images')->delete();
-        $srid = config('freegle.srid', 3857);
-        $lat = 51.5074;
-        $lng = -0.1278;
 
-        DB::table('jobs')->insert([
-            'title' => 'Test Job',
-            'location' => 'London',
-            'company' => 'Test',
-            'city' => 'London',
-            'url' => 'https://example.com',
-            'cpc' => 0.05,
-            'visible' => 1,
-            'geometry' => DB::raw("ST_GeomFromText('POINT($lng $lat)', $srid)"),
-        ]);
+        $this->seedJob(['title' => 'Test Job']);
 
-        $result = Job::nearLocation($lat, $lng);
+        $result = Job::nearLocation(51.5074, -0.1278);
 
         $this->assertCount(1, $result);
         $job = $result->first();
@@ -341,44 +237,27 @@ class JobModelTest extends TestCase
     {
         DB::table('jobs')->delete();
         DB::table('ai_images')->delete();
-        $srid = config('freegle.srid', 3857);
-        $lat = 51.5074;
-        $lng = -0.1278;
 
         $jobTitle = 'Software Developer';
-
         $canonicalTitle = strtolower($jobTitle);
 
-        DB::table('jobs')->insert([
-            'title' => $jobTitle,
-            'canonical_title' => $canonicalTitle,
-            'location' => 'London',
-            'company' => 'Test',
-            'city' => 'London',
-            'url' => 'https://example.com',
-            'cpc' => 0.05,
-            'visible' => 1,
-            'geometry' => DB::raw("ST_GeomFromText('POINT($lng $lat)', $srid)"),
-        ]);
+        $this->seedJob(['title' => $jobTitle, 'canonical_title' => $canonicalTitle]);
 
-        // Add AI image for this job's canonical title.
         DB::table('ai_images')->insert([
             'name' => $canonicalTitle,
             'externaluid' => 'freegletusd-abc123',
         ]);
 
-        $result = Job::nearLocation($lat, $lng);
+        $result = Job::nearLocation(51.5074, -0.1278);
 
         $this->assertCount(1, $result);
         $job = $result->first();
         $this->assertNotNull($job->image_url);
-        // Should contain the file ID from the externaluid.
         $this->assertStringContainsString('abc123', $job->image_url);
     }
 
     public function test_build_image_url_returns_null_for_null_externaluid(): void
     {
-        // Use reflection to test protected method.
         $reflection = new \ReflectionClass(Job::class);
         $method = $reflection->getMethod('buildImageUrl');
         $method->setAccessible(true);
@@ -394,7 +273,6 @@ class JobModelTest extends TestCase
         $method = $reflection->getMethod('buildImageUrl');
         $method->setAccessible(true);
 
-        // Missing freegletusd- prefix.
         $result = $method->invoke(null, 'invalid-format');
 
         $this->assertNull($result);
@@ -426,30 +304,15 @@ class JobModelTest extends TestCase
         $this->assertStringContainsString('w=50', $result);
     }
 
-    public function test_near_location_expands_search_area_to_find_jobs(): void
+    public function test_near_location_finds_jobs_within_search_reach(): void
     {
+        // A job ~5.5km north is still within the spatial KNN's search reach.
         DB::table('jobs')->delete();
-        $srid = config('freegle.srid', 3857);
 
-        // Place job slightly outside initial search box but within expansion range.
-        $jobLat = 51.5074 + 0.05;  // About 5.5km north.
-        $jobLng = -0.1278;
+        $this->seedJob(['title' => 'Distant Job', 'location' => 'North London'], 51.5074 + 0.05, -0.1278);
 
-        DB::table('jobs')->insert([
-            'title' => 'Distant Job',
-            'location' => 'North London',
-            'company' => 'Test',
-            'city' => 'London',
-            'url' => 'https://example.com',
-            'cpc' => 0.05,
-            'visible' => 1,
-            'geometry' => DB::raw("ST_GeomFromText('POINT($jobLng $jobLat)', $srid)"),
-        ]);
-
-        // Search from a point where initial box won't contain the job.
         $result = Job::nearLocation(51.5074, -0.1278);
 
-        // Should find the job through box expansion.
         $this->assertCount(1, $result);
     }
 }

--- a/iznik-batch/tests/Unit/Models/JobModelTest.php
+++ b/iznik-batch/tests/Unit/Models/JobModelTest.php
@@ -38,6 +38,7 @@ class JobModelTest extends TestCase
             'city' => 'London',
             'url' => 'https://example.com',
             'cpc' => 0.20,
+            'clickability' => 1,
             'visible' => 1,
         ];
         $attrs['geometry'] = DB::raw(sprintf("ST_GeomFromText('POINT(%F %F)', %d)", $lng, $lat, $srid));

--- a/iznik-batch/tests/Unit/Models/LocationTest.php
+++ b/iznik-batch/tests/Unit/Models/LocationTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit\Models;
 use App\Models\Group;
 use App\Models\Location;
 use Illuminate\Support\Facades\DB;
+use Tests\Support\SeedsSpatialIndex;
 use Tests\TestCase;
 
 /**
@@ -16,47 +17,58 @@ use Tests\TestCase;
  */
 class LocationTest extends TestCase
 {
-    private const NO_POSTCODE_DATA = 'No postcode data in test database';
+    use SeedsSpatialIndex;
+
+    private const TEST_PC_ID = 99000001;
+
     /**
-     * Check if test location data exists before running spatial tests.
+     * Seed a known full postcode into both the test DB (for the by-id enrich)
+     * and the spatial server's live "postcodes" index (for the KNN lookup).
      */
-    private function hasLocationData(): bool
+    private function seedPostcode(int $id, string $name, float $lat, float $lng): void
     {
-        return DB::table('locations')
-            ->where('type', 'Postcode')
-            ->whereRaw("LOCATE(' ', name) > 0")
-            ->exists();
+        $srid = (int) config('freegle.srid', 3857);
+        DB::table('locations')->updateOrInsert(['id' => $id], [
+            'name'     => $name,
+            'type'     => 'Postcode',
+            'lat'      => $lat,
+            'lng'      => $lng,
+            'geometry' => DB::raw(sprintf("ST_GeomFromText('POINT(%F %F)', %d)", $lng, $lat, $srid)),
+        ]);
+        $this->seedSpatialPoint('postcodes', $id, $lat, $lng);
     }
 
     public function test_closest_postcode_returns_result_for_known_coords(): void
     {
-        if (!$this->hasLocationData()) {
-            $this->markTestSkipped(self::NO_POSTCODE_DATA);
+        $this->seedPostcode(self::TEST_PC_ID, 'EH1 1AA', 55.9533, -3.1883);
+
+        try {
+            $result = Location::closestPostcode(55.9533, -3.1883);
+
+            $this->assertNotNull($result);
+            $this->assertEquals(self::TEST_PC_ID, (int) $result->id);
+            $this->assertEquals('EH1 1AA', $result->name);
+            $this->assertNotEmpty($result->name);
+        } finally {
+            $this->removeSpatial('postcodes', [self::TEST_PC_ID]);
+            DB::table('locations')->where('id', self::TEST_PC_ID)->delete();
         }
-
-        // Central Edinburgh — should find a postcode.
-        $result = Location::closestPostcode(55.9533, -3.1883);
-
-        $this->assertNotNull($result);
-        $this->assertArrayHasKey('id', $result);
-        $this->assertArrayHasKey('name', $result);
-        $this->assertArrayHasKey('lat', $result);
-        $this->assertArrayHasKey('lng', $result);
-        $this->assertNotEmpty($result['name']);
     }
 
     public function test_closest_postcode_returns_full_postcode(): void
     {
-        if (!$this->hasLocationData()) {
-            $this->markTestSkipped(self::NO_POSTCODE_DATA);
+        $this->seedPostcode(self::TEST_PC_ID, 'SW1A 1AA', 51.5074, -0.1278);
+
+        try {
+            $result = Location::closestPostcode(51.5074, -0.1278);
+
+            $this->assertNotNull($result);
+            // Full postcodes have a space in them (e.g. "SW1A 1AA").
+            $this->assertStringContainsString(' ', $result->name);
+        } finally {
+            $this->removeSpatial('postcodes', [self::TEST_PC_ID]);
+            DB::table('locations')->where('id', self::TEST_PC_ID)->delete();
         }
-
-        // Central London — well-populated area.
-        $result = Location::closestPostcode(51.5074, -0.1278);
-
-        $this->assertNotNull($result);
-        // Full postcodes have a space in them (e.g. "SW1A 1AA").
-        $this->assertStringContainsString(' ', $result['name']);
     }
 
     public function test_closest_postcode_returns_null_for_ocean(): void
@@ -115,25 +127,21 @@ class LocationTest extends TestCase
         $this->assertNotContains($towerHamlets->id, $groups, 'Group with no containing polygon must not appear when containment match exists');
     }
 
-    public function test_closest_postcode_includes_area_data(): void
+    public function test_closest_postcode_returns_coordinates(): void
     {
-        if (!$this->hasLocationData()) {
-            $this->markTestSkipped(self::NO_POSTCODE_DATA);
-        }
+        // Nottingham.
+        $this->seedPostcode(self::TEST_PC_ID, 'NG1 1AA', 52.9548, -1.1581);
 
-        // Nottingham — should have area data.
-        $result = Location::closestPostcode(52.9548, -1.1581);
+        try {
+            $result = Location::closestPostcode(52.9548, -1.1581);
 
-        if ($result === null) {
-            $this->markTestSkipped('No postcode found near Nottingham in test data');
-        }
-
-        // If the postcode has an areaid, we should get area info.
-        // Not all postcodes have area data, so only assert structure if present.
-        if (isset($result['area'])) {
-            $this->assertIsArray($result['area']);
-            $this->assertArrayHasKey('id', $result['area']);
-            $this->assertArrayHasKey('name', $result['area']);
+            $this->assertNotNull($result);
+            $this->assertEquals(self::TEST_PC_ID, (int) $result->id);
+            $this->assertNotNull($result->lat);
+            $this->assertNotNull($result->lng);
+        } finally {
+            $this->removeSpatial('postcodes', [self::TEST_PC_ID]);
+            DB::table('locations')->where('id', self::TEST_PC_ID)->delete();
         }
     }
 }

--- a/iznik-batch/tests/Unit/Services/Mail/Incoming/LocationIdTest.php
+++ b/iznik-batch/tests/Unit/Services/Mail/Incoming/LocationIdTest.php
@@ -2,20 +2,21 @@
 
 namespace Tests\Unit\Services\Mail\Incoming;
 
-use App\Models\Group;
-use App\Models\User;
 use App\Services\Mail\Incoming\IncomingMailService;
 use App\Services\Mail\Incoming\ParsedEmail;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
-use Illuminate\Support\Facades\DB;
 use Mockery;
 use PHPUnit\Framework\Attributes\Test;
 use ReflectionClass;
+use Tests\Support\SeedsSpatialIndex;
 use Tests\TestCase;
 
 class LocationIdTest extends TestCase
 {
     use DatabaseTransactions;
+    use SeedsSpatialIndex;
+
+    private const PC_ID = 99000011;
 
     private IncomingMailService $service;
 
@@ -26,6 +27,12 @@ class LocationIdTest extends TestCase
         parent::setUp();
         $this->service = app(IncomingMailService::class);
         $this->reflection = new ReflectionClass($this->service);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeSpatial('postcodes', [self::PC_ID]);
+        parent::tearDown();
     }
 
     /**
@@ -42,100 +49,39 @@ class LocationIdTest extends TestCase
     #[Test]
     public function it_finds_closest_postcode_by_coordinates(): void
     {
-        // Create a test location in the database
-        $locationId = DB::table('locations')->insertGetId([
-            'name' => 'AB10 1AB',
-            'type' => 'Postcode',
-            'lat' => 57.145,
-            'lng' => -2.095,
-        ]);
+        // Seed a postcode point into the spatial server's live index.
+        $this->seedSpatialPoint('postcodes', self::PC_ID, 57.145, -2.095);
 
-        // Add to spatial index
-        $srid = config('freegle.srid', 3857);
-        DB::statement("INSERT INTO locations_spatial (locationid, geometry) VALUES (?, ST_GeomFromText('POINT(-2.095 57.145)', ?))", [
-            $locationId, $srid,
-        ]);
-
-        // Test finding it
         $foundId = $this->invokePrivateMethod('findClosestPostcodeId', [57.145, -2.095]);
 
-        $this->assertEquals($locationId, $foundId);
+        $this->assertEquals(self::PC_ID, $foundId);
     }
 
     #[Test]
     public function it_returns_null_when_no_postcode_found(): void
     {
-        // Test with coordinates in the middle of the ocean
+        // Middle of the ocean, nothing seeded nearby.
         $foundId = $this->invokePrivateMethod('findClosestPostcodeId', [0.0, 0.0]);
 
         $this->assertNull($foundId);
     }
 
     #[Test]
-    public function it_finds_closest_postcode_within_expanding_radius(): void
+    public function it_finds_closest_postcode_offset_from_search_point(): void
     {
-        // Create a test location slightly offset from search point
-        $locationId = DB::table('locations')->insertGetId([
-            'name' => 'AB11 1AB',
-            'type' => 'Postcode',
-            'lat' => 57.150,
-            'lng' => -2.100,
-        ]);
+        // Seed a postcode slightly offset from the search point — KNN still finds it.
+        $this->seedSpatialPoint('postcodes', self::PC_ID, 57.150, -2.100);
 
-        $srid = config('freegle.srid', 3857);
-        DB::statement("INSERT INTO locations_spatial (locationid, geometry) VALUES (?, ST_GeomFromText('POINT(-2.100 57.150)', ?))", [
-            $locationId, $srid,
-        ]);
-
-        // Search from nearby point - should still find it due to expanding radius
         $foundId = $this->invokePrivateMethod('findClosestPostcodeId', [57.145, -2.095]);
 
-        $this->assertEquals($locationId, $foundId);
+        $this->assertEquals(self::PC_ID, $foundId);
     }
 
-    #[Test]
-    public function it_ignores_non_postcode_locations(): void
-    {
-        // Create a non-postcode location
-        $nonPostcodeId = DB::table('locations')->insertGetId([
-            'name' => 'Some Area',
-            'type' => 'Polygon',
-            'lat' => 57.145,
-            'lng' => -2.095,
-        ]);
-
-        $srid = config('freegle.srid', 3857);
-        DB::statement("INSERT INTO locations_spatial (locationid, geometry) VALUES (?, ST_GeomFromText('POINT(-2.095 57.145)', ?))", [
-            $nonPostcodeId, $srid,
-        ]);
-
-        // Should not find the non-postcode
-        $foundId = $this->invokePrivateMethod('findClosestPostcodeId', [57.145, -2.095]);
-
-        $this->assertNull($foundId);
-    }
-
-    #[Test]
-    public function it_requires_space_in_postcode_name(): void
-    {
-        // Create a postcode without space (invalid format)
-        $invalidId = DB::table('locations')->insertGetId([
-            'name' => 'AB101AB',
-            'type' => 'Postcode',
-            'lat' => 57.145,
-            'lng' => -2.095,
-        ]);
-
-        $srid = config('freegle.srid', 3857);
-        DB::statement("INSERT INTO locations_spatial (locationid, geometry) VALUES (?, ST_GeomFromText('POINT(-2.095 57.145)', ?))", [
-            $invalidId, $srid,
-        ]);
-
-        // Should not find postcodes without spaces (they're postcode areas, not full postcodes)
-        $foundId = $this->invokePrivateMethod('findClosestPostcodeId', [57.145, -2.095]);
-
-        $this->assertNull($foundId);
-    }
+    // NB: the old "ignores non-postcode locations" and "requires a space in the
+    // name" tests asserted findClosestPostcodeId's own type/LOCATE filtering.
+    // That filtering now lives in the spatial server's postcodes dataset loader
+    // (loadPostcodes: WHERE type='Postcode' AND LOCATE(' ', name) > 0) and is
+    // covered by iznik-spatial-go, so they no longer belong here.
 
     #[Test]
     public function it_gets_lat_lng_from_tn_coordinates_header(): void

--- a/iznik-server-go/location/location.go
+++ b/iznik-server-go/location/location.go
@@ -42,56 +42,23 @@ type Location struct {
 	Dist       float32        `json:"dist" gorm:"-"`
 }
 
+// ClosestPostcode returns the nearest full postcode to a point via the spatial
+// server's "postcodes" KNN dataset. Returns a zero Location if the spatial
+// server has nothing nearby or is unreachable.
 func ClosestPostcode(lat float32, lng float32) Location {
-	results, err := spatial.KNN("locations", float64(lng), float64(lat), 1, "Postcode")
-	if err == nil && len(results) > 0 {
-		id := results[0].ID
-		var loc Location
-		database.DBConn.Raw(
-			"SELECT l1.id, l1.name, l1.type, l1.lat, l1.lng, l1.areaid, l2.name AS areaname "+
-				"FROM locations l1 LEFT JOIN locations l2 ON l2.id = l1.areaid WHERE l1.id = ?",
-			id,
-		).Scan(&loc)
-		return loc
+	results, err := spatial.KNN("postcodes", float64(lng), float64(lat), 1, "")
+	if err != nil || len(results) == 0 {
+		return Location{}
 	}
 
-	// Fallback: spatial server unavailable or no polygon postcodes loaded (e.g. test environment).
-	// Use MySQL spatial query against locations_spatial which stores postcode point/polygon geometries.
-	return closestPostcodeMySQL(lat, lng)
-}
-
-func closestPostcodeMySQL(lat float32, lng float32) Location {
-	var scan = float32(0.00001953125)
-	db := database.DBConn
-
-	for {
-		swlat := lat - scan
-		swlng := lng - scan
-		nelat := lat + scan
-		nelng := lng + scan
-
-		var locs []Location
-		db.Raw("SELECT l1.id, l1.name, l1.areaid, l1.lat, l1.lng, l1.type, l2.name as areaname, "+
-			"ST_distance(locations_spatial.geometry, ST_SRID(POINT(?, ?), ?)) AS dist "+
-			"FROM locations_spatial INNER JOIN locations l1 ON l1.id = locations_spatial.locationid "+
-			"LEFT JOIN locations l2 ON l2.id = l1.areaid "+
-			"WHERE MBRContains(ST_Envelope(ST_SRID(POLYGON(LINESTRING(POINT(?, ?), POINT(?, ?), POINT(?, ?), POINT(?, ?), POINT(?, ?))), ?)), locations_spatial.geometry) AND "+
-			"l1.type = ? "+
-			"ORDER BY dist ASC, CASE WHEN ST_Dimension(locations_spatial.geometry) < 2 THEN 0 ELSE ST_AREA(locations_spatial.geometry) END ASC LIMIT 1;",
-			lng, lat, utils.SRID,
-			swlng, swlat, swlng, nelat, nelng, nelat, nelng, swlat, swlng, swlat,
-			utils.SRID, utils.LOCATION_TYPE_POSTCODE,
-		).Scan(&locs)
-
-		if len(locs) > 0 {
-			return locs[0]
-		}
-		scan = scan * 2
-		if scan > 0.2 {
-			break
-		}
-	}
-	return Location{}
+	id := results[0].ID
+	var loc Location
+	database.DBConn.Raw(
+		"SELECT l1.id, l1.name, l1.type, l1.lat, l1.lng, l1.areaid, l2.name AS areaname "+
+			"FROM locations l1 LEFT JOIN locations l2 ON l2.id = l1.areaid WHERE l1.id = ?",
+		id,
+	).Scan(&loc)
+	return loc
 }
 
 type ClosestGroup struct {

--- a/iznik-server-go/location/location.go
+++ b/iznik-server-go/location/location.go
@@ -46,6 +46,16 @@ type Location struct {
 // server's "postcodes" KNN dataset. Returns a zero Location if the spatial
 // server has nothing nearby or is unreachable.
 func ClosestPostcode(lat float32, lng float32) Location {
+	// (0,0) is the codebase-wide "location unknown" sentinel (e.g. GetLatLng
+	// returns it for a user with no derivable location). It sits in the Atlantic
+	// off Africa, so a UK KNN would still return *some* postcode (the nearest,
+	// however far) — the old expanding-bbox lookup returned empty here. Preserve
+	// that: no location in, no postcode out. (lng=0 alone is valid — the Greenwich
+	// meridian crosses the UK — so only the both-zero sentinel is excluded.)
+	if lat == 0 && lng == 0 {
+		return Location{}
+	}
+
 	results, err := spatial.KNN("postcodes", float64(lng), float64(lat), 1, "")
 	if err != nil || len(results) == 0 {
 		return Location{}

--- a/iznik-server-go/test/main_test.go
+++ b/iznik-server-go/test/main_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/freegle/iznik-server-go/database"
@@ -104,11 +105,34 @@ func setupLocationTestData() {
 	db.Exec(`INSERT IGNORE INTO locations_spatial (locationid, geometry)
 		VALUES (1000002, ST_GeomFromText('POINT(-3.206000 55.958000)', 3857))`)
 
+	// Seed the postcode points into the spatial server's live "postcodes" index
+	// so ClosestPostcode (which now queries spatial KNN, not locations_spatial)
+	// finds them without waiting for a MySQL-driven index rebuild.
+	seedSpatialPostcode(1687412, -4.939858, 52.006292)
+	seedSpatialPostcode(1000001, -3.205333, 55.957571)
+	seedSpatialPostcode(1000002, -3.206000, 55.958000)
+
 	// PAF addresses for TestAddresses (linked to location 1687412)
 	db.Exec(`INSERT IGNORE INTO paf_addresses (id, postcodeid, udprn) VALUES (102367696, 1687412, 50464672)`)
 
 	// LoveJunk partner key for TestCreateChatMessageLoveJunk
 	db.Exec("INSERT IGNORE INTO partners_keys (partner, `key`) VALUES ('lovejunk', 'testkey123')")
+}
+
+// seedSpatialPostcode upserts a postcode point into the spatial server's live
+// "postcodes" index via the admin API, so ClosestPostcode tests get a
+// deterministic result decoupled from the MySQL-driven index rebuild. The admin
+// port is the public port + 1 (8194 -> 8195), matching the spatial server.
+func seedSpatialPostcode(id int64, lng, lat float64) {
+	admin := os.Getenv("SPATIAL_KNN_URL")
+	if admin == "" {
+		admin = "http://localhost:8194"
+	}
+	admin = strings.Replace(admin, ":8194", ":8195", 1)
+	body := fmt.Sprintf(`{"items":[{"id":%d,"wkt":"POINT(%f %f)"}]}`, id, lng, lat)
+	if resp, err := http.Post(admin+"/v1/postcodes/upsert", "application/json", strings.NewReader(body)); err == nil && resp != nil {
+		resp.Body.Close()
+	}
 }
 
 // verifyRequiredTables checks that tables created by Laravel migrations exist.

--- a/iznik-server-go/test/main_test.go
+++ b/iznik-server-go/test/main_test.go
@@ -2,9 +2,13 @@ package test
 
 import (
 	"fmt"
+	"math"
 	"net/http"
+	"net/http/httptest"
 	"os"
+	"strconv"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/freegle/iznik-server-go/database"
@@ -105,12 +109,11 @@ func setupLocationTestData() {
 	db.Exec(`INSERT IGNORE INTO locations_spatial (locationid, geometry)
 		VALUES (1000002, ST_GeomFromText('POINT(-3.206000 55.958000)', 3857))`)
 
-	// Seed the postcode points into the spatial server's live "postcodes" index
-	// so ClosestPostcode (which now queries spatial KNN, not locations_spatial)
-	// finds them without waiting for a MySQL-driven index rebuild.
-	seedSpatialPostcode(1687412, -4.939858, 52.006292)
-	seedSpatialPostcode(1000001, -3.205333, 55.957571)
-	seedSpatialPostcode(1000002, -3.206000, 55.958000)
+	// ClosestPostcode now queries the spatial KNN with no MySQL fallback, but the
+	// spatial server's index isn't reliably populated in the test environment (it
+	// builds from the DB at startup, before this test data exists — see
+	// jobs_test.go). Point the spatial client at a deterministic in-process mock.
+	ensureSpatialMock()
 
 	// PAF addresses for TestAddresses (linked to location 1687412)
 	db.Exec(`INSERT IGNORE INTO paf_addresses (id, postcodeid, udprn) VALUES (102367696, 1687412, 50464672)`)
@@ -119,20 +122,43 @@ func setupLocationTestData() {
 	db.Exec("INSERT IGNORE INTO partners_keys (partner, `key`) VALUES ('lovejunk', 'testkey123')")
 }
 
-// seedSpatialPostcode upserts a postcode point into the spatial server's live
-// "postcodes" index via the admin API, so ClosestPostcode tests get a
-// deterministic result decoupled from the MySQL-driven index rebuild. The admin
-// port is the public port + 1 (8194 -> 8195), matching the spatial server.
-func seedSpatialPostcode(id int64, lng, lat float64) {
-	admin := os.Getenv("SPATIAL_KNN_URL")
-	if admin == "" {
-		admin = "http://localhost:8194"
-	}
-	admin = strings.Replace(admin, ":8194", ":8195", 1)
-	body := fmt.Sprintf(`{"items":[{"id":%d,"wkt":"POINT(%f %f)"}]}`, id, lng, lat)
-	if resp, err := http.Post(admin+"/v1/postcodes/upsert", "application/json", strings.NewReader(body)); err == nil && resp != nil {
-		resp.Body.Close()
-	}
+var spatialMockOnce sync.Once
+
+// ensureSpatialMock points the spatial client (SPATIAL_KNN_URL) at an in-process
+// server that answers /v1/postcodes/knn with the nearest of the test postcodes
+// and returns empty for every other dataset. This keeps ClosestPostcode
+// deterministic without depending on a live, populated spatial server, which the
+// test environment doesn't provide.
+func ensureSpatialMock() {
+	spatialMockOnce.Do(func() {
+		type pc struct {
+			id       int64
+			lng, lat float64
+		}
+		pts := []pc{
+			{1000001, -3.205333, 55.957571},
+			{1000002, -3.206000, 55.958000},
+			{1687412, -4.939858, 52.006292},
+		}
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			if strings.Contains(r.URL.Path, "/postcodes/knn") {
+				lat, _ := strconv.ParseFloat(r.URL.Query().Get("lat"), 64)
+				lng, _ := strconv.ParseFloat(r.URL.Query().Get("lng"), 64)
+				best, bestD := int64(0), math.MaxFloat64
+				for _, p := range pts {
+					d := (p.lng-lng)*(p.lng-lng) + (p.lat-lat)*(p.lat-lat)
+					if d < bestD {
+						bestD, best = d, p.id
+					}
+				}
+				fmt.Fprintf(w, `{"results":[{"id":%d,"distance":%g}]}`, best, bestD)
+				return
+			}
+			w.Write([]byte(`{"results":[],"ids":[]}`))
+		}))
+		os.Setenv("SPATIAL_KNN_URL", srv.URL)
+	})
 }
 
 // verifyRequiredTables checks that tables created by Laravel migrations exist.

--- a/iznik-spatial-go/dataset_postcodes.go
+++ b/iznik-spatial-go/dataset_postcodes.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"log"
+	"time"
+)
+
+// PostcodesDataset implements Dataset for postcode locations (point geometry).
+//
+// Postcodes are by far the largest dataset (~2M rows) and are points, so each is
+// stored with a degenerate bbox and nil WKB, and queried with FindNearestPoints.
+// Only full postcodes (name contains a space, e.g. "SW1A 2DU") are indexed —
+// outward-only districts are excluded, matching Location::closestPostcode in the
+// PHP batch which has always returned full postcodes.
+//
+// Extra is left nil deliberately: at 2M rows a per-item map would cost a lot of
+// allocations/JSON for no benefit — the nearest lookup only needs the id, and
+// callers resolve name/lat/lng from MySQL by id afterwards.
+type PostcodesDataset struct{}
+
+func (d *PostcodesDataset) Name() string { return "postcodes" }
+
+func (d *PostcodesDataset) RebuildInterval() time.Duration { return 24 * time.Hour }
+
+// Postcodes change rarely (only when the Doogal import adds new ones or nudges a
+// lat/lng), so an hourly incremental delta is ample; the nightly full rebuild
+// reconciles deletions/exclusions.
+func (d *PostcodesDataset) DeltaInterval() time.Duration { return 1 * time.Hour }
+
+func (d *PostcodesDataset) Load(mysqlDB *sql.DB, idx *Index) error {
+	return loadPostcodes(mysqlDB, idx, "")
+}
+
+func (d *PostcodesDataset) ApplyDelta(mysqlDB *sql.DB, idx *Index, since time.Time) error {
+	return loadPostcodes(mysqlDB, idx, fmt.Sprintf(
+		" AND locations.timestamp > '%s'", since.UTC().Format("2006-01-02 15:04:05")))
+}
+
+func (d *PostcodesDataset) Query(idx *Index, params QueryParams) ([]QueryResult, error) {
+	if params.Limit <= 0 {
+		params.Limit = 1
+	}
+	return FindNearestPoints(idx, params.Lng, params.Lat, params.Limit, params.Polygon)
+}
+
+func (d *PostcodesDataset) Within(idx *Index, params QueryParams) ([]int64, error) {
+	if params.Polygon == nil {
+		return nil, fmt.Errorf("polygon parameter is required for Within queries")
+	}
+	ids, err := idx.QueryWithin(*params.Polygon)
+	if err != nil {
+		return nil, err
+	}
+	if len(ids) > maxWithinResults {
+		return nil, ErrTooManyResults
+	}
+	return ids, nil
+}
+
+func loadPostcodes(mysqlDB *sql.DB, idx *Index, extraWhere string) error {
+	query := `
+		SELECT locations.id,
+		       ST_X(COALESCE(ourgeometry, geometry)) AS lng,
+		       ST_Y(COALESCE(ourgeometry, geometry)) AS lat
+		FROM locations
+		LEFT JOIN locations_excluded le ON locations.id = le.locationid
+		WHERE le.locationid IS NULL
+		  AND locations.type = 'Postcode'
+		  AND LOCATE(' ', locations.name) > 0
+		  AND COALESCE(ourgeometry, geometry) IS NOT NULL
+	` + extraWhere
+
+	rows, err := mysqlDB.Query(query)
+	if err != nil {
+		return fmt.Errorf("postcodes load query: %w", err)
+	}
+	defer rows.Close()
+
+	var items []Item
+	for rows.Next() {
+		var id int64
+		var lng, lat float64
+		if err := rows.Scan(&id, &lng, &lat); err != nil {
+			return fmt.Errorf("scan: %w", err)
+		}
+		items = append(items, Item{
+			ExtID:  id,
+			MinLng: lng,
+			MaxLng: lng,
+			MinLat: lat,
+			MaxLat: lat,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	log.Printf("postcodes load: loaded %d items", len(items))
+	return InsertItems(idx, items, nil)
+}

--- a/iznik-spatial-go/dataset_test.go
+++ b/iznik-spatial-go/dataset_test.go
@@ -178,6 +178,32 @@ func TestMessagesDataset_Within(t *testing.T) {
 	assert.Contains(t, ids, int64(60))
 }
 
+func TestPostcodesDataset_Query(t *testing.T) {
+	idx, err := CreateIndex(":memory:")
+	require.NoError(t, err)
+	defer idx.Close()
+
+	// Two postcode points; the one at (0.01, 51.50) is nearest to (0, 51.5).
+	items := []Item{
+		{ExtID: 70, MinLng: 0.01, MaxLng: 0.01, MinLat: 51.50, MaxLat: 51.50},
+		{ExtID: 71, MinLng: 1.00, MaxLng: 1.00, MinLat: 51.50, MaxLat: 51.50},
+	}
+	require.NoError(t, InsertItems(idx, items, nil))
+
+	ds := &PostcodesDataset{}
+	results, err := ds.Query(idx, QueryParams{Lng: 0, Lat: 51.5, Limit: 1})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, int64(70), results[0].ID, "nearest postcode should be returned")
+}
+
+func TestPostcodesDataset_Meta(t *testing.T) {
+	ds := &PostcodesDataset{}
+	assert.Equal(t, "postcodes", ds.Name())
+	// Postcodes use an incremental delta (not rebuild-only).
+	assert.Greater(t, ds.DeltaInterval(), time.Duration(0))
+}
+
 func TestUserApproxLocsDataset_ApplyDeltaNotSupported(t *testing.T) {
 	ds := &UserApproxLocsDataset{}
 	err := ds.ApplyDelta(nil, nil, zeroTime)

--- a/iznik-spatial-go/index.go
+++ b/iznik-spatial-go/index.go
@@ -30,6 +30,10 @@ func CreateIndex(path string) (*Index, error) {
 	if err != nil {
 		return nil, fmt.Errorf("open sqlite %q: %w", path, err)
 	}
+	// Build on a single connection so the loader and the pre-rename WAL
+	// checkpoint share one connection — the checkpoint must flush every page into
+	// the main .db file, because rebuild renames only the .db (not the -wal/-shm).
+	db.SetMaxOpenConns(1)
 	if _, err := db.Exec(`PRAGMA journal_mode=WAL`); err != nil {
 		db.Close()
 		return nil, fmt.Errorf("set WAL mode: %w", err)
@@ -68,6 +72,15 @@ func OpenIndex(path string) (*Index, error) {
 // Close releases the SQLite connection.
 func (idx *Index) Close() error {
 	return idx.db.Close()
+}
+
+// Checkpoint flushes the WAL fully into the main .db file and truncates it, so
+// the .db is self-contained. rebuild() renames only the .db file, so without
+// this a large index keeps its newest pages (including the schema) in the
+// orphaned -wal and reopens as "no items table".
+func (idx *Index) Checkpoint() error {
+	_, err := idx.db.Exec(`PRAGMA wal_checkpoint(TRUNCATE)`)
+	return err
 }
 
 func initSchema(db *sql.DB) error {

--- a/iznik-spatial-go/index_test.go
+++ b/iznik-spatial-go/index_test.go
@@ -1,12 +1,47 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/peterstace/simplefeatures/geom"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestRebuildFlow_CheckpointSurvivesRename(t *testing.T) {
+	// Regression: rebuild() renames only the .db file, so the WAL must be
+	// checkpointed into it first — otherwise a large index reopens as
+	// "no items table" (its newest pages stranded in the orphaned -wal).
+	dir := t.TempDir()
+	tmpPath := filepath.Join(dir, "x.db.building")
+	finalPath := filepath.Join(dir, "x.db")
+
+	idx, err := CreateIndex(tmpPath)
+	require.NoError(t, err)
+
+	const n = 5000
+	items := make([]Item, n)
+	for i := 0; i < n; i++ {
+		lng := -3 + float64(i%400)/100
+		lat := 51 + float64(i%500)/100
+		items[i] = Item{ExtID: int64(i + 1), MinLng: lng, MaxLng: lng, MinLat: lat, MaxLat: lat}
+	}
+	require.NoError(t, InsertItems(idx, items, nil))
+	require.NoError(t, idx.Checkpoint())
+	require.NoError(t, idx.Close())
+
+	require.NoError(t, os.Rename(tmpPath, finalPath))
+
+	reopened, err := OpenIndex(finalPath)
+	require.NoError(t, err, "reopened renamed index must still have its items table")
+	defer reopened.Close()
+
+	cnt, err := reopened.CountRows()
+	require.NoError(t, err)
+	assert.Equal(t, int64(n), cnt)
+}
 
 // mustGeom parses a WKT string into a geom.Geometry, failing the test on error.
 func mustGeom(t *testing.T, wkt string) geom.Geometry {

--- a/iznik-spatial-go/main.go
+++ b/iznik-spatial-go/main.go
@@ -375,6 +375,70 @@ func main() {
 		return c.JSON(fiber.Map{"removed": removed})
 	})
 
+	// POST /v1/:dataset/upsert — insert/replace specific items by WKT geometry.
+	// Intended for integration tests, which seed a known geometry into the live
+	// index (decoupled from the nightly MySQL rebuild) and remove it afterwards.
+	admin.Post("/v1/:dataset/upsert", func(c *fiber.Ctx) error {
+		name := c.Params("dataset")
+		state, ok := srv.getDataset(name)
+		if !ok {
+			return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": "unknown dataset"})
+		}
+
+		var req struct {
+			Items []struct {
+				ID    int64          `json:"id"`
+				WKT   string         `json:"wkt"`
+				Extra map[string]any `json:"extra"`
+			} `json:"items"`
+		}
+		if err := c.BodyParser(&req); err != nil {
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid request body"})
+		}
+
+		items := make([]Item, 0, len(req.Items))
+		for _, in := range req.Items {
+			g, err := geom.UnmarshalWKT(in.WKT, geom.NoValidate{})
+			if err != nil {
+				return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "bad wkt for id " + fmt.Sprint(in.ID) + ": " + err.Error()})
+			}
+			min, max, okEnv := g.Envelope().MinMaxXYs()
+			if !okEnv {
+				return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "empty geometry for id " + fmt.Sprint(in.ID)})
+			}
+			it := Item{
+				ExtID:  in.ID,
+				MinLng: min.X,
+				MaxLng: max.X,
+				MinLat: min.Y,
+				MaxLat: max.Y,
+				Extra:  in.Extra,
+			}
+			// Polygon (non-degenerate envelope) → keep WKB + area so the polygon
+			// nearest/within queries work; point → leave WKB nil.
+			if min.X != max.X || min.Y != max.Y {
+				it.WKB = g.AsBinary()
+				it.Area = g.Area()
+			}
+			items = append(items, it)
+		}
+
+		if len(items) == 0 {
+			return c.JSON(fiber.Map{"upserted": 0})
+		}
+
+		err := state.withIndex(func(idx *Index) error {
+			return InsertItems(idx, items, nil)
+		})
+		if err == errIndexNotReady {
+			return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{"error": "dataset not ready"})
+		}
+		if err != nil {
+			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+		}
+		return c.JSON(fiber.Map{"upserted": len(items)})
+	})
+
 	port := getenv("SPATIAL_PORT", "8194")
 	adminPort := getenv("SPATIAL_ADMIN_PORT", "8195")
 

--- a/iznik-spatial-go/main.go
+++ b/iznik-spatial-go/main.go
@@ -41,6 +41,7 @@ func main() {
 		&UserApproxLocsDataset{},
 		&GroupsDataset{},
 		&JobsDataset{},
+		&PostcodesDataset{},
 	}
 
 	srv := newServer(mysqlDB, idxDir, allDatasets)

--- a/iznik-spatial-go/server.go
+++ b/iznik-spatial-go/server.go
@@ -99,6 +99,13 @@ func (srv *server) rebuild(name string) error {
 		os.Remove(tmpPath)
 		return fmt.Errorf("%s: load: %w", name, err)
 	}
+	// Flush the WAL into the main .db before close+rename — rename moves only the
+	// .db file, so anything still in the -wal would be lost (large indexes).
+	if err := newIdx.Checkpoint(); err != nil {
+		newIdx.Close()
+		os.Remove(tmpPath)
+		return fmt.Errorf("%s: checkpoint: %w", name, err)
+	}
 	newIdx.Close()
 
 	if err := os.Rename(tmpPath, idxPath); err != nil {


### PR DESCRIPTION
## Summary
Migrates all five expanding-bounding-box nearest-neighbour lookups off raw MySQL spatial queries and onto the `iznik-spatial-go` KNN server, collapses a duplicated postcode lookup, and removes the vestigial `locations_grids` "grid" approach.

- **New `postcodes` dataset** in `iznik-spatial-go` (point, full postcodes only) + registered. The locations dataset only held area polygons, so the existing `type=Postcode` callers always missed and silently fell back to MySQL.
- **`Location::closestPostcode`** and **`IncomingMailService::findClosestPostcodeId`** (a duplicate of it) collapse to one `SpatialQueryService->nearestIds('postcodes')` call.
- **apiv2 `location.ClosestPostcode`** → `spatial.KNN("postcodes")`; `closestPostcodeMySQL` removed.
- **`Job::nearLocation`** (digest/chat job ads) → spatial `jobs` KNN.
- **`NewsfeedDigestService`** → spatial `newsfeed` KNN.
- **Grid removed**: `DoogalService` no longer writes `gridid`; dropped from `Location::PUBLIC_ATTS` + `UserLocationRemapService` (no remaining consumers, incl. frontend).
- New admin endpoint `POST /v1/{dataset}/upsert` (WKT) so integration tests can seed the live index.
- **Config fix**: `freegle.spatial_server_url` now reads `SPATIAL_KNN_URL` (was `SPATIAL_SERVER_URL`, which belongs to the *routing* server and resolved to `localhost` on batch — would have broken `closestPostcode`/`PostcodeRemapService` in prod once the fallback was gone).

## Behaviour changes (deliberate)
- **No MySQL fallback** for postcode lookups — the spatial server is now a hard dependency for incoming-mail geocoding + TNSync (agreed).
- **Jobs digest cpc floor 0.02 → 0.10**, matching the spatial `jobs` index and the public jobs page.
- **Jobs variety pool** is now *nearest*-then-CPC (matching the web view `job.GetJobs`), not top-CPC-in-area. The old digest-only "top-CPC pool" guarantee is gone.
- **Newsfeed digest**: density-adaptive radius (grow until ~10 posters) → nearest-500 then filter.
- Spatial server now builds + syncs a ~2M-row `postcodes` index (hourly delta + nightly rebuild).

## Code Quality Review / flags
- Admin URL is derived from `SPATIAL_KNN_URL` by swapping `:8194`→`:8195`; fragile if that port ever changes — consider setting `SPATIAL_KNN_ADMIN_URL` explicitly on batch/batch-prod.
- The 2M-row postcode load (`InsertItems`, single tx) could **not be load-tested locally** (dev DB has 0 postcodes); validate the nightly rebuild's memory/time on real data at deploy.
- Postcodes delta upserts on `locations.timestamp` and doesn't hard-remove exclusions/deletions until the nightly rebuild (minor).
- Job ordering uses `cpc`; the web uses `cpc × clickability` (minor).

## Test Plan
Verified locally via the status API:
- `LocationTest` (5), `LocationIdTest` (4), `JobModelTest` (20), `UserModelTest` (59), `SendDigestCommandTest` (14) — all green.
- Full apiv2 Go suite — 3187 green (incl. `TestClosest`).
- spatial-go: `PostcodesDataset` unit test added; end-to-end smoke (upsert → KNN → remove) confirmed. Runs in CI's serial spatial step.
- Tests seed the live index via the new admin `upsert` (point for postcodes/newsfeed, polygon for jobs) and clean up in teardown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
