### PR TITLE
fix(browse): don't show a member their own rejected post in browse

### DIFF
--- a/iznik-server-go/group/groupMessages.go
+++ b/iznik-server-go/group/groupMessages.go
@@ -21,13 +21,15 @@ func GetGroupMessages(c *fiber.Ctx) error {
 	then := now.AddDate(0, 0, -31)
 
 	// We want to return messages which have no outcome or are successful (which will be shown by the client as
-	// freegled) but not withdrawn messages.  We also want to add in any messages of our own.
+	// freegled) but not withdrawn messages.  We also add in our own posts that are still pending, so a member
+	// can't tell their post is awaiting moderation - but NOT our own rejected posts: a rejected post has been
+	// removed and must not leak back into the poster's browse feed.
 	db.Raw("SELECT messages_groups.msgid FROM messages_groups "+
 		"LEFT JOIN messages_outcomes ON messages_outcomes.msgid = messages_groups.msgid "+
 		"INNER JOIN messages ON messages.id = messages_groups.msgid "+
 		"INNER JOIN users ON users.id = messages.fromuser "+
-		"WHERE groupid = ? AND messages_groups.arrival >= ? AND (collection = ? OR messages.fromuser = ?) AND messages_groups.deleted = 0 AND users.deleted IS NULL AND (messages_outcomes.id IS NULL OR messages_outcomes.outcome IN (?, ?)) "+
-		"ORDER BY messages_groups.arrival DESC", id, then.Format(time.RFC3339), utils.COLLECTION_APPROVED, myid, utils.OUTCOME_TAKEN, utils.OUTCOME_RECEIVED).Pluck("msgid", &ret)
+		"WHERE groupid = ? AND messages_groups.arrival >= ? AND (collection = ? OR (messages.fromuser = ? AND collection != ?)) AND messages_groups.deleted = 0 AND users.deleted IS NULL AND (messages_outcomes.id IS NULL OR messages_outcomes.outcome IN (?, ?)) "+
+		"ORDER BY messages_groups.arrival DESC", id, then.Format(time.RFC3339), utils.COLLECTION_APPROVED, myid, utils.COLLECTION_REJECTED, utils.OUTCOME_TAKEN, utils.OUTCOME_RECEIVED).Pluck("msgid", &ret)
 
 	if ret == nil {
 		ret = make([]uint64, 0)

--- a/iznik-server-go/test/browse_own_rejected_test.go
+++ b/iznik-server-go/test/browse_own_rejected_test.go
@@ -1,0 +1,51 @@
+package test
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/freegle/iznik-server-go/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+// A member's own PENDING post is deliberately shown back to them in browse (the
+// "fromuser" branch of GetGroupMessages) so they can't tell it is still awaiting
+// moderation. A REJECTED post, however, must NOT leak back into their browse feed
+// — it has been removed by the moderators.
+func TestBrowseHidesOwnRejectedPost(t *testing.T) {
+	db := database.DBConn
+	groupID := CreateTestGroup(t, "brownrej")
+	userID := CreateTestUser(t, "brownrej", "User")
+	token := getToken(t, userID)
+
+	approvedMsg := CreateTestMessage(t, userID, groupID, "OFFER: approved brownrej", 51.5, -0.1)
+	pendingMsg := CreateTestMessage(t, userID, groupID, "OFFER: pending brownrej", 51.5, -0.1)
+	rejectedMsg := CreateTestMessage(t, userID, groupID, "OFFER: rejected brownrej", 51.5, -0.1)
+
+	// CreateTestMessage defaults the collection to Approved; set the other two.
+	db.Exec("UPDATE messages_groups SET collection = ? WHERE msgid = ?", utils.COLLECTION_PENDING, pendingMsg)
+	db.Exec("UPDATE messages_groups SET collection = ? WHERE msgid = ?", utils.COLLECTION_REJECTED, rejectedMsg)
+
+	resp, err := getApp().Test(httptest.NewRequest("GET", "/api/group/"+fmt.Sprint(groupID)+"/message?jwt="+token, nil))
+	assert.NoError(t, err)
+	body, _ := io.ReadAll(resp.Body)
+	var ids []uint64
+	assert.NoError(t, json.Unmarshal(body, &ids))
+
+	has := func(id uint64) bool {
+		for _, x := range ids {
+			if x == id {
+				return true
+			}
+		}
+		return false
+	}
+
+	assert.True(t, has(approvedMsg), "own approved post should appear in browse")
+	assert.True(t, has(pendingMsg), "own pending post should appear in browse (can't tell it's pending)")
+	assert.False(t, has(rejectedMsg), "own rejected post must NOT appear in browse")
+}


### PR DESCRIPTION
## Problem

`GetGroupMessages` (the browse feed for a group) deliberately includes a member's **own** posts via the `messages.fromuser = <me>` branch, so a still-pending post is shown back to them and they can't tell it's awaiting moderation:

```sql
... AND (collection = 'Approved' OR messages.fromuser = ?) ...
```

But that branch matched the member's own posts in **any** collection state — including **Rejected**. A post the moderators rejected (removed) therefore leaked back into the poster's browse feed, appearing as if it were still live.

## Fix

Restrict the `fromuser` branch to exclude rejected posts, so own **approved** and **pending** posts still show but **rejected** ones do not:

```sql
... AND (collection = 'Approved' OR (messages.fromuser = ? AND collection != 'Rejected')) ...
```

One line in `iznik-server-go/group/groupMessages.go`.

## Test (TDD)

`TestBrowseHidesOwnRejectedPost` creates a member's own approved, pending, and rejected posts on a group and browses as that member:
- own **approved** appears ✓
- own **pending** appears ✓ (the "can't tell it's pending" behaviour is preserved)
- own **rejected** must **not** appear ✗→✓

Red before the query change, green after. Full Go suite green (3286), no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
