### PR TITLE
fix(push): daily new-posts digest no longer inflates the FD app badge

### DIFF
--- a/iznik-batch/app/Services/PushNotificationService.php
+++ b/iznik-batch/app/Services/PushNotificationService.php
@@ -289,7 +289,15 @@ class PushNotificationService
      * Exhort: title/body/route taken from the notification, EXHORT category/tips
      * channel).
      */
-    public function buildUserNotificationPayload(int $userId): array
+    /**
+     * The unread counts that make up a consumer's app-icon badge: unseen
+     * on-site notifications + unread User2User/User2Mod chats. This is the
+     * "actionable items" count the badge should reflect - NOT informational
+     * pushes such as the daily "new posts near you" digest.
+     *
+     * @return array{0:int,1:int} [chatcount, notifcount]
+     */
+    public function consumerUnreadCounts(int $userId): array
     {
         $notifcount = (int) DB::table('users_notifications')
             ->where('touser', $userId)
@@ -307,6 +315,13 @@ class PushNotificationService
                 WHERE cm.chatid = cr.chatid AND cm.userid <> ?
             ))', [$userId])
             ->count();
+
+        return [$chatcount, $notifcount];
+    }
+
+    public function buildUserNotificationPayload(int $userId): array
+    {
+        [$chatcount, $notifcount] = $this->consumerUnreadCounts($userId);
 
         $total = $chatcount + $notifcount;
 
@@ -1309,6 +1324,15 @@ class PushNotificationService
         }
         $imageUrl = $imageUrls[0] ?? null;
 
+        // The app-icon badge must reflect the user's actionable unread items
+        // (unread chats + unseen notifications), NOT the number of posts in this
+        // informational digest. Previously this was `(string) $count`, so a daily
+        // "new posts near you" push set the FD badge to the post count and made it
+        // look like there was unread activity to deal with. Use the real unread
+        // total so the digest never inflates the badge.
+        [$chatcount, $notifcount] = $this->consumerUnreadCounts($userId);
+        $badge = $chatcount + $notifcount;
+
         return [
             'channel_id'        => 'new_posts',
             'category'          => self::CATEGORY_NEW_POSTS,
@@ -1323,7 +1347,7 @@ class PushNotificationService
             'summary'           => 'Freegle • ' . $count . ' new post' . ($count === 1 ? '' : 's'),
             'moreCount'         => (string) $moreCount,
             'timestamp'         => (string) time(),
-            'badge'             => (string) $count,
+            'badge'             => (string) $badge,
             'content-available' => '1',
             'modtools'          => 'false',
         ];

--- a/iznik-batch/tests/Unit/Services/DailyPostsPushTest.php
+++ b/iznik-batch/tests/Unit/Services/DailyPostsPushTest.php
@@ -65,8 +65,42 @@ class DailyPostsPushTest extends TestCase
         $this->assertSame('Sofa', $payload['title'],
             'Single-post title must be the bare item name (stripped prefix + location)');
         $this->assertSame('1', $payload['count']);
-        $this->assertSame('1', $payload['badge']);
+        // The badge reflects the user's unread chats + notifications, NOT the
+        // number of posts in the digest. This fresh user has neither, so 0.
+        $this->assertSame('0', $payload['badge']);
         $this->assertSame('0', $payload['moreCount']);
+    }
+
+    public function test_badge_is_user_unread_not_post_count(): void
+    {
+        // The daily "new posts near you" digest is informational and must not
+        // inflate the app-icon badge with the post count. The badge must equal
+        // the user's actual unread items (unseen notifications + unread chats).
+        $user  = $this->createTestUser();
+        $group = $this->createTestGroup();
+
+        // Three posts in the digest...
+        $msgs = [
+            $this->createApprovedMessage($user, $group, 'OFFER: Sofa (Kingston)'),
+            $this->createApprovedMessage($user, $group, 'WANTED: Bike (Surbiton)'),
+            $this->createApprovedMessage($user, $group, 'OFFER: Lamp (Kingston)'),
+        ];
+        $posts = $this->buildPostsArray($msgs);
+
+        // ...but two genuinely unseen notifications for the recipient.
+        for ($i = 0; $i < 2; $i++) {
+            DB::table('users_notifications')->insert([
+                'touser' => $user->id,
+                'type' => 'Exhort',
+                'seen' => 0,
+                'timestamp' => now(),
+            ]);
+        }
+
+        $payload = $this->pushService->buildDailyNewPostsPayload($user->id, $posts);
+
+        $this->assertSame('3', $payload['count'], 'count reflects the posts in the digest');
+        $this->assertSame('2', $payload['badge'], 'badge reflects unread items, not the post count');
     }
 
     public function test_multi_post_title_is_count_new_things(): void


### PR DESCRIPTION
## Summary
- The daily "new posts near you" digest push was inflating the **Freegle app icon badge**.
- `PushNotificationService::buildDailyNewPostsPayload()` set the FCM `badge` to `(string) $count` — the **number of posts in the digest**. The app applies a push's `badge` straight to the icon (`stores/mobile.js` `handleNotification` -> `setBadgeCount`), even for `new_posts` pushes, so an informational digest made the badge look like there were that many unread items to act on.
- Fix: the app badge should reflect **actionable unread items only**. Extracted the unread-count queries (unseen `users_notifications` + unread User2User/User2Mod chats) into a shared `consumerUnreadCounts()` helper — the exact source the normal chat/notification push (`buildUserNotificationPayload`) already uses — and the daily push now sets `badge` from that, not the post count. The digest still shows its content (`count`, `lines`, `summary`); only the icon badge is corrected.

## Discourse
https://discourse.ilovefreegle.org/t/9806/6

## Test Plan
- `DailyPostsPushTest`:
  - `test_single_post_title_is_item_name` now asserts `badge` = `0` (fresh user has no unread) while `count` = `1`.
  - New `test_badge_is_user_unread_not_post_count`: 3 posts in the digest + 2 unseen notifications -> `count` = `3`, `badge` = `2`.
- Payload-builder tests pass. (`buildUserNotificationPayload` is a behaviour-preserving refactor onto the shared helper.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
