### PR TITLE
feat(rippling): actual-vs-expected reach on the mod reach map

### DIFF
--- a/iznik-nuxt3/api/MessageAPI.js
+++ b/iznik-nuxt3/api/MessageAPI.js
@@ -10,6 +10,11 @@ export default class MessageAPI extends BaseAPI {
     return await this.$getv2('/message/' + id, rest, logError)
   }
 
+  // Actual rippling-out progress of a post, for the moderation reach map (mod-of-group only).
+  reach(id, logError = true) {
+    return this.$getv2('/message/' + id + '/reach', {}, logError)
+  }
+
   fetchByUser(id, active, logError = true) {
     return this.$getv2(
       '/user/' + id + '/message',

--- a/iznik-nuxt3/modtools/components/ModMessage.vue
+++ b/iznik-nuxt3/modtools/components/ModMessage.vue
@@ -693,6 +693,7 @@
     <ModMessageReachMap
       v-if="message && message.id"
       ref="reachMapModal"
+      :messageid="message.id"
       :lat="position?.lat"
       :lng="position?.lng"
       :arrival="reachArrival"

--- a/iznik-nuxt3/modtools/components/ModMessageReachMap.vue
+++ b/iznik-nuxt3/modtools/components/ModMessageReachMap.vue
@@ -20,6 +20,7 @@
             :initial-lat="lat"
             :initial-lng="lng"
             :initial-elapsed-hours="elapsedHours"
+            :actual-elapsed-hours="actualElapsedHours"
             :spatial-url="spatialUrl"
             :jwt="jwt"
           />
@@ -34,8 +35,10 @@ import { useRuntimeConfig } from '#imports'
 import RipplingExplorer from './RipplingExplorer.vue'
 import { useOurModal } from '~/composables/useOurModal'
 import { useMe } from '~/composables/useMe'
+import { useMessageStore } from '~/stores/message'
 
 const props = defineProps({
+  messageid: { type: Number, default: null },
   lat: { type: Number, default: null },
   lng: { type: Number, default: null },
   // The post's arrival time, so the reach opens at how far it has already rippled.
@@ -44,19 +47,23 @@ const props = defineProps({
 
 const runtimeConfig = useRuntimeConfig()
 const { jwt } = useMe()
+const messageStore = useMessageStore()
 
 const { modal, show: showModal, hide } = useOurModal({ autoShow: false })
 
 // Only mount the explorer while the modal is open, so it seeds + plays the ripple
 // fresh each time and tears down (releasing its map/animation) on close.
 const rendered = ref(false)
+// The post's ACTUAL rippling progress from the backend (null until fetched).
+const reach = ref(null)
 
 const spatialUrl = computed(
   () => runtimeConfig.public.SPATIAL_SERVER_URL || 'http://localhost:8196'
 )
 const hasLocation = computed(() => props.lat != null && props.lng != null)
 
-// How long the post has already been live, so the reach opens at its current point.
+// How long the post has already been live: the EXPECTED point (where reach SHOULD be).
+// The map + scrubber open here; this is the "up to" marker.
 const elapsedHours = computed(() => {
   if (!props.arrival) return 0
   const t = new Date(props.arrival).getTime()
@@ -64,9 +71,37 @@ const elapsedHours = computed(() => {
   return Math.max(0, (Date.now() - t) / 3600000)
 })
 
-function show() {
+// The hazard schedule (wall-clock hours per reach tick) — mirrors config/freegle.php.
+const HAZARD_HOURS = [1, 3, 6, 12, 24, 48, 72, 120, 168]
+function tickForHours(hours) {
+  let t = 1
+  HAZARD_HOURS.forEach((h, i) => {
+    if (hours >= h) t = i + 1
+  })
+  return Math.min(t, HAZARD_HOURS.length)
+}
+
+// The ACTUAL point ("now"), as elapsed-hours, ONLY when the engine is behind where it
+// should be. Null = up to date (or not rippling / dark) -> the modal shows just "up to".
+const actualElapsedHours = computed(() => {
+  const r = reach.value
+  if (!r || !r.rippling || !r.tick) return null
+  const expectedTick = tickForHours(elapsedHours.value)
+  if (r.tick >= expectedTick) return null // caught up -> only "up to"
+  return HAZARD_HOURS[Math.min(r.tick, HAZARD_HOURS.length) - 1]
+})
+
+async function show() {
   rendered.value = true
+  reach.value = null
   showModal()
+  if (props.messageid) {
+    try {
+      reach.value = await messageStore.fetchReach(props.messageid, false)
+    } catch (e) {
+      reach.value = null
+    }
+  }
 }
 
 defineExpose({ show, hide })

--- a/iznik-nuxt3/modtools/components/RipplingExplorer.vue
+++ b/iznik-nuxt3/modtools/components/RipplingExplorer.vue
@@ -383,8 +383,11 @@ const props = defineProps({
   initialLng: { type: Number, default: null },
   initialView: { type: String, default: null },
   // How long the post has already been live (hours). The seeded reach opens at the
-  // matching point on the scrubber (static, no animation), so mods see where it is now.
+  // matching point on the scrubber (static, no animation): the EXPECTED point ("up to").
   initialElapsedHours: { type: Number, default: null },
+  // The ACTUAL reach point (elapsed-hours equivalent), shown as a "now" marker ONLY when
+  // the engine is behind the expected point. Null = up to date -> show just "up to".
+  actualElapsedHours: { type: Number, default: null },
 })
 
 let cleanup = null

--- a/iznik-nuxt3/modtools/composables/rippling/setupRipplingExplorer.js
+++ b/iznik-nuxt3/modtools/composables/rippling/setupRipplingExplorer.js
@@ -1706,6 +1706,32 @@ export async function setupRipplingExplorer({
     staticCrossMarked = true
   }
 
+  // Static mode: mark where the reach SHOULD be ("up to", expected — bottom) and, only when
+  // the engine is behind, where it ACTUALLY is ("now", actual — top). When they match we show
+  // just "up to", so a visible "now" means the post hasn't rippled as far as it should.
+  function addReachMarker(layer, hours, text, color, where) {
+    const pct = hoursToLogPct(Math.max(0, Math.min(hours, MAX_HOURS)))
+    const mark = document.createElement('div')
+    mark.className = 'rpl-tick-mark'
+    mark.style.cssText = `left:${pct}%;background:${color};height:16px;top:-11px;width:2px`
+    layer.appendChild(mark)
+    const label = document.createElement('div')
+    const xform =
+      pct < 12 ? 'translateX(0)' : pct > 88 ? 'translateX(-100%)' : 'translateX(-50%)'
+    const top = where === 'top' ? '-28px' : '16px'
+    label.style.cssText = `position:absolute;left:${pct}%;top:${top};color:${color};font-size:10px;font-weight:700;white-space:nowrap;transform:${xform}`
+    label.textContent = text
+    layer.appendChild(label)
+  }
+  function renderReachMarkers() {
+    const layer = document.getElementById('rippling-tl-tick-layer')
+    if (!layer || props.initialElapsedHours == null) return
+    addReachMarker(layer, props.initialElapsedHours, '▼ up to', '#2c7be5', 'bottom')
+    if (props.actualElapsedHours != null) {
+      addReachMarker(layer, props.actualElapsedHours, 'now ▲', '#e07000', 'top')
+    }
+  }
+
   const EXPANSION_HOURS = [0, 1, 3, 6, 12, 24, 48, 72, 120, 168, 336, 720]
   const MAX_HOURS = 720
   let timelineBuilt = false
@@ -2107,6 +2133,7 @@ export async function setupRipplingExplorer({
       const clamped = Math.max(0, Math.min(staticAtHours, MAX_HOURS))
       jumpToFrame(Math.round((clamped / MAX_HOURS) * maxIdx))
       markCrossPostingStatic()
+      renderReachMarkers()
       return
     }
 

--- a/iznik-nuxt3/stores/message.js
+++ b/iznik-nuxt3/stores/message.js
@@ -564,6 +564,10 @@ export const useMessageStore = defineStore({
       if (message && !message.subject) message.subject = ''
       return message
     },
+    // Actual rippling-out progress of a post, for the moderation reach map.
+    async fetchReach(id, logError = true) {
+      return await api(this.config).message.reach(id, logError)
+    },
     async updateMT(params) {
       // Rely on refresh elsewhere
       return await api(this.config).message.update(params)

--- a/iznik-nuxt3/tests/unit/components/modtools/ModMessageReachMap.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModMessageReachMap.spec.js
@@ -5,6 +5,7 @@ import ModMessageReachMap from '~/modtools/components/ModMessageReachMap.vue'
 
 const mockShow = vi.fn()
 const mockHide = vi.fn()
+const mockFetchReach = vi.fn(() => Promise.resolve({ rippling: false }))
 
 vi.mock('~/composables/useOurModal', () => ({
   useOurModal: () => ({
@@ -16,6 +17,10 @@ vi.mock('~/composables/useOurModal', () => ({
 
 vi.mock('~/composables/useMe', () => ({
   useMe: () => ({ jwt: 'jwt-token' }),
+}))
+
+vi.mock('~/stores/message', () => ({
+  useMessageStore: () => ({ fetchReach: mockFetchReach }),
 }))
 
 vi.mock('#imports', () => ({
@@ -31,11 +36,18 @@ const ExplorerStub = {
     initialLat: { default: null },
     initialLng: { default: null },
     initialView: { default: null },
+    initialElapsedHours: { default: null },
+    actualElapsedHours: { default: null },
     spatialUrl: { default: null },
     jwt: { default: null },
   },
   template:
-    '<div class="explorer-stub" :data-lat="initialLat" :data-lng="initialLng" :data-view="initialView" :data-minimal="minimal" :data-spatial="spatialUrl" />',
+    '<div class="explorer-stub" :data-lat="initialLat" :data-lng="initialLng" :data-view="initialView" :data-minimal="minimal" :data-spatial="spatialUrl" :data-actual="actualElapsedHours" />',
+}
+
+// arrival N hours ago, as an ISO string.
+function hoursAgo(n) {
+  return new Date(Date.now() - n * 3600 * 1000).toISOString()
 }
 
 function mountComponent(props = { lat: 51.5, lng: -0.1 }) {
@@ -83,6 +95,51 @@ describe('ModMessageReachMap', () => {
     // minimal mode: no panel / tunable controls, just map + scrubber.
     expect(explorer.attributes('data-minimal')).toBeTruthy()
     expect(explorer.attributes('data-spatial')).toBe('http://spatial.test')
+  })
+
+  it('passes a "now" (actual) point only when the engine is behind expected', async () => {
+    // Post ~14h old -> expected tick 4 (12h band). Actual tick 2 (3h) = behind.
+    mockFetchReach.mockResolvedValueOnce({ rippling: true, tick: 2, totalticks: 9 })
+    const wrapper = mountComponent({
+      messageid: 42,
+      lat: 55.95,
+      lng: -3.19,
+      arrival: hoursAgo(14),
+    })
+    await wrapper.vm.show()
+    await flushPromises()
+    expect(mockFetchReach).toHaveBeenCalledWith(42, false)
+    // actual = HAZARD_HOURS[tick-1] = HAZARD_HOURS[1] = 3
+    expect(wrapper.find('.explorer-stub').attributes('data-actual')).toBe('3')
+  })
+
+  it('does NOT pass a "now" point when the engine is up to date', async () => {
+    // Post ~14h old -> expected tick 4. Actual tick 4 = caught up.
+    mockFetchReach.mockResolvedValueOnce({ rippling: true, tick: 4, totalticks: 9 })
+    const wrapper = mountComponent({
+      messageid: 42,
+      lat: 55.95,
+      lng: -3.19,
+      arrival: hoursAgo(14),
+    })
+    await wrapper.vm.show()
+    await flushPromises()
+    const a = wrapper.find('.explorer-stub').attributes('data-actual')
+    expect(a === undefined || a === '').toBe(true)
+  })
+
+  it('does NOT pass a "now" point when the post is not rippling (dark)', async () => {
+    mockFetchReach.mockResolvedValueOnce({ rippling: false, reason: 'disabled' })
+    const wrapper = mountComponent({
+      messageid: 42,
+      lat: 55.95,
+      lng: -3.19,
+      arrival: hoursAgo(14),
+    })
+    await wrapper.vm.show()
+    await flushPromises()
+    const a = wrapper.find('.explorer-stub').attributes('data-actual')
+    expect(a === undefined || a === '').toBe(true)
   })
 
   it('shows a no-location message instead of the map when the post has no location', async () => {

--- a/iznik-server-go/message/reach.go
+++ b/iznik-server-go/message/reach.go
@@ -1,0 +1,114 @@
+package message
+
+import (
+	"strconv"
+
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/freegle/iznik-server-go/user"
+	"github.com/gofiber/fiber/v2"
+)
+
+// ReachResponse is a post's ACTUAL rippling-out progress, for the moderation reach map to
+// compare against the EXPECTED progress (the map itself draws the expected/projected reach;
+// this tells the modal how far the post has really rippled, so it can flag when the engine
+// is behind). `Rippling` is false (with a Reason) when the post has no reach row.
+type ReachResponse struct {
+	Rippling bool `json:"rippling"`
+	// Reason explains why a post has no actual reach (only set when Rippling is false):
+	//   "disabled"     - rippling is switched off globally (the dark default).
+	//   "notbrowsable" - the post isn't browsable (pending/taken/withdrawn).
+	//   "pending"      - eligible but no reach row yet (the ~1-minute post-approval window,
+	//                    or it arrived before the go-live cutoff).
+	Reason          string  `json:"reason,omitempty"`
+	Msgid           uint64  `json:"msgid"`
+	Tick            int     `json:"tick"`
+	TotalTicks      int     `json:"totalticks"`
+	Status          string  `json:"status"`
+	Arrival         *string `json:"arrival"`
+	NextExpansionAt *string `json:"nextexpansionat"`
+}
+
+type reachRow struct {
+	Tick            int
+	TotalTicks      int
+	Status          string
+	Arrival         *string
+	NextExpansionAt *string
+}
+
+// Reach returns a post's current ACTUAL rippling-out progress (the hazard-schedule tick it has
+// really reached), for moderators to compare with the expected progress on the reach map.
+// Mod-of-group (or Admin/Support) only; returns rippling:false (not 404) with a reason when the
+// post has no reach row.
+//
+// @Router /message/{id}/reach [get]
+// @Summary Actual rippling-out progress of a post (moderation)
+// @Tags message
+// @Produce json
+// @Param id path int true "Message ID"
+// @Security BearerAuth
+// @Success 200 {object} message.ReachResponse
+// @Failure 403 {object} fiber.Error "Moderator of the post's group required"
+func Reach(c *fiber.Ctx) error {
+	db := database.DBConn
+
+	myid := user.WhoAmI(c)
+	if myid == 0 {
+		return fiber.NewError(fiber.StatusUnauthorized, "Not logged in")
+	}
+
+	id, err := strconv.ParseUint(c.Params("id"), 10, 64)
+	if err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, "Invalid message id")
+	}
+
+	// The groups the post is on, for the mod-of-group authorisation and to confirm it exists.
+	var groupids []uint64
+	db.Raw("SELECT groupid FROM messages_groups WHERE msgid = ? AND deleted = 0", id).Scan(&groupids)
+	if len(groupids) == 0 {
+		return fiber.NewError(fiber.StatusNotFound, "Message not found")
+	}
+
+	allowed := user.IsAdminOrSupport(myid)
+	if !allowed {
+		for _, gid := range groupids {
+			if user.IsModOfGroup(myid, gid) {
+				allowed = true
+				break
+			}
+		}
+	}
+	if !allowed {
+		return fiber.NewError(fiber.StatusForbidden, "Not a moderator of this post's group")
+	}
+
+	var row reachRow
+	found := db.Raw("SELECT tick, total_ticks, status, arrival, next_expansion_at "+
+		"FROM rippling_reach WHERE msgid = ?", id).Scan(&row)
+
+	if found.RowsAffected == 0 {
+		// No actual reach row. Work out WHY so the UI doesn't imply the engine is behind when
+		// it simply isn't running (dark) or the post isn't eligible yet.
+		reason := "pending"
+		if !rippleEnabled() {
+			reason = "disabled"
+		} else {
+			var inSpatial int
+			db.Raw("SELECT COUNT(*) FROM messages_spatial WHERE msgid = ?", id).Scan(&inSpatial)
+			if inSpatial == 0 {
+				reason = "notbrowsable"
+			}
+		}
+		return c.JSON(ReachResponse{Rippling: false, Reason: reason, Msgid: id})
+	}
+
+	return c.JSON(ReachResponse{
+		Rippling:        true,
+		Msgid:           id,
+		Tick:            row.Tick,
+		TotalTicks:      row.TotalTicks,
+		Status:          row.Status,
+		Arrival:         row.Arrival,
+		NextExpansionAt: row.NextExpansionAt,
+	})
+}

--- a/iznik-server-go/router/routes.go
+++ b/iznik-server-go/router/routes.go
@@ -845,6 +845,17 @@ func SetupRoutes(app *fiber.App) {
 		// @Param ids path string true "Message IDs (comma separated)"
 		// @Success 200 {array} message.Message
 		// @Failure 404 {object} fiber.Error "Message not found"
+		// Actual rippling-out progress of a post, for the moderation reach map to compare
+		// against the expected/projected reach. Mod-of-group only.
+		// @Router /message/{id}/reach [get]
+		// @Summary Actual rippling-out progress of a post (moderation)
+		// @Tags message
+		// @Produce json
+		// @Param id path int true "Message ID"
+		// @Success 200 {object} message.ReachResponse
+		// @Failure 403 {object} fiber.Error "Moderator of the post's group required"
+		rg.Get("/message/:id/reach", message.Reach)
+
 		rg.Get("/message/:ids", message.GetMessagesWithHistory)
 
 		// Mark Messages Seen

--- a/iznik-server-go/test/message_reach_test.go
+++ b/iznik-server-go/test/message_reach_test.go
@@ -1,0 +1,107 @@
+package test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/stretchr/testify/assert"
+)
+
+// ensureRippleReachTable stands up rippling_reach with the columns the reach endpoint reads,
+// so these tests run regardless of whether the reach-engine migration is in this schema yet.
+func ensureRippleReachTable() {
+	db := database.DBConn
+	db.Exec(`CREATE TABLE IF NOT EXISTS rippling_reach (
+		msgid BIGINT UNSIGNED NOT NULL PRIMARY KEY,
+		lat DOUBLE NOT NULL, lng DOUBLE NOT NULL,
+		polygon GEOMETRY NOT NULL SRID 3857,
+		arrival TIMESTAMP NULL DEFAULT NULL,
+		tick SMALLINT UNSIGNED NOT NULL DEFAULT 0,
+		total_ticks SMALLINT UNSIGNED NOT NULL DEFAULT 0,
+		next_expansion_at TIMESTAMP NULL DEFAULT NULL,
+		status VARCHAR(16) NOT NULL DEFAULT 'expanding',
+		SPATIAL INDEX msgreach_poly (polygon)
+	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`)
+}
+
+func insertReach(mid uint64, tick, total int) {
+	db := database.DBConn
+	db.Exec("INSERT INTO rippling_reach (msgid, lat, lng, polygon, tick, total_ticks, status) VALUES (?, 51.5, -0.1, "+
+		"ST_GeomFromText('POLYGON((-0.2 51.4, 0.0 51.4, 0.0 51.6, -0.2 51.6, -0.2 51.4))', 3857), ?, ?, 'expanding') "+
+		"ON DUPLICATE KEY UPDATE tick = VALUES(tick), total_ticks = VALUES(total_ticks)", mid, tick, total)
+}
+
+// A moderator of the post's group sees the post's ACTUAL rippling progress (tick/total/status).
+func TestMessageReachAsMod(t *testing.T) {
+	ensureRippleReachTable()
+	db := database.DBConn
+
+	prefix := uniquePrefix("reachmod")
+	posterID := CreateTestUser(t, prefix+"_poster", "User")
+	group := CreateTestGroup(t, prefix)
+	mid := CreateTestMessage(t, posterID, group, "OFFER: reach test", 51.5, -0.1)
+
+	modID := CreateTestUser(t, prefix+"_mod", "User")
+	CreateTestMembership(t, modID, group, "Moderator")
+	_, token := CreateTestSession(t, modID)
+
+	insertReach(mid, 3, 9)
+	defer db.Exec("DELETE FROM rippling_reach WHERE msgid = ?", mid)
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET", fmt.Sprintf("/api/message/%d/reach?jwt=%s", mid, token), nil))
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json.Unmarshal(rsp(resp), &result)
+	assert.Equal(t, true, result["rippling"], "post has a reach row")
+	assert.Equal(t, float64(3), result["tick"], "actual tick surfaced")
+	assert.Equal(t, float64(9), result["totalticks"], "total ticks surfaced")
+}
+
+// A non-moderator is forbidden.
+func TestMessageReachForbiddenForNonMod(t *testing.T) {
+	ensureRippleReachTable()
+	db := database.DBConn
+
+	prefix := uniquePrefix("reachnomod")
+	posterID := CreateTestUser(t, prefix+"_poster", "User")
+	group := CreateTestGroup(t, prefix)
+	mid := CreateTestMessage(t, posterID, group, "OFFER: reach forbidden", 51.5, -0.1)
+
+	userID := CreateTestUser(t, prefix+"_user", "User")
+	CreateTestMembership(t, userID, group, "Member")
+	_, token := CreateTestSession(t, userID)
+
+	insertReach(mid, 3, 9)
+	defer db.Exec("DELETE FROM rippling_reach WHERE msgid = ?", mid)
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET", fmt.Sprintf("/api/message/%d/reach?jwt=%s", mid, token), nil))
+	assert.Equal(t, 403, resp.StatusCode, "non-moderator is forbidden from a post's reach")
+}
+
+// A post with no reach row returns rippling:false with a reason rather than 404.
+func TestMessageReachNoReachRow(t *testing.T) {
+	ensureRippleReachTable()
+	db := database.DBConn
+
+	prefix := uniquePrefix("reachnone")
+	posterID := CreateTestUser(t, prefix+"_poster", "User")
+	group := CreateTestGroup(t, prefix)
+	mid := CreateTestMessage(t, posterID, group, "OFFER: reach none", 51.5, -0.1)
+	db.Exec("DELETE FROM rippling_reach WHERE msgid = ?", mid)
+
+	modID := CreateTestUser(t, prefix+"_mod", "User")
+	CreateTestMembership(t, modID, group, "Moderator")
+	_, token := CreateTestSession(t, modID)
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET", fmt.Sprintf("/api/message/%d/reach?jwt=%s", mid, token), nil))
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json.Unmarshal(rsp(resp), &result)
+	assert.Equal(t, false, result["rippling"], "no reach row → rippling:false")
+	assert.NotEmpty(t, result["reason"], "a reason is given for why it isn't rippling")
+}


### PR DESCRIPTION
## Summary

The moderation reach map shows where a post's reach **should** be (the projected reach for how long it's been live). This adds the post's **actual** rippling progress so mods can spot when the engine is behind.

- Reinstates `GET /message/:id/reach` (mod-of-group / Admin / Support only), returning the post's **actual** `rippling_reach` tick / total / status / arrival / next_expansion_at (no polygon - the map draws the expected reach). Returns `rippling:false` + a `reason` (`disabled` / `notbrowsable` / `pending`) when there's no reach row.
- The modal fetches it and, **only when the engine is behind** the expected tick, marks a **"now"** (actual) point on the scrubber above the **"up to"** (expected) point. When caught up - or dark / not rippling - it shows just **"up to"**, so a visible "now" means the post hasn't rippled as far as it should.

## Notes

- The `GET /message/:id/reach` endpoint was originally added and then removed during the reach-modal work (the modal computes the *expected* reach client-side via the routing server); it's reinstated here for the *actual* comparison.
- Branch is based on the b-badge CI fix (`983e362b1`) already on master.

## Test Plan

- **Go** (full suite green locally, 3230 passed): `TestMessageReachAsMod` (mod sees tick/total), `TestMessageReachForbiddenForNonMod` (403), `TestMessageReachNoReachRow` (rippling:false + reason).
- **Modal spec** (7 passed): "now" passed only when behind; hidden when up to date or not rippling; seeded explorer; no-location message.
- `ModMessage` spec green (80).