### PR TITLE
fix(content-moderation): match multi-word worry-word phrases in matchesFuzzy

### DIFF
--- a/iznik-batch/app/Services/ContentCheckService.php
+++ b/iznik-batch/app/Services/ContentCheckService.php
@@ -385,6 +385,13 @@ class ContentCheckService
             return false;
         }
 
+        // Multi-word phrases: token-by-token matching can never match a phrase
+        // like "discounted price" against individual haystack tokens. Use a
+        // word-boundary-anchored phrase match instead (Discourse #9620/283).
+        if (str_contains($kwLower, ' ')) {
+            return (bool) preg_match('/\b' . preg_quote($kwLower, '/') . '\b/', $haystack);
+        }
+
         $variants = $this->inflectionVariants($kwLower);
 
         foreach (preg_split('/\s+/', $haystack, -1, PREG_SPLIT_NO_EMPTY) as $token) {

--- a/iznik-batch/tests/Unit/Services/ContentCheckServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/ContentCheckServiceTest.php
@@ -921,6 +921,56 @@ class ContentCheckServiceTest extends TestCase
         $this->assertNull($result);
     }
 
+    public function test_check_per_group_worry_words_multiword_phrase_matches(): void
+    {
+        // Discourse #9620 post 283: "free or at a discounted price" bypassed the
+        // content filter. Mods configured "discounted price" as a two-word worry
+        // word. matchesFuzzy() compared individual whitespace tokens against the
+        // full phrase, so "discounted" ≠ "discounted price" → no match.
+        $group = $this->createTestGroup();
+        DB::table('groups')->where('id', $group->id)->update([
+            'settings' => json_encode(['spammers' => ['worrywords' => 'discounted price']]),
+        ]);
+
+        $result = $this->service->checkPerGroupWorryWords(
+            '',
+            'I can give it away free or at a discounted price if needed',
+            $group->id
+        );
+        $this->assertNotNull($result, 'Multi-word worry word "discounted price" must flag text containing that phrase');
+        $this->assertSame(ContentCheckService::CHECK_PER_GROUP_WORRY, $result['check']);
+    }
+
+    public function test_check_per_group_worry_words_multiword_phrase_no_partial_match(): void
+    {
+        // "discounted price" as a phrase must NOT match text that only contains
+        // "discounted" (one word) or "price" (one word) separately.
+        $group = $this->createTestGroup();
+        DB::table('groups')->where('id', $group->id)->update([
+            'settings' => json_encode(['spammers' => ['worrywords' => 'discounted price']]),
+        ]);
+
+        $result = $this->service->checkPerGroupWorryWords(
+            '',
+            'Collection any time, discounted delivery not available, just free',
+            $group->id
+        );
+        $this->assertNull($result, '"discounted price" phrase must not fire when only "discounted" appears alone');
+    }
+
+    public function test_matches_fuzzy_multiword_phrase_matches_in_haystack(): void
+    {
+        // matchesFuzzy() must handle multi-word keywords — the root cause of #9620.
+        $result = $this->callPrivate('matchesFuzzy', 'free or at a discounted price today', 'discounted price');
+        $this->assertTrue($result, 'matchesFuzzy must match a two-word keyword phrase found in the haystack');
+    }
+
+    public function test_matches_fuzzy_multiword_phrase_no_match_when_absent(): void
+    {
+        $result = $this->callPrivate('matchesFuzzy', 'free sofa in good condition', 'discounted price');
+        $this->assertFalse($result);
+    }
+
     // =========================================================================
     // checkKnownSpammer — needs DB
     // =========================================================================


### PR DESCRIPTION
## Root Cause

matchesFuzzy() in ContentCheckService split the haystack on whitespace and compared individual tokens against the keyword. A two-word keyword like "discounted price" can never equal a single token, so per-group worry words containing a space were silently skipped -- allowing posts using selling language such as "free or at a discounted price" to pass the content filter unchallenged.

## Evidence

    # test_matches_fuzzy_multiword_phrase_matches_in_haystack FAILS before fix:
    callPrivate(matchesFuzzy, free or at a discounted price today, discounted price)
    # Expected: true  Actual (buggy): false

## Fix

Added a short-circuit at the top of matchesFuzzy(): if the keyword contains a space, use a word-boundary preg_match on the full (unsplit) haystack instead of the token loop. 7 lines in ContentCheckService.php. This also corrects any multi-word concern_keywords entries with match_mode=fuzzy (same code path).

## Other Call Sites

matchesFuzzy is called from exactly two places:
- checkConcernKeywords() line 576 (also benefits from fix)
- checkPerGroupWorryWords() line 1029 (primary bug site)

## Test

File: iznik-batch/tests/Unit/Services/ContentCheckServiceTest.php

- test_matches_fuzzy_multiword_phrase_matches_in_haystack: FAILS before fix, PASSES after
- test_check_per_group_worry_words_multiword_phrase_matches: FAILS before fix, PASSES after
- test_check_per_group_worry_words_multiword_phrase_no_partial_match: guards against false positives
- Full suite: 192 ContentCheckServiceTest tests pass (no regressions)

## Discourse

https://discourse.ilovefreegle.org/t/9620/283