### PR TITLE
fix(batch): retry Discourse rate-limits so the not-signed-up report isn't inflated

### DIFF
--- a/iznik-batch/app/Services/DiscourseClient.php
+++ b/iznik-batch/app/Services/DiscourseClient.php
@@ -44,6 +44,59 @@ class DiscourseClient
     }
 
     /**
+     * GET a Discourse JSON endpoint, mirroring V1 Utils::curlWithRetry + the
+     * per-call error check the callers (GetAllUsers/GetUser/GetUserEmail) did.
+     *
+     * Discourse rate-limits the admin API aggressively. V1 retried on HTTP 429
+     * (or an "errors" body containing "too many") up to 60× with a 1s delay,
+     * and threw on any other error response — so the run aborted loudly rather
+     * than emailing a report built on partially-resolved Discourse users. The
+     * earlier port did neither: a 429 silently became a body with no
+     * single_sign_on_record, so the mod looked absent from Discourse and their
+     * groups were falsely flagged NOT REPRESENTED. Restore the retry + throw.
+     *
+     * @param  array<string, mixed>  $query
+     * @return array<string, mixed>
+     */
+    private function getJson(string $url, array $query = []): array
+    {
+        $maxRetries = max(1, (int) config('freegle.discourse.max_retries', 60));
+        $retryDelay = max(0, (int) config('freegle.discourse.retry_delay_s', 1));
+
+        for ($attempt = 1; ; $attempt++) {
+            $resp = $this->request()->get($url, $query);
+            $data = $resp->json();
+            $errors = is_array($data) && isset($data['errors']) ? (array) $data['errors'] : [];
+
+            $rateLimited = $resp->status() === 429;
+            foreach ($errors as $error) {
+                if (stripos((string) $error, 'too many') !== false) {
+                    $rateLimited = true;
+                }
+            }
+
+            if ($rateLimited) {
+                if ($attempt >= $maxRetries) {
+                    throw new \RuntimeException("Discourse: max retries ($maxRetries) exceeded due to rate limiting: {$url}");
+                }
+                if ($retryDelay > 0) {
+                    sleep($retryDelay);
+                }
+                continue;
+            }
+
+            if (!is_array($data)) {
+                throw new \RuntimeException("Discourse: unexpected non-JSON response (HTTP {$resp->status()}): {$url}");
+            }
+            if ($errors !== []) {
+                throw new \RuntimeException('Discourse: '.implode(', ', $errors).": {$url}");
+            }
+
+            return $data;
+        }
+    }
+
+    /**
      * All trust_level_0 members (effectively every user), first 1000 — overrides
      * Discourse's default page size of 20.
      *
@@ -51,15 +104,13 @@ class DiscourseClient
      */
     public function getAllUsers(): array
     {
-        $resp = $this->request()->get($this->baseUrl.'/groups/trust_level_0/members.json', [
+        $data = $this->getJson($this->baseUrl.'/groups/trust_level_0/members.json', [
             'limit' => 1000,
             'offset' => 0,
         ]);
-        $data = $resp->json();
 
-        if (!is_array($data) || !isset($data['members'])) {
-            $err = is_array($data) && isset($data['errors']) ? implode(', ', (array) $data['errors']) : 'unexpected response';
-            throw new \RuntimeException('Discourse getAllUsers: '.$err);
+        if (!isset($data['members'])) {
+            throw new \RuntimeException('Discourse getAllUsers: unexpected response (no members)');
         }
 
         return $data['members'];
@@ -73,14 +124,14 @@ class DiscourseClient
      */
     public function getUser(int $id, string $username): array
     {
-        return (array) $this->request()->get($this->baseUrl."/admin/users/{$id}/{$username}.json")->json();
+        return $this->getJson($this->baseUrl."/admin/users/{$id}/{$username}.json");
     }
 
     /** The user's primary email address. */
     public function getUserEmail(string $username): string
     {
-        $data = $this->request()->get($this->baseUrl."/users/{$username}/emails.json")->json();
+        $data = $this->getJson($this->baseUrl."/users/{$username}/emails.json");
 
-        return is_array($data) ? (string) ($data['email'] ?? '') : '';
+        return (string) ($data['email'] ?? '');
     }
 }

--- a/iznik-batch/config/freegle.php
+++ b/iznik-batch/config/freegle.php
@@ -119,6 +119,11 @@ return [
         'url' => env('DISCOURSE_URL', 'https://discourse.ilovefreegle.org'),
         'api_key' => env('DISCOURSE_APIKEY', ''),
         'api_username' => env('DISCOURSE_API_USERNAME', 'system'),
+        // Per-user pacing between Discourse API calls (V1 used usleep(250000)).
+        'throttle_us' => (int) env('DISCOURSE_THROTTLE_US', 250000),
+        // Rate-limit retry policy (V1 Utils::curlWithRetry: 60 retries, 1s delay).
+        'max_retries' => (int) env('DISCOURSE_MAX_RETRIES', 60),
+        'retry_delay_s' => (int) env('DISCOURSE_RETRY_DELAY_S', 1),
     ],
 
     // PayPal NVP/SOAP API (V1 paypal_download.php fallback transaction downloader).

--- a/iznik-batch/tests/Unit/Services/DiscourseClientTest.php
+++ b/iznik-batch/tests/Unit/Services/DiscourseClientTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Services\DiscourseClient;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+/**
+ * The Discourse REST client mirrors V1 Utils::curlWithRetry + the per-call
+ * error check the V1 callers did: retry on rate-limiting (HTTP 429 or an
+ * "errors" body containing "too many"), throw on persistent rate-limiting or
+ * any other error response. The earlier port swallowed these, so a throttled
+ * getUser silently dropped that Discourse user and falsely flagged the groups
+ * they moderate as NOT REPRESENTED.
+ */
+class DiscourseClientTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config([
+            'freegle.discourse.url' => 'https://discourse.test',
+            'freegle.discourse.api_key' => 'test-key',
+            'freegle.discourse.api_username' => 'system',
+            'freegle.discourse.max_retries' => 5,
+            'freegle.discourse.retry_delay_s' => 0, // don't sleep in tests
+        ]);
+    }
+
+    public function test_get_user_retries_on_http_429_then_succeeds(): void
+    {
+        Http::fakeSequence()
+            ->push(['errors' => ['Too many requests']], 429)
+            ->push(['errors' => ['Too many requests']], 429)
+            ->push(['single_sign_on_record' => ['external_id' => '12345']], 200);
+
+        $user = (new DiscourseClient())->getUser(1, 'alice');
+
+        $this->assertSame('12345', $user['single_sign_on_record']['external_id']);
+        Http::assertSentCount(3);
+    }
+
+    public function test_get_user_retries_when_body_says_too_many(): void
+    {
+        // A 200 whose body carries a "too many" error is still rate-limiting.
+        Http::fakeSequence()
+            ->push(['errors' => ['You have performed this action too many times']], 200)
+            ->push(['single_sign_on_record' => ['external_id' => '7']], 200);
+
+        $user = (new DiscourseClient())->getUser(7, 'bob');
+
+        $this->assertSame('7', $user['single_sign_on_record']['external_id']);
+        Http::assertSentCount(2);
+    }
+
+    public function test_get_user_throws_after_max_retries(): void
+    {
+        Http::fake(fn () => Http::response(['errors' => ['Too many requests']], 429));
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/max retries/i');
+
+        (new DiscourseClient())->getUser(1, 'alice');
+    }
+
+    public function test_get_user_throws_on_non_rate_limit_error_body(): void
+    {
+        // A non-rate-limit error must abort loudly, not be swallowed.
+        Http::fake(fn () => Http::response(['errors' => ['The requested URL or resource could not be found.']], 404));
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/could not be found/');
+
+        (new DiscourseClient())->getUser(99, 'ghost');
+    }
+
+    public function test_get_all_users_returns_members(): void
+    {
+        Http::fake(fn () => Http::response(['members' => [['id' => 1, 'username' => 'a']]], 200));
+
+        $members = (new DiscourseClient())->getAllUsers();
+
+        $this->assertCount(1, $members);
+        $this->assertSame('a', $members[0]['username']);
+    }
+
+    public function test_get_user_email_returns_primary_email(): void
+    {
+        Http::fake(fn () => Http::response(['email' => 'mod@example.com'], 200));
+
+        $this->assertSame('mod@example.com', (new DiscourseClient())->getUserEmail('alice'));
+    }
+}


### PR DESCRIPTION
## Problem

`discourse:not-signed-up` decides which Freegle groups are "represented by an active mod" by resolving every Discourse user's MT `external_id` through the admin API (`getUser`). Its NOT REPRESENTED list looked too large.

Cause is a parity gap in `DiscourseClient` vs V1 `discourse_not_signed_up.php`:

- **V1** (`Utils::curlWithRetry` + the `GetUser`/`GetAllUsers`/`GetUserEmail` error checks): retried on rate-limiting — HTTP 429, or an `errors` body containing "too many" — up to **60×** with a 1s delay, and **threw** on any other error response. So V1 never emailed a report built on partially-resolved Discourse users; it either resolved everyone or aborted loudly.
- **Port**: `(array) $this->request()->get(...)->json()` with **no retry and no error check**. A 429 silently became an array with no `single_sign_on_record`, so `getUser` yielded no `external_id`, the mod looked absent from Discourse, and **every group they moderate was falsely flagged NOT REPRESENTED** (and the mod listed under "volunteers not on Discourse").

With ~410 Discourse users each needing a `getUser` call against the aggressively rate-limited admin endpoint (at 250 ms spacing), partial 429s inflate the report by however many users got throttled mid-run. `getUserEmail` had the same no-retry gap (weakened the email fallback). Only `getAllUsers` already threw on a bad response.

## Fix

A single `getJson()` chokepoint mirrors V1: retry on rate-limiting (429 / "too many"), throw after `max_retries`, throw on any other error or non-JSON response. `getAllUsers`/`getUser`/`getUserEmail` all route through it. Retry policy is configurable (`freegle.discourse.max_retries` / `retry_delay_s`, defaulting to V1's 60 / 1s; `throttle_us` now explicit).

This converts silent data corruption (an inflated, untrustworthy report) back into V1's loud-failure-or-correct behaviour.

## Rest of the parity audit

The selection/representation logic itself is a faithful port and was left unchanged: `groups WHERE publish=1`; active mods = `role IN ('Owner','Moderator')` + `groups.type='Freegle'` + `users.lastaccess > now()-6mo`; external_id via SSO with `users_emails` email-fallback; representation gated on `memberships.settings` containing `"active":0`; the not-represented + per-group moderator listing. API endpoints/headers/`limit=1000` all match.

## Tests

New `DiscourseClientTest` (Http::fake): retry-then-succeed on 429, retry on a "too many" body, throw after max retries, throw on a non-rate-limit error body, plus the happy paths. CI runs the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)