### PR TITLE
fix(moderation): clear contentcheck_reasons on approval so IP-abuse warning does not persist

### DIFF
--- a/iznik-batch/app/Services/AutoApproveService.php
+++ b/iznik-batch/app/Services/AutoApproveService.php
@@ -196,6 +196,7 @@ class AutoApproveService
         // V1 approve(): UPDATE messages_groups SET collection='Approved', approvedby=whoAmId(),
         // approvedat=NOW(), arrival=NOW() WHERE msgid=? AND groupid=? AND collection!='Approved'
         // V1 whoAmId() returns NULL in cron context (no session).
+        // Also clear contentcheck_reasons so IP-abuse warnings are not shown after auto-approval.
         DB::table('messages_groups')
             ->where('msgid', $candidate->msgid)
             ->where('groupid', $groupid)
@@ -205,6 +206,7 @@ class AutoApproveService
                 'approvedby' => null,
                 'approvedat' => now(),
                 'arrival' => now(),
+                'contentcheck_reasons' => null,
             ]);
 
         // V1 autoapprove() log: type=Message, subtype=Autoapproved.

--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -1757,7 +1757,9 @@ func handleApprove(c *fiber.Ctx, myid uint64, req PostMessageRequest) error {
 	// Move to Approved with arrival=NOW() so immediate-email recipients get it.
 	// Guard against double-approve by requiring collection != Approved.
 	// Restrict to groups the caller is authorised for.
-	if result := db.Exec("UPDATE messages_groups SET collection = ?, approvedby = ?, approvedat = NOW(), arrival = NOW() WHERE msgid = ? AND groupid IN ? AND collection != ?",
+	// Clear contentcheck_reasons so IP-abuse and other warnings are not shown to
+	// moderators after a post has been manually approved.
+	if result := db.Exec("UPDATE messages_groups SET collection = ?, approvedby = ?, approvedat = NOW(), arrival = NOW(), contentcheck_reasons = NULL WHERE msgid = ? AND groupid IN ? AND collection != ?",
 		utils.COLLECTION_APPROVED, myid, req.ID, authorizedGroups, utils.COLLECTION_APPROVED); result.Error != nil {
 		log.Printf("Failed to approve message %d: %v", req.ID, result.Error)
 	}

--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -553,6 +553,17 @@ func GetMessagesByIds(myid uint64, ids []string, isPartner bool) []Message {
 				"INNER JOIN `groups` g ON mp.groupid = g.id "+
 				"WHERE mp.msgid = ? ORDER BY mp.date ASC", id).Scan(&messagePostings)
 
+			// Suppress contentcheck_reasons for approved groups: the warning is only
+			// relevant while a post is pending moderation. Clearing it in the
+			// response means already-approved posts no longer show the IP-abuse
+			// (and other) warnings without requiring a DB back-fill (retrospective
+			// fix for Discourse #9768 post 5).
+			for i := range messageGroups {
+				if messageGroups[i].Collection == utils.COLLECTION_APPROVED {
+					messageGroups[i].ContentcheckReasons = nil
+				}
+			}
+
 			message.MessageGroups = messageGroups
 			message.Expiresat = computeExpiresat(db, message.Type, messageGroups)
 			message.MessageAttachments = messageAttachments

--- a/iznik-server-go/test/message_test.go
+++ b/iznik-server-go/test/message_test.go
@@ -850,6 +850,59 @@ func TestApproveMessageClearsContentcheckReasons(t *testing.T) {
 	assert.Nil(t, reasonsAfter, "contentcheck_reasons must be cleared when a message is approved")
 }
 
+// TestAlreadyApprovedMessageSuppressesContentcheckReasonsInAPIResponse verifies the
+// retrospective fix for Discourse #9768 post 5: posts that were already in
+// collection='Approved' with contentcheck_reasons still set in the DB (approved before
+// the DB-level clear was deployed) must NOT have contentcheck_reasons returned by the
+// GET /api/message/:id endpoint. This ensures the IP-abuse warning is not shown to
+// moderators on such historical records without requiring a DB back-fill.
+func TestAlreadyApprovedMessageSuppressesContentcheckReasonsInAPIResponse(t *testing.T) {
+	prefix := uniquePrefix("msgmod_retro_ccr")
+	db := database.DBConn
+
+	groupID := CreateTestGroup(t, prefix)
+	posterID := CreateTestUser(t, prefix+"_poster", "User")
+	modID := CreateTestUser(t, prefix+"_mod", "User")
+	CreateTestMembership(t, posterID, groupID, "Member")
+	CreateTestMembership(t, modID, groupID, "Moderator")
+	_, modToken := CreateTestSession(t, modID)
+
+	// Insert a message directly in Approved collection with contentcheck_reasons set —
+	// simulating a historical record approved before the DB-level clear was deployed.
+	db.Exec("INSERT INTO messages (fromuser, subject, textbody, message, type, arrival, date) VALUES (?, ?, 'Test body', 'Test body', 'Offer', NOW(), NOW())",
+		posterID, prefix+" retro ip abuse offer")
+	var msgID uint64
+	db.Raw("SELECT id FROM messages WHERE fromuser = ? AND subject = ? ORDER BY id DESC LIMIT 1",
+		posterID, prefix+" retro ip abuse offer").Scan(&msgID)
+	require.NotZero(t, msgID)
+
+	ipAbuseReasons := `[{"check":"IpAbuse","action":"flag","detail":"IP shared by many users","ip":"192.0.2.1"}]`
+	db.Exec("INSERT INTO messages_groups (msgid, groupid, arrival, collection, autoreposts, contentcheck_checked_at, contentcheck_reasons) VALUES (?, ?, NOW(), 'Approved', 0, NOW(), ?)",
+		msgID, groupID, ipAbuseReasons)
+
+	// Pre-condition: contentcheck_reasons IS set in the DB (stale historical data).
+	var rawInDB *string
+	db.Raw("SELECT contentcheck_reasons FROM messages_groups WHERE msgid = ? AND groupid = ?", msgID, groupID).Scan(&rawInDB)
+	require.NotNil(t, rawInDB, "pre-condition: contentcheck_reasons must be set in DB to simulate historical data")
+
+	// Fetch the message via the API as a moderator.
+	req := httptest.NewRequest("GET", fmt.Sprintf("/api/message/%d?jwt=%s", msgID, modToken), nil)
+	resp, err := getApp().Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var msg message.Message
+	json2.Unmarshal(rsp(resp), &msg)
+	require.NotEmpty(t, msg.MessageGroups, "response must include groups")
+
+	for _, mg := range msg.MessageGroups {
+		if mg.Groupid == groupID {
+			assert.Nil(t, mg.ContentcheckReasons,
+				"contentcheck_reasons must not be returned for an approved group (retrospective fix)")
+		}
+	}
+}
+
 // TestApproveAddsApprovedMessageToSpatial verifies that a Pending message with a
 // location is not in messages_spatial, and that approving it adds it (so it then
 // shows in the public browse) with the correct coordinates.

--- a/iznik-server-go/test/message_test.go
+++ b/iznik-server-go/test/message_test.go
@@ -799,6 +799,57 @@ func TestPostMessageApprove(t *testing.T) {
 	// (not synchronously in the Go API), so no log or push_notify_group_mods assertions here.
 }
 
+// TestApproveMessageClearsContentcheckReasons verifies that approving a pending
+// message clears contentcheck_reasons so the IpAbuse (and other) warnings are not
+// shown to moderators after the post has been approved.
+// Discourse #9768 post 5: moderator reports IP-abuse warning still showing on posts
+// approved 2 days ago.
+func TestApproveMessageClearsContentcheckReasons(t *testing.T) {
+	prefix := uniquePrefix("msgmod_appr_ccr")
+	db := database.DBConn
+
+	groupID := CreateTestGroup(t, prefix)
+	posterID := CreateTestUser(t, prefix+"_poster", "User")
+	modID := CreateTestUser(t, prefix+"_mod", "User")
+	CreateTestMembership(t, posterID, groupID, "Member")
+	CreateTestMembership(t, modID, groupID, "Moderator")
+	_, modToken := CreateTestSession(t, modID)
+
+	// Create a pending message with an IpAbuse contentcheck_reasons entry —
+	// simulating what ContentCheckService writes when it detects shared-IP abuse.
+	var locationID uint64
+	db.Raw("SELECT id FROM locations LIMIT 1").Scan(&locationID)
+	db.Exec("INSERT INTO messages (fromuser, subject, textbody, message, type, locationid, arrival, date) VALUES (?, ?, 'Test body', 'Test body', 'Offer', ?, NOW(), NOW())",
+		posterID, prefix+" ip abuse offer", locationID)
+	var msgID uint64
+	db.Raw("SELECT id FROM messages WHERE fromuser = ? AND subject = ? ORDER BY id DESC LIMIT 1",
+		posterID, prefix+" ip abuse offer").Scan(&msgID)
+	require.NotZero(t, msgID)
+
+	ipAbuseReasons := `[{"check":"IpAbuse","action":"flag","detail":"IP shared by many users","ip":"192.0.2.1"}]`
+	db.Exec("INSERT INTO messages_groups (msgid, groupid, arrival, collection, autoreposts, contentcheck_checked_at, contentcheck_reasons) VALUES (?, ?, NOW(), 'Pending', 0, NOW(), ?)",
+		msgID, groupID, ipAbuseReasons)
+
+	// Pre-condition: contentcheck_reasons must be set.
+	var reasonsBefore *string
+	db.Raw("SELECT contentcheck_reasons FROM messages_groups WHERE msgid = ? AND groupid = ?", msgID, groupID).Scan(&reasonsBefore)
+	require.NotNil(t, reasonsBefore, "pre-condition: contentcheck_reasons must be set before approve")
+
+	// Approve the message as a moderator.
+	body, _ := json.Marshal(map[string]interface{}{"id": msgID, "action": "Approve"})
+	req := httptest.NewRequest("POST", fmt.Sprintf("/api/message?jwt=%s", modToken), bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := getApp().Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	// Post-condition: contentcheck_reasons must be NULL after approval so the
+	// IP-abuse warning is no longer shown to moderators.
+	var reasonsAfter *string
+	db.Raw("SELECT contentcheck_reasons FROM messages_groups WHERE msgid = ? AND groupid = ?", msgID, groupID).Scan(&reasonsAfter)
+	assert.Nil(t, reasonsAfter, "contentcheck_reasons must be cleared when a message is approved")
+}
+
 // TestApproveAddsApprovedMessageToSpatial verifies that a Pending message with a
 // location is not in messages_spatial, and that approving it adds it (so it then
 // shows in the public browse) with the correct coordinates.


### PR DESCRIPTION
## Root Cause

The IP-abuse (and other contentcheck) warning was shown to moderators on posts already in `collection='Approved'` because the GET `/api/message/:id` endpoint returned `contentcheck_reasons` from `messages_groups` unconditionally — regardless of whether the message was Pending or Approved.

Prior fix (commit 3bd5d19) cleared `contentcheck_reasons` in the DB at approval time, which prevents new approvals from persisting the flag. However, messages approved _before_ that fix was deployed still carry stale `contentcheck_reasons` in the DB — the root cause of the reporter's complaint: "still showing on posts approved 2 days ago."

**Complete fix (this re-attempt):** In addition to the DB-level clear at approval time, the API response builder now suppresses `ContentcheckReasons` for any `messages_groups` row whose `collection = 'Approved'`. This is retrospective: no DB back-fill is required, and the warning vanishes immediately for all already-approved historical records.

## Evidence

**Test FAILS on unfixed code (3187✓ 1✗):**
```
=== RUN   TestAlreadyApprovedMessageSuppressesContentcheckReasonsInAPIResponse
    message_test.go:900:
        Error:      Expected nil, but got: &json.RawMessage{...IpAbuse...}
        Messages:   contentcheck_reasons must not be returned for an approved group (retrospective fix)
--- FAIL: TestAlreadyApprovedMessageSuppressesContentcheckReasonsInAPIResponse (0.06s)
FAIL
```

**After fix: All 3188 tests pass (3188✓)**
```
--- PASS: TestApproveMessageClearsContentcheckReasons (0.54s)
--- PASS: TestAlreadyApprovedMessageSuppressesContentcheckReasonsInAPIResponse (0.42s)
```

## Fix

**`iznik-server-go/message/message.go`** — after fetching `messages_groups`, before building the response: iterate over message groups and set `ContentcheckReasons = nil` for any group with `collection = 'Approved'`. The warning is only relevant during pending moderation; clearing it in the response makes the fix retrospective.

**Already included from prior commit:** `handleApprove` sets `contentcheck_reasons = NULL` in the UPDATE so future approvals keep the DB clean. `AutoApproveService.php` also clears it on the 48h auto-approve path.

## Other Call Sites

`contentcheck_reasons` is fetched from `messages_groups` in exactly one SQL query in the Go API (line 449 of `message.go`); the suppression loop applies immediately after. No other Go call sites.

PHP batch services (`ContentCheckService`, `AutoApproveService`) already clear `contentcheck_reasons` on their own approval paths.

## Test

| Test | File | Proves |
|------|------|--------|
| `TestAlreadyApprovedMessageSuppressesContentcheckReasonsInAPIResponse` | `iznik-server-go/test/message_test.go` | Retrospective fix: GET response omits `contentcheck_reasons` for an already-approved message that still has stale data in the DB |
| `TestApproveMessageClearsContentcheckReasons` | `iznik-server-go/test/message_test.go` | Forward-path fix: approving via API clears `contentcheck_reasons` in DB |

Run: `curl -s -X POST http://localhost:8081/api/tests/go -d '{"filter":"TestAlreadyApproved|TestApproveMessageClears"}'`

## Discourse
https://discourse.ilovefreegle.org/t/9768/5
