### PR TITLE
fix(message/tn): scrape TN photos for every crossposted copy, not just the first

### DIFF
--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -3023,26 +3023,34 @@ func PatchMessageByTN(c *fiber.Ctx) error {
 		req.Type = req.Messagetype
 	}
 
+	// TN never sends an explicit attachments array.  We detect photo changes
+	// through the textbody:
+	//   • No trashnothing.com/pics/ links → user removed all photos → remove AI.
+	//   • Links present → scrape+store TN photos AND remove AI (TN photos replace it).
+	// In both cases the AI attachment must go; in the second case we also strip the
+	// "Check out the pictures…" block from the stored textbody and kick off scraping.
+	//
+	// This MUST be computed once, from the original textbody, BEFORE the per-message
+	// loop below.  A tnpostid can map to several crossposted FD messages; if we
+	// extracted the links and stripped req.Textbody inside the loop, the first
+	// iteration would remove the pic links from req.Textbody, so every subsequent
+	// crossposted copy would read an already-stripped body, find no links, and have
+	// its attachments deleted but never re-scraped — leaving all but the first copy
+	// with no photo.
+	var picPageURLs []string
+	if req.Textbody != nil {
+		picPageURLs = tnPicPageURLRegexp.FindAllString(*req.Textbody, -1)
+		if len(picPageURLs) > 0 {
+			// Strip the photo-link block before persisting the textbody.
+			stripped := tnPicHeaderRegexp.ReplaceAllString(*req.Textbody, "")
+			stripped = tnPicURLLineRegexp.ReplaceAllString(stripped, "")
+			stripped = strings.TrimSpace(stripped)
+			req.Textbody = &stripped
+		}
+	}
+
 	for _, msgID := range msgIDs {
 		req.ID = msgID
-
-		// TN never sends an explicit attachments array.  We detect photo changes
-		// through the textbody:
-		//   • No trashnothing.com/pics/ links → user removed all photos → remove AI.
-		//   • Links present → scrape+store TN photos AND remove AI (TN photos replace it).
-		// In both cases the AI attachment must go; in the second case we also strip the
-		// "Check out the pictures…" block from the stored textbody and kick off scraping.
-		var picPageURLs []string
-		if req.Textbody != nil {
-			picPageURLs = tnPicPageURLRegexp.FindAllString(*req.Textbody, -1)
-			if len(picPageURLs) > 0 {
-				// Strip the photo-link block before persisting the textbody.
-				stripped := tnPicHeaderRegexp.ReplaceAllString(*req.Textbody, "")
-				stripped = tnPicURLLineRegexp.ReplaceAllString(stripped, "")
-				stripped = strings.TrimSpace(stripped)
-				req.Textbody = &stripped
-			}
-		}
 
 		// Attachments must reach their final state BEFORE the edit's change signal is
 		// written.  applyPatchMessageCore writes the messages_edits row that /api/changes

--- a/iznik-server-go/test/message_test.go
+++ b/iznik-server-go/test/message_test.go
@@ -8181,6 +8181,74 @@ func TestPatchMessageByTnPostidUpdatesAllMessages(t *testing.T) {
 	assert.Equal(t, "TN Multi Updated Subject", subject2, "second message should also be updated")
 }
 
+// TestPatchMessageByTnPostidScrapesPhotosForAllMessages verifies that when a tnpostid
+// maps to several crossposted FD messages, the TN photo scrape runs for EVERY copy, not
+// just the first.  Regression test: the pic-link extraction used to strip req.Textbody
+// inside the per-message loop, so the second copy read an already-stripped body, found no
+// links, had its attachments deleted but never re-scraped, and ended up with no photo.
+func TestPatchMessageByTnPostidScrapesPhotosForAllMessages(t *testing.T) {
+	prefix := uniquePrefix("patchtn_multiscrape")
+	db := database.DBConn
+
+	group1ID := CreateTestGroup(t, prefix+"_g1")
+	group2ID := CreateTestGroup(t, prefix+"_g2")
+	ownerID := CreateTestUser(t, prefix+"_owner", "User")
+	CreateTestMembership(t, ownerID, group1ID, "Member")
+	CreateTestMembership(t, ownerID, group2ID, "Member")
+	db.Exec("UPDATE users SET tnuserid = ? WHERE id = ?", 88811, ownerID)
+
+	tnpostid := fmt.Sprintf("tn-multiscrape-%s", prefix)
+	msg1ID := CreateTestMessage(t, ownerID, group1ID, prefix+" Offer G1", 55.9533, -3.1883)
+	msg2ID := CreateTestMessage(t, ownerID, group2ID, prefix+" Offer G2", 55.9533, -3.1883)
+	db.Exec("UPDATE messages SET tnpostid = ? WHERE id IN (?, ?)", tnpostid, msg1ID, msg2ID)
+
+	key := insertTestPartnerKeyMsg(t, prefix, "tn.com")
+	defer db.Exec("DELETE FROM partners_keys WHERE partner = ?", prefix+"_partner")
+
+	// Stub out the network steps so the scrape is deterministic.
+	origFetcher := message.TNPageFetcher
+	message.TNPageFetcher = func(pageURL string) []string {
+		return []string{"https://img.trashnothing.com/fake/photo.jpg"}
+	}
+	defer func() { message.TNPageFetcher = origFetcher }()
+
+	origImageFetcher := message.TNImageFetcher
+	message.TNImageFetcher = func(imageURL string) ([]byte, string, error) {
+		return []byte("fake-image-data"), "image/jpeg", nil
+	}
+	defer func() { message.TNImageFetcher = origImageFetcher }()
+
+	// Distinct externaluid per upload so both rows survive INSERT IGNORE.
+	uploadCount := 0
+	origUploader := aiimage.ImageUploader
+	aiimage.ImageUploader = func(data []byte, mime string) (string, error) {
+		uploadCount++
+		return fmt.Sprintf("freegletusd-multiscrape-%s-%d", prefix, uploadCount), nil
+	}
+	defer func() { aiimage.ImageUploader = origUploader }()
+
+	origScrapeRunner := message.TNPhotoScrapeRunner
+	message.TNPhotoScrapeRunner = message.ScrapeTNPhotosSync
+	defer func() { message.TNPhotoScrapeRunner = origScrapeRunner }()
+
+	textbody := "I have a sofa to give away.\n\nCheck out the pictures at:\nhttps://trashnothing.com/pics/abc123\n"
+	body := map[string]interface{}{"textbody": textbody}
+	bodyBytes, _ := json.Marshal(body)
+	reqURL := fmt.Sprintf("/api/message/tn/%s?partner=%s&tnuserid=88811&email=%s@tn.com", tnpostid, key, prefix+"_owner")
+	req := httptest.NewRequest("PATCH", reqURL, bytes.NewBuffer(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := getApp().Test(req, -1)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	// BOTH crossposted copies must have a scraped photo.
+	var count1, count2 int64
+	db.Raw("SELECT COUNT(*) FROM messages_attachments WHERE msgid = ?", msg1ID).Scan(&count1)
+	db.Raw("SELECT COUNT(*) FROM messages_attachments WHERE msgid = ?", msg2ID).Scan(&count2)
+	assert.Equal(t, int64(1), count1, "first crossposted copy should have the scraped photo")
+	assert.Equal(t, int64(1), count2, "second crossposted copy should also have the scraped photo")
+}
+
 // TestPostMessageByTnPostidUpdatesAllMessages verifies that POST /message with tnpostid
 // applies the action to ALL Freegle messages sharing the same tnpostid.
 func TestPostMessageByTnPostidUpdatesAllMessages(t *testing.T) {


### PR DESCRIPTION
## What this fixes (user impact)

When someone on TrashNothing added or changed a photo on an item they were giving away, and that item had been listed to **more than one Freegle community**, the photo only attached to **one** community's copy of the listing.

(A TrashNothing post is crossposted: one TN post becomes several separate Freegle messages, one per community.)

On every other community's copy the item then showed up with **no photo at all**, or with a stale AI-generated placeholder illustration left over from before the edit. To Freeglers browsing those communities the item looked photo-less, which makes it far less likely to be claimed, and the real photo the giver had just uploaded was silently thrown away. The edit reported success everywhere, so nothing surfaced that the photo had gone missing.

## Root cause

A single TrashNothing post (`tnpostid`) maps to several crossposted Freegle messages, and `PatchMessageByTN` loops over all of them. The code that pulls the `trashnothing.com/pics/` photo links out of the message text, and strips that link block out before saving, was running **inside** that loop and overwrote the shared `req.Textbody` as it went:

- **First copy:** photo links still present, so the photo is scraped and stored, and `req.Textbody` is then replaced with the stripped-down text.
- **Every later copy:** reads that already-stripped text, finds no photo links, so its old attachments are still deleted but the scrape is **skipped**, leaving it with no photo.

The scrape success path logged nothing, so the loss was invisible in the logs. It was exposed by #714 (which made a TN edit delete all existing attachments and strip the photo links) combined with the loop over every crossposted copy.

## Evidence (production)

`tnpostid 46935669`, crossposted to messages `120703243 / 120703246 / 120703249`:

- `243` (first copy): had the correctly scraped `freegletusd-` photo.
- `246`: only a leftover `{"ai":true}` placeholder illustration.
- `249`: no photo at all.

## Fix

Move the photo-link extraction and the text strip **above** the loop, so they run once against the original message text. Every crossposted copy then sees the same links and scrapes the photo. The behavioural change is one of ordering; the diff only looks large because the block moved out of the loop.

## Test

`TestPatchMessageByTnPostidScrapesPhotosForAllMessages`: two crossposted copies sharing a `tnpostid` must **both** end up with the scraped photo. It fails on the old in-loop mutation and passes with the fix.

> Note: the Go suite could not be run locally on the batch-prod host (no apiv2 container or Go toolchain); verified via CI.