### PR TITLE
feat(clearance): logged-out secret-link page to update bulk-offer availability

### DIFF
--- a/iznik-batch/database/migrations/2026_07_03_000001_add_available_to_messages_bulk_items_table.php
+++ b/iznik-batch/database/migrations/2026_07_03_000001_add_available_to_messages_bulk_items_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Add `available` to messages_bulk_items so the offerer - including an external
+ * owner using the logged-out secret-link update page - can mark an individual
+ * catalogue item taken/gone independently of its quantity. messages.availablenow
+ * is recomputed as the sum of quantities across items still marked available.
+ * Defaults to 1 so every existing item reads as available.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasColumn('messages_bulk_items', 'available')) {
+            return;
+        }
+
+        Schema::table('messages_bulk_items', function (Blueprint $table) {
+            $table->boolean('available')->default(true)->after('quantity')
+                ->comment('Owner flag: is this item still on offer (0 = taken/gone elsewhere)');
+        });
+    }
+
+    public function down(): void
+    {
+        if (!Schema::hasColumn('messages_bulk_items', 'available')) {
+            return;
+        }
+
+        Schema::table('messages_bulk_items', function (Blueprint $table) {
+            $table->dropColumn('available');
+        });
+    }
+};

--- a/iznik-batch/database/migrations/2026_07_03_000001_add_available_to_messages_bulk_items_table_migration.sql
+++ b/iznik-batch/database/migrations/2026_07_03_000001_add_available_to_messages_bulk_items_table_migration.sql
@@ -1,0 +1,12 @@
+-- Production idempotent SQL: messages_bulk_items.available (bulk-offer external update link).
+-- Lets the offerer / an external owner (via the logged-out secret-link page) mark a single
+-- catalogue item taken/gone independently of its quantity; messages.availablenow is recomputed
+-- as the sum of quantities across items still marked available. NOT NULL DEFAULT 1 -> existing
+-- items read as available. Positioned bool -> INSTANT add in MySQL 8. Run once on production
+-- BEFORE deploying.
+SET @col_exists := (SELECT COUNT(*) FROM information_schema.columns
+    WHERE table_schema = DATABASE() AND table_name = 'messages_bulk_items' AND column_name = 'available');
+SET @ddl := IF(@col_exists = 0,
+    'ALTER TABLE messages_bulk_items ADD COLUMN available TINYINT(1) NOT NULL DEFAULT 1 AFTER quantity',
+    'SELECT 1');
+PREPARE stmt FROM @ddl; EXECUTE stmt; DEALLOCATE PREPARE stmt;

--- a/iznik-batch/database/migrations/2026_07_03_000002_add_edittoken_to_messages_bulk_access_table.php
+++ b/iznik-batch/database/migrations/2026_07_03_000002_add_edittoken_to_messages_bulk_access_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Add `edittoken` to messages_bulk_access: an unguessable secret that lets an
+ * external item-owner open a logged-out page to update this bulk offer's item
+ * availability/counts (see the Go /bulkoffer/update endpoints). One token per
+ * offer (messages_bulk_access has one row per msgid); nulling it revokes the link.
+ * No login is granted - the token only authorises availability/count edits on
+ * this one offer, and exposes no replier data.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasColumn('messages_bulk_access', 'edittoken')) {
+            return;
+        }
+
+        Schema::table('messages_bulk_access', function (Blueprint $table) {
+            $table->string('edittoken', 64)->nullable()->after('accessinstructions')
+                ->comment('Secret token for the logged-out availability-update page');
+            $table->unique('edittoken');
+        });
+    }
+
+    public function down(): void
+    {
+        if (!Schema::hasColumn('messages_bulk_access', 'edittoken')) {
+            return;
+        }
+
+        Schema::table('messages_bulk_access', function (Blueprint $table) {
+            $table->dropUnique(['edittoken']);
+            $table->dropColumn('edittoken');
+        });
+    }
+};

--- a/iznik-batch/database/migrations/2026_07_03_000002_add_edittoken_to_messages_bulk_access_table_migration.sql
+++ b/iznik-batch/database/migrations/2026_07_03_000002_add_edittoken_to_messages_bulk_access_table_migration.sql
@@ -1,0 +1,17 @@
+-- Production idempotent SQL: messages_bulk_access.edittoken (bulk-offer external update link).
+-- Unguessable per-offer secret authorising the logged-out availability-update page. One row per
+-- msgid; NULL = no link issued. Adds a UNIQUE index for fast, safe token lookup (MySQL allows
+-- multiple NULLs in a unique index). Run once on production BEFORE deploying.
+SET @col_exists := (SELECT COUNT(*) FROM information_schema.columns
+    WHERE table_schema = DATABASE() AND table_name = 'messages_bulk_access' AND column_name = 'edittoken');
+SET @ddl := IF(@col_exists = 0,
+    'ALTER TABLE messages_bulk_access ADD COLUMN edittoken VARCHAR(64) NULL DEFAULT NULL AFTER accessinstructions',
+    'SELECT 1');
+PREPARE stmt FROM @ddl; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @idx_exists := (SELECT COUNT(*) FROM information_schema.statistics
+    WHERE table_schema = DATABASE() AND table_name = 'messages_bulk_access' AND index_name = 'messages_bulk_access_edittoken_unique');
+SET @ddl2 := IF(@idx_exists = 0,
+    'ALTER TABLE messages_bulk_access ADD UNIQUE INDEX messages_bulk_access_edittoken_unique (edittoken)',
+    'SELECT 1');
+PREPARE stmt2 FROM @ddl2; EXECUTE stmt2; DEALLOCATE PREPARE stmt2;

--- a/iznik-nuxt3/api/MessageAPI.js
+++ b/iznik-nuxt3/api/MessageAPI.js
@@ -300,4 +300,30 @@ export default class MessageAPI extends BaseAPI {
       false
     )
   }
+
+  // --- Bulk-offer ("clearance") logged-out update link ---------------------
+
+  // Mint (or fetch the existing) secret link that lets an external owner update
+  // this bulk offer's item availability/counts without logging in. Owner/mod only.
+  async bulkEditLink(id) {
+    return await this.$postv2('/message', { id, action: 'BulkEditLink' })
+  }
+
+  // Load a bulk offer's catalogue from a secret update-link token (logged out).
+  // logError defaults to false so a stale/typo'd link doesn't spam Sentry.
+  async fetchBulkEditOffer(token, logError = false) {
+    return await this.$getv2(
+      '/bulkoffer/update/' + encodeURIComponent(token),
+      {},
+      logError
+    )
+  }
+
+  // Update one item's availability and/or count from the logged-out page.
+  async updateBulkEditItem(token, itemid, changes) {
+    return await this.$postv2('/bulkoffer/update/' + encodeURIComponent(token), {
+      itemid,
+      ...changes,
+    })
+  }
 }

--- a/iznik-nuxt3/components/BulkOfferUpdateItem.vue
+++ b/iznik-nuxt3/components/BulkOfferUpdateItem.vue
@@ -1,0 +1,249 @@
+<template>
+  <div
+    class="bulkupdate-item"
+    :class="{ 'bulkupdate-item--taken': !item.available }"
+    :data-testid="'bulkupdate-item-' + item.id"
+  >
+    <div class="bulkupdate-item__head">
+      <div class="bulkupdate-item__photo">
+        <img
+          v-if="item.photo"
+          :src="item.photo"
+          alt=""
+          loading="lazy"
+          @error="brokenImage"
+        />
+        <v-icon v-else icon="image" class="bulkupdate-item__nophoto" />
+      </div>
+      <div class="bulkupdate-item__title">
+        <span class="bulkupdate-item__ref">#{{ index + 1 }}</span>
+        <span class="bulkupdate-item__name">{{ item.name }}</span>
+        <b-badge
+          v-if="item.condition && item.condition !== 'Unknown'"
+          variant="info"
+        >
+          {{ conditionLabel }}
+        </b-badge>
+        <span
+          v-if="item.dimensions"
+          class="bulkupdate-item__dims small text-muted"
+        >
+          {{ item.dimensions }}
+        </span>
+      </div>
+    </div>
+
+    <div class="bulkupdate-item__controls">
+      <!-- Available / taken toggle -->
+      <div class="bulkupdate-item__avail">
+        <b-form-checkbox
+          v-model="availableModel"
+          switch
+          :disabled="saving"
+          :data-testid="'bulkupdate-toggle-' + item.id"
+        >
+          <span v-if="item.available" class="text-success fw-semibold"
+            >Available</span
+          >
+          <span v-else class="text-muted fw-semibold">Taken / gone</span>
+        </b-form-checkbox>
+      </div>
+
+      <!-- Count editor -->
+      <div class="bulkupdate-item__count" :class="{ 'is-muted': !item.available }">
+        <label :for="'bulkupdate-qty-' + item.id" class="small mb-0 me-1">
+          Number available
+        </label>
+        <b-button
+          variant="outline-secondary"
+          size="sm"
+          :disabled="saving || count <= 0"
+          aria-label="Decrease"
+          :data-testid="'bulkupdate-dec-' + item.id"
+          @click="step(-1)"
+        >
+          <v-icon icon="minus" />
+        </b-button>
+        <b-form-input
+          :id="'bulkupdate-qty-' + item.id"
+          v-model.number="count"
+          type="number"
+          min="0"
+          class="bulkupdate-item__qtyinput"
+          :disabled="saving"
+          :data-testid="'bulkupdate-qty-' + item.id"
+          @change="commitCount"
+          @blur="commitCount"
+        />
+        <b-button
+          variant="outline-secondary"
+          size="sm"
+          :disabled="saving"
+          aria-label="Increase"
+          :data-testid="'bulkupdate-inc-' + item.id"
+          @click="step(1)"
+        >
+          <v-icon icon="plus" />
+        </b-button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, watch } from 'vue'
+
+const props = defineProps({
+  // One catalogue item: { id, name, quantity, condition, dimensions, available, photo }.
+  item: { type: Object, required: true },
+  // Zero-based position, for the #N reference.
+  index: { type: Number, default: 0 },
+  // Disable the controls while a save is in flight.
+  saving: { type: Boolean, default: false },
+})
+
+const emit = defineEmits(['update'])
+
+// Local count, kept in step with the item (the server is the source of truth:
+// the parent updates the prop from the API response after each change).
+const count = ref(props.item.quantity)
+watch(
+  () => props.item.quantity,
+  (v) => {
+    count.value = v
+  }
+)
+
+// The switch's two-way model: flipping it emits an availability change. We don't
+// mutate the prop directly - the parent re-renders us from the API response.
+const availableModel = computed({
+  get: () => !!props.item.available,
+  set: (val) => {
+    if (val !== !!props.item.available) {
+      emit('update', { itemid: props.item.id, available: val })
+    }
+  },
+})
+
+function step(delta) {
+  const next = Math.max(0, (parseInt(count.value, 10) || 0) + delta)
+  count.value = next
+  emit('update', { itemid: props.item.id, quantity: next })
+}
+
+function commitCount() {
+  let next = parseInt(count.value, 10)
+  if (isNaN(next) || next < 0) next = 0
+  count.value = next
+  if (next !== props.item.quantity) {
+    emit('update', { itemid: props.item.id, quantity: next })
+  }
+}
+
+const conditionLabel = computed(() =>
+  props.item.condition === 'LikeNew' ? 'Like new' : props.item.condition
+)
+
+function brokenImage(event) {
+  event.target.style.display = 'none'
+}
+
+defineExpose({ count, availableModel, step, commitCount })
+</script>
+
+<style scoped lang="scss">
+@import 'bootstrap/scss/functions';
+@import 'assets/css/_color-vars.scss';
+
+.bulkupdate-item {
+  border: 1px solid $color-gray--light;
+  border-radius: 8px;
+  padding: 0.85rem 1rem;
+  margin-bottom: 0.85rem;
+  background-color: $color-white;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+  transition: opacity 0.15s ease;
+}
+
+/* A taken item is dimmed so the eye skips to what's still available. */
+.bulkupdate-item--taken {
+  opacity: 0.65;
+  background-color: $color-gray--lighter;
+}
+.bulkupdate-item--taken .bulkupdate-item__name {
+  text-decoration: line-through;
+}
+
+.bulkupdate-item__head {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.bulkupdate-item__photo {
+  flex: 0 0 48px;
+  width: 48px;
+  height: 48px;
+  border-radius: 5px;
+  overflow: hidden;
+  background-color: $color-gray--lighter;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+}
+
+.bulkupdate-item__nophoto {
+  color: $color-gray--normal;
+}
+
+.bulkupdate-item__title {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.bulkupdate-item__ref {
+  color: $color-gray--normal;
+  font-size: 0.85em;
+}
+
+.bulkupdate-item__name {
+  font-weight: 600;
+}
+
+.bulkupdate-item__dims {
+  flex-basis: 100%;
+}
+
+.bulkupdate-item__controls {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.75rem 1.25rem;
+  margin-top: 0.6rem;
+}
+
+.bulkupdate-item__count {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+
+  &.is-muted {
+    opacity: 0.7;
+  }
+}
+
+.bulkupdate-item__qtyinput {
+  width: 4.5rem;
+  text-align: center;
+}
+</style>

--- a/iznik-nuxt3/components/ClearanceManager.vue
+++ b/iznik-nuxt3/components/ClearanceManager.vue
@@ -144,6 +144,48 @@
         </b-button>
       </div>
 
+      <!-- A secret link so an external owner (e.g. someone giving items away
+           through other channels too) can keep availability up to date without
+           a Freegle login. Only the item list + counts are exposed - no replies. -->
+      <div
+        class="clearance-manager__sharelink mb-3"
+        data-testid="clearance-sharelink-section"
+      >
+        <b-button
+          v-if="!shareLink"
+          variant="outline-primary"
+          size="sm"
+          :disabled="shareLoading"
+          data-testid="clearance-sharelink-get"
+          @click="getShareLink"
+        >
+          <b-spinner v-if="shareLoading" small class="me-1" />
+          <v-icon v-else icon="link" /> Get an update link to share
+        </b-button>
+        <div v-else data-testid="clearance-sharelink-ready">
+          <label class="small text-muted d-block mb-1">
+            Send this to whoever manages the items - they can update what's left
+            (available/taken and how many) without logging in:
+          </label>
+          <div class="d-flex gap-2 align-items-center">
+            <b-form-input
+              :model-value="shareLink"
+              readonly
+              class="flex-grow-1"
+              data-testid="clearance-sharelink-input"
+              @focus="selectAll"
+            />
+            <b-button
+              variant="outline-secondary"
+              data-testid="clearance-sharelink-copy"
+              @click="copyShareLink"
+            >
+              {{ shareCopied ? 'Copied!' : 'Copy' }}
+            </b-button>
+          </div>
+        </div>
+      </div>
+
       <ClearanceManageItem
         v-for="(item, idx) in items"
         :key="item.id"
@@ -159,7 +201,7 @@
 
 <script setup>
 import { computed, ref, watch, onMounted, onUnmounted } from 'vue'
-import { useRouter } from '#imports'
+import { useRouter, useRuntimeConfig, useNuxtApp } from '#imports'
 import { useMessageStore } from '~/stores/message'
 import { useUserStore } from '~/stores/user'
 import { useMe } from '~/composables/useMe'
@@ -180,6 +222,45 @@ const messageStore = useMessageStore()
 const userStore = useUserStore()
 const { myid } = useMe()
 const router = useRouter()
+const runtimeConfig = useRuntimeConfig()
+const { $api } = useNuxtApp()
+
+// Secret update-link sharing (for an external item-owner).
+const shareLink = ref('')
+const shareLoading = ref(false)
+const shareCopied = ref(false)
+
+async function getShareLink() {
+  shareLoading.value = true
+  try {
+    const res = await $api.message.bulkEditLink(props.id)
+    if (res?.token) {
+      const base =
+        runtimeConfig.public?.USER_SITE || 'https://www.ilovefreegle.org'
+      shareLink.value = base + '/clearance/update/' + res.token
+    }
+  } catch (e) {
+    console.error('Failed to get update link', e)
+  } finally {
+    shareLoading.value = false
+  }
+}
+
+async function copyShareLink() {
+  try {
+    await navigator.clipboard.writeText(shareLink.value)
+    shareCopied.value = true
+    setTimeout(() => {
+      shareCopied.value = false
+    }, 2000)
+  } catch (e) {
+    // Clipboard blocked (e.g. insecure context) - the field is selectable to copy manually.
+  }
+}
+
+function selectAll(e) {
+  e.target.select()
+}
 
 // Open the create/edit form pre-loaded with this clearance for editing.
 function goEdit() {
@@ -370,6 +451,11 @@ defineExpose({
   onResolve,
   localAccessInstructions,
   saveAccessInstructions,
+  shareLink,
+  shareLoading,
+  shareCopied,
+  getShareLink,
+  copyShareLink,
 })
 </script>
 

--- a/iznik-nuxt3/composables/useBulkOfferUpdate.js
+++ b/iznik-nuxt3/composables/useBulkOfferUpdate.js
@@ -1,0 +1,79 @@
+import { ref } from 'vue'
+import { useNuxtApp } from '#imports'
+
+// Drives the logged-out bulk-offer availability page, authorised by a secret
+// link token. Loads the catalogue and pushes each availability/count change to
+// the token-gated API, re-syncing the list from the server response so the UI
+// never shows an unsaved state as saved. Kept as a composable (not inline in the
+// page) so the logic is unit-testable without a dynamic-route bracket import.
+export function useBulkOfferUpdate(token) {
+  const { $api } = useNuxtApp()
+
+  const loading = ref(true)
+  const notFound = ref(false)
+  const offer = ref({ id: 0, subject: '', items: [] })
+  const savingId = ref(null)
+  const savedFlash = ref(false)
+  const saveError = ref(false)
+
+  let flashTimer = null
+  function flashSaved() {
+    saveError.value = false
+    savedFlash.value = true
+    if (flashTimer) clearTimeout(flashTimer)
+    flashTimer = setTimeout(() => {
+      savedFlash.value = false
+    }, 2000)
+  }
+
+  async function load() {
+    loading.value = true
+    notFound.value = false
+    try {
+      const res = await $api.message.fetchBulkEditOffer(token)
+      if (!res || res.ret !== 0 || !Array.isArray(res.items)) {
+        notFound.value = true
+      } else {
+        offer.value = { id: res.id, subject: res.subject, items: res.items }
+      }
+    } catch (e) {
+      notFound.value = true
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function onUpdate({ itemid, available, quantity }) {
+    const changes = {}
+    if (available !== undefined) changes.available = available
+    if (quantity !== undefined) changes.quantity = quantity
+    savingId.value = itemid
+    saveError.value = false
+    try {
+      const res = await $api.message.updateBulkEditItem(token, itemid, changes)
+      if (res && res.ret === 0 && Array.isArray(res.items)) {
+        offer.value = { ...offer.value, items: res.items }
+        flashSaved()
+      } else {
+        saveError.value = true
+      }
+    } catch (e) {
+      saveError.value = true
+      // Re-sync from the server so the UI never shows an unsaved state as saved.
+      await load()
+    } finally {
+      savingId.value = null
+    }
+  }
+
+  return {
+    loading,
+    notFound,
+    offer,
+    savingId,
+    savedFlash,
+    saveError,
+    load,
+    onUpdate,
+  }
+}

--- a/iznik-nuxt3/pages/clearance/update/[token].vue
+++ b/iznik-nuxt3/pages/clearance/update/[token].vue
@@ -1,0 +1,105 @@
+<template>
+  <client-only>
+    <b-container class="py-3">
+      <b-row>
+        <b-col cols="12" lg="8" offset-lg="2">
+          <div v-if="loading" class="text-center my-5" data-testid="bulkupdate-loading">
+            <b-spinner variant="success" />
+            <p class="text-muted mt-2">Loading the items…</p>
+          </div>
+
+          <NoticeMessage
+            v-else-if="notFound"
+            variant="warning"
+            data-testid="bulkupdate-notfound"
+          >
+            <h4 class="mb-1">This link isn't valid</h4>
+            <p class="mb-0">
+              The update link may be wrong or may have been withdrawn. Please
+              check the link, or ask whoever sent it to you for a fresh one.
+            </p>
+          </NoticeMessage>
+
+          <template v-else>
+            <h1 class="bulkupdate__title" data-testid="bulkupdate-title">
+              Update what's still available
+            </h1>
+            <p class="text-muted">
+              These are the items in
+              <strong>{{ offer.subject }}</strong
+              >. If you've given some away elsewhere, switch them to
+              <em>taken</em> or change the number left, so Freeglers only ask for
+              what's still going. Your changes save as you make them - no login
+              needed.
+            </p>
+
+            <div
+              v-if="savedFlash"
+              class="bulkupdate__saved small text-success mb-2"
+              data-testid="bulkupdate-saved"
+            >
+              <v-icon icon="check" /> Saved
+            </div>
+            <NoticeMessage
+              v-if="saveError"
+              variant="danger"
+              data-testid="bulkupdate-error"
+            >
+              Sorry, that didn't save - please try again.
+            </NoticeMessage>
+
+            <BulkOfferUpdateItem
+              v-for="(item, idx) in offer.items"
+              :key="item.id"
+              :item="item"
+              :index="idx"
+              :saving="savingId === item.id"
+              @update="onUpdate"
+            />
+
+            <p class="text-muted small mt-3">
+              Thanks for keeping this up to date - it saves everyone a wasted
+              journey.
+            </p>
+          </template>
+        </b-col>
+      </b-row>
+    </b-container>
+  </client-only>
+</template>
+
+<script setup>
+import { onMounted } from 'vue'
+import { useRoute } from '#imports'
+import NoticeMessage from '~/components/NoticeMessage'
+import BulkOfferUpdateItem from '~/components/BulkOfferUpdateItem'
+import { useBulkOfferUpdate } from '~/composables/useBulkOfferUpdate'
+
+// Public, logged-out page: no login layout, no forceLogin. The secret token in
+// the URL is the sole credential and only authorises availability/count edits to
+// this one offer. All the logic lives in useBulkOfferUpdate (unit-tested).
+definePageMeta({
+  layout: 'default',
+})
+
+const route = useRoute()
+const {
+  loading,
+  notFound,
+  offer,
+  savingId,
+  savedFlash,
+  saveError,
+  load,
+  onUpdate,
+} = useBulkOfferUpdate(route.params.token)
+
+onMounted(load)
+</script>
+
+<style scoped lang="scss">
+.bulkupdate__title {
+  font-size: 1.5rem;
+  font-weight: 700;
+}
+</style>

--- a/iznik-nuxt3/tests/unit/components/BulkOfferUpdateItem.spec.js
+++ b/iznik-nuxt3/tests/unit/components/BulkOfferUpdateItem.spec.js
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import BulkOfferUpdateItem from '~/components/BulkOfferUpdateItem.vue'
+
+function makeItem(overrides = {}) {
+  return {
+    id: 10,
+    name: 'Filing cabinet',
+    quantity: 4,
+    condition: 'Good',
+    dimensions: '120x80cm',
+    available: true,
+    photo: 'https://images.example/timg_1.jpg',
+    ...overrides,
+  }
+}
+
+function mountItem(item, props = {}) {
+  return mount(BulkOfferUpdateItem, {
+    props: { item, index: 0, ...props },
+  })
+}
+
+describe('BulkOfferUpdateItem', () => {
+  it('renders the item name, condition and dimensions', () => {
+    const w = mountItem(makeItem())
+    expect(w.text()).toContain('Filing cabinet')
+    expect(w.text()).toContain('Good')
+    expect(w.text()).toContain('120x80cm')
+    expect(w.find('img').attributes('src')).toContain('timg_1.jpg')
+  })
+
+  it('maps LikeNew to a friendly "Like new" label', () => {
+    const w = mountItem(makeItem({ condition: 'LikeNew' }))
+    expect(w.text()).toContain('Like new')
+  })
+
+  it('emits an availability change when the toggle is switched off', async () => {
+    const w = mountItem(makeItem())
+    const cb = w.find('[data-testid="bulkupdate-toggle-10"] input')
+    await cb.setValue(false)
+    const ev = w.emitted('update')
+    expect(ev).toBeTruthy()
+    expect(ev[0][0]).toEqual({ itemid: 10, available: false })
+  })
+
+  it('increments the count and emits the new quantity', async () => {
+    const w = mountItem(makeItem())
+    await w.find('[data-testid="bulkupdate-inc-10"]').trigger('click')
+    const ev = w.emitted('update')
+    expect(ev[0][0]).toEqual({ itemid: 10, quantity: 5 })
+  })
+
+  it('decrements the count but never below zero', async () => {
+    const w = mountItem(makeItem({ quantity: 1 }))
+    await w.find('[data-testid="bulkupdate-dec-10"]').trigger('click')
+    expect(w.emitted('update')[0][0]).toEqual({ itemid: 10, quantity: 0 })
+  })
+
+  it('commits a typed count on change', async () => {
+    const w = mountItem(makeItem())
+    const input = w.find('[data-testid="bulkupdate-qty-10"]')
+    input.element.value = '2'
+    await input.trigger('input')
+    await input.trigger('change')
+    const ev = w.emitted('update')
+    expect(ev[ev.length - 1][0]).toEqual({ itemid: 10, quantity: 2 })
+  })
+
+  it('shows a taken item as struck-through/dimmed', () => {
+    const w = mountItem(makeItem({ available: false }))
+    expect(w.classes()).toContain('bulkupdate-item--taken')
+  })
+
+  it('shows a placeholder when there is no photo', () => {
+    const w = mountItem(makeItem({ photo: '' }))
+    expect(w.find('img').exists()).toBe(false)
+    expect(w.find('.bulkupdate-item__nophoto').exists()).toBe(true)
+  })
+})

--- a/iznik-nuxt3/tests/unit/components/ClearanceManagerShareLink.spec.js
+++ b/iznik-nuxt3/tests/unit/components/ClearanceManagerShareLink.spec.js
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+
+// The bulk offer the manager renders (owner === me).
+const mockMessage = {
+  id: 1,
+  subject: 'Office clearance',
+  fromuser: 99,
+  bulkcount: 1,
+  bulkitems: [{ id: 10, position: 0, name: 'Cabinet', quantity: 2, interest: [] }],
+}
+
+const bulkEditLink = vi.hoisted(() => vi.fn())
+
+vi.mock('~/stores/message', () => ({
+  useMessageStore: () => ({ byId: () => mockMessage, fetch: vi.fn() }),
+}))
+vi.mock('~/stores/user', () => ({
+  useUserStore: () => ({ fetchMultiple: vi.fn(), byId: () => null }),
+}))
+vi.mock('~/composables/useMe', () => ({
+  useMe: () => ({ myid: { value: 99 } }),
+}))
+vi.mock('~/components/NoticeMessage', () => ({
+  default: { name: 'NoticeMessage', template: '<div class="notice-stub"><slot /></div>' },
+}))
+vi.mock('~/components/ClearanceManageItem', () => ({
+  default: { name: 'ClearanceManageItem', template: '<div class="item-stub" />', props: ['message', 'item', 'index'] },
+}))
+vi.mock('~/components/HelperProposalCard', () => ({
+  default: { name: 'HelperProposalCard', template: '<div class="proposal-stub" />' },
+}))
+
+// #imports supplies the Nuxt composables the component uses, incl. a fake $api.
+vi.mock('#imports', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  useRuntimeConfig: () => ({ public: { USER_SITE: 'https://www.ilovefreegle.org' } }),
+  useNuxtApp: () => ({ $api: { message: { bulkEditLink } } }),
+}))
+
+import ClearanceManager from '~/components/ClearanceManager.vue'
+
+const mountOpts = {
+  props: { id: 1 },
+  global: { stubs: { 'b-spinner': true, 'b-form-textarea': true } },
+}
+
+describe('ClearanceManager share update link', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    bulkEditLink.mockResolvedValue({ ret: 0, token: 'abc123token' })
+  })
+
+  it('offers a "Get an update link" button to the owner', () => {
+    const w = mount(ClearanceManager, mountOpts)
+    expect(w.find('[data-testid="clearance-sharelink-get"]').exists()).toBe(true)
+  })
+
+  it('mints a link and shows a shareable /clearance/update URL', async () => {
+    const w = mount(ClearanceManager, mountOpts)
+    await w.find('[data-testid="clearance-sharelink-get"]').trigger('click')
+    await flushPromises()
+    expect(bulkEditLink).toHaveBeenCalledWith(1)
+    expect(w.vm.shareLink).toBe(
+      'https://www.ilovefreegle.org/clearance/update/abc123token'
+    )
+    expect(w.find('[data-testid="clearance-sharelink-input"]').exists()).toBe(true)
+  })
+})

--- a/iznik-nuxt3/tests/unit/composables/useBulkOfferUpdate.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useBulkOfferUpdate.spec.js
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Fake v2 API injected via $api.message.
+const api = vi.hoisted(() => ({
+  fetchBulkEditOffer: vi.fn(),
+  updateBulkEditItem: vi.fn(),
+}))
+
+vi.mock('#imports', () => ({
+  useNuxtApp: () => ({ $api: { message: api } }),
+}))
+
+import { useBulkOfferUpdate } from '~/composables/useBulkOfferUpdate'
+
+const offer = () => ({
+  ret: 0,
+  id: 5,
+  subject: 'Office clearance',
+  items: [
+    { id: 10, name: 'Cabinet', quantity: 2, available: true },
+    { id: 11, name: 'Desk', quantity: 1, available: true },
+  ],
+})
+
+describe('useBulkOfferUpdate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    api.fetchBulkEditOffer.mockResolvedValue(offer())
+    api.updateBulkEditItem.mockResolvedValue({
+      ret: 0,
+      items: [
+        { id: 10, name: 'Cabinet', quantity: 2, available: false },
+        { id: 11, name: 'Desk', quantity: 1, available: true },
+      ],
+    })
+  })
+
+  it('loads the offer by its token', async () => {
+    const c = useBulkOfferUpdate('tok123')
+    await c.load()
+    expect(api.fetchBulkEditOffer).toHaveBeenCalledWith('tok123')
+    expect(c.loading.value).toBe(false)
+    expect(c.notFound.value).toBe(false)
+    expect(c.offer.value.items).toHaveLength(2)
+    expect(c.offer.value.subject).toBe('Office clearance')
+  })
+
+  it('flags not-found for an invalid or withdrawn link', async () => {
+    api.fetchBulkEditOffer.mockResolvedValue({ ret: 1 })
+    const c = useBulkOfferUpdate('bad')
+    await c.load()
+    expect(c.notFound.value).toBe(true)
+  })
+
+  it('flags not-found when the fetch throws', async () => {
+    api.fetchBulkEditOffer.mockRejectedValue(new Error('network'))
+    const c = useBulkOfferUpdate('tok')
+    await c.load()
+    expect(c.notFound.value).toBe(true)
+    expect(c.loading.value).toBe(false)
+  })
+
+  it('sends an availability change and re-renders from the response', async () => {
+    const c = useBulkOfferUpdate('tok123')
+    await c.load()
+    await c.onUpdate({ itemid: 10, available: false })
+    expect(api.updateBulkEditItem).toHaveBeenCalledWith('tok123', 10, {
+      available: false,
+    })
+    expect(c.offer.value.items.find((i) => i.id === 10).available).toBe(false)
+    expect(c.savingId.value).toBe(null)
+  })
+
+  it('sends a quantity change', async () => {
+    const c = useBulkOfferUpdate('tok123')
+    await c.load()
+    await c.onUpdate({ itemid: 11, quantity: 3 })
+    expect(api.updateBulkEditItem).toHaveBeenCalledWith('tok123', 11, {
+      quantity: 3,
+    })
+  })
+
+  it('surfaces a save error when the update returns a non-zero ret', async () => {
+    api.updateBulkEditItem.mockResolvedValue({ ret: 1 })
+    const c = useBulkOfferUpdate('tok123')
+    await c.load()
+    await c.onUpdate({ itemid: 10, available: false })
+    expect(c.saveError.value).toBe(true)
+  })
+
+  it('re-syncs from the server when a save throws', async () => {
+    const c = useBulkOfferUpdate('tok123')
+    await c.load()
+    api.fetchBulkEditOffer.mockClear()
+    api.updateBulkEditItem.mockRejectedValueOnce(new Error('boom'))
+    await c.onUpdate({ itemid: 10, available: false })
+    expect(c.saveError.value).toBe(true)
+    expect(api.fetchBulkEditOffer).toHaveBeenCalled()
+  })
+})

--- a/iznik-server-go/message/bulkEdit.go
+++ b/iznik-server-go/message/bulkEdit.go
@@ -1,0 +1,265 @@
+package message
+
+// Logged-out "secret link" page for a bulk offer (clearance). An external
+// item-owner - who may give items away through other channels - opens a page at
+// /clearance/update/<token> and toggles each catalogue item available/taken and
+// edits its count, WITHOUT logging in.
+//
+// Security model (mirrors iznik-server-go/amp): the unguessable token in the URL
+// is the sole credential. It is stored once per offer on messages_bulk_access
+// (one row per msgid) and authorises ONLY availability/count edits to that one
+// offer - no session, no account access, and no replier/interest data is ever
+// returned. Nulling messages_bulk_access.edittoken revokes the link.
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/freegle/iznik-server-go/misc"
+	"github.com/gofiber/fiber/v2"
+	"gorm.io/gorm"
+)
+
+// generateEditToken returns a 32-char URL-safe random secret (192 bits of
+// entropy) for a bulk-offer edit link.
+func generateEditToken() (string, error) {
+	b := make([]byte, 24)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+// ensureBulkEditToken returns the offer's edit token, creating one on first use.
+// The token is stored on the per-offer messages_bulk_access row and is stable
+// across calls so a shared link keeps working; nulling the column revokes it. A
+// concurrent create is handled by re-reading the stored value.
+func ensureBulkEditToken(db *gorm.DB, msgid uint64) string {
+	var token string
+	db.Raw("SELECT COALESCE(edittoken, '') FROM messages_bulk_access WHERE msgid = ?", msgid).Scan(&token)
+	if token != "" {
+		return token
+	}
+	newTok, err := generateEditToken()
+	if err != nil || newTok == "" {
+		return ""
+	}
+	// COALESCE keeps any token another request set first (unique index also guards).
+	db.Exec("INSERT INTO messages_bulk_access (msgid, edittoken) VALUES (?, ?) "+
+		"ON DUPLICATE KEY UPDATE edittoken = COALESCE(edittoken, VALUES(edittoken))", msgid, newTok)
+	db.Raw("SELECT COALESCE(edittoken, '') FROM messages_bulk_access WHERE msgid = ?", msgid).Scan(&token)
+	return token
+}
+
+// resolveBulkEditToken maps a secret edit token to its offer, requiring the
+// message to still exist (not deleted) and to actually be a bulk offer. Returns 0
+// for an unknown/blank token.
+func resolveBulkEditToken(db *gorm.DB, token string) uint64 {
+	token = strings.TrimSpace(token)
+	// A real token is 32 URL-safe chars; refuse anything implausibly short so a
+	// blank/1-char guess can never match an empty column.
+	if len(token) < 16 {
+		return 0
+	}
+	var msgid uint64
+	db.Raw("SELECT a.msgid FROM messages_bulk_access a "+
+		"INNER JOIN messages m ON m.id = a.msgid AND m.deleted IS NULL "+
+		"WHERE a.edittoken = ? AND a.edittoken <> '' "+
+		"AND EXISTS (SELECT 1 FROM messages_bulk_items bi WHERE bi.msgid = a.msgid) LIMIT 1",
+		token).Scan(&msgid)
+	return msgid
+}
+
+// BulkEditItem is the privacy-trimmed per-item shape returned to the logged-out
+// owner page. It deliberately carries NO replier/interest data.
+type BulkEditItem struct {
+	ID         uint64  `json:"id"`
+	Position   uint    `json:"position"`
+	Name       string  `json:"name"`
+	Quantity   uint    `json:"quantity"`
+	Condition  string  `json:"condition"`
+	Dimensions *string `json:"dimensions"`
+	Available  bool    `json:"available"`
+	Photo      string  `json:"photo,omitempty"`
+}
+
+// bulkEditItems loads the catalogue for the logged-out page, resolving one
+// thumbnail per item (an uploaded attachment preferred, else the item's photourl
+// fallback). Same image-domain logic as the main message read.
+func bulkEditItems(db *gorm.DB, msgid uint64) []BulkEditItem {
+	type row struct {
+		ID         uint64
+		Position   uint
+		Name       string
+		Quantity   uint
+		Available  int
+		Condition  string
+		Dimensions *string
+		Photourl   *string
+	}
+	var rows []row
+	db.Raw("SELECT id, position, name, quantity, available, `condition`, dimensions, photourl "+
+		"FROM messages_bulk_items WHERE msgid = ? ORDER BY position ASC, id ASC", msgid).Scan(&rows)
+
+	// One representative attachment per item (primary first), for the thumbnail.
+	type att struct {
+		Bulkitemid   uint64
+		ID           uint64
+		Archived     int
+		Externaluid  string
+		Externalmods string
+	}
+	var atts []att
+	db.Raw("SELECT bia.bulkitemid, ma.id, ma.archived, "+
+		"COALESCE(ma.externaluid, '') AS externaluid, COALESCE(ma.externalmods, '') AS externalmods "+
+		"FROM messages_bulk_item_attachments bia "+
+		"INNER JOIN messages_attachments ma ON ma.id = bia.attachmentid "+
+		"WHERE ma.msgid = ? ORDER BY ma.`primary` DESC, ma.id ASC", msgid).Scan(&atts)
+	firstAtt := map[uint64]att{}
+	for _, a := range atts {
+		if _, ok := firstAtt[a.Bulkitemid]; !ok {
+			firstAtt[a.Bulkitemid] = a
+		}
+	}
+
+	imageDomain := os.Getenv("IMAGE_DOMAIN")
+	archiveDomain := os.Getenv("IMAGE_ARCHIVED_DOMAIN")
+
+	items := make([]BulkEditItem, 0, len(rows))
+	for _, r := range rows {
+		it := BulkEditItem{
+			ID:         r.ID,
+			Position:   r.Position,
+			Name:       r.Name,
+			Quantity:   r.Quantity,
+			Condition:  r.Condition,
+			Dimensions: r.Dimensions,
+			Available:  r.Available != 0,
+		}
+		if a, ok := firstAtt[r.ID]; ok {
+			if a.Externaluid != "" {
+				it.Photo = misc.GetImageDeliveryUrl(a.Externaluid, a.Externalmods)
+			} else if a.Archived > 0 {
+				it.Photo = "https://" + archiveDomain + "/timg_" + strconv.FormatUint(a.ID, 10) + ".jpg"
+			} else {
+				it.Photo = "https://" + imageDomain + "/timg_" + strconv.FormatUint(a.ID, 10) + ".jpg"
+			}
+		} else if r.Photourl != nil && *r.Photourl != "" {
+			it.Photo = *r.Photourl
+		}
+		items = append(items, it)
+	}
+	return items
+}
+
+// recomputeBulkAvailableNow keeps messages.availablenow in step as the external
+// owner toggles availability / edits counts: the sum of quantities across items
+// still marked available.
+func recomputeBulkAvailableNow(db *gorm.DB, msgid uint64) {
+	db.Exec("UPDATE messages SET availablenow = "+
+		"(SELECT COALESCE(SUM(quantity), 0) FROM messages_bulk_items WHERE msgid = ? AND available = 1) "+
+		"WHERE id = ?", msgid, msgid)
+}
+
+// GetBulkEditOffer returns a bulk offer's catalogue for the logged-out owner
+// page, authorised solely by the secret token in the path. No JWT, no PII.
+//
+// @Summary Get a bulk offer's items via a secret update-link token
+// @Description Logged-out access for an external item-owner. Returns the offer's catalogue only (no replier data).
+// @Tags message
+// @Produce json
+// @Param token path string true "Secret edit-link token"
+// @Success 200 {object} map[string]interface{}
+// @Router /bulkoffer/update/{token} [get]
+func GetBulkEditOffer(c *fiber.Ctx) error {
+	db := database.DBConn
+	msgid := resolveBulkEditToken(db, c.Params("token"))
+	if msgid == 0 {
+		return fiber.NewError(fiber.StatusNotFound, "Unknown or expired link")
+	}
+	var subject string
+	db.Raw("SELECT subject FROM messages WHERE id = ?", msgid).Scan(&subject)
+	items := bulkEditItems(db, msgid)
+	return c.JSON(fiber.Map{
+		"ret":     0,
+		"status":  "Success",
+		"id":      msgid,
+		"subject": subject,
+		"items":   items,
+	})
+}
+
+// BulkEditUpdateRequest is the write payload from the logged-out page: change one
+// item's availability and/or count.
+type BulkEditUpdateRequest struct {
+	Itemid    uint64 `json:"itemid"`
+	Available *bool  `json:"available"`
+	Quantity  *int   `json:"quantity"`
+}
+
+// PostBulkEditOffer updates one item's availability and/or count, authorised
+// solely by the secret token. Two-step check (as in the amp handlers): the token
+// resolves the msgid, then the item must belong to that msgid. Recomputes
+// messages.availablenow and returns the fresh catalogue.
+//
+// @Summary Update a bulk offer's item availability/count via a secret token
+// @Description Logged-out write for an external item-owner. Toggles available/taken and edits the count for one item.
+// @Tags message
+// @Accept json
+// @Produce json
+// @Param token path string true "Secret edit-link token"
+// @Success 200 {object} map[string]interface{}
+// @Router /bulkoffer/update/{token} [post]
+func PostBulkEditOffer(c *fiber.Ctx) error {
+	db := database.DBConn
+	msgid := resolveBulkEditToken(db, c.Params("token"))
+	if msgid == 0 {
+		return fiber.NewError(fiber.StatusNotFound, "Unknown or expired link")
+	}
+
+	var req BulkEditUpdateRequest
+	if err := c.BodyParser(&req); err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, "Invalid body")
+	}
+	if req.Itemid == 0 {
+		return fiber.NewError(fiber.StatusBadRequest, "itemid is required")
+	}
+	if req.Available == nil && req.Quantity == nil {
+		return fiber.NewError(fiber.StatusBadRequest, "Nothing to update")
+	}
+
+	// The item must belong to the offer the token authorises.
+	var owning uint64
+	db.Raw("SELECT msgid FROM messages_bulk_items WHERE id = ?", req.Itemid).Scan(&owning)
+	if owning != msgid {
+		return fiber.NewError(fiber.StatusNotFound, "Item not found")
+	}
+
+	if req.Available != nil {
+		av := 0
+		if *req.Available {
+			av = 1
+		}
+		db.Exec("UPDATE messages_bulk_items SET available = ? WHERE id = ? AND msgid = ?", av, req.Itemid, msgid)
+	}
+	if req.Quantity != nil {
+		q := *req.Quantity
+		if q < 0 {
+			q = 0
+		}
+		db.Exec("UPDATE messages_bulk_items SET quantity = ? WHERE id = ? AND msgid = ?", q, req.Itemid, msgid)
+	}
+
+	recomputeBulkAvailableNow(db, msgid)
+
+	items := bulkEditItems(db, msgid)
+	return c.JSON(fiber.Map{
+		"ret":    0,
+		"status": "Success",
+		"items":  items,
+	})
+}

--- a/iznik-server-go/message/bulkItem.go
+++ b/iznik-server-go/message/bulkItem.go
@@ -25,6 +25,9 @@ type BulkItem struct {
 	Position    uint    `json:"position"`
 	Name        string  `json:"name"`
 	Quantity    uint    `json:"quantity"`
+	// Available is the owner's per-item on-offer flag: false once they mark the
+	// item taken/gone (here or via the logged-out secret-link update page).
+	Available   bool    `json:"available"`
 	Condition   string  `json:"condition"`
 	Dimensions  *string `json:"dimensions"`
 	Photourl    *string `json:"photourl,omitempty"`
@@ -96,7 +99,7 @@ func saveAccessInstructions(db *gorm.DB, msgid uint64, instructions string) {
 // non-bulk message so the JSON field is omitted.
 func LoadBulkItems(db *gorm.DB, msgid uint64, myid uint64, canSeeInterest bool, attachments []MessageAttachment) []BulkItem {
 	var items []BulkItem
-	db.Raw("SELECT id, msgid, position, name, quantity, `condition`, dimensions, photourl, description "+
+	db.Raw("SELECT id, msgid, position, name, quantity, available, `condition`, dimensions, photourl, description "+
 		"FROM messages_bulk_items WHERE msgid = ? ORDER BY position ASC, id ASC", msgid).Scan(&items)
 
 	if len(items) == 0 {
@@ -343,6 +346,41 @@ func handleBulkInterestState(c *fiber.Ctx, myid uint64, req PostMessageRequest) 
 	}
 
 	return c.JSON(fiber.Map{"ret": 0, "status": "Success"})
+}
+
+// handleBulkEditLink mints (or returns the existing) secret token that lets an
+// external item-owner update this bulk offer's item availability/counts from a
+// logged-out page, without a Freegle login. Owner or moderator only. The token
+// authorises ONLY availability/count edits to this one offer (see bulkEdit.go).
+func handleBulkEditLink(c *fiber.Ctx, myid uint64, req PostMessageRequest) error {
+	db := database.DBConn
+
+	if req.ID == 0 {
+		return fiber.NewError(fiber.StatusBadRequest, "id is required")
+	}
+
+	var fromuser uint64
+	db.Raw("SELECT fromuser FROM messages WHERE id = ? AND deleted IS NULL", req.ID).Scan(&fromuser)
+	if fromuser == 0 {
+		return fiber.NewError(fiber.StatusNotFound, "Message not found")
+	}
+	if fromuser != myid && !isModForMessage(db, myid, req.ID) {
+		return fiber.NewError(fiber.StatusForbidden, "Not your post")
+	}
+
+	// Only a bulk offer (one with catalogue items) can have an update link.
+	var items int64
+	db.Raw("SELECT COUNT(*) FROM messages_bulk_items WHERE msgid = ?", req.ID).Scan(&items)
+	if items == 0 {
+		return fiber.NewError(fiber.StatusBadRequest, "Not a bulk offer")
+	}
+
+	token := ensureBulkEditToken(db, req.ID)
+	if token == "" {
+		return fiber.NewError(fiber.StatusInternalServerError, "Could not create link")
+	}
+
+	return c.JSON(fiber.Map{"ret": 0, "status": "Success", "token": token})
 }
 
 // sendAccessInstructions delivers the offer's private access instructions to a

--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -4131,6 +4131,8 @@ func dispatchPostMessageAction(c *fiber.Ctx, myid uint64, req PostMessageRequest
 		return handleBulkInterest(c, myid, req)
 	case "BulkInterestState":
 		return handleBulkInterestState(c, myid, req)
+	case "BulkEditLink":
+		return handleBulkEditLink(c, myid, req)
 	default:
 		return fiber.NewError(fiber.StatusBadRequest, "Unknown action")
 	}

--- a/iznik-server-go/router/routes.go
+++ b/iznik-server-go/router/routes.go
@@ -924,6 +924,13 @@ func SetupRoutes(app *fiber.App) {
 		rg.Put("/message", message.PutMessage)
 		rg.Delete("/message/:id", message.DeleteMessageEndpoint)
 
+		// Bulk-offer ("clearance") logged-out update page: an external item-owner
+		// toggles item available/taken and edits counts via an unguessable secret
+		// token in the URL. No JWT - the token is the sole credential and grants
+		// only availability/count edits to that one offer (see message/bulkEdit.go).
+		rg.Get("/bulkoffer/update/:token", message.GetBulkEditOffer)
+		rg.Post("/bulkoffer/update/:token", message.PostBulkEditOffer)
+
 		// Freegle Helper — cross-clearance escalated queue (ModTools). Registered
 		// before /helper/:msgid so the literal "escalated" isn't parsed as a msgid.
 		rg.Get("/helper/escalated", message.GetHelperEscalated)

--- a/iznik-server-go/test/bulk_edit_test.go
+++ b/iznik-server-go/test/bulk_edit_test.go
@@ -1,0 +1,254 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/freegle/iznik-server-go/message"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setEditToken stores a known secret edit token for an offer (the mint endpoint
+// is exercised separately in TestBulkEditLinkMint).
+func setEditToken(t *testing.T, msgid uint64, token string) {
+	res := database.DBConn.Exec(
+		"INSERT INTO messages_bulk_access (msgid, edittoken) VALUES (?, ?) "+
+			"ON DUPLICATE KEY UPDATE edittoken = VALUES(edittoken)", msgid, token)
+	require.NoError(t, res.Error)
+}
+
+// bulkEditOfferResp is the decoded logged-out GET response.
+type bulkEditOfferResp struct {
+	Ret     int                    `json:"ret"`
+	ID      uint64                 `json:"id"`
+	Subject string                 `json:"subject"`
+	Items   []message.BulkEditItem `json:"items"`
+}
+
+// getOfferByToken calls the logged-out GET endpoint and decodes the response.
+func getOfferByToken(t *testing.T, token string) (int, bulkEditOfferResp) {
+	var out bulkEditOfferResp
+	resp, err := getApp().Test(httptest.NewRequest("GET", "/api/bulkoffer/update/"+token, nil), 10000)
+	require.NoError(t, err)
+	if resp.StatusCode == 200 {
+		json.Unmarshal(rsp(resp), &out)
+	}
+	return resp.StatusCode, out
+}
+
+// postUpdate calls the logged-out POST endpoint with a JSON body.
+func postUpdate(t *testing.T, token string, body map[string]interface{}) *httptestResponse {
+	b, _ := json.Marshal(body)
+	req := httptest.NewRequest("POST", "/api/bulkoffer/update/"+token, bytes.NewBuffer(b))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := getApp().Test(req, 10000)
+	require.NoError(t, err)
+	return &httptestResponse{StatusCode: resp.StatusCode, Body: rsp(resp)}
+}
+
+type httptestResponse struct {
+	StatusCode int
+	Body       []byte
+}
+
+// TestBulkEditGetOfferByToken: the logged-out page loads the catalogue from a
+// secret token, sees each item's available flag, and gets NO replier/interest data.
+func TestBulkEditGetOfferByToken(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("bulkeditget")
+	groupID := CreateTestGroup(t, prefix)
+	ownerID := CreateTestUser(t, prefix+"_owner", "User")
+	wanterID := CreateTestUser(t, prefix+"_wanter", "User")
+	CreateTestMembership(t, ownerID, groupID, "Member")
+
+	msgID := CreateTestMessage(t, ownerID, groupID, prefix+" Office Clearance", 55.95, -3.18)
+	deskID := addBulkItem(t, msgID, prefix+"Desk", 4, "Good")
+	addBulkItem(t, msgID, prefix+"Chair", 14, "Used")
+
+	// A replier's interest exists in the DB but must NOT leak to the logged-out page.
+	secretMarker := prefix + "_SECRET_REPLIER"
+	db.Exec("UPDATE users SET fullname = ? WHERE id = ?", secretMarker, wanterID)
+	db.Exec("INSERT INTO messages_bulk_items_interest (bulkitemid, msgid, userid, quantity, state) VALUES (?, ?, ?, 2, 'Reserved')",
+		deskID, msgID, wanterID)
+
+	token := fmt.Sprintf("edittok_%s_0123456789abcdef", prefix)
+	setEditToken(t, msgID, token)
+
+	status, out := getOfferByToken(t, token)
+	require.Equal(t, 200, status)
+	assert.Equal(t, 0, out.Ret)
+	assert.Equal(t, msgID, out.ID)
+	require.Len(t, out.Items, 2)
+	for _, it := range out.Items {
+		assert.True(t, it.Available, "items default to available")
+		assert.NotZero(t, it.Quantity)
+	}
+
+	// Privacy: no replier id/name anywhere in the payload.
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/bulkoffer/update/"+token, nil), 10000)
+	raw := string(rsp(resp))
+	assert.NotContains(t, raw, secretMarker, "replier name must not appear on the logged-out page")
+	assert.NotContains(t, raw, "interest", "no interest data on the logged-out page")
+	assert.NotContains(t, raw, "userid", "no userid on the logged-out page")
+}
+
+// TestBulkEditUpdateAvailability: toggling an item taken updates its flag and
+// removes its quantity from messages.availablenow; toggling back restores it.
+func TestBulkEditUpdateAvailability(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("bulkeditavail")
+	groupID := CreateTestGroup(t, prefix)
+	ownerID := CreateTestUser(t, prefix+"_owner", "User")
+	CreateTestMembership(t, ownerID, groupID, "Member")
+
+	msgID := CreateTestMessage(t, ownerID, groupID, prefix+" Clearance", 55.95, -3.18)
+	deskID := addBulkItem(t, msgID, prefix+"Desk", 4, "Good")
+	chairID := addBulkItem(t, msgID, prefix+"Chair", 14, "Used")
+
+	token := fmt.Sprintf("edittok_%s_0123456789abcdef", prefix)
+	setEditToken(t, msgID, token)
+
+	// Mark the chairs taken.
+	res := postUpdate(t, token, map[string]interface{}{"itemid": chairID, "available": false})
+	require.Equal(t, 200, res.StatusCode)
+
+	var avail int
+	db.Raw("SELECT available FROM messages_bulk_items WHERE id = ?", chairID).Scan(&avail)
+	assert.Equal(t, 0, avail, "chair marked taken")
+
+	var availablenow int
+	db.Raw("SELECT availablenow FROM messages WHERE id = ?", msgID).Scan(&availablenow)
+	assert.Equal(t, 4, availablenow, "availablenow = sum of remaining available items (desk 4)")
+
+	// The desk is still available and unaffected.
+	var deskAvail int
+	db.Raw("SELECT available FROM messages_bulk_items WHERE id = ?", deskID).Scan(&deskAvail)
+	assert.Equal(t, 1, deskAvail)
+
+	// Toggle the chairs back to available.
+	res = postUpdate(t, token, map[string]interface{}{"itemid": chairID, "available": true})
+	require.Equal(t, 200, res.StatusCode)
+	db.Raw("SELECT availablenow FROM messages WHERE id = ?", msgID).Scan(&availablenow)
+	assert.Equal(t, 18, availablenow, "availablenow restored to 4+14")
+}
+
+// TestBulkEditUpdateQuantity: editing a count updates the item and availablenow.
+func TestBulkEditUpdateQuantity(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("bulkeditqty")
+	groupID := CreateTestGroup(t, prefix)
+	ownerID := CreateTestUser(t, prefix+"_owner", "User")
+	CreateTestMembership(t, ownerID, groupID, "Member")
+
+	msgID := CreateTestMessage(t, ownerID, groupID, prefix+" Clearance", 55.95, -3.18)
+	deskID := addBulkItem(t, msgID, prefix+"Desk", 4, "Good")
+	addBulkItem(t, msgID, prefix+"Chair", 14, "Used")
+
+	token := fmt.Sprintf("edittok_%s_0123456789abcdef", prefix)
+	setEditToken(t, msgID, token)
+
+	res := postUpdate(t, token, map[string]interface{}{"itemid": deskID, "quantity": 2})
+	require.Equal(t, 200, res.StatusCode)
+
+	var qty int
+	db.Raw("SELECT quantity FROM messages_bulk_items WHERE id = ?", deskID).Scan(&qty)
+	assert.Equal(t, 2, qty)
+
+	var availablenow int
+	db.Raw("SELECT availablenow FROM messages WHERE id = ?", msgID).Scan(&availablenow)
+	assert.Equal(t, 16, availablenow, "availablenow = 2 desks + 14 chairs")
+}
+
+// TestBulkEditItemNotInOffer: a token for one offer cannot edit another offer's item.
+func TestBulkEditItemNotInOffer(t *testing.T) {
+	prefix := uniquePrefix("bulkeditxoffer")
+	groupID := CreateTestGroup(t, prefix)
+	ownerID := CreateTestUser(t, prefix+"_owner", "User")
+	CreateTestMembership(t, ownerID, groupID, "Member")
+
+	msgA := CreateTestMessage(t, ownerID, groupID, prefix+" A", 55.95, -3.18)
+	addBulkItem(t, msgA, prefix+"A-item", 3, "Good")
+	msgB := CreateTestMessage(t, ownerID, groupID, prefix+" B", 55.95, -3.18)
+	bItem := addBulkItem(t, msgB, prefix+"B-item", 5, "Good")
+
+	token := fmt.Sprintf("edittok_%s_0123456789abcdef", prefix)
+	setEditToken(t, msgA, token)
+
+	// Token is for offer A; try to edit an item that belongs to offer B.
+	res := postUpdate(t, token, map[string]interface{}{"itemid": bItem, "available": false})
+	assert.Equal(t, 404, res.StatusCode, "cannot edit an item outside the token's offer")
+}
+
+// TestBulkEditBadToken: unknown tokens are rejected on both read and write.
+func TestBulkEditBadToken(t *testing.T) {
+	status, _ := getOfferByToken(t, "definitely_not_a_real_token_1234")
+	assert.Equal(t, 404, status)
+
+	res := postUpdate(t, "definitely_not_a_real_token_1234", map[string]interface{}{"itemid": 1, "available": false})
+	assert.Equal(t, 404, res.StatusCode)
+}
+
+// TestBulkEditLinkMint: the owner mints a stable secret link; a non-owner is
+// refused; a non-bulk message is rejected.
+func TestBulkEditLinkMint(t *testing.T) {
+	prefix := uniquePrefix("bulkeditmint")
+	groupID := CreateTestGroup(t, prefix)
+	ownerID := CreateTestUser(t, prefix+"_owner", "User")
+	strangerID := CreateTestUser(t, prefix+"_stranger", "User")
+	CreateTestMembership(t, ownerID, groupID, "Member")
+
+	msgID := CreateTestMessage(t, ownerID, groupID, prefix+" Clearance", 55.95, -3.18)
+	addBulkItem(t, msgID, prefix+"Desk", 4, "Good")
+
+	mint := func(userID uint64) (int, string) {
+		tok := getToken(t, userID)
+		body, _ := json.Marshal(map[string]interface{}{"id": msgID, "action": "BulkEditLink"})
+		req := httptest.NewRequest("POST", "/api/message?jwt="+tok, bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := getApp().Test(req, 10000)
+		require.NoError(t, err)
+		var out map[string]interface{}
+		if resp.StatusCode == 200 {
+			json.Unmarshal(rsp(resp), &out)
+		}
+		token, _ := out["token"].(string)
+		return resp.StatusCode, token
+	}
+
+	// Owner mints a link.
+	status, token := mint(ownerID)
+	require.Equal(t, 200, status)
+	require.NotEmpty(t, token)
+	assert.GreaterOrEqual(t, len(token), 16)
+
+	// Minting again returns the SAME stable token.
+	status2, token2 := mint(ownerID)
+	require.Equal(t, 200, status2)
+	assert.Equal(t, token, token2, "the link is stable across calls")
+
+	// The minted token actually works on the logged-out endpoint.
+	getStatus, out := getOfferByToken(t, token)
+	require.Equal(t, 200, getStatus)
+	assert.Equal(t, msgID, out.ID)
+
+	// A stranger cannot mint a link for someone else's offer.
+	strangerStatus, _ := mint(strangerID)
+	assert.Equal(t, 403, strangerStatus)
+
+	// A message with no bulk items is not a bulk offer.
+	plainMsg := CreateTestMessage(t, ownerID, groupID, prefix+" Plain", 55.95, -3.18)
+	plainTok := getToken(t, ownerID)
+	body, _ := json.Marshal(map[string]interface{}{"id": plainMsg, "action": "BulkEditLink"})
+	req := httptest.NewRequest("POST", "/api/message?jwt="+plainTok, bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := getApp().Test(req, 10000)
+	require.NoError(t, err)
+	assert.Equal(t, 400, resp.StatusCode, "a non-bulk message has no update link")
+	assert.True(t, strings.Contains(strings.ToLower(string(rsp(resp))), "bulk"))
+}


### PR DESCRIPTION
## Summary

A **logged-out, secret-link page** that lets an external item-owner keep a bulk offer ("clearance") up to date without a Freegle login. They open `/clearance/update/<token>` and, per item, toggle **available / taken** and edit the **count** - useful when items are also being given away through other channels, so Freeglers only ask for what's still going.

- **New per-item field** `messages_bulk_items.available` (migration + idempotent prod SQL): the owner's on-offer flag, kept **distinct from `quantity`** so marking an item taken never destroys the count. `messages.availablenow` is recomputed as the sum of quantities across items still available.
- **Secret token** `messages_bulk_access.edittoken` (migration + prod SQL): an unguessable 32-char secret, one row per offer, **stable** (a shared link keeps working) and **revocable** (null it to revoke). No login is granted - the token only authorises availability/count edits to that one offer.
- **Token-gated Go endpoints** (no JWT), mirroring the existing `/amp` security model:
  - `GET /bulkoffer/update/:token` - returns only the item catalogue (name, quantity, condition, dimensions, photo, available). **No replier/interest data.**
  - `POST /bulkoffer/update/:token` - two-step check (token → msgid, then the item must belong to that msgid), updates availability/count, recomputes `availablenow`.
  - `BulkEditLink` action mints/returns the stable token (owner/mod only).
- **Frontend**: `pages/clearance/update/[token].vue` (default layout, no forced login) rendering a privacy-trimmed `BulkOfferUpdateItem` card that mirrors the clearance manage-page styling - available/taken switch + count stepper, taken items dimmed/struck-through. Logic lives in the `useBulkOfferUpdate` composable. A **"Get an update link to share"** button on the owner's `ClearanceManager` mints and copies the link.

## Code Quality Review

- **Privacy boundary**: the logged-out page exposes only the owner's own catalogue - never who's interested, replier names, or chat. Verified by a Go test that seeds an interest row with a marker name and asserts it is absent from the response.
- **Blast radius**: a leaked link can only change availability/counts on one offer - no PII, no account access, no money. Constant-length high-entropy token; unknown/short tokens 404; an item from another offer 404s.
- **Consistency**: the existing owner clearance read now also exposes `available`; `upsertBulkItems` leaves the flag untouched on edits (new items default available).
- **No hardcoding**: the page title and every item field are derived from the Freegle post (`SELECT subject FROM messages`, the catalogue rows) - no offer-specific literals in the code.

## Future Improvements

- Reflect a taken item's zero remaining in the owner's `ClearanceManageItem` view (the `available` flag is already exposed in the API).
- Optional per-link revocation UI (regenerate the token) on the manage page.

## Test Plan

- **Go** (`test/bulk_edit_test.go`): mint owner-only (403 for a stranger, 400 for a non-bulk post, stable across calls); get-by-token; toggle available updates the flag and `availablenow`; edit count; cross-offer item and bad token both 404; no replier PII in the payload. Full Go suite green (3376).
- **Vitest**: `BulkOfferUpdateItem` (toggle/step/commit emits, taken styling, placeholder), `useBulkOfferUpdate` (load / not-found / error / save / re-sync), `ClearanceManagerShareLink` (mints and shows the `/clearance/update` URL). Full unit suite green.
- **Laravel**: full suite green (4670); both migrations apply cleanly under `migrate:fresh`.
- **Browser (WSL Chrome, GPU off)**: loaded the page logged-out via a seeded token; desktop + mobile render cleanly; toggling an item saved live and re-rendered it as taken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUZmYaNfGvSrFe3CmpLxuL
