### PR TITLE
fix(jobs): attribute job-ad clicks to the logged-in user

### DIFF
--- a/iznik-server-go/job/job.go
+++ b/iznik-server-go/job/job.go
@@ -7,6 +7,7 @@ import (
 	"github.com/freegle/iznik-server-go/database"
 	"github.com/freegle/iznik-server-go/misc"
 	"github.com/freegle/iznik-server-go/spatial"
+	"github.com/freegle/iznik-server-go/user"
 	"github.com/freegle/iznik-server-go/utils"
 	"github.com/gofiber/fiber/v2"
 	"regexp"
@@ -274,16 +275,14 @@ func RecordJobClick(c *fiber.Ctx) error {
 		})
 	}
 
-	// Get user ID from context if authenticated (optional)
+	// Get the user ID from the JWT / persistent token if the caller is logged in (optional).
+	// The web app and digest-email links both authenticate via the standard Authorization
+	// headers, so user.WhoAmI resolves the click to a user, returning 0 when anonymous.
+	// The previous c.Locals("session") lookup read a context key that nothing in this
+	// codebase ever sets, so every click was silently logged with userid=NULL.
 	var userID *uint64
-	if c.Locals("session") != nil {
-		if session, ok := c.Locals("session").(map[string]interface{}); ok {
-			if id, exists := session["id"]; exists {
-				if idUint, ok := id.(uint64); ok {
-					userID = &idUint
-				}
-			}
-		}
+	if myid := user.WhoAmI(c); myid > 0 {
+		userID = &myid
 	}
 
 	// Don't require ID, just record what we have.

--- a/iznik-server-go/test/jobs_test.go
+++ b/iznik-server-go/test/jobs_test.go
@@ -98,6 +98,31 @@ func TestJobClick_JSONBody(t *testing.T) {
 	assert.Equal(t, link, gotLink)
 }
 
+// TestJobClick_UserAttribution guards click->user attribution: a click from a logged-in
+// user must record their userid in logs_jobs. The handler previously read the userid from
+// c.Locals("session") - a context key nothing in this codebase ever sets - so every click,
+// web or email, was silently stored with userid=NULL. It now resolves the user via
+// user.WhoAmI, the same JWT / persistent-token path every other write handler uses.
+func TestJobClick_UserAttribution(t *testing.T) {
+	prefix := uniquePrefix("jobclick")
+	userID, token := CreateFullTestUser(t, prefix)
+	jobID := CreateTestJob(t, 52.5833189, -2.0455619)
+
+	// Post the click the way the web app does: JSON body + JWT in the Authorization header.
+	body := fmt.Sprintf(`{"id":%d,"link":"https://example.com/job/%d"}`, jobID, jobID)
+	req := httptest.NewRequest("POST", "/api/job", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", token)
+
+	resp, _ := getApp().Test(req, 60000)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	// The click must be attributed to the logged-in user, not stored as NULL.
+	var gotUser uint64
+	database.DBConn.Raw("SELECT COALESCE(userid, 0) FROM logs_jobs WHERE jobid = ? ORDER BY id DESC LIMIT 1", jobID).Row().Scan(&gotUser)
+	assert.Equal(t, userID, gotUser)
+}
+
 // TestJobClick_Placement guards per-placement attribution: a click records WHICH slot it came
 // from, so click-through can be measured per placement (sticky footer / sidebar / jobs page /
 // email / modal) rather than as a single global count. Covers the JSON body (web app), the query


### PR DESCRIPTION
## Problem

Investigating **today's job-ad clicks** surfaced that `userid` is NULL on **every** click: 0 of the last 2,554 clicks (7 days) on prod carried a user, and the last attributed click was **2026-06-25**.

Root cause: `RecordJobClick` read the user from `c.Locals("session")` — a Fiber context key that **nothing in this codebase ever sets** (the only references were the two reads in `job.go`). So the branch was always skipped and every click, web app and digest-email link alike, was silently logged with `userid=NULL`.

The JWT was reaching the endpoint the whole time — `GetJWTFromRequest` reads the `?jwt=` param and the `Authorization` header, and the web app's `$postv2` sends both `Authorization` (jwt) and `Authorization2` (persistent). The handler just never consulted it.

## Fix

Resolve the user via `user.WhoAmI(c)` — the same JWT / persistent-token path every other write handler (`noticeboard`, `donations`, `spammers`, `team`, `tryst`, …) uses. Returns 0 → `NULL` for genuinely anonymous clicks.

## Why it matters

Beyond analytics, losing `userid` blunts our own defence against WhatJobs' same-user repeat-click "invalid" rule — we can't dedupe repeat clicks we can't attribute.

## Test

Adds `TestJobClick_UserAttribution`, which posts a click the way the web app actually does (JSON body + JWT in the `Authorization` header) and asserts the `logs_jobs` row is attributed to the logged-in user.

## Validation

- No import cycle (`user` does not import `job`); import added in alphabetical order.
- Go isn't installed on the deploy host and tests aren't run there by policy — **CI compiles and runs the Go suite**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
