### PR TITLE
docs(plans): redact PII from Google Ads plan

### DIFF
--- a/plans/2026-07-03-google-ads-optimization.md
+++ b/plans/2026-07-03-google-ads-optimization.md
@@ -1,7 +1,7 @@
 # Google Ads (Ad Grants) Deep Dive & Optimization Plan
 
 **Date:** 3 July 2026
-**Account:** FreegleAds, 495-138-8253 (freegleads2@gmail.com) — **Google Ad Grants** account ("We don't bill you"), USD, created March 2012.
+**Account:** FreegleAds (Google Ad Grants) — **Google Ad Grants** account ("We don't bill you"), USD, created March 2012.
 **Author:** Claude deep-dive (account UI audit + 20-agent fact-checked research sweep).
 
 ---
@@ -51,7 +51,7 @@ Budgets deliberately sum to $327.42/day = the $10k/month grant cap, but only ~$2
 8. **Brand under-defended:** Freegle wins only **63.3% impression share on its own brand**; **freecycle.org shows on 27.4% of "freegle" auctions** and outranks Freegle 41.9% of the time when both show. (Freecycle very likely runs its own $10k Ad Grant.)
 9. **Rogue asset:** an app asset "**Snaply: Sell stuff simply**" (a third-party selling app!) attached at account level since Aug 2022.
 10. **"Rotate ads indefinitely"** set on Freegle & Freecycle campaigns (never show best ad preferentially).
-11. **Nobody home:** last substantive change 17 Feb 2025 (southwestkate@gmail.com); ~39 change-history entries in 2 years. Auto-apply recommendations: off (good). Google-AI auto-assets: on (added a structured snippet + "Find A Location" sitelink).
+11. **Nobody home:** last substantive change 17 Feb 2025 (a volunteer); ~39 change-history entries in 2 years. Auto-apply recommendations: off (good). Google-AI auto-assets: on (added a structured snippet + "Find A Location" sitelink).
 12. AI Max exists in the account UI but is not enabled (correct for now — see §3.6).
 
 ---


### PR DESCRIPTION
Redacts three sensitive values from `plans/2026-07-03-google-ads-optimization.md`, which is public in this repo:
- the Google Ads customer account number
- the account login email
- a volunteer's personal Gmail address

Replaced with neutral descriptions; all analysis/content otherwise unchanged (2-line diff).

**History note:** these values also exist in the earlier merge commit (`cbe3da4c3`, via #935), so they remain retrievable in git history. Scrubbing that would need a history rewrite/force-push on `master` — deliberately NOT done here; flagging so it can be a conscious decision rather than assumed. The values are account identifiers/emails (not API keys/secrets), so ongoing tip-level exposure is the main thing this PR reduces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)