### PR TITLE
fix(reply): restore photo zoom in the chat-style reply pane (Discourse 9363)

### DIFF
--- a/iznik-nuxt3/components/ChatReplyPane.vue
+++ b/iznik-nuxt3/components/ChatReplyPane.vue
@@ -53,11 +53,15 @@
           {{ message.type === 'Offer' ? 'their offer' : 'what they want' }}.
         </p>
 
-        <!-- The post being replied to, shown as a chat message from the poster -->
+        <!-- The post being replied to, shown as a chat message from the poster.
+             We swallow the card's own click (which would navigate to the post
+             page — pointless while you're already replying to it) but, when the
+             post has photos, repurpose the tap to open the photo zoom modal so
+             people arriving from an email can still enlarge the picture. -->
         <div
           v-if="message"
           class="reply-card__incoming"
-          @click.capture.stop.prevent
+          @click.capture.stop.prevent="onPostClick"
         >
           <ChatMessageCard :id="messageId" class="reply-card__post" />
         </div>
@@ -229,6 +233,14 @@
     <div class="d-none">
       <ChatButton ref="replyToPostChatButton" :userid="replyToUser" />
     </div>
+
+    <!-- Photo zoom: lets people enlarge the post's photo from inside the reply
+         pane, matching the behaviour on Browse. -->
+    <MessagePhotosModal
+      v-if="showPhotos && attachmentCount"
+      :id="messageId"
+      @hidden="showPhotos = false"
+    />
   </div>
 </template>
 
@@ -265,6 +277,9 @@ import { FAR_AWAY } from '~/constants'
 
 const NewFreegler = defineAsyncComponent(() =>
   import('~/components/NewFreegler')
+)
+const MessagePhotosModal = defineAsyncComponent(() =>
+  import('~/components/MessagePhotosModal')
 )
 
 const props = defineProps({
@@ -309,6 +324,18 @@ await messageStore.fetch(props.messageId)
 const message = computed(() => {
   return messageStore?.byId(props.messageId)
 })
+
+const attachmentCount = computed(() => message.value?.attachments?.length || 0)
+
+// Tapping the post card would normally navigate to the post page; inside the
+// reply pane that's pointless (you're already replying), so we open the photo
+// zoom modal instead when there's a photo to enlarge.
+const showPhotos = ref(false)
+function onPostClick() {
+  if (attachmentCount.value) {
+    showPhotos.value = true
+  }
+}
 
 // Fetch poster info
 watch(

--- a/iznik-nuxt3/tests/unit/components/ChatReplyPane.spec.js
+++ b/iznik-nuxt3/tests/unit/components/ChatReplyPane.spec.js
@@ -173,6 +173,11 @@ describe('ChatReplyPane', () => {
           NewFreegler: {
             template: '<div class="new-freegler" />',
           },
+          MessagePhotosModal: {
+            template: '<div class="photos-modal-stub" :data-id="id" />',
+            props: ['id', 'initialIndex'],
+            emits: ['hidden'],
+          },
           SpinButton: {
             template:
               '<button class="spin-button" :disabled="disabled" @click="$emit(\'handle\', () => {})"><slot /></button>',
@@ -240,6 +245,56 @@ describe('ChatReplyPane', () => {
     await flushPromises()
     return wrapper
   }
+
+  describe('post photo zoom', () => {
+    it('opens the photo carousel modal when a multi-photo post is tapped', async () => {
+      // Multiple photos → the modal is the swipeable carousel (it shows all
+      // attachments with prev/next + dots); a single photo just shows the one.
+      mockMessageStore.byId.mockReturnValue({
+        ...mockMessage,
+        attachments: [
+          { id: 10, path: 'https://example.com/p1.jpg' },
+          { id: 11, path: 'https://example.com/p2.jpg' },
+          { id: 12, path: 'https://example.com/p3.jpg' },
+        ],
+      })
+      const wrapper = await createWrapper()
+
+      expect(wrapper.find('.photos-modal-stub').exists()).toBe(false)
+
+      await wrapper.find('.reply-card__incoming').trigger('click')
+      await flushPromises()
+
+      // The modal is opened for the whole message (id), so it carousels through
+      // every attachment rather than showing a single fixed image.
+      const modal = wrapper.find('.photos-modal-stub')
+      expect(modal.exists()).toBe(true)
+      expect(modal.attributes('data-id')).toBe('1')
+    })
+
+    it('opens the photo modal for a single-photo post too', async () => {
+      mockMessageStore.byId.mockReturnValue({
+        ...mockMessage,
+        attachments: [{ id: 10, path: 'https://example.com/p.jpg' }],
+      })
+      const wrapper = await createWrapper()
+
+      await wrapper.find('.reply-card__incoming').trigger('click')
+      await flushPromises()
+
+      expect(wrapper.find('.photos-modal-stub').exists()).toBe(true)
+    })
+
+    it('does not open the photo modal when the post has no photo', async () => {
+      mockMessageStore.byId.mockReturnValue({ ...mockMessage, attachments: [] })
+      const wrapper = await createWrapper()
+
+      await wrapper.find('.reply-card__incoming').trigger('click')
+      await flushPromises()
+
+      expect(wrapper.find('.photos-modal-stub').exists()).toBe(false)
+    })
+  })
 
   describe('rendering', () => {
     it('renders the reply overlay container', async () => {


### PR DESCRIPTION
## Summary

Fixes a regression in the new chat-style reply pane (#149) reported on [Discourse topic 9363](https://discourse.ilovefreegle.org/t/formatting-of-emails-top-is-filled-with-job-vacancies/9363/29): arriving at a post from an email, **you can see the post's photo but can't tap to enlarge it** — whereas Browse lets you.

**Root cause**: `ChatReplyPane` shows the post via `ChatMessageCard`, wrapped in `<div @click.capture.stop.prevent>`. That handler was added to suppress the card's navigate-to-post click, but it captures **every** click on the card — including the photo. `ChatMessageCard` has no zoom of its own (it only navigates), so the photo is inert in the reply pane.

**Fix**: repurpose the tap. When the post has attachments, open the existing `MessagePhotosModal` — the **same swipeable carousel Browse uses**: prev/next arrows, dot indicators, touch-swipe and pinch-zoom over *all* the item's photos (counter shows "2 / 3"). So a multi-photo post carousels through every image, and a single-photo post just shows the one. Navigation stays suppressed; no photo → no-op.

## Multiple photos

`MessagePhotosModal` iterates `message.attachments` and gates its prev/next + dots on `attachmentCount > 1`, so the carousel appears only when there's more than one photo — matching Browse exactly. The modal is opened against the message id (not a single image), so it always has the full set.

## Code Quality Review

- Reuses the existing `MessagePhotosModal` (async-imported, same component `MessageExpanded` uses on Browse) — no new viewer.
- `attachmentCount`/`showPhotos` mirror the pattern already in `MessageExpanded`.
- No behaviour change when the post has no photo (tap still suppressed, no navigation).

## Test Plan

- Added unit tests to `ChatReplyPane.spec.js`:
  - tapping a **multi-photo** post opens the carousel modal (asserts it's opened for the whole message id);
  - tapping a **single-photo** post opens the modal;
  - tapping a post with **no photo** does nothing.
- `ChatReplyPane.spec.js`: 37/37 pass. eslint clean.


## Discourse

https://discourse.ilovefreegle.org/t/9363/29