### PR TITLE
fix(abtest): make epsilon-greedy selection coverage deterministic

### DIFF
--- a/iznik-server-go/abtest/abtest.go
+++ b/iznik-server-go/abtest/abtest.go
@@ -45,15 +45,28 @@ func GetABTest(c *fiber.Ctx) error {
 		return c.JSON(fiber.Map{"ret": 0, "status": "Success", "variant": nil})
 	}
 
-	// Epsilon-greedy bandit: 10% exploration, 90% exploitation
-	var chosen ABTestVariant
-	if rand.Float64() < 0.1 {
-		chosen = variants[rand.Intn(len(variants))]
-	} else {
-		chosen = variants[0]
-	}
+	chosen := chooseVariant(variants, rand.Float64, rand.Intn)
 
 	return c.JSON(fiber.Map{"ret": 0, "status": "Success", "variant": chosen})
+}
+
+// chooseVariant applies an epsilon-greedy bandit over the suggestible variants
+// (already sorted by rate DESC): 10% exploration (a uniformly random pick) and
+// 90% exploitation (the best-rate variant). Callers pass a non-empty slice
+// (GetABTest returns early when there are no variants).
+//
+// The randomness is injected (randFloat/randIntn) purely so both branches are
+// reachable from deterministic unit tests. Inline, the selection sits after the
+// DB query, so it was exercised only by the live-DB integration test — where the
+// 10% exploration branch is hit only ~1 run in 10 (Go auto-seeds the global
+// math/rand source). That made abtest.go's reported coverage flap between 95.34%
+// and 97.67% run-to-run and intermittently tripped the Coveralls "coverage
+// decreased" gate on unrelated PRs.
+func chooseVariant(variants []ABTestVariant, randFloat func() float64, randIntn func(int) int) ABTestVariant {
+	if randFloat() < 0.1 {
+		return variants[randIntn(len(variants))]
+	}
+	return variants[0]
 }
 
 func PostABTest(c *fiber.Ctx) error {

--- a/iznik-server-go/abtest/abtest_test.go
+++ b/iznik-server-go/abtest/abtest_test.go
@@ -59,6 +59,46 @@ func doPost(t *testing.T, app *fiber.App, body string) (int, []byte) {
 }
 
 // ---------------------------------------------------------------------------
+// chooseVariant — epsilon-greedy selection (rand injected for determinism)
+//
+// These cover the post-DB selection branches without a database: GetABTest only
+// reaches them with a non-empty, rate-sorted slice, and the branch taken depends
+// solely on the injected randFloat/randIntn. Both branches plus the threshold
+// boundary are exercised on every run, so abtest.go no longer has a line whose
+// coverage flaps with the global RNG seed.
+// ---------------------------------------------------------------------------
+
+func TestChooseVariant_Exploitation_PicksBestRate(t *testing.T) {
+	// randFloat >= 0.1 → exploitation → variants[0] (best rate); randIntn unused.
+	variants := []ABTestVariant{{Variant: "best"}, {Variant: "other"}}
+	got := chooseVariant(variants,
+		func() float64 { return 0.5 },
+		func(int) int { t.Fatal("randIntn must not be called on the exploitation branch"); return 0 })
+	assert.Equal(t, "best", got.Variant)
+}
+
+func TestChooseVariant_Exploration_PicksRandomIndex(t *testing.T) {
+	// randFloat < 0.1 → exploration → variants[randIntn(len(variants))].
+	variants := []ABTestVariant{{Variant: "a"}, {Variant: "b"}, {Variant: "c"}}
+	got := chooseVariant(variants,
+		func() float64 { return 0.0 },
+		func(n int) int {
+			assert.Equal(t, len(variants), n, "randIntn must be bounded by len(variants)")
+			return 2
+		})
+	assert.Equal(t, "c", got.Variant)
+}
+
+func TestChooseVariant_ThresholdBoundary_IsExploitation(t *testing.T) {
+	// Exactly 0.1 is NOT < 0.1 → exploitation branch (guards the boundary).
+	variants := []ABTestVariant{{Variant: "best"}, {Variant: "other"}}
+	got := chooseVariant(variants,
+		func() float64 { return 0.1 },
+		func(int) int { return 1 })
+	assert.Equal(t, "best", got.Variant)
+}
+
+// ---------------------------------------------------------------------------
 // GetABTest — pre-DB paths
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Root Cause

The **Coveralls - go** status check fails intermittently on PRs that touch no Go code at all (most recently the PHP-only #863) with a tiny "coverage decreased" delta. The decrease is always the same single line: the epsilon-greedy **exploration** branch in `iznik-server-go/abtest/abtest.go`.

`GetABTest` picks a variant with a 10%-exploration / 90%-exploitation bandit, and that selection sits **after** the DB query, so its branches are reachable only via the live-DB integration test. Go 1.20+ auto-seeds the global `math/rand` source, so the 10% exploration branch is exercised only ~1 run in 10. abtest.go's reported coverage therefore flaps between **95.34%** and **97.67%** run to run, and Coveralls flags the unlucky runs as a regression on whatever unrelated PR happens to be building.

## Fix

- Extract the selection into a pure `chooseVariant(variants, randFloat, randIntn)` with the RNG injected, so **both branches are reachable without a DB**.
- `GetABTest` calls it with `rand.Float64, rand.Intn` — runtime behaviour is identical.
- Add deterministic unit tests covering exploration, exploitation, and the `0.1` threshold boundary.

abtest.go coverage is now stable across runs, so the flaky `Coveralls - go` gate stops firing on unrelated PRs.

## Test

`abtest` package unit tests (no DB), deterministic every run:
- `TestChooseVariant_Exploitation_PicksBestRate`
- `TestChooseVariant_Exploration_PicksRandomIndex`
- `TestChooseVariant_ThresholdBoundary_IsExploitation`

🤖 Generated with [Claude Code](https://claude.com/claude-code)