### PR TITLE
ripple 03/12: moderator location-change display (mod-only, no reach dependency)

### DIFF
--- a/iznik-nuxt3/modtools/components/ModMember.vue
+++ b/iznik-nuxt3/modtools/components/ModMember.vue
@@ -77,6 +77,14 @@
           This freegler recently active on groups
           {{ user.activedistance }} miles apart.
         </NoticeMessage>
+        <NoticeMessage
+          v-if="user.locationchanges >= 3"
+          variant="warning"
+          class="mb-2"
+        >
+          This freegler has changed location
+          {{ user.locationchanges }} times in the last 90 days.
+        </NoticeMessage>
         <ModBouncing v-if="user.bouncing" :userid="member.userid" />
         <NoticeMessage v-if="member.bandate">
           Banned

--- a/iznik-nuxt3/modtools/components/ModMemberReview.vue
+++ b/iznik-nuxt3/modtools/components/ModMemberReview.vue
@@ -50,6 +50,14 @@
           This freegler recently active on groups
           {{ user.activedistance }} miles apart.
         </NoticeMessage>
+        <NoticeMessage
+          v-if="user && user.locationchanges >= 3"
+          variant="warning"
+          class="mb-2"
+        >
+          This freegler has changed location
+          {{ user.locationchanges }} times in the last 90 days.
+        </NoticeMessage>
         <ModBouncing v-if="user && user.bouncing" :userid="member.userid" />
         <NoticeMessage v-if="member.bandate">
           Banned

--- a/iznik-nuxt3/tests/unit/components/modtools/ModMember.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModMember.spec.js
@@ -353,6 +353,23 @@ describe('ModMember', () => {
     })
   })
 
+  describe('location changes', () => {
+    it('shows location-change warning when locationchanges >= 3', () => {
+      const wrapper = mountComponent({
+        member: createMember({ locationchanges: 4 }),
+      })
+      expect(wrapper.text()).toContain('changed location')
+      expect(wrapper.text()).toContain('4 times in the last 90 days')
+    })
+
+    it('hides location-change warning when locationchanges < 3', () => {
+      const wrapper = mountComponent({
+        member: createMember({ locationchanges: 2 }),
+      })
+      expect(wrapper.text()).not.toContain('changed location')
+    })
+  })
+
   describe('banned member', () => {
     it('shows banned notice when member is banned', () => {
       const wrapper = mountComponent({

--- a/iznik-nuxt3/tests/unit/components/modtools/ModMemberReview.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModMemberReview.spec.js
@@ -276,6 +276,21 @@ describe('ModMemberReview', () => {
       expect(wrapper.text()).not.toContain('miles apart')
     })
 
+    it('shows location-change warning when locationchanges >= 3', () => {
+      const wrapper = mountComponent({
+        user: createUser({ locationchanges: 4 }),
+      })
+      expect(wrapper.text()).toContain('changed location')
+      expect(wrapper.text()).toContain('4 times in the last 90 days')
+    })
+
+    it('hides location-change warning when locationchanges < 3', () => {
+      const wrapper = mountComponent({
+        user: createUser({ locationchanges: 2 }),
+      })
+      expect(wrapper.text()).not.toContain('changed location')
+    })
+
     it('shows bouncing component when member is bouncing', () => {
       const wrapper = mountComponent({
         user: createUser({ bouncing: true }),

--- a/iznik-server-go/test/user_test.go
+++ b/iznik-server-go/test/user_test.go
@@ -4352,3 +4352,55 @@ func TestRecentWanted_GoAPI_ExcludesNonApproved(t *testing.T) {
 		"messagehistory entries must include 'postdate' field (bug: Go API returns 'arrival' only; "+
 			"frontend uses msg.postdate → dayjs(undefined) = current time instead of original arrival)")
 }
+
+// Under rippling-out a post's reach follows the poster's declared location, so a member who keeps
+// changing location is the spam vector that group-spread (activedistance) used to be. The mod user
+// info therefore exposes a count of distinct postcodes the member set in the last 90 days, gated to
+// moderators of the member (and self/admin), like activedistance.
+func TestUserLocationChangesModInfo(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("locchg")
+
+	modID := CreateTestUser(t, prefix+"_mod", "Moderator")
+	_, modToken := CreateTestSession(t, modID)
+	targetID := CreateTestUser(t, prefix+"_target", "User")
+	groupID := CreateTestGroup(t, prefix)
+	CreateTestMembership(t, modID, groupID, "Moderator")
+	CreateTestMembership(t, targetID, groupID, "Member")
+
+	// Three distinct postcodes within the window, a duplicate (must not double-count) and one older
+	// than 90 days (must be excluded).
+	for _, pc := range []string{"AB1 1AA", "AB2 2BB", "AB3 3CC", "AB3 3CC"} {
+		db.Exec("INSERT INTO logs (type, subtype, user, byuser, text, timestamp) "+
+			"VALUES ('User', 'PostcodeChange', ?, ?, ?, NOW())", targetID, targetID, pc)
+	}
+	db.Exec("INSERT INTO logs (type, subtype, user, byuser, text, timestamp) "+
+		"VALUES ('User', 'PostcodeChange', ?, ?, 'OLD9 9ZZ', NOW() - INTERVAL 91 DAY)", targetID, targetID)
+	defer db.Exec("DELETE FROM logs WHERE user = ? AND subtype = 'PostcodeChange'", targetID)
+
+	t.Run("Moderator sees distinct 90-day location-change count", func(t *testing.T) {
+		url := fmt.Sprintf("/api/user/%d?modtools=true&jwt=%s", targetID, modToken)
+		resp, err := getApp().Test(httptest.NewRequest("GET", url, nil))
+		assert.NoError(t, err)
+		assert.Equal(t, 200, resp.StatusCode)
+
+		var u user2.User
+		err = json.NewDecoder(resp.Body).Decode(&u)
+		assert.NoError(t, err)
+		assert.Equal(t, targetID, u.ID)
+		assert.NotNil(t, u.Locationchanges, "mod should see the location-change count")
+		assert.Equal(t, 3, *u.Locationchanges, "3 distinct postcodes in 90 days; duplicate and old one excluded")
+	})
+
+	t.Run("Without modtools the count is not computed", func(t *testing.T) {
+		url := fmt.Sprintf("/api/user/%d?jwt=%s", targetID, modToken)
+		resp, err := getApp().Test(httptest.NewRequest("GET", url, nil))
+		assert.NoError(t, err)
+		assert.Equal(t, 200, resp.StatusCode)
+
+		var u user2.User
+		err = json.NewDecoder(resp.Body).Decode(&u)
+		assert.NoError(t, err)
+		assert.Nil(t, u.Locationchanges, "non-modtools fetch omits the location-change count")
+	})
+}

--- a/iznik-server-go/user/user.go
+++ b/iznik-server-go/user/user.go
@@ -81,6 +81,7 @@ type User struct {
 	Modmails           uint64          `json:"modmails" gorm:"-"`
 	Suspectreason      *string         `json:"suspectreason,omitempty" gorm:"-"`
 	Activedistance     *float64        `json:"activedistance" gorm:"-"`
+	Locationchanges    *int            `json:"locationchanges,omitempty" gorm:"-"`
 	Chatmodstatus      *string         `json:"chatmodstatus,omitempty" gorm:"->"`
 	Newsfeedmodstatus  *string         `json:"newsfeedmodstatus,omitempty" gorm:"->"`
 	Tnuserid           *uint64         `json:"tnuserid,omitempty" gorm:"->"`
@@ -1304,6 +1305,26 @@ func enrichUserForModtools(u *User, id uint64, myid uint64, modtools bool) {
 		}()
 	}
 
+	// Under rippling-out a post's reach follows the poster's declared location, so a member who keeps
+	// changing location is the spam vector that group-spread (activedistance) used to be. Surface the
+	// count of distinct postcodes they have set in the last 90 days so mods reviewing a flagged member
+	// can see the hopping directly. We expose the count (cleanly available from the PostcodeChange log)
+	// rather than a geographic spread, which would need historical lat/lng we do not retain.
+	var locationchanges *int
+	if modtools {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			var n int
+			db.Raw("SELECT COUNT(DISTINCT text) FROM logs "+
+				"WHERE user = ? AND type = ? AND subtype = ? AND timestamp >= NOW() - INTERVAL 90 DAY",
+				id, log2.LOG_TYPE_USER, log2.LOG_SUBTYPE_POSTCODECHANGE).Scan(&n)
+			if n > 0 {
+				locationchanges = &n
+			}
+		}()
+	}
+
 	wg.Wait()
 
 	// Resolve NULL ourPostingStatus → MODERATED.
@@ -1329,6 +1350,7 @@ func enrichUserForModtools(u *User, id uint64, myid uint64, modtools bool) {
 
 	if callerIsMod || myid == id || auth.IsAdminOrSupport(myid) {
 		u.Activedistance = activedistance
+		u.Locationchanges = locationchanges
 		u.Lastpush = lastpush
 	}
 


### PR DESCRIPTION
## Summary

Surfaces a member's recent **location-change count** to moderators, completing the spam-check review's note that `activedistance` (the "groups N miles apart" reach signal) now misleads mods under rippling-out.

Background: under rippling a post's reach follows the poster's declared location and drive-time isochrone, not how many groups they have joined. So group spread is no longer a reach signal - changing location is. This adds the missing mod-facing view of that.

- **Go mod-info** (`iznik-server-go/user/user.go`): new `locationchanges` field - `COUNT(DISTINCT text)` of `PostcodeChange` logs in the last 90 days - computed only for the modtools view and gated to moderators of the member (and self/admin), exactly like `activedistance`.
- **ModTools** (`ModMember.vue`, `ModMemberReview.vue`): a warning when a member has changed location >= 3 times in 90 days, shown next to the existing "groups N miles apart" notice.

It exposes the **count** (cleanly available from the log) rather than a geographic spread, which would require historical lat/lng we do not retain. It complements the location-velocity auto-flag (PR #816) by giving a reviewing mod the actual hop count, not just the flag reason.

This is additive and display-only, so it is safe to merge independently of when rippling goes live.

## Code Quality Review

- Mirrors the existing `activedistance` goroutine, gating and ModTools notice exactly, so it is consistent and low-risk.
- `omitempty` on the field and the same mod/self/admin gate mean it never leaks to non-mods.
- 90-day window uses the indexed `logs.timestamp`.

## Test Plan

- Go `TestUserLocationChangesModInfo`: a moderator of the member sees the distinct 90-day count (duplicate postcode and an out-of-window change excluded); a non-modtools fetch omits the field. (Validated by CI - compiled off master.)
- ModTools specs (`ModMember.spec.js`, `ModMemberReview.spec.js`): the notice shows when `locationchanges >= 3` and hides below it. Run locally, green (482 ModMember-suite specs pass).
