### PR TITLE
feat(rippling): trial-groups-only scope on the sysadmin dashboard

### DIFF
--- a/iznik-batch/app/Console/Commands/Ripple/ExpandCommand.php
+++ b/iznik-batch/app/Console/Commands/Ripple/ExpandCommand.php
@@ -32,6 +32,15 @@ class ExpandCommand extends Command
         $this->registerShutdownHandlers();
 
         $dryRun = (bool) $this->option('dry-run');
+
+        // Mirror the current trial group set (RIPPLE_WITHIN_GROUPS) into the shared
+        // `config` table (key 'ripple.within_groups') so the Go API - which runs on a
+        // different server and can't read this batch env var - can scope the rippling
+        // dashboard to just the trial groups. Cheap upsert; skipped on --dry-run.
+        if (!$dryRun) {
+            $this->publishTrialGroups();
+        }
+
         $limit = max(1, (int) $this->option('limit'));
         $onlyMsgid = $this->option('msgid') !== null ? (int) $this->option('msgid') : null;
 
@@ -77,6 +86,25 @@ class ExpandCommand extends Command
         Log::info('ripple:expand complete', $stats);
 
         return $stats['errors'] > 0 ? Command::FAILURE : Command::SUCCESS;
+    }
+
+    /**
+     * Publish the current rippling trial group set into the shared `config` table.
+     *
+     * The trial groups live in RIPPLE_WITHIN_GROUPS (config freegle.ripple.within_groups),
+     * which only the batch container sees. The Go API runs on a separate server, so it reads
+     * the value from the `config` table (key 'ripple.within_groups') to scope the rippling
+     * dashboard to the trial groups. We upsert a comma-separated id list on each run.
+     */
+    protected function publishTrialGroups(): void
+    {
+        $withinGroups = array_map('strval', (array) config('freegle.ripple.within_groups', []));
+
+        DB::table('config')->upsert(
+            [['key' => 'ripple.within_groups', 'value' => implode(',', $withinGroups)]],
+            ['key'],
+            ['value'],
+        );
     }
 
     /**

--- a/iznik-batch/tests/Unit/Commands/Ripple/ExpandCommandTest.php
+++ b/iznik-batch/tests/Unit/Commands/Ripple/ExpandCommandTest.php
@@ -33,13 +33,14 @@ class ExpandCommandTest extends TestCase
      */
     public function test_publishes_trial_group_set_to_config(): void
     {
+        Http::fake();
         config(['freegle.ripple.within_groups' => ['111', '222']]);
         DB::table('config')->where('key', 'ripple.within_groups')->delete();
 
-        $command = new \App\Console\Commands\Ripple\ExpandCommand();
-        $method = new \ReflectionMethod($command, 'publishTrialGroups');
-        $method->setAccessible(true);
-        $method->invoke($command);
+        // A real (non-dry-run) run mirrors RIPPLE_WITHIN_GROUPS into config via handle(),
+        // so the Go API (a different server, no access to this batch env var) can read the
+        // trial set. --dry-run deliberately skips the publish (covered by the run-clean test).
+        $this->artisan('ripple:expand', ['--limit' => 1])->assertExitCode(0);
 
         $this->assertSame(
             '111,222',
@@ -47,9 +48,9 @@ class ExpandCommandTest extends TestCase
             'RIPPLE_WITHIN_GROUPS is mirrored into config for the Go API to read'
         );
 
-        // Re-publishing a changed set upserts (one row, updated value), not a duplicate.
+        // Re-running with a changed set upserts (one row, updated value), not a duplicate.
         config(['freegle.ripple.within_groups' => ['333']]);
-        $method->invoke($command);
+        $this->artisan('ripple:expand', ['--limit' => 1])->assertExitCode(0);
         $this->assertSame('333', DB::table('config')->where('key', 'ripple.within_groups')->value('value'));
         $this->assertSame(1, DB::table('config')->where('key', 'ripple.within_groups')->count());
 

--- a/iznik-batch/tests/Unit/Commands/Ripple/ExpandCommandTest.php
+++ b/iznik-batch/tests/Unit/Commands/Ripple/ExpandCommandTest.php
@@ -27,6 +27,36 @@ class ExpandCommandTest extends TestCase
     }
 
     /**
+     * publishTrialGroups mirrors RIPPLE_WITHIN_GROUPS into the shared `config` table so the Go API
+     * (which runs on a different server and can't read this batch env var) can scope the rippling
+     * dashboard to the trial groups. Upserts a comma-separated id list keyed 'ripple.within_groups'.
+     */
+    public function test_publishes_trial_group_set_to_config(): void
+    {
+        config(['freegle.ripple.within_groups' => ['111', '222']]);
+        DB::table('config')->where('key', 'ripple.within_groups')->delete();
+
+        $command = new \App\Console\Commands\Ripple\ExpandCommand();
+        $method = new \ReflectionMethod($command, 'publishTrialGroups');
+        $method->setAccessible(true);
+        $method->invoke($command);
+
+        $this->assertSame(
+            '111,222',
+            DB::table('config')->where('key', 'ripple.within_groups')->value('value'),
+            'RIPPLE_WITHIN_GROUPS is mirrored into config for the Go API to read'
+        );
+
+        // Re-publishing a changed set upserts (one row, updated value), not a duplicate.
+        config(['freegle.ripple.within_groups' => ['333']]);
+        $method->invoke($command);
+        $this->assertSame('333', DB::table('config')->where('key', 'ripple.within_groups')->value('value'));
+        $this->assertSame(1, DB::table('config')->where('key', 'ripple.within_groups')->count());
+
+        DB::table('config')->where('key', 'ripple.within_groups')->delete();
+    }
+
+    /**
      * --within-group accepts a comma-separated list of group ids (the experiment scope) and resolves
      * it to the union of those groups' polyindex polygons. MySQL ST_Union is binary, so the command
      * chains it over per-id subqueries; this exercises that path with two real group polygons.

--- a/iznik-nuxt3/api/RipplingAPI.js
+++ b/iznik-nuxt3/api/RipplingAPI.js
@@ -4,11 +4,14 @@ export default class RipplingAPI extends BaseAPI {
   // Rippling-out live event counters for sysadmin (§15/§16). Support/Admin only.
   // Optional groupid scopes the reply/reuse KPIs to one origin group (0 = all);
   // start/end bound the headline KPI date range (default last 30 days server-side).
-  fetchMetrics(groupid = 0, start = '', end = '') {
+  // trialOnly scopes every KPI to the RIPPLE_WITHIN_GROUPS trial set so the trial
+  // signal isn't buried by the majority of groups that aren't rippling yet.
+  fetchMetrics(groupid = 0, start = '', end = '', trialOnly = false) {
     const params = {}
     if (groupid) params.groupid = groupid
     if (start) params.start = start
     if (end) params.end = end
+    if (trialOnly) params.trialOnly = 1
     return this.$getv2('/rippling/metrics', params)
   }
 }

--- a/iznik-nuxt3/modtools/components/ModSysAdminRippling.vue
+++ b/iznik-nuxt3/modtools/components/ModSysAdminRippling.vue
@@ -21,8 +21,25 @@
     </div>
     <div v-else-if="error" class="text-danger">Failed to load: {{ error }}</div>
     <div v-else>
+      <b-form-checkbox
+        v-model="trialOnly"
+        switch
+        size="sm"
+        class="mb-2"
+        @change="onTrialChange"
+      >
+        Trial groups only<span
+          v-if="trialOnly && trialGroupIds.length"
+          class="text-muted small"
+        >
+          ({{ trialGroupIds.length }} in RIPPLE_WITHIN_GROUPS)</span>
+      </b-form-checkbox>
+      <p v-if="trialOnly && !trialGroupIds.length" class="text-warning small mb-2">
+        No trial groups configured (RIPPLE_WITHIN_GROUPS is empty) - nothing to show.
+      </p>
+
       <b-form-group
-        v-if="groupOptions.length"
+        v-if="groupOptions.length && !trialOnly"
         label="Group:"
         label-cols="auto"
         label-class="small fw-bold"
@@ -252,6 +269,11 @@ const takenRate = ref([])
 // Per-group KPI filter (results differ a lot by place; 0 = all groups).
 const groupOptions = ref([])
 const groupFilter = ref(0)
+// Trial scope: limit every KPI to the RIPPLE_WITHIN_GROUPS trial set so the trial
+// signal isn't masked by the majority of groups that aren't rippling. trialGroupIds
+// echoes the resolved set back from the server (drives the count + empty warning).
+const trialOnly = ref(false)
+const trialGroupIds = ref([])
 
 const COHORT_HEADER = (allLabel) => [
   'Date',
@@ -404,7 +426,8 @@ async function fetchMetrics() {
     const result = await apiInstance.rippling.fetchMetrics(
       groupFilter.value,
       startDate.value,
-      endDate.value
+      endDate.value,
+      trialOnly.value
     )
     hotspots.value = result?.hotspots || []
     heldReplySummary.value = result?.held_reply_summary || []
@@ -414,6 +437,7 @@ async function fetchMetrics() {
     replyDistance.value = result?.reply_distance_median || []
     takenRate.value = result?.taken_rate || []
     groupOptions.value = result?.groups || []
+    trialGroupIds.value = result?.trial_group_ids || []
   } catch (e) {
     error.value = e.message || 'Unknown error'
   } finally {
@@ -425,6 +449,13 @@ function onGroupChange() {
   fetchMetrics()
 }
 
+function onTrialChange() {
+  // Trial scope and a single-group filter are mutually exclusive (the server lets
+  // groupid win), so clear the group filter when switching to trial-only.
+  groupFilter.value = 0
+  fetchMetrics()
+}
+
 // ModEmailDateFilter fires this on mount and whenever the period changes, so it
 // drives the initial load too (no separate onMounted fetch needed).
 function onFilterFetch({ start, end }) {
@@ -433,5 +464,13 @@ function onFilterFetch({ start, end }) {
   fetchMetrics()
 }
 
-defineExpose({ fetchMetrics, groupFilter, onGroupChange, onFilterFetch })
+defineExpose({
+  fetchMetrics,
+  groupFilter,
+  onGroupChange,
+  onFilterFetch,
+  trialOnly,
+  trialGroupIds,
+  onTrialChange,
+})
 </script>

--- a/iznik-nuxt3/tests/unit/components/modtools/ModSysAdminRippling.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModSysAdminRippling.spec.js
@@ -34,6 +34,10 @@ function mountComponent() {
           template: '<select><slot /></select>',
           props: ['modelValue'],
         },
+        'b-form-checkbox': {
+          template: '<label><slot /></label>',
+          props: ['modelValue'],
+        },
         // Drive the initial fetch deterministically: the real filter fires
         // 'fetch' on mount, so the stub mirrors that with a fixed range.
         ModEmailDateFilter: {
@@ -64,7 +68,40 @@ describe('ModSysAdminRippling', () => {
     const wrapper = mountComponent()
     await flushPromises()
 
-    expect(mockFetchMetrics).toHaveBeenCalledWith(0, '2026-05-24', '2026-06-23')
+    expect(mockFetchMetrics).toHaveBeenCalledWith(0, '2026-05-24', '2026-06-23', false)
+    wrapper.unmount()
+  })
+
+  it('scopes the metrics to the trial groups when "Trial groups only" is on', async () => {
+    mockFetchMetrics.mockResolvedValue({ trial_group_ids: [111, 222] })
+
+    const wrapper = mountComponent()
+    await flushPromises()
+    mockFetchMetrics.mockClear()
+
+    // Turn on the trial scope and refetch via the exposed handler.
+    wrapper.vm.trialOnly = true
+    wrapper.vm.onTrialChange()
+    await flushPromises()
+
+    // The refetch carries trialOnly=true (4th arg) with the group filter reset to 0,
+    // and the resolved trial set is surfaced in the UI.
+    expect(mockFetchMetrics).toHaveBeenCalledWith(0, '2026-05-24', '2026-06-23', true)
+    expect(wrapper.html()).toContain('in RIPPLE_WITHIN_GROUPS')
+    wrapper.unmount()
+  })
+
+  it('warns when trial scope is on but no trial groups are configured', async () => {
+    mockFetchMetrics.mockResolvedValue({ trial_group_ids: [] })
+
+    const wrapper = mountComponent()
+    await flushPromises()
+
+    wrapper.vm.trialOnly = true
+    wrapper.vm.onTrialChange()
+    await flushPromises()
+
+    expect(wrapper.html()).toContain('No trial groups configured')
     wrapper.unmount()
   })
 

--- a/iznik-server-go/rippling/metrics.go
+++ b/iznik-server-go/rippling/metrics.go
@@ -3,6 +3,8 @@
 package rippling
 
 import (
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -186,6 +188,32 @@ type GroupOption struct {
 	Name string `json:"name" gorm:"column:name"`
 }
 
+// trialGroupIDs returns the rippling trial group set. Laravel mirrors the current
+// RIPPLE_WITHIN_GROUPS value into the shared `config` table (key 'ripple.within_groups')
+// because the Go API runs on a different server and can't read that batch env var
+// directly. Returns an empty slice when the key is absent/empty or holds no valid ids.
+func trialGroupIDs() []uint64 {
+	var value string
+	database.DBConn.Raw("SELECT value FROM config WHERE `key` = 'ripple.within_groups'").Scan(&value)
+	ids := []uint64{}
+	for _, p := range strings.Split(value, ",") {
+		if n, err := strconv.ParseUint(strings.TrimSpace(p), 10, 64); err == nil && n > 0 {
+			ids = append(ids, n)
+		}
+	}
+	return ids
+}
+
+// uint64InList renders ids as a comma-separated SQL IN(...) body. Safe to inline:
+// the values are validated uint64s, not user-supplied strings.
+func uint64InList(ids []uint64) string {
+	parts := make([]string, len(ids))
+	for i, id := range ids {
+		parts[i] = strconv.FormatUint(id, 10)
+	}
+	return strings.Join(parts, ",")
+}
+
 // Metrics returns the rippling-out event counters plus the §15/§16 rollout-health metrics.
 // Events: reply_blocked (#2), held/released/taken_gone (#3), secondary_reject (#6),
 // immediate_mailed (#0), rippled_in (#6). Support/Admin only.
@@ -211,6 +239,18 @@ func Metrics(c *fiber.Ctx) error {
 	// rippled_in=0 messages_groups row), so results read per place - dense Croydon won't look
 	// like rural Ribble Valley. 0 = all groups. Each scoped query takes one gid arg.
 	gid := c.QueryInt("groupid", 0)
+	// Optional ?trialOnly=1 scopes every KPI to the rippling TRIAL groups (the set in
+	// RIPPLE_WITHIN_GROUPS). During the trial only a handful of groups ripple, so stats
+	// over all groups bury the signal under the majority that aren't rippling. The Go API
+	// runs on a different server from the batch container that holds that env var, so
+	// Laravel mirrors the current value into the shared `config` table (key
+	// 'ripple.within_groups') and we read it here. ?groupid= (a single group) wins when both
+	// are given.
+	trialOnly := c.QueryBool("trialOnly", false)
+	trialIDs := []uint64{}
+	if trialOnly && gid == 0 {
+		trialIDs = trialGroupIDs()
+	}
 	// Optional ?start= & ?end= date range bounds every KPI below; default to the last 30 days.
 	// This is what lets you read a treatment group's before vs after rippling went on.
 	start := c.Query("start")
@@ -226,6 +266,19 @@ func Metrics(c *fiber.Ctx) error {
 		rateGroup = " AND mg.groupid = ? AND mg.rippled_in = 0"
 		srcGroup = " JOIN messages_groups mg ON mg.msgid = rra.msgid AND mg.groupid = ? AND mg.rippled_in = 0 AND mg.deleted = 0"
 		distGroup = " JOIN messages_groups mg ON mg.msgid = m.id AND mg.groupid = ? AND mg.rippled_in = 0 AND mg.deleted = 0"
+	} else if trialOnly {
+		// Inline the trial group ids as an IN(...) literal: they are validated uint64s read
+		// from trusted config, so there is no injection risk and no new bind args (the
+		// arg-builders only add a value when gid>0, so they stay correct). When the trial set
+		// is unset we scope to IN(0) so "trial only" honestly yields no data rather than
+		// silently showing all groups.
+		inList := "0"
+		if len(trialIDs) > 0 {
+			inList = uint64InList(trialIDs)
+		}
+		rateGroup = " AND mg.groupid IN (" + inList + ") AND mg.rippled_in = 0"
+		srcGroup = " JOIN messages_groups mg ON mg.msgid = rra.msgid AND mg.groupid IN (" + inList + ") AND mg.rippled_in = 0 AND mg.deleted = 0"
+		distGroup = " JOIN messages_groups mg ON mg.msgid = m.id AND mg.groupid IN (" + inList + ") AND mg.rippled_in = 0 AND mg.deleted = 0"
 	}
 	// Per-query args: the group filter (when set) sits in a JOIN before the date-bounded WHERE,
 	// so gid comes first, then start, end.
@@ -638,6 +691,8 @@ func Metrics(c *fiber.Ctx) error {
 		"taken_rate":            takenRates,
 		"groups":                groupOpts,
 		"groupid":               gid,
+		"trial_only":            trialOnly,
+		"trial_group_ids":       trialIDs,
 		"start":                 start,
 		"end":                   end,
 	})

--- a/iznik-server-go/test/rippling_metrics_test.go
+++ b/iznik-server-go/test/rippling_metrics_test.go
@@ -581,3 +581,37 @@ func TestRipplingMetricsDistanceCohorts(t *testing.T) {
 	// Near replier is at the same spot as the post (~0 km); far replier is in Edinburgh (~535 km).
 	assert.Greater(t, row["ripple_median_km"].(float64), row["home_median_km"].(float64), "rippled replies are further away")
 }
+
+// ?trialOnly=1 scopes the metrics to the RIPPLE_WITHIN_GROUPS trial set, which Laravel mirrors
+// into config['ripple.within_groups'] (the Go API runs on a different server and can't read that
+// batch env var). The endpoint echoes the resolved set so the dashboard can show it. Without the
+// param there is no trial scope and the set is empty.
+func TestRipplingMetricsTrialScope(t *testing.T) {
+	prefix := uniquePrefix("rippletrial")
+	adminID := CreateTestUser(t, prefix+"_admin", "Support")
+	_, token := CreateTestSession(t, adminID)
+
+	db := database.DBConn
+	db.Exec("INSERT INTO config (`key`, value) VALUES ('ripple.within_groups', '99000001,99000002') " +
+		"ON DUPLICATE KEY UPDATE value = VALUES(value)")
+	defer db.Exec("DELETE FROM config WHERE `key` = 'ripple.within_groups'")
+
+	// With the param: trial_only flagged and trial_group_ids echoes the config-mirrored set.
+	resp, _ := getApp().Test(httptest.NewRequest("GET", fmt.Sprintf("/api/rippling/metrics?trialOnly=1&jwt=%s", token), nil))
+	assert.Equal(t, 200, resp.StatusCode)
+	var result map[string]interface{}
+	json.Unmarshal(rsp(resp), &result)
+	assert.Equal(t, true, result["trial_only"], "trial_only flagged when ?trialOnly=1")
+	ids, _ := result["trial_group_ids"].([]interface{})
+	assert.ElementsMatch(t, []interface{}{float64(99000001), float64(99000002)}, ids,
+		"trial_group_ids echoes RIPPLE_WITHIN_GROUPS mirrored via config")
+
+	// Without the param: no trial scope, empty set (even though the config row exists).
+	resp2, _ := getApp().Test(httptest.NewRequest("GET", fmt.Sprintf("/api/rippling/metrics?jwt=%s", token), nil))
+	assert.Equal(t, 200, resp2.StatusCode)
+	var result2 map[string]interface{}
+	json.Unmarshal(rsp(resp2), &result2)
+	assert.Equal(t, false, result2["trial_only"], "trial_only false without the param")
+	ids2, _ := result2["trial_group_ids"].([]interface{})
+	assert.Empty(t, ids2, "trial_group_ids empty without the param")
+}


### PR DESCRIPTION
## Why

During the rippling trial, only the groups in `RIPPLE_WITHIN_GROUPS` actually ripple. The sysadmin Rippling dashboard aggregates over **all** groups, so the trial signal is buried under the hundreds of groups that aren't rippling yet - you can't see the trial's impact.

## The cross-server problem

In production `apiv2` (Go) and the batch container run on **different servers**, so the Go API can't read the `RIPPLE_WITHIN_GROUPS` env var. The shared medium is the DB. So:

- **Laravel** (`ripple:expand`) mirrors the current `RIPPLE_WITHIN_GROUPS` value into the shared `config` table (key `ripple.within_groups`) on each run - the same key/value store the Go API already reads for `app_min_webversion` and `deploy.laravel_commit`.
- **Go** (`rippling/metrics.go`) reads that row under `?trialOnly=1` and scopes every KPI to the trial set via an inlined `IN(...)` of validated `uint64`s (no new bind args; the existing arg-builders stay correct). `IN(0)` when the set is unset, so "trial only" honestly shows **nothing** rather than silently showing all groups. The response echoes `trial_only` + `trial_group_ids`.
- **UI** (`ModSysAdminRippling.vue`): a **"Trial groups only"** toggle that surfaces the resolved trial-group count and warns when `RIPPLE_WITHIN_GROUPS` is empty. `?groupid=` (single-group drill-down) still wins when both are set.

This reads the **authoritative** trial set (the exact env var), not a proxy, so the dashboard shows precisely the groups in the trial.

## Tests

- **Laravel** `ExpandCommandTest`: publishes the set to `config`, and re-publishing a changed set upserts (one row) rather than duplicating. (3/3)
- **Go** `TestRipplingMetricsTrialScope`: `?trialOnly=1` echoes the config-mirrored set and flags the scope; absent param → no scope, empty set. (full suite 3259/0)
- **Component spec**: the toggle refetches with `trialOnly=true` and group filter reset, surfaces the set, and warns when empty; updated the existing `fetchMetrics` assertion for the new arg. (11/11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)