### PR TITLE
ripple 01/12: location-velocity moderator-review flag (mod-only, no reach dependency)

### DIFF
--- a/iznik-server-go/test/location_velocity_test.go
+++ b/iznik-server-go/test/location_velocity_test.go
@@ -1,0 +1,73 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/freegle/iznik-server-go/user"
+	"github.com/stretchr/testify/assert"
+)
+
+// Rippling-out makes a post's reach follow the poster's declared location, so rapidly changing
+// location is the new way to push posts into unrelated areas. CheckLocationChangeVelocity flags a
+// user for moderator review (non-destructively) when they set too many distinct postcodes in 24h.
+func TestLocationChangeVelocityFlagsRapidHopper(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("locvel")
+	groupID := CreateTestGroup(t, prefix)
+	userID := CreateTestUser(t, prefix, "User")
+	CreateTestMembership(t, userID, groupID, "Member")
+
+	db.Exec("UPDATE memberships SET reviewrequestedat = NULL, reviewreason = NULL WHERE userid = ?", userID)
+	db.Exec("DELETE FROM logs WHERE user = ? AND subtype IN ('PostcodeChange', 'Suspect')", userID)
+	defer db.Exec("DELETE FROM logs WHERE user = ? AND subtype IN ('PostcodeChange', 'Suspect')", userID)
+
+	seed := func(name string) {
+		db.Exec("INSERT INTO logs (type, subtype, user, byuser, text, timestamp) "+
+			"VALUES ('User', 'PostcodeChange', ?, ?, ?, NOW())", userID, userID, name)
+	}
+	flaggedCount := func() int {
+		var n int
+		db.Raw("SELECT COUNT(*) FROM memberships WHERE userid = ? AND reviewrequestedat IS NOT NULL", userID).Scan(&n)
+		return n
+	}
+
+	// Below threshold (2 distinct postcodes) -> not flagged.
+	seed("AB1 1AA")
+	seed("AB2 2BB")
+	user.CheckLocationChangeVelocity(db, userID)
+	assert.Equal(t, 0, flaggedCount(), "two location changes is not enough to flag")
+
+	// At threshold (4 distinct postcodes in 24h) -> flagged for review + a Suspect log written.
+	seed("AB3 3CC")
+	seed("AB4 4DD")
+	user.CheckLocationChangeVelocity(db, userID)
+	assert.Greater(t, flaggedCount(), 0, "four distinct location changes in 24h flags the user for review")
+
+	var suspect int
+	db.Raw("SELECT COUNT(*) FROM logs WHERE user = ? AND type = 'User' AND subtype = 'Suspect'", userID).Scan(&suspect)
+	assert.Greater(t, suspect, 0, "a Suspect log is written for mods")
+}
+
+// A moderator is never flagged, however often they change location.
+func TestLocationChangeVelocitySkipsMods(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("locvelmod")
+	groupID := CreateTestGroup(t, prefix)
+	modID := CreateTestUser(t, prefix, "User")
+	CreateTestMembership(t, modID, groupID, "Moderator")
+
+	db.Exec("UPDATE memberships SET reviewrequestedat = NULL WHERE userid = ?", modID)
+	db.Exec("DELETE FROM logs WHERE user = ? AND subtype IN ('PostcodeChange', 'Suspect')", modID)
+	defer db.Exec("DELETE FROM logs WHERE user = ? AND subtype IN ('PostcodeChange', 'Suspect')", modID)
+
+	for _, pc := range []string{"AB1 1AA", "AB2 2BB", "AB3 3CC", "AB4 4DD", "AB5 5EE"} {
+		db.Exec("INSERT INTO logs (type, subtype, user, byuser, text, timestamp) "+
+			"VALUES ('User', 'PostcodeChange', ?, ?, ?, NOW())", modID, modID, pc)
+	}
+	user.CheckLocationChangeVelocity(db, modID)
+
+	var flagged int
+	db.Raw("SELECT COUNT(*) FROM memberships WHERE userid = ? AND reviewrequestedat IS NOT NULL", modID).Scan(&flagged)
+	assert.Equal(t, 0, flagged, "moderators are never flagged for location velocity")
+}

--- a/iznik-server-go/user/user.go
+++ b/iznik-server-go/user/user.go
@@ -2007,6 +2007,58 @@ func PutUser(c *fiber.Ctx) error {
 // Returns the pruned settings JSON ready for storage, and appends any SET clauses needed for the
 // users table (e.g. lastlocation) to the provided slices. Callers must include those clauses in
 // their UPDATE statement.
+// RapidLocationChangeThreshold is the number of DISTINCT postcodes a user may set within 24 hours
+// before they are flagged for moderator review. Rippling-out makes a post's reach follow the
+// poster's declared location (not their group memberships), so rapidly hopping location is the new
+// way to push posts into unrelated areas. This catches that pattern; it is the one spam signal
+// rippling newly requires (see plans/rippling-out-rollout/spam-checks-review-2026-06-18.md). Tune
+// the constant if it proves too tight/loose.
+const RapidLocationChangeThreshold = 4
+
+// CheckLocationChangeVelocity flags a user for moderator review when they have set too many distinct
+// postcodes in the last 24 hours. It is NON-DESTRUCTIVE: it sets the existing member-review flag
+// that mods already act on (memberships.reviewrequestedat), NOT a block, post-suppression, or
+// auto-ban, so a genuine mover/traveller is reviewed rather than punished. Moderators are never
+// flagged. Called right after a PostcodeChange has been logged.
+func CheckLocationChangeVelocity(db *gorm.DB, myid uint64) {
+	if RapidLocationChangeThreshold <= 0 {
+		return
+	}
+
+	var distinct int
+	db.Raw("SELECT COUNT(DISTINCT text) FROM logs WHERE user = ? AND type = ? AND subtype = ? "+
+		"AND timestamp >= NOW() - INTERVAL 24 HOUR",
+		myid, log2.LOG_TYPE_USER, log2.LOG_SUBTYPE_POSTCODECHANGE).Scan(&distinct)
+
+	if distinct < RapidLocationChangeThreshold {
+		return
+	}
+
+	// Never flag moderators/owners.
+	var modCount int
+	db.Raw("SELECT COUNT(*) FROM memberships WHERE userid = ? AND role IN (?, ?)",
+		myid, utils.ROLE_MODERATOR, utils.ROLE_OWNER).Scan(&modCount)
+	if modCount > 0 {
+		return
+	}
+
+	reason := fmt.Sprintf("Changed location %d times in 24h (rippling-out reach-hopping signal)", distinct)
+
+	// Flag the user's memberships for review, but don't re-flag rows already pending (only a fresh
+	// request, or one whose previous request has already been actioned).
+	db.Exec("UPDATE memberships SET reviewrequestedat = NOW(), reviewreason = ? WHERE userid = ? "+
+		"AND (reviewrequestedat IS NULL OR (reviewedat IS NOT NULL AND reviewedat >= reviewrequestedat))",
+		reason, myid)
+
+	log2.Log(log2.LogEntry{
+		Type:    log2.LOG_TYPE_USER,
+		Subtype: log2.LOG_SUBTYPE_SUSPECT,
+		User:    &myid,
+		Byuser:  &myid,
+		Text:    &reason,
+	})
+}
+
 func ProcessSettingsUpdate(settingsJSON []byte, myid uint64, setClauses *[]string, setArgs *[]interface{}) []byte {
 	db := database.DBConn
 
@@ -2043,6 +2095,10 @@ func ProcessSettingsUpdate(settingsJSON []byte, myid uint64, setClauses *[]strin
 				Byuser:  &myid,
 				Text:    textPtr,
 			})
+
+			// Rippling-out: reach now follows declared location, so flag rapid location-hopping
+			// for moderator review (non-destructive).
+			CheckLocationChangeVelocity(db, myid)
 		}
 	}
 


### PR DESCRIPTION
## Summary

Adds the one spam signal that rippling-out newly requires: a **location-change velocity** check.

- Under rippling, a post's reach follows the poster's **declared location**, not their group memberships. Changing location is therefore the new, frictionless way to push posts into unrelated areas, and the spam-check review (FreegleDocker `plans/rippling-out-rollout/spam-checks-review-2026-06-18.md`) found this vector completely unguarded: the existing code only *logs* a `PostcodeChange`, it never counts velocity or raises a flag.
- `CheckLocationChangeVelocity` (in `iznik-server-go/user/user.go`) runs at the `settings.mylocation` write path, right after a PostcodeChange is logged. It counts the **distinct** postcodes the user has set in the last 24h; at `>= RapidLocationChangeThreshold` (4) it:
  - flags the user's memberships for moderator review via the existing `memberships.reviewrequestedat` / `reviewreason` surface, and
  - writes a `Suspect` log entry for mod tooling.
- **Non-destructive by design**: it does NOT block the location change, suppress posts, or auto-ban. A genuine mover or traveller is simply surfaced for review. Moderators and owners are never flagged.

## Code Quality Review

- Re-uses the established member-review mechanism (`reviewrequestedat`) rather than inventing a new state, so existing mod tooling picks it up with no UI change.
- The UPDATE only (re)flags rows that are not already pending review, so repeated changes do not churn the flag.
- Threshold is a single named constant (`RapidLocationChangeThreshold`) for easy tuning; a value of `<= 0` disables the check.
- Mod/owner exemption queries `memberships.role` so volunteers who legitimately manage several areas are never caught.

## Future Improvements

- Sequenced separately (this PR does not touch them): relax `SEEN_THRESHOLD` (groups-joined no longer multiplies reach), tighten `checkReplyDistance` to the isochrone radius, and add 90-day windows to the unbounded IP/subject checks. These change live detection thresholds and the relaxes must not ship ahead of rippling going live; see that review doc.
- Could later weight by geographic distance between successive postcodes rather than a raw distinct-count, to distinguish a genuine house move from city-hopping.

## Test Plan

`iznik-server-go/test/location_velocity_test.go`:
- `TestLocationChangeVelocityFlagsRapidHopper`: 2 distinct postcodes in 24h -> not flagged; 4 distinct -> memberships flagged for review and a `Suspect` log written.
- `TestLocationChangeVelocitySkipsMods`: a moderator with 5 distinct postcodes -> never flagged.

CI green on this branch (`build-test-katapult` success; Go suite passed).