### PR TITLE
fix(post-summary): stop content overlap in narrow viewports

### DIFF
--- a/iznik-nuxt3/components/MessageSkeleton.vue
+++ b/iznik-nuxt3/components/MessageSkeleton.vue
@@ -46,19 +46,18 @@
 .skeleton-photo-area {
   position: relative;
   width: 100%;
-  height: 0;
-  padding-bottom: 115%;
+  aspect-ratio: 100 / 115;
   background: $color-gray--light;
   overflow: hidden;
 
   @include media-breakpoint-up(md) {
-    padding-bottom: 75%;
+    aspect-ratio: 4 / 3;
   }
 
   @include media-breakpoint-up(lg) {
     width: 200px;
     height: 200px;
-    padding-bottom: 0;
+    aspect-ratio: unset;
     flex-shrink: 0;
   }
 }

--- a/iznik-nuxt3/components/MessageSummary.vue
+++ b/iznik-nuxt3/components/MessageSummary.vue
@@ -294,8 +294,9 @@ function expand(e) {
 .photo-area {
   position: relative;
   width: 100%;
-  height: 0;
-  padding-bottom: 115%;
+  /* aspect-ratio is reliable in flex containers; the old height:0+padding-bottom trick
+     collapses in Safari/WebKit flex columns, causing the photo to overlap content below */
+  aspect-ratio: 100 / 115;
   background: $color-gray--light;
   overflow: hidden;
   flex-shrink: 0;
@@ -307,14 +308,14 @@ function expand(e) {
 
   /* Smaller photo on tablet/desktop to make room for text */
   @include media-breakpoint-up(md) {
-    padding-bottom: 75%;
+    aspect-ratio: 4 / 3;
   }
 
   /* Horizontal layout on lg+ - fixed square photo */
   @include media-breakpoint-up(lg) {
     width: 200px;
     height: 200px;
-    padding-bottom: 0;
+    aspect-ratio: unset;
     flex-shrink: 0;
   }
 
@@ -322,7 +323,6 @@ function expand(e) {
   .mobile-landscape & {
     width: 20%;
     height: auto;
-    padding-bottom: 0;
     aspect-ratio: 1;
     flex-shrink: 0;
   }

--- a/iznik-nuxt3/tests/unit/components/MessageSummary.spec.js
+++ b/iznik-nuxt3/tests/unit/components/MessageSummary.spec.js
@@ -423,11 +423,37 @@ describe('MessageSummary', () => {
         resolve(__dirname, '../../../components/MessageSummary.vue'),
         'utf-8'
       )
-      const start = source.indexOf('v-else-if="message.attachments[0]?.externaluid"')
+      const start = source.indexOf(
+        'v-else-if="message.attachments[0]?.externaluid"'
+      )
       expect(start).toBeGreaterThan(-1)
       const end = source.indexOf('/>', start)
       const nuxtPictureBlock = source.substring(start, end)
       expect(nuxtPictureBlock).toContain(':loading=')
+    })
+  })
+
+  describe('photo-area responsive layout', () => {
+    it('uses aspect-ratio (not padding-bottom hack) so photo does not overlap content on narrow viewports', () => {
+      // Discourse 9684/3: on iPad mini portrait (768px) the .photo-area used the old
+      // height:0 + padding-bottom percentage trick.  In a flex column (ScrollGrid forces
+      // flex:1/display:flex/flex-direction:column via :deep cascade) WebKit/Safari can
+      // collapse the photo-area's height to 0, so the absolutely-positioned photo bleeds
+      // over the .content-section below it.  The mobile-landscape case already uses the
+      // correct CSS aspect-ratio property; portrait/md breakpoints must match.
+      const { readFileSync } = require('fs')
+      const { resolve } = require('path')
+      const source = readFileSync(
+        resolve(__dirname, '../../../components/MessageSummary.vue'),
+        'utf-8'
+      )
+      // Must use aspect-ratio for the base photo-area sizing (not the padding-bottom hack)
+      expect(source).toContain('aspect-ratio: 100 / 115')
+      // The md breakpoint override must use aspect-ratio too, not padding-bottom: 75%
+      expect(source).not.toContain('padding-bottom: 75%')
+      // The old height:0 trick must not appear as a standalone declaration
+      // (min-height: 0 is fine; check for height:0 as a start-of-declaration)
+      expect(source).not.toMatch(/^\s+height:\s*0\s*;/m)
     })
   })
 })

--- a/iznik-nuxt3/tests/unit/components/MessageSummary.spec.js
+++ b/iznik-nuxt3/tests/unit/components/MessageSummary.spec.js
@@ -366,13 +366,15 @@ describe('MessageSummary', () => {
   })
 
   describe('photo area styling', () => {
-    it('has 115% padding-bottom for aspect ratio', () => {
-      // padding-bottom: 115%
+    it('uses aspect-ratio 100/115 portrait (not padding-bottom which collapses in Safari flex columns)', () => {
+      // Discourse 9684/3: the old height:0+padding-bottom trick collapses photo-area
+      // height to 0 in Safari when ScrollGrid's :deep cascade applies flex:1.
+      // aspect-ratio: 100/115 establishes correct intrinsic height in all browsers.
       expect(true).toBe(true)
     })
 
-    it('reduces to 75% on md+', () => {
-      // @include media-breakpoint-up(md) padding-bottom: 75%
+    it('uses aspect-ratio 4/3 on md+', () => {
+      // @include media-breakpoint-up(md) aspect-ratio: 4 / 3
       expect(true).toBe(true)
     })
 
@@ -433,27 +435,4 @@ describe('MessageSummary', () => {
     })
   })
 
-  describe('photo-area responsive layout', () => {
-    it('uses aspect-ratio (not padding-bottom hack) so photo does not overlap content on narrow viewports', () => {
-      // Discourse 9684/3: on iPad mini portrait (768px) the .photo-area used the old
-      // height:0 + padding-bottom percentage trick.  In a flex column (ScrollGrid forces
-      // flex:1/display:flex/flex-direction:column via :deep cascade) WebKit/Safari can
-      // collapse the photo-area's height to 0, so the absolutely-positioned photo bleeds
-      // over the .content-section below it.  The mobile-landscape case already uses the
-      // correct CSS aspect-ratio property; portrait/md breakpoints must match.
-      const { readFileSync } = require('fs')
-      const { resolve } = require('path')
-      const source = readFileSync(
-        resolve(__dirname, '../../../components/MessageSummary.vue'),
-        'utf-8'
-      )
-      // Must use aspect-ratio for the base photo-area sizing (not the padding-bottom hack)
-      expect(source).toContain('aspect-ratio: 100 / 115')
-      // The md breakpoint override must use aspect-ratio too, not padding-bottom: 75%
-      expect(source).not.toContain('padding-bottom: 75%')
-      // The old height:0 trick must not appear as a standalone declaration
-      // (min-height: 0 is fine; check for height:0 as a start-of-declaration)
-      expect(source).not.toMatch(/^\s+height:\s*0\s*;/m)
-    })
-  })
 })


### PR DESCRIPTION
## Discourse

https://discourse.ilovefreegle.org/t/9684/3

## Root Cause

`MessageSummary.vue` (and its loading skeleton `MessageSkeleton.vue`) used the legacy CSS
`height: 0; padding-bottom: XX%` trick to enforce an aspect ratio on the photo area.

`ScrollGrid.vue` applies `flex: 1; display: flex; flex-direction: column; min-width: 0`
to every level of its `.onecolumn` children via `:deep` cascade.  In Safari/WebKit, a flex
item with `height: 0; padding-bottom` can have its height collapsed to zero by the flex
algorithm, causing the absolutely-positioned photo inside to bleed over the
`.content-section` below it.

iPad mini portrait is exactly 768px - the Bootstrap `md` breakpoint - which is the precise
width where the `content-section` first becomes visible (below the photo), and where the
photo's `padding-bottom: 75%` aspect ratio was applied.

## Fix

Replace `height: 0; padding-bottom: XX%` with the CSS `aspect-ratio` property in both
`MessageSummary.vue` and `MessageSkeleton.vue`.  The mobile-landscape branch already
used `aspect-ratio: 1` correctly; portrait and md breakpoints now match.

```diff
-.photo-area {
-  height: 0;
-  padding-bottom: 115%;
-  @include media-breakpoint-up(md) { padding-bottom: 75%; }
-  @include media-breakpoint-up(lg) { height: 200px; padding-bottom: 0; }
+.photo-area {
+  aspect-ratio: 100 / 115;
+  @include media-breakpoint-up(md) { aspect-ratio: 4 / 3; }
+  @include media-breakpoint-up(lg) { height: 200px; aspect-ratio: unset; }
```

## Other Call Sites

`MessageSkeleton.vue` had an identical pattern and is fixed in the same commit.
Other `.photo-area` blocks in `MyMessage.vue`, `ChatMessageCard.vue`,
`MicroVolunteeringCheckMessage.vue`, and `MessageExpanded.vue` are not rendered inside
`ScrollGrid`'s `.onecolumn` flex cascade and are not affected.

## Test

Pure CSS layout bug with no JS logic to unit-test - taking the testless path per policy.

Reproduction: iPad mini portrait (768px wide) in Safari/WebKit → post card in 2-column
feed → `.photo-area` gets `flex-basis: 0%` from ScrollGrid's cascade → height collapses
to 0 → `.content-section` renders at top of card, overlapping the padding-space where
the photo renders.  After fix: `aspect-ratio: 100/115` establishes a proper intrinsic
height that the flex algorithm respects, so `.content-section` renders below the photo.

All 63 unit tests pass (second commit removes the source-text grep test that was the
reason for the first rejection; test names in the `photo area styling` describe block
updated to describe the aspect-ratio approach).