### PR TITLE
feat(rippling): mark the home group in a rippled post's group list and show it first

### DIFF
--- a/iznik-nuxt3/components/MessageExpanded.vue
+++ b/iznik-nuxt3/components/MessageExpanded.vue
@@ -328,8 +328,8 @@
             <!-- Bulk-offer ("clearance") catalogue with per-item interest. -->
             <BulkItemsInterest
               v-if="isBulk"
-              ref="bulkInterestRef"
               :id="id"
+              ref="bulkInterestRef"
               @can-register="bulkCanRegister = $event"
               @submitted="bulkSubmitted = $event"
               @had-interest="bulkHadInterest = $event"
@@ -404,7 +404,12 @@
                 On:
                 <ShowMore :items="messageGroups" :limit="3" inline>
                   <template #item="{ item }"
-                    ><NuxtLink
+                    ><v-icon
+                      v-if="item.isHome"
+                      icon="home"
+                      class="me-1 text-muted"
+                      title="Home community (where this was originally posted)"
+                    /><NuxtLink
                       no-prefetch
                       :to="'/explore/' + item.nameshort"
                       class="posted-on-group-link"
@@ -663,7 +668,7 @@ import { useMobileStore } from '~/stores/mobile'
 import { useGroupStore } from '~/stores/group'
 import { useMe } from '~/composables/useMe'
 import { useMessageDisplay } from '~/composables/useMessageDisplay'
-import { homeGroupFirst } from '~/composables/rippleStatus'
+import { homeGroupFirst, isHomeGroup } from '~/composables/rippleStatus'
 import { action } from '~/composables/useClientLog'
 import MessageTextBody from '~/components/MessageTextBody'
 import MessageTag from '~/components/MessageTag'
@@ -744,11 +749,16 @@ const {
 // out or been cross-posted). Resolve each to the group record for its display
 // name + explore link; drop any not yet in the group store.
 const messageGroups = computed(() => {
-  if (!message.value?.groups?.length) return []
+  const raw = message.value?.groups
+  if (!raw?.length) return []
   // List the home/origin group first: the list is truncated (ShowMore), so otherwise
-  // the home group could be hidden behind "more".
-  return homeGroupFirst(message.value.groups)
-    .map((g) => groupStore.get(g.groupid))
+  // the home group could be hidden behind "more". Flag it so the template can show a
+  // home icon next to it.
+  return homeGroupFirst(raw)
+    .map((g) => {
+      const grp = groupStore.get(g.groupid)
+      return grp ? { ...grp, isHome: isHomeGroup(g, raw) } : null
+    })
     .filter(Boolean)
 })
 

--- a/iznik-nuxt3/components/MessageHistory.vue
+++ b/iznik-nuxt3/components/MessageHistory.vue
@@ -11,6 +11,12 @@
           <span v-if="showSummaryDetails">on </span>
         </span>
       </client-only>
+      <v-icon
+        v-if="showSummaryDetails && parseInt(group.groupid) === postHomeGroupId"
+        icon="home"
+        class="me-1 text-muted"
+        title="Home community (where this was originally posted)"
+      />
       <nuxt-link
         v-if="group.groupid in groups && showSummaryDetails"
         no-prefetch
@@ -26,7 +32,9 @@
           :to="
             modinfo && group.groupid
               ? '/messages/' +
-                (['Pending', 'PendingOther', 'Spam'].includes(group.collection) ? 'pending' : 'approved') +
+                (['Pending', 'PendingOther', 'Spam'].includes(group.collection)
+                  ? 'pending'
+                  : 'approved') +
                 '/' +
                 group.groupid +
                 '/' +
@@ -90,6 +98,7 @@ import { useGroupStore } from '~/stores/group'
 import { timeago } from '~/composables/useTimeFormat'
 import { useMiscStore } from '~/stores/misc'
 import { useMe } from '~/composables/useMe'
+import { homeGroupFirst, homeGroupId } from '~/composables/rippleStatus'
 
 const props = defineProps({
   id: {
@@ -128,8 +137,12 @@ const displayGroups = computed(() => {
   if (props.onlyGroupid) {
     return groups.filter((g) => parseInt(g.groupid) === props.onlyGroupid)
   }
-  return groups
+  // Home/origin group first, so it leads the list of communities the post appears on.
+  return homeGroupFirst(groups)
 })
+
+// The post's home/origin group id, used to mark it with a home icon in the list.
+const postHomeGroupId = computed(() => homeGroupId(message.value?.groups || []))
 
 const groupStore = useGroupStore()
 const messageStore = useMessageStore()

--- a/iznik-nuxt3/components/MyMessage.vue
+++ b/iznik-nuxt3/components/MyMessage.vue
@@ -138,7 +138,12 @@
                   <div class="group-row">
                     <ShowMore :items="messageGroups" :limit="3" inline>
                       <template #item="{ item }"
-                        ><nuxt-link
+                        ><v-icon
+                          v-if="item.isHome"
+                          icon="home"
+                          class="me-1 text-muted"
+                          title="Home community (where this was originally posted)"
+                        /><nuxt-link
                           :to="'/explore/' + item.nameshort"
                           class="group-link"
                           @click.stop
@@ -199,7 +204,12 @@
                       <span v-if="message.area" class="desktop-sep">·</span>
                       <ShowMore :items="messageGroups" :limit="3" inline>
                         <template #item="{ item }"
-                          ><nuxt-link
+                          ><v-icon
+                            v-if="item.isHome"
+                            icon="home"
+                            class="me-1 text-muted"
+                            title="Home community (where this was originally posted)"
+                          /><nuxt-link
                             :to="'/explore/' + item.nameshort"
                             class="desktop-group-link"
                             @click.stop
@@ -520,7 +530,7 @@ import { milesAway } from '~/composables/useDistance'
 import { onMounted, ref, computed, watch, useRouter, toRef } from '#imports'
 import { useMe } from '~/composables/useMe'
 import { useMessageDisplay } from '~/composables/useMessageDisplay'
-import { homeGroupFirst } from '~/composables/rippleStatus'
+import { homeGroupFirst, isHomeGroup } from '~/composables/rippleStatus'
 import ProfileImage from '~/components/ProfileImage'
 import MessageTag from '~/components/MessageTag'
 import OurUploadedImage from '~/components/OurUploadedImage'
@@ -795,11 +805,15 @@ const canrepostatago = computed(() => {
 })
 
 const messageGroups = computed(() => {
-  if (message.value?.groups?.length) {
+  const raw = message.value?.groups
+  if (raw?.length) {
     // List the home/origin group first: the list is truncated (ShowMore), so otherwise
-    // the home group could be hidden behind "more".
-    return homeGroupFirst(message.value.groups)
-      .map((g) => groupStore?.get(g.groupid))
+    // the home group could be hidden behind "more". Flag it for the home icon.
+    return homeGroupFirst(raw)
+      .map((g) => {
+        const grp = groupStore?.get(g.groupid)
+        return grp ? { ...grp, isHome: isHomeGroup(g, raw) } : null
+      })
       .filter(Boolean)
   }
   return []

--- a/iznik-nuxt3/composables/rippleStatus.js
+++ b/iznik-nuxt3/composables/rippleStatus.js
@@ -130,3 +130,21 @@ export function homeGroupFirst(groups) {
   copy.unshift(home)
   return copy
 }
+
+/**
+ * Is this group the post's home/origin group? Used to mark it with a home icon in the
+ * group lists. Accepts either a raw messages_groups entry ({groupid}) or a resolved
+ * group-store object ({id}); `groups` must be the raw message.groups array (it carries
+ * the rippled_in / arrival info homeGroupId needs).
+ *
+ * @param {{groupid?:number|string, id?:number|string}} group
+ * @param {Array<{groupid:number|string, arrival?:string, rippled_in?:number|boolean}>} groups
+ * @returns {boolean}
+ */
+export function isHomeGroup(group, groups) {
+  if (!group) return false
+  const homeId = homeGroupId(groups)
+  if (homeId == null) return false
+  const gid = group.groupid ?? group.id
+  return gid != null && parseInt(gid) === homeId
+}

--- a/iznik-nuxt3/package-lock.json
+++ b/iznik-nuxt3/package-lock.json
@@ -27350,9 +27350,9 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
     },
     "node_modules/srvx": {
-      "version": "0.11.18",
-      "resolved": "https://registry.npmjs.org/srvx/-/srvx-0.11.18.tgz",
-      "integrity": "sha512-7/EW5sPdC1bU7iq1tgTvCZqUQDkJdsqIVzYqBv7SuBfQQ10oWkKj4KYNOw0H4Ig26bXuUYDA7XTKxB+/HC5SRw==",
+      "version": "0.11.20",
+      "resolved": "https://registry.npmjs.org/srvx/-/srvx-0.11.20.tgz",
+      "integrity": "sha512-gdPvbwpJOJpMyBYcp39q78C4pmv/Aw5WwZKB3+/pfeUVxo3EvNXlOi1fxzoy2ECGvUeBhouXy9rBxstjQQOPog==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/iznik-nuxt3/tests/unit/composables/rippleStatus.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/rippleStatus.spec.js
@@ -3,6 +3,7 @@ import {
   isRippledInToContextGroup,
   earliestArrivalGroupId,
   homeGroupFirst,
+  isHomeGroup,
   RIPPLE_ORIGIN_WINDOW_MS,
 } from '~/composables/rippleStatus'
 
@@ -277,5 +278,47 @@ describe('homeGroupFirst', () => {
       { groupid: '1', arrival: at(0) },
     ]
     expect(ids(homeGroupFirst(groups))).toEqual([1, 2])
+  })
+})
+
+// isHomeGroup marks which entry in a post's group list is the home/origin group, so the
+// UI can show a home icon next to it. It accepts a raw messages_groups entry ({groupid})
+// or a resolved group-store object ({id}).
+describe('isHomeGroup', () => {
+  const groups = [
+    { groupid: 2, arrival: at(120), rippled_in: 1 }, // rippled in
+    { groupid: 1, arrival: at(0), rippled_in: 0 }, // home/origin
+    { groupid: 3, arrival: at(120), rippled_in: 1 }, // rippled in
+  ]
+
+  it('is true only for the home/origin group (raw entry)', () => {
+    expect(isHomeGroup({ groupid: 1 }, groups)).toBe(true)
+    expect(isHomeGroup({ groupid: 2 }, groups)).toBe(false)
+    expect(isHomeGroup({ groupid: 3 }, groups)).toBe(false)
+  })
+
+  it('accepts a resolved group-store object keyed by id', () => {
+    expect(isHomeGroup({ id: 1 }, groups)).toBe(true)
+    expect(isHomeGroup({ id: 2 }, groups)).toBe(false)
+  })
+
+  it('honours rippled_in over arrival when the origin was re-stamped late', () => {
+    const g = [
+      { groupid: 2, arrival: at(30), rippled_in: 1 },
+      { groupid: 1, arrival: at(200), rippled_in: 0 }, // home, later arrival
+    ]
+    expect(isHomeGroup({ groupid: 1 }, g)).toBe(true)
+    expect(isHomeGroup({ groupid: 2 }, g)).toBe(false)
+  })
+
+  it('handles string groupids', () => {
+    expect(isHomeGroup({ groupid: '1' }, groups)).toBe(true)
+    expect(isHomeGroup({ groupid: '2' }, groups)).toBe(false)
+  })
+
+  it('is false for null/empty inputs', () => {
+    expect(isHomeGroup(null, groups)).toBe(false)
+    expect(isHomeGroup({ groupid: 1 }, [])).toBe(false)
+    expect(isHomeGroup({ groupid: 1 }, null)).toBe(false)
   })
 })


### PR DESCRIPTION
## What

When a post has rippled out to several communities, the list of groups it appears on should make the **home/origin community** obvious. This adds a home fonticon next to the home group and ensures that group is shown first, on **both Freegle (FD) and ModTools (MT)**.

"Home group" = the group where the post was **originally posted** (`rippled_in = 0`), not the viewer's own home group.

## Before / after

- **FD** (`MessageExpanded.vue` post detail, `MyMessage.vue` My Posts): the group list was already sorted home-first (`homeGroupFirst`) but had no marker → now shows a `<v-icon icon="home">` next to the home community.
- **MT** (`MessageHistory.vue`, rendered by `ModMessageSummary` as the "groups this post appears on" list): was neither sorted nor marked → now sorted home-first and the origin group carries the home icon.

## How

- New `isHomeGroup(group, groups)` in `composables/rippleStatus.js` — accepts a raw `messages_groups` entry (`{groupid}`) or a resolved group-store object (`{id}`), and reuses the existing `homeGroupId` (authoritative `rippled_in` flag, earliest-arrival tie-break, robust to the approve path re-stamping the origin row's arrival to NOW()).
- FD components flag the home entry in the `messageGroups` computed; templates render the icon on `item.isHome`.
- MT `MessageHistory` sorts `displayGroups` via `homeGroupFirst` and compares each row against a `postHomeGroupId` computed for the icon. The single-group mod view (`only-groupid`) is unaffected apart from showing the icon when that group is the origin.

Out of scope: `MessageHistoryExpanded.vue` (unused/dead) and `ExportPost.vue` (a print/export tool), which aren't the interactive FD/MT group lists.

## Verification

- New `isHomeGroup` unit cases in `tests/unit/composables/rippleStatus.spec.js` (raw vs resolved shape, `rippled_in` winning over a late-stamped arrival, string group ids, null/empty inputs).
- Full frontend unit run green locally: 13745 passed, 0 failed (653 files) — includes the existing `MessageExpanded`, `MyMessage`, `MessageHistory`, and `ModMessageSummary` component specs, which render the changed templates. ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
