### PR TITLE
fix(microvolunteering): clear stale badge notifications for already-reviewed posts (Discourse 9856)

### DIFF
--- a/iznik-batch/app/Console/Commands/AI/MicrovolunteeringNotifyCommand.php
+++ b/iznik-batch/app/Console/Commands/AI/MicrovolunteeringNotifyCommand.php
@@ -31,7 +31,7 @@ class MicrovolunteeringNotifyCommand extends Command
 
             $verb = $dryRun ? 'would notify' : 'notified';
             $this->info(
-                "Considered {$stats['messages_considered']} messages: {$verb} {$stats['users_notified']} user(s), skipped {$stats['users_skipped']}."
+                "Considered {$stats['messages_considered']} messages: {$verb} {$stats['users_notified']} user(s), skipped {$stats['users_skipped']}, cleared {$stats['stale_notifications_cleared']} stale notification(s)."
             );
 
             Log::info('Microvolunteering notify complete', $stats);

--- a/iznik-batch/app/Services/MicrovolunteeringNotifyService.php
+++ b/iznik-batch/app/Services/MicrovolunteeringNotifyService.php
@@ -39,10 +39,23 @@ class MicrovolunteeringNotifyService
         $this->alreadyNotifiedToday = $this->loadAlreadyNotifiedToday();
         $this->reviewedByMessage    = [];
 
+        // Second surface of Discourse 9856: the exclusion below only stops a NEW
+        // duplicate notification from being created. It does nothing about an
+        // Exhort notification that already exists and is still unseen for a
+        // message the recipient has since reviewed (e.g. inserted before this
+        // exclusion existed, or via any other race) - that row would otherwise
+        // stay seen=0 for ever, keeping the badge lit and its link re-presenting
+        // the already-reviewed post. Sweep those clear on every run, independent
+        // of today's candidate set, so the badge/count stays consistent with the
+        // review-selection exclusion (confirmed against production: 81 such
+        // stuck rows exist at time of writing).
+        $staleNotificationsCleared = $this->markStaleReviewedNotificationsSeen($dryRun);
+
         $stats = [
-            'messages_considered' => 0,
-            'users_notified'      => 0,
-            'users_skipped'       => 0,
+            'messages_considered'         => 0,
+            'users_notified'              => 0,
+            'users_skipped'               => 0,
+            'stale_notifications_cleared' => $staleNotificationsCleared,
         ];
 
         $msgs = DB::select("
@@ -245,14 +258,6 @@ class MicrovolunteeringNotifyService
     }
 
     /**
-     * Build {userid => true} for users with any microvolunteering Exhort
-     * notification in the last 24 h. Equivalent to the per-message
-     * `LEFT JOIN users_notifications … IS NULL` filter the V1 candidate
-     * query did, hoisted out of the per-message hot loop.
-     *
-     * @return array<int, bool>
-     */
-    /**
      * Build {msgid => {userid => true}} for users who have already recorded a
      * CheckMessage microaction for each of the given messages. Preloaded once per
      * run (mirrors loadAlreadyNotifiedToday) so pickCandidates can skip anyone who
@@ -283,6 +288,14 @@ class MicrovolunteeringNotifyService
         return $map;
     }
 
+    /**
+     * Build {userid => true} for users with any microvolunteering Exhort
+     * notification in the last 24 h. Equivalent to the per-message
+     * `LEFT JOIN users_notifications … IS NULL` filter the V1 candidate
+     * query did, hoisted out of the per-message hot loop.
+     *
+     * @return array<int, bool>
+     */
     private function loadAlreadyNotifiedToday(): array
     {
         $rows = DB::select(
@@ -299,5 +312,47 @@ class MicrovolunteeringNotifyService
             $set[(int) $row->touser] = true;
         }
         return $set;
+    }
+
+    /**
+     * Mark seen any existing Exhort "post to check" notification whose recipient
+     * has already recorded a CheckMessage microaction for the message it points
+     * at. The per-message exclusion in pickCandidates only prevents a NEW
+     * duplicate from being created; it cannot retroactively clear a notification
+     * that already exists (e.g. inserted before this exclusion shipped, or via
+     * any other race). Without this sweep the badge stays lit and the
+     * notification's link keeps re-presenting an already-reviewed post
+     * indefinitely. See Discourse 9856.
+     *
+     * @return int Number of notifications cleared (0 in dry-run mode, since
+     *             nothing is written).
+     */
+    private function markStaleReviewedNotificationsSeen(bool $dryRun): int
+    {
+        if ($dryRun) {
+            $row = DB::selectOne(
+                "SELECT COUNT(*) AS count
+                 FROM users_notifications un
+                 INNER JOIN microactions ma
+                     ON ma.userid = un.touser
+                     AND ma.actiontype = 'CheckMessage'
+                     AND un.url = CONCAT('/microvolunteering/message/', ma.msgid)
+                 WHERE un.type = ? AND un.seen = 0",
+                [self::NOTIFICATION_TYPE]
+            );
+
+            return (int) $row->count;
+        }
+
+        return DB::update(
+            "UPDATE users_notifications un
+             INNER JOIN microactions ma
+                 ON ma.userid = un.touser
+                 AND ma.actiontype = 'CheckMessage'
+                 AND un.url = CONCAT('/microvolunteering/message/', ma.msgid)
+             SET un.seen = 1
+             WHERE un.type = ? AND un.seen = 0",
+            [self::NOTIFICATION_TYPE]
+        );
     }
 }

--- a/iznik-batch/tests/Feature/AI/MicrovolunteeringNotifyCommandTest.php
+++ b/iznik-batch/tests/Feature/AI/MicrovolunteeringNotifyCommandTest.php
@@ -274,6 +274,48 @@ class MicrovolunteeringNotifyCommandTest extends TestCase
         ]);
     }
 
+    public function test_stale_notification_for_already_reviewed_message_is_cleared(): void
+    {
+        // Second surface of Discourse 9856: pickCandidates only stops NEW duplicate
+        // notifications from being created. It does nothing for an Exhort
+        // notification that already exists (e.g. inserted before this exclusion
+        // existed, or via any other race) - that row stays seen=0 forever, so the
+        // badge never clears and its link keeps re-presenting the reviewed post.
+        // Confirmed against production: 81 such stuck rows currently exist.
+        $groupId  = $this->createGroup(microvolunteering: true);
+        $fromUser = $this->createUser('Basic');
+        $reviewer = $this->createUser('Moderate');
+
+        $this->addMembership($fromUser, $groupId);
+        $this->addMembership($reviewer, $groupId);
+
+        $msgId = $this->createMessage($groupId, $fromUser, 'Pending');
+
+        // The reviewer has already checked this message...
+        DB::table('microactions')->insert([
+            'actiontype'     => 'CheckMessage',
+            'userid'         => $reviewer,
+            'msgid'          => $msgId,
+            'result'         => 'Approve',
+            'score_negative' => 0,
+        ]);
+
+        // ...but a stale unseen notification for it is still sitting there.
+        $notifId = DB::table('users_notifications')->insertGetId([
+            'touser' => $reviewer,
+            'type'   => 'Exhort',
+            'url'    => '/microvolunteering/message/' . $msgId,
+        ]);
+
+        $this->artisan('microvolunteering:notify')
+            ->assertExitCode(0);
+
+        $this->assertDatabaseHas('users_notifications', [
+            'id'   => $notifId,
+            'seen' => 1,
+        ]);
+    }
+
     public function test_skips_user_already_notified_3_times(): void
     {
         $groupId  = $this->createGroup(microvolunteering: true);


### PR DESCRIPTION
Follow-up to #967 (merged): fixes the "microvolunteer post to check keeps re-appearing / badge never clears" bug: https://discourse.ilovefreegle.org/t/9856/3

#967 merged a fix for one surface of this bug; this PR fixes the other surface, which is why Jacky still saw the problem after retesting.

## Root Cause
This bug has **two distinct surfaces**:

1. **Review selection** (which post is next to review) - `getApprovedMessageChallenge` / `getPendingMessageChallenge` in `iznik-server-go/microvolunteering/microvolunteering.go` already `LEFT JOIN microactions ... WHERE microactions.id IS NULL`, so an already-reviewed message is correctly excluded from being re-selected. This side was never broken.
2. **Notification badge/count** (`notification.Count` in `iznik-server-go/notification/notification.go`) counts unseen `users_notifications` rows. #967's fix (`MicrovolunteeringNotifyService::pickCandidates`) stops a **new** duplicate `Exhort` notification from being created for a user who already reviewed a message - but it does nothing for a notification that **already exists**. That row stays `seen=0` forever, so the badge never clears, and tapping its `/microvolunteering/message/<id>` link re-presents the already-reviewed post (the "repeat post" Jacky saw) - independent of the review-selection query, because that page fetches the message directly rather than going through the "next challenge" endpoint.

Confirmed against production (read-only, via the V2 live-DB tunnel): **81 currently-stuck unseen `Exhort` notifications** exist right now where the recipient already has a `CheckMessage` microaction for that message, and **100% of them (81/81) were created after the user's review** - i.e. exactly the notifications #967 prevents going forward, but cannot clear retroactively.

## Evidence
New test `test_stale_notification_for_already_reviewed_message_is_cleared` in `MicrovolunteeringNotifyCommandTest`:
- Characterized the bug first: pre-insert a `CheckMessage` microaction plus a stale unseen `Exhort` notification for the same message/user, ran `microvolunteering:notify`, confirmed the notification stayed `seen=0` on the unfixed code.
- Inverted to assert `seen=1`; confirmed it fails on the unfixed code (`Failed asserting that a row ... matches ... "seen": 1. Found ... "seen": 0`).
- Full pre-fix run of the class: **10 passed, 1 failed** (the new test) - no regressions from adding the test.

## Fix
Added `MicrovolunteeringNotifyService::markStaleReviewedNotificationsSeen()`, called once per `notifyForMessages()` run (independent of the day's candidate-message set, since a stuck notification can point at a message older than the 1-day candidate window). It's a single `UPDATE users_notifications un INNER JOIN microactions ma ON ma.userid = un.touser AND ma.actiontype = 'CheckMessage' AND un.url = CONCAT(...) SET un.seen = 1 WHERE un.type = 'Exhort' AND un.seen = 0` - mirrors the exact join already used (and tested) in `loadReviewedByMessage`. Dry-run mode counts instead of writing. The cleared count is now surfaced in `$stats` and the command's info line.

This makes the badge/count consistent with the review-selection exclusion: once a message is excluded from re-selection because the user reviewed it, any notification still pointing at it is also cleared.

## Other Call Sites
Grepped for other `users_notifications` writes/reads touching Exhort/microvolunteering: only `MicrovolunteeringNotifyService` (Laravel, creates them) and the Go `PostResponse` handler (`iznik-server-go/microvolunteering/microvolunteering.go`, marks the *current* vote's notification seen at vote time) touch this type. No other call site needed changing.

## Test
- File: `iznik-batch/tests/Feature/AI/MicrovolunteeringNotifyCommandTest.php`
- Command: `php artisan test --filter=MicrovolunteeringNotifyCommandTest`
- Proves fail-before/pass-after: characterized RED against unfixed code (seen stays 0), fix makes it GREEN (seen becomes 1).

Full post-fix run (after several retries blocked by other concurrent worktree sessions sharing the same `iznik_batch_test` database and its `migrate:fresh`): **11 passed, 0 failed, 22 assertions** - all pre-existing tests plus the new one, fully green.

## History
This commit was originally pushed to #967's branch (`fix/microvol-renotify-9856`) as a re-attempt, but that PR was merged (containing only the first-surface fix) before the push landed, so the commit needed a fresh PR against master to reach production.

## Discourse
https://discourse.ilovefreegle.org/t/9856/3