### PR TITLE
fix(ci): retry composer install to survive transient codeload 400s

### DIFF
--- a/iznik-batch/docker/Dockerfile
+++ b/iznik-batch/docker/Dockerfile
@@ -60,8 +60,17 @@ WORKDIR /var/www/html
 # Copy application files
 COPY . .
 
-# Install PHP dependencies including dev dependencies for testing
-RUN composer install --no-interaction --prefer-dist --optimize-autoloader
+# Install PHP dependencies including dev dependencies for testing.
+# Retry composer install: codeload.github.com (composer's `dist` source)
+# intermittently returns HTTP 400 for a random subset of packages. Composer
+# caches what it fetched, so retries only re-download the failures. Mirrors the
+# --fetch-retries convention used for npm installs elsewhere in this repo.
+RUN n=0; until composer install --no-interaction --prefer-dist --optimize-autoloader; do \
+      n=$((n+1)); \
+      [ "$n" -ge 5 ] && { echo "composer install failed after $n attempts" >&2; exit 1; }; \
+      echo "composer install attempt $n hit a transient network error; retrying in 15s..."; \
+      sleep 15; \
+    done
 
 # Create .env file from example for Laravel to find (testing uses phpunit.xml env vars)
 RUN cp .env.example .env || touch .env

--- a/iznik-server/Dockerfile
+++ b/iznik-server/Dockerfile
@@ -77,11 +77,21 @@ RUN cp install/iznik.conf.php /etc/iznik.conf \
     && echo "password=$SQLPASSWORD" >> ~/.my.cnf \
     && echo "redis" > /etc/iznikredis
 
-# Install composer dependencies
+# Install composer dependencies.
+# Retry composer install: codeload.github.com (composer's `dist` source)
+# intermittently returns HTTP 400 for a random subset of packages, which would
+# otherwise fail the whole build. Composer caches packages it already fetched,
+# so each retry only re-downloads the ones that failed previously. Mirrors the
+# --fetch-retries convention used for npm installs elsewhere in this repo.
 RUN wget https://getcomposer.org/composer-2.phar -O composer.phar \
     && php composer.phar self-update \
     && cd composer \
-    && echo Y | php ../composer.phar install \
+    && { n=0; until echo Y | php ../composer.phar install; do \
+           n=$((n+1)); \
+           [ "$n" -ge 5 ] && { echo "composer install failed after $n attempts" >&2; exit 1; }; \
+           echo "composer install attempt $n hit a transient network error; retrying in 15s..."; \
+           sleep 15; \
+         done; } \
     && cd ..
 
 # Cron jobs for background scripts (excluding messages_spatial)


### PR DESCRIPTION
## Problem

The apiv1 (`iznik-server/Dockerfile`) and batch (`iznik-batch/docker/Dockerfile`) Docker builds run a **bare `composer install`**. Composer's `dist` source is `codeload.github.com`, which intermittently returns **HTTP 400 for a random subset of packages** under load. A single such 400 fails the whole build.

This was breaking PR CircleCI builds, e.g. **#908**:

```
importing cache manifest from 185.44.254.6:5002/ci/apiv1:latest
ERROR: failed to configure registry cache importer: ... 500 Internal Server Error
...
Failed to download rize/uri-template from dist: ... (HTTP/2 400 )
ERROR: ... composer ... did not complete successfully: exit code: 100
```

### Why now / why not master

- The self-hosted layer-cache registry (`185.44.254.6:5002`) currently returns **500** for the `ci/apiv1` (and `ci/playwright`) manifest. Reproduced live; other repos' manifests return 200.
- Any build whose `COPY . /var/www/iznik` source layer differs from the cached one — i.e. **any PR that touches `iznik-server`** — rebuilds the composer layer from scratch and hammers codeload, hitting the 400s.
- **master passes only because its unchanged source reuses the cached layer** and never re-runs `composer install`.
- The failing package differed on every run (`rize/uri-template`, `symfony/deprecation-contracts`, `jean85/pretty-package-versions`, `graphp/graphviz`) — the signature of transient throttling, **not** a broken dependency.

## Fix

Wrap both composer installs in a retry loop (up to 5 attempts). Composer caches packages it already fetched, so each retry only re-downloads the ones that failed. This mirrors the `--fetch-retries` convention already used for **every** npm install in this repo (and the `until` retry loop in `docker/embedding-sidecar/Dockerfile`); the two composer installs were the only network installs missing it.

## Follow-up

Once merged, PRs that touch `iznik-server` (e.g. #908) should merge/rebase master to inherit the retry; their CircleCI build will then pass. The first successful build also pushes a fresh `--cache-to` layer, self-healing the corrupted `ci/apiv1:latest` cache manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**Update (incident resolved separately):** the underlying cause was the build-layer cache registry (`185.44.254.6:5002`) returning 500 — its `/cache` disk was 100% full (no garbage collection for ~6 weeks), which truncated the apiv1/playwright manifest links. That has been fixed directly on the host: ran `registry garbage-collect --delete-untagged` (freed 196G→~12G), repopulated the caches, and installed a **weekly GC cron** so it cannot recur. PR #908 now passes CircleCI without this change.

This PR remains worth merging as **durable hardening**: any PR touching `iznik-server` rebuilds the composer layer and hits codeload directly, so the retry protects every future build against transient codeload 400s regardless of cache health.