### PR TITLE
fix(rippling): consistent date x-axis + zero-filled charts on the sysadmin dashboard

### DIFF
--- a/iznik-nuxt3/modtools/components/ModSysAdminRippling.vue
+++ b/iznik-nuxt3/modtools/components/ModSysAdminRippling.vue
@@ -66,6 +66,31 @@
       </div>
 
       <div class="mb-3">
+        <strong class="small">Are posts getting more replies?</strong>
+        <p class="text-muted small mb-1">
+          Mean number of replies a post gets within 36h.
+          <span class="text-success fw-bold">Good:</span> rippled-out posts
+          average more replies each than home-only - reach is deepening
+          interest, not just turning 0-reply posts into 1.
+        </p>
+        <GChart
+          v-if="repliesPerPostChart"
+          type="LineChart"
+          :data="repliesPerPostChart"
+          :options="cohortPctOptions('Mean replies / post')"
+          style="width: 100%; height: 300px"
+        />
+        <p
+          v-if="repliesPerPostChart"
+          class="text-muted small fst-italic mt-1 mb-0"
+        >
+          The dashed tail is still settling - the most recent posts haven't had
+          a full 36h to gather replies yet.
+        </p>
+        <p v-if="!repliesPerPostChart" class="text-muted small">No data yet.</p>
+      </div>
+
+      <div class="mb-3">
         <strong class="small">Share of replies from rippling</strong>
         <p class="text-muted small mb-1">
           Share of replies that came via rippling vs your own members.
@@ -220,6 +245,7 @@ const hotspots = ref([])
 const heldReplySummary = ref([])
 // Headline reply KPIs (per-day series for the line charts)
 const replyRate = ref([])
+const repliesPerPost = ref([])
 const replySource = ref([])
 const replyDistance = ref([])
 const takenRate = ref([])
@@ -242,6 +268,22 @@ const replyRateChart = computed(() => {
   const rows = [...replyRate.value].reverse().map((r) => {
     const certain = !r.provisional
     return [new Date(r.day), r.reply_pct, certain, r.home_pct, certain, r.ripple_pct, certain]
+  })
+  return [COHORT_HEADER('All offers'), ...rows]
+})
+const repliesPerPostChart = computed(() => {
+  if (!repliesPerPost.value.length) return null
+  const rows = [...repliesPerPost.value].reverse().map((r) => {
+    const certain = !r.provisional
+    return [
+      new Date(r.day),
+      r.mean_replies,
+      certain,
+      r.home_mean,
+      certain,
+      r.ripple_mean,
+      certain,
+    ]
   })
   return [COHORT_HEADER('All offers'), ...rows]
 })
@@ -367,6 +409,7 @@ async function fetchMetrics() {
     hotspots.value = result?.hotspots || []
     heldReplySummary.value = result?.held_reply_summary || []
     replyRate.value = result?.reply_rate_36h || []
+    repliesPerPost.value = result?.replies_per_post || []
     replySource.value = result?.reply_source_split || []
     replyDistance.value = result?.reply_distance_median || []
     takenRate.value = result?.taken_rate || []

--- a/iznik-nuxt3/modtools/components/ModSysAdminRippling.vue
+++ b/iznik-nuxt3/modtools/components/ModSysAdminRippling.vue
@@ -269,13 +269,45 @@ const takenRateChart = computed(() => {
   return [COHORT_HEADER('All offers'), ...rows]
 })
 
+// Shared x-axis so EVERY chart spans the same filter date range with the same
+// date ticks. Without this each chart auto-scaled to its own data: a single-point
+// chart collapsed to one repeated date ("23 Jun" all along) and dense charts
+// dropped their labels entirely. viewWindow pins the range; explicit ticks force
+// a consistent, readable set of date labels (~8 max) across all charts.
+function dateTicks() {
+  if (!startDate.value || !endDate.value) return undefined
+  const start = new Date(startDate.value)
+  const end = new Date(endDate.value)
+  if (isNaN(start) || isNaN(end) || end < start) return undefined
+  const days = Math.round((end - start) / 86400000)
+  const step = Math.max(1, Math.ceil((days + 1) / 8))
+  const ticks = []
+  for (let d = new Date(start); d <= end; d.setDate(d.getDate() + step)) {
+    ticks.push(new Date(d))
+  }
+  return ticks
+}
+function dateHAxis() {
+  const h = { title: 'Date', format: 'dd MMM' }
+  if (startDate.value && endDate.value) {
+    const min = new Date(startDate.value)
+    const max = new Date(endDate.value)
+    if (!isNaN(min) && !isNaN(max) && max >= min) {
+      h.viewWindow = { min, max }
+      const ticks = dateTicks()
+      if (ticks && ticks.length) h.ticks = ticks
+    }
+  }
+  return h
+}
+
 function pctChartOptions(vTitle, color) {
   return {
     curveType: 'function',
     legend: { position: 'none' },
     chartArea: { width: '85%', height: '70%' },
     vAxis: { title: vTitle, viewWindow: { min: 0 }, format: '#.#' },
-    hAxis: { title: 'Date', format: 'dd MMM' },
+    hAxis: dateHAxis(),
     series: { 0: { color } },
     animation: { startup: true, duration: 400, easing: 'out' },
   }
@@ -287,7 +319,7 @@ function cohortPctOptions(vTitle) {
     legend: { position: 'bottom' },
     chartArea: { width: '85%', height: '65%' },
     vAxis: { title: vTitle, viewWindow: { min: 0 }, format: '#.#' },
-    hAxis: { title: 'Date', format: 'dd MMM' },
+    hAxis: dateHAxis(),
     series: {
       0: { color: '#6c757d' }, // All — grey
       1: { color: '#17a2b8' }, // Home-only — teal
@@ -302,7 +334,7 @@ function cohortKmOptions() {
     legend: { position: 'bottom' },
     chartArea: { width: '85%', height: '65%' },
     vAxis: { title: 'Median km', viewWindow: { min: 0 }, format: '#.#' },
-    hAxis: { title: 'Date', format: 'dd MMM' },
+    hAxis: dateHAxis(),
     series: {
       0: { color: '#6c757d' },
       1: { color: '#17a2b8' },

--- a/iznik-nuxt3/modtools/components/ModSysAdminRippling.vue
+++ b/iznik-nuxt3/modtools/components/ModSysAdminRippling.vue
@@ -246,10 +246,21 @@ const replyRateChart = computed(() => {
   return [COHORT_HEADER('All offers'), ...rows]
 })
 const replySourceChart = computed(() => {
-  if (!replySource.value.length) return null
-  const rows = [...replySource.value]
-    .reverse()
-    .map((r) => [new Date(r.day), r.ripple_pct])
+  if (!startDate.value || !endDate.value) return null
+  // Zero-fill the whole filter range. The backend only returns days that had a
+  // rippling-attributed reply, so early in the rollout this was a single lone
+  // point. A day with no rippling reply genuinely has a 0% rippling share, so
+  // filling the gaps draws a continuous line across the same range as the other
+  // charts instead of one dot floating on a one-day axis.
+  const byDay = new Map(replySource.value.map((r) => [r.day, r.ripple_pct]))
+  const start = new Date(startDate.value)
+  const end = new Date(endDate.value)
+  if (isNaN(start) || isNaN(end) || end < start) return null
+  const rows = []
+  for (const d = new Date(start); d <= end; d.setDate(d.getDate() + 1)) {
+    const key = d.toISOString().slice(0, 10)
+    rows.push([new Date(d), byDay.has(key) ? byDay.get(key) : 0])
+  }
   return [['Date', '% of replies via rippling'], ...rows]
 })
 const replyDistanceChart = computed(() => {

--- a/iznik-server-go/rippling/metrics.go
+++ b/iznik-server-go/rippling/metrics.go
@@ -110,6 +110,27 @@ type ReplyRateRow struct {
 	Provisional bool `json:"provisional"` // computed in Go (day within the 36h settling window)
 }
 
+// RepliesPerPostRow is the mean number of Interested replies a post got within 36h, per arrival day,
+// split into home-only vs rippled-out cohorts. Where reply RATE (ReplyRateRow) asks "did a post get
+// any reply", this asks "how many" - so it shows whether rippling lifts the depth of interest, not
+// just its presence. Means are computed in Go; counts come from SQL.
+type RepliesPerPostRow struct {
+	Day         string  `json:"day"          gorm:"column:day"`
+	Posts       int     `json:"posts"        gorm:"column:posts"`
+	Replies     int     `json:"replies"      gorm:"column:replies"`
+	MeanReplies float64 `json:"mean_replies"` // computed in Go (Replies / Posts)
+
+	HomePosts   int     `json:"home_posts"   gorm:"column:home_posts"`
+	HomeReplies int     `json:"home_replies" gorm:"column:home_replies"`
+	HomeMean    float64 `json:"home_mean"` // computed in Go
+
+	RipplePosts   int     `json:"ripple_posts"   gorm:"column:ripple_posts"`
+	RippleReplies int     `json:"ripple_replies" gorm:"column:ripple_replies"`
+	RippleMean    float64 `json:"ripple_mean"` // computed in Go
+
+	Provisional bool `json:"provisional"` // computed in Go (day within the 36h settling window)
+}
+
 // ReplySourceRow is the daily split of Interested replies by whether the replier reached the post
 // via rippling or via their own (home) group. A reply counts as "home" only if the replier was an
 // approved member of an ORIGIN (rippled_in=0) group of the post BEFORE the post arrived
@@ -253,6 +274,7 @@ func Metrics(c *fiber.Ctx) error {
 	var cg crossGroupRaw
 	var capture CaptureSummary
 	replyRates := []ReplyRateRow{}
+	repliesPerPost := []RepliesPerPostRow{}
 	replySources := []ReplySourceRow{}
 	replyDistances := []ReplyDistanceRow{}
 	takenRates := []TakenRateRow{}
@@ -388,6 +410,41 @@ func Metrics(c *fiber.Ctx) error {
 			ORDER BY day DESC`, replyRateArgs(gid, start, end)...).Scan(&replyRates)
 	}()
 
+	// (1b) Mean number of Interested replies per Offer within 36h, per arrival day, split by cohort.
+	// Mirrors query (1) exactly (same arg order via replyRateArgs) but COUNTs replies instead of
+	// asking did-any-reply. COUNT(DISTINCT cm.id) because a post sits in several messages_groups rows
+	// (it can ripple into many groups), which would otherwise multiply the reply count.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		db.Raw(`
+			SELECT day,
+			       COUNT(*) AS posts,
+			       SUM(reply_count) AS replies,
+			       SUM(1 - is_rippled) AS home_posts, -- is_rippled is 0/1 from EXISTS (never NULL)
+			       SUM(CASE WHEN is_rippled = 0 THEN reply_count ELSE 0 END) AS home_replies,
+			       SUM(is_rippled) AS ripple_posts,
+			       SUM(CASE WHEN is_rippled = 1 THEN reply_count ELSE 0 END) AS ripple_replies
+			FROM (
+			    SELECT m.id,
+			           DATE_FORMAT(m.arrival, '%Y-%m-%d') AS day,
+			           COUNT(DISTINCT cm.id) AS reply_count,
+			           EXISTS (SELECT 1 FROM messages_groups mgr
+			                   WHERE mgr.msgid = m.id AND mgr.rippled_in = 1 AND mgr.deleted = 0) AS is_rippled
+			    FROM messages m
+			    JOIN messages_groups mg ON mg.msgid = m.id AND mg.collection = 'Approved' AND mg.deleted = 0`+rateGroup+`
+			    LEFT JOIN chat_messages cm
+			           ON cm.refmsgid = m.id AND cm.type = 'Interested'
+			          AND cm.date >= ? AND cm.date < (? + INTERVAL 36 HOUR)
+			          AND cm.date >= m.arrival AND cm.date < m.arrival + INTERVAL 36 HOUR
+			    WHERE m.type = 'Offer'
+			      AND m.arrival >= ? AND m.arrival < ?
+			    GROUP BY m.id, m.arrival
+			) per_msg
+			GROUP BY day
+			ORDER BY day DESC`, replyRateArgs(gid, start, end)...).Scan(&repliesPerPost)
+	}()
+
 	// (2) Rippling vs home-group replies, per day, from rippling_reply_attribution (captured at
 	//     reply time - the only sound attribution, since replying joins the member to the group).
 	wg.Add(1)
@@ -511,6 +568,20 @@ func Metrics(c *fiber.Ctx) error {
 		replyRates[i].Provisional = replyRates[i].Day >= reply36hCutoff
 	}
 
+	// Mean replies per post (overall + cohorts). Same 36h settling window as the reply rate.
+	for i := range repliesPerPost {
+		if repliesPerPost[i].Posts > 0 {
+			repliesPerPost[i].MeanReplies = float64(repliesPerPost[i].Replies) / float64(repliesPerPost[i].Posts)
+		}
+		if repliesPerPost[i].HomePosts > 0 {
+			repliesPerPost[i].HomeMean = float64(repliesPerPost[i].HomeReplies) / float64(repliesPerPost[i].HomePosts)
+		}
+		if repliesPerPost[i].RipplePosts > 0 {
+			repliesPerPost[i].RippleMean = float64(repliesPerPost[i].RippleReplies) / float64(repliesPerPost[i].RipplePosts)
+		}
+		repliesPerPost[i].Provisional = repliesPerPost[i].Day >= reply36hCutoff
+	}
+
 	// Compute derived fields for reply-source rows.
 	for i := range replySources {
 		replySources[i].Ripple = replySources[i].Replies - replySources[i].Home
@@ -561,6 +632,7 @@ func Metrics(c *fiber.Ctx) error {
 		"cross_group_summary":   crossGroup,
 		"capture_summary":       capture,
 		"reply_rate_36h":        replyRates,
+		"replies_per_post":      repliesPerPost,
 		"reply_source_split":    replySources,
 		"reply_distance_median": replyDistances,
 		"taken_rate":            takenRates,

--- a/iznik-server-go/test/rippling_metrics_test.go
+++ b/iznik-server-go/test/rippling_metrics_test.go
@@ -38,6 +38,32 @@ func TestRipplingMetricsEndpoint(t *testing.T) {
 	assert.True(t, found, "reply_blocked total present in the rollup")
 }
 
+// The mean-replies-per-post metric is surfaced as a well-formed cohort series. (Like the other
+// per-day reply metrics it carries no seeded fixture here; this guards the wiring + the response
+// shape - the SQL is validated separately, and the query mirrors the proven reply-rate one.)
+func TestRipplingMetricsRepliesPerPost(t *testing.T) {
+	prefix := uniquePrefix("ripplerpp")
+	adminID := CreateTestUser(t, prefix+"_admin", "Support")
+	_, token := CreateTestSession(t, adminID)
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET", fmt.Sprintf("/api/rippling/metrics?jwt=%s", token), nil))
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json.Unmarshal(rsp(resp), &result)
+
+	rpp, ok := result["replies_per_post"].([]interface{})
+	assert.True(t, ok, "replies_per_post field present in the response")
+	for _, row := range rpp {
+		m, ok := row.(map[string]interface{})
+		assert.True(t, ok, "each replies_per_post row is an object")
+		assert.Contains(t, m, "day")
+		assert.Contains(t, m, "mean_replies")
+		assert.Contains(t, m, "home_mean")
+		assert.Contains(t, m, "ripple_mean")
+	}
+}
+
 // A non-admin must be forbidden from the sysadmin metrics endpoint.
 func TestRipplingMetricsRequiresAdmin(t *testing.T) {
 	prefix := uniquePrefix("ripplemetrics_noauth")


### PR DESCRIPTION
Fixes the four things flagged on the rippling sysadmin dashboard.

## 1-3. Chart display fixes (frontend only)

- **No date labels on chart 1; "23 Jun" repeated all along chart 2; charts not aligned.** Each `LineChart` auto-scaled to its own data, so a single-point chart collapsed its date axis to one repeated day and dense charts dropped their labels. A shared `dateHAxis` now pins `hAxis.viewWindow` to the filter's date range and emits a consistent ~8 date ticks on **every** chart - so they all span the same days with the same labels.
- **"Share of replies from rippling" was a single lone point.** The backend only returns days that had a rippling-attributed reply. A day with no rippling reply has a 0% rippling share, so the chart is now **zero-filled** across the range - a continuous line instead of one floating dot.

## 4. New chart: "Are posts getting more replies?"

The mean number of `Interested` replies a post gets within 36h, per arrival day, split **Home-only vs Rippled-out** - so it shows whether rippling *deepens* interest (more replies per post), not just presence (any reply).

- **Backend** (`iznik-server-go/rippling/metrics.go`): a new `replies_per_post` metric mirroring the proven reply-rate query but `COUNT(DISTINCT cm.id)`-ing replies within 36h of arrival (distinct to avoid `messages_groups` row inflation), split by cohort, means computed in Go.
- **Frontend**: a new cohort chart card reusing `cohortPctOptions` + the shared `dateHAxis`.

## Verification

- Full Go suite green: **3258 passed, 0 failed**, including the new `TestRipplingMetricsRepliesPerPost`. The new SQL was also run directly against the DB (valid syntax/columns).
- Date-tick + zero-fill logic unit-checked (a 14-day range → 8 evenly-spaced labels; a single 12.9% point → `0,0,0,12.9,0`).
- The dashboard is support/admin-gated (`/sysadmin` → Rippling) - please confirm visuals on the deploy preview. (CI builds apiv2 fresh, so the new metric serves there.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)