### PR TITLE
fix(browse): mygroups view shows only member-group posts, with a consistent count

### DIFF
--- a/iznik-nuxt3/components/MessageList.vue
+++ b/iznik-nuxt3/components/MessageList.vue
@@ -148,6 +148,7 @@ import MessageListUpToDate from './MessageListUpToDate'
 import ScrollGrid from '~/components/ScrollGrid'
 import { useGroupStore } from '~/stores/group'
 import { useMessageStore } from '~/stores/message'
+import { useIsochroneStore } from '~/stores/isochrone'
 import { throttleFetches } from '~/composables/useThrottle'
 import { useMe } from '~/composables/useMe'
 import { useScrollDepth } from '~/composables/useScrollDepth'
@@ -245,6 +246,7 @@ const emit = defineEmits(['update:none', 'update:visible'])
 
 const groupStore = useGroupStore()
 const messageStore = useMessageStore()
+const isochroneStore = useIsochroneStore()
 const { me, myid, myGroups: myMemberships } = useMe()
 
 // Browse-feed scroll-depth instrumentation: record how far down the feed this
@@ -502,10 +504,15 @@ function visibilityChanged(visible) {
 }
 
 function markSeen() {
-  // Collect all unseen message IDs
+  // Mark the whole list the count is computed over (the full isochrone/mygroups response),
+  // not just the rendered/viewport subset — otherwise unseen posts that are off-screen or
+  // filtered out keep the server count above zero and "Mark seen" can never clear it.
+  const source = isochroneStore.messageList?.length
+    ? isochroneStore.messageList
+    : props.messagesForList
   const ids = []
 
-  props.messagesForList.forEach((m) => {
+  source.forEach((m) => {
     if (m.unseen) {
       ids.push(m.id)
     }
@@ -527,7 +534,7 @@ function pollUntilZero() {
   }
 
   markSeenTimer = setTimeout(async () => {
-    const count = await messageStore.fetchCount(me?.settings?.browseView, false)
+    const count = await messageStore.fetchCount(me.value?.settings?.browseView, false)
     pollCount++
 
     if (count > 0 && pollCount < MAX_POLL_COUNT) {

--- a/iznik-nuxt3/stores/isochrone.js
+++ b/iznik-nuxt3/stores/isochrone.js
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia'
 import { nextTick } from 'vue'
 import Wkt from 'wicket'
 import api from '~/api'
+import { useAuthStore } from '~/stores/auth'
 
 export const useIsochroneStore = defineStore({
   id: 'isochrone',
@@ -45,7 +46,12 @@ export const useIsochroneStore = defineStore({
           await this.fetchingMessages
           await nextTick()
         } else {
-          this.fetchingMessages = api(this.config).isochrone.fetchMessages()
+          // Pass the user's browse view so the list matches the count: 'mygroups' returns
+          // member-group posts, anything else the location/isochrone feed.
+          const browseView = useAuthStore().user?.settings?.browseView
+          this.fetchingMessages = api(this.config).isochrone.fetchMessages(
+            browseView ? { browseView } : undefined
+          )
           this.messageList = await this.fetchingMessages
           this.fetchingMessages = null
         }

--- a/iznik-server-go/isochrone/message.go
+++ b/iznik-server-go/isochrone/message.go
@@ -31,6 +31,15 @@ func Messages(c *fiber.Ctx) error {
 
 	db := database.DBConn
 
+	// The 'mygroups' browse view shows posts from the user's member groups only — the same
+	// universe Count uses for that view — so the nav badge/divider count matches what the feed
+	// renders and "Mark seen" can actually clear it. (The default 'nearby' view below is the
+	// location/isochrone feed.) Without this the list always returned the location feed while
+	// Count branched to member groups, leaving a non-clearable count for mygroups users.
+	if effectiveBrowseView(c, db, myid) == "mygroups" {
+		return myGroupsMessages(c, db, myid)
+	}
+
 	var isochrones []IsochronesUsers
 	res := []message.MessageSummary{}
 
@@ -132,6 +141,68 @@ func Messages(c *fiber.Ctx) error {
 	return c.JSON(res)
 }
 
+// effectiveBrowseView resolves the browse view for this request: an explicit ?browseView= wins,
+// otherwise the user's saved setting, otherwise "nearby". Defaulting to the user's setting (rather
+// than always "nearby") keeps the count and feed correct even when a client path omits or mis-sends
+// the param — the cause of mygroups users seeing a stuck "nearby" count they couldn't clear.
+func effectiveBrowseView(c *fiber.Ctx, db *gorm.DB, myid uint64) string {
+	if bv := c.Query("browseView", ""); bv != "" {
+		return bv
+	}
+	var setting string
+	db.Raw("SELECT JSON_UNQUOTE(JSON_EXTRACT(settings, '$.browseView')) FROM users WHERE id = ?", myid).Scan(&setting)
+	if setting == "mygroups" {
+		return "mygroups"
+	}
+	return "nearby"
+}
+
+// myGroupsMsgIDs returns the open (successful=0) message ids in the user's member groups — the
+// shared universe for the 'mygroups' browse view, so Messages (the feed) and Count (the badge)
+// agree and "Mark seen" can drain the count.
+func myGroupsMsgIDs(db *gorm.DB, myid uint64) []uint64 {
+	var ids []uint64
+	db.Raw("SELECT DISTINCT messages_spatial.msgid FROM memberships "+
+		"INNER JOIN messages_spatial ON messages_spatial.groupid = memberships.groupid "+
+		"WHERE memberships.userid = ? AND messages_spatial.successful = 0", myid).Scan(&ids)
+	return ids
+}
+
+// myGroupsMessages renders the 'mygroups' browse feed: posts from the viewer's member groups,
+// with the unseen flag, blurred. No location/postvisibility/reach filtering — the viewer is a
+// member, and Count's mygroups branch is unfiltered too, so feed and badge stay in lock-step.
+func myGroupsMessages(c *fiber.Ctx, db *gorm.DB, myid uint64) error {
+	res := []message.MessageSummary{}
+	msgIDs := myGroupsMsgIDs(db, myid)
+
+	if len(msgIDs) > 0 {
+		placeholders := make([]string, len(msgIDs))
+		args := make([]any, len(msgIDs)+2)
+		args[0] = myid
+		args[1] = utils.MESSAGE_LIKES_VIEW
+		for i, id := range msgIDs {
+			placeholders[i] = "?"
+			args[i+2] = id
+		}
+		db.Raw(fmt.Sprintf(
+			"SELECT ST_Y(ms.point) AS lat, ST_X(ms.point) AS lng, "+
+				"ms.msgid AS id, ms.successful, ms.promised, ms.groupid, "+
+				"ms.msgtype AS type, ms.arrival, "+
+				"CASE WHEN ml.msgid IS NULL THEN 1 ELSE 0 END AS unseen "+
+				"FROM messages_spatial ms "+
+				"LEFT JOIN messages_likes ml ON ml.msgid = ms.msgid AND ml.userid = ? AND ml.type = ? "+
+				"WHERE ms.msgid IN (%s)",
+			strings.Join(placeholders, ",")),
+			args...).Scan(&res)
+	}
+
+	for ix, r := range res {
+		res[ix].Lat, res[ix].Lng = utils.Blur(r.Lat, r.Lng, utils.BLUR_USER)
+	}
+
+	return c.JSON(res)
+}
+
 // FilterReachBlocked removes messages whose rippling reach exists but does not yet cover
 // the viewer's location (§6 — a post stays hidden until the ripple reaches you). It is
 // inert until the reach engine populates rippling_reach: a missing table or no matching
@@ -181,7 +252,7 @@ func Count(c *fiber.Ctx) error {
 
 	var count uint64 = 0
 
-	browseView := c.Query("browseView", "nearby")
+	browseView := effectiveBrowseView(c, db, myid)
 
 	if browseView == "mygroups" {
 		db.Raw("SELECT COUNT(DISTINCT(messages_spatial.msgid)) FROM memberships "+

--- a/iznik-server-go/test/isochrone_test.go
+++ b/iznik-server-go/test/isochrone_test.go
@@ -952,3 +952,49 @@ func TestHealPointIsochronesNullTransport(t *testing.T) {
 	db.Exec("DELETE FROM isochrones WHERE locationid = ?", locID)
 	db.Exec("DELETE FROM locations WHERE id = ?", locID)
 }
+
+// TestIsochroneMyGroupsView verifies the 'mygroups' browse view: the list feed and the count BOTH
+// restrict to the user's member groups, and a non-member group's post is excluded — so the nav
+// badge matches the feed and "Mark seen" can clear it. effectiveBrowseView resolves the view from
+// the user's saved setting, so no ?browseView= param is needed (the bug was a client path omitting
+// it, defaulting to 'nearby', and counting non-member nearby posts the member feed never showed).
+func TestIsochroneMyGroupsView(t *testing.T) {
+	prefix := uniquePrefix("isomygroups")
+	userID := CreateTestUser(t, prefix+"_u", "User")
+	_, token := CreateTestSession(t, userID)
+	posterID := CreateTestUser(t, prefix+"_p", "User")
+	db := database.DBConn
+
+	memberGroup := CreateTestGroup(t, prefix+"_member")
+	otherGroup := CreateTestGroup(t, prefix+"_other")
+	db.Exec("INSERT INTO memberships (userid, groupid) VALUES (?, ?)", userID, memberGroup)
+	db.Exec("UPDATE users SET settings = JSON_SET(COALESCE(settings, '{}'), '$.browseView', 'mygroups') WHERE id = ?", userID)
+
+	memberMsg := CreateTestMessage(t, posterID, memberGroup, prefix+" memberpost", 55.9533, -3.1883)
+	otherMsg := CreateTestMessage(t, posterID, otherGroup, prefix+" otherpost", 55.9533, -3.1883)
+	// The browse feed shows open posts (messages_spatial.successful = 0); the helper inserts 1.
+	db.Exec("UPDATE messages_spatial SET successful = 0 WHERE msgid IN (?, ?)", memberMsg, otherMsg)
+
+	defer db.Exec("DELETE FROM memberships WHERE userid = ? AND groupid = ?", userID, memberGroup)
+	defer db.Exec("DELETE FROM messages_groups WHERE msgid IN (?, ?)", memberMsg, otherMsg)
+	defer db.Exec("DELETE FROM messages WHERE id IN (?, ?)", memberMsg, otherMsg)
+
+	// List with NO browseView param: effectiveBrowseView resolves 'mygroups' from the user's setting.
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/isochrone/message?jwt="+token, nil))
+	assert.Equal(t, 200, resp.StatusCode)
+	var msgs []message.MessageSummary
+	json2.Unmarshal(rsp(resp), &msgs)
+	got := map[uint64]bool{}
+	for _, m := range msgs {
+		got[m.ID] = true
+	}
+	assert.True(t, got[memberMsg], "member-group post appears in the mygroups feed")
+	assert.False(t, got[otherMsg], "non-member-group post is excluded from the mygroups feed")
+
+	// Count uses the same member-group universe — includes the unseen member post.
+	resp, _ = getApp().Test(httptest.NewRequest("GET", "/api/message/count?jwt="+token, nil))
+	assert.Equal(t, 200, resp.StatusCode)
+	var cres map[string]interface{}
+	json2.Unmarshal(rsp(resp), &cres)
+	assert.GreaterOrEqual(t, cres["count"].(float64), float64(1), "mygroups count includes the unseen member-group post")
+}


### PR DESCRIPTION
## Problem

On the browse page, the "N unread posts / Mark seen" badge/divider could stay non-zero **while** "YOU'RE UP TO DATE" also showed, and **Mark seen never cleared it** — reported by Mal Cooper (and Derek, FifeFreegle owner). Both have the non-default `browseView = "mygroups"`; default `nearby` users are unaffected.

## Cause

The browse rework unified the **feed** to the location/isochrone view for everyone, but only **`Count`** branched on `browseView` (`mygroups` → member-group query). So a `mygroups` user got a **member-group count over a location feed**: the badge counted member-group posts the feed never rendered, and "Mark seen" (which marks the rendered/viewport set) could never drain it. A client path also omitted `browseView`, so the count fell back to `nearby` and counted non-member nearby posts.

Confirmed on prod (apiv2-live): Mal's real `mygroups` count is **0** (he's up to date on his groups), but the badge showed 4 — a phantom `nearby` count.

## Fix

- **`isochrone/message.go`**: `effectiveBrowseView` (explicit `?browseView=` → user's saved setting → `nearby`) used by **both** `Count` and `Messages`, so no client path can leak the wrong view; add a `mygroups` branch to `Messages` returning member-group posts (`myGroupsMessages`/`myGroupsMsgIDs`), sharing `Count`'s universe so **feed == badge**.
- **isochrone store**: thread `browseView` into the list fetch (today it sends nothing).
- **`MessageList.vue`**: `markSeen` marks the full list (not just the viewport subset); fix the `me.value?.settings?.browseView` deref in the post-mark-seen re-poll (`me` is a `useMe()` ComputedRef).

## Verification

- Go: new `TestIsochroneMyGroupsView` (feed + count restrict to member groups; a non-member group's post is excluded). Full Go suite green (3255/0).
- Vitest green (13403/0).
- Behaviour validated against Mal's prod data.

`nearby` (default) users are unaffected. Humans merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)