### PR TITLE
fix(view): record a source (browse vs message_page) with each message view

### DIFF
--- a/iznik-nuxt3/api/MessageAPI.js
+++ b/iznik-nuxt3/api/MessageAPI.js
@@ -96,11 +96,18 @@ export default class MessageAPI extends BaseAPI {
     })
   }
 
-  view(id) {
-    return this.$postv2('/message', {
+  view(id, source) {
+    const body = {
       action: 'View',
       id,
-    })
+    }
+    // Optional context tag (e.g. 'browse' vs 'message_page', or a notification
+    // ?src= value) so the server can tell a browse-feed view from a detail view.
+    // handleView persists it via COALESCE; omit when absent so we never clear it.
+    if (source) {
+      body.source = source
+    }
+    return this.$postv2('/message', body)
   }
 
   async getIllustration(item) {

--- a/iznik-nuxt3/components/OurMessage.vue
+++ b/iznik-nuxt3/components/OurMessage.vue
@@ -142,6 +142,15 @@ const props = defineProps({
     required: false,
     default: false,
   },
+  // Where this card is rendered, recorded with the view so browse-feed views are
+  // distinguishable from detail views. The feed leaves the default ('browse');
+  // the message page passes 'message_page' (or a notification ?src= tag). Both
+  // the passive dwell and the tap-to-expand are still "in the feed" → 'browse'.
+  viewSource: {
+    type: String,
+    required: false,
+    default: 'browse',
+  },
 })
 
 const emit = defineEmits(['notFound', 'view', 'visible'])
@@ -203,10 +212,10 @@ function closeMobileExpanded() {
   showMobileExpanded.value = false
 }
 
-async function view() {
+async function view(source = props.viewSource) {
   if (props.recordView) {
     if (me.value && message.value?.unseen) {
-      await messageStore.view(props.id)
+      await messageStore.view(props.id, source)
     }
 
     emit('view')

--- a/iznik-nuxt3/pages/message/[id].vue
+++ b/iznik-nuxt3/pages/message/[id].vue
@@ -103,6 +103,7 @@
             :id="id"
             class="mt-3"
             :start-expanded="true"
+            :view-source="$route.query.src || 'message_page'"
             hide-close
             record-view
             @not-found="error = true"

--- a/iznik-nuxt3/stores/message.js
+++ b/iznik-nuxt3/stores/message.js
@@ -297,8 +297,8 @@ export const useMessageStore = defineStore({
 
       return messages || []
     },
-    async view(id) {
-      await api(this.config).message.view(id)
+    async view(id, source) {
+      await api(this.config).message.view(id, source)
     },
     async update(params) {
       const authStore = useAuthStore()

--- a/iznik-nuxt3/tests/unit/components/OurMessage.spec.js
+++ b/iznik-nuxt3/tests/unit/components/OurMessage.spec.js
@@ -190,11 +190,22 @@ describe('OurMessage', () => {
   })
 
   describe('view tracking', () => {
-    it('calls view when recordView is true and user logged in', async () => {
+    it('calls view with the browse source when recordView is true and user logged in', async () => {
       const wrapper = await createWrapper({ recordView: true })
       await wrapper.find('.message-summary').trigger('click')
       await flushPromises()
-      expect(mockMessageStore.view).toHaveBeenCalledWith(1)
+      // A feed view (tap-to-expand) records 'browse', the default viewSource.
+      expect(mockMessageStore.view).toHaveBeenCalledWith(1, 'browse')
+    })
+
+    it('records the configured viewSource (e.g. message_page) on startExpanded', async () => {
+      await createWrapper({
+        recordView: true,
+        startExpanded: true,
+        viewSource: 'message_page',
+      })
+      await flushPromises()
+      expect(mockMessageStore.view).toHaveBeenCalledWith(1, 'message_page')
     })
 
     it('does not call view when recordView is false', async () => {

--- a/iznik-nuxt3/tests/unit/stores/message.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/message.spec.js
@@ -10,6 +10,7 @@ const mockFetch = vi.fn()
 const mockSearch = vi.fn()
 const mockFetchMessages = vi.fn()
 const mockFetchMT = vi.fn()
+const mockView = vi.fn()
 
 vi.mock('~/api', () => ({
   default: () => ({
@@ -19,6 +20,7 @@ vi.mock('~/api', () => ({
       fetch: mockFetch,
       search: mockSearch,
       fetchMessages: mockFetchMessages,
+      view: mockView,
     },
   }),
 }))
@@ -43,6 +45,25 @@ const mockMiscStore = { modtools: false }
 vi.mock('~/stores/misc', () => ({
   useMiscStore: () => mockMiscStore,
 }))
+
+describe('message store - view()', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('forwards a browse source to the API', async () => {
+    const store = useMessageStore()
+    await store.view(1234, 'browse')
+    expect(mockView).toHaveBeenCalledWith(1234, 'browse')
+  })
+
+  it('forwards a message_page source to the API', async () => {
+    const store = useMessageStore()
+    await store.view(99, 'message_page')
+    expect(mockView).toHaveBeenCalledWith(99, 'message_page')
+  })
+})
 
 describe('message store - patch()', () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary
- Records a `source` with each message view so a **browse-feed** view is distinguishable from a **detail-page** view. Previously all three `OurMessage` view triggers — passive dwell, tap-to-expand, and `startExpanded` — called `messageStore.view(id)` with no context, so every organic view stored `source=NULL`.
- Threads an optional `source` through the existing chain: `OurMessage` `viewSource` prop (default `browse`) → `messageStore.view(id, source)` → `MessageAPI.view(id, source)` → POST body. Both feed triggers record `browse`; the message page records `message_page`, honouring a notification `?src=` tag when present.
- **No backend or schema change**: `handleView` already reads `req.Source` and persists it via `COALESCE(?, source)`. `source` is omitted from the body when absent, so an existing value is never cleared.

## Code Quality Review
- Additive and backward-compatible: `view(source = props.viewSource)` defaults to the feed source; existing callers are unchanged. `viewSource` defaults to `browse`, so any current `OurMessage` usage keeps recording browse views.
- No new dependency in the hot `OurMessage` component (no `useRoute`); the message page supplies the source via the prop.

## Future Improvements
- The feed can pass `view-source="search"` when a search term is active (the page already knows it), to split search-feed views from browse-feed views.
- The companion notification-link writing side (`?src=ripple_notify` on email links) now flows straight through.

## Validation
- `tests/unit/stores/message.spec.js`: `view()` forwards both `browse` and `message_page` sources to the API (added; 20/20 in the spec locally).
- Full frontend + Go suites via CI. `handleView` source persistence is already covered by `TestMessagePageviewSource`.
