### PR TITLE
fix(stories): guard StoryOne against a missing story (undefined userid crash)

### DIFF
--- a/iznik-nuxt3/components/StoryOne.vue
+++ b/iznik-nuxt3/components/StoryOne.vue
@@ -124,10 +124,15 @@ const loggedIn = computed(() => authStore.user !== null)
 const showShare = ref(false)
 const showPhotoModal = ref(false)
 
-// Fetch data
+// Fetch data. The story can come back null/undefined when the id no longer
+// exists (deleted story, or a stale bad id in a list) - guard the follow-on
+// user fetches so we render nothing (template is v-if="story") instead of
+// throwing "Cannot read properties of undefined (reading 'userid')".
 const story = await storyStore.fetch(props.id)
-const user = await userStore.fetch(story.userid)
-const userLocation = await userStore.fetchPublicLocation(story.userid)
+const user = story ? await userStore.fetch(story.userid) : null
+const userLocation = story
+  ? await userStore.fetchPublicLocation(story.userid)
+  : null
 
 // Fetch group data if groupId is provided
 let group = null

--- a/iznik-nuxt3/tests/unit/components/StoryOne.spec.js
+++ b/iznik-nuxt3/tests/unit/components/StoryOne.spec.js
@@ -298,6 +298,25 @@ describe('StoryOne', () => {
     })
   })
 
+  describe('missing story', () => {
+    it('renders nothing and does not fetch the user when the story is not found', async () => {
+      // A deleted story (or a stale/bad id in a list) makes storyStore.fetch
+      // resolve null. Previously we then read story.userid and threw
+      // "Cannot read properties of undefined (reading 'userid')" during render.
+      mockStoryStore.fetch.mockResolvedValue(null)
+      const wrapper = await createWrapper()
+      expect(wrapper.find('.story-card').exists()).toBe(false)
+      expect(mockUserStore.fetch).not.toHaveBeenCalled()
+      expect(mockUserStore.fetchPublicLocation).not.toHaveBeenCalled()
+    })
+
+    it('renders nothing when the story is undefined', async () => {
+      mockStoryStore.fetch.mockResolvedValue(undefined)
+      const wrapper = await createWrapper()
+      expect(wrapper.find('.story-card').exists()).toBe(false)
+    })
+  })
+
   describe('data fetching', () => {
     it('fetches story on mount', async () => {
       await createWrapper()


### PR DESCRIPTION
## What

`StoryOne.vue` fetched a story then immediately read `story.userid` to fetch the author:

```js
const story = await storyStore.fetch(props.id)
const user = await userStore.fetch(story.userid)   // throws if story is null
```

When the id no longer resolves — a deleted story, or a stale/bad id fed in from a list — `story` is null and `story.userid` throws **"Cannot read properties of undefined (reading 'userid')"** during render. This is the **top client-side error in Sentry** (project `nuxt3`, ~3,500 events, e.g. on `/stories/21465`).

## Fix

Guard the follow-on user fetches when `story` is nullish, so the component renders nothing (the template root is already `v-if="story"`) instead of throwing.

## Tests

Adds two `StoryOne.spec.js` cases: story resolves `null` → renders nothing and does not fetch the user; story resolves `undefined` → renders nothing. Full `StoryOne` spec passes locally (28/28).

🤖 Generated with [Claude Code](https://claude.com/claude-code)