### PR TITLE
fix(notification): refresh cached seen flag on refetch (stale unread highlight)

### DIFF
--- a/iznik-nuxt3/stores/notification.js
+++ b/iznik-nuxt3/stores/notification.js
@@ -37,8 +37,17 @@ export const useNotificationStore = defineStore({
         this.list = await api(this.config).notification.list()
 
         this.list.forEach((item) => {
-          // Notifications are immutable so we can avoid triggering a re-render.
-          if (!this.listById[item.id]) {
+          const existing = this.listById[item.id]
+          if (existing) {
+            // A notification's content is immutable, so we keep the same object
+            // reference to avoid needless re-renders. But `seen` flips
+            // false->true once the user reviews what the notification points at
+            // (e.g. a microvolunteering "post to check"). Refresh it in place so
+            // components rendering via byId() reflect the latest seen status
+            // instead of the frozen unread state from the first fetch
+            // (Discourse 9856).
+            existing.seen = item.seen
+          } else {
             this.listById[item.id] = item
           }
         })

--- a/iznik-nuxt3/tests/unit/stores/notification.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/notification.spec.js
@@ -133,6 +133,29 @@ describe('notification store', () => {
       await store.fetchList()
       logSpy.mockRestore()
     })
+
+    it('refreshes the seen flag on refetch so a reviewed notification stops showing as unread (Discourse 9856)', async () => {
+      const store = useNotificationStore()
+      store.init({ public: {} })
+
+      // First load: the notification is unread.
+      mockList.mockResolvedValue([
+        { id: 1, title: 'Post to check', seen: false },
+      ])
+      await store.fetchList()
+      expect(store.byId(1).seen).toBe(false)
+
+      // The user reviews the post the notification points at; the server flips
+      // its seen flag to true. A later poll re-fetches the list.
+      mockList.mockResolvedValue([
+        { id: 1, title: 'Post to check', seen: true },
+      ])
+      await store.fetchList()
+
+      // The cached copy that components render via byId() must reflect the
+      // latest seen status, not the frozen unread state from the first fetch.
+      expect(store.byId(1).seen).toBe(true)
+    })
   })
 
   describe('seen', () => {


### PR DESCRIPTION
## What

`iznik-nuxt3/stores/notification.js` never refreshes a cached notification's `seen` flag. `fetchList()` caches each notification in `listById` the first time it is seen and, per the comment "Notifications are immutable so we can avoid triggering a re-render", never touches that cached copy again:

```js
this.list.forEach((item) => {
  // Notifications are immutable so we can avoid triggering a re-render.
  if (!this.listById[item.id]) {
    this.listById[item.id] = item
  }
})
```

Every notification-rendering path reads the cached copy via the `byId(id)` getter, not the freshly-fetched `list` array. The assumption is correct for a notification's *content* but false for `seen`: `PostResponse` (Go) and `/notification/seen` flip `seen` from `false` to `true` server-side once the user reviews what the notification points at (e.g. a microvolunteering "post to check"). Within a single browser session (no full page reload), a notification first loaded as unread keeps rendering as unread - bold / `bg-info` highlight in `NotificationOne.vue` - even after the count badge has already dropped to 0.

## Fix

When a notification already exists in `listById`, refresh its `seen` flag in place instead of skipping it. This keeps the same object reference (so unchanged content does not churn re-renders - the point of the original optimisation) while letting the one genuinely-mutable field update:

```js
this.list.forEach((item) => {
  const existing = this.listById[item.id]
  if (existing) {
    existing.seen = item.seen
  } else {
    this.listById[item.id] = item
  }
})
```

## Tests

New test in `tests/unit/stores/notification.spec.js`: `refreshes the seen flag on refetch so a reviewed notification stops showing as unread (Discourse 9856)`.
- Characterised first (TDD): asserted `byId(1).seen === true` after a second `fetchList()` returns the same id with `seen: true`. **Failed on unfixed code** (cache returned the frozen `false`) - 1 failed / 13,924 passed.
- Passes after the fix. Full suite green (13,925), including the pre-existing `does not overwrite existing listById entries` test, which still holds because content is left untouched.

## Scope / context

This is a real, self-contained store-correctness bug. It surfaced while reviewing Discourse 9856 (https://discourse.ilovefreegle.org/t/9856) but is **not claimed to be the fix for that report** - Jacky's remaining complaint there is about list *membership* (reviewed items persisting in the list), which is behaviour-by-design (see https://discourse.ilovefreegle.org/t/9856/10) and a separate product question. This PR only fixes stale *unread highlighting* within a session.

Follow-up (deliberately not bundled): `seen()` / `allSeen()` actions could also update the local `listById` copy immediately, rather than waiting for the next `fetchList()` poll, to close the up-to-60s window between voting and the highlight clearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
