### PR TITLE
feat(ripple): join the poster to groups their post ripples into (logged as 'Rippled')

### DIFF
--- a/RIPPLING-OUT-FOR-MEMBERS.md
+++ b/RIPPLING-OUT-FOR-MEMBERS.md
@@ -1,0 +1,129 @@
+# Rippling Out - A Guide for Members
+
+> **Current reference document.** Supersedes the draft at
+> `plans/rippling-out-rollout/CHANGES-FOR-MEMBERS.md`.
+
+---
+
+## What is rippling out?
+
+When you post something on Freegle, your item is shown to people nearby first. If nobody
+close enough picks it up quickly, it is gradually shown to people a little further away -
+and so on, working outwards in waves over time. This is rippling out.
+
+The aim is to keep freegling as local as possible. Your neighbours get first chance,
+which means less driving and a fairer go for everyone close by. If nobody nearby wants
+it, it reaches further afield automatically - you do not need to do anything extra.
+
+---
+
+## What happens when your post ripples into a new community?
+
+When your post reaches a new Freegle community, two things happen automatically.
+
+### You are joined as a member
+
+You are added as a normal member of that community so that:
+
+- People there can reply to your post and get in touch.
+- Moderators can contact you if they need to.
+- Your post behaves just like any other post in that community.
+
+This is invisible to you in day-to-day use. You will see these communities listed under
+your "My Communities" in Settings.
+
+### Your email settings are adjusted on your behalf
+
+We do not want your inbox filling up with new post alerts from every community your item
+travels through. So we apply these defaults for any community you are joined to via
+rippling:
+
+- **If you were on "immediate" emails** on your home community, the rippled communities
+  are set to daily digest instead. You still hear about them - just once a day rather
+  than instantly.
+- **If you were already on daily digest or no emails**, those settings are kept exactly
+  as they are.
+- **Community events and volunteering emails** are left at whatever you already had. No change there.
+
+You can adjust any of these settings yourself at any time - see below.
+
+---
+
+## The intro email
+
+Instead of receiving a separate welcome email for every community your post ripples
+into (which could be quite a few), you get **one single email** that explains:
+
+- That your post is now reaching nearby communities beyond your own.
+- What email settings we applied on your behalf.
+- How to change them or leave a community if you prefer.
+- A welcome message from each community your post reached (so you still see what each
+  community wanted to say, without a separate welcome email from every one).
+
+This is a one-off notice about your own post. It is sent even if you normally have
+emails turned off for group-feed messages, because it is about something that just
+happened to your account.
+
+---
+
+## Staying in control
+
+### Changing your email settings
+
+You can adjust how often you hear from any community in **Settings** at any time. You
+can set individual communities to immediate, daily, or no emails, just as you can for
+any other community you belong to.
+
+### Leaving a community
+
+If you would rather not be a member of a community your post rippled into, you can leave
+it in Settings.
+
+Two things happen when you leave:
+
+1. Your post is **removed from that community** - people there will no longer see it.
+2. You will **not be re-joined** to that community, even if your post continues to ripple
+   elsewhere.
+
+Your post carries on being visible in every other community it reached, so leaving one
+community does not affect the rest.
+
+---
+
+## Things you will notice on the browse page
+
+### Nearest and freshest first
+
+On the browse page you will see posts that are close to you and new to you. The old
+travel-time slider and transport picker are gone - the system works out the right
+distance for you and widens it automatically over time. You can still sort by "Newest
+posted" or "Nearby" if you prefer.
+
+### When you post, there is no group to choose
+
+When you create a post you no longer pick which community it goes to. Your post simply
+reflects where the item actually is (based on the postcode you give), and rippling then
+shows it to the right people, closest first. You no longer need to think about "which
+group should I post to?" or post to a second group for more reach - the system handles
+that for you.
+
+### "You can reply when it reaches you"
+
+You might occasionally see a post that you cannot yet reply to, because it has not
+rippled out to your area yet. You will see a friendly message explaining this. As soon
+as the post reaches your area, the reply option appears and you can get in touch as
+normal. Nothing is lost - it is just "not yet" rather than "no".
+
+---
+
+## Quick summary
+
+| What | How it works |
+|---|---|
+| Your post | Shown to people nearby first, then gradually further away |
+| New communities | You are joined automatically so replies and contact work |
+| Email defaults | Immediate is switched to daily; no-email and daily are unchanged |
+| Community events/volunteering emails | Left at whatever you already had |
+| Intro email | One bundled email explains what happened and how to change things |
+| Leaving a community | Removes your post from it; you are not re-joined |
+| Changing settings | Adjust per community in Settings at any time |

--- a/RIPPLING-OUT-FOR-MODERATORS.md
+++ b/RIPPLING-OUT-FOR-MODERATORS.md
@@ -1,0 +1,171 @@
+# Rippling Out - A Guide for Moderators
+
+> **Current reference document.** Supersedes the draft at
+> `plans/rippling-out-rollout/CHANGES-FOR-MODERATORS.md`.
+
+---
+
+## The one big "please don't"
+
+> ### Don't reject a post just because it looks "out of area"
+>
+> With rippling out, a post that started on a neighbouring community can appear on
+> **your** community's pending list, even if the poster lives some distance away.
+> **That is expected and correct.** It means the system is deliberately spreading a post
+> that has not been collected locally so your members get a chance at it.
+>
+> Only reject it for the usual reasons - spam, breaks the rules, wrong sort of thing,
+> and so on. "They're not from round here" is no longer a reason to reject.
+
+### The same applies to replies
+
+If someone replies to a post from outside what you think of as your area, that is the
+system working as intended. Do not ban or block a member simply because they replied to
+a post you think is out of their area.
+
+---
+
+## How posters appear in your community
+
+When a post ripples into your community, **the poster is automatically joined as a full
+Member/Approved**. This is intentional - moderators need to be able to contact posters
+and moderate their posts in the usual way, so they must be real members.
+
+What this means in practice:
+
+- You can contact the poster, moderate their post, and use all the normal moderation
+  tools, exactly as you would for any other member.
+- The poster appears in your member list.
+- Your community's member count may include rippled members.
+- The join is recorded with reason **'Rippled'** in the membership log, so you can
+  distinguish it from a manual or organic join if you need to.
+
+---
+
+## What you will see that is new
+
+### 1. Posts arriving from other communities
+
+Some posts in your pending list will have started on another community and rippled into
+yours. You will see a small notice on the post making this clear. These go through your
+normal pending list like any other post - approve or reject them as you normally would
+(remembering the "please don't" above).
+
+**Auto-approval for pre-approved posts.** A post that rippled in and was already approved
+on the community where it started will auto-approve on your community after about an hour
+if nobody rejects it first. It was already vetted, so we do not make it sit out the full
+review window again. You still see it in your pending list and can reject it for the usual
+reasons - just do so reasonably promptly if you do not want it to go live locally. A post
+that has not been approved anywhere yet follows your normal pending process, unchanged.
+
+### 2. A reach/map view on posts
+
+On posts in your moderation screens there is a button (labelled something like "Who can
+see this?" or "Reach") that shows you on a map the area a post is currently visible in.
+This is useful for checking how far a post has spread or why it turned up on your list.
+
+### 3. A reminder when you edit a shared post
+
+If you edit a post that is on more than one community, you will see a warning:
+
+> *"This edit will apply to the post on all groups."*
+
+Edit as normal - just be aware your change is seen everywhere the post appears.
+
+### 4. Held replies in Chat Review
+
+Occasionally a reply is held because the post has not yet rippled out to where that
+member is. Chat Review shows you it is held because of rippling (not because you chose
+to hold it). You do not need to do anything - the reply is released automatically once
+the post reaches that member's area. Members are never shown this reason; only moderators
+see it.
+
+---
+
+## When a poster leaves your community
+
+If a poster leaves your community (or is removed), their rippled-in post is **pulled
+from your community** automatically. The post continues to appear on all other communities
+where it was approved. The poster is not re-added to your community, even if the post
+carries on rippling elsewhere.
+
+---
+
+## Email settings for rippled members
+
+For your awareness, when a poster is auto-joined to a community via rippling, their email
+settings for that community are set as follows:
+
+- **Immediate email** - downgraded to daily digest.
+- **Daily digest or no emails** - preserved exactly as-is.
+- **Community events and volunteering** - copied from their home community settings (no extra emails).
+
+The poster receives one bundled intro email explaining all of this, rather than a separate
+welcome email from each community they were joined to.
+
+---
+
+## The spam-flag and "seen on many groups"
+
+Rippling joins a poster to multiple communities. This does **not** trigger the "seen on
+many groups" spam review flag. Ripple-joins are excluded from that count, so a poster
+whose item has rippled widely will not be incorrectly flagged as a spammer.
+
+---
+
+## Rejecting a rippled-in post
+
+If you reject a post that rippled in from another community, two things happen:
+
+1. **The poster is not told.** They posted to their own community and the post is still
+   visible there. A faraway community saying "not for us" is not something they need to
+   hear about.
+2. **The post stops showing in your community's area.** It carries on being visible
+   everywhere else it has been approved. Your rejection simply trims your patch off the map.
+
+A secondary rejection is low-stakes: it quietly removes the post from your area and
+nobody is upset. Use it if a post genuinely is not suitable locally - but not simply
+because the poster is from out of area.
+
+---
+
+## TrashNothing posts
+
+Posts coming in through TrashNothing behave exactly like any other post under rippling
+out. They ripple outwards from the community they started on, appear in your pending list
+with the same notice, and can be approved or rejected in the same way.
+
+---
+
+## What to expect from members
+
+The main thing members may ask you about is **"why can't I reply to this post?"** The
+answer is reassuring:
+
+> *The post has not rippled out to your area yet. It is being shown to people closest
+> to it first. As soon as it reaches you, you will be able to reply - you do not need
+> to do anything.*
+
+Some members may also ask why they have been joined to communities they did not sign up
+for. The answer is that their post has been travelling to reach more people, and the
+membership is what makes replies and contact work properly. They can leave any of those
+communities in Settings, which will remove their post from that community.
+
+---
+
+## The two habits to build
+
+1. **Do not reject a post just for being out of area** - that is the system working.
+2. **Do not ban a member just for replying from out of area** - same reason.
+
+Everything else about your day-to-day moderation routine stays the same.
+
+---
+
+## Reference: what the 'Rippled' log entry means
+
+The membership log shows `reason='Rippled'` for any join created by rippling out. This
+is purely for provenance and audit - you do not need to do anything with it. It lets us
+distinguish ripple-joins from manual or organic joins, and it is used internally to
+suppress the per-group welcome email (replaced by a single bundled intro) and to exclude
+these joins from the "seen on many groups" spam check.

--- a/docs/superpowers/specs/2026-06-23-rippling-membership-mitigations-design.md
+++ b/docs/superpowers/specs/2026-06-23-rippling-membership-mitigations-design.md
@@ -1,0 +1,223 @@
+# Rippling-Out Auto-Join: Membership Side-Effect Mitigations
+
+**Date:** 2026-06-23
+**Branch:** `feat/ripple-poster-membership-on-rippled` (PR #855) - all of this ships *as part of 855*, not as separate PRs.
+**Status:** Design approved, ready for implementation plan.
+
+## 1. Background
+
+PR #855 (`ExpandService::addPosterMembershipToRippledGroups`) makes the poster a
+`Member`/`Approved` of every group their post ripples into, so the rippled post behaves
+like a normal post (replies, mod contact, abuse tracking). Today it copies the poster's
+home-group email settings, writes a `memberships_history` row (`processingrequired=1`),
+and logs `Group/Joined` with `text='Rippled'`.
+
+That auto-join is **unexpected** for the user and has a family of knock-on user-visible
+side effects. A 13-agent investigation (live system only - Laravel `iznik-batch`, Go
+`iznik-server-go`, frontend `iznik-nuxt3`; V1 `iznik-server/include` is obsolete and not
+the source of truth) mapped ~27 distinct side effects. The product decision is to **keep
+the membership** (mods expect that people who post are members - a workflow contract that
+overrides the "don't join" option) and **mitigate the side effects piecemeal**, all on PR #855.
+
+This document is the agreed design for those mitigations.
+
+## 2. Decision ledger
+
+Side effects and their disposition. "No-op" = confirmed acceptable, no change.
+
+| # | Side effect | Disposition |
+|---|---|---|
+| A1 | Welcome-email storm (one per rippled group) | **Fix**: suppress per-group welcomes for rippled joins; send ONE bundled intro email per post |
+| A2 | Immediate-email volume explosion (home `emailfrequency=-1` copied) | **Fix**: downgrade only `emailfrequency=-1` (immediate) -> `24` (daily); preserve every other home value (a no-email `0` stays `0`) |
+| A3 | Daily digest / push scope expansion | No-op |
+| A4 | Events / volunteering digest content widening | No-op: **copy from home** (separate emails but one-per-user with cadence guard, so no extra emails - only wider content) |
+| A4n | Newsfeed-chitchat digest | No-op: it is unified per user and governed by the account-level `notificationmails` setting (not per-group), so a rippled membership does not change it - preserve existing setting |
+| A5 | Birthday email "from" an unknown group | **Fix**: suppress for rippled memberships |
+| A5b | Stories-ask / newsletter / engage | No-op: gated on *any* membership, already satisfied by home group |
+| B1 | Groups appear in "My Communities" UI | No-op |
+| B2 | Leave / re-join loop | **Fix**: a `Group/Left` log suppresses both re-join AND re-rippling the post into that group; existing rippled rows in left groups are pulled |
+| B3 | Per-group vs account "simple email" conflict | No-op: confirmed no conflict (see §3) |
+| B4 | Silent `MODERATED` posting status on rippled group | No-op |
+| C1 | False "seen on many groups" spam flag | **Fix**: exclude `logs.text='Rippled'` from `checkSeenOnManyGroups` |
+| C2 | Flagged-comment review fan-out | No-op |
+| C3 | membercount / ratings / microvolunteering inflation | No-op |
+| D1 | SAR export duplicates the post per group | **Fix**: dedup in `UserDataExportService::getMessages` |
+| D2 | `forgetUser` leaves `memberships_history` | No-op |
+| D3 | Auto-memberships block inactive auto-forget | No-op: home-group membership already blocks it (moot) |
+
+Plus two added deliverables: a **backfill artisan command** and **top-level member/mod docs**.
+
+## 3. Resolved investigation findings (rationale for the no-ops)
+
+- **B3 - simple email (no conflict).** `simplemail` lives in `users.settings` JSON and is
+  only a join-time default plus the account-level `None` opt-out. The nuxt
+  `EmailSettingsSection.vue` `simpleSettings` computed returns `true` whenever `simplemail`
+  is set, regardless of per-group divergence, so a rippled group at daily while real groups
+  are immediate does NOT flip the user into the advanced/per-group view. At send time
+  `memberships.emailfrequency` is the sole authority (`UnifiedDigestService` getUsersForDigest);
+  `simplemail` is never consulted except `None` as a global opt-out. Forcing daily is therefore
+  safe and invisible. A `Full` (immediate-everywhere) user gets the rippled group silently
+  delivered daily instead of immediate - which is exactly the A2 intent.
+- **A4 - events/volunteering are NOT in the Unified digest** (`mail:events-digest`,
+  `mail:volunteering-digest` are separate crons with their own templates) but ARE one-email-
+  per-user with a 3-day cadence guard (`BuildsUserRoundups::eligibleUsers`, gated on
+  `eventsallowed=1`/`volunteeringallowed=1`). Leaving them at the home setting adds zero extra
+  emails - only wider roundup content. Decision: copy from home (PR #855's existing behaviour).
+- **D3 - moot.** Posting always does `INSERT IGNORE INTO memberships` for the home group
+  (`message.go` JoinAndPost), and `forgetInactiveUsers` is blocked by any membership row, so the
+  home membership already blocks auto-forget. The only edge case (leaving the home group while
+  keeping rippled ones) is covered by the B2 leave behaviour.
+- **Opt-out posters (no-email, home `emailfrequency=0`) keep `0`:** they are still auto-joined
+  (mods expect posters to be members) but their rippled memberships preserve `emailfrequency=0`,
+  so they receive no ongoing group-feed mail. They still get the single one-off intro notice
+  (the intro is a transactional notice about their own post, sent regardless of digest opt-out).
+  Only `emailfrequency=-1` (immediate) is downgraded to `24` (daily); all other home values are
+  preserved verbatim.
+
+## 4. Schema changes (all instant-add)
+
+New migrations in `iznik-batch/database/migrations/`:
+
+1. `memberships.rippled TINYINT(1) NOT NULL DEFAULT 0` - marks a ripple-added membership.
+   Consumed by NewsfeedDigest + Birthday suppression and the backfill command.
+2. `memberships_history.rippled TINYINT(1) NOT NULL DEFAULT 0` - lets
+   `MembershipsProcessingService` suppress the per-group welcome for rippled joins without
+   depending on the (possibly-deleted) membership row.
+3. `rippling_reach.ripple_intro_sent TINYINT(1) NOT NULL DEFAULT 0` - one intro email per post.
+4. Composite index `logs(user, groupid, type, subtype)` - makes the `Group/Left` guard a
+   point-lookup.
+
+Go reads memberships via an explicit-column struct (`MembershipTable`), so adding a column it
+does not select is safe; verify no `SELECT *` scan path breaks during implementation.
+
+## 5. Component design
+
+All file references are on the PR #855 branch.
+
+### 5.1 Membership creation - `ExpandService::addPosterMembershipToRippledGroups`
+
+- Set `rippled=1`. **Copy** `eventsallowed` / `volunteeringallowed` from the home group
+  (unchanged from current PR #855). For `emailfrequency`, copy the home value but **downgrade
+  only immediate to daily**: `emailfrequency = (home == -1) ? 24 : home`. So a no-email home
+  setting (`0`) is preserved as `0`, a daily home (`24`) stays `24`, and only immediate (`-1`)
+  becomes daily (`24`).
+- Add a guard so a poster who has left a group is never re-joined:
+  `AND NOT EXISTS (SELECT 1 FROM logs l WHERE l.user=? AND l.groupid=g.id AND l.type='Group' AND l.subtype='Left')`.
+  This respects self-leave, mod-removal, ban, and partner-removal (all write `Group/Left`).
+- Write `memberships_history` with `rippled=1` (still `processingrequired=1` so abuse
+  detection runs; only the welcome is suppressed downstream).
+- Keep the `Group/Joined`, `text='Rippled'` log (needed for provenance and the C1 exclusion).
+- After the loop, if at least one membership was added for this post and
+  `rippling_reach.ripple_intro_sent=0`, set it to 1 and spool one `RippleIntroMail` to the
+  poster (sent to all posters including `None` opt-outs).
+
+### 5.2 Leave also pulls the post - `rippleIntoNewGroups` + reconciliation
+
+- `rippleIntoNewGroups`: add the same `NOT EXISTS Group/Left` guard to the
+  `messages_groups` INSERT, so the post is never (re-)rippled into a group the poster left.
+- New reconciliation step (Laravel-side, in `ExpandService`, run each expand tick), removing
+  the post from groups the poster has left:
+  ```sql
+  UPDATE messages_groups mg
+    JOIN messages m ON m.id = mg.msgid
+    JOIN logs l ON l.user = m.fromuser AND l.groupid = mg.groupid
+                 AND l.type='Group' AND l.subtype='Left'
+  SET mg.deleted = 1
+  WHERE mg.rippled_in = 1 AND mg.deleted = 0
+  ```
+  Soft-delete (`deleted=1`) matches the codebase pattern (feeds/digests filter `deleted=0`),
+  is auditable, and (together with the guard) is idempotent. The home-group row
+  (`rippled_in=0`) is never touched. Implementation may bound the scan to recent `Group/Left`
+  logs for efficiency; correctness does not require it.
+- **Log the removal.** Each post pulled from a group writes a `logs` row for audit:
+  `type='Message'`, `subtype='Deleted'`, `msgid`, `groupid`, `user=poster`, `byuser=NULL`,
+  `text='Rippling: removed on leave'`. One row per (msgid, group) removed; do not re-log a row
+  already soft-deleted (so re-runs stay idempotent).
+
+### 5.3 Welcome -> bundled intro email
+
+- `MembershipsProcessingService::processEntry`: guard the `GroupWelcomeMail` spool with
+  `&& !($entry->rippled ?? false)` so rippled joins send no per-group welcome.
+- New `App\Mail\Ripple\RippleIntroMail` (extends `MjmlMailable`) + MJML/text templates.
+  Copy must explain, in plain language:
+  - **Lead reassurance (top)** - "there's nothing you need to do"; this just helps the post reach
+    the right person.
+  - **What happened & why** - the post is reaching nearby communities the user is not in
+    (so more people see it), and we added them so it behaves like a normal post.
+  - **What we set up** - daily digest for these communities; community events/volunteering left at
+    their normal setting.
+  - **What they can change & how** - adjust email frequency per community in Settings; leave any
+    community (the post is pulled from it and they are not re-added).
+  - **Each community's own welcome message** - the per-group `groups.welcomemail` text for the
+    rippled-into communities the poster joined, bundled into this one email (gathered at send
+    time in `ExpandService::maybeSendRippleIntro` and passed as `welcomeGroups`). This replaces
+    the suppressed per-group welcomes so the poster still sees what each community wanted to say,
+    without a welcome email per community. Because step-70 front-loads ~70% of reach into the
+    first tick, the one intro (sent at first join) carries the bulk of the welcome texts.
+- **Copy-review checkpoint:** render a sample into Mailpit (the batch `mail:test` path) and get
+  Edward's sign-off on the wording before the PR is finalized. Iterate on copy in Mailpit.
+
+### 5.4 Birthday suppression via `memberships.rippled`
+
+- `BirthdayService` (members fetch): add `->where('memberships.rippled', 0)` so a rippled
+  membership never causes a birthday email "from" a group the user never knowingly joined.
+- Events/volunteering need no change (copied-from-home `eventsallowed`/`volunteeringallowed`
+  already gate them via `BuildsUserRoundups::eligibleUsers`).
+- Newsfeed-chitchat digest needs no change: it is unified per user and governed by the
+  account-level `notificationmails` setting, which a rippled membership does not affect.
+
+### 5.5 Spam + data fixes
+
+- C1 - `MembershipsProcessingService::checkSeenOnManyGroups`: add
+  `AND (logs.text IS NULL OR logs.text != 'Rippled')` to the `Group/Joined` count so
+  ripple-joins do not trip the multi-group spam flag.
+- D1 - `UserDataExportService::getMessages`: dedup so a rippled post appears once
+  (one row per `msgid`, keeping the origin/home group context) rather than once per group.
+
+## 6. Backfill artisan command
+
+New command (e.g. `ripple:backfill-memberships`) to retroactively apply this behaviour to
+members already auto-joined before these changes (identified by their `Group/Joined`
+`text='Rippled'` logs, since `memberships.rippled` is unset on pre-existing rows).
+
+- **Per user**, idempotent. Flags: `--user=ID` (scope to one), `--limit=N`, `--send`.
+- **Dry-run by default**: with no flags it reports what it would do (counts, sample users) and
+  changes nothing. DB updates *and* intro emails happen only with `--send`.
+- On `--send`, per rippled user: set `memberships.rippled=1` on their rippled memberships and
+  apply the §5.1 email-frequency policy (downgrade only immediate `-1` -> `24`; preserve all
+  other values, including `0`), and send the `RippleIntroMail` once (tracked via
+  `rippling_reach.ripple_intro_sent`, or an equivalent per-user guard, so re-runs never
+  re-send). Already-sent welcomes cannot be unsent; the backfill only normalizes going forward.
+
+## 7. Member / moderator documentation
+
+Promote the existing `plans/rippling-out-rollout/CHANGES-FOR-MEMBERS.md` and
+`CHANGES-FOR-MODERATORS.md` to **two top-level files** and make them current:
+
+- `RIPPLING-OUT-FOR-MEMBERS.md`
+- `RIPPLING-OUT-FOR-MODERATORS.md`
+
+They must reflect current behaviour: auto-join on ripple, the daily-digest default, the intro
+email, events/volunteering left as-is, leaving a community pulls the post and prevents re-add,
+and (for mods) that posters appear as members, what the `text='Rippled'` provenance means, and
+that membercount/stats may include rippled members. The `plans/` copies become historical.
+
+## 8. Testing
+
+- `ExpandServiceTest`: emailfrequency=24 + rippled=1 + events/vol copied; `Group/Left` guard
+  blocks re-join and blocks re-ripple; reconciliation soft-deletes the post in a left group;
+  intro email spooled once per post; intro sent to a `None` poster.
+- `MembershipsProcessingServiceTest`: welcome suppressed when `memberships_history.rippled=1`;
+  `checkSeenOnManyGroups` ignores `text='Rippled'` joins.
+- `NewsfeedDigestServiceTest`, `BirthdayServiceTest`: rippled memberships excluded.
+- `UserDataExportService` test: rippled post appears once.
+- `RippleIntroMail` test: renders; correct recipient/subject.
+- Backfill command test: dry-run changes nothing; `--send` sets flags, normalizes frequency,
+  sends one intro, and is idempotent on re-run.
+- Run the full relevant suites locally (Laravel + Go) before pushing, per repo rules.
+
+## 9. Out of scope (explicit no-ops)
+
+A3, A5b (stories/newsletter/engage), B1, B3, B4, C2, C3, D2, D3 - confirmed acceptable, no
+change. The "don't auto-join" option is rejected (mods expect posters to be members). No
+"first-class rippled membership type" - the only marker is a single internal `rippled` boolean.

--- a/iznik-batch/app/Console/Commands/Mail/TestMailCommand.php
+++ b/iznik-batch/app/Console/Commands/Mail/TestMailCommand.php
@@ -66,6 +66,7 @@ class TestMailCommand extends Command
         'chaseup-promised' => 'Chase-up promised email (promised variant)',
         'deadline-reached' => 'Deadline reached notification',
         'stories-newsletter' => 'Monthly stories newsletter (real stories from DB, or sample data if none found)',
+        'ripple-intro' => 'Rippling Out intro email (one-off "your post is reaching more people" notice)',
     ];
 
     /**
@@ -355,8 +356,49 @@ class TestMailCommand extends Command
             'chaseup-promised' => $this->buildChaseUp(true),
             'deadline-reached' => $this->buildDeadlineReached(),
             'stories-newsletter' => $this->buildStoriesNewsletter(),
+            'ripple-intro' => $this->buildRippleIntro(),
             default => null,
         };
+    }
+
+    /**
+     * Build the Rippling Out intro email (one-off "your post is reaching more people" notice).
+     * Use to preview/review the copy in Mailpit: mail:test ripple-intro --user=ID --send-to=you@...
+     */
+    protected function buildRippleIntro(): ?\App\Mail\Ripple\RippleIntroMail
+    {
+        $user = $this->findUserWithEmail($this->option('user'));
+        if (! $user) {
+            return null;
+        }
+
+        $this->info("Generating Rippling Out intro email for user: {$user->displayname} (ID: {$user->id})");
+
+        // Optionally attach one of the user's posts for light context (subject/body only).
+        $message = \App\Models\Message::where('fromuser', $user->id)->latest('id')->first();
+
+        // For preview: show the per-community welcome section using a couple of real groups'
+        // welcome text where available, else sample text, so the layout can be reviewed.
+        $welcomeGroups = DB::table('groups')
+            ->where('onhere', 1)
+            ->whereNotNull('welcomemail')
+            ->where('welcomemail', '<>', '')
+            ->orderByDesc('id')
+            ->limit(2)
+            ->get(['namefull', 'nameshort', 'welcomemail'])
+            ->map(fn ($g) => [
+                'name' => $g->namefull ?: $g->nameshort,
+                'welcome' => $g->welcomemail,
+            ])->all();
+
+        if (empty($welcomeGroups)) {
+            $welcomeGroups = [
+                ['name' => 'Freegle Sampleton', 'welcome' => "Welcome to Freegle Sampleton!\nPlease keep posts local and be kind. Our volunteers are here to help."],
+                ['name' => 'Freegle Exampleford', 'welcome' => "Hi and welcome!\nOffers and Wanteds both welcome - thanks for helping us reuse rather than bin."],
+            ];
+        }
+
+        return new \App\Mail\Ripple\RippleIntroMail($user, $message, $welcomeGroups);
     }
 
     /**

--- a/iznik-batch/app/Console/Commands/Ripple/BackfillMembershipsCommand.php
+++ b/iznik-batch/app/Console/Commands/Ripple/BackfillMembershipsCommand.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Console\Commands\Ripple;
+
+use App\Console\Concerns\PreventsOverlapping;
+use App\Services\Ripple\RippleMembershipBackfillService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Backfill the Rippling Out auto-join mitigations onto members auto-joined before they existed:
+ * mark rippled memberships, downgrade immediate -> daily, and send the one bundled intro email
+ * (once per user). DRY-RUN BY DEFAULT - reports what it would do and changes nothing; pass --send
+ * to actually apply changes and send the intro emails.
+ */
+class BackfillMembershipsCommand extends Command
+{
+    use PreventsOverlapping;
+
+    protected $signature = 'ripple:backfill-memberships
+                            {--user= : Restrict to a single user id}
+                            {--limit=0 : Max users to process (0 = no limit)}
+                            {--send : Apply changes and send intro emails (default: dry-run report only)}';
+
+    protected $description = 'Backfill Rippling Out membership mitigations (flag rippled, downgrade immediate->daily, send one intro email) for already-rippled members';
+
+    public function handle(RippleMembershipBackfillService $service): int
+    {
+        if (!$this->acquireLock()) {
+            $this->info('Already running, exiting.');
+            return Command::SUCCESS;
+        }
+
+        try {
+            $send = (bool) $this->option('send');
+            $userId = $this->option('user') !== null ? (int) $this->option('user') : null;
+            $limit = (int) $this->option('limit');
+
+            if (!$send) {
+                $this->info('DRY RUN - no changes will be made and no emails sent. Pass --send to apply.');
+            }
+
+            $stats = $service->backfill($userId, $limit, $send);
+
+            $prefix = $send ? 'Backfilled' : '[DRY RUN] Would backfill';
+            $this->info("{$prefix}: {$stats['users']} user(s), {$stats['memberships']} rippled membership(s) "
+                . "({$stats['flagged']} newly flagged, {$stats['downgraded']} downgraded immediate->daily), "
+                . "{$stats['intros']} intro email(s).");
+            Log::info('ripple:backfill-memberships complete', $stats + ['send' => $send]);
+
+            return Command::SUCCESS;
+        } finally {
+            $this->releaseLock();
+        }
+    }
+}

--- a/iznik-batch/app/Mail/Ripple/RippleIntroMail.php
+++ b/iznik-batch/app/Mail/Ripple/RippleIntroMail.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\Mail\Ripple;
+
+use App\Mail\MjmlMailable;
+use App\Mail\Traits\LoggableEmail;
+use App\Models\Message;
+use App\Models\User;
+use Illuminate\Mail\Mailables\Address;
+use Illuminate\Mail\Mailables\Envelope;
+
+/**
+ * One bundled "your post is reaching nearby communities" intro email, sent once per post the
+ * first time Rippling Out auto-joins the poster to a community their post has rippled into.
+ *
+ * Replaces the per-group welcome storm (a post can ripple into many groups; sending one welcome
+ * per group would flood the inbox). Its job is transparency + control: explain what happened, the
+ * email defaults we applied on their behalf (daily digest for the rippled communities; events and
+ * volunteering left as their normal setting), and how to change them or leave - not to "welcome"
+ * them to a specific group. Sent from the Freegle-wide no-reply address, not a group address.
+ */
+class RippleIntroMail extends MjmlMailable
+{
+    use LoggableEmail;
+
+    /**
+     * @param User                                  $user          The poster who has been auto-joined.
+     * @param Message|null                          $message       The post that rippled (for light context).
+     * @param array<int,array{name:string,welcome:string}> $welcomeGroups The communities the post was joined
+     *        to that have a custom welcome message - each community's own welcome text is shown in the
+     *        bundled intro, so the poster still sees what each community wanted to say (without N separate
+     *        welcome emails).
+     */
+    public function __construct(
+        public User $user,
+        public ?Message $message = null,
+        public array $welcomeGroups = []
+    ) {
+        parent::__construct();
+    }
+
+    protected function getRecipientUserId(): ?int
+    {
+        return $this->user->id;
+    }
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            from: new Address(
+                config('freegle.mail.noreply_addr', 'noreply@ilovefreegle.org'),
+                config('freegle.branding.name', 'Freegle')
+            ),
+            subject: $this->getSubject(),
+        );
+    }
+
+    protected function getSubject(): string
+    {
+        return 'Your ' . config('freegle.branding.name', 'Freegle') . ' post is reaching more people';
+    }
+
+    public function build(): static
+    {
+        $recipientEmail = $this->user->email_preferred;
+        $userSite = config('freegle.sites.user');
+
+        // Normalise each community's welcome entry to {name, welcome} (raw text). The HTML
+        // template converts line breaks with nl2br; the plain-text template uses it as-is.
+        $welcomeGroups = array_map(static fn ($g) => [
+            'name' => $g['name'] ?? '',
+            'welcome' => $g['welcome'] ?? '',
+        ], $this->welcomeGroups);
+
+        return $this->mjmlView(
+            'emails.mjml.ripple.intro',
+            [
+                'firstName' => $this->user->firstname ?? null,
+                'email' => $recipientEmail,
+                'userSite' => $userSite,
+                'settingsUrl' => "{$userSite}/settings",
+                'unsubscribeUrl' => "{$userSite}/unsubscribe",
+                'welcomeGroups' => $welcomeGroups,
+            ],
+            'emails.text.ripple.intro'
+        )->to($recipientEmail)
+            ->applyLogging('RippleIntro');
+    }
+}

--- a/iznik-batch/app/Services/BirthdayService.php
+++ b/iznik-batch/app/Services/BirthdayService.php
@@ -48,6 +48,9 @@ class BirthdayService
                 ->join('memberships', 'users.id', '=', 'memberships.userid')
                 ->where('memberships.groupid', $group->id)
                 ->where('memberships.collection', 'Approved')
+                // Exclude Rippling Out auto-joins: a birthday appeal must never appear to come
+                // "from" a community the member never knowingly joined.
+                ->where('memberships.rippled', 0)
                 ->whereNull('users.deleted')
                 ->where('users.marketingconsent', 1)
                 ->select('users.id', 'users.settings')

--- a/iznik-batch/app/Services/MembershipsProcessingService.php
+++ b/iznik-batch/app/Services/MembershipsProcessingService.php
@@ -60,7 +60,11 @@ class MembershipsProcessingService
             $group = Group::find($groupId);
             $hasWelcome = $group && $group->onhere && !empty($group->welcomemail);
             $user = $hasWelcome ? User::find($userId) : null;
-            $wouldSendWelcome = $hasWelcome && $user && $user->email_preferred;
+            // Rippled auto-joins (Rippling Out) get NO per-group welcome - a single bundled intro
+            // email (RippleIntroMail) is sent by the ripple expander instead. Suppressing here
+            // (not skipping the history row) keeps abuse detection running for the join.
+            $isRippled = (bool) ($entry->rippled ?? false);
+            $wouldSendWelcome = $hasWelcome && $user && $user->email_preferred && !$isRippled;
 
             $flaggedCount = $this->countFlaggedComments($userId, $groupId);
 
@@ -92,7 +96,7 @@ class MembershipsProcessingService
             }
 
             $this->applyFlaggedComments($userId, $groupId);
-            $this->checkSeenOnManyGroups($userId, $groupId);
+            $this->checkSeenOnManyGroups($userId, $groupId, $isRippled);
         }
 
         if (!$dryRun) {
@@ -113,7 +117,7 @@ class MembershipsProcessingService
      * memberships_processing, but only the flagged-comments check was ported.
      * The result was that the members-flagged-for-review queue dried up to ~0.
      */
-    private function checkSeenOnManyGroups(int $userId, int $groupJustAdded): void
+    private function checkSeenOnManyGroups(int $userId, int $groupJustAdded, bool $justAddedIsRippled = false): void
     {
         // Distinct groups joined/applied to in a year before a member is "suspect" and flagged.
         // Relaxed 16 -> 35 for rippling-out: a post's reach now follows the poster's declared
@@ -147,13 +151,23 @@ class MembershipsProcessingService
             ->where('logs.user', $userId)
             ->where('logs.type', 'Group')
             ->where('logs.subtype', 'Joined')
+            // Exclude rippling auto-joins (text='Rippled'): they follow the poster's post reaching
+            // a group, not a deliberate join spree, so they must not count toward "seen on many
+            // groups" - otherwise a single far-reaching post would flag the poster everywhere.
+            ->where(function ($q) {
+                $q->whereNull('logs.text')->orWhere('logs.text', '!=', 'Rippled');
+            })
             ->where('logs.groupid', '!=', $groupJustAdded)
             ->whereNull('spam_users.userid')
             ->where('logs.timestamp', '>=', $start)
             ->distinct()
             ->count('logs.groupid');
 
-        $count++; // the just-added group, excluded from the query above
+        // The just-added group is excluded from the query above and counted here - but NOT when it
+        // is itself a rippling auto-join, so a rippled membership never pushes the total over.
+        if (!$justAddedIsRippled) {
+            $count++;
+        }
 
         if ($count <= $threshold) {
             return;

--- a/iznik-batch/app/Services/Ripple/ExpandService.php
+++ b/iznik-batch/app/Services/Ripple/ExpandService.php
@@ -46,6 +46,7 @@ class ExpandService
         $stats = [
             'initialized' => 0, 'expanded' => 0, 'completed' => 0,
             'removed' => 0, 'skipped' => 0, 'errors' => 0, 'rippled_in' => 0, 'mailed' => 0,
+            'memberships_added' => 0,
         ];
 
         // A scoped run ($onlyMsgid or $withinPolyWkt) targets a chosen subset of posts (controlled/area
@@ -369,9 +370,95 @@ class ExpandService
                     // best-effort; never affect the expander
                 }
             }
+
+            // The poster becomes a member of every group their post has rippled into, exactly
+            // as if they had posted there directly. Backfills any rippled-in group they're not
+            // yet on (idempotent), so it also catches posts rippled before this existed.
+            $this->addPosterMembershipToRippledGroups($msgid, $stats);
         } catch (\Throwable $e) {
             $stats['errors']++;
             Log::warning("ripple: ripple-into-groups failed for msg {$msgid}: {$e->getMessage()}");
+        }
+    }
+
+    /**
+     * Add the poster as a member of every group their post has rippled into, exactly as if
+     * they had posted there directly: role Member, collection Approved. Email settings are
+     * copied from the poster's membership on their home/origin group (the earliest-arrival
+     * group on the message where they're already a member) rather than the system default,
+     * so a rippled-in membership behaves like their existing ones. Existing memberships —
+     * including a Banned row — are left untouched (INSERT IGNORE on the unique userid+groupid
+     * key, and the NOT EXISTS guard). Mirrors V1 User::addMembership, including the
+     * memberships_history row used by abuse detection. Best-effort: never breaks the expander.
+     */
+    private function addPosterMembershipToRippledGroups(int $msgid, array &$stats): void
+    {
+        try {
+            $msg = DB::table('messages')->where('id', $msgid)->first(['fromuser']);
+            $posterId = $msg->fromuser ?? null;
+            if (!$posterId) {
+                return;
+            }
+
+            // Email settings = the poster's settings on their home group: the earliest-arrival
+            // group on this message where they're already a member. Fall back to the same
+            // defaults addMembership uses if (unexpectedly) no such membership exists.
+            $home = DB::selectOne(
+                'SELECT m.emailfrequency, m.eventsallowed, m.volunteeringallowed
+                 FROM messages_groups mg
+                 JOIN memberships m ON m.groupid = mg.groupid AND m.userid = ?
+                 WHERE mg.msgid = ?
+                 ORDER BY mg.arrival ASC
+                 LIMIT 1',
+                [$posterId, $msgid]
+            );
+            $emailfrequency = $home->emailfrequency ?? 24;
+            $eventsallowed = $home->eventsallowed ?? 1;
+            $volunteeringallowed = $home->volunteeringallowed ?? 1;
+
+            // Groups this post has rippled into where the poster has no membership row yet.
+            $targets = DB::select(
+                'SELECT mg.groupid
+                 FROM messages_groups mg
+                 WHERE mg.msgid = ? AND mg.rippled_in = 1
+                   AND NOT EXISTS (
+                       SELECT 1 FROM memberships m WHERE m.userid = ? AND m.groupid = mg.groupid
+                   )',
+                [$msgid, $posterId]
+            );
+
+            foreach ($targets as $t) {
+                $added = DB::affectingStatement(
+                    "INSERT IGNORE INTO memberships
+                        (userid, groupid, role, collection, emailfrequency, eventsallowed, volunteeringallowed, added)
+                     VALUES (?, ?, 'Member', 'Approved', ?, ?, ?, NOW())",
+                    [$posterId, $t->groupid, $emailfrequency, $eventsallowed, $volunteeringallowed]
+                );
+                if ($added > 0) {
+                    $stats['memberships_added'] = ($stats['memberships_added'] ?? 0) + 1;
+                    DB::statement(
+                        "INSERT INTO memberships_history (userid, groupid, collection, processingrequired)
+                         VALUES (?, ?, 'Approved', 1)",
+                        [$posterId, $t->groupid]
+                    );
+                    // Log the join with a rippling-specific reason. V1 addMembership logs a
+                    // Group/Joined entry whose text is 'Manual' (clicked join) or 'Auto'; we use
+                    // 'Rippled' so the modlog - and MembershipsProcessingService, which reads
+                    // Group/Joined logs - can tell a rippled-in auto-join apart from those.
+                    // byuser is NULL: the system joined them off their post rippling in, no actor.
+                    DB::table('logs')->insert([
+                        'timestamp' => now(),
+                        'type' => 'Group',
+                        'subtype' => 'Joined',
+                        'user' => $posterId,
+                        'byuser' => null,
+                        'groupid' => $t->groupid,
+                        'text' => 'Rippled',
+                    ]);
+                }
+            }
+        } catch (\Throwable $e) {
+            Log::warning("ripple: add-poster-membership failed for msg {$msgid}: {$e->getMessage()}");
         }
     }
 

--- a/iznik-batch/app/Services/Ripple/ExpandService.php
+++ b/iznik-batch/app/Services/Ripple/ExpandService.php
@@ -46,7 +46,7 @@ class ExpandService
         $stats = [
             'initialized' => 0, 'expanded' => 0, 'completed' => 0,
             'removed' => 0, 'skipped' => 0, 'errors' => 0, 'rippled_in' => 0, 'mailed' => 0,
-            'memberships_added' => 0,
+            'memberships_added' => 0, 'pulled_on_leave' => 0,
         ];
 
         // A scoped run ($onlyMsgid or $withinPolyWkt) targets a chosen subset of posts (controlled/area
@@ -66,6 +66,9 @@ class ExpandService
         if (!$scoped) {
             // 1. Drop reach for posts that have left the browsable set (taken/withdrawn).
             $stats['removed'] = $this->removeStale($dryRun);
+            // 1b. Pull rippled-in posts from any group whose poster has actively left it, so a
+            //     leave removes the poster's post from that group (not just their membership).
+            $this->pullRippledPostsFromLeftGroups($dryRun, $stats);
         }
 
         // 2. Initialise reach for posts new to messages_spatial.
@@ -354,6 +357,11 @@ class ExpandService
                    AND ST_Intersects(g.polyindex, ST_GeomFromText(?, " . self::SRID . "))
                    AND NOT EXISTS (
                        SELECT 1 FROM messages_groups mg WHERE mg.msgid = ? AND mg.groupid = g.id
+                   )
+                   AND NOT EXISTS (
+                       SELECT 1 FROM logs l
+                       WHERE l.user = m.fromuser AND l.groupid = g.id
+                         AND l.type = 'Group' AND l.subtype = 'Left'
                    )",
                 [$msgid, $msgid, $reachWkt, $msgid]
             );
@@ -382,14 +390,15 @@ class ExpandService
     }
 
     /**
-     * Add the poster as a member of every group their post has rippled into, exactly as if
-     * they had posted there directly: role Member, collection Approved. Email settings are
-     * copied from the poster's membership on their home/origin group (the earliest-arrival
-     * group on the message where they're already a member) rather than the system default,
-     * so a rippled-in membership behaves like their existing ones. Existing memberships —
-     * including a Banned row — are left untouched (INSERT IGNORE on the unique userid+groupid
-     * key, and the NOT EXISTS guard). Mirrors V1 User::addMembership, including the
-     * memberships_history row used by abuse detection. Best-effort: never breaks the expander.
+     * Add the poster as a member of every group their post has rippled into (role Member,
+     * collection Approved), marked rippled=1. Email settings come from the poster's home/origin
+     * group membership, except immediate (-1) is downgraded to daily (24) so an unrequested
+     * membership never starts a flood of immediate mail (a no-email 0 or daily 24 home setting is
+     * preserved). Existing memberships - including a Banned row - are left untouched (INSERT IGNORE
+     * + NOT EXISTS), and a group the poster has actively LEFT is never re-joined (Group/Left guard).
+     * Writes a memberships_history row (rippled=1) so abuse detection still runs while the per-group
+     * welcome is suppressed, and sends one bundled intro email per post. Best-effort: never breaks
+     * the expander.
      */
     private function addPosterMembershipToRippledGroups(int $msgid, array &$stats): void
     {
@@ -412,39 +421,61 @@ class ExpandService
                  LIMIT 1',
                 [$posterId, $msgid]
             );
-            $emailfrequency = $home->emailfrequency ?? 24;
+            // Email frequency: preserve the poster's home-group setting, but DOWNGRADE ONLY
+            // immediate (-1) to daily (24). A rippled-into group is a lower-priority, unrequested
+            // membership, so we never start a flood of immediate emails from it - but we also never
+            // silently start emailing a no-email (0) member, nor change a daily (24) member. Events
+            // and volunteering are copied verbatim: they are one-email-per-user roundups with their
+            // own cadence guard, so leaving them at the home setting adds no extra emails.
+            $homeFreq = $home->emailfrequency ?? 24;
+            $emailfrequency = ((int) $homeFreq === -1) ? 24 : $homeFreq;
             $eventsallowed = $home->eventsallowed ?? 1;
             $volunteeringallowed = $home->volunteeringallowed ?? 1;
 
-            // Groups this post has rippled into where the poster has no membership row yet.
+            // Groups this post has rippled into where the poster has no membership row yet AND
+            // which the poster has not actively LEFT. A Group/Left log (self-leave, mod-remove,
+            // unban, partner-remove) is a durable "do not put me back here" signal: rippling must
+            // never re-join a group the poster chose to leave. (The post itself is also pulled from
+            // such groups by pullRippledPostsFromLeftGroups; here we only gate the membership.)
             $targets = DB::select(
-                'SELECT mg.groupid
+                "SELECT mg.groupid
                  FROM messages_groups mg
                  WHERE mg.msgid = ? AND mg.rippled_in = 1
                    AND NOT EXISTS (
                        SELECT 1 FROM memberships m WHERE m.userid = ? AND m.groupid = mg.groupid
-                   )',
-                [$msgid, $posterId]
+                   )
+                   AND NOT EXISTS (
+                       SELECT 1 FROM logs l
+                       WHERE l.user = ? AND l.groupid = mg.groupid
+                         AND l.type = 'Group' AND l.subtype = 'Left'
+                   )",
+                [$msgid, $posterId, $posterId]
             );
 
+            $addedThisCall = 0;
             foreach ($targets as $t) {
                 $added = DB::affectingStatement(
                     "INSERT IGNORE INTO memberships
-                        (userid, groupid, role, collection, emailfrequency, eventsallowed, volunteeringallowed, added)
-                     VALUES (?, ?, 'Member', 'Approved', ?, ?, ?, NOW())",
+                        (userid, groupid, role, collection, emailfrequency, eventsallowed, volunteeringallowed, rippled, added)
+                     VALUES (?, ?, 'Member', 'Approved', ?, ?, ?, 1, NOW())",
                     [$posterId, $t->groupid, $emailfrequency, $eventsallowed, $volunteeringallowed]
                 );
                 if ($added > 0) {
+                    $addedThisCall++;
                     $stats['memberships_added'] = ($stats['memberships_added'] ?? 0) + 1;
+                    // memberships_history with rippled=1: abuse detection still runs (processingrequired=1),
+                    // but MembershipsProcessingService reads rippled to SUPPRESS the per-group welcome -
+                    // a single bundled intro email (RippleIntroMail) is sent below instead.
                     DB::statement(
-                        "INSERT INTO memberships_history (userid, groupid, collection, processingrequired)
-                         VALUES (?, ?, 'Approved', 1)",
+                        "INSERT INTO memberships_history (userid, groupid, collection, processingrequired, rippled)
+                         VALUES (?, ?, 'Approved', 1, 1)",
                         [$posterId, $t->groupid]
                     );
                     // Log the join with a rippling-specific reason. V1 addMembership logs a
                     // Group/Joined entry whose text is 'Manual' (clicked join) or 'Auto'; we use
                     // 'Rippled' so the modlog - and MembershipsProcessingService, which reads
-                    // Group/Joined logs - can tell a rippled-in auto-join apart from those.
+                    // Group/Joined logs - can tell a rippled-in auto-join apart from those (and the
+                    // 'seen on many groups' spam check excludes text='Rippled').
                     // byuser is NULL: the system joined them off their post rippling in, no actor.
                     DB::table('logs')->insert([
                         'timestamp' => now(),
@@ -457,8 +488,122 @@ class ExpandService
                     ]);
                 }
             }
+
+            // One bundled intro email per post, the first time the poster is actually auto-joined
+            // anywhere off this post. Explains what happened, the email defaults we applied, and how
+            // to change them. Replaces the per-group welcome storm (suppressed above).
+            if ($addedThisCall > 0) {
+                $this->maybeSendRippleIntro($posterId, $msgid);
+            }
         } catch (\Throwable $e) {
             Log::warning("ripple: add-poster-membership failed for msg {$msgid}: {$e->getMessage()}");
+        }
+    }
+
+    /**
+     * Send the bundled "your post is reaching nearby communities" intro email at most once per
+     * post. Claims the send atomically via rippling_reach.ripple_intro_sent (0 -> 1) so it fires
+     * exactly once no matter how many ticks/groups the post ripples into. Best-effort: a spool
+     * failure never breaks the expander (the spooler has its own durable retry).
+     */
+    private function maybeSendRippleIntro(int $posterId, int $msgid): void
+    {
+        // Atomic claim: only the run that flips 0 -> 1 gets to send. No row (e.g. backfill path)
+        // => nothing to claim here => no send (the backfill command sends those).
+        $claimed = DB::affectingStatement(
+            'UPDATE rippling_reach SET ripple_intro_sent = 1 WHERE msgid = ? AND ripple_intro_sent = 0',
+            [$msgid]
+        );
+        if ($claimed < 1) {
+            return;
+        }
+
+        try {
+            $user = \App\Models\User::find($posterId);
+            if (!$user || !$user->email_preferred) {
+                return;
+            }
+            $message = \App\Models\Message::find($msgid);
+
+            // Each rippled-into community's own welcome text (groups.welcomemail), so the one
+            // bundled intro carries what each community wanted to say - instead of a separate
+            // per-group welcome email (which MembershipsProcessingService suppresses for rippled
+            // joins). Limited to the rippled groups the poster is now a member of that have a
+            // welcome configured and are live here.
+            $welcomeGroups = array_map(
+                static fn ($r) => ['name' => $r->name, 'welcome' => $r->welcome],
+                DB::select(
+                    "SELECT COALESCE(g.namefull, g.nameshort) AS name, g.welcomemail AS welcome
+                     FROM messages_groups mg
+                     JOIN `groups` g ON g.id = mg.groupid
+                     JOIN memberships m ON m.groupid = g.id AND m.userid = ?
+                     WHERE mg.msgid = ? AND mg.rippled_in = 1 AND m.rippled = 1
+                       AND g.onhere = 1 AND g.welcomemail IS NOT NULL AND g.welcomemail <> ''
+                     ORDER BY mg.arrival ASC",
+                    [$posterId, $msgid]
+                )
+            );
+
+            app(\App\Services\EmailSpoolerService::class)
+                ->spool(new \App\Mail\Ripple\RippleIntroMail($user, $message, $welcomeGroups));
+        } catch (\Throwable $e) {
+            Log::warning("ripple: intro email failed for msg {$msgid}: {$e->getMessage()}");
+        }
+    }
+
+    /**
+     * Leaving a group the post rippled into also pulls the POST from that group (the product
+     * decision: a leave means "I want nothing to do with this group", not just "stop my
+     * membership"). Soft-deletes (deleted=1) every rippled-in messages_groups row whose post's
+     * author has a Group/Left log for that group, and audits each removal with a Message/Deleted
+     * log. Idempotent (only touches deleted=0 rows); the membership re-join and any future
+     * re-ripple are separately blocked by the Group/Left guard. Best-effort: never breaks the run.
+     */
+    private function pullRippledPostsFromLeftGroups(bool $dryRun, array &$stats): void
+    {
+        try {
+            $rows = DB::select(
+                "SELECT mg.msgid, mg.groupid, m.fromuser
+                 FROM messages_groups mg
+                 JOIN messages m ON m.id = mg.msgid
+                 JOIN logs l ON l.user = m.fromuser AND l.groupid = mg.groupid
+                              AND l.type = 'Group' AND l.subtype = 'Left'
+                 WHERE mg.rippled_in = 1 AND mg.deleted = 0
+                 GROUP BY mg.msgid, mg.groupid, m.fromuser"
+            );
+
+            if (empty($rows)) {
+                return;
+            }
+
+            if ($dryRun) {
+                $stats['pulled_on_leave'] += count($rows);
+                return;
+            }
+
+            foreach ($rows as $r) {
+                $n = DB::affectingStatement(
+                    'UPDATE messages_groups SET deleted = 1
+                     WHERE msgid = ? AND groupid = ? AND rippled_in = 1 AND deleted = 0',
+                    [$r->msgid, $r->groupid]
+                );
+                if ($n > 0) {
+                    DB::table('logs')->insert([
+                        'timestamp' => now(),
+                        'type' => 'Message',
+                        'subtype' => 'Deleted',
+                        'user' => $r->fromuser,
+                        'byuser' => null,
+                        'groupid' => $r->groupid,
+                        'msgid' => $r->msgid,
+                        'text' => 'Rippling: removed on leave',
+                    ]);
+                    $stats['pulled_on_leave']++;
+                }
+            }
+        } catch (\Throwable $e) {
+            $stats['errors']++;
+            Log::warning("ripple: pull-on-leave failed: {$e->getMessage()}");
         }
     }
 

--- a/iznik-batch/app/Services/Ripple/RippleMembershipBackfillService.php
+++ b/iznik-batch/app/Services/Ripple/RippleMembershipBackfillService.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace App\Services\Ripple;
+
+use App\Mail\Ripple\RippleIntroMail;
+use App\Models\User;
+use App\Services\EmailSpoolerService;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Backfill the Rippling Out auto-join mitigations onto members who were auto-joined BEFORE those
+ * mitigations existed (their memberships carry a Group/Joined text='Rippled' provenance log but
+ * rippled=0 and possibly an un-downgraded emailfrequency, and they never got the intro email).
+ *
+ * Per user, idempotently:
+ *  - mark every rippled membership rippled=1,
+ *  - apply the live email policy (downgrade only immediate -1 -> daily 24; preserve everything else),
+ *  - send the one bundled intro email once (tracked by a User/Mailed text='RippleIntro' log so a
+ *    re-run never re-sends).
+ *
+ * Dry-run (default) computes the same counts but writes nothing and sends nothing.
+ */
+class RippleMembershipBackfillService
+{
+    /**
+     * @return array{users:int,memberships:int,downgraded:int,flagged:int,intros:int}
+     */
+    public function backfill(?int $userId, int $limit, bool $send): array
+    {
+        $stats = ['users' => 0, 'memberships' => 0, 'downgraded' => 0, 'flagged' => 0, 'intros' => 0];
+
+        // Distinct users who have a rippled membership, identified by its durable provenance log.
+        $userIds = DB::table('memberships as m')
+            ->join('logs as l', function ($j) {
+                $j->on('l.user', '=', 'm.userid')
+                    ->on('l.groupid', '=', 'm.groupid')
+                    ->where('l.type', 'Group')
+                    ->where('l.subtype', 'Joined')
+                    ->where('l.text', 'Rippled');
+            })
+            ->when($userId !== null, fn ($q) => $q->where('m.userid', $userId))
+            ->distinct()
+            ->orderBy('m.userid')
+            ->when($limit > 0, fn ($q) => $q->limit($limit))
+            ->pluck('m.userid');
+
+        foreach ($userIds as $uid) {
+            $memberships = DB::table('memberships as m')
+                ->join('logs as l', function ($j) {
+                    $j->on('l.user', '=', 'm.userid')
+                        ->on('l.groupid', '=', 'm.groupid')
+                        ->where('l.type', 'Group')
+                        ->where('l.subtype', 'Joined')
+                        ->where('l.text', 'Rippled');
+                })
+                ->where('m.userid', $uid)
+                ->select('m.id', 'm.emailfrequency', 'm.rippled')
+                ->distinct()
+                ->get();
+
+            if ($memberships->isEmpty()) {
+                continue;
+            }
+            $stats['users']++;
+
+            foreach ($memberships as $mem) {
+                $stats['memberships']++;
+                $currentFreq = (int) $mem->emailfrequency;
+                $newFreq = ($currentFreq === -1) ? 24 : $currentFreq;
+                $needsFlag = !$mem->rippled;
+                $needsDowngrade = $newFreq !== $currentFreq;
+
+                if ($needsFlag) {
+                    $stats['flagged']++;
+                }
+                if ($needsDowngrade) {
+                    $stats['downgraded']++;
+                }
+
+                if ($send && ($needsFlag || $needsDowngrade)) {
+                    DB::table('memberships')->where('id', $mem->id)->update([
+                        'rippled' => 1,
+                        'emailfrequency' => $newFreq,
+                    ]);
+                }
+            }
+
+            // One intro email per user, once ever (marker log keeps re-runs idempotent).
+            $alreadySent = DB::table('logs')
+                ->where('user', $uid)->where('type', 'User')
+                ->where('subtype', 'Mailed')->where('text', 'RippleIntro')
+                ->exists();
+
+            if (!$alreadySent) {
+                $user = User::find($uid);
+                if ($user && $user->email_preferred) {
+                    $stats['intros']++;
+                    if ($send) {
+                        $this->sendIntro($user);
+                    }
+                }
+            }
+        }
+
+        return $stats;
+    }
+
+    private function sendIntro(User $user): void
+    {
+        // Claim first (write the once-marker) so a transient render/spool failure can never cause a
+        // re-send on the next run; the spool itself has its own durable retry.
+        DB::table('logs')->insert([
+            'timestamp' => now(),
+            'type' => 'User',
+            'subtype' => 'Mailed',
+            'user' => $user->id,
+            'text' => 'RippleIntro',
+        ]);
+
+        try {
+            app(EmailSpoolerService::class)->spool(new RippleIntroMail($user));
+        } catch (\Throwable $e) {
+            Log::warning("ripple backfill: intro email failed for user {$user->id}: {$e->getMessage()}");
+        }
+    }
+}

--- a/iznik-batch/app/Services/UserDataExportService.php
+++ b/iznik-batch/app/Services/UserDataExportService.php
@@ -443,6 +443,10 @@ class UserDataExportService
             ->join('messages_groups', 'messages.id', '=', 'messages_groups.msgid')
             ->join('groups', 'messages_groups.groupid', '=', 'groups.id')
             ->where('messages.fromuser', $userId)
+            // Exclude Rippling Out copies (messages_groups.rippled_in = 1): the post is reported
+            // once via its origin group rather than once per group it rippled into, so the export
+            // does not look like deliberate cross-posting.
+            ->where('messages_groups.rippled_in', 0)
             ->select(
                 'messages.id',
                 'messages.subject',

--- a/iznik-batch/database/migrations/2026_06_23_000010_add_rippled_to_memberships.php
+++ b/iznik-batch/database/migrations/2026_06_23_000010_add_rippled_to_memberships.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * memberships.rippled - marks a membership that was auto-created because the user's post
+ * rippled into that group (Rippling Out, PR #855 mitigations). Lets consuming queries that
+ * have no other suppressible flag treat ripple-added memberships differently from real ones:
+ * BirthdayService excludes them (no birthday email "from" a group the user never knowingly
+ * joined), and the backfill command identifies them.
+ *
+ * NOT NULL DEFAULT 0 so every existing/real membership reads as 0 (not rippled). Trailing/
+ * positioned bool -> INSTANT add in MySQL 8.
+ */
+return new class extends Migration {
+    public function up(): void
+    {
+        if (!Schema::hasColumn('memberships', 'rippled')) {
+            Schema::table('memberships', function (Blueprint $t) {
+                $t->boolean('rippled')->default(false)->after('volunteeringallowed');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasColumn('memberships', 'rippled')) {
+            Schema::table('memberships', function (Blueprint $t) {
+                $t->dropColumn('rippled');
+            });
+        }
+    }
+};

--- a/iznik-batch/database/migrations/2026_06_23_000010_add_rippled_to_memberships_migration.sql
+++ b/iznik-batch/database/migrations/2026_06_23_000010_add_rippled_to_memberships_migration.sql
@@ -1,0 +1,10 @@
+-- Production idempotent SQL: memberships.rippled (Rippling Out auto-join mitigations, PR #855).
+-- Marks a membership auto-created by a post rippling into that group, so BirthdayService can
+-- exclude it and the backfill command can find it. NOT NULL DEFAULT 0 -> every real membership
+-- reads as not-rippled. Trailing/positioned bool -> INSTANT add in MySQL 8.
+SET @col_exists := (SELECT COUNT(*) FROM information_schema.columns
+    WHERE table_schema = DATABASE() AND table_name = 'memberships' AND column_name = 'rippled');
+SET @ddl := IF(@col_exists = 0,
+    'ALTER TABLE memberships ADD COLUMN rippled TINYINT(1) NOT NULL DEFAULT 0 AFTER volunteeringallowed',
+    'SELECT 1');
+PREPARE stmt FROM @ddl; EXECUTE stmt; DEALLOCATE PREPARE stmt;

--- a/iznik-batch/database/migrations/2026_06_23_000011_add_rippled_to_memberships_history.php
+++ b/iznik-batch/database/migrations/2026_06_23_000011_add_rippled_to_memberships_history.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * memberships_history.rippled - marks the history row written for a ripple auto-join (Rippling
+ * Out, PR #855). MembershipsProcessingService reads this to SUPPRESS the per-group welcome email
+ * for rippled joins (a single bundled intro email is sent instead). The history row still has
+ * processingrequired=1 so abuse detection still runs; only the welcome is suppressed. Flagging
+ * the history row (not the membership) is robust: the membership could be deleted by the time the
+ * async processing runs.
+ *
+ * NOT NULL DEFAULT 0 -> existing rows read as not-rippled. Trailing bool -> INSTANT add in MySQL 8.
+ */
+return new class extends Migration {
+    public function up(): void
+    {
+        if (!Schema::hasColumn('memberships_history', 'rippled')) {
+            Schema::table('memberships_history', function (Blueprint $t) {
+                $t->boolean('rippled')->default(false)->after('processingrequired');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasColumn('memberships_history', 'rippled')) {
+            Schema::table('memberships_history', function (Blueprint $t) {
+                $t->dropColumn('rippled');
+            });
+        }
+    }
+};

--- a/iznik-batch/database/migrations/2026_06_23_000011_add_rippled_to_memberships_history_migration.sql
+++ b/iznik-batch/database/migrations/2026_06_23_000011_add_rippled_to_memberships_history_migration.sql
@@ -1,0 +1,11 @@
+-- Production idempotent SQL: memberships_history.rippled (Rippling Out auto-join mitigations, PR #855).
+-- Marks the history row of a ripple auto-join so MembershipsProcessingService suppresses the
+-- per-group welcome email (a single bundled intro email is sent instead). The row keeps
+-- processingrequired=1 so abuse detection still runs. NOT NULL DEFAULT 0 -> existing rows read as
+-- not-rippled. Trailing/positioned bool -> INSTANT add in MySQL 8.
+SET @col_exists := (SELECT COUNT(*) FROM information_schema.columns
+    WHERE table_schema = DATABASE() AND table_name = 'memberships_history' AND column_name = 'rippled');
+SET @ddl := IF(@col_exists = 0,
+    'ALTER TABLE memberships_history ADD COLUMN rippled TINYINT(1) NOT NULL DEFAULT 0 AFTER processingrequired',
+    'SELECT 1');
+PREPARE stmt FROM @ddl; EXECUTE stmt; DEALLOCATE PREPARE stmt;

--- a/iznik-batch/database/migrations/2026_06_23_000012_add_ripple_intro_sent_to_rippling_reach.php
+++ b/iznik-batch/database/migrations/2026_06_23_000012_add_ripple_intro_sent_to_rippling_reach.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * rippling_reach.ripple_intro_sent - one-shot guard so the bundled "your post is reaching nearby
+ * communities" intro email (RippleIntroMail) is sent at most once per post, no matter how many
+ * ticks/groups the post ripples into (Rippling Out, PR #855). rippling_reach already has exactly
+ * one row per rippling post, so it is the natural place to track per-post send state.
+ *
+ * NOT NULL DEFAULT 0 -> existing reach rows read as not-yet-sent (the backfill command sends the
+ * intro for already-rippled posters and stamps this). Trailing bool -> INSTANT add in MySQL 8.
+ */
+return new class extends Migration {
+    public function up(): void
+    {
+        if (!Schema::hasColumn('rippling_reach', 'ripple_intro_sent')) {
+            Schema::table('rippling_reach', function (Blueprint $t) {
+                // No AFTER: appended at the end so this does not depend on a specific column's
+                // position (the dev-DB-only reach_arm column is not created by any migration).
+                $t->boolean('ripple_intro_sent')->default(false);
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasColumn('rippling_reach', 'ripple_intro_sent')) {
+            Schema::table('rippling_reach', function (Blueprint $t) {
+                $t->dropColumn('ripple_intro_sent');
+            });
+        }
+    }
+};

--- a/iznik-batch/database/migrations/2026_06_23_000012_add_ripple_intro_sent_to_rippling_reach_migration.sql
+++ b/iznik-batch/database/migrations/2026_06_23_000012_add_ripple_intro_sent_to_rippling_reach_migration.sql
@@ -1,0 +1,11 @@
+-- Production idempotent SQL: rippling_reach.ripple_intro_sent (Rippling Out auto-join mitigations, PR #855).
+-- One-shot guard so the bundled intro email (RippleIntroMail) is sent at most once per post,
+-- regardless of how many ticks/groups the post ripples into. rippling_reach has one row per
+-- rippling post. NOT NULL DEFAULT 0 -> existing rows read as not-yet-sent. Trailing/positioned
+-- bool -> INSTANT add in MySQL 8.
+SET @col_exists := (SELECT COUNT(*) FROM information_schema.columns
+    WHERE table_schema = DATABASE() AND table_name = 'rippling_reach' AND column_name = 'ripple_intro_sent');
+SET @ddl := IF(@col_exists = 0,
+    'ALTER TABLE rippling_reach ADD COLUMN ripple_intro_sent TINYINT(1) NOT NULL DEFAULT 0',
+    'SELECT 1');
+PREPARE stmt FROM @ddl; EXECUTE stmt; DEALLOCATE PREPARE stmt;

--- a/iznik-batch/database/migrations/2026_06_23_000013_add_ripple_leave_guard_index_to_logs.php
+++ b/iznik-batch/database/migrations/2026_06_23_000013_add_ripple_leave_guard_index_to_logs.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * logs(user, groupid, type, subtype) composite index - makes the Rippling Out "did this user
+ * leave this group?" guard a point-lookup (PR #855). The ripple expander must not re-join (or
+ * re-ripple a post into) a group the poster has actively left, which it detects via a
+ * Group/Left log row; without this index that NOT EXISTS sub-select would scan.
+ *
+ * Index-only, high-cardinality on (user, groupid). On the large production logs table this is an
+ * online ADD INDEX (ALGORITHM=INPLACE, LOCK=NONE in MySQL 8). Idempotent: guarded on
+ * information_schema so a re-run is a no-op.
+ */
+return new class extends Migration {
+    public function up(): void
+    {
+        $exists = DB::selectOne(
+            "SELECT COUNT(*) AS n FROM information_schema.statistics
+             WHERE table_schema = DATABASE() AND table_name = 'logs' AND index_name = 'ripple_leave_guard'"
+        );
+        if ((int) ($exists->n ?? 0) === 0) {
+            DB::statement('ALTER TABLE logs ADD INDEX ripple_leave_guard (user, groupid, type, subtype)');
+        }
+    }
+
+    public function down(): void
+    {
+        $exists = DB::selectOne(
+            "SELECT COUNT(*) AS n FROM information_schema.statistics
+             WHERE table_schema = DATABASE() AND table_name = 'logs' AND index_name = 'ripple_leave_guard'"
+        );
+        if ((int) ($exists->n ?? 0) > 0) {
+            DB::statement('ALTER TABLE logs DROP INDEX ripple_leave_guard');
+        }
+    }
+};

--- a/iznik-batch/database/migrations/2026_06_23_000013_add_ripple_leave_guard_index_to_logs_migration.sql
+++ b/iznik-batch/database/migrations/2026_06_23_000013_add_ripple_leave_guard_index_to_logs_migration.sql
@@ -1,0 +1,10 @@
+-- Production idempotent SQL: logs(user, groupid, type, subtype) index (Rippling Out, PR #855).
+-- Makes the "has this user left this group?" guard (a Group/Left log lookup) a point-lookup so
+-- the ripple expander never re-joins, or re-ripples a post into, a group the poster left.
+-- Online ADD INDEX in MySQL 8 (ALGORITHM=INPLACE, LOCK=NONE). Guarded so a re-run is a no-op.
+SET @idx_exists := (SELECT COUNT(*) FROM information_schema.statistics
+    WHERE table_schema = DATABASE() AND table_name = 'logs' AND index_name = 'ripple_leave_guard');
+SET @ddl := IF(@idx_exists = 0,
+    'ALTER TABLE logs ADD INDEX ripple_leave_guard (user, groupid, type, subtype), ALGORITHM=INPLACE, LOCK=NONE',
+    'SELECT 1');
+PREPARE stmt FROM @ddl; EXECUTE stmt; DEALLOCATE PREPARE stmt;

--- a/iznik-batch/resources/views/emails/mjml/ripple/intro.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/ripple/intro.blade.php
@@ -1,0 +1,111 @@
+<mjml>
+  @include('emails.mjml.partials.head', [
+    'preview' => 'Your post is reaching more people on ' . config('freegle.branding.name')
+  ])
+  <mj-body background-color="#ffffff">
+
+    {{-- Header --}}
+    <mj-section mj-class="bg-success" padding="10px 0">
+      <mj-column width="65%" vertical-align="middle">
+        <mj-text font-size="18px" font-weight="bold" color="#ffffff" padding="0 25px">
+          Your post is reaching more people
+        </mj-text>
+      </mj-column>
+      <mj-column width="35%" vertical-align="middle">
+        <mj-image
+          width="80px"
+          src="{{ config('freegle.branding.logo_url', config('freegle.logo_url', 'https://www.ilovefreegle.org/icon.png')) }}"
+          alt="{{ config('freegle.branding.name') }}"
+          align="right"
+          padding="0 20px"
+        />
+      </mj-column>
+    </mj-section>
+
+    {{-- Body --}}
+    <mj-section background-color="#F7F6EC" padding="20px 0">
+      <mj-column>
+        <mj-text font-size="14px" color="#000000" line-height="1.6" padding="10px 25px">
+          @if(!empty($firstName))Hi {{ $firstName }},@else Hi,@endif
+        </mj-text>
+        <mj-text font-size="14px" color="#000000" line-height="1.6" padding="6px 25px">
+          Good news - your recent {{ config('freegle.branding.name') }} post is being shown to
+          nearby communities beyond your own, so even more people can take what you're offering
+          or help with what you're looking for.
+        </mj-text>
+        <mj-text font-size="15px" font-weight="bold" color="#338808" line-height="1.6" padding="6px 25px">
+          There's nothing you need to do - this just helps your post reach the right person.
+        </mj-text>
+        <mj-text font-size="14px" color="#000000" line-height="1.6" padding="6px 25px">
+          So this works smoothly, we've added you to those communities - just as if you'd posted
+          there yourself. That way people there can reply to you, and our volunteers can reach you
+          about your post if they need to.
+        </mj-text>
+
+        <mj-text font-size="14px" font-weight="bold" color="#000000" line-height="1.6" padding="14px 25px 4px 25px">
+          We've kept things calm for you
+        </mj-text>
+        <mj-text font-size="14px" color="#000000" line-height="1.6" padding="0 25px">
+          <ul>
+            <li>Posts from those communities come in your <strong>once-a-day digest</strong>, not as
+              they happen - so your inbox won't fill up.</li>
+            <li>Your community events and volunteering emails stay <strong>exactly as you set them</strong>.</li>
+          </ul>
+        </mj-text>
+
+        <mj-text font-size="14px" font-weight="bold" color="#000000" line-height="1.6" padding="14px 25px 4px 25px">
+          You're in control
+        </mj-text>
+        <mj-text font-size="14px" color="#000000" line-height="1.6" padding="0 25px">
+          <ul>
+            <li>Change how often each community emails you any time in your
+              <a href="{{ $settingsUrl }}">settings</a>.</li>
+            <li>Leave any community you'd rather not be in - and we won't add you back. Leaving also
+              removes your post from that community.</li>
+          </ul>
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+    {{-- Each community's own welcome message, so the poster still sees what each one wanted to
+         say - bundled here instead of as a separate welcome email per community. --}}
+    @if(!empty($welcomeGroups))
+    <mj-section background-color="#ffffff" padding="6px 0 0 0">
+      <mj-column>
+        <mj-text font-size="15px" font-weight="bold" color="#000000" line-height="1.6" padding="10px 25px 4px 25px">
+          A welcome from the communities your post reached
+        </mj-text>
+      </mj-column>
+    </mj-section>
+    @foreach($welcomeGroups as $wg)
+    <mj-section background-color="#F7F6EC" padding="6px 0" border-radius="4px">
+      <mj-column>
+        <mj-text font-size="14px" font-weight="bold" color="#338808" line-height="1.5" padding="8px 25px 2px 25px">
+          {{ $wg['name'] }}
+        </mj-text>
+        <mj-text font-size="13px" color="#000000" line-height="1.6" padding="0 25px 8px 25px">
+          {!! nl2br(e($wg['welcome'])) !!}
+        </mj-text>
+      </mj-column>
+    </mj-section>
+    @endforeach
+    @endif
+
+    {{-- CTA --}}
+    <mj-section background-color="#ffffff" padding="20px">
+      <mj-column>
+        <mj-button href="{{ $settingsUrl }}" mj-class="btn-success" font-size="14px" padding="12px 25px">
+          Your email settings
+        </mj-button>
+      </mj-column>
+    </mj-section>
+
+    {{-- Footer --}}
+    @include('emails.mjml.partials.footer', [
+      'email' => $email,
+      'settingsUrl' => $settingsUrl,
+      'unsubscribeUrl' => $unsubscribeUrl,
+    ])
+
+  </mj-body>
+</mjml>

--- a/iznik-batch/resources/views/emails/text/ripple/intro.blade.php
+++ b/iznik-batch/resources/views/emails/text/ripple/intro.blade.php
@@ -1,0 +1,28 @@
+@if(!empty($firstName))Hi {{ $firstName }},@else Hi,@endif
+
+Good news - your recent {{ config('freegle.branding.name') }} post is being shown to nearby communities beyond your own, so even more people can take what you're offering or help with what you're looking for.
+
+THERE'S NOTHING YOU NEED TO DO - this just helps your post reach the right person.
+
+So this works smoothly, we've added you to those communities - just as if you'd posted there yourself. That way people there can reply to you, and our volunteers can reach you about your post if they need to.
+
+WE'VE KEPT THINGS CALM FOR YOU
+- Posts from those communities come in your once-a-day digest, not as they happen - so your inbox won't fill up.
+- Your community events and volunteering emails stay exactly as you set them.
+
+YOU'RE IN CONTROL
+- Change how often each community emails you any time in your settings: {{ $settingsUrl }}
+- Leave any community you'd rather not be in - and we won't add you back. Leaving also removes your post from that community.
+@if(!empty($welcomeGroups))
+
+A WELCOME FROM THE COMMUNITIES YOUR POST REACHED
+@foreach($welcomeGroups as $wg)
+== {{ $wg['name'] }} ==
+{{ $wg['welcome'] }}
+@endforeach
+@endif
+
+--
+This email was sent to {{ $email }}
+Change your email settings: {{ $settingsUrl }}
+Unsubscribe: {{ $unsubscribeUrl }}

--- a/iznik-batch/tests/Unit/Mail/Ripple/RippleIntroMailTest.php
+++ b/iznik-batch/tests/Unit/Mail/Ripple/RippleIntroMailTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\Unit\Mail\Ripple;
+
+use App\Mail\Ripple\RippleIntroMail;
+use Tests\TestCase;
+
+class RippleIntroMailTest extends TestCase
+{
+    public function test_can_be_constructed_with_user(): void
+    {
+        $user = $this->createTestUser();
+        $mail = new RippleIntroMail($user);
+
+        $this->assertInstanceOf(RippleIntroMail::class, $mail);
+        $this->assertSame($user->id, $mail->user->id);
+        $this->assertNull($mail->message);
+    }
+
+    public function test_from_is_the_freegle_noreply_address_not_a_group(): void
+    {
+        $user = $this->createTestUser();
+        $envelope = (new RippleIntroMail($user))->envelope();
+
+        $this->assertNotNull($envelope->from);
+        $this->assertSame(config('freegle.mail.noreply_addr'), $envelope->from->address);
+    }
+
+    public function test_subject_is_about_reaching_more_people(): void
+    {
+        $user = $this->createTestUser();
+        $envelope = (new RippleIntroMail($user))->envelope();
+
+        $this->assertStringContainsString('reaching more people', $envelope->subject);
+    }
+
+    public function test_build_renders_and_sets_recipient(): void
+    {
+        $user = $this->createTestUser();
+        $this->createTestUserEmail($user);
+
+        $mail = new RippleIntroMail($user);
+        $result = $mail->build();
+
+        $this->assertInstanceOf(RippleIntroMail::class, $result);
+        $this->assertContains($user->email_preferred, array_column($mail->to, 'address'));
+    }
+
+    public function test_carries_per_community_welcome_text_and_builds(): void
+    {
+        $user = $this->createTestUser();
+        $this->createTestUserEmail($user);
+
+        $groups = [
+            ['name' => 'Freegle Testown', 'welcome' => "Welcome to Testown!\nPlease be kind."],
+            ['name' => 'Freegle Exampleford', 'welcome' => 'Hi and welcome.'],
+        ];
+        $mail = new RippleIntroMail($user, null, $groups);
+
+        $this->assertSame($groups, $mail->welcomeGroups);
+        // Builds (renders the welcome section) without error.
+        $this->assertInstanceOf(RippleIntroMail::class, $mail->build());
+    }
+}

--- a/iznik-batch/tests/Unit/Services/BirthdayServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/BirthdayServiceTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Services\BirthdayService;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class BirthdayServiceTest extends TestCase
+{
+    /**
+     * A Rippling Out auto-join (memberships.rippled = 1) must never make the member a birthday-
+     * appeal recipient - the appeal would appear to come "from" a community they never knowingly
+     * joined. Only the genuine member is counted.
+     */
+    public function test_rippled_members_are_excluded_from_birthday_appeals(): void
+    {
+        $service = new BirthdayService();
+
+        // A group whose birthday is today (founded same month-day, a year ago).
+        $group = $this->createTestGroup();
+        DB::table('groups')->where('id', $group->id)->update([
+            'type' => 'Freegle',
+            'publish' => 1,
+            'onmap' => 1,
+            'founded' => now()->subYear()->format('Y-m-d H:i:s'),
+        ]);
+
+        $genuine = $this->makeBirthdayRecipient();
+        $rippled = $this->makeBirthdayRecipient();
+
+        // Genuine member (rippled=0) and a rippled auto-join (rippled=1).
+        DB::table('memberships')->insert([
+            'userid' => $genuine->id, 'groupid' => $group->id,
+            'role' => 'Member', 'collection' => 'Approved', 'rippled' => 0, 'added' => now(),
+        ]);
+        DB::table('memberships')->insert([
+            'userid' => $rippled->id, 'groupid' => $group->id,
+            'role' => 'Member', 'collection' => 'Approved', 'rippled' => 1, 'added' => now(),
+        ]);
+
+        $count = $service->sendBirthdayEmails(null, [$group->id], dryRun: true);
+
+        $this->assertSame(1, $count, 'only the genuine member receives the birthday appeal');
+    }
+
+    /** A user who passes every birthday gate: consenting, active, contactable, no recent appeal. */
+    private function makeBirthdayRecipient(): object
+    {
+        $user = $this->createTestUser();
+        $this->createTestUserEmail($user);
+        DB::table('users')->where('id', $user->id)->update([
+            'marketingconsent' => 1,
+            'bouncing' => 0,
+            'deleted' => null,
+            'onholidaytill' => null,
+            'lastaccess' => now(),
+            'settings' => json_encode(['notifications' => ['email' => true]]),
+        ]);
+
+        return $user;
+    }
+}

--- a/iznik-batch/tests/Unit/Services/MembershipsProcessingServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/MembershipsProcessingServiceTest.php
@@ -132,6 +132,32 @@ class MembershipsProcessingServiceTest extends TestCase
         Mail::assertNotSent(GroupWelcomeMail::class);
     }
 
+    public function test_does_not_send_per_group_welcome_for_a_rippled_join(): void
+    {
+        // Rippling Out auto-joins (memberships_history.rippled = 1) get NO per-group welcome -
+        // a single bundled intro email is sent by the ripple expander instead.
+        $user = $this->createTestUser();
+        $this->createTestUserEmail($user);
+        $group = $this->createTestGroup(['welcomemail' => 'Welcome to our group! Please be nice.']);
+        DB::table('groups')->where('id', $group->id)->update(['onhere' => 1]);
+
+        DB::table('memberships_history')->insert([
+            'userid' => $user->id,
+            'groupid' => $group->id,
+            'collection' => 'Approved',
+            'processingrequired' => 1,
+            'rippled' => 1,
+        ]);
+
+        $this->service->processAll();
+
+        Mail::assertNotSent(GroupWelcomeMail::class);
+
+        // The entry is still processed (abuse detection runs), only the welcome is suppressed.
+        $entry = DB::table('memberships_history')->where('userid', $user->id)->where('groupid', $group->id)->first();
+        $this->assertEquals(0, (int) $entry->processingrequired, 'rippled entry still marked processed');
+    }
+
     // --- Flagged mod comments ---
 
     public function test_flags_member_for_review_when_flagged_comment_exists(): void
@@ -258,6 +284,53 @@ class MembershipsProcessingServiceTest extends TestCase
             DB::table('logs')->where('user', $user->id)
                 ->where('type', 'User')->where('subtype', 'Suspect')->exists(),
             'a User/Suspect log should be written'
+        );
+    }
+
+    public function test_rippled_joins_do_not_count_toward_seen_on_many_groups(): void
+    {
+        // A single far-reaching post can ripple the poster into dozens of groups (Group/Joined
+        // text='Rippled'). Those must NOT count toward "seen on many groups", or the poster would
+        // be flagged for review everywhere off one popular post.
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+
+        DB::table('memberships')->insertOrIgnore([
+            'userid' => $user->id,
+            'groupid' => $group->id,
+            'collection' => 'Approved',
+        ]);
+
+        // 40 rippling joins - well over the threshold IF they counted, but they must be excluded.
+        for ($i = 0; $i < 40; $i++) {
+            DB::table('logs')->insert([
+                'type' => 'Group',
+                'subtype' => 'Joined',
+                'user' => $user->id,
+                'groupid' => 900000 + $i,
+                'text' => 'Rippled',
+                'timestamp' => now()->subDays(30),
+            ]);
+        }
+
+        // The just-added group is itself a rippled join.
+        DB::table('memberships_history')->insert([
+            'userid' => $user->id,
+            'groupid' => $group->id,
+            'collection' => 'Approved',
+            'processingrequired' => 1,
+            'rippled' => 1,
+        ]);
+
+        $this->service->processAll();
+
+        $membership = DB::table('memberships')
+            ->where('userid', $user->id)->where('groupid', $group->id)->first();
+        $this->assertNull($membership->reviewrequestedat ?? null, 'rippled joins must not trip the spam flag');
+        $this->assertFalse(
+            DB::table('logs')->where('user', $user->id)
+                ->where('type', 'User')->where('subtype', 'Suspect')->exists(),
+            'no User/Suspect log for a poster whose joins are all rippled'
         );
     }
 

--- a/iznik-batch/tests/Unit/Services/Ripple/ExpandServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/Ripple/ExpandServiceTest.php
@@ -704,4 +704,89 @@ class ExpandServiceTest extends TestCase
             'post with empty tnpostid is inserted into the intersecting group'
         );
     }
+
+    public function test_poster_is_added_as_member_of_rippled_into_group_with_home_email_settings(): void
+    {
+        // When a post ripples into a new group the poster becomes a member of it, exactly as
+        // if they had posted there directly (Member / Approved), with email settings copied
+        // from their home (origin) group rather than the system default.
+        $this->fakeRouting(3);
+        $msgid = $this->seedSpatialPost(now()->subMinutes(30));
+        $posterId = (int) DB::table('messages')->where('id', $msgid)->value('fromuser');
+        $originGid = (int) DB::table('messages_groups')->where('msgid', $msgid)->value('groupid');
+
+        // Home-group membership with NON-default email settings, to prove they're copied.
+        DB::table('memberships')->insert([
+            'userid' => $posterId, 'groupid' => $originGid, 'role' => 'Member',
+            'collection' => 'Approved', 'emailfrequency' => -1, 'eventsallowed' => 0,
+            'volunteeringallowed' => 0, 'added' => now(),
+        ]);
+
+        // Group B: area intersects the fake reach.
+        $groupB = $this->createTestGroup();
+        DB::statement(
+            "UPDATE `groups` SET publish = 1, polyindex = ST_GeomFromText(?, ?) WHERE id = ?",
+            ['POLYGON((-0.18 51.52,-0.12 51.52,-0.12 51.58,-0.18 51.58,-0.18 51.52))', 3857, $groupB->id]
+        );
+
+        $stats = $this->service()->process(false, 500);
+
+        // Post rippled into B...
+        $this->assertNotNull(
+            DB::table('messages_groups')->where('msgid', $msgid)->where('groupid', $groupB->id)->first(),
+            'post rippled into group B'
+        );
+
+        // ...and the poster is now a Member/Approved of B with the home group's email settings.
+        $m = DB::table('memberships')->where('userid', $posterId)->where('groupid', $groupB->id)->first();
+        $this->assertNotNull($m, 'poster added as a member of the rippled-into group');
+        $this->assertSame('Member', $m->role);
+        $this->assertSame('Approved', $m->collection);
+        $this->assertSame(-1, (int) $m->emailfrequency, 'emailfrequency copied from home group');
+        $this->assertSame(0, (int) $m->eventsallowed, 'eventsallowed copied from home group');
+        $this->assertSame(0, (int) $m->volunteeringallowed, 'volunteeringallowed copied from home group');
+        $this->assertGreaterThanOrEqual(1, $stats['memberships_added']);
+
+        // memberships_history row written (abuse detection), as addMembership does.
+        $this->assertGreaterThanOrEqual(
+            1,
+            DB::table('memberships_history')->where('userid', $posterId)->where('groupid', $groupB->id)->count(),
+            'memberships_history row recorded for the new membership'
+        );
+
+        // A Group/Joined log is written with the rippling-specific reason, so the join is
+        // audited and distinguishable from a button click ('Manual') or other auto-join ('Auto').
+        $this->assertDatabaseHas('logs', [
+            'type' => 'Group',
+            'subtype' => 'Joined',
+            'user' => $posterId,
+            'groupid' => $groupB->id,
+            'text' => 'Rippled',
+        ]);
+    }
+
+    public function test_rippling_does_not_overwrite_an_existing_banned_membership(): void
+    {
+        // A poster already Banned on a group the post ripples into must stay Banned — we
+        // never silently convert a ban into a normal membership.
+        $this->fakeRouting(3);
+        $msgid = $this->seedSpatialPost(now()->subMinutes(30));
+        $posterId = (int) DB::table('messages')->where('id', $msgid)->value('fromuser');
+
+        $groupB = $this->createTestGroup();
+        DB::statement(
+            "UPDATE `groups` SET publish = 1, polyindex = ST_GeomFromText(?, ?) WHERE id = ?",
+            ['POLYGON((-0.18 51.52,-0.12 51.52,-0.12 51.58,-0.18 51.58,-0.18 51.52))', 3857, $groupB->id]
+        );
+
+        DB::table('memberships')->insert([
+            'userid' => $posterId, 'groupid' => $groupB->id, 'role' => 'Member',
+            'collection' => 'Banned', 'added' => now(),
+        ]);
+
+        $this->service()->process(false, 500);
+
+        $m = DB::table('memberships')->where('userid', $posterId)->where('groupid', $groupB->id)->first();
+        $this->assertSame('Banned', $m->collection, 'existing banned membership left untouched');
+    }
 }

--- a/iznik-batch/tests/Unit/Services/Ripple/ExpandServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/Ripple/ExpandServiceTest.php
@@ -705,17 +705,19 @@ class ExpandServiceTest extends TestCase
         );
     }
 
-    public function test_poster_is_added_as_member_of_rippled_into_group_with_home_email_settings(): void
+    public function test_poster_is_added_as_member_of_rippled_into_group_immediate_downgraded_to_daily(): void
     {
-        // When a post ripples into a new group the poster becomes a member of it, exactly as
-        // if they had posted there directly (Member / Approved), with email settings copied
-        // from their home (origin) group rather than the system default.
+        // When a post ripples into a new group the poster becomes a member of it (Member /
+        // Approved, rippled=1). Email settings follow the home group EXCEPT immediate (-1) is
+        // downgraded to daily (24) so an unrequested membership never floods the inbox; events
+        // and volunteering are copied verbatim.
         $this->fakeRouting(3);
         $msgid = $this->seedSpatialPost(now()->subMinutes(30));
         $posterId = (int) DB::table('messages')->where('id', $msgid)->value('fromuser');
         $originGid = (int) DB::table('messages_groups')->where('msgid', $msgid)->value('groupid');
 
-        // Home-group membership with NON-default email settings, to prove they're copied.
+        // Home-group membership on IMMEDIATE with events/volunteering off, to prove the downgrade
+        // (-1 -> 24) and the verbatim copy of events/volunteering.
         DB::table('memberships')->insert([
             'userid' => $posterId, 'groupid' => $originGid, 'role' => 'Member',
             'collection' => 'Approved', 'emailfrequency' => -1, 'eventsallowed' => 0,
@@ -737,21 +739,29 @@ class ExpandServiceTest extends TestCase
             'post rippled into group B'
         );
 
-        // ...and the poster is now a Member/Approved of B with the home group's email settings.
+        // ...and the poster is now a Member/Approved of B, marked rippled, with immediate downgraded
+        // to daily and events/volunteering copied from home.
         $m = DB::table('memberships')->where('userid', $posterId)->where('groupid', $groupB->id)->first();
         $this->assertNotNull($m, 'poster added as a member of the rippled-into group');
         $this->assertSame('Member', $m->role);
         $this->assertSame('Approved', $m->collection);
-        $this->assertSame(-1, (int) $m->emailfrequency, 'emailfrequency copied from home group');
+        $this->assertSame(24, (int) $m->emailfrequency, 'immediate (-1) downgraded to daily (24)');
         $this->assertSame(0, (int) $m->eventsallowed, 'eventsallowed copied from home group');
         $this->assertSame(0, (int) $m->volunteeringallowed, 'volunteeringallowed copied from home group');
+        $this->assertSame(1, (int) $m->rippled, 'rippled membership marked rippled=1');
         $this->assertGreaterThanOrEqual(1, $stats['memberships_added']);
 
-        // memberships_history row written (abuse detection), as addMembership does.
-        $this->assertGreaterThanOrEqual(
+        // memberships_history row written (abuse detection) with rippled=1 (welcome suppression).
+        $hist = DB::table('memberships_history')->where('userid', $posterId)->where('groupid', $groupB->id)->first();
+        $this->assertNotNull($hist, 'memberships_history row recorded for the new membership');
+        $this->assertSame(1, (int) $hist->rippled, 'history row marked rippled=1 to suppress the per-group welcome');
+        $this->assertSame(1, (int) $hist->processingrequired, 'history row still requires processing for abuse detection');
+
+        // The intro email is claimed exactly once for the post.
+        $this->assertSame(
             1,
-            DB::table('memberships_history')->where('userid', $posterId)->where('groupid', $groupB->id)->count(),
-            'memberships_history row recorded for the new membership'
+            (int) DB::table('rippling_reach')->where('msgid', $msgid)->value('ripple_intro_sent'),
+            'bundled intro email claimed once for the post'
         );
 
         // A Group/Joined log is written with the rippling-specific reason, so the join is
@@ -788,5 +798,175 @@ class ExpandServiceTest extends TestCase
 
         $m = DB::table('memberships')->where('userid', $posterId)->where('groupid', $groupB->id)->first();
         $this->assertSame('Banned', $m->collection, 'existing banned membership left untouched');
+    }
+
+    /** A no-email home setting (0) is preserved on the rippled membership - never forced to daily. */
+    public function test_no_email_home_setting_is_preserved_on_rippled_membership(): void
+    {
+        $this->fakeRouting(3);
+        $msgid = $this->seedSpatialPost(now()->subMinutes(30));
+        $posterId = (int) DB::table('messages')->where('id', $msgid)->value('fromuser');
+        $originGid = (int) DB::table('messages_groups')->where('msgid', $msgid)->value('groupid');
+
+        // Home membership on NO email (emailfrequency 0).
+        DB::table('memberships')->insert([
+            'userid' => $posterId, 'groupid' => $originGid, 'role' => 'Member',
+            'collection' => 'Approved', 'emailfrequency' => 0, 'eventsallowed' => 1,
+            'volunteeringallowed' => 1, 'added' => now(),
+        ]);
+
+        $groupB = $this->createTestGroup();
+        DB::statement(
+            "UPDATE `groups` SET publish = 1, polyindex = ST_GeomFromText(?, ?) WHERE id = ?",
+            ['POLYGON((-0.18 51.52,-0.12 51.52,-0.12 51.58,-0.18 51.58,-0.18 51.52))', 3857, $groupB->id]
+        );
+
+        $this->service()->process(false, 500);
+
+        $m = DB::table('memberships')->where('userid', $posterId)->where('groupid', $groupB->id)->first();
+        $this->assertNotNull($m, 'poster added as member of rippled-into group');
+        $this->assertSame(0, (int) $m->emailfrequency, 'no-email (0) home setting preserved, not forced to daily');
+    }
+
+    /**
+     * A poster who has actively LEFT a group (Group/Left log) is never re-joined AND their post is
+     * never (re-)rippled into that group - rippling must not override an explicit departure.
+     */
+    public function test_left_group_is_not_rejoined_and_post_not_rippled_in(): void
+    {
+        $this->fakeRouting(3);
+        $msgid = $this->seedSpatialPost(now()->subMinutes(30));
+        $posterId = (int) DB::table('messages')->where('id', $msgid)->value('fromuser');
+
+        $groupB = $this->createTestGroup();
+        DB::statement(
+            "UPDATE `groups` SET publish = 1, polyindex = ST_GeomFromText(?, ?) WHERE id = ?",
+            ['POLYGON((-0.18 51.52,-0.12 51.52,-0.12 51.58,-0.18 51.58,-0.18 51.52))', 3857, $groupB->id]
+        );
+
+        // The poster previously left group B (any reason writes Group/Left).
+        DB::table('logs')->insert([
+            'timestamp' => now()->subDay(), 'type' => 'Group', 'subtype' => 'Left',
+            'user' => $posterId, 'groupid' => $groupB->id,
+        ]);
+
+        $this->service()->process(false, 500);
+
+        $this->assertNull(
+            DB::table('memberships')->where('userid', $posterId)->where('groupid', $groupB->id)->first(),
+            'poster who left B is not re-joined by rippling'
+        );
+        $this->assertNull(
+            DB::table('messages_groups')->where('msgid', $msgid)->where('groupid', $groupB->id)->first(),
+            'post is not rippled into a group the poster has left'
+        );
+    }
+
+    /** Leaving a group the post rippled into pulls the post from that group (soft-delete + log). */
+    public function test_leaving_a_rippled_group_pulls_the_post(): void
+    {
+        $this->fakeRouting(3);
+        $msgid = $this->seedSpatialPost(now()->subMinutes(30));
+        $posterId = (int) DB::table('messages')->where('id', $msgid)->value('fromuser');
+
+        $groupB = $this->createTestGroup();
+        DB::statement(
+            "UPDATE `groups` SET publish = 1, polyindex = ST_GeomFromText(?, ?) WHERE id = ?",
+            ['POLYGON((-0.18 51.52,-0.12 51.52,-0.12 51.58,-0.18 51.58,-0.18 51.52))', 3857, $groupB->id]
+        );
+
+        // First run: post ripples into B, poster auto-joined.
+        $this->service()->process(false, 500);
+        $row = DB::table('messages_groups')->where('msgid', $msgid)->where('groupid', $groupB->id)->first();
+        $this->assertNotNull($row, 'post rippled into B');
+        $this->assertSame(0, (int) $row->deleted, 'rippled-in row live before leave');
+
+        // Poster leaves B (Go leave path: delete membership + Group/Left log).
+        DB::table('memberships')->where('userid', $posterId)->where('groupid', $groupB->id)->delete();
+        DB::table('logs')->insert([
+            'timestamp' => now(), 'type' => 'Group', 'subtype' => 'Left',
+            'user' => $posterId, 'groupid' => $groupB->id,
+        ]);
+
+        // Second run: reconciliation pulls the post from B.
+        $stats = $this->service()->process(false, 500);
+
+        $row = DB::table('messages_groups')->where('msgid', $msgid)->where('groupid', $groupB->id)->first();
+        $this->assertSame(1, (int) $row->deleted, 'post soft-deleted from the group the poster left');
+        $this->assertGreaterThanOrEqual(1, $stats['pulled_on_leave']);
+        $this->assertDatabaseHas('logs', [
+            'type' => 'Message', 'subtype' => 'Deleted', 'user' => $posterId,
+            'groupid' => $groupB->id, 'msgid' => $msgid, 'text' => 'Rippling: removed on leave',
+        ]);
+    }
+
+    /** The bundled intro email is claimed exactly once per post, even as more groups are added. */
+    public function test_intro_email_claimed_once_per_post_across_groups(): void
+    {
+        $this->fakeRouting(3);
+        $msgid = $this->seedSpatialPost(now()->subMinutes(30));
+        $posterId = (int) DB::table('messages')->where('id', $msgid)->value('fromuser');
+
+        $groupB = $this->createTestGroup();
+        DB::statement(
+            "UPDATE `groups` SET publish = 1, polyindex = ST_GeomFromText(?, ?) WHERE id = ?",
+            ['POLYGON((-0.18 51.52,-0.12 51.52,-0.12 51.58,-0.18 51.58,-0.18 51.52))', 3857, $groupB->id]
+        );
+
+        $this->service()->process(false, 500);
+        $this->assertSame(1, (int) DB::table('rippling_reach')->where('msgid', $msgid)->value('ripple_intro_sent'));
+
+        // A second group appears on a later tick; make the post due for a HIGHER tick (advanceDue
+        // only ripples when the target tick exceeds the current one). Back-date arrival to ~4h so
+        // tickForElapsedHours advances it past tick 1. The poster joins C but the intro must NOT
+        // be re-claimed.
+        $groupC = $this->createTestGroup();
+        DB::statement(
+            "UPDATE `groups` SET publish = 1, polyindex = ST_GeomFromText(?, ?) WHERE id = ?",
+            ['POLYGON((-0.17 51.53,-0.13 51.53,-0.13 51.57,-0.17 51.57,-0.17 51.53))', 3857, $groupC->id]
+        );
+        DB::table('rippling_reach')->where('msgid', $msgid)->update([
+            'arrival' => now()->subHours(4),
+            'next_expansion_at' => now()->subMinute(),
+            'status' => 'expanding',
+        ]);
+
+        $this->service()->process(false, 500);
+        $this->assertNotNull(
+            DB::table('memberships')->where('userid', $posterId)->where('groupid', $groupC->id)->first(),
+            'poster joined the second rippled-into group'
+        );
+        $this->assertSame(
+            1,
+            (int) DB::table('rippling_reach')->where('msgid', $msgid)->value('ripple_intro_sent'),
+            'intro stays claimed once - not re-sent when more groups are added'
+        );
+    }
+
+    /** The bundled intro email carries each rippled-into community's own welcome text. */
+    public function test_intro_email_includes_rippled_group_welcome_text(): void
+    {
+        \Illuminate\Support\Facades\Mail::fake();
+        $this->fakeRouting(3);
+        $msgid = $this->seedSpatialPost(now()->subMinutes(30));
+        $posterId = (int) DB::table('messages')->where('id', $msgid)->value('fromuser');
+        // The poster needs a usable address for the intro to be sent.
+        $this->createTestUserEmail(\App\Models\User::find($posterId));
+
+        $groupB = $this->createTestGroup();
+        DB::statement(
+            "UPDATE `groups` SET publish = 1, onhere = 1, welcomemail = ?, polyindex = ST_GeomFromText(?, ?) WHERE id = ?",
+            ['Welcome to our lovely community! Please be kind.',
+             'POLYGON((-0.18 51.52,-0.12 51.52,-0.12 51.58,-0.18 51.58,-0.18 51.52))', 3857, $groupB->id]
+        );
+
+        $this->service()->process(false, 500);
+
+        \Illuminate\Support\Facades\Mail::assertSent(\App\Mail\Ripple\RippleIntroMail::class, function ($mail) use ($posterId) {
+            return $mail->user->id === $posterId
+                && collect($mail->welcomeGroups)->contains(
+                    fn ($g) => str_contains($g['welcome'] ?? '', 'lovely community')
+                );
+        });
     }
 }

--- a/iznik-batch/tests/Unit/Services/Ripple/RippleMembershipBackfillServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/Ripple/RippleMembershipBackfillServiceTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Tests\Unit\Services\Ripple;
+
+use App\Services\Ripple\RippleMembershipBackfillService;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class RippleMembershipBackfillServiceTest extends TestCase
+{
+    private function service(): RippleMembershipBackfillService
+    {
+        return new RippleMembershipBackfillService();
+    }
+
+    /** Set up a member auto-joined BEFORE the mitigations: Rippled provenance log, rippled=0, immediate. */
+    private function seedPreMitigationRippledMember(): array
+    {
+        $user = $this->createTestUser();
+        $this->createTestUserEmail($user);
+        $group = $this->createTestGroup();
+
+        DB::table('memberships')->insert([
+            'userid' => $user->id, 'groupid' => $group->id, 'role' => 'Member',
+            'collection' => 'Approved', 'emailfrequency' => -1, 'rippled' => 0, 'added' => now(),
+        ]);
+        DB::table('logs')->insert([
+            'timestamp' => now()->subDay(), 'type' => 'Group', 'subtype' => 'Joined',
+            'user' => $user->id, 'groupid' => $group->id, 'text' => 'Rippled',
+        ]);
+
+        return [$user->id, $group->id];
+    }
+
+    public function test_dry_run_changes_nothing(): void
+    {
+        [$userId, $groupId] = $this->seedPreMitigationRippledMember();
+
+        $stats = $this->service()->backfill(null, 0, send: false);
+
+        $this->assertSame(1, $stats['users']);
+        $this->assertSame(1, $stats['flagged']);
+        $this->assertSame(1, $stats['downgraded']);
+        $this->assertSame(1, $stats['intros']);
+
+        // Nothing actually changed.
+        $m = DB::table('memberships')->where('userid', $userId)->where('groupid', $groupId)->first();
+        $this->assertSame(0, (int) $m->rippled, 'dry run does not flag');
+        $this->assertSame(-1, (int) $m->emailfrequency, 'dry run does not downgrade');
+        $this->assertFalse(
+            DB::table('logs')->where('user', $userId)->where('type', 'User')
+                ->where('subtype', 'Mailed')->where('text', 'RippleIntro')->exists(),
+            'dry run sends no intro'
+        );
+    }
+
+    public function test_send_flags_downgrades_and_sends_intro_once(): void
+    {
+        [$userId, $groupId] = $this->seedPreMitigationRippledMember();
+
+        $stats = $this->service()->backfill(null, 0, send: true);
+        $this->assertSame(1, $stats['intros']);
+
+        $m = DB::table('memberships')->where('userid', $userId)->where('groupid', $groupId)->first();
+        $this->assertSame(1, (int) $m->rippled, 'membership flagged rippled=1');
+        $this->assertSame(24, (int) $m->emailfrequency, 'immediate downgraded to daily');
+        $this->assertSame(
+            1,
+            DB::table('logs')->where('user', $userId)->where('type', 'User')
+                ->where('subtype', 'Mailed')->where('text', 'RippleIntro')->count(),
+            'one intro marker written'
+        );
+
+        // Idempotent: a second send re-flags nothing and re-sends no intro.
+        $stats2 = $this->service()->backfill(null, 0, send: true);
+        $this->assertSame(0, $stats2['intros'], 'no intro re-sent on re-run');
+        $this->assertSame(0, $stats2['flagged'], 'nothing left to flag');
+        $this->assertSame(0, $stats2['downgraded'], 'nothing left to downgrade');
+        $this->assertSame(
+            1,
+            DB::table('logs')->where('user', $userId)->where('type', 'User')
+                ->where('subtype', 'Mailed')->where('text', 'RippleIntro')->count(),
+            'still exactly one intro marker'
+        );
+    }
+
+    public function test_user_filter_restricts_scope(): void
+    {
+        [$userId1] = $this->seedPreMitigationRippledMember();
+        [$userId2] = $this->seedPreMitigationRippledMember();
+
+        $stats = $this->service()->backfill($userId1, 0, send: true);
+
+        $this->assertSame(1, $stats['users'], 'only the targeted user is processed');
+        $this->assertSame(0, (int) DB::table('memberships')->where('userid', $userId2)
+            ->value('rippled'), 'the other user is untouched');
+    }
+}

--- a/iznik-batch/tests/Unit/Services/UserDataExportServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/UserDataExportServiceTest.php
@@ -152,6 +152,43 @@ class UserDataExportServiceTest extends TestCase
         $this->assertContains($email->email, array_column($json['emails'], 'email'));
     }
 
+    public function test_rippled_post_appears_once_in_export_not_per_group(): void
+    {
+        // A post that rippled into other groups must appear ONCE in the SAR export (via its origin
+        // group), not once per group - otherwise the export looks like deliberate cross-posting.
+        $user = $this->createTestUser();
+        $this->createTestUserEmail($user);
+        $originGroup = $this->createTestGroup();
+        $rippledGroup = $this->createTestGroup();
+
+        $message = \App\Models\Message::create([
+            'type' => \App\Models\Message::TYPE_OFFER,
+            'fromuser' => $user->id,
+            'subject' => 'OFFER: a single sofa',
+            'textbody' => 'A sofa.',
+            'source' => 'Platform',
+            'date' => now(),
+            'arrival' => now(),
+        ]);
+        DB::table('messages_groups')->insert([
+            ['msgid' => $message->id, 'groupid' => $originGroup->id, 'collection' => 'Approved', 'arrival' => now(), 'rippled_in' => 0],
+            ['msgid' => $message->id, 'groupid' => $rippledGroup->id, 'collection' => 'Approved', 'arrival' => now(), 'rippled_in' => 1],
+        ]);
+
+        $exportId = DB::table('users_exports')->insertGetId([
+            'userid' => $user->id, 'tag' => 'test-tag', 'requested' => now(),
+        ]);
+
+        $this->service->processAll();
+
+        $export = DB::table('users_exports')->where('id', $exportId)->first();
+        $json = json_decode(gzinflate($export->data), true);
+
+        $rows = array_values(array_filter($json['messages'] ?? [], fn ($m) => (int) $m['id'] === (int) $message->id));
+        $this->assertCount(1, $rows, 'the rippled post appears exactly once');
+        $this->assertEquals($originGroup->id, (int) $rows[0]['groupid'], 'and via its origin group, not the rippled copy');
+    }
+
     public function test_export_contains_memberships(): void
     {
         $user = $this->createTestUser();


### PR DESCRIPTION
## Summary
When a post ripples into a new group, the poster now becomes a **Member / Approved** of that group, as if they had posted there directly - so replies, digests, and abuse tracking behave normally.

This recovers and brings up to master a complete, tested feature that was sitting as **uncommitted WIP** in a worktree on the (merged) `ripple-reach-group-union` branch - it grafts cleanly onto master's current `ExpandService`.

## What it does (`ExpandService::addPosterMembershipToRippledGroups`)
- **Idempotent** - `INSERT IGNORE` + `NOT EXISTS`; safe to re-run, and backfills posts rippled before this existed.
- **Email settings inherited** from the poster's home/origin group (earliest-arrival group they're already on), not the system default - so the rippled membership behaves like their real ones.
- **Leaves an existing Banned membership untouched** - never silently converts a ban.
- Writes a `memberships_history` row for abuse detection (V1 `addMembership` parity).
- Adds a `memberships_added` stat.

## Join provenance (per review)
Logs a `Group`/`Joined` entry with **`text = 'Rippled'`**, so the modlog - and `MembershipsProcessingService`, which reads `Group`/`Joined` logs - can distinguish a rippled-in auto-join from a button click (`'Manual'`) or other auto-join (`'Auto'`). `byuser` is NULL (system join, no actor).

## Test Plan
`ExpandServiceTest` (24 pass, 90 assertions):
- `test_poster_is_added_as_member_of_rippled_into_group_with_home_email_settings` - membership added Member/Approved with home email settings, `memberships_history` row, and the `'Rippled'` join log.
- `test_rippling_does_not_overwrite_an_existing_banned_membership` - existing Banned membership left as-is.

## Note
This is a product-visible behaviour change (posters auto-join rippled-into groups). Flagging for a merge decision rather than assuming it should ship.
---

## Side-effect mitigations (commit `d96b7558f`)

Auto-joining the poster had a family of unexpected, user-visible side effects. These are now mitigated so the feature ships tamed:

- **Email volume** - rippled memberships follow the home email frequency, but immediate (-1) is downgraded to daily (24); no-email (0) and daily (24) are preserved. Events/volunteering copied verbatim (one-per-user roundups, no extra emails).
- **Welcome storm -> one intro email** - per-group welcomes are suppressed for rippled joins (`memberships_history.rippled`), replaced by a single bundled `RippleIntroMail` per post (claimed once via `rippling_reach.ripple_intro_sent`). Sent to all posters, including no-email ones.
- **Leave is honoured** - a `Group/Left` log blocks BOTH re-joining the poster AND re-rippling the post into that group; the poster's post is pulled from a group they leave (soft-delete + `Message/Deleted` audit log).
- **Spam** - ripple-joins (`logs.text='Rippled'`) are excluded from the "seen on many groups" review flag.
- **Birthday** - rippled memberships are excluded, so no birthday appeal comes "from" a community the member never knowingly joined.
- **SAR export** - a rippled post is reported once (via its origin group), not once per group.
- **Backfill** - `ripple:backfill-memberships` (dry-run by default, `--send` to apply) flags existing rippled memberships, downgrades immediate->daily, and sends one intro per user.
- **Docs** - top-level `RIPPLING-OUT-FOR-MEMBERS.md` and `RIPPLING-OUT-FOR-MODERATORS.md`, made current.

### Schema (all instant-add)
`memberships.rippled`, `memberships_history.rippled`, `rippling_reach.ripple_intro_sent`; composite index `logs(user, groupid, type, subtype)` for the leave guard. Each migration ships an idempotent `_migration.sql`.

### Test plan
Full batch Unit+Feature suite green locally (**4377 passed**). New tests cover the email policy + immediate->daily downgrade, the leave-guard + post-pull, intro-once-per-post, welcome suppression, the spam exclusion, birthday exclusion, SAR dedup, and the backfill command.

### Copy review
The intro email copy is pending review in Mailpit: `php artisan mail:test ripple-intro --user=<id> --send-to=<you>`.

Design: `docs/superpowers/specs/2026-06-23-rippling-membership-mitigations-design.md`
