### PR TITLE
feat(ripple): retire pending appearances when a post is taken before approval

### DIFF
--- a/iznik-batch/app/Services/AutoApproveService.php
+++ b/iznik-batch/app/Services/AutoApproveService.php
@@ -91,6 +91,17 @@ class AutoApproveService
                     ->where('spam_mg.collection', MessageGroup::COLLECTION_SPAM)
                     ->where('spam_mg.deleted', 0);
             })
+            // Never auto-approve a post that has already been collected. A rippled-in row can
+            // still be Pending when the poster marks the item Taken/Received - the take retires the
+            // pending rows it can see, but a take via a non-Go path (V1 mark()) leaves them. Approving
+            // it would re-list a gone item in a new group and fire a "newly reached" mail, so skip
+            // anything with a Taken/Received outcome.
+            ->whereNotExists(function ($q) {
+                $q->select(DB::raw(1))
+                    ->from('messages_outcomes')
+                    ->whereColumn('messages_outcomes.msgid', 'messages_groups.msgid')
+                    ->whereIn('messages_outcomes.outcome', ['Taken', 'Received']);
+            })
             ->where(function ($q) {
                 // Normal posts: the 48h fallback (unchanged).
                 $q->where(function ($q2) {

--- a/iznik-batch/app/Services/UnifiedDigestService.php
+++ b/iznik-batch/app/Services/UnifiedDigestService.php
@@ -487,6 +487,10 @@ class UnifiedDigestService
                  JOIN users u ON u.id = m.userid
                  LEFT JOIN locations l ON l.id = u.lastlocation
                  WHERE mg.msgid = ? AND mg.collection = 'Approved' AND mg.deleted = 0
+                   AND NOT EXISTS (
+                         SELECT 1 FROM messages_outcomes mo
+                         WHERE mo.msgid = mg.msgid AND mo.outcome IN ('Taken', 'Received')
+                       )
                    AND u.deleted IS NULL AND (u.lastaccess IS NULL OR u.lastaccess > ?)
                    AND ST_Contains(mr.polygon, ST_SRID(POINT(
                          CASE WHEN JSON_EXTRACT(u.settings, '$.mylocation.lat') IS NOT NULL

--- a/iznik-batch/tests/Unit/Services/AutoApproveServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/AutoApproveServiceTest.php
@@ -115,6 +115,47 @@ class AutoApproveServiceTest extends TestCase
         );
     }
 
+    /**
+     * The newly-reached reach mail must never go out for a post that has already been collected -
+     * notifying people about a gone item. mailNewlyReachedForPost guards on the outcome directly.
+     */
+    public function test_mail_newly_reached_skips_taken_post(): void
+    {
+        config(['freegle.digest.immediate_allowlist' => '*']);
+
+        $poster = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $this->createMembership($poster, $group, ['added' => now()->subHours(72)]);
+        $member = $this->createTestUser();
+        $this->createMembership($member, $group, ['added' => now()->subHours(72)]);
+        $member->settings = ['mylocation' => ['lat' => 51.5, 'lng' => -0.1]];
+        $member->save();
+
+        $message = $this->createTestMessage($poster, $group);
+        DB::table('messages_groups')->where('msgid', $message->id)->where('groupid', $group->id)->update([
+            'collection' => MessageGroup::COLLECTION_APPROVED,
+            'arrival' => now()->subHours(1),
+        ]);
+        DB::statement(
+            "INSERT INTO rippling_reach (msgid, lat, lng, polygon, arrival, mode, tick, total_ticks, "
+            . "total_freeglers, max_drive_min, schedule, next_expansion_at, status, created_at, updated_at) "
+            . "VALUES (?, 51.5, -0.1, ST_GeomFromText(?, 3857), NOW(), 'drive', 3, 3, 0, 30, NULL, NULL, 'done', NOW(), NOW())",
+            [$message->id, 'POLYGON((-0.2 51.4,0.0 51.4,0.0 51.6,-0.2 51.6,-0.2 51.4))']
+        );
+        // The item has been collected before the newly-reached mail runs.
+        DB::table('messages_outcomes')->insert([
+            'msgid' => $message->id, 'outcome' => 'Taken', 'timestamp' => now(),
+        ]);
+
+        $sent = app(\App\Services\UnifiedDigestService::class)->mailNewlyReachedForPost((int) $message->id);
+
+        $this->assertEquals(0, $sent, 'a taken post is not mailed to newly-reached members');
+        $this->assertFalse(
+            DB::table('rippling_reach_notified')->where('msgid', $message->id)->exists(),
+            'no reach notification recorded for a taken post'
+        );
+    }
+
     public function test_does_not_auto_approve_message_marked_spam_on_another_group(): void
     {
         // A message that is Pending (and otherwise eligible) on one group but
@@ -476,6 +517,44 @@ class AutoApproveServiceTest extends TestCase
             'msgid' => $message->id, 'groupid' => $nearbyGroup->id,
             'collection' => MessageGroup::COLLECTION_PENDING, 'arrival' => now()->subHours(2),
             'msgtype' => 'Offer', 'rippled_in' => 1,
+        ]);
+
+        $this->service->process();
+
+        $this->assertDatabaseHas('messages_groups', [
+            'msgid' => $message->id, 'groupid' => $nearbyGroup->id,
+            'collection' => MessageGroup::COLLECTION_PENDING,
+        ]);
+    }
+
+    /**
+     * A rippled-in post that has already been collected (a Taken/Received outcome exists) is
+     * never auto-approved into the receiving group - approving it would re-list a gone item and
+     * fire a "newly reached" mail. The take normally retires the pending rows, but a take via a
+     * non-Go path leaves them, so this guard is the catch-all.
+     */
+    public function test_does_not_auto_approve_rippled_in_post_already_taken(): void
+    {
+        $user = $this->createTestUser();
+        $originGroup = $this->createTestGroup();
+        $nearbyGroup = $this->createTestGroup();
+        $this->createMembership($user, $originGroup, ['added' => now()->subHours(72)]);
+
+        $message = $this->createTestMessage($user, $originGroup);
+        DB::table('messages_groups')
+            ->where('msgid', $message->id)->where('groupid', $originGroup->id)
+            ->update(['collection' => MessageGroup::COLLECTION_APPROVED, 'arrival' => now()->subHours(3)]);
+
+        // Rippled into the nearby group 2h ago (past the 1h veto window), still Pending.
+        DB::table('messages_groups')->insert([
+            'msgid' => $message->id, 'groupid' => $nearbyGroup->id,
+            'collection' => MessageGroup::COLLECTION_PENDING, 'arrival' => now()->subHours(2),
+            'msgtype' => 'Offer', 'rippled_in' => 1,
+        ]);
+
+        // The item has been collected.
+        DB::table('messages_outcomes')->insert([
+            'msgid' => $message->id, 'outcome' => 'Taken', 'timestamp' => now(),
         ]);
 
         $this->service->process();

--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -4155,6 +4155,35 @@ func handleOutcome(c *fiber.Ctx, myid uint64, req PostMessageRequest) error {
 		db.Exec("UPDATE messages_spatial SET successful = 1 WHERE msgid = ?", req.ID)
 	}
 
+	// When a post is collected while still Pending in some groups - chiefly the rippling-out
+	// case, where it was rippled into a neighbouring group and is awaiting that group's approval,
+	// but also ordinary cross-posts - retire those Pending appearances so the now-taken item
+	// leaves those mod queues (and is never auto-approved/mailed into them later). We do this
+	// ONLY when the post is Approved on some other group, so the post and its Taken record
+	// survive and a post pending only on its single group is never stranded. Mirrors the
+	// Withdrawn-while-pending cleanup above, but keeps the message.
+	if req.Outcome == utils.OUTCOME_TAKEN || req.Outcome == utils.OUTCOME_RECEIVED {
+		var approvedElsewhere int64
+		db.Raw("SELECT COUNT(*) FROM messages_groups WHERE msgid = ? AND collection = ? AND deleted = 0",
+			req.ID, utils.COLLECTION_APPROVED).Scan(&approvedElsewhere)
+		if approvedElsewhere > 0 {
+			var pendingGroups []uint64
+			db.Raw("SELECT groupid FROM messages_groups WHERE msgid = ? AND collection = ? AND deleted = 0",
+				req.ID, utils.COLLECTION_PENDING).Scan(&pendingGroups)
+			if len(pendingGroups) > 0 {
+				db.Exec("UPDATE messages_groups SET deleted = 1 WHERE msgid = ? AND collection = ? AND deleted = 0",
+					req.ID, utils.COLLECTION_PENDING)
+				// V1 parity: log a Deleted entry per group so the post's disappearance from
+				// that pending queue is audited (matches the Withdrawn-pending path).
+				var fromuser uint64
+				db.Raw("SELECT fromuser FROM messages WHERE id = ?", req.ID).Scan(&fromuser)
+				for _, gid := range pendingGroups {
+					logModAction(db, flog.LOG_TYPE_MESSAGE, flog.LOG_SUBTYPE_DELETED, gid, fromuser, myid, req.ID, 0, req.Outcome)
+				}
+			}
+		}
+	}
+
 	// Remove from freebiealerts.app — post is no longer available regardless of outcome type.
 	if err := queue.QueueTask(queue.TaskFreebieAlertsRemove, map[string]interface{}{
 		"msgid": req.ID,

--- a/iznik-server-go/test/messageoutcome_pending_test.go
+++ b/iznik-server-go/test/messageoutcome_pending_test.go
@@ -1,0 +1,110 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/stretchr/testify/assert"
+)
+
+// When a post is collected (Taken/Received) while still Pending in another group - the
+// rippling-out case, where the post was rippled into a neighbouring group and is awaiting
+// that group's approval - the still-Pending appearance is retired so it leaves that group's
+// mod queue, but the post itself and its Approved (origin) appearance survive as a Taken record.
+func TestPostMessageTakenRetiresRippledPendingKeepsApproved(t *testing.T) {
+	prefix := uniquePrefix("outcome_ripple_pending")
+	db := database.DBConn
+
+	originGroup := CreateTestGroup(t, prefix+"_origin")
+	rippledGroup := CreateTestGroup(t, prefix+"_rippled")
+	posterID := CreateTestUser(t, prefix+"_poster", "User")
+	CreateTestMembership(t, posterID, originGroup, "Member")
+	_, posterToken := CreateTestSession(t, posterID)
+
+	var locationID uint64
+	db.Raw("SELECT id FROM locations LIMIT 1").Scan(&locationID)
+	db.Exec("INSERT INTO messages (fromuser, subject, textbody, message, type, locationid, arrival, date) VALUES (?, ?, 'Body', 'Body', 'Offer', ?, NOW(), NOW())",
+		posterID, prefix+" offer", locationID)
+	var msgID uint64
+	db.Raw("SELECT id FROM messages WHERE fromuser = ? AND subject = ? ORDER BY id DESC LIMIT 1", posterID, prefix+" offer").Scan(&msgID)
+	if msgID == 0 {
+		t.Fatal("failed to create message")
+	}
+
+	// Approved on the origin group; Pending + rippled_in=1 on the rippled-into group.
+	db.Exec("INSERT INTO messages_groups (msgid, groupid, arrival, collection, autoreposts, rippled_in, approvedat) VALUES (?, ?, NOW(), 'Approved', 0, 0, NOW())", msgID, originGroup)
+	db.Exec("INSERT INTO messages_groups (msgid, groupid, arrival, collection, autoreposts, rippled_in) VALUES (?, ?, NOW(), 'Pending', 0, 1)", msgID, rippledGroup)
+	defer db.Exec("DELETE FROM messages_groups WHERE msgid = ?", msgID)
+	defer db.Exec("DELETE FROM messages_outcomes WHERE msgid = ?", msgID)
+
+	body := map[string]interface{}{"id": msgID, "action": "Outcome", "outcome": "Taken"}
+	bodyBytes, _ := json.Marshal(body)
+	req := httptest.NewRequest("POST", fmt.Sprintf("/api/message?jwt=%s", posterToken), bytes.NewBuffer(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := getApp().Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode, "poster can mark their offer Taken")
+
+	// The rippled-in Pending row is retired (soft-deleted) - removed from that group's pending.
+	var rippledDeleted int
+	db.Raw("SELECT deleted FROM messages_groups WHERE msgid = ? AND groupid = ?", msgID, rippledGroup).Scan(&rippledDeleted)
+	assert.Equal(t, 1, rippledDeleted, "rippled-in Pending row should be soft-deleted on Take")
+
+	// The origin Approved row survives.
+	var originDeleted int
+	db.Raw("SELECT deleted FROM messages_groups WHERE msgid = ? AND groupid = ?", msgID, originGroup).Scan(&originDeleted)
+	assert.Equal(t, 0, originDeleted, "origin Approved row must survive")
+
+	// The post itself is NOT deleted.
+	var msgDeleted *string
+	db.Raw("SELECT deleted FROM messages WHERE id = ?", msgID).Scan(&msgDeleted)
+	assert.Nil(t, msgDeleted, "the post itself must NOT be deleted")
+
+	// The Taken outcome is recorded.
+	var outcomeCount int
+	db.Raw("SELECT COUNT(*) FROM messages_outcomes WHERE msgid = ? AND outcome = 'Taken'", msgID).Scan(&outcomeCount)
+	assert.Equal(t, 1, outcomeCount, "Taken outcome recorded")
+}
+
+// Guard: a post that is Pending only on its single group (Approved nowhere) must NOT have its
+// lone Pending row removed on Take - doing so would strand the message (no live appearance left).
+func TestPostMessageTakenSingleGroupPendingNotStranded(t *testing.T) {
+	prefix := uniquePrefix("outcome_single_pending")
+	db := database.DBConn
+
+	groupID := CreateTestGroup(t, prefix)
+	posterID := CreateTestUser(t, prefix+"_poster", "User")
+	CreateTestMembership(t, posterID, groupID, "Member")
+	_, posterToken := CreateTestSession(t, posterID)
+
+	var locationID uint64
+	db.Raw("SELECT id FROM locations LIMIT 1").Scan(&locationID)
+	db.Exec("INSERT INTO messages (fromuser, subject, textbody, message, type, locationid, arrival, date) VALUES (?, ?, 'Body', 'Body', 'Offer', ?, NOW(), NOW())",
+		posterID, prefix+" offer", locationID)
+	var msgID uint64
+	db.Raw("SELECT id FROM messages WHERE fromuser = ? AND subject = ? ORDER BY id DESC LIMIT 1", posterID, prefix+" offer").Scan(&msgID)
+	if msgID == 0 {
+		t.Fatal("failed to create message")
+	}
+
+	// Pending on its only group, Approved nowhere.
+	db.Exec("INSERT INTO messages_groups (msgid, groupid, arrival, collection, autoreposts, rippled_in) VALUES (?, ?, NOW(), 'Pending', 0, 0)", msgID, groupID)
+	defer db.Exec("DELETE FROM messages_groups WHERE msgid = ?", msgID)
+	defer db.Exec("DELETE FROM messages_outcomes WHERE msgid = ?", msgID)
+
+	body := map[string]interface{}{"id": msgID, "action": "Outcome", "outcome": "Taken"}
+	bodyBytes, _ := json.Marshal(body)
+	req := httptest.NewRequest("POST", fmt.Sprintf("/api/message?jwt=%s", posterToken), bytes.NewBuffer(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	// Not Approved elsewhere -> the lone Pending row is left intact (post not stranded).
+	var deleted int
+	db.Raw("SELECT deleted FROM messages_groups WHERE msgid = ? AND groupid = ?", msgID, groupID).Scan(&deleted)
+	assert.Equal(t, 0, deleted, "single-group Pending row must NOT be removed (would strand the post)")
+}


### PR DESCRIPTION
## Summary
- When a post is rippled into a neighbouring group and sits **Pending** there awaiting that group's approval, marking the item **Taken/Received** now instantly retires those Pending appearances (soft-delete) **when the post is Approved elsewhere** - so the taken item leaves those mod queues, while the post itself and its origin Approved appearance survive as a Taken record. A post pending only on its single group is left untouched (never stranded).
- **AutoApproveService** no longer auto-approves any post with a Taken/Received outcome - a catch-all for takes via the V1 `mark()` path, which doesn't retire the rows.
- **mailNewlyReachedForPost** skips posts with a Taken/Received outcome, so newly-reached members are never emailed about an already-collected item.

## Background
The post itself was never deleted on take (that part was already correct). But marking Taken/Received only recorded the outcome and did nothing to the still-Pending rippled-in rows - only **Withdrawn** had instant pending cleanup. Those rows lingered (hidden from view by the `messages_outcomes IS NULL` filter), were auto-approved by the veto-window cron, and could trigger a "newly reached" mail for a gone item.

## Code Quality Review
- The Go cleanup in `handleOutcome` mirrors the existing Withdrawn-pending pattern (soft-delete + per-group Deleted audit log), guarded by "Approved elsewhere" so it never strands a single-group pending post.
- The two Laravel guards are defence-in-depth for take paths that bypass the Go handler.

## Test Plan
- Go (full suite, 3241 pass): `TestPostMessageTakenRetiresRippledPendingKeepsApproved`, `TestPostMessageTakenSingleGroupPendingNotStranded`.
- Laravel `AutoApproveServiceTest` (27 pass): `test_does_not_auto_approve_rippled_in_post_already_taken`, `test_mail_newly_reached_skips_taken_post`.