### PR TITLE
fix(modtools): restore duplicate-post highlighting for groups with no stored settings (9518/341)

### DIFF
--- a/iznik-nuxt3/modtools/components/ModMessage.vue
+++ b/iznik-nuxt3/modtools/components/ModMessage.vue
@@ -1041,19 +1041,22 @@ const duplicateAge = computed(() => {
   let check = false
   if (!message.value?.groups) return null
 
+  const msgtype = message.value.type.toLowerCase()
   message.value.groups.forEach((g) => {
     const grp = myModGroup(g.groupid)
+    if (!grp) return
 
-    // console.log("duplicateAge group", group?.settings?.duplicates)
-    if (
-      grp &&
-      grp.settings &&
-      grp.settings.duplicates && // TODO: MT group does not have settings
-      grp.settings.duplicates.check
-    ) {
+    // V1 parity: the group's default settings (Group.php) enable duplicate
+    // detection with a 14-day window. The V2 group API returns only the
+    // stored settings (no default merge), so a group with no explicit
+    // `duplicates` block must fall back to the default rather than silently
+    // disabling duplicate highlighting. Explicit check:0 still turns it off.
+    // (Discourse 9518/341)
+    const dup = grp.settings?.duplicates
+    const enabled = dup?.check ?? true
+    if (enabled) {
       check = true
-      const msgtype = message.value.type.toLowerCase()
-      ret = Math.min(ret, grp.settings.duplicates[msgtype])
+      ret = Math.min(ret, dup?.[msgtype] ?? 14)
     }
   })
 


### PR DESCRIPTION
## Summary

Fixes the report that **duplicate posts aren't highlighted in ModTools** (Derek: *"Still not being highlighted"*).

## Root Cause

The pending-message "Duplicate of …" highlight (`ModMessageDuplicate`) is driven by `duplicates = checkHistory(true)`, whose loop only does anything when `duplicateAge` is non-null — and `duplicateAge` returned null unless `grp.settings.duplicates.check` was truthy.

V1 (`Group.php`) merges a default `duplicates` block into **every** group (`check:1, offer/taken/wanted/received:14`). The V2 Go group API returns only the **raw stored** settings (null → `{}`), with no default merge. So groups without an explicit `duplicates` block have `grp.settings.duplicates === undefined` → `duplicateAge` null → `checkHistory` never flags duplicates → no highlight. The in-code TODO (*"MT group does not have settings"*) was exactly this. (Not related to #795, which was a server-side subject-repeat check.)

## Fix

Default `duplicateAge` to the V1 behaviour (detection on, 14-day window) when the `duplicates` block is absent. An explicit `check: 0` still disables it. This restores both `checkHistory(true)` (duplicates) and `checkHistory(false)` (crossposts), which share `duplicateAge`.

## Verification

Logic fix; eslint clean. (Reproducing a fresh-arrival pending duplicate against a real group in dev is impractical, so this is a default-when-absent guard matching V1 rather than a browser repro.)

## Discourse

https://discourse.ilovefreegle.org/t/9518/341
