### PR TITLE
docs(standards): require embedded Discourse post link in PRs

### DIFF
--- a/codingstandards.md
+++ b/codingstandards.md
@@ -12,6 +12,7 @@
 
 - NEVER commit unless tests pass. NEVER push unless told to. NEVER add "Claude Code" to commits. Full stops at end of sentences.
 - **Backend first**: Deploy backend before dependent frontend. Split cross-component changes into separate PRs. Link related PRs. Verify production deployment before merging frontend.
+- **Discourse-reported issues**: a PR (or PR comment) addressing a Discourse report must embed the post-specific link in a `## Discourse` section: `https://discourse.ilovefreegle.org/t/<topicid>/<postnumber>`. NEVER write `Closes #<topic>` for a Discourse topic — a topic is not a GitHub issue, and `Closes #NNNN` would try to auto-close an unrelated GitHub issue. Never reference a thread as a bare "topic NNNN" with no link.
 
 ## Code Style
 


### PR DESCRIPTION
## Summary

PRs addressing a Discourse-reported issue keep getting opened with no link, or a bare `Closes #<topic>` that treats the Discourse topic id as a GitHub issue. #787 had `Closes #9719` — 9719 is a Discourse topic, and on merge `Closes #9719` would try to auto-close an unrelated GitHub issue.

The rule previously lived only in `monitor-fsm/workflow.json`, so general (non-FSM) PRs missed it. This documents it in `codingstandards.md`, which `CLAUDE.md` points every agent to:

- embed the post-specific link in a `## Discourse` section: `https://discourse.ilovefreegle.org/t/<topicid>/<postnumber>`;
- never write `Closes #<topic>` for a Discourse topic;
- never reference a thread as a bare "topic NNNN".

Docs-only change.