### PR TITLE
fix(rippling-explorer): correct misleading TN tooltip

### DIFF
--- a/iznik-nuxt3/modtools/composables/rippling/freeglerBar.js
+++ b/iznik-nuxt3/modtools/composables/rippling/freeglerBar.js
@@ -1,0 +1,21 @@
+// Builds the HTML for the "~X would be notified" sidebar bar.
+// Returns null when the bar should be hidden (zero estimate or no located total).
+export function buildFreeglerBarHTML(
+  estimatedInsideLocated,
+  totalLocated,
+  unlocatedFraction
+) {
+  if (!(estimatedInsideLocated > 0 && totalLocated > 0)) return null
+  const totalEstimate = Math.round(
+    estimatedInsideLocated / (1 - unlocatedFraction)
+  )
+  const unlocatedShare = totalEstimate - estimatedInsideLocated
+  return (
+    `<div style="font-size:13px;font-weight:600;color:#333;line-height:1.4">~${totalEstimate.toLocaleString()} would be notified</div>` +
+    `<div style="font-size:10px;color:#666;margin-top:1px">${estimatedInsideLocated.toLocaleString()} with known location` +
+    (unlocatedShare > 0
+      ? ` + ~${unlocatedShare.toLocaleString()} estimated unlocated`
+      : '') +
+    `</div>`
+  )
+}

--- a/iznik-nuxt3/modtools/composables/rippling/setupRipplingExplorer.js
+++ b/iznik-nuxt3/modtools/composables/rippling/setupRipplingExplorer.js
@@ -22,6 +22,7 @@ import {
 } from './polygon.js'
 import { partitionInboxData, swingometerDisplay } from './scoring.js'
 import { renderPie as renderPieSvg } from './pie.js'
+import { buildFreeglerBarHTML } from './freeglerBar.js'
 
 export async function setupRipplingExplorer({
   props,
@@ -587,9 +588,13 @@ export async function setupRipplingExplorer({
   const urlParams = new URLSearchParams(window.location.search)
   const pendingView = props.initialView || urlParams.get('view')
   const pendingLat =
-    props.initialLat != null ? props.initialLat : parseFloat(urlParams.get('lat'))
+    props.initialLat != null
+      ? props.initialLat
+      : parseFloat(urlParams.get('lat'))
   const pendingLng =
-    props.initialLng != null ? props.initialLng : parseFloat(urlParams.get('lng'))
+    props.initialLng != null
+      ? props.initialLng
+      : parseFloat(urlParams.get('lng'))
   const pendingPostcode = urlParams.get('postcode') || urlParams.get('q')
   const seededFromProps = props.initialLat != null && props.initialLng != null
 
@@ -606,7 +611,9 @@ export async function setupRipplingExplorer({
       // post's current point (how far it has already rippled), with the scrubber, and
       // let the user drag forwards/backwards. No animation.
       if (seededFromProps) {
-        startRipple(props.initialElapsedHours != null ? props.initialElapsedHours : 0)
+        startRipple(
+          props.initialElapsedHours != null ? props.initialElapsedHours : 0
+        )
       }
       return true
     }
@@ -1318,21 +1325,16 @@ export async function setupRipplingExplorer({
   function renderFreeglerBar(estimatedInsideLocated) {
     const totalLocated = totalLocatedFromServer || allFreeglers.length
     const bar = document.getElementById('rippling-freegler-bar')
-    if (!(estimatedInsideLocated > 0 && totalLocated > 0)) {
+    const html = buildFreeglerBarHTML(
+      estimatedInsideLocated,
+      totalLocated,
+      UNLOCATED_FRACTION
+    )
+    if (!html) {
       bar.style.display = 'none'
       return
     }
-    const totalEstimate = Math.round(
-      estimatedInsideLocated / (1 - UNLOCATED_FRACTION)
-    )
-    const unlocatedShare = totalEstimate - estimatedInsideLocated
-    bar.innerHTML =
-      `<div style="font-size:13px;font-weight:600;color:#333;line-height:1.4">~${totalEstimate.toLocaleString()} would be notified</div>` +
-      `<div style="font-size:10px;color:#666;margin-top:1px">${estimatedInsideLocated.toLocaleString()} with known location` +
-      (unlocatedShare > 0
-        ? ` + ~${unlocatedShare.toLocaleString()} estimated unlocated`
-        : '') +
-      `</div><div style="font-size:10px;color:#aaa;font-style:italic;margin-top:3px">TrashNothing members use a separate algorithm</div>`
+    bar.innerHTML = html
     bar.style.display = ''
   }
 
@@ -1594,7 +1596,9 @@ export async function setupRipplingExplorer({
       hits
         .map(
           (g) =>
-            `<div class="rpl-rg-item">${g.home ? '🏠 ' : '⚡ '}${esc(g.name)}</div>`
+            `<div class="rpl-rg-item">${g.home ? '🏠 ' : '⚡ '}${esc(
+              g.name
+            )}</div>`
         )
         .join('')
   }
@@ -1694,7 +1698,11 @@ export async function setupRipplingExplorer({
     layer.appendChild(mark)
     const label = document.createElement('div')
     const xform =
-      pct < 15 ? 'translateX(0)' : pct > 80 ? 'translateX(-100%)' : 'translateX(-50%)'
+      pct < 15
+        ? 'translateX(0)'
+        : pct > 80
+        ? 'translateX(-100%)'
+        : 'translateX(-50%)'
     label.style.cssText = `position:absolute;left:${pct}%;top:-22px;color:#e07000;font-size:11px;font-weight:700;white-space:nowrap;transform:${xform}`
     label.textContent = '⚡'
     layer.appendChild(label)
@@ -1782,7 +1790,11 @@ export async function setupRipplingExplorer({
     layer.appendChild(mark)
     const label = document.createElement('div')
     const xform =
-      pct < 12 ? 'translateX(0)' : pct > 88 ? 'translateX(-100%)' : 'translateX(-50%)'
+      pct < 12
+        ? 'translateX(0)'
+        : pct > 88
+        ? 'translateX(-100%)'
+        : 'translateX(-50%)'
     const top = where === 'top' ? '-28px' : '16px'
     label.style.cssText = `position:absolute;left:${pct}%;top:${top};color:${color};font-size:10px;font-weight:700;white-space:nowrap;transform:${xform}`
     label.textContent = text
@@ -1795,7 +1807,13 @@ export async function setupRipplingExplorer({
     // is the "up to" indicator (no separate marker needed). Only when the engine is BEHIND
     // do we add an "actually here" marker, so the gap to the thumb is the lag.
     if (props.actualElapsedHours != null) {
-      addReachMarker(layer, props.actualElapsedHours, 'actually here ▲', '#e07000', 'top')
+      addReachMarker(
+        layer,
+        props.actualElapsedHours,
+        'actually here ▲',
+        '#e07000',
+        'top'
+      )
     }
   }
 

--- a/iznik-nuxt3/tests/unit/composables/rippling-freegler-bar.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/rippling-freegler-bar.spec.js
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import { buildFreeglerBarHTML } from '~/modtools/composables/rippling/freeglerBar.js'
+
+describe('rippling/freeglerBar', () => {
+  it('returns null when estimate is zero', () => {
+    expect(buildFreeglerBarHTML(0, 5000, 0.35)).toBeNull()
+  })
+
+  it('returns null when total located is zero', () => {
+    expect(buildFreeglerBarHTML(100, 0, 0.35)).toBeNull()
+  })
+
+  it('shows "would be notified" headline', () => {
+    const html = buildFreeglerBarHTML(1000, 5000, 0.35)
+    expect(html).toContain('would be notified')
+  })
+
+  it('shows located count with "with known location"', () => {
+    const html = buildFreeglerBarHTML(1000, 5000, 0.35)
+    expect(html).toContain('1,000 with known location')
+  })
+
+  it('shows estimated unlocated addend when total > located', () => {
+    const html = buildFreeglerBarHTML(1000, 5000, 0.35)
+    expect(html).toContain('estimated unlocated')
+  })
+
+  it('omits the unlocated addend when all members have known locations', () => {
+    const html = buildFreeglerBarHTML(1000, 5000, 0)
+    expect(html).not.toContain('estimated unlocated')
+  })
+
+  it('does not mention TrashNothing or a separate algorithm (misleading tooltip fixed)', () => {
+    const html = buildFreeglerBarHTML(1000, 5000, 0.35)
+    expect(html).not.toContain('TrashNothing')
+    expect(html).not.toContain('separate algorithm')
+  })
+})

--- a/iznik-nuxt3/tests/unit/mocks/qr-code-styling.js
+++ b/iznik-nuxt3/tests/unit/mocks/qr-code-styling.js
@@ -1,0 +1,10 @@
+class QRCodeStyling {
+  constructor() {}
+  append() {}
+  download() {
+    return Promise.resolve()
+  }
+  update() {}
+}
+
+export default QRCodeStyling

--- a/iznik-nuxt3/vitest.config.mts
+++ b/iznik-nuxt3/vitest.config.mts
@@ -91,6 +91,10 @@ export default defineConfig({
         'tests/unit/mocks/quill-html-edit-button.js'
       ),
       papaparse: path.join(rootDir, 'tests/unit/mocks/papaparse.js'),
+      'qr-code-styling': path.join(
+        rootDir,
+        'tests/unit/mocks/qr-code-styling.js'
+      ),
       'vue-letter': path.join(rootDir, 'tests/unit/mocks/vue-letter.js'),
       letterparser: path.join(rootDir, 'tests/unit/mocks/letterparser.js'),
       // Handsontable mocks


### PR DESCRIPTION
## Root Cause

The "~X would be notified" sidebar bar in the rippling explorer always showed an italic note: _"TrashNothing members use a separate algorithm"_. This is misleading because:

- TN members who are also Freegle users **are** counted in the notification figure via the same rippling algorithm as everyone else (they appear in `users_approxlocs`)
- The actual TN-specific behaviour (TN-originated posts with `tnpostid` are not rippled into new groups) relates to **post sources**, not notification recipients - irrelevant to this count bar
- The note was shown for **all** posts, not just TN-originated ones, adding confusion with no benefit

## Evidence

Test failure on buggy code (Step 3b):

```
FAIL  tests/unit/composables/rippling-freegler-bar.spec.js > rippling/freeglerBar
       > does not mention TrashNothing or a separate algorithm (misleading tooltip fixed)
AssertionError: expected '...' not to contain 'TrashNothing'
     35|     expect(html).not.toContain('TrashNothing')
```

## Fix

- Extract the bar's HTML-building logic to `modtools/composables/rippling/freeglerBar.js` (pure function, no DOM/closure dependencies, matches the pattern of `pie.js` / `scoring.js`)
- Remove the misleading note from the generated HTML
- `renderFreeglerBar` in `setupRipplingExplorer.js` now delegates to `buildFreeglerBarHTML`

## Other Call Sites

No other user-visible TrashNothing references found in source (`grep -rn "TrashNothing" --include="*.js" --include="*.vue"` returns only the code comment at line 439 and the new test).

## Test

**File**: `tests/unit/composables/rippling-freegler-bar.spec.js`  
**Command**: `npx vitest run tests/unit/composables/rippling-freegler-bar.spec.js`  
**Proves**: 7 tests; the "does not mention TrashNothing" test failed before the fix and passes after.

## Discourse

https://discourse.ilovefreegle.org/t/9808/56