### PR TITLE
fix(batch): drift-free scheduler via schedule:work so dailyAt minutes don't get skipped

### DIFF
--- a/iznik-batch/docker/supervisor.conf
+++ b/iznik-batch/docker/supervisor.conf
@@ -6,7 +6,13 @@ pidfile=/var/run/supervisord.pid
 
 [program:laravel-scheduler]
 process_name=%(program_name)s
-command=/bin/bash -c "while true; do php /var/www/html/artisan schedule:run --verbose --no-interaction >> /var/www/html/storage/logs/scheduler.log 2>&1; sleep 60; done"
+# schedule:work runs schedule:run aligned to each clock minute and never drifts.
+# The previous "while true; schedule:run; sleep 60" loop accumulated ~1s/minute of
+# drift (schedule:run dispatch time + a flat 60s sleep), so roughly once an hour the
+# loop straddled a minute boundary and skipped a whole clock minute. Any job pinned to
+# an exact ->dailyAt('HH:MM') minute could then silently never fire — e.g. on
+# 2026-06-18 the 02:30 minute was dropped and stats:generate-daily never ran.
+command=php /var/www/html/artisan schedule:work --no-interaction
 autostart=true
 autorestart=true
 user=root


### PR DESCRIPTION
## Problem

`monitor:scheduled-outcomes` alerted (Sentry 7559501667) that `stats:generate-daily` produced 0 rows for 2026-06-17 — *"did it run?"*. It didn't, but the command is fine; the cause is the scheduler loop.

The `laravel-scheduler` supervisor program ran:

```bash
while true; do php artisan schedule:run; sleep 60; done
```

Each iteration takes ~61s (dispatching ~25 background jobs + a flat `sleep 60`), so the loop drifts ~1s/minute. Roughly once an hour the loop straddles a clock-minute boundary and skips that whole minute of `schedule:run`. Any job pinned to an exact `->dailyAt('HH:MM')` then silently never fires.

Evidence from `scheduler.log` on 2026-06-18:

```
02:29:58 Running ...
02:31:00 Running ...   <-- the 02:30 minute was never sampled
02:32:01 Running ...
```

`stats:generate-daily` (`->dailyAt('02:30')`) is the only job on the 02:30 minute, so the per-group `stats` rows for 2026-06-17 were never generated.

## Fix

Switch the scheduler to `php artisan schedule:work`, Laravel's purpose-built runner that fires `schedule:run` aligned to the top of each clock minute and never drifts. This removes the whole class of bug for every `dailyAt` job, not just stats.

## Operational steps already taken on batch-prod

- Hot-patched the running container's supervisor program to `schedule:work` and restarted it — verified ticks now fire at `:00` aligned, no drift. (Hot-patch holds until the image is rebuilt with this change.)
- Backfilled the missing 2026-06-17 stats via `stats:generate-daily --date=2026-06-17` (idempotent REPLACE).

## Deploy

`supervisor.conf` is COPY'd into the image (not bind-mounted), so this takes effect on the next **batch-prod rebuild**. No test suite covers supervisor config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)