### PR TITLE
fix(tests): stop JobModelTest spatial teardown flaking the Laravel suite

### DIFF
--- a/iznik-batch/tests/Support/SeedsSpatialIndex.php
+++ b/iznik-batch/tests/Support/SeedsSpatialIndex.php
@@ -44,12 +44,25 @@ trait SeedsSpatialIndex
 
     /**
      * Remove seeded ids from a dataset's live index (teardown).
+     *
+     * Best-effort: a failed/slow remove must never error the test. This runs in
+     * teardown, so a propagated exception (e.g. cURL 28 when the spatial server
+     * is briefly slow under CI load) would skip the rest of teardown — including
+     * parent::tearDown()'s connection cleanup — leaving the DB connection holding
+     * locks and flaking *subsequent* tests with "1205 Lock wait timeout" on the
+     * next clearJobsTable() DELETE. Swallow failures and let the next seed/remove
+     * or the nightly rebuild reconcile the index, exactly as the production
+     * SpatialAdminService::removeItems does.
      */
     protected function removeSpatial(string $dataset, array $ids): void
     {
-        Http::timeout(5)->post(
-            "{$this->spatialAdminUrl()}/v1/{$dataset}/remove",
-            ['ids' => array_values($ids)]
-        );
+        try {
+            Http::timeout(10)->post(
+                "{$this->spatialAdminUrl()}/v1/{$dataset}/remove",
+                ['ids' => array_values($ids)]
+            );
+        } catch (\Throwable $e) {
+            // Index cleanup is best-effort; see the note above.
+        }
     }
 }

--- a/iznik-batch/tests/Unit/Models/JobModelTest.php
+++ b/iznik-batch/tests/Unit/Models/JobModelTest.php
@@ -17,11 +17,18 @@ class JobModelTest extends TestCase
 
     protected function tearDown(): void
     {
-        if ($this->seededJobIds) {
-            $this->removeSpatial('jobs', $this->seededJobIds);
-            $this->seededJobIds = [];
+        // parent::tearDown() must always run (it cleans up the DB connection);
+        // removeSpatial() is already best-effort, but guard with finally so no
+        // teardown failure can ever leave the connection holding locks and flake
+        // the next test's clearJobsTable() DELETE.
+        try {
+            if ($this->seededJobIds) {
+                $this->removeSpatial('jobs', $this->seededJobIds);
+                $this->seededJobIds = [];
+            }
+        } finally {
+            parent::tearDown();
         }
-        parent::tearDown();
     }
 
     /**


### PR DESCRIPTION
## Problem

Intermittent CI failures in the **Laravel** suite, e.g. PR #872 build-test job 23218:

- 2× `cURL error 28 ... timed out after 5002 ms ... http://spatial-knn:8195/v1/jobs/remove`
- 5× `SQLSTATE[HY000] 1205 Lock wait timeout exceeded ... delete from jobs`

All 7 errors were in `Tests\Unit\Models\JobModelTest` (an integration test that seeds the live spatial-knn `jobs` index).

## Root cause — one mechanism, not two

`JobModelTest::tearDown()` calls `SeedsSpatialIndex::removeSpatial()`, which made an **un-try-caught** `Http::timeout(5)->post(.../v1/jobs/remove)`. When spatial-knn was briefly slow under parallel-suite load, that threw `ConnectionException` (cURL 28) **straight out of `tearDown` before `parent::tearDown()` ran**. The skipped teardown left the DB connection holding locks, so the *following* tests' whole-table `delete from jobs` in `clearJobsTable()` hit `1205 Lock wait timeout`. A single slow teardown therefore cascaded into a run of unrelated lock-wait errors.

The author had already added a retry loop to `clearJobsTable()`, but a retry can't survive a connection left dirty by a teardown that never completed.

## Fix (test-only)

1. **`SeedsSpatialIndex::removeSpatial`** — wrap the POST in try/catch so a slow/unreachable spatial server during teardown logs nothing and never errors the test. This mirrors production `SpatialAdminService::removeItems`, which deliberately swallows the identical failure ("Failures are logged as warnings and do not throw"). Timeout bumped 5s → 10s.
2. **`JobModelTest::tearDown`** — `try { … } finally { parent::tearDown(); }` so connection cleanup always runs regardless of any teardown failure, structurally breaking the lock-wait cascade.

No production code changes.

## Validation

`JobModelTest` run via the status API in an isolated worktree: **21 passed, 46 assertions, 0 failures, 0 errors.** The flake is load-dependent and won't reproduce in isolation, but the cascade path is now removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)