### PR TITLE
fix(modtools): soften multi-group post wording (Also on -> May also be shown to some members in)

### DIFF
--- a/iznik-nuxt3/modtools/components/ModMessage.vue
+++ b/iznik-nuxt3/modtools/components/ModMessage.vue
@@ -160,7 +160,7 @@
               <span v-if="!homegroupontn"> but group not on TN </span>
             </div>
             <div v-if="otherGroups.length > 0" class="small text-muted">
-              Also on:
+              May also be shown to some members in
               <ShowMore
                 :items="otherGroups"
                 :limit="3"
@@ -943,7 +943,7 @@ const contextGroup = computed(() => {
 })
 
 // The origin group: the earliest arrival across the post's groups (shown as "First
-// posted on ..."). Excluded from "Also on" so it isn't listed twice.
+// posted on ..."). Excluded from the "may also be shown" list so it isn't listed twice.
 const originGroupid = computed(() => {
   const groups = message.value?.groups || []
   let earliest = null
@@ -955,8 +955,9 @@ const originGroupid = computed(() => {
   return earliest ? parseInt(earliest.groupid) : null
 })
 
-// Other groups this message is on (for the "Also on" indicator): everything except the
-// group being administered (context) and the origin/first-posted group.
+// Other groups this message is on (for the "may also be shown to some members in"
+// indicator): everything except the group being administered (context) and the
+// origin/first-posted group.
 const otherGroups = computed(() => {
   if (!message.value?.groups) return []
   const gid = currentGroupid.value

--- a/iznik-nuxt3/tests/unit/components/modtools/ModMessage.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModMessage.spec.js
@@ -1323,8 +1323,18 @@ describe('ModMessage', () => {
         { contextGroupid: 789 },
         {
           groups: [
-            { groupid: 999, namedisplay: 'Origin', collection: 'Approved', arrival: rippleEarlier },
-            { groupid: 789, namedisplay: 'Context', collection: 'Pending', arrival: rippleLater },
+            {
+              groupid: 999,
+              namedisplay: 'Origin',
+              collection: 'Approved',
+              arrival: rippleEarlier,
+            },
+            {
+              groupid: 789,
+              namedisplay: 'Context',
+              collection: 'Pending',
+              arrival: rippleLater,
+            },
           ],
         }
       )
@@ -1342,8 +1352,18 @@ describe('ModMessage', () => {
         { contextGroupid: 789 },
         {
           groups: [
-            { groupid: 999, namedisplay: 'Origin', collection: 'Approved', arrival: rippleEarlier },
-            { groupid: 789, namedisplay: 'Context', collection: 'Pending', arrival: rippleEarlier },
+            {
+              groupid: 999,
+              namedisplay: 'Origin',
+              collection: 'Approved',
+              arrival: rippleEarlier,
+            },
+            {
+              groupid: 789,
+              namedisplay: 'Context',
+              collection: 'Pending',
+              arrival: rippleEarlier,
+            },
           ],
         }
       )
@@ -1358,8 +1378,18 @@ describe('ModMessage', () => {
         { contextGroupid: 789 },
         {
           groups: [
-            { groupid: 999, namedisplay: 'Origin', collection: 'Approved', arrival: rippleEarlier },
-            { groupid: 789, namedisplay: 'Context', collection: 'Approved', arrival: rippleLater },
+            {
+              groupid: 999,
+              namedisplay: 'Origin',
+              collection: 'Approved',
+              arrival: rippleEarlier,
+            },
+            {
+              groupid: 789,
+              namedisplay: 'Context',
+              collection: 'Approved',
+              arrival: rippleLater,
+            },
           ],
         }
       )
@@ -1411,7 +1441,7 @@ describe('ModMessage', () => {
       expect(wrapper.vm.otherGroups[0].groupid).toBe(999)
     })
 
-    it('shows "Also on" indicator for multi-group messages', async () => {
+    it('shows the multi-group ("may also be shown") indicator for multi-group messages', async () => {
       const wrapper = mountComponent(
         { contextGroupid: 789 },
         {
@@ -1422,10 +1452,10 @@ describe('ModMessage', () => {
         }
       )
       await flushPromises()
-      expect(wrapper.text()).toContain('Also on')
+      expect(wrapper.text()).toContain('May also be shown to some members in')
     })
 
-    it('does not show "Also on" for single-group messages', async () => {
+    it('does not show the multi-group indicator for single-group messages', async () => {
       const wrapper = mountComponent(
         { contextGroupid: 789 },
         {
@@ -1435,7 +1465,9 @@ describe('ModMessage', () => {
         }
       )
       await flushPromises()
-      expect(wrapper.text()).not.toContain('Also on')
+      expect(wrapper.text()).not.toContain(
+        'May also be shown to some members in'
+      )
     })
   })
 
@@ -1449,7 +1481,9 @@ describe('ModMessage', () => {
       const wrapper = mountComponent({ summary: true })
       const usernameEl = wrapper.find('.text-truncate.d-inline-block')
       expect(usernameEl.exists()).toBe(true)
-      expect(usernameEl.text()).toContain('AVeryLongUsernameThatWouldSqueezeEditFields')
+      expect(usernameEl.text()).toContain(
+        'AVeryLongUsernameThatWouldSqueezeEditFields'
+      )
       expect(usernameEl.attributes('style')).toContain('max-width: 8rem')
     })
 


### PR DESCRIPTION
## What

Softens the ModTools multi-group post indicator wording while moderators get used to rippling.

`iznik-nuxt3/modtools/components/ModMessage.vue` — the indicator shown when a post is on groups other than the one being administered changes from:

> **Also on:** Group A, Group B

to:

> **May also be shown to some members in** Group A, Group B

"Also on" is concise but reads like a full cross-post; the new wording makes clear the post isn't on those groups for everyone — it's just shown to some of their members (the rippling reach). Easy to revert to "Also on" once the concept is familiar.

The unit spec assertions + code comments are updated to match. The ModMessage unit suite is green (508 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
