### PR TITLE
fix(session): use LastInsertId for new session/export ids, not SELECT max-id

### DIFF
--- a/iznik-server-go/auth/auth.go
+++ b/iznik-server-go/auth/auth.go
@@ -277,15 +277,26 @@ func CreateSessionAndJWT(userID uint64) (map[string]interface{}, string, error) 
 	series := utils.RandomUint64()
 	token := utils.RandomHex(16)
 
-	db.Exec("INSERT INTO sessions (userid, series, token, date, lastactive) VALUES (?, ?, ?, NOW(), NOW())",
+	// Read the new session id from the INSERT's LastInsertId on the write
+	// connection. A "SELECT id ... WHERE userid ORDER BY id DESC LIMIT 1" here is
+	// routed to a read replica by the read/write split and, under Galera's
+	// cross-node apply window, can return the user's PREVIOUS session - so the
+	// persistent token/JWT would carry the wrong session id (cf. message create,
+	// Discourse 9832). db.DB() returns the source even with dbresolver registered.
+	sqlDB, err := db.DB()
+	if err != nil {
+		return nil, "", fmt.Errorf("database error: %w", err)
+	}
+	res, err := sqlDB.Exec("INSERT INTO sessions (userid, series, token, date, lastactive) VALUES (?, ?, ?, NOW(), NOW())",
 		userID, series, token)
-
-	var sessionID uint64
-	db.Raw("SELECT id FROM sessions WHERE userid = ? ORDER BY id DESC LIMIT 1", userID).Scan(&sessionID)
-
-	if sessionID == 0 {
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to create session: %w", err)
+	}
+	lastID, err := res.LastInsertId()
+	if err != nil || lastID <= 0 {
 		return nil, "", fmt.Errorf("failed to create session")
 	}
+	sessionID := uint64(lastID)
 
 	persistent := map[string]interface{}{
 		"id":     sessionID,

--- a/iznik-server-go/export/export.go
+++ b/iznik-server-go/export/export.go
@@ -48,14 +48,23 @@ func PostExport(c *fiber.Ctx) error {
 	}
 	tag := hex.EncodeToString(tagBytes)
 
-	result := db.Exec("INSERT INTO users_exports (userid, tag) VALUES (?, ?)", myid, tag)
-	if result.Error != nil {
-		log.Printf("Failed to insert export for user %d: %v", myid, result.Error)
+	// Use LastInsertId on the write connection: a SELECT here would be routed to a
+	// read replica by the read/write split and, under Galera's cross-node apply
+	// window, may not yet see the just-inserted row (returning id=0).
+	var id uint64
+	sqlDB, err := db.DB()
+	if err != nil {
+		log.Printf("Failed to get DB handle for export, user %d: %v", myid, err)
 		return fiber.NewError(fiber.StatusInternalServerError, "Failed to create export")
 	}
-
-	var id uint64
-	db.Raw("SELECT id FROM users_exports WHERE userid = ? AND tag = ? ORDER BY id DESC LIMIT 1", myid, tag).Scan(&id)
+	res, err := sqlDB.Exec("INSERT INTO users_exports (userid, tag) VALUES (?, ?)", myid, tag)
+	if err != nil {
+		log.Printf("Failed to insert export for user %d: %v", myid, err)
+		return fiber.NewError(fiber.StatusInternalServerError, "Failed to create export")
+	}
+	if lastID, idErr := res.LastInsertId(); idErr == nil && lastID > 0 {
+		id = uint64(lastID)
+	}
 
 	return c.JSON(fiber.Map{
 		"id":  id,

--- a/iznik-server-go/user/user.go
+++ b/iznik-server-go/user/user.go
@@ -1974,11 +1974,19 @@ func PutUser(c *fiber.Ctx) error {
 	// which collided across every session for the same user.
 	series := utils.RandomUint64()
 	token := utils.RandomHex(16)
-	db.Exec("INSERT INTO sessions (userid, series, token, lastactive) VALUES (?, ?, ?, NOW())",
-		newUserID, series, token)
-
+	// Use the INSERT's LastInsertId (write connection) rather than a
+	// "SELECT ... WHERE userid ORDER BY id DESC LIMIT 1", which the read/write
+	// split routes to a replica that can return the user's PREVIOUS session under
+	// Galera's cross-node apply window - putting the wrong session id in the JWT.
 	var sessionID uint64
-	db.Raw("SELECT id FROM sessions WHERE userid = ? ORDER BY id DESC LIMIT 1", newUserID).Scan(&sessionID)
+	if sqlDB, dberr := db.DB(); dberr == nil {
+		if res, exErr := sqlDB.Exec("INSERT INTO sessions (userid, series, token, lastactive) VALUES (?, ?, ?, NOW())",
+			newUserID, series, token); exErr == nil {
+			if lastID, idErr := res.LastInsertId(); idErr == nil && lastID > 0 {
+				sessionID = uint64(lastID)
+			}
+		}
+	}
 
 	// Generate JWT.
 	jwtToken := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{


### PR DESCRIPTION
## Summary

Hardens the same "read back a just-inserted id with `SELECT … ORDER BY id DESC
LIMIT 1`" pattern that caused the mixed-up offers in #899, at the highest-impact
remaining sites: **session creation**.

Under the read/write split (`MYSQL_HOST_READ` set) that `SELECT` is routed to a
read replica, which under Galera's cross-node apply window may not yet see the
just-inserted row. For a query filtered only by `userid` that returns the user's
**previous** row:

- `auth.go` `CreateSessionAndJWT` and `user.go` (draft signup): create a session,
  then `SELECT id FROM sessions WHERE userid = ? ORDER BY id DESC LIMIT 1`. A stale
  read returns the user's **previous** session id, so the persistent token / JWT
  is issued with the wrong `sessionid` - a login/auth correctness bug.
- `export.go`: filtered by a unique random `tag`, so a stale read instead returns
  `id = 0` (export "not found") - softer, but still wrong.

**Fix:** read the id from the INSERT's `LastInsertId()` on the write connection
(`db.DB()` returns the source even with dbresolver registered), as in `CreateGroup`
and #899.

## Note / recommendation

A few lower-severity sites filter by a unique key (token / TransactionID / email /
isochroneid / story) so a stale read yields `id = 0` rather than a wrong row:
`message.go:3511`, `donations/stripeipn.go`, `user.go` (email), `isochrone.go`,
`newsfeed.go`. The systemic fix for the whole class is `wsrep_sync_wait=1` (causal
reads) on the read replica, which makes every read-after-write across the split
safe without per-site code changes - worth doing alongside these.

## Test Plan

- Full Go suite green (existing session tests, incl. the persistent-series /
  sessionID-matches-DB checks, still pass; no regressions).
