### PR TITLE
feat(browse): browse-feed scroll-depth instrumentation + sysadmin "Scrolling" tab

### DIFF
--- a/iznik-batch/database/migrations/2026_06_24_000001_create_browse_scroll_depth.php
+++ b/iznik-batch/database/migrations/2026_06_24_000001_create_browse_scroll_depth.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * browse_scroll_depth: one row per browse-feed session recording the FURTHEST feed position
+ * (0-based item index) the member scrolled to. Powers the sysadmin "Scrolling" tab's scroll-depth
+ * curve - for each position N, the fraction of sessions that reached at least N - the browse-feed
+ * analogue of the digest click-by-position chart (email_tracking_clicks.link_position).
+ *
+ * Written by the Go apiv2 scroll-depth handler, one record per session (the browse page sends the
+ * max position reached on leave/hide). userid is NULL for logged-out browsing. items_available is
+ * the feed length at record time, so "stopped early" is distinguishable from "reached the end".
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (!Schema::hasTable('browse_scroll_depth')) {
+            Schema::create('browse_scroll_depth', function (Blueprint $t) {
+                $t->bigIncrements('id');
+                $t->unsignedBigInteger('userid')->nullable();
+                $t->unsignedInteger('max_position')
+                    ->comment('Furthest 0-based feed item index reached in the session');
+                $t->unsignedInteger('items_available')->nullable()
+                    ->comment('Feed length when recorded; tells "stopped early" from "reached the end"');
+                $t->string('context', 16)->nullable()
+                    ->comment("Which feed: 'browse' or 'search'");
+                $t->timestamp('created_at')->useCurrent();
+                $t->index('created_at', 'bsd_created_at');
+                $t->index('userid', 'bsd_userid');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('browse_scroll_depth');
+    }
+};

--- a/iznik-batch/database/migrations/2026_06_24_000001_create_browse_scroll_depth_migration.sql
+++ b/iznik-batch/database/migrations/2026_06_24_000001_create_browse_scroll_depth_migration.sql
@@ -1,0 +1,15 @@
+-- Production idempotent SQL: browse_scroll_depth (sysadmin "Scrolling" tab - browse-feed scroll depth).
+-- One row per browse-feed session recording the furthest 0-based feed position reached. Powers the
+-- scroll-depth curve (fraction of sessions reaching position N), the browse analogue of digest
+-- click-by-position. Written by the Go apiv2 scroll-depth handler; userid is NULL for logged-out.
+CREATE TABLE IF NOT EXISTS browse_scroll_depth (
+    id              BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    userid          BIGINT UNSIGNED NULL,
+    max_position    INT UNSIGNED NOT NULL,
+    items_available INT UNSIGNED NULL,
+    context         VARCHAR(16) NULL,
+    created_at      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    KEY bsd_created_at (created_at),
+    KEY bsd_userid (userid)
+);

--- a/iznik-nuxt3/api/BrowseAPI.js
+++ b/iznik-nuxt3/api/BrowseAPI.js
@@ -1,0 +1,12 @@
+import BaseAPI from '@/api/BaseAPI'
+
+export default class BrowseAPI extends BaseAPI {
+  /**
+   * Fetch the browse-feed scroll-depth curve for the sysadmin "Scrolling" tab.
+   * Returns { total, positions: [{ position, sessions_reaching, pct }] }.
+   * @param {Object} params - { start, end } as YYYY-MM-DD (defaults to last 7 days server-side)
+   */
+  async fetchScrollDepth(params = {}) {
+    return await this.$getv2('/modtools/scroll/depth', params)
+  }
+}

--- a/iznik-nuxt3/api/index.js
+++ b/iznik-nuxt3/api/index.js
@@ -14,6 +14,7 @@ import AIImagesAPI from './AIImagesAPI.js'
 import AlertAPI from './AlertAPI.js'
 import AuthorityAPI from './AuthorityAPI.js'
 import BanditAPI from './BanditAPI.js'
+import BrowseAPI from './BrowseAPI.js'
 import CharityAPI from './CharityAPI.js'
 import ChatAPI from './ChatAPI.js'
 import CommentAPI from './CommentAPI.js'
@@ -64,6 +65,7 @@ export default (config) => {
     alert: new AlertAPI(options),
     authority: new AuthorityAPI(options),
     bandit: new BanditAPI(options),
+    browse: new BrowseAPI(options),
     charity: new CharityAPI(options),
     chat: new ChatAPI(options),
     comment: new CommentAPI(options),

--- a/iznik-nuxt3/components/MessageList.vue
+++ b/iznik-nuxt3/components/MessageList.vue
@@ -150,6 +150,7 @@ import { useGroupStore } from '~/stores/group'
 import { useMessageStore } from '~/stores/message'
 import { throttleFetches } from '~/composables/useThrottle'
 import { useMe } from '~/composables/useMe'
+import { useScrollDepth } from '~/composables/useScrollDepth'
 
 const OurMessage = defineAsyncComponent(() =>
   import('~/components/OurMessage.vue')
@@ -245,6 +246,15 @@ const emit = defineEmits(['update:none', 'update:visible'])
 const groupStore = useGroupStore()
 const messageStore = useMessageStore()
 const { me, myid, myGroups: myMemberships } = useMe()
+
+// Browse-feed scroll-depth instrumentation: record how far down the feed this
+// session scrolls (reported once on leave/hide). 'search' vs 'browse' so the
+// sysadmin "Scrolling" tab can tell the two feeds apart.
+const runtimeConfig = useRuntimeConfig()
+const { record: recordScrollDepth } = useScrollDepth(
+  runtimeConfig?.public?.APIv2,
+  () => (props.search ? 'search' : 'browse')
+)
 
 // Get the initial messages to show in a single call.
 // Wait for fetch to complete before enabling the split view (unseen/seen),
@@ -528,6 +538,11 @@ function pollUntilZero() {
 }
 
 async function handleLoadMore(currentIndex) {
+  // Record the furthest feed position this session has reached (the infinite-scroll
+  // index grows as the member scrolls down). The composable keeps the max and reports
+  // it once on leave/hide.
+  recordScrollDepth(currentIndex, reduceSuccessful.value?.length || 0)
+
   // Prefetch upcoming messages when scrolling.
   // ScrollGrid loads 10 items at a time, so we need to fetch at least 10 ahead.
   const batchSize = 15

--- a/iznik-nuxt3/composables/useScrollDepth.js
+++ b/iznik-nuxt3/composables/useScrollDepth.js
@@ -1,0 +1,97 @@
+// Browse-feed scroll-depth capture.
+//
+// Tracks the FURTHEST feed position a browse session reached and reports it once,
+// on leave/hide, to POST /scrolldepth. This is the browse-feed analogue of the
+// digest click-by-position instrumentation: aggregated server-side into a
+// scroll-depth curve (what fraction of sessions reach position N) on the sysadmin
+// "Scrolling" tab.
+//
+// record(position, total) is called as the feed grows (e.g. from the infinite-scroll
+// load-more handler, which knows the furthest item index revealed). The send is
+// fire-and-forget via navigator.sendBeacon so it survives the page unload; a single
+// session reports at most once.
+//
+// apiBase is the APIv2 base URL (so the composable stays unit-testable without the
+// Nuxt runtime). getContext returns 'browse' or 'search' for the current feed.
+
+import { onBeforeUnmount, getCurrentInstance } from 'vue'
+
+export function useScrollDepth(apiBase, getContext) {
+  let maxPos = -1
+  let itemsAvailable = 0
+  let sent = false
+
+  function record(position, total) {
+    if (typeof position === 'number' && position > maxPos) {
+      maxPos = position
+    }
+    if (typeof total === 'number' && total > itemsAvailable) {
+      itemsAvailable = total
+    }
+  }
+
+  function send() {
+    // Nothing scrolled, already reported this session, or no API base (e.g. SSR
+    // or missing runtime config) — never emit a broken request.
+    if (sent || maxPos < 0 || !apiBase) {
+      return
+    }
+    sent = true
+
+    const body = JSON.stringify({
+      maxposition: maxPos,
+      itemsavailable: itemsAvailable,
+      context: (getContext && getContext()) || 'browse',
+    })
+    const url = `${apiBase}/scrolldepth`
+
+    try {
+      // sendBeacon is the reliable way to get a request out during unload; fall back
+      // to a keepalive fetch where it's unavailable (older browsers / test env).
+      if (typeof navigator !== 'undefined' && navigator.sendBeacon) {
+        navigator.sendBeacon(
+          url,
+          new Blob([body], { type: 'application/json' })
+        )
+      } else if (typeof fetch !== 'undefined') {
+        fetch(url, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body,
+          keepalive: true,
+        }).catch(() => {})
+      }
+    } catch (e) {
+      // Fire-and-forget: instrumentation must never disrupt browsing.
+    }
+  }
+
+  // Report when the tab is hidden (covers mobile app-switch / tab close, where
+  // unmount may not fire) and on component teardown (SPA route change away).
+  function onVisibilityChange() {
+    if (
+      typeof document !== 'undefined' &&
+      document.visibilityState === 'hidden'
+    ) {
+      send()
+    }
+  }
+
+  if (typeof document !== 'undefined') {
+    document.addEventListener('visibilitychange', onVisibilityChange)
+  }
+
+  // Only register the unmount hook when used inside a component (the SPA
+  // route-away case). Guarding on the instance keeps the composable usable — and
+  // warning-free — outside a setup context, e.g. in unit tests.
+  if (getCurrentInstance()) {
+    onBeforeUnmount(() => {
+      if (typeof document !== 'undefined') {
+        document.removeEventListener('visibilitychange', onVisibilityChange)
+      }
+      send()
+    })
+  }
+
+  return { record, send }
+}

--- a/iznik-nuxt3/modtools/components/ModSysAdminBrowseScroll.vue
+++ b/iznik-nuxt3/modtools/components/ModSysAdminBrowseScroll.vue
@@ -1,0 +1,165 @@
+<template>
+  <div class="browse-scroll">
+    <p class="text-muted">
+      How far down the <strong>browse feed</strong> do people scroll? Each
+      browse session records the furthest feed position it reached. This shows,
+      for each position (0 = top), the percentage of sessions that scrolled at
+      least that far — the browse-feed counterpart to the digest
+      click-by-position chart, so you can see where people stop.
+    </p>
+
+    <ModEmailDateFilter
+      :loading="loading"
+      fetch-label="Fetch"
+      default-preset="30days"
+      @fetch="onFilterFetch"
+    />
+
+    <div v-if="loading" class="text-center py-4">
+      <b-spinner small class="me-2" />
+      Loading browse scroll depth...
+    </div>
+
+    <NoticeMessage v-else-if="error" variant="danger" class="mb-3">
+      {{ error }}
+    </NoticeMessage>
+
+    <template v-else-if="positions.length">
+      <NoticeMessage v-if="insight" variant="info" class="mb-3">
+        {{ insight }}
+      </NoticeMessage>
+
+      <div class="chart-container mb-4">
+        <GChart
+          type="LineChart"
+          :data="chartData"
+          :options="chartOptions"
+          class="chart"
+        />
+      </div>
+
+      <b-table
+        :items="tableRows"
+        :fields="tableFields"
+        striped
+        hover
+        responsive
+        small
+      />
+      <p class="text-muted small">
+        Based on <strong>{{ total.toLocaleString() }}</strong> browse sessions
+        in the selected period. <strong>Sessions reaching</strong> counts
+        sessions that scrolled to at least that position.
+      </p>
+    </template>
+
+    <div v-else class="text-muted text-center py-4">
+      <p>No browse scroll data for the selected period.</p>
+      <p class="small">Try widening the date range.</p>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed } from 'vue'
+import { GChart } from 'vue-google-charts'
+import api from '~/api'
+import ModEmailDateFilter from '~/modtools/components/ModEmailDateFilter.vue'
+
+const runtimeConfig = useRuntimeConfig()
+const apiInstance = api(runtimeConfig)
+
+const loading = ref(false)
+const error = ref(null)
+const positions = ref([])
+const total = ref(0)
+const startDate = ref('')
+const endDate = ref('')
+
+const tableFields = [
+  { key: 'position', label: 'Feed position', sortable: true },
+  { key: 'sessions_reaching', label: 'Sessions reaching', sortable: true },
+  { key: 'pct', label: '% of sessions', sortable: true },
+]
+
+const tableRows = computed(() =>
+  (positions.value || []).map((p) => ({
+    position: p.position,
+    sessions_reaching: (p.sessions_reaching || 0).toLocaleString(),
+    pct: `${(p.pct || 0).toFixed(1)}%`,
+  }))
+)
+
+const chartData = computed(() => {
+  const rows = positions.value || []
+  if (!rows.length) return null
+  return [
+    ['Feed position', '% of sessions reaching'],
+    ...rows.map((p) => [p.position, p.pct || 0]),
+  ]
+})
+
+const chartOptions = {
+  title: 'Browse-feed scroll depth: % of sessions reaching each position',
+  legend: { position: 'none' },
+  chartArea: { width: '80%', height: '70%' },
+  hAxis: { title: 'Feed position (0 = top)' },
+  vAxis: {
+    title: '% of sessions reaching',
+    viewWindow: { min: 0, max: 100 },
+    format: '#.#',
+  },
+  colors: ['#17a2b8'],
+  animation: { startup: true, duration: 500, easing: 'out' },
+}
+
+// Plain-English takeaway: where reach falls below half.
+const insight = computed(() => {
+  const rows = positions.value || []
+  if (rows.length < 2) return null
+  const half = rows.find((p) => (p.pct || 0) < 50)
+  if (!half) return null
+  return `Half of browse sessions never scroll past position ${half.position}.`
+})
+
+async function fetchScrollDepth() {
+  loading.value = true
+  error.value = null
+  try {
+    const result = await apiInstance.browse.fetchScrollDepth({
+      start: startDate.value,
+      end: endDate.value,
+    })
+    positions.value = result?.positions || []
+    total.value = result?.total || 0
+  } catch (e) {
+    error.value = e.message || 'Unknown error'
+  } finally {
+    loading.value = false
+  }
+}
+
+// ModEmailDateFilter fires this on mount and whenever the period changes, so it
+// drives the initial load too.
+function onFilterFetch({ start, end }) {
+  startDate.value = start || ''
+  endDate.value = end || ''
+  fetchScrollDepth()
+}
+
+defineExpose({ fetchScrollDepth, onFilterFetch, chartData, tableRows, insight })
+</script>
+
+<style scoped lang="scss">
+.browse-scroll {
+  .chart-container {
+    width: 100%;
+    min-height: 380px;
+  }
+
+  .chart {
+    width: 100%;
+    height: 380px;
+  }
+}
+</style>

--- a/iznik-nuxt3/modtools/pages/sysadmin/index.vue
+++ b/iznik-nuxt3/modtools/pages/sysadmin/index.vue
@@ -53,15 +53,23 @@
           />
         </b-tab>
 
-        <!-- Digest Clicks Tab -->
+        <!-- Scrolling Tab: how far people scroll/engage — digest click-through by
+             position, and browse-feed scroll depth. -->
         <b-tab @click="onDigestClicksTab">
           <template #title>
-            <h2 class="ms-2 me-2">Digest Clicks</h2>
+            <h2 class="ms-2 me-2">Scrolling</h2>
           </template>
-          <ModSysAdminDigestClicks
-            v-if="showDigestClicks"
-            :key="'digestclicks-' + digestClicksBump"
-          />
+          <template v-if="showDigestClicks">
+            <h3 class="ms-2 mt-2">Digest click-through by position</h3>
+            <ModSysAdminDigestClicks
+              :key="'digestclicks-' + digestClicksBump"
+            />
+            <hr class="my-4" />
+            <h3 class="ms-2 mt-2">Browse-feed scroll depth</h3>
+            <ModSysAdminBrowseScroll
+              :key="'browsescroll-' + digestClicksBump"
+            />
+          </template>
         </b-tab>
 
         <!-- Incoming Email Tab -->

--- a/iznik-nuxt3/tests/unit/components/modtools/ModSysAdminBrowseScroll.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModSysAdminBrowseScroll.spec.js
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+
+import ModSysAdminBrowseScroll from '~/modtools/components/ModSysAdminBrowseScroll.vue'
+
+const mockFetchScrollDepth = vi.fn().mockResolvedValue({ total: 0, positions: [] })
+
+vi.mock('~/api', () => ({
+  default: () => ({ browse: { fetchScrollDepth: mockFetchScrollDepth } }),
+}))
+
+vi.mock('#app', () => ({
+  useRuntimeConfig: () => ({ public: { APIv2: 'http://test/apiv2' } }),
+}))
+
+vi.mock('vue-google-charts', () => ({
+  GChart: {
+    template: '<div class="gchart" :data-type="type" />',
+    props: ['type', 'data', 'options'],
+  },
+}))
+
+describe('ModSysAdminBrowseScroll', () => {
+  function mountComponent() {
+    return mount(ModSysAdminBrowseScroll, {
+      global: {
+        stubs: {
+          NoticeMessage: {
+            template:
+              '<div class="notice-message" :class="variant"><slot /></div>',
+            props: ['variant'],
+          },
+          'b-spinner': { template: '<span class="spinner" />' },
+          'b-table': {
+            template: '<table class="table" />',
+            props: ['items', 'fields', 'striped', 'hover', 'responsive', 'small'],
+          },
+          GChart: {
+            template: '<div class="gchart" :data-type="type" />',
+            props: ['type', 'data', 'options'],
+          },
+          ModEmailDateFilter: {
+            template: '<div class="date-filter" />',
+            props: ['loading', 'fetchLabel', 'defaultPreset'],
+          },
+        },
+      },
+    })
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockFetchScrollDepth.mockResolvedValue({ total: 0, positions: [] })
+  })
+
+  // Drive a fetch with a given curve, then return the mounted wrapper.
+  async function withPositions(positions, total = 1000) {
+    mockFetchScrollDepth.mockResolvedValue({ total, positions })
+    const wrapper = mountComponent()
+    wrapper.vm.onFilterFetch({ start: '2026-01-01', end: '2026-01-31' })
+    await flushPromises()
+    return wrapper
+  }
+
+  describe('rendering', () => {
+    it('explains the browse-feed scroll metric', () => {
+      expect(mountComponent().text().toLowerCase()).toContain('browse feed')
+    })
+
+    it('renders the date filter', () => {
+      expect(mountComponent().find('.date-filter').exists()).toBe(true)
+    })
+
+    it('shows the empty message before any data is fetched', () => {
+      expect(mountComponent().text()).toContain('No browse scroll data')
+    })
+
+    it('shows the chart once data is present', async () => {
+      const wrapper = await withPositions([{ position: 0, sessions_reaching: 10, pct: 100 }])
+      expect(wrapper.find('.gchart').exists()).toBe(true)
+      expect(wrapper.find('.gchart').attributes('data-type')).toBe('LineChart')
+    })
+  })
+
+  describe('tableRows', () => {
+    it('formats position, sessions reaching, and percentage', async () => {
+      const wrapper = await withPositions([
+        { position: 0, sessions_reaching: 1000, pct: 100 },
+        { position: 5, sessions_reaching: 620, pct: 62 },
+      ])
+      const rows = wrapper.vm.tableRows
+      expect(rows[0]).toMatchObject({
+        position: 0,
+        sessions_reaching: '1,000',
+        pct: '100.0%',
+      })
+      expect(rows[1]).toMatchObject({
+        position: 5,
+        sessions_reaching: '620',
+        pct: '62.0%',
+      })
+    })
+  })
+
+  describe('chartData', () => {
+    it('maps each position to its percentage reaching', async () => {
+      const wrapper = await withPositions([
+        { position: 0, sessions_reaching: 1000, pct: 100 },
+        { position: 1, sessions_reaching: 900, pct: 90 },
+      ])
+      expect(wrapper.vm.chartData).toEqual([
+        ['Feed position', '% of sessions reaching'],
+        [0, 100],
+        [1, 90],
+      ])
+    })
+  })
+
+  describe('insight', () => {
+    it('names the position where reach first falls below half', async () => {
+      const wrapper = await withPositions([
+        { position: 0, sessions_reaching: 1000, pct: 100 },
+        { position: 7, sessions_reaching: 480, pct: 48 },
+      ])
+      expect(wrapper.vm.insight).toContain('position 7')
+    })
+
+    it('is null when reach never drops below half', async () => {
+      const wrapper = await withPositions([
+        { position: 0, sessions_reaching: 1000, pct: 100 },
+        { position: 1, sessions_reaching: 900, pct: 90 },
+      ])
+      expect(wrapper.vm.insight).toBeNull()
+    })
+  })
+
+  describe('fetching', () => {
+    it('onFilterFetch fetches via api.browse.fetchScrollDepth with the dates', async () => {
+      const wrapper = mountComponent()
+      wrapper.vm.onFilterFetch({ start: '2026-01-01', end: '2026-01-31' })
+      await flushPromises()
+      expect(mockFetchScrollDepth).toHaveBeenCalledWith({
+        start: '2026-01-01',
+        end: '2026-01-31',
+      })
+    })
+  })
+})

--- a/iznik-nuxt3/tests/unit/composables/useScrollDepth.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useScrollDepth.spec.js
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { useScrollDepth } from '~/composables/useScrollDepth'
+
+// useScrollDepth registers an onBeforeUnmount hook; called outside a component it
+// just warns and is a no-op, which is fine — we drive record()/send() directly.
+
+describe('useScrollDepth', () => {
+  let beacon
+
+  beforeEach(() => {
+    beacon = vi.fn(() => true)
+    global.navigator = { sendBeacon: beacon }
+    global.document = {
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      visibilityState: 'visible',
+    }
+  })
+
+  it('reports the furthest recorded position once, as JSON, on send()', async () => {
+    const { record, send } = useScrollDepth('https://api.test/apiv2', () => 'search')
+    record(3, 50)
+    record(12, 60)
+    record(7, 60) // lower than the max — ignored
+
+    send()
+
+    expect(beacon).toHaveBeenCalledTimes(1)
+    const [url, blob] = beacon.mock.calls[0]
+    expect(url).toBe('https://api.test/apiv2/scrolldepth')
+    expect(blob.type).toBe('application/json')
+    const payload = JSON.parse(await blob.text())
+    expect(payload).toEqual({ maxposition: 12, itemsavailable: 60, context: 'search' })
+  })
+
+  it('does not send when nothing was recorded', () => {
+    const { send } = useScrollDepth('https://api.test/apiv2', () => 'browse')
+    send()
+    expect(beacon).not.toHaveBeenCalled()
+  })
+
+  it('does not send when there is no API base', () => {
+    const { record, send } = useScrollDepth(undefined, () => 'browse')
+    record(5, 10)
+    send()
+    expect(beacon).not.toHaveBeenCalled()
+  })
+
+  it('sends at most once per session', () => {
+    const { record, send } = useScrollDepth('https://api.test/apiv2', () => 'browse')
+    record(5, 10)
+    send()
+    send()
+    expect(beacon).toHaveBeenCalledTimes(1)
+  })
+
+  it('defaults the context to browse', async () => {
+    const { record, send } = useScrollDepth('https://api.test/apiv2')
+    record(2, 10)
+    send()
+    const payload = JSON.parse(await beacon.mock.calls[0][1].text())
+    expect(payload.context).toBe('browse')
+  })
+})

--- a/iznik-server-go/browse/scroll.go
+++ b/iznik-server-go/browse/scroll.go
@@ -1,0 +1,161 @@
+// Package browse holds browse-feed instrumentation endpoints.
+package browse
+
+import (
+	"strings"
+	"time"
+
+	"github.com/freegle/iznik-server-go/auth"
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/freegle/iznik-server-go/user"
+	"github.com/gofiber/fiber/v2"
+)
+
+// maxScrollPosition caps a recorded position so a malformed or malicious client
+// can't write an absurd value (the browse feed never has anywhere near this many
+// items in one session).
+const maxScrollPosition = 100000
+
+type RecordScrollDepthRequest struct {
+	// MaxPosition is the furthest 0-based feed item index reached in the session.
+	MaxPosition int `json:"maxposition"`
+	// ItemsAvailable is the feed length when recorded (optional context).
+	ItemsAvailable int `json:"itemsavailable"`
+	// Context is which feed: "browse" (default) or "search".
+	Context string `json:"context"`
+}
+
+// RecordScrollDepth records how far down the browse feed a session scrolled.
+//
+// POST /api/scrolldepth — one row per browse session (the client sends the max
+// position reached on leave/hide). No login required: logged-out browsing is
+// recorded with a NULL userid. Powers the sysadmin "Scrolling" scroll-depth curve.
+func RecordScrollDepth(c *fiber.Ctx) error {
+	var req RecordScrollDepthRequest
+	if err := c.BodyParser(&req); err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, "Invalid request body")
+	}
+
+	// Silently ignore nonsense rather than erroring the client; the beacon is fire-and-forget.
+	if req.MaxPosition < 0 || req.MaxPosition > maxScrollPosition {
+		return c.JSON(fiber.Map{"ret": 0, "status": "Success"})
+	}
+
+	db := database.DBConn
+
+	// Record the userid only when logged in; NULL otherwise.
+	var userid interface{}
+	if myid := user.WhoAmI(c); myid > 0 {
+		userid = myid
+	}
+
+	// Normalise the feed context to the two known values.
+	ctx := req.Context
+	if ctx != "browse" && ctx != "search" {
+		ctx = "browse"
+	}
+
+	// items_available is optional context; store NULL when not supplied.
+	var items interface{}
+	if req.ItemsAvailable > 0 {
+		items = req.ItemsAvailable
+	}
+
+	db.Exec("INSERT INTO browse_scroll_depth (userid, max_position, items_available, context) VALUES (?, ?, ?, ?)",
+		userid, req.MaxPosition, items, ctx)
+
+	return c.JSON(fiber.Map{"ret": 0, "status": "Success"})
+}
+
+// ScrollDepthPoint is one position on the scroll-depth curve.
+type ScrollDepthPoint struct {
+	Position         int     `json:"position"`
+	SessionsReaching int64   `json:"sessions_reaching"`
+	Pct              float64 `json:"pct"`
+}
+
+// ScrollDepthCurve returns the browse-feed scroll-depth curve for the sysadmin
+// "Scrolling" tab: for each feed position N, the number and fraction of sessions
+// that scrolled to at least position N. The browse-feed analogue of the digest
+// click-by-position chart.
+//
+// GET /api/modtools/scroll/depth — Support or Admin only. Defaults to the last 7
+// days; pass ?start=YYYY-MM-DD&end=YYYY-MM-DD for a wider window.
+func ScrollDepthCurve(c *fiber.Ctx) error {
+	db := database.DBConn
+
+	myid := user.WhoAmI(c)
+	if myid == 0 {
+		return fiber.NewError(fiber.StatusUnauthorized, "Not logged in")
+	}
+	if !auth.IsAdminOrSupport(myid) {
+		return fiber.NewError(fiber.StatusForbidden, "Support or Admin role required")
+	}
+
+	startDate := c.Query("start", "")
+	endDate := c.Query("end", "")
+	if startDate == "" || endDate == "" {
+		now := time.Now()
+		endDate = now.Format("2006-01-02")
+		startDate = now.AddDate(0, 0, -7).Format("2006-01-02")
+	}
+	endDateTime := endDate
+	if !strings.Contains(endDate, " ") && !strings.Contains(endDate, "T") {
+		endDateTime = endDate + " 23:59:59"
+	}
+
+	// One row per distinct furthest-position reached, with how many sessions stopped there.
+	var rows []struct {
+		MaxPosition int   `gorm:"column:max_position"`
+		Cnt         int64 `gorm:"column:cnt"`
+	}
+	db.Raw(`SELECT max_position, COUNT(*) AS cnt
+	        FROM browse_scroll_depth
+	        WHERE created_at BETWEEN ? AND ?
+	        GROUP BY max_position`, startDate, endDateTime).Scan(&rows)
+
+	var total int64
+	maxObserved := 0
+	for _, r := range rows {
+		total += r.Cnt
+		if r.MaxPosition > maxObserved {
+			maxObserved = r.MaxPosition
+		}
+	}
+
+	// Cap the number of points so a long tail can't bloat the payload.
+	limit := maxObserved
+	if limit > 200 {
+		limit = 200
+	}
+
+	// reaching[n] = sessions whose furthest position was >= n. Built as a suffix sum
+	// over the per-position counts: walk positions high->low accumulating the count.
+	counts := make([]int64, maxObserved+1)
+	for _, r := range rows {
+		if r.MaxPosition >= 0 && r.MaxPosition <= maxObserved {
+			counts[r.MaxPosition] += r.Cnt
+		}
+	}
+	suffix := make([]int64, maxObserved+2)
+	for n := maxObserved; n >= 0; n-- {
+		suffix[n] = suffix[n+1] + counts[n]
+	}
+
+	positions := make([]ScrollDepthPoint, 0, limit+1)
+	for n := 0; n <= limit; n++ {
+		reaching := suffix[n]
+		pct := 0.0
+		if total > 0 {
+			pct = float64(reaching) / float64(total) * 100
+		}
+		positions = append(positions, ScrollDepthPoint{Position: n, SessionsReaching: reaching, Pct: pct})
+	}
+
+	return c.JSON(fiber.Map{
+		"ret":       0,
+		"status":    "Success",
+		"total":     total,
+		"positions": positions,
+	})
+}

--- a/iznik-server-go/router/routes.go
+++ b/iznik-server-go/router/routes.go
@@ -25,6 +25,7 @@ import (
 	"github.com/freegle/iznik-server-go/abtest"
 	"github.com/freegle/iznik-server-go/address"
 	"github.com/freegle/iznik-server-go/admin"
+	"github.com/freegle/iznik-server-go/browse"
 	"github.com/freegle/iznik-server-go/avatar"
 	"github.com/freegle/iznik-server-go/aiimage"
 	"github.com/freegle/iznik-server-go/alert"
@@ -105,6 +106,15 @@ func SetupRoutes(app *fiber.App) {
 		// @Accept json
 		// @Produce json
 		rg.Post("/abtest", abtest.PostABTest)
+
+		// Browse-feed scroll depth: record how far down the feed a session scrolled.
+		// @Router /scrolldepth [post]
+		// @Summary Record browse-feed scroll depth
+		// @Description One row per browse session (furthest feed position reached); no login required
+		// @Tags browse
+		// @Accept json
+		// @Produce json
+		rg.Post("/scrolldepth", browse.RecordScrollDepth)
 
 		// Message Activity
 		// @Router /activity [get]
@@ -1296,6 +1306,14 @@ func SetupRoutes(app *fiber.App) {
 		// @Failure 401 {object} fiber.Error "Unauthorized"
 		// @Failure 403 {object} fiber.Error "Forbidden"
 		rg.Get("/modtools/email/stats/digestpositions", emailtracking.DigestClickPositions)
+
+		// Browse-feed scroll-depth curve for the sysadmin "Scrolling" tab (Support/Admin).
+		// @Router /modtools/scroll/depth [get]
+		// @Summary Browse-feed scroll-depth curve
+		// @Description For each feed position N, the fraction of sessions that scrolled at least N deep
+		// @Tags browse
+		// @Produce json
+		rg.Get("/modtools/scroll/depth", browse.ScrollDepthCurve)
 
 		// Email Tracking for specific user (authenticated, admin only)
 		// @Router /email/user/{id} [get]

--- a/iznik-server-go/test/browse_test.go
+++ b/iznik-server-go/test/browse_test.go
@@ -1,0 +1,89 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/stretchr/testify/assert"
+)
+
+// POST /scrolldepth records how far down the browse feed a session scrolled. No login
+// required; userid is NULL for logged-out browsing.
+func TestRecordScrollDepth(t *testing.T) {
+	db := database.DBConn
+	// A distinctive position so we can find our row without colliding with other sessions.
+	pos := 4242
+	defer db.Exec("DELETE FROM browse_scroll_depth WHERE max_position = ?", pos)
+
+	body := fmt.Sprintf(`{"maxposition":%d,"itemsavailable":60,"context":"browse"}`, pos)
+	req := httptest.NewRequest("POST", "/api/scrolldepth", bytes.NewReader([]byte(body)))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var count int
+	db.Raw("SELECT COUNT(*) FROM browse_scroll_depth WHERE max_position = ? AND context = 'browse'", pos).Scan(&count)
+	assert.Equal(t, 1, count, "a scroll-depth row was recorded")
+}
+
+// An out-of-range position is silently ignored (the beacon is fire-and-forget) and writes no row.
+func TestRecordScrollDepth_IgnoresOutOfRange(t *testing.T) {
+	db := database.DBConn
+	body := `{"maxposition":-5,"context":"browse"}`
+	req := httptest.NewRequest("POST", "/api/scrolldepth", bytes.NewReader([]byte(body)))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var count int
+	db.Raw("SELECT COUNT(*) FROM browse_scroll_depth WHERE max_position = -5").Scan(&count)
+	assert.Equal(t, 0, count, "an out-of-range position is not recorded")
+}
+
+// GET /modtools/scroll/depth returns the scroll-depth curve (Support/Admin only). Position 0 is,
+// by construction, reached by 100% of sessions, so that's a stable assertion regardless of what
+// other sessions are in the window.
+func TestScrollDepthCurve(t *testing.T) {
+	prefix := uniquePrefix("scrolldepth")
+	adminID := CreateTestUser(t, prefix+"_admin", "Support")
+	_, token := CreateTestSession(t, adminID)
+
+	db := database.DBConn
+	ctx := prefix
+	db.Exec("INSERT INTO browse_scroll_depth (max_position, context) VALUES (0, ?), (5, ?), (10, ?)", ctx, ctx, ctx)
+	defer db.Exec("DELETE FROM browse_scroll_depth WHERE context = ?", ctx)
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET", fmt.Sprintf("/api/modtools/scroll/depth?jwt=%s", token), nil))
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json.Unmarshal(rsp(resp), &result)
+
+	positions, _ := result["positions"].([]interface{})
+	assert.NotEmpty(t, positions, "the curve has positions")
+
+	first, _ := positions[0].(map[string]interface{})
+	assert.Equal(t, float64(0), first["position"], "the curve starts at position 0")
+	assert.Equal(t, float64(100), first["pct"], "every session reaches position 0")
+	assert.Contains(t, first, "sessions_reaching")
+}
+
+// The scroll-depth curve requires login.
+func TestScrollDepthCurveRequiresLogin(t *testing.T) {
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/modtools/scroll/depth", nil))
+	assert.Equal(t, 401, resp.StatusCode, "the scroll-depth curve requires login")
+}
+
+// The scroll-depth curve is Support/Admin only.
+func TestScrollDepthCurveRequiresAdmin(t *testing.T) {
+	prefix := uniquePrefix("scrolldepth_noauth")
+	userID := CreateTestUser(t, prefix, "User")
+	_, token := CreateTestSession(t, userID)
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET", fmt.Sprintf("/api/modtools/scroll/depth?jwt=%s", token), nil))
+	assert.Equal(t, 403, resp.StatusCode, "non-admin is forbidden from the scroll-depth curve")
+}


### PR DESCRIPTION
## Summary
Instruments **how far down the browse feed people scroll**, modelled on the existing digest click-by-position instrumentation, and surfaces it on a renamed sysadmin **"Scrolling"** tab.

**Backend**
- Migration `browse_scroll_depth` (+ idempotent prod SQL): one row per browse session recording the **furthest 0-based feed position reached** (`userid` nullable for logged-out browsing; `items_available` + `context` for the feed type).
- `browse.RecordScrollDepth` — `POST /scrolldepth`, no login required (fire-and-forget beacon).
- `browse.ScrollDepthCurve` — `GET /modtools/scroll/depth` (Support/Admin): for each position N, the count and fraction of sessions reaching at least N (suffix-sum curve), with a 7-day default window.

**Frontend**
- `useScrollDepth` composable: tracks the furthest feed position and reports it **once** on leave/hide via `navigator.sendBeacon` (keepalive `fetch` fallback); no-op when nothing scrolled or no API base.
- `MessageList` records the furthest infinite-scroll position reached; context is `search` vs `browse`.
- `ModSysAdminBrowseScroll` renders the scroll-depth curve. The sysadmin **"Digest Clicks" tab is renamed "Scrolling"** and now shows both the digest click-by-position chart and the new browse scroll-depth chart.

## Code Quality Review
- The capture composable is self-contained and side-effect-safe outside a component (guards `getCurrentInstance()`, `typeof document`, missing API base) so it's unit-testable and SSR-safe.
- The write endpoint caps `max_position` to reject malformed/abusive values and stores `userid` only when logged in.
- The read curve is computed with an O(positions) suffix sum and caps the returned points to keep the payload bounded.
- Reuses the established patterns: `ModEmailDateFilter` + `GChart`, `api(runtimeConfig)` fetch (as `ModSysAdminRippling`), and a `BrowseAPI` registered alongside the other namespaces.

## Future Improvements
- The feed could pass a finer context (e.g. per group) for segmenting scroll depth.
- Pair with the view-source distinction (#866) to correlate scroll depth with dwell/open rates.

## Validation
- `useScrollDepth` composable: 5 cases (max tracking, JSON beacon payload, once-only, default context, no-API-base no-op) — pass.
- `ModSysAdminBrowseScroll`: 9 cases (rendering, chart presence, table formatting, curve mapping, insight, fetch) — pass.
- `MessageList` existing suite — 55 pass (wiring did not regress it).
- Go backend + migration validated by CI.
