### PR TITLE
fix(session): lost-password mails the address used; banner names the bouncing one

### DIFF
--- a/iznik-nuxt3/components/BouncingEmail.vue
+++ b/iznik-nuxt3/components/BouncingEmail.vue
@@ -7,17 +7,39 @@
         class="mb-3 text-center"
       >
         <v-icon icon="exclamation-triangle" />
-        We can't send to your email address. Please go to
-        <nuxt-link no-prefetch to="/settings">Settings</nuxt-link>
-        to fix or retry.
+        <template v-if="bouncingEmails.length">
+          We can't send to your
+          {{ bouncingEmails.length > 1 ? 'email addresses' : 'email address' }}
+          <strong>{{ bouncingEmails.join(', ') }}</strong
+          >. Please go to
+          <nuxt-link no-prefetch to="/settings">Settings</nuxt-link>
+          to fix or retry.
+        </template>
+        <template v-else>
+          We can't send to your email address. Please go to
+          <nuxt-link no-prefetch to="/settings">Settings</nuxt-link>
+          to fix or retry.
+        </template>
       </NoticeMessage>
     </b-col>
   </b-row>
 </template>
 <script setup>
+import { useMe } from '~/composables/useMe'
+
 const NoticeMessage = defineAsyncComponent(() =>
   import('~/components/NoticeMessage')
 )
+
+const { me } = useMe()
+
+// The specific address(es) that bounced, so we can name them in the banner.
+// users_emails.bounced carries a timestamp for permanently-bounced addresses;
+// internal (ourdomain) addresses are never shown to the member.
+const bouncingEmails = computed(() => {
+  const emails = me.value?.emails || []
+  return emails.filter((e) => e.bounced && !e.ourdomain).map((e) => e.email)
+})
 </script>
 <style scoped>
 .bottom {

--- a/iznik-nuxt3/tests/unit/components/BouncingEmail.spec.js
+++ b/iznik-nuxt3/tests/unit/components/BouncingEmail.spec.js
@@ -1,9 +1,19 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { mount } from '@vue/test-utils'
 import BouncingEmail from '~/components/BouncingEmail.vue'
 
+const { mockMe } = vi.hoisted(() => {
+  const { ref } = require('vue')
+  return { mockMe: ref(null) }
+})
+
+vi.mock('~/composables/useMe', () => ({
+  useMe: () => ({ me: mockMe }),
+}))
+
 describe('BouncingEmail', () => {
   function createWrapper(meValue = null) {
+    mockMe.value = meValue
     return mount(BouncingEmail, {
       global: {
         stubs: {
@@ -26,13 +36,13 @@ describe('BouncingEmail', () => {
             props: ['to', 'noPrefetch'],
           },
         },
-        // Provide me via mocks which works in vue-test-utils
-        mocks: {
-          me: meValue,
-        },
       },
     })
   }
+
+  beforeEach(() => {
+    mockMe.value = null
+  })
 
   describe('rendering', () => {
     it('renders row and column structure', () => {
@@ -41,9 +51,14 @@ describe('BouncingEmail', () => {
       expect(wrapper.find('.col').exists()).toBe(true)
     })
 
-    it('renders notice message component', () => {
+    it('renders notice message component when bouncing', () => {
       const wrapper = createWrapper({ bouncing: true })
       expect(wrapper.find('.notice-message').exists()).toBe(true)
+    })
+
+    it('does not render notice when not bouncing', () => {
+      const wrapper = createWrapper({ bouncing: false })
+      expect(wrapper.find('.notice-message').exists()).toBe(false)
     })
 
     it('applies danger variant to notice', () => {
@@ -75,9 +90,86 @@ describe('BouncingEmail', () => {
     })
   })
 
+  describe('names the bouncing address', () => {
+    it('shows the specific bouncing email and not the healthy one', () => {
+      const wrapper = createWrapper({
+        bouncing: true,
+        emails: [
+          {
+            id: 1,
+            email: 'good@example.com',
+            ourdomain: false,
+            bounced: null,
+          },
+          {
+            id: 2,
+            email: 'bad@example.com',
+            ourdomain: false,
+            bounced: '2026-06-25 10:00:00',
+          },
+        ],
+      })
+      expect(wrapper.text()).toContain('bad@example.com')
+      expect(wrapper.text()).not.toContain('good@example.com')
+      // Singular wording for a single bouncing address.
+      expect(wrapper.text()).not.toContain('addresses')
+    })
+
+    it('lists multiple bouncing addresses with plural wording', () => {
+      const wrapper = createWrapper({
+        bouncing: true,
+        emails: [
+          {
+            id: 1,
+            email: 'one@example.com',
+            ourdomain: false,
+            bounced: '2026-06-25 10:00:00',
+          },
+          {
+            id: 2,
+            email: 'two@example.com',
+            ourdomain: false,
+            bounced: '2026-06-25 11:00:00',
+          },
+        ],
+      })
+      expect(wrapper.text()).toContain('one@example.com')
+      expect(wrapper.text()).toContain('two@example.com')
+      expect(wrapper.text()).toContain('email addresses')
+    })
+
+    it('never shows internal ourdomain addresses', () => {
+      const wrapper = createWrapper({
+        bouncing: true,
+        emails: [
+          {
+            id: 1,
+            email: 'real@example.com',
+            ourdomain: false,
+            bounced: '2026-06-25 10:00:00',
+          },
+          {
+            id: 2,
+            email: 'internal@users.ilovefreegle.org',
+            ourdomain: true,
+            bounced: '2026-06-25 10:00:00',
+          },
+        ],
+      })
+      expect(wrapper.text()).toContain('real@example.com')
+      expect(wrapper.text()).not.toContain('users.ilovefreegle.org')
+    })
+
+    it('falls back to generic wording when bouncing but no specific address is known', () => {
+      const wrapper = createWrapper({ bouncing: true, emails: [] })
+      expect(wrapper.find('.notice-message').exists()).toBe(true)
+      expect(wrapper.text()).toContain("can't send to your email address")
+      expect(wrapper.text()).toContain('fix or retry')
+    })
+  })
+
   describe('conditional rendering', () => {
     it('component exists regardless of me value', () => {
-      // Component always renders, the v-if is on the NoticeMessage
       const wrapper = createWrapper(null)
       expect(wrapper.exists()).toBe(true)
     })
@@ -89,20 +181,6 @@ describe('BouncingEmail', () => {
 
     it('renders with me.bouncing true', () => {
       const wrapper = createWrapper({ bouncing: true })
-      expect(wrapper.exists()).toBe(true)
-    })
-  })
-
-  describe('layout', () => {
-    it('uses 12 column layout', () => {
-      const wrapper = createWrapper({ bouncing: true })
-      // Component uses cols="12" on b-col
-      expect(wrapper.html()).toContain('col')
-    })
-
-    it('has bottom and verytop classes for fixed positioning', () => {
-      const wrapper = createWrapper({ bouncing: true })
-      // These are in the component's scoped styles
       expect(wrapper.exists()).toBe(true)
     })
   })

--- a/iznik-server-go/session/session.go
+++ b/iznik-server-go/session/session.go
@@ -365,13 +365,20 @@ func handleLostPassword(c *fiber.Ctx, email string) error {
 
 	db := database.DBConn
 
-	// Find user by email. Deleted users can still use forgot-password so they
-	// can recover their account.
-	var userID uint64
-	db.Raw("SELECT users.id FROM users "+
+	// Find user by the email they actually typed. Deleted users can still use
+	// forgot-password so they can recover their account. Capture the stored
+	// (canonical) form of the matched address so we send the login link to the
+	// exact email the user used - not their preferred address, which may differ
+	// and may be the one that is bouncing.
+	var match struct {
+		ID    uint64 `gorm:"column:id"`
+		Email string `gorm:"column:email"`
+	}
+	db.Raw("SELECT users.id, users_emails.email FROM users "+
 		"INNER JOIN users_emails ON users_emails.userid = users.id "+
 		"WHERE users_emails.email = ? "+
-		"LIMIT 1", email).Scan(&userID)
+		"LIMIT 1", email).Scan(&match)
+	userID := match.ID
 
 	if userID == 0 {
 		// Return ret=2 for unknown email.
@@ -414,18 +421,17 @@ func handleLostPassword(c *fiber.Ctx, email string) error {
 	userSite := os.Getenv("USER_SITE")
 	resetURL := fmt.Sprintf("https://%s/settings?u=%d&k=%s&src=forgotpass", userSite, userID, key)
 
-	// Get user's preferred email for sending.
-	var preferredEmail string
-	db.Raw("SELECT email FROM users_emails WHERE userid = ? ORDER BY preferred DESC, id ASC LIMIT 1", userID).Scan(&preferredEmail)
-
-	if preferredEmail == "" {
-		preferredEmail = email
+	// Send the login link to the address the user actually used. Prefer the
+	// canonical stored form of the matched address; fall back to the typed value.
+	destEmail := match.Email
+	if destEmail == "" {
+		destEmail = email
 	}
 
 	// Queue the forgot-password email.
 	if err := queue.QueueTask(queue.TaskEmailForgotPassword, map[string]interface{}{
 		"user_id":   userID,
-		"email":     preferredEmail,
+		"email":     destEmail,
 		"reset_url": resetURL,
 	}); err != nil {
 		stdlog.Printf("Failed to queue forgot-password email for user %d: %v", userID, err)
@@ -846,6 +852,7 @@ func GetSession(c *fiber.Ctx) error {
 		Email     string     `json:"email"`
 		Preferred int        `json:"preferred"`
 		Validated *time.Time `json:"validated"`
+		Bounced   *time.Time `json:"bounced"`
 		Ourdomain int        `json:"ourdomain"`
 	}
 
@@ -923,7 +930,7 @@ func GetSession(c *fiber.Ctx) error {
 	}()
 	go func() {
 		defer wg.Done()
-		db.Raw("SELECT id, email, preferred, validated FROM users_emails WHERE userid = ? ORDER BY preferred DESC", myid).Scan(&emails)
+		db.Raw("SELECT id, email, preferred, validated, bounced FROM users_emails WHERE userid = ? ORDER BY preferred DESC", myid).Scan(&emails)
 	}()
 	go func() {
 		defer wg.Done()

--- a/iznik-server-go/test/session_test.go
+++ b/iznik-server-go/test/session_test.go
@@ -52,6 +52,33 @@ func TestLostPasswordSuccess(t *testing.T) {
 	assert.Equal(t, int64(1), keyCount)
 }
 
+func TestLostPasswordSendsToEmailUsedNotPreferred(t *testing.T) {
+	// A user with two emails who triggers a reset using their NON-preferred
+	// address must get the login link at the address they actually used - not
+	// at their preferred address, which may differ and may be the one bouncing.
+	prefix := uniquePrefix("lostpw-used")
+	userID := CreateTestUser(t, prefix, "User")
+	primaryEmail := fmt.Sprintf("%s@test.com", prefix)
+	secondaryEmail := fmt.Sprintf("%s-secondary@test.com", prefix)
+
+	db := database.DBConn
+	// Make the auto-created address the preferred one, and add a non-preferred
+	// secondary address.
+	db.Exec("UPDATE users_emails SET preferred = 1 WHERE userid = ? AND email = ?", userID, primaryEmail)
+	db.Exec("INSERT INTO users_emails (userid, email, preferred) VALUES (?, ?, 0)", userID, secondaryEmail)
+
+	body := fmt.Sprintf(`{"action":"LostPassword","email":"%s"}`, secondaryEmail)
+	resp := postSession(body)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var queuedEmail string
+	db.Raw("SELECT JSON_UNQUOTE(JSON_EXTRACT(data, '$.email')) FROM background_tasks "+
+		"WHERE task_type = 'email_forgot_password' AND JSON_EXTRACT(data, '$.user_id') = ? "+
+		"ORDER BY id DESC LIMIT 1", userID).Scan(&queuedEmail)
+	assert.Equal(t, secondaryEmail, queuedEmail,
+		"reset link must be queued to the email the user actually used, not their preferred address")
+}
+
 func TestLostPasswordUnknownEmail(t *testing.T) {
 	body := `{"action":"LostPassword","email":"nonexistent-session-test@example.com"}`
 	resp := postSession(body)
@@ -355,6 +382,49 @@ func TestGetSessionEmailsHaveOurdomainFlag(t *testing.T) {
 	me := result["me"].(map[string]interface{})
 	email, _ := me["email"].(string)
 	assert.NotContains(t, email, "@users.ilovefreegle.org")
+}
+
+func TestGetSessionEmailsExposeBouncedTimestamp(t *testing.T) {
+	// The session payload must expose which specific address is bouncing so the
+	// website banner can name it. A healthy email has bounced=null; a bounced
+	// one carries a timestamp.
+	prefix := uniquePrefix("sess_bounced")
+	db := database.DBConn
+	userID := CreateTestUser(t, prefix, "User")
+	_, token := CreateTestSession(t, userID)
+
+	healthyEmail := fmt.Sprintf("%s@test.com", prefix)
+	bouncingEmail := fmt.Sprintf("%s-bounce@test.com", prefix)
+	db.Exec("INSERT INTO users_emails (userid, email, preferred, bounced) VALUES (?, ?, 0, NOW())",
+		userID, bouncingEmail)
+
+	req := httptest.NewRequest("GET", "/api/session?jwt="+token, nil)
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&result)
+
+	emails, ok := result["emails"].([]interface{})
+	assert.True(t, ok, "emails should be an array")
+
+	var healthyBounced, bouncingBounced interface{}
+	healthyFound, bouncingFound := false, false
+	for _, e := range emails {
+		em := e.(map[string]interface{})
+		switch em["email"] {
+		case healthyEmail:
+			healthyFound = true
+			healthyBounced = em["bounced"]
+		case bouncingEmail:
+			bouncingFound = true
+			bouncingBounced = em["bounced"]
+		}
+	}
+	assert.True(t, healthyFound, "healthy email should be present")
+	assert.True(t, bouncingFound, "bouncing email should be present")
+	assert.Nil(t, healthyBounced, "healthy email should have bounced=null")
+	assert.NotNil(t, bouncingBounced, "bouncing email should expose a bounced timestamp")
 }
 
 func TestGetSessionReturnsMailFlags(t *testing.T) {


### PR DESCRIPTION
## Summary

Two related fixes for members who have more than one email address on their account.

**1. Lost-password link now goes to the email the member actually used.**
When a member with two addresses (one marked preferred) triggered a password
reset using their *other* address, the Go session handler looked the account up
by the address typed but then sent the login link to the **preferred** address.
That is not where the member expects it, and the preferred address may itself be
the one that is bouncing - so the link could silently bounce too. The handler
now sends to the canonical stored form of the address the member actually used.
(`iznik-server-go/session/session.go` - `handleLostPassword`.)

**2. The "your email is bouncing" banner now names the bouncing address.**
The site-wide banner just said "We can't send to your email address". A member
with several addresses had no idea which one was the problem. The banner now
names the specific bouncing address(es) so they recognise it once logged in.
- Go session payload now exposes the per-address `bounced` timestamp
  (`users_emails.bounced`) on each `me.emails` entry.
- `BouncingEmail.vue` lists the address(es) whose `bounced` is set (internal
  `ourdomain` addresses are never shown), with singular/plural wording and a
  generic fallback if the flag is set but no specific address is known.

## Code Quality Review

- Reused the existing `users_emails.bounced` signal (set by `BounceService` for
  permanent bounces) rather than introducing new state.
- `me.emails` already flows to the client untouched, so only the SELECT and the
  `EmailRow` struct needed the new field.
- `BouncingEmail.vue` switched from the legacy global `me` to the standard
  `useMe()` composable so the new computed has `me` in scope (matches
  `ExternalDa.vue` etc.); spec updated to mock `useMe` via the repo's
  `vi.hoisted` pattern.

## Future Improvements

- `handleUnsubscribe` has the identical "send to preferred, not the address
  used" pattern. Left out of this PR to keep it scoped to the reported
  lost-password issue; happy to fix it the same way in a follow-up.

## Test Plan

- Go (`iznik-server-go/test/session_test.go`):
  - `TestLostPasswordSendsToEmailUsedNotPreferred` - two-email user, reset via
    the non-preferred address; asserts the queued `email_forgot_password` task
    targets the address used, not the preferred one. (Verified red before the
    fix, green after.)
  - `TestGetSessionEmailsExposeBouncedTimestamp` - asserts the session payload
    exposes `bounced` (null for healthy, a timestamp for a bounced address).
- Vitest (`iznik-nuxt3/tests/unit/components/BouncingEmail.spec.js`): names the
  bouncing address, plural wording for several, never shows internal addresses,
  generic fallback, and the existing rendering/conditional cases.
