### PR TITLE
fix(reply): tolerate a late form ref instead of erroring on Send

### DIFF
--- a/iznik-nuxt3/composables/useReplyStateMachine.js
+++ b/iznik-nuxt3/composables/useReplyStateMachine.js
@@ -598,7 +598,37 @@ export function useReplyStateMachine(messageId, options = {}) {
 
     transitionTo(ReplyState.VALIDATING, { event: ReplyEvent.SUBMIT })
 
-    // Validate form
+    // Validate form. Under CI load (and occasionally on slow devices) the BForm
+    // template ref can momentarily lag the click that triggers submit(), so
+    // formRef.value is transiently null even though the form is mounted and
+    // filled. Wait for setRefs() to provide it (event-based, not a microtask
+    // busy-wait), mirroring the chatButtonRef handling in handleCreateChat(). A
+    // nextTick loop is unreliable here: the ref is supplied by the component's
+    // render cycle, which under load may not settle within a few flushes, so the
+    // loop can still miss it and log a console error that fails the e2e
+    // reply-flow test. Time out so a genuinely-missing ref still falls through to
+    // the null check below.
+    if (!formRef.value) {
+      await Promise.race([
+        new Promise((resolve) => {
+          const stop = watch(formRef, (val) => {
+            if (val) {
+              stop()
+              resolve()
+            }
+          })
+          // Also resolve immediately if it became available during watch setup.
+          if (formRef.value) {
+            stop()
+            resolve()
+          }
+        }),
+        // Timeout — if the ref still hasn't arrived, fall through to the null
+        // check below and fall back to COMPOSING as before.
+        new Promise((resolve) => setTimeout(resolve, 5000)),
+      ])
+    }
+
     if (!formRef.value) {
       logError('Form ref not set', null, state.value, messageId)
       // Don't go to ERROR - just go back to COMPOSING so user can retry

--- a/iznik-nuxt3/tests/unit/composables/useReplyStateMachine.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useReplyStateMachine.spec.js
@@ -715,9 +715,34 @@ describe('submit', () => {
     const { result } = mountComposable()
     result.startTyping()
     const callback = vi.fn()
-    await result.submit(callback)
+    // The ref never arrives, so submit() waits on the readiness watch until its
+    // timeout before falling back. Advance past the timeout (fake timers) so the
+    // pending submit settles rather than hanging.
+    const pending = result.submit(callback)
+    await vi.advanceTimersByTimeAsync(5001)
+    await pending
     expect(result.state.value).toBe(ReplyState.COMPOSING)
     expect(callback).toHaveBeenCalled()
+  })
+
+  it('waits for a late formRef instead of erroring (CI race tolerance)', async () => {
+    // Reproduces the e2e flake: the form ref lags the Send click, so it is
+    // briefly null when submit() runs. submit() should wait on the readiness
+    // watch and proceed to validate once setRefs() supplies the ref, rather than
+    // logging an error and falling back.
+    const { result } = mountComposable()
+    // Initialise first (without a form ref) so supplying the form during the
+    // wait below doesn't re-initialise the machine mid-submit.
+    result.setRefs({ chatButton: makeChatButtonRef() })
+    result.startTyping()
+    const formRef = makeFormRef(true)
+    const callback = vi.fn()
+
+    const pending = result.submit(callback) // formRef null here → enters wait
+    result.setRefs({ form: formRef }) // ref wires up during the wait → watch fires
+    await pending
+
+    expect(formRef.validate).toHaveBeenCalled()
   })
 
   it('falls back to COMPOSING when formRef.validate throws', async () => {


### PR DESCRIPTION
## Summary

Fixes an intermittent Playwright flake in `test-reply-flow-logged-in.spec.js` (`1.1 can reply from Message Page`): under CI load the `BForm` template ref can momentarily lag the click that triggers `submit()`, so `formRef.value` is transiently null. The old behaviour logged `[ReplyStateMachine] Form ref not set` and fell back to COMPOSING; the fallback is harmless but the console error trips the e2e critical-console-error detector and fails the run.

## Review note (reworked)

The first version waited with a bounded `for` loop of `await nextTick()`. On review that is the wrong tool: `formRef` is supplied by the component's render cycle via `setRefs()`, which under load may not settle within a few microtask flushes, so the loop can still miss the very race it targets. It also cited the `emailValidator` block as precedent, which is a revalidate, not a ref-readiness wait.

Reworked to the event-based pattern this file already uses for the identical late-ref problem with `chatButtonRef` in `handleCreateChat()`: race a `watch(formRef)` that resolves when the ref arrives against a timeout that falls through to the existing null check. Same structure, robust to render-cycle timing, and consistent with the rest of the state machine. If the ref genuinely never arrives, it still logs and falls back exactly as before.

## Test plan

`useReplyStateMachine.spec.js`: **89/89 pass** (run via the status API in the dev container).
- `waits for a late formRef ...` - asserts the `watch` fires when `setRefs()` supplies the form during the wait and validation proceeds.
- `falls back to COMPOSING when formRef is not set` - now advances fake timers past the watch timeout and asserts the fallback.
- Mirrors the existing `chatButtonRef is still null after 5s wait` test, which also passes.