### PR TITLE
fix(test): make Playwright coverage deterministic (SpinButton timeout line)

### DIFF
--- a/iznik-nuxt3/components/SpinButton.vue
+++ b/iznik-nuxt3/components/SpinButton.vue
@@ -148,6 +148,14 @@ const finishSpinner = () => {
     if (props.doneIcon) {
       done.value = true
       setTimeout(() => {
+        // Resets the transient "done" check icon props.timeout (5s) after the
+        // action completes. Playwright e2e only covers this line when a test
+        // happens to stay on the page for the full timeout, so it flips in and
+        // out of coverage run-to-run — it is the sole source of Playwright
+        // coverage non-determinism, which trips Coveralls on unrelated PRs.
+        // Excluded from V8/Playwright coverage only; vitest (istanbul, which
+        // ignores v8 comments) still counts it.
+        /* v8 ignore next */
         done.value = false
       }, props.timeout)
     }


### PR DESCRIPTION
## Problem

Coveralls **"Coverage decreased"** failures keep appearing on the `Coveralls - playwright` check for PRs that **don't touch the frontend at all** — e.g. backend-only #908 (`iznik-batch`), #907 (`iznik-server-go`), config-only #894. A PR that changes no frontend code cannot genuinely reduce frontend coverage, so these are spurious.

## Root cause (proven with data)

I pulled the per-file Coveralls coverage for three master runs and diffed them:

| master run | playwright % | SpinButton.vue |
|---|---|---|
| 22.861% (typical) | baseline | **10/12** |
| 22.886% | +0.025% | 11/12 |
| 22.91% (current HEAD) | +0.05% | 11/12 |

The **only** file whose coverage varies run-to-run is `components/SpinButton.vue`, by **exactly one line**:

```js
const finishSpinner = () => {
  clearTimeout(timer)
  cancelLoading().then(() => {
    if (props.doneIcon) {
      done.value = true
      setTimeout(() => {
        done.value = false   // <-- covered only if a test lingers props.timeout (5s)
      }, props.timeout)
    }
  })
}
```

That reset runs 5s after the action completes, so the e2e suite covers it only when a test happens to stay on the page that long. When a master build lands on the 11/12 sample (current HEAD = 22.91%), every later PR that lands on the normal 10/12 is reported as **"-0.05% decreased"** and the check goes red. Pure measurement noise.

## Fix

Exclude that single timing-only line from **V8** coverage with `/* v8 ignore next */` (monocart honours it; `v8Ignore` defaults on). `vitest` uses **istanbul**, which ignores v8 comments, so the line is still counted in unit coverage. This matches the file's existing pattern of excluding e2e-nondeterministic paths from the e2e coverage only (`useSuppressException`, `useUppyRetryCoalesce`, `ChatMobileNavbar`).

After this lands, per-commit coverage is deterministic, so a PR that doesn't change frontend code reports **no delta** and the gate stops firing spuriously.

## Verification

I will confirm from the PR's own Coveralls job that `SpinButton.vue` becomes a stable **10/11** (relevant drops 12→11, the flaky line removed). Note: the introducing commit resets the baseline, so master's value re-stabilises on the first build after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
