### PR TITLE
fix(modtools): anchor edit review to a post's origin group, not a rippled-in copy

### DIFF
--- a/iznik-nuxt3/composables/rippleStatus.js
+++ b/iznik-nuxt3/composables/rippleStatus.js
@@ -43,3 +43,36 @@ export function isRippledInToContextGroup(
   const earliest = Math.min(...arrivals)
   return ctxArrival > earliest + thresholdMs
 }
+
+/**
+ * Of the supplied group rows, return the groupid (as a number) with the earliest
+ * arrival - the post's origin-most copy.
+ *
+ * An edit under review belongs to the post's ORIGIN group, not to a copy that rippled
+ * in later. The moderation UI must therefore anchor edit review to this group rather
+ * than to the most-recent rippled-in copy - otherwise a moderator who is only a backup
+ * on a receiving group is told they are "moderating for" that backup group for an edit
+ * that actually lives on the origin group (Discourse 9518).
+ *
+ * Falls back to the first row's id when no arrival is parseable, and returns null for
+ * empty/invalid input.
+ *
+ * @param {Array<{groupid:number|string, arrival:string}>} groups
+ * @returns {number|null}
+ */
+export function earliestArrivalGroupId(groups) {
+  if (!Array.isArray(groups) || groups.length === 0) return null
+
+  let best = null
+  for (const g of groups) {
+    const t = g && g.arrival ? new Date(g.arrival).getTime() : NaN
+    if (Number.isNaN(t)) continue
+    if (best === null || t < best.t) best = { id: parseInt(g.groupid), t }
+  }
+
+  if (best === null) {
+    const id = parseInt(groups[0].groupid)
+    return Number.isNaN(id) ? null : id
+  }
+  return best.id
+}

--- a/iznik-nuxt3/modtools/components/ModMessage.vue
+++ b/iznik-nuxt3/modtools/components/ModMessage.vue
@@ -767,7 +767,10 @@ import { buildKeywordRegex } from '~/composables/useKeywordRegex'
 import { useModGroupStore } from '@/stores/modgroup'
 
 import { twem } from '~/composables/useTwem'
-import { isRippledInToContextGroup as isRippledIn } from '~/composables/rippleStatus'
+import {
+  isRippledInToContextGroup as isRippledIn,
+  earliestArrivalGroupId,
+} from '~/composables/rippleStatus'
 
 const props = defineProps({
   messageid: {
@@ -914,6 +917,15 @@ const currentGroupid = computed(() => {
   if (props.contextGroupid) return parseInt(props.contextGroupid)
   const mine = moderatedGroupsOnPost.value
   if (mine.length) {
+    // An edit under review belongs to the post's ORIGIN group, not to a copy that
+    // rippled in later. Anchor to the origin-most group I moderate (earliest arrival)
+    // so the "moderating for X" banner and the Approve/Reject target the origin group
+    // - otherwise a post that originated on a group I'm active on but rippled into a
+    // group I only back up gets shown as "moderating for <backup group>" (Discourse 9518).
+    if (props.editreview) {
+      const originPick = earliestArrivalGroupId(mine)
+      if (originPick != null) return originPick
+    }
     const pending = mine.filter((g) =>
       ['Pending', 'PendingOther', 'Spam'].includes(g.collection)
     )

--- a/iznik-nuxt3/tests/unit/composables/rippleStatus.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/rippleStatus.spec.js
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   isRippledInToContextGroup,
+  earliestArrivalGroupId,
   RIPPLE_ORIGIN_WINDOW_MS,
 } from '~/composables/rippleStatus'
 
@@ -100,5 +101,54 @@ describe('isRippledInToContextGroup', () => {
 
   it('exports the origin window as 10 minutes', () => {
     expect(RIPPLE_ORIGIN_WINDOW_MS).toBe(10 * 60 * 1000)
+  })
+})
+
+describe('earliestArrivalGroupId', () => {
+  it('returns the earliest-arriving group (the origin), not a later rippled-in copy', () => {
+    // Derek's case: post originates on Oxford and ripples into Vale/Didcot later.
+    // An edit belongs to the origin, so we must anchor to Oxford (the earliest),
+    // not the most-recent rippled-in copy.
+    const groups = [
+      { groupid: 21671, arrival: at(120) }, // Vale (rippled in)
+      { groupid: 21555, arrival: at(0) }, // Oxford (origin)
+      { groupid: 522858, arrival: at(120) }, // Didcot (rippled in)
+    ]
+    expect(earliestArrivalGroupId(groups)).toBe(21555)
+  })
+
+  it('returns null for empty/missing input', () => {
+    expect(earliestArrivalGroupId([])).toBeNull()
+    expect(earliestArrivalGroupId(null)).toBeNull()
+    expect(earliestArrivalGroupId(undefined)).toBeNull()
+  })
+
+  it('returns the single group id for a one-group post', () => {
+    expect(earliestArrivalGroupId([{ groupid: 42, arrival: at(0) }])).toBe(42)
+  })
+
+  it('returns a number even for string groupids', () => {
+    const groups = [
+      { groupid: '2', arrival: at(90) },
+      { groupid: '1', arrival: at(0) },
+    ]
+    expect(earliestArrivalGroupId(groups)).toBe(1)
+  })
+
+  it('falls back to the first group id when no arrival is parseable', () => {
+    const groups = [
+      { groupid: 7, arrival: 'not-a-date' },
+      { groupid: 8, arrival: null },
+    ]
+    expect(earliestArrivalGroupId(groups)).toBe(7)
+  })
+
+  it('ignores entries with missing arrivals when others are valid', () => {
+    const groups = [
+      { groupid: 5, arrival: null },
+      { groupid: 6, arrival: at(30) },
+      { groupid: 7, arrival: at(10) },
+    ]
+    expect(earliestArrivalGroupId(groups)).toBe(7)
   })
 })


### PR DESCRIPTION
## Problem (Discourse [9518/369](https://discourse.ilovefreegle.org/t/modtools-changes-likely-bugs/9518/369))

A moderator (Derek) who is only a **backup** on a group kept being shown an **Edit to review for a rippled post** on that backup group.

Verified against the live v2 API + prod DB: the post (#120826822) **originates on Oxford-Freegle** (where Derek is an **active** mod) and only **rippled into** Vale of White Horse / Didcot / Witney (where he is **backup**). The backend correctly returns the edit via the Oxford origin row (the `rippled_in = 0` fix from `6f56ac259` / #915 is live and working) — but the ModTools UI displayed it as *"You're moderating for Vale of White Horse Freegle — approving or rejecting here affects Vale of White Horse Freegle only"*.

## Cause

In `ModMessage.vue`, `currentGroupid` (the group a copy is administered on, in the all-communities view) was chosen by **most-recent arrival** among the mod's groups on the post. For a rippled post the most-recent arrivals are the **rippled-in copies**, so an edit that belongs to the **origin** group was attributed to a rippled-in (often backup) group.

## Fix

- Add `earliestArrivalGroupId()` to `composables/rippleStatus.js` — the origin-most group is the earliest arrival.
- In `ModMessage.vue`, for the **Edit review** case anchor `currentGroupid` to that origin group. Pending/Spam review is unchanged (rippled-in copies there are meant to be vetoable, so most-recent-arrival anchoring still applies).

## Tests

`tests/unit/composables/rippleStatus.spec.js` covers `earliestArrivalGroupId`: origin wins over later rippled-in copies (Derek's exact case), single-group, string groupids, empty/invalid input, and unparseable/missing arrivals. Verified RED → GREEN locally (6 new tests fail without the helper; all 18 pass with it); eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)