### PR TITLE
feat(edge): front-end server migration — plan + dev-validated preparatory implementation

### DIFF
--- a/docker-compose.override.edge.yml
+++ b/docker-compose.override.edge.yml
@@ -1,0 +1,29 @@
+# docker-compose.override.edge.yml — VM-ONLY override for the `edge` profile.
+#
+# Opt in ONLY on the front-end Katapult VM by adding this file to COMPOSE_FILE in
+# that VM's .env, e.g.:
+#   COMPOSE_FILE=docker-compose.yml:docker-compose.override.edge.yml
+#   COMPOSE_PROFILES=edge
+#   COMPOSE_PROJECT_NAME=freegle-edge
+#   TUSD_COMMAND=-upload-dir=/srv/tusd-data -behind-proxy -base-path / -disable-cors
+#
+# It is NEVER part of the default COMPOSE_FILE, so local dev and CI are unaffected
+# (plan §5.4/§5.5). It does two things the base file deliberately omits:
+#   1. Publishes the front-door host ports (no traefik on the VM).
+#   2. Binds tusd's upload dir to the shared-NFS host mount so uploaded image
+#      originals are zero-copy (the same NFS app1 serves today — plan §2/§7).
+
+services:
+  frontend-nginx:
+    ports:
+      - "80:80"       # HAProxy reaches this with send-proxy (PROXY protocol)
+      - "8080:8080"   # plain — the :8080 upload-URL form (apps/Freebie Alerts)
+
+  tusd:
+    volumes:
+      # /srv/tusd-data on the VM host is the shared-NFS mount
+      # (nfs2.nlc.storage.katapult.io:/katapult/fsv_5ivInYUXp22oVueE), mounted
+      # read-only during prep and flipped to rw only at the human-gated upload
+      # cutover (plan §7/§11). Replace with a `tusd-data:` named volume only for a
+      # non-NFS deployment.
+      - /srv/tusd-data:/srv/tusd-data

--- a/docker-compose.override.edge.yml
+++ b/docker-compose.override.edge.yml
@@ -1,29 +1,44 @@
-# docker-compose.override.edge.yml — VM-ONLY override for the `edge` profile.
+# docker-compose.override.edge.yml — PROD-DOCKER-HOST-ONLY override for the
+# `edge` profile (scale-in-place, decided 2026-07-08 — see the REVISION in
+# plans/2026-06-25-frontend-server-migration.md).
 #
-# Opt in ONLY on the front-end Katapult VM by adding this file to COMPOSE_FILE in
-# that VM's .env, e.g.:
-#   COMPOSE_FILE=docker-compose.yml:docker-compose.override.edge.yml
-#   COMPOSE_PROFILES=edge
-#   COMPOSE_PROJECT_NAME=freegle-edge
+# Opt in ONLY on the existing prod docker/batch host by adding this file to
+# COMPOSE_FILE in its .env, alongside the batch-host slice override:
+#   COMPOSE_FILE=docker-compose.yml:docker-compose.override.batchprod.yml:docker-compose.override.edge.yml
+#   COMPOSE_PROFILES=backend,production,mail,edge
 #   TUSD_COMMAND=-upload-dir=/srv/tusd-data -behind-proxy -base-path / -disable-cors
 #
-# It is NEVER part of the default COMPOSE_FILE, so local dev and CI are unaffected
-# (plan §5.4/§5.5). It does two things the base file deliberately omits:
-#   1. Publishes the front-door host ports (no traefik on the VM).
+# It is NEVER part of the default COMPOSE_FILE, so local dev and CI are
+# unaffected. It does three things the base file deliberately omits:
+#   1. Publishes the front-door host ports. NOT :80/:8080 — on this host
+#      native nginx owns :80/:443 (certbot TLS for tiles/geocode/wiki) and the
+#      legacy standalone tile container published :8080. HAProxy backends
+#      simply target the new ports instead.
 #   2. Binds tusd's upload dir to the shared-NFS host mount so uploaded image
 #      originals are zero-copy (the same NFS app1 serves today — plan §2/§7).
+#   3. Remaps the osm volumes to the host's EXISTING unprefixed Docker volumes
+#      (used by the standalone confident_curran container) so the compose
+#      tile-server ADOPTS the 56G PostGIS + 44G tile data instead of creating
+#      empty project-scoped volumes (freegledocker_osm-data) and serving
+#      nothing.
 
 services:
   frontend-nginx:
     ports:
-      - "80:80"       # HAProxy reaches this with send-proxy (PROXY protocol)
-      - "8080:8080"   # plain — the :8080 upload-URL form (apps/Freebie Alerts)
+      - "8180:80"     # HAProxy reaches this with send-proxy (PROXY protocol)
+      - "8188:8080"   # plain — the :8080 upload-URL form (apps/Freebie Alerts)
 
   tusd:
     volumes:
-      # /srv/tusd-data on the VM host is the shared-NFS mount
+      # /srv/tusd-data on the host is the shared-NFS mount
       # (nfs2.nlc.storage.katapult.io:/katapult/fsv_5ivInYUXp22oVueE), mounted
       # read-only during prep and flipped to rw only at the human-gated upload
-      # cutover (plan §7/§11). Replace with a `tusd-data:` named volume only for a
-      # non-NFS deployment.
+      # cutover (plan §7/§11). NFS reachability from this host verified
+      # 2026-07-08 (TCP 2049 via the default route).
       - /srv/tusd-data:/srv/tusd-data
+
+volumes:
+  osm-data:
+    name: osm-data      # adopt the existing volume, do not create freegledocker_osm-data
+  osm-tiles:
+    name: osm-tiles     # adopt the existing volume

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -349,12 +349,14 @@ services:
       - "traefik.http.middlewares.tusd-cors-headers.headers.customresponseheaders.Access-Control-Allow-Headers=Authorization, Origin, X-Requested-With, X-Request-ID, X-HTTP-Method-Override, Content-Type, Upload-Length, Upload-Offset, Tus-Resumable, Upload-Metadata, Upload-Defer-Length, Upload-Concat, Upload-Complete, Upload-Draft-Interop-Version, x-token, baggage, sentry-trace"
 
   # ===========================================================================
-  # edge profile — front-end host (Katapult VM). See
-  # plans/2026-06-25-frontend-server-migration.md. These services run ONLY under
-  # the `edge` profile, which is in NO default profile set, so dev/CI never start
-  # them and are completely unaffected. Host port bindings live in the VM-only
-  # docker-compose.override.edge.yml (no traefik on the VM); on dev the stack is
-  # validated over the compose network.
+  # edge profile — user-facing front-end services, deployed on the existing
+  # docker/batch host (scale-in-place, decided 2026-07-08 — see the REVISION in
+  # plans/2026-06-25-frontend-server-migration.md). These services run ONLY
+  # under the `edge` profile, which is in NO default profile set, so dev/CI
+  # never start them and are completely unaffected. Host port bindings and the
+  # adoption of the host's existing osm volumes live in the host-only
+  # docker-compose.override.edge.yml; on dev the stack is validated over the
+  # compose network.
   # ===========================================================================
   frontend-nginx:
     image: nginx:1.27-alpine
@@ -382,7 +384,12 @@ services:
       start_period: 10s
 
   tile-server:
-    image: overv/openstreetmap-tile-server:latest
+    # Pinned to the EXACT image the prod host's standalone tile container
+    # (confident_curran) runs, so adopting its existing osm-data volume works:
+    # the PostGIS data dir is Postgres-major-version-locked and a newer
+    # :latest could refuse to start on it. Upgrade deliberately after
+    # adoption, not implicitly via a pull.
+    image: overv/openstreetmap-tile-server@sha256:b6a79da39b6d0758368f7c62d22e49dd3ec59e78b194a5ef9dee2723b1f3fa79
     container_name: ${COMPOSE_PROJECT_NAME:-freegle}-tile-server
     profiles:
       - edge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -276,6 +276,7 @@ services:
     container_name: ${COMPOSE_PROJECT_NAME:-freegle}-delivery
     profiles:
       - frontend
+      - edge   # front-end host: weserv replaces the external wsrv.nl dependency
     networks:
       - default
     image: ghcr.io/weserv/images:5.x
@@ -318,13 +319,17 @@ services:
     container_name: ${COMPOSE_PROJECT_NAME:-freegle}-tusd
     profiles:
       - frontend
+      - edge   # front-end host: same tusd image, prod flags via ${TUSD_COMMAND}
     networks:
       default:
         aliases:
           - tusd.localhost
     ports:
       - "${PORT_TUSD:-1080}:8080"
-    command: -hooks-http=http://apiv1:80/api/image -hooks-enabled-events=pre-create,post-finish -base-path=/tus/ -cors-allow-headers=baggage,sentry-trace
+    # Default == the dev/CI command (unchanged). The edge VM overrides it via .env:
+    #   TUSD_COMMAND=-upload-dir=/srv/tusd-data -behind-proxy -base-path / -disable-cors
+    # (app1 prod runs WITHOUT -hooks-http — see plan §3/§5.)
+    command: ${TUSD_COMMAND:--hooks-http=http://apiv1:80/api/image -hooks-enabled-events=pre-create,post-finish -base-path=/tus/ -cors-allow-headers=baggage,sentry-trace}
     depends_on:
       reverse-proxy:
         condition: service_healthy
@@ -342,6 +347,57 @@ services:
       - "traefik.http.routers.tusd.middlewares=tusd-cors-headers"
       - "traefik.http.services.tusd.loadbalancer.server.port=8080"
       - "traefik.http.middlewares.tusd-cors-headers.headers.customresponseheaders.Access-Control-Allow-Headers=Authorization, Origin, X-Requested-With, X-Request-ID, X-HTTP-Method-Override, Content-Type, Upload-Length, Upload-Offset, Tus-Resumable, Upload-Metadata, Upload-Defer-Length, Upload-Concat, Upload-Complete, Upload-Draft-Interop-Version, x-token, baggage, sentry-trace"
+
+  # ===========================================================================
+  # edge profile — front-end host (Katapult VM). See
+  # plans/2026-06-25-frontend-server-migration.md. These services run ONLY under
+  # the `edge` profile, which is in NO default profile set, so dev/CI never start
+  # them and are completely unaffected. Host port bindings live in the VM-only
+  # docker-compose.override.edge.yml (no traefik on the VM); on dev the stack is
+  # validated over the compose network.
+  # ===========================================================================
+  frontend-nginx:
+    image: nginx:1.27-alpine
+    container_name: ${COMPOSE_PROJECT_NAME:-freegle}-frontend-nginx
+    profiles:
+      - edge
+    networks:
+      - default
+    depends_on:
+      delivery:
+        condition: service_started
+      tusd:
+        condition: service_started
+      tile-server:
+        condition: service_started
+        required: false
+    volumes:
+      - ./frontend-nginx.conf:/etc/nginx/nginx.conf:ro
+      - delivery-cache:/var/cache/nginx/wsrv_cache
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O- http://127.0.0.1:8081/healthz || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+
+  tile-server:
+    image: overv/openstreetmap-tile-server:latest
+    container_name: ${COMPOSE_PROJECT_NAME:-freegle}-tile-server
+    profiles:
+      - edge
+    networks:
+      - default
+    command: run
+    environment:
+      # Emit NO CORS here — frontend-nginx adds exactly one ACAO (plan §2
+      # double-CORS fix). Tiles need a real osm-data import before they render
+      # (plan §7); the service definition exists so the front door can be wired.
+      - ALLOW_CORS=disabled
+    shm_size: 256m
+    volumes:
+      - osm-data:/data/database
+      - osm-tiles:/data/tiles
 
   # Old status container - replaced by status-nuxt (2026-01-18)
   # Keeping commented out for reference during transition
@@ -1922,6 +1978,15 @@ volumes:
     driver: local
   mcp-audit-logs:
     driver: local
+  # edge profile (front-end host) — see plans/2026-06-25-frontend-server-migration.md
+  delivery-cache:
+    driver: local   # frontend-nginx wsrv_cache (mirror of app1's 41 GB delivery cache)
+  tusd-data:
+    driver: local   # Docker-managed tusd upload dir; the VM override points /srv/tusd-data at NFS instead
+  osm-data:
+    driver: local   # tile-server PostGIS (osm-data, ~56 GB once imported)
+  osm-tiles:
+    driver: local   # tile-server rendered tiles (~44 GB)
 
 networks:
   default:

--- a/frontend-nginx.conf
+++ b/frontend-nginx.conf
@@ -1,0 +1,186 @@
+# frontend-nginx.conf — front door for the `edge` (front-end host) Compose profile.
+#
+# Replaces, on a dedicated Katapult VM:
+#   - app1's delivery cache nginx (delivery.ilovefreegle.org → wsrv.nl) and tusd
+#     proxy (uploads.ilovefreegle.org), and
+#   - this docker host's tiles/geocode/wiki nginx vhosts.
+#
+# See plans/2026-06-25-frontend-server-migration.md (§2, §5, §10) for the
+# load-bearing facts encoded below. This file is consumed ONLY by the
+# `frontend-nginx` service, which only runs under the `edge` profile — so dev/CI
+# never load it.
+#
+# Validate before use:  nginx -t  (the upstreams use `set $x …; proxy_pass $x;`
+# plus the Docker resolver, so the config parses with NO backends present).
+
+user  nginx;
+worker_processes  auto;
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+worker_rlimit_nofile 65535;
+
+events {
+    worker_connections  8192;
+}
+
+http {
+    include       mime.types;
+    default_type  application/octet-stream;
+
+    # Docker's embedded DNS — lets `set $x http://service; proxy_pass $x;` resolve
+    # at request time, so the config validates (`nginx -t`) without backends up.
+    resolver 127.0.0.11 valid=10s ipv6=off;
+    resolver_timeout 5s;
+
+    log_format  main  '$remote_addr - $remote_user [$time_iso8601] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" cache=$upstream_cache_status rt=$request_time';
+    access_log /var/log/nginx/access.log main;
+
+    sendfile        on;
+    tcp_nopush      on;
+    tcp_nodelay     on;
+    keepalive_timeout  65;
+    server_tokens   off;
+
+    # --- PROXY protocol / real client IP ----------------------------------
+    # In prod HAProxy (ha-internal) reaches our :80 with `send-proxy`, so every
+    # :80 listener below is `proxy_protocol` and we recover the client IP from
+    # the PROXY header. :8080 (tusd) is reached plain. (Open decision §12.6:
+    # send-proxy vs XFF — switch real_ip_header to X-Forwarded-For if dropped.)
+    set_real_ip_from 10.220.0.0/22;   # internal net (ha-internal / applb)
+    set_real_ip_from 172.16.0.0/12;   # docker bridge (dev validation)
+    set_real_ip_from 127.0.0.1;       # local PROXY-framing test
+    real_ip_header proxy_protocol;
+
+    # --- Delivery (weserv) cache ------------------------------------------
+    # Mirror app1's cache exactly so the warm-started 41 GB cache is reusable.
+    # The cache KEY is pinned to the wsrv.nl form (verified from a live cache
+    # file's `KEY:` header) even though our upstream is the LOCAL weserv
+    # container — otherwise the warm-started entries orphan.
+    proxy_cache_path /var/cache/nginx/wsrv_cache levels=1:2 keys_zone=wsrv_cache:100m
+                     max_size=40g inactive=30d use_temp_path=off;
+
+    # ======================================================================
+    # uploads.ilovefreegle.org  → tusd   (NO CORS here — HAProxy adds it)
+    #   :80  proxy_protocol  (HAProxy send-proxy)
+    #   :8080 plain          (the upload-URL form used by apps/Freebie Alerts;
+    #                         kept indefinitely — §2). Default for :8080.
+    # ======================================================================
+    server {
+        listen 80 proxy_protocol;
+        listen 8080 default_server;
+        server_name uploads.ilovefreegle.org;
+
+        client_max_body_size 0;   # tus streams arbitrarily large uploads
+
+        location / {
+            set $tusd_upstream http://tusd:8080;
+            proxy_pass $tusd_upstream;
+            proxy_http_version 1.1;
+            proxy_request_buffering off;
+            proxy_set_header Host              $host;
+            proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Upgrade           $http_upgrade;
+            proxy_set_header Connection        "";
+            # Deliberately NO Access-Control-* headers: app1 tusd runs
+            # `-disable-cors` and ALL tus CORS comes from HAProxy tusd_backend.
+        }
+    }
+
+    # ======================================================================
+    # delivery.ilovefreegle.org → local weserv container (cached)
+    # ======================================================================
+    server {
+        listen 80 proxy_protocol;
+        server_name delivery.ilovefreegle.org uploadcare-cache.ilovefreegle.org
+                    uploadcare-proxy-cache.ilovefreegle.org;
+
+        location / {
+            proxy_cache wsrv_cache;
+            proxy_cache_key "https://wsrv.nl$request_uri";
+            proxy_cache_methods GET HEAD;
+            proxy_cache_valid 200 301 410 30d;
+            proxy_cache_valid 429 500 502 503 504 0;
+            proxy_cache_valid any 15m;
+            proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
+            proxy_cache_lock on;
+            # weserv emits its own X-Cache-Status (its tiny inner cache); hide it
+            # so the front door exposes exactly one — our 41 GB cache's status,
+            # which is what cutover HIT-rate measurement (§10) must read.
+            proxy_hide_header X-Cache-Status;
+            add_header X-Cache-Status $upstream_cache_status always;
+
+            # Upstream is the local weserv container's PUBLIC (default) server,
+            # which runs its own engine + small cache. Do NOT send
+            # Host: images.weserv.local — that is weserv's internal
+            # localhost-only engine vhost (allow 127.0.0.1; deny all → 403).
+            set $delivery_upstream http://delivery:80;
+            proxy_pass $delivery_upstream;
+            proxy_set_header Host             $host;
+            proxy_set_header X-Forwarded-For  $remote_addr;
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+
+            # weserv may 301/302 to the origin image; follow once so the
+            # cached object is the final image, matching app1 behaviour.
+            proxy_intercept_errors on;
+            recursive_error_pages on;
+            error_page 301 302 307 = @handle_redirect;
+        }
+
+        location @handle_redirect {
+            set $redirect_target $upstream_http_location;
+            proxy_pass $redirect_target;
+            proxy_cache wsrv_cache;
+            proxy_cache_key "https://wsrv.nl$request_uri";
+            proxy_hide_header X-Cache-Status;
+            add_header X-Cache-Status $upstream_cache_status always;
+        }
+    }
+
+    # ======================================================================
+    # tiles.ilovefreegle.org → overv tile-server  (EXACTLY ONE ACAO)
+    #   Run tile-server with ALLOW_CORS=disabled so it emits zero ACAO; we add
+    #   exactly one here. (app1+overv today emit two — the bug §2 calls out.)
+    # ======================================================================
+    server {
+        listen 80 proxy_protocol;
+        server_name tiles.ilovefreegle.org;
+
+        add_header Access-Control-Allow-Origin "*" always;
+
+        location / {
+            set $tiles_upstream http://tile-server:80;
+            proxy_pass $tiles_upstream;
+            proxy_set_header Host             $host;
+            proxy_set_header X-Forwarded-For  $remote_addr;
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+        }
+    }
+
+    # ======================================================================
+    # Catch-all — unknown Host gets nothing (no default backend leak).
+    # ======================================================================
+    server {
+        listen 80 proxy_protocol default_server;
+        server_name _;
+        return 444;
+    }
+
+    # ======================================================================
+    # Health check — plain listener (NOT proxy_protocol) for the container
+    # healthcheck and ops probes.
+    # ======================================================================
+    server {
+        listen 8081;
+        server_name _;
+        default_type text/plain;
+        location = /healthz {
+            access_log off;
+            return 200 "ok\n";
+        }
+    }
+}

--- a/plans/2026-06-25-frontend-server-migration.md
+++ b/plans/2026-06-25-frontend-server-migration.md
@@ -59,11 +59,16 @@
 >    the current overload, and the priority mechanism everything else relies
 >    on). Investigate batch-prod's 428% CPU separately (likely the ripple
 >    loop - see plans/routing-performance-step-change.md).
-> 1. **Upsize the host** (Krystal package upgrades are live/no-downtime):
->    target ROCK-48-class 16 vCPU/48G. RAM is the binding constraint: current
->    real working set ~20-24G (box is 12G into swap) + weserv/nginx/tusd
->    (small) + MemoryLow-protected page cache for the 41G image cache.
->    ROCK-96 (32/96, £480/mo) is the escape hatch.
+> 1. **Upsize the host ONLY on evidence** (Krystal package upgrades are
+>    live/no-downtime, so buying early gains nothing). Measured 2026-07-08:
+>    the 12G swap is COLD pages (photon JVM 6.2G + renderd 4.0G idle;
+>    swap-in ~4 pages/s - no thrash), the hot set fits in 23G, and app1 runs
+>    the entire image tier in 2.8G/1 vCPU - so consolidation adds only
+>    ~1 core + 2-4G and fits the current size once the ripple CPU waste is
+>    fixed. Upsize triggers: sustained swap-in (100s of pages/s), PSI memory
+>    pressure, digest shards overrunning the 07:00-12:00 window, or
+>    interactive-tier CPU stalls after the ripple fix. Then: ROCK-48
+>    (16 vCPU/48G, +£120/mo), ROCK-96 as the further escape hatch.
 > 2. **Adopt standalone containers into Compose** (same host, same data):
 >    `tile-server` service on external volumes `osm-data`/`osm-tiles` (stop
 >    `confident_curran`, `up` the compose service); `wiki-media`+`wiki-mysql`

--- a/plans/2026-06-25-frontend-server-migration.md
+++ b/plans/2026-06-25-frontend-server-migration.md
@@ -1,6 +1,102 @@
 # Front-End Server Migration — consolidated plan (2026-06-25)
 
-**Goal.** Stand up a new Katapult VM running a FreegleDocker Compose environment that hosts **every externally-accessed service** currently split across (a) `app1-internal` bare-metal and (b) this `docker` host's Compose env + host nginx. Afterwards: **app1 is retired**, and this `docker` host keeps **only internal batch/mail/ops** (it is also the prod batch host, `batch-prod`).
+> ## REVISION 2026-07-08 — scale-in-place on the existing docker host (DECIDED)
+>
+> **Direction change (Edward):** no new VM. Scale the existing `docker` host,
+> adopt its standalone containers into Compose, and migrate app1's services
+> onto it. app1 is retired; the docker host becomes the single mixed node
+> running everything (edge + batch), with priority guaranteed by **cgroup v2
+> slices** (work-conserving weights - batch soaks idle capacity, yields under
+> contention), not by physical partitioning. Slices implemented in **PR #1006**
+> (`interactive.slice`/`batch.slice` + `docker-compose.override.batchprod.yml`).
+>
+> **Why consolidation won** (measured 2026-07-08): edge traffic is ~10:1
+> peak:trough (app1 delivery logs: ~9K req/hr at 03:00 vs ~98K/hr 08:00-10:00)
+> and CPU-light (app1 serves the whole image tier's peak on 1 vCPU at load
+> 0.11), while batch is CPU-shaped and starving (docker host load 13.6 on 8
+> cores, batch-prod at 428% CPU, 12G into swap). Complementary shapes: a
+> dedicated edge VM would waste CPU at all hours; on a shared box batch gets
+> the 12-14 cores edge doesn't use. Caveat: digests (07:00-12:00) *cause* the
+> edge morning peak (emails full of image links), so the biggest batch job and
+> the edge peak coincide - weights let image-serving win and digest shards
+> stretch within their window; watch `/proc/pressure/cpu` there post-merge.
+>
+> **What this revision eliminates from the plan below:**
+> - §3 two-VM target architecture and all of §7's VM provisioning.
+> - tiles/geocode/wiki "migration" - they are **already on this host**; the
+>   DNS A-records already point here (185.44.254.12). They don't move at all;
+>   the tile server and wiki containers just get adopted into Compose.
+> - The osm-data/osm-tiles/wiki data-sync problem - verified 2026-07-08: the
+>   tile server (`confident_curran`) already uses named Docker volumes
+>   `osm-data`/`osm-tiles` (adopt via `external: true`), and wiki uses bind
+>   mounts under `/var/wiki` - zero data movement, same-host container swap.
+>
+> **What survives unchanged:** §2 verified facts; §5/§6 dev-validated `edge`
+> profile artifacts (deployed here instead of on a VM, alongside the existing
+> profiles → `COMPOSE_PROFILES=backend,production,mail,edge`); the §8 HAProxy
+> cutover mechanics for uploads/delivery; §10 risks/observability (promtail,
+> cache-key HIT replay, PROXY framing); §11 AI-safety protocol.
+>
+> **Feasibility verified live 2026-07-08 (read-only):**
+> - NFS: `nfs2.nlc.storage.katapult.io` (10.11.3.10/.20) **is reachable from
+>   this host** - TCP 2049 connects via the default route; no Katapult network
+>   change needed. Export allowlist for this host still to be confirmed at
+>   first mount (`-o ro` first, per §11).
+> - Host is cgroup v2 + systemd cgroup driver + controllers delegated
+>   (Docker 29.2.1/runc 1.3.4) - PR #1006 slices work with no daemon changes.
+> - Port constraint: native nginx owns `:80`/`:443` (certbot TLS for
+>   tiles/geocode/wiki + stale discourse) and `:8080` is the tile container's
+>   published port. So the HAProxy-fronted vhosts (uploads incl. the
+>   `:8080`-URL form + delivery) publish on **new ports** (e.g. `:8180`
+>   proxy_protocol, `:8188` plain) and the HAProxy backends target those.
+>   Native nginx keeps the direct-A TLS domains initially; moving
+>   tiles/geocode/wiki behind applb (DNS repoint → HAProxy TLS) is an optional
+>   later step that removes certbot from this host and makes failover uniform.
+>
+> **Revised staging** (each step independently reversible, human-gated):
+> 0. **Immediately, before anything else:** disk is at 89% - add block storage
+>    (£0.15/GB/mo) and grow the filesystem. Deploy PR #1006 slices (relief for
+>    the current overload, and the priority mechanism everything else relies
+>    on). Investigate batch-prod's 428% CPU separately (likely the ripple
+>    loop - see plans/routing-performance-step-change.md).
+> 1. **Upsize the host** (Krystal package upgrades are live/no-downtime):
+>    target ROCK-48-class 16 vCPU/48G. RAM is the binding constraint: current
+>    real working set ~20-24G (box is 12G into swap) + weserv/nginx/tusd
+>    (small) + MemoryLow-protected page cache for the 41G image cache.
+>    ROCK-96 (32/96, £480/mo) is the escape hatch.
+> 2. **Adopt standalone containers into Compose** (same host, same data):
+>    `tile-server` service on external volumes `osm-data`/`osm-tiles` (stop
+>    `confident_curran`, `up` the compose service); `wiki-media`+`wiki-mysql`
+>    services on the existing `/var/wiki` binds; drop `ors-app` (superseded by
+>    spatial on db1/2/3) and the stale discourse vhost. Photon stays native
+>    under monit for now (own later stage). tile-server sits in the default
+>    tier (it mixes user serving with render storms), wiki likewise.
+> 3. **Images migration (the only real move):** mount NFS `/images` ro; bring
+>    up `delivery` (weserv) + `tusd` + `frontend-nginx` (uploads + delivery
+>    vhosts only, pinned cache key per §2) on the new ports under
+>    `interactive.slice`; low-priority rsync of app1's 41G `/wsrv_cache`;
+>    replay-validate >90% HIT (§10); then HAProxy cutover per §8 - repoint
+>    `tusd_backend`, add `delivery_backend`, and **keep app1 as `backup`
+>    server in both** (free rollback AND a warm failover sibling until
+>    retirement).
+> 4. **Legacy `images`/`cdn`/`users`-web** (app1 PHP-coupled, HAProxy default
+>    backend): still the awkward tail - needs the legacy PHP served here
+>    (apiv1 container or port the vhosts) before app1 can retire. Own stage;
+>    `users` mail-alias MX remains a separate workstream (§8).
+> 5. **Retire app1** per §9 (after ≥1 week clean, and only after step 4).
+>    Post-retirement failover: the next investments are a second HAProxy on a
+>    Katapult VIP, and - if wanted later - a second mixed node as backup
+>    backend for uploads/delivery (NFS is shared; caches cold-start).
+>
+> A host reboot now takes user-facing services down with it - the reboot
+> runbook (plans/2026-07-03-host-reboot-runbook.md) becomes the canonical
+> procedure, and restart policies deserve hardening (most edge services are
+> `restart: "no"`, relying on `freegle-docker.service`).
+>
+> The original plan below is retained for its verified facts, dev-validation
+> results, HAProxy mechanics, and safety protocol. Read §3/§7 as superseded.
+
+**Goal.** ~~Stand up a new Katapult VM~~ **(superseded 2026-07-08 - see REVISION above: scale the existing docker host in place)** running a FreegleDocker Compose environment that hosts **every externally-accessed service** currently split across (a) `app1-internal` bare-metal and (b) this `docker` host's Compose env + host nginx. Afterwards: **app1 is retired** - the docker host runs everything, with cgroup slices separating the tiers (it remains the prod batch host, `batch-prod`).
 
 This supersedes and broadens `docs/superpowers/specs/2026-04-11-frontend-server-design.md` (which scoped only images + tiles). Scope is now: **anything reached from the outside world moves; internal batch processing stays.**
 

--- a/plans/2026-06-25-frontend-server-migration.md
+++ b/plans/2026-06-25-frontend-server-migration.md
@@ -1,0 +1,156 @@
+# Front-End Server Migration — consolidated plan (2026-06-25)
+
+**Goal.** Stand up a new Katapult VM running a FreegleDocker Compose environment that hosts **every externally-accessed service** currently split across (a) `app1-internal` bare-metal and (b) this `docker` host's Compose env + host nginx. Afterwards: **app1 is retired**, and this `docker` host keeps **only internal batch/mail/ops** (it is also the prod batch host, `batch-prod`).
+
+This supersedes and broadens `docs/superpowers/specs/2026-04-11-frontend-server-design.md` (which scoped only images + tiles). Scope is now: **anything reached from the outside world moves; internal batch processing stays.**
+
+> Status: PLAN ONLY. Nothing in production has been changed. One inert artifact has been drafted: `frontend-nginx.conf` at repo root (referenced in §5). The Katapult key is available. SSH confirmed to app1 (`10.220.0.45`), `ha-internal` (HAProxy), this `docker` host, and `db{1,2,3}-internal`.
+
+---
+
+## 1. Corrected scope — external (MOVE) vs internal (STAY) vs DROP
+
+All verified read-only on 2026-06-25.
+
+### 1a. External-facing → MOVE to the new front-end server
+
+| Hostname | Today: host / backend | Fronted by | Cutover | Data to move |
+|---|---|---|---|---|
+| `uploads.ilovefreegle.org` | app1 bare-metal **tusd** `:8080` (`-upload-dir=images -behind-proxy -base-path / -disable-cors`, cwd `/` → `/images` NFS) | HAProxy `tusd_backend` (+ `tusd_frontend :8080`) | **HAProxy backend switch — no DNS** | None — shared NFS (mount it) |
+| `delivery.ilovefreegle.org` | app1 nginx/1.28.2 cache → **wsrv.nl** | HAProxy `http_backend_cache` (shared) | HAProxy backend switch (add `delivery_backend`) | 41 GB `/wsrv_cache` (warm-start, optional) |
+| `uploadcare-cache` / `uploadcare-proxy-cache` | app1, **same** `http_backend_cache` | HAProxy | Rides delivery's backend (do **not** repoint shared backend; add a new one) | Shared with delivery |
+| `images.ilovefreegle.org` | app1 **legacy PHP** image serving | HAProxy `http_backend` (default) | HAProxy backend switch | PHP app (not self-contained) |
+| `cdn.ilovefreegle.org` | app1 nginx vhost (email image links, `timg_*`) | HAProxy `http_backend` (default) | HAProxy backend switch | app1 vhost |
+| `users.ilovefreegle.org` | app1 (web 302→www **and** the `<id>@users.ilovefreegle.org` mail-alias reply domain) | HAProxy `http_backend` (default) + MX | HAProxy for web; **mail/MX is separate** | Web vhost; mail routing is its own workstream |
+| `tiles.ilovefreegle.org` | **this docker host** nginx/1.24.0 → `127.0.0.1:8080` (overv tile container) | **Direct A → 185.44.254.12** | **DNS A-record repoint (TTL 60)** | `osm-data` 56 GB (live PostGIS) + `osm-tiles` 44 GB |
+| `geocode.ilovefreegle.org` | **this docker host** nginx → `127.0.0.1:2322` (Photon, bare-metal Java) | **Direct A → 185.44.254.12** | **DNS A-record repoint (TTL 3600 — lower first)** | Photon index (~GBs, rebuildable) |
+| `wiki.ilovefreegle.org` | **this docker host** nginx → `127.0.0.1:8088` (`wiki-media` mediawiki:1.39 + `wiki-mysql`) | **Direct A → 185.44.254.12** | **DNS A-record repoint** | MediaWiki files + `wiki-mysql` DB dump (stateful) |
+
+### 1b. Internal-only → STAY on this docker host (becomes batch/mail/ops only)
+
+`freegledocker-batch-prod` (scheduler), `freegledocker-mjml`, `freegledocker-redis`, `freegledocker-postfix` (`:25`), `freegledocker-rspamd`, `freegledocker-spamassassin`, `freegledocker-embedding-sidecar` (`:3200`, apiv2 semantic search — cross-host internal), `freegledocker-spatial` (`:8196`) + `freegledocker-spatial-knn` (`:8194/5`) (**batch-digest** path, localhost-only; the *public* `spatial.ilovefreegle.org` routing is on db1/2/3, not here), `freegledocker-loki` (`:3100`), `freegledocker-status` (`:18081`, ops; public `status.ilovefreegle.org` → applb).
+
+To confirm before finalizing: `freegledocker-ai-support-helper` (`:8083`) — appears mod/support-internal (`/api/log-analysis` requires mod auth); classify internal unless a public hostname points at it.
+
+### 1c. DROP (do not migrate)
+
+- `ors-app` (OpenRouteService) — superseded by **PR459** (merged `242d8a15c`); routing now runs natively on db1/2/3 as `spatial.ilovefreegle.org`. Decommission on this host independently.
+- The `discourse.ilovefreegle.org` nginx vhost here is **stale** — DNS now resolves to `freegle.discoursehosting.net (178.156.182.236)` (external SaaS). Remove the dead vhost; nothing to move.
+
+---
+
+## 2. Load-bearing verified facts
+
+- **HAProxy** on `ha-internal` (= `10.220.0.172` = `applb` = public `185.199.221.13`), v2.4.30, `/etc/haproxy/haproxy.cfg`, backups `haproxy.cfg.bak.YYYYMMDD-*`. ACLs: `uploader→tusd_backend`; `delivery`+`uploadcare_cache`+`uploadcare_proxy_cache`→`http_backend_cache` (**shared**); `api`+shortlinks→`api_server_backend` (db1/2/3:8192); `spatial`→`spatial_backend` (db1/2/3:8196); `modtools.org`→Netlify; default→`http_backend`. **app4 (10.220.0.188) is dead** ("no route to host") yet still listed in `tusd_backend`/`http_backend_cache` (backup) AND `http_backend` (**non-backup active** — clean all three). New rate-limit layer (`per_ip_rates`/`per_user_rates`, 200 req/s/IP, `lua.rate_delay`) — verify image bursts aren't shaped post-cutover.
+- **DNS fronting**: `uploads`/`delivery`/`images`/`cdn`/`users`(A)/`spatial` → applb (HAProxy) ⇒ **backend switch, no DNS**. `tiles`(TTL 60)/`geocode`(TTL 3600)/`wiki` → direct A `185.44.254.12` (this host) ⇒ **DNS repoint**.
+- **Delivery cache key (de-risked)**: app1 sets *no* explicit `proxy_cache_key`, but a live cache file's header shows `KEY: https://wsrv.nl/?url=…&w=240&h=240&fit=cover`. So the new front nginx MUST pin `proxy_cache_key "https://wsrv.nl$request_uri"` (since its upstream becomes the local weserv container, not wsrv.nl) or the 41 GB orphans. `proxy_cache_path … levels=1:2 keys_zone=wsrv_cache:100m max_size=40g inactive=30d use_temp_path=off` (mirror exactly).
+- **tusd CORS**: app1 tusd runs `-disable-cors`; **all** tus CORS comes from HAProxy `tusd_backend`. New front nginx adds **zero** CORS on the uploads vhost.
+- **Tiles double-CORS**: today both the host nginx and the overv container (`ALLOW_CORS=enabled`) emit `Access-Control-Allow-Origin: *` → **two** headers. New front nginx must emit exactly one (run overv with `ALLOW_CORS=disabled`).
+- **PROXY protocol**: HAProxy reaches `:80` backends with `send-proxy`; `:8080` (tusd) plain. New front nginx: `listen 80 proxy_protocol; listen 8080;` and recover client IP from the PROXY header.
+- **Traffic (HAProxy stats)**: delivery tier ~**864 K req/day / ~78 GB/day** (incl. uploadcare); uploads ~**38 K req/day / ~17.8 GB/day**; legacy `images` ~**120 K/day** (92 K emit the `:8080` delivery form). Tiles ~**35–42 K/day** (this host's `maps_access.log`). Cache-hit ~92% claim is **unverifiable** (app1 nginx logs don't ship to Loki — see §10 observability).
+- **`:8080` upload-URL form is in active live traffic** (Freebie Alerts, native apps, weserv fetcher) and hardcoded in apiv2 `GetImageDeliveryUrl` + frontend `config.js` + V1 — keep the `:8080` listener indefinitely; its retirement is separate work.
+- **app1 disk** 75% (112/158 G); `/images` NFS = `nfs2.nlc.storage.katapult.io:/katapult/fsv_5ivInYUXp22oVueE` (882 G/4.9 T, concurrent-mountable). **This host** `/` at 86% (after laravel.log rotation). osm-data 56 G, osm-tiles ~44 G. **NFS storage net = `10.11.3.0/24`** (separate from `10.220.0.0/22`) — the new VM needs a route to it.
+
+---
+
+## 3. Target architecture
+
+New front-end VM(s) run FreegleDocker with a dedicated profile (proposed name **`edge`** / `frontend-host`, broadened from the doc's `image-host`):
+
+- `frontend-nginx` (new front door, `:80 proxy_protocol` + `:8080`) — replaces app1's delivery cache nginx + tusd proxy AND this host's tiles/geocode/wiki nginx vhosts (single nginx, multiple `server` blocks).
+- `delivery` (weserv, **reuse existing compose service**) — local weserv replaces the external wsrv.nl dependency.
+- `tusd` (**reuse existing compose service**) — `-upload-dir=/srv/tusd-data` (NFS bind), replicate app1's exact flags incl. **no `-hooks-http`** (app1 prod runs without hooks — do not point at a non-existent apiv1).
+- `tile-server` (overv, new) + `osm-data`/`osm-tiles` volumes.
+- Photon (geocode) + MediaWiki (`wiki-media`+`wiki-mysql`) — later stages; both stateful.
+
+**Recommendation: two VMs.** VM-A = images (weserv/tusd/frontend-nginx, ~4 vCPU/8 GB/80 GB, needs NFS route). VM-B = tiles+geocode+wiki (renderd/PostGIS/Photon/MediaWiki are RAM/CPU/disk-heavy, ~8 vCPU/24 GB/160 GB) — keeps the latency-sensitive image cache away from render storms/replication. Both need a public IP (for the direct-A DNS cutovers).
+
+---
+
+## 4. The "existing image hosting" correction
+
+The `delivery` and `tusd` services already **exist** in `docker-compose.yml` (used by dev/CI under the `frontend` profile); they are simply **not active** on this host (`COMPOSE_PROFILES=backend,production,mail`). So the front-end build is **not from scratch** — it promotes existing service definitions to a dedicated prod env, adds the front-door nginx + tile-server, and folds in geocode/wiki. Prod image upload/delivery itself lives on **app1**, not this compose env.
+
+---
+
+## 5. Repo changes (author on a branch; test on dev first)
+
+1. **`docker-compose.yml`**: add the `edge` profile to `delivery` + `tusd`; parameterize tusd `command` via `${TUSD_COMMAND:-<current dev default>}` so dev/CI are unchanged and the VM overrides it; add `frontend-nginx`, `tile-server` services (profile `edge` only); add `delivery-cache`/`tusd-data`/`osm-data`/`osm-tiles` volumes. (Later: `photon`, reuse `wiki-media`/`wiki-mysql` under `edge`.)
+2. **`frontend-nginx.conf`** — DRAFTED at repo root (inert). Encodes: uploads `:80`+`:8080` (no CORS), delivery cache with the **verified** `proxy_cache_key "https://wsrv.nl$request_uri"` + `@handle_redirect` + `X-Cache-Status`, tiles single-CORS, PROXY-protocol real-IP, catch-all. Validate with `nginx -t` on dev/VM before use.
+3. **`docker-compose.override.edge.yml`** (VM-only, opted in via `COMPOSE_FILE`): bind `tusd` upload dir to the NFS host mount `/srv/tusd-data`.
+4. VM `.env`: `COMPOSE_PROFILES=edge`, `COMPOSE_FILE` **without** `docker-compose.ports.yml` (traefik off → no `:80`/`:8080` contention), unique `COMPOSE_PROJECT_NAME`, `TUSD_COMMAND=-upload-dir=/srv/tusd-data -behind-proxy -base-path / -disable-cors`.
+5. **Local-dev/CI unaffected**: `edge` is not in any default profile set; `frontend-nginx`/`tile-server` never start there; the parameterized tusd command defaults to today's literal.
+
+---
+
+## 6. IMPLEMENT ON DEV FIRST (the immediate next step)
+
+Dev = local FreegleDocker (`frontend,database,backend,dev,monitoring`, traefik routing `*.localhost`). To build/validate the `edge` stack on dev without clashing with traefik's `:80`:
+
+1. Create an **isolated worktree** (`./freegle worktree create edge-dev`) so ports/containers are namespaced and the main dev env is untouched.
+2. Land the §5 repo changes on a branch in that worktree.
+3. `nginx -t` the `frontend-nginx.conf` (upstreams use `set $x …; proxy_pass $x;` + Docker resolver, so it parses without backends present).
+4. Bring up only the edge services with remapped ports: `COMPOSE_PROFILES=edge docker compose up -d frontend-nginx delivery tusd tile-server` (map host `:80/:8080` to spare ports to avoid traefik).
+5. Validate via `Host:`-header curls against the edge nginx port:
+   - `curl -H 'Host: uploads.ilovefreegle.org' -X OPTIONS …` → expect tusd reachable (CORS comes from HAProxy in prod, so absent on dev is expected).
+   - `curl -H 'Host: delivery.ilovefreegle.org' '…/?url=<dev image>&w=200'` → 200 + `X-Cache-Status`.
+   - `curl -H 'Host: tiles.ilovefreegle.org' …/tile/0/0/0.png` → 200, **exactly one** ACAO header.
+6. Iterate the compose/nginx config on dev until green, then it's ready to deploy to the Katapult VM (§7).
+
+This proves the front-door + cache-key + CORS behavior with zero prod and zero traefik impact before any VM exists.
+
+---
+
+## 7. Provision + non-intrusive prep (Step 0 — zero prod impact)
+
+- **Katapult key**: capability **probe first** (list orgs/DC/networks/NFS/DNS — never `create` to discover scope). Confirm: VM create, internal `10.220.0.0/22` attach, route to NFS `10.11.3.0/24`, public IP, NFS-share access (export allowlist may need the VM's storage-net IP), DNS scope (only if `tiles/geocode/wiki` A-records are Katapult-managed — needed for tile/geocode/wiki cutover, **not** for images), firewall (`:80`/`:8080` from ha-internal; `:80/:443` internet for tiles/geocode/wiki).
+- Provision VM(s) per §3; **pin Docker 27.5.1** (28+ breaks container networking — CLAUDE.md); tag `*-staging`.
+- **NFS mount read-only** at `/srv/tusd-data`; verify `ls` parity vs app1 `/images`; benchmark read latency vs app1.
+- Deploy the dev-proven branch; `COMPOSE_PROFILES=edge`; `docker compose up -d`.
+- **Sync (non-intrusive)**: images originals = **no copy** (shared NFS). Delivery cache = read-only incremental `rsync` of app1 `/wsrv_cache` (low-priority, while app1 serves), final delta at cutover. osm-tiles = rsync live. **osm-data** = **fresh import on VM-B** (keeps prep 100% non-intrusive; replication catches up) — avoid hot-rsync of live PostGIS. wiki = `mysqldump`/file copy from `wiki-mysql`. geocode = copy or rebuild Photon index.
+- **Step-0 validation** (Host-header curls vs VM IP, real cached hash → HIT, real `{z}/{x}/{y}` tile, NFS latency). Nothing public changes; rollback = delete VM.
+
+---
+
+## 8. Cutover (one service at a time; each independently reversible)
+
+- **Images (uploads, then delivery)** — HAProxy edits on ha-internal (snapshot `haproxy.cfg.bak.YYYYMMDD-pre-<step>`, `haproxy -c` before reload): repoint `tusd_backend` → VM; **add** `delivery_backend` (don't touch shared `http_backend_cache`) and switch `use_backend delivery_backend if delivery`; clean **all** app4 lines. `reload`, not restart. Rollback = revert snapshot (app1 still serving shared NFS).
+- **Legacy `images`/`cdn`/`users`-web** — HAProxy default backend; move when retiring app1 (these are app1-PHP-coupled).
+- **tiles / geocode / wiki** — DNS A-record repoint to the VM public IP. Lower `geocode` TTL (3600→60) ≥1 h ahead. Verify via Host-header curl before flip. Rollback = revert A-record (old still serving). **Change `tiles` A only** — `tiles`+`geocode` share host nginx, so don't reconfigure the shared nginx; just stop the overv container at decommission.
+- `users.ilovefreegle.org` **mail-alias** routing is an MX/exim workstream, separate from the web move.
+
+---
+
+## 9. Decommission
+
+After ≥1 week clean **and** a rollback target exists (provision the 2nd VM as HAProxy primary/backup before removing app1 — app4 is dead, so single-VM = no failover): stop app1 tusd + `checktusd` monit, disable delivery/images/cdn/users nginx sites, delete `/wsrv_cache`, unmount `/images`. On this docker host: stop/rm the overv tile container + osm volumes, the Photon, the `wiki-media`/`wiki-mysql` (once on VM-B), drop `ors-app`, remove the stale `discourse` vhost. Every destructive step is **human-gated** (see §11).
+
+---
+
+## 10. Risks / go-no-go (from the audit)
+
+Critical: send-proxy↔plain-HTTP mismatch (test with real PROXY framing, not plain curl); double-CORS on tus/tiles (exactly one ACAO); tusd hook target (replicate app1 = **no hooks**); cache-key mismatch (use the verified key; replay yesterday's URLs → >90% HIT); single-VM SPOF (2 VMs before decommission); osm-data torn copy (fresh import or stop-rsync-start, never hot-rsync); geocode/tiles shared-host coupling; Sentry per-image `captureMessage` flood in `OurUploadedImage.vue` (remove/rate-limit before delivery cutover). **Observability gap**: app1 + this host don't ship access logs to Loki → put **promtail on the VM** (with `X-Cache-Status` in the log format) so cutover is measurable. Go/No-Go checklist per service: `haproxy -c` passes; exactly-one ACAO; HIT replay >90%; real tile render; NFS latency within ~20% of app1; failover sibling exists before decommission.
+
+---
+
+## 11. AI-safety protocol (executing with the Katapult key)
+
+Capability probe before acting; snapshot/backup before any mutating op; `haproxy -c` + dated snapshot before any reload; NFS mounted **ro** until the human-gated upload cutover; **one host/one service at a time** (no big-bang); **explicit human GO** before each: HAProxy reload, DNS change (+TTL lowering), VM/volume delete, app1/host decommission, NFS→rw. Prod DB writes (if ever) one-row-at-a-time (Galera). Stop and ask on any surprise (missing scope, NFS export rejection, no route to `10.11.3.0/24`, sizing mismatch).
+
+---
+
+## 12. Open decisions
+
+1. **One VM or two** (recommend two: images / tiles+geocode+wiki).
+2. Profile name: keep `image-host` or rename to **`edge`/`frontend-host`** (scope broadened).
+3. **wiki** scope+timing (stateful MediaWiki + its MySQL — biggest lift; could be its own stage).
+4. **geocode** stage (Photon) — bundle with tiles (same source host) or defer.
+5. Classify `ai-support-helper` / `status` (confirm not externally required).
+6. CORS source for tus (keep at HAProxy) and PROXY-protocol vs XFF on `delivery_backend` (recommend drop send-proxy → XFF).
+7. `:8080` upload-URL-form retirement (separate, non-blocking — keep `:8080` indefinitely).
+8. `users.ilovefreegle.org` mail-alias migration (separate MX workstream).
+
+---
+
+## Appendix — unrelated incident discovered this session (2026-06-25)
+Galera cluster commit-pipeline wedge (~07:16): all 3 nodes Primary/Synced but commits frozen in "replicating and certifying write set" after a BF-abort storm (db1 3671 / db3 3901) starting 07:13:37 — 33 s after the every-minute uncommitted `ripple:expand --within-poly` cron (07:13:04). User's structural hypothesis: **no read/write split in batch** (all batch reads+writes hit db2 while apiv2 writes hit db3 → cross-conflict) — PR en route. Diags saved on each node `/root/galera-diag-20260625-0735-db-{1,2,3}.txt`. Recovery = single-node IST restart of db1 (no bootstrap; cluster had quorum). Also fixed this session: rotated the 7 GB unbounded `iznik-batch/storage/logs/laravel.log` (durable fix still needed: `LOG_CHANNEL=daily` / lower level / logrotate). Separate `cron_job_status.command` unique-key overflow bug truncates the long `--within-group` string. **These are batch/DB concerns, not part of the front-end migration.**

--- a/plans/2026-06-25-frontend-server-migration.md
+++ b/plans/2026-06-25-frontend-server-migration.md
@@ -4,7 +4,9 @@
 
 This supersedes and broadens `docs/superpowers/specs/2026-04-11-frontend-server-design.md` (which scoped only images + tiles). Scope is now: **anything reached from the outside world moves; internal batch processing stays.**
 
-> Status: PLAN ONLY. Nothing in production has been changed. One inert artifact has been drafted: `frontend-nginx.conf` at repo root (referenced in §5). The Katapult key is available. SSH confirmed to app1 (`10.220.0.45`), `ha-internal` (HAProxy), this `docker` host, and `db{1,2,3}-internal`.
+> Status: **PREP IMPLEMENTED + DEV-VALIDATED — nothing in production has been changed.** The repo-side §5 artifacts now exist and were brought up and exercised end-to-end on an isolated dev worktree (`edge-dev`, see §6); no VM has been provisioned and no prod/HAProxy/DNS change has been made. The Katapult key is available. SSH confirmed to app1 (`10.220.0.45`), `ha-internal` (HAProxy), this `docker` host, and `db{1,2,3}-internal`.
+>
+> Implemented & validated on dev (2026-06-25): `docker-compose.yml` `edge` profile (`delivery`+`tusd` joined, parameterized `${TUSD_COMMAND}`, new `frontend-nginx`+`tile-server`, `delivery-cache`/`tusd-data`/`osm-data`/`osm-tiles` volumes); `frontend-nginx.conf` (front door); `docker-compose.override.edge.yml` (VM-only ports + tusd NFS bind). See §6 for the dev test results and the four behaviours they pin down.
 
 ---
 
@@ -76,7 +78,7 @@ The `delivery` and `tusd` services already **exist** in `docker-compose.yml` (us
 ## 5. Repo changes (author on a branch; test on dev first)
 
 1. **`docker-compose.yml`**: add the `edge` profile to `delivery` + `tusd`; parameterize tusd `command` via `${TUSD_COMMAND:-<current dev default>}` so dev/CI are unchanged and the VM overrides it; add `frontend-nginx`, `tile-server` services (profile `edge` only); add `delivery-cache`/`tusd-data`/`osm-data`/`osm-tiles` volumes. (Later: `photon`, reuse `wiki-media`/`wiki-mysql` under `edge`.)
-2. **`frontend-nginx.conf`** — DRAFTED at repo root (inert). Encodes: uploads `:80`+`:8080` (no CORS), delivery cache with the **verified** `proxy_cache_key "https://wsrv.nl$request_uri"` + `@handle_redirect` + `X-Cache-Status`, tiles single-CORS, PROXY-protocol real-IP, catch-all. Validate with `nginx -t` on dev/VM before use.
+2. **`frontend-nginx.conf`** — at repo root, **implemented + dev-validated** (§6). Encodes: uploads `:80`+`:8080` (no CORS), delivery cache with the **verified** `proxy_cache_key "https://wsrv.nl$request_uri"` + `@handle_redirect` + `X-Cache-Status` (the upstream weserv's own `X-Cache-Status` is `proxy_hide_header`-ed so the front door exposes exactly one), tiles single-CORS, PROXY-protocol real-IP, a plain `:8081 /healthz`, and a `return 444` catch-all. `nginx -t` clean.
 3. **`docker-compose.override.edge.yml`** (VM-only, opted in via `COMPOSE_FILE`): bind `tusd` upload dir to the NFS host mount `/srv/tusd-data`.
 4. VM `.env`: `COMPOSE_PROFILES=edge`, `COMPOSE_FILE` **without** `docker-compose.ports.yml` (traefik off → no `:80`/`:8080` contention), unique `COMPOSE_PROJECT_NAME`, `TUSD_COMMAND=-upload-dir=/srv/tusd-data -behind-proxy -base-path / -disable-cors`.
 5. **Local-dev/CI unaffected**: `edge` is not in any default profile set; `frontend-nginx`/`tile-server` never start there; the parameterized tusd command defaults to today's literal.
@@ -98,6 +100,29 @@ Dev = local FreegleDocker (`frontend,database,backend,dev,monitoring`, traefik r
 6. Iterate the compose/nginx config on dev until green, then it's ready to deploy to the Katapult VM (§7).
 
 This proves the front-door + cache-key + CORS behavior with zero prod and zero traefik impact before any VM exists.
+
+### 6a. DONE — dev validation results (2026-06-25, worktree `edge-dev`)
+
+Built on the isolated `edge-dev` worktree (own compose project/ports; main dev env untouched). Edge services brought up over the compose network (no host `:80`/`:8080` bind → no traefik clash); `:80` proxy_protocol vhosts exercised with **real PROXY framing** via `curl --haproxy-protocol` (per §10's "test with real PROXY framing, not plain curl").
+
+| Check | Method | Result |
+|---|---|---|
+| `docker-compose config` — dev unaffected | default profiles | `tusd` command renders to the **unchanged** dev literal; `frontend-nginx`/`tile-server` absent ✓ |
+| `docker-compose config` — edge | `COMPOSE_PROFILES=edge` | renders `delivery`/`tusd`/`frontend-nginx`/`tile-server` only ✓ |
+| `docker-compose config` — VM | edge + `override.edge.yml` + `TUSD_COMMAND` | `frontend-nginx` publishes `:80`/`:8080`; tusd cmd = prod flags; tusd bound `/srv/tusd-data` ✓ |
+| `nginx -t` | throwaway `nginx:1.27-alpine` | syntax ok (variable upstreams + resolver parse with no backends) ✓ |
+| uploads `:8080` (plain) → tusd | `GET /tus/` | `405` (correct tus); **no** nginx-added `Access-Control-*` (HAProxy owns tus CORS) ✓ |
+| delivery `:80` (proxy_protocol) | real image, repeat | `200` `image/webp`, `X-Cache-Status: MISS` → `HIT`; **exactly one** `X-Cache-Status` ✓ |
+| tiles `:80` (proxy_protocol) | `/tile/0/0/0.png` | `502` (no osm import on dev) but **exactly one** `Access-Control-Allow-Origin` — the §2 double-CORS fix holds even on errors ✓ |
+| catch-all `:80` | unknown `Host` | `444` (empty reply / closed) ✓ |
+
+Findings folded back into the artifacts:
+- **Healthcheck must use `127.0.0.1`, not `localhost`** — busybox resolves `localhost`→`::1`, nginx listens IPv4-only → false "unhealthy". (Would have bitten on the VM too.)
+- **Don't send `Host: images.weserv.local`** to the local weserv container — that's its `allow 127.0.0.1; deny all` internal engine vhost (→ 403). Proxy to its public/default server with the original Host.
+- **`proxy_hide_header X-Cache-Status`** on the delivery vhost — weserv emits its own (tiny inner cache); without hiding it the front door returned two, muddying §10 HIT-rate measurement.
+- Dev-iteration note: `frontend-nginx.conf` is a **single-file bind mount**, so editing it needs a container **recreate** (not `nginx -s reload`) to re-resolve the inode.
+
+Not locally verifiable (deferred to §7 on the VM): real tile render (needs the ~56 GB osm-data import), Photon/MediaWiki stages, NFS latency, and HAProxy `send-proxy`↔`proxy_protocol` framing against the real HAProxy (validated here with synthetic PROXY framing only).
 
 ---
 


### PR DESCRIPTION
Plan **and** the dev-validated preparatory implementation to retire `app1-internal` and move **all externally-accessed services** off both app1 and the shared `docker`/`batch-prod` host onto a dedicated front-end Compose environment (the new **`edge`** profile), leaving this host **internal-batch-only**.

Plan: `plans/2026-06-25-frontend-server-migration.md`. Broadens the Apr-11 `frontend-server-design.md` (images + tiles only) per the corrected definition: *anything reached from the outside world moves; internal batch processing stays.*

## Now implemented + dev-validated (was "plan only")

The repo-side §5 artifacts are now in the tree and were brought up and exercised end-to-end on an **isolated `edge-dev` worktree** (own compose project/ports; main dev env untouched). **Nothing in production changed** — no VM provisioned, no HAProxy/DNS edits.

- **`docker-compose.yml`** — `delivery`+`tusd` joined to the `edge` profile; tusd `command` parameterized via `${TUSD_COMMAND:-<dev default>}` (dev/CI literal **unchanged**); new `frontend-nginx` + `tile-server` services (edge-only); new `delivery-cache`/`tusd-data`/`osm-data`/`osm-tiles` volumes.
- **`frontend-nginx.conf`** (new, repo root) — front door: uploads (`:80` proxy_protocol + `:8080` plain, **no** CORS — HAProxy owns tus CORS), delivery cache pinned to the verified `proxy_cache_key "https://wsrv.nl$request_uri"` (so app1's 41 GB warm cache is reusable) with `@handle_redirect` and a single `X-Cache-Status`, tiles **single** ACAO (the §2 double-CORS fix), PROXY-protocol real-IP, `:8081 /healthz`, `444` catch-all.
- **`docker-compose.override.edge.yml`** (new, VM-only) — publishes `:80`/`:8080` (no traefik on the VM) and binds tusd's upload dir to the shared-NFS host mount `/srv/tusd-data`.

### Validation evidence (plan §6a)

| Check | Result |
|---|---|
| `docker-compose config` (default / edge / VM+override) | dev render **unchanged** (tusd literal, no edge services); edge renders 4 services; VM render publishes ports + tusd prod flags + NFS bind |
| `nginx -t` | syntax ok |
| uploads `:8080` to tusd | `405` (correct tus), **no** nginx-added CORS |
| delivery `:80` (real PROXY framing) | `200` webp, `X-Cache-Status` MISS to HIT, **exactly one** |
| tiles `:80` | `502` (no osm import on dev) but **exactly one** ACAO even on error |
| catch-all `:80` | `444` |

Three bugs found+fixed during validation: healthcheck `localhost` to `127.0.0.1` (busybox IPv6), weserv internal-host `403` (`Host: images.weserv.local` hits its localhost-only engine vhost), and a double `X-Cache-Status` (hide weserv's inner-cache header).

**Deferred to the VM (§7), not locally verifiable:** real tile render (~56 GB osm-data import), Photon/MediaWiki stages, NFS latency, and `send-proxy` to `proxy_protocol` against the real HAProxy (validated here with synthetic PROXY framing only). Cutover (HAProxy switch / DNS repoint), decommission, and the Katapult-key AI-safety protocol remain plan-only and human-gated (§8-§11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)