### PR TITLE
fix(message): use LastInsertId for new message id, not SELECT max-id

### DIFF
--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -3644,19 +3644,27 @@ func PutMessage(c *fiber.Ctx) error {
 	if req.Groupid > 0 {
 		messageid = fmt.Sprintf("%s-%d", messageid, req.Groupid)
 	}
-	result := db.Exec("INSERT INTO messages (fromuser, type, subject, textbody, message, arrival, date, source, availableinitially, availablenow, locationid, fromip, messageid) VALUES (?, ?, ?, ?, ?, NOW(), NOW(), 'Platform', ?, ?, ?, ?, ?)",
+	// Use the INSERT's own auto-increment id. A "SELECT id ... ORDER BY id DESC
+	// LIMIT 1" here is unsafe under the read/write split: the SELECT is routed to
+	// a read replica that may not yet have applied this INSERT, so it can return
+	// the user's PREVIOUS message - causing the new post (and its photos) to be
+	// grafted onto an existing one (Discourse 9832 "mixed up offers"). Read the id
+	// back from the write connection via LastInsertId, as CreateGroup does.
+	sqlDB, err := db.DB()
+	if err != nil {
+		return fiber.NewError(fiber.StatusInternalServerError, "Database error")
+	}
+	sqlResult, err := sqlDB.Exec("INSERT INTO messages (fromuser, type, subject, textbody, message, arrival, date, source, availableinitially, availablenow, locationid, fromip, messageid) VALUES (?, ?, ?, ?, ?, NOW(), NOW(), 'Platform', ?, ?, ?, ?, ?)",
 		myid, req.Type, req.Subject, req.Textbody, req.Textbody, availInit, availNow, req.Locationid, fromip, messageid)
-
-	if result.Error != nil {
+	if err != nil {
 		return fiber.NewError(fiber.StatusInternalServerError, "Failed to create message")
 	}
 
-	var newMsgID uint64
-	db.Raw("SELECT id FROM messages WHERE fromuser = ? ORDER BY id DESC LIMIT 1", myid).Scan(&newMsgID)
-
-	if newMsgID == 0 {
+	lastID, err := sqlResult.LastInsertId()
+	if err != nil || lastID <= 0 {
 		return fiber.NewError(fiber.StatusInternalServerError, "Failed to retrieve message ID")
 	}
+	newMsgID := uint64(lastID)
 
 	// For Draft collection, store in messages_drafts.
 	// For other collections, add to messages_groups.

--- a/iznik-server-go/test/message_create_id_test.go
+++ b/iznik-server-go/test/message_create_id_test.go
@@ -1,0 +1,73 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Regression guard for Discourse 9832 "mixed up offers": each created offer must
+// receive the id of its OWN newly-inserted message. The old code read the new id
+// back with "SELECT id FROM messages WHERE fromuser=? ORDER BY id DESC LIMIT 1",
+// which the read/write split routes to a read replica - under replication lag
+// that returned the user's PREVIOUS message, so a new offer (and its photos) got
+// grafted onto an existing post. The create now uses the INSERT's LastInsertId.
+//
+// The replica-lag trigger can't be reproduced against the single test DB, so this
+// is a contract guard: it pins that two consecutive creates return distinct ids
+// each pointing at their own content (the second offer must not land on the first).
+func TestCreateMessageReturnsItsOwnNewId(t *testing.T) {
+	prefix := uniquePrefix("create-ownid")
+	db := database.DBConn
+	groupID := CreateTestGroup(t, prefix)
+	userID := CreateTestUser(t, prefix, "User")
+	_, token := CreateTestSession(t, userID)
+
+	var locationID uint64
+	db.Raw("SELECT id FROM locations LIMIT 1").Scan(&locationID)
+	require.NotZero(t, locationID, "need a location row for the offer")
+
+	create := func(item, subject string) uint64 {
+		payload := map[string]interface{}{
+			"type":        "Offer",
+			"messagetype": "Offer",
+			"item":        item,
+			"subject":     subject,
+			"textbody":    "body for " + item,
+			"collection":  "Draft",
+			"groupid":     groupID,
+			"locationid":  locationID,
+		}
+		s, _ := json.Marshal(payload)
+		req := httptest.NewRequest("PUT", fmt.Sprintf("/api/message?jwt=%s", token), bytes.NewBuffer(s))
+		req.Header.Set("Content-Type", "application/json")
+		resp, _ := getApp().Test(req, 10000)
+		require.Equal(t, 200, resp.StatusCode)
+		var result map[string]interface{}
+		json.NewDecoder(resp.Body).Decode(&result)
+		idf, ok := result["id"].(float64)
+		require.True(t, ok, "create must return a numeric id")
+		return uint64(idf)
+	}
+
+	idA := create("Silk fabric", "OFFER: Silk fabric ("+prefix+")")
+	idB := create("Cheese slicer", "OFFER: Cheese slicer ("+prefix+")")
+
+	assert.NotZero(t, idA)
+	assert.NotZero(t, idB)
+	assert.NotEqual(t, idA, idB, "a second new offer must not reuse the first offer's message id")
+
+	// Each id must point at its OWN content - the second create must not have
+	// landed on (and overwritten/merged into) the first message.
+	var subjA, subjB string
+	db.Raw("SELECT subject FROM messages WHERE id = ?", idA).Scan(&subjA)
+	db.Raw("SELECT subject FROM messages WHERE id = ?", idB).Scan(&subjB)
+	assert.Contains(t, subjA, "Silk fabric", "first offer keeps its own subject")
+	assert.Contains(t, subjB, "Cheese slicer", "second offer points at the newly-created message")
+}


### PR DESCRIPTION
## Summary

Fixes the "mixed up offers" data corruption reported in Discourse 9832 (debugged
via production Loki).

When a member posts a **new** offer, the create handler inserted the message and
then read its id back with:

```go
db.Raw("SELECT id FROM messages WHERE fromuser = ? ORDER BY id DESC LIMIT 1", myid)
```

Under the **read/write split** (PR #887) that `SELECT` is routed to a read replica,
which under replication lag had **not yet applied the just-done INSERT** - so it
returned the member's *previous* message id. The new draft, its photos
(`UPDATE messages_attachments SET msgid = newMsgID`), and the subsequent
`JoinAndPost` then all bound to that old message, **grafting the new offer onto an
existing post and merging the photos**.

Real example (user 33810820): a new "Cheese slicer" offer (`POST /apiv2/message`
with no id, only the 2 freshly-uploaded photos) came back as id `120768038` - her
existing "Silk fabric" post (promised to another member). The result was one
message with cheese-slicer text and the fabric photo still attached.

**Fix:** read the new id from the INSERT's own `LastInsertId()` on the write
connection, using the pattern already established in `CreateGroup`
(`group.go:~909`). This is correct regardless of which node a later `SELECT` would
hit.

## Code Quality Review

- Switched the create INSERT to `sqlDB.Exec(...)` + `LastInsertId()` (write
  connection) - no extra round-trip, and never reads back a stale id.
- Same anti-pattern exists at a few other sites (e.g. `export.go:58`); left for a
  follow-up since they're lower-impact, but they have the same read-split hazard.

## Test Plan

- Go `TestCreateMessageReturnsItsOwnNewId`: two consecutive offer creates return
  distinct ids, each pointing at its own subject (the second offer must not land on
  the first). Note: the replica-lag trigger isn't reproducible against the single
  test DB, so this is a contract/regression guard; the fix's correctness rests on
  using `LastInsertId` (the proven `CreateGroup` pattern).
- Full Go suite green (no regressions).
