### PR TITLE
fix(modtools): hide a group's work queue from backup mods (explicit-groupid path)

### DIFF
--- a/iznik-server-go/message/message_list.go
+++ b/iznik-server-go/message/message_list.go
@@ -107,6 +107,12 @@ func ListMessages(c *fiber.Ctx) error {
 			if !user.IsModOfGroup(myid, groupid) {
 				return fiber.NewError(fiber.StatusForbidden, "Not a moderator for this group")
 			}
+			// Backup mods (settings.active=0, or legacy showmessages=0) have stepped back and must
+			// not see a group's work queue (Pending/Spam/Edit/Rejected) even via an explicit
+			// groupid - mirrors the groupid=0 path and the work-count badges.
+			if !user.IsActiveModOfGroup(myid, groupid) {
+				return c.JSON(ListMessagesResponse{Messages: []ListMessageItem{}})
+			}
 		}
 		groupIDs = []uint64{groupid}
 	}
@@ -419,6 +425,15 @@ func ListMessagesMT(c *fiber.Ctx) error {
 		if collection != utils.COLLECTION_APPROVED {
 			if !user.IsModOfGroup(myid, groupid) {
 				return fiber.NewError(fiber.StatusForbidden, "Not a moderator for this group")
+			}
+			// Work queues (Pending/Spam/Edit/Rejected) belong to ACTIVE mods only. A backup mod
+			// (settings.active=0, or legacy showmessages=0) has stepped back and must not see this
+			// group's queue even when an explicit groupid is requested - e.g. the ModTools group
+			// selector re-sending a remembered backup group's id. Mirrors the groupid=0 path
+			// (GetActiveModGroupIDs) and the work-count badges; return an empty list (not 403) so
+			// the UI degrades gracefully if it re-selects a now-backup group.
+			if !user.IsActiveModOfGroup(myid, groupid) {
+				return c.JSON(fiber.Map{"messages": []uint64{}})
 			}
 		}
 		groupIDs = []uint64{groupid}

--- a/iznik-server-go/test/modtools_edits_backup_test.go
+++ b/iznik-server-go/test/modtools_edits_backup_test.go
@@ -1,0 +1,72 @@
+package test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestModtoolsEditsHiddenFromBackupMod covers the leak (Discourse: mod Torbrexbones/Derek, Fife)
+// where GET /modtools/messages?collection=Edit returned a group's edit-review queue to a BACKUP
+// moderator. The all-groups path (groupid=0) was already safe via GetActiveModGroupIDs; the leak
+// was the explicit-groupid path, which only checked role (IsModOfGroup) with no active check, so a
+// backup mod whose ModTools group selector re-sent a remembered backup group's id saw its edits.
+// Both active=0 and the legacy showmessages=0 backup markers must hide the queue.
+func TestModtoolsEditsHiddenFromBackupMod(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("editbackup")
+
+	groupID := CreateTestGroup(t, prefix)
+	modID := CreateTestUser(t, prefix, "Moderator")
+	memID := CreateTestMembership(t, modID, groupID, "Moderator")
+	_, modToken := CreateTestSession(t, modID)
+
+	// A poster's message on the group, with a pending (reviewrequired=1) edit awaiting review.
+	posterID := CreateTestUser(t, prefix, "User")
+	CreateTestMembership(t, posterID, groupID, "Member")
+	msgID := CreateTestMessage(t, posterID, groupID, prefix+" edit", 53.0, -2.0)
+	db.Exec("INSERT INTO messages_edits (msgid, byuser, oldtext, newtext, reviewrequired, timestamp) VALUES (?, ?, 'old', 'new', 1, NOW())", msgID, posterID)
+	defer db.Exec("DELETE FROM messages_edits WHERE msgid = ?", msgID)
+
+	editVisible := func(urlStr string) bool {
+		resp, err := getApp().Test(httptest.NewRequest("GET", urlStr, nil))
+		require.NoError(t, err)
+		require.Equal(t, 200, resp.StatusCode)
+		var body map[string]interface{}
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+		ids, _ := body["messages"].([]interface{})
+		for _, id := range ids {
+			if uint64(id.(float64)) == msgID {
+				return true
+			}
+		}
+		return false
+	}
+	byGroup := fmt.Sprintf("/api/modtools/messages?collection=Edit&groupid=%d&jwt=%s", groupID, modToken)
+	allGroups := fmt.Sprintf("/api/modtools/messages?collection=Edit&jwt=%s", modToken)
+
+	setSettings := func(s string) {
+		db.Exec("UPDATE memberships SET collection = 'Approved', settings = ? WHERE id = ?", s, memID)
+	}
+
+	// Active mod sees the edit on both routes - guards against over-blocking.
+	setSettings(`{"active":1}`)
+	assert.True(t, editVisible(byGroup), "active mod must see the group's edit via explicit groupid")
+	assert.True(t, editVisible(allGroups), "active mod must see the group's edit in the all-groups view")
+
+	// Backup via active=0: hidden on BOTH routes (explicit groupid was the leak).
+	setSettings(`{"active":0}`)
+	assert.False(t, editVisible(byGroup), "backup mod (active=0) must NOT see the edit via explicit groupid")
+	assert.False(t, editVisible(allGroups), "backup mod (active=0) must NOT see the edit in the all-groups view")
+
+	// Backup via legacy showmessages=0 (no active key): also hidden - GetActiveModGroupIDs and
+	// IsActiveModOfGroup honour the showmessages fallback, matching the isActiveModForGroup helper.
+	setSettings(`{"showmessages":0}`)
+	assert.False(t, editVisible(byGroup), "backup mod (showmessages=0) must NOT see the edit via explicit groupid")
+	assert.False(t, editVisible(allGroups), "backup mod (showmessages=0) must NOT see the edit in the all-groups view")
+}

--- a/iznik-server-go/user/authorization.go
+++ b/iznik-server-go/user/authorization.go
@@ -19,6 +19,31 @@ func IsModOfGroup(myid uint64, groupid uint64) bool {
 	return auth.IsModOfGroup(myid, groupid)
 }
 
+// IsActiveModOfGroup reports whether myid is an ACTIVE moderator/owner of the group. Admin/Support
+// always qualify; otherwise the membership must be Moderator/Owner AND the mod must not have stepped
+// back to backup (activeModSettingsSQL: settings.active wins, legacy settings.showmessages as
+// fallback). This is stricter than IsModOfGroup, which checks role only - it is used to keep a
+// group's work queues (Pending/Spam/Edit) hidden from backup mods even when an explicit groupid is
+// requested, matching the groupid=0 path (GetActiveModGroupIDs) and the work-count badges.
+func IsActiveModOfGroup(myid uint64, groupid uint64) bool {
+	if auth.IsAdminOrSupport(myid) {
+		return true
+	}
+	if groupid == 0 {
+		return false
+	}
+	db := database.DBConn
+	var count int64
+	result := db.Raw("SELECT COUNT(*) FROM memberships WHERE userid = ? AND groupid = ? AND role IN (?, ?) AND collection = ? "+
+		"AND "+activeModSettingsSQL,
+		myid, groupid, utils.ROLE_MODERATOR, utils.ROLE_OWNER, utils.COLLECTION_APPROVED).Scan(&count)
+	if result.Error != nil {
+		log.Printf("Failed to check active mod role for user %d group %d: %v", myid, groupid, result.Error)
+		return false
+	}
+	return count > 0
+}
+
 // IsModOfUser checks if myid is Admin/Support or a Moderator/Owner of any
 // group that targetid also belongs to (including groups the target is banned from).
 func IsModOfUser(myid, targetid uint64) bool {

--- a/iznik-server-go/user/user.go
+++ b/iznik-server-go/user/user.go
@@ -446,11 +446,21 @@ func InventName(db *gorm.DB, id uint64) string {
 	return name
 }
 
+// activeModSettingsSQL is a SQL predicate over a memberships.settings JSON column that mirrors the
+// isActiveModForGroup Go helper used for the work-count badges: a mod is "active" (not stepped back
+// to backup) unless settings.active=0; when the active key is ABSENT the legacy settings.showmessages
+// flag governs (showmessages=0 => backup); a NULL/empty settings, or both keys absent, means active.
+// Shared by GetActiveModGroupIDs and IsActiveModOfGroup so the work queues (Edit/Pending/Spam) and
+// their per-group access checks agree, and so a backup mod never sees a backup group's queue.
+const activeModSettingsSQL = "(settings IS NULL " +
+	"OR (JSON_EXTRACT(settings, '$.active') IS NOT NULL AND JSON_EXTRACT(settings, '$.active') != 0) " +
+	"OR (JSON_EXTRACT(settings, '$.active') IS NULL AND (JSON_EXTRACT(settings, '$.showmessages') IS NULL OR JSON_EXTRACT(settings, '$.showmessages') != 0)))"
+
 func GetActiveModGroupIDs(userid uint64) []uint64 {
 	db := database.DBConn
 	var groupIDs []uint64
 	result := db.Raw("SELECT groupid FROM memberships WHERE userid = ? AND role IN (?, ?) AND collection = ? "+
-		"AND (settings IS NULL OR JSON_EXTRACT(settings, '$.active') IS NULL OR JSON_EXTRACT(settings, '$.active') != 0)",
+		"AND "+activeModSettingsSQL,
 		userid, utils.ROLE_MODERATOR, utils.ROLE_OWNER, utils.COLLECTION_APPROVED).Pluck("groupid", &groupIDs)
 	if result.Error != nil {
 		log.Printf("Failed to get active mod group IDs for user %d: %v", userid, result.Error)


### PR DESCRIPTION
## Problem
A moderator (Torbrexbones / Derek, Fife) reported seeing the **Edits** queue in ModTools for groups he is only a **backup** mod on — "never used to be the case".

## Root cause
`GET /apiv2/modtools/messages?collection=Edit` resolves groups two ways in `ListMessagesMT`:
- **all-groups (`groupid=0`)** → `GetActiveModGroupIDs`, which excludes backup mods (`settings.active=0`). **Safe.**
- **explicit `groupid`** → `IsModOfGroup`, a **role-only** check with **no active filter**. A backup mod still has role `Moderator`/`Owner`, so they pass and get that group's edit-review queue.

The ModTools group selector (`ModGroupSelect`, `remember="edits"`) lists backup groups and re-sends a remembered backup group's id on mount, hitting the explicit-groupid path. Verified on prod: Derek is `Owner` with `active:0` on `freegle_seleicestershire` (253451), which had a live `reviewrequired=1` edit returned to him. Prod apiv2 = current master tip, so this is a master bug, not a stale deploy. The work-count badges (`session.go`/`groupWork.go`) were already correct — they use `isActiveModForGroup`.

## Fix
- **`user.IsActiveModOfGroup(uid, gid)`** — role **and** active, with the Admin/Support shortcut `IsModOfGroup` has.
- **`ListMessagesMT` + `ListMessages`** — the explicit-`groupid` work-collection path returns an **empty list** for backup mods (graceful, not 403), matching the `groupid=0` path and the badges. Applies to all work collections (Edit/Pending/Spam/Rejected).
- **`GetActiveModGroupIDs`** gains the legacy **`showmessages`** fallback via a shared `activeModSettingsSQL` predicate, matching `isActiveModForGroup` — closing a secondary gap where a mod marked backup via `showmessages=0` (16 prod memberships) leaked via the all-groups path too.

## Testing
`modtools_edits_backup_test.go`: an active mod **sees** the edit (explicit groupid + all-groups); a backup mod — via **`active=0`** and legacy **`showmessages=0`** — **does not**, on both routes. **Full Go suite passes locally.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012NjYtwJBGymZyZgZbc59oS