### PR TITLE
fix(ripple): hold out-of-reach direct-email replies to a post

### DIFF
--- a/iznik-batch/app/Services/Mail/Incoming/IncomingMailService.php
+++ b/iznik-batch/app/Services/Mail/Incoming/IncomingMailService.php
@@ -3156,7 +3156,7 @@ class IncomingMailService
 
         // Use TYPE_INTERESTED only when we found the post being replied to.
         // Without a refmsgid, use TYPE_DEFAULT since we can't link to a specific post.
-        $this->createChatMessageFromEmail(
+        $chatMsgId = $this->createChatMessageFromEmail(
             $chat,
             $senderUser->id,
             $email,
@@ -3165,6 +3165,14 @@ class IncomingMailService
             spamScore: $spamScore,
             prependSubject: $prependSubject
         );
+
+        // Rippling-out (#3): a direct-email reply to a SPECIFIC post (refmsgid resolved via the
+        // x-fd-msgid header or subject match) must be held when the replier's area isn't covered
+        // by the post's reach yet - the same gate as the digest reply path - so the poster isn't
+        // notified out-of-reach via this route. Only when we linked the reply to a post.
+        if ($refMsgId !== null && $chatMsgId !== null) {
+            $this->holdReplyIfOutsideReach($chat->id, $chatMsgId, $refMsgId, $senderUser);
+        }
 
         // Track email reply in email_tracking for AMP comparison stats.
         $this->trackEmailReply($chat->id, $senderUser->id);

--- a/iznik-batch/tests/Unit/Services/Mail/Incoming/IncomingMailServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/Mail/Incoming/IncomingMailServiceTest.php
@@ -1105,6 +1105,58 @@ class IncomingMailServiceTest extends TestCase
         $this->assertEquals(ChatMessage::TYPE_INTERESTED, $chatMsg->type);
     }
 
+    /**
+     * Rippling-out: a direct-email reply to a specific post (refmsgid resolved via x-fd-msgid) from
+     * a replier whose area the post's reach has NOT reached yet must be HELD - the same gate as the
+     * digest reply path - so the poster is not notified out-of-reach via the direct-mail route.
+     */
+    public function test_direct_mail_reply_to_post_held_when_replier_outside_reach(): void
+    {
+        $poster = $this->createTestUser(['email_preferred' => $this->uniqueEmail('poster')]);
+        // Replier located OUTSIDE the post's reach polygon (reach covers ~51.5,-0.1; replier 52.0,1.0).
+        $replier = $this->createTestUser([
+            'email_preferred' => $this->uniqueEmail('replier'),
+            'lastlocation' => $this->createLocation(52.0, 1.0),
+        ]);
+        $group = $this->createTestGroup();
+        $this->createMembership($poster, $group);
+        $message = $this->createTestMessage($poster, $group);
+
+        // The post is rippling out; its reach does not yet cover the replier's location.
+        DB::statement('DELETE FROM rippling_reach WHERE msgid = ?', [$message->id]);
+        DB::insert(
+            "INSERT INTO rippling_reach (msgid, lat, lng, polygon, arrival, mode, tick, total_ticks,
+                total_freeglers, max_drive_min, schedule, rejected_groups, status, created_at, updated_at)
+             VALUES (?, 51.5, -0.1, ST_GeomFromText(?, 3857), NOW(), 'drive', 1, 3, 0, 30, NULL, NULL, 'expanding', NOW(), NOW())",
+            [$message->id, 'POLYGON((-0.2 51.4, 0.0 51.4, 0.0 51.6, -0.2 51.6, -0.2 51.4))']
+        );
+
+        $replierEmail = $replier->emails->first()->email;
+        $posterSlugAddr = "someslug-{$poster->id}@users.ilovefreegle.org";
+        $emailRaw = $this->createMinimalEmail([
+            'From' => $replierEmail,
+            'To' => $posterSlugAddr,
+            'Subject' => $message->subject,
+            'x-fd-msgid' => (string) $message->id,
+        ], 'I would love this item!');
+        $parsed = $this->parser->parse($emailRaw, $replierEmail, $posterSlugAddr);
+
+        $this->service->route($parsed);
+
+        $chatMsg = DB::table('chat_messages')
+            ->where('userid', $replier->id)
+            ->where('type', ChatMessage::TYPE_INTERESTED)
+            ->orderBy('id', 'desc')
+            ->first();
+        $this->assertNotNull($chatMsg, 'Direct mail reply to a post should create a TYPE_INTERESTED message');
+        $this->assertEquals($message->id, $chatMsg->refmsgid);
+
+        // The out-of-reach reply must be HELD so the poster is not notified until reach catches up.
+        $held = DB::table('rippling_held_replies')->where('chatmsgid', $chatMsg->id)->first();
+        $this->assertNotNull($held, 'Out-of-reach direct-email reply to a post must be held');
+        $this->assertSame('held', $held->status);
+    }
+
     public function test_direct_mail_finds_refmsgid_by_subject(): void
     {
         $poster = $this->createTestUser(['email_preferred' => $this->uniqueEmail('poster')]);


### PR DESCRIPTION
## Problem
The rippling **reply-hold** gate — the poster isn't notified about an interested reply until the post ripples to the replier's area — was enforced on the web/app path (`chatmessage.go` → `403 not_in_reach`) and the **digest** email reply path (`IncomingMailService:1643` `holdReplyIfOutsideReach`), but **not** the **direct-email** path. So a user outside a post's reach could still notify the poster by replying via direct email — the one route your "any route including email" concern pointed at.

## Root cause
`IncomingMailService::handleDirectMail` resolves the post being replied to (`refmsgid` via the `x-fd-msgid` header or subject match) and creates a `TYPE_INTERESTED` reply (line 3159), but does **not** call `holdReplyIfOutsideReach` — unlike the digest reply path.

## Fix
Capture the returned chat-message id and, when the reply is linked to a post, run the **same** `holdReplyIfOutsideReach` gate as the digest path:
```php
$chatMsgId = $this->createChatMessageFromEmail(... type: $refMsgId !== null ? TYPE_INTERESTED : TYPE_DEFAULT ...);
if ($refMsgId !== null && $chatMsgId !== null) {
    $this->holdReplyIfOutsideReach($chat->id, $chatMsgId, $refMsgId, $senderUser);
}
```
Inert until the reach engine populates `rippling_reach` (`hasReach` fails open before then).

## Testing
`test_direct_mail_reply_to_post_held_when_replier_outside_reach`: a direct-email reply (`x-fd-msgid`) from a replier whose `lastlocation` is outside the post's `rippling_reach` polygon is **held** (`rippling_held_replies.status = 'held'`). The existing direct-mail tests (no reach row → not held) still pass — **10 tests / 29 assertions green locally**.

## Reach enforcement now complete
| Route | Out-of-reach behaviour |
|---|---|
| Browse | filtered out (`FilterReachBlocked`) |
| Notify (digest) | excluded; reach-mailer mails only newly-reached |
| Message page | view-only "not yet" |
| Reply — web/app | `403 not_in_reach` |
| Reply — email (digest) | held until reach catches up |
| Reply — email (direct) | **held until reach catches up (this PR)** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012NjYtwJBGymZyZgZbc59oS