### PR TITLE
fix(app): show a clear "out of date" message on session ret:123

### DIFF
--- a/iznik-nuxt3/components/SomethingWentWrong.vue
+++ b/iznik-nuxt3/components/SomethingWentWrong.vue
@@ -2,7 +2,35 @@
   <client-only>
     <div v-if="!unloading" class="d-flex justify-content-around">
       <NoticeMessage
-        v-if="showError"
+        v-if="appOutOfDate"
+        variant="danger"
+        class="posit text-center"
+        show
+      >
+        <p class="font-weight-bold mb-2">
+          {{
+            appOutOfDateMessage ||
+            'Freegle is out of date - please update to the latest version.'
+          }}
+        </p>
+        <div v-if="mobileStore.isApp">
+          <p class="mb-0">
+            Please update the Freegle app from your app store to get the latest
+            version, or
+            <a
+              href="https://www.ilovefreegle.org"
+              target="_blank"
+              rel="noopener"
+              >use the website</a
+            >.
+          </p>
+        </div>
+        <div v-else class="d-flex justify-content-around">
+          <b-button variant="primary" @click="reload"> Reload now </b-button>
+        </div>
+      </NoticeMessage>
+      <NoticeMessage
+        v-else-if="showError"
         variant="danger"
         class="posit text-center"
         show
@@ -100,6 +128,7 @@ import { storeToRefs } from 'pinia'
 import NoticeMessage from './NoticeMessage'
 import { ref, watch, onBeforeUnmount } from '#imports'
 import { useMiscStore } from '~/stores/misc'
+import { useMobileStore } from '~/stores/mobile'
 import SupportLink from '~/components/SupportLink'
 import { HARD_RELOAD_COUNTDOWN_SECS, TYPING_TIME_INVERVAL } from '~/constants'
 
@@ -111,6 +140,7 @@ const hardCountdown = ref(HARD_RELOAD_COUNTDOWN_SECS)
 const hardReloadTimer = ref(null)
 
 const miscStore = useMiscStore()
+const mobileStore = useMobileStore()
 const {
   somethingWentWrong,
   needToReload,
@@ -119,6 +149,8 @@ const {
   unloading,
   errorDetails,
   lastTyping,
+  appOutOfDate,
+  appOutOfDateMessage,
 } = storeToRefs(miscStore)
 
 const showStackTrace = ref(false)

--- a/iznik-nuxt3/stores/auth.js
+++ b/iznik-nuxt3/stores/auth.js
@@ -333,6 +333,18 @@ export const useAuthStore = defineStore({
             false
           )
 
+          if (sessionData?.ret === 123) {
+            // Server kill switch: GET /session returns HTTP 200 with ret:123 when
+            // this client build is older than app_min_webversion and is therefore
+            // too old to function. The auth tokens are still valid, so we must NOT
+            // clear them - doing so would silently log the user out and bounce them
+            // to the login screen, which looks like a generic failure. Instead
+            // surface a clear "app is out of date" message and stop here.
+            useMiscStore().setAppOutOfDate(sessionData.status)
+            this.loginStateKnown = true
+            return this.user
+          }
+
           if (sessionData && sessionData.me && sessionData.me.id) {
             me = sessionData.me
 

--- a/iznik-nuxt3/stores/misc.js
+++ b/iznik-nuxt3/stores/misc.js
@@ -16,6 +16,8 @@ export const useMiscStore = defineStore({
     vals: {},
     somethingWentWrong: false,
     errorDetails: null,
+    appOutOfDate: false,
+    appOutOfDateMessage: '',
     needToReload: false,
     needToReloadHard: false,
     visible: true,
@@ -74,6 +76,13 @@ export const useMiscStore = defineStore({
     clearError() {
       this.somethingWentWrong = false
       this.errorDetails = null
+    },
+    setAppOutOfDate(message) {
+      // The server kill switch (ret:123 from GET /session) tells us this client
+      // build is too old to function. Surface it as a clear, explicit message
+      // rather than letting it manifest as a silent logout or generic error.
+      this.appOutOfDate = true
+      this.appOutOfDateMessage = message || ''
     },
     api(diff) {
       this.apiCount += diff

--- a/iznik-nuxt3/tests/unit/components/SomethingWentWrong.spec.js
+++ b/iznik-nuxt3/tests/unit/components/SomethingWentWrong.spec.js
@@ -17,6 +17,11 @@ const offlineRef = ref(false)
 const unloadingRef = ref(false)
 const errorDetailsRef = ref(null)
 const lastTypingRef = ref(null)
+const appOutOfDateRef = ref(false)
+const appOutOfDateMessageRef = ref('')
+
+// Mutable mobile-store state so each test can pick the app vs website variant.
+const mobileState = { isApp: false }
 
 // Mock Pinia's storeToRefs to return our refs while preserving other exports
 vi.mock('pinia', async (importOriginal) => {
@@ -31,6 +36,8 @@ vi.mock('pinia', async (importOriginal) => {
       unloading: unloadingRef,
       errorDetails: errorDetailsRef,
       lastTyping: lastTypingRef,
+      appOutOfDate: appOutOfDateRef,
+      appOutOfDateMessage: appOutOfDateMessageRef,
     }),
   }
 })
@@ -40,6 +47,11 @@ vi.mock('~/stores/misc', () => ({
   useMiscStore: () => ({
     clearError: mockClearError,
   }),
+}))
+
+// Mock mobile store so we can toggle the app vs website experience.
+vi.mock('~/stores/mobile', () => ({
+  useMobileStore: () => mobileState,
 }))
 
 describe('SomethingWentWrong', () => {
@@ -56,6 +68,9 @@ describe('SomethingWentWrong', () => {
     unloadingRef.value = false
     errorDetailsRef.value = null
     lastTypingRef.value = null
+    appOutOfDateRef.value = false
+    appOutOfDateMessageRef.value = ''
+    mobileState.isApp = false
     // jsdom's location.reload is not directly assignable; redefine it so we can
     // observe forced reloads without navigating.
     reloadSpy = vi.fn()
@@ -152,6 +167,65 @@ describe('SomethingWentWrong', () => {
       const wrapper = createWrapper()
       // Component should mount and connect to store without error
       expect(wrapper.exists()).toBe(true)
+    })
+  })
+
+  describe('app out of date (server kill switch / ret:123)', () => {
+    it('shows a danger banner with the server message and a Reload button on the website', () => {
+      appOutOfDateRef.value = true
+      appOutOfDateMessageRef.value =
+        'App is out of date - please upgrade or use the website'
+      mobileState.isApp = false
+
+      const wrapper = createWrapper()
+      const notice = wrapper.find('.notice-message')
+
+      expect(notice.exists()).toBe(true)
+      expect(notice.classes()).toContain('danger')
+      expect(wrapper.text()).toContain(
+        'App is out of date - please upgrade or use the website'
+      )
+      expect(wrapper.text()).toContain('Reload')
+    })
+
+    it('reloads when the Reload button is clicked on the website', async () => {
+      appOutOfDateRef.value = true
+      mobileState.isApp = false
+
+      const wrapper = createWrapper()
+      await wrapper.find('button').trigger('click')
+
+      expect(reloadSpy).toHaveBeenCalled()
+    })
+
+    it('tells app users to update via their app store, offers the website, and shows no Reload button', () => {
+      appOutOfDateRef.value = true
+      appOutOfDateMessageRef.value =
+        'App is out of date - please upgrade or use the website'
+      mobileState.isApp = true
+
+      const wrapper = createWrapper()
+
+      expect(wrapper.find('.notice-message').exists()).toBe(true)
+      expect(wrapper.text().toLowerCase()).toContain('app store')
+      // Website fallback link is offered.
+      expect(wrapper.find('a').exists()).toBe(true)
+      // Reloading won't refresh a stale embedded app bundle, so no Reload button.
+      expect(wrapper.find('button').exists()).toBe(false)
+    })
+
+    it('takes priority over the stale-build hard-reload banner', () => {
+      appOutOfDateRef.value = true
+      appOutOfDateMessageRef.value =
+        'App is out of date - please upgrade or use the website'
+      // needToReloadHard renders immediately (immediate watcher); the
+      // out-of-date banner must still win.
+      needToReloadHardRef.value = true
+
+      const wrapper = createWrapper()
+
+      expect(wrapper.text()).toContain('App is out of date')
+      expect(wrapper.text()).not.toContain('more than a week out of date')
     })
   })
 

--- a/iznik-nuxt3/tests/unit/stores/auth.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/auth.spec.js
@@ -13,6 +13,7 @@ const mockRelated = vi.fn()
 const mockLostPassword = vi.fn()
 const mockUnsubscribe = vi.fn()
 const mockSave = vi.fn()
+const mockSetAppOutOfDate = vi.fn()
 
 vi.mock('~/api', () => ({
   default: () => ({
@@ -61,7 +62,11 @@ vi.mock('~/stores/mobile', () => ({
 }))
 
 vi.mock('~/stores/misc', () => ({
-  useMiscStore: () => ({ modtools: false, source: null }),
+  useMiscStore: () => ({
+    modtools: false,
+    source: null,
+    setAppOutOfDate: mockSetAppOutOfDate,
+  }),
 }))
 
 describe('auth store', () => {
@@ -382,6 +387,41 @@ describe('auth store', () => {
 
       expect(store.auth.jwt).toBe('valid-jwt')
       expect(store.user.id).toBe(42)
+    })
+  })
+
+  describe('fetchUser app out of date (ret:123)', () => {
+    it('flags the app as out of date and preserves auth when session returns ret:123', async () => {
+      store.setAuth('valid-jwt', 'valid-persistent')
+
+      // Server kill switch: GET /session returns HTTP 200 with ret:123 when the
+      // client build is older than app_min_webversion.
+      mockFetchv2.mockResolvedValue({
+        ret: 123,
+        status: 'App is out of date - please upgrade or use the website',
+      })
+
+      await store.fetchUser()
+
+      // Auth must NOT be wiped (otherwise the user is silently bounced to the
+      // login screen, which looks like a generic failure).
+      expect(store.auth.jwt).toBe('valid-jwt')
+      expect(store.auth.persistent).toBe('valid-persistent')
+      expect(store.user).toBeNull()
+      // ...and the message must be surfaced clearly.
+      expect(mockSetAppOutOfDate).toHaveBeenCalledWith(
+        'App is out of date - please upgrade or use the website'
+      )
+    })
+
+    it('does not flag out of date on a normal successful session', async () => {
+      store.setAuth('valid-jwt', 'valid-persistent')
+      mockFetchv2.mockResolvedValue({ me: { id: 5 }, groups: [] })
+
+      await store.fetchUser()
+
+      expect(mockSetAppOutOfDate).not.toHaveBeenCalled()
+      expect(store.user.id).toBe(5)
     })
   })
 

--- a/iznik-nuxt3/tests/unit/stores/misc.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/misc.spec.js
@@ -26,6 +26,8 @@ describe('misc store', () => {
       expect(store.vals).toEqual({})
       expect(store.somethingWentWrong).toBe(false)
       expect(store.errorDetails).toBeNull()
+      expect(store.appOutOfDate).toBe(false)
+      expect(store.appOutOfDateMessage).toBe('')
       expect(store.needToReload).toBe(false)
       expect(store.visible).toBe(true)
       expect(store.apiCount).toBe(0)
@@ -139,6 +141,28 @@ describe('misc store', () => {
     })
   })
 
+  describe('setAppOutOfDate', () => {
+    it('sets appOutOfDate flag and stores the server message', () => {
+      const store = useMiscStore()
+      store.setAppOutOfDate(
+        'App is out of date - please upgrade or use the website'
+      )
+
+      expect(store.appOutOfDate).toBe(true)
+      expect(store.appOutOfDateMessage).toBe(
+        'App is out of date - please upgrade or use the website'
+      )
+    })
+
+    it('falls back to an empty message when none is supplied', () => {
+      const store = useMiscStore()
+      store.setAppOutOfDate()
+
+      expect(store.appOutOfDate).toBe(true)
+      expect(store.appOutOfDateMessage).toBe('')
+    })
+  })
+
   describe('api counter', () => {
     it('increments api count', () => {
       const store = useMiscStore()
@@ -176,7 +200,11 @@ describe('misc store', () => {
       const mockResponse = { status: 200 }
       vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResponse))
 
-      const result = await store.fetchWithTimeout('http://test/online', null, 5000)
+      const result = await store.fetchWithTimeout(
+        'http://test/online',
+        null,
+        5000
+      )
       expect(result).toBe(mockResponse)
     })
 
@@ -253,10 +281,7 @@ describe('misc store', () => {
 
       const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 
-      vi.stubGlobal(
-        'fetch',
-        vi.fn().mockResolvedValue({ status: 500 })
-      )
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ status: 500 }))
 
       await store.checkOnline()
 


### PR DESCRIPTION
## Problem

The apiv2 `GET /session` kill switch (`iznik-server-go/session/session.go`) returns **HTTP 200** with `{ret:123, "App is out of date - please upgrade or use the website"}` when the client build is older than `app_min_webversion` (or `app_min_webversion_mt` for ModTools).

Because it's HTTP 200, `BaseAPI` did not throw, so `auth.js` `fetchUser()` saw a response with no `me`, no error, and fell through to clearing auth - silently logging the user out and bouncing them to the login screen. To the user this is indistinguishable from a generic "something went wrong" failure, and the clear server message was discarded.

## Fix (client-side, iznik-nuxt3)

- **`stores/misc.js`**: new `appOutOfDate` / `appOutOfDateMessage` state and a `setAppOutOfDate(message)` action.
- **`stores/auth.js`**: `fetchUser()` detects `sessionData.ret === 123`, surfaces the server message via `setAppOutOfDate`, and returns early **without** wiping the (still-valid) auth tokens, so the user is no longer bounced to login.
- **`components/SomethingWentWrong.vue`** (rendered globally): a new highest-priority, non-dismissable danger banner. On the **website** it offers a Reload button (a fresh deploy self-heals); inside the **Capacitor app** it tells the user to update from their app store and offers a website link, since reloading a stale embedded bundle won't help.

## Tests (TDD)

- misc store: `setAppOutOfDate` sets the flag/message and defaults to an empty message.
- auth store: `fetchUser` on `ret:123` flags out-of-date, preserves auth, and leaves the user null; a normal session does not flag it.
- `SomethingWentWrong.vue`: website variant (message + Reload), app variant (app-store guidance + website link, no Reload), and priority over the stale-build banner.

Full Vitest unit suite green locally (13569 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)