### PR TITLE
fix(digest): use V1-parity 182.5-day inactivity window for immediate emails

### DIFF
--- a/iznik-batch/app/Services/UnifiedDigestService.php
+++ b/iznik-batch/app/Services/UnifiedDigestService.php
@@ -228,11 +228,15 @@ class UnifiedDigestService
             return ['emails' => 0, 'users' => []];
         }
 
-        // Recipients: members at emailfrequency=-1, active in the last 90 days,
-        // plus allowlist gate. NULL lastaccess (new users who have never logged
-        // in) are included; users whose lastaccess is older than 90 days are
-        // excluded to prevent long-inactive accounts from receiving per-post
-        // emails (matches the daily-digest eligibility threshold).
+        // Recipients: members at emailfrequency=-1, plus allowlist gate. The
+        // inactivity gate must match the daily path's V1-parity threshold
+        // (getUsersForDigest: Engage::USER_INACTIVE = 365*12*3600 = 182.5 days),
+        // NOT a stricter 90-day cutoff. A 90-day window silently dropped members
+        // who are inactive for 90-182.5 days from per-post emails even though V1
+        // (Digest.php recipient query had no lastaccess filter at all) and the
+        // daily digest would still mail them. NULL lastaccess (new users who have
+        // never logged in) are included so a brand-new immediate member gets posts
+        // right away.
         $memberQuery = DB::table('memberships')
             ->join('users', 'users.id', '=', 'memberships.userid')
             ->where('memberships.groupid', $groupid)
@@ -241,7 +245,7 @@ class UnifiedDigestService
             ->whereNull('users.deleted')
             ->where(function ($q) {
                 $q->whereNull('users.lastaccess')
-                  ->orWhere('users.lastaccess', '>', now()->subDays(90));
+                  ->orWhere('users.lastaccess', '>', now()->subSeconds(365 * 12 * 3600));
             });
 
         if ($userFilter) {

--- a/iznik-batch/tests/Unit/Services/UnifiedDigestServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/UnifiedDigestServiceTest.php
@@ -1636,15 +1636,20 @@ class UnifiedDigestServiceTest extends TestCase
      * Long-inactive members and daily members must not get immediate
      * per-post emails (Discourse topic 9728 posts 11-12: member 39318461
      * "no recent activity"; support flooded). processGroupImmediate gates
-     * recipients on a 90-day lastaccess window and on emailfrequency=-1.
+     * recipients on the same V1-parity inactivity window the daily path uses
+     * (Engage::USER_INACTIVE = 365*12*3600 = 182.5 days) and on
+     * emailfrequency=-1. It must NOT use a stricter 90-day cutoff: that
+     * silently dropped members inactive for 90-182.5 days (member 41020747,
+     * lastaccess 111 days) even though V1 and the daily digest still mail them.
      *
-     * Four-user group:
-     *   poster        emailfrequency=-1, active → receives (V1 parity: own post loops back)
-     *   immediateUser emailfrequency=-1, active → receives
-     *   dailyUser     emailfrequency=24, active → excluded (emailfrequency filter)
-     *   inactiveUser  emailfrequency=-1, lastaccess 2 years ago → excluded (90-day lastaccess gate)
+     * Five-user group:
+     *   poster         emailfrequency=-1, active → receives (V1 parity: own post loops back)
+     *   immediateUser  emailfrequency=-1, active → receives
+     *   deadZoneUser   emailfrequency=-1, lastaccess 120 days ago → receives (inside 182.5d)
+     *   dailyUser      emailfrequency=24, active → excluded (emailfrequency filter)
+     *   inactiveUser   emailfrequency=-1, lastaccess 2 years ago → excluded (182.5d gate)
      *
-     * So exactly the poster + immediateUser receive: 2 emails.
+     * So poster + immediateUser + deadZoneUser receive: 3 emails.
      */
     public function test_inactive_and_daily_users_must_not_receive_immediate_individual_emails(): void
     {
@@ -1655,11 +1660,18 @@ class UnifiedDigestServiceTest extends TestCase
         // Active immediate-frequency member — receives (alongside the poster).
         $immediateUser = $this->createTestUser();
 
+        // Immediate-frequency member inactive for 120 days — inside the 182.5-day
+        // V1-parity window, so must still receive. A 90-day cutoff would wrongly
+        // drop them (the member 41020747 regression).
+        $deadZoneUser = $this->createTestUser();
+        $deadZoneUser->lastaccess = now()->subDays(120);
+        $deadZoneUser->save();
+
         // Active daily-digest member — correctly excluded by the emailfrequency filter.
         $dailyUser = $this->createTestUser();
 
-        // Long-inactive immediate-frequency member (lastaccess 2 years ago).
-        // Should be excluded once processGroupImmediate adds a lastaccess gate.
+        // Long-inactive immediate-frequency member (lastaccess 2 years ago) —
+        // beyond the 182.5-day window, correctly excluded.
         $inactiveUser = $this->createTestUser();
         $inactiveUser->lastaccess = now()->subYears(2);
         $inactiveUser->save();
@@ -1667,6 +1679,7 @@ class UnifiedDigestServiceTest extends TestCase
         $group = $this->createTestGroup();
         $this->createMembership($poster, $group);
         $this->createMembership($immediateUser, $group);
+        $this->createMembership($deadZoneUser, $group);
         $this->createMembership($dailyUser, $group, [
             'emailfrequency' => Membership::EMAIL_FREQUENCY_DAILY,
         ]);
@@ -1678,10 +1691,10 @@ class UnifiedDigestServiceTest extends TestCase
 
         $stats = $this->service->sendDigests(UnifiedDigestService::MODE_IMMEDIATE);
 
-        // poster + immediateUser receive; dailyUser (freq) and inactiveUser
-        // (90-day lastaccess gate) are excluded.
-        $this->assertEquals(2, $stats['emails_sent']);
-        $this->assertEquals(2, $stats['users_processed']);
+        // poster + immediateUser + deadZoneUser receive; dailyUser (freq) and
+        // inactiveUser (182.5-day gate) are excluded.
+        $this->assertEquals(3, $stats['emails_sent']);
+        $this->assertEquals(3, $stats['users_processed']);
     }
 
     // ─── V1-PARITY: per-group emailfrequency is authoritative ────────────


### PR DESCRIPTION
## Problem

The **immediate** per-post path in `UnifiedDigestService` (`processGroupImmediate`) excluded members whose `users.lastaccess` was older than **90 days**. But:

- V1's recipient query (`iznik-server/include/mail/Digest.php:418`) had **no `lastaccess` filter at all**.
- The **daily** path (`getUsersForDigest`) uses **182.5 days** (`Engage::USER_INACTIVE = 365*12*3600`), explicitly for V1 parity.

So members inactive for **90–182.5 days** were silently dropped from per-post emails even though both V1 and the daily digest would still mail them. The in-code comment claimed the 90-day cutoff "matches the daily-digest eligibility threshold" — it didn't.

## Diagnosis

Member **41020747** (Tendring-Freegle, `emailfrequency = -1` immediate, `lastaccess` 111 days) — excluded from immediate emails by the 90-day cutoff, but inside the 182.5-day window used everywhere else.

## Fix

- Align the immediate window with the daily path: `now()->subSeconds(365 * 12 * 3600)`.
- NULL `lastaccess` (brand-new members) is still included so a new immediate member gets posts right away.
- Update the misleading comment.
- Add a regression case to `test_inactive_and_daily_users_must_not_receive_immediate_individual_emails`: a member inactive for 120 days (the dead zone) must now **receive**; a member inactive 2 years is still excluded.

## Scope

This addresses the over-strict cutoff only. A separate, related gap (V1's `MailRouter` bumped `lastaccess` on incoming mail / link logins; the Laravel path does not, so `lastaccess` can go stale for email-only members) was intentionally left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)