### PR TITLE
fix(modtools): make the TrashNothing listing toggle read-only

### DIFF
--- a/iznik-nuxt3/modtools/components/ModGroupSetting.vue
+++ b/iznik-nuxt3/modtools/components/ModGroupSetting.vue
@@ -10,7 +10,7 @@
           variant="white"
           icon-name="save"
           label="Save"
-          :disabled="readonly"
+          :disabled="disabledOrReadonly"
           @handle="save"
         />
       </slot>
@@ -22,7 +22,7 @@
           variant="white"
           icon-name="save"
           label="Save"
-          :disabled="readonly"
+          :disabled="disabledOrReadonly"
           @handle="save"
         />
       </slot>
@@ -40,7 +40,7 @@
             icon-name="save"
             label="Save"
             class="mt-2"
-            :disabled="readonly"
+            :disabled="disabledOrReadonly"
             @handle="save"
           />
         </b-col>
@@ -56,10 +56,11 @@
         :sync="true"
         :labels="{ checked: toggleChecked, unchecked: toggleUnchecked }"
         variant="modgreen"
-        :disabled="readonly"
+        :disabled="disabledOrReadonly"
         @change="save"
       />
     </div>
+    <slot name="note" />
   </b-form-group>
 </template>
 <script setup>
@@ -114,6 +115,13 @@ const props = defineProps({
     required: false,
     default: null,
   },
+  // Force the control read-only regardless of role - e.g. for flags that only
+  // track external state (TrashNothing listing) and can't be changed from here.
+  disabled: {
+    type: Boolean,
+    required: false,
+    default: false,
+  },
 })
 
 const modGroupStore = useModGroupStore()
@@ -124,6 +132,10 @@ const mounted = ref(false)
 const group = computed(() => modGroupStore.get(props.groupid))
 
 const readonly = computed(() => group.value?.myrole !== 'Owner')
+
+// A control is non-editable if the user lacks the role OR it's been forced
+// read-only via the `disabled` prop.
+const disabledOrReadonly = computed(() => readonly.value || props.disabled)
 
 /**
  * From https://stackoverflow.com/questions/18936915/dynamically-set-property-of-nested-object
@@ -183,6 +195,12 @@ function getValueFromGroup() {
 }
 
 async function save(callbackorvalue) {
+  // A forced read-only control must never write, even if something triggers
+  // save programmatically.
+  if (props.disabled) {
+    if (typeof callbackorvalue === 'function') callbackorvalue()
+    return
+  }
   if (mounted.value) {
     const data = {
       id: props.groupid,

--- a/iznik-nuxt3/modtools/components/ModSettingsGroup.vue
+++ b/iznik-nuxt3/modtools/components/ModSettingsGroup.vue
@@ -4,7 +4,11 @@
       <ModGroupSelect v-model="groupid" modonly />
     </div>
     <div v-if="group && group.mysettings" class="mt-2 scrollinplace">
-      <NoticeMessage v-if="group.settings?.closed" variant="danger" class="mb-1">
+      <NoticeMessage
+        v-if="group.settings?.closed"
+        variant="danger"
+        class="mb-1"
+      >
         Your community is currently closed. You can change this in
         <em>Features for Members</em>.
       </NoticeMessage>
@@ -982,7 +986,24 @@
               type="toggle"
               toggle-checked="On TN"
               toggle-unchecked="Not on TN"
-            />
+              disabled
+            >
+              <template #note>
+                <b-form-text class="text-warning mt-1">
+                  This only records whether the community is listed on
+                  TrashNothing - changing it here won't list or delist it, so
+                  it's read-only.
+                  <template v-if="group.tnkey && group.tnkey.url">
+                    To change it, use your
+                    <!-- eslint-disable-next-line -->
+                    <ExternalLink :href="group.tnkey.url">TrashNothing group settings</ExternalLink>.
+                  </template>
+                  <template v-else>
+                    Listing is managed in your TrashNothing group settings.
+                  </template>
+                </b-form-text>
+              </template>
+            </ModGroupSetting>
             <ModGroupSetting
               :groupid="groupid"
               name="onlovejunk"

--- a/iznik-nuxt3/tests/unit/components/modtools/ModGroupSetting.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModGroupSetting.spec.js
@@ -544,4 +544,78 @@ describe('ModGroupSetting', () => {
       }
     )
   })
+
+  describe('disabled prop (forced read-only)', () => {
+    it('disabledOrReadonly is true when disabled is set, even for an Owner', () => {
+      const wrapper = mountComponent({ disabled: true }) // Owner by default
+      expect(wrapper.vm.readonly).toBe(false)
+      expect(wrapper.vm.disabledOrReadonly).toBe(true)
+    })
+
+    it('disables the toggle for an Owner when disabled is set', async () => {
+      const wrapper = mountComponent({
+        name: 'ontn',
+        type: 'toggle',
+        disabled: true,
+      })
+      await flushPromises()
+      expect(wrapper.find('.our-toggle').attributes('data-disabled')).toBe(
+        'true'
+      )
+    })
+
+    it('does not write when the disabled toggle is clicked', async () => {
+      const wrapper = mountComponent(
+        { name: 'ontn', type: 'toggle', disabled: true },
+        { ontn: 1 }
+      )
+      await flushPromises()
+      vi.runAllTimers()
+      await flushPromises()
+
+      await wrapper.find('.our-toggle').trigger('click')
+      expect(mockModGroupStore.updateMT).not.toHaveBeenCalled()
+    })
+
+    it('save() never writes when disabled, even if called directly', async () => {
+      const wrapper = mountComponent({
+        name: 'ontn',
+        type: 'toggle',
+        disabled: true,
+      })
+      await flushPromises()
+      vi.runAllTimers()
+      await flushPromises()
+
+      await wrapper.vm.save(true)
+      expect(mockModGroupStore.updateMT).not.toHaveBeenCalled()
+    })
+
+    it('still runs the callback when disabled (so spin buttons reset)', async () => {
+      const wrapper = mountComponent({ name: 'ontn', disabled: true })
+      await flushPromises()
+      vi.runAllTimers()
+      await flushPromises()
+
+      const callback = vi.fn()
+      await wrapper.vm.save(callback)
+      expect(callback).toHaveBeenCalled()
+      expect(mockModGroupStore.updateMT).not.toHaveBeenCalled()
+    })
+
+    it('renders the note slot', () => {
+      const wrapper = mount(ModGroupSetting, {
+        props: {
+          ...defaultProps,
+          name: 'ontn',
+          type: 'toggle',
+          disabled: true,
+        },
+        slots: { note: '<span class="my-note">Managed on TrashNothing</span>' },
+        global: { stubs: defaultStubs },
+      })
+      expect(wrapper.find('.my-note').exists()).toBe(true)
+      expect(wrapper.text()).toContain('Managed on TrashNothing')
+    })
+  })
 })


### PR DESCRIPTION
## Summary

On the ModTools group settings page, the **"On TrashNothing?"** toggle was
editable - but the `ontn` flag only *records* whether the community is listed on
TrashNothing. It doesn't control TrashNothing. A moderator toggled it off and
believed they had delisted their group, when nothing had actually changed on TN.

This makes the toggle **read-only** and adds a note explaining that it only
records the listing, linking to the moderator's TrashNothing group settings -
where the listing is actually managed.

- `ModGroupSetting`: new `disabled` prop forces any control read-only regardless
  of role (composing with the existing owner-only `readonly`); `save()` now
  early-returns when disabled (defence in depth) while still firing any provided
  callback so spin buttons reset; added a `note` slot for explanatory text below
  a control.
- `ModSettingsGroup`: the `ontn` setting is now `disabled` with a note linking to
  the group's TrashNothing settings (`group.tnkey.url`), falling back to a generic
  message when no per-group URL is available.

Edward confirmed: *"The flag on MT is just to keep track - there's nothing on my
side that controls TN to turn it on/off."* Verified that `ontn` is only **read**
for display (`ModSupportListGroups`, `ModMessage`, `ModSupportFindGroup`) and
never triggers a TN action, so making it read-only changes no real behaviour.

## Code Quality Review

- Reused the existing role-based `readonly` mechanism; `disabled` composes with it
  via `disabledOrReadonly`.
- `save()` guards against writing when disabled, so even a programmatic trigger
  can't change the flag.
- The note is a slot, keeping the link/markup in the calling component.

## Future Improvements

- The adjacent **"On LoveJunk?"** (`onlovejunk`) toggle is the same kind of
  external-state flag and probably warrants the same treatment. Left out to keep
  this scoped to the reported TrashNothing issue.

## Test Plan

- Vitest `ModGroupSetting.spec.js` - 50 pass (+6 new): `disabled` forces
  read-only even for Owners; a disabled toggle doesn't write on click; `save()`
  never writes when disabled but still runs the callback; the note slot renders.
- Vitest `ModSettingsGroup.spec.js` - 50 pass (unchanged; the TrashNothing notice
  test stays green).
- Visual: a small template change (disabled state + note text) covered by the
  unit tests; the Netlify ModTools deploy preview can be used to eyeball it.
