### PR TITLE
fix(spatial): centroid postcode geometry so the 2M-row load doesn't error on non-point rows

### DIFF
--- a/iznik-spatial-go/dataset_postcodes.go
+++ b/iznik-spatial-go/dataset_postcodes.go
@@ -9,8 +9,11 @@ import (
 
 // PostcodesDataset implements Dataset for postcode locations (point geometry).
 //
-// Postcodes are by far the largest dataset (~2M rows) and are points, so each is
-// stored with a degenerate bbox and nil WKB, and queried with FindNearestPoints.
+// Postcodes are by far the largest dataset (~2M rows) and are essentially points,
+// so each is stored with a degenerate bbox and nil WKB, and queried with
+// FindNearestPoints. A few Postcode rows carry a non-point ourgeometry (a
+// LINESTRING/polygon override) which would make a bare ST_X error out, so we take
+// ST_Centroid first (a POINT is its own centroid) — matching compare.go.
 // Only full postcodes (name contains a space, e.g. "SW1A 2DU") are indexed —
 // outward-only districts are excluded, matching Location::closestPostcode in the
 // PHP batch which has always returned full postcodes.
@@ -62,8 +65,8 @@ func (d *PostcodesDataset) Within(idx *Index, params QueryParams) ([]int64, erro
 func loadPostcodes(mysqlDB *sql.DB, idx *Index, extraWhere string) error {
 	query := `
 		SELECT locations.id,
-		       ST_X(COALESCE(ourgeometry, geometry)) AS lng,
-		       ST_Y(COALESCE(ourgeometry, geometry)) AS lat
+		       ST_X(ST_Centroid(COALESCE(ourgeometry, geometry))) AS lng,
+		       ST_Y(ST_Centroid(COALESCE(ourgeometry, geometry))) AS lat
 		FROM locations
 		LEFT JOIN locations_excluded le ON locations.id = le.locationid
 		WHERE le.locationid IS NULL


### PR DESCRIPTION
## Problem

PR #764 added the `postcodes` KNN dataset, but on **production data the load aborts immediately**:

```
postcodes: load: Error 3516 (22S01): POINT value is a geometry of unexpected type LINESTRING in st_x.
```

`loadPostcodes` calls `ST_X`/`ST_Y` directly on `COALESCE(ourgeometry, geometry)`. A handful of `type='Postcode'` rows carry a **non-point `ourgeometry`** (a LINESTRING/polygon override), and `ST_X` only accepts a `POINT`, so the entire load fails. The index is left empty (`count 0, ready false`), which breaks:

- `Location::closestPostcode` (batch)
- apiv2 `location.ClosestPostcode` — now has **no MySQL fallback**, so a locationless/affected lookup returns nothing

CI was green because its seeded test postcodes are all points, so the SQL path with mixed geometry was never exercised against real data.

## Fix

Wrap the geometry in `ST_Centroid` before `ST_X`/`ST_Y` — a `POINT` is its own centroid, and a `LINESTRING`/`POLYGON` collapses to a representative point. This mirrors the existing expression already used in `compare.go`.

## Verification (against prod DB)

- **1,961,927** postcodes load (previously 0).
- KNN returns the correct nearest full postcode:
  - Charing Cross `(51.508, -0.128)` → **WC2N 5DU** (~90 m)
  - Central Manchester `(53.4808, -2.2426)` → **M2 4NG** (~25 m)
- `go test ./...` for `iznik-spatial-go` passes.
- Deployed to the running `spatial-knn` container on the batch-prod host; all 7 datasets ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)