### PR TITLE
fix(moderation): stop content-check fighting mods + silent no-op rejects (9815)

### DIFF
--- a/iznik-batch/app/Services/ContentCheckService.php
+++ b/iznik-batch/app/Services/ContentCheckService.php
@@ -201,30 +201,69 @@ class ContentCheckService
     }
 
     /**
-     * Process all unprocessed pending messages in batches of 100.
+     * Only NEW approved-on-arrival posts are content-checked (bounded by arrival),
+     * so the historical backlog of already-live posts is never rescanned.
+     */
+    private const APPROVED_CHECK_WINDOW_HOURS = 24;
+
+    /**
+     * Process all unprocessed messages in batches of 100.
      *
-     * Returns stats: ['approved' => int, 'kept_pending' => int, 'blocked' => int, 'errors' => int]
+     * Covers Pending posts awaiting their first check, and NEW Approved-on-arrival
+     * posts (e.g. from unmoderated members) that bypass the Pending queue - those
+     * are checked too but never auto-demoted; problems are surfaced to mods.
+     *
+     * Returns stats: ['approved' => int, 'kept_pending' => int, 'blocked' => int,
+     *                 'checked_approved' => int, 'flagged_approved' => int, 'errors' => int]
      */
     public function processUnprocessed(bool $dryRun = false): array
     {
-        $stats = ['approved' => 0, 'kept_pending' => 0, 'blocked' => 0, 'errors' => 0];
+        $stats = [
+            'approved'         => 0,
+            'kept_pending'     => 0,
+            'blocked'          => 0,
+            'checked_approved' => 0,
+            'flagged_approved' => 0,
+            'errors'           => 0,
+        ];
 
         DB::table('messages_groups as mg')
             ->join('messages as m', 'm.id', '=', 'mg.msgid')
             ->join('users as u', 'u.id', '=', 'm.fromuser')
-            ->select('mg.msgid', 'mg.groupid', DB::raw('m.type as msgtype'), DB::raw('m.fromuser as fromuser'))
-            ->where('mg.collection', MessageGroup::COLLECTION_PENDING)
+            ->select('mg.msgid', 'mg.groupid', 'mg.collection', DB::raw('m.type as msgtype'), DB::raw('m.fromuser as fromuser'))
             ->whereNull('mg.contentcheck_checked_at')
             ->where('mg.deleted', 0)
+            // Never fight a mod: a held message has been deliberately pulled back /
+            // is under review, so leave it alone rather than re-promoting it (9816/9815).
+            ->whereNull('mg.heldby')
             ->whereNull('m.deleted')
             ->whereNotNull('m.fromuser')
             ->whereNull('u.deleted')
+            ->where(function ($q) {
+                // Pending posts awaiting their first check (existing behaviour).
+                $q->where('mg.collection', MessageGroup::COLLECTION_PENDING)
+                    // NEW approved-on-arrival posts, bounded to recent arrivals so the
+                    // historical backlog of live posts is never rescanned.
+                    ->orWhere(function ($q2) {
+                        $q2->where('mg.collection', MessageGroup::COLLECTION_APPROVED)
+                            ->where('mg.arrival', '>', now()->subHours(self::APPROVED_CHECK_WINDOW_HOURS));
+                    });
+            })
             ->orderBy('mg.msgid')
             ->orderBy('mg.groupid')
             ->chunk(100, function ($candidates) use (&$stats, $dryRun) {
                 foreach ($candidates as $row) {
                     try {
-                        $reasons     = $this->checkMessage((int) $row->msgid, (int) $row->groupid);
+                        $reasons = $this->checkMessage((int) $row->msgid, (int) $row->groupid);
+
+                        // Already-live (Approved-on-arrival) posts: content-check them but
+                        // never auto-demote a post members can already see. Clean -> just
+                        // record the check; any reasons -> store them and notify mods.
+                        if ($row->collection === MessageGroup::COLLECTION_APPROVED) {
+                            $this->recordApprovedCheck($row, $reasons, $dryRun, $stats);
+                            continue;
+                        }
+
                         $isModerated = $this->isUserModerated((int) $row->msgid, (int) $row->groupid, (int) $row->fromuser)
                                     || $this->isGroupModerated((int) $row->groupid);
                         $promote     = empty($reasons) && !$isModerated;
@@ -313,6 +352,54 @@ class ContentCheckService
             });
 
         return $stats;
+    }
+
+    /**
+     * Record the content check for an already-Approved (live) post. We never demote a
+     * post members can already see: a clean post is simply stamped as checked; a post
+     * with reasons keeps its reasons stored and notifies the group's mods so a human
+     * can review it. Bounded to new arrivals by the caller.
+     */
+    private function recordApprovedCheck(object $row, array $reasons, bool $dryRun, array &$stats): void
+    {
+        $hasReasons = !empty($reasons);
+
+        if ($dryRun) {
+            $stats[$hasReasons ? 'flagged_approved' : 'checked_approved']++;
+            return;
+        }
+
+        if ($hasReasons) {
+            DB::transaction(function () use ($row, $reasons, &$stats) {
+                DB::table('messages_groups')
+                    ->where('msgid', $row->msgid)
+                    ->where('groupid', $row->groupid)
+                    ->update([
+                        'contentcheck_checked_at' => now(),
+                        'contentcheck_reasons'    => json_encode($reasons),
+                    ]);
+
+                DB::table('background_tasks')->insert([
+                    'task_type' => BackgroundTask::TASK_PUSH_NOTIFY_GROUP_MODS,
+                    'data'      => json_encode(['group_id' => (int) $row->groupid]),
+                ]);
+
+                $stats['flagged_approved']++;
+            });
+
+            Log::info("ContentCheck: flagged already-approved message #{$row->msgid} on group #{$row->groupid}", ['reasons' => $reasons]);
+            return;
+        }
+
+        DB::table('messages_groups')
+            ->where('msgid', $row->msgid)
+            ->where('groupid', $row->groupid)
+            ->update([
+                'contentcheck_checked_at' => now(),
+                'contentcheck_reasons'    => null,
+            ]);
+
+        $stats['checked_approved']++;
     }
 
     /**

--- a/iznik-batch/tests/Feature/Message/ContentCheckTest.php
+++ b/iznik-batch/tests/Feature/Message/ContentCheckTest.php
@@ -17,10 +17,10 @@ class ContentCheckTest extends TestCase
     {
         parent::setUp();
         $this->service = new ContentCheckService();
-        // Mark any unprocessed pending messages so processUnprocessed() only
-        // sees rows inserted within this test's transaction.
+        // Mark any unprocessed messages so processUnprocessed() only sees rows
+        // inserted within this test. Covers both Pending candidates and the
+        // recently-arrived Approved candidates the service now also checks.
         DB::table('messages_groups')
-            ->where('collection', 'Pending')
             ->whereNull('contentcheck_checked_at')
             ->update(['contentcheck_checked_at' => now()]);
     }
@@ -2797,5 +2797,171 @@ class ContentCheckTest extends TestCase
         $result  = $service->checkConcernKeywords('OFFER: warning — I was asked for a bank transfer, report this scam', '', $group->id);
 
         $this->assertNull($result, 'Embedding service said innocent — should not flag scam warning');
+    }
+
+    // -------------------------------------------------------------------------
+    // Held messages must be left alone (Discourse 9816 / mod-veto), and new
+    // approved-on-arrival posts must be content-checked too.
+    // -------------------------------------------------------------------------
+
+    public function test_held_pending_message_is_not_promoted(): void
+    {
+        // A mod has pulled a post back to Pending and is holding it for review
+        // (heldby set). The content-check job must not fight the mod by promoting
+        // it straight back to Approved.
+        $group = $this->createTestGroup();
+        $user  = $this->createTestUser();
+        $this->createMembership($user, $group, ['ourPostingStatus' => 'DEFAULT']);
+        $modId = $this->createTestUser()->id;
+
+        $msgid = DB::table('messages')->insertGetId([
+            'fromuser' => $user->id,
+            'type'     => 'Offer',
+            'subject'  => 'OFFER: Solid oak table (SW1A)',
+            'textbody' => 'Beautiful table. Collection only.',
+            'message'  => 'Beautiful table. Collection only.',
+            'arrival'  => now(),
+            'date'     => now(),
+            'source'   => 'Platform',
+        ]);
+        DB::table('items')->insertOrIgnore(['name' => 'Solid oak table']);
+        $itemId = DB::table('items')->where('name', 'Solid oak table')->value('id');
+        DB::table('messages_items')->insert(['msgid' => $msgid, 'itemid' => $itemId]);
+
+        DB::table('messages_groups')->insert([
+            'msgid'      => $msgid,
+            'groupid'    => $group->id,
+            'collection' => 'Pending',
+            'arrival'    => now(),
+            'deleted'    => 0,
+            'heldby'     => $modId,
+        ]);
+
+        $stats = $this->service->processUnprocessed();
+
+        $this->assertEquals('Pending', DB::table('messages_groups')->where('msgid', $msgid)->value('collection'),
+            'A held message must not be auto-promoted');
+        $this->assertNull(DB::table('messages_groups')->where('msgid', $msgid)->value('contentcheck_checked_at'),
+            'A held message must not be processed at all');
+    }
+
+    public function test_new_approved_message_is_content_checked(): void
+    {
+        // Unmoderated members post straight to Approved, bypassing the Pending
+        // queue. Those new posts must still be content-checked (just recorded
+        // when clean — never demoted).
+        $group = $this->createTestGroup();
+        $user  = $this->createTestUser();
+        $this->createMembership($user, $group, ['ourPostingStatus' => 'DEFAULT']);
+
+        $msgid = DB::table('messages')->insertGetId([
+            'fromuser' => $user->id,
+            'type'     => 'Offer',
+            'subject'  => 'OFFER: Solid oak table (SW1A)',
+            'textbody' => 'Beautiful table. Collection only.',
+            'message'  => 'Beautiful table. Collection only.',
+            'arrival'  => now(),
+            'date'     => now(),
+            'source'   => 'Platform',
+        ]);
+        DB::table('items')->insertOrIgnore(['name' => 'Solid oak table']);
+        $itemId = DB::table('items')->where('name', 'Solid oak table')->value('id');
+        DB::table('messages_items')->insert(['msgid' => $msgid, 'itemid' => $itemId]);
+
+        DB::table('messages_groups')->insert([
+            'msgid'      => $msgid,
+            'groupid'    => $group->id,
+            'collection' => 'Approved',
+            'arrival'    => now(),
+            'deleted'    => 0,
+        ]);
+
+        $stats = $this->service->processUnprocessed();
+
+        $this->assertEquals('Approved', DB::table('messages_groups')->where('msgid', $msgid)->value('collection'),
+            'A clean approved post must stay Approved (never auto-demoted)');
+        $this->assertNotNull(DB::table('messages_groups')->where('msgid', $msgid)->value('contentcheck_checked_at'),
+            'A new approved post must be content-checked');
+    }
+
+    public function test_new_approved_message_with_reason_notifies_mods_and_stays_live(): void
+    {
+        $group = $this->createTestGroup();
+        $user  = $this->createTestUser();
+        $this->createMembership($user, $group, ['ourPostingStatus' => 'DEFAULT']);
+
+        $msgid = DB::table('messages')->insertGetId([
+            'fromuser' => $user->id,
+            'type'     => 'Offer',
+            'subject'  => 'OFFER: stuff (SW1A)',
+            'textbody' => 'Some stuff.',
+            'message'  => 'Some stuff.',
+            'arrival'  => now(),
+            'date'     => now(),
+            'source'   => 'Platform',
+        ]);
+        // Vague item name -> a content-check reason.
+        DB::table('items')->insertOrIgnore(['name' => 'stuff']);
+        $itemId = DB::table('items')->where('name', 'stuff')->value('id');
+        DB::table('messages_items')->insert(['msgid' => $msgid, 'itemid' => $itemId]);
+
+        DB::table('messages_groups')->insert([
+            'msgid'      => $msgid,
+            'groupid'    => $group->id,
+            'collection' => 'Approved',
+            'arrival'    => now(),
+            'deleted'    => 0,
+        ]);
+
+        $this->service->processUnprocessed();
+
+        $this->assertEquals('Approved', DB::table('messages_groups')->where('msgid', $msgid)->value('collection'),
+            'A flagged approved post stays live (mods are notified, not auto-removed)');
+        $this->assertNotNull(DB::table('messages_groups')->where('msgid', $msgid)->value('contentcheck_reasons'),
+            'Reasons must be stored for a flagged approved post');
+        $this->assertTrue(
+            DB::table('background_tasks')
+                ->where('task_type', \App\Models\BackgroundTask::TASK_PUSH_NOTIFY_GROUP_MODS)
+                ->whereRaw("JSON_EXTRACT(data, '$.group_id') = ?", [$group->id])
+                ->exists(),
+            'Mods must be notified about a flagged approved post'
+        );
+    }
+
+    public function test_old_approved_message_is_not_content_checked(): void
+    {
+        // Bound: only NEW approved posts are checked. An older approved post
+        // (outside the recent-arrival window) must never be rescanned, so the
+        // historical backlog is untouched.
+        $group = $this->createTestGroup();
+        $user  = $this->createTestUser();
+        $this->createMembership($user, $group, ['ourPostingStatus' => 'DEFAULT']);
+
+        $msgid = DB::table('messages')->insertGetId([
+            'fromuser' => $user->id,
+            'type'     => 'Offer',
+            'subject'  => 'OFFER: Solid oak table (SW1A)',
+            'textbody' => 'Beautiful table. Collection only.',
+            'message'  => 'Beautiful table. Collection only.',
+            'arrival'  => now()->subHours(72),
+            'date'     => now()->subHours(72),
+            'source'   => 'Platform',
+        ]);
+        DB::table('items')->insertOrIgnore(['name' => 'Solid oak table']);
+        $itemId = DB::table('items')->where('name', 'Solid oak table')->value('id');
+        DB::table('messages_items')->insert(['msgid' => $msgid, 'itemid' => $itemId]);
+
+        DB::table('messages_groups')->insert([
+            'msgid'      => $msgid,
+            'groupid'    => $group->id,
+            'collection' => 'Approved',
+            'arrival'    => now()->subHours(72),
+            'deleted'    => 0,
+        ]);
+
+        $this->service->processUnprocessed();
+
+        $this->assertNull(DB::table('messages_groups')->where('msgid', $msgid)->value('contentcheck_checked_at'),
+            'An old approved post (outside the recent-arrival window) must not be rescanned');
     }
 }

--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -2032,11 +2032,24 @@ func handleReject(c *fiber.Ctx, myid uint64, req PostMessageRequest) error {
 	}
 	ctx.Groupid = authorizedGroups[0]
 
+	// Only groups where this message is currently Pending can be rejected/deleted via
+	// this action. If it has since been (re-)approved to live, this click is a no-op
+	// (Discourse 9815): we must not move a non-pending row and - for a reject-with-
+	// explanation - must not log a phantom rejection or email the poster a "rejected"
+	// notice while the post stays live.
+	var pendingGroups []uint64
+	db.Raw("SELECT groupid FROM messages_groups WHERE msgid = ? AND groupid IN ? AND collection = ? AND deleted = 0",
+		req.ID, authorizedGroups, utils.COLLECTION_PENDING).Scan(&pendingGroups)
+
+	if subject != "" && len(pendingGroups) == 0 {
+		return c.JSON(fiber.Map{"ret": 1, "status": "Message is no longer pending and was not rejected"})
+	}
+
 	// With a subject (stdmsg), move to Rejected collection (user can edit and resubmit).
 	// Without a subject (plain delete), mark as deleted.
 	if subject != "" {
 		if result := db.Exec("UPDATE messages_groups SET collection = ?, rejectedat = NOW() WHERE msgid = ? AND groupid IN ? AND collection = ?",
-			utils.COLLECTION_REJECTED, req.ID, authorizedGroups, utils.COLLECTION_PENDING); result.Error != nil {
+			utils.COLLECTION_REJECTED, req.ID, pendingGroups, utils.COLLECTION_PENDING); result.Error != nil {
 			log.Printf("Failed to reject message %d: %v", req.ID, result.Error)
 		}
 	} else {
@@ -2072,8 +2085,9 @@ func handleReject(c *fiber.Ctx, myid uint64, req PostMessageRequest) error {
 	// Queue the rejection email only for the origin group (the batch processor creates
 	// one log+push per group). Secondary-group rejections are silent to the poster and
 	// logged for #9 observability (how often rippling pushes a post somewhere a group
-	// rejects it).
-	for _, gid := range authorizedGroups {
+	// rejects it). Iterate only the groups actually rejected here (Pending at the time)
+	// so a group where the post had already gone live gets no phantom email/log (#9815).
+	for _, gid := range pendingGroups {
 		if originGid != 0 && gid != originGid {
 			log.Printf("ripple: secondary-group reject msgid=%d groupid=%d byuser=%d (poster not notified)", req.ID, gid, myid)
 			RecordRippleEvent(db, "secondary_reject")

--- a/iznik-server-go/test/message_test.go
+++ b/iznik-server-go/test/message_test.go
@@ -2,8 +2,8 @@ package test
 
 import (
 	"bytes"
-	json2 "encoding/json"
 	"encoding/json"
+	json2 "encoding/json"
 	"fmt"
 	"net/http/httptest"
 	"net/url"
@@ -1306,6 +1306,52 @@ func TestPostMessageRejectCreatesLog(t *testing.T) {
 	assert.Equal(t, "Rejected", collection, "Reject with stdmsg should move to Rejected collection")
 
 	// Log creation is now handled by the batch processor (not synchronously in the Go API).
+}
+
+// A reject that lands on a message which is no longer Pending (e.g. it was
+// re-approved/promoted to live before the mod's click arrived) must NOT silently
+// queue a rejection email/log nor claim success - otherwise the mod and the poster
+// both get told it was rejected while the post stays live (Discourse 9815).
+func TestPostMessageRejectNonPendingDoesNotEmailOrLog(t *testing.T) {
+	prefix := uniquePrefix("msgmod_rej_nonpending")
+	db := database.DBConn
+
+	groupID := CreateTestGroup(t, prefix)
+	modID := CreateTestUser(t, prefix+"_mod", "User")
+	posterID := CreateTestUser(t, prefix+"_poster", "User")
+	CreateTestMembership(t, modID, groupID, "Moderator")
+	CreateTestMembership(t, posterID, groupID, "Member")
+	_, modToken := CreateTestSession(t, modID)
+
+	msgID := createPendingMessage(t, posterID, groupID, prefix)
+	// The message is live (Approved) by the time the reject lands.
+	db.Exec("UPDATE messages_groups SET collection = 'Approved' WHERE msgid = ? AND groupid = ?", msgID, groupID)
+
+	body := map[string]interface{}{
+		"id":      msgID,
+		"action":  "Reject",
+		"groupid": groupID,
+		"subject": "Sorry",
+		"body":    "Not suitable for this group.",
+	}
+	bodyBytes, _ := json.Marshal(body)
+	url := fmt.Sprintf("/api/message?jwt=%s", modToken)
+	req := httptest.NewRequest("POST", url, bytes.NewBuffer(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := getApp().Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	// No rejection email/log task must be queued — nothing was actually rejected.
+	var taskCount int64
+	db.Raw("SELECT COUNT(*) FROM background_tasks WHERE task_type = 'email_message_rejected' AND data LIKE ?",
+		fmt.Sprintf("%%\"msgid\": %d%%", msgID)).Scan(&taskCount)
+	assert.Equal(t, int64(0), taskCount, "Must not queue a rejection email when the message was not Pending")
+
+	// Collection must be unchanged (still live), not falsely Rejected.
+	var collection string
+	db.Raw("SELECT collection FROM messages_groups WHERE msgid = ? AND groupid = ?", msgID, groupID).Scan(&collection)
+	assert.Equal(t, "Approved", collection, "A non-pending message must not be silently rejected")
 }
 
 func TestPostMessageRejectNoSubjectDeletes(t *testing.T) {


### PR DESCRIPTION
## Problem (Discourse 9815)

A mod (iOS app) reported: she rejected a TN \"Jobs Fair\" offer on Birmingham with an explanation (the poster got the rejection email), but hours later it was **back on the live board**, and she had to keep pulling it back to Pending.

## Root cause (from prod logs + DB trace)

- The poster is an **unmoderated member on an unmoderated group**, so the post was **approved on arrival** and never went through the **Pending-only** content check (`contentcheck_checked_at` stayed NULL).
- When the mod pulled it **Back to Pending**, the every-minute `messages:contentcheck` cron picked it up (Pending + unchecked), found it clean + unmoderated, and **re-promoted it to Approved within ~1 min** (`approvedby=NULL`, no audit log) — fighting the mod.
- Her **Reject** then hit `handleReject`'s `collection='Pending'` guard, which **no-op'd** (the row was Approved again) — but it still wrote a \"Rejected\" log and **queued the rejection email**. So `rejectedat` is NULL, the poster got a rejection notice, and the post stayed live.

## Fixes

1. **`ContentCheckService` — skip held messages** (`heldby IS NOT NULL`). A mod holding a post for review must not have it auto-promoted out from under them.
2. **`handleReject` (Go) — no phantom reject.** A reject-with-explanation on a non-Pending row returns a clear \"not rejected\" status and queues **no** email/log. Notifications iterate only the groups actually rejected (Pending at the time).
3. **`ContentCheckService` — also check NEW approved-on-arrival posts**, bounded to recent arrivals so the historical backlog is never rescanned. Live posts are **never auto-demoted**: clean → just recorded; flagged → reasons stored + group mods notified for review.

## Tests

- Go: `TestPostMessageRejectNonPendingDoesNotEmailOrLog` (+ existing reject tests still pass). **3237 pass / 0 fail.**
- PHP: `test_held_pending_message_is_not_promoted`, `test_new_approved_message_is_content_checked`, `test_new_approved_message_with_reason_notifies_mods_and_stays_live`, `test_old_approved_message_is_not_content_checked`. **4356 pass / 0 fail.**

## Note for review

For new approved-on-arrival posts that trip a content check, this PR is deliberately conservative — it **notifies mods** rather than auto-removing a post members can already see. Auto-demoting hard spam could be a follow-up if wanted.

## Discourse

https://discourse.ilovefreegle.org/t/rejected-message-returning-to-live-messages/9815

🤖 Generated with [Claude Code](https://claude.com/claude-code)