### PR TITLE
perf(browse): make browse feed filtering O(n) and cheaper on large post sets

### DIFF
--- a/iznik-nuxt3/components/MessageList.vue
+++ b/iznik-nuxt3/components/MessageList.vue
@@ -152,6 +152,10 @@ import { useNearbyStore } from '~/stores/nearby'
 import { throttleFetches } from '~/composables/useThrottle'
 import { useMe } from '~/composables/useMe'
 import { useScrollDepth } from '~/composables/useScrollDepth'
+import {
+  deduplicateMessages,
+  findDuplicates,
+} from '~/composables/useMessageDedup'
 
 const OurMessage = defineAsyncComponent(() =>
   import('~/components/OurMessage.vue')
@@ -450,78 +454,19 @@ function isOnMyGroup(message) {
   return message.groups.some((g) => myGroupIdSet.value.has(parseInt(g.groupid)))
 }
 
-const deDuplicatedMessages = computed(() => {
-  let ret = []
-  const dups = []
-  const ids = {}
-  const seen = new Set()
-
-  filteredMessagesToShow.value
-    .filter((m) => !failedIds.value.has(m.id))
-    .forEach((m) => {
-      if (seen.has(m.id)) {
-        return
-      }
-
-      const message = filteredMessagesInStore.value[m.id]
-
-      if (!message) {
-        seen.add(m.id)
-        ret.push(m)
-      } else if (m.id in ids) {
-        // Already got this id
-      } else if (m.id !== props.exclude) {
-        ids[m.id] = true
-        // Strip trailing (location) so that "bike (Bethnal Green)" and "bike (Bethel)"
-        // from the same poster collapse to one entry (Discourse 9733/7).
-        const stripLocation = (s) => s.replace(/\s*\([^)]*\)\s*$/, '').trimEnd()
-        let key = message.fromuser + '|' + stripLocation(message.subject)
-        const p = message.subject.indexOf(':')
-
-        if (p !== -1) {
-          key =
-            message.fromuser +
-            '|' +
-            message.type +
-            stripLocation(message.subject.substring(p))
-        }
-
-        const already = key in dups
-
-        if (m.id === props.firstSeenMessage) {
-          if (already) {
-            ret = ret.filter((m) => m.id !== dups[key])
-          }
-          ret.push(m)
-          dups[key] = m.id
-        } else if (!already) {
-          ret.push(m)
-          dups[key] = m.id
-        } else {
-          // Duplicate of one we're already showing (same poster + item, e.g. a
-          // crosspost or a re-post on another group). Prefer the copy on a group
-          // the user is already a member of: otherwise we'd dedup to a non-member
-          // group and replying to it would silently sign them up to that group
-          // (Discourse 9733 / 9729). firstSeenMessage always wins and is never
-          // replaced here.
-          const keptId = dups[key]
-          if (
-            keptId !== props.firstSeenMessage &&
-            isOnMyGroup(message) &&
-            !isOnMyGroup(filteredMessagesInStore.value[keptId])
-          ) {
-            const idx = ret.findIndex((x) => x.id === keptId)
-            if (idx !== -1) {
-              ret[idx] = m
-            }
-            dups[key] = m.id
-          }
-        }
-      }
-    })
-
-  return ret
-})
+// Collapse a poster's crosspost/repost of the same item to one entry, preferring the copy
+// on a group the viewer belongs to (Discourse 9733 / 9729); firstSeenMessage always wins.
+// Delegates to the pure deduplicateMessages, whose member-group swap is O(1) (id->index
+// Map) rather than the previous ret.findIndex() scan.
+const deDuplicatedMessages = computed(() =>
+  deduplicateMessages(filteredMessagesToShow.value, {
+    getMessage: (id) => filteredMessagesInStore.value[id],
+    exclude: props.exclude,
+    firstSeenMessage: props.firstSeenMessage,
+    isOnMyGroup,
+    failedIds: failedIds.value,
+  })
+)
 
 const unseenMessages = computed(() => {
   return deDuplicatedMessages.value.filter((m) => m.unseen)
@@ -531,17 +476,11 @@ const seenMessages = computed(() => {
   return deDuplicatedMessages.value.filter((m) => !m.unseen)
 })
 
-const duplicates = computed(() => {
-  const ret = []
-
-  filteredMessagesToShow.value.forEach((m) => {
-    if (!deDuplicatedMessages.value.find((d) => d.id === m.id)) {
-      ret.push(m)
-    }
-  })
-
-  return ret
-})
+const duplicates = computed(() =>
+  // The items dropped by deduplication. O(n) via a Set of kept ids rather than the
+  // previous O(n^2) find()-per-item scan over deDuplicatedMessages.
+  findDuplicates(filteredMessagesToShow.value, deDuplicatedMessages.value)
+)
 
 const noneFound = computed(() => {
   return !props.loading && !deDuplicatedMessages.value?.length

--- a/iznik-nuxt3/components/PostMap.vue
+++ b/iznik-nuxt3/components/PostMap.vue
@@ -114,6 +114,7 @@ import {
   isWithinDistance,
   filterMessagesByDistance,
 } from '~/composables/useDistance'
+import { distinctGroupIds } from '~/composables/useMessageDedup'
 import { BROWSE_DISTANCE_UNLIMITED, ISOCHRONE_COLOR } from '~/constants'
 
 const props = defineProps({
@@ -282,17 +283,9 @@ const showGroups = computed(() => {
 })
 
 const groups = computed(() => {
-  const ret = []
-
-  if (messageList.value) {
-    messageList.value.forEach((m) => {
-      if (!ret.includes(m.groupid)) {
-        ret.push(m.groupid)
-      }
-    })
-  }
-
-  return ret
+  // Distinct groupids in first-appearance order (O(n) via a Set rather than the previous
+  // includes()-in-loop).
+  return distinctGroupIds(messageList.value)
 })
 
 const largeGroupMarkers = computed(() => {

--- a/iznik-nuxt3/components/PostMapAndList.vue
+++ b/iznik-nuxt3/components/PostMapAndList.vue
@@ -130,6 +130,7 @@ import { useAuthStore } from '~/stores/auth'
 import { useMiscStore } from '~/stores/misc'
 import { getDistance } from '~/composables/useMap'
 import { filterMessagesByDistance } from '~/composables/useDistance'
+import { sortBrowseMessages } from '~/composables/useMessageSort'
 import { MAX_MAP_ZOOM, BROWSE_DISTANCE_UNLIMITED } from '~/constants'
 import { useNearbyStore } from '~/stores/nearby'
 
@@ -395,56 +396,12 @@ const filteredMessages = computed(() => {
   return ret
 })
 
-// Helper function to sort messages
+// Helper function to sort messages. Delegates to the pure sortBrowseMessages, which
+// computes each message's distance and arrival sort key ONCE (a Schwartzian transform)
+// instead of re-deriving getDistance (haversine/trig) and Date parsing on every
+// comparison - a big saving on large feeds. Ordering is unchanged.
 function sortMessages(messages) {
-  // Rippling-out (#1): the "Nearby" sort orders nearest-first from the viewer's
-  // location. Falls back to recency if we don't have a centre (no known location).
-  const nearbyRef =
-    props.selectedSort === 'Nearby' &&
-    centre.value?.lat != null &&
-    centre.value?.lng != null
-      ? [centre.value.lat, centre.value.lng]
-      : null
-
-  return messages.slice().sort((a, b) => {
-    if (props.selectedSort === 'Unseen') {
-      // Unseen messages first, then by descending date/time. But we don't want to treat successful posts as
-      // unseen otherwise they bob up to the top.
-      const aunseen = a.unseen && !a.successful
-      const bunseen = b.unseen && !b.successful
-
-      if (aunseen && !bunseen) {
-        return -1
-      } else if (!aunseen && bunseen) {
-        return 1
-      } else {
-        // Within each bucket (unseen, then seen), order by the server's rippling
-        // relevance score rather than raw recency, so the most relevant posts (a mix
-        // of closeness, freshness and quietness) come first rather than just the
-        // newest. Missing score (e.g. an API not yet returning it) treats as 0, so
-        // everything still sorts stably rather than breaking.
-        return (b.score ?? 0) - (a.score ?? 0)
-      }
-    } else if (nearbyRef) {
-      // Nearby: nearest-first, then recency as a tiebreak. Posts with no
-      // coordinates sort last.
-      const da =
-        a.lat != null && a.lng != null
-          ? getDistance(nearbyRef, [a.lat, a.lng])
-          : Infinity
-      const db =
-        b.lat != null && b.lng != null
-          ? getDistance(nearbyRef, [b.lat, b.lng])
-          : Infinity
-      if (da !== db) {
-        return da - db
-      }
-      return new Date(b.arrival).getTime() - new Date(a.arrival).getTime()
-    } else {
-      // Descending date/time (Newest posted; also Nearby with no known location).
-      return new Date(b.arrival).getTime() - new Date(a.arrival).getTime()
-    }
-  })
+  return sortBrowseMessages(messages, props.selectedSort, centre.value)
 }
 
 const sortedMessagesOnMap = computed(() => {

--- a/iznik-nuxt3/composables/useMessageDedup.js
+++ b/iznik-nuxt3/composables/useMessageDedup.js
@@ -1,0 +1,141 @@
+// Pure de-duplication / grouping helpers for the Browse feed, extracted from
+// MessageList.vue and PostMap.vue so they can be unit tested and so the hot paths run in
+// O(n) instead of O(n^2). Behaviour (which item is kept, the output order) is unchanged.
+
+// Build the dedup key for a message. Mirrors the original inline logic exactly: strip a
+// trailing "(location)" so the same poster's crossposts of one item collapse, and when
+// the subject has a "TYPE: ..." prefix key on type + the stripped remainder.
+function dedupKey(message) {
+  const stripLocation = (s) => s.replace(/\s*\([^)]*\)\s*$/, '').trimEnd()
+  let key = message.fromuser + '|' + stripLocation(message.subject)
+  const p = message.subject.indexOf(':')
+
+  if (p !== -1) {
+    key =
+      message.fromuser +
+      '|' +
+      message.type +
+      stripLocation(message.subject.substring(p))
+  }
+
+  return key
+}
+
+// De-duplicate the browse list: collapse a poster's crosspost/repost of the same item to
+// a single entry, preferring the copy on a group the viewer belongs to (so replying does
+// not silently sign them up to a non-member group - Discourse 9733 / 9729).
+// firstSeenMessage always wins and is never displaced. The kept items are returned in
+// their original input order.
+//
+// This is the O(n) form of MessageList.vue's deDuplicatedMessages: the member-group swap
+// now looks the kept item up in an id->index Map instead of ret.findIndex() (which was an
+// O(n) scan per swap, i.e. O(n^2) when many items are duplicates).
+//
+//   items            - list to dedup (feed summary objects with .id)
+//   getMessage(id)   - full message detail for id (or undefined if not loaded yet)
+//   exclude          - an id to drop entirely, or null
+//   firstSeenMessage - id that must always be kept and never displaced, or null
+//   isOnMyGroup(msg) - true if msg is on a group the viewer belongs to
+//   failedIds        - Set of ids to skip (failed to load), or null
+export function deduplicateMessages(
+  items,
+  {
+    getMessage,
+    exclude = null,
+    firstSeenMessage = null,
+    isOnMyGroup = () => false,
+    failedIds = null,
+  } = {}
+) {
+  const ret = []
+  const retIndexById = new Map()
+  const dups = Object.create(null) // dedupKey -> kept id
+  const idsSeen = Object.create(null) // ids whose dedup key we've already processed
+  const seen = new Set() // ids pushed raw because no detail was available yet
+
+  const pushKept = (m) => {
+    retIndexById.set(m.id, ret.length)
+    ret.push(m)
+  }
+
+  for (const m of items || []) {
+    if (failedIds && failedIds.has(m.id)) {
+      continue
+    }
+
+    if (seen.has(m.id)) {
+      continue
+    }
+
+    const message = getMessage ? getMessage(m.id) : undefined
+
+    if (!message) {
+      // No detail cached yet - keep it as-is; if it recurs we skip it via `seen`.
+      seen.add(m.id)
+      pushKept(m)
+    } else if (m.id in idsSeen) {
+      // Already processed this id.
+    } else if (m.id !== exclude) {
+      idsSeen[m.id] = true
+      const key = dedupKey(message)
+      const already = key in dups
+
+      if (m.id === firstSeenMessage) {
+        if (already) {
+          // firstSeenMessage displaces the previously-kept copy of this item.
+          const removeId = dups[key]
+          const idx = retIndexById.get(removeId)
+          if (idx !== undefined) {
+            ret.splice(idx, 1)
+            // Indices after the removed slot shifted - rebuild the map. This branch runs
+            // at most once (firstSeenMessage is a single id), so the O(n) rebuild is fine.
+            retIndexById.clear()
+            for (let i = 0; i < ret.length; i++) {
+              retIndexById.set(ret[i].id, i)
+            }
+          }
+        }
+        pushKept(m)
+        dups[key] = m.id
+      } else if (!already) {
+        pushKept(m)
+        dups[key] = m.id
+      } else {
+        // Duplicate of one we're already showing. Prefer the copy on a group the viewer
+        // belongs to; firstSeenMessage is never replaced.
+        const keptId = dups[key]
+        if (
+          keptId !== firstSeenMessage &&
+          isOnMyGroup(message) &&
+          !isOnMyGroup(getMessage ? getMessage(keptId) : undefined)
+        ) {
+          const idx = retIndexById.get(keptId)
+          if (idx !== undefined) {
+            ret[idx] = m
+            retIndexById.delete(keptId)
+            retIndexById.set(m.id, idx)
+          }
+          dups[key] = m.id
+        }
+      }
+    }
+  }
+
+  return ret
+}
+
+// The complement of deduplicateMessages: the items that were dropped (crossposts, the
+// excluded id, failed-to-load ids). O(n) via a Set of kept ids, replacing the previous
+// O(n^2) forEach + Array.find() scan.
+export function findDuplicates(items, keptList) {
+  const keptIds = new Set((keptList || []).map((d) => d.id))
+  return (items || []).filter((m) => !keptIds.has(m.id))
+}
+
+// Distinct groupids in first-appearance order. Replaces an O(n*u) includes()-in-loop.
+export function distinctGroupIds(messages) {
+  if (!messages) {
+    return []
+  }
+  return [...new Set(messages.map((m) => m.groupid))]
+}

--- a/iznik-nuxt3/composables/useMessageSort.js
+++ b/iznik-nuxt3/composables/useMessageSort.js
@@ -1,0 +1,74 @@
+import { getDistance } from '~/composables/useMap'
+
+// Pure sort for the Browse feed, extracted from PostMapAndList.vue so it can be unit
+// tested and so the expensive sort keys are computed ONCE per message (a Schwartzian
+// transform) rather than re-derived on every comparator call.
+//
+// The previous inline comparator called getDistance() (a haversine with several trig
+// ops) and new Date(m.arrival).getTime() for BOTH operands on every comparison, so a
+// full sort did O(n log n) trig/date evaluations. On a large feed (a heavy-membership
+// user's list can be thousands of posts) that dominated the sort. Here each message's
+// distance and arrival timestamp are computed once - O(n) key work - leaving only cheap
+// numeric compares in the O(n log n) sort. The resulting order is identical to the old
+// comparator (same null->Infinity handling, same score/recency fallbacks, same stable
+// tie behaviour).
+//
+//   messages     - array of feed summary objects
+//   selectedSort - 'Unseen' | 'Nearby' | anything else (treated as Newest-first)
+//   centre       - { lat, lng } viewer location, or null; only used for 'Nearby'
+//
+// Returns a NEW array; the input is not mutated (matches the old messages.slice()).
+export function sortBrowseMessages(messages, selectedSort, centre) {
+  const list = messages || []
+
+  // Rippling-out (#1): "Nearby" orders nearest-first from the viewer's location. Only
+  // active when we actually have a centre - otherwise we fall through to recency below.
+  const nearbyRef =
+    selectedSort === 'Nearby' && centre?.lat != null && centre?.lng != null
+      ? [centre.lat, centre.lng]
+      : null
+
+  // 'Unseen' orders by unseen-bucket then relevance score and never consults arrival, so
+  // only pay for Date parsing when a recency tiebreak/order is actually needed.
+  const needsRecency = selectedSort !== 'Unseen'
+
+  const decorated = list.map((m) => ({
+    m,
+    dist:
+      nearbyRef && m.lat != null && m.lng != null
+        ? getDistance(nearbyRef, [m.lat, m.lng])
+        : Infinity,
+    ts: needsRecency ? new Date(m.arrival).getTime() : 0,
+  }))
+
+  decorated.sort((a, b) => {
+    if (selectedSort === 'Unseen') {
+      // Unseen first, then by descending rippling relevance score. Successful posts are
+      // not treated as unseen so they don't bob to the top. Missing score -> 0.
+      const am = a.m
+      const bm = b.m
+      const aunseen = am.unseen && !am.successful
+      const bunseen = bm.unseen && !bm.successful
+
+      if (aunseen && !bunseen) {
+        return -1
+      } else if (!aunseen && bunseen) {
+        return 1
+      } else {
+        return (bm.score ?? 0) - (am.score ?? 0)
+      }
+    } else if (nearbyRef) {
+      // Nearby: nearest-first (posts with no coordinates sort last via Infinity), then
+      // recency as a tiebreak.
+      if (a.dist !== b.dist) {
+        return a.dist - b.dist
+      }
+      return b.ts - a.ts
+    } else {
+      // Descending date/time (Newest posted; also Nearby with no known location).
+      return b.ts - a.ts
+    }
+  })
+
+  return decorated.map((d) => d.m)
+}

--- a/iznik-nuxt3/stores/message.js
+++ b/iznik-nuxt3/stores/message.js
@@ -537,12 +537,14 @@ export const useMessageStore = defineStore({
       const nearbyStore = useNearbyStore()
       nearbyStore.markSeen(ids)
 
-      // Also update local cache to prevent watcher loop in MessageList.vue
-      const idSet = new Set(ids)
-      Object.keys(this.list).forEach((key) => {
-        const id = parseInt(key)
-        if (idSet.has(id) && this.list[id]) {
-          this.list[id].unseen = false
+      // Also update local cache to prevent watcher loop in MessageList.vue. Index the
+      // ids directly rather than scanning the whole message cache, which grows for the
+      // lifetime of the session (a long infinite-scroll made this an O(cache) scan per
+      // mark-seen, i.e. trending to O(total^2) over a session).
+      ids.forEach((id) => {
+        const cached = this.list[id]
+        if (cached) {
+          cached.unseen = false
         }
       })
 

--- a/iznik-nuxt3/tests/unit/composables/useMessageDedup.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useMessageDedup.spec.js
@@ -1,0 +1,237 @@
+import { describe, it, expect } from 'vitest'
+import {
+  deduplicateMessages,
+  findDuplicates,
+  distinctGroupIds,
+} from '~/composables/useMessageDedup'
+
+// Build a getMessage(id) lookup from a list of detail objects.
+function storeOf(details) {
+  const map = {}
+  for (const d of details) map[d.id] = d
+  return (id) => map[id]
+}
+
+// isOnMyGroup predicate mirroring MessageList's, for a given set of member group ids.
+function memberOf(groupIds) {
+  const set = new Set(groupIds)
+  return (message) =>
+    !!message?.groups &&
+    message.groups.some((g) => set.has(parseInt(g.groupid)))
+}
+
+describe('deduplicateMessages', () => {
+  it('returns items unchanged when there are no duplicates', () => {
+    const items = [{ id: 1 }, { id: 2 }]
+    const getMessage = storeOf([
+      { id: 1, fromuser: 5, type: 'Offer', subject: 'OFFER: Sofa' },
+      { id: 2, fromuser: 6, type: 'Offer', subject: 'OFFER: Table' },
+    ])
+    const out = deduplicateMessages(items, { getMessage })
+    expect(out.map((m) => m.id)).toEqual([1, 2])
+  })
+
+  it('collapses same poster + same item to one entry', () => {
+    const items = [{ id: 1 }, { id: 2 }]
+    const getMessage = storeOf([
+      { id: 1, fromuser: 5, type: 'Offer', subject: 'OFFER: Sofa' },
+      { id: 2, fromuser: 5, type: 'Offer', subject: 'OFFER: Sofa' },
+    ])
+    const out = deduplicateMessages(items, { getMessage })
+    expect(out.map((m) => m.id)).toEqual([1])
+  })
+
+  it('strips a trailing (location) so crossposts of one item collapse (Discourse 9733/7)', () => {
+    const items = [{ id: 1 }, { id: 2 }]
+    const getMessage = storeOf([
+      {
+        id: 1,
+        fromuser: 5,
+        type: 'Offer',
+        subject: 'OFFER: bike (Bethnal Green)',
+      },
+      { id: 2, fromuser: 5, type: 'Offer', subject: 'OFFER: bike (Bethel)' },
+    ])
+    const out = deduplicateMessages(items, { getMessage })
+    expect(out).toHaveLength(1)
+  })
+
+  it('prefers the duplicate on a group the viewer belongs to (Discourse 9733/9729)', () => {
+    const items = [{ id: 1 }, { id: 2 }]
+    const getMessage = storeOf([
+      {
+        id: 1,
+        fromuser: 5,
+        type: 'Offer',
+        subject: 'OFFER: Sofa',
+        groups: [{ groupid: 20 }],
+      },
+      {
+        id: 2,
+        fromuser: 5,
+        type: 'Offer',
+        subject: 'OFFER: Sofa',
+        groups: [{ groupid: 10 }],
+      },
+    ])
+    const out = deduplicateMessages(items, {
+      getMessage,
+      isOnMyGroup: memberOf([10]),
+    })
+    // Keeps id 2 (member group 10), not id 1 (non-member group 20).
+    expect(out.map((m) => m.id)).toEqual([2])
+  })
+
+  it('does not displace the kept copy when neither is on a member group', () => {
+    const items = [{ id: 1 }, { id: 2 }]
+    const getMessage = storeOf([
+      {
+        id: 1,
+        fromuser: 5,
+        type: 'Offer',
+        subject: 'OFFER: Sofa',
+        groups: [{ groupid: 20 }],
+      },
+      {
+        id: 2,
+        fromuser: 5,
+        type: 'Offer',
+        subject: 'OFFER: Sofa',
+        groups: [{ groupid: 30 }],
+      },
+    ])
+    const out = deduplicateMessages(items, {
+      getMessage,
+      isOnMyGroup: memberOf([10]),
+    })
+    expect(out.map((m) => m.id)).toEqual([1])
+  })
+
+  it('keeps firstSeenMessage and lets it displace an earlier-kept duplicate', () => {
+    const items = [{ id: 1 }, { id: 2 }, { id: 3 }]
+    const getMessage = storeOf([
+      { id: 1, fromuser: 5, type: 'Offer', subject: 'OFFER: Sofa' },
+      { id: 2, fromuser: 6, type: 'Offer', subject: 'OFFER: Table' },
+      { id: 3, fromuser: 5, type: 'Offer', subject: 'OFFER: Sofa' },
+    ])
+    // 3 is a duplicate of 1 but is the firstSeenMessage -> it replaces 1.
+    const out = deduplicateMessages(items, { getMessage, firstSeenMessage: 3 })
+    expect(out.map((m) => m.id)).toEqual([2, 3])
+  })
+
+  it('never displaces firstSeenMessage even for a member-group duplicate', () => {
+    const items = [{ id: 1 }, { id: 2 }]
+    const getMessage = storeOf([
+      {
+        id: 1,
+        fromuser: 5,
+        type: 'Offer',
+        subject: 'OFFER: Sofa',
+        groups: [{ groupid: 20 }],
+      },
+      {
+        id: 2,
+        fromuser: 5,
+        type: 'Offer',
+        subject: 'OFFER: Sofa',
+        groups: [{ groupid: 10 }],
+      },
+    ])
+    const out = deduplicateMessages(items, {
+      getMessage,
+      firstSeenMessage: 1,
+      isOnMyGroup: memberOf([10]),
+    })
+    // 1 is firstSeenMessage so it is kept even though 2 is on the member group.
+    expect(out.map((m) => m.id)).toEqual([1])
+  })
+
+  it('drops the excluded id entirely', () => {
+    const items = [{ id: 1 }, { id: 2 }]
+    const getMessage = storeOf([
+      { id: 1, fromuser: 5, type: 'Offer', subject: 'OFFER: Sofa' },
+      { id: 2, fromuser: 6, type: 'Offer', subject: 'OFFER: Table' },
+    ])
+    const out = deduplicateMessages(items, { getMessage, exclude: 1 })
+    expect(out.map((m) => m.id)).toEqual([2])
+  })
+
+  it('skips failed ids', () => {
+    const items = [{ id: 1 }, { id: 2 }]
+    const getMessage = storeOf([
+      { id: 1, fromuser: 5, type: 'Offer', subject: 'OFFER: Sofa' },
+      { id: 2, fromuser: 6, type: 'Offer', subject: 'OFFER: Table' },
+    ])
+    const out = deduplicateMessages(items, {
+      getMessage,
+      failedIds: new Set([1]),
+    })
+    expect(out.map((m) => m.id)).toEqual([2])
+  })
+
+  it('keeps items whose detail is not yet loaded, as-is', () => {
+    const items = [{ id: 1 }, { id: 2 }]
+    // Only id 2 has detail.
+    const getMessage = storeOf([
+      { id: 2, fromuser: 6, type: 'Offer', subject: 'OFFER: Table' },
+    ])
+    const out = deduplicateMessages(items, { getMessage })
+    expect(out.map((m) => m.id)).toEqual([1, 2])
+  })
+
+  it('preserves input order of the kept items', () => {
+    const items = [{ id: 3 }, { id: 1 }, { id: 2 }]
+    const getMessage = storeOf([
+      { id: 1, fromuser: 5, type: 'Offer', subject: 'OFFER: A' },
+      { id: 2, fromuser: 6, type: 'Offer', subject: 'OFFER: B' },
+      { id: 3, fromuser: 7, type: 'Offer', subject: 'OFFER: C' },
+    ])
+    const out = deduplicateMessages(items, { getMessage })
+    expect(out.map((m) => m.id)).toEqual([3, 1, 2])
+  })
+})
+
+describe('findDuplicates', () => {
+  it('returns items not present in the kept list', () => {
+    const items = [{ id: 1 }, { id: 2 }, { id: 3 }]
+    const kept = [{ id: 1 }, { id: 3 }]
+    expect(findDuplicates(items, kept).map((m) => m.id)).toEqual([2])
+  })
+
+  it('includes failed/excluded items that were dropped from the kept list', () => {
+    const items = [{ id: 1 }, { id: 2 }]
+    const getMessage = storeOf([
+      { id: 1, fromuser: 5, type: 'Offer', subject: 'OFFER: Sofa' },
+      { id: 2, fromuser: 6, type: 'Offer', subject: 'OFFER: Table' },
+    ])
+    const kept = deduplicateMessages(items, {
+      getMessage,
+      failedIds: new Set([1]),
+    })
+    // id 1 was skipped as failed, so it is a "duplicate" (not kept).
+    expect(findDuplicates(items, kept).map((m) => m.id)).toEqual([1])
+  })
+
+  it('handles empty inputs', () => {
+    expect(findDuplicates([], [])).toEqual([])
+    expect(findDuplicates(undefined, undefined)).toEqual([])
+  })
+})
+
+describe('distinctGroupIds', () => {
+  it('returns distinct groupids in first-appearance order', () => {
+    const msgs = [
+      { groupid: 3 },
+      { groupid: 1 },
+      { groupid: 3 },
+      { groupid: 2 },
+      { groupid: 1 },
+    ]
+    expect(distinctGroupIds(msgs)).toEqual([3, 1, 2])
+  })
+
+  it('handles empty/undefined input', () => {
+    expect(distinctGroupIds([])).toEqual([])
+    expect(distinctGroupIds(undefined)).toEqual([])
+  })
+})

--- a/iznik-nuxt3/tests/unit/composables/useMessageSort.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useMessageSort.spec.js
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest'
+import { sortBrowseMessages } from '~/composables/useMessageSort'
+
+// Small helper: sort and return the resulting id order.
+function order(messages, sort, centre) {
+  return sortBrowseMessages(messages, sort, centre).map((m) => m.id)
+}
+
+describe('sortBrowseMessages', () => {
+  it('returns an empty array for empty/undefined input', () => {
+    expect(sortBrowseMessages([], 'Unseen')).toEqual([])
+    expect(sortBrowseMessages(undefined, 'Unseen')).toEqual([])
+  })
+
+  it('does not mutate the input array', () => {
+    const input = [
+      { id: 1, arrival: '2024-01-01T00:00:00Z' },
+      { id: 2, arrival: '2024-01-02T00:00:00Z' },
+    ]
+    const snapshot = input.map((m) => m.id)
+    sortBrowseMessages(input, 'Newest')
+    expect(input.map((m) => m.id)).toEqual(snapshot)
+  })
+
+  describe('Unseen sort', () => {
+    it('puts unseen before seen', () => {
+      const msgs = [
+        { id: 1, unseen: false, score: 5 },
+        { id: 2, unseen: true, score: 1 },
+      ]
+      expect(order(msgs, 'Unseen')).toEqual([2, 1])
+    })
+
+    it('treats successful posts as not-unseen so they do not bob to the top', () => {
+      const msgs = [
+        { id: 1, unseen: false, score: 1 },
+        { id: 2, unseen: true, successful: true, score: 9 },
+      ]
+      // 2 is unseen but successful -> treated as seen -> ordered by score within the
+      // seen bucket. Both are seen; higher score first.
+      expect(order(msgs, 'Unseen')).toEqual([2, 1])
+    })
+
+    it('orders within a bucket by descending score', () => {
+      const msgs = [
+        { id: 1, unseen: true, score: 2 },
+        { id: 2, unseen: true, score: 8 },
+        { id: 3, unseen: true, score: 5 },
+      ]
+      expect(order(msgs, 'Unseen')).toEqual([2, 3, 1])
+    })
+
+    it('treats a missing score as 0', () => {
+      const msgs = [
+        { id: 1, unseen: true, score: undefined },
+        { id: 2, unseen: true, score: 3 },
+        { id: 3, unseen: true, score: -1 },
+      ]
+      expect(order(msgs, 'Unseen')).toEqual([2, 1, 3])
+    })
+
+    it('keeps input order for equal scores (stable)', () => {
+      const msgs = [
+        { id: 10, unseen: true, score: 4 },
+        { id: 11, unseen: true, score: 4 },
+        { id: 12, unseen: true, score: 4 },
+      ]
+      expect(order(msgs, 'Unseen')).toEqual([10, 11, 12])
+    })
+  })
+
+  describe('Nearby sort', () => {
+    const centre = { lat: 51.5, lng: -0.1 }
+
+    it('orders nearest-first from the centre', () => {
+      const msgs = [
+        { id: 'far', lat: 53.0, lng: -0.1, arrival: '2024-01-01T00:00:00Z' },
+        { id: 'near', lat: 51.6, lng: -0.1, arrival: '2024-01-01T00:00:00Z' },
+        { id: 'mid', lat: 52.0, lng: -0.1, arrival: '2024-01-01T00:00:00Z' },
+      ]
+      expect(order(msgs, 'Nearby', centre)).toEqual(['near', 'mid', 'far'])
+    })
+
+    it('sorts posts with no coordinates last', () => {
+      const msgs = [
+        {
+          id: 'nocoord',
+          lat: null,
+          lng: null,
+          arrival: '2024-01-01T00:00:00Z',
+        },
+        { id: 'near', lat: 51.6, lng: -0.1, arrival: '2024-01-01T00:00:00Z' },
+      ]
+      expect(order(msgs, 'Nearby', centre)).toEqual(['near', 'nocoord'])
+    })
+
+    it('breaks equal-distance ties by recency (newest first)', () => {
+      const msgs = [
+        { id: 'older', lat: 51.6, lng: -0.1, arrival: '2024-01-01T00:00:00Z' },
+        { id: 'newer', lat: 51.6, lng: -0.1, arrival: '2024-06-01T00:00:00Z' },
+      ]
+      expect(order(msgs, 'Nearby', centre)).toEqual(['newer', 'older'])
+    })
+
+    it('falls back to recency when there is no centre', () => {
+      const msgs = [
+        { id: 'older', lat: 51.6, lng: -0.1, arrival: '2024-01-01T00:00:00Z' },
+        { id: 'newer', lat: 53.0, lng: -0.1, arrival: '2024-06-01T00:00:00Z' },
+      ]
+      // No centre -> not nearest-first; newest arrival wins regardless of distance.
+      expect(order(msgs, 'Nearby', null)).toEqual(['newer', 'older'])
+    })
+  })
+
+  describe('Newest / other sorts', () => {
+    it('orders by descending arrival', () => {
+      const msgs = [
+        { id: 1, arrival: '2024-01-01T00:00:00Z' },
+        { id: 2, arrival: '2024-03-01T00:00:00Z' },
+        { id: 3, arrival: '2024-02-01T00:00:00Z' },
+      ]
+      expect(order(msgs, 'Newest')).toEqual([2, 3, 1])
+      // An unknown sort is treated the same (recency).
+      expect(order(msgs, 'Whatever')).toEqual([2, 3, 1])
+    })
+  })
+})

--- a/iznik-nuxt3/tests/unit/stores/message.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/message.spec.js
@@ -9,8 +9,10 @@ const mockSave = vi.fn()
 const mockFetch = vi.fn()
 const mockSearch = vi.fn()
 const mockFetchMessages = vi.fn()
-const mockFetchMT = vi.fn()
 const mockView = vi.fn()
+const mockMarkSeen = vi.fn()
+const mockCount = vi.fn()
+const mockNearbyMarkSeen = vi.fn()
 
 vi.mock('~/api', () => ({
   default: () => ({
@@ -21,6 +23,8 @@ vi.mock('~/api', () => ({
       search: mockSearch,
       fetchMessages: mockFetchMessages,
       view: mockView,
+      markSeen: mockMarkSeen,
+      count: mockCount,
     },
   }),
 }))
@@ -38,7 +42,7 @@ vi.mock('~/stores/user', () => ({
 }))
 
 vi.mock('~/stores/nearby', () => ({
-  useNearbyStore: () => ({}),
+  useNearbyStore: () => ({ markSeen: mockNearbyMarkSeen }),
 }))
 
 const mockMiscStore = { modtools: false }
@@ -291,10 +295,7 @@ describe('message store - searchMT()', () => {
 
   it('handles fetchMT failure for individual results gracefully', async () => {
     useAuthStore.mockReturnValue({ user: { id: 1 } })
-    mockSearch.mockResolvedValue([
-      { id: 201 },
-      { id: 202 },
-    ])
+    mockSearch.mockResolvedValue([{ id: 201 }, { id: 202 }])
 
     const store = useMessageStore()
     store.fetchMT = vi.fn().mockImplementation(({ id }) => {
@@ -447,5 +448,43 @@ describe('message store - fetchMessagesMT() pagination context', () => {
     })
 
     expect(mockFetchMessages.mock.calls[0][0].context).toBeNull()
+  })
+})
+
+describe('message store - markSeen()', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+    useAuthStore.mockReturnValue({ user: { id: 1 } })
+    mockCount.mockResolvedValue({ count: 0 })
+  })
+
+  it('marks only the given ids as seen in the local cache', async () => {
+    const store = useMessageStore()
+    store.init({})
+    store.list = {
+      1: { id: 1, unseen: true },
+      2: { id: 2, unseen: true },
+      3: { id: 3, unseen: true },
+    }
+
+    await store.markSeen([1, 3])
+
+    expect(mockMarkSeen).toHaveBeenCalledWith([1, 3])
+    expect(mockNearbyMarkSeen).toHaveBeenCalledWith([1, 3])
+    expect(store.list[1].unseen).toBe(false)
+    expect(store.list[2].unseen).toBe(true) // untouched
+    expect(store.list[3].unseen).toBe(false)
+  })
+
+  it('ignores ids that are not in the cache', async () => {
+    const store = useMessageStore()
+    store.init({})
+    store.list = { 1: { id: 1, unseen: true } }
+
+    await store.markSeen([1, 999])
+
+    expect(store.list[1].unseen).toBe(false)
+    expect(store.list[999]).toBeUndefined()
   })
 })


### PR DESCRIPTION
## Why

On the browse page the computed/filtering properties run over the **whole** post
set returned by the server. For a heavy-membership "all my communities" or the
nearby/reach feed that can be **many thousands** of posts, and several of those
computeds were super-linear or repeated avoidable per-item work on every
recompute (and they recompute on every mark-seen). This made scrolling and
mark-seen janky on large feeds.

This PR is **purely client-side**: no API/Go changes, no extra per-message data
from the server, no pagination / "load more".

## What changed

The sort and dedup logic is extracted into two pure, unit-tested composables
(`useMessageSort`, `useMessageDedup`) and the hot paths are fixed:

| File · symbol | Before | After |
|---|---|---|
| `MessageList.vue` · `duplicates` | O(n²): `.find()` over `deDuplicatedMessages` per item | O(n): `Set` of kept ids |
| `MessageList.vue` · `deDuplicatedMessages` | member-group swap via `ret.findIndex()` (O(n) per swap) | id→index `Map` (O(1) per swap) |
| `PostMapAndList.vue` · `sortMessages` | `getDistance` (haversine) + `Date` parse for **both** operands every compare — O(n log n) trig/date | Schwartzian transform: each sort key computed once — O(n) keys + O(n log n) numeric compares |
| `PostMap.vue` · `groups` | `includes()` in a loop | `Set` |
| `stores/message.js` · `markSeen` | scanned the **whole session-lifetime** message cache each call | indexes the given ids directly |

## Behaviour is unchanged

Every one of these is behaviour-preserving:

- Rippling relevance sort (unseen-first, then `score`; "Nearby" nearest-first
  with recency tiebreak; null-coord posts last).
- Dedup preference (collapse a poster's crossposts, strip trailing `(location)`,
  prefer the copy on a group the viewer belongs to — Discourse 9733/9729 —
  `firstSeenMessage` never displaced).
- Distance-slider filtering, successful/outcome handling, CLS gating.

Verified by:
- A **differential-equivalence check** of the old vs new logic over 10,000
  randomized inputs (sort, dedup, duplicates, group-ids) — all identical.
- New unit tests: `useMessageSort.spec.js`, `useMessageDedup.spec.js`, and a
  `markSeen` cache-update test.
- `eslint` clean on all changed files.

## Scope / follow-ups (not in this PR)

Deliberately excluded, per the requirement to stay client-side:
- Mutating `nearby.markSeen` in place + dropping the `{deep:true}` watch — needs
  browser verification of the `updatedMessagesOnMap` unseen-sync and is left for
  a separate change.
- The `mygroups` server `LIMIT`/pagination and extending the feed summary — out
  of scope (no backend changes, no load-more).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
