### PR TITLE
fix(chitchat): reserve right-side space for thread-menu button (Discourse #9749)

### DIFF
--- a/iznik-nuxt3/components/NewsThread.vue
+++ b/iznik-nuxt3/components/NewsThread.vue
@@ -13,10 +13,10 @@
             <span v-else>the system</span>
             and is only visible to volunteers and the person who posted it.
           </div>
-          <div v-if="isNewsComponent">
+          <div v-if="isNewsComponent" class="news-component-wrapper">
             <b-dropdown
               lazy
-              class="float-end thread-menu"
+              class="thread-menu"
               right
               variant="link"
               no-caret
@@ -666,13 +666,20 @@ async function unmute() {
   z-index: 10000;
 }
 
+.news-component-wrapper {
+  /* Reserve right-side space for the "..." button so every line of text has
+     clearance, not just lines vertically adjacent to a float. The wrapper is
+     the containing block; the button sits inside its reserved padding area. */
+  position: relative;
+  padding-right: 3rem;
+}
+
 .thread-menu {
-  /* The "..." menu is floated to the end; the post text wraps beside it on the
-     first line (and reclaims full width below, so no space is wasted). Give it a
-     clear gap so it does not sit right up against the text — 0.5rem (the first
-     attempt) was too small on inline name+body replies at narrow/iPad widths
-     (Discourse #9749 - chitchat niggle). */
-  margin-left: 1.5rem;
+  /* Absolutely positioned in the wrapper's reserved right-side padding so no
+     text can reach it regardless of content height (Discourse #9749). */
+  position: absolute;
+  top: 0;
+  right: 0;
 }
 
 :deep(.strike) {

--- a/iznik-nuxt3/tests/unit/components/NewsThread.spec.js
+++ b/iznik-nuxt3/tests/unit/components/NewsThread.spec.js
@@ -510,6 +510,15 @@ describe('NewsThread', () => {
       expect(wrapper.find('.b-dropdown').exists()).toBe(true)
     })
 
+    it('thread-menu is not floated and wrapper reserves right-side space for the button (Discourse #9749)', async () => {
+      const wrapper = await createWrapper()
+      const dropdown = wrapper.find('.b-dropdown')
+      // The button must NOT use float-end; instead the wrapper reserves padding so
+      // all content lines — not just the line beside a float — have clearance.
+      expect(dropdown.classes()).not.toContain('float-end')
+      expect(wrapper.find('.news-component-wrapper').exists()).toBe(true)
+    })
+
     it('shows "Open in new window" option', async () => {
       const wrapper = await createWrapper()
       expect(wrapper.text()).toContain('Open in new window')


### PR DESCRIPTION
Re-attempt of #785 (closed due to force-push invalidating the PR state; branch is the same).

## Root Cause

The thread-level "…" dropdown in `NewsThread.vue` was positioned with `float-end` (CSS `float: inline-end`), relying on float-layout to push adjacent text left. Float-shortening only affects line-boxes *vertically adjacent* to the float element. For post types whose preceding content (e.g. a CommunityEvent type-badge at ~28 px) is shorter than the button (~36 px), the title `<h3>` text begins at the same vertical level as the float and is not shortened — the text runs underneath the button.

## Evidence

Discourse post https://discourse.ilovefreegle.org/t/9749/5 shows a ChitChat thread where a long first line of text overlaps the "…" button because the float mechanism does not reserve space on that line.

## Fix

Replace float-based positioning with an absolutely-positioned button inside a `position: relative; padding-right: 3rem` wrapper:

- Added `class="news-component-wrapper"` to the outer `<div v-if="isNewsComponent">`.
- Removed `float-end` from the `<b-dropdown>` → `class="thread-menu"`.
- CSS:
  ```scss
  .news-component-wrapper {
    position: relative;
    padding-right: 3rem;
  }
  .thread-menu {
    position: absolute;
    top: 0;
    right: 0;
  }
  ```

The `padding-right` reserve applies to every line of content regardless of vertical position, so no text can reach the button area.

## Other Call Sites

`NewsReply.vue` already uses `position: absolute; top: -0.25rem; right: -1rem` for its reply menu and is unaffected.

## Test

Added to `NewsThread.spec.js` (inside `describe('dropdown menu', ...)`):

```js
it('thread-menu is not floated and wrapper reserves right-side space for the button (Discourse #9749)', async () => {
  const wrapper = await createWrapper()
  const dropdown = wrapper.find('.b-dropdown')
  expect(dropdown.classes()).not.toContain('float-end')
  expect(wrapper.find('.news-component-wrapper').exists()).toBe(true)
})
```

AssertFlip confirmed: step 3a passed on buggy code (`.toContain('float-end')`), step 3b failed on buggy code, passes after fix. Full suite: 102 tests pass.

## Discourse

https://discourse.ilovefreegle.org/t/9749/5