### PR TITLE
fix(ios): wire the NSE target via absolute path so it stops silently no-op'ing

### DIFF
--- a/iznik-nuxt3/fastlane/Fastfile
+++ b/iznik-nuxt3/fastlane/Fastfile
@@ -419,8 +419,15 @@ platform :ios do
     # App.xcodeproj so it builds + signs in CI (no manual Xcode step). Runs BEFORE the
     # version bumps below so increment_version_number / increment_build_number cover it too.
     # Non-fatal: if anything goes wrong the app still builds without the extension and iOS
-    # notifications fall back to plain text — so this can never break the live release.
-    sh("bundle exec ruby fastlane/add_nse_target.rb || bundle exec ruby add_nse_target.rb || echo '⚠️  NSE wiring step did not run'")
+    # notifications fall back to plain text - so this can never break the live release.
+    # Invoke by ABSOLUTE path from this Fastfile's location. The previous cwd-relative
+    # forms (fastlane/add_nse_target.rb, add_nse_target.rb) did not resolve from
+    # fastlane's sh working directory, so this step LoadError'd and silently no-op'd on
+    # every build - the NSE target was never wired and iOS rich push always degraded to
+    # plain text. The script itself is cwd-independent (it derives all paths from its own
+    # __dir__), so locating it by absolute path is the whole fix.
+    nse_script = File.expand_path('add_nse_target.rb', __dir__)
+    sh("bundle exec ruby \"#{nse_script}\" || echo '⚠️  NSE wiring step did not run'")
     # Confirmed wired only when BOTH the source is present AND the target is in the project.
     nse_present = File.exist?('../ios/App/NotificationServiceExtension/NotificationService.swift') &&
                   File.exist?('../ios/App/App.xcodeproj/project.pbxproj') &&


### PR DESCRIPTION
## Problem

The iOS build's Notification Service Extension wiring step runs:

```
bundle exec ruby fastlane/add_nse_target.rb || bundle exec ruby add_nse_target.rb || echo '⚠️  NSE wiring step did not run'
```

Both forms are cwd-relative, and neither resolves from fastlane's `sh` working directory, so every build logs:

```
ruby: No such file or directory -- fastlane/add_nse_target.rb (LoadError)
```

and falls through to the `|| echo`. The `add_nse_target.rb` script exists (committed at `iznik-nuxt3/fastlane/add_nse_target.rb`) - it just was never found. Result: the NSE target has never been added to `App.xcodeproj`, so iOS **rich push has been silently degrading to plain text** since the NSE rollout. It was swallowed because the step is intentionally non-fatal.

## Fix

Invoke the script by an **absolute path** derived from the Fastfile's own `__dir__`:

```ruby
nse_script = File.expand_path('add_nse_target.rb', __dir__)
sh("bundle exec ruby \"#{nse_script}\" || echo '⚠️  NSE wiring step did not run'")
```

The script is already cwd-independent (all its paths derive from its own `__dir__`), so locating it is the entire fix. Kept non-fatal so it can never break a release.

## Not today's production red

Today's `deploy-apps` failure is a separate, Apple-side blocker: an updated **Program License Agreement** the account holder must accept before any iOS provisioning (`get_provisioning_profile`) succeeds. No code change can bypass that. This PR fixes the NSE-wiring bug that surfaced in the same log.

## Test plan

- Full Fastfile parses (`ruby -c`: Syntax OK).
- Can't run the iOS lane locally (needs the macOS executor + Apple credentials); the change is a path-resolution fix and the invoked script's cwd-independence is verified by inspection.