### PR TITLE
fix: pin read-your-writes reads to the writer under the DB read/write split

### DIFF
--- a/iznik-batch/app/Models/User.php
+++ b/iznik-batch/app/Models/User.php
@@ -1121,6 +1121,14 @@ class User extends Model implements Auditable
             // --- Merge memberships ---
             $id2Memberships = Membership::where('userid', $id2)->get();
 
+            // Conflict memberships (id1 was already a member, so id2's row is merged
+            // into id1's and then removed) are collected here and deleted AFTER commit.
+            // We keep the in-memory models rather than re-querying by userid post-commit:
+            // under the read/write split that re-query hits a possibly-lagging replica,
+            // where a just-reparented membership can still show userid=$id2 and would be
+            // wrongly deleted, silently dropping a membership that should survive on id1.
+            $membershipsToDelete = [];
+
             # Merge the top-level memberships
             foreach ($id2Memberships as $id2Memb) {
                 $id1Memb = Membership::where('userid', $id1)
@@ -1159,6 +1167,9 @@ class User extends Model implements Auditable
                     if (!$dryRun) {
                         $id1Memb->save();
                     }
+
+                    // id2's row for this group is now redundant — delete it after commit.
+                    $membershipsToDelete[] = $id2Memb;
                 }
             }
 
@@ -1522,12 +1533,16 @@ class User extends Model implements Auditable
         # Make sure we don't pick up an old cached version, as we've just changed it quite a bit.
         try {
             Logger::info("Merged {$id1} < {$id2}, {$reason}");
-            Membership::where('userid', $id2)->get()->each(function ($m) use ($dryRun) {
+            // Delete the conflict memberships collected during the merge loop above.
+            // These are in-memory models, so $m->delete() removes them by primary key
+            // (firing model events for auditing) WITHOUT a fresh SELECT — avoiding the
+            // read-split replica-lag hazard described where $membershipsToDelete is built.
+            foreach ($membershipsToDelete as $m) {
                 Logger::info("TN-SYNC-TRACE [WRITE] table=memberships op=delete where=userid={$m->userid},groupid={$m->groupid}");
                 if (!$dryRun) {
                     $m->delete();
                 }
-            });
+            }
             Logger::info("TN-SYNC-TRACE [WRITE] table=users op=delete where=id={$id2}");
             if (!$dryRun) {
                 User::find($id2)?->delete();

--- a/iznik-batch/app/Services/Mail/Incoming/IncomingMailService.php
+++ b/iznik-batch/app/Services/Mail/Incoming/IncomingMailService.php
@@ -2128,7 +2128,12 @@ class IncomingMailService
                 // visible link. Without the lookup the chat message exists
                 // but ModTools wouldn't be able to show the original SMTP
                 // source.
+                // useWritePdo: a concurrent sibling process inserted this row on the
+                // write host. Under the read/write split a plain read could hit a
+                // lagging replica that hasn't applied that insert yet, returning null
+                // and dropping the chat-message-to-SMTP-source link.
                 $existingId = DB::table('messages')
+                    ->useWritePdo()
                     ->where('messageid', $messageId)
                     ->value('id');
                 if ($existingId) {
@@ -3982,15 +3987,20 @@ class IncomingMailService
      */
     private function addToSpatialIndex(int $messageId, int $groupId): void
     {
-        $message = Message::find($messageId);
+        // useWritePdo: this runs immediately after the message is created and its
+        // messages_groups row set to Approved (see routeToGroup). Under the read/write
+        // split a plain read could hit a lagging replica and return null, silently
+        // skipping the spatial-index entry until the reconciler cron catches up.
+        $message = Message::query()->useWritePdo()->find($messageId);
         if (! $message || (! $message->lat && ! $message->lng)) {
             return;
         }
 
         $srid = config('freegle.srid', 3857);
 
-        // Get arrival from messages_groups
+        // Get arrival from messages_groups (same read-your-write reasoning as above).
         $mg = DB::table('messages_groups')
+            ->useWritePdo()
             ->where('msgid', $messageId)
             ->where('groupid', $groupId)
             ->first();

--- a/iznik-batch/app/Services/SpamCleanupService.php
+++ b/iznik-batch/app/Services/SpamCleanupService.php
@@ -135,7 +135,12 @@ class SpamCleanupService
         if (!empty($msgs)) {
             $msgIds = array_unique(array_column($msgs, 'id'));
             foreach ($msgIds as $msgId) {
+                // useWritePdo: this count gates the parent-message soft-delete below,
+                // and it reads the rows we just UPDATEd to deleted=1 above. Under the
+                // read/write split a plain read could hit a lagging replica that still
+                // shows those rows as deleted=0, leaving the spam message live.
                 $remainingGroups = DB::table('messages_groups')
+                    ->useWritePdo()
                     ->where('msgid', $msgId)
                     ->where('deleted', 0)
                     ->count();

--- a/iznik-batch/tests/Unit/Models/UserMergeTest.php
+++ b/iznik-batch/tests/Unit/Models/UserMergeTest.php
@@ -107,6 +107,52 @@ class UserMergeTest extends TestCase
         $this->assertEquals(0, DB::table('memberships')->where('userid', $user2->id)->count());
     }
 
+    /**
+     * Mixed case: user2 has both a UNIQUE membership (reparented to user1) and a
+     * CONFLICT membership (shared group, merged into user1's row then removed).
+     * This exercises the post-commit cleanup path: the reparented membership must
+     * survive on user1 while only the conflict row is deleted. Under the read/write
+     * split, re-querying user2's memberships after commit could read a lagging
+     * replica and wrongly delete the just-reparented row — this guards against that
+     * by asserting the reparented membership still belongs to user1.
+     */
+    public function test_merge_keeps_reparented_membership_when_also_merging_conflict(): void
+    {
+        $user1 = $this->createTestUser();
+        $user2 = $this->createTestUser();
+        $sharedGroup = $this->createTestGroup();
+        $uniqueGroup = $this->createTestGroup();
+
+        // Conflict: both are members of sharedGroup (user2 is Moderator).
+        $this->createMembership($user1, $sharedGroup, ['role' => Membership::ROLE_MEMBER]);
+        $this->createMembership($user2, $sharedGroup, ['role' => Membership::ROLE_MODERATOR]);
+
+        // Reparent: only user2 is a member of uniqueGroup.
+        $this->createMembership($user2, $uniqueGroup);
+
+        $this->assertTrue(User::merge($user1->id, $user2->id, self::MERGE_REASON));
+
+        // user1 keeps both groups; user2 has none left.
+        $this->assertEquals(2, DB::table('memberships')->where('userid', $user1->id)->count());
+        $this->assertEquals(0, DB::table('memberships')->where('userid', $user2->id)->count());
+
+        // The reparented (unique) membership must have survived on user1.
+        $this->assertTrue(
+            DB::table('memberships')
+                ->where('userid', $user1->id)
+                ->where('groupid', $uniqueGroup->id)
+                ->exists(),
+            'Reparented membership for the unique group must survive on user1'
+        );
+
+        // The conflict membership merged into user1 keeping the highest role.
+        $sharedRole = DB::table('memberships')
+            ->where('userid', $user1->id)
+            ->where('groupid', $sharedGroup->id)
+            ->value('role');
+        $this->assertEquals(Membership::ROLE_MODERATOR, $sharedRole);
+    }
+
     public function test_merge_transfers_messages(): void
     {
         $user1 = $this->createTestUser();

--- a/iznik-server-go/chat/chatmessage.go
+++ b/iznik-server-go/chat/chatmessage.go
@@ -17,6 +17,7 @@ import (
 	"github.com/freegle/iznik-server-go/utils"
 	"github.com/gofiber/fiber/v2"
 	"gorm.io/gorm"
+	"gorm.io/plugin/dbresolver"
 )
 
 // =============================================================================
@@ -1212,7 +1213,11 @@ func updateMessageCounts(db *gorm.DB, chatID uint64) {
 	}
 
 	var counts []countRow
-	db.Raw("SELECT CASE WHEN reviewrequired = 0 AND reviewrejected = 0 AND processingsuccessful = 1 THEN 1 ELSE 0 END AS valid, "+
+	// Pin to the write host: callers invoke this immediately after UPDATEing
+	// chat_messages.reviewrequired/reviewrejected on the source, and these recounted
+	// totals are written back to chat_rooms. A lagging replica read would persist
+	// stale valid/invalid counts that survive until the next approve/reject.
+	db.Clauses(dbresolver.Write).Raw("SELECT CASE WHEN reviewrequired = 0 AND reviewrejected = 0 AND processingsuccessful = 1 THEN 1 ELSE 0 END AS valid, "+
 		"COUNT(*) AS count FROM chat_messages WHERE chatid = ? "+
 		"GROUP BY CASE WHEN reviewrequired = 0 AND reviewrejected = 0 AND processingsuccessful = 1 THEN 1 ELSE 0 END",
 		chatID).Scan(&counts)

--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -32,6 +32,7 @@ import (
 	"github.com/golang-jwt/jwt/v4"
 	"golang.org/x/net/html"
 	"gorm.io/gorm"
+	"gorm.io/plugin/dbresolver"
 )
 
 // Pre-compiled regexps to avoid recompiling on every message fetch.
@@ -1857,7 +1858,12 @@ func addApprovedMessageToSpatialIndex(db *gorm.DB, msgid uint64) {
 		Arrival string
 	}
 	var rows []spatialRow
-	db.Raw("SELECT messages.lat AS lat, messages.lng AS lng, messages.type AS msgtype, "+
+	// Pin to the write host: the caller has just UPDATEd messages_groups.collection
+	// to Approved on the source. Under the read/write split a plain SELECT would be
+	// routed to the read replica, which may not have applied that write yet (Galera
+	// apply-lag), so the row would be missed and the post left out of the spatial
+	// index until the periodic reconciler runs.
+	db.Clauses(dbresolver.Write).Raw("SELECT messages.lat AS lat, messages.lng AS lng, messages.type AS msgtype, "+
 		"messages_groups.groupid AS groupid, "+
 		"DATE_FORMAT(messages_groups.arrival, '%Y-%m-%d %H:%i:%s') AS arrival "+
 		"FROM messages "+
@@ -1915,8 +1921,10 @@ func handleApprove(c *fiber.Ctx, myid uint64, req PostMessageRequest) error {
 	db.Exec("UPDATE messages_groups SET heldby = NULL WHERE msgid = ? AND groupid IN ?", req.ID, authorizedGroups)
 
 	// Check if still held on any group — if not, clear messages.heldby for backwards compat.
+	// Pin to the write host: this gates a cascade on rows we just UPDATEd, so it must
+	// read the source rather than a possibly-lagging replica.
 	var stillHeldCount int64
-	db.Raw("SELECT COUNT(*) FROM messages_groups WHERE msgid = ? AND heldby IS NOT NULL", req.ID).Scan(&stillHeldCount)
+	db.Clauses(dbresolver.Write).Raw("SELECT COUNT(*) FROM messages_groups WHERE msgid = ? AND heldby IS NOT NULL", req.ID).Scan(&stillHeldCount)
 	if stillHeldCount == 0 {
 		db.Exec("UPDATE messages SET heldby = NULL WHERE id = ?", req.ID)
 	}
@@ -2066,7 +2074,9 @@ func handleReject(c *fiber.Ctx, myid uint64, req PostMessageRequest) error {
 		// Cascade soft-delete: if no non-deleted groups remain, mark messages.deleted
 		// so list queries filtering `messages.deleted IS NULL` don't see an orphan row.
 		var remainingGroups int64
-		db.Raw("SELECT COUNT(*) FROM messages_groups WHERE msgid = ? AND deleted = 0", req.ID).Scan(&remainingGroups)
+		// Pin to the write host: this gates the parent-message soft-delete on rows we
+	// just modified, so it must read the source, not a possibly-lagging replica.
+	db.Clauses(dbresolver.Write).Raw("SELECT COUNT(*) FROM messages_groups WHERE msgid = ? AND deleted = 0", req.ID).Scan(&remainingGroups)
 		if remainingGroups == 0 {
 			if result := db.Exec("UPDATE messages SET deleted = NOW(), messageid = NULL WHERE id = ?", req.ID); result.Error != nil {
 				log.Printf("Failed to soft-delete rejected message %d: %v", req.ID, result.Error)
@@ -2175,7 +2185,9 @@ func handleDeleteMessage(c *fiber.Ctx, myid uint64, req PostMessageRequest) erro
 
 	// If no non-deleted groups remain, soft-delete the message itself.
 	var remainingGroups int64
-	db.Raw("SELECT COUNT(*) FROM messages_groups WHERE msgid = ? AND deleted = 0", req.ID).Scan(&remainingGroups)
+	// Pin to the write host: this gates the parent-message soft-delete on rows we
+	// just modified, so it must read the source, not a possibly-lagging replica.
+	db.Clauses(dbresolver.Write).Raw("SELECT COUNT(*) FROM messages_groups WHERE msgid = ? AND deleted = 0", req.ID).Scan(&remainingGroups)
 	if remainingGroups == 0 {
 		if result := db.Exec("UPDATE messages SET deleted = NOW(), messageid = NULL WHERE id = ?", req.ID); result.Error != nil {
 			log.Printf("Failed to soft-delete message %d: %v", req.ID, result.Error)
@@ -2238,7 +2250,9 @@ func handleSpam(c *fiber.Ctx, myid uint64, req PostMessageRequest) error {
 
 	// If no non-deleted groups remain, soft-delete the message itself.
 	var remainingGroups int64
-	db.Raw("SELECT COUNT(*) FROM messages_groups WHERE msgid = ? AND deleted = 0", req.ID).Scan(&remainingGroups)
+	// Pin to the write host: this gates the parent-message soft-delete on rows we
+	// just modified, so it must read the source, not a possibly-lagging replica.
+	db.Clauses(dbresolver.Write).Raw("SELECT COUNT(*) FROM messages_groups WHERE msgid = ? AND deleted = 0", req.ID).Scan(&remainingGroups)
 	if remainingGroups == 0 {
 		db.Exec("UPDATE messages SET deleted = NOW() WHERE id = ?", req.ID)
 
@@ -2345,8 +2359,10 @@ func handleRelease(c *fiber.Ctx, myid uint64, req PostMessageRequest) error {
 	db.Exec("UPDATE messages_groups SET heldby = NULL WHERE msgid = ? AND groupid IN ?", req.ID, authorizedGroups)
 
 	// Check if still held on any group — if not, clear messages.heldby for backwards compat.
+	// Pin to the write host: this gates a cascade on rows we just UPDATEd, so it must
+	// read the source rather than a possibly-lagging replica.
 	var stillHeldCount int64
-	db.Raw("SELECT COUNT(*) FROM messages_groups WHERE msgid = ? AND heldby IS NOT NULL", req.ID).Scan(&stillHeldCount)
+	db.Clauses(dbresolver.Write).Raw("SELECT COUNT(*) FROM messages_groups WHERE msgid = ? AND heldby IS NOT NULL", req.ID).Scan(&stillHeldCount)
 	if stillHeldCount == 0 {
 		db.Exec("UPDATE messages SET heldby = NULL WHERE id = ?", req.ID)
 	}
@@ -2701,7 +2717,10 @@ func handleJoinAndPost(c *fiber.Ctx, myid uint64, req PostMessageRequest) error 
 	// This catches pre-validation drafts created before PUT /message required
 	// item, and any other path that leaves subject empty by submit time.
 	var finalSubject string
-	db.Raw("SELECT COALESCE(subject, '') FROM messages WHERE id = ?", req.ID).Scan(&finalSubject)
+	// Pin to the write host: we may have just UPDATEd messages.subject above, and this
+	// read gates a hard validation error. A lagging replica could see the old/empty
+	// subject and wrongly reject a valid post.
+	db.Clauses(dbresolver.Write).Raw("SELECT COALESCE(subject, '') FROM messages WHERE id = ?", req.ID).Scan(&finalSubject)
 	if strings.TrimSpace(finalSubject) == "" {
 		return fiber.NewError(fiber.StatusBadRequest, "Item is required")
 	}
@@ -2728,7 +2747,9 @@ func handleJoinAndPost(c *fiber.Ctx, myid uint64, req PostMessageRequest) error 
 	// Record history entry for spam checking (V1 parity: Message::save() inserts into messages_history).
 	// We fetch user email/name from the DB since platform messages don't have envelope headers.
 	var histSubject string
-	db.Raw("SELECT COALESCE(subject, '') FROM messages WHERE id = ?", req.ID).Scan(&histSubject)
+	// Pin to the write host: this is the subject we may have just UPDATEd, written here
+	// into messages_history. A lagging replica read would persist a stale/empty subject.
+	db.Clauses(dbresolver.Write).Raw("SELECT COALESCE(subject, '') FROM messages WHERE id = ?", req.ID).Scan(&histSubject)
 	var histFromname string
 	db.Raw("SELECT COALESCE(fullname, '') FROM users WHERE id = ?", myid).Scan(&histFromname)
 	// V1 parity: submit() calls inventEmail() to get/create the user's @users.ilovefreegle.org


### PR DESCRIPTION
## Why

Follow-up to the recent `LastInsertId` fix (the insert-then-`SELECT`-the-id bug that caused the "mixed up offers" incident, [Discourse 9832](https://discourse.ilovefreegle.org/t/9832)). That fix closed the *re-read an auto-increment id* case. This PR closes a **second, related class** the audit turned up: code that writes rows and then immediately reads those same rows back **outside a transaction** to gate a follow-up action.

Under our read/write split this is unsafe:

- **Go** (`iznik-server-go`, GORM + `dbresolver`): plain `SELECT` is routed to the read replica; everything else (and any transaction) goes to the write host. There is **no per-connection stickiness**, so an `UPDATE`/`DELETE` followed by a plain `SELECT` of the same rows can read a replica that hasn't applied the write yet.
- **Laravel** (`iznik-batch`, `read`/`write` connections, `sticky => false`): there is **no read-your-writes within a request** — a `SELECT` after a write goes to the read host. Only reads inside an open `DB::transaction()` are pinned to the writer.

The DB is a Galera cluster: replication is synchronous at commit (certification) but **apply on the replica is asynchronous**, so there is a real window after a committed write where another node's read does not yet see it. That window is exactly what bit us before.

## What

### Go — `.Clauses(dbresolver.Write)` on the gating read
- `message.go` moderation handlers — the "write a flag to `messages_groups`, then `COUNT` `messages_groups` to decide whether to cascade to `messages`" pattern:
  - `handleApprove` / `handleRelease` (the `heldby` count that clears `messages.heldby`)
  - `handleReject` / `handleDeleteMessage` / `handleSpam` (the `deleted` count that soft-deletes the parent message)
  - `addApprovedMessageToSpatialIndex` (reads `collection` just set to `Approved`; a stale read leaves the post out of the spatial/browse index)
  - `handleJoinAndPost` (two re-reads of `messages.subject` just written — one gates a hard "Item is required" rejection, one is persisted into `messages_history`)
- `chat/chatmessage.go` `updateMessageCounts` — recount of `chat_messages` immediately after setting `reviewrequired=0`, written back to `chat_rooms`.

### Laravel
- **`User::merge`** (highest impact). The post-commit membership cleanup re-queried `Membership::where('userid', $id2)` on the replica and, under apply-lag, could **delete just-reparented memberships** (silent data loss on `id1`). Now the conflict membership models are collected **in-memory during the merge loop** and those specific rows are deleted after commit — no stale re-query, and it preserves the author's deliberate "delete outside the transaction" choice. New test `test_merge_keeps_reparented_membership_when_also_merging_conflict` covers the mixed reparent+conflict case.
- **`SpamCleanupService::deleteSpamMessages`** — the cascade-gating count → `useWritePdo()`.
- **`IncomingMailService`** — the sibling-race `messageid` lookup and the `addToSpatialIndex` re-reads → `useWritePdo()`.

## Safety

`.Clauses(dbresolver.Write)` and `useWritePdo()` are **no-ops when no read replica is configured** (dev/CI run a single host), so behaviour is byte-identical there. The audit also confirmed the codebase otherwise uses safe patterns throughout (`LastInsertId` / `insertGetId` / `$model->id` / in-memory attributes), so this is a targeted set of fixes, not a sweeping change.

## Tests

- Go suite: all pass.
- Laravel suite: all pass (incl. the new merge test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)