### PR TITLE
fix(upload): downscale photos client-side to cut the upload-stage drop-off

### DIFF
--- a/iznik-nuxt3/components/OurUploader.vue
+++ b/iznik-nuxt3/components/OurUploader.vue
@@ -408,7 +408,12 @@ onMounted(() => {
       uploadDataDuringCreation: true,
       retryDelays: [0, 3000, 5000, 10000, 20000],
     })
-    .use(Compressor)
+    // Downscale, not just quality-compress. The plugin default is quality-only, so
+    // 12MP phone photos stayed full-resolution and multi-MB. Upload telemetry (Loki,
+    // 2026-07) showed size-driven loss: ~13% of selected photos abandoned during the
+    // client-side compress-then-start step, ~40% of upload sessions running >30s on
+    // mobile. A 1600px cap keeps listing photos crisp while cutting upload size ~5-10x.
+    .use(Compressor, { quality: 0.8, maxWidth: 1600, maxHeight: 1600 })
   uppy.on('file-added', (file) => {
     console.log('Added file', file)
     // Ships to Loki (event_type=action) so we can distinguish "opened the picker but

--- a/iznik-nuxt3/components/PhotoUploader.vue
+++ b/iznik-nuxt3/components/PhotoUploader.vue
@@ -733,7 +733,10 @@ onMounted(() => {
       endpoint: runtimeConfig.public.TUS_UPLOADER,
       uploadDataDuringCreation: true,
     })
-    .use(Compressor)
+    // Downscale, not just quality-compress (plugin default is quality-only), so 12MP
+    // phone photos don't upload at full resolution — the size-driven upload drop-off
+    // seen in Loki telemetry. 1600px cap keeps listing photos crisp; ~5-10x smaller.
+    .use(Compressor, { quality: 0.8, maxWidth: 1600, maxHeight: 1600 })
 
   uppy.value.on('complete', handleUppySuccess)
   const scheduleRetry = createRetryCoalescer(() => uppy.value)


### PR DESCRIPTION
## What the telemetry showed

The upload lifecycle logging added in 938186f4 (shipping Uppy events to Loki) let me measure the photo-upload drop-off directly (24h):

| stage | count |
|---|---|
| photo **selected** | 87 |
| upload **started** | 76 |
| upload **succeeded** | 76 |
| stalled / rejected | **0** |
| failed | 8 (mostly retries of ~3 files — one Android user's file retried 5×) |
| modal open >30s | 35 (~40%) |

**The upload path itself isn't the problem** — once an upload starts it succeeds ~100%. The loss is **size-driven**:
- **~13%** of *selected* photos (11/87) are abandoned in the client-side **compress-then-start** window (Compressor runs between file-added and the upload firing; slow on mobile).
- **~40%** of upload sessions run the modal open **>30s** (large photos on mobile).

Selected photo sizes: p50 **3.2MB**, p90 **4.9MB**, max 8.2MB.

## Root cause

`@uppy/compressor` was already in use — but as `.use(Compressor)` with **default options**, which is **quality-only compression with no dimension limit**. So a 4000×3000 phone photo stayed full-resolution.

## Fix

Pass `maxWidth`/`maxHeight` (1600) + `quality` 0.8 to Compressor in **both** uploaders (`OurUploader.vue`, `PhotoUploader.vue`). compressorjs downscales to fit, preserving aspect ratio. Listing photos are displayed far smaller than 1600px so they stay crisp, while upload size drops ~5–10×, shrinking both the >30s slow tail and the select→start abandonment window.

`quality`/dimension values are easy to tune in review if you'd prefer a different target.

## Not run locally
Frontend change; CI runs vitest/build. The 1600px cap is a standard, safe size for reuse-listing photos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)