### PR TITLE
fix(jobs): self-heal stale spatial jobs index after a WhatJobs swap

### DIFF
--- a/iznik-spatial-go/dataset.go
+++ b/iznik-spatial-go/dataset.go
@@ -63,6 +63,29 @@ type Dataset interface {
 	DeltaInterval() time.Duration
 }
 
+// DriftChecker is an optional interface for delta datasets whose source table
+// can change in ways the incremental delta cannot self-heal.
+//
+// The WhatJobs sync RENAME-swaps the `jobs` table, hard-DELETEing postings that
+// have closed/left the feed. The add/update-only delta (ApplyDelta keys on
+// `seenat > since`) never sees those vanished ids, so their index entries linger
+// as orphans until the next full (nightly) rebuild — leaving the server to serve
+// stale/closed jobs. In sparse areas every nearest result can be an orphan, so
+// users see no jobs at all.
+//
+// A dataset implementing this reports, on the delta cadence, when a full rebuild
+// is warranted so the orphans are cleared promptly rather than waiting up to 24h.
+type DriftChecker interface {
+	// CheckDrift inspects the source DB and the live index and returns whether a
+	// full rebuild is warranted, plus a short human-readable reason for logs.
+	CheckDrift(mysqlDB *sql.DB, idx *Index) (need bool, reason string, err error)
+
+	// NoteReconciled records that the index is now in sync with the source —
+	// called after a successful (re)build — so the next CheckDrift compares
+	// against this fresh baseline rather than re-triggering on the same change.
+	NoteReconciled(mysqlDB *sql.DB) error
+}
+
 // Item is the generic unit stored in the spatial index.
 // For polygon datasets: MinLng != MaxLng (actual envelope), WKB non-nil.
 // For point datasets: MinLng == MaxLng, MinLat == MaxLat (degenerate bbox), WKB nil.

--- a/iznik-spatial-go/dataset_drift_test.go
+++ b/iznik-spatial-go/dataset_drift_test.go
@@ -1,0 +1,247 @@
+package main
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// newFakeJobsDB returns an in-memory sqlite DB with a minimal `jobs` table
+// standing in for the production MySQL source. The drift queries
+// (CAST(MAX(seenat) AS CHAR) and COUNT over jobsLiveFilter) are portable SQL, so
+// they run identically here without needing MySQL. MaxOpenConns(1) keeps the
+// :memory: DB on a single connection (otherwise each pooled connection is a
+// distinct empty database).
+func newFakeJobsDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	require.NoError(t, err)
+	db.SetMaxOpenConns(1)
+	t.Cleanup(func() { db.Close() })
+	_, err = db.Exec(`CREATE TABLE jobs (
+		id       INTEGER PRIMARY KEY,
+		seenat   TEXT,
+		visible  INTEGER,
+		cpc      REAL,
+		geometry BLOB
+	)`)
+	require.NoError(t, err)
+	return db
+}
+
+// insertJob inserts one row into the fake jobs table. A nil geom inserts NULL.
+func insertJob(t *testing.T, db *sql.DB, id int64, seenat string, visible int, cpc float64, geom any) {
+	t.Helper()
+	_, err := db.Exec(`INSERT INTO jobs (id, seenat, visible, cpc, geometry) VALUES (?,?,?,?,?)`,
+		id, seenat, visible, cpc, geom)
+	require.NoError(t, err)
+}
+
+// indexWith returns an in-memory index seeded with the given external IDs
+// (degenerate bounding boxes — only the row count matters for drift).
+func indexWith(t *testing.T, ids ...int64) *Index {
+	t.Helper()
+	idx, err := CreateIndex(":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { idx.Close() })
+	items := make([]Item, 0, len(ids))
+	for _, id := range ids {
+		items = append(items, Item{ExtID: id})
+	}
+	require.NoError(t, InsertItems(idx, items, nil))
+	return idx
+}
+
+// A swap that closes and opens the SAME number of postings leaves the row count
+// unchanged but stamps every row with a fresh seenat. The seenat trigger catches
+// it; a bare count comparison would not. This is the headline case for choosing
+// seenat as the primary signal.
+func TestJobsDataset_CheckDrift_SeenatAdvanceOnEqualCountSwap(t *testing.T) {
+	db := newFakeJobsDB(t)
+	for _, id := range []int64{1, 2, 3} {
+		insertJob(t, db, id, "2026-06-23 10:00:00", 1, 0.12, []byte("g"))
+	}
+	d := &JobsDataset{}
+	idx := indexWith(t, 1, 2, 3)
+
+	// First call establishes the baseline and must NOT trigger (no spurious
+	// rebuild 5 minutes after startup).
+	need, _, err := d.CheckDrift(db, idx)
+	require.NoError(t, err)
+	require.False(t, need, "first call should only baseline, not trigger")
+
+	// Simulate a swap: same three ids stay, but every row gets a fresh seenat.
+	_, err = db.Exec(`UPDATE jobs SET seenat = '2026-06-23 13:00:00'`)
+	require.NoError(t, err)
+
+	need, reason, err := d.CheckDrift(db, idx)
+	require.NoError(t, err)
+	require.True(t, need, "seenat advance must trigger even when the row count is unchanged")
+	require.Contains(t, reason, "swap detected")
+
+	// After reconciling (as a rebuild would), the same state must not re-trigger.
+	require.NoError(t, d.NoteReconciled(db))
+	need, _, err = d.CheckDrift(db, idx)
+	require.NoError(t, err)
+	require.False(t, need, "no further trigger once reconciled")
+}
+
+// The count backstop fires when orphans accumulate without a seenat advance —
+// the stale-adopted-index case. seenat is held constant so only the count path
+// can trigger.
+func TestJobsDataset_CheckDrift_CountBackstop(t *testing.T) {
+	db := newFakeJobsDB(t)
+	for _, id := range []int64{1, 2, 3} {
+		insertJob(t, db, id, "2026-06-23 10:00:00", 1, 0.12, []byte("g"))
+	}
+	d := &JobsDataset{}
+
+	// Index carries the 3 live ids plus enough orphans to exceed the tolerance.
+	orphans := make([]int64, 0, driftCountTolerance+10)
+	ids := []int64{1, 2, 3}
+	for i := int64(0); i < driftCountTolerance+10; i++ {
+		ids = append(ids, 1000+i)
+		orphans = append(orphans, 1000+i)
+	}
+	idx := indexWith(t, ids...)
+
+	// First call baselines seenat; the backstop still evaluates this tick, so a
+	// stale adopted index is caught immediately.
+	need, reason, err := d.CheckDrift(db, idx)
+	require.NoError(t, err)
+	require.True(t, need, "orphan count over tolerance must trigger via the backstop")
+	require.Contains(t, reason, "drift")
+
+	// Just under the tolerance must NOT trigger.
+	d2 := &JobsDataset{}
+	few := []int64{1, 2, 3}
+	for i := int64(0); i < driftCountTolerance-1; i++ {
+		few = append(few, 2000+i)
+	}
+	idxFew := indexWith(t, few...)
+	need, _, err = d2.CheckDrift(db, idxFew)
+	require.NoError(t, err)
+	require.False(t, need, "drift within tolerance must not trigger")
+}
+
+// liveCount and the delta filter must agree with loadJobs: non-visible, sub-cpc
+// and null-geometry rows are not served and must not count toward the live set
+// (otherwise they would register as phantom drift).
+func TestJobsDataset_LiveCount_FilterAlignment(t *testing.T) {
+	db := newFakeJobsDB(t)
+	insertJob(t, db, 1, "2026-06-23 10:00:00", 1, 0.12, []byte("g")) // servable
+	insertJob(t, db, 2, "2026-06-23 10:00:00", 1, 0.12, []byte("g")) // servable
+	insertJob(t, db, 3, "2026-06-23 10:00:00", 0, 0.12, []byte("g")) // invisible
+	insertJob(t, db, 4, "2026-06-23 10:00:00", 1, 0.05, []byte("g")) // sub-cpc
+	insertJob(t, db, 5, "2026-06-23 10:00:00", 1, 0.12, nil)         // null geometry
+
+	d := &JobsDataset{}
+	n, err := d.liveCount(db)
+	require.NoError(t, err)
+	require.EqualValues(t, 2, n, "only visible, paying, geolocated rows count")
+}
+
+// An empty table yields an empty MAX(seenat); CheckDrift must not panic or
+// falsely trigger on it.
+func TestJobsDataset_CheckDrift_EmptyTable(t *testing.T) {
+	db := newFakeJobsDB(t)
+	d := &JobsDataset{}
+	idx := indexWith(t) // empty index
+	need, _, err := d.CheckDrift(db, idx)
+	require.NoError(t, err)
+	require.False(t, need)
+}
+
+// fakeDriftDataset is a minimal DriftChecker whose Load rebuilds a clean index
+// from a fixed live set, so the wiring (checkAndRebuildOnDrift -> rebuild) can be
+// exercised without MySQL.
+type fakeDriftDataset struct {
+	liveIDs []int64
+}
+
+func (f *fakeDriftDataset) Name() string { return "fakedrift" }
+func (f *fakeDriftDataset) Load(_ *sql.DB, idx *Index) error {
+	items := make([]Item, 0, len(f.liveIDs))
+	for _, id := range f.liveIDs {
+		items = append(items, Item{ExtID: id})
+	}
+	return InsertItems(idx, items, nil)
+}
+func (f *fakeDriftDataset) ApplyDelta(_ *sql.DB, _ *Index, _ time.Time) error { return nil }
+func (f *fakeDriftDataset) Query(_ *Index, _ QueryParams) ([]QueryResult, error) {
+	return nil, nil
+}
+func (f *fakeDriftDataset) Within(_ *Index, _ QueryParams) ([]int64, error) { return nil, nil }
+func (f *fakeDriftDataset) RebuildInterval() time.Duration                  { return time.Hour }
+func (f *fakeDriftDataset) DeltaInterval() time.Duration                    { return time.Minute }
+func (f *fakeDriftDataset) CheckDrift(_ *sql.DB, idx *Index) (bool, string, error) {
+	n, err := idx.CountRows()
+	if err != nil {
+		return false, "", err
+	}
+	if int(n) != len(f.liveIDs) {
+		return true, "count mismatch", nil
+	}
+	return false, "", nil
+}
+func (f *fakeDriftDataset) NoteReconciled(_ *sql.DB) error { return nil }
+
+// allExtIDs returns the external ids currently in the index, sorted ascending.
+func allExtIDs(t *testing.T, idx *Index) []int64 {
+	t.Helper()
+	rows, err := idx.db.Query(`SELECT extid FROM items ORDER BY extid`)
+	require.NoError(t, err)
+	defer rows.Close()
+	var ids []int64
+	for rows.Next() {
+		var id int64
+		require.NoError(t, rows.Scan(&id))
+		ids = append(ids, id)
+	}
+	require.NoError(t, rows.Err())
+	return ids
+}
+
+// The brief's scenario: an index holds stale ext-ids absent from the source; the
+// drift check rebuilds and the orphans are gone.
+func TestCheckAndRebuildOnDrift_ClearsOrphans(t *testing.T) {
+	dir := t.TempDir()
+	ds := &fakeDriftDataset{liveIDs: []int64{1, 2, 3}}
+	srv := newServer(nil, dir, []Dataset{ds})
+	state := srv.datasets["fakedrift"]
+
+	// Seed a live index with the 3 source ids plus 2 orphans (99, 100) that the
+	// source no longer has — the swap-leftover situation.
+	idxPath := srv.idxPath("fakedrift")
+	seed, err := CreateIndex(idxPath)
+	require.NoError(t, err)
+	require.NoError(t, InsertItems(seed, []Item{
+		{ExtID: 1}, {ExtID: 2}, {ExtID: 3}, {ExtID: 99}, {ExtID: 100},
+	}, nil))
+	require.NoError(t, seed.Checkpoint())
+	require.NoError(t, seed.Close())
+
+	live, err := OpenIndex(idxPath)
+	require.NoError(t, err)
+	state.idx = live
+
+	rebuilt := srv.checkAndRebuildOnDrift("fakedrift", state)
+	require.True(t, rebuilt, "drift (5 indexed vs 3 live) must trigger a rebuild")
+
+	n, err := state.idx.CountRows()
+	require.NoError(t, err)
+	require.EqualValues(t, 3, n)
+	require.Equal(t, []int64{1, 2, 3}, allExtIDs(t, state.idx), "orphans 99,100 must be gone")
+
+	// A second check is now clean (no rebuild).
+	require.False(t, srv.checkAndRebuildOnDrift("fakedrift", state))
+}
+
+// Datasets that don't implement DriftChecker are a no-op (e.g. locations).
+func TestCheckAndRebuildOnDrift_NonDriftDataset(t *testing.T) {
+	srv := newServer(nil, t.TempDir(), []Dataset{&LocationsDataset{}})
+	state := srv.datasets["locations"]
+	require.False(t, srv.checkAndRebuildOnDrift("locations", state))
+}

--- a/iznik-spatial-go/dataset_jobs.go
+++ b/iznik-spatial-go/dataset_jobs.go
@@ -4,13 +4,44 @@ import (
 	"database/sql"
 	"fmt"
 	"log"
+	"sync"
 	"time"
 
 	"github.com/peterstace/simplefeatures/geom"
 )
 
-// JobsDataset implements Dataset for the jobs (polygon) table.
-type JobsDataset struct{}
+// minJobsCPC is the minimum cost-per-click for a job to be servable. Kept in
+// step with the WhatJobs sync (WhatJobsService::MINIMUM_CPC) and jobsLiveFilter.
+const minJobsCPC = 0.10
+
+// jobsLiveFilter selects the rows the server actually serves: visible, paying,
+// and geolocated. Single-sourced so the full load (loadJobs) and the drift
+// live-count query stay identical; ApplyDelta applies the same predicate in Go
+// so the incremental set can never diverge from the full-load set (which would
+// otherwise make the index/table count comparison report phantom drift).
+const jobsLiveFilter = "visible = 1 AND cpc >= 0.10 AND geometry IS NOT NULL"
+
+// driftCountTolerance is how far the index row count may drift from the live
+// table before the backstop forces a rebuild. The seenat trigger already
+// rebuilds on every swap, so in steady state the drift is ~0; this backstop only
+// matters when the seenat baseline was masked — e.g. the server adopted a stale
+// on-disk index at startup (no rebuild ran to set the baseline) and orphans
+// accumulated. Small but non-zero to absorb the brief race between the COUNT and
+// CountRows reads around a concurrent swap.
+const driftCountTolerance = 100
+
+// JobsDataset implements Dataset (and DriftChecker) for the jobs (polygon) table.
+type JobsDataset struct {
+	mu sync.Mutex
+	// lastMaxSeen is CAST(MAX(seenat) AS CHAR) as of the last reconcile (build or
+	// drift-rebuild). A WhatJobs swap stamps seenat=now on every row and is the
+	// only writer of seenat, so MAX(seenat) advancing past this is an exact "a
+	// swap happened" signal. Stored as the raw textual timestamp (not time.Time)
+	// so it scans cleanly on both the MySQL driver and the sqlite test fake; the
+	// fixed "YYYY-MM-DD HH:MM:SS" format orders lexically == chronologically.
+	lastMaxSeen string
+	baselined   bool
+}
 
 func (d *JobsDataset) Name() string { return "jobs" }
 
@@ -42,9 +73,15 @@ func (d *JobsDataset) ApplyDelta(mysqlDB *sql.DB, idx *Index, since time.Time) e
 		if err := rows.Scan(&id, &wkbRaw, &title, &city, &cpc, &visible); err != nil {
 			return fmt.Errorf("scan: %w", err)
 		}
-		if visible == 0 {
+		// Remove any row that no longer meets jobsLiveFilter, not just visible=0.
+		// loadJobs (the full rebuild) excludes sub-cpc and null-geometry rows, so
+		// the delta must drop them too — otherwise a row that drops below cpc or
+		// loses its geometry while staying visible would linger in the index as a
+		// phantom and inflate the index/table drift count. ST_AsWKB(NULL geometry)
+		// scans as an empty/nil blob, so len(wkbRaw)==0 detects the null-geom case.
+		if visible == 0 || cpc < minJobsCPC || len(wkbRaw) == 0 {
 			if err := idx.DeleteByExtID(id); err != nil {
-				log.Printf("jobs delta: remove invisible id=%d: %v", id, err)
+				log.Printf("jobs delta: remove non-servable id=%d: %v", id, err)
 			}
 			removed++
 			continue
@@ -106,8 +143,7 @@ func loadJobs(mysqlDB *sql.DB, idx *Index, extraWhere string) error {
 	query := `
 		SELECT id, ST_AsWKB(geometry) AS wkb, COALESCE(title, '') AS title, COALESCE(city, '') AS city, cpc
 		FROM jobs
-		WHERE visible = 1 AND cpc >= 0.10
-		  AND geometry IS NOT NULL
+		WHERE ` + jobsLiveFilter + `
 	` + extraWhere
 
 	rows, err := mysqlDB.Query(query)
@@ -154,4 +190,108 @@ func loadJobs(mysqlDB *sql.DB, idx *Index, extraWhere string) error {
 	}
 	log.Printf("jobs load: loaded %d items (%d skipped)", len(items), skipped)
 	return InsertItems(idx, items, nil)
+}
+
+// jobsMaxSeen returns CAST(MAX(seenat) AS CHAR) — a stable textual timestamp.
+// Casting to CHAR avoids driver-specific time handling: the MySQL driver
+// (parseTime=true) returns a time.Time for a DATETIME column but the textual
+// CHAR result is a plain string, and the sqlite test fake returns the same
+// text. The empty string is returned for an empty table (MAX over no rows).
+func (d *JobsDataset) jobsMaxSeen(db *sql.DB) (string, error) {
+	var s sql.NullString
+	if err := db.QueryRow(`SELECT CAST(MAX(seenat) AS CHAR) FROM jobs`).Scan(&s); err != nil {
+		return "", err
+	}
+	return s.String, nil
+}
+
+// liveCount returns the number of rows the server would serve (the loadJobs
+// set). Compared against the index row count to detect orphan drift.
+func (d *JobsDataset) liveCount(db *sql.DB) (int64, error) {
+	var n int64
+	err := db.QueryRow(`SELECT COUNT(*) FROM jobs WHERE ` + jobsLiveFilter).Scan(&n)
+	return n, err
+}
+
+// NoteReconciled records the source's current MAX(seenat) as the baseline the
+// next CheckDrift compares against. Called after every successful (re)build so
+// startup/nightly/drift rebuilds all reset the baseline uniformly.
+func (d *JobsDataset) NoteReconciled(db *sql.DB) error {
+	max, err := d.jobsMaxSeen(db)
+	if err != nil {
+		return err
+	}
+	d.mu.Lock()
+	d.lastMaxSeen = max
+	d.baselined = true
+	d.mu.Unlock()
+	return nil
+}
+
+// CheckDrift reports whether the jobs index has drifted from the live table
+// enough to warrant a full rebuild. See DriftChecker.
+//
+// Primary signal — seenat advance: a WhatJobs swap stamps seenat=now on every
+// row and is the only writer of seenat, so MAX(seenat) advancing past the last
+// reconciled baseline means a swap happened (which hard-deleted closed postings,
+// leaving orphans the add/update-only delta can't remove). This is exact and
+// fires exactly once per swap; it even catches a swap that closes and opens
+// equal numbers of postings (identical row count, all-new seenat) — the case a
+// bare count comparison would miss.
+//
+// Backstop — count drift: abs(indexCount - liveCount) over the tolerance. Covers
+// the case the seenat baseline was masked (a stale on-disk index adopted at
+// startup without a rebuild), where orphans are present but seenat didn't move.
+//
+// On the very first call after an adopted index (no rebuild set a baseline) the
+// seenat baseline is established here and the seenat trigger is suppressed for
+// that tick; the count backstop still runs, so a stale adopted index is caught
+// immediately.
+func (d *JobsDataset) CheckDrift(db *sql.DB, idx *Index) (bool, string, error) {
+	max, err := d.jobsMaxSeen(db)
+	if err != nil {
+		return false, "", fmt.Errorf("jobs drift: max seenat: %w", err)
+	}
+	live, err := d.liveCount(db)
+	if err != nil {
+		return false, "", fmt.Errorf("jobs drift: live count: %w", err)
+	}
+	indexCount, err := idx.CountRows()
+	if err != nil {
+		return false, "", fmt.Errorf("jobs drift: index count: %w", err)
+	}
+
+	d.mu.Lock()
+	baselined := d.baselined
+	last := d.lastMaxSeen
+	if !d.baselined {
+		// Lazy baseline for an adopted index — record the current max and treat
+		// this tick's table state as the reference (no seenat trigger), leaving
+		// the count backstop below to catch a stale adopted index.
+		d.lastMaxSeen = max
+		d.baselined = true
+	}
+	d.mu.Unlock()
+
+	// Note: a seenat trigger deliberately does NOT advance the baseline here —
+	// only a successful rebuild (via NoteReconciled) does. So if a triggered
+	// rebuild fails, the next tick re-fires and retries.
+	swapped := baselined && max != "" && max > last
+
+	drift := indexCount - live
+	if drift < 0 {
+		drift = -drift
+	}
+	countDrift := drift > driftCountTolerance
+
+	switch {
+	case swapped:
+		return true, fmt.Sprintf("swap detected: seenat advanced %q -> %q (index=%d live=%d)",
+			last, max, indexCount, live), nil
+	case countDrift:
+		return true, fmt.Sprintf("index/table drift %d > tolerance %d (index=%d live=%d, seenat=%q)",
+			drift, driftCountTolerance, indexCount, live, max), nil
+	default:
+		return false, "", nil
+	}
 }

--- a/iznik-spatial-go/server.go
+++ b/iznik-spatial-go/server.go
@@ -171,8 +171,58 @@ func (srv *server) rebuild(name string) error {
 
 	state.swapIndex(live)
 	state.lastSync = time.Now()
+	// The index now matches the source as of this build. For drift-aware
+	// datasets, record that baseline so the next CheckDrift compares against the
+	// freshly-built state rather than re-triggering on the change we just healed.
+	if dc, ok := state.ds.(DriftChecker); ok {
+		if err := dc.NoteReconciled(srv.mysqlDB); err != nil {
+			log.Printf("spatial-server: %s note-reconciled failed: %v", name, err)
+		}
+	}
 	log.Printf("spatial-server: %s rebuilt in %s", name, time.Since(start).Round(time.Millisecond))
 	return nil
+}
+
+// checkAndRebuildOnDrift runs a dataset's optional drift check and, if it
+// reports the index has drifted from the source in a way the incremental delta
+// cannot self-heal (swap-style hard deletes), triggers a full rebuild. It is a
+// no-op for datasets that do not implement DriftChecker. Returns whether a
+// rebuild ran. Safe to call on every delta tick.
+func (srv *server) checkAndRebuildOnDrift(name string, state *datasetState) bool {
+	dc, ok := state.ds.(DriftChecker)
+	if !ok {
+		return false
+	}
+	// Skip if a rebuild is already running — rebuild() also guards via its
+	// atomic CAS, but checking first avoids a wasted CheckDrift and a noisy
+	// "already in progress" error.
+	if state.rebuilding.Load() {
+		return false
+	}
+
+	var need bool
+	var reason string
+	err := state.withIndex(func(idx *Index) error {
+		var e error
+		need, reason, e = dc.CheckDrift(srv.mysqlDB, idx)
+		return e
+	})
+	switch {
+	case err == errIndexNotReady:
+		return false
+	case err != nil:
+		log.Printf("spatial-server: drift check %s failed: %v", name, err)
+		return false
+	case !need:
+		return false
+	}
+
+	log.Printf("spatial-server: drift-triggered rebuild of %s: %s", name, reason)
+	if err := srv.rebuild(name); err != nil {
+		log.Printf("spatial-server: drift rebuild %s failed: %v", name, err)
+		return false
+	}
+	return true
 }
 
 // rebuildAll rebuilds all datasets.
@@ -266,6 +316,11 @@ func (srv *server) startScheduler() {
 				default:
 					s.lastSync = time.Now()
 				}
+				// After applying the delta, check whether the source table has
+				// drifted from the index in a way the delta can't self-heal
+				// (swap-style hard deletes) and rebuild if so. No-op for datasets
+				// that don't implement DriftChecker.
+				srv.checkAndRebuildOnDrift(n, s)
 			}
 		}(name, state, interval)
 	}


### PR DESCRIPTION
## Summary

- The WhatJobs sync RENAME-swaps the `jobs` table, **hard-DELETE**ing closed postings. The spatial server's add/update-only delta (`ApplyDelta` keys on `seenat > since`) never sees the vanished ids, so their index entries linger as **orphans** until the once-a-day (03:00) rebuild. In sparse areas every nearest indexed job can be an orphan, so users (e.g. Fife, reported by derek) see **zero job ads** until the nightly rebuild. The batch-side post-swap `rebuildDataset('jobs')` only rebuilds the local spatial-knn container, never the prod db1/2/3 servers - so prod must self-heal.
- This adds drift detection on the **existing 5-minute jobs cadence** that triggers a full rebuild when a swap is detected, so orphans are cleared within minutes instead of up to 24h.

## How it detects a swap

An optional `DriftChecker` interface; `JobsDataset` implements it.

- **Primary - `seenat` advance (exact):** the sync stamps `seenat = now` on **every** row on every swap and is the *only* writer of `seenat`, so `MAX(seenat)` advancing past the last reconciled baseline means a swap happened. Fires exactly once per swap. Crucially it also catches a swap that closes and opens **equal numbers** of postings (identical row count, all-new `seenat`) - the case a bare index-vs-table count comparison would miss. `seenat` is indexed, so this is an instant index-max lookup.
- **Backstop - count drift:** `abs(indexCount - liveCount) > tolerance (100)`, for the case the `seenat` baseline was masked (a stale on-disk index adopted at startup without a rebuild, where orphans exist but `seenat` didn't move).

Cost: the sync runs every 3h (08:00-22:00) + 05:00 UK = **at most 7 rebuilds/day**, each detected exactly once - trivially cheap (the nightly already rebuilds everything).

## Filter-alignment fix

`ApplyDelta` previously upserted any `visible=1` row regardless of `cpc`/`geometry`, but `loadJobs` (the full rebuild) requires `cpc >= 0.10 AND geometry IS NOT NULL`. A row that dropped below cpc or lost its geometry while staying visible would linger in the index as a phantom and inflate the drift count. `ApplyDelta` now drops such rows too, and the predicate is single-sourced as `jobsLiveFilter` (used by `loadJobs` and the live-count query). Latent today (the sync only inserts `cpc >= 0.10`, geolocated rows) but necessary now that a count comparison depends on the two sets matching.

## Baseline bookkeeping

`rebuild()` records the baseline via `NoteReconciled` on every successful (re)build, so startup / nightly / drift rebuilds all reset it uniformly. A `seenat` trigger deliberately does **not** advance the baseline - only a successful rebuild does - so a failed rebuild re-fires and retries next tick. Re-entrancy is guarded by the existing `rebuilding` atomic; the index swap is the existing WAL-orphan-safe atomic rename.

## Code Quality Review

- Concurrency: `JobsDataset.mu` guards the baseline; `rebuilding` atomic guards rebuilds; `withIndex` RLock guards the index during `CheckDrift`.
- `seenat` is read as `CAST(MAX(seenat) AS CHAR)` into a string and compared lexically, avoiding driver-specific time parsing (works identically on the MySQL driver and the sqlite test fake; the fixed `YYYY-MM-DD HH:MM:SS` format orders lexically == chronologically).
- Drift-check errors are logged and non-fatal (never block the delta loop).

## Future Improvements

- The same hard-delete-vs-delta gap could affect any future swap-style dataset; the `DriftChecker` interface generalises cleanly if another such dataset appears.

## Test Plan

New `dataset_drift_test.go` (self-contained; sqlite fake `jobs` table + in-memory index, no MySQL):

- `seenat` advance triggers on an **equal-count** swap; first call only baselines (no spurious trigger); `NoteReconciled` resets.
- Count backstop fires over tolerance, not under it.
- `liveCount` / delta filter alignment: invisible, sub-cpc, null-geometry rows excluded.
- Empty table: no panic, no false trigger.
- Wiring (`checkAndRebuildOnDrift`): an index seeded with orphan ext-ids absent from the source rebuilds to a clean index with the orphans gone; non-`DriftChecker` datasets are a no-op.

Compile-checked (build + vet, gofmt clean) in a throwaway golang:1.23 container. Per the task brief, the suite was **not** run locally - CI is the validation gate.
