### PR TITLE
fix(sysadmin): digest-click position analysis shows the daily digest only

### DIFF
--- a/iznik-nuxt3/modtools/components/ModSysAdminDigestClicks.vue
+++ b/iznik-nuxt3/modtools/components/ModSysAdminDigestClicks.vue
@@ -1,31 +1,22 @@
 <template>
   <div class="digest-clicks">
     <p class="text-muted">
-      How far down the unified digest do people click? Each post in a digest is
+      How far down the daily digest do people click? Each post in a digest is
       tracked with its position (1 = top). This shows the
       <strong>click-through rate</strong> — the percentage of digests displaying
       a post at each position where the recipient clicked that post — so you can
       see how a post's position affects engagement.
     </p>
 
-    <!-- Date Range + digest type filter -->
+    <!-- Date range filter. We only ever analyse the DAILY digest: immediate digests
+         contain a single post, so they are always position 1 and tell us nothing about
+         how position affects clicks. -->
     <ModEmailDateFilter
       :loading="emailTrackingStore.digestPositionsLoading"
       fetch-label="Fetch"
       default-preset="30days"
       @fetch="onFilterFetch"
-    >
-      <template #extra-filters>
-        <label class="filter-label">Digest:</label>
-        <b-form-select
-          v-model="digestType"
-          :options="digestTypeOptions"
-          size="sm"
-          style="width: 150px"
-          @change="onTypeChange"
-        />
-      </template>
-    </ModEmailDateFilter>
+    />
 
     <!-- Error -->
     <NoticeMessage
@@ -84,10 +75,8 @@
       v-else-if="!emailTrackingStore.digestPositionsError"
       class="text-muted text-center py-4"
     >
-      <p>No digest click data available for the selected period.</p>
-      <p class="small">
-        Try widening the date range or selecting a different digest type.
-      </p>
+      <p>No daily-digest click data available for the selected period.</p>
+      <p class="small">Try widening the date range.</p>
     </div>
   </div>
 </template>
@@ -102,14 +91,9 @@ const emailTrackingStore = useEmailTrackingStore()
 
 const startDate = ref('')
 const endDate = ref('')
-const digestType = ref('')
-
-// The unified digest is sent in two modes; allow filtering to each.
-const digestTypeOptions = [
-  { text: 'All digests', value: '' },
-  { text: 'Immediate', value: 'UnifiedDigestImmediate' },
-  { text: 'Daily', value: 'UnifiedDigestDaily' },
-]
+// Daily digest only - immediate digests are single-post (always position 1), so position
+// analysis is meaningless for them. Fixed, not user-selectable.
+const digestType = ref('UnifiedDigestDaily')
 
 const tableFields = [
   { key: 'position', label: 'Position', sortable: true },
@@ -161,13 +145,6 @@ function onFilterFetch({ start, end }) {
   fetchData()
 }
 
-function onTypeChange() {
-  // Re-fetch with the existing date range when the digest type changes.
-  if (startDate.value && endDate.value) {
-    fetchData()
-  }
-}
-
 function getPositionChartOptions() {
   return {
     title: 'Click-through rate by position in the digest',
@@ -205,13 +182,11 @@ function getPositionChartOptions() {
 // Exposed for unit testing.
 defineExpose({
   digestType,
-  digestTypeOptions,
   tableFields,
   tableRows,
   insight,
   fetchData,
   onFilterFetch,
-  onTypeChange,
   getPositionChartOptions,
 })
 </script>

--- a/iznik-nuxt3/tests/unit/components/modtools/ModSysAdminDigestClicks.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModSysAdminDigestClicks.spec.js
@@ -91,7 +91,7 @@ describe('ModSysAdminDigestClicks', () => {
 
     it('shows the empty message when there is no data', () => {
       const wrapper = mountComponent()
-      expect(wrapper.text()).toContain('No digest click data available')
+      expect(wrapper.text()).toContain('No daily-digest click data available')
     })
 
     it('shows the chart when data is present', async () => {
@@ -114,19 +114,10 @@ describe('ModSysAdminDigestClicks', () => {
     })
   })
 
-  describe('digest type options', () => {
-    it('offers All / Immediate / Daily', () => {
+  describe('digest type', () => {
+    it('is pinned to the daily digest (immediate is always position 1)', () => {
       const wrapper = mountComponent()
-      const options = wrapper.vm.digestTypeOptions
-      expect(options).toContainEqual({ text: 'All digests', value: '' })
-      expect(options).toContainEqual({
-        text: 'Immediate',
-        value: 'UnifiedDigestImmediate',
-      })
-      expect(options).toContainEqual({
-        text: 'Daily',
-        value: 'UnifiedDigestDaily',
-      })
+      expect(wrapper.vm.digestType).toBe('UnifiedDigestDaily')
     })
   })
 
@@ -195,25 +186,10 @@ describe('ModSysAdminDigestClicks', () => {
       wrapper.vm.onFilterFetch({ start: '2026-01-01', end: '2026-01-31' })
 
       expect(mockEmailTrackingStore.setFilters).toHaveBeenCalledWith({
-        type: '',
+        type: 'UnifiedDigestDaily',
         start: '2026-01-01',
         end: '2026-01-31',
       })
-      expect(mockEmailTrackingStore.fetchDigestPositions).toHaveBeenCalled()
-    })
-
-    it('onTypeChange refetches only once dates are known', () => {
-      const wrapper = mountComponent()
-
-      // No dates yet → should not fetch.
-      wrapper.vm.onTypeChange()
-      expect(mockEmailTrackingStore.fetchDigestPositions).not.toHaveBeenCalled()
-
-      // After a fetch sets the dates → type change refetches.
-      wrapper.vm.onFilterFetch({ start: '2026-01-01', end: '2026-01-31' })
-      mockEmailTrackingStore.fetchDigestPositions.mockClear()
-      wrapper.vm.digestType = 'UnifiedDigestDaily'
-      wrapper.vm.onTypeChange()
       expect(mockEmailTrackingStore.fetchDigestPositions).toHaveBeenCalled()
     })
   })


### PR DESCRIPTION
## Summary

The sysadmin **Digest Clicks** page analyses how a post's position in the digest affects its click-through rate. Immediate digests contain a single post, so they are always position 1 and tell us nothing about position - they only inflate position 1 in the combined "All digests" view.

This pins the page to the **daily digest** (`UnifiedDigestDaily`) and removes the All/Immediate/Daily selector, so the analysis is always over the multi-post digests where position actually varies.

## Code Quality Review

- The Go handler (`DigestClickPositions`) already supports a `type` filter and correct normalisation (clicks divided by digests-that-showed-that-position); no backend change needed - the page just always requests `UnifiedDigestDaily`.
- `digestType` is now a fixed value, not user-selectable; the dropdown, its options, and `onTypeChange` are removed.
- Intro and empty-state copy updated to say "daily digest".

## Test Plan

- vitest `ModSysAdminDigestClicks.spec.js`: 12/12 green. Updated to assert the page is pinned to Daily and that `onFilterFetch` requests `UnifiedDigestDaily`; removed the dropdown-options and `onTypeChange` checks.
- Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R7nho6dYwTaUkEgdu2Cj4Y
