### PR TITLE
fix(modtools): flag duplicate posts while still in Pending state

### DIFF
--- a/iznik-nuxt3/modtools/components/ModMessage.vue
+++ b/iznik-nuxt3/modtools/components/ModMessage.vue
@@ -1356,8 +1356,16 @@ function checkHistory(duplicateCheck) {
 
           const key = histMsg.id + '-' + histMsg.arrival
 
-          if (duplicateCheck && groupsInCommon) {
-            // Same group - so this is a duplicate
+          if (duplicateCheck && groupsInCommon && histMsg.id < message.value.id) {
+            // Same group, and this history message was posted before the one we're
+            // rendering (message ids are auto-increment, so a lower id means earlier).
+            // So the message we're rendering is the second/subsequent copy and IS a
+            // duplicate of this earlier one. We deliberately do NOT flag the first
+            // (original) post: when rendering it, every same-subject match in its
+            // history has a higher id, so checkHistory returns empty and it stays
+            // unflagged. This keeps the duplicate badge on the 2nd+ copies only - which
+            // matters now that Pending messages appear in messagehistory (PR #805), as
+            // otherwise both copies of a duplicated Pending post would be flagged.
             if (!dupids[key]) {
               dupids[key] = true
               ret.push(histMsg)

--- a/iznik-server-go/test/user_test.go
+++ b/iznik-server-go/test/user_test.go
@@ -4352,3 +4352,74 @@ func TestRecentWanted_GoAPI_ExcludesNonApproved(t *testing.T) {
 		"messagehistory entries must include 'postdate' field (bug: Go API returns 'arrival' only; "+
 			"frontend uses msg.postdate → dayjs(undefined) = current time instead of original arrival)")
 }
+
+// TestGetUserMessageHistory_IncludesPending verifies that Pending messages appear in the
+// messagehistory returned by GET /api/user/:id?modtools=true.
+//
+// ModTools duplicate detection (ModMessage.vue checkHistory) relies on messagehistory to
+// flag a new Pending post as a duplicate of a prior pending post from the same user.
+// Commit b277d9fab added AND mg.collection='Approved' to GetUserMessageHistory, which
+// broke this: Pending messages were silently excluded so no duplicate was ever flagged.
+// (Discourse 9518/341)
+//
+// This test asserts the FIXED behaviour (FAILS on buggy code, PASSES after fix).
+func TestGetUserMessageHistory_IncludesPending(t *testing.T) {
+	prefix := uniquePrefix("msghistory_pending")
+	db := database.DBConn
+
+	groupID := CreateTestGroup(t, prefix)
+	posterID := CreateTestUser(t, prefix+"_poster", "User")
+	modID := CreateTestUser(t, prefix+"_mod", "User")
+	CreateTestMembership(t, posterID, groupID, "Member")
+	CreateTestMembership(t, modID, groupID, "Moderator")
+	_, modToken := CreateTestSession(t, modID)
+
+	// Insert a Pending message — simulates a post awaiting moderation.
+	pendingSubject := prefix + " OFFER free bike"
+	db.Exec(
+		"INSERT INTO messages (fromuser, subject, textbody, message, type, arrival) "+
+			"VALUES (?, ?, 'body', 'body', 'Offer', NOW())",
+		posterID, pendingSubject)
+	var pendingMsgID uint64
+	db.Raw("SELECT id FROM messages WHERE fromuser = ? AND subject = ? ORDER BY id DESC LIMIT 1",
+		posterID, pendingSubject).Scan(&pendingMsgID)
+	require.NotZero(t, pendingMsgID, "pending message must be created")
+	db.Exec(
+		"INSERT INTO messages_groups (msgid, groupid, arrival, collection) "+
+			"VALUES (?, ?, NOW(), 'Pending')",
+		pendingMsgID, groupID)
+
+	t.Cleanup(func() {
+		db.Exec("DELETE FROM messages_groups WHERE msgid = ?", pendingMsgID)
+		db.Exec("DELETE FROM messages WHERE id = ?", pendingMsgID)
+	})
+
+	url := fmt.Sprintf("/api/user/%d?modtools=true&jwt=%s", posterID, modToken)
+	resp, err := getApp().Test(httptest.NewRequest("GET", url, nil))
+	require.NoError(t, err)
+	require.Equal(t, 200, resp.StatusCode)
+
+	var raw map[string]interface{}
+	err = json.NewDecoder(resp.Body).Decode(&raw)
+	require.NoError(t, err)
+
+	// messagehistory is omitted (omitempty) when empty; nil means no history was returned.
+	pendingFound := false
+	if histRaw, exists := raw["messagehistory"]; exists {
+		if history, ok := histRaw.([]interface{}); ok {
+			for _, h := range history {
+				entry, _ := h.(map[string]interface{})
+				id := uint64(entry["id"].(float64))
+				if id == pendingMsgID {
+					pendingFound = true
+				}
+			}
+		}
+	}
+
+	// FIXED behaviour: Pending must appear so checkHistory() in ModMessage.vue can flag it
+	// as a duplicate. FAILS on code with mg.collection='Approved' filter.
+	assert.True(t, pendingFound,
+		"Pending message must appear in messagehistory for duplicate detection "+
+			"(regression: b277d9fab added mg.collection='Approved' filter that excludes Pending)")
+}

--- a/iznik-server-go/user/user.go
+++ b/iznik-server-go/user/user.go
@@ -483,8 +483,8 @@ func GetUserMessageHistory(userid uint64) []UserMessageHistory {
 		"FROM messages m "+
 		"INNER JOIN messages_groups mg ON m.id = mg.msgid "+
 		"LEFT JOIN messages_postings mp ON mp.msgid = m.id "+
-		"WHERE m.fromuser = ? AND mg.deleted = 0 AND m.deleted IS NULL AND mg.collection = ? "+
-		"ORDER BY arrival DESC", userid, utils.COLLECTION_APPROVED).Scan(&history)
+		"WHERE m.fromuser = ? AND mg.deleted = 0 AND m.deleted IS NULL AND mg.collection IN (?, ?) "+
+		"ORDER BY arrival DESC", userid, utils.COLLECTION_APPROVED, utils.COLLECTION_PENDING).Scan(&history)
 
 	now := time.Now()
 	for ix, h := range history {


### PR DESCRIPTION
## Root Cause

`GetUserMessageHistory` in `iznik-server-go/user/user.go` (line 486) filtered `mg.collection = 'Approved'` only. This was introduced by commit b277d9fab ("fix(modtools): \$recentwanted uses original arrival time and excludes non-approved messages") and is a regression: before that commit, all collections were returned, so Pending messages appeared in `messagehistory`.

ModTools duplicate detection works by comparing a message's canonical subject against `fromUser.messagehistory` in `checkHistory()` (ModMessage.vue:1330). Since Pending messages were excluded from `messagehistory`, a second identical Pending post from the same user was never flagged as a duplicate.

## Evidence

```
--- FAIL: TestGetUserMessageHistory_IncludesPending (0.13s)
    user_test.go:4422:
            Error Trace: /app/test/user_test.go:4422
            Error:       Should be true
            Test:        TestGetUserMessageHistory_IncludesPending
            Messages:    Pending message must appear in messagehistory for duplicate detection
                         (regression: b277d9fab added mg.collection='Approved' filter that excludes Pending)
FAIL
```

## Fix

In `GetUserMessageHistory`, extend the collection filter from `= 'Approved'` to `IN ('Approved', 'Pending')`. Rejected/Spam/Banned remain excluded. The existing `TestRecentWanted_GoAPI_ExcludesNonApproved` test still passes (Rejected messages are still excluded).

## Other Call Sites

`GetUserMessageHistory` is called only from `enrichUserForModtools` - no other callers.

## Test

File: `iznik-server-go/test/user_test.go` - `TestGetUserMessageHistory_IncludesPending`

Command: `go test ./test/... -run TestGetUserMessageHistory_IncludesPending -v`

Proves: FAIL before fix (Pending message absent from messagehistory), PASS after fix.

## Discourse
https://discourse.ilovefreegle.org/t/9518/341

## Follow-up: flag only the 2nd+ copy, not the first

Including Pending in `messagehistory` means a duplicated Pending post now has BOTH copies in the user's history. `checkHistory()` previously compared a message against every same-subject history entry regardless of order, so it flagged the original as well as the duplicate.

`checkHistory()` now guards the duplicate branch on `histMsg.id < message.value.id` - a history message only counts as the "original" when it was posted earlier (message ids are auto-increment). The first/original post finds no earlier match and stays unflagged; the second and subsequent copies are flagged. Crosspost detection is unchanged.