### PR TITLE
ci: auto-cancel stray CircleCI workflows when a PR merges/closes

### DIFF
--- a/.github/workflows/cancel-merged-pr-ci.yml
+++ b/.github/workflows/cancel-merged-pr-ci.yml
@@ -1,0 +1,55 @@
+name: Cancel CI for merged/closed PRs
+
+# When a PR is merged (or closed without merging) while its branch's
+# build-test-katapult workflow is still running, that workflow keeps holding a
+# self-hosted Katapult runner for no reason. CircleCI's built-in auto-cancel only
+# covers same-branch supersession, not "the PR is now merged", so cancel those
+# stray workflows here as soon as the PR closes. Scoped to the PR's own head
+# branch, so it can never touch master/production.
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  cancel:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel running CircleCI workflows for this PR's branch
+        env:
+          CIRCLE_TOKEN: ${{ secrets.CIRCLECI_TOKEN }}
+        run: |
+          BRANCH="${{ github.event.pull_request.head.ref }}"
+          # Defensive: never act on the integration branches (a PR head should
+          # never be one of these, but make it impossible to cancel their CI).
+          if [ -z "$BRANCH" ] || [ "$BRANCH" = "master" ] || [ "$BRANCH" = "production" ]; then
+            echo "No cancellable head branch ('$BRANCH') - skipping"
+            exit 0
+          fi
+          echo "PR #${{ github.event.pull_request.number }} closed (merged=${{ github.event.pull_request.merged }}); cancelling stray CI on branch: $BRANCH"
+
+          # Use -s (not -sf) so a transient API error doesn't fail the job; a
+          # missed cancel just leaves one workflow running, same as before.
+          PIPELINES=$(curl -s -H "Circle-Token: $CIRCLE_TOKEN" \
+            "https://circleci.com/api/v2/project/gh/Freegle/Iznik/pipeline?branch=${BRANCH}" 2>/dev/null || echo "")
+
+          # Most-recent few pipelines for the branch (covers superseded pushes).
+          IDS=$(echo "$PIPELINES" | jq -r '.items[0:5][].id // empty' 2>/dev/null || echo "")
+          if [ -z "$IDS" ]; then
+            echo "No pipelines found for $BRANCH - nothing to cancel"
+            exit 0
+          fi
+
+          CANCELLED=0
+          for PID in $IDS; do
+            WFS=$(curl -s -H "Circle-Token: $CIRCLE_TOKEN" \
+              "https://circleci.com/api/v2/pipeline/${PID}/workflow" 2>/dev/null || echo "")
+            for WID in $(echo "$WFS" | jq -r '.items[] | select(.status=="running" or .status=="on_hold") | .id' 2>/dev/null); do
+              echo "Cancelling workflow $WID (pipeline $PID)"
+              if curl -s -X POST -H "Circle-Token: $CIRCLE_TOKEN" \
+                "https://circleci.com/api/v2/workflow/${WID}/cancel" >/dev/null 2>&1; then
+                CANCELLED=$((CANCELLED + 1))
+              fi
+            done
+          done
+          echo "Cancelled $CANCELLED workflow(s) for $BRANCH"


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/cancel-merged-pr-ci.yml`: on `pull_request: closed`, cancels any **running/on_hold** CircleCI workflows for that PR's head branch.
- Closes the gap where merging a PR (especially via admin-merge before CI finishes, or a superseded push) leaves `build-test-katapult` running on a now-pointless branch, holding a self-hosted Katapult runner for nothing. CircleCI's built-in auto-cancel only covers **same-branch** supersession, not "the PR is now merged".

## Why a GitHub Action (not the reaper)
- **Event-driven**: fires the instant the PR closes - no polling latency.
- **In-repo**: version-controlled, no hand-deploy lag (the katapult-reaper's deployed copy is known to drift from master).
- **Reuses existing infra**: modeled directly on `retry-infra-fail.yml`, same `secrets.CIRCLECI_TOKEN`.
- **Composes with the reaper**: cancelling the dead workflow frees its runner, which the reaper then reaps normally. No reaper change needed.

## Safety
- Scoped to `github.event.pull_request.head.ref` only - the CircleCI query is per-branch, so it can only cancel that PR's own workflows.
- Explicit guard rejects empty / `master` / `production` head refs, so integration-branch CI can never be cancelled.
- Uses `curl -s` (non-failing) throughout: a transient API error just leaves a workflow running, same as today - never a hard failure.

## Test plan
- YAML validated (`yaml.safe_load`).
- After merge, the next PR that closes mid-CI should show this action cancelling its `build-test-katapult` workflow (visible in the Actions tab + the workflow flipping to `canceled` in CircleCI).
- Manual equivalent already verified today: cancelling 5 merged rippling branches' workflows via the same `POST /api/v2/workflow/{id}/cancel` endpoint returned `Accepted` and freed the runners.