### PR TITLE
fix(contentcheck): use item name for subject-repeat length guard (V1 parity)

### DIFF
--- a/iznik-batch/app/Services/ContentCheckService.php
+++ b/iznik-batch/app/Services/ContentCheckService.php
@@ -148,7 +148,7 @@ class ContentCheckService
         if ($r = $this->checkLanguage($subject, $textbody)) {
             $reasons[] = $r;
         }
-        if ($r = $this->checkSubjectRepeat($subject, $msgid)) {
+        if ($r = $this->checkSubjectRepeat($subject, $msgid, $itemName)) {
             $reasons[] = $r;
         }
         if ($r = $this->checkKnownSpammer($textbody)) {
@@ -1343,10 +1343,14 @@ class ContentCheckService
     // checkSubjectRepeat — flag mass-submission spam (V1 parity)
     // -------------------------------------------------------------------------
 
-    public function checkSubjectRepeat(string $subject, int $msgid): ?array
+    public function checkSubjectRepeat(string $subject, int $msgid, ?string $itemName = null): ?array
     {
-        // Don't check very short subjects - might be something like "TAKEN"
-        if (strlen(trim($subject)) < 10) {
+        // V1 parity: use the item name (pruned subject) for the length guard, not the full
+        // subject. The type prefix ("Offer: ") adds 7+ chars, making "Offer: Test" 11 chars
+        // but the actual item is "Test" (4 chars). Without this, test subjects accumulate
+        // across many groups over time and falsely flag legitimate mod/tester posts.
+        $textToCheck = ($itemName !== null && trim($itemName) !== '') ? trim($itemName) : trim($subject);
+        if (strlen($textToCheck) < 10) {
             return null;
         }
 

--- a/iznik-batch/tests/Feature/Message/ContentCheckTest.php
+++ b/iznik-batch/tests/Feature/Message/ContentCheckTest.php
@@ -1440,6 +1440,71 @@ class ContentCheckTest extends TestCase
         $this->assertNull($result, 'Subject older than 7 days should not be flagged');
     }
 
+    public function test_subject_repeat_not_flagged_for_short_item_name_test_post(): void
+    {
+        // Regression: "Offer: Test" is 11 chars and was NOT skipped by the < 10 guard,
+        // so common test-post subjects accumulated across many groups and falsely flagged
+        // legitimate mod/tester posts. V1 parity: use the item name ("Test" = 4 chars)
+        // for the length guard, not the full subject. See Discourse 9788/28.
+        $subject = 'Offer: Test';
+
+        // Simulate 30 prior posts with the same subject from different groups (as happens
+        // when many mods routinely post "Offer: Test" messages to their own groups).
+        $groups = [];
+        for ($i = 0; $i < 30; $i++) {
+            $groups[] = $this->createTestGroup();
+        }
+
+        $priorUser = $this->createTestUser();
+        $priorMsgId = DB::table('messages')->insertGetId([
+            'fromuser' => $priorUser->id,
+            'type'     => 'Offer',
+            'subject'  => $subject,
+            'textbody' => 'Test',
+            'message'  => 'Test',
+            'arrival'  => now(),
+            'date'     => now(),
+            'source'   => 'Platform',
+        ]);
+
+        foreach ($groups as $group) {
+            DB::table('messages_groups')->insert([
+                'msgid'      => $priorMsgId,
+                'groupid'    => $group->id,
+                'collection' => 'Pending',
+                'arrival'    => now(),
+                'deleted'    => 0,
+            ]);
+        }
+
+        // A new mod now posts "Offer: Test" — with item name "Test" (< 10 chars).
+        // V1 would skip the subject-repeat check (item name "Test" < 10 chars);
+        // the regression caused it to NOT skip and falsely flag.
+        $newUser = $this->createTestUser();
+        $newGroup = $this->createTestGroup();
+        $newMsgId = DB::table('messages')->insertGetId([
+            'fromuser' => $newUser->id,
+            'type'     => 'Offer',
+            'subject'  => $subject,
+            'textbody' => 'Test',
+            'message'  => 'Test',
+            'arrival'  => now(),
+            'date'     => now(),
+            'source'   => 'Platform',
+        ]);
+        DB::table('messages_groups')->insert([
+            'msgid'      => $newMsgId,
+            'groupid'    => $newGroup->id,
+            'collection' => 'Pending',
+            'arrival'    => now(),
+            'deleted'    => 0,
+        ]);
+
+        $result = $this->service->checkSubjectRepeat($subject, $newMsgId, 'Test');
+
+        $this->assertNull($result, 'Short item name "Test" should not trigger subject-repeat flag even when 30+ prior posts exist');
+    }
+
     // -------------------------------------------------------------------------
     // checkKnownSpammer — flag messages containing spammer email (V1 parity)
     // -------------------------------------------------------------------------

--- a/iznik-batch/tests/Feature/Message/ContentCheckTest.php
+++ b/iznik-batch/tests/Feature/Message/ContentCheckTest.php
@@ -1442,14 +1442,16 @@ class ContentCheckTest extends TestCase
 
     public function test_subject_repeat_not_flagged_for_short_item_name_test_post(): void
     {
-        // Regression: "Offer: Test" is 11 chars and was NOT skipped by the < 10 guard,
-        // so common test-post subjects accumulated across many groups and falsely flagged
-        // legitimate mod/tester posts. V1 parity: use the item name ("Test" = 4 chars)
-        // for the length guard, not the full subject. See Discourse 9788/28.
+        // Regression (Discourse 9788/28): "Offer: Test" is 11 chars and was NOT skipped
+        // by the < 10 guard, so common test-post subjects accumulated across many groups
+        // over time and falsely flagged legitimate mod/tester posts.
+        // Root cause: the old code checked strlen(full subject) instead of strlen(item name).
+        // "Offer: Test" = 11 chars passes the guard; "Test" = 4 chars does not.
+        // Fix: checkSubjectRepeat now accepts $itemName and guards on item name length.
         $subject = 'Offer: Test';
 
-        // Simulate 30 prior posts with the same subject from different groups (as happens
-        // when many mods routinely post "Offer: Test" messages to their own groups).
+        // Simulate 30 prior "Offer: Test" posts from different groups (as accumulates
+        // naturally when mods routinely post Test messages to verify their groups).
         $groups = [];
         for ($i = 0; $i < 30; $i++) {
             $groups[] = $this->createTestGroup();
@@ -1477,9 +1479,7 @@ class ContentCheckTest extends TestCase
             ]);
         }
 
-        // A new mod now posts "Offer: Test" — with item name "Test" (< 10 chars).
-        // V1 would skip the subject-repeat check (item name "Test" < 10 chars);
-        // the regression caused it to NOT skip and falsely flag.
+        // A new mod posts "Offer: Test" to their own group.
         $newUser = $this->createTestUser();
         $newGroup = $this->createTestGroup();
         $newMsgId = DB::table('messages')->insertGetId([
@@ -1500,9 +1500,19 @@ class ContentCheckTest extends TestCase
             'deleted'    => 0,
         ]);
 
-        $result = $this->service->checkSubjectRepeat($subject, $newMsgId, 'Test');
+        // BUG (old code path): calling WITHOUT $itemName uses the full subject
+        // "Offer: Test" (11 chars >= 10), so the guard does not fire. With 30+
+        // groups in the window, the repeat check triggers and flags the message.
+        // This proves the DB state is correct and the bug is real.
+        $buggyPathResult = $this->service->checkSubjectRepeat($subject, $newMsgId);
+        $this->assertNotNull($buggyPathResult, 'Without itemName, "Offer: Test" (11 chars) passes the length guard and 30+ groups causes a false flag — this confirms the bug exists');
+        $this->assertEquals('SubjectRepeat', $buggyPathResult['check']);
 
-        $this->assertNull($result, 'Short item name "Test" should not trigger subject-repeat flag even when 30+ prior posts exist');
+        // FIX (new code path): calling WITH $itemName='Test' uses the item name
+        // length (4 chars < 10), so the guard fires immediately and returns null.
+        // A real mod "Test" post must not be blocked even with 30+ prior groups.
+        $fixedPathResult = $this->service->checkSubjectRepeat($subject, $newMsgId, 'Test');
+        $this->assertNull($fixedPathResult, 'With itemName="Test" (4 chars < 10), the length guard fires before the group count query — no false flag');
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
## Root Cause

`checkSubjectRepeat` in `ContentCheckService` used the **full message subject** (`"Offer: Test"` = 11 chars) for its `< 10` char skip-guard. Common test subjects like `"Offer: Test"` exceed the threshold, so they accumulate across groups whenever mods/testers post. Once ≥ 30 distinct groups have received that exact subject in the past 7 days, every new `"Offer: Test"` post is falsely flagged and left Pending.

V1's `Spam.php` used `getPrunedSubject()` (item name only, stripping type prefix) for the length check — `"Test"` is 4 chars < 10 → always skipped. The Laravel port checked the full subject instead, losing that protection.

## Evidence

**Bug path** — calling without `$itemName` (as the old code did) with 30+ groups, `"Offer: Test"` (11 chars) passes the length guard and the repeat check fires:
```
$buggyPathResult = $this->service->checkSubjectRepeat($subject, $newMsgId);
assertNotNull($buggyPathResult);  // PASSES — confirms the bug is real
assertEquals('SubjectRepeat', $buggyPathResult['check']);
```

**Fix path** — calling with `$itemName='Test'` (4 chars < 10), the length guard fires immediately:
```
$fixedPathResult = $this->service->checkSubjectRepeat($subject, $newMsgId, 'Test');
assertNull($fixedPathResult);  // PASSES — legitimate mod test-post not blocked
```

## Fix

`checkSubjectRepeat` accepts an optional `$itemName` parameter. When provided, it guards on item name length instead of the full subject. `checkMessage` passes `$itemName` (already fetched for other checks). Short item names like `"Test"` (4 chars < 10) skip the repeat check entirely, matching V1 behaviour.

**How this differs from the rejected approach**: The original PR #795 test only asserted the fixed path — the item-name guard fired immediately so the 30-group DB setup was never exercised and the bug was never proven to exist. This re-attempt adds a `assertNotNull` on the OLD code path (no `$itemName`) which proves the 30-group state actually triggers the flag, before asserting the fix prevents it.

## Other Call Sites

`checkSubjectRepeat` is only called from `checkMessage` (line 151). No other call sites.

## Test

**File**: `iznik-batch/tests/Feature/Message/ContentCheckTest.php`  
**Method**: `test_subject_repeat_not_flagged_for_short_item_name_test_post`  
**Command**: `curl -X POST http://localhost:8081/api/tests/laravel -d '{"filter":"ContentCheckTest"}'`  
**Proves**: fail-before (buggyPathResult assertNotNull) → pass-after (fixedPathResult assertNull); all 149 ContentCheckTest tests pass.

## Discourse

https://discourse.ilovefreegle.org/t/9788/28