### PR TITLE
fix(modtools): self-deleted accounts show "left platform" not "Rejected member"

### DIFF
--- a/iznik-nuxt3/modtools/components/ModLog.vue
+++ b/iznik-nuxt3/modtools/components/ModLog.vue
@@ -239,7 +239,9 @@
             <ModLogStdMsg :logid="logid" />
           </span>
           <span v-else-if="log.subtype === 'Deleted'">
-            <span v-if="logByuser">Rejected member</span>
+            <span v-if="logUser && logByuser && logByuser.id !== logUser.id"
+              >Rejected member</span
+            >
             <span v-else>User left platform ({{ log.text }})</span>
             <ModLogUser :userid="logUser.id" />
             <ModLogGroup :logid="logid" tag="on" />

--- a/iznik-nuxt3/tests/unit/components/modtools/ModLog.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModLog.spec.js
@@ -707,8 +707,8 @@ describe('ModLog', () => {
       expect(wrapper.find('.row').exists()).toBe(true)
     })
 
-    it('handles User/Deleted with byuser (Rejected) and without byuser (self-leave)', () => {
-      // With byuser - shows Rejected member
+    it('handles User/Deleted: another mod (Rejected), no byuser and self-delete (left platform)', () => {
+      // byuser is a different person (a mod removed them) - shows Rejected member
       const wrapperWithByuser = createWrapper({
         id: 1,
         type: 'User',
@@ -728,6 +728,20 @@ describe('ModLog', () => {
         text: 'privacy',
       })
       expect(wrapperWithoutByuser.text()).toContain('User left platform')
+
+      // Self-delete: byuser === user. The V2 soft-delete records the actor, who
+      // for a self-delete is the user themselves, so it must NOT say "Rejected
+      // member" (that wording is for a moderator removing someone else).
+      const wrapperSelfDelete = createWrapper({
+        id: 1,
+        type: 'User',
+        subtype: 'Deleted',
+        user: { id: 1, displayname: 'User' },
+        byuser: { id: 1, displayname: 'User' },
+        text: 'privacy',
+      })
+      expect(wrapperSelfDelete.text()).toContain('User left platform')
+      expect(wrapperSelfDelete.text()).not.toContain('Rejected member')
     })
   })
 


### PR DESCRIPTION
## Problem

In ModTools, the member-logs view showed **"Rejected member"** for people who had simply **deleted their own Freegle account**. A moderator (Dee) asked what "Rejected member" meant and whether it meant someone had left a group - it doesn't, and the wording was misleading.

### Root cause

`ModLog.vue`'s `User`/`Deleted` branch displayed "Rejected member" whenever the log had **any** `byuser`:

```vue
<span v-if="logByuser">Rejected member</span>
<span v-else>User left platform ({{ log.text }})</span>
```

The intent was "a moderator removed them" (byuser = a mod) vs "they left themselves" (no byuser). But the V2 soft-delete path (`softLimboUser` in `iznik-server-go/user/user.go`) records the **actor** on every deletion - and for a self-service account deletion that actor is the **user themselves**. So self-deletions now carry `byuser = user`, tripping the `v-if="logByuser"` branch and mislabelling a voluntary account closure as a moderator "rejection".

Verified against live data: user #40425833 self-deleted on 2 Jun 2026 (`User/Deleted`, `user == byuser`, no group, no reason), then logged back in within the 14-day grace period and recovered the account. ModTools showed this as "Rejected member".

## Fix

Guard the "Rejected member" wording on `logByuser.id !== logUser.id`, exactly as every other branch in the component already does (e.g. `Group`/`Left` shows "Removed member" when a mod removes someone vs "Left" for a self-leave).

- Self-delete (`byuser == user`) -> **"User left platform"**
- Moderator removal (`byuser` is a different person) -> still **"Rejected member"**
- No `byuser` -> still **"User left platform"**

## Tests

Extended the existing `User/Deleted` edge-case spec to add the self-delete case (`byuser.id === user.id`), asserting it shows "User left platform" and **not** "Rejected member". Full ModLog vitest suite green (208 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
