### PR TITLE
fix(qr): restrict the QR generator page to mods (or above)

### DIFF
--- a/iznik-nuxt3/pages/qr.vue
+++ b/iznik-nuxt3/pages/qr.vue
@@ -2,41 +2,66 @@
   <div class="qr-page py-4">
     <b-container>
       <h1 class="h3 mb-2">Freegle QR code generator</h1>
-      <p class="text-muted">
-        Enter a link and we'll make a Freegle-branded QR code you can download
-        as a PNG to print, share or stick up wherever you like.
-      </p>
 
-      <b-form-group label="Link (URL)" label-for="qr-url" class="qr-input">
-        <b-form-input
-          id="qr-url"
-          v-model="url"
-          type="url"
-          placeholder="https://www.ilovefreegle.org"
-          autocomplete="off"
-        />
-      </b-form-group>
+      <!-- This is a volunteer tool: only show it to mods (or above). -->
+      <div v-if="mod">
+        <p class="text-muted">
+          Enter a link and we'll make a Freegle-branded QR code you can download
+          as a PNG to print, share or stick up wherever you like.
+        </p>
 
-      <div class="qr-stage my-3">
-        <div ref="qrTarget" class="qr-target" :class="{ 'd-none': !hasCode }" />
-        <p v-if="!url" class="text-muted mb-0">
-          Enter a link above to see your QR code.
-        </p>
-        <p v-else-if="loadError" class="text-danger mb-0">
-          Sorry — the QR generator failed to load. Please reload the page.
-        </p>
+        <b-form-group label="Link (URL)" label-for="qr-url" class="qr-input">
+          <b-form-input
+            id="qr-url"
+            v-model="url"
+            type="url"
+            placeholder="https://www.ilovefreegle.org"
+            autocomplete="off"
+          />
+        </b-form-group>
+
+        <div class="qr-stage my-3">
+          <div ref="qrTarget" class="qr-target" :class="{ 'd-none': !hasCode }" />
+          <p v-if="!url" class="text-muted mb-0">
+            Enter a link above to see your QR code.
+          </p>
+          <p v-else-if="loadError" class="text-danger mb-0">
+            Sorry — the QR generator failed to load. Please reload the page.
+          </p>
+        </div>
+
+        <b-button variant="primary" :disabled="!hasCode" @click="download">
+          Download PNG
+        </b-button>
       </div>
 
-      <b-button variant="primary" :disabled="!hasCode" @click="download">
-        Download PNG
-      </b-button>
+      <!-- Logged in, but not a volunteer. -->
+      <b-alert v-else-if="me" :model-value="true" variant="warning">
+        Sorry, this page is only available to Freegle volunteers.
+      </b-alert>
+
+      <!-- Not logged in. -->
+      <div v-else>
+        <p class="text-muted">
+          This page is only available to Freegle volunteers. Please log in to
+          continue.
+        </p>
+        <b-button variant="primary" size="lg" @click="forceLogin">
+          Log in to continue <v-icon icon="angle-double-right" />
+        </b-button>
+      </div>
     </b-container>
   </div>
 </template>
 
 <script setup>
-import { ref, watch, onMounted } from 'vue'
+import { ref, watch, nextTick, onMounted } from 'vue'
 import { createFreegleQr } from '~/composables/useFreegleQr'
+import { useMe } from '~/composables/useMe'
+import { useAuthStore } from '~/stores/auth'
+
+const { me, mod } = useMe()
+const authStore = useAuthStore()
 
 const url = ref('https://www.ilovefreegle.org')
 const qrTarget = ref(null)
@@ -44,7 +69,15 @@ const hasCode = ref(false)
 const loadError = ref(false)
 let qrCode = null
 
-onMounted(async () => {
+function forceLogin() {
+  authStore.forceLogin = true
+}
+
+// Build the generator only for a mod, and only once the target element is in
+// the DOM. Both `mod` (auth loads async) and the v-if'd target may resolve
+// after mount, so initialise on whichever happens last.
+async function initQr() {
+  if (qrCode || !mod.value || !qrTarget.value) return
   try {
     // qr-code-styling touches the DOM, so build it only on the client.
     qrCode = await createFreegleQr(url.value)
@@ -52,6 +85,16 @@ onMounted(async () => {
     hasCode.value = !!url.value
   } catch (e) {
     loadError.value = true
+  }
+}
+
+onMounted(() => {
+  initQr()
+})
+
+watch(mod, (isMod) => {
+  if (isMod) {
+    nextTick(initQr)
   }
 })
 

--- a/iznik-nuxt3/tests/unit/pages/qr.spec.js
+++ b/iznik-nuxt3/tests/unit/pages/qr.spec.js
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { ref } from 'vue'
+import QrPage from '~/pages/qr.vue'
+import { createFreegleQr } from '~/composables/useFreegleQr'
+
+// useMe drives the access gate: `mod` is true for Moderator/Support/Admin.
+const mockMe = ref(null)
+const mockMod = ref(false)
+vi.mock('~/composables/useMe', () => ({
+  useMe: () => ({ me: mockMe, mod: mockMod }),
+}))
+
+// The QR generator touches the DOM; stub it out. The factory must be
+// self-contained (vi.mock is hoisted above any top-level consts).
+vi.mock('~/composables/useFreegleQr', () => ({
+  createFreegleQr: vi.fn(() =>
+    Promise.resolve({ append: vi.fn(), update: vi.fn(), download: vi.fn() })
+  ),
+}))
+
+// ~/stores/auth is pre-aliased to tests/unit/mocks/auth-store.js; override via
+// globalThis.__mockAuthStore.
+
+function mountPage() {
+  return mount(QrPage, {
+    global: {
+      stubs: {
+        'b-container': { template: '<div><slot /></div>' },
+        'b-form-group': {
+          template: '<div><slot /></div>',
+          props: ['label', 'labelFor'],
+        },
+        'b-form-input': {
+          template:
+            '<input :id="id" :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" />',
+          props: ['id', 'modelValue', 'type', 'placeholder', 'autocomplete'],
+        },
+        'b-button': {
+          template:
+            '<button :disabled="disabled" @click="$emit(\'click\')"><slot /></button>',
+          props: ['variant', 'size', 'disabled'],
+        },
+        'b-alert': {
+          template: '<div class="alert"><slot /></div>',
+          props: ['modelValue', 'variant'],
+        },
+        'v-icon': { template: '<i />', props: ['icon'] },
+      },
+    },
+  })
+}
+
+describe('qr page access gate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockMe.value = null
+    mockMod.value = false
+    globalThis.__mockAuthStore = { forceLogin: false }
+  })
+
+  it('shows the generator to a mod (or above)', async () => {
+    mockMe.value = { id: 1, systemrole: 'Moderator' }
+    mockMod.value = true
+
+    const wrapper = mountPage()
+    await flushPromises()
+
+    expect(wrapper.find('#qr-url').exists()).toBe(true)
+    expect(wrapper.text()).toContain('Download PNG')
+    expect(wrapper.text()).not.toContain('Log in to continue')
+  })
+
+  it('blocks a logged-in non-mod with a volunteers-only message', () => {
+    mockMe.value = { id: 2, systemrole: 'User' }
+    mockMod.value = false
+
+    const wrapper = mountPage()
+
+    expect(wrapper.find('#qr-url').exists()).toBe(false)
+    expect(wrapper.text()).toContain('only available to Freegle volunteers')
+    expect(wrapper.text()).not.toContain('Download PNG')
+  })
+
+  it('prompts a logged-out visitor to log in, and triggers forceLogin', async () => {
+    mockMe.value = null
+    mockMod.value = false
+
+    const wrapper = mountPage()
+
+    expect(wrapper.find('#qr-url').exists()).toBe(false)
+    expect(wrapper.text()).toContain('Log in to continue')
+
+    await wrapper.find('button').trigger('click')
+    expect(globalThis.__mockAuthStore.forceLogin).toBe(true)
+  })
+
+  it('does not build a QR code for a non-mod', () => {
+    mockMe.value = { id: 3, systemrole: 'User' }
+    mockMod.value = false
+
+    mountPage()
+
+    // createFreegleQr is the (mocked) generator; it must not run for non-mods.
+    expect(createFreegleQr).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- `/qr` (the Freegle-branded QR code generator) is a volunteer tool, but it was reachable by anyone. Gate it on the signed-in user's role.
- Uses `useMe().mod` (true for **Moderator / Support / Admin**):
  - **mod or above** -> the generator works exactly as before;
  - **logged in but not a volunteer** -> a "this page is only available to Freegle volunteers" notice;
  - **logged out** -> a "Log in to continue" button that triggers `authStore.forceLogin`, matching the pattern used by `/myposts`.
- The QR builder is initialised only once the user is confirmed as a mod **and** the target element is in the DOM (both can resolve after mount), so `createFreegleQr` never runs for non-mods.

## Code Quality Review
- Reuses the existing `useMe().mod` role flag and the established `forceLogin` login-gate pattern - no new auth machinery.
- Gating is client-side, consistent with other role-gated pages in this app; the generator is purely client-side (no sensitive server data), so hiding the tool is the appropriate control.

## Test Plan
- New `tests/unit/pages/qr.spec.js` (4 cases, all green, run via the status API):
  - mod -> generator shown (URL input + Download button), no login prompt;
  - logged-in non-mod -> "only available to Freegle volunteers", generator hidden;
  - logged-out -> "Log in to continue", and clicking it sets `forceLogin`;
  - non-mod -> the generator is never built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
