### PR TITLE
refactor(ripple): make the sysadmin rippling page decision-oriented

### DIFF
--- a/iznik-nuxt3/modtools/components/ModSysAdminRippling.vue
+++ b/iznik-nuxt3/modtools/components/ModSysAdminRippling.vue
@@ -1,9 +1,12 @@
 <template>
   <div>
-    <p class="text-muted">
-      Live counters for the rippling-out rollout: reply-blocked-by-reach, held /
-      released / taken-gone external replies, secondary-group rejections, and
-      immediate mails on expansion.
+    <p class="text-muted small mb-2">
+      <strong>How to read this:</strong> rippling is working in a group when its
+      reply rate and reuse rate step up after you switch it on - with a real
+      share of replies coming via rippling, and travel distance staying
+      sensible. If reply and reuse stay flat it isn't helping there; if distance
+      climbs with no gain, tighten the reach. Pick a date range, and a group to
+      compare places.
     </p>
 
     <ModEmailDateFilter
@@ -18,16 +21,6 @@
     </div>
     <div v-else-if="error" class="text-danger">Failed to load: {{ error }}</div>
     <div v-else>
-      <h6>Reply outcomes (headline KPIs)</h6>
-      <p class="text-muted small mb-2">
-        The rollout's goal is to turn more 0-reply posts into 1-reply posts. (1)
-        share of Offers that get a reply within 36h; (2) of replies, the share
-        that came via rippling vs existing group members (captured at reply
-        time, so a join-to-reply isn't mis-counted as a member); (3) median
-        distance from post to replier; (4) the reuse outcome - share
-        taken/received. Filter by group to compare places.
-      </p>
-
       <b-form-group
         v-if="groupOptions.length"
         label="Group:"
@@ -47,9 +40,18 @@
           </option>
         </b-form-select>
       </b-form-group>
+      <p v-else class="text-muted small fst-italic mb-2">
+        Per-group comparison appears here once groups have rippled.
+      </p>
 
-      <div class="mb-2">
-        <strong class="small">% of Offers with a reply within 36h</strong>
+      <div class="mb-3">
+        <strong class="small">Are more offers getting a reply?</strong>
+        <p class="text-muted small mb-1">
+          Share of offers that get a reply within 36h.
+          <span class="text-success fw-bold">Good:</span> trends up after
+          rippling starts. <span class="text-danger fw-bold">Bad:</span> flat -
+          rippling isn't getting posts seen here.
+        </p>
         <GChart
           v-if="replyRateChart"
           type="LineChart"
@@ -60,8 +62,15 @@
         <p v-else class="text-muted small">No data yet.</p>
       </div>
 
-      <div class="mb-2">
-        <strong class="small">% of replies that came via rippling</strong>
+      <div class="mb-3">
+        <strong class="small">How much of the lift is rippling?</strong>
+        <p class="text-muted small mb-1">
+          Share of replies that came via rippling vs your own members.
+          <span class="text-success fw-bold">Good:</span> a real share - the
+          lift is coming from reach.
+          <span class="text-danger fw-bold">Bad:</span> ~0% - reach isn't
+          producing replies.
+        </p>
         <GChart
           v-if="replySourceChart"
           type="LineChart"
@@ -76,7 +85,13 @@
       </div>
 
       <div class="mb-3">
-        <strong class="small">Median reply distance (km)</strong>
+        <strong class="small">Are repliers a sensible distance away?</strong>
+        <p class="text-muted small mb-1">
+          Median distance from a post to its replier.
+          <span class="fw-bold">Watch:</span> climbing while the reply rate
+          stays flat means you're reaching too far for no gain - tighten the
+          reach.
+        </p>
         <GChart
           v-if="replyDistanceChart"
           type="LineChart"
@@ -88,7 +103,12 @@
       </div>
 
       <div class="mb-3">
-        <strong class="small">% of posts taken/received (reuse outcome)</strong>
+        <strong class="small">Is more stuff actually being reused?</strong>
+        <p class="text-muted small mb-1">
+          Share of posts taken/received - the real outcome.
+          <span class="text-success fw-bold">Good:</span> up - rippling is
+          driving reuse. This is the number that justifies it.
+        </p>
         <GChart
           v-if="takenRateChart"
           type="LineChart"
@@ -99,33 +119,12 @@
         <p v-else class="text-muted small">No data yet.</p>
       </div>
 
-      <h6 class="mt-3">Last 30 days</h6>
-      <b-table-simple hover responsive small>
-        <b-thead>
-          <b-tr>
-            <b-th>Day</b-th>
-            <b-th>Event</b-th>
-            <b-th>Count</b-th>
-          </b-tr>
-        </b-thead>
-        <b-tbody>
-          <b-tr v-for="(r, ix) in recent" :key="ix">
-            <b-td class="text-nowrap">{{ r.day }}</b-td>
-            <b-td>
-              <code>{{ r.event }}</code>
-            </b-td>
-            <b-td>{{ r.count }}</b-td>
-          </b-tr>
-          <b-tr v-if="!recent.length">
-            <b-td colspan="3" class="text-muted">No recent events.</b-td>
-          </b-tr>
-        </b-tbody>
-      </b-table-simple>
-
-      <h6 class="mt-3">Geographic hotspots (last 30 days)</h6>
+      <h6 class="mt-4">Where to look — geographic hotspots</h6>
       <p class="text-muted small mb-1">
-        Areas whose metric is a robust outlier vs the rest of the network, so a
-        local problem the overall average hides is surfaced here.
+        Areas behaving unusually vs the rest of the network - a local problem
+        the overall average hides.
+        <span class="fw-bold">Action:</span> investigate any row flagged
+        <b-badge variant="danger">alert</b-badge>.
       </p>
       <b-table-simple hover responsive small>
         <b-thead>
@@ -154,158 +153,19 @@
             </b-td>
           </b-tr>
           <b-tr v-if="!hotspots.length">
-            <b-td colspan="6" class="text-muted">No hotspots flagged.</b-td>
-          </b-tr>
-        </b-tbody>
-      </b-table-simple>
-
-      <h6 class="mt-3">Proposed parameter changes (advisory)</h6>
-      <b-table-simple hover responsive small>
-        <b-thead>
-          <b-tr>
-            <b-th>ONS category</b-th>
-            <b-th>max_minutes</b-th>
-            <b-th>Rationale</b-th>
-            <b-th>Proposed</b-th>
-          </b-tr>
-        </b-thead>
-        <b-tbody>
-          <b-tr v-for="(p, ix) in proposedParams" :key="ix">
-            <b-td>
-              <code>{{ p.ons_category }}</code>
+            <b-td colspan="6" class="text-muted">
+              No hotspots flagged — nothing unusual to act on.
             </b-td>
-            <b-td>{{ p.max_minutes }}</b-td>
-            <b-td>{{ p.rationale }}</b-td>
-            <b-td class="text-nowrap">{{ p.proposed_at }}</b-td>
-          </b-tr>
-          <b-tr v-if="!proposedParams.length">
-            <b-td colspan="4" class="text-muted">No proposals.</b-td>
           </b-tr>
         </b-tbody>
       </b-table-simple>
 
-      <!-- §16.1/§16.2 Volume + reach: overall weekly rollup from ripple:tune -->
-      <h6 class="mt-3">Volume &amp; reach — weekly rollup (last 2 weeks)</h6>
+      <h6 class="mt-4">Reply friction — held external replies</h6>
       <p class="text-muted small mb-1">
-        Written by <code>ripple:tune</code> each week. Guard-rail band:
-        &minus;10% to +50% vs each group's own baseline (ripple-thresholds).
-        Empty until the first tune run.
-      </p>
-      <b-table-simple hover responsive small>
-        <b-thead>
-          <b-tr>
-            <b-th>Period start</b-th>
-            <b-th>Metric</b-th>
-            <b-th>Value</b-th>
-            <b-th>Sample size</b-th>
-          </b-tr>
-        </b-thead>
-        <b-tbody>
-          <b-tr v-for="(m, ix) in liveMetrics" :key="ix">
-            <b-td class="text-nowrap">{{ m.period_start }}</b-td>
-            <b-td>
-              <code>{{ m.metric }}</code>
-            </b-td>
-            <b-td>{{ m.value }}</b-td>
-            <b-td>{{ m.sample_size }}</b-td>
-          </b-tr>
-          <b-tr v-if="!liveMetrics.length">
-            <b-td colspan="4" class="text-muted">No rollup data yet.</b-td>
-          </b-tr>
-        </b-tbody>
-      </b-table-simple>
-
-      <!-- §16.3 Cross-group reach -->
-      <h6 class="mt-3">Cross-group reach (last 30 days)</h6>
-      <p class="text-muted small mb-1">
-        Fraction of post appearances that were rippled in by the engine to a
-        group the poster was not a member of, and how many of those were
-        subsequently approved.
-      </p>
-      <b-table-simple small>
-        <b-tbody>
-          <b-tr>
-            <b-th>Post appearances (total)</b-th>
-            <b-td>{{ crossGroupSummary.total }}</b-td>
-          </b-tr>
-          <b-tr>
-            <b-th>Rippled-in appearances</b-th>
-            <b-td>{{ crossGroupSummary.rippled_in }}</b-td>
-          </b-tr>
-          <b-tr>
-            <b-th>Cross-group %</b-th>
-            <b-td>{{
-              crossGroupSummary.cross_group_pct != null
-                ? crossGroupSummary.cross_group_pct.toFixed(1) + '%'
-                : '—'
-            }}</b-td>
-          </b-tr>
-          <b-tr>
-            <b-th>Approval rate (rippled-in)</b-th>
-            <b-td>{{
-              crossGroupSummary.rippled_in > 0
-                ? crossGroupSummary.approval_rate.toFixed(1) + '%'
-                : '—'
-            }}</b-td>
-          </b-tr>
-        </b-tbody>
-      </b-table-simple>
-
-      <!-- §16.4 Timing / capture from offline simulator -->
-      <h6 class="mt-3">Timing &amp; capture — latest simulator week</h6>
-      <p class="text-muted small mb-1">
-        From <code>rippling_algorithm_metrics</code> ('all' group). Capture rate
-        = repliers notified before they replied / total repliers. Empty until
-        the first simulator run.
-      </p>
-      <div v-if="captureSummary.week_start">
-        <b-table-simple small>
-          <b-tbody>
-            <b-tr>
-              <b-th>Week</b-th>
-              <b-td class="text-nowrap">{{ captureSummary.week_start }}</b-td>
-            </b-tr>
-            <b-tr>
-              <b-th>Curve</b-th>
-              <b-td>
-                <code>{{ captureSummary.curve }}</code>
-              </b-td>
-            </b-tr>
-            <b-tr>
-              <b-th>Pairs total</b-th>
-              <b-td>{{ captureSummary.pairs_total }}</b-td>
-            </b-tr>
-            <b-tr>
-              <b-th>In-time</b-th>
-              <b-td>{{ captureSummary.pairs_in_time }}</b-td>
-            </b-tr>
-            <b-tr>
-              <b-th>Late</b-th>
-              <b-td>{{ captureSummary.pairs_late }}</b-td>
-            </b-tr>
-            <b-tr>
-              <b-th>Capture rate</b-th>
-              <b-td>{{ captureSummary.capture_rate.toFixed(1) }}%</b-td>
-            </b-tr>
-            <b-tr>
-              <b-th>Reply p50</b-th>
-              <b-td>{{ captureSummary.reply_p50_hours.toFixed(1) }}h</b-td>
-            </b-tr>
-            <b-tr>
-              <b-th>Reply p75</b-th>
-              <b-td>{{ captureSummary.reply_p75_hours.toFixed(1) }}h</b-td>
-            </b-tr>
-          </b-tbody>
-        </b-table-simple>
-      </div>
-      <p v-else class="text-muted small">No simulator data yet.</p>
-
-      <!-- §15 / §16.5 Held-reply friction -->
-      <h6 class="mt-3">Held external replies — status breakdown</h6>
-      <p class="text-muted small mb-1">
-        External (email / TrashNothing) replies held because the post had not
-        yet rippled to the replier's location. Avg hold duration shown for
-        released rows.
+        Email / TrashNothing replies held because the post hadn't yet rippled to
+        the replier's location.
+        <span class="fw-bold">Action:</span> a growing held count means replies
+        are waiting - consider widening reach or shortening the hold.
       </p>
       <b-table-simple hover responsive small>
         <b-thead>
@@ -346,32 +206,12 @@ const apiInstance = api(runtimeConfig)
 
 const loading = ref(true)
 const error = ref(null)
-const recent = ref([])
 // Date range driving the headline KPI queries (set by ModEmailDateFilter).
 const startDate = ref('')
 const endDate = ref('')
+// Action surfaces kept on the page: where to look, and reply friction.
 const hotspots = ref([])
-const proposedParams = ref([])
-// §16 rollout-health metrics
-const liveMetrics = ref([])
 const heldReplySummary = ref([])
-const crossGroupSummary = ref({
-  period_days: 30,
-  rippled_in: 0,
-  total: 0,
-  cross_group_pct: 0,
-  approval_rate: 0,
-})
-const captureSummary = ref({
-  week_start: '',
-  curve: '',
-  pairs_total: 0,
-  pairs_in_time: 0,
-  pairs_late: 0,
-  capture_rate: 0,
-  reply_p50_hours: 0,
-  reply_p75_hours: 0,
-})
 // Headline reply KPIs (per-day series for the line charts)
 const replyRate = ref([])
 const replySource = ref([])
@@ -442,17 +282,8 @@ async function fetchMetrics() {
       startDate.value,
       endDate.value
     )
-    recent.value = result?.recent || []
     hotspots.value = result?.hotspots || []
-    proposedParams.value = result?.proposed_params || []
-    liveMetrics.value = result?.live_metrics || []
     heldReplySummary.value = result?.held_reply_summary || []
-    if (result?.cross_group_summary) {
-      crossGroupSummary.value = result.cross_group_summary
-    }
-    if (result?.capture_summary) {
-      captureSummary.value = result.capture_summary
-    }
     replyRate.value = result?.reply_rate_36h || []
     replySource.value = result?.reply_source_split || []
     replyDistance.value = result?.reply_distance_median || []

--- a/iznik-nuxt3/tests/unit/components/modtools/ModSysAdminRippling.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModSysAdminRippling.spec.js
@@ -57,33 +57,8 @@ describe('ModSysAdminRippling', () => {
     mockFetchMetrics.mockReset()
   })
 
-  it('renders recent rippling event rows from the metrics endpoint', async () => {
-    mockFetchMetrics.mockResolvedValue({
-      totals: [],
-      recent: [{ day: '2026-06-18', event: 'reply_blocked', count: 7 }],
-    })
-
-    const wrapper = mountComponent()
-    await flushPromises()
-
-    expect(mockFetchMetrics).toHaveBeenCalled()
-    const html = wrapper.html()
-    expect(html).toContain('reply_blocked')
-    expect(html).toContain('2026-06-18')
-    expect(html).toContain('7')
-  })
-
-  it('shows an empty state when there are no recent events', async () => {
-    mockFetchMetrics.mockResolvedValue({ totals: [], recent: [] })
-
-    const wrapper = mountComponent()
-    await flushPromises()
-
-    expect(wrapper.html()).toContain('No recent events')
-  })
-
   it('passes the selected date range to the metrics API', async () => {
-    mockFetchMetrics.mockResolvedValue({ totals: [], recent: [] })
+    mockFetchMetrics.mockResolvedValue({})
 
     const wrapper = mountComponent()
     await flushPromises()
@@ -92,14 +67,27 @@ describe('ModSysAdminRippling', () => {
     wrapper.unmount()
   })
 
-  it('renders geographic hotspots and proposed parameter changes', async () => {
+  it('renders the headline KPI questions and a chart when there is series data', async () => {
     mockFetchMetrics.mockResolvedValue({
-      totals: [],
-      recent: [],
+      reply_rate_36h: [{ day: '2026-06-18', reply_pct: 35 }],
+      taken_rate: [{ day: '2026-06-18', taken_pct: 58 }],
+    })
+
+    const wrapper = mountComponent()
+    await flushPromises()
+
+    const html = wrapper.html()
+    // Plain-English, decision-oriented headings replace the old jargon.
+    expect(html).toContain('Are more offers getting a reply?')
+    expect(html).toContain('Is more stuff actually being reused?')
+    // Charts render once their series has data.
+    expect(wrapper.findAll('.gchart').length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('renders geographic hotspots as an action surface', async () => {
+    mockFetchMetrics.mockResolvedValue({
       hotspots: [
         {
-          period_start: '2026-06-11',
-          area_type: 'group',
           area_id: 99,
           area_name: 'Anomaly Town',
           metric: 'secondary_reject_rate',
@@ -110,168 +98,37 @@ describe('ModSysAdminRippling', () => {
           severity: 'alert',
         },
       ],
-      proposed_params: [
-        {
-          ons_category: 'urban_major',
-          max_minutes: 25,
-          rationale: 'volume delta +80% outside band; propose to tighten reach',
-          proposed_at: '2026-06-18 09:00',
-        },
-      ],
     })
 
     const wrapper = mountComponent()
     await flushPromises()
 
     const html = wrapper.html()
+    expect(html).toContain('Where to look')
     expect(html).toContain('Anomaly Town')
     expect(html).toContain('secondary_reject_rate')
     expect(html).toContain('alert')
-    expect(html).toContain('urban_major')
-    expect(html).toContain('tighten reach')
   })
 
-  it('shows empty states for hotspots and proposals when there are none', async () => {
-    mockFetchMetrics.mockResolvedValue({
-      totals: [],
-      recent: [],
-      hotspots: [],
-      proposed_params: [],
-    })
+  it('shows an empty state when there are no hotspots', async () => {
+    mockFetchMetrics.mockResolvedValue({ hotspots: [] })
 
     const wrapper = mountComponent()
     await flushPromises()
 
     expect(wrapper.html()).toContain('No hotspots flagged')
-    expect(wrapper.html()).toContain('No proposals')
   })
 
-  // §16.1/§16.2 — volume & reach weekly rollup
-  describe('live_metrics section', () => {
-    it('shows "No rollup data yet" when live_metrics is empty or absent', async () => {
-      mockFetchMetrics.mockResolvedValue({ totals: [], recent: [] })
-      const wrapper = mountComponent()
-      await flushPromises()
-      expect(wrapper.html()).toContain('No rollup data yet')
-    })
-
-    it('renders live metric rows returned by the API', async () => {
-      mockFetchMetrics.mockResolvedValue({
-        totals: [],
-        recent: [],
-        live_metrics: [
-          {
-            period_start: '2026-06-16',
-            metric: 'volume_posts_p50',
-            value: 42.5,
-            sample_size: 80,
-          },
-        ],
-      })
-      const wrapper = mountComponent()
-      await flushPromises()
-      const html = wrapper.html()
-      expect(html).toContain('volume_posts_p50')
-      expect(html).toContain('42.5')
-      expect(html).toContain('2026-06-16')
-    })
-  })
-
-  // §16.3 — cross-group reach summary
-  describe('cross_group_summary section', () => {
-    it('renders the cross-group reach heading', async () => {
-      mockFetchMetrics.mockResolvedValue({ totals: [], recent: [] })
-      const wrapper = mountComponent()
-      await flushPromises()
-      expect(wrapper.html()).toContain('Cross-group reach')
-    })
-
-    it('shows the rippled-in count and cross_group_pct from the API', async () => {
-      mockFetchMetrics.mockResolvedValue({
-        totals: [],
-        recent: [],
-        cross_group_summary: {
-          period_days: 30,
-          rippled_in: 57,
-          total: 300,
-          cross_group_pct: 19.0,
-          approval_rate: 72.0,
-        },
-      })
-      const wrapper = mountComponent()
-      await flushPromises()
-      const html = wrapper.html()
-      expect(html).toContain('57')
-      expect(html).toContain('19.0%')
-    })
-
-    it('shows — for approval_rate when rippled_in is zero', async () => {
-      mockFetchMetrics.mockResolvedValue({
-        totals: [],
-        recent: [],
-        cross_group_summary: {
-          period_days: 30,
-          rippled_in: 0,
-          total: 100,
-          cross_group_pct: 0,
-          approval_rate: 0,
-        },
-      })
-      const wrapper = mountComponent()
-      await flushPromises()
-      expect(wrapper.html()).toContain('—')
-    })
-  })
-
-  // §16.4 — timing / capture from offline simulator
-  describe('capture_summary section', () => {
-    it('shows "No simulator data yet" when week_start is empty', async () => {
-      mockFetchMetrics.mockResolvedValue({ totals: [], recent: [] })
-      const wrapper = mountComponent()
-      await flushPromises()
-      expect(wrapper.html()).toContain('No simulator data yet')
-    })
-
-    it('renders capture rate and curve when data is present', async () => {
-      mockFetchMetrics.mockResolvedValue({
-        totals: [],
-        recent: [],
-        capture_summary: {
-          week_start: '2026-06-09',
-          curve: 'front-heavy',
-          pairs_total: 200,
-          pairs_in_time: 150,
-          pairs_late: 40,
-          capture_rate: 75.0,
-          reply_p50_hours: 2.5,
-          reply_p75_hours: 6.0,
-        },
-      })
-      const wrapper = mountComponent()
-      await flushPromises()
-      const html = wrapper.html()
-      expect(html).toContain('front-heavy')
-      expect(html).toContain('75.0%')
-      expect(html).toContain('2.5h')
-      expect(html).toContain('2026-06-09')
-    })
-  })
-
-  // §15/§16.5 — held-reply friction summary
   describe('held_reply_summary section', () => {
-    it('renders the held external replies heading', async () => {
-      mockFetchMetrics.mockResolvedValue({ totals: [], recent: [] })
+    it('renders the reply-friction heading', async () => {
+      mockFetchMetrics.mockResolvedValue({})
       const wrapper = mountComponent()
       await flushPromises()
-      expect(wrapper.html()).toContain('Held external replies')
+      expect(wrapper.html()).toContain('Reply friction')
     })
 
     it('shows "No held replies recorded yet" when the list is empty', async () => {
-      mockFetchMetrics.mockResolvedValue({
-        totals: [],
-        recent: [],
-        held_reply_summary: [],
-      })
+      mockFetchMetrics.mockResolvedValue({ held_reply_summary: [] })
       const wrapper = mountComponent()
       await flushPromises()
       expect(wrapper.html()).toContain('No held replies recorded yet')
@@ -279,8 +136,6 @@ describe('ModSysAdminRippling', () => {
 
     it('renders held/released rows with counts from the API', async () => {
       mockFetchMetrics.mockResolvedValue({
-        totals: [],
-        recent: [],
         held_reply_summary: [
           { status: 'held', count: 3, median_hold_hours: 0 },
           { status: 'released', count: 1, median_hold_hours: 4.2 },
@@ -293,5 +148,27 @@ describe('ModSysAdminRippling', () => {
       expect(html).toContain('released')
       expect(html).toContain('4.2')
     })
+  })
+
+  it('no longer renders the dropped absolute-number sections', async () => {
+    mockFetchMetrics.mockResolvedValue({
+      recent: [{ day: '2026-06-18', event: 'reply_blocked', count: 7 }],
+      live_metrics: [
+        { period_start: '2026-06-16', metric: 'volume_posts_p50', value: 42.5 },
+      ],
+      cross_group_summary: { rippled_in: 57, total: 300, cross_group_pct: 19 },
+      capture_summary: { week_start: '2026-06-09', curve: 'front-heavy' },
+      proposed_params: [{ ons_category: 'urban_major', max_minutes: 25 }],
+    })
+
+    const wrapper = mountComponent()
+    await flushPromises()
+
+    const html = wrapper.html()
+    expect(html).not.toContain('Last 30 days')
+    expect(html).not.toContain('Cross-group reach')
+    expect(html).not.toContain('Volume')
+    expect(html).not.toContain('simulator')
+    expect(html).not.toContain('Proposed parameter changes')
   })
 })


### PR DESCRIPTION
## Summary
The rippling sysadmin page threw numbers on screen instead of telling you what to do. This refocuses it on **what success looks like and what action to take**.

- **Top "how to read this"**: rippling is working in a group when its reply rate and reuse rate step up after you switch it on, with a real share of replies via rippling and sensible travel distance; flat = not helping; distance climbing with no gain = tighten.
- **The 4 headline KPIs stay** (relative %), each reframed with a plain-English question + Good/Bad/Watch read:
  - "Are more offers getting a reply?" (reply rate 36h)
  - "How much of the lift is rippling?" (rippling vs home-member replies)
  - "Are repliers a sensible distance away?" (median distance)
  - "Is more stuff actually being reused?" (taken/received)
- **Group filter** shows a hint when no group has rippled yet (it was just hidden before).

## Removed (absolute numbers / not actionable in the experiment phase)
Last-30-days event table, Volume & reach weekly rollup, Cross-group reach, Timing & capture (simulator), **Proposed parameter changes**.

> Note: you only named hotspots + held replies as the action surfaces to keep, so I also dropped **Proposed parameter changes** (the tuner's advisory output, empty until `ripple:tune` runs). Say if you'd rather keep it.

## Kept + reframed as action surfaces
- **Geographic hotspots** -> "Where to look" (investigate any `alert` row).
- **Held external replies** -> "Reply friction" (growing held count = widen reach / shorten hold).

## Notes
- The `/rippling/metrics` endpoint is unchanged - it still returns the dropped fields, the page just ignores them. Can trim it in a follow-up if you want a lighter payload.

## Test Plan
`ModSysAdminRippling` unit suite - 8 pass (date range passed through; KPI headings + chart render; hotspots + empty state; reply-friction heading/rows/empty; dropped sections absent).
