### PR TITLE
feat(views): genuine page-view instrumentation (messages_likes.pageview)

### DIFF
--- a/iznik-batch/database/migrations/2026_06_22_000001_add_pageview_to_messages_likes.php
+++ b/iznik-batch/database/migrations/2026_06_22_000001_add_pageview_to_messages_likes.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * Adds messages_likes.pageview to distinguish a genuine page-open from a
+     * list-scroll impression:
+     *   - pageview = 1  : genuine page-open  (Go handleView writes/upgrades to 1)
+     *   - pageview = 0  : list-scroll impression (Go MarkSeen writes 0 on a fresh insert)
+     *   - pageview = NULL: legacy / unknown (all pre-migration rows)
+     *
+     * The 'View' type still marks "seen" for list de-duplication; pageview isolates
+     * real eyeballs for the rippling extent governor and the reach experiment.
+     *
+     * Nullable ON PURPOSE: pre-existing rows never distinguished views from
+     * impressions, so they are genuinely unknown (NULL) - not impressions (0).
+     */
+    public function up(): void
+    {
+        if (!Schema::hasColumn('messages_likes', 'pageview')) {
+            Schema::table('messages_likes', function (Blueprint $table) {
+                $table->boolean('pageview')->nullable()->default(null)->after('count');
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if (Schema::hasColumn('messages_likes', 'pageview')) {
+            Schema::table('messages_likes', function (Blueprint $table) {
+                $table->dropColumn('pageview');
+            });
+        }
+    }
+};

--- a/iznik-batch/database/migrations/2026_06_22_000001_add_pageview_to_messages_likes_migration.sql
+++ b/iznik-batch/database/migrations/2026_06_22_000001_add_pageview_to_messages_likes_migration.sql
@@ -1,0 +1,20 @@
+-- Production idempotent SQL: add messages_likes.pageview (genuine page-view instrumentation).
+--   pageview = 1  -> genuine page-open       (Go handleView writes/upgrades to 1)
+--   pageview = 0  -> list-scroll impression  (Go MarkSeen writes 0 on a fresh insert)
+--   pageview = NULL -> legacy / unknown      (all pre-migration rows)
+-- The 'View' type still marks "seen" for list de-duplication; pageview isolates real
+-- eyeballs for the rippling extent governor + reach experiment.
+-- Nullable ON PURPOSE: pre-existing rows are genuinely unknown, not impressions, so they
+-- must read NULL (not 0). Nullable column with NULL default -> INSTANT add in MySQL 8.
+SET @col_exists := (
+    SELECT COUNT(*) FROM information_schema.columns
+    WHERE table_schema = DATABASE()
+      AND table_name = 'messages_likes'
+      AND column_name = 'pageview'
+);
+SET @ddl := IF(@col_exists = 0,
+    'ALTER TABLE messages_likes ADD COLUMN pageview TINYINT(1) NULL DEFAULT NULL AFTER count',
+    'SELECT 1');
+PREPARE stmt FROM @ddl;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;

--- a/iznik-batch/database/migrations/2026_06_23_000002_add_source_to_messages_likes.php
+++ b/iznik-batch/database/migrations/2026_06_23_000002_add_source_to_messages_likes.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * messages_likes.source (rippling reach experiment - Blocker 2). Tags WHERE a genuine
+ * page-open (pageview=1) arrived from, so notification-click opens can be distinguished
+ * from organic browse within the experiment outcome window. Notification links append
+ * ?src=ripple_notify; handleView reads it and stores it here.
+ *
+ * Nullable: pre-existing / untagged opens are genuinely unknown (NULL), not a known source.
+ * Complements messages_likes.pageview (1=open, 0=impression, NULL=legacy).
+ */
+return new class extends Migration {
+    public function up(): void
+    {
+        if (!Schema::hasColumn('messages_likes', 'source')) {
+            Schema::table('messages_likes', function (Blueprint $t) {
+                $t->string('source', 32)->nullable()->default(null)->after('pageview');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasColumn('messages_likes', 'source')) {
+            Schema::table('messages_likes', function (Blueprint $t) {
+                $t->dropColumn('source');
+            });
+        }
+    }
+};

--- a/iznik-batch/database/migrations/2026_06_23_000002_add_source_to_messages_likes_migration.sql
+++ b/iznik-batch/database/migrations/2026_06_23_000002_add_source_to_messages_likes_migration.sql
@@ -1,0 +1,10 @@
+-- Production idempotent SQL: messages_likes.source (rippling reach experiment Blocker 2).
+-- Tags the arrival path of a genuine page-open (pageview=1) so notification-click opens
+-- (source='ripple_notify', set by handleView from ?src=ripple_notify) are distinguishable
+-- from organic browse (NULL). Nullable trailing/positioned column -> INSTANT add in MySQL 8.
+SET @col_exists := (SELECT COUNT(*) FROM information_schema.columns
+    WHERE table_schema = DATABASE() AND table_name = 'messages_likes' AND column_name = 'source');
+SET @ddl := IF(@col_exists = 0,
+    'ALTER TABLE messages_likes ADD COLUMN source VARCHAR(32) NULL DEFAULT NULL AFTER pageview',
+    'SELECT 1');
+PREPARE stmt FROM @ddl; EXECUTE stmt; DEALLOCATE PREPARE stmt;

--- a/iznik-server-go/message/markseen.go
+++ b/iznik-server-go/message/markseen.go
@@ -41,10 +41,13 @@ func MarkSeen(c *fiber.Ctx) error {
 
 	db := database.DBConn
 
-	// Insert a View record for each message. ON DUPLICATE KEY UPDATE
-	// increments the count and updates the timestamp.
+	// Insert a 'View' record (marks the message "seen" for list de-duplication).
+	// pageview=0 marks this as a list-scroll impression, distinct from a genuine
+	// page-open (handleView writes 1). It is set only when this INSERT *creates* the
+	// row; the ON DUPLICATE KEY UPDATE deliberately does NOT touch pageview, so an
+	// existing genuine view (1) or legacy/unknown row (NULL) is never downgraded.
 	for _, msgID := range req.IDs {
-		db.Exec("INSERT INTO messages_likes (msgid, userid, type) VALUES (?, ?, ?) "+
+		db.Exec("INSERT INTO messages_likes (msgid, userid, type, pageview) VALUES (?, ?, ?, 0) "+
 			"ON DUPLICATE KEY UPDATE timestamp = NOW(), count = count + 1",
 			msgID, myid, utils.MESSAGE_LIKES_VIEW)
 	}

--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -4272,13 +4272,24 @@ func handleRemoveBy(c *fiber.Ctx, myid uint64, req PostMessageRequest) error {
 func handleView(c *fiber.Ctx, myid uint64, req PostMessageRequest) error {
 	db := database.DBConn
 
-	// Check for a recent view within 30 minutes to avoid redundant writes.
+	// Check for a recent view within 30 minutes to avoid double-counting.
 	var recentCount int64
 	db.Raw("SELECT COUNT(*) FROM messages_likes WHERE msgid = ? AND userid = ? AND type = 'View' AND timestamp >= DATE_SUB(NOW(), INTERVAL 30 MINUTE)",
 		req.ID, myid).Scan(&recentCount)
 
+	// pageview=1 marks a genuine page-open (a real eyeball), as opposed to a list-scroll
+	// impression (MarkSeen writes 0) or a legacy row (NULL). The 'View' type still marks
+	// "seen" for list de-duplication.
 	if recentCount == 0 {
-		db.Exec("INSERT INTO messages_likes (msgid, userid, type) VALUES (?, ?, 'View') ON DUPLICATE KEY UPDATE timestamp = NOW(), count = count + 1",
+		// First view in the window: create/refresh the row as a genuine page-open.
+		db.Exec("INSERT INTO messages_likes (msgid, userid, type, pageview) VALUES (?, ?, 'View', 1) ON DUPLICATE KEY UPDATE timestamp = NOW(), count = count + 1, pageview = 1",
+			req.ID, myid)
+	} else {
+		// A recent 'View' row already exists, so we de-duplicate the count - but that row
+		// may be a list-scroll impression (pageview=0) or legacy (NULL). A real page-open
+		// must still upgrade it to a genuine view; otherwise a scroll immediately before an
+		// open would suppress the open and the eyeball would never be recorded.
+		db.Exec("UPDATE messages_likes SET pageview = 1 WHERE msgid = ? AND userid = ? AND type = 'View'",
 			req.ID, myid)
 	}
 

--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -3751,6 +3751,7 @@ type PostMessageRequest struct {
 	Deliverypossible *bool   `json:"deliverypossible"`
 	ForcePending     *bool   `json:"forcepending"`
 	Tnpostid         *string `json:"tnpostid"`
+	Source           *string `json:"source"`
 }
 
 // PostMessage dispatches POST /message actions.
@@ -4272,6 +4273,14 @@ func handleRemoveBy(c *fiber.Ctx, myid uint64, req PostMessageRequest) error {
 func handleView(c *fiber.Ctx, myid uint64, req PostMessageRequest) error {
 	db := database.DBConn
 
+	// Optional source tag (e.g. "ripple_notify" from a notification link's ?src=), recording
+	// HOW a genuine page-open arrived so notification-click opens are distinguishable from
+	// organic browse. nil when absent; COALESCE below means it never clears a known source.
+	var src interface{}
+	if req.Source != nil && *req.Source != "" {
+		src = *req.Source
+	}
+
 	// Check for a recent view within 30 minutes to avoid double-counting.
 	var recentCount int64
 	db.Raw("SELECT COUNT(*) FROM messages_likes WHERE msgid = ? AND userid = ? AND type = 'View' AND timestamp >= DATE_SUB(NOW(), INTERVAL 30 MINUTE)",
@@ -4279,18 +4288,19 @@ func handleView(c *fiber.Ctx, myid uint64, req PostMessageRequest) error {
 
 	// pageview=1 marks a genuine page-open (a real eyeball), as opposed to a list-scroll
 	// impression (MarkSeen writes 0) or a legacy row (NULL). The 'View' type still marks
-	// "seen" for list de-duplication.
+	// "seen" for list de-duplication. source records the arrival path; COALESCE keeps any
+	// existing source so a later organic view never clears the notification attribution.
 	if recentCount == 0 {
 		// First view in the window: create/refresh the row as a genuine page-open.
-		db.Exec("INSERT INTO messages_likes (msgid, userid, type, pageview) VALUES (?, ?, 'View', 1) ON DUPLICATE KEY UPDATE timestamp = NOW(), count = count + 1, pageview = 1",
-			req.ID, myid)
+		db.Exec("INSERT INTO messages_likes (msgid, userid, type, pageview, source) VALUES (?, ?, 'View', 1, ?) ON DUPLICATE KEY UPDATE timestamp = NOW(), count = count + 1, pageview = 1, source = COALESCE(?, source)",
+			req.ID, myid, src, src)
 	} else {
 		// A recent 'View' row already exists, so we de-duplicate the count - but that row
 		// may be a list-scroll impression (pageview=0) or legacy (NULL). A real page-open
 		// must still upgrade it to a genuine view; otherwise a scroll immediately before an
 		// open would suppress the open and the eyeball would never be recorded.
-		db.Exec("UPDATE messages_likes SET pageview = 1 WHERE msgid = ? AND userid = ? AND type = 'View'",
-			req.ID, myid)
+		db.Exec("UPDATE messages_likes SET pageview = 1, source = COALESCE(?, source) WHERE msgid = ? AND userid = ? AND type = 'View'",
+			src, req.ID, myid)
 	}
 
 	return c.JSON(fiber.Map{"ret": 0, "status": "Success"})

--- a/iznik-server-go/test/message_test.go
+++ b/iznik-server-go/test/message_test.go
@@ -4640,6 +4640,80 @@ func TestPostMessageViewDedup(t *testing.T) {
 	assert.Equal(t, 1, viewCount)
 }
 
+// TestMessagePageviewSemantics verifies the pageview flag distinguishes a genuine
+// page-open (handleView => 1) from a list-scroll impression (MarkSeen => 0), that a
+// scroll-then-open is upgraded to 1, and that an open-then-scroll is never downgraded.
+func TestMessagePageviewSemantics(t *testing.T) {
+	db := database.DBConn
+
+	// Returns (exists, pageview) where pageview is -1 for NULL (legacy/unknown).
+	getPageview := func(msgID, userID uint64) (bool, int) {
+		var cnt int
+		db.Raw("SELECT COUNT(*) FROM messages_likes WHERE msgid = ? AND userid = ? AND type = 'View'", msgID, userID).Scan(&cnt)
+		if cnt == 0 {
+			return false, -1
+		}
+		var pv int
+		db.Raw("SELECT COALESCE(pageview, -1) FROM messages_likes WHERE msgid = ? AND userid = ? AND type = 'View'", msgID, userID).Scan(&pv)
+		return true, pv
+	}
+	doView := func(token string, msgID uint64) {
+		body, _ := json.Marshal(map[string]interface{}{"id": msgID, "action": "View"})
+		req := httptest.NewRequest("POST", "/api/message?jwt="+token, bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := getApp().Test(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, resp.StatusCode)
+	}
+	doMarkSeen := func(token string, msgID uint64) {
+		req := httptest.NewRequest("POST", "/api/messages/markseen?jwt="+token, bytes.NewBufferString(fmt.Sprintf(`{"ids": [%d]}`, msgID)))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := getApp().Test(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, resp.StatusCode)
+	}
+	// Distinct viewer (not the owner) so MarkSeen records against a real recipient.
+	setup := func(label string) (msgID uint64, token string, viewerID uint64) {
+		prefix := uniquePrefix(label)
+		groupID := CreateTestGroup(t, prefix)
+		ownerID := CreateTestUser(t, prefix+"_owner", "User")
+		CreateTestMembership(t, ownerID, groupID, "Member")
+		viewerID = CreateTestUser(t, prefix+"_viewer", "User")
+		CreateTestMembership(t, viewerID, groupID, "Member")
+		_, token = CreateTestSession(t, viewerID)
+		msgID = CreateTestMessage(t, ownerID, groupID, prefix+" item", 55.9533, -3.1883)
+		return
+	}
+
+	// genuine page-open => pageview = 1
+	msgID, token, viewerID := setup("pv_open")
+	doView(token, msgID)
+	exists, pv := getPageview(msgID, viewerID)
+	assert.True(t, exists, "page-open should create a View row")
+	assert.Equal(t, 1, pv, "page-open => pageview=1")
+
+	// list-scroll impression => pageview = 0
+	msgID, token, viewerID = setup("pv_seen")
+	doMarkSeen(token, msgID)
+	exists, pv = getPageview(msgID, viewerID)
+	assert.True(t, exists, "impression should create a View row")
+	assert.Equal(t, 0, pv, "scroll impression => pageview=0")
+
+	// scroll THEN open => upgraded to 1
+	msgID, token, viewerID = setup("pv_seen_open")
+	doMarkSeen(token, msgID)
+	doView(token, msgID)
+	_, pv = getPageview(msgID, viewerID)
+	assert.Equal(t, 1, pv, "open after scroll => upgraded to pageview=1")
+
+	// open THEN scroll => stays 1 (never downgraded)
+	msgID, token, viewerID = setup("pv_open_seen")
+	doView(token, msgID)
+	doMarkSeen(token, msgID)
+	_, pv = getPageview(msgID, viewerID)
+	assert.Equal(t, 1, pv, "scroll after open must not downgrade pageview")
+}
+
 // --- Adversarial tests ---
 
 func TestPostMessageAddByNegativeCount(t *testing.T) {

--- a/iznik-server-go/test/message_test.go
+++ b/iznik-server-go/test/message_test.go
@@ -4714,6 +4714,57 @@ func TestMessagePageviewSemantics(t *testing.T) {
 	assert.Equal(t, 1, pv, "scroll after open must not downgrade pageview")
 }
 
+// TestMessagePageviewSource verifies a notification-tagged page-open records its source
+// (e.g. ripple_notify), and that a later untagged (organic) open never clears that
+// attribution - the key property for distinguishing notification-click from organic browse.
+func TestMessagePageviewSource(t *testing.T) {
+	db := database.DBConn
+
+	getSource := func(msgID, userID uint64) string {
+		var s string
+		db.Raw("SELECT COALESCE(source, '') FROM messages_likes WHERE msgid = ? AND userid = ? AND type = 'View'", msgID, userID).Scan(&s)
+		return s
+	}
+	doView := func(token string, msgID uint64, source string) {
+		body := map[string]interface{}{"id": msgID, "action": "View"}
+		if source != "" {
+			body["source"] = source
+		}
+		b, _ := json.Marshal(body)
+		req := httptest.NewRequest("POST", "/api/message?jwt="+token, bytes.NewBuffer(b))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := getApp().Test(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, resp.StatusCode)
+	}
+
+	// notification-tagged open records the source; a later organic open does not clear it
+	{
+		prefix := uniquePrefix("pv_src_notify")
+		userID := CreateTestUser(t, prefix+"_user", "User")
+		_, token := CreateTestSession(t, userID)
+		groupID := CreateTestGroup(t, prefix)
+		msgID := CreateTestMessage(t, userID, groupID, prefix+" item", 52.5, -1.8)
+
+		doView(token, msgID, "ripple_notify")
+		assert.Equal(t, "ripple_notify", getSource(msgID, userID), "tagged open records source")
+		doView(token, msgID, "") // organic, within dedup window -> UPDATE path
+		assert.Equal(t, "ripple_notify", getSource(msgID, userID), "organic open must not clear notification source")
+	}
+
+	// organic-only open leaves source unset (NULL)
+	{
+		prefix := uniquePrefix("pv_src_organic")
+		userID := CreateTestUser(t, prefix+"_user", "User")
+		_, token := CreateTestSession(t, userID)
+		groupID := CreateTestGroup(t, prefix)
+		msgID := CreateTestMessage(t, userID, groupID, prefix+" item", 52.5, -1.8)
+
+		doView(token, msgID, "")
+		assert.Equal(t, "", getSource(msgID, userID), "organic open leaves source NULL")
+	}
+}
+
 // --- Adversarial tests ---
 
 func TestPostMessageAddByNegativeCount(t *testing.T) {

--- a/iznik-server-go/test/session_test.go
+++ b/iznik-server-go/test/session_test.go
@@ -2938,7 +2938,7 @@ func TestGetSessionRejectsOldAppVersion(t *testing.T) {
 	var result map[string]interface{}
 	json.NewDecoder(resp.Body).Decode(&result)
 	assert.Equal(t, float64(123), result["ret"])
-	assert.Equal(t, "App is out of date", result["status"])
+	assert.Equal(t, "App is out of date - please upgrade or use the website", result["status"])
 }
 
 func TestGetSessionRecordsWebVersion(t *testing.T) {


### PR DESCRIPTION
## What

Adds `messages_likes.pageview` so a genuine page-open is distinguishable from a list-scroll impression:

| value | meaning | written by |
|---|---|---|
| `1` | genuine page-open (a real eyeball) | `handleView` (sets / upgrades) |
| `0` | list-scroll impression | `MarkSeen` (on a fresh insert) |
| `NULL` | legacy / unknown | all pre-migration rows |

## Why

The rippling extent governor and the upcoming reach experiment need a clean engagement signal. Today `handleView` (real open) and `MarkSeen` (list scroll) write the **same** `'View'` row, so views are inflated by passive impressions. This separates them.

## Design notes

- The `'View'` type still marks "seen" for list de-duplication, so the ~6 `unseen` joins + dashboard are unaffected.
- **Nullable on purpose:** pre-migration rows never distinguished views from impressions, so they are genuinely *unknown* (NULL), not impressions (0).
- `MarkSeen`'s `ON DUPLICATE KEY UPDATE` leaves `pageview` untouched, so a real view (1) or legacy (NULL) is never downgraded by a later scroll.
- `handleView`'s 30-minute dedup still **upgrades** a recent row to `pageview=1` (without re-counting) when it skips the insert, so a scroll immediately before an open still records the eyeball.
- Migration is idempotent; the column has already been applied INSTANT on prod.

## Incidental fix

Includes a separate commit fixing `TestGetSessionRejectsOldAppVersion`, which was **failing on master** (the app-version killswitch message was changed in `6b40fb21f` but the assertion never updated). Aligns the test with the live message.

## Testing

Full Go suite green locally via the status API: **3233 passed, 0 failures**, including `TestMessagePageviewSemantics` (4 transition cases), `TestPostMessageView`, `TestPostMessageViewDedup`, `TestMessagesMarkSeen`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Update: page-open source tagging

Adds `messages_likes.source` and an optional `?src` tag on the View action so a notification-click open (`source=ripple_notify`) is distinguishable from organic browse. Nullable and `COALESCE`-preserved (an organic open never clears a known notification source). Pulled into this still-open PR rather than stacked behind it. Covered by `TestMessagePageviewSource`.