### PR TITLE
fix(post-warnings): show personal-info restriction warning when group setting is set

### DIFF
--- a/iznik-nuxt3/components/PostPersonalInfoWarning.vue
+++ b/iznik-nuxt3/components/PostPersonalInfoWarning.vue
@@ -1,0 +1,30 @@
+<template>
+  <NoticeMessage v-if="shouldWarn" variant="warning" class="mt-2">
+    This group restricts personal info in posts. Please remove any phone numbers
+    or email addresses before posting.
+  </NoticeMessage>
+</template>
+<script setup>
+import { computed } from 'vue'
+import {
+  groupRestrictsPersonalInfo,
+  detectPersonalInfo,
+} from '~/composables/usePersonalInfoWarning'
+
+const props = defineProps({
+  group: {
+    type: Object,
+    default: null,
+  },
+  text: {
+    type: String,
+    default: '',
+  },
+})
+
+const shouldWarn = computed(() => {
+  if (!groupRestrictsPersonalInfo(props.group)) return false
+  const { hasPhone, hasEmail } = detectPersonalInfo(props.text)
+  return hasPhone || hasEmail
+})
+</script>

--- a/iznik-nuxt3/composables/usePersonalInfoWarning.js
+++ b/iznik-nuxt3/composables/usePersonalInfoWarning.js
@@ -1,0 +1,54 @@
+import { computed } from 'vue'
+
+// UK phone number pattern matching the server-side ContentCheckService.
+// Requires a proper UK prefix (0, +44, or 0044) followed by 9–10 digits
+// (with optional spaces/hyphens). This mirrors the PHP regex:
+//   /(?<!\d)(?:(?:\+44|0044)\s?|0)(?:\d[\s\-]?){9,10}(?!\d)/
+const UK_PHONE_RE = /(?<!\d)(?:(?:\+44|0044)\s?|0)(?:\d[\s-]?){9,10}(?!\d)/
+
+// External email address pattern (freegle/trashnothing addresses are excluded).
+const EMAIL_RE = /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/
+
+const FREEGLE_EMAIL_DOMAINS = [
+  'ilovefreegle.org',
+  'trashnothing',
+  'yahoogroups',
+]
+
+export function detectPersonalInfo(text) {
+  if (!text) return { hasPhone: false, hasEmail: false }
+
+  const hasPhone = UK_PHONE_RE.test(text)
+
+  let hasEmail = false
+  const emailMatch = text.match(EMAIL_RE)
+  if (emailMatch) {
+    const email = emailMatch[0].toLowerCase()
+    const isOurs = FREEGLE_EMAIL_DOMAINS.some((d) => email.includes(d))
+    hasEmail = !isOurs
+  }
+
+  return { hasPhone, hasEmail }
+}
+
+export function groupRestrictsPersonalInfo(group) {
+  if (!group) return false
+  let rules = group.rules
+  if (!rules) return false
+  if (typeof rules === 'string') {
+    try {
+      rules = JSON.parse(rules)
+    } catch {
+      return false
+    }
+  }
+  return !!rules.restrictpersonalinfo
+}
+
+export function usePersonalInfoWarning(groupRef, textRef) {
+  return computed(() => {
+    if (!groupRestrictsPersonalInfo(groupRef.value)) return false
+    const { hasPhone, hasEmail } = detectPersonalInfo(textRef.value)
+    return hasPhone || hasEmail
+  })
+}

--- a/iznik-nuxt3/pages/find/mobile/whereami.vue
+++ b/iznik-nuxt3/pages/find/mobile/whereami.vue
@@ -20,6 +20,7 @@
       <div v-if="!closed && postcodeValid" class="form-section">
         <label class="form-label">Your local community:</label>
         <ComposeGroup />
+        <PostPersonalInfoWarning :group="group" :text="postText" />
       </div>
 
       <div v-if="postcodeValid && noGroups" class="no-groups-notice">
@@ -115,6 +116,7 @@ import NoticeMessage from '~/components/NoticeMessage.vue'
 import ExternalLink from '~/components/ExternalLink.vue'
 import EmailValidator from '~/components/EmailValidator.vue'
 import EmailBelongsToSomeoneElse from '~/components/EmailBelongsToSomeoneElse.vue'
+import PostPersonalInfoWarning from '~/components/PostPersonalInfoWarning.vue'
 import { useComposeStore } from '~/stores/compose'
 import { useUserStore } from '~/stores/user'
 import { useAuthStore } from '~/stores/auth'
@@ -156,7 +158,15 @@ const {
   notAllowed,
   unvalidatedEmail,
   wentWrong,
+  group,
 } = await setup('Wanted')
+
+const postText = computed(() => {
+  const msgs = composeStore.all.filter((m) => m.type === 'Wanted')
+  if (!msgs.length) return ''
+  const msg = msgs[0]
+  return ((msg.item || '') + ' ' + (msg.description || '')).trim()
+})
 
 const canSubmit = makeCanSubmit({
   messageValid,

--- a/iznik-nuxt3/pages/find/whereami.vue
+++ b/iznik-nuxt3/pages/find/whereami.vue
@@ -51,6 +51,7 @@
                 Tap to choose a different community nearby.
               </p>
             </div>
+            <PostPersonalInfoWarning :group="group" :text="postText" />
           </div>
         </div>
 
@@ -73,6 +74,7 @@
 </template>
 
 <script setup>
+import { computed } from 'vue'
 import { useRoute, useHead, useRuntimeConfig } from '#imports'
 import NoticeMessage from '~/components/NoticeMessage.vue'
 import ExternalLink from '~/components/ExternalLink.vue'
@@ -80,8 +82,10 @@ import GlobalMessage from '~/components/GlobalMessage.vue'
 import PostCode from '~/components/PostCode.vue'
 import WizardProgressCompact from '~/components/WizardProgressCompact.vue'
 import ComposeGroup from '~/components/ComposeGroup.vue'
+import PostPersonalInfoWarning from '~/components/PostPersonalInfoWarning.vue'
 import { setup, postcodeSelect, postcodeClear } from '~/composables/useCompose'
 import { buildHead } from '~/composables/useBuildHead'
+import { useComposeStore } from '~/stores/compose'
 
 const route = useRoute()
 const runtimeConfig = useRuntimeConfig()
@@ -95,9 +99,17 @@ useHead(
   )
 )
 
-const { initialPostcode, postcodeValid, noGroups, closed } = await setup(
+const { initialPostcode, postcodeValid, noGroups, closed, group } = await setup(
   'Wanted'
 )
+
+const composeStore = useComposeStore()
+const postText = computed(() => {
+  const msgs = composeStore.all.filter((m) => m.type === 'Wanted')
+  if (!msgs.length) return ''
+  const msg = msgs[0]
+  return ((msg.item || '') + ' ' + (msg.description || '')).trim()
+})
 </script>
 
 <style scoped lang="scss">

--- a/iznik-nuxt3/pages/give/mobile/whereami.vue
+++ b/iznik-nuxt3/pages/give/mobile/whereami.vue
@@ -20,6 +20,7 @@
       <div v-if="!closed && postcodeValid" class="form-section">
         <label class="form-label">Your local community:</label>
         <ComposeGroup />
+        <PostPersonalInfoWarning :group="group" :text="postText" />
       </div>
 
       <div v-if="postcodeValid && noGroups" class="no-groups-notice">
@@ -115,6 +116,7 @@ import NoticeMessage from '~/components/NoticeMessage.vue'
 import ExternalLink from '~/components/ExternalLink.vue'
 import EmailValidator from '~/components/EmailValidator.vue'
 import EmailBelongsToSomeoneElse from '~/components/EmailBelongsToSomeoneElse.vue'
+import PostPersonalInfoWarning from '~/components/PostPersonalInfoWarning.vue'
 import { useComposeStore } from '~/stores/compose'
 import { useUserStore } from '~/stores/user'
 import { useAuthStore } from '~/stores/auth'
@@ -156,7 +158,15 @@ const {
   notAllowed,
   unvalidatedEmail,
   wentWrong,
+  group,
 } = await setup('Offer')
+
+const postText = computed(() => {
+  const msgs = composeStore.all.filter((m) => m.type === 'Offer')
+  if (!msgs.length) return ''
+  const msg = msgs[0]
+  return ((msg.item || '') + ' ' + (msg.description || '')).trim()
+})
 
 const canSubmit = makeCanSubmit({
   messageValid,

--- a/iznik-nuxt3/pages/give/whereami.vue
+++ b/iznik-nuxt3/pages/give/whereami.vue
@@ -54,6 +54,7 @@
                 Tap to choose a different community nearby.
               </p>
             </div>
+            <PostPersonalInfoWarning :group="group" :text="postText" />
           </div>
         </div>
 
@@ -76,6 +77,7 @@
 </template>
 
 <script setup>
+import { computed } from 'vue'
 import { useRoute, useHead, useRuntimeConfig } from '#imports'
 import NoticeMessage from '~/components/NoticeMessage.vue'
 import ExternalLink from '~/components/ExternalLink.vue'
@@ -83,8 +85,10 @@ import GlobalMessage from '~/components/GlobalMessage.vue'
 import PostCode from '~/components/PostCode.vue'
 import WizardProgressCompact from '~/components/WizardProgressCompact.vue'
 import ComposeGroup from '~/components/ComposeGroup.vue'
+import PostPersonalInfoWarning from '~/components/PostPersonalInfoWarning.vue'
 import { setup, postcodeSelect, postcodeClear } from '~/composables/useCompose'
 import { buildHead } from '~/composables/useBuildHead'
+import { useComposeStore } from '~/stores/compose'
 
 const route = useRoute()
 const runtimeConfig = useRuntimeConfig()
@@ -98,9 +102,17 @@ useHead(
   )
 )
 
-const { initialPostcode, postcodeValid, noGroups, closed } = await setup(
+const { initialPostcode, postcodeValid, noGroups, closed, group } = await setup(
   'Offer'
 )
+
+const composeStore = useComposeStore()
+const postText = computed(() => {
+  const msgs = composeStore.all.filter((m) => m.type === 'Offer')
+  if (!msgs.length) return ''
+  const msg = msgs[0]
+  return ((msg.item || '') + ' ' + (msg.description || '')).trim()
+})
 </script>
 
 <style scoped lang="scss">

--- a/iznik-nuxt3/tests/unit/components/PostPersonalInfoWarning.spec.js
+++ b/iznik-nuxt3/tests/unit/components/PostPersonalInfoWarning.spec.js
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import PostPersonalInfoWarning from '~/components/PostPersonalInfoWarning.vue'
+
+function createWrapper(props = {}) {
+  return mount(PostPersonalInfoWarning, {
+    props,
+    global: {
+      stubs: {
+        NoticeMessage: {
+          template:
+            '<div class="notice-message" :data-variant="variant"><slot /></div>',
+          props: ['variant'],
+        },
+      },
+    },
+  })
+}
+
+const GROUP_NO_RESTRICT = { id: 1, rules: '{}' }
+const GROUP_RESTRICT = {
+  id: 2,
+  rules: JSON.stringify({ restrictpersonalinfo: true }),
+}
+const GROUP_RESTRICT_PARSED = {
+  id: 3,
+  rules: { restrictpersonalinfo: true },
+}
+
+describe('PostPersonalInfoWarning', () => {
+  it('does not warn when group has no restrictpersonalinfo rule', () => {
+    const wrapper = createWrapper({
+      group: GROUP_NO_RESTRICT,
+      text: 'Call me on 07700 900000',
+    })
+    expect(wrapper.find('.notice-message').exists()).toBe(false)
+  })
+
+  it('does not warn when group restricts but post has no personal info', () => {
+    const wrapper = createWrapper({
+      group: GROUP_RESTRICT,
+      text: 'Nice red sofa, good condition',
+    })
+    expect(wrapper.find('.notice-message').exists()).toBe(false)
+  })
+
+  it('does not warn when group is null', () => {
+    const wrapper = createWrapper({
+      group: null,
+      text: 'Call me on 07700 900000',
+    })
+    expect(wrapper.find('.notice-message').exists()).toBe(false)
+  })
+
+  it('warns when group restricts personal info and post contains a UK phone number', () => {
+    const wrapper = createWrapper({
+      group: GROUP_RESTRICT,
+      text: 'Please call 07700 900000 to arrange collection',
+    })
+    expect(wrapper.find('.notice-message').exists()).toBe(true)
+    expect(wrapper.find('.notice-message').text()).toContain(
+      'This group restricts personal info'
+    )
+  })
+
+  it('warns when group restricts personal info and post contains +44 phone number', () => {
+    const wrapper = createWrapper({
+      group: GROUP_RESTRICT,
+      text: 'Ring +447700900000 to collect',
+    })
+    expect(wrapper.find('.notice-message').exists()).toBe(true)
+  })
+
+  it('warns when group restricts personal info and post contains an email address', () => {
+    const wrapper = createWrapper({
+      group: GROUP_RESTRICT,
+      text: 'Email me at someone@example.com',
+    })
+    expect(wrapper.find('.notice-message').exists()).toBe(true)
+  })
+
+  it('does not warn for freegle email addresses even when group restricts', () => {
+    const wrapper = createWrapper({
+      group: GROUP_RESTRICT,
+      text: 'Contact admin@ilovefreegle.org',
+    })
+    expect(wrapper.find('.notice-message').exists()).toBe(false)
+  })
+
+  it('works when group.rules is already a parsed object (not a JSON string)', () => {
+    const wrapper = createWrapper({
+      group: GROUP_RESTRICT_PARSED,
+      text: 'Call 07700 900000',
+    })
+    expect(wrapper.find('.notice-message').exists()).toBe(true)
+  })
+
+  it('does not warn when restrictpersonalinfo is false', () => {
+    const wrapper = createWrapper({
+      group: { id: 4, rules: JSON.stringify({ restrictpersonalinfo: false }) },
+      text: 'Call 07700 900000',
+    })
+    expect(wrapper.find('.notice-message').exists()).toBe(false)
+  })
+})


### PR DESCRIPTION
## Root Cause

The `restrictpersonalinfo` group rule (set via ModTools → Group Settings) was handled server-side by `ContentCheckService` (holds posts for review) but was never checked in the Nuxt3 compose flow. No warning was ever shown to the poster during composition, so the user had no feedback that their post contained a phone number or email address that would be flagged.

The rule check and the UK phone/email patterns that gate it exist entirely in the batch PHP backend — the frontend had no equivalent client-side guard.

## Evidence

AssertFlip: before this fix, `PostPersonalInfoWarning.vue` didn't exist. Any test checking "warning IS shown" failed. After the fix, 9 new Vitest tests pass:

```
✓ does not warn when group has no restrictpersonalinfo rule
✓ does not warn when group restricts but post has no personal info  
✓ does not warn when group is null
✓ warns when group restricts personal info and post contains a UK phone number
✓ warns when group restricts personal info and post contains +44 phone number
✓ warns when group restricts personal info and post contains an email address
✓ does not warn for freegle email addresses even when group restricts
✓ works when group.rules is already a parsed object (not a JSON string)
✓ does not warn when restrictpersonalinfo is false

Test Files  1 passed (1)
      Tests  9 passed (9)
   Duration  479ms
```

## Fix

- **`composables/usePersonalInfoWarning.js`** — `detectPersonalInfo(text)` detects UK phone numbers (matching the PHP `ContentCheckService` regex) and external email addresses; `groupRestrictsPersonalInfo(group)` parses `group.rules` JSON for the `restrictpersonalinfo` flag.

- **`components/PostPersonalInfoWarning.vue`** — thin wrapper component, shows a `NoticeMessage` warning when both the group restricts personal info AND the post text contains a phone/email.

- **Four whereami pages updated** — `give/whereami.vue`, `find/whereami.vue`, `give/mobile/whereami.vue`, `find/mobile/whereami.vue` — all now render `<PostPersonalInfoWarning :group="group" :text="postText" />` after the community selector. The `whereami` pages are where both the group (the restriction setting) and the post content are simultaneously known.

## Other Call Sites

The `restrictpersonalinfo` field is stored in `groups.rules` JSON. The only server-side consumer is `ContentCheckService::checkPhoneNumbers()` and `::checkPII()` (both gated on the same rule). No other frontend component or page references it. The `ModMessageWorry.vue` mod-side warning (`PhoneNumber`/`EmailAddress` content-check reasons) remains unchanged.

## Test

**File:** `iznik-nuxt3/tests/unit/components/PostPersonalInfoWarning.spec.js`  
**Command:** `POST http://localhost:8081/api/tests/vitest {"filter":"PostPersonalInfoWarning"}`  
**Before fix:** component didn't exist → import error / 0 tests  
**After fix:** 9 tests pass (0 failures)

## Discourse
https://discourse.ilovefreegle.org/t/9766/14