### PR TITLE
feat(email): per-kind content-carrying inbox previews + ripple intro reword

### DIFF
--- a/iznik-batch/app/Mail/Admin/ModNotifMail.php
+++ b/iznik-batch/app/Mail/Admin/ModNotifMail.php
@@ -61,6 +61,9 @@ class ModNotifMail extends MjmlMailable
             'email' => $this->email,
             'htmlSummary' => $this->htmlSummary,
             'settingsUrl' => $this->settingsUrl,
+            // The count-bearing subject (e.g. "MODERATE: 5 things to do") so the inbox
+            // preview shows how much is waiting, not a generic line.
+            'modNotifSubject' => $this->modNotifSubject,
         ];
 
         return $this

--- a/iznik-batch/app/Mail/Ripple/RippleIntroMail.php
+++ b/iznik-batch/app/Mail/Ripple/RippleIntroMail.php
@@ -76,6 +76,8 @@ class RippleIntroMail extends MjmlMailable
             'emails.mjml.ripple.intro',
             [
                 'firstName' => $this->user->firstname ?? null,
+                // The post that rippled, so the preheader can name it in the inbox preview.
+                'postSubject' => $this->message?->subject,
                 'email' => $recipientEmail,
                 'userSite' => $userSite,
                 'settingsUrl' => "{$userSite}/settings",

--- a/iznik-batch/resources/views/emails/mjml/admin/ai-image-review-digest.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/admin/ai-image-review-digest.blade.php
@@ -1,5 +1,5 @@
 <mjml>
-  @include('emails.mjml.partials.head', ['preview' => 'AI Image Review Daily Digest'])
+  @include('emails.mjml.partials.head', ['preview' => $todayVerdicts . ' verdicts today, ' . $needsImproving . ' need improving'])
 
   <mj-body>
     @include('emails.mjml.partials.header', ['title' => 'AI Image Review Digest'])

--- a/iznik-batch/resources/views/emails/mjml/admin/chase.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/admin/chase.blade.php
@@ -1,5 +1,5 @@
 <mjml>
-  @include('emails.mjml.partials.head', ['preview' => 'Action needed: Pending suggested admin for ' . $groupName])
+  @include('emails.mjml.partials.head', ['preview' => $groupName . ': \'' . \Illuminate\Support\Str::limit(strip_tags($adminSubject), 50) . '\' pending for ' . $pendingTimeText])
   <mj-body background-color="#ffffff">
     {{-- Header - ModTools blue --}}
     <mj-section mj-class="bg-modtools" padding="20px">

--- a/iznik-batch/resources/views/emails/mjml/admin/mod-notif.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/admin/mod-notif.blade.php
@@ -1,5 +1,5 @@
 <mjml>
-    @include('emails.mjml.partials.head', ['preview' => "There's stuff to do on ModTools"])
+    @include('emails.mjml.partials.head', ['preview' => $modNotifSubject ?? "There's stuff to do on ModTools"])
 
     <mj-body background-color="#f4f4f4">
         @include('emails.mjml.components.modtools-header')

--- a/iznik-batch/resources/views/emails/mjml/charity/charity-signup.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/charity/charity-signup.blade.php
@@ -1,5 +1,5 @@
 <mjml>
-  @include('emails.mjml.partials.head', ['preview' => 'New Charity Partner signup'])
+  @include('emails.mjml.partials.head', ['preview' => 'New Charity Partner signup: ' . $orgName])
 
   <mj-body>
     @include('emails.mjml.partials.header', ['title' => 'Charity Partner Signup'])

--- a/iznik-batch/resources/views/emails/mjml/chat/chaseup-mods.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/chat/chaseup-mods.blade.php
@@ -1,5 +1,5 @@
 <mjml>
-  @include('emails.mjml.partials.head', ['preview' => 'Member conversation needs a reply'])
+  @include('emails.mjml.partials.head', ['preview' => $memberName . ' on ' . $groupName . ' - member conversation needs a reply'])
 
   <mj-body background-color="#f4f4f4">
 

--- a/iznik-batch/resources/views/emails/mjml/chat/notification.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/chat/notification.blade.php
@@ -1,12 +1,12 @@
 <mjml>
   @if($isMod2Mod ?? false)
-  @include('emails.mjml.partials.head', ['preview' => $senderName . ' sent a message in Volunteer Chat'])
+  @include('emails.mjml.partials.head', ['preview' => $senderName . ': ' . \Illuminate\Support\Str::limit(strip_tags($chatMessage['text']), 70)])
   @elseif($isModerator ?? false)
-  @include('emails.mjml.partials.head', ['preview' => 'Member conversation with ' . ($memberName ?? 'a member')])
+  @include('emails.mjml.partials.head', ['preview' => ($memberName ?? 'Member') . ': ' . \Illuminate\Support\Str::limit(strip_tags($chatMessage['text']), 70)])
   @elseif($isOwnMessage ?? false)
-  @include('emails.mjml.partials.head', ['preview' => 'Copy of your message to ' . ($otherUserName ?? 'the other user')])
+  @include('emails.mjml.partials.head', ['preview' => 'Your message to ' . ($otherUserName ?? 'the other user') . ': ' . \Illuminate\Support\Str::limit(strip_tags($chatMessage['text']), 55)])
   @else
-  @include('emails.mjml.partials.head', ['preview' => $senderName . ' sent you a message'])
+  @include('emails.mjml.partials.head', ['preview' => $senderName . ': ' . \Illuminate\Support\Str::limit(strip_tags($chatMessage['text']), 75)])
   @endif
   <mj-body background-color="#ffffff">
     {{-- Header - ModTools blue for moderators, Freegle green for members --}}

--- a/iznik-batch/resources/views/emails/mjml/chat/review-pending.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/chat/review-pending.blade.php
@@ -1,5 +1,5 @@
 <mjml>
-  @include('emails.mjml.partials.head', ['preview' => 'Chat messages waiting for your review'])
+  @include('emails.mjml.partials.head', ['preview' => $count . ' message' . ($count !== 1 ? 's' : '') . ' between members need reviewing on ' . $groupName])
 
   <mj-body background-color="#f4f4f4">
 

--- a/iznik-batch/resources/views/emails/mjml/chat/review-summary.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/chat/review-summary.blade.php
@@ -1,5 +1,5 @@
 <mjml>
-  @include('emails.mjml.partials.head', ['preview' => 'Groups with chat messages pending review'])
+  @include('emails.mjml.partials.head', ['preview' => $total . ' message' . ($total !== 1 ? 's' : '') . ' across groups waiting for review'])
 
   <mj-body background-color="#f4f4f4">
 

--- a/iznik-batch/resources/views/emails/mjml/chat/spam-warning.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/chat/spam-warning.blade.php
@@ -1,5 +1,5 @@
 <mjml>
-  @include('emails.mjml.partials.head', ['preview' => 'A warning from ' . $siteName . ' about ' . $spammerName])
+  @include('emails.mjml.partials.head', ['preview' => 'Be careful - you have been talking to ' . $spammerName . (!empty($messageSubject) ? ' about: ' . $messageSubject : '')])
   <mj-body background-color="#ffffff">
     {{-- Header --}}
     <mj-section mj-class="bg-freegle" padding="20px">

--- a/iznik-batch/resources/views/emails/mjml/digest/reply-notice.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/digest/reply-notice.blade.php
@@ -1,5 +1,5 @@
 <mjml>
-  @include('emails.mjml.partials.head', ['preview' => 'How to reply to posts on Freegle'])
+  @include('emails.mjml.partials.head', ['preview' => 'To reply to a post, use the Reply button next to it in the digest email.'])
   <mj-body background-color="#ffffff">
     {{-- Header with logo --}}
     @include('emails.mjml.components.header')

--- a/iznik-batch/resources/views/emails/mjml/digest/unified.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/digest/unified.blade.php
@@ -31,7 +31,12 @@
         ';
     @endphp
     @include('emails.mjml.partials.head', [
-        'preview' => $postCount . ' new post' . ($postCount === 1 ? '' : 's') . ' near you',
+        {{-- Preheader = the actual content, so the inbox preview shows what the post(s)
+             are (V1 parity: single.mjml used the post body, multiple.mjml the subject list).
+             $post (loop-local) is not in scope here, so build from $posts (the array). --}}
+        'preview' => $mode === 'immediate'
+            ? (collect($posts)->first()['subject'] ?? ($postCount . ' new post near you'))
+            : (collect($posts)->pluck('itemName')->filter()->take(3)->implode(', ') ?: ($postCount . ' new posts near you')),
         'mediaStyles' => $mediaStyles ?? '',
     ])
 

--- a/iznik-batch/resources/views/emails/mjml/donation/ask.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/donation/ask.blade.php
@@ -1,5 +1,5 @@
 <mjml>
-    @include('emails.mjml.partials.head', ['preview' => 'Thanks for freegling!'])
+    @include('emails.mjml.partials.head', ['preview' => $itemSubject ? 'Did you just get this from Freegle? ' . \Illuminate\Support\Str::limit(strip_tags($itemSubject), 65) : 'Thanks for freegling!'])
 
     <mj-body background-color="#f4f4f4">
         @include('emails.mjml.components.header')

--- a/iznik-batch/resources/views/emails/mjml/donation/daily-summary.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/donation/daily-summary.blade.php
@@ -1,6 +1,6 @@
 <mjml>
   @include('emails.mjml.partials.head', [
-    'preview' => 'Daily donation summary',
+    'preview' => 'Total today: £' . number_format($total, 2),
     /* MJML parses mj-style contents as XML, so the comments below avoid
        literal angle brackets — those would be read as tag delimiters and
        blow up compilation with "Malformed MJML". */

--- a/iznik-batch/resources/views/emails/mjml/donation/donate-external.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/donation/donate-external.blade.php
@@ -1,5 +1,5 @@
 <mjml>
-  @include('emails.mjml.partials.head', ['preview' => 'Donation received'])
+  @include('emails.mjml.partials.head', ['preview' => $userName . ' donated £' . number_format($amount, 2) . ' via ' . $channel])
 
   <mj-body>
     @include('emails.mjml.partials.header', ['title' => 'Donation'])

--- a/iznik-batch/resources/views/emails/mjml/donation/thank-you.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/donation/thank-you.blade.php
@@ -1,5 +1,5 @@
 <mjml>
-    @include('emails.mjml.partials.head', ['preview' => 'Thank you for your donation!'])
+    @include('emails.mjml.partials.head', ['preview' => 'Thank you for your donation - you help keep Freegle free for everyone.'])
 
     <mj-body background-color="#f4f4f4">
         @include('emails.mjml.components.header')

--- a/iznik-batch/resources/views/emails/mjml/engage/missing.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/engage/missing.blade.php
@@ -1,5 +1,5 @@
 <mjml>
-  @include('emails.mjml.partials.head', ['preview' => 'We miss you on Freegle!'])
+  @include('emails.mjml.partials.head', ['preview' => 'We miss you - could we tempt you back?'])
   <mj-body background-color="#f4f4f4">
 
     {{-- Header — vertical padding on the SECTION (not the text) so mj-column

--- a/iznik-batch/resources/views/emails/mjml/event/events-digest.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/event/events-digest.blade.php
@@ -1,5 +1,5 @@
 <mjml>
-  @include('emails.mjml.partials.head', ['preview' => 'Upcoming community events near you'])
+  @include('emails.mjml.partials.head', ['preview' => count($events) === 1 ? (\Illuminate\Support\Str::limit(strip_tags($events[0]['title']), 60) . ' - ' . $events[0]['start']) : (\Illuminate\Support\Str::limit(strip_tags($events[0]['title']), 50) . ' and ' . (count($events) - 1) . ' more community event' . (count($events) > 2 ? 's' : '') . ' near you')])
 
   <mj-body background-color="#f4f4f4">
 

--- a/iznik-batch/resources/views/emails/mjml/group/alert-no-messages.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/group/alert-no-messages.blade.php
@@ -1,5 +1,5 @@
 <mjml>
-  @include('emails.mjml.partials.head', ['preview' => 'Groups with no recent messages'])
+  @include('emails.mjml.partials.head', ['preview' => $count . ' group' . ($count === 1 ? '' : 's') . ' not receiving messages'])
 
   <mj-body background-color="#f4f4f4">
 

--- a/iznik-batch/resources/views/emails/mjml/group/boundary-error.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/group/boundary-error.blade.php
@@ -1,5 +1,5 @@
 <mjml>
-  @include('emails.mjml.partials.head', ['preview' => 'Invalid group boundary'])
+  @include('emails.mjml.partials.head', ['preview' => 'Invalid CGA/DPA for ' . $groupName])
 
   <mj-body background-color="#f4f4f4">
 

--- a/iznik-batch/resources/views/emails/mjml/group/closed-reminder.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/group/closed-reminder.blade.php
@@ -1,5 +1,5 @@
 <mjml>
-  @include('emails.mjml.partials.head', ['preview' => 'Reminder: Your Freegle group is currently closed'])
+  @include('emails.mjml.partials.head', ['preview' => $groupName . ' is currently closed - re-open it from ModTools'])
 
   <mj-body background-color="#f4f4f4">
 

--- a/iznik-batch/resources/views/emails/mjml/group/customisation-reminder.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/group/customisation-reminder.blade.php
@@ -1,5 +1,5 @@
 <mjml>
-  @include('emails.mjml.partials.head', ['preview' => 'Make your group more welcoming'])
+  @include('emails.mjml.partials.head', ['preview' => 'Make ' . $groupName . ' more welcoming for your members'])
 
   <mj-body background-color="#f4f4f4">
 

--- a/iznik-batch/resources/views/emails/mjml/group/welcome-review.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/group/welcome-review.blade.php
@@ -1,5 +1,5 @@
 <mjml>
-  @include('emails.mjml.partials.head', ['preview' => 'Please review your welcome mail'])
+  @include('emails.mjml.partials.head', ['preview' => 'Check the welcome mail for ' . $groupName . ' is still up to date'])
 
   <mj-body background-color="#f4f4f4">
 

--- a/iznik-batch/resources/views/emails/mjml/housekeeper/results.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/housekeeper/results.blade.php
@@ -1,5 +1,5 @@
 <mjml>
-  @include('emails.mjml.partials.head', ['preview' => 'Housekeeper: ' . $task])
+  @include('emails.mjml.partials.head', ['preview' => ($taskStatus === 'success' ? 'OK' : 'FAILED') . ': ' . $summary])
 
   <mj-body background-color="#ffffff">
     @include('emails.mjml.partials.header', ['title' => 'Housekeeper: ' . $task])

--- a/iznik-batch/resources/views/emails/mjml/lovejunk/tn-invoice.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/lovejunk/tn-invoice.blade.php
@@ -1,5 +1,5 @@
 <mjml>
-  @include('emails.mjml.partials.head', ['preview' => 'Please raise an invoice for LoveJunk advertising income'])
+  @include('emails.mjml.partials.head', ['preview' => 'Please raise a LoveJunk invoice for £' . $tnAmount . ' (' . $start . ' to ' . $end . ')'])
 
   <mj-body background-color="#f4f4f4">
 

--- a/iznik-batch/resources/views/emails/mjml/message/autorepost-warning.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/message/autorepost-warning.blade.php
@@ -1,5 +1,5 @@
 <mjml>
-    @include('emails.mjml.partials.head', ['preview' => 'We will automatically repost your message soon'])
+    @include('emails.mjml.partials.head', ['preview' => 'Will repost soon: ' . \Illuminate\Support\Str::limit(strip_tags($messageSubject), 75)])
 
     <mj-body background-color="#f4f4f4">
         @include('emails.mjml.components.header')

--- a/iznik-batch/resources/views/emails/mjml/message/chaseup-promised.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/message/chaseup-promised.blade.php
@@ -1,5 +1,5 @@
 <mjml>
-    @include('emails.mjml.partials.head', ['preview' => 'You promised this to someone - has it been collected?'])
+    @include('emails.mjml.partials.head', ['preview' => 'Promised: ' . \Illuminate\Support\Str::limit(strip_tags($messageSubject), 60) . ' - has it been collected?'])
 
     <mj-body background-color="#f4f4f4">
         @include('emails.mjml.components.header')

--- a/iznik-batch/resources/views/emails/mjml/message/chaseup.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/message/chaseup.blade.php
@@ -1,5 +1,5 @@
 <mjml>
-    @include('emails.mjml.partials.head', ['preview' => 'What happened to your message?'])
+    @include('emails.mjml.partials.head', ['preview' => 'What happened to: ' . \Illuminate\Support\Str::limit(strip_tags($messageSubject), 76)])
 
     <mj-body background-color="#f4f4f4">
         @include('emails.mjml.components.header')

--- a/iznik-batch/resources/views/emails/mjml/message/deadline-reached.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/message/deadline-reached.blade.php
@@ -1,5 +1,5 @@
 <mjml>
-    @include('emails.mjml.partials.head', ['preview' => 'Your post has reached its deadline'])
+    @include('emails.mjml.partials.head', ['preview' => 'Deadline reached: ' . \Illuminate\Support\Str::limit(strip_tags($post->subject), 70)])
 
     <mj-body background-color="#f4f4f4">
         @include('emails.mjml.components.header')

--- a/iznik-batch/resources/views/emails/mjml/message/mod-std-message.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/message/mod-std-message.blade.php
@@ -1,5 +1,5 @@
 <mjml>
-    @include('emails.mjml.partials.head', ['preview' => 'Message from ' . $groupName . ' volunteers'])
+    @include('emails.mjml.partials.head', ['preview' => \Illuminate\Support\Str::limit(strip_tags($body), 87)])
 
     <mj-body background-color="#f4f4f4">
         @include('emails.mjml.components.header')

--- a/iznik-batch/resources/views/emails/mjml/newsfeed/chitchat-report.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/newsfeed/chitchat-report.blade.php
@@ -1,5 +1,5 @@
 <mjml>
-  @include('emails.mjml.partials.head', ['preview' => 'ChitChat post reported'])
+  @include('emails.mjml.partials.head', ['preview' => 'Reported by ' . $reporterName . ': ' . \Illuminate\Support\Str::limit($reason, 70)])
 
   <mj-body>
     @include('emails.mjml.partials.header', ['title' => 'ChitChat Report'])

--- a/iznik-batch/resources/views/emails/mjml/newsfeed/digest.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/newsfeed/digest.blade.php
@@ -1,5 +1,5 @@
 <mjml>
-  @include('emails.mjml.partials.head', ['preview' => $count . ' conversation' . ($count !== 1 ? 's' : '') . ' from your neighbours'])
+  @include('emails.mjml.partials.head', ['preview' => \Illuminate\Support\Str::limit($items[0]['text'] ?? '', 80) . (count($items) > 1 ? ' - and ' . (count($items) - 1) . ' more' : '')])
 
   <mj-body background-color="#f4f4f4">
 

--- a/iznik-batch/resources/views/emails/mjml/newsfeed/mod-notif.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/newsfeed/mod-notif.blade.php
@@ -1,5 +1,5 @@
 <mjml>
-  @include('emails.mjml.partials.head', ['preview' => $count . ' chitchat post' . ($count !== 1 ? 's' : '') . ' from your members'])
+  @include('emails.mjml.partials.head', ['preview' => $count . ' chitchat post' . ($count !== 1 ? 's' : '') . ' from your members - ' . \Illuminate\Support\Str::limit(!empty($posts[0]['preview']) ? $posts[0]['preview'] : (($posts[0]['userName'] ?? 'A freegler') . ' posted'), 60)])
 
   <mj-body background-color="#f4f4f4">
 

--- a/iznik-batch/resources/views/emails/mjml/notification/chaseup.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/notification/chaseup.blade.php
@@ -1,6 +1,19 @@
 <mjml>
   @include('emails.mjml.partials.head', [
-    'preview' => 'You have ' . $count . ' notification' . ($count === 1 ? '' : 's') . ' on Freegle'
+    'preview' => (function() use ($notifications, $count) {
+        $n = $notifications[0] ?? null;
+        if (!$n) { return 'You have a notification'; }
+        $type = $n['type'] ?? '';
+        $from = $n['fromname'] ?? 'Someone';
+        $msg = \Illuminate\Support\Str::limit(strip_tags($n['newsfeed']['message'] ?? ''), 40);
+        if ($type === 'CommentOnCommented') { $first = $from . ' replied: ' . $msg; }
+        elseif ($type === 'CommentOnYourPost') { $first = $from . ' commented: ' . $msg; }
+        elseif ($type === 'LovedPost') { $first = $from . ' loved your post' . ($msg ? ': ' . $msg : ''); }
+        elseif ($type === 'LovedComment') { $first = $from . ' loved your comment' . ($msg ? ': ' . $msg : ''); }
+        elseif ($type === 'Exhort') { $first = $n['title'] ?? 'You have a notification'; }
+        else { $first = 'You have a notification from ' . $from; }
+        return \Illuminate\Support\Str::limit($first, 80) . ($count > 1 ? ' (and ' . ($count - 1) . ' more)' : '');
+    })()
   ])
   <mj-body background-color="#ffffff">
 

--- a/iznik-batch/resources/views/emails/mjml/ripple/intro.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/ripple/intro.blade.php
@@ -1,6 +1,8 @@
 <mjml>
   @include('emails.mjml.partials.head', [
-    'preview' => 'Your post is reaching more people on ' . config('freegle.branding.name')
+    'preview' => !empty($postSubject)
+        ? 'Nearby freeglers might be interested in: ' . \Illuminate\Support\Str::limit($postSubject, 60)
+        : 'Nearby freeglers might be interested in your post'
   ])
   <mj-body background-color="#ffffff">
 
@@ -29,9 +31,9 @@
           @if(!empty($firstName))Hi {{ $firstName }},@else Hi,@endif
         </mj-text>
         <mj-text font-size="14px" color="#000000" line-height="1.6" padding="6px 25px">
-          Good news - your recent {{ config('freegle.branding.name') }} post is being shown to
-          nearby communities beyond your own, so even more people can take what you're offering
-          or help with what you're looking for.
+          Good news - we've noticed that some of the nearby freeglers in neighbouring communities
+          might be interested in your recent {{ config('freegle.branding.name') }} post, so we're
+          showing it to them too.
         </mj-text>
         <mj-text font-size="15px" font-weight="bold" color="#338808" line-height="1.6" padding="6px 25px">
           There's nothing you need to do - this just helps your post reach the right person.

--- a/iznik-batch/resources/views/emails/mjml/session/merge-offer.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/session/merge-offer.blade.php
@@ -1,5 +1,5 @@
 <mjml>
-  @include('emails.mjml.partials.head', ['preview' => 'You may have multiple Freegle accounts'])
+  @include('emails.mjml.partials.head', ['preview' => 'We think ' . $email1 . ' and ' . $email2 . ' may be the same person - merge them?'])
 
   <mj-body background-color="#ffffff">
     @include('emails.mjml.partials.header', ['title' => 'Multiple Freegle accounts'])

--- a/iznik-batch/resources/views/emails/mjml/session/verify-email.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/session/verify-email.blade.php
@@ -1,5 +1,5 @@
 <mjml>
-  @include('emails.mjml.partials.head', ['preview' => 'Please verify your email address'])
+  @include('emails.mjml.partials.head', ['preview' => 'Click to verify ' . $email . ' and complete your Freegle sign-up'])
 
   <mj-body background-color="#ffffff">
     @include('emails.mjml.partials.header', ['title' => 'Verify your email'])

--- a/iznik-batch/resources/views/emails/mjml/stories/newsletter.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/stories/newsletter.blade.php
@@ -1,5 +1,5 @@
 <mjml>
-  @include('emails.mjml.partials.head', ['preview' => $previewText ?? 'Stories from other freeglers!'])
+  @include('emails.mjml.partials.head', ['preview' => !empty($stories) ? ("\u{201c}" . \Illuminate\Support\Str::limit($stories[0]['headline'], 70) . "\u{201d} and more freegler stories") : 'Stories from other freeglers!'])
 
   <mj-body background-color="#f0f0eb">
 

--- a/iznik-batch/resources/views/emails/mjml/tryst/calendar-invite.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/tryst/calendar-invite.blade.php
@@ -1,5 +1,5 @@
 <mjml>
-  @include('emails.mjml.partials.head', ['preview' => 'Add your Freegle handover to your calendar'])
+  @include('emails.mjml.partials.head', ['preview' => 'Handover arranged: ' . $title])
 
   <mj-body background-color="#f4f4f4">
 

--- a/iznik-batch/resources/views/emails/mjml/volunteering/digest.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/volunteering/digest.blade.php
@@ -1,5 +1,5 @@
 <mjml>
-  @include('emails.mjml.partials.head', ['preview' => 'Volunteer opportunities near you'])
+  @include('emails.mjml.partials.head', ['preview' => ($volunteerings[0]['title'] ?? 'Volunteer opportunities near you') . (count($volunteerings) > 1 ? ' and ' . (count($volunteerings) - 1) . ' more' : '')])
 
   <mj-body background-color="#f4f4f4">
 

--- a/iznik-batch/resources/views/emails/mjml/volunteering/renew.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/volunteering/renew.blade.php
@@ -1,5 +1,5 @@
 <mjml>
-  @include('emails.mjml.partials.head', ['preview' => 'Is your volunteer opportunity still active?'])
+  @include('emails.mjml.partials.head', ['preview' => 'Please confirm: ' . $title . ' on ' . $groupName . ' - is it still active?'])
 
   <mj-body background-color="#f4f4f4">
 

--- a/iznik-batch/resources/views/emails/mjml/welcome/welcome.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/welcome/welcome.blade.php
@@ -1,5 +1,5 @@
 <mjml>
-  @include('emails.mjml.partials.head')
+  @include('emails.mjml.partials.head', ['preview' => $firstName ? 'Welcome, ' . $firstName . '! Give stuff away or find what you need for free.' : 'Welcome to Freegle! Give stuff away or find what you need for free.'])
   <mj-body>
     <mj-wrapper padding="0px" full-width="full-width">
       {{-- Welcome header --}}

--- a/iznik-batch/resources/views/emails/text/ripple/intro.blade.php
+++ b/iznik-batch/resources/views/emails/text/ripple/intro.blade.php
@@ -1,6 +1,6 @@
 @if(!empty($firstName))Hi {{ $firstName }},@else Hi,@endif
 
-Good news - your recent {{ config('freegle.branding.name') }} post is being shown to nearby communities beyond your own, so even more people can take what you're offering or help with what you're looking for.
+Good news - we've noticed that some of the nearby freeglers in neighbouring communities might be interested in your recent {{ config('freegle.branding.name') }} post, so we're showing it to them too.
 
 THERE'S NOTHING YOU NEED TO DO - this just helps your post reach the right person.
 

--- a/iznik-batch/tests/Feature/LoveJunk/LoveJunkTnInvoiceTest.php
+++ b/iznik-batch/tests/Feature/LoveJunk/LoveJunkTnInvoiceTest.php
@@ -64,6 +64,25 @@ class LoveJunkTnInvoiceTest extends TestCase
         $this->assertStringNotContainsString('Freegle Limited', $html);
     }
 
+    public function test_preheader_contains_amount_and_period(): void
+    {
+        // The mj-preview should carry the invoice amount and date range so the
+        // inbox preview line is informative rather than generic.
+        $html = view('emails.mjml.lovejunk.tn-invoice', [
+            'tnAmount'      => '375.50',
+            'start'         => '2025-03-01',
+            'end'           => '2025-04-01',
+            'tnPercent'     => 60,
+            'treasurerAddr' => 'treasurer@example.com',
+            'email'         => 'partner@example.com',
+        ])->render();
+
+        $this->assertStringContainsString(
+            '<mj-preview>Please raise a LoveJunk invoice for £375.50 (2025-03-01 to 2025-04-01)</mj-preview>',
+            $html
+        );
+    }
+
     public function test_dry_run_does_not_send_email(): void
     {
         $msgId = $this->insertMessage('TN-abc123', '2020-01-15 12:00:00');

--- a/iznik-batch/tests/Unit/Commands/AI/SendAIImageReviewDigestCommandTest.php
+++ b/iznik-batch/tests/Unit/Commands/AI/SendAIImageReviewDigestCommandTest.php
@@ -124,6 +124,27 @@ class SendAIImageReviewDigestCommandTest extends TestCase
         $this->assertStringContainsString('0%', $envelope->subject);
     }
 
+    public function test_preheader_shows_verdicts_and_needs_improving(): void
+    {
+        // The inbox preview should immediately surface the two headline stats —
+        // how many verdicts were cast today and how many images still need work.
+        $html = view('emails.mjml.admin.ai-image-review-digest', [
+            'todayVerdicts'   => 42,
+            'totalReviewed'   => 80,
+            'totalImages'     => 200,
+            'percentReviewed' => 40,
+            'needsImproving'  => 7,
+            'topProblems'     => [],
+            'siteName'        => config('freegle.branding.name', 'Freegle'),
+        ])->render();
+
+        $this->assertStringContainsString(
+            '<mj-preview>42 verdicts today, 7 need improving</mj-preview>',
+            $html,
+            'Preheader must show the verdict count and needs-improving count'
+        );
+    }
+
     protected function createTestUserForDigest(string $name): int
     {
         DB::table('users')->insert([

--- a/iznik-batch/tests/Unit/Mail/AdminMailTest.php
+++ b/iznik-batch/tests/Unit/Mail/AdminMailTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit\Mail;
 
 use App\Mail\Admin\AdminMail;
+use App\Mail\Admin\ChaseAdminMail;
 use App\Models\User;
 use Tests\TestCase;
 
@@ -227,5 +228,30 @@ class AdminMailTest extends TestCase
         $envelope = $mail->envelope();
 
         $this->assertEquals(config('freegle.mail.noreply_addr'), $envelope->from->address);
+    }
+
+    public function test_chase_admin_preheader_shows_group_subject_and_pending_time(): void
+    {
+        // The inbox preview should tell the moderator which group needs attention,
+        // which admin is waiting, and how long it has been pending — all without
+        // opening the email.
+        $html = view('emails.mjml.admin.chase', [
+            'groupName'       => 'Freegle Testington',
+            'adminSubject'    => 'Welcome post for new members',
+            'pendingTimeText' => '3 days',
+            'pendingHours'    => 72,
+            'modToolsUrl'     => 'https://modtools.org/admins',
+            'adminId'         => 1,
+            'userName'        => 'Test Mod',
+            'siteName'        => config('freegle.branding.name', 'Freegle'),
+            'trackingPixelMjml' => null,
+        ])->render();
+
+        $this->assertStringContainsString('Freegle Testington', $html,
+            'Preheader must contain the group name');
+        $this->assertStringContainsString('Welcome post for new members', $html,
+            'Preheader must contain the admin subject');
+        $this->assertStringContainsString('3 days', $html,
+            'Preheader must state how long the admin has been pending');
     }
 }

--- a/iznik-batch/tests/Unit/Mail/Charity/CharitySignupMailTest.php
+++ b/iznik-batch/tests/Unit/Mail/Charity/CharitySignupMailTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Unit\Mail\Charity;
+
+use Tests\TestCase;
+
+class CharitySignupMailTest extends TestCase
+{
+    /**
+     * Build minimal data to render the charity-signup MJML view directly.
+     *
+     * @param string $orgName The organisation name to embed in the preheader.
+     */
+    private function viewData(string $orgName = 'Helping Hands Bristol'): array
+    {
+        return [
+            'charityId'    => 1,
+            'orgName'      => $orgName,
+            'orgType'      => 'registered',
+            'charityNumber' => '1234567',
+            'contactEmail' => 'contact@helpinghands.example.com',
+            'contactName'  => 'Jane Doe',
+            'website'      => 'https://helpinghands.example.com',
+            'description'  => 'We help people in need.',
+            'siteName'     => 'Freegle',
+        ];
+    }
+
+    public function test_preheader_contains_new_charity_partner_signup_and_org_name(): void
+    {
+        $orgName = 'Helping Hands Bristol';
+
+        $html = view('emails.mjml.charity.charity-signup', $this->viewData($orgName))->render();
+
+        $this->assertStringContainsString(
+            '<mj-preview>New Charity Partner signup: ' . $orgName . '</mj-preview>',
+            $html
+        );
+    }
+
+    public function test_preheader_reflects_dynamic_org_name(): void
+    {
+        $orgName = 'Acme Community Trust';
+
+        $html = view('emails.mjml.charity.charity-signup', $this->viewData($orgName))->render();
+
+        $this->assertStringContainsString('Acme Community Trust', $html);
+        $this->assertStringContainsString('<mj-preview>New Charity Partner signup: Acme Community Trust</mj-preview>', $html);
+    }
+}

--- a/iznik-batch/tests/Unit/Mail/ChatNotificationTest.php
+++ b/iznik-batch/tests/Unit/Mail/ChatNotificationTest.php
@@ -1988,4 +1988,129 @@ class ChatNotificationTest extends TestCase
         // "Kate Offerer sent you an address."
         $this->assertStringContainsString('Kate Offerer sent you an address', $html);
     }
+
+    // ---------------------------------------------------------------------------
+    // Preheader (mj-preview) tests for chat/notification.blade.php
+    // ---------------------------------------------------------------------------
+
+    /**
+     * User2User: preheader carries sender name and message snippet.
+     */
+    public function test_chat_notification_preheader_user2user_shows_sender_and_snippet(): void
+    {
+        ['mail' => $mail] = $this->createUser2UserChatSetup([
+            'user1_attrs'  => ['fullname' => 'Alice Sender'],
+            'message_text' => 'I am still interested in the sofa, is it available?',
+        ]);
+
+        $mail->build();
+        $html = $mail->render();
+
+        $this->assertStringContainsString('Alice Sender: I am still interested in the sofa', $html);
+    }
+
+    /**
+     * User2Mod (moderator recipient): preheader shows member name and message text.
+     */
+    public function test_chat_notification_preheader_user2mod_moderator_shows_member_name(): void
+    {
+        $member    = $this->createTestUser(['fullname' => 'Bob Member']);
+        $moderator = $this->createTestUser();
+        $group     = $this->createTestGroup();
+
+        $room = ChatRoom::create([
+            'chattype' => ChatRoom::TYPE_USER2MOD,
+            'user1'    => $member->id,
+            'groupid'  => $group->id,
+            'created'  => now(),
+        ]);
+
+        $message = $this->createTestChatMessage($room, $member, [
+            'message' => 'Please can you help me with my account?',
+        ]);
+
+        $mail = new ChatNotification(
+            $moderator,
+            $member,
+            $room,
+            $message,
+            ChatRoom::TYPE_USER2MOD
+        );
+
+        $mail->build();
+        $html = $mail->render();
+
+        // Moderator branch: memberName + ': ' + snippet
+        $this->assertStringContainsString('Bob Member: Please can you help me', $html);
+    }
+
+    /**
+     * Copy-to-self (isOwnMessage): preheader says "Your message to <otherUser>".
+     */
+    public function test_chat_notification_preheader_own_message_copy_shows_other_user_name(): void
+    {
+        $user1 = $this->createTestUser(['fullname' => 'Carol Owner']);
+        $user2 = $this->createTestUser(['fullname' => 'Dave Recipient']);
+
+        $room = ChatRoom::create([
+            'chattype' => ChatRoom::TYPE_USER2USER,
+            'user1'    => $user1->id,
+            'user2'    => $user2->id,
+            'created'  => now(),
+        ]);
+
+        // Message sent BY user1 and notification sent TO user1 (copy to self)
+        $message = $this->createTestChatMessage($room, $user1, [
+            'message' => 'Here is my address for collection.',
+        ]);
+
+        $mail = new ChatNotification(
+            $user1,   // recipient = sender themselves (copy to self)
+            $user2,
+            $room,
+            $message,
+            ChatRoom::TYPE_USER2USER
+        );
+
+        $mail->build();
+        $html = $mail->render();
+
+        // isOwnMessage branch: "Your message to <otherUser>: <snippet>"
+        $this->assertStringContainsString('Your message to Dave Recipient:', $html);
+    }
+
+    /**
+     * Mod2Mod: preheader shows the sender name and message snippet.
+     */
+    public function test_chat_notification_preheader_mod2mod_shows_sender_and_snippet(): void
+    {
+        $mod1  = $this->createTestUser(['fullname' => 'Eve Moderator']);
+        $mod2  = $this->createTestUser();
+        $group = $this->createTestGroup();
+
+        $room = ChatRoom::create([
+            'chattype' => ChatRoom::TYPE_MOD2MOD,
+            'user1'    => $mod1->id,
+            'groupid'  => $group->id,
+            'created'  => now(),
+        ]);
+
+        $message = $this->createTestChatMessage($room, $mod1, [
+            'message' => 'Can you cover moderation this weekend?',
+        ]);
+
+        $mail = new ChatNotification(
+            $mod2,
+            $mod1,
+            $room,
+            $message,
+            ChatRoom::TYPE_MOD2MOD
+        );
+
+        $mail->build();
+        $html = $mail->render();
+
+        // Mod2Mod branch: senderName + ': ' + snippet
+        $this->assertStringContainsString('Eve Moderator: Can you cover moderation', $html);
+    }
 }

--- a/iznik-batch/tests/Unit/Mail/ChatPreheaderTest.php
+++ b/iznik-batch/tests/Unit/Mail/ChatPreheaderTest.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace Tests\Unit\Mail;
+
+use Tests\TestCase;
+
+/**
+ * Preheader (mj-preview) tests for chat email templates:
+ * - chat/chaseup-mods.blade.php
+ * - chat/review-pending.blade.php
+ * - chat/review-summary.blade.php
+ * - chat/spam-warning.blade.php
+ *
+ * Each test renders the Blade view (pre-MJML-compilation) and asserts the
+ * dynamic text appears inside the <mj-preview>…</mj-preview> element.
+ */
+class ChatPreheaderTest extends TestCase
+{
+    // -----------------------------------------------------------------------
+    // chat/chaseup-mods.blade.php
+    // -----------------------------------------------------------------------
+
+    /**
+     * Preheader includes member name and group name.
+     */
+    public function test_chaseup_mods_preheader_shows_member_and_group_name(): void
+    {
+        $html = view('emails.mjml.chat.chaseup-mods', [
+            'groupName'   => 'Freegle Leeds',
+            'memberName'  => 'Frank Member',
+            'memberEmail' => 'frank@example.com',
+            'textSummary' => 'Hello, I need help.',
+            'chatUrl'     => 'https://modtools.org/chats/42',
+            'email'       => 'mods@example.com',
+        ])->render();
+
+        $this->assertStringContainsString(
+            '<mj-preview>Frank Member on Freegle Leeds - member conversation needs a reply</mj-preview>',
+            $html
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // chat/review-pending.blade.php
+    // -----------------------------------------------------------------------
+
+    /**
+     * Preheader uses the plural "messages" form when count > 1.
+     */
+    public function test_review_pending_preheader_shows_count_and_group_name_plural(): void
+    {
+        $html = view('emails.mjml.chat.review-pending', [
+            'groupName'   => 'Freegle Manchester',
+            'count'       => 3,
+            'reviewUrl'   => 'https://modtools.org/modtools/chats/review',
+            'mentorsAddr' => 'mentors@ilovefreegle.org',
+            'email'       => 'mods@example.com',
+        ])->render();
+
+        $this->assertStringContainsString(
+            '<mj-preview>3 messages between members need reviewing on Freegle Manchester</mj-preview>',
+            $html
+        );
+    }
+
+    /**
+     * Preheader uses the singular "message" form when count == 1.
+     */
+    public function test_review_pending_preheader_singular_when_count_is_one(): void
+    {
+        $html = view('emails.mjml.chat.review-pending', [
+            'groupName'   => 'Freegle Bristol',
+            'count'       => 1,
+            'reviewUrl'   => 'https://modtools.org/modtools/chats/review',
+            'mentorsAddr' => 'mentors@ilovefreegle.org',
+            'email'       => 'mods@example.com',
+        ])->render();
+
+        $this->assertStringContainsString(
+            '<mj-preview>1 message between members need reviewing on Freegle Bristol</mj-preview>',
+            $html
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // chat/review-summary.blade.php
+    // -----------------------------------------------------------------------
+
+    /**
+     * Preheader shows the total count with plural "messages".
+     */
+    public function test_review_summary_preheader_shows_total_plural(): void
+    {
+        $html = view('emails.mjml.chat.review-summary', [
+            'total'   => 7,
+            'summary' => 'Freegle Leeds: 4 messages, Freegle Bradford: 3 messages',
+            'email'   => 'admin@example.com',
+        ])->render();
+
+        $this->assertStringContainsString(
+            '<mj-preview>7 messages across groups waiting for review</mj-preview>',
+            $html
+        );
+    }
+
+    /**
+     * Preheader uses the singular "message" form when total == 1.
+     */
+    public function test_review_summary_preheader_singular_when_total_is_one(): void
+    {
+        $html = view('emails.mjml.chat.review-summary', [
+            'total'   => 1,
+            'summary' => 'Freegle Leeds: 1 message',
+            'email'   => 'admin@example.com',
+        ])->render();
+
+        $this->assertStringContainsString(
+            '<mj-preview>1 message across groups waiting for review</mj-preview>',
+            $html
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // chat/spam-warning.blade.php
+    // -----------------------------------------------------------------------
+
+    /**
+     * Preheader includes the spammer name and message subject when a subject is provided.
+     */
+    public function test_spam_warning_preheader_with_subject_shows_spammer_and_subject(): void
+    {
+        $html = view('emails.mjml.chat.spam-warning', [
+            'spammerName'    => 'Suspicious Pete',
+            'messageSubject' => 'OFFER: Free laptop (London)',
+            'siteName'       => 'Freegle',
+        ])->render();
+
+        $this->assertStringContainsString(
+            '<mj-preview>Be careful - you have been talking to Suspicious Pete about: OFFER: Free laptop (London)</mj-preview>',
+            $html
+        );
+    }
+
+    /**
+     * Preheader omits the "about:" clause when no message subject is supplied.
+     */
+    public function test_spam_warning_preheader_without_subject_omits_about_clause(): void
+    {
+        $html = view('emails.mjml.chat.spam-warning', [
+            'spammerName'    => 'Suspicious Pete',
+            'messageSubject' => null,
+            'siteName'       => 'Freegle',
+        ])->render();
+
+        $this->assertStringContainsString(
+            '<mj-preview>Be careful - you have been talking to Suspicious Pete</mj-preview>',
+            $html
+        );
+        $this->assertStringNotContainsString('about:', $html);
+    }
+}

--- a/iznik-batch/tests/Unit/Mail/DigestReplyNoticeTest.php
+++ b/iznik-batch/tests/Unit/Mail/DigestReplyNoticeTest.php
@@ -46,4 +46,25 @@ class DigestReplyNoticeTest extends TestCase
         $this->assertNotNull($tracking);
         $this->assertEquals('DigestReplyNotice', $tracking->email_type);
     }
+
+    public function test_preheader_contains_reply_instructions(): void
+    {
+        // The mj-preview for this email is a static instruction telling the
+        // recipient how to reply to a specific post in the digest. Assert the
+        // literal text appears in the rendered Blade/MJML output so we catch
+        // any accidental change to the preheader copy.
+        $html = view('emails.mjml.digest.reply-notice', [
+            'recipientName'    => 'Test User',
+            'recipientEmail'   => 'test@example.com',
+            'browseUrl'        => 'https://example.com/browse',
+            'settingsUrl'      => 'https://example.com/settings',
+            'trackingPixelHtml' => '',
+        ])->render();
+
+        $this->assertStringContainsString(
+            '<mj-preview>To reply to a post, use the Reply button next to it in the digest email.</mj-preview>',
+            $html,
+            'DigestReplyNotice preheader must contain the static reply instructions'
+        );
+    }
 }

--- a/iznik-batch/tests/Unit/Mail/DonationMailTest.php
+++ b/iznik-batch/tests/Unit/Mail/DonationMailTest.php
@@ -3,6 +3,8 @@
 namespace Tests\Unit\Mail;
 
 use App\Mail\Donation\AskForDonation;
+use App\Mail\Donation\DonateExternalMail;
+use App\Mail\Donation\DonationSummaryMail;
 use App\Mail\Donation\DonationThankYou;
 use App\Models\User;
 use Tests\TestCase;
@@ -146,5 +148,90 @@ class DonationMailTest extends TestCase
         $mail = new AskForDonation($user);
 
         $this->assertNotEmpty($mail->donateUrl);
+    }
+
+    // --- Preheader tests ---
+
+    public function test_ask_for_donation_preheader_shows_item_subject(): void
+    {
+        $user = $this->createTestUser();
+        $itemSubject = 'OFFER: Sofa (Bristol)';
+
+        $html = view('emails.mjml.donation.ask', [
+            'user'       => $user,
+            'userSite'   => 'https://www.ilovefreegle.org',
+            'itemSubject' => $itemSubject,
+            'target'     => 2500.0,
+            'donateUrl'  => 'https://example.com/donate',
+            'settingsUrl' => 'https://example.com/settings',
+            'continueUrl' => 'https://example.com',
+        ])->render();
+
+        $this->assertStringContainsString('Did you just get this from Freegle?', $html);
+        $this->assertStringContainsString('Sofa (Bristol)', $html);
+    }
+
+    public function test_ask_for_donation_preheader_fallback_without_item(): void
+    {
+        $user = $this->createTestUser();
+
+        $html = view('emails.mjml.donation.ask', [
+            'user'        => $user,
+            'userSite'    => 'https://www.ilovefreegle.org',
+            'itemSubject' => null,
+            'target'      => 2500.0,
+            'donateUrl'   => 'https://example.com/donate',
+            'settingsUrl' => 'https://example.com/settings',
+            'continueUrl' => 'https://example.com',
+        ])->render();
+
+        $this->assertStringContainsString('Thanks for freegling!', $html);
+    }
+
+    public function test_donation_thank_you_preheader_shows_static_message(): void
+    {
+        $user = $this->createTestUser();
+
+        $html = view('emails.mjml.donation.thank-you', [
+            'user'        => $user,
+            'userSite'    => 'https://www.ilovefreegle.org',
+            'continueUrl' => 'https://example.com',
+            'settingsUrl' => 'https://example.com/settings',
+        ])->render();
+
+        $this->assertStringContainsString(
+            'Thank you for your donation - you help keep Freegle free for everyone.',
+            $html
+        );
+    }
+
+    public function test_donate_external_preheader_shows_donor_name_and_amount(): void
+    {
+        $html = view('emails.mjml.donation.donate-external', [
+            // siteName/logoUrl are injected globally by MjmlMailable when sent via the
+            // mailable; a bare view()->render() must supply them itself.
+            'siteName'  => 'Freegle',
+            'logoUrl'   => 'https://example.com/logo.png',
+            'userName'  => 'Alice Smith',
+            'userId'    => 42,
+            'userEmail' => 'alice@example.com',
+            'amount'    => 25.00,
+            'channel'   => 'PayPal Donate',
+        ])->render();
+
+        $this->assertStringContainsString('Alice Smith', $html);
+        $this->assertStringContainsString('25.00', $html);
+        $this->assertStringContainsString('PayPal Donate', $html);
+    }
+
+    public function test_donation_daily_summary_preheader_shows_total(): void
+    {
+        $html = view('emails.mjml.donation.daily-summary', [
+            'htmlContent' => '<p>Donations today</p>',
+            'total'       => 123.45,
+            'email'       => 'fundraising@example.com',
+        ])->render();
+
+        $this->assertStringContainsString('Total today: £123.45', $html);
     }
 }

--- a/iznik-batch/tests/Unit/Mail/Engage/EngageMissingMailTest.php
+++ b/iznik-batch/tests/Unit/Mail/Engage/EngageMissingMailTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Unit\Mail\Engage;
+
+use App\Mail\Engage\EngageMail;
+use Tests\TestCase;
+
+class EngageMissingMailTest extends TestCase
+{
+    private function viewData(): array
+    {
+        return [
+            'name'           => 'Alice',
+            'email'          => 'alice@example.com',
+            'engageId'       => 42,
+            'userSite'       => 'https://www.ilovefreegle.org',
+            'unsubscribeUrl' => 'https://www.ilovefreegle.org/unsubscribe/abc',
+        ];
+    }
+
+    public function test_missing_template_preheader_contains_re_engagement_text(): void
+    {
+        $html = view('emails.mjml.engage.missing', $this->viewData())->render();
+
+        $this->assertStringContainsString(
+            '<mj-preview>We miss you - could we tempt you back?</mj-preview>',
+            $html,
+            'The engage/missing preheader must carry the re-engagement teaser text'
+        );
+    }
+
+    public function test_can_be_constructed_and_built(): void
+    {
+        $mail = new EngageMail(
+            recipientName:  'Alice',
+            recipientEmail: 'alice@example.com',
+            emailSubject:   'We miss you on Freegle!',
+            template:       'missing',
+            engageId:       42,
+            unsubscribeUrl: 'https://www.ilovefreegle.org/unsubscribe/abc',
+        );
+
+        $result = $mail->build();
+
+        $this->assertInstanceOf(EngageMail::class, $result);
+    }
+}

--- a/iznik-batch/tests/Unit/Mail/EventsDigestMailTest.php
+++ b/iznik-batch/tests/Unit/Mail/EventsDigestMailTest.php
@@ -87,4 +87,51 @@ class EventsDigestMailTest extends TestCase
         $this->assertStringStartsWith($userSite, $eventUrl,
             'Event URL must start with the configured site URL (no extra protocol prepended)');
     }
+
+    public function test_preheader_contains_event_title_and_date_for_single_event(): void
+    {
+        $userSite = config('freegle.sites.user');
+
+        $event = $this->makeEvent(1);
+        $event['title'] = 'Repair Cafe Lewisham';
+        $event['start'] = 'Sat, 14th June 2:00pm';
+
+        $mail = new EventsDigestMail(
+            recipientEmail: 'test@example.com',
+            events:         [$event],
+            unsubscribeUrl: $userSite . '/unsubscribe?email=' . urlencode('test@example.com'),
+        );
+
+        $html = $mail->render();
+
+        // Single-event preview: "<title> - <start>"
+        $this->assertStringContainsString('Repair Cafe Lewisham', $html,
+            'Single-event preheader must contain the event title');
+        $this->assertStringContainsString('Sat, 14th June 2:00pm', $html,
+            'Single-event preheader must contain the event start date');
+    }
+
+    public function test_preheader_contains_title_and_more_count_for_multiple_events(): void
+    {
+        $userSite = config('freegle.sites.user');
+
+        $first  = $this->makeEvent(1);
+        $first['title'] = 'Repair Cafe Lewisham';
+        $second = $this->makeEvent(2);
+        $third  = $this->makeEvent(3);
+
+        $mail = new EventsDigestMail(
+            recipientEmail: 'test@example.com',
+            events:         [$first, $second, $third],
+            unsubscribeUrl: $userSite . '/unsubscribe?email=' . urlencode('test@example.com'),
+        );
+
+        $html = $mail->render();
+
+        // Multiple-event preview: "<first title> and N more community events near you"
+        $this->assertStringContainsString('Repair Cafe Lewisham', $html,
+            'Multi-event preheader must contain the first event title');
+        $this->assertStringContainsString('2 more community events near you', $html,
+            'Multi-event preheader must state the count of remaining events');
+    }
 }

--- a/iznik-batch/tests/Unit/Mail/GroupMailPreheaderTest.php
+++ b/iznik-batch/tests/Unit/Mail/GroupMailPreheaderTest.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace Tests\Unit\Mail;
+
+use App\Mail\Group\AlertNoMessagesMail;
+use App\Mail\Group\BoundaryErrorMail;
+use App\Mail\Group\ClosedGroupReminderMail;
+use App\Mail\Group\CustomisationReminderMail;
+use App\Mail\Group\WelcomeReviewMail;
+use Tests\TestCase;
+
+/**
+ * Preheader (inbox preview) tests for group admin email templates.
+ *
+ * Each test renders the Blade view directly and asserts the
+ * <mj-preview>…</mj-preview> element carries the expected dynamic value,
+ * so inbox clients show meaningful content rather than a blank preview.
+ */
+class GroupMailPreheaderTest extends TestCase
+{
+    // -------------------------------------------------------------------------
+    // Minimal view-data helpers
+    // -------------------------------------------------------------------------
+
+    private function alertNoMessagesData(int $count): array
+    {
+        return [
+            'count' => $count,
+            'body'  => 'The following groups have not received any messages recently.',
+            'email' => 'geeks@ilovefreegle.org',
+        ];
+    }
+
+    private function boundaryErrorData(string $groupName): array
+    {
+        return [
+            'groupId'      => 42,
+            'groupName'    => $groupName,
+            'errorMessage' => 'The boundary polygon is not valid GeoJSON.',
+            'email'        => 'geeks@ilovefreegle.org',
+        ];
+    }
+
+    private function closedReminderData(string $groupName): array
+    {
+        return [
+            'groupName' => $groupName,
+            'modSite'   => 'https://modtools.org',
+            'email'     => 'mod@example.com',
+        ];
+    }
+
+    private function customisationReminderData(string $groupName): array
+    {
+        return [
+            'groupName'   => $groupName,
+            'missing'     => "- Group description\n- Group photo",
+            'modSite'     => 'https://modtools.org',
+            'mentorsAddr' => 'mentors@ilovefreegle.org',
+            'email'       => 'mod@example.com',
+        ];
+    }
+
+    private function welcomeReviewData(string $groupName): array
+    {
+        return [
+            'groupName'      => $groupName,
+            'welcomeContent' => 'Welcome to the group! Please read our rules.',
+            'modSite'        => 'https://modtools.org',
+            'email'          => 'mod@example.com',
+        ];
+    }
+
+    // -------------------------------------------------------------------------
+    // alert-no-messages
+    // -------------------------------------------------------------------------
+
+    public function test_alert_no_messages_preheader_shows_count_for_plural(): void
+    {
+        $mjml = view('emails.mjml.group.alert-no-messages', $this->alertNoMessagesData(3))->render();
+
+        // Preview must carry the count and the plural "groups".
+        $this->assertStringContainsString('<mj-preview>3 groups not receiving messages</mj-preview>', $mjml);
+    }
+
+    public function test_alert_no_messages_preheader_shows_singular_for_count_one(): void
+    {
+        $mjml = view('emails.mjml.group.alert-no-messages', $this->alertNoMessagesData(1))->render();
+
+        // When count === 1 the preview uses "group" (no 's').
+        $this->assertStringContainsString('<mj-preview>1 group not receiving messages</mj-preview>', $mjml);
+    }
+
+    // -------------------------------------------------------------------------
+    // boundary-error
+    // -------------------------------------------------------------------------
+
+    public function test_boundary_error_preheader_shows_group_name(): void
+    {
+        $mjml = view('emails.mjml.group.boundary-error', $this->boundaryErrorData('FreegleTestington'))->render();
+
+        $this->assertStringContainsString('<mj-preview>Invalid CGA/DPA for FreegleTestington</mj-preview>', $mjml);
+    }
+
+    // -------------------------------------------------------------------------
+    // closed-reminder
+    // -------------------------------------------------------------------------
+
+    public function test_closed_reminder_preheader_shows_group_name(): void
+    {
+        $mjml = view('emails.mjml.group.closed-reminder', $this->closedReminderData('FreegleSometown'))->render();
+
+        $this->assertStringContainsString(
+            '<mj-preview>FreegleSometown is currently closed - re-open it from ModTools</mj-preview>',
+            $mjml
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // customisation-reminder
+    // -------------------------------------------------------------------------
+
+    public function test_customisation_reminder_preheader_shows_group_name(): void
+    {
+        $mjml = view('emails.mjml.group.customisation-reminder', $this->customisationReminderData('FreegleNorthampton'))->render();
+
+        $this->assertStringContainsString(
+            '<mj-preview>Make FreegleNorthampton more welcoming for your members</mj-preview>',
+            $mjml
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // welcome-review
+    // -------------------------------------------------------------------------
+
+    public function test_welcome_review_preheader_shows_group_name(): void
+    {
+        $mjml = view('emails.mjml.group.welcome-review', $this->welcomeReviewData('FreegleBristol'))->render();
+
+        $this->assertStringContainsString(
+            '<mj-preview>Check the welcome mail for FreegleBristol is still up to date</mj-preview>',
+            $mjml
+        );
+    }
+}

--- a/iznik-batch/tests/Unit/Mail/HousekeeperResultsMailTest.php
+++ b/iznik-batch/tests/Unit/Mail/HousekeeperResultsMailTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Tests\Unit\Mail;
+
+use Tests\TestCase;
+
+class HousekeeperResultsMailTest extends TestCase
+{
+    private function makeViewData(array $overrides = []): array
+    {
+        return array_merge([
+            'task'       => 'facebook-deletion',
+            'taskStatus' => 'success',
+            'summary'    => '3 users processed',
+            'results'    => [],
+            'timestamp'  => '24/06/2026 10:00:00',
+        ], $overrides);
+    }
+
+    public function test_preheader_shows_ok_prefix_and_summary_on_success(): void
+    {
+        $data = $this->makeViewData([
+            'taskStatus' => 'success',
+            'summary'    => 'Deleted 7 Facebook accounts',
+        ]);
+
+        $html = view('emails.mjml.housekeeper.results', $data)->render();
+
+        $this->assertStringContainsString(
+            '<mj-preview>OK: Deleted 7 Facebook accounts</mj-preview>',
+            $html,
+            'Preheader must start with "OK: " followed by the summary on success'
+        );
+    }
+
+    public function test_preheader_shows_failed_prefix_and_summary_on_failure(): void
+    {
+        $data = $this->makeViewData([
+            'taskStatus' => 'failure',
+            'summary'    => 'Could not connect to Facebook API',
+        ]);
+
+        $html = view('emails.mjml.housekeeper.results', $data)->render();
+
+        $this->assertStringContainsString(
+            '<mj-preview>FAILED: Could not connect to Facebook API</mj-preview>',
+            $html,
+            'Preheader must start with "FAILED: " followed by the summary on failure'
+        );
+    }
+}

--- a/iznik-batch/tests/Unit/Mail/MessageMailTest.php
+++ b/iznik-batch/tests/Unit/Mail/MessageMailTest.php
@@ -164,4 +164,121 @@ class MessageMailTest extends TestCase
         // Should not be null — falls back to groups->first().
         $this->assertNotNull($mail->getTracking()->groupid);
     }
+
+    // ─── Preheader (mj-preview) assertions ────────────────────────────────────
+
+    public function test_deadline_reached_preheader_contains_post_subject(): void
+    {
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $this->createMembership($user, $group);
+        $message = $this->createTestMessage($user, $group, [
+            'subject' => 'OFFER: Vintage Sofa (Bristol)',
+        ]);
+
+        $html = view('emails.mjml.message.deadline-reached', [
+            'post'         => $message,
+            'user'         => $user,
+            'outcomeType'  => 'taken',
+            'groupName'    => $group->nameshort,
+            'extendUrl'    => 'https://example.com/extend',
+            'completedUrl' => 'https://example.com/completed',
+            'withdrawUrl'  => 'https://example.com/withdraw',
+            'settingsUrl'  => 'https://example.com/settings',
+            'email'        => $user->email_preferred,
+        ])->render();
+
+        $this->assertStringContainsString(
+            '<mj-preview>Deadline reached: OFFER: Vintage Sofa (Bristol)',
+            $html,
+            'deadline-reached preheader must contain the post subject'
+        );
+    }
+
+    public function test_autorepost_warning_preheader_contains_message_subject(): void
+    {
+        $html = view('emails.mjml.message.autorepost-warning', [
+            'messageSubject' => 'OFFER: Garden Tools (Manchester)',
+            'userName'       => 'Alice',
+            'outcomeType'    => 'taken',
+            'isOffer'        => true,
+            'completedUrl'   => 'https://example.com/completed',
+            'withdrawUrl'    => 'https://example.com/withdraw',
+            'promiseUrl'     => 'https://example.com/promise',
+            'settingsUrl'    => 'https://example.com/settings',
+            'email'          => 'alice@example.com',
+        ])->render();
+
+        $this->assertStringContainsString(
+            '<mj-preview>Will repost soon: OFFER: Garden Tools (Manchester)',
+            $html,
+            'autorepost-warning preheader must contain the message subject'
+        );
+    }
+
+    public function test_chaseup_preheader_contains_message_subject(): void
+    {
+        $html = view('emails.mjml.message.chaseup', [
+            'messageSubject' => 'OFFER: Oak Bookcase (Leeds)',
+            'userName'       => 'Bob',
+            'outcomeType'    => 'taken',
+            'repostUrl'      => 'https://example.com/repost',
+            'completedUrl'   => 'https://example.com/completed',
+            'withdrawUrl'    => 'https://example.com/withdraw',
+            'chatsUrl'       => 'https://example.com/chats',
+            'myPostsUrl'     => 'https://example.com/myposts',
+            'settingsUrl'    => 'https://example.com/settings',
+            'email'          => 'bob@example.com',
+        ])->render();
+
+        $this->assertStringContainsString(
+            '<mj-preview>What happened to: OFFER: Oak Bookcase (Leeds)',
+            $html,
+            'chaseup preheader must contain the message subject'
+        );
+    }
+
+    public function test_chaseup_promised_preheader_contains_message_subject_and_suffix(): void
+    {
+        $html = view('emails.mjml.message.chaseup-promised', [
+            'messageSubject' => 'OFFER: Red Bicycle (Edinburgh)',
+            'userName'       => 'Carol',
+            'outcomeType'    => 'taken',
+            'completedUrl'   => 'https://example.com/completed',
+            'repostUrl'      => 'https://example.com/repost',
+            'withdrawUrl'    => 'https://example.com/withdraw',
+            'myPostsUrl'     => 'https://example.com/myposts',
+            'settingsUrl'    => 'https://example.com/settings',
+            'email'          => 'carol@example.com',
+        ])->render();
+
+        $this->assertStringContainsString(
+            'OFFER: Red Bicycle (Edinburgh)',
+            $html,
+            'chaseup-promised preheader must contain the message subject'
+        );
+        $this->assertStringContainsString(
+            'has it been collected?',
+            $html,
+            'chaseup-promised preheader must include the "has it been collected?" suffix'
+        );
+    }
+
+    public function test_mod_std_message_preheader_contains_body_snippet(): void
+    {
+        $html = view('emails.mjml.message.mod-std-message', [
+            'body'           => 'Your post has been approved by the moderators. Welcome to Freegle!',
+            'modName'        => 'Mod Dave',
+            'groupName'      => 'Freegle Sheffield',
+            'messageSubject' => 'OFFER: Dining Table (Sheffield)',
+            'userSite'       => 'https://www.ilovefreegle.org',
+            'email'          => 'member@example.com',
+        ])->render();
+
+        $this->assertStringContainsString(
+            'Your post has been approved by the moderators',
+            $html,
+            'mod-std-message preheader must contain the start of the body text'
+        );
+    }
 }

--- a/iznik-batch/tests/Unit/Mail/ModNotifMailTest.php
+++ b/iznik-batch/tests/Unit/Mail/ModNotifMailTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Unit\Mail;
+
+use App\Mail\Admin\ModNotifMail;
+use Tests\TestCase;
+
+class ModNotifMailTest extends TestCase
+{
+    public function test_preheader_shows_subject_when_provided(): void
+    {
+        // The inbox preview carries the mod-notif subject (e.g. "MODERATE: 5 things
+        // to do") so the moderator sees how much is waiting before opening the email.
+        $mail = new ModNotifMail(
+            recipientName: 'Alice Mod',
+            recipientEmail: 'alice@example.com',
+            recipientUserId: null,
+            subject: 'MODERATE: 5 things to do on FreegleSomewhere',
+            htmlSummary: '<p>There are 5 items awaiting your attention.</p>',
+            textSummary: 'There are 5 items awaiting your attention.',
+        );
+
+        $html = $mail->render();
+
+        $this->assertStringContainsString(
+            'MODERATE: 5 things to do on FreegleSomewhere',
+            $html,
+            'Preheader must show the count-bearing subject so the moderator sees how much is waiting'
+        );
+    }
+
+    public function test_preheader_falls_back_to_generic_text_when_subject_absent(): void
+    {
+        // When the subject is empty the template falls back to the static default
+        // "There's stuff to do on ModTools" rather than leaving the preview blank.
+        $html = view('emails.mjml.admin.mod-notif', [
+            'recipientName' => 'Bob Mod',
+            'email'         => 'bob@example.com',
+            'htmlSummary'   => '<p>Some items await.</p>',
+            'settingsUrl'   => 'https://modtools.org/modtools/settings',
+            // modNotifSubject absent — triggers the ?? fallback in the template
+        ])->render();
+
+        $this->assertStringContainsString(
+            "There's stuff to do on ModTools",
+            $html,
+            'Preheader must fall back to the static text when no subject is supplied'
+        );
+    }
+}

--- a/iznik-batch/tests/Unit/Mail/Newsfeed/ChitchatReportMailTest.php
+++ b/iznik-batch/tests/Unit/Mail/Newsfeed/ChitchatReportMailTest.php
@@ -68,4 +68,44 @@ class ChitchatReportMailTest extends TestCase
         // The mail should be addressed to the chitchat support address.
         $this->assertTrue($builtMail->hasTo(config('freegle.mail.chitchat_support_addr')));
     }
+
+    public function test_preheader_contains_reporter_name_and_reason(): void
+    {
+        // The mj-preview should name the reporter and show a snippet of the reason
+        // so moderators can triage the report from the inbox preview alone.
+        $html = view('emails.mjml.newsfeed.chitchat-report', [
+            'reporterName'  => 'Jane Doe',
+            'reporterId'    => 42,
+            'reporterEmail' => 'jane@example.com',
+            'newsfeedId'    => 123,
+            'reason'        => 'This post contains offensive language',
+            'threadUrl'     => 'https://www.ilovefreegle.org/chitchat/123',
+            'siteName'      => 'Freegle',
+        ])->render();
+
+        $this->assertStringContainsString('<mj-preview>Reported by Jane Doe: This post contains offensive language</mj-preview>', $html);
+    }
+
+    public function test_preheader_truncates_long_reason(): void
+    {
+        // Reasons longer than 70 characters should be truncated with "..." so the
+        // preview tag stays concise enough for inbox display.
+        $longReason = 'This is a very long reason that definitely exceeds seventy characters and should be cut';
+        $html = view('emails.mjml.newsfeed.chitchat-report', [
+            'reporterName'  => 'Bob Smith',
+            'reporterId'    => 7,
+            'reporterEmail' => 'bob@example.com',
+            'newsfeedId'    => 99,
+            'reason'        => $longReason,
+            'threadUrl'     => 'https://www.ilovefreegle.org/chitchat/99',
+            'siteName'      => 'Freegle',
+        ])->render();
+
+        // The full long reason must not appear verbatim in the preview.
+        $this->assertStringNotContainsString('<mj-preview>Reported by Bob Smith: ' . $longReason . '</mj-preview>', $html);
+        // The reporter name prefix must still be present.
+        $this->assertStringContainsString('Reported by Bob Smith:', $html);
+        // Truncation marker must appear in the preview element.
+        $this->assertMatchesRegularExpression('/<mj-preview>Reported by Bob Smith:.*\.\.\.<\/mj-preview>/', $html);
+    }
 }

--- a/iznik-batch/tests/Unit/Mail/Newsfeed/NewsfeedDigestMailTest.php
+++ b/iznik-batch/tests/Unit/Mail/Newsfeed/NewsfeedDigestMailTest.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace Tests\Unit\Mail\Newsfeed;
+
+use Tests\TestCase;
+
+/**
+ * Unit tests for the newsfeed ("chitchat") digest email preheader.
+ *
+ * The mj-preview was updated to show a snippet of the first item's text instead
+ * of the generic "N conversation(s) from your neighbours", so recipients can see
+ * at a glance what is being discussed before opening the email.
+ */
+class NewsfeedDigestMailTest extends TestCase
+{
+    private function makeItems(array $overrides = []): array
+    {
+        return array_merge([
+            [
+                'type'    => 'Message',
+                'text'    => 'Has anyone tried the new bakery on the high street?',
+                'author'  => 'Alice',
+                'replies' => [],
+            ],
+        ], $overrides);
+    }
+
+    public function test_preheader_contains_first_item_text(): void
+    {
+        // The mj-preview should show the first chitchat post's text so recipients
+        // know immediately what is being discussed without opening the email.
+        $userSite = config('freegle.sites.user', 'https://www.ilovefreegle.org');
+
+        $items = $this->makeItems();
+
+        $html = view('emails.mjml.newsfeed.digest', [
+            'items'       => $items,
+            'count'       => count($items),
+            'readUrl'     => $userSite . '/chitchat?src=newsfeeddigest',
+            'settingsUrl' => $userSite . '/settings?src=newsfeeddigest',
+            'userSite'    => $userSite,
+            'email'       => 'recipient@example.com',
+        ])->render();
+
+        $this->assertStringContainsString(
+            'Has anyone tried the new bakery on the high street?',
+            $html,
+            'Preheader must include the first item\'s text'
+        );
+    }
+
+    public function test_preheader_shows_and_more_suffix_for_multiple_items(): void
+    {
+        // When there is more than one chitchat post, the preheader should append
+        // " - and N more" so the recipient knows additional posts are included.
+        $userSite = config('freegle.sites.user', 'https://www.ilovefreegle.org');
+
+        $items = [
+            [
+                'type'    => 'Message',
+                'text'    => 'Does anyone have a spare bicycle pump?',
+                'author'  => 'Bob',
+                'replies' => [],
+            ],
+            [
+                'type'    => 'Message',
+                'text'    => 'Community litter pick this Saturday at 10am',
+                'author'  => 'Carol',
+                'replies' => [],
+            ],
+            [
+                'type'    => 'Message',
+                'text'    => 'Lost cat spotted near the park — ginger tabby',
+                'author'  => 'Dave',
+                'replies' => [],
+            ],
+        ];
+
+        $html = view('emails.mjml.newsfeed.digest', [
+            'items'       => $items,
+            'count'       => count($items),
+            'readUrl'     => $userSite . '/chitchat?src=newsfeeddigest',
+            'settingsUrl' => $userSite . '/settings?src=newsfeeddigest',
+            'userSite'    => $userSite,
+            'email'       => 'recipient@example.com',
+        ])->render();
+
+        // First item text must appear in the preview.
+        $this->assertStringContainsString('Does anyone have a spare bicycle pump?', $html);
+        // The " - and 2 more" suffix must be appended for the remaining two items.
+        $this->assertStringContainsString('- and 2 more', $html);
+    }
+
+    public function test_preheader_has_no_and_more_suffix_for_single_item(): void
+    {
+        // A single-item digest must not produce a "- and 0 more" artefact.
+        $userSite = config('freegle.sites.user', 'https://www.ilovefreegle.org');
+
+        $items = $this->makeItems();
+
+        $html = view('emails.mjml.newsfeed.digest', [
+            'items'       => $items,
+            'count'       => count($items),
+            'readUrl'     => $userSite . '/chitchat?src=newsfeeddigest',
+            'settingsUrl' => $userSite . '/settings?src=newsfeeddigest',
+            'userSite'    => $userSite,
+            'email'       => 'recipient@example.com',
+        ])->render();
+
+        $this->assertStringNotContainsString('- and 0 more', $html);
+        $this->assertStringNotContainsString('and 0 more', $html);
+    }
+
+    public function test_preheader_truncates_long_item_text(): void
+    {
+        // Str::limit($text, 80) is applied in the template, so texts longer than
+        // 80 characters should be truncated with "..." in the preheader.
+        $userSite = config('freegle.sites.user', 'https://www.ilovefreegle.org');
+
+        $longText = 'This is a very long chitchat post that goes well beyond eighty characters and should therefore be trimmed in the inbox preview so it does not overflow';
+
+        $html = view('emails.mjml.newsfeed.digest', [
+            'items'       => [
+                [
+                    'type'    => 'Message',
+                    'text'    => $longText,
+                    'author'  => 'Eve',
+                    'replies' => [],
+                ],
+            ],
+            'count'       => 1,
+            'readUrl'     => $userSite . '/chitchat?src=newsfeeddigest',
+            'settingsUrl' => $userSite . '/settings?src=newsfeeddigest',
+            'userSite'    => $userSite,
+            'email'       => 'recipient@example.com',
+        ])->render();
+
+        // The raw long text must not appear verbatim inside the mj-preview tag.
+        $this->assertStringNotContainsString(
+            '<mj-preview>' . $longText . '</mj-preview>',
+            $html
+        );
+        // The truncation marker must appear in the preview.
+        $this->assertMatchesRegularExpression('/<mj-preview>.*\.\.\.<\/mj-preview>/', $html);
+    }
+}

--- a/iznik-batch/tests/Unit/Mail/Newsfeed/NewsfeedModNotifMailTest.php
+++ b/iznik-batch/tests/Unit/Mail/Newsfeed/NewsfeedModNotifMailTest.php
@@ -118,4 +118,87 @@ class NewsfeedModNotifMailTest extends TestCase
             '"View all chitchat" button must link to ' . $userSite . '/chitchat'
         );
     }
+
+    public function test_preheader_contains_count_and_post_preview(): void
+    {
+        // The mj-preview should include both the count (so moderators know how many
+        // posts await) and a snippet from the first post so they can triage at a glance.
+        $userSite = config('freegle.sites.user', 'https://www.ilovefreegle.org');
+
+        $html = view('emails.mjml.newsfeed.mod-notif', [
+            'posts'    => [
+                [
+                    'id'         => 42,
+                    'action'     => 'posted on ChitChat',
+                    'preview'    => 'Anyone know a good plumber nearby?',
+                    'added'      => '2026-05-22 10:30:00',
+                    'userName'   => 'Jane Plumber',
+                    'userAvatar' => null,
+                ],
+            ],
+            'count'    => 1,
+            'userSite' => $userSite,
+            'email'    => 'mod@example.com',
+        ])->render();
+
+        $this->assertStringContainsString('1 chitchat post from your members', $html);
+        $this->assertStringContainsString('Anyone know a good plumber nearby?', $html);
+    }
+
+    public function test_preheader_pluralises_count_correctly(): void
+    {
+        // Two or more posts should produce "posts" (plural) in the preview.
+        $userSite = config('freegle.sites.user', 'https://www.ilovefreegle.org');
+
+        $html = view('emails.mjml.newsfeed.mod-notif', [
+            'posts'    => [
+                [
+                    'id'         => 1,
+                    'action'     => 'posted on ChitChat',
+                    'preview'    => 'First post preview text here',
+                    'added'      => '2026-05-22 10:00:00',
+                    'userName'   => 'Alice',
+                    'userAvatar' => null,
+                ],
+                [
+                    'id'         => 2,
+                    'action'     => 'posted on ChitChat',
+                    'preview'    => 'Second post preview text here',
+                    'added'      => '2026-05-22 11:00:00',
+                    'userName'   => 'Bob',
+                    'userAvatar' => null,
+                ],
+            ],
+            'count'    => 2,
+            'userSite' => $userSite,
+            'email'    => 'mod@example.com',
+        ])->render();
+
+        $this->assertStringContainsString('2 chitchat posts from your members', $html);
+    }
+
+    public function test_preheader_falls_back_to_username_when_no_post_preview(): void
+    {
+        // When no preview text is available, the preheader should fall back to
+        // "<userName> posted" so the inbox line is still informative.
+        $userSite = config('freegle.sites.user', 'https://www.ilovefreegle.org');
+
+        $html = view('emails.mjml.newsfeed.mod-notif', [
+            'posts'    => [
+                [
+                    'id'         => 5,
+                    'action'     => 'posted on ChitChat',
+                    'preview'    => '',
+                    'added'      => '2026-05-22 09:00:00',
+                    'userName'   => 'Maria Garcia',
+                    'userAvatar' => null,
+                ],
+            ],
+            'count'    => 1,
+            'userSite' => $userSite,
+            'email'    => 'mod@example.com',
+        ])->render();
+
+        $this->assertStringContainsString('Maria Garcia posted', $html);
+    }
 }

--- a/iznik-batch/tests/Unit/Mail/Notification/ChaseUpMailPreheaderTest.php
+++ b/iznik-batch/tests/Unit/Mail/Notification/ChaseUpMailPreheaderTest.php
@@ -1,0 +1,255 @@
+<?php
+
+namespace Tests\Unit\Mail\Notification;
+
+use Tests\TestCase;
+
+/**
+ * Preheader (mj-preview) tests for the notification chaseup email.
+ *
+ * The template builds a dynamic preview from the first notification in the
+ * batch. These tests render the Blade/MJML view directly (before MJML
+ * compilation) and assert the <mj-preview>...</mj-preview> tag contains the
+ * expected dynamic text, which is what inbox clients display as the preview
+ * line.
+ */
+class ChaseUpMailPreheaderTest extends TestCase
+{
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    /**
+     * Minimal notification stub for use with view()->render().
+     * Only the fields touched by the preview closure and the body template
+     * are required; everything else defaults to safe fallbacks.
+     */
+    private function makeNotification(array $overrides = []): array
+    {
+        return array_merge([
+            'type'        => 'CommentOnYourPost',
+            'fromname'    => 'Alice',
+            'fromimage'   => 'https://example.com/avatar.png',
+            'newsfeed'    => [
+                'id'      => 1,
+                'type'    => 'Message',
+                'message' => 'Hello there',
+                'replyto' => null,
+            ],
+            'title'       => null,
+            'text'        => null,
+            'url'         => null,
+            'id'          => 1,
+            'timestamp'   => 'just now',
+            'trackedUrl'  => 'https://www.ilovefreegle.org/chitchat/1',
+        ], $overrides);
+    }
+
+    private function renderChaseUpView(array $notifications, int $count = 1): string
+    {
+        return view('emails.mjml.notification.chaseup', [
+            'notifications'  => $notifications,
+            'count'          => $count,
+            'userSite'       => 'https://www.ilovefreegle.org',
+            'chitchatUrl'    => 'https://www.ilovefreegle.org/chitchat',
+            'settingsUrl'    => 'https://www.ilovefreegle.org/settings',
+            'unsubscribeUrl' => 'https://www.ilovefreegle.org/unsubscribe',
+            'email'          => 'test@example.com',
+        ])->render();
+    }
+
+    // -----------------------------------------------------------------------
+    // CommentOnYourPost preview
+    // -----------------------------------------------------------------------
+
+    public function test_preheader_shows_commenter_name_and_snippet_for_comment_on_post(): void
+    {
+        $notif = $this->makeNotification([
+            'type'     => 'CommentOnYourPost',
+            'fromname' => 'Alice',
+            'newsfeed' => [
+                'id'      => 1,
+                'type'    => 'Message',
+                'message' => 'This is a wonderful post!',
+                'replyto' => null,
+            ],
+        ]);
+
+        $html = $this->renderChaseUpView([$notif]);
+
+        $this->assertStringContainsString('<mj-preview>', $html);
+        $this->assertStringContainsString('Alice', $html);
+        $this->assertStringContainsString('commented', $html);
+        $this->assertStringContainsString('This is a wonderful post!', $html);
+    }
+
+    // -----------------------------------------------------------------------
+    // CommentOnCommented preview
+    // -----------------------------------------------------------------------
+
+    public function test_preheader_shows_replier_name_for_comment_on_commented(): void
+    {
+        $notif = $this->makeNotification([
+            'type'     => 'CommentOnCommented',
+            'fromname' => 'Bob',
+            'newsfeed' => [
+                'id'      => 2,
+                'type'    => 'Message',
+                'message' => 'Agreed, great item!',
+                'replyto' => ['message' => 'Original post'],
+            ],
+        ]);
+
+        $html = $this->renderChaseUpView([$notif]);
+
+        $this->assertStringContainsString('Bob', $html);
+        $this->assertStringContainsString('replied', $html);
+        $this->assertStringContainsString('Agreed, great item!', $html);
+    }
+
+    // -----------------------------------------------------------------------
+    // LovedPost preview
+    // -----------------------------------------------------------------------
+
+    public function test_preheader_shows_lover_name_for_loved_post(): void
+    {
+        $notif = $this->makeNotification([
+            'type'     => 'LovedPost',
+            'fromname' => 'Carol',
+            'newsfeed' => [
+                'id'      => 3,
+                'type'    => 'Message',
+                'message' => 'OFFER: Vintage table (London)',
+                'replyto' => null,
+            ],
+        ]);
+
+        $html = $this->renderChaseUpView([$notif]);
+
+        $this->assertStringContainsString('Carol', $html);
+        $this->assertStringContainsString('loved your post', $html);
+        $this->assertStringContainsString('OFFER: Vintage table (London)', $html);
+    }
+
+    // -----------------------------------------------------------------------
+    // LovedComment preview
+    // -----------------------------------------------------------------------
+
+    public function test_preheader_shows_lover_name_for_loved_comment(): void
+    {
+        $notif = $this->makeNotification([
+            'type'     => 'LovedComment',
+            'fromname' => 'Dave',
+            'newsfeed' => [
+                'id'      => 4,
+                'type'    => 'Message',
+                'message' => 'That is so kind, thank you!',
+                'replyto' => null,
+            ],
+        ]);
+
+        $html = $this->renderChaseUpView([$notif]);
+
+        $this->assertStringContainsString('Dave', $html);
+        $this->assertStringContainsString('loved your comment', $html);
+        $this->assertStringContainsString('That is so kind, thank you!', $html);
+    }
+
+    // -----------------------------------------------------------------------
+    // Exhort preview
+    // -----------------------------------------------------------------------
+
+    public function test_preheader_shows_title_for_exhort_notification(): void
+    {
+        $notif = $this->makeNotification([
+            'type'      => 'Exhort',
+            'fromname'  => 'Freegle',
+            'title'     => 'Tell us your story!',
+            'newsfeed'  => null,
+            'trackedUrl' => 'https://www.ilovefreegle.org/story',
+        ]);
+
+        $html = $this->renderChaseUpView([$notif]);
+
+        $this->assertStringContainsString('Tell us your story!', $html);
+    }
+
+    // -----------------------------------------------------------------------
+    // Fallback preview for unknown types
+    // -----------------------------------------------------------------------
+
+    public function test_preheader_shows_generic_fallback_for_unknown_type(): void
+    {
+        $notif = $this->makeNotification([
+            'type'     => 'MembershipApproved',
+            'fromname' => 'Eve',
+            'newsfeed' => null,
+            'url'      => 'Freegle Bristol',
+            'trackedUrl' => 'https://www.ilovefreegle.org/chitchat',
+        ]);
+
+        $html = $this->renderChaseUpView([$notif]);
+
+        $this->assertStringContainsString('You have a notification from Eve', $html);
+    }
+
+    // -----------------------------------------------------------------------
+    // Multi-notification: "(and N more)" suffix
+    // -----------------------------------------------------------------------
+
+    public function test_preheader_appends_and_more_suffix_for_multiple_notifications(): void
+    {
+        $notif1 = $this->makeNotification([
+            'type'     => 'CommentOnYourPost',
+            'fromname' => 'Alice',
+            'newsfeed' => [
+                'id'      => 1,
+                'type'    => 'Message',
+                'message' => 'Great sofa!',
+                'replyto' => null,
+            ],
+            'id' => 1,
+        ]);
+        $notif2 = $this->makeNotification([
+            'type'     => 'LovedPost',
+            'fromname' => 'Bob',
+            'newsfeed' => [
+                'id'      => 2,
+                'type'    => 'Message',
+                'message' => 'Nice item',
+                'replyto' => null,
+            ],
+            'id' => 2,
+        ]);
+        $notif3 = $this->makeNotification([
+            'type'     => 'LovedComment',
+            'fromname' => 'Carol',
+            'newsfeed' => [
+                'id'      => 3,
+                'type'    => 'Message',
+                'message' => 'Thanks!',
+                'replyto' => null,
+            ],
+            'id' => 3,
+        ]);
+
+        $html = $this->renderChaseUpView([$notif1, $notif2, $notif3], 3);
+
+        // Preview is driven by the first notification.
+        $this->assertStringContainsString('Alice', $html);
+        $this->assertStringContainsString('commented', $html);
+        // And the suffix tells the recipient there are more.
+        $this->assertStringContainsString('(and 2 more)', $html);
+    }
+
+    // -----------------------------------------------------------------------
+    // Empty notifications fallback
+    // -----------------------------------------------------------------------
+
+    public function test_preheader_shows_generic_fallback_when_notifications_empty(): void
+    {
+        $html = $this->renderChaseUpView([], 0);
+
+        $this->assertStringContainsString('You have a notification', $html);
+    }
+}

--- a/iznik-batch/tests/Unit/Mail/Ripple/RippleIntroMailTest.php
+++ b/iznik-batch/tests/Unit/Mail/Ripple/RippleIntroMailTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit\Mail\Ripple;
 
 use App\Mail\Ripple\RippleIntroMail;
+use App\Models\Message;
 use Tests\TestCase;
 
 class RippleIntroMailTest extends TestCase
@@ -60,5 +61,84 @@ class RippleIntroMailTest extends TestCase
         $this->assertSame($groups, $mail->welcomeGroups);
         // Builds (renders the welcome section) without error.
         $this->assertInstanceOf(RippleIntroMail::class, $mail->build());
+    }
+
+    public function test_preheader_shows_post_subject_when_post_is_present(): void
+    {
+        // When a Message is provided, the inbox preview should name the post so
+        // the recipient knows immediately which item triggered the ripple.
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $this->createMembership($user, $group);
+        $message = $this->createTestMessage($user, $group, [
+            'subject' => 'OFFER: Sofa (London)',
+        ]);
+
+        $html = view('emails.mjml.ripple.intro', [
+            'firstName'      => $user->firstname,
+            'postSubject'    => $message->subject,
+            'email'          => 'test@example.com',
+            'userSite'       => config('freegle.sites.user'),
+            'settingsUrl'    => config('freegle.sites.user') . '/settings',
+            'unsubscribeUrl' => config('freegle.sites.user') . '/unsubscribe',
+            'welcomeGroups'  => [],
+        ])->render();
+
+        $this->assertStringContainsString(
+            '<mj-preview>Nearby freeglers might be interested in: OFFER: Sofa (London)</mj-preview>',
+            $html,
+            'Preheader must include the post subject so the inbox preview names the item'
+        );
+    }
+
+    public function test_preheader_shows_fallback_when_no_post_subject(): void
+    {
+        // When no Message is provided (or subject is empty), the preheader should
+        // fall back to a sensible generic string rather than an empty preview.
+        $user = $this->createTestUser();
+
+        $html = view('emails.mjml.ripple.intro', [
+            'firstName'      => null,
+            'postSubject'    => null,
+            'email'          => 'test@example.com',
+            'userSite'       => config('freegle.sites.user'),
+            'settingsUrl'    => config('freegle.sites.user') . '/settings',
+            'unsubscribeUrl' => config('freegle.sites.user') . '/unsubscribe',
+            'welcomeGroups'  => [],
+        ])->render();
+
+        $this->assertStringContainsString(
+            '<mj-preview>Nearby freeglers might be interested in your post</mj-preview>',
+            $html,
+            'Preheader must use the fallback string when no post subject is available'
+        );
+    }
+
+    public function test_preheader_truncates_long_post_subject(): void
+    {
+        // Str::limit($postSubject, 60) is applied in the template, so subjects
+        // longer than 60 characters should be truncated with "..." in the preheader.
+        $user  = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $this->createMembership($user, $group);
+        $longSubject = 'OFFER: Very Long Item Name That Exceeds Sixty Characters Easily Here (London)';
+        $message = $this->createTestMessage($user, $group, ['subject' => $longSubject]);
+
+        $html = view('emails.mjml.ripple.intro', [
+            'firstName'      => null,
+            'postSubject'    => $message->subject,
+            'email'          => 'test@example.com',
+            'userSite'       => config('freegle.sites.user'),
+            'settingsUrl'    => config('freegle.sites.user') . '/settings',
+            'unsubscribeUrl' => config('freegle.sites.user') . '/unsubscribe',
+            'welcomeGroups'  => [],
+        ])->render();
+
+        // The full long subject must NOT appear verbatim.
+        $this->assertStringNotContainsString($longSubject, $html);
+        // The preview preamble must still be present.
+        $this->assertStringContainsString('Nearby freeglers might be interested in:', $html);
+        // The truncation marker must be present.
+        $this->assertStringContainsString('...', $html);
     }
 }

--- a/iznik-batch/tests/Unit/Mail/Session/MergeOfferMailTest.php
+++ b/iznik-batch/tests/Unit/Mail/Session/MergeOfferMailTest.php
@@ -68,4 +68,20 @@ class MergeOfferMailTest extends TestCase
             $envelope->from->address
         );
     }
+
+    public function test_preheader_contains_both_email_addresses(): void
+    {
+        $html = view('emails.mjml.session.merge-offer', [
+            'name1'    => 'Account One',
+            'email1'   => 'one@example.com',
+            'name2'    => 'Account Two',
+            'email2'   => 'two@example.com',
+            'mergeUrl' => 'https://www.ilovefreegle.org/merge/abc123',
+        ])->render();
+
+        $this->assertStringContainsString(
+            '<mj-preview>We think one@example.com and two@example.com may be the same person - merge them?</mj-preview>',
+            $html
+        );
+    }
 }

--- a/iznik-batch/tests/Unit/Mail/Session/VerifyEmailMailTest.php
+++ b/iznik-batch/tests/Unit/Mail/Session/VerifyEmailMailTest.php
@@ -97,4 +97,17 @@ class VerifyEmailMailTest extends TestCase
             $envelope->from->address
         );
     }
+
+    public function test_preheader_contains_email_address(): void
+    {
+        $html = view('emails.mjml.session.verify-email', [
+            'email'      => 'newuser@example.com',
+            'confirmUrl' => 'https://www.ilovefreegle.org/settings/confirmmail/abc123',
+        ])->render();
+
+        $this->assertStringContainsString(
+            '<mj-preview>Click to verify newuser@example.com and complete your Freegle sign-up</mj-preview>',
+            $html
+        );
+    }
 }

--- a/iznik-batch/tests/Unit/Mail/StoriesNewsletterMailTest.php
+++ b/iznik-batch/tests/Unit/Mail/StoriesNewsletterMailTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Tests\Unit\Mail;
+
+use Tests\TestCase;
+
+/**
+ * Preheader coverage for resources/views/emails/mjml/stories/newsletter.blade.php.
+ *
+ * The mj-preview now uses the first story headline so the inbox preview line
+ * carries real content rather than the generic "Stories from other freeglers!"
+ * fallback.  These tests render the Blade view directly and assert that the
+ * <mj-preview> element in the generated MJML source contains the expected text.
+ */
+class StoriesNewsletterMailTest extends TestCase
+{
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private function makeStory(string $headline, string $story = 'Something wonderful happened.'): array
+    {
+        return [
+            'headline'   => $headline,
+            'story'      => $story,
+            'username'   => 'Test Freegler',
+            'groupname'  => 'Freegle Testown',
+            'profileurl' => null,
+            'photo'      => null,
+        ];
+    }
+
+    /**
+     * Render the newsletter Blade view with the given stories and return the
+     * raw MJML source (before MJML→HTML compilation).
+     */
+    private function renderView(array $stories): string
+    {
+        return view('emails.mjml.stories.newsletter', [
+            'stories'        => $stories,
+            'headerImageUrl' => 'https://example.com/header.jpg',
+            'tellUrl'        => 'https://www.ilovefreegle.org/stories',
+            'giveUrl'        => 'https://www.ilovefreegle.org/give',
+            'findUrl'        => 'https://www.ilovefreegle.org/find',
+            'previewText'    => '',
+            'email'          => 'reader@example.com',
+            'unsubscribeUrl' => 'https://www.ilovefreegle.org/unsubscribe',
+            'settingsUrl'    => 'https://www.ilovefreegle.org/settings',
+        ])->render();
+    }
+
+    // ── Tests ─────────────────────────────────────────────────────────────────
+
+    public function test_preheader_contains_first_story_headline(): void
+    {
+        // The inbox preview must carry the headline of the first story so
+        // recipients know what to expect before opening the email.
+        $stories = [
+            $this->makeStory('I gave my old piano a new home'),
+            $this->makeStory('A wardrobe saved from landfill'),
+        ];
+
+        $html = $this->renderView($stories);
+
+        $this->assertStringContainsString(
+            'I gave my old piano a new home',
+            $html,
+            'mj-preview must include the first story headline'
+        );
+    }
+
+    public function test_preheader_wraps_headline_in_curly_quotes_with_suffix(): void
+    {
+        // The full preview expression is: "\u{201c}" . Str::limit($headline, 70) . "\u{201d} and more freegler stories"
+        $stories = [
+            $this->makeStory('Rescued a sofa from the skip'),
+        ];
+
+        $html = $this->renderView($stories);
+
+        $this->assertStringContainsString(
+            "\u{201c}Rescued a sofa from the skip\u{201d} and more freegler stories",
+            $html,
+            'mj-preview must wrap the headline in curly quotes and append " and more freegler stories"'
+        );
+    }
+
+    public function test_preheader_falls_back_to_static_text_when_no_stories(): void
+    {
+        // When the stories array is empty the ternary falls back to the static string.
+        $html = $this->renderView([]);
+
+        $this->assertStringContainsString(
+            'Stories from other freeglers!',
+            $html,
+            'mj-preview must show the fallback text when there are no stories'
+        );
+    }
+
+    public function test_preheader_truncates_long_headline_to_70_chars(): void
+    {
+        // Str::limit($headline, 70) appends "..." when the headline exceeds 70 characters.
+        $longHeadline  = 'This is a very long headline that definitely exceeds seventy characters in total length here';
+        $truncated     = \Illuminate\Support\Str::limit($longHeadline, 70);
+
+        $stories = [$this->makeStory($longHeadline)];
+
+        $html = $this->renderView($stories);
+
+        // Isolate the preheader: the newsletter body legitimately renders the full
+        // headline, so the truncation check must look only inside <mj-preview>.
+        preg_match('/<mj-preview>(.*?)<\/mj-preview>/s', $html, $m);
+        $preview = $m[1] ?? '';
+
+        $this->assertStringContainsString(
+            $truncated,
+            $preview,
+            'mj-preview must truncate long headlines to 70 characters'
+        );
+        $this->assertStringNotContainsString(
+            $longHeadline,
+            $preview,
+            'mj-preview must not contain the un-truncated headline'
+        );
+    }
+}

--- a/iznik-batch/tests/Unit/Mail/Tryst/TrystCalendarInviteMailTest.php
+++ b/iznik-batch/tests/Unit/Mail/Tryst/TrystCalendarInviteMailTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Tests\Unit\Mail\Tryst;
+
+use App\Mail\Tryst\TrystCalendarInviteMail;
+use Tests\TestCase;
+
+class TrystCalendarInviteMailTest extends TestCase
+{
+    private function makeMail(string $title = 'Handover: Sofa'): TrystCalendarInviteMail
+    {
+        $user = $this->createTestUser();
+
+        return new TrystCalendarInviteMail(
+            title: $title,
+            calendarLink: 'https://www.ilovefreegle.org/calendar?data=abc123',
+            recipientUserId: $user->id,
+            recipientName: $user->fullname,
+            recipientEmail: $user->email_preferred,
+        );
+    }
+
+    public function test_preheader_contains_handover_arranged_and_title(): void
+    {
+        // The template sets preview = 'Handover arranged: ' . $title.
+        // Rendering the Blade view (before MJML compilation) is sufficient to
+        // verify the <mj-preview> tag carries the dynamic value.
+        $user = $this->createTestUser();
+        $title = 'Handover: Corner Sofa (London)';
+
+        $html = view('emails.mjml.tryst.calendar-invite', [
+            'title'          => $title,
+            'calendarLink'   => 'https://www.ilovefreegle.org/calendar?data=abc123',
+            'email'          => $user->email_preferred,
+            'settingsUrl'    => config('freegle.sites.user') . '/settings',
+            'unsubscribeUrl' => config('freegle.sites.user') . '/unsubscribe/' . $user->id,
+        ])->render();
+
+        $this->assertStringContainsString(
+            '<mj-preview>Handover arranged: Handover: Corner Sofa (London)</mj-preview>',
+            $html,
+            'Preheader must include the handover title so the inbox preview names the item'
+        );
+    }
+
+    public function test_preheader_uses_provided_title_verbatim(): void
+    {
+        // Ensure the dynamic part of the preview exactly matches what was passed
+        // so there is no accidental truncation or escaping at the Blade layer.
+        $user  = $this->createTestUser();
+        $title = 'Tea Set (Bristol)';
+
+        $html = view('emails.mjml.tryst.calendar-invite', [
+            'title'          => $title,
+            'calendarLink'   => 'https://www.ilovefreegle.org/calendar?data=abc123',
+            'email'          => $user->email_preferred,
+            'settingsUrl'    => config('freegle.sites.user') . '/settings',
+            'unsubscribeUrl' => config('freegle.sites.user') . '/unsubscribe/' . $user->id,
+        ])->render();
+
+        $this->assertStringContainsString('Handover arranged: Tea Set (Bristol)', $html);
+    }
+
+    public function test_mailable_builds_without_error(): void
+    {
+        $mail = $this->makeMail();
+
+        $result = $mail->build();
+
+        $this->assertInstanceOf(TrystCalendarInviteMail::class, $result);
+    }
+
+    public function test_subject_includes_title(): void
+    {
+        $mail = $this->makeMail('Wardrobe (Edinburgh)');
+
+        $envelope = $mail->envelope();
+
+        $this->assertStringContainsString('Wardrobe (Edinburgh)', $envelope->subject);
+    }
+
+    public function test_to_address_matches_recipient(): void
+    {
+        $user = $this->createTestUser();
+        $mail = new TrystCalendarInviteMail(
+            title: 'Bike (Leeds)',
+            calendarLink: 'https://www.ilovefreegle.org/calendar?data=xyz',
+            recipientUserId: $user->id,
+            recipientName: $user->fullname,
+            recipientEmail: $user->email_preferred,
+        );
+
+        $envelope = $mail->envelope();
+
+        $this->assertSame($user->email_preferred, $envelope->to[0]->address);
+    }
+}

--- a/iznik-batch/tests/Unit/Mail/UnifiedDigestTest.php
+++ b/iznik-batch/tests/Unit/Mail/UnifiedDigestTest.php
@@ -1097,4 +1097,97 @@ class UnifiedDigestTest extends TestCase
             'A reposted message must render the "First posted" date line'
         );
     }
+
+    public function test_daily_preheader_lists_item_names(): void
+    {
+        // Daily-mode preheader: comma-separated item names from the first three
+        // posts so the inbox preview shows what's in the digest rather than a
+        // generic count. Assert the distinct item names appear in the rendered
+        // email (the <mj-preview> content becomes a hidden element in the
+        // compiled HTML).
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $this->createMembership($user, $group);
+
+        $poster = $this->createTestUser();
+        $this->createMembership($poster, $group);
+
+        $msg1 = $this->createTestMessage($poster, $group, ['subject' => 'OFFER: Wardrobe (Bristol)']);
+        $msg2 = $this->createTestMessage($poster, $group, ['subject' => 'WANTED: Bicycle (Bristol)']);
+        $msg3 = $this->createTestMessage($poster, $group, ['subject' => 'OFFER: Dining Table (Bristol)']);
+
+        $posts = collect([
+            ['message' => $msg1, 'postedToGroups' => [$group->id]],
+            ['message' => $msg2, 'postedToGroups' => [$group->id]],
+            ['message' => $msg3, 'postedToGroups' => [$group->id]],
+        ]);
+
+        $mail = new UnifiedDigest($user, $posts, UnifiedDigestService::MODE_DAILY);
+        $spooled = $this->spoolAndLoad($mail, $user->email_preferred ?? 'r@example.com');
+        $html = $spooled['html'] ?? '';
+
+        $this->assertNotEmpty($html, 'Spooled daily digest HTML should not be empty');
+
+        // The daily preheader lists up to three item names. Each of these
+        // distinctive item names must appear somewhere in the compiled HTML
+        // (within the hidden preheader element).
+        $this->assertStringContainsString(
+            'Wardrobe',
+            $html,
+            'Daily preheader must include the first post item name'
+        );
+        $this->assertStringContainsString(
+            'Bicycle',
+            $html,
+            'Daily preheader must include the second post item name'
+        );
+        $this->assertStringContainsString(
+            'Dining Table',
+            $html,
+            'Daily preheader must include the third post item name'
+        );
+    }
+
+    public function test_immediate_preheader_shows_post_subject(): void
+    {
+        // Immediate-mode preheader: the full post subject so the inbox preview
+        // shows exactly what the post is about (V1 parity: single.mjml used the
+        // post subject as the preheader). The subject is written into the hidden
+        // <mj-preview> element; after MJML compilation it becomes a display:none
+        // span in the compiled HTML.
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $this->createMembership($user, $group);
+
+        $poster = $this->createTestUser();
+        $this->createMembership($poster, $group);
+        $message = $this->createTestMessage($poster, $group, [
+            'subject' => 'OFFER: Rocking Chair (Edinburgh)',
+        ]);
+
+        $posts = collect([
+            ['message' => $message, 'postedToGroups' => [$group->id]],
+        ]);
+
+        $mail = new UnifiedDigest($user, $posts, UnifiedDigestService::MODE_IMMEDIATE);
+        $spooled = $this->spoolAndLoad($mail, $user->email_preferred ?? 'r@example.com');
+        $html = $spooled['html'] ?? '';
+
+        $this->assertNotEmpty($html, 'Spooled immediate digest HTML should not be empty');
+
+        // The subject "OFFER: Rocking Chair (Edinburgh)" is passed directly as
+        // the preheader. "Rocking Chair" is a distinctive term that only
+        // originates from the preheader (or the card body — both are correct
+        // signals that the subject reached the email).
+        $this->assertStringContainsString(
+            'Rocking Chair',
+            $html,
+            'Immediate-mode preheader must contain the post subject item name'
+        );
+        $this->assertStringContainsString(
+            'Edinburgh',
+            $html,
+            'Immediate-mode preheader must contain the post subject location'
+        );
+    }
 }

--- a/iznik-batch/tests/Unit/Mail/VolunteeringDigestMailTest.php
+++ b/iznik-batch/tests/Unit/Mail/VolunteeringDigestMailTest.php
@@ -153,4 +153,85 @@ class VolunteeringDigestMailTest extends TestCase
         $this->assertStringStartsWith($userSite, $volUrl,
             'Volunteering URL must start with the configured site URL (no extra protocol prepended)');
     }
+
+    // ─── Preheader (mj-preview) assertions ────────────────────────────────────
+
+    public function test_preheader_shows_first_title_for_single_opportunity(): void
+    {
+        // Single opportunity: preview is just the title with no trailing " and N more".
+        $userSite = config('freegle.sites.user');
+
+        $vol = $this->makeVolunteering(1);
+        $vol['title'] = 'Help at the Riverside Food Bank';
+
+        $html = view('emails.mjml.volunteering.digest', [
+            'volunteerings'  => [$vol],
+            'userSite'       => $userSite,
+            'unsubscribeUrl' => $userSite . '/unsubscribe',
+            'email'          => 'test@example.com',
+            'jobAds'         => collect(),
+            'jobsUrl'        => $userSite . '/jobs',
+            'donateUrl'      => 'https://freegle.in/paypal1510',
+        ])->render();
+
+        $this->assertStringContainsString(
+            '<mj-preview>Help at the Riverside Food Bank</mj-preview>',
+            $html,
+            'Single-opportunity preheader must contain the opportunity title'
+        );
+    }
+
+    public function test_preheader_shows_title_and_more_count_for_multiple_opportunities(): void
+    {
+        // Multiple opportunities: preview appends " and N more" after the first title.
+        $userSite = config('freegle.sites.user');
+
+        $vol1 = $this->makeVolunteering(1);
+        $vol1['title'] = 'Help at the Riverside Food Bank';
+
+        $vol2 = $this->makeVolunteering(2);
+        $vol2['title'] = 'Garden volunteer at Greenway Park';
+
+        $vol3 = $this->makeVolunteering(3);
+        $vol3['title'] = 'Admin helper for local charity';
+
+        $html = view('emails.mjml.volunteering.digest', [
+            'volunteerings'  => [$vol1, $vol2, $vol3],
+            'userSite'       => $userSite,
+            'unsubscribeUrl' => $userSite . '/unsubscribe',
+            'email'          => 'test@example.com',
+            'jobAds'         => collect(),
+            'jobsUrl'        => $userSite . '/jobs',
+            'donateUrl'      => 'https://freegle.in/paypal1510',
+        ])->render();
+
+        $this->assertStringContainsString(
+            '<mj-preview>Help at the Riverside Food Bank and 2 more</mj-preview>',
+            $html,
+            'Multi-opportunity preheader must show the first title followed by " and N more"'
+        );
+    }
+
+    public function test_preheader_falls_back_when_volunteerings_is_empty(): void
+    {
+        // When the volunteerings array happens to be empty the null-coalescing
+        // fallback in the template must prevent a blank preheader.
+        $userSite = config('freegle.sites.user');
+
+        $html = view('emails.mjml.volunteering.digest', [
+            'volunteerings'  => [],
+            'userSite'       => $userSite,
+            'unsubscribeUrl' => $userSite . '/unsubscribe',
+            'email'          => 'test@example.com',
+            'jobAds'         => collect(),
+            'jobsUrl'        => $userSite . '/jobs',
+            'donateUrl'      => 'https://freegle.in/paypal1510',
+        ])->render();
+
+        $this->assertStringContainsString(
+            '<mj-preview>Volunteer opportunities near you</mj-preview>',
+            $html,
+            'Preheader must fall back to the generic string when the opportunities list is empty'
+        );
+    }
 }

--- a/iznik-batch/tests/Unit/Mail/VolunteeringRenewMailTest.php
+++ b/iznik-batch/tests/Unit/Mail/VolunteeringRenewMailTest.php
@@ -56,4 +56,28 @@ class VolunteeringRenewMailTest extends TestCase
         $this->assertStringNotContainsString('https://https://', $html,
             'Renewal email must not contain doubled https://');
     }
+
+    // ─── Preheader (mj-preview) assertions ────────────────────────────────────
+
+    public function test_preheader_contains_title_and_group_name(): void
+    {
+        // The preheader is: "Please confirm: {title} on {groupName} - is it still active?"
+        // Assert both the dynamic title and the group name appear so inbox preview
+        // clearly identifies which listing needs attention.
+        $userSite = config('freegle.sites.user');
+
+        $html = view('emails.mjml.volunteering.renew', [
+            'title'          => 'Litter-pick helpers needed',
+            'renewUrl'       => $userSite . '/volunteering/77?u=3&k=xyz',
+            'groupName'      => 'Freegle Riverside',
+            'email'          => 'owner@example.com',
+            'unsubscribeUrl' => $userSite . '/unsubscribe',
+        ])->render();
+
+        $this->assertStringContainsString(
+            '<mj-preview>Please confirm: Litter-pick helpers needed on Freegle Riverside - is it still active?</mj-preview>',
+            $html,
+            'Renewal preheader must name the opportunity title and the group so the inbox preview is informative'
+        );
+    }
 }

--- a/iznik-batch/tests/Unit/Mail/WelcomeMailTest.php
+++ b/iznik-batch/tests/Unit/Mail/WelcomeMailTest.php
@@ -83,6 +83,51 @@ class WelcomeMailTest extends TestCase
     }
 
     /**
+     * Build minimal stub data to render the welcome MJML view directly.
+     */
+    private function welcomeViewData(?string $firstName): array
+    {
+        $dummyImage = ['src' => 'https://example.com/img.jpg', 'srcset' => ''];
+
+        return [
+            'firstName'         => $firstName,
+            'email'             => 'stub@example.com',
+            'password'          => null,
+            'giveUrl'           => 'https://www.ilovefreegle.org/give',
+            'findUrl'           => 'https://www.ilovefreegle.org/find',
+            'termsUrl'          => 'https://www.ilovefreegle.org/terms',
+            'helpUrl'           => 'https://www.ilovefreegle.org/help',
+            'safetyUrl'         => 'https://www.ilovefreegle.org/safety',
+            'settingsUrl'       => 'https://www.ilovefreegle.org/settings',
+            'heroImage'         => $dummyImage,
+            'ruleFreeImage'     => $dummyImage,
+            'ruleNiceImage'     => $dummyImage,
+            'ruleSafeImage'     => $dummyImage,
+            'trackingPixelMjml' => null,
+        ];
+    }
+
+    public function test_preheader_contains_first_name_when_provided(): void
+    {
+        $html = view('emails.mjml.welcome.welcome', $this->welcomeViewData('Beatrice'))->render();
+
+        $this->assertStringContainsString(
+            '<mj-preview>Welcome, Beatrice! Give stuff away or find what you need for free.</mj-preview>',
+            $html
+        );
+    }
+
+    public function test_preheader_uses_fallback_when_no_first_name(): void
+    {
+        $html = view('emails.mjml.welcome.welcome', $this->welcomeViewData(null))->render();
+
+        $this->assertStringContainsString(
+            '<mj-preview>Welcome to Freegle! Give stuff away or find what you need for free.</mj-preview>',
+            $html
+        );
+    }
+
+    /**
      * Regression: the `groups` table has no `autoemail`/`modsemail` columns
      * and the previous fallback `config('freegle.mail.support')` did not exist
      * (the actual key is `support_addr`). The envelope() therefore handed null


### PR DESCRIPTION
## Why

The inbox **preview snippet** comes from each MJML template's `<mj-preview>` (preheader). Most Laravel emails passed a generic static string (the immediate digest's "1 new post near you", chat's "X sent you a message"), so the preview carried nothing about the actual content. V1 fed the post body/subject into the preview, so the inbox showed what the email was about. This restores that - with a preview **appropriate to each kind of mail**, compared against the V1 equivalent.

## What

- **Digest** (`mjml/digest/unified`): immediate → the post subject; daily → the first few item names (was "N new posts near you").
- **Chat notification**: sender + message snippet (V1 `{{ textbody }}` parity).
- **Mod notif**: the count-bearing subject, e.g. "MODERATE: 5 things to do" (was "There's stuff to do on ModTools").
- **Ripple intro**: names the post in the preview; **body reworded** to *"we've noticed that some of the nearby freeglers in neighbouring communities might be interested in your post, so we're showing it to them too"*.
- **Events / volunteering / newsfeed digests**: first item(s) + count.
- **Transactional mails** (verify, reset, donations, group/mod ops): a specific action line.
- **Welcome**: filled in (it passed no preview → empty preheader).
- 41 templates updated; 2 Mailables pass extra view data (`ModNotifMail` subject, `RippleIntroMail` `postSubject`).

**Method:** audited every email against its V1 equivalent (`iznik-server/mailtemplates`, `include/mail`) and adopted V1's preview approach where it was good.

## Tests

Per-email preheader assertions added/extended (79 tests across 27 files). Full Laravel suite green: **4481 passed, 0 failures**.

Two real bugs fixed along the way:
- The newsfeed mod-notif fallback used `?? `, which doesn't fall through on an **empty-string** preview → now uses `!empty()`.
- (test infra) bare `view()->render()` tests must supply the globals `MjmlMailable::getDefaultData()` injects (`siteName`, `logoUrl`, …), which sending via the mailable provides automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
