### PR TITLE
fix(ripple): bypass recent-logs gate for rippled-in auto-approve

### DIFF
--- a/iznik-batch/app/Services/AutoApproveService.php
+++ b/iznik-batch/app/Services/AutoApproveService.php
@@ -132,20 +132,34 @@ class AutoApproveService
 
         foreach ($candidates as $msgid => $groupRows) {
             try {
-                // V1: check for recent logs referencing this message ONCE (not per group).
-                // This avoids auto-approving messages recently held/unheld, while still
-                // allowing multi-group messages to be approved across all groups in one pass.
-                $recentLogs = DB::table('logs')
-                    ->where('msgid', $msgid)
-                    ->where('timestamp', '>', now()->subHours(self::PENDING_HOURS))
-                    ->exists();
-
-                if ($recentLogs) {
-                    $stats['skipped'] += $groupRows->count();
-                    continue;
-                }
+                // V1 parity: skip auto-approving a message that was recently held/unheld.
+                // Lazy-evaluated so the query only runs when there is at least one non-rippled-in
+                // candidate that needs the guard. Rippled-in rows bypass this check entirely:
+                // the relevant hold on the nearby group is already expressed by the heldby IS NULL
+                // filter in the candidates query, and finding an approval log from the ORIGIN group
+                // here must not block the short veto window on the receiving group (which is how
+                // ~30 posts "disappeared suddenly" — they were stuck Pending for 48h instead of 1h
+                // and then batch-approved when the origin-approval log aged out, Discourse 9812/3).
+                $recentLogsChecked = false;
+                $recentLogs = false;
 
                 foreach ($groupRows as $candidate) {
+                    $isRippledIn = (int) ($candidate->rippled_in ?? 0) === 1;
+
+                    if (!$isRippledIn) {
+                        if (!$recentLogsChecked) {
+                            $recentLogs = DB::table('logs')
+                                ->where('msgid', $msgid)
+                                ->where('timestamp', '>', now()->subHours(self::PENDING_HOURS))
+                                ->exists();
+                            $recentLogsChecked = true;
+                        }
+                        if ($recentLogs) {
+                            $stats['skipped']++;
+                            continue;
+                        }
+                    }
+
                     if ($this->shouldApproveOnGroup($candidate, $candidate->groupid)) {
                         if ($dryRun) {
                             Log::info("Dry run: would auto-approve message #{$candidate->msgid} on group #{$candidate->groupid}");

--- a/iznik-batch/tests/Unit/Services/AutoApproveServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/AutoApproveServiceTest.php
@@ -434,6 +434,57 @@ class AutoApproveServiceTest extends TestCase
             'rippled-in post vetted on origin is fast-tracked past the membership gate');
     }
 
+    /**
+     * A rippled-in post is auto-approved after the veto window even when a recent logs row
+     * exists for the message (e.g. the Approved/Autoapproved row created by ProcessBackgroundTasksCommand
+     * or AutoApproveService when the post was approved on its origin group).
+     *
+     * Bug: the $recentLogs check in process() was applied to ALL candidates including rippled-in rows.
+     * It found the origin-approval log (<48h old) and skipped auto-approval, keeping rippled-in posts
+     * Pending for up to 48h instead of the 1h veto window — then approving them all at once, which is
+     * what mods observed as "~30 posts disappeared suddenly" (Discourse 9812 post 3).
+     */
+    public function test_fast_tracks_rippled_in_despite_recent_origin_approval_log(): void
+    {
+        config(['freegle.ripple.rippled_in_pending_hours' => 1]);
+
+        $user = $this->createTestUser();
+        $originGroup = $this->createTestGroup();
+        $nearbyGroup = $this->createTestGroup();
+        $this->createMembership($user, $originGroup, ['added' => now()->subHours(72)]);
+
+        $message = $this->createTestMessage($user, $originGroup);
+        DB::table('messages_groups')
+            ->where('msgid', $message->id)->where('groupid', $originGroup->id)
+            ->update(['collection' => MessageGroup::COLLECTION_APPROVED, 'arrival' => now()->subHours(3)]);
+
+        // Simulate the logs row that ProcessBackgroundTasksCommand inserts when a mod approves
+        // (or AutoApproveService inserts as 'Autoapproved') on the origin group. This is always
+        // present in production and is what the $recentLogs check finds.
+        DB::table('logs')->insert([
+            'timestamp' => now()->subHours(2),
+            'type' => 'Message',
+            'subtype' => 'Autoapproved',
+            'msgid' => $message->id,
+            'groupid' => $originGroup->id,
+            'user' => $user->id,
+        ]);
+
+        // Rippled into the nearby group 90 minutes ago — past the 1h veto window.
+        DB::table('messages_groups')->insert([
+            'msgid' => $message->id, 'groupid' => $nearbyGroup->id,
+            'collection' => MessageGroup::COLLECTION_PENDING, 'arrival' => now()->subMinutes(90),
+            'msgtype' => 'Offer', 'rippled_in' => 1,
+        ]);
+
+        $this->service->process();
+
+        $mg = DB::table('messages_groups')
+            ->where('msgid', $message->id)->where('groupid', $nearbyGroup->id)->first();
+        $this->assertEquals(MessageGroup::COLLECTION_APPROVED, $mg->collection,
+            'rippled-in post must be auto-approved after veto window regardless of origin-approval logs');
+    }
+
     /** Within the short veto window a rippled-in post stays Pending (mods can still reject). */
     public function test_holds_rippled_in_post_within_veto_window(): void
     {


### PR DESCRIPTION
## Root Cause

`AutoApproveService::process()` checked for any log with the message's `msgid` in the past 48h (`$recentLogs`) to guard against approving recently held/unheld messages (V1 parity). For rippled-in rows (`rippled_in = 1`) this check wrongly found the `Approved`/`Autoapproved` log that `ProcessBackgroundTasksCommand` or `AutoApproveService` writes when the post is vetted on its **origin group**, and treated that as a "recently actioned - skip" signal.

Effect: rippled-in Pending rows were blocked from the 1h mod-veto window and sat Pending for up to 48h (until the origin-approval log aged out of the 48h window), then were all batch-approved in a single `AutoApproveService` run - mods saw ~30 posts disappear suddenly from the ModTools pending queue.

## Evidence

Failing test output (before fix) on `test_fast_tracks_rippled_in_despite_recent_origin_approval_log`:

```
1) Tests\Unit\Services\AutoApproveServiceTest::test_fast_tracks_rippled_in_despite_recent_origin_approval_log
rippled-in post must be auto-approved after veto window regardless of origin-approval logs
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'Approved'
+'Pending'
```

After fix: all 28 `AutoApproveServiceTest` tests pass.

## Fix

Moved the `$recentLogs` query inside the per-candidate loop with a lazy-evaluation flag (`$recentLogsChecked`) and skipped the check entirely for `rippled_in = 1` rows. A hold on the **nearby group** is already expressed by the `heldby IS NULL` filter in the candidates query, so no hold-protection signal is lost. Non-rippled-in candidates continue to be guarded exactly as before.

## Other Call Sites

`grep` for `recentLogs` / `PENDING_HOURS` across `iznik-batch/app/`: only `AutoApproveService.php`. No other sites.

## Test

File: `iznik-batch/tests/Unit/Services/AutoApproveServiceTest.php`  
Method: `test_fast_tracks_rippled_in_despite_recent_origin_approval_log`  
Proves: **FAIL** before fix (post stays Pending due to origin-approval log blocking), **PASS** after fix (post is approved after veto window).

## Discourse
https://discourse.ilovefreegle.org/t/9812/3