### PR TITLE
fix(routing): exclude toll roads from car routing

### DIFF
--- a/iznik-routing-go/graph.go
+++ b/iznik-routing-go/graph.go
@@ -513,6 +513,13 @@ func waySpeedsAndOneway(w *osm.Way) ([3]float32, bool) {
 	if tags["motor_vehicle"] == "no" || tags["vehicle"] == "no" || tags["access"] == "no" {
 		speeds[Drive] = -1
 	}
+	// Exclude toll roads from car routing entirely (the Humber/Dartford/Mersey/Tyne
+	// crossings, the M6 Toll, etc.). OSM tags the tolled carriageway toll=yes; the free
+	// foot/cycle ways alongside are separate, untagged ways, so this drops only the car
+	// edge and leaves walking/cycling routes intact.
+	if tags["toll"] == "yes" {
+		speeds[Drive] = -1
+	}
 	if ms := tags["maxspeed"]; ms != "" && speeds[Drive] > 0 {
 		if s := parseMaxspeed(ms); s > 0 {
 			speeds[Drive] = s

--- a/iznik-routing-go/toll_test.go
+++ b/iznik-routing-go/toll_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/paulmach/osm"
+)
+
+// wayWith builds an osm.Way carrying the given key/value tag pairs.
+func wayWith(kv ...string) *osm.Way {
+	w := &osm.Way{}
+	for i := 0; i+1 < len(kv); i += 2 {
+		w.Tags = append(w.Tags, osm.Tag{Key: kv[i], Value: kv[i+1]})
+	}
+	return w
+}
+
+// TestWaySpeedsAndOneway_TollExcludesDriving checks that ways tagged toll=yes
+// are dropped from car routing (Drive = -1) while walking and cycling are left
+// untouched. This is what keeps the UK toll crossings — the Humber Bridge,
+// Dartford Crossing, M6 Toll, Mersey Gateway and Tyne Tunnel — out of drive
+// isochrones. Verified end-to-end against real Humber OSM data: with this in
+// place a drive isochrone from Hull no longer crosses the Humber Bridge, while
+// the cycle isochrone (using the separate, untolled foot/cycle way) still does.
+func TestWaySpeedsAndOneway_TollExcludesDriving(t *testing.T) {
+	// Baseline: an untolled primary road allows all three modes.
+	base, _ := waySpeedsAndOneway(wayWith("highway", "primary"))
+	if base[Drive] <= 0 {
+		t.Fatalf("untolled primary should be drivable, got Drive=%v", base[Drive])
+	}
+	if base[Walk] <= 0 || base[Cycle] <= 0 {
+		t.Fatalf("untolled primary should allow walk/cycle, got Walk=%v Cycle=%v", base[Walk], base[Cycle])
+	}
+
+	// toll=yes on the same road drops the car edge only.
+	tolled, _ := waySpeedsAndOneway(wayWith("highway", "primary", "toll", "yes"))
+	if tolled[Drive] != -1 {
+		t.Errorf("toll=yes primary must exclude driving (Drive=-1), got %v", tolled[Drive])
+	}
+	if tolled[Walk] != base[Walk] {
+		t.Errorf("toll=yes must leave walking intact, got Walk=%v want %v", tolled[Walk], base[Walk])
+	}
+	if tolled[Cycle] != base[Cycle] {
+		t.Errorf("toll=yes must leave cycling intact, got Cycle=%v want %v", tolled[Cycle], base[Cycle])
+	}
+
+	// The Humber Bridge carriageway is highway=trunk + toll=yes (trunk already
+	// excludes foot/cycle; those cross on separate untagged ways). The car edge
+	// must still be dropped.
+	trunkToll, _ := waySpeedsAndOneway(wayWith("highway", "trunk", "toll", "yes"))
+	if trunkToll[Drive] != -1 {
+		t.Errorf("toll=yes trunk (Humber Bridge) must exclude driving, got %v", trunkToll[Drive])
+	}
+}


### PR DESCRIPTION
## What

Exclude UK toll roads from **car** routing in the isochrone/routing engine (`iznik-routing-go`).

OSM tags tolled carriageways `toll=yes` (the Humber Bridge, Dartford Crossing, M6 Toll, Mersey Gateway, Tyne Tunnel, Itchen Bridge, …). `waySpeedsAndOneway` now drops the car edge (`Drive = -1`) for any `toll=yes` way, so drive isochrones route around them rather than treating a paid crossing as a free shortcut.

Walking and cycling are deliberately **untouched** - the free foot/cycle ways alongside a toll crossing are separate, untagged OSM ways, so the change only ever sets the `Drive` index.

## Why

A drive-time isochrone that crosses, say, the Humber Bridge silently assumes Freeglers will pay a toll to reach an item. Excluding tolled carriageways makes the reachable area reflect the genuinely free road network.

## Verification (real OSM data)

Built the router twice (with/without the change) against a real Humber OSM extract and compared 30-min **drive** isochrones from Hull:

| | south extent | Barton-upon-Humber | south bank |
|---|---|---|---|
| **before** (bridge included) | 53.588 (deep into Lincs) | IN | IN |
| **after** (bridge excluded) | 53.700 (stops at the river) | OUT | OUT |

From the bridge's north foot, comparing every mode before/after:

- **walk** isochrone: byte-identical before/after
- **cycle** isochrone: byte-identical before/after, and still crosses to Barton (the untolled shared path)
- **drive** isochrone: changed - no longer crosses (south extent 53.565 → 53.700, the river)

So the exclusion is surgical: only car routing changes; foot/cycle are unaffected.

Confirmed via Overpass that the other major UK toll crossings are tagged `toll=yes` too, so the same one-line exclusion covers them: M6 Toll (77 ways), Dartford/A282, Mersey Gateway + Silver Jubilee Bridge, Tyne Tunnel + New Tyne Tunnel, Itchen Bridge.

## Tests

- New `TestWaySpeedsAndOneway_TollExcludesDriving` (a `toll=yes` primary drops `Drive` to `-1` while `Walk`/`Cycle` are preserved; a `toll=yes` trunk - the Humber Bridge case - also drops `Drive`).
- Full `iznik-routing-go` suite run locally via the status API (`/api/tests/routing`): green, including the new test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
