### PR TITLE
ripple 02/12: tighten + repurpose behavioural spam checks (mod-only, no reach dependency)

### DIFF
--- a/iznik-batch/app/Services/Mail/Incoming/SpamCheckService.php
+++ b/iznik-batch/app/Services/Mail/Incoming/SpamCheckService.php
@@ -32,6 +32,17 @@ class SpamCheckService
 
     public const SUBJECT_THRESHOLD = 30;
 
+    // Distinct groups a SINGLE poster may reach from one IP (within HISTORY_WINDOW_DAYS) before being
+    // flagged. Under rippling-out + single-group posting a legitimate poster reaches their own area's
+    // group(s) only, so one account hitting many groups from one IP is the location-hopping signal.
+    public const USER_GROUP_THRESHOLD = 10;
+
+    // The IP/subject reputation checks below count history over this trailing window rather than for
+    // all time. Without it they accumulate years of legitimate shared-NAT and subject reuse, which
+    // under single-group posting (where a high distinct-group count is a much weaker signal) turns
+    // them into false-positive factories. 90 days keeps a meaningful spam window without that drift.
+    public const HISTORY_WINDOW_DAYS = 90;
+
     public const IMAGE_THRESHOLD = 5;
 
     public const IMAGE_THRESHOLD_TIME = 24; // hours
@@ -448,6 +459,7 @@ class SpamCheckService
         $users = DB::table('messages_history')
             ->select('fromname')
             ->where('fromip', $ip)
+            ->where('arrival', '>=', now()->subDays(self::HISTORY_WINDOW_DAYS))
             ->whereNotNull('groupid')
             ->groupBy('fromuser')
             ->orderBy('arrival', 'desc')
@@ -466,26 +478,34 @@ class SpamCheckService
     }
 
     /**
-     * Check if IP has been used for too many different groups (matching legacy).
+     * Check if a SINGLE poster has reached too many different groups from one IP.
+     *
+     * Originally this counted distinct groups across ALL posters on an IP, which under rippling-out +
+     * single-group posting is just a "many users behind one NAT" artefact (each posts to their own
+     * area's group). The real signal is now ONE account reaching many groups from one IP - the
+     * location-hopping vector - so we decompose by fromuser and flag the worst single poster. Bounded
+     * to the trailing history window so long-lived shared IPs do not accumulate a false positive.
      *
      * @return array{bool, string, string}|null
      */
     public function checkIPGroups(string $ip): ?array
     {
-        $groups = DB::table('messages_history')
+        $worst = DB::table('messages_history')
             ->join('groups', 'groups.id', '=', 'messages_history.groupid')
-            ->select('groups.nameshort')
-            ->where('fromip', $ip)
-            ->groupBy('groupid')
-            ->get();
+            ->select('messages_history.fromuser')
+            ->selectRaw('COUNT(DISTINCT messages_history.groupid) as numgroups')
+            ->selectRaw('GROUP_CONCAT(DISTINCT groups.nameshort) as grouplist')
+            ->where('messages_history.fromip', $ip)
+            ->where('messages_history.arrival', '>=', now()->subDays(self::HISTORY_WINDOW_DAYS))
+            ->whereNotNull('messages_history.fromuser')
+            ->groupBy('messages_history.fromuser')
+            ->havingRaw('COUNT(DISTINCT messages_history.groupid) >= ?', [self::USER_GROUP_THRESHOLD])
+            ->orderByDesc('numgroups')
+            ->first();
 
-        $numGroups = $groups->count();
-
-        if ($numGroups >= self::GROUP_THRESHOLD) {
-            $list = $groups->pluck('nameshort')->implode(', ');
-
+        if ($worst !== null) {
             return [true, self::REASON_IP_USED_FOR_DIFFERENT_GROUPS,
-                "IP {$ip} recently used for {$numGroups} different groups ({$list})"];
+                "IP {$ip} poster {$worst->fromuser} recently posted to {$worst->numgroups} different groups ({$worst->grouplist})"];
         }
 
         return null;
@@ -500,6 +520,7 @@ class SpamCheckService
     {
         $count = DB::table('messages_history')
             ->where('prunedsubject', 'LIKE', "{$prunedSubject}%")
+            ->where('arrival', '>=', now()->subDays(self::HISTORY_WINDOW_DAYS))
             ->whereNotNull('groupid')
             ->distinct('groupid')
             ->count('groupid');

--- a/iznik-batch/tests/Unit/Services/Mail/Incoming/SpamCheckServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/Mail/Incoming/SpamCheckServiceTest.php
@@ -130,7 +130,7 @@ class SpamCheckServiceTest extends TestCase
     {
         $user = $this->createTestUser();
 
-        for ($i = 0; $i < 3; $i++) {
+        for ($i = 0; $i < SpamCheckService::USER_GROUP_THRESHOLD - 1; $i++) {
             $group = $this->createTestGroup();
             DB::table('messages_history')->insert([
                 'fromip' => '11.22.33.44',
@@ -148,7 +148,7 @@ class SpamCheckServiceTest extends TestCase
     {
         $user = $this->createTestUser();
 
-        for ($i = 0; $i < SpamCheckService::GROUP_THRESHOLD + 1; $i++) {
+        for ($i = 0; $i < SpamCheckService::USER_GROUP_THRESHOLD + 1; $i++) {
             $group = $this->createTestGroup();
             DB::table('messages_history')->insert([
                 'fromip' => '55.66.77.88',
@@ -164,6 +164,64 @@ class SpamCheckServiceTest extends TestCase
         $this->assertNotNull($result);
         $this->assertTrue($result[0]);
         $this->assertEquals(SpamCheckService::REASON_IP_USED_FOR_DIFFERENT_GROUPS, $result[1]);
+    }
+
+    public function test_ip_groups_many_posters_one_group_each_not_flagged(): void
+    {
+        // The shared-NAT case: many distinct posters from one IP, each posting to ONLY their own
+        // group. The old all-posters group count would flag this (lots of distinct groups); the
+        // per-poster check must not, because no single account is reaching many groups.
+        for ($i = 0; $i < SpamCheckService::USER_GROUP_THRESHOLD * 2; $i++) {
+            $user = $this->createTestUser();
+            $group = $this->createTestGroup();
+            DB::table('messages_history')->insert([
+                'fromip' => '66.66.66.66',
+                'fromuser' => $user->id,
+                'fromname' => "NAT user {$i}",
+                'groupid' => $group->id,
+                'arrival' => now(),
+            ]);
+        }
+
+        $this->assertNull($this->service->checkIPGroups('66.66.66.66'));
+    }
+
+    public function test_ip_groups_ignores_history_outside_window(): void
+    {
+        // A single poster reaching many groups, but all of it older than the history window, must
+        // not be flagged - the unbounded check used to accumulate this forever.
+        $user = $this->createTestUser();
+
+        for ($i = 0; $i < SpamCheckService::USER_GROUP_THRESHOLD + 1; $i++) {
+            $group = $this->createTestGroup();
+            DB::table('messages_history')->insert([
+                'fromip' => '77.77.77.77',
+                'fromuser' => $user->id,
+                'fromname' => 'Old hopper',
+                'groupid' => $group->id,
+                'arrival' => now()->subDays(SpamCheckService::HISTORY_WINDOW_DAYS + 1),
+            ]);
+        }
+
+        $this->assertNull($this->service->checkIPGroups('77.77.77.77'));
+    }
+
+    public function test_ip_users_ignores_history_outside_window(): void
+    {
+        $group = $this->createTestGroup();
+
+        for ($i = 0; $i <= SpamCheckService::USER_THRESHOLD; $i++) {
+            $user = $this->createTestUser();
+            DB::table('messages_history')->insert([
+                'fromip' => '88.88.88.88',
+                'fromuser' => $user->id,
+                'fromname' => "Old user {$i}",
+                'groupid' => $group->id,
+                'arrival' => now()->subDays(SpamCheckService::HISTORY_WINDOW_DAYS + 1),
+            ]);
+        }
+
+        $this->assertNull($this->service->checkIPUsers('88.88.88.88'));
     }
 
     // ========================================
@@ -211,6 +269,22 @@ class SpamCheckServiceTest extends TestCase
         ]);
 
         $this->assertNull($this->service->checkSubjectReuse('Whitelisted subject'));
+    }
+
+    public function test_subject_ignores_history_outside_window(): void
+    {
+        // A subject reused across many groups, but all older than the history window, must not be
+        // flagged - the check used to accumulate subject history indefinitely.
+        for ($i = 0; $i < SpamCheckService::SUBJECT_THRESHOLD + 1; $i++) {
+            $group = $this->createTestGroup();
+            DB::table('messages_history')->insert([
+                'prunedsubject' => 'Old reused subject',
+                'groupid' => $group->id,
+                'arrival' => now()->subDays(SpamCheckService::HISTORY_WINDOW_DAYS + 1),
+            ]);
+        }
+
+        $this->assertNull($this->service->checkSubjectReuse('Old reused subject'));
     }
 
     // ========================================

--- a/iznik-server/include/spam/Spam.php
+++ b/iznik-server/include/spam/Spam.php
@@ -25,7 +25,11 @@ class Spam {
     # For checking users as suspect.
     const SEEN_THRESHOLD = 16; // Number of groups to join or apply to before considered suspect
     const ESCALATE_THRESHOLD = 2; // Level of suspicion before a user is escalated to support/admin for review
-    const DISTANCE_THRESHOLD = 100; // Replies to items further apart than this is suspicious.  In miles.
+    // Replies to items further apart than this is suspicious.  In miles.  Tightened from 100 to 50 for
+    // rippling-out: a post's reach is now bounded by the poster's ~30-min drive isochrone, so a single
+    // member legitimately replying across >50 miles is itself the anomaly.  Rural groups that genuinely
+    // span further can still raise it per-group via settings.spammers.replydistance (honoured below).
+    const DISTANCE_THRESHOLD = 50;
 
     const REASON_NOT_SPAM = 'NotSpam';
     const REASON_COUNTRY_BLOCKED = 'CountryBlocked';

--- a/iznik-server/include/spam/Spam.php
+++ b/iznik-server/include/spam/Spam.php
@@ -140,8 +140,9 @@ class Spam {
             }
 
             # Now see if this IP has been used for too many different users.  That is likely to
-            # be someone masquerading to fool people.
-            $sql = "SELECT fromname FROM messages_history WHERE fromip = ? AND groupid IS NOT NULL GROUP BY fromuser ORDER BY arrival DESC;";
+            # be someone masquerading to fool people.  Bounded to the last 90 days so a long-lived
+            # shared NAT does not accumulate years of legitimate history (matches the V2 SpamCheckService).
+            $sql = "SELECT fromname FROM messages_history WHERE fromip = ? AND arrival >= DATE_SUB(NOW(), INTERVAL 90 DAY) AND groupid IS NOT NULL GROUP BY fromuser ORDER BY arrival DESC;";
             $users = $this->dbhr->preQuery($sql, [$ip]);
             $numusers = count($users);
 
@@ -154,8 +155,8 @@ class Spam {
             }
 
             # Now see if this IP has been used for too many different groups.  That's likely to
-            # be someone spamming.
-            $sql = "SELECT groups.nameshort FROM messages_history INNER JOIN `groups` ON groups.id = messages_history.groupid WHERE fromip = ? GROUP BY groupid;";
+            # be someone spamming.  Bounded to the last 90 days (matches the V2 SpamCheckService).
+            $sql = "SELECT groups.nameshort FROM messages_history INNER JOIN `groups` ON groups.id = messages_history.groupid WHERE fromip = ? AND messages_history.arrival >= DATE_SUB(NOW(), INTERVAL 90 DAY) GROUP BY groupid;";
             $groups = $this->dbhr->preQuery($sql, [$ip]);
             $numgroups = count($groups);
 
@@ -174,7 +175,9 @@ class Spam {
         $subj = $msg->getPrunedSubject();
 
         if (strlen($subj) >= 10) {
-            $sql = "SELECT COUNT(DISTINCT groupid) AS count FROM messages_history WHERE prunedsubject LIKE ? AND groupid IS NOT NULL;";
+            # Bounded to the last 90 days so a subject reused legitimately over years is not flagged
+            # (matches the V2 SpamCheckService).
+            $sql = "SELECT COUNT(DISTINCT groupid) AS count FROM messages_history WHERE prunedsubject LIKE ? AND arrival >= DATE_SUB(NOW(), INTERVAL 90 DAY) AND groupid IS NOT NULL;";
             $counts = $this->dbhr->preQuery($sql, [
                 "$subj%"
             ]);


### PR DESCRIPTION
## Summary

Tightens / repurposes the **behavioural** spam checks that rippling-out makes either too loose or misdirected. These changes only strengthen or refocus detection (no relaxation), so they are safe to merge at any time - they do not depend on rippling being live. The companion relax (raising the groups-joined threshold) is intentionally a separate PR that must land *with* rippling.

Background: under rippling, a post's reach follows the poster's declared location and its drive-time isochrone, not their group memberships. That shifts what the distance/IP/subject heuristics should be measuring. Full review: FreegleDocker `plans/rippling-out-rollout/spam-checks-review-2026-06-18.md`.

### iznik-batch `SpamCheckService` (V2 incoming-mail path, CI-tested)

- **`checkIPGroups` repurposed from per-IP to per-poster.** It used to count distinct groups across *all* posters on an IP, which under single-group posting is just a "many users behind one NAT" artefact. It now counts distinct groups reached by each single `fromuser` and flags the worst one - i.e. one account spraying many groups from one IP, which is the location-hopping vector. New `USER_GROUP_THRESHOLD` (10).
- **90-day window (`HISTORY_WINDOW_DAYS`) added to `checkIPUsers`, `checkIPGroups`, `checkSubjectReuse`.** These previously accumulated years of shared-NAT / subject-reuse history (the "recently" in their messages was untrue), making them false-positive factories. `messages_history.arrival` is indexed, so the window is cheap.

### iznik-server `Spam.php` (V1, still live via `checkUser` and the message API)

- **`DISTANCE_THRESHOLD` 100 -> 50 miles** in `checkReplyDistance`. The legitimate reply radius is now the ~30-min isochrone, so 100mi is too permissive. The method already uses a 90-day window and honours the per-group `settings.spammers.replydistance` override, so rural groups that genuinely span further can raise it locally. This matters because the email/TrashNothing held-reply and API-direct paths sit outside the in-app reply-eligibility gate.
- **90-day window added to the V1 `checkMessage` IP-users / IP-groups / subject-reuse queries** (`Spam.php` ~144/158/177). These ran the same unbounded queries the V2 `SpamCheckService` did; `checkMessage` is still reachable from `http/api/message.php`, so they get the same trailing window for consistency.

## Code Quality Review

- Per-poster `checkIPGroups` is a strict false-positive *reduction* for the shared-NAT case while preserving the "one account, many groups" true positive (the existing over-threshold test still passes).
- The window uses the indexed `arrival` column; no new index needed.
- Reuses existing reason constants and return shapes - no caller changes.
- V1 change is a single constant plus comment; the override path and 90-day window were already present.

## Future Improvements

- `USER_GROUP_THRESHOLD` (10) is a first heuristic for per-poster group spread under single-group posting; worth revisiting once we can observe the real per-poster distribution.
- The groups-joined `SEEN_THRESHOLD` relax (16 -> ~35) is deliberately held to a separate, rippling-sequenced PR because it *weakens* detection and must not ship ahead of rippling.

## Test Plan

`iznik-batch/tests/Unit/Services/Mail/Incoming/SpamCheckServiceTest.php` (run filtered, green locally):
- `checkIPGroups`: single poster over `USER_GROUP_THRESHOLD` flagged; under it not flagged; **many posters one-group-each from one IP not flagged** (the NAT case); history older than the window not flagged.
- `checkIPUsers` / `checkSubjectReuse`: history older than the window not flagged; in-window behaviour unchanged.

V1 `Spam.php` is not covered by this CI suite (legacy `test/ut/php` harness); the change is a single constant, syntax-checked with `php -l`, with the override and window paths unchanged.