### PR TITLE
fix(browse): "Newest posted" by original post time; keep distance-slider headroom (Discourse 9844)

### DIFF
--- a/iznik-nuxt3/components/PostFilters.vue
+++ b/iznik-nuxt3/components/PostFilters.vue
@@ -366,11 +366,28 @@ const feedMax = computed(() => {
     .map((m) => m.distance)
     .filter((d) => typeof d === 'number' && isFinite(d))
 
-  if (!distances.length) {
-    return FEED_MAX_FLOOR
-  }
+  const dataMax = distances.length
+    ? Math.max(FEED_MAX_FLOOR, Math.ceil(Math.max(...distances)))
+    : FEED_MAX_FLOOR
 
-  return Math.max(FEED_MAX_FLOOR, Math.ceil(Math.max(...distances)))
+  // The server PRE-FILTERS the feed to the member's saved browseMaxDistance (so the feed
+  // matches the unread count). That means once a narrow distance is saved, the farthest loaded
+  // post - and hence dataMax - collapses down to roughly that distance, so the thumb (positioned
+  // at the saved distance) would pin to the far right, indistinguishable from "Further"/unlimited.
+  // A member who pulled the slider in then came back saw a SMALL blue coverage area but the thumb
+  // at maximum (Discourse 9844). Keep headroom above a finite saved distance so a narrow setting
+  // still reads as narrow, with room to widen. When the feed is NOT pre-filtered (dataMax already
+  // exceeds the saved distance) the Math.max leaves the true feed extent untouched.
+  const saved = me.value?.settings?.browseMaxDistance
+  const savedFinite =
+    typeof saved === 'number' && saved > 0 && saved < BROWSE_DISTANCE_UNLIMITED
+      ? saved
+      : 0
+  const withHeadroom = savedFinite
+    ? Math.max(savedFinite + 1, Math.ceil(savedFinite * 1.25))
+    : 0
+
+  return Math.max(FEED_MAX_FLOOR, dataMax, withHeadroom)
 })
 
 // Distance is meaningless without a known location.

--- a/iznik-nuxt3/composables/useMessageSort.js
+++ b/iznik-nuxt3/composables/useMessageSort.js
@@ -25,10 +25,25 @@ export function sortBrowseMessages(messages, selectedSort) {
   // only pay for Date parsing when a recency tiebreak/order is actually needed.
   const needsRecency = selectedSort !== 'Unseen'
 
+  // "Newest posted" (and the recency tiebreak) means ORIGINAL post time - `m.posted`,
+  // which the server exposes as the stable messages.arrival. We must NOT use `m.arrival`
+  // here: on the reach feed that is the messages_spatial arrival, which the reach engine
+  // bumps forward every time the post ripples into a new group, so ordering by it floats a
+  // days-old post to the top the moment its reach grows again while the card still shows the
+  // original "3 days ago" - the exact "Newest posted isn't chronological" bug (Discourse
+  // 9844). Fall back to `m.arrival` only when `posted` is absent (older cached feeds); guard
+  // against the Go zero-time sentinel (serialised as year 0001, i.e. a large negative epoch)
+  // that appears on any path that didn't populate posted.
+  const recencyTs = (m) => {
+    const posted = m.posted ? new Date(m.posted).getTime() : NaN
+    if (Number.isFinite(posted) && posted > 0) return posted
+    return new Date(m.arrival).getTime()
+  }
+
   const decorated = list.map((m) => ({
     m,
     dist: isNearby && Number.isFinite(m.distance) ? m.distance : Infinity,
-    ts: needsRecency ? new Date(m.arrival).getTime() : 0,
+    ts: needsRecency ? recencyTs(m) : 0,
   }))
 
   decorated.sort((a, b) => {

--- a/iznik-nuxt3/tests/unit/components/PostFilters.spec.js
+++ b/iznik-nuxt3/tests/unit/components/PostFilters.spec.js
@@ -505,6 +505,29 @@ describe('PostFilters', () => {
       expect(Number(input.element.value)).toBe(3)
     })
 
+    // Discourse 9844: the server pre-filters the feed to the saved browseMaxDistance, so after
+    // a narrow distance is saved the farthest loaded post - and hence the feed-derived max -
+    // collapses to roughly that distance. Without headroom the thumb (at the saved distance)
+    // would pin to the far right, indistinguishable from "Further", while the blue coverage area
+    // stayed small. The slider max must keep headroom so a narrow setting still reads as narrow.
+    it('keeps headroom above a finite saved distance when the pre-filtered feed collapses', () => {
+      // Feed pre-filtered to ~5mi (farthest post 4.8) while the member saved a 5mi limit.
+      mockMe.value = meWithLocation({ browseMaxDistance: 5 })
+      mockNearbyMessageList.value = [
+        { id: 1, distance: 1.1 },
+        { id: 2, distance: 4.8 },
+      ]
+      const wrapper = createWrapper({ forceShowFilters: true })
+      const input = wrapper.find('.range-slider-stub')
+      const max = Number(input.attributes('max'))
+      const value = Number(input.element.value)
+      // ceil(5 * 1.25) = 7, so the scale extends past the saved distance...
+      expect(max).toBe(7)
+      // ...and the thumb sits at the saved 5, NOT pinned to the far right (the bug).
+      expect(value).toBe(5)
+      expect(value).toBeLessThan(max)
+    })
+
     it('stores BROWSE_DISTANCE_UNLIMITED (not the feed max) when dragged to the rightmost stop', async () => {
       const wrapper = createWrapper({ forceShowFilters: true })
       const input = wrapper.find('.range-slider-stub')

--- a/iznik-nuxt3/tests/unit/composables/useMessageSort.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useMessageSort.spec.js
@@ -141,6 +141,75 @@ describe('sortBrowseMessages', () => {
     })
   })
 
+  // Discourse 9844: "Newest posted" must order by ORIGINAL post time (`posted`), not the
+  // reach-feed `arrival` (messages_spatial.arrival), which rippling bumps forward every time
+  // a post's reach grows. Ordering by arrival floated days-old posts to the top of "Newest".
+  describe('"Newest posted" uses posted (original), not the ripple-bumped arrival', () => {
+    it('orders by posted even when arrival says otherwise', () => {
+      // `old` was posted first but rippled MOST recently (newest arrival); `new` was posted
+      // later but has an older arrival. Newest-posted must put `new` first.
+      const msgs = [
+        {
+          id: 'old',
+          posted: '2024-01-01T00:00:00Z',
+          arrival: '2024-06-01T00:00:00Z',
+        },
+        {
+          id: 'new',
+          posted: '2024-05-01T00:00:00Z',
+          arrival: '2024-02-01T00:00:00Z',
+        },
+      ]
+      expect(order(msgs, 'Newest')).toEqual(['new', 'old'])
+    })
+
+    it('uses posted for the Nearby equal-distance recency tiebreak too', () => {
+      const msgs = [
+        {
+          id: 'postedOlder',
+          distance: 4,
+          posted: '2024-01-01T00:00:00Z',
+          arrival: '2024-09-01T00:00:00Z',
+        },
+        {
+          id: 'postedNewer',
+          distance: 4,
+          posted: '2024-06-01T00:00:00Z',
+          arrival: '2024-02-01T00:00:00Z',
+        },
+      ]
+      expect(order(msgs, 'Nearby')).toEqual(['postedNewer', 'postedOlder'])
+    })
+
+    it('falls back to arrival when posted is absent (older cached feed)', () => {
+      const msgs = [
+        { id: 1, arrival: '2024-01-01T00:00:00Z' },
+        { id: 2, arrival: '2024-03-01T00:00:00Z' },
+      ]
+      expect(order(msgs, 'Newest')).toEqual([2, 1])
+    })
+
+    it('ignores the Go zero-time sentinel (year 0001) and falls back to arrival', () => {
+      // A feed path that did not populate posted serialises Go's zero time as year 0001,
+      // which parses to a large NEGATIVE epoch. Treating that as the post time would wrongly
+      // sink the post; we must fall back to its real arrival instead.
+      const msgs = [
+        {
+          id: 'zeroPosted',
+          posted: '0001-01-01T00:00:00Z',
+          arrival: '2024-06-01T00:00:00Z',
+        },
+        {
+          id: 'realPosted',
+          posted: '2024-01-01T00:00:00Z',
+          arrival: '2024-01-01T00:00:00Z',
+        },
+      ]
+      // zeroPosted falls back to its arrival (June) -> newest; realPosted (Jan) second.
+      expect(order(msgs, 'Newest')).toEqual(['zeroPosted', 'realPosted'])
+    })
+  })
+
   // A pinned post (a paid bulk-offer clearance) must lead the feed under every sort mode,
   // ahead of a higher-scoring / nearer / newer post.
   describe('pinned posts', () => {

--- a/iznik-server-go/isochrone/message.go
+++ b/iznik-server-go/isochrone/message.go
@@ -28,17 +28,29 @@ const BrowseDistanceUnlimited = 9007199254740991 // Number.MAX_SAFE_INTEGER
 // their columns to exactly these names so one struct/one scoring path serves
 // both.
 type reachCandidateRow struct {
-	Lat        float64   `gorm:"column:lat"`
-	Lng        float64   `gorm:"column:lng"`
-	ID         uint64    `gorm:"column:id"`
-	Successful bool      `gorm:"column:successful"`
-	Promised   bool      `gorm:"column:promised"`
-	Groupid    uint64    `gorm:"column:groupid"`
-	Type       string    `gorm:"column:type"`
-	Arrival    time.Time `gorm:"column:arrival"`
-	Unseen     bool      `gorm:"column:unseen"`
-	Views      int64     `gorm:"column:views"`
-	Replies    int64     `gorm:"column:replies"`
+	Lat        float64 `gorm:"column:lat"`
+	Lng        float64 `gorm:"column:lng"`
+	ID         uint64  `gorm:"column:id"`
+	Successful bool    `gorm:"column:successful"`
+	Promised   bool    `gorm:"column:promised"`
+	Groupid    uint64  `gorm:"column:groupid"`
+	Type       string  `gorm:"column:type"`
+	// Arrival is the messages_spatial arrival, which the reach engine bumps
+	// forward each time the post ripples into a new group — so it tracks "when
+	// did this most recently expand", NOT the original post time. It feeds the
+	// relevance score's freshness term (that IS what we want there) and the
+	// server-side tie-break, but it must NOT drive "Newest posted": ordering by
+	// it floats a days-old post to the top of the feed the moment its reach grows
+	// again (Discourse 9844). Use Posted for anything member-facing about "when
+	// was this posted".
+	Arrival time.Time `gorm:"column:arrival"`
+	// Posted is the ORIGINAL post arrival (messages.arrival), stable across
+	// rippling. It is what the client's "Newest posted" sort and the card's time
+	// badge mean, so exposing it lets the feed order agree with the badge.
+	Posted  time.Time `gorm:"column:posted"`
+	Unseen  bool      `gorm:"column:unseen"`
+	Views   int64     `gorm:"column:views"`
+	Replies int64     `gorm:"column:replies"`
 	// ReachLat/ReachLng/ReachWKT describe the post's rippling_reach row (the
 	// origin the reach grew from, and the current reach polygon as WKT).
 	// Empty/zero when the post has no reach row (own-posts arm only; the
@@ -94,6 +106,7 @@ func (r reachCandidateRow) toSummary(viewerLat, viewerLng float64, w ScoreWeight
 		Groupid:    r.Groupid,
 		Type:       r.Type,
 		Arrival:    r.Arrival,
+		Posted:     r.Posted,
 		Lat:        blurLat,
 		Lng:        blurLng,
 		Unseen:     r.Unseen,
@@ -119,12 +132,15 @@ func fetchReachCandidates(db *gorm.DB, myid uint64, latlng utils.LatLng, unseenO
 	db.Raw(
 		"SELECT ST_Y(ms.point) AS lat, ST_X(ms.point) AS lng, "+
 			"ms.msgid AS id, ms.successful, ms.promised, ms.groupid, "+
-			"ms.msgtype AS type, ms.arrival, "+
+			"ms.msgtype AS type, ms.arrival, m.arrival AS posted, "+
 			"CASE WHEN ml.msgid IS NULL THEN 1 ELSE 0 END AS unseen, "+
 			"COALESCE((SELECT SUM(mlv.count) FROM messages_likes mlv WHERE mlv.msgid = ms.msgid AND mlv.type = ?), 0) AS views, "+
 			"(SELECT COUNT(*) FROM chat_messages cm WHERE cm.refmsgid = ms.msgid AND cm.type = ? AND cm.reviewrejected = 0 AND cm.reviewrequired = 0) AS replies, "+
 			"rr.lat AS reach_lat, rr.lng AS reach_lng, ST_AsText(rr.polygon) AS reach_wkt "+
 			"FROM messages_spatial ms "+
+			// JOIN messages for the ORIGINAL post arrival (m.arrival). ms.arrival is
+			// the ripple-bumped spatial arrival, so it can't stand in for "posted".
+			"INNER JOIN messages m ON m.id = ms.msgid "+
 			"INNER JOIN rippling_reach rr ON rr.msgid = ms.msgid "+
 			"LEFT JOIN messages_likes ml ON ml.msgid = ms.msgid AND ml.userid = ? AND ml.type = ? "+
 			"WHERE ms.successful = 0 "+
@@ -235,7 +251,7 @@ func Messages(c *fiber.Ctx) error {
 				"ANY_VALUE(CASE WHEN mo.outcome IN (?, ?) THEN 1 ELSE 0 END) AS successful, "+
 				"ANY_VALUE(CASE WHEN mp.id IS NOT NULL THEN 1 ELSE 0 END) AS promised, "+
 				"ANY_VALUE(mg.groupid) AS groupid, m.type, "+
-				"MAX(mg.arrival) AS arrival, "+
+				"MAX(mg.arrival) AS arrival, m.arrival AS posted, "+
 				"ANY_VALUE(CASE WHEN ml.msgid IS NULL THEN 1 ELSE 0 END) AS unseen, "+
 				"COALESCE((SELECT SUM(mlv.count) FROM messages_likes mlv WHERE mlv.msgid = m.id AND mlv.type = ?), 0) AS views, "+
 				"(SELECT COUNT(*) FROM chat_messages cm WHERE cm.refmsgid = m.id AND cm.type = ? AND cm.reviewrejected = 0 AND cm.reviewrequired = 0) AS replies, "+
@@ -430,12 +446,15 @@ func myGroupsMessages(c *fiber.Ctx, db *gorm.DB, myid uint64) error {
 		db.Raw(fmt.Sprintf(
 			"SELECT ST_Y(ms.point) AS lat, ST_X(ms.point) AS lng, "+
 				"ms.msgid AS id, ms.successful, ms.promised, ms.groupid, "+
-				"ms.msgtype AS type, ms.arrival, "+
+				"ms.msgtype AS type, ms.arrival, m.arrival AS posted, "+
 				"CASE WHEN ml.msgid IS NULL THEN 1 ELSE 0 END AS unseen, "+
 				"COALESCE((SELECT SUM(mlv.count) FROM messages_likes mlv WHERE mlv.msgid = ms.msgid AND mlv.type = ?), 0) AS views, "+
 				"(SELECT COUNT(*) FROM chat_messages cm WHERE cm.refmsgid = ms.msgid AND cm.type = ? AND cm.reviewrejected = 0 AND cm.reviewrequired = 0) AS replies, "+
 				"COALESCE(rr.lat, 0) AS reach_lat, COALESCE(rr.lng, 0) AS reach_lng, COALESCE(ST_AsText(rr.polygon), '') AS reach_wkt "+
 				"FROM messages_spatial ms "+
+				// JOIN messages for the ORIGINAL post arrival (m.arrival), stable across
+				// rippling — see the reach arm above.
+				"INNER JOIN messages m ON m.id = ms.msgid "+
 				"LEFT JOIN messages_likes ml ON ml.msgid = ms.msgid AND ml.userid = ? AND ml.type = ? "+
 				"LEFT JOIN rippling_reach rr ON rr.msgid = ms.msgid "+
 				"WHERE ms.msgid IN (%s)",
@@ -471,6 +490,7 @@ func myGroupsMessages(c *fiber.Ctx, db *gorm.DB, myid uint64) error {
 					Groupid:    cand.Groupid,
 					Type:       cand.Type,
 					Arrival:    cand.Arrival,
+					Posted:     cand.Posted,
 					Lat:        blurLat,
 					Lng:        blurLng,
 					Unseen:     cand.Unseen,

--- a/iznik-server-go/message/messageSummary.go
+++ b/iznik-server-go/message/messageSummary.go
@@ -12,10 +12,17 @@ type MessageSummary struct {
 	SpatialID  *uint64   `json:"spatialid,omitempty" gorm:"column:spatialid"`
 	Type       string    `json:"type"`
 	Arrival    time.Time `json:"arrival"`
-	Date       time.Time `json:"date"`
-	Lat        float64   `json:"lat"`
-	Lng        float64   `json:"lng"`
-	Unseen     bool      `json:"unseen"`
+	// Posted is the ORIGINAL post arrival (messages.arrival), stable across
+	// rippling. On the nearby/reach feed the client's "Newest posted" sort orders
+	// by this so a post that merely rippled again does not jump to the top with a
+	// days-old badge (Discourse 9844). Arrival, by contrast, is the reach-bumped
+	// spatial arrival used for the relevance score. Only populated on the browse
+	// feed; zero elsewhere (falls back to arrival client-side).
+	Posted time.Time `json:"posted,omitempty"`
+	Date   time.Time `json:"date"`
+	Lat    float64   `json:"lat"`
+	Lng    float64   `json:"lng"`
+	Unseen bool      `json:"unseen"`
 	// Score is the rippling relevance score (see isochrone.Score) used to
 	// order the 'nearby' browse feed. Only populated on that path; zero/
 	// omitted elsewhere.

--- a/iznik-server-go/test/isochrone_reach_test.go
+++ b/iznik-server-go/test/isochrone_reach_test.go
@@ -4,6 +4,7 @@ import (
 	json2 "encoding/json"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/freegle/iznik-server-go/database"
 	"github.com/freegle/iznik-server-go/message"
@@ -247,4 +248,65 @@ func TestNearbyFeedHonoursDistanceLimit(t *testing.T) {
 	limited := inFeed("/api/isochrone/message?jwt=" + token)
 	assert.True(t, limited[float64(near)], "near post still appears within the 10-mile browseMaxDistance")
 	assert.False(t, limited[float64(far)], "the ~27-mile far post is filtered out of the feed, matching the count")
+}
+
+// TestNearbyFeedPostedIsOriginalArrival: the nearby feed exposes `posted` = the ORIGINAL post
+// arrival (messages.arrival), which is stable across rippling, DISTINCT from `arrival` =
+// messages_spatial.arrival, which the reach engine bumps forward every time the post ripples
+// into a new group. The client's "Newest posted" sort orders by `posted`, so a post that merely
+// rippled again does not leap to the top of the feed with a days-old badge (Discourse 9844). This
+// guards the SQL that JOINs messages for m.arrival AS posted on the reach arm.
+func TestNearbyFeedPostedIsOriginalArrival(t *testing.T) {
+	db := database.DBConn
+
+	db.Exec(`CREATE TABLE IF NOT EXISTS rippling_reach (
+		msgid BIGINT UNSIGNED NOT NULL PRIMARY KEY,
+		lat DOUBLE NOT NULL, lng DOUBLE NOT NULL,
+		polygon GEOMETRY NOT NULL SRID 3857,
+		status VARCHAR(16) NOT NULL DEFAULT 'expanding',
+		SPATIAL INDEX msgreach_poly (polygon)
+	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`)
+
+	prefix := uniquePrefix("nearbyposted")
+	posterID := CreateTestUser(t, prefix+"_poster", "Poster")
+	group := CreateTestGroup(t, prefix)
+	msg := CreateTestMessage(t, posterID, group, "OFFER: originally posted long ago, rippled recently (nearbyposted)", 51.5, -0.1)
+	db.Exec("UPDATE messages_spatial SET successful = 0 WHERE msgid = ?", msg)
+	defer db.Exec("DELETE FROM rippling_reach WHERE msgid = ?", msg)
+
+	// A post first offered on 2024-01-01 (messages.arrival) that has since rippled out: the reach
+	// engine bumped messages_spatial.arrival forward to its latest expansion time (2024-06-01).
+	db.Exec("UPDATE messages SET arrival = '2024-01-01 00:00:00' WHERE id = ?", msg)
+	db.Exec("UPDATE messages_spatial SET arrival = '2024-06-01 00:00:00' WHERE msgid = ?", msg)
+
+	viewerID, token := CreateFullTestUser(t, prefix+"_viewer")
+	db.Exec("UPDATE users SET settings = JSON_SET(COALESCE(settings,'{}'), '$.mylocation', "+
+		"JSON_OBJECT('lat', 51.5, 'lng', -0.1)) WHERE id = ?", viewerID)
+
+	// Reach polygon covers the viewer so the post is on the nearby feed.
+	db.Exec("INSERT INTO rippling_reach (msgid, lat, lng, polygon, status) VALUES (?, 51.5, -0.1, "+
+		"ST_GeomFromText('POLYGON((-0.2 51.4, 0.0 51.4, 0.0 51.6, -0.2 51.6, -0.2 51.4))', 3857), 'expanding') "+
+		"ON DUPLICATE KEY UPDATE polygon = VALUES(polygon)", msg)
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/isochrone/message?jwt="+token, nil))
+	assert.Equal(t, 200, resp.StatusCode)
+	var msgs []message.MessageSummary
+	json2.Unmarshal(rsp(resp), &msgs)
+
+	var found *message.MessageSummary
+	for i := range msgs {
+		if msgs[i].ID == msg {
+			found = &msgs[i]
+			break
+		}
+	}
+	assert.NotNil(t, found, "the rippled post appears in the nearby feed")
+	if found != nil {
+		// posted = original messages.arrival (January); arrival = ripple-bumped spatial arrival (June).
+		assert.Equal(t, 2024, found.Posted.Year(), "posted carries the original post year")
+		assert.Equal(t, time.January, found.Posted.Month(), "posted is the original post month, not the ripple month")
+		assert.Equal(t, time.June, found.Arrival.Month(), "arrival is the ripple-bumped spatial month")
+		assert.True(t, found.Posted.Before(found.Arrival),
+			"posted (original post time) is strictly earlier than the ripple-bumped spatial arrival")
+	}
 }


### PR DESCRIPTION
## Summary

Fixes two member-reported bugs in the rippling-out browse feed, raised on Discourse: https://discourse.ilovefreegle.org/t/rippling-out-on-my-groups/9844 (posts #19, #23, #24).

**Bug 1 — "Newest posted" wasn't chronological.** The nearby/reach feed's "Newest posted" sort ordered by the feed summary's `arrival`, which is `messages_spatial.arrival`. The reach engine **bumps that column forward every time a post ripples into a new group**, so it holds the *latest reach-expansion* time, not the original post time. Confirmed against live production data: for recently-rippled posts `messages_spatial.arrival` runs **33–38 hours ahead** of the original post time (one spatial row per msgid, holding the last ripple). Meanwhile the card's time badge shows the original post time. So a post first offered days ago jumped to the top of "Newest posted" the moment its reach grew again, while its card still read "3 days ago" — exactly the member's "it goes from minutes to 3 days, then 2 days" report.

Fix (option A — "Newest posted" means original post time): the feed now also exposes `posted` = the stable `messages.arrival`, and the client's "Newest posted" sort (and the Closest recency tie-break) orders by `posted`. `arrival` (the ripple-bumped spatial arrival) is kept unchanged for the relevance score's freshness term, so the default "New to you" ordering is untouched.

**Bug 2b — distance-slider thumb sat at "max" while the blue coverage area was small.** The server pre-filters the feed to the member's saved `browseMaxDistance` (so the feed matches the unread count). The client scales the slider's right-hand end (`feedMax`) to the farthest post in that feed — so once a narrow distance is saved, `feedMax` collapses down to it and the thumb pins to the far right, indistinguishable from "Further", even though the coverage area stays small. The slider now keeps headroom above a finite saved distance, so a narrow setting still reads as narrow (with room to widen). When the feed is not pre-filtered the true feed extent is unchanged.

Not changed: the blue coverage hull not visibly tracking small slider moves (post #23, first half) is expected — it is a convex hull of the posts currently shown, not a radius ring, and only moves when the outermost posts are filtered out. The Leaflet layer does redraw reactively.

## Code Quality Review

- Backend `arrival` semantics preserved for scoring/tie-break; only a new, additive `posted` field drives member-facing "newest". `posted` added on all three feed arms (reach, own-posts, mygroups) so the client sort is consistent across views.
- Client falls back to `arrival` when `posted` is absent (older cached feeds) and guards the Go zero-time sentinel (year 0001) so a missing `posted` can't wrongly sink a post.
- `feedMax` headroom uses `Math.max`, so it never *reduces* a genuine feed extent — it only adds room in the collapsed (pre-filtered) case.

## Future Improvements

- Bug 2b's clean fix is to surface the full reach extent to the client (so the slider scale is independent of the pre-filtered feed) and refetch the feed when the member widens. Deferred to avoid disturbing the feed/count consistency (guarded by `TestNearbyFeedHonoursDistanceLimit`, a real prior incident).
- Consider pointing the card time badge at the same `posted` value for byte-exact agreement with the sort (currently it uses `groups[0].arrival`, which is the origin group in the common case).

## Test Plan

- Go: `TestNearbyFeedPostedIsOriginalArrival` — a post originally offered 2024-01 but rippled (spatial arrival bumped to 2024-06) returns `posted` = January and `arrival` = June, with `posted` strictly before `arrival`. Full Go suite green.
- Vitest: `useMessageSort` — "Newest posted" orders by `posted` even when `arrival` disagrees; Nearby tie-break uses `posted`; falls back to `arrival` when `posted` absent; ignores the year-0001 sentinel. `PostFilters` — slider keeps headroom above a finite saved distance when the pre-filtered feed collapses. Full Vitest suite green (13853 passed).
