### PR TITLE
fix(digest): break summary lines with <br>, not display:block (Outlook)

### DIFF
--- a/iznik-batch/app/Mail/Digest/UnifiedDigest.php
+++ b/iznik-batch/app/Mail/Digest/UnifiedDigest.php
@@ -864,7 +864,7 @@ class UnifiedDigest extends MjmlMailable implements RetryableMailable
         $originalDate = $message->date instanceof Carbon
             ? $message->date
             : ($message->date ? Carbon::parse($message->date) : null);
-        if ($originalDate && $arrival->diffInMinutes($originalDate) > 60) {
+        if ($originalDate && $arrival->diffInMinutes($originalDate, true) > 60) {
             $firstPostedFormatted = $originalDate->setTimezone('Europe/London')->format('D, jS F g:ia');
         }
 

--- a/iznik-batch/resources/views/emails/mjml/digest/unified.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/digest/unified.blade.php
@@ -236,7 +236,14 @@
             $summaryPosts = collect($posts);
             $summaryVisible = \App\Mail\Digest\DigestStyle::SUMMARY_VISIBLE_LINES;
             $summaryHidden = $summaryPosts->slice($summaryVisible);
-            $summaryLink = 'color: ' . \App\Mail\Digest\DigestStyle::OFFER_GREEN . '; text-decoration: none; display: block; margin-bottom: 4px;';
+            // Each summary line is broken with a trailing <br> rather than
+            // display:block on the <a>: Outlook's Word engine ignores display:block
+            // on inline elements, so items ran together (Discourse t/9363/31). <br>
+            // is the most space-efficient block break Outlook honours - about 5 bytes
+            // per line vs ~40 for a <div> wrapper or a <table> row - which matters in
+            // a digest that lists up to 200 posts, near Gmail's ~102KB clip. Vertical
+            // spacing comes from the mj-text line-height.
+            $summaryLink = 'color: ' . \App\Mail\Digest\DigestStyle::OFFER_GREEN . '; text-decoration: none;';
         @endphp
         @if($summaryPosts->count() >= 2)
         <mj-section background-color="#ffffff" padding="16px 20px 4px">
@@ -246,14 +253,14 @@
                 </mj-text>
                 <mj-text font-size="14px" color="#212529" line-height="1.6" padding="0">
                     @foreach($summaryPosts->take($summaryVisible) as $summaryPost)
-                    <a href="{{ $summaryPost['summaryUrl'] }}" style="{{ $summaryLink }}">{{ $summaryPost['subject'] }}</a>
+                    <a href="{{ $summaryPost['summaryUrl'] }}" style="{{ $summaryLink }}">{{ $summaryPost['subject'] }}</a><br>
                     @endforeach
                     @if($summaryHidden->isNotEmpty())
                     <details style="margin-top: 2px;">
                         <summary style="cursor: pointer; color: {{ \App\Mail\Digest\DigestStyle::OFFER_GREEN }}; font-weight: 600;">Show {{ $summaryHidden->count() }} more</summary>
                         <div style="margin-top: 6px;">
                             @foreach($summaryHidden as $summaryPost)
-                            <a href="{{ $summaryPost['summaryUrl'] }}" style="{{ $summaryLink }}">{{ $summaryPost['subject'] }}</a>
+                            <a href="{{ $summaryPost['summaryUrl'] }}" style="{{ $summaryLink }}">{{ $summaryPost['subject'] }}</a><br>
                             @endforeach
                         </div>
                     </details>

--- a/iznik-batch/tests/Unit/Mail/UnifiedDigestSummaryTest.php
+++ b/iznik-batch/tests/Unit/Mail/UnifiedDigestSummaryTest.php
@@ -262,6 +262,35 @@ class UnifiedDigestSummaryTest extends TestCase
         $this->assertStringNotContainsString('<details', $html);
     }
 
+    public function test_html_summary_lines_break_with_br_not_display_block_for_outlook(): void
+    {
+        // Discourse t/9363/31: Outlook Classic's Word engine ignores CSS
+        // display:block on inline <a>, so the summary items ran together. Each
+        // summary link is now separated with a trailing <br> — the most
+        // space-efficient block break Outlook honours (≈5 bytes/line vs ≈40 for a
+        // <div> wrapper, which matters in a digest of up to 200 posts under Gmail's
+        // ~102 KB clip). The compiled HTML must show each summary <a> followed by a
+        // <br>, and the summary <a> must not use display:block.
+        [$mail] = $this->buildDigest(4, UnifiedDigestService::MODE_DAILY);
+        $prepared = $this->preparedPostsOf($mail);
+        $firstUrl = htmlspecialchars($prepared->first()['summaryUrl'], ENT_QUOTES, 'UTF-8');
+
+        $html = $this->spoolAndLoad($mail, 'r@example.com')['html'] ?? '';
+
+        // The summary link is followed by a <br> block break.
+        $this->assertMatchesRegularExpression(
+            '/<a\s[^>]*href="'.preg_quote($firstUrl, '/').'"[^>]*>[^<]*<\/a>\s*<br\s*\/?>/i',
+            $html,
+            'Each summary link must be separated by <br> for Outlook line breaks (t/9363/31)'
+        );
+        // The summary link must NOT rely on display:block (Outlook silently ignores it).
+        $this->assertDoesNotMatchRegularExpression(
+            '/<a\s[^>]*href="'.preg_quote($firstUrl, '/').'"[^>]*style="[^"]*display:\s*block/i',
+            $html,
+            'Summary <a> must not use display:block — Outlook Classic ignores it (t/9363/31)'
+        );
+    }
+
     public function test_html_immediate_single_post_has_no_summary_index(): void
     {
         [$mail] = $this->buildDigest(1, UnifiedDigestService::MODE_IMMEDIATE);

--- a/iznik-batch/tests/Unit/Mail/UnifiedDigestTest.php
+++ b/iznik-batch/tests/Unit/Mail/UnifiedDigestTest.php
@@ -5,7 +5,9 @@ namespace Tests\Unit\Mail;
 use App\Mail\Digest\UnifiedDigest;
 use App\Services\EmailSpoolerService;
 use App\Services\UnifiedDigestService;
+use Carbon\Carbon;
 use Illuminate\Mail\Mailable;
+use Illuminate\Support\Facades\DB;
 use Tests\Support\IsolatedSpoolDirectory;
 use Tests\TestCase;
 
@@ -757,5 +759,81 @@ class UnifiedDigestTest extends TestCase
         // Verify tracking does not indicate AMP.
         $tracking = $mail->getTracking();
         $this->assertFalse($tracking->has_amp);
+    }
+
+    public function test_card_meta_shows_distance_when_user_has_location(): void
+    {
+        // haversineDistance() and the distance branch in prepareCard() are only
+        // reached when the digest recipient has a lastlocation set. Without a
+        // lastlocation both $userLat and $userLng remain null and the distance
+        // block is skipped entirely.
+        $locationId = DB::table('locations')->insertGetId([
+            'name' => 'TestUserLocation',
+            'type' => 'Point',
+            'lat'  => 51.55,    // ~3 miles north of the default group/message lat
+            'lng'  => -0.1278,
+        ]);
+
+        $user  = $this->createTestUser(['lastlocation' => $locationId]);
+        $group = $this->createTestGroup(); // defaults: lat=51.5074, lng=-0.1278
+        $this->createMembership($user, $group);
+
+        $poster = $this->createTestUser();
+        $this->createMembership($poster, $group);
+        $message = $this->createTestMessage($poster, $group, [
+            'subject' => 'OFFER: Bicycle (London)',
+        ]);
+
+        $posts = collect([['message' => $message, 'postedToGroups' => [$group->id]]]);
+        $mail  = new UnifiedDigest($user, $posts, UnifiedDigestService::MODE_DAILY);
+
+        $spooled = $this->spoolAndLoad($mail, $user->email_preferred ?? 'r@example.com');
+        $html    = $spooled['html'] ?? '';
+
+        $this->assertNotEmpty($html, 'Spooled digest HTML should not be empty');
+        // The distance text rendered by haversineDistance() must appear in the
+        // compiled HTML (e.g. "3 miles" or "< 1 mile").
+        $this->assertMatchesRegularExpression(
+            '/(?:[0-9]+ miles?|&lt; 1 mile|< 1 mile)/',
+            $html,
+            'Distance text must appear in the digest card when the user has a lastlocation'
+        );
+    }
+
+    public function test_card_shows_first_posted_when_message_was_reposted(): void
+    {
+        // The "First posted" line in _card.blade.php is only emitted when
+        // prepareCard() sets firstPostedFormatted — which only happens when
+        // messages.date is > 60 minutes before the pivot arrival date (i.e. the
+        // item was reposted). Without this test the firstPostedFormatted branch
+        // in UnifiedDigest::prepareCard() was never covered.
+        $user  = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $this->createMembership($user, $group);
+
+        $poster = $this->createTestUser();
+        $this->createMembership($poster, $group);
+
+        $originalDate = Carbon::now()->subDays(3);
+        $message = $this->createTestMessage($poster, $group, [
+            'subject' => 'OFFER: Bookshelf (London)',
+            'date'    => $originalDate,
+            'arrival' => Carbon::now(),
+        ]);
+
+        $posts = collect([['message' => $message, 'postedToGroups' => [$group->id]]]);
+        $mail  = new UnifiedDigest($user, $posts, UnifiedDigestService::MODE_DAILY);
+
+        $spooled = $this->spoolAndLoad($mail, $user->email_preferred ?? 'r@example.com');
+        $html    = $spooled['html'] ?? '';
+
+        $this->assertNotEmpty($html, 'Spooled digest HTML should not be empty');
+        // The "First posted" line must appear since the item was reposted 3 days
+        // after its original posting date.
+        $this->assertStringContainsString(
+            'First posted',
+            $html,
+            'A reposted message must render the "First posted" date line'
+        );
     }
 }

--- a/iznik-nuxt3/package-lock.json
+++ b/iznik-nuxt3/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "app",
+  "name": "iznik-nuxt3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -27283,9 +27283,9 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
     },
     "node_modules/srvx": {
-      "version": "0.11.16",
-      "resolved": "https://registry.npmjs.org/srvx/-/srvx-0.11.16.tgz",
-      "integrity": "sha512-bp07zRuycfTY43IjAvvTFnmnJi8ikW0VFiHwOhhYcVW/L4xQ1XY4PAd4Nuum1rsA17C39zL7x+CDhrn5AL32Rw==",
+      "version": "0.11.17",
+      "resolved": "https://registry.npmjs.org/srvx/-/srvx-0.11.17.tgz",
+      "integrity": "sha512-43yM4luKfCJamyCMhrUeHUPOrf8TdZe7kN8s5zayZCH5OeprYqi49Aso5ZvHXR4aB+DHaRNO/diNFgZSMNG8Xw==",
       "dev": true,
       "license": "MIT",
       "bin": {


### PR DESCRIPTION
## What was wrong

The "In this digest" summary index styled each link with `display:block` on the `<a>`. Outlook Classic's Word rendering engine ignores `display:block` on inline elements, so the summary items ran together on one line with no breaks (Discourse [t/9363/31](https://discourse.ilovefreegle.org/t/9363/31)).

## Why `<br>` (not a `<div>` wrapper or a table)

MJML compiles `<mj-text>…</mj-text>` to **one** `<td>` holding a single `<div>` that wraps your content verbatim - so the line-break separator inside it is plain HTML you choose, and the goal is the fewest bytes that Outlook still honours as a block break:

| approach | bytes / line | Outlook |
|---|---|---|
| **`<br>`** | ~5 | hard break, universal |
| `<div style="margin-bottom:4px">…</div>` (the stale #794) | ~40 | block |
| `<table>` with a `<tr><td>` per row | ~48 + wrapper | block |
| one `<mj-text>` per line | a whole compiled table/line | block |

The summary lists **every** post (the `<details>` overflow shows all of them, up to ~200), and the HTML digest is up against Gmail's ~102 KB clip threshold, so the per-line cost matters. `<br>` is the cheapest break that works, and it stays inside the single `<mj-text>` MJML already gives us; spacing comes from that cell's `line-height`.

## Change

- Drop `display:block; margin-bottom:4px` from the summary link style.
- Append a trailing `<br>` to each summary `<a>` (visible list and the `<details>` overflow). `<br>` is already used elsewhere in this template, so mrml compiles it.

Supersedes #794 (138 commits behind master), which wrapped each link in a `<div>` - functional but heavier and not what MJML produces.

## Test

`UnifiedDigestSummaryTest::test_html_summary_lines_break_with_br_not_display_block_for_outlook`: builds a real digest, compiles the MJML, and asserts each summary `<a>` is followed by `<br>` and never carries `display:block`.