### PR TITLE
feat(ripple): reply-saturation stop (T1.1) - stop expanding posts with 5+ distinct repliers

### DIFF
--- a/iznik-batch/app/Services/Ripple/ExpandService.php
+++ b/iznik-batch/app/Services/Ripple/ExpandService.php
@@ -108,12 +108,14 @@ class ExpandService
         // entire historical pending backlog eligible at once. Empty config = no cutoff.
         $enabledAt = config('freegle.ripple.enabled_at');
         $cutoffSql = '';
+        $satSql = '';
         $params = [];
         $scopeSql = '';
         if ($onlyMsgid !== null) {
             // A single chosen post (controlled test) targets its msgid directly and bypasses the
-            // arrival cutoff — the chosen post may predate go-live, and selecting nothing would be
-            // a surprising no-op for an explicit one-post request.
+            // arrival cutoff AND the reply-saturation stop — the chosen post may predate go-live or
+            // already be saturated, and selecting nothing would be a surprising no-op for an
+            // explicit one-post request.
             $scopeSql = ' AND ms.msgid = ?';
             $params[] = $onlyMsgid;
         } else {
@@ -128,6 +130,15 @@ class ExpandService
                 $cutoffSql = ' AND ms.arrival >= ?';
                 $params[] = $enabledAt;
             }
+            // Reply-saturation stop (extent-governor T1.1): a post that already has >= threshold
+            // distinct repliers never starts rippling - it has enough interest without reach.
+            // 0 disables. Applies to normal and scoped (experiment) runs alike.
+            $satStop = (int) config('freegle.ripple.reply_saturation_stop', 5);
+            if ($satStop > 0) {
+                $satSql = " AND (SELECT COUNT(DISTINCT cm.userid) FROM chat_messages cm
+                                  WHERE cm.refmsgid = ms.msgid AND cm.type = 'Interested') < ?";
+                $params[] = $satStop;
+            }
         }
         $params[] = $limit;
 
@@ -138,7 +149,7 @@ class ExpandService
                     MIN(ms.arrival) AS arrival
              FROM messages_spatial ms
              LEFT JOIN rippling_reach mr ON mr.msgid = ms.msgid
-             WHERE mr.msgid IS NULL' . $scopeSql . $cutoffSql . '
+             WHERE mr.msgid IS NULL' . $scopeSql . $cutoffSql . $satSql . '
              GROUP BY ms.msgid
              LIMIT ?',
             $params
@@ -241,6 +252,24 @@ class ExpandService
                     continue;
                 }
                 $arrival = Carbon::parse($row->arrival);
+
+                // Reply-saturation stop (extent-governor T1.1): once a post has enough distinct
+                // repliers it already has plenty of interest, so stop expanding - mark it done and
+                // do not fan out further. Type-agnostic; 0 disables.
+                $satStop = (int) config('freegle.ripple.reply_saturation_stop', 5);
+                if ($satStop > 0 && $this->distinctReplierCount((int) $row->msgid) >= $satStop) {
+                    if (!$dryRun) {
+                        DB::table('rippling_reach')->where('msgid', $row->msgid)->update([
+                            'status' => 'done',
+                            'next_expansion_at' => null,
+                            'updated_at' => now(),
+                        ]);
+                    }
+                    $stats['completed']++;
+                    $this->logEvent($row->msgid, 'reply_saturated', (int) $row->tick, []);
+                    continue;
+                }
+
                 $elapsedHours = $arrival->diffInMinutes(now()) / 60.0;
                 // The post's own hazard-schedule length (stored at init), used as the ceiling
                 // for both the target tick and the 'done' transition.
@@ -547,6 +576,18 @@ class ExpandService
      * #9 observability: one structured line per expansion event. Rolled up by the
      * later metrics job; for now it makes the engine's behaviour visible in Loki.
      */
+    /**
+     * Distinct-replier count for a post: distinct users with an Interested chat reply
+     * (chat_messages.refmsgid = msgid). Drives the reply-saturation stop (extent-governor T1.1).
+     */
+    private function distinctReplierCount(int $msgid): int
+    {
+        return (int) (DB::selectOne(
+            "SELECT COUNT(DISTINCT userid) AS n FROM chat_messages WHERE refmsgid = ? AND type = 'Interested'",
+            [$msgid]
+        )->n ?? 0);
+    }
+
     private function logEvent(int|string $msgid, string $kind, int $tick, array $entry): void
     {
         Log::info('ripple:reach', [

--- a/iznik-batch/config/freegle.php
+++ b/iznik-batch/config/freegle.php
@@ -307,6 +307,13 @@ return [
         'mode' => env('RIPPLE_MODE', 'drive'),
         // Maximum drive-time (minutes) the reach may grow to.
         'max_minutes' => (float) env('RIPPLE_MAX_MINUTES', 30),
+        // Reply-saturation stop (extent-governor design T1.1): a post with at least this many
+        // DISTINCT repliers (distinct users with an Interested chat reply on the post,
+        // chat_messages.refmsgid = msgid) stops expanding - it already has plenty of interest, so
+        // further reach is wasted. Applies both at init (an already-saturated post never starts
+        // rippling) and per tick (a post that becomes saturated stops fanning out). 0 disables.
+        // 5 = the figure from the Discourse rippling thread.
+        'reply_saturation_stop' => (int) env('RIPPLE_REPLY_SATURATION_STOP', 5),
         // Hours a rippled-in (messages_groups.rippled_in=1) post, already Approved on its
         // origin group, waits before it is approved onto the rippled-in group (it was already
         // vetted on origin). Default 0 = approve AT ripple-in time, so it never even flickers

--- a/iznik-batch/tests/Unit/Services/Ripple/ExpandServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/Ripple/ExpandServiceTest.php
@@ -2,9 +2,11 @@
 
 namespace Tests\Unit\Services\Ripple;
 
+use App\Models\ChatMessage;
 use App\Models\Group;
 use App\Models\Message;
 use App\Models\MessageGroup;
+use App\Models\User;
 use App\Services\Ripple\ExpandService;
 use App\Services\Ripple\ReachService;
 use Illuminate\Support\Carbon;
@@ -703,5 +705,77 @@ class ExpandServiceTest extends TestCase
             DB::table('messages_groups')->where('msgid', $msgid)->where('groupid', $groupB->id)->first(),
             'post with empty tnpostid is inserted into the intersecting group'
         );
+    }
+
+    /** Seed $count DISTINCT users each leaving an Interested chat reply on the post. */
+    private function seedInterestedRepliers(int $msgid, int $count): void
+    {
+        $poster = User::find((int) DB::table('messages')->where('id', $msgid)->value('fromuser'));
+        for ($i = 0; $i < $count; $i++) {
+            $replier = $this->createTestUser();
+            $room = $this->createTestChatRoom($replier, $poster);
+            $this->createTestChatMessage($room, $replier, [
+                'type' => ChatMessage::TYPE_INTERESTED,
+                'refmsgid' => $msgid,
+            ]);
+        }
+    }
+
+    /**
+     * Reply-saturation stop (extent-governor T1.1): a post that already has the threshold number
+     * of distinct repliers (5) has enough interest, so it never starts rippling.
+     */
+    public function test_saturated_post_does_not_start_rippling(): void
+    {
+        $this->fakeRouting(3);
+        $msgid = $this->seedSpatialPost(now()->subMinutes(30));
+        $this->seedInterestedRepliers($msgid, 5);
+
+        $stats = $this->service()->process(false, 500);
+
+        $this->assertSame(0, $stats['initialized'], 'a post at the saturation threshold never starts rippling');
+        $this->assertSame(
+            0,
+            DB::table('rippling_reach')->where('msgid', $msgid)->count(),
+            'no rippling_reach row for an already-saturated post'
+        );
+    }
+
+    /** A post below the saturation threshold ripples normally. */
+    public function test_post_below_saturation_threshold_still_ripples(): void
+    {
+        $this->fakeRouting(3);
+        $msgid = $this->seedSpatialPost(now()->subMinutes(30));
+        $this->seedInterestedRepliers($msgid, 4);
+
+        $stats = $this->service()->process(false, 500);
+
+        $this->assertSame(1, $stats['initialized'], 'a post below the threshold ripples normally');
+    }
+
+    /** A post that crosses the saturation threshold mid-expansion stops expanding. */
+    public function test_post_that_becomes_saturated_stops_expanding(): void
+    {
+        $this->fakeRouting(3);
+        $msgid = $this->seedSpatialPost(now()->subMinutes(30));
+
+        // First pass: reach is initialised and expanding.
+        $this->service()->process(false, 500);
+        $this->assertSame(
+            'expanding',
+            DB::table('rippling_reach')->where('msgid', $msgid)->value('status'),
+            'reach is expanding before saturation'
+        );
+
+        // The post now saturates and its next tick falls due.
+        $this->seedInterestedRepliers($msgid, 5);
+        DB::table('rippling_reach')->where('msgid', $msgid)->update(['next_expansion_at' => now()->subMinute()]);
+
+        $stats = $this->service()->process(false, 500);
+
+        $row = DB::table('rippling_reach')->where('msgid', $msgid)->first();
+        $this->assertSame('done', $row->status, 'a post crossing the saturation threshold stops expanding');
+        $this->assertNull($row->next_expansion_at, 'a saturated post is not rescheduled');
+        $this->assertGreaterThanOrEqual(1, $stats['completed']);
     }
 }


### PR DESCRIPTION
## Summary
Implements **T1.1 of the extent-governor design** (`docs/superpowers/specs/2026-06-22-rippling-extent-governor-design.md`) - the **reply-saturation stop**. This was specified and live-validated but never built (the engine shipped the *rate* half / step-70 schedule; the *extent* governor was deferred). A post that already has plenty of interest shouldn't keep fanning out its reach.

## Behaviour
A post with **≥ `reply_saturation_stop` distinct repliers** (distinct users with an `Interested` chat reply, `chat_messages.refmsgid = msgid`):
- **never starts rippling** (`initialiseNew` excludes it), and
- **stops expanding mid-flight** (`advanceDue` marks the reach `done`, clears `next_expansion_at`, fans out no further).

Type-agnostic (Offers and Wanteds). Threshold is config `RIPPLE_REPLY_SATURATION_STOP` (default **5**; `0` disables). Applies to normal and scoped (experiment) runs alike; a controlled single-`msgid` test run bypasses it (same as the arrival cutoff).

Live validation in the design: of 83 currently-rippling posts, 8 already had ≥5 distinct repliers - they'd stop under this guard.

## Discourse
The `=5` figure is the community-validated "enough replies for an Offer" number: [How many replies do you need to an Offer?](https://discourse.ilovefreegle.org/t/how-many-replies-do-you-need-to-an-offer/8415)

## Test Plan
`ExpandServiceTest` (25 pass):
- `test_saturated_post_does_not_start_rippling` - a post at the threshold never initialises reach.
- `test_post_below_saturation_threshold_still_ripples` - below threshold ripples normally.
- `test_post_that_becomes_saturated_stops_expanding` - crossing the threshold mid-expansion → `done`, not rescheduled.
