### PR TITLE
feat(ripple): gate ripple targeting on road-reachable groups (batch consumer)

### DIFF
--- a/iznik-batch/app/Services/Ripple/ExpandService.php
+++ b/iznik-batch/app/Services/Ripple/ExpandService.php
@@ -224,12 +224,13 @@ class ExpandService
             DB::statement(
                 'UPDATE rippling_reach
                     SET polygon = ST_GeomFromText(?, ' . self::SRID . '),
-                        schedule = ?, total_freeglers = ?, max_drive_min = ?,
+                        schedule = ?, reachable_group_ids = ?, total_freeglers = ?, max_drive_min = ?,
                         updated_at = updated_at
                   WHERE msgid = ?',
                 [
                     $storeWkt,
                     json_encode($ticks),
+                    json_encode($schedule['reachable_group_ids'] ?? []),
                     (int) $schedule['total_freeglers'],
                     $schedule['max_drive_min'],
                     $row->msgid,
@@ -448,7 +449,19 @@ class ExpandService
         }
 
         // Rippled-in groups whose polyindex no longer intersects the post's current
-        // (capped) reach polygon — i.e. groups we would NOT ripple into now.
+        // (capped) reach polygon — i.e. groups we would NOT ripple into now. With the
+        // reachable-gate on, ALSO retract groups the polygon still covers but which are
+        // no longer in the node-reachable set (rr.reachable_group_ids), so a reach that
+        // overshot water self-heals. The `rr.reachable_group_ids IS NOT NULL` guard means
+        // reaches computed before the gate rolled out (NULL column) are never retracted by
+        // it - only polygon-based retraction applies to them.
+        $reachClause = $this->reachableGateEnabled()
+            ? "AND (NOT ST_Intersects(g.polyindex, rr.polygon)
+                    OR (rr.reachable_group_ids IS NOT NULL
+                        AND JSON_VALID(rr.reachable_group_ids)
+                        AND NOT JSON_CONTAINS(rr.reachable_group_ids, CAST(g.id AS JSON))))"
+            : "AND NOT ST_Intersects(g.polyindex, rr.polygon)";
+
         $rows = DB::select(
             "SELECT g.id
                FROM messages_groups mg
@@ -457,7 +470,7 @@ class ExpandService
               WHERE mg.msgid = ? AND mg.rippled_in = 1 AND mg.deleted = 0
                 AND rr.status <> 'held'
                 AND g.polyindex IS NOT NULL AND ST_GeometryType(g.polyindex) <> 'POINT'
-                AND NOT ST_Intersects(g.polyindex, rr.polygon)",
+                " . $reachClause,
             [$msgid]
         );
 
@@ -861,24 +874,27 @@ class ExpandService
                     DB::statement(
                         'INSERT INTO rippling_reach
                            (msgid, lat, lng, polygon, arrival, mode, tick, total_ticks,
-                            total_freeglers, max_drive_min, schedule, next_expansion_at, status,
-                            created_at, updated_at)
-                         VALUES (?, ?, ?, ST_GeomFromText(?, ' . self::SRID . '), ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), NOW())
+                            total_freeglers, max_drive_min, schedule, reachable_group_ids,
+                            next_expansion_at, status, created_at, updated_at)
+                         VALUES (?, ?, ?, ST_GeomFromText(?, ' . self::SRID . '), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), NOW())
                          ON DUPLICATE KEY UPDATE
                             lat = VALUES(lat), lng = VALUES(lng), polygon = VALUES(polygon),
                             arrival = VALUES(arrival), mode = VALUES(mode), tick = VALUES(tick),
                             total_ticks = VALUES(total_ticks), total_freeglers = VALUES(total_freeglers),
                             max_drive_min = VALUES(max_drive_min), schedule = VALUES(schedule),
+                            reachable_group_ids = VALUES(reachable_group_ids),
                             next_expansion_at = VALUES(next_expansion_at), status = VALUES(status),
                             updated_at = NOW()',
                         [
                             $row->msgid, $lat, $lng, $storeWkt, $arrival,
                             $this->reach->mode(), $tick, $total,
                             $schedule['total_freeglers'], $schedule['max_drive_min'],
-                            json_encode($schedule['ticks']), $next, $status,
+                            json_encode($schedule['ticks']),
+                            json_encode($schedule['reachable_group_ids'] ?? []),
+                            $next, $status,
                         ]
                     );
-                    $this->rippleIntoNewGroups((int) $row->msgid, $storeWkt, $stats);
+                    $this->rippleIntoNewGroups((int) $row->msgid, $storeWkt, $stats, $schedule['reachable_group_ids'] ?? null);
                     // Reach mail is decoupled into the sharded `mail:digest:unified --mode=reach`
                     // pass (UnifiedDigestService::sendReachDigests). It must NOT run inline here:
                     // the 2026-06-24 live profile showed it was ~75% of this serial Phase-2 loop's
@@ -1000,7 +1016,15 @@ class ExpandService
                     // include any secondary-group rejection clips. Re-subtract every rejected
                     // group so a secondary "out of area" rejection survives expansion (#9).
                     $this->reapplyClips((int) $row->msgid, $row->rejected_groups ?? null);
-                    $this->rippleIntoNewGroups((int) $row->msgid, $storeWkt, $stats);
+                    // The reachable-group set was computed at init and cached on the reach
+                    // row; later ticks re-ripple against the same set (a cheap keyed lookup,
+                    // only when the gate is on).
+                    $cachedReachable = null;
+                    if ($this->reachableGateEnabled()) {
+                        $raw = DB::table('rippling_reach')->where('msgid', $row->msgid)->value('reachable_group_ids');
+                        $cachedReachable = $raw ? json_decode($raw, true) : null;
+                    }
+                    $this->rippleIntoNewGroups((int) $row->msgid, $storeWkt, $stats, $cachedReachable);
                     // Reach mail decoupled into `mail:digest:unified --mode=reach` — see
                     // initialiseNew and UnifiedDigestService::sendReachDigests.
                 }
@@ -1018,6 +1042,16 @@ class ExpandService
     }
 
     /**
+     * True when the road-reachable ripple gate is enabled (plan 2026-07-06). Off by
+     * default and independent of RIPPLE_ENABLED; enable only once the routing server
+     * that returns reachable_group_ids is deployed and validated.
+     */
+    private function reachableGateEnabled(): bool
+    {
+        return (bool) config('freegle.ripple.reachable_gate', false);
+    }
+
+    /**
      * Ripple a post INTO every published group whose area the reach now covers (#6).
      *
      * "Crosses into a new group" = the reach polygon intersects the group's area. A
@@ -1032,7 +1066,7 @@ class ExpandService
      * (the default - no Pending flicker, since the post was already vetted on origin), else
      * Pending so AutoApproveService approves it after the mod-veto window.
      */
-    private function rippleIntoNewGroups(int $msgid, string $reachWkt, array &$stats): void
+    private function rippleIntoNewGroups(int $msgid, string $reachWkt, array &$stats, ?array $reachableGroupIds = null): void
     {
         try {
             // Never ripple a post that has already been taken/received/withdrawn into new groups,
@@ -1080,6 +1114,17 @@ class ExpandService
                 return;
             }
 
+            // Reachable-gate (plan 2026-07-06): when enabled AND the routing server sent a
+            // reachable-group set, restrict targets to groups containing a road node
+            // reachable from the origin - so a reach polygon that overshoots water can't
+            // ripple across an uncrossable barrier. The polygon ST_Intersects stays as the
+            // cheap spatial-index prefilter; this is an AND gate on top. IDs are
+            // server-sourced int64s, cast via (int) so they can't inject. Empty set or gate
+            // off => clause omitted => unchanged behaviour (fall back to polygon only).
+            $reachableGate = ($this->reachableGateEnabled() && !empty($reachableGroupIds))
+                ? ' AND g.id IN (' . implode(',', array_map('intval', $reachableGroupIds)) . ')'
+                : '';
+
             $targetGroups = DB::select(
                 "SELECT g.id
                  FROM `groups` g
@@ -1089,7 +1134,7 @@ class ExpandService
                    AND g.nameshort NOT LIKE '%playground%'
                    AND g.polyindex IS NOT NULL
                    AND ST_GeometryType(g.polyindex) <> 'POINT'
-                   AND ST_Intersects(g.polyindex, ST_GeomFromText(?, " . self::SRID . "))
+                   AND ST_Intersects(g.polyindex, ST_GeomFromText(?, " . self::SRID . "))" . $reachableGate . "
                    AND NOT EXISTS (
                        SELECT 1 FROM messages_groups mg WHERE mg.msgid = ? AND mg.groupid = g.id
                    )

--- a/iznik-batch/app/Services/Ripple/ReachService.php
+++ b/iznik-batch/app/Services/Ripple/ReachService.php
@@ -72,7 +72,7 @@ class ReachService
      * — the container has no UK graph loaded). Callers treat null as "leave the
      * reach unchanged this run".
      *
-     * @return array{total_freeglers:int,max_drive_min:float,ticks:array<int,array{tick:int,drive_min:float,cumulative_users:int,wkt:string}>}|null
+     * @return array{total_freeglers:int,max_drive_min:float,ticks:array<int,array{tick:int,drive_min:float,cumulative_users:int,wkt:string}>,reachable_group_ids:int[]}|null
      */
     public function computeSchedule(float $lat, float $lng): ?array
     {
@@ -227,7 +227,7 @@ class ReachService
      * Parse a /v1/ripple-schedule JSON body into the schedule structure, or null if it
      * carries no usable ticks. Shared by the single and batch paths.
      *
-     * @return array{total_freeglers:int,max_drive_min:float,ticks:array<int,array{tick:int,drive_min:float,cumulative_users:int,wkt:string}>}|null
+     * @return array{total_freeglers:int,max_drive_min:float,ticks:array<int,array{tick:int,drive_min:float,cumulative_users:int,wkt:string}>,reachable_group_ids:int[]}|null
      */
     public function parseScheduleResponse(array $body): ?array
     {
@@ -257,6 +257,10 @@ class ReachService
             'total_freeglers' => (int) ($body['total_freeglers'] ?? 0),
             'max_drive_min' => (float) ($body['max_drive_min'] ?? $this->maxMinutes),
             'ticks' => $ticks,
+            // Groups containing a road node reachable from the origin - the
+            // water/toll-correct ripple-targeting signal. Empty when the server
+            // omits it (older build); the gate treats [] as "not available".
+            'reachable_group_ids' => array_map('intval', $body['reachable_group_ids'] ?? []),
         ];
     }
 

--- a/iznik-batch/config/freegle.php
+++ b/iznik-batch/config/freegle.php
@@ -331,6 +331,13 @@ return [
         // independent of RIPPLE_ENABLED).
         'proximity_notes' => filter_var(env('RIPPLE_PROXIMITY_NOTES', true), FILTER_VALIDATE_BOOLEAN),
         'proximity_timeout' => (int) env('RIPPLE_PROXIMITY_TIMEOUT', 15),
+        // reachable_gate (plan 2026-07-06): when on, ripple targeting is AND-gated on
+        // the routing server's reachable_group_ids (groups with a road node reachable
+        // from the origin), so a reach polygon that overshoots water can't ripple a
+        // post across an uncrossable barrier. Default OFF: enable only after the new
+        // routing server (which returns reachable_group_ids) is deployed and validated.
+        // Independent of RIPPLE_ENABLED; an empty/absent list falls back to polygon-only.
+        'reachable_gate' => filter_var(env('RIPPLE_REACHABLE_GATE', false), FILTER_VALIDATE_BOOLEAN),
         'proximity_slow_ms' => (int) env('RIPPLE_PROXIMITY_SLOW_MS', 3000),
         // Reply-saturation stop (extent-governor design T1.1): a post with at least this many
         // DISTINCT repliers (distinct users with an Interested chat reply on the post,

--- a/iznik-batch/database/migrations/2026_07_06_000001_add_reachable_group_ids_to_rippling_reach.php
+++ b/iznik-batch/database/migrations/2026_07_06_000001_add_reachable_group_ids_to_rippling_reach.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (!Schema::hasColumn('rippling_reach', 'reachable_group_ids')) {
+            Schema::table('rippling_reach', function (Blueprint $t) {
+                // JSON array of group IDs that contain at least one road node reachable
+                // from the post origin - the water/toll-correct ripple-targeting signal
+                // from the routing server (GET /v1/ripple-schedule reachable_group_ids).
+                // Nullable: rows written before the reachable-gate rollout have no value,
+                // and the gate/retraction treat NULL as "not available", falling back to
+                // the polygon only.
+                $t->json('reachable_group_ids')->nullable()->after('schedule');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasColumn('rippling_reach', 'reachable_group_ids')) {
+            Schema::table('rippling_reach', function (Blueprint $t) {
+                $t->dropColumn('reachable_group_ids');
+            });
+        }
+    }
+};

--- a/iznik-batch/database/migrations/2026_07_06_000001_add_reachable_group_ids_to_rippling_reach_migration.sql
+++ b/iznik-batch/database/migrations/2026_07_06_000001_add_reachable_group_ids_to_rippling_reach_migration.sql
@@ -1,0 +1,16 @@
+-- Production deploy SQL for the Laravel migration of the same name (idempotent).
+-- Adds the reachable_group_ids JSON column to rippling_reach: the set of group IDs
+-- containing a road node reachable from the post origin (water/toll-correct ripple
+-- targeting). NULL on pre-rollout rows; gate/retraction fall back to the polygon then.
+SET @exists := (
+    SELECT COUNT(*) FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'rippling_reach'
+      AND COLUMN_NAME = 'reachable_group_ids'
+);
+SET @sql := IF(@exists = 0,
+    'ALTER TABLE rippling_reach ADD COLUMN reachable_group_ids JSON NULL AFTER schedule',
+    'DO 0');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;

--- a/iznik-batch/tests/Unit/Services/Ripple/ExpandServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/Ripple/ExpandServiceTest.php
@@ -90,6 +90,25 @@ class ExpandServiceTest extends TestCase
         ], 200)]);
     }
 
+    /** Like fakeRouting(), but the schedule response also carries reachable_group_ids. */
+    private function fakeRoutingWithReachable(array $reachableIds, int $ticks = 3): void
+    {
+        $polygon = [
+            'type' => 'Feature',
+            'geometry' => ['type' => 'Polygon', 'coordinates' => [[
+                [-0.10, 51.50], [-0.20, 51.50], [-0.20, 51.60], [-0.10, 51.60], [-0.10, 51.50],
+            ]]],
+        ];
+        $schedule = [];
+        for ($k = 1; $k <= $ticks; $k++) {
+            $schedule[] = ['tick' => $k, 'drive_min' => 5.0 * $k, 'cumulative_users' => 30 * $k, 'polygon' => $polygon];
+        }
+        Http::fake(['*ripple-schedule*' => Http::response([
+            'total_freeglers' => 90, 'max_drive_min' => 30, 'schedule' => $schedule,
+            'reachable_group_ids' => array_values($reachableIds),
+        ], 200)]);
+    }
+
     /**
      * Fakes the routing server's /v1/group-proximity response used by
      * ReachService::groupProximity(). Layers on top of any Http::fake() already
@@ -680,6 +699,150 @@ class ExpandServiceTest extends TestCase
             1,
             (int) DB::table('messages_groups')->where('msgid', $msgid)->where('groupid', $groupB->id)->count()
         );
+    }
+
+    // --- Reachable-node gate (plan 2026-07-06) -----------------------------------
+
+    private function seedTargetGroupCoveringReach(): object
+    {
+        // Area intersects the fake reach box (-0.20..-0.10 lng, 51.50..51.60 lat), so
+        // ST_Intersects passes and only the node-set gate can exclude it.
+        $g = $this->createTestGroup();
+        DB::statement(
+            "UPDATE `groups` SET publish = 1, polyindex = ST_GeomFromText(?, ?) WHERE id = ?",
+            ['POLYGON((-0.18 51.52,-0.12 51.52,-0.12 51.58,-0.18 51.58,-0.18 51.52))', 3857, $g->id]
+        );
+        return $g;
+    }
+
+    public function test_reachable_gate_blocks_a_group_the_polygon_covers_but_the_nodes_do_not(): void
+    {
+        config(['freegle.ripple.reachable_gate' => true]);
+        $msgid = $this->seedSpatialPost(now()->subMinutes(30));
+        $originGid = (int) DB::table('messages_groups')->where('msgid', $msgid)->value('groupid');
+        $groupB = $this->seedTargetGroupCoveringReach();
+
+        // Non-empty reachable set that does NOT include B (only the origin is node-reachable).
+        $this->fakeRoutingWithReachable([$originGid], 3);
+
+        $this->service()->process(false, 500);
+
+        $this->assertNull(
+            DB::table('messages_groups')->where('msgid', $msgid)->where('groupid', $groupB->id)->first(),
+            'gate on: a group the polygon covers but with no reachable node is NOT rippled in'
+        );
+    }
+
+    public function test_reachable_gate_allows_a_group_in_the_reachable_set(): void
+    {
+        config(['freegle.ripple.reachable_gate' => true]);
+        $msgid = $this->seedSpatialPost(now()->subMinutes(30));
+        $groupB = $this->seedTargetGroupCoveringReach();
+
+        $this->fakeRoutingWithReachable([$groupB->id], 3);
+
+        $this->service()->process(false, 500);
+
+        $this->assertNotNull(
+            DB::table('messages_groups')->where('msgid', $msgid)->where('groupid', $groupB->id)->first(),
+            'gate on: a group in the reachable set IS rippled in'
+        );
+    }
+
+    public function test_reachable_gate_off_ripples_an_intersecting_group_regardless_of_the_set(): void
+    {
+        // Default (off): unchanged behaviour - the polygon alone decides, even though B
+        // is not in reachable_group_ids.
+        config(['freegle.ripple.reachable_gate' => false]);
+        $msgid = $this->seedSpatialPost(now()->subMinutes(30));
+        $originGid = (int) DB::table('messages_groups')->where('msgid', $msgid)->value('groupid');
+        $groupB = $this->seedTargetGroupCoveringReach();
+
+        $this->fakeRoutingWithReachable([$originGid], 3); // B not in the set
+
+        $this->service()->process(false, 500);
+
+        $this->assertNotNull(
+            DB::table('messages_groups')->where('msgid', $msgid)->where('groupid', $groupB->id)->first(),
+            'gate off: an intersecting group is still rippled in (backward compatible)'
+        );
+    }
+
+    /**
+     * @param int[] $reachableIds JSON-stored on the reach row
+     */
+    private function seedRippledCopyWithReach(array $reachableIds): array
+    {
+        $user = $this->createTestUser();
+        $origin = $this->createTestGroup();
+        $rippled = $this->createTestGroup();
+        // Rippled group's area INTERSECTS the reach polygon, so the polygon-only path
+        // keeps it - only the node-set gate can retract it.
+        DB::statement(
+            "UPDATE `groups` SET publish = 1, polyindex = ST_GeomFromText(?, ?) WHERE id = ?",
+            ['POLYGON((-0.18 51.52,-0.12 51.52,-0.12 51.58,-0.18 51.58,-0.18 51.52))', 3857, $rippled->id]
+        );
+        $message = Message::create([
+            'type' => Message::TYPE_OFFER, 'fromuser' => $user->id,
+            'subject' => 'OFFER: reach', 'textbody' => 'x', 'source' => 'Platform',
+            'date' => now()->subDay(), 'arrival' => now()->subDay(), 'lat' => 51.5, 'lng' => -0.1,
+        ]);
+        MessageGroup::create(['msgid' => $message->id, 'groupid' => $origin->id, 'collection' => MessageGroup::COLLECTION_APPROVED, 'arrival' => now()->subDay()]);
+        MessageGroup::create(['msgid' => $message->id, 'groupid' => $rippled->id, 'collection' => MessageGroup::COLLECTION_APPROVED, 'arrival' => now()->subDay()]);
+        DB::table('messages_groups')->where('msgid', $message->id)->where('groupid', $rippled->id)->update(['rippled_in' => 1]);
+        DB::statement(
+            "INSERT INTO rippling_reach
+               (msgid, lat, lng, polygon, arrival, mode, tick, total_ticks, total_freeglers,
+                max_drive_min, schedule, reachable_group_ids, next_expansion_at, status, created_at, updated_at)
+             VALUES (?, 51.5, -0.1, ST_GeomFromText(?, 3857), ?, 'drive', 3, 3, 90, 30, NULL, ?, NULL, 'expanding', NOW(), NOW())",
+            [$message->id, self::WKT, now()->subDay(), json_encode(array_values($reachableIds))]
+        );
+        return [(int) $message->id, (int) $rippled->id];
+    }
+
+    public function test_reachable_gate_retracts_a_rippled_group_outside_the_reachable_set(): void
+    {
+        config(['freegle.ripple.reachable_gate' => true]);
+        [$msgid, $rippledId] = $this->seedRippledCopyWithReach([]); // reachable set excludes it (empty -> not contained)
+
+        $stats = [];
+        $this->service()->retractOutOfReachCopies($msgid, false, $stats);
+
+        $copy = DB::table('messages_groups')->where('msgid', $msgid)->where('groupid', $rippledId)->first();
+        $this->assertSame(1, (int) $copy->deleted, 'a rippled group outside the reachable set is retracted');
+    }
+
+    public function test_reachable_gate_keeps_a_rippled_group_inside_the_reachable_set(): void
+    {
+        config(['freegle.ripple.reachable_gate' => true]);
+        $user = $this->createTestUser();
+        $origin = $this->createTestGroup();
+        $rippled = $this->createTestGroup();
+        DB::statement(
+            "UPDATE `groups` SET publish = 1, polyindex = ST_GeomFromText(?, ?) WHERE id = ?",
+            ['POLYGON((-0.18 51.52,-0.12 51.52,-0.12 51.58,-0.18 51.58,-0.18 51.52))', 3857, $rippled->id]
+        );
+        $message = Message::create([
+            'type' => Message::TYPE_OFFER, 'fromuser' => $user->id,
+            'subject' => 'OFFER: keep', 'textbody' => 'x', 'source' => 'Platform',
+            'date' => now()->subDay(), 'arrival' => now()->subDay(), 'lat' => 51.5, 'lng' => -0.1,
+        ]);
+        MessageGroup::create(['msgid' => $message->id, 'groupid' => $origin->id, 'collection' => MessageGroup::COLLECTION_APPROVED, 'arrival' => now()->subDay()]);
+        MessageGroup::create(['msgid' => $message->id, 'groupid' => $rippled->id, 'collection' => MessageGroup::COLLECTION_APPROVED, 'arrival' => now()->subDay()]);
+        DB::table('messages_groups')->where('msgid', $message->id)->where('groupid', $rippled->id)->update(['rippled_in' => 1]);
+        DB::statement(
+            "INSERT INTO rippling_reach
+               (msgid, lat, lng, polygon, arrival, mode, tick, total_ticks, total_freeglers,
+                max_drive_min, schedule, reachable_group_ids, next_expansion_at, status, created_at, updated_at)
+             VALUES (?, 51.5, -0.1, ST_GeomFromText(?, 3857), ?, 'drive', 3, 3, 90, 30, NULL, ?, NULL, 'expanding', NOW(), NOW())",
+            [$message->id, self::WKT, now()->subDay(), json_encode([$rippled->id, $origin->id])]
+        );
+
+        $stats = [];
+        $this->service()->retractOutOfReachCopies((int) $message->id, false, $stats);
+
+        $copy = DB::table('messages_groups')->where('msgid', $message->id)->where('groupid', $rippled->id)->first();
+        $this->assertSame(0, (int) $copy->deleted, 'a rippled group inside the reachable set is kept');
     }
 
     /**

--- a/iznik-batch/tests/Unit/Services/Ripple/ReachServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/Ripple/ReachServiceTest.php
@@ -85,6 +85,57 @@ class ReachServiceTest extends TestCase
         $this->assertStringEndsWith('-0.1 51.5))', $result['ticks'][0]['wkt']);
     }
 
+    public function test_parseScheduleResponse_includes_reachable_group_ids(): void
+    {
+        $s = $this->service();
+        $polygon = [
+            'type' => 'Feature',
+            'geometry' => [
+                'type' => 'Polygon',
+                'coordinates' => [[
+                    [-0.10, 51.50], [-0.20, 51.50], [-0.20, 51.60], [-0.10, 51.60], [-0.10, 51.50],
+                ]],
+            ],
+        ];
+        $result = $s->parseScheduleResponse([
+            'total_freeglers' => 5,
+            'max_drive_min' => 30,
+            'schedule' => [
+                ['tick' => 1, 'drive_min' => 5.0, 'cumulative_users' => 2, 'polygon' => $polygon],
+            ],
+            // The routing server may send them as JSON numbers; keep them ints.
+            'reachable_group_ids' => [21439, 21656],
+        ]);
+
+        $this->assertNotNull($result);
+        $this->assertSame([21439, 21656], $result['reachable_group_ids']);
+    }
+
+    public function test_parseScheduleResponse_defaults_reachable_group_ids_to_empty(): void
+    {
+        // An older routing server omits the field entirely - the batch must see []
+        // (not null), which the gate treats as "not available" and leaves targeting
+        // unchanged.
+        $s = $this->service();
+        $polygon = [
+            'type' => 'Feature',
+            'geometry' => [
+                'type' => 'Polygon',
+                'coordinates' => [[
+                    [-0.10, 51.50], [-0.20, 51.50], [-0.20, 51.60], [-0.10, 51.60], [-0.10, 51.50],
+                ]],
+            ],
+        ];
+        $result = $s->parseScheduleResponse([
+            'schedule' => [
+                ['tick' => 1, 'drive_min' => 5.0, 'cumulative_users' => 2, 'polygon' => $polygon],
+            ],
+        ]);
+
+        $this->assertNotNull($result);
+        $this->assertSame([], $result['reachable_group_ids']);
+    }
+
     public function test_schedule_omits_target_users_when_extent_disabled(): void
     {
         // Default / dark: the audience cap must not touch the request at all,


### PR DESCRIPTION
Consumer side of `plans/2026-07-06-ripple-reach-crosses-water.md` — pairs with the routing server in #972.

## Why
The rippling reach **polygon** is a lossy smoothing of the reachable road-node set and over-approximates, bridging rivers (the ~0.8 km Thames at Tilbury) so posts ripple into groups you can't actually drive to. #972 makes the routing server return the exact signal — **which groups contain a reachable road node** (`reachable_group_ids`). This PR makes the batch consume it to gate ripple targeting.

## What
- **ReachService::parseScheduleResponse** now carries `reachable_group_ids` (empty when an older server omits it, so the gate can tell "computed zero" from "not available").
- **Migration**: `rippling_reach.reachable_group_ids` JSON column (Laravel + idempotent prod SQL). NULL on pre-rollout rows.
- **Config flag** `freegle.ripple.reachable_gate` (`RIPPLE_REACHABLE_GATE`, **default off**, independent of `RIPPLE_ENABLED`). Enable only once #972's routing server is deployed.
- **ExpandService::rippleIntoNewGroups** — when the gate is on AND a non-empty reachable set is present, the target SELECT is AND-gated with `g.id IN (…server-sourced ints…)` on top of the existing polygon `ST_Intersects` prefilter. Threaded through both ripple paths (fresh schedule at init; cached column on later ticks). The reach row is populated on both writes.
- **ExpandService::retractOutOfReachCopies** — with the gate on, also retracts a rippled-in group the polygon still covers but which is no longer in the node-reachable set, so a reach that overshot water self-heals. Guarded by `reachable_group_ids IS NOT NULL`, so pre-rollout rows are only ever retracted by the existing polygon rule.

Gate off (default): every query is byte-for-byte the pre-feature behaviour — the added clause is omitted entirely.

## Tests
- ReachServiceTest: `reachable_group_ids` parsed; defaults to `[]` when absent (RED confirmed, then GREEN).
- ExpandServiceTest: gate **blocks** a polygon-covered group not in the set, **allows** one in the set, and **off** ripples the intersecting group regardless; retraction **removes** a rippled group outside the set and **keeps** one inside.

## Rollout
1. Deploy #972 (routing server returns `reachable_group_ids`).
2. Deploy this (column + code, gate off — no behaviour change; reach rows start recording the set).
3. Flip `RIPPLE_REACHABLE_GATE=true` once enough rows carry a set; the retraction backfill then self-heals existing over-water copies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
