### PR TITLE
fix(isochrone): COALESCE browseView so unset setting doesn't NULL-scan

### DIFF
--- a/iznik-server-go/isochrone/message.go
+++ b/iznik-server-go/isochrone/message.go
@@ -150,7 +150,10 @@ func effectiveBrowseView(c *fiber.Ctx, db *gorm.DB, myid uint64) string {
 		return bv
 	}
 	var setting string
-	db.Raw("SELECT JSON_UNQUOTE(JSON_EXTRACT(settings, '$.browseView')) FROM users WHERE id = ?", myid).Scan(&setting)
+	// COALESCE to '' so users who have never set browseView (JSON_EXTRACT -> SQL NULL) scan cleanly
+	// into the non-nullable string instead of erroring "converting NULL to string is unsupported"
+	// on every such request. NULL still falls through to the "nearby" default below.
+	db.Raw("SELECT COALESCE(JSON_UNQUOTE(JSON_EXTRACT(settings, '$.browseView')), '') FROM users WHERE id = ?", myid).Scan(&setting)
 	if setting == "mygroups" {
 		return "mygroups"
 	}


### PR DESCRIPTION
## Problem
`effectiveBrowseView` (isochrone/message.go) scanned `JSON_UNQUOTE(JSON_EXTRACT(settings, '$.browseView'))` into a non-nullable Go `string`. For any user who has never set `browseView`, that JSON path is **SQL NULL**, so GORM logged `converting NULL to string is unsupported` on **every such request** (observed flooding the apiv2 error log on db1/db3). The fallback to `"nearby"` still happened, so it was log noise rather than a functional break — but noisy and masking real errors.

## Fix
`COALESCE(..., '')` the value in SQL — the same pattern already used in `visualise.go:199/201` — so NULL scans cleanly to `''` and still falls through to the `"nearby"` default. No behaviour change, just no error.

The two sibling `settings` scans (`message.go:919`, `:1727`) already scan into `*string` and are NULL-safe; only this one used a bare `string`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PfxahVbxhqzd9XWp2ptA7R