### PR TITLE
fix(admin): restore sent-admin archive in Previous tab + stop cross-group leak

### DIFF
--- a/iznik-server-go/admin/admin.go
+++ b/iznik-server-go/admin/admin.go
@@ -28,7 +28,6 @@ type Admin struct {
 	Editprotected bool       `json:"editprotected"`
 }
 
-
 // GetAdmin handles GET /admin/:id - get a single admin by ID.
 //
 // @Summary Get a specific admin message
@@ -81,30 +80,40 @@ func ListAdmins(c *fiber.Ctx) error {
 	groupidParam, _ := strconv.ParseUint(c.Query("groupid", "0"), 10, 64)
 	pendingParam := c.Query("pending", "")
 
-	// Build query: admins for groups the user moderates, not yet complete.
-	// System Admin/Support users can see all admins.
+	// Build query: admins for the relevant group(s). We deliberately do NOT filter on
+	// `complete` - the ModTools "Previous" tab is the archive of *sent* admins (which have
+	// `complete` set), so filtering complete IS NULL hid the entire history and left only
+	// stale, approved-but-never-sent admins on show (Discourse 9816). Matches V1
+	// Admin::listForGroup, which returned all admins for a group ordered by created DESC.
+	// The frontend partitions pending vs previous client-side by the `pending` flag.
+	selectCols := "SELECT a.id, a.createdby, a.groupid, a.subject, a.text, a.ctatext, a.ctalink, a.created, a.complete, a.heldby, a.pending, a.essential, a.template, a.editprotected " +
+		"FROM admins a WHERE "
 	var query string
 	var args []interface{}
 
-	if auth.IsAdminOrSupport(myid) {
-		query = "SELECT a.id, a.createdby, a.groupid, a.subject, a.text, a.ctatext, a.ctalink, a.created, a.complete, a.heldby, a.pending, a.essential, a.template, a.editprotected " +
-			"FROM admins a WHERE a.complete IS NULL"
+	if groupidParam > 0 && auth.IsAdminOrSupport(myid) {
+		// System Admin/Support may view the admin history for any specific group they ask for
+		// (e.g. to look up a sent admin), without needing a membership on it.
+		query = selectCols + "a.groupid = ?"
+		args = append(args, groupidParam)
 	} else {
-		// filter by active mod groups (checks settings.active flag),
-		// not just role. This prevents showing admins for groups the mod has
-		// stepped back from.
+		// Restrict to the caller's active mod groups (checks settings.active, not just role,
+		// so admins for groups the mod has stepped back from are hidden). This applies to
+		// ordinary mods always, and to Admin/Support when no specific group is requested -
+		// otherwise the unscoped sweep leaked other groups' admins into the Pending tab
+		// (Discourse 9816: "I can see Admins for groups I am not on"). Matches V1
+		// Admin::listPending, which always scoped to the caller's own active mod groups.
 		activeGroupIDs := user.GetActiveModGroupIDs(myid)
 		if len(activeGroupIDs) == 0 {
 			return c.JSON(make([]Admin, 0))
 		}
-		query = "SELECT a.id, a.createdby, a.groupid, a.subject, a.text, a.ctatext, a.ctalink, a.created, a.complete, a.heldby, a.pending, a.essential, a.template, a.editprotected " +
-			"FROM admins a WHERE a.complete IS NULL AND a.groupid IN (?)"
+		query = selectCols + "a.groupid IN (?)"
 		args = append(args, activeGroupIDs)
-	}
 
-	if groupidParam > 0 {
-		query += " AND a.groupid = ?"
-		args = append(args, groupidParam)
+		if groupidParam > 0 {
+			query += " AND a.groupid = ?"
+			args = append(args, groupidParam)
+		}
 	}
 
 	if pendingParam == "true" {
@@ -113,7 +122,7 @@ func ListAdmins(c *fiber.Ctx) error {
 		query += " AND a.pending = 0"
 	}
 
-	query += " ORDER BY a.id DESC"
+	query += " ORDER BY a.created DESC, a.id DESC"
 
 	var admins []Admin
 	db.Raw(query, args...).Scan(&admins)

--- a/iznik-server-go/test/admin_test.go
+++ b/iznik-server-go/test/admin_test.go
@@ -82,7 +82,7 @@ func TestListAdminsNotMod(t *testing.T) {
 
 func TestListAdminsSystemAdmin(t *testing.T) {
 	prefix := uniquePrefix("adm_sysadm")
-	// System Admin user with no group membership should see all admins.
+	// System Admin user with no group membership.
 	adminUserID := CreateTestUser(t, prefix+"_admin", "Admin")
 	_, adminToken := CreateTestSession(t, adminUserID)
 
@@ -92,6 +92,9 @@ func TestListAdminsSystemAdmin(t *testing.T) {
 	CreateTestMembership(t, modID, groupID, "Moderator")
 	adminID := createTestAdmin(t, modID, groupID, "SysAdmin Test "+prefix)
 
+	// Discourse 9816: with NO group requested, even a system admin must NOT see other
+	// groups' admins - the unscoped sweep leaked admins for groups the user isn't on into
+	// the Pending tab. The default listing is scoped to the caller's own active mod groups.
 	req := httptest.NewRequest("GET", fmt.Sprintf("/api/modtools/admin?jwt=%s", adminToken), nil)
 	resp, _ := getApp().Test(req)
 	assert.Equal(t, 200, resp.StatusCode)
@@ -99,7 +102,22 @@ func TestListAdminsSystemAdmin(t *testing.T) {
 	var result []map[string]interface{}
 	json2.Unmarshal(rsp(resp), &result)
 
-	// System admin should see admins from any group.
+	leaked := false
+	for _, a := range result {
+		if a["id"] == float64(adminID) {
+			leaked = true
+			break
+		}
+	}
+	assert.False(t, leaked, "System admin should NOT see other groups' admins when no group is requested")
+
+	// But when a specific group IS requested, a system admin may view that group's admin
+	// history even without a membership (e.g. to look up a sent admin for a mod).
+	req = httptest.NewRequest("GET", fmt.Sprintf("/api/modtools/admin?groupid=%d&jwt=%s", groupID, adminToken), nil)
+	resp, _ = getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	json2.Unmarshal(rsp(resp), &result)
 	found := false
 	for _, a := range result {
 		if a["id"] == float64(adminID) {
@@ -107,11 +125,47 @@ func TestListAdminsSystemAdmin(t *testing.T) {
 			break
 		}
 	}
-	assert.True(t, found, "System admin should see admins from any group")
+	assert.True(t, found, "System admin should see a specific group's admins when that group is requested")
 
 	// Cleanup
 	db := database.DBConn
 	db.Exec("DELETE FROM admins WHERE id = ?", adminID)
+}
+
+func TestListAdminsIncludesCompleted(t *testing.T) {
+	// Discourse 9816: the ModTools "Previous" tab is the archive of *sent* admins, which have
+	// `complete` set. The V2 listing previously filtered `complete IS NULL`, hiding every sent
+	// admin and leaving only stale, approved-but-never-sent ones (Derek saw a 3-year-old
+	// Christmas admin as the newest). The listing must include completed admins.
+	prefix := uniquePrefix("adm_done")
+	modID := CreateTestUser(t, prefix+"_mod", "User")
+	groupID := CreateTestGroup(t, prefix)
+	CreateTestMembership(t, modID, groupID, "Moderator")
+	_, modToken := CreateTestSession(t, modID)
+
+	// A sent (completed) admin.
+	completedID := createTestAdmin(t, modID, groupID, "Sent Admin "+prefix)
+	db := database.DBConn
+	db.Exec("UPDATE admins SET complete = NOW(), pending = 0 WHERE id = ?", completedID)
+
+	req := httptest.NewRequest("GET", fmt.Sprintf("/api/modtools/admin?groupid=%d&jwt=%s", groupID, modToken), nil)
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result []map[string]interface{}
+	json2.Unmarshal(rsp(resp), &result)
+
+	found := false
+	for _, a := range result {
+		if a["id"] == float64(completedID) {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "Completed (sent) admins must appear in the listing for the Previous tab")
+
+	// Cleanup
+	db.Exec("DELETE FROM admins WHERE id = ?", completedID)
 }
 
 func TestCreateAdmin(t *testing.T) {


### PR DESCRIPTION
## Problem (Discourse 9816)

Mods reported the ModTools **Admin → Previous** tab was broken:
- Derek: *"The newest one I can see on most of my groups is a christmas message from 3 years ago."*
- Derek / Angelika: *"I can see Admins for groups I am not on"* / *"a pending message for a group that's not mine."*

## Root cause

The V2 Go `ListAdmins` handler:
1. Filtered `WHERE a.complete IS NULL` in **both** branches. The "Previous" tab is the archive of **sent** admins, which by definition have `complete` set — so every actually-sent admin was excluded, leaving only stale approved-but-never-sent rows (the years-old Christmas admin).
2. For Admin/Support users, applied **no group scoping at all**, so with no group selected the Pending tab swept in every group's pending admins.

V1 behaviour: `Admin::listForGroup` returned all admins for a group (newest first, no `complete` filter); `Admin::listPending` always scoped to the caller's own active mod groups.

## Fix

- Drop the `complete IS NULL` filter so sent admins appear in Previous again.
- Scope the default listing to the caller's active mod groups for everyone (matching V1). Admin/Support can still view a specific group's full history when they request a `groupid`.

## Tests (Go suite green: 3237 passed, 0 failed locally)

- `TestListAdminsIncludesCompleted` — completed/sent admins are returned.
- `TestListAdminsSystemAdmin` reworked — asserts no cross-group leak when no group is requested, and access to a specifically-requested group.

## Discourse

https://discourse.ilovefreegle.org/t/admin-messages/9816/4

🤖 Generated with [Claude Code](https://claude.com/claude-code)