### PR TITLE
fix(microvolunteering): stop notification store caching stale seen status (Discourse 9856)

### DIFF
--- a/iznik-nuxt3/stores/notification.js
+++ b/iznik-nuxt3/stores/notification.js
@@ -37,10 +37,12 @@ export const useNotificationStore = defineStore({
         this.list = await api(this.config).notification.list()
 
         this.list.forEach((item) => {
-          // Notifications are immutable so we can avoid triggering a re-render.
-          if (!this.listById[item.id]) {
-            this.listById[item.id] = item
-          }
+          // seen (and other fields, e.g. via allSeen/PostResponse marking a
+          // stale Exhort notification seen server-side) can change between
+          // fetches, so always take the latest copy rather than the first one
+          // seen — else the indicator/highlight for an already-actioned
+          // notification never clears within the same browser session.
+          this.listById[item.id] = item
         })
 
         return this.list

--- a/iznik-nuxt3/tests/unit/stores/notification.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/notification.spec.js
@@ -112,14 +112,21 @@ describe('notification store', () => {
       expect(store.listById[2].title).toBe('Notif 2')
     })
 
-    it('does not overwrite existing listById entries', async () => {
+    it('picks up the latest seen status on refetch (Discourse 9856)', async () => {
+      // The server just marked this notification seen (e.g. the user reviewed
+      // the microvolunteering post it points at), but a stale cached copy from
+      // an earlier fetchList() would keep reporting seen: false forever, so
+      // the notification indicator (and re-servable "post to check" link)
+      // never clears within the same browser session.
       const store = useNotificationStore()
       store.init({ public: {} })
-      store.listById[1] = { id: 1, title: 'Original' }
-      mockList.mockResolvedValue([{ id: 1, title: 'Updated' }])
-
+      mockList.mockResolvedValue([{ id: 1, title: 'Notif 1', seen: false }])
       await store.fetchList()
-      expect(store.listById[1].title).toBe('Original')
+      expect(store.byId(1).seen).toBe(false)
+
+      mockList.mockResolvedValue([{ id: 1, title: 'Notif 1', seen: true }])
+      await store.fetchList()
+      expect(store.byId(1).seen).toBe(true)
     })
 
     it('swallows 401 errors', async () => {


### PR DESCRIPTION
Fixes the "microvolunteer post to check keeps re-appearing / notification indicator stays stuck" bug, specifically on the website: https://discourse.ilovefreegle.org/t/9856/4

Follow-up to #967 and #969 (both merged, and both correct on their own facts) — this fixes a **third, independent surface** of the same overall report, on the frontend rather than the backend.

## Root Cause
`iznik-nuxt3/stores/notification.js`'s `fetchList()` caches each notification in `listById` the first time it's seen and — per the comment "Notifications are immutable so we can avoid triggering a re-render" — never updates that cached copy again:

```js
this.list.forEach((item) => {
  if (!this.listById[item.id]) {
    this.listById[item.id] = item
  }
})
```

That assumption is false for `seen`. `PostResponse` (Go) and `/notification/seen` both flip `seen` from `false` to `true` server-side once a user reviews the microvolunteering post an Exhort notification points at. But every notification-rendering component (`NotificationOne.vue`, `NotificationExhort.vue`, and everything else that goes through `composables/useNotification.js`'s `notificationStore.byId(id)`) reads from this frozen cache, not the freshly-fetched `list` array. Within a single browser session (no full page reload — exactly "the website on my laptop" scenario Jacky described), a notification that was first loaded as unseen keeps rendering as unseen (`bg-info` highlight in `NotificationOne.vue`) forever, even though the count badge (`notification.Count`, which is *not* cached and is correctly re-fetched) has already dropped to 0. That matches the report precisely: "no notification number showing, but there is still a small list of 10" (Discourse post 6) — the aggregate count is fresh, but the individual list items are stale.

This is a distinct bug from #967/#969, which fixed the *server* ever creating/leaving stuck `Exhort` rows. Confirmed live (read-only, via the V2 tunnel) that mechanism is now fully resolved — 0 rows currently match the "unseen Exhort where the recipient already has a `CheckMessage` microaction" pattern within the 90-day notification window. So the residual "indicator stays stuck on the website" Jacky saw is explained by this frontend caching bug, which is untouched by either prior fix.

## Evidence
New test `picks up the latest seen status on refetch (Discourse 9856)` in `tests/unit/stores/notification.spec.js`:
- Characterized the bug first (inverted assertion `expect(store.byId(1).seen).toBe(false)` after a second `fetchList()` returned `seen: true` from the server) — passed on unfixed code, confirming the stale-cache behaviour.
- Inverted to the correct assertion `expect(store.byId(1).seen).toBe(true)`; failed on unfixed code:
  ```
  FAIL  tests/unit/stores/notification.spec.js > notification store > fetchList > picks up the latest seen status on refetch (Discourse 9856)
  AssertionError: expected false to be true // Object.is equality
  - Expected: true
  + Received: false
  ```
- After the fix: 12/12 passed in this file, 156/156 across all `Notification*` specs, 346/346 across the wider `microvolunteering` filter — no regressions.

## Fix
Removed the `if (!this.listById[item.id])` guard so `fetchList()` always takes the latest copy of each notification. This is the minimal change that removes the false immutability assumption; the count badge already worked this way (always re-fetched, never cached), so this brings the list in line with it.

## Other Call Sites
- Grepped `notificationStore.byId` / `notificationStore.listById` across the whole nuxt3 app: the only consumer is `composables/useNotification.js`, used by every `Notification*.vue` component — all fixed by this one store change, nothing else to update.
- A similar "cache once by id" pattern exists in unrelated stores (`compose.js` messages, `group.js` groups, `newsfeed.js`, `team.js`) — those cache content that's genuinely closer to immutable (message text, group definitions) and are out of scope for this report; not touched.
- Not part of this fix, but noted for awareness: `pages/microvolunteering/message/[[id]].client.vue` (the page a notification's `url` links to) renders whatever `msgid` is in the URL unconditionally, with no check for an existing `microactions` row — unlike the main challenge queue (`GetChallenge` in Go), which correctly excludes already-reviewed messages. With this fix, a reviewed notification no longer visually invites a re-click, so this doesn't reproduce in the reported scenario, but it'd be worth hardening separately if a stale link is ever revisited (e.g. from an old email or bookmark).

## Test
- File: `iznik-nuxt3/tests/unit/stores/notification.spec.js`
- Command: `POST http://localhost:8081/api/tests/vitest {"filter":"stores/notification.spec.js"}`
- Proves fail-before/pass-after (see Evidence above).

## Discourse
https://discourse.ilovefreegle.org/t/9856/4