### PR TITLE
fix(chat): hide rippling-held replies from the recipient's chat-list count & preview

### DIFF
--- a/iznik-nuxt3/package-lock.json
+++ b/iznik-nuxt3/package-lock.json
@@ -27350,9 +27350,9 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
     },
     "node_modules/srvx": {
-      "version": "0.11.18",
-      "resolved": "https://registry.npmjs.org/srvx/-/srvx-0.11.18.tgz",
-      "integrity": "sha512-7/EW5sPdC1bU7iq1tgTvCZqUQDkJdsqIVzYqBv7SuBfQQ10oWkKj4KYNOw0H4Ig26bXuUYDA7XTKxB+/HC5SRw==",
+      "version": "0.11.20",
+      "resolved": "https://registry.npmjs.org/srvx/-/srvx-0.11.20.tgz",
+      "integrity": "sha512-gdPvbwpJOJpMyBYcp39q78C4pmv/Aw5WwZKB3+/pfeUVxo3EvNXlOi1fxzoy2ECGvUeBhouXy9rBxstjQQOPog==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/iznik-server-go/chat/chatroom.go
+++ b/iznik-server-go/chat/chatroom.go
@@ -1093,7 +1093,10 @@ func listChats(myid uint64, chattypes []string, start string, search string, onl
 				"CASE WHEN JSON_EXTRACT(u2.settings, '$.useprofile') IS NULL THEN 1 ELSE JSON_EXTRACT(u2.settings, '$.useprofile') END AS u2useprofile, " +
 				"(SELECT COUNT(*) AS count FROM chat_messages WHERE id > " +
 				"  COALESCE((SELECT lastmsgseen FROM chat_roster c1 WHERE chatid = chat_rooms.id AND userid = ? " +
-				"  " + statusq + "), 0) AND chatid = chat_rooms.id AND userid != ? AND chat_messages.date >= ? AND (reviewrequired = 0 AND reviewrejected = 0 AND processingsuccessful = 1)) AS unseen, " +
+				// Rippling held-reply gate: a reply held because the post hasn't yet rippled to the
+				// replier's area (rippling_held_replies, status <> 'released') must not inflate the
+				// poster's unseen badge — mirrors the FetchChatMessages delivery gate. Param-free.
+				"  " + statusq + "), 0) AND chatid = chat_rooms.id AND userid != ? AND chat_messages.date >= ? AND (reviewrequired = 0 AND reviewrejected = 0 AND processingsuccessful = 1) AND NOT EXISTS (SELECT 1 FROM rippling_held_replies rhr WHERE rhr.chatmsgid = chat_messages.id AND rhr.status <> 'released')) AS unseen, " +
 				"(SELECT COUNT(*) AS count FROM chat_messages WHERE chatid = chat_rooms.id AND replyexpected = 1 AND" +
 				"  replyreceived = 0 AND userid != ? AND chat_messages.date >= ? AND chat_rooms.chattype = ? AND processingsuccessful = 1) AS replyexpected, " +
 				"i1.id AS u1imageid, " +
@@ -1122,11 +1125,14 @@ func listChats(myid uint64, chattypes []string, start string, search string, onl
 				"LEFT JOIN users_images i2 ON i2.id = (SELECT id FROM users_images WHERE userid = u2.id ORDER BY id DESC LIMIT 1) " +
 				"LEFT JOIN groups_images i3 ON i3.id = (SELECT id FROM groups_images WHERE groupid = chat_rooms.groupid ORDER BY id DESC LIMIT 1) " +
 				"LEFT JOIN chat_messages ON chat_messages.id = " +
-				"  (SELECT id FROM chat_messages WHERE chat_messages.chatid = chat_rooms.id AND reviewrequired = 0 AND reviewrejected = 0 AND (processingsuccessful = 1 OR chat_messages.userid = ?) ORDER BY chat_messages.id DESC LIMIT 1) " +
+				"  (SELECT id FROM chat_messages WHERE chat_messages.chatid = chat_rooms.id AND reviewrequired = 0 AND reviewrejected = 0 AND (processingsuccessful = 1 OR chat_messages.userid = ?) AND NOT EXISTS (SELECT 1 FROM rippling_held_replies rhr WHERE rhr.chatmsgid = chat_messages.id AND rhr.status <> 'released') ORDER BY chat_messages.id DESC LIMIT 1) " +
 				"LEFT JOIN messages ON messages.id = chat_messages.refmsgid " +
 				"LEFT JOIN (WITH cm AS (SELECT chat_messages.id AS lastmsg, chat_messages.chatid, chat_messages.message AS chatmsg," +
 				" chat_messages.date AS lastdate, chat_messages.type AS chatmsgtype, ROW_NUMBER() OVER (PARTITION BY chatid ORDER BY id DESC) AS rn " +
-				" FROM chat_messages WHERE chatid IN " + idlist + " AND (reviewrequired = 0 AND reviewrejected = 0 AND (processingsuccessful = 1 OR chat_messages.userid = ?) OR userid = ?)) " +
+				// Rippling held-reply gate inside the deliverable branch: a held reply must not be the
+				// poster's snippet/preview. The trailing `OR userid = ?` still lets the sender see their
+				// own message, matching FetchChatMessages. Param-free (correlates on chat_messages.id).
+				" FROM chat_messages WHERE chatid IN " + idlist + " AND (reviewrequired = 0 AND reviewrejected = 0 AND (processingsuccessful = 1 OR chat_messages.userid = ?) AND NOT EXISTS (SELECT 1 FROM rippling_held_replies rhr WHERE rhr.chatmsgid = chat_messages.id AND rhr.status <> 'released') OR userid = ?)) " +
 				"  SELECT * FROM cm WHERE rn = 1) rcm ON rcm.chatid = chat_rooms.id " +
 				"WHERE chat_rooms.id IN " + idlist
 
@@ -1491,7 +1497,8 @@ func handleRosterUpdate(c *fiber.Ctx, db *gorm.DB, myid uint64, req ChatRoomPost
 		WHERE chatid = ? AND userid != ?
 		AND id > COALESCE((SELECT lastmsgseen FROM chat_roster WHERE chatid = ? AND userid = ?), 0)
 		AND chat_messages.date >= ?
-		AND reviewrequired = 0 AND reviewrejected = 0 AND processingsuccessful = 1`,
+		AND reviewrequired = 0 AND reviewrejected = 0 AND processingsuccessful = 1
+		AND NOT EXISTS (SELECT 1 FROM rippling_held_replies rhr WHERE rhr.chatmsgid = chat_messages.id AND rhr.status <> 'released')`,
 		req.ID, myid, req.ID, myid, activeSince).Scan(&unseen)
 
 	if roster == nil {

--- a/iznik-server-go/test/chatlist_rippling_held_test.go
+++ b/iznik-server-go/test/chatlist_rippling_held_test.go
@@ -1,0 +1,105 @@
+package test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/freegle/iznik-server-go/chat"
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestListChats_HeldReplyNotCountedOrPreviewed verifies that a rippling-held reply
+// (rippling_held_replies, status='held') is invisible to the RECIPIENT (the poster) in the
+// chat LIST: it must not inflate the room's unseen count and must not appear as the room's
+// snippet/preview. The message-list fetch (FetchChatMessages) already hides held replies from
+// the poster; the sibling count/snippet queries in listChats did not, so the poster saw an
+// unread badge and preview text for a reply they are not yet allowed to see. Releasing the
+// hold (status='released') reveals it in both surfaces, matching normal delivery.
+func TestListChats_HeldReplyNotCountedOrPreviewed(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("listheld")
+
+	// rippling_held_replies ships with the reach engine; stand it up so this test is self-sufficient.
+	db.Exec(`CREATE TABLE IF NOT EXISTS rippling_held_replies (
+		id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+		chatid BIGINT UNSIGNED NOT NULL,
+		chatmsgid BIGINT UNSIGNED NOT NULL,
+		msgid BIGINT UNSIGNED NOT NULL,
+		replieruserid BIGINT UNSIGNED NOT NULL,
+		lat DOUBLE, lng DOUBLE,
+		status ENUM('held','released','dropped','taken-gone') NOT NULL DEFAULT 'held',
+		created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		releasedat TIMESTAMP NULL,
+		INDEX (msgid), INDEX (chatid), INDEX (status)
+	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`)
+
+	groupID := CreateTestGroup(t, prefix)
+	posterID := CreateTestUser(t, prefix+"_poster", "User")
+	replierID := CreateTestUser(t, prefix+"_replier", "User")
+	CreateTestMembership(t, posterID, groupID, "Member")
+	CreateTestMembership(t, replierID, groupID, "Member")
+
+	// The original post being replied to (FK target for rippling_held_replies.msgid).
+	postMsgID := CreateTestMessage(t, posterID, groupID, "OFFER: held reply list test", 51.5, -0.1)
+
+	// Replier initiated the chat with the poster; user1=replier, user2=poster (the recipient).
+	chatID := CreateTestChatRoom(t, replierID, &posterID, nil, "User2User")
+
+	// A fully-processed reply FROM the replier (reviewrequired=0, processingsuccessful=1) — it
+	// passes the normal "deliverable" predicate, so only the rippling gate can hide it.
+	const replyText = "I would love this please, can I collect?"
+	db.Exec(
+		"INSERT INTO chat_messages (chatid, userid, message, type, date, refmsgid, "+
+			"reviewrequired, reviewrejected, processingrequired, processingsuccessful) "+
+			"VALUES (?, ?, ?, 'Default', NOW(), ?, 0, 0, 0, 1)",
+		chatID, replierID, replyText, postMsgID,
+	)
+	var replyMsgID uint64
+	db.Raw("SELECT id FROM chat_messages WHERE chatid = ? ORDER BY id DESC LIMIT 1", chatID).Scan(&replyMsgID)
+	if replyMsgID == 0 {
+		t.Fatal("failed to create the reply chat message")
+	}
+
+	// Hold the reply — the replier is outside the post's current reach.
+	db.Exec("INSERT INTO rippling_held_replies (chatid, chatmsgid, msgid, replieruserid, status) "+
+		"VALUES (?, ?, ?, ?, 'held')", chatID, replyMsgID, postMsgID, replierID)
+	defer db.Exec("DELETE FROM rippling_held_replies WHERE chatmsgid = ?", replyMsgID)
+	defer db.Exec("DELETE FROM chat_messages WHERE id = ?", replyMsgID)
+
+	_, posterToken := CreateTestSession(t, posterID)
+
+	// Fetch the poster's chat list and return this room's unseen count + snippet.
+	roomState := func() (uint64, string) {
+		req := httptest.NewRequest("GET", fmt.Sprintf("/api/chat?includeClosed=true&chattypes[]=User2User&jwt=%s", posterToken), nil)
+		resp, err := getApp().Test(req, -1)
+		if err != nil {
+			t.Fatalf("chat list request failed: %v", err)
+		}
+		assert.Equal(t, 200, resp.StatusCode)
+		var rooms []chat.ChatRoomListEntry
+		if err := json.Unmarshal(rsp(resp), &rooms); err != nil {
+			t.Fatalf("failed to decode chat list: %v", err)
+		}
+		for _, r := range rooms {
+			if r.ID == chatID {
+				return r.Unseen, r.Snippet
+			}
+		}
+		t.Fatalf("chat room %d not found in poster's list", chatID)
+		return 0, ""
+	}
+
+	// While held: the poster must NOT see the reply as unread, nor as the room preview.
+	unseen, snippet := roomState()
+	assert.Equal(t, uint64(0), unseen, "held reply must not count towards the poster's unseen badge")
+	assert.NotContains(t, snippet, replyText, "held reply text must not appear as the room snippet for the poster")
+
+	// Releasing the hold makes the reply deliverable — it now counts and previews normally.
+	db.Exec("UPDATE rippling_held_replies SET status = 'released', releasedat = NOW() WHERE chatmsgid = ?", replyMsgID)
+	unseen, snippet = roomState()
+	assert.Equal(t, uint64(1), unseen, "released reply must count towards the poster's unseen badge")
+	assert.Contains(t, snippet, replyText, "released reply must appear as the room snippet for the poster")
+}


### PR DESCRIPTION
## Problem

When a chat reply is **held** because it's out of the post's rippling reach (e.g. an email/TrashNothing reply from outside the post's `rippling_reach`), it should be invisible to the recipient (the poster) until the post's reach catches up. It wasn't fully invisible.

The rippling reply-hold is enforced by a *delivery gate* — `NOT EXISTS (rippling_held_replies … status <> 'released')` — deliberately **not** via `chat_messages.reviewrequired` (that bit is shared with the spam/mod hold, so reusing it would pollute the mod queue and risk auto-rejection). That gate was wired into:

- ✅ the message list — `FetchChatMessages` (`chatmessage.go`)
- ✅ poster email — `ChatNotificationService`
- ✅ push — `PushNotificationService`

…but **not** into the sibling count/snippet queries in the chat-list ("beast") query. So a held reply still:

- ❌ inflated the room's **unseen** badge (per-room, and the summed header badge the app computes from `chat.unseen`)
- ❌ appeared as the room's **snippet / preview** text
- ❌ the single-room unseen recount on roster update (`handleRosterUpdate`) had the same gap

This is exactly the leak that `reviewrequired`-held (spam/mod) messages are already immune to — those queries filter `reviewrequired = 0` — but the rippling hold doesn't set `reviewrequired`, so it slipped past.

## Fix (Go v2 only — v1 PHP API is retired)

Add the identical, param-free rippling delivery gate to the recipient-facing count/snippet queries in `iznik-server-go/chat/chatroom.go`:

1. `listChats` **unseen** subquery
2. `listChats` snippet — the latest-message join (drives `refmsgtype`) **and** the `rcm` CTE (the preview text); the CTE keeps the sender's own message visible via the existing trailing `OR userid = ?`, matching `FetchChatMessages`
3. `handleRosterUpdate` single-room unseen recount

The gate correlates on `chat_messages.id` and uses a literal status, so it adds **no** query parameters — the existing arg lists are unchanged.

## Not affected (verified)

- **Email** (`ChatNotificationService`) and **push** (`PushNotificationService`) already apply the gate.
- **Mod work counts** count only `reviewrequired = 1`, which held replies never are — correct by design.
- **Chaseup-expected email** / room-list **replyexpected** count can't leak: a held email reply never gets `replyexpected = 1` (that's only set by nudges and the client PATCH).

## Test

`TestListChats_HeldReplyNotCountedOrPreviewed` — a fully-processed held reply from the replier is **not** counted as unseen and **not** shown as the snippet for the poster; releasing the hold reveals it in both surfaces (positive control).

TDD: the test failed before the fix (`unseen=1`, snippet contained the held text) and passes after. **Full Go suite: 3365 passed, 0 failed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)