### PR TITLE
fix(rippling): stop rippling a post out once it has a terminal outcome

### DIFF
--- a/iznik-batch/app/Services/Ripple/ExpandService.php
+++ b/iznik-batch/app/Services/Ripple/ExpandService.php
@@ -310,6 +310,25 @@ class ExpandService
                     continue;
                 }
 
+                // Outcome stop: a post that has been taken/received/withdrawn has left the
+                // browsable set, so stop expanding and do not ripple it any further. Checked
+                // here against messages_outcomes (not just via removeStale) because removeStale
+                // runs on UNSCOPED runs only and keys off messages_spatial, which the separate
+                // messages:update-spatial-index cron lags - so without this an already-taken post
+                // keeps rippling into new groups for a tick or two after the outcome is recorded.
+                if ($this->hasTerminalOutcome((int) $row->msgid)) {
+                    if (!$dryRun) {
+                        DB::table('rippling_reach')->where('msgid', $row->msgid)->update([
+                            'status' => 'done',
+                            'next_expansion_at' => null,
+                            'updated_at' => now(),
+                        ]);
+                    }
+                    $stats['completed']++;
+                    $this->logEvent($row->msgid, 'outcome_stop', (int) $row->tick, []);
+                    continue;
+                }
+
                 $elapsedHours = $arrival->diffInMinutes(now()) / 60.0;
                 // The post's own hazard-schedule length (stored at init), used as the ceiling
                 // for both the target tick and the 'done' transition.
@@ -386,6 +405,15 @@ class ExpandService
     private function rippleIntoNewGroups(int $msgid, string $reachWkt, array &$stats): void
     {
         try {
+            // Never ripple a post that has already been taken/received/withdrawn into new groups,
+            // even if its reach row has not yet been stopped - covers the tick-0 ripple from
+            // initialiseNew and the manual `ripple:expand --msgid=...` path, both of which reach
+            // here without advanceDue's outcome-stop having run. messages_outcomes is the source of
+            // truth; messages_spatial lags the outcome (see hasTerminalOutcome).
+            if ($this->hasTerminalOutcome($msgid)) {
+                return;
+            }
+
             // TN posts must not be rippled into new groups while TN still cross-posts the same
             // item to multiple Freegle groups by tnpostid. Once TN is restricted to a single
             // origin group (design.md #10), this guard can be removed.
@@ -908,6 +936,26 @@ class ExpandService
             "SELECT COUNT(DISTINCT userid) AS n FROM chat_messages WHERE refmsgid = ? AND type = 'Interested'",
             [$msgid]
         )->n ?? 0);
+    }
+
+    /**
+     * Whether a post has a TERMINAL outcome (Taken/Received/Withdrawn) and so has left the
+     * browsable set and must not ripple any further. 'Repost' is deliberately NOT terminal -
+     * a reposted item is still active. Checked against messages_outcomes (the source of truth)
+     * rather than messages_spatial, which the messages:update-spatial-index cron lags behind, so
+     * a just-taken post can still appear spatial for a tick or two after the outcome is recorded.
+     */
+    private function hasTerminalOutcome(int $msgid): bool
+    {
+        return DB::selectOne(
+            'SELECT 1 AS x FROM messages_outcomes WHERE msgid = ? AND outcome IN (?, ?, ?) LIMIT 1',
+            [
+                $msgid,
+                \App\Models\MessageOutcome::OUTCOME_TAKEN,
+                \App\Models\MessageOutcome::OUTCOME_RECEIVED,
+                \App\Models\MessageOutcome::OUTCOME_WITHDRAWN,
+            ]
+        ) !== null;
     }
 
     private function logEvent(int|string $msgid, string $kind, int $tick, array $entry): void

--- a/iznik-batch/tests/Unit/Services/Ripple/ExpandServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/Ripple/ExpandServiceTest.php
@@ -1196,4 +1196,108 @@ class ExpandServiceTest extends TestCase
             ->count();
         $this->assertSame(2, $scheduleCalls, 'same-origin posts dedup to a single routing call');
     }
+
+    /** Seed a terminal outcome (Taken/Received/Withdrawn) on a post. */
+    private function seedOutcome(int $msgid, string $outcome): void
+    {
+        DB::table('messages_outcomes')->insert([
+            'msgid' => $msgid,
+            'outcome' => $outcome,
+            'timestamp' => now(),
+        ]);
+    }
+
+    /** Make a covering group whose polyindex intersects the fake reach polygon. */
+    private function seedCoveringGroup(): int
+    {
+        $group = $this->createTestGroup();
+        DB::statement(
+            "UPDATE `groups` SET publish = 1, polyindex = ST_GeomFromText(?, ?) WHERE id = ?",
+            ['POLYGON((-0.18 51.52,-0.12 51.52,-0.12 51.58,-0.18 51.58,-0.18 51.52))', 3857, $group->id]
+        );
+
+        return (int) $group->id;
+    }
+
+    /**
+     * BUG FIX: the exact reported failure. A post with a terminal outcome (here Received) that is
+     * STILL in messages_spatial (messages:update-spatial-index lags the outcome) must never be
+     * rippled into a covering group. The outcome is checked directly against messages_outcomes, not
+     * inferred from the spatial index, so the lag window cannot leak a taken post into new groups.
+     */
+    public function test_taken_post_still_in_spatial_is_never_rippled_in(): void
+    {
+        $this->fakeRouting(3);
+        $msgid = $this->seedSpatialPost(now()->subMinutes(30)); // still in messages_spatial
+        $this->seedOutcome($msgid, \App\Models\MessageOutcome::OUTCOME_RECEIVED);
+        $groupB = $this->seedCoveringGroup();
+
+        $stats = $this->service()->process(false, 500);
+
+        $this->assertSame(0, $stats['rippled_in'], 'a post with a terminal outcome is never rippled in, even while still spatial');
+        $this->assertNull(
+            DB::table('messages_groups')->where('msgid', $msgid)->where('groupid', $groupB)->first(),
+            'post with a terminal outcome is not inserted into a covering group via the tick-0 init ripple'
+        );
+    }
+
+    /**
+     * A post that becomes Taken mid-expansion stops expanding (status done, not rescheduled) and is
+     * not rippled into a group whose area its reach now covers - mirrors the saturation-stop, but
+     * driven by the outcome. Covers advanceDue's outcome-stop on a scoped-or-unscoped tick where
+     * removeStale's spatial cleanup has not yet caught up.
+     */
+    public function test_post_taken_mid_expansion_stops_expanding(): void
+    {
+        $this->fakeRouting(3);
+        $msgid = $this->seedSpatialPost(now()->subMinutes(30));
+
+        // First pass: reach initialised and expanding (no covering group yet → nothing rippled in).
+        $this->service()->process(false, 500);
+        $this->assertSame(
+            'expanding',
+            DB::table('rippling_reach')->where('msgid', $msgid)->value('status'),
+            'reach is expanding before the outcome'
+        );
+
+        // The post is now Taken, a covering group appears, and its next tick falls due.
+        $this->seedOutcome($msgid, \App\Models\MessageOutcome::OUTCOME_TAKEN);
+        $groupB = $this->seedCoveringGroup();
+        DB::table('rippling_reach')->where('msgid', $msgid)->update([
+            'arrival' => now()->subHours(4),
+            'next_expansion_at' => now()->subMinute(),
+            'status' => 'expanding',
+        ]);
+
+        $stats = $this->service()->process(false, 500);
+
+        $row = DB::table('rippling_reach')->where('msgid', $msgid)->first();
+        $this->assertSame('done', $row->status, 'a taken post stops expanding');
+        $this->assertNull($row->next_expansion_at, 'a taken post is not rescheduled');
+        $this->assertGreaterThanOrEqual(1, $stats['completed']);
+        $this->assertNull(
+            DB::table('messages_groups')->where('msgid', $msgid)->where('groupid', $groupB)->first(),
+            'a taken post is not rippled into a new group even though its reach now covers it'
+        );
+    }
+
+    /**
+     * 'Repost' is NOT a terminal outcome - a reposted item is still active and must ripple normally.
+     * Guards against the outcome check over-reaching to any messages_outcomes row.
+     */
+    public function test_repost_outcome_is_not_terminal_and_post_still_ripples(): void
+    {
+        $this->fakeRouting(3);
+        $msgid = $this->seedSpatialPost(now()->subMinutes(30));
+        $this->seedOutcome($msgid, \App\Models\MessageOutcome::OUTCOME_REPOST);
+        $groupB = $this->seedCoveringGroup();
+
+        $stats = $this->service()->process(false, 500);
+
+        $this->assertGreaterThanOrEqual(1, $stats['rippled_in'], 'a Repost outcome does not stop rippling');
+        $this->assertNotNull(
+            DB::table('messages_groups')->where('msgid', $msgid)->where('groupid', $groupB)->first(),
+            'post with only a Repost outcome still ripples into a covering group'
+        );
+    }
 }


### PR DESCRIPTION
## Problem
`ExpandService` advanced reach and rippled posts into new groups **without checking the message outcome**. The only outcome guard was `removeStale`, which:
- runs on **unscoped** runs only (so scoped experiment runs never apply it), and
- keys off `messages_spatial`, which the separate `messages:update-spatial-index` cron **lags** behind — so a just-taken post can still be in `messages_spatial` for a tick or two after the outcome is recorded.

Result: a post that was Taken/Received/Withdrawn kept rippling into new groups during that lag window (and indefinitely on scoped runs).

## Fix
- `hasTerminalOutcome()` checks `messages_outcomes` **directly** (Taken/Received/Withdrawn; `Repost` is deliberately **not** terminal — a reposted item is still active).
- `advanceDue` stops expanding a post with a terminal outcome (`status=done`, not rescheduled) before it can ripple.
- `rippleIntoNewGroups` early-return guard covers the tick-0 init ripple and the manual `ripple:expand --msgid=…` path.

## Tests
3 new `ExpandServiceTest` cases: still-in-spatial-but-taken → never rippled in; taken mid-expansion → stops expanding; `Repost` outcome → still ripples (non-terminal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PfxahVbxhqzd9XWp2ptA7R