### PR TITLE
fix(chitchat): reserve space so reply text clears the "..." menu (Discourse 9749)

### DIFF
--- a/iznik-nuxt3/components/NewsReply.vue
+++ b/iznik-nuxt3/components/NewsReply.vue
@@ -705,6 +705,10 @@ function showReplyPhotoModal() {
 .reply-content {
   flex: 1;
   min-width: 0;
+  /* Reserve a right-hand column so the inline name+text never runs under the
+     absolutely-positioned "..." menu (.reply-menu, right: -1rem). Without this
+     a long first line butts right against the dots (Discourse #9749). */
+  padding-right: 1.5rem;
 }
 
 /* Three dots menu - positioned at top right of the reply */


### PR DESCRIPTION
## Summary

Replaces #785 (which was misdiagnosed as an image-size issue). The real issue from [Discourse 9749](https://discourse.ilovefreegle.org/t/9749/5) ("Silly niggle on chitchat") is the **"…" options menu sitting too close to the post text** — specifically on **replies**.

The reply "…" menu is absolutely positioned at the reply's top-right (`.reply-menu`, `right: -1rem`), but `.reply-content` had no right padding, so a long first line of the inline *name + text* ran right up to (and under) the dots. This is the residual *"mostly good but still the odd one"* (post #5) that the prior fixes (#612/#644, which adjusted `.thread-menu`/`.chat-content`) never reached.

## Fix

`padding-right: 1.5rem` on `.reply-content`, reserving a right-hand column so the inline text always wraps before the menu.

## Verification (in-browser, dev-live, real data)

- **Before:** the PacificTrashVortex reply rendered *"…I still receive replies in"* with "in" butting the dots.
- **After:** it wraps to *"…I still receive"* with a clear gap before the "…". Same improvement on the Jos replies.

## Discourse

https://discourse.ilovefreegle.org/t/9749/5
