### PR TITLE
fix(site): show unread count badge in the browser tab title

### DIFF
--- a/iznik-nuxt3/app.vue
+++ b/iznik-nuxt3/app.vue
@@ -145,6 +145,7 @@ import { computed, onMounted, useRoute } from '#imports'
 // polyfills
 import 'core-js/actual/array/to-sorted'
 import { useConfigStore } from '~/stores/config'
+import { badgeTitle } from '~/composables/useTitleBadge'
 
 const route = useRoute()
 const loadingIndicatorThrottle = ref(5000)
@@ -368,17 +369,12 @@ if (process.client) {
 
   useHead({
     titleTemplate: (titleChunk) => {
+      // Read the count refs' .value here (inside the reactive titleTemplate) so
+      // the badge updates as chats/notifications arrive. totalCount is a plain
+      // number - the previous code checked totalCount.value (undefined), so the
+      // count was never shown on the Freegle site (Discourse 9806/6).
       const totalCount = notificationCount.value + chatCount.value
-
-      if (titleChunk) {
-        if (titleChunk.charAt(0) !== '(' && totalCount.value > 0) {
-          return '(' + totalCount.value + ') ' + titleChunk
-        } else {
-          return titleChunk
-        }
-      } else {
-        return null
-      }
+      return badgeTitle(titleChunk, totalCount)
     },
   })
 }

--- a/iznik-nuxt3/composables/useTitleBadge.js
+++ b/iznik-nuxt3/composables/useTitleBadge.js
@@ -1,0 +1,21 @@
+/**
+ * Build the browser-tab title with an unread-count badge prefix, e.g.
+ * "(3) Freegle - ...". Mirrors what ModTools (and apps like Messenger) do so a
+ * member sees they have new messages without opening the tab.
+ *
+ * @param {string|null|undefined} titleChunk The page's own title.
+ * @param {number} totalCount Combined unread count (chats + notifications).
+ * @returns {string|null} The title to display, count-prefixed when > 0.
+ */
+export function badgeTitle(titleChunk, totalCount) {
+  if (!titleChunk) {
+    return null
+  }
+
+  // Don't double-prefix if a count is already there, and only add when > 0.
+  if (titleChunk.charAt(0) !== '(' && totalCount > 0) {
+    return '(' + totalCount + ') ' + titleChunk
+  }
+
+  return titleChunk
+}

--- a/iznik-nuxt3/tests/unit/composables/useTitleBadge.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useTitleBadge.spec.js
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import { badgeTitle } from '~/composables/useTitleBadge'
+
+describe('badgeTitle', () => {
+  it('prefixes the count when there are unread items', () => {
+    expect(badgeTitle('Freegle - Home', 3)).toBe('(3) Freegle - Home')
+  })
+
+  it('does not prefix when the count is zero', () => {
+    expect(badgeTitle('Freegle - Home', 0)).toBe('Freegle - Home')
+  })
+
+  it('does not prefix for a negative/falsey count', () => {
+    expect(badgeTitle('Freegle - Home', -1)).toBe('Freegle - Home')
+  })
+
+  it('does not double-prefix when a count is already present', () => {
+    expect(badgeTitle('(2) Freegle - Home', 5)).toBe('(2) Freegle - Home')
+  })
+
+  it('returns null when there is no title', () => {
+    expect(badgeTitle('', 3)).toBe(null)
+    expect(badgeTitle(null, 3)).toBe(null)
+    expect(badgeTitle(undefined, 3)).toBe(null)
+  })
+
+  it('combines chats + notifications (caller sums them)', () => {
+    // The app passes notificationCount + chatCount; verify a typical total.
+    expect(badgeTitle('Freegle', 1 + 99)).toBe('(100) Freegle')
+  })
+})


### PR DESCRIPTION
## Summary
- The Freegle website was supposed to prefix the browser-tab title with the unread count (the way ModTools and apps like Messenger do), so a member sees new messages without opening the tab. It never worked.
- Root cause: in `app.vue`'s `useHead` titleTemplate, `totalCount` is a plain number, but the code checked `totalCount.value` (`undefined`). `undefined > 0` is always false, so the count was never prepended (and would have rendered "(undefined)" if it had been).
- Extracted the logic into a tested `badgeTitle(titleChunk, totalCount)` helper and wired it in. The count refs' `.value` are read inside the reactive titleTemplate so the badge updates live as chats/notifications arrive.

Counts combined = `notificationStore.count` + `chatStore.unreadCount` (same sources already used for the page).

## Discourse
https://discourse.ilovefreegle.org/t/9806/6

## Test Plan
- New `tests/unit/composables/useTitleBadge.spec.js` (6 cases, all green): prefixes when count > 0; no prefix at 0/negative; no double-prefix when already "(n)"; null when no title; combined chats+notifications total.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
