### PR TITLE
fix(jobs): stop serving stale jobs (KNN rebuild on swap + 05:00 sync + freshness weighting)

### DIFF
--- a/iznik-batch/app/Models/Job.php
+++ b/iznik-batch/app/Models/Job.php
@@ -59,9 +59,14 @@ class Job extends Model
             ->whereIn('id', $ids)
             ->whereRaw('cpc >= ?', [self::MINIMUM_CPC])
             ->where('visible', 1)
-            // Rank by expected value (cpc * clickability), matching the public
-            // jobs page (Go job.GetJobs) so digest and web agree on ordering.
-            ->orderByRaw('cpc * clickability DESC, id ASC')
+            // Rank by expected value (cpc * clickability) discounted by a mild
+            // freshness factor, matching the public jobs page (Go job.GetJobs)
+            // so digest and web agree on ordering. Older WhatJobs postings are
+            // likelier already filled/closed (so a click redirects to a
+            // different job and doesn't convert), so decay the score with the
+            // posting age: factor 1.0 when fresh, floored at 0.5 by ~7 days.
+            // posted_at NULL -> treated as fresh (no penalty).
+            ->orderByRaw('cpc * clickability * GREATEST(0.5, 1 - COALESCE(DATEDIFF(NOW(), posted_at), 0) * 0.07) DESC, id ASC')
             ->get();
 
         // Randomize the candidate pool so consecutive immediate-mode digests

--- a/iznik-batch/app/Services/SpatialAdminService.php
+++ b/iznik-batch/app/Services/SpatialAdminService.php
@@ -43,4 +43,31 @@ class SpatialAdminService
             ]);
         }
     }
+
+    /**
+     * Ask the spatial server to fully rebuild a dataset's index from MySQL.
+     *
+     * Used after the WhatJobs sync RENAME-swaps the `jobs` table: the swap
+     * drops rows for vanished/closed postings, but the spatial index's 5-min
+     * delta only adds/updates (it never removes), so without an explicit
+     * rebuild the KNN index keeps returning ids that are gone or now map to a
+     * different posting until the nightly 03:00 rebuild — which is what made
+     * job clicks stop converting to billable after the KNN cutover (#764).
+     *
+     * The server rebuild is asynchronous; this just kicks it off. Failures are
+     * logged as warnings and do not throw — the periodic delta and the nightly
+     * rebuild remain as backstops.
+     */
+    public function rebuildDataset(string $dataset): void
+    {
+        try {
+            $response = Http::timeout(5)->post("{$this->adminUrl}/v1/{$dataset}/rebuild");
+
+            if (!$response->successful()) {
+                Log::warning("SpatialAdmin: rebuild {$dataset} HTTP {$response->status()}");
+            }
+        } catch (\Throwable $e) {
+            Log::warning("SpatialAdmin: rebuild {$dataset} failed: {$e->getMessage()}");
+        }
+    }
 }

--- a/iznik-batch/app/Services/WhatJobsService.php
+++ b/iznik-batch/app/Services/WhatJobsService.php
@@ -517,6 +517,16 @@ class WhatJobsService
         $this->analyseClickability();
         $this->updateClickability();
 
+        // The swap drops rows for postings that have closed/left the feed. The
+        // spatial server's "jobs" index backs both the web jobs page and the
+        // digest (since #764), and its incremental delta only adds/updates — it
+        // never removes vanished ids. Without an explicit rebuild the index
+        // keeps serving stale ids (gone, or remapped to a different posting)
+        // until the nightly 03:00 rebuild, so clicks land on the wrong/closed
+        // job and don't convert to billable. Trigger a rebuild now so the index
+        // matches the freshly-swapped table.
+        app(SpatialAdminService::class)->rebuildDataset('jobs');
+
         Log::info('WhatJobs sync complete', ['total' => $inserted, 'inserted' => $inserted]);
 
         return ['total' => $inserted, 'inserted' => $inserted, 'dry_run' => false];

--- a/iznik-batch/routes/console.php
+++ b/iznik-batch/routes/console.php
@@ -838,6 +838,20 @@ Schedule::command('integrations:sync-whatjobs')
     ->sendOutputTo(cronLog('integrations:sync-whatjobs'))
     ->runInBackground();
 
+// Early-morning sync ahead of the 07:00 UK daily digest. The every-3h UTC
+// schedule above starts at 09:00 UTC, so the morning digest would otherwise
+// ship jobs last synced ~21:00 the night before (9-10h stale -> closed
+// postings -> clicks don't convert to billable). Run at 05:00 UK so the sync
+// (and the post-swap KNN rebuild it triggers) completes before the digest.
+// Pinned to the local zone so it tracks BST/GMT with the digest; shares the
+// command mutex with the run above via withoutOverlapping.
+Schedule::command('integrations:sync-whatjobs')
+    ->timezone(config('freegle.timezone'))
+    ->dailyAt('05:00')
+    ->withoutOverlapping(240)
+    ->sendOutputTo(cronLog('integrations:sync-whatjobs'))
+    ->runInBackground();
+
 // Sync Freegle offers with LoveJunk - runs every minute.
 // V1: cron/lovejunk.php
 Schedule::command('integrations:sync-lovejunk')

--- a/iznik-batch/tests/Feature/Integrations/SyncWhatJobsCommandTest.php
+++ b/iznik-batch/tests/Feature/Integrations/SyncWhatJobsCommandTest.php
@@ -6,6 +6,7 @@ use App\Services\WhatJobsService;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
 use Tests\TestCase;
 
 class SyncWhatJobsCommandTest extends TestCase
@@ -400,6 +401,10 @@ class SyncWhatJobsCommandTest extends TestCase
     {
         DB::statement('DROP TABLE IF EXISTS jobs_new');
 
+        // A real swap must trigger a KNN "jobs" index rebuild so the spatial
+        // index doesn't keep serving stale ids after the table swap.
+        Http::fake(['*/v1/jobs/rebuild' => Http::response(['status' => 'rebuilding'], 200)]);
+
         $geom = WhatJobsService::boxPoly(53.8, -1.55, 53.9, -1.45);
         $xml  = $this->makeFeedXml([
             ['job_reference' => 'sync-e2e-1', 'city' => 'Leeds', 'state' => 'West Yorkshire', 'country' => 'UK'],
@@ -432,6 +437,9 @@ class SyncWhatJobsCommandTest extends TestCase
         $this->assertEquals(1, $result['total']);
         $this->assertEquals(1, $result['inserted']);
         $this->assertEquals(1, DB::table('jobs_new')->where('job_reference', 'sync-e2e-1')->count());
+
+        Http::assertSent(fn ($request) => str_ends_with($request->url(), '/v1/jobs/rebuild')
+            && $request->method() === 'POST');
 
         DB::statement('DROP TABLE IF EXISTS jobs_new');
     }

--- a/iznik-batch/tests/Unit/Models/JobModelTest.php
+++ b/iznik-batch/tests/Unit/Models/JobModelTest.php
@@ -243,6 +243,32 @@ class JobModelTest extends TestCase
         $this->assertEquals('Low CPC', $result[2]->title);
     }
 
+    public function test_near_location_prefers_fresher_postings_at_equal_value(): void
+    {
+        $this->clearJobsTable();
+
+        // Equal cpc * clickability, so the only differentiator is posting age:
+        // older WhatJobs postings are likelier already filled/closed, so the
+        // fresher one should rank first.
+        $this->seedJob([
+            'title' => 'Stale',
+            'cpc' => 0.20,
+            'clickability' => 1,
+            'posted_at' => date('Y-m-d H:i:s', strtotime('-7 days')),
+        ]);
+        $this->seedJob([
+            'title' => 'Fresh',
+            'cpc' => 0.20,
+            'clickability' => 1,
+            'posted_at' => date('Y-m-d H:i:s'),
+        ]);
+
+        $result = Job::nearLocation(51.5074, -0.1278);
+
+        $this->assertEquals('Fresh', $result[0]->title);
+        $this->assertEquals('Stale', $result[1]->title);
+    }
+
     public function test_near_location_title_cases_lowercase_location(): void
     {
         // The jobs feed stores location names lowercase ("stoke-on-trent");

--- a/iznik-batch/tests/Unit/Services/SpatialAdminServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/SpatialAdminServiceTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Services\SpatialAdminService;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class SpatialAdminServiceTest extends TestCase
+{
+    public function test_rebuild_dataset_posts_to_rebuild_endpoint(): void
+    {
+        Http::fake(['*/v1/jobs/rebuild' => Http::response(['status' => 'rebuilding'], 200)]);
+
+        (new SpatialAdminService())->rebuildDataset('jobs');
+
+        Http::assertSent(fn ($request) => str_ends_with($request->url(), '/v1/jobs/rebuild')
+            && $request->method() === 'POST');
+    }
+
+    public function test_rebuild_dataset_swallows_http_error(): void
+    {
+        Http::fake(['*/v1/jobs/rebuild' => Http::response('boom', 500)]);
+
+        // A failed rebuild must not throw — the delta and nightly rebuild are
+        // backstops, and the sync must still complete.
+        (new SpatialAdminService())->rebuildDataset('jobs');
+
+        Http::assertSent(fn ($request) => str_ends_with($request->url(), '/v1/jobs/rebuild'));
+    }
+
+    public function test_rebuild_dataset_swallows_connection_exception(): void
+    {
+        Http::fake(function () {
+            throw new \Illuminate\Http\Client\ConnectionException('no route to host');
+        });
+
+        // Must not propagate the exception.
+        (new SpatialAdminService())->rebuildDataset('jobs');
+
+        $this->assertTrue(true);
+    }
+}

--- a/iznik-server-go/job/job.go
+++ b/iznik-server-go/job/job.go
@@ -127,7 +127,13 @@ func JobsForIDs(ids []int64, distByID map[int64]float64, lat, lng float64, categ
 			"jobs.category, jobs.cpc, jobs.clickability, ai_images.externaluid "+
 			"FROM `jobs` LEFT JOIN ai_images ON ai_images.name = jobs.canonical_title "+
 			"WHERE jobs.id IN (%s) AND %s AND %s "+
-			"ORDER BY jobs.cpc * jobs.clickability DESC, jobs.id ASC LIMIT %d",
+			// Rank by expected value (cpc * clickability) discounted by a mild
+			// freshness factor: older WhatJobs postings are likelier already
+			// filled/closed, so a click redirects to a different job and doesn't
+			// convert. Decay the score with posting age (floored at 0.5 by ~7
+			// days); posted_at NULL -> treated as fresh. Kept identical to the
+			// digest ordering in iznik-batch Job::nearLocation.
+			"ORDER BY jobs.cpc * jobs.clickability * GREATEST(0.5, 1 - COALESCE(DATEDIFF(NOW(), jobs.posted_at), 0) * 0.07) DESC, jobs.id ASC LIMIT %d",
 		placeholders, categoryClause, areaClause, JOBS_LIMIT,
 	), categoryArgs...).Scan(&rows)
 

--- a/plans/2026-06-23-jobs-stale-knn-billable-drop.md
+++ b/plans/2026-06-23-jobs-stale-knn-billable-drop.md
@@ -1,0 +1,52 @@
+# Fix: billable job-click drop from 2026-06-16 (stale KNN jobs index)
+
+## Diagnosis
+
+Billable job clicks (WhatJobs partner dashboard) stepped down ~37% on 2026-06-16,
+while our own click log (`logs_jobs`) barely moved (-18%, no step) and total email
+clicks were steady-to-rising. So clicks kept happening but stopped *converting* to
+billable — i.e. we served stale/wrong jobs (matches user reports of clicking a job
+and being redirected to a different one = a closed posting).
+
+Root cause: PR #764 (deployed to master 2026-06-16 08:26) moved job selection (web
+and digest) from a direct MySQL query on the `jobs` table to the **spatial KNN
+`jobs` index** (a separate snapshot). The WhatJobs sync replaces `jobs` by RENAME
+swap (`jobs_new` -> `jobs`), but nothing rebuilds the KNN index on swap. The index
+only fully rebuilds nightly at 03:00 UTC; the 5-min delta adds/updates rows
+(`seenat > since`) but never removes IDs that vanished in the swap. So between syncs
+the KNN index returns IDs that are gone or now map to different postings.
+
+Compounding: the morning daily digest fires 07:00 UK, but the first WhatJobs sync of
+the day is 09:00 UTC (`cron('0 */3 * * *')->between('08:00','22:00')`), so the digest
+ships jobs last synced ~21:00 the previous night (9-10h stale).
+
+Ruled out: unified digest / email volume (email + job-email clicks steady/up); CPC
+floor change (zero jobs sit in the excluded 0.02-0.10 band).
+
+## Fixes (all approved)
+
+### A. Rebuild the KNN `jobs` index on swap  (the regression fix)
+- `SpatialAdminService::rebuildDataset(string $dataset)` -> POST `/v1/{dataset}/rebuild`
+  (async on the server; non-throwing + logged, mirroring `removeItems`).
+- Call `rebuildDataset('jobs')` in `WhatJobsService::sync()` immediately after the
+  swap + clickability update succeed (real runs only, not when swap is skipped).
+
+### B. Sync (and therefore rebuild) before the 07:00 UK digest
+- Add a dedicated `integrations:sync-whatjobs` run at **05:00 UK** (Europe/London),
+  `withoutOverlapping(240)`, sharing the command mutex with the existing every-3h
+  UTC schedule. 2h margin before the 07:00 digest; the post-swap rebuild (A) makes
+  the fresh jobs visible to the KNN-backed digest path.
+
+### C. Weight ranking by `posted_at` freshness (secondary guard)
+- Older WhatJobs postings are likelier already filled/closed. Add a mild freshness
+  multiplier to the ranking score in both ranking sites so the stale tail is
+  de-prioritised without nuking high-CPC ads:
+  `cpc * clickability * GREATEST(<floor>, 1 - days_old * <decay>)`.
+  - PHP: `Job::nearLocation` ORDER BY (`iznik-batch/app/Models/Job.php`).
+  - Go: `JobsForIDs` ORDER BY (`iznik-server-go/job/job.go`).
+  - Keep web + digest ordering identical (they intentionally match today).
+
+## Validation
+- iznik-batch: PHPUnit (WhatJobsService swap triggers rebuild; ordering).
+- iznik-server-go: Go job tests (ordering with freshness factor).
+- Full relevant suites green before PR. Update the orb if test changes need it.


### PR DESCRIPTION
## Why

Billable job clicks (WhatJobs partner dashboard) dropped ~37% starting **2026-06-16**, with a clean step on that date. Our own click log (`logs_jobs`) barely moved (-18%, no step) and total email clicks were steady-to-rising — so people kept clicking, but the clicks stopped **converting to billable**. That matches user reports of clicking a job and being **redirected to a different one** (what WhatJobs does when the original posting has closed).

**Root cause:** PR #764 (deployed to master 2026-06-16 08:26) moved job selection — for both the website jobs page and the digest emails — from a direct MySQL query to the **spatial KNN `jobs` index** (a separate snapshot). The WhatJobs sync replaces the `jobs` table by a RENAME swap (`jobs_new` → `jobs`), but **nothing rebuilds the KNN index on swap**. The index only fully rebuilds nightly at 03:00 UTC; the 5-minute delta adds/updates rows but **never removes** ids that vanished in the swap. So between syncs the index returned ids that were gone or now mapped to a different posting → users were shown / clicked through to the wrong or closed job → no billable conversion.

Compounding it: the daily digest fires **07:00 UK**, but the first WhatJobs sync of the day was **09:00 UTC**, so the morning digest shipped job ads last synced ~21:00 the previous night (9–10h stale).

**Ruled out** (with live-prod data): the unified digest / email volume (email + job-email clicks steady-to-rising through the period); the CPC-floor change in #764 (zero visible jobs sit in the excluded 0.02–0.10 band).

## What

- **A — rebuild KNN `jobs` index on swap (the regression fix).** `WhatJobsService::sync()` calls the new `SpatialAdminService::rebuildDataset('jobs')` (`POST /v1/{dataset}/rebuild`) right after the table swap, so the index matches the freshly-swapped table. Non-throwing; the periodic delta and nightly rebuild stay as backstops.
- **B — sync before the digest.** Adds a **05:00 UK** `integrations:sync-whatjobs` run (shares the command mutex via `withoutOverlapping`) so the morning digest reads fresh jobs. 05:00 leaves ~2h margin for a slow cold-cache (Photon geocoding) run plus the post-swap rebuild before the 07:00 digest.
- **C — freshness weighting.** Older WhatJobs postings are likelier already filled/closed, so a click redirects and doesn't convert. Ranking is now `cpc * clickability * GREATEST(0.5, 1 - days_old*0.07)` in **both** `Job::nearLocation` (digest) and Go `JobsForIDs` (web), kept identical so the two agree. `posted_at` NULL → treated as fresh.

## Tests

- `iznik-batch` (Laravel): **4356 pass** — new `SpatialAdminServiceTest` (success / HTTP-error / connection-exception), a freshness-ordering test in `JobModelTest`, and a rebuild-triggered assertion in the sync e2e test.
- `iznik-server-go`: **3236 pass**.

No orb change (test files only, no runner-config change). Deploy note: `batch` and `apiv2` need their usual rebuilds.

## Plan
`plans/2026-06-23-jobs-stale-knn-billable-drop.md`