### PR TITLE
fix(app): restore real "Rate this app" (was a web stub shipped to the app)

### DIFF
--- a/iznik-nuxt3/components/RateAppAsk.vue
+++ b/iznik-nuxt3/components/RateAppAsk.vue
@@ -1,13 +1,84 @@
 <template>
-  <!-- Stub component for web builds - actual implementation in app-ci-fd branch -->
-  <div></div>
+  <div class="rate-app-ask">
+    <h4 class="rate-app-ask__title">Enjoying Freegle?</h4>
+    <p class="mb-2">
+      If you like Freegle - or even if you don't - a quick rating and review
+      really helps other people find us. It only takes a moment.
+    </p>
+    <p class="text-muted small mb-0">
+      "Rate now" opens the {{ isiOS ? 'App Store' : 'Play Store' }}. The review
+      option isn't always available there - that's not our fault!
+    </p>
+    <div class="rate-app-ask__actions">
+      <b-button variant="outline-secondary" @click="notAgain">
+        Don't ask again
+      </b-button>
+      <b-button variant="success" @click="rateNow"> Rate now </b-button>
+    </div>
+  </div>
 </template>
 
 <script setup>
-// This is a stub component for web builds.
-// The real RateAppAsk component exists only in the app-ci-fd branch.
-// This stub prevents build errors when DonationAskModal imports it,
-// even though it's never actually used on web (rateapp variant is app-only).
+import { computed } from 'vue'
+import { useMobileStore } from '~/stores/mobile'
 
-defineEmits(['hide'])
+const emit = defineEmits(['hide'])
+
+const mobileStore = useMobileStore()
+const isiOS = computed(() => mobileStore.isiOS)
+
+// Store-review deep links. iOS opens the App Store review sheet directly;
+// Android's market:// hands off to the Play Store app for the listing.
+const IOS_REVIEW_URL =
+  'https://apps.apple.com/gb/app/freegle/id970045029?action=write-review'
+const ANDROID_REVIEW_URL = 'market://details?id=org.ilovefreegle.direct'
+
+function remember() {
+  try {
+    window.localStorage.setItem('rateappnotagain', 'true')
+  } catch (e) {
+    // localStorage can throw in private mode - not worth failing the action over.
+  }
+}
+
+function notAgain() {
+  remember()
+  emit('hide')
+}
+
+async function rateNow() {
+  remember()
+  const url = isiOS.value ? IOS_REVIEW_URL : ANDROID_REVIEW_URL
+  try {
+    // Dynamic import (matching ExternalLink.vue / stores/mobile.js) keeps the
+    // native plugin out of the web/SSR bundle, so this single component works in
+    // both the app build and the web build - no stub needed.
+    const { AppLauncher } = await import('@capacitor/app-launcher')
+    await AppLauncher.openUrl({ url })
+  } catch (e) {
+    // Launcher unavailable (e.g. plain web) - fall back to a normal navigation.
+    window.open(url, '_blank')
+  }
+  emit('hide')
+}
 </script>
+
+<style scoped lang="scss">
+.rate-app-ask {
+  background: white;
+  padding: 1.25rem;
+  text-align: center;
+}
+
+.rate-app-ask__title {
+  margin-bottom: 0.75rem;
+}
+
+.rate-app-ask__actions {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: center;
+  flex-wrap: wrap;
+  margin-top: 1rem;
+}
+</style>

--- a/iznik-nuxt3/tests/unit/components/RateAppAsk.spec.js
+++ b/iznik-nuxt3/tests/unit/components/RateAppAsk.spec.js
@@ -1,29 +1,101 @@
-import { describe, it, expect } from 'vitest'
-import { mount } from '@vue/test-utils'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
 import RateAppAsk from '~/components/RateAppAsk.vue'
 
+const { mockMobileStore, mockOpenUrl } = vi.hoisted(() => ({
+  mockMobileStore: { isiOS: false },
+  mockOpenUrl: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('~/stores/mobile', () => ({
+  useMobileStore: () => mockMobileStore,
+}))
+
+vi.mock('@capacitor/app-launcher', () => ({
+  AppLauncher: { openUrl: mockOpenUrl },
+}))
+
 describe('RateAppAsk', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockMobileStore.isiOS = false
+    window.localStorage.clear()
+  })
+
   function createWrapper() {
-    return mount(RateAppAsk)
+    return mount(RateAppAsk, {
+      global: {
+        stubs: {
+          'b-button': {
+            template:
+              '<button class="b-button" :class="variant" @click="$emit(\'click\')"><slot /></button>',
+            props: ['variant'],
+            emits: ['click'],
+          },
+        },
+      },
+    })
+  }
+
+  function findButton(wrapper, text) {
+    return wrapper.findAll('.b-button').find((b) => b.text().includes(text))
   }
 
   describe('rendering', () => {
-    it('renders stub container', () => {
+    it('renders the prompt and both buttons', () => {
       const wrapper = createWrapper()
-      expect(wrapper.find('div').exists()).toBe(true)
+      expect(wrapper.text()).toContain('Enjoying Freegle?')
+      expect(findButton(wrapper, 'Rate now')).toBeDefined()
+      expect(findButton(wrapper, "Don't ask again")).toBeDefined()
     })
 
-    it('renders empty content (stub)', () => {
-      const wrapper = createWrapper()
-      expect(wrapper.text()).toBe('')
+    it('names the Play Store on Android and the App Store on iOS', () => {
+      expect(createWrapper().text()).toContain('Play Store')
+      mockMobileStore.isiOS = true
+      expect(createWrapper().text()).toContain('App Store')
     })
   })
 
-  describe('emits', () => {
-    it('defines hide emit', () => {
+  describe('rate now', () => {
+    it('opens the Android review link and hides', async () => {
       const wrapper = createWrapper()
-      // Check that the component defines the hide emit
-      expect(wrapper.vm.$options.emits).toContain('hide')
+      await findButton(wrapper, 'Rate now').trigger('click')
+      await flushPromises()
+      expect(mockOpenUrl).toHaveBeenCalledWith({
+        url: 'market://details?id=org.ilovefreegle.direct',
+      })
+      expect(wrapper.emitted('hide')).toBeTruthy()
+      expect(window.localStorage.getItem('rateappnotagain')).toBe('true')
+    })
+
+    it('opens the App Store write-review link on iOS', async () => {
+      mockMobileStore.isiOS = true
+      const wrapper = createWrapper()
+      await findButton(wrapper, 'Rate now').trigger('click')
+      await flushPromises()
+      expect(mockOpenUrl).toHaveBeenCalledWith({
+        url: 'https://apps.apple.com/gb/app/freegle/id970045029?action=write-review',
+      })
+    })
+
+    it('still hides if the launcher throws', async () => {
+      mockOpenUrl.mockRejectedValueOnce(new Error('no launcher'))
+      const openSpy = vi.spyOn(window, 'open').mockImplementation(() => {})
+      const wrapper = createWrapper()
+      await findButton(wrapper, 'Rate now').trigger('click')
+      await flushPromises()
+      expect(openSpy).toHaveBeenCalled()
+      expect(wrapper.emitted('hide')).toBeTruthy()
+    })
+  })
+
+  describe("don't ask again", () => {
+    it('records the preference and hides without opening the store', async () => {
+      const wrapper = createWrapper()
+      await findButton(wrapper, "Don't ask again").trigger('click')
+      expect(window.localStorage.getItem('rateappnotagain')).toBe('true')
+      expect(mockOpenUrl).not.toHaveBeenCalled()
+      expect(wrapper.emitted('hide')).toBeTruthy()
     })
   })
 })


### PR DESCRIPTION
## What

Reported on Discourse #9858 (iOS): tapping the gold **"Rate this app"** link on the Help page shows a grey transparent overlay that does nothing.

## Root cause

`RateAppAsk.vue` was a stub — literally `<div></div>` — with a comment claiming the real implementation "exists only in the app-ci-fd branch". But **the apps are built from `production` (← master)**, so the app shipped the stub. `RateAppModal` opens (auto-shows), renders the empty stub inside a transparent modal, and the user sees the backdrop with no content. (My first pass wrongly assumed a separate app branch — corrected.)

## Fix

Implement the real component: it opens the store review page and remembers "don't ask again".
- iOS → `https://apps.apple.com/gb/app/freegle/id970045029?action=write-review`
- Android → `market://details?id=org.ilovefreegle.direct`

Crucially it loads `@capacitor/app-launcher` via a **dynamic import** inside the click handler — the same pattern used in `ExternalLink.vue` and `stores/mobile.js`. That keeps the native plugin out of the web/SSR bundle, so this single component works in **both** the app build and the web build with no stub (which is why the previous static-import version had to be stubbed for web).

## Tests

`RateAppAsk.spec.js` rewritten for the real component: renders the prompt + buttons, iOS vs Android review URLs, `AppLauncher.openUrl` called + `hide` emitted, launcher-throws fallback, and "don't ask again" records the preference without opening the store. 6/6 pass locally.

Note: since this ships in the app, the fix reaches users on the next app-store release.

Reported on Discourse: https://discourse.ilovefreegle.org/t/9858/1

🤖 Generated with [Claude Code](https://claude.com/claude-code)