### PR TITLE
feat(hooks): block `gh pr create` when the working tree is dirty

### DIFF
--- a/.claude/check-pr-uncommitted.sh
+++ b/.claude/check-pr-uncommitted.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# PreToolUse hook: block `gh pr create` when the target repo's working tree has
+# uncommitted files (modified-tracked OR untracked-non-ignored).
+#
+# Why: a PR should be opened from a clean tree. Otherwise unrelated work-in-
+# progress lingers uncommitted in the checkout and silently rots (stale drafts,
+# orphaned files, sibling-worktree sync contamination). Opening the PR is the
+# natural checkpoint to force that WIP to a decision.
+#
+# Scope: only `gh pr create`. Pushing a branch is fine; it is PR creation that
+# declares "this is ready", at which point nothing should be left dangling.
+#
+# Escape hatch: prefix the command with `ALLOW_DIRTY_PR=1` for a genuine case.
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+[ -z "$COMMAND" ] && exit 0
+
+# Only fire for `gh pr create`.
+echo "$COMMAND" | grep -qE '\bgh[[:space:]]+pr[[:space:]]+create\b' || exit 0
+
+# Explicit override (env in the command, or already exported).
+if echo "$COMMAND" | grep -qE '\bALLOW_DIRTY_PR=1\b' || [ "${ALLOW_DIRTY_PR:-}" = "1" ]; then
+  exit 0
+fi
+
+HOOK_CWD=$(echo "$INPUT" | jq -r '.cwd // empty' 2>/dev/null)
+
+# Determine which repo to check: a leading `cd <path>` in the command wins,
+# else the tool's cwd, else the project dir.
+CD_PATH=$(echo "$COMMAND" | grep -oE '(^|&&|\||;)[[:space:]]*cd[[:space:]]+[^&|;]+' | head -1 \
+  | sed -E 's/^.*cd[[:space:]]+//; s/[[:space:]]+$//' | tr -d '"'"'"'')
+BASE_DIR="${HOOK_CWD:-${CLAUDE_PROJECT_DIR:-$PWD}}"
+if [ -n "$CD_PATH" ]; then
+  case "$CD_PATH" in
+    /*) TARGET_DIR="$CD_PATH" ;;
+    *)  TARGET_DIR="$BASE_DIR/$CD_PATH" ;;
+  esac
+else
+  TARGET_DIR="$BASE_DIR"
+fi
+
+# Resolve to the git toplevel; if not a git repo, nothing to enforce.
+TOPLEVEL=$(git -C "$TARGET_DIR" rev-parse --show-toplevel 2>/dev/null)
+[ -z "$TOPLEVEL" ] && exit 0
+
+DIRTY=$(git -C "$TOPLEVEL" status --porcelain 2>/dev/null)
+[ -z "$DIRTY" ] && exit 0
+
+COUNT=$(echo "$DIRTY" | grep -c .)
+{
+  echo "STOP. Refusing to open a PR: the working tree at $TOPLEVEL has $COUNT uncommitted file(s)."
+  echo ""
+  echo "$DIRTY" | head -30
+  [ "$COUNT" -gt 30 ] && echo "... and $((COUNT - 30)) more"
+  echo ""
+  echo "Open PRs from a clean tree so work does not linger uncommitted. First:"
+  echo "  - commit the files that belong to THIS PR;"
+  echo "  - commit unrelated work to its own branch (or stash it);"
+  echo "  - remove or .gitignore throwaway files."
+  echo "If leaving them is genuinely intentional, prefix the command with ALLOW_DIRTY_PR=1."
+} >&2
+exit 2

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -81,6 +81,16 @@
             "timeout": 5
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/check-pr-uncommitted.sh",
+            "timeout": 5
+          }
+        ]
       }
     ],
     "Stop": [


### PR DESCRIPTION
## Summary

- Adds `.claude/check-pr-uncommitted.sh`, wired as a `PreToolUse`/`Bash` hook in `.claude/settings.json`.
- It refuses `gh pr create` when the target repo's working tree has uncommitted files (modified-tracked **or** untracked non-ignored).
- Rationale: a PR is the natural checkpoint for "this is ready". Blocking it on a dirty tree forces unrelated work-in-progress to a decision instead of letting it rot in the checkout - stale drafts, orphaned files, sibling-worktree sync contamination. (This was prompted by a cleanup that surfaced dozens of such lingering files.)

## Code Quality Review

- Fires **only** for `gh pr create`; pushing a branch is unaffected.
- Resolves which repo to check from a leading `cd <path>` in the command, else the tool's `cwd`, else `$CLAUDE_PROJECT_DIR`; silently passes when the target isn't a git repo.
- Respects `.gitignore` (uses `git status --porcelain`), so build artefacts don't false-positive.
- Escape hatch: prefix the command with `ALLOW_DIRTY_PR=1` for a genuine case (this PR was opened that way, since the only "dirty" files were the hook's own content on this branch).
- Matches the existing `.claude/check-*.sh` convention (reads `.tool_input.command`, blocks via stderr + `exit 2`).

## Future Improvements

- Could optionally ignore a configurable allow-list of paths (e.g. `plans/`) if that proves too strict in practice.

## Test Plan

Exercised the script directly with simulated hook input:
- `gh pr create` with a dirty tree → **blocked** (exit 2), lists the offending files.
- `ALLOW_DIRTY_PR=1 gh pr create` → passes (exit 0).
- non-PR command (`git status`) → passes.
- `cd <non-git-dir> && gh pr create` → passes (not a repo).

`settings.json` validated as well-formed JSON after wiring.