### PR TITLE
fix(digest): render "First posted" line for reposted items under Carbon 3

### DIFF
--- a/iznik-batch/app/Mail/Digest/UnifiedDigest.php
+++ b/iznik-batch/app/Mail/Digest/UnifiedDigest.php
@@ -864,7 +864,7 @@ class UnifiedDigest extends MjmlMailable implements RetryableMailable
         $originalDate = $message->date instanceof Carbon
             ? $message->date
             : ($message->date ? Carbon::parse($message->date) : null);
-        if ($originalDate && $arrival->diffInMinutes($originalDate) > 60) {
+        if ($originalDate && $arrival->diffInMinutes($originalDate, true) > 60) {
             $firstPostedFormatted = $originalDate->setTimezone('Europe/London')->format('D, jS F g:ia');
         }
 

--- a/iznik-batch/tests/Unit/Mail/UnifiedDigestTest.php
+++ b/iznik-batch/tests/Unit/Mail/UnifiedDigestTest.php
@@ -5,7 +5,9 @@ namespace Tests\Unit\Mail;
 use App\Mail\Digest\UnifiedDigest;
 use App\Services\EmailSpoolerService;
 use App\Services\UnifiedDigestService;
+use Carbon\Carbon;
 use Illuminate\Mail\Mailable;
+use Illuminate\Support\Facades\DB;
 use Tests\Support\IsolatedSpoolDirectory;
 use Tests\TestCase;
 
@@ -757,5 +759,81 @@ class UnifiedDigestTest extends TestCase
         // Verify tracking does not indicate AMP.
         $tracking = $mail->getTracking();
         $this->assertFalse($tracking->has_amp);
+    }
+
+    public function test_card_meta_shows_distance_when_user_has_location(): void
+    {
+        // haversineDistance() and the distance branch in prepareCard() are only
+        // reached when the digest recipient has a lastlocation set. Without a
+        // lastlocation both $userLat and $userLng remain null and the distance
+        // block is skipped entirely.
+        $locationId = DB::table('locations')->insertGetId([
+            'name' => 'TestUserLocation',
+            'type' => 'Point',
+            'lat'  => 51.55,    // ~3 miles north of the default group/message lat
+            'lng'  => -0.1278,
+        ]);
+
+        $user  = $this->createTestUser(['lastlocation' => $locationId]);
+        $group = $this->createTestGroup(); // defaults: lat=51.5074, lng=-0.1278
+        $this->createMembership($user, $group);
+
+        $poster = $this->createTestUser();
+        $this->createMembership($poster, $group);
+        $message = $this->createTestMessage($poster, $group, [
+            'subject' => 'OFFER: Bicycle (London)',
+        ]);
+
+        $posts = collect([['message' => $message, 'postedToGroups' => [$group->id]]]);
+        $mail  = new UnifiedDigest($user, $posts, UnifiedDigestService::MODE_DAILY);
+
+        $spooled = $this->spoolAndLoad($mail, $user->email_preferred ?? 'r@example.com');
+        $html    = $spooled['html'] ?? '';
+
+        $this->assertNotEmpty($html, 'Spooled digest HTML should not be empty');
+        // The distance text rendered by haversineDistance() must appear in the
+        // compiled HTML (e.g. "3 miles" or "< 1 mile").
+        $this->assertMatchesRegularExpression(
+            '/(?:[0-9]+ miles?|&lt; 1 mile|< 1 mile)/',
+            $html,
+            'Distance text must appear in the digest card when the user has a lastlocation'
+        );
+    }
+
+    public function test_card_shows_first_posted_when_message_was_reposted(): void
+    {
+        // The "First posted" line in _card.blade.php is only emitted when
+        // prepareCard() sets firstPostedFormatted — which only happens when
+        // messages.date is > 60 minutes before the pivot arrival date (i.e. the
+        // item was reposted). Without this test the firstPostedFormatted branch
+        // in UnifiedDigest::prepareCard() was never covered.
+        $user  = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $this->createMembership($user, $group);
+
+        $poster = $this->createTestUser();
+        $this->createMembership($poster, $group);
+
+        $originalDate = Carbon::now()->subDays(3);
+        $message = $this->createTestMessage($poster, $group, [
+            'subject' => 'OFFER: Bookshelf (London)',
+            'date'    => $originalDate,
+            'arrival' => Carbon::now(),
+        ]);
+
+        $posts = collect([['message' => $message, 'postedToGroups' => [$group->id]]]);
+        $mail  = new UnifiedDigest($user, $posts, UnifiedDigestService::MODE_DAILY);
+
+        $spooled = $this->spoolAndLoad($mail, $user->email_preferred ?? 'r@example.com');
+        $html    = $spooled['html'] ?? '';
+
+        $this->assertNotEmpty($html, 'Spooled digest HTML should not be empty');
+        // The "First posted" line must appear since the item was reposted 3 days
+        // after its original posting date.
+        $this->assertStringContainsString(
+            'First posted',
+            $html,
+            'A reposted message must render the "First posted" date line'
+        );
     }
 }


### PR DESCRIPTION
## Summary

- The "First posted" line in daily digests (the original post date shown when an item has been reposted) silently stopped rendering after the Carbon 3 upgrade.
- `UnifiedDigest::prepareCard()` gates that line on `$arrival->diffInMinutes($originalDate) > 60`. Carbon 3 made `diffInMinutes` **signed**, so when the original post predates the digest arrival (which is true for every repost) the diff is negative and `> 60` is never satisfied. The line disappeared.
- Fix: pass the absolute flag (`diffInMinutes($originalDate, true)`) so the 60-minute threshold compares magnitude regardless of argument order. One-line change.

## Code Quality Review

- Minimal, targeted change to the single faulty comparison; no behavioural change for non-reposted items (diff already < 60 there).
- Adds coverage for two previously-untested `prepareCard()` branches:
  - `test_card_shows_first_posted_when_message_was_reposted` - directly exercises this fix (item reposted 3 days after original date must render "First posted").
  - `test_card_meta_shows_distance_when_user_has_location` - the distance line, only reached when the recipient has a `lastlocation`.

## Future Improvements

- A broader audit of other `diffInMinutes`/`diffInHours`/`diffInDays` call sites for the same Carbon 3 signed-diff assumption would be worthwhile (this class of bug is easy to reintroduce).

## Test Plan

- `UnifiedDigestTest` run locally via the status API (worktree off current master): **25/25 pass, 63 assertions, 0 failures**, including the two new tests. MJML rendering exercised (the tests assert on compiled HTML).
- No sibling card test regressed by the `diffInMinutes` change.