### PR TITLE
fix(browse): record scroll depth as we scroll, debounced, one row per session

### DIFF
--- a/iznik-batch/database/migrations/2026_06_25_000001_add_session_to_browse_scroll_depth.php
+++ b/iznik-batch/database/migrations/2026_06_25_000001_add_session_to_browse_scroll_depth.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Add a per-browse-session id to browse_scroll_depth and make it unique, so the
+ * client can report scroll depth repeatedly (debounced as it scrolls) and the Go
+ * apiv2 handler upserts one row per session keeping GREATEST(max_position) -
+ * instead of one INSERT per leave-beacon. Idempotent across repeat sends and
+ * re-entry, so a browse session is counted exactly once.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (
+            Schema::hasTable('browse_scroll_depth') &&
+            !Schema::hasColumn('browse_scroll_depth', 'session')
+        ) {
+            Schema::table('browse_scroll_depth', function (Blueprint $t) {
+                $t->string('session', 64)->nullable()->after('id');
+                $t->unique('session', 'bsd_session');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasColumn('browse_scroll_depth', 'session')) {
+            Schema::table('browse_scroll_depth', function (Blueprint $t) {
+                $t->dropUnique('bsd_session');
+                $t->dropColumn('session');
+            });
+        }
+    }
+};

--- a/iznik-batch/database/migrations/2026_06_25_000001_add_session_to_browse_scroll_depth_migration.sql
+++ b/iznik-batch/database/migrations/2026_06_25_000001_add_session_to_browse_scroll_depth_migration.sql
@@ -1,0 +1,7 @@
+-- Production SQL: add a unique per-session id to browse_scroll_depth so the Go
+-- apiv2 handler upserts one row per browse session (keeping GREATEST(max_position))
+-- as the debounced client reports scroll depth, instead of one INSERT per beacon.
+-- Run once (MySQL has no ADD COLUMN IF NOT EXISTS); safe on the near-empty table.
+ALTER TABLE browse_scroll_depth
+    ADD COLUMN session VARCHAR(64) NULL AFTER id,
+    ADD UNIQUE KEY bsd_session (session);

--- a/iznik-nuxt3/components/MessageList.vue
+++ b/iznik-nuxt3/components/MessageList.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div ref="feedRoot">
     <h2 v-if="group && showGroupHeader" class="visually-hidden">
       Community Information
     </h2>
@@ -141,6 +141,7 @@ import {
   computed,
   watch,
   defineAsyncComponent,
+  onMounted,
   onBeforeUnmount,
 } from 'vue'
 import dayjs from 'dayjs'
@@ -250,13 +251,61 @@ const isochroneStore = useIsochroneStore()
 const { me, myid, myGroups: myMemberships } = useMe()
 
 // Browse-feed scroll-depth instrumentation: record how far down the feed this
-// session scrolls (reported once on leave/hide). 'search' vs 'browse' so the
-// sysadmin "Scrolling" tab can tell the two feeds apart.
+// session scrolls. 'search' vs 'browse' so the sysadmin "Scrolling" tab can tell
+// the two feeds apart. The composable debounces the send and upserts one row per
+// session (keyed on its session id), so repeat sends never double-count.
 const runtimeConfig = useRuntimeConfig()
 const { record: recordScrollDepth } = useScrollDepth(
   runtimeConfig?.public?.APIv2,
   () => (props.search ? 'search' : 'browse')
 )
+
+// Record the furthest feed position actually reached as the member scrolls -
+// not just at infinite-scroll batch boundaries (handleLoadMore), so even small
+// scrolls register. The message wrappers are in feed order, so the furthest one
+// whose top has entered the viewport is the deepest position reached; binary
+// search keeps this to O(log n) layout reads. The composable debounces the send.
+const feedRoot = ref(null)
+let scrollDepthTimer = null
+function captureScrollDepth() {
+  const root = feedRoot.value
+  if (!root || typeof window === 'undefined') return
+  const wrappers = root.querySelectorAll('.messagewrapper')
+  if (!wrappers.length) return
+  const vh = window.innerHeight || 0
+  let lo = 0
+  let hi = wrappers.length - 1
+  let furthest = -1
+  while (lo <= hi) {
+    const mid = (lo + hi) >> 1
+    if (wrappers[mid].getBoundingClientRect().top < vh) {
+      furthest = mid
+      lo = mid + 1
+    } else {
+      hi = mid - 1
+    }
+  }
+  if (furthest >= 0) {
+    recordScrollDepth(furthest, wrappers.length)
+  }
+}
+function onFeedScroll() {
+  if (scrollDepthTimer) clearTimeout(scrollDepthTimer)
+  scrollDepthTimer = setTimeout(captureScrollDepth, 200)
+}
+onMounted(() => {
+  if (typeof window !== 'undefined') {
+    window.addEventListener('scroll', onFeedScroll, { passive: true })
+    // Count what's already on screen at landing (reached without scrolling).
+    captureScrollDepth()
+  }
+})
+onBeforeUnmount(() => {
+  if (scrollDepthTimer) clearTimeout(scrollDepthTimer)
+  if (typeof window !== 'undefined') {
+    window.removeEventListener('scroll', onFeedScroll)
+  }
+})
 
 // Get the initial messages to show in a single call.
 // Wait for fetch to complete before enabling the split view (unseen/seen),
@@ -534,7 +583,10 @@ function pollUntilZero() {
   }
 
   markSeenTimer = setTimeout(async () => {
-    const count = await messageStore.fetchCount(me.value?.settings?.browseView, false)
+    const count = await messageStore.fetchCount(
+      me.value?.settings?.browseView,
+      false
+    )
     pollCount++
 
     if (count > 0 && pollCount < MAX_POLL_COUNT) {

--- a/iznik-nuxt3/composables/useScrollDepth.js
+++ b/iznik-nuxt3/composables/useScrollDepth.js
@@ -1,26 +1,55 @@
 // Browse-feed scroll-depth capture.
 //
-// Tracks the FURTHEST feed position a browse session reached and reports it once,
-// on leave/hide, to POST /scrolldepth. This is the browse-feed analogue of the
-// digest click-by-position instrumentation: aggregated server-side into a
-// scroll-depth curve (what fraction of sessions reach position N) on the sysadmin
-// "Scrolling" tab.
+// Tracks the FURTHEST feed position a browse session reached and reports it to
+// POST /scrolldepth. This is the browse-feed analogue of the digest
+// click-by-position instrumentation: aggregated server-side into a scroll-depth
+// curve (what fraction of sessions reach position N) on the sysadmin "Scrolling"
+// tab.
 //
-// record(position, total) is called as the feed grows (e.g. from the infinite-scroll
-// load-more handler, which knows the furthest item index revealed). The send is
-// fire-and-forget via navigator.sendBeacon so it survives the page unload; a single
-// session reports at most once.
+// record(position, total) is called as items scroll into view (per-item
+// visibility), so even small scrolls register - not just the infinite-scroll
+// load-more boundary. The send is DEBOUNCED: it fires a short time after
+// scrolling settles, and re-sends only when the furthest position grows. Each
+// session has a stable id and the server upserts one row per session keeping the
+// max, so a debounced timer firing repeatedly - or after re-entry - never
+// double-counts. We also flush on tab-hide and on unmount (and clear the timer
+// then, so a stale timer can't fire after teardown).
 //
-// apiBase is the APIv2 base URL (so the composable stays unit-testable without the
-// Nuxt runtime). getContext returns 'browse' or 'search' for the current feed.
+// apiBase is the APIv2 base URL (so the composable stays unit-testable without
+// the Nuxt runtime). getContext returns 'browse' or 'search' for the current feed.
 
 import { onBeforeUnmount, getCurrentInstance } from 'vue'
 
-export function useScrollDepth(apiBase, getContext) {
+function newSessionId() {
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+    return crypto.randomUUID()
+  }
+  return (
+    'sd-' + Math.random().toString(36).slice(2) + '-' + Date.now().toString(36)
+  )
+}
+
+export function useScrollDepth(apiBase, getContext, options = {}) {
+  const debounceMs =
+    typeof options.debounceMs === 'number' ? options.debounceMs : 1500
+
+  // Stable per-session id: one browse session = one row server-side.
+  const session = newSessionId()
+
   let maxPos = -1
   let itemsAvailable = 0
-  let sent = false
+  let lastSentPos = -1
+  let timer = null
 
+  function clearTimer() {
+    if (timer) {
+      clearTimeout(timer)
+      timer = null
+    }
+  }
+
+  // Called as items scroll into view. Keeps the running max and (re)arms a
+  // debounced send so we report a short time after scrolling settles.
   function record(position, total) {
     if (typeof position === 'number' && position > maxPos) {
       maxPos = position
@@ -28,17 +57,26 @@ export function useScrollDepth(apiBase, getContext) {
     if (typeof total === 'number' && total > itemsAvailable) {
       itemsAvailable = total
     }
+    if (maxPos < 0 || !apiBase) {
+      return
+    }
+    clearTimer()
+    timer = setTimeout(send, debounceMs)
   }
 
   function send() {
-    // Nothing scrolled, already reported this session, or no API base (e.g. SSR
-    // or missing runtime config) — never emit a broken request.
-    if (sent || maxPos < 0 || !apiBase) {
+    clearTimer()
+    // Nothing scrolled, no growth since the last send, or no API base (SSR /
+    // missing runtime config) - never emit a redundant or broken request. The
+    // server keys on `session` and keeps GREATEST(max_position), so repeat sends
+    // and re-entry are idempotent.
+    if (maxPos < 0 || maxPos === lastSentPos || !apiBase) {
       return
     }
-    sent = true
+    lastSentPos = maxPos
 
     const body = JSON.stringify({
+      session,
       maxposition: maxPos,
       itemsavailable: itemsAvailable,
       context: (getContext && getContext()) || 'browse',
@@ -46,8 +84,8 @@ export function useScrollDepth(apiBase, getContext) {
     const url = `${apiBase}/scrolldepth`
 
     try {
-      // sendBeacon is the reliable way to get a request out during unload; fall back
-      // to a keepalive fetch where it's unavailable (older browsers / test env).
+      // sendBeacon survives unload; fall back to a keepalive fetch where it's
+      // unavailable (older browsers / test env).
       if (typeof navigator !== 'undefined' && navigator.sendBeacon) {
         navigator.sendBeacon(
           url,
@@ -66,8 +104,8 @@ export function useScrollDepth(apiBase, getContext) {
     }
   }
 
-  // Report when the tab is hidden (covers mobile app-switch / tab close, where
-  // unmount may not fire) and on component teardown (SPA route change away).
+  // Flush immediately when the tab is hidden (mobile app-switch / tab close,
+  // where unmount may not fire).
   function onVisibilityChange() {
     if (
       typeof document !== 'undefined' &&
@@ -81,17 +119,18 @@ export function useScrollDepth(apiBase, getContext) {
     document.addEventListener('visibilitychange', onVisibilityChange)
   }
 
-  // Only register the unmount hook when used inside a component (the SPA
-  // route-away case). Guarding on the instance keeps the composable usable — and
-  // warning-free — outside a setup context, e.g. in unit tests.
+  // Flush and tear down on unmount (SPA route away). Clearing the timer here is
+  // what stops a debounced send firing after the component - and its session -
+  // are gone.
   if (getCurrentInstance()) {
     onBeforeUnmount(() => {
       if (typeof document !== 'undefined') {
         document.removeEventListener('visibilitychange', onVisibilityChange)
       }
       send()
+      clearTimer()
     })
   }
 
-  return { record, send }
+  return { record, send, session }
 }

--- a/iznik-nuxt3/tests/unit/composables/useScrollDepth.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useScrollDepth.spec.js
@@ -1,37 +1,108 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 import { useScrollDepth } from '~/composables/useScrollDepth'
 
 // useScrollDepth registers an onBeforeUnmount hook; called outside a component it
-// just warns and is a no-op, which is fine — we drive record()/send() directly.
+// just warns and is a no-op, which is fine - we drive record()/send() directly.
 
 describe('useScrollDepth', () => {
   let beacon
+  let visibilityHandler
 
   beforeEach(() => {
+    vi.useFakeTimers()
     beacon = vi.fn(() => true)
     global.navigator = { sendBeacon: beacon }
+    visibilityHandler = null
     global.document = {
-      addEventListener: vi.fn(),
+      addEventListener: vi.fn((evt, cb) => {
+        if (evt === 'visibilitychange') visibilityHandler = cb
+      }),
       removeEventListener: vi.fn(),
       visibilityState: 'visible',
     }
   })
 
-  it('reports the furthest recorded position once, as JSON, on send()', async () => {
-    const { record, send } = useScrollDepth('https://api.test/apiv2', () => 'search')
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  async function payloadOf(call) {
+    return JSON.parse(await call[1].text())
+  }
+
+  it('debounces a send as we scroll, reporting the furthest position with a session', async () => {
+    const { record, session } = useScrollDepth(
+      'https://api.test/apiv2',
+      () => 'search',
+      {
+        debounceMs: 500,
+      }
+    )
+    expect(typeof session).toBe('string')
+    expect(session.length).toBeGreaterThan(0)
+
     record(3, 50)
     record(12, 60)
-    record(7, 60) // lower than the max — ignored
+    record(7, 60) // lower than the max - ignored
 
-    send()
+    expect(beacon).not.toHaveBeenCalled() // not yet - debounced
+    vi.advanceTimersByTime(500)
 
     expect(beacon).toHaveBeenCalledTimes(1)
     const [url, blob] = beacon.mock.calls[0]
     expect(url).toBe('https://api.test/apiv2/scrolldepth')
     expect(blob.type).toBe('application/json')
-    const payload = JSON.parse(await blob.text())
-    expect(payload).toEqual({ maxposition: 12, itemsavailable: 60, context: 'search' })
+    expect(await payloadOf(beacon.mock.calls[0])).toEqual({
+      session,
+      maxposition: 12,
+      itemsavailable: 60,
+      context: 'search',
+    })
+  })
+
+  it('re-sends (same session) when the furthest position grows, but not when it is unchanged', async () => {
+    const { record } = useScrollDepth(
+      'https://api.test/apiv2',
+      () => 'browse',
+      {
+        debounceMs: 200,
+      }
+    )
+    record(5, 30)
+    vi.advanceTimersByTime(200)
+    expect(beacon).toHaveBeenCalledTimes(1)
+
+    // Scroll deeper -> new send with the higher max, same session id.
+    record(20, 40)
+    vi.advanceTimersByTime(200)
+    expect(beacon).toHaveBeenCalledTimes(2)
+    const p1 = await payloadOf(beacon.mock.calls[0])
+    const p2 = await payloadOf(beacon.mock.calls[1])
+    expect(p1.session).toBe(p2.session)
+    expect(p2.maxposition).toBe(20)
+
+    // Re-record the same (or shallower) max -> nothing new to report.
+    record(20, 40)
+    record(8, 40)
+    vi.advanceTimersByTime(200)
+    expect(beacon).toHaveBeenCalledTimes(2)
+  })
+
+  it('flushes immediately when the tab is hidden (does not wait for the debounce)', () => {
+    const { record } = useScrollDepth(
+      'https://api.test/apiv2',
+      () => 'browse',
+      {
+        debounceMs: 5000,
+      }
+    )
+    record(9, 20)
+    expect(beacon).not.toHaveBeenCalled()
+
+    global.document.visibilityState = 'hidden'
+    visibilityHandler()
+    expect(beacon).toHaveBeenCalledTimes(1)
   })
 
   it('does not send when nothing was recorded', () => {
@@ -47,19 +118,14 @@ describe('useScrollDepth', () => {
     expect(beacon).not.toHaveBeenCalled()
   })
 
-  it('sends at most once per session', () => {
-    const { record, send } = useScrollDepth('https://api.test/apiv2', () => 'browse')
-    record(5, 10)
-    send()
-    send()
-    expect(beacon).toHaveBeenCalledTimes(1)
-  })
-
-  it('defaults the context to browse', async () => {
-    const { record, send } = useScrollDepth('https://api.test/apiv2')
+  it('defaults the context to browse and exposes a stable session id', async () => {
+    const { record, send, session } = useScrollDepth('https://api.test/apiv2')
+    expect(typeof session).toBe('string')
+    expect(session.length).toBeGreaterThan(0)
     record(2, 10)
     send()
-    const payload = JSON.parse(await beacon.mock.calls[0][1].text())
+    const payload = await payloadOf(beacon.mock.calls[0])
     expect(payload.context).toBe('browse')
+    expect(payload.session).toBe(session)
   })
 })

--- a/iznik-server-go/browse/scroll.go
+++ b/iznik-server-go/browse/scroll.go
@@ -17,6 +17,10 @@ import (
 const maxScrollPosition = 100000
 
 type RecordScrollDepthRequest struct {
+	// Session is a client-generated per-browse-session id. When present we upsert
+	// one row per session keeping the max, so the debounced client can report
+	// repeatedly as it scrolls (and after re-entry) without double-counting.
+	Session string `json:"session"`
 	// MaxPosition is the furthest 0-based feed item index reached in the session.
 	MaxPosition int `json:"maxposition"`
 	// ItemsAvailable is the feed length when recorded (optional context).
@@ -27,9 +31,11 @@ type RecordScrollDepthRequest struct {
 
 // RecordScrollDepth records how far down the browse feed a session scrolled.
 //
-// POST /api/scrolldepth — one row per browse session (the client sends the max
-// position reached on leave/hide). No login required: logged-out browsing is
-// recorded with a NULL userid. Powers the sysadmin "Scrolling" scroll-depth curve.
+// POST /api/scrolldepth — one row per browse session. The client reports the
+// furthest position reached, debounced as it scrolls; with a session id we upsert
+// (keeping GREATEST(max_position)) so repeat reports collapse to one row. No login
+// required: logged-out browsing is recorded with a NULL userid. Powers the
+// sysadmin "Scrolling" scroll-depth curve.
 func RecordScrollDepth(c *fiber.Ctx) error {
 	var req RecordScrollDepthRequest
 	if err := c.BodyParser(&req); err != nil {
@@ -61,8 +67,21 @@ func RecordScrollDepth(c *fiber.Ctx) error {
 		items = req.ItemsAvailable
 	}
 
-	db.Exec("INSERT INTO browse_scroll_depth (userid, max_position, items_available, context) VALUES (?, ?, ?, ?)",
-		userid, req.MaxPosition, items, ctx)
+	if req.Session != "" {
+		// Upsert keyed on the unique session id: keep the furthest position the
+		// session reached. Idempotent across the debounced client's repeat sends
+		// and any re-entry, so a session is counted exactly once.
+		db.Exec("INSERT INTO browse_scroll_depth (session, userid, max_position, items_available, context) VALUES (?, ?, ?, ?, ?) "+
+			"ON DUPLICATE KEY UPDATE "+
+			"max_position = GREATEST(max_position, VALUES(max_position)), "+
+			"items_available = COALESCE(VALUES(items_available), items_available), "+
+			"userid = COALESCE(VALUES(userid), userid)",
+			req.Session, userid, req.MaxPosition, items, ctx)
+	} else {
+		// Legacy clients without a session id: a single fire-and-forget insert.
+		db.Exec("INSERT INTO browse_scroll_depth (userid, max_position, items_available, context) VALUES (?, ?, ?, ?)",
+			userid, req.MaxPosition, items, ctx)
+	}
 
 	return c.JSON(fiber.Map{"ret": 0, "status": "Success"})
 }

--- a/iznik-server-go/test/browse_test.go
+++ b/iznik-server-go/test/browse_test.go
@@ -44,6 +44,35 @@ func TestRecordScrollDepth_IgnoresOutOfRange(t *testing.T) {
 	assert.Equal(t, 0, count, "an out-of-range position is not recorded")
 }
 
+// With a session id the handler upserts a single row per session, keeping the furthest
+// position - so the debounced client can report repeatedly (and on re-entry) without
+// double-counting.
+func TestRecordScrollDepth_SessionUpsertKeepsMax(t *testing.T) {
+	db := database.DBConn
+	session := uniquePrefix("sdsess")
+	defer db.Exec("DELETE FROM browse_scroll_depth WHERE session = ?", session)
+
+	post := func(max int) {
+		body := fmt.Sprintf(`{"session":%q,"maxposition":%d,"context":"browse"}`, session, max)
+		req := httptest.NewRequest("POST", "/api/scrolldepth", bytes.NewReader([]byte(body)))
+		req.Header.Set("Content-Type", "application/json")
+		resp, _ := getApp().Test(req)
+		assert.Equal(t, 200, resp.StatusCode)
+	}
+
+	post(10)
+	post(25) // scrolled deeper - should win
+	post(8)  // shallower re-report - ignored
+
+	var count int
+	db.Raw("SELECT COUNT(*) FROM browse_scroll_depth WHERE session = ?", session).Scan(&count)
+	assert.Equal(t, 1, count, "repeat reports for one session collapse to a single row")
+
+	var maxpos int
+	db.Raw("SELECT max_position FROM browse_scroll_depth WHERE session = ?", session).Scan(&maxpos)
+	assert.Equal(t, 25, maxpos, "the row keeps GREATEST(max_position)")
+}
+
 // GET /modtools/scroll/depth returns the scroll-depth curve (Support/Admin only). Position 0 is,
 // by construction, reached by 100% of sessions, so that's a stable assertion regardless of what
 // other sessions are in the window.


### PR DESCRIPTION
## Summary

The browse-feed scroll-depth tab on the sysadmin "Scrolling" page recorded **no
data**. Two reasons, fixed here:

1. **Recording only happened at infinite-scroll batch boundaries.** `record()`
   was called solely from `handleLoadMore` (the load-more handler), so a scroll
   that didn't cross a batch boundary recorded nothing - `maxPos` stayed `-1` and
   the send no-oped. A short scroll registered zero depth.
2. **A single beacon on leave is fragile** - it often doesn't fire (mobile
   backgrounding, etc.), so even sessions that did scroll frequently sent nothing.

### What changed

- **Record as we scroll.** `MessageList` now has a debounced scroll handler that
  finds the furthest message wrapper whose top has entered the viewport (binary
  search over the in-feed-order wrappers, O(log n) layout reads) and records that
  position - so even small scrolls register.
- **Debounced send, not leave-only.** `useScrollDepth` sends a short time after
  scrolling settles and re-sends only when the furthest position grows; it still
  flushes on tab-hide and unmount (and clears the timer on teardown so a stale
  timer can't fire after the component - and its session - are gone).
- **No double-counting.** Each browse session gets a stable id; the Go handler
  **upserts** one row per session keeping `GREATEST(max_position)`. Repeat
  debounced sends, and re-entry with a stale timer, all collapse to that one row.

### Schema

Adds a unique `session` column to `browse_scroll_depth` (migration
`2026_06_25_000001`). **Run this once in prod** (safe on the near-empty table):

```sql
ALTER TABLE browse_scroll_depth
  ADD COLUMN session VARCHAR(64) NULL AFTER id,
  ADD UNIQUE KEY bsd_session (session);
```

Legacy clients (no session id) still do a single plain insert, so nothing breaks
before the new frontend ships.

## Test Plan

- Vitest `useScrollDepth.spec.js` (6): debounced send; furthest position only;
  re-send when depth grows but not when unchanged; flush on tab-hide; no send
  without a recorded position or API base; stable session id in the payload.
- Vitest `MessageList` (73) - unaffected by the new scroll handler.
- Go `TestRecordScrollDepth_SessionUpsertKeepsMax`: repeat reports for one session
  collapse to a single row keeping the max; existing scroll tests still pass.
