### PR TITLE
fix(fsm): COVERAGE_GATE skips exhausted/held red PRs so coverage and Sentry can run

### DIFF
--- a/monitor-fsm/src/__tests__/driver.coverage_loop.test.ts
+++ b/monitor-fsm/src/__tests__/driver.coverage_loop.test.ts
@@ -97,6 +97,49 @@ describe('Driver: iteration loop logic', () => {
     })
   })
 
+  describe('COVERAGE_GATE exhausted-red-PR routing', () => {
+    // Regression: coverage_gate_decide must exclude exhausted red PRs (fix-attempt
+    // budget spent, or deliberately held) when deciding whether to route back to
+    // CI_ROUTER. Counting them as actionable CI ping-ponged COVERAGE_GATE↔CI_ROUTER
+    // forever and starved WRITE_COVERAGE/Sentry (the bug that hung the 10-loop run).
+    const MAX_FIX_ATTEMPTS = 3
+
+    // Mirror of coverage_gate_decide's target selection.
+    const decide = (redPRs: Array<{ number: number; attempts: number }>, opts: { dirty?: boolean; pending?: number; prCount?: number } = {}) => {
+      const pickableRedCount = redPRs.filter(p => p.attempts < MAX_FIX_ATTEMPTS).length
+      if (pickableRedCount > 0) return 'CI_ROUTER'
+      if (opts.dirty) return 'REBASE_DIRTY_PRS'
+      if ((opts.pending ?? 0) > 0) return 'WRAP_UP'
+      if ((opts.prCount ?? 0) > 0) return 'WRAP_UP'
+      return 'WRITE_COVERAGE'
+    }
+
+    it('routes to CI_ROUTER when at least one red PR is still pickable', () => {
+      expect(decide([{ number: 818, attempts: 1 }])).toBe('CI_ROUTER')
+      expect(decide([{ number: 818, attempts: 3 }, { number: 42, attempts: 0 }])).toBe('CI_ROUTER')
+    })
+
+    it('falls through to WRITE_COVERAGE when ALL red PRs are exhausted', () => {
+      // The exact hang: #828, #639, #818 all at the attempt cap.
+      expect(decide([
+        { number: 828, attempts: 3 },
+        { number: 639, attempts: 3 },
+        { number: 818, attempts: 3 },
+      ])).toBe('WRITE_COVERAGE')
+    })
+
+    it('still prefers rebase/drain over coverage once CI is non-actionable', () => {
+      const exhausted = [{ number: 818, attempts: 3 }]
+      expect(decide(exhausted, { dirty: true })).toBe('REBASE_DIRTY_PRS')
+      expect(decide(exhausted, { pending: 2 })).toBe('WRAP_UP')
+      expect(decide(exhausted, { prCount: 1 })).toBe('WRAP_UP')
+    })
+
+    it('routes to WRITE_COVERAGE when there are no red PRs at all', () => {
+      expect(decide([])).toBe('WRITE_COVERAGE')
+    })
+  })
+
   describe('MAX_STEPS hard cap', () => {
     const MAX_STEPS = 40
 

--- a/monitor-fsm/src/actions/index.ts
+++ b/monitor-fsm/src/actions/index.ts
@@ -2319,7 +2319,7 @@ ANALYSIS_COMPLETE is for tasks that involve NO code changes (e.g. Discourse tria
 
   {
     name: 'coverage_gate_decide',
-    description: 'Pure-logic branch for COVERAGE_GATE. Priority: (1) red CI → CI_ROUTER; (2) dirty/needs-rebase PRs → REBASE_DIRTY_PRS; (3) PRs created this iteration → WRAP_UP; (4) else → WRITE_COVERAGE.',
+    description: 'Pure-logic branch for COVERAGE_GATE. Priority: (1) PICKABLE (non-exhausted) red CI → CI_ROUTER; (2) dirty/needs-rebase PRs → REBASE_DIRTY_PRS; (3) PRs created this iteration → WRAP_UP; (4) else → WRITE_COVERAGE. Red PRs whose fix-attempt budget is exhausted are NOT counted as actionable CI (otherwise they ping-pong COVERAGE_GATE↔CI_ROUTER and starve coverage/Sentry).',
     paramsSchema: { type: 'object', properties: {} },
     handler: async (_params, context) => {
       const verifyDef = actions.find(a => a.name === 'verify_pr_created')!
@@ -2329,8 +2329,23 @@ ANALYSIS_COMPLETE is for tasks that involve NO code changes (e.g. Discourse tria
       const red = await redDef.handler({}, context)
       const v = verify as any
       const r = red as any
-      const redCount = Array.isArray(r.redPRs) ? r.redPRs.length : 0
+      const redPRs: Array<{ number: number }> = Array.isArray(r.redPRs) ? r.redPRs : []
+      const redCount = redPRs.length
       const prCount = typeof v.count === 'number' ? v.count : 0
+
+      // Exclude PRs whose fix-attempt budget is exhausted (mirrors ci_router_decide).
+      // An exhausted PR is permanently red (we've stopped trying to fix it, or it's
+      // being deliberately held) — counting it as actionable CI makes COVERAGE_GATE
+      // bounce straight back to CI_ROUTER forever, starving WRITE_COVERAGE and Sentry.
+      // Only route to CI_ROUTER when there is at least one PICKABLE red PR.
+      const MAX_FIX_ATTEMPTS = 3
+      const db = getDb()
+      const pickableRedCount = redPRs.filter(pr => {
+        const countStr = kvGet(db, `pr_fix_attempts_${pr.number}`)
+        const count = countStr ? parseInt(countStr, 10) : 0
+        return count < MAX_FIX_ATTEMPTS
+      }).length
+      const exhaustedRedCount = redCount - pickableRedCount
 
       // Check for PRs that need rebase (mergeStateStatus === 'DIRTY')
       const listRes = await sh('gh', [
@@ -2350,15 +2365,15 @@ ANALYSIS_COMPLETE is for tasks that involve NO code changes (e.g. Discourse tria
       const pendingCount = Array.isArray(r.pendingPRs) ? r.pendingPRs.length : 0
       const coverageJitterPRs = Array.isArray(r.coverageJitterPRs) ? r.coverageJitterPRs : []
       let target: string
-      if (redCount > 0) target = 'CI_ROUTER'
+      if (pickableRedCount > 0) target = 'CI_ROUTER'
       else if (dirtyPRs.length > 0) target = 'REBASE_DIRTY_PRS'
       else if (pendingCount > 0) target = 'WRAP_UP'  // drain mode — CI running, don't create coverage PRs
       else if (prCount > 0) target = 'WRAP_UP'
-      else target = 'WRITE_COVERAGE'  // includes the coverage-jitter-boost path (see WRITE_COVERAGE STEP 0)
+      else target = 'WRITE_COVERAGE'  // all red PRs exhausted/held → coverage (incl. jitter-boost, see WRITE_COVERAGE STEP 0); lets Sentry run too
       if (coverageJitterPRs.length > 0) {
         out(`coverage_gate_decide: ${coverageJitterPRs.length} coverage-jitter PR(s) [${coverageJitterPRs.map((p: any) => '#' + p.number).join(', ')}] — booster will add genuine coverage to clear the noise floor`)
       }
-      return { count: prCount, redCount, pendingCount, dirtyPRs, coverageJitterPRs, verify, red, _transition: target }
+      return { count: prCount, redCount, pickableRedCount, exhaustedRedCount, pendingCount, dirtyPRs, coverageJitterPRs, verify, red, _transition: target }
     },
   },
 


### PR DESCRIPTION
## Summary

- The monitor-fsm per-PR fix-attempt budget (3 tries → "exhausted") was enforced **only** in `ci_router_decide`. `coverage_gate_decide` used the raw red-PR count, so it counted permanently-red PRs (budget spent, or deliberately held like #818 until rippling goes live) as actionable CI and routed back to `CI_ROUTER`.
- `CI_ROUTER` then found nothing pickable and fell through to `COVERAGE_GATE` again → an infinite `COVERAGE_GATE ↔ CI_ROUTER` ping-pong that consumed the entire ~1h iteration and starved `WRITE_COVERAGE` (and Sentry, which routes via `WORK_ROUTER`).
- Observed live: a bounded 10-loop run spent loops 1–2 cycling exhausted CI fix attempts on #828/#639/#818 with `create_pr succeeded: 0`, never reaching coverage or Sentry. The `coverage-checks.ts:14` comment had already predicted this starvation.

## Fix

- `coverage_gate_decide` now computes the same exhaustion set `ci_router_decide` uses and routes to `CI_ROUTER` **only when at least one red PR is still pickable** (`pickableRedCount > 0`).
- When every red PR is exhausted/held, it falls through to `WRITE_COVERAGE`, and `WORK_ROUTER` can reach `FIX_SENTRY_ISSUE` when there are issues.
- The coverage-jitter-boost path is preserved unchanged.

## Code Quality Review

- Reuses the exact attempt-budget constant and KV key scheme (`pr_fix_attempts_<n>`, cap 3) as `ci_router_decide`, so the two routers agree on what "exhausted" means.
- Built on current `origin/master` (not the stale branch copy), so the `coverageJitterPRs`/`partitionFailedChecks` feature is retained. Diff is confined to `coverage_gate_decide`.

## Test Plan

- New regression block in `driver.coverage_loop.test.ts` (4 cases): pickable red → `CI_ROUTER`; all of #828/#639/#818 exhausted → `WRITE_COVERAGE`; rebase/drain still preferred over coverage; no red PRs → `WRITE_COVERAGE`.
- `tsc --noEmit` clean; full monitor-fsm suite **230/230 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)