### PR TITLE
feat(digest): rank daily digest posts by personal relevance (flagged, with holdout)

### DIFF
--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -49,7 +49,15 @@ orbs:
   # and downloads anyway; it now also falls back to the gradle-deps cache that
   # build-android-debug/-dev keep warm from master, which already contains the
   # unpacked distribution.
-  freegle: freegle/tests@1.1.375
+  #
+  # 1.1.377 retries `npm ci` in run-vitest-tests. package.json resolves
+  # cordova-plugin-calendar to a GitHub tarball URL, not a registry package, so
+  # npm's own --fetch-retries (registry fetches only) never covers it. Pipeline
+  # #10740 job 31779 lost `npm ci` outright to one ECONNRESET fetching that
+  # tarball, which failed Vitest and reded the whole build-and-test check. Wrapped
+  # in the same 3-attempt/15s shell retry already used for the Nuxt docker-build
+  # ECONNRESET case above.
+  freegle: freegle/tests@1.1.377
 
 jobs:
   mark-ci-passed:

--- a/.circleci/orb/freegle-tests.yml
+++ b/.circleci/orb/freegle-tests.yml
@@ -1468,7 +1468,20 @@ commands:
             fi
 
             echo "📦 Installing npm dependencies..."
-            npm ci --prefer-offline --no-audit
+            # package.json pulls cordova-plugin-calendar straight from a GitHub tarball
+            # URL rather than the npm registry, so npm's own --fetch-retries (registry
+            # fetches only) does not cover it — an ECONNRESET there aborts npm ci outright.
+            # Retry at the shell level, same pattern used for the Nuxt docker-build retry
+            # elsewhere in this file.
+            for attempt in 1 2 3; do
+              npm ci --prefer-offline --no-audit && break
+              if [ $attempt -eq 3 ]; then
+                echo "❌ npm ci failed after 3 attempts"
+                exit 1
+              fi
+              echo "⚠️ npm ci attempt $attempt failed (possible transient network error, e.g. ECONNRESET fetching a GitHub tarball dependency), retrying in 15s..."
+              sleep 15
+            done
 
             echo "🔧 Running nuxi prepare..."
             npx nuxi prepare
@@ -2559,7 +2572,20 @@ jobs:
                 fi
                 cd "$NUXT_DIR"
                 echo "running" > /tmp/vitest-result
-                npm ci --prefer-offline --no-audit
+                # package.json pulls cordova-plugin-calendar straight from a GitHub tarball
+                # URL rather than the npm registry, so npm's own --fetch-retries (registry
+                # fetches only) does not cover it — an ECONNRESET there aborts npm ci outright.
+                # Retry at the shell level, same pattern as the Nuxt docker-build retry above.
+                for attempt in 1 2 3; do
+                  npm ci --prefer-offline --no-audit && break
+                  if [ $attempt -eq 3 ]; then
+                    echo "fail" > /tmp/vitest-result
+                    echo "❌ npm ci failed after 3 attempts"
+                    exit 1
+                  fi
+                  echo "⚠️ npm ci attempt $attempt failed (possible transient network error, e.g. ECONNRESET fetching a GitHub tarball dependency), retrying in 15s..."
+                  sleep 15
+                done
                 npx nuxi prepare
                 npm run test:unit:run -- --reporter=verbose --coverage 2>&1 | tee /tmp/vitest-output.log
                 EXIT_CODE=${PIPESTATUS[0]}

--- a/iznik-batch/MIGRATION-STATUS.md
+++ b/iznik-batch/MIGRATION-STATUS.md
@@ -315,7 +315,7 @@ These original scripts need to be migrated to Laravel artisan commands:
 |--------|------|----------|-------------|
 | ~~`chat_chaseup_expected.php`~~ | ~~06:00~~ | ~~Medium~~ | ~~Chat expected response chase-up~~ — **Migrated: `chats:chaseup-expected`** (WAITING FOR REPLY user2user notification; scheduler disabled pending go-live) |
 | ~~`birthday.php`~~ | ~~12:00~~ | ~~Low~~ | ~~Birthday notifications~~ — **Migrated: `birthday:send-emails`** |
-| ~~`relevant.php`~~ | ~~14:30~~ | ~~Medium~~ | ~~Relevant message matching~~ — **Retired 2026-07**: folded into the daily digest as personal relevance ranking (`DigestRelevanceService` in UnifiedDigestService, gated by `FEATURE_DIGEST_RELEVANCE`). No separate mail; cron `relevant.php` deleted. Live crontab entry to be removed at deploy. |
+| ~~`relevant.php`~~ | ~~14:30~~ | ~~Medium~~ | ~~Relevant message matching~~ — **Retired 2026-07**: folded into the daily digest as personal relevance ranking (`DigestRelevanceService` in UnifiedDigestService, gated by `FEATURE_DIGEST_RELEVANCE`). No separate mail; cron `relevant.php` deleted (V1 no longer runs in production, so this was already dead code — no deploy action). |
 | `chat_chaseupmods.php` | 15:30 | Medium | Moderator chat chase-up |
 | ~~`newsfeed_digest.php`~~ | ~~15:30~~ | ~~Low~~ | ~~Newsfeed digest~~ — **Migrated: `mail:newsfeed:digest`** (nearby chitchat digest with per-user spatial bounding box; scheduler disabled pending go-live) |
 | `newsfeed_modnotif.php` | 13:30 | Low | Newsfeed mod notifications |

--- a/iznik-batch/MIGRATION-STATUS.md
+++ b/iznik-batch/MIGRATION-STATUS.md
@@ -315,7 +315,7 @@ These original scripts need to be migrated to Laravel artisan commands:
 |--------|------|----------|-------------|
 | ~~`chat_chaseup_expected.php`~~ | ~~06:00~~ | ~~Medium~~ | ~~Chat expected response chase-up~~ — **Migrated: `chats:chaseup-expected`** (WAITING FOR REPLY user2user notification; scheduler disabled pending go-live) |
 | ~~`birthday.php`~~ | ~~12:00~~ | ~~Low~~ | ~~Birthday notifications~~ — **Migrated: `birthday:send-emails`** |
-| `relevant.php` | 14:30 | Medium | Relevant message matching |
+| ~~`relevant.php`~~ | ~~14:30~~ | ~~Medium~~ | ~~Relevant message matching~~ — **Retired 2026-07**: folded into the daily digest as personal relevance ranking (`DigestRelevanceService` in UnifiedDigestService, gated by `FEATURE_DIGEST_RELEVANCE`). No separate mail; cron `relevant.php` deleted. Live crontab entry to be removed at deploy. |
 | `chat_chaseupmods.php` | 15:30 | Medium | Moderator chat chase-up |
 | ~~`newsfeed_digest.php`~~ | ~~15:30~~ | ~~Low~~ | ~~Newsfeed digest~~ — **Migrated: `mail:newsfeed:digest`** (nearby chitchat digest with per-user spatial bounding box; scheduler disabled pending go-live) |
 | `newsfeed_modnotif.php` | 13:30 | Low | Newsfeed mod notifications |

--- a/iznik-batch/app/Mail/Digest/UnifiedDigest.php
+++ b/iznik-batch/app/Mail/Digest/UnifiedDigest.php
@@ -69,6 +69,7 @@ class UnifiedDigest extends MjmlMailable implements RetryableMailable
         public string $mode,
         protected Collection $sponsors = new Collection(),
         protected Collection $completedPosts = new Collection(),
+        protected bool $relevanceRanked = false,
         public ?string $matchReason = null
     ) {
         parent::__construct();
@@ -107,6 +108,12 @@ class UnifiedDigest extends MjmlMailable implements RetryableMailable
                 // position P in N digests" denominator is recoverable. Without
                 // this only the rare clicked post can be attributed.
                 'post_msgids' => $this->posts->map(fn ($p) => $p['message']->id)->values()->all(),
+                // 1 when relevance ranking actually reordered this digest. The
+                // click-by-position dashboard's "ranked" arm filters on this
+                // rather than on "not in the holdout", which would also count
+                // members who had no interest signal and so received an
+                // identical unranked digest.
+                'relevance_ranked' => $this->relevanceRanked ? 1 : 0,
                 'digest_number' => $this->digestNumber,
                 'has_amp' => $this->ampForRecipient(),
             ],

--- a/iznik-batch/app/Services/DigestRelevanceService.php
+++ b/iznik-batch/app/Services/DigestRelevanceService.php
@@ -1,0 +1,195 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Ranks the daily digest's live posts by vector similarity to what a member
+ * cares about — the subject embeddings of their own recent posts and the posts
+ * they've recently viewed — so the most relevant items float to the top.
+ *
+ * Ships behind config('freegle.digest.relevance_enabled') (default OFF). When
+ * off, or for the 10% holdout (userid % 10 == 0), or when a member has no
+ * interest signal, rank() returns the input order UNCHANGED, so the digest is
+ * byte-identical to today. That holdout, plus the existing click-by-position
+ * dashboard (which measures whatever order post_msgids records), is how we tell
+ * whether the ranking is worth it.
+ *
+ * Embeddings are the same nomic-embed-text-v1.5 256-dim vectors used for search,
+ * stored little-endian in messages_embeddings.subject_embedding and normalized
+ * to unit length, so a plain dot product is the cosine similarity.
+ */
+class DigestRelevanceService
+{
+    /** Max interest vectors to consider (newest first). Keeps the per-user cost bounded. */
+    public const MAX_INTERESTS = 40;
+
+    /** Days of the member's own posts to treat as interest signal. */
+    public const OWN_POST_DAYS = 60;
+
+    /** Days of the member's views to treat as interest signal. */
+    public const VIEW_DAYS = 30;
+
+    private const DIM = 256;
+
+    /**
+     * Reorder a member's daily-digest posts by relevance. Each post must expose
+     * an `id` (the msgid). Returns a new collection in ranked order, or the
+     * input unchanged when ranking is off / holdout / no interest signal.
+     */
+    public function rank(int $userid, Collection $posts): Collection
+    {
+        if (!config('freegle.digest.relevance_enabled')) {
+            return $posts;
+        }
+        // 10% holdout: always keep the existing order so we have a clean control.
+        if ($userid % 10 === 0) {
+            return $posts;
+        }
+        if ($posts->count() < 2) {
+            return $posts;
+        }
+
+        $interests = $this->interests($userid);
+        if (empty($interests)) {
+            return $posts;
+        }
+
+        $ids = $posts->map(fn ($p) => (int) $p->id)->all();
+        $embeddings = $this->embeddingsFor($ids);
+        if (empty($embeddings)) {
+            return $posts;
+        }
+
+        // Score each post by its best match to any interest vector. Posts with no
+        // embedding score below everything so they sink to the bottom (but keep
+        // their relative order). A stable sort keeps the existing order as the
+        // tiebreak, so relevance only *reorders*, it never invents an order.
+        $indexed = $posts->values();
+        $scored = $indexed->map(function ($post, $i) use ($embeddings, $interests) {
+            $vec = $embeddings[(int) $post->id] ?? null;
+            $score = $vec === null ? -INF : $this->maxCosine($vec, $interests);
+
+            return ['post' => $post, 'score' => $score, 'orig' => $i];
+        });
+
+        $sorted = $scored->sort(function ($a, $b) {
+            if ($a['score'] === $b['score']) {
+                return $a['orig'] <=> $b['orig'];
+            }
+
+            return $b['score'] <=> $a['score'];
+        })->values();
+
+        return $sorted->map(fn ($x) => $x['post'])->values();
+    }
+
+    /**
+     * The member's interest vectors: subject embeddings of their own posts in the
+     * last OWN_POST_DAYS and the posts they viewed in the last VIEW_DAYS, newest
+     * first, capped at MAX_INTERESTS. Returns an array of float arrays.
+     *
+     * @return array<int, array<int, float>>
+     */
+    public function interests(int $userid): array
+    {
+        $rows = DB::select(
+            'SELECT emb FROM (
+                SELECT me.subject_embedding AS emb, m.arrival AS ts
+                FROM messages m
+                INNER JOIN messages_embeddings me ON me.msgid = m.id
+                WHERE m.fromuser = ? AND m.arrival >= DATE_SUB(NOW(), INTERVAL ? DAY)
+                UNION ALL
+                SELECT me.subject_embedding AS emb, ml.timestamp AS ts
+                FROM messages_likes ml
+                INNER JOIN messages_embeddings me ON me.msgid = ml.msgid
+                WHERE ml.userid = ? AND ml.type = ? AND ml.timestamp >= DATE_SUB(NOW(), INTERVAL ? DAY)
+            ) x
+            ORDER BY x.ts DESC
+            LIMIT ?',
+            [$userid, self::OWN_POST_DAYS, $userid, 'View', self::VIEW_DAYS, self::MAX_INTERESTS]
+        );
+
+        $vectors = [];
+        foreach ($rows as $row) {
+            $vec = $this->decode($row->emb);
+            if ($vec !== null) {
+                $vectors[] = $vec;
+            }
+        }
+
+        return $vectors;
+    }
+
+    /**
+     * Subject embeddings for the given msgids, keyed by msgid.
+     *
+     * @param  array<int, int>  $ids
+     * @return array<int, array<int, float>>
+     */
+    private function embeddingsFor(array $ids): array
+    {
+        if (empty($ids)) {
+            return [];
+        }
+
+        $rows = DB::table('messages_embeddings')
+            ->whereIn('msgid', $ids)
+            ->select('msgid', 'subject_embedding')
+            ->get();
+
+        $out = [];
+        foreach ($rows as $row) {
+            $vec = $this->decode($row->subject_embedding);
+            if ($vec !== null) {
+                $out[(int) $row->msgid] = $vec;
+            }
+        }
+
+        return $out;
+    }
+
+    /**
+     * Decode a little-endian float32 embedding BLOB (DIM floats). Returns null
+     * for a wrong-sized blob rather than a partial vector.
+     *
+     * @return array<int, float>|null
+     */
+    private function decode(?string $blob): ?array
+    {
+        if ($blob === null || strlen($blob) !== self::DIM * 4) {
+            return null;
+        }
+
+        // 'g' is a little-endian float — matches Go's binary.LittleEndian +
+        // math.Float32bits used to write the blob, and the sidecar's output.
+        $vec = array_values(unpack('g'.self::DIM, $blob));
+
+        return $vec;
+    }
+
+    /**
+     * Best cosine of a vector against any of the interest vectors. Both sides are
+     * unit-normalized, so cosine is the dot product.
+     *
+     * @param  array<int, float>  $vec
+     * @param  array<int, array<int, float>>  $interests
+     */
+    private function maxCosine(array $vec, array $interests): float
+    {
+        $best = -INF;
+        foreach ($interests as $interest) {
+            $dot = 0.0;
+            for ($i = 0; $i < self::DIM; $i++) {
+                $dot += $vec[$i] * $interest[$i];
+            }
+            if ($dot > $best) {
+                $best = $dot;
+            }
+        }
+
+        return $best;
+    }
+}

--- a/iznik-batch/app/Services/DigestRelevanceService.php
+++ b/iznik-batch/app/Services/DigestRelevanceService.php
@@ -13,9 +13,19 @@ use Illuminate\Support\Facades\DB;
  * Ships behind config('freegle.digest.relevance_enabled') (default OFF). When
  * off, or for the 10% holdout (userid % 10 == 0), or when a member has no
  * interest signal, rank() returns the input order UNCHANGED, so the digest is
- * byte-identical to today. That holdout, plus the existing click-by-position
- * dashboard (which measures whatever order post_msgids records), is how we tell
- * whether the ranking is worth it.
+ * byte-identical to the unranked one. That holdout, plus the existing
+ * click-by-position dashboard (which measures whatever order post_msgids
+ * records), is how we tell whether the ranking is worth it. didRank() reports
+ * whether ranking was really applied, so the dashboard's ranked arm can exclude
+ * members who were never reranked instead of assuming everyone outside the
+ * holdout was.
+ *
+ * Two things the ranking deliberately leaves alone:
+ *  - posts pinned upstream (the two nearest, UnifiedDigestService::pinClosestTwo)
+ *    keep the front of the list;
+ *  - a post with no embedding holds its position rather than sinking, since the
+ *    digest is truncated at DigestStyle::DIGEST_POST_CAP and sinking it would
+ *    delete it from a long digest for want of an embedding.
  *
  * Embeddings are the same nomic-embed-text-v1.5 256-dim vectors used for search,
  * stored little-endian in messages_embeddings.subject_embedding and normalized
@@ -34,13 +44,43 @@ class DigestRelevanceService
 
     private const DIM = 256;
 
+    /** Entries held by the cross-recipient embedding memo before it is dropped. */
+    private const EMBEDDING_CACHE_MAX = 20000;
+
+    /**
+     * Decoded subject embeddings keyed by msgid, shared across recipients within a
+     * digest run (a null value records "no embedding", so misses aren't re-queried).
+     * Static because the service is resolved per recipient.
+     *
+     * @var array<int, array<int, float>|null>
+     */
+    private static array $embeddingCache = [];
+
+    /**
+     * Whether the last rank() call actually applied relevance ranking, as opposed
+     * to returning the input untouched (flag off, holdout, no interest signal,
+     * no embeddings, nothing rankable). The digest records this so the click
+     * dashboard's "ranked" arm contains only genuinely ranked recipients.
+     */
+    private bool $ranked = false;
+
+    public function didRank(): bool
+    {
+        return $this->ranked;
+    }
+
     /**
      * Reorder a member's daily-digest posts by relevance. Each post must expose
      * an `id` (the msgid). Returns a new collection in ranked order, or the
      * input unchanged when ranking is off / holdout / no interest signal.
+     *
+     * Posts carrying `_pinned` (set by UnifiedDigestService::pinClosestTwo) keep
+     * their place at the front: relevance reorders only what sits below the pin.
      */
     public function rank(int $userid, Collection $posts): Collection
     {
+        $this->ranked = false;
+
         if (!config('freegle.digest.relevance_enabled')) {
             return $posts;
         }
@@ -52,38 +92,80 @@ class DigestRelevanceService
             return $posts;
         }
 
-        $interests = $this->interests($userid);
+        // The two nearest posts are pinned to the top upstream to answer "I keep
+        // seeing posts far away", and that pin deliberately skips posts the
+        // recipient has already seen. Re-sorting the whole collection would throw
+        // it away for every ranked member, so hold the pinned posts in place and
+        // rank only the tail.
+        $indexed = $posts->values();
+        $pinned = $indexed->filter(fn ($p) => !empty($p->_pinned))->values();
+        $rankable = $indexed->reject(fn ($p) => !empty($p->_pinned))->values();
+
+        if ($rankable->count() < 2) {
+            return $posts;
+        }
+
+        $ids = $rankable->map(fn ($p) => (int) $p->id)->all();
+
+        // Exclude the digest's own posts from the interest set. A post the member
+        // viewed within VIEW_DAYS is otherwise one of its own interest vectors, so
+        // it self-matches at cosine 1.0 and takes the top slot — resurfacing the
+        // very post the digest's seen penalty just pushed down.
+        $interests = $this->interests($userid, $indexed->map(fn ($p) => (int) $p->id)->all());
         if (empty($interests)) {
             return $posts;
         }
 
-        $ids = $posts->map(fn ($p) => (int) $p->id)->all();
         $embeddings = $this->embeddingsFor($ids);
         if (empty($embeddings)) {
             return $posts;
         }
 
-        // Score each post by its best match to any interest vector. Posts with no
-        // embedding score below everything so they sink to the bottom (but keep
-        // their relative order). A stable sort keeps the existing order as the
-        // tiebreak, so relevance only *reorders*, it never invents an order.
-        $indexed = $posts->values();
-        $scored = $indexed->map(function ($post, $i) use ($embeddings, $interests) {
+        // Score each post the member could care about by its best match to any
+        // interest vector.
+        //
+        // A post with no embedding is of UNKNOWN relevance, not low relevance, so
+        // it holds its position rather than sinking. The digest is truncated at
+        // DigestStyle::DIGEST_POST_CAP, so sinking unembedded posts would drop
+        // them from any digest longer than the cap — silent content deletion
+        // driven by embedding coverage rather than by relevance, landing hardest
+        // on the newest posts, which are the ones still waiting on the embedding
+        // pipeline. Instead the embedded posts are permuted among the slots they
+        // already collectively occupied, so which posts survive the cap changes
+        // only through relevance.
+        $list = $rankable->all();
+        $slots = [];
+        $scored = [];
+        foreach ($list as $i => $post) {
             $vec = $embeddings[(int) $post->id] ?? null;
-            $score = $vec === null ? -INF : $this->maxCosine($vec, $interests);
+            if ($vec === null) {
+                continue;
+            }
+            $slots[] = $i;
+            $scored[] = ['post' => $post, 'score' => $this->maxCosine($vec, $interests), 'orig' => $i];
+        }
 
-            return ['post' => $post, 'score' => $score, 'orig' => $i];
-        });
+        if (count($scored) < 2) {
+            return $posts;
+        }
 
-        $sorted = $scored->sort(function ($a, $b) {
+        // Descending by score, with the existing order as a stable tiebreak, so
+        // relevance only reorders — it never invents an order.
+        usort($scored, function ($a, $b) {
             if ($a['score'] === $b['score']) {
                 return $a['orig'] <=> $b['orig'];
             }
 
             return $b['score'] <=> $a['score'];
-        })->values();
+        });
 
-        return $sorted->map(fn ($x) => $x['post'])->values();
+        foreach ($scored as $k => $x) {
+            $list[$slots[$k]] = $x['post'];
+        }
+
+        $this->ranked = true;
+
+        return $pinned->concat(collect(array_values($list)))->values();
     }
 
     /**
@@ -91,25 +173,45 @@ class DigestRelevanceService
      * last OWN_POST_DAYS and the posts they viewed in the last VIEW_DAYS, newest
      * first, capped at MAX_INTERESTS. Returns an array of float arrays.
      *
+     * $excludeMsgids drops those posts from the interest signal. rank() passes the
+     * digest's own msgids so a post can't be its own interest vector.
+     *
+     * @param  array<int, int>  $excludeMsgids
      * @return array<int, array<int, float>>
      */
-    public function interests(int $userid): array
+    public function interests(int $userid, array $excludeMsgids = []): array
     {
+        $exclude = array_values(array_unique(array_map('intval', $excludeMsgids)));
+        $notIn = '';
+        if (!empty($exclude)) {
+            $notIn = ' AND %s NOT IN ('.implode(',', array_fill(0, count($exclude), '?')).')';
+        }
+
+        $params = array_merge(
+            [$userid, self::OWN_POST_DAYS],
+            $exclude,
+            [$userid, 'View', self::VIEW_DAYS],
+            $exclude,
+            [self::MAX_INTERESTS]
+        );
+
         $rows = DB::select(
             'SELECT emb FROM (
                 SELECT me.subject_embedding AS emb, m.arrival AS ts
                 FROM messages m
                 INNER JOIN messages_embeddings me ON me.msgid = m.id
-                WHERE m.fromuser = ? AND m.arrival >= DATE_SUB(NOW(), INTERVAL ? DAY)
+                WHERE m.fromuser = ? AND m.arrival >= DATE_SUB(NOW(), INTERVAL ? DAY)'
+            .($notIn === '' ? '' : sprintf($notIn, 'm.id')).'
                 UNION ALL
                 SELECT me.subject_embedding AS emb, ml.timestamp AS ts
                 FROM messages_likes ml
                 INNER JOIN messages_embeddings me ON me.msgid = ml.msgid
-                WHERE ml.userid = ? AND ml.type = ? AND ml.pageview = 1 AND ml.timestamp >= DATE_SUB(NOW(), INTERVAL ? DAY)
+                WHERE ml.userid = ? AND ml.type = ? AND ml.pageview = 1 AND ml.timestamp >= DATE_SUB(NOW(), INTERVAL ? DAY)'
+            .($notIn === '' ? '' : sprintf($notIn, 'ml.msgid')).'
             ) x
             ORDER BY x.ts DESC
             LIMIT ?',
-            [$userid, self::OWN_POST_DAYS, $userid, 'View', self::VIEW_DAYS, self::MAX_INTERESTS]
+            $params
         );
 
         $vectors = [];
@@ -135,20 +237,51 @@ class DigestRelevanceService
             return [];
         }
 
-        $rows = DB::table('messages_embeddings')
-            ->whereIn('msgid', $ids)
-            ->select('msgid', 'subject_embedding')
-            ->get();
+        // Recipients in the same area see largely the same posts, so a digest run
+        // asks for the same blobs over and over. Memoise across recipients for the
+        // life of the run, and cache the misses too so a post with no embedding
+        // isn't re-queried for every recipient it reaches.
+        $missing = array_values(array_filter(
+            array_map('intval', $ids),
+            fn ($id) => !array_key_exists($id, self::$embeddingCache)
+        ));
+
+        if (!empty($missing)) {
+            if (count(self::$embeddingCache) > self::EMBEDDING_CACHE_MAX) {
+                self::$embeddingCache = [];
+            }
+
+            $rows = DB::table('messages_embeddings')
+                ->whereIn('msgid', $missing)
+                ->select('msgid', 'subject_embedding')
+                ->get();
+
+            foreach ($missing as $id) {
+                self::$embeddingCache[$id] = null;
+            }
+            foreach ($rows as $row) {
+                self::$embeddingCache[(int) $row->msgid] = $this->decode($row->subject_embedding);
+            }
+        }
 
         $out = [];
-        foreach ($rows as $row) {
-            $vec = $this->decode($row->subject_embedding);
+        foreach ($ids as $id) {
+            $vec = self::$embeddingCache[(int) $id] ?? null;
             if ($vec !== null) {
-                $out[(int) $row->msgid] = $vec;
+                $out[(int) $id] = $vec;
             }
         }
 
         return $out;
+    }
+
+    /**
+     * Clear the cross-recipient embedding memo. Called between digest runs (and by
+     * tests) so a long-lived worker doesn't serve a stale or unbounded cache.
+     */
+    public static function flushEmbeddingCache(): void
+    {
+        self::$embeddingCache = [];
     }
 
     /**

--- a/iznik-batch/app/Services/DigestRelevanceService.php
+++ b/iznik-batch/app/Services/DigestRelevanceService.php
@@ -105,7 +105,7 @@ class DigestRelevanceService
                 SELECT me.subject_embedding AS emb, ml.timestamp AS ts
                 FROM messages_likes ml
                 INNER JOIN messages_embeddings me ON me.msgid = ml.msgid
-                WHERE ml.userid = ? AND ml.type = ? AND ml.timestamp >= DATE_SUB(NOW(), INTERVAL ? DAY)
+                WHERE ml.userid = ? AND ml.type = ? AND ml.pageview = 1 AND ml.timestamp >= DATE_SUB(NOW(), INTERVAL ? DAY)
             ) x
             ORDER BY x.ts DESC
             LIMIT ?',

--- a/iznik-batch/app/Services/UnifiedDigestService.php
+++ b/iznik-batch/app/Services/UnifiedDigestService.php
@@ -111,6 +111,11 @@ class UnifiedDigestService
             $users = $users->take($limit);
         }
 
+        // Relevance ranking memoises decoded embeddings across recipients within a
+        // run (neighbouring members see largely the same posts). Start each run
+        // clean so a long-lived worker can't serve yesterday's vectors.
+        DigestRelevanceService::flushEmbeddingCache();
+
         foreach ($users as $user) {
             // Graceful interrupt: SIGTERM/SIGINT (or an abort-file touch) flips
             // the caller's shouldStop flag. Check between users so a kill
@@ -1391,6 +1396,9 @@ class UnifiedDigestService
         // withdrawn/expired (has_outcome && !has_success) appear in neither.
         $posts = $allPosts->filter(fn ($p) => !$p->has_outcome)->values();
 
+        // Whether relevance ranking actually reordered this digest (daily only).
+        $relevanceRanked = false;
+
         // Order the live posts by the rippling digest-preview score (nearer +
         // newer + less-seen float up), matching the /rippling "Digest preview".
         // Daily only — immediate mode stays chronological (single-group, real-time).
@@ -1421,7 +1429,14 @@ class UnifiedDigestService
             // what post_msgids records (the position the click dashboard measures).
             // A no-op (returns $posts unchanged) when the flag is off, the member
             // is in the holdout, or they have no interest signal.
-            $posts = app(DigestRelevanceService::class)->rank((int) $user->id, $posts);
+            $relevance = app(DigestRelevanceService::class);
+            $posts = $relevance->rank((int) $user->id, $posts);
+            // Record whether ranking was genuinely applied, so the dashboard's
+            // "ranked" arm holds only reranked digests. Defining that arm as
+            // "not in the holdout" would count every member who had no interest
+            // signal — they got an identical unranked digest and would drag any
+            // measured effect toward zero.
+            $relevanceRanked = $relevance->didRank();
         }
 
         $completedPosts = $mode === self::MODE_DAILY
@@ -1511,7 +1526,7 @@ class UnifiedDigestService
         // went" Taken/Received set) was partitioned from the same query above.
         if (!$dryRun) {
             app(\App\Services\EmailSpoolerService::class)->spool(
-                new UnifiedDigest($user, $deduplicatedPosts, $mode, $sponsors, $completedPosts),
+                new UnifiedDigest($user, $deduplicatedPosts, $mode, $sponsors, $completedPosts, $relevanceRanked),
                 emailType: 'digest_daily',
             );
             // Advance the cursor past everything examined this window (live,
@@ -2082,6 +2097,11 @@ class UnifiedDigestService
         $closest = $sorted->filter(fn ($p) => empty($p->seen_by_user))
             ->sortBy('_dist')->take(2)->values();
         $closestIds = $closest->pluck('id')->all();
+        // Mark the pin so a later re-sort can honour it. Relevance ranking runs
+        // after this and would otherwise discard the pin for every ranked member.
+        $closest->each(function ($p) {
+            $p->_pinned = true;
+        });
         $rest = $sorted->reject(fn ($p) => in_array($p->id, $closestIds, true))->values();
         return $closest->concat($rest)->values();
     }

--- a/iznik-batch/app/Services/UnifiedDigestService.php
+++ b/iznik-batch/app/Services/UnifiedDigestService.php
@@ -1413,6 +1413,15 @@ class UnifiedDigestService
                 (int) $p->fromuser === (int) $user->id,
                 $this->authorMaxMiles((int) $p->fromuser)
             ))->values();
+
+            // Personal relevance ranking (flag-gated, default OFF, with a 10%
+            // holdout). Float the posts most like what this member cares about
+            // to the top. Applied here — after scoring/distance, before dedup —
+            // so the ranked order is what dedup picks its representative from and
+            // what post_msgids records (the position the click dashboard measures).
+            // A no-op (returns $posts unchanged) when the flag is off, the member
+            // is in the holdout, or they have no interest signal.
+            $posts = app(DigestRelevanceService::class)->rank((int) $user->id, $posts);
         }
 
         $completedPosts = $mode === self::MODE_DAILY

--- a/iznik-batch/config/freegle.php
+++ b/iznik-batch/config/freegle.php
@@ -290,6 +290,14 @@ return [
         // The scheduled `mail:digest:unified --mode=daily` is inert until this
         // is set; an explicit `--user=` bypasses the gate for manual sampling.
         'daily_allowlist' => env('FREEGLE_DIGEST_DAILY_ALLOWLIST', ''),
+
+        // Rank the daily digest's live posts by vector similarity to the
+        // member's own recent posts and recently-viewed items, so the things
+        // most like what they care about float to the top. Default OFF — this
+        // changes email ordering, so it ships dark and is enabled deliberately.
+        // A 10% holdout (userid % 10 == 0) always keeps the existing order so we
+        // can measure the effect via the digest click-by-position dashboard.
+        'relevance_enabled' => (bool) env('FEATURE_DIGEST_RELEVANCE', false),
     ],
 
     // Firebase Cloud Messaging for push notifications
@@ -1177,15 +1185,5 @@ return [
         'publish_brands'    => env('EEE_PUBLISH_BRANDS', false),
         'publish_category'  => env('EEE_PUBLISH_CATEGORY', true),
         'publish_condition' => env('EEE_PUBLISH_CONDITION', true),
-    ],
-
-    'digest' => [
-        // Rank the daily digest's live posts by vector similarity to the
-        // member's own recent posts and recently-viewed items, so the things
-        // most like what they care about float to the top. Default OFF — this
-        // changes email ordering, so it ships dark and is enabled deliberately.
-        // A 10% holdout (userid % 10 == 0) always keeps the existing order so we
-        // can measure the effect via the digest click-by-position dashboard.
-        'relevance_enabled' => (bool) env('FEATURE_DIGEST_RELEVANCE', false),
     ],
 ];

--- a/iznik-batch/config/freegle.php
+++ b/iznik-batch/config/freegle.php
@@ -1178,4 +1178,14 @@ return [
         'publish_category'  => env('EEE_PUBLISH_CATEGORY', true),
         'publish_condition' => env('EEE_PUBLISH_CONDITION', true),
     ],
+
+    'digest' => [
+        // Rank the daily digest's live posts by vector similarity to the
+        // member's own recent posts and recently-viewed items, so the things
+        // most like what they care about float to the top. Default OFF — this
+        // changes email ordering, so it ships dark and is enabled deliberately.
+        // A 10% holdout (userid % 10 == 0) always keeps the existing order so we
+        // can measure the effect via the digest click-by-position dashboard.
+        'relevance_enabled' => (bool) env('FEATURE_DIGEST_RELEVANCE', false),
+    ],
 ];

--- a/iznik-batch/database/migrations/2026_07_31_000001_add_messages_likes_user_type_ts_index.php
+++ b/iznik-batch/database/migrations/2026_07_31_000001_add_messages_likes_user_type_ts_index.php
@@ -1,0 +1,52 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * messages_likes(userid, type, timestamp) index for DigestRelevanceService::interests(),
+ * which reads a member's recently viewed posts to build their interest vectors.
+ *
+ * That query filters `userid = ? AND type = 'View' AND timestamp >= ?` and takes the
+ * newest MAX_INTERESTS rows. The existing (userid) index can only seek the member, so
+ * MySQL reads every like row they have ever had — thousands for an engaged member — to
+ * keep a few dozen, and it runs once per digest recipient. The existing
+ * messages_likes_source_ts_user index cannot serve it: that index leads on `source`,
+ * which this query does not constrain. Leading on (userid, type) and range-scanning
+ * timestamp lets the query stop as soon as it has enough rows.
+ *
+ * PRODUCTION NOTE: messages_likes is ~75M rows and HOT (every markseen writes it), and
+ * prod is Percona/Galera with wsrep_OSU_method=TOI, so a plain ALTER serialises
+ * cluster-wide for the whole index build. If the auto-migrate stall is unacceptable,
+ * deploy the companion _migration.sql node-by-node under wsrep_OSU_method=RSU instead
+ * of the auto-migrate path. Online (ALGORITHM=INPLACE, LOCK=NONE) and idempotent:
+ * guarded on information_schema so a re-run is a no-op.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $exists = DB::selectOne(
+            "SELECT COUNT(*) AS n FROM information_schema.statistics
+             WHERE table_schema = DATABASE() AND table_name = 'messages_likes'
+               AND index_name = 'messages_likes_user_type_ts'"
+        );
+        if ((int) ($exists->n ?? 0) === 0) {
+            DB::statement(
+                'ALTER TABLE messages_likes ADD INDEX messages_likes_user_type_ts (userid, type, timestamp), ALGORITHM=INPLACE, LOCK=NONE'
+            );
+        }
+    }
+
+    public function down(): void
+    {
+        $exists = DB::selectOne(
+            "SELECT COUNT(*) AS n FROM information_schema.statistics
+             WHERE table_schema = DATABASE() AND table_name = 'messages_likes'
+               AND index_name = 'messages_likes_user_type_ts'"
+        );
+        if ((int) ($exists->n ?? 0) > 0) {
+            DB::statement('ALTER TABLE messages_likes DROP INDEX messages_likes_user_type_ts');
+        }
+    }
+};

--- a/iznik-batch/database/migrations/2026_07_31_000001_add_messages_likes_user_type_ts_index_migration.sql
+++ b/iznik-batch/database/migrations/2026_07_31_000001_add_messages_likes_user_type_ts_index_migration.sql
@@ -1,0 +1,24 @@
+-- Production idempotent SQL: messages_likes(userid, type, timestamp) index for
+-- DigestRelevanceService::interests(), which builds a member's interest vectors from
+-- the posts they recently viewed.
+--
+-- That query filters `userid = ? AND type = 'View' AND timestamp >= ?` and keeps the
+-- newest MAX_INTERESTS rows. With only the (userid) index, MySQL reads every like row
+-- the member has ever had (thousands for an engaged member) to keep a few dozen, once
+-- per digest recipient. messages_likes_source_ts_user cannot serve it: that index leads
+-- on `source`, which this query does not constrain.
+--
+-- messages_likes is ~75M rows and HOT, and prod is Galera (wsrep_OSU_method=TOI): a
+-- plain ALTER serialises cluster-wide writes for the whole index build. To avoid that
+-- stall, run this node-by-node under RSU so no single node blocks the cluster:
+--   SET SESSION wsrep_OSU_method = 'RSU';
+--   -- run the guarded ALTER below on this node
+--   SET SESSION wsrep_OSU_method = 'TOI';
+-- Online (ALGORITHM=INPLACE, LOCK=NONE) and guarded so a re-run is a no-op.
+SET @idx_exists := (SELECT COUNT(*) FROM information_schema.statistics
+    WHERE table_schema = DATABASE() AND table_name = 'messages_likes'
+      AND index_name = 'messages_likes_user_type_ts');
+SET @ddl := IF(@idx_exists = 0,
+    'ALTER TABLE messages_likes ADD INDEX messages_likes_user_type_ts (userid, type, timestamp), ALGORITHM=INPLACE, LOCK=NONE',
+    'SELECT 1');
+PREPARE stmt FROM @ddl; EXECUTE stmt; DEALLOCATE PREPARE stmt;

--- a/iznik-batch/tests/Unit/Services/DigestRelevanceServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/DigestRelevanceServiceTest.php
@@ -121,21 +121,24 @@ class DigestRelevanceServiceTest extends TestCase
     {
         config(['freegle.digest.relevance_enabled' => true]);
 
-        // Force a holdout user id (multiple of 10) by inserting one directly.
-        $group = $this->createTestGroup();
-        $holdoutId = ((int) (DB::table('users')->max('id') + 10) / 10) * 10;
+        // A fixed, high id that is a multiple of 10 (so it is always in the
+        // holdout) and safely above any auto-increment value in the test DB.
+        $holdoutId = 2000000000;
         DB::table('users')->insert(['id' => $holdoutId, 'firstname' => 'Hold', 'lastname' => 'Out', 'fullname' => 'Hold Out']);
 
+        // Give the holdout user an interest vector that WOULD rank $b first if
+        // ranking ran — the point of the test is that holdout suppresses it.
+        $group = $this->createTestGroup();
         $own = $this->createTestMessage($this->createTestUser(), $group, ['fromuser' => $holdoutId, 'arrival' => now()]);
         $this->insertEmbedding($own->id, $this->unitVec(2.0));
         $a = $this->createTestMessage($this->createTestUser(), $group, ['arrival' => now()]);
         $b = $this->createTestMessage($this->createTestUser(), $group, ['arrival' => now()]);
         $this->insertEmbedding($a->id, $this->unitVec(9.0));
-        $this->insertEmbedding($b->id, $this->unitVec(2.0001));
+        $this->insertEmbedding($b->id, $this->unitVec(2.0001)); // most similar to the interest
 
         $input = collect([$this->makePost($a->id), $this->makePost($b->id)]);
         $ranked = (new DigestRelevanceService)->rank($holdoutId, $input);
-        $this->assertSame([$a->id, $b->id], $ranked->map(fn ($p) => $p->id)->all(), 'holdout → unchanged order');
+        $this->assertSame([$a->id, $b->id], $ranked->map(fn ($p) => $p->id)->all(), 'holdout → unchanged order despite a matching interest');
     }
 
     public function test_user_with_no_interests_returns_input_order_unchanged(): void

--- a/iznik-batch/tests/Unit/Services/DigestRelevanceServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/DigestRelevanceServiceTest.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Models\Message;
+use App\Services\DigestRelevanceService;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class DigestRelevanceServiceTest extends TestCase
+{
+    private const DIM = 256;
+
+    /**
+     * Build a unit vector distinct per seed, matching the test-vector recipe used
+     * on the Go side so a round-trip is meaningful.
+     *
+     * @return array<int, float>
+     */
+    private function unitVec(float $seed): array
+    {
+        $v = [];
+        $norm = 0.0;
+        for ($i = 0; $i < self::DIM; $i++) {
+            $v[$i] = $seed + $i * 0.01;
+            $norm += $v[$i] * $v[$i];
+        }
+        $norm = sqrt($norm);
+        for ($i = 0; $i < self::DIM; $i++) {
+            $v[$i] /= $norm;
+        }
+
+        return $v;
+    }
+
+    /** Little-endian float32 pack — must match the service's unpack('g'). */
+    private function pack(array $vec): string
+    {
+        return pack('g*', ...$vec);
+    }
+
+    private function insertEmbedding(int $msgid, array $vec): void
+    {
+        DB::table('messages_embeddings')->insert([
+            'msgid' => $msgid,
+            'subject_embedding' => $this->pack($vec),
+            'model_version' => 'test',
+        ]);
+    }
+
+    /** A tiny fake post object as the digest passes (only ->id is read). */
+    private function post(int $id): object
+    {
+        return (object) ['id' => $id];
+    }
+
+    public function test_pack_unpack_round_trips_little_endian(): void
+    {
+        // The blob the service decodes must equal the vector we packed — this is
+        // the cross-language contract with the Go writer.
+        $vec = $this->unitVec(1.0);
+        $blob = $this->pack($vec);
+        $this->assertSame(self::DIM * 4, strlen($blob));
+        $decoded = array_values(unpack('g'.self::DIM, $blob));
+        for ($i = 0; $i < self::DIM; $i++) {
+            $this->assertEqualsWithDelta($vec[$i], $decoded[$i], 1e-6);
+        }
+    }
+
+    public function test_rank_orders_by_relevance_to_interest(): void
+    {
+        config(['freegle.digest.relevance_enabled' => true]);
+
+        $user = $this->createTestUser();
+        // Ensure not in the holdout so ranking actually runs.
+        if ($user->id % 10 === 0) {
+            $this->markTestSkipped('user landed in holdout; rerun');
+        }
+        $group = $this->createTestGroup();
+
+        // The user's own recent post establishes an interest vector.
+        $ownVec = $this->unitVec(2.0);
+        $own = $this->createTestMessage($user, $group, ['type' => Message::TYPE_WANTED, 'arrival' => now()]);
+        $this->insertEmbedding($own->id, $ownVec);
+
+        // Three candidate posts: one near the interest, two unrelated. The near
+        // one must rank first even though it's given LAST in input order.
+        $poster = $this->createTestUser();
+        $far1 = $this->createTestMessage($poster, $group, ['arrival' => now()]);
+        $far2 = $this->createTestMessage($poster, $group, ['arrival' => now()]);
+        $near = $this->createTestMessage($poster, $group, ['arrival' => now()]);
+        $this->insertEmbedding($far1->id, $this->unitVec(9.0));
+        $this->insertEmbedding($far2->id, $this->unitVec(8.0));
+        $this->insertEmbedding($near->id, $this->unitVec(2.0001)); // cosine ~1 with ownVec
+
+        $service = new DigestRelevanceService;
+        $ranked = $service->rank($user->id, collect([$this->post($far1->id), $this->post($far2->id), $this->post($near->id)]));
+
+        $this->assertSame($near->id, $ranked->first()->id, 'the post most similar to the user interest ranks first');
+    }
+
+    public function test_flag_off_returns_input_order_unchanged(): void
+    {
+        config(['freegle.digest.relevance_enabled' => false]);
+
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $own = $this->createTestMessage($user, $group, ['arrival' => now()]);
+        $this->insertEmbedding($own->id, $this->unitVec(2.0));
+        $a = $this->createTestMessage($user, $group, ['arrival' => now()]);
+        $b = $this->createTestMessage($user, $group, ['arrival' => now()]);
+        $this->insertEmbedding($a->id, $this->unitVec(9.0));
+        $this->insertEmbedding($b->id, $this->unitVec(2.0001));
+
+        $input = collect([$this->post($a->id), $this->post($b->id)]);
+        $ranked = (new DigestRelevanceService)->rank($user->id, $input);
+        $this->assertSame([$a->id, $b->id], $ranked->map(fn ($p) => $p->id)->all(), 'flag off → unchanged order');
+    }
+
+    public function test_holdout_user_returns_input_order_unchanged(): void
+    {
+        config(['freegle.digest.relevance_enabled' => true]);
+
+        // Force a holdout user id (multiple of 10) by inserting one directly.
+        $group = $this->createTestGroup();
+        $holdoutId = ((int) (DB::table('users')->max('id') + 10) / 10) * 10;
+        DB::table('users')->insert(['id' => $holdoutId, 'firstname' => 'Hold', 'lastname' => 'Out', 'fullname' => 'Hold Out']);
+
+        $own = $this->createTestMessage($this->createTestUser(), $group, ['fromuser' => $holdoutId, 'arrival' => now()]);
+        $this->insertEmbedding($own->id, $this->unitVec(2.0));
+        $a = $this->createTestMessage($this->createTestUser(), $group, ['arrival' => now()]);
+        $b = $this->createTestMessage($this->createTestUser(), $group, ['arrival' => now()]);
+        $this->insertEmbedding($a->id, $this->unitVec(9.0));
+        $this->insertEmbedding($b->id, $this->unitVec(2.0001));
+
+        $input = collect([$this->post($a->id), $this->post($b->id)]);
+        $ranked = (new DigestRelevanceService)->rank($holdoutId, $input);
+        $this->assertSame([$a->id, $b->id], $ranked->map(fn ($p) => $p->id)->all(), 'holdout → unchanged order');
+    }
+
+    public function test_user_with_no_interests_returns_input_order_unchanged(): void
+    {
+        config(['freegle.digest.relevance_enabled' => true]);
+
+        $user = $this->createTestUser();
+        if ($user->id % 10 === 0) {
+            $this->markTestSkipped('holdout');
+        }
+        $group = $this->createTestGroup();
+        // No own posts and no views → no interest signal.
+        $a = $this->createTestMessage($this->createTestUser(), $group, ['arrival' => now()]);
+        $b = $this->createTestMessage($this->createTestUser(), $group, ['arrival' => now()]);
+        $this->insertEmbedding($a->id, $this->unitVec(9.0));
+        $this->insertEmbedding($b->id, $this->unitVec(2.0001));
+
+        $input = collect([$this->post($a->id), $this->post($b->id)]);
+        $ranked = (new DigestRelevanceService)->rank($user->id, $input);
+        $this->assertSame([$a->id, $b->id], $ranked->map(fn ($p) => $p->id)->all(), 'no interests → unchanged order');
+    }
+
+    public function test_candidates_without_embeddings_sink_below_embedded(): void
+    {
+        config(['freegle.digest.relevance_enabled' => true]);
+
+        $user = $this->createTestUser();
+        if ($user->id % 10 === 0) {
+            $this->markTestSkipped('holdout');
+        }
+        $group = $this->createTestGroup();
+        $own = $this->createTestMessage($user, $group, ['arrival' => now()]);
+        $this->insertEmbedding($own->id, $this->unitVec(2.0));
+
+        $poster = $this->createTestUser();
+        $embedded = $this->createTestMessage($poster, $group, ['arrival' => now()]);
+        $this->insertEmbedding($embedded->id, $this->unitVec(2.0001)); // relevant
+        $noEmb = $this->createTestMessage($poster, $group, ['arrival' => now()]); // no embedding row
+
+        $input = collect([$this->post($noEmb->id), $this->post($embedded->id)]);
+        $ranked = (new DigestRelevanceService)->rank($user->id, $input);
+        $this->assertSame($embedded->id, $ranked->first()->id, 'embedded relevant post outranks the unembedded one');
+        $this->assertSame($noEmb->id, $ranked->last()->id, 'unembedded post sinks to the bottom');
+    }
+}

--- a/iznik-batch/tests/Unit/Services/DigestRelevanceServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/DigestRelevanceServiceTest.php
@@ -183,4 +183,48 @@ class DigestRelevanceServiceTest extends TestCase
         $this->assertSame($embedded->id, $ranked->first()->id, 'embedded relevant post outranks the unembedded one');
         $this->assertSame($noEmb->id, $ranked->last()->id, 'unembedded post sinks to the bottom');
     }
+
+    public function test_interests_counts_a_genuinely_viewed_post_pageview_1(): void
+    {
+        // The interest signal includes posts the member actually OPENED - a
+        // messages_likes View with pageview=1 - not only their own posts. This is
+        // the "recently viewed" half of the UNION, previously untested.
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $poster = $this->createTestUser();
+        $viewed = $this->createTestMessage($poster, $group, ['arrival' => now()]);
+        $vec = $this->unitVec(3.0);
+        $this->insertEmbedding($viewed->id, $vec);
+        DB::table('messages_likes')->insert([
+            'msgid' => $viewed->id, 'userid' => $user->id, 'type' => 'View',
+            'pageview' => 1, 'count' => 1, 'timestamp' => now(),
+        ]);
+
+        $interests = (new DigestRelevanceService)->interests($user->id);
+
+        $this->assertCount(1, $interests, 'a genuinely-viewed post contributes to interests');
+        foreach ($vec as $i => $expected) {
+            $this->assertEqualsWithDelta($expected, $interests[0][$i], 1e-6);
+        }
+    }
+
+    public function test_interests_ignores_a_scroll_impression_pageview_0(): void
+    {
+        // A pageview=0 View row is a mere list-scroll impression (MarkSeen), not a
+        // genuine read. It must NOT count as an interest signal, or an active
+        // browser's 40-slot budget is swamped by everything that scrolled past.
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $poster = $this->createTestUser();
+        $scrolled = $this->createTestMessage($poster, $group, ['arrival' => now()]);
+        $this->insertEmbedding($scrolled->id, $this->unitVec(4.0));
+        DB::table('messages_likes')->insert([
+            'msgid' => $scrolled->id, 'userid' => $user->id, 'type' => 'View',
+            'pageview' => 0, 'count' => 1, 'timestamp' => now(),
+        ]);
+
+        $interests = (new DigestRelevanceService)->interests($user->id);
+
+        $this->assertCount(0, $interests, 'a scroll-impression (pageview=0) is not an interest signal');
+    }
 }

--- a/iznik-batch/tests/Unit/Services/DigestRelevanceServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/DigestRelevanceServiceTest.php
@@ -11,6 +11,14 @@ class DigestRelevanceServiceTest extends TestCase
 {
     private const DIM = 256;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // The embedding memo is shared across recipients within a digest run, so
+        // drop it between tests or one test's rows leak into the next.
+        DigestRelevanceService::flushEmbeddingCache();
+    }
+
     /**
      * Build a unit vector distinct per seed, matching the test-vector recipe used
      * on the Go side so a round-trip is meaningful.
@@ -161,8 +169,13 @@ class DigestRelevanceServiceTest extends TestCase
         $this->assertSame([$a->id, $b->id], $ranked->map(fn ($p) => $p->id)->all(), 'no interests → unchanged order');
     }
 
-    public function test_candidates_without_embeddings_sink_below_embedded(): void
+    public function test_candidate_without_an_embedding_holds_its_position(): void
     {
+        // A post with no embedding is of UNKNOWN relevance, not low relevance. The
+        // digest is truncated at DIGEST_POST_CAP, so sinking it would delete it
+        // from any digest longer than the cap for want of an embedding — content
+        // loss driven by pipeline coverage rather than by relevance. It must keep
+        // its slot while the embedded posts reorder around it.
         config(['freegle.digest.relevance_enabled' => true]);
 
         $user = $this->createTestUser();
@@ -174,14 +187,167 @@ class DigestRelevanceServiceTest extends TestCase
         $this->insertEmbedding($own->id, $this->unitVec(2.0));
 
         $poster = $this->createTestUser();
-        $embedded = $this->createTestMessage($poster, $group, ['arrival' => now()]);
-        $this->insertEmbedding($embedded->id, $this->unitVec(2.0001)); // relevant
+        $dull = $this->createTestMessage($poster, $group, ['arrival' => now()]);
         $noEmb = $this->createTestMessage($poster, $group, ['arrival' => now()]); // no embedding row
+        $relevant = $this->createTestMessage($poster, $group, ['arrival' => now()]);
+        $this->insertEmbedding($dull->id, $this->unitVec(9.0));
+        $this->insertEmbedding($relevant->id, $this->unitVec(2.0001)); // cosine ~1 with own
 
-        $input = collect([$this->makePost($noEmb->id), $this->makePost($embedded->id)]);
+        $input = collect([
+            $this->makePost($dull->id),
+            $this->makePost($noEmb->id),
+            $this->makePost($relevant->id),
+        ]);
         $ranked = (new DigestRelevanceService)->rank($user->id, $input);
-        $this->assertSame($embedded->id, $ranked->first()->id, 'embedded relevant post outranks the unembedded one');
-        $this->assertSame($noEmb->id, $ranked->last()->id, 'unembedded post sinks to the bottom');
+
+        // Slots 0 and 2 held the embedded posts and swap; slot 1 is untouched.
+        $this->assertSame(
+            [$relevant->id, $noEmb->id, $dull->id],
+            $ranked->map(fn ($p) => $p->id)->all(),
+            'embedded posts reorder among their own slots; the unembedded post keeps position 1'
+        );
+    }
+
+    public function test_a_digest_post_does_not_become_its_own_interest_vector(): void
+    {
+        // A post the member viewed in the last VIEW_DAYS is otherwise one of its
+        // own interest vectors: it self-matches at cosine 1.0 and takes the top
+        // slot, resurfacing exactly the already-seen post the digest's seen
+        // penalty pushed down.
+        config(['freegle.digest.relevance_enabled' => true]);
+
+        $user = $this->createTestUser();
+        if ($user->id % 10 === 0) {
+            $this->markTestSkipped('holdout');
+        }
+        $group = $this->createTestGroup();
+        $poster = $this->createTestUser();
+
+        // The member's genuine interest, from their own recent post.
+        $own = $this->createTestMessage($user, $group, ['arrival' => now()]);
+        $this->insertEmbedding($own->id, $this->unitVec(2.0));
+
+        // A digest candidate matching that interest.
+        $wanted = $this->createTestMessage($poster, $group, ['arrival' => now()]);
+        $this->insertEmbedding($wanted->id, $this->unitVec(2.0001));
+
+        // A candidate the member already viewed, unrelated to their interest.
+        $seen = $this->createTestMessage($poster, $group, ['arrival' => now()]);
+        $this->insertEmbedding($seen->id, $this->unitVec(9.0));
+        DB::table('messages_likes')->insert([
+            'msgid' => $seen->id, 'userid' => $user->id, 'type' => 'View',
+            'pageview' => 1, 'count' => 1, 'timestamp' => now(),
+        ]);
+
+        $input = collect([$this->makePost($seen->id), $this->makePost($wanted->id)]);
+        $ranked = (new DigestRelevanceService)->rank($user->id, $input);
+
+        $this->assertSame(
+            $wanted->id,
+            $ranked->first()->id,
+            'the already-viewed candidate must not self-match to the top slot'
+        );
+    }
+
+    public function test_pinned_posts_keep_the_front_of_the_list(): void
+    {
+        // The two nearest posts are pinned to the top upstream to answer "I keep
+        // seeing posts far away". Re-sorting the whole collection would discard
+        // that pin for every ranked member.
+        config(['freegle.digest.relevance_enabled' => true]);
+
+        $user = $this->createTestUser();
+        if ($user->id % 10 === 0) {
+            $this->markTestSkipped('holdout');
+        }
+        $group = $this->createTestGroup();
+        $own = $this->createTestMessage($user, $group, ['arrival' => now()]);
+        $this->insertEmbedding($own->id, $this->unitVec(2.0));
+
+        $poster = $this->createTestUser();
+        $pinned = $this->createTestMessage($poster, $group, ['arrival' => now()]);
+        $dull = $this->createTestMessage($poster, $group, ['arrival' => now()]);
+        $relevant = $this->createTestMessage($poster, $group, ['arrival' => now()]);
+        // The pinned post is the LEAST relevant, so an unguarded rank would sink it.
+        $this->insertEmbedding($pinned->id, $this->unitVec(9.0));
+        $this->insertEmbedding($dull->id, $this->unitVec(8.0));
+        $this->insertEmbedding($relevant->id, $this->unitVec(2.0001));
+
+        $pinnedPost = $this->makePost($pinned->id);
+        $pinnedPost->_pinned = true;
+
+        $input = collect([$pinnedPost, $this->makePost($dull->id), $this->makePost($relevant->id)]);
+        $ranked = (new DigestRelevanceService)->rank($user->id, $input);
+
+        $this->assertSame($pinned->id, $ranked->first()->id, 'the pinned post stays at the front');
+        $this->assertSame($relevant->id, $ranked->get(1)->id, 'the rest are ranked below the pin');
+    }
+
+    public function test_did_rank_reports_whether_ranking_was_applied(): void
+    {
+        // The dashboard's ranked arm filters on what was recorded. Reporting a
+        // member as ranked when rank() bailed would put recipients of an identical
+        // unranked digest in the treatment arm and dilute the measured effect.
+        config(['freegle.digest.relevance_enabled' => true]);
+
+        $user = $this->createTestUser();
+        if ($user->id % 10 === 0) {
+            $this->markTestSkipped('holdout');
+        }
+        $group = $this->createTestGroup();
+        $poster = $this->createTestUser();
+        $a = $this->createTestMessage($poster, $group, ['arrival' => now()]);
+        $b = $this->createTestMessage($poster, $group, ['arrival' => now()]);
+        $this->insertEmbedding($a->id, $this->unitVec(9.0));
+        $this->insertEmbedding($b->id, $this->unitVec(8.0));
+        $input = collect([$this->makePost($a->id), $this->makePost($b->id)]);
+
+        // No interest signal at all: the digest goes out unranked.
+        $noSignal = new DigestRelevanceService;
+        $noSignal->rank($user->id, $input);
+        $this->assertFalse($noSignal->didRank(), 'a member with no interest signal is not in the ranked arm');
+
+        // Give the member an interest and it does rank.
+        $own = $this->createTestMessage($user, $group, ['arrival' => now()]);
+        $this->insertEmbedding($own->id, $this->unitVec(2.0));
+        $withSignal = new DigestRelevanceService;
+        $withSignal->rank($user->id, $input);
+        $this->assertTrue($withSignal->didRank(), 'a genuinely reranked member is in the ranked arm');
+
+        // The holdout is never ranked, whatever signal they have.
+        config(['freegle.digest.relevance_enabled' => false]);
+        $flagOff = new DigestRelevanceService;
+        $flagOff->rank($user->id, $input);
+        $this->assertFalse($flagOff->didRank(), 'flag off is never in the ranked arm');
+    }
+
+    public function test_embeddings_are_fetched_once_across_recipients(): void
+    {
+        // interests()/embeddingsFor() run once per digest recipient, and recipients
+        // in the same area see largely the same posts. Without a memo the same
+        // blobs are re-fetched and re-decoded for every recipient in the run.
+        $group = $this->createTestGroup();
+        $poster = $this->createTestUser();
+        $a = $this->createTestMessage($poster, $group, ['arrival' => now()]);
+        $this->insertEmbedding($a->id, $this->unitVec(5.0));
+
+        DigestRelevanceService::flushEmbeddingCache();
+
+        $queries = 0;
+        DB::listen(function ($q) use (&$queries) {
+            if (str_contains($q->sql, 'messages_embeddings')) {
+                $queries++;
+            }
+        });
+
+        $service = new DigestRelevanceService;
+        $method = new \ReflectionMethod($service, 'embeddingsFor');
+        $method->setAccessible(true);
+        $first = $method->invoke($service, [$a->id]);
+        $second = $method->invoke(new DigestRelevanceService, [$a->id]);
+
+        $this->assertSame(1, $queries, 'the second recipient reuses the memo rather than re-querying');
+        $this->assertEquals($first, $second, 'the memo returns the same decoded vectors');
     }
 
     public function test_interests_counts_a_genuinely_viewed_post_pageview_1(): void

--- a/iznik-batch/tests/Unit/Services/DigestRelevanceServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/DigestRelevanceServiceTest.php
@@ -49,7 +49,7 @@ class DigestRelevanceServiceTest extends TestCase
     }
 
     /** A tiny fake post object as the digest passes (only ->id is read). */
-    private function post(int $id): object
+    private function makePost(int $id): object
     {
         return (object) ['id' => $id];
     }
@@ -94,7 +94,7 @@ class DigestRelevanceServiceTest extends TestCase
         $this->insertEmbedding($near->id, $this->unitVec(2.0001)); // cosine ~1 with ownVec
 
         $service = new DigestRelevanceService;
-        $ranked = $service->rank($user->id, collect([$this->post($far1->id), $this->post($far2->id), $this->post($near->id)]));
+        $ranked = $service->rank($user->id, collect([$this->makePost($far1->id), $this->makePost($far2->id), $this->makePost($near->id)]));
 
         $this->assertSame($near->id, $ranked->first()->id, 'the post most similar to the user interest ranks first');
     }
@@ -112,7 +112,7 @@ class DigestRelevanceServiceTest extends TestCase
         $this->insertEmbedding($a->id, $this->unitVec(9.0));
         $this->insertEmbedding($b->id, $this->unitVec(2.0001));
 
-        $input = collect([$this->post($a->id), $this->post($b->id)]);
+        $input = collect([$this->makePost($a->id), $this->makePost($b->id)]);
         $ranked = (new DigestRelevanceService)->rank($user->id, $input);
         $this->assertSame([$a->id, $b->id], $ranked->map(fn ($p) => $p->id)->all(), 'flag off → unchanged order');
     }
@@ -133,7 +133,7 @@ class DigestRelevanceServiceTest extends TestCase
         $this->insertEmbedding($a->id, $this->unitVec(9.0));
         $this->insertEmbedding($b->id, $this->unitVec(2.0001));
 
-        $input = collect([$this->post($a->id), $this->post($b->id)]);
+        $input = collect([$this->makePost($a->id), $this->makePost($b->id)]);
         $ranked = (new DigestRelevanceService)->rank($holdoutId, $input);
         $this->assertSame([$a->id, $b->id], $ranked->map(fn ($p) => $p->id)->all(), 'holdout → unchanged order');
     }
@@ -153,7 +153,7 @@ class DigestRelevanceServiceTest extends TestCase
         $this->insertEmbedding($a->id, $this->unitVec(9.0));
         $this->insertEmbedding($b->id, $this->unitVec(2.0001));
 
-        $input = collect([$this->post($a->id), $this->post($b->id)]);
+        $input = collect([$this->makePost($a->id), $this->makePost($b->id)]);
         $ranked = (new DigestRelevanceService)->rank($user->id, $input);
         $this->assertSame([$a->id, $b->id], $ranked->map(fn ($p) => $p->id)->all(), 'no interests → unchanged order');
     }
@@ -175,7 +175,7 @@ class DigestRelevanceServiceTest extends TestCase
         $this->insertEmbedding($embedded->id, $this->unitVec(2.0001)); // relevant
         $noEmb = $this->createTestMessage($poster, $group, ['arrival' => now()]); // no embedding row
 
-        $input = collect([$this->post($noEmb->id), $this->post($embedded->id)]);
+        $input = collect([$this->makePost($noEmb->id), $this->makePost($embedded->id)]);
         $ranked = (new DigestRelevanceService)->rank($user->id, $input);
         $this->assertSame($embedded->id, $ranked->first()->id, 'embedded relevant post outranks the unembedded one');
         $this->assertSame($noEmb->id, $ranked->last()->id, 'unembedded post sinks to the bottom');

--- a/iznik-nuxt3/modtools/components/ModSysAdminDigestClicks.vue
+++ b/iznik-nuxt3/modtools/components/ModSysAdminDigestClicks.vue
@@ -97,7 +97,10 @@ const endDate = ref('')
 // analysis is meaningless for them. Fixed, not user-selectable.
 const digestType = ref('UnifiedDigestDaily')
 
-// Recipient cohort for the digest relevance-ranking experiment.
+// Recipient cohort for the digest relevance-ranking experiment. "Ranked" counts
+// only digests the ranker actually reordered (recorded per digest), not everyone
+// outside the holdout - members with no interest signal got an identical
+// unranked digest and would flatten the comparison.
 const cohort = ref('')
 const cohortOptions = [
   { value: '', text: 'All recipients' },

--- a/iznik-nuxt3/modtools/components/ModSysAdminDigestClicks.vue
+++ b/iznik-nuxt3/modtools/components/ModSysAdminDigestClicks.vue
@@ -19,6 +19,19 @@
       @fetch="onFilterFetch"
     />
 
+    <!-- Relevance-ranking experiment cohort split. Compare the ranked group's
+         position curve against the 10% holdout: if ranking helps, the ranked
+         curve should be steeper (more clicks concentrated at the top). -->
+    <div class="d-flex align-items-center mb-3">
+      <label class="me-2 mb-0">Cohort</label>
+      <b-form-select
+        v-model="cohort"
+        :options="cohortOptions"
+        style="width: auto"
+        @change="fetchData"
+      />
+    </div>
+
     <!-- Error -->
     <NoticeMessage
       v-if="emailTrackingStore.digestPositionsError"
@@ -83,6 +96,14 @@ const endDate = ref('')
 // Daily digest only - immediate digests are single-post (always position 1), so position
 // analysis is meaningless for them. Fixed, not user-selectable.
 const digestType = ref('UnifiedDigestDaily')
+
+// Recipient cohort for the digest relevance-ranking experiment.
+const cohort = ref('')
+const cohortOptions = [
+  { value: '', text: 'All recipients' },
+  { value: 'ranked', text: 'Ranked (relevance)' },
+  { value: 'holdout', text: 'Holdout (unranked)' },
+]
 
 // Minimum number of digests that must have shown a post at a position for its
 // click-through rate to be trustworthy. Deep positions appear in very few
@@ -168,6 +189,7 @@ function fetchData() {
     type: digestType.value,
     start: startDate.value,
     end: endDate.value,
+    cohort: cohort.value,
   })
   emailTrackingStore.fetchDigestPositions()
 }

--- a/iznik-nuxt3/modtools/stores/emailtracking.js
+++ b/iznik-nuxt3/modtools/stores/emailtracking.js
@@ -42,6 +42,10 @@ export const useEmailTrackingStore = defineStore({
       type: '',
       start: '',
       end: '',
+      // Recipient cohort for the digest relevance-ranking experiment:
+      // '' = all, 'ranked' = users who get relevance ranking, 'holdout' = the
+      // 10% who always get the unranked order.
+      cohort: '',
     },
 
     // Current user ID or email being viewed.
@@ -224,6 +228,9 @@ export const useEmailTrackingStore = defineStore({
         }
         if (this.filters.end) {
           params.end = this.filters.end
+        }
+        if (this.filters.cohort) {
+          params.cohort = this.filters.cohort
         }
 
         const response = await api(

--- a/iznik-nuxt3/tests/unit/components/modtools/ModSysAdminDigestClicks.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModSysAdminDigestClicks.spec.js
@@ -210,6 +210,7 @@ describe('ModSysAdminDigestClicks', () => {
         type: 'UnifiedDigestDaily',
         start: '2026-01-01',
         end: '2026-01-31',
+        cohort: '',
       })
       expect(mockEmailTrackingStore.fetchDigestPositions).toHaveBeenCalled()
     })

--- a/iznik-server-go/emailtracking/emailtracking.go
+++ b/iznik-server-go/emailtracking/emailtracking.go
@@ -1678,6 +1678,18 @@ func DigestClickPositions(c *fiber.Ctx) error {
 		AND JSON_LENGTH(e.metadata, '$.post_msgids') > 0
 		AND e.sent_at BETWEEN ? AND ?`
 
+	// Optional recipient-cohort split for the digest relevance-ranking experiment:
+	//   cohort=holdout → the 10% who always get the unranked (arrival) order,
+	//   cohort=ranked  → everyone else (who get relevance ranking when enabled).
+	// Absent → all recipients (the default, pre-experiment behaviour). Same
+	// userid % 10 == 0 rule as DigestRelevanceService's holdout.
+	switch c.Query("cohort", "") {
+	case "holdout":
+		cohort += " AND e.userid IS NOT NULL AND e.userid % 10 = 0"
+	case "ranked":
+		cohort += " AND e.userid IS NOT NULL AND e.userid % 10 <> 0"
+	}
+
 	// 1. Denominator: distribution of digest sizes. A digest with `num_posts`
 	//    posts displayed positions 0..num_posts-1.
 	denomQuery := `

--- a/iznik-server-go/emailtracking/emailtracking.go
+++ b/iznik-server-go/emailtracking/emailtracking.go
@@ -1679,15 +1679,23 @@ func DigestClickPositions(c *fiber.Ctx) error {
 		AND e.sent_at BETWEEN ? AND ?`
 
 	// Optional recipient-cohort split for the digest relevance-ranking experiment:
-	//   cohort=holdout → the 10% who always get the unranked (arrival) order,
-	//   cohort=ranked  → everyone else (who get relevance ranking when enabled).
-	// Absent → all recipients (the default, pre-experiment behaviour). Same
-	// userid % 10 == 0 rule as DigestRelevanceService's holdout.
+	//   cohort=holdout → the 10% control, the same userid % 10 == 0 rule
+	//                    DigestRelevanceService uses to withhold ranking,
+	//   cohort=ranked  → digests the ranker actually reordered.
+	// Absent → all recipients (the default, pre-experiment behaviour).
+	//
+	// The ranked arm reads what was recorded (metadata.relevance_ranked, written
+	// by UnifiedDigest) rather than deriving membership from "not in the
+	// holdout". A rule-derived arm also sweeps in every member who had no
+	// interest signal, or any period when the flag was off: they received an
+	// identical unranked digest, so counting them drags the measured effect
+	// toward zero. Same approach as the recommendations funnel, which derives
+	// its arms from recorded impressions.
 	switch c.Query("cohort", "") {
 	case "holdout":
 		cohort += " AND e.userid IS NOT NULL AND e.userid % 10 = 0"
 	case "ranked":
-		cohort += " AND e.userid IS NOT NULL AND e.userid % 10 <> 0"
+		cohort += " AND e.userid IS NOT NULL AND JSON_EXTRACT(e.metadata, '$.relevance_ranked') = 1"
 	}
 
 	// 1. Denominator: distribution of digest sizes. A digest with `num_posts`

--- a/iznik-server-go/test/emailtracking_digestpositions_test.go
+++ b/iznik-server-go/test/emailtracking_digestpositions_test.go
@@ -264,6 +264,27 @@ func createDigestTrackingRecordForUser(t *testing.T, emailType string, sentAt ti
 	return id
 }
 
+// createSyntheticCohortUser inserts a minimal real users row at an explicit
+// id, so email_tracking.userid (FK'd to users.id since the 2026-07-21
+// schema-parity migration) can be set to that id without violating the
+// constraint. tnuserid is left NULL, so the row still passes the cohort
+// query's Trash Nothing exclusion like any other test user.
+func createSyntheticCohortUser(t *testing.T, id uint64) {
+	db := database.DBConn
+	settings := `{"mylocation": {"lat": 55.9533, "lng": -3.1883}}`
+	result := db.Exec("INSERT INTO users (id, firstname, lastname, fullname, systemrole, lastlocation, settings) "+
+		"VALUES (?, 'Synthetic', 'CohortUser', ?, 'User', NULL, ?)",
+		id, fmt.Sprintf("Synthetic Cohort User %d", id), settings)
+	if result.Error != nil {
+		t.Fatalf("ERROR: Failed to create synthetic cohort user %d: %v", id, result.Error)
+	}
+}
+
+func deleteSyntheticCohortUser(id uint64) {
+	db := database.DBConn
+	db.Exec("DELETE FROM users WHERE id = ?", id)
+}
+
 // TestDigestPositions_CohortSplit verifies the ranked/holdout cohort filter
 // (userid % 10) partitions the click data: a holdout recipient's clicks appear
 // only under cohort=holdout, a ranked recipient's only under cohort=ranked, and
@@ -276,11 +297,16 @@ func TestDigestPositions_CohortSplit(t *testing.T) {
 	now := time.Now()
 	etype := uniqueDigestType()
 
-	// Synthetic high userids with no matching users row (LEFT JOIN → tnuserid
-	// NULL → passes the cohort's tnuserid filter). 990000000 % 10 == 0 (holdout);
-	// 990000001 % 10 == 1 (ranked).
+	// Recipient users for the cohort split. email_tracking.userid FKs to
+	// users.id (added by the 2026-07-21 schema-parity migration), so these
+	// must be real rows rather than arbitrary high numbers. 990000000 % 10
+	// == 0 (holdout); 990000001 % 10 == 1 (ranked).
 	const holdoutUser = uint64(990000000)
 	const rankedUser = uint64(990000001)
+	createSyntheticCohortUser(t, holdoutUser)
+	createSyntheticCohortUser(t, rankedUser)
+	defer deleteSyntheticCohortUser(holdoutUser)
+	defer deleteSyntheticCohortUser(rankedUser)
 
 	// Holdout recipient: 2-post digest, clicks position 0.
 	idHold := createDigestTrackingRecordForUser(t, etype, now, 2, holdoutUser)

--- a/iznik-server-go/test/emailtracking_digestpositions_test.go
+++ b/iznik-server-go/test/emailtracking_digestpositions_test.go
@@ -285,10 +285,27 @@ func deleteSyntheticCohortUser(id uint64) {
 	db.Exec("DELETE FROM users WHERE id = ?", id)
 }
 
-// TestDigestPositions_CohortSplit verifies the ranked/holdout cohort filter
-// (userid % 10) partitions the click data: a holdout recipient's clicks appear
-// only under cohort=holdout, a ranked recipient's only under cohort=ranked, and
-// both under no cohort.
+// setRelevanceRanked stamps metadata.relevance_ranked on a digest tracking row,
+// as UnifiedDigest does when it records whether the ranker actually reordered
+// that recipient's digest.
+func setRelevanceRanked(t *testing.T, id uint64, ranked int) {
+	db := database.DBConn
+	result := db.Exec("UPDATE email_tracking SET metadata = JSON_SET(metadata, '$.relevance_ranked', ?) WHERE id = ?", ranked, id)
+	if result.Error != nil {
+		t.Fatalf("ERROR: Failed to set relevance_ranked on %d: %v", id, result.Error)
+	}
+}
+
+// TestDigestPositions_CohortSplit verifies the cohort filter partitions the
+// click data: a holdout recipient's clicks appear only under cohort=holdout, a
+// genuinely reranked recipient's only under cohort=ranked, and all of them under
+// no cohort.
+//
+// The ranked arm reads the recorded metadata.relevance_ranked rather than
+// "not in the holdout", so a recipient outside the holdout whose digest was
+// never reranked (no interest signal, or the flag off) must NOT count as ranked:
+// they received an identical unranked digest and would drag the measured effect
+// toward zero.
 func TestDigestPositions_CohortSplit(t *testing.T) {
 	prefix := uniquePrefix("dpcohort")
 	userID := CreateTestUser(t, prefix, "Support")
@@ -301,21 +318,33 @@ func TestDigestPositions_CohortSplit(t *testing.T) {
 	// users.id (added by the 2026-07-21 schema-parity migration), so these
 	// must be real rows rather than arbitrary high numbers. 990000000 % 10
 	// == 0 (holdout); 990000001 % 10 == 1 (ranked).
+	// 990000002 % 10 == 2, so it is outside the holdout, but its digest records
+	// relevance_ranked = 0: the ranker declined to rerank it.
 	const holdoutUser = uint64(990000000)
 	const rankedUser = uint64(990000001)
+	const unrankedUser = uint64(990000002)
 	createSyntheticCohortUser(t, holdoutUser)
 	createSyntheticCohortUser(t, rankedUser)
+	createSyntheticCohortUser(t, unrankedUser)
 	defer deleteSyntheticCohortUser(holdoutUser)
 	defer deleteSyntheticCohortUser(rankedUser)
+	defer deleteSyntheticCohortUser(unrankedUser)
 
-	// Holdout recipient: 2-post digest, clicks position 0.
-	idHold := createDigestTrackingRecordForUser(t, etype, now, 2, holdoutUser)
-	// Ranked recipient: 2-post digest, clicks position 1.
-	idRank := createDigestTrackingRecordForUser(t, etype, now, 2, rankedUser)
-	defer cleanupTestTrackingByID([]uint64{idHold, idRank})
+	// Holdout recipient: 3-post digest, clicks position 0.
+	idHold := createDigestTrackingRecordForUser(t, etype, now, 3, holdoutUser)
+	// Genuinely reranked recipient: 3-post digest, clicks position 1.
+	idRank := createDigestTrackingRecordForUser(t, etype, now, 3, rankedUser)
+	// Outside the holdout but never reranked: 3-post digest, clicks position 2.
+	idUnranked := createDigestTrackingRecordForUser(t, etype, now, 3, unrankedUser)
+	defer cleanupTestTrackingByID([]uint64{idHold, idRank, idUnranked})
+
+	setRelevanceRanked(t, idHold, 0)
+	setRelevanceRanked(t, idRank, 1)
+	setRelevanceRanked(t, idUnranked, 0)
 
 	createPositionClick(t, idHold, "post_0", now)
 	createPositionClick(t, idRank, "post_1", now)
+	createPositionClick(t, idUnranked, "post_2", now)
 
 	start := now.AddDate(0, 0, -1).Format("2006-01-02")
 	end := now.AddDate(0, 0, 1).Format("2006-01-02")
@@ -342,12 +371,16 @@ func TestDigestPositions_CohortSplit(t *testing.T) {
 	// Holdout cohort sees only the holdout recipient's position-0 click.
 	assert.Equal(t, float64(1), clicksAt("holdout", 0), "holdout: pos0 clicked")
 	assert.Equal(t, float64(0), clicksAt("holdout", 1), "holdout: pos1 not clicked (that was the ranked user)")
+	assert.Equal(t, float64(0), clicksAt("holdout", 2), "holdout: pos2 not clicked (that was the unranked user)")
 
-	// Ranked cohort sees only the ranked recipient's position-1 click.
+	// Ranked cohort sees only the genuinely reranked recipient's position-1 click.
 	assert.Equal(t, float64(0), clicksAt("ranked", 0), "ranked: pos0 not clicked (that was the holdout user)")
 	assert.Equal(t, float64(1), clicksAt("ranked", 1), "ranked: pos1 clicked")
+	assert.Equal(t, float64(0), clicksAt("ranked", 2),
+		"ranked: a recipient outside the holdout whose digest was never reranked must not dilute the arm")
 
-	// No cohort sees both.
+	// No cohort sees all three.
 	assert.Equal(t, float64(1), clicksAt("", 0), "all: pos0 clicked")
 	assert.Equal(t, float64(1), clicksAt("", 1), "all: pos1 clicked")
+	assert.Equal(t, float64(1), clicksAt("", 2), "all: pos2 clicked")
 }

--- a/iznik-server-go/test/emailtracking_digestpositions_test.go
+++ b/iznik-server-go/test/emailtracking_digestpositions_test.go
@@ -254,3 +254,74 @@ func TestDigestPositions_CumulativeShownAcrossSizes(t *testing.T) {
 	assert.Equal(t, float64(1), p3["emails_clicked"])
 	assert.InDelta(t, 100.0, p3["ctr"].(float64), 0.01)
 }
+
+// createDigestTrackingRecordForUser is like createDigestTrackingRecord but sets
+// the recipient userid, so cohort filtering (userid % 10) can be exercised.
+func createDigestTrackingRecordForUser(t *testing.T, emailType string, sentAt time.Time, numPosts int, userid uint64) uint64 {
+	db := database.DBConn
+	id := createDigestTrackingRecord(t, emailType, sentAt, numPosts)
+	db.Exec("UPDATE email_tracking SET userid = ? WHERE id = ?", userid, id)
+	return id
+}
+
+// TestDigestPositions_CohortSplit verifies the ranked/holdout cohort filter
+// (userid % 10) partitions the click data: a holdout recipient's clicks appear
+// only under cohort=holdout, a ranked recipient's only under cohort=ranked, and
+// both under no cohort.
+func TestDigestPositions_CohortSplit(t *testing.T) {
+	prefix := uniquePrefix("dpcohort")
+	userID := CreateTestUser(t, prefix, "Support")
+	_, token := CreateTestSession(t, userID)
+
+	now := time.Now()
+	etype := uniqueDigestType()
+
+	// Synthetic high userids with no matching users row (LEFT JOIN → tnuserid
+	// NULL → passes the cohort's tnuserid filter). 990000000 % 10 == 0 (holdout);
+	// 990000001 % 10 == 1 (ranked).
+	const holdoutUser = uint64(990000000)
+	const rankedUser = uint64(990000001)
+
+	// Holdout recipient: 2-post digest, clicks position 0.
+	idHold := createDigestTrackingRecordForUser(t, etype, now, 2, holdoutUser)
+	// Ranked recipient: 2-post digest, clicks position 1.
+	idRank := createDigestTrackingRecordForUser(t, etype, now, 2, rankedUser)
+	defer cleanupTestTrackingByID([]uint64{idHold, idRank})
+
+	createPositionClick(t, idHold, "post_0", now)
+	createPositionClick(t, idRank, "post_1", now)
+
+	start := now.AddDate(0, 0, -1).Format("2006-01-02")
+	end := now.AddDate(0, 0, 1).Format("2006-01-02")
+	base := "/api/modtools/email/stats/digestpositions?jwt=" + token + "&type=" + etype + "&start=" + start + "&end=" + end
+
+	// clicksAt returns emails_clicked at a given position for a cohort query.
+	clicksAt := func(cohort string, pos int) float64 {
+		url := base
+		if cohort != "" {
+			url += "&cohort=" + cohort
+		}
+		resp, _ := getApp().Test(httptest.NewRequest("GET", url, nil))
+		assert.Equal(t, 200, resp.StatusCode)
+		var result map[string]interface{}
+		json2.Unmarshal(rsp(resp), &result)
+		data, _ := result["data"].([]interface{})
+		if pos >= len(data) {
+			return 0
+		}
+		p := data[pos].(map[string]interface{})
+		return p["emails_clicked"].(float64)
+	}
+
+	// Holdout cohort sees only the holdout recipient's position-0 click.
+	assert.Equal(t, float64(1), clicksAt("holdout", 0), "holdout: pos0 clicked")
+	assert.Equal(t, float64(0), clicksAt("holdout", 1), "holdout: pos1 not clicked (that was the ranked user)")
+
+	// Ranked cohort sees only the ranked recipient's position-1 click.
+	assert.Equal(t, float64(0), clicksAt("ranked", 0), "ranked: pos0 not clicked (that was the holdout user)")
+	assert.Equal(t, float64(1), clicksAt("ranked", 1), "ranked: pos1 clicked")
+
+	// No cohort sees both.
+	assert.Equal(t, float64(1), clicksAt("", 0), "all: pos0 clicked")
+	assert.Equal(t, float64(1), clicksAt("", 1), "all: pos1 clicked")
+}

--- a/plans/active/2026-07-04-vector-search-rollout.md
+++ b/plans/active/2026-07-04-vector-search-rollout.md
@@ -431,7 +431,7 @@ Outcome (per Edward 2026-07-04): similarity-to-previous-items becomes part of th
 
 ### Task 4.5: Retire the V1 Relevant email
 
-- [ ] Delete `iznik-server/scripts/cron/relevant.php`; add a header comment to `iznik-server/include/mail/Relevant.php`: "RETIRED 2026-07 — replaced by digest relevance ranking (iznik-batch DigestRelevanceService); do not resurrect" (class deletion happens with the rest of V1; the cron file is what runs). Update `iznik-batch/MIGRATION-STATUS.md` (~line 318): "Relevant message matching" → Retired, folded into digest relevance ranking, with date. **PR body must flag: the LIVE crontab entry for relevant.php (not tracked in-repo) needs removing at deploy time — action for Edward.**
+- [ ] Delete `iznik-server/scripts/cron/relevant.php`; add a header comment to `iznik-server/include/mail/Relevant.php`: "RETIRED 2026-07 — replaced by digest relevance ranking (iznik-batch DigestRelevanceService); do not resurrect" (class deletion happens with the rest of V1). Update `iznik-batch/MIGRATION-STATUS.md` (~line 318): "Relevant message matching" → Retired, folded into digest relevance ranking, with date. (V1 no longer runs in production, so this is dead-code cleanup — no live crontab entry exists and no deploy action is needed.)
 - [ ] Full Laravel + Go + vitest suites green. Code review. Push. PR `feat: digest relevance ranking (flagged) + retire V1 relevant email`.
 
 ---
@@ -500,7 +500,7 @@ The hybrid keyword leg (GetWordsExact/Starts) currently guarantees literal match
 
 - [ ] Repo-wide sweep: `grep -rn --include='*.php' --include='*.go' --include='*.js' --include='*.vue' -i "messages_index\|items_index\|words_cache\|search_terms\|GetWordsTypo\|GetWordsSounds\|ExpandQuery\|SOUNDEX" iznik-server iznik-server-go iznik-batch iznik-nuxt3` — every remaining hit must be: kept-by-design (damlevlim email domains; search_history stats) or removed. Document the survivors list in the PR body.
 - [ ] `migration-parity-audit` skill mindset check (manual): for each deleted execution path, name its replacement (cascade→vector+lexical tier; index maintenance→embeddings:generate; Relevant→mail:relevant; typeahead→none, orphaned; SearchTerm challenge→none, purpose obsolete).
-- [ ] Full suites green; code review; push; PR `feat!: retire legacy keyword search` with body: merge-order requirement (after Phase 1 + Phase 4), the dropped-tables list, the keep-list with reasons, prod deploy notes (run the `*_migration.sql`; remove relevant.php crontab line if still present; `embedding-sidecar` is already a standing prod service).
+- [ ] Full suites green; code review; push; PR `feat!: retire legacy keyword search` with body: merge-order requirement (after Phase 1 + Phase 4), the dropped-tables list, the keep-list with reasons, prod deploy notes (run the `*_migration.sql`; `embedding-sidecar` is already a standing prod service).
 
 ---
 


### PR DESCRIPTION
Merge after #947 — this branch is based on it so its CI carries the srvx package-lock fix. It is otherwise independent of the similar-posts and wanted-match work.

## What this does

Personal relevance becomes a sort-ranking signal inside the existing daily digest rather than a separate email, covering the job of the standalone V1 "Relevant" mail.

**`DigestRelevanceService`** ranks a member's daily-digest posts by vector similarity to what they care about: the subject embeddings of their own posts from the last `OWN_POST_DAYS` (60) days and the posts they viewed in the last `VIEW_DAYS` (30), newest first and capped at `MAX_INTERESTS` (40) vectors. A post scores its best cosine against any interest vector. It reuses the same `nomic-embed-text-v1.5` 256-dim embeddings as search, decoded in PHP with `unpack('g')` against the Go writer's little-endian encoding.

**`UnifiedDigestService::sendDigestToUser`** calls `rank()` after scoring and distance filtering, and before dedup — so the ranked order decides which post dedup keeps as the representative, and what `metadata.post_msgids` records. That is the field the digest click-by-position dashboard reads, so measurement needs no new tracking.

### What ranking deliberately leaves alone

The digest already makes three ordering promises that relevance must not quietly undo.

- **The two-nearest pin.** `pinClosestTwo` puts the two closest posts at the top to answer "I keep seeing posts far away", choosing only among posts the recipient has not already seen. It marks those posts `_pinned`, and `rank()` holds them at the front and reorders only the tail.
- **The seen-post sink.** Already-seen posts are demoted by `seen_penalty`. A post the member viewed within `VIEW_DAYS` is also one of their interest vectors, so it would self-match at cosine 1.0 and retake the top slot. `rank()` passes the digest's own msgids to `interests()`, which excludes them, so no post is its own interest vector.
- **Which posts appear at all.** `UnifiedDigest` truncates the prepared list at `DigestStyle::DIGEST_POST_CAP` (65), so in a longer digest the order decides what is shown, not merely where. A post with no embedding is therefore treated as unknown relevance rather than low relevance: it holds its position while the embedded posts are permuted among the slots they already occupied. Sinking it would delete it from a long digest for want of an embedding — content loss driven by pipeline coverage, falling hardest on the newest posts.

### Flag, holdout and measurement

Gated on `FEATURE_DIGEST_RELEVANCE`, default off, since it changes email ordering. A 10% holdout (`userid % 10 == 0`) always keeps the arrival order as a control. With the flag off, in the holdout, or with no interest signal, `rank()` returns its input unchanged and the digest is byte-identical to the unranked one.

`rank()` reports through `didRank()` whether it actually reordered, and `UnifiedDigest` records that as `metadata.relevance_ranked`. The dashboard's ranked arm filters on that recorded value rather than on "not in the holdout", which would also sweep in every member who had no interest signal: they received an identical unranked digest and would drag the measured effect toward zero. This mirrors the recommendations funnel, which derives its arms from recorded impressions. `ModSysAdminDigestClicks` and the Go `emailtracking` digest-positions endpoint take the resulting `cohort=ranked|holdout` filter.

### Send cost

`interests()` runs once per recipient. It filters `messages_likes` on `userid`, `type` and `timestamp`, which the existing indexes cannot serve efficiently — `messages_likes_source_ts_user` leads on `source`, which this query does not constrain — so MySQL reads every like row a member has ever had to keep a few dozen. A `messages_likes (userid, type, timestamp)` index lets it stop early. `messages_likes` is ~75M rows and hot and production is Galera under TOI, so the migration ships with a guarded companion `_migration.sql`, matching how the other `messages_likes` index is deployed, for node-by-node application under RSU.

Decoded embeddings are also memoised across recipients for the life of a run, since neighbouring members see largely the same posts, with misses cached so an unembedded post is not re-queried per recipient. The memo is bounded and flushed at the start of each run.

### V1 "Relevant" email

The V1 tree, including `scripts/cron/relevant.php` (the "Any of these take your fancy?" mail) and `include/mail/Relevant.php`, is already gone from master, so there is no code here to remove. `MIGRATION-STATUS.md` marks that job retired and records where its purpose is served instead, which closes the last non-search dependency on the `messages_index` keyword index that Phase 5 of the rollout retires. No deploy action.

## Decision criterion

After four weeks with `FEATURE_DIGEST_RELEVANCE` on: keep the ranking if the ranked cohort's overall digest CTR is at least the holdout's, the expected signature being a steeper position curve with clicks concentrated at the top.

## Tests

- `DigestRelevanceServiceTest` covers the Go↔PHP embedding blob round-trip; ordering by relevance; each path that must leave the order untouched (flag off, holdout member, no interest signal); the pin surviving ranking; an already-viewed post not self-matching to the top; an unembedded post holding its position; `didRank()` reporting; and the cross-recipient embedding memo.
- `TestDigestPositions_CohortSplit` covers the cohort partition, including that a recipient outside the holdout whose digest was never reranked stays out of the ranked arm.
- The ModTools digest-clicks spec covers the `cohort` filter parameter.

## Rollback

The feature is off by default and does nothing without `FEATURE_DIGEST_RELEVANCE`. The index is additive and separately reversible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZo5x38csZdz3vHGgERZfi

