### PR TITLE
perf(ripple): decouple reach-mail from the serial expand loop into a sharded pass

### DIFF
--- a/iznik-batch/app/Console/Commands/Mail/SendUnifiedDigestCommand.php
+++ b/iznik-batch/app/Console/Commands/Mail/SendUnifiedDigestCommand.php
@@ -93,8 +93,8 @@ class SendUnifiedDigestCommand extends Command
             return Command::FAILURE;
         }
 
-        if (! in_array($mode, [UnifiedDigestService::MODE_DAILY, UnifiedDigestService::MODE_IMMEDIATE])) {
-            $this->error("Invalid mode '{$mode}'. Must be 'daily' or 'immediate'.");
+        if (! in_array($mode, [UnifiedDigestService::MODE_DAILY, UnifiedDigestService::MODE_IMMEDIATE, UnifiedDigestService::MODE_REACH])) {
+            $this->error("Invalid mode '{$mode}'. Must be 'daily', 'immediate' or 'reach'.");
             return Command::FAILURE;
         }
 
@@ -149,7 +149,7 @@ class SendUnifiedDigestCommand extends Command
         // no_new_posts_groups); daily mode reports per-user ones
         // (no_new_posts). Initialise both so either summary table below can
         // read its keys regardless of which mode ran.
-        $stats = ['groups_processed' => 0, 'users_processed' => 0, 'emails_sent' => 0, 'no_new_posts_groups' => 0, 'no_new_posts' => 0, 'errors' => 0];
+        $stats = ['groups_processed' => 0, 'users_processed' => 0, 'posts_processed' => 0, 'emails_sent' => 0, 'no_new_posts_groups' => 0, 'no_new_posts' => 0, 'errors' => 0];
 
         $shouldStop = fn () => $this->shouldStop();
 
@@ -157,7 +157,7 @@ class SendUnifiedDigestCommand extends Command
             $r = $service->sendDigests($mode, $userId, $limit, $dryRun, $groupId, $shard, $shards, $shouldStop);
 
             // Daily mode returns a different stat shape — match keys best-effort.
-            foreach (['groups_processed', 'users_processed', 'emails_sent', 'no_new_posts_groups', 'no_new_posts', 'errors'] as $k) {
+            foreach (['groups_processed', 'users_processed', 'posts_processed', 'emails_sent', 'no_new_posts_groups', 'no_new_posts', 'errors'] as $k) {
                 if (isset($r[$k])) {
                     $stats[$k] += $r[$k];
                 }
@@ -181,7 +181,16 @@ class SendUnifiedDigestCommand extends Command
 
         $this->newLine();
 
-        if ($mode === UnifiedDigestService::MODE_IMMEDIATE) {
+        if ($mode === UnifiedDigestService::MODE_REACH) {
+            $this->table(
+                ['Metric', 'Count'],
+                [
+                    ['Posts Processed', $stats['posts_processed']],
+                    ['Emails Sent', $stats['emails_sent']],
+                    ['Errors', $stats['errors']],
+                ]
+            );
+        } elseif ($mode === UnifiedDigestService::MODE_IMMEDIATE) {
             $this->table(
                 ['Metric', 'Count'],
                 [

--- a/iznik-batch/app/Services/Ripple/ExpandService.php
+++ b/iznik-batch/app/Services/Ripple/ExpandService.php
@@ -249,8 +249,11 @@ class ExpandService
                         ]
                     );
                     $this->rippleIntoNewGroups((int) $row->msgid, $storeWkt, $stats);
-                    $stats['mailed'] += app(\App\Services\UnifiedDigestService::class)
-                        ->mailNewlyReachedForPost((int) $row->msgid);
+                    // Reach mail is decoupled into the sharded `mail:digest:unified --mode=reach`
+                    // pass (UnifiedDigestService::sendReachDigests). It must NOT run inline here:
+                    // the 2026-06-24 live profile showed it was ~75% of this serial Phase-2 loop's
+                    // wall-clock, and mail has no Galera single-writer constraint. The reach write
+                    // above bumps rippling_reach.updated_at, which is the signal that pass picks up.
                 }
 
                 $stats['initialized']++;
@@ -349,8 +352,8 @@ class ExpandService
                     // group so a secondary "out of area" rejection survives expansion (#9).
                     $this->reapplyClips((int) $row->msgid, $row->rejected_groups ?? null);
                     $this->rippleIntoNewGroups((int) $row->msgid, $storeWkt, $stats);
-                    $stats['mailed'] += app(\App\Services\UnifiedDigestService::class)
-                        ->mailNewlyReachedForPost((int) $row->msgid);
+                    // Reach mail decoupled into `mail:digest:unified --mode=reach` — see
+                    // initialiseNew and UnifiedDigestService::sendReachDigests.
                 }
 
                 $stats['expanded']++;

--- a/iznik-batch/app/Services/UnifiedDigestService.php
+++ b/iznik-batch/app/Services/UnifiedDigestService.php
@@ -37,6 +37,8 @@ class UnifiedDigestService
      */
     public const MODE_IMMEDIATE = 'immediate';
     public const MODE_DAILY = 'daily';
+    /** Reach-mail: decoupled, sharded pass that mails members newly inside a rippling post's reach. */
+    public const MODE_REACH = 'reach';
 
     /**
      * Send unified digests to users who want them.
@@ -49,6 +51,10 @@ class UnifiedDigestService
     {
         if ($mode === self::MODE_IMMEDIATE) {
             return $this->sendImmediateDigests($limit, $dryRun, $groupId, $userId, $shard, $shards, $shouldStop);
+        }
+
+        if ($mode === self::MODE_REACH) {
+            return $this->sendReachDigests($limit, $dryRun, $shard, $shards, $shouldStop);
         }
 
         $stats = [
@@ -462,9 +468,75 @@ class UnifiedDigestService
      * messages with identical microsecond-precision arrival timestamps
      * can't both fall past the cursor and one of them be missed.
      */
+
     /**
-     * Expander-driven rippling immediate mail (#0 step 4). Called by ExpandService after each
-     * reach write (init + every tick). Mails the post to every immediate-eligible member of a
+     * Decoupled, sharded reach-mail pass. Mails members who are newly inside a rippling post's
+     * reach polygon — the work that used to run inline in ExpandService's serial Phase-2 loop,
+     * where (per the 2026-06-24 live profile) it was ~75% of the run's wall-clock. Pulling it out
+     * lets the reach writes stay serial (Galera single-writer) while the mail fans out in parallel.
+     *
+     * Processes rippling_reach rows whose reach changed recently (updated_at within the configured
+     * window — reach only changes on init/advance, never on this pass, which writes only
+     * rippling_reach_notified), partitioned across parallel workers by MOD(msgid, shards) exactly
+     * as the immediate-digest cron partitions by MOD(groupid, shards). Disjoint partitions → shards
+     * run concurrently with no locking. Idempotent regardless of window overlap: the
+     * rippling_reach_notified ledger means an already-notified member is never re-mailed.
+     *
+     * @param int|null $limit Cap on posts processed per run (null = no cap).
+     * @param int $shard Shard index (0..shards-1).
+     * @param int $shards Total shard count; posts partitioned by MOD(msgid, shards).
+     * @return array{posts_processed:int,emails_sent:int,errors:int,stopped?:bool}
+     */
+    public function sendReachDigests(?int $limit = null, bool $dryRun = false, int $shard = 0, int $shards = 1, ?callable $shouldStop = null): array
+    {
+        $stats = ['posts_processed' => 0, 'emails_sent' => 0, 'errors' => 0];
+
+        if (!self::isEmailTypeEnabled(self::EMAIL_TYPE)) {
+            return $stats;
+        }
+
+        // Only posts whose reach changed recently need a mail check — an unchanged polygon has no
+        // newly-inside members the ledger hasn't already covered. This mirrors the old inline
+        // trigger (mail fired on each init/advance). The window overlaps the cron interval so a
+        // post is never dropped between ticks; overlap is harmless because the ledger dedupes.
+        $windowMinutes = (int) config('freegle.ripple.reach_mail_window_minutes', 60);
+
+        $query = DB::table('rippling_reach')
+            ->whereIn('status', ['expanding', 'done'])
+            ->where('updated_at', '>=', now()->subMinutes($windowMinutes));
+
+        // Disjoint MOD(msgid, shards) partition — same model as sendImmediateDigests' MOD(groupid,
+        // shards); each post is owned by exactly one shard, so shards run concurrently safely.
+        if ($shards > 1) {
+            $query->whereRaw('MOD(msgid, ?) = ?', [$shards, $shard]);
+        }
+
+        $query->orderBy('updated_at'); // oldest-changed first so a backlog drains fairly
+        if ($limit !== null) {
+            $query->limit($limit);
+        }
+
+        foreach ($query->pluck('msgid') as $msgid) {
+            if ($shouldStop && $shouldStop()) {
+                $stats['stopped'] = true;
+                break;
+            }
+            try {
+                $stats['emails_sent'] += $this->mailNewlyReachedForPost((int) $msgid, $dryRun);
+                $stats['posts_processed']++;
+            } catch (\Throwable $e) {
+                $stats['errors']++;
+                Log::warning('reach-mail: failed for post', ['msgid' => $msgid, 'error' => $e->getMessage()]);
+            }
+        }
+
+        return $stats;
+    }
+
+    /**
+     * Newly-reached rippling immediate mail (#0 step 4). Called by the decoupled, sharded reach-mail
+     * pass (sendReachDigests) and by AutoApproveService (the post-'done' approval gap) — no longer
+     * inline in ExpandService's serial loop. Mails the post to every immediate-eligible member of a
      * group it is APPROVED on whose location the reach NOW covers and who has not already been
      * notified (rippling_reach_notified), recording each so a later tick — or another rippled-in
      * group — never re-mails them. Because it re-runs every tick (no cursor), members the reach

--- a/iznik-batch/routes/console.php
+++ b/iznik-batch/routes/console.php
@@ -496,6 +496,22 @@ foreach (range(0, $immediateShardCount - 1) as $shardIndex) {
         ->runInBackground();
 }
 
+// Reach mail - rippling reach notifications, decoupled from ExpandService's serial Phase-2
+// loop (which no longer mails inline; see ExpandService::initialiseNew). Mails members newly
+// inside a rippling post's reach, sharded by MOD(msgid, N) exactly as immediate mode shards by
+// MOD(groupid, N) - disjoint partitions, per-shard flock (lockKeySuffix), no locking between
+// shards. Scheduled unconditionally like ripple:release-replies above: sendReachDigests' window
+// query self-idles when no reach rows changed recently, so it costs nothing while rippling is
+// dark AND it covers both the global cron and the scoped group experiment (the old inline mail
+// ran in both paths). Each invocation drains the whole window in one pass, so no --max-iterations.
+$reachMailShardCount = 4;
+foreach (range(0, $reachMailShardCount - 1) as $reachShard) {
+    Schedule::command("mail:digest:unified --mode=reach --shard={$reachShard} --shards={$reachMailShardCount}")
+        ->everyMinute()
+        ->sendOutputTo(cronLog("mail:digest:unified.reach.shard{$reachShard}"))
+        ->runInBackground();
+}
+
 // Donation-related commands. V1 equivalents on bulk3 disabled 2026-05-12.
 Schedule::command('mail:donations:thank')
     ->dailyAt('09:00')

--- a/iznik-batch/tests/Unit/Services/UnifiedDigestServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/UnifiedDigestServiceTest.php
@@ -2090,4 +2090,83 @@ class UnifiedDigestServiceTest extends TestCase
         $ids = $captured->getPosts()->map(fn ($p) => $p['message']->id)->all();
         $this->assertSame([$near->id, $far->id], $ids); // near outranks far on closeness
     }
+
+    // ---- Decoupled, sharded reach-mail pass (sendReachDigests) -------------------
+    // Reach mail used to run inline in ExpandService's serial Phase-2 loop (~75% of
+    // run time). It is now a separate sharded pass over recently-changed reach rows,
+    // mirroring the immediate-digest cron's MOD(...,shards) partitioning.
+
+    /** Set up a rippling post whose reach covers one immediate-frequency member. */
+    private function setUpRippledPostWithReachableImmediateMember(): array
+    {
+        config(['freegle.digest.immediate_allowlist' => '*']);
+        $poster = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $this->createMembership($poster, $group, ['added' => now()->subHours(72)]);
+        $member = $this->createTestUser();
+        $this->createMembership($member, $group, ['added' => now()->subHours(72)]); // immediate by default
+        $member->settings = ['mylocation' => ['lat' => 51.5, 'lng' => -0.1]];
+        $member->save();
+
+        $message = $this->createTestMessage($poster, $group);
+        DB::table('messages_groups')->where('msgid', $message->id)->where('groupid', $group->id)->update([
+            'collection' => MessageGroup::COLLECTION_APPROVED,
+            'arrival' => now()->subHours(1),
+        ]);
+        // Reach polygon (status 'expanding', just updated) covering the member's location.
+        DB::statement(
+            "INSERT INTO rippling_reach (msgid, lat, lng, polygon, arrival, mode, tick, total_ticks, "
+            . "total_freeglers, max_drive_min, schedule, next_expansion_at, status, created_at, updated_at) "
+            . "VALUES (?, 51.5, -0.1, ST_GeomFromText(?, 3857), NOW(), 'drive', 3, 3, 0, 30, NULL, NULL, 'expanding', NOW(), NOW())",
+            [$message->id, 'POLYGON((-0.2 51.4,0.0 51.4,0.0 51.6,-0.2 51.6,-0.2 51.4))']
+        );
+
+        return [$message, $member];
+    }
+
+    public function test_send_reach_digests_mails_newly_reached_immediate_member(): void
+    {
+        [$message, $member] = $this->setUpRippledPostWithReachableImmediateMember();
+
+        $stats = $this->service->sendReachDigests();
+
+        $this->assertGreaterThanOrEqual(1, $stats['emails_sent'], 'a reachable immediate member is mailed');
+        $this->assertTrue(
+            DB::table('rippling_reach_notified')->where('msgid', $message->id)->where('userid', $member->id)->exists(),
+            'the reach-mail pass records the notification in the ledger'
+        );
+    }
+
+    public function test_send_reach_digests_is_idempotent_via_ledger(): void
+    {
+        $this->setUpRippledPostWithReachableImmediateMember();
+
+        $this->service->sendReachDigests();
+        $second = $this->service->sendReachDigests();
+
+        $this->assertSame(0, $second['emails_sent'], 'already-notified members are not re-mailed on a second pass');
+    }
+
+    public function test_send_reach_digests_partitions_posts_by_msgid_shard(): void
+    {
+        [$message, $member] = $this->setUpRippledPostWithReachableImmediateMember();
+
+        $shards = 2;
+        $ownShard = (int) $message->id % $shards;
+        $otherShard = 1 - $ownShard;
+
+        // The shard that does NOT own this msgid must skip it entirely.
+        $this->service->sendReachDigests(null, false, $otherShard, $shards);
+        $this->assertFalse(
+            DB::table('rippling_reach_notified')->where('msgid', $message->id)->exists(),
+            'a shard does not process posts outside its MOD(msgid, shards) partition'
+        );
+
+        // The owning shard processes it.
+        $this->service->sendReachDigests(null, false, $ownShard, $shards);
+        $this->assertTrue(
+            DB::table('rippling_reach_notified')->where('msgid', $message->id)->where('userid', $member->id)->exists(),
+            'the owning shard mails the reachable member'
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Decouples the rippling **reach-mail** send from `ExpandService`'s serial Phase-2 loop and runs it as a separate **sharded** pass — the same disjoint-partition model the immediate digest already uses.

A live profile of `ripple:expand` (real prod data, 2026-06-24) found that `mailNewlyReachedForPost`, called **inline** in the serial per-post loop, was **~75% of the run's wall-clock** (mail SQL ~25s + MJML render/spool ~20s; ~18.5k queries across 694 emails). The reach writes must stay serial (Galera single-writer), but the notification mail has no such constraint — so it doesn't belong on that critical path.

- **`ExpandService`** — remove the two inline `mailNewlyReachedForPost` calls (`initialiseNew` + `advanceDue`). The loop now only writes reach; the reach write bumps `rippling_reach.updated_at`, which is the signal the new pass keys off.
- **`UnifiedDigestService`** — add `MODE_REACH` + `sendReachDigests($limit,$dryRun,$shard,$shards,$shouldStop)`: processes `rippling_reach` rows (status `expanding`/`done`) whose `updated_at` is within a configurable window, partitioned by `MOD(msgid, shards)` — exactly as `sendImmediateDigests` partitions by `MOD(groupid, shards)`. Reuses `mailNewlyReachedForPost`; idempotent via the `rippling_reach_notified` ledger, so window overlap and re-runs never double-mail.
- **`SendUnifiedDigestCommand`** — accept `--mode=reach` (with a `posts_processed` summary); per-shard flock already handled by `lockKeySuffix()`.
- **`routes/console.php`** — schedule `mail:digest:unified --mode=reach` 4-way `everyMinute`, unconditionally (like `ripple:release-replies`): the window query self-idles when no reach changed, so it costs nothing while rippling is dark, and it covers both the global cron and the scoped group experiment (where the old inline mail also ran).

`AutoApproveService`'s own `mailNewlyReachedForPost` call is unchanged — it closes a different gap (mailing a post auto-approved on a group *after* its reach finished expanding).

## Code Quality Review

- **No behaviour change to who gets mailed.** The pass calls the identical `mailNewlyReachedForPost` per post; recipients and the ledger semantics are unchanged — mail just moves out of the serial loop.
- **Concurrency-safe.** `MOD(msgid, shards)` gives disjoint partitions (each post owned by one shard); per-shard flock; the ledger is idempotent so overlap is harmless.
- **Self-idling / dark-safe.** No reach rows changed → the window query returns nothing → no work and no mail while rippling is disabled.
- **Trigger parity.** The old inline path mailed on every init/advance (reach change); `updated_at` reflects reach writes only (this pass writes only the ledger), so the window-driven trigger matches.

## Future Improvements

- The reach-mail window (`freegle.ripple.reach_mail_window_minutes`, default 60) overlaps the cron interval for safety; a watermark/queue table would remove the re-query overlap if volume grows.
- `mailNewlyReachedForPost` still rebuilds shared per-post data once per recipient; a render-once/per-post-prep optimisation could cut its SQL further (separate change).

## Test Plan

- New unit tests (`UnifiedDigestServiceTest`): `sendReachDigests` mails a reachable immediate member; is idempotent via the ledger on a second pass; partitions posts by `MOD(msgid, shards)` (the non-owning shard skips the post).
- Full `ExpandServiceTest` re-run green — confirms removing the inline calls introduces no regression to reach writes, ripple-into-groups, membership, or the intro email.
- Full Laravel Unit+Feature suite green with coverage before push.
