### PR TITLE
fix(modtools): colour post subjects by recognised keyword, not just default subjreg

### DIFF
--- a/iznik-nuxt3/composables/useKeywordRegex.js
+++ b/iznik-nuxt3/composables/useKeywordRegex.js
@@ -1,0 +1,41 @@
+/**
+ * Build a case-insensitive regex matching a well-formed Freegle subject prefix —
+ * the keyword and its colon, e.g. "OFFER:", "WANTED:", or a group's custom keyword
+ * like "OFFERED:"/"REQUESTED:".
+ *
+ * Groups can configure their own OFFER/WANTED/TAKEN/RECEIVED keywords (group
+ * settings.keywords), and a few common variants are recognised too. This single
+ * source is used both to STRIP the keyword for display (useMessageDisplay) and, in
+ * ModTools, to decide whether a subject follows the group's keyword convention for
+ * the subject-colour highlight — so a Wanted post shown with a custom keyword such
+ * as "REQUESTED" is recognised rather than wrongly flagged. See Discourse 9481/594.
+ *
+ * @param {Object} keywords A group's settings.keywords ({offer,wanted,taken,received}).
+ * @returns {RegExp} matches "^<keyword>:\s*" case-insensitively.
+ */
+export function buildKeywordRegex(keywords = {}) {
+  const kw = keywords || {}
+  // Include BOTH the group's configured keyword AND the standard keyword + common
+  // variants for each type. A group that customises its WANTED keyword to "Request"
+  // still has older posts titled "WANTED:" — both must be recognised so the same
+  // type is treated (and coloured) consistently.
+  const keywordList = [
+    kw.offer,
+    'OFFER',
+    'OFFERED', // common offer variant
+    'OFFERING', // common offer variant
+    kw.wanted,
+    'WANTED',
+    'REQUESTED', // common wanted variant
+    'REQUEST', // common wanted variant
+    kw.taken,
+    'TAKEN',
+    kw.received,
+    'RECEIVED',
+  ]
+  const pattern = keywordList
+    .filter(Boolean)
+    .map((k) => String(k).replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+    .join('|')
+  return new RegExp(`^(${pattern}):\\s*`, 'i')
+}

--- a/iznik-nuxt3/composables/useMessageDisplay.js
+++ b/iznik-nuxt3/composables/useMessageDisplay.js
@@ -11,6 +11,7 @@ import {
   timeago,
 } from '~/composables/useTimeFormat'
 import { milesAway } from '~/composables/useDistance'
+import { buildKeywordRegex } from '~/composables/useKeywordRegex'
 
 /**
  * Shared composable for message display logic used by both
@@ -63,21 +64,9 @@ export function useMessageDisplay(messageId) {
 
   const strippedSubject = computed(() => {
     const subject = message.value?.subject || ''
-    // Build regex from group keywords if available, otherwise use defaults
-    const keywords = messageGroup.value?.settings?.keywords || {}
-    const keywordList = [
-      keywords.offer || 'OFFER',
-      'OFFERED', // Common variant
-      keywords.taken || 'TAKEN',
-      keywords.wanted || 'WANTED',
-      'REQUESTED', // Common variant for wanted
-      keywords.received || 'RECEIVED',
-    ]
-    // Escape any regex special chars and build pattern
-    const pattern = keywordList
-      .map((k) => k.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
-      .join('|')
-    const regex = new RegExp(`^(${pattern}):\\s*`, 'i')
+    // Strip the keyword prefix using the group's configured keywords (+ common
+    // variants). Shared with the ModTools subject-colour check via buildKeywordRegex.
+    const regex = buildKeywordRegex(messageGroup.value?.settings?.keywords)
     return subject.replace(regex, '')
   })
 

--- a/iznik-nuxt3/modtools/components/ModMessage.vue
+++ b/iznik-nuxt3/modtools/components/ModMessage.vue
@@ -702,6 +702,7 @@ import { useMiscStore } from '~/stores/misc'
 import { SUBJECT_REGEX } from '~/constants'
 import { useMe } from '~/composables/useMe'
 import { useModMe } from '~/composables/useModMe'
+import { buildKeywordRegex } from '~/composables/useKeywordRegex'
 
 import { useModGroupStore } from '@/stores/modgroup'
 
@@ -990,15 +991,28 @@ watch(
   { immediate: true }
 )
 
+// A subject "follows the keyword convention" if it starts with a keyword this
+// group recognises for any type — built from the group's own settings.keywords
+// plus the standard OFFER/WANTED and common variants (OFFERED/REQUESTED/REQUEST).
+const keywordRegex = computed(() =>
+  buildKeywordRegex(group.value?.settings?.keywords)
+)
+
 const subjectClass = computed(() => {
   let ret = 'text-success'
 
   if (message.value && modconfig.value && modconfig.value.coloursubj) {
-    ret =
-      message.value.subject?.match &&
-      message.value.subject.match(modconfig.value.subjreg)
-        ? 'text-success'
-        : 'text-danger'
+    const subj = message.value.subject
+    // Green when the subject uses a recognised keyword for this group, OR matches
+    // the mod's own subjreg. Previously this tested ONLY subjreg (default
+    // /^(OFFER|WANTED):/i), so a Wanted post shown with a custom keyword such as
+    // "REQUESTED" was wrongly coloured red even though it's a valid Wanted.
+    // See Discourse https://discourse.ilovefreegle.org/t/9481/594
+    const ok =
+      subj?.match &&
+      (subj.match(keywordRegex.value) ||
+        (modconfig.value.subjreg && subj.match(modconfig.value.subjreg)))
+    ret = ok ? 'text-success' : 'text-danger'
   }
 
   return ret

--- a/iznik-nuxt3/tests/unit/components/modtools/ModMessage.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModMessage.spec.js
@@ -487,6 +487,30 @@ describe('ModMessage', () => {
       const wrapper = mountComponent({}, { subject: 'OFFER: Test Item' })
       expect(wrapper.vm.subjectClass).toBe('text-success')
     })
+
+    // Discourse 9481/594: with subject-colouring ON and the default subjreg
+    // (/^(OFFER|WANTED):/i, which does NOT match "REQUESTED"), a Wanted post shown
+    // with the custom/variant keyword "REQUESTED" must still be GREEN — it's a
+    // recognised Wanted keyword. Previously it was wrongly red.
+    it('keeps a REQUESTED (Wanted variant) subject green even when subjreg only knows OFFER/WANTED', async () => {
+      const wrapper = mountComponent(
+        {},
+        { subject: 'REQUESTED: Green House', type: 'Wanted' }
+      )
+      wrapper.vm.modconfig = { coloursubj: true, subjreg: /^(OFFER|WANTED):/i }
+      await wrapper.vm.$nextTick()
+      expect(wrapper.vm.subjectClass).toBe('text-success')
+    })
+
+    it('still flags a subject with no recognised keyword (red) when colouring is on', async () => {
+      const wrapper = mountComponent(
+        {},
+        { subject: 'random junk with no keyword' }
+      )
+      wrapper.vm.modconfig = { coloursubj: true, subjreg: /^(OFFER|WANTED):/i }
+      await wrapper.vm.$nextTick()
+      expect(wrapper.vm.subjectClass).toBe('text-danger')
+    })
   })
 
   describe('Expand/collapse', () => {

--- a/iznik-nuxt3/tests/unit/composables/useKeywordRegex.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useKeywordRegex.spec.js
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+import { buildKeywordRegex } from '~/composables/useKeywordRegex'
+
+describe('buildKeywordRegex', () => {
+  it('matches the standard keywords and common variants (case-insensitive)', () => {
+    const re = buildKeywordRegex()
+    for (const s of [
+      'OFFER: Sofa',
+      'offer: sofa',
+      'OFFERED: Sofa',
+      'WANTED: Bike',
+      'REQUESTED: Green House',
+      'REQUEST: Green House',
+      'TAKEN: Sofa',
+      'RECEIVED: Bike',
+    ]) {
+      expect(s.match(re), s).toBeTruthy()
+    }
+  })
+
+  it('does not match a subject with no recognised keyword', () => {
+    const re = buildKeywordRegex()
+    expect('random junk with no keyword'.match(re)).toBeFalsy()
+    expect('Green House (Norwich)'.match(re)).toBeFalsy()
+  })
+
+  it("honours a group's custom keywords", () => {
+    const re = buildKeywordRegex({ offer: 'Offered', wanted: 'Looking for' })
+    expect('Offered: Sofa'.match(re)).toBeTruthy()
+    expect('Looking for: Bike'.match(re)).toBeTruthy()
+    // Standard keywords still recognised alongside the custom ones.
+    expect('WANTED: Bike'.match(re)).toBeTruthy()
+  })
+
+  it('escapes regex special characters in custom keywords', () => {
+    const re = buildKeywordRegex({ wanted: 'Want (urgent)' })
+    expect('Want (urgent): Bike'.match(re)).toBeTruthy()
+    // The parens are literal, not a group — a bare "Want" must not match.
+    expect('Want: Bike'.match(re)).toBeFalsy()
+  })
+})


### PR DESCRIPTION
## Summary

Fixes the ModTools subject-keyword **colour** bug reported on Discourse: a `Wanted` post shown with a custom group keyword like **"REQUESTED"** appeared in **red**, while plain **"WANTED:"** posts (the same type) stayed **green** — inconsistent and confusing for groups that customise their keywords.

**Root cause:** the `coloursubj` highlight in `ModMessage.vue` coloured a subject green only if it matched the mod config's free-text `subjreg` (default `/^(OFFER|WANTED):/i`). That regex doesn't know about per-group custom keywords, so "REQUESTED:" failed to match → red. The colour was driven by the **keyword text**, not the message **type**.

Verified on live prod data via the apiv2 tunnel: msg `120694369` ("REQUESTED: Green House") and `120305657` ("WANTED: Wheelie Bins") are **both** type `Wanted`.

## Fix

Decide "well-formed subject" from the **group's configured keywords** plus the standard OFFER/WANTED and common variants (OFFERED / REQUESTED / REQUEST) — the same construct-regex idea already used by `useMessageDisplay.strippedSubject`. A subject is green if it matches that keyword set **or** the mod's own `subjreg`; otherwise it's still flagged red.

- New `composables/useKeywordRegex.js` (`buildKeywordRegex`) — one source for the keyword set, including each group's custom keyword **and** the standard + variants (so both "WANTED:" and "REQUESTED:" on the same group are treated consistently).
- `useMessageDisplay.strippedSubject` now uses it (same behaviour, more thorough stripping).
- `ModMessage.subjectClass` uses it for the colour decision.

## Code Quality Review
- Single shared keyword source (no duplicated keyword lists).
- Regex special chars in custom keywords are escaped.
- Backwards compatible: a mod's custom `subjreg` is still honoured as an additional match.

## Future Improvements
- The ModTools edit type dropdown is intentionally OFFER/WANTED (it labels them with the group keyword); the reporter's "can't change to Requested" is the keyword being a per-group display setting, not a per-post one — out of scope here.

## Test Plan
- `useKeywordRegex.spec.js` (4): standard + variants + custom keywords + regex escaping.
- `ModMessage.spec.js` subjectClass (488 total): **"REQUESTED" stays green** even when `subjreg` only knows OFFER/WANTED; a subject with no recognised keyword stays red; valid subjects green.
- `useMessageDisplay.spec.js` (85) unchanged-green after the refactor.

## Discourse

https://discourse.ilovefreegle.org/t/9481/594

🤖 Generated with [Claude Code](https://claude.com/claude-code)
