### PR TITLE
fix(distance): correct lat/lng order in milesAway (inflated east-west distances)

### DIFF
--- a/iznik-nuxt3/composables/useDistance.js
+++ b/iznik-nuxt3/composables/useDistance.js
@@ -6,8 +6,8 @@ export function milesAway(flat, flng, tlat, tlng) {
 
   if ((flat || flng) && (tlat || tlng)) {
     ret = turfdistance(
-      turfpoint([flat, flng]),
-      turfpoint([tlat, tlng]),
+      turfpoint([flng, flat]),
+      turfpoint([tlng, tlat]),
       'miles'
     )
 

--- a/iznik-nuxt3/tests/unit/composables/useDistance.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useDistance.spec.js
@@ -19,6 +19,13 @@ describe('milesAway', () => {
     expect(d).toBeLessThan(60)
   })
 
+  it('computes an east-west distance correctly', () => {
+    // NR29 (Norfolk) -> CB1 (Cambridge), ~72 miles almost due west.
+    const d = milesAway(52.679929, 1.688231, 52.196389, 0.182197)
+    expect(d).toBeGreaterThan(65)
+    expect(d).toBeLessThan(78)
+  })
+
   it('returns 0 for the same point', () => {
     expect(milesAway(51.5, -0.1, 51.5, -0.1)).toBe(0)
   })


### PR DESCRIPTION
## Summary

`milesAway` (`composables/useDistance.js`) passed `turfpoint([flat, flng])`, but turf/GeoJSON points are `[longitude, latitude]`. The swapped order maps UK coordinates to near the equator:

- **North-south distances survive** the swap (London→Brighton: 47.3 → 47.3) — and the only existing test was a N-S case, so it passed and the bug hid for years.
- **East-west distances inflate ~1.6×** (NR29 Norfolk → CB1 Cambridge: true **71.7mi → swapped 109.3mi**), because at UK latitude 1° longitude ≈ 43mi but the swap treats it as ~69mi.

A Norfolk (far-east) moderator reported the digest mileage being correct while the app showed much larger distances on Browse and the reply warning. The digest is server-computed (correct); the app uses `milesAway` for the reply "This item is N miles away" warning (gated at `FAR_AWAY = 37`), browse distance fallback, and chat — all inflated for any post to the west.

## Fix

- Pass `[lng, lat]` to `turfpoint` (the order turf expects). North-south distances are unchanged; east-west are now correct.

## Test Plan

- Existing N-S tests (London→Brighton, same-longitude rounding) still pass.
- Added an east-west regression: `milesAway(52.679929, 1.688231, 52.196389, 0.182197)` (NR29→CB1) now asserts ~72mi (was ~109mi with the swap).
- Verified locally: all 9 `useDistance` specs pass.

## Discourse

https://discourse.ilovefreegle.org/t/testing-please/9481/591

🤖 Generated with [Claude Code](https://claude.com/claude-code)