### PR TITLE
fix(auth): guard addRelatedUser against a non-array userlist (Sentry 7556593585)

### DIFF
--- a/iznik-nuxt3/stores/auth.js
+++ b/iznik-nuxt3/stores/auth.js
@@ -97,8 +97,11 @@ export const useAuthStore = defineStore({
     },
     async addRelatedUser(id) {
       if (id) {
-        // Keep track of which users we log in as.
-        if (!this.userlist) {
+        // Keep track of which users we log in as. Guard against a non-array
+        // value: userlist is persisted to localStorage, and state shape drift
+        // (older app versions, or a serialization quirk) can rehydrate it as an
+        // object rather than an array, which would make .includes() throw.
+        if (!Array.isArray(this.userlist)) {
           this.userlist = []
         }
 

--- a/iznik-nuxt3/tests/unit/stores/auth.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/auth.spec.js
@@ -175,6 +175,16 @@ describe('auth store', () => {
       await store.addRelatedUser(null)
       expect(store.userlist).toHaveLength(0)
     })
+
+    it('recovers when userlist rehydrated as a non-array', async () => {
+      // State-shape drift: persisted userlist can come back as an object
+      // instead of an array, which used to make .includes() throw
+      // (Sentry: "this.userlist.includes is not a function").
+      store.userlist = { 0: 99 }
+      await store.addRelatedUser(42)
+      expect(Array.isArray(store.userlist)).toBe(true)
+      expect(store.userlist).toContain(42)
+    })
   })
 
   describe('clearRelated', () => {


### PR DESCRIPTION
## Summary

- Fixes Sentry `7556593585`: `TypeError: this.userlist.includes is not a function`, thrown on ModTools during `fetchUser → setUser → addRelatedUser` (called from `checkWork`).
- `userlist` is persisted to `localStorage` (`pick: ['auth', 'userlist', 'loggedInEver']`). State-shape drift — an older app version, or a serialization quirk — can rehydrate it as an **object** instead of an array.
- The existing guard `if (!this.userlist)` only catches falsy values, so a non-array object passes through and `this.userlist.includes(id)` throws.
- Fix: guard with `Array.isArray(this.userlist)` so any non-array value is reset to `[]`.

## Code Quality Review

- Minimal, targeted change at the exact failure site; behaviour is unchanged for the normal (array) case.
- No new dependencies; preserves the existing reset-to-`[]` recovery.

## Future Improvements

- A persisted-state migration/validator could normalise drifted shapes on hydration across the store rather than guarding at each use site.

## Test Plan

- Added unit test `recovers when userlist rehydrated as a non-array` that sets `userlist` to an object and calls `addRelatedUser`.
- Verified TDD-style: the new test **fails** on master (`TypeError: this.userlist.includes is not a function` at `auth.js:105`) and **passes** with the fix.
- `tests/unit/stores/auth.spec.js`: 39/39 pass with the fix (38/39 without).
