### PR TITLE
fix(myposts): show a rippled post once, not once per rippled-into group

### DIFF
--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -1087,6 +1087,11 @@ func GetMessagesForUser(c *fiber.Ctx) error {
 			}
 
 			sql += "WHERE fromuser = ? AND messages.deleted IS NULL AND users.deleted IS NULL AND messages_groups.deleted = 0 AND " +
+				// Rippling-out adds a messages_groups row (rippled_in=1) per group a post ripples
+				// into, so without this a rippled post appears once PER GROUP in My Posts. Restrict
+				// to the origin membership (rippled_in=0) so each of the user's own posts shows
+				// exactly once; the rippled-in copies are system propagation, not separate posts.
+				"messages_groups.rippled_in = 0 AND " +
 				"messages.type IN (?, ?)"
 
 			if active {

--- a/iznik-server-go/test/message_test.go
+++ b/iznik-server-go/test/message_test.go
@@ -490,6 +490,44 @@ func TestMessagesByUser(t *testing.T) {
 	assert.Equal(t, 404, resp.StatusCode)
 }
 
+// Regression: rippling-out writes a messages_groups row (rippled_in=1) per group a post ripples
+// into, so the same post has many messages_groups rows. My Posts must still show the post ONCE
+// (at its origin group), not once per group — the join must restrict to the origin (rippled_in=0)
+// membership. Before the fix this returned the post once per group.
+func TestMyPostsRippledMessageAppearsOnce(t *testing.T) {
+	prefix := uniquePrefix("ripplededup")
+	originGroup := CreateTestGroup(t, prefix+"orig")
+	rippledGroupA := CreateTestGroup(t, prefix+"ripA")
+	rippledGroupB := CreateTestGroup(t, prefix+"ripB")
+	userID := CreateTestUser(t, prefix, "User")
+	CreateTestMembership(t, userID, originGroup, "Member")
+	msgID := CreateTestMessage(t, userID, originGroup, "OFFER: Rippled Downlighter", 51.5, -0.1)
+
+	// Simulate ExpandService::rippleIntoNewGroups: the post gains a messages_groups row
+	// (rippled_in=1) in each rippled-into group, exactly as the live rippler does.
+	db := database.DBConn
+	for _, g := range []uint64{rippledGroupA, rippledGroupB} {
+		db.Exec("INSERT INTO messages_groups (msgid, groupid, arrival, collection, autoreposts, rippled_in) "+
+			"VALUES (?, ?, NOW(), 'Approved', 0, 1)", msgID, g)
+	}
+
+	_, token := CreateTestSession(t, userID)
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/user/"+fmt.Sprint(userID)+"/message?active=true&jwt="+token, nil))
+	require.Equal(t, 200, resp.StatusCode)
+
+	var msgs []message.MessageSummary
+	json2.Unmarshal(rsp(resp), &msgs)
+
+	count := 0
+	for _, m := range msgs {
+		if m.ID == msgID {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count, "a post rippled into multiple groups must appear exactly once in My Posts")
+}
+
 func TestActiveQueryExcludesExpiredMessages(t *testing.T) {
 	prefix := uniquePrefix("expire")
 	groupID := CreateTestGroup(t, prefix)


### PR DESCRIPTION
## Summary

My Posts was showing a rippled post **once per group it had rippled into** (a post rippled into ~30 groups rendered ~30 duplicate cards).

Root cause: rippling-out (`ExpandService::rippleIntoNewGroups`) writes a `messages_groups` row with `rippled_in = 1` for every group a post ripples into, so a post in N groups has N+1 `messages_groups` rows (1 origin + N rippled-in). The My Posts endpoint `GET /user/:id/message` (`GetMessagesForUser`, `iznik-server-go/message/message.go`) `INNER JOIN`s `messages_groups` with no `GROUP BY`/`DISTINCT`, so it returned the same `messages.id` once per group, and the frontend faithfully rendered each as a separate card.

Fix: restrict the join to the **origin membership** (`messages_groups.rippled_in = 0`) so each of the user's own posts appears exactly once. Rippled-in copies are the system propagating the post into other communities — not separate posts the user made — so they don't belong as extra My Posts entries.

## Code Quality Review

- **One-line, surgical change** to the `WHERE` clause of the My Posts query; no change to the frontend (it faithfully renders whatever the API returns).
- **Semantically correct**: My Posts = the posts you made, shown at the group you posted to. The origin row (`rippled_in = 0`) is exactly that.
- **Applies to both branches of the endpoint** (your own posts and viewing another user's posts) — both should list a post once.
- **No new index needed**: the query already filters by `fromuser` (indexed); adding `rippled_in = 0` only narrows the already-fetched `messages_groups` rows.
- Edge case: if a post's *origin* membership were soft-deleted while rippled-in copies remained, the post would drop out of My Posts. That's acceptable — a post removed from its origin group shouldn't surface via a rippled copy — and the pre-fix behaviour of surfacing it via rippled rows was itself wrong.

## Future Improvements

- The frontend store (`fetchByUser`) and `MyPostsPostsList` do no dedup-by-id; a belt-and-braces `uniqBy(id)` there would harden against any future endpoint that returns per-group rows, but isn't needed for this fix.

## Test Plan

- New regression test `TestMyPostsRippledMessageAppearsOnce` (`iznik-server-go/test/message_test.go`): creates a post in an origin group, simulates rippling by inserting `rippled_in = 1` `messages_groups` rows in two more groups, calls `GET /user/:id/message?active=true`, and asserts the post appears **exactly once**. (Fails pre-fix: the post returns 3×.)
- Full Go suite green locally (3251 passed, 0 failed) including the `test` package.
