### PR TITLE
fix(myposts): age out old pending posts by original date, not arrival

### DIFF
--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -1107,13 +1107,14 @@ func applyExpiry(db *gorm.DB, msgs []MessageSummary) []int {
 		}
 
 		// Age the post against the same expireTime V1 uses (maxagetoshow /
-		// EXPIRE_TIME = 90 days, or the repost window). For Rejected posts age by
-		// the ORIGINAL date (messages.date) rather than arrival: a rejected post's
-		// arrival can be recent while the post itself is years old, which would
-		// otherwise keep a long-dead rejected message in the member's active posts
-		// (Discourse topic 9481/561). V1 capped a member's own posts by age too.
+		// EXPIRE_TIME = 90 days, or the repost window). For Rejected/Pending posts
+		// age by the ORIGINAL date (messages.date) rather than arrival: a post
+		// returned to the pending queue gets a recent arrival while the original
+		// message can be years old, which would otherwise keep it in the member's
+		// active posts (Discourse topic 9481/561 for Rejected, 9481/583 for Pending).
+		// V1 capped a member's own posts by age too.
 		ageBasis := m.Arrival
-		if m.Collection == utils.COLLECTION_REJECTED && !m.Date.IsZero() {
+		if (m.Collection == utils.COLLECTION_REJECTED || m.Collection == utils.COLLECTION_PENDING) && !m.Date.IsZero() {
 			ageBasis = m.Date
 		}
 		daysAgo := int(now.Sub(ageBasis).Hours() / 24)

--- a/iznik-server-go/test/message_test.go
+++ b/iznik-server-go/test/message_test.go
@@ -291,6 +291,76 @@ func TestOldRejectedMessageClassifiedAsOld(t *testing.T) {
 	}
 }
 
+func TestOldPendingMessageClassifiedAsOld(t *testing.T) {
+	// A post that is 69+ months old but has been returned to the Pending queue
+	// (recent messages_groups.arrival) must still be aged out using its ORIGINAL
+	// date (messages.date), not the recent arrival. Regression from Discourse
+	// topic 9481/583: the prior fix (#664) only covered COLLECTION_REJECTED.
+	db := database.DBConn
+	prefix := uniquePrefix("oldpend")
+	groupID := CreateTestGroup(t, prefix)
+	userID := CreateTestUser(t, prefix, "User")
+	CreateTestMembership(t, userID, groupID, "Member")
+	_, token := CreateTestSession(t, userID)
+
+	var locationID uint64
+	db.Raw("SELECT id FROM locations LIMIT 1").Scan(&locationID)
+
+	// createPending inserts a Pending post (no spatial row) with a given
+	// original date but a RECENT arrival — simulating a post returned to the
+	// pending queue long after it was first submitted.
+	createPending := func(subject string, dateDaysAgo int) uint64 {
+		db.Exec("INSERT INTO messages (fromuser, subject, textbody, message, type, locationid, arrival, date) "+
+			"VALUES (?, ?, 'body', 'body', 'Offer', ?, DATE_SUB(NOW(), INTERVAL 1 DAY), DATE_SUB(NOW(), INTERVAL ? DAY))",
+			userID, subject, locationID, dateDaysAgo)
+		var id uint64
+		db.Raw("SELECT id FROM messages WHERE fromuser = ? AND subject = ? ORDER BY id DESC LIMIT 1",
+			userID, subject).Scan(&id)
+		require.NotZero(t, id)
+		db.Exec("INSERT INTO messages_groups (msgid, groupid, arrival, collection, autoreposts) "+
+			"VALUES (?, ?, DATE_SUB(NOW(), INTERVAL 1 DAY), 'Pending', 0)", id, groupID)
+		t.Cleanup(func() {
+			db.Exec("DELETE FROM messages_groups WHERE msgid = ?", id)
+			db.Exec("DELETE FROM messages WHERE id = ?", id)
+		})
+		return id
+	}
+
+	oldPendID := createPending("OFFER: Ancient Pending Lamp", 400) // years-old → must be aged out
+	midPendID := createPending("OFFER: Two-Month Pending Chair", 60) // within 90-day expiry → still active
+
+	// active=true: old pending excluded, mid-age (within expiry) still present.
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/user/"+fmt.Sprint(userID)+"/message?active=true&jwt="+token, nil))
+	assert.Equal(t, 200, resp.StatusCode)
+	var msgs []message.MessageSummary
+	json2.Unmarshal(rsp(resp), &msgs)
+
+	foundOld, foundMid := false, false
+	for _, m := range msgs {
+		if m.ID == oldPendID {
+			foundOld = true
+		}
+		if m.ID == midPendID {
+			foundMid = true
+		}
+	}
+	assert.False(t, foundOld, "Years-old pending post should NOT appear in active (Discourse 9481/583)")
+	assert.True(t, foundMid, "Pending post within the 90-day expiry should still appear in active")
+
+	// active=false: old pending marked hasoutcome=true (Old); mid one not.
+	resp, _ = getApp().Test(httptest.NewRequest("GET", "/api/user/"+fmt.Sprint(userID)+"/message?active=false&jwt="+token, nil))
+	assert.Equal(t, 200, resp.StatusCode)
+	json2.Unmarshal(rsp(resp), &msgs)
+	for _, m := range msgs {
+		if m.ID == oldPendID {
+			assert.True(t, m.Hasoutcome, "Years-old pending post should be hasoutcome=true (Old) in non-active query")
+		}
+		if m.ID == midPendID {
+			assert.False(t, m.Hasoutcome, "Pending post within expiry should not be marked Old")
+		}
+	}
+}
+
 func TestExpiredPromisedMessageExcludedFromActive(t *testing.T) {
 	db := database.DBConn
 	prefix := uniquePrefix("exprms")


### PR DESCRIPTION
## Root Cause

`applyExpiry` in `message/message.go` ages messages against `messages_groups.arrival` by default. The prior fix (#664 / Discourse 9481/561) overrode this to use `messages.date` for `COLLECTION_REJECTED` posts. However, it did not extend the same fix to `COLLECTION_PENDING` posts.

A post returned to the Pending queue gets a fresh `messages_groups.arrival` (today), while its `messages.date` is the original post date — potentially 69+ months ago. The age check used the recent arrival, so `daysAgo < expireTime (90)` and the post was never filtered out. It kept appearing in the member's active My Posts list.

## Evidence

```
--- FAIL: TestOldPendingMessageClassifiedAsOld (0.29s)
    message_test.go:347:
        Error:       Should be false
        Messages:    Years-old pending post should NOT appear in active (Discourse 9481/583)
    message_test.go:356:
        Error:       Should be true
        Messages:    Years-old pending post should be hasoutcome=true (Old) in non-active query
```

## Fix

Extended the `COLLECTION_REJECTED` condition in `applyExpiry` to also cover `COLLECTION_PENDING`:

```go
// Before
if m.Collection == utils.COLLECTION_REJECTED && !m.Date.IsZero() {
    ageBasis = m.Date
}

// After
if (m.Collection == utils.COLLECTION_REJECTED || m.Collection == utils.COLLECTION_PENDING) && !m.Date.IsZero() {
    ageBasis = m.Date
}
```

Fresh pending posts (where `m.Date` ≈ today) are unaffected: `daysAgo ≈ 0 < expireTime`.

## Other Call Sites

`ageBasis` is only set inside `applyExpiry`. `markExpiredMessages` already correctly excludes Pending/Rejected from the spatial-entry nullity check (line 1185). No other changes needed.

## Test

**File**: `iznik-server-go/test/message_test.go` — `TestOldPendingMessageClassifiedAsOld`

**Command**: `go test ./test/... -run TestOldPendingMessageClassifiedAsOld`

**Proves**: Fail-before (400-day-old pending post appears in active query) → Pass-after (filtered out). Mid-age (60-day) pending post still appears in active (V1 parity).

Full suite: 3184 tests pass (3183 pre-existing + 1 new).

## Discourse

https://discourse.ilovefreegle.org/t/9481/583