### PR TITLE
fix(rippling): dedupe posting-history list by origin group

### DIFF
--- a/iznik-server-go/test/user_test.go
+++ b/iznik-server-go/test/user_test.go
@@ -4523,6 +4523,62 @@ func TestMessageHistory_NoDuplicatesOnRepost(t *testing.T) {
 		"exactly one messagehistory entry per (msgID, groupID) regardless of repost count")
 }
 
+// TestMessageHistory_NoDuplicatesOnRipple: a post rippled OUT to other groups gets
+// an extra messages_groups row (rippled_in=1) per receiving group. The posting
+// history must count the origin only, so a widely-rippled post appears ONCE - not
+// once per group (Discourse #9851 / the 23x Posting History for a bulk offer).
+func TestMessageHistory_NoDuplicatesOnRipple(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("mh_ripple")
+
+	userID := CreateTestUser(t, prefix, "User")
+	originGroup := CreateTestGroup(t, prefix)
+	rippledGroup := CreateTestGroup(t, prefix+"r")
+
+	msgID := CreateTestMessage(t, userID, originGroup, prefix+" Table", 55.9533, -3.1883)
+
+	// Rippling-out: an Approved messages_groups row (rippled_in=1) on a receiving group.
+	db.Exec("INSERT INTO messages_groups (msgid, groupid, arrival, collection, deleted, rippled_in) VALUES (?, ?, NOW(), 'Approved', 0, 1)", msgID, rippledGroup)
+	t.Cleanup(func() {
+		db.Exec("DELETE FROM messages_groups WHERE msgid = ? AND groupid = ?", msgID, rippledGroup)
+	})
+
+	history := user2.GetUserMessageHistory(userID)
+
+	var count int
+	for _, h := range history {
+		if h.ID == msgID {
+			count++
+		}
+	}
+
+	assert.Equal(t, 1, count,
+		"a post rippled to another group appears once in posting history, not per group")
+}
+
+// TestUserInfo_OfferCountNotInflatedByRipple guards the COUNT(DISTINCT) fix in
+// GetUserInfo: a post rippled to N groups counts as ONE offer, not N (Discourse
+// #9851 - offer/wanted numbers showing incorrectly on chitchat).
+func TestUserInfo_OfferCountNotInflatedByRipple(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("info_ripple")
+
+	userID := CreateTestUser(t, prefix, "User")
+	originGroup := CreateTestGroup(t, prefix)
+	rippledGroup := CreateTestGroup(t, prefix+"r")
+
+	msgID := CreateTestMessage(t, userID, originGroup, prefix+" Chair", 55.9533, -3.1883)
+
+	db.Exec("INSERT INTO messages_groups (msgid, groupid, arrival, collection, deleted, rippled_in) VALUES (?, ?, NOW(), 'Approved', 0, 1)", msgID, rippledGroup)
+	t.Cleanup(func() {
+		db.Exec("DELETE FROM messages_groups WHERE msgid = ? AND groupid = ?", msgID, rippledGroup)
+	})
+
+	info := user2.GetUserInfo(userID, 0)
+	assert.Equal(t, uint64(1), info.Offers,
+		"a post rippled to another group counts as one offer, not per group")
+}
+
 // TestGetUserMessageHistory_WithdrawnPendingAppearsInSummary covers Discourse #9783/7.
 //
 // "Strange case": a post is in Pending state (collection='Pending', mg.deleted=0,

--- a/iznik-server-go/user/user.go
+++ b/iznik-server-go/user/user.go
@@ -491,7 +491,13 @@ func GetUserMessageHistory(userid uint64) []UserMessageHistory {
 		"(SELECT outcome FROM messages_outcomes WHERE messages_outcomes.msgid = m.id ORDER BY timestamp DESC LIMIT 1) AS outcome "+
 		"FROM messages m "+
 		"INNER JOIN messages_groups mg ON m.id = mg.msgid "+
-		"WHERE m.fromuser = ? AND mg.deleted = 0 AND m.deleted IS NULL AND mg.collection IN (?, ?) "+
+		// rippled_in = 0: a post rippled OUT gets an extra messages_groups row
+		// (rippled_in = 1) per receiving group. Without this filter the join fans
+		// out to one history entry per group, so a post reaching N groups showed
+		// N identical rows (Discourse #9851 / the 23x Posting History). Restricting
+		// to origin rows shows the post once (still per group for genuine
+		// cross-posts, matching pre-rippling behaviour).
+		"WHERE m.fromuser = ? AND mg.deleted = 0 AND mg.rippled_in = 0 AND m.deleted IS NULL AND mg.collection IN (?, ?) "+
 		"ORDER BY arrival DESC", userid, utils.COLLECTION_APPROVED, utils.COLLECTION_PENDING).Scan(&history)
 
 	now := time.Now()


### PR DESCRIPTION
The ModTools Posting History showed a rippled post once per group — a bulk offer rippled to 23 groups appeared **23 identical rows** (see the screenshot in the Discourse thread).

## Cause
A post rippled out to N groups gets one extra `messages_groups` row (`rippled_in=1`) per receiving group. `GetUserMessageHistory` (`user/user.go`) joins `messages → messages_groups` without excluding those rows, so it returns one history entry per group.

## Fix
Restrict the join to origin rows (`mg.rippled_in = 0`) — the same pattern already used across the codebase (`message.go`, `session.go`, `message_list.go`, `groupWork.go`, `rippling/metrics.go`). The post now shows **once** (still once per group for genuine cross-posts, matching pre-rippling behaviour).

The sibling offer/wanted **count** (`GetUserInfo`) was already fixed to `COUNT(DISTINCT messages.id)` at an earlier commit; this PR adds a regression test guarding it too.

## Tests
- `TestMessageHistory_NoDuplicatesOnRipple` — a post with a rippled-in copy appears once in the history.
- `TestUserInfo_OfferCountNotInflatedByRipple` — a rippled post counts as one offer.

Discourse: https://discourse.ilovefreegle.org/t/offers-wanted-numbers-showing-incorrectly-on-chitchat/9851

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUZmYaNfGvSrFe3CmpLxuL