### PR TITLE
fix(rippling): one repost reminder & chase-up per item, not per group

### DIFF
--- a/RIPPLING-OUT-FOR-MEMBERS.md
+++ b/RIPPLING-OUT-FOR-MEMBERS.md
@@ -15,6 +15,9 @@ The aim is to keep freegling as local as possible. Your neighbours get first cha
 which means less driving and a fairer go for everyone close by. If nobody nearby wants
 it, it reaches further afield automatically - you do not need to do anything extra.
 
+If enough people nearby reply to your post, it stops spreading further - it already has
+plenty of interest, so there is no need to show it to people further away.
+
 ---
 
 ## What happens when your post ripples into a new community?
@@ -78,6 +81,17 @@ count. Nothing is missing - everything is always there on the browse page.
 
 ---
 
+## Reminders about your post
+
+If your item is still available after a while, we remind you shortly before we
+automatically repost it ("Will Repost: ..."), and later we check in to ask what happened
+("What happened to: ..."). Even though your post may be live in several communities at
+once through rippling, you only ever get **one** reminder and **one** check-in each time -
+not one per community. Whatever you choose - mark it taken, withdraw it, or promise it to
+someone - applies to your post everywhere it has reached, so a single tap settles it.
+
+---
+
 ## Staying in control
 
 ### Changing your email settings
@@ -137,5 +151,6 @@ normal. Nothing is lost - it is just "not yet" rather than "no".
 | Email defaults | Immediate is switched to daily; no-email and daily are unchanged |
 | Community events/volunteering emails | Left at whatever you already had |
 | Intro email | One bundled email explains what happened and how to change things |
+| Repost reminders / check-ins | One per item, not one per community |
 | Leaving a community | Removes your post from it; you are not re-joined |
 | Changing settings | Adjust per community in Settings at any time |

--- a/RIPPLING-OUT-FOR-MEMBERS.md
+++ b/RIPPLING-OUT-FOR-MEMBERS.md
@@ -81,6 +81,19 @@ count. Nothing is missing - everything is always there on the browse page.
 
 ---
 
+## Getting posts that ripple towards you
+
+Rippling works in the other direction too: posts from neighbouring communities ripple
+towards you. If you have a community set to **immediate emails**, you will get an alert
+the moment a rippling post first reaches your area - just as you would for a post made
+directly in that community. You only ever get **one** alert per post, however far it
+later travels, and only once it is actually close enough for you to reply.
+
+If you would rather not hear about them straight away, set that community to daily digest
+in Settings - those posts then simply appear in your next "What's New" instead.
+
+---
+
 ## Reminders about your post
 
 If your item is still available after a while, we remind you shortly before we

--- a/RIPPLING-OUT-FOR-MODERATORS.md
+++ b/RIPPLING-OUT-FOR-MODERATORS.md
@@ -10,9 +10,10 @@
 > ### Don't reject a post just because it looks "out of area"
 >
 > With rippling out, a post that started on a neighbouring community can appear on
-> **your** community's pending list, even if the poster lives some distance away.
-> **That is expected and correct.** It means the system is deliberately spreading a post
-> that has not been collected locally so your members get a chance at it.
+> **your** community, even if the poster lives some distance away (by default it arrives
+> already approved; see below). **That is expected and correct.** It means the system is
+> deliberately spreading a post that has not been collected locally so your members get a
+> chance at it.
 >
 > Only reject it for the usual reasons - spam, breaks the rules, wrong sort of thing,
 > and so on. "They're not from round here" is no longer a reason to reject.
@@ -46,39 +47,45 @@ What this means in practice:
 
 ### 1. Posts arriving from other communities
 
-Some posts in your pending list will have started on another community and rippled into
-yours. You will see a small notice on the post making this clear. These go through your
-normal pending list like any other post - approve or reject them as you normally would
-(remembering the "please don't" above).
+Some posts on your community will have started on another community and rippled into
+yours. You will see a small notice on the post making this clear ("This post has rippled
+in from a neighbouring community").
 
-**Auto-approval for pre-approved posts.** A post that rippled in and was already approved
-on the community where it started will auto-approve on your community after about an hour
-if nobody rejects it first. It was already vetted, so we do not make it sit out the full
-review window again. You still see it in your pending list and can reject it for the usual
-reasons - just do so reasonably promptly if you do not want it to go live locally. A post
-that has not been approved anywhere yet follows your normal pending process, unchanged.
+A post only ripples after it has already been approved on the community where it started,
+so it has already been vetted. We therefore do not make it sit out a full review again.
+**With the default settings it is approved on your community straight away** - it appears
+among your approved posts with the rippled-in notice, not in your pending list. You can
+still reject it for the usual reasons (spam, breaks the rules, wrong sort of thing) - see
+"Rejecting a rippled-in post" below.
+
+(If your instance is configured with a mod-veto window - `RIPPLE_RIPPLED_IN_PENDING_HOURS`
+set above zero - a rippled-in post instead waits in your pending list for that many hours
+and auto-approves if nobody rejects it first. Either way, "they're not from round here" is
+never a reason to reject.)
 
 ### 2. A reach/map view on posts
 
-On posts in your moderation screens there is a button (labelled something like "Who can
-see this?" or "Reach") that shows you on a map the area a post is currently visible in.
-This is useful for checking how far a post has spread or why it turned up on your list.
+On posts in your moderation screens there is a **"View rippling reach"** button (with a
+map-marker icon) that shows you on a map the area a post is currently visible in. This is
+useful for checking how far a post has spread or why it turned up on your list.
 
 ### 3. A reminder when you edit a shared post
 
 If you edit a post that is on more than one community, you will see a warning:
 
-> *"This edit will apply to the post on all groups."*
+> *"This edit will apply to the post on all N groups it appears on."*
 
-Edit as normal - just be aware your change is seen everywhere the post appears.
+(N is the actual number of communities the post is on.) Edit as normal - just be aware
+your change is seen everywhere the post appears.
 
 ### 4. Held replies in Chat Review
 
 Occasionally a reply is held because the post has not yet rippled out to where that
 member is. Chat Review shows you it is held because of rippling (not because you chose
 to hold it). You do not need to do anything - the reply is released automatically once
-the post reaches that member's area. Members are never shown this reason; only moderators
-see it.
+the post reaches that member's area, or once the post has finished spreading as far as it
+will go, so no reply is ever held indefinitely. Members are never shown this reason; only
+moderators see it.
 
 ---
 
@@ -111,6 +118,21 @@ the rest, and the subject line says simply "What's New" instead of a post count.
 
 ---
 
+## Repost reminders and chase-ups happen once per item
+
+Freegle reminds a poster shortly before it auto-reposts their item ("Will Repost: ...")
+and, once reposting is exhausted, chases them up to ask what happened ("What happened
+to: ..."). Under rippling a single item can be live on several communities at once, but
+the poster still gets **one** reminder and **one** chase-up per cycle - not one per
+community. Whatever they do in response (mark it taken, withdraw it, or promise it)
+applies to the item everywhere it has rippled, so one email is enough to settle it.
+
+Behind the scenes the item is still reposted on each community independently, so it stays
+near the top of every local browse list - that part is invisible to the poster and costs
+them no extra email.
+
+---
+
 ## The spam-flag and "seen on many groups"
 
 Rippling joins a poster to multiple communities. This does **not** trigger the "seen on
@@ -137,9 +159,11 @@ because the poster is from out of area.
 
 ## TrashNothing posts
 
-Posts coming in through TrashNothing behave exactly like any other post under rippling
-out. They ripple outwards from the community they started on, appear in your pending list
-with the same notice, and can be approved or rejected in the same way.
+TrashNothing posts are currently **not** rippled out into new communities. TrashNothing
+still cross-posts an item to several Freegle communities itself, so rippling deliberately
+stays out of its way to avoid the same item appearing twice. They behave on your community
+exactly as they always have. This exclusion is temporary - once TrashNothing posts to a
+single origin community, those posts will ripple like any other.
 
 ---
 

--- a/RIPPLING-OUT-FOR-MODERATORS.md
+++ b/RIPPLING-OUT-FOR-MODERATORS.md
@@ -176,6 +176,12 @@ answer is reassuring:
 > to it first. As soon as it reaches you, you will be able to reply - you do not need
 > to do anything.*
 
+Members on **immediate emails** may also notice they get an alert when a post that
+started on a neighbouring community ripples close enough to reach them. That is expected:
+they get one immediate alert per such post, the moment it reaches their area - exactly as
+they would for a post made directly on the community. If they would rather not, they can
+switch that community to daily digest in Settings.
+
 Some members may also ask why they have been joined to communities they did not sign up
 for. The answer is that their post has been travelling to reach more people, and the
 membership is what makes replies and contact work properly. They can leave any of those

--- a/docs/superpowers/specs/2026-06-25-repost-reminder-dedup-rippling-design.md
+++ b/docs/superpowers/specs/2026-06-25-repost-reminder-dedup-rippling-design.md
@@ -1,0 +1,79 @@
+# Repost reminders & chase-ups: once per item under rippling-out
+
+**Date:** 2026-06-25
+**Branch:** `fix/repost-reminder-dedup-rippling`
+
+## Problem
+
+Rippling-out puts a single post on many groups (`messages_groups` rows with
+`rippled_in = 1`). Auto-reposting runs per group, which is correct for the repost
+itself (it keeps the item fresh in each community). But the poster-facing
+*notification* emails were not deduplicated across groups:
+
+- **Auto-repost warning ("Will Repost: …")** — `AutoRepostService` stamped
+  `lastautopostwarning` per group (`WHERE msgid = ? AND groupid = ?`, a deliberate
+  "multi-group fix"). So each group fired its own warning. A widely-rippled item could
+  email the poster once per group, per cycle. Because rippled-in rows get a fresh
+  `arrival` as the reach expands over hours/days, their repost windows are *staggered*,
+  so even a simple "stamp all groups" 24h dedup leaks repeat emails days apart.
+- **Chase-up ("What happened to: …")** — `ChaseUpService` already stamps `lastchaseup`
+  on every group of the message when one is sent, so it was largely deduped, but it
+  shared the same staggered-window hole (a rippled row reaching max-reposts later could
+  initiate a second chase-up).
+
+## Key insight
+
+Every action a poster can take from these emails acts on the **whole item**, not one
+group. The buttons are `…/mypost/{msgid}/completed|withdraw|promise`:
+
+- "Mark completed" → `messages_outcomes` row keyed by `msgid` (Taken/Received).
+- "Withdraw" → `Withdrawn` outcome on the `msgid`; `MessageSpatialService` also deletes
+  the spatial row, so the ripple engine drops the reach and pulls the post from
+  rippled-in groups.
+- "Promise" → `messages_promises` row keyed by `msgid`.
+
+Both the auto-repost and chase-up candidate queries exclude any message that has an
+outcome (`whereNull('messages_outcomes.msgid')`) or promise, so a single response stops
+reposting and chasing on **every** group at once. Therefore one email per item loses
+nothing — and sending more than one is pure noise.
+
+## Design
+
+Anchor the poster-facing notification to the post's **home posting**
+(`messages_groups.rippled_in = 0`), while leaving the repost itself per-group.
+
+1. **Auto-repost warning** — only a `rippled_in = 0` row may send the warning. Rippled-in
+   rows are still reposted (kept fresh) but never warn. When the warning is sent, stamp
+   `lastautopostwarning` on **every** group of the message (revert to V1's
+   `WHERE msgid = ?`) so a rare multi-home cross-post (TN / manual) is also deduped.
+2. **Chase-up** — only a `rippled_in = 0` row may initiate a chase-up; keep the existing
+   all-groups `lastchaseup` stamp. This closes the staggered-window hole and makes both
+   emails behave identically.
+3. **Reposting itself stays per-group** — unchanged
+   (`test_multiple_groups_each_repost_independently` still passes).
+
+`rippled_in` is a stable home marker (unlike `arrival`, which a repost resets).
+
+### Not changed (deliberately)
+
+- `notifyLanguishing` counts a languishing post once per group, but only ever creates one
+  `OpenPosts` notification per user per day with no count stored — no user-visible
+  duplication. Left as-is.
+
+## Tests
+
+- `AutoRepostServiceTest::test_warning_sent_once_across_rippled_groups` — home + 2 rippled
+  rows, all in the window → `warned == 1`, every group stamped.
+- `AutoRepostServiceTest::test_rippled_in_row_reposts_without_warning` — rippled row past
+  the repost window reposts (`reposted == 1`) with no warning.
+- `ChaseUpServiceTest::test_rippled_item_chased_up_once_from_home` — home + rippled, both
+  "max reposts" → `chased == 1`, every group stamped.
+- `ChaseUpServiceTest::test_rippled_only_item_is_not_chased_up` — rippled-only row → not
+  chased.
+- All existing assertions kept (per-group reposts; existing cross-post chase-up dedup).
+
+## Docs
+
+`RIPPLING-OUT-FOR-MODERATORS.md` gains a "repost reminders & chase-ups are once per item"
+note; `RIPPLING-OUT-FOR-MEMBERS.md` gains a member-facing line. A separate accuracy pass
+verifies both docs against the current rippling implementation.

--- a/iznik-batch/app/Services/AutoRepostService.php
+++ b/iznik-batch/app/Services/AutoRepostService.php
@@ -40,15 +40,20 @@ class AutoRepostService
      *
      * Matches V1 autorepost.php → Message::autoRepostGroup().
      *
-     * Multi-group fix: V1 autoRepost() updates ALL messages_groups rows
-     * (WHERE msgid = ?). We update only the specific group's row
-     * (WHERE msgid = ? AND groupid = ?).
+     * Multi-group fix: the REPOST itself stays per-group — V1 autoRepost() updates ALL
+     * messages_groups rows (WHERE msgid = ?), we update only the specific group's row
+     * (WHERE msgid = ? AND groupid = ?), so a rippled item is kept fresh in each
+     * community independently.
+     *
+     * Rippling-out fix: the WARNING email is anchored to the home posting
+     * (rippled_in = 0) and stamped across every group of the message, so a widely-rippled
+     * post reminds the poster once per cycle, not once per group. See processGroup().
      *
      * V1 side effects included:
      *   - UPDATE messages_groups SET arrival=NOW(), autoreposts=autoreposts+1 (per-group)
      *   - Log AUTOREPOSTED entry per group
      *   - INSERT messages_postings per group
-     *   - UPDATE lastautopostwarning for warning emails
+     *   - UPDATE lastautopostwarning for warning emails (home posting only; stamped on all groups)
      *   - Warning email: "Will Repost: {subject}" with completed/withdraw/promise buttons
      *
      * V1 side effects NOT included:
@@ -190,15 +195,26 @@ class AutoRepostService
                 && $msg->hoursago > ($interval - 1) * 24
                 && (is_null($lastwarnago) || $lastwarnago > 24 * 60 * 60)
             ) {
-                if (!$msg->lastautopostwarning || ($lastwarnago > 24 * 60 * 60)) {
+                // Rippling-out fix: the repost reminder is anchored to the message's HOME
+                // posting (rippled_in = 0). A post that rippled INTO this group must never
+                // generate its own "Will Repost" reminder — otherwise a widely-rippled item
+                // would email the poster once per group, which is burdensome. The reminder's
+                // buttons (mark taken / withdraw / promise) act on the whole item, so one
+                // email from the home group governs the post on every group. Rippled rows are
+                // still reposted (the elseif below) to keep the item fresh in each community;
+                // they just stay silent.
+                if ($msg->rippled_in) {
+                    $stats['skipped']++;
+                } elseif (!$msg->lastautopostwarning || ($lastwarnago > 24 * 60 * 60)) {
                     if ($dryRun) {
                         Log::info("Dry run: would send repost warning for message #{$msg->msgid} on group #{$group->id}");
                     } elseif ($warningEmailEnabled) {
-                        // Multi-group fix: update per-group, not global.
-                        // V1: UPDATE messages_groups SET lastautopostwarning = NOW() WHERE msgid = ?
+                        // Stamp lastautopostwarning on EVERY group of the message (V1's
+                        // WHERE msgid = ?), so a message cross-posted to several home groups
+                        // (and all its rippled-in rows) is reminded once per cycle, not once
+                        // per group. Mirrors ChaseUpService's cross-group lastchaseup stamp.
                         DB::table('messages_groups')
                             ->where('msgid', $msg->msgid)
-                            ->where('groupid', $group->id)
                             ->update(['lastautopostwarning' => now()]);
 
                         // V1: "Will Repost: {subject}" with links to mark completed/withdraw/promise.
@@ -254,6 +270,7 @@ class AutoRepostService
                 'messages_groups.groupid',
                 'messages_groups.autoreposts',
                 'messages_groups.lastautopostwarning',
+                'messages_groups.rippled_in',
                 'messages.type',
                 'messages.subject',
                 'messages.fromaddr',

--- a/iznik-batch/app/Services/ChaseUpService.php
+++ b/iznik-batch/app/Services/ChaseUpService.php
@@ -368,9 +368,12 @@ class ChaseUpService
      * after max reposts reached.
      *
      * Multi-group: a chase-up is about the item's global outcome, so a cross-posted
-     * message is chased up at most once per interval (not once per group). When one
-     * is sent we stamp lastchaseup on EVERY group of the message (WHERE msgid = ?),
-     * matching V1, so the other groups skip it. Reposting stays per-group.
+     * message is chased up at most once per interval (not once per group). Two guards
+     * combine: (1) only the HOME posting (rippled_in = 0) may initiate a chase-up, so a
+     * post that rippled into other groups never chases up once per rippled group; and
+     * (2) when one is sent we stamp lastchaseup on EVERY group of the message
+     * (WHERE msgid = ?), matching V1, so any home cross-posts skip it too. Reposting
+     * stays per-group.
      *
      * V1 side effects included:
      *   - UPDATE messages_groups SET lastchaseup = NOW() (all the message's groups)
@@ -434,6 +437,17 @@ class ChaseUpService
         foreach ($messages as $msg) {
             // V1: Mail::ourDomain check.
             if (!MailHelper::isOurDomain($msg->fromaddr)) {
+                $stats['skipped']++;
+                continue;
+            }
+
+            // Rippling-out fix: anchor the chase-up to the message's HOME posting
+            // (rippled_in = 0). A "What happened to…" chase-up asks about the item's
+            // global outcome, so a row that rippled INTO this group must not initiate
+            // its own chase-up — that would email the poster once per rippled group.
+            // The home posting drives it (still deduped across any home cross-posts by
+            // the cross-group lastchaseup stamp below).
+            if ($msg->rippled_in) {
                 $stats['skipped']++;
                 continue;
             }
@@ -549,6 +563,7 @@ class ChaseUpService
                 'messages_groups.groupid',
                 'messages_groups.lastchaseup',
                 'messages_groups.autoreposts',
+                'messages_groups.rippled_in',
                 'messages.type',
                 'messages.subject',
                 'messages.fromaddr',
@@ -569,6 +584,7 @@ class ChaseUpService
                 'messages_groups.groupid',
                 'messages_groups.lastchaseup',
                 'messages_groups.autoreposts',
+                'messages_groups.rippled_in',
                 'messages.type',
                 'messages.subject',
                 'messages.fromaddr',

--- a/iznik-batch/tests/Unit/Services/AutoRepostServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/AutoRepostServiceTest.php
@@ -564,6 +564,103 @@ class AutoRepostServiceTest extends TestCase
     }
 
     /**
+     * Rippling-out: a post on its home group plus two rippled-into groups, all in the
+     * warning window, must remind the poster ONCE (from the home posting), not once per
+     * group. The reminder's buttons act on the whole item, so one email is enough.
+     */
+    public function test_warning_sent_once_across_rippled_groups(): void
+    {
+        $domain = config('freegle.mail.user_domain', 'users.ilovefreegle.org');
+        $user = $this->createTestUser();
+        $home = $this->createTestGroup();
+        $rippledA = $this->createTestGroup();
+        $rippledB = $this->createTestGroup();
+
+        DB::table('users')->where('id', $user->id)->update(['lastaccess' => now()->subHours(1)]);
+        $this->createMembership($user, $home, ['added' => now()->subDays(30)]);
+        $this->createMembership($user, $rippledA, ['added' => now()->subDays(30)]);
+        $this->createMembership($user, $rippledB, ['added' => now()->subDays(30)]);
+
+        // Home posting in the warning window (50h; offer interval 3d => window 48-72h).
+        $message = $this->createTestMessage($user, $home, [
+            'type' => 'Offer',
+            'fromaddr' => 'test-' . $user->id . '@' . $domain,
+            'source' => Message::SOURCE_PLATFORM,
+        ]);
+        DB::table('messages_groups')
+            ->where('msgid', $message->id)->where('groupid', $home->id)
+            ->update(['arrival' => now()->subHours(50), 'autoreposts' => 0, 'rippled_in' => 0]);
+
+        // Two rippled-in postings, also in the warning window.
+        foreach ([$rippledA, $rippledB] as $g) {
+            DB::table('messages_groups')->insert([
+                'msgid' => $message->id,
+                'groupid' => $g->id,
+                'collection' => MessageGroup::COLLECTION_APPROVED,
+                'arrival' => now()->subHours(50),
+                'autoreposts' => 0,
+                'rippled_in' => 1,
+            ]);
+        }
+
+        $stats = $this->service->process();
+
+        $this->assertEquals(1, $stats['warned'], 'rippled item must warn once, not once per group');
+        $this->assertEquals(0, $stats['reposted']);
+
+        // lastautopostwarning stamped on EVERY group so none re-fires next run.
+        $rows = DB::table('messages_groups')->where('msgid', $message->id)->get();
+        $this->assertCount(3, $rows);
+        foreach ($rows as $r) {
+            $this->assertNotNull($r->lastautopostwarning, 'every group of the item must be stamped');
+        }
+    }
+
+    /**
+     * Rippling-out: a rippled-in posting (rippled_in=1) is still reposted on its group to
+     * keep the item fresh there, but it never generates its own repost reminder email.
+     */
+    public function test_rippled_in_row_reposts_without_warning(): void
+    {
+        $domain = config('freegle.mail.user_domain', 'users.ilovefreegle.org');
+        $user = $this->createTestUser();
+        $home = $this->createTestGroup();
+        $rippled = $this->createTestGroup();
+
+        DB::table('users')->where('id', $user->id)->update(['lastaccess' => now()->subHours(1)]);
+        $this->createMembership($user, $home, ['added' => now()->subDays(30)]);
+        $this->createMembership($user, $rippled, ['added' => now()->subDays(30)]);
+
+        // Home posting still fresh (not in any window); rippled posting past the repost window.
+        $message = $this->createTestMessage($user, $home, [
+            'type' => 'Offer',
+            'fromaddr' => 'test-' . $user->id . '@' . $domain,
+            'source' => Message::SOURCE_PLATFORM,
+        ]);
+        DB::table('messages_groups')
+            ->where('msgid', $message->id)->where('groupid', $home->id)
+            ->update(['arrival' => now()->subHours(1), 'autoreposts' => 0, 'rippled_in' => 0]);
+
+        DB::table('messages_groups')->insert([
+            'msgid' => $message->id,
+            'groupid' => $rippled->id,
+            'collection' => MessageGroup::COLLECTION_APPROVED,
+            'arrival' => now()->subHours(80), // past the 72h offer interval
+            'autoreposts' => 0,
+            'rippled_in' => 1,
+        ]);
+
+        $stats = $this->service->process();
+
+        $this->assertEquals(1, $stats['reposted'], 'rippled-in row must still repost');
+        $this->assertEquals(0, $stats['warned'], 'rippled-in row must not generate a reminder');
+
+        $mgRippled = DB::table('messages_groups')
+            ->where('msgid', $message->id)->where('groupid', $rippled->id)->first();
+        $this->assertEquals(1, $mgRippled->autoreposts);
+    }
+
+    /**
      * Regression test for Discourse #9481 (posts 502-510): messages 119974515 and 116335125
      * were not auto-reposted even though they were eligible.
      *

--- a/iznik-batch/tests/Unit/Services/ChaseUpServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/ChaseUpServiceTest.php
@@ -308,6 +308,88 @@ class ChaseUpServiceTest extends TestCase
         }
     }
 
+    /**
+     * Rippling-out: a post eligible for chase-up on its home group that has also rippled
+     * into another group is chased up ONCE (anchored to the home posting), and the stamp
+     * lands on every group so neither re-fires.
+     */
+    public function test_rippled_item_chased_up_once_from_home(): void
+    {
+        $domain = config('freegle.mail.user_domain', 'users.ilovefreegle.org');
+        $user = $this->createTestUser();
+        $home = $this->createTestGroup();
+        $rippled = $this->createTestGroup();
+        $this->createMembership($user, $home, ['added' => now()->subDays(60)]);
+        $this->createMembership($user, $rippled, ['added' => now()->subDays(60)]);
+
+        $message = $this->createTestMessage($user, $home, [
+            'fromaddr' => 'test-' . $user->id . '@' . $domain,
+            'source' => Message::SOURCE_PLATFORM,
+        ]);
+
+        // Home posting: max reposts reached, old arrival, native (rippled_in=0).
+        DB::table('messages_groups')
+            ->where('msgid', $message->id)->where('groupid', $home->id)
+            ->update(['arrival' => now()->subHours(500), 'autoreposts' => 5, 'rippled_in' => 0]);
+
+        // Rippled-in posting: also "max reposts", but must NOT initiate a chase-up itself.
+        MessageGroup::create([
+            'msgid' => $message->id,
+            'groupid' => $rippled->id,
+            'collection' => MessageGroup::COLLECTION_APPROVED,
+            'arrival' => now()->subHours(500),
+        ]);
+        DB::table('messages_groups')
+            ->where('msgid', $message->id)->where('groupid', $rippled->id)
+            ->update(['autoreposts' => 5, 'rippled_in' => 1]);
+
+        $replier = $this->createTestUser();
+        $room = $this->createTestChatRoom($user, $replier);
+        $this->createTestChatMessage($room, $replier, [
+            'refmsgid' => $message->id,
+            'date' => now()->subHours(200),
+        ]);
+
+        $stats = $this->service->process();
+
+        $this->assertEquals(1, $stats['chased'], 'chase-up anchored to home posting: exactly one');
+        $rows = DB::table('messages_groups')->where('msgid', $message->id)->get();
+        foreach ($rows as $r) {
+            $this->assertNotNull($r->lastchaseup, 'lastchaseup must be set on every group of the item');
+        }
+    }
+
+    /**
+     * Rippling-out (defensive): a posting that exists ONLY as a rippled-in row (its home
+     * posting has gone) must not initiate a chase-up — that is the home posting's job.
+     */
+    public function test_rippled_only_item_is_not_chased_up(): void
+    {
+        $domain = config('freegle.mail.user_domain', 'users.ilovefreegle.org');
+        $user = $this->createTestUser();
+        $rippled = $this->createTestGroup();
+        $this->createMembership($user, $rippled, ['added' => now()->subDays(60)]);
+
+        $message = $this->createTestMessage($user, $rippled, [
+            'fromaddr' => 'test-' . $user->id . '@' . $domain,
+            'source' => Message::SOURCE_PLATFORM,
+        ]);
+        DB::table('messages_groups')
+            ->where('msgid', $message->id)->where('groupid', $rippled->id)
+            ->update(['arrival' => now()->subHours(500), 'autoreposts' => 5, 'rippled_in' => 1]);
+
+        $replier = $this->createTestUser();
+        $room = $this->createTestChatRoom($user, $replier);
+        $this->createTestChatMessage($room, $replier, [
+            'refmsgid' => $message->id,
+            'date' => now()->subHours(200),
+        ]);
+
+        $stats = $this->service->process();
+
+        $this->assertEquals(0, $stats['chased'], 'a rippled-only posting must not be chased up');
+    }
+
     public function test_constants(): void
     {
         $this->assertEquals(90, ChaseUpService::LOOKBACK_DAYS);

--- a/iznik-nuxt3/tests/unit/components/JobMosaicTile.spec.js
+++ b/iznik-nuxt3/tests/unit/components/JobMosaicTile.spec.js
@@ -304,7 +304,10 @@ describe('JobMosaicTile', () => {
     it('logs job click', async () => {
       const wrapper = createWrapper()
       await wrapper.find('.mosaic-tile').trigger('click')
-      expect(mockJobStore.log).toHaveBeenCalledWith({ id: 1 })
+      expect(mockJobStore.log).toHaveBeenCalledWith({
+        id: 1,
+        link: 'https://example.com/job/1',
+      })
     })
 
     it('navigates to /jobs when not already on jobs page', async () => {

--- a/iznik-nuxt3/tests/unit/components/JobOne.spec.js
+++ b/iznik-nuxt3/tests/unit/components/JobOne.spec.js
@@ -218,7 +218,10 @@ describe('JobOne', () => {
     it('logs click to jobStore', async () => {
       const wrapper = createWrapper()
       await wrapper.find('.job-item').trigger('click')
-      expect(mockJobStore.log).toHaveBeenCalledWith({ id: 123 })
+      expect(mockJobStore.log).toHaveBeenCalledWith({
+        id: 123,
+        link: 'https://jobs.example.com/123',
+      })
     })
 
     it('logs click action for analytics', async () => {


### PR DESCRIPTION
## Problem

Rippling-out puts a single post on many groups (`messages_groups.rippled_in = 1`). Auto-reposting runs per group, which is correct for the *repost* (it keeps the item fresh in each community), but the poster-facing **notification emails** were not deduplicated across groups:

- **Auto-repost warning ("Will Repost: …")** — `AutoRepostService` stamped `lastautopostwarning` per group (`WHERE msgid = ? AND groupid = ?`), so a widely-rippled item could email the poster once per group, per cycle. Because rippled-in rows get a fresh `arrival` as the reach expands over hours/days, their repost windows are *staggered*, so even a simple "stamp all groups" 24h dedup would still leak repeat emails days apart.
- **Chase-up ("What happened to: …")** — `ChaseUpService` already stamped `lastchaseup` on every group, but shared the same staggered-window hole (a rippled row reaching max-reposts later could re-chase).

## Key insight

Every action on these emails (`…/mypost/{msgid}/completed|withdraw|promise`) is recorded against the **msgid**, and both the auto-repost and chase-up candidate queries exclude any message that has an outcome/promise. So one response already stops reposting and chasing on **every** group — one email per item loses nothing.

## Fix

Anchor both poster-facing notifications to the post's **home posting** (`rippled_in = 0`), leaving the repost itself per-group.

- **Warning** — only a `rippled_in = 0` row sends it; rippled rows still repost silently. When sent, stamp `lastautopostwarning` across **every** group of the message (revert to V1's `WHERE msgid = ?`).
- **Chase-up** — only a `rippled_in = 0` row may initiate it; keep the existing all-groups `lastchaseup` stamp. Closes the staggered-window hole.
- **Reposting stays per-group** — unchanged (`test_multiple_groups_each_repost_independently` preserved).

## Docs — deep-dive accuracy pass

Verified every rippling claim in both guides against the code and corrected:

**Moderators:**
- Rippled-in posts are **approved on arrival by default** (`rippled_in_pending_hours = 0`), not "~1h in pending"; documented the optional mod-veto window.
- Reach button label corrected to **"View rippling reach"**.
- Edit warning corrected to include the group count.
- **TrashNothing** is currently **excluded** from rippling (was: "behaves exactly like any other post").
- Held replies also release when a post **finishes spreading** (not only when it reaches the member).
- New "repost reminders & chase-ups happen once per item" section.

**Members:**
- Reply-saturation note (a post stops spreading once enough people nearby reply).
- "Reminders about your post" once-per-item section + summary-table row.

(The audit also flagged the "What's New" subject-cap as reverted — that was the main checkout's unrelated uncommitted WIP; this branch, from committed HEAD, has the fix, so the docs are accurate here.)

## Tests

4 new (all green in a filtered Unit run — 81 cases, 0 failed):
- `AutoRepostServiceTest::test_warning_sent_once_across_rippled_groups`
- `AutoRepostServiceTest::test_rippled_in_row_reposts_without_warning`
- `ChaseUpServiceTest::test_rippled_item_chased_up_once_from_home`
- `ChaseUpServiceTest::test_rippled_only_item_is_not_chased_up`

Design spec: `docs/superpowers/specs/2026-06-25-repost-reminder-dedup-rippling-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)