### PR TITLE
Rippling dashboard: home-vs-rippled cohort lines + much faster load (+ digest-preview 65 cap)

### DIFF
--- a/iznik-nuxt3/modtools/components/ModSysAdminRippling.vue
+++ b/iznik-nuxt3/modtools/components/ModSysAdminRippling.vue
@@ -279,17 +279,7 @@ function pctChartOptions(vTitle, color) {
     animation: { startup: true, duration: 400, easing: 'out' },
   }
 }
-function kmChartOptions() {
-  return {
-    curveType: 'function',
-    legend: { position: 'none' },
-    chartArea: { width: '85%', height: '70%' },
-    vAxis: { title: 'Median km', viewWindow: { min: 0 }, format: '#.#' },
-    hAxis: { title: 'Date', format: 'dd MMM' },
-    series: { 0: { color: '#fd7e14' } },
-    animation: { startup: true, duration: 400, easing: 'out' },
-  }
-}
+
 function cohortPctOptions(vTitle) {
   return {
     curveType: 'function',

--- a/iznik-nuxt3/modtools/components/ModSysAdminRippling.vue
+++ b/iznik-nuxt3/modtools/components/ModSysAdminRippling.vue
@@ -59,7 +59,7 @@
           :options="cohortPctOptions('Reply rate (%)')"
           style="width: 100%; height: 300px"
         />
-        <p class="text-muted small fst-italic mt-1 mb-0">
+        <p v-if="replyRateChart" class="text-muted small fst-italic mt-1 mb-0">
           The dashed tail is still settling - the most recent posts haven't had a full 36h to get a reply yet.
         </p>
         <p v-if="!replyRateChart" class="text-muted small">No data yet.</p>
@@ -119,7 +119,7 @@
           :options="cohortPctOptions('Taken/received (%)')"
           style="width: 100%; height: 300px"
         />
-        <p class="text-muted small fst-italic mt-1 mb-0">
+        <p v-if="takenRateChart" class="text-muted small fst-italic mt-1 mb-0">
           The dashed tail is still settling - recent posts haven't had time to be collected yet.
         </p>
         <p v-if="!takenRateChart" class="text-muted small">No data yet.</p>

--- a/iznik-nuxt3/modtools/components/ModSysAdminRippling.vue
+++ b/iznik-nuxt3/modtools/components/ModSysAdminRippling.vue
@@ -257,7 +257,8 @@ const replyDistanceChart = computed(() => {
   const rows = [...replyDistance.value].reverse().map((r) => [
     new Date(r.day), r.median_km, true, r.home_median_km, true, r.ripple_median_km, true,
   ])
-  return [COHORT_HEADER('All offers'), ...rows]
+  // Distance is a median over replies, not a count of offers, so label the "all" line accordingly.
+  return [COHORT_HEADER('All replies'), ...rows]
 })
 const takenRateChart = computed(() => {
   if (!takenRate.value.length) return null

--- a/iznik-nuxt3/modtools/components/ModSysAdminRippling.vue
+++ b/iznik-nuxt3/modtools/components/ModSysAdminRippling.vue
@@ -56,14 +56,17 @@
           v-if="replyRateChart"
           type="LineChart"
           :data="replyRateChart"
-          :options="pctChartOptions('Reply rate (%)', '#28a745')"
+          :options="cohortPctOptions('Reply rate (%)')"
           style="width: 100%; height: 300px"
         />
-        <p v-else class="text-muted small">No data yet.</p>
+        <p class="text-muted small fst-italic mt-1 mb-0">
+          The dashed tail is still settling - the most recent posts haven't had a full 36h to get a reply yet.
+        </p>
+        <p v-if="!replyRateChart" class="text-muted small">No data yet.</p>
       </div>
 
       <div class="mb-3">
-        <strong class="small">How much of the lift is rippling?</strong>
+        <strong class="small">Share of replies from rippling</strong>
         <p class="text-muted small mb-1">
           Share of replies that came via rippling vs your own members.
           <span class="text-success fw-bold">Good:</span> a real share - the
@@ -96,7 +99,7 @@
           v-if="replyDistanceChart"
           type="LineChart"
           :data="replyDistanceChart"
-          :options="kmChartOptions()"
+          :options="cohortKmOptions()"
           style="width: 100%; height: 300px"
         />
         <p v-else class="text-muted small">No data yet.</p>
@@ -113,10 +116,13 @@
           v-if="takenRateChart"
           type="LineChart"
           :data="takenRateChart"
-          :options="pctChartOptions('Taken/received (%)', '#6f42c1')"
+          :options="cohortPctOptions('Taken/received (%)')"
           style="width: 100%; height: 300px"
         />
-        <p v-else class="text-muted small">No data yet.</p>
+        <p class="text-muted small fst-italic mt-1 mb-0">
+          The dashed tail is still settling - recent posts haven't had time to be collected yet.
+        </p>
+        <p v-if="!takenRateChart" class="text-muted small">No data yet.</p>
       </div>
 
       <h6 class="mt-4">Where to look — geographic hotspots</h6>
@@ -221,12 +227,23 @@ const takenRate = ref([])
 const groupOptions = ref([])
 const groupFilter = ref(0)
 
+const COHORT_HEADER = (allLabel) => [
+  'Date',
+  allLabel,
+  { role: 'certainty', type: 'boolean' },
+  'Home-only',
+  { role: 'certainty', type: 'boolean' },
+  'Rippled-out',
+  { role: 'certainty', type: 'boolean' },
+]
+
 const replyRateChart = computed(() => {
   if (!replyRate.value.length) return null
-  const rows = [...replyRate.value]
-    .reverse()
-    .map((r) => [new Date(r.day), r.reply_pct])
-  return [['Date', '% with reply in 36h'], ...rows]
+  const rows = [...replyRate.value].reverse().map((r) => {
+    const certain = !r.provisional
+    return [new Date(r.day), r.reply_pct, certain, r.home_pct, certain, r.ripple_pct, certain]
+  })
+  return [COHORT_HEADER('All offers'), ...rows]
 })
 const replySourceChart = computed(() => {
   if (!replySource.value.length) return null
@@ -237,17 +254,18 @@ const replySourceChart = computed(() => {
 })
 const replyDistanceChart = computed(() => {
   if (!replyDistance.value.length) return null
-  const rows = [...replyDistance.value]
-    .reverse()
-    .map((r) => [new Date(r.day), r.median_km])
-  return [['Date', 'Median km'], ...rows]
+  const rows = [...replyDistance.value].reverse().map((r) => [
+    new Date(r.day), r.median_km, true, r.home_median_km, true, r.ripple_median_km, true,
+  ])
+  return [COHORT_HEADER('All offers'), ...rows]
 })
 const takenRateChart = computed(() => {
   if (!takenRate.value.length) return null
-  const rows = [...takenRate.value]
-    .reverse()
-    .map((r) => [new Date(r.day), r.taken_pct])
-  return [['Date', '% taken/received'], ...rows]
+  const rows = [...takenRate.value].reverse().map((r) => {
+    const certain = !r.provisional
+    return [new Date(r.day), r.taken_pct, certain, r.home_pct, certain, r.ripple_pct, certain]
+  })
+  return [COHORT_HEADER('All offers'), ...rows]
 })
 
 function pctChartOptions(vTitle, color) {
@@ -269,6 +287,36 @@ function kmChartOptions() {
     vAxis: { title: 'Median km', viewWindow: { min: 0 }, format: '#.#' },
     hAxis: { title: 'Date', format: 'dd MMM' },
     series: { 0: { color: '#fd7e14' } },
+    animation: { startup: true, duration: 400, easing: 'out' },
+  }
+}
+function cohortPctOptions(vTitle) {
+  return {
+    curveType: 'function',
+    legend: { position: 'bottom' },
+    chartArea: { width: '85%', height: '65%' },
+    vAxis: { title: vTitle, viewWindow: { min: 0 }, format: '#.#' },
+    hAxis: { title: 'Date', format: 'dd MMM' },
+    series: {
+      0: { color: '#6c757d' }, // All — grey
+      1: { color: '#17a2b8' }, // Home-only — teal
+      2: { color: '#28a745' }, // Rippled-out — green
+    },
+    animation: { startup: true, duration: 400, easing: 'out' },
+  }
+}
+function cohortKmOptions() {
+  return {
+    curveType: 'function',
+    legend: { position: 'bottom' },
+    chartArea: { width: '85%', height: '65%' },
+    vAxis: { title: 'Median km', viewWindow: { min: 0 }, format: '#.#' },
+    hAxis: { title: 'Date', format: 'dd MMM' },
+    series: {
+      0: { color: '#6c757d' },
+      1: { color: '#17a2b8' },
+      2: { color: '#fd7e14' }, // Rippled-out distance — orange
+    },
     animation: { startup: true, duration: 400, easing: 'out' },
   }
 }

--- a/iznik-nuxt3/modtools/components/RipplingDigestModal.vue
+++ b/iznik-nuxt3/modtools/components/RipplingDigestModal.vue
@@ -111,7 +111,7 @@ function openDigest(ranked, memberLat, memberLng) {
     sections[cls.section].push(buildDigestRow(p, p._rank, memberLat, memberLng))
   })
 
-  const SOFT_CAP = 100
+  const SOFT_CAP = 100 // Display cap for the promised/completed sections (active uses DIGEST_POST_CAP).
   // The real unified digest only emails the first DigestStyle::DIGEST_POST_CAP (65) live
   // posts ("Top picks"); the rest are website-only. Mirror that cap here so the preview
   // reflects what actually goes out, rather than the looser 100-row display soft cap.

--- a/iznik-nuxt3/modtools/components/RipplingDigestModal.vue
+++ b/iznik-nuxt3/modtools/components/RipplingDigestModal.vue
@@ -112,6 +112,10 @@ function openDigest(ranked, memberLat, memberLng) {
   })
 
   const SOFT_CAP = 100
+  // The real unified digest only emails the first DigestStyle::DIGEST_POST_CAP (65) live
+  // posts ("Top picks"); the rest are website-only. Mirror that cap here so the preview
+  // reflects what actually goes out, rather than the looser 100-row display soft cap.
+  const DIGEST_POST_CAP = 65
   const truncate = (rows) => {
     if (rows.length <= SOFT_CAP) return { html: rows.join(''), extra: 0 }
     return {
@@ -130,9 +134,10 @@ function openDigest(ranked, memberLat, memberLng) {
   let html = intro
   if (sections.active.length) {
     html += sectionHeader(`Top picks (${sections.active.length})`)
-    const r = truncate(sections.active)
-    html += r.html
-    if (r.extra) html += moreFooter(r.extra)
+    // Apply the real digest's 65 live-post cap (not the 100-row display soft cap).
+    const extra = Math.max(0, sections.active.length - DIGEST_POST_CAP)
+    html += sections.active.slice(0, DIGEST_POST_CAP).join('')
+    if (extra) html += moreFooter(extra)
   }
   if (sections.promised.length) {
     html += sectionHeader(

--- a/iznik-nuxt3/tests/unit/components/modtools/ModSysAdminRippling.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModSysAdminRippling.spec.js
@@ -44,6 +44,7 @@ function mountComponent() {
           },
         },
         GChart: {
+          name: 'GChart',
           template: '<div class="gchart" />',
           props: ['type', 'data', 'options'],
         },
@@ -148,6 +149,52 @@ describe('ModSysAdminRippling', () => {
       expect(html).toContain('released')
       expect(html).toContain('4.2')
     })
+  })
+
+  it('retitles the reply-source chart and renders cohort series', async () => {
+    mockFetchMetrics.mockResolvedValue({
+      reply_rate_36h: [
+        { day: '2026-06-20', posts: 10, replied: 4, reply_pct: 40,
+          home_posts: 6, home_replied: 2, home_pct: 33.3,
+          ripple_posts: 4, ripple_replied: 2, ripple_pct: 50, provisional: false },
+        { day: '2026-06-23', posts: 5, replied: 1, reply_pct: 20,
+          home_posts: 3, home_replied: 0, home_pct: 0,
+          ripple_posts: 2, ripple_replied: 1, ripple_pct: 50, provisional: true },
+      ],
+      reply_distance_median: [
+        { day: '2026-06-20', replies: 8, median_km: 5,
+          home_replies: 5, home_median_km: 3, ripple_replies: 3, ripple_median_km: 9 },
+      ],
+      taken_rate: [
+        { day: '2026-06-15', posts: 12, taken: 6, taken_pct: 50,
+          home_posts: 8, home_taken: 4, home_pct: 50,
+          ripple_posts: 4, ripple_taken: 2, ripple_pct: 50, provisional: false },
+      ],
+    })
+
+    const wrapper = mountComponent()
+    await flushPromises()
+
+    // Chart 2 retitled.
+    expect(wrapper.html()).toContain('Share of replies from rippling')
+    expect(wrapper.html()).not.toContain('How much of the lift is rippling?')
+
+    const charts = wrapper.findAllComponents({ name: 'GChart' })
+    // Order matches the template: 0 reply-rate, 1 reply-source, 2 distance, 3 taken.
+    const replyHeader = charts[0].props('data')[0]
+    expect(replyHeader).toContain('Home-only')
+    expect(replyHeader).toContain('Rippled-out')
+
+    // The provisional row (2026-06-23) carries certainty=false in every certainty column.
+    const replyRows = charts[0].props('data').slice(1)
+    const provisionalRow = replyRows.find((r) => {
+      const d = r[0]
+      return d instanceof Date && d.toISOString().startsWith('2026-06-23')
+    })
+    // Header: ['Date','All',{certainty},'Home-only',{certainty},'Rippled-out',{certainty}]
+    expect(provisionalRow[2]).toBe(false)
+    expect(provisionalRow[4]).toBe(false)
+    expect(provisionalRow[6]).toBe(false)
   })
 
   it('no longer renders the dropped absolute-number sections', async () => {

--- a/iznik-nuxt3/tests/unit/components/modtools/ModSysAdminRippling.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModSysAdminRippling.spec.js
@@ -180,7 +180,7 @@ describe('ModSysAdminRippling', () => {
     expect(wrapper.html()).not.toContain('How much of the lift is rippling?')
 
     const charts = wrapper.findAllComponents({ name: 'GChart' })
-    // Order matches the template: 0 reply-rate, 1 reply-source, 2 distance, 3 taken.
+    // charts[0] is the reply-rate chart (reply-source is omitted from this mock, so it doesn't render).
     const replyHeader = charts[0].props('data')[0]
     expect(replyHeader).toContain('Home-only')
     expect(replyHeader).toContain('Rippled-out')

--- a/iznik-server-go/rippling/metrics.go
+++ b/iznik-server-go/rippling/metrics.go
@@ -218,22 +218,24 @@ func Metrics(c *fiber.Ctx) error {
 
 	// replyRateArgs orders args to match the SQL: optional group filter, then the fr-subquery
 	// window (start, end), then the outer arrival window (start, end).
-	replyRateArgs := func(gid int, start, end string) []interface{} {
+	// Parallel in structure to takenRateArgs — keep the two in sync.
+	replyRateArgs := func(groupID int, windowStart, windowEnd string) []interface{} {
 		a := []interface{}{}
-		if gid > 0 {
-			a = append(a, gid)
+		if groupID > 0 {
+			a = append(a, groupID)
 		}
-		return append(a, start, end, start, end)
+		return append(a, windowStart, windowEnd, windowStart, windowEnd)
 	}
 
 	// takenRateArgs orders args to match the SQL: optional group filter, then the outcomes
 	// subquery lower bound (start), then the outer arrival window (start, end).
-	takenRateArgs := func(gid int, start, end string) []interface{} {
+	// Parallel in structure to replyRateArgs — keep the two in sync.
+	takenRateArgs := func(groupID int, windowStart, windowEnd string) []interface{} {
 		a := []interface{}{}
-		if gid > 0 {
-			a = append(a, gid)
+		if groupID > 0 {
+			a = append(a, groupID)
 		}
-		return append(a, start, start, end)
+		return append(a, windowStart, windowStart, windowEnd)
 	}
 
 	// ---- Declare all result variables up front so goroutines can capture them --------
@@ -354,6 +356,7 @@ func Metrics(c *fiber.Ctx) error {
 	// The fr subquery is bounded to the requested window (+ 36h slack) so it doesn't
 	// scan the full chat_messages history. The young-cut (arrival < NOW()-36h) is removed
 	// because the window end already controls which days are complete.
+	// Parallel in structure to query (4) (taken rate) — keep the two in sync.
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
@@ -361,7 +364,7 @@ func Metrics(c *fiber.Ctx) error {
 			SELECT day,
 			       COUNT(*) AS posts,
 			       SUM(replied) AS replied,
-			       SUM(1 - is_rippled) AS home_posts,
+			       SUM(1 - is_rippled) AS home_posts, -- is_rippled is 0/1 from EXISTS (never NULL)
 			       SUM(CASE WHEN is_rippled = 0 THEN replied ELSE 0 END) AS home_replied,
 			       SUM(is_rippled) AS ripple_posts,
 			       SUM(CASE WHEN is_rippled = 1 THEN replied ELSE 0 END) AS ripple_replied
@@ -409,9 +412,9 @@ func Metrics(c *fiber.Ctx) error {
 			SELECT day,
 			       MAX(cnt_all) AS replies,
 			       AVG(CASE WHEN rn_all IN (FLOOR((cnt_all + 1) / 2), FLOOR((cnt_all + 2) / 2)) THEN dist_km END) AS median_km,
-			       MAX(CASE WHEN is_rippled = 0 THEN cnt_coh END) AS home_replies,
+			       MAX(CASE WHEN is_rippled = 0 THEN cnt_coh ELSE 0 END) AS home_replies,
 			       AVG(CASE WHEN is_rippled = 0 AND rn_coh IN (FLOOR((cnt_coh + 1) / 2), FLOOR((cnt_coh + 2) / 2)) THEN dist_km END) AS home_median_km,
-			       MAX(CASE WHEN is_rippled = 1 THEN cnt_coh END) AS ripple_replies,
+			       MAX(CASE WHEN is_rippled = 1 THEN cnt_coh ELSE 0 END) AS ripple_replies,
 			       AVG(CASE WHEN is_rippled = 1 AND rn_coh IN (FLOOR((cnt_coh + 1) / 2), FLOOR((cnt_coh + 2) / 2)) THEN dist_km END) AS ripple_median_km
 			FROM (
 			  SELECT day, dist_km, is_rippled,
@@ -441,6 +444,7 @@ func Metrics(c *fiber.Ctx) error {
 	// The outcomes subquery is bounded to the requested window so it doesn't scan all
 	// history. The young-cut (arrival < NOW()-7d) is removed; the window end controls
 	// which days are complete.
+	// Parallel in structure to query (1) (reply rate) — keep the two in sync.
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
@@ -448,7 +452,7 @@ func Metrics(c *fiber.Ctx) error {
 			SELECT day,
 			       COUNT(*) AS posts,
 			       SUM(taken) AS taken,
-			       SUM(1 - is_rippled) AS home_posts,
+			       SUM(1 - is_rippled) AS home_posts, -- is_rippled is 0/1 from EXISTS (never NULL)
 			       SUM(CASE WHEN is_rippled = 0 THEN taken ELSE 0 END) AS home_taken,
 			       SUM(is_rippled) AS ripple_posts,
 			       SUM(CASE WHEN is_rippled = 1 THEN taken ELSE 0 END) AS ripple_taken
@@ -490,7 +494,9 @@ func Metrics(c *fiber.Ctx) error {
 	// Compute derived percentage fields for reply-rate rows (overall + home/ripple cohorts).
 	// Days whose arrival is within 36h of now are still maturing (their 36h reply window hasn't
 	// fully elapsed) — flag them so the client dashes the tail. Day-granularity is enough for the
-	// visual; compare the ISO day string against the cutoff date.
+	// visual; compare the ISO day string against the cutoff date. This is intentionally cautious:
+	// a day may be flagged provisional for a short window around midnight even once its settling
+	// window has fully elapsed (errs toward dashing one extra day, which is safe).
 	reply36hCutoff := time.Now().Add(-36 * time.Hour).Format("2006-01-02")
 	for i := range replyRates {
 		if replyRates[i].Posts > 0 {
@@ -514,6 +520,9 @@ func Metrics(c *fiber.Ctx) error {
 	}
 
 	// Compute derived percentage fields for taken-rate rows (overall + home/ripple cohorts).
+	// The provisional flag is intentionally cautious: a day may be flagged provisional for a
+	// short window around midnight even once its settling window has fully elapsed (errs toward
+	// dashing one extra day, which is safe).
 	taken7dCutoff := time.Now().AddDate(0, 0, -7).Format("2006-01-02")
 	for i := range takenRates {
 		if takenRates[i].Posts > 0 {

--- a/iznik-server-go/rippling/metrics.go
+++ b/iznik-server-go/rippling/metrics.go
@@ -92,11 +92,22 @@ type CaptureSummary struct {
 // Interested reply within 36h. This is the "are we turning 0-reply posts into 1-reply posts"
 // number. Computed live from messages + chat_messages, so it works over all history with no
 // instrumentation and no capture (reply timestamps don't change).
+// HomePosts/RipplePosts partition Posts by whether the post has any rippled-in messages_groups row.
 type ReplyRateRow struct {
 	Day      string  `json:"day"     gorm:"column:day"`
 	Posts    int     `json:"posts"   gorm:"column:posts"`
 	Replied  int     `json:"replied" gorm:"column:replied"`
 	ReplyPct float64 `json:"reply_pct"` // computed in Go
+
+	HomePosts   int     `json:"home_posts"   gorm:"column:home_posts"`
+	HomeReplied int     `json:"home_replied" gorm:"column:home_replied"`
+	HomePct     float64 `json:"home_pct"` // computed in Go
+
+	RipplePosts   int     `json:"ripple_posts"   gorm:"column:ripple_posts"`
+	RippleReplied int     `json:"ripple_replied" gorm:"column:ripple_replied"`
+	RipplePct     float64 `json:"ripple_pct"` // computed in Go
+
+	Provisional bool `json:"provisional"` // computed in Go (day within the 36h settling window)
 }
 
 // ReplySourceRow is the daily split of Interested replies by whether the replier reached the post
@@ -115,19 +126,36 @@ type ReplySourceRow struct {
 
 // ReplyDistanceRow is the daily median crow-flies distance (km) from a post's location to the
 // replier's home location, over Interested replies - how far rippling is pulling replies from.
+// HomeMedianKm/RippleMedianKm split the median by whether the post was rippled-out.
 type ReplyDistanceRow struct {
 	Day      string  `json:"day"       gorm:"column:day"`
 	Replies  int     `json:"replies"   gorm:"column:replies"`
 	MedianKm float64 `json:"median_km" gorm:"column:median_km"`
+
+	HomeReplies    int     `json:"home_replies"     gorm:"column:home_replies"`
+	HomeMedianKm   float64 `json:"home_median_km"   gorm:"column:home_median_km"`
+	RippleReplies  int     `json:"ripple_replies"   gorm:"column:ripple_replies"`
+	RippleMedianKm float64 `json:"ripple_median_km" gorm:"column:ripple_median_km"`
 }
 
 // TakenRateRow is the daily reuse outcome: of posts that arrived that day (and have had a settling
 // window to find a taker), what fraction reached a Taken (offer) or Received (wanted) outcome.
+// HomePosts/RipplePosts partition Posts by whether the post has any rippled-in messages_groups row.
 type TakenRateRow struct {
 	Day      string  `json:"day"   gorm:"column:day"`
 	Posts    int     `json:"posts" gorm:"column:posts"`
 	Taken    int     `json:"taken" gorm:"column:taken"`
 	TakenPct float64 `json:"taken_pct"` // computed in Go
+
+	HomePosts int     `json:"home_posts" gorm:"column:home_posts"`
+	HomeTaken int     `json:"home_taken" gorm:"column:home_taken"`
+	HomePct   float64 `json:"home_pct"` // computed in Go
+
+	RipplePosts int     `json:"ripple_posts" gorm:"column:ripple_posts"`
+	RippleTaken int     `json:"ripple_taken" gorm:"column:ripple_taken"`
+	RipplePct   float64 `json:"ripple_pct"` // computed in Go
+
+	Provisional bool `json:"provisional"` // computed in Go (day within the 7-day settling window)
 }
 
 // GroupOption is one entry in the per-group KPI filter: a group whose posts have rippled, so its
@@ -330,18 +358,30 @@ func Metrics(c *fiber.Ctx) error {
 	go func() {
 		defer wg.Done()
 		db.Raw(`
-			SELECT DATE_FORMAT(m.arrival, '%Y-%m-%d') AS day,
-			       COUNT(DISTINCT m.id) AS posts,
-			       COUNT(DISTINCT CASE WHEN fr.first_reply <= m.arrival + INTERVAL 36 HOUR THEN m.id END) AS replied
-			FROM messages m
-			JOIN messages_groups mg ON mg.msgid = m.id AND mg.collection = 'Approved' AND mg.deleted = 0`+rateGroup+`
-			LEFT JOIN (
-			    SELECT refmsgid, MIN(date) AS first_reply FROM chat_messages
-			    WHERE type = 'Interested' AND date >= ? AND date < (? + INTERVAL 36 HOUR) GROUP BY refmsgid
-			) fr ON fr.refmsgid = m.id
-			WHERE m.type = 'Offer'
-			  AND m.arrival >= ? AND m.arrival < ?
-			GROUP BY DATE_FORMAT(m.arrival, '%Y-%m-%d')
+			SELECT day,
+			       COUNT(*) AS posts,
+			       SUM(replied) AS replied,
+			       SUM(1 - is_rippled) AS home_posts,
+			       SUM(CASE WHEN is_rippled = 0 THEN replied ELSE 0 END) AS home_replied,
+			       SUM(is_rippled) AS ripple_posts,
+			       SUM(CASE WHEN is_rippled = 1 THEN replied ELSE 0 END) AS ripple_replied
+			FROM (
+			    SELECT m.id,
+			           DATE_FORMAT(m.arrival, '%Y-%m-%d') AS day,
+			           MAX(CASE WHEN fr.first_reply <= m.arrival + INTERVAL 36 HOUR THEN 1 ELSE 0 END) AS replied,
+			           EXISTS (SELECT 1 FROM messages_groups mgr
+			                   WHERE mgr.msgid = m.id AND mgr.rippled_in = 1 AND mgr.deleted = 0) AS is_rippled
+			    FROM messages m
+			    JOIN messages_groups mg ON mg.msgid = m.id AND mg.collection = 'Approved' AND mg.deleted = 0`+rateGroup+`
+			    LEFT JOIN (
+			        SELECT refmsgid, MIN(date) AS first_reply FROM chat_messages
+			        WHERE type = 'Interested' AND date >= ? AND date < (? + INTERVAL 36 HOUR) GROUP BY refmsgid
+			    ) fr ON fr.refmsgid = m.id
+			    WHERE m.type = 'Offer'
+			      AND m.arrival >= ? AND m.arrival < ?
+			    GROUP BY m.id, m.arrival
+			) per_msg
+			GROUP BY day
 			ORDER BY day DESC`, replyRateArgs(gid, start, end)...).Scan(&replyRates)
 	}()
 
@@ -366,14 +406,24 @@ func Metrics(c *fiber.Ctx) error {
 	go func() {
 		defer wg.Done()
 		db.Raw(`
-			SELECT day, MAX(cnt) AS replies, AVG(dist_km) AS median_km
+			SELECT day,
+			       MAX(cnt_all) AS replies,
+			       AVG(CASE WHEN rn_all IN (FLOOR((cnt_all + 1) / 2), FLOOR((cnt_all + 2) / 2)) THEN dist_km END) AS median_km,
+			       MAX(CASE WHEN is_rippled = 0 THEN cnt_coh END) AS home_replies,
+			       AVG(CASE WHEN is_rippled = 0 AND rn_coh IN (FLOOR((cnt_coh + 1) / 2), FLOOR((cnt_coh + 2) / 2)) THEN dist_km END) AS home_median_km,
+			       MAX(CASE WHEN is_rippled = 1 THEN cnt_coh END) AS ripple_replies,
+			       AVG(CASE WHEN is_rippled = 1 AND rn_coh IN (FLOOR((cnt_coh + 1) / 2), FLOOR((cnt_coh + 2) / 2)) THEN dist_km END) AS ripple_median_km
 			FROM (
-			  SELECT day, dist_km,
-			         ROW_NUMBER() OVER (PARTITION BY day ORDER BY dist_km) AS rn,
-			         COUNT(*)     OVER (PARTITION BY day) AS cnt
+			  SELECT day, dist_km, is_rippled,
+			         ROW_NUMBER() OVER (PARTITION BY day ORDER BY dist_km)              AS rn_all,
+			         COUNT(*)     OVER (PARTITION BY day)                                AS cnt_all,
+			         ROW_NUMBER() OVER (PARTITION BY day, is_rippled ORDER BY dist_km)   AS rn_coh,
+			         COUNT(*)     OVER (PARTITION BY day, is_rippled)                     AS cnt_coh
 			  FROM (
 			    SELECT DATE_FORMAT(cm.date, '%Y-%m-%d') AS day,
-			           ST_Distance_Sphere(POINT(ml.lng, ml.lat), POINT(ul.lng, ul.lat)) / 1000 AS dist_km
+			           ST_Distance_Sphere(POINT(ml.lng, ml.lat), POINT(ul.lng, ul.lat)) / 1000 AS dist_km,
+			           EXISTS (SELECT 1 FROM messages_groups mgr
+			                   WHERE mgr.msgid = m.id AND mgr.rippled_in = 1 AND mgr.deleted = 0) AS is_rippled
 			    FROM chat_messages cm
 			    JOIN messages m   ON m.id = cm.refmsgid AND m.type = 'Offer'`+distGroup+`
 			    JOIN locations ml ON ml.id = m.locationid
@@ -383,7 +433,6 @@ func Metrics(c *fiber.Ctx) error {
 			      AND ml.lat IS NOT NULL AND ul.lat IS NOT NULL
 			  ) d
 			) r
-			WHERE r.rn IN (FLOOR((r.cnt + 1) / 2), FLOOR((r.cnt + 2) / 2))
 			GROUP BY day
 			ORDER BY day DESC`, gargs()...).Scan(&replyDistances)
 	}()
@@ -396,17 +445,29 @@ func Metrics(c *fiber.Ctx) error {
 	go func() {
 		defer wg.Done()
 		db.Raw(`
-			SELECT DATE_FORMAT(m.arrival, '%Y-%m-%d') AS day,
-			       COUNT(DISTINCT m.id) AS posts,
-			       COUNT(DISTINCT o.msgid) AS taken
-			FROM messages m
-			JOIN messages_groups mg ON mg.msgid = m.id AND mg.collection = 'Approved' AND mg.deleted = 0`+rateGroup+`
-			LEFT JOIN (SELECT DISTINCT msgid FROM messages_outcomes
-			           WHERE outcome IN ('Taken','Received') AND timestamp >= ?) o
-			       ON o.msgid = m.id
-			WHERE m.type IN ('Offer','Wanted')
-			  AND m.arrival >= ? AND m.arrival < ?
-			GROUP BY DATE_FORMAT(m.arrival, '%Y-%m-%d')
+			SELECT day,
+			       COUNT(*) AS posts,
+			       SUM(taken) AS taken,
+			       SUM(1 - is_rippled) AS home_posts,
+			       SUM(CASE WHEN is_rippled = 0 THEN taken ELSE 0 END) AS home_taken,
+			       SUM(is_rippled) AS ripple_posts,
+			       SUM(CASE WHEN is_rippled = 1 THEN taken ELSE 0 END) AS ripple_taken
+			FROM (
+			    SELECT m.id,
+			           DATE_FORMAT(m.arrival, '%Y-%m-%d') AS day,
+			           MAX(CASE WHEN o.msgid IS NOT NULL THEN 1 ELSE 0 END) AS taken,
+			           EXISTS (SELECT 1 FROM messages_groups mgr
+			                   WHERE mgr.msgid = m.id AND mgr.rippled_in = 1 AND mgr.deleted = 0) AS is_rippled
+			    FROM messages m
+			    JOIN messages_groups mg ON mg.msgid = m.id AND mg.collection = 'Approved' AND mg.deleted = 0`+rateGroup+`
+			    LEFT JOIN (SELECT DISTINCT msgid FROM messages_outcomes
+			               WHERE outcome IN ('Taken','Received') AND timestamp >= ?) o
+			           ON o.msgid = m.id
+			    WHERE m.type IN ('Offer','Wanted')
+			      AND m.arrival >= ? AND m.arrival < ?
+			    GROUP BY m.id, m.arrival
+			) per_msg
+			GROUP BY day
 			ORDER BY day DESC`, takenRateArgs(gid, start, end)...).Scan(&takenRates)
 	}()
 
@@ -426,11 +487,22 @@ func Metrics(c *fiber.Ctx) error {
 
 	// ---- Post-processing (serial; all goroutines done) --------------------------------
 
-	// Compute derived percentage fields for reply-rate rows.
+	// Compute derived percentage fields for reply-rate rows (overall + home/ripple cohorts).
+	// Days whose arrival is within 36h of now are still maturing (their 36h reply window hasn't
+	// fully elapsed) — flag them so the client dashes the tail. Day-granularity is enough for the
+	// visual; compare the ISO day string against the cutoff date.
+	reply36hCutoff := time.Now().Add(-36 * time.Hour).Format("2006-01-02")
 	for i := range replyRates {
 		if replyRates[i].Posts > 0 {
 			replyRates[i].ReplyPct = float64(replyRates[i].Replied) / float64(replyRates[i].Posts) * 100
 		}
+		if replyRates[i].HomePosts > 0 {
+			replyRates[i].HomePct = float64(replyRates[i].HomeReplied) / float64(replyRates[i].HomePosts) * 100
+		}
+		if replyRates[i].RipplePosts > 0 {
+			replyRates[i].RipplePct = float64(replyRates[i].RippleReplied) / float64(replyRates[i].RipplePosts) * 100
+		}
+		replyRates[i].Provisional = replyRates[i].Day >= reply36hCutoff
 	}
 
 	// Compute derived fields for reply-source rows.
@@ -441,11 +513,19 @@ func Metrics(c *fiber.Ctx) error {
 		}
 	}
 
-	// Compute derived percentage fields for taken-rate rows.
+	// Compute derived percentage fields for taken-rate rows (overall + home/ripple cohorts).
+	taken7dCutoff := time.Now().AddDate(0, 0, -7).Format("2006-01-02")
 	for i := range takenRates {
 		if takenRates[i].Posts > 0 {
 			takenRates[i].TakenPct = float64(takenRates[i].Taken) / float64(takenRates[i].Posts) * 100
 		}
+		if takenRates[i].HomePosts > 0 {
+			takenRates[i].HomePct = float64(takenRates[i].HomeTaken) / float64(takenRates[i].HomePosts) * 100
+		}
+		if takenRates[i].RipplePosts > 0 {
+			takenRates[i].RipplePct = float64(takenRates[i].RippleTaken) / float64(takenRates[i].RipplePosts) * 100
+		}
+		takenRates[i].Provisional = takenRates[i].Day >= taken7dCutoff
 	}
 
 	// Assemble the cross-group summary struct from the raw scan.

--- a/iznik-server-go/rippling/metrics.go
+++ b/iznik-server-go/rippling/metrics.go
@@ -3,6 +3,7 @@
 package rippling
 
 import (
+	"sync"
 	"time"
 
 	"github.com/freegle/iznik-server-go/database"
@@ -156,92 +157,7 @@ type GroupOption struct {
 func Metrics(c *fiber.Ctx) error {
 	db := database.DBConn
 
-	// ---- §15 raw event counters -------------------------------------------------------
-	// Errors are ignored on purpose: until the rippling event table exists the result is
-	// simply empty, so the endpoint never 500s during rollout.
-	totals := []EventMetric{}
-	db.Raw("SELECT '' AS day, event, COALESCE(SUM(count), 0) AS count " +
-		"FROM rippling_event_metrics GROUP BY event ORDER BY event").Scan(&totals)
-
-	recent := []EventMetric{}
-	db.Raw("SELECT DATE_FORMAT(day, '%Y-%m-%d') AS day, event, count " +
-		"FROM rippling_event_metrics WHERE day >= CURDATE() - INTERVAL 30 DAY " +
-		"ORDER BY day DESC, event").Scan(&recent)
-
-	// ---- §16 tuner hotspots and advisory param proposals ------------------------------
-	// These tables ship with PR G, so the scans simply return empty until then.
-	hotspots := []Hotspot{}
-	db.Raw("SELECT DATE_FORMAT(period_start, '%Y-%m-%d') AS period_start, area_type, area_id, " +
-		"COALESCE(area_name, '') AS area_name, metric, value, baseline, deviation, direction, severity " +
-		"FROM rippling_hotspots WHERE detected_at >= NOW() - INTERVAL 30 DAY " +
-		"ORDER BY (severity = 'alert') DESC, ABS(deviation) DESC LIMIT 100").Scan(&hotspots)
-
-	proposed := []ProposedParam{}
-	db.Raw("SELECT ons_category, max_minutes, COALESCE(rationale, '') AS rationale, " +
-		"DATE_FORMAT(proposed_at, '%Y-%m-%d %H:%i') AS proposed_at " +
-		"FROM rippling_params WHERE status = 'proposed' ORDER BY ons_category").Scan(&proposed)
-
-	// ---- §16.1 / §16.2 volume + reach: overall live-metrics from weekly batch rollup --
-	// Returns the two most recent weekly periods' overall rows so the dashboard can show a
-	// trend. Defensive: returns empty if rippling_live_metrics doesn't exist yet.
-	liveMetrics := []LiveMetricRow{}
-	db.Raw("SELECT DATE_FORMAT(period_start, '%Y-%m-%d') AS period_start, metric, value, sample_size " +
-		"FROM rippling_live_metrics " +
-		"WHERE stratum_type = 'overall' AND period_type = 'weekly' " +
-		"AND period_start >= CURDATE() - INTERVAL 14 DAY " +
-		"ORDER BY period_start DESC, metric").Scan(&liveMetrics)
-
-	// ---- §15 / §16.5 held-reply friction summary ------------------------------------
-	// Live aggregate of rippling_held_replies by status, with median hold duration for
-	// released rows. Defensive: returns empty if rippling_held_replies doesn't exist yet.
-	heldReplySummary := []HeldReplySummary{}
-	db.Raw("SELECT status, COUNT(*) AS count, " +
-		"COALESCE(AVG(TIMESTAMPDIFF(SECOND, created_at, COALESCE(releasedat, NOW())) / 3600.0), 0) AS median_hold_hours " +
-		"FROM rippling_held_replies " +
-		"GROUP BY status ORDER BY status").Scan(&heldReplySummary)
-
-	// ---- §16.3 cross-group reach summary (last 30 days) -----------------------------
-	// Uses messages_groups.rippled_in (added by migration 2026_06_18_000004). Measures
-	// what fraction of post appearances were rippled in by the engine, and of those, what
-	// fraction were approved (not rejected). Defensive: returns zero struct if column absent.
-	type crossGroupRaw struct {
-		Total           int64 `gorm:"column:total"`
-		RippledIn       int64 `gorm:"column:rippled_in"`
-		ApprovedRippled int64 `gorm:"column:approved_rippled"`
-	}
-	var cg crossGroupRaw
-	db.Raw("SELECT " +
-		"COUNT(*) AS total, " +
-		"COALESCE(SUM(rippled_in), 0) AS rippled_in, " +
-		"COALESCE(SUM(CASE WHEN rippled_in = 1 AND collection = 'Approved' THEN 1 ELSE 0 END), 0) AS approved_rippled " +
-		"FROM messages_groups " +
-		"WHERE arrival >= CURDATE() - INTERVAL 30 DAY " +
-		"AND deleted = 0").Scan(&cg)
-	crossGroup := CrossGroupSummary{PeriodDays: 30, Total: cg.Total, RippledIn: cg.RippledIn}
-	if cg.Total > 0 {
-		crossGroup.CrossGroupPct = float64(cg.RippledIn) / float64(cg.Total) * 100
-	}
-	if cg.RippledIn > 0 {
-		crossGroup.ApprovalRate = float64(cg.ApprovedRippled) / float64(cg.RippledIn) * 100
-	}
-
-	// ---- §16.4 timing / capture: latest offline-simulator week ----------------------
-	// Reads the most recent 'all'-group row from rippling_algorithm_metrics (renamed from
-	// ripple_algorithm_metrics by migration 2026_06_18_000002). Returns zero struct if the
-	// table is empty or doesn't exist yet.
-	var capture CaptureSummary
-	db.Raw("SELECT DATE_FORMAT(week_start, '%Y-%m-%d') AS week_start, curve, " +
-		"pairs_total, pairs_in_time, pairs_late, " +
-		"COALESCE(reply_p50_hours, 0) AS reply_p50_hours, " +
-		"COALESCE(reply_p75_hours, 0) AS reply_p75_hours " +
-		"FROM rippling_algorithm_metrics " +
-		"WHERE `group` = 'all' " +
-		"ORDER BY week_start DESC LIMIT 1").Scan(&capture)
-	if capture.PairsTotal > 0 {
-		capture.CaptureRate = float64(capture.PairsInTime) / float64(capture.PairsTotal) * 100
-	}
-
-	// ---- Reply + reuse KPIs (the rollout's headline outcomes) ------------------------
+	// ---- Reply + reuse KPIs: parse params first so arg-builder closures can capture them ----
 	// Optional ?groupid= scopes every KPI below to posts ORIGINATING in that group (its
 	// rippled_in=0 messages_groups row), so results read per place - dense Croydon won't look
 	// like rural Ribble Valley. 0 = all groups. Each scoped query takes one gid arg.
@@ -272,41 +188,252 @@ func Metrics(c *fiber.Ctx) error {
 		return append(a, start, end)
 	}
 
-	// (1) % of Offers with a reply within 36h, per arrival day. Only days whose full 36h window
-	//     has elapsed are counted, so each point is complete (no trailing dip).
+	// replyRateArgs orders args to match the SQL: optional group filter, then the fr-subquery
+	// window (start, end), then the outer arrival window (start, end).
+	replyRateArgs := func(gid int, start, end string) []interface{} {
+		a := []interface{}{}
+		if gid > 0 {
+			a = append(a, gid)
+		}
+		return append(a, start, end, start, end)
+	}
+
+	// takenRateArgs orders args to match the SQL: optional group filter, then the outcomes
+	// subquery lower bound (start), then the outer arrival window (start, end).
+	takenRateArgs := func(gid int, start, end string) []interface{} {
+		a := []interface{}{}
+		if gid > 0 {
+			a = append(a, gid)
+		}
+		return append(a, start, start, end)
+	}
+
+	// ---- Declare all result variables up front so goroutines can capture them --------
+	totals := []EventMetric{}
+	recent := []EventMetric{}
+	hotspots := []Hotspot{}
+	proposed := []ProposedParam{}
+	liveMetrics := []LiveMetricRow{}
+	heldReplySummary := []HeldReplySummary{}
+	type crossGroupRaw struct {
+		Total           int64 `gorm:"column:total"`
+		RippledIn       int64 `gorm:"column:rippled_in"`
+		ApprovedRippled int64 `gorm:"column:approved_rippled"`
+	}
+	var cg crossGroupRaw
+	var capture CaptureSummary
 	replyRates := []ReplyRateRow{}
-	db.Raw(`
-		SELECT DATE_FORMAT(m.arrival, '%Y-%m-%d') AS day,
-		       COUNT(DISTINCT m.id) AS posts,
-		       COUNT(DISTINCT CASE WHEN fr.first_reply <= m.arrival + INTERVAL 36 HOUR THEN m.id END) AS replied
-		FROM messages m
-		JOIN messages_groups mg ON mg.msgid = m.id AND mg.collection = 'Approved' AND mg.deleted = 0`+rateGroup+`
-		LEFT JOIN (
-		    SELECT refmsgid, MIN(date) AS first_reply FROM chat_messages
-		    WHERE type = 'Interested' AND date >= CURDATE() - INTERVAL 200 DAY GROUP BY refmsgid
-		) fr ON fr.refmsgid = m.id
-		WHERE m.type = 'Offer'
-		  AND m.arrival >= ? AND m.arrival < ?
-		  AND m.arrival <  NOW() - INTERVAL 36 HOUR
-		GROUP BY DATE_FORMAT(m.arrival, '%Y-%m-%d')
-		ORDER BY day DESC`, gargs()...).Scan(&replyRates)
+	replySources := []ReplySourceRow{}
+	replyDistances := []ReplyDistanceRow{}
+	takenRates := []TakenRateRow{}
+	groupOpts := []GroupOption{}
+
+	// ---- Run all independent DB queries concurrently --------------------------------
+	var wg sync.WaitGroup
+
+	// §15 raw event counters – errors ignored on purpose (table may not exist yet).
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		db.Raw("SELECT '' AS day, event, COALESCE(SUM(count), 0) AS count " +
+			"FROM rippling_event_metrics GROUP BY event ORDER BY event").Scan(&totals)
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		db.Raw("SELECT DATE_FORMAT(day, '%Y-%m-%d') AS day, event, count " +
+			"FROM rippling_event_metrics WHERE day >= CURDATE() - INTERVAL 30 DAY " +
+			"ORDER BY day DESC, event").Scan(&recent)
+	}()
+
+	// §16 tuner hotspots – defensive; empty until PR G ships the table.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		db.Raw("SELECT DATE_FORMAT(period_start, '%Y-%m-%d') AS period_start, area_type, area_id, " +
+			"COALESCE(area_name, '') AS area_name, metric, value, baseline, deviation, direction, severity " +
+			"FROM rippling_hotspots WHERE detected_at >= NOW() - INTERVAL 30 DAY " +
+			"ORDER BY (severity = 'alert') DESC, ABS(deviation) DESC LIMIT 100").Scan(&hotspots)
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		db.Raw("SELECT ons_category, max_minutes, COALESCE(rationale, '') AS rationale, " +
+			"DATE_FORMAT(proposed_at, '%Y-%m-%d %H:%i') AS proposed_at " +
+			"FROM rippling_params WHERE status = 'proposed' ORDER BY ons_category").Scan(&proposed)
+	}()
+
+	// §16.1 / §16.2 volume + reach: overall live-metrics from weekly batch rollup.
+	// Returns the two most recent weekly periods' overall rows so the dashboard can show a
+	// trend. Defensive: returns empty if rippling_live_metrics doesn't exist yet.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		db.Raw("SELECT DATE_FORMAT(period_start, '%Y-%m-%d') AS period_start, metric, value, sample_size " +
+			"FROM rippling_live_metrics " +
+			"WHERE stratum_type = 'overall' AND period_type = 'weekly' " +
+			"AND period_start >= CURDATE() - INTERVAL 14 DAY " +
+			"ORDER BY period_start DESC, metric").Scan(&liveMetrics)
+	}()
+
+	// §15 / §16.5 held-reply friction summary.
+	// Live aggregate of rippling_held_replies by status, with median hold duration for
+	// released rows. Defensive: returns empty if rippling_held_replies doesn't exist yet.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		db.Raw("SELECT status, COUNT(*) AS count, " +
+			"COALESCE(AVG(TIMESTAMPDIFF(SECOND, created_at, COALESCE(releasedat, NOW())) / 3600.0), 0) AS median_hold_hours " +
+			"FROM rippling_held_replies " +
+			"GROUP BY status ORDER BY status").Scan(&heldReplySummary)
+	}()
+
+	// §16.3 cross-group reach summary (last 30 days).
+	// Uses messages_groups.rippled_in (added by migration 2026_06_18_000004). Measures
+	// what fraction of post appearances were rippled in by the engine, and of those, what
+	// fraction were approved (not rejected). Defensive: returns zero struct if column absent.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		db.Raw("SELECT " +
+			"COUNT(*) AS total, " +
+			"COALESCE(SUM(rippled_in), 0) AS rippled_in, " +
+			"COALESCE(SUM(CASE WHEN rippled_in = 1 AND collection = 'Approved' THEN 1 ELSE 0 END), 0) AS approved_rippled " +
+			"FROM messages_groups " +
+			"WHERE arrival >= CURDATE() - INTERVAL 30 DAY " +
+			"AND deleted = 0").Scan(&cg)
+	}()
+
+	// §16.4 timing / capture: latest offline-simulator week.
+	// Reads the most recent 'all'-group row from rippling_algorithm_metrics (renamed from
+	// ripple_algorithm_metrics by migration 2026_06_18_000002). Returns zero struct if the
+	// table is empty or doesn't exist yet.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		db.Raw("SELECT DATE_FORMAT(week_start, '%Y-%m-%d') AS week_start, curve, " +
+			"pairs_total, pairs_in_time, pairs_late, " +
+			"COALESCE(reply_p50_hours, 0) AS reply_p50_hours, " +
+			"COALESCE(reply_p75_hours, 0) AS reply_p75_hours " +
+			"FROM rippling_algorithm_metrics " +
+			"WHERE `group` = 'all' " +
+			"ORDER BY week_start DESC LIMIT 1").Scan(&capture)
+	}()
+
+	// (1) % of Offers with a reply within 36h, per arrival day.
+	// The fr subquery is bounded to the requested window (+ 36h slack) so it doesn't
+	// scan the full chat_messages history. The young-cut (arrival < NOW()-36h) is removed
+	// because the window end already controls which days are complete.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		db.Raw(`
+			SELECT DATE_FORMAT(m.arrival, '%Y-%m-%d') AS day,
+			       COUNT(DISTINCT m.id) AS posts,
+			       COUNT(DISTINCT CASE WHEN fr.first_reply <= m.arrival + INTERVAL 36 HOUR THEN m.id END) AS replied
+			FROM messages m
+			JOIN messages_groups mg ON mg.msgid = m.id AND mg.collection = 'Approved' AND mg.deleted = 0`+rateGroup+`
+			LEFT JOIN (
+			    SELECT refmsgid, MIN(date) AS first_reply FROM chat_messages
+			    WHERE type = 'Interested' AND date >= ? AND date < (? + INTERVAL 36 HOUR) GROUP BY refmsgid
+			) fr ON fr.refmsgid = m.id
+			WHERE m.type = 'Offer'
+			  AND m.arrival >= ? AND m.arrival < ?
+			GROUP BY DATE_FORMAT(m.arrival, '%Y-%m-%d')
+			ORDER BY day DESC`, replyRateArgs(gid, start, end)...).Scan(&replyRates)
+	}()
+
+	// (2) Rippling vs home-group replies, per day, from rippling_reply_attribution (captured at
+	//     reply time - the only sound attribution, since replying joins the member to the group).
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		db.Raw(`
+			SELECT DATE_FORMAT(rra.replied_at, '%Y-%m-%d') AS day,
+			       COUNT(*) AS replies,
+			       COALESCE(SUM(rra.was_home_member), 0) AS home
+			FROM rippling_reply_attribution rra`+srcGroup+`
+			WHERE rra.replied_at >= ? AND rra.replied_at < ?
+			GROUP BY DATE_FORMAT(rra.replied_at, '%Y-%m-%d')
+			ORDER BY day DESC`, gargs()...).Scan(&replySources)
+	}()
+
+	// (3) Median crow-flies distance (km) from post to replier, per reply day. The origin-group
+	//     join is added only when filtering (avoids multi-group row inflation in the all view).
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		db.Raw(`
+			SELECT day, MAX(cnt) AS replies, AVG(dist_km) AS median_km
+			FROM (
+			  SELECT day, dist_km,
+			         ROW_NUMBER() OVER (PARTITION BY day ORDER BY dist_km) AS rn,
+			         COUNT(*)     OVER (PARTITION BY day) AS cnt
+			  FROM (
+			    SELECT DATE_FORMAT(cm.date, '%Y-%m-%d') AS day,
+			           ST_Distance_Sphere(POINT(ml.lng, ml.lat), POINT(ul.lng, ul.lat)) / 1000 AS dist_km
+			    FROM chat_messages cm
+			    JOIN messages m   ON m.id = cm.refmsgid AND m.type = 'Offer'`+distGroup+`
+			    JOIN locations ml ON ml.id = m.locationid
+			    JOIN users u      ON u.id = cm.userid
+			    JOIN locations ul ON ul.id = u.lastlocation
+			    WHERE cm.type = 'Interested' AND cm.date >= ? AND cm.date < ?
+			      AND ml.lat IS NOT NULL AND ul.lat IS NOT NULL
+			  ) d
+			) r
+			WHERE r.rn IN (FLOOR((r.cnt + 1) / 2), FLOOR((r.cnt + 2) / 2))
+			GROUP BY day
+			ORDER BY day DESC`, gargs()...).Scan(&replyDistances)
+	}()
+
+	// (4) Reuse outcome: % of posts (Offers taken / Wanteds received) per arrival day.
+	// The outcomes subquery is bounded to the requested window so it doesn't scan all
+	// history. The young-cut (arrival < NOW()-7d) is removed; the window end controls
+	// which days are complete.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		db.Raw(`
+			SELECT DATE_FORMAT(m.arrival, '%Y-%m-%d') AS day,
+			       COUNT(DISTINCT m.id) AS posts,
+			       COUNT(DISTINCT o.msgid) AS taken
+			FROM messages m
+			JOIN messages_groups mg ON mg.msgid = m.id AND mg.collection = 'Approved' AND mg.deleted = 0`+rateGroup+`
+			LEFT JOIN (SELECT DISTINCT msgid FROM messages_outcomes
+			           WHERE outcome IN ('Taken','Received') AND timestamp >= ?) o
+			       ON o.msgid = m.id
+			WHERE m.type IN ('Offer','Wanted')
+			  AND m.arrival >= ? AND m.arrival < ?
+			GROUP BY DATE_FORMAT(m.arrival, '%Y-%m-%d')
+			ORDER BY day DESC`, takenRateArgs(gid, start, end)...).Scan(&takenRates)
+	}()
+
+	// Groups whose posts have rippled - the per-group filter options (the experiment groups appear
+	// here once they ripple). Defensive: empty while rippling is dark.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		db.Raw("SELECT DISTINCT g.id AS id, g.nameshort AS name " +
+			"FROM rippling_reach rr " +
+			"JOIN messages_groups mg ON mg.msgid = rr.msgid AND mg.rippled_in = 0 AND mg.deleted = 0 " +
+			"JOIN `groups` g ON g.id = mg.groupid " +
+			"ORDER BY g.nameshort").Scan(&groupOpts)
+	}()
+
+	wg.Wait()
+
+	// ---- Post-processing (serial; all goroutines done) --------------------------------
+
+	// Compute derived percentage fields for reply-rate rows.
 	for i := range replyRates {
 		if replyRates[i].Posts > 0 {
 			replyRates[i].ReplyPct = float64(replyRates[i].Replied) / float64(replyRates[i].Posts) * 100
 		}
 	}
 
-	// (2) Rippling vs home-group replies, per day, from rippling_reply_attribution (captured at
-	//     reply time - the only sound attribution, since replying joins the member to the group).
-	replySources := []ReplySourceRow{}
-	db.Raw(`
-		SELECT DATE_FORMAT(rra.replied_at, '%Y-%m-%d') AS day,
-		       COUNT(*) AS replies,
-		       COALESCE(SUM(rra.was_home_member), 0) AS home
-		FROM rippling_reply_attribution rra`+srcGroup+`
-		WHERE rra.replied_at >= ? AND rra.replied_at < ?
-		GROUP BY DATE_FORMAT(rra.replied_at, '%Y-%m-%d')
-		ORDER BY day DESC`, gargs()...).Scan(&replySources)
+	// Compute derived fields for reply-source rows.
 	for i := range replySources {
 		replySources[i].Ripple = replySources[i].Replies - replySources[i].Home
 		if replySources[i].Replies > 0 {
@@ -314,62 +441,26 @@ func Metrics(c *fiber.Ctx) error {
 		}
 	}
 
-	// (3) Median crow-flies distance (km) from post to replier, per reply day. The origin-group
-	//     join is added only when filtering (avoids multi-group row inflation in the all view).
-	replyDistances := []ReplyDistanceRow{}
-	db.Raw(`
-		SELECT day, MAX(cnt) AS replies, AVG(dist_km) AS median_km
-		FROM (
-		  SELECT day, dist_km,
-		         ROW_NUMBER() OVER (PARTITION BY day ORDER BY dist_km) AS rn,
-		         COUNT(*)     OVER (PARTITION BY day) AS cnt
-		  FROM (
-		    SELECT DATE_FORMAT(cm.date, '%Y-%m-%d') AS day,
-		           ST_Distance_Sphere(POINT(ml.lng, ml.lat), POINT(ul.lng, ul.lat)) / 1000 AS dist_km
-		    FROM chat_messages cm
-		    JOIN messages m   ON m.id = cm.refmsgid AND m.type = 'Offer'`+distGroup+`
-		    JOIN locations ml ON ml.id = m.locationid
-		    JOIN users u      ON u.id = cm.userid
-		    JOIN locations ul ON ul.id = u.lastlocation
-		    WHERE cm.type = 'Interested' AND cm.date >= ? AND cm.date < ?
-		      AND ml.lat IS NOT NULL AND ul.lat IS NOT NULL
-		  ) d
-		) r
-		WHERE r.rn IN (FLOOR((r.cnt + 1) / 2), FLOOR((r.cnt + 2) / 2))
-		GROUP BY day
-		ORDER BY day DESC`, gargs()...).Scan(&replyDistances)
-
-	// (4) Reuse outcome: % of posts (Offers taken / Wanteds received) per arrival day. An outcome
-	//     of Taken or Received counts. A 7-day settling cut stops the most recent days looking bad
-	//     just because their posts are too young to have been collected (the rate accrues longer).
-	takenRates := []TakenRateRow{}
-	db.Raw(`
-		SELECT DATE_FORMAT(m.arrival, '%Y-%m-%d') AS day,
-		       COUNT(DISTINCT m.id) AS posts,
-		       COUNT(DISTINCT o.msgid) AS taken
-		FROM messages m
-		JOIN messages_groups mg ON mg.msgid = m.id AND mg.collection = 'Approved' AND mg.deleted = 0`+rateGroup+`
-		LEFT JOIN (SELECT DISTINCT msgid FROM messages_outcomes WHERE outcome IN ('Taken','Received')) o
-		       ON o.msgid = m.id
-		WHERE m.type IN ('Offer','Wanted')
-		  AND m.arrival >= ? AND m.arrival < ?
-		  AND m.arrival <  NOW() - INTERVAL 7 DAY
-		GROUP BY DATE_FORMAT(m.arrival, '%Y-%m-%d')
-		ORDER BY day DESC`, gargs()...).Scan(&takenRates)
+	// Compute derived percentage fields for taken-rate rows.
 	for i := range takenRates {
 		if takenRates[i].Posts > 0 {
 			takenRates[i].TakenPct = float64(takenRates[i].Taken) / float64(takenRates[i].Posts) * 100
 		}
 	}
 
-	// Groups whose posts have rippled - the per-group filter options (the experiment groups appear
-	// here once they ripple). Defensive: empty while rippling is dark.
-	groupOpts := []GroupOption{}
-	db.Raw("SELECT DISTINCT g.id AS id, g.nameshort AS name " +
-		"FROM rippling_reach rr " +
-		"JOIN messages_groups mg ON mg.msgid = rr.msgid AND mg.rippled_in = 0 AND mg.deleted = 0 " +
-		"JOIN `groups` g ON g.id = mg.groupid " +
-		"ORDER BY g.nameshort").Scan(&groupOpts)
+	// Assemble the cross-group summary struct from the raw scan.
+	crossGroup := CrossGroupSummary{PeriodDays: 30, Total: cg.Total, RippledIn: cg.RippledIn}
+	if cg.Total > 0 {
+		crossGroup.CrossGroupPct = float64(cg.RippledIn) / float64(cg.Total) * 100
+	}
+	if cg.RippledIn > 0 {
+		crossGroup.ApprovalRate = float64(cg.ApprovedRippled) / float64(cg.RippledIn) * 100
+	}
+
+	// Compute capture rate from the offline-simulator summary.
+	if capture.PairsTotal > 0 {
+		capture.CaptureRate = float64(capture.PairsInTime) / float64(capture.PairsTotal) * 100
+	}
 
 	return c.JSON(fiber.Map{
 		"totals":                totals,

--- a/iznik-server-go/test/rippling_metrics_test.go
+++ b/iznik-server-go/test/rippling_metrics_test.go
@@ -341,3 +341,42 @@ func TestRipplingMetricsDateRange(t *testing.T) {
 	assert.NotEmpty(t, rd["start"], "start defaults when absent")
 	assert.NotEmpty(t, rd["end"], "end defaults when absent")
 }
+
+// Stage A guard: bounding the outcomes subquery to the window must still count an
+// in-window Taken outcome. Seeds one Offer 3 days ago, marks it Taken, and asserts the
+// taken_rate row for that day reports posts>=1 and taken>=1.
+func TestRipplingMetricsTakenInWindowCounted(t *testing.T) {
+	prefix := uniquePrefix("rippletaken")
+	adminID := CreateTestUser(t, prefix+"_admin", "Support")
+	_, token := CreateTestSession(t, adminID)
+	posterID := CreateTestUser(t, prefix+"_poster", "User")
+	groupID := CreateTestGroup(t, prefix+"_grp")
+
+	db := database.DBConn
+	msgID := CreateTestMessage(t, posterID, groupID, prefix+" sofa", 51.5, -0.1)
+	db.Exec("UPDATE messages SET arrival = NOW() - INTERVAL 3 DAY WHERE id = ?", msgID)
+	db.Exec("UPDATE messages_groups SET arrival = NOW() - INTERVAL 3 DAY WHERE msgid = ?", msgID)
+	db.Exec("INSERT INTO messages_outcomes (timestamp, msgid, outcome) VALUES (NOW() - INTERVAL 2 DAY, ?, 'Taken')", msgID)
+	defer db.Exec("DELETE FROM messages_outcomes WHERE msgid = ?", msgID)
+	defer db.Exec("DELETE FROM messages_groups WHERE msgid = ?", msgID)
+	defer db.Exec("DELETE FROM messages WHERE id = ?", msgID)
+
+	var wantDay string
+	db.Raw("SELECT DATE_FORMAT(NOW() - INTERVAL 3 DAY, '%Y-%m-%d')").Scan(&wantDay)
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET", fmt.Sprintf("/api/rippling/metrics?jwt=%s", token), nil))
+	assert.Equal(t, 200, resp.StatusCode)
+	var result map[string]interface{}
+	json.Unmarshal(rsp(resp), &result)
+
+	taken, _ := result["taken_rate"].([]interface{})
+	found := false
+	for _, r := range taken {
+		if m, ok := r.(map[string]interface{}); ok && m["day"] == wantDay {
+			found = true
+			assert.GreaterOrEqual(t, m["posts"].(float64), float64(1), "the seeded post is counted")
+			assert.GreaterOrEqual(t, m["taken"].(float64), float64(1), "the Taken outcome is counted within the window")
+		}
+	}
+	assert.True(t, found, "the seeded day appears in taken_rate")
+}

--- a/iznik-server-go/test/rippling_metrics_test.go
+++ b/iznik-server-go/test/rippling_metrics_test.go
@@ -407,9 +407,9 @@ func TestRipplingMetricsReplyRateCohorts(t *testing.T) {
 	cmID := CreateTestChatMessage(t, chatID, replierID, "I'd like it")
 	db.Exec("UPDATE chat_messages SET type = 'Interested', refmsgid = ?, date = NOW() - INTERVAL 5 DAY + INTERVAL 1 HOUR WHERE id = ?", rippMsg, cmID)
 
-	defer db.Exec("DELETE FROM chat_messages WHERE id = ?", cmID)
-	defer db.Exec("DELETE FROM messages_groups WHERE msgid IN (?, ?)", homeMsg, rippMsg)
 	defer db.Exec("DELETE FROM messages WHERE id IN (?, ?)", homeMsg, rippMsg)
+	defer db.Exec("DELETE FROM messages_groups WHERE msgid IN (?, ?)", homeMsg, rippMsg)
+	defer db.Exec("DELETE FROM chat_messages WHERE id = ?", cmID)
 
 	var wantDay string
 	db.Raw("SELECT DATE_FORMAT(NOW() - INTERVAL 5 DAY, '%Y-%m-%d')").Scan(&wantDay)
@@ -431,6 +431,7 @@ func TestRipplingMetricsReplyRateCohorts(t *testing.T) {
 	assert.GreaterOrEqual(t, row["ripple_posts"].(float64), float64(1), "the rippled-out post is in the ripple cohort")
 	assert.GreaterOrEqual(t, row["home_posts"].(float64), float64(1), "the home-only post is in the home cohort")
 	assert.GreaterOrEqual(t, row["ripple_replied"].(float64), float64(1), "the rippled-out post's reply is counted")
+	assert.Equal(t, float64(0), row["home_replied"], "the home-only post had no reply")
 }
 
 // Cohort split on taken_rate: a home-only Offer and a rippled-out Offer the same day; only the
@@ -454,9 +455,9 @@ func TestRipplingMetricsTakenRateCohorts(t *testing.T) {
 		"VALUES (?, ?, NOW() - INTERVAL 5 DAY, 'Approved', 1, 0)", rippMsg, awayGrp)
 	db.Exec("INSERT INTO messages_outcomes (timestamp, msgid, outcome) VALUES (NOW() - INTERVAL 4 DAY, ?, 'Taken')", rippMsg)
 
-	defer db.Exec("DELETE FROM messages_outcomes WHERE msgid IN (?, ?)", homeMsg, rippMsg)
-	defer db.Exec("DELETE FROM messages_groups WHERE msgid IN (?, ?)", homeMsg, rippMsg)
 	defer db.Exec("DELETE FROM messages WHERE id IN (?, ?)", homeMsg, rippMsg)
+	defer db.Exec("DELETE FROM messages_groups WHERE msgid IN (?, ?)", homeMsg, rippMsg)
+	defer db.Exec("DELETE FROM messages_outcomes WHERE msgid IN (?, ?)", homeMsg, rippMsg)
 
 	var wantDay string
 	db.Raw("SELECT DATE_FORMAT(NOW() - INTERVAL 5 DAY, '%Y-%m-%d')").Scan(&wantDay)
@@ -514,6 +515,7 @@ func TestRipplingMetricsDistanceCohorts(t *testing.T) {
 	// Set replier home locations.
 	db.Exec("UPDATE users SET lastlocation = ? WHERE id = ?", nearLocID, nearReplier)
 	db.Exec("UPDATE users SET lastlocation = ? WHERE id = ?", farLocID, farReplier)
+	defer db.Exec("UPDATE users SET lastlocation = NULL WHERE id IN (?, ?)", nearReplier, farReplier)
 
 	homeMsg := CreateTestMessage(t, posterID, homeGrp, prefix+" homebike", 51.5, -0.1)
 	rippMsg := CreateTestMessage(t, posterID, homeGrp, prefix+" rippbike", 51.5, -0.1)
@@ -528,9 +530,9 @@ func TestRipplingMetricsDistanceCohorts(t *testing.T) {
 	rCm := CreateTestChatMessage(t, rChat, farReplier, "far")
 	db.Exec("UPDATE chat_messages SET type='Interested', refmsgid=?, date=NOW() - INTERVAL 5 DAY WHERE id=?", rippMsg, rCm)
 
-	defer db.Exec("DELETE FROM chat_messages WHERE id IN (?, ?)", hCm, rCm)
-	defer db.Exec("DELETE FROM messages_groups WHERE msgid IN (?, ?)", homeMsg, rippMsg)
 	defer db.Exec("DELETE FROM messages WHERE id IN (?, ?)", homeMsg, rippMsg)
+	defer db.Exec("DELETE FROM messages_groups WHERE msgid IN (?, ?)", homeMsg, rippMsg)
+	defer db.Exec("DELETE FROM chat_messages WHERE id IN (?, ?)", hCm, rCm)
 
 	var wantDay string
 	db.Raw("SELECT DATE_FORMAT(NOW() - INTERVAL 5 DAY, '%Y-%m-%d')").Scan(&wantDay)

--- a/iznik-server-go/test/rippling_metrics_test.go
+++ b/iznik-server-go/test/rippling_metrics_test.go
@@ -380,3 +380,176 @@ func TestRipplingMetricsTakenInWindowCounted(t *testing.T) {
 	}
 	assert.True(t, found, "the seeded day appears in taken_rate")
 }
+
+// Cohort split on reply_rate_36h: a home-only Offer (no rippled_in=1 row) and a rippled-out Offer
+// (has a rippled_in=1 row) arriving the same day. The rippled one gets an Interested reply within
+// 36h; the home one does not. Asserts the counts partition (home+ripple=posts) and the rippled
+// cohort shows the reply.
+func TestRipplingMetricsReplyRateCohorts(t *testing.T) {
+	prefix := uniquePrefix("ripplerc")
+	adminID := CreateTestUser(t, prefix+"_admin", "Support")
+	_, token := CreateTestSession(t, adminID)
+	posterID := CreateTestUser(t, prefix+"_poster", "User")
+	replierID := CreateTestUser(t, prefix+"_replier", "User")
+	homeGrp := CreateTestGroup(t, prefix+"_home")
+	awayGrp := CreateTestGroup(t, prefix+"_away")
+
+	db := database.DBConn
+	homeMsg := CreateTestMessage(t, posterID, homeGrp, prefix+" homechair", 51.5, -0.1)
+	rippMsg := CreateTestMessage(t, posterID, homeGrp, prefix+" rippchair", 51.5, -0.1)
+	for _, id := range []uint64{homeMsg, rippMsg} {
+		db.Exec("UPDATE messages SET arrival = NOW() - INTERVAL 5 DAY WHERE id = ?", id)
+		db.Exec("UPDATE messages_groups SET arrival = NOW() - INTERVAL 5 DAY WHERE msgid = ?", id)
+	}
+	db.Exec("INSERT INTO messages_groups (msgid, groupid, arrival, collection, rippled_in, autoreposts) "+
+		"VALUES (?, ?, NOW() - INTERVAL 5 DAY, 'Approved', 1, 0)", rippMsg, awayGrp)
+	chatID := CreateTestChatRoom(t, replierID, &posterID, &homeGrp, "User2User")
+	cmID := CreateTestChatMessage(t, chatID, replierID, "I'd like it")
+	db.Exec("UPDATE chat_messages SET type = 'Interested', refmsgid = ?, date = NOW() - INTERVAL 5 DAY + INTERVAL 1 HOUR WHERE id = ?", rippMsg, cmID)
+
+	defer db.Exec("DELETE FROM chat_messages WHERE id = ?", cmID)
+	defer db.Exec("DELETE FROM messages_groups WHERE msgid IN (?, ?)", homeMsg, rippMsg)
+	defer db.Exec("DELETE FROM messages WHERE id IN (?, ?)", homeMsg, rippMsg)
+
+	var wantDay string
+	db.Raw("SELECT DATE_FORMAT(NOW() - INTERVAL 5 DAY, '%Y-%m-%d')").Scan(&wantDay)
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET", fmt.Sprintf("/api/rippling/metrics?jwt=%s", token), nil))
+	assert.Equal(t, 200, resp.StatusCode)
+	var result map[string]interface{}
+	json.Unmarshal(rsp(resp), &result)
+
+	rate, _ := result["reply_rate_36h"].([]interface{})
+	var row map[string]interface{}
+	for _, r := range rate {
+		if m, ok := r.(map[string]interface{}); ok && m["day"] == wantDay {
+			row = m
+		}
+	}
+	assert.NotNil(t, row, "the seeded day appears in reply_rate_36h")
+	assert.Equal(t, row["posts"], row["home_posts"].(float64)+row["ripple_posts"].(float64), "post counts partition")
+	assert.GreaterOrEqual(t, row["ripple_posts"].(float64), float64(1), "the rippled-out post is in the ripple cohort")
+	assert.GreaterOrEqual(t, row["home_posts"].(float64), float64(1), "the home-only post is in the home cohort")
+	assert.GreaterOrEqual(t, row["ripple_replied"].(float64), float64(1), "the rippled-out post's reply is counted")
+}
+
+// Cohort split on taken_rate: a home-only Offer and a rippled-out Offer the same day; only the
+// rippled-out one is Taken. Asserts counts partition and the ripple cohort carries the take.
+func TestRipplingMetricsTakenRateCohorts(t *testing.T) {
+	prefix := uniquePrefix("rippletc")
+	adminID := CreateTestUser(t, prefix+"_admin", "Support")
+	_, token := CreateTestSession(t, adminID)
+	posterID := CreateTestUser(t, prefix+"_poster", "User")
+	homeGrp := CreateTestGroup(t, prefix+"_home")
+	awayGrp := CreateTestGroup(t, prefix+"_away")
+
+	db := database.DBConn
+	homeMsg := CreateTestMessage(t, posterID, homeGrp, prefix+" homedesk", 51.5, -0.1)
+	rippMsg := CreateTestMessage(t, posterID, homeGrp, prefix+" rippdesk", 51.5, -0.1)
+	for _, id := range []uint64{homeMsg, rippMsg} {
+		db.Exec("UPDATE messages SET arrival = NOW() - INTERVAL 5 DAY WHERE id = ?", id)
+		db.Exec("UPDATE messages_groups SET arrival = NOW() - INTERVAL 5 DAY WHERE msgid = ?", id)
+	}
+	db.Exec("INSERT INTO messages_groups (msgid, groupid, arrival, collection, rippled_in, autoreposts) "+
+		"VALUES (?, ?, NOW() - INTERVAL 5 DAY, 'Approved', 1, 0)", rippMsg, awayGrp)
+	db.Exec("INSERT INTO messages_outcomes (timestamp, msgid, outcome) VALUES (NOW() - INTERVAL 4 DAY, ?, 'Taken')", rippMsg)
+
+	defer db.Exec("DELETE FROM messages_outcomes WHERE msgid IN (?, ?)", homeMsg, rippMsg)
+	defer db.Exec("DELETE FROM messages_groups WHERE msgid IN (?, ?)", homeMsg, rippMsg)
+	defer db.Exec("DELETE FROM messages WHERE id IN (?, ?)", homeMsg, rippMsg)
+
+	var wantDay string
+	db.Raw("SELECT DATE_FORMAT(NOW() - INTERVAL 5 DAY, '%Y-%m-%d')").Scan(&wantDay)
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET", fmt.Sprintf("/api/rippling/metrics?jwt=%s", token), nil))
+	assert.Equal(t, 200, resp.StatusCode)
+	var result map[string]interface{}
+	json.Unmarshal(rsp(resp), &result)
+
+	taken, _ := result["taken_rate"].([]interface{})
+	var row map[string]interface{}
+	for _, r := range taken {
+		if m, ok := r.(map[string]interface{}); ok && m["day"] == wantDay {
+			row = m
+		}
+	}
+	assert.NotNil(t, row, "the seeded day appears in taken_rate")
+	assert.Equal(t, row["posts"], row["home_posts"].(float64)+row["ripple_posts"].(float64), "post counts partition")
+	assert.GreaterOrEqual(t, row["ripple_taken"].(float64), float64(1), "the rippled-out take is in the ripple cohort")
+	assert.Equal(t, float64(0), row["home_taken"], "the home-only post was not taken")
+}
+
+// Cohort medians on reply_distance_median: a home-only post whose replier is near the post
+// and a rippled-out post whose replier is far away, replying the same day. Asserts both cohort
+// medians are present and ripple_median_km > home_median_km.
+// Uses explicit locations inserted at known coordinates so the test does not depend on what
+// locations happen to exist in the test DB at runtime.
+func TestRipplingMetricsDistanceCohorts(t *testing.T) {
+	prefix := uniquePrefix("rippledc")
+	adminID := CreateTestUser(t, prefix+"_admin", "Support")
+	_, token := CreateTestSession(t, adminID)
+	posterID := CreateTestUser(t, prefix+"_poster", "User")
+	nearReplier := CreateTestUser(t, prefix+"_near", "User")
+	farReplier := CreateTestUser(t, prefix+"_far", "User")
+	homeGrp := CreateTestGroup(t, prefix+"_home")
+	awayGrp := CreateTestGroup(t, prefix+"_away")
+
+	db := database.DBConn
+
+	// Insert explicit locations at known coordinates. Post location: London (51.5, -0.1).
+	// Near replier: same location as the post (~0 km away).
+	// Far replier: Edinburgh (55.95, -3.19) — ~535 km from London.
+	// Using name prefixed by uniquePrefix to avoid collisions.
+	// 'type' is required (NOT NULL); 'Point' is valid per the enum.
+	var postLocID, nearLocID, farLocID uint64
+	db.Exec("INSERT INTO locations (name, type, lat, lng) VALUES (?, 'Point', 51.5, -0.1)", prefix+"_postloc")
+	db.Raw("SELECT id FROM locations WHERE name = ?", prefix+"_postloc").Scan(&postLocID)
+	db.Exec("INSERT INTO locations (name, type, lat, lng) VALUES (?, 'Point', 51.5, -0.1)", prefix+"_nearloc")
+	db.Raw("SELECT id FROM locations WHERE name = ?", prefix+"_nearloc").Scan(&nearLocID)
+	db.Exec("INSERT INTO locations (name, type, lat, lng) VALUES (?, 'Point', 55.95, -3.19)", prefix+"_farloc")
+	db.Raw("SELECT id FROM locations WHERE name = ?", prefix+"_farloc").Scan(&farLocID)
+
+	defer db.Exec("DELETE FROM locations WHERE name IN (?, ?, ?)", prefix+"_postloc", prefix+"_nearloc", prefix+"_farloc")
+
+	// Set replier home locations.
+	db.Exec("UPDATE users SET lastlocation = ? WHERE id = ?", nearLocID, nearReplier)
+	db.Exec("UPDATE users SET lastlocation = ? WHERE id = ?", farLocID, farReplier)
+
+	homeMsg := CreateTestMessage(t, posterID, homeGrp, prefix+" homebike", 51.5, -0.1)
+	rippMsg := CreateTestMessage(t, posterID, homeGrp, prefix+" rippbike", 51.5, -0.1)
+	// Override the locationid to the explicit post location we inserted.
+	db.Exec("UPDATE messages SET locationid = ? WHERE id IN (?, ?)", postLocID, homeMsg, rippMsg)
+	db.Exec("INSERT INTO messages_groups (msgid, groupid, arrival, collection, rippled_in, autoreposts) "+
+		"VALUES (?, ?, NOW() - INTERVAL 5 DAY, 'Approved', 1, 0)", rippMsg, awayGrp)
+	hChat := CreateTestChatRoom(t, nearReplier, &posterID, &homeGrp, "User2User")
+	hCm := CreateTestChatMessage(t, hChat, nearReplier, "near")
+	db.Exec("UPDATE chat_messages SET type='Interested', refmsgid=?, date=NOW() - INTERVAL 5 DAY WHERE id=?", homeMsg, hCm)
+	rChat := CreateTestChatRoom(t, farReplier, &posterID, &homeGrp, "User2User")
+	rCm := CreateTestChatMessage(t, rChat, farReplier, "far")
+	db.Exec("UPDATE chat_messages SET type='Interested', refmsgid=?, date=NOW() - INTERVAL 5 DAY WHERE id=?", rippMsg, rCm)
+
+	defer db.Exec("DELETE FROM chat_messages WHERE id IN (?, ?)", hCm, rCm)
+	defer db.Exec("DELETE FROM messages_groups WHERE msgid IN (?, ?)", homeMsg, rippMsg)
+	defer db.Exec("DELETE FROM messages WHERE id IN (?, ?)", homeMsg, rippMsg)
+
+	var wantDay string
+	db.Raw("SELECT DATE_FORMAT(NOW() - INTERVAL 5 DAY, '%Y-%m-%d')").Scan(&wantDay)
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET", fmt.Sprintf("/api/rippling/metrics?jwt=%s", token), nil))
+	assert.Equal(t, 200, resp.StatusCode)
+	var result map[string]interface{}
+	json.Unmarshal(rsp(resp), &result)
+
+	dist, _ := result["reply_distance_median"].([]interface{})
+	var row map[string]interface{}
+	for _, r := range dist {
+		if m, ok := r.(map[string]interface{}); ok && m["day"] == wantDay {
+			row = m
+		}
+	}
+	assert.NotNil(t, row, "the seeded day appears in reply_distance_median")
+	assert.GreaterOrEqual(t, row["home_replies"].(float64), float64(1), "home cohort has a reply")
+	assert.GreaterOrEqual(t, row["ripple_replies"].(float64), float64(1), "ripple cohort has a reply")
+	// Near replier is at the same spot as the post (~0 km); far replier is in Edinburgh (~535 km).
+	assert.Greater(t, row["ripple_median_km"].(float64), row["home_median_km"].(float64), "rippled replies are further away")
+}


### PR DESCRIPTION
## What

Upgrades the sysadmin **Rippling** dashboard to distinguish posts confined to their **home group** from posts **rippled out** to adjacent groups, and makes the page load fast. Also folds in a small fix to the `/rippling` digest preview.

### Dashboard cohort lines
- The **reply-rate**, **reply-distance**, and **taken-rate** charts now show three lines: **All / Home-only / Rippled-out**. A post is "rippled-out" if it has any `messages_groups` row with `rippled_in=1`, else "home-only" (classified per-post via an indexed `EXISTS`).
- The reply-source chart is retitled **"Share of replies from rippling"** (kept single-line — it already decomposes replies).
- The reply-rate and taken-rate charts now plot **right up to today**, with the immature "settling" tail rendered **dashed** (Google Charts `certainty` role) instead of being cut off ~7 days back. The backend marks each day `provisional`.

### Performance (the page was effectively hanging)
The `rippling.Metrics` Go handler ran ~13 queries **serially**, two of which over-scanned every request. Now:
- All independent queries run **concurrently** (`sync.WaitGroup`).
- The reply-rate subquery is bounded to the requested window (was a fixed 200-day `chat_messages` scan); the taken-rate subquery is bounded to outcomes since the window start (was a full-history `messages_outcomes` scan).

**Measured on production data (30-day window, via the apiv2-live tunnel):**

| Query | Before | After |
|---|---|---|
| Reply-rate | **>120s (never completed)** | **2.7s** |
| Taken-rate | **22.8s** | **1.1s** |
| Distance (now with cohorts) | – | 6.2s |

Serial total was >140s; parallelized the endpoint is bounded by its slowest query (~6s). Cohort counts reconcile exactly on real data (`home_posts + ripple_posts = posts`).

### Digest preview cap (folded in)
The `/rippling` "Digest preview" ("Top picks" section) now caps live posts at **65** to mirror the real unified digest (`DigestStyle::DIGEST_POST_CAP`) — it previously only had a looser 100-row display cap, so the preview overstated what actually gets emailed.

## Verification
- **Go suite:** green — 3249 passed, 0 failed (new tests: cohort partitioning for reply/taken/distance, bounded-window correctness).
- **Vitest:** green — 13388 passed, 0 failed (cohort series + chart-2 retitle + dashed certainty asserted).
- Per-task two-stage review (spec + code-quality) plus a final whole-diff review.

## Notes
- Backend response is additive (new `home_*`/`ripple_*`/`provisional` fields) — backward compatible.
- The 5 changed files are orthogonal to the commits master has gained since branching (no conflicts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)