### PR TITLE
feat(groups): cap inline group lists to 3 with a "+N more" toggle

### DIFF
--- a/iznik-nuxt3/components/CommunityEvent.vue
+++ b/iznik-nuxt3/components/CommunityEvent.vue
@@ -83,10 +83,9 @@
               <v-icon icon="users" />
               <span>
                 Posted on
-                <span v-for="(group, index) in groups" :key="index">
-                  <span v-if="index > 0">, </span>
-                  {{ group.namedisplay }}
-                </span>
+                <ShowMore :items="groups" :limit="3" inline>
+                  <template #item="{ item }">{{ item.namedisplay }}</template>
+                </ShowMore>
               </span>
             </div>
           </div>

--- a/iznik-nuxt3/components/CommunityEventModal.vue
+++ b/iznik-nuxt3/components/CommunityEventModal.vue
@@ -131,10 +131,12 @@
           </div>
           <p v-if="user?.id" class="posted-by">
             Posted by {{ user.displayname }}
-            <span v-for="(group, index) in groups" :key="index">
-              <span v-if="index > 0">, </span><span v-else>&nbsp;on</span>
-              {{ group.namedisplay }}
-            </span>
+            <template v-if="groups.length">
+              &nbsp;on
+              <ShowMore :items="groups" :limit="3" inline>
+                <template #item="{ item }">{{ item.namedisplay }}</template>
+              </ShowMore>
+            </template>
           </p>
         </div>
         <VeeForm v-else-if="event" ref="form">

--- a/iznik-nuxt3/components/ExportPost.vue
+++ b/iznik-nuxt3/components/ExportPost.vue
@@ -6,11 +6,14 @@
         {{ dateonly(post.arrival) }}
       </b-col>
       <b-col cols="2">
-        <span v-if="post.groups && post.groups.length">
-          <span v-for="(g, idx) in post.groups" :key="g.groupid">
-            {{ g.namedisplay }}<span v-if="idx < post.groups.length - 1">, </span>
-          </span>
-        </span>
+        <ShowMore
+          v-if="post.groups && post.groups.length"
+          :items="post.groups"
+          :limit="3"
+          inline
+        >
+          <template #item="{ item }">{{ item.namedisplay }}</template>
+        </ShowMore>
       </b-col>
       <b-col cols="4">
         {{ post.subject }}

--- a/iznik-nuxt3/components/MessageExpanded.vue
+++ b/iznik-nuxt3/components/MessageExpanded.vue
@@ -390,17 +390,17 @@
               </div>
               <div v-if="messageGroups.length" class="posted-on-groups">
                 On:
-                <template
-                  v-for="(g, idx) in messageGroups"
-                  :key="g.id"
-                  ><NuxtLink
-                    no-prefetch
-                    :to="'/explore/' + g.nameshort"
-                    class="posted-on-group-link"
-                    @click.stop
-                    >{{ g.namedisplay }}</NuxtLink
-                  ><span v-if="idx < messageGroups.length - 1">, </span></template
-                >
+                <ShowMore :items="messageGroups" :limit="3" inline>
+                  <template #item="{ item }"
+                    ><NuxtLink
+                      no-prefetch
+                      :to="'/explore/' + item.nameshort"
+                      class="posted-on-group-link"
+                      @click.stop
+                      >{{ item.namedisplay }}</NuxtLink
+                    ></template
+                  >
+                </ShowMore>
               </div>
             </client-only>
           </div>

--- a/iznik-nuxt3/components/MyMessage.vue
+++ b/iznik-nuxt3/components/MyMessage.vue
@@ -136,31 +136,24 @@
                     </span>
                   </div>
                   <div class="group-row">
-                    <template
-                      v-for="(mg, idx) in messageGroups"
-                      :key="mg.id"
-                    >
-                      <nuxt-link
-                        :to="'/explore/' + mg.nameshort"
-                        class="group-link"
-                        @click.stop
+                    <ShowMore :items="messageGroups" :limit="3" inline>
+                      <template #item="{ item }"
+                        ><nuxt-link
+                          :to="'/explore/' + item.nameshort"
+                          class="group-link"
+                          @click.stop
+                          >{{ item.namedisplay }}</nuxt-link
+                        ></template
                       >
-                        {{ mg.namedisplay }}
-                      </nuxt-link>
-                      <span
-                        v-if="idx < messageGroups.length - 1"
-                        class="group-time-separator"
-                        >,</span
-                      >
-                    </template>
+                    </ShowMore>
                     <span
                       v-if="messageGroups.length && timeAgoExpandedDisplay"
                       class="group-time-separator"
                       >·</span
                     >
-                    <span v-if="timeAgoExpandedDisplay" class="group-time"
-                      >{{ timeAgoExpandedDisplay }}</span
-                    >
+                    <span v-if="timeAgoExpandedDisplay" class="group-time">{{
+                      timeAgoExpandedDisplay
+                    }}</span>
                     <span class="group-time-separator">·</span>
                     <nuxt-link
                       :to="'/message/' + message.id"
@@ -204,22 +197,16 @@
                     </template>
                     <template v-if="messageGroups.length">
                       <span v-if="message.area" class="desktop-sep">·</span>
-                      <template
-                        v-for="(mg, idx) in messageGroups"
-                        :key="mg.id"
-                      >
-                        <nuxt-link
-                          :to="'/explore/' + mg.nameshort"
-                          class="desktop-group-link"
-                          @click.stop
+                      <ShowMore :items="messageGroups" :limit="3" inline>
+                        <template #item="{ item }"
+                          ><nuxt-link
+                            :to="'/explore/' + item.nameshort"
+                            class="desktop-group-link"
+                            @click.stop
+                            >{{ item.namedisplay }}</nuxt-link
+                          ></template
                         >
-                          {{ mg.namedisplay }}
-                        </nuxt-link>
-                        <span
-                          v-if="idx < messageGroups.length - 1"
-                          >,
-                        </span>
-                      </template>
+                      </ShowMore>
                     </template>
                     <template v-if="timeAgoExpandedDisplay">
                       <span class="desktop-sep">·</span>
@@ -592,7 +579,6 @@ const {
   message,
   strippedSubject,
   gotAttachments: hasPhoto,
-  timeAgoExpanded,
   timeAgoExpandedDisplay,
   placeholderClass,
   categoryIcon,
@@ -814,10 +800,6 @@ const messageGroups = computed(() => {
       .filter(Boolean)
   }
   return []
-})
-
-const messageGroup = computed(() => {
-  return messageGroups.value.length ? messageGroups.value[0] : null
 })
 
 // Methods

--- a/iznik-nuxt3/components/NewsCommunityEvent.vue
+++ b/iznik-nuxt3/components/NewsCommunityEvent.vue
@@ -15,10 +15,13 @@
       </span>
       <span v-if="event.groups?.length" class="meta-item">
         on
-        <span v-for="(groupid, index) in event.groups" :key="groupid">
-          <span v-if="index > 0">, </span>
-          <span v-if="group(groupid)">{{ group(groupid).namedisplay }}</span>
-        </span>
+        <ShowMore
+          :items="event.groups.map((id) => group(id)).filter(Boolean)"
+          :limit="3"
+          inline
+        >
+          <template #item="{ item }">{{ item.namedisplay }}</template>
+        </ShowMore>
       </span>
     </div>
 

--- a/iznik-nuxt3/components/NewsVolunteerOpportunity.vue
+++ b/iznik-nuxt3/components/NewsVolunteerOpportunity.vue
@@ -15,10 +15,13 @@
       </span>
       <span v-if="volunteering.groups?.length" class="meta-item">
         on
-        <span v-for="(groupid, index) in volunteering.groups" :key="groupid">
-          <span v-if="index > 0">, </span>
-          <span v-if="group(groupid)">{{ group(groupid).namedisplay }}</span>
-        </span>
+        <ShowMore
+          :items="volunteering.groups.map((id) => group(id)).filter(Boolean)"
+          :limit="3"
+          inline
+        >
+          <template #item="{ item }">{{ item.namedisplay }}</template>
+        </ShowMore>
       </span>
     </div>
 

--- a/iznik-nuxt3/components/ShowMore.vue
+++ b/iznik-nuxt3/components/ShowMore.vue
@@ -1,18 +1,48 @@
 <template>
-  <div>
-    <div v-for="item in itemsToShow" :key="item[keyfield]">
-      <slot name="item" :item="item"> Item {{ item[keyfield] }} </slot>
-    </div>
-    <b-button
-      v-if="items.length > limit && !expanded"
+  <component :is="inline ? 'span' : 'div'" class="show-more">
+    <component
+      :is="inline ? 'span' : 'div'"
+      v-for="(item, index) in itemsToShow"
+      :key="(item && item[keyfield]) ?? index"
+      class="show-more__item"
+      ><span v-if="inline && index > 0">, </span
+      ><slot name="item" :item="item" :index="index"
+        ><slot :item="item" :index="index"
+          >Item {{ item[keyfield] }}</slot
+        ></slot
+      ></component
+    ><b-button
+      v-if="!expanded && overflow"
       variant="link"
+      size="sm"
+      class="show-more__toggle"
+      :class="{ 'p-0 align-baseline ms-1': inline }"
       @click="expanded = true"
+      >+{{ overflow }} more</b-button
+    ><b-button
+      v-if="expanded && overflow"
+      variant="link"
+      size="sm"
+      class="show-more__toggle"
+      :class="{ 'p-0 align-baseline ms-1': inline }"
+      @click="expanded = false"
+      >show less</b-button
     >
-      Show more...
-    </b-button>
-  </div>
+  </component>
 </template>
 <script setup>
+// Truncates a list to `limit` items with a clickable "+N more" that expands to
+// the full list (and a "show less" to collapse back).
+//
+// inline=false (default): one item per line (a <div> per item). Used by the GDPR
+//   data-export page (pages/mydata.vue) for its many block lists.
+// inline=true: a comma-separated inline run ("A, B, C +2 more") with the toggle
+//   inline. Used for the "Posted on GroupA, GroupB" / "Also on: ..." group lists
+//   across FD and ModTools, capped at limit=3.
+//
+// The slot may be the named #item slot OR the default slot (both are used in
+// mydata.vue). In inline mode this component renders the commas, so call sites
+// only supply each group's name/link.
 const props = defineProps({
   items: {
     type: Array,
@@ -28,15 +58,23 @@ const props = defineProps({
     required: false,
     default: 'id',
   },
+  inline: {
+    type: Boolean,
+    required: false,
+    default: false,
+  },
 })
 
 const expanded = ref(false)
 
+const overflow = computed(() =>
+  props.items.length > props.limit ? props.items.length - props.limit : 0
+)
+
 const itemsToShow = computed(() => {
-  if (expanded.value || props.items.length < props.limit) {
+  if (expanded.value || props.items.length <= props.limit) {
     return props.items
-  } else {
-    return props.items.slice(0, props.limit)
   }
+  return props.items.slice(0, props.limit)
 })
 </script>

--- a/iznik-nuxt3/components/VolunteerOpportunityModal.vue
+++ b/iznik-nuxt3/components/VolunteerOpportunityModal.vue
@@ -148,10 +148,12 @@
           <p v-if="user" class="posted-by">
             Posted
             <span v-if="user.displayname">by {{ user.displayname }}</span>
-            <span v-for="(group, index) in groups" :key="index">
-              <span v-if="index > 0">, </span><span v-else>&nbsp;on</span>
-              {{ group.namedisplay }}
-            </span>
+            <template v-if="groups.length">
+              &nbsp;on
+              <ShowMore :items="groups" :limit="3" inline>
+                <template #item="{ item }">{{ item.namedisplay }}</template>
+              </ShowMore>
+            </template>
           </p>
         </div>
         <VeeForm v-else-if="volunteering" ref="form">

--- a/iznik-nuxt3/modtools/components/ModMessage.vue
+++ b/iznik-nuxt3/modtools/components/ModMessage.vue
@@ -161,12 +161,17 @@
             </div>
             <div v-if="otherGroups.length > 0" class="small text-muted">
               Also on:
-              <span v-for="(g, idx) in otherGroups" :key="g.groupid"
-                >{{
-                  groupStore.get(g.groupid)?.namedisplay ||
-                  'Group ' + g.groupid
-                }}<span v-if="idx < otherGroups.length - 1">, </span></span
+              <ShowMore
+                :items="otherGroups"
+                :limit="3"
+                inline
+                keyfield="groupid"
               >
+                <template #item="{ item }">{{
+                  groupStore.get(item.groupid)?.namedisplay ||
+                  'Group ' + item.groupid
+                }}</template>
+              </ShowMore>
             </div>
             <NoticeMessage
               v-if="onMultipleOfMyGroups || isRippledInToContextGroup"
@@ -742,6 +747,7 @@
 <script setup>
 import { ref, reactive, computed, watch, onMounted, onBeforeUnmount } from 'vue'
 import Highlighter from 'vue-highlight-words'
+import ShowMore from '~/components/ShowMore.vue'
 
 import { useAuthStore } from '~/stores/auth'
 import { useGroupStore } from '~/stores/group'

--- a/iznik-nuxt3/tests/unit/components/ShowMore.spec.js
+++ b/iznik-nuxt3/tests/unit/components/ShowMore.spec.js
@@ -87,7 +87,7 @@ describe('ShowMore', () => {
       const wrapper = createWrapper({ items, limit: 10 })
 
       expect(wrapper.find('button').exists()).toBe(true)
-      expect(wrapper.text()).toContain('Show more...')
+      expect(wrapper.text()).toContain('+5 more')
     })
 
     it('hides button when items under limit', () => {
@@ -97,13 +97,14 @@ describe('ShowMore', () => {
       expect(wrapper.find('button').exists()).toBe(false)
     })
 
-    it('hides button when expanded', async () => {
+    it('replaces "+N more" with a "show less" toggle when expanded', async () => {
       const items = Array.from({ length: 15 }, (_, i) => ({ id: i + 1 }))
       const wrapper = createWrapper({ items, limit: 10 })
 
       await wrapper.find('button').trigger('click')
 
-      expect(wrapper.find('button').exists()).toBe(false)
+      expect(wrapper.text()).not.toContain('+5 more')
+      expect(wrapper.text()).toContain('show less')
     })
   })
 
@@ -194,6 +195,58 @@ describe('ShowMore', () => {
 
       expect(wrapper.text()).toContain('Item Alice')
       expect(wrapper.text()).toContain('Item Bob')
+    })
+  })
+
+  describe('inline mode', () => {
+    const five = [
+      { id: 1, name: 'Alpha' },
+      { id: 2, name: 'Bravo' },
+      { id: 3, name: 'Charlie' },
+      { id: 4, name: 'Delta' },
+      { id: 5, name: 'Echo' },
+    ]
+
+    function inlineWrapper(props = {}) {
+      return mount(ShowMore, {
+        props: { items: five, limit: 3, inline: true, ...props },
+        slots: { item: (p) => p.item.name },
+        global: {
+          stubs: {
+            'b-button': {
+              template: '<button @click="$emit(\'click\')"><slot /></button>',
+            },
+          },
+        },
+      })
+    }
+
+    it('shows the first `limit` comma-separated with a "+N more" toggle', () => {
+      const wrapper = inlineWrapper()
+      expect(wrapper.text()).toContain('Alpha, Bravo, Charlie')
+      expect(wrapper.text()).toContain('+2 more')
+      expect(wrapper.text()).not.toContain('Delta')
+      // No stray/double separators around the truncation point.
+      expect(wrapper.text()).not.toMatch(/,\s*,/)
+      expect(wrapper.text().trim()).not.toMatch(/^,/)
+    })
+
+    it('expands to the full comma list and offers "show less", then collapses', async () => {
+      const wrapper = inlineWrapper()
+      await wrapper.find('button').trigger('click')
+      expect(wrapper.text()).toContain('Alpha, Bravo, Charlie, Delta, Echo')
+      expect(wrapper.text()).toContain('show less')
+      expect(wrapper.text()).not.toContain('+2 more')
+
+      await wrapper.find('button').trigger('click')
+      expect(wrapper.text()).not.toContain('Delta')
+      expect(wrapper.text()).toContain('+2 more')
+    })
+
+    it('renders no toggle when the list is within the limit', () => {
+      const wrapper = inlineWrapper({ items: five.slice(0, 3) })
+      expect(wrapper.text()).toContain('Alpha, Bravo, Charlie')
+      expect(wrapper.findAll('button')).toHaveLength(0)
     })
   })
 })

--- a/iznik-nuxt3/tests/unit/setup.ts
+++ b/iznik-nuxt3/tests/unit/setup.ts
@@ -237,6 +237,17 @@ config.global.stubs = {
     ],
     emits: ['error'],
   },
+
+  // Stub ShowMore (components/ShowMore.vue): render every item via its #item (or
+  // default) slot - a <div> per item in block mode, comma-separated spans in
+  // inline mode - so group-list specs see the names. The real cap / "+N more" /
+  // collapse behaviour is covered by ShowMore.spec.js, which mounts ShowMore
+  // directly (a directly-mounted root is not replaced by a global stub).
+  ShowMore: {
+    props: ['items', 'limit', 'inline', 'keyfield'],
+    template:
+      '<span><component :is="inline ? \'span\' : \'div\'" v-for="(item, i) in (items || [])" :key="i"><span v-if="inline && i > 0">, </span><slot name="item" :item="item" :index="i"><slot :item="item" :index="i" /></slot></component></span>',
+  },
 }
 
 // ============================================


### PR DESCRIPTION
## What

Wherever FD or ModTools render an **inline, comma-separated list of groups** ("Posted on A, B, C", "Also on: …", "On: …"), a long list pushed the rest of the card down. This caps each to the **first 3** with a clickable **"+N more"** that expands the full list inline (and a **"show less"** to collapse back).

## How

Extends the existing `ShowMore` component rather than adding a parallel one:
- new **`inline`** mode renders the comma separators itself + an inline toggle, so call sites only supply each group's name/link;
- the collapsed label is now **"+N more"**, an expanded list offers **"show less"**;
- the `v-for` key falls back to the index, so it works for group objects keyed on `id` or `groupid` and for lists resolved from ids.

Block mode (one item per line) is unchanged for the GDPR data-export page (`mydata.vue`), its only other caller.

## Sites changed

`CommunityEvent`, `CommunityEventModal`, `VolunteerOpportunityModal`, `NewsCommunityEvent`, `NewsVolunteerOpportunity`, `ExportPost`, `MessageExpanded`, `MyMessage` (both layout branches) and `ModMessage`.

**Separator preserved:** every site used `", "`, which `ShowMore` reproduces (the spec asserts `"Alpha, Bravo, Charlie"` with no double/leading commas). The two modals fold an `on` prefix into the first item - lifted out of the loop so it's kept. Dropdowns/selectors, map overlays and the sysadmin stats grid are intentionally left alone (not inline display lists).

Also removes two pre-existing unused vars in `MyMessage` that the lint-on-changed run surfaced.

## Tests

`ShowMore.spec.js` extended (24 pass): inline comma output, "+N more", expand → "show less" → collapse, no-overflow case, block mode unchanged, both `#item` and default slots, index-key fallback.

## Visual review

A 9-site multi-group change is impractical to reproduce locally, so please eyeball the **Netlify deploy preview** for the inline rendering on a few real multi-group cards (a cross-posted message, a multi-group community event, the newsfeed cards).

🤖 Generated with [Claude Code](https://claude.com/claude-code)