### PR TITLE
fix(microvolunteering): refresh notification count after checking a post

### DIFF
--- a/iznik-nuxt3/components/MicroVolunteeringCheckMessage.vue
+++ b/iznik-nuxt3/components/MicroVolunteeringCheckMessage.vue
@@ -201,6 +201,7 @@ import ProxyImage from './ProxyImage'
 import { useMicroVolunteeringStore } from '~/stores/microvolunteering'
 import { useMessageStore } from '~/stores/message'
 import { useAuthStore } from '~/stores/auth'
+import { useNotificationStore } from '~/stores/notification'
 
 const props = defineProps({
   id: {
@@ -214,6 +215,7 @@ const emit = defineEmits(['next'])
 const microVolunteeringStore = useMicroVolunteeringStore()
 const messageStore = useMessageStore()
 const authStore = useAuthStore()
+const notificationStore = useNotificationStore()
 
 // State
 const showComments = ref(false)
@@ -303,6 +305,7 @@ async function sendComments(callback) {
     comments: comments.value,
     msgcategory: msgcategory.value,
   })
+  await refreshNotificationCount()
   callback()
 
   emit('next')
@@ -315,9 +318,26 @@ async function approve(callback) {
     groupid: groupid.value,
     response: 'Approve',
   })
+  await refreshNotificationCount()
   callback()
 
   emit('next')
+}
+
+// After recording a response the server has already marked the "post to check"
+// notification seen. Refresh the badge count straight away so the indicator
+// clears immediately, rather than lingering (and re-presenting the same post)
+// until the next 60-second poll. Never let a count refresh failure block the
+// flow - the user has already voted.
+async function refreshNotificationCount() {
+  try {
+    await notificationStore.fetchCount()
+  } catch (e) {
+    console.log(
+      'Failed to refresh notification count after microvolunteering',
+      e
+    )
+  }
 }
 </script>
 <style scoped lang="scss">

--- a/iznik-nuxt3/tests/unit/components/MicroVolunteeringCheckMessage.spec.js
+++ b/iznik-nuxt3/tests/unit/components/MicroVolunteeringCheckMessage.spec.js
@@ -7,6 +7,7 @@ import MicroVolunteeringCheckMessage from '~/components/MicroVolunteeringCheckMe
 const mockMessageById = vi.fn()
 const mockMessageFetch = vi.fn()
 const mockMicroVolunteeringRespond = vi.fn()
+const mockNotificationFetchCount = vi.fn()
 
 vi.mock('~/stores/message', () => ({
   useMessageStore: () => ({
@@ -18,6 +19,12 @@ vi.mock('~/stores/message', () => ({
 vi.mock('~/stores/microvolunteering', () => ({
   useMicroVolunteeringStore: () => ({
     respond: mockMicroVolunteeringRespond,
+  }),
+}))
+
+vi.mock('~/stores/notification', () => ({
+  useNotificationStore: () => ({
+    fetchCount: mockNotificationFetchCount,
   }),
 }))
 
@@ -145,6 +152,40 @@ describe('MicroVolunteeringCheckMessage', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+  })
+
+  describe('notification refresh after responding', () => {
+    it('refreshes the notification count after approving a post', async () => {
+      mockMicroVolunteeringRespond.mockResolvedValue(undefined)
+      mockNotificationFetchCount.mockResolvedValue(0)
+      const wrapper = createWrapper()
+      await flushPromises()
+      const approveBtn = wrapper
+        .findAll('button')
+        .find((b) => b.text().includes('Yes, that looks ok'))
+      await approveBtn.trigger('click')
+      await flushPromises()
+      expect(mockMicroVolunteeringRespond).toHaveBeenCalledWith(
+        expect.objectContaining({ msgid: 123, response: 'Approve' })
+      )
+      // The stale badge/re-presented-post bug (#9856): the count must be
+      // refreshed from the server as soon as the response is recorded.
+      expect(mockNotificationFetchCount).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not throw if the count refresh fails after responding', async () => {
+      mockMicroVolunteeringRespond.mockResolvedValue(undefined)
+      mockNotificationFetchCount.mockRejectedValue(new Error('offline'))
+      const wrapper = createWrapper()
+      await flushPromises()
+      const approveBtn = wrapper
+        .findAll('button')
+        .find((b) => b.text().includes('Yes, that looks ok'))
+      await approveBtn.trigger('click')
+      await flushPromises()
+      expect(mockMicroVolunteeringRespond).toHaveBeenCalled()
+      expect(mockNotificationFetchCount).toHaveBeenCalledTimes(1)
+    })
   })
 
   describe('rendering', () => {


### PR DESCRIPTION
## What

Reported on Discourse #9856: a microvolunteer taps the "posts to check" notification, checks a post, taps "Yes, that looks ok", gets a "thanks" — but **the notification indicator keeps showing and the same post is presented again**.

## Root cause

`MicroVolunteeringCheckMessage.approve()` / `sendComments()` record the response via `microVolunteeringStore.respond(...)` but never refresh the notification badge. The Go API *does* mark the notification seen server-side, but the client's `notificationStore.count` only updates on its next **60-second** poll — so the badge stays lit, and tapping it again re-opens the same message before the state has caught up.

## Fix

Refresh the count from the server immediately after the response is recorded (both the approve and the reject-with-comments paths). The refresh is wrapped in try/catch so a network failure can't block the flow — the vote is already recorded.

The component is the single choke point for the respond action, so this covers both the modal flow and the notification-deep-link page flow.

## Tests

`MicroVolunteeringCheckMessage.spec.js`: approving now calls `notificationStore.fetchCount()` once after `respond`; a failing refresh doesn't break the action. Full spec passes locally (28/28).

Reported on Discourse: https://discourse.ilovefreegle.org/t/9856/1

🤖 Generated with [Claude Code](https://claude.com/claude-code)