### PR TITLE
fix(digest): exclude banned users from post emails (standalone — not in rippling merge chain)

### DIFF
--- a/iznik-batch/app/Services/UnifiedDigestService.php
+++ b/iznik-batch/app/Services/UnifiedDigestService.php
@@ -233,6 +233,13 @@ class UnifiedDigestService
             ->where('memberships.groupid', $groupid)
             ->where('memberships.emailfrequency', Membership::EMAIL_FREQUENCY_IMMEDIATE)
             ->where('memberships.collection', Membership::COLLECTION_APPROVED)
+            // A user banned from the group must never be emailed about its posts,
+            // even if a membership row still exists (re-added by TN sync, or stale).
+            ->whereNotExists(function ($q) use ($groupid) {
+                $q->select(DB::raw(1))->from('users_banned')
+                    ->whereColumn('users_banned.userid', 'memberships.userid')
+                    ->where('users_banned.groupid', $groupid);
+            })
             ->whereNull('users.deleted')
             ->where(function ($q) {
                 $q->whereNull('users.lastaccess')
@@ -901,7 +908,13 @@ class UnifiedDigestService
         // every group on a periodic cadence (hourly/2h/4h/8h/daily), folding
         // them all into the single daily roll-up. See applyDigestFrequency().
         $membershipQuery = $user->memberships()
-            ->where('collection', Membership::COLLECTION_APPROVED);
+            ->where('collection', Membership::COLLECTION_APPROVED)
+            // Exclude groups this user is banned from — they must not receive its posts.
+            ->whereNotExists(function ($q) use ($user) {
+                $q->select(DB::raw(1))->from('users_banned')
+                    ->whereColumn('users_banned.groupid', 'memberships.groupid')
+                    ->where('users_banned.userid', $user->id);
+            });
         $this->applyDigestFrequency($membershipQuery, $mode);
 
         $groupIds = $membershipQuery->pluck('groupid');

--- a/iznik-batch/tests/Unit/Services/UnifiedDigestServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/UnifiedDigestServiceTest.php
@@ -172,6 +172,55 @@ class UnifiedDigestServiceTest extends TestCase
         $this->assertEquals(1, $stats['emails_sent']);
     }
 
+    public function test_immediate_digest_excludes_banned_user(): void
+    {
+        // A user banned from a group must not be emailed about its posts, even if a
+        // membership row still exists (e.g. re-added by TN sync, or a stale row).
+        config(['freegle.digest.immediate_allowlist' => '']);
+        [$group, $poster, $recipient] = $this->bootstrapImmediateGroup();
+
+        DB::table('users_banned')->insert([
+            'userid' => $recipient->id,
+            'groupid' => $group->id,
+        ]);
+
+        $msg = $this->createTestMessage($poster, $group, ['subject' => 'OFFER: Item (TestLocation)']);
+        $this->makeImmediateReady($msg);
+
+        $stats = $this->service->sendDigests(UnifiedDigestService::MODE_IMMEDIATE);
+
+        // Without the ban both members get it (2). The banned recipient is excluded,
+        // so only the poster is emailed.
+        $this->assertEquals(1, $stats['emails_sent']);
+    }
+
+    public function test_daily_digest_excludes_banned_user(): void
+    {
+        // A user banned from a group must not get its posts in their daily digest.
+        $poster = $this->createTestUser();
+        $recipient = $this->createTestUser();
+        $group = $this->createTestGroup();
+
+        $recipient->settings = ['simplemail' => User::SIMPLE_MAIL_BASIC];
+        $recipient->lastaccess = now();
+        $recipient->save();
+
+        $this->createMembership($poster, $group);
+        $this->createMembership($recipient, $group, [
+            'emailfrequency' => Membership::EMAIL_FREQUENCY_DAILY,
+        ]);
+        DB::table('users_banned')->insert([
+            'userid' => $recipient->id,
+            'groupid' => $group->id,
+        ]);
+
+        $this->createTestMessage($poster, $group);
+
+        $stats = $this->service->sendDigests(UnifiedDigestService::MODE_DAILY, $recipient->id);
+
+        $this->assertEquals(0, $stats['emails_sent']);
+    }
+
     public function test_daily_digest_excludes_posts_with_an_outcome(): void
     {
         // V1 parity (Digest.php:218): a post that already has an outcome


### PR DESCRIPTION
## Summary
A user banned from a group must not receive its posts in the unified digest (immediate or daily). Banning deletes the membership, so the membership-based recipient queries normally exclude them — but if a membership row lingers (TN sync re-add, stale row, race) they would still be emailed. Adds an explicit `users_banned` exclusion to both recipient paths:

- **Immediate** recipient query — exclude members banned from that group.
- **Daily** `getPostsForUser` — exclude groups the user is banned from.

## Tests
`test_immediate_digest_excludes_banned_user` (banned member not emailed; poster still is) and `test_daily_digest_excludes_banned_user` (banned recipient gets no daily digest). Full Laravel suite green.

## Follow-up (noted from cross-PR review)
The future reach-gated digest (PR F) selects recipients by **location**, not membership — it will need the same `users_banned` exclusion added to its reach recipient query. Not a regression here.

Not merged — humans merge.