### PR TITLE
chore(batch-prod): graceful stop_grace_period so restarts resume cleanly

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1630,6 +1630,13 @@ services:
     container_name: ${COMPOSE_PROJECT_NAME:-freegle}-batch-prod
     profiles:
       - production
+    # Give the scheduler + daemons (schedule:work, mail:spool:process, ripple, digest
+    # shards) time to reach a safe stopping point on SIGTERM before Docker SIGKILLs them.
+    # The default is only 10s, too short for an in-flight email send / digest sweep to
+    # finish cleanly; a graceful shutdown was measured at ~9s, so 60s is generous headroom.
+    # This makes a plain `docker restart` / `docker compose restart` graceful without a
+    # manual -t flag (applied to the container's StopTimeout on next recreate).
+    stop_grace_period: 60s
     networks:
       - default
     build:


### PR DESCRIPTION
## Why

`batch-prod` runs the Laravel scheduler + long-lived daemons (`schedule:work`, `mail:spool:process --daemon`) plus scheduled digest/ripple sweeps. Docker's **default stop grace is 10s** — too short for an in-flight SMTP send or a digest sweep to reach a safe stopping point, so a plain `docker restart` risks a mid-work SIGKILL (stranded `spool/mail/sending/` entries, orphaned Redis locks).

Today's digest-window restart needed a manual `docker restart -t 45` to be safe. This makes that the default.

## Change

`stop_grace_period: 60s` on the `batch-prod` service. A measured graceful shutdown took **~9s**, so 60s is generous headroom. Now `docker restart` / `docker compose restart` are graceful with no manual `-t` flag.

## Notes

- Takes effect on the next **recreate** (`up -d` / rebuild) of batch-prod — it sets the container's `StopTimeout` at create time. The currently-running container (plain-restarted today) keeps the old 10s until then; use `-t 45` in the meantime.
- `docker compose config` validates; renders as `batch-prod: stop_grace_period: 1m0s`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)