### PR TITLE
fix(microvolunteering): clear bell badge + review list after approve

### DIFF
--- a/iznik-server-go/notification/notification.go
+++ b/iznik-server-go/notification/notification.go
@@ -71,10 +71,19 @@ func List(c *fiber.Ctx) error {
 
 	start := time.Now().AddDate(0, 0, -utils.NOTIFICATION_AGE).Format("2006-01-02")
 
+	// Exhort notifications for microvolunteering "post to check" challenges are never
+	// deleted once actioned, so without this join they resurface in the list (and
+	// reappear every time the bell is reopened) for up to NOTIFICATION_AGE days after
+	// the user has already approved/rejected the post - even though the badge count and
+	// the challenge-selection queries in microvolunteering.go correctly treat it as done.
+	// See Discourse 9856.
 	var notifications []Notification
-	db.Raw("SELECT * FROM users_notifications "+
+	db.Raw("SELECT users_notifications.* FROM users_notifications "+
 		"LEFT JOIN spam_users ON spam_users.userid = users_notifications.fromuser AND collection IN (?, ?) "+
-		"WHERE touser = ? AND timestamp >= ? AND spam_users.id IS NULL ORDER BY users_notifications.id DESC", utils.SPAM_COLLECTION_PENDING_ADD, utils.SPAM_COLLECTION_SPAMMER, myid, start).Scan(&notifications)
+		"LEFT JOIN microactions ON microactions.actiontype = 'CheckMessage' AND microactions.userid = users_notifications.touser "+
+		"AND users_notifications.type = 'Exhort' AND users_notifications.url = CONCAT('/microvolunteering/message/', microactions.msgid) "+
+		"WHERE users_notifications.touser = ? AND users_notifications.timestamp >= ? AND spam_users.id IS NULL AND microactions.id IS NULL "+
+		"ORDER BY users_notifications.id DESC", utils.SPAM_COLLECTION_PENDING_ADD, utils.SPAM_COLLECTION_SPAMMER, myid, start).Scan(&notifications)
 
 	if notifications == nil {
 		notifications = make([]Notification, 0)

--- a/iznik-server-go/test/notifications_test.go
+++ b/iznik-server-go/test/notifications_test.go
@@ -122,6 +122,66 @@ func TestNotificationAllSeenUnauthorized(t *testing.T) {
 	assert.Equal(t, 401, resp.StatusCode)
 }
 
+func TestNotificationListExcludesReviewedMicrovolunteeringPost(t *testing.T) {
+	// Discourse 9856 post 9: after approving a microvolunteering "post to check",
+	// the Exhort notification for that message keeps reappearing in the bell's
+	// notification list (though the badge count is correctly 0), because List()
+	// never excludes it - unlike the challenge-selection queries in
+	// microvolunteering.go, which already exclude reviewed messages via
+	// "LEFT JOIN microactions ... WHERE microactions.id IS NULL".
+	db := database.DBConn
+	prefix := uniquePrefix("notif_mv")
+
+	userID := CreateTestUser(t, prefix, "User")
+	posterID := CreateTestUser(t, prefix+"_poster", "User")
+	groupID := CreateTestGroup(t, prefix)
+	_, token := CreateTestSession(t, userID)
+
+	reviewedMsgID := CreateTestMessage(t, posterID, groupID, "Reviewed test message "+prefix, 55.9533, -3.1883)
+	pendingMsgID := CreateTestMessage(t, posterID, groupID, "Pending test message "+prefix, 55.9533, -3.1883)
+
+	// Exhort notification for a message the user has already reviewed (seen=1,
+	// exactly as PostResponse leaves it after Approve/Reject).
+	result := db.Exec("INSERT INTO users_notifications (touser, type, url, timestamp, seen) "+
+		"VALUES (?, 'Exhort', ?, NOW(), 1)", userID, fmt.Sprintf("/microvolunteering/message/%d", reviewedMsgID))
+	if result.Error != nil {
+		t.Fatalf("ERROR: Failed to create reviewed-message notification: %v", result.Error)
+	}
+	var reviewedNotifID uint64
+	db.Raw("SELECT id FROM users_notifications WHERE touser = ? AND url = ?",
+		userID, fmt.Sprintf("/microvolunteering/message/%d", reviewedMsgID)).Scan(&reviewedNotifID)
+
+	db.Exec("INSERT INTO microactions (actiontype, userid, msgid, result, version, score_negative) "+
+		"VALUES ('CheckMessage', ?, ?, 'Approve', 4, 0)", userID, reviewedMsgID)
+
+	// Exhort notification for a message the user has NOT reviewed yet - this one
+	// must stay in the list.
+	result = db.Exec("INSERT INTO users_notifications (touser, type, url, timestamp, seen) "+
+		"VALUES (?, 'Exhort', ?, NOW(), 0)", userID, fmt.Sprintf("/microvolunteering/message/%d", pendingMsgID))
+	if result.Error != nil {
+		t.Fatalf("ERROR: Failed to create pending-message notification: %v", result.Error)
+	}
+	var pendingNotifID uint64
+	db.Raw("SELECT id FROM users_notifications WHERE touser = ? AND url = ?",
+		userID, fmt.Sprintf("/microvolunteering/message/%d", pendingMsgID)).Scan(&pendingNotifID)
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/notification?jwt="+token, nil))
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var notifications []notification.Notification
+	json2.Unmarshal(rsp(resp), &notifications)
+
+	var returnedIDs []uint64
+	for _, n := range notifications {
+		returnedIDs = append(returnedIDs, uint64(n.ID))
+	}
+
+	assert.NotContains(t, returnedIDs, reviewedNotifID,
+		"an Exhort notification for an already-reviewed microvolunteering post must not stay in the list")
+	assert.Contains(t, returnedIDs, pendingNotifID,
+		"an Exhort notification for a not-yet-reviewed microvolunteering post must still be in the list")
+}
+
 func TestNotificationListRecordsUsersActive(t *testing.T) {
 	// V1 parity: notification.php GET calls $me->recordActive() which inserts a row into
 	// users_active (userid, timestamp) with timestamp truncated to the hour. This is read by


### PR DESCRIPTION
## Root Cause
Discourse 9856 post 9 (Android app v759): after approving a microvolunteering "post to check", the post's Exhort notification kept reappearing in the bell's notification list, even though the badge count correctly showed no number - and reopening the bell after "Mark all read" brought the list right back.

The bell badge count and the review list are computed by two different queries in `iznik-server-go/notification/notification.go`:
- `Count()` counts unseen (`seen = 0`) rows - already correct. `PostResponse` (in `microvolunteering.go`) sets `seen = 1` on the Exhort notification immediately when a post is approved/rejected, so the badge clears right away (matches Jacky's "No notification number showing").
- `List()` (backs the bell dropdown, via `NotificationOptions.vue` → `notificationStore.fetchList()`) returns **every** notification within the 90-day `NOTIFICATION_AGE` window regardless of `seen` status, with no exclusion for messages the user has already reviewed. Unlike the challenge-selection queries in `microvolunteering.go` (`LEFT JOIN microactions ... WHERE microactions.id IS NULL`), it never excludes a message once a `CheckMessage` microaction exists for it. So the same Exhort notification keeps resurfacing in the list - dimmed (not highlighted), but still present - for up to 90 days after being reviewed, exactly matching "post still showing" / "clicking bell reveals the list once again".

This is a genuinely separate gap from #967/#969 (backend: stop/clear stuck *unseen* notifications) and #971 (frontend: stop caching a stale `seen` flag) - none of those touch list *membership*, only the `seen` flag.

Confirmed against production (read-only, via the V2 live-DB tunnel): **7,505** current `Exhort` notifications exist where the recipient already has a matching `CheckMessage` microaction (i.e. will keep resurfacing in `List()` for up to 90 days). Checked specifically against Jacky's account (44500773): her `CheckMessage` microactions from her 2026-07-02 and 2026-07-04 retests (msgids 120046201, 120047018, 119992040, 119968892, 119953979) all still have their original `Exhort` notification row sitting in `users_notifications`, well within the 90-day window - exactly the entries she's seeing reappear.

## Evidence
New test `TestNotificationListExcludesReviewedMicrovolunteeringPost` in `iznik-server-go/test/notifications_test.go`:
- Characterized the bug first (asserted the reviewed notification **stays** in the list): passed against unfixed code.
- Inverted to the correct assertion (must **not** stay in the list, while an unreviewed one must remain): failed against unfixed code:
  ```
  Error:      	[]uint64{0x23, 0x22} should not contain 0x22
  Messages:   	an Exhort notification for an already-reviewed microvolunteering post must not stay in the list
  --- FAIL: TestNotificationListExcludesReviewedMicrovolunteeringPost (0.20s)
  ```

## Fix
`notification.List()` now LEFT JOINs `microactions` (matching on `actiontype = 'CheckMessage'`, `userid = touser`, and `url = CONCAT('/microvolunteering/message/', microactions.msgid)` - the same URL convention already used by `PostResponse`'s seen-marking update) and excludes rows where a match exists. The join is scoped to `type = 'Exhort'` and the microvolunteering URL pattern, so it only affects "post to check" nudges - other `Exhort` notifications (e.g. the unrelated "tell us your story" nudge, which uses a different URL) are unaffected, and non-Exhort notification types are untouched.

## Other Call Sites
Grepped all `SELECT ... FROM users_notifications` sites:
- `notification.Count()` (Go) - already filters `seen = 0`, unaffected by this gap.
- `NotificationChaseUpService` (Laravel, chase-up emails) - already filters `seen = 0` before emailing, unaffected.
- No other site reads `users_notifications` for display purposes.

## Test
- File: `iznik-server-go/test/notifications_test.go`
- Command: `go test ./test/... -run TestNotificationListExcludesReviewedMicrovolunteeringPost -v`
- Proves fail-before/pass-after (see Evidence). Full `iznik-server-go/test` package also run: 2000 passed, 0 failed (includes all `TestNotification*` and `TestGetMicrovolunteering*`/`TestMicrovolunteering*` tests).

## Discourse
https://discourse.ilovefreegle.org/t/9856/9