### PR TITLE
fix(modtools): restore Save button in config standard-message editor (null lock owner)

### DIFF
--- a/iznik-nuxt3/modtools/components/ModSettingsStandardMessageModal.vue
+++ b/iznik-nuxt3/modtools/components/ModSettingsStandardMessageModal.vue
@@ -134,10 +134,15 @@ const config = computed(() => {
 })
 
 const locked = computed(() => {
-  return (
+  // A protected config with a null createdby has no real lock owner, so it must
+  // not read as locked - otherwise parseInt(null) is NaN, NaN !== myid is always
+  // true, and every user (including the creator) loses the Save/Add and Delete
+  // buttons. Guard createdby truthy first, matching ModSettingsModConfig.vue.
+  return Boolean(
     config.value &&
-    config.value.protected &&
-    parseInt(config.value.createdby) !== myid.value
+      config.value.protected &&
+      config.value.createdby &&
+      parseInt(config.value.createdby) !== myid.value
   )
 })
 

--- a/iznik-nuxt3/tests/unit/components/modtools/ModSettingsStandardMessageModal.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModSettingsStandardMessageModal.spec.js
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { ref } from 'vue'
 
 // Test the component logic directly without mounting the full component
 // The component uses template refs and complex composables that are hard to test
@@ -137,25 +136,33 @@ describe('ModSettingsStandardMessageModal - Logic Tests', () => {
   })
 
   describe('locked logic', () => {
+    // Mirrors the component's `locked` computed: a protected config with a null
+    // createdby has no real lock owner and must NOT read as locked (otherwise
+    // parseInt(null) is NaN, NaN !== myid is always true, and the Save/Add and
+    // Delete buttons vanish for everyone).
+    const isLocked = (config, myid) =>
+      Boolean(
+        config &&
+          config.protected &&
+          config.createdby &&
+          parseInt(config.createdby) !== myid
+      )
+
     it('returns false when config is not protected', () => {
-      const config = { protected: false, createdby: 123 }
-      const myid = 123
-      const locked = config.protected && parseInt(config.createdby) !== myid
-      expect(locked).toBe(false)
+      expect(isLocked({ protected: false, createdby: 123 }, 123)).toBe(false)
     })
 
     it('returns false when config is protected but user is creator', () => {
-      const config = { protected: true, createdby: 123 }
-      const myid = 123
-      const locked = config.protected && parseInt(config.createdby) !== myid
-      expect(locked).toBe(false)
+      expect(isLocked({ protected: true, createdby: 123 }, 123)).toBe(false)
     })
 
     it('returns true when config is protected and user is not creator', () => {
-      const config = { protected: true, createdby: 456 }
-      const myid = 123
-      const locked = config.protected && parseInt(config.createdby) !== myid
-      expect(locked).toBe(true)
+      expect(isLocked({ protected: true, createdby: 456 }, 123)).toBe(true)
+    })
+
+    it('returns false when config is protected but createdby is null (no lock owner)', () => {
+      // Regression: this is the "only a Cancel button" bug from Discourse #9793.
+      expect(isLocked({ protected: true, createdby: null }, 123)).toBe(false)
     })
   })
 


### PR DESCRIPTION
## What

Follows up [PR #810], which fixed the parent `ModSettingsModConfig` so a **protected config with a null `createdby`** no longer showed "locked by #null" and no longer blocked edits. The identical `locked` computed in **`ModSettingsStandardMessageModal`** was left unpatched:

```js
const locked = computed(() =>
  config.value && config.value.protected &&
  parseInt(config.value.createdby) !== myid.value   // NaN !== myid → always true when createdby is null
)
```

So for a protected config with no real lock owner, `locked` was `true` for **everyone** — the Save/Add button (`v-if="!locked"`) and the Delete button never rendered, leaving only **Cancel**. That's the "it lets me create the message but won't let me save it — the only button is Cancel" report.

## Fix

Guard `config.createdby` truthy before the `parseInt`, exactly matching the parent fix. Adds the null-`createdby` regression case to the locked-logic tests (24/24 pass locally).

Reported on Discourse: https://discourse.ilovefreegle.org/t/9793/10

🤖 Generated with [Claude Code](https://claude.com/claude-code)