### PR TITLE
ci: clear all sibling CI-status labels before setting one (fixes dual Passed+Failed)

### DIFF
--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -40,6 +40,8 @@ jobs:
             REPO="Freegle/Iznik"
             curl -sf -X DELETE -H "Authorization: token $GITHUB_TOKEN" \
               "https://api.github.com/repos/$REPO/issues/$PR_NUMBER/labels/CI%3A%20Running" 2>/dev/null || true
+            curl -sf -X DELETE -H "Authorization: token $GITHUB_TOKEN" \
+              "https://api.github.com/repos/$REPO/issues/$PR_NUMBER/labels/CI%3A%20Failed" 2>/dev/null || true
             curl -sf -X POST -H "Authorization: token $GITHUB_TOKEN" \
               -H "Content-Type: application/json" \
               -d '{"labels":["CI: Passed"]}' \
@@ -74,6 +76,8 @@ workflows:
                   REPO="Freegle/Iznik"
                   curl -sf -X DELETE -H "Authorization: token $GITHUB_TOKEN" \
                     "https://api.github.com/repos/$REPO/issues/$PR_NUMBER/labels/CI%3A%20Passed" 2>/dev/null || true
+                  curl -sf -X DELETE -H "Authorization: token $GITHUB_TOKEN" \
+                    "https://api.github.com/repos/$REPO/issues/$PR_NUMBER/labels/CI%3A%20Running" 2>/dev/null || true
                   curl -sf -X POST -H "Authorization: token $GITHUB_TOKEN" \
                     -H "Content-Type: application/json" \
                     -d '{"labels":["CI: Failed"]}' \
@@ -137,6 +141,8 @@ workflows:
                   REPO="Freegle/Iznik"
                   curl -sf -X DELETE -H "Authorization: token $GITHUB_TOKEN" \
                     "https://api.github.com/repos/$REPO/issues/$PR_NUMBER/labels/CI%3A%20Passed" 2>/dev/null || true
+                  curl -sf -X DELETE -H "Authorization: token $GITHUB_TOKEN" \
+                    "https://api.github.com/repos/$REPO/issues/$PR_NUMBER/labels/CI%3A%20Running" 2>/dev/null || true
                   curl -sf -X POST -H "Authorization: token $GITHUB_TOKEN" \
                     -H "Content-Type: application/json" \
                     -d '{"labels":["CI: Failed"]}' \
@@ -280,6 +286,8 @@ workflows:
                   REPO="Freegle/Iznik"
                   curl -sf -X DELETE -H "Authorization: token $GITHUB_TOKEN" \
                     "https://api.github.com/repos/$REPO/issues/$PR_NUMBER/labels/CI%3A%20Passed" 2>/dev/null || true
+                  curl -sf -X DELETE -H "Authorization: token $GITHUB_TOKEN" \
+                    "https://api.github.com/repos/$REPO/issues/$PR_NUMBER/labels/CI%3A%20Running" 2>/dev/null || true
                   curl -sf -X POST -H "Authorization: token $GITHUB_TOKEN" \
                     -H "Content-Type: application/json" \
                     -d '{"labels":["CI: Failed"]}' \


### PR DESCRIPTION
## Summary

A PR could end up with **both** `CI: Passed` and `CI: Failed` labels at once (seen on #769).

**Cause**: the labellers in `continue-config.yml` each removed only *one* prior label:
- the **pass** block removed `CI: Running` but not `CI: Failed`;
- the **fail** blocks removed `CI: Passed` but not `CI: Running`.

So a PR that failed and then later passed (e.g. after re-running a flake) kept the stale `CI: Failed` alongside the new `CI: Passed`.

**Fix**: every block now removes *both* sibling labels before adding its own, so a PR always carries exactly one CI-status label. (`config.yml`'s `CI: Running` setter already cleared both siblings — left unchanged.)

## Test Plan

- Config-only change; takes effect on the next pipeline. Verified the YAML parses and that each labeller now issues two `DELETE`s (the two non-target states) before its `POST`.
- Note: #769's stale `CI: Failed` label has already been removed manually; this prevents recurrence on all PRs.
