### PR TITLE
chore: comprehensive .gitattributes so Linguist reflects active code

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,14 +1,58 @@
-# Git attributes for FreegleDocker
+# Git attributes for FreegleDocker (one monorepo: Go APIs, Vue/Nuxt front ends,
+# Laravel batch, Kotlin/Swift apps, plus the retired V1 PHP monolith).
 
+# ─── Line endings ────────────────────────────────────────────────────────────
 # Bash scripts must always use LF (Unix) line endings, even on Windows
 *.sh text eol=lf
-
 # Windows batch files should use CRLF line endings
 *.cmd text eol=crlf
 *.bat text eol=crlf
-
 # Markdown and documentation can use platform-native line endings
 *.md text
-
 # Git hooks should always use LF (they are bash scripts)
 .git/hooks/* text eol=lf
+
+# ─── GitHub Linguist ─────────────────────────────────────────────────────────
+# Keep the repo's language stats reflecting the ACTIVELY-DEVELOPED code
+# (Go, Vue/JS/TS, Laravel PHP, Kotlin/Swift). Without these overrides the badge
+# is dominated by a bulk JSON data archive, generated migrations, and the
+# retired V1 PHP monolith. Linguist reads these attributes to decide what to
+# count; linguist-vendored / linguist-generated / linguist-documentation remove
+# a path from the language breakdown.
+
+# Retired V1 monolith — no longer developed (superseded by iznik-server-go +
+# iznik-batch). Kept for reference only, so don't count it as active code.
+iznik-server/** linguist-vendored
+
+# Bulk data archive of incoming messages — data, not source (thousands of JSON).
+iznik-batch/incoming-archive/** linguist-generated
+iznik-batch/incoming-archive/** linguist-vendored
+
+# Laravel migrations are machine-generated from the DB schema
+# (laravel-migrations-generator) — authoritative but boilerplate.
+iznik-batch/database/migrations/** linguist-generated
+
+# Generated Swagger / OpenAPI artefacts.
+iznik-server-go/swagger/** linguist-generated
+**/swagger.json linguist-generated
+
+# Dependency lock files.
+**/package-lock.json linguist-generated
+**/composer.lock linguist-generated
+**/yarn.lock linguist-generated
+**/pnpm-lock.yaml linguist-generated
+
+# Minified / bundled / source-map assets.
+*.min.js linguist-generated
+*.min.css linguist-generated
+*.map linguist-generated
+
+# Vendored third-party trees (usually gitignored, but be explicit).
+**/vendor/** linguist-vendored
+**/node_modules/** linguist-vendored
+
+# Documentation.
+*.md linguist-documentation
+docs/** linguist-documentation
+**/CHANGELOG* linguist-documentation
+LICENSE* linguist-documentation


### PR DESCRIPTION
## What

The repo's GitHub language badge was dominated by things that aren't actively-developed source, so it read as a PHP repo:

- **`iznik-batch/incoming-archive/`** — a ~9,500-file JSON data archive of incoming messages (data, not code)
- **`iznik-batch/database/migrations/`** — ~450 machine-generated Laravel migrations
- **`iznik-server-go/**/swagger/`** — generated Swagger/OpenAPI artefacts
- **`iznik-server/`** — the retired V1 PHP monolith (superseded by `iznik-server-go` + `iznik-batch`)

## Change

Add Linguist overrides (`linguist-vendored` / `linguist-generated` / `linguist-documentation`) for those paths, plus lock files, minified/bundled assets, and docs. Existing line-ending rules are preserved unchanged.

## Effect (counted source files)

| Language | before | after |
|---|--:|--:|
| PHP | 2224 | 929 |
| JSON | 9573 | 59 |
| JS | 1043 | 1040 |
| Vue | 668 | 668 |
| Go | 405 | 404 |
| TS | 104 | 104 |
| Kotlin | 33 | 33 |

The breakdown now reflects the real polyglot codebase — Go APIs, Vue/JS/TS front ends, active Laravel PHP, Kotlin/Swift apps — rather than a data archive and retired code. (Counts are by file; Linguist weighs by bytes, so exact percentages will differ, but the direction is the same.)

Verified each rule matches with `git check-attr`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)