### PR TITLE
fix(rippling): retract rippled copies and halt expansion on origin removal

### DIFF
--- a/RIPPLING-OUT-FOR-MODERATORS.md
+++ b/RIPPLING-OUT-FOR-MODERATORS.md
@@ -157,6 +157,29 @@ because the poster is from out of area.
 
 ---
 
+## Rejecting or removing a post on its home community
+
+This is different from a secondary rejection above. When a post is rejected, deleted or
+withdrawn on the community it was **originally posted to** (its home community), it is no
+longer a live offer anywhere - so:
+
+1. **It is pulled from every community it had rippled into**, automatically. You do not have
+   to chase it around the neighbouring communities; removing it at home cleans it up
+   everywhere it had spread.
+2. **It stops spreading.** Its rippling is halted, so it will not appear on any further
+   communities.
+
+This is exactly what you want when you catch spam or a rule-breaking post on its home
+community: dealing with it once removes it everywhere, instead of leaving live copies
+sitting on the neighbouring communities it had already reached.
+
+The poster is also removed from any community they had been auto-joined to **only** to carry
+that post (i.e. where they have no other posts). They keep their home community and any
+community where they have other activity, and - because this is a tidy-up rather than them
+choosing to leave - a later post of theirs can still ripple into those communities normally.
+
+---
+
 ## TrashNothing posts
 
 TrashNothing posts are currently **not** rippled out into new communities. TrashNothing

--- a/docs/superpowers/specs/2026-06-25-rippling-stop-and-retract-on-origin-removal-design.md
+++ b/docs/superpowers/specs/2026-06-25-rippling-stop-and-retract-on-origin-removal-design.md
@@ -1,0 +1,84 @@
+# Rippling: stop-and-retract on origin removal (incl. scoped runs) — design
+
+Date: 2026-06-25
+
+## Problem
+
+When a post leaves `messages_spatial` because it was **rejected/removed on its origin
+group** (or withdrawn / expired / deleted), rippling currently does the wrong thing:
+
+1. **`ExpandService::removeStale` stops but never retracts.** It is the only reactor to
+   "post left `messages_spatial`", and it merely deletes the `rippling_reach` row. The
+   already-rippled `messages_groups` copies on neighbouring groups stay `Approved`/live,
+   so a rejected (or withdrawn) post keeps showing everywhere it had rippled. In the live
+   Stroud "Fish" incident the 6 rippled copies only vanished because the poster happened
+   to *withdraw* later; a mod's spam-reject on the home group would have left them live on
+   all 6 neighbours.
+
+2. **All retraction is dark during the scoped (group-experiment) run.** Both `removeStale`
+   and `pullRippledPostsFromLeftGroups` are gated `if (!$scoped)`. For a scoped post
+   neither runs, so the reach row lingers `status='expanding'` and the scoped cron keeps
+   rippling the rejected post into *more* groups.
+
+`Taken`/`Received` posts intentionally **stay** in `messages_spatial`
+(`MessageSpatialService` marks them `successful=1` rather than removing them), so this
+trigger fires only on reject / withdraw / expire / delete — exactly the set where the post
+is no longer a live offer.
+
+## Fix
+
+Turn "post left `messages_spatial`" into a single **stop-and-retract** step that also runs
+for scoped runs. In `ExpandService`:
+
+- Replace `removeStale` with `removeStaleAndRetract($dryRun, &$stats, $onlyMsgid,
+  $withinPolyWkt)`. For each `rippling_reach` row whose `msgid` is no longer in
+  `messages_spatial` (scoped to the in-scope subset when scoped):
+  - **Retract** — soft-delete (`deleted=1`) every `rippled_in=1` `messages_groups` copy of
+    that `msgid` (`retractRippledCopiesForRemovedPost`), writing one `Message/Deleted`
+    audit log per group (`text='Rippling: removed on origin removal'`). Stat:
+    `pulled_on_removal`.
+  - **Remove now-purposeless rippled memberships** — for each group a copy was pulled from,
+    if the poster has **no other live (`deleted=0`) post on that group** and their
+    membership there is a ripple-join (`memberships.rippled=1`), `DELETE` that membership.
+    Stat: `memberships_removed`.
+    - **Deliberately log NO `Group/Left`.** The re-ripple guard keys on any `Group/Left`
+      after a `Group/Joined text='Rippled'` (text-agnostic), so logging a `Left` here would
+      permanently bar this poster's *future* legitimate posts from ever rippling into that
+      group — wrong, especially since the trigger also fires on withdraw/expire. The
+      removal is a system cleanup, not a user opt-out; the retraction is already audited by
+      `Message/Deleted`. The dangling `Group/Joined text='Rippled'` (no `Left`, no
+      membership) is exactly the state that lets a later ripple re-add the membership.
+  - **Stop** — delete the `rippling_reach` row (existing behaviour; also releases held
+    replies, since `ripple:release-replies` treats a missing reach row as "gone"). Stat:
+    `removed` (unchanged meaning: reach rows dropped).
+- Make `pullRippledPostsFromLeftGroups` scope-aware too and run it for scoped runs (same
+  dark-during-experiment flaw; the poster-leaves trigger).
+- Run both retraction steps for scoped runs, restricted to the in-scope subset
+  (`onlyMsgid`, or origin point within `withinPolyWkt`, matching `advanceDue`).
+
+### Scope filters
+- `onlyMsgid`: `AND mr.msgid = ?` (and `AND mg.msgid = ?` for the leave-pull).
+- `withinPolyWkt`: `ST_Contains(ST_GeomFromText(?,3857), ST_SRID(POINT(lng,lat),3857))` on
+  the reach origin (for the leave-pull, on `messages.lng/lat`).
+
+## Out of scope
+- Organic memberships (`rippled` not `1`) and memberships where the poster still has a live
+  post on the group are never touched.
+- Outcome propagation for Taken/Received is unchanged (those posts stay in spatial).
+
+## Tests (Laravel, `ExpandServiceTest`)
+1. Origin removal soft-deletes the `rippled_in` copies, writes a `Message/Deleted` log per
+   group, and drops the reach row.
+2. The poster's `rippled=1` membership on a pulled group is removed when they have no other
+   live post there; kept when another live post exists; an organic membership is never
+   removed.
+3. No `Group/Left` is logged, and a later post by the same poster still ripples into the
+   group and re-adds the membership (future re-ripple not poisoned).
+4. Scoped (`onlyMsgid`) run retracts only the in-scope post.
+5. Scoped (`withinPolyWkt`) run retracts only posts whose origin is inside the polygon.
+6. `pullRippledPostsFromLeftGroups` runs under a scoped run.
+
+## Docs
+`RIPPLING-OUT-FOR-MODERATORS.md`: rejecting/removing a post on its origin group now pulls it
+from every rippled group and stops it spreading; the poster is removed from groups they were
+only on because of that post.

--- a/iznik-batch/app/Services/Ripple/ExpandService.php
+++ b/iznik-batch/app/Services/Ripple/ExpandService.php
@@ -47,11 +47,13 @@ class ExpandService
             'initialized' => 0, 'expanded' => 0, 'completed' => 0,
             'removed' => 0, 'skipped' => 0, 'errors' => 0, 'rippled_in' => 0, 'mailed' => 0,
             'memberships_added' => 0, 'pulled_on_leave' => 0,
+            'pulled_on_removal' => 0, 'memberships_removed' => 0,
         ];
 
         // A scoped run ($onlyMsgid or $withinPolyWkt) targets a chosen subset of posts (controlled/area
-        // testing): stale-removal is skipped because it operates over the WHOLE reach set and is not
-        // scope-aware, and both init and advance are restricted to the same subset.
+        // testing): init, advance AND retraction are all restricted to the same subset, so the group
+        // experiment retracts a rejected/removed post (drops reach + pulls its rippled copies) instead
+        // of leaving live copies behind and continuing to ripple it into yet more groups.
         $scoped = $onlyMsgid !== null || $withinPolyWkt !== null;
 
         // Master activation switch. While rippling is globally disabled an UNSCOPED run does nothing
@@ -63,13 +65,14 @@ class ExpandService
             return $stats;
         }
 
-        if (!$scoped) {
-            // 1. Drop reach for posts that have left the browsable set (taken/withdrawn).
-            $stats['removed'] = $this->removeStale($dryRun);
-            // 1b. Pull rippled-in posts from any group whose poster has actively left it, so a
-            //     leave removes the poster's post from that group (not just their membership).
-            $this->pullRippledPostsFromLeftGroups($dryRun, $stats);
-        }
+        // 1. Stop-and-retract for posts that have left the browsable set — rejected/removed on
+        //    their origin group, withdrawn, expired or deleted (Taken/Received stay in
+        //    messages_spatial and are excluded): drop reach AND pull every rippled-in copy,
+        //    removing now-purposeless ripple-joined memberships.
+        $this->removeStaleAndRetract($dryRun, $stats, $onlyMsgid, $withinPolyWkt);
+        // 1b. Pull rippled-in posts from any group whose poster has actively left it, so a
+        //     leave removes the poster's post from that group (not just their membership).
+        $this->pullRippledPostsFromLeftGroups($dryRun, $stats, $onlyMsgid, $withinPolyWkt);
 
         // 2. Initialise reach for posts new to messages_spatial.
         $this->initialiseNew($dryRun, $limit, $stats, $onlyMsgid, $withinPolyWkt);
@@ -82,27 +85,137 @@ class ExpandService
         return $stats;
     }
 
-    private function removeStale(bool $dryRun): int
+    /**
+     * Stop-and-retract for every post that has left messages_spatial — rejected/removed on its
+     * origin group, withdrawn, expired or deleted (Taken/Received stay in messages_spatial and
+     * are intentionally excluded). For each such post we drop its rippling_reach row (which both
+     * stops further expansion and lets ripple:release-replies treat the post as gone, releasing
+     * any held replies) and retract every rippled-in copy (see retractRippledCopiesForRemovedPost).
+     *
+     * Scope-aware: a scoped run restricts removal to the in-scope subset (onlyMsgid, or reach
+     * origin within withinPolyWkt — the same filter advanceDue uses), so the group experiment
+     * retracts correctly. $stats['removed'] keeps its meaning: reach rows dropped.
+     */
+    private function removeStaleAndRetract(bool $dryRun, array &$stats, ?int $onlyMsgid = null, ?string $withinPolyWkt = null): void
     {
-        if ($dryRun) {
-            return (int) DB::table('rippling_reach as mr')
-                ->whereNotExists(function ($q) {
-                    $q->select(DB::raw(1))
-                        ->from('messages_spatial as ms')
-                        ->whereColumn('ms.msgid', 'mr.msgid');
-                })->count();
+        try {
+            $scopeSql = '';
+            $params = [];
+            if ($onlyMsgid !== null) {
+                $scopeSql = ' AND mr.msgid = ?';
+                $params[] = $onlyMsgid;
+            } elseif ($withinPolyWkt !== null) {
+                $scopeSql = ' AND ST_Contains(ST_GeomFromText(?, ' . self::SRID . '), ST_SRID(POINT(mr.lng, mr.lat), ' . self::SRID . '))';
+                $params[] = $withinPolyWkt;
+            }
+
+            $stale = DB::select(
+                'SELECT mr.msgid AS msgid
+                 FROM rippling_reach mr
+                 LEFT JOIN messages_spatial ms ON ms.msgid = mr.msgid
+                 WHERE ms.msgid IS NULL' . $scopeSql,
+                $params
+            );
+            if (empty($stale)) {
+                return;
+            }
+            $msgids = array_map(static fn ($r) => (int) $r->msgid, $stale);
+
+            if ($dryRun) {
+                $stats['removed'] += count($msgids);
+                $stats['pulled_on_removal'] += (int) DB::table('messages_groups')
+                    ->whereIn('msgid', $msgids)
+                    ->where('rippled_in', 1)
+                    ->where('deleted', 0)
+                    ->count();
+
+                return;
+            }
+
+            foreach ($msgids as $msgid) {
+                $this->retractRippledCopiesForRemovedPost($msgid, $stats);
+                DB::table('rippling_reach')->where('msgid', $msgid)->delete();
+                $stats['removed']++;
+            }
+        } catch (\Throwable $e) {
+            $stats['errors']++;
+            Log::warning("ripple: remove-stale-and-retract failed: {$e->getMessage()}");
         }
+    }
 
-        // Single DELETE then ROW_COUNT() so the reported figure is exactly what was
-        // deleted (a separate COUNT then DELETE can drift — messages:update-spatial-index
-        // mutates messages_spatial concurrently).
-        DB::statement(
-            'DELETE mr FROM rippling_reach mr
-             LEFT JOIN messages_spatial ms ON ms.msgid = mr.msgid
-             WHERE ms.msgid IS NULL'
-        );
+    /**
+     * Pull every rippled-in copy of a post that has left the browsable set and clean up the
+     * memberships rippling created for it. Soft-deletes (deleted=1) each rippled_in
+     * messages_groups copy with a Message/Deleted audit log, then — for each group the copy was
+     * pulled from — removes the poster's ripple-joined (rippled=1) membership IFF they have no
+     * other live post on that group, so a retracted post does not strand the poster in groups
+     * they only joined to carry it.
+     *
+     * Deliberately writes NO Group/Left log for the membership removal. The re-ripple guard
+     * (rippleIntoNewGroups / addPosterMembershipToRippledGroups / pullRippledPostsFromLeftGroups)
+     * treats ANY Group/Left after a Group/Joined text='Rippled' as the poster opting out of that
+     * group, so a Left here would permanently bar this poster's FUTURE posts from rippling into
+     * the group (the trigger also fires on withdraw/expire, not just rejection). The removal is a
+     * system cleanup, not an opt-out — the retraction itself is audited by Message/Deleted, and
+     * the dangling Joined='Rippled' (no Left, no membership) is exactly what lets a later ripple
+     * re-add the membership. Idempotent (only touches deleted=0 rows). Best-effort: never breaks
+     * the run.
+     */
+    private function retractRippledCopiesForRemovedPost(int $msgid, array &$stats): void
+    {
+        $posterId = DB::table('messages')->where('id', $msgid)->value('fromuser');
 
-        return (int) (DB::selectOne('SELECT ROW_COUNT() AS n')->n ?? 0);
+        $groupids = DB::table('messages_groups')
+            ->where('msgid', $msgid)
+            ->where('rippled_in', 1)
+            ->where('deleted', 0)
+            ->pluck('groupid');
+
+        foreach ($groupids as $groupid) {
+            $n = DB::affectingStatement(
+                'UPDATE messages_groups SET deleted = 1
+                 WHERE msgid = ? AND groupid = ? AND rippled_in = 1 AND deleted = 0',
+                [$msgid, $groupid]
+            );
+            if ($n < 1) {
+                continue;
+            }
+            $stats['pulled_on_removal']++;
+            DB::table('logs')->insert([
+                'timestamp' => now(),
+                'type' => 'Message',
+                'subtype' => 'Deleted',
+                'user' => $posterId,
+                'byuser' => null,
+                'groupid' => $groupid,
+                'msgid' => $msgid,
+                'text' => 'Rippling: removed on origin removal',
+            ]);
+
+            if (!$posterId) {
+                continue;
+            }
+            // Only remove the membership when this poster has no OTHER live post on the group
+            // (the copy we just pulled is now deleted=1, so it is excluded by deleted=0).
+            $hasOtherPost = DB::table('messages_groups as mg')
+                ->join('messages as m', 'm.id', '=', 'mg.msgid')
+                ->where('m.fromuser', $posterId)
+                ->where('mg.groupid', $groupid)
+                ->where('mg.deleted', 0)
+                ->exists();
+            if ($hasOtherPost) {
+                continue;
+            }
+            // Only a ripple-join (rippled=1) is removed; an organic membership is never touched.
+            $removed = DB::table('memberships')
+                ->where('userid', $posterId)
+                ->where('groupid', $groupid)
+                ->where('rippled', 1)
+                ->delete();
+            if ($removed > 0) {
+                $stats['memberships_removed']++;
+            }
+        }
     }
 
     private function initialiseNew(bool $dryRun, int $limit, array &$stats, ?int $onlyMsgid = null, ?string $withinPolyWkt = null): void
@@ -691,14 +804,26 @@ class ExpandService
      * rows); the membership re-join and any future re-ripple are blocked by the same
      * most-recent-join-wins rule. Best-effort: never breaks the run.
      */
-    private function pullRippledPostsFromLeftGroups(bool $dryRun, array &$stats): void
+    private function pullRippledPostsFromLeftGroups(bool $dryRun, array &$stats, ?int $onlyMsgid = null, ?string $withinPolyWkt = null): void
     {
         try {
+            // Scope-aware so this runs under a scoped (group-experiment) run too: restrict to the
+            // chosen post, or to posts whose origin point falls inside the area polygon.
+            $scopeSql = '';
+            $params = [];
+            if ($onlyMsgid !== null) {
+                $scopeSql = ' AND mg.msgid = ?';
+                $params[] = $onlyMsgid;
+            } elseif ($withinPolyWkt !== null) {
+                $scopeSql = ' AND ST_Contains(ST_GeomFromText(?, ' . self::SRID . '), ST_SRID(POINT(m.lng, m.lat), ' . self::SRID . '))';
+                $params[] = $withinPolyWkt;
+            }
+
             $rows = DB::select(
                 "SELECT mg.msgid, mg.groupid, m.fromuser
                  FROM messages_groups mg
                  JOIN messages m ON m.id = mg.msgid
-                 WHERE mg.rippled_in = 1 AND mg.deleted = 0
+                 WHERE mg.rippled_in = 1 AND mg.deleted = 0" . $scopeSql . "
                    AND EXISTS (
                        SELECT 1 FROM logs lj
                        WHERE lj.user = m.fromuser AND lj.groupid = mg.groupid
@@ -716,7 +841,8 @@ class ExpandService
                                AND ll.id > lj.id
                          )
                    )
-                 GROUP BY mg.msgid, mg.groupid, m.fromuser"
+                 GROUP BY mg.msgid, mg.groupid, m.fromuser",
+                $params
             );
 
             if (empty($rows)) {

--- a/iznik-batch/tests/Unit/Services/Ripple/ExpandServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/Ripple/ExpandServiceTest.php
@@ -1300,4 +1300,250 @@ class ExpandServiceTest extends TestCase
             'post with only a Repost outcome still ripples into a covering group'
         );
     }
+
+    // ── Stop-and-retract on origin removal (rejected/withdrawn/expired → left spatial) ──
+
+    /**
+     * Ripple a fresh post into one covering group via the real engine and return
+     * [msgid, posterId, groupBId]. Afterwards the post is live on its origin group AND
+     * rippled (rippled_in=1, deleted=0) into group B, with the poster auto-joined to B
+     * (memberships.rippled=1) and a Group/Joined text='Rippled' log written.
+     */
+    private function rippleIntoOneGroup(): array
+    {
+        $this->fakeRouting(3);
+        $msgid = $this->seedSpatialPost(now()->subMinutes(30));
+        $posterId = (int) DB::table('messages')->where('id', $msgid)->value('fromuser');
+        $groupB = $this->seedCoveringGroup();
+
+        $this->service()->process(false, 500);
+
+        $row = DB::table('messages_groups')->where('msgid', $msgid)->where('groupid', $groupB)->first();
+        $this->assertNotNull($row, 'precondition: post rippled into B');
+        $this->assertSame(0, (int) $row->deleted, 'precondition: rippled-in copy live');
+
+        return [$msgid, $posterId, $groupB];
+    }
+
+    /** The post is removed from the browsable set (rejected on origin / withdrawn): it leaves messages_spatial. */
+    private function leaveSpatial(int $msgid): void
+    {
+        DB::table('messages_spatial')->where('msgid', $msgid)->delete();
+    }
+
+    /** A post with a reach row but NOT in messages_spatial, with one rippled-in copy + ripple-membership on a fresh group. Returns [msgid, groupB, posterId]. */
+    private function seedStaleReachWithRippledCopy(float $lat = 51.5, float $lng = -0.1): array
+    {
+        $user = $this->createTestUser();
+        $origin = $this->createTestGroup();
+        $message = Message::create([
+            'type' => Message::TYPE_OFFER, 'fromuser' => $user->id,
+            'subject' => 'OFFER: stale', 'textbody' => 'x', 'source' => 'Platform',
+            'date' => now()->subHours(2), 'arrival' => now()->subHours(2), 'lat' => $lat, 'lng' => $lng,
+        ]);
+        MessageGroup::create([
+            'msgid' => $message->id, 'groupid' => $origin->id,
+            'collection' => MessageGroup::COLLECTION_APPROVED, 'arrival' => now()->subHours(2),
+        ]);
+        $groupB = $this->createTestGroup();
+        DB::table('messages_groups')->insert([
+            'msgid' => $message->id, 'groupid' => $groupB->id, 'collection' => 'Approved',
+            'approvedat' => now(), 'arrival' => now(), 'autoreposts' => 0,
+            'msgtype' => Message::TYPE_OFFER, 'rippled_in' => 1, 'deleted' => 0,
+        ]);
+        DB::table('memberships')->insert([
+            'userid' => $user->id, 'groupid' => $groupB->id, 'role' => 'Member', 'collection' => 'Approved',
+            'emailfrequency' => 24, 'eventsallowed' => 1, 'volunteeringallowed' => 1, 'rippled' => 1, 'added' => now(),
+        ]);
+        DB::statement(
+            "INSERT INTO rippling_reach
+               (msgid, lat, lng, polygon, arrival, mode, tick, total_ticks, total_freeglers,
+                max_drive_min, schedule, next_expansion_at, status, created_at, updated_at)
+             VALUES (?, ?, ?, ST_GeomFromText(?, 3857), ?, 'drive', 1, 3, 90, 30, NULL, NULL, 'expanding', NOW(), NOW())",
+            [$message->id, $lat, $lng, self::WKT, now()->subHours(2)]
+        );
+
+        return [(int) $message->id, (int) $groupB->id, (int) $user->id];
+    }
+
+    /** Origin removal pulls every rippled-in copy (soft-delete + Message/Deleted log) and drops the reach row. */
+    public function test_origin_removal_pulls_rippled_copies_and_drops_reach(): void
+    {
+        [$msgid, $posterId, $groupB] = $this->rippleIntoOneGroup();
+        $this->assertSame(1, (int) DB::table('rippling_reach')->where('msgid', $msgid)->count(), 'precondition: reach row exists');
+
+        $this->leaveSpatial($msgid);
+        $stats = $this->service()->process(false, 500);
+
+        $this->assertSame(0, (int) DB::table('rippling_reach')->where('msgid', $msgid)->count(), 'reach row dropped - expansion stopped');
+        $b = DB::table('messages_groups')->where('msgid', $msgid)->where('groupid', $groupB)->first();
+        $this->assertSame(1, (int) $b->deleted, 'rippled-in copy pulled on origin removal');
+        $this->assertGreaterThanOrEqual(1, $stats['pulled_on_removal']);
+        $this->assertDatabaseHas('logs', [
+            'type' => 'Message', 'subtype' => 'Deleted', 'user' => $posterId,
+            'groupid' => $groupB, 'msgid' => $msgid, 'text' => 'Rippling: removed on origin removal',
+        ]);
+    }
+
+    /** The poster's ripple-membership is removed when the retracted post was their only post on that group. */
+    public function test_origin_removal_removes_ripple_membership_when_no_other_post(): void
+    {
+        [$msgid, $posterId, $groupB] = $this->rippleIntoOneGroup();
+        $m = DB::table('memberships')->where('userid', $posterId)->where('groupid', $groupB)->first();
+        $this->assertNotNull($m, 'precondition: poster ripple-joined to B');
+        $this->assertSame(1, (int) $m->rippled);
+
+        $this->leaveSpatial($msgid);
+        $stats = $this->service()->process(false, 500);
+
+        $this->assertNull(
+            DB::table('memberships')->where('userid', $posterId)->where('groupid', $groupB)->first(),
+            'ripple-membership removed when the retracted post was the poster\'s only post on the group'
+        );
+        $this->assertGreaterThanOrEqual(1, $stats['memberships_removed']);
+    }
+
+    /** The membership is KEPT when the poster still has another live post on the group. */
+    public function test_origin_removal_keeps_membership_when_poster_has_another_live_post(): void
+    {
+        [$msgid, $posterId, $groupB] = $this->rippleIntoOneGroup();
+
+        // A second, live post by the same poster directly on group B.
+        $other = Message::create([
+            'type' => Message::TYPE_OFFER, 'fromuser' => $posterId,
+            'subject' => 'OFFER: other', 'textbody' => 'y', 'source' => 'Platform',
+            'date' => now(), 'arrival' => now(), 'lat' => 51.5, 'lng' => -0.1,
+        ]);
+        MessageGroup::create([
+            'msgid' => $other->id, 'groupid' => $groupB,
+            'collection' => MessageGroup::COLLECTION_APPROVED, 'arrival' => now(),
+        ]);
+
+        $this->leaveSpatial($msgid);
+        $this->service()->process(false, 500);
+
+        $this->assertNotNull(
+            DB::table('memberships')->where('userid', $posterId)->where('groupid', $groupB)->first(),
+            'membership kept because the poster still has another live post on the group'
+        );
+        $this->assertSame(
+            1,
+            (int) DB::table('messages_groups')->where('msgid', $msgid)->where('groupid', $groupB)->value('deleted'),
+            'the retracted post is still pulled from the group'
+        );
+    }
+
+    /** An organic (non-ripple) membership is never removed by retraction. */
+    public function test_origin_removal_keeps_organic_membership(): void
+    {
+        [$msgid, $posterId, $groupB] = $this->rippleIntoOneGroup();
+        DB::table('memberships')->where('userid', $posterId)->where('groupid', $groupB)->update(['rippled' => 0]);
+
+        $this->leaveSpatial($msgid);
+        $this->service()->process(false, 500);
+
+        $this->assertNotNull(
+            DB::table('memberships')->where('userid', $posterId)->where('groupid', $groupB)->first(),
+            'organic (rippled=0) membership is never removed by retraction'
+        );
+    }
+
+    /**
+     * Membership removal writes NO Group/Left log (which would poison the re-ripple guard),
+     * so a later post by the same poster still ripples into the same group and re-adds the membership.
+     */
+    public function test_origin_removal_logs_no_group_left_and_future_reripple_works(): void
+    {
+        [$msgid, $posterId, $groupB] = $this->rippleIntoOneGroup();
+
+        $this->leaveSpatial($msgid);
+        $this->service()->process(false, 500);
+
+        $this->assertSame(
+            0,
+            (int) DB::table('logs')->where('user', $posterId)->where('groupid', $groupB)
+                ->where('type', 'Group')->where('subtype', 'Left')->count(),
+            'system retraction must not log a Group/Left (it is not a user opt-out)'
+        );
+
+        // A later post by the SAME poster, in the covering area, must still ripple into B.
+        $newMsg = Message::create([
+            'type' => Message::TYPE_OFFER, 'fromuser' => $posterId,
+            'subject' => 'OFFER: later', 'textbody' => 'z', 'source' => 'Platform',
+            'date' => now()->subMinutes(10), 'arrival' => now()->subMinutes(10), 'lat' => 51.5, 'lng' => -0.1,
+        ]);
+        $newOrigin = $this->createTestGroup();
+        MessageGroup::create([
+            'msgid' => $newMsg->id, 'groupid' => $newOrigin->id,
+            'collection' => MessageGroup::COLLECTION_APPROVED, 'arrival' => now()->subMinutes(10),
+        ]);
+        DB::insert(
+            "INSERT INTO messages_spatial (msgid, point, groupid, msgtype, arrival)
+             VALUES (?, ST_GeomFromText('POINT(-0.1 51.5)', 3857), ?, ?, ?)",
+            [$newMsg->id, $newOrigin->id, Message::TYPE_OFFER, now()->subMinutes(10)]
+        );
+
+        $this->service()->process(false, 500);
+
+        $this->assertNotNull(
+            DB::table('messages_groups')->where('msgid', $newMsg->id)->where('groupid', $groupB)->first(),
+            'a later post by the same poster still ripples into B (retraction did not poison re-ripple)'
+        );
+        $this->assertNotNull(
+            DB::table('memberships')->where('userid', $posterId)->where('groupid', $groupB)->first(),
+            'membership re-added by the later ripple'
+        );
+    }
+
+    /** A scoped (onlyMsgid) run retracts only the in-scope post, leaving others untouched. */
+    public function test_scoped_only_msgid_retracts_only_in_scope_post(): void
+    {
+        Http::fake();
+        [$m1, $g1] = $this->seedStaleReachWithRippledCopy();
+        [$m2, $g2] = $this->seedStaleReachWithRippledCopy();
+
+        $this->service()->process(false, 500, $m1);
+
+        $this->assertSame(0, (int) DB::table('rippling_reach')->where('msgid', $m1)->count(), 'in-scope reach dropped');
+        $this->assertSame(1, (int) DB::table('rippling_reach')->where('msgid', $m2)->count(), 'out-of-scope reach untouched');
+        $this->assertSame(1, (int) DB::table('messages_groups')->where('msgid', $m1)->where('groupid', $g1)->value('deleted'), 'in-scope copy pulled');
+        $this->assertSame(0, (int) DB::table('messages_groups')->where('msgid', $m2)->where('groupid', $g2)->value('deleted'), 'out-of-scope copy untouched');
+    }
+
+    /** A scoped (withinPolyWkt) run retracts only posts whose origin falls inside the polygon. */
+    public function test_scoped_within_poly_retracts_only_posts_inside_polygon(): void
+    {
+        Http::fake();
+        [$london] = $this->seedStaleReachWithRippledCopy(51.5, -0.1);
+        [$edinburgh] = $this->seedStaleReachWithRippledCopy(55.95, -3.19);
+
+        $poly = 'POLYGON((-0.5 51.3, 0.3 51.3, 0.3 51.8, -0.5 51.8, -0.5 51.3))';
+        $this->service()->process(false, 500, null, $poly);
+
+        $this->assertSame(0, (int) DB::table('rippling_reach')->where('msgid', $london)->count(), 'London post (inside polygon) retracted');
+        $this->assertSame(1, (int) DB::table('rippling_reach')->where('msgid', $edinburgh)->count(), 'Edinburgh post (outside polygon) untouched');
+    }
+
+    /** The poster-leaves-a-rippled-group pull also runs under a scoped run (was dark during the experiment). */
+    public function test_pull_on_leave_runs_under_scoped_run(): void
+    {
+        [$msgid, $posterId, $groupB] = $this->rippleIntoOneGroup();
+
+        // Poster leaves B (Go leave path: delete membership + Group/Left log).
+        DB::table('memberships')->where('userid', $posterId)->where('groupid', $groupB)->delete();
+        DB::table('logs')->insert([
+            'timestamp' => now(), 'type' => 'Group', 'subtype' => 'Left',
+            'user' => $posterId, 'groupid' => $groupB,
+        ]);
+
+        // Scoped run (the post is still in spatial, so only the leave-pull should act).
+        $stats = $this->service()->process(false, 500, $msgid);
+
+        $this->assertSame(
+            1,
+            (int) DB::table('messages_groups')->where('msgid', $msgid)->where('groupid', $groupB)->value('deleted'),
+            'leave-pull runs under a scoped run'
+        );
+        $this->assertGreaterThanOrEqual(1, $stats['pulled_on_leave']);
+    }
 }


### PR DESCRIPTION
## Problem

When a post leaves `messages_spatial` because it was **rejected/removed on its origin group** (or withdrawn / expired / deleted), rippling only *stopped expansion* - it dropped the `rippling_reach` row but left the already-rippled `messages_groups` copies **live on every neighbouring group**. In the live Stroud "Fish" incident the 6 rippled copies only vanished because the poster happened to *withdraw* later; a mod's spam-reject on the home group would have left them live on all 6 neighbours.

Worse, both retraction paths (`removeStale` and `pullRippledPostsFromLeftGroups`) were gated `if (!$scoped)`, so during the **scoped group experiment** no retraction ran at all: the reach row lingered `status='expanding'` and the cron kept rippling the rejected post into *more* groups.

## Fix

Turn "post left `messages_spatial`" into a single **stop-and-retract** step that also runs for scoped runs (`ExpandService`):

- **`removeStaleAndRetract`** - for each reach row whose post is no longer in `messages_spatial` (scoped to `onlyMsgid` / origin point within `withinPolyWkt`, matching `advanceDue`): soft-delete (`deleted=1`) every `rippled_in` copy with a `Message/Deleted` audit log, then drop the reach row (which also releases any held replies, since `ripple:release-replies` treats a missing reach row as "gone").
- **Membership cleanup** - removes the poster's ripple-joined (`rippled=1`) membership on a pulled group **only when they have no other live post there**, so a retracted post does not strand them in groups they only joined to carry it. Deliberately logs **no `Group/Left`** (which would poison the re-ripple guard and permanently bar future legitimate ripples, including after a mere withdraw/expire); organic memberships are never touched.
- **`pullRippledPostsFromLeftGroups`** is now scope-aware and runs for scoped runs too (same dark-during-experiment flaw).

`Taken`/`Received` stay in `messages_spatial` (`successful=1`) and are therefore excluded - only reject/withdraw/expire/delete trigger retraction.

## Tests

Added `ExpandServiceTest` coverage: retract + audit log + reach drop; membership removed-when-sole-post / kept-when-other-live-post / organic-never-removed; no `Group/Left` + future re-ripple still works; scoped `onlyMsgid` and `withinPolyWkt` retraction; leave-pull under a scoped run.

Full Laravel suite green locally (4531 tests, 0 failures). Mod docs updated in `RIPPLING-OUT-FOR-MODERATORS.md`; design at `docs/superpowers/specs/2026-06-25-rippling-stop-and-retract-on-origin-removal-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)