### PR TITLE
fix(modtools): correct off-by-one badge count for newly-promoted moderator

### DIFF
--- a/iznik-server-go/session/session.go
+++ b/iznik-server-go/session/session.go
@@ -1403,7 +1403,9 @@ func GetSession(c *fiber.Ctx) error {
 
 		// Total only includes actionable work items (primary/red badge counts),
 		// not informational ones (other/blue badge counts like chatreviewother, happiness, giftaid, pendingother).
-		total := pending + spam + pendingmembers + spammembers + pendingevents +
+		// pendingmembers is intentionally excluded: the frontend has no left-menu red badge for it,
+		// so including it inflates the hamburger count beyond the sum of visible items (bug 9654).
+		total := pending + spam + spammembers + pendingevents +
 			pendingadmins + editreview + pendingvolunteering + stories +
 			spammerpendingadd + spammerpendingremove +
 			chatreview + newsletterstories + relatedmembers + housekeeping + cronjobs +

--- a/iznik-server-go/test/session_test.go
+++ b/iznik-server-go/test/session_test.go
@@ -2234,9 +2234,9 @@ func TestWorkCountTotalExcludesInformational(t *testing.T) {
 
 	// Compute expected total from all actionable fields.
 	// giftaid is excluded from total to match PHP API behaviour (commit df11b11).
+	// pendingmembers is excluded: no left-menu red badge exists for it (bug 9654).
 	actionable := work["pending"].(float64) +
 		work["spam"].(float64) +
-		work["pendingmembers"].(float64) +
 		work["spammembers"].(float64) +
 		work["pendingevents"].(float64) +
 		work["pendingadmins"].(float64) +
@@ -2253,6 +2253,56 @@ func TestWorkCountTotalExcludesInformational(t *testing.T) {
 	_ = chatreviewother
 	_ = happiness
 	_ = giftaid
+}
+
+// ---------------------------------------------------------------------------
+// Work Counts: Pending members excluded from total (bug 9654)
+// ---------------------------------------------------------------------------
+
+// TestWorkCountPendingMembersExcludedFromTotal verifies that pendingmembers
+// (group join requests awaiting approval) do NOT inflate work.total.
+// The frontend has no left-menu red badge for pendingmembers, so including it
+// in total causes the hamburger to show one more than the sum of visible items —
+// the symptom reported by newly-promoted moderators.
+func TestWorkCountPendingMembersExcludedFromTotal(t *testing.T) {
+	prefix := uniquePrefix("wc_pendmem")
+	db := database.DBConn
+	groupID := CreateTestGroup(t, prefix)
+	modID := CreateTestUser(t, prefix+"_mod", "User")
+	CreateTestMembership(t, modID, groupID, "Moderator")
+	_, token := CreateTestSession(t, modID)
+
+	// Create a user with a pending membership (someone who applied to join the group).
+	applicantID := CreateTestUser(t, prefix+"_applicant", "User")
+	db.Exec("INSERT INTO memberships (userid, groupid, role, collection) VALUES (?, ?, ?, ?)",
+		applicantID, groupID, "Member", "Pending")
+
+	work := getSessionWork(t, token)
+
+	total := work["total"].(float64)
+	pendingmembers := work["pendingmembers"].(float64)
+
+	assert.Equal(t, float64(1), pendingmembers, "Setup: should have one pending member application")
+
+	// Compute expected total: sum of all actionable items excluding pendingmembers.
+	// pendingmembers has no corresponding left-menu red badge in the frontend,
+	// so it must not inflate total (which drives the hamburger badge count).
+	expected := work["pending"].(float64) +
+		work["spam"].(float64) +
+		work["spammembers"].(float64) +
+		work["pendingevents"].(float64) +
+		work["pendingadmins"].(float64) +
+		work["editreview"].(float64) +
+		work["pendingvolunteering"].(float64) +
+		work["stories"].(float64) +
+		work["spammerpendingadd"].(float64) +
+		work["spammerpendingremove"].(float64) +
+		work["chatreview"].(float64) +
+		work["newsletterstories"].(float64) +
+		work["relatedmembers"].(float64)
+
+	assert.Equal(t, expected, total,
+		"pendingmembers must not be included in total: hamburger would exceed visible left-menu badge sum")
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `pendingmembers` (count of pending group join requests awaiting approval) was included in `work.total`, which drives the red hamburger badge count in ModTools
- The frontend has **no left-menu red badge** for `pendingmembers` — so the hamburger showed `pendingmembers` more than the sum of visible left-menu items
- For a newly-promoted moderator whose group has any pending member applications, the hamburger count was exactly that many too high (typically 1)

## Root cause

In `iznik-server-go/session/session.go`, the `total` formula included `pendingmembers`:
```go
total := pending + spam + pendingmembers + spammembers + ...
```
But a search of the entire `iznik-nuxt3` codebase finds **zero** uses of `pendingmembers` as a badge count in any left-menu component. Every other field in `total` has a visible left-menu red badge home; `pendingmembers` does not.

## Fix

Remove `pendingmembers` from `total`. It remains in the `work` map so the frontend can display it in a dedicated badge if one is added later.

## Test plan

- [x] New failing test `TestWorkCountPendingMembersExcludedFromTotal` added: creates a mod + group with 1 pending member application, asserts `work.total` equals sum of all actionable items **excluding** `pendingmembers` — failed before fix, passes after
- [x] Updated `TestWorkCountTotalExcludesInformational` to reflect `pendingmembers` is now excluded from `total`
- [x] Full Go test suite: **3183 tests pass, 0 failures**

Fixes Discourse topic 9654 post 19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)