### PR TITLE
fix(postcode): preserve partial postcode name on mount - do not auto-replace with first typeahead result

### DIFF
--- a/iznik-nuxt3/components/PostCode.vue
+++ b/iznik-nuxt3/components/PostCode.vue
@@ -209,7 +209,16 @@ async function select(pc) {
       const locs = await locationStore.typeahead(pc.name)
 
       if (locs?.length) {
-        pc = locs[0]
+        // Only upgrade to the resolved record when the name matches exactly.
+        // Picking locs[0] blindly would silently replace a partial/area code
+        // (e.g. "BB4") with an arbitrary full postcode (e.g. "BB4 5AA") when
+        // the typeahead returns multiple results, corrupting the saved location.
+        const exact = locs.find(
+          (l) => l.name.toLowerCase() === pc.name.toLowerCase()
+        )
+        if (exact) {
+          pc = exact
+        }
       }
     }
     emit('selected', pc)

--- a/iznik-nuxt3/tests/unit/components/PostCode.spec.js
+++ b/iznik-nuxt3/tests/unit/components/PostCode.spec.js
@@ -336,6 +336,36 @@ describe('PostCode', () => {
     })
   })
 
+  describe('onMounted value resolution', () => {
+    it('does not replace a partial postcode with the first typeahead result when multiple matches exist', async () => {
+      // "BB4" is an area-level outward code; typeahead returns many full postcodes
+      // but none are named exactly "BB4". The mounted component must NOT silently
+      // swap the original name to locs[0].name (Discourse 9481/585).
+      mockTypeahead.mockResolvedValue([
+        { name: 'BB4 5AA', id: 1 },
+        { name: 'BB4 5AB', id: 2 },
+      ])
+
+      const wrapper = createWrapper({ value: 'BB4' })
+      await flushPromises()
+
+      const emitted = wrapper.emitted('selected')
+      expect(emitted).toBeTruthy()
+      expect(emitted[emitted.length - 1][0].name).toBe('BB4')
+    })
+
+    it('resolves a full postcode to its location record when the typeahead returns an exact name match', async () => {
+      mockTypeahead.mockResolvedValue([{ name: 'SW1A 1AA', id: 456 }])
+
+      const wrapper = createWrapper({ value: 'SW1A 1AA' })
+      await flushPromises()
+
+      const emitted = wrapper.emitted('selected')
+      expect(emitted).toBeTruthy()
+      expect(emitted[emitted.length - 1][0]).toMatchObject({ name: 'SW1A 1AA', id: 456 })
+    })
+  })
+
   describe('source computed', () => {
     it('returns API typeahead URL', () => {
       const wrapper = createWrapper()


### PR DESCRIPTION
## Summary

When PostCode.vue mounts with an initial location name that has no `id` (e.g. `\"BB4\"`, an area-level outward code stored against a post), `select()` called `locationStore.typeahead(pc.name)` and unconditionally took `locs[0]` - the first result in an arbitrary order - even when multiple results existed. For a partial outward code, the typeahead SQL has no ORDER BY and returns many full postcodes starting with that prefix, so `locs[0]` is an arbitrary full postcode like `\"BB4 5AA\"`.

This silently changed `postcode.value` in `MessageEditModal` from the original location to a different full postcode on every open of the edit modal. Saving then sent the wrong `location` name to the server, which looked up the new locationid, rebuilt the subject line as "Rossendale BB4" (area + outward code) instead of just "BB4", and persisted the corrupted location.

**Fix**: in `select()`, only upgrade `pc` to the resolved record when the typeahead returns a result whose `name` exactly matches (case-insensitive). Otherwise keep the original `{ name }` object unchanged so the stored location is not altered without user action.

A full postcode like `\"SW1A 1AA\"` still resolves correctly because the typeahead returns exactly one result with a matching name.

## Tests

- New `describe('onMounted value resolution')` block in `PostCode.spec.js` with two tests:
  - Asserts that mounting with `value=\"BB4\"` and multiple typeahead results emits `selected` with the original `\"BB4\"` name (not `locs[0].name`)
  - Asserts that mounting with `value=\"SW1A 1AA\"` and an exact typeahead match still emits the resolved location object (with `id`)
- All 61 PostCode unit tests pass

## Discourse

https://discourse.ilovefreegle.org/t/9481/585