### PR TITLE
fix(digest): send WANTED posts immediately — only OFFERs wait for an AI image

### DIFF
--- a/iznik-batch/app/Services/UnifiedDigestService.php
+++ b/iznik-batch/app/Services/UnifiedDigestService.php
@@ -401,6 +401,14 @@ class UnifiedDigestService
             }
         }
 
+        // Only OFFERs get AI-generated illustrations, so only an OFFER is worth
+        // holding back while an image is generated. A WANTED (or any non-OFFER)
+        // will never gain an attachment — send it immediately rather than
+        // needlessly deferring it for the whole attachment-wait deadline.
+        if ((string) $message->type !== Message::TYPE_OFFER) {
+            return true;
+        }
+
         $arrival = $message->mg_arrival
             ?? ($message->arrival instanceof \Carbon\Carbon ? $message->arrival : \Carbon\Carbon::parse($message->arrival ?? $message->date));
         $arrival = $arrival instanceof \Carbon\Carbon ? $arrival : \Carbon\Carbon::parse($arrival);

--- a/iznik-batch/tests/Unit/Services/UnifiedDigestServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/UnifiedDigestServiceTest.php
@@ -1242,6 +1242,32 @@ class UnifiedDigestServiceTest extends TestCase
         $this->assertNotNull($cursor->msgdate, 'Cursor must advance after we give up waiting');
     }
 
+    public function test_immediate_sends_recent_wanted_without_attachment(): void
+    {
+        // A WANTED never gets an AI-generated illustration, so there is nothing
+        // to wait for — it must be sent immediately even when freshly posted
+        // with no attachment, not held back for the OFFER image-wait deadline.
+        config(['freegle.digest.immediate_allowlist' => '*']);
+
+        [$group, $poster, $recipient] = $this->bootstrapImmediateGroup();
+        $msg = $this->createTestMessage($poster, $group, [
+            'type' => Message::TYPE_WANTED,
+            'subject' => 'WANTED: Recent no-image (TestLocation)',
+        ]);
+        DB::table('messages_groups')->where('msgid', $msg->id)->update(['arrival' => now()]);
+
+        $stats = $this->service->sendDigests(UnifiedDigestService::MODE_IMMEDIATE);
+
+        // recipient + poster both receive immediately (own post included) — no defer.
+        $this->assertEquals(2, $stats['emails_sent']);
+
+        $cursor = DB::table('groups_digests')
+            ->where('groupid', $group->id)
+            ->where('frequency', Membership::EMAIL_FREQUENCY_IMMEDIATE)
+            ->first();
+        $this->assertNotNull($cursor->msgdate, 'Cursor must advance for a WANTED with no attachment');
+    }
+
     public function test_immediate_shard_partitions_groups_by_modulo(): void
     {
         // Each shard must own a disjoint slice of groups (MOD(groupid, N)


### PR DESCRIPTION
## Summary
- `isImmediateMessageReady()` deferred **any** attachment-less message for the full `ATTACHMENT_WAIT_DEADLINE_MINUTES` window, waiting for an AI-generated illustration.
- But only **OFFERs** get AI illustrations — a WANTED (or any non-OFFER) was needlessly held back for an image that never arrives, delaying the immediate email by the whole wait window.
- Non-OFFERs are now ready immediately.

## Why
Raised during the rippling-out side-effect review: "consider the deferred posts for wanted not just offers." Standalone digest-correctness fix, independent of the rippling merge chain.

## Test Plan
- New: `test_immediate_sends_recent_wanted_without_attachment` — a freshly-posted WANTED with no attachment is mailed immediately and the cursor advances.
- Unchanged: the OFFER defer (`test_immediate_defers_recent_message_with_no_attachment`) and after-deadline (`test_immediate_sends_unattached_message_after_deadline`) tests still pass (OFFERs still wait).