### PR TITLE
test(ripple): per-group content checks are independent across rippled groups

### DIFF
--- a/iznik-batch/tests/Feature/Message/ContentCheckTest.php
+++ b/iznik-batch/tests/Feature/Message/ContentCheckTest.php
@@ -150,6 +150,117 @@ class ContentCheckTest extends TestCase
         $this->assertNull($noMatchGroup2);
     }
 
+    /**
+     * Rippling re-runs the per-group content check on each group a post lands on, so a post that is
+     * clean on its origin group but breaks a rule on a group it RIPPLED INTO is flagged on that
+     * second group only. Guards the rippling x per-group-moderation interaction: a rule violation
+     * that exists on the rippled-into group (but not the origin) must still be caught when the post
+     * rides in. Drives the live processUnprocessed() poll, not just the keyword matcher.
+     */
+    public function test_rippled_post_flagged_on_second_group_whose_rule_it_breaks_not_the_origin(): void
+    {
+        $poster = $this->createTestUser();
+        $origin = $this->createTestGroup();
+        $rippledInto = $this->createTestGroup();
+
+        // A concern keyword scoped to the rippled-into group ONLY - the origin has no such rule.
+        DB::table('concern_keywords')->insert([
+            'keyword'  => 'testripplekw_cc',
+            'category' => 'review',
+            'action'   => 'flag',
+            'scope'    => 'group',
+            'group_id' => $rippledInto->id,
+        ]);
+
+        // Post made on the origin group, carrying the word that only breaks the rippled-into group's
+        // rule. createTestMessage adds the origin's Approved messages_groups row (still unchecked).
+        $message = $this->createTestMessage($poster, $origin, [
+            'subject' => 'OFFER: testripplekw_cc item (TestLocation)',
+        ]);
+
+        // The post rippling into the second group: an Approved, rippled-in, not-yet-content-checked
+        // row with a fresh arrival - exactly what ExpandService::rippleIntoNewGroups inserts.
+        MessageGroup::create([
+            'msgid'      => $message->id,
+            'groupid'    => $rippledInto->id,
+            'collection' => MessageGroup::COLLECTION_APPROVED,
+            'arrival'    => now(),
+            'rippled_in' => 1,
+        ]);
+
+        $this->service->processUnprocessed();
+
+        $originRow = DB::table('messages_groups')
+            ->where('msgid', $message->id)->where('groupid', $origin->id)->first();
+        $rippledRow = DB::table('messages_groups')
+            ->where('msgid', $message->id)->where('groupid', $rippledInto->id)->first();
+
+        // Both rows were content-checked...
+        $this->assertNotNull($originRow->contentcheck_checked_at, 'origin row was content-checked');
+        $this->assertNotNull($rippledRow->contentcheck_checked_at, 'rippled-into row was content-checked');
+
+        // ...but only the rippled-into group, whose rule the post breaks, is flagged.
+        $this->assertNull($originRow->contentcheck_reasons, 'origin group has no matching rule -> not flagged');
+        $this->assertNotNull($rippledRow->contentcheck_reasons, 'rippled-into group rule is caught -> flagged');
+        $this->assertStringContainsString('testripplekw_cc', $rippledRow->contentcheck_reasons);
+    }
+
+    /**
+     * The reverse: a post a HOME group holds for review (its per-group rule keeps it Pending) is
+     * still auto-approved on a group it ripples INTO that has no such rule. Per-group routing is
+     * independent in both directions - a hold on the origin group does not bleed into the rippled
+     * group, and an approval on the rippled group does not override the origin's hold.
+     */
+    public function test_post_held_pending_on_home_group_rule_is_still_approved_on_rippled_into_group(): void
+    {
+        $poster = $this->createTestUser();
+        $home = $this->createTestGroup();
+        $rippledInto = $this->createTestGroup();
+
+        // A flag rule scoped to the HOME group only - it holds matching posts for review there.
+        DB::table('concern_keywords')->insert([
+            'keyword'  => 'testpendkw_cc',
+            'category' => 'review',
+            'action'   => 'flag',
+            'scope'    => 'group',
+            'group_id' => $home->id,
+        ]);
+
+        // Post carries the word. createTestMessage adds the home row Approved; make it Pending so the
+        // content check decides its fate (the natural state of a not-yet-approved post on the home group).
+        $message = $this->createTestMessage($poster, $home, [
+            'subject' => 'OFFER: testpendkw_cc item (TestLocation)',
+        ]);
+        DB::table('messages_groups')
+            ->where('msgid', $message->id)->where('groupid', $home->id)
+            ->update(['collection' => MessageGroup::COLLECTION_PENDING]);
+
+        // The same post rippling into the second group - Approved, rippled-in, not yet checked.
+        MessageGroup::create([
+            'msgid'      => $message->id,
+            'groupid'    => $rippledInto->id,
+            'collection' => MessageGroup::COLLECTION_APPROVED,
+            'arrival'    => now(),
+            'rippled_in' => 1,
+        ]);
+
+        $this->service->processUnprocessed();
+
+        $homeRow = DB::table('messages_groups')
+            ->where('msgid', $message->id)->where('groupid', $home->id)->first();
+        $rippledRow = DB::table('messages_groups')
+            ->where('msgid', $message->id)->where('groupid', $rippledInto->id)->first();
+
+        // The home group's rule holds the post Pending for review there...
+        $this->assertSame(MessageGroup::COLLECTION_PENDING, $homeRow->collection, 'home group rule holds the post Pending');
+        $this->assertNotNull($homeRow->contentcheck_reasons, 'held home post carries its reasons');
+        $this->assertStringContainsString('testpendkw_cc', $homeRow->contentcheck_reasons);
+
+        // ...but on the rippled-into group, which has no such rule, it stays Approved and unflagged.
+        $this->assertSame(MessageGroup::COLLECTION_APPROVED, $rippledRow->collection, 'rippled-into group has no such rule -> stays Approved');
+        $this->assertNull($rippledRow->contentcheck_reasons, 'rippled-into group not flagged');
+    }
+
     public function test_allowed_category_keywords_are_not_flagged(): void
     {
         // 'allowed' is a category (whitelist) in concern_keywords, not an action.


### PR DESCRIPTION
## Why

When a post **ripples** into a new group, the content check is re-run per-group: the rippled-in `messages_groups` row is inserted Approved-but-unchecked (`contentcheck_checked_at IS NULL`, fresh `arrival`), so `ContentCheckService::processUnprocessed` picks it up and runs `checkMessage(msgid, newGroupId)` against **that group's** rules. So a rule violation specific to the rippled-into group does get caught - but this interaction had **no test coverage**. These two feature tests lock it in, in both directions.

## Tests (test-only, no production change)

Both live in `iznik-batch/tests/Feature/Message/ContentCheckTest.php` and drive the live `processUnprocessed()` poll end to end:

1. **`test_rippled_post_flagged_on_second_group_whose_rule_it_breaks_not_the_origin`** - a `concern_keywords` rule scoped to the rippled-into group only; a post clean on its origin lands there via an Approved/`rippled_in=1`/unchecked row. Asserts the post is **flagged on the rippled-into group but not the origin** (both rows are checked; only the one whose rule it breaks carries reasons).

2. **`test_post_held_pending_on_home_group_rule_is_still_approved_on_rippled_into_group`** - the reverse: a flag rule scoped to the **home** group holds the home `messages_groups` row **Pending** for review, while the rippled-into group (no such rule) keeps its row **Approved** and unflagged. Per-group routing is independent the other way too.

## Verification

Full `ContentCheckTest` class green: **160 cases, 0 failures** (the two new tests + no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
