### PR TITLE
fix(modtools): clearer digest click-by-position chart

### DIFF
--- a/iznik-nuxt3/modtools/components/ModSysAdminDigestClicks.vue
+++ b/iznik-nuxt3/modtools/components/ModSysAdminDigestClicks.vue
@@ -1,16 +1,17 @@
 <template>
   <div class="digest-clicks">
     <p class="text-muted">
-      How far down the daily digest do people click? Each post in a digest is
-      tracked with its position (1 = top). This shows the
-      <strong>click-through rate</strong> — the percentage of digests displaying
-      a post at each position where the recipient clicked that post — so you can
-      see how a post's position affects engagement.
+      How far down the daily digest do people click? For each post position (1 =
+      top), this is the <strong>click-through rate</strong>:
+      <em
+        >clicks &divide; the number of digests that actually showed a post at
+        that position</em
+      >. So it already controls for the fact that far fewer digests are long
+      enough to have a post low down — a position with a tiny denominator isn't
+      compared on raw clicks. Positions whose sample is too small to be
+      meaningful are left off.
     </p>
 
-    <!-- Date range filter. We only ever analyse the DAILY digest: immediate digests
-         contain a single post, so they are always position 1 and tell us nothing about
-         how position affects clicks. -->
     <ModEmailDateFilter
       :loading="emailTrackingStore.digestPositionsLoading"
       fetch-label="Fetch"
@@ -43,30 +44,18 @@
         {{ insight }}
       </NoticeMessage>
 
-      <!-- Chart -->
-      <div class="chart-container mb-4">
+      <!-- Chart: click-through rate by position (adequate-sample positions only) -->
+      <div class="chart-container mb-2">
         <GChart
           type="ComboChart"
-          :data="emailTrackingStore.digestPositionsChartData"
+          :data="chartData"
           :options="getPositionChartOptions()"
           class="chart"
         />
       </div>
 
-      <!-- Detail table -->
-      <b-table
-        :items="tableRows"
-        :fields="tableFields"
-        striped
-        hover
-        responsive
-        small
-      />
-      <p class="text-muted small">
-        <strong>Emails shown</strong> is the number of digests that displayed a
-        post at that position (the click-through denominator).
-        <strong>Clicked</strong> counts the distinct digests where the recipient
-        clicked the post at that position.
+      <p v-if="summary" class="text-muted small">
+        {{ summary }}
       </p>
     </template>
 
@@ -95,39 +84,83 @@ const endDate = ref('')
 // analysis is meaningless for them. Fixed, not user-selectable.
 const digestType = ref('UnifiedDigestDaily')
 
-const tableFields = [
-  { key: 'position', label: 'Position', sortable: true },
-  { key: 'shown', label: 'Emails shown', sortable: true },
-  { key: 'clicks', label: 'Total clicks', sortable: true },
-  { key: 'emails_clicked', label: 'Clicked', sortable: true },
-  { key: 'ctr', label: 'Click-through rate', sortable: true },
-]
+// Minimum number of digests that must have shown a post at a position for its
+// click-through rate to be trustworthy. Deep positions appear in very few
+// digests, so a single click swings the rate wildly (a position seen 30 times
+// with one click reads as "3%"); plotting those produces meaningless spikes.
+// We require an absolute floor AND a fraction of the top position's sample, so
+// the cutoff scales with the period.
+const MIN_SAMPLE_ABS = 1000
+const MIN_SAMPLE_FRACTION = 0.01
 
-const tableRows = computed(() =>
-  (emailTrackingStore.digestPositions || []).map((p) => ({
-    position: (p.position ?? 0) + 1,
-    shown: (p.shown || 0).toLocaleString(),
-    clicks: (p.clicks || 0).toLocaleString(),
-    emails_clicked: (p.emails_clicked || 0).toLocaleString(),
-    ctr: `${(p.ctr || 0).toFixed(1)}%`,
-  }))
+const minSample = computed(() => {
+  const rows = emailTrackingStore.digestPositions || []
+  const top = rows.length ? rows[0].shown || 0 : 0
+  return Math.max(MIN_SAMPLE_ABS, Math.round(top * MIN_SAMPLE_FRACTION))
+})
+
+// Positions with a big enough sample to plot, in order.
+const significantPositions = computed(() =>
+  (emailTrackingStore.digestPositions || []).filter(
+    (p) => (p.shown || 0) >= minSample.value
+  )
 )
 
-// A plain-English takeaway comparing the top position to the rest.
-const insight = computed(() => {
+// Chart data: a single series - click-through rate vs position. No second axis;
+// the "emails shown" denominator is context, not a co-equal series to read off.
+const chartData = computed(() => {
+  const header = ['Position', 'Click-through rate (%)']
+  const rows = significantPositions.value.map((p) => [
+    (p.position ?? 0) + 1,
+    Number((p.ctr || 0).toFixed(3)),
+  ])
+  return [header, ...rows]
+})
+
+// One-line context under the chart: how much data, and where we stopped.
+const summary = computed(() => {
   const rows = emailTrackingStore.digestPositions || []
-  if (rows.length < 2) return null
-  const first = rows[0]
-  const last = rows[rows.length - 1]
-  if (!first.ctr) return null
-  const drop = first.ctr - last.ctr
-  if (drop <= 0) return null
-  const pct = Math.round((drop / first.ctr) * 100)
+  if (!rows.length) return null
+  const totalDigests = rows[0].shown || 0
+  const sig = significantPositions.value
+  if (!sig.length) return null
+  const lastPos = (sig[sig.length - 1].position ?? 0) + 1
   return (
-    `The top post is clicked ${first.ctr.toFixed(1)}% of the time, ` +
-    `falling to ${last.ctr.toFixed(1)}% by position ${last.position + 1} — ` +
-    `${pct}% lower. Posts further down the digest get fewer clicks.`
+    `Based on ${totalDigests.toLocaleString()} daily digests. ` +
+    `Shown to position ${lastPos} - beyond that, fewer than ` +
+    `${minSample.value.toLocaleString()} digests reached that depth, ` +
+    `so the rate is too noisy to plot.`
   )
+})
+
+// Plain-English takeaway: describe the actual shape of the decline using only
+// well-sampled positions, rather than the noisy deepest row.
+const insight = computed(() => {
+  const sig = significantPositions.value
+  if (sig.length < 2) return null
+  const first = sig[0]
+  if (!first.ctr) return null
+
+  const last = sig[sig.length - 1]
+  // Only describe a decline if there actually is one.
+  if (last.ctr >= first.ctr) return null
+
+  const at = (displayPos) =>
+    sig.find((p) => (p.position ?? 0) + 1 === displayPos)
+  const five = at(5) || sig[Math.min(4, sig.length - 1)]
+  const lastPos = (last.position ?? 0) + 1
+
+  let msg = `The top post is clicked ${first.ctr.toFixed(2)}% of the time`
+  if (five && five !== first) {
+    const halvedPos = (five.position ?? 0) + 1
+    msg += `, roughly halving to ${five.ctr.toFixed(
+      2
+    )}% by position ${halvedPos}`
+  }
+  msg +=
+    `, and it keeps declining - down to ${last.ctr.toFixed(2)}% by position ` +
+    `${lastPos}. Clicks fall off steadily with depth rather than levelling off.`
+  return msg
 })
 
 function fetchData() {
@@ -148,32 +181,18 @@ function onFilterFetch({ start, end }) {
 function getPositionChartOptions() {
   return {
     title: 'Click-through rate by position in the digest',
-    seriesType: 'bars',
-    legend: { position: 'bottom' },
-    chartArea: { width: '80%', height: '70%' },
+    legend: { position: 'none' },
+    chartArea: { width: '82%', height: '72%' },
     hAxis: {
       title: 'Position in digest (1 = top)',
     },
-    vAxes: {
-      0: {
-        title: 'Click-through rate (%)',
-        viewWindow: { min: 0 },
-        format: '#.#',
-      },
-      1: {
-        title: 'Emails shown',
-        viewWindow: { min: 0 },
-      },
+    vAxis: {
+      title: 'Click-through rate (%)',
+      viewWindow: { min: 0 },
+      format: '#.##',
     },
     series: {
-      0: { type: 'bars', targetAxisIndex: 0, color: '#17a2b8' },
-      1: {
-        type: 'line',
-        targetAxisIndex: 1,
-        color: '#adb5bd',
-        lineDashStyle: [4, 4],
-        pointSize: 3,
-      },
+      0: { type: 'line', color: '#17a2b8', lineWidth: 2, pointSize: 0 },
     },
     animation: { startup: true, duration: 500, easing: 'out' },
   }
@@ -182,8 +201,10 @@ function getPositionChartOptions() {
 // Exposed for unit testing.
 defineExpose({
   digestType,
-  tableFields,
-  tableRows,
+  minSample,
+  significantPositions,
+  chartData,
+  summary,
   insight,
   fetchData,
   onFilterFetch,

--- a/iznik-nuxt3/tests/unit/components/modtools/ModSysAdminDigestClicks.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModSysAdminDigestClicks.spec.js
@@ -9,7 +9,6 @@ const mockEmailTrackingStore = {
   digestPositionsLoading: false,
   digestPositionsError: null,
   hasDigestPositions: false,
-  digestPositionsChartData: null,
   setFilters: vi.fn(),
   fetchDigestPositions: vi.fn().mockResolvedValue({}),
 }
@@ -39,23 +38,7 @@ describe('ModSysAdminDigestClicks', () => {
               '<div class="notice-message" :class="variant"><slot /></div>',
             props: ['variant'],
           },
-          'b-form-select': {
-            template:
-              '<select :value="modelValue" @change="$emit(\'update:modelValue\', $event.target.value); $emit(\'change\', $event.target.value)"><slot /></select>',
-            props: ['modelValue', 'options', 'size'],
-          },
           'b-spinner': { template: '<span class="spinner" />' },
-          'b-table': {
-            template: '<table class="table"><slot /></table>',
-            props: [
-              'items',
-              'fields',
-              'striped',
-              'hover',
-              'responsive',
-              'small',
-            ],
-          },
           GChart: {
             template: '<div class="gchart" :data-type="type" />',
             props: ['type', 'data', 'options'],
@@ -75,13 +58,15 @@ describe('ModSysAdminDigestClicks', () => {
     mockEmailTrackingStore.digestPositionsLoading = false
     mockEmailTrackingStore.digestPositionsError = null
     mockEmailTrackingStore.hasDigestPositions = false
-    mockEmailTrackingStore.digestPositionsChartData = null
   })
 
   describe('rendering', () => {
-    it('explains the click-through metric', () => {
+    it('explains the click-through metric and its denominator', () => {
       const wrapper = mountComponent()
       expect(wrapper.text()).toContain('click-through rate')
+      expect(wrapper.text().toLowerCase()).toContain(
+        'digests that actually showed a post'
+      )
     })
 
     it('renders the date filter', () => {
@@ -94,16 +79,34 @@ describe('ModSysAdminDigestClicks', () => {
       expect(wrapper.text()).toContain('No daily-digest click data available')
     })
 
-    it('shows the chart when data is present', async () => {
+    it('shows a single-series CTR chart when data is present', async () => {
       mockEmailTrackingStore.hasDigestPositions = true
-      mockEmailTrackingStore.digestPositionsChartData = [
-        ['Position', 'Click-through rate (%)', 'Emails shown'],
-        ['1', 50, 100],
+      mockEmailTrackingStore.digestPositions = [
+        {
+          position: 0,
+          shown: 200000,
+          emails_clicked: 1000,
+          clicks: 1200,
+          ctr: 0.5,
+        },
+        {
+          position: 1,
+          shown: 100000,
+          emails_clicked: 300,
+          clicks: 350,
+          ctr: 0.3,
+        },
       ]
       const wrapper = mountComponent()
       await wrapper.vm.$nextTick()
       expect(wrapper.find('.gchart').exists()).toBe(true)
       expect(wrapper.find('.gchart').attributes('data-type')).toBe('ComboChart')
+      // Two columns only - no "Emails shown" series.
+      expect(wrapper.vm.chartData[0]).toEqual([
+        'Position',
+        'Click-through rate (%)',
+      ])
+      expect(wrapper.vm.chartData[1]).toEqual([1, 0.5])
     })
 
     it('shows an error message when the store has an error', async () => {
@@ -121,62 +124,80 @@ describe('ModSysAdminDigestClicks', () => {
     })
   })
 
-  describe('tableRows', () => {
-    it('formats positions as 1-based and CTR as a percentage', () => {
+  describe('sample-size cutoff', () => {
+    it('drops positions whose sample is too small to trust', () => {
       mockEmailTrackingStore.digestPositions = [
-        { position: 0, shown: 1000, clicks: 520, emails_clicked: 500, ctr: 50 },
-        { position: 1, shown: 1000, clicks: 260, emails_clicked: 250, ctr: 25 },
+        { position: 0, shown: 200000, emails_clicked: 1000, ctr: 0.5 },
+        { position: 1, shown: 100000, emails_clicked: 300, ctr: 0.3 },
+        // Deep tail: a single click off 31 digests reads as 3.2% - noise.
+        { position: 329, shown: 31, emails_clicked: 1, ctr: 3.2 },
       ]
       const wrapper = mountComponent()
-      const rows = wrapper.vm.tableRows
-      expect(rows[0].position).toBe(1)
-      expect(rows[0].ctr).toBe('50.0%')
-      expect(rows[0].shown).toBe('1,000')
-      expect(rows[1].position).toBe(2)
-      expect(rows[1].ctr).toBe('25.0%')
+      expect(wrapper.vm.significantPositions.map((p) => p.position)).toEqual([
+        0, 1,
+      ])
+      // The 3.2% spike is not plotted.
+      expect(wrapper.vm.chartData.some((r) => r[1] === 3.2)).toBe(false)
     })
   })
 
   describe('insight', () => {
-    it('is null with fewer than two positions', () => {
+    it('is null with fewer than two well-sampled positions', () => {
       mockEmailTrackingStore.digestPositions = [
-        { position: 0, shown: 10, clicks: 5, emails_clicked: 5, ctr: 50 },
+        { position: 0, shown: 200000, emails_clicked: 1000, ctr: 0.5 },
+        { position: 329, shown: 31, emails_clicked: 1, ctr: 3.2 },
       ]
       const wrapper = mountComponent()
       expect(wrapper.vm.insight).toBeNull()
     })
 
-    it('describes the drop from the top position to the last', () => {
+    it('describes the decline using well-sampled positions, not the noisy tail', () => {
       mockEmailTrackingStore.digestPositions = [
-        { position: 0, shown: 100, clicks: 80, emails_clicked: 80, ctr: 80 },
-        { position: 2, shown: 100, clicks: 20, emails_clicked: 20, ctr: 20 },
+        { position: 0, shown: 200000, emails_clicked: 1160, ctr: 0.58 },
+        { position: 4, shown: 150000, emails_clicked: 345, ctr: 0.23 },
+        { position: 29, shown: 100000, emails_clicked: 70, ctr: 0.07 },
+        { position: 329, shown: 31, emails_clicked: 1, ctr: 3.2 },
       ]
       const wrapper = mountComponent()
       const text = wrapper.vm.insight
-      expect(text).toContain('80.0%')
-      expect(text).toContain('20.0%')
-      expect(text).toContain('position 3')
-      expect(text).toContain('75% lower')
+      expect(text).toContain('0.58%')
+      expect(text).toContain('position 5')
+      expect(text).toContain('0.07%')
+      expect(text).toContain('position 30')
+      expect(text).not.toContain('3.2') // the noisy tail spike is not used
+      expect(text.toLowerCase()).toContain('declin')
     })
 
-    it('is null when there is no drop (flat or rising)', () => {
+    it('is null when clicks do not decline', () => {
       mockEmailTrackingStore.digestPositions = [
-        { position: 0, shown: 100, clicks: 20, emails_clicked: 20, ctr: 20 },
-        { position: 1, shown: 100, clicks: 30, emails_clicked: 30, ctr: 30 },
+        { position: 0, shown: 200000, emails_clicked: 200, ctr: 0.1 },
+        { position: 1, shown: 150000, emails_clicked: 450, ctr: 0.3 },
       ]
       const wrapper = mountComponent()
       expect(wrapper.vm.insight).toBeNull()
     })
   })
 
+  describe('summary', () => {
+    it('reports the total digests and the cutoff position', () => {
+      mockEmailTrackingStore.digestPositions = [
+        { position: 0, shown: 200000, emails_clicked: 1000, ctr: 0.5 },
+        { position: 1, shown: 100000, emails_clicked: 300, ctr: 0.3 },
+      ]
+      const wrapper = mountComponent()
+      expect(wrapper.vm.summary).toContain('200,000')
+      expect(wrapper.vm.summary).toContain('position 2')
+    })
+  })
+
   describe('chart options', () => {
-    it('returns a ComboChart configuration with two axes', () => {
+    it('uses a single click-through-rate axis (no emails-shown axis)', () => {
       const wrapper = mountComponent()
       const options = wrapper.vm.getPositionChartOptions()
-      expect(options.seriesType).toBe('bars')
-      expect(options.vAxes[0].title).toBe('Click-through rate (%)')
-      expect(options.vAxes[1].title).toBe('Emails shown')
-      expect(options.series[1].type).toBe('line')
+      expect(options.vAxis.title).toBe('Click-through rate (%)')
+      expect(options.vAxes).toBeUndefined()
+      expect(options.series[0].type).toBe('line')
+      expect(options.series[1]).toBeUndefined()
     })
   })
 


### PR DESCRIPTION
## Summary

Reworks the sysadmin "Scrolling" tab's digest click-by-position chart, which
looked wrong on live data.

- **States the metric.** The intro now spells out: click-through rate = clicks
  &divide; the digests that actually showed a post at that position. 66% of daily
  digests contain a single post, so the denominator collapses after position 1 -
  raw click counts mislead, and this is already normalised for that.
- **Cuts the noisy tail.** Positions are plotted only where the sample is big
  enough to trust (>= 1,000 digests AND >= 1% of the top position's sample). That
  removes spikes like "3.2% at position 329" off a sample of 31.
- **Drops the distractions.** Removed the "Emails shown" secondary axis (it's the
  denominator, not a co-equal series) and the long per-position table. The chart
  is now a single click-through-rate line, with a one-line context note.
- **Honest headline.** Describes the real shape from well-sampled positions -
  steep early decline, roughly halving by ~position 5, continuing down - instead
  of "0% by position 576", which was a small-sample artefact. The insight is null
  when there is no genuine decline.

## Test Plan

- Vitest `ModSysAdminDigestClicks.spec.js` (13): normalization text; single-series
  CTR `chartData` (no emails-shown column); the sample-size cutoff drops the noisy
  tail; the insight uses well-sampled positions (not the spike) and is null with
  no decline; the summary reports totals + cutoff; single-axis chart options.
