### PR TITLE
fix(ripple): don't gate rippled-copy retraction on the trial area scope

### DIFF
--- a/iznik-batch/app/Services/Ripple/ExpandService.php
+++ b/iznik-batch/app/Services/Ripple/ExpandService.php
@@ -69,10 +69,16 @@ class ExpandService
         //    their origin group, withdrawn, expired or deleted (Taken/Received stay in
         //    messages_spatial and are excluded): drop reach AND pull every rippled-in copy,
         //    removing now-purposeless ripple-joined memberships.
-        $this->removeStaleAndRetract($dryRun, $stats, $onlyMsgid, $withinPolyWkt);
+        // Retraction is deliberately NOT area-scoped (only --msgid restricts it). A rippled_in
+        // copy is a committed artifact whose cleanup must complete even after the post's origin
+        // group leaves the trial - at which point its origin drops out of $withinPolyWkt. Area-
+        // scoping the retraction stranded copies in receiving groups when a group was removed
+        // from the experiment (poster had already left, but the post stayed live there). See
+        // ExpandServiceTest::test_*_retraction_*_not_gated_by_current_area_scope.
+        $this->removeStaleAndRetract($dryRun, $stats, $onlyMsgid);
         // 1b. Pull rippled-in posts from any group whose poster has actively left it, so a
         //     leave removes the poster's post from that group (not just their membership).
-        $this->pullRippledPostsFromLeftGroups($dryRun, $stats, $onlyMsgid, $withinPolyWkt);
+        $this->pullRippledPostsFromLeftGroups($dryRun, $stats, $onlyMsgid);
 
         // 2. Initialise reach for posts new to messages_spatial.
         $this->initialiseNew($dryRun, $limit, $stats, $onlyMsgid, $withinPolyWkt);
@@ -92,11 +98,12 @@ class ExpandService
      * stops further expansion and lets ripple:release-replies treat the post as gone, releasing
      * any held replies) and retract every rippled-in copy (see retractRippledCopiesForRemovedPost).
      *
-     * Scope-aware: a scoped run restricts removal to the in-scope subset (onlyMsgid, or reach
-     * origin within withinPolyWkt — the same filter advanceDue uses), so the group experiment
-     * retracts correctly. $stats['removed'] keeps its meaning: reach rows dropped.
+     * Scope: only --msgid restricts this (controlled single-post testing). It is intentionally
+     * NOT area-scoped - retracting an already-rippled copy must complete regardless of whether the
+     * post's origin is still inside the current trial polygon, otherwise copies are stranded in
+     * receiving groups when a group leaves the experiment. $stats['removed'] = reach rows dropped.
      */
-    private function removeStaleAndRetract(bool $dryRun, array &$stats, ?int $onlyMsgid = null, ?string $withinPolyWkt = null): void
+    private function removeStaleAndRetract(bool $dryRun, array &$stats, ?int $onlyMsgid = null): void
     {
         try {
             $scopeSql = '';
@@ -104,9 +111,6 @@ class ExpandService
             if ($onlyMsgid !== null) {
                 $scopeSql = ' AND mr.msgid = ?';
                 $params[] = $onlyMsgid;
-            } elseif ($withinPolyWkt !== null) {
-                $scopeSql = ' AND ST_Contains(ST_GeomFromText(?, ' . self::SRID . '), ST_SRID(POINT(mr.lng, mr.lat), ' . self::SRID . '))';
-                $params[] = $withinPolyWkt;
             }
 
             $stale = DB::select(
@@ -826,19 +830,18 @@ class ExpandService
      * rows); the membership re-join and any future re-ripple are blocked by the same
      * most-recent-join-wins rule. Best-effort: never breaks the run.
      */
-    private function pullRippledPostsFromLeftGroups(bool $dryRun, array &$stats, ?int $onlyMsgid = null, ?string $withinPolyWkt = null): void
+    private function pullRippledPostsFromLeftGroups(bool $dryRun, array &$stats, ?int $onlyMsgid = null): void
     {
         try {
-            // Scope-aware so this runs under a scoped (group-experiment) run too: restrict to the
-            // chosen post, or to posts whose origin point falls inside the area polygon.
+            // Scope: only --msgid restricts this (controlled single-post testing). Deliberately NOT
+            // area-scoped - a poster who left a rippled-into group must have their post pulled even
+            // after the post's origin group leaves the trial (its origin then falls outside the
+            // current area), otherwise the copy is stranded in a group they explicitly opted out of.
             $scopeSql = '';
             $params = [];
             if ($onlyMsgid !== null) {
                 $scopeSql = ' AND mg.msgid = ?';
                 $params[] = $onlyMsgid;
-            } elseif ($withinPolyWkt !== null) {
-                $scopeSql = ' AND ST_Contains(ST_GeomFromText(?, ' . self::SRID . '), ST_SRID(POINT(m.lng, m.lat), ' . self::SRID . '))';
-                $params[] = $withinPolyWkt;
             }
 
             $rows = DB::select(

--- a/iznik-batch/tests/Unit/Services/Ripple/ExpandServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/Ripple/ExpandServiceTest.php
@@ -1026,6 +1026,98 @@ class ExpandServiceTest extends TestCase
         ]);
     }
 
+    /**
+     * Regression (Discourse rippling-out #176/#179, msg 117580503): the group experiment runs
+     * SCOPED (global rippling off). A post rippled into B while its origin group was in the trial;
+     * the poster then LEFT B; later the origin group was REMOVED from the trial, so the post's
+     * origin fell OUTSIDE the current scope union. The leave-retraction must STILL pull the copy -
+     * cleanup of a committed rippled_in artifact is not gated by the current area scope, otherwise
+     * the post is stranded in a group the poster explicitly opted out of.
+     */
+    public function test_leave_retraction_is_not_gated_by_current_area_scope(): void
+    {
+        config(['freegle.ripple.enabled' => false]); // mirror production: scoped experiment only
+        $this->fakeRouting(3);
+        $msgid = $this->seedSpatialPost(now()->subMinutes(30)); // origin (51.5, -0.1) London
+        $posterId = (int) DB::table('messages')->where('id', $msgid)->value('fromuser');
+
+        $groupB = $this->createTestGroup();
+        DB::statement(
+            "UPDATE `groups` SET publish = 1, polyindex = ST_GeomFromText(?, ?) WHERE id = ?",
+            ['POLYGON((-0.18 51.52,-0.12 51.52,-0.12 51.58,-0.18 51.58,-0.18 51.52))', 3857, $groupB->id]
+        );
+
+        // Origin group still in the trial: scope union COVERS the origin -> post ripples into B,
+        // poster auto-joined (Group/Joined text='Rippled').
+        $coveringScope = 'POLYGON((-0.30 51.40,0.10 51.40,0.10 51.70,-0.30 51.70,-0.30 51.40))';
+        $this->service()->process(false, 500, null, $coveringScope);
+        $row = DB::table('messages_groups')->where('msgid', $msgid)->where('groupid', $groupB->id)->first();
+        $this->assertNotNull($row, 'precondition: post rippled into B');
+        $this->assertSame(0, (int) $row->deleted, 'precondition: rippled-in row live before leave');
+
+        // Poster leaves B (Go leave path: delete membership + Group/Left log).
+        DB::table('memberships')->where('userid', $posterId)->where('groupid', $groupB->id)->delete();
+        DB::table('logs')->insert([
+            'timestamp' => now(), 'type' => 'Group', 'subtype' => 'Left',
+            'user' => $posterId, 'groupid' => $groupB->id,
+        ]);
+
+        // Origin group REMOVED from the trial: the scope union no longer covers the post's origin
+        // (a far-away Edinburgh polygon). Retraction must still run.
+        $nonCoveringScope = 'POLYGON((-3.30 55.90,-3.10 55.90,-3.10 56.00,-3.30 56.00,-3.30 55.90))';
+        $stats = $this->service()->process(false, 500, null, $nonCoveringScope);
+
+        $row = DB::table('messages_groups')->where('msgid', $msgid)->where('groupid', $groupB->id)->first();
+        $this->assertSame(1, (int) $row->deleted,
+            'rippled copy must be pulled on leave even though the origin is outside the current trial scope');
+        $this->assertGreaterThanOrEqual(1, $stats['pulled_on_leave']);
+        $this->assertDatabaseHas('logs', [
+            'type' => 'Message', 'subtype' => 'Deleted', 'user' => $posterId,
+            'groupid' => $groupB->id, 'msgid' => $msgid, 'text' => 'Rippling: removed on leave',
+        ]);
+    }
+
+    /**
+     * Companion to the leave case: when the origin post leaves the browsable set (withdrawn / taken
+     * / deleted) AFTER its origin group has left the trial, removeStaleAndRetract must still drop the
+     * reach and retract the rippled copies - it is no longer area-scoped, so an out-of-scope origin
+     * does not leave stale reach rows and orphaned copies behind.
+     */
+    public function test_stale_origin_retraction_is_not_gated_by_current_area_scope(): void
+    {
+        config(['freegle.ripple.enabled' => false]);
+        $this->fakeRouting(3);
+        $msgid = $this->seedSpatialPost(now()->subMinutes(30)); // origin (51.5, -0.1) London
+        $posterId = (int) DB::table('messages')->where('id', $msgid)->value('fromuser');
+
+        $groupB = $this->createTestGroup();
+        DB::statement(
+            "UPDATE `groups` SET publish = 1, polyindex = ST_GeomFromText(?, ?) WHERE id = ?",
+            ['POLYGON((-0.18 51.52,-0.12 51.52,-0.12 51.58,-0.18 51.58,-0.18 51.52))', 3857, $groupB->id]
+        );
+
+        $coveringScope = 'POLYGON((-0.30 51.40,0.10 51.40,0.10 51.70,-0.30 51.70,-0.30 51.40))';
+        $this->service()->process(false, 500, null, $coveringScope);
+        $this->assertSame(1, DB::table('rippling_reach')->where('msgid', $msgid)->count(), 'precondition: reach exists');
+        $b = DB::table('messages_groups')->where('msgid', $msgid)->where('groupid', $groupB->id)->first();
+        $this->assertNotNull($b, 'precondition: post rippled into B');
+        $this->assertSame(0, (int) $b->deleted, 'precondition: rippled-in row live');
+
+        // The post leaves the browsable set (withdrawn/taken/deleted -> gone from messages_spatial).
+        DB::table('messages_spatial')->where('msgid', $msgid)->delete();
+
+        // Origin group removed from the trial: scope no longer covers the origin.
+        $nonCoveringScope = 'POLYGON((-3.30 55.90,-3.10 55.90,-3.10 56.00,-3.30 56.00,-3.30 55.90))';
+        $stats = $this->service()->process(false, 500, null, $nonCoveringScope);
+
+        $this->assertSame(0, DB::table('rippling_reach')->where('msgid', $msgid)->count(),
+            'reach dropped even though the origin is outside the current trial scope');
+        $b = DB::table('messages_groups')->where('msgid', $msgid)->where('groupid', $groupB->id)->first();
+        $this->assertSame(1, (int) $b->deleted,
+            'rippled copy retracted on origin removal regardless of the current area scope');
+        $this->assertGreaterThanOrEqual(1, $stats['removed']);
+    }
+
     /** The bundled intro email is claimed exactly once per post, even as more groups are added. */
     public function test_intro_email_claimed_once_per_post_across_groups(): void
     {
@@ -1510,8 +1602,15 @@ class ExpandServiceTest extends TestCase
         $this->assertSame(0, (int) DB::table('messages_groups')->where('msgid', $m2)->where('groupid', $g2)->value('deleted'), 'out-of-scope copy untouched');
     }
 
-    /** A scoped (withinPolyWkt) run retracts only posts whose origin falls inside the polygon. */
-    public function test_scoped_within_poly_retracts_only_posts_inside_polygon(): void
+    /**
+     * The withinPolyWkt area scope limits EXPANSION only, NOT retraction: a scoped run retracts
+     * EVERY stale post, including one whose origin is outside the polygon. (Previously this asserted
+     * the out-of-polygon post was left untouched - that area-scoped retraction stranded rippled
+     * copies when a group was removed from the trial; see the two _not_gated_by_current_area_scope
+     * tests and Discourse rippling-out #176/#179.) Area-scoped expansion is still covered by
+     * test_within_poly_restricts_run_to_posts_inside_polygon.
+     */
+    public function test_scoped_within_poly_does_not_limit_retraction(): void
     {
         Http::fake();
         [$london] = $this->seedStaleReachWithRippledCopy(51.5, -0.1);
@@ -1521,7 +1620,7 @@ class ExpandServiceTest extends TestCase
         $this->service()->process(false, 500, null, $poly);
 
         $this->assertSame(0, (int) DB::table('rippling_reach')->where('msgid', $london)->count(), 'London post (inside polygon) retracted');
-        $this->assertSame(1, (int) DB::table('rippling_reach')->where('msgid', $edinburgh)->count(), 'Edinburgh post (outside polygon) untouched');
+        $this->assertSame(0, (int) DB::table('rippling_reach')->where('msgid', $edinburgh)->count(), 'Edinburgh post (outside polygon) ALSO retracted - cleanup is not area-scoped');
     }
 
     /** The poster-leaves-a-rippled-group pull also runs under a scoped run (was dark during the experiment). */


### PR DESCRIPTION
## Problem (Discourse [rippling-out #176/#179](https://discourse.ilovefreegle.org/t/rippling-out/9808/179))

A Hertford member's OFFER (msg `117580503`) was rippled into **Enfield** and **Cheshunt & Waltham Cross**. The poster was auto-joined to both, then left them straight away (didn't want them) — but their post stayed live there (`deleted=0`) days on, on groups they'd explicitly opted out of.

## Root cause

The group experiment runs **scoped** (`RIPPLE_ENABLED=false`, a trial-group polygon passed as `withinPolyWkt`). Both retraction methods — `removeStaleAndRetract` and `pullRippledPostsFromLeftGroups` — filtered on the post's **origin being inside the current trial polygon**, mirroring the expansion scope. The unscoped run can't pick it up either — it early-returns while `RIPPLE_ENABLED` is off.

So **any rippled post whose origin is not in the current trial scope is never retracted**, regardless of how it was rippled.

### How this post came to be rippled while out of scope (traced from prod data)

Hertford was **never** in `ripple.within_groups`, and no group was removed. The cron's real chained `ST_Union` of all 50 trial polygons (all valid, none null) does **not** contain this post's origin point, so the scoped experiment cron mathematically can't have rippled it. The reach data shows what did:

- the Hertford reach row was **created 2026-06-22 14:34 and has never advanced** since (frozen mid-schedule);
- **all 59 reach rows whose origin is outside the trial were created on 2026-06-22**, scattered nationwide (Westminster, Brent, Angus, Leeds, Brighton, Isle of Wight…); **57/59 never advanced**;
- from **2026-06-23 onward only in-scope (trial) reaches are created, and they advance every tick**.

i.e. on 06-22 rippling ran **broadly across the network** (global, not the scoped trial); from 06-23 it was **scoped down to the trial groups**, orphaning everything the 06-22 run had rippled outside the trial. Those orphans sit forever: the scoped cron skips them (out of area scope) and the unscoped cron is inert (`RIPPLE_ENABLED=false`), so they neither advance nor retract. The Discourse case is one of them — poster left 06-23 18:59, copies still `deleted=0`.

## Fix

Retraction of an already-rippled copy is **cleanup of a committed artifact** and must complete regardless of the current area scope, however the post was rippled. So:

- Drop the `withinPolyWkt` area filter from `removeStaleAndRetract` and `pullRippledPostsFromLeftGroups`.
- **Keep `--msgid` scoping** (controlled single-post testing).
- Area scope still limits **expansion** (`initialiseNew` / `advanceDue`) — only cleanup is now global.

`pullRippledPostsFromLeftGroups` works off the `rippled_in=1` `messages_groups` rows, not the reach, so it pulls these orphans even though their reach is frozen. The stranded copies self-heal on the next cron tick once this deploys (poster-left / terminal-outcome).

## Testing (TDD)

- **+2 regression tests**, both confirmed **failing pre-fix** then passing:
  - `test_leave_retraction_is_not_gated_by_current_area_scope`
  - `test_stale_origin_retraction_is_not_gated_by_current_area_scope`
- Updated `test_scoped_within_poly_retracts_only_posts_inside_polygon` → `…does_not_limit_retraction`: it asserted the buggy area-scoped behaviour; now asserts global cleanup.
- `--msgid`-scoped retraction tests unaffected (preserved).
- Full `ExpandServiceTest`: **49 tests, 186 assertions, all pass**.

## Not fixed here (separate)
The 06-22 broad run left ~59 orphaned out-of-scope reaches that the scoped cron will never advance or clean up unless their poster leaves / they go terminal. A one-off sweep to retract/stop orphaned out-of-trial reaches may be worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012NjYtwJBGymZyZgZbc59oS