### PR TITLE
chore(batch): gitignore locally-generated EEE classification artifacts

### DIFF
--- a/iznik-batch/.gitignore
+++ b/iznik-batch/.gitignore
@@ -29,3 +29,6 @@ npm-debug.log
 yarn-error.log
 Thumbs.db
 storage/incoming-archive/
+# Locally-generated EEE classification data (classifications.sqlite, eee-labels.db,
+# bridge). Runtime artifacts, explicitly not deployed - see EeeBackfillClassifiedTableCommand.
+storage/eee/


### PR DESCRIPTION
`iznik-batch/storage/eee/` holds runtime-generated files (`classifications.sqlite`, `eee-labels.db`, `bridge`) that `EeeBackfillClassifiedTableCommand` explicitly documents as **not deployed**. They sat untracked and cluttered `git status` (and risked an accidental `git add -A` committing a binary SQLite DB). Ignore the directory the same way Laravel's other `storage/*` runtime paths already are.

🤖 Generated with [Claude Code](https://claude.com/claude-code)