### PR TITLE
feat(concierge): Freegle Helper reply-concierge agent (skill + poller)

### DIFF
--- a/.claude/skills/freegle-helper-concierge/SKILL.md
+++ b/.claude/skills/freegle-helper-concierge/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: freegle-helper-concierge
+description: Use to run the Freegle Helper — the AI concierge that manages replies to a bulk "clearance" offer on the offerer's behalf. Reads each replier's chat, gathers what's needed for allocation, scores candidates, drafts allocation proposals for the offerer to approve, and sends warm human-sounding replies as the offerer. Triggers - "run the helper", "concierge", "manage replies for my clearance", "helper for message <id>".
+---
+
+# Freegle Helper — reply concierge
+
+Manage the back-and-forth on a bulk-offer (clearance) post so the offerer isn't overwhelmed,
+and present them with simple decisions ("Bob can come Tuesday and take 6 chairs + 2 desks —
+accept?"). The Helper sends messages **as the offerer** (warm, human, brief — the replier
+thinks they're talking to the person who posted) but **never makes allocation decisions** —
+the human does. Every Helper-sent message is flagged `fromhelper=1` for moderator oversight.
+
+**FULL DESIGN (read first):** `plans/active/freegle-helper-concierge.md` — the FSM, scoring
+rubric, tone rules, failure modes, and trial findings. This skill is the operational loop.
+
+**API CONTRACTS:** `api-reference.md` in this skill dir — exact endpoints + payloads for the
+helper control plane (`/helper`), chat read/send-as-offerer, user reputation, and the haversine.
+
+## What's already built (the foundation this drives)
+- **Per-item interest** (#618): `GET /message/<id>` returns `bulkitems[].interest[]` with
+  `userid, firstname, created_at, blurred lat/lng, quantity, cancollect, state` (owner-visible).
+- **Control plane** (#838): `helper_batches` + `helper_repliers` (the knowledge record) +
+  `helper_item_states` + `helper_proposals` + `helper_sent_messages`, driven by `GET/POST /helper`.
+- **Send-as-offerer** (#618 + #838): scoped `helper_delegate` token + the `Send` action; sends
+  are rate-limited (20/chat/24h), scoped to the offer's chats, and written `fromhelper=1`.
+- **Allocation**: `POST /message {action:"BulkInterestState", state:"Reserved"|"Collected"|"Rejected"}`
+  (writes the promise + notifies) or the batch endpoint `POST /message/bulk/state`.
+
+## Setup (once per batch)
+1. **Identify the batch** — the managed `msgid`s (the clearance post; bulk batches may span
+   several posts). The Helper scopes ALL operations to these IDs.
+2. **Authenticate as the offerer** — obtain the offerer's session (Link key → JWT) for
+   `/helper` control-plane calls, and mint a scoped send token for chat replies:
+   `POST /api/message/<msgid>/helpertoken` → `{token}` (offerer-only; 24h; scoped to that msgid).
+   Use that token as `Authorization: Bearer <token>` on `POST /chat/<chatid>/message`.
+3. **`EnsureBatch`** — `POST /helper {action:"EnsureBatch", msgid}` creates the batch row.
+4. **Extract the briefing from the post body** (NOT hardcoded) and store it:
+   `POST /helper {action:"SetStatus", msgid, briefing:"..."}` — collection constraints (dates/
+   times/location from body + `message.deadline`), recipient criteria (e.g. "charities only", or
+   none), items + quantities + sizes (from the catalogue), offerer preferences. Everything below
+   uses these generically.
+
+## The loop (run continuously; LLM only on change)
+1. **Poll** with `helper-poll.sh <STATUS_OR_API_BASE> <msgid> <token>` — a curl loop that checks
+   `chatcount:unseencount` every 30s and prints `CHANGED` only when something new arrives. Drive
+   it with `/loop` or as a background task. Do NOT invoke the model every cycle.
+2. **On CHANGED**, for the batch:
+   a. `GET /helper/<msgid>` → current batch, repliers (knowledge records + item states), pending
+      proposals, sent log.
+   b. For each replier with new chat activity, `GET /chat/<chatid>/message` (only messages after
+      `last_processed_chatmsgid`). Read what they said.
+   c. **Apply the FSM** (plans doc) against their current `state` + the knowledge checklist:
+      which items + how many (`refmsgid`), other-items-mentioned, collection-ok, criteria-met,
+      transport (size-based — see plan), and any question to answer. Update the record:
+      `POST /helper {action:"UpsertReplier", msgid, userid/chatid, state, collection_ok,
+      criteria_met, transport_ok, distance_miles, next_action, ...}` and per item
+      `{action:"SetItemState", replierid, bulkitemid, state, qty_wanted, score, score_breakdown}`.
+      Always advance `last_processed_chatmsgid`.
+   d. **Reply if there's a reason** (acknowledge + ask all gaps in ONE message; answer a factual
+      question from listing data; nudge after timeout; allocation/rejection). Send via
+      `POST /helper {action:"Send", msgid, replierid, body, kind, auto:true}` (records the send +
+      sets `fromhelper`). Silence is fine — don't mail-bomb.
+3. **Allocation (Phase B)** — when the per-item pool is ready (urgency ramp on `deadline`, plan
+   §"Scoring & Allocation Timing"): score candidates, then draft a proposal for the **human**:
+   `POST /helper {action:"Proposal", msgid, type:"allocation", bulkitemid, replierid, summary,
+   proposed_text, rationale}`. Present pending proposals to the offerer (see Dashboard).
+4. **Human resolves** → `POST /helper {action:"ResolveProposal", proposalid, decision:"approve"|
+   "reject"|"edit", text}`. On approve:
+   - `POST /message {action:"BulkInterestState", id:msgid, bulkitemid, userid, state:"Reserved"}`
+     (records the promise + sends the system Promised notification), then
+   - `Send` the "Great news — N allocated to you, collection ..., please confirm" message.
+   - For losing candidates on that item: `state:"Rejected"` (sends the polite rejection).
+5. **Confirmation / collection / follow-up** — nudge unconfirmed allocations (24h/48h ramp);
+   on collection day remind confirmed collectors; after collection `BulkInterestState
+   state:"Collected"` (updates stats) and prompt the offerer to mark the post Taken when done.
+
+## Hard rules (do not break)
+- **Human decides allocation.** The Helper gathers + proposes; it never promises or allocates
+  without an approved proposal. Treat every replier neutrally in conversation.
+- **No LLM geography.** Distances ONLY from API `lat/lng` + haversine (see api-reference). Never
+  judge "too far" from a place name.
+- **One message, all questions.** Don't drip-feed. If their message answers everything, skip to
+  QUALIFIED with no further message. Don't mail-bomb.
+- **Tone:** warm, brief, human, named; "we've noted your interest" not "you're down for"; always
+  "subject to availability". Never sound like the "sold to a mate" brush-off.
+- **Offerer override:** if the offerer posts in a chat directly, start a 1h cooldown
+  (`cooldown_until`); after it, only continue if consistent with what they said, else `ESCALATE`.
+- **Scope:** every call is scoped to the batch's `msgid`s. The send token is per-msgid.
+- **Disclosure:** messages are sent as the offerer (no "I'm a bot" to the replier) but carry
+  `fromhelper=1` so moderators can see them in the chat-review queue. Do not remove that flag.
+
+## Dashboard (Phase 3 — start simple)
+Present pending proposals + per-item allocation status to the offerer as a structured summary in
+their own chat (or a page later): per item — candidates ranked with one-line reason + the
+Helper's recommendation, and accept/modify controls that map to `ResolveProposal`.
+
+## Safety / escalate to a human when
+- A subjective question (photos, condition judgement), a complaint, anything outside the briefing,
+  or the offerer contradicts the Helper. Set `state:"ESCALATED"` + `escalation_reason` and tell
+  the replier "we'll check and come back to you".

--- a/.claude/skills/freegle-helper-concierge/api-reference.md
+++ b/.claude/skills/freegle-helper-concierge/api-reference.md
@@ -1,0 +1,70 @@
+# Freegle Helper — API reference
+
+Exact contracts the concierge uses. Base URL is the V2 Go API (`/api` via the app, or
+`http://apiv2.localhost:8192/api` locally). All examples assume the offerer's auth (see Auth).
+
+## Auth
+Two credentials:
+- **Offerer session JWT** (Link key → JWT) — used for the `/helper` control plane and
+  `/message` reads/state. The Helper authenticates as the offerer.
+- **Scoped send token** — `POST /message/<msgid>/helpertoken` (offerer-authed) →
+  `{"ret":0,"token":"<jwt>"}`. 24h, `purpose=helper_delegate`, bound to that one `msgid`. Use as
+  `Authorization: Bearer <token>` ONLY for `POST /chat/<chatid>/message`. The server enforces:
+  the chat must already be about `<msgid>`, the message must carry `refmsgid=<msgid>`, type is
+  Default/Interested only, rate-limited 20/chat/24h, and the row is written `fromhelper=1`.
+
+## Control plane
+
+### GET /helper/<msgid>
+Returns the whole batch state:
+```
+{ "batch": { id, msgid, offereruserid, status, briefing, lastpolledat, lastrunat, pausedat } | null,
+  "repliers": [ { id, batchid, userid, chatid, state, collection_ok, criteria_met, transport_ok,
+                  distance_miles, is_connector, related_to, escalation_reason, parked_reason,
+                  next_action, other_items_mentioned, cooldown_until, offerer_last_message_at,
+                  last_processed_chatmsgid, knowledge,
+                  item_states: [ { id, replierid, bulkitemid, state, qty_wanted, qty_allocated,
+                                   score, score_breakdown } ] } ],
+  "proposals": [ { id, batchid, type, replierid, bulkitemid, summary, proposed_text, payload,
+                   rationale, status, resolved_text, resolvedat, resolvedby } ],
+  "sent": [ { id, batchid, chatmsgid, chatid, replierid, kind, auto, proposalid } ] }
+```
+`batch: null` means the Helper hasn't been started for this offer → `EnsureBatch` first.
+
+### POST /helper  (body: `{ "action": "...", "msgid": <id>, ...fields }`)
+| action | required fields | effect |
+|--------|-----------------|--------|
+| `EnsureBatch` | `msgid` | create the batch row |
+| `SetStatus` | `msgid`, `status` ("active"\|"paused"\|"stopped") and/or `briefing` | set batch status / briefing |
+| `UpsertReplier` | `msgid`, (`userid` or `chatid`) + any record fields | upsert the knowledge record. Record fields: `state, collection_ok, criteria_met, transport_ok` (string yes/no/unknown/not_applicable), `distance_miles`, `is_connector`, `related_to`, `escalation_reason`, `parked_reason`, `next_action`, `other_items_mentioned`, `cooldown_until` (RFC3339), `offerer_last_message_at`, `last_processed_chatmsgid`, `knowledge` (free JSON string) |
+| `SetItemState` | `replierid`, `bulkitemid`, `state` | per-item state + `qty_wanted`, `qty_allocated`, `score`, `score_breakdown` |
+| `Proposal` | `msgid`, `type` ("allocation"\|"message"\|"rejection"\|"escalation"\|"reminder"\|"withdrawal_notice"), + `replierid`, `bulkitemid`, `summary`, `proposed_text`, `payload`, `rationale` | create a pending proposal for the offerer |
+| `ResolveProposal` | `proposalid`, `decision` ("approve"\|"reject"\|"edit"), optional `text` | offerer resolves; on approve, downstream effects fire |
+| `Send` | `msgid`, (`replierid` or `chatid`), `body`, `kind`, `auto` | send a chat message AS the offerer, record it in `helper_sent_messages`, set `fromhelper=1` |
+
+Replier states (FSM): `NEW, GATHERING, QUALIFIED, ALLOCATED, CONFIRMED, COLLECTED,
+PARKED_REPLIED, PARKED_QUIET, ESCALATED, TIMED_OUT, WITHDRAWN, REJECTED` (plan §"Conversation State Tracking").
+
+## Reads for judgement
+- `GET /message/<msgid>` → `bulkitems[]` (catalogue) + per-item `interest[]` (owner-visible:
+  `userid, firstname, created_at, quantity, cancollect, state, lat, lng` blurred) +
+  `availablenow`, `availableinitially`, `deadline`, `textbody` (briefing source).
+- `GET /chat/rooms?msgid=<id>&since_msgid=<cursor>` → only chat rooms about this offer, since a
+  cursor (the #618 shortcut — O(one post), not O(all chats)).
+- `GET /chat/<chatid>/message` → messages in a room (filter by id > `last_processed_chatmsgid`).
+- `GET /user/<id>` → reputation for scoring: ratings (thumbs up/down), `replytime`, `reneged`
+  count, `collected` history, and `lat`/`lng` (for distance).
+
+## Allocation + outcome
+- `POST /message {action:"BulkInterestState", id:<msgid>, bulkitemid, userid, state:"Reserved"}`
+  — records the promise (`messages_promises`) + sends `CHAT_MESSAGE_PROMISED`. Over-allocation
+  is rejected (409). `state:"Collected"` decrements `availablenow` + feeds stats. `state:"Rejected"`
+  notifies the candidate.
+- `POST /message/bulk/state {items:[{bulkitemid,userid,state}]}` — many transitions in one call
+  (transactional, same guards).
+- Outcome (mark the whole post Taken when done): the standard outcomes API used by My Posts.
+
+## Distance (no LLM geography)
+Haversine between the replier's `lat/lng` (`GET /user/<id>`) and the item's `lat/lng`
+(`GET /message/<id>`). Miles = `3958.8 * 2*asin(sqrt(sin²(Δφ/2) + cos φ1·cos φ2·sin²(Δλ/2)))`,
+φ/λ in radians. Never infer distance from a place name in chat.

--- a/.claude/skills/freegle-helper-concierge/helper-poll.sh
+++ b/.claude/skills/freegle-helper-concierge/helper-poll.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Freegle Helper — LLM-free poller.
+#
+# Watches the offerer's chats for a managed bulk-offer and prints "CHANGED" only
+# when something new arrives (new message / unseen-count change). This is the
+# token-saving front door: run it as a background task or via /loop, and only
+# invoke the concierge model (the freegle-helper-concierge skill) when it emits
+# CHANGED — never on every poll cycle.
+#
+# Usage:
+#   helper-poll.sh <api_base> <msgid> <offerer_jwt> [interval_secs] [state_file]
+# Example:
+#   helper-poll.sh http://apiv2.localhost:8192/api 123456 "$JWT" 30
+#
+# Auth: the offerer's session JWT (Link key -> JWT). Reads (/chat/rooms) need a
+# normal offerer session; the scoped helper_delegate token is only for sends.
+set -u
+
+BASE="${1:?usage: helper-poll.sh <api_base> <msgid> <offerer_jwt> [interval] [state_file]}"
+MSGID="${2:?msgid required}"
+JWT="${3:?offerer jwt required}"
+INTERVAL="${4:-30}"
+STATE="${5:-/tmp/helper-poll-${MSGID}.sig}"
+
+# Uses the #618 shortcut: /chat/rooms?msgid= returns only rooms about this offer.
+URL="${BASE%/}/chat/rooms?msgid=${MSGID}"
+
+prev=""
+[ -f "$STATE" ] && prev="$(cat "$STATE" 2>/dev/null)"
+
+echo "helper-poll: watching msgid=$MSGID every ${INTERVAL}s (state: $STATE)"
+while true; do
+  resp="$(curl -s -m 20 -H "Authorization: Bearer ${JWT}" "$URL" 2>/dev/null)"
+  if [ -n "$resp" ] && printf '%s' "$resp" | grep -q '[{[]'; then
+    # Signature over the whole response: any new message or unseen-count change
+    # flips it. No need to know the exact field names.
+    sig="$(printf '%s' "$resp" | md5sum | cut -d' ' -f1)"
+    if [ "$sig" != "$prev" ]; then
+      echo "CHANGED msgid=${MSGID} sig=${sig} at=$(date -u +%FT%TZ)"
+      printf '%s' "$sig" > "$STATE"
+      prev="$sig"
+    fi
+  else
+    echo "warn: empty/invalid response from $URL at $(date -u +%FT%TZ)" >&2
+  fi
+  sleep "$INTERVAL"
+done


### PR DESCRIPTION
## What

Phase 2 of the **Freegle Helper reply concierge** (`plans/active/freegle-helper-concierge.md`): the agent that manages replies to a bulk "clearance" offer on the offerer's behalf — reads each replier's chat, gathers what's needed for allocation, scores candidates, drafts allocation proposals for the offerer to approve, and sends warm, human-sounding replies **as the offerer** (flagged `fromhelper` for moderator oversight; the replier just sees the offerer).

The data + control plane already exist; this adds the operating agent on top:
- **Per-item interest** (#618): `GET /message/<id>` → `bulkitems[].interest[]` (owner-visible, with name/distance/responsiveness signals).
- **Control plane** (#838): `helper_batches`/`helper_repliers`/`helper_item_states`/`helper_proposals` + `GET/POST /helper`.
- **Send-as-offerer** (#618): scoped `helper_delegate` token + `fromhelper`, rate-limited and per-offer scoped.

## Files (`.claude/skills/freegle-helper-concierge/`)
- **`SKILL.md`** — the operating loop: set up a batch, extract the briefing from the post body, poll for changes, run each replier through the FSM + knowledge checklist, score, draft proposals for the human, and send replies. Hard rules: **human decides allocation**, **no LLM geography** (haversine only), one-message-all-questions, no mail-bombing, per-`msgid` scope, offerer-override cooldown, disclosure-to-mods-not-repliers.
- **`api-reference.md`** — exact contracts: helper-token mint, `GET/POST /helper` actions + payloads, chat read/send, user reputation, allocation (`BulkInterestState` / `bulk/state`), haversine.
- **`helper-poll.sh`** — LLM-free poller; emits `CHANGED` only when the offerer's chats for the managed offer change, so the model runs only when there's work.

## Status / dependencies
- **Depends on #618 + #838** being available — the agent drives their APIs. A live trial needs both merged.
- **Phase 3 (offerer dashboard)** starts as structured chat summaries (described in `SKILL.md`); a dedicated page is a follow-up.
- **Auth note:** `/helper` control-plane calls use the offerer's session (Link key → JWT); the scoped `helper_delegate` token currently covers the chat-send path. Extending the scoped token to `/helper` (so the concierge can run on the narrow token alone) is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
