### PR TITLE
chore(outreach): Gmail attachment support, NDR trash command, donation summary tests

### DIFF
--- a/.claude/skills/community-reuse-outreach/SKILL.md
+++ b/.claude/skills/community-reuse-outreach/SKILL.md
@@ -42,6 +42,22 @@ Archive every evidence URL to archive.org at the moment of checking, so the audi
 5. **Aggregate** to a spreadsheet with two sheets: **Included** (Category, Tier, Name, Website, Email, Postcode/Area, Activity evidence [URL+date+one-line], Item-cluster fit, Why they fit, Confidence, Priority) + operator columns (Decision send/skip, Sent?, Reply?, Outcome, Notes); and **Rejected** (with reason, for audit + false-negative analysis).
 6. **Validate after the clearance.** Compare the shortlist to who actually took items: true/false positives, and false negatives (orgs that took but weren't found - trace which source would have caught them). Promote responders to Tier 1; feed source gaps into the next run.
 
+## Bounce salvage (recover the bounced sends - proven on the WAGGGS clearance, 2026)
+
+A bounce usually means the *listed* address is stale, not that the org is unreachable. On the WAGGGS run, **16 of 24 bounces** yielded a different, MX-valid published address (the rest were dead orgs or email-less). Per bounced org, in order:
+
+1. **Is the org still alive? Check this FIRST**, before hunting an address. Charity Commission register (status "Removed" / "Does not operate"), Companies House (dissolved), Ofsted for nurseries/schools ("Closed"). If dead, DROP it - don't spend time. (WAGGGS run: 4 confirmed dead by exactly these registers.)
+2. **Hunt a DIFFERENT published email** from, in rough priority: the org's own site contact/about page; its Facebook page About/Contact tab; the Charity Commission register's contact-information page; the local CVS/council directory. Verbatim + source URL only; never construct or infer an address.
+3. **Grep the RAW HTML, not the WebFetch/WebSearch summary.** Those summaries invent placeholder addresses ("[email protected]", a guessed "info@..."). `curl` the page and grep for genuine `@` patterns (filter `@font-face`/`@media`/`@context` noise) and decode Cloudflare-obfuscated mailto links. A hallucinated address that then MX-passes on a real provider is the worst failure mode - it looks verified. (A group-C agent caught exactly this for a nursery.)
+4. **Common bounce patterns (check these before deep research):**
+   - Trussell Trust **foodbanks**: the generic `<branch>@foodbank.org.uk` bounces (routes to national), but a live `info@<branch>.foodbank.org.uk` sits on the branch's own site. (Held for all 3 foodbanks on the WAGGGS run.)
+   - Generic `admin@` / `office@` / `enquiries@` often bounce while `info@` or a named-person address on the same domain works.
+   - `.org` vs `.org.uk` (and similar TLD) typos in the original list.
+   - Whole-domain death (NXDOMAIN / broken DNS delegation) = no email channel at all; fall back to Facebook/phone, or drop.
+5. **MX-gate every candidate** before re-sending (`dns.resolveMx`, or `~/.claude/bin`-style helper). A resolving MX is necessary, not sufficient - it says the domain accepts mail, not that the mailbox exists.
+6. **Facebook as the fallback channel.** When no email survives but the org has an active, ownership-verified Facebook page (linked from its own site, or a handle its own site confirms), message the page / post the offer - a manual, human-in-the-loop step. Login walls block dating posts, so verify the page is *theirs* via a link on their own site and treat activity as "unknown" rather than guessing a URL.
+7. **Re-send is a fresh send:** same one-cluster discipline, same human sign-off, and add BOTH the bounced and the new address to the ledger (suppression + alternatives) so the next run starts clean.
+
 ## The output is a candidate list, NOT a send list
 
 A human reviews and marks send/skip PER ROW. The whole exercise is stakeable on one bad email, so the human gate is deliberate and sticky (no bulk-send > 5; rate-limit ~20/hour). Tier 1 first, then Tier 2 one-cluster emails, each naming specific items - no mail-merge. Sign as the human facilitator, never "AI".
@@ -52,7 +68,9 @@ A human reviews and marks send/skip PER ROW. The whole exercise is stakeable on 
 - **Scope the donor's upfront ask in ONE go**, not across drifting messages: item name, dimensions (H x W x D), condition (rubric, eBay-style), dismantlable?, notes, a photo per item, and a **number per item**. Orgs will do surprising amounts of upfront work if the ask is clear and single.
 - **Item numbers and measurements are essential** - "I'd like the desk and the chest with two drawers" is undisambiguable across 50 desks without them.
 - **Open days** (people come in pairs to look before committing) dramatically raise uptake - worth offering if the donor organises early; allocate with a short memorable word-code, not QR.
+- **Waiting list, don't dead-end.** When a replier wants only items already allocated/gone, don't just say no - reply that they're **on the waiting list** and you'll come back if it frees up or more is confirmed. Keep a waiting-list table; call-back order when an item frees is priority orgs first, individuals last. Costs nothing, keeps goodwill, and catches the common case where a promised collection falls through.
 - **PECR / privacy:** legitimate-interest basis, published org addresses only, never individuals; one email per org per ~6 months; persistent suppression list for opt-outs.
+- **WebFetch/WebSearch hallucinate email addresses** (placeholder "[email protected]", plausible-looking "info@..." guesses). Verify every address against the RAW page HTML or the Charity Commission register before trusting it - a hallucinated address that MX-passes on a real provider looks fully verified but isn't. Provenance rule: verbatim published address + source URL + MX gate, always.
 
 ## Files
 - `reuse-organisations.md` - **the Tier-1 directory**: 73 verified UK reuse organisations and networks by material type (furniture, electricals, IT, bikes/tools, books, textiles/uniform/baby, paint/wood/scrap), each with a "find your local branch/member" route. Start here for Tier 1.

--- a/iznik-batch/app/Console/Commands/BulkOffer/ReplyGmailOutreachCommand.php
+++ b/iznik-batch/app/Console/Commands/BulkOffer/ReplyGmailOutreachCommand.php
@@ -18,7 +18,9 @@ class ReplyGmailOutreachCommand extends Command
 {
     protected $signature = 'bulkoffer:reply-outreach
                             {--thread= : Gmail thread id to reply in (required)}
-                            {--body= : Reply text (required)}
+                            {--body= : Reply text (or use --body-file)}
+                            {--body-file= : Read the reply text from a file (alternative to --body)}
+                            {--attach= : Files to attach: a directory (all files in it) or a comma-separated list of paths}
                             {--live : Actually send when the mailbox is configured live}';
 
     protected $description = 'Send a concierge reply in an outreach mail thread (mailbox FSM transport)';
@@ -27,9 +29,23 @@ class ReplyGmailOutreachCommand extends Command
     {
         $threadId = (string) $this->option('thread');
         $body = (string) $this->option('body');
-        if ($threadId === '' || trim($body) === '') {
-            $this->error('--thread and --body are required.');
+        if ($this->option('body-file')) {
+            $path = (string) $this->option('body-file');
+            if (! is_file($path)) {
+                $this->error("--body-file not found: {$path}");
 
+                return self::FAILURE;
+            }
+            $body = (string) file_get_contents($path);
+        }
+        if ($threadId === '' || trim($body) === '') {
+            $this->error('--thread and a reply body (--body or --body-file) are required.');
+
+            return self::FAILURE;
+        }
+
+        $attachments = $this->resolveAttachments((string) $this->option('attach'));
+        if ($attachments === null) {
             return self::FAILURE;
         }
         if (! $gmail->isDryRun() && ! $this->option('live')) {
@@ -75,6 +91,7 @@ class ReplyGmailOutreachCommand extends Command
                 html: $html,
                 text: $text,
                 headers: $headers,
+                attachments: $attachments,
             );
         } catch (\Throwable $e) {
             $this->error("Send failed: {$e->getMessage()}");
@@ -120,5 +137,41 @@ class ReplyGmailOutreachCommand extends Command
         }
 
         return $ctx;
+    }
+
+    /**
+     * Resolve the --attach option into an attachments array for GmailService::send.
+     * Accepts a directory (all files within) or a comma-separated list of paths.
+     * Returns [] when empty, or null (with an error printed) if any path is missing.
+     *
+     * @return array<int,array{path:string,name:string}>|null
+     */
+    private function resolveAttachments(string $spec): ?array
+    {
+        $spec = trim($spec);
+        if ($spec === '') {
+            return [];
+        }
+
+        if (is_dir($spec)) {
+            $paths = array_values(array_filter(
+                glob(rtrim($spec, '/').'/*') ?: [],
+                'is_file'
+            ));
+        } else {
+            $paths = array_map('trim', explode(',', $spec));
+        }
+
+        $out = [];
+        foreach ($paths as $p) {
+            if ($p === '' || ! is_file($p)) {
+                $this->error("--attach path not found: {$p}");
+
+                return null;
+            }
+            $out[] = ['path' => $p, 'name' => basename($p)];
+        }
+
+        return $out;
     }
 }

--- a/iznik-batch/app/Console/Commands/BulkOffer/TrashOutreachCommand.php
+++ b/iznik-batch/app/Console/Commands/BulkOffer/TrashOutreachCommand.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Console\Commands\BulkOffer;
+
+use App\Services\Gmail\GmailService;
+use Illuminate\Console\Command;
+
+/**
+ * Move matching mailbox messages to Trash - e.g. delivery-failure NDRs whose
+ * bounce has already been handled (address corrected + re-queued, or org marked
+ * defunct), so the outreach inbox stays clean. Reusable: pass any Gmail search.
+ *
+ * Dry-run by default (lists what it would trash); --live actually trashes.
+ */
+class TrashOutreachCommand extends Command
+{
+    protected $signature = 'bulkoffer:trash-outreach
+                            {--query= : Gmail search for messages to trash (required)}
+                            {--live : Actually trash; default is a dry-run listing}';
+
+    protected $description = 'Move matching outreach-mailbox messages (e.g. handled bounce NDRs) to Trash';
+
+    public function handle(GmailService $gmail): int
+    {
+        $query = trim((string) $this->option('query'));
+        if ($query === '') {
+            $this->error('--query is required.');
+
+            return self::FAILURE;
+        }
+
+        try {
+            $threads = $gmail->listThreads($query, 100);
+        } catch (\Throwable $e) {
+            $this->error('listThreads failed: '.$e->getMessage());
+
+            return self::FAILURE;
+        }
+
+        $live = (bool) $this->option('live');
+        $count = 0;
+        foreach ($threads as $t) {
+            $threadId = $t['id'] ?? null;
+            if (! $threadId) {
+                continue;
+            }
+            try {
+                $full = $gmail->getThread($threadId);
+            } catch (\Throwable $e) {
+                $this->warn("getThread {$threadId} failed: {$e->getMessage()}");
+
+                continue;
+            }
+            foreach (($full['messages'] ?? []) as $m) {
+                if (empty($m['id'])) {
+                    continue;
+                }
+                // Only touch messages actually in the Inbox: Gmail threads a bounce
+                // NDR together with our own Sent copy, and we must not trash the latter.
+                if (! in_array('INBOX', $m['labelIds'] ?? [], true)) {
+                    continue;
+                }
+                $subject = '';
+                foreach (($m['payload']['headers'] ?? []) as $h) {
+                    if (isset($h['name']) && strtolower($h['name']) === 'subject') {
+                        $subject = $h['value'] ?? '';
+                    }
+                }
+                if ($live) {
+                    try {
+                        $gmail->modifyMessageLabels($m['id'], ['TRASH']);
+                    } catch (\Throwable $e) {
+                        $this->warn("trash {$m['id']} failed: {$e->getMessage()}");
+
+                        continue;
+                    }
+                }
+                $this->line(($live ? 'TRASHED ' : 'would trash ').$m['id'].'  '.substr($subject, 0, 80));
+                $count++;
+            }
+        }
+
+        $this->info(($live ? 'Trashed ' : 'Would trash ').$count.' message(s) matching: '.$query);
+
+        return self::SUCCESS;
+    }
+}

--- a/iznik-batch/app/Services/Gmail/GmailService.php
+++ b/iznik-batch/app/Services/Gmail/GmailService.php
@@ -75,6 +75,7 @@ class GmailService
         ?Address $replyTo = null,
         array $headers = [],
         ?string $fromName = null,
+        array $attachments = [],
     ): array {
         $from = new Address($this->mailbox, $fromName ?? (string) config('services.gmail_outreach.from_name', 'Natalie @ Freegle'));
 
@@ -84,6 +85,16 @@ class GmailService
             ->subject($subject)
             ->text($text)
             ->html($html);
+
+        // Optional file attachments: each item is a path string, or an array
+        // ['path' => ..., 'name' => ?display name, 'type' => ?content type].
+        foreach ($attachments as $att) {
+            if (is_array($att)) {
+                $email->attachFromPath($att['path'], $att['name'] ?? null, $att['type'] ?? null);
+            } else {
+                $email->attachFromPath($att);
+            }
+        }
 
         if ($replyTo) {
             $email->replyTo($replyTo);

--- a/iznik-batch/tests/Unit/Services/DonationSummaryServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/DonationSummaryServiceTest.php
@@ -1,0 +1,256 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Mail\Donation\DonationSummaryMail;
+use App\Models\Group;
+use App\Models\Membership;
+use App\Services\DonationSummaryService;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Mail;
+use Tests\TestCase;
+
+class DonationSummaryServiceTest extends TestCase
+{
+    private DonationSummaryService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->service = new DonationSummaryService();
+
+        // The service queries users_donations globally (no group/day scoping
+        // beyond "today"), so any committed rows left by a previous test
+        // method would inflate counts/totals for this test.
+        DB::table('users_donations')->whereRaw('DATE(timestamp) = DATE(NOW())')->delete();
+    }
+
+    private function insertDonation(array $attributes = []): void
+    {
+        DB::insert(
+            'INSERT INTO users_donations (userid, GrossAmount, TransactionType, Payer, timestamp)
+             VALUES (?, ?, ?, ?, ?)',
+            [
+                $attributes['userid'] ?? null,
+                $attributes['GrossAmount'] ?? 10.00,
+                $attributes['TransactionType'] ?? 'Completed',
+                $attributes['Payer'] ?? 'donor@example.com',
+                $attributes['timestamp'] ?? now(),
+            ]
+        );
+    }
+
+    public function test_no_donations_returns_zero_result_and_sends_nothing(): void
+    {
+        Mail::fake();
+
+        $result = $this->service->sendDailySummary();
+
+        $this->assertSame(['donations' => 0, 'total' => 0.0, 'sent' => false], $result);
+        Mail::assertNothingSent();
+    }
+
+    public function test_sums_multiple_donations_and_sends_one_email(): void
+    {
+        Mail::fake();
+
+        $this->insertDonation(['GrossAmount' => 15.00, 'Payer' => 'alice@example.com']);
+        $this->insertDonation(['GrossAmount' => 25.50, 'Payer' => 'bob@example.com']);
+        $this->insertDonation(['GrossAmount' => 4.49, 'Payer' => 'carol@example.com']);
+
+        $result = $this->service->sendDailySummary();
+
+        $this->assertSame(3, $result['donations']);
+        $this->assertEqualsWithDelta(44.99, $result['total'], 0.001);
+        $this->assertTrue($result['sent']);
+
+        Mail::assertSentCount(1);
+        Mail::assertSent(DonationSummaryMail::class, function ($mail) {
+            return $mail->recipientEmail === config('freegle.mail.fundraising_addr')
+                && abs($mail->total - 44.99) < 0.001
+                && str_contains($mail->htmlContent, 'alice@example.com')
+                && str_contains($mail->htmlContent, 'bob@example.com')
+                && str_contains($mail->htmlContent, 'carol@example.com');
+        });
+    }
+
+    public function test_dry_run_reports_totals_but_sends_nothing(): void
+    {
+        Mail::fake();
+
+        $this->insertDonation(['GrossAmount' => 20.00]);
+
+        $result = $this->service->sendDailySummary(true);
+
+        $this->assertSame(1, $result['donations']);
+        $this->assertEqualsWithDelta(20.00, $result['total'], 0.001);
+        $this->assertFalse($result['sent']);
+
+        Mail::assertNothingSent();
+    }
+
+    public function test_ignores_donations_from_other_days(): void
+    {
+        Mail::fake();
+
+        $this->insertDonation(['GrossAmount' => 50.00, 'timestamp' => now()->subDay()]);
+        $this->insertDonation(['GrossAmount' => 5.00, 'timestamp' => now()->addDay()]);
+
+        $result = $this->service->sendDailySummary();
+
+        $this->assertSame(['donations' => 0, 'total' => 0.0, 'sent' => false], $result);
+        Mail::assertNothingSent();
+    }
+
+    public function test_flags_recurring_payment_type(): void
+    {
+        Mail::fake();
+
+        $this->insertDonation(['GrossAmount' => 5.00, 'TransactionType' => 'recurring_payment']);
+
+        $this->service->sendDailySummary();
+
+        Mail::assertSent(DonationSummaryMail::class, function ($mail) {
+            return str_contains($mail->htmlContent, 'Recurring');
+        });
+    }
+
+    public function test_flags_subscr_payment_type_as_recurring(): void
+    {
+        Mail::fake();
+
+        $this->insertDonation(['GrossAmount' => 5.00, 'TransactionType' => 'subscr_payment']);
+
+        $this->service->sendDailySummary();
+
+        Mail::assertSent(DonationSummaryMail::class, function ($mail) {
+            return str_contains($mail->htmlContent, 'Recurring');
+        });
+    }
+
+    public function test_does_not_flag_a_one_off_completed_payment_as_recurring(): void
+    {
+        Mail::fake();
+
+        $this->insertDonation(['GrossAmount' => 5.00, 'TransactionType' => 'Completed']);
+
+        $this->service->sendDailySummary();
+
+        Mail::assertSent(DonationSummaryMail::class, function ($mail) {
+            return !str_contains($mail->htmlContent, 'Recurring');
+        });
+    }
+
+    public function test_escapes_html_special_characters_in_payer_name(): void
+    {
+        Mail::fake();
+
+        $this->insertDonation(['GrossAmount' => 5.00, 'Payer' => '<script>alert("x")</script>']);
+
+        $this->service->sendDailySummary();
+
+        Mail::assertSent(DonationSummaryMail::class, function ($mail) {
+            return !str_contains($mail->htmlContent, '<script>')
+                && str_contains($mail->htmlContent, '&lt;script&gt;');
+        });
+    }
+
+    public function test_flags_birthday_for_donor_whose_group_was_founded_on_this_day(): void
+    {
+        Mail::fake();
+
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup([
+            'onmap' => 1,
+            'founded' => now()->subYears(3)->format('Y-m-d'),
+        ]);
+        $this->createMembership($user, $group, ['role' => Membership::ROLE_MEMBER]);
+
+        $this->insertDonation([
+            'userid' => $user->id,
+            'GrossAmount' => 12.00,
+            'TransactionType' => 'Completed',
+        ]);
+
+        $this->service->sendDailySummary();
+
+        Mail::assertSent(DonationSummaryMail::class, function ($mail) {
+            return str_contains($mail->htmlContent, 'Birthday?');
+        });
+    }
+
+    public function test_does_not_flag_birthday_when_no_matching_group_anniversary(): void
+    {
+        Mail::fake();
+
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup([
+            'onmap' => 1,
+            // Founded six months from now (mod 12) - never matches today/yesterday/two-days-ago.
+            'founded' => now()->addMonths(6)->subYears(2)->format('Y-m-d'),
+        ]);
+        $this->createMembership($user, $group, ['role' => Membership::ROLE_MEMBER]);
+
+        $this->insertDonation([
+            'userid' => $user->id,
+            'GrossAmount' => 12.00,
+            'TransactionType' => 'Completed',
+        ]);
+
+        $this->service->sendDailySummary();
+
+        Mail::assertSent(DonationSummaryMail::class, function ($mail) {
+            return !str_contains($mail->htmlContent, 'Birthday?');
+        });
+    }
+
+    public function test_does_not_check_birthday_when_donation_has_no_userid(): void
+    {
+        Mail::fake();
+
+        // No userid on the donation - donorHasBirthdayGroup should never run,
+        // regardless of any birthday groups that may exist in the database.
+        $this->insertDonation(['userid' => null, 'GrossAmount' => 8.00]);
+
+        $result = $this->service->sendDailySummary();
+
+        $this->assertSame(1, $result['donations']);
+        Mail::assertSent(DonationSummaryMail::class, function ($mail) {
+            return !str_contains($mail->htmlContent, 'Birthday?');
+        });
+    }
+
+    public function test_skips_birthday_check_when_matching_recurring_donation_seen_last_month(): void
+    {
+        Mail::fake();
+
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup([
+            'onmap' => 1,
+            'founded' => now()->subYears(4)->format('Y-m-d'),
+        ]);
+        $this->createMembership($user, $group, ['role' => Membership::ROLE_MEMBER]);
+
+        // A prior recurring donation of the same amount within the last month
+        // makes the service skip the (expensive) birthday check entirely, even
+        // though this donor genuinely belongs to a group with today's anniversary.
+        $this->insertDonation([
+            'userid' => $user->id,
+            'GrossAmount' => 9.99,
+            'TransactionType' => 'recurring_payment',
+            'timestamp' => now()->subDays(10),
+        ]);
+        $this->insertDonation([
+            'userid' => $user->id,
+            'GrossAmount' => 9.99,
+            'TransactionType' => 'recurring_payment',
+        ]);
+
+        $this->service->sendDailySummary();
+
+        Mail::assertSent(DonationSummaryMail::class, function ($mail) {
+            return !str_contains($mail->htmlContent, 'Birthday?');
+        });
+    }
+}


### PR DESCRIPTION
Audited uncommitted working-tree items from earlier outreach/donation sessions - in neither master nor any open PR - given a home. Gmail attachment plumbing for the outreach sender, the NDR bounce-trash command, unit tests for DonationSummaryService, and outreach-skill doc updates. Full Laravel suite green locally with these present (4,713).