### PR TITLE
fix(rippling): make read-path reply-eligibility data-driven, not master-switch gated

### DIFF
--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -848,10 +848,28 @@ func GetMessagesByIds(myid uint64, ids []string, isPartner bool) []Message {
 	// only run when there's something to find (a known location / an actual ban), keeping
 	// them off the hot path for the common case.
 	//
-	// Gated by the master activation switch: while rippling is off this whole section is skipped,
-	// so ReplyEligible is never set and the response matches pre-rippling exactly (no reach query,
-	// no ban-eligibility query, no metrics write).
-	if rippleEnabled() && myid > 0 && len(messages) > 0 {
+	// Activation is DATA-DRIVEN, mirroring the write-path reach gate in
+	// chat.CreateChatMessage: the section runs when EITHER the RIPPLE_ENABLED master switch
+	// is on, OR at least one fetched post is actually rippling (it has a rippling_reach row).
+	// The per-group trial (RIPPLE_WITHIN_GROUPS) ripples posts WITHOUT the master switch, and
+	// the write gate is not switch-gated either — so keying the read path on the master switch
+	// alone left the UI offering a Reply button on trial posts that the write path then
+	// rejected with 403 not_in_reach (Discourse: dejavu / msg 120820564). The EXISTS probe
+	// runs only when the switch is off, so the fully-disabled case stays a single cheap
+	// indexed lookup and otherwise matches pre-rippling exactly.
+	active := rippleEnabled()
+	if !active && myid > 0 && len(messages) > 0 {
+		probeIDs := make([]uint64, 0, len(messages))
+		for _, m := range messages {
+			probeIDs = append(probeIDs, m.ID)
+		}
+		var anyReach int
+		// rippling_reach may not exist until the reach engine (PR A) ships → treat as inactive.
+		_ = db.Raw("SELECT EXISTS(SELECT 1 FROM rippling_reach WHERE msgid IN (?))", probeIDs).Scan(&anyReach).Error
+		active = anyReach == 1
+	}
+
+	if active && myid > 0 && len(messages) > 0 {
 		ids := make([]uint64, 0, len(messages))
 		for _, m := range messages {
 			ids = append(ids, m.ID)

--- a/iznik-server-go/test/message_reply_eligible_test.go
+++ b/iznik-server-go/test/message_reply_eligible_test.go
@@ -80,10 +80,50 @@ func TestReplyEligibleReach(t *testing.T) {
 	db.Exec("DELETE FROM users_banned WHERE userid = ? AND groupid = ?", viewerID, group)
 }
 
-// While the master activation switch is OFF (the default), the reply-eligibility path is skipped
-// entirely: even a post that has rippled out beyond the viewer (and even a ban) leaves ReplyEligible
-// omitted, so the API is identical to pre-rippling and the app shows no view-only blocks.
-func TestReplyEligibleDarkWhenDisabled(t *testing.T) {
+// Data-driven activation: with the RIPPLE_ENABLED master switch OFF, a post that is actually
+// rippling (it has a rippling_reach row) is STILL reply-gated. This is the per-group trial
+// (RIPPLE_WITHIN_GROUPS) case — the reach engine populates rippling_reach without the master
+// switch, and the write-path gate (chat.CreateChatMessage) is likewise data-driven. The read
+// path must mark out-of-reach posts view-only here too, otherwise the UI offers a Reply button
+// the write path then rejects with 403 not_in_reach (Discourse: dejavu / msg 120820564).
+func TestReplyEligibleReachWhenMasterSwitchOff(t *testing.T) {
+	t.Setenv("RIPPLE_ENABLED", "false")
+	db := database.DBConn
+
+	db.Exec(`CREATE TABLE IF NOT EXISTS rippling_reach (
+		msgid BIGINT UNSIGNED NOT NULL PRIMARY KEY,
+		lat DOUBLE NOT NULL, lng DOUBLE NOT NULL,
+		polygon GEOMETRY NOT NULL SRID 3857,
+		status VARCHAR(16) NOT NULL DEFAULT 'expanding',
+		SPATIAL INDEX msgreach_poly (polygon)
+	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`)
+
+	prefix := uniquePrefix("repeligtrial")
+	posterID := CreateTestUser(t, prefix, "Poster")
+	group := CreateTestGroup(t, prefix)
+	mid := CreateTestMessage(t, posterID, group, "OFFER: reply-eligible trial test", 51.5, -0.1)
+	viewerID := CreateTestUser(t, prefix+"v", "Viewer")
+	db.Exec("UPDATE users SET settings = JSON_SET(COALESCE(settings,'{}'), '$.mylocation', "+
+		"JSON_OBJECT('lat', 51.5, 'lng', -0.1)) WHERE id = ?", viewerID)
+	idStr := fmt.Sprint(mid)
+
+	// Reach row whose polygon does NOT contain the viewer → out of reach → replyeligible=false,
+	// even though RIPPLE_ENABLED is off (the post is rippling via the per-group trial).
+	db.Exec("INSERT INTO rippling_reach (msgid, lat, lng, polygon, status) VALUES (?, 51.5, -0.1, "+
+		"ST_GeomFromText('POLYGON((2.4 53.4, 2.6 53.4, 2.6 53.6, 2.4 53.6, 2.4 53.4))', 3857), 'expanding') "+
+		"ON DUPLICATE KEY UPDATE polygon = VALUES(polygon)", mid)
+	msgs := message.GetMessagesByIds(viewerID, []string{idStr}, false)
+	if assert.Len(t, msgs, 1) && assert.NotNil(t, msgs[0].ReplyEligible, "trial post, master off → replyeligible set") {
+		assert.False(t, *msgs[0].ReplyEligible, "trial post outside reach, master off → replyeligible=false")
+	}
+
+	db.Exec("DELETE FROM rippling_reach WHERE msgid = ?", mid)
+}
+
+// When a post is NOT rippling at all (no rippling_reach row) and the master switch is OFF, the
+// reply-eligibility path stays dark: the field is omitted so the API is identical to pre-rippling,
+// and a ban alone — with no reach row in play — does not mark the post view-only on this path.
+func TestReplyEligibleDarkWhenNotRippling(t *testing.T) {
 	t.Setenv("RIPPLE_ENABLED", "false")
 	db := database.DBConn
 
@@ -104,19 +144,15 @@ func TestReplyEligibleDarkWhenDisabled(t *testing.T) {
 		"JSON_OBJECT('lat', 51.5, 'lng', -0.1)) WHERE id = ?", viewerID)
 	idStr := fmt.Sprint(mid)
 
-	// A reach row that does NOT contain the viewer AND a ban: both would set replyeligible=false
-	// when rippling is ON, so this proves the switch (not just absent data) makes the path dark.
-	db.Exec("INSERT INTO rippling_reach (msgid, lat, lng, polygon, status) VALUES (?, 51.5, -0.1, "+
-		"ST_GeomFromText('POLYGON((2.4 53.4, 2.6 53.4, 2.6 53.6, 2.4 53.6, 2.4 53.4))', 3857), 'expanding') "+
-		"ON DUPLICATE KEY UPDATE polygon = VALUES(polygon)", mid)
+	// No reach row for this post → not rippling. A ban alone must not set replyeligible here.
+	db.Exec("DELETE FROM rippling_reach WHERE msgid = ?", mid)
 	db.Exec("INSERT INTO users_banned (userid, groupid) VALUES (?, ?) "+
 		"ON DUPLICATE KEY UPDATE userid = VALUES(userid)", viewerID, group)
 
 	msgs := message.GetMessagesByIds(viewerID, []string{idStr}, false)
 	if assert.Len(t, msgs, 1) {
-		assert.Nil(t, msgs[0].ReplyEligible, "rippling off → reply-eligibility never set (post stays eligible)")
+		assert.Nil(t, msgs[0].ReplyEligible, "not rippling + master off → reply-eligibility stays dark")
 	}
 
-	db.Exec("DELETE FROM rippling_reach WHERE msgid = ?", mid)
 	db.Exec("DELETE FROM users_banned WHERE userid = ? AND groupid = ?", viewerID, group)
 }


### PR DESCRIPTION
## Problem
On the web, an out-of-reach member could fully compose and submit a reply to a rippled post and get a **403 not_in_reach**, with the failed send stuck retrying in their outbox on every app open (Discourse: dejavu / msg 120820564).

**Root cause — mismatched activation conditions:**
- **Read/UI gate** (`message.go` `GetMessagesByIds`): set `replyeligible=false` only when the `RIPPLE_ENABLED` master switch is on.
- **Write gate** (`chat.CreateChatMessage`): enforces `rippling_reach` directly, with **no** switch.

During the per-group trial (`RIPPLE_WITHIN_GROUPS`, master switch off), the reach engine populates `rippling_reach`, so the write gate fires but the read gate stays dark → the UI offers a Reply button the write path then rejects.

## Fix
Make the read enrichment **data-driven**, mirroring the write gate: run it when `RIPPLE_ENABLED` is on **or** a fetched post actually has a `rippling_reach` row. A single cheap `EXISTS` probe runs only when the switch is off, so the fully-disabled case stays one indexed lookup and otherwise matches pre-rippling exactly.

## Tests
- `TestReplyEligibleReachWhenMasterSwitchOff` — trial post (master off, reach row excludes viewer) -> `replyeligible=false` (regression test).
- `TestReplyEligibleDarkWhenNotRippling` — no reach row + master off -> stays dark (pre-rippling parity; a ban alone doesn't gate here).
- `TestReplyEligibleReach` (master on) — unchanged.

Tests written but not run locally (per project policy); CI to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014aXkxBPEiPSJBaRMjz7opk