### PR TITLE
fix(outreach): concierge poller skips auto-replies/OOO and bounces, not just unsubscribes

### DIFF
--- a/iznik-batch/app/Console/Commands/BulkOffer/PollGmailOutreachCommand.php
+++ b/iznik-batch/app/Console/Commands/BulkOffer/PollGmailOutreachCommand.php
@@ -16,13 +16,68 @@ use Illuminate\Support\Facades\Log;
  * For each unread inbox thread that matches a Sent outreach row (by gmail_thread_id):
  *  - an unsubscribe (sent to the +unsub address, or body/subject says UNSUBSCRIBE)
  *    sets suppressed_until far in the future and marks the row Declined (PECR);
+ *  - a delivery-failure bounce (mailer-daemon/postmaster, a DSN subject, or a
+ *    multipart/report + message/delivery-status MIME part) marks the row Bounced
+ *    and suppresses it far in the future, so a dead address is never re-contacted;
+ *  - an auto-reply / out-of-office / auto-acknowledgement (RFC 3834
+ *    Auto-Submitted header, Precedence: bulk/auto_reply/junk, X-Autoreply /
+ *    X-Autorespond, or the usual OOO subject/body patterns) marks the row
+ *    AutoAck - it is NOT a genuine human reply, so it is not emitted to the FSM;
  *  - any other reply marks the row Replied and is emitted (as JSON) for the FSM;
- *  - the thread's messages are marked read so they are not re-emitted next poll.
+ *  - the thread's messages are marked read so they are not re-emitted next poll,
+ *    regardless of which of the above applies.
  *
  * Emits a JSON array of reply threads to stdout so the gmail FSM driver can act.
  */
 class PollGmailOutreachCommand extends Command
 {
+    /**
+     * Subject substrings that indicate an auto-reply / OOO / auto-acknowledgement.
+     * Mirrors App\Services\Mail\Incoming\ParsedEmail::isAutoReply() - kept as a
+     * small, deliberate duplication here rather than reworking ParsedEmail (which
+     * parses raw MIME, not the Gmail API thread/message JSON this command reads).
+     */
+    private const AUTO_REPLY_SUBJECT_PATTERNS = [
+        'Auto Response', 'Autoresponder', 'If your enquiry is urgent',
+        'Thankyou for your enquiry', 'Thanks for your email',
+        'Thanks for contacting', 'Thank you for your enquiry',
+        'Many thanks for your', 'Automatic reply', 'Automated reply',
+        'Auto-Reply', 'Out of Office', 'maternity leave', 'paternity leave',
+        'return to the office', 'due to return', 'annual leave',
+        'on holiday', 'vacation reply', 'YOUR ORDER MANAGEMENT REQUEST',
+    ];
+
+    /** Body substrings that indicate an auto-reply / OOO / auto-acknowledgement. */
+    private const AUTO_REPLY_BODY_PATTERNS = [
+        'I aim to respond within', 'Our team aims to respond',
+        'reply as soon as possible', 'with clients right now',
+        'Automated response', 'Please note his new address',
+        'THIS IS AN AUTO-RESPONSE MESSAGE', 'out of the office',
+        'on annual leave', 'Thank you so much for your email enquiry',
+        "Thanks for your email enquiry", "don't check this very often",
+        'below to complete the verification process',
+        'We respond to emails as quickly as we can',
+        'this email address is no longer in use', 'away from the office',
+        "I won't be able to check any emails until after",
+        "I'm on leave at the moment",
+        "We'll get back to you as soon as possible",
+        'currently on leave', 'To complete this verification',
+        'I am currently away from my computer, but will reply to your message as soon as I return',
+        "E-mails to personal mailboxes aren't monitored",
+        'I am currently unavailable',
+        'We appreciate your patience while we get back to you.',
+    ];
+
+    /**
+     * Subject substrings that indicate a delivery-failure bounce/DSN. Mirrors (a
+     * subset of) App\Services\Mail\Incoming\MailParserService::isBounceSubject(),
+     * per the same "small duplication over cross-service coupling" rationale.
+     */
+    private const BOUNCE_SUBJECT_PATTERNS = [
+        'Delivery Status Notification', 'Undelivered', 'Mail delivery failed',
+        'failure notice', 'Returned mail', 'Address not found',
+    ];
+
     protected $signature = 'bulkoffer:poll-outreach
                             {--msgid= : Only poll replies for this bulk offer}
                             {--query=in:inbox is:unread newer_than:60d : Gmail search for candidate threads}';
@@ -77,7 +132,8 @@ class PollGmailOutreachCommand extends Command
                 continue;
             }
 
-            // Mark every message in the thread read so it isn't re-emitted.
+            // Mark every message in the thread read so it isn't re-emitted, no
+            // matter how it classifies below.
             foreach (($thread['messages'] ?? []) as $m) {
                 if (! empty($m['id'])) {
                     try {
@@ -88,6 +144,8 @@ class PollGmailOutreachCommand extends Command
                 }
             }
 
+            $headers = $latest['headers'] ?? [];
+
             if ($this->isUnsubscribe($latest, $unsubAddress)) {
                 DB::table('messages_bulk_outreach')->where('id', $row->id)->update([
                     'status' => MessagesBulkOutreach::STATUS_DECLINED,
@@ -96,6 +154,27 @@ class PollGmailOutreachCommand extends Command
                     'updated_at' => now(),
                 ]);
                 $this->info("Outreach #{$row->id}: unsubscribe recorded, suppressed.");
+
+                continue;
+            }
+
+            if ($this->isBounce($latest, $headers)) {
+                DB::table('messages_bulk_outreach')->where('id', $row->id)->update([
+                    'status' => MessagesBulkOutreach::STATUS_BOUNCED,
+                    'suppressed_until' => now()->addYears(100)->toDateString(),
+                    'updated_at' => now(),
+                ]);
+                $this->info("Outreach #{$row->id}: delivery-failure bounce, suppressed.");
+
+                continue;
+            }
+
+            if ($this->isAutoReply($latest, $headers)) {
+                DB::table('messages_bulk_outreach')->where('id', $row->id)->update([
+                    'status' => MessagesBulkOutreach::STATUS_AUTO_ACK,
+                    'updated_at' => now(),
+                ]);
+                $this->info("Outreach #{$row->id}: auto-reply/OOO detected, not a genuine reply.");
 
                 continue;
             }
@@ -123,9 +202,10 @@ class PollGmailOutreachCommand extends Command
 
     /**
      * The most recent message in the thread that wasn't sent by us (an inbound
-     * reply), reduced to {from, subject, body, to}.
+     * reply), reduced to {from, to, subject, body} plus the handful of raw
+     * headers/MIME signals the auto-reply and bounce classifiers need.
      *
-     * @return array<string,string>|null
+     * @return array<string,mixed>|null
      */
     private function latestInbound(array $thread): ?array
     {
@@ -143,6 +223,17 @@ class PollGmailOutreachCommand extends Command
                 'to' => $headers['to'] ?? '',
                 'subject' => $headers['subject'] ?? '',
                 'body' => $this->plainBody($m['payload'] ?? []),
+                'is_delivery_report' => $this->isDeliveryReportMime($m['payload'] ?? []),
+                // Raw headers the isAutoReply()/isBounce() classifiers key off,
+                // kept alongside (not instead of) the flattened fields above.
+                'headers' => [
+                    'auto-submitted' => $headers['auto-submitted'] ?? '',
+                    'precedence' => $headers['precedence'] ?? '',
+                    'x-autoreply' => $headers['x-autoreply'] ?? '',
+                    'x-autorespond' => $headers['x-autorespond'] ?? '',
+                    'return-path' => $headers['return-path'] ?? '',
+                    'list-id' => $headers['list-id'] ?? '',
+                ],
             ];
         }
 
@@ -183,6 +274,27 @@ class PollGmailOutreachCommand extends Command
         return '';
     }
 
+    /**
+     * Does this (possibly multipart) Gmail payload carry a delivery-status
+     * report part (multipart/report + message/delivery-status), the MIME shape
+     * of an RFC 3464 bounce/DSN? Mirrors the MIME check in
+     * App\Services\Mail\Incoming\MailParserService::extractBounceInfo().
+     */
+    private function isDeliveryReportMime(array $payload): bool
+    {
+        $mime = strtolower((string) ($payload['mimeType'] ?? ''));
+        if ($mime === 'multipart/report' || $mime === 'message/delivery-status') {
+            return true;
+        }
+        foreach (($payload['parts'] ?? []) as $part) {
+            if ($this->isDeliveryReportMime($part)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     private function decode(string $data): string
     {
         return (string) base64_decode(strtr($data, '-_', '+/'));
@@ -197,5 +309,69 @@ class PollGmailOutreachCommand extends Command
         $haystack = strtolower(($latest['subject'] ?? '').' '.($latest['body'] ?? ''));
 
         return str_contains($haystack, 'unsubscribe') || preg_match('/\bstop\b/', $haystack) === 1;
+    }
+
+    /**
+     * Is this an auto-reply / out-of-office / auto-acknowledgement rather than a
+     * genuine human reply? Mirrors
+     * App\Services\Mail\Incoming\ParsedEmail::isAutoReply(): the RFC 3834
+     * Auto-Submitted header (present and not "no"), common bulk/auto Precedence
+     * values, the non-standard X-Autoreply/X-Autorespond headers some MTAs send,
+     * and the legacy subject/body substring patterns.
+     */
+    private function isAutoReply(array $latest, array $headers): bool
+    {
+        $autoSubmitted = strtolower(trim($headers['auto-submitted'] ?? ''));
+        if ($autoSubmitted !== '' && $autoSubmitted !== 'no') {
+            return true;
+        }
+
+        $precedence = strtolower(trim($headers['precedence'] ?? ''));
+        if (in_array($precedence, ['auto_reply', 'bulk', 'junk'], true)) {
+            return true;
+        }
+
+        if (trim($headers['x-autoreply'] ?? '') !== '' || trim($headers['x-autorespond'] ?? '') !== '') {
+            return true;
+        }
+
+        $subject = $latest['subject'] ?? '';
+        foreach (self::AUTO_REPLY_SUBJECT_PATTERNS as $pattern) {
+            if (stripos($subject, $pattern) !== false) {
+                return true;
+            }
+        }
+
+        $body = $latest['body'] ?? '';
+        foreach (self::AUTO_REPLY_BODY_PATTERNS as $pattern) {
+            if (stripos($body, $pattern) !== false) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Is this a delivery-failure bounce/DSN rather than a genuine human reply?
+     * Mirrors App\Services\Mail\Incoming\MailParserService::extractBounceInfo():
+     * a mailer-daemon/postmaster sender, a DSN-style subject, or a
+     * multipart/report + message/delivery-status MIME part.
+     */
+    private function isBounce(array $latest, array $headers): bool
+    {
+        $from = strtolower($latest['from'] ?? '');
+        if (str_contains($from, 'mailer-daemon') || str_contains($from, 'postmaster')) {
+            return true;
+        }
+
+        $subject = $latest['subject'] ?? '';
+        foreach (self::BOUNCE_SUBJECT_PATTERNS as $pattern) {
+            if (stripos($subject, $pattern) !== false) {
+                return true;
+            }
+        }
+
+        return ! empty($latest['is_delivery_report']);
     }
 }

--- a/iznik-batch/app/Models/MessagesBulkOutreach.php
+++ b/iznik-batch/app/Models/MessagesBulkOutreach.php
@@ -33,6 +33,16 @@ class MessagesBulkOutreach extends Model
     public const STATUS_NORESPONSE = 'NoResponse';
     public const STATUS_SKIPPED = 'Skipped';
 
+    // An auto-reply / out-of-office / auto-acknowledgement, NOT a genuine human
+    // reply - set by PollGmailOutreachCommand so it isn't emitted to the FSM
+    // brain or counted as a Replied.
+    public const STATUS_AUTO_ACK = 'AutoAck';
+
+    // A delivery-failure bounce/DSN for the outreach email - set by
+    // PollGmailOutreachCommand, which also suppresses the row so the (dead)
+    // address is never re-contacted.
+    public const STATUS_BOUNCED = 'Bounced';
+
     public function user()
     {
         return $this->belongsTo(User::class, 'userid');

--- a/iznik-batch/database/migrations/2026_07_02_000001_add_autoack_bounced_to_messages_bulk_outreach_status.php
+++ b/iznik-batch/database/migrations/2026_07_02_000001_add_autoack_bounced_to_messages_bulk_outreach_status.php
@@ -1,0 +1,62 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Widen messages_bulk_outreach.status to add AutoAck and Bounced.
+ *
+ * PollGmailOutreachCommand previously marked any non-unsubscribe inbound reply
+ * as Replied and emitted it to the FSM brain, including auto-replies/OOO
+ * auto-acknowledgements and delivery-failure bounces. Those two new statuses
+ * let the poller record what actually happened without miscounting them as a
+ * genuine human reply (see App\Console\Commands\BulkOffer\PollGmailOutreachCommand).
+ *
+ * Append-only ENUM widening: existing values kept in their original order, new
+ * values appended at the end (see FreegleDocker memory
+ * reference_galera_enum_alter - INPLACE + LOCK=NONE is valid for end-append on
+ * Percona 8.0; Galera TOI still pauses cluster writes for the metadata-only DDL,
+ * ms-scale on this table).
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('messages_bulk_outreach')) {
+            return;
+        }
+
+        DB::statement("
+            ALTER TABLE messages_bulk_outreach
+              MODIFY COLUMN status ENUM(
+                'Imported','Queued','Sent','Replied','Took','Declined','NoResponse','Skipped',
+                'AutoAck','Bounced'
+              ) NOT NULL DEFAULT 'Imported',
+              ALGORITHM=INPLACE, LOCK=NONE
+        ");
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasTable('messages_bulk_outreach')) {
+            return;
+        }
+
+        // Coerce any new values back to NoResponse before narrowing the column,
+        // otherwise the ALTER fails on rows whose value is no longer in the enum.
+        DB::statement("
+            UPDATE messages_bulk_outreach
+            SET status = 'NoResponse'
+            WHERE status IN ('AutoAck','Bounced')
+        ");
+
+        DB::statement("
+            ALTER TABLE messages_bulk_outreach
+              MODIFY COLUMN status ENUM(
+                'Imported','Queued','Sent','Replied','Took','Declined','NoResponse','Skipped'
+              ) NOT NULL DEFAULT 'Imported',
+              ALGORITHM=INPLACE, LOCK=NONE
+        ");
+    }
+};

--- a/iznik-batch/tests/Feature/BulkOffer/PollGmailOutreachCommandTest.php
+++ b/iznik-batch/tests/Feature/BulkOffer/PollGmailOutreachCommandTest.php
@@ -1,0 +1,209 @@
+<?php
+
+namespace Tests\Feature\BulkOffer;
+
+use App\Models\MessagesBulkOutreach;
+use App\Services\Gmail\GmailService;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+/**
+ * Exercises bulkoffer:poll-outreach against a faked GmailService so reply
+ * classification (unsubscribe / bounce / auto-reply / genuine reply) can be
+ * verified without contacting Google. The command emits a JSON array of
+ * genuine replies to stdout for the FSM brain to act on - auto-acks and
+ * bounces must NOT appear in that output, and must not be marked Replied.
+ */
+class PollGmailOutreachCommandTest extends TestCase
+{
+    private int $msgid;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $donor = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $this->msgid = $this->createTestMessage($donor, $group, [
+            'subject' => 'OFFER: Office clearance (Hampstead)',
+        ])->id;
+    }
+
+    /** Insert a Sent outreach row watching the given Gmail thread id. */
+    private function sentOutreach(string $threadId, array $overrides = []): int
+    {
+        $org = $this->createTestUser(['email_preferred' => $this->uniqueEmail('org')]);
+
+        return DB::table('messages_bulk_outreach')->insertGetId(array_merge([
+            'msgid' => $this->msgid,
+            'userid' => $org->id,
+            'orgname' => 'Hampstead Community Centre',
+            'area' => 'Hampstead, NW3',
+            'tier' => '2',
+            'status' => MessagesBulkOutreach::STATUS_SENT,
+            'gmail_thread_id' => $threadId,
+            'gmail_message_id' => 'sent-'.$threadId,
+            'sent_at' => now(),
+            'sent_via' => 'email',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ], $overrides));
+    }
+
+    /** Build a Gmail API message array with the given headers and plain-text body. */
+    private function gmailMessage(array $headers, string $body, string $mimeType = 'text/plain'): array
+    {
+        $headerPairs = [];
+        foreach ($headers as $name => $value) {
+            $headerPairs[] = ['name' => $name, 'value' => $value];
+        }
+
+        return [
+            'id' => 'msg-'.substr(md5(uniqid('', true)), 0, 12),
+            'payload' => [
+                'mimeType' => $mimeType,
+                'headers' => $headerPairs,
+                'body' => ['data' => rtrim(strtr(base64_encode($body), '+/', '-_'), '=')],
+            ],
+        ];
+    }
+
+    /** Our own outbound message in the thread, so latestInbound() has something to skip past. */
+    private function outboundMessage(): array
+    {
+        return $this->gmailMessage([
+            'From' => 'Natalie @ Freegle <natalie-wagg@ilovefreegle.org>',
+            'To' => 'org@example.com',
+            'Subject' => 'OFFER: Office clearance (Hampstead) - would you like some of these?',
+        ], 'Hi, we have some office furniture available, would your organisation like any of it?');
+    }
+
+    /** Bind a fake GmailService whose listThreads()/getThread() surface the given thread. */
+    private function fakeGmail(string $threadId, array $thread): void
+    {
+        $mock = $this->createMock(GmailService::class);
+        $mock->method('listThreads')->willReturn([['id' => $threadId]]);
+        $mock->method('getThread')->with($threadId)->willReturn($thread);
+        // void return type - stub the method without willReturn(), which
+        // PHPUnit rejects (IncompatibleReturnValueException) even for null.
+        $mock->method('modifyMessageLabels');
+        $this->app->instance(GmailService::class, $mock);
+    }
+
+    /** Run the poller for $this->msgid and return the decoded JSON reply array. */
+    private function poll(): array
+    {
+        $code = \Artisan::call('bulkoffer:poll-outreach', ['--msgid' => $this->msgid]);
+        $this->assertSame(0, $code, 'poller should exit cleanly');
+
+        $lines = array_values(array_filter(explode("\n", trim(\Artisan::output()))));
+        $jsonLine = end($lines) ?: '[]';
+
+        $decoded = json_decode($jsonLine, true);
+        $this->assertIsArray($decoded, "expected the last output line to be a JSON array, got: {$jsonLine}");
+
+        return $decoded;
+    }
+
+    public function test_auto_submitted_header_marks_auto_ack_and_is_not_emitted(): void
+    {
+        $threadId = 'thread-autosubmitted';
+        $id = $this->sentOutreach($threadId);
+
+        $this->fakeGmail($threadId, [
+            'messages' => [
+                $this->outboundMessage(),
+                $this->gmailMessage([
+                    'From' => 'Org Contact <org@example.com>',
+                    'To' => 'natalie-wagg@ilovefreegle.org',
+                    'Subject' => 'Re: OFFER: Office clearance (Hampstead)',
+                    'Auto-Submitted' => 'auto-replied',
+                ], 'This mailbox is not monitored, please try another address.'),
+            ],
+        ]);
+
+        $replies = $this->poll();
+
+        $row = DB::table('messages_bulk_outreach')->find($id);
+        $this->assertSame(MessagesBulkOutreach::STATUS_AUTO_ACK, $row->status);
+        $this->assertNull($row->replied_at, 'an auto-ack is not a genuine reply');
+        $this->assertEmpty($replies, 'auto-ack must not be emitted to the FSM brain');
+    }
+
+    public function test_out_of_office_subject_marks_auto_ack(): void
+    {
+        $threadId = 'thread-ooo';
+        $id = $this->sentOutreach($threadId);
+
+        $this->fakeGmail($threadId, [
+            'messages' => [
+                $this->outboundMessage(),
+                $this->gmailMessage([
+                    'From' => 'Org Contact <org@example.com>',
+                    'To' => 'natalie-wagg@ilovefreegle.org',
+                    'Subject' => 'Out of Office: Re: OFFER: Office clearance',
+                ], "I'm currently on annual leave and will respond when I return."),
+            ],
+        ]);
+
+        $replies = $this->poll();
+
+        $row = DB::table('messages_bulk_outreach')->find($id);
+        $this->assertSame(MessagesBulkOutreach::STATUS_AUTO_ACK, $row->status);
+        $this->assertNull($row->replied_at);
+        $this->assertEmpty($replies, 'OOO auto-reply must not be emitted to the FSM brain');
+    }
+
+    public function test_mailer_daemon_bounce_marks_bounced_and_suppresses(): void
+    {
+        $threadId = 'thread-bounce';
+        $id = $this->sentOutreach($threadId);
+
+        $this->fakeGmail($threadId, [
+            'messages' => [
+                $this->outboundMessage(),
+                $this->gmailMessage([
+                    'From' => 'Mail Delivery System <MAILER-DAEMON@ilovefreegle.org>',
+                    'To' => 'natalie-wagg@ilovefreegle.org',
+                    'Subject' => 'Delivery Status Notification (Failure)',
+                ], 'Your message could not be delivered to org@example.com: mailbox unavailable'),
+            ],
+        ]);
+
+        $replies = $this->poll();
+
+        $row = DB::table('messages_bulk_outreach')->find($id);
+        $this->assertSame(MessagesBulkOutreach::STATUS_BOUNCED, $row->status);
+        $this->assertNotNull($row->suppressed_until, 'a bounced address must be suppressed from re-contact');
+        $this->assertTrue(\Carbon\Carbon::parse($row->suppressed_until)->isFuture());
+        $this->assertNull($row->replied_at);
+        $this->assertEmpty($replies, 'a bounce must not be emitted to the FSM brain');
+    }
+
+    public function test_genuine_human_reply_is_still_marked_replied_and_emitted(): void
+    {
+        $threadId = 'thread-genuine';
+        $id = $this->sentOutreach($threadId);
+
+        $this->fakeGmail($threadId, [
+            'messages' => [
+                $this->outboundMessage(),
+                $this->gmailMessage([
+                    'From' => 'Org Contact <org@example.com>',
+                    'To' => 'natalie-wagg@ilovefreegle.org',
+                    'Subject' => 'Re: OFFER: Office clearance (Hampstead)',
+                ], "Hi Natalie, yes we'd love the desk lamps, when can we collect them?"),
+            ],
+        ]);
+
+        $replies = $this->poll();
+
+        $row = DB::table('messages_bulk_outreach')->find($id);
+        $this->assertSame(MessagesBulkOutreach::STATUS_REPLIED, $row->status);
+        $this->assertNotNull($row->replied_at, 'a genuine reply must still stamp replied_at');
+        $this->assertCount(1, $replies, 'a genuine reply must still be emitted to the FSM brain');
+        $this->assertSame($id, $replies[0]['outreachid']);
+        $this->assertSame($threadId, $replies[0]['threadid']);
+        $this->assertStringContainsString('desk lamps', $replies[0]['body']);
+    }
+}


### PR DESCRIPTION
## Problem

`bulkoffer:poll-outreach` (the mailbox transport of the outreach concierge FSM) classified **every** inbound thread that wasn't an unsubscribe as a genuine human reply: it marked the row `Replied` and emitted it to the LLM brain. So an **out-of-office / auto-acknowledgement** or a **mailer-daemon bounce** would be handed to the brain, which then drafts and sends a pointless reply into an auto-responder or a dead address.

This surfaced live during the WAGGGS furniture-outreach send: the mailbox is receiving exactly these auto-acks (Citizens Advice Barnet, AWRC, "on leave" OOO replies) and hard bounces ("Address not found").

## Fix

Classify each inbound in order **unsubscribe → bounce → auto-reply → genuine reply**, reusing the signals already used elsewhere in this codebase (`App\Services\Mail\Incoming\ParsedEmail::isAutoReply()` and `MailParserService`), reimplemented against the Gmail-API thread JSON this command reads:

- **Bounce/DSN** (mailer-daemon/postmaster sender, DSN subject, or `multipart/report` + `message/delivery-status` MIME) → new status `Bounced` + `suppressed_until` far future, so a dead address is never re-contacted. Not emitted to the FSM.
- **Auto-reply / OOO / auto-ack** (RFC 3834 `Auto-Submitted` header, `Precedence: bulk/auto_reply/junk`, `X-Autoreply`/`X-Autorespond`, or the usual OOO subject/body patterns) → new status `AutoAck` (no `replied_at`). Not emitted to the FSM.
- **Genuine reply** → unchanged (`Replied` + emitted). Thread messages are still marked read in all cases.

Adds `STATUS_AUTO_ACK`/`STATUS_BOUNCED` to `MessagesBulkOutreach` and a migration widening the `status` ENUM (append-only, `ALGORITHM=INPLACE, LOCK=NONE`).

## Tests

New `PollGmailOutreachCommandTest` covering: Auto-Submitted → AutoAck (not emitted); "Out of Office" subject → AutoAck; mailer-daemon delivery-failure → Bounced + suppressed; genuine reply → still Replied + emitted (regression). All 4 pass; the full BulkOffer suite (25 tests) stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)