### PR TITLE
Report a chat with no group in common → spam team fallback

### DIFF
--- a/docs/superpowers/plans/2026-06-25-report-chat-no-common-group.md
+++ b/docs/superpowers/plans/2026-06-25-report-chat-no-common-group.md
@@ -1,0 +1,1032 @@
+# Report-a-chat spammer-team fallback — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When a member reports a User2User chat with someone they share no Freegle group with, route the report to the central spam team instead of forcing a community choice; keep the community selector (restricted to genuinely common groups) when a group *is* in common.
+
+**Architecture:** Live path only — Nuxt3 frontend → Go apiv2 → Laravel batch. A new `GET /chat/{id}/commongroups` tells the modal whether a common group exists. A new `ReportNoGroup` action on `POST /chatrooms` queues an `email_chat_spam_report` background task; the batch worker emails the spam team (new `spam_addr` config) with a ModTools link. PHP apiv1 is reference-only and untouched.
+
+**Tech Stack:** Go (fiber, gorm), Laravel (Mailable + background-task worker), Vue 3 (`<script setup>`, bootstrap-vue-next), Go `testing`, PHPUnit, Vitest.
+
+**Spec:** `docs/superpowers/specs/2026-06-25-report-chat-no-common-group-design.md`
+**Discourse:** https://discourse.ilovefreegle.org/t/reporting-chat-with-no-group/9828
+
+---
+
+## Working environment
+
+All work happens in the worktree `/home/edward/FreegleDocker-report-chat-no-group`
+on branch `feature/report-chat-no-common-group`. The escape guard is already
+pointed there (`./freegle switch report-chat-no-group` was run).
+
+**Running tests (project rule: status API only, never direct runners).** From the
+worktree directory, use the helper which reads `PORT_STATUS` from the worktree's
+`./.env`:
+
+```bash
+cd /home/edward/FreegleDocker-report-chat-no-group
+~/.claude/bin/test-wait go --start --timeout 1200       # Go (apiv2)
+~/.claude/bin/test-wait laravel --start --timeout 1200  # batch
+~/.claude/bin/test-wait vitest --start --timeout 1200   # frontend
+```
+
+The worktree status port (e.g. 12150) is shown by `./freegle status`; the curl
+form is `curl -s -X POST http://localhost:<PORT>/api/tests/go` then poll
+`.../api/tests/go/status`. Worktree vitest may need the changed spec/component
+copied into the modtools-dev container before the run — see
+`finding_worktree_hostscripts_escape_and_vitest_runner`.
+
+## File structure
+
+- **Go** `iznik-server-go/`
+  - `chat/chatroom.go` — add `CommonGroup` type, `GetCommonGroups` handler, extend
+    `ChatRoomPostRequest`, add `handleReportNoGroup`, add the dispatcher case.
+  - `router/routes.go` — register `GET /chat/:id/commongroups`.
+  - `test/chat_test.go` — tests for both new pieces.
+- **Batch** `iznik-batch/`
+  - `config/freegle.php` — add `spam_addr`.
+  - `app/Models/BackgroundTask.php` — add `TASK_EMAIL_CHAT_SPAM_REPORT`.
+  - `app/Mail/Chat/ChatSpamReportMail.php` — new Mailable.
+  - `app/Console/Commands/Queue/ProcessBackgroundTasksCommand.php` — import the
+    mail, add dispatch case + `handleEmailChatSpamReport`.
+  - `tests/Unit/Queue/ProcessBackgroundTasksCommandTest.php` — handler test.
+- **Frontend** `iznik-nuxt3/`
+  - `api/ChatAPI.js` — `commonGroups()` + `reportNoGroup()`.
+  - `stores/chat.js` — `commonGroups()` + `reportNoGroup()` actions.
+  - `components/ChatReportModal.vue` — fetch common groups, branch the UI.
+  - `tests/unit/components/ChatReportModal.spec.js` — rewrite for both branches.
+
+---
+
+## Task 1: Go — `GET /chat/{id}/commongroups`
+
+**Files:**
+- Modify: `iznik-server-go/chat/chatroom.go` (add type + handler)
+- Modify: `iznik-server-go/router/routes.go` (register route, after the
+  `rg.Get("/chat/:id/message", chat.GetChatMessages)` line ~291)
+- Test: `iznik-server-go/test/chat_test.go` (append)
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `iznik-server-go/test/chat_test.go`:
+
+```go
+// =============================================================================
+// CommonGroups tests
+// =============================================================================
+
+func TestCommonGroupsShared(t *testing.T) {
+	prefix := uniquePrefix("commongroups")
+	user1ID := CreateTestUser(t, prefix+"_u1", "User")
+	user2ID := CreateTestUser(t, prefix+"_u2", "User")
+	groupID := CreateTestGroup(t, prefix+"_g")
+	CreateTestMembership(t, user1ID, groupID, "Member")
+	CreateTestMembership(t, user2ID, groupID, "Member")
+	chatid := CreateTestChatRoom(t, user1ID, &user2ID, nil, "User2User")
+	_, token := CreateTestSession(t, user1ID)
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET",
+		"/api/chat/"+fmt.Sprint(chatid)+"/commongroups?jwt="+token, nil))
+	assert.Equal(t, 200, resp.StatusCode)
+	var groups []chat.CommonGroup
+	json2.Unmarshal(rsp(resp), &groups)
+	assert.Equal(t, 1, len(groups))
+	assert.Equal(t, groupID, groups[0].ID)
+}
+
+func TestCommonGroupsNone(t *testing.T) {
+	prefix := uniquePrefix("commongroupsnone")
+	user1ID := CreateTestUser(t, prefix+"_u1", "User")
+	user2ID := CreateTestUser(t, prefix+"_u2", "User")
+	g1 := CreateTestGroup(t, prefix+"_g1")
+	g2 := CreateTestGroup(t, prefix+"_g2")
+	CreateTestMembership(t, user1ID, g1, "Member")
+	CreateTestMembership(t, user2ID, g2, "Member")
+	chatid := CreateTestChatRoom(t, user1ID, &user2ID, nil, "User2User")
+	_, token := CreateTestSession(t, user1ID)
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET",
+		"/api/chat/"+fmt.Sprint(chatid)+"/commongroups?jwt="+token, nil))
+	assert.Equal(t, 200, resp.StatusCode)
+	var groups []chat.CommonGroup
+	json2.Unmarshal(rsp(resp), &groups)
+	assert.Equal(t, 0, len(groups))
+}
+
+func TestCommonGroupsNotMember(t *testing.T) {
+	prefix := uniquePrefix("commongroupsnm")
+	user1ID := CreateTestUser(t, prefix+"_u1", "User")
+	user2ID := CreateTestUser(t, prefix+"_u2", "User")
+	outsiderID := CreateTestUser(t, prefix+"_out", "User")
+	chatid := CreateTestChatRoom(t, user1ID, &user2ID, nil, "User2User")
+	_, token := CreateTestSession(t, outsiderID)
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET",
+		"/api/chat/"+fmt.Sprint(chatid)+"/commongroups?jwt="+token, nil))
+	assert.Equal(t, 403, resp.StatusCode)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /home/edward/FreegleDocker-report-chat-no-group && ~/.claude/bin/test-wait go --start --timeout 1200`
+Expected: FAIL — `chat.CommonGroup` undefined / route 404.
+
+- [ ] **Step 3: Add the type and handler in `chat/chatroom.go`**
+
+Add near the other request/response types (e.g. just above `PostChatRoom`):
+
+```go
+// CommonGroup is a group that both participants of a chat belong to.
+type CommonGroup struct {
+	ID          uint64 `json:"id"`
+	Namedisplay string `json:"namedisplay"`
+}
+
+// GetCommonGroups handles GET /chat/{id}/commongroups - the groups the two
+// participants of a chat have in common. The report flow uses this to decide
+// whether to route a report to a community's moderators (a common group exists)
+// or to the central spam team (none). Caller must be a participant.
+func GetCommonGroups(c *fiber.Ctx) error {
+	myid := user.WhoAmI(c)
+	if myid == 0 {
+		return fiber.NewError(fiber.StatusUnauthorized, "Not logged in")
+	}
+
+	id, err := strconv.ParseUint(c.Params("id"), 10, 64)
+	if err != nil || id == 0 {
+		return fiber.NewError(fiber.StatusBadRequest, "Invalid chat ID")
+	}
+
+	db := database.DBConn
+
+	var room struct {
+		ID    uint64
+		User1 uint64
+		User2 uint64
+	}
+	db.Raw("SELECT id, user1, user2 FROM chat_rooms WHERE id = ?", id).Scan(&room)
+	if room.ID == 0 {
+		return fiber.NewError(fiber.StatusNotFound, "Chat not found")
+	}
+	if room.User1 != myid && room.User2 != myid {
+		return fiber.NewError(fiber.StatusForbidden, "Not a member of this chat")
+	}
+
+	groups := []CommonGroup{}
+	db.Raw("SELECT g.id, COALESCE(NULLIF(g.namefull, ''), g.nameshort) AS namedisplay "+
+		"FROM `groups` g "+
+		"INNER JOIN memberships m1 ON m1.groupid = g.id AND m1.userid = ? "+
+		"INNER JOIN memberships m2 ON m2.groupid = g.id AND m2.userid = ? "+
+		"ORDER BY namedisplay",
+		room.User1, room.User2).Scan(&groups)
+
+	return c.JSON(groups)
+}
+```
+
+If `strconv` is not already imported in `chatroom.go`, add it to the import block.
+
+- [ ] **Step 4: Register the route in `router/routes.go`**
+
+Immediately after `rg.Get("/chat/:id/message", chat.GetChatMessages)`:
+
+```go
+		// @Router /chat/{id}/commongroups [get]
+		// @Summary Groups in common between the two chat participants
+		// @Tags chat
+		// @Produce json
+		// @Param id path integer true "Chat ID"
+		// @Success 200 {array} chat.CommonGroup
+		rg.Get("/chat/:id/commongroups", chat.GetCommonGroups)
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd /home/edward/FreegleDocker-report-chat-no-group && ~/.claude/bin/test-wait go --start --timeout 1200`
+Expected: PASS for `TestCommonGroupsShared`, `TestCommonGroupsNone`, `TestCommonGroupsNotMember`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/edward/FreegleDocker-report-chat-no-group
+git add iznik-server-go/chat/chatroom.go iznik-server-go/router/routes.go iznik-server-go/test/chat_test.go
+git commit -m "$(cat <<'EOF'
+feat(chat): GET /chat/{id}/commongroups for the report flow
+
+Returns the groups the two chat participants share, so the report modal can
+decide between community-routed and central-spam-team-routed reports.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01M56vbv9WabnZAkrfmeY4vL
+EOF
+)"
+```
+
+---
+
+## Task 2: Go — `ReportNoGroup` action
+
+**Files:**
+- Modify: `iznik-server-go/chat/chatroom.go` (extend `ChatRoomPostRequest`,
+  add `handleReportNoGroup`, add dispatcher case in `PostChatRoom`)
+- Test: `iznik-server-go/test/chat_test.go` (append)
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `iznik-server-go/test/chat_test.go`:
+
+```go
+// =============================================================================
+// ReportNoGroup tests
+// =============================================================================
+
+func TestReportNoGroup(t *testing.T) {
+	prefix := uniquePrefix("reportnogroup")
+	db := database.DBConn
+	user1ID := CreateTestUser(t, prefix+"_u1", "User")
+	user2ID := CreateTestUser(t, prefix+"_u2", "User")
+	chatid := CreateTestChatRoom(t, user1ID, &user2ID, nil, "User2User")
+	CreateTestChatMessage(t, chatid, user2ID, "Want a girlfriend?")
+	_, token := CreateTestSession(t, user1ID)
+
+	payload := map[string]interface{}{
+		"id": chatid, "action": "ReportNoGroup", "reason": "Spam", "comment": "creepy",
+	}
+	s, _ := json2.Marshal(payload)
+	request := httptest.NewRequest("POST", "/api/chatrooms?jwt="+token, bytes.NewBuffer(s))
+	request.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(request)
+	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+
+	var taskCount int64
+	db.Raw("SELECT COUNT(*) FROM background_tasks WHERE task_type = 'email_chat_spam_report' AND JSON_EXTRACT(data, '$.chatid') = ?", chatid).Scan(&taskCount)
+	assert.Greater(t, taskCount, int64(0))
+}
+
+func TestReportNoGroupRejectedWhenCommonGroup(t *testing.T) {
+	prefix := uniquePrefix("reportnogroupcg")
+	user1ID := CreateTestUser(t, prefix+"_u1", "User")
+	user2ID := CreateTestUser(t, prefix+"_u2", "User")
+	groupID := CreateTestGroup(t, prefix+"_g")
+	CreateTestMembership(t, user1ID, groupID, "Member")
+	CreateTestMembership(t, user2ID, groupID, "Member")
+	chatid := CreateTestChatRoom(t, user1ID, &user2ID, nil, "User2User")
+	_, token := CreateTestSession(t, user1ID)
+
+	payload := map[string]interface{}{"id": chatid, "action": "ReportNoGroup", "reason": "Spam"}
+	s, _ := json2.Marshal(payload)
+	request := httptest.NewRequest("POST", "/api/chatrooms?jwt="+token, bytes.NewBuffer(s))
+	request.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(request)
+	assert.Equal(t, fiber.StatusBadRequest, resp.StatusCode)
+}
+
+func TestReportNoGroupNotMember(t *testing.T) {
+	prefix := uniquePrefix("reportnogroupnm")
+	user1ID := CreateTestUser(t, prefix+"_u1", "User")
+	user2ID := CreateTestUser(t, prefix+"_u2", "User")
+	outsiderID := CreateTestUser(t, prefix+"_out", "User")
+	chatid := CreateTestChatRoom(t, user1ID, &user2ID, nil, "User2User")
+	_, token := CreateTestSession(t, outsiderID)
+
+	payload := map[string]interface{}{"id": chatid, "action": "ReportNoGroup", "reason": "Spam"}
+	s, _ := json2.Marshal(payload)
+	request := httptest.NewRequest("POST", "/api/chatrooms?jwt="+token, bytes.NewBuffer(s))
+	request.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(request)
+	assert.Equal(t, fiber.StatusForbidden, resp.StatusCode)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /home/edward/FreegleDocker-report-chat-no-group && ~/.claude/bin/test-wait go --start --timeout 1200`
+Expected: FAIL — `ReportNoGroup` action falls through to roster update; no task row.
+
+- [ ] **Step 3: Extend the request struct and add the handler in `chat/chatroom.go`**
+
+Add two fields to `ChatRoomPostRequest`:
+
+```go
+type ChatRoomPostRequest struct {
+	ID          uint64 `json:"id"`
+	Action      string `json:"action"`
+	Status      string `json:"status"`
+	Lastmsgseen uint64 `json:"lastmsgseen"`
+	Allowback   bool   `json:"allowback"`
+	Reason      string `json:"reason"`
+	Comment     string `json:"comment"`
+}
+```
+
+Add the handler (next to `handleReferToSupport`):
+
+```go
+// handleReportNoGroup queues a report to the central spam team for a User2User
+// chat whose participants share no Freegle group (so it can't be routed to a
+// community's moderators). The server re-checks "no common group" so a client
+// cannot misuse this to bypass community routing.
+func handleReportNoGroup(c *fiber.Ctx, db *gorm.DB, myid uint64, req ChatRoomPostRequest) error {
+	if req.ID == 0 {
+		return fiber.NewError(fiber.StatusBadRequest, "Chat ID required")
+	}
+	if req.Reason == "" {
+		return fiber.NewError(fiber.StatusBadRequest, "Reason required")
+	}
+
+	var room ChatRoom
+	db.Raw("SELECT id, chattype, user1, user2 FROM chat_rooms WHERE id = ?", req.ID).Scan(&room)
+	if room.ID == 0 {
+		return fiber.NewError(fiber.StatusNotFound, "Chat not found")
+	}
+	if room.User1 != myid && room.User2 != myid {
+		return fiber.NewError(fiber.StatusForbidden, "Not a member of this chat")
+	}
+
+	var common int64
+	db.Raw("SELECT COUNT(*) FROM memberships m1 "+
+		"INNER JOIN memberships m2 ON m1.groupid = m2.groupid "+
+		"WHERE m1.userid = ? AND m2.userid = ?",
+		room.User1, room.User2).Scan(&common)
+	if common > 0 {
+		return fiber.NewError(fiber.StatusBadRequest, "Groups in common exist; use the normal report flow")
+	}
+
+	db.Exec("INSERT INTO background_tasks (task_type, data) VALUES (?, JSON_OBJECT('chatid', ?, 'userid', ?, 'reason', ?, 'comment', ?))",
+		"email_chat_spam_report", req.ID, myid, req.Reason, req.Comment)
+
+	return c.JSON(fiber.Map{"ret": 0, "status": "Success"})
+}
+```
+
+- [ ] **Step 4: Add the dispatcher case in `PostChatRoom`**
+
+In the `switch req.Action` block, after the `ReferToSupport` case:
+
+```go
+	case "ReportNoGroup":
+		return handleReportNoGroup(c, db, myid, req)
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd /home/edward/FreegleDocker-report-chat-no-group && ~/.claude/bin/test-wait go --start --timeout 1200`
+Expected: PASS for the three `TestReportNoGroup*` tests (and Task 1 tests still pass).
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/edward/FreegleDocker-report-chat-no-group
+git add iznik-server-go/chat/chatroom.go iznik-server-go/test/chat_test.go
+git commit -m "$(cat <<'EOF'
+feat(chat): ReportNoGroup action queues a spam-team report
+
+For a User2User chat whose participants share no group, queue an
+email_chat_spam_report background task. Server re-checks there is genuinely no
+common group so the action can't bypass community routing.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01M56vbv9WabnZAkrfmeY4vL
+EOF
+)"
+```
+
+---
+
+## Task 3: Batch — `spam_addr` config
+
+**Files:**
+- Modify: `iznik-batch/config/freegle.php`
+
+- [ ] **Step 1: Add the config entry**
+
+In `iznik-batch/config/freegle.php`, immediately after the `chitchat_support_addr`
+line, add:
+
+```php
+        // Spam team - receives chat reports where the two users share no group.
+        'spam_addr' => env('FREEGLE_SPAM_ADDR', env('FREEGLE_SUPPORT_ADDR', 'support@ilovefreegle.org')),
+```
+
+- [ ] **Step 2: Verify it loads (no dedicated test; covered by Task 4's test which reads the address)**
+
+This entry is exercised end-to-end by the Task 4 handler test (it asserts the mail
+is sent, which requires `config('freegle.mail.spam_addr')` to resolve). No separate
+step.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/edward/FreegleDocker-report-chat-no-group
+git add iznik-batch/config/freegle.php
+git commit -m "$(cat <<'EOF'
+feat(config): add spam_addr for chat-with-no-group reports
+
+Defaults to the support address; production can point FREEGLE_SPAM_ADDR at the
+real spam-team inbox without a code change.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01M56vbv9WabnZAkrfmeY4vL
+EOF
+)"
+```
+
+---
+
+## Task 4: Batch — `ChatSpamReportMail` + background-task handler
+
+**Files:**
+- Create: `iznik-batch/app/Mail/Chat/ChatSpamReportMail.php`
+- Modify: `iznik-batch/app/Models/BackgroundTask.php` (add constant)
+- Modify: `iznik-batch/app/Console/Commands/Queue/ProcessBackgroundTasksCommand.php`
+  (import, dispatch case, handler method)
+- Test: `iznik-batch/tests/Unit/Queue/ProcessBackgroundTasksCommandTest.php` (append)
+
+- [ ] **Step 1: Write the failing test**
+
+Add `use App\Mail\Chat\ChatSpamReportMail;` near the top of
+`ProcessBackgroundTasksCommandTest.php` (beside the existing
+`use App\Mail\Chat\ReferToSupportMail;`), then append this test method to the class:
+
+```php
+    public function test_processes_email_chat_spam_report_task(): void
+    {
+        Mail::fake();
+
+        $reporter = $this->createTestUser(['fullname' => 'Melissa Reporter']);
+        $other = $this->createTestUser(['fullname' => 'Creepy Guy']);
+
+        $chatId = DB::table('chat_rooms')->insertGetId([
+            'chattype' => 'User2User',
+            'user1' => $reporter->id,
+            'user2' => $other->id,
+        ]);
+
+        DB::table('background_tasks')->insert([
+            'task_type' => 'email_chat_spam_report',
+            'data' => json_encode([
+                'chatid' => $chatId,
+                'userid' => $reporter->id,
+                'reason' => 'Spam',
+                'comment' => 'asked me out',
+            ]),
+            'created_at' => now(),
+        ]);
+
+        $this->mock(PushNotificationService::class);
+
+        $this->artisan('queue:background-tasks', ['--max-iterations' => 1, '--sleep' => 0])
+            ->assertSuccessful();
+        $this->artisan('mail:spool:process')->assertSuccessful();
+
+        Mail::assertSent(ChatSpamReportMail::class, function (ChatSpamReportMail $mail) use ($reporter, $other, $chatId) {
+            $this->assertEquals('Melissa Reporter', $mail->reporterName);
+            $this->assertEquals($reporter->id, $mail->reporterId);
+            $this->assertEquals('Creepy Guy', $mail->otherUserName);
+            $this->assertEquals($chatId, $mail->chatId);
+            $this->assertEquals('Spam', $mail->reason);
+            $this->assertEquals('asked me out', $mail->comment);
+            return TRUE;
+        });
+
+        $task = DB::table('background_tasks')->first();
+        $this->assertNotNull($task->processed_at);
+    }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd /home/edward/FreegleDocker-report-chat-no-group && ~/.claude/bin/test-wait laravel --start --timeout 1200`
+Expected: FAIL — `ChatSpamReportMail` class not found / task type unhandled.
+
+- [ ] **Step 3: Create the Mailable**
+
+Create `iznik-batch/app/Mail/Chat/ChatSpamReportMail.php`:
+
+```php
+<?php
+
+namespace App\Mail\Chat;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Address;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Plain text email sent to the central spam team when a user reports a chat with
+ * someone they share no Freegle group with, so it can't be routed to a
+ * community's moderators.
+ *
+ * Discourse: https://discourse.ilovefreegle.org/t/reporting-chat-with-no-group/9828
+ */
+class ChatSpamReportMail extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public function __construct(
+        public readonly string $reporterName,
+        public readonly int $reporterId,
+        public readonly string $otherUserName,
+        public readonly int $otherUserId,
+        public readonly int $chatId,
+        public readonly string $reason,
+        public readonly string $comment,
+    ) {
+    }
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            from: new Address(
+                config('freegle.mail.noreply_addr'),
+                config('freegle.branding.name')
+            ),
+            subject: "{$this->reporterName} (#{$this->reporterId}) reported {$this->otherUserName} (#{$this->otherUserId}) - chat #{$this->chatId} (no group in common)",
+        );
+    }
+
+    public function build(): static
+    {
+        $modSite = config('freegle.sites.mod');
+
+        $lines = [];
+        $lines[] = "This chat was reported, but the two people share no Freegle group, so it can't go to a community's volunteers - it has come to the central spam team.";
+        $lines[] = "";
+        $lines[] = "Reason: {$this->reason}";
+        if ($this->comment !== '') {
+            $lines[] = "Comment: {$this->comment}";
+        }
+        $lines[] = "";
+        $lines[] = "Review the chat at {$modSite}/modtools/support/refer/{$this->chatId}";
+
+        return $this->text('emails.plain.refer-to-support', ['body' => implode("\n", $lines)]);
+    }
+}
+```
+
+(The `emails.plain.refer-to-support` text view is the generic `{{ $body }}`
+wrapper already used by `ReferToSupportMail`.)
+
+- [ ] **Step 4: Add the BackgroundTask constant**
+
+In `iznik-batch/app/Models/BackgroundTask.php`, beside the other `TASK_EMAIL_*`
+constants, add:
+
+```php
+    public const TASK_EMAIL_CHAT_SPAM_REPORT    = 'email_chat_spam_report';
+```
+
+- [ ] **Step 5: Wire the dispatch + handler in `ProcessBackgroundTasksCommand.php`**
+
+Add the import near the top (beside `use App\Mail\Chat\ReferToSupportMail;`):
+
+```php
+use App\Mail\Chat\ChatSpamReportMail;
+```
+
+In the `match ($taskType)` block, after the `TASK_REFER_TO_SUPPORT` line:
+
+```php
+            BackgroundTask::TASK_EMAIL_CHAT_SPAM_REPORT  => $this->handleEmailChatSpamReport($data, $spooler, $shouldSpool),
+```
+
+Add the handler method (next to `handleReferToSupport`):
+
+```php
+    protected function handleEmailChatSpamReport(
+        array $data,
+        EmailSpoolerService $spooler,
+        bool $shouldSpool
+    ): void {
+        $chatId = (int) ($data['chatid'] ?? 0);
+        $userId = (int) ($data['userid'] ?? 0);
+
+        if ($chatId === 0 || $userId === 0) {
+            throw new \RuntimeException('email_chat_spam_report requires chatid and userid');
+        }
+
+        $chat = DB::table('chat_rooms')->where('id', $chatId)->first();
+        if (! $chat) {
+            Log::warning("Chat not found for email_chat_spam_report: {$chatId}");
+            return;
+        }
+
+        $user = User::find($userId);
+        if (! $user) {
+            Log::warning("User not found for email_chat_spam_report: {$userId}");
+            return;
+        }
+
+        $otherUserId = $chat->user1 == $userId ? $chat->user2 : $chat->user1;
+        $otherUser = $otherUserId ? User::find($otherUserId) : null;
+        $otherUserName = $otherUser ? ($otherUser->fullname ?: 'Unknown') : 'Unknown';
+
+        $mail = new ChatSpamReportMail(
+            reporterName: $user->fullname ?: 'Unknown',
+            reporterId: $userId,
+            otherUserName: $otherUserName,
+            otherUserId: (int) ($otherUserId ?? 0),
+            chatId: $chatId,
+            reason: (string) ($data['reason'] ?? ''),
+            comment: (string) ($data['comment'] ?? ''),
+        );
+
+        $recipients = array_map('trim', explode(',', config('freegle.mail.spam_addr')));
+        $spooler->spool($mail, $recipients);
+
+        Log::info('Sent chat spam report email', [
+            'reporter_id' => $userId,
+            'chat_id' => $chatId,
+        ]);
+    }
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `cd /home/edward/FreegleDocker-report-chat-no-group && ~/.claude/bin/test-wait laravel --start --timeout 1200`
+Expected: PASS for `test_processes_email_chat_spam_report_task`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /home/edward/FreegleDocker-report-chat-no-group
+git add iznik-batch/app/Mail/Chat/ChatSpamReportMail.php iznik-batch/app/Models/BackgroundTask.php iznik-batch/app/Console/Commands/Queue/ProcessBackgroundTasksCommand.php iznik-batch/tests/Unit/Queue/ProcessBackgroundTasksCommandTest.php
+git commit -m "$(cat <<'EOF'
+feat(batch): email the spam team for chat reports with no common group
+
+Handle the email_chat_spam_report background task: build ChatSpamReportMail with
+the reason, optional comment, and a ModTools link to the chat, and spool it to
+spam_addr.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01M56vbv9WabnZAkrfmeY4vL
+EOF
+)"
+```
+
+---
+
+## Task 5: Frontend — API + store methods
+
+**Files:**
+- Modify: `iznik-nuxt3/api/ChatAPI.js` (after `referToSupport`)
+- Modify: `iznik-nuxt3/stores/chat.js` (after `report`)
+
+- [ ] **Step 1: Add the API methods in `ChatAPI.js`**
+
+After the `referToSupport(chatid) { ... }` method:
+
+```js
+  commonGroups(chatid) {
+    return this.$getv2('/chat/' + chatid + '/commongroups')
+  }
+
+  reportNoGroup(chatid, reason, comment) {
+    return this.$postv2('/chatrooms', {
+      id: chatid,
+      action: 'ReportNoGroup',
+      reason,
+      comment,
+    })
+  }
+```
+
+- [ ] **Step 2: Add the store actions in `stores/chat.js`**
+
+Immediately after the `report(chatid, reason, comments, refchatid)` action:
+
+```js
+    async commonGroups(chatid) {
+      return await api(this.config).chat.commonGroups(chatid)
+    },
+    async reportNoGroup(chatid, reason, comment) {
+      await api(this.config).chat.reportNoGroup(chatid, reason, comment)
+    },
+```
+
+- [ ] **Step 3: Commit (verified together with the modal in Task 6)**
+
+```bash
+cd /home/edward/FreegleDocker-report-chat-no-group
+git add iznik-nuxt3/api/ChatAPI.js iznik-nuxt3/stores/chat.js
+git commit -m "$(cat <<'EOF'
+feat(chat): commonGroups + reportNoGroup client methods
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01M56vbv9WabnZAkrfmeY4vL
+EOF
+)"
+```
+
+---
+
+## Task 6: Frontend — `ChatReportModal.vue` branches + tests
+
+**Files:**
+- Modify: `iznik-nuxt3/components/ChatReportModal.vue`
+- Test: `iznik-nuxt3/tests/unit/components/ChatReportModal.spec.js` (rewrite)
+
+- [ ] **Step 1: Rewrite the spec for both branches**
+
+Replace the contents of `iznik-nuxt3/tests/unit/components/ChatReportModal.spec.js`:
+
+```js
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { ref } from 'vue'
+import { modalBootstrapStubs } from '../mocks/bootstrap-stubs'
+import ChatReportModal from '~/components/ChatReportModal.vue'
+
+const mockHide = vi.fn()
+vi.mock('~/composables/useOurModal', () => ({
+  useOurModal: () => ({ modal: ref(null), hide: mockHide }),
+}))
+
+const mockOpenChatToMods = vi.fn()
+const mockReport = vi.fn()
+const mockReportNoGroup = vi.fn()
+const mockCommonGroups = vi.fn()
+vi.mock('~/stores/chat', () => ({
+  useChatStore: () => ({
+    openChatToMods: mockOpenChatToMods,
+    report: mockReport,
+    reportNoGroup: mockReportNoGroup,
+    commonGroups: mockCommonGroups,
+  }),
+}))
+
+async function createWrapper(props = {}) {
+  const wrapper = mount(ChatReportModal, {
+    props: { user: { displayname: 'Test User' }, chatid: 123, ...props },
+    global: { stubs: { ...modalBootstrapStubs } },
+  })
+  await flushPromises()
+  return wrapper
+}
+
+describe('ChatReportModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockOpenChatToMods.mockResolvedValue(999)
+    mockCommonGroups.mockResolvedValue([])
+  })
+
+  describe('common group exists', () => {
+    beforeEach(() => {
+      mockCommonGroups.mockResolvedValue([{ id: 1, namedisplay: 'Group 1' }])
+    })
+
+    it('shows the community selector', async () => {
+      const wrapper = await createWrapper()
+      expect(wrapper.text()).toContain('Which community is this about?')
+      expect(wrapper.find('[data-testid="group-select"]').exists()).toBe(true)
+    })
+
+    it('routes the report to the community mods', async () => {
+      const wrapper = await createWrapper()
+      await wrapper.find('[data-testid="reason-select"]').setValue('Spam')
+      await wrapper.find('textarea').setValue('creepy')
+      const sendBtn = wrapper
+        .findAll('button')
+        .find((b) => b.text().includes('Send Report'))
+      await sendBtn.trigger('click')
+      await flushPromises()
+      expect(mockOpenChatToMods).toHaveBeenCalledWith(1)
+      expect(mockReport).toHaveBeenCalled()
+      expect(mockReportNoGroup).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('no common group (spam-team fallback)', () => {
+    it('hides the selector and shows the central-volunteers note', async () => {
+      const wrapper = await createWrapper()
+      expect(wrapper.text()).not.toContain('Which community is this about?')
+      expect(wrapper.text()).toContain('central volunteers')
+      expect(wrapper.find('[data-testid="group-select"]').exists()).toBe(false)
+    })
+
+    it('routes the report to the spam team with an optional empty comment', async () => {
+      const wrapper = await createWrapper()
+      await wrapper.find('[data-testid="reason-select"]').setValue('Spam')
+      const sendBtn = wrapper
+        .findAll('button')
+        .find((b) => b.text().includes('Send Report'))
+      await sendBtn.trigger('click')
+      await flushPromises()
+      expect(mockReportNoGroup).toHaveBeenCalledWith(123, 'Spam', '')
+      expect(mockOpenChatToMods).not.toHaveBeenCalled()
+    })
+
+    it('does not send without a reason', async () => {
+      const wrapper = await createWrapper()
+      const sendBtn = wrapper
+        .findAll('button')
+        .find((b) => b.text().includes('Send Report'))
+      await sendBtn.trigger('click')
+      await flushPromises()
+      expect(mockReportNoGroup).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('close action', () => {
+    it('calls hide when Close is clicked', async () => {
+      const wrapper = await createWrapper()
+      const closeBtn = wrapper
+        .findAll('button')
+        .find((b) => b.text().includes('Close'))
+      await closeBtn.trigger('click')
+      expect(mockHide).toHaveBeenCalled()
+    })
+  })
+})
+```
+
+- [ ] **Step 2: Run the spec to verify it fails**
+
+Run: `cd /home/edward/FreegleDocker-report-chat-no-group && ~/.claude/bin/test-wait vitest --start --timeout 1200`
+Expected: FAIL — modal still renders `GroupSelect`, has no `reason-select` testid,
+calls neither `commonGroups` nor `reportNoGroup`. (If the worktree runner can't see
+the changed files, `docker cp` the component + spec into the modtools-dev container
+first per `finding_worktree_hostscripts_escape_and_vitest_runner`.)
+
+- [ ] **Step 3: Rewrite the component**
+
+Replace the contents of `iznik-nuxt3/components/ChatReportModal.vue`:
+
+```vue
+<template>
+  <b-modal
+    ref="modal"
+    scrollable
+    title="Oh dear..."
+    size="lg"
+    no-stacking
+    modal-class="confirm-modal"
+  >
+    <template #default>
+      <b-row>
+        <b-col>
+          <p>Sorry you're having trouble.</p>
+          <div v-if="loading" class="text-center my-3">
+            <b-spinner />
+          </div>
+          <template v-else>
+            <template v-if="commonGroups.length">
+              <h4>Which community is this about?</h4>
+              <b-form-select
+                v-model="groupid"
+                class="mt-1 mb-1"
+                data-testid="group-select"
+              >
+                <option :value="null">-- Please choose --</option>
+                <option v-for="g in commonGroups" :key="g.id" :value="g.id">
+                  {{ g.namedisplay }}
+                </option>
+              </b-form-select>
+            </template>
+            <p v-else class="text-muted">
+              We'll pass this to our central volunteers who deal with this kind of
+              thing.
+            </p>
+            <h4>Why are you reporting this?</h4>
+            <b-form-select
+              v-model="reason"
+              class="mt-1 mb-1"
+              data-testid="reason-select"
+            >
+              <option :value="null">-- Please choose --</option>
+              <option value="Spam">It's Spam</option>
+              <option value="Other">Something else</option>
+            </b-form-select>
+            <h4>What's wrong?</h4>
+            <b-form-textarea
+              v-model="comments"
+              placeholder="Please tell us what's wrong.  This will go to our lovely volunteers, who will try to help you."
+            />
+          </template>
+        </b-col>
+      </b-row>
+    </template>
+    <template #footer>
+      <b-button variant="white" @click="hide"> Close </b-button>
+      <b-button variant="primary" :disabled="loading" @click="send">
+        Send Report
+      </b-button>
+    </template>
+  </b-modal>
+</template>
+<script setup>
+import { ref, onMounted } from 'vue'
+import { useChatStore } from '~/stores/chat'
+import { useOurModal } from '~/composables/useOurModal'
+
+const props = defineProps({
+  user: {
+    type: Object,
+    required: true,
+  },
+  chatid: {
+    type: Number,
+    required: true,
+  },
+})
+
+const chatStore = useChatStore()
+const { modal, hide } = useOurModal()
+
+const groupid = ref(null)
+const reason = ref(null)
+const comments = ref(null)
+const commonGroups = ref([])
+const loading = ref(true)
+
+onMounted(async () => {
+  try {
+    const groups = await chatStore.commonGroups(props.chatid)
+    commonGroups.value = Array.isArray(groups) ? groups : []
+    if (commonGroups.value.length === 1) {
+      groupid.value = commonGroups.value[0].id
+    }
+  } catch (e) {
+    commonGroups.value = []
+  } finally {
+    loading.value = false
+  }
+})
+
+async function send() {
+  if (!reason.value) {
+    return
+  }
+
+  if (commonGroups.value.length) {
+    // Route to the chosen community's moderators (existing flow).
+    if (!groupid.value || !comments.value) {
+      return
+    }
+    const chatid = await chatStore.openChatToMods(groupid.value)
+    await chatStore.report(chatid, reason.value, comments.value, props.chatid)
+  } else {
+    // No group in common: route to the central spam team. Comment optional.
+    await chatStore.reportNoGroup(props.chatid, reason.value, comments.value || '')
+  }
+
+  hide()
+}
+</script>
+```
+
+- [ ] **Step 4: Run the spec to verify it passes**
+
+Run: `cd /home/edward/FreegleDocker-report-chat-no-group && ~/.claude/bin/test-wait vitest --start --timeout 1200`
+Expected: PASS for all `ChatReportModal` cases.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/edward/FreegleDocker-report-chat-no-group
+git add iznik-nuxt3/components/ChatReportModal.vue iznik-nuxt3/tests/unit/components/ChatReportModal.spec.js
+git commit -m "$(cat <<'EOF'
+feat(chat): spammer-team fallback in the report modal
+
+Fetch groups in common on open: keep the community selector (restricted to the
+genuinely common groups) when one exists; otherwise hide it and route the report
+to the central spam team with a simple click. Fixes the silent no-op when no
+group was selectable.
+
+Discourse: https://discourse.ilovefreegle.org/t/reporting-chat-with-no-group/9828
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01M56vbv9WabnZAkrfmeY4vL
+EOF
+)"
+```
+
+---
+
+## Final verification
+
+- [ ] Run the three suites green from the worktree:
+  `~/.claude/bin/test-wait go --start --timeout 1200`,
+  `~/.claude/bin/test-wait laravel --start --timeout 1200`,
+  `~/.claude/bin/test-wait vitest --start --timeout 1200`.
+- [ ] Manually sanity-check in the worktree browser (URL from `./freegle status`,
+  Chrome MCP `isolatedContext: "report-chat-no-group"`): open a User2User chat with
+  someone in no common group, click Report — no community dropdown, simple submit;
+  open one with a common group — dropdown present, lists only common groups.
+- [ ] Push the branch and open a PR (allowed once all suites pass locally). PR body
+  must embed the Discourse link. Do **not** merge.
+
+## Spec coverage check
+
+- "Fallback to spam team when no common group" → Tasks 2, 4, 6.
+- "Community selector stays when a group is in common" → Task 6 (common-group branch).
+- "No destination choice / simple click / note for the team" → Task 4 (server-built
+  note in the mail), Task 6 (no selector, comment optional).
+- "Fix the silent no-op" → Task 6 `send()`.
+- "Restrict dropdown to genuinely common groups" → Tasks 1 + 6.
+- "Email delivery reusing ReferToSupport pattern; config address" → Tasks 3, 4.
+- apiv1 explicitly not modified → noted in spec; no task.

--- a/docs/superpowers/specs/2026-06-25-report-chat-no-common-group-design.md
+++ b/docs/superpowers/specs/2026-06-25-report-chat-no-common-group-design.md
@@ -1,0 +1,192 @@
+# Reporting a chat when there's no group in common
+
+- **Date:** 2026-06-25
+- **Discourse:** https://discourse.ilovefreegle.org/t/reporting-chat-with-no-group/9828
+- **Branch:** `feature/report-chat-no-common-group`
+
+## Problem
+
+A member (Melissa) received unwanted direct messages from people she met via
+ChitChat (the central newsfeed), not via a Freegle group. When she tries to
+**Report** the chat, the report modal forces her to pick a community ("Which
+community is this about?"). Because the other person shares no group with her,
+there is no correct community to choose, so she cannot report at all.
+
+There are two faults today:
+
+1. **No fallback.** If there is no group in common, the report cannot be sent.
+   The submit handler silently does nothing when no group is selected
+   (`ChatReportModal.vue` `send()` guards on `groupid.value && ...`).
+2. **Latent misrouting.** The dropdown is populated from the **reporter's own**
+   group memberships (`GroupSelect` defaults `allMy: true`), *not* the groups the
+   two participants have in common. So even when it "works" the reporter can pick
+   a community the other person isn't in, and the report lands with mods who have
+   no context.
+
+## Goals
+
+- When the two participants **share a group**, keep today's behaviour: the report
+  goes to that community's moderators. The community selector stays.
+- When they **share no group**, provide a fallback: the report goes to the central
+  **spam team**, with no community selector and no choice of destination for the
+  reporter — a simple click. A note is added so the spam team understands why the
+  report reached them.
+- Fix the silent no-op so the report button always does something.
+
+## Non-goals
+
+- No change to how mods review group-routed chat reports.
+- Not auto-nominating the reported user into the `spam_users` queue. The spam team
+  decides that after reviewing — the fallback only *delivers the report to them*.
+- No redesign of `GroupSelect` beyond restricting its options for this modal.
+
+## Current behaviour (references)
+
+- **Modal:** `iznik-nuxt3/components/ChatReportModal.vue` — `GroupSelect`, reason
+  (`Spam`/`Other`), free-text comment. `send()` requires
+  `groupid && reason && comments`, then `chatStore.openChatToMods(groupid)` →
+  `chatStore.report(chatid, reason, comments, refchatid)`.
+- **Invocation:** `iznik-nuxt3/components/ChatHeader.vue` (~242-302) — Report
+  button only for `chattype === 'User2User'`; passes `:user="otheruser"` and
+  `:chatid="chat.id"`.
+- **Report submit:** `chatStore.report()` → `POST /chat/{roomid}/message` with
+  `reportreason` + `refchatid`. `openChatToMods()` → `PUT /chat/rooms`
+  (`chattype: User2Mod`, `groupid`).
+- **Go API:** `chat.CreateChatMessage` (`iznik-server-go/chat/chatmessage.go`
+  ~338) sets `CHAT_MESSAGE_REPORTEDUSER` when `refchatid` is present;
+  `chat.PutChatRoom` (`chatroom.go` ~406-431) opens the User2Mod room and adds the
+  group's mods to the roster.
+- **Mutual-membership SQL** already exists in `canSeeChatRoom`
+  (`chatmessage.go` ~782-792): `memberships m1 JOIN memberships m2 ON
+  m1.groupid = m2.groupid WHERE m1.userid = ? AND m2.userid IN (?, ?)`.
+- **Precedents for central/email routing:**
+  - `ReferToSupport` (`chatroom.go handleReferToSupport` ~1459) queues a
+    `refer_to_support` background task → `iznik-batch` `ReferToSupportMail` →
+    `support_addr`, with a `/modtools/support/refer/{chatid}` link. Currently a
+    mod-only action, not wired to the user Report button.
+  - Newsfeed `Report` (`newsfeed/newsfeed.go` ~970) queues
+    `email_chitchat_report` → `ChitchatReportMail` → `chitchat_support_addr`.
+- **The spam team:** `SpamAdmin` permission (granted via the `teams` table) gates
+  the `/modtools/spammers` queue (`spammers/spammers.go`, `session.go` ~1195).
+
+## Design
+
+### Routing decision
+
+The report routes by whether the two participants share a group:
+
+- **≥1 common group** → existing User2Mod report to that community's mods.
+- **0 common groups** → fallback: email the spam team.
+
+The decision needs data the frontend does not currently have (the other user's
+memberships), so a small backend lookup supplies it.
+
+### Frontend — `ChatReportModal.vue`
+
+- On open, call `GET /chat/{chatid}/commongroups`.
+- **Common groups returned:** render "Which community is this about?" with
+  `GroupSelect` **restricted to those groups** (pass them in; preselect if exactly
+  one). Submit via the existing `openChatToMods` → `report` flow. (This also fixes
+  the misrouting fault.)
+- **No common groups:** hide the community selector. Show one reassuring line,
+  e.g. *"We'll pass this to our central volunteers who deal with this kind of
+  thing."* Submit via the fallback route (below). The explanatory note for the
+  spam team is added **server-side** when the email is built (so it's
+  authoritative and can't be edited away by the client), not typed by the user —
+  e.g. *"No Freegle group in common — reported to the central spam team."*
+- Submit guard fixed: require `reason` (+ comment when present), never silently
+  no-op. The free-text **comment is optional in the fallback** (simple click);
+  the **reason** selector stays (one click, useful triage signal for the team).
+
+### Backend — Go `apiv2` (`iznik-server-go`)
+
+1. **`GET /chat/{id}/commongroups`** → `[{ id, namedisplay }]`.
+   - Caller must be a participant of chat `{id}` (user1 or user2); else 403.
+   - Query the groups in common between the two participants (reuse the
+     mutual-membership pattern, returning the group rows not just a count).
+2. **Fallback report path.** A new action that, for a no-common-group report,
+   queues a background task to email the spam team. Mirrors
+   `handleReferToSupport`: insert into `background_tasks` with task type
+   `email_chat_spam_report` carrying `chatid`, reporter `userid`, `reason`,
+   `comment`. Validate the caller is a participant and that there is genuinely no
+   common group (server re-checks; the client decision is not trusted).
+
+   Shape: extend the existing `POST /chatrooms` action set (where
+   `ReferToSupport` already lives) with a `ReportNoGroup` action carrying
+   `reason` + `comment`, OR add a focused endpoint. Decision: **add a
+   `ReportNoGroup` action to `POST /chatrooms`** for consistency with the
+   sibling `ReferToSupport` action.
+
+### Backend — PHP `apiv1` (`iznik-server`)
+
+Parity for both the `commongroups` read and the fallback action, matching the
+existing `chatmessages.php` / `ChatRoom.php` `referToSupport` structure, so the
+two APIs stay equivalent.
+
+### Batch — `iznik-batch`
+
+- New `BackgroundTask` constant `TASK_EMAIL_CHAT_SPAM_REPORT =
+  'email_chat_spam_report'` (`app/Models/BackgroundTask.php`).
+- Handler in `ProcessBackgroundTasksCommand` (modelled on `handleReferToSupport`):
+  load chat + reporter + other user, build the mail, spool to the spam team.
+- New Mailable `App\Mail\Chat\ChatSpamReportMail` (modelled on
+  `ReferToSupportMail`): subject identifies reporter, other user, chat id and that
+  there is no common group; body carries the reason, the optional comment, the
+  auto-note, and a `{mod_site}/modtools/...` link to the chat so the team can view
+  it, ban, or add the user to the spammers queue.
+
+### Config
+
+- Add `spam_addr` to `iznik-batch/config/freegle.php`:
+  `'spam_addr' => env('FREEGLE_SPAM_ADDR', env('FREEGLE_SUPPORT_ADDR', 'support@ilovefreegle.org'))`.
+  Defaults to the support address so production can point it at the real spam-team
+  inbox via the `FREEGLE_SPAM_ADDR` env var without a code change. Document it
+  alongside the other `_addr` entries.
+
+## Data flow (no-common-group case)
+
+1. User clicks **Report** on a User2User chat (ChatHeader).
+2. Modal opens → `GET /chat/{id}/commongroups` → `[]`.
+3. Modal hides the selector; user picks a reason, optionally types a comment,
+   clicks Send.
+4. `POST /chatrooms` `{ id, action: 'ReportNoGroup', reason, comment }`.
+5. Go re-verifies participant + no-common-group, inserts
+   `background_tasks(email_chat_spam_report, {chatid, userid, reason, comment})`.
+6. Batch task runs → `ChatSpamReportMail` → spam team inbox, with chat link.
+
+## Error handling
+
+- `commongroups` for a non-participant → 403; for an unknown chat → 404.
+- `ReportNoGroup` when a common group actually exists → reject (the client should
+  have used the normal flow); the server re-checks rather than trusting the client.
+- Missing reporter/chat in the batch handler → log a warning and skip (parity with
+  `handleReferToSupport`).
+- Empty `commongroups` response must not break the modal — it simply renders the
+  fallback variant.
+
+## Testing (TDD)
+
+- **Go** (`iznik-server-go/test`): `commongroups` returns shared groups when they
+  exist and `[]` when none; rejects non-participants. `ReportNoGroup` enqueues the
+  background task for a genuinely group-less chat and rejects when a common group
+  exists or the caller isn't a participant.
+- **Batch** (`iznik-batch/tests`): the `email_chat_spam_report` handler builds
+  `ChatSpamReportMail` and spools it to `spam_addr`; subject/body contain the
+  reason, note, and chat link; missing-data cases are handled.
+- **Vitest** (`iznik-nuxt3`): the modal shows the community selector when
+  `commongroups` is non-empty and hides it (and submits via the fallback) when
+  empty; the submit button is never a silent no-op.
+
+## Decisions made
+
+- **Fallback only.** Community selector stays whenever a group is in common; the
+  spam-team route is purely the no-common-group fallback. (Per product owner.)
+- **Reporter has no destination choice.** No spam-team option is ever shown; the
+  server decides. (Per product owner: "they just need a simple click, don't care
+  about destination".)
+- **Reason kept, comment optional in fallback.** One-click reason is a cheap,
+  useful triage signal; free text is optional to keep it simple.
+- **Restrict the dropdown to genuinely common groups** (not all the reporter's
+  groups), fixing the latent misrouting fault while we're here.
+- **Email delivery to the spam team**, reusing the `ReferToSupport` pattern rather
+  than inventing new infrastructure; destination is a config address.

--- a/docs/superpowers/specs/2026-06-25-report-chat-no-common-group-design.md
+++ b/docs/superpowers/specs/2026-06-25-report-chat-no-common-group-design.md
@@ -119,9 +119,9 @@ memberships), so a small backend lookup supplies it.
 
 ### Backend — PHP `apiv1` (`iznik-server`)
 
-Parity for both the `commongroups` read and the fallback action, matching the
-existing `chatmessages.php` / `ChatRoom.php` `referToSupport` structure, so the
-two APIs stay equivalent.
+Not modified. The live frontend calls apiv2 (Go) exclusively for chat
+(`$getv2`/`$postv2`/`$putv2`); apiv1 is reference-only and not in use, so adding
+parity there would be wasted effort.
 
 ### Batch — `iznik-batch`
 

--- a/iznik-batch/app/Console/Commands/Queue/ProcessBackgroundTasksCommand.php
+++ b/iznik-batch/app/Console/Commands/Queue/ProcessBackgroundTasksCommand.php
@@ -4,6 +4,7 @@ namespace App\Console\Commands\Queue;
 
 use App\Console\Concerns\PreventsOverlapping;
 use App\Mail\Charity\CharitySignupMail;
+use App\Mail\Chat\ChatSpamReportMail;
 use App\Mail\Chat\ReferToSupportMail;
 use App\Mail\Donation\DonateExternalMail;
 use App\Mail\Newsfeed\ChitchatReportMail;
@@ -219,6 +220,7 @@ class ProcessBackgroundTasksCommand extends Command
             BackgroundTask::TASK_PUSH_NOTIFY_CHAT_MESSAGE => $this->handlePushNotifyChatMessage($data, $pushService),
             BackgroundTask::TASK_PUSH_NOTIFY_GROUP_MODS  => $this->handlePushNotifyGroupMods($data, $pushService),
             BackgroundTask::TASK_EMAIL_CHITCHAT_REPORT   => $this->handleEmailChitchatReport($data, $spooler, $shouldSpool),
+            BackgroundTask::TASK_EMAIL_CHAT_SPAM_REPORT  => $this->handleEmailChatSpamReport($data, $spooler, $shouldSpool),
             BackgroundTask::TASK_EMAIL_CHARITY_SIGNUP    => $this->handleEmailCharitySignup($data, $spooler, $shouldSpool),
             BackgroundTask::TASK_EMAIL_DONATE_EXTERNAL   => $this->handleEmailDonateExternal($data, $spooler, $shouldSpool),
             BackgroundTask::TASK_EMAIL_FORGOT_PASSWORD   => $this->handleEmailForgotPassword($data, $spooler, $shouldSpool),
@@ -1079,6 +1081,57 @@ class ProcessBackgroundTasksCommand extends Command
         Log::info('Sent refer to support email', [
             'chat_id' => $chatId,
             'user_id' => $userId,
+        ]);
+    }
+
+    /**
+     * Email the central spam team when a user reports a chat with someone they
+     * share no Freegle group with (so it can't be routed to a community's mods).
+     */
+    protected function handleEmailChatSpamReport(
+        array $data,
+        EmailSpoolerService $spooler,
+        bool $shouldSpool
+    ): void {
+        $chatId = (int) ($data['chatid'] ?? 0);
+        $userId = (int) ($data['userid'] ?? 0);
+
+        if ($chatId === 0 || $userId === 0) {
+            throw new \RuntimeException('email_chat_spam_report requires chatid and userid');
+        }
+
+        $chat = DB::table('chat_rooms')->where('id', $chatId)->first();
+        if (! $chat) {
+            Log::warning("Chat not found for email_chat_spam_report: {$chatId}");
+            return;
+        }
+
+        $user = User::find($userId);
+        if (! $user) {
+            Log::warning("User not found for email_chat_spam_report: {$userId}");
+            return;
+        }
+
+        $otherUserId = $chat->user1 == $userId ? $chat->user2 : $chat->user1;
+        $otherUser = $otherUserId ? User::find($otherUserId) : null;
+        $otherUserName = $otherUser ? ($otherUser->fullname ?: 'Unknown') : 'Unknown';
+
+        $mail = new ChatSpamReportMail(
+            reporterName: $user->fullname ?: 'Unknown',
+            reporterId: $userId,
+            otherUserName: $otherUserName,
+            otherUserId: (int) ($otherUserId ?? 0),
+            chatId: $chatId,
+            reason: (string) ($data['reason'] ?? ''),
+            comment: (string) ($data['comment'] ?? ''),
+        );
+
+        $recipients = array_map('trim', explode(',', config('freegle.mail.spam_addr')));
+        $spooler->spool($mail, $recipients);
+
+        Log::info('Sent chat spam report email', [
+            'reporter_id' => $userId,
+            'chat_id' => $chatId,
         ]);
     }
 

--- a/iznik-batch/app/Mail/Chat/ChatSpamReportMail.php
+++ b/iznik-batch/app/Mail/Chat/ChatSpamReportMail.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Mail\Chat;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Address;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Plain text email sent to the central spam team when a user reports a chat with
+ * someone they share no Freegle group with, so it can't be routed to a
+ * community's moderators.
+ *
+ * Discourse: https://discourse.ilovefreegle.org/t/reporting-chat-with-no-group/9828
+ */
+class ChatSpamReportMail extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public function __construct(
+        public readonly string $reporterName,
+        public readonly int $reporterId,
+        public readonly string $otherUserName,
+        public readonly int $otherUserId,
+        public readonly int $chatId,
+        public readonly string $reason,
+        public readonly string $comment,
+    ) {
+    }
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            from: new Address(
+                config('freegle.mail.noreply_addr'),
+                config('freegle.branding.name')
+            ),
+            subject: "{$this->reporterName} (#{$this->reporterId}) reported {$this->otherUserName} (#{$this->otherUserId}) - chat #{$this->chatId} (no group in common)",
+        );
+    }
+
+    public function build(): static
+    {
+        $modSite = config('freegle.sites.mod');
+
+        $lines = [];
+        $lines[] = "This chat was reported, but the two people share no Freegle group, so it can't go to a community's volunteers - it has come to the central spam team.";
+        $lines[] = "";
+        $lines[] = "Reason: {$this->reason}";
+        if ($this->comment !== '') {
+            $lines[] = "Comment: {$this->comment}";
+        }
+        $lines[] = "";
+        $lines[] = "Review the chat at {$modSite}/modtools/support/refer/{$this->chatId}";
+
+        return $this->text('emails.plain.refer-to-support', ['body' => implode("\n", $lines)]);
+    }
+}

--- a/iznik-batch/app/Models/BackgroundTask.php
+++ b/iznik-batch/app/Models/BackgroundTask.php
@@ -30,6 +30,7 @@ class BackgroundTask extends Model
     // Task types produced by the Go API and consumed by the PHP batch processor.
     // Keep in sync with the Go API (iznik-server-go).
     public const TASK_EMAIL_CHARITY_SIGNUP      = 'email_charity_signup';
+    public const TASK_EMAIL_CHAT_SPAM_REPORT    = 'email_chat_spam_report';
     public const TASK_EMAIL_CHITCHAT_REPORT     = 'email_chitchat_report';
     public const TASK_EMAIL_DONATE_EXTERNAL     = 'email_donate_external';
     public const TASK_EMAIL_FORGOT_PASSWORD     = 'email_forgot_password';

--- a/iznik-batch/config/freegle.php
+++ b/iznik-batch/config/freegle.php
@@ -81,6 +81,8 @@ return [
         'support_addr' => env('FREEGLE_SUPPORT_ADDR', 'support@ilovefreegle.org'),
         // ChitChat support - receives newsfeed report emails.
         'chitchat_support_addr' => env('FREEGLE_CHITCHAT_SUPPORT_ADDR', 'support@ilovefreegle.org'),
+        // Spam team - receives chat reports where the two users share no group.
+        'spam_addr' => env('FREEGLE_SPAM_ADDR', env('FREEGLE_SUPPORT_ADDR', 'support@ilovefreegle.org')),
         // Partnerships address for charity partner signups.
         'partnerships_addr' => env('FREEGLE_PARTNERSHIPS_ADDR', 'partnerships@ilovefreegle.org'),
         // Info address for donation notifications and general admin emails.

--- a/iznik-batch/tests/Unit/Queue/ProcessBackgroundTasksCommandTest.php
+++ b/iznik-batch/tests/Unit/Queue/ProcessBackgroundTasksCommandTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Queue;
 
+use App\Mail\Chat\ChatSpamReportMail;
 use App\Mail\Chat\ReferToSupportMail;
 use App\Mail\Donation\DonateExternalMail;
 use App\Mail\Newsfeed\ChitchatReportMail;
@@ -1686,6 +1687,50 @@ class ProcessBackgroundTasksCommandTest extends TestCase
             $this->assertEquals('Alice Mod', $mail->userName);
             $this->assertEquals($user->id, $mail->userId);
             $this->assertEquals($chatId, $mail->chatId);
+            return TRUE;
+        });
+
+        $task = DB::table('background_tasks')->first();
+        $this->assertNotNull($task->processed_at);
+    }
+
+    public function test_processes_email_chat_spam_report_task(): void
+    {
+        Mail::fake();
+
+        $reporter = $this->createTestUser(['fullname' => 'Melissa Reporter']);
+        $other = $this->createTestUser(['fullname' => 'Creepy Guy']);
+
+        $chatId = DB::table('chat_rooms')->insertGetId([
+            'chattype' => 'User2User',
+            'user1' => $reporter->id,
+            'user2' => $other->id,
+        ]);
+
+        DB::table('background_tasks')->insert([
+            'task_type' => 'email_chat_spam_report',
+            'data' => json_encode([
+                'chatid' => $chatId,
+                'userid' => $reporter->id,
+                'reason' => 'Spam',
+                'comment' => 'asked me out',
+            ]),
+            'created_at' => now(),
+        ]);
+
+        $this->mock(PushNotificationService::class);
+
+        $this->artisan('queue:background-tasks', ['--max-iterations' => 1, '--sleep' => 0])
+            ->assertSuccessful();
+        $this->artisan('mail:spool:process')->assertSuccessful();
+
+        Mail::assertSent(ChatSpamReportMail::class, function (ChatSpamReportMail $mail) use ($reporter, $other, $chatId) {
+            $this->assertEquals('Melissa Reporter', $mail->reporterName);
+            $this->assertEquals($reporter->id, $mail->reporterId);
+            $this->assertEquals('Creepy Guy', $mail->otherUserName);
+            $this->assertEquals($chatId, $mail->chatId);
+            $this->assertEquals('Spam', $mail->reason);
+            $this->assertEquals('asked me out', $mail->comment);
             return TRUE;
         });
 

--- a/iznik-batch/tests/Unit/Queue/ProcessBackgroundTasksCommandTest.php
+++ b/iznik-batch/tests/Unit/Queue/ProcessBackgroundTasksCommandTest.php
@@ -1738,6 +1738,69 @@ class ProcessBackgroundTasksCommandTest extends TestCase
         $this->assertNotNull($task->processed_at);
     }
 
+    public function test_email_chat_spam_report_sends_without_a_comment(): void
+    {
+        Mail::fake();
+
+        $reporter = $this->createTestUser(['fullname' => 'Melissa Reporter']);
+        $other = $this->createTestUser(['fullname' => 'Creepy Guy']);
+
+        $chatId = DB::table('chat_rooms')->insertGetId([
+            'chattype' => 'User2User',
+            'user1' => $reporter->id,
+            'user2' => $other->id,
+        ]);
+
+        DB::table('background_tasks')->insert([
+            'task_type' => 'email_chat_spam_report',
+            'data' => json_encode([
+                'chatid' => $chatId,
+                'userid' => $reporter->id,
+                'reason' => 'Other',
+                'comment' => '',
+            ]),
+            'created_at' => now(),
+        ]);
+
+        $this->mock(PushNotificationService::class);
+
+        $this->artisan('queue:background-tasks', ['--max-iterations' => 1, '--sleep' => 0])
+            ->assertSuccessful();
+        $this->artisan('mail:spool:process')->assertSuccessful();
+
+        Mail::assertSent(ChatSpamReportMail::class, function (ChatSpamReportMail $mail) {
+            $this->assertEquals('', $mail->comment);
+            $this->assertEquals('Other', $mail->reason);
+            return TRUE;
+        });
+    }
+
+    public function test_email_chat_spam_report_skips_when_chat_missing(): void
+    {
+        Mail::fake();
+
+        $reporter = $this->createTestUser();
+
+        DB::table('background_tasks')->insert([
+            'task_type' => 'email_chat_spam_report',
+            'data' => json_encode([
+                'chatid' => 99999999,
+                'userid' => $reporter->id,
+                'reason' => 'Spam',
+                'comment' => '',
+            ]),
+            'created_at' => now(),
+        ]);
+
+        $this->mock(PushNotificationService::class);
+
+        $this->artisan('queue:background-tasks', ['--max-iterations' => 1, '--sleep' => 0])
+            ->assertSuccessful();
+        $this->artisan('mail:spool:process')->assertSuccessful();
+
+        Mail::assertNotSent(ChatSpamReportMail::class);
+    }
+
     public function test_email_verify_sends_verification_email(): void
     {
         Mail::fake();

--- a/iznik-nuxt3/api/ChatAPI.js
+++ b/iznik-nuxt3/api/ChatAPI.js
@@ -102,4 +102,17 @@ export default class ChatAPI extends BaseAPI {
   referToSupport(chatid) {
     return this.$postv2('/chatrooms', { id: chatid, action: 'ReferToSupport' })
   }
+
+  commonGroups(chatid) {
+    return this.$getv2('/chat/' + chatid + '/commongroups')
+  }
+
+  reportNoGroup(chatid, reason, comment) {
+    return this.$postv2('/chatrooms', {
+      id: chatid,
+      action: 'ReportNoGroup',
+      reason,
+      comment,
+    })
+  }
 }

--- a/iznik-nuxt3/components/ChatReportModal.vue
+++ b/iznik-nuxt3/components/ChatReportModal.vue
@@ -11,31 +11,56 @@
       <b-row>
         <b-col>
           <p>Sorry you're having trouble.</p>
-          <h4>Which community is this about?</h4>
-          <GroupSelect v-model="groupid" class="mt-1 mb-1" />
-          <h4>Why are you reporting this?</h4>
-          <b-form-select v-model="reason" class="mt-1 mb-1">
-            <option value="null">-- Please choose --</option>
-            <option value="Spam">It's Spam</option>
-            <option value="Other">Something else</option>
-          </b-form-select>
-          <h4>What's wrong?</h4>
-          <b-form-textarea
-            v-model="comments"
-            placeholder="Please tell us what's wrong.  This will go to our lovely volunteers, who will try to help you."
-          />
+          <div v-if="loading" class="text-center my-3">
+            <b-spinner />
+          </div>
+          <template v-else>
+            <template v-if="commonGroups.length">
+              <h4>Which community is this about?</h4>
+              <b-form-select
+                v-model="groupid"
+                class="mt-1 mb-1"
+                data-testid="group-select"
+              >
+                <option :value="null">-- Please choose --</option>
+                <option v-for="g in commonGroups" :key="g.id" :value="g.id">
+                  {{ g.namedisplay }}
+                </option>
+              </b-form-select>
+            </template>
+            <p v-else class="text-muted">
+              We'll pass this to our central volunteers who deal with this kind of
+              thing.
+            </p>
+            <h4>Why are you reporting this?</h4>
+            <b-form-select
+              v-model="reason"
+              class="mt-1 mb-1"
+              data-testid="reason-select"
+            >
+              <option :value="null">-- Please choose --</option>
+              <option value="Spam">It's Spam</option>
+              <option value="Other">Something else</option>
+            </b-form-select>
+            <h4>What's wrong?</h4>
+            <b-form-textarea
+              v-model="comments"
+              placeholder="Please tell us what's wrong.  This will go to our lovely volunteers, who will try to help you."
+            />
+          </template>
         </b-col>
       </b-row>
     </template>
     <template #footer>
       <b-button variant="white" @click="hide"> Close </b-button>
-      <b-button variant="primary" @click="send"> Send Report </b-button>
+      <b-button variant="primary" :disabled="loading" @click="send">
+        Send Report
+      </b-button>
     </template>
   </b-modal>
 </template>
 <script setup>
-import { ref } from 'vue'
-import GroupSelect from './GroupSelect'
+import { ref, onMounted } from 'vue'
 import { useChatStore } from '~/stores/chat'
 import { useOurModal } from '~/composables/useOurModal'
 
@@ -56,14 +81,40 @@ const { modal, hide } = useOurModal()
 const groupid = ref(null)
 const reason = ref(null)
 const comments = ref(null)
+const commonGroups = ref([])
+const loading = ref(true)
+
+onMounted(async () => {
+  try {
+    const groups = await chatStore.commonGroups(props.chatid)
+    commonGroups.value = Array.isArray(groups) ? groups : []
+    if (commonGroups.value.length === 1) {
+      groupid.value = commonGroups.value[0].id
+    }
+  } catch (e) {
+    commonGroups.value = []
+  } finally {
+    loading.value = false
+  }
+})
 
 async function send() {
-  if (groupid.value && reason.value && comments.value) {
-    const chatid = await chatStore.openChatToMods(groupid.value)
-
-    await chatStore.report(chatid, reason.value, comments.value, props.chatid)
-
-    hide()
+  if (!reason.value) {
+    return
   }
+
+  if (commonGroups.value.length) {
+    // Route to the chosen community's moderators (existing flow).
+    if (!groupid.value || !comments.value) {
+      return
+    }
+    const chatid = await chatStore.openChatToMods(groupid.value)
+    await chatStore.report(chatid, reason.value, comments.value, props.chatid)
+  } else {
+    // No group in common: route to the central spam team. Comment optional.
+    await chatStore.reportNoGroup(props.chatid, reason.value, comments.value || '')
+  }
+
+  hide()
 }
 </script>

--- a/iznik-nuxt3/stores/chat.js
+++ b/iznik-nuxt3/stores/chat.js
@@ -385,6 +385,12 @@ export const useChatStore = defineStore({
       })
       this.fetchMessages(chatid)
     },
+    async commonGroups(chatid) {
+      return await api(this.config).chat.commonGroups(chatid)
+    },
+    async reportNoGroup(chatid, reason, comment) {
+      await api(this.config).chat.reportNoGroup(chatid, reason, comment)
+    },
     // Chat review moderation actions (approve/reject/hold/release/redact).
     async _sendChatMT(data) {
       // 404 means the message was already acted on (race condition with another mod).

--- a/iznik-nuxt3/tests/unit/components/ChatReportModal.spec.js
+++ b/iznik-nuxt3/tests/unit/components/ChatReportModal.spec.js
@@ -1,91 +1,125 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { mount } from '@vue/test-utils'
+import { mount, flushPromises } from '@vue/test-utils'
 import { ref } from 'vue'
 import { modalBootstrapStubs } from '../mocks/bootstrap-stubs'
 import ChatReportModal from '~/components/ChatReportModal.vue'
 
 const mockHide = vi.fn()
 vi.mock('~/composables/useOurModal', () => ({
-  useOurModal: () => ({
-    modal: ref(null),
-    hide: mockHide,
-  }),
+  useOurModal: () => ({ modal: ref(null), hide: mockHide }),
 }))
 
 const mockOpenChatToMods = vi.fn()
 const mockReport = vi.fn()
+const mockReportNoGroup = vi.fn()
+const mockCommonGroups = vi.fn()
 vi.mock('~/stores/chat', () => ({
   useChatStore: () => ({
     openChatToMods: mockOpenChatToMods,
     report: mockReport,
+    reportNoGroup: mockReportNoGroup,
+    commonGroups: mockCommonGroups,
   }),
 }))
+
+// The shared b-form-select stub renders options from an `options` prop, but this
+// component uses slotted <option> children, so override it with a stub that
+// renders the default slot and drives v-model on change. b-spinner isn't in the
+// shared stubs, so stub it too (an unresolved component triggers a Vue warning
+// that the test harness treats as a failure).
+const selectStub = {
+  template:
+    '<select :value="modelValue" @change="$emit(\'update:modelValue\', $event.target.value)"><slot /></select>',
+  props: ['modelValue', 'disabled'],
+}
+
+async function createWrapper(props = {}) {
+  const wrapper = mount(ChatReportModal, {
+    props: { user: { displayname: 'Test User' }, chatid: 123, ...props },
+    global: {
+      stubs: {
+        ...modalBootstrapStubs,
+        'b-form-select': selectStub,
+        'b-spinner': { template: '<span class="spinner" />' },
+      },
+    },
+  })
+  await flushPromises()
+  return wrapper
+}
 
 describe('ChatReportModal', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockOpenChatToMods.mockResolvedValue(999)
+    mockCommonGroups.mockResolvedValue([])
   })
 
-  function createWrapper(props = {}) {
-    return mount(ChatReportModal, {
-      props: {
-        user: { displayname: 'Test User' },
-        chatid: 123,
-        ...props,
-      },
-      global: {
-        stubs: {
-          ...modalBootstrapStubs,
-          GroupSelect: {
-            template:
-              '<select data-testid="group-select" :value="modelValue" @change="$emit(\'update:modelValue\', parseInt($event.target.value))"><option value="1">Group 1</option></select>',
-            props: ['modelValue'],
-          },
-        },
-      },
+  describe('common group exists', () => {
+    beforeEach(() => {
+      mockCommonGroups.mockResolvedValue([{ id: 1, namedisplay: 'Group 1' }])
     })
-  }
 
-  describe('rendering', () => {
-    it('shows modal with title, questions, and buttons', () => {
-      const wrapper = createWrapper()
-      expect(wrapper.find('.modal-title').text()).toBe('Oh dear...')
-      expect(wrapper.text()).toContain("Sorry you're having trouble")
+    it('shows the community selector', async () => {
+      const wrapper = await createWrapper()
       expect(wrapper.text()).toContain('Which community is this about?')
-      expect(wrapper.text()).toContain('Why are you reporting this?')
-      expect(wrapper.text()).toContain("What's wrong?")
-      expect(wrapper.text()).toContain('Close')
-      expect(wrapper.text()).toContain('Send Report')
+      expect(wrapper.find('[data-testid="group-select"]').exists()).toBe(true)
     })
 
-    it('renders GroupSelect and form inputs', () => {
-      const wrapper = createWrapper()
-      expect(wrapper.find('[data-testid="group-select"]').exists()).toBe(true)
-      expect(wrapper.find('textarea').exists()).toBe(true)
-      expect(wrapper.find('select').exists()).toBe(true)
+    it('routes the report to the community mods', async () => {
+      const wrapper = await createWrapper()
+      await wrapper.find('[data-testid="reason-select"]').setValue('Spam')
+      await wrapper.find('textarea').setValue('creepy')
+      const sendBtn = wrapper
+        .findAll('button')
+        .find((b) => b.text().includes('Send Report'))
+      await sendBtn.trigger('click')
+      await flushPromises()
+      expect(mockOpenChatToMods).toHaveBeenCalledWith(1)
+      expect(mockReport).toHaveBeenCalled()
+      expect(mockReportNoGroup).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('no common group (spam-team fallback)', () => {
+    it('hides the selector and shows the central-volunteers note', async () => {
+      const wrapper = await createWrapper()
+      expect(wrapper.text()).not.toContain('Which community is this about?')
+      expect(wrapper.text()).toContain('central volunteers')
+      expect(wrapper.find('[data-testid="group-select"]').exists()).toBe(false)
+    })
+
+    it('routes the report to the spam team with an optional empty comment', async () => {
+      const wrapper = await createWrapper()
+      await wrapper.find('[data-testid="reason-select"]').setValue('Spam')
+      const sendBtn = wrapper
+        .findAll('button')
+        .find((b) => b.text().includes('Send Report'))
+      await sendBtn.trigger('click')
+      await flushPromises()
+      expect(mockReportNoGroup).toHaveBeenCalledWith(123, 'Spam', '')
+      expect(mockOpenChatToMods).not.toHaveBeenCalled()
+    })
+
+    it('does not send without a reason', async () => {
+      const wrapper = await createWrapper()
+      const sendBtn = wrapper
+        .findAll('button')
+        .find((b) => b.text().includes('Send Report'))
+      await sendBtn.trigger('click')
+      await flushPromises()
+      expect(mockReportNoGroup).not.toHaveBeenCalled()
     })
   })
 
   describe('close action', () => {
     it('calls hide when Close is clicked', async () => {
-      const wrapper = createWrapper()
+      const wrapper = await createWrapper()
       const closeBtn = wrapper
         .findAll('button')
         .find((b) => b.text().includes('Close'))
       await closeBtn.trigger('click')
       expect(mockHide).toHaveBeenCalled()
-    })
-  })
-
-  describe('send report validation', () => {
-    it('does not send report without required fields', async () => {
-      const wrapper = createWrapper()
-      const sendBtn = wrapper
-        .findAll('button')
-        .find((b) => b.text().includes('Send Report'))
-      await sendBtn.trigger('click')
-      expect(mockReport).not.toHaveBeenCalled()
     })
   })
 })

--- a/iznik-nuxt3/tests/unit/components/JobMosaicTile.spec.js
+++ b/iznik-nuxt3/tests/unit/components/JobMosaicTile.spec.js
@@ -304,7 +304,10 @@ describe('JobMosaicTile', () => {
     it('logs job click', async () => {
       const wrapper = createWrapper()
       await wrapper.find('.mosaic-tile').trigger('click')
-      expect(mockJobStore.log).toHaveBeenCalledWith({ id: 1 })
+      expect(mockJobStore.log).toHaveBeenCalledWith({
+        id: 1,
+        link: 'https://example.com/job/1',
+      })
     })
 
     it('navigates to /jobs when not already on jobs page', async () => {

--- a/iznik-nuxt3/tests/unit/components/JobOne.spec.js
+++ b/iznik-nuxt3/tests/unit/components/JobOne.spec.js
@@ -218,7 +218,10 @@ describe('JobOne', () => {
     it('logs click to jobStore', async () => {
       const wrapper = createWrapper()
       await wrapper.find('.job-item').trigger('click')
-      expect(mockJobStore.log).toHaveBeenCalledWith({ id: 123 })
+      expect(mockJobStore.log).toHaveBeenCalledWith({
+        id: 123,
+        link: 'https://jobs.example.com/123',
+      })
     })
 
     it('logs click action for analytics', async () => {

--- a/iznik-server-go/chat/chatroom.go
+++ b/iznik-server-go/chat/chatroom.go
@@ -602,6 +602,53 @@ func GetOrCreateUser2UserChat(db *gorm.DB, userA, userB uint64) (uint64, error) 
 	return chatID, nil
 }
 
+// CommonGroup is a group that both participants of a chat belong to.
+type CommonGroup struct {
+	ID          uint64 `json:"id"`
+	Namedisplay string `json:"namedisplay"`
+}
+
+// GetCommonGroups handles GET /chat/{id}/commongroups - the groups the two
+// participants of a chat have in common. The report flow uses this to decide
+// whether to route a report to a community's moderators (a common group exists)
+// or to the central spam team (none). Caller must be a participant.
+func GetCommonGroups(c *fiber.Ctx) error {
+	myid := user.WhoAmI(c)
+	if myid == 0 {
+		return fiber.NewError(fiber.StatusUnauthorized, "Not logged in")
+	}
+
+	id, err := strconv.ParseUint(c.Params("id"), 10, 64)
+	if err != nil || id == 0 {
+		return fiber.NewError(fiber.StatusBadRequest, "Invalid chat ID")
+	}
+
+	db := database.DBConn
+
+	var room struct {
+		ID    uint64
+		User1 uint64
+		User2 uint64
+	}
+	db.Raw("SELECT id, user1, user2 FROM chat_rooms WHERE id = ?", id).Scan(&room)
+	if room.ID == 0 {
+		return fiber.NewError(fiber.StatusNotFound, "Chat not found")
+	}
+	if room.User1 != myid && room.User2 != myid {
+		return fiber.NewError(fiber.StatusForbidden, "Not a member of this chat")
+	}
+
+	groups := []CommonGroup{}
+	db.Raw("SELECT g.id, COALESCE(NULLIF(g.namefull, ''), g.nameshort) AS namedisplay "+
+		"FROM `groups` g "+
+		"INNER JOIN memberships m1 ON m1.groupid = g.id AND m1.userid = ? "+
+		"INNER JOIN memberships m2 ON m2.groupid = g.id AND m2.userid = ? "+
+		"ORDER BY namedisplay",
+		room.User1, room.User2).Scan(&groups)
+
+	return c.JSON(groups)
+}
+
 // =============================================================================
 // POST handler (roster updates, nudge, typing, actions)
 // =============================================================================
@@ -612,6 +659,8 @@ type ChatRoomPostRequest struct {
 	Status      string `json:"status"`
 	Lastmsgseen uint64 `json:"lastmsgseen"`
 	Allowback   bool   `json:"allowback"`
+	Reason      string `json:"reason"`
+	Comment     string `json:"comment"`
 }
 
 type RosterEntry struct {
@@ -642,6 +691,8 @@ func PostChatRoom(c *fiber.Ctx) error {
 		return handleTyping(c, db, myid, req.ID)
 	case "ReferToSupport":
 		return handleReferToSupport(c, db, myid, req.ID)
+	case "ReportNoGroup":
+		return handleReportNoGroup(c, db, myid, req)
 	default:
 		if req.ID == 0 {
 			return fiber.NewError(fiber.StatusBadRequest, "Chat ID required")
@@ -1474,6 +1525,44 @@ func handleReferToSupport(c *fiber.Ctx, db *gorm.DB, myid uint64, chatid uint64)
 	// Queue sending a support referral email.
 	db.Exec("INSERT INTO background_tasks (task_type, data) VALUES (?, JSON_OBJECT('chatid', ?, 'userid', ?))",
 		"refer_to_support", chatid, myid)
+
+	return c.JSON(fiber.Map{"ret": 0, "status": "Success"})
+}
+
+// handleReportNoGroup queues a report to the central spam team for a User2User
+// chat whose participants share no Freegle group (so it can't be routed to a
+// community's moderators). The server re-checks "no common group" so a client
+// cannot misuse this to bypass community routing.
+func handleReportNoGroup(c *fiber.Ctx, db *gorm.DB, myid uint64, req ChatRoomPostRequest) error {
+	if req.ID == 0 {
+		return fiber.NewError(fiber.StatusBadRequest, "Chat ID required")
+	}
+	if req.Reason == "" {
+		return fiber.NewError(fiber.StatusBadRequest, "Reason required")
+	}
+
+	var room ChatRoom
+	db.Raw("SELECT id, chattype, user1, user2 FROM chat_rooms WHERE id = ?", req.ID).Scan(&room)
+	if room.ID == 0 {
+		return fiber.NewError(fiber.StatusNotFound, "Chat not found")
+	}
+	if room.User1 != myid && room.User2 != myid {
+		return fiber.NewError(fiber.StatusForbidden, "Not a member of this chat")
+	}
+
+	// Re-check that there really is no group in common; if there is, the client
+	// should have used the normal group-routed report flow.
+	var common int64
+	db.Raw("SELECT COUNT(*) FROM memberships m1 "+
+		"INNER JOIN memberships m2 ON m1.groupid = m2.groupid "+
+		"WHERE m1.userid = ? AND m2.userid = ?",
+		room.User1, room.User2).Scan(&common)
+	if common > 0 {
+		return fiber.NewError(fiber.StatusBadRequest, "Groups in common exist; use the normal report flow")
+	}
+
+	db.Exec("INSERT INTO background_tasks (task_type, data) VALUES (?, JSON_OBJECT('chatid', ?, 'userid', ?, 'reason', ?, 'comment', ?))",
+		"email_chat_spam_report", req.ID, myid, req.Reason, req.Comment)
 
 	return c.JSON(fiber.Map{"ret": 0, "status": "Success"})
 }

--- a/iznik-server-go/router/routes.go
+++ b/iznik-server-go/router/routes.go
@@ -290,6 +290,15 @@ func SetupRoutes(app *fiber.App) {
 		// @Success 200 {array} chat.ChatMessage
 		rg.Get("/chat/:id/message", chat.GetChatMessages)
 
+		// @Router /chat/{id}/commongroups [get]
+		// @Summary Groups in common between the two chat participants
+		// @Tags chat
+		// @Produce json
+		// @Param id path integer true "Chat ID"
+		// @Security BearerAuth
+		// @Success 200 {array} chat.CommonGroup
+		rg.Get("/chat/:id/commongroups", chat.GetCommonGroups)
+
 		// Create Chat Message
 		// @Router /chat/{id}/message [post]
 		// @Summary Create chat message

--- a/iznik-server-go/test/chat_test.go
+++ b/iznik-server-go/test/chat_test.go
@@ -4470,3 +4470,119 @@ func TestModeratorUnreadCountClearedByMarkAllRead(t *testing.T) {
 	assert.Equal(t, int64(0), countAfter,
 		"after markAllRead, unread count must be 0 (got %d: handleAllSeen skips chats with no roster entry)", countAfter)
 }
+
+// =============================================================================
+// CommonGroups tests
+// =============================================================================
+
+func TestCommonGroupsShared(t *testing.T) {
+	prefix := uniquePrefix("commongroups")
+	user1ID := CreateTestUser(t, prefix+"_u1", "User")
+	user2ID := CreateTestUser(t, prefix+"_u2", "User")
+	groupID := CreateTestGroup(t, prefix+"_g")
+	CreateTestMembership(t, user1ID, groupID, "Member")
+	CreateTestMembership(t, user2ID, groupID, "Member")
+	chatid := CreateTestChatRoom(t, user1ID, &user2ID, nil, "User2User")
+	_, token := CreateTestSession(t, user1ID)
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET",
+		"/api/chat/"+fmt.Sprint(chatid)+"/commongroups?jwt="+token, nil))
+	assert.Equal(t, 200, resp.StatusCode)
+	var groups []chat.CommonGroup
+	json2.Unmarshal(rsp(resp), &groups)
+	assert.Equal(t, 1, len(groups))
+	assert.Equal(t, groupID, groups[0].ID)
+}
+
+func TestCommonGroupsNone(t *testing.T) {
+	prefix := uniquePrefix("commongroupsnone")
+	user1ID := CreateTestUser(t, prefix+"_u1", "User")
+	user2ID := CreateTestUser(t, prefix+"_u2", "User")
+	g1 := CreateTestGroup(t, prefix+"_g1")
+	g2 := CreateTestGroup(t, prefix+"_g2")
+	CreateTestMembership(t, user1ID, g1, "Member")
+	CreateTestMembership(t, user2ID, g2, "Member")
+	chatid := CreateTestChatRoom(t, user1ID, &user2ID, nil, "User2User")
+	_, token := CreateTestSession(t, user1ID)
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET",
+		"/api/chat/"+fmt.Sprint(chatid)+"/commongroups?jwt="+token, nil))
+	assert.Equal(t, 200, resp.StatusCode)
+	var groups []chat.CommonGroup
+	json2.Unmarshal(rsp(resp), &groups)
+	assert.Equal(t, 0, len(groups))
+}
+
+func TestCommonGroupsNotMember(t *testing.T) {
+	prefix := uniquePrefix("commongroupsnm")
+	user1ID := CreateTestUser(t, prefix+"_u1", "User")
+	user2ID := CreateTestUser(t, prefix+"_u2", "User")
+	outsiderID := CreateTestUser(t, prefix+"_out", "User")
+	chatid := CreateTestChatRoom(t, user1ID, &user2ID, nil, "User2User")
+	_, token := CreateTestSession(t, outsiderID)
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET",
+		"/api/chat/"+fmt.Sprint(chatid)+"/commongroups?jwt="+token, nil))
+	assert.Equal(t, 403, resp.StatusCode)
+}
+
+// =============================================================================
+// ReportNoGroup tests
+// =============================================================================
+
+func TestReportNoGroup(t *testing.T) {
+	prefix := uniquePrefix("reportnogroup")
+	db := database.DBConn
+	user1ID := CreateTestUser(t, prefix+"_u1", "User")
+	user2ID := CreateTestUser(t, prefix+"_u2", "User")
+	chatid := CreateTestChatRoom(t, user1ID, &user2ID, nil, "User2User")
+	CreateTestChatMessage(t, chatid, user2ID, "Want a girlfriend?")
+	_, token := CreateTestSession(t, user1ID)
+
+	payload := map[string]interface{}{
+		"id": chatid, "action": "ReportNoGroup", "reason": "Spam", "comment": "creepy",
+	}
+	s, _ := json2.Marshal(payload)
+	request := httptest.NewRequest("POST", "/api/chatrooms?jwt="+token, bytes.NewBuffer(s))
+	request.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(request)
+	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+
+	var taskCount int64
+	db.Raw("SELECT COUNT(*) FROM background_tasks WHERE task_type = 'email_chat_spam_report' AND JSON_EXTRACT(data, '$.chatid') = ?", chatid).Scan(&taskCount)
+	assert.Greater(t, taskCount, int64(0))
+}
+
+func TestReportNoGroupRejectedWhenCommonGroup(t *testing.T) {
+	prefix := uniquePrefix("reportnogroupcg")
+	user1ID := CreateTestUser(t, prefix+"_u1", "User")
+	user2ID := CreateTestUser(t, prefix+"_u2", "User")
+	groupID := CreateTestGroup(t, prefix+"_g")
+	CreateTestMembership(t, user1ID, groupID, "Member")
+	CreateTestMembership(t, user2ID, groupID, "Member")
+	chatid := CreateTestChatRoom(t, user1ID, &user2ID, nil, "User2User")
+	_, token := CreateTestSession(t, user1ID)
+
+	payload := map[string]interface{}{"id": chatid, "action": "ReportNoGroup", "reason": "Spam"}
+	s, _ := json2.Marshal(payload)
+	request := httptest.NewRequest("POST", "/api/chatrooms?jwt="+token, bytes.NewBuffer(s))
+	request.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(request)
+	assert.Equal(t, fiber.StatusBadRequest, resp.StatusCode)
+}
+
+func TestReportNoGroupNotMember(t *testing.T) {
+	prefix := uniquePrefix("reportnogroupnm")
+	user1ID := CreateTestUser(t, prefix+"_u1", "User")
+	user2ID := CreateTestUser(t, prefix+"_u2", "User")
+	outsiderID := CreateTestUser(t, prefix+"_out", "User")
+	chatid := CreateTestChatRoom(t, user1ID, &user2ID, nil, "User2User")
+	_, token := CreateTestSession(t, outsiderID)
+
+	payload := map[string]interface{}{"id": chatid, "action": "ReportNoGroup", "reason": "Spam"}
+	s, _ := json2.Marshal(payload)
+	request := httptest.NewRequest("POST", "/api/chatrooms?jwt="+token, bytes.NewBuffer(s))
+	request.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(request)
+	assert.Equal(t, fiber.StatusForbidden, resp.StatusCode)
+}

--- a/iznik-server-go/test/chat_test.go
+++ b/iznik-server-go/test/chat_test.go
@@ -4586,3 +4586,45 @@ func TestReportNoGroupNotMember(t *testing.T) {
 	resp, _ := getApp().Test(request)
 	assert.Equal(t, fiber.StatusForbidden, resp.StatusCode)
 }
+
+func TestCommonGroupsNotLoggedIn(t *testing.T) {
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/chat/1/commongroups", nil))
+	assert.Equal(t, 401, resp.StatusCode)
+}
+
+func TestCommonGroupsChatNotFound(t *testing.T) {
+	prefix := uniquePrefix("commongroupsnf")
+	uid := CreateTestUser(t, prefix+"_u", "User")
+	_, token := CreateTestSession(t, uid)
+	resp, _ := getApp().Test(httptest.NewRequest("GET",
+		"/api/chat/999999999/commongroups?jwt="+token, nil))
+	assert.Equal(t, 404, resp.StatusCode)
+}
+
+func TestReportNoGroupMissingReason(t *testing.T) {
+	prefix := uniquePrefix("reportnogroupmr")
+	user1ID := CreateTestUser(t, prefix+"_u1", "User")
+	user2ID := CreateTestUser(t, prefix+"_u2", "User")
+	chatid := CreateTestChatRoom(t, user1ID, &user2ID, nil, "User2User")
+	_, token := CreateTestSession(t, user1ID)
+
+	payload := map[string]interface{}{"id": chatid, "action": "ReportNoGroup"}
+	s, _ := json2.Marshal(payload)
+	request := httptest.NewRequest("POST", "/api/chatrooms?jwt="+token, bytes.NewBuffer(s))
+	request.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(request)
+	assert.Equal(t, fiber.StatusBadRequest, resp.StatusCode)
+}
+
+func TestReportNoGroupChatNotFound(t *testing.T) {
+	prefix := uniquePrefix("reportnogroupnf")
+	uid := CreateTestUser(t, prefix+"_u", "User")
+	_, token := CreateTestSession(t, uid)
+
+	payload := map[string]interface{}{"id": 999999999, "action": "ReportNoGroup", "reason": "Spam"}
+	s, _ := json2.Marshal(payload)
+	request := httptest.NewRequest("POST", "/api/chatrooms?jwt="+token, bytes.NewBuffer(s))
+	request.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(request)
+	assert.Equal(t, fiber.StatusNotFound, resp.StatusCode)
+}


### PR DESCRIPTION
## Reporting a chat when there's no group in common

Addresses the Discourse request: https://discourse.ilovefreegle.org/t/reporting-chat-with-no-group/9828

A member reported that when someone DMs her via ChitChat (no shared Freegle group), she can't report the chat — the report modal forces her to pick a community, and there's no correct one to choose. This adds a fallback so such reports reach the central **spam team**, with a simple one-click report and no destination choice for the reporter.

### Behaviour
- **Group in common** → unchanged: the report goes to that community's moderators. The community selector stays (now restricted to the *genuinely common* groups, fixing a latent misrouting where it previously listed the reporter's own groups).
- **No group in common** → the selector is hidden; the reporter picks a reason (comment optional) and clicks Send; the report is emailed to the spam team with a server-built note explaining why it reached them, plus a ModTools link to the chat.
- Fixes the previous silent no-op when no group was selectable.

### Changes
- **apiv2 (Go):** `GET /chat/{id}/commongroups`; new `ReportNoGroup` action on `POST /chatrooms` that re-checks "no common group" server-side and queues an `email_chat_spam_report` background task.
- **batch (Laravel):** `email_chat_spam_report` handler → new `ChatSpamReportMail` → new `spam_addr` config (defaults to the support address; override via `FREEGLE_SPAM_ADDR`).
- **frontend (Nuxt3):** `ChatReportModal` fetches common groups on open and branches; new `commonGroups`/`reportNoGroup` store + API methods.
- PHP apiv1 is reference-only and not modified.

Spec & plan: `docs/superpowers/specs/2026-06-25-report-chat-no-common-group-design.md`, `docs/superpowers/plans/2026-06-25-report-chat-no-common-group.md`.

### Testing
- **Full Go suite:** 3257 passed, 0 failed (6 new tests: commongroups shared/none/not-member, ReportNoGroup success/rejected-when-common/not-member).
- **Full Laravel suite:** 4396 passed, 0 failed (new `test_processes_email_chat_spam_report_task`).
- **Frontend modal unit tests:** 6/6 pass. The full frontend unit suite runs in CI (it OOMs in worktree environments).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M56vbv9WabnZAkrfmeY4vL
