### PR TITLE
fix(group): return real onhere/ontn/onlovejunk in the default group list

### DIFF
--- a/iznik-server-go/group/group.go
+++ b/iznik-server-go/group/group.go
@@ -511,7 +511,7 @@ func ListGroups(c *fiber.Ctx) error {
 			"backupmodsactive, backupownersactive, affiliationconfirmed, affiliationconfirmedby "+
 			"FROM `groups` WHERE type = ?", FREEGLE).Scan(&groups)
 	} else {
-		db.Raw("SELECT id, nameshort, namefull, lat, lng, onmap, publish, region, contactmail, mentored, CAST(JSON_EXTRACT(groups.settings, '$.showjoin') AS UNSIGNED) AS showjoin FROM `groups` WHERE publish = 1 AND onhere = 1 AND type = ?", FREEGLE).Scan(&groups)
+		db.Raw("SELECT id, nameshort, namefull, lat, lng, onmap, onhere, ontn, onlovejunk, publish, region, contactmail, mentored, CAST(JSON_EXTRACT(groups.settings, '$.showjoin') AS UNSIGNED) AS showjoin FROM `groups` WHERE publish = 1 AND onhere = 1 AND type = ?", FREEGLE).Scan(&groups)
 	}
 
 	// For support mode, fetch recent auto-approve, manual-approve, and moderation counts in parallel.

--- a/iznik-server-go/test/group_test.go
+++ b/iznik-server-go/test/group_test.go
@@ -66,6 +66,34 @@ func TestListGroups(t *testing.T) {
 	assert.Equal(t, 404, resp.StatusCode)
 }
 
+func TestListGroupsReturnsPlatformFlags(t *testing.T) {
+	// The default /api/group list (used by partner integrations) must return the
+	// real onhere/ontn/onlovejunk values, not a hardcoded 0 - the SELECT used to
+	// omit these columns so they serialised as the zero value for every group.
+	prefix := uniquePrefix("grp-flags")
+	groupID := CreateTestGroup(t, prefix)
+	db := database.DBConn
+	db.Exec("UPDATE `groups` SET publish = 1, onhere = 1, ontn = 1, onlovejunk = 1 WHERE id = ?", groupID)
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/group", nil))
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var groups []group.GroupEntry
+	json2.Unmarshal(rsp(resp), &groups)
+
+	var found *group.GroupEntry
+	for i := range groups {
+		if groups[i].ID == groupID {
+			found = &groups[i]
+			break
+		}
+	}
+	require.NotNil(t, found, "created group should appear in the default /api/group list")
+	assert.Equal(t, 1, found.Onhere, "onhere should reflect the stored value, not default to 0")
+	assert.Equal(t, 1, found.Ontn, "ontn should reflect the stored value")
+	assert.Equal(t, 1, found.Onlovejunk, "onlovejunk should reflect the stored value")
+}
+
 func TestGetGroup_NonFreegleType(t *testing.T) {
 	// Groups with non-Freegle types should still be fetchable by ID.
 	// V1 returns any group by ID regardless of type.


### PR DESCRIPTION
## Summary

The default `/api/group` list - the path partner integrations use, e.g.
`/api/group?polygon=true&partner=…` - returned `onhere` (and its siblings `ontn`
and `onlovejunk`) as `0` for **every** group.

`GroupEntry` always serialises those three "which platforms is this community on"
flags, but the non-support `SELECT` in `ListGroups` didn't include the columns,
so they scanned as the Go zero value (`0`) regardless of the stored values. The
support-mode query (`support=true`, Admin/Support only) already selected them -
only the default/partner path was missing them.

**Fix:** add `onhere, ontn, onlovejunk` to the default `ListGroups` SELECT.

- `onhere` is `1` for every group on this path (it's filtered `WHERE onhere = 1`),
  so the field now reports that real value instead of `0`.
- `ontn` / `onlovejunk` vary per group and now carry their real values through to
  partners, rather than always being `0`.

The reported symptom was `onhere` always 0; `ontn`/`onlovejunk` had the identical
defect on the same line and are fixed together.

## Test Plan

- Go `TestListGroupsReturnsPlatformFlags`: creates a group with
  `onhere=ontn=onlovejunk=1`, lists `/api/group`, and asserts all three come back
  as `1`. Verified failing before the fix (all `0`) and passing after.
