### PR TITLE
perf(markseen): batch "mark seen" inserts (Galera-safe) so it stops scaling per post

### DIFF
--- a/iznik-server-go/message/markseen.go
+++ b/iznik-server-go/message/markseen.go
@@ -1,11 +1,27 @@
 package message
 
 import (
+	"sort"
+	"strings"
+
 	"github.com/freegle/iznik-server-go/database"
-	"github.com/freegle/iznik-server-go/utils"
 	"github.com/freegle/iznik-server-go/user"
+	"github.com/freegle/iznik-server-go/utils"
 	"github.com/gofiber/fiber/v2"
+	"gorm.io/gorm"
 )
+
+// markSeenChunk bounds how many message ids go into a single INSERT statement. "Mark seen" on a
+// busy browse feed can pass hundreds of ids; one INSERT per id (the old behaviour) meant one DB
+// round-trip per unread post, so the call scaled linearly with the unread count and felt slow.
+// Batching into multi-row INSERTs collapses that to a handful of round-trips.
+//
+// The chunk is kept moderate rather than "all in one" deliberately for Galera (Percona XtraDB
+// Cluster): a multi-row INSERT is a single transaction, so a certification conflict rolls the
+// WHOLE statement back. A moderate chunk bounds that blast radius and the lock footprint while
+// still cutting round-trips ~100x for a typical feed. It also stays well under max_allowed_packet
+// and the placeholder limit.
+const markSeenChunk = 100
 
 // MarkSeenRequest is the request body for marking messages as seen.
 type MarkSeenRequest struct {
@@ -41,18 +57,81 @@ func MarkSeen(c *fiber.Ctx) error {
 
 	db := database.DBConn
 
-	// Insert a 'View' record (marks the message "seen" for list de-duplication).
+	// Sort + de-duplicate the ids. De-dup guards against a caller repeating an id (which would
+	// otherwise appear twice in one multi-row INSERT and hit the ON DUPLICATE KEY UPDATE against
+	// its own earlier row within the same statement). Sorting makes every mark-seen acquire row
+	// locks in a consistent (ascending) order, so two concurrent same-user mark-seens can't
+	// deadlock by grabbing the same rows in opposite orders.
+	ids := dedupeSortedIDs(req.IDs)
+
+	// Insert a 'View' record per message (marks it "seen" for list de-duplication).
 	// pageview=0 marks this as a list-scroll impression, distinct from a genuine
 	// page-open (handleView writes 1). It is set only when this INSERT *creates* the
 	// row; the ON DUPLICATE KEY UPDATE deliberately does NOT touch pageview, so an
 	// existing genuine view (1) or legacy/unknown row (NULL) is never downgraded.
-	for _, msgID := range req.IDs {
-		db.Exec("INSERT INTO messages_likes (msgid, userid, type, pageview) VALUES (?, ?, ?, 0) "+
-			"ON DUPLICATE KEY UPDATE timestamp = NOW(), count = count + 1",
-			msgID, myid, utils.MESSAGE_LIKES_VIEW)
+	//
+	// The rows are batched into multi-row INSERTs (markSeenChunk at a time) rather than one
+	// statement per id, so marking a large unread feed as seen is a few round-trips instead of
+	// one per post. The ON DUPLICATE KEY UPDATE clause is per-conflicting-row, so batching
+	// preserves the exact per-message semantics of the old loop.
+	for start := 0; start < len(ids); start += markSeenChunk {
+		end := start + markSeenChunk
+		if end > len(ids) {
+			end = len(ids)
+		}
+		chunk := ids[start:end]
+
+		// RetryExec retries transient connection/WSREP errors (Galera node not yet synced). It
+		// does NOT retry deadlocks/lock-timeouts - a Galera certification conflict rolls the whole
+		// multi-row statement back. If that happens we fall back to per-row inserts for this chunk
+		// so the rest still land: each is its own tiny autocommit transaction that certifies
+		// independently (exactly the old behaviour), degrading gracefully instead of losing the
+		// whole chunk. In practice this is rare: mark-seen rows are keyed (msgid, userid, type),
+		// so different users never conflict; only concurrent same-user mark-seens can.
+		if err := insertViewBatch(db, chunk, myid); err != nil && database.IsDeadlockOrLockTimeout(err) {
+			for _, msgID := range chunk {
+				_ = database.RetryExec(db,
+					"INSERT INTO messages_likes (msgid, userid, type, pageview) VALUES (?, ?, ?, 0) "+
+						"ON DUPLICATE KEY UPDATE timestamp = NOW(), count = count + 1",
+					msgID, myid, utils.MESSAGE_LIKES_VIEW)
+			}
+		}
 	}
 
 	return c.JSON(fiber.Map{
 		"success": true,
 	})
+}
+
+// insertViewBatch inserts (or bumps) a 'View' row for every msgid in the chunk in a single
+// multi-row INSERT ... ON DUPLICATE KEY UPDATE, retrying transient connection/WSREP errors.
+func insertViewBatch(db *gorm.DB, chunk []uint64, myid uint64) error {
+	placeholders := make([]string, len(chunk))
+	args := make([]interface{}, 0, len(chunk)*3)
+	for i, msgID := range chunk {
+		placeholders[i] = "(?, ?, ?, 0)"
+		args = append(args, msgID, myid, utils.MESSAGE_LIKES_VIEW)
+	}
+	return database.RetryExec(db,
+		"INSERT INTO messages_likes (msgid, userid, type, pageview) VALUES "+
+			strings.Join(placeholders, ",")+
+			" ON DUPLICATE KEY UPDATE timestamp = NOW(), count = count + 1",
+		args...)
+}
+
+// dedupeSortedIDs returns the ids sorted ascending with duplicates removed.
+func dedupeSortedIDs(in []uint64) []uint64 {
+	if len(in) < 2 {
+		return in
+	}
+	sorted := make([]uint64, len(in))
+	copy(sorted, in)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+	out := sorted[:1]
+	for _, v := range sorted[1:] {
+		if v != out[len(out)-1] {
+			out = append(out, v)
+		}
+	}
+	return out
 }

--- a/iznik-server-go/message/markseen_pure_test.go
+++ b/iznik-server-go/message/markseen_pure_test.go
@@ -1,0 +1,48 @@
+package message
+
+import (
+	"reflect"
+	"testing"
+)
+
+// dedupeSortedIDs backs the batched "mark seen": it must sort ascending (so concurrent same-user
+// mark-seens lock rows in a consistent order and can't deadlock) and drop duplicates (so a repeated
+// id doesn't appear twice in one multi-row INSERT).
+func TestDedupeSortedIDs(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []uint64
+		want []uint64
+	}{
+		{"empty", []uint64{}, []uint64{}},
+		{"single", []uint64{5}, []uint64{5}},
+		{"already sorted, distinct", []uint64{1, 2, 3}, []uint64{1, 2, 3}},
+		{"unsorted", []uint64{3, 1, 2}, []uint64{1, 2, 3}},
+		{"duplicates", []uint64{2, 1, 2, 3, 1}, []uint64{1, 2, 3}},
+		{"all same", []uint64{7, 7, 7}, []uint64{7}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := dedupeSortedIDs(tc.in)
+			// Compare as sorted-distinct slices; empty vs single are returned as-is by the fast path.
+			if len(tc.in) < 2 {
+				if !reflect.DeepEqual(got, tc.in) {
+					t.Fatalf("small input passthrough: got %v, want %v", got, tc.in)
+				}
+				return
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("dedupeSortedIDs(%v) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// The input slice must not be mutated (it is the request body's IDs, which the caller may still use).
+func TestDedupeSortedIDsDoesNotMutateInput(t *testing.T) {
+	in := []uint64{3, 1, 2, 1}
+	_ = dedupeSortedIDs(in)
+	if !reflect.DeepEqual(in, []uint64{3, 1, 2, 1}) {
+		t.Fatalf("input was mutated: %v", in)
+	}
+}

--- a/iznik-server-go/test/message_test.go
+++ b/iznik-server-go/test/message_test.go
@@ -5868,6 +5868,80 @@ func TestMessagesMarkSeenIdempotent(t *testing.T) {
 	assert.Equal(t, 200, resp.StatusCode)
 }
 
+// TestMessagesMarkSeenBatchPreservesSemantics marks MANY messages in a single call (the batched
+// multi-row INSERT path that replaced the per-id loop) and verifies the per-message semantics are
+// unchanged: every message ends up with a View row (seen), a brand-new one gets pageview=0 (a
+// scroll impression), and a message that already has a genuine page-open (pageview=1) keeps
+// pageview=1 and has its count incremented - i.e. batching never downgrades an existing view.
+func TestMessagesMarkSeenBatchPreservesSemantics(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("markseen_batch")
+	groupID := CreateTestGroup(t, prefix)
+
+	ownerID := CreateTestUser(t, prefix+"_owner", "User")
+	CreateTestMembership(t, ownerID, groupID, "Member")
+	viewerID := CreateTestUser(t, prefix+"_viewer", "User")
+	CreateTestMembership(t, viewerID, groupID, "Member")
+	_, viewerToken := CreateTestSession(t, viewerID)
+
+	// A batch of messages (enough to exercise the multi-row INSERT).
+	const n = 12
+	ids := make([]uint64, n)
+	for i := 0; i < n; i++ {
+		ids[i] = CreateTestMessage(t, ownerID, groupID, fmt.Sprintf("%s item %d", prefix, i), 55.9533, -3.1883)
+	}
+
+	// Give the FIRST message a genuine page-open first (pageview=1), so we can prove the batch
+	// mark-seen does not downgrade it.
+	openBody, _ := json.Marshal(map[string]interface{}{"id": ids[0], "action": "View"})
+	openReq := httptest.NewRequest("POST", "/api/message?jwt="+viewerToken, bytes.NewBuffer(openBody))
+	openReq.Header.Set("Content-Type", "application/json")
+	openResp, _ := getApp().Test(openReq)
+	assert.Equal(t, 200, openResp.StatusCode)
+
+	var pvBefore, countBefore int
+	db.Raw("SELECT COALESCE(pageview, -1), count FROM messages_likes WHERE msgid = ? AND userid = ? AND type = 'View'",
+		ids[0], viewerID).Row().Scan(&pvBefore, &countBefore)
+	assert.Equal(t, 1, pvBefore, "page-open should set pageview=1 before the batch mark-seen")
+
+	// Mark ALL of them seen in one batched call.
+	idParts := make([]string, n)
+	for i, id := range ids {
+		idParts[i] = fmt.Sprint(id)
+	}
+	body := fmt.Sprintf(`{"ids": [%s]}`, strings.Join(idParts, ","))
+	req := httptest.NewRequest("POST", "/api/messages/markseen?jwt="+viewerToken, bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	// Every message now has a View row.
+	var seenCount int
+	placeholders := make([]string, n)
+	args := make([]interface{}, 0, n+2)
+	for i, id := range ids {
+		placeholders[i] = "?"
+		args = append(args, id)
+	}
+	args = append(args, viewerID)
+	db.Raw("SELECT COUNT(*) FROM messages_likes WHERE msgid IN ("+strings.Join(placeholders, ",")+
+		") AND userid = ? AND type = 'View'", args...).Scan(&seenCount)
+	assert.Equal(t, n, seenCount, "every message in the batch has a View row")
+
+	// A brand-new message (ids[1]) got pageview=0 (scroll impression).
+	var pvNew int
+	db.Raw("SELECT COALESCE(pageview, -1) FROM messages_likes WHERE msgid = ? AND userid = ? AND type = 'View'",
+		ids[1], viewerID).Scan(&pvNew)
+	assert.Equal(t, 0, pvNew, "a newly-seen message gets pageview=0")
+
+	// The pre-opened message (ids[0]) keeps pageview=1 (NOT downgraded) and its count incremented.
+	var pvAfter, countAfter int
+	db.Raw("SELECT COALESCE(pageview, -1), count FROM messages_likes WHERE msgid = ? AND userid = ? AND type = 'View'",
+		ids[0], viewerID).Row().Scan(&pvAfter, &countAfter)
+	assert.Equal(t, 1, pvAfter, "batch mark-seen must not downgrade an existing genuine view")
+	assert.Greater(t, countAfter, countBefore, "the ON DUPLICATE KEY UPDATE increments count on the existing row")
+}
+
 // --- Tests: Subject reconstruction from item + location ---
 
 func TestPatchMessageReconstructsSubjectFromItemLocation(t *testing.T) {


### PR DESCRIPTION
## Summary

"Mark seen" on Browse scaled linearly with the number of unread posts: the `/messages/markseen`
handler ran **one `INSERT ... ON DUPLICATE KEY UPDATE` per message id**, so a feed with many unread
meant one DB round-trip per post and felt slow. The frontend already sends all ids in a single
request; the cost was entirely server-side.

This batches the inserts into multi-row statements, cutting a mark-seen of N posts from N round-trips
to ~`ceil(N/100)`. Per-message semantics are unchanged (the `ON DUPLICATE KEY UPDATE` clause applies
per conflicting row).

## Galera safety

A multi-row INSERT is a single transaction, so on Percona XtraDB Cluster a certification conflict
rolls back the whole statement — unlike the old per-row loop where a conflict lost only one row.
The change is designed around that:

- **Moderate chunk (100)** bounds the rollback blast radius and lock footprint (vs. "all in one"),
  while still cutting round-trips ~100×.
- **Sort + de-dupe the ids** so concurrent same-user mark-seens acquire row locks in a consistent
  ascending order (can't deadlock by grabbing the same rows in opposite orders), and a repeated id
  can't collide with itself inside one statement.
- **`database.RetryExec`** retries transient connection/WSREP errors (Galera node not yet synced).
- **Per-row fallback on deadlock/lock-timeout:** if a chunk hits a certification conflict, it falls
  back to per-row inserts for that chunk — each its own tiny autocommit transaction that certifies
  independently (exactly the old behaviour), so the rest still land instead of the whole chunk being
  lost. In practice this is rare: rows are keyed `(msgid, userid, type)`, so different users never
  conflict; only concurrent same-user mark-seens can.

## Code Quality Review

- No behaviour change for the common case; pure latency win.
- Reuses the existing two-layer retry helpers (`RetryExec` / `IsDeadlockOrLockTimeout`) rather than
  inventing new error handling.
- `dedupeSortedIDs` does not mutate the caller's slice.

## Future Improvements

The deeper fix (separate, larger design) is to make "Mark seen" O(1) by recording a per-user,
per-view **high-water mark** and moving the per-item `View` writes (needed anyway for view-counts,
dedup and the rippling underexposure score) to the `background_tasks` queue — decoupling
user-perceived latency from write volume entirely. Tracked as a follow-up.

## Test Plan

- `message.TestDedupeSortedIDs` / `TestDedupeSortedIDsDoesNotMutateInput` — sort/dedupe/no-mutate (pure).
- `TestMessagesMarkSeenBatchPreservesSemantics` — marks 12 messages in one batched call and asserts:
  every message gets a `View` row; a brand-new one gets `pageview=0`; a message with a prior genuine
  page-open keeps `pageview=1` (not downgraded) and has its `count` incremented — i.e. batching
  preserves the exact per-message semantics.
- Existing markseen tests (single, idempotent, empty, unauthorized, non-existent ids) still pass.
- Full Go suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ZeG2zmg2JCR8pYEjAUaAk
