### PR TITLE
feat(ripple): auto-approve rippled-in posts + reply-outcome KPIs on sysadmin

### DIFF
--- a/docs/superpowers/specs/2026-06-23-rippling-reply-kpis-and-autoapprove-design.md
+++ b/docs/superpowers/specs/2026-06-23-rippling-reply-kpis-and-autoapprove-design.md
@@ -1,0 +1,85 @@
+# Rippling: auto-approve rippled-in posts + reply-outcome KPIs
+
+Date: 2026-06-23
+Status: implemented (this PR)
+
+## Why this exists (the decision that shaped it)
+
+We considered a live reach-randomized experiment to learn "how far / how many people to
+ripple to". We dropped it. The reasoning, recorded so nobody re-derives it:
+
+- The reach **curve** (step-70) and **catch-rate** are already answered from history: the
+  `ripplesim` simulator over ~10,521 posts and the `spiralling_analysis.php` hazard analysis
+  over 303,491 messages. "Would the schedule reach the eventual replier in time" is a history
+  question, and it was answered.
+- The remaining unknown was the per-notification conversion rate for an out-of-group immediate
+  notification. **We decided to trust the membership-neutral assumption**: response depends on
+  whether the person wants the item and how far it is, not on whether they were already a member
+  of the posting group (the notification is from Freegle either way). Under that assumption,
+  historical reply-by-distance already gives the conversion, so no experiment is needed.
+- Therefore the only real cost of rippling is **moderation load**, which we remove by
+  auto-approving rippled-in posts. And instead of a randomized trial we **monitor the outcome
+  live** with reply KPIs on the sysadmin page.
+
+If the membership-neutral assumption is ever doubted, the minimal check is a small
+reach-randomized test of whether out-of-group reach lifts the first-reply rate by what the
+history model predicts; it is not built here.
+
+## What this PR ships
+
+### (a) Auto-approve rippled-in posts
+`ExpandService` inserts a rippled-in `messages_groups` row as `Approved` at ripple-in time
+(no Pending flicker), because the post was already moderated on its origin group. Configurable
+via `RIPPLE_RIPPLED_IN_PENDING_HOURS` (default 0 = immediate; >0 = a mod-veto window honoured by
+`AutoApproveService`). The receiving-group mod notice explains it was already checked on origin.
+
+### (b) Reply-outcome KPIs on the sysadmin rippling page
+Three per-day line charts in `ModSysAdminRippling.vue`, served by `rippling/metrics.go`:
+
+1. **% of Offers with a reply within 36h** - the headline "turn 0-reply posts into 1-reply
+   posts" metric. Live from `messages` + `chat_messages`; only days whose 36h window has fully
+   elapsed are plotted. Baseline at build time: ~32%.
+2. **% of replies that came via rippling** (vs existing group members). Sourced from
+   `rippling_reply_attribution` - see the capture note below.
+3. **Median reply distance (km)** - post to replier, live from locations.
+
+### (c) View tracking
+Lives on PR #848 (`messages_likes.pageview` + `.source`): distinguishes a genuine page-open from
+a list-scroll impression and tags a notification-click, so a view->reply correlation can be
+measured later. Not in this PR.
+
+## The capture problem (why KPI 2 needs a table, not a query)
+
+Attributing a reply to "rippling vs existing member" cannot be done retrospectively:
+
+- A naive "is the replier a member now?" check is wrong because the Nuxt reply flow **joins the
+  group in order to reply** (`useReplyStateMachine.handleJoinGroup`), so every rippling replier
+  looks like a member afterwards.
+- "Did they join after the post arrived?" is also wrong: someone who joined a week later for
+  unrelated reasons, then replied, would be wrongly credited to rippling.
+
+So we capture at reply time, in `CreateChatMessage` (Go), into `rippling_reply_attribution`:
+`was_home_member = 1` iff the replier is an approved member of an **origin** (non-rippled-in)
+group of the post whose membership was **established more than the join grace (300s) before the
+reply**. That excludes a join-made-to-reply (membership age ~0 -> rippling) while still counting a
+genuinely established member (membership age large -> home). Frozen at reply time so a later leave
+can't erase it. KPI 2 reads this table; it accrues from go-live (no history).
+
+## Reusable guardrail concepts (noted, not built here)
+
+From the dropped experiment harness, two ideas worth keeping for the production reach mailer if
+fan-out ever needs bounding: a **per-member fatigue cap** (max N ripple notifications per person
+per 24h) and a **per-post nearest-first reach cap**. Neither is needed for (a)/(b)/(c).
+
+## Files
+
+- `iznik-batch/app/Services/Ripple/ExpandService.php`, `AutoApproveService.php`,
+  `config/freegle.php`, `iznik-nuxt3/modtools/components/ModMessage.vue` - (a)
+- `iznik-batch/database/migrations/2026_06_23_000003_create_rippling_reply_attribution.php`
+  (+ `_migration.sql`) - (b) capture table
+- `iznik-server-go/chat/chatmessage.go` - (b) reply-time capture
+- `iznik-server-go/rippling/metrics.go`, `iznik-nuxt3/modtools/components/ModSysAdminRippling.vue`
+  - (b) KPIs + charts
+- Tests: `iznik-server-go/test/rippling_metrics_test.go`,
+  `iznik-server-go/test/chatmessage_reach_test.go`
+</content>

--- a/iznik-batch/app/Services/AutoApproveService.php
+++ b/iznik-batch/app/Services/AutoApproveService.php
@@ -100,8 +100,12 @@ class AutoApproveService
                 // Rippling-out rows already Approved on their origin group: a short mod-veto
                 // window, then auto-approve (membership gate bypassed in shouldApproveOnGroup).
                 ->orWhere(function ($q2) {
+                    // Configurable mod-veto window (default 1h via the const; 0 = immediate,
+                    // used during reach experiments to keep moderation load off receiving
+                    // groups). >= so that 0 means "eligible as soon as it arrives".
+                    $rippledInHours = (int) config('freegle.ripple.rippled_in_pending_hours', self::RIPPLED_IN_PENDING_HOURS);
                     $q2->where('messages_groups.rippled_in', 1)
-                        ->whereRaw('TIMESTAMPDIFF(HOUR, messages_groups.arrival, NOW()) > ?', [self::RIPPLED_IN_PENDING_HOURS])
+                        ->whereRaw('TIMESTAMPDIFF(HOUR, messages_groups.arrival, NOW()) >= ?', [$rippledInHours])
                         ->whereExists(function ($q3) {
                             $q3->select(DB::raw(1))
                                 ->from('messages_groups as origin_mg')

--- a/iznik-batch/app/Services/Ripple/ExpandService.php
+++ b/iznik-batch/app/Services/Ripple/ExpandService.php
@@ -305,10 +305,11 @@ class ExpandService
      * ST_GeomFromText(COALESCE(poly, polyofficial, 'POINT(0 0)'))), so we test the
      * spatial-indexed polyindex and skip the (0,0) point sentinel.
      *
-     * Inserts a fresh-Pending messages_groups row (collection forced to 'Pending', so the
-     * existing moderation pipeline — ContentCheck/AutoApprove/visibility — treats it as a
-     * new arrival), idempotently (INSERT IGNORE + NOT EXISTS on the existing (msgid,groupid)
-     * rows, so the origin group and already-rippled groups are never touched or duplicated).
+     * Inserts a messages_groups row idempotently (INSERT IGNORE + NOT EXISTS on the existing
+     * (msgid,groupid) rows, so the origin group and already-rippled groups are never touched
+     * or duplicated). The row is inserted Approved when ripple.rippled_in_pending_hours = 0
+     * (the default - no Pending flicker, since the post was already vetted on origin), else
+     * Pending so AutoApproveService approves it after the mod-veto window.
      */
     private function rippleIntoNewGroups(int $msgid, string $reachWkt, array &$stats): void
     {
@@ -325,9 +326,18 @@ class ExpandService
                 return;
             }
 
+            // rippled_in_pending_hours = 0 (default) approves the rippled-in row AT ripple-in
+            // time, so it never flickers into the Pending mod queue (the post was already
+            // vetted on its origin group; matches AutoApproveService::approveOnGroup -
+            // collection='Approved', approvedby NULL, approvedat NOW; spatial indexing follows
+            // via the message_spatial cron). >0 inserts Pending for the mod-veto window.
+            $immediateApprove = ((int) config('freegle.ripple.rippled_in_pending_hours', 0)) <= 0;
+            $collection = $immediateApprove ? 'Approved' : 'Pending';
+            $approvedAt = $immediateApprove ? 'NOW()' : 'NULL';
+
             $n = DB::affectingStatement(
-                "INSERT IGNORE INTO messages_groups (msgid, groupid, collection, arrival, autoreposts, msgtype, rippled_in)
-                 SELECT ?, g.id, 'Pending', NOW(), 0, m.type, 1
+                "INSERT IGNORE INTO messages_groups (msgid, groupid, collection, approvedat, arrival, autoreposts, msgtype, rippled_in)
+                 SELECT ?, g.id, '$collection', $approvedAt, NOW(), 0, m.type, 1
                  FROM `groups` g
                  CROSS JOIN messages m
                  WHERE m.id = ?

--- a/iznik-batch/config/freegle.php
+++ b/iznik-batch/config/freegle.php
@@ -294,6 +294,14 @@ return [
         'mode' => env('RIPPLE_MODE', 'drive'),
         // Maximum drive-time (minutes) the reach may grow to.
         'max_minutes' => (float) env('RIPPLE_MAX_MINUTES', 30),
+        // Hours a rippled-in (messages_groups.rippled_in=1) post, already Approved on its
+        // origin group, waits before it is approved onto the rippled-in group (it was already
+        // vetted on origin). Default 0 = approve AT ripple-in time, so it never even flickers
+        // into the Pending mod queue - this keeps the moderation load of rippling off the
+        // receiving groups, since the post was already moderated on its origin group. >0 leaves
+        // it Pending for AutoApproveService to approve after the window (a mod-veto window for
+        // groups that want to eyeball rippled-in posts before they appear).
+        'rippled_in_pending_hours' => (int) env('RIPPLE_RIPPLED_IN_PENDING_HOURS', 0),
         // Wall-clock hazard schedule (hours since arrival) at which the reach
         // expands one tick. One schedule tick is requested per entry, so the
         // number of ticks equals the length of this array.

--- a/iznik-batch/database/migrations/2026_06_23_000003_create_rippling_reply_attribution.php
+++ b/iznik-batch/database/migrations/2026_06_23_000003_create_rippling_reply_attribution.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * rippling_reply_attribution: one row per (post, replier) first Interested reply, recording AT
+ * REPLY TIME whether the replier was already an established home-group member.
+ *
+ * This is the only sound way to split "rippling vs existing-member" replies for the sysadmin KPI.
+ * The Nuxt reply flow JOINS the replier to the group in order to reply
+ * (useReplyStateMachine.handleJoinGroup -> authStore.joinGroup), so by the time the reply reaches
+ * the server the rippling replier already looks like a member - a retrospective membership check
+ * would mis-count every rippling reply as home-group. We therefore snapshot, in the Go reply
+ * handler (CreateChatMessage), whether the replier was an approved member of an ORIGIN
+ * (non-rippled-in) group of the post whose membership was ESTABLISHED before this reply action
+ * (added more than the join grace ago). Frozen here so a later leave can't erase the signal.
+ *
+ * Read by the sysadmin rippling dashboard (reply_source_split in rippling/metrics.go).
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (!Schema::hasTable('rippling_reply_attribution')) {
+            Schema::create('rippling_reply_attribution', function (Blueprint $t) {
+                $t->unsignedBigInteger('msgid');
+                $t->unsignedBigInteger('userid');
+                $t->timestamp('replied_at')->useCurrent();
+                $t->boolean('was_home_member')
+                    ->comment('1 = replier was an established member of an origin (non-rippled-in) group of the post at reply time; 0 = reached via rippling');
+                $t->primary(['msgid', 'userid']);
+                $t->index('replied_at', 'rra_replied_at');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('rippling_reply_attribution');
+    }
+};

--- a/iznik-batch/database/migrations/2026_06_23_000003_create_rippling_reply_attribution_migration.sql
+++ b/iznik-batch/database/migrations/2026_06_23_000003_create_rippling_reply_attribution_migration.sql
@@ -1,0 +1,13 @@
+-- Production idempotent SQL: rippling_reply_attribution (sysadmin reply-source KPI).
+-- One row per (post, replier) first Interested reply, snapshotting AT REPLY TIME whether the
+-- replier was an established home-group member. Captured by the Go reply handler because the
+-- Nuxt reply flow joins the group in order to reply, so the membership state must be frozen at
+-- the reply instant (and a join made to reply is excluded by the join-grace in the capture).
+CREATE TABLE IF NOT EXISTS rippling_reply_attribution (
+    msgid           BIGINT UNSIGNED NOT NULL,
+    userid          BIGINT UNSIGNED NOT NULL,
+    replied_at      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    was_home_member TINYINT(1) NOT NULL,
+    PRIMARY KEY (msgid, userid),
+    KEY rra_replied_at (replied_at)
+);

--- a/iznik-batch/tests/Unit/Services/AutoApproveServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/AutoApproveServiceTest.php
@@ -396,6 +396,9 @@ class AutoApproveServiceTest extends TestCase
     /** Within the short veto window a rippled-in post stays Pending (mods can still reject). */
     public function test_holds_rippled_in_post_within_veto_window(): void
     {
+        // A mod-veto window only exists when configured > 0 (default is now 0 = approve at
+        // ripple-in). Set a 1h window so a just-rippled-in post is held within it.
+        config(['freegle.ripple.rippled_in_pending_hours' => 1]);
         $user = $this->createTestUser();
         $originGroup = $this->createTestGroup();
         $nearbyGroup = $this->createTestGroup();
@@ -419,6 +422,40 @@ class AutoApproveServiceTest extends TestCase
             'msgid' => $message->id, 'groupid' => $nearbyGroup->id,
             'collection' => MessageGroup::COLLECTION_PENDING,
         ]);
+    }
+
+    /**
+     * With ripple.rippled_in_pending_hours = 0 (experiment mode) a rippled-in post already
+     * Approved on its origin auto-approves immediately, keeping moderation load off the
+     * receiving groups during a reach experiment.
+     */
+    public function test_rippled_in_pending_hours_zero_auto_approves_immediately(): void
+    {
+        config(['freegle.ripple.rippled_in_pending_hours' => 0]);
+
+        $user = $this->createTestUser();
+        $originGroup = $this->createTestGroup();
+        $nearbyGroup = $this->createTestGroup();
+        $this->createMembership($user, $originGroup, ['added' => now()->subHours(72)]);
+
+        $message = $this->createTestMessage($user, $originGroup);
+        DB::table('messages_groups')
+            ->where('msgid', $message->id)->where('groupid', $originGroup->id)
+            ->update(['collection' => MessageGroup::COLLECTION_APPROVED, 'arrival' => now()->subHours(3)]);
+
+        // Rippled in 2 minutes ago — inside the default 1h window, but 0h approves immediately.
+        DB::table('messages_groups')->insert([
+            'msgid' => $message->id, 'groupid' => $nearbyGroup->id,
+            'collection' => MessageGroup::COLLECTION_PENDING, 'arrival' => now()->subMinutes(2),
+            'msgtype' => 'Offer', 'rippled_in' => 1,
+        ]);
+
+        $this->service->process();
+
+        $mg = DB::table('messages_groups')
+            ->where('msgid', $message->id)->where('groupid', $nearbyGroup->id)->first();
+        $this->assertEquals(MessageGroup::COLLECTION_APPROVED, $mg->collection,
+            'rippled_in_pending_hours=0 auto-approves a just-rippled-in post immediately');
     }
 
     /** A rippled-in post NOT yet Approved on its origin group is never fast-tracked. */

--- a/iznik-batch/tests/Unit/Services/Ripple/ExpandServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/Ripple/ExpandServiceTest.php
@@ -443,11 +443,14 @@ class ExpandServiceTest extends TestCase
 
         $stats = $this->service()->process(false, 500);
 
-        // Rippled into B as fresh Pending, carrying the post's msgtype (else it is invisible
-        // to type-filtered browse once approved — addApprovedMessage copies messages_groups.msgtype).
+        // Rippled into B carrying the post's msgtype (else it is invisible to type-filtered
+        // browse once approved — addApprovedMessage copies messages_groups.msgtype). With
+        // rippled_in_pending_hours=0 (default) it is approved AT ripple-in time, so it never
+        // flickers into the Pending mod queue.
         $b = DB::table('messages_groups')->where('msgid', $msgid)->where('groupid', $groupB->id)->first();
         $this->assertNotNull($b, 'post rippled into group B whose area the reach covers');
-        $this->assertSame('Pending', $b->collection);
+        $this->assertSame('Approved', $b->collection);
+        $this->assertNotNull($b->approvedat, 'approved at ripple-in time carries approvedat');
         $this->assertSame(Message::TYPE_OFFER, $b->msgtype);
         $this->assertGreaterThanOrEqual(1, $stats['rippled_in']);
         // §15/§16: the ripple-in is also recorded in the event metrics.
@@ -476,6 +479,28 @@ class ExpandServiceTest extends TestCase
             1,
             (int) DB::table('messages_groups')->where('msgid', $msgid)->where('groupid', $groupB->id)->count()
         );
+    }
+
+    /**
+     * With ripple.rippled_in_pending_hours > 0 the rippled-in row is inserted Pending, so
+     * AutoApproveService approves it after the mod-veto window (rather than at ripple-in).
+     */
+    public function test_positive_window_inserts_rippled_in_as_pending(): void
+    {
+        config(['freegle.ripple.rippled_in_pending_hours' => 2]);
+        $this->fakeRouting(3);
+        $msgid = $this->seedSpatialPost(now()->subMinutes(30));
+        $groupB = $this->createTestGroup();
+        DB::statement(
+            "UPDATE `groups` SET publish = 1, polyindex = ST_GeomFromText(?, ?) WHERE id = ?",
+            ['POLYGON((-0.18 51.52,-0.12 51.52,-0.12 51.58,-0.18 51.58,-0.18 51.52))', 3857, $groupB->id]
+        );
+
+        $this->service()->process(false, 500);
+
+        $b = DB::table('messages_groups')->where('msgid', $msgid)->where('groupid', $groupB->id)->first();
+        $this->assertNotNull($b, 'post rippled into group B');
+        $this->assertSame('Pending', $b->collection, 'a positive window leaves the rippled-in row Pending for the mod-veto');
     }
 
     /**

--- a/iznik-nuxt3/modtools/components/ModMessage.vue
+++ b/iznik-nuxt3/modtools/components/ModMessage.vue
@@ -171,17 +171,25 @@
                 <strong>{{ currentGroupName || 'this group' }}</strong> only.
               </span>
               <span v-if="isRippledInToContextGroup">
-                This post has rippled out to some of your group members from a
-                neighbouring community - that's expected<span
-                  v-if="pending"
-                  data-test="ripple-out-of-area-reject-warning"
-                  >, so
+                <span v-if="pending" data-test="ripple-out-of-area-reject-warning">
+                  This post has rippled in from a neighbouring community - that's
+                  expected, so
                   <strong class="text-danger"
                     >please don't reject it just for being "out of area"</strong
                   >
                   (only reject for the usual reasons: spam, breaks the rules,
-                  wrong sort of thing)</span
-                >.
+                  wrong sort of thing).
+                </span>
+                <span v-else>
+                  This post was
+                  <strong>rippled in</strong> from a neighbouring community and
+                  automatically approved onto
+                  <strong>{{ currentGroupName || 'this group' }}</strong> to keep
+                  moderation load low - it was already checked by the moderators
+                  of the community it came from. You don't need to do anything;
+                  you can still reject it for the usual reasons (spam, breaks the
+                  rules), just not for being "out of area".
+                </span>
                 <a href="#" @click.prevent="ripplingExplanationModal?.show()">
                   Learn more
                 </a>

--- a/iznik-nuxt3/modtools/components/ModMessage.vue
+++ b/iznik-nuxt3/modtools/components/ModMessage.vue
@@ -23,7 +23,12 @@
               </b-input-group>
             </NoticeMessage>
             <NoticeMessage
-              v-if="editing && editmessage && message.groups && message.groups.length > 1"
+              v-if="
+                editing &&
+                editmessage &&
+                message.groups &&
+                message.groups.length > 1
+              "
               variant="warning"
               class="w-100 mb-2"
             >
@@ -89,7 +94,8 @@
               <span
                 v-if="message.matchedon && message.matchedon.type === 'Vector'"
                 class="highlight"
-              >{{ eSubject }}</span>
+                >{{ eSubject }}</span
+              >
               <Highlighter
                 v-else-if="message.matchedon"
                 :search-words="[String(message.matchedon.word)]"
@@ -148,15 +154,14 @@
               Possibly should be on {{ homegroup }}
               <span v-if="!homegroupontn"> but group not on TN </span>
             </div>
-            <div
-              v-if="otherGroups.length > 0"
-              class="small text-muted"
-            >
+            <div v-if="otherGroups.length > 0" class="small text-muted">
               Also on:
-              <span
-                v-for="(g, idx) in otherGroups"
-                :key="g.groupid"
-              >{{ groupStore.get(g.groupid)?.namedisplay || 'Group ' + g.groupid }}<span v-if="idx < otherGroups.length - 1">, </span></span>
+              <span v-for="(g, idx) in otherGroups" :key="g.groupid"
+                >{{
+                  groupStore.get(g.groupid)?.namedisplay ||
+                  'Group ' + g.groupid
+                }}<span v-if="idx < otherGroups.length - 1">, </span></span
+              >
             </div>
             <NoticeMessage
               v-if="onMultipleOfMyGroups || isRippledInToContextGroup"
@@ -171,9 +176,12 @@
                 <strong>{{ currentGroupName || 'this group' }}</strong> only.
               </span>
               <span v-if="isRippledInToContextGroup">
-                <span v-if="pending" data-test="ripple-out-of-area-reject-warning">
-                  This post has rippled in from a neighbouring community - that's
-                  expected, so
+                <span
+                  v-if="pending"
+                  data-test="ripple-out-of-area-reject-warning"
+                >
+                  This post has rippled in from a neighbouring community -
+                  that's expected, so
                   <strong class="text-danger"
                     >please don't reject it just for being "out of area"</strong
                   >
@@ -184,11 +192,11 @@
                   This post was
                   <strong>rippled in</strong> from a neighbouring community and
                   automatically approved onto
-                  <strong>{{ currentGroupName || 'this group' }}</strong> to keep
-                  moderation load low - it was already checked by the moderators
-                  of the community it came from. You don't need to do anything;
-                  you can still reject it for the usual reasons (spam, breaks the
-                  rules), just not for being "out of area".
+                  <strong>{{ currentGroupName || 'this group' }}</strong> to
+                  keep moderation load low - it was already checked by the
+                  moderators of the community it came from. You don't need to do
+                  anything; you can still reject it for the usual reasons (spam,
+                  breaks the rules), just not for being "out of area".
                 </span>
                 <a href="#" @click.prevent="ripplingExplanationModal?.show()">
                   Learn more
@@ -254,7 +262,9 @@
                   icon-name="reply"
                   confirm
                   @handle="backToPending"
-                  ><span class="d-none d-sm-inline">Back to Pending</span></SpinButton
+                  ><span class="d-none d-sm-inline"
+                    >Back to Pending</span
+                  ></SpinButton
                 >
               </div>
               <div class="ms-2">
@@ -356,7 +366,11 @@
               {{ message.spamreason }}
             </NoticeMessage>
             <NoticeMessage
-              v-if="pending && membership && membership.ourpostingstatus === 'MODERATED'"
+              v-if="
+                pending &&
+                membership &&
+                membership.ourpostingstatus === 'MODERATED'
+              "
               variant="info"
               class="mb-2"
             >
@@ -399,9 +413,7 @@
               v-if="
                 message.worry?.length ||
                 message.groups?.some(
-                  (g) =>
-                    g.contentcheck_reasons &&
-                    g.contentcheck_reasons.length
+                  (g) => g.contentcheck_reasons && g.contentcheck_reasons.length
                 )
               "
               :messageid="message.id"
@@ -439,9 +451,12 @@
                 class="mb-3 rounded border p-2 preline forcebreak fw-bold"
               >
                 <span
-                  v-if="message.matchedon && message.matchedon.type === 'Vector'"
+                  v-if="
+                    message.matchedon && message.matchedon.type === 'Vector'
+                  "
                   class="highlight"
-                >{{ eBody }}</span>
+                  >{{ eBody }}</span
+                >
                 <Highlighter
                   v-else-if="message.matchedon"
                   :search-words="[String(message.matchedon.word)]"
@@ -894,7 +909,10 @@ const currentGroupid = computed(() => {
     const pool = pending.length ? pending : mine
     let pick = pool[0]
     for (const g of pool) {
-      if (g.arrival && (!pick.arrival || new Date(g.arrival) > new Date(pick.arrival)))
+      if (
+        g.arrival &&
+        (!pick.arrival || new Date(g.arrival) > new Date(pick.arrival))
+      )
         pick = g
     }
     return parseInt(pick.groupid)
@@ -920,7 +938,8 @@ const originGroupid = computed(() => {
   let earliest = null
   for (const g of groups) {
     if (!g.arrival) continue
-    if (!earliest || new Date(g.arrival) < new Date(earliest.arrival)) earliest = g
+    if (!earliest || new Date(g.arrival) < new Date(earliest.arrival))
+      earliest = g
   }
   return earliest ? parseInt(earliest.groupid) : null
 })
@@ -1531,7 +1550,11 @@ function checkHistory(duplicateCheck) {
 
           const key = histMsg.id + '-' + histMsg.arrival
 
-          if (duplicateCheck && groupsInCommon && histMsg.id < message.value.id) {
+          if (
+            duplicateCheck &&
+            groupsInCommon &&
+            histMsg.id < message.value.id
+          ) {
             // Same group, and this history message was posted before the one we're
             // rendering (message ids are auto-increment, so a lower id means earlier).
             // So the message we're rendering is the second/subsequent copy and IS a

--- a/iznik-nuxt3/modtools/components/ModSysAdminRippling.vue
+++ b/iznik-nuxt3/modtools/components/ModSysAdminRippling.vue
@@ -11,7 +11,55 @@
     </div>
     <div v-else-if="error" class="text-danger">Failed to load: {{ error }}</div>
     <div v-else>
-      <h6>Totals (all time)</h6>
+      <h6>Reply outcomes (headline KPIs)</h6>
+      <p class="text-muted small mb-2">
+        The rollout's goal is to turn more 0-reply posts into 1-reply posts. (1)
+        share of Offers that get a reply within 36h; (2) of replies, the share
+        that came via rippling rather than from existing group members (captured
+        at reply time, so a join-to-reply isn't mis-counted as a member); (3)
+        median distance from post to replier.
+      </p>
+
+      <div class="mb-2">
+        <strong class="small">% of Offers with a reply within 36h</strong>
+        <GChart
+          v-if="replyRateChart"
+          type="LineChart"
+          :data="replyRateChart"
+          :options="pctChartOptions('Reply rate (%)', '#28a745')"
+          style="width: 100%; height: 300px"
+        />
+        <p v-else class="text-muted small">No data yet.</p>
+      </div>
+
+      <div class="mb-2">
+        <strong class="small">% of replies that came via rippling</strong>
+        <GChart
+          v-if="replySourceChart"
+          type="LineChart"
+          :data="replySourceChart"
+          :options="pctChartOptions('Share of replies (%)', '#007bff')"
+          style="width: 100%; height: 300px"
+        />
+        <p v-else class="text-muted small">
+          No data yet — accrues from reply-time capture
+          (<code>rippling_reply_attribution</code>).
+        </p>
+      </div>
+
+      <div class="mb-3">
+        <strong class="small">Median reply distance (km)</strong>
+        <GChart
+          v-if="replyDistanceChart"
+          type="LineChart"
+          :data="replyDistanceChart"
+          :options="kmChartOptions()"
+          style="width: 100%; height: 300px"
+        />
+        <p v-else class="text-muted small">No data yet.</p>
+      </div>
+
+      <h6 class="mt-3">Totals (all time)</h6>
       <b-table-simple hover responsive small>
         <b-thead>
           <b-tr>
@@ -122,8 +170,9 @@
       <!-- §16.1/§16.2 Volume + reach: overall weekly rollup from ripple:tune -->
       <h6 class="mt-3">Volume &amp; reach — weekly rollup (last 2 weeks)</h6>
       <p class="text-muted small mb-1">
-        Written by <code>ripple:tune</code> each week. Guard-rail band: &minus;10% to +50%
-        vs each group's own baseline (ripple-thresholds). Empty until the first tune run.
+        Written by <code>ripple:tune</code> each week. Guard-rail band:
+        &minus;10% to +50% vs each group's own baseline (ripple-thresholds).
+        Empty until the first tune run.
       </p>
       <b-table-simple hover responsive small>
         <b-thead>
@@ -152,8 +201,9 @@
       <!-- §16.3 Cross-group reach -->
       <h6 class="mt-3">Cross-group reach (last 30 days)</h6>
       <p class="text-muted small mb-1">
-        Fraction of post appearances that were rippled in by the engine to a group the poster
-        was not a member of, and how many of those were subsequently approved.
+        Fraction of post appearances that were rippled in by the engine to a
+        group the poster was not a member of, and how many of those were
+        subsequently approved.
       </p>
       <b-table-simple small>
         <b-tbody>
@@ -167,11 +217,19 @@
           </b-tr>
           <b-tr>
             <b-th>Cross-group %</b-th>
-            <b-td>{{ crossGroupSummary.cross_group_pct != null ? crossGroupSummary.cross_group_pct.toFixed(1) + '%' : '—' }}</b-td>
+            <b-td>{{
+              crossGroupSummary.cross_group_pct != null
+                ? crossGroupSummary.cross_group_pct.toFixed(1) + '%'
+                : '—'
+            }}</b-td>
           </b-tr>
           <b-tr>
             <b-th>Approval rate (rippled-in)</b-th>
-            <b-td>{{ crossGroupSummary.rippled_in > 0 ? crossGroupSummary.approval_rate.toFixed(1) + '%' : '—' }}</b-td>
+            <b-td>{{
+              crossGroupSummary.rippled_in > 0
+                ? crossGroupSummary.approval_rate.toFixed(1) + '%'
+                : '—'
+            }}</b-td>
           </b-tr>
         </b-tbody>
       </b-table-simple>
@@ -179,8 +237,9 @@
       <!-- §16.4 Timing / capture from offline simulator -->
       <h6 class="mt-3">Timing &amp; capture — latest simulator week</h6>
       <p class="text-muted small mb-1">
-        From <code>rippling_algorithm_metrics</code> ('all' group). Capture rate = repliers
-        notified before they replied / total repliers. Empty until the first simulator run.
+        From <code>rippling_algorithm_metrics</code> ('all' group). Capture rate
+        = repliers notified before they replied / total repliers. Empty until
+        the first simulator run.
       </p>
       <div v-if="captureSummary.week_start">
         <b-table-simple small>
@@ -227,8 +286,9 @@
       <!-- §15 / §16.5 Held-reply friction -->
       <h6 class="mt-3">Held external replies — status breakdown</h6>
       <p class="text-muted small mb-1">
-        External (email / TrashNothing) replies held because the post had not yet rippled to
-        the replier's location. Avg hold duration shown for released rows.
+        External (email / TrashNothing) replies held because the post had not
+        yet rippled to the replier's location. Avg hold duration shown for
+        released rows.
       </p>
       <b-table-simple hover responsive small>
         <b-thead>
@@ -244,10 +304,14 @@
               <code>{{ h.status }}</code>
             </b-td>
             <b-td>{{ h.count }}</b-td>
-            <b-td>{{ h.median_hold_hours > 0 ? h.median_hold_hours.toFixed(1) : '—' }}</b-td>
+            <b-td>{{
+              h.median_hold_hours > 0 ? h.median_hold_hours.toFixed(1) : '—'
+            }}</b-td>
           </b-tr>
           <b-tr v-if="!heldReplySummary.length">
-            <b-td colspan="3" class="text-muted">No held replies recorded yet.</b-td>
+            <b-td colspan="3" class="text-muted"
+              >No held replies recorded yet.</b-td
+            >
           </b-tr>
         </b-tbody>
       </b-table-simple>
@@ -256,6 +320,7 @@
 </template>
 
 <script setup>
+import { GChart } from 'vue-google-charts'
 import api from '~/api'
 
 const runtimeConfig = useRuntimeConfig()
@@ -270,8 +335,72 @@ const proposedParams = ref([])
 // §16 rollout-health metrics
 const liveMetrics = ref([])
 const heldReplySummary = ref([])
-const crossGroupSummary = ref({ period_days: 30, rippled_in: 0, total: 0, cross_group_pct: 0, approval_rate: 0 })
-const captureSummary = ref({ week_start: '', curve: '', pairs_total: 0, pairs_in_time: 0, pairs_late: 0, capture_rate: 0, reply_p50_hours: 0, reply_p75_hours: 0 })
+const crossGroupSummary = ref({
+  period_days: 30,
+  rippled_in: 0,
+  total: 0,
+  cross_group_pct: 0,
+  approval_rate: 0,
+})
+const captureSummary = ref({
+  week_start: '',
+  curve: '',
+  pairs_total: 0,
+  pairs_in_time: 0,
+  pairs_late: 0,
+  capture_rate: 0,
+  reply_p50_hours: 0,
+  reply_p75_hours: 0,
+})
+// Headline reply KPIs (per-day series for the line charts)
+const replyRate = ref([])
+const replySource = ref([])
+const replyDistance = ref([])
+
+const replyRateChart = computed(() => {
+  if (!replyRate.value.length) return null
+  const rows = [...replyRate.value]
+    .reverse()
+    .map((r) => [new Date(r.day), r.reply_pct])
+  return [['Date', '% with reply in 36h'], ...rows]
+})
+const replySourceChart = computed(() => {
+  if (!replySource.value.length) return null
+  const rows = [...replySource.value]
+    .reverse()
+    .map((r) => [new Date(r.day), r.ripple_pct])
+  return [['Date', '% of replies via rippling'], ...rows]
+})
+const replyDistanceChart = computed(() => {
+  if (!replyDistance.value.length) return null
+  const rows = [...replyDistance.value]
+    .reverse()
+    .map((r) => [new Date(r.day), r.median_km])
+  return [['Date', 'Median km'], ...rows]
+})
+
+function pctChartOptions(vTitle, color) {
+  return {
+    curveType: 'function',
+    legend: { position: 'none' },
+    chartArea: { width: '85%', height: '70%' },
+    vAxis: { title: vTitle, viewWindow: { min: 0 }, format: '#.#' },
+    hAxis: { title: 'Date', format: 'dd MMM' },
+    series: { 0: { color } },
+    animation: { startup: true, duration: 400, easing: 'out' },
+  }
+}
+function kmChartOptions() {
+  return {
+    curveType: 'function',
+    legend: { position: 'none' },
+    chartArea: { width: '85%', height: '70%' },
+    vAxis: { title: 'Median km', viewWindow: { min: 0 }, format: '#.#' },
+    hAxis: { title: 'Date', format: 'dd MMM' },
+    series: { 0: { color: '#fd7e14' } },
+    animation: { startup: true, duration: 400, easing: 'out' },
+  }
+}
 
 async function fetchMetrics() {
   loading.value = true
@@ -290,6 +419,9 @@ async function fetchMetrics() {
     if (result?.capture_summary) {
       captureSummary.value = result.capture_summary
     }
+    replyRate.value = result?.reply_rate_36h || []
+    replySource.value = result?.reply_source_split || []
+    replyDistance.value = result?.reply_distance_median || []
   } catch (e) {
     error.value = e.message || 'Unknown error'
   } finally {

--- a/iznik-server-go/chat/chatmessage.go
+++ b/iznik-server-go/chat/chatmessage.go
@@ -431,6 +431,25 @@ func CreateChatMessage(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusInternalServerError, "Error creating chat message")
 	}
 
+	// Rippling reply attribution (sysadmin KPI): for an Interested reply, snapshot whether the
+	// replier was already an ESTABLISHED home-group member at the instant they replied. The Nuxt
+	// reply flow joins the group in order to reply (useReplyStateMachine.handleJoinGroup), so a
+	// membership existing right now isn't enough - we require an approved membership of an ORIGIN
+	// (non-rippled-in) group of the post that predates this reply by more than the join grace
+	// (300s). A join made to reply (added ~ now) is therefore excluded and counts as rippling.
+	// Frozen here so a later leave can't erase the signal. INSERT IGNORE = first reply only.
+	// Best-effort: never blocks the reply.
+	if chattype == utils.CHAT_MESSAGE_INTERESTED && payload.Refmsgid != nil {
+		var wasHome int
+		db.Raw("SELECT EXISTS(SELECT 1 FROM messages_groups mg "+
+			"INNER JOIN memberships mem ON mem.groupid = mg.groupid AND mem.userid = ? "+
+			"AND mem.collection = ? AND mem.added < NOW() - INTERVAL 300 SECOND "+
+			"WHERE mg.msgid = ? AND mg.rippled_in = 0 AND mg.deleted = 0)",
+			myid, utils.COLLECTION_APPROVED, *payload.Refmsgid).Scan(&wasHome)
+		db.Exec("INSERT IGNORE INTO rippling_reply_attribution (msgid, userid, replied_at, was_home_member) "+
+			"VALUES (?, ?, NOW(), ?)", *payload.Refmsgid, myid, wasHome)
+	}
+
 	if payload.Imageid != nil {
 		// Update the chat image to link it to this chat message.  This also stops it being purged in
 		// purge_chats.

--- a/iznik-server-go/rippling/metrics.go
+++ b/iznik-server-go/rippling/metrics.go
@@ -84,6 +84,40 @@ type CaptureSummary struct {
 	ReplyP75H   float64 `json:"reply_p75_hours" gorm:"column:reply_p75_hours"`
 }
 
+// ReplyRateRow is the headline KPI per arrival day: of Offers that arrived that day (and whose
+// full 36h window has elapsed, so the figure is complete), what fraction received at least one
+// Interested reply within 36h. This is the "are we turning 0-reply posts into 1-reply posts"
+// number. Computed live from messages + chat_messages, so it works over all history with no
+// instrumentation and no capture (reply timestamps don't change).
+type ReplyRateRow struct {
+	Day      string  `json:"day"     gorm:"column:day"`
+	Posts    int     `json:"posts"   gorm:"column:posts"`
+	Replied  int     `json:"replied" gorm:"column:replied"`
+	ReplyPct float64 `json:"reply_pct"` // computed in Go
+}
+
+// ReplySourceRow is the daily split of Interested replies by whether the replier reached the post
+// via rippling or via their own (home) group. A reply counts as "home" only if the replier was an
+// approved member of an ORIGIN (rippled_in=0) group of the post BEFORE the post arrived
+// (memberships.added < arrival). We key on the join TIMESTAMP, not current membership, because
+// replying can join the member to the group - a naive membership check would mis-label every
+// rippling reply as home-group. Everything else is rippling-attributable.
+type ReplySourceRow struct {
+	Day       string  `json:"day"     gorm:"column:day"`
+	Replies   int     `json:"replies" gorm:"column:replies"`
+	Home      int     `json:"home"    gorm:"column:home"`
+	Ripple    int     `json:"ripple"`     // computed in Go (replies - home)
+	RipplePct float64 `json:"ripple_pct"` // computed in Go
+}
+
+// ReplyDistanceRow is the daily median crow-flies distance (km) from a post's location to the
+// replier's home location, over Interested replies - how far rippling is pulling replies from.
+type ReplyDistanceRow struct {
+	Day      string  `json:"day"       gorm:"column:day"`
+	Replies  int     `json:"replies"   gorm:"column:replies"`
+	MedianKm float64 `json:"median_km" gorm:"column:median_km"`
+}
+
 // Metrics returns the rippling-out event counters plus the §15/§16 rollout-health metrics.
 // Events: reply_blocked (#2), held/released/taken_gone (#3), secondary_reject (#6),
 // immediate_mailed (#0), rippled_in (#6). Support/Admin only.
@@ -189,14 +223,89 @@ func Metrics(c *fiber.Ctx) error {
 		capture.CaptureRate = float64(capture.PairsInTime) / float64(capture.PairsTotal) * 100
 	}
 
+	// ---- Reply KPIs (the rollout's headline outcome) --------------------------------
+	// (1) % of Offers with a reply within 36h, per arrival day. Only days whose full 36h
+	//     window has elapsed are counted, so each point is complete (no trailing dip).
+	//     Live from messages + chat_messages: works over all history, no instrumentation.
+	replyRates := []ReplyRateRow{}
+	db.Raw(`
+		SELECT DATE_FORMAT(m.arrival, '%Y-%m-%d') AS day,
+		       COUNT(DISTINCT m.id) AS posts,
+		       COUNT(DISTINCT CASE WHEN fr.first_reply <= m.arrival + INTERVAL 36 HOUR THEN m.id END) AS replied
+		FROM messages m
+		JOIN messages_groups mg ON mg.msgid = m.id AND mg.collection = 'Approved' AND mg.deleted = 0
+		LEFT JOIN (
+		    SELECT refmsgid, MIN(date) AS first_reply FROM chat_messages
+		    WHERE type = 'Interested' AND date >= CURDATE() - INTERVAL 33 DAY GROUP BY refmsgid
+		) fr ON fr.refmsgid = m.id
+		WHERE m.type = 'Offer'
+		  AND m.arrival >= CURDATE() - INTERVAL 30 DAY
+		  AND m.arrival <  NOW() - INTERVAL 36 HOUR
+		GROUP BY DATE_FORMAT(m.arrival, '%Y-%m-%d')
+		ORDER BY day DESC`).Scan(&replyRates)
+	for i := range replyRates {
+		if replyRates[i].Posts > 0 {
+			replyRates[i].ReplyPct = float64(replyRates[i].Replied) / float64(replyRates[i].Posts) * 100
+		}
+	}
+
+	// (2) Rippling vs home-group replies, per day. Sourced from rippling_reply_attribution,
+	//     which records at REPLY time whether the replier was already a home-group member -
+	//     the only sound way to attribute, because replying later joins them to the group and
+	//     a retrospective membership check would mis-credit every rippling reply. Defensive:
+	//     empty until the capture (in CreateChatMessage) has accrued rows.
+	replySources := []ReplySourceRow{}
+	db.Raw(`
+		SELECT DATE_FORMAT(replied_at, '%Y-%m-%d') AS day,
+		       COUNT(*) AS replies,
+		       COALESCE(SUM(was_home_member), 0) AS home
+		FROM rippling_reply_attribution
+		WHERE replied_at >= CURDATE() - INTERVAL 30 DAY
+		GROUP BY DATE_FORMAT(replied_at, '%Y-%m-%d')
+		ORDER BY day DESC`).Scan(&replySources)
+	for i := range replySources {
+		replySources[i].Ripple = replySources[i].Replies - replySources[i].Home
+		if replySources[i].Replies > 0 {
+			replySources[i].RipplePct = float64(replySources[i].Ripple) / float64(replySources[i].Replies) * 100
+		}
+	}
+
+	// (3) Median crow-flies distance (km) from post to replier, per reply day. Distance isn't
+	//     changed by replying, so this is sound computed retrospectively from locations.
+	replyDistances := []ReplyDistanceRow{}
+	db.Raw(`
+		SELECT day, MAX(cnt) AS replies, AVG(dist_km) AS median_km
+		FROM (
+		  SELECT day, dist_km,
+		         ROW_NUMBER() OVER (PARTITION BY day ORDER BY dist_km) AS rn,
+		         COUNT(*)     OVER (PARTITION BY day) AS cnt
+		  FROM (
+		    SELECT DATE_FORMAT(cm.date, '%Y-%m-%d') AS day,
+		           ST_Distance_Sphere(POINT(ml.lng, ml.lat), POINT(ul.lng, ul.lat)) / 1000 AS dist_km
+		    FROM chat_messages cm
+		    JOIN messages m   ON m.id = cm.refmsgid AND m.type = 'Offer'
+		    JOIN locations ml ON ml.id = m.locationid
+		    JOIN users u      ON u.id = cm.userid
+		    JOIN locations ul ON ul.id = u.lastlocation
+		    WHERE cm.type = 'Interested' AND cm.date >= CURDATE() - INTERVAL 30 DAY
+		      AND ml.lat IS NOT NULL AND ul.lat IS NOT NULL
+		  ) d
+		) r
+		WHERE r.rn IN (FLOOR((r.cnt + 1) / 2), FLOOR((r.cnt + 2) / 2))
+		GROUP BY day
+		ORDER BY day DESC`).Scan(&replyDistances)
+
 	return c.JSON(fiber.Map{
-		"totals":              totals,
-		"recent":              recent,
-		"hotspots":            hotspots,
-		"proposed_params":     proposed,
-		"live_metrics":        liveMetrics,
-		"held_reply_summary":  heldReplySummary,
-		"cross_group_summary": crossGroup,
-		"capture_summary":     capture,
+		"totals":                totals,
+		"recent":                recent,
+		"hotspots":              hotspots,
+		"proposed_params":       proposed,
+		"live_metrics":          liveMetrics,
+		"held_reply_summary":    heldReplySummary,
+		"cross_group_summary":   crossGroup,
+		"capture_summary":       capture,
+		"reply_rate_36h":        replyRates,
+		"reply_source_split":    replySources,
+		"reply_distance_median": replyDistances,
 	})
 }

--- a/iznik-server-go/test/chatmessage_reach_test.go
+++ b/iznik-server-go/test/chatmessage_reach_test.go
@@ -70,3 +70,60 @@ func TestCreateChatMessage_ReachBlockedReplyRejected(t *testing.T) {
 		"'POLYGON((-0.2 51.4,0.0 51.4,0.0 51.6,-0.2 51.6,-0.2 51.4))', 3857) WHERE msgid = ?", msgID)
 	assert.Equal(t, fiber.StatusOK, post(), "in-app reply accepted once the reach covers the replier")
 }
+
+// TestCreateChatMessage_RecordsReplyAttribution verifies the rippling reply-source capture: posting
+// an Interested reply records, in rippling_reply_attribution, whether the replier was an ESTABLISHED
+// home-group member at reply time. A membership made well before the reply -> home (1). A non-member
+// (and, identically, a join-to-reply whose membership is younger than the 300s grace) -> rippling (0).
+func TestCreateChatMessage_RecordsReplyAttribution(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("replyattr")
+
+	db.Exec(`CREATE TABLE IF NOT EXISTS rippling_reply_attribution (
+		msgid BIGINT UNSIGNED NOT NULL, userid BIGINT UNSIGNED NOT NULL,
+		replied_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, was_home_member TINYINT(1) NOT NULL,
+		PRIMARY KEY (msgid, userid), KEY rra_replied_at (replied_at))`)
+
+	groupID := CreateTestGroup(t, prefix)
+	posterID := CreateTestUser(t, prefix+"_poster", "User")
+	CreateTestMembership(t, posterID, groupID, "Member")
+	msgID := CreateTestMessage(t, posterID, groupID, "OFFER: reply attribution test item", 51.5, -0.1)
+	defer db.Exec("DELETE FROM rippling_reply_attribution WHERE msgid = ?", msgID)
+
+	postReply := func(replierID uint64) int {
+		chatID := CreateTestChatRoom(t, replierID, &posterID, nil, "User2User")
+		_, token := CreateTestSession(t, replierID)
+		var payload chat.ChatMessage
+		payload.Message = "I'd like this please"
+		payload.Refmsgid = &msgID
+		s, _ := json.Marshal(payload)
+		req := httptest.NewRequest("POST", fmt.Sprintf("/api/chat/%d/message?jwt=%s", chatID, token), bytes.NewBuffer(s))
+		req.Header.Set("Content-Type", "application/json")
+		resp, _ := getApp().Test(req)
+		return resp.StatusCode
+	}
+	attribution := func(uid uint64) (int, bool) {
+		var rows []int
+		db.Raw("SELECT was_home_member FROM rippling_reply_attribution WHERE msgid = ? AND userid = ?", msgID, uid).Scan(&rows)
+		if len(rows) == 0 {
+			return 0, false
+		}
+		return rows[0], true
+	}
+
+	// Established member: approved membership added an hour ago -> home (was_home_member = 1).
+	memberID := CreateTestUser(t, prefix+"_member", "User")
+	CreateTestMembership(t, memberID, groupID, "Member")
+	db.Exec("UPDATE memberships SET added = NOW() - INTERVAL 1 HOUR, collection = 'Approved' WHERE userid = ? AND groupid = ?", memberID, groupID)
+	assert.Equal(t, fiber.StatusOK, postReply(memberID))
+	v, ok := attribution(memberID)
+	assert.True(t, ok, "attribution row recorded for the established-member reply")
+	assert.Equal(t, 1, v, "established member reply recorded as home-group (was_home_member=1)")
+
+	// Non-member: no membership of the origin group -> reached via rippling (was_home_member = 0).
+	nonMemberID := CreateTestUser(t, prefix+"_nonmember", "User")
+	assert.Equal(t, fiber.StatusOK, postReply(nonMemberID))
+	v, ok = attribution(nonMemberID)
+	assert.True(t, ok, "attribution row recorded for the non-member reply")
+	assert.Equal(t, 0, v, "non-member reply recorded as rippling (was_home_member=0)")
+}

--- a/iznik-server-go/test/rippling_metrics_test.go
+++ b/iznik-server-go/test/rippling_metrics_test.go
@@ -246,3 +246,48 @@ func TestRipplingMetricsHeldReplySummary(t *testing.T) {
 	assert.GreaterOrEqual(t, statusCounts["held"], float64(2), "at least 2 held rows counted")
 	assert.GreaterOrEqual(t, statusCounts["released"], float64(1), "at least 1 released row counted")
 }
+
+// The endpoint surfaces the three reply KPIs. reply_source_split is sourced from
+// rippling_reply_attribution (captured at reply time): a home row and a rippling row on the same
+// day must yield a 50% rippling share. reply_rate_36h and reply_distance_median are computed live
+// from messages/chat_messages and are always present arrays.
+func TestRipplingMetricsReplyKPIs(t *testing.T) {
+	prefix := uniquePrefix("ripplereply")
+	adminID := CreateTestUser(t, prefix+"_admin", "Support")
+	_, token := CreateTestSession(t, adminID)
+
+	db := database.DBConn
+	db.Exec(`CREATE TABLE IF NOT EXISTS rippling_reply_attribution (
+		msgid BIGINT UNSIGNED NOT NULL, userid BIGINT UNSIGNED NOT NULL,
+		replied_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, was_home_member TINYINT(1) NOT NULL,
+		PRIMARY KEY (msgid, userid), KEY rra_replied_at (replied_at))`)
+	// Two replies on an isolated day (5 days ago): one established member (home), one via rippling.
+	db.Exec("INSERT IGNORE INTO rippling_reply_attribution (msgid, userid, replied_at, was_home_member) VALUES " +
+		"(900000091, 900000091, NOW() - INTERVAL 5 DAY, 1), (900000091, 900000092, NOW() - INTERVAL 5 DAY, 0)")
+	defer db.Exec("DELETE FROM rippling_reply_attribution WHERE msgid = 900000091")
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET", fmt.Sprintf("/api/rippling/metrics?jwt=%s", token), nil))
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json.Unmarshal(rsp(resp), &result)
+
+	// All three reply-KPI keys are present (arrays).
+	_, hasRate := result["reply_rate_36h"].([]interface{})
+	_, hasDist := result["reply_distance_median"].([]interface{})
+	split, hasSplit := result["reply_source_split"].([]interface{})
+	assert.True(t, hasRate, "reply_rate_36h present")
+	assert.True(t, hasDist, "reply_distance_median present")
+	assert.True(t, hasSplit, "reply_source_split present")
+
+	// The seeded day's split row: 2 replies, 1 home, 1 ripple -> 50% rippling.
+	found := false
+	for _, r := range split {
+		if m, ok := r.(map[string]interface{}); ok && m["replies"] == float64(2) && m["home"] == float64(1) {
+			found = true
+			assert.Equal(t, float64(1), m["ripple"], "one rippling reply")
+			assert.Equal(t, float64(50), m["ripple_pct"], "50% of replies via rippling")
+		}
+	}
+	assert.True(t, found, "the seeded rippling/home split is surfaced")
+}


### PR DESCRIPTION
## Summary

Two changes that make rippling-out cheaper to run and observable, in place of a randomized reach experiment (we trust the membership-neutral assumption instead — see `docs/superpowers/specs/2026-06-23-rippling-reply-kpis-and-autoapprove-design.md` for why).

- **Auto-approve rippled-in posts.** A post that ripples into a neighbouring community was already moderated on its origin group, so re-queueing it for approval on every receiving group is mod load for no safety gain. `ExpandService` now inserts rippled-in copies as `Approved` at ripple-in time (no Pending flicker). Configurable via `RIPPLE_RIPPLED_IN_PENDING_HOURS` (default `0` = immediate; `>0` leaves them Pending for a mod-veto window honoured by `AutoApproveService`). The receiving-group mod notice explains the post was already checked on origin.
- **Reply-outcome KPIs** on the sysadmin rippling page (`ModSysAdminRippling.vue` ← `rippling/metrics.go`), three per-day line charts:
  1. **% of Offers with a reply within 36h** — the "turn 0-reply posts into 1-reply posts" headline. Live from `messages`+`chat_messages`; only days whose 36h window has elapsed are plotted. Current baseline ~32%.
  2. **% of replies that came via rippling** (vs existing group members).
  3. **Median reply distance (km)** — post to replier.

View tracking (`messages_likes.pageview`/`.source`) is already on master via #848 and is not part of this PR.

## Code Quality Review

- **KPI 2 needs a capture, not a query.** The Nuxt reply flow joins the group *in order to reply* (`useReplyStateMachine.handleJoinGroup`), so "is the replier a member now?" counts every rippling reply as home-group, and "joined after the post arrived" wrongly credits an unrelated week-later joiner. So `CreateChatMessage` snapshots, into a new `rippling_reply_attribution` table, whether the replier was an approved member of an **origin** (non-rippled-in) group whose membership was established more than the join grace (300s) before the reply. Join-to-reply (membership age ~0) → rippling; genuinely established member → home. Frozen at reply time so a later leave can't erase it. The capture is best-effort and never blocks a reply.
- All three KPI queries are defensive (empty/zero when source data is absent) and admin-gated by the existing route group.
- Idempotent production SQL alongside the Laravel migration.

## Future Improvements

- KPI 2 accrues only from go-live (the capture has no history). KPI 1 and 3 work retrospectively.
- Two guardrail concepts noted in the design doc but not built here (not needed for this change): a per-member fatigue cap and a per-post nearest-first reach cap for the reach mailer.

## Test Plan

- Go (full suite green, 3236): `TestCreateChatMessage_RecordsReplyAttribution` (established member → `was_home_member=1`, non-member → `0`) and `TestRipplingMetricsReplyKPIs` (endpoint surfaces all three KPIs and a 50/50 home/rippling split).
- Laravel: `migrate:fresh` applies the new migration; `AutoApproveServiceTest` + `ExpandServiceTest` green (46/46).
- Vue lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R7nho6dYwTaUkEgdu2Cj4Y