### PR TITLE
fix(config): show locker's name in locked-config notice

### DIFF
--- a/iznik-nuxt3/modtools/components/ModSettingsModConfig.vue
+++ b/iznik-nuxt3/modtools/components/ModSettingsModConfig.vue
@@ -46,7 +46,12 @@
           change or delete it.
         </span>
         <span v-else>
-          This is locked by #{{ config.createdby }}. You can use, view or copy
+          This is locked by
+          <strong>{{
+            lockerUser?.displayname ||
+            lockerUser?.fullname ||
+            '#' + config.createdby
+          }}</strong>. You can use, view or copy
           it, but you can't change or delete it.
         </span>
       </NoticeMessage>
@@ -367,6 +372,12 @@ const config = computed(() => {
   return modConfigStore.current
 })
 
+const lockerUser = computed(() => {
+  return config.value?.createdby
+    ? userStore.byId(parseInt(config.value.createdby))
+    : null
+})
+
 const sharedbyUser = computed(() => {
   return config.value?.sharedbyid
     ? userStore.byId(config.value.sharedbyid)
@@ -403,6 +414,13 @@ watch(
         id: newval,
         configuring: true,
       })
+
+      if (
+        config.value?.protected &&
+        parseInt(config.value?.createdby) !== myid.value
+      ) {
+        await userStore.fetch(parseInt(config.value.createdby))
+      }
     }
 
     loading.value = false

--- a/iznik-nuxt3/tests/unit/components/modtools/ModSettingsModConfig.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModSettingsModConfig.spec.js
@@ -446,6 +446,21 @@ describe('ModSettingsModConfig', () => {
       await flushPromises()
       expect(wrapper.text()).toContain('You have locked this')
     })
+
+    it('shows the locker displayname in locked notice instead of bare user ID', async () => {
+      mockModConfigStore.current = {
+        ...defaultConfig,
+        protected: true,
+        createdby: 456,
+      }
+      mockUserStore.byId.mockImplementation((id) => {
+        if (id === 456) return { displayname: 'Alice Moderator' }
+        return null
+      })
+      const wrapper = mountComponent()
+      await flushPromises()
+      expect(wrapper.text()).toContain('Alice Moderator')
+    })
   })
 
   describe('using notice', () => {


### PR DESCRIPTION
## Root Cause

`ModSettingsModConfig.vue` displayed the locker's user ID as a bare number (`#456`) because `config.createdby` is a numeric ID and the component never resolved it to a user object. The template interpolated `#{{ config.createdby }}` directly without fetching the user's display name.

## Evidence

Failing test output (before fix):

```
FAIL  tests/unit/components/modtools/ModSettingsModConfig.spec.js
  ModSettingsModConfig > locked notice > shows the locker displayname in locked notice instead of bare user ID
AssertionError: expected '...This is locked by #456...' to contain 'Alice Moderator'
```

## Fix

- Added `lockerUser` computed property that calls `userStore.byId(parseInt(config.createdby))`
- In the `watch(configid)` handler, after `fetchConfig` resolves, fetch the locker's user record via `userStore.fetch()` when the config is protected and locked by someone else
- Updated the template to display `lockerUser?.displayname || lockerUser?.fullname || '#' + config.createdby` (falls back to `#id` if fetch fails)

## Other Call Sites

`grep` over all `.vue` files for `createdby` / `locked by`:
- `ModAdmin.vue:89` — already uses `admin.createdby.displayname` (object, not ID) ✓
- `ModSettingsStandardMessageModal.vue:140` — logic-only check, no display ✓
- No other "locked by" display sites found

## Test

**File:** `iznik-nuxt3/tests/unit/components/modtools/ModSettingsModConfig.spec.js`  
**Command:** `npx vitest run tests/unit/components/modtools/ModSettingsModConfig.spec.js`  
**Proves:** Fails before fix (component renders `#456`), passes after fix (component renders `Alice Moderator`)

All 59 tests pass (58 pre-existing + 1 new).

## Discourse
https://discourse.ilovefreegle.org/t/9793/5