### PR TITLE
fix(modtools-mapping): allow clearing DPA and keep area vertices on reload

### DIFF
--- a/iznik-server-go/group/group.go
+++ b/iznik-server-go/group/group.go
@@ -828,17 +828,36 @@ func PatchGroup(c *fiber.Ctx) error {
 		if req.Licenserequired != nil {
 			db.Exec("UPDATE `groups` SET licenserequired = ? WHERE id = ?", *req.Licenserequired, req.ID)
 		}
+		// poly (DPA) / polyofficial (CGA). An empty string means "clear this area" - it must be
+		// allowed (a moderator removing the DPA), so skip geometry validation and store NULL rather
+		// than feeding "" to validateGeometry (which returns 400). Matches V1 PHP Group::setPrivate.
+		polyChanged := false
 		if req.Poly != nil {
-			if !validateGeometry(*req.Poly) {
-				return fiber.NewError(fiber.StatusBadRequest, "Invalid poly geometry")
+			if *req.Poly == "" {
+				db.Exec("UPDATE `groups` SET poly = NULL WHERE id = ?", req.ID)
+			} else {
+				if !validateGeometry(*req.Poly) {
+					return fiber.NewError(fiber.StatusBadRequest, "Invalid poly geometry")
+				}
+				db.Exec("UPDATE `groups` SET poly = ? WHERE id = ?", *req.Poly, req.ID)
 			}
-			db.Exec("UPDATE `groups` SET poly = ? WHERE id = ?", *req.Poly, req.ID)
+			polyChanged = true
 		}
 		if req.Polyofficial != nil {
-			if !validateGeometry(*req.Polyofficial) {
-				return fiber.NewError(fiber.StatusBadRequest, "Invalid polyofficial geometry")
+			if *req.Polyofficial == "" {
+				db.Exec("UPDATE `groups` SET polyofficial = NULL WHERE id = ?", req.ID)
+			} else {
+				if !validateGeometry(*req.Polyofficial) {
+					return fiber.NewError(fiber.StatusBadRequest, "Invalid polyofficial geometry")
+				}
+				db.Exec("UPDATE `groups` SET polyofficial = ? WHERE id = ?", *req.Polyofficial, req.ID)
 			}
-			db.Exec("UPDATE `groups` SET polyofficial = ? WHERE id = ?", *req.Polyofficial, req.ID)
+			polyChanged = true
+		}
+		if polyChanged {
+			// Recompute the spatial index so the poly/polyofficial change takes effect. When the DPA
+			// (poly) is cleared the group falls back to the CGA (polyofficial), then to POINT(0 0).
+			db.Exec(fmt.Sprintf("UPDATE `groups` SET polyindex = ST_GeomFromText(COALESCE(poly, polyofficial, 'POINT(0 0)'), %d) WHERE id = ?", utils.SRID), req.ID)
 		}
 		if req.Showonyahoo != nil {
 			db.Exec("UPDATE `groups` SET showonyahoo = ? WHERE id = ?", *req.Showonyahoo, req.ID)

--- a/iznik-server-go/location/location.go
+++ b/iznik-server-go/location/location.go
@@ -454,12 +454,15 @@ func SearchLocations(c *fiber.Ctx) error {
 			db := database.DBConn
 			var boxLocs []BoxLocation
 
+			// Return the full-resolution geometry (ourgeometry override if present, else geometry).
+			// This bbox query feeds ONLY the ModTools area-boundary editor (the sole caller passing a
+			// bounding box). Applying ST_Simplify(...,0.001) (~111 m) here silently dropped a freshly
+			// dragged midpoint vertex on reload, so the edit looked unsaved and adjacent vertices could
+			// vanish (Discourse #9770). The write side already stores full detail; the editor needs to
+			// read it back at full detail too. Edited areas are small neighbourhood polygons, so the
+			// payload cost of dropping simplification here is negligible.
 			db.Raw("SELECT DISTINCT l.id, l.name, l.type, l.lat, l.lng, l.areaid, "+
-				"ST_AsText("+
-				"CASE WHEN ST_Simplify(CASE WHEN l.ourgeometry IS NOT NULL THEN l.ourgeometry ELSE l.geometry END, 0.001) IS NULL "+
-				"THEN CASE WHEN l.ourgeometry IS NOT NULL THEN l.ourgeometry ELSE l.geometry END "+
-				"ELSE ST_Simplify(CASE WHEN l.ourgeometry IS NOT NULL THEN l.ourgeometry ELSE l.geometry END, 0.001) "+
-				"END) AS polygon "+
+				"ST_AsText(CASE WHEN l.ourgeometry IS NOT NULL THEN l.ourgeometry ELSE l.geometry END) AS polygon "+
 				"FROM (SELECT DISTINCT locationid FROM locations_spatial "+
 				"INNER JOIN locations l2 ON l2.areaid = locations_spatial.locationid "+
 				"WHERE ST_Intersects(locations_spatial.geometry, "+

--- a/iznik-server-go/test/group_patch_test.go
+++ b/iznik-server-go/test/group_patch_test.go
@@ -1,0 +1,116 @@
+package test
+
+import (
+	"fmt"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/freegle/iznik-server-go/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+// Tests for PATCH /api/group (PatchGroup) polygon handling.
+//
+// Regression: clearing the DPA (poly) via ModTools Support returned HTTP 400
+// "Invalid poly geometry" because an empty string was fed to validateGeometry.
+// Clearing the DPA should be allowed - the group then falls back to the CGA
+// (polyofficial) via the polyindex COALESCE, matching the old PHP behaviour.
+// See https://discourse.ilovefreegle.org/t/error-when-editing-dpa-using-support-on-modtools/9867
+
+func TestPatchGroupClearDPASucceedsAndFallsBackToCGA(t *testing.T) {
+	prefix := uniquePrefix("PatchGrpClearDPA")
+	groupID := CreateTestGroup(t, prefix)
+	adminID := CreateTestUser(t, prefix+"_admin", "Admin")
+	_, token := CreateTestSession(t, adminID)
+
+	db := database.DBConn
+	defer func() {
+		db.Exec("DELETE FROM memberships WHERE groupid = ?", groupID)
+		db.Exec("DELETE FROM `groups` WHERE id = ?", groupID)
+	}()
+
+	// Set a DPA (poly) and a CGA (polyofficial); initialise polyindex from the DPA.
+	dpa := "POLYGON((-0.1 51.5, -0.1 51.6, 0.0 51.6, 0.0 51.5, -0.1 51.5))"
+	cga := "POLYGON((-0.2 51.4, -0.2 51.7, 0.1 51.7, 0.1 51.4, -0.2 51.4))"
+	db.Exec("UPDATE `groups` SET poly = ?, polyofficial = ?, polyindex = ST_GeomFromText(?, ?) WHERE id = ?",
+		dpa, cga, dpa, utils.SRID, groupID)
+
+	// Clear the DPA, exactly as ModTools Support does when the DPA box is emptied.
+	body := fmt.Sprintf(`{"id":%d,"poly":""}`, groupID)
+	req := httptest.NewRequest("PATCH", fmt.Sprintf("/api/group?jwt=%s", token), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req)
+
+	assert.Equal(t, 200, resp.StatusCode, "clearing the DPA should succeed, not 400")
+
+	// The DPA should now be cleared.
+	var polyNull int64
+	db.Raw("SELECT COUNT(*) FROM `groups` WHERE id = ? AND poly IS NULL", groupID).Scan(&polyNull)
+	assert.Equal(t, int64(1), polyNull, "poly (DPA) should be NULL after clearing")
+
+	// The CGA should be untouched.
+	var cgaPresent int64
+	db.Raw("SELECT COUNT(*) FROM `groups` WHERE id = ? AND polyofficial IS NOT NULL", groupID).Scan(&cgaPresent)
+	assert.Equal(t, int64(1), cgaPresent, "polyofficial (CGA) should be unchanged when clearing the DPA")
+
+	// polyindex should now fall back to the CGA.
+	var matchesCGA int64
+	db.Raw("SELECT ST_Equals(polyindex, ST_GeomFromText(polyofficial, ?)) FROM `groups` WHERE id = ?",
+		utils.SRID, groupID).Scan(&matchesCGA)
+	assert.Equal(t, int64(1), matchesCGA, "polyindex should fall back to the CGA when the DPA is cleared")
+}
+
+func TestPatchGroupSetValidDPAUpdatesPolyindex(t *testing.T) {
+	prefix := uniquePrefix("PatchGrpSetDPA")
+	groupID := CreateTestGroup(t, prefix)
+	adminID := CreateTestUser(t, prefix+"_admin", "Admin")
+	_, token := CreateTestSession(t, adminID)
+
+	db := database.DBConn
+	defer func() {
+		db.Exec("DELETE FROM memberships WHERE groupid = ?", groupID)
+		db.Exec("DELETE FROM `groups` WHERE id = ?", groupID)
+	}()
+
+	dpa := "POLYGON((-0.1 51.5, -0.1 51.6, 0.0 51.6, 0.0 51.5, -0.1 51.5))"
+	body := fmt.Sprintf(`{"id":%d,"poly":%q}`, groupID, dpa)
+	req := httptest.NewRequest("PATCH", fmt.Sprintf("/api/group?jwt=%s", token), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req)
+
+	assert.Equal(t, 200, resp.StatusCode, "setting a valid DPA should succeed")
+
+	// poly stored.
+	var polyPresent int64
+	db.Raw("SELECT COUNT(*) FROM `groups` WHERE id = ? AND poly IS NOT NULL", groupID).Scan(&polyPresent)
+	assert.Equal(t, int64(1), polyPresent, "poly (DPA) should be stored")
+
+	// polyindex should track the new DPA.
+	var matchesDPA int64
+	db.Raw("SELECT ST_Equals(polyindex, ST_GeomFromText(poly, ?)) FROM `groups` WHERE id = ?",
+		utils.SRID, groupID).Scan(&matchesDPA)
+	assert.Equal(t, int64(1), matchesDPA, "polyindex should track the DPA when one is set")
+}
+
+func TestPatchGroupInvalidDPAStillRejected(t *testing.T) {
+	prefix := uniquePrefix("PatchGrpBadDPA")
+	groupID := CreateTestGroup(t, prefix)
+	adminID := CreateTestUser(t, prefix+"_admin", "Admin")
+	_, token := CreateTestSession(t, adminID)
+
+	db := database.DBConn
+	defer func() {
+		db.Exec("DELETE FROM memberships WHERE groupid = ?", groupID)
+		db.Exec("DELETE FROM `groups` WHERE id = ?", groupID)
+	}()
+
+	// A non-empty but invalid geometry must still be rejected.
+	body := fmt.Sprintf(`{"id":%d,"poly":"NOT A POLYGON"}`, groupID)
+	req := httptest.NewRequest("PATCH", fmt.Sprintf("/api/group?jwt=%s", token), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req)
+
+	assert.Equal(t, 400, resp.StatusCode, "an invalid (non-empty) polygon should still return 400")
+}

--- a/iznik-server-go/test/location_test.go
+++ b/iznik-server-go/test/location_test.go
@@ -221,6 +221,77 @@ func TestUpdateLocationPreservesNearbyVertex(t *testing.T) {
 	db.Exec("DELETE FROM locations WHERE id = ?", locID)
 }
 
+// Reproduces the STILL-OPEN half of Discourse #9770 (post #7: "no change from before").
+// The earlier fix removed write-time ST_Simplify, so ourgeometry keeps the dragged midpoint -
+// but the areas display query (SearchLocations, areas=true) still ST_Simplify(...,0.001)s the
+// geometry it returns. The map editor (ModGroupMapLocation.vue) loads that returned polygon,
+// so after Save+reload the new vertex has vanished and the edit looks unsaved. The vertex must
+// survive the exact round-trip the editor uses: PATCH save -> GET areas reload.
+func TestUpdateLocationMidpointVertexSurvivesAreasReload(t *testing.T) {
+	prefix := uniquePrefix("locwr_reload")
+	adminID := CreateTestUser(t, prefix+"_admin", "Admin")
+	_, adminToken := CreateTestSession(t, adminID)
+
+	db := database.DBConn
+
+	// The area the moderator edits.
+	db.Exec("INSERT INTO locations (name, type, canon, popularity) VALUES (?, 'Polygon', ?, 0)",
+		"ReloadArea "+prefix, "reloadarea "+prefix)
+	var areaID uint64
+	db.Raw("SELECT id FROM locations WHERE name = ? ORDER BY id DESC LIMIT 1", "ReloadArea "+prefix).Scan(&areaID)
+	assert.Greater(t, areaID, uint64(0))
+
+	// A postcode whose areaid points at the area, so the areas query returns it.
+	db.Exec("INSERT INTO locations (name, type, canon, popularity, areaid, lat, lng) VALUES (?, ?, ?, 0, ?, 55.955, -3.195)",
+		"ReloadPC "+prefix, utils.LOCATION_TYPE_POSTCODE, "reloadpc "+prefix, areaID)
+
+	defer func() {
+		db.Exec("DELETE FROM background_tasks WHERE task_type = 'remap_postcodes' AND JSON_EXTRACT(data, '$.location_id') = ?", areaID)
+		db.Exec("DELETE FROM locations_spatial WHERE locationid = ?", areaID)
+		db.Exec("DELETE FROM locations WHERE name IN (?, ?)", "ReloadArea "+prefix, "ReloadPC "+prefix)
+	}()
+
+	// User drags a midpoint (5th vertex, ~55 m above the bottom edge) and saves.
+	withMidpoint := "POLYGON((-3.21 55.94, -3.21 55.97, -3.18 55.97, -3.18 55.94, -3.195 55.9405, -3.21 55.94))"
+	body := fmt.Sprintf(`{"id":%d,"polygon":"%s"}`, areaID, withMidpoint)
+	req := httptest.NewRequest("PATCH", "/api/locations?jwt="+adminToken, bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	// Sanity: the stored geometry keeps the vertex (write side already fixed).
+	var storedPoints int
+	db.Raw("SELECT ST_NumPoints(ST_ExteriorRing(ourgeometry)) FROM locations WHERE id = ?", areaID).Scan(&storedPoints)
+	assert.Equal(t, 6, storedPoints, "stored ourgeometry should keep the dragged midpoint vertex")
+
+	// Reload exactly as the map editor does: GET /locations?areas=true over a covering bbox.
+	url := "/api/locations?areas=true&groupsnear=false&swlat=55.93&swlng=-3.22&nelat=55.98&nelng=-3.17&jwt=" + adminToken
+	resp2, _ := getApp().Test(httptest.NewRequest("GET", url, nil))
+	assert.Equal(t, 200, resp2.StatusCode)
+
+	var listResult struct {
+		Locations []struct {
+			ID      uint64 `json:"id"`
+			Polygon string `json:"polygon"`
+		} `json:"locations"`
+	}
+	json2.Unmarshal(rsp(resp2), &listResult)
+
+	var reloaded string
+	for _, l := range listResult.Locations {
+		if l.ID == areaID {
+			reloaded = l.Polygon
+		}
+	}
+	assert.NotEmpty(t, reloaded, "the edited area should be returned by the areas query")
+
+	// The polygon the editor receives back must still contain the dragged midpoint vertex.
+	var reloadedPoints int
+	db.Raw("SELECT ST_NumPoints(ST_ExteriorRing(ST_GeomFromText(?)))", reloaded).Scan(&reloadedPoints)
+	assert.Equal(t, 6, reloadedPoints,
+		"midpoint vertex must survive the areas reload the editor uses (Discourse #9770 post #7)")
+}
+
 func TestUpdateLocation(t *testing.T) {
 	prefix := uniquePrefix("locwr_upd")
 	adminID := CreateTestUser(t, prefix+"_admin", "Admin")


### PR DESCRIPTION
Two Go-API regressions in ModTools boundary editing, both introduced when the `/group` and `/locations` PATCH handlers moved from PHP to Go.

## 1. Clearing a group's DPA returned 400 — Discourse [/t/error-when-editing-dpa-using-support-on-modtools/9867](https://discourse.ilovefreegle.org/t/error-when-editing-dpa-using-support-on-modtools/9867)

Removing a group's DPA (Default Posting Area) via Support → Find Group failed with `API Error PATCH /group ... status: 400`, and the DPA reappeared on refresh.

`PatchGroup` fed the empty string straight to `validateGeometry()`, which runs `ST_GeomFromText('')` and fails, so it returned 400 before the `UPDATE`. An empty `poly`/`polyofficial` now clears the field (`NULL`) and skips geometry validation, then recomputes `polyindex = ST_GeomFromText(COALESCE(poly, polyofficial, 'POINT(0 0)'), SRID)` so the group falls back to its CGA — matching the old PHP `Group::setPrivate`. The Go handler previously never recomputed `polyindex` at all.

**Loki confirmation:** the failing request was `requestid=4567, loggedInAs=42396318`, body `{"id":21406,"modtools":true,"poly":""}` (group 21406 = freegle-kingston), duration 2 ms, paired with two 400 Sentry events.

## 2. Dragging a boundary midpoint looked unsaved — Discourse [/t/mapping-additional-boundary-markers-not-saved/9770/7](https://discourse.ilovefreegle.org/t/mapping-additional-boundary-markers-not-saved/9770/7)

Dragging a polygon midpoint to add a vertex did not persist, and adjacent vertices could disappear. An earlier fix removed write-time `ST_Simplify`, but the **areas display query** — the boundary editor's only caller (it is the sole `/locations` caller passing a bounding box) — still `ST_Simplify(..., 0.001)`'d (~111 m) the geometry it returned. The editor loads that polygon, so on save + reload the freshly placed vertex (within 111 m of the edge) was simplified away. That query now returns full-resolution geometry (`ourgeometry` override, else `geometry`).

**Live confirmation:** Neville's edited Limehouse area (location 1859072) stores 11 vertices, but the areas endpoint returned 10 — the dragged vertex dropped on reload.

## Tests

- `iznik-server-go/test/group_patch_test.go` — clearing the DPA returns 200, sets `poly` NULL, and `polyindex` falls back to the CGA; a valid poly updates `polyindex`; an invalid (non-empty) poly still returns 400.
- `iznik-server-go/test/location_test.go` — new round-trip test: PATCH save → areas reload preserves the dragged midpoint vertex (fails before the fix, passes after). The existing write-side test still passes.

Full Go suite green (3389 passed / 0 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U3Hp9AG5RzAxVQVzXpkwgn
