### PR TITLE
fix(modtools): de-duplicate member history and reset group filter

### DIFF
--- a/iznik-nuxt3/modtools/components/ModPostingHistoryModal.vue
+++ b/iznik-nuxt3/modtools/components/ModPostingHistoryModal.vue
@@ -10,7 +10,7 @@
         <NoticeMessage v-if="!messages.length" variant="info" class="mb-2">
           There are no posts to show.
         </NoticeMessage>
-        <ModGroupSelect v-model="groupid" modonly class="mb-2" />
+        <ModGroupSelect v-model="groupid" modonly :all="true" class="mb-2" />
         <b-row
           v-for="message in messages"
           :key="message.id"
@@ -105,17 +105,28 @@ const messages = computed(() => {
   let ret = []
 
   if (user.value && user.value.messagehistory) {
-    ret = user.value.messagehistory.filter((message) => {
-      return !props.type || props.type === message.type
-    })
+    // The server SQL JOINs messages_postings without aggregation, producing one row
+    // per repost entry per (message, group) pair.  Deduplicate by (id, groupid),
+    // keeping the entry with the latest arrival date (= most recent repost).
+    const seen = new Map()
+    for (const message of user.value.messagehistory) {
+      if (props.type && props.type !== message.type) continue
+      const key = `${message.id}-${message.groupid}`
+      const existing = seen.get(key)
+      if (!existing || new Date(message.arrival) > new Date(existing.arrival)) {
+        seen.set(key, message)
+      }
+    }
 
-    ret.forEach((message) => {
+    // Spread into plain copies so we never mutate reactive store objects.
+    ret = Array.from(seen.values()).map((message) => {
       const group = groupStore.get(message.groupid)
-      if (group) {
-        message.groupname = group.namedisplay
-      } else {
-        message.groupname = '#' + message.groupid
+      if (!group) {
         groupStore.fetch(message.groupid)
+      }
+      return {
+        ...message,
+        groupname: group ? group.namedisplay : '#' + message.groupid,
       }
     })
 

--- a/iznik-nuxt3/tests/unit/components/modtools/ModPostingHistoryModal.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModPostingHistoryModal.spec.js
@@ -335,4 +335,71 @@ describe('ModPostingHistoryModal', () => {
       expect(wrapper.vm.messages.length).toBe(3)
     })
   })
+
+  describe('deduplication of reposted messages (Discourse 9672)', () => {
+    // The server SQL JOINs messages_postings without aggregation, producing one row
+    // per repost for each message.  This causes duplicate (id, groupid) pairs in
+    // messagehistory that must be deduplicated client-side.
+
+    const createUserWithReposts = () =>
+      createUser({
+        messagehistory: [
+          // message 201 appears twice in group 123 — simulates two messages_postings rows
+          {
+            id: 201,
+            subject: 'Offer: Sofa',
+            type: 'Offer',
+            arrival: '2024-01-10T10:00:00Z',
+            groupid: 123,
+            outcome: null,
+            repost: false,
+            autorepost: false,
+            collection: 'Approved',
+          },
+          {
+            id: 201,
+            subject: 'Offer: Sofa',
+            type: 'Offer',
+            arrival: '2024-02-10T10:00:00Z',
+            groupid: 123,
+            outcome: null,
+            repost: true,
+            autorepost: true,
+            collection: 'Approved',
+          },
+          // message 202 in a different group — unique
+          {
+            id: 202,
+            subject: 'Wanted: Table',
+            type: 'Wanted',
+            arrival: '2024-01-15T10:00:00Z',
+            groupid: 456,
+            outcome: null,
+            repost: false,
+            autorepost: false,
+            collection: 'Approved',
+          },
+        ],
+      })
+
+    it('deduplicates messages with same (id, groupid), keeping the entry with the latest arrival', async () => {
+      const wrapper = mountComponent({ user: createUserWithReposts() })
+      wrapper.vm.groupid = 123
+      await wrapper.vm.$nextTick()
+      expect(wrapper.vm.messages.length).toBe(1)
+      expect(wrapper.vm.messages[0].arrival).toBe('2024-02-10T10:00:00Z')
+    })
+
+    it('reverting the group filter to all-groups shows the full deduplicated history', async () => {
+      const wrapper = mountComponent({ user: createUserWithReposts() })
+
+      wrapper.vm.groupid = 123
+      await wrapper.vm.$nextTick()
+      expect(wrapper.vm.messages.length).toBe(1)
+
+      wrapper.vm.groupid = 0
+      await wrapper.vm.$nextTick()
+      expect(wrapper.vm.messages.length).toBe(2)
+    })
+  })
 })


### PR DESCRIPTION
## Root Cause

The server-side SQL in `GetUserMessageHistory` (`iznik-server-go/user/user.go:479`) JOINs `messages_postings` without aggregation:

```sql
LEFT JOIN messages_postings mp ON mp.msgid = m.id
```

A message that has been reposted multiple times has one row per repost in `messages_postings`.  The join therefore produces one row per repost per `(message, group)` pair, causing duplicate `(id, groupid)` entries in the returned `messagehistory`.

In the posting-history modal:
1. **Duplication**: when a frequent reposter's history is filtered to a single group, every repost of the same message appears as a separate row.
2. **"Not reverting"**: for a user who only posts in one group, the all-groups and single-group-filtered views look identical because all the duplicated rows are from the same group.

## Evidence

Tests — fail before the fix, pass after:
```
✓ deduplicates messages with same (id, groupid), keeping the entry with the latest arrival
✓ reverting the group filter to all-groups shows the full deduplicated history
```

Failing output before fix:
```
× deduplicates messages with same (id, groupid), keeping the entry with the latest arrival 7ms
  → expected 2 to be 1 // Object.is equality
× reverting the group filter to all-groups shows the full deduplicated history 7ms
  → expected 2 to be 1 // Object.is equality
```

## Fix

`iznik-nuxt3/modtools/components/ModPostingHistoryModal.vue`:
- **Deduplicate** `messagehistory` by `(id, groupid)` in the `messages` computed, keeping the entry with the latest `arrival` (= most recent repost date).
- **No-mutation**: spread each deduplicated entry into a plain object instead of mutating reactive Pinia store objects inside the computed.
- **UX**: add `:all="true"` to `ModGroupSelect` so the first option reads "All my communities" instead of "Please choose", making the filter-reset option obvious to moderators.

## Other Call Sites

`messagehistory` is also iterated in:
- `ModMessage.vue:1341` — duplicate-check loop; guarded by `histMsg.id !== message.value.id` so same-id duplicates are skipped.
- `ModPostingHistory.vue:123`, `ModMemberSummary.vue:133` — count OFFERs/WANTEDs by `daysago`; duplicate rows would inflate counts.  Those are a separate issue.

## Test

File: `iznik-nuxt3/tests/unit/components/modtools/ModPostingHistoryModal.spec.js`
Command: `POST http://localhost:8081/api/tests/vitest {"filter":"ModPostingHistoryModal"}`
Result: 31/31 pass

Proves fail-before (2 rows for duplicated message), pass-after (1 deduplicated row; all-groups count different from single-group count).

## Discourse

https://discourse.ilovefreegle.org/t/9672/3