### PR TITLE
fix(modtools): deduplicate member posting history when message has reposts (#9672)

### DIFF
--- a/iznik-server-go/test/user_test.go
+++ b/iznik-server-go/test/user_test.go
@@ -4352,3 +4352,101 @@ func TestRecentWanted_GoAPI_ExcludesNonApproved(t *testing.T) {
 		"messagehistory entries must include 'postdate' field (bug: Go API returns 'arrival' only; "+
 			"frontend uses msg.postdate → dayjs(undefined) = current time instead of original arrival)")
 }
+
+// TestMessageHistory_NoDuplicatesOnRepost covers Discourse #9672 post 3.
+//
+// Root cause: GetUserMessageHistory LEFT JOINed messages_postings without a
+// groupid constraint (mp ON mp.msgid = m.id).  A message reposted N times has N
+// rows in messages_postings; the unconstrained JOIN fans those rows out into N
+// duplicate history entries per (message, group) pair, causing the "duplicated
+// and incomplete" posting history the reporter sees when filtering by a specific
+// community group in ModPostingHistoryModal.
+//
+// Fix: replace the JOIN with a correlated subquery
+//
+//	COALESCE((SELECT MAX(mp.date) ... WHERE mp.msgid = m.id AND mp.groupid = mg.groupid), m.arrival)
+//
+// which produces exactly one row per (message, group) and uses only postings
+// for that specific group (no cross-group contamination of arrival dates).
+func TestMessageHistory_NoDuplicatesOnRepost(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("mh_dup")
+
+	userID := CreateTestUser(t, prefix, "User")
+	groupID := CreateTestGroup(t, prefix)
+
+	msgID := CreateTestMessage(t, userID, groupID, prefix+" Table", 55.9533, -3.1883)
+
+	// Insert two messages_postings rows for the same (msgid, groupid): the initial
+	// post and one autorepost — exactly the pattern the real submit+repost path
+	// produces.  Before the fix, the LEFT JOIN fans these into 2 history rows.
+	db.Exec("INSERT INTO messages_postings (msgid, groupid, repost, autorepost) VALUES (?, ?, 0, 0)", msgID, groupID)
+	db.Exec("INSERT INTO messages_postings (msgid, groupid, repost, autorepost) VALUES (?, ?, 1, 1)", msgID, groupID)
+
+	t.Cleanup(func() {
+		db.Exec("DELETE FROM messages_postings WHERE msgid = ?", msgID)
+	})
+
+	history := user2.GetUserMessageHistory(userID)
+
+	var count int
+	for _, h := range history {
+		if h.ID == msgID && h.Groupid == groupID {
+			count++
+		}
+	}
+
+	assert.Equal(t, 1, count,
+		"exactly one messagehistory entry per (msgID, groupID) regardless of repost count")
+}
+
+// TestMessageHistory_ArrivalUsesLatestGroupPosting verifies that when a message
+// is posted to two groups and each group has its own messages_postings rows, the
+// arrival date returned for each group reflects only that group's most recent
+// posting date (no cross-group contamination).
+func TestMessageHistory_ArrivalUsesLatestGroupPosting(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("mh_grp_arr")
+
+	userID := CreateTestUser(t, prefix, "User")
+	groupA := CreateTestGroup(t, prefix+"a")
+	groupB := CreateTestGroup(t, prefix+"b")
+
+	// Create message approved in both groups.
+	msgID := CreateTestMessage(t, userID, groupA, prefix+" Chair", 55.9533, -3.1883)
+	db.Exec("INSERT INTO messages_groups (msgid, groupid, arrival, collection, autoreposts) VALUES (?, ?, NOW(), 'Approved', 0)", msgID, groupB)
+
+	// Group A had a posting 5 days ago; Group B had a posting 2 days ago.
+	db.Exec("INSERT INTO messages_postings (msgid, groupid, date, repost, autorepost) VALUES (?, ?, DATE_SUB(NOW(), INTERVAL 5 DAY), 0, 0)", msgID, groupA)
+	db.Exec("INSERT INTO messages_postings (msgid, groupid, date, repost, autorepost) VALUES (?, ?, DATE_SUB(NOW(), INTERVAL 2 DAY), 0, 0)", msgID, groupB)
+
+	t.Cleanup(func() {
+		db.Exec("DELETE FROM messages_postings WHERE msgid = ?", msgID)
+		db.Exec("DELETE FROM messages_groups WHERE msgid = ? AND groupid = ?", msgID, groupB)
+	})
+
+	history := user2.GetUserMessageHistory(userID)
+
+	var daysAgoA, daysAgoB int
+	var foundA, foundB bool
+	for _, h := range history {
+		if h.ID == msgID {
+			if h.Groupid == groupA {
+				foundA = true
+				daysAgoA = h.Daysago
+			} else if h.Groupid == groupB {
+				foundB = true
+				daysAgoB = h.Daysago
+			}
+		}
+	}
+
+	assert.True(t, foundA, "should have a history entry for groupA")
+	assert.True(t, foundB, "should have a history entry for groupB")
+	// Group A posting was 5 days ago; Group B posting was 2 days ago.
+	// Each should use only ITS OWN group's posting date.
+	assert.GreaterOrEqual(t, daysAgoA, 4, "groupA arrival should reflect its 5-day-old posting")
+	assert.LessOrEqual(t, daysAgoA, 6, "groupA arrival should reflect its 5-day-old posting")
+	assert.GreaterOrEqual(t, daysAgoB, 1, "groupB arrival should reflect its 2-day-old posting")
+	assert.LessOrEqual(t, daysAgoB, 3, "groupB arrival should reflect its 2-day-old posting")
+}

--- a/iznik-server-go/user/user.go
+++ b/iznik-server-go/user/user.go
@@ -476,13 +476,20 @@ func GetUserMessageHistory(userid uint64) []UserMessageHistory {
 	db := database.DBConn
 
 	var history []UserMessageHistory
+	// Use a correlated subquery to get the most recent posting date for each
+	// (message, group) pair instead of LEFT JOIN messages_postings.  The JOIN
+	// approach fans out: N messages_postings rows per message produce N result
+	// rows, causing duplicated entries in the posting-history modal when a message
+	// has been reposted (Discourse #9672).  The subquery filters by groupid so
+	// postings for one group never contaminate the arrival date of another group.
 	db.Raw("SELECT m.id, m.subject, m.type, "+
-		"GREATEST(COALESCE(mp.date, m.arrival), COALESCE(mp.date, m.arrival)) AS arrival, "+
+		"COALESCE("+
+		"(SELECT MAX(mp.date) FROM messages_postings mp WHERE mp.msgid = m.id AND mp.groupid = mg.groupid), "+
+		"m.arrival) AS arrival, "+
 		"mg.groupid, mg.collection, "+
 		"(SELECT outcome FROM messages_outcomes WHERE messages_outcomes.msgid = m.id ORDER BY timestamp DESC LIMIT 1) AS outcome "+
 		"FROM messages m "+
 		"INNER JOIN messages_groups mg ON m.id = mg.msgid "+
-		"LEFT JOIN messages_postings mp ON mp.msgid = m.id "+
 		"WHERE m.fromuser = ? AND mg.deleted = 0 AND m.deleted IS NULL AND mg.collection = ? "+
 		"ORDER BY arrival DESC", userid, utils.COLLECTION_APPROVED).Scan(&history)
 


### PR DESCRIPTION
## What mods saw

In ModTools, a member's posting history (the posting-history modal opened from a member) showed **the same post repeated many times**. Filtering that history to a **specific community** made it worse: lots of duplicates, the member's **most recent posts appeared to be missing**, and the list was **not in date order**. Reported on both the Android ModTools app (v16) and Chrome.

Discourse 9672, "Log history is duplicated": https://discourse.ilovefreegle.org/t/9672/3

## Why

`GetUserMessageHistory` (`iznik-server-go/user/user.go`) built the history by joining the postings table on the message id alone:

```sql
LEFT JOIN messages_postings mp ON mp.msgid = m.id
```

A message that has been reposted has one `messages_postings` row per repost (and per group it was posted to). With no `groupid` constraint, that join produced **one duplicate history row for every posting** - exactly the repeated entries mods saw.

The same unconstrained join also corrupted the date each row is sorted by. The modal sorts history by `arrival` (newest first), and `arrival` came from `mp.date` of *any* matching posting - so it could be a different community's posting, or an older repost. A recent post could therefore be stamped with an old date and sink to the bottom of the list, which is why the member's latest posts looked **missing** and the order looked **random**. (The old `GREATEST(COALESCE(mp.date, m.arrival), COALESCE(mp.date, m.arrival))` was also a no-op - the greatest of a value with itself.)

## Fix

Drop the fan-out join. Take each row's date from a correlated subquery that uses **only that group's** postings:

```sql
COALESCE(
  (SELECT MAX(mp.date) FROM messages_postings mp WHERE mp.msgid = m.id AND mp.groupid = mg.groupid),
  m.arrival
) AS arrival
```

This returns exactly **one row per (post, group)** however many times the post was reposted, with `arrival` set to that group's own latest posting date.

## Result

The posting-history modal shows each post **once**, in correct **date order**, latest at the top - the same when filtered to a single community. `ModPostingHistoryModal.vue` only sorts/filters the data the API returns (sort by `arrival` desc, then filter by selected group), so fixing the data fixes all three symptoms; no client change is needed.

## Other call sites

The only other `messages_postings` use in the Go code (`message/message.go`, posting history for one specific message via `WHERE mp.msgid = ?`) has no cross-message fan-out and is unchanged.

## Tests (`iznik-server-go/test/user_test.go`)

- `TestMessageHistory_NoDuplicatesOnRepost` - a message with 2 postings rows for the same (msgid, groupid) yields exactly 1 history entry. Fails on the old join (count=2), passes on the fix.
- `TestMessageHistory_ArrivalUsesLatestGroupPosting` - a message posted to two groups with different dates: each group's entry uses its own posting date, not the other group's.

Full Go suite green (3192 passing).