### PR TITLE
fix(myposts): age out old posts pinned active by unrelated shared-room chat

### DIFF
--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -1213,14 +1213,24 @@ func applyExpiry(db *gorm.DB, msgs []MessageSummary) []int {
 	}
 
 	// Batch query: latest chat activity for all candidate messages.
+	//
+	// Recency is measured by the latest chat message that actually REFERENCES the
+	// post (chat_messages.date where refmsgid = the post), NOT chat_rooms.latestmessage.
+	// Freegle user-to-user rooms are one long-lived room per pair of people, so the
+	// room's overall latest message reflects any conversation between them. Using it
+	// pinned years-old posts in the member's active My Posts whenever the two users
+	// had chatted about anything else recently (Discourse 9481/583): the reported
+	// posts' own chat reference was from 2020, but the shared room had a message 3
+	// days ago, so the room-level check kept them "active" indefinitely. The per-post
+	// reference date is the real "is this post still being discussed" signal.
 	type chatLatest struct {
 		Refmsgid uint64     `gorm:"column:refmsgid"`
 		Latest   *time.Time `gorm:"column:latest"`
 	}
 	var chatResults []chatLatest
-	db.Raw("SELECT chat_messages.refmsgid, MAX(latestmessage) AS latest "+
-		"FROM chat_rooms INNER JOIN chat_messages ON chat_rooms.id = chat_messages.chatid "+
-		"WHERE chat_messages.refmsgid IN (?) GROUP BY chat_messages.refmsgid", candidateIDs).Scan(&chatResults)
+	db.Raw("SELECT refmsgid, MAX(date) AS latest "+
+		"FROM chat_messages "+
+		"WHERE refmsgid IN (?) GROUP BY refmsgid", candidateIDs).Scan(&chatResults)
 
 	recentChat := map[uint64]bool{}
 	for _, cr := range chatResults {

--- a/iznik-server-go/test/message_test.go
+++ b/iznik-server-go/test/message_test.go
@@ -364,6 +364,55 @@ func TestExpiredMessageWithRecentChatKeptActive(t *testing.T) {
 	assert.True(t, found, "Old message with recent chat should remain active")
 }
 
+func TestExpiredMessageHeldActiveByUnrelatedRoomChatAgedOut(t *testing.T) {
+	// An old post must NOT be kept in active My Posts merely because the chat ROOM
+	// that once referenced it has had recent UNRELATED activity. Freegle user-to-user
+	// rooms are one long-lived room per pair of people, so chat_rooms.latestmessage
+	// tracks any conversation between them. Recency must be judged by the chat message
+	// that actually references the post (refmsgid), not the room's overall last
+	// message — otherwise old posts get pinned active whenever the two users chat
+	// about anything else (Discourse 9481/583). Companion to
+	// TestExpiredMessageWithRecentChatKeptActive: same shape, but the reference is OLD
+	// while the room is recent, so this one must age out.
+	db := database.DBConn
+	prefix := uniquePrefix("roomchat")
+	groupID := CreateTestGroup(t, prefix)
+	userID := CreateTestUser(t, prefix, "User")
+	otherID := CreateTestUser(t, prefix, "User")
+	CreateTestMembership(t, userID, groupID, "Member")
+	_, token := CreateTestSession(t, userID)
+
+	// Old message (200 days) — past expiry.
+	msgID := CreateTestMessageWithArrival(t, userID, groupID, "OFFER: "+prefix+" stale shared-room item", 55.9533, -3.1883, 200)
+
+	// Long-lived room whose LATEST message is recent (unrelated chat), but the chat
+	// message that references THIS post is old — the discussion of this post ended
+	// long ago.
+	var chatID uint64
+	db.Exec("INSERT INTO chat_rooms (user1, user2, chattype, latestmessage) VALUES (?, ?, 'User2User', NOW())", userID, otherID)
+	db.Raw("SELECT id FROM chat_rooms WHERE user1 = ? AND user2 = ? AND chattype = 'User2User'", userID, otherID).Scan(&chatID)
+	db.Exec("INSERT INTO chat_messages (chatid, userid, message, type, refmsgid, date, processingsuccessful, reviewrequired, reviewrejected) VALUES (?, ?, 'interested long ago', 'Default', ?, DATE_SUB(NOW(), INTERVAL 200 DAY), 1, 0, 0)",
+		chatID, otherID, msgID)
+	t.Cleanup(func() {
+		db.Exec("DELETE FROM chat_messages WHERE chatid = ?", chatID)
+		db.Exec("DELETE FROM chat_rooms WHERE id = ?", chatID)
+	})
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/user/"+fmt.Sprint(userID)+"/message?active=true&jwt="+token, nil))
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var msgs []message.MessageSummary
+	json2.Unmarshal(rsp(resp), &msgs)
+
+	found := false
+	for _, m := range msgs {
+		if m.ID == msgID {
+			found = true
+		}
+	}
+	assert.False(t, found, "Old post must age out of active My Posts despite recent UNRELATED chat in the shared room (Discourse 9481/583)")
+}
+
 func TestNonSpatialMessageMarkedOldInInactiveQuery(t *testing.T) {
 	// Messages without a spatial entry (not publicly visible) should be marked
 	// hasoutcome=true in the active=false response so the client's old/active


### PR DESCRIPTION
## What members saw

Years-old posts kept reappearing in a member's **active** My Posts list and would not move to Old, even though the member had done nothing to them (Discourse [9481/583](https://discourse.ilovefreegle.org/t/9481/583), follow-on from 9481/561). The reporter named three ~2020 rejected posts: two stuck in active, one correctly in Old.

## Root cause (verified in production)

| id | collection | date | arrival | outcome | room last msg | post's own chat ref | shows |
|---|---|---|---|---|---|---|---|
| 70022383 | Rejected | 2020-08-15 | 2020-08-15 | none | **3 days ago** | 2020 | active (bug) |
| 70023547 | Rejected | 2020-08-15 | 2020-08-15 | none | **3 days ago** | 2020 | active (bug) |
| 70516224 | Rejected | 2020-08-28 | 2020-08-28 | Withdrawn | 3 days ago | 2020 | Old (correct) |

It is **not** arrival-vs-date (arrival already equals the 2020 date) and **not** pending. `applyExpiry` correctly flags all three as past expiry, but its `recentChat` guard then keeps them active because it measured recency with `MAX(chat_rooms.latestmessage)` - the **whole room's** last message. Freegle user-to-user rooms are one long-lived room per pair of people, so any recent message between the two users (here 3 days ago, about something unrelated) made every old post they ever referenced in that room look "actively discussed." The post-specific chat reference for all three was 2020. #70516224 only reaches Old via its separate `Withdrawn` outcome; the two with no outcome have nothing else to move them out.

(For context, this is the actual bug behind the closed #789, which mis-framed it as a pending/arrival issue and could never have fixed these rejected posts.)

## Fix

Judge recency by the latest chat message that **references the post** (`MAX(chat_messages.date) WHERE refmsgid = the post`), not the room's overall last message. A genuinely active post still has a recent reference and stays active; an old post whose discussion ended long ago now ages out even when the shared room is still busy.

## Test plan

- New `TestExpiredMessageHeldActiveByUnrelatedRoomChatAgedOut`: old post + recent room `latestmessage` + an **old** `refmsgid` reference must age out of active. Fails on the old room-level query, passes on the per-post query.
- Existing `TestExpiredMessageWithRecentChatKeptActive` (recent reference -> stays active) is unchanged and still passes.