### PR TITLE
feat(rippling): treat reports + Back to Pending as review verdicts

### DIFF
--- a/RIPPLING-OUT-FOR-MODERATORS.md
+++ b/RIPPLING-OUT-FOR-MODERATORS.md
@@ -177,14 +177,13 @@ because the poster is from out of area.
 
 ## Rejecting or removing a post on its home community
 
-This is different from a secondary rejection above. When a post is **rejected, deleted,
-withdrawn, or moved back to pending** on the community it was **originally posted to** (its
-home community), it is no longer a live offer there - so:
+This is different from a secondary rejection above. When a post is **rejected, deleted, or
+withdrawn** on the community it was **originally posted to** (its home community), it is no
+longer a live offer there - so:
 
 1. **It is pulled from every community it had rippled into**, automatically. You do not have
    to chase it around the neighbouring communities; removing it at home cleans it up
-   everywhere it had spread. This includes **Delete** and **Back to Pending** - taking a post
-   off the board on its home community, for any reason, takes its rippled copies down with it.
+   everywhere it had spread.
 2. **It stops spreading.** Its rippling is halted, so it will not appear on any further
    communities.
 
@@ -192,16 +191,101 @@ This is exactly what you want when you catch spam or a rule-breaking post on its
 community: dealing with it once removes it everywhere, instead of leaving live copies
 stranded on the neighbouring communities it had already reached.
 
-If you move a post **back to pending** and later **approve it again**, it starts rippling
-out afresh from your community - so re-approving simply lets it spread again as normal.
-
 The clean-up happens on the next rippling run (within about a minute), not the instant you
 click - so a rippled copy may linger very briefly before it disappears.
+
+(**Back to Pending** now works differently from Delete/Reject: it keeps each community's
+copy for per-group review and does **not** re-ripple on re-approval - see **Reporting a
+post** below.)
 
 The poster is also removed from any community they had been auto-joined to **only** to carry
 that post (i.e. where they have no other posts). They keep their home community and any
 community where they have other activity, and - because this is a tidy-up rather than them
 choosing to leave - a later post of theirs can still ripple into those communities normally.
+
+---
+
+## Reporting a post
+
+There are two different actions here, on two different sites, and it helps to keep them
+straight:
+
+- **Reporting** is a **Freegle-site (FD)** action - the **Report this post** link members
+  (and you) use while browsing the Freegle website.
+- **Approve / Reject / Back to Pending** are **ModTools (MT)** actions - what you do to a
+  post in your moderation queue.
+
+Reporting now has teeth: enough member reports, or a single moderator's report, pull the
+post back into your **Pending** queue in ModTools for review, rather than only sending a
+message to the volunteers.
+
+### When members report (on the Freegle site)
+
+A member's report is a **review vote**. Reports made with **Report this post** on the
+Freegle site and the in-app "Does this look OK?" microvolunteering checks count the same
+way - they are both members saying "something's not right" about a post.
+
+When **two** different members flag the same post, it is moved **back to Pending on every
+community it is on** - its home community *and* every community it had rippled into. From
+that point:
+
+- The post is **hidden from members** and **stops rippling** any further while it is under
+  review.
+- The copies are **not deleted** - each community keeps its own copy in its **Pending**
+  queue.
+- **Each community's moderators decide for themselves** whether to approve or reject their
+  own copy. One community's decision does not affect another's.
+
+> Two members flagging a post is treated as "worth a look everywhere", not "definitely
+> bad". It simply puts the post in front of every affected community's moderators - you
+> still make the call.
+
+### When you (a moderator) report (also on the Freegle site)
+
+When you use **Report this post** on the Freegle site, the report dialog shows **every
+community the post is on** and lets you **choose which ones to report it on** - with an
+**All communities** option to select them all at once.
+
+- Reporting it on a community moves **that community's copy** straight to Pending - your
+  moderator judgement counts on its own, no quorum needed.
+- Choose **All communities** to pull the post everywhere in one go (the same effect as Back
+  to Pending in ModTools) when it is bad for everyone.
+- Communities you **don't** pick are **left alone** - their copy stays live. If a post is
+  fine for one community but not another, report it only where it is a problem.
+
+### Approving or rejecting a reported post (in ModTools)
+
+Once a post is Pending from a report, you handle your community's copy in ModTools exactly
+as normal:
+
+- **Approve** puts it back live on your community. Members are **not** emailed again - it
+  simply reappears; there are no duplicate "new post" notifications, and it does **not**
+  re-ripple out from scratch.
+- **Reject** removes it from your community only (the usual low-stakes secondary rejection;
+  the poster is not told). Other communities are unaffected.
+
+A post being **held** (shown as "held by" a moderator) is **per community**, on that
+community's own Pending copy, and only applies while the copy is Pending. It is
+**independent**: a copy being held on one community has no effect on the same post's copy on
+any other community. You approve or reject your own community's copy regardless of whether
+another community has held, approved, or rejected theirs.
+
+Because each community's copy is independent and stays put, a reported post **cannot
+flip-flop**: one community approving it will never re-create a copy on a community that has
+rejected it.
+
+### Moving a post back to pending in ModTools
+
+You don't have to go via the Freegle site at all. Moving a post from **Approved back to
+Pending** in **ModTools** - the ordinary moderation action - now does the same thing as a
+report: it pulls the post to Pending on **every** community it is on (its home community and
+every rippled copy), not just yours.
+
+So one moderator catching a problem in ModTools takes the post off the board **everywhere**
+for review, instead of leaving live copies stranded on the neighbouring communities you
+cannot see. As with a report, the copies are **kept** (not deleted), each community approves
+or rejects its own, and **re-approving brings a copy back without re-notifying members or
+re-rippling from scratch**.
 
 ---
 

--- a/iznik-batch/app/Services/Ripple/ExpandService.php
+++ b/iznik-batch/app/Services/Ripple/ExpandService.php
@@ -298,7 +298,7 @@ class ExpandService
                 'SELECT mr.msgid AS msgid
                  FROM rippling_reach mr
                  LEFT JOIN messages_spatial ms ON ms.msgid = mr.msgid
-                 WHERE ms.msgid IS NULL' . $scopeSql,
+                 WHERE ms.msgid IS NULL AND mr.status <> \'held\'' . $scopeSql,
                 $params
             );
             if (empty($stale)) {
@@ -355,7 +355,7 @@ class ExpandService
                    FROM rippling_reach mr
                    JOIN messages_groups mg
                      ON mg.msgid = mr.msgid AND mg.rippled_in = 1 AND mg.deleted = 0
-                  WHERE NOT EXISTS (
+                  WHERE mr.status <> \'held\' AND NOT EXISTS (
                           SELECT 1 FROM messages_groups o
                            WHERE o.msgid = mr.msgid AND o.rippled_in = 0
                              AND o.deleted = 0 AND o.collection = ?
@@ -455,6 +455,7 @@ class ExpandService
                JOIN `groups` g ON g.id = mg.groupid
                JOIN rippling_reach rr ON rr.msgid = mg.msgid
               WHERE mg.msgid = ? AND mg.rippled_in = 1 AND mg.deleted = 0
+                AND rr.status <> 'held'
                 AND g.polyindex IS NOT NULL AND ST_GeometryType(g.polyindex) <> 'POINT'
                 AND NOT ST_Intersects(g.polyindex, rr.polygon)",
             [$msgid]

--- a/iznik-batch/database/migrations/2026_07_04_000001_add_held_to_rippling_reach_status.php
+++ b/iznik-batch/database/migrations/2026_07_04_000001_add_held_to_rippling_reach_status.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Adds 'held' to rippling_reach.status.
+ *
+ * 'held' marks a post whose ripple has been frozen because it was pulled back to Pending for
+ * review - a report / microvolunteering quorum, or a moderator Back to Pending. Unlike 'done'
+ * (a normally-completed ripple, which stays retractable), a 'held' post keeps its rippled-in
+ * copies as Pending for per-group moderation, so ExpandService's retraction paths must SKIP
+ * it. Freezing the reach row (rather than deleting it) also stops initialiseNew's anti-join
+ * (WHERE mr.msgid IS NULL) from re-reaching and re-notifying the post if a moderator later
+ * re-approves a copy.
+ *
+ * Additive + idempotent so it never conflicts with the create migration on branch merges.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (!Schema::hasTable('rippling_reach')) {
+            return;
+        }
+        DB::statement("ALTER TABLE rippling_reach MODIFY status ENUM('expanding','stopped','done','held') NOT NULL DEFAULT 'expanding'");
+    }
+
+    public function down(): void
+    {
+        if (!Schema::hasTable('rippling_reach')) {
+            return;
+        }
+        DB::statement("ALTER TABLE rippling_reach MODIFY status ENUM('expanding','stopped','done') NOT NULL DEFAULT 'expanding'");
+    }
+};

--- a/iznik-batch/database/migrations/2026_07_04_000001_add_held_to_rippling_reach_status_migration.sql
+++ b/iznik-batch/database/migrations/2026_07_04_000001_add_held_to_rippling_reach_status_migration.sql
@@ -1,0 +1,19 @@
+-- Production idempotent SQL: add 'held' to rippling_reach.status.
+-- 'held' freezes a post's ripple when it is pulled back to Pending for review (report /
+-- microvolunteering quorum, or moderator Back to Pending): the rippled-in copies are kept as
+-- Pending for per-group moderation, so ExpandService's retraction paths skip 'held' posts, and
+-- keeping (not deleting) the reach row stops initialiseNew re-reaching + re-notifying on a later
+-- re-approval.
+SET @has_held := (
+    SELECT COUNT(*) FROM information_schema.columns
+    WHERE table_schema = DATABASE()
+      AND table_name = 'rippling_reach'
+      AND column_name = 'status'
+      AND column_type LIKE '%''held''%'
+);
+SET @ddl := IF(@has_held = 0,
+    "ALTER TABLE rippling_reach MODIFY status ENUM('expanding','stopped','done','held') NOT NULL DEFAULT 'expanding'",
+    'SELECT 1');
+PREPARE stmt FROM @ddl;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;

--- a/iznik-batch/tests/Unit/Services/Ripple/ExpandServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/Ripple/ExpandServiceTest.php
@@ -506,6 +506,73 @@ class ExpandServiceTest extends TestCase
         $this->assertSame(0, DB::table('rippling_reach')->where('msgid', $message->id)->count());
     }
 
+    public function test_held_reach_persists_pending_copies_and_reach_row(): void
+    {
+        // A report / microvolunteering quorum (or a moderator Back to Pending) pulls a post to
+        // Pending on all its groups and FREEZES the reach (status='held'). The Pending
+        // rippled-in copies must persist for per-group moderation and the reach row must NOT be
+        // removed - so a later per-group re-approval brings a copy back without re-rippling.
+        Http::fake();
+        $user = $this->createTestUser();
+        $origin = $this->createTestGroup();
+        $rippled = $this->createTestGroup();
+        $message = Message::create([
+            'type' => Message::TYPE_OFFER, 'fromuser' => $user->id,
+            'subject' => 'OFFER: held', 'textbody' => 'x', 'source' => 'Platform',
+            'date' => now()->subDay(), 'arrival' => now()->subDay(), 'lat' => 51.5, 'lng' => -0.1,
+        ]);
+        MessageGroup::create(['msgid' => $message->id, 'groupid' => $origin->id, 'collection' => MessageGroup::COLLECTION_PENDING, 'arrival' => now()->subDay()]);
+        MessageGroup::create(['msgid' => $message->id, 'groupid' => $rippled->id, 'collection' => MessageGroup::COLLECTION_PENDING, 'arrival' => now()->subDay()]);
+        DB::table('messages_groups')->where('msgid', $message->id)->where('groupid', $rippled->id)->update(['rippled_in' => 1]);
+        // Frozen reach. The post is Pending → not in messages_spatial, so the stale/orphan
+        // retraction paths would normally fire and delete the copies + reach row.
+        DB::statement(
+            "INSERT INTO rippling_reach
+               (msgid, lat, lng, polygon, arrival, mode, tick, total_ticks, total_freeglers,
+                max_drive_min, schedule, next_expansion_at, status, created_at, updated_at)
+             VALUES (?, 51.5, -0.1, ST_GeomFromText(?, 3857), ?, 'drive', 3, 3, 90, 30, NULL, NULL, 'held', NOW(), NOW())",
+            [$message->id, self::WKT, now()->subDay()]
+        );
+
+        $this->service()->process(false, 500);
+
+        $this->assertSame(1, DB::table('rippling_reach')->where('msgid', $message->id)->count(),
+            'held reach row must persist (removeStaleAndRetract skips held)');
+        $copy = DB::table('messages_groups')->where('msgid', $message->id)->where('groupid', $rippled->id)->first();
+        $this->assertSame(0, (int) $copy->deleted, 'held post rippled-in copy must not be retracted');
+        $this->assertSame(MessageGroup::COLLECTION_PENDING, $copy->collection, 'held post rippled-in copy stays Pending');
+    }
+
+    public function test_non_held_orphaned_reach_is_removed(): void
+    {
+        // Contrast: an ordinary (non-held) reach whose post has left messages_spatial IS
+        // removed - proving the 'held' guard is what protects the report/back-to-pending copies.
+        Http::fake();
+        $user = $this->createTestUser();
+        $origin = $this->createTestGroup();
+        $rippled = $this->createTestGroup();
+        $message = Message::create([
+            'type' => Message::TYPE_OFFER, 'fromuser' => $user->id,
+            'subject' => 'OFFER: gone', 'textbody' => 'x', 'source' => 'Platform',
+            'date' => now()->subDay(), 'arrival' => now()->subDay(), 'lat' => 51.5, 'lng' => -0.1,
+        ]);
+        MessageGroup::create(['msgid' => $message->id, 'groupid' => $origin->id, 'collection' => MessageGroup::COLLECTION_PENDING, 'arrival' => now()->subDay()]);
+        MessageGroup::create(['msgid' => $message->id, 'groupid' => $rippled->id, 'collection' => MessageGroup::COLLECTION_PENDING, 'arrival' => now()->subDay()]);
+        DB::table('messages_groups')->where('msgid', $message->id)->where('groupid', $rippled->id)->update(['rippled_in' => 1]);
+        DB::statement(
+            "INSERT INTO rippling_reach
+               (msgid, lat, lng, polygon, arrival, mode, tick, total_ticks, total_freeglers,
+                max_drive_min, schedule, next_expansion_at, status, created_at, updated_at)
+             VALUES (?, 51.5, -0.1, ST_GeomFromText(?, 3857), ?, 'drive', 3, 3, 90, 30, NULL, NULL, 'done', NOW(), NOW())",
+            [$message->id, self::WKT, now()->subDay()]
+        );
+
+        $this->service()->process(false, 500);
+
+        $this->assertSame(0, DB::table('rippling_reach')->where('msgid', $message->id)->count(),
+            'a non-held reach whose post left spatial is removed as normal');
+    }
+
     public function test_handles_filtered_empty_polygon_tick_and_still_completes(): void
     {
         // Routing returns all 3 ticks, but tick 2's polygon is empty → it is filtered

--- a/iznik-server-go/chat/chatmessage.go
+++ b/iznik-server-go/chat/chatmessage.go
@@ -12,6 +12,7 @@ import (
 	"github.com/freegle/iznik-server-go/auth"
 	"github.com/freegle/iznik-server-go/database"
 	"github.com/freegle/iznik-server-go/log"
+	"github.com/freegle/iznik-server-go/microvolunteering"
 	"github.com/freegle/iznik-server-go/misc"
 	"github.com/freegle/iznik-server-go/user"
 	"github.com/freegle/iznik-server-go/utils"
@@ -482,6 +483,25 @@ func CreateChatMessage(c *fiber.Ctx) error {
 			myid, utils.COLLECTION_APPROVED, *payload.Refmsgid).Scan(&wasHome)
 		db.Exec("INSERT IGNORE INTO rippling_reply_attribution (msgid, userid, replied_at, was_home_member) "+
 			"VALUES (?, ?, NOW(), ?)", *payload.Refmsgid, myid, wasHome)
+	}
+
+	// A report from the website is a User2Mod chat message referencing the reported
+	// post (that's what the report flow sends). Treat it as a microvolunteering Reject
+	// verdict feeding the review quorum: a moderator of the reported community pulls that
+	// community's copy to Pending, and once the quorum of verdicts is reached the post is
+	// pulled to Pending on ALL its groups. The report's target community is the User2Mod
+	// chat's group. Only User2Mod refmsgid messages are reports - a User2User refmsgid
+	// message is an Interested reply to the poster, not a report. Best-effort: never
+	// blocks the report.
+	if chattype == utils.CHAT_MESSAGE_INTERESTED && payload.Refmsgid != nil {
+		var reportRoom struct {
+			Chattype string
+			Groupid  uint64
+		}
+		db.Raw("SELECT chattype, COALESCE(groupid, 0) AS groupid FROM chat_rooms WHERE id = ?", id).Scan(&reportRoom)
+		if reportRoom.Chattype == utils.CHAT_TYPE_USER2MOD {
+			microvolunteering.RecordReportVerdict(db, myid, *payload.Refmsgid, reportRoom.Groupid, payload.Message)
+		}
 	}
 
 	if payload.Imageid != nil {

--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -2409,9 +2409,20 @@ func handleBackToPending(c *fiber.Ctx, myid uint64, req PostMessageRequest) erro
 	// Also update messages.heldby for backwards compatibility.
 	db.Exec("UPDATE messages SET heldby = ? WHERE id = ?", myid, req.ID)
 
-	// Move from Approved back to Pending for authorized groups.
-	db.Exec("UPDATE messages_groups SET collection = ?, approvedby = NULL, approvedat = NULL WHERE msgid = ? AND groupid IN ? AND collection = ?",
-		utils.COLLECTION_PENDING, req.ID, authorizedGroups, utils.COLLECTION_APPROVED)
+	// Pull the WHOLE post back to Pending, not just this mod's groups: a moderator moving
+	// any copy back to pending takes the post off the board on EVERY community it is on
+	// (home + rippled-out copies), so it is never left stranded and still visible on the
+	// neighbouring communities. Each community then approves or rejects its own copy
+	// independently. Clear approvedby/approvedat on every live copy first, then flip to
+	// Pending.
+	db.Exec("UPDATE messages_groups SET approvedby = NULL, approvedat = NULL WHERE msgid = ? AND collection = ?",
+		req.ID, utils.COLLECTION_APPROVED)
+	microvolunteering.SendForReviewAllGroups(db, req.ID, "A moderator moved this post back to pending for review.")
+
+	// Freeze the ripple once the origin is Pending: the copies persist for per-group
+	// moderation and a later re-approval brings a copy back without re-rippling or
+	// re-notifying members.
+	microvolunteering.FreezeReachIfOriginPending(db, req.ID)
 
 	// Log to each group we acted on.
 	for _, gid := range authorizedGroups {

--- a/iznik-server-go/microvolunteering/microvolunteering.go
+++ b/iznik-server-go/microvolunteering/microvolunteering.go
@@ -723,10 +723,12 @@ func PostResponse(c *fiber.Ctx) error {
 					req.Msgid).Scan(&rejectCount)
 
 				if rejectCount >= int64(ApprovalQuorum) {
-					// Quorum reached — send the message for review on the group
-					// the voter is acting in. Other groups the message is on are
-					// left alone; their members can flag it independently.
-					sendForReview(db, req.Msgid, req.Groupid, "Members think there is something wrong with this message.")
+					// Quorum reached — pull the post back to Pending on ALL the
+					// groups it is live on (home + rippled-out copies), so every
+					// affected community's moderators review it, not only the group
+					// where this vote happened, then freeze the ripple.
+					SendForReviewAllGroups(db, req.Msgid, "Members think there is something wrong with this message.")
+					FreezeReachIfOriginPending(db, req.Msgid)
 				}
 			}
 		}
@@ -884,20 +886,116 @@ func ModFeedback(c *fiber.Ctx) error {
 	return c.JSON(fiber.Map{"ret": 0, "status": "Success"})
 }
 
-// sendForReview moves a message back to Pending on a single group and records
-// the spam reason on that group's row. Other groups the message is on are
-// left alone — each group's members must reach quorum independently to send
-// it for review on their group.
-//
-// If groupid is 0 (legacy clients that don't yet send a group context), no
-// update is made. The client is expected to pass the group the volunteer is
-// voting in via the request body.
-func sendForReview(db *gorm.DB, msgid uint64, groupid uint64, reason string) {
-	if groupid == 0 {
+// SendForReviewAllGroups moves a message back to Pending on ALL the groups it is
+// currently live (Approved) on - its home group AND any rippled-out copies. Used once
+// the aggregate review quorum is reached (from in-app CheckMessage checks or website
+// reports) or on a moderator Back to Pending, so every affected community's moderators
+// see the post. Only Approved rows are touched. Exported so the moderation path reuses it.
+func SendForReviewAllGroups(db *gorm.DB, msgid uint64, reason string) {
+	if msgid == 0 {
+		return
+	}
+	db.Exec("UPDATE messages_groups SET collection = ?, spamreason = ? WHERE msgid = ? AND collection = ?",
+		utils.COLLECTION_PENDING, reason, msgid, utils.COLLECTION_APPROVED)
+}
+
+// sendForReviewGroup moves a single group's copy back to Pending - used for a
+// moderator's scoped report (they reported the post on that community only).
+func sendForReviewGroup(db *gorm.DB, msgid uint64, groupid uint64, reason string) {
+	if msgid == 0 || groupid == 0 {
 		return
 	}
 	db.Exec("UPDATE messages_groups SET collection = ?, spamreason = ? WHERE msgid = ? AND groupid = ? AND collection = ?",
 		utils.COLLECTION_PENDING, reason, msgid, groupid, utils.COLLECTION_APPROVED)
+}
+
+// FreezeReachIfOriginPending freezes a post's ripple once its ORIGIN copy is no longer
+// live-Approved (pulled back for review). Freezing keeps the rippling_reach row but sets
+// status='held' + next_expansion_at=NULL, so: (a) it stops expanding, (b) ExpandService's
+// retraction paths skip it and the Pending rippled copies persist for per-group
+// moderation, and (c) initialiseNew's anti-join can never re-reach + re-notify it if a
+// moderator later re-approves a copy. No-op if the origin is still live, or there is no
+// reach row. Exported for the moderation Back to Pending path.
+func FreezeReachIfOriginPending(db *gorm.DB, msgid uint64) {
+	if msgid == 0 {
+		return
+	}
+	var approvedOrigin int64
+	db.Raw("SELECT COUNT(*) FROM messages_groups WHERE msgid = ? AND rippled_in = 0 AND deleted = 0 AND collection = ?",
+		msgid, utils.COLLECTION_APPROVED).Scan(&approvedOrigin)
+	if approvedOrigin > 0 {
+		return
+	}
+	db.Exec("UPDATE rippling_reach SET status = 'held', next_expansion_at = NULL WHERE msgid = ? AND status <> 'held'", msgid)
+}
+
+// reporterIsModOf reports whether the reporter's verdict on the group they reported on
+// is authoritative on its own: Support/Admin, or a Moderator/Owner of that group.
+func reporterIsModOf(db *gorm.DB, reporterID uint64, groupid uint64) bool {
+	if auth.IsAdminOrSupport(reporterID) {
+		return true
+	}
+	if groupid == 0 {
+		return false
+	}
+	var c int64
+	db.Raw("SELECT COUNT(*) FROM memberships WHERE userid = ? AND groupid = ? AND role IN (?, ?)",
+		reporterID, groupid, utils.ROLE_MODERATOR, utils.ROLE_OWNER).Scan(&c)
+	return c > 0
+}
+
+// RecordReportVerdict treats a report of a post (the User2Mod chat message the website
+// report flow sends, targeted at `groupid`) as a microvolunteering "Reject" verdict, so
+// website reports feed the SAME review quorum as in-app CheckMessage checks:
+//   - a MODERATOR of the reported group (or Support/Admin) pulls THAT community's copy to
+//     Pending on its own - scoped, their choice of which communities to report on;
+//   - once ApprovalQuorum distinct Reject verdicts accumulate, the post is pulled to
+//     Pending on ALL its groups (home + rippled-out).
+// Whenever the origin copy ends up Pending the ripple is frozen, so the copies persist for
+// per-group moderation and it never re-ripples/re-notifies on a later re-approval.
+// Best-effort: never blocks the report itself.
+func RecordReportVerdict(db *gorm.DB, reporterID uint64, msgid uint64, groupid uint64, comments string) {
+	if reporterID == 0 || msgid == 0 {
+		return
+	}
+
+	// A poster reporting their own post must not count toward the quorum.
+	var fromuser uint64
+	db.Raw("SELECT fromuser FROM messages WHERE id = ?", msgid).Scan(&fromuser)
+	if fromuser == reporterID {
+		return
+	}
+
+	// Record the report as a CheckMessage Reject verdict: ShouldntBeHere + non-null
+	// comments so it counts toward the quorum, exactly like an in-app "something's not
+	// right" check. The (userid, msgid) unique key makes a repeat report one verdict.
+	if comments == "" {
+		comments = "Reported via the website"
+	}
+	db.Exec(`INSERT INTO microactions (actiontype, userid, msgid, result, msgcategory, comments, version, score_negative)
+			VALUES (?, ?, ?, 'Reject', 'ShouldntBeHere', ?, ?, 0)
+			ON DUPLICATE KEY UPDATE result = 'Reject', msgcategory = 'ShouldntBeHere', comments = ?, version = ?`,
+		ChallengeCheckMessage, reporterID, msgid, comments, Version, comments, Version)
+
+	const reason = "Members or moderators think there is something wrong with this message."
+
+	// A moderator's report is authoritative for the community they reported on.
+	if reporterIsModOf(db, reporterID, groupid) {
+		sendForReviewGroup(db, msgid, groupid, reason)
+	}
+
+	// Aggregate quorum (all distinct Reject verdicts, reports or in-app checks) pulls
+	// the post to Pending on every community it is on.
+	var rejectCount int64
+	db.Raw(`SELECT COUNT(*) FROM microactions
+			WHERE msgid = ? AND result = 'Reject' AND comments IS NOT NULL
+			AND (msgcategory IS NULL OR msgcategory = 'ShouldntBeHere')`, msgid).Scan(&rejectCount)
+	if rejectCount >= int64(ApprovalQuorum) {
+		SendForReviewAllGroups(db, msgid, reason)
+	}
+
+	// If the origin copy is now Pending, freeze the ripple (stops spread + re-reach).
+	FreezeReachIfOriginPending(db, msgid)
 }
 
 // listMicroActions returns microvolunteering activity for moderator review.

--- a/iznik-server-go/test/message_test.go
+++ b/iznik-server-go/test/message_test.go
@@ -8020,7 +8020,7 @@ func TestPostMessageSpamPerGroup(t *testing.T) {
 	assert.Equal(t, 0, isDeleted, "Message should not be soft-deleted when still on another group")
 }
 
-func TestPostMessageBackToPendingPerGroup(t *testing.T) {
+func TestPostMessageBackToPendingPullsAllGroups(t *testing.T) {
 	prefix := uniquePrefix("btp_pg")
 	db := database.DBConn
 
@@ -8039,7 +8039,10 @@ func TestPostMessageBackToPendingPerGroup(t *testing.T) {
 	db.Exec("UPDATE messages_groups SET collection = 'Approved' WHERE msgid = ? AND groupid = ?", msgID, groupA)
 	db.Exec("INSERT INTO messages_groups (msgid, groupid, arrival, collection, autoreposts) VALUES (?, ?, NOW(), 'Approved', 0)", msgID, groupB)
 
-	// BackToPending on group A only.
+	// BackToPending on group A now pulls the WHOLE post back to Pending (every group it
+	// is on), so a rippled post is never left stranded and still visible elsewhere. The
+	// acting mod holds their acted-on group (A); other groups go Pending awaiting their
+	// own mods.
 	body := map[string]interface{}{
 		"id":      msgID,
 		"action":  "BackToPending",
@@ -8063,10 +8066,11 @@ func TestPostMessageBackToPendingPerGroup(t *testing.T) {
 	assert.NotNil(t, heldbyA)
 	assert.Equal(t, modID, *heldbyA)
 
-	// Group B should still be Approved and not held.
+	// Group B is ALSO pulled to Pending (the whole post is taken off the board), but is
+	// NOT held by this mod — they acted on group A, so only A carries their heldby.
 	var collectionB string
 	db.Raw("SELECT collection FROM messages_groups WHERE msgid = ? AND groupid = ?", msgID, groupB).Scan(&collectionB)
-	assert.Equal(t, "Approved", collectionB)
+	assert.Equal(t, "Pending", collectionB)
 
 	var heldbyB *uint64
 	db.Raw("SELECT heldby FROM messages_groups WHERE msgid = ? AND groupid = ?", msgID, groupB).Scan(&heldbyB)

--- a/iznik-server-go/test/microvolunteering_report_test.go
+++ b/iznik-server-go/test/microvolunteering_report_test.go
@@ -1,0 +1,110 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/freegle/iznik-server-go/microvolunteering"
+	"github.com/freegle/iznik-server-go/utils"
+)
+
+// addRippledCopy adds a rippled-in (rippled_in=1) Approved copy of msgid on groupid.
+func addRippledCopy(msgid, groupid uint64) {
+	database.DBConn.Exec(
+		"INSERT INTO messages_groups (msgid, groupid, arrival, collection, autoreposts, rippled_in) "+
+			"VALUES (?, ?, NOW(), 'Approved', 0, 1)", msgid, groupid)
+}
+
+// addReachRow seeds a rippling_reach row for msgid with the given status.
+func addReachRow(msgid uint64, status string) {
+	database.DBConn.Exec(
+		"INSERT INTO rippling_reach (msgid, lat, lng, polygon, arrival, mode, tick, total_ticks, "+
+			"total_freeglers, max_drive_min, schedule, next_expansion_at, status, created_at, updated_at) "+
+			"VALUES (?, 51.5, -0.1, ST_GeomFromText('POLYGON((-0.1 51.5, -0.2 51.5, -0.2 51.6, -0.1 51.6, -0.1 51.5))', ?), "+
+			"NOW(), 'drive', 1, 3, 90, 30, NULL, NULL, ?, NOW(), NOW())", msgid, utils.SRID, status)
+}
+
+func collectionOf(msgid, groupid uint64) string {
+	var c string
+	database.DBConn.Raw("SELECT collection FROM messages_groups WHERE msgid = ? AND groupid = ?", msgid, groupid).Scan(&c)
+	return c
+}
+
+func reachStatusOf(msgid uint64) string {
+	var s string
+	database.DBConn.Raw("SELECT status FROM rippling_reach WHERE msgid = ?", msgid).Scan(&s)
+	return s
+}
+
+// A quorum of member reports pulls the post to Pending on ALL its groups (home + rippled)
+// and freezes the reach.
+func TestReportVerdictMemberQuorumPendsAllGroupsAndFreezes(t *testing.T) {
+	db := database.DBConn
+	poster := CreateTestUser(t, "rvposter", "User")
+	origin := CreateTestGroup(t, "rvorigin")
+	rippled := CreateTestGroup(t, "rvrippled")
+	m1 := CreateTestUser(t, "rvmem1", "User")
+	m2 := CreateTestUser(t, "rvmem2", "User")
+	msgid := CreateTestMessage(t, poster, origin, "OFFER: rvquorum", 51.5, -0.1)
+	addRippledCopy(msgid, rippled)
+	addReachRow(msgid, "expanding")
+
+	// One member report → below quorum → nothing pended.
+	microvolunteering.RecordReportVerdict(db, m1, msgid, origin, "spam")
+	if collectionOf(msgid, origin) != utils.COLLECTION_APPROVED || collectionOf(msgid, rippled) != utils.COLLECTION_APPROVED {
+		t.Fatalf("one member report must not pend anything: origin=%s rippled=%s",
+			collectionOf(msgid, origin), collectionOf(msgid, rippled))
+	}
+
+	// Second, different member → quorum → all groups Pending + reach frozen.
+	microvolunteering.RecordReportVerdict(db, m2, msgid, rippled, "spam")
+	if collectionOf(msgid, origin) != utils.COLLECTION_PENDING {
+		t.Errorf("origin must be Pending after quorum, got %s", collectionOf(msgid, origin))
+	}
+	if collectionOf(msgid, rippled) != utils.COLLECTION_PENDING {
+		t.Errorf("rippled copy must be Pending after quorum, got %s", collectionOf(msgid, rippled))
+	}
+	if reachStatusOf(msgid) != "held" {
+		t.Errorf("reach must be frozen 'held' once the origin is Pending, got %s", reachStatusOf(msgid))
+	}
+}
+
+// A moderator's report is scoped to the community they reported on; other communities
+// (including the origin) are unaffected and the reach keeps running.
+func TestReportVerdictModScopedToReportedGroup(t *testing.T) {
+	db := database.DBConn
+	poster := CreateTestUser(t, "rvmodposter", "User")
+	origin := CreateTestGroup(t, "rvmodorigin")
+	rippled := CreateTestGroup(t, "rvmodrippled")
+	mod := CreateTestUser(t, "rvmodreporter", "User")
+	CreateTestMembership(t, mod, rippled, "Moderator") // moderator of the rippled group only
+	msgid := CreateTestMessage(t, poster, origin, "OFFER: rvmodscope", 51.5, -0.1)
+	addRippledCopy(msgid, rippled)
+	addReachRow(msgid, "expanding")
+
+	microvolunteering.RecordReportVerdict(db, mod, msgid, rippled, "not ok here")
+
+	if collectionOf(msgid, rippled) != utils.COLLECTION_PENDING {
+		t.Errorf("a mod's report on the rippled group must pend that copy, got %s", collectionOf(msgid, rippled))
+	}
+	if collectionOf(msgid, origin) != utils.COLLECTION_APPROVED {
+		t.Errorf("the origin must stay Approved when a mod reports only a rippled group, got %s", collectionOf(msgid, origin))
+	}
+	if reachStatusOf(msgid) == "held" {
+		t.Errorf("reach must NOT be frozen while the origin is still live")
+	}
+}
+
+// Reporting your own post does not count toward the quorum.
+func TestReportVerdictOwnPostIgnored(t *testing.T) {
+	db := database.DBConn
+	poster := CreateTestUser(t, "rvownposter", "User")
+	origin := CreateTestGroup(t, "rvownorigin")
+	msgid := CreateTestMessage(t, poster, origin, "OFFER: rvownpost", 51.5, -0.1)
+
+	microvolunteering.RecordReportVerdict(db, poster, msgid, origin, "spam")
+
+	if collectionOf(msgid, origin) != utils.COLLECTION_APPROVED {
+		t.Errorf("reporting your own post must not pend it, got %s", collectionOf(msgid, origin))
+	}
+}


### PR DESCRIPTION
## What

Website **Report this post** now feeds the same review quorum as in-app microvolunteering CheckMessage checks, and a ModTools **Back to Pending** pulls a rippled post off the board on every community it reached.

## Why

A rippled post could be pulled back to Pending on only one community while its copies stayed live (Approved) elsewhere - leaving it stranded and still visible on the neighbouring communities it had rippled into. Raised on Discourse: https://discourse.ilovefreegle.org/t/rippling-out/9808/471

## Behaviour

- **Member reports** are recorded as microvolunteering Reject verdicts. Once `ApprovalQuorum` distinct verdicts accumulate (reports or in-app checks), the post is pulled to Pending on **all** its groups (home + rippled-out).
- A **moderator's report** is scoped to the community they reported on - their choice of which communities. Support/Admin, or a mod/owner of the reported group, pends that copy on its own.
- **ModTools Back to Pending** pulls the whole post to Pending on every group.
- Whenever the origin copy ends up Pending the ripple is **frozen** (`rippling_reach.status='held'`) rather than deleted, so the Pending copies persist for independent per-group moderation and the post never re-ripples or re-notifies members on a later re-approval. `ExpandService`'s retraction paths skip `held` posts.

## Changes

- Migration adds the `held` reach status (`.php` + idempotent prod `.sql`).
- `ExpandService.php`: all three retraction paths skip `held`.
- Go `microvolunteering` (verdict recording + freeze), `chat` (report hook passes the User2Mod chat's group), `message` (Back to Pending → all groups + freeze).
- `RIPPLING-OUT-FOR-MODERATORS.md`: new "Reporting a post" section distinguishing Freegle-site reporting from ModTools Back to Pending.

## Tests (both suites green)

- **Go**: member quorum → all groups + freeze; mod scoped to reported group; own-post ignored; Back to Pending pulls all groups.
- **Laravel**: retraction skips `held` + a non-held contrast.

## Deliberately not included

Blocking replies while a post is under review. A member who was notified (or who received a link the poster shared) can still reply to a Pending post. That needs client-side handling of the poster-share case, so it is deferred as a separate feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ZeG2zmg2JCR8pYEjAUaAk
