### PR TITLE
fix(donations): remove broken PayPal Giving Fund link and fix DonationButton type coercion

### DIFF
--- a/iznik-nuxt3/pages/donate.vue
+++ b/iznik-nuxt3/pages/donate.vue
@@ -50,7 +50,7 @@
                 v-if="payPalFallback && !isApp"
                 :key="amount + '-fallback'"
                 :text="'Donate £' + amount"
-                :value="amount"
+                :value="String(amount)"
               />
               <p v-else-if="payPalFallback && isApp" class="text-muted">
                 Payment is temporarily unavailable. Please try again later.
@@ -70,25 +70,6 @@
               We keep costs low with volunteers, but some things we have to pay
               for.
             </p>
-          </div>
-        </div>
-
-        <!-- PayPal favourite -->
-        <div class="section-card">
-          <div class="section-header">
-            <v-icon icon="star" class="section-icon" />
-            <h2>PayPal favourite</h2>
-          </div>
-          <div class="section-content">
-            <p>
-              Set Freegle as your favourite PayPal charity for easy donations at
-              checkout.
-            </p>
-            <ExternalLink
-              href="https://www.paypal.com/fundraiser/charity/55681"
-            >
-              <b-button variant="primary"> Go to PayPal Giving Fund </b-button>
-            </ExternalLink>
           </div>
         </div>
 
@@ -180,7 +161,6 @@ import { buildHead } from '~/composables/useBuildHead'
 import { useAuthStore } from '~/stores/auth'
 import { useMobileStore } from '~/stores/mobile'
 import DonationButton from '~/components/DonationButton'
-import ExternalLink from '~/components/ExternalLink'
 import DonationThank from '~/components/DonationThank'
 import StripeDonate from '~/components/StripeDonate'
 

--- a/iznik-nuxt3/tests/unit/pages/donate.spec.js
+++ b/iznik-nuxt3/tests/unit/pages/donate.spec.js
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+
+// useHead is auto-imported by Nuxt; expose it globally so donate.vue can call it
+globalThis.useHead = vi.fn()
+
+// Mock mobile store (auth is already aliased via vitest.config.mts)
+vi.mock('~/stores/mobile', () => ({
+  useMobileStore: () => ({ isApp: false, isMobile: false }),
+}))
+
+vi.mock('~/composables/useBuildHead', () => ({
+  buildHead: () => ({}),
+}))
+
+// Stub heavy child components to avoid pulling in Stripe/PayPal SDKs
+vi.mock('~/components/DonationButton', () => ({
+  default: {
+    name: 'DonationButton',
+    template: '<div class="donation-button" data-value="value" />',
+    props: {
+      value: { type: String, default: null },
+      text: { type: String, default: null },
+      directDonation: { type: Boolean, default: false },
+    },
+  },
+}))
+
+vi.mock('~/components/StripeDonate', () => ({
+  default: {
+    name: 'StripeDonate',
+    template: '<div class="stripe-donate" />',
+    props: ['price', 'monthly'],
+    emits: ['success', 'error', 'noPaymentMethods'],
+  },
+}))
+
+vi.mock('~/components/DonationThank', () => ({
+  default: { template: '<div class="donation-thank" />' },
+}))
+
+vi.mock('~/components/ExternalLink', () => ({
+  default: {
+    name: 'ExternalLink',
+    template: '<a :href="href"><slot /></a>',
+    props: ['href'],
+  },
+}))
+
+import DonatePage from '~/pages/donate.vue'
+
+function createWrapper() {
+  return mount(DonatePage, {
+    global: {
+      stubs: {
+        // Render ClientOnly slot content in JSDOM
+        ClientOnly: { template: '<div><slot /></div>' },
+        // Bootstrap-vue components not covered by global setup
+        'b-input': {
+          template:
+            '<input :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" />',
+          props: ['modelValue', 'type', 'min', 'step'],
+          emits: ['update:modelValue'],
+        },
+        'b-input-group': {
+          template: '<div class="input-group"><slot /></div>',
+          props: ['prepend'],
+        },
+        'b-img': { template: '<img />', props: ['src', 'fluid', 'alt'] },
+        'nuxt-link': {
+          template: '<a :href="to"><slot /></a>',
+          props: ['to', 'noPrefetch'],
+        },
+      },
+    },
+  })
+}
+
+describe('donate page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // Step 3b: the page must NOT render the discontinued PayPal Giving Fund URL.
+  // PayPal shut down the Giving Fund in 2024; the URL
+  // https://www.paypal.com/fundraiser/charity/55681 now leads to a broken page.
+  // This test FAILS on the unfixed code (the link is present) and PASSES after fix.
+  it('does not render the discontinued PayPal Giving Fund link', async () => {
+    const wrapper = createWrapper()
+    await flushPromises()
+    expect(wrapper.html()).not.toContain('paypal.com/fundraiser/charity/55681')
+  })
+
+  // The PayPal fallback DonationButton must receive a STRING value so the
+  // buttonId switch (===) selects the right hosted-button ID.
+  // donate.vue passes :value="amount" where amount starts as ref(3) — a Number —
+  // causing the switch to fall through to the default ID for every amount.
+  // This test FAILS on unfixed code (Vue prop warning + wrong type) and PASSES after fix.
+  it('passes a string value to DonationButton in the PayPal fallback path', async () => {
+    const wrapper = createWrapper()
+    await flushPromises()
+
+    const stripeDonate = wrapper.findComponent({ name: 'StripeDonate' })
+    expect(stripeDonate.exists()).toBe(true)
+    await stripeDonate.vm.$emit('noPaymentMethods')
+    await flushPromises()
+
+    const donationButton = wrapper.findComponent({ name: 'DonationButton' })
+    expect(donationButton.exists()).toBe(true)
+    expect(typeof donationButton.props('value')).toBe('string')
+  })
+})


### PR DESCRIPTION
## Root Cause

Two bugs on the `/donate` page:

1. **Broken PayPal Giving Fund link** - PayPal shut down the Giving Fund in 2024. The link `https://www.paypal.com/fundraiser/charity/55681` (in a \"PayPal favourite\" section) leads to a broken page. Removed the entire section.

2. **DonationButton receives a Number instead of String** - `amount` is `ref(3)` (a Number), but `DonationButton.vue` declares `value: { type: String }` and its `buttonId` computed uses a `switch` with `===`. Passing `3` (Number) to `case '3':` (String) always falls through to the default button ID regardless of amount. `DonationAskStripe.vue` already uses `String(price)` correctly; this fix applies the same coercion to `donate.vue`.

## Evidence

```
# Test 1 - FAILS on unfixed code (PayPal Giving Fund URL present in HTML):
✗ does not render the discontinued PayPal Giving Fund link

# Test 2 - FAILS on unfixed code (Vue warn: Invalid prop: type check failed for prop "value";
#           expected String, got Number - thrown by setup.ts as an unhandled rejection):
✗ passes a string value to DonationButton in the PayPal fallback path

# After fix - both PASS:
✓ does not render the discontinued PayPal Giving Fund link
✓ passes a string value to DonationButton in the PayPal fallback path

630 test files, 13394 tests - all pass.
```

## Fix

- `iznik-nuxt3/pages/donate.vue`: removed the "PayPal favourite" section (broken `https://www.paypal.com/fundraiser/charity/55681` link), changed `:value="amount"` to `:value="String(amount)"` in the DonationButton fallback, removed unused `ExternalLink` import.
- `iznik-nuxt3/tests/unit/pages/donate.spec.js`: new test file with two assertions (AssertFlip verified: both failed on buggy code, both pass after fix).

## Other Call Sites

`grep -r "fundraiser/charity/55681"` - no other occurrences.
`grep -r ':value="amount"' iznik-nuxt3/` - no other instances of this pattern (DonationAskStripe.vue already uses `String(price)`).

## Test

File: `iznik-nuxt3/tests/unit/pages/donate.spec.js`

Command: `cd iznik-nuxt3 && npx vitest run tests/unit/pages/donate.spec.js`

Proves: fail-before (broken URL present; Number passed to String prop) then pass-after (URL removed; value coerced to String).

## Discourse
https://discourse.ilovefreegle.org/t/9810/1