### PR TITLE
fix(notification): route in-app notification links via router, not window.open

### DIFF
--- a/iznik-nuxt3/components/NotificationOne.vue
+++ b/iznik-nuxt3/components/NotificationOne.vue
@@ -89,7 +89,31 @@ function click() {
   markSeen()
 
   if (notification.value?.url) {
-    window.open(notification.value.url)
+    const url = notification.value.url
+
+    // In-app links (relative, or absolute but same-origin) must navigate via
+    // the router rather than window.open(). window.open() spins up a
+    // separate browsing context that doesn't share this SPA instance's
+    // Pinia stores, so - for example - voting on a microvolunteering "check
+    // this message" notification there never updates the notification badge
+    // count shown here, leaving it stuck and the same link re-openable to
+    // the same post (#9856).
+    if (url.startsWith('/')) {
+      router.push(url)
+      return
+    }
+
+    try {
+      const parsed = new URL(url)
+      if (parsed.origin === window.location.origin) {
+        router.push(parsed.pathname + parsed.search + parsed.hash)
+        return
+      }
+    } catch (e) {
+      // Not a parseable absolute URL - fall through to window.open below.
+    }
+
+    window.open(url)
   } else if (newsfeed?.value) {
     router.push('/chitchat/' + newsfeed.value.id)
   }

--- a/iznik-nuxt3/tests/unit/components/NotificationOne.spec.js
+++ b/iznik-nuxt3/tests/unit/components/NotificationOne.spec.js
@@ -255,6 +255,40 @@ describe('NotificationOne', () => {
 
       expect(mockRouter.push).toHaveBeenCalledWith('/chitchat/789')
     })
+
+    it('navigates internally via the router for in-app links (e.g. a microvolunteering check) instead of opening a new browsing context', async () => {
+      const openSpy = vi.spyOn(window, 'open').mockImplementation(() => {})
+      mockNotification.value.url = '/microvolunteering/message/456'
+      const wrapper = await createWrapper()
+
+      await wrapper.find('.notification__wrapper').trigger('click')
+
+      // #9856: window.open() for an in-app route spins up a separate
+      // browsing context, so this SPA instance's Pinia stores (and the
+      // notification badge count they drive) never see the vote that
+      // happens there - the badge stays stuck and the link can be
+      // reopened to the same post.
+      expect(mockRouter.push).toHaveBeenCalledWith(
+        '/microvolunteering/message/456'
+      )
+      expect(openSpy).not.toHaveBeenCalled()
+      openSpy.mockRestore()
+    })
+
+    it('navigates internally via the router for same-origin absolute urls', async () => {
+      const openSpy = vi.spyOn(window, 'open').mockImplementation(() => {})
+      mockNotification.value.url =
+        window.location.origin + '/microvolunteering/message/789'
+      const wrapper = await createWrapper()
+
+      await wrapper.find('.notification__wrapper').trigger('click')
+
+      expect(mockRouter.push).toHaveBeenCalledWith(
+        '/microvolunteering/message/789'
+      )
+      expect(openSpy).not.toHaveBeenCalled()
+      openSpy.mockRestore()
+    })
   })
 
   describe('showModal emit', () => {


### PR DESCRIPTION
## Root Cause
`NotificationOne.vue`'s click handler used `window.open(notification.value.url)` for **every** notification link, including in-app SPA routes like `/microvolunteering/message/<msgid>` (the "post to check" Exhort notification). `window.open()` spins up a **separate browsing context** (new tab, or on the Android app a WebView/system-browser boundary) with its own fresh Pinia stores. Voting there correctly marks the notification `seen=1` on the server and correctly refreshes the notification count *inside that new context* (via the existing `notificationStore.fetchCount()` fix from PR #941) - but the **original tab/view** the user came from (where the badge is rendered) never learns about it, since it's a distinct JS runtime with its own stale store state. Result: the badge stays stuck, and the still-listed notification can be clicked again, reopening the same message to be "checked" again - exactly as reported, on both the Android app and the website.

This is why PR #941 (client-side count refresh after voting) did not fix it: that refresh runs in the wrong browsing context.

## Evidence
Failing test (`tests/unit/components/NotificationOne.spec.js`) before the fix:
```
× NotificationOne > click handling > navigates internally via the router for in-app links (e.g. a microvolunteering check) instead of opening a new browsing context
  AssertionError: expected "spy" to be called with arguments: [ '/microvolunteering/message/456' ]
  Number of calls: 0
```
(`router.push` was never called; `window.open` was called instead.)

## Fix
`click()` now routes in-app links (relative URLs, or absolute URLs whose origin matches `window.location.origin`) through Vue Router (`router.push`), so the navigation stays within the same SPA instance/Pinia store that rendered the badge. Genuinely external URLs still use `window.open`, preserving existing behaviour (covered by the pre-existing `opens URL when notification has url` test with an `example.com` URL).

## Other Call Sites
`grep -rn "window.open" iznik-nuxt3/components` shows other uses (`ChatButton.vue`, `MessageHistoryExpanded.vue`, `AppUpdateAvailable.vue`, `RateAppAsk.vue`, `NewsPreview.vue`) are all deliberate "open in a new tab/popup" UX for chat/profile/external links, unrelated to this notification-click path - left untouched.

## Test
- File: `iznik-nuxt3/tests/unit/components/NotificationOne.spec.js`
- Command: `npx vitest run tests/unit/components/NotificationOne.spec.js`
- New tests assert `router.push` is called (and `window.open` is not) for a relative in-app URL and for a same-origin absolute URL; confirmed to fail against the pre-fix code (see Evidence) and pass after the fix. Full `tests/unit` suite (659 files / 13838 tests) still passes.

## Discourse
https://discourse.ilovefreegle.org/t/9856/4