### PR TITLE
fix(modtools_chat): show member name not group name after group-change + standard message

### DIFF
--- a/iznik-server-go/chat/chatroom.go
+++ b/iznik-server-go/chat/chatroom.go
@@ -722,8 +722,8 @@ func listChats(myid uint64, chattypes []string, start string, search string, onl
 				// Exclude backup mods (active:0 in membership settings) unless searching.
 				unions = append(unions,
 					"SELECT 0 AS search, user1 AS otheruid, nameshort, namefull, "+
-						"COALESCE((SELECT fullname FROM users WHERE users.id = user1), '') AS firstname, "+
-						"'' AS lastname, "+
+						"COALESCE((SELECT firstname FROM users WHERE users.id = user1), '') AS firstname, "+
+						"COALESCE((SELECT lastname FROM users WHERE users.id = user1), '') AS lastname, "+
 						"COALESCE((SELECT fullname FROM users WHERE users.id = user1), '') AS fullname, "+
 						"(SELECT deleted FROM users WHERE users.id = user1) AS otherdeleted, "+
 						atts+", c1.status, NULL AS lasttype FROM chat_rooms "+
@@ -851,8 +851,8 @@ func listChats(myid uint64, chattypes []string, start string, search string, onl
 					// ModTools: search User2Mod chats visible to user — by message content/subject.
 					unions = append(unions,
 						"SELECT 1 AS search, user1 AS otheruid, nameshort, namefull, "+
-							"COALESCE((SELECT fullname FROM users WHERE users.id = user1), '') AS firstname, "+
-							"'' AS lastname, "+
+							"COALESCE((SELECT firstname FROM users WHERE users.id = user1), '') AS firstname, "+
+							"COALESCE((SELECT lastname FROM users WHERE users.id = user1), '') AS lastname, "+
 							"COALESCE((SELECT fullname FROM users WHERE users.id = user1), '') AS fullname, "+
 							"(SELECT deleted FROM users WHERE users.id = user1) AS otherdeleted, "+
 							atts+", c1.status, NULL AS lasttype FROM chat_rooms "+
@@ -869,10 +869,10 @@ func listChats(myid uint64, chattypes []string, start string, search string, onl
 					// ModTools: search User2Mod chats by member's name/email.
 					unions = append(unions,
 						"SELECT 1 AS search, user1 AS otheruid, nameshort, namefull, "+
-							"COALESCE((SELECT fullname FROM users WHERE users.id = user1), '') AS firstname, "+
-							"'' AS lastname, "+
-							"COALESCE((SELECT fullname FROM users WHERE users.id = user1), '') AS fullname, "+
-							"(SELECT deleted FROM users WHERE users.id = user1) AS otherdeleted, "+
+							"COALESCE(users.firstname, '') AS firstname, "+
+							"COALESCE(users.lastname, '') AS lastname, "+
+							"COALESCE(users.fullname, '') AS fullname, "+
+							"users.deleted AS otherdeleted, "+
 							atts+", c1.status, NULL AS lasttype FROM chat_rooms "+
 							"INNER JOIN `groups` ON groups.id = chat_rooms.groupid "+
 							"LEFT JOIN chat_roster c1 ON c1.userid = ? AND chat_rooms.id = c1.chatid "+
@@ -967,6 +967,17 @@ func listChats(myid uint64, chattypes []string, start string, search string, onl
 					groupName = chat.Namefull
 				}
 				chats[ix].Name = tnre.ReplaceAllString(chat.Fullname, "$1")
+				if groupName != "" {
+					chats[ix].Name += " (" + groupName + ")"
+				}
+			} else if chat.Otheruid != myid && (len(chat.Firstname) > 0 || len(chat.Lastname) > 0) {
+				// Member has no fullname but does have firstname/lastname — use those.
+				groupName := chat.Nameshort
+				if groupName == "" {
+					groupName = chat.Namefull
+				}
+				name := strings.TrimSpace(chat.Firstname + " " + chat.Lastname)
+				chats[ix].Name = tnre.ReplaceAllString(name, "$1")
 				if groupName != "" {
 					chats[ix].Name += " (" + groupName + ")"
 				}

--- a/iznik-server-go/test/chat_test.go
+++ b/iznik-server-go/test/chat_test.go
@@ -288,6 +288,85 @@ func TestGroupChatIconUsesNewestImage(t *testing.T) {
 	db.Exec("DELETE FROM groups_images WHERE id IN (?, ?)", img1ID, img2ID)
 }
 
+// TestModToolsChatNameUsesFirstLastWhenFullnameNull verifies that when a member has
+// firstname/lastname but no fullname, the ModTools chat list shows "Firstname Lastname (Group)"
+// instead of "GroupName Volunteers". This is the scenario that occurs after a volunteer
+// edits a member's post to move it to a new group and sends a standard welcome message.
+func TestModToolsChatNameUsesFirstLastWhenFullnameNull(t *testing.T) {
+	prefix := uniquePrefix("chatName9719")
+	db := database.DBConn
+
+	// Create a member with firstname/lastname but explicitly NULL fullname.
+	// This mirrors accounts that have only partial name data.
+	var memberID uint64
+	db.Exec(
+		"INSERT INTO users (firstname, lastname, fullname, systemrole, lastlocation, settings) "+
+			"VALUES (?, ?, NULL, 'User', NULL, ?)",
+		prefix+"First", prefix+"Last",
+		`{"mylocation":{"lat":51.5,"lng":-0.1}}`,
+	)
+	db.Raw("SELECT LAST_INSERT_ID()").Scan(&memberID)
+	if memberID == 0 {
+		t.Fatal("failed to create member user")
+	}
+	db.Exec("INSERT INTO users_emails (userid, email) VALUES (?, ?)", memberID, prefix+"@test.com")
+
+	// Create a mod with a full name and token.
+	modID := CreateTestUser(t, prefix+"_mod", "Moderator")
+	_, modToken := CreateTestSession(t, modID)
+
+	groupID := CreateTestGroup(t, prefix+"_grp")
+	CreateTestMembership(t, memberID, groupID, "Member")
+	CreateTestMembership(t, modID, groupID, "Moderator")
+
+	// Create a User2Mod chat (member → group mods).
+	chatID, err := chat.GetOrCreateUser2ModChat(db, memberID, groupID)
+	assert.NoError(t, err)
+
+	db.Exec(
+		"INSERT INTO chat_messages (chatid, userid, message, type, date, reviewrequired, processingrequired, processingsuccessful) "+
+			"VALUES (?, ?, 'welcome message', 'ModMail', NOW(), 0, 0, 1)",
+		chatID, modID,
+	)
+
+	// ModTools endpoint (/api/chat/rooms) — the mod should see this chat.
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/chat/rooms?chattypes[]=User2Mod&jwt="+modToken, nil))
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var wrapper struct {
+		Chatrooms []chat.ChatRoomListEntry `json:"chatrooms"`
+	}
+	json2.Unmarshal(rsp(resp), &wrapper)
+
+	var found *chat.ChatRoomListEntry
+	for i := range wrapper.Chatrooms {
+		if wrapper.Chatrooms[i].ID == chatID {
+			found = &wrapper.Chatrooms[i]
+			break
+		}
+	}
+
+	assert.NotNil(t, found, "ModTools /api/chat/rooms should show User2Mod chat %d to mod %d", chatID, modID)
+	if found != nil {
+		expectedFirst := prefix + "First"
+		expectedLast := prefix + "Last"
+		assert.Contains(t, found.Name, expectedFirst,
+			"Chat name should contain member's firstname when fullname is NULL, got %q", found.Name)
+		assert.Contains(t, found.Name, expectedLast,
+			"Chat name should contain member's lastname when fullname is NULL, got %q", found.Name)
+		assert.NotContains(t, found.Name, "Volunteers",
+			"Chat name should NOT be 'GroupName Volunteers' when member has firstname/lastname, got %q", found.Name)
+	}
+
+	// Clean up.
+	db.Exec("DELETE FROM chat_messages WHERE chatid = ?", chatID)
+	db.Exec("DELETE FROM chat_roster WHERE chatid = ?", chatID)
+	db.Exec("DELETE FROM chat_rooms WHERE id = ?", chatID)
+	db.Exec("DELETE FROM users_emails WHERE userid = ?", memberID)
+	db.Exec("DELETE FROM memberships WHERE userid = ?", memberID)
+	db.Exec("DELETE FROM users WHERE id = ?", memberID)
+}
+
 func TestCreateChatMessage(t *testing.T) {
 	// Invalid chat id
 	resp, _ := getApp().Test(httptest.NewRequest("POST", "/api/chat/-1/message", nil))


### PR DESCRIPTION
## Summary

- **Bug**: After a volunteer edits a member's post to move it to a new group and sends a standard welcome message, ModTools chat showed "GroupName Volunteers" instead of the member's name.
- **Root cause**: The User2Mod SQL in `listChats()` (non-memberOnly / ModTools path) aliased `fullname` as `firstname` and hardcoded `lastname = ''`. When a member has `fullname = NULL` (but does have `firstname`/`lastname`), the naming logic fell through to the group-name fallback branch.
- **V1 parity**: this restores the V1 behaviour. V1 `ChatRoom` computes the name as `CASE WHEN fullname IS NOT NULL THEN fullname ELSE CONCAT(firstname,' ',lastname) END` (`iznik-server/include/chat/ChatRoom.php:91-92`) and shows the mod *"<member> on <group>"*, never *"<group> Volunteers"* (that suffix is only the member's own view, `:172`/`:720`). V2's `fullname AS firstname, '' AS lastname` aliasing dropped the firstname/lastname fallback — a V2 regression, not intended parity. So this is a parity restoration, not a behaviour change.
- **Fix**: Fetch real `firstname`/`lastname` columns from the `users` table in all three ModTools User2Mod SQL query paths, and add a fallback naming branch that uses `firstname + lastname` when `fullname` is empty but the member has partial name data.
- **Test**: `TestModToolsChatNameUsesFirstLastWhenFullnameNull` creates a member with `firstname`/`lastname` but NULL `fullname`, creates a User2Mod chat, and asserts the ModTools chat list shows the member's name rather than "GroupName Volunteers".

## Files changed

- `iznik-server-go/chat/chatroom.go` — fix the SQL and naming logic in `listChats()`
- `iznik-server-go/test/chat_test.go` — add regression test

## Test plan

- [x] `TestModToolsChatNameUsesFirstLastWhenFullnameNull` passes
- [x] All 3183 Go tests pass locally

## Discourse

https://discourse.ilovefreegle.org/t/9719/1