### PR TITLE
feat(status): restore /api/tests/vitest runner endpoint

### DIFF
--- a/status/server.js
+++ b/status/server.js
@@ -35,6 +35,7 @@ const APIV1_PHPUNIT = `${PROJECT}-apiv1-phpunit`;
 const BATCH = `${PROJECT}-batch`;
 const PLAYWRIGHT = `${PROJECT}-playwright`;
 const PROD_LOCAL = `${PROJECT}-prod-local`;
+const DEV_LOCAL = `${PROJECT}-dev-local`;
 const PERCONA = `${PROJECT}-percona`;
 console.log(`Using container prefix: ${PROJECT}`);
 
@@ -1931,6 +1932,143 @@ const httpServer = http.createServer(async (req, res) => {
       testStatuses.goTests.status = "failed";
       testStatuses.goTests.message = `Error: ${error.message}`;
       testStatuses.goTests.endTime = Date.now();
+    });
+
+    return;
+  }
+
+  // Vitest (frontend unit) tests status endpoint
+  if (parsedUrl.pathname === "/api/tests/vitest/status" && req.method === "GET") {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify(testStatuses.vitestTests || { status: "idle" }));
+    return;
+  }
+
+  // Vitest (frontend unit) tests endpoint
+  // Runs iznik-nuxt3's Vitest suite (the frontend unit-test gate that previously
+  // only ran in CI) inside the running nuxt3 dev container, which has the source
+  // baked at /app, node_modules present, and .nuxt already prepared by the dev
+  // server. Mirrors CI's `npm run test:unit:run`. Optional JSON body {"filter":"X"}
+  // narrows to matching spec files/names; ?coverage=true enables coverage.
+  if (parsedUrl.pathname === "/api/tests/vitest" && req.method === "POST") {
+    console.log("Starting Vitest (frontend unit) tests...");
+
+    // Check if already running
+    if (
+      testStatuses.vitestTests &&
+      testStatuses.vitestTests.status === "running"
+    ) {
+      res.writeHead(409, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "Vitest tests are already running" }));
+      return;
+    }
+
+    // Parse request body for optional filter parameter
+    let body = "";
+    req.on("data", (chunk) => {
+      body += chunk.toString();
+    });
+
+    req.on("end", () => {
+      let filter = "";
+      if (body) {
+        try {
+          const parsed = JSON.parse(body);
+          if (parsed && typeof parsed.filter === "string") filter = parsed.filter;
+        } catch (e) {
+          // Malformed body — fall back to running the full suite.
+        }
+      }
+      // Sanitise to a safe pattern (no shell metacharacters reach the container).
+      const safeFilter = filter.replace(/[^A-Za-z0-9_./-]/g, "");
+      const withCoverage =
+        parsedUrl.query && parsedUrl.query.coverage === "true";
+
+      // Initialize test status
+      testStatuses.vitestTests = {
+        status: "running",
+        message: safeFilter
+          ? `Running Vitest (filter: ${safeFilter})...`
+          : "Running Vitest unit tests...",
+        logs: "",
+        filter: safeFilter,
+        progress: { completed: 0, total: 0, passed: 0, failed: 0, current: "" },
+        startTime: Date.now(),
+        withCoverage,
+      };
+
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ status: "started" }));
+
+      const coverageArg = withCoverage ? " --coverage" : "";
+      const filterArg = safeFilter ? ` ${safeFilter}` : "";
+      const innerCmd = `npm run test:unit:run -- --reporter=verbose${coverageArg}${filterArg}`;
+
+      const { spawn } = require("child_process");
+      const testProcess = spawn(
+        "sh",
+        ["-c", `docker exec -w /app ${DEV_LOCAL} sh -c "${innerCmd} 2>&1"`],
+        { stdio: "pipe" }
+      );
+
+      testProcess.stdout.on("data", (data) => {
+        const text = data.toString();
+        testStatuses.vitestTests.logs += text;
+
+        const lines = text.split("\n");
+        for (const line of lines) {
+          // Per-test/file marks from the verbose reporter (✓ pass, ×/✗ fail).
+          // These can over-count (file + test level); the final summary below
+          // overrides with the authoritative totals.
+          if (/^\s*[✓√]\s/.test(line)) {
+            testStatuses.vitestTests.progress.passed++;
+            testStatuses.vitestTests.progress.completed++;
+            const m = line.match(/^\s*[✓√]\s+(.*?)(?:\s+\d+\s*ms)?$/);
+            if (m && m[1]) testStatuses.vitestTests.progress.current = m[1];
+          } else if (/^\s*[×✗✘]\s/.test(line)) {
+            testStatuses.vitestTests.progress.failed++;
+            testStatuses.vitestTests.progress.completed++;
+          }
+          // Authoritative summary, e.g.:
+          //   Tests  2 failed | 338 passed | 1 skipped (341)
+          //   Tests  340 passed (340)
+          const tm = line.match(
+            /Tests\s+(?:(\d+)\s+failed\s*\|\s*)?(\d+)\s+passed(?:\s*\|\s*(\d+)\s+skipped)?\s*\((\d+)\)/
+          );
+          if (tm) {
+            testStatuses.vitestTests.progress.failed = parseInt(tm[1] || "0", 10);
+            testStatuses.vitestTests.progress.passed = parseInt(tm[2] || "0", 10);
+            testStatuses.vitestTests.progress.total = parseInt(tm[4] || "0", 10);
+            testStatuses.vitestTests.progress.completed =
+              testStatuses.vitestTests.progress.total;
+          }
+        }
+
+        const p = testStatuses.vitestTests.progress;
+        testStatuses.vitestTests.message = `Running... ${p.passed}✓ ${p.failed}✗`;
+      });
+
+      testProcess.stderr.on("data", (data) => {
+        testStatuses.vitestTests.logs += data.toString();
+      });
+
+      testProcess.on("close", (code) => {
+        const p = testStatuses.vitestTests.progress;
+        testStatuses.vitestTests.status = code === 0 ? "completed" : "failed";
+        testStatuses.vitestTests.success = code === 0;
+        testStatuses.vitestTests.endTime = Date.now();
+        testStatuses.vitestTests.message =
+          code === 0
+            ? `All tests passed (${p.passed}✓)`
+            : `Tests failed (${p.passed}✓ ${p.failed}✗)`;
+        console.log(`Vitest tests completed with code ${code}`);
+      });
+
+      testProcess.on("error", (error) => {
+        testStatuses.vitestTests.status = "failed";
+        testStatuses.vitestTests.message = `Error: ${error.message}`;
+        testStatuses.vitestTests.endTime = Date.now();
+      });
     });
 
     return;


### PR DESCRIPTION
## Problem

The status server (`status/server.js`) runs the go / laravel / php / playwright suites via `POST /api/tests/<suite>`, but it has **no frontend unit (Vitest) runner** on `master`. The commit that originally added one (`8d43ee146`) is orphaned - it never reached `origin/master` (not an ancestor, not on any branch; a lost local commit). 

So on a fresh checkout there is no local way to run Vitest, even though both `CLAUDE.md` and the test-guard hook (`.claude/check-test-command.sh`) explicitly direct contributors to `curl -X POST localhost:<port>/api/tests/vitest`. The hook also blocks direct `vitest` invocations, leaving no working local path at all.

## Fix

Restores `POST /api/tests/vitest` (+ `GET /api/tests/vitest/status`), mirroring the existing go/laravel runners:

- runs iznik-nuxt3's `test:unit:run` inside the `freegle-dev-local` container (source baked at `/app`, deps and `.nuxt` present);
- optional body `{"filter":"X"}` narrows to matching specs;
- `?coverage=true` enables coverage;
- 409 if a run is already in progress; success keyed off the process exit code; progress parsing for passed/failed counts.

## Verification

Exercised end-to-end while developing PR #917: filtered runs plus the full unit suite (**13569 passed**) all ran through this endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)