### PR TITLE
fix(modtools/stdmsg): auto-grow the standard-message edit boxes

### DIFF
--- a/iznik-nuxt3/modtools/components/ModStdMessageModal.vue
+++ b/iznik-nuxt3/modtools/components/ModStdMessageModal.vue
@@ -56,10 +56,11 @@
         </p>
       </NoticeMessage>
       <!-- Plain textarea for messages with no directives. -->
-      <b-form-textarea
+      <AutoHeightTextarea
         v-if="!useSegmentedEditor"
         v-model="body"
         rows="10"
+        max-rows="40"
         class="mt-2"
       />
       <!-- Segmented inline editor: the message in flow, with a box per <editthis>
@@ -73,14 +74,14 @@
         </p>
         <div class="segmented-body">
           <template v-for="(seg, i) in segments" :key="'seg' + i">
-            <b-form-textarea
+            <AutoHeightTextarea
               v-if="seg.type === 'text'"
               v-model="seg.content"
               class="seg-text"
               rows="3"
               max-rows="30"
             />
-            <b-form-textarea
+            <AutoHeightTextarea
               v-else-if="seg.type === 'editthis'"
               v-model="seg.value"
               :class="['seg-editthis', { 'seg-todo': !segEdited(seg) }]"

--- a/iznik-nuxt3/tests/unit/components/modtools/ModStdMessageModal.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModStdMessageModal.spec.js
@@ -278,6 +278,11 @@ describe('ModStdMessageModal', () => {
             props: ['value', 'find'],
             emits: ['selected'],
           },
+          AutoHeightTextarea: {
+            template:
+              '<textarea :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" />',
+            props: ['modelValue', 'rows', 'maxRows', 'placeholder'],
+          },
         },
       },
     })


### PR DESCRIPTION
## Summary

The standard-message editor boxes weren't growing to fit content (reported on the new **segmented editor**). They were `b-form-textarea` with `rows`/`max-rows` — but **bootstrap-vue-next's `b-form-textarea` doesn't grow with `max-rows`**, which is exactly why `AutoHeightTextarea` exists (it monitors the textarea's `scrollHeight` and adds rows). So #755's segmented boxes had a 3-line minimum but never grew.

## Fix

Swap the three std-message edit boxes to `AutoHeightTextarea` (the auto-grow component already used in `NewsReply`/`NewsThread`/chitchat), keeping the same `rows`/`max-rows`:
- plain editor (`!useSegmentedEditor`) — `rows=10 max-rows=40`
- segment `text` (prose) — `rows=3 max-rows=30`
- segment `editthis` (fill-in) — `rows=3 max-rows=12`

`AutoHeightTextarea` is a single-root `b-form-textarea` wrapper, so `class` / `v-model` / `placeholder` all forward unchanged.

## Verification

- Confirmed `AutoHeightTextarea` auto-grows in-browser on freegle-dev-live (the ChitChat composer): typing 9 lines grew it from **2 rows / 78px → 6 rows / 174px**.
- The std-message modal lives only in ModTools; modtools-dev-live was on a stale build (`constants.js` missing `HARD_RELOAD_COUNTDOWN_SECS`), so I couldn't drive that exact modal there — but the change is a drop-in to the verified-growing component.
