### PR TITLE
fix(push): prefer real photos over AI illustrations in daily-posts collage

### DIFF
--- a/iznik-batch/app/Services/PushNotificationService.php
+++ b/iznik-batch/app/Services/PushNotificationService.php
@@ -1312,17 +1312,33 @@ class PushNotificationService
         // images = up to 4 photo URLs across the top posts; the app tiles these into a
         //          collage for the multi-post expanded view (needs >=2, else it falls back
         //          to the text list).
-        $imageUrls = [];
+        //
+        // Prefer real (user-uploaded) photos over AI illustrations: collect real photos
+        // first (in digest order), then pad the remaining collage slots with AI photos
+        // only when there aren't enough real ones. The single `image` follows the same
+        // preference (real photos come first in the merged list).
+        $realUrls = [];
+        $aiUrls   = [];
         foreach ($posts as $item) {
-            if (count($imageUrls) >= 4) {
+            // Once four real photos are found they fill the whole collage, so there is
+            // no need to keep scanning for AI padding.
+            if (count($realUrls) >= 4) {
                 break;
             }
-            $url = $this->extractPostImageUrl($item['message']);
-            if ($url) {
-                $imageUrls[] = $url;
+            $img = $this->extractPostImage($item['message']);
+            if (! $img) {
+                continue;
+            }
+            if ($img['ai']) {
+                if (count($aiUrls) < 4) {
+                    $aiUrls[] = $img['url'];
+                }
+            } else {
+                $realUrls[] = $img['url'];
             }
         }
-        $imageUrl = $imageUrls[0] ?? null;
+        $imageUrls = array_slice(array_merge($realUrls, $aiUrls), 0, 4);
+        $imageUrl  = $imageUrls[0] ?? null;
 
         // The app-icon badge must reflect the user's actionable unread items
         // (unread chats + unseen notifications), NOT the number of posts in this
@@ -1410,8 +1426,8 @@ class PushNotificationService
     }
 
     /**
-     * Return a public image URL for the first usable attachment on a post,
-     * or null if the post has no photo.
+     * Return ['url' => string, 'ai' => bool] for the best usable attachment on a
+     * post (real photo preferred over AI illustration), or null if it has no photo.
      *
      * Mirrors UnifiedDigest::getMessageImageUrl() but returns the raw source
      * URL (no delivery-service resizing) so that FCM stores it on its CDN and
@@ -1420,28 +1436,50 @@ class PushNotificationService
      * resizing step is unnecessary and adds a round-trip that can time out in
      * the NSE's short execution window.
      */
-    private function extractPostImageUrl(\App\Models\Message $msg): ?string
+    private function extractPostImage(\App\Models\Message $msg): ?array
     {
         if (! $msg->attachments || $msg->attachments->isEmpty()) {
             return null;
         }
 
-        // Prefer primary=1; skip attachments that haven't finished uploading
-        // (no externaluid/externalurl/archived yet — same filter as prepareCard).
-        $attachment = $msg->attachments
-            ->filter(fn ($a) => ! empty($a->externaluid) || ! empty($a->externalurl) || (int) ($a->archived ?? 0) === 1)
-            ->sortByDesc('primary')
-            ->first();
+        // Skip attachments that haven't finished uploading (no
+        // externaluid/externalurl/archived yet — same filter as prepareCard).
+        $usable = $msg->attachments
+            ->filter(fn ($a) => ! empty($a->externaluid) || ! empty($a->externalurl) || (int) ($a->archived ?? 0) === 1);
 
-        if (! $attachment) {
+        if ($usable->isEmpty()) {
             return null;
         }
 
+        // Within a post, prefer a real (non-AI) photo over an AI illustration,
+        // then prefer primary=1. A post that transiently carries both contributes
+        // its real photo. Rank ascending: real+primary=0, real=1, ai+primary=2, ai=3.
+        $attachment = $usable
+            ->sortBy(fn ($a) => ($this->attachmentIsAi($a) ? 2 : 0) + ($a->primary ? 0 : 1))
+            ->first();
+
         if (! empty($attachment->externalurl)) {
-            return $attachment->externalurl;
+            $url = $attachment->externalurl;
+        } else {
+            $imagesDomain = config('freegle.images.domain', 'https://images.ilovefreegle.org');
+            $url          = "{$imagesDomain}/img_{$attachment->id}.jpg";
         }
 
-        $imagesDomain = config('freegle.images.domain', 'https://images.ilovefreegle.org');
-        return "{$imagesDomain}/img_{$attachment->id}.jpg";
+        return ['url' => $url, 'ai' => $this->attachmentIsAi($attachment)];
+    }
+
+    /**
+     * Whether an attachment is an AI-generated illustration. The flag lives in the
+     * externalmods JSON as {"ai": true} (see iznik-server messages_illustrations cron).
+     */
+    private function attachmentIsAi(\App\Models\MessageAttachment $attachment): bool
+    {
+        if (empty($attachment->externalmods)) {
+            return false;
+        }
+
+        $mods = json_decode($attachment->externalmods, true);
+
+        return is_array($mods) && ($mods['ai'] ?? false) === true;
     }
 }

--- a/iznik-batch/tests/Unit/Services/DailyPostsPushTest.php
+++ b/iznik-batch/tests/Unit/Services/DailyPostsPushTest.php
@@ -273,6 +273,130 @@ class DailyPostsPushTest extends TestCase
         $this->assertSame('https://cdn.example.com/a.jpg', $payload['image']);
     }
 
+    /**
+     * Helper: create an approved OFFER with a single attachment, optionally AI.
+     */
+    private function postWithPhoto(User $user, Group $group, string $subject, string $url, bool $ai = false, int $primary = 1): Message
+    {
+        $msg = $this->createApprovedMessage($user, $group, $subject);
+        MessageAttachment::create([
+            'msgid'        => $msg->id,
+            'externalurl'  => $url,
+            'archived'     => 0,
+            'primary'      => $primary,
+            'externalmods' => $ai ? json_encode(['ai' => true]) : null,
+        ]);
+        $msg->load('attachments');
+
+        return $msg;
+    }
+
+    public function test_collage_puts_real_photos_before_ai_and_pads_with_ai(): void
+    {
+        $user  = $this->createTestUser();
+        $group = $this->createTestGroup();
+
+        // Interleaved real/AI posts: real A, AI X, real B, AI Y, real C.
+        // Collage must list real photos first (in order), then pad to 4 with AI.
+        $posts = $this->buildPostsArray([
+            $this->postWithPhoto($user, $group, 'OFFER: A (London)', 'https://cdn.example.com/realA.jpg'),
+            $this->postWithPhoto($user, $group, 'OFFER: X (London)', 'https://cdn.example.com/aiX.jpg', true),
+            $this->postWithPhoto($user, $group, 'OFFER: B (London)', 'https://cdn.example.com/realB.jpg'),
+            $this->postWithPhoto($user, $group, 'OFFER: Y (London)', 'https://cdn.example.com/aiY.jpg', true),
+            $this->postWithPhoto($user, $group, 'OFFER: C (London)', 'https://cdn.example.com/realC.jpg'),
+        ]);
+
+        $payload = $this->pushService->buildDailyNewPostsPayload($user->id, $posts);
+        $images  = json_decode($payload['images'], true);
+
+        // 3 real first (digest order), then 1 AI to fill the 4-photo collage.
+        $this->assertSame([
+            'https://cdn.example.com/realA.jpg',
+            'https://cdn.example.com/realB.jpg',
+            'https://cdn.example.com/realC.jpg',
+            'https://cdn.example.com/aiX.jpg',
+        ], $images);
+        // The single image also prefers a real photo.
+        $this->assertSame('https://cdn.example.com/realA.jpg', $payload['image']);
+    }
+
+    public function test_collage_pads_with_ai_when_too_few_real(): void
+    {
+        $user  = $this->createTestUser();
+        $group = $this->createTestGroup();
+
+        // Only one real photo available; AI photos fill the remaining slots so the
+        // collage still renders (needs >= 2 photos).
+        $posts = $this->buildPostsArray([
+            $this->postWithPhoto($user, $group, 'OFFER: X (London)', 'https://cdn.example.com/aiX.jpg', true),
+            $this->postWithPhoto($user, $group, 'OFFER: A (London)', 'https://cdn.example.com/realA.jpg'),
+            $this->postWithPhoto($user, $group, 'OFFER: Y (London)', 'https://cdn.example.com/aiY.jpg', true),
+        ]);
+
+        $payload = $this->pushService->buildDailyNewPostsPayload($user->id, $posts);
+        $images  = json_decode($payload['images'], true);
+
+        $this->assertSame([
+            'https://cdn.example.com/realA.jpg',
+            'https://cdn.example.com/aiX.jpg',
+            'https://cdn.example.com/aiY.jpg',
+        ], $images);
+        // image prefers the real photo even though an AI post came first in the digest.
+        $this->assertSame('https://cdn.example.com/realA.jpg', $payload['image']);
+    }
+
+    public function test_collage_uses_ai_when_no_real_photos(): void
+    {
+        $user  = $this->createTestUser();
+        $group = $this->createTestGroup();
+
+        // No real photos at all — AI photos are the only option, so use them.
+        $posts = $this->buildPostsArray([
+            $this->postWithPhoto($user, $group, 'OFFER: X (London)', 'https://cdn.example.com/aiX.jpg', true),
+            $this->postWithPhoto($user, $group, 'OFFER: Y (London)', 'https://cdn.example.com/aiY.jpg', true),
+        ]);
+
+        $payload = $this->pushService->buildDailyNewPostsPayload($user->id, $posts);
+        $images  = json_decode($payload['images'], true);
+
+        $this->assertSame([
+            'https://cdn.example.com/aiX.jpg',
+            'https://cdn.example.com/aiY.jpg',
+        ], $images);
+    }
+
+    public function test_within_post_prefers_real_attachment_over_ai(): void
+    {
+        $user  = $this->createTestUser();
+        $group = $this->createTestGroup();
+
+        // A single post carrying BOTH an AI illustration (primary) and a real photo.
+        // The post must contribute its real photo, even though the AI one is primary.
+        $msg = $this->createApprovedMessage($user, $group, 'OFFER: Sofa (London)');
+        MessageAttachment::create([
+            'msgid'        => $msg->id,
+            'externalurl'  => 'https://cdn.example.com/ai.jpg',
+            'archived'     => 0,
+            'primary'      => 1,
+            'externalmods' => json_encode(['ai' => true]),
+        ]);
+        MessageAttachment::create([
+            'msgid'        => $msg->id,
+            'externalurl'  => 'https://cdn.example.com/real.jpg',
+            'archived'     => 0,
+            'primary'      => 0,
+            'externalmods' => null,
+        ]);
+        $msg->load('attachments');
+
+        $posts   = $this->buildPostsArray([$msg]);
+        $payload = $this->pushService->buildDailyNewPostsPayload($user->id, $posts);
+
+        $this->assertSame('https://cdn.example.com/real.jpg', $payload['image']);
+        $images = json_decode($payload['images'], true);
+        $this->assertSame(['https://cdn.example.com/real.jpg'], $images);
+    }
+
     // -------------------------------------------------------------------------
     // notifyDailyNewPosts — send path (mocked service)
     // -------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The daily "new posts near you" push notification builds a photo collage (up to 4 tiles) from the top posts in the digest. Sometimes those tiles show **AI-generated illustrations** instead of real, user-uploaded photos.

The selection in `PushNotificationService::buildDailyNewPostsPayload()` had no AI awareness: it walked the posts in digest order and took each post's `primary`-sorted attachment, so AI illustrations could fill collage slots ahead of real photos.

## Change

Prefer real photos, falling back to AI only when there aren't enough real ones (you chose "pad to 4 with AI"):

- **Within a post**, pick a real (non-AI) attachment over an AI illustration, then `primary=1`. A post that transiently carries both contributes its real photo. AI is detected via the `messages_attachments.externalmods` JSON `{"ai": true}` flag — the same flag set by the `messages_illustrations` cron and surfaced as `attachment.ai` by the Go API.
- **Across posts**, collect real photos first (in digest order, the existing "most desirable first" ordering), then pad the remaining collage slots with AI photos. The single `image` field (single-post BigPicture / large icon) follows the same preference.

Resulting behaviour:

| Available | Collage |
|---|---|
| 3 real + 2 AI | 3 real + 1 AI (4 tiles) |
| 2 real + 2 AI | 2 real + 2 AI (4 tiles) |
| 1 real + 2 AI | 1 real + 2 AI (3 tiles) |
| 0 real + 3 AI | 3 AI |
| 4 real + 1 AI | 4 real |

No change to the native Android/iOS collage builders — they just receive a better-ordered `images` array. Scanning all posts (instead of stopping at the first 4 photos) adds no DB queries because attachments are eager-loaded on the digest posts.

## Tests

Added to `DailyPostsPushTest`:

- `test_collage_puts_real_photos_before_ai_and_pads_with_ai`
- `test_collage_pads_with_ai_when_too_few_real`
- `test_collage_uses_ai_when_no_real_photos`
- `test_within_post_prefers_real_attachment_over_ai`

Written test-first (watched them fail, then implemented). Full Laravel suite green locally: **4396 tests passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kw9zynBASZV9Yz3piJeSfd
