### PR TITLE
fix(events): event digest images never render (invented user-site route)

### DIFF
--- a/iznik-batch/app/Services/EventsDigestService.php
+++ b/iznik-batch/app/Services/EventsDigestService.php
@@ -155,6 +155,10 @@ class EventsDigestService
      */
     protected function fetchUpcomingEvents(array $groupIds, string $userSite): array
     {
+        $imagesDomain = config('freegle.images.domain', 'https://images.ilovefreegle.org');
+        $tusUploader = config('freegle.tus_uploader', 'https://uploads.ilovefreegle.org:8080');
+        $deliveryUrl = config('freegle.delivery.base_url');
+
         $rawEvents = DB::table('communityevents')
             ->join('communityevents_groups', 'communityevents_groups.eventid', '=', 'communityevents.id')
             ->join('communityevents_dates', 'communityevents_dates.eventid', '=', 'communityevents.id')
@@ -218,11 +222,28 @@ class EventsDigestService
                 ? Carbon::parse($event->end)->setTimezone('Europe/London')->format('g:ia')
                 : null;
 
+            // Build a working image URL. The previous fallback pointed at
+            // {userSite}/communityevent/{id}/image/{imgid}, which is not a real route
+            // on the user site and 404s in every client. Mirror how volunteering (and
+            // V1) serve images: an externally-hosted URL as-is; a TUS upload through
+            // the delivery/resize proxy; otherwise the image domain's community-event
+            // thumbnail route (cimg_/tcimg_ -> /api/image?id=X&communityevent=1).
             $imageUrl = null;
             if ($images->has($event->id)) {
                 $img = $images->get($event->id);
                 $mods = $img->externalmods ? json_decode($img->externalmods, true) : [];
-                $imageUrl = $mods['url'] ?? "{$userSite}/communityevent/{$event->id}/image/{$img->id}";
+                if (!empty($mods['url'])) {
+                    $imageUrl = $mods['url'];
+                } elseif ($img->externaluid
+                    && ($p = strpos($img->externaluid, 'freegletusd-')) !== false) {
+                    $fileId = substr($img->externaluid, $p + strlen('freegletusd-'));
+                    $source = $tusUploader . '/' . $fileId;
+                    $imageUrl = $deliveryUrl
+                        ? $deliveryUrl . '?url=' . urlencode($source) . '&w=400'
+                        : $source;
+                } else {
+                    $imageUrl = "{$imagesDomain}/tcimg_{$img->id}.jpg";
+                }
             }
 
             $eventsById[(int) $event->id] = [

--- a/iznik-batch/tests/Feature/Mail/EventsDigestCommandTest.php
+++ b/iznik-batch/tests/Feature/Mail/EventsDigestCommandTest.php
@@ -447,6 +447,57 @@ class EventsDigestCommandTest extends TestCase
         });
     }
 
+    public function test_local_event_image_uses_image_domain_thumbnail(): void
+    {
+        // A locally-uploaded event image (no externalmods url, no external uid) must
+        // resolve to the image domain's community-event thumbnail route. The old code
+        // pointed at {userSite}/communityevent/{id}/image/{imgid}, which is not a real
+        // route and 404'd, so event-digest photos never rendered.
+        Mail::fake();
+
+        $group  = $this->createTestGroup();
+        $member = $this->createTestUser();
+        $this->createMembership($member, $group, ['eventsallowed' => 1, 'emailfrequency' => 24]);
+
+        $eventId = $this->createEvent($group->id, 'Local Photo Event');
+        $imageId = $this->addEventImage($eventId);
+
+        $this->artisan('mail:events-digest')->assertExitCode(0);
+
+        $expected = config('freegle.images.domain') . "/tcimg_{$imageId}.jpg";
+        Mail::assertSent(EventsDigestMail::class, function (EventsDigestMail $mail) use ($expected) {
+            $url = $mail->events[0]['imageUrl'];
+            return $url === $expected && ! str_contains($url, '/communityevent/');
+        });
+    }
+
+    public function test_tus_uploaded_event_image_uses_delivery_proxy(): void
+    {
+        // A TUS-uploaded image (externaluid contains freegletusd-) routes the raw file
+        // through the delivery/resize proxy, exactly as volunteering does.
+        Mail::fake();
+
+        $group  = $this->createTestGroup();
+        $member = $this->createTestUser();
+        $this->createMembership($member, $group, ['eventsallowed' => 1, 'emailfrequency' => 24]);
+
+        $eventId = $this->createEvent($group->id, 'Tus Photo Event');
+        DB::table('communityevents_images')->insert([
+            'eventid'     => $eventId,
+            'contenttype' => 'image/jpeg',
+            'archived'    => 0,
+            'externaluid' => 'freegletusd-abc123',
+        ]);
+
+        $this->artisan('mail:events-digest')->assertExitCode(0);
+
+        $source   = config('freegle.tus_uploader') . '/abc123';
+        $expected = config('freegle.delivery.base_url') . '?url=' . urlencode($source) . '&w=400';
+        Mail::assertSent(EventsDigestMail::class, function (EventsDigestMail $mail) use ($expected) {
+            return $mail->events[0]['imageUrl'] === $expected;
+        });
+    }
+
     public function test_event_without_image_has_null_image_url(): void
     {
         Mail::fake();


### PR DESCRIPTION
## Problem

Community-event digest emails showed broken images. The reported example, `https://www.ilovefreegle.org/communityevent/184895/image/48488`, returns **HTTP 404**: that path is not a real route on the user site, so the event photo never renders in any mail client.

## Root cause

`EventsDigestService` built the image URL as `{userSite}/communityevent/{id}/image/{imgid}` whenever the image row had no `externalmods.url`. For every locally-uploaded or imported event image (the common case), that invented route was emitted and 404'd. The MJML template renders it fine via `<mj-image src="{{ event.imageUrl }}">`; the value was simply wrong.

## Fix

Resolve event images the same way `VolunteeringDigestService` (and V1) already do:

- `externalmods.url` present -> use it as-is (externally hosted, pre-processed);
- `externaluid` is a TUS upload (`freegletusd-`) -> route the raw file through the delivery/resize proxy (`?url=...&w=400`);
- otherwise -> the image domain's community-event thumbnail route `{imagesDomain}/tcimg_{imgid}.jpg`, which maps to `/api/image?id=X&communityevent=1` and serves the stored image.

Verified against production: `https://images.ilovefreegle.org/tcimg_48488.jpg` returns **200 image/jpeg** (a real 143 KB photo); the old user-site route returns 404.

## Volunteering (also asked about)

Checked. `VolunteeringDigestService` already uses the correct image-domain route (`toimg_`) plus the delivery proxy, and never builds a user-site `/...` route, so volunteering digest images are not affected by this bug.

## Test plan

Added two cases to `EventsDigestCommandTest`:
- local image (no external URL) must resolve to `{imagesDomain}/tcimg_{id}.jpg` and must **not** contain `/communityevent/`;
- TUS-uploaded image resolves to the delivery proxy URL.

Full `EventsDigestCommandTest` run: **27 passed, 0 failed**.