### PR TITLE
feat(distance): distance preference in Settings + ripple email/help wording

### DIFF
--- a/RIPPLING-OUT-FOR-MODERATORS.md
+++ b/RIPPLING-OUT-FOR-MODERATORS.md
@@ -97,13 +97,22 @@ of scoring already used to order the rippling digest email. This changes the ord
 member's own browse page shows posts in; it does not change what rippling approves, joins,
 or who a post reaches.
 
-Members also have a new distance slider in their filters, marked "Nearer" and "Further"
-with no numbers shown. It is a **personal display preference each member sets for
+Members also have a distance slider marked "Nearer" and "Further" with no numbers shown,
+in two places: their **browse filters**, and (new) their **Settings**, under a "Feed"
+section above Email Settings. It is a **personal preference each member sets for
 themselves** - by default it is left at "Further" (no extra limit beyond their normal
-rippling reach), and moving it towards "Nearer" simply narrows what appears on their own
-screen. It has no effect on rippling itself, on what other members see, or on moderation -
-and, like their other browse filters (which posts, which communities, sort order), their
-choice is remembered between visits.
+rippling reach), and moving it towards "Nearer" narrows how far away posts can be.
+
+Importantly, this preference now applies **both to what they see when browsing and to the
+posts in the emails we send them** (their daily digest and immediate emails). A member who
+sets it "Nearer" will stop seeing - and stop being emailed about - posts from further away,
+including rippled-in ones. It still has **no effect on rippling itself, on what other
+members see, or on moderation**, and their choice is remembered between visits.
+
+A practical consequence worth knowing: a rippled-in post is shown to the members of your
+community who are **closest to the poster and whose own distance preference reaches that
+far - not necessarily everyone**. If a member says a post "isn't showing for them", their
+distance slider being set to "Nearer" is a likely reason.
 
 ---
 

--- a/iznik-batch/resources/views/emails/mjml/ripple/intro.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/ripple/intro.blade.php
@@ -35,6 +35,12 @@
           might be interested in your recent {{ config('freegle.branding.name') }} post, so we're
           showing it to them too.
         </mj-text>
+        <mj-text font-size="14px" color="#000000" line-height="1.6" padding="6px 25px">
+          It's shown to the freeglers there who are nearest to you &mdash; not everyone in those
+          communities. Each freegler chooses how far away they want to see posts from, using the
+          <strong>How far away</strong> distance setting in their
+          <a href="{{ $settingsUrl }}">settings</a> (you have one there too).
+        </mj-text>
         <mj-text font-size="15px" font-weight="bold" color="#338808" line-height="1.6" padding="6px 25px">
           There's nothing you need to do - this just helps your post reach the right person.
         </mj-text>

--- a/iznik-batch/resources/views/emails/text/ripple/intro.blade.php
+++ b/iznik-batch/resources/views/emails/text/ripple/intro.blade.php
@@ -2,6 +2,8 @@
 
 Good news - we've noticed that some of the nearby freeglers in neighbouring communities might be interested in your recent {{ config('freegle.branding.name') }} post, so we're showing it to them too.
 
+It's shown to the freeglers there who are nearest to you - not everyone in those communities. Each freegler chooses how far away they want to see posts from, using the "How far away" distance setting in their settings ({{ $settingsUrl }}) - you have one there too.
+
 THERE'S NOTHING YOU NEED TO DO - this just helps your post reach the right person.
 
 So this works smoothly, we've added you to those communities - just as if you'd posted there yourself. That way people there can reply to you, and our volunteers can reach you about your post if they need to.

--- a/iznik-batch/tests/Unit/Services/DeprivationDataServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/DeprivationDataServiceTest.php
@@ -1,0 +1,405 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Services\DeprivationDataService;
+use Illuminate\Support\Facades\Http;
+use PHPUnit\Framework\Attributes\DataProvider;
+use RuntimeException;
+use Tests\TestCase;
+
+/**
+ * Covers DeprivationDataService::build() — the mySociety IMD lookup parser
+ * (quintile and decile-fallback columns, malformed rows) and the three
+ * per-nation fetchers (England & Wales / Scotland ArcGIS pagination,
+ * Northern Ireland polygon-centroid + Irish Grid transform), all driven
+ * through the Http facade so no real network calls are made.
+ */
+class DeprivationDataServiceTest extends TestCase
+{
+    private DeprivationDataService $service;
+
+    private string $outputPath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new DeprivationDataService();
+        $this->outputPath = sys_get_temp_dir().'/deprivation-test-'.uniqid().'.csv';
+    }
+
+    protected function tearDown(): void
+    {
+        if (file_exists($this->outputPath)) {
+            unlink($this->outputPath);
+        }
+        parent::tearDown();
+    }
+
+    /**
+     * Fake all four upstream hosts with benign, non-throwing defaults;
+     * $overrides replaces individual host patterns for a given test.
+     */
+    private function fakeAll(array $overrides = []): void
+    {
+        $defaults = [
+            'raw.githubusercontent.com/*' => Http::response("lsoa,UK_IMD_E_pop_quintile\nE01000001,3\n", 200),
+            'services1.arcgis.com/*' => Http::response(['features' => []], 200),
+            'maps.gov.scot/*' => Http::response(['features' => []], 200),
+            'admin.opendatani.gov.uk/*' => Http::response(['features' => []], 200),
+        ];
+
+        Http::fake(array_merge($defaults, $overrides));
+    }
+
+    /** Read the written CSV (minus header) as [lat, lng, quintile] rows keyed by nothing in particular. */
+    private function readCsvRows(): array
+    {
+        $lines = array_filter(explode("\n", trim(file_get_contents($this->outputPath))));
+        array_shift($lines); // drop header
+        return array_map(fn ($line) => str_getcsv($line), $lines);
+    }
+
+    // =========================================================================
+    // Happy path — all three nations, mixed with the skip branches each
+    // fetcher must handle (missing geometry, unmatched code, invalid quintile,
+    // unsupported NI geometry type).
+    // =========================================================================
+
+    public function test_build_success_writes_matched_rows_across_all_three_nations(): void
+    {
+        $imdCsv = "lsoa,UK_IMD_E_pop_quintile\n"
+            ."E01000001,3\n"
+            ."E01000002,1\n"
+            ."NI0001,2\n"
+            ."NI0002,5\n"
+            ."NI0003,4\n"
+            ."SGA,4\n"
+            ."\n" // blank line — must be skipped without error
+            ."E01099999,9\n" // out-of-range quintile — excluded from the lookup entirely
+            ."E01000005\n"; // code present but no quintile/decile cell — must be skipped, not crash
+
+        $ew = [
+            'features' => [
+                ['attributes' => ['lsoa11cd' => 'E01000001'], 'geometry' => ['x' => -0.10, 'y' => 51.50]],
+                ['attributes' => ['lsoa11cd' => 'E01000002'], 'geometry' => ['x' => -1.20, 'y' => 52.10]],
+                // Quintile 9 was invalid, so this code was never added to the lookup — skipped.
+                ['attributes' => ['lsoa11cd' => 'E01099999'], 'geometry' => ['x' => -2.00, 'y' => 53.00]],
+            ],
+        ];
+
+        // A single, non-paginated page of Scotland results: exceededTransferLimit
+        // is absent, so the loop must break via the "no more pages" path (as
+        // opposed to the pagination test's empty-features break).
+        $scotland = [
+            'features' => [
+                ['attributes' => ['objectid' => 1, 'datazone' => 'SGA'], 'geometry' => ['x' => -3.2, 'y' => 55.8]],
+            ],
+        ];
+
+        $niSquareRing = [[300000, 350000], [300100, 350000], [300100, 350100], [300000, 350100], [300000, 350000]];
+        $niHexRing = [[320000, 370000], [320100, 370000], [320150, 370050], [320100, 370100], [320000, 370100], [319950, 370050], [320000, 370000]];
+        $niSmallRing = [[310000, 360000], [310100, 360000], [310050, 360100], [310000, 360000]];
+        $niUnmatchedRing = [[330000, 380000], [330100, 380000], [330100, 380100], [330000, 380100], [330000, 380000]];
+
+        $ni = [
+            'features' => [
+                // Polygon — matched. GeoJSON Polygon coordinates are an array of
+                // rings (exterior first), hence the extra wrapping array.
+                ['properties' => ['SOA_CODE' => 'NI0001'], 'geometry' => ['type' => 'Polygon', 'coordinates' => [$niSquareRing]]],
+                // MultiPolygon — the larger (hexagon) ring must be selected over the smaller triangle.
+                ['properties' => ['SOA_CODE' => 'NI0002'], 'geometry' => ['type' => 'MultiPolygon', 'coordinates' => [[$niSmallRing], [$niHexRing]]]],
+                // Unsupported geometry type — skipped regardless of the code being in the lookup.
+                ['properties' => ['SOA_CODE' => 'NI0003'], 'geometry' => ['type' => 'Point', 'coordinates' => [300000, 350000]]],
+                // Code absent from the lookup — skipped despite valid geometry.
+                ['properties' => ['SOA_CODE' => 'NI9999'], 'geometry' => ['type' => 'Polygon', 'coordinates' => [$niUnmatchedRing]]],
+            ],
+        ];
+
+        $this->fakeAll([
+            'raw.githubusercontent.com/*' => Http::response($imdCsv, 200),
+            'services1.arcgis.com/*' => Http::response($ew, 200),
+            'maps.gov.scot/*' => Http::response($scotland, 200),
+            'admin.opendatani.gov.uk/*' => Http::response($ni, 200),
+        ]);
+
+        $this->service->build($this->outputPath);
+
+        $rows = $this->readCsvRows();
+        $this->assertCount(5, $rows, 'expected 2 matched E&W + 1 matched Scotland + 2 matched NI rows, all edge cases skipped');
+
+        $byQuintile = [];
+        foreach ($rows as [$lat, $lng, $q]) {
+            $byQuintile[$q][] = [(float) $lat, (float) $lng];
+        }
+
+        // E&W rows carry their raw WGS84 x/y through untransformed.
+        $this->assertEqualsWithDelta(51.50, $byQuintile['3'][0][0], 0.0001);
+        $this->assertEqualsWithDelta(-0.10, $byQuintile['3'][0][1], 0.0001);
+        $this->assertEqualsWithDelta(52.10, $byQuintile['1'][0][0], 0.0001);
+        $this->assertEqualsWithDelta(-1.20, $byQuintile['1'][0][1], 0.0001);
+        $this->assertEqualsWithDelta(55.80, $byQuintile['4'][0][0], 0.0001);
+        $this->assertEqualsWithDelta(-3.20, $byQuintile['4'][0][1], 0.0001);
+
+        // NI rows went through the Irish Grid → WGS84 transform; just sanity-check
+        // they land somewhere plausible (the exact maths is covered by IrishGridConverterTest).
+        foreach ([$byQuintile['2'][0], $byQuintile['5'][0]] as [$lat, $lng]) {
+            $this->assertGreaterThan(49.0, $lat);
+            $this->assertLessThan(61.0, $lat);
+            $this->assertGreaterThan(-11.0, $lng);
+            $this->assertLessThan(2.0, $lng);
+        }
+    }
+
+    // =========================================================================
+    // England & Wales — pagination (exceededTransferLimit) and per-feature skips
+    // =========================================================================
+
+    public function test_ew_pagination_merges_pages_and_skips_missing_or_unmatched_features(): void
+    {
+        $page1 = [
+            'features' => [
+                ['attributes' => ['lsoa11cd' => 'PGA'], 'geometry' => ['x' => -1.0, 'y' => 51.0]],
+                // No geometry at all — lat/lng resolve to null and the feature is skipped.
+                ['attributes' => ['lsoa11cd' => 'PGX'], 'geometry' => []],
+            ],
+            'exceededTransferLimit' => true,
+        ];
+        $page2 = [
+            'features' => [
+                ['attributes' => ['lsoa11cd' => 'PGB'], 'geometry' => ['x' => -2.0, 'y' => 52.0]],
+                // Valid geometry but the code was never in the IMD lookup.
+                ['attributes' => ['lsoa11cd' => 'PGY'], 'geometry' => ['x' => -3.0, 'y' => 53.0]],
+            ],
+        ];
+
+        $this->fakeAll([
+            'raw.githubusercontent.com/*' => Http::response("lsoa,UK_IMD_E_pop_quintile\nPGA,1\nPGB,2\n", 200),
+            'services1.arcgis.com/*' => Http::sequence()->push($page1, 200)->push($page2, 200),
+        ]);
+
+        $this->service->build($this->outputPath);
+
+        $rows = $this->readCsvRows();
+        $this->assertCount(2, $rows, 'expected only PGA (page 1) and PGB (page 2) to survive');
+
+        usort($rows, fn ($a, $b) => $a[2] <=> $b[2]);
+        [$latA, $lngA, $qA] = $rows[0];
+        [$latB, $lngB, $qB] = $rows[1];
+        $this->assertSame('1', $qA);
+        $this->assertEqualsWithDelta(51.0, (float) $latA, 0.0001);
+        $this->assertEqualsWithDelta(-1.0, (float) $lngA, 0.0001);
+        $this->assertSame('2', $qB);
+        $this->assertEqualsWithDelta(52.0, (float) $latB, 0.0001);
+        $this->assertEqualsWithDelta(-2.0, (float) $lngB, 0.0001);
+    }
+
+    // =========================================================================
+    // Scotland — objectid-based pagination, empty-page break, per-feature skips
+    // =========================================================================
+
+    public function test_scotland_pagination_tracks_last_objectid_and_breaks_on_empty_page(): void
+    {
+        $page1 = [
+            'features' => [
+                ['attributes' => ['objectid' => 5, 'datazone' => 'SGA'], 'geometry' => ['x' => -3.5, 'y' => 55.9]],
+                // Missing geometry — skipped.
+                ['attributes' => ['objectid' => 8, 'datazone' => 'SGX'], 'geometry' => []],
+                // Valid geometry, code not in the IMD lookup — skipped.
+                ['attributes' => ['objectid' => 10, 'datazone' => 'SGZ'], 'geometry' => ['x' => -4.0, 'y' => 56.0]],
+            ],
+            'exceededTransferLimit' => true,
+        ];
+        // Second page is empty — the loop must break immediately rather than looping forever.
+        $page2 = ['features' => []];
+
+        $this->fakeAll([
+            'raw.githubusercontent.com/*' => Http::response("lsoa,UK_IMD_E_pop_quintile\nSGA,4\n", 200),
+            'maps.gov.scot/*' => Http::sequence()->push($page1, 200)->push($page2, 200),
+        ]);
+
+        $this->service->build($this->outputPath);
+
+        $rows = $this->readCsvRows();
+        $this->assertCount(1, $rows);
+        [$lat, $lng, $q] = $rows[0];
+        $this->assertSame('4', $q);
+        $this->assertEqualsWithDelta(55.9, (float) $lat, 0.0001);
+        $this->assertEqualsWithDelta(-3.5, (float) $lng, 0.0001);
+    }
+
+    // =========================================================================
+    // Northern Ireland — degenerate (zero-area) polygon centroid fallback
+    // =========================================================================
+
+    public function test_ni_degenerate_polygon_falls_back_to_vertex_average(): void
+    {
+        // A ring collapsed to a single repeated point has zero signed area, so
+        // polygonCentroid() must fall back to averaging the raw vertices
+        // instead of dividing by (6 * area).
+        $degenerateRing = [[300000, 350000], [300000, 350000], [300000, 350000]];
+
+        $ni = [
+            'features' => [
+                ['properties' => ['SOA_CODE' => 'NIDEG'], 'geometry' => ['type' => 'Polygon', 'coordinates' => [$degenerateRing]]],
+            ],
+        ];
+
+        $this->fakeAll([
+            'raw.githubusercontent.com/*' => Http::response("lsoa,UK_IMD_E_pop_quintile\nNIDEG,3\n", 200),
+            'admin.opendatani.gov.uk/*' => Http::response($ni, 200),
+        ]);
+
+        $this->service->build($this->outputPath);
+
+        $rows = $this->readCsvRows();
+        $this->assertCount(1, $rows);
+        [$lat, $lng, $q] = $rows[0];
+        $this->assertSame('3', $q);
+        $this->assertIsNumeric($lat);
+        $this->assertIsNumeric($lng);
+        $this->assertGreaterThan(49.0, (float) $lat);
+        $this->assertLessThan(61.0, (float) $lat);
+    }
+
+    // =========================================================================
+    // IMD lookup — decile fallback column and malformed-row handling
+    // =========================================================================
+
+    public function test_imd_decile_fallback_column_computes_quintile(): void
+    {
+        // ceil(10/2)=5, ceil(1/2)=1, ceil(3/2)=2 — verifies both the
+        // decile→quintile conversion and its 1..5 clamping.
+        $imdCsv = "Code,E_expanded_decile\nDECA,10\nDECB,1\nDECC,3\n";
+
+        $ew = [
+            'features' => [
+                ['attributes' => ['lsoa11cd' => 'DECA'], 'geometry' => ['x' => -1.0, 'y' => 51.0]],
+                ['attributes' => ['lsoa11cd' => 'DECB'], 'geometry' => ['x' => -1.1, 'y' => 51.1]],
+                ['attributes' => ['lsoa11cd' => 'DECC'], 'geometry' => ['x' => -1.2, 'y' => 51.2]],
+            ],
+        ];
+
+        $this->fakeAll([
+            'raw.githubusercontent.com/*' => Http::response($imdCsv, 200),
+            'services1.arcgis.com/*' => Http::response($ew, 200),
+        ]);
+
+        $this->service->build($this->outputPath);
+
+        $byCode = [];
+        foreach ($this->readCsvRows() as [$lat, $lng, $q]) {
+            $byCode[$lat.','.$lng] = $q;
+        }
+        $this->assertSame('5', $byCode['51,-1']);
+        $this->assertSame('1', $byCode['51.1,-1.1']);
+        $this->assertSame('2', $byCode['51.2,-1.2']);
+    }
+
+    public function test_imd_row_with_missing_code_column_is_skipped_without_error(): void
+    {
+        // Code column is second here, so a short (single-field) row leaves it
+        // unset — the parser must skip it rather than warning on an undefined
+        // array key.
+        $imdCsv = "UK_IMD_E_pop_quintile,lsoa\n3,E01000001\n5\n";
+
+        $ew = ['features' => [
+            ['attributes' => ['lsoa11cd' => 'E01000001'], 'geometry' => ['x' => -0.1, 'y' => 51.5]],
+        ]];
+
+        $this->fakeAll([
+            'raw.githubusercontent.com/*' => Http::response($imdCsv, 200),
+            'services1.arcgis.com/*' => Http::response($ew, 200),
+        ]);
+
+        $this->service->build($this->outputPath);
+
+        $rows = $this->readCsvRows();
+        $this->assertCount(1, $rows, 'the malformed "5" row must contribute nothing, not crash the run');
+        $this->assertSame('3', $rows[0][2]);
+    }
+
+    public function test_imd_csv_with_only_a_header_row_throws(): void
+    {
+        $this->fakeAll(['raw.githubusercontent.com/*' => Http::response("lsoa,UK_IMD_E_pop_quintile", 200)]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('IMD CSV has no data rows');
+
+        $this->service->build($this->outputPath);
+    }
+
+    public static function badImdHeaderProvider(): array
+    {
+        return [
+            'missing code column' => ["foo,bar\n1,2\n", "IMD CSV missing 'lsoa' or 'Code' column"],
+            'missing quintile/decile column' => ["lsoa,other\nE01000001,3\n", 'IMD CSV missing quintile or decile column'],
+        ];
+    }
+
+    #[DataProvider('badImdHeaderProvider')]
+    public function test_imd_csv_with_bad_header_throws(string $csv, string $expectedMessage): void
+    {
+        $this->fakeAll(['raw.githubusercontent.com/*' => Http::response($csv, 200)]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage($expectedMessage);
+
+        $this->service->build($this->outputPath);
+    }
+
+    // =========================================================================
+    // Upstream HTTP failures — each of the four hosts must abort the whole build
+    // =========================================================================
+
+    public static function httpFailureHostProvider(): array
+    {
+        return [
+            'IMD download' => ['raw.githubusercontent.com/*', 'Failed to download IMD CSV'],
+            'England & Wales ArcGIS' => ['services1.arcgis.com/*', 'E&W ArcGIS API failed'],
+            'Scotland ArcGIS' => ['maps.gov.scot/*', 'Scotland API failed'],
+            'Northern Ireland OpenData' => ['admin.opendatani.gov.uk/*', 'NI OpenData API failed'],
+        ];
+    }
+
+    #[DataProvider('httpFailureHostProvider')]
+    public function test_upstream_http_failure_throws(string $failingHost, string $expectedMessage): void
+    {
+        $this->fakeAll([$failingHost => Http::response('server error', 500)]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage($expectedMessage);
+
+        $this->service->build($this->outputPath);
+    }
+
+    public function test_ew_api_error_field_throws(): void
+    {
+        $this->fakeAll([
+            'services1.arcgis.com/*' => Http::response(['error' => ['code' => 400, 'message' => 'bad request']], 200),
+        ]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('E&W ArcGIS API error');
+
+        $this->service->build($this->outputPath);
+    }
+
+    // =========================================================================
+    // writeCsv — unwritable output path
+    // =========================================================================
+
+    // TODO: latent bug — writeCsv()'s `if (!$handle) throw new RuntimeException(...)`
+    // guard is unreachable: fopen() against a non-existent directory raises a PHP
+    // warning first, which Laravel's HandleExceptions bootstrap promotes to an
+    // ErrorException before the guard ever sees a false $handle. Callers expecting
+    // to catch RuntimeException from build() will not catch this. Not fixed here —
+    // this PR is test-only.
+    public function test_unwritable_output_path_throws(): void
+    {
+        $this->markTestSkipped(
+            'Latent bug: fopen() warning is promoted to ErrorException before the '
+            .'intended RuntimeException guard in writeCsv() can run — see TODO above.'
+        );
+    }
+}

--- a/iznik-batch/tests/Unit/Services/PollinationsServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/PollinationsServiceTest.php
@@ -1,0 +1,256 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Services\PollinationsService;
+use App\Services\TusService;
+use Illuminate\Support\Facades\DB;
+use PHPUnit\Framework\Attributes\DataProvider;
+use ReflectionClass;
+use Tests\TestCase;
+
+/**
+ * Covers PollinationsService's pure prompt/URL builders, the file-backed
+ * failure/hash caches (via the real cache file paths — reflected out of the
+ * private constants so tests stay in sync if they ever change), the GD
+ * duotone filter, and uploadImageAndCache()'s three branches (duotone
+ * failure / TUS failure / success) via TusService::fake().
+ *
+ * fetchBatch()'s network body and checkForPeople()'s OpenAI call are not
+ * covered beyond their early-return guards: both talk to the outside world
+ * via file_get_contents()/curl directly (no injectable HTTP client), so
+ * exercising their request/response branches would mean hitting real
+ * external services — out of scope for a unit test.
+ */
+class PollinationsServiceTest extends TestCase
+{
+    private PollinationsService $service;
+
+    private string $failedCacheFile;
+
+    private string $hashCacheFile;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new PollinationsService(new TusService('https://test-tus-server.example.com'));
+
+        $ref = new ReflectionClass(PollinationsService::class);
+        $this->failedCacheFile = $ref->getConstant('FAILED_CACHE_FILE');
+        $this->hashCacheFile = $ref->getConstant('HASH_CACHE_FILE');
+        $this->clearCacheFiles();
+    }
+
+    protected function tearDown(): void
+    {
+        TusService::clearFake();
+        $this->clearCacheFiles();
+        parent::tearDown();
+    }
+
+    private function clearCacheFiles(): void
+    {
+        foreach ([$this->failedCacheFile, $this->hashCacheFile] as $f) {
+            if (file_exists($f)) {
+                unlink($f);
+            }
+        }
+    }
+
+    /** A minimal valid PNG, generated with GD, as raw string data. */
+    private function tinyPng(): string
+    {
+        $img = imagecreatetruecolor(4, 4);
+        imagefill($img, 0, 0, imagecolorallocate($img, 120, 60, 200));
+        ob_start();
+        imagepng($img);
+        $data = ob_get_clean();
+        imagedestroy($img);
+        return $data;
+    }
+
+    // =========================================================================
+    // Prompt / URL builders — pure functions
+    // =========================================================================
+
+    public static function promptStrippingProvider(): array
+    {
+        return [
+            'plain name' => ['wooden chair', 'wooden chair'],
+            'strips CRITICAL: marker' => ['CRITICAL: wooden chair', ' wooden chair'],
+            'strips Draw only marker' => ['Draw only a red bicycle', ' a red bicycle'],
+            'strips both markers' => ['CRITICAL: Draw only a lamp', '  a lamp'],
+        ];
+    }
+
+    #[DataProvider('promptStrippingProvider')]
+    public function test_build_message_prompt_strips_control_markers(string $input, string $expectedClean): void
+    {
+        $prompt = $this->service->buildMessagePrompt($input);
+        $this->assertStringContainsString("single isolated {$expectedClean} centered on plain dark green background", $prompt);
+        $this->assertStringContainsString('UK audience', $prompt);
+    }
+
+    #[DataProvider('promptStrippingProvider')]
+    public function test_build_job_prompt_strips_control_markers(string $input, string $expectedClean): void
+    {
+        $prompt = $this->service->buildJobPrompt($input);
+        $this->assertStringContainsString("single isolated {$expectedClean} centered on plain dark green background", $prompt);
+        $this->assertStringContainsString('Square format', $prompt);
+    }
+
+    public function test_build_image_url_encodes_prompt_and_dimensions(): void
+    {
+        $url = $this->service->buildImageUrl('a red & blue chair', 640, 480);
+
+        $this->assertStringStartsWith('https://image.pollinations.ai/prompt/', $url);
+        $this->assertStringContainsString(rawurlencode('a red & blue chair'), $url);
+        $this->assertStringContainsString('width=640', $url);
+        $this->assertStringContainsString('height=480', $url);
+        $this->assertStringContainsString('nologo=true&model=flux', $url);
+        $this->assertMatchesRegularExpression('/seed=\d+/', $url);
+    }
+
+    // =========================================================================
+    // fetchBatch — the only branch reachable without real network I/O
+    // =========================================================================
+
+    public function test_fetch_batch_returns_empty_immediately_for_no_items(): void
+    {
+        $result = $this->service->fetchBatch([]);
+        $this->assertSame(['results' => [], 'failed' => []], $result);
+    }
+
+    // =========================================================================
+    // checkForPeople — only the "no API key configured" guard is reachable
+    // without a real OpenAI call.
+    // =========================================================================
+
+    public function test_check_for_people_returns_null_when_no_api_key_configured(): void
+    {
+        config(['services.openai.key' => null]);
+        $this->assertNull($this->service->checkForPeople('irrelevant image bytes', 'test item'));
+    }
+
+    // =========================================================================
+    // Failure cache — shouldSkipItem() / recordFailure()
+    // =========================================================================
+
+    public function test_should_skip_item_is_false_with_no_cache_file(): void
+    {
+        $this->assertFalse($this->service->shouldSkipItem('never seen before'));
+    }
+
+    public function test_record_failure_returns_false_until_max_failures_reached(): void
+    {
+        $this->assertFalse($this->service->recordFailure('flaky item'));
+        $this->assertFalse($this->service->shouldSkipItem('flaky item'));
+
+        $this->assertFalse($this->service->recordFailure('flaky item'));
+        $this->assertFalse($this->service->shouldSkipItem('flaky item'));
+
+        // Third failure reaches MAX_FAILURES (3) — now it should be skipped.
+        $this->assertTrue($this->service->recordFailure('flaky item'));
+        $this->assertTrue($this->service->shouldSkipItem('flaky item'));
+    }
+
+    public function test_expired_failure_entries_are_not_counted(): void
+    {
+        // Write a failure cache entry whose timestamp is outside the 1-day expiry.
+        file_put_contents($this->failedCacheFile, json_encode([
+            'stale item' => ['count' => 5, 'timestamp' => time() - 172800], // 2 days ago
+        ]));
+
+        $this->assertFalse(
+            $this->service->shouldSkipItem('stale item'),
+            'an expired failure record must not count towards the skip threshold'
+        );
+    }
+
+    public function test_should_skip_item_false_for_corrupt_cache_file(): void
+    {
+        file_put_contents($this->failedCacheFile, 'not valid json {{{');
+        $this->assertFalse($this->service->shouldSkipItem('anything'));
+    }
+
+    // =========================================================================
+    // cacheImage — plain DB upsert
+    // =========================================================================
+
+    public function test_cache_image_upserts_ai_images_row(): void
+    {
+        $this->service->cacheImage('my-item', 'freegletusd-abc123', md5('some data'));
+
+        $this->assertDatabaseHas('ai_images', [
+            'name' => 'my-item',
+            'externaluid' => 'freegletusd-abc123',
+            'imagehash' => md5('some data'),
+        ]);
+
+        // Upsert on the same name must update, not duplicate.
+        $this->service->cacheImage('my-item', 'freegletusd-xyz999', md5('other data'));
+        $this->assertSame(1, DB::table('ai_images')->where('name', 'my-item')->count());
+        $this->assertDatabaseHas('ai_images', ['name' => 'my-item', 'externaluid' => 'freegletusd-xyz999']);
+    }
+
+    // =========================================================================
+    // applyDuotoneGreen — real GD image manipulation
+    // =========================================================================
+
+    public function test_apply_duotone_green_returns_valid_jpeg_for_valid_image(): void
+    {
+        $result = $this->service->applyDuotoneGreen($this->tinyPng());
+
+        $this->assertNotFalse($result);
+        // JPEG magic bytes.
+        $this->assertSame("\xFF\xD8", substr($result, 0, 2));
+    }
+
+    public function test_apply_duotone_green_returns_false_for_invalid_image_data(): void
+    {
+        $this->assertFalse($this->service->applyDuotoneGreen('not an image, just garbage bytes'));
+    }
+
+    // =========================================================================
+    // uploadImageAndCache — composes duotone + TusService::upload + cacheImage
+    // =========================================================================
+
+    public function test_upload_image_and_cache_returns_null_when_duotone_fails(): void
+    {
+        $result = $this->service->uploadImageAndCache('bad-item', 'garbage', md5('garbage'));
+
+        $this->assertNull($result);
+        $this->assertDatabaseMissing('ai_images', ['name' => 'bad-item']);
+    }
+
+    public function test_upload_image_and_cache_returns_null_when_tus_upload_fails(): void
+    {
+        TusService::fake([
+            ['status' => 500],
+        ]);
+
+        $result = $this->service->uploadImageAndCache('tus-fail-item', $this->tinyPng(), md5('hash-a'));
+
+        $this->assertNull($result);
+        $this->assertDatabaseMissing('ai_images', ['name' => 'tus-fail-item']);
+    }
+
+    public function test_upload_image_and_cache_succeeds_and_caches(): void
+    {
+        TusService::fake([
+            ['status' => 201, 'headers' => ['Location' => 'https://test-tus-server.example.com/files/img42']],
+            ['status' => 200, 'headers' => ['Upload-Offset' => '0']],
+            ['status' => 204],
+        ]);
+
+        $hash = md5('hash-b');
+        $result = $this->service->uploadImageAndCache('good-item', $this->tinyPng(), $hash);
+
+        $this->assertSame('freegletusd-img42', $result);
+        $this->assertDatabaseHas('ai_images', [
+            'name' => 'good-item',
+            'externaluid' => 'freegletusd-img42',
+            'imagehash' => $hash,
+        ]);
+    }
+}

--- a/iznik-batch/tests/Unit/Support/EloquentUtilsTest.php
+++ b/iznik-batch/tests/Unit/Support/EloquentUtilsTest.php
@@ -58,6 +58,13 @@ class EloquentUtilsTest extends TestCase
         $container = new Container;
         $container->instance('log', $this->logger);
         Facade::setFacadeApplication($container);
+
+        // Facades cache resolved instances statically, keyed by accessor name.
+        // If an earlier test in this process already resolved Log against the
+        // real (booted) app, that stale instance survives the swap above and
+        // EloquentUtils::reparentRow() would log through it instead of our
+        // fake logger - clear it so Log:: re-resolves against $container.
+        Facade::clearResolvedInstances();
     }
 
     protected function tearDown(): void

--- a/iznik-batch/tests/Unit/Support/EloquentUtilsTest.php
+++ b/iznik-batch/tests/Unit/Support/EloquentUtilsTest.php
@@ -1,0 +1,216 @@
+<?php
+
+namespace Tests\Unit\Support;
+
+use App\Support\EloquentUtils;
+use Illuminate\Container\Container;
+use Illuminate\Database\Capsule\Manager as Capsule;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Facade;
+use Illuminate\Support\Facades\Log;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\AbstractLogger;
+
+/**
+ * Standalone unit tests for EloquentUtils using an isolated in-memory SQLite
+ * connection (via Capsule) and a fake Log facade binding, so these never touch
+ * the shared MySQL test database.
+ */
+class EloquentUtilsTest extends TestCase
+{
+    private TestLoggerForEloquentUtils $logger;
+
+    /** @var mixed Facade app in effect before this test, restored in tearDown(). */
+    private mixed $previousFacadeApplication;
+
+    /** @var mixed Eloquent connection resolver in effect before this test, restored in tearDown(). */
+    private mixed $previousConnectionResolver;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->previousFacadeApplication = Facade::getFacadeApplication();
+        $this->previousConnectionResolver = Model::getConnectionResolver();
+
+        $capsule = new Capsule;
+        $capsule->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+        $capsule->setAsGlobal();
+        $capsule->bootEloquent();
+
+        $capsule::schema()->dropIfExists('reparent_plain');
+        $capsule::schema()->create('reparent_plain', function ($table) {
+            $table->increments('id');
+            $table->unsignedInteger('parent_id');
+        });
+
+        $capsule::schema()->dropIfExists('reparent_unique');
+        $capsule::schema()->create('reparent_unique', function ($table) {
+            $table->increments('id');
+            $table->unsignedInteger('parent_id')->unique();
+        });
+
+        $this->logger = new TestLoggerForEloquentUtils;
+        $container = new Container;
+        $container->instance('log', $this->logger);
+        Facade::setFacadeApplication($container);
+    }
+
+    protected function tearDown(): void
+    {
+        // Restore whatever facade application (Laravel's real app, or none) and
+        // Eloquent connection resolver were in effect before this test, so other
+        // tests in the same PHPUnit process don't resolve facades/models against
+        // this test's throwaway sqlite container.
+        Facade::setFacadeApplication($this->previousFacadeApplication);
+        Facade::clearResolvedInstances();
+        if ($this->previousConnectionResolver !== null) {
+            Model::setConnectionResolver($this->previousConnectionResolver);
+        } else {
+            Model::unsetConnectionResolver();
+        }
+        parent::tearDown();
+    }
+
+    public function test_reparent_row_updates_the_matching_row(): void
+    {
+        ReparentPlainModel::create(['parent_id' => 5]);
+
+        EloquentUtils::reparentRow(ReparentPlainModel::class, 'parent_id', 5, 99);
+
+        $this->assertSame(0, ReparentPlainModel::where('parent_id', 5)->count());
+        $this->assertSame(1, ReparentPlainModel::where('parent_id', 99)->count());
+    }
+
+    public function test_reparent_row_updates_all_matching_rows(): void
+    {
+        ReparentPlainModel::create(['parent_id' => 5]);
+        ReparentPlainModel::create(['parent_id' => 5]);
+        ReparentPlainModel::create(['parent_id' => 5]);
+
+        EloquentUtils::reparentRow(ReparentPlainModel::class, 'parent_id', 5, 99);
+
+        $this->assertSame(0, ReparentPlainModel::where('parent_id', 5)->count());
+        $this->assertSame(3, ReparentPlainModel::where('parent_id', 99)->count());
+    }
+
+    public function test_reparent_row_does_not_persist_when_dry_run(): void
+    {
+        ReparentPlainModel::create(['parent_id' => 5]);
+
+        EloquentUtils::reparentRow(ReparentPlainModel::class, 'parent_id', 5, 99, true);
+
+        $this->assertSame(1, ReparentPlainModel::where('parent_id', 5)->count());
+        $this->assertSame(0, ReparentPlainModel::where('parent_id', 99)->count());
+    }
+
+    public function test_reparent_row_is_a_noop_when_nothing_matches(): void
+    {
+        ReparentPlainModel::create(['parent_id' => 1]);
+
+        EloquentUtils::reparentRow(ReparentPlainModel::class, 'parent_id', 5, 99);
+
+        $this->assertSame(1, ReparentPlainModel::where('parent_id', 1)->count());
+        $this->assertSame(0, ReparentPlainModel::where('parent_id', 99)->count());
+    }
+
+    public function test_reparent_row_logs_the_write_it_is_about_to_make(): void
+    {
+        ReparentPlainModel::create(['parent_id' => 5]);
+
+        EloquentUtils::reparentRow(ReparentPlainModel::class, 'parent_id', 5, 99);
+
+        $this->assertNotEmpty($this->logger->logs);
+        [$level, $message] = $this->logger->logs[0];
+        $this->assertSame('info', $level);
+        $this->assertStringContainsString('parent_id=5', $message);
+        $this->assertStringContainsString('parent_id=99', $message);
+    }
+
+    public function test_reparent_row_ignore_updates_the_matching_row_when_no_conflict(): void
+    {
+        ReparentIgnoreModel::create(['parent_id' => 5]);
+
+        EloquentUtils::reparentRowIgnore(ReparentIgnoreModel::class, 'parent_id', 5, 99);
+
+        $this->assertSame(0, ReparentIgnoreModel::where('parent_id', 5)->count());
+        $this->assertSame(1, ReparentIgnoreModel::where('parent_id', 99)->count());
+        $this->assertEmpty($this->logger->logs('warning'));
+    }
+
+    public function test_reparent_row_ignore_does_not_persist_when_dry_run(): void
+    {
+        ReparentIgnoreModel::create(['parent_id' => 5]);
+
+        EloquentUtils::reparentRowIgnore(ReparentIgnoreModel::class, 'parent_id', 5, 99, true);
+
+        $this->assertSame(1, ReparentIgnoreModel::where('parent_id', 5)->count());
+        $this->assertSame(0, ReparentIgnoreModel::where('parent_id', 99)->count());
+        $this->assertEmpty($this->logger->logs('warning'));
+    }
+
+    public function test_reparent_row_ignore_suppresses_a_unique_constraint_conflict(): void
+    {
+        // The row being reparented from 5 would collide with a pre-existing,
+        // unrelated row that already occupies the target value 99. The save()
+        // must be swallowed rather than throwing, leaving both rows as they were.
+        $row = ReparentIgnoreModel::create(['parent_id' => 5]);
+        $occupant = ReparentIgnoreModel::create(['parent_id' => 99]);
+
+        EloquentUtils::reparentRowIgnore(ReparentIgnoreModel::class, 'parent_id', 5, 99);
+
+        $this->assertSame(5, $row->fresh()->parent_id);
+        $this->assertSame(99, $occupant->fresh()->parent_id);
+        $this->assertSame(1, ReparentIgnoreModel::where('parent_id', 5)->count());
+        $this->assertSame(1, ReparentIgnoreModel::where('parent_id', 99)->count());
+
+        $warnings = $this->logger->logs('warning');
+        $this->assertCount(1, $warnings);
+        $this->assertStringContainsString('Reparent conflict', $warnings[0]);
+        $this->assertStringContainsString(ReparentIgnoreModel::class, $warnings[0]);
+    }
+}
+
+class ReparentPlainModel extends Model
+{
+    protected $table = 'reparent_plain';
+
+    public $timestamps = false;
+
+    protected $guarded = [];
+}
+
+class ReparentIgnoreModel extends Model
+{
+    protected $table = 'reparent_unique';
+
+    public $timestamps = false;
+
+    protected $guarded = [];
+}
+
+class TestLoggerForEloquentUtils extends AbstractLogger
+{
+    /** @var array<int, array{0: string, 1: string}> */
+    public array $logs = [];
+
+    public function log($level, $message, array $context = []): void
+    {
+        $this->logs[] = [(string) $level, (string) $message];
+    }
+
+    /**
+     * @return string[]
+     */
+    public function logs(string $level): array
+    {
+        return array_values(array_map(
+            fn ($entry) => $entry[1],
+            array_filter($this->logs, fn ($entry) => $entry[0] === $level)
+        ));
+    }
+}

--- a/iznik-nuxt3/components/WhichPostsExplanation.vue
+++ b/iznik-nuxt3/components/WhichPostsExplanation.vue
@@ -40,6 +40,22 @@
       come across one that hasn't reached you quite yet - you'll be able to
       reply as soon as it does.
     </p>
+    <h5>Why don't I see posts that are too far away?</h5>
+    <p>
+      You decide how far away posts can be, using the <strong>distance slider</strong>
+      - both here above the map and in your
+      <nuxt-link no-prefetch to="/settings">settings</nuxt-link> under
+      <strong>Feed</strong>. Anything further away than that won't show up on
+      Browse or in the emails we send you. Drag towards "Further" to cast a wider
+      net, or "Nearer" to keep things local.
+    </p>
+    <h5>Why is my post shown to only some people nearby?</h5>
+    <p>
+      When your post reaches a neighbouring community, it's shown to the freeglers
+      there who are closest to you and who've chosen to see posts from that far
+      away - not necessarily everyone in that community. That keeps it relevant,
+      so it reaches the people most likely to want your item.
+    </p>
   </div>
 </template>
 <script setup></script>

--- a/iznik-nuxt3/components/settings/FeedSettingsSection.vue
+++ b/iznik-nuxt3/components/settings/FeedSettingsSection.vue
@@ -26,8 +26,6 @@
         aria-label="How far away"
         @change="onSliderChange"
       />
-
-      <p class="readout mt-2 mb-0">{{ readout }}</p>
     </div>
   </div>
 </template>
@@ -67,15 +65,9 @@ watch(maxDistance, (d) => {
   sliderValue.value = sliderPositionFor(d, feedMax)
 })
 
-// Live readout follows the drag (RangeSlider updates v-model on every tick).
-const readout = computed(() => {
-  const v = sliderValue.value
-  if (v >= feedMax) {
-    return 'Showing posts at any distance.'
-  }
-  return `Showing posts within ${v} ${v === 1 ? 'mile' : 'miles'}.`
-})
-
+// Deliberately no numeric readout - the Nearer/Further labels are enough, and a
+// per-tick "within N miles" text made the drag janky (matches the browse slider,
+// which is numeric-readout-free for the same reason).
 // Only persist on release/keyup (RangeSlider's `change`), not every drag tick.
 async function onSliderChange(val) {
   const settings = me.value?.settings
@@ -136,11 +128,5 @@ async function onSliderChange(val) {
 .option-desc {
   font-size: 0.8rem;
   color: var(--color-gray-600);
-}
-
-.readout {
-  font-size: 0.8rem;
-  font-weight: 600;
-  color: $color-green-background;
 }
 </style>

--- a/iznik-nuxt3/components/settings/FeedSettingsSection.vue
+++ b/iznik-nuxt3/components/settings/FeedSettingsSection.vue
@@ -1,0 +1,146 @@
+<template>
+  <div class="settings-section">
+    <div class="section-header">
+      <v-icon icon="sliders" class="section-icon" />
+      <h2>Feed</h2>
+    </div>
+
+    <div class="section-content">
+      <div class="option-info mb-2">
+        <span class="option-label">How far away</span>
+        <span class="option-desc">
+          How far away posts can be &mdash; this applies both when you browse
+          <em>and</em> to the posts in the emails we send you. Drag towards
+          <strong>Nearer</strong> to see only nearby posts, or
+          <strong>Further</strong> for no distance limit.
+        </span>
+      </div>
+
+      <RangeSlider
+        v-model="sliderValue"
+        :min="0.5"
+        :max="feedMax"
+        :step="0.5"
+        left-label="Nearer"
+        right-label="Further"
+        aria-label="How far away"
+        @change="onSliderChange"
+      />
+
+      <p class="readout mt-2 mb-0">{{ readout }}</p>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, watch, defineEmits } from 'vue'
+import { useAuthStore } from '~/stores/auth'
+import { useMe } from '~/composables/useMe'
+import RangeSlider from '~/components/RangeSlider.vue'
+import { BROWSE_DISTANCE_UNLIMITED } from '~/constants'
+
+const emit = defineEmits(['update'])
+
+const authStore = useAuthStore()
+const { me } = useMe()
+
+// The browse filter's slider scales its max to the current feed's extent. There's
+// no feed here, so we use a fixed extent; the far-right stop always means "no
+// distance limit" (BROWSE_DISTANCE_UNLIMITED), matching the browse behaviour.
+const feedMax = 30
+
+const maxDistance = computed(
+  () => me.value?.settings?.browseMaxDistance ?? BROWSE_DISTANCE_UNLIMITED
+)
+
+// Far-right when unlimited, or when a saved value is at/above our fixed extent
+// (e.g. it was set from a wider browse feed); otherwise the real mile value.
+function sliderPositionFor(distance, max) {
+  return distance === BROWSE_DISTANCE_UNLIMITED || distance >= max
+    ? max
+    : distance
+}
+
+const sliderValue = ref(sliderPositionFor(maxDistance.value, feedMax))
+
+watch(maxDistance, (d) => {
+  sliderValue.value = sliderPositionFor(d, feedMax)
+})
+
+// Live readout follows the drag (RangeSlider updates v-model on every tick).
+const readout = computed(() => {
+  const v = sliderValue.value
+  if (v >= feedMax) {
+    return 'Showing posts at any distance.'
+  }
+  return `Showing posts within ${v} ${v === 1 ? 'mile' : 'miles'}.`
+})
+
+// Only persist on release/keyup (RangeSlider's `change`), not every drag tick.
+async function onSliderChange(val) {
+  const settings = me.value?.settings
+  if (!settings) {
+    return
+  }
+  settings.browseMaxDistance = val >= feedMax ? BROWSE_DISTANCE_UNLIMITED : val
+  await authStore.saveAndGet({ settings })
+  emit('update')
+}
+</script>
+
+<style scoped lang="scss">
+@import 'assets/css/_color-vars.scss';
+
+.settings-section {
+  background: white;
+  border-radius: var(--radius-lg, 0.75rem);
+  box-shadow: var(--shadow-md);
+  margin-bottom: 1rem;
+  overflow: hidden;
+}
+
+.section-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+
+  h2 {
+    margin: 0;
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: $color-green-background;
+  }
+
+  .section-icon {
+    color: $color-green-background;
+  }
+}
+
+.section-content {
+  padding: 1rem 1.25rem;
+}
+
+.option-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+}
+
+.option-label {
+  font-weight: 500;
+  font-size: 0.95rem;
+}
+
+.option-desc {
+  font-size: 0.8rem;
+  color: var(--color-gray-600);
+}
+
+.readout {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: $color-green-background;
+}
+</style>

--- a/iznik-nuxt3/pages/settings/index.vue
+++ b/iznik-nuxt3/pages/settings/index.vue
@@ -13,6 +13,7 @@
           @show-email-confirm-modal="showEmailConfirmModal = true"
         />
         <AddressBookSection @show-address-modal="showAddressModal = true" />
+        <FeedSettingsSection @update="updateMe" />
         <EmailSettingsSection @update="updateMe" />
         <AppNotificationsSection @update="updateMe" />
         <OtherSettingsSection @update="updateMe" />
@@ -50,6 +51,7 @@ import { buildHead } from '~/composables/useBuildHead'
 import ProfileSection from '~/components/settings/ProfileSection.vue'
 import AccountSection from '~/components/settings/AccountSection.vue'
 import AddressBookSection from '~/components/settings/AddressBookSection.vue'
+import FeedSettingsSection from '~/components/settings/FeedSettingsSection.vue'
 import EmailSettingsSection from '~/components/settings/EmailSettingsSection.vue'
 import AppNotificationsSection from '~/components/settings/AppNotificationsSection.vue'
 import OtherSettingsSection from '~/components/settings/OtherSettingsSection.vue'

--- a/iznik-nuxt3/tests/unit/components/settings/FeedSettingsSection.spec.js
+++ b/iznik-nuxt3/tests/unit/components/settings/FeedSettingsSection.spec.js
@@ -48,14 +48,10 @@ describe('FeedSettingsSection', () => {
     expect(wrapper.text().toLowerCase()).toContain('emails')
   })
 
-  it('reads a saved mile value into the readout', () => {
+  it('has no numeric miles readout (matches the browse slider; avoids janky drag)', () => {
     const wrapper = mountWith(3)
-    expect(wrapper.text()).toContain('Showing posts within 3 miles.')
-  })
-
-  it('shows "any distance" when unlimited', () => {
-    const wrapper = mountWith(BROWSE_DISTANCE_UNLIMITED)
-    expect(wrapper.text()).toContain('Showing posts at any distance.')
+    expect(wrapper.text()).not.toContain('miles')
+    expect(wrapper.text()).not.toContain('any distance')
   })
 
   it('persists a chosen mile value via saveAndGet', async () => {

--- a/iznik-nuxt3/tests/unit/components/settings/FeedSettingsSection.spec.js
+++ b/iznik-nuxt3/tests/unit/components/settings/FeedSettingsSection.spec.js
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { ref } from 'vue'
+import FeedSettingsSection from '~/components/settings/FeedSettingsSection.vue'
+import { BROWSE_DISTANCE_UNLIMITED } from '~/constants'
+
+const saveAndGet = vi.fn().mockResolvedValue({})
+const me = ref({ settings: { browseMaxDistance: BROWSE_DISTANCE_UNLIMITED } })
+
+vi.mock('~/stores/auth', () => ({
+  useAuthStore: () => ({ saveAndGet }),
+}))
+
+vi.mock('~/composables/useMe', () => ({
+  useMe: () => ({ me }),
+}))
+
+vi.mock('~/components/RangeSlider.vue', () => ({
+  default: {
+    name: 'RangeSlider',
+    props: ['modelValue', 'min', 'max', 'step'],
+    emits: ['update:modelValue', 'change'],
+    template: '<div class="range-slider" />',
+  },
+}))
+
+function mountWith(browseMaxDistance) {
+  me.value = { settings: { browseMaxDistance } }
+  return mount(FeedSettingsSection, {
+    global: { stubs: { 'v-icon': true, 'nuxt-link': true } },
+  })
+}
+
+const slider = (wrapper) => wrapper.findComponent({ name: 'RangeSlider' })
+
+describe('FeedSettingsSection', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('renders the Feed section with a slider', () => {
+    const wrapper = mountWith(BROWSE_DISTANCE_UNLIMITED)
+    expect(wrapper.text()).toContain('Feed')
+    expect(wrapper.find('.range-slider').exists()).toBe(true)
+  })
+
+  it('explains it applies to both browse and emails', () => {
+    const wrapper = mountWith(BROWSE_DISTANCE_UNLIMITED)
+    expect(wrapper.text()).toContain('browse')
+    expect(wrapper.text().toLowerCase()).toContain('emails')
+  })
+
+  it('reads a saved mile value into the readout', () => {
+    const wrapper = mountWith(3)
+    expect(wrapper.text()).toContain('Showing posts within 3 miles.')
+  })
+
+  it('shows "any distance" when unlimited', () => {
+    const wrapper = mountWith(BROWSE_DISTANCE_UNLIMITED)
+    expect(wrapper.text()).toContain('Showing posts at any distance.')
+  })
+
+  it('persists a chosen mile value via saveAndGet', async () => {
+    const wrapper = mountWith(BROWSE_DISTANCE_UNLIMITED)
+    await slider(wrapper).vm.$emit('change', 5)
+    expect(saveAndGet).toHaveBeenCalledTimes(1)
+    expect(me.value.settings.browseMaxDistance).toBe(5)
+  })
+
+  it('stores the unlimited sentinel when dragged to the far end', async () => {
+    const wrapper = mountWith(2)
+    await slider(wrapper).vm.$emit('change', 30)
+    expect(me.value.settings.browseMaxDistance).toBe(BROWSE_DISTANCE_UNLIMITED)
+  })
+})

--- a/iznik-nuxt3/tests/unit/composables/useFreegleQr.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useFreegleQr.spec.js
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+  freegleQrOptions,
+  createFreegleQr,
+  downloadFreegleQr,
+} from '~/composables/useFreegleQr'
+
+const mockDownload = vi.fn()
+const MockQRCodeStyling = vi.fn().mockImplementation(() => ({
+  download: mockDownload,
+}))
+
+vi.mock('qr-code-styling', () => ({
+  default: MockQRCodeStyling,
+}))
+
+describe('freegleQrOptions', () => {
+  it('uses the given data verbatim when non-empty', () => {
+    const options = freegleQrOptions('https://ilovefreegle.org/some/path')
+    expect(options.data).toBe('https://ilovefreegle.org/some/path')
+  })
+
+  it.each([[undefined], [null], ['']])(
+    'falls back to a single space when data is %p (qr-code-styling errors on empty data)',
+    (data) => {
+      expect(freegleQrOptions(data).data).toBe(' ')
+    }
+  )
+
+  it('sets Freegle brand styling and high error correction for the embedded logo', () => {
+    const options = freegleQrOptions('data')
+    expect(options.qrOptions.errorCorrectionLevel).toBe('H')
+    expect(options.image).toBe('/icon.png')
+    expect(options.width).toBe(320)
+    expect(options.height).toBe(320)
+    expect(options.dotsOptions.color).toBe('#61AE24')
+    expect(options.cornersSquareOptions.color).toBe('#3B8070')
+  })
+})
+
+describe('createFreegleQr', () => {
+  beforeEach(() => {
+    MockQRCodeStyling.mockClear()
+    mockDownload.mockClear()
+  })
+
+  it('constructs a QRCodeStyling instance using freegleQrOptions for the data', async () => {
+    await createFreegleQr('hello')
+
+    expect(MockQRCodeStyling).toHaveBeenCalledTimes(1)
+    const passedOptions = MockQRCodeStyling.mock.calls[0][0]
+    expect(passedOptions.data).toBe('hello')
+  })
+})
+
+describe('downloadFreegleQr', () => {
+  beforeEach(() => {
+    MockQRCodeStyling.mockClear()
+    mockDownload.mockClear()
+  })
+
+  it('downloads a PNG with the default name when none is given', async () => {
+    await downloadFreegleQr('some-data')
+
+    expect(mockDownload).toHaveBeenCalledWith({
+      name: 'freegle-qr',
+      extension: 'png',
+    })
+  })
+
+  it('downloads a PNG using the given name', async () => {
+    await downloadFreegleQr('some-data', 'my-custom-name')
+
+    expect(mockDownload).toHaveBeenCalledWith({
+      name: 'my-custom-name',
+      extension: 'png',
+    })
+  })
+})

--- a/iznik-nuxt3/tests/unit/composables/usePersonalInfoWarning.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/usePersonalInfoWarning.spec.js
@@ -1,0 +1,165 @@
+import { describe, it, expect } from 'vitest'
+import { ref } from 'vue'
+import {
+  detectPersonalInfo,
+  groupRestrictsPersonalInfo,
+  usePersonalInfoWarning,
+} from '~/composables/usePersonalInfoWarning'
+
+describe('detectPersonalInfo', () => {
+  it('returns no phone/email for empty/falsy text', () => {
+    expect(detectPersonalInfo('')).toEqual({ hasPhone: false, hasEmail: false })
+    expect(detectPersonalInfo(null)).toEqual({
+      hasPhone: false,
+      hasEmail: false,
+    })
+    expect(detectPersonalInfo(undefined)).toEqual({
+      hasPhone: false,
+      hasEmail: false,
+    })
+  })
+
+  it('returns no phone/email for plain text with neither', () => {
+    expect(detectPersonalInfo('Free to a good home, one sofa')).toEqual({
+      hasPhone: false,
+      hasEmail: false,
+    })
+  })
+
+  it.each([
+    ['leading zero UK mobile', 'Call me on 07911123456 please'],
+    ['+44 prefix', 'Call me on +447911123456 please'],
+    ['+44 with space', 'Call me on +44 7911123456 please'],
+    ['0044 prefix', 'Call me on 00447911123456 please'],
+    ['spaced digits', 'Call me on 0791 112 3456 please'],
+    ['hyphenated digits', 'Call me on 0791-112-3456 please'],
+    ['landline 10 digit', 'Call 01611234567 today'],
+  ])('detects a UK phone number: %s', (_label, text) => {
+    expect(detectPersonalInfo(text).hasPhone).toBe(true)
+  })
+
+  it('does not detect a phone number in an ordinary number sequence', () => {
+    expect(detectPersonalInfo('It weighs about 123 grams').hasPhone).toBe(false)
+  })
+
+  it('detects an external email address as hasEmail true', () => {
+    const result = detectPersonalInfo('Reach me at bob@example.com thanks')
+    expect(result.hasEmail).toBe(true)
+  })
+
+  it('is case-insensitive when matching freegle domains', () => {
+    const result = detectPersonalInfo('Email me at Bob@ILoveFreegle.ORG')
+    expect(result.hasEmail).toBe(false)
+  })
+
+  it.each([
+    ['ilovefreegle.org', 'contact bob@ilovefreegle.org now'],
+    ['trashnothing', 'contact bob@trashnothing.com now'],
+    ['yahoogroups', 'contact bob@yahoogroups.com now'],
+  ])('does not flag freegle-owned email domain: %s', (_label, text) => {
+    expect(detectPersonalInfo(text).hasEmail).toBe(false)
+  })
+
+  it('does not detect an email when there is none', () => {
+    expect(detectPersonalInfo('no contact info here').hasEmail).toBe(false)
+  })
+
+  it('detects both a phone and an external email in the same text', () => {
+    const result = detectPersonalInfo(
+      'Call 07911123456 or email bob@example.com'
+    )
+    expect(result).toEqual({ hasPhone: true, hasEmail: true })
+  })
+})
+
+describe('groupRestrictsPersonalInfo', () => {
+  it('returns false when there is no group', () => {
+    expect(groupRestrictsPersonalInfo(null)).toBe(false)
+    expect(groupRestrictsPersonalInfo(undefined)).toBe(false)
+  })
+
+  it('returns false when the group has no rules', () => {
+    expect(groupRestrictsPersonalInfo({})).toBe(false)
+    expect(groupRestrictsPersonalInfo({ rules: null })).toBe(false)
+    expect(groupRestrictsPersonalInfo({ rules: '' })).toBe(false)
+  })
+
+  it('returns false when rules is a string that fails to parse as JSON', () => {
+    expect(groupRestrictsPersonalInfo({ rules: '{not valid json' })).toBe(false)
+  })
+
+  it('parses a JSON string rules value and reads restrictpersonalinfo', () => {
+    expect(
+      groupRestrictsPersonalInfo({
+        rules: JSON.stringify({ restrictpersonalinfo: true }),
+      })
+    ).toBe(true)
+    expect(
+      groupRestrictsPersonalInfo({
+        rules: JSON.stringify({ restrictpersonalinfo: false }),
+      })
+    ).toBe(false)
+  })
+
+  it('reads restrictpersonalinfo directly when rules is already an object', () => {
+    expect(
+      groupRestrictsPersonalInfo({ rules: { restrictpersonalinfo: true } })
+    ).toBe(true)
+  })
+
+  it('returns false when rules is an object without restrictpersonalinfo', () => {
+    expect(groupRestrictsPersonalInfo({ rules: { somethingElse: true } })).toBe(
+      false
+    )
+  })
+})
+
+describe('usePersonalInfoWarning', () => {
+  it('is false when the group does not restrict personal info, regardless of text', () => {
+    const group = ref({ rules: { restrictpersonalinfo: false } })
+    const text = ref('Call me on 07911123456')
+    const warning = usePersonalInfoWarning(group, text)
+    expect(warning.value).toBe(false)
+  })
+
+  it('is false when the group restricts personal info but the text has none', () => {
+    const group = ref({ rules: { restrictpersonalinfo: true } })
+    const text = ref('Free to a good home')
+    const warning = usePersonalInfoWarning(group, text)
+    expect(warning.value).toBe(false)
+  })
+
+  it('is true when the group restricts personal info and the text has a phone number', () => {
+    const group = ref({ rules: { restrictpersonalinfo: true } })
+    const text = ref('Call me on 07911123456')
+    const warning = usePersonalInfoWarning(group, text)
+    expect(warning.value).toBe(true)
+  })
+
+  it('is true when the group restricts personal info and the text has an external email', () => {
+    const group = ref({ rules: { restrictpersonalinfo: true } })
+    const text = ref('Email bob@example.com')
+    const warning = usePersonalInfoWarning(group, text)
+    expect(warning.value).toBe(true)
+  })
+
+  it('is reactive to changes in the text ref', () => {
+    const group = ref({ rules: { restrictpersonalinfo: true } })
+    const text = ref('nothing to see here')
+    const warning = usePersonalInfoWarning(group, text)
+    expect(warning.value).toBe(false)
+
+    text.value = 'call 07911123456'
+    expect(warning.value).toBe(true)
+  })
+
+  it('is reactive to changes in the group ref', () => {
+    const group = ref(null)
+    const text = ref('call 07911123456')
+    const warning = usePersonalInfoWarning(group, text)
+    expect(warning.value).toBe(false)
+
+    group.value = { rules: { restrictpersonalinfo: true } }
+    expect(warning.value).toBe(true)
+  })
+})


### PR DESCRIPTION
Surfaces and explains the browse **distance preference** (`settings.browseMaxDistance`) more widely. The filtering itself — browse + digest/immediate emails — already exists on master (`DistancePreferenceFilter`); this adds the missing UX and wording.

## Changes
- **New "Feed" settings section** (above Email Settings) with the distance slider — makes clear it applies **both to browsing and to the posts we email you**. Deliberately no numeric distance readout — just the Nearer/Further labels, matching the browse slider. (Placement per request: a dedicated Feed section above Email Settings.)
- **Ripple intro email** ("your post is reaching more people"): clarifies the post is shown to the freeglers **nearest** the poster — *not everyone* in those communities — and mentions each freegler's distance setting. (mjml + text.)
- **Help explainer** (`WhichPostsExplanation`, shown on `/help` and the browse "how does this work?" modal): adds "Why don't I see posts that are too far away?" and "Why is my post shown to only some people nearby?".
- **`RIPPLING-OUT-FOR-MODERATORS.md`**: the slider is now in Settings too and filters emails as well as browse; a rippled-in post reaches only members close enough / whose distance preference reaches that far.

## Verification
- `FeedSettingsSection.spec.js` — 5 tests (renders, explains browse+email scope, asserts there is no numeric miles readout, persists via saveAndGet, stores the unlimited sentinel at the far end). Passing locally.
- Feed section verified live in the settings page (renders above Email Settings; Nearer/Further labels only, no numeric readout). eslint clean.

## Coverage
Coveralls' coverage-delta checks (`Coveralls - laravel`, `Coveralls - vitest`) were red on a sub-0.1% run-to-run dip unrelated to this PR's own changed lines (already covered). Added real, substantial tests for previously fully-untested (0% coverage) modules to lift each suite's global coverage back above that noise floor:
- `usePersonalInfoWarning.spec.js` — 29 tests covering `detectPersonalInfo`, `groupRestrictsPersonalInfo` and the `usePersonalInfoWarning` computed (UK phone/email detection, freegle-domain exclusion, group rule parsing incl. invalid JSON, reactivity). 0% → 100% line/branch coverage.
- `useFreegleQr.spec.js` — 8 tests covering `freegleQrOptions`, `createFreegleQr`, `downloadFreegleQr` (default/custom data, empty-data fallback, brand styling, download naming). 0% → 100% coverage.
- `EloquentUtilsTest.php` — 8 tests covering `App\Support\EloquentUtils::reparentRow` / `reparentRowIgnore` (bulk update, dry-run, no-op, unique-constraint conflict suppression + logging). 0% → 100% method/line coverage. Runs against an isolated in-memory SQLite connection with a fake Log facade binding rather than the shared `iznik_batch_test` database, restoring the prior Facade app / Eloquent connection resolver in `tearDown()` so it can't leak state into other tests in the same PHPUnit process.
- The Coveralls-laravel check was still red after the above (-0.006%, still noise-level), so two more previously 0%-covered Laravel services were added:
  - `DeprivationDataServiceTest.php` — 15 tests driving `DeprivationDataService::build()` end-to-end through the `Http` facade: England & Wales / Scotland ArcGIS pagination and per-feature skips (missing geometry, unmatched code), Northern Ireland polygon-centroid computation (Polygon, MultiPolygon largest-ring selection, degenerate zero-area fallback) plus the Irish Grid → WGS84 transform, the IMD quintile/decile-fallback CSV parser (blank lines, malformed rows, out-of-range quintiles, missing columns), and every upstream HTTP-failure path. 170 statements, 0% → 98.8% covered. One test documents a latent bug found (not fixed, per this being a test-only PR): `writeCsv()`'s `RuntimeException` guard on a failed `fopen()` is unreachable because Laravel's `HandleExceptions` promotes the underlying PHP warning to an `ErrorException` first — the test is skipped with a `// TODO: latent bug` marker rather than asserting the wrong exception type.
  - `PollinationsServiceTest.php` — 21 tests covering the prompt/URL builders, the file-backed failure/hash caches (max-failure threshold, expiry, corrupt-file handling), `cacheImage`'s DB upsert, the GD duotone-filter (valid/invalid image data), and `uploadImageAndCache`'s three branches (duotone failure / TUS failure / success) via `TusService::fake()`. 226 statements, 0% → 38.9% covered — `fetchBatch()`'s network loop and `checkForPeople()`'s OpenAI call have no injectable HTTP seam (raw `file_get_contents`/`curl`), so only their early-return guards are covered; the rest would require hitting real external services.
  - Combined effect of these two: +252 covered statements, lifting suite-wide Laravel coverage 68.18% → 68.87% (+0.69pp).

Note: the mobile placement of the slider (above Offer/Wanted in the browse filter) is in the separate browse-filter PR #968.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

