### PR TITLE
fix(post content validation): block 'test' as item title (Discourse 9788/32)

### DIFF
--- a/iznik-nuxt3/composables/useItemValidation.js
+++ b/iznik-nuxt3/composables/useItemValidation.js
@@ -39,6 +39,7 @@ const UNPOSTABLE_ITEM_PATTERNS = [
   /^browse$/,
   /^eney fink$/,
   /^eney think$/,
+  /^test$/,
 ]
 
 // Shared core: true when the value has no descriptive letters after trimming —

--- a/iznik-nuxt3/tests/unit/composables/useItemValidation.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useItemValidation.spec.js
@@ -119,6 +119,19 @@ describe('isVagueItem', () => {
     expect(isVagueItem('garden')).toBe(false)
   })
 
+  it('rejects "test" placeholder (Discourse 9788/32)', () => {
+    expect(isVagueItem('test')).toBe(true)
+    expect(isVagueItem('Test')).toBe(true)
+    expect(isVagueItem('TEST')).toBe(true)
+    expect(isVagueItem('  test  ')).toBe(true)
+  })
+
+  it('does not block real items containing "test"', () => {
+    expect(isVagueItem('test kit')).toBe(false)
+    expect(isVagueItem('covid test')).toBe(false)
+    expect(isVagueItem('pregnancy test')).toBe(false)
+  })
+
   it('treats empty / nullish as not-vague', () => {
     expect(isVagueItem('')).toBe(false)
     expect(isVagueItem(null)).toBe(false)

--- a/iznik-nuxt3/tests/unit/stores/compose.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/compose.spec.js
@@ -680,6 +680,22 @@ describe('compose store', () => {
       expect(store.messageValid({ value: 'Offer' })).toBe(false)
     })
 
+    it('returns false when item is "Test" (Discourse 9788/32)', () => {
+      const store = useComposeStore()
+      store.messages = [
+        { type: 'Offer', item: 'Test', description: 'Test' },
+      ]
+      expect(store.messageValid({ value: 'Offer' })).toBe(false)
+    })
+
+    it('returns false when item is "test" as Wanted (Discourse 9788/32)', () => {
+      const store = useComposeStore()
+      store.messages = [
+        { type: 'Wanted', item: 'test', description: 'test' },
+      ]
+      expect(store.messageValid({ value: 'Wanted' })).toBe(false)
+    })
+
     it('returns false when the description is purely numeric and there are no photos', () => {
       const store = useComposeStore()
       store.messages = [{ type: 'Offer', item: 'Sofa', description: '24' }]


### PR DESCRIPTION
## Root Cause

`UNPOSTABLE_ITEM_PATTERNS` in `composables/useItemValidation.js` did not include the word `test`, so `isVagueItem('test')` returned false and `messageValid` accepted `item='Test'` as a valid compose title. The user could post an OFFER or WANTED with both title and description set to "Test" from the browser (Freegle Direct).

## Evidence

```
FAIL  tests/unit/composables/useItemValidation.spec.js > isVagueItem > rejects "test" placeholder
AssertionError: expected false to be true
 ❯ useItemValidation.spec.js:123:33
   expect(isVagueItem('test')).toBe(true)  // was false

FAIL  tests/unit/stores/compose.spec.js > compose store > messageValid getter > returns false when item is "Test" (Discourse 9788/32)
AssertionError: expected true to be false
 ❯ compose.spec.js:688:54
   expect(store.messageValid({ value: 'Offer' })).toBe(false)  // was true
```

## Fix

One line: add `/^test$/` to `UNPOSTABLE_ITEM_PATTERNS`.

`isVagueItem('test')` → true → `isUnpostableItem('test')` → true → `messageValid` returns false → submit button disabled on desktop, mobile give, mobile find, and edit modal.

## Other Call Sites

The fix flows through `isVagueItem` → `isUnpostableItem`, which is used in:
- `stores/compose.js` (`messageValid` — desktop compose)
- `pages/give/mobile/details.vue` (mobile give)
- `pages/find/mobile/details.vue` (mobile find)
- `components/MessageEditModal.vue` (edit modal)
- `components/PostItem.vue` (`isVagueItem` directly for inline warning)

All of these correctly block `test` as a bare title. Items that contain "test" — `test kit`, `covid test`, `pregnancy test` — are unaffected (pattern is anchored `^test$`).

## Test

File: `iznik-nuxt3/tests/unit/composables/useItemValidation.spec.js`
Command: vitest filter `useItemValidation`

Fail before (buggy): `isVagueItem('test')` returned false
Pass after (fixed): `isVagueItem('test')` returns true; all 27/27 tests pass

File: `iznik-nuxt3/tests/unit/stores/compose.spec.js`
Command: vitest filter `compose.spec`

Fail before: `messageValid({ value: 'Offer' })` with item='Test'/description='Test' returned true
Pass after: returns false; all 91/91 tests pass

## Discourse

https://discourse.ilovefreegle.org/t/9788/32