### PR TITLE
fix(lovejunk): wire up TN invoice recipient so the monthly invoice actually sends

### DIFF
--- a/.env.background.example
+++ b/.env.background.example
@@ -127,3 +127,10 @@ WHATJOBS_FEED2=https://clickcastfeeds.s3.amazonaws.com/<account-id>/feed.xml.gz
 # the daily thanks digest ALSO lands there. Set both to route them separately.
 FREEGLE_FUNDRAISING_ADDR=log@ehibbert.org.uk
 FREEGLE_THANKS_ADDR=info@ilovefreegle.org
+
+# Recipient of the monthly LoveJunk/TrashNothing invoice request (V1: TN_ADDR).
+# Required for lovejunk:send-tn-invoice to actually send; if unset the command
+# computes the split but silently sends nothing. Partner contact - get from prod.
+FREEGLE_TN_INVOICE_ADDR=
+# Treasurer address quoted in the invoice body (V1: TREASURER_ADDR).
+FREEGLE_TREASURER_ADDR=treasurer@ilovefreegle.org

--- a/iznik-batch/app/Console/Commands/LoveJunk/SendTnInvoiceCommand.php
+++ b/iznik-batch/app/Console/Commands/LoveJunk/SendTnInvoiceCommand.php
@@ -25,7 +25,13 @@ class SendTnInvoiceCommand extends Command
         $this->info("{$prefix}TN invoice amount: £{$result['tn_amount']}");
 
         if (!$dryRun && $result['tn_amount'] > 0) {
-            $this->info('Invoice email sent.');
+            if (!empty($result['sent'])) {
+                $this->info("Invoice email sent to {$result['recipient']}.");
+            } else {
+                $this->error('Invoice NOT sent: freegle.mail.tn_invoice_addr (FREEGLE_TN_INVOICE_ADDR) is not configured.');
+
+                return self::FAILURE;
+            }
         } elseif (!$dryRun && $result['tn_amount'] === 0.0) {
             $this->warn('No LoveJunk data for this period — no email sent.');
         }

--- a/iznik-batch/app/Mail/LoveJunk/TnInvoiceMail.php
+++ b/iznik-batch/app/Mail/LoveJunk/TnInvoiceMail.php
@@ -26,12 +26,16 @@ class TnInvoiceMail extends MjmlMailable
 
     public function envelope(): Envelope
     {
+        // V1 (lovejunk_tn_invoice.php) CC'd the audit log address.
+        $cc = config('freegle.mail.donation_cc_addr');
+
         return new Envelope(
             from: new Address(
                 config('freegle.mail.geeks_addr', 'geeks@ilovefreegle.org'),
                 config('freegle.branding.name', 'Freegle')
             ),
             to: [new Address($this->recipientEmail)],
+            cc: $cc ? [new Address($cc)] : [],
             subject: $this->getSubject(),
         );
     }

--- a/iznik-batch/app/Services/LoveJunkInvoiceService.php
+++ b/iznik-batch/app/Services/LoveJunkInvoiceService.php
@@ -51,7 +51,7 @@ class LoveJunkInvoiceService
         $total = $tnCount + $fdCount;
 
         if ($total === 0) {
-            return ['tn' => 0, 'fd' => 0, 'tn_percent' => 0, 'fd_percent' => 0, 'tn_amount' => 0.0];
+            return ['tn' => 0, 'fd' => 0, 'tn_percent' => 0, 'fd_percent' => 0, 'tn_amount' => 0.0, 'sent' => false, 'recipient' => null];
         }
 
         $tnPercent = (int) round(($tnCount / $total) * 100);
@@ -61,6 +61,7 @@ class LoveJunkInvoiceService
         $tnAddr = config('freegle.mail.tn_invoice_addr');
         $treasurerAddr = config('freegle.mail.treasurer_addr');
 
+        $sent = false;
         if (!$dryRun && $tnAddr) {
             app(\App\Services\EmailSpoolerService::class)->spool(new TnInvoiceMail(
                 recipientEmail: $tnAddr,
@@ -70,6 +71,7 @@ class LoveJunkInvoiceService
                 tnPercent: $tnPercent,
                 treasurerAddr: $treasurerAddr,
             ));
+            $sent = true;
         }
 
         return [
@@ -78,6 +80,8 @@ class LoveJunkInvoiceService
             'tn_percent' => $tnPercent,
             'fd_percent' => $fdPercent,
             'tn_amount' => $tnAmount,
+            'sent' => $sent,
+            'recipient' => $tnAddr ?: null,
         ];
     }
 }

--- a/iznik-batch/config/freegle.php
+++ b/iznik-batch/config/freegle.php
@@ -99,6 +99,12 @@ return [
         'centralmods_addr' => env('FREEGLE_CENTRALMODS_ADDR', 'volunteersupport@ilovefreegle.org'),
         // CC address for donation notification emails (legacy logging).
         'donation_cc_addr' => env('FREEGLE_DONATION_CC_ADDR', 'log@ehibbert.org.uk'),
+        // TrashNothing contact that receives the monthly LoveJunk invoice request
+        // (V1 TN_ADDR). Held in env as it's a partner contact; no committed default.
+        'tn_invoice_addr' => env('FREEGLE_TN_INVOICE_ADDR', ''),
+        // Treasurer address quoted in the invoice body — where TN should send the
+        // PDF invoice (V1 TREASURER_ADDR).
+        'treasurer_addr' => env('FREEGLE_TREASURER_ADDR', 'treasurer@ilovefreegle.org'),
         // Modbot email — the automated moderator account; excluded from mod-welfare checks.
         'moderator_email' => env('FREEGLE_MODERATOR_EMAIL', 'modbot@users.ilovefreegle.org'),
         // Trash Nothing domain for incoming mail detection

--- a/iznik-batch/tests/Feature/LoveJunk/LoveJunkTnInvoiceTest.php
+++ b/iznik-batch/tests/Feature/LoveJunk/LoveJunkTnInvoiceTest.php
@@ -2,9 +2,11 @@
 
 namespace Tests\Feature\LoveJunk;
 
+use App\Services\EmailSpoolerService;
 use App\Services\LoveJunkInvoiceService;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Mail;
+use Mockery;
 use Tests\TestCase;
 
 class LoveJunkTnInvoiceTest extends TestCase
@@ -161,6 +163,54 @@ class LoveJunkTnInvoiceTest extends TestCase
         $result = (new LoveJunkInvoiceService())->sendInvoice('2020-01', true);
 
         $this->assertSame(0, $result['tn']);
+    }
+
+    public function test_does_not_send_when_recipient_not_configured(): void
+    {
+        // Regression: with no tn_invoice_addr configured the command logged
+        // "Invoice email sent." but actually spooled nothing (the silent gap
+        // that meant the May 2026 invoice never reached TrashNothing).
+        config(['freegle.mail.tn_invoice_addr' => '']);
+
+        $spooler = Mockery::mock(EmailSpoolerService::class);
+        $spooler->shouldNotReceive('spool');
+        $this->app->instance(EmailSpoolerService::class, $spooler);
+
+        $msgId = $this->insertMessage('TN-abc', '2020-01-15 12:00:00');
+        $this->insertLoveJunkRow($msgId, '2020-01-15 12:00:00');
+
+        $result = (new LoveJunkInvoiceService())->sendInvoice('2020-01', false);
+
+        $this->assertFalse($result['sent']);
+        $this->assertNull($result['recipient']);
+    }
+
+    public function test_sends_to_configured_recipient(): void
+    {
+        config(['freegle.mail.tn_invoice_addr' => 'partner@example.com']);
+
+        $spooler = Mockery::mock(EmailSpoolerService::class);
+        $spooler->shouldReceive('spool')->once();
+        $this->app->instance(EmailSpoolerService::class, $spooler);
+
+        $msgId = $this->insertMessage('TN-abc', '2020-01-15 12:00:00');
+        $this->insertLoveJunkRow($msgId, '2020-01-15 12:00:00');
+
+        $result = (new LoveJunkInvoiceService())->sendInvoice('2020-01', false);
+
+        $this->assertTrue($result['sent']);
+        $this->assertSame('partner@example.com', $result['recipient']);
+    }
+
+    public function test_command_fails_when_recipient_not_configured(): void
+    {
+        config(['freegle.mail.tn_invoice_addr' => '']);
+
+        $msgId = $this->insertMessage('TN-abc', '2020-01-15 12:00:00');
+        $this->insertLoveJunkRow($msgId, '2020-01-15 12:00:00');
+
+        $this->artisan('lovejunk:send-tn-invoice', ['--period' => '2020-01'])
+            ->assertExitCode(1);
     }
 
     public function test_deduplicates_by_subject(): void

--- a/iznik-nuxt3/package-lock.json
+++ b/iznik-nuxt3/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "app",
+  "name": "iznik-nuxt3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
## Problem

The `lovejunk_tn_invoice.php` → Laravel migration (`3d8a9f0eb`, 2026-05-09) reads `config('freegle.mail.tn_invoice_addr')`, but **that config key was never added** to `config/freegle.php`. The send is guarded by `if (!$dryRun && $tnAddr)`, so a null address silently skipped the spool — while `SendTnInvoiceCommand` still logged **"Invoice email sent."**

Net effect: the first invoice due after migration (May 2026, the 1 June cron run) computed the split but **sent nothing to TrashNothing**. Confirmed on prod (batch-prod): config resolved empty, spool had no invoice mail, cron log falsely said "sent".

## Fix

- Add `freegle.mail.tn_invoice_addr` (env `FREEGLE_TN_INVOICE_ADDR`) and `freegle.mail.treasurer_addr` (env `FREEGLE_TREASURER_ADDR`, default `treasurer@ilovefreegle.org`), matching V1 `TN_ADDR` / `TREASURER_ADDR`.
- Restore V1 parity: CC the audit log address (V1 had `->setCc('log@ehibbert.org.uk')`, dropped in the port).
- Make the silent failure loud: the service returns whether it actually sent and to whom; the command reports the real recipient and **exits non-zero** when the address is unconfigured, so this can't recur unnoticed.
- Document the two env vars in `.env.background.example`.
- Add tests for the configured-send, unconfigured-no-send, and command-fail paths.

## Prod remediation already done

`FREEGLE_TN_INVOICE_ADDR=atrusty@trashnothing.com` set in batch-prod `.env.background`, container recreated, and the **missed May 2026 invoice resent** (confirmed delivered: spool → `sent/`). NB the resend amount was £209.45 vs the 1 June point-in-time figure of £209.84 (deleted/rejected posts purged in the interim) — awaiting a decision on whether a correction is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)