### PR TITLE
fix(modtools): don't suggest a post 'should be on' a group it's already on

### DIFF
--- a/iznik-nuxt3/modtools/components/ModMessage.vue
+++ b/iznik-nuxt3/modtools/components/ModMessage.vue
@@ -148,7 +148,12 @@
               :only-groupid="currentGroupid"
             />
             <div
-              v-if="homegroup && groupid && groupid !== homegroupids[0]"
+              v-if="
+                homegroup &&
+                groupid &&
+                groupid !== homegroupids[0] &&
+                !alreadyOnHomeGroup
+              "
               class="small text-danger"
             >
               Possibly should be on {{ homegroup }}
@@ -953,6 +958,20 @@ const otherGroups = computed(() => {
     const id = parseInt(g.groupid)
     return id !== gid && id !== origin
   })
+})
+
+// Suppress the "Possibly should be on <homegroup>" hint when the post is ALREADY on that
+// group - e.g. it's the origin/first-posted group, or the post has rippled onto it. The
+// template's `groupid !== homegroupids[0]` only covers the case where the home group is the
+// group currently being administered; a post on its home group but viewed under a different
+// group's context (common once a post ripples onto several groups) would otherwise be told
+// it "should be on" a group it's already a member of.
+const alreadyOnHomeGroup = computed(() => {
+  const homeId = homegroupids.value?.[0]
+  if (!homeId) return false
+  return (message.value?.groups || []).some(
+    (g) => parseInt(g.groupid) === homeId
+  )
 })
 
 // The groups this post is on that the current user actually moderates. When there's more

--- a/iznik-nuxt3/tests/unit/components/modtools/ModMessage.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModMessage.spec.js
@@ -412,6 +412,67 @@ describe('ModMessage', () => {
     })
   })
 
+  describe('Computed: alreadyOnHomeGroup', () => {
+    // Regression: a post must not be told it "Possibly should be on" a group it is ALREADY
+    // on (its origin, or a group it has rippled onto). The hint previously fired whenever the
+    // post was viewed under a different group's context than its nearest home group, so a
+    // multi-group/rippled post on its home group wrongly showed "Possibly should be on <home>".
+    it('is true and suppresses the hint when the post is already on its nearest home group', async () => {
+      const wrapper = mountComponent(
+        {},
+        {
+          groups: [
+            {
+              groupid: 789,
+              namedisplay: 'Home Group',
+              collection: 'Approved',
+              arrival: '2024-01-01T00:00:00Z',
+            },
+            {
+              groupid: 790,
+              namedisplay: 'Other Group',
+              collection: 'Approved',
+              arrival: '2024-01-02T00:00:00Z',
+            },
+          ],
+          location: {
+            name: 'SW1A 1AA',
+            lat: 51.5,
+            lng: -0.1,
+            groupsnear: [{ id: 789, namedisplay: 'Home Group', ontn: true }],
+          },
+        }
+      )
+      await flushPromises()
+      expect(wrapper.vm.alreadyOnHomeGroup).toBe(true)
+      expect(wrapper.text()).not.toContain('Possibly should be on')
+    })
+
+    it('is false when the post is NOT on its nearest home group', async () => {
+      const wrapper = mountComponent(
+        {},
+        {
+          groups: [
+            {
+              groupid: 790,
+              namedisplay: 'Other Group',
+              collection: 'Approved',
+              arrival: '2024-01-02T00:00:00Z',
+            },
+          ],
+          location: {
+            name: 'SW1A 1AA',
+            lat: 51.5,
+            lng: -0.1,
+            groupsnear: [{ id: 789, namedisplay: 'Home Group', ontn: true }],
+          },
+        }
+      )
+      await flushPromises()
+      expect(wrapper.vm.alreadyOnHomeGroup).toBe(false)
+    })
+  })
+
   describe('Computed: pending', () => {
     it.each([
       ['Pending', true],


### PR DESCRIPTION
## Summary

ModTools showed **"Possibly should be on <group>"** for a post that was already on that group - its origin/first-posted group, or a group it had rippled onto (reported: a post on Huddersfield Freegle + 7 rippled groups told it "Possibly should be on Huddersfield Freegle").

Root cause (`modtools/components/ModMessage.vue`): the hint's condition only checked that the currently-viewed group differs from the nearest home group (`groupid !== homegroupids[0]`). It never checked the post's actual group memberships, so a post on its home group but viewed under a *different* group's context - common once a post ripples onto several groups - was told it should be on a group it's already a member of. (The `groupid !== homegroupids[0]` check was an earlier partial fix for the same class of bug.)

Fix: add an `alreadyOnHomeGroup` computed (true when the post's `groups` include the nearest home group `homegroupids[0]`) and require `!alreadyOnHomeGroup` before rendering the hint.

## Code Quality Review

- Minimal: one computed + one extra clause on the existing `v-if`; no API change (the API's `groupsnear` is general "nearby groups" data - whether to *suggest* a group is the ModTools UI's call).
- Covers both reasons a post is on a nearby group: it's the origin, or it rippled onto it - both are in `message.groups`.
- Doesn't over-suppress: when the post is genuinely not on its nearest home group, `alreadyOnHomeGroup` is false and the hint still shows.

## Test Plan

- New `ModMessage.spec.js` tests (`Computed: alreadyOnHomeGroup`): true (and hint not rendered) when the post is on its nearest home group; false when it isn't.
- Filtered vitest green locally (498 passed); CI runs the full matrix.
