### PR TITLE
feat(email): clarify ChitChat mod-notif and show poster name + avatar

### DIFF
--- a/iznik-batch/app/Services/NewsfeedModNotifService.php
+++ b/iznik-batch/app/Services/NewsfeedModNotifService.php
@@ -3,13 +3,17 @@
 namespace App\Services;
 
 use App\Mail\Newsfeed\NewsfeedModNotifMail;
+use App\Mail\Traits\AvatarResolver;
 use App\Models\Group;
 use App\Models\Membership;
+use App\Models\User;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Mail;
 
 class NewsfeedModNotifService
 {
+    use AvatarResolver;
+
     // System address that must be excluded from mod notifications (not a real human).
     public const SYSTEM_MOD_EMAIL = 'modtools@modtools.org';
 
@@ -132,27 +136,39 @@ class NewsfeedModNotifService
             $maxId = 0;
             $postsData = [];
 
+            // Resolve the poster's display name + avatar once per author so the
+            // email can show who posted (not just an anonymous "POST").
+            $authorIds = array_values(array_unique(array_map(fn ($p) => (int) $p->userid, $posts)));
+            $authors = User::whereIn('id', $authorIds)->get()->keyBy('id');
+
             foreach ($posts as $post) {
                 $maxId = max($maxId, $post->id);
 
-                $label = match($post->type) {
-                    'Story'   => 'Freegle story',
-                    'AboutMe' => 'About me',
-                    default   => 'Post',
+                $author = $authors->get((int) $post->userid);
+
+                // What the member did, phrased so the mod sees this is ChitChat
+                // community activity rather than an OFFER/WANTED post on the group.
+                $action = match($post->type) {
+                    'Story'   => 'shared their Freegle story',
+                    'AboutMe' => 'updated their About Me',
+                    default   => 'posted on ChitChat',
                 };
 
-                if ($post->type === 'Story') {
-                    $preview = 'shared their Freegle story';
-                } else {
+                // Story/AboutMe are described by the action line; only Message
+                // posts carry a text preview.
+                $preview = '';
+                if ($post->type !== 'Story') {
                     $msg = $post->message ?? '';
                     $preview = mb_strlen($msg) > 200 ? mb_substr($msg, 0, 200) . '...' : $msg;
                 }
 
                 $postsData[] = [
-                    'id'      => $post->id,
-                    'label'   => $label,
-                    'preview' => $preview,
-                    'added'   => $post->added,
+                    'id'         => $post->id,
+                    'action'     => $action,
+                    'preview'    => $preview,
+                    'added'      => $post->added,
+                    'userName'   => $author?->displayname ?: 'A freegler',
+                    'userAvatar' => $this->resolveAvatarUrl($author),
                 ];
             }
 

--- a/iznik-batch/resources/views/emails/mjml/newsfeed/mod-notif.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/newsfeed/mod-notif.blade.php
@@ -8,29 +8,38 @@
     <mj-section background-color="#ffffff" padding="20px 20px 10px">
       <mj-column>
         <mj-text font-size="20px" font-weight="bold" mj-class="text-modtools">
-          {{ $count }} chitchat post{{ $count !== 1 ? 's' : '' }} from your members
+          {{ $count }} ChitChat post{{ $count !== 1 ? 's' : '' }} from your members
         </mj-text>
-        <mj-text font-size="14px" color="#555555">
-          Recent chitchat activity in your groups on Freegle.
+        <mj-text font-size="14px" color="#555555" line-height="20px">
+          ChitChat is Freegle's community chat feed — not OFFER or WANTED posts on
+          your group. Here's what your members have posted there that you haven't
+          seen yet.
         </mj-text>
       </mj-column>
     </mj-section>
 
     @foreach ($posts as $post)
     <mj-section background-color="#F7F6EC" padding="12px 20px">
-      <mj-column>
-        <mj-text font-size="11px" font-weight="bold" color="#888888" padding="0 0 4px">
-          {{ strtoupper($post['label']) }}
+      <mj-column width="52px" vertical-align="top" padding="0">
+        @if (!empty($post['userAvatar']))
+        <mj-image src="{{ $post['userAvatar'] }}" alt="{{ $post['userName'] ?? '' }}" width="40px" height="40px" border-radius="20px" align="left" padding="2px 0 0" />
+        @endif
+      </mj-column>
+      <mj-column vertical-align="top" padding="0">
+        <mj-text font-size="14px" color="#333333" padding="0 0 4px">
+          <strong>{{ $post['userName'] ?? 'A freegler' }}</strong> {{ $post['action'] ?? 'posted on ChitChat' }}
         </mj-text>
-        <mj-text font-size="14px" color="#333333" padding="0 0 6px">
+        @if (!empty($post['preview']))
+        <mj-text font-size="14px" color="#555555" padding="0 0 6px">
           {{ $post['preview'] }}
         </mj-text>
+        @endif
         <mj-text font-size="11px" color="#999999" padding="0">
           {{ $post['added'] }}
         </mj-text>
       </mj-column>
-      <mj-column width="110px" vertical-align="middle">
-        <mj-button mj-class="btn-modtools" href="{{ $userSite }}/chitchat/{{ $post['id'] }}" font-size="13px" inner-padding="8px 14px">
+      <mj-column width="84px" vertical-align="middle" padding="0">
+        <mj-button mj-class="btn-modtools" href="{{ $userSite }}/chitchat/{{ $post['id'] }}" font-size="13px" inner-padding="8px 10px" width="84px" align="right">
           View
         </mj-button>
       </mj-column>

--- a/iznik-batch/tests/Feature/Mail/NewsfeedModNotifCommandTest.php
+++ b/iznik-batch/tests/Feature/Mail/NewsfeedModNotifCommandTest.php
@@ -56,7 +56,7 @@ class NewsfeedModNotifCommandTest extends TestCase
         Mail::fake();
 
         $mod = $this->createTestUser();
-        $member = $this->createTestUser();
+        $member = $this->createTestUser(['fullname' => 'Bob Member']);
         $group = $this->createTestGroup();
 
         $this->createMembership($mod, $group, ['role' => Membership::ROLE_MODERATOR]);
@@ -69,6 +69,17 @@ class NewsfeedModNotifCommandTest extends TestCase
             ->assertExitCode(0);
 
         Mail::assertSentCount(1);
+
+        // The notification carries the poster's resolved display name + avatar
+        // and the ChitChat action context, so the mod sees who posted.
+        $expectedName = \App\Models\User::find($member->id)->displayname;
+        Mail::assertSent(NewsfeedModNotifMail::class, function ($mail) use ($expectedName) {
+            $post = $mail->posts[0] ?? [];
+            return ($post['userName'] ?? null) === $expectedName
+                && $expectedName !== 'A freegler'
+                && !empty($post['userAvatar'])
+                && ($post['action'] ?? null) === 'posted on ChitChat';
+        });
     }
 
     public function test_skips_mod_with_no_unseen_posts(): void

--- a/iznik-batch/tests/Feature/Mail/NewsfeedModNotifCommandTest.php
+++ b/iznik-batch/tests/Feature/Mail/NewsfeedModNotifCommandTest.php
@@ -313,4 +313,33 @@ class NewsfeedModNotifCommandTest extends TestCase
 
         Mail::assertNothingSent();
     }
+
+    public function test_action_text_reflects_post_type(): void
+    {
+        Mail::fake();
+
+        $mod = $this->createTestUser();
+        $member = $this->createTestUser();
+        $group = $this->createTestGroup();
+
+        $this->createMembership($mod, $group, ['role' => Membership::ROLE_MODERATOR]);
+        $this->createMembership($member, $group, ['role' => Membership::ROLE_MEMBER]);
+
+        // A Story and an AboutMe post each get a type-specific action line, so the
+        // mod understands what kind of ChitChat activity it was rather than seeing
+        // a generic "posted" for every newsfeed type.
+        $this->createNewsfeedPost($member->id, $group->id, ['type' => 'Story']);
+        $this->createNewsfeedPost($member->id, $group->id, ['type' => 'AboutMe']);
+
+        $this->artisan('mail:newsfeed-mod-notif')
+            ->expectsOutputToContain('Notified 1 mod(s)')
+            ->assertExitCode(0);
+
+        Mail::assertSent(NewsfeedModNotifMail::class, function ($mail) {
+            $actions = array_map(fn ($p) => $p['action'] ?? null, $mail->posts);
+
+            return in_array('shared their Freegle story', $actions, true)
+                && in_array('updated their About Me', $actions, true);
+        });
+    }
 }

--- a/iznik-batch/tests/Unit/Mail/Newsfeed/NewsfeedModNotifMailTest.php
+++ b/iznik-batch/tests/Unit/Mail/Newsfeed/NewsfeedModNotifMailTest.php
@@ -22,12 +22,37 @@ class NewsfeedModNotifMailTest extends TestCase
     {
         return [
             [
-                'id'      => 42,
-                'label'   => 'Post',
-                'preview' => 'Anyone know a good plumber nearby?',
-                'added'   => '2026-05-22 10:30:00',
+                'id'         => 42,
+                'action'     => 'posted on ChitChat',
+                'preview'    => 'Anyone know a good plumber nearby?',
+                'added'      => '2026-05-22 10:30:00',
+                'userName'   => 'Jane Plumber',
+                'userAvatar' => 'https://www.ilovefreegle.org/avatar/jane-plumber.png',
             ],
         ];
+    }
+
+    public function test_shows_poster_name_avatar_and_chitchat_context(): void
+    {
+        $mail = new NewsfeedModNotifMail(
+            recipientEmail: 'mod@example.com',
+            posts: $this->makePosts(),
+        );
+
+        $html = $mail->render();
+
+        // Who posted — name and avatar (previously the card showed only "POST").
+        $this->assertStringContainsString('Jane Plumber', $html, 'poster name should render');
+        $this->assertStringContainsString(
+            'https://www.ilovefreegle.org/avatar/jane-plumber.png',
+            $html,
+            'poster avatar image should render'
+        );
+        $this->assertStringContainsString('posted on ChitChat', $html, 'action context should render');
+
+        // Clarifies this is ChitChat, not an OFFER/WANTED post on the group.
+        $this->assertStringContainsString('community chat feed', $html);
+        $this->assertStringContainsString('not OFFER or WANTED posts', $html);
     }
 
     public function test_chitchat_link_goes_to_user_site_not_modtools(): void


### PR DESCRIPTION
## Summary
The moderator "chitchat post from your members" notification (`mail:newsfeed-mod-notif`) had two problems, both reported from a real email:

1. **Reads like a group post.** Each post showed an anonymous uppercase **"POST"** and the wording didn't make clear this is *ChitChat* (Freegle's community chat feed), not an OFFER/WANTED post on the group that needs moderating.
2. **No poster identity.** The card never showed *who* posted — no username, no avatar.

### Changes
- **`NewsfeedModNotifService`**: resolves each poster's display name (`User::displayname`) + avatar (via the existing `AvatarResolver` trait), batch-fetching authors to avoid N+1, and an action phrase per type (`posted on ChitChat` / `shared their Freegle story` / `updated their About Me`).
- **`mod-notif.blade.php`**: each card now shows the avatar + "**Name** posted on ChitChat" + preview; the intro clarifies *"ChitChat is Freegle's community chat feed — not OFFER or WANTED posts on your group."* (Also sized the per-post "View" button so it stays on one line next to the avatar/text columns.)

### Before / After
Before: greyed `POST` label, no name/avatar. After: avatar + "Jane Smith posted on ChitChat", clarifying intro. (Screenshot shared with the requester.)

## Test Plan
- `NewsfeedModNotifMailTest`: renders the mail and asserts the poster name, avatar `<img>`, the "posted on ChitChat" action, and the clarifying "community chat feed" / "not OFFER or WANTED posts" copy.
- `NewsfeedModNotifCommandTest::test_notifies_mod_with_new_posts`: asserts the sent mail carries the poster's resolved display name + non-empty avatar + action context.
- Full `NewsfeedModNotif*` suite: **17/17 pass** locally; MJML compiles; `php -l` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)