### PR TITLE
fix(ripple): only block re-rippling for groups rippled-into then left

### DIFF
--- a/iznik-batch/app/Services/Ripple/ExpandService.php
+++ b/iznik-batch/app/Services/Ripple/ExpandService.php
@@ -421,9 +421,22 @@ class ExpandService
                        SELECT 1 FROM messages_groups mg WHERE mg.msgid = ? AND mg.groupid = g.id
                    )
                    AND NOT EXISTS (
-                       SELECT 1 FROM logs l
-                       WHERE l.user = m.fromuser AND l.groupid = g.id
-                         AND l.type = 'Group' AND l.subtype = 'Left'
+                       -- Only a group the poster was RIPPLED into (a Group/Joined log with
+                       -- text='Rippled') and then LEFT (a later Group/Left log) is barred from
+                       -- re-rippling - that pairing is the poster opting out of the ripple. A group
+                       -- they joined manually/ordinarily and later left must NOT block rippling.
+                       -- ll.id > lj.id requires the leave to post-date the ripple-join, so a group
+                       -- left long before being rippled in is not treated as opted-out. Sites B/C
+                       -- apply the identical rule.
+                       SELECT 1 FROM logs lj
+                       WHERE lj.user = m.fromuser AND lj.groupid = g.id
+                         AND lj.type = 'Group' AND lj.subtype = 'Joined' AND lj.text = 'Rippled'
+                         AND EXISTS (
+                             SELECT 1 FROM logs ll
+                             WHERE ll.user = lj.user AND ll.groupid = lj.groupid
+                               AND ll.type = 'Group' AND ll.subtype = 'Left'
+                               AND ll.id > lj.id
+                         )
                    )",
                 [$msgid, $msgid, $reachWkt, $msgid]
             );
@@ -457,7 +470,8 @@ class ExpandService
      * group membership, except immediate (-1) is downgraded to daily (24) so an unrequested
      * membership never starts a flood of immediate mail (a no-email 0 or daily 24 home setting is
      * preserved). Existing memberships - including a Banned row - are left untouched (INSERT IGNORE
-     * + NOT EXISTS), and a group the poster has actively LEFT is never re-joined (Group/Left guard).
+     * + NOT EXISTS), and a group the poster was rippled into and then LEFT is never re-joined
+     * (the rippled-in-then-left guard; an ordinary membership they left does not block rippling).
      * Writes a memberships_history row (rippled=1) so abuse detection still runs while the per-group
      * welcome is suppressed, and sends one bundled intro email per post. Best-effort: never breaks
      * the expander.
@@ -495,10 +509,12 @@ class ExpandService
             $volunteeringallowed = $home->volunteeringallowed ?? 1;
 
             // Groups this post has rippled into where the poster has no membership row yet AND
-            // which the poster has not actively LEFT. A Group/Left log (self-leave, mod-remove,
-            // unban, partner-remove) is a durable "do not put me back here" signal: rippling must
-            // never re-join a group the poster chose to leave. (The post itself is also pulled from
-            // such groups by pullRippledPostsFromLeftGroups; here we only gate the membership.)
+            // which the poster has not "rippled in then left". Only a group the poster was once
+            // RIPPLED into (Group/Joined log text='Rippled') and subsequently LEFT (a later
+            // Group/Left log) is a durable "do not ripple me back here" signal; a group they joined
+            // manually/ordinarily and later left must NOT block rippling. (The post itself is also
+            // pulled from such groups by pullRippledPostsFromLeftGroups; here we only gate the
+            // membership.)
             $targets = DB::select(
                 "SELECT mg.groupid
                  FROM messages_groups mg
@@ -507,9 +523,15 @@ class ExpandService
                        SELECT 1 FROM memberships m WHERE m.userid = ? AND m.groupid = mg.groupid
                    )
                    AND NOT EXISTS (
-                       SELECT 1 FROM logs l
-                       WHERE l.user = ? AND l.groupid = mg.groupid
-                         AND l.type = 'Group' AND l.subtype = 'Left'
+                       SELECT 1 FROM logs lj
+                       WHERE lj.user = ? AND lj.groupid = mg.groupid
+                         AND lj.type = 'Group' AND lj.subtype = 'Joined' AND lj.text = 'Rippled'
+                         AND EXISTS (
+                             SELECT 1 FROM logs ll
+                             WHERE ll.user = lj.user AND ll.groupid = lj.groupid
+                               AND ll.type = 'Group' AND ll.subtype = 'Left'
+                               AND ll.id > lj.id
+                         )
                    )",
                 [$msgid, $posterId, $posterId]
             );
@@ -614,12 +636,15 @@ class ExpandService
     }
 
     /**
-     * Leaving a group the post rippled into also pulls the POST from that group (the product
-     * decision: a leave means "I want nothing to do with this group", not just "stop my
-     * membership"). Soft-deletes (deleted=1) every rippled-in messages_groups row whose post's
-     * author has a Group/Left log for that group, and audits each removal with a Message/Deleted
-     * log. Idempotent (only touches deleted=0 rows); the membership re-join and any future
-     * re-ripple are separately blocked by the Group/Left guard. Best-effort: never breaks the run.
+     * Leaving a group the post was RIPPLED into also pulls the POST from that group (the product
+     * decision: leaving a group you were rippled into means "I want nothing to do with this group",
+     * not just "stop my membership"). Soft-deletes (deleted=1) every rippled-in messages_groups row
+     * whose author was rippled into that group (a Group/Joined log text='Rippled') and then LEFT it
+     * (a later Group/Left log), and audits each removal with a Message/Deleted log. An ordinary
+     * membership the author left is left alone - matching sites A/B - so a fresh ripple into a group
+     * they once normally-left is not immediately pulled back out. Idempotent (only touches deleted=0
+     * rows); the membership re-join and any future re-ripple are blocked by the same
+     * rippled-in-then-left rule. Best-effort: never breaks the run.
      */
     private function pullRippledPostsFromLeftGroups(bool $dryRun, array &$stats): void
     {
@@ -628,9 +653,18 @@ class ExpandService
                 "SELECT mg.msgid, mg.groupid, m.fromuser
                  FROM messages_groups mg
                  JOIN messages m ON m.id = mg.msgid
-                 JOIN logs l ON l.user = m.fromuser AND l.groupid = mg.groupid
-                              AND l.type = 'Group' AND l.subtype = 'Left'
                  WHERE mg.rippled_in = 1 AND mg.deleted = 0
+                   AND EXISTS (
+                       SELECT 1 FROM logs lj
+                       WHERE lj.user = m.fromuser AND lj.groupid = mg.groupid
+                         AND lj.type = 'Group' AND lj.subtype = 'Joined' AND lj.text = 'Rippled'
+                         AND EXISTS (
+                             SELECT 1 FROM logs ll
+                             WHERE ll.user = lj.user AND ll.groupid = lj.groupid
+                               AND ll.type = 'Group' AND ll.subtype = 'Left'
+                               AND ll.id > lj.id
+                         )
+                   )
                  GROUP BY mg.msgid, mg.groupid, m.fromuser"
             );
 

--- a/iznik-batch/app/Services/Ripple/ExpandService.php
+++ b/iznik-batch/app/Services/Ripple/ExpandService.php
@@ -421,16 +421,22 @@ class ExpandService
                        SELECT 1 FROM messages_groups mg WHERE mg.msgid = ? AND mg.groupid = g.id
                    )
                    AND NOT EXISTS (
-                       -- Only a group the poster was RIPPLED into (a Group/Joined log with
-                       -- text='Rippled') and then LEFT (a later Group/Left log) is barred from
-                       -- re-rippling - that pairing is the poster opting out of the ripple. A group
-                       -- they joined manually/ordinarily and later left must NOT block rippling.
-                       -- ll.id > lj.id requires the leave to post-date the ripple-join, so a group
-                       -- left long before being rippled in is not treated as opted-out. Sites B/C
-                       -- apply the identical rule.
+                       -- Suppress re-rippling only when the poster's MOST RECENT Group/Joined log
+                       -- for this group is a ripple-join (text='Rippled') AND they then LEFT it -
+                       -- i.e. the membership they last opted out of was a rippled one. Most recent
+                       -- join wins: the NOT EXISTS lj2 makes lj the latest Joined, so a later
+                       -- manual/ordinary join (then leave) means they treated it as a normal group
+                       -- and rippling is NOT blocked; ll.id > lj.id requires the leave to follow
+                       -- that ripple-join. Sites B/C apply the identical rule.
                        SELECT 1 FROM logs lj
                        WHERE lj.user = m.fromuser AND lj.groupid = g.id
                          AND lj.type = 'Group' AND lj.subtype = 'Joined' AND lj.text = 'Rippled'
+                         AND NOT EXISTS (
+                             SELECT 1 FROM logs lj2
+                             WHERE lj2.user = lj.user AND lj2.groupid = lj.groupid
+                               AND lj2.type = 'Group' AND lj2.subtype = 'Joined'
+                               AND lj2.id > lj.id
+                         )
                          AND EXISTS (
                              SELECT 1 FROM logs ll
                              WHERE ll.user = lj.user AND ll.groupid = lj.groupid
@@ -470,8 +476,9 @@ class ExpandService
      * group membership, except immediate (-1) is downgraded to daily (24) so an unrequested
      * membership never starts a flood of immediate mail (a no-email 0 or daily 24 home setting is
      * preserved). Existing memberships - including a Banned row - are left untouched (INSERT IGNORE
-     * + NOT EXISTS), and a group the poster was rippled into and then LEFT is never re-joined
-     * (the rippled-in-then-left guard; an ordinary membership they left does not block rippling).
+     * + NOT EXISTS), and a group whose most recent join was a ripple-join the poster then LEFT is
+     * never re-joined ("most recent join wins"; an ordinary last membership they left does not block
+     * rippling).
      * Writes a memberships_history row (rippled=1) so abuse detection still runs while the per-group
      * welcome is suppressed, and sends one bundled intro email per post. Best-effort: never breaks
      * the expander.
@@ -509,12 +516,12 @@ class ExpandService
             $volunteeringallowed = $home->volunteeringallowed ?? 1;
 
             // Groups this post has rippled into where the poster has no membership row yet AND
-            // which the poster has not "rippled in then left". Only a group the poster was once
-            // RIPPLED into (Group/Joined log text='Rippled') and subsequently LEFT (a later
-            // Group/Left log) is a durable "do not ripple me back here" signal; a group they joined
-            // manually/ordinarily and later left must NOT block rippling. (The post itself is also
-            // pulled from such groups by pullRippledPostsFromLeftGroups; here we only gate the
-            // membership.)
+            // which the poster has not "rippled in then left". Only a group whose MOST RECENT
+            // Group/Joined log is a ripple-join (text='Rippled') that the poster then LEFT is a
+            // durable "do not ripple me back here" signal ("most recent join wins"); a group they
+            // last joined manually/ordinarily and then left must NOT block rippling. (The post
+            // itself is also pulled from such groups by pullRippledPostsFromLeftGroups; here we only
+            // gate the membership.)
             $targets = DB::select(
                 "SELECT mg.groupid
                  FROM messages_groups mg
@@ -526,6 +533,12 @@ class ExpandService
                        SELECT 1 FROM logs lj
                        WHERE lj.user = ? AND lj.groupid = mg.groupid
                          AND lj.type = 'Group' AND lj.subtype = 'Joined' AND lj.text = 'Rippled'
+                         AND NOT EXISTS (
+                             SELECT 1 FROM logs lj2
+                             WHERE lj2.user = lj.user AND lj2.groupid = lj.groupid
+                               AND lj2.type = 'Group' AND lj2.subtype = 'Joined'
+                               AND lj2.id > lj.id
+                         )
                          AND EXISTS (
                              SELECT 1 FROM logs ll
                              WHERE ll.user = lj.user AND ll.groupid = lj.groupid
@@ -639,12 +652,13 @@ class ExpandService
      * Leaving a group the post was RIPPLED into also pulls the POST from that group (the product
      * decision: leaving a group you were rippled into means "I want nothing to do with this group",
      * not just "stop my membership"). Soft-deletes (deleted=1) every rippled-in messages_groups row
-     * whose author was rippled into that group (a Group/Joined log text='Rippled') and then LEFT it
-     * (a later Group/Left log), and audits each removal with a Message/Deleted log. An ordinary
-     * membership the author left is left alone - matching sites A/B - so a fresh ripple into a group
-     * they once normally-left is not immediately pulled back out. Idempotent (only touches deleted=0
+     * whose author's MOST RECENT Group/Joined log for that group is a ripple-join (text='Rippled')
+     * that they then LEFT (a later Group/Left log) - "most recent join wins". An author whose last
+     * join was ordinary, or who manually rejoined after a rippled leave, is left alone (matching
+     * sites A/B) - so a fresh ripple into a group they once normally-left is not immediately pulled
+     * back out. Audits each removal with a Message/Deleted log. Idempotent (only touches deleted=0
      * rows); the membership re-join and any future re-ripple are blocked by the same
-     * rippled-in-then-left rule. Best-effort: never breaks the run.
+     * most-recent-join-wins rule. Best-effort: never breaks the run.
      */
     private function pullRippledPostsFromLeftGroups(bool $dryRun, array &$stats): void
     {
@@ -658,6 +672,12 @@ class ExpandService
                        SELECT 1 FROM logs lj
                        WHERE lj.user = m.fromuser AND lj.groupid = mg.groupid
                          AND lj.type = 'Group' AND lj.subtype = 'Joined' AND lj.text = 'Rippled'
+                         AND NOT EXISTS (
+                             SELECT 1 FROM logs lj2
+                             WHERE lj2.user = lj.user AND lj2.groupid = lj.groupid
+                               AND lj2.type = 'Group' AND lj2.subtype = 'Joined'
+                               AND lj2.id > lj.id
+                         )
                          AND EXISTS (
                              SELECT 1 FROM logs ll
                              WHERE ll.user = lj.user AND ll.groupid = lj.groupid

--- a/iznik-batch/tests/Unit/Services/Ripple/ExpandServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/Ripple/ExpandServiceTest.php
@@ -910,6 +910,51 @@ class ExpandServiceTest extends TestCase
     }
 
     /**
+     * "Most recent join wins": a poster rippled into B, left, then MANUALLY rejoined and left again
+     * is NOT blocked - their last join was ordinary, so the rippled opt-out no longer applies and
+     * the post is rippled back in. Only a group whose MOST RECENT join was a ripple-join (then left)
+     * stays barred.
+     */
+    public function test_manual_rejoin_after_rippled_left_allows_rippling(): void
+    {
+        $this->fakeRouting(3);
+        $msgid = $this->seedSpatialPost(now()->subMinutes(30));
+        $posterId = (int) DB::table('messages')->where('id', $msgid)->value('fromuser');
+
+        $groupB = $this->createTestGroup();
+        DB::statement(
+            "UPDATE `groups` SET publish = 1, polyindex = ST_GeomFromText(?, ?) WHERE id = ?",
+            ['POLYGON((-0.18 51.52,-0.12 51.52,-0.12 51.58,-0.18 51.58,-0.18 51.52))', 3857, $groupB->id]
+        );
+
+        // History oldest -> newest (insertion order = ascending log id):
+        // rippled in -> left -> MANUALLY rejoined -> left again. The latest Joined is 'Manual'.
+        $events = [
+            ['Joined', 'Rippled', 40],
+            ['Left', null, 30],
+            ['Joined', 'Manual', 20],
+            ['Left', null, 10],
+        ];
+        foreach ($events as [$subtype, $text, $minsAgo]) {
+            DB::table('logs')->insert([
+                'timestamp' => now()->subMinutes($minsAgo), 'type' => 'Group', 'subtype' => $subtype,
+                'user' => $posterId, 'groupid' => $groupB->id, 'text' => $text,
+            ]);
+        }
+
+        $this->service()->process(false, 500);
+
+        $this->assertNotNull(
+            DB::table('messages_groups')->where('msgid', $msgid)->where('groupid', $groupB->id)->first(),
+            'post IS rippled in - the most recent join was manual, not a ripple opt-out'
+        );
+        $this->assertNotNull(
+            DB::table('memberships')->where('userid', $posterId)->where('groupid', $groupB->id)->first(),
+            'poster IS re-added (most-recent-join-wins: the last join was ordinary)'
+        );
+    }
+
+    /**
      * BUG FIX (pull side): a freshly rippled-in post is NOT pulled just because the poster has an
      * ordinary Group/Left log that pre-dates the ripple-in. Without this, a post rippling into a
      * group the poster once normally-left would be added and then immediately pulled back out.

--- a/iznik-batch/tests/Unit/Services/Ripple/ExpandServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/Ripple/ExpandServiceTest.php
@@ -831,10 +831,11 @@ class ExpandServiceTest extends TestCase
     }
 
     /**
-     * A poster who has actively LEFT a group (Group/Left log) is never re-joined AND their post is
-     * never (re-)rippled into that group - rippling must not override an explicit departure.
+     * A poster who was RIPPLED into a group (Group/Joined, text='Rippled') and then LEFT it is
+     * never re-joined AND their post is never (re-)rippled in: leaving a group you were rippled
+     * into is the opt-out signal rippling must respect.
      */
-    public function test_left_group_is_not_rejoined_and_post_not_rippled_in(): void
+    public function test_rippled_in_then_left_is_not_rejoined_and_post_not_rippled_in(): void
     {
         $this->fakeRouting(3);
         $msgid = $this->seedSpatialPost(now()->subMinutes(30));
@@ -846,7 +847,12 @@ class ExpandServiceTest extends TestCase
             ['POLYGON((-0.18 51.52,-0.12 51.52,-0.12 51.58,-0.18 51.58,-0.18 51.52))', 3857, $groupB->id]
         );
 
-        // The poster previously left group B (any reason writes Group/Left).
+        // The poster was rippled into B (Group/Joined, text='Rippled') and then LEFT it. The
+        // Joined/Rippled log is inserted first so it has the lower id (the leave post-dates it).
+        DB::table('logs')->insert([
+            'timestamp' => now()->subDays(2), 'type' => 'Group', 'subtype' => 'Joined',
+            'user' => $posterId, 'groupid' => $groupB->id, 'text' => 'Rippled',
+        ]);
         DB::table('logs')->insert([
             'timestamp' => now()->subDay(), 'type' => 'Group', 'subtype' => 'Left',
             'user' => $posterId, 'groupid' => $groupB->id,
@@ -856,12 +862,85 @@ class ExpandServiceTest extends TestCase
 
         $this->assertNull(
             DB::table('memberships')->where('userid', $posterId)->where('groupid', $groupB->id)->first(),
-            'poster who left B is not re-joined by rippling'
+            'poster rippled into B then left is not re-joined by rippling'
         );
         $this->assertNull(
             DB::table('messages_groups')->where('msgid', $msgid)->where('groupid', $groupB->id)->first(),
-            'post is not rippled into a group the poster has left'
+            'post is not (re-)rippled into a group the poster was rippled into then left'
         );
+    }
+
+    /**
+     * BUG FIX: a poster who left a group they were NOT rippled into (an ordinary/manual membership
+     * they later left) IS still rippled in. Only a rippled-in-then-left opt-out blocks rippling -
+     * an unrelated prior departure must not bar the post or the membership.
+     */
+    public function test_ordinary_left_does_not_block_rippling(): void
+    {
+        $this->fakeRouting(3);
+        $msgid = $this->seedSpatialPost(now()->subMinutes(30));
+        $posterId = (int) DB::table('messages')->where('id', $msgid)->value('fromuser');
+
+        $groupB = $this->createTestGroup();
+        DB::statement(
+            "UPDATE `groups` SET publish = 1, polyindex = ST_GeomFromText(?, ?) WHERE id = ?",
+            ['POLYGON((-0.18 51.52,-0.12 51.52,-0.12 51.58,-0.18 51.58,-0.18 51.52))', 3857, $groupB->id]
+        );
+
+        // Poster joined B manually (text='Manual') and later left - no rippled-in history at all.
+        DB::table('logs')->insert([
+            'timestamp' => now()->subDays(2), 'type' => 'Group', 'subtype' => 'Joined',
+            'user' => $posterId, 'groupid' => $groupB->id, 'text' => 'Manual',
+        ]);
+        DB::table('logs')->insert([
+            'timestamp' => now()->subDay(), 'type' => 'Group', 'subtype' => 'Left',
+            'user' => $posterId, 'groupid' => $groupB->id,
+        ]);
+
+        $this->service()->process(false, 500);
+
+        $this->assertNotNull(
+            DB::table('messages_groups')->where('msgid', $msgid)->where('groupid', $groupB->id)->first(),
+            'post IS rippled into a group the poster only ordinarily left'
+        );
+        $this->assertNotNull(
+            DB::table('memberships')->where('userid', $posterId)->where('groupid', $groupB->id)->first(),
+            'poster IS re-added as a member (an ordinary prior leave does not block rippling)'
+        );
+    }
+
+    /**
+     * BUG FIX (pull side): a freshly rippled-in post is NOT pulled just because the poster has an
+     * ordinary Group/Left log that pre-dates the ripple-in. Without this, a post rippling into a
+     * group the poster once normally-left would be added and then immediately pulled back out.
+     */
+    public function test_ordinary_left_does_not_pull_a_freshly_rippled_post(): void
+    {
+        $this->fakeRouting(3);
+        $msgid = $this->seedSpatialPost(now()->subMinutes(30));
+        $posterId = (int) DB::table('messages')->where('id', $msgid)->value('fromuser');
+
+        $groupB = $this->createTestGroup();
+        DB::statement(
+            "UPDATE `groups` SET publish = 1, polyindex = ST_GeomFromText(?, ?) WHERE id = ?",
+            ['POLYGON((-0.18 51.52,-0.12 51.52,-0.12 51.58,-0.18 51.58,-0.18 51.52))', 3857, $groupB->id]
+        );
+
+        // An ordinary leave of B, recorded BEFORE the post ripples in (so its log id is lower than
+        // the Joined/Rippled log process() writes at ripple-in time).
+        DB::table('logs')->insert([
+            'timestamp' => now()->subDay(), 'type' => 'Group', 'subtype' => 'Left',
+            'user' => $posterId, 'groupid' => $groupB->id,
+        ]);
+
+        // Run 1 ripples the post into B (writes the Joined/Rippled log). Run 2 exercises the
+        // pull-on-leave reconciliation, which runs at the start of a process() pass.
+        $this->service()->process(false, 500);
+        $this->service()->process(false, 500);
+
+        $row = DB::table('messages_groups')->where('msgid', $msgid)->where('groupid', $groupB->id)->first();
+        $this->assertNotNull($row, 'post rippled into B despite the ordinary prior leave');
+        $this->assertSame(0, (int) $row->deleted, 'freshly rippled-in post is NOT pulled by a pre-existing ordinary leave');
     }
 
     /** Leaving a group the post rippled into pulls the post from that group (soft-delete + log). */


### PR DESCRIPTION
## Problem

The rippling expander blocked rippling a poster into **any** group they had a `Group/Left` log for. Because that guard fired on *any* prior departure - a manual leave, mod-remove, unban, "moved house" - a single past leave **permanently** barred that user's future posts from ever rippling into the group again, even though the leave had nothing to do with rippling.

The intended rule is narrower: only a group the poster was **rippled into** (a `Group/Joined` log with `text='Rippled'`) and then **left** should count as an opt-out. An ordinary membership they joined normally and later left must **not** block rippling.

## Why the marker exists

We always join-then-post, so every rippled membership writes a distinct join log: `addPosterMembershipToRippledGroups` records `logs(type='Group', subtype='Joined', text='Rippled')`. That marker is exactly what tells a rippling auto-join apart from a manual/auto one.

## Fix — "most recent join wins"

All three `Group/Left` guards in `ExpandService` now suppress **only** when the poster's **most recent** `Group/Joined` log for the group is a ripple-join (`text='Rippled'`) **and** they then left it (a `Left` after it). Concretely the predicate requires:
- a `Joined/Rippled` log `lj`, **and**
- `NOT EXISTS` any later `Joined` log (so `lj` is the latest join → "most recent join wins"), **and**
- `EXISTS` a `Left` with `id > lj.id` (they left after that ripple-join).

| Site | Function | Effect |
|---|---|---|
| A | `rippleIntoNewGroups` | whether the **post** ripples into the group |
| B | `addPosterMembershipToRippledGroups` | whether the **membership** is added |
| C | `pullRippledPostsFromLeftGroups` | whether a rippled post is **pulled** when the poster left |

Site C is kept consistent on purpose: if only A+B were relaxed, a post would ripple into a group the user *normally* left and then C would immediately pull it back out (churn).

No changes needed in Go (`iznik-server-go` writes `Left` logs but never reads them to gate rippling) or V1 PHP. Confirmed by a full-repo audit.

## Behaviour after the fix

| Scenario (oldest→newest) | Before | After |
|---|---|---|
| No prior history | ripples | ripples |
| Manual/auto join → left | **blocked** | **ripples (bug fixed)** |
| Rippled in → left | blocked | blocked (the opt-out) |
| Rippled in → still a member | ripples | ripples |
| **Rippled in → left → manually rejoined → left again** | blocked | **ripples (most-recent-join-wins)** |

The last row is the refinement: because the latest join was manual, the earlier rippled opt-out no longer applies.

## Tests (`ExpandServiceTest`, 36 passed locally)

- `test_rippled_in_then_left_is_not_rejoined_and_post_not_rippled_in` (genuine opt-out → suppressed)
- `test_ordinary_left_does_not_block_rippling` (manual/auto leave → ripples)
- `test_manual_rejoin_after_rippled_left_allows_rippling` (most-recent-join-wins)
- `test_ordinary_left_does_not_pull_a_freshly_rippled_post` (no pull-churn; also covers a Left predating the ripple-join)
- Existing `test_leaving_a_rippled_group_pulls_the_post` still passes

**Verification:** an adversarial sweep of 42 log-history scenarios (multi-cycle, boundary, NULL-text, id-ordering) found **0 divergences** between the SQL and the most-recent-join-wins intent.

## Index/perf

The new correlated subqueries filter `logs` by `user = ? AND groupid = ?` first - the same access pattern the original guard used - served by the existing `user`/`group` indexes; `type`/`subtype`/`text` are cheap residual filters on a user's handful of per-group rows. Runs in the batch expander, not a request path. No new index or migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)