### PR TITLE
feat(report): let mods report a post to every community it's on

### DIFF
--- a/iznik-nuxt3/components/MessageReportModal.vue
+++ b/iznik-nuxt3/components/MessageReportModal.vue
@@ -56,6 +56,32 @@
           </div>
         </div>
 
+        <div v-if="showGroupSelector" class="report-groups">
+          <label class="form-label"
+            >Which communities should be notified?</label
+          >
+          <p class="report-groups-hint">
+            This post is on several communities. As a moderator you can report
+            it to more than one team.
+          </p>
+          <b-form-checkbox
+            v-model="allSelected"
+            :indeterminate="someSelected"
+            class="report-group-all"
+          >
+            All communities
+          </b-form-checkbox>
+          <b-form-checkbox-group v-model="selectedGroupIds" stacked>
+            <b-form-checkbox
+              v-for="grp in reportableGroups"
+              :key="grp.groupid"
+              :value="grp.groupid"
+            >
+              {{ grp.name }}
+            </b-form-checkbox>
+          </b-form-checkbox-group>
+        </div>
+
         <div class="report-details">
           <label class="form-label">Additional details (optional)</label>
           <b-form-textarea
@@ -64,6 +90,11 @@
             placeholder="Please provide any additional information that might help our volunteers."
           />
         </div>
+
+        <p v-if="submitError" class="report-error text-danger">
+          Sorry, we couldn't send your report. Please check your connection and
+          try again.
+        </p>
       </div>
 
       <div v-else class="report-success">
@@ -72,6 +103,9 @@
         <p>
           Thank you for helping keep Freegle safe. Our volunteers will review
           this post and take appropriate action.
+        </p>
+        <p v-if="failedGroups.length" class="report-partial text-warning">
+          We couldn't reach the volunteers for: {{ failedGroups.join(', ') }}.
         </p>
       </div>
     </template>
@@ -98,11 +132,13 @@
 </template>
 
 <script setup>
-import { ref, computed } from 'vue'
+import { ref, computed, watch } from 'vue'
 import { useRuntimeConfig } from 'nuxt/app'
 import { useMessageStore } from '~/stores/message'
 import { useChatStore } from '~/stores/chat'
 import { useAuthStore } from '~/stores/auth'
+import { useGroupStore } from '~/stores/group'
+import { useMe } from '~/composables/useMe'
 import { useOurModal } from '~/composables/useOurModal'
 
 const props = defineProps({
@@ -117,12 +153,17 @@ defineEmits(['hidden'])
 const messageStore = useMessageStore()
 const chatStore = useChatStore()
 const authStore = useAuthStore()
+const groupStore = useGroupStore()
+const { me } = useMe()
 const { modal, hide } = useOurModal()
 
 const selectedReason = ref(null)
 const additionalDetails = ref('')
 const submitting = ref(false)
 const submitted = ref(false)
+const submitError = ref(false)
+const failedGroups = ref([])
+const selectedGroupIds = ref([])
 
 const message = computed(() => {
   return messageStore?.byId(props.id)
@@ -135,13 +176,86 @@ const reportGroupId = computed(() => {
   const shared = message.value.groups
     .filter((g) => myGroupIds.includes(parseInt(g.groupid)))
     .sort((a, b) => new Date(b.arrival) - new Date(a.arrival))
-  return shared.length > 0
-    ? shared[0].groupid
-    : message.value.groups[0].groupid
+  return shared.length > 0 ? shared[0].groupid : message.value.groups[0].groupid
 })
 
+// Moderators (and above) can report a post to more than one community's mod
+// team, since a post can be on several groups once it has rippled out.
+const isMod = computed(() => {
+  const role = me.value?.systemrole
+  return role === 'Moderator' || role === 'Support' || role === 'Admin'
+})
+
+// Every community the post is on, resolved to a display name via the group
+// store, with today's default group first. De-duplicated by group id.
+const reportableGroups = computed(() => {
+  const raw = message.value?.groups
+  if (!raw?.length) return []
+  const defaultId = parseInt(reportGroupId.value)
+  const seen = new Set()
+  const groups = []
+  for (const g of raw) {
+    const groupid = parseInt(g.groupid)
+    if (seen.has(groupid)) continue
+    seen.add(groupid)
+    const grp = groupStore.get(groupid)
+    groups.push({
+      groupid,
+      name: grp?.namedisplay || grp?.nameshort || 'Community #' + groupid,
+    })
+  }
+  return groups.sort((a, b) => {
+    if (a.groupid === defaultId) return -1
+    if (b.groupid === defaultId) return 1
+    return a.name.localeCompare(b.name)
+  })
+})
+
+// Only show the multi-community selector to mods, and only when there is a
+// real choice to make (the post is on more than one community).
+const showGroupSelector = computed(
+  () => isMod.value && reportableGroups.value.length > 1
+)
+
+const allSelected = computed({
+  get() {
+    return (
+      reportableGroups.value.length > 0 &&
+      selectedGroupIds.value.length === reportableGroups.value.length
+    )
+  },
+  set(val) {
+    selectedGroupIds.value = val
+      ? reportableGroups.value.map((g) => g.groupid)
+      : []
+  },
+})
+
+const someSelected = computed(
+  () =>
+    selectedGroupIds.value.length > 0 &&
+    selectedGroupIds.value.length < reportableGroups.value.length
+)
+
+// Seed the selection with today's default single group so a mod who ignores
+// the selector and just hits Submit gets the same behaviour as before.
+watch(
+  reportGroupId,
+  (id) => {
+    if (id !== null && id !== undefined && !selectedGroupIds.value.length) {
+      selectedGroupIds.value = [parseInt(id)]
+    }
+  },
+  { immediate: true }
+)
+
 const canSubmit = computed(() => {
-  return selectedReason.value !== null
+  if (selectedReason.value === null) return false
+  // A mod who has opened the selector must pick at least one community.
+  if (showGroupSelector.value && selectedGroupIds.value.length === 0) {
+    return false
+  }
+  return true
 })
 
 const reasonLabels = {
@@ -155,33 +269,52 @@ async function report() {
   if (!canSubmit.value || submitting.value) return
 
   submitting.value = true
+  submitError.value = false
+  failedGroups.value = []
 
-  try {
-    const chatid = await chatStore.openChatToMods(reportGroupId.value)
+  const runtimeConfig = useRuntimeConfig()
+  const reasonText = reasonLabels[selectedReason.value] || selectedReason.value
+  let reportMessage =
+    "I'm reporting this post as inappropriate:\n" +
+    runtimeConfig.public.USER_SITE +
+    '/message/' +
+    message.value.id +
+    '\n\nReason: ' +
+    reasonText
 
-    const runtimeConfig = useRuntimeConfig()
-    const reasonText =
-      reasonLabels[selectedReason.value] || selectedReason.value
-    let reportMessage =
-      "I'm reporting this post as inappropriate:\n" +
-      runtimeConfig.public.USER_SITE +
-      '/message/' +
-      message.value.id +
-      '\n\nReason: ' +
-      reasonText
+  if (additionalDetails.value?.trim()) {
+    reportMessage +=
+      '\n\nAdditional details: "' + additionalDetails.value.trim() + '"'
+  }
 
-    if (additionalDetails.value?.trim()) {
-      reportMessage +=
-        '\n\nAdditional details: "' + additionalDetails.value.trim() + '"'
+  // Mods can widen the report to several communities; everyone else reports to
+  // the single natural group exactly as before.
+  const targetIds =
+    showGroupSelector.value && selectedGroupIds.value.length
+      ? selectedGroupIds.value
+      : [parseInt(reportGroupId.value)]
+
+  // Report to each community's mod team in turn. One failure must not stop the
+  // rest, and we surface any that failed rather than swallowing them.
+  let anySucceeded = false
+  for (const groupid of targetIds) {
+    try {
+      const chatid = await chatStore.openChatToMods(groupid)
+      await chatStore.send(chatid, reportMessage, null, null, props.id)
+      anySucceeded = true
+    } catch (error) {
+      console.error('Failed to submit report to group ' + groupid, error)
+      const grp = reportableGroups.value.find((g) => g.groupid === groupid)
+      failedGroups.value.push(grp?.name || 'Community #' + groupid)
     }
+  }
 
-    await chatStore.send(chatid, reportMessage, null, null, props.id)
+  submitting.value = false
 
+  if (anySucceeded) {
     submitted.value = true
-  } catch (error) {
-    console.error('Failed to submit report:', error)
-  } finally {
-    submitting.value = false
+  } else {
+    submitError.value = true
   }
 }
 </script>
@@ -251,6 +384,35 @@ async function report() {
     color: $color-gray--darker;
     margin-bottom: 0.5rem;
   }
+}
+
+.report-groups {
+  .form-label {
+    font-weight: 600;
+    color: $color-gray--darker;
+    margin-bottom: 0.25rem;
+  }
+}
+
+.report-groups-hint {
+  color: var(--color-gray-600);
+  font-size: 0.85rem;
+  margin: 0 0 0.5rem;
+}
+
+.report-group-all {
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+
+.report-error {
+  font-size: 0.9rem;
+  margin: 0;
+}
+
+.report-partial {
+  font-size: 0.9rem;
+  margin: 0.5rem 0 0;
 }
 
 .report-success {

--- a/iznik-nuxt3/tests/unit/components/MessageReportModal.spec.js
+++ b/iznik-nuxt3/tests/unit/components/MessageReportModal.spec.js
@@ -29,6 +29,12 @@ const mockAuthStore = {
   groups: [{ groupid: 100 }, { groupid: 200 }],
 }
 
+const mockMe = ref({ systemrole: 'User' })
+
+const mockGroupStore = {
+  get: vi.fn((id) => ({ namedisplay: 'Community ' + id })),
+}
+
 vi.mock('~/stores/message', () => ({
   useMessageStore: () => mockMessageStore,
 }))
@@ -39,6 +45,14 @@ vi.mock('~/stores/chat', () => ({
 
 vi.mock('~/stores/auth', () => ({
   useAuthStore: () => mockAuthStore,
+}))
+
+vi.mock('~/stores/group', () => ({
+  useGroupStore: () => mockGroupStore,
+}))
+
+vi.mock('~/composables/useMe', () => ({
+  useMe: () => ({ me: mockMe }),
 }))
 
 vi.mock('~/composables/useOurModal', () => ({
@@ -60,6 +74,12 @@ describe('MessageReportModal', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockMessageStore.byId.mockReturnValue(mockMessage)
+    mockMe.value = { systemrole: 'User' }
+    mockGroupStore.get.mockImplementation((id) => ({
+      namedisplay: 'Community ' + id,
+    }))
+    mockChatStore.openChatToMods.mockResolvedValue(123)
+    mockChatStore.send.mockResolvedValue({})
   })
 
   function createWrapper(props = {}) {
@@ -101,6 +121,17 @@ describe('MessageReportModal', () => {
           'b-spinner': {
             template: '<span class="b-spinner" />',
             props: ['small'],
+          },
+          'b-form-checkbox': {
+            template:
+              '<label class="b-form-checkbox"><input type="checkbox" @change="$emit(\'update:modelValue\', $event.target.checked)" /><slot /></label>',
+            props: ['modelValue', 'value', 'indeterminate'],
+            emits: ['update:modelValue'],
+          },
+          'b-form-checkbox-group': {
+            template: '<div class="b-form-checkbox-group"><slot /></div>',
+            props: ['modelValue', 'stacked'],
+            emits: ['update:modelValue'],
           },
           'v-icon': {
             template: '<span class="v-icon" :data-icon="icon" />',
@@ -280,6 +311,149 @@ describe('MessageReportModal', () => {
     it('does not show success state initially', () => {
       const wrapper = createWrapper()
       expect(wrapper.find('.report-success').exists()).toBe(false)
+    })
+  })
+
+  describe('mod multi-community reporting', () => {
+    function modWrapperOnGroups(groups, role = 'Moderator') {
+      mockMe.value = { systemrole: role }
+      mockMessageStore.byId.mockReturnValue({ ...mockMessage, groups })
+      return createWrapper()
+    }
+
+    it('hides the community selector for non-mods', () => {
+      mockMessageStore.byId.mockReturnValue({
+        ...mockMessage,
+        groups: [{ groupid: 100 }, { groupid: 300 }],
+      })
+      const wrapper = createWrapper()
+      expect(wrapper.vm.showGroupSelector).toBe(false)
+      expect(wrapper.find('.report-groups').exists()).toBe(false)
+    })
+
+    it('hides the community selector for a mod on a single-group post', () => {
+      const wrapper = modWrapperOnGroups([{ groupid: 100 }])
+      expect(wrapper.vm.showGroupSelector).toBe(false)
+      expect(wrapper.find('.report-groups').exists()).toBe(false)
+    })
+
+    it('shows the community selector for a mod on a multi-group post', () => {
+      const wrapper = modWrapperOnGroups([{ groupid: 100 }, { groupid: 300 }])
+      expect(wrapper.vm.showGroupSelector).toBe(true)
+      expect(wrapper.find('.report-groups').exists()).toBe(true)
+      expect(wrapper.text()).toContain('Community 100')
+      expect(wrapper.text()).toContain('Community 300')
+    })
+
+    it('shows the selector for Support and Admin too', () => {
+      expect(
+        modWrapperOnGroups([{ groupid: 100 }, { groupid: 300 }], 'Support').vm
+          .showGroupSelector
+      ).toBe(true)
+      expect(
+        modWrapperOnGroups([{ groupid: 100 }, { groupid: 300 }], 'Admin').vm
+          .showGroupSelector
+      ).toBe(true)
+    })
+
+    it('lists the default group first', () => {
+      // User shares group 300; it should be the default and sort first.
+      mockMe.value = { systemrole: 'Moderator' }
+      mockMessageStore.byId.mockReturnValue({
+        ...mockMessage,
+        groups: [
+          { groupid: 100, arrival: '2024-01-01T00:00:00Z' },
+          { groupid: 300, arrival: '2024-01-02T00:00:00Z' },
+        ],
+      })
+      mockAuthStore.groups = [{ groupid: 300 }]
+      const wrapper = createWrapper()
+      expect(wrapper.vm.reportableGroups[0].groupid).toBe(300)
+      mockAuthStore.groups = [{ groupid: 100 }, { groupid: 200 }]
+    })
+
+    it('de-duplicates repeated group ids', () => {
+      const wrapper = modWrapperOnGroups([
+        { groupid: 100 },
+        { groupid: 100 },
+        { groupid: 300 },
+      ])
+      expect(wrapper.vm.reportableGroups.length).toBe(2)
+    })
+
+    it('seeds the selection with the default single group', () => {
+      const wrapper = modWrapperOnGroups([{ groupid: 100 }, { groupid: 300 }])
+      expect(wrapper.vm.selectedGroupIds).toEqual([100])
+    })
+
+    it('all-communities toggle selects and clears every group', () => {
+      const wrapper = modWrapperOnGroups([{ groupid: 100 }, { groupid: 300 }])
+      wrapper.vm.allSelected = true
+      expect(wrapper.vm.selectedGroupIds).toEqual([100, 300])
+      wrapper.vm.allSelected = false
+      expect(wrapper.vm.selectedGroupIds).toEqual([])
+    })
+
+    it('reports to every selected community', async () => {
+      const wrapper = modWrapperOnGroups([{ groupid: 100 }, { groupid: 300 }])
+      wrapper.vm.selectedReason = 'spam'
+      wrapper.vm.selectedGroupIds = [100, 300]
+      await wrapper.vm.report()
+      expect(mockChatStore.openChatToMods).toHaveBeenCalledTimes(2)
+      expect(mockChatStore.openChatToMods).toHaveBeenCalledWith(100)
+      expect(mockChatStore.openChatToMods).toHaveBeenCalledWith(300)
+      expect(mockChatStore.send).toHaveBeenCalledTimes(2)
+      expect(wrapper.vm.submitted).toBe(true)
+      expect(wrapper.vm.failedGroups).toEqual([])
+    })
+
+    it('reports to a single group for a non-mod', async () => {
+      mockMessageStore.byId.mockReturnValue({
+        ...mockMessage,
+        groups: [{ groupid: 100 }, { groupid: 300 }],
+      })
+      const wrapper = createWrapper()
+      wrapper.vm.selectedReason = 'spam'
+      await wrapper.vm.report()
+      expect(mockChatStore.openChatToMods).toHaveBeenCalledTimes(1)
+      expect(mockChatStore.openChatToMods).toHaveBeenCalledWith(100)
+      expect(wrapper.vm.submitted).toBe(true)
+    })
+
+    it('continues after one group fails and reports the failure', async () => {
+      const wrapper = modWrapperOnGroups([{ groupid: 100 }, { groupid: 300 }])
+      mockChatStore.openChatToMods.mockImplementation((groupid) => {
+        if (groupid === 300) return Promise.reject(new Error('boom'))
+        return Promise.resolve(123)
+      })
+      wrapper.vm.selectedReason = 'spam'
+      wrapper.vm.selectedGroupIds = [100, 300]
+      await wrapper.vm.report()
+      expect(mockChatStore.openChatToMods).toHaveBeenCalledTimes(2)
+      expect(wrapper.vm.submitted).toBe(true)
+      expect(wrapper.vm.failedGroups).toEqual(['Community 300'])
+      expect(wrapper.vm.submitError).toBe(false)
+    })
+
+    it('shows an error and stays on the form when all groups fail', async () => {
+      const wrapper = modWrapperOnGroups([{ groupid: 100 }, { groupid: 300 }])
+      mockChatStore.openChatToMods.mockRejectedValue(new Error('boom'))
+      wrapper.vm.selectedReason = 'spam'
+      wrapper.vm.selectedGroupIds = [100, 300]
+      await wrapper.vm.report()
+      expect(wrapper.vm.submitted).toBe(false)
+      expect(wrapper.vm.submitError).toBe(true)
+      expect(wrapper.vm.failedGroups).toEqual([
+        'Community 100',
+        'Community 300',
+      ])
+    })
+
+    it('blocks submit when a mod deselects every community', () => {
+      const wrapper = modWrapperOnGroups([{ groupid: 100 }, { groupid: 300 }])
+      wrapper.vm.selectedReason = 'spam'
+      wrapper.vm.selectedGroupIds = []
+      expect(wrapper.vm.canSubmit).toBe(false)
     })
   })
 })


### PR DESCRIPTION
## What

On FD the "Report this post" modal currently sends the report to a single group's mod team — the reporter's shared/home group. Once a post has rippled out it can be on several communities, and a moderator often wants every affected team to see the report so each can take action on their own group.

For reporters whose `systemrole` is **Moderator, Support or Admin**, the modal now shows a checkbox list of all the communities the post is on, plus an **"All communities"** toggle. The report is then sent to each selected community's mod team from the client — one `User2Mod` chat per group.

## Behaviour

- **Non-mods**: unchanged — no selector, reports to the single natural group exactly as before.
- **Mods on a single-group post**: unchanged — no selector (nothing to choose).
- **Mods on a multi-group post**: selector appears. The default single group is **pre-selected**, so a mod who ignores the selector and just clicks Submit gets the same result as today; they can widen to any/all communities.
- Communities are listed by display name (resolved via the group store), default group first, de-duplicated by id.
- Submit is blocked if a mod deselects every community.

## Reliability

Reports are sent per group. A failure on one group no longer aborts the rest, and failures are **surfaced** rather than swallowed into a bare console.error:
- all succeeded → success panel (notes any partial failures);
- some failed → success panel naming the communities that couldn't be reached;
- all failed → stays on the form with an inline error.

## Testing

The component spec was extended — selector gating (non-mod / single-group / mod+multi / Support+Admin), default seeding, all-toggle, de-dup, per-group send loop, non-mod single-send, partial-failure, all-failure, and empty-selection submit guard. Full spec file passes locally via the status-API unit-test runner (37/37).

No API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)