### PR TITLE
fix(chitchat): cap Compressor maxWidth/maxHeight to prevent oversized uploads

### DIFF
--- a/iznik-nuxt3/components/OurUploader.vue
+++ b/iznik-nuxt3/components/OurUploader.vue
@@ -407,7 +407,7 @@ onMounted(() => {
       uploadDataDuringCreation: true,
       retryDelays: [0, 3000, 5000, 10000, 20000],
     })
-    .use(Compressor)
+    .use(Compressor, { maxWidth: 1024, maxHeight: 1024 })
   uppy.on('file-added', (file) => {
     console.log('Added file', file)
   })

--- a/iznik-nuxt3/components/PhotoUploader.vue
+++ b/iznik-nuxt3/components/PhotoUploader.vue
@@ -707,7 +707,7 @@ onMounted(() => {
       endpoint: runtimeConfig.public.TUS_UPLOADER,
       uploadDataDuringCreation: true,
     })
-    .use(Compressor)
+    .use(Compressor, { maxWidth: 1024, maxHeight: 1024 })
 
   uppy.value.on('complete', handleUppySuccess)
   const scheduleRetry = createRetryCoalescer(() => uppy.value)

--- a/iznik-nuxt3/tests/unit/components/OurUploader.spec.js
+++ b/iznik-nuxt3/tests/unit/components/OurUploader.spec.js
@@ -452,6 +452,38 @@ describe('OurUploader', () => {
       expect(mockUppy.use).toHaveBeenCalled()
     })
 
+    // Regression test for Discourse 9749/post-5:
+    // Images from phone cameras (e.g. 1536×2048, 285 KB) were uploaded at full
+    // resolution because @uppy/compressor was called with no options, leaving
+    // compressorjs with its default maxWidth:Infinity / maxHeight:Infinity.
+    it('configures Compressor with maxWidth to prevent oversized uploads (Discourse 9749)', async () => {
+      mockIsApp.value = false
+      await createWrapper()
+      const Compressor = (await import('@uppy/compressor')).default
+      const compressorCall = mockUppy.use.mock.calls.find(
+        (c) => c[0] === Compressor
+      )
+      expect(compressorCall).toBeDefined()
+      const compressorOpts = compressorCall[1]
+      expect(compressorOpts).toBeDefined()
+      expect(typeof compressorOpts.maxWidth).toBe('number')
+      expect(compressorOpts.maxWidth).toBeLessThanOrEqual(1024)
+    })
+
+    it('configures Compressor with maxHeight to prevent oversized uploads (Discourse 9749)', async () => {
+      mockIsApp.value = false
+      await createWrapper()
+      const Compressor = (await import('@uppy/compressor')).default
+      const compressorCall = mockUppy.use.mock.calls.find(
+        (c) => c[0] === Compressor
+      )
+      expect(compressorCall).toBeDefined()
+      const compressorOpts = compressorCall[1]
+      expect(compressorOpts).toBeDefined()
+      expect(typeof compressorOpts.maxHeight).toBe('number')
+      expect(compressorOpts.maxHeight).toBeLessThanOrEqual(1024)
+    })
+
     it('registers event listeners on Uppy', async () => {
       mockIsApp.value = false
       await createWrapper()

--- a/iznik-nuxt3/tests/unit/components/PhotoUploader.spec.js
+++ b/iznik-nuxt3/tests/unit/components/PhotoUploader.spec.js
@@ -1127,6 +1127,25 @@ describe('PhotoUploader', () => {
       expect(wrapper.vm.uppy).not.toBeNull()
     })
 
+    it('Compressor plugin has maxWidth and maxHeight dimension cap (fix for 9749/5)', async () => {
+      // AssertFlip step 3b: FAILS on buggy code (no options → no dimension cap),
+      // PASSES once .use(Compressor, { maxWidth: 1024, maxHeight: 1024 }) is added.
+      // Root cause: CompressorJS defaults to maxWidth/maxHeight=Infinity, so without
+      // explicit options images are quality-compressed but NOT dimension-capped.
+      createWrapper()
+      await flushPromises()
+
+      const Compressor = (await import('@uppy/compressor')).default
+      const compressorCall = mockUppyInstance.use.mock.calls.find(
+        (c) => c[0] === Compressor
+      )
+      expect(compressorCall).toBeDefined()
+      expect(compressorCall[1]).toMatchObject({
+        maxWidth: 1024,
+        maxHeight: 1024,
+      })
+    })
+
     // Regression guard for NUXT3-D2C (Sentry TypeError `'error' in undefined`).
     // Three consecutive per-file upload-error events fired concurrent retryAll
     // calls that raced inside Uppy's filterNonFailedFiles. Coalesce bursts into


### PR DESCRIPTION
## Root Cause

`@uppy/compressor` delegates options directly to `compressorjs`, whose defaults are `maxWidth: Infinity, maxHeight: Infinity`. Both `OurUploader.vue` (chitchat/newsfeed) and `PhotoUploader.vue` (compose flow) called `.use(Compressor)` with no options, so the web upload path applied JPEG quality compression (reducing file size) but never constrained image dimensions — allowing 1536×2048 images (285 KB as reported) to reach the server at full resolution.

## Evidence

```
# Before fix — Compressor registered with no options (Infinity limits):
.use(Compressor)

# Tests FAIL on buggy code:
✗ configures Compressor with maxWidth to prevent oversized uploads (Discourse 9749)
  Expected: typeof compressorOpts.maxWidth to be 'number', got undefined
```

## Fix

Added `{ maxWidth: 1024, maxHeight: 1024 }` to both `.use(Compressor)` calls, matching the advisory `height: 1024` constraint already used on the Capacitor Camera native-app path:

- `iznik-nuxt3/components/OurUploader.vue` (chitchat/newsfeed path)
- `iznik-nuxt3/components/PhotoUploader.vue` (compose flow — same pattern)

## Other Call Sites

Both `.use(Compressor)` call sites in the codebase are now fixed. No other occurrences.

## Test

- File: `iznik-nuxt3/tests/unit/components/OurUploader.spec.js`
- Command: `npm run test:unit:run -- OurUploader`
- Proves: FAIL before fix (no options → no dimension cap), PASS after fix (98✓)
- Also: `PhotoUploader.spec.js` 89✓

## Discourse

https://discourse.ilovefreegle.org/t/9749/5