### PR TITLE
DB read/write connection split (batch + Go API, V1 parity); login wording fix

### DIFF
--- a/.env.background.example
+++ b/.env.background.example
@@ -13,8 +13,11 @@ APP_KEY=base64:GENERATE_A_NEW_KEY_HERE
 # =============================================================================
 # Database Configuration
 # =============================================================================
-# Production database server IP address
+# Production database server IP address (the single Galera WRITE node).
 DB_HOST_IP=10.x.x.x
+# Optional read-replica IP for the read/write split. Leave blank to send all
+# reads to DB_HOST_IP (single-host behaviour). Writes always go to DB_HOST_IP.
+DB_HOST_READ_IP=
 # Database password
 DB_PASSWORD=your_database_password_here
 

--- a/.env.example
+++ b/.env.example
@@ -74,6 +74,12 @@ COVERALLS_REPO_TOKEN=your_coveralls_repo_token_here
 # For local development: Use "iznik" (the default dev password)
 MYSQL_PRODUCTION_ROOT_PASSWORD=iznik
 
+# Optional read replica for the database read/write split (apiv2-live / Go API
+# and batch-prod / Laravel). Leave blank to send all reads to the write host;
+# writes always go to the write host. See DATABASE-READ-WRITE-SPLIT.md.
+# LIVE_DB_READ_HOST=          # read-replica host for apiv2-live (Go)
+# DB_HOST_READ_IP=            # read-replica IP for batch-prod (Laravel)
+
 # Sentry Integration (Optional - for automated error fixing with Claude Code CLI)
 # See SENTRY-INTEGRATION.md for setup instructions
 # Requires 'claude' CLI to be installed and configured

--- a/DATABASE-READ-WRITE-SPLIT.md
+++ b/DATABASE-READ-WRITE-SPLIT.md
@@ -1,0 +1,94 @@
+# Database read/write split
+
+Both the Laravel batch app (`iznik-batch`) and the Go API (`iznik-server-go`)
+can split database traffic so that **all writes go to one host** while **reads
+go to a separate host**. This mirrors the V1 split (`SQLHOSTS_MOD` /
+`SQLHOSTS_READ` in `iznik-server`) and exists to protect the single Galera write
+node from cluster write conflicts and lockups, and to offload read load.
+
+It is **off by default**: with no read host configured, both apps behave exactly
+as a single-host deployment. Nothing changes until you set the read-host env var.
+
+## Enabling it
+
+| App | Write host (always) | Read host (optional) |
+|-----|---------------------|----------------------|
+| Laravel batch | `DB_HOST` | `DB_HOST_READ` (blank/unset → `DB_HOST`) |
+| Go API | `MYSQL_HOST` | `MYSQL_HOST_READ` (blank/unset → no split) |
+
+Both read vars accept a comma-separated list; one host is chosen at random per
+connection (V1 parity).
+
+Production wiring is already in place in `docker-compose.yml`:
+
+- **batch-prod**: `DB_HOST_READ=db-host-read`, an `extra_hosts` alias that
+  resolves to `DB_HOST_READ_IP` (falling back to `DB_HOST_IP`). Set
+  `DB_HOST_READ_IP` in `.env.background` to activate.
+- **apiv2-live**: `MYSQL_HOST_READ=${LIVE_DB_READ_HOST:-}`. Set `LIVE_DB_READ_HOST`
+  to activate.
+
+## How routing works
+
+### Laravel (native read/write connection)
+
+`config/database.php` gives the `mysql` connection `read` / `write` host arrays
+(`sticky => false`). Laravel routes automatically, with **no per-query changes**:
+
+- `SELECT` (`DB::select`, query-builder `get/first/pluck/value/count`, Eloquent
+  reads) → **read** host.
+- `INSERT / UPDATE / DELETE / statement / affectingStatement` → **write** host.
+- Everything inside an **open transaction** → **write** connection. Laravel's
+  `getReadPdo()` returns the write PDO whenever `transactions > 0`, so a
+  transaction always sees its own uncommitted writes - the one case that must
+  stay on a single node.
+
+There is **no `sticky`**. Galera replication is synchronous (certification-based),
+so a committed write is visible on the read nodes without meaningful delay; reads
+always use the read host - even in long-running daemons - which is the point of
+the split and matches V1 (which had no sticky). Sticky would pin a daemon's reads
+to the write node after its first write and defeat offloading. If a particular
+read node ever needs hard read-your-writes across nodes, enable Galera
+`wsrep_sync_wait` there rather than re-introducing sticky.
+
+### Go (GORM dbresolver)
+
+`database/database.go` registers `gorm.io/plugin/dbresolver` only when
+`MYSQL_HOST_READ` is set. Routing is by statement:
+
+- Plain `SELECT` (not `... FOR UPDATE`) → **replica** (read host).
+- `db.Exec(...)`, GORM `Create/Save/Updates/Delete`, `SELECT ... FOR UPDATE`,
+  DDL, and every transaction → **source** (write host).
+- `db.DB()` returns the source pool, so the `LastInsertId` write sites that drop
+  to the raw `*sql.DB` are unaffected.
+
+Unlike Laravel there is **no sticky / per-request pinning** in Go: each statement
+is routed independently. Plain reads that immediately follow a write may observe
+brief replica lag (the same behaviour V1 had). This is acceptable for the
+existing read-back patterns, but see the caveat below for connection-local
+state, which is a hard break rather than mere staleness.
+
+## Caveat: connection-local state must be pinned to the writer
+
+State that lives on a single connection - **temporary tables**, session
+variables (`SET @x`), `GET_LOCK`, `FOUND_ROWS()` - is created on the write host
+but a later plain `SELECT` would be routed to the replica, where it does not
+exist. Such reads must be pinned to the writer:
+
+- **Go**: `database.DBConn.Clauses(dbresolver.Write).Raw(...)`. A fresh handle is
+  required per statement (a `.Clauses()` result is not reusable). See
+  `authority.GetStatsByAuthority`, the only such site (a `CREATE TEMPORARY TABLE`
+  followed by reads), which is pinned and covered by tests in
+  `authority/stats_split_test.go`.
+- **Laravel**: the one temp-table command (`UpdateAIImageUsageCountsCommand`) is
+  safe without any pinning because its temporary table is only ever accessed by
+  writes - `CREATE TEMPORARY TABLE` and an `UPDATE ... JOIN` it - which all use
+  the write connection. Its only plain `SELECT` reads a real table
+  (`ai_images`), not the temp table. Any future Laravel code that reads a temp
+  table / session variable via a plain `SELECT` must either run inside a
+  transaction (which routes reads to the write connection) or read it via the
+  write connection explicitly.
+
+A full audit found these to be the only connection-local patterns in either
+codebase (no `SET @`, `GET_LOCK`, `FOUND_ROWS`, or `LOCK TABLES`; the many
+`LAST_INSERT_ID(id)` uses are all single `ON DUPLICATE KEY UPDATE` statements,
+which are safe).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -864,6 +864,10 @@ services:
     restart: "no"
     environment:
       - MYSQL_HOST=db-live
+      # Optional read replica for the DB read/write split. Empty = single-host
+      # (all reads use MYSQL_HOST); set LIVE_DB_READ_HOST to route reads to a
+      # replica. Writes always go to MYSQL_HOST.
+      - MYSQL_HOST_READ=${LIVE_DB_READ_HOST:-}
       - MYSQL_PORT=${LIVE_DB_PORT:-1234}
       - MYSQL_USER=${LIVE_DB_USER:-root}
       - MYSQL_PASSWORD=${LIVE_DB_PASSWORD:-}
@@ -1633,6 +1637,9 @@ services:
       - ${FIREBASE_HOST_PATH:-/dev/null}:/etc/firebase.json:ro
     extra_hosts:
       - "db-host:${DB_HOST_IP:-127.0.0.1}"
+      # Read replica for the DB read/write split. Falls back to the write host
+      # (DB_HOST_IP) when DB_HOST_READ_IP is not set, giving single-host behaviour.
+      - "db-host-read:${DB_HOST_READ_IP:-${DB_HOST_IP:-127.0.0.1}}"
       - "mail-host:${MAIL_HOST_IP:-127.0.0.1}"
     depends_on:
       loki:
@@ -1654,6 +1661,9 @@ services:
       # Database (production)
       - DB_CONNECTION=mysql
       - DB_HOST=db-host
+      # Reads go to the replica alias; it resolves to the write host unless
+      # DB_HOST_READ_IP is set in .env.background (see extra_hosts above).
+      - DB_HOST_READ=db-host-read
       - DB_PORT=3306
       - DB_DATABASE=iznik
       - DB_USERNAME=root

--- a/iznik-batch/.env.example
+++ b/iznik-batch/.env.example
@@ -21,7 +21,8 @@ LOG_DEPRECATIONS_CHANNEL=null
 LOG_LEVEL=debug
 
 DB_CONNECTION=sqlite
-# DB_HOST=127.0.0.1
+# DB_HOST=127.0.0.1                 # the (write) host - all writes go here
+# DB_HOST_READ=                     # optional read replica; blank = same as DB_HOST
 # DB_PORT=3306
 # DB_DATABASE=laravel
 # DB_USERNAME=root

--- a/iznik-batch/config/database.php
+++ b/iznik-batch/config/database.php
@@ -44,10 +44,31 @@ return [
         ],
 
         // Main connection - uses iznik database (or iznik_batch_test for PHPUnit).
+        //
+        // Read/write split (V1 parity: SQLHOSTS_READ / SQLHOSTS_MOD). Writes always
+        // go to DB_HOST - the single Galera write node - to avoid cluster write
+        // conflicts and lockups. Reads go to DB_HOST_READ when set, otherwise fall
+        // back to DB_HOST so single-host deployments (dev/CI) are unchanged. Both
+        // accept a comma-separated list of hosts; Laravel picks one at random.
+        //
+        // No 'sticky': Galera replication is synchronous (certification-based), so a
+        // committed write is visible on the read nodes without meaningful delay -
+        // reads can always use the read host, even in long-running daemons (V1 had no
+        // sticky either). The only case that must stay on one node is an OPEN
+        // transaction, whose uncommitted changes are node-local; Laravel already
+        // routes every read to the write connection while a transaction is open
+        // (getReadPdo() checks transactions > 0 before anything else), so sticky is
+        // unnecessary for that and would only defeat read offloading.
         'mysql' => [
             'driver' => 'mysql',
             'url' => env('DB_URL'),
-            'host' => env('DB_HOST', '127.0.0.1'),
+            'read' => [
+                'host' => array_map('trim', explode(',', (string) (env('DB_HOST_READ') ?: env('DB_HOST', '127.0.0.1')))),
+            ],
+            'write' => [
+                'host' => array_map('trim', explode(',', (string) env('DB_HOST', '127.0.0.1'))),
+            ],
+            'sticky' => false,
             'port' => env('DB_PORT', '3306'),
             'database' => defined('PHPUNIT_COMPOSER_INSTALL') ? 'iznik_batch_test' : env('DB_DATABASE', 'iznik'),
             'username' => env('DB_USERNAME', 'root'),

--- a/iznik-batch/tests/Unit/Config/DatabaseReadWriteSplitTest.php
+++ b/iznik-batch/tests/Unit/Config/DatabaseReadWriteSplitTest.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace Tests\Unit\Config;
+
+use Tests\TestCase;
+
+/**
+ * Verifies the read/write database split in config/database.php:
+ * writes always go to DB_HOST, reads go to DB_HOST_READ when set and fall back
+ * to DB_HOST otherwise, and sticky is enabled for Galera read-after-write
+ * safety. See the 'mysql' connection in config/database.php.
+ */
+class DatabaseReadWriteSplitTest extends TestCase
+{
+    /**
+     * Re-evaluate config/database.php with a controlled environment and return
+     * the resolved 'mysql' connection array. Reads the file directly so we test
+     * the resolution logic rather than the booted app's already-resolved config.
+     *
+     * @param  array<string,string>  $env  Keys present are set; keys absent are unset.
+     * @return array<string,mixed>
+     */
+    private function loadMysqlConfig(array $env): array
+    {
+        $keys = ['DB_HOST', 'DB_HOST_READ', 'DB_PORT'];
+
+        $saved = [];
+        foreach ($keys as $k) {
+            $saved[$k] = [
+                'env' => array_key_exists($k, $_ENV) ? $_ENV[$k] : null,
+                'server' => array_key_exists($k, $_SERVER) ? $_SERVER[$k] : null,
+                'getenv' => getenv($k),
+            ];
+        }
+
+        try {
+            foreach ($keys as $k) {
+                if (array_key_exists($k, $env)) {
+                    $val = $env[$k];
+                    putenv("{$k}={$val}");
+                    $_ENV[$k] = $val;
+                    $_SERVER[$k] = $val;
+                } else {
+                    putenv($k);
+                    unset($_ENV[$k], $_SERVER[$k]);
+                }
+            }
+
+            $config = require base_path('config/database.php');
+
+            return $config['connections']['mysql'];
+        } finally {
+            foreach ($keys as $k) {
+                $s = $saved[$k];
+                if ($s['getenv'] === false) {
+                    putenv($k);
+                } else {
+                    putenv("{$k}={$s['getenv']}");
+                }
+                if ($s['env'] === null) {
+                    unset($_ENV[$k]);
+                } else {
+                    $_ENV[$k] = $s['env'];
+                }
+                if ($s['server'] === null) {
+                    unset($_SERVER[$k]);
+                } else {
+                    $_SERVER[$k] = $s['server'];
+                }
+            }
+        }
+    }
+
+    public function test_read_falls_back_to_write_host_when_read_host_unset(): void
+    {
+        $mysql = $this->loadMysqlConfig(['DB_HOST' => '10.0.0.1']);
+
+        $this->assertSame(['10.0.0.1'], $mysql['write']['host']);
+        $this->assertSame(['10.0.0.1'], $mysql['read']['host'], 'read host must fall back to DB_HOST when DB_HOST_READ is unset');
+    }
+
+    public function test_read_host_uses_db_host_read_when_set(): void
+    {
+        $mysql = $this->loadMysqlConfig(['DB_HOST' => '10.0.0.1', 'DB_HOST_READ' => '10.0.0.2']);
+
+        $this->assertSame(['10.0.0.1'], $mysql['write']['host'], 'writes always go to DB_HOST');
+        $this->assertSame(['10.0.0.2'], $mysql['read']['host']);
+    }
+
+    public function test_empty_read_host_falls_back_to_write_host(): void
+    {
+        $mysql = $this->loadMysqlConfig(['DB_HOST' => '10.0.0.1', 'DB_HOST_READ' => '']);
+
+        $this->assertSame(['10.0.0.1'], $mysql['read']['host'], 'an empty DB_HOST_READ must fall back to DB_HOST');
+    }
+
+    public function test_comma_separated_read_hosts_become_a_trimmed_list(): void
+    {
+        $mysql = $this->loadMysqlConfig(['DB_HOST' => '10.0.0.1', 'DB_HOST_READ' => '10.0.0.2, 10.0.0.3']);
+
+        $this->assertSame(['10.0.0.2', '10.0.0.3'], $mysql['read']['host']);
+    }
+
+    public function test_sticky_is_disabled(): void
+    {
+        $mysql = $this->loadMysqlConfig(['DB_HOST' => '10.0.0.1']);
+
+        // Galera is synchronous; only an open transaction must stay on one node,
+        // which Laravel handles independently of sticky. Sticky would only defeat
+        // read offloading.
+        $this->assertFalse($mysql['sticky'], 'sticky must be false for a Galera read/write split');
+    }
+
+    public function test_booted_mysql_connection_is_configured_with_split(): void
+    {
+        // The resolved connection the app actually uses - not just the file - must
+        // carry the split for it to take effect at runtime.
+        $this->assertFalse(config('database.connections.mysql.sticky'));
+        $this->assertIsArray(config('database.connections.mysql.read.host'));
+        $this->assertIsArray(config('database.connections.mysql.write.host'));
+        $this->assertNotEmpty(config('database.connections.mysql.write.host'));
+    }
+
+    public function test_runtime_splits_reads_and_writes_without_sticky_pinning(): void
+    {
+        // Build a throwaway connection from the real mysql config. Read and write
+        // resolve to the same test host (no DB_HOST_READ in CI), but Laravel still
+        // opens distinct read/write PDOs. This connection is NOT wrapped by
+        // DatabaseTransactions (only the default connection is), so transactions
+        // == 0 and read routing is actually observable.
+        config(['database.connections.mysql_split_probe' => config('database.connections.mysql')]);
+
+        try {
+            $conn = \DB::connection('mysql_split_probe');
+
+            // Split active: a read uses a separate read PDO from the write PDO.
+            $this->assertNotSame(
+                $conn->getPdo(),
+                $conn->getReadPdo(),
+                'the read/write split must open distinct read and write PDOs'
+            );
+
+            // No sticky: a prior write does NOT pin later reads to the write host.
+            $conn->statement('DO 1');
+            $this->assertNotSame(
+                $conn->getPdo(),
+                $conn->getReadPdo(),
+                'without sticky, reads keep using the read host after a write'
+            );
+
+            // But an OPEN transaction routes reads to the write connection, so a
+            // transaction always sees its own uncommitted writes (the one case
+            // that genuinely needs one node).
+            $conn->beginTransaction();
+            try {
+                $this->assertSame(
+                    $conn->getPdo(),
+                    $conn->getReadPdo(),
+                    'inside a transaction, reads must use the write connection'
+                );
+            } finally {
+                $conn->rollBack();
+            }
+        } finally {
+            \DB::purge('mysql_split_probe');
+        }
+    }
+}

--- a/iznik-nuxt3/components/LoginModal.vue
+++ b/iznik-nuxt3/components/LoginModal.vue
@@ -404,7 +404,7 @@ function gtmRegister() {
 }
 
 function loginNative(e) {
-  loginType.value = 'Freegle'
+  loginType.value = 'email/password'
 
   if (signUp.value) {
     api.bandit.chosen({

--- a/iznik-nuxt3/tests/unit/components/LoginModal.spec.js
+++ b/iznik-nuxt3/tests/unit/components/LoginModal.spec.js
@@ -847,6 +847,14 @@ describe('LoginModal', () => {
       await flushPromises()
       expect(wrapper.text()).not.toContain('You usually use')
     })
+
+    it('shows email/password hint for native login type', async () => {
+      mockLoginType.value = 'email/password'
+      mockForceLogin.value = true
+      const wrapper = createWrapper()
+      await flushPromises()
+      expect(wrapper.text()).toContain('You usually use email/password')
+    })
   })
 
   describe('exposed methods', () => {

--- a/iznik-server-go/authority/stats.go
+++ b/iznik-server-go/authority/stats.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/freegle/iznik-server-go/database"
 	"github.com/freegle/iznik-server-go/utils"
+	"gorm.io/gorm"
+	"gorm.io/plugin/dbresolver"
 )
 
 // Constants for authority statistics types.
@@ -31,7 +33,14 @@ type PostcodeStats struct {
 // GetStatsByAuthority retrieves statistics for an authority area.
 // Returns a map of partial postcodes to their stats.
 func GetStatsByAuthority(authorityID uint64, start, end string) (map[string]PostcodeStats, error) {
-	db := database.DBConn
+	// Every statement here must run on the WRITE host. The temporary table `pc`
+	// is connection-local, so the SELECTs that read it must hit the same server
+	// that created it. Under the read/write split a plain SELECT would otherwise
+	// be routed to the read replica, where `pc` does not exist. writer() returns
+	// a fresh handle pinned to the source; .Clauses(dbresolver.Write) is a no-op
+	// when no replica is configured. A new handle per call is required because a
+	// .Clauses() result is not safe to reuse across multiple queries.
+	writer := func() *gorm.DB { return database.DBConn.Clauses(dbresolver.Write) }
 
 	// Parse dates, defaulting to last 365 days.
 	startTime, err := parseRelativeDate(start)
@@ -48,12 +57,12 @@ func GetStatsByAuthority(authorityID uint64, start, end string) (map[string]Post
 
 	// Create temporary table of locationids for postcodes within the authority.
 	// Use a temporary table of postcode locationids within the authority.
-	err = db.Exec(`DROP TEMPORARY TABLE IF EXISTS pc`).Error
+	err = writer().Exec(`DROP TEMPORARY TABLE IF EXISTS pc`).Error
 	if err != nil {
 		return nil, err
 	}
 
-	err = db.Exec(`CREATE TEMPORARY TABLE pc AS (
+	err = writer().Exec(`CREATE TEMPORARY TABLE pc AS (
 		SELECT locationid
 		FROM authorities
 		INNER JOIN locations_spatial ON authorities.id = ?
@@ -72,7 +81,7 @@ func GetStatsByAuthority(authorityID uint64, start, end string) (map[string]Post
 			Count           int    `gorm:"column:count"`
 		}
 
-		db.Raw(`
+		writer().Raw(`
 			SELECT SUBSTRING(locations.name, 1, LENGTH(locations.name) - 2) AS PartialPostcode,
 				   COUNT(*) as count
 			FROM pc
@@ -103,7 +112,7 @@ func GetStatsByAuthority(authorityID uint64, start, end string) (map[string]Post
 			Count           int    `gorm:"column:count"`
 		}
 
-		db.Raw(`
+		writer().Raw(`
 			SELECT SUBSTRING(locations.name, 1, LENGTH(locations.name) - 2) AS PartialPostcode,
 				   COUNT(*) as count
 			FROM pc
@@ -130,7 +139,7 @@ func GetStatsByAuthority(authorityID uint64, start, end string) (map[string]Post
 		Count           int    `gorm:"column:count"`
 	}
 
-	db.Raw(`
+	writer().Raw(`
 		SELECT SUBSTRING(locations.name, 1, LENGTH(locations.name) - 2) AS PartialPostcode,
 			   COUNT(*) AS count
 		FROM pc
@@ -155,7 +164,7 @@ func GetStatsByAuthority(authorityID uint64, start, end string) (map[string]Post
 	var avgResult struct {
 		Average *float64 `gorm:"column:average"`
 	}
-	db.Raw(`SELECT SUM(popularity * weight) / SUM(popularity) AS average
+	writer().Raw(`SELECT SUM(popularity * weight) / SUM(popularity) AS average
 		FROM items WHERE weight IS NOT NULL AND weight != 0`).Scan(&avgResult)
 
 	avg := float64(0)
@@ -168,7 +177,7 @@ func GetStatsByAuthority(authorityID uint64, start, end string) (map[string]Post
 		Weight          float64 `gorm:"column:weight"`
 	}
 
-	db.Raw(fmt.Sprintf(`
+	writer().Raw(fmt.Sprintf(`
 		SELECT SUBSTRING(locations.name, 1, LENGTH(locations.name) - 2) AS PartialPostcode,
 			   SUM(COALESCE(weight, %f)) AS weight
 		FROM pc
@@ -196,7 +205,7 @@ func GetStatsByAuthority(authorityID uint64, start, end string) (map[string]Post
 		Count           int    `gorm:"column:count"`
 	}
 
-	db.Raw(`
+	writer().Raw(`
 		SELECT SUBSTRING(locations.name, 1, LENGTH(locations.name) - 2) AS PartialPostcode,
 			   COUNT(*) AS count
 		FROM pc
@@ -215,7 +224,7 @@ func GetStatsByAuthority(authorityID uint64, start, end string) (map[string]Post
 	}
 
 	// Clean up temporary table.
-	db.Exec(`DROP TEMPORARY TABLE IF EXISTS pc`)
+	writer().Exec(`DROP TEMPORARY TABLE IF EXISTS pc`)
 
 	return ret, nil
 }

--- a/iznik-server-go/authority/stats_split_test.go
+++ b/iznik-server-go/authority/stats_split_test.go
@@ -1,0 +1,101 @@
+package authority
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/stretchr/testify/assert"
+	"gorm.io/driver/mysql"
+	"gorm.io/gorm"
+	"gorm.io/plugin/dbresolver"
+)
+
+// splitDSN mirrors database.buildDSN (unexported) for test setup.
+func splitDSN(host string) string {
+	return fmt.Sprintf(
+		"%s:%s@%s(%s:%s)/%s?charset=utf8mb4&parseTime=True&loc=Local&interpolateParams=true",
+		os.Getenv("MYSQL_USER"),
+		os.Getenv("MYSQL_PASSWORD"),
+		os.Getenv("MYSQL_PROTOCOL"),
+		host,
+		os.Getenv("MYSQL_PORT"),
+		os.Getenv("MYSQL_DBNAME"),
+	)
+}
+
+// newSplitDB opens a gorm.DB and registers dbresolver with the replica pointing
+// at the SAME host as the source. Even same-host, dbresolver uses a separate
+// connection pool for the replica, so connection-local state (e.g. a temporary
+// table) is not shared between the source and replica pools. That lets us
+// exercise the read/write split's routing in CI without a real replica server.
+//
+// The source pool is capped to a single connection so the temporary table is
+// always visible to a pinned read (the same guarantee production relies on for
+// sequential queries).
+func newSplitDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	host := os.Getenv("MYSQL_HOST")
+	db, err := gorm.Open(mysql.Open(splitDSN(host)), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open source: %v", err)
+	}
+	if err := db.Use(dbresolver.Register(dbresolver.Config{
+		Replicas: []gorm.Dialector{mysql.Open(splitDSN(host))},
+		Policy:   dbresolver.RandomPolicy{},
+	})); err != nil {
+		t.Fatalf("register dbresolver: %v", err)
+	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("source DB(): %v", err)
+	}
+	sqlDB.SetMaxOpenConns(1)
+	return db
+}
+
+// TestSplitTempTableRoutingHazard proves that under the read/write split a plain
+// SELECT is routed to the replica pool (a different connection), so a temporary
+// table created on the source is NOT visible to an unpinned read - and that
+// pinning the read with .Clauses(dbresolver.Write) fixes it. This is the exact
+// pattern GetStatsByAuthority depends on.
+func TestSplitTempTableRoutingHazard(t *testing.T) {
+	db := newSplitDB(t)
+
+	if err := db.Exec(`DROP TEMPORARY TABLE IF EXISTS t_probe`).Error; err != nil {
+		t.Fatalf("drop: %v", err)
+	}
+	if err := db.Exec(`CREATE TEMPORARY TABLE t_probe (id INT)`).Error; err != nil {
+		t.Fatalf("create temp: %v", err)
+	}
+	if err := db.Exec(`INSERT INTO t_probe (id) VALUES (42)`).Error; err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	// Unpinned read -> routed to the replica pool -> temp table not visible.
+	var got int
+	unpinnedErr := db.Raw(`SELECT id FROM t_probe LIMIT 1`).Scan(&got).Error
+	assert.Error(t, unpinnedErr, "unpinned SELECT from a temp table should fail (routed to the read replica pool)")
+
+	// Pinned read -> routed to the source -> temp table visible.
+	got = 0
+	pinnedErr := db.Clauses(dbresolver.Write).Raw(`SELECT id FROM t_probe LIMIT 1`).Scan(&got).Error
+	assert.NoError(t, pinnedErr, "pinned SELECT from a temp table should succeed (routed to the write source)")
+	assert.Equal(t, 42, got)
+}
+
+// TestGetStatsByAuthorityUnderSplit runs the real handler against a
+// dbresolver-registered connection (source and replica on the same host). It
+// must complete without a "Table 'pc' doesn't exist" error, proving the
+// writer() pin keeps the temporary-table reads on the write host. Without the
+// pin this test fails because the SELECTs from `pc` are routed to the replica
+// pool, where the temporary table does not exist.
+func TestGetStatsByAuthorityUnderSplit(t *testing.T) {
+	saved := database.DBConn
+	database.DBConn = newSplitDB(t)
+	defer func() { database.DBConn = saved }()
+
+	_, err := GetStatsByAuthority(1, "30 days ago", "today")
+	assert.NoError(t, err)
+}

--- a/iznik-server-go/database/database.go
+++ b/iznik-server-go/database/database.go
@@ -7,6 +7,7 @@ import (
 	"gorm.io/driver/mysql"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
+	"gorm.io/plugin/dbresolver"
 	"os"
 	"time"
 )
@@ -16,21 +17,31 @@ var (
 	Pool   *sql.DB
 )
 
-func InitDatabase() {
-	var err error
-	var err2 error
-
-	fmt.Println("Connecting to database", os.Getenv("MYSQL_HOST"), os.Getenv("MYSQL_PORT"), os.Getenv("MYSQL_DBNAME"), os.Getenv("MYSQL_USER"), os.Getenv("MYSQL_PROTOCOL"))
-
-	mysqlCredentials := fmt.Sprintf(
+// buildDSN constructs the MySQL DSN for a given host, sharing all other
+// connection parameters (user, password, protocol, port, database) across the
+// write host and any read replica.
+func buildDSN(host string) string {
+	return fmt.Sprintf(
 		"%s:%s@%s(%s:%s)/%s?charset=utf8mb4&parseTime=True&loc=Local&interpolateParams=true",
 		os.Getenv("MYSQL_USER"),
 		os.Getenv("MYSQL_PASSWORD"),
 		os.Getenv("MYSQL_PROTOCOL"),
-		os.Getenv("MYSQL_HOST"),
+		host,
 		os.Getenv("MYSQL_PORT"),
 		os.Getenv("MYSQL_DBNAME"),
 	)
+}
+
+func InitDatabase() {
+	var err error
+	var err2 error
+
+	writeHost := os.Getenv("MYSQL_HOST")
+	readHost := os.Getenv("MYSQL_HOST_READ")
+
+	fmt.Println("Connecting to database", writeHost, os.Getenv("MYSQL_PORT"), os.Getenv("MYSQL_DBNAME"), os.Getenv("MYSQL_USER"), os.Getenv("MYSQL_PROTOCOL"))
+
+	mysqlCredentials := buildDSN(writeHost)
 
 	newLogger := sentrylogpackage.New(
 		sentrylogpackage.Config(logger.Config{
@@ -48,6 +59,7 @@ func InitDatabase() {
 	// the standard library. See https://medium.com/@rocketlaunchr.cloud/canceling-mysql-in-go-827ed8f83b30.
 	//
 	// We use this in cases where we want to be able to cancel long-running queries.
+	// It always targets the write host - a write is never safe on a replica.
 	Pool, err2 = sql.Open(mysqlCredentials)
 
 	// Database-level retry is available via RetryQuery/RetryExec in retry.go.
@@ -56,9 +68,43 @@ func InitDatabase() {
 		panic("failed to connect database")
 	}
 
+	// Read/write split (V1 parity: SQLHOSTS_READ / SQLHOSTS_MOD). When
+	// MYSQL_HOST_READ is set we route reads to that replica and keep ALL writes
+	// on MYSQL_HOST - this protects the single Galera write node from cluster
+	// write conflicts/lockups. dbresolver routes by statement: anything that is
+	// not a plain SELECT (INSERT/UPDATE/DELETE/REPLACE/DDL, SELECT ... FOR
+	// UPDATE, and every transaction) goes to the source (write host); plain
+	// SELECTs go to the replica. db.DB() still returns the source pool, so the
+	// LastInsertId write sites are unaffected.
+	//
+	// When MYSQL_HOST_READ is empty the resolver is NOT registered and behaviour
+	// is byte-identical to a single-host deployment, so dev/CI/existing prod are
+	// unchanged until a replica is explicitly configured.
+	//
+	// CAVEAT: connection-local state created on the source and read back (e.g.
+	// CREATE TEMPORARY TABLE ... then SELECT FROM it) must be pinned to the
+	// writer with .Clauses(dbresolver.Write); see authority.GetStatsByAuthority.
+	if readHost != "" {
+		fmt.Println("Read replica enabled at", readHost)
+		resolverErr := DBConn.Use(
+			dbresolver.Register(dbresolver.Config{
+				Replicas: []gorm.Dialector{mysql.Open(buildDSN(readHost))},
+				Policy:   dbresolver.RandomPolicy{},
+			}).
+				SetMaxOpenConns(200).
+				SetMaxIdleConns(200).
+				SetConnMaxLifetime(time.Hour),
+		)
+		if resolverErr != nil {
+			panic("failed to register read replica: " + resolverErr.Error())
+		}
+	}
+
 	// We want lots of connections for parallelisation, but must stay below
 	// MySQL's max_connections (500 in percona-my.cnf).  Leave headroom for
 	// other services (batch, tests) sharing the same MySQL instance.
+	// DBConn.DB() returns the source (write) *sql.DB even when dbresolver is
+	// registered, so this sizes the write pool.
 	dbConfig, err3 := DBConn.DB()
 	if err3 != nil {
 		panic("failed to get database config: " + err3.Error())

--- a/iznik-server-go/go.mod
+++ b/iznik-server-go/go.mod
@@ -33,40 +33,28 @@ require (
 require (
 	github.com/freegle/iznik-server-go v0.0.0-00010101000000-000000000000
 	golang.org/x/net v0.26.0
+	gorm.io/plugin/dbresolver v1.6.2
 	modernc.org/sqlite v1.38.0
 )
 
 require (
-	dario.cat/mergo v1.0.0 // indirect
 	filippo.io/edwards25519 v1.1.0 // indirect
-	github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 // indirect
-	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/andybalholm/brotli v1.1.0 // indirect
-	github.com/containerd/continuity v0.4.5 // indirect
+	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/docker/cli v27.4.1+incompatible // indirect
-	github.com/docker/docker v27.1.1+incompatible // indirect
-	github.com/docker/go-connections v0.5.0 // indirect
-	github.com/docker/go-units v0.5.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5 // indirect
-	github.com/go-viper/mapstructure/v2 v2.1.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
-	github.com/jmoiron/sqlx v1.4.0 // indirect
 	github.com/klauspost/compress v1.17.9 // indirect
 	github.com/kylelemons/go-gypsy v1.0.0 // indirect
 	github.com/lib/pq v1.10.9 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.15 // indirect
-	github.com/moby/docker-image-spec v1.3.1 // indirect
-	github.com/moby/term v0.5.0 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
-	github.com/opencontainers/image-spec v1.1.0 // indirect
-	github.com/opencontainers/runc v1.2.3 // indirect
-	github.com/ory/dockertest v0.0.0-00010101000000-000000000000 // indirect
+	github.com/ory/dockertest/v3 v3.12.0 // indirect
 	github.com/philhofer/fwd v1.1.2 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
@@ -75,7 +63,6 @@ require (
 	github.com/tinylib/msgp v1.1.8 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/tcplisten v1.0.0 // indirect
-	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/ziutek/mymysql v1.5.4 // indirect
 	golang.org/x/exp v0.0.0-20250620022241-b7579e27df2b // indirect
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // indirect

--- a/iznik-server-go/go.sum
+++ b/iznik-server-go/go.sum
@@ -82,7 +82,6 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.15 h1:UNAjwbU9l54TA3KzvqLGxwWjHmMgBUVhBiTjelZgg3U=
 github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
-github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3Nl2EsFP0=
 github.com/moby/docker-image-spec v1.3.1/go.mod h1:eKmb5VW8vQEh/BAr2yvVNvuiJuY6UIocYsFu/DxxRpo=
 github.com/moby/sys/user v0.3.0 h1:9ni5DlcW5an3SvRSx4MouotOygvzaXbaSrc/wGDFWPo=
@@ -179,7 +178,6 @@ golang.org/x/sync v0.15.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -217,6 +215,8 @@ gorm.io/driver/mysql v1.5.7/go.mod h1:sEtPWMiqiN1N1cMXoXmBbd8C6/l+TESwriotuRRpkD
 gorm.io/gorm v1.25.7/go.mod h1:hbnx/Oo0ChWMn1BIhpy1oYozzpM15i4YPuHDmfYtwg8=
 gorm.io/gorm v1.31.0 h1:0VlycGreVhK7RF/Bwt51Fk8v0xLiiiFdbGDPIZQ7mJY=
 gorm.io/gorm v1.31.0/go.mod h1:XyQVbO2k6YkOis7C2437jSit3SsDK72s7n7rsSHd+Gs=
+gorm.io/plugin/dbresolver v1.6.2 h1:F4b85TenghUeITqe3+epPSUtHH7RIk3fXr5l83DF8Pc=
+gorm.io/plugin/dbresolver v1.6.2/go.mod h1:tctw63jdrOezFR9HmrKnPkmig3m5Edem9fdxk9bQSzM=
 modernc.org/cc/v4 v4.26.2 h1:991HMkLjJzYBIfha6ECZdjrIYz2/1ayr+FL8GN+CNzM=
 modernc.org/cc/v4 v4.26.2/go.mod h1:uVtb5OGqUKpoLWhqwNQo/8LwvoiEBLvZXIQ/SmO6mL0=
 modernc.org/ccgo/v4 v4.28.0 h1:rjznn6WWehKq7dG4JtLRKxb52Ecv8OUGah8+Z/SfpNU=


### PR DESCRIPTION
## Summary

Restores the V1 read/write database split (`SQLHOSTS_READ` / `SQLHOSTS_MOD`) in both the Laravel batch app and the Go API, so **all writes go to one host** (the Galera write node, avoiding cluster write conflicts/lockups) while **reads can be offloaded to a replica**. Central, with no per-query changes, and **off by default** — behaviour is byte-identical to a single-host deployment until a read host is configured.

- **Laravel (`iznik-batch`)**: `config/database.php` `mysql` connection gains native `read` / `write` host arrays. Reads → `DB_HOST_READ` (falls back to `DB_HOST`); writes → `DB_HOST`. Comma-separated read hosts supported (random pick, V1 parity).
- **`sticky => false`**: Galera replication is synchronous, so a committed write is visible on read nodes without meaningful delay — reads always use the read host, even in long-running daemons (this is the point of the split, and matches V1, which had no sticky). The only case that must stay on one node is an **open transaction**, which Laravel already routes to the write connection (`getReadPdo()` checks `transactions > 0` first), independent of sticky.
- **Go API (`iznik-server-go`)**: `database.go` registers `gorm.io/plugin/dbresolver` only when `MYSQL_HOST_READ` is set. Plain `SELECT`s → replica; `Exec`/`Create`/`Update`/`Delete`, `SELECT … FOR UPDATE`, DDL, and transactions → source (write host). `db.DB()` still returns the source pool, so the `LastInsertId` write sites are unaffected.
- **Temp-table pin** (Go): `authority.GetStatsByAuthority` pins its `CREATE TEMPORARY TABLE` + reads to the writer (`.Clauses(dbresolver.Write)`). The temp table is connection-local; a plain `SELECT` would otherwise be routed to the replica where it does not exist. A full audit found this to be the only connection-local hard-break site in either codebase.
- **Infra/docs**: `docker-compose.yml` wires `DB_HOST_READ` (batch-prod, via an `extra_hosts` alias that falls back to the write host) and `MYSQL_HOST_READ` (apiv2-live); env examples updated; `DATABASE-READ-WRITE-SPLIT.md` documents the design, enablement, and the connection-local caveat.
- **Login wording fix** (separate commit, `iznik-nuxt3`): the login screen showed "You usually use Freegle" for the native email/password method; it now reads "You usually use email/password".

## Code Quality Review

- **No per-query changes**: routing is handled centrally (Laravel native read/write; GORM dbresolver) — the codebase's read/write call sites are unchanged.
- **Audit-driven**: every routing-sensitive site was classified. The only connection-local hard break (temp table read via a plain `SELECT`) was the Go `authority` stats query; it is pinned to the writer. No `SET @`, `GET_LOCK`, `FOUND_ROWS`, or `LOCK TABLES`; all `LAST_INSERT_ID(id)` uses are single `ON DUPLICATE KEY UPDATE` statements (safe). The `db.DB().Exec` LastInsertId write sites were verified to hit the source pool under dbresolver.
- **Fail-safe default**: no read host configured ⇒ Laravel falls back to `DB_HOST`; Go does not register dbresolver at all. Empty-string env values are treated as "unset".
- **`backup_demerge`** (runtime-built single backup host) and the Eee SQLite path are intentionally excluded from the split.

## Future Improvements

- If a specific read node ever needs hard read-your-writes across nodes, enable Galera `wsrep_sync_wait` there rather than re-introducing sticky.
- The standalone Go `Pool` (cancellable queries, currently unused in production) stays on the write host; a replica pool can be added if a cancellable read path appears.

## Test Plan

Validated in a clean worktree off `origin/master` (containers = `origin/master` + this branch, matching CI):

- **Go full suite: 3262 passed, 0 failed** — including the two new split tests:
  - `TestSplitTempTableRoutingHazard` — proves an unpinned temp-table `SELECT` is routed to the replica pool and fails, and the writer-pinned read succeeds.
  - `TestGetStatsByAuthorityUnderSplit` — runs the real handler under a dbresolver-registered connection with no "table doesn't exist" error.
- **Laravel `DatabaseReadWriteSplitTest`: 7 passed** — read/write resolution + fallback + empty-string handling + comma-lists; plus a runtime test proving the split opens **distinct read/write PDOs**, that there is **no sticky pinning** after a write, and that an **open transaction routes reads to the write PDO**.
- **Laravel full Unit+Feature suite: 4500 passed, 0 failed** (no regression from the split config).
- **vitest `LoginModal`: 49 passed** — including the new "You usually use email/password" assertion.
