### PR TITLE
fix(modtools): de-dupe worry-word flags and scope them to the moderated group

### DIFF
--- a/iznik-batch/app/Services/ContentCheckService.php
+++ b/iznik-batch/app/Services/ContentCheckService.php
@@ -162,7 +162,48 @@ class ContentCheckService
             $reasons[] = $r;
         }
 
-        return $reasons;
+        return $this->dedupeReasons($reasons);
+    }
+
+    /**
+     * Collapse reasons that flag the SAME keyword more than once.
+     *
+     * Concern keywords and the legacy per-group worry words overlap: a per-group
+     * worry word that has been migrated into concern_keywords (scope=group) is
+     * matched by BOTH checkConcernKeywords and checkPerGroupWorryWords, producing
+     * two reasons ("Matched concern keyword 'x'" and "Matched per-group worry
+     * word 'x'") for the one word. Keep a single reason per keyword, preferring
+     * the richer ConcernKeyword (it carries a category that drives mod guidance).
+     * Reasons without a keyword (Vague, PhoneNumber, …) are never de-duplicated.
+     */
+    private function dedupeReasons(array $reasons): array
+    {
+        $indexByKeyword = [];
+        $out = [];
+
+        foreach ($reasons as $reason) {
+            $keyword = isset($reason['keyword']) ? strtolower(trim((string) $reason['keyword'])) : '';
+
+            if ($keyword === '') {
+                $out[] = $reason;
+                continue;
+            }
+
+            if (!isset($indexByKeyword[$keyword])) {
+                $indexByKeyword[$keyword] = count($out);
+                $out[] = $reason;
+                continue;
+            }
+
+            // Already have a reason for this keyword; prefer ConcernKeyword.
+            $existingIndex = $indexByKeyword[$keyword];
+            if ($reason['check'] === self::CHECK_CONCERN_KEYWORD
+                && $out[$existingIndex]['check'] !== self::CHECK_CONCERN_KEYWORD) {
+                $out[$existingIndex] = $reason;
+            }
+        }
+
+        return $out;
     }
 
     /**
@@ -696,6 +737,7 @@ class ContentCheckService
                 'check'    => self::CHECK_CONCERN_KEYWORD,
                 'category' => $kw->category,
                 'action'   => $kw->action ?? 'flag',
+                'keyword'  => $word,
                 'detail'   => "Matched concern keyword '{$word}'",
             ];
         }
@@ -1132,6 +1174,7 @@ class ContentCheckService
                     'check'    => self::CHECK_PER_GROUP_WORRY,
                     'category' => null,
                     'action'   => 'flag',
+                    'keyword'  => $word,
                     'detail'   => "Matched per-group worry word '{$word}'",
                 ];
             }

--- a/iznik-batch/tests/Feature/Message/ContentCheckTest.php
+++ b/iznik-batch/tests/Feature/Message/ContentCheckTest.php
@@ -599,6 +599,135 @@ class ContentCheckTest extends TestCase
     }
 
     // -------------------------------------------------------------------------
+    // Reason keyword field + de-duplication across concern keywords and the
+    // legacy per-group worry words (which overlap: a per-group worry word that
+    // has also been migrated into concern_keywords would otherwise be flagged
+    // twice — once as ConcernKeyword and once as PerGroupWorryWord).
+    // -------------------------------------------------------------------------
+
+    public function test_concern_keyword_reason_includes_matched_keyword(): void
+    {
+        $group = $this->createTestGroup();
+        DB::table('concern_keywords')->insert([
+            'keyword'  => 'testkwfield_cc',
+            'category' => 'review',
+            'action'   => 'flag',
+        ]);
+
+        $result = $this->service->checkConcernKeywords('OFFER: testkwfield_cc item', '', $group->id);
+
+        $this->assertNotNull($result);
+        $this->assertEquals('testkwfield_cc', $result['keyword']);
+    }
+
+    public function test_per_group_worry_reason_includes_matched_keyword(): void
+    {
+        $group = $this->createTestGroup([
+            'settings' => ['spammers' => ['worrywords' => 'pgkwfield_cc']],
+        ]);
+
+        $result = $this->service->checkPerGroupWorryWords('OFFER: pgkwfield_cc item', '', $group->id);
+
+        $this->assertNotNull($result);
+        $this->assertEquals('pgkwfield_cc', $result['keyword']);
+    }
+
+    public function test_check_message_dedupes_same_keyword_in_concern_and_per_group(): void
+    {
+        // The word lives in BOTH concern_keywords (migrated copy) AND the legacy
+        // per-group settings list — exactly the production "cot mattress" case.
+        $group = $this->createTestGroup([
+            'settings' => ['spammers' => ['worrywords' => 'dupeword_cc']],
+        ]);
+        $user = $this->createTestUser();
+        DB::table('concern_keywords')->insert([
+            'keyword'  => 'dupeword_cc',
+            'category' => 'review',
+            'action'   => 'flag',
+            'scope'    => 'group',
+            'group_id' => $group->id,
+        ]);
+
+        $msgid = DB::table('messages')->insertGetId([
+            'fromuser' => $user->id,
+            'type'     => 'Wanted',
+            'subject'  => 'WANTED: dupeword_cc please (SW1A)',
+            'textbody' => 'Looking for a dupeword_cc.',
+            'message'  => 'Looking for a dupeword_cc.',
+            'arrival'  => now(),
+            'date'     => now(),
+            'source'   => 'Platform',
+        ]);
+
+        $reasons = $this->service->checkMessage($msgid, $group->id);
+
+        $forWord = array_values(array_filter(
+            $reasons,
+            fn ($r) => strtolower($r['keyword'] ?? '') === 'dupeword_cc'
+        ));
+        $this->assertCount(1, $forWord, 'the same keyword must not be flagged twice');
+        $this->assertEquals('ConcernKeyword', $forWord[0]['check'], 'the richer ConcernKeyword reason is kept');
+    }
+
+    public function test_check_message_keeps_per_group_word_not_in_concern_keywords(): void
+    {
+        // A per-group worry word that was never migrated into concern_keywords
+        // (e.g. production group 21486's "venue") must still be flagged.
+        $group = $this->createTestGroup([
+            'settings' => ['spammers' => ['worrywords' => 'venueword_cc']],
+        ]);
+        $user = $this->createTestUser();
+
+        $msgid = DB::table('messages')->insertGetId([
+            'fromuser' => $user->id,
+            'type'     => 'Offer',
+            'subject'  => 'OFFER: venueword_cc (SW1A)',
+            'textbody' => 'A venueword_cc.',
+            'message'  => 'A venueword_cc.',
+            'arrival'  => now(),
+            'date'     => now(),
+            'source'   => 'Platform',
+        ]);
+
+        $reasons = $this->service->checkMessage($msgid, $group->id);
+
+        $checks = array_column($reasons, 'check');
+        $this->assertContains('PerGroupWorryWord', $checks, 'un-migrated per-group word must still flag');
+    }
+
+    public function test_check_message_keeps_distinct_concern_and_per_group_words(): void
+    {
+        $group = $this->createTestGroup([
+            'settings' => ['spammers' => ['worrywords' => 'pgonly_cc']],
+        ]);
+        $user = $this->createTestUser();
+        DB::table('concern_keywords')->insert([
+            'keyword'  => 'ckonly_cc',
+            'category' => 'review',
+            'action'   => 'flag',
+            'scope'    => 'group',
+            'group_id' => $group->id,
+        ]);
+
+        $msgid = DB::table('messages')->insertGetId([
+            'fromuser' => $user->id,
+            'type'     => 'Offer',
+            'subject'  => 'OFFER: ckonly_cc and pgonly_cc (SW1A)',
+            'textbody' => 'Has ckonly_cc and pgonly_cc.',
+            'message'  => 'Has ckonly_cc and pgonly_cc.',
+            'arrival'  => now(),
+            'date'     => now(),
+            'source'   => 'Platform',
+        ]);
+
+        $reasons = $this->service->checkMessage($msgid, $group->id);
+
+        $checks = array_column($reasons, 'check');
+        $this->assertContains('ConcernKeyword', $checks);
+        $this->assertContains('PerGroupWorryWord', $checks);
+    }
+
+    // -------------------------------------------------------------------------
     // processUnprocessed — promotion and notification logic
     // -------------------------------------------------------------------------
 

--- a/iznik-nuxt3/modtools/components/ModMessage.vue
+++ b/iznik-nuxt3/modtools/components/ModMessage.vue
@@ -421,6 +421,7 @@
                 )
               "
               :messageid="message.id"
+              :groupid="currentGroupid"
             />
             <div v-if="expanded">
               <!-- eslint-disable-next-line -->

--- a/iznik-nuxt3/modtools/components/ModMessageWorry.vue
+++ b/iznik-nuxt3/modtools/components/ModMessageWorry.vue
@@ -2,7 +2,7 @@
   <div v-if="message">
     <!-- Worry words flagged by the Go API (real-time, per-request check) -->
     <NoticeMessage
-      v-for="(match, i) in worryMatches"
+      v-for="(match, i) in displayedWorry"
       :key="'worry-' + message.id + '-' + i"
       variant="warning"
       class="mb-1"
@@ -10,24 +10,32 @@
       <p>
         Flagged for review: "<span class="text-danger fw-bold">{{
           match.worryword.keyword
-        }}</span>".
+        }}</span
+        >".
       </p>
       <p v-if="match.worryword.type === 'Regulated'">
         This post looks as though it might contain a regulated substance. These
         are not legal on Freegle. If in doubt please check on
-        <ExternalLink href="https://discourse.ilovefreegle.org/">Central</ExternalLink>
+        <ExternalLink href="https://discourse.ilovefreegle.org/"
+          >Central</ExternalLink
+        >
         first.
       </p>
       <p v-else-if="match.worryword.type === 'Reportable'">
         This post looks as though it might contain a reportable substance. These
         may need to be reported to the police. Please ask the member about it,
         and if in doubt discuss on
-        <ExternalLink href="https://discourse.ilovefreegle.org/">Central</ExternalLink>.
+        <ExternalLink href="https://discourse.ilovefreegle.org/"
+          >Central</ExternalLink
+        >.
       </p>
       <p v-else-if="match.worryword.type === 'Medicine'">
-        This post looks as though it might contain a drug, medicine or supplement.
-        These are not legal on Freegle. Please do not approve this without checking on
-        <ExternalLink href="https://discourse.ilovefreegle.org/">Central</ExternalLink>
+        This post looks as though it might contain a drug, medicine or
+        supplement. These are not legal on Freegle. Please do not approve this
+        without checking on
+        <ExternalLink href="https://discourse.ilovefreegle.org/"
+          >Central</ExternalLink
+        >
         first.
       </p>
       <p v-else>
@@ -38,7 +46,7 @@
 
     <!-- Content check failure reasons (stored, from batch processing) -->
     <NoticeMessage
-      v-for="(reason, i) in contentcheckReasons"
+      v-for="(reason, i) in displayedReasons"
       :key="'contentcheck-' + message.id + '-' + i"
       variant="warning"
       class="mb-1"
@@ -56,8 +64,8 @@
         posts. Please ask the member to remove their email address.
       </span>
       <span v-else-if="reason.check === 'MessagingLink'">
-        <strong>Messaging app link:</strong> {{ reason.detail }}. Please ask
-        the member to remove the link.
+        <strong>Messaging app link:</strong> {{ reason.detail }}. Please ask the
+        member to remove the link.
       </span>
       <span v-else-if="reason.check === 'ConcernKeyword'">
         <span v-if="reason.category === 'substance_regulated'">
@@ -88,12 +96,12 @@
         </span>
         <span v-else-if="reason.category === 'scam'">
           <strong>Possible scam:</strong> This post has been flagged as a
-          possible scam or containing items that are not permitted. If you
-          can't see anything wrong, it's fine to approve.
+          possible scam or containing items that are not permitted. If you can't
+          see anything wrong, it's fine to approve.
         </span>
         <span v-else>
-          <strong>Flagged for review:</strong> {{ reason.detail }}. If you
-          can't see anything wrong, it's fine to approve.
+          <strong>Flagged for review:</strong> {{ reason.detail }}. If you can't
+          see anything wrong, it's fine to approve.
         </span>
       </span>
       <span v-else-if="reason.check === 'IpAbuse'">
@@ -106,15 +114,12 @@
         </span>
       </span>
       <span v-else-if="reason.check === 'NotAnItem'">
-        <strong>Possibly not an item:</strong> {{ reason.detail }}. This may be a
-        service, rental, job, or help/advice request rather than a physical item
-        — please check before approving.
+        <strong>Possibly not an item:</strong> {{ reason.detail }}. This may be
+        a service, rental, job, or help/advice request rather than a physical
+        item — please check before approving.
       </span>
-      <span v-else>
-        <strong>Flagged:</strong> {{ reason.detail }}
-      </span>
+      <span v-else> <strong>Flagged:</strong> {{ reason.detail }} </span>
     </NoticeMessage>
-
   </div>
 </template>
 <script setup>
@@ -125,6 +130,15 @@ const props = defineProps({
   messageid: {
     type: Number,
     required: true,
+  },
+  /* The group this copy is being moderated on (ModMessage's currentGroupid).
+     When set, only that group's stored flags are shown, so a per-group worry
+     word configured on one group doesn't appear when moderating another. 0 =
+     no group context (e.g. legacy callers) -> fall back to first group with
+     reasons. */
+  groupid: {
+    type: Number,
+    default: 0,
   },
 })
 
@@ -139,21 +153,103 @@ watch(
   { immediate: true }
 )
 
-/* Worry word matches from the Go API (message.worry array). */
-const worryMatches = computed(() => {
-  return message.value?.worry ?? []
-})
+/* The keyword a flag is about, for de-duplication. Only the keyword-based
+   checks carry one; other checks (Vague, PhoneNumber, …) return null and are
+   never de-duplicated. New reasons carry an explicit `keyword`; older stored
+   reasons are parsed from the quoted word in the detail text. */
+function reasonKeyword(reason) {
+  if (
+    !reason ||
+    (reason.check !== 'ConcernKeyword' && reason.check !== 'PerGroupWorryWord')
+  ) {
+    return null
+  }
+  if (reason.keyword) return String(reason.keyword).toLowerCase()
+  const m = /'([^']+)'/.exec(reason.detail || '')
+  return m ? m[1].toLowerCase() : null
+}
 
-/* Extract contentcheck_reasons from the first message group that has them.
-   The API field is `groups` (not `messagegroups`). */
-const contentcheckReasons = computed(() => {
-  if (!message.value?.groups) return []
-  for (const mg of message.value.groups) {
-    const reasons = mg.contentcheck_reasons
-    if (reasons && Array.isArray(reasons) && reasons.length > 0) {
-      return reasons
+/* Collapse reasons that name the same keyword, preferring the richer
+   ConcernKeyword (it carries a category that drives the guidance shown). */
+function dedupeByKeyword(reasons) {
+  const indexByKeyword = {}
+  const out = []
+  for (const reason of reasons) {
+    const kw = reasonKeyword(reason)
+    if (!kw) {
+      out.push(reason)
+      continue
+    }
+    if (!(kw in indexByKeyword)) {
+      indexByKeyword[kw] = out.length
+      out.push(reason)
+      continue
+    }
+    const i = indexByKeyword[kw]
+    if (
+      reason.check === 'ConcernKeyword' &&
+      out[i].check !== 'ConcernKeyword'
+    ) {
+      out[i] = reason
     }
   }
-  return []
+  return out
+}
+
+/* Keywords flagged by the stored content checks on ANY group the post is on.
+   Used to suppress the redundant real-time worry box once the batch has stored
+   a richer reason for that keyword somewhere. */
+const allStoredKeywords = computed(() => {
+  const set = new Set()
+  for (const mg of message.value?.groups ?? []) {
+    if (Array.isArray(mg.contentcheck_reasons)) {
+      for (const reason of mg.contentcheck_reasons) {
+        const kw = reasonKeyword(reason)
+        if (kw) set.add(kw)
+      }
+    }
+  }
+  return set
+})
+
+/* Stored contentcheck_reasons to show, scoped to the group being moderated. */
+const displayedReasons = computed(() => {
+  const groups = message.value?.groups
+  if (!groups || !groups.length) return []
+
+  let reasons = []
+  if (props.groupid) {
+    const row = groups.find(
+      (mg) => parseInt(mg.groupid) === parseInt(props.groupid)
+    )
+    reasons =
+      row && Array.isArray(row.contentcheck_reasons)
+        ? row.contentcheck_reasons
+        : []
+  } else {
+    /* No group context: fall back to the first group that has reasons. */
+    for (const mg of groups) {
+      if (
+        Array.isArray(mg.contentcheck_reasons) &&
+        mg.contentcheck_reasons.length
+      ) {
+        reasons = mg.contentcheck_reasons
+        break
+      }
+    }
+  }
+  return dedupeByKeyword(reasons)
+})
+
+/* Real-time worry words from the Go API (message.worry), minus any keyword the
+   stored content check has already flagged (shown via displayedReasons). */
+const displayedWorry = computed(() => {
+  const stored = allStoredKeywords.value
+  return (message.value?.worry ?? []).filter((match) => {
+    const kw = match?.worryword?.keyword
+      ? String(match.worryword.keyword).toLowerCase()
+      : null
+    return !kw || !stored.has(kw)
+  })
 })
 </script>

--- a/iznik-nuxt3/tests/unit/components/modtools/ModMessageWorry.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModMessageWorry.spec.js
@@ -57,8 +57,16 @@ describe('ModMessageWorry', () => {
 
     it('renders one NoticeMessage per reason', () => {
       const wrapper = mountWithReasons([
-        { check: 'Vague', category: null, detail: "Item name 'stuff' is too generic" },
-        { check: 'PhoneNumber', category: null, detail: 'Post contains what looks like a phone number' },
+        {
+          check: 'Vague',
+          category: null,
+          detail: "Item name 'stuff' is too generic",
+        },
+        {
+          check: 'PhoneNumber',
+          category: null,
+          detail: 'Post contains what looks like a phone number',
+        },
       ])
       expect(wrapper.findAll('.notice-message').length).toBe(2)
     })
@@ -98,10 +106,13 @@ describe('ModMessageWorry', () => {
     })
 
     it('shows one NoticeMessage per worry match', () => {
-      const message = makeMessage([], [
-        { word: 'gun', worryword: { keyword: 'gun', type: 'Review' } },
-        { word: 'knife', worryword: { keyword: 'knife', type: 'Regulated' } },
-      ])
+      const message = makeMessage(
+        [],
+        [
+          { word: 'gun', worryword: { keyword: 'gun', type: 'Review' } },
+          { word: 'knife', worryword: { keyword: 'knife', type: 'Regulated' } },
+        ]
+      )
       mockMessageStore.byId.mockReturnValue(message)
       const wrapper = mount(ModMessageWorry, {
         props: { messageid: 123 },
@@ -111,9 +122,10 @@ describe('ModMessageWorry', () => {
     })
 
     it('shows the matched keyword and review text for Review type', () => {
-      const message = makeMessage([], [
-        { word: 'gun', worryword: { keyword: 'gun', type: 'Review' } },
-      ])
+      const message = makeMessage(
+        [],
+        [{ word: 'gun', worryword: { keyword: 'gun', type: 'Review' } }]
+      )
       mockMessageStore.byId.mockReturnValue(message)
       const wrapper = mount(ModMessageWorry, {
         props: { messageid: 123 },
@@ -124,9 +136,10 @@ describe('ModMessageWorry', () => {
     })
 
     it('shows Regulated substance text for Regulated type', () => {
-      const message = makeMessage([], [
-        { word: 'gun', worryword: { keyword: 'gun', type: 'Regulated' } },
-      ])
+      const message = makeMessage(
+        [],
+        [{ word: 'gun', worryword: { keyword: 'gun', type: 'Regulated' } }]
+      )
       mockMessageStore.byId.mockReturnValue(message)
       const wrapper = mount(ModMessageWorry, {
         props: { messageid: 123 },
@@ -136,9 +149,10 @@ describe('ModMessageWorry', () => {
     })
 
     it('shows Reportable substance text for Reportable type', () => {
-      const message = makeMessage([], [
-        { word: 'acid', worryword: { keyword: 'acid', type: 'Reportable' } },
-      ])
+      const message = makeMessage(
+        [],
+        [{ word: 'acid', worryword: { keyword: 'acid', type: 'Reportable' } }]
+      )
       mockMessageStore.byId.mockReturnValue(message)
       const wrapper = mount(ModMessageWorry, {
         props: { messageid: 123 },
@@ -148,9 +162,15 @@ describe('ModMessageWorry', () => {
     })
 
     it('shows Medicine text for Medicine type', () => {
-      const message = makeMessage([], [
-        { word: 'codeine', worryword: { keyword: 'codeine', type: 'Medicine' } },
-      ])
+      const message = makeMessage(
+        [],
+        [
+          {
+            word: 'codeine',
+            worryword: { keyword: 'codeine', type: 'Medicine' },
+          },
+        ]
+      )
       mockMessageStore.byId.mockReturnValue(message)
       const wrapper = mount(ModMessageWorry, {
         props: { messageid: 123 },
@@ -176,21 +196,33 @@ describe('ModMessageWorry', () => {
   describe('Vague check', () => {
     it('shows Vague post heading', () => {
       const wrapper = mountWithReasons([
-        { check: 'Vague', category: null, detail: "Item name 'stuff' is too generic" },
+        {
+          check: 'Vague',
+          category: null,
+          detail: "Item name 'stuff' is too generic",
+        },
       ])
       expect(wrapper.text()).toContain('Vague post')
     })
 
     it('shows the detail text', () => {
       const wrapper = mountWithReasons([
-        { check: 'Vague', category: null, detail: "Item name 'stuff' is too generic" },
+        {
+          check: 'Vague',
+          category: null,
+          detail: "Item name 'stuff' is too generic",
+        },
       ])
       expect(wrapper.text()).toContain("Item name 'stuff' is too generic")
     })
 
     it('asks mod to request a more specific description', () => {
       const wrapper = mountWithReasons([
-        { check: 'Vague', category: null, detail: "Item name 'junk' is too generic" },
+        {
+          check: 'Vague',
+          category: null,
+          detail: "Item name 'junk' is too generic",
+        },
       ])
       expect(wrapper.text()).toContain('describe the item more specifically')
     })
@@ -199,14 +231,22 @@ describe('ModMessageWorry', () => {
   describe('PhoneNumber check', () => {
     it('shows Phone number heading', () => {
       const wrapper = mountWithReasons([
-        { check: 'PhoneNumber', category: null, detail: 'Post contains what looks like a phone number' },
+        {
+          check: 'PhoneNumber',
+          category: null,
+          detail: 'Post contains what looks like a phone number',
+        },
       ])
       expect(wrapper.text()).toContain('Phone number')
     })
 
     it('asks mod to request phone number removal', () => {
       const wrapper = mountWithReasons([
-        { check: 'PhoneNumber', category: null, detail: 'Post contains what looks like a phone number' },
+        {
+          check: 'PhoneNumber',
+          category: null,
+          detail: 'Post contains what looks like a phone number',
+        },
       ])
       expect(wrapper.text()).toContain('remove their phone number')
     })
@@ -215,14 +255,22 @@ describe('ModMessageWorry', () => {
   describe('EmailAddress check', () => {
     it('shows Email address heading', () => {
       const wrapper = mountWithReasons([
-        { check: 'EmailAddress', category: null, detail: 'Post contains an external email address' },
+        {
+          check: 'EmailAddress',
+          category: null,
+          detail: 'Post contains an external email address',
+        },
       ])
       expect(wrapper.text()).toContain('Email address')
     })
 
     it('asks mod to request email removal', () => {
       const wrapper = mountWithReasons([
-        { check: 'EmailAddress', category: null, detail: 'Post contains an external email address' },
+        {
+          check: 'EmailAddress',
+          category: null,
+          detail: 'Post contains an external email address',
+        },
       ])
       expect(wrapper.text()).toContain('remove their email address')
     })
@@ -231,21 +279,35 @@ describe('ModMessageWorry', () => {
   describe('MessagingLink check', () => {
     it('shows Messaging app link heading', () => {
       const wrapper = mountWithReasons([
-        { check: 'MessagingLink', category: null, detail: 'Post contains a messaging app link (wa.me)' },
+        {
+          check: 'MessagingLink',
+          category: null,
+          detail: 'Post contains a messaging app link (wa.me)',
+        },
       ])
       expect(wrapper.text()).toContain('Messaging app link')
     })
 
     it('shows the detail text', () => {
       const wrapper = mountWithReasons([
-        { check: 'MessagingLink', category: null, detail: 'Post contains a messaging app link (wa.me)' },
+        {
+          check: 'MessagingLink',
+          category: null,
+          detail: 'Post contains a messaging app link (wa.me)',
+        },
       ])
-      expect(wrapper.text()).toContain('Post contains a messaging app link (wa.me)')
+      expect(wrapper.text()).toContain(
+        'Post contains a messaging app link (wa.me)'
+      )
     })
 
     it('asks mod to request link removal', () => {
       const wrapper = mountWithReasons([
-        { check: 'MessagingLink', category: null, detail: 'Post contains a messaging app link (wa.me)' },
+        {
+          check: 'MessagingLink',
+          category: null,
+          detail: 'Post contains a messaging app link (wa.me)',
+        },
       ])
       expect(wrapper.text()).toContain('remove the link')
     })
@@ -254,21 +316,33 @@ describe('ModMessageWorry', () => {
   describe('ConcernKeyword check — categories', () => {
     it('substance_regulated: shows Regulated substance heading', () => {
       const wrapper = mountWithReasons([
-        { check: 'ConcernKeyword', category: 'substance_regulated', detail: "Matched concern keyword 'cocaine'" },
+        {
+          check: 'ConcernKeyword',
+          category: 'substance_regulated',
+          detail: "Matched concern keyword 'cocaine'",
+        },
       ])
       expect(wrapper.text()).toContain('Regulated substance')
     })
 
     it('substance_regulated: mentions not legal on Freegle', () => {
       const wrapper = mountWithReasons([
-        { check: 'ConcernKeyword', category: 'substance_regulated', detail: "Matched concern keyword 'cocaine'" },
+        {
+          check: 'ConcernKeyword',
+          category: 'substance_regulated',
+          detail: "Matched concern keyword 'cocaine'",
+        },
       ])
       expect(wrapper.text()).toContain('not legal on Freegle')
     })
 
     it('substance_regulated: links to Central', () => {
       const wrapper = mountWithReasons([
-        { check: 'ConcernKeyword', category: 'substance_regulated', detail: "Matched concern keyword 'cocaine'" },
+        {
+          check: 'ConcernKeyword',
+          category: 'substance_regulated',
+          detail: "Matched concern keyword 'cocaine'",
+        },
       ])
       const links = wrapper.findAll('a')
       const centralLink = links.find((l) =>
@@ -279,63 +353,99 @@ describe('ModMessageWorry', () => {
 
     it('substance_reportable: shows Reportable substance heading', () => {
       const wrapper = mountWithReasons([
-        { check: 'ConcernKeyword', category: 'substance_reportable', detail: "Matched concern keyword 'asbestos'" },
+        {
+          check: 'ConcernKeyword',
+          category: 'substance_reportable',
+          detail: "Matched concern keyword 'asbestos'",
+        },
       ])
       expect(wrapper.text()).toContain('Reportable substance')
     })
 
     it('substance_reportable: mentions reporting to police', () => {
       const wrapper = mountWithReasons([
-        { check: 'ConcernKeyword', category: 'substance_reportable', detail: "Matched concern keyword 'asbestos'" },
+        {
+          check: 'ConcernKeyword',
+          category: 'substance_reportable',
+          detail: "Matched concern keyword 'asbestos'",
+        },
       ])
       expect(wrapper.text()).toContain('reported to the police')
     })
 
     it('substance_medicine: shows Medicine or drug heading', () => {
       const wrapper = mountWithReasons([
-        { check: 'ConcernKeyword', category: 'substance_medicine', detail: "Matched concern keyword 'aspirin'" },
+        {
+          check: 'ConcernKeyword',
+          category: 'substance_medicine',
+          detail: "Matched concern keyword 'aspirin'",
+        },
       ])
       expect(wrapper.text()).toContain('Medicine or drug')
     })
 
     it('substance_medicine: mentions not legal on Freegle', () => {
       const wrapper = mountWithReasons([
-        { check: 'ConcernKeyword', category: 'substance_medicine', detail: "Matched concern keyword 'aspirin'" },
+        {
+          check: 'ConcernKeyword',
+          category: 'substance_medicine',
+          detail: "Matched concern keyword 'aspirin'",
+        },
       ])
       expect(wrapper.text()).toContain('not legal on Freegle')
     })
 
     it('scam: shows Possible scam heading', () => {
       const wrapper = mountWithReasons([
-        { check: 'ConcernKeyword', category: 'scam', detail: "Matched concern keyword 'lottery'" },
+        {
+          check: 'ConcernKeyword',
+          category: 'scam',
+          detail: "Matched concern keyword 'lottery'",
+        },
       ])
       expect(wrapper.text()).toContain('Possible scam')
     })
 
     it('scam: says fine to approve if nothing wrong', () => {
       const wrapper = mountWithReasons([
-        { check: 'ConcernKeyword', category: 'scam', detail: "Matched concern keyword 'lottery'" },
+        {
+          check: 'ConcernKeyword',
+          category: 'scam',
+          detail: "Matched concern keyword 'lottery'",
+        },
       ])
-      expect(wrapper.text()).toContain("fine to approve")
+      expect(wrapper.text()).toContain('fine to approve')
     })
 
     it('review (generic category): shows Flagged for review heading', () => {
       const wrapper = mountWithReasons([
-        { check: 'ConcernKeyword', category: 'review', detail: "Matched concern keyword 'test'" },
+        {
+          check: 'ConcernKeyword',
+          category: 'review',
+          detail: "Matched concern keyword 'test'",
+        },
       ])
       expect(wrapper.text()).toContain('Flagged for review')
     })
 
     it('review: shows detail text', () => {
       const wrapper = mountWithReasons([
-        { check: 'ConcernKeyword', category: 'review', detail: "Matched concern keyword 'suspicious'" },
+        {
+          check: 'ConcernKeyword',
+          category: 'review',
+          detail: "Matched concern keyword 'suspicious'",
+        },
       ])
       expect(wrapper.text()).toContain("Matched concern keyword 'suspicious'")
     })
 
     it('unknown category: falls through to Flagged for review', () => {
       const wrapper = mountWithReasons([
-        { check: 'ConcernKeyword', category: 'unknown_future_category', detail: 'some detail' },
+        {
+          check: 'ConcernKeyword',
+          category: 'unknown_future_category',
+          detail: 'some detail',
+        },
       ])
       expect(wrapper.text()).toContain('Flagged for review')
     })
@@ -344,21 +454,36 @@ describe('ModMessageWorry', () => {
   describe('NotAnItem check', () => {
     it('shows Possibly not an item heading', () => {
       const wrapper = mountWithReasons([
-        { check: 'NotAnItem', category: 'service', detail: 'Post may be a non-physical request (service) rather than an item — matched "cleaner wanted"' },
+        {
+          check: 'NotAnItem',
+          category: 'service',
+          detail:
+            'Post may be a non-physical request (service) rather than an item — matched "cleaner wanted"',
+        },
       ])
       expect(wrapper.text()).toContain('Possibly not an item')
     })
 
     it('shows the detail text (matched phrase)', () => {
       const wrapper = mountWithReasons([
-        { check: 'NotAnItem', category: 'accommodation', detail: 'Post may be a non-physical request (accommodation) rather than an item — matched "to rent"' },
+        {
+          check: 'NotAnItem',
+          category: 'accommodation',
+          detail:
+            'Post may be a non-physical request (accommodation) rather than an item — matched "to rent"',
+        },
       ])
       expect(wrapper.text()).toContain('matched "to rent"')
     })
 
     it('explains it may not be a physical item', () => {
       const wrapper = mountWithReasons([
-        { check: 'NotAnItem', category: 'work', detail: 'Post may be a non-physical request (work) rather than an item — matched "job vacancy"' },
+        {
+          check: 'NotAnItem',
+          category: 'work',
+          detail:
+            'Post may be a non-physical request (work) rather than an item — matched "job vacancy"',
+        },
       ])
       expect(wrapper.text()).toContain('rather than a physical item')
     })
@@ -367,14 +492,22 @@ describe('ModMessageWorry', () => {
   describe('unknown check type', () => {
     it('shows generic Flagged heading', () => {
       const wrapper = mountWithReasons([
-        { check: 'SomeFutureCheck', category: null, detail: 'something flagged' },
+        {
+          check: 'SomeFutureCheck',
+          category: null,
+          detail: 'something flagged',
+        },
       ])
       expect(wrapper.text()).toContain('Flagged')
     })
 
     it('shows the detail text', () => {
       const wrapper = mountWithReasons([
-        { check: 'SomeFutureCheck', category: null, detail: 'something flagged' },
+        {
+          check: 'SomeFutureCheck',
+          category: null,
+          detail: 'something flagged',
+        },
       ])
       expect(wrapper.text()).toContain('something flagged')
     })
@@ -383,9 +516,21 @@ describe('ModMessageWorry', () => {
   describe('multiple reasons', () => {
     it('renders a separate NoticeMessage for each reason', () => {
       const wrapper = mountWithReasons([
-        { check: 'Vague', category: null, detail: "Item name 'stuff' is too generic" },
-        { check: 'ConcernKeyword', category: 'scam', detail: "Matched concern keyword 'lottery'" },
-        { check: 'PhoneNumber', category: null, detail: 'Post contains what looks like a phone number' },
+        {
+          check: 'Vague',
+          category: null,
+          detail: "Item name 'stuff' is too generic",
+        },
+        {
+          check: 'ConcernKeyword',
+          category: 'scam',
+          detail: "Matched concern keyword 'lottery'",
+        },
+        {
+          check: 'PhoneNumber',
+          category: null,
+          detail: 'Post contains what looks like a phone number',
+        },
       ])
       expect(wrapper.findAll('.notice-message').length).toBe(3)
     })
@@ -395,6 +540,228 @@ describe('ModMessageWorry', () => {
     it('messageid prop is required and used', () => {
       const wrapper = mountWithReasons([])
       expect(wrapper.props('messageid')).toBe(123)
+    })
+  })
+
+  describe('keyword de-duplication and per-group scoping', () => {
+    function mountMessage(message, props = {}) {
+      mockMessageStore.byId.mockImplementation((id) =>
+        id === message.id ? message : null
+      )
+      return mount(ModMessageWorry, {
+        props: { messageid: message.id, ...props },
+        global: { stubs: STUBS },
+      })
+    }
+
+    it('shows one box when a live worry word and a stored reason name the same keyword', () => {
+      const message = {
+        id: 1,
+        worry: [
+          {
+            word: 'cot mattress',
+            worryword: { keyword: 'cot mattress', type: 'Review' },
+          },
+        ],
+        groups: [
+          {
+            groupid: 10,
+            contentcheck_reasons: [
+              {
+                check: 'ConcernKeyword',
+                category: 'review',
+                keyword: 'cot mattress',
+                detail: "Matched concern keyword 'cot mattress'",
+              },
+            ],
+          },
+        ],
+      }
+      const wrapper = mountMessage(message, { groupid: 10 })
+      expect(wrapper.findAll('.notice-message').length).toBe(1)
+    })
+
+    it('collapses ConcernKeyword and PerGroupWorryWord reasons for the same keyword', () => {
+      const message = {
+        id: 2,
+        worry: [],
+        groups: [
+          {
+            groupid: 10,
+            contentcheck_reasons: [
+              {
+                check: 'ConcernKeyword',
+                category: 'review',
+                keyword: 'cot mattress',
+                detail: "Matched concern keyword 'cot mattress'",
+              },
+              {
+                check: 'PerGroupWorryWord',
+                category: null,
+                keyword: 'cot mattress',
+                detail: "Matched per-group worry word 'cot mattress'",
+              },
+            ],
+          },
+        ],
+      }
+      const wrapper = mountMessage(message, { groupid: 10 })
+      expect(wrapper.findAll('.notice-message').length).toBe(1)
+      expect(wrapper.text()).toContain('Flagged for review')
+    })
+
+    it("does not show another group's worry word when moderating a clean group", () => {
+      const message = {
+        id: 3,
+        worry: [
+          {
+            word: 'cot mattress',
+            worryword: { keyword: 'cot mattress', type: 'Review' },
+          },
+        ],
+        groups: [
+          { groupid: 10, contentcheck_reasons: null },
+          {
+            groupid: 20,
+            contentcheck_reasons: [
+              {
+                check: 'ConcernKeyword',
+                category: 'review',
+                keyword: 'cot mattress',
+                detail: "Matched concern keyword 'cot mattress'",
+              },
+            ],
+          },
+        ],
+      }
+      const wrapper = mountMessage(message, { groupid: 10 })
+      expect(wrapper.findAll('.notice-message').length).toBe(0)
+    })
+
+    it('shows the flag for the group that configured it', () => {
+      const message = {
+        id: 4,
+        worry: [
+          {
+            word: 'cot mattress',
+            worryword: { keyword: 'cot mattress', type: 'Review' },
+          },
+        ],
+        groups: [
+          { groupid: 10, contentcheck_reasons: null },
+          {
+            groupid: 20,
+            contentcheck_reasons: [
+              {
+                check: 'ConcernKeyword',
+                category: 'review',
+                keyword: 'cot mattress',
+                detail: "Matched concern keyword 'cot mattress'",
+              },
+            ],
+          },
+        ],
+      }
+      const wrapper = mountMessage(message, { groupid: 20 })
+      expect(wrapper.findAll('.notice-message').length).toBe(1)
+      expect(wrapper.text()).toContain("Matched concern keyword 'cot mattress'")
+    })
+
+    it('keeps distinct keywords as separate boxes (no false de-dup)', () => {
+      const message = {
+        id: 5,
+        worry: [{ word: 'gun', worryword: { keyword: 'gun', type: 'Review' } }],
+        groups: [
+          {
+            groupid: 10,
+            contentcheck_reasons: [
+              {
+                check: 'ConcernKeyword',
+                category: 'scam',
+                keyword: 'lottery',
+                detail: "Matched concern keyword 'lottery'",
+              },
+            ],
+          },
+        ],
+      }
+      const wrapper = mountMessage(message, { groupid: 10 })
+      expect(wrapper.findAll('.notice-message').length).toBe(2)
+    })
+
+    it('never de-duplicates non-keyword checks', () => {
+      const message = {
+        id: 6,
+        worry: [],
+        groups: [
+          {
+            groupid: 10,
+            contentcheck_reasons: [
+              {
+                check: 'Vague',
+                category: null,
+                detail: "Item name 'stuff' is too generic",
+              },
+              {
+                check: 'PhoneNumber',
+                category: null,
+                detail: 'Post contains a phone number',
+              },
+            ],
+          },
+        ],
+      }
+      const wrapper = mountMessage(message, { groupid: 10 })
+      expect(wrapper.findAll('.notice-message').length).toBe(2)
+    })
+
+    it('matches the group row when groupid is a string in the API data', () => {
+      const message = {
+        id: 8,
+        worry: [],
+        groups: [
+          { groupid: '10', contentcheck_reasons: null },
+          {
+            groupid: '20',
+            contentcheck_reasons: [
+              {
+                check: 'ConcernKeyword',
+                category: 'review',
+                keyword: 'cot mattress',
+                detail: "Matched concern keyword 'cot mattress'",
+              },
+            ],
+          },
+        ],
+      }
+      const wrapper = mountMessage(message, { groupid: 20 })
+      expect(wrapper.findAll('.notice-message').length).toBe(1)
+    })
+
+    it('de-dupes against legacy stored reasons that have no keyword field', () => {
+      const message = {
+        id: 7,
+        worry: [
+          {
+            word: 'cot mattress',
+            worryword: { keyword: 'cot mattress', type: 'Review' },
+          },
+        ],
+        groups: [
+          {
+            groupid: 10,
+            contentcheck_reasons: [
+              {
+                check: 'ConcernKeyword',
+                category: 'review',
+                detail: "Matched concern keyword 'cot mattress'",
+              },
+            ],
+          },
+        ],
+      }
+      const wrapper = mountMessage(message, { groupid: 10 })
+      expect(wrapper.findAll('.notice-message').length).toBe(1)
     })
   })
 })


### PR DESCRIPTION
## Problem

A rippled **WANTED: Corner sofa** post (msg #119344616) showed the worry word **`cot mattress`** as **three** separate "flagged for review" notice boxes in ModTools, on the **Huddersfield** view — a group that never configured that word.

Verified against the live DB: the post's origin is Huddersfield (clean, auto-approved). The flag actually belongs to **Oldham**, a group it rippled *into*. Oldham's stored `contentcheck_reasons` held two reasons for the one word, and the Go live worry check pooled Oldham's word onto the message so it leaked onto every group's view.

## Root causes

1. **Data duplication.** `cot mattress` is configured for Oldham in **both** the unified `concern_keywords` table (scope=group) **and** the legacy `groups.settings → spammers.worrywords` list, so `ContentCheckService` stored two reasons (`ConcernKeyword` + `PerGroupWorryWord`) for the same word.
   - The legacy path **cannot simply be deleted**: mods still manage per-group worry words through the old "Worry words?" settings field, and the `data:migrate-concern-keywords` command that copies them into `concern_keywords` is **not scheduled** (one such word — group 21486's `venue` — is already only in the legacy list). So the legacy check is kept as a fallback.
2. **No de-dup / no group scoping in the UI.** The Go live worry check pools every group's words onto the message, and `ModMessageWorry.vue` rendered the live worry box plus *every* group's stored reasons with no de-duplication and no scoping to the group being moderated.

## Fix (no coverage removed)

- **`ContentCheckService.php`** — tag concern/worry reasons with the matched `keyword`; collapse reasons that flag the same keyword, preferring the richer `ConcernKeyword`. A per-group worry word **not** in `concern_keywords` still flags (fallback retained).
- **`ModMessageWorry.vue`** — de-dupe by keyword across live worry words and stored reasons; scope the displayed stored reasons to the group being moderated (`currentGroupid`). A keyword the batch has stored on any group no longer also shows as a redundant live worry box.
- **`ModMessage.vue`** — pass `currentGroupid` to `ModMessageWorry`.

**Net:** one attributed box per keyword, shown only for the group that flagged it. A Huddersfield mod no longer sees Oldham's `cot mattress` flag; an Oldham mod sees exactly one.

## Tests
- 5 new `ContentCheckTest` cases: keyword field on both reason types, de-dup of the same keyword across concern + per-group, un-migrated per-group word still flags, distinct words both kept.
- 8 new `ModMessageWorry` cases: live-vs-stored de-dup, ConcernKeyword/PerGroupWorryWord collapse, cross-group suppression, group scoping, string/number `groupid`, legacy reasons without a `keyword` field.
- Full Laravel suite (4406) and full modtools component suite (4205) green locally.

## Follow-up (not in this PR)
Fully retiring the legacy `spammers.worrywords` path would require migrating the ModTools "Worry words?" UI to write to `concern_keywords` directly (+ a one-shot data migration), so mods have a single source of truth. Left as a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PRRBG6pjX3EAqch5ntxpfZ
