### PR TITLE
feat(browse): distance slider + relevance sort in all "Show posts from" views

### DIFF
--- a/iznik-nuxt3/components/PostFilters.vue
+++ b/iznik-nuxt3/components/PostFilters.vue
@@ -373,13 +373,16 @@ const feedMax = computed(() => {
   return Math.max(FEED_MAX_FLOOR, Math.ceil(Math.max(...distances)))
 })
 
-// Distance is meaningless without a known location, and for the mygroups view.
+// Distance is meaningless without a known location.
 const hasLocation = computed(() => {
   return !!(me.value && (me.value.lat || me.value.lng))
 })
 
+// Shown in every "Show posts from" view (nearby, all-my-groups, a single group), not just
+// Nearby: the mygroups feed now carries a per-post distance server-side too, so the slider
+// narrows whichever view is active. It only needs a known location to measure from.
 const showDistanceSlider = computed(() => {
-  return browseView.value === 'nearby' && hasLocation.value
+  return hasLocation.value
 })
 
 const maxDistance = computed({

--- a/iznik-nuxt3/tests/unit/components/PostFilters.spec.js
+++ b/iznik-nuxt3/tests/unit/components/PostFilters.spec.js
@@ -457,10 +457,13 @@ describe('PostFilters', () => {
       expect(wrapper.find('.range-slider-stub').exists()).toBe(false)
     })
 
-    it('hides the slider outside the nearby view', () => {
+    it('shows the slider in the mygroups view when the viewer has a location', () => {
+      // The mygroups feed now carries a per-post distance (server-side), so the slider
+      // narrows any "Show posts from" view - not just Nearby - as long as we know where
+      // the viewer is.
       mockMe.value = meWithLocation({ browseView: 'mygroups' })
       const wrapper = createWrapper({ forceShowFilters: true })
-      expect(wrapper.find('.range-slider-stub').exists()).toBe(false)
+      expect(wrapper.find('.range-slider-stub').exists()).toBe(true)
     })
 
     it('scales the slider max to the farthest distance in the feed (rounded up)', () => {

--- a/iznik-server-go/isochrone/message.go
+++ b/iznik-server-go/isochrone/message.go
@@ -363,40 +363,90 @@ func myGroupsMsgIDs(db *gorm.DB, myid uint64) []uint64 {
 	return ids
 }
 
-// myGroupsMessages renders the 'mygroups' browse feed: posts from the viewer's member groups,
-// with the unseen flag, blurred. No location/postvisibility/reach filtering — the viewer is a
-// member, and Count's mygroups branch is unfiltered too, so feed and badge stay in lock-step.
+// myGroupsMessages renders the 'mygroups' browse feed: posts from the viewer's member groups.
+// Membership (not location/reach) decides what shows — the viewer is a member, and Count's
+// mygroups branch counts the same universe, so feed and badge stay in lock-step. Each post is
+// still scored and distance-stamped exactly like the nearby feed (reachCandidateRow.toSummary)
+// whenever the viewer has a location, so the "New to you" relevance sort and the distance slider
+// work in this view too — member-group posts have no reach row of their own, so the reach radius
+// falls back to the configured default extent (ReachRadiusMetres), the same fallback the nearby
+// view's own-posts arm uses.
 func myGroupsMessages(c *fiber.Ctx, db *gorm.DB, myid uint64) error {
 	res := []message.MessageSummary{}
 	msgIDs := myGroupsMsgIDs(db, myid)
 
 	if len(msgIDs) > 0 {
 		placeholders := make([]string, len(msgIDs))
-		args := make([]any, len(msgIDs)+2)
-		args[0] = myid
-		args[1] = utils.MESSAGE_LIKES_VIEW
+		// args: MESSAGE_LIKES_VIEW (views subquery), CHAT_MESSAGE_INTERESTED (replies subquery),
+		// then myid + MESSAGE_LIKES_VIEW (the seen-flag join), then the member-group msgids.
+		args := make([]any, len(msgIDs)+4)
+		args[0] = utils.MESSAGE_LIKES_VIEW
+		args[1] = utils.CHAT_MESSAGE_INTERESTED
+		args[2] = myid
+		args[3] = utils.MESSAGE_LIKES_VIEW
 		for i, id := range msgIDs {
 			placeholders[i] = "?"
-			args[i+2] = id
+			args[i+4] = id
 		}
+
+		// Select the same scoring/distance ingredients as the nearby arm (fetchReachCandidates):
+		// per-post views and reply counts, plus the post's reach row (LEFT JOINed — a member-group
+		// post need not have one) so toSummary can derive its distance and relevance score.
+		var candidates []reachCandidateRow
 		db.Raw(fmt.Sprintf(
 			"SELECT ST_Y(ms.point) AS lat, ST_X(ms.point) AS lng, "+
 				"ms.msgid AS id, ms.successful, ms.promised, ms.groupid, "+
 				"ms.msgtype AS type, ms.arrival, "+
-				"CASE WHEN ml.msgid IS NULL THEN 1 ELSE 0 END AS unseen "+
+				"CASE WHEN ml.msgid IS NULL THEN 1 ELSE 0 END AS unseen, "+
+				"COALESCE((SELECT SUM(mlv.count) FROM messages_likes mlv WHERE mlv.msgid = ms.msgid AND mlv.type = ?), 0) AS views, "+
+				"(SELECT COUNT(*) FROM chat_messages cm WHERE cm.refmsgid = ms.msgid AND cm.type = ? AND cm.reviewrejected = 0 AND cm.reviewrequired = 0) AS replies, "+
+				"COALESCE(rr.lat, 0) AS reach_lat, COALESCE(rr.lng, 0) AS reach_lng, COALESCE(ST_AsText(rr.polygon), '') AS reach_wkt "+
 				"FROM messages_spatial ms "+
 				"LEFT JOIN messages_likes ml ON ml.msgid = ms.msgid AND ml.userid = ? AND ml.type = ? "+
+				"LEFT JOIN rippling_reach rr ON rr.msgid = ms.msgid "+
 				"WHERE ms.msgid IN (%s)",
 			strings.Join(placeholders, ",")),
-			args...).Scan(&res)
-	}
+			args...).Scan(&candidates)
 
-	for ix, r := range res {
-		res[ix].Lat, res[ix].Lng = utils.Blur(r.Lat, r.Lng, utils.BLUR_USER)
+		latlng := user.GetLatLng(myid)
+		if latlng.Lat != 0 || latlng.Lng != 0 {
+			viewerLat, viewerLng := float64(latlng.Lat), float64(latlng.Lng)
+			weights := LoadScoreWeights()
+			env := LoadScoreEnv()
+			for _, cand := range candidates {
+				res = append(res, cand.toSummary(viewerLat, viewerLng, weights, env))
+			}
+			// Rippling relevance order (score desc, arrival tie-break), mirroring the nearby
+			// arm, so the client's "New to you" sort has a meaningful score to rank on.
+			sort.SliceStable(res, func(i, j int) bool {
+				if res[i].Score != res[j].Score {
+					return res[i].Score > res[j].Score
+				}
+				return res[i].Arrival.After(res[j].Arrival)
+			})
+		} else {
+			// No known location: distance/score can't be measured, so keep the prior behaviour
+			// (blurred coords, Distance/Score left at zero). The distance slider is hidden
+			// client-side without a location, so nothing here depends on Distance.
+			for _, cand := range candidates {
+				blurLat, blurLng := utils.Blur(cand.Lat, cand.Lng, utils.BLUR_USER)
+				res = append(res, message.MessageSummary{
+					ID:         cand.ID,
+					Successful: cand.Successful,
+					Promised:   cand.Promised,
+					Groupid:    cand.Groupid,
+					Type:       cand.Type,
+					Arrival:    cand.Arrival,
+					Lat:        blurLat,
+					Lng:        blurLng,
+					Unseen:     cand.Unseen,
+				})
+			}
+		}
 	}
 
 	// Float any pinned post (a paid bulk-offer clearance) to the top of the member-group
-	// feed too. This view has no relevance score, so pinned-first is the only reordering.
+	// feed, above the relevance order.
 	markPinned(db, res)
 	sort.SliceStable(res, func(i, j int) bool {
 		return res[i].Pinned && !res[j].Pinned
@@ -414,18 +464,7 @@ func Count(c *fiber.Ctx) error {
 	browseView := effectiveBrowseView(c, db, myid)
 
 	if browseView == "mygroups" {
-		// Test membership via messages_groups (the post's full group set), not
-		// messages_spatial.groupid — which stores only ONE group per post and mis-attributes
-		// rippled/cross-posted messages (see myGroupsMsgIDs). This EXISTS matches the mygroups
-		// feed (message.Groups / myGroupsMsgIDs), so feed == badge and "Mark seen" drains to
-		// zero instead of sticking on rows the feed never renders.
-		db.Raw("SELECT COUNT(DISTINCT ms.msgid) FROM messages_spatial ms "+
-			"LEFT JOIN messages_likes ml ON ml.msgid = ms.msgid AND ml.userid = ? AND ml.type = ? "+
-			"WHERE ms.successful = 0 AND ml.msgid IS NULL "+
-			"AND EXISTS (SELECT 1 FROM messages_groups mg "+
-			"INNER JOIN memberships mem ON mem.groupid = mg.groupid "+
-			"WHERE mg.msgid = ms.msgid AND mem.userid = ? "+
-			"AND mg.collection = 'Approved' AND mg.deleted = 0)", myid, utils.MESSAGE_LIKES_VIEW, myid).Scan(&count)
+		count = myGroupsCount(db, myid, resolveMaxDistance(c, db, myid))
 	} else {
 		count = nearbyCount(myid, resolveMaxDistance(c, db, myid))
 	}
@@ -433,6 +472,65 @@ func Count(c *fiber.Ctx) error {
 	return c.JSON(fiber.Map{
 		"count": count,
 	})
+}
+
+// myGroupsCountUnfiltered is the plain unseen-post count for the 'mygroups' browse view: open,
+// unviewed posts in the viewer's member groups. Membership is tested via messages_groups (the
+// post's full group set), not messages_spatial.groupid — which stores only ONE group per post and
+// mis-attributes rippled/cross-posted messages (see myGroupsMsgIDs). This EXISTS matches the
+// mygroups feed (message.Groups / myGroupsMsgIDs), so feed == badge and "Mark seen" drains to zero
+// instead of sticking on rows the feed never renders.
+func myGroupsCountUnfiltered(db *gorm.DB, myid uint64) uint64 {
+	var count uint64 = 0
+	db.Raw("SELECT COUNT(DISTINCT ms.msgid) FROM messages_spatial ms "+
+		"LEFT JOIN messages_likes ml ON ml.msgid = ms.msgid AND ml.userid = ? AND ml.type = ? "+
+		"WHERE ms.successful = 0 AND ml.msgid IS NULL "+
+		"AND EXISTS (SELECT 1 FROM messages_groups mg "+
+		"INNER JOIN memberships mem ON mem.groupid = mg.groupid "+
+		"WHERE mg.msgid = ms.msgid AND mem.userid = ? "+
+		"AND mg.collection = 'Approved' AND mg.deleted = 0)", myid, utils.MESSAGE_LIKES_VIEW, myid).Scan(&count)
+	return count
+}
+
+// myGroupsCount is the unseen-post count for the 'mygroups' browse view. maxDistanceMiles narrows
+// it to posts within that many miles of the viewer using the SAME blurred-coordinate Haversine the
+// feed exposes as `distance` (reachCandidateRow.blurredDistanceMiles), so the nav badge tracks the
+// distance-filtered list exactly. BrowseDistanceUnlimited (the common case — most members leave the
+// slider at "no limit") skips the per-post distance work and uses the fast unfiltered COUNT.
+func myGroupsCount(db *gorm.DB, myid uint64, maxDistanceMiles float64) uint64 {
+	if maxDistanceMiles >= BrowseDistanceUnlimited {
+		return myGroupsCountUnfiltered(db, myid)
+	}
+
+	latlng := user.GetLatLng(myid)
+	if latlng.Lat == 0 && latlng.Lng == 0 {
+		// No location to measure from — the slider can't be set without one, so this is a
+		// defensive fallback: count everything (as if unlimited) rather than zero the badge.
+		return myGroupsCountUnfiltered(db, myid)
+	}
+
+	// Distance-limited path: enumerate the same unseen member-group posts (with coordinates) the
+	// unfiltered count covers, and keep those within maxDistance of the viewer's blurred-point
+	// Haversine — the same measure the feed uses — so badge and list agree at the boundary.
+	viewerLat, viewerLng := float64(latlng.Lat), float64(latlng.Lng)
+	var candidates []reachCandidateRow
+	db.Raw("SELECT ST_Y(ms.point) AS lat, ST_X(ms.point) AS lng, ms.msgid AS id "+
+		"FROM messages_spatial ms "+
+		"LEFT JOIN messages_likes ml ON ml.msgid = ms.msgid AND ml.userid = ? AND ml.type = ? "+
+		"WHERE ms.successful = 0 AND ml.msgid IS NULL "+
+		"AND EXISTS (SELECT 1 FROM messages_groups mg "+
+		"INNER JOIN memberships mem ON mem.groupid = mg.groupid "+
+		"WHERE mg.msgid = ms.msgid AND mem.userid = ? "+
+		"AND mg.collection = 'Approved' AND mg.deleted = 0)", myid, utils.MESSAGE_LIKES_VIEW, myid).Scan(&candidates)
+
+	var count uint64 = 0
+	for _, cand := range candidates {
+		_, _, distanceMiles := cand.blurredDistanceMiles(viewerLat, viewerLng)
+		if distanceMiles <= maxDistanceMiles {
+			count++
+		}
+	}
+	return count
 }
 
 // resolveMaxDistance returns the viewer's effective nearby-feed distance limit in miles: an

--- a/iznik-server-go/test/mygroups_distance_test.go
+++ b/iznik-server-go/test/mygroups_distance_test.go
@@ -1,0 +1,126 @@
+package test
+
+import (
+	json2 "encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/freegle/iznik-server-go/message"
+	"github.com/stretchr/testify/assert"
+)
+
+// The 'mygroups' browse feed (GET /isochrone/message, browseView=mygroups) now stamps each
+// member-group post with a distance and a rippling relevance score — the same toSummary path the
+// nearby feed uses — so the distance slider and the "New to you" relevance sort work in this view
+// too, not just Nearby. A closer post must score higher and sort above a far one, and both carry a
+// non-negative distance.
+func TestMyGroupsFeedDistanceAndScore(t *testing.T) {
+	db := database.DBConn
+
+	prefix := uniquePrefix("myggdist")
+	posterID := CreateTestUser(t, prefix+"_poster", "Poster")
+	group := CreateTestGroup(t, prefix+"_member")
+
+	// 'near' at the viewer's location; 'far' ~44km (~27 miles) north — same group, same age, no
+	// views/replies, so the ONLY score difference is closeness.
+	near := CreateTestMessage(t, posterID, group, "OFFER: near mygroups distance (myggdist)", 51.5, -0.1)
+	far := CreateTestMessage(t, posterID, group, "OFFER: far mygroups distance (myggdist)", 51.9, -0.1)
+	// The browse feed shows open posts (messages_spatial.successful = 0); the helper inserts 1.
+	db.Exec("UPDATE messages_spatial SET successful = 0 WHERE msgid IN (?, ?)", near, far)
+	defer db.Exec("DELETE FROM messages_groups WHERE msgid IN (?, ?)", near, far)
+	defer db.Exec("DELETE FROM messages WHERE id IN (?, ?)", near, far)
+
+	// Viewer is a MEMBER of the group, browses the mygroups view, and has a known location.
+	viewerID, token := CreateFullTestUser(t, prefix+"_viewer")
+	db.Exec("INSERT INTO memberships (userid, groupid) VALUES (?, ?)", viewerID, group)
+	defer db.Exec("DELETE FROM memberships WHERE userid = ? AND groupid = ?", viewerID, group)
+	db.Exec("UPDATE users SET settings = JSON_SET(COALESCE(settings,'{}'), "+
+		"'$.browseView', 'mygroups', '$.mylocation', JSON_OBJECT('lat', 51.5, 'lng', -0.1)) WHERE id = ?", viewerID)
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/isochrone/message?jwt="+token, nil))
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var msgs []message.MessageSummary
+	json2.Unmarshal(rsp(resp), &msgs)
+
+	byID := map[uint64]message.MessageSummary{}
+	nearIdx, farIdx := -1, -1
+	for i, m := range msgs {
+		byID[m.ID] = m
+		if m.ID == near {
+			nearIdx = i
+		}
+		if m.ID == far {
+			farIdx = i
+		}
+	}
+
+	assert.Contains(t, byID, near, "member-group near post appears in the mygroups feed")
+	assert.Contains(t, byID, far, "member-group far post appears in the mygroups feed")
+
+	// Every post carries a non-negative distance (miles, viewer -> blurred coords), and the far
+	// post is meaningfully further than the near one.
+	assert.GreaterOrEqual(t, byID[near].Distance, 0.0, "near post has a non-negative distance")
+	assert.Greater(t, byID[far].Distance, byID[near].Distance,
+		"the ~27-mile post is further away than the one at the viewer's location")
+
+	// The relevance score is populated and closeness-weighted: the near post scores strictly
+	// higher and sorts above the far one (was 0 for every mygroups post before this change).
+	assert.Greater(t, byID[near].Score, byID[far].Score,
+		"a closer member-group post scores higher than a farther one")
+	assert.Greater(t, byID[near].Score, 0.0, "mygroups posts now carry a non-zero relevance score")
+	assert.Less(t, nearIdx, farIdx, "the near post sorts above the far post in the mygroups feed")
+}
+
+// TestMyGroupsCountDistanceLimit: the nav badge for the 'mygroups' view (GET /message/count) now
+// narrows to posts within maxDistance miles of the viewer — the SAME blurred-coordinate Haversine
+// the feed exposes as `distance` — so the badge tracks the distance-filtered list. Both an explicit
+// ?maxDistance= and the saved settings.browseMaxDistance are honoured.
+func TestMyGroupsCountDistanceLimit(t *testing.T) {
+	db := database.DBConn
+
+	prefix := uniquePrefix("myggcountdist")
+	posterID := CreateTestUser(t, prefix+"_poster", "Poster")
+	group := CreateTestGroup(t, prefix+"_member")
+
+	near := CreateTestMessage(t, posterID, group, "OFFER: near mygroups count (myggcountdist)", 51.5, -0.1)
+	far := CreateTestMessage(t, posterID, group, "OFFER: far mygroups count (myggcountdist)", 51.9, -0.1)
+	db.Exec("UPDATE messages_spatial SET successful = 0 WHERE msgid IN (?, ?)", near, far)
+	defer db.Exec("DELETE FROM messages_groups WHERE msgid IN (?, ?)", near, far)
+	defer db.Exec("DELETE FROM messages WHERE id IN (?, ?)", near, far)
+
+	viewerID, token := CreateFullTestUser(t, prefix+"_viewer")
+	db.Exec("INSERT INTO memberships (userid, groupid) VALUES (?, ?)", viewerID, group)
+	defer db.Exec("DELETE FROM memberships WHERE userid = ? AND groupid = ?", viewerID, group)
+	db.Exec("UPDATE users SET settings = JSON_SET(COALESCE(settings,'{}'), "+
+		"'$.browseView', 'mygroups', '$.mylocation', JSON_OBJECT('lat', 51.5, 'lng', -0.1)) WHERE id = ?", viewerID)
+
+	// No limit: both unseen member-group posts are counted.
+	unlimitedResp, _ := getApp().Test(httptest.NewRequest("GET", "/api/message/count?jwt="+token, nil))
+	assert.Equal(t, 200, unlimitedResp.StatusCode)
+	var unlimitedBody map[string]interface{}
+	json2.Unmarshal(rsp(unlimitedResp), &unlimitedBody)
+	unlimitedCount := unlimitedBody["count"].(float64)
+	assert.GreaterOrEqual(t, unlimitedCount, float64(2),
+		"with no distance limit, the mygroups count includes both unseen posts")
+
+	// maxDistance=10 (miles): 'near' (≈0mi) is within it, 'far' (≈27mi) is not.
+	limitedResp, _ := getApp().Test(httptest.NewRequest("GET", "/api/message/count?jwt="+token+"&maxDistance=10", nil))
+	assert.Equal(t, 200, limitedResp.StatusCode)
+	var limitedBody map[string]interface{}
+	json2.Unmarshal(rsp(limitedResp), &limitedBody)
+	limitedCount := limitedBody["count"].(float64)
+	assert.GreaterOrEqual(t, limitedCount, float64(1), "the near post is still counted within a 10-mile limit")
+	assert.Less(t, limitedCount, unlimitedCount,
+		"a 10-mile limit excludes the ~27-mile post, so the mygroups count drops below unlimited")
+
+	// settings.browseMaxDistance is honoured server-side too (no query param needed).
+	db.Exec("UPDATE users SET settings = JSON_SET(COALESCE(settings,'{}'), '$.browseMaxDistance', 10) WHERE id = ?", viewerID)
+	settingResp, _ := getApp().Test(httptest.NewRequest("GET", "/api/message/count?jwt="+token, nil))
+	assert.Equal(t, 200, settingResp.StatusCode)
+	var settingBody map[string]interface{}
+	json2.Unmarshal(rsp(settingResp), &settingBody)
+	assert.Equal(t, limitedCount, settingBody["count"].(float64),
+		"settings.browseMaxDistance is honoured for mygroups, matching the explicit query param")
+}


### PR DESCRIPTION
## Summary

The Browse distance slider and the "New to you" relevance ordering previously worked **only in the Nearby view**. In "All my groups" or a single group they were inert: the `mygroups` feed returned every post with `distance: 0` and `score: 0`, so the slider filtered nothing (`0 ≤ any limit` always passes) and "New to you" silently degraded to unseen-first-then-DB-order. This makes both work in **every** "Show posts from" view.

- **Frontend (`PostFilters.vue`)** — show the distance slider in every "Show posts from" view when the viewer has a location (was gated to `browseView === 'nearby'`).
- **Go (`isochrone/message.go` `myGroupsMessages`)** — score and distance-stamp each member-group post through the same `reachCandidateRow.toSummary()` path the Nearby feed uses (per-post views/replies + reach radius, which falls back to the default extent since member-group posts have no reach row of their own), ordered by relevance. Falls back to the prior blur-only behaviour when the viewer has no location.
- **Go (`Count`)** — the `mygroups` nav badge now honours the slider: when `maxDistance` is set it counts only unseen member-group posts within that many miles, using the SAME blurred-coordinate Haversine the feed exposes as `distance`, so badge and list agree at the boundary. Extracted `myGroupsCountUnfiltered` to keep the fast unlimited-count path.

## Code Quality Review

- Distance and score come from ONE place (`blurredDistanceMiles` / `toSummary`), shared by the Nearby feed, the mygroups feed and the count, so feed/map/badge can't drift at the distance boundary.
- Behaviour preserved: no-location viewers get the old blur-only feed; pinned-first ordering preserved (applied above the relevance sort); the unlimited count still uses the original fast `COUNT`.

## Future Improvements

- `myGroupsMessages` runs per-row correlated subqueries (views/replies) over the full member-group post set, mirroring the Nearby arm. For very heavy-membership users this could be optimised to JOIN-based aggregation.
- The "we show posts near you first" help text stays Nearby-only; a mygroups-specific explainer could be added later.

## Test Plan

- **Frontend** — `PostFilters.spec.js`: inverted the old "hides the slider outside the nearby view" test to assert the slider now shows in the mygroups view when the viewer has a location. 52/52 pass.
- **Go** — `TestMyGroupsFeedDistanceAndScore` (mygroups posts carry a non-negative distance and a non-zero, closeness-weighted relevance score; the closer post scores higher and sorts first) and `TestMyGroupsCountDistanceLimit` (the mygroups badge drops when a far post falls outside `maxDistance`; `settings.browseMaxDistance` is honoured server-side).
- Full Go + Vitest suites via CI.
