### PR TITLE
feat(batch): rotate, compress and retain batch logs for 7 days

### DIFF
--- a/iznik-batch/.env.example
+++ b/iznik-batch/.env.example
@@ -16,7 +16,11 @@ APP_MAINTENANCE_DRIVER=file
 BCRYPT_ROUNDS=12
 
 LOG_CHANNEL=stack
-LOG_STACK=single
+# Sub-channels for the 'stack' driver. 'daily' rotates into dated files
+# (laravel-YYYY-MM-DD.log) and prunes to LOG_DAILY_DAYS days; the logs:rotate
+# scheduled command additionally gzip-compresses the rotated files.
+LOG_STACK=daily
+LOG_DAILY_DAYS=7
 LOG_DEPRECATIONS_CHANNEL=null
 LOG_LEVEL=debug
 

--- a/iznik-batch/app/Console/Commands/Logs/RotateLogsCommand.php
+++ b/iznik-batch/app/Console/Commands/Logs/RotateLogsCommand.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Console\Commands\Logs;
+
+use App\Services\LogRotationService;
+use Illuminate\Console\Command;
+
+class RotateLogsCommand extends Command
+{
+    protected $signature = 'logs:rotate
+                            {--days=7 : Days of log files to retain before deletion}
+                            {--dry-run : Report what would change without modifying any files}';
+
+    protected $description = 'Compress rotated batch log files and prune those older than the retention window';
+
+    public function handle(LogRotationService $service): int
+    {
+        $days = (int) $this->option('days');
+        $dryRun = (bool) $this->option('dry-run');
+        $dir = storage_path('logs');
+
+        if ($dryRun) {
+            $this->info('Dry run: no files will be changed.');
+        }
+
+        // Prune first so we never spend time compressing a file that is about to be deleted.
+        $pruned = $service->prune($dir, $days, $dryRun);
+        $compressed = $service->compress($dir, $dryRun);
+
+        $this->table(
+            ['Action', 'Files', 'Bytes'],
+            [
+                ['Pruned (older than '.$days.' days)', $pruned['deleted'], number_format($pruned['bytes'])],
+                ['Compressed', $compressed['compressed'], number_format($compressed['bytes_before'])],
+            ]
+        );
+
+        $this->info(sprintf(
+            'logs:rotate complete - pruned %d file(s) (%s bytes), compressed %d file(s).',
+            $pruned['deleted'],
+            number_format($pruned['bytes']),
+            $compressed['compressed']
+        ));
+
+        return self::SUCCESS;
+    }
+}

--- a/iznik-batch/app/Services/LogRotationService.php
+++ b/iznik-batch/app/Services/LogRotationService.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace App\Services;
+
+/**
+ * Compresses and prunes the Laravel batch log directory (storage/logs).
+ *
+ * The Monolog 'daily' channel rotates app logs into dated files but does not
+ * compress them, and the supervisor-written logs (scheduler.log, worker.log,
+ * ...) are not Monolog-managed at all. This service gzip-compresses rotated
+ * (non-live) log files and deletes anything older than the retention window,
+ * keeping storage/logs bounded. It is driven daily by the logs:rotate command.
+ */
+class LogRotationService
+{
+    /**
+     * Delete log files whose modification time is older than $days days.
+     *
+     * Recurses into subdirectories (e.g. logs/cron). Never deletes .gitignore.
+     *
+     * @return array{deleted:int, bytes:int, files:list<string>}
+     */
+    public function prune(string $dir, int $days, bool $dryRun = false): array
+    {
+        $deleted = 0;
+        $bytes = 0;
+        $files = [];
+        $cutoff = time() - ($days * 86400);
+
+        foreach ($this->listFiles($dir) as $path) {
+            if (basename($path) === '.gitignore') {
+                continue;
+            }
+            $mtime = @filemtime($path);
+            if ($mtime === false || $mtime >= $cutoff) {
+                continue;
+            }
+
+            $bytes += @filesize($path) ?: 0;
+            if (!$dryRun) {
+                @unlink($path);
+            }
+            $deleted++;
+            $files[] = $path;
+        }
+
+        return ['deleted' => $deleted, 'bytes' => $bytes, 'files' => $files];
+    }
+
+    /**
+     * Gzip-compress rotated (non-live) log files in $dir.
+     *
+     * Targets files named like "*.log" or "*.log.<n>" (e.g. supervisor backups)
+     * last modified before today. Files written today are assumed to still be
+     * live (a daemon may hold the handle open) and are left alone, as are files
+     * already compressed (.gz). The original is removed only after a successful
+     * gzip. The file list is materialised before any mutation so newly created
+     * .gz files are never re-scanned mid-run.
+     *
+     * @return array{compressed:int, bytes_before:int, bytes_after:int, files:list<string>}
+     */
+    public function compress(string $dir, bool $dryRun = false): array
+    {
+        $compressed = 0;
+        $bytesBefore = 0;
+        $bytesAfter = 0;
+        $files = [];
+        $todayStart = strtotime('today');
+
+        foreach ($this->listFiles($dir) as $path) {
+            // Only rotate actual log files: foo.log or foo.log.N (numbered backups).
+            if (!preg_match('/\.log(\.\d+)?$/', basename($path))) {
+                continue;
+            }
+            // Leave files written today - they may still be open and appended to.
+            $mtime = @filemtime($path);
+            if ($mtime === false || $mtime >= $todayStart) {
+                continue;
+            }
+
+            $bytesBefore += @filesize($path) ?: 0;
+            $compressed++;
+            $files[] = $path;
+
+            if ($dryRun) {
+                continue;
+            }
+
+            $dest = $path.'.gz';
+            if ($this->gzipFile($path, $dest)) {
+                @unlink($path);
+                $bytesAfter += @filesize($dest) ?: 0;
+            }
+        }
+
+        return [
+            'compressed' => $compressed,
+            'bytes_before' => $bytesBefore,
+            'bytes_after' => $bytesAfter,
+            'files' => $files,
+        ];
+    }
+
+    /**
+     * Stream a file through gzip without loading it entirely into memory.
+     */
+    private function gzipFile(string $source, string $dest): bool
+    {
+        $in = @fopen($source, 'rb');
+        if ($in === false) {
+            return false;
+        }
+        $out = @gzopen($dest, 'wb6');
+        if ($out === false) {
+            fclose($in);
+
+            return false;
+        }
+
+        while (!feof($in)) {
+            $chunk = fread($in, 1 << 20); // 1 MiB
+            if ($chunk === false) {
+                break;
+            }
+            gzwrite($out, $chunk);
+        }
+
+        fclose($in);
+        gzclose($out);
+
+        return true;
+    }
+
+    /**
+     * List all files (not directories) under $dir, recursively, materialised
+     * into an array so the caller can safely mutate the directory while looping.
+     *
+     * @return list<string>
+     */
+    private function listFiles(string $dir): array
+    {
+        if (!is_dir($dir)) {
+            return [];
+        }
+
+        $out = [];
+        $it = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::LEAVES_ONLY
+        );
+        foreach ($it as $file) {
+            if ($file->isFile()) {
+                $out[] = $file->getPathname();
+            }
+        }
+
+        return $out;
+    }
+}

--- a/iznik-batch/config/logging.php
+++ b/iznik-batch/config/logging.php
@@ -54,7 +54,7 @@ return [
 
         'stack' => [
             'driver' => 'stack',
-            'channels' => explode(',', (string) env('LOG_STACK', 'single')),
+            'channels' => explode(',', (string) env('LOG_STACK', 'daily')),
             'ignore_exceptions' => false,
         ],
 
@@ -69,7 +69,7 @@ return [
             'driver' => 'daily',
             'path' => storage_path('logs/laravel.log'),
             'level' => env('LOG_LEVEL', 'debug'),
-            'days' => env('LOG_DAILY_DAYS', 14),
+            'days' => env('LOG_DAILY_DAYS', 7),
             'replace_placeholders' => true,
         ],
 
@@ -129,10 +129,14 @@ return [
 
         // Incoming mail processing logs
         // Structured for Loki ingestion
+        // 'daily' rotates into incoming-mail-YYYY-MM-DD.log and prunes to LOG_DAILY_DAYS.
+        // (Loki ingests the separate /var/log/freegle/incoming_mail.log written by
+        // LokiService, not this file, so rotating here does not affect ingestion.)
         'incoming_mail' => [
-            'driver' => 'single',
+            'driver' => 'daily',
             'path' => storage_path('logs/incoming-mail.log'),
             'level' => env('LOG_LEVEL', 'debug'),
+            'days' => env('LOG_DAILY_DAYS', 7),
             'replace_placeholders' => true,
         ],
 

--- a/iznik-batch/docker/supervisor.conf
+++ b/iznik-batch/docker/supervisor.conf
@@ -19,6 +19,8 @@ user=root
 numprocs=1
 redirect_stderr=true
 stdout_logfile=/var/www/html/storage/logs/scheduler.log
+stdout_logfile_maxbytes=50MB
+stdout_logfile_backups=5
 stopwaitsecs=3600
 
 [program:laravel-worker]
@@ -32,6 +34,8 @@ user=root
 numprocs=2
 redirect_stderr=true
 stdout_logfile=/var/www/html/storage/logs/worker.log
+stdout_logfile_maxbytes=50MB
+stdout_logfile_backups=5
 stopwaitsecs=3600
 
 [program:mail-spooler]
@@ -43,6 +47,8 @@ user=root
 numprocs=1
 redirect_stderr=true
 stdout_logfile=/var/www/html/storage/logs/spooler.log
+stdout_logfile_maxbytes=50MB
+stdout_logfile_backups=5
 stopwaitsecs=60
 
 [program:mail-receiver]
@@ -54,4 +60,6 @@ user=root
 numprocs=1
 redirect_stderr=true
 stdout_logfile=/var/www/html/storage/logs/mail-receiver.log
+stdout_logfile_maxbytes=50MB
+stdout_logfile_backups=5
 stopwaitsecs=10

--- a/iznik-batch/routes/console.php
+++ b/iznik-batch/routes/console.php
@@ -203,6 +203,16 @@ Schedule::command('cleanup:sessions')
     ->sendOutputTo(cronLog('cleanup:sessions'))
     ->runInBackground();
 
+// Compress rotated batch log files and prune those older than the retention
+// window (default 7 days). The Monolog 'daily' channel rotates app logs but
+// does not compress them, and supervisor's scheduler/worker/spooler logs are
+// not Monolog-managed at all - this keeps storage/logs bounded.
+Schedule::command('logs:rotate')
+    ->dailyAt('00:30')
+    ->withoutOverlapping()
+    ->sendOutputTo(cronLog('logs:rotate'))
+    ->runInBackground();
+
 // Remove spam members from groups and clean up their content.
 // V1: cron/check_spammers.php (every 5 minutes)
 Schedule::command('users:remove-spammers')

--- a/iznik-batch/tests/Unit/Commands/Logs/RotateLogsCommandTest.php
+++ b/iznik-batch/tests/Unit/Commands/Logs/RotateLogsCommandTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Tests\Unit\Commands\Logs;
+
+use App\Services\LogRotationService;
+use Illuminate\Console\Command;
+use Tests\TestCase;
+
+class RotateLogsCommandTest extends TestCase
+{
+    public function test_runs_prune_then_compress_and_succeeds(): void
+    {
+        $service = $this->createMock(LogRotationService::class);
+        $service->expects($this->once())
+            ->method('prune')
+            ->with($this->isType('string'), 7, false)
+            ->willReturn(['deleted' => 2, 'bytes' => 1024, 'files' => []]);
+        $service->expects($this->once())
+            ->method('compress')
+            ->with($this->isType('string'), false)
+            ->willReturn(['compressed' => 3, 'bytes_before' => 2048, 'bytes_after' => 512, 'files' => []]);
+
+        $this->app->instance(LogRotationService::class, $service);
+
+        $this->artisan('logs:rotate')
+            ->expectsOutputToContain('pruned 2')
+            ->assertExitCode(Command::SUCCESS);
+    }
+
+    public function test_days_option_is_passed_to_prune(): void
+    {
+        $service = $this->createMock(LogRotationService::class);
+        $service->expects($this->once())
+            ->method('prune')
+            ->with($this->isType('string'), 14, false)
+            ->willReturn(['deleted' => 0, 'bytes' => 0, 'files' => []]);
+        $service->method('compress')
+            ->willReturn(['compressed' => 0, 'bytes_before' => 0, 'bytes_after' => 0, 'files' => []]);
+
+        $this->app->instance(LogRotationService::class, $service);
+
+        $this->artisan('logs:rotate', ['--days' => 14])
+            ->assertExitCode(Command::SUCCESS);
+    }
+
+    public function test_dry_run_is_passed_through_to_service(): void
+    {
+        $service = $this->createMock(LogRotationService::class);
+        $service->expects($this->once())
+            ->method('prune')
+            ->with($this->isType('string'), 7, true)
+            ->willReturn(['deleted' => 0, 'bytes' => 0, 'files' => []]);
+        $service->expects($this->once())
+            ->method('compress')
+            ->with($this->isType('string'), true)
+            ->willReturn(['compressed' => 0, 'bytes_before' => 0, 'bytes_after' => 0, 'files' => []]);
+
+        $this->app->instance(LogRotationService::class, $service);
+
+        $this->artisan('logs:rotate', ['--dry-run' => true])
+            ->assertExitCode(Command::SUCCESS);
+    }
+}

--- a/iznik-batch/tests/Unit/Services/LogRotationServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/LogRotationServiceTest.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Services\LogRotationService;
+use Tests\TestCase;
+
+class LogRotationServiceTest extends TestCase
+{
+    private string $dir;
+    private LogRotationService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new LogRotationService();
+        $this->dir = sys_get_temp_dir().'/logrot_test_'.uniqid('', true);
+        mkdir($this->dir, 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_dir($this->dir)) {
+            $it = new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator($this->dir, \FilesystemIterator::SKIP_DOTS),
+                \RecursiveIteratorIterator::CHILD_FIRST
+            );
+            foreach ($it as $f) {
+                $f->isDir() ? rmdir($f->getPathname()) : unlink($f->getPathname());
+            }
+            rmdir($this->dir);
+        }
+        parent::tearDown();
+    }
+
+    /**
+     * Create a fixture file with a controlled modification time.
+     */
+    private function writeFile(string $name, string $contents, int $ageDays = 0): string
+    {
+        $path = $this->dir.'/'.$name;
+        if (!is_dir(dirname($path))) {
+            mkdir(dirname($path), 0755, true);
+        }
+        file_put_contents($path, $contents);
+        // file_put_contents bumps mtime to now; pin it back to the desired age.
+        touch($path, time() - ($ageDays * 86400));
+
+        return $path;
+    }
+
+    public function test_prune_deletes_files_older_than_retention(): void
+    {
+        $old = $this->writeFile('laravel-old.log', 'old', 10);
+        $recent = $this->writeFile('laravel-recent.log', 'recent', 2);
+
+        $result = $this->service->prune($this->dir, 7);
+
+        $this->assertFalse(file_exists($old), 'file older than 7 days should be deleted');
+        $this->assertTrue(file_exists($recent), 'file within 7 days should be kept');
+        $this->assertSame(1, $result['deleted']);
+    }
+
+    public function test_prune_preserves_gitignore_even_when_old(): void
+    {
+        $gitignore = $this->writeFile('.gitignore', "*\n!.gitignore", 30);
+
+        $result = $this->service->prune($this->dir, 7);
+
+        $this->assertTrue(file_exists($gitignore), '.gitignore must never be pruned');
+        $this->assertSame(0, $result['deleted']);
+    }
+
+    public function test_prune_recurses_into_subdirectories(): void
+    {
+        $old = $this->writeFile('cron/some_job.log', 'old', 10);
+
+        $result = $this->service->prune($this->dir, 7);
+
+        $this->assertFalse(file_exists($old), 'old file in subdirectory should be pruned');
+        $this->assertSame(1, $result['deleted']);
+    }
+
+    public function test_prune_dry_run_reports_without_deleting(): void
+    {
+        $old = $this->writeFile('laravel-old.log', 'old', 10);
+
+        $result = $this->service->prune($this->dir, 7, true);
+
+        $this->assertTrue(file_exists($old), 'dry run must not delete');
+        $this->assertSame(1, $result['deleted'], 'dry run still reports the would-be count');
+    }
+
+    public function test_compress_gzips_rotated_logs_and_removes_original(): void
+    {
+        $content = str_repeat("a log line that compresses well\n", 100);
+        $rotated = $this->writeFile('laravel-2020-01-01.log', $content, 2);
+
+        $result = $this->service->compress($this->dir);
+
+        $this->assertFalse(file_exists($rotated), 'original removed after compression');
+        $this->assertTrue(file_exists($rotated.'.gz'), 'gzip created');
+        $this->assertSame($content, gzdecode(file_get_contents($rotated.'.gz')), 'gzip round-trips the original content');
+        $this->assertSame(1, $result['compressed']);
+    }
+
+    public function test_compress_skips_files_modified_today(): void
+    {
+        $live = $this->writeFile('scheduler.log', 'live content', 0);
+
+        $result = $this->service->compress($this->dir);
+
+        $this->assertTrue(file_exists($live), 'a file written today (still live) must not be compressed');
+        $this->assertFalse(file_exists($live.'.gz'));
+        $this->assertSame(0, $result['compressed']);
+    }
+
+    public function test_compress_skips_already_compressed_files(): void
+    {
+        $gz = $this->writeFile('laravel-2020-01-01.log.gz', 'already gz', 5);
+
+        $result = $this->service->compress($this->dir);
+
+        $this->assertTrue(file_exists($gz));
+        $this->assertSame(0, $result['compressed']);
+    }
+
+    public function test_compress_handles_supervisor_numbered_backups(): void
+    {
+        $backup = $this->writeFile('scheduler.log.1', 'supervisor backup', 3);
+
+        $result = $this->service->compress($this->dir);
+
+        $this->assertFalse(file_exists($backup), 'numbered .log.N backup should be compressed');
+        $this->assertTrue(file_exists($backup.'.gz'));
+        $this->assertSame(1, $result['compressed']);
+    }
+
+    public function test_compress_ignores_non_log_files(): void
+    {
+        $txt = $this->writeFile('mjml-diff-report.txt', 'report', 5);
+
+        $result = $this->service->compress($this->dir);
+
+        $this->assertTrue(file_exists($txt), 'non-.log files are not compressed');
+        $this->assertFalse(file_exists($txt.'.gz'));
+        $this->assertSame(0, $result['compressed']);
+    }
+
+    public function test_compress_dry_run_reports_without_writing(): void
+    {
+        $rotated = $this->writeFile('laravel-2020-01-01.log', 'data', 2);
+
+        $result = $this->service->compress($this->dir, true);
+
+        $this->assertTrue(file_exists($rotated), 'dry run keeps the original');
+        $this->assertFalse(file_exists($rotated.'.gz'), 'dry run writes no gz');
+        $this->assertSame(1, $result['compressed'], 'dry run still reports the would-be count');
+    }
+
+    public function test_prune_on_missing_directory_is_a_noop(): void
+    {
+        $result = $this->service->prune($this->dir.'/does-not-exist', 7);
+
+        $this->assertSame(0, $result['deleted']);
+        $this->assertSame(0, $result['bytes']);
+    }
+
+    public function test_compress_on_missing_directory_is_a_noop(): void
+    {
+        $result = $this->service->compress($this->dir.'/does-not-exist');
+
+        $this->assertSame(0, $result['compressed']);
+    }
+}


### PR DESCRIPTION
## Summary

Sets up log rotation, gzip compression, and a 7-day retention window for the Laravel batch (`iznik-batch`) logs, which previously grew without bound (`storage/logs/` was 655 MB on the dev box, including a single orphaned 481 MB `scheduler.log.1`).

The active log channel was `single` (no rotation at all) even though a `daily` channel was defined but unused. The biggest offenders were not Monolog-managed: the supervisor-written `scheduler.log` / `worker.log` / `spooler.log` / `mail-receiver.log`. So this is a three-part fix:

- **Monolog rotation + retention** (`config/logging.php`, `.env.example`)
  - Active stack default `single` → `daily`, so app logs rotate into `laravel-YYYY-MM-DD.log`.
  - `incoming_mail` channel `single` → `daily` (nothing tails `storage/logs/incoming-mail.log`; Loki ingests the separate `/var/log/freegle/incoming_mail.log` written by `LokiService`, so this is safe).
  - Retention `LOG_DAILY_DAYS` default `14` → `7` (env-overridable).
- **`logs:rotate` command + `LogRotationService`** (`app/Console/Commands/Logs/`, `app/Services/`)
  - `prune()` deletes any file under `storage/logs/` (recursively, incl. `cron/`) older than the retention window — this is what reclaims the 481 MB orphan. Never touches `.gitignore`.
  - `compress()` gzips rotated, non-live `*.log` / `*.log.N` files (skips files modified today, which may still be open). Streams through gzip so a multi-hundred-MB file is never loaded into memory.
  - Scheduled `dailyAt('00:30')`, `withoutOverlapping()`, `runInBackground()`.
- **Supervisor size caps** (`docker/supervisor.conf`)
  - `stdout_logfile_maxbytes=50MB` + `stdout_logfile_backups=5` on all four programs, bounding the live supervisor logs going forward (`logs:rotate` then compresses/prunes the numbered backups).

### Interpretation note — "retain 7 days if not already got a retention level"

The active logging (`single`) had **no** retention, so I set a 7-day window. It stays env-overridable (`LOG_DAILY_DAYS` / the `--days` option), so any environment that already pins a retention wins. The previously-unused `daily` channel had a stale 14-day default, which I aligned to the requested 7.

## Code Quality Review

- `LogRotationService` materialises the file list before mutating the directory, so newly created `.gz` files are never re-scanned mid-run.
- gzip is streamed in 1 MiB chunks (`gzopen`/`gzwrite`) — safe for very large rotated logs.
- `compress()` only targets `*.log` / `*.log.N` and skips anything modified today, so a live file held open by a daemon (supervisor, Monolog single) is never compressed out from under it.
- `prune()` runs before `compress()` so we never gzip a file that is about to be deleted.
- Command is a thin delegation to the service (testable in isolation via a mock); service is pure filesystem logic (testable against temp-dir fixtures, no DB).

## Future Improvements

- `queue:background-tasks` uses `->appendOutputTo()` (line ~570 of `routes/console.php`), so `cron/queue_background-tasks.log` grows within a day; could switch to `->sendOutputTo()`.
- The supervisor caps require a **batch image rebuild** to take effect (`docker-compose build batch && up -d batch`; production: rebuild `batch-prod`). Until then the running container keeps supervisor's defaults (50 MB × 10).
- Deployments that pin `LOG_STACK=single` in their own `.env` need `LOG_STACK=daily` to activate Monolog rotation (config default is now `daily`, and `.env.example` is updated).

## Test Plan

- `LogRotationServiceTest` (temp-dir fixtures): prune deletes >N-day files / preserves `.gitignore` / recurses / dry-run; compress gzips rotated logs + removes original + round-trips content / skips today / skips `.gz` / handles `*.log.N` backups / ignores non-`.log` / dry-run.
- `RotateLogsCommandTest` (mocked service): prune-then-compress + exit 0; `--days` forwarded; `--dry-run` forwarded.
- Run via the worktree status API (`POST /api/tests/laravel`). Result: **15/15 passed**. Statement coverage on the touched modules: `LogRotationService` 94.1% (64/68), `RotateLogsCommand` 100% (21/21). The 4 uncovered service statements are `gzipFile` I/O-failure branches (fopen/gzopen returning false), not reachable as root.
