### PR TITLE
feat(routing): reachable-node group set for water/toll-correct ripple targeting

### DIFF
--- a/iznik-routing-go/polygon_test.go
+++ b/iznik-routing-go/polygon_test.go
@@ -48,18 +48,4 @@ func TestAutoResolution(t *testing.T) {
 	t.Logf("walk15 res=%.5f drive15 res=%.5f", walkRes, driveRes)
 }
 
-// pointInPolygon uses ray casting. Coords are [lng, lat].
-func pointInPolygon(lng, lat float64, ring [][2]float64) bool {
-	inside := false
-	n := len(ring)
-	j := n - 1
-	for i := 0; i < n; i++ {
-		xi, yi := ring[i][0], ring[i][1]
-		xj, yj := ring[j][0], ring[j][1]
-		if ((yi > lat) != (yj > lat)) && (lng < (xj-xi)*(lat-yi)/(yj-yi)+xi) {
-			inside = !inside
-		}
-		j = i
-	}
-	return inside
-}
+// pointInPolygon now lives in reachable_groups.go (production code), reused here.

--- a/iznik-routing-go/reachable_groups.go
+++ b/iznik-routing-go/reachable_groups.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"math"
+	"strings"
+)
+
+// parseGroupPolys turns a group's polyindex WKT (POLYGON or MULTIPOLYGON) into
+// one or more groupPoly values. A MULTIPOLYGON yields several groupPoly sharing
+// the same ID; reachableGroupIDs dedupes them. Non-polygon WKT yields nothing.
+func parseGroupPolys(id int64, wkt string) []groupPoly {
+	trimmed := strings.TrimSpace(wkt)
+	upper := strings.ToUpper(trimmed)
+	var out []groupPoly
+
+	switch {
+	case strings.HasPrefix(upper, "MULTIPOLYGON"):
+		start := strings.Index(trimmed, "(")
+		end := strings.LastIndex(trimmed, ")")
+		if start < 0 || end <= start {
+			return out
+		}
+		// inner = ((ring)),((ring),(hole)),... — split into per-polygon groups.
+		for _, part := range splitRings(trimmed[start+1 : end]) {
+			rings, err := wktPolygonToCoords("POLYGON" + part)
+			if err == nil && len(rings) > 0 {
+				out = append(out, newGroupPoly(id, rings))
+			}
+		}
+	case strings.HasPrefix(upper, "POLYGON"):
+		if rings, err := wktPolygonToCoords(trimmed); err == nil && len(rings) > 0 {
+			out = append(out, newGroupPoly(id, rings))
+		}
+	}
+	return out
+}
+
+// groupPoly holds a group's polygon parsed into [lng,lat] rings, ready for
+// point-in-polygon classification of reached road nodes. A MULTIPOLYGON group is
+// represented as several groupPoly values that share the same ID.
+type groupPoly struct {
+	ID    int64
+	rings [][][2]float64 // outer ring first, holes follow; [lng,lat] per point
+
+	// Outer-ring bounding box, precomputed for fast rejection.
+	minLng, maxLng, minLat, maxLat float64
+}
+
+// newGroupPoly builds a groupPoly and precomputes the outer ring's bounding box.
+func newGroupPoly(id int64, rings [][][2]float64) groupPoly {
+	gp := groupPoly{
+		ID:     id,
+		rings:  rings,
+		minLng: math.MaxFloat64,
+		minLat: math.MaxFloat64,
+		maxLng: -math.MaxFloat64,
+		maxLat: -math.MaxFloat64,
+	}
+	if len(rings) > 0 {
+		for _, p := range rings[0] {
+			lng, lat := p[0], p[1]
+			if lng < gp.minLng {
+				gp.minLng = lng
+			}
+			if lng > gp.maxLng {
+				gp.maxLng = lng
+			}
+			if lat < gp.minLat {
+				gp.minLat = lat
+			}
+			if lat > gp.maxLat {
+				gp.maxLat = lat
+			}
+		}
+	}
+	return gp
+}
+
+// pointInPolygon uses ray casting. Coords are [lng, lat].
+func pointInPolygon(lng, lat float64, ring [][2]float64) bool {
+	inside := false
+	n := len(ring)
+	j := n - 1
+	for i := 0; i < n; i++ {
+		xi, yi := ring[i][0], ring[i][1]
+		xj, yj := ring[j][0], ring[j][1]
+		if ((yi > lat) != (yj > lat)) && (lng < (xj-xi)*(lat-yi)/(yj-yi)+xi) {
+			inside = !inside
+		}
+		j = i
+	}
+	return inside
+}
+
+// reachableGroupIDs returns the IDs of groups that contain at least one reached
+// road node. This is the plan's threshold-free, water/toll-correct targeting
+// signal: no reached node can cross a river (no edge does) or use an excluded
+// toll tunnel, so a group with zero reached nodes inside it is genuinely
+// unreachable and is dropped. Each ID is returned at most once (dedupes a
+// MULTIPOLYGON group split across several groupPoly values). The returned slice
+// is non-nil even when empty, so callers can distinguish "computed zero groups"
+// from "not computed".
+func reachableGroupIDs(g *Graph, reached map[NodeID]float32, groups []groupPoly) []int64 {
+	seen := make(map[int64]bool)
+	out := make([]int64, 0)
+	for _, gp := range groups {
+		if seen[gp.ID] || len(gp.rings) == 0 {
+			continue
+		}
+		for id := range reached {
+			n := g.Nodes[id]
+			lng, lat := float64(n.Lng), float64(n.Lat)
+			if lng < gp.minLng || lng > gp.maxLng || lat < gp.minLat || lat > gp.maxLat {
+				continue
+			}
+			if pointInPolygon(lng, lat, gp.rings[0]) {
+				out = append(out, gp.ID)
+				seen[gp.ID] = true
+				break
+			}
+		}
+	}
+	return out
+}

--- a/iznik-routing-go/reachable_groups_handler.go
+++ b/iznik-routing-go/reachable_groups_handler.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"database/sql"
+	"strconv"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+// loadAllGroupPolygons loads every publishable, listable group that has a polygon
+// polyindex, as groupPoly values ready for reached-node classification. A
+// MULTIPOLYGON group becomes several groupPoly sharing its ID (reachableGroupIDs
+// dedupes them).
+func loadAllGroupPolygons(db *sql.DB) ([]groupPoly, error) {
+	rows, err := db.Query("SELECT id, ST_AsText(polyindex) FROM `groups` " +
+		"WHERE publish = 1 AND listable = 1 AND polyindex IS NOT NULL " +
+		"AND ST_GeometryType(polyindex) <> 'POINT'")
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := make([]groupPoly, 0)
+	for rows.Next() {
+		var id int64
+		var wkt sql.NullString
+		if err := rows.Scan(&id, &wkt); err != nil {
+			continue
+		}
+		if wkt.Valid {
+			out = append(out, parseGroupPolys(id, wkt.String)...)
+		}
+	}
+	return out, rows.Err()
+}
+
+// handleReachableGroups serves GET /v1/reachable-groups?lat=&lng=&minutes=&mode=,
+// returning the IDs of groups containing at least one road node reachable within
+// the budget. Unlike the smoothed reach polygon (which over-approximates and can
+// bridge water), a reached node cannot cross a river or an excluded toll, so this
+// is the correct ripple-targeting signal (plan 2026-07-06). The polygon is kept
+// for display only. reachable_group_ids is always present and non-null; it is
+// empty when computable-but-zero, so callers can tell "gate computed nothing"
+// from "no data".
+func handleReachableGroups(g *Graph) fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		latS, lngS := c.Query("lat"), c.Query("lng")
+		if latS == "" || lngS == "" {
+			return fiber.NewError(fiber.StatusBadRequest, "lat and lng required")
+		}
+		lat, err1 := strconv.ParseFloat(latS, 64)
+		lng, err2 := strconv.ParseFloat(lngS, 64)
+		if err1 != nil || err2 != nil {
+			return fiber.NewError(fiber.StatusBadRequest, "lat and lng must be numeric")
+		}
+
+		minutes, _ := strconv.ParseFloat(c.Query("minutes", "30"), 64)
+		if minutes <= 0 || minutes > 120 {
+			minutes = 30
+		}
+
+		mode := Drive
+		switch c.Query("mode", "drive") {
+		case "walk":
+			mode = Walk
+		case "cycle":
+			mode = Cycle
+		}
+
+		ids := make([]int64, 0)
+		iso := Isochrone(g, lat, lng, float32(minutes*60), mode)
+		if len(iso.ReachedNodes) > 0 {
+			if db := ensureGroupsDB(); db != nil {
+				if polys, err := loadAllGroupPolygons(db); err == nil {
+					ids = reachableGroupIDs(g, iso.ReachedNodes, polys)
+				}
+			}
+		}
+		return c.JSON(fiber.Map{"reachable_group_ids": ids})
+	}
+}

--- a/iznik-routing-go/reachable_groups_handler_test.go
+++ b/iznik-routing-go/reachable_groups_handler_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestReachableGroups_MissingParams(t *testing.T) {
+	app := newInternalApp(t)
+	req := httptest.NewRequest(http.MethodGet, "/v1/reachable-groups?lng=-2.5879", nil)
+	resp, err := app.Test(req, 5000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 400 {
+		t.Fatalf("missing lat should be 400, got %d", resp.StatusCode)
+	}
+}
+
+// The endpoint always returns a present, non-null reachable_group_ids list (empty
+// when there is no group DB / no reached nodes). Exercises the full handler path.
+func TestReachableGroups_ReturnsPresentList(t *testing.T) {
+	app := newInternalApp(t)
+	req := httptest.NewRequest(http.MethodGet, "/v1/reachable-groups?lat=51.4545&lng=-2.5879&minutes=5", nil)
+	resp, err := app.Test(req, 30000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 200 {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	var out struct {
+		ReachableGroupIDs []int64 `json:"reachable_group_ids"`
+	}
+	if err := json.Unmarshal(body, &out); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if out.ReachableGroupIDs == nil {
+		t.Error("reachable_group_ids must be present (non-null) even when empty")
+	}
+}

--- a/iznik-routing-go/reachable_groups_test.go
+++ b/iznik-routing-go/reachable_groups_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"testing"
+)
+
+// boxGroup builds a rectangular groupPoly (closed ring, [lng,lat]) for tests.
+func boxGroup(id int64, minLng, minLat, maxLng, maxLat float64) groupPoly {
+	ring := [][2]float64{
+		{minLng, minLat},
+		{maxLng, minLat},
+		{maxLng, maxLat},
+		{minLng, maxLat},
+		{minLng, minLat},
+	}
+	return newGroupPoly(id, [][][2]float64{ring})
+}
+
+func containsID(ids []int64, want int64) bool {
+	for _, id := range ids {
+		if id == want {
+			return true
+		}
+	}
+	return false
+}
+
+// A group whose polygon covers the reachable nodes is returned; a group far away
+// (no reached node inside it) is not. This is the exact "does any reachable road
+// node fall in the group's polygon?" signal the plan wants.
+func TestReachableGroupIDs_SeparatedClusters(t *testing.T) {
+	g := getTestGraph(t)
+	result := Isochrone(g, 51.4545, -2.5879, 15*60, Walk)
+	if len(result.ReachedNodes) == 0 {
+		t.Fatal("expected some reached nodes from the Bristol test graph")
+	}
+
+	near := boxGroup(21656, -2.62, 51.43, -2.55, 51.48) // around the Bristol origin
+	far := boxGroup(99999, 0.0, 51.0, 0.2, 51.2)         // ~2.7 deg east, no nodes
+
+	ids := reachableGroupIDs(g, result.ReachedNodes, []groupPoly{near, far})
+
+	if !containsID(ids, 21656) {
+		t.Errorf("expected the covering group 21656 to be reachable, got %v", ids)
+	}
+	if containsID(ids, 99999) {
+		t.Errorf("the far group 99999 has no reached node inside it and must not be reachable, got %v", ids)
+	}
+}
+
+func TestReachableGroupIDs_Empty(t *testing.T) {
+	g := getTestGraph(t)
+	near := boxGroup(1, -2.62, 51.43, -2.55, 51.48)
+	ids := reachableGroupIDs(g, map[NodeID]float32{}, []groupPoly{near})
+	if len(ids) != 0 {
+		t.Errorf("an empty reached-node set should yield no reachable groups, got %v", ids)
+	}
+}
+
+// A group id appearing in more than one groupPoly (e.g. a MULTIPOLYGON split into
+// parts) must be returned at most once.
+func TestReachableGroupIDs_Dedupe(t *testing.T) {
+	g := getTestGraph(t)
+	result := Isochrone(g, 51.4545, -2.5879, 15*60, Walk)
+	part1 := boxGroup(500, -2.62, 51.43, -2.55, 51.48)
+	part2 := boxGroup(500, -2.60, 51.44, -2.56, 51.47) // same id, also covers origin
+	ids := reachableGroupIDs(g, result.ReachedNodes, []groupPoly{part1, part2})
+	count := 0
+	for _, id := range ids {
+		if id == 500 {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("group 500 should appear exactly once, appeared %d times (%v)", count, ids)
+	}
+}

--- a/iznik-routing-go/ripple.go
+++ b/iznik-routing-go/ripple.go
@@ -235,6 +235,11 @@ type rippleScheduleResponse struct {
 	TotalFreeglers int                   `json:"total_freeglers"`
 	MaxDriveMin    float64               `json:"max_drive_min"`
 	Schedule       []rippleScheduleEntry `json:"schedule"`
+	// ReachableGroupIDs is the set of groups containing >=1 road node reachable
+	// within the max budget - the water/toll-correct ripple-targeting signal
+	// (plan 2026-07-06). Present (non-null) when computed, so batch can tell it
+	// apart from an older server that omits the field. No omitempty on purpose.
+	ReachableGroupIDs []int64 `json:"reachable_group_ids"`
 }
 
 // handleRippleSchedule produces the density-driven ripple schedule for a given
@@ -323,6 +328,19 @@ func handleRippleSchedule(g *Graph, spatialURL string) fiber.Handler {
 		iso := Isochrone(g, latF, lngF, maxSecs, mode)
 		if len(iso.ReachedNodes) == 0 {
 			return c.JSON(empty)
+		}
+
+		// Reachable-group set for road-reachable ripple targeting (plan
+		// 2026-07-06): which groups contain >=1 reached road node. Computed once
+		// per reach from the node set already in hand; empty (non-nil) if no group
+		// DB is configured, which the batch treats as "gate not available".
+		reachableGroups := make([]int64, 0)
+		if db := ensureGroupsDB(); db != nil {
+			if polys, err := loadAllGroupPolygons(db); err == nil {
+				reachableGroups = reachableGroupIDs(g, iso.ReachedNodes, polys)
+			} else {
+				log.Printf("ripple-schedule: loadAllGroupPolygons failed: %v", err)
+			}
 		}
 
 		// --- Step 2: get the freeglers within the max polygon via spatial ---
@@ -444,9 +462,10 @@ func handleRippleSchedule(g *Graph, spatialURL string) fiber.Handler {
 		}
 
 		return c.JSON(rippleScheduleResponse{
-			TotalFreeglers: total,
-			MaxDriveMin:    maxDriveMin,
-			Schedule:       schedule,
+			TotalFreeglers:    total,
+			MaxDriveMin:       maxDriveMin,
+			Schedule:          schedule,
+			ReachableGroupIDs: reachableGroups,
 		})
 	}
 }

--- a/iznik-routing-go/ripple_reachable_test.go
+++ b/iznik-routing-go/ripple_reachable_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestRippleScheduleResponse_CarriesReachableGroupIDs(t *testing.T) {
+	b, err := json.Marshal(rippleScheduleResponse{
+		Schedule:          []rippleScheduleEntry{},
+		ReachableGroupIDs: []int64{21656, 21458},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(b), `"reachable_group_ids":[21656,21458]`) {
+		t.Errorf("reachable_group_ids not carried in schedule response: %s", b)
+	}
+
+	// An empty (non-nil) list must serialise as [] rather than null, so the batch
+	// can distinguish a new server that computed zero groups from an old server
+	// that omits the field entirely.
+	be, _ := json.Marshal(rippleScheduleResponse{ReachableGroupIDs: []int64{}})
+	if !strings.Contains(string(be), `"reachable_group_ids":[]`) {
+		t.Errorf("empty reachable_group_ids should serialise as []: %s", be)
+	}
+}

--- a/iznik-routing-go/server.go
+++ b/iznik-routing-go/server.go
@@ -405,6 +405,7 @@ func newApp(g *Graph, spatialURL string, requireAuth bool) *fiber.App {
 	v1.Get("/group-actives", handleGroupActives())
 	v1.Get("/nearby-freeglers", handleNearbyFreeglers(g, spatialURL))
 	v1.Get("/ripple-schedule", handleRippleSchedule(g, spatialURL))
+	v1.Get("/reachable-groups", handleReachableGroups(g))
 	v1.Post("/ripple-eval", handleRippleEval(g, spatialURL))
 	v1.Get("/posts-for-member", handlePostsForMember(g, spatialURL))
 	v1.Get("/digest-simulator", handleDigestSimulator(g, spatialURL))

--- a/iznik-routing-go/server_test.go
+++ b/iznik-routing-go/server_test.go
@@ -122,8 +122,15 @@ func TestExternalPort_HealthNoAuth(t *testing.T) {
 // TestExternalPort_ValidJWT_IsochroneAccessible verifies that a valid JWT
 // grants access to /v1/isochrone on the external port.
 // When groupsDB is nil (no MySQL in test), JWT signature check still runs
-// but session validation is skipped.
+// but session validation is skipped. Force that precondition explicitly
+// (matching the NoDB tests below) rather than relying on no earlier test
+// having connected groupsDB — TestReachableGroups_ReturnsPresentList does
+// exactly that, and package-level groupsDB stays set for the rest of the
+// binary's tests once established, which used to make this test's outcome
+// depend on run order.
 func TestExternalPort_ValidJWT_IsochroneAccessible(t *testing.T) {
+	t.Setenv("MYSQL_HOST", "")
+	groupsDB = nil
 	app := newExternalApp(t)
 	tok := makeJWT(t, "12345", "67890")
 	req := httptest.NewRequest(http.MethodGet,


### PR DESCRIPTION
Implements the routing-server side of `plans/2026-07-06-ripple-reach-crosses-water.md` (TDD).

## Why
The rippling reach **polygon** is a lossy smoothing of the reachable road-node set (Dijkstra) and over-approximates — it bridges rivers (the ~0.8 km Thames at Tilbury), so posts ripple into groups you can't drive to (canonical case: msgid 120898144 Corringham → Gravesend). The exact, correct signal — *which groups contain a reachable node* — is computed then thrown away. A reached node can't cross a river (no edge does) or use an excluded toll, so this is threshold-free and correct for both severance and tolls.

## What (routing server only)
- `reachable_groups.go`: `reachableGroupIDs(g, reached, groups)` — bbox + ray-cast each reached node against group polygons; dedupes a MULTIPOLYGON group split across parts. `pointInPolygon` promoted from the test file to production.
- **`GET /v1/reachable-groups?lat=&lng=&minutes=&mode=`** and a **`reachable_group_ids`** field on **`/v1/ripple-schedule`** — computed once per reach from the node set already in hand (cheap: one bbox+PIP pass, no extra Dijkstra). Empty serialises as `[]` (not `null`) so batch can tell a new server from an old one.
- **The smoothed polygon is untouched** and still drives map display / digest scoring / nearby-reach.

## Tests
Routing suite green (75). New: node→group classification (separated clusters / empty / MULTIPOLYGON dedupe), the handler (missing-param 400, present-list 200), and the schedule-field roundtrip (incl. `[]` vs `null`).

## Follow-ups (separate PRs, per the plan)
- **Batch gate**: `ExpandService::rippleIntoNewGroups` AND-gated on `reachable_group_ids` behind `freegle.ripple.reachable_gate` (default off) + the `rippling_reach.reachable_group_ids` migration + `removeGroupsNoLongerReached` extension; then the `ripple:retract-unreachable` backfill (throttled, one row at a time).
- **Display-polygon refinement (your "better display" ask)**: assessed as **defer**. Once targeting is node-gated the polygon crossing water is cosmetic, and it feeds 5+ consumers (map, digest, nearby-reach PR #921, retract, ripple-eval), so changing `IsochronePolygon` carries real regression risk. Lowest-risk future option: skip the morphological closing for drive mode, guarded by a two-cluster regression test — noted for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)