### PR TITLE
fix(digest): wrap summary links in <div> for Outlook Classic line-break rendering

### DIFF
--- a/iznik-batch/resources/views/emails/mjml/digest/unified.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/digest/unified.blade.php
@@ -236,7 +236,7 @@
             $summaryPosts = collect($posts);
             $summaryVisible = \App\Mail\Digest\DigestStyle::SUMMARY_VISIBLE_LINES;
             $summaryHidden = $summaryPosts->slice($summaryVisible);
-            $summaryLink = 'color: ' . \App\Mail\Digest\DigestStyle::OFFER_GREEN . '; text-decoration: none; display: block; margin-bottom: 4px;';
+            $summaryLink = 'color: ' . \App\Mail\Digest\DigestStyle::OFFER_GREEN . '; text-decoration: none;';
         @endphp
         @if($summaryPosts->count() >= 2)
         <mj-section background-color="#ffffff" padding="16px 20px 4px">
@@ -246,14 +246,14 @@
                 </mj-text>
                 <mj-text font-size="14px" color="#212529" line-height="1.6" padding="0">
                     @foreach($summaryPosts->take($summaryVisible) as $summaryPost)
-                    <a href="{{ $summaryPost['summaryUrl'] }}" style="{{ $summaryLink }}">{{ $summaryPost['subject'] }}</a>
+                    <div style="margin-bottom: 4px;"><a href="{{ $summaryPost['summaryUrl'] }}" style="{{ $summaryLink }}">{{ $summaryPost['subject'] }}</a></div>
                     @endforeach
                     @if($summaryHidden->isNotEmpty())
                     <details style="margin-top: 2px;">
                         <summary style="cursor: pointer; color: {{ \App\Mail\Digest\DigestStyle::OFFER_GREEN }}; font-weight: 600;">Show {{ $summaryHidden->count() }} more</summary>
                         <div style="margin-top: 6px;">
                             @foreach($summaryHidden as $summaryPost)
-                            <a href="{{ $summaryPost['summaryUrl'] }}" style="{{ $summaryLink }}">{{ $summaryPost['subject'] }}</a>
+                            <div style="margin-bottom: 4px;"><a href="{{ $summaryPost['summaryUrl'] }}" style="{{ $summaryLink }}">{{ $summaryPost['subject'] }}</a></div>
                             @endforeach
                         </div>
                     </details>

--- a/iznik-batch/tests/Unit/Mail/UnifiedDigestSummaryTest.php
+++ b/iznik-batch/tests/Unit/Mail/UnifiedDigestSummaryTest.php
@@ -157,6 +157,9 @@ class UnifiedDigestSummaryTest extends TestCase
                 'heroImageUrl' => 'https://example.com/hero.png',
                 'displayImageUrl' => 'https://example.com/img.png',
                 'isPlaceholder' => false,
+                'postedToText' => null,
+                'metaText' => null,
+                'isOwnPost' => false,
             ]);
         }
 
@@ -183,6 +186,7 @@ class UnifiedDigestSummaryTest extends TestCase
             ])->toArray(),
             'ampApiUrl' => 'https://api.example.com/amp',
             'ampUserId' => 42,
+            'accentColor' => \App\Mail\Digest\DigestStyle::OFFER_GREEN,
         ];
     }
 
@@ -260,6 +264,28 @@ class UnifiedDigestSummaryTest extends TestCase
         // No overflow → no collapsible control ("Show N more" only ever
         // appears inside the <details>, so its absence proves no collapse).
         $this->assertStringNotContainsString('<details', $html);
+    }
+
+    public function test_html_summary_links_wrapped_in_div_for_outlook_compatibility(): void
+    {
+        // Discourse t/9363/31: Outlook Classic (Word HTML rendering engine) ignores
+        // CSS `display:block` on inline <a> elements, so summary items ran together
+        // with no visible line breaks. Fix: each summary <a> must be wrapped in a
+        // <div> block element, which Outlook's Word engine does respect.
+        // Uses direct view rendering (same pattern as AMP tests) since the MJML
+        // content inside <mj-text> is passed through verbatim to compiled HTML.
+        $mjml = view('emails.mjml.digest.unified', $this->summaryViewData(3))->render();
+
+        $this->assertStringContainsString('In this digest', $mjml);
+
+        // Each visible summary link must appear as <div...><a href="..."> — not as
+        // a bare <a style="display:block"> that Outlook Classic silently ignores.
+        $this->assertMatchesRegularExpression(
+            '/<div[^>]*>\s*<a\s[^>]*href="https:\/\/example\.com\/message\/1000"/',
+            $mjml,
+            'Summary links must be wrapped in <div> for Outlook classic compatibility (t/9363/31); '
+            . 'bare <a style="display:block"> is ignored by Outlook\'s Word rendering engine'
+        );
     }
 
     public function test_html_immediate_single_post_has_no_summary_index(): void


### PR DESCRIPTION
## Root Cause

The \"In this digest\" summary index uses `\$summaryLink` CSS applied directly to `<a>` elements (including `display: block; margin-bottom: 4px`). Outlook Classic's Word rendering engine ignores `display:block` on inline elements like `<a>`, so all summary items ran together on the same line with no visible separation.

Affected template: `iznik-batch/resources/views/emails/mjml/digest/unified.blade.php` lines 239–257 (both the visible list and the `<details>` overflow block).

## Evidence

Before fix (origin/master, line 249):
```html
<a href="..." style="color: ...; text-decoration: none; display: block; margin-bottom: 4px;">Alpha</a>
<a href="..." style="color: ...; text-decoration: none; display: block; margin-bottom: 4px;">Bravo</a>
```
Outlook Classic renders these inline — items run together.

After fix:
```html
<div style="margin-bottom: 4px;"><a href="..." style="color: ...; text-decoration: none;">Alpha</a></div>
<div style="margin-bottom: 4px;"><a href="..." style="color: ...; text-decoration: none;">Bravo</a></div>
```
Outlook Classic respects `<div>` as a block element — each item on its own line.

Regression test asserts `/<div[^>]*>\s*<a\s[^>]*href=.../` — fails on master, passes on fix branch.

## Fix

- Removed `display: block; margin-bottom: 4px;` from `\$summaryLink` inline style (the `<a>` no longer carries the block layout)
- Wrapped each summary `<a>` in `<div style="margin-bottom: 4px;">` — Outlook Classic's Word engine treats `<div>` as block-level, creating a line break after each item
- Applied to both the visible summary section and the collapsed `<details>` overflow block
- Also fixes `summaryViewData()` fixture to include `postedToText`/`metaText`/`isOwnPost`/`accentColor` so direct view rendering covers the full MJML template

## Other Call Sites

The `\$summaryLink` pattern (bare `<a>` with `display:block`) is used only in `unified.blade.php` (two foreach loops). The AMP digest uses `<a class="summary-link">` with a stylesheet CSS class — AMP is never sent to Outlook Classic, so no change needed there. No other email templates use the same pattern.

## Test

File: `iznik-batch/tests/Unit/Mail/UnifiedDigestSummaryTest.php`
Test: `test_html_summary_links_wrapped_in_div_for_outlook_compatibility`
Command: `POST http://localhost:8081/api/tests/laravel {"filter": "UnifiedDigestSummaryTest"}`

Proves: renders the MJML blade directly (MJML content inside `<mj-text>` passes through verbatim), then asserts each visible summary link is preceded by `<div>`. Fails on master (bare `<a>`), passes on fix branch.

## Discourse

https://discourse.ilovefreegle.org/t/9363/31

🤖 Generated with [Claude Code](https://claude.com/claude-code)