### PR TITLE
fix(upload): contain retryAll() async rejection (Uppy 'in operator' crash)

### DIFF
--- a/iznik-nuxt3/composables/useUppyRetryCoalesce.js
+++ b/iznik-nuxt3/composables/useUppyRetryCoalesce.js
@@ -18,7 +18,21 @@ export function createRetryCoalescer(getUppy) {
     queueMicrotask(() => {
       scheduled = false
       try {
-        getUppy()?.retryAll()
+        // retryAll() returns a promise in Uppy 4. Uppy's own tus retry can throw
+        // "Cannot use 'in' operator to search for 'error' in undefined" from an
+        // undefined file in its internal list - and because that surfaces from
+        // an async continuation it REJECTS the promise rather than throwing
+        // synchronously, so the try/catch alone misses it and it reaches Sentry
+        // uncaught. Handle the rejection too.
+        const result = getUppy()?.retryAll()
+        if (result && typeof result.then === 'function') {
+          result.catch((retryError) => {
+            console.error(
+              'retryAll() rejected (Uppy state corruption)',
+              retryError
+            )
+          })
+        }
       } catch (retryError) {
         console.error('retryAll() failed (Uppy state corruption)', retryError)
       }

--- a/iznik-nuxt3/tests/unit/composables/useUppyRetryCoalesce.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useUppyRetryCoalesce.spec.js
@@ -3,11 +3,9 @@ import { createRetryCoalescer } from '~/composables/useUppyRetryCoalesce'
 
 describe('createRetryCoalescer', () => {
   let microtasks
-  let originalQueueMicrotask
 
   beforeEach(() => {
     microtasks = []
-    originalQueueMicrotask = global.queueMicrotask
     vi.stubGlobal('queueMicrotask', (fn) => microtasks.push(fn))
   })
 
@@ -116,7 +114,9 @@ describe('createRetryCoalescer', () => {
         throw error
       })
       const scheduleRetry = createRetryCoalescer(() => ({ retryAll }))
-      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const consoleError = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {})
 
       scheduleRetry()
       flushMicrotasks()
@@ -125,6 +125,29 @@ describe('createRetryCoalescer', () => {
       expect(consoleError).toHaveBeenCalledWith(
         'retryAll() failed (Uppy state corruption)',
         error
+      )
+    })
+
+    it('handles a rejected promise returned by retryAll (async Uppy corruption)', async () => {
+      const rejection = new TypeError(
+        "Cannot use 'in' operator to search for 'error' in undefined"
+      )
+      const retryAll = vi.fn().mockRejectedValue(rejection)
+      const scheduleRetry = createRetryCoalescer(() => ({ retryAll }))
+      const consoleError = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {})
+
+      scheduleRetry()
+      // The synchronous flush kicks off retryAll(); its rejection settles on a
+      // later microtask, so let the event loop drain before asserting.
+      flushMicrotasks()
+      await Promise.resolve()
+      await Promise.resolve()
+
+      expect(consoleError).toHaveBeenCalledWith(
+        'retryAll() rejected (Uppy state corruption)',
+        rejection
       )
     })
 
@@ -179,8 +202,12 @@ describe('createRetryCoalescer', () => {
     it('two separate coalescer instances do not interfere', () => {
       const retryAll1 = vi.fn()
       const retryAll2 = vi.fn()
-      const scheduleRetry1 = createRetryCoalescer(() => ({ retryAll: retryAll1 }))
-      const scheduleRetry2 = createRetryCoalescer(() => ({ retryAll: retryAll2 }))
+      const scheduleRetry1 = createRetryCoalescer(() => ({
+        retryAll: retryAll1,
+      }))
+      const scheduleRetry2 = createRetryCoalescer(() => ({
+        retryAll: retryAll2,
+      }))
 
       scheduleRetry1()
       scheduleRetry1()


### PR DESCRIPTION
## What

Second-highest client crash in Sentry (project `nuxt3`, ~1,000 events): `TypeError: Cannot use 'in' operator to search for 'error' in undefined`, thrown inside `@uppy/core` `retryAll()` → `@uppy/tus` → `@uppy/utils` `fileFilters` on chat image uploads.

## Root cause

`useUppyRetryCoalesce` already coalesces error-burst retries and catches **synchronous** throws from `retryAll()`. But in Uppy 4 `retryAll()` returns a **promise**, and this particular corruption (an `undefined` entry in Uppy's internal file list → `'error' in undefined`) surfaces from an async continuation inside the tus retry, so it **rejects the promise** instead of throwing synchronously. The `try/catch` misses it and it reaches Sentry uncaught.

## Fix

Attach a `.catch()` to the promise `retryAll()` returns, logging and containing the rejection alongside the existing synchronous guard. This is defensive hardening around a known Uppy-internal state-corruption path — it stops the uncaught error; it doesn't change upload behaviour.

## Tests

Adds a `useUppyRetryCoalesce.spec.js` case: a `retryAll()` that returns a rejected promise is caught and logged, not left unhandled. Full spec passes locally (12/12). (Also removes a pre-existing unused local the linter flagged on the touched file.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)