### PR TITLE
fix(group config editing): treat protected config with null createdby as unlocked

### DIFF
--- a/iznik-nuxt3/modtools/components/ModSettingsModConfig.vue
+++ b/iznik-nuxt3/modtools/components/ModSettingsModConfig.vue
@@ -39,7 +39,7 @@
     </div>
     <Spinner v-if="loading" :size="50" class="d-block mt-2" />
     <div v-else-if="configid && config">
-      <NoticeMessage v-if="config.protected" variant="info" class="mb-2">
+      <NoticeMessage v-if="config.protected && config.createdby" variant="info" class="mb-2">
         <v-icon icon="lock" />
         <span v-if="parseInt(config.createdby) === myid">
           You have locked this. Other people can use, view or copy it, but can't
@@ -344,6 +344,7 @@ const locked = computed(() => {
   return Boolean(
     config.value &&
       config.value.protected &&
+      config.value.createdby &&
       parseInt(config.value.createdby) !== myid.value
   )
 })
@@ -417,6 +418,7 @@ watch(
 
       if (
         config.value?.protected &&
+        config.value?.createdby &&
         parseInt(config.value?.createdby) !== myid.value
       ) {
         await userStore.fetch(parseInt(config.value.createdby))

--- a/iznik-nuxt3/tests/unit/components/modtools/ModSettingsModConfig.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModSettingsModConfig.spec.js
@@ -301,6 +301,18 @@ describe('ModSettingsModConfig', () => {
       const wrapper = mountComponent()
       expect(wrapper.vm.locked).toBe(false)
     })
+
+    it('returns false when config is protected but createdby is null (no valid lock owner)', () => {
+      // Regression: parseInt(null) = NaN, and NaN !== myid is always true,
+      // causing a null-owner config to appear locked for everyone.
+      mockModConfigStore.current = {
+        ...defaultConfig,
+        protected: 1,
+        createdby: null,
+      }
+      const wrapper = mountComponent()
+      expect(wrapper.vm.locked).toBe(false)
+    })
   })
 
   describe('config sections', () => {
@@ -460,6 +472,20 @@ describe('ModSettingsModConfig', () => {
       const wrapper = mountComponent()
       await flushPromises()
       expect(wrapper.text()).toContain('Alice Moderator')
+    })
+
+    it('does not show locked notice when protected but createdby is null', async () => {
+      // Regression: protected=1 with createdby=null showed 'locked by #null'
+      // because '#' + null = '#null' in JS. No valid lock owner = not locked.
+      mockModConfigStore.current = {
+        ...defaultConfig,
+        protected: 1,
+        createdby: null,
+      }
+      const wrapper = mountComponent()
+      await flushPromises()
+      expect(wrapper.text()).not.toContain('#null')
+      expect(wrapper.find('.notice-message').exists()).toBe(false)
     })
   })
 

--- a/iznik-server-go/modconfig/modconfig.go
+++ b/iznik-server-go/modconfig/modconfig.go
@@ -70,8 +70,8 @@ func canModify(myid uint64, cfg *ModConfig) bool {
 	if cfg.Createdby != nil && *cfg.Createdby == myid {
 		return true
 	}
-	if cfg.Protected == 0 {
-		// Check if they can see it.
+	if cfg.Protected == 0 || cfg.Createdby == nil {
+		// Not protected, or no valid lock owner — open to any mod who can see it.
 		return canSee(myid, cfg)
 	}
 	return false


### PR DESCRIPTION
## Root Cause

When a `mod_config` row has `protected=1` but `createdby=NULL` in the database (legacy or
orphaned configs), the frontend `locked` computed evaluated:

```js
parseInt(null) !== myid  // parseInt(null) = NaN; NaN !== anything = always true
```

This made every user see the config as locked. The template then rendered:

```
'#' + null  = '#null'   // JS string concatenation
```

producing the "locked by #null" message reported in Discourse 9793/8.

The server-side `canModify` had the same gap: `protected=1 && createdby=nil` fell through
to `return false`, blocking actual saves even if the frontend UI were somehow bypassed.

## Evidence

Discourse 9793/8 (Jools, Bridlington and Hull): after PR #779 resolved the locker's name, the
groups still showed "locked by #null" and editing remained blocked.

The bug was introduced by data state (null createdby) that existed before #779; #779 changed
`#{{ config.createdby }}` (Vue renders `null` as empty → `#`) to `'#' + config.createdby`
(JS string concat → `#null`), making the null visible.

## Fix

**Frontend (`ModSettingsModConfig.vue`):**
- `locked` computed: add `config.value.createdby &&` guard — null owner = not locked
- `NoticeMessage v-if`: add `&& config.createdby` — suppresses the "locked by #null" notice
- Watch user-fetch: add `config.value?.createdby &&` guard — prevents `userStore.fetch(NaN)`

**Server (`modconfig/modconfig.go` — `canModify`):**
- Added `|| cfg.Createdby == nil` to the unprotected branch: a config with no valid lock
  owner is treated the same as an unprotected config — any mod who can see it may edit it

## Other Call Sites

- `parseInt(config.createdby) === myid` in the `<span v-if>` inside `NoticeMessage` is not
  reachable when `createdby` is null because the outer `NoticeMessage v-if` now gates on
  `config.createdby` being truthy
- `DeleteModConfig` also calls `canModify` — the server fix is correct there too (an
  orphaned locked config with no owner can be deleted by any mod who can see it)

## Test

Two new vitest tests added in `ModSettingsModConfig.spec.js`:
- `locked computed > returns false when config is protected but createdby is null`
- `locked notice > does not show locked notice when protected but createdby is null`

Both tests FAILED before the fix and PASS after. Full suite: 61 tests pass.

## Discourse

https://discourse.ilovefreegle.org/t/9793/8