### PR TITLE
feat(bulk-offer): clearance management page for offerers

### DIFF
--- a/iznik-batch/app/Services/LoveJunkService.php
+++ b/iznik-batch/app/Services/LoveJunkService.php
@@ -58,6 +58,10 @@ class LoveJunkService
               AND lovejunk.msgid IS NULL
               AND messages_groups.collection = 'Approved'
               AND groups.onlovejunk = 1
+              AND NOT EXISTS (
+                SELECT 1 FROM messages_bulk_items
+                WHERE messages_bulk_items.msgid = messages.id
+              )
             ORDER BY messages.arrival ASC
         ", [$since]);
 

--- a/iznik-batch/tests/Unit/Services/LoveJunkServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/LoveJunkServiceTest.php
@@ -19,6 +19,7 @@ class LoveJunkServiceTest extends TestCase
         DB::table('messages_items')->delete();
         DB::table('messages_attachments')->delete();
         DB::table('messages_edits')->delete();
+        DB::table('messages_bulk_items')->delete();
         DB::table('messages')->delete();
         DB::table('chat_rooms')->delete();
         DB::table('items')->delete();
@@ -140,6 +141,34 @@ class LoveJunkServiceTest extends TestCase
 
         $this->assertEquals(0, $result['sent']);
         Http::assertNothingSent();
+    }
+
+    public function test_skips_bulk_offer_message(): void
+    {
+        // Bulk "clearance" offers (a message with messages_bulk_items rows) must
+        // never be sent to LoveJunk — its draft model is one item per post and
+        // can't represent a multi-item catalogue.
+        Http::fake();
+
+        $userId = $this->createUser();
+        $groupId = $this->createGroup();
+        $locationId = $this->createLocation();
+        $msgId = $this->createMessage($userId, $groupId, $locationId);
+
+        // Mark it as a bulk offer by giving it catalogue items.
+        DB::table('messages_bulk_items')->insert([
+            ['msgid' => $msgId, 'position' => 0, 'name' => 'Office chairs', 'quantity' => 10],
+            ['msgid' => $msgId, 'position' => 1, 'name' => 'Desks', 'quantity' => 4],
+        ]);
+
+        $service = new LoveJunkService();
+        $result = $service->sync();
+
+        $this->assertEquals(0, $result['sent']);
+        Http::assertNothingSent();
+
+        // And it must not have been recorded in the lovejunk table.
+        $this->assertNull(DB::table('lovejunk')->where('msgid', $msgId)->first());
     }
 
     public function test_skips_message_from_non_lovejunk_group(): void

--- a/iznik-nuxt3/components/ClearanceCandidate.vue
+++ b/iznik-nuxt3/components/ClearanceCandidate.vue
@@ -6,11 +6,23 @@
   >
     <div class="clearance-candidate__who">
       <span class="clearance-candidate__name">{{ displayName }}</span>
-      <UserRatings
-        v-if="interest.userid"
-        :id="interest.userid"
-        class="clearance-candidate__ratings"
-      />
+      <!-- Read-only reputation: only shown when the freegler actually has
+           ratings, so a clearance of new repliers isn't cluttered with "0"s.
+           The offerer shouldn't be rating people from here, so it's not
+           interactive (unlike the full UserRatings widget). -->
+      <span
+        v-if="reputation"
+        class="clearance-candidate__rep small"
+        :title="reputation.title"
+        data-testid="reputation"
+      >
+        <span v-if="reputation.up" class="text-success me-1">
+          <v-icon icon="thumbs-up" /> {{ reputation.up }}
+        </span>
+        <span v-if="reputation.down" class="text-danger">
+          <v-icon icon="thumbs-down" /> {{ reputation.down }}
+        </span>
+      </span>
     </div>
 
     <div class="clearance-candidate__detail small text-muted">
@@ -67,7 +79,6 @@
 import { ref, computed } from 'vue'
 import { useMessageStore } from '~/stores/message'
 import { useUserStore } from '~/stores/user'
-import UserRatings from '~/components/UserRatings'
 import {
   clearanceStateLabel,
   clearanceStateVariant,
@@ -97,6 +108,18 @@ const busy = ref(false)
 const displayName = computed(
   () => userStore.byId(props.interest.userid)?.displayname || 'Freegler'
 )
+
+// Compact, read-only reputation from the user's rating counts. Null when the
+// freegler has no thumbs either way, so new repliers don't show "0 / 0".
+const reputation = computed(() => {
+  const r = userStore.byId(props.interest.userid)?.info?.ratings
+  if (!r || (!r.Up && !r.Down)) return null
+  return {
+    up: r.Up || 0,
+    down: r.Down || 0,
+    title: `${r.Up || 0} thumbs up, ${r.Down || 0} down`,
+  }
+})
 const stateLabel = computed(() => clearanceStateLabel(props.interest.state))
 const stateVariant = computed(() => clearanceStateVariant(props.interest.state))
 const actions = computed(() => clearanceActions(props.interest.state))
@@ -166,10 +189,35 @@ defineExpose({ setState, actions, displayName, inactive, busy })
   flex: 0 0 auto;
 }
 
+.clearance-candidate__rep {
+  flex: 0 0 auto;
+  white-space: nowrap;
+}
+
 .clearance-candidate__actions {
   flex: 1 1 auto;
   display: flex;
   flex-wrap: wrap;
   justify-content: flex-end;
+}
+
+/* On a phone the name | detail | badges | actions don't fit on one row, which
+   truncated names to "Jane Sm…". Stack each part full-width so names read in
+   full and the actions sit left-aligned under them. */
+@media (max-width: 575.98px) {
+  .clearance-candidate__who,
+  .clearance-candidate__detail,
+  .clearance-candidate__badges,
+  .clearance-candidate__actions {
+    flex-basis: 100%;
+  }
+
+  .clearance-candidate__name {
+    white-space: normal;
+  }
+
+  .clearance-candidate__actions {
+    justify-content: flex-start;
+  }
 }
 </style>

--- a/iznik-nuxt3/components/ClearanceCandidate.vue
+++ b/iznik-nuxt3/components/ClearanceCandidate.vue
@@ -1,0 +1,175 @@
+<template>
+  <div
+    class="clearance-candidate"
+    :class="{ 'clearance-candidate--inactive': inactive }"
+    :data-testid="'candidate-' + interest.userid"
+  >
+    <div class="clearance-candidate__who">
+      <span class="clearance-candidate__name">{{ displayName }}</span>
+      <UserRatings
+        v-if="interest.userid"
+        :id="interest.userid"
+        class="clearance-candidate__ratings"
+      />
+    </div>
+
+    <div class="clearance-candidate__detail small text-muted">
+      <span class="me-2">wants {{ interest.quantity }}</span>
+      <span v-if="interest.cancollect" class="clearance-candidate__collect">
+        · can collect: {{ interest.cancollect }}
+      </span>
+    </div>
+
+    <div class="clearance-candidate__badges">
+      <b-badge :variant="stateVariant">{{ stateLabel }}</b-badge>
+      <!-- Cross-item hint: this person is already collecting other items in the
+           same clearance, so giving them this one saves a separate visit. -->
+      <b-badge
+        v-if="otherAllocations.length"
+        variant="info"
+        class="ms-1"
+        :title="'Already collecting: ' + otherAllocations.join(', ')"
+        data-testid="also-collecting"
+      >
+        <v-icon icon="truck" class="me-1" />also collecting
+        {{ otherAllocations.length }} more
+      </b-badge>
+    </div>
+
+    <div class="clearance-candidate__actions">
+      <b-button
+        v-for="a in actions"
+        :key="a.state"
+        :variant="a.variant"
+        size="sm"
+        :disabled="busy"
+        class="ms-1 mb-1"
+        :data-testid="'action-' + interest.userid + '-' + a.state"
+        @click="setState(a.state)"
+      >
+        {{ a.label }}
+      </b-button>
+      <b-button
+        v-if="interest.chatid"
+        variant="link"
+        size="sm"
+        class="ms-1"
+        :to="'/chats/' + interest.chatid"
+        data-testid="open-chat"
+      >
+        <v-icon icon="comments" class="me-1" />Message
+      </b-button>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed } from 'vue'
+import { useMessageStore } from '~/stores/message'
+import { useUserStore } from '~/stores/user'
+import UserRatings from '~/components/UserRatings'
+import {
+  clearanceStateLabel,
+  clearanceStateVariant,
+  clearanceActions,
+  isInactiveState,
+} from '~/composables/useClearance'
+
+const props = defineProps({
+  // The bulk offer this interest belongs to.
+  messageId: { type: Number, required: true },
+  // The catalogue item this interest is for.
+  bulkitemid: { type: Number, required: true },
+  // One interest row: { userid, quantity, cancollect, state, chatid }.
+  interest: { type: Object, required: true },
+  // Names of OTHER items in this clearance this person is already allocated, so
+  // we can flag a single-visit collector.
+  otherAllocations: { type: Array, default: () => [] },
+})
+
+const emit = defineEmits(['changed'])
+
+const messageStore = useMessageStore()
+const userStore = useUserStore()
+
+const busy = ref(false)
+
+const displayName = computed(
+  () => userStore.byId(props.interest.userid)?.displayname || 'Freegler'
+)
+const stateLabel = computed(() => clearanceStateLabel(props.interest.state))
+const stateVariant = computed(() => clearanceStateVariant(props.interest.state))
+const actions = computed(() => clearanceActions(props.interest.state))
+const inactive = computed(() => isInactiveState(props.interest.state))
+
+// Transition this interest to a new state. The store refetches the message
+// afterwards, so the parent's grouping/totals update reactively.
+async function setState(state) {
+  if (busy.value) return
+  busy.value = true
+  try {
+    await messageStore.bulkInterestState(
+      props.messageId,
+      props.bulkitemid,
+      props.interest.userid,
+      state
+    )
+    emit('changed', { userid: props.interest.userid, state })
+  } catch (e) {
+    console.error('Failed to change interest state', e)
+  } finally {
+    busy.value = false
+  }
+}
+
+defineExpose({ setState, actions, displayName, inactive, busy })
+</script>
+
+<style scoped lang="scss">
+@import 'bootstrap/scss/functions';
+@import 'assets/css/_color-vars.scss';
+
+.clearance-candidate {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem 0.6rem;
+  padding: 0.4rem 0;
+  border-bottom: 1px solid $color-gray--lighter;
+}
+
+.clearance-candidate--inactive {
+  opacity: 0.6;
+}
+
+.clearance-candidate__who {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  flex: 1 1 12rem;
+  min-width: 0;
+}
+
+.clearance-candidate__name {
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.clearance-candidate__detail {
+  flex: 1 1 10rem;
+  min-width: 0;
+}
+
+.clearance-candidate__badges {
+  flex: 0 0 auto;
+}
+
+.clearance-candidate__actions {
+  flex: 1 1 auto;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+</style>

--- a/iznik-nuxt3/components/ClearanceManageItem.vue
+++ b/iznik-nuxt3/components/ClearanceManageItem.vue
@@ -1,0 +1,278 @@
+<template>
+  <div class="clearance-item" :data-testid="'clearance-item-' + item.id">
+    <div class="clearance-item__head">
+      <span class="clearance-item__photo">
+        <img
+          v-if="thumb"
+          :src="thumb"
+          alt=""
+          loading="lazy"
+          @error="brokenImage"
+        />
+        <v-icon v-else icon="image" class="clearance-item__nophoto" />
+      </span>
+      <div class="clearance-item__title">
+        <span class="clearance-item__ref">#{{ index + 1 }}</span>
+        <span class="clearance-item__name">{{ item.name }}</span>
+        <b-badge variant="light">{{ item.quantity }} available</b-badge>
+        <b-badge
+          v-if="item.condition && item.condition !== 'Unknown'"
+          variant="info"
+        >
+          {{ conditionLabel }}
+        </b-badge>
+      </div>
+    </div>
+
+    <!-- Allocation progress: how much of this item is spoken for. -->
+    <div class="clearance-item__alloc">
+      <b-progress :max="item.quantity || 1" class="clearance-item__bar">
+        <b-progress-bar :value="allocated" variant="success" />
+      </b-progress>
+      <span class="clearance-item__allocnum small">
+        <b-badge v-if="remaining <= 0" variant="success"
+          >Fully allocated</b-badge
+        >
+        <template v-else>
+          Allocated {{ allocated }} of {{ item.quantity }} ·
+          <strong>{{ remaining }} left</strong>
+        </template>
+      </span>
+      <span class="clearance-item__intnum small text-muted">
+        {{ item.interestcount || 0 }} interested
+      </span>
+    </div>
+
+    <!-- Allocated recipients (Reserved / Collected). -->
+    <div v-if="allocatedRows.length" class="clearance-item__group">
+      <h6 class="clearance-item__grouphead">Allocated to</h6>
+      <ClearanceCandidate
+        v-for="row in allocatedRows"
+        :key="row.userid"
+        :message-id="message.id"
+        :bulkitemid="item.id"
+        :interest="row"
+        :other-allocations="otherAllocationsFor(row.userid)"
+      />
+    </div>
+
+    <!-- Everyone still in the pool. Once something's been allocated these are
+         the fallbacks the offerer can fall back on. -->
+    <div v-if="poolRows.length" class="clearance-item__group">
+      <h6 class="clearance-item__grouphead">
+        {{ allocatedRows.length ? 'Fallback recipients' : 'Interested' }}
+      </h6>
+      <ClearanceCandidate
+        v-for="row in poolRows"
+        :key="row.userid"
+        :message-id="message.id"
+        :bulkitemid="item.id"
+        :interest="row"
+        :other-allocations="otherAllocationsFor(row.userid)"
+      />
+    </div>
+
+    <p v-if="!activeRows.length" class="text-muted small mb-0">
+      No-one's asked for this yet.
+    </p>
+
+    <!-- Declined / withdrawn, tucked away. -->
+    <div v-if="inactiveRows.length" class="clearance-item__group">
+      <b-button
+        variant="link"
+        size="sm"
+        class="p-0 clearance-item__inactivetoggle"
+        data-testid="toggle-inactive"
+        @click="showInactive = !showInactive"
+      >
+        {{ showInactive ? 'Hide' : 'Show' }} {{ inactiveRows.length }}
+        declined/withdrawn
+      </b-button>
+      <template v-if="showInactive">
+        <ClearanceCandidate
+          v-for="row in inactiveRows"
+          :key="row.userid"
+          :message-id="message.id"
+          :bulkitemid="item.id"
+          :interest="row"
+        />
+      </template>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed } from 'vue'
+import ClearanceCandidate from '~/components/ClearanceCandidate'
+import {
+  isAllocatedState,
+  isPoolState,
+  isInactiveState,
+  allocatedQuantity,
+} from '~/composables/useClearance'
+
+const props = defineProps({
+  // The whole bulk offer (so we can look across items for single-visit hints).
+  message: { type: Object, required: true },
+  // This catalogue item, including its owner-only `interest` array.
+  item: { type: Object, required: true },
+  // Zero-based position, for the #N reference shown to the offerer.
+  index: { type: Number, default: 0 },
+})
+
+const showInactive = ref(false)
+
+const interest = computed(() => props.item.interest || [])
+
+const allocatedRows = computed(() =>
+  // Reserved before Collected, so "still to collect" sits at the top.
+  interest.value
+    .filter((i) => isAllocatedState(i.state))
+    .slice()
+    .sort(
+      (a, b) =>
+        (a.state === 'Reserved' ? -1 : 1) - (b.state === 'Reserved' ? -1 : 1)
+    )
+)
+
+const poolRows = computed(() =>
+  // Bulk collectors first (fewer collection visits), then those who gave a
+  // collection time, then by quantity.
+  interest.value
+    .filter((i) => isPoolState(i.state))
+    .slice()
+    .sort(
+      (a, b) =>
+        (b.cancollect ? 1 : 0) - (a.cancollect ? 1 : 0) ||
+        (b.quantity || 0) - (a.quantity || 0)
+    )
+)
+
+const inactiveRows = computed(() =>
+  interest.value.filter((i) => isInactiveState(i.state))
+)
+
+const activeRows = computed(() => [...allocatedRows.value, ...poolRows.value])
+
+const allocated = computed(() => allocatedQuantity(interest.value))
+const remaining = computed(() =>
+  Math.max(0, (props.item.quantity || 0) - allocated.value)
+)
+
+const conditionLabel = computed(() =>
+  props.item.condition === 'LikeNew' ? 'Like new' : props.item.condition
+)
+
+const thumb = computed(() => {
+  const a = props.item.attachments && props.item.attachments[0]
+  return (a && (a.paththumb || a.path)) || props.item.photourl || null
+})
+
+// Names of OTHER items in this clearance the given user is already allocated.
+// Surfacing this lets the offerer give one person several items in one trip.
+function otherAllocationsFor(userid) {
+  const names = []
+  for (const other of props.message.bulkitems || []) {
+    if (other.id === props.item.id) continue
+    const theirs = (other.interest || []).find((i) => i.userid === userid)
+    if (theirs && isAllocatedState(theirs.state)) names.push(other.name)
+  }
+  return names
+}
+
+function brokenImage(event) {
+  event.target.src = '/placeholder.jpg'
+}
+
+defineExpose({
+  allocatedRows,
+  poolRows,
+  inactiveRows,
+  activeRows,
+  allocated,
+  remaining,
+  otherAllocationsFor,
+})
+</script>
+
+<style scoped lang="scss">
+@import 'bootstrap/scss/functions';
+@import 'assets/css/_color-vars.scss';
+
+.clearance-item {
+  border: 1px solid $color-gray--lighter;
+  border-radius: 6px;
+  padding: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.clearance-item__head {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.clearance-item__photo {
+  flex: 0 0 44px;
+  width: 44px;
+  height: 44px;
+  border-radius: 5px;
+  overflow: hidden;
+  background-color: $color-gray--lighter;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+}
+
+.clearance-item__nophoto {
+  color: $color-gray--normal;
+}
+
+.clearance-item__title {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.clearance-item__ref {
+  color: $color-gray--normal;
+  font-size: 0.85em;
+}
+
+.clearance-item__name {
+  font-weight: 600;
+}
+
+.clearance-item__alloc {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin: 0.5rem 0;
+}
+
+.clearance-item__bar {
+  flex: 1 1 8rem;
+  min-width: 6rem;
+}
+
+.clearance-item__grouphead {
+  font-size: 0.9rem;
+  font-weight: 700;
+  margin: 0.5rem 0 0.1rem;
+  color: $color-gray--dark;
+}
+
+.clearance-item__inactivetoggle {
+  margin-top: 0.25rem;
+}
+</style>

--- a/iznik-nuxt3/components/ClearanceManager.vue
+++ b/iznik-nuxt3/components/ClearanceManager.vue
@@ -1,0 +1,162 @@
+<template>
+  <div class="clearance-manager" data-testid="clearance-manager">
+    <div
+      v-if="!message"
+      class="text-center my-5"
+      data-testid="clearance-loading"
+    >
+      <b-spinner />
+      <p class="text-muted mt-2">Loading your clearance…</p>
+    </div>
+
+    <NoticeMessage v-else-if="!isClearance" variant="warning">
+      This post isn't a clearance with multiple items, so there's nothing to
+      manage here.
+    </NoticeMessage>
+
+    <NoticeMessage v-else-if="!canManage" variant="warning">
+      You can only manage clearances that you posted.
+    </NoticeMessage>
+
+    <template v-else>
+      <div class="clearance-manager__head">
+        <h2 class="clearance-manager__title">{{ message.subject }}</h2>
+        <p class="clearance-manager__totals" data-testid="clearance-totals">
+          {{ items.length }} items ·
+          <strong>{{ peopleInterested }}</strong>
+          {{ peopleInterested === 1 ? 'person' : 'people' }} interested ·
+          <strong>{{ fullyAllocated }}/{{ items.length }}</strong>
+          items fully allocated
+        </p>
+
+        <details class="clearance-manager__legend small text-muted">
+          <summary>What the labels mean</summary>
+          <ul class="mb-0 mt-1">
+            <li>
+              <strong>Wants it</strong> — they've asked; still in the pool.
+            </li>
+            <li>
+              <strong>Allocated</strong> — you've promised it; we send them the
+              collection details automatically.
+            </li>
+            <li><strong>Collected</strong> — they've picked it up.</li>
+            <li>
+              <strong>Fallback recipients</strong> — backups if an allocation
+              falls through.
+            </li>
+          </ul>
+        </details>
+      </div>
+
+      <ClearanceManageItem
+        v-for="(item, idx) in items"
+        :key="item.id"
+        :message="message"
+        :item="item"
+        :index="idx"
+      />
+    </template>
+  </div>
+</template>
+
+<script setup>
+import { computed, watch, onMounted } from 'vue'
+import { useMessageStore } from '~/stores/message'
+import { useUserStore } from '~/stores/user'
+import { useMe } from '~/composables/useMe'
+import NoticeMessage from '~/components/NoticeMessage'
+import ClearanceManageItem from '~/components/ClearanceManageItem'
+import {
+  isActiveInterest,
+  allocatedQuantity,
+  distinctInterestedUsers,
+} from '~/composables/useClearance'
+
+const props = defineProps({
+  // The bulk offer's message id.
+  id: { type: Number, required: true },
+})
+
+const messageStore = useMessageStore()
+const userStore = useUserStore()
+const { myid } = useMe()
+
+const message = computed(() => messageStore.byId(props.id))
+
+const items = computed(() =>
+  (message.value?.bulkitems || [])
+    .slice()
+    .sort((a, b) => (a.position || 0) - (b.position || 0))
+)
+
+const isClearance = computed(
+  () => (message.value?.bulkcount || items.value.length) > 0
+)
+
+// Only the offerer manages a clearance. (Mods have their own modtools view.)
+const canManage = computed(
+  () => !!message.value && message.value.fromuser === myid.value
+)
+
+const peopleInterested = computed(() => distinctInterestedUsers(items.value))
+
+const fullyAllocated = computed(
+  () =>
+    items.value.filter(
+      (it) =>
+        it.quantity > 0 && allocatedQuantity(it.interest || []) >= it.quantity
+    ).length
+)
+
+// Load the full message (with the owner-only interest arrays), then the
+// display names / reputation of everyone who's expressed interest so the
+// candidate rows can show who they are.
+async function load() {
+  await messageStore.fetch(props.id, true)
+  const ids = new Set()
+  for (const item of message.value?.bulkitems || []) {
+    for (const i of item.interest || []) {
+      if (isActiveInterest(i)) ids.add(i.userid)
+    }
+  }
+  if (ids.size) {
+    await userStore.fetchMultiple([...ids])
+  }
+}
+
+onMounted(load)
+watch(() => props.id, load)
+
+defineExpose({
+  message,
+  items,
+  isClearance,
+  canManage,
+  peopleInterested,
+  fullyAllocated,
+  load,
+})
+</script>
+
+<style scoped lang="scss">
+@import 'bootstrap/scss/functions';
+@import 'assets/css/_color-vars.scss';
+
+.clearance-manager__title {
+  font-size: 1.4rem;
+  font-weight: 700;
+}
+
+.clearance-manager__totals {
+  color: $color-gray--dark;
+  margin-bottom: 0.25rem;
+}
+
+.clearance-manager__legend {
+  margin-bottom: 1rem;
+
+  summary {
+    cursor: pointer;
+  }
+}
+</style>

--- a/iznik-nuxt3/components/ClearanceManager.vue
+++ b/iznik-nuxt3/components/ClearanceManager.vue
@@ -67,7 +67,6 @@ import { useMe } from '~/composables/useMe'
 import NoticeMessage from '~/components/NoticeMessage'
 import ClearanceManageItem from '~/components/ClearanceManageItem'
 import {
-  isActiveInterest,
   allocatedQuantity,
   distinctInterestedUsers,
 } from '~/composables/useClearance'
@@ -113,10 +112,13 @@ const fullyAllocated = computed(
 // candidate rows can show who they are.
 async function load() {
   await messageStore.fetch(props.id, true)
+  // Fetch everyone who's expressed interest — including withdrawn/rejected, so
+  // their names still show in the declined/withdrawn section (and if the offerer
+  // restores a rejected candidate).
   const ids = new Set()
   for (const item of message.value?.bulkitems || []) {
     for (const i of item.interest || []) {
-      if (isActiveInterest(i)) ids.add(i.userid)
+      ids.add(i.userid)
     }
   }
   if (ids.size) {

--- a/iznik-nuxt3/components/MyPostsClearances.vue
+++ b/iznik-nuxt3/components/MyPostsClearances.vue
@@ -1,0 +1,110 @@
+<template>
+  <div
+    v-if="clearances.length"
+    class="myposts-clearances"
+    data-testid="myposts-clearances"
+  >
+    <h5 class="myposts-clearances__head">
+      <v-icon icon="gift" class="text-success me-1" />Your clearances
+    </h5>
+    <p class="small text-muted mb-2">
+      These posts offer several items at once. Manage replies and decide who
+      gets what.
+    </p>
+    <div
+      v-for="c in clearances"
+      :key="c.id"
+      class="myposts-clearances__row"
+      :data-testid="'clearance-row-' + c.id"
+    >
+      <div class="myposts-clearances__detail">
+        <span class="myposts-clearances__subject">{{ c.subject }}</span>
+        <b-badge variant="light">{{ c.bulkcount }} items</b-badge>
+        <b-badge v-if="c.interested" variant="info" class="ms-1">
+          {{ c.interested }} interested
+        </b-badge>
+      </div>
+      <b-button
+        variant="primary"
+        size="sm"
+        :to="'/clearance/' + c.id"
+        :data-testid="'manage-' + c.id"
+      >
+        Manage <v-icon icon="angle-right" />
+      </b-button>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import { useMessageStore } from '~/stores/message'
+import { distinctInterestedUsers } from '~/composables/useClearance'
+
+const props = defineProps({
+  // The user's posts (message summaries from myposts). The full message — with
+  // bulkcount — is loaded into the store for active posts, which is where we
+  // read the clearance details from.
+  posts: { type: Array, default: () => [] },
+})
+
+const messageStore = useMessageStore()
+
+const clearances = computed(() =>
+  (props.posts || [])
+    .map((p) => {
+      const full = messageStore.byId(p.id)
+      const bulkcount = full?.bulkcount ?? full?.bulkitems?.length ?? 0
+      return {
+        id: p.id,
+        subject: full?.subject || p.subject,
+        bulkcount,
+        interested: full?.bulkitems
+          ? distinctInterestedUsers(full.bulkitems)
+          : 0,
+      }
+    })
+    .filter((c) => c.bulkcount > 0)
+)
+</script>
+
+<style scoped lang="scss">
+@import 'bootstrap/scss/functions';
+@import 'assets/css/_color-vars.scss';
+
+.myposts-clearances {
+  border: 1px solid $color-gray--lighter;
+  border-radius: 6px;
+  padding: 0.75rem;
+  margin-bottom: 1rem;
+  background-color: $color-green--light;
+}
+
+.myposts-clearances__head {
+  font-weight: 700;
+}
+
+.myposts-clearances__row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.4rem 0;
+  border-top: 1px solid $color-gray--lighter;
+}
+
+.myposts-clearances__detail {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  min-width: 0;
+}
+
+.myposts-clearances__subject {
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+</style>

--- a/iznik-nuxt3/composables/useClearance.js
+++ b/iznik-nuxt3/composables/useClearance.js
@@ -1,0 +1,105 @@
+// Shared helpers for the bulk-offer ("clearance") management view. The interest
+// rows on a bulk item are persisted with one of five states
+// (Interested/Reserved/Collected/Withdrawn/Rejected — see
+// messages_bulk_items_interest). This module maps those raw states to the
+// decisions an offerer actually makes ("allocate", "decline", "mark collected")
+// and provides the allocation maths the management UI shows. Keeping it pure
+// (no Vue reactivity) means it can be unit-tested directly and reused across the
+// manager, item and candidate components without duplication.
+
+// Persisted states grouped for the management UI.
+export const CLEARANCE_ALLOCATED_STATES = ['Reserved', 'Collected']
+export const CLEARANCE_POOL_STATES = ['Interested']
+export const CLEARANCE_INACTIVE_STATES = ['Withdrawn', 'Rejected']
+
+// Offerer-facing label + badge variant per persisted state. Reserved is shown as
+// "Allocated" because that's the offerer's mental model — the API also sends the
+// access instructions to the replier on that transition.
+export const CLEARANCE_STATE_META = {
+  Interested: { label: 'Wants it', variant: 'secondary' },
+  Reserved: { label: 'Allocated', variant: 'success' },
+  Collected: { label: 'Collected', variant: 'primary' },
+  Rejected: { label: 'Declined', variant: 'danger' },
+  Withdrawn: { label: 'Withdrew', variant: 'light' },
+}
+
+export function clearanceStateLabel(state) {
+  return CLEARANCE_STATE_META[state]?.label || state || 'Unknown'
+}
+
+export function clearanceStateVariant(state) {
+  return CLEARANCE_STATE_META[state]?.variant || 'secondary'
+}
+
+export function isAllocatedState(state) {
+  return CLEARANCE_ALLOCATED_STATES.includes(state)
+}
+
+export function isPoolState(state) {
+  return CLEARANCE_POOL_STATES.includes(state)
+}
+
+export function isInactiveState(state) {
+  return CLEARANCE_INACTIVE_STATES.includes(state)
+}
+
+// Whether an interest row still counts as "live". Mirrors the API's
+// interestcount, which excludes withdrawn/rejected rows.
+export function isActiveInterest(interest) {
+  return !!interest && !isInactiveState(interest.state)
+}
+
+// Quantity allocated for an item: the sum of quantities across Reserved or
+// Collected rows. Drives the "allocated N of M" progress.
+export function allocatedQuantity(interest = []) {
+  return interest
+    .filter((i) => isAllocatedState(i.state))
+    .reduce((sum, i) => sum + (parseInt(i.quantity, 10) || 0), 0)
+}
+
+// The number of distinct people with live interest across a set of items.
+export function distinctInterestedUsers(items = []) {
+  const ids = new Set()
+  for (const item of items) {
+    for (const i of item.interest || []) {
+      if (isActiveInterest(i)) ids.add(i.userid)
+    }
+  }
+  return ids.size
+}
+
+// The next-state buttons an offerer can press from a given state, as
+// { state, label, variant } entries. Withdrawn has none — the replier backed
+// out, so there's nothing for the offerer to decide.
+export function clearanceActions(state) {
+  switch (state) {
+    case 'Interested':
+      return [
+        { state: 'Reserved', label: 'Allocate', variant: 'success' },
+        { state: 'Rejected', label: 'Decline', variant: 'outline-danger' },
+      ]
+    case 'Reserved':
+      return [
+        { state: 'Collected', label: 'Mark collected', variant: 'primary' },
+        {
+          state: 'Interested',
+          label: 'Un-allocate',
+          variant: 'outline-secondary',
+        },
+      ]
+    case 'Collected':
+      return [
+        {
+          state: 'Reserved',
+          label: 'Undo collected',
+          variant: 'outline-secondary',
+        },
+      ]
+    case 'Rejected':
+      return [
+        { state: 'Interested', label: 'Restore', variant: 'outline-secondary' },
+      ]
+    default:
+      return []
+  }
+}

--- a/iznik-nuxt3/pages/clearance/[id].vue
+++ b/iznik-nuxt3/pages/clearance/[id].vue
@@ -1,0 +1,38 @@
+<template>
+  <client-only>
+    <b-container class="py-3">
+      <b-row>
+        <b-col cols="12" lg="8" offset-lg="2">
+          <ClearanceManager :id="id" />
+        </b-col>
+      </b-row>
+    </b-container>
+  </client-only>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import { useRoute, useRouter, useHead } from '#imports'
+import { useRuntimeConfig } from '#app'
+import { buildHead } from '~/composables/useBuildHead'
+import ClearanceManager from '~/components/ClearanceManager'
+
+definePageMeta({
+  layout: 'login',
+})
+
+const route = useRoute()
+const router = useRouter()
+const runtimeConfig = useRuntimeConfig()
+
+const id = computed(() => parseInt(route.params.id))
+
+useHead(
+  buildHead(
+    router.currentRoute.value,
+    runtimeConfig,
+    'Manage clearance',
+    'See replies, allocate items and track collection for your bulk offer.'
+  )
+)
+</script>

--- a/iznik-nuxt3/pages/myposts.vue
+++ b/iznik-nuxt3/pages/myposts.vue
@@ -35,6 +35,8 @@
               @donation-made="donationMade"
             />
 
+            <MyPostsClearances :posts="posts" />
+
             <MyPostsPostsList
               :posts="posts"
               :loading="loading"
@@ -84,6 +86,7 @@ import SidebarLeft from '~/components/SidebarLeft'
 import SidebarRight from '~/components/SidebarRight'
 import ExpectedRepliesWarning from '~/components/ExpectedRepliesWarning'
 import MyPostsPostsList from '~/components/MyPostsPostsList.vue'
+import MyPostsClearances from '~/components/MyPostsClearances.vue'
 import MyPostsSearchesList from '~/components/MyPostsSearchesList.vue'
 import MyPostsDonationAsk from '~/components/MyPostsDonationAsk.vue'
 import NewUserInfo from '~/components/NewUserInfo.vue'

--- a/iznik-nuxt3/tests/unit/components/ClearanceCandidate.spec.js
+++ b/iznik-nuxt3/tests/unit/components/ClearanceCandidate.spec.js
@@ -10,15 +10,13 @@ vi.mock('~/stores/message', () => ({
 }))
 vi.mock('~/stores/user', () => ({
   useUserStore: () => ({
-    byId: (id) => (id === 7 ? { displayname: 'Sam' } : null),
+    byId: (id) => {
+      if (id === 7) return { displayname: 'Sam' } // no ratings
+      if (id === 8)
+        return { displayname: 'Pat', info: { ratings: { Up: 5, Down: 1 } } }
+      return null
+    },
   }),
-}))
-vi.mock('~/components/UserRatings', () => ({
-  default: {
-    name: 'UserRatings',
-    template: '<span class="ur-stub" />',
-    props: ['id'],
-  },
 }))
 
 import ClearanceCandidate from '~/components/ClearanceCandidate.vue'
@@ -43,6 +41,17 @@ describe('ClearanceCandidate', () => {
     expect(known.vm.displayName).toBe('Sam')
     const unknown = mountRow({ userid: 99, quantity: 1, state: 'Interested' })
     expect(unknown.vm.displayName).toBe('Freegler')
+  })
+
+  it('shows a read-only reputation only when the freegler has ratings', () => {
+    // User 7 has no ratings → no clutter.
+    const none = mountRow({ userid: 7, quantity: 1, state: 'Interested' })
+    expect(none.vm.reputation).toBeNull()
+    expect(none.find('[data-testid="reputation"]').exists()).toBe(false)
+    // User 8 has thumbs → compact read-only reputation shown.
+    const rated = mountRow({ userid: 8, quantity: 1, state: 'Interested' })
+    expect(rated.vm.reputation).toMatchObject({ up: 5, down: 1 })
+    expect(rated.find('[data-testid="reputation"]').exists()).toBe(true)
   })
 
   it('offers allocate/decline for an interested candidate', () => {

--- a/iznik-nuxt3/tests/unit/components/ClearanceCandidate.spec.js
+++ b/iznik-nuxt3/tests/unit/components/ClearanceCandidate.spec.js
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+
+const h = vi.hoisted(() => ({
+  bulkInterestState: vi.fn().mockResolvedValue({}),
+}))
+
+vi.mock('~/stores/message', () => ({
+  useMessageStore: () => ({ bulkInterestState: h.bulkInterestState }),
+}))
+vi.mock('~/stores/user', () => ({
+  useUserStore: () => ({
+    byId: (id) => (id === 7 ? { displayname: 'Sam' } : null),
+  }),
+}))
+vi.mock('~/components/UserRatings', () => ({
+  default: {
+    name: 'UserRatings',
+    template: '<span class="ur-stub" />',
+    props: ['id'],
+  },
+}))
+
+import ClearanceCandidate from '~/components/ClearanceCandidate.vue'
+
+const mountOpts = {
+  global: {
+    stubs: { 'b-button': true, 'b-badge': true },
+  },
+}
+
+const mountRow = (interest, otherAllocations = []) =>
+  mount(ClearanceCandidate, {
+    ...mountOpts,
+    props: { messageId: 1, bulkitemid: 10, interest, otherAllocations },
+  })
+
+describe('ClearanceCandidate', () => {
+  beforeEach(() => h.bulkInterestState.mockClear())
+
+  it('shows the display name from the user store (fallback when unknown)', () => {
+    const known = mountRow({ userid: 7, quantity: 2, state: 'Interested' })
+    expect(known.vm.displayName).toBe('Sam')
+    const unknown = mountRow({ userid: 99, quantity: 1, state: 'Interested' })
+    expect(unknown.vm.displayName).toBe('Freegler')
+  })
+
+  it('offers allocate/decline for an interested candidate', () => {
+    const w = mountRow({ userid: 7, quantity: 2, state: 'Interested' })
+    expect(w.vm.actions.map((a) => a.state)).toEqual(['Reserved', 'Rejected'])
+    expect(w.vm.inactive).toBe(false)
+  })
+
+  it('offers collect/un-allocate for an allocated candidate', () => {
+    const w = mountRow({ userid: 7, quantity: 2, state: 'Reserved' })
+    expect(w.vm.actions.map((a) => a.state)).toEqual([
+      'Collected',
+      'Interested',
+    ])
+  })
+
+  it('treats withdrawn as inactive with no actions', () => {
+    const w = mountRow({ userid: 7, quantity: 0, state: 'Withdrawn' })
+    expect(w.vm.actions).toEqual([])
+    expect(w.vm.inactive).toBe(true)
+  })
+
+  it('setState calls the store with the right args and emits changed', async () => {
+    const w = mountRow({ userid: 7, quantity: 2, state: 'Interested' })
+    await w.vm.setState('Reserved')
+    expect(h.bulkInterestState).toHaveBeenCalledWith(1, 10, 7, 'Reserved')
+    expect(w.emitted().changed).toBeTruthy()
+    expect(w.emitted().changed[0][0]).toMatchObject({
+      userid: 7,
+      state: 'Reserved',
+    })
+  })
+
+  it('renders an "also collecting" hint when allocated elsewhere', () => {
+    const w = mountRow({ userid: 7, quantity: 1, state: 'Interested' }, [
+      'Desk',
+      'Lamp',
+    ])
+    expect(w.find('[data-testid="also-collecting"]').exists()).toBe(true)
+  })
+})

--- a/iznik-nuxt3/tests/unit/components/ClearanceManageItem.spec.js
+++ b/iznik-nuxt3/tests/unit/components/ClearanceManageItem.spec.js
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { vi } from 'vitest'
+
+// Stub the candidate so we can inspect the props the item passes down without
+// pulling in its store dependencies.
+vi.mock('~/components/ClearanceCandidate', () => ({
+  default: {
+    name: 'ClearanceCandidate',
+    template: '<div class="cc-stub" />',
+    props: ['messageId', 'bulkitemid', 'interest', 'otherAllocations'],
+  },
+}))
+
+import ClearanceManageItem from '~/components/ClearanceManageItem.vue'
+
+const message = {
+  id: 1,
+  bulkitems: [
+    {
+      id: 10,
+      name: 'Chairs',
+      quantity: 10,
+      condition: 'Good',
+      attachments: [],
+      interestcount: 4,
+      interest: [
+        { userid: 1, quantity: 4, state: 'Reserved' },
+        { userid: 2, quantity: 2, state: 'Collected' },
+        { userid: 3, quantity: 3, state: 'Interested', cancollect: 'Tue' },
+        { userid: 4, quantity: 1, state: 'Interested' },
+        { userid: 5, quantity: 1, state: 'Withdrawn' },
+        { userid: 6, quantity: 1, state: 'Rejected' },
+      ],
+    },
+    {
+      id: 11,
+      name: 'Desk',
+      quantity: 1,
+      attachments: [],
+      interest: [{ userid: 1, quantity: 1, state: 'Reserved' }],
+    },
+  ],
+}
+
+const mountItem = (item) =>
+  mount(ClearanceManageItem, {
+    props: { message, item, index: 0 },
+    global: {
+      stubs: {
+        // Render slot content so badge/button text appears in w.text().
+        'b-badge': { template: '<span class="badge-stub"><slot /></span>' },
+        'b-button': { template: '<button class="btn-stub"><slot /></button>' },
+        'b-progress': true,
+        'b-progress-bar': true,
+      },
+    },
+  })
+
+describe('ClearanceManageItem', () => {
+  it('groups interest into allocated, pool and inactive', () => {
+    const w = mountItem(message.bulkitems[0])
+    expect(w.vm.allocatedRows.map((r) => r.userid).sort()).toEqual([1, 2])
+    expect(w.vm.poolRows.map((r) => r.userid).sort()).toEqual([3, 4])
+    expect(w.vm.inactiveRows.map((r) => r.userid).sort()).toEqual([5, 6])
+  })
+
+  it('computes allocated and remaining quantities', () => {
+    const w = mountItem(message.bulkitems[0])
+    expect(w.vm.allocated).toBe(6) // 4 reserved + 2 collected
+    expect(w.vm.remaining).toBe(4) // of 10
+  })
+
+  it('orders the pool with collection-time givers first', () => {
+    const w = mountItem(message.bulkitems[0])
+    // user 3 gave a time, user 4 didn't.
+    expect(w.vm.poolRows[0].userid).toBe(3)
+  })
+
+  it('flags items a candidate is already allocated elsewhere', () => {
+    const w = mountItem(message.bulkitems[0])
+    // user 1 is Reserved on the Desk (item 11) too.
+    expect(w.vm.otherAllocationsFor(1)).toEqual(['Desk'])
+    // user 3 isn't allocated anywhere else.
+    expect(w.vm.otherAllocationsFor(3)).toEqual([])
+  })
+
+  it('shows a fully-allocated state when nothing remains', () => {
+    const w = mountItem(message.bulkitems[1]) // Desk: 1 of 1 reserved
+    expect(w.vm.remaining).toBe(0)
+    expect(w.text()).toContain('Fully allocated')
+  })
+
+  it('renders nothing-yet text when there is no interest', () => {
+    const w = mountItem({
+      id: 12,
+      name: 'Empty',
+      quantity: 5,
+      attachments: [],
+      interest: [],
+    })
+    expect(w.vm.activeRows).toEqual([])
+    expect(w.text()).toContain("No-one's asked for this yet")
+  })
+})

--- a/iznik-nuxt3/tests/unit/components/ClearanceManager.spec.js
+++ b/iznik-nuxt3/tests/unit/components/ClearanceManager.spec.js
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+
+const h = vi.hoisted(() => ({
+  myid: 99,
+  fetch: vi.fn().mockResolvedValue({}),
+  fetchMultiple: vi.fn().mockResolvedValue([]),
+}))
+
+const defaultItems = () => [
+  {
+    id: 10,
+    position: 0,
+    name: 'Chairs',
+    quantity: 4,
+    interest: [
+      { userid: 1, quantity: 4, state: 'Reserved' },
+      { userid: 2, quantity: 1, state: 'Interested' },
+      { userid: 3, quantity: 1, state: 'Withdrawn' }, // inactive → not counted
+    ],
+  },
+  {
+    id: 11,
+    position: 1,
+    name: 'Desk',
+    quantity: 2,
+    interest: [{ userid: 2, quantity: 1, state: 'Interested' }],
+  },
+]
+
+const mockMessage = {
+  id: 1,
+  subject: 'Office clearance',
+  fromuser: 99,
+  bulkcount: 2,
+  bulkitems: defaultItems(),
+}
+
+vi.mock('~/stores/message', () => ({
+  useMessageStore: () => ({ byId: () => mockMessage, fetch: h.fetch }),
+}))
+vi.mock('~/stores/user', () => ({
+  useUserStore: () => ({ fetchMultiple: h.fetchMultiple, byId: () => null }),
+}))
+vi.mock('~/composables/useMe', () => ({
+  useMe: () => ({
+    myid: {
+      get value() {
+        return h.myid
+      },
+    },
+  }),
+}))
+vi.mock('~/components/NoticeMessage', () => ({
+  default: {
+    name: 'NoticeMessage',
+    template: '<div class="notice-stub"><slot /></div>',
+  },
+}))
+vi.mock('~/components/ClearanceManageItem', () => ({
+  default: {
+    name: 'ClearanceManageItem',
+    template: '<div class="item-stub" />',
+    props: ['message', 'item', 'index'],
+  },
+}))
+
+import ClearanceManager from '~/components/ClearanceManager.vue'
+
+const mountOpts = {
+  props: { id: 1 },
+  global: { stubs: { 'b-spinner': true } },
+}
+
+describe('ClearanceManager', () => {
+  beforeEach(() => {
+    h.myid = 99
+    h.fetch.mockClear()
+    h.fetchMultiple.mockClear()
+    mockMessage.fromuser = 99
+    mockMessage.bulkcount = 2
+    mockMessage.bulkitems = defaultItems()
+  })
+
+  it('lets the offerer manage their own clearance', () => {
+    const w = mount(ClearanceManager, mountOpts)
+    expect(w.vm.canManage).toBe(true)
+    expect(w.vm.isClearance).toBe(true)
+    expect(w.vm.items.map((i) => i.id)).toEqual([10, 11]) // sorted by position
+  })
+
+  it('counts distinct interested people and fully-allocated items', () => {
+    const w = mount(ClearanceManager, mountOpts)
+    // Active interest across items: users 1 and 2 (user 3 withdrew).
+    expect(w.vm.peopleInterested).toBe(2)
+    // Chairs: 4 of 4 reserved → full. Desk: 0 of 2 → not full.
+    expect(w.vm.fullyAllocated).toBe(1)
+  })
+
+  it('refuses management to a non-owner', () => {
+    h.myid = 42
+    const w = mount(ClearanceManager, mountOpts)
+    expect(w.vm.canManage).toBe(false)
+    expect(w.find('.notice-stub').exists()).toBe(true)
+  })
+
+  it('treats a post with no bulk items as not a clearance', () => {
+    mockMessage.bulkcount = 0
+    mockMessage.bulkitems = []
+    const w = mount(ClearanceManager, mountOpts)
+    expect(w.vm.isClearance).toBe(false)
+  })
+
+  it('loads the message then the interested users on mount', async () => {
+    mount(ClearanceManager, mountOpts)
+    await flushPromises()
+    expect(h.fetch).toHaveBeenCalledWith(1, true)
+    expect(h.fetchMultiple).toHaveBeenCalledTimes(1)
+    expect(h.fetchMultiple.mock.calls[0][0].sort()).toEqual([1, 2])
+  })
+})

--- a/iznik-nuxt3/tests/unit/components/ClearanceManager.spec.js
+++ b/iznik-nuxt3/tests/unit/components/ClearanceManager.spec.js
@@ -111,11 +111,13 @@ describe('ClearanceManager', () => {
     expect(w.vm.isClearance).toBe(false)
   })
 
-  it('loads the message then the interested users on mount', async () => {
+  it('loads the message then ALL interested users on mount (incl. withdrawn, for names)', async () => {
     mount(ClearanceManager, mountOpts)
     await flushPromises()
     expect(h.fetch).toHaveBeenCalledWith(1, true)
     expect(h.fetchMultiple).toHaveBeenCalledTimes(1)
-    expect(h.fetchMultiple.mock.calls[0][0].sort()).toEqual([1, 2])
+    // Users 1 (Reserved) + 2 (Interested) + 3 (Withdrawn) — withdrawn included
+    // so their name renders in the declined/withdrawn section.
+    expect(h.fetchMultiple.mock.calls[0][0].sort()).toEqual([1, 2, 3])
   })
 })

--- a/iznik-nuxt3/tests/unit/components/MyPostsClearances.spec.js
+++ b/iznik-nuxt3/tests/unit/components/MyPostsClearances.spec.js
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+
+// Full messages in the store, keyed by id. Only id 1 is a clearance.
+const store = {
+  1: {
+    id: 1,
+    subject: 'Office clearance',
+    bulkcount: 2,
+    bulkitems: [
+      { interest: [{ userid: 7, state: 'Interested' }] },
+      { interest: [{ userid: 8, state: 'Reserved' }] },
+    ],
+  },
+  2: { id: 2, subject: 'Single sofa', bulkcount: 0, bulkitems: [] },
+}
+
+vi.mock('~/stores/message', () => ({
+  useMessageStore: () => ({ byId: (id) => store[id] || null }),
+}))
+
+import MyPostsClearances from '~/components/MyPostsClearances.vue'
+
+const mountOpts = (posts) => ({
+  props: { posts },
+  global: { stubs: { 'b-button': true, 'b-badge': true } },
+})
+
+describe('MyPostsClearances', () => {
+  it('lists only the posts that are clearances', () => {
+    const w = mount(
+      MyPostsClearances,
+      mountOpts([{ id: 1 }, { id: 2 }, { id: 3 }])
+    )
+    expect(w.vm.clearances.map((c) => c.id)).toEqual([1])
+    expect(w.find('[data-testid="clearance-row-1"]').exists()).toBe(true)
+    expect(w.find('[data-testid="clearance-row-2"]').exists()).toBe(false)
+  })
+
+  it('surfaces the item and interested counts', () => {
+    const w = mount(MyPostsClearances, mountOpts([{ id: 1 }]))
+    const c = w.vm.clearances[0]
+    expect(c.bulkcount).toBe(2)
+    expect(c.interested).toBe(2) // users 7 and 8
+    expect(c.subject).toBe('Office clearance')
+  })
+
+  it('links each clearance to its management page', () => {
+    const w = mount(MyPostsClearances, mountOpts([{ id: 1 }]))
+    expect(w.find('[data-testid="manage-1"]').exists()).toBe(true)
+  })
+
+  it('renders nothing when the user has no clearances', () => {
+    const w = mount(MyPostsClearances, mountOpts([{ id: 2 }]))
+    expect(w.find('[data-testid="myposts-clearances"]').exists()).toBe(false)
+  })
+})

--- a/iznik-nuxt3/tests/unit/composables/useClearance.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useClearance.spec.js
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest'
+import {
+  clearanceStateLabel,
+  clearanceStateVariant,
+  clearanceActions,
+  isAllocatedState,
+  isPoolState,
+  isInactiveState,
+  isActiveInterest,
+  allocatedQuantity,
+  distinctInterestedUsers,
+} from '~/composables/useClearance'
+
+describe('useClearance', () => {
+  it('labels and variants map known states, falling back gracefully', () => {
+    expect(clearanceStateLabel('Reserved')).toBe('Allocated')
+    expect(clearanceStateLabel('Interested')).toBe('Wants it')
+    expect(clearanceStateLabel('Wibble')).toBe('Wibble')
+    expect(clearanceStateVariant('Collected')).toBe('primary')
+    expect(clearanceStateVariant('Wibble')).toBe('secondary')
+  })
+
+  it('classifies states into groups', () => {
+    expect(isAllocatedState('Reserved')).toBe(true)
+    expect(isAllocatedState('Collected')).toBe(true)
+    expect(isAllocatedState('Interested')).toBe(false)
+    expect(isPoolState('Interested')).toBe(true)
+    expect(isInactiveState('Withdrawn')).toBe(true)
+    expect(isInactiveState('Rejected')).toBe(true)
+    expect(isInactiveState('Reserved')).toBe(false)
+  })
+
+  it('treats withdrawn/rejected rows as inactive interest', () => {
+    expect(isActiveInterest({ state: 'Interested' })).toBe(true)
+    expect(isActiveInterest({ state: 'Reserved' })).toBe(true)
+    expect(isActiveInterest({ state: 'Withdrawn' })).toBe(false)
+    expect(isActiveInterest(null)).toBe(false)
+  })
+
+  it('sums only allocated quantities', () => {
+    const interest = [
+      { state: 'Reserved', quantity: 3 },
+      { state: 'Collected', quantity: 2 },
+      { state: 'Interested', quantity: 5 }, // not counted
+      { state: 'Withdrawn', quantity: 9 }, // not counted
+    ]
+    expect(allocatedQuantity(interest)).toBe(5)
+    expect(allocatedQuantity([])).toBe(0)
+  })
+
+  it('counts distinct interested users across items, ignoring inactive', () => {
+    const items = [
+      {
+        interest: [
+          { userid: 1, state: 'Interested' },
+          { userid: 2, state: 'Reserved' },
+        ],
+      },
+      {
+        interest: [
+          { userid: 2, state: 'Interested' }, // dup user
+          { userid: 3, state: 'Withdrawn' }, // inactive → ignored
+        ],
+      },
+    ]
+    expect(distinctInterestedUsers(items)).toBe(2)
+    expect(distinctInterestedUsers([])).toBe(0)
+  })
+
+  it('offers the right next-state actions per state', () => {
+    expect(clearanceActions('Interested').map((a) => a.state)).toEqual([
+      'Reserved',
+      'Rejected',
+    ])
+    expect(clearanceActions('Reserved').map((a) => a.state)).toEqual([
+      'Collected',
+      'Interested',
+    ])
+    expect(clearanceActions('Collected').map((a) => a.state)).toEqual([
+      'Reserved',
+    ])
+    expect(clearanceActions('Rejected').map((a) => a.state)).toEqual([
+      'Interested',
+    ])
+    // The replier withdrew — nothing for the offerer to do.
+    expect(clearanceActions('Withdrawn')).toEqual([])
+  })
+})

--- a/iznik-server/scripts/cron/lovejunk.php
+++ b/iznik-server/scripts/cron/lovejunk.php
@@ -49,10 +49,11 @@ $msgs = $dbhr->preQuery("SELECT messages.id FROM messages
     INNER JOIN `groups` ON groups.id = messages_groups.groupid
     WHERE messages.arrival >= ? AND
           messages.arrival >= '2023-06-13 14:50' AND
-      messages.type = ? AND   
+      messages.type = ? AND
       lovejunk.msgid IS NULL AND
       messages_groups.collection = ? AND
-      groups.onlovejunk = 1
+      groups.onlovejunk = 1 AND
+      NOT EXISTS (SELECT 1 FROM messages_bulk_items WHERE messages_bulk_items.msgid = messages.id)
       ORDER BY messages.arrival ASC;
 ", [
     $start,


### PR DESCRIPTION
Builds the offerer-facing **management page** for a bulk ("clearance") offer — the dashboard explicitly deferred from #618. Stacked on `feature/bulk-offer-clearance`; targets that branch (depends on its data model + API).

A bulk offerer can be swamped by replies across dozens of items. This page gives them one place to see who wants what, decide allocations, and keep fallbacks warm — exposing the persisted interest FSM (`Interested → Reserved → Collected`, plus `Rejected`/`Withdrawn`) in plain language.

## Summary
- **New route `/clearance/:id`** (login-gated, owner-only). Per catalogue item it shows: allocation progress (`Allocated N of M · X left` / `Fully allocated`), **who it's allocated to**, the **interested pool / fallback recipients**, and a tucked-away declined/withdrawn list.
- **Per-candidate controls** drive the existing `BulkInterestState` action: **Allocate** (→ Reserved; the API auto-sends collection details), **Mark collected**, **Un-allocate**, **Decline**, **Restore**. Each candidate shows their name + reputation, quantity wanted, collection availability, a link to the chat, and a **"also collecting N more"** hint when they're already allocated other items in the same clearance (minimise collection visits).
- **Totals header** — items / distinct people interested / items fully allocated — plus a legend mapping raw states to plain language.
- **Discoverability** — a "Your clearances" panel on `/myposts` linking to each management page (renders nothing for users with no clearances). Two-line addition to `myposts.vue`.
- **Shared logic** in `composables/useClearance.js` (state labels/variants, allocation maths, action lists) — pure and unit-tested, reused across the components.

## No backend change
The Go API already returns the owner-only per-item `interest[]` array (gated on `message.Fromuser == myid`) and exposes the `BulkInterestState` action and `messageStore.bulkInterestState()` store method — previously unused. This PR is the first consumer. User names/reputation are fetched client-side via `userStore.fetchMultiple()` (the `interest[]` rows carry only `userid`).

## Code Quality Review
- Logic split: pure helpers in a composable; presentational components (`ClearanceManager` → `ClearanceManageItem` → `ClearanceCandidate`) mirror the existing `BulkItemsInterest`/`BulkInterestEditor` structure, SCSS conventions and `data-testid` usage.
- Owner guard + "not a clearance" guard handled in `ClearanceManager`; mods continue to use modtools.
- Icons used (`truck`, `comments`, `gift`, `angle-right`, `image`) confirmed registered in `plugins/vue-awesome.js`. Prettier-clean.

## Test Plan
- **Vitest (27 new, all passing)** via the worktree status API: `useClearance` (label/variant/group/maths/actions), `ClearanceCandidate` (per-state actions, `setState` store call + emit, also-collecting hint), `ClearanceManageItem` (grouping into allocated/pool/inactive, allocation maths, fully-allocated, cross-item hint), `ClearanceManager` (owner guard, distinct-interested + fully-allocated counts, load fetches users), `MyPostsClearances` (filters to clearances, links, renders nothing when none).
- Existing **`myposts` page suite still passes (79)** — the panel addition doesn't regress it.
- **Not yet done:** live render with seeded multi-user interest data (needs a rebuilt worktree dev container + seeded clearance). CI's full build + Playwright is the live gate; manual walkthrough recommended before merge.

## Future Improvements
- Optional: enrich the API `interest[]` with `displayname`/ratings to drop the client-side `fetchMultiple`.
- Optional: quantity-aware allocation (cap a reserve at remaining quantity) and bulk "allocate all to X" for single-visit collectors.
- A Playwright E2E once a seedable clearance fixture exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)