### PR TITLE
fix(modtools): exclude rippled-in copies from Edit work counts

### DIFF
--- a/iznik-server-go/group/groupWork.go
+++ b/iznik-server-go/group/groupWork.go
@@ -281,10 +281,16 @@ func GetGroupWork(c *fiber.Ctx) error {
 			return
 		}
 		var rows []countRow
+		// rippled_in = 0: an edit belongs to the post's ORIGIN group only. A post
+		// rippled INTO a group has an Approved messages_groups row (rippled_in=1)
+		// there, so without this filter its edit is counted in every receiving
+		// group's Edit badge while the Edit list (which filters rippled_in=0) shows
+		// nothing — a "ghost" count (Discourse 9839). Matches the ListMessagesMT
+		// Edit query and the session editreview count.
 		db.Raw("SELECT mg.groupid, COUNT(DISTINCT me.msgid) as count FROM messages_edits me "+
 			"INNER JOIN messages_groups mg ON mg.msgid = me.msgid "+
 			"WHERE mg.groupid IN ? AND me.reviewrequired = 1 AND me.approvedat IS NULL AND me.revertedat IS NULL "+
-			"AND me.timestamp > DATE_SUB(NOW(), INTERVAL 7 DAY) AND mg.deleted = 0 "+
+			"AND me.timestamp > DATE_SUB(NOW(), INTERVAL 7 DAY) AND mg.deleted = 0 AND mg.rippled_in = 0 "+
 			"GROUP BY mg.groupid", activeGroupIDs).Scan(&rows)
 		mapMutex.Lock()
 		for _, r := range rows {

--- a/iznik-server-go/session/session.go
+++ b/iznik-server-go/session/session.go
@@ -1163,8 +1163,12 @@ func GetSession(c *fiber.Ctx) error {
 		go func() {
 			defer wg2.Done()
 			if len(activeGroupIDs) > 0 {
+				// rippled_in = 0: an edit belongs to the post's origin group only;
+				// without this the Edit badge counts rippled-in copies that the Edit
+				// list (filtered rippled_in=0) never shows — a ghost count (Discourse
+				// 9839). Matches ListMessagesMT and groupWork's per-group Editreview.
 				db.Raw("SELECT COUNT(DISTINCT me.msgid) FROM messages_edits me "+
-					"INNER JOIN messages_groups mg ON mg.msgid = me.msgid AND mg.deleted = 0 "+
+					"INNER JOIN messages_groups mg ON mg.msgid = me.msgid AND mg.deleted = 0 AND mg.rippled_in = 0 "+
 					"WHERE mg.groupid IN ? AND me.reviewrequired = 1 AND me.approvedat IS NULL AND me.revertedat IS NULL AND me.timestamp > DATE_SUB(NOW(), INTERVAL 7 DAY)",
 					activeGroupIDs).Scan(&editreview)
 			}

--- a/iznik-server-go/test/groupWork_test.go
+++ b/iznik-server-go/test/groupWork_test.go
@@ -465,6 +465,58 @@ func TestGetGroupWork_EditReview(t *testing.T) {
 	db.Exec("DELETE FROM messages WHERE id = ?", msgID)
 }
 
+// Regression (Discourse 9839): an edit on a post that rippled INTO a group must
+// NOT inflate that group's Edit work count. The rippled-in copy is Approved with
+// rippled_in=1; the Edit list filters rippled_in=0, so a count that ignored that
+// showed a "ghost" badge against a group whose Edit list is empty. The count must
+// match the list — edits belong to the post's ORIGIN group only.
+func TestGetGroupWork_EditReviewExcludesRippledIn(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("gweditrip")
+
+	originGroup := CreateTestGroup(t, prefix+"_orig")
+	rippledGroup := CreateTestGroup(t, prefix+"_rip")
+	originMod := CreateTestUser(t, prefix+"_omod", "User")
+	rippledMod := CreateTestUser(t, prefix+"_rmod", "User")
+	CreateTestMembership(t, originMod, originGroup, "Moderator")
+	CreateTestMembership(t, rippledMod, rippledGroup, "Moderator")
+	_, originToken := CreateTestSession(t, originMod)
+	_, rippledToken := CreateTestSession(t, rippledMod)
+
+	senderID := CreateTestUser(t, prefix+"_sender", "User")
+	var msgID uint64
+	db.Exec("INSERT INTO messages (fromuser, type, subject, textbody, message) VALUES (?, 'Offer', 'Rippled edit count', 'b', 'b')", senderID)
+	db.Raw("SELECT id FROM messages WHERE fromuser = ? ORDER BY id DESC LIMIT 1", senderID).Scan(&msgID)
+	// Origin row (rippled_in=0) plus a rippled-in copy (rippled_in=1).
+	db.Exec("INSERT INTO messages_groups (msgid, groupid, collection, deleted, rippled_in) VALUES (?, ?, 'Approved', 0, 0)", msgID, originGroup)
+	db.Exec("INSERT INTO messages_groups (msgid, groupid, collection, deleted, rippled_in) VALUES (?, ?, 'Approved', 0, 1)", msgID, rippledGroup)
+	db.Exec("INSERT INTO messages_edits (msgid, timestamp, reviewrequired, oldtext, newtext) VALUES (?, NOW(), 1, 'old', 'new')", msgID)
+
+	t.Cleanup(func() {
+		db.Exec("DELETE FROM messages_edits WHERE msgid = ?", msgID)
+		db.Exec("DELETE FROM messages_groups WHERE msgid = ?", msgID)
+		db.Exec("DELETE FROM messages WHERE id = ?", msgID)
+	})
+
+	editCountFor := func(token string, gid uint64) int64 {
+		resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/group/work?jwt="+token, nil))
+		assert.Equal(t, 200, resp.StatusCode)
+		var result []group.GroupWork
+		json2.Unmarshal(rsp(resp), &result)
+		for i := range result {
+			if result[i].Groupid == gid {
+				return result[i].Editreview
+			}
+		}
+		return 0
+	}
+
+	assert.GreaterOrEqual(t, editCountFor(originToken, originGroup), int64(1),
+		"origin group's Edit count should include the edit")
+	assert.Equal(t, int64(0), editCountFor(rippledToken, rippledGroup),
+		"rippled-into group's Edit count must NOT include the rippled-in copy's edit (Discourse 9839)")
+}
+
 func TestGetGroupWork_OwnerRole(t *testing.T) {
 	// Owners should also see work counts.
 	prefix := uniquePrefix("gwowner")


### PR DESCRIPTION
## Problem
Mods report "ghost" Edit counts in ModTools - [message-count-errors/9839](https://discourse.ilovefreegle.org/t/message-count-errors/9839):
- Jeni: a red badge for **2 Edits**, but **5** shown against groups (2 Witney, 2 Vale of White Horse, 1 Didcot) — all of which open to an empty Edit list.
- Derek sees those Vale of White Horse edits on a group he doesn't own.

## Root cause
The earlier fix (`6f56ac259`) added `rippled_in = 0` to the Edit **list** query (`ListMessagesMT`), so the list correctly excludes posts that only rippled INTO a group (those have an Approved `messages_groups` row with `rippled_in = 1`). But the Edit **count** queries were not updated, so the badge counts edits the list never shows — a count/list mismatch, and counts leaking onto receiving groups.

## Fix
Add `AND mg.rippled_in = 0` to both Edit-count queries, matching the list:
- `group/groupWork.go` — per-group `Editreview` count
- `session/session.go` — the overall `editreview` badge

An edit belongs to the post's **origin** group only.

## Test
`TestGetGroupWork_EditReviewExcludesRippledIn`: with a post whose edit is pending and a rippled-in copy on a second group, the origin group's Edit count includes the edit and the rippled-into group's stays **0**. Full Go suite green (3288✓).

🤖 Generated with [Claude Code](https://claude.com/claude-code)