### PR TITLE
fix(batch): make scheduler overlap protection DB-independent and self-healing

### DIFF
--- a/iznik-batch/.env.example
+++ b/iznik-batch/.env.example
@@ -45,7 +45,12 @@ QUEUE_CONNECTION=database
 CACHE_STORE=database
 # CACHE_PREFIX=
 
-# Lock store for scheduler mutex (flock = process-aware, auto-releases on crash)
+# Backend for the scheduler's withoutOverlapping() mutexes. See config/cache.php
+# and App\Console\SchedulerMutex. 'flock' auto-releases on crash but gives NO
+# overlap protection for our runInBackground jobs (the lock dies with the
+# schedule:run tick, before the job finishes). Set to 'redis' in the batch
+# environment so overlap protection actually holds across ticks and survives a
+# primary-DB stall; the bounded expiries in routes/console.php prevent stale locks.
 LOCK_STORE=flock
 
 MEMCACHED_HOST=127.0.0.1

--- a/iznik-batch/app/Console/ResilientCacheEventMutex.php
+++ b/iznik-batch/app/Console/ResilientCacheEventMutex.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Console;
+
+use Illuminate\Console\Scheduling\CacheEventMutex;
+use Illuminate\Console\Scheduling\Event;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * A cache-backed scheduler mutex (redis) that FAILS OPEN when the store is
+ * unavailable, instead of letting the exception escape and kill the whole
+ * schedule:run tick.
+ *
+ * Why this matters: withoutOverlapping() registers a skip() filter that calls
+ * $mutex->exists() from inside Event::filtersPass(), which ScheduleRunCommand
+ * iterates OUTSIDE the try/catch that wraps a task's actual run. So if the store
+ * throws (e.g. a redis blip), the exception propagates out of the loop and aborts
+ * the entire tick — starving every job registered after the first guarded one.
+ * With schedule:work spawning a fresh tick each minute, a transient redis outage
+ * would become a near-total batch-scheduler outage.
+ *
+ * Failing open (create -> "acquired", exists -> "no lock") means that during a
+ * store outage jobs simply run without overlap protection — no worse than the
+ * flock default, and far better than not running at all. The overlap protection
+ * that matters for the incident (a DB stall while redis is healthy) is unaffected,
+ * because in that case the store is up and the real mutex is used.
+ */
+class ResilientCacheEventMutex extends CacheEventMutex
+{
+    public function create(Event $event)
+    {
+        try {
+            return parent::create($event);
+        } catch (\Throwable $e) {
+            $this->failOpen('create', $e);
+
+            return true; // treat as acquired -> let the job run
+        }
+    }
+
+    public function exists(Event $event)
+    {
+        try {
+            return parent::exists($event);
+        } catch (\Throwable $e) {
+            $this->failOpen('exists', $e);
+
+            return false; // treat as "no overlap" -> don't skip the job
+        }
+    }
+
+    public function forget(Event $event)
+    {
+        try {
+            parent::forget($event);
+        } catch (\Throwable $e) {
+            $this->failOpen('forget', $e);
+        }
+    }
+
+    private function failOpen(string $op, \Throwable $e): void
+    {
+        Log::warning(
+            "Scheduler overlap mutex {$op}() failed on store '".($this->store ?? 'default')."' "
+            ."({$e->getMessage()}); failing open so the job still runs."
+        );
+    }
+}

--- a/iznik-batch/app/Console/SchedulerMutex.php
+++ b/iznik-batch/app/Console/SchedulerMutex.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace App\Console;
+
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Chooses the store that backs the scheduler's withoutOverlapping() mutexes.
+ *
+ * Driven by the LOCK_STORE env var (config key cache.lock_store), default 'flock'.
+ *
+ *   LOCK_STORE=flock  (default) -> App\Console\FlockEventMutex is bound as the
+ *                                   scheduler EventMutex (see AppServiceProvider).
+ *   LOCK_STORE=redis            -> flock is NOT bound; a fail-open cache mutex
+ *                                   (App\Console\ResilientCacheEventMutex) is bound
+ *                                   and pointed at the 'redis' cache store here.
+ *   LOCK_STORE=<other store>    -> as above, using that cache store.
+ *   LOCK_STORE=<unknown/typo>   -> falls back to flock (with a logged warning)
+ *                                   rather than crashing every overlap check.
+ *
+ * Why this exists (batch scheduler resilience, incident 2026-07-02):
+ *
+ * All scheduled jobs run with ->runInBackground(). With FlockEventMutex the OS
+ * flock is acquired inside the short-lived `schedule:run` tick process and is
+ * released the instant that process exits — which is seconds after the background
+ * job is *spawned*, not when it *finishes*. So on the next tick the lock is free
+ * and a fresh copy is spawned even though the previous one is still running. Under
+ * a stalled database (jobs hang far longer than their cadence) this let copies
+ * pile up until the host ran out of memory.
+ *
+ * A cache-based mutex fixes this: the lock lives in the store (redis) with a TTL,
+ * so it persists across the per-tick `schedule:run` processes and genuinely blocks
+ * a second spawn while the first is still running. Redis is also independent of the
+ * primary DB that stalled. The reason flock was originally chosen — avoiding a
+ * crashed job leaving a 24h stale lock — is handled instead by the bounded
+ * withoutOverlapping() expiries in routes/console.php (minutes, not 24h), so a
+ * killed job self-heals quickly.
+ *
+ * Kept as an env-gated switch (default flock) so this is a no-op until a human
+ * flips LOCK_STORE=redis in the batch environment.
+ */
+class SchedulerMutex
+{
+    /** The raw configured lock store name (e.g. 'flock', 'redis', 'database'). */
+    public static function lockStore(): string
+    {
+        return (string) config('cache.lock_store', 'flock');
+    }
+
+    /**
+     * The cache store name to back the overlap mutex, or null when using flock
+     * (either explicitly, empty, or because the configured value is not a defined
+     * cache store — in which case we fall back to flock rather than crash). The
+     * value is normalised (trim + lowercase) and validated against config('cache.stores').
+     */
+    public static function cacheStore(): ?string
+    {
+        $store = strtolower(trim(self::lockStore()));
+
+        if ($store === '' || $store === 'flock') {
+            return null;
+        }
+
+        return in_array($store, self::definedStores(), true) ? $store : null;
+    }
+
+    /** Whether the flock (process-death) mutex is in use. Derived from cacheStore() so they agree. */
+    public static function usesFlock(): bool
+    {
+        return self::cacheStore() === null;
+    }
+
+    /**
+     * Point the schedule's overlap mutex at the configured cache store.
+     * No-op under flock (Schedule::useCache only affects the CacheEventMutex).
+     * If a non-flock value was configured but is not a defined store, warn so the
+     * misconfiguration is visible (we have already fallen back to flock).
+     */
+    public static function apply(Schedule $schedule): void
+    {
+        $store = self::cacheStore();
+
+        if ($store !== null) {
+            $schedule->useCache($store);
+
+            return;
+        }
+
+        $raw = strtolower(trim(self::lockStore()));
+        if ($raw !== '' && $raw !== 'flock') {
+            Log::warning(
+                "Scheduler LOCK_STORE='".self::lockStore()."' is not a defined cache store; "
+                .'using flock instead. Valid stores: '.implode(', ', self::definedStores()).'.'
+            );
+        }
+    }
+
+    /** @return list<string> defined cache store names (lowercase). */
+    private static function definedStores(): array
+    {
+        return array_map(fn ($k) => strtolower((string) $k), array_keys((array) config('cache.stores', [])));
+    }
+}

--- a/iznik-batch/app/Providers/AppServiceProvider.php
+++ b/iznik-batch/app/Providers/AppServiceProvider.php
@@ -3,6 +3,8 @@
 namespace App\Providers;
 
 use App\Console\FlockEventMutex;
+use App\Console\ResilientCacheEventMutex;
+use App\Console\SchedulerMutex;
 use App\Database\DeadlockRetryConnection;
 use App\Listeners\CronJobStatusListener;
 use App\Listeners\SpamCheckListener;
@@ -35,11 +37,22 @@ class AppServiceProvider extends ServiceProvider
             return new LokiService();
         });
 
-        // Register FlockEventMutex for process-aware scheduler locks.
-        // Uses OS-level flock() which auto-releases on process death.
-        if (config('cache.lock_store', 'flock') === 'flock') {
+        // Scheduler overlap mutex backend. Default (LOCK_STORE=flock) binds
+        // FlockEventMutex — OS-level flock that auto-releases on process death.
+        // Setting LOCK_STORE=redis (or another cache store) binds a TTL-based cache
+        // mutex instead; routes/console.php points it at that store. See
+        // App\Console\SchedulerMutex for why (flock does not protect
+        // ->runInBackground() jobs across ticks). We bind our own
+        // ResilientCacheEventMutex rather than the framework default so a store
+        // outage fails open (logs + runs the job) instead of throwing out of the
+        // schedule:run filter and killing the whole tick.
+        if (SchedulerMutex::usesFlock()) {
             $this->app->singleton(EventMutex::class, function ($app) {
                 return new FlockEventMutex();
+            });
+        } else {
+            $this->app->singleton(EventMutex::class, function ($app) {
+                return new ResilientCacheEventMutex($app->make('cache'));
             });
         }
     }

--- a/iznik-batch/config/cache.php
+++ b/iznik-batch/config/cache.php
@@ -22,9 +22,34 @@ return [
     | Scheduler Lock Store
     |--------------------------------------------------------------------------
     |
-    | This option controls the lock mechanism used for scheduler mutexes.
-    | 'flock' uses OS-level file locks that auto-release on process death.
-    | 'cache' uses Laravel's default cache-based locks with TTL expiry.
+    | Backend for the scheduler's withoutOverlapping() mutexes (see
+    | App\Console\SchedulerMutex).
+    |
+    | 'flock' (default) uses OS-level file locks that auto-release on process
+    | death. Caveat: our jobs all run ->runInBackground(), so the flock is held
+    | only by the short-lived schedule:run tick — it is released seconds after a
+    | job is *spawned*, NOT when it finishes, giving no real overlap protection
+    | across ticks. A hung/slow job (e.g. during a DB stall) is therefore spawned
+    | again every tick and can pile up.
+    |
+    | 'redis' (or any other DEFINED cache store name) uses a fail-open cache mutex
+    | (App\Console\ResilientCacheEventMutex) pointed at that store: a TTL lock that
+    | lives in the store (redis), so it persists across the per-tick schedule:run
+    | processes and genuinely blocks a second spawn while the first is still
+    | running, and is independent of the primary DB that can stall. The bounded
+    | withoutOverlapping() expiries in routes/console.php cap the TTL so a killed
+    | job self-heals in minutes, not the 24h default that originally motivated
+    | flock. Note the TTL BOUNDS but does not fully eliminate pileup: a stall
+    | longer than a job's expiry lets its lock expire mid-run and a second copy
+    | start — capped by TTL/cadence (e.g. ~4/hour for a 15min-bucket everyMinute
+    | job) rather than the unbounded every-tick pileup flock allowed.
+    |
+    | The value must be a store defined in 'stores' below; an unknown/mis-cased
+    | value (e.g. 'Redis') falls back to flock with a logged warning rather than
+    | crashing every overlap check. If the store is briefly unreachable the mutex
+    | fails open (logs + runs the job) instead of aborting the whole schedule:run.
+    |
+    | Recommended in production (batch): LOCK_STORE=redis.
     |
     */
 

--- a/iznik-batch/routes/console.php
+++ b/iznik-batch/routes/console.php
@@ -24,6 +24,13 @@ if (!function_exists('cronLog')) {
     }
 }
 
+// Point the withoutOverlapping() mutexes below at the configured store. Under the
+// default LOCK_STORE=flock this is a no-op (FlockEventMutex handles locking); under
+// LOCK_STORE=redis it backs overlap protection with a redis TTL lock that survives
+// across the per-tick schedule:run processes and is independent of the primary DB —
+// the resilient path for our all-runInBackground jobs. See App\Console\SchedulerMutex.
+\App\Console\SchedulerMutex::apply(app(\Illuminate\Console\Scheduling\Schedule::class));
+
 // =============================================================================
 // ACTIVE SCHEDULED COMMANDS
 // =============================================================================
@@ -51,7 +58,7 @@ Schedule::command('mail:welcome:send --limit=100 --spool')
 // disabled and deploy:refresh is too heavy to schedule.
 Schedule::command('deploy:record-commit')
     ->everyFifteenMinutes()
-    ->withoutOverlapping()
+    ->withoutOverlapping(30)
     ->sendOutputTo(cronLog('deploy:record-commit'))
     ->runInBackground();
 
@@ -81,7 +88,7 @@ Schedule::command('mail:chat:user2mod --max-iterations=60 --spool')
 // Sends alert email to GeekAlerts if fetch fails.
 Schedule::command('data:update-cpi')
     ->monthly()
-    ->withoutOverlapping()
+    ->withoutOverlapping(360)
     ->sendOutputTo(cronLog('data:update-cpi'))
     ->runInBackground();
 
@@ -89,7 +96,7 @@ Schedule::command('data:update-cpi')
 // CGNAT shared-egress IPs stay exempt from the IP-abuse check (Discourse #9768).
 Schedule::command('spam:refresh-mobile-cidrs')
     ->monthly()
-    ->withoutOverlapping()
+    ->withoutOverlapping(360)
     ->sendOutputTo(cronLog('spam:refresh-mobile-cidrs'))
     ->runInBackground();
 
@@ -98,7 +105,7 @@ Schedule::command('spam:refresh-mobile-cidrs')
 // in Pending with failure reasons stored, then notifies group mods.
 Schedule::command('messages:contentcheck')
     ->everyMinute()
-    ->withoutOverlapping()
+    ->withoutOverlapping(15)
     ->sendOutputTo(cronLog('messages:contentcheck'))
     ->runInBackground();
 
@@ -112,7 +119,7 @@ Schedule::command('messages:contentcheck')
 if (config('freegle.ripple.enabled')) {
     Schedule::command('ripple:expand')
         ->everyMinute()
-        ->withoutOverlapping()
+        ->withoutOverlapping(15)
         ->sendOutputTo(cronLog('ripple:expand'))
         ->runInBackground();
 }
@@ -125,7 +132,7 @@ $rippleWithinGroups = (array) config('freegle.ripple.within_groups', []);
 if (!empty($rippleWithinGroups)) {
     Schedule::command('ripple:expand', ['--within-group' => implode(',', $rippleWithinGroups)])
         ->everyMinute()
-        ->withoutOverlapping()
+        ->withoutOverlapping(15)
         ->sendOutputTo(cronLog('ripple:expand-experiment'))
         ->runInBackground();
 }
@@ -134,7 +141,7 @@ if (!empty($rippleWithinGroups)) {
 // Inert until the reach engine is live -- nothing to release until a reply is held.
 Schedule::command('ripple:release-replies')
     ->everyMinute()
-    ->withoutOverlapping()
+    ->withoutOverlapping(15)
     ->sendOutputTo(cronLog('ripple:release-replies'))
     ->runInBackground();
 
@@ -143,7 +150,7 @@ Schedule::command('ripple:release-replies')
 // Signals Go spatial server to reload after update.
 Schedule::command('spatial:update-data')
     ->monthlyOn(1, '03:00')
-    ->withoutOverlapping()
+    ->withoutOverlapping(360)
     ->sendOutputTo(cronLog('spatial:update-data'))
     ->runInBackground();
 
@@ -151,7 +158,7 @@ Schedule::command('spatial:update-data')
 // V1: cron/autoapprove.php
 Schedule::command('messages:auto-approve')
     ->hourly()
-    ->withoutOverlapping()
+    ->withoutOverlapping(120)
     ->sendOutputTo(cronLog('messages:auto-approve'))
     ->runInBackground();
 
@@ -159,7 +166,7 @@ Schedule::command('messages:auto-approve')
 // V1: cron/autorepost.php
 Schedule::command('messages:auto-repost')
     ->hourly()
-    ->withoutOverlapping()
+    ->withoutOverlapping(120)
     ->sendOutputTo(cronLog('messages:auto-repost'))
     ->runInBackground();
 
@@ -167,7 +174,7 @@ Schedule::command('messages:auto-repost')
 // V1: cron/chaseup.php
 Schedule::command('messages:chase-up')
     ->hourly()
-    ->withoutOverlapping()
+    ->withoutOverlapping(120)
     ->sendOutputTo(cronLog('messages:chase-up'))
     ->runInBackground();
 
@@ -175,7 +182,7 @@ Schedule::command('messages:chase-up')
 // V1: cron/searchdups.php
 Schedule::command('cleanup:search-duplicates')
     ->hourly()
-    ->withoutOverlapping()
+    ->withoutOverlapping(120)
     ->sendOutputTo(cronLog('cleanup:search-duplicates'))
     ->runInBackground();
 
@@ -183,7 +190,7 @@ Schedule::command('cleanup:search-duplicates')
 // V1: cron/chatdups.php
 Schedule::command('cleanup:chat-duplicates')
     ->everyTwoHours()
-    ->withoutOverlapping()
+    ->withoutOverlapping(120)
     ->sendOutputTo(cronLog('cleanup:chat-duplicates'))
     ->runInBackground();
 
@@ -191,7 +198,7 @@ Schedule::command('cleanup:chat-duplicates')
 // V1: cron/archive_attachments.php — disabled pending sign-off
 Schedule::command('cleanup:archive-profile-images')
     ->dailyAt('22:30')
-    ->withoutOverlapping()
+    ->withoutOverlapping(360)
     ->sendOutputTo(cronLog('cleanup:archive-profile-images'))
     ->runInBackground();
 
@@ -199,7 +206,7 @@ Schedule::command('cleanup:archive-profile-images')
 // V1: cron/purge_sessions.php
 Schedule::command('cleanup:sessions')
     ->dailyAt('03:00')
-    ->withoutOverlapping()
+    ->withoutOverlapping(360)
     ->sendOutputTo(cronLog('cleanup:sessions'))
     ->runInBackground();
 
@@ -209,7 +216,7 @@ Schedule::command('cleanup:sessions')
 // not Monolog-managed at all - this keeps storage/logs bounded.
 Schedule::command('logs:rotate')
     ->dailyAt('00:30')
-    ->withoutOverlapping()
+    ->withoutOverlapping(360)
     ->sendOutputTo(cronLog('logs:rotate'))
     ->runInBackground();
 
@@ -217,7 +224,7 @@ Schedule::command('logs:rotate')
 // V1: cron/check_spammers.php (every 5 minutes)
 Schedule::command('users:remove-spammers')
     ->everyFiveMinutes()
-    ->withoutOverlapping()
+    ->withoutOverlapping(15)
     ->sendOutputTo(cronLog('users:remove-spammers'))
     ->runInBackground();
 
@@ -225,7 +232,7 @@ Schedule::command('users:remove-spammers')
 // V1: cron/bounce.php + bounce_users.php
 Schedule::command('mail:bounced')
     ->hourly()
-    ->withoutOverlapping()
+    ->withoutOverlapping(120)
     ->sendOutputTo(cronLog('mail:bounced'))
     ->runInBackground();
 
@@ -233,7 +240,7 @@ Schedule::command('mail:bounced')
 // charities table (which would otherwise sit Pending, unwatched).
 Schedule::command('charity:notify-signups')
     ->hourly()
-    ->withoutOverlapping()
+    ->withoutOverlapping(120)
     ->sendOutputTo(cronLog('charity:notify-signups'))
     ->runInBackground();
 
@@ -242,7 +249,7 @@ Schedule::command('charity:notify-signups')
 // V1: cron/mod_notifs.php (hourly)
 Schedule::command('mail:mod-notifs')
     ->hourly()
-    ->withoutOverlapping()
+    ->withoutOverlapping(120)
     ->sendOutputTo(cronLog('mail:mod-notifs'))
     ->runInBackground();
 
@@ -254,7 +261,7 @@ Schedule::command('mail:mod-notifs')
 // in the bulk3-internal crontab at the same time to avoid double-sending.
 Schedule::command('mail:alerts:send')
     ->everyTenMinutes()
-    ->withoutOverlapping()
+    ->withoutOverlapping(30)
     ->sendOutputTo(cronLog('mail:alerts:send'))
     ->runInBackground();
 
@@ -280,7 +287,7 @@ Schedule::call(fn () => null)
 // configurable thresholds during daytime hours.
 Schedule::command('monitor:email-health')
     ->everyFifteenMinutes()
-    ->withoutOverlapping()
+    ->withoutOverlapping(30)
     ->sendOutputTo(cronLog('monitor:email-health'))
     ->runInBackground();
 
@@ -296,7 +303,7 @@ Schedule::command('monitor:email-health')
 Schedule::command('monitor:scheduled-outcomes')
     ->everyTenMinutes()
     ->name('scheduled-outcomes-monitor')
-    ->withoutOverlapping()
+    ->withoutOverlapping(30)
     // sentryMonitor(slug, checkInMargin, maxRuntime, updateMonitorConfig, failureIssueThreshold, recoveryThreshold)
     ->sentryMonitor('scheduled-outcomes-monitor', 20, null, true, 2, 1)
     ->sendOutputTo(cronLog('monitor:scheduled-outcomes'));
@@ -305,7 +312,7 @@ Schedule::command('monitor:scheduled-outcomes')
 // V1: cron/notification_chaseup.php (every 5 minutes)
 Schedule::command('mail:notifications:chaseup')
     ->everyFiveMinutes()
-    ->withoutOverlapping()
+    ->withoutOverlapping(15)
     ->sendOutputTo(cronLog('mail:notifications:chaseup'))
     ->runInBackground();
 
@@ -313,7 +320,7 @@ Schedule::command('mail:notifications:chaseup')
 // V1: cron/purge_chats.php
 Schedule::command('purge:chats')
     ->dailyAt('02:00')
-    ->withoutOverlapping()
+    ->withoutOverlapping(360)
     ->sendOutputTo(cronLog('purge:chats'))
     ->runInBackground();
 
@@ -321,7 +328,7 @@ Schedule::command('purge:chats')
 // V1: cron/purge_logs.php
 Schedule::command('purge:logs')
     ->dailyAt('03:30')
-    ->withoutOverlapping()
+    ->withoutOverlapping(360)
     ->sendOutputTo(cronLog('purge:logs'))
     ->runInBackground();
 
@@ -329,7 +336,7 @@ Schedule::command('purge:logs')
 // V1: cron/email_validate.php
 Schedule::command('emails:validate')
     ->dailyAt('04:30')
-    ->withoutOverlapping()
+    ->withoutOverlapping(360)
     ->sendOutputTo(cronLog('emails:validate'))
     ->runInBackground();
 
@@ -337,7 +344,7 @@ Schedule::command('emails:validate')
 // V1: cron/membercounts.php
 Schedule::command('groups:update-counts')
     ->hourly()
-    ->withoutOverlapping()
+    ->withoutOverlapping(120)
     ->sendOutputTo(cronLog('groups:update-counts'))
     ->runInBackground();
 
@@ -346,7 +353,7 @@ Schedule::command('groups:update-counts')
 // V1: cron/chat_latestmessage.php
 Schedule::command('chats:update-counts')
     ->hourly()
-    ->withoutOverlapping()
+    ->withoutOverlapping(120)
     ->sendOutputTo(cronLog('chats:update-counts'))
     ->runInBackground();
 
@@ -354,7 +361,7 @@ Schedule::command('chats:update-counts')
 // V1: cron/users_modmails.php (every 5 minutes)
 Schedule::command('users:update-modmails')
     ->everyFiveMinutes()
-    ->withoutOverlapping()
+    ->withoutOverlapping(15)
     ->sendOutputTo(cronLog('users:update-modmails'))
     ->runInBackground();
 
@@ -362,7 +369,7 @@ Schedule::command('users:update-modmails')
 // V1: cron/lastaccess.php
 Schedule::command('users:update-lastaccess')
     ->hourly()
-    ->withoutOverlapping()
+    ->withoutOverlapping(120)
     ->sendOutputTo(cronLog('users:update-lastaccess'))
     ->runInBackground();
 
@@ -370,7 +377,7 @@ Schedule::command('users:update-lastaccess')
 // V1: cron/chat_expected.php (every 5 minutes)
 Schedule::command('chats:update-expected')
     ->everyFiveMinutes()
-    ->withoutOverlapping()
+    ->withoutOverlapping(15)
     ->sendOutputTo(cronLog('chats:update-expected'))
     ->runInBackground();
 
@@ -378,7 +385,7 @@ Schedule::command('chats:update-expected')
 // V1: cron/tryst.php (every 1 minute)
 Schedule::command('chats:send-tryst-reminders')
     ->everyMinute()
-    ->withoutOverlapping()
+    ->withoutOverlapping(15)
     ->sendOutputTo(cronLog('chats:send-tryst-reminders'))
     ->runInBackground();
 
@@ -386,7 +393,7 @@ Schedule::command('chats:send-tryst-reminders')
 // V1: cron/chat_chaseupmods.php (daily 15:30)
 Schedule::command('chats:chaseup-mods')
     ->dailyAt('15:30')
-    ->withoutOverlapping()
+    ->withoutOverlapping(360)
     ->sendOutputTo(cronLog('chats:chaseup-mods'))
     ->runInBackground();
 
@@ -394,7 +401,7 @@ Schedule::command('chats:chaseup-mods')
 // V1: cron/chat_spam.php (every 5 minutes)
 Schedule::command('chats:process-spam')
     ->everyFiveMinutes()
-    ->withoutOverlapping()
+    ->withoutOverlapping(15)
     ->sendOutputTo(cronLog('chats:process-spam'))
     ->runInBackground();
 
@@ -403,7 +410,7 @@ Schedule::command('chats:process-spam')
 // e.g. to reduce latency by requesting an immediate sync after sending a chat message.
 Schedule::command('tn:sync')
     ->everyMinute()
-    ->withoutOverlapping()
+    ->withoutOverlapping(15)
     ->runInBackground();
 
 // =============================================================================
@@ -434,7 +441,7 @@ Schedule::command('mail:digest:unified --mode=daily')
     ->timezone(config('freegle.timezone'))
     ->everyThirtyMinutes()
     ->between('7:00', '12:00')
-    ->withoutOverlapping()
+    ->withoutOverlapping(300)
     ->sendOutputTo(cronLog('mail:digest:unified.daily'))
     ->runInBackground();
 
@@ -466,7 +473,7 @@ Schedule::command('push:daily-posts')
     ->timezone(config('freegle.timezone'))
     ->everyThirtyMinutes()
     ->between('7:30', '12:00')
-    ->withoutOverlapping()
+    ->withoutOverlapping(60)
     ->sendOutputTo(cronLog('push:daily-posts'))
     ->runInBackground();
 
@@ -525,13 +532,13 @@ foreach (range(0, $reachMailShardCount - 1) as $reachShard) {
 // Donation-related commands. V1 equivalents on bulk3 disabled 2026-05-12.
 Schedule::command('mail:donations:thank')
     ->dailyAt('09:00')
-    ->withoutOverlapping()
+    ->withoutOverlapping(360)
     ->sendOutputTo(cronLog('mail:donations:thank'))
     ->runInBackground();
 
 Schedule::command('mail:donations:ask')
     ->dailyAt('17:00')
-    ->withoutOverlapping()
+    ->withoutOverlapping(360)
     ->sendOutputTo(cronLog('mail:donations:ask'))
     ->runInBackground();
 
@@ -545,7 +552,7 @@ Schedule::command('mail:donations:ask')
 Schedule::command('mail:donations:summary')
     ->hourly()
     ->between('06:00', '22:00')
-    ->withoutOverlapping()
+    ->withoutOverlapping(120)
     ->sendOutputTo(cronLog('mail:donations:summary'))
     ->runInBackground();
 
@@ -558,7 +565,7 @@ Schedule::command('mail:donations:summary')
 // last status mail; recipient is freegle.mail.thanks_addr.
 Schedule::command('mail:donations:thank-prep')
     ->dailyAt('20:30')
-    ->withoutOverlapping()
+    ->withoutOverlapping(360)
     ->sendOutputTo(cronLog('mail:donations:thank-prep'))
     ->runInBackground();
 
@@ -583,14 +590,14 @@ Schedule::command('queue:background-tasks --max-iterations=60 --spool')
 // Clean up old sent emails - run daily.
 Schedule::command('mail:spool:process --cleanup --cleanup-days=7')
     ->dailyAt('04:00')
-    ->withoutOverlapping()
+    ->withoutOverlapping(360)
     ->sendOutputTo(cronLog('mail:spool:process'))
     ->runInBackground();
 
 // Clean up incoming email archives older than 48 hours.
 Schedule::command('mail:cleanup-archive')
     ->hourly()
-    ->withoutOverlapping()
+    ->withoutOverlapping(120)
     ->sendOutputTo(cronLog('mail:cleanup-archive'))
     ->runInBackground();
 
@@ -598,7 +605,7 @@ Schedule::command('mail:cleanup-archive')
 // V1: cron/birthday.php (daily 12:00)
 Schedule::command('birthday:send-emails')
     ->dailyAt('12:00')
-    ->withoutOverlapping()
+    ->withoutOverlapping(360)
     ->sendOutputTo(cronLog('birthday:send-emails'))
     ->runInBackground();
 
@@ -606,7 +613,7 @@ Schedule::command('birthday:send-emails')
 // V1: cron/mod_active.php (Monday 15:00)
 Schedule::command('groups:check-mod-welfare')
     ->weeklyOn(1, '15:00')
-    ->withoutOverlapping()
+    ->withoutOverlapping(360)
     ->sendOutputTo(cronLog('groups:check-mod-welfare'))
     ->runInBackground();
 
@@ -618,7 +625,7 @@ Schedule::command('groups:check-mod-welfare')
 // on the same day.
 Schedule::command('groups:welcome-review')
     ->dailyAt('15:00')
-    ->withoutOverlapping()
+    ->withoutOverlapping(360)
     ->sendOutputTo(cronLog('groups:welcome-review'))
     ->runInBackground();
 
@@ -626,7 +633,7 @@ Schedule::command('groups:welcome-review')
 // V1: cron/lovejunk_tn_invoice.php (1st of month at 15:00)
 Schedule::command('lovejunk:send-tn-invoice')
     ->monthlyOn(1, '15:00')
-    ->withoutOverlapping()
+    ->withoutOverlapping(360)
     ->sendOutputTo(cronLog('lovejunk:send-tn-invoice'))
     ->runInBackground();
 
@@ -635,7 +642,7 @@ Schedule::command('lovejunk:send-tn-invoice')
 // engagement='Inactive' and runs per-user eligibility queries.
 Schedule::command('mail:engage')
     ->dailyAt('16:00')
-    ->withoutOverlapping()
+    ->withoutOverlapping(360)
     ->sendOutputTo(cronLog('mail:engage'))
     ->runInBackground();
 
@@ -643,7 +650,7 @@ Schedule::command('mail:engage')
 // V1: cron/stories.php (weekly Saturday 11:00)
 Schedule::command('stories:ask')
     ->weeklyOn(6, '11:00')
-    ->withoutOverlapping()
+    ->withoutOverlapping(360)
     ->sendOutputTo(cronLog('stories:ask'))
     ->runInBackground();
 
@@ -656,7 +663,7 @@ Schedule::command('stories:ask')
 // then marks the suggested admin as complete.
 Schedule::command('mail:admin:copy')
     ->everyMinute()
-    ->withoutOverlapping()
+    ->withoutOverlapping(15)
     ->sendOutputTo(cronLog('mail:admin:copy'))
     ->runInBackground();
 
@@ -664,7 +671,7 @@ Schedule::command('mail:admin:copy')
 // Only processes admins that are approved (pending=0) and not yet complete.
 Schedule::command('mail:admin:send --spool')
     ->everyMinute()
-    ->withoutOverlapping()
+    ->withoutOverlapping(15)
     ->sendOutputTo(cronLog('mail:admin:send'))
     ->runInBackground();
 
@@ -672,7 +679,7 @@ Schedule::command('mail:admin:send --spool')
 // Sends reminder emails after 48h, once per day, up to 7 days.
 Schedule::command('mail:admin:chase')
     ->hourly()
-    ->withoutOverlapping()
+    ->withoutOverlapping(120)
     ->sendOutputTo(cronLog('mail:admin:chase'))
     ->runInBackground();
 
@@ -686,7 +693,7 @@ Schedule::command('mail:admin:chase')
 // IncomingMailService creates messages with processingrequired=1; this makes them visible to notifications.
 Schedule::command('chats:process-incoming')
     ->everyMinute()
-    ->withoutOverlapping()
+    ->withoutOverlapping(15)
     ->sendOutputTo(cronLog('chats:process-incoming'))
     ->runInBackground();
 
@@ -695,7 +702,7 @@ Schedule::command('chats:process-incoming')
 // Go API creates memberships_history with processingrequired=1; this sends welcome emails + review flags.
 Schedule::command('memberships:process')
     ->everyMinute()
-    ->withoutOverlapping()
+    ->withoutOverlapping(15)
     ->sendOutputTo(cronLog('memberships:process'))
     ->runInBackground();
 
@@ -703,7 +710,7 @@ Schedule::command('memberships:process')
 // V1: cron/exports.php (every 1 minute)
 Schedule::command('users:process-exports')
     ->everyMinute()
-    ->withoutOverlapping()
+    ->withoutOverlapping(15)
     ->sendOutputTo(cronLog('users:process-exports'))
     ->runInBackground();
 
@@ -711,7 +718,7 @@ Schedule::command('users:process-exports')
 // V1: cron/engage_update.php (daily at 03:00)
 Schedule::command('users:update-engagement')
     ->dailyAt('03:00')
-    ->withoutOverlapping()
+    ->withoutOverlapping(360)
     ->sendOutputTo(cronLog('users:update-engagement'))
     ->runInBackground();
 
@@ -719,7 +726,7 @@ Schedule::command('users:update-engagement')
 // V1: cron/message_deindex.php (daily at 01:00)
 Schedule::command('messages:deindex')
     ->dailyAt('01:00')
-    ->withoutOverlapping()
+    ->withoutOverlapping(360)
     ->sendOutputTo(cronLog('messages:deindex'))
     ->runInBackground();
 
@@ -730,7 +737,7 @@ Schedule::command('messages:deindex')
 // run after migration may bulk-promote backlog (catch-up).
 Schedule::command('microvolunteering:score')
     ->dailyAt('23:00')
-    ->withoutOverlapping()
+    ->withoutOverlapping(360)
     ->sendOutputTo(cronLog('microvolunteering:score'))
     ->runInBackground();
 
@@ -739,7 +746,7 @@ Schedule::command('microvolunteering:score')
 // V1: cron/microvolunteering.php (every 5 minutes).
 Schedule::command('microvolunteering:notify')
     ->everyFiveMinutes()
-    ->withoutOverlapping()
+    ->withoutOverlapping(15)
     ->sendOutputTo(cronLog('microvolunteering:notify'))
     ->runInBackground();
 
@@ -749,7 +756,7 @@ Schedule::command('microvolunteering:notify')
 // V1: cron/user_exhort.php (every minute).
 Schedule::command('notifications:exhort')
     ->everyMinute()
-    ->withoutOverlapping()
+    ->withoutOverlapping(15)
     ->sendOutputTo(cronLog('notifications:exhort'))
     ->runInBackground();
 
@@ -757,7 +764,7 @@ Schedule::command('notifications:exhort')
 // Downloads + unzips the CSV itself. V1: cron/doogal wrapper (daily at 03:00).
 Schedule::command('locations:update-postcodes')
     ->dailyAt('03:00')
-    ->withoutOverlapping()
+    ->withoutOverlapping(360)
     ->sendOutputTo(cronLog('locations:update-postcodes'))
     ->runInBackground();
 
@@ -765,7 +772,7 @@ Schedule::command('locations:update-postcodes')
 // V1: cron/paypal_download.php (every 4 hours at :30). Skips if PayPal creds unset.
 Schedule::command('donations:paypal-download')
     ->cron('30 */4 * * *')
-    ->withoutOverlapping()
+    ->withoutOverlapping(240)
     ->sendOutputTo(cronLog('donations:paypal-download'))
     ->runInBackground();
 
@@ -773,7 +780,7 @@ Schedule::command('donations:paypal-download')
 // signed up. V1: cron/discourse_not_signed_up.php (daily at 03:23). Skips if key unset.
 Schedule::command('discourse:not-signed-up')
     ->dailyAt('03:23')
-    ->withoutOverlapping()
+    ->withoutOverlapping(360)
     ->sendOutputTo(cronLog('discourse:not-signed-up'))
     ->runInBackground();
 
@@ -781,14 +788,14 @@ Schedule::command('discourse:not-signed-up')
 // V1: cron/users_remap.php (daily at 05:00)
 Schedule::command('users:remap-locations')
     ->dailyAt('05:00')
-    ->withoutOverlapping()
+    ->withoutOverlapping(360)
     ->sendOutputTo(cronLog('users:remap-locations'))
     ->runInBackground();
 
 // V1: cron/tn_names.php — fix display names for TN users whose email encodes their name.
 Schedule::command('users:fix-tn-names')
     ->dailyAt('06:30')
-    ->withoutOverlapping()
+    ->withoutOverlapping(360)
     ->sendOutputTo(cronLog('users:fix-tn-names'))
     ->runInBackground();
 
@@ -796,7 +803,7 @@ Schedule::command('users:fix-tn-names')
 // V1: cron/messages_remap.php (every 5 minutes)
 Schedule::command('messages:remap-subjects')
     ->everyFiveMinutes()
-    ->withoutOverlapping()
+    ->withoutOverlapping(15)
     ->sendOutputTo(cronLog('messages:remap-subjects'))
     ->runInBackground();
 
@@ -806,7 +813,7 @@ Schedule::command('messages:remap-subjects')
 //       since it involved external HTTP calls and is unrelated to the visualise insert.
 Schedule::command('messages:update-visualise')
     ->everyFiveMinutes()
-    ->withoutOverlapping()
+    ->withoutOverlapping(15)
     ->sendOutputTo(cronLog('messages:update-visualise'))
     ->runInBackground();
 
@@ -815,7 +822,7 @@ Schedule::command('messages:update-visualise')
 // Note: V1 also pushed freebie-alert jobs to Pheanstalk — that mechanism is retired in the new stack.
 Schedule::command('messages:update-spatial-index')
     ->everyFiveMinutes()
-    ->withoutOverlapping()
+    ->withoutOverlapping(15)
     ->sendOutputTo(cronLog('messages:update-spatial-index'))
     ->runInBackground();
 
@@ -823,7 +830,7 @@ Schedule::command('messages:update-spatial-index')
 // V1: cron/domains_common.php (weekly, Friday 07:00)
 Schedule::command('domains:update-common')
     ->weeklyOn(5, '07:00')
-    ->withoutOverlapping()
+    ->withoutOverlapping(360)
     ->sendOutputTo(cronLog('domains:update-common'))
     ->runInBackground();
 
@@ -831,7 +838,7 @@ Schedule::command('domains:update-common')
 // V1: cron/messages_illustrations.php (every 1 minute) — V1 cron already disabled on bulk3.
 Schedule::command('messages:generate-illustrations')
     ->everyMinute()
-    ->withoutOverlapping()
+    ->withoutOverlapping(15)
     ->sendOutputTo(cronLog('messages:generate-illustrations'))
     ->runInBackground();
 
@@ -839,7 +846,7 @@ Schedule::command('messages:generate-illustrations')
 // V1: cron/jobs_illustrations.php (every 30 minutes) — V1 cron already disabled on bulk3.
 Schedule::command('jobs:generate-illustrations')
     ->everyThirtyMinutes()
-    ->withoutOverlapping()
+    ->withoutOverlapping(60)
     ->sendOutputTo(cronLog('jobs:generate-illustrations'))
     ->runInBackground();
 
@@ -847,7 +854,7 @@ Schedule::command('jobs:generate-illustrations')
 // V1: cron/get_app_release_versions.php
 Schedule::command('data:fetch-app-versions')
     ->everySixHours()
-    ->withoutOverlapping()
+    ->withoutOverlapping(240)
     ->sendOutputTo(cronLog('data:fetch-app-versions'))
     ->runInBackground();
 
@@ -882,7 +889,7 @@ Schedule::command('integrations:sync-whatjobs')
 // V1: cron/lovejunk.php
 Schedule::command('integrations:sync-lovejunk')
     ->everyMinute()
-    ->withoutOverlapping()
+    ->withoutOverlapping(15)
     ->sendOutputTo(cronLog('integrations:sync-lovejunk'))
     ->runInBackground();
 
@@ -890,7 +897,7 @@ Schedule::command('integrations:sync-lovejunk')
 // V1: cron/restartproject.php (23:00 daily)
 Schedule::command('integrations:sync-restartproject')
     ->dailyAt('23:00')
-    ->withoutOverlapping()
+    ->withoutOverlapping(360)
     ->sendOutputTo(cronLog('integrations:sync-restartproject'))
     ->runInBackground();
 
@@ -898,7 +905,7 @@ Schedule::command('integrations:sync-restartproject')
 // V1: cron/repaircafewales.php (23:00 daily)
 Schedule::command('integrations:sync-repaircafewales')
     ->dailyAt('23:00')
-    ->withoutOverlapping()
+    ->withoutOverlapping(360)
     ->sendOutputTo(cronLog('integrations:sync-repaircafewales'))
     ->runInBackground();
 
@@ -908,7 +915,7 @@ Schedule::command('integrations:sync-repaircafewales')
 // Spatial pass mirrors V1 Message::processExpiry(): only acts on messages already marked OUTCOME_EXPIRED.
 Schedule::command('messages:process-expired --spatial')
     ->dailyAt('03:00')
-    ->withoutOverlapping()
+    ->withoutOverlapping(360)
     ->sendOutputTo(cronLog('messages:process-expired'))
     ->runInBackground();
 
@@ -916,14 +923,14 @@ Schedule::command('messages:process-expired --spatial')
 // Fixed: messages_history default corrected to 31 days (matches V1 MessageCollection::RECENTPOSTS).
 Schedule::command('purge:messages')
     ->dailyAt('02:30')
-    ->withoutOverlapping()
+    ->withoutOverlapping(360)
     ->sendOutputTo(cronLog('purge:messages'))
     ->runInBackground();
 
 // V1: cron/locations_skewwhiff.php
 Schedule::command('locations:fix-skewed')
     ->dailyAt('05:00')
-    ->withoutOverlapping()
+    ->withoutOverlapping(360)
     ->sendOutputTo(cronLog('locations:fix-skewed'))
     ->runInBackground();
 
@@ -932,14 +939,14 @@ Schedule::command('locations:fix-skewed')
 // postcodes rely on this pass to be mapped onto group areas.
 Schedule::command('locations:remap-postcodes')
     ->dailyAt('01:00')
-    ->withoutOverlapping()
+    ->withoutOverlapping(360)
     ->sendOutputTo(cronLog('locations:remap-postcodes'))
     ->runInBackground();
 
 // V1: cron/user_ratings.php
 Schedule::command('users:update-ratings')
     ->everyTenMinutes()
-    ->withoutOverlapping()
+    ->withoutOverlapping(30)
     ->sendOutputTo(cronLog('users:update-ratings'))
     ->runInBackground();
 
@@ -947,7 +954,7 @@ Schedule::command('users:update-ratings')
 // Note: safer than V1 — never downgrades Admin users, only Support.
 Schedule::command('users:update-support-roles')
     ->hourly()
-    ->withoutOverlapping()
+    ->withoutOverlapping(120)
     ->sendOutputTo(cronLog('users:update-support-roles'))
     ->runInBackground();
 
@@ -955,7 +962,7 @@ Schedule::command('users:update-support-roles')
 // V1: cron/check_cgas.php (every 5 minutes) — disabled pending sign-off
 Schedule::command('groups:check-boundaries')
     ->everyFiveMinutes()
-    ->withoutOverlapping()
+    ->withoutOverlapping(15)
     ->sendOutputTo(cronLog('groups:check-boundaries'))
     ->runInBackground();
 
@@ -965,7 +972,7 @@ Schedule::command('groups:check-boundaries')
 // TrashNothing group sync is intentionally not migrated (V1 keyed off TNKEY constant).
 Schedule::command('groups:update-stats')
     ->dailyAt('02:00')
-    ->withoutOverlapping()
+    ->withoutOverlapping(360)
     ->sendOutputTo(cronLog('groups:update-stats'))
     ->runInBackground();
 
@@ -975,14 +982,14 @@ Schedule::command('groups:update-stats')
 // rows on the NEXT day's run (V1 had the same one-day-stale property).
 Schedule::command('stats:generate-daily')
     ->dailyAt('02:30')
-    ->withoutOverlapping()
+    ->withoutOverlapping(360)
     ->sendOutputTo(cronLog('stats:generate-daily'))
     ->runInBackground();
 
 // V1: cron/groups_closed.php
 Schedule::command('groups:remind-closed')
     ->weeklyOn(1, '09:00')
-    ->withoutOverlapping()
+    ->withoutOverlapping(360)
     ->sendOutputTo(cronLog('groups:remind-closed'))
     ->runInBackground();
 
@@ -1007,7 +1014,7 @@ Schedule::command('groups:remind-closed')
 // V1: cron/donations_ads_target.php
 Schedule::command('donations:update-ads-target')
     ->everyMinute()
-    ->withoutOverlapping()
+    ->withoutOverlapping(15)
     ->sendOutputTo(cronLog('donations:update-ads-target'))
     ->runInBackground();
 
@@ -1018,7 +1025,7 @@ Schedule::command('donations:update-ads-target')
 // Update usage counts for AI images (how many posts use each image).
 Schedule::command('ai:usage-counts:update')
     ->hourly()
-    ->withoutOverlapping()
+    ->withoutOverlapping(120)
     ->sendOutputTo(cronLog('ai:usage-counts:update'))
     ->runInBackground();
 
@@ -1032,7 +1039,7 @@ Schedule::command('ai:usage-counts:update')
 // V1: cron/donations_giftaid.php (every 10 minutes)
 Schedule::command('donations:update-giftaid')
     ->everyTenMinutes()
-    ->withoutOverlapping()
+    ->withoutOverlapping(30)
     ->sendOutputTo(cronLog('donations:update-giftaid'))
     ->runInBackground();
 
@@ -1043,7 +1050,7 @@ Schedule::command('donations:update-giftaid')
 // Generate vector embeddings for new messages (for semantic search).
 Schedule::command('embeddings:generate')
     ->everyFiveMinutes()
-    ->withoutOverlapping()
+    ->withoutOverlapping(15)
     ->sendOutputTo(cronLog('embeddings:generate'))
     ->runInBackground();
 
@@ -1053,7 +1060,7 @@ Schedule::command('embeddings:generate')
 // V1: cron/message_unindexed.php (every 30 min)
 Schedule::command('messages:update-index')
     ->everyThirtyMinutes()
-    ->withoutOverlapping()
+    ->withoutOverlapping(60)
     ->sendOutputTo(cronLog('messages:update-index'))
     ->runInBackground();
 // Remove confirmed spammers from groups.
@@ -1100,7 +1107,7 @@ Schedule::command('messages:update-index')
 // now stamps askedtorenew and won't re-ask within a renewal cycle.
 Schedule::command('volunteering:maintain')
     ->dailyAt('22:00')
-    ->withoutOverlapping()
+    ->withoutOverlapping(360)
     ->sendOutputTo(cronLog('volunteering:maintain'))
     ->runInBackground();
 
@@ -1112,7 +1119,7 @@ Schedule::command('volunteering:maintain')
 // disabled there 2026-05-12 when this Laravel command took over).
 Schedule::command('mail:volunteering-digest')
     ->weeklyOn(1, '23:00')  // Monday at 11pm
-    ->withoutOverlapping()
+    ->withoutOverlapping(360)
     ->sendOutputTo(cronLog('mail:volunteering-digest'))
     ->runInBackground();
 
@@ -1126,7 +1133,7 @@ Schedule::command('mail:volunteering-digest')
 // activity-filtered query keeps the working set well below V1's count.
 Schedule::command('mail:events-digest')
     ->weeklyOn(4, '23:00')  // Thursday at 11pm
-    ->withoutOverlapping()
+    ->withoutOverlapping(360)
     ->sendOutputTo(cronLog('mail:events-digest'))
     ->runInBackground();
 
@@ -1134,7 +1141,7 @@ Schedule::command('mail:events-digest')
 // V1: cron/newsfeed_modnotif.php (daily 13:30)
 Schedule::command('mail:newsfeed-mod-notif')
     ->dailyAt('13:30')
-    ->withoutOverlapping()
+    ->withoutOverlapping(360)
     ->sendOutputTo(cronLog('mail:newsfeed-mod-notif'))
     ->runInBackground();
 
@@ -1146,7 +1153,7 @@ Schedule::command('mail:newsfeed-mod-notif')
 // V1: cron/newsfeed_link_previews.php (every 1 minute)
 Schedule::command('newsfeed:generate-link-previews')
     ->everyMinute()
-    ->withoutOverlapping()
+    ->withoutOverlapping(15)
     ->sendOutputTo(cronLog('newsfeed:generate-link-previews'))
     ->runInBackground();
 
@@ -1158,7 +1165,7 @@ Schedule::command('newsfeed:generate-link-previews')
 // V1: cron/noticeboards.php (daily at 15:30)
 Schedule::command('noticeboards:thank-users')
     ->dailyAt('15:30')
-    ->withoutOverlapping()
+    ->withoutOverlapping(360)
     ->sendOutputTo(cronLog('noticeboards:thank-users'))
     ->runInBackground();
 
@@ -1170,7 +1177,7 @@ Schedule::command('noticeboards:thank-users')
 // V1: cron/stories_tocentral.php (weekly, Friday 14:00)
 Schedule::command('stories:send-to-central')
     ->weeklyOn(5, '14:00')
-    ->withoutOverlapping()
+    ->withoutOverlapping(360)
     ->sendOutputTo(cronLog('stories:send-to-central'))
     ->runInBackground();
 
@@ -1178,7 +1185,7 @@ Schedule::command('stories:send-to-central')
 // V1: cron/stories_newsletter.php (monthly, 12th 23:00)
 Schedule::command('stories:newsletter')
     ->monthlyOn(12, '23:00')
-    ->withoutOverlapping()
+    ->withoutOverlapping(360)
     ->sendOutputTo(cronLog('stories:newsletter'))
     ->runInBackground();
 
@@ -1190,7 +1197,7 @@ Schedule::command('stories:newsletter')
 // Sends AI-powered summary of code changes to Discourse.
 Schedule::command('data:git-summary')
     ->weeklyOn(3, '18:00')  // Wednesday at 6pm UTC
-    ->withoutOverlapping()
+    ->withoutOverlapping(360)
     ->sendOutputTo(cronLog('data:git-summary'))
     ->runInBackground();
 
@@ -1204,7 +1211,7 @@ Schedule::command('data:git-summary')
 // V1: cron/chat_review.php (daily)
 Schedule::command('chats:review-pending')
     ->dailyAt('09:00')
-    ->withoutOverlapping()
+    ->withoutOverlapping(360)
     ->sendOutputTo(cronLog('chats:review-pending'))
     ->runInBackground();
 
@@ -1213,7 +1220,7 @@ Schedule::command('chats:review-pending')
 // crontab entry, so it never ran in V1. Migrating to Laravel adds the schedule.
 Schedule::command('groups:alert-no-messages')
     ->dailyAt('07:00')
-    ->withoutOverlapping()
+    ->withoutOverlapping(360)
     ->sendOutputTo(cronLog('groups:alert-no-messages'))
     ->runInBackground();
 
@@ -1221,7 +1228,7 @@ Schedule::command('groups:alert-no-messages')
 // V1: cron/reachvolunteering.php (daily at 21:00)
 Schedule::command('integrations:sync-reachvolunteering')
     ->dailyAt('21:00')
-    ->withoutOverlapping()
+    ->withoutOverlapping(360)
     ->sendOutputTo(cronLog('integrations:sync-reachvolunteering'))
     ->runInBackground();
 
@@ -1230,7 +1237,7 @@ Schedule::command('integrations:sync-reachvolunteering')
 // (upserts) and uses an incremental cursor, so frequent runs are safe.
 Schedule::command('eee:sync-mv-labels')
     ->everyTenMinutes()
-    ->withoutOverlapping()
+    ->withoutOverlapping(30)
     ->sendOutputTo(cronLog('eee:sync-mv-labels'))
     ->runInBackground();
 

--- a/iznik-batch/tests/Feature/Console/SchedulerResilienceTest.php
+++ b/iznik-batch/tests/Feature/Console/SchedulerResilienceTest.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace Tests\Feature\Console;
+
+use App\Console\FlockEventMutex;
+use App\Console\ResilientCacheEventMutex;
+use App\Console\SchedulerMutex;
+use Illuminate\Console\Scheduling\CacheEventMutex;
+use Illuminate\Console\Scheduling\EventMutex;
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Support\Facades\Schedule as ScheduleFacade;
+use Tests\TestCase;
+
+/**
+ * Guards the batch scheduler resilience work (incident 2026-07-02):
+ *
+ *  - Every ->withoutOverlapping() guard is bounded well below Laravel's 24h
+ *    default, so a killed job's mutex self-heals in minutes not a day.
+ *  - The overlap mutex store is selectable: flock by default (unchanged), or a
+ *    cache store (redis) that survives across the per-tick schedule:run processes
+ *    and is independent of the primary DB. See App\Console\SchedulerMutex.
+ */
+class SchedulerResilienceTest extends TestCase
+{
+    /** Reflect the cache store name a CacheEventMutex is pointed at. */
+    private function mutexCacheStore(Schedule $schedule): ?string
+    {
+        $mp = new \ReflectionProperty(Schedule::class, 'eventMutex');
+        $mp->setAccessible(true);
+        $mutex = $mp->getValue($schedule);
+
+        if (! $mutex instanceof CacheEventMutex) {
+            return '(not-a-cache-mutex)';
+        }
+
+        return $mutex->store; // public on CacheEventMutex
+    }
+
+    public function test_default_lock_store_is_flock_and_binds_flock_mutex(): void
+    {
+        // Default env (LOCK_STORE unset) keeps the current behaviour so this change
+        // is a no-op until a human opts in.
+        config(['cache.lock_store' => 'flock']);
+
+        $this->assertTrue(SchedulerMutex::usesFlock());
+        $this->assertNull(SchedulerMutex::cacheStore());
+        $this->assertInstanceOf(FlockEventMutex::class, $this->app->make(EventMutex::class));
+    }
+
+    /**
+     * @dataProvider lockStoreCases
+     */
+    public function test_helper_selects_cache_store_from_config(string $configured, bool $usesFlock, ?string $cacheStore): void
+    {
+        config(['cache.lock_store' => $configured]);
+
+        $this->assertSame($usesFlock, SchedulerMutex::usesFlock());
+        $this->assertSame($cacheStore, SchedulerMutex::cacheStore());
+    }
+
+    public static function lockStoreCases(): array
+    {
+        return [
+            'flock (default)'          => ['flock', true, null],
+            'empty is flock'           => ['', true, null],
+            'redis'                    => ['redis', false, 'redis'],
+            'database'                 => ['database', false, 'database'],
+            'mixed case is normalized' => ['Redis', false, 'redis'],
+            'unknown store -> flock'   => ['reddis-typo', true, null],
+        ];
+    }
+
+    public function test_resilient_cache_mutex_fails_open_when_store_unavailable(): void
+    {
+        // A store outage must NOT propagate out of the withoutOverlapping filter and
+        // abort the whole schedule:run tick — it must fail open so jobs still run.
+        $mutex = new ResilientCacheEventMutex($this->app->make('cache'));
+        $mutex->useStore('nonexistent-store-xyz'); // parent create()/exists() will throw
+
+        $schedule = new Schedule();
+        $event = $schedule->command('test:overlap-probe')->everyMinute()->withoutOverlapping(5);
+
+        $this->assertTrue($mutex->create($event), 'create() must fail open (true) when the store is unavailable');
+        $this->assertFalse($mutex->exists($event), 'exists() must fail open (false) when the store is unavailable');
+        $mutex->forget($event); // must not throw
+        $this->assertTrue(true, 'forget() swallowed the store error');
+    }
+
+    public function test_apply_points_cache_event_mutex_at_configured_store(): void
+    {
+        // Force the cache-backed mutex (as when LOCK_STORE != flock leaves it unbound).
+        $this->app->instance(EventMutex::class, new CacheEventMutex($this->app->make('cache')));
+
+        config(['cache.lock_store' => 'array']);
+        $schedule = new Schedule();
+        SchedulerMutex::apply($schedule);
+
+        $this->assertSame('array', $this->mutexCacheStore($schedule));
+    }
+
+    public function test_apply_is_a_noop_under_flock(): void
+    {
+        $this->app->instance(EventMutex::class, new CacheEventMutex($this->app->make('cache')));
+
+        config(['cache.lock_store' => 'flock']);
+        $schedule = new Schedule();
+        SchedulerMutex::apply($schedule);
+
+        // useCache was never called, so the mutex keeps the default (null) store.
+        $this->assertNull($this->mutexCacheStore($schedule));
+    }
+
+    public function test_all_scheduled_overlap_guards_are_bounded(): void
+    {
+        // Load the real schedule (routes/console.php) onto a fresh instance.
+        $schedule = new Schedule();
+        ScheduleFacade::swap($schedule);
+        require base_path('routes/console.php');
+
+        $events = $schedule->events();
+        $this->assertNotEmpty($events, 'routes/console.php failed to register any scheduled events');
+
+        $guarded = 0;
+        foreach ($events as $event) {
+            if (! $event->withoutOverlapping) {
+                continue;
+            }
+            $guarded++;
+            $label = $event->command ?? $event->description ?? 'unknown';
+            $this->assertGreaterThan(
+                0,
+                $event->expiresAt,
+                "Overlap expiry for [{$label}] must be positive"
+            );
+            $this->assertLessThan(
+                1440,
+                $event->expiresAt,
+                "Overlap expiry for [{$label}] must be bounded below Laravel's 24h (1440min) default so a killed job self-heals quickly"
+            );
+        }
+
+        // The scheduler has many overlap-guarded jobs; guard against the test
+        // silently passing because nothing loaded.
+        $this->assertGreaterThan(50, $guarded, 'expected many overlap-guarded scheduled jobs');
+    }
+}


### PR DESCRIPTION
## Batch scheduler resilience (follow-up to the 2026-07-02 DB-stall incident)

On 2026-07-02 a Galera node went Donor/Desynced and stalled cluster-wide commits
for ~85 min. Batch scheduled jobs hung on the dead DB and piled up (`mail:digest`
launched 1058× in ~1h45m), contributing to host OOM/swap-thrash. This is the
scheduler-resilience follow-up (not the DB incident itself, which is recovered).

### What I found (the incident brief's premise was out of date)

The brief assumed `withoutOverlapping()` mutexes live in the MySQL `cache_locks`
table (the stalling DB). They don't. Since 2026-01-07 `App\Console\FlockEventMutex`
is bound as the scheduler `EventMutex` (gated by `config('cache.lock_store')`,
default `flock`), so overlap mutexes use OS **flock**.

But **flock gives no real overlap protection for our jobs**, because:

- every scheduled job uses `->runInBackground()`, and prod runs `schedule:work`
  (a fresh `schedule:run` subprocess per tick);
- flock is released the moment the acquiring process exits — i.e. seconds after a
  job is *spawned*, not when it *finishes*.

Verified empirically: P1 acquires the flock and exits; P2 (next tick) re-acquires
immediately. So when a job hangs (e.g. a DB stall) far longer than its cadence, the
scheduler spawns a fresh copy every tick → pileup. That is the mechanism behind the
incident.

### The fix

1. **Bounded overlap expiries** — every bare `->withoutOverlapping()` in
   `routes/console.php` now has an explicit expiry, tiered by cadence (15 min for
   ≤5-min jobs … 360 min for daily/weekly/monthly), all far below Laravel's 24h
   default, so a killed job's mutex self-heals in minutes. `mail:digest:unified
   --mode=daily` is pinned to 300 (its 07:00–12:00 window relies on overlap to
   avoid duplicate multi-hour sends). Pre-existing `whatjobs(240)` untouched;
   commented-out example schedules untouched.

2. **Selectable, DB-independent mutex store** (`App\Console\SchedulerMutex`) —
   with `LOCK_STORE=redis` the scheduler uses a cache mutex on redis instead of
   flock. A redis TTL lock **persists across the per-tick `schedule:run` processes**
   (verified: P2 create → false while P1's is live), so overlap is genuinely
   prevented for background jobs, and it is independent of the primary DB that
   stalled. The bounded expiries above cap the TTL, so the 24h-stale-lock concern
   that originally motivated flock no longer applies.

**Default is unchanged (`LOCK_STORE=flock`) → this PR is a no-op at runtime until a
human sets `LOCK_STORE=redis` in the batch environment.** Recommended prod action:
set `LOCK_STORE=redis` (batch already has `REDIS_HOST=redis`, healthy).

### Hardening (from an adversarial review of the redis path)

Two ways the redis path could have been *worse* than flock — both fixed and tested:

- **Mis-cased / typo `LOCK_STORE`** (e.g. `Redis`, `reddis`) previously would have
  made every overlap check throw "Cache store not defined" and stop the whole
  scheduler. `SchedulerMutex` now normalises (trim+lowercase) and validates the
  value against `config('cache.stores')`; an unknown value falls back to flock with
  a logged warning.
- **Redis briefly unreachable** would have thrown out of the `withoutOverlapping`
  `skip()` filter — which runs *outside* `ScheduleRunCommand`'s try/catch — aborting
  the entire `schedule:run` tick and starving every job after the first guarded one.
  `App\Console\ResilientCacheEventMutex` now **fails open** (logs + lets the job run)
  on any store error. Verified: with redis pointed at a dead port, the tick that
  previously exited 1 at `messages:contentcheck` now runs to completion (exit 0).

### Known bound (not a regression)

- A TTL mutex *bounds* rather than *eliminates* pileup: a stall longer than a job's
  expiry lets its lock expire mid-run and a second copy start — capped by
  TTL/cadence (e.g. ~4/hour for a 15-min-bucket everyMinute job) vs the unbounded
  every-tick pileup flock allowed.

### Out of scope (noted follow-ups)

- The `mail:digest`/chat/welcome jobs use a *separate* in-command flock
  (`PreventsOverlapping` trait) and don't call `->withoutOverlapping()`. Adding
  scheduler-level `withoutOverlapping` (now that the redis mutex works) would stop
  their spawn-pileup too — deliberately left for a focused follow-up.
- Command max-runtime / DB statement timeouts so a hung job dies fast (brief item
  #3) — larger, separate.

### Related (already on master, not in this PR)

- The `isochrone/message.go:153` "converting NULL to string" log flood is already
  fixed on `master` (COALESCE at both `effectiveBrowseView`/`resolveMaxDistance`
  settings reads); production just needs the deploy. No code change needed here.

### Tests

`tests/Feature/Console/SchedulerResilienceTest.php`: every scheduled overlap guard
is bounded below 1440 min; the mutex store is selected/normalised correctly from
`cache.lock_store` (incl. mixed-case and unknown-store→flock fallback) and applied
to the cache mutex; the default binding stays `FlockEventMutex`; the resilient cache
mutex fails open when its store is unavailable. Full Laravel suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
