### PR TITLE
fix(modtools): gap to the right of the "Joined" calendar icon

### DIFF
--- a/iznik-nuxt3/modtools/components/ModMessageUserInfo.vue
+++ b/iznik-nuxt3/modtools/components/ModMessageUserInfo.vue
@@ -46,7 +46,7 @@
       </span>
     </nuxt-link>
     <span v-if="modinfo && membership" class="ms-2 order-1 order-sm-1 small">
-      <v-icon icon="calendar-alt" />
+      <v-icon icon="calendar-alt" class="me-1" />
       <span :class="joinedAge <= 31 ? 'text-danger' : ''"
         >Joined {{ dateshort(membership.added) }}</span
       >


### PR DESCRIPTION
## Summary

The `calendar-alt` icon on the **Joined <date>** line in ModTools (`ModMessageUserInfo`) sat flush against the text. Added `me-1` so the icon has a small right margin, matching the spacing convention used elsewhere.

Trivial one-class spacing fix (reported directly with a screenshot).