### PR TITLE
docs(plans): reach-design evidence pack; monitor-fsm ops scripts

### DIFF
--- a/monitor-fsm/reply-watch.sh
+++ b/monitor-fsm/reply-watch.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# Lightweight Discourse reply watcher for the threads where AI Edward posted
+# fix-confirmations this session. Surfaces only NEW posts (after startup) NOT
+# authored by Edward_Hibbert (mod/member replies, incl. retest results), then
+# exits so the harness notifies the agent to assess + refix; the agent restarts
+# this afterwards (re-seeds past the assessed posts).
+#
+# Robustness: Discourse rate-limits rapid requests, so a naive seed of 22
+# threads back-to-back returns empty for the later ones, defaulting their
+# baseline to 0 and flagging their entire history. Guards against that:
+#   - inter-request delay + retry-on-empty when reading highest_post_number
+#   - baseline 0 == "not yet seeded": never flag on it, just set it silently
+#   - only flag when we have a valid prior baseline (>0) AND a valid new count
+
+set -u
+KEY=$(python3 -c "import json;print(json.load(open('/home/edward/profile.json'))['auth_pairs'][0]['user_api_key'])")
+BASE="https://discourse.ilovefreegle.org"
+TOPICS="9481 9518 9582 9592 9597 9610 9620 9672 9703 9707 9741 9770 9783 9793 9806 9808 9812 9815 9816 9828 9833 9839"
+DELAY=0.8   # between requests, to stay under Discourse rate limits
+
+# Fetch a topic's JSON into $REPLY_JSON and its highest_post_number into $REPLY_HP.
+# Retries on empty/non-numeric (rate limit / transient). $REPLY_HP="" if it can't.
+fetch_topic() {
+  local t=$1 tries=0 hp json
+  REPLY_JSON=""; REPLY_HP=""
+  while [ $tries -lt 4 ]; do
+    json=$(curl -s -H "User-Api-Key: $KEY" "$BASE/t/$t.json")
+    hp=$(printf '%s' "$json" | python3 -c "import sys,json
+try: print(json.load(sys.stdin).get('highest_post_number',''))
+except Exception: print('')" 2>/dev/null)
+    if [ -n "$hp" ] && [ "$hp" -eq "$hp" ] 2>/dev/null; then
+      REPLY_JSON="$json"; REPLY_HP="$hp"; return 0
+    fi
+    tries=$((tries+1)); sleep 2
+  done
+  return 1
+}
+
+declare -A SEEN
+for t in $TOPICS; do
+  if fetch_topic "$t"; then SEEN[$t]=$REPLY_HP; else SEEN[$t]=0; fi
+  sleep "$DELAY"
+done
+seeded=0; for t in $TOPICS; do [ "${SEEN[$t]:-0}" -gt 0 ] && seeded=$((seeded+1)); done
+echo "[seeded] $seeded/$(echo $TOPICS | wc -w) threads have a valid baseline at startup"
+
+while true; do
+  ts=$(date '+%H:%M')
+  found=0; out=""
+  for t in $TOPICS; do
+    if ! fetch_topic "$t"; then sleep "$DELAY"; continue; fi   # transient: skip this cycle
+    hp=$REPLY_HP; last=${SEEN[$t]:-0}
+    if [ "$last" -eq 0 ]; then SEEN[$t]=$hp; sleep "$DELAY"; continue; fi  # late seed, don't flag
+    if [ "$hp" -gt "$last" ]; then
+      new=$(printf '%s' "$REPLY_JSON" | python3 -c "
+import sys,json,re
+d=json.load(sys.stdin); last=$last
+for p in d.get('post_stream',{}).get('posts',[]):
+    n=p.get('post_number',0)
+    if n>last and p.get('username')!='Edward_Hibbert':
+        raw=re.sub(r'<[^>]+>',' ',p.get('cooked','')); raw=re.sub(r'\s+',' ',raw).strip()
+        print(f\"  {d.get('title','')[:45]} ($t/{n}) {p.get('username')}: {raw[:200]}\")
+" 2>/dev/null)
+      [ -n "$new" ] && { out="$out$new"$'\n'; found=1; }
+      SEEN[$t]=$hp
+    fi
+    sleep "$DELAY"
+  done
+  if [ "$found" -eq 1 ]; then
+    echo "[$ts] NEW MOD REPLIES - need assessment/refix:"
+    printf '%s' "$out"
+    exit 0
+  fi
+  echo "[$ts] no new replies on $(echo $TOPICS | wc -w) threads"
+  sleep 2700
+done

--- a/monitor-fsm/wf-bulk-understand.js
+++ b/monitor-fsm/wf-bulk-understand.js
@@ -1,0 +1,85 @@
+export const meta = {
+  name: 'bulk-offer-feature-understand',
+  description: 'Map the PR 618 bulk-offer feature end to end (poster, replier, mod, lifecycle) for docs + PR text + video',
+  phases: [{ title: 'Understand' }, { title: 'Synthesize' }],
+}
+
+const FIND = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    summary: { type: 'string' },
+    steps: {
+      type: 'array',
+      description: 'ordered user-visible steps in plain English for this perspective',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          step: { type: 'string' },
+          how: { type: 'string', description: 'what the user does / sees' },
+          behindScenes: { type: 'string', description: 'what the code does, with file:line' },
+        },
+        required: ['step', 'how', 'behindScenes'],
+      },
+    },
+    components: { type: 'array', items: { type: 'string' }, description: 'key files/components for this perspective' },
+    gotchas: { type: 'array', items: { type: 'string' } },
+  },
+  required: ['summary', 'steps', 'components', 'gotchas'],
+}
+
+const BR = 'origin/feature/bulk-offer-clearance'
+const NUXT = '/home/edward/FreegleDockerWSL/iznik-nuxt3'
+const GO = '/home/edward/FreegleDockerWSL/iznik-server-go'
+const note = 'The PR branch is ' + BR + '; to read a file as it exists on the branch use: git show ' + BR + ':<path>. The current working tree is on a DIFFERENT branch, so read via git show, not the working copy.'
+
+phase('Understand')
+
+const readers = [
+  {
+    label: 'poster-compose-flow',
+    prompt: note + '\n\nMap how a POSTER creates a bulk/clearance offer in PR 618. Read (via git show ' + BR + ':PATH): ' + NUXT + '/composables/useBulkItems.js (the spreadsheet/paste parser), ' + NUXT + '/components/BulkItemEditor.vue, ' + NUXT + '/stores/compose.js (bulk handling, search photourl/bulk), and the Go create path ' + GO + '/message/message.go around lines 3300-3360 and 3880-3920 (where bulk items + ingestBulkItemPhotos are handled) and ' + GO + '/message/bulkItem.go upsertBulkItems. Explain in PLAIN ENGLISH: how does a poster enter many items at once (paste a spreadsheet? columns: name/quantity/condition/dimensions/photourl/description)? How are photos handled? What does posting do? Return ordered steps (what the poster does + behindScenes file:line), key components, gotchas.',
+  },
+  {
+    label: 'replier-interest-flow',
+    prompt: note + '\n\nMap how a REPLIER expresses interest in items of a bulk offer in PR 618. Read: ' + NUXT + '/components/BulkItemsInterest.vue, ' + NUXT + '/components/BulkInterestEditor.vue, and Go ' + GO + '/message/bulkItem.go handleBulkInterest + LoadBulkItems + the messages_bulk_items_interest model. Explain in PLAIN ENGLISH: how does a replier pick which items and quantities they want, say when they can collect (cancollect), and what happens (a single consolidated "Interested" chat message to the giver; per-item interest rows; re-express updates not spams). What can the replier see of others interest (privacy)? Return ordered steps (replier does + behindScenes file:line), key components, gotchas.',
+  },
+  {
+    label: 'giver-handling-and-collection',
+    prompt: note + '\n\nMap how the GIVER/offerer HANDLES replies and arranges COLLECTION in PR 618. Read Go ' + GO + '/message/bulkItem.go (interest states: Interested/Reserved/Collected/Rejected/Withdrawn; HandleBulkInterestStateBatch; routes /message/bulk/state) and frontend ' + NUXT + '/components/ClearanceManageItem.vue + any ClearanceManage*/BulkManage* component (find them: git grep -l Clearance ' + BR + '). Explain in PLAIN ENGLISH: how does the giver see who wants what, reserve items for people, mark items collected/rejected, handle quantities across multiple repliers, and set/agree collection times? How are repliers notified of state changes? Return ordered steps (giver does + behindScenes file:line), key components, gotchas.',
+  },
+  {
+    label: 'mod-modtools-flow',
+    prompt: note + '\n\nMap what MODS see and do with bulk/clearance offers in PR 618. Find and read the ModTools components: git grep -l -iE "bulk|clearance" ' + BR + ' -- ' + NUXT + '/modtools ; read ' + NUXT + '/modtools/components/ModBulkPreviewModal.vue and any mod bulk view, plus how a bulk offer appears in the mod message view/approval queue (does it show the item catalogue? interest counts?). Explain in PLAIN ENGLISH what a mod sees when moderating/approving a bulk offer and any mod-only actions. Return ordered steps (mod sees/does + behindScenes file:line), key components, gotchas.',
+  },
+  {
+    label: 'pr-scope-inventory',
+    prompt: note + '\n\nInventory WHAT IS IN PR 618 for a descriptive (non-historical) PR write-up. Run: git diff --stat origin/master..' + BR + ' and group the changed files by area (DB migrations for messages_bulk_items + messages_bulk_items_interest; Go message/bulkItem.go + routes; Nuxt compose + interest + manage components; ModTools; batch/Laravel commands e.g. ImportOrgsCommand, notification/digest changes; tests). Read the migration(s) that create the bulk tables (git grep -l bulk_items ' + BR + ' -- iznik-batch/database/migrations) and summarise the schema. Return: a structured inventory of the PR contents by area (so a reader knows WHAT the PR adds), key components, and gotchas. Use the steps array to list each area as one entry (step=area name, how=what it adds, behindScenes=key files).',
+  },
+]
+
+const findings = (
+  await parallel(readers.map((r) => () => agent(r.prompt, { label: r.label, phase: 'Understand', schema: FIND })))
+).filter(Boolean)
+
+phase('Synthesize')
+const OUT = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    posterDocOutline: { type: 'array', items: { type: 'string' } },
+    replierDocOutline: { type: 'array', items: { type: 'string' } },
+    modDocOutline: { type: 'array', items: { type: 'string' } },
+    prDescriptionOutline: { type: 'array', items: { type: 'string' } },
+    videoShotList: { type: 'array', items: { type: 'string' } },
+    openQuestions: { type: 'array', items: { type: 'string' } },
+  },
+  required: ['posterDocOutline', 'replierDocOutline', 'modDocOutline', 'prDescriptionOutline', 'videoShotList', 'openQuestions'],
+}
+const syn = await agent(
+  'From these per-perspective findings on the PR 618 bulk-offer feature, produce outlines (bullet lists) for: (a) a plain-English poster doc, (b) a plain-English replier doc, (c) a plain-English mod doc, (d) a DESCRIPTIVE (not historical) PR description, and (e) a video shot list covering compose -> reply -> giver handling -> collection -> ModTools. Keep everything concrete and grounded in the findings. Findings JSON:\n\n' + JSON.stringify(findings, null, 2),
+  { label: 'synthesize', phase: 'Synthesize', schema: OUT }
+)
+
+return { findings, syn }

--- a/monitor-fsm/wf-phase1b.js
+++ b/monitor-fsm/wf-phase1b.js
@@ -1,0 +1,119 @@
+export const meta = {
+  name: 'jobs-phase1b-impressions-understand',
+  description: 'Map exact integration points for Phase 1b job/playwire impression logging, then spec + critique',
+  phases: [
+    { title: 'Understand' },
+    { title: 'Design' },
+    { title: 'Critique' },
+  ],
+}
+
+const FIND = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    summary: { type: 'string' },
+    facts: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        properties: { claim: { type: 'string' }, evidence: { type: 'string' } },
+        required: ['claim', 'evidence'],
+      },
+    },
+    recommendation: { type: 'string' },
+  },
+  required: ['summary', 'facts', 'recommendation'],
+}
+
+const ROOT = '/home/edward/FreegleDockerWSL'
+phase('Understand')
+
+const readers = [
+  {
+    label: 'jobone-impression-hooks',
+    prompt:
+      'Read ' + ROOT + '/iznik-nuxt3/components/JobOne.vue FULLY. I am adding a job IMPRESSION beacon (fired when the ad has dwelt in view) for Phase 1b. Find with exact line numbers: (1) Any existing IntersectionObserver / visibility detection and the job_ad_visible (or similar) action call - quote it. (2) Is there a dwell timer already, or must I add one? (3) Search the WHOLE iznik-nuxt3 repo for getSessionId, freegle_session_id, sessionStorage, useSession and report exactly how a stable session id is obtained. (4) Is there an abVariant prop or A/B variant available? (5) How does JobOne talk to the server today (jobStore.log -> JobAPI -> $postv2)? Could the impression reuse that path or use $fetch to /apiv2/job/impression? Return facts with file:line evidence and a recommendation for exactly where/how to fire a per-job impression with type=job, placement (props.context), page (router route name), session, position, list_length.',
+  },
+  {
+    label: 'externalda-fill-detection',
+    prompt:
+      'Read ' + ROOT + '/iznik-nuxt3/components/ExternalDa.vue FULLY (recently changed to thread a placement prop). For Phase 1b I must fire a NON-job impression (type = playwire|adsense|prebid|fallback) when a non-job fill renders, so job vs Playwire is comparable. Determine: (1) JobsDaSlot/OurPlaywireDa/OurGoogleDa/OurPrebidDa all emit rendered routed to rippleRendered(). At the moment rippleRendered fires, how can I tell WHICH fill rendered? Quote the template v-if/v-else-if chain (playWire/adSense refs) and rippleRendered(). (2) Does ExternalDa have placement (yes) and can it get the page/route name (does it import useRouter)? (3) Is a session id available here? (4) Recommend the cleanest way to fire ONE non-job impression when a non-job fill becomes viewable (checkStillVisible already enforces a 100ms delay) WITHOUT double-firing for the job fill (JobOne logs its own). Return facts with file:line evidence + recommendation.',
+  },
+  {
+    label: 'go-impression-reference',
+    prompt:
+      'In ' + ROOT + '/iznik-server-go: (1) Read browse/scroll.go END TO END as the reference for a fire-and-forget POST logging endpoint - how it reads the JSON body, validates/bot-filters, obtains userid (auth), runs INSERT ... ON DUPLICATE KEY UPDATE, returns. Quote the handler. (2) Read job/job.go RecordJobClick to see how it gets userid (c.Locals session) - quote that block. (3) Find where /job and /scrolldepth routes are registered (router/routes.go) and quote the lines. (4) Note the package + imports a new RecordJobImpression in job/job.go would need. Return facts with file:line evidence and the exact skeleton to mirror for RecordJobImpression.',
+  },
+  {
+    label: 'session-and-test-patterns',
+    prompt:
+      'In ' + ROOT + ': (1) iznik-nuxt3 - how is a stable per-session/per-browser id generated and stored? Search for sessionStorage, localStorage, freegle_session_id, getSessionId, uniqueId, useSession; report the exact helper to call from JobOne/ExternalDa. (2) Any existing frontend code that POSTs a fire-and-forget analytics beacon to /apiv2 (search /apiv2/ with POST, $fetch, scrolldepth)? Quote it. (3) In iznik-server-go/test read jobs_test.go and any scroll/browse test to learn the harness for a POST logging endpoint (getApp().Test, CreateTestJob, DBConn.Raw asserts). Return patterns + a recommendation for how the beacon obtains and sends the session id, and how to test RecordJobImpression.',
+  },
+]
+
+const findings = (
+  await parallel(
+    readers.map((r) => () => agent(r.prompt, { label: r.label, phase: 'Understand', schema: FIND }))
+  )
+).filter(Boolean)
+
+phase('Design')
+const SPEC = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    migration: { type: 'string' },
+    goHandler: { type: 'string' },
+    joboneChange: { type: 'string' },
+    externaldaChange: { type: 'string' },
+    sessionMechanism: { type: 'string' },
+    tests: { type: 'string' },
+    openQuestions: { type: 'array', items: { type: 'string' } },
+  },
+  required: ['migration', 'goHandler', 'joboneChange', 'externaldaChange', 'sessionMechanism', 'tests', 'openQuestions'],
+}
+const designInput = JSON.stringify(findings, null, 2)
+const designPrompt =
+  'Design Phase 1b: job + non-job (Playwire/AdSense/Prebid) impression logging into logs_job_impressions, so revenue-per-impression and job-vs-Playwire are measurable per (placement, page). Findings JSON:\n\n' +
+  designInput +
+  '\n\nThe plan file ' + ROOT + '/plans/2026-06-29-jobs-optimization-plan.md Phase 1b section already sketches the table (type, placement, page, jobid nullable, variant, position, session, unique key) and the approach - read it and align. Produce a concrete, minimal, correct, idempotent spec: migration (hasTable/hasColumn guards), Go RecordJobImpression mirroring the scroll-depth handler exactly (fire-and-forget, bot filter gated on type=job, type+placement allowlist normalisation, INSERT ON DUPLICATE KEY), route registration, JobOne dwell-confirmed type=job beacon, ExternalDa per-fill non-job beacon (no double count), session mechanism, and tests. Be explicit about every file and line touched. NOTE: MySQL treats NULL as distinct in UNIQUE keys, so a UNIQUE key including a nullable jobid will NOT dedupe non-job rows; account for this.'
+const spec = await agent(designPrompt, { label: 'design-spec', phase: 'Design', schema: SPEC })
+
+phase('Critique')
+const CRIT = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    verdict: { type: 'string', enum: ['sound', 'needs-changes'] },
+    problems: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          issue: { type: 'string' },
+          severity: { type: 'string', enum: ['blocker', 'major', 'minor'] },
+          fix: { type: 'string' },
+        },
+        required: ['issue', 'severity', 'fix'],
+      },
+    },
+    finalRecommendation: { type: 'string' },
+  },
+  required: ['verdict', 'problems', 'finalRecommendation'],
+}
+const lenses = ['double-counting-and-dedup', 'bot-filter-and-nullable-jobid', 'session-and-frontend-hotpath', 'test-completeness']
+const critiques = (
+  await parallel(
+    lenses.map((lens) => () =>
+      agent(
+        'Adversarially critique this Phase 1b impression-logging spec through the lens of ' + lens + '. Spec:\n\n' + JSON.stringify(spec) + '\n\nFindings:\n\n' + designInput + '\n\nHunt for: double-counting (job impression fired by BOTH JobOne and ExternalDa; the same fill firing twice on re-intersection/re-render; the UNIQUE key not preventing dupes because jobid is NULL for non-job fills and MySQL treats NULL as distinct); bot/empty filter dropping legitimate non-job impressions that have no jobid; nullable jobid handling in the Go INSERT; firing on the ad hot path causing perf issues; session id absent on SSR; tests not proving dedup or the playwire path. Default severity major if unsure. Return verdict, problems, finalRecommendation.',
+        { label: 'critique:' + lens, phase: 'Critique', schema: CRIT }
+      )
+    )
+  )
+).filter(Boolean)
+
+return { findings, spec, critiques }

--- a/plans/2026-07-02-reach-design-evidence/1-mechanics.md
+++ b/plans/2026-07-02-reach-design-evidence/1-mechanics.md
@@ -1,0 +1,380 @@
+# Rippling reach — current-mechanics map
+
+Date: 2026-07-02. Scope: read-only code/config audit. No implementation. This is the
+factual baseline for the "principled tuning-parameter" design work (task: DESIGN
+principled method for setting rippling reach parameter, no slider).
+
+Sources read: `plans/2026-06-28-ripple-extent-governor-mvp.md`,
+`plans/rippling-out-algorithm.md` ("Eyeball-governed reach" section + glossary +
+technical-detail sections), `2026-06-22-rippling-extent-governor-design.md`,
+`2026-06-22-rippling-reach-experiment-spec.md`, `2026-06-22-rippling-experiment-userlevel-redesign.md`
+(all under `~/Downloads`), and the live code: `iznik-batch/app/Services/Ripple/*.php`,
+`iznik-batch/config/freegle.php` (`ripple` block), `iznik-routing-go/ripple.go`,
+`fairness.go`, `deprivation.go`, `ripple_extent_test.go`, `iznik-server-go/message/message.go`
+(`handleView`) + `markseen.go`, and the `iznik-batch` migrations for every `rippling_*` table.
+
+**Headline correction to the design docs**: several things the plan documents describe as
+open blockers or "not yet buildable" are **already implemented in code**, just dark
+(feature-flagged off) or otherwise unwired. The docs are dated 2026-06-22/28; code has moved
+since. See "What's newer than the docs" below.
+
+---
+
+## 1. Parameter inventory — every tuning knob, where it lives, its value, provenance
+
+| # | Name | Lives in | Current value | Who/what set it | Basis |
+|---|------|----------|----------------|------------------|-------|
+| 1 | `RIPPLE_ENABLED` | `config/freegle.php:285` (`ripple.enabled`) | `true` in prod (per memory: live ~2026-06-14) | Product go-live decision | Master kill-switch; gates the whole `ripple:expand` cron |
+| 2 | `RIPPLE_ENABLED_AT` | `ripple.enabled_at` | `2026-06-23` | Go-live flood guard | Only posts arriving on/after this date ever start rippling |
+| 3 | `RIPPLE_WITHIN_GROUPS` | `ripple.within_groups` | empty (no experiment scope active) | Per-group before/after experiment mechanism | Lets a subset of groups ripple while global switch is off |
+| 4 | `RIPPLE_CURVE` | `ripple.curve` | `step-70` | Simulator-derived (10,521 historical posts; see algorithm doc empirical-results table) | Won on catch-rate/waste/lead-time vs 8 other shapes tested |
+| 5 | `RIPPLE_MODE` | `ripple.mode` | `drive` | Design choice | Only drive-time mode is used in production |
+| 6 | **`RIPPLE_MAX_MINUTES`** | `ripple.max_minutes` | **30** (float, minutes) | Simulator-derived original design | **This is the live ceiling — NOT 45.** Confirmed: no `45` literal exists anywhere in `iznik-routing-go/*.go` or `ExpandService.php`/`ReachService.php`/`config/freegle.php`. The "45-min ceiling" language in both the eyeball-governed-reach design and the MVP plan is a **proposed future ceiling for the (unbuilt) audience-sized-burst mode**, not a value that has shipped. Go server independently clamps any caller-supplied `max_minutes` to `(0, 120]` (`ripple.go:277-279`, `:56-58`), falling back to 30 if out of range — so 120 is a hard upper sanity bound, not a design ceiling. |
+| 7 | `RIPPLE_COMPUTE_CONCURRENCY` | `ripple.compute_concurrency` | 8 | Ops tuning (routing-host core count) | Throughput knob, not a reach knob |
+| 8 | `RIPPLE_REUSE_REACH` | `ripple.reuse_reach` | `true` | Perf optimisation | Reuses schedule for same blurred origin (4dp); must be `false` for one full recompute after changing curve/max_minutes/extent |
+| 9 | `RIPPLE_REQUEST_TIMEOUT` | `ripple.request_timeout` | 60s | Ops | Per-`/v1/ripple-schedule` call timeout |
+| 10 | **`RIPPLE_REPLY_SATURATION_STOP`** | `ripple.reply_saturation_stop` | **5** (distinct repliers) | Discourse community consensus ("How many replies do you need to an Offer?" thread, #8415) | **Live and load-bearing.** Applied at both `initialiseNew` (a post with ≥5 distinct `Interested` chat repliers never starts rippling) and every `advanceDue` tick (a post that becomes saturated mid-ripple stops and is marked `done`). Type-agnostic (Offers and Wanteds). 0 disables. |
+| 11 | `RIPPLE_RIPPLED_IN_PENDING_HOURS` | `ripple.rippled_in_pending_hours` | 0 | Mod-load design decision | 0 = rippled-in posts auto-approve immediately on receiving groups (already vetted on origin); >0 would leave a mod-veto window |
+| 12 | **`hazard_hours`** (array, not an env var) | `ripple.hazard_hours` | `[1, 3, 6, 12, 24, 48, 72, 120, 168]` (hours since arrival) | Simulator-derived | 9 ticks over 7 days wall-clock (not literally "24h/30 ticks" as the prose glossary says — see discrepancy note below) |
+| 13 | `RIPPLE_ACTIVE_START_HOUR` / `RIPPLE_ACTIVE_END_HOUR` | `ripple.active_start_hour/active_end_hour` | 06 / 23 | Ops/UX (don't wake devices at 3am) | Ticks due outside this window wait |
+| 14 | **`RIPPLE_EXTENT_ENABLED`** | `ripple.extent.enabled` | **`false` (dark)** | MVP plan (2026-06-28), coded not activated | Stage-A audience-budget cap master switch |
+| 15 | **`RIPPLE_EXTENT_TARGET_USERS`** | `ripple.extent.target_users` | **4000** (inert while #14 is false) | Placeholder default, **not calibrated** — no per-RU-class table wired (`target_by_ru` mentioned in the MVP plan doc is NOT present in the actual `config/freegle.php`, only a single flat `target_users`) | This IS the parameter the overall design effort is meant to derive |
+| 16 | `RIPPLE_DIGEST_W_CLOSE/FRESH/BUDGET/ANCHOR` | `ripple.score.weights` | close=1.0, fresh=0.0, budget=1.0, anchor=0.0 | Problem-2 (digest ordering), separate concern | Not an extent/reach knob — governs sort order within the already-computed reach, not how far reach extends |
+| 17 | `RIPPLE_DIGEST_WINDOW_HOURS` | `ripple.score.window_hours` | 24 | Problem-2 | Freshness decay window for digest scoring |
+| 18 | `RIPPLE_DIGEST_BUDGET_DECAY` | `ripple.score.budget_decay` | 25 | Problem-2 | Engagement-budget decay constant |
+| 19 | `RIPPLE_DIGEST_DEFAULT_REACH_M` | `ripple.score.default_reach_metres` | 30000 (~30km) | Fallback for posts with no `rippling_reach` row | Approximation of the 30-min isochrone in metres, for pre-rippling/backlog posts |
+| 20 | `RIPPLE_DISTANCE_FILTER_ENABLED` | `ripple.distance_filter.enabled` | `true` | Separate, newer feature (member-set `browseMaxDistance` slider extended to emails, PR merged 2026-07-01) | Per-member opt-in narrowing, not a system-wide extent governor; orthogonal axis |
+| 21 | IMD deprivation-quintile weight `W` | `iznik-routing-go/fairness.go` `/v1/fairness` endpoint, `fairnessWeight` query param | Only used by the **separate** `/v1/fairness` endpoint (Q1 up to 2.0× time-budget at W=1) | Fairness/equity-access feature | **NOT called by the ripple pipeline at all.** `ReachService`/`ExpandService` never hit `/v1/fairness`; only `/v1/ripple-schedule`. This is IMD deprivation (English indices of multiple deprivation, LSOA-level, quintiles 1-5), a *different axis* from ONS Rural-Urban class. The plan docs' claim "a `fairness.go` deprivation-quintile time-budget multiplier already exists ... a second shape lever besides drive time" is code-true but pipeline-false: it exists in the codebase, unconnected to rippling. |
+| 22 | ONS Rural-Urban class (`ru_category`: A1/B1/C1/C2/D1/D2/E1/E2/F1/F2) | `transport_postcode_classification` table (Laravel migration `2025_12_10_094529`) | Static reference table, populated from ONSPD | Offline data import | **Used ONLY by the offline extractor** `iznik-routing-go/cmd/rippleextract/main.go` (joins post postcode → RU category for the historical-data dump fed to the simulator/`ripplesim`). **Not read anywhere in the live `ripple:expand` request path.** No RU-stratified `target_users` exists in the live pipeline despite being named in both design docs as the intended stratification axis. |
+| 23 | Reach-mail per-post/per-member caps (3,000-member cap, 24h fatigue cap, explosion-detector 5,000 threshold, group-insertion cap of 5) | Described in the **experiment spec** (`2026-06-22-rippling-reach-experiment-spec.md` §6.1-6.4) as required blockers | **Not present in `ExpandService.php` at all** — confirmed by grep: no `notified_count >= cap`, no fatigue-cap query, no explosion-detector count check, no per-post group-insertion cap in the live code | Experiment-spec authors flagged these explicitly as "current state: absent from codebase, this is a blocker" | Still true as of this read — these guardrails are speculative/planned, not shipped |
+| 24 | `rippling_params` per-`ons_category` overrides (`curve`, `max_minutes`, `target_density`, `hazard_schedule`) | `rippling_params` table (migration `2026_06_18_000010`) | Table exists; **`ripple:tune` (the only writer) is not scheduled** (`routes/console.php:1244-1250`, explicit comment: "left unscheduled for now... pending decision on production rollout") | Self-tuning-loop scaffold (§16 in some earlier design pass) | **Nothing in the live pipeline reads `rippling_params`.** It's a write-only, unscheduled, dead table today — no consumer exists in `ReachService`/`ExpandService`. Even if scheduled, `proposeParams()` (below) is a crude stub. |
+| 25 | `messages_likes.pageview` / `messages_likes.source` | Migrations `2026_06_22_000001` and `2026_06_23_000002` | **Live in schema and partially wired** | T1.2 "dwell-gated View" design item | See "What's newer than the docs" — this is further along than the design docs assume |
+
+### Discrepancy note: "24h / 30 ticks" prose vs the actual hazard schedule
+
+`plans/rippling-out-algorithm.md`'s glossary says "We use 30 ticks over 24 hours, so a
+tick fires every 48 minutes" and "70% up front, 30% over a day." The **live config**
+(`ripple.hazard_hours`) is `[1, 3, 6, 12, 24, 48, 72, 120, 168]` — **9 ticks over 7 days**
+(168 hours), not 30 ticks over 24 hours. The `step-70` curve shape (70% at tick 1, remaining
+30% linear across the rest) is unchanged, but the tick *granularity* and *lifetime* the prose
+describes is the earlier/simulator design, not what `ExpandService`/`ReachService` actually
+schedule against in production. Tick 1 fires at t=1h (not t=0 as several design docs say
+loosely — "70% of sends committed at t=0" is an approximation for "by the first tick, 1h in").
+This matters for any lag-vs-tick-1 arithmetic in the eyeball-governor design (e.g. the
+"~70% of sends already committed by t≈3h" claim spans hazard-hours ticks 1-2, i.e. 1h and 3h
+elapsed — consistent, but the "t=0" shorthand used throughout both design docs should read
+"tick 1 / ~1h in", not literally zero).
+
+---
+
+## 2. Expansion timeline (mechanics, precisely)
+
+1. **Trigger**: `ripple:expand` cron, every minute, `withoutOverlapping(15)` (only runs when
+   `ripple.enabled=true`, or scoped via `--within-group` for an experiment).
+2. **Init (`initialiseNew`)**: for every post in `messages_spatial` with no `rippling_reach`
+   row yet (subject to the arrival cutoff, reply-saturation pre-check, and any area/shard
+   scope), fan out to `iznik-routing-go GET /v1/ripple-schedule` (`compute_concurrency=8`
+   parallel via `Http::pool`), passing `lat, lng, mode=drive, ticks=9, max_minutes=30,
+   curve=step-70` (+ `target_users` only if extent cap is enabled — currently never sent).
+3. **Routing server computes**, per origin:
+   - One Dijkstra out to the 30-min isochrone (`Isochrone()`).
+   - Queries `iznik-spatial-go` for every `users_approxlocs` member inside that 30-min
+     polygon (`/v1/userapproxlocs/within_coords`) → sorted ascending by drive-time; this
+     sorted list is `total_freeglers` (the full reachable pool, pre-cap).
+   - `effectiveTotal = effectiveScheduleTotal(total, targetUsers)` — currently always equals
+     `total` because `targetUsers` is never sent (extent cap dark).
+   - For tick `k` in 1..9: `frac = curveFraction("step-70", k/9, 9)`; `target =
+     round(frac * effectiveTotal)`; drive-time for tick `k` = the drive-time of the
+     `target`-th nearest member; polygon = isochrone filtered to nodes reached within that
+     drive-time.
+   - Response: `{total_freeglers, max_drive_min, schedule: [{tick, drive_min,
+     cumulative_users, polygon}, ...]}` (9 entries).
+4. **Batch stores** the parsed schedule into `rippling_reach` (`schedule` = JSON array of the
+   9 tick entries, `polygon` = the current tick's WKT unioned with the origin group's own
+   area, `tick`=1, `total_ticks`=9, `total_freeglers`, `max_drive_min`, `next_expansion_at` =
+   arrival + hazard_hours[1] = arrival+3h).
+5. **Cross-post**: `rippleIntoNewGroups` inserts a `messages_groups` row (Pending or
+   auto-Approved per `rippled_in_pending_hours`) for every published/onhere Freegle group
+   whose `polyindex` intersects the current reach polygon — **every intersecting group**, not
+   a chunked/home-first selection (the "T2.1b mod-load-aware chunking" design item is unbuilt).
+6. **Mail**: `mailNewlyReachedForPost` / `UnifiedDigestService::sendReachDigests` notify
+   newly-in-reach members not yet in `rippling_reach_notified` (composite PK
+   `(msgid,userid)`, so re-notification is impossible by construction).
+7. **Advance (`advanceDue`)**, every minute, for rows `status='expanding' AND
+   next_expansion_at <= now()`:
+   - Re-check reply-saturation stop (≥5 distinct repliers → `status='done'`, no more ticks).
+   - Re-check terminal outcome (Taken/Received/Withdrawn/Promised → `status='done'`).
+   - Compute `target = tickForElapsedHours(elapsedHours)` clamped to the post's own
+     `total_ticks`; if due, overwrite `polygon`/`tick`/`next_expansion_at` from the cached
+     schedule entry (no new Dijkstra call — reuses the stored 9-tick schedule).
+   - `next_expansion_at = arrival + hazard_hours[tick]`; `status='done'` once `tick=9`
+     (168h/7 days after arrival) with no further entry.
+8. **Stop conditions that exist today**: reply-saturation (≥5), terminal outcome
+   (claim/promise/withdraw — "stop-on-claim"), post removed from `messages_spatial`
+   (rejected/expired/deleted — `removeStaleAndRetract`, unscoped runs only), 30-min geometry
+   ceiling (implicit — the schedule simply has no tick beyond `max_drive_min`).
+9. **Stop conditions that do NOT exist today**: no eyeball/view-based stop, no `E*` target,
+   no per-post people-cap, no per-member fatigue cap, no explosion-detector circuit breaker,
+   no futility-cut, no trailing-extension, no RU-class-stratified anything in the live path.
+
+---
+
+## 3. `rippling_reach.schedule` JSON — exact contents
+
+Confirmed from `ReachService::parseScheduleResponse` + the `rippling_reach` migration
+comment. One row per rippling post; `schedule` (longtext) holds a JSON array, one entry per
+hazard-schedule tick (currently 9 entries):
+
+```json
+[
+  {
+    "tick": 1,
+    "drive_min": 8.4,
+    "cumulative_users": 2909,
+    "wkt": "POLYGON((...))"
+  },
+  { "tick": 2, "drive_min": 12.1, "cumulative_users": 3450, "wkt": "..." },
+  ...
+  { "tick": 9, "drive_min": 30.0, "cumulative_users": 12544, "wkt": "..." }
+]
+```
+
+Sibling columns on the same `rippling_reach` row: `msgid` (PK), `lat`/`lng` (blurred
+origin), `arrival`, `mode`, `tick` (current cursor, 1-9), `total_ticks` (9), `total_freeglers`
+(the full uncapped pool size — this is what the MVP plan calls "the routing schedule already
+carries member counts... no schema change needed for member-based governance" — confirmed
+true), `max_drive_min`, `polygon` (current tick's geometry, SRID 3857, spatially indexed),
+`next_expansion_at`, `status` (`expanding`/`stopped`/`done`), `rejected_groups` (secondary
+"out of area" clips), `ripple_intro_sent` (added later). **`cumulative_users` is the
+audience-size number every governor design (MVP audience-cap, reply-calibrated `N_t0`) would
+key off — it already exists per-tick, per-post, right now, with zero schema change.**
+
+---
+
+## 4. Other data already persisted per post (beyond `rippling_reach`)
+
+| Table | What it holds | Live? |
+|---|---|---|
+| `rippling_reach_notified` | `(msgid, userid, notified_at)` — who's been mailed, prevents re-notify | Live, load-bearing |
+| `rippling_held_replies` | Replies from out-of-reach repliers held pending coverage | Live (`RippleReplyService`) |
+| `rippling_event_metrics` | Daily counters per event type (`reply-blocked-by-reach`, `held-reply` transitions, `secondary-group-rejection`, `immediate-mail-on-expansion`, `rippled-in-group`, `reply_saturated`, `outcome_stop`, `reach_shrunk`) | Live, upsert-on-event |
+| `rippling_live_metrics` | Weekly rollup: `volume_posts` (per-group + p50/p90 overall), `reach_drive_min` (per-group avg) | **Dormant** — only written by `RippleTuneService::rollup()`, which only runs if `ripple:tune` is invoked, and `ripple:tune` is unscheduled |
+| `rippling_hotspots` | Robust-outlier (median+MAD z-score) per-group anomaly flags | **Dormant**, same reason |
+| `rippling_params` | Per-`ons_category` proposed/active param overrides | **Dormant + effectively a stub** — see below |
+| `rippling_reply_attribution` | Migration exists (`2026_06_23_000003`); not inspected in depth this pass — flagged for follow-up, likely the reply-calibration `r` support table |
+| `messages_likes.pageview` / `.source` | Per-(msgid,userid) genuine-open flag + arrival-path tag | **Schema live, partially wired** — see below |
+
+---
+
+## 5. What's newer than the docs (code has moved past the design snapshots)
+
+The three `~/Downloads` design docs and the MVP plan are dated 2026-06-22/28 and describe
+several things as unresolved blockers. As of this read (2026-07-02), some have moved:
+
+1. **T1.2 "dwell-gated View split" (design doc's single most load-bearing open issue) is
+   now schema-live and partially wired**, not merely proposed:
+   - `messages_likes.pageview` (migration `2026_06_22_000001`): 1 = genuine page-open
+     (`handleView`), 0 = list-scroll impression (`MarkSeen`), NULL = legacy/unknown.
+   - `messages_likes.source` (migration `2026_06_23_000002`): tags arrival path (comment
+     explicitly says `?src=ripple_notify` for notification-click opens).
+   - `handleView` (`message.go:4506`) now writes `pageview=1` + `source` on a genuine
+     open, upgrading an existing scroll-impression row rather than being conflated with it.
+     `MarkSeen` (`markseen.go`) writes `pageview=0` and never overwrites an existing `1`.
+   - **This resolves the exact ambiguity** the eyeball-governed-reach design (rev.2) calls
+     "the single most load-bearing open issue" ("`MarkSeen` and `handleView` write the same
+     row with no distinguishing column"). That is no longer true in the live schema.
+   - **However it is not fully wired**: no code was found that actually appends
+     `?src=ripple_notify` to any outgoing rippling notification link (grepped
+     `ExpandService`, `UnifiedDigest.php`, `RippleIntroMail.php` — none build such a URL).
+     So `pageview` correctly distinguishes real opens from scroll-impressions today, but
+     `source`-based ripple-notification attribution (needed for a clean `r` = eyeballs/
+     delivered calibration split by channel) is still not populated in practice. **The
+     dwell/pageview half of T1.2 has shipped; the source-tagging half has schema but no
+     producer.**
+2. **T2.1 Stage-A audience-budget cap (`N_t0`/`target_users`) is fully coded, tested, and
+   wired end-to-end** — not just designed. `iznik-routing-go/ripple.go`
+   `effectiveScheduleTotal()` (unit-tested in `ripple_extent_test.go`, 6 cases including the
+   dense/rural/boundary cases), `ReachService::scheduleParams()` conditionally sends
+   `target_users`, `ExpandService::recomputeReach()` exists to retroactively shrink
+   already-rippling posts once the cap is turned on. **Everything is dark
+   (`RIPPLE_EXTENT_ENABLED=false`) and the value (4000) is an inert placeholder**, but "needs
+   a product decision on N*" (the MVP plan's stated blocker) is the *only* remaining gap —
+   the plumbing is done.
+3. **A self-tuning loop scaffold is built** (`RippleTuneService`, 3 tables:
+   `rippling_live_metrics`/`rippling_hotspots`/`rippling_params`) that is more advanced
+   machinery than either design doc credits, but it is **weaker than it sounds**:
+   - `proposeParams()` only fires when a category's post-volume delta vs its own prior period
+     falls outside a flat ±10%/+50% band, and then just writes `max_minutes = 25` (tighten)
+     or `35` (widen) — hardcoded literals, not derived from any eyeball/reply/collection
+     signal, and **not proportional to how far outside the band** the category is.
+   - `categoryVolumeDeltas()` — the method that would compute those per-category deltas — is
+     a **literal stub returning `[]`** ("baseline wiring lands once live-vs-baseline data
+     accrues (advisory stub)"). So `proposeParams()` never actually proposes anything today
+     even if `ripple:tune` were scheduled.
+   - `rippling_params` has **no reader** anywhere in the codebase — even if a human promoted a
+     proposed row to `status='active'`, nothing in `ReachService`/`ExpandService` selects from
+     it. The loop is entirely open (write-only, unconsumed).
+   - `ripple:tune` is coded but **not scheduled** in `routes/console.php` (explicit comment:
+     "pending decision on production rollout").
+   - Ground truth: **this is not a working self-tuning system, it is an unwired scaffold with
+     one stubbed method** — closer to a placeholder than the design docs' framing of "existing
+     machinery" suggests.
+
+---
+
+## 6. Decisions the existing designs already made (do not relitigate)
+
+From `rippling-out-algorithm.md` "Givens" + the MVP plan + the extent-governor design:
+
+- **Objective is eyeballs, not raw notification count.** People-notified is a proxy, not
+  the target. (Design-level decision; not yet implementable — see open items.)
+- **Reply is the interim success proxy**, not collection/Taken (too sparse; `Taken` outcome
+  data is noisy re: chase-up-prompted marking, per the experiment spec's Blocker/confound
+  analysis).
+- **Assume the 66%-zero-reply problem is an exposure deficit, not a desirability deficit**,
+  pending contrary evidence. First real-data test (33k Offers, 60-30 days old) *supports*
+  this (reply rate rises 14%→28% with exposure, holds within rural alone, urban≈rural at
+  matched size) — kill-switch did not fire.
+- **Rural posts riding to the drive-time ceiling is intended, not a bug.** Any governor must
+  not artificially truncate sparse-area reach.
+- **A people-count cap that DECREASES with density is wrong** — the taker-distance
+  validation (7,800 Taken Offers, 120 days) refutes it: dense-area real takers rank ~1,719th
+  nearest active member (mean 5,126th), so a tight cap (1,500) misses 54% of real collectors;
+  loosening to `E*=5`(≈7,015 active) only misses ~19%. Collector *abundance* ≠ interested-
+  collector abundance.
+- **The extent decision is the burst-sizing decision**, because ~70% of the pool is
+  committed by tick 1 (~1-3h in) before any eyeball signal can possibly exist for
+  digest-majority recipients (lag to eyeball is ~24-31h for daily digest). So governance must
+  be feed-forward (frozen prior `r`) for the dominant tick-1 burst; a live closed loop can
+  only ever touch the trailing ~30%, and mostly matters as cross-post calibration, not
+  within-post control.
+- **No per-member fatigue/contention cap until Unified-Digest scroll/click data exists** —
+  explicitly deferred, not because it's unimportant but because there's no measurement to
+  size it against yet.
+- **`r` (conversion prior) must be computed on the ACTIVE-member basis**, matching the pool
+  (`users_approxlocs` pool is already ~97.5% active) — historical reply-calibration gives
+  `r_reply,active ≈ 1/1,403` (1 reply per 1,403 active members reached), NOT the ~14,600
+  figure you get from nominal (dormant-diluted) group membership.
+- **The primary test for whichever cap-shape is chosen must be the taker-distance /
+  collection-catch validation**, not just a volume-reduction number — a cheap-looking cap can
+  still be a collection-catastrophe if it doesn't reach where real interest lives.
+- **Group-level (per-group slider) rejected by product owner** (would be set randomly by
+  groups) — this is the reason the effort must be a data-derived, self-maintaining, per-area
+  method instead.
+- **Mod-load and member-notification-volume are governed by DIFFERENT levers**: reply-stop +
+  home-first group chunking controls mod load (groups opened); the audience cap (`E*`/
+  `target_users`) controls notification volume. Capping members alone does *not* shrink group
+  count under the current "ripple into every intersecting group" engine — chunking
+  (unbuilt) is required for that.
+
+---
+
+## 7. The decisions that remain explicitly open
+
+In priority/dependency order, as the source designs themselves frame it:
+
+1. **What is `N*` / `E*` — the actual numeric target, and by what unit (people vs
+   eyeballs vs replies)?** The MVP plan ships a single flat placeholder (4000); the extent-
+   governor design's reply-calibrated version (`N_t0 = E*·1,403`) is a specific, computed
+   candidate (from the *existing* reply-saturation-stop threshold of 5, giving `N_t0≈7,015`
+   active members) but explicitly flagged "generous v1... learn it later" — not adopted as
+   the production value. **This is the parameter the whole effort exists to derive
+   properly**, and no per-area/self-maintaining mechanism for setting it exists in the live
+   pipeline today (the `rippling_params`/`ripple:tune` scaffold that could hold it is
+   unwired and its core proposal method is a stub).
+2. **Per-area stratification axis and its calibration.** Two candidate axes exist in the
+   codebase and neither is wired into the ripple decision path: ONS RU-class
+   (`transport_postcode_classification`, offline-only, used by the simulator/extractor) and
+   IMD deprivation quintile (`fairness.go`, wired to a *different* endpoint, `/v1/fairness`,
+   never called by `ReachService`). The design docs assume RU-class will be the
+   stratification key ("`target_by_ru`") but this key does not exist in
+   `config/freegle.php` today — only a flat global `target_users`.
+3. **Whether the primitive is a people-count cap, an expand-until-signal (`E*` eyeball/
+   reply-count) stop, or a hybrid** — the experiment spec (5-arm design: Control /
+   People-cap-Low(500) / People-cap-High(3000) / Signal-stop(2 replies) / Signal-stop+cap) is
+   the proposed way to discriminate between these empirically, but it has not run — six
+   preconditions are listed as blockers (3,000-member cap, 24h fatigue cap, schema, explosion
+   detector, LIA/GDPR sign-off, SAR export), of which the reply-and-notification-volume
+   caps are confirmed absent from `ExpandService` today.
+4. **Whether `r` (the eyeball-per-notified-member conversion prior) can be calibrated at all
+   yet.** The dwell/pageview split (T1.2) has shipped in schema+read form but the
+   notification-link `?src=ripple_notify` write-side tagging has not, so a clean
+   channel-attributed eyeball signal for calibrating `r` is still not accruing in practice —
+   this is a smaller, more precisely-scoped gap than the design docs describe (they treat the
+   whole pageview/View ambiguity as unresolved; it's actually just the source-tagging
+   producer that's missing).
+5. **The explosion-detector / auto-pause circuit breaker** — repeatedly named across all
+   docs as the thing that must exist and be wired *before* re-enabling/scaling any governor
+   change, on the grounds that "an explosion is by definition a failure regardless of cause."
+   Confirmed absent from `ExpandService` (no notified-count threshold check, no
+   `rippling_live_metrics`-driven auto-pause).
+6. **Whether/how to activate the self-tuning loop** (`ripple:tune`, `rippling_params`) —
+   coded scaffold exists but (a) is unscheduled, (b) its core `categoryVolumeDeltas()` is a
+   stub, (c) nothing reads `rippling_params` back into the pipeline even if populated, (d) its
+   only proposal logic (flat volume-delta band → hardcoded 25/35 min) has no relationship to
+   the eyeball/reply/collection-outcome calibration the design docs actually argue for. This
+   table/command pairing looks more like an earlier, abandoned first-cut at "self-maintaining"
+   than a component the current design should build on as-is.
+7. **Mod-load chunking** (`T2.1b`, "fill home group first, open a neighbour only when budget
+   exceeds it") — the modelled ~1,185→~133-207 group-count reduction depends entirely on this
+   being built; today's engine still opens every intersecting group regardless of any cap on
+   member count. Not started.
+8. **Per-member fatigue/contention cap** — explicitly deferred pending Unified-Digest
+   scroll/click data; still zero fatigue-cap code in `ExpandService` (confirmed by grep).
+9. **GDPR/LIA sign-off for out-of-group notification** — flagged as a hard precondition in
+   the experiment spec, explicitly marked TBD/placeholder pending Edward's separate
+   assessment; not something this read can resolve.
+10. **Deliverability→`r` feedback loop guard** — a second positive-feedback path (high
+    volume → spam-foldering → measured `r` looks artificially low → bigger `N_t0` computed →
+    more volume) flagged as needing an independent high-side volume/complaint circuit
+    breaker; not designed in detail, not built.
+11. **Recipient de-dup across overlapping groups** (~4.5 groups/member average) — flagged as
+    an `r`-denominator and `N_t0`-arithmetic bias; tracked but explicitly "not blocking v1."
+
+---
+
+## 8. Answers to the specific resolve-questions posed
+
+- **Is the live ceiling 30 or 45 min?** **30.** `RIPPLE_MAX_MINUTES` default and only
+  configured value is 30 (`config/freegle.php:311`, `ReachService.php:41`). No 45 exists
+  anywhere in the live code path. "45-min ceiling" is design-doc language for a proposed
+  *future* ceiling once the audience-sized-burst extent governor ships (both the MVP plan and
+  the eyeball-governed-reach design use 45 as the intended outer cap once `N_t0`/`target_users`
+  becomes the primary stop condition and drive-time becomes "shape only, not the limit") — it
+  has not been implemented or configured anywhere.
+- **What is the expansion schedule (how much at t=0)?** Not literally t=0 — **tick 1 fires
+  at t=1h** post-arrival (first `hazard_hours` entry). At tick 1, `step-70` puts **70% of the
+  (uncapped) reachable pool** in reach (`stepCurve(0.70, 9, 1/9)`, ramped smoothly within the
+  first tick but production snaps to tick boundaries so it's effectively "70% at the 1h mark").
+  The remaining 30% spreads **linearly across ticks 2-9**, i.e. hours 3, 6, 12, 24, 48, 72,
+  120, 168 (up to 7 days). A live measurement cited in the extent-governor design confirmed
+  this empirically: tick 1 on a real suburban post = 2,909/4,156 members (70%) at 21 min
+  drive-time; ticks 2-9 add only the outer 30% out to 30 min.
+- **What does `rippling_reach.schedule` JSON contain exactly?** A 9-element array (one per
+  hazard-hours tick), each `{tick, drive_min, cumulative_users, wkt}` — see §3 above for the
+  exact shape, confirmed against `ReachService::parseScheduleResponse` and
+  `rippleScheduleEntry`/`rippleScheduleResponse` in `ripple.go`.
+- **What per-RU-class machinery already exists?** An offline reference table
+  (`transport_postcode_classification`, ONS 2011 A1-F2 codes) used only by the historical
+  extractor for simulator analysis, and a **different**, code-complete but pipeline-
+  disconnected IMD-deprivation-quintile isochrone multiplier (`fairness.go`, `/v1/fairness`
+  endpoint) that the ripple pipeline never calls. **No RU-class stratification exists in the
+  live `/v1/ripple-schedule` → `ReachService` → `ExpandService` path.** The
+  `rippling_params.ons_category` column is the closest hook for this, but it has no reader.
+- **What governor pieces are built vs planned?**
+  - **Built, dark**: the audience-budget cap plumbing end-to-end (Go `effectiveScheduleTotal`
+    + tests, `ReachService` conditional `target_users` param, `ExpandService::recomputeReach`
+    shrink-in-place backfill) — gated by `RIPPLE_EXTENT_ENABLED=false`.
+  - **Built, live**: reply-saturation stop (≥5 repliers), stop-on-claim/terminal-outcome,
+    30-min geometry ceiling, `messages_likes.pageview` genuine-open vs scroll-impression
+    split (schema + read side).
+  - **Built, unwired/stub**: self-tuning loop (`RippleTuneService`, `rippling_params`,
+    `rippling_hotspots`) — scheduled command missing, core delta method stubbed, no
+    consumer of its output; `messages_likes.source` schema exists but no producer appends
+    `?src=ripple_notify` to any real notification link yet.
+  - **Planned, not built at all**: per-post people-cap, per-member 24h fatigue cap,
+    explosion-detector circuit breaker, per-post group-insertion cap, home-first group
+    chunking, RU-class-stratified `target_users`, eyeball/view-based `N_t0` (v2, needs
+    trustworthy `r`), the full reach-dose experiment (post-level or ADD/user-level
+    redesign) and its schema (`messages.experiment_arm`, `rippling_experiment_assignments`,
+    etc.) — none of this exists in `iznik-batch`/`iznik-server-go` as of this read.

--- a/plans/2026-07-02-reach-design-evidence/2-discourse.md
+++ b/plans/2026-07-02-reach-design-evidence/2-discourse.md
@@ -1,0 +1,375 @@
+# Discourse Topic 9808 ("Rippling Out") — Complaint Signal Extraction
+
+**Source**: https://discourse.ilovefreegle.org/t/9808 — 414 posts, 2026-06-21 to 2026-07-02 (12 days),
+30 distinct human participants (+ Edward_Hibbert as thread owner/developer, 120 posts; Neil as Board
+Chair, 8 posts). Fetched in full via Discourse API (`User-Api-Key` header only — see auth note at end).
+
+This is signal extraction, not sentiment: every concrete claim, distance, and proposal is pulled out
+below with post numbers for citation. The thread is a general "rippling out" rollout-feedback thread
+(covers auto-join, auto-approve, UI bugs, accessibility, moderator-control anxieties, etc.) — **most
+of the 414 posts are NOT about reach/distance**. This document filters to the reach-specific subset
+plus enough context to judge what would satisfy each complainant.
+
+---
+
+## 1. Who is complaining (population count)
+
+30 distinct named participants posted in the thread. Of these, participants who raised **reach/distance**
+complaints specifically (as opposed to auto-join UX, accessibility, moderation-control, or general
+change-aversion complaints):
+
+| Complainant | Posts in thread | Reach-specific complaints | Role/group |
+|---|---|---|---|
+| Jax (Jackie) | 55 | Yes — repeated, detailed (London/Brent-Harrow-Ealing) | Mod, Brent/Harrow |
+| Derek | 34 | Yes — repeated, with distance screenshots | Mod, Fife/Perth (Scotland) |
+| Jos | 35 | Yes — Swindon vs London/Islington/Croydon comparison | Mod, Fife/Livingston/Dumfries |
+| Neville_Reid | 28 | Yes — Chilterns/32-groups, Hull/Castleford, Harlow | Mod (multiple London/Yorks groups) |
+| Group-Mod-J (Jools) | 13 | Yes — Hull/Scunthorpe/Castleford "over the water" | Mod, Hull/Bridlington/Scarborough |
+| Sheila | 13 | Yes (via forwarded member complaints) | Mod (unnamed groups) |
+| Angelika | 14 | Partial (mostly auto-join/clutter, not raw distance) | Mod, Tendring |
+| Louise | 6 | Yes — rural North Lancashire | Mod, Kendal/Carnforth/Lancaster |
+| Michael | 8 | Yes — Wellingborough/St Neots vs Bedford | Mod, Milton Keynes area |
+| May_Stirling_Freegle | 3 | Yes — remote northern Stirling under-reach | Mod, Stirling |
+| Mike_Jury | 3 | Yes — Thurrock/Farnborough | Mod |
+| Melissa | 11 | Yes (as a *member*, no car) | Mod, Eastbourne (dual role) |
+| Diz | 8 | No (broadly positive) | Mod, Gloucestershire |
+| Jacky | 10 | No (rural, "always been absurd to me too") | Mod, Norfolk |
+| Vee | 2 | No — objects to auto-join/consent, not distance per se | Mod |
+
+**Count**: roughly **10-12 of 30 distinct posters** (about a third) raised genuine reach/distance
+complaints with concrete detail. A further 3-4 raised *forwarded member* complaints (Sheila, Angelika,
+Derek relaying named members like "Tony Almond", "Doug Freecycle", "Robin Langley", member IDs
+41876853, 41649498, etc.) — so the complaint surfaces both as direct-mod opinion and as
+mod-as-conduit-for-member. The rest of the 30 either didn't engage with reach specifically, were
+positive, or complained about orthogonal things (auto-join consent, accessibility, TrashNothing
+crossposting, UI bugs, moderation-control philosophy).
+
+Freegle has roughly 500 groups nationally; this is a vocal, self-selected Discourse-reading subset,
+explicitly **not** representative (Post #395, Neil: "we need to improve our internal communications...
+only about 20% of Freegle volunteers are members of the WhatsApp groups" — implying an even smaller
+fraction actively read/post on Discourse).
+
+---
+
+## 2. (a) "Reach is genuinely too large" — concrete examples
+
+These are complaints with a specific place-pair, distance, or travel-time attached, i.e. falsifiable
+claims about the mechanism rather than pure sentiment.
+
+### Distance/place-pair table
+
+| # | Post | Poster | From → To | Claimed distance/time | Claim type |
+|---|---|---|---|---|---|
+| 1 | #42 | Jacky | Norwich/Lowestoft/Cromer → (home, unnamed) | 17-28 miles, replies within 8h | Reported as **success**, not complaint (context for calibration) |
+| 2 | #204 | Derek | 30 miles vs 8 miles | shown before closer ones | Ordering bug, not reach size |
+| 3 | #205 | Jax | London, "large amount" | ripples "almost immediately" | Speed complaint, not distance |
+| 4 | #207 | Jos | Harrow → "pretty much all of London" | half the slider ≈ too far | Reach-too-large |
+| 5 | #209 | Jos | Croydon → S. Kensington & Chelsea (crosses the river) | half slider | Reach-too-large, cultural/psychological barrier (river) |
+| 6 | #215/272 | Derek | KY7 (Glenrothes) → Cameron Toll/Blackhall, Edinburgh | shown as 16-18 miles (crow-flies), actual ~30-45 miles / ~1h by road | **Crow-flies vs road-distance display bug**, not reach-radius per se |
+| 7 | #224 | Jos | Kensington & Chelsea ← Brent (W), Islington (E), Croydon (S) | "just under 40 groups in London" reachable | Reach-too-large (density) |
+| 8 | #229/246/255/279/281 | Jax | Brent → auto-joined to 27, then 32 groups, incl. Hemel Hempstead | 40 miles, "hour on good day, 2 on bad" | Reach-too-large + auto-join volume |
+| 9 | #234 | Neville_Reid | crosspost reaching 25-32 communities "within minutes" | — | Speed + breadth complaint |
+| 10 | #244 | Jax | Watford member: "20 miles away, don't even want to see 10" | 20mi rural-OK vs "like 100" in London | Explicit urban/rural asymmetry articulation |
+| 11 | #248/250 | Jos, Neville_Reid | **Swindon vs London(Islington)**: halfway on reach slider = ~30 min travel Swindon (judged "pretty perfect"), vs ~50+ min London/Islington (judged too far); Swindon ~1,000 members vs London ~27,000 members at that slider position | 30 min "perfect" vs 50 min "too far" at same slider % | **Core structural complaint** — same slider position, wildly different real minutes and audience size |
+| 12 | #250 | Neville_Reid | NW London offer → East London to **the Chilterns** | "an hour's drive each way," 32 groups | **The canonical complaint** cited in project brief |
+| 13 | #255 | Jax | Brent → Hemel Hempstead shown as "near me" first | 40 miles, 1-2h | Reach-too-large + ranking bug (shown before genuinely-near posts) |
+| 14 | #260/262 | Derek | Fife → Queensferry | member "would never travel to" | Reach-too-large |
+| 15 | #272 | Derek | Glenrothes (KY7) → Blackhall, Edinburgh | shown 16mi, actual ~30mi one-way | Distance-display bug feeding perceived reach-too-large |
+| 16 | #277 | Derek | Fife, "some, like me, live right in the middle...not interested in what is offered 30+ miles away. 60 miles is a long way to travel for a stick of rhubarb" | 30-60 miles | Reach-too-large (rural but "middle of group", not boundary) |
+| 17 | #321/340 | Mike_Jury | (Medway?) → Thurrock | 35 miles | Reach-too-large |
+| 18 | #341/346 | Mike_Jury | → Farnborough | 75 miles claimed, resolved as Farnborough-Kent confusion (~20mi from Thurrock) | Turned out to be a **place-name ambiguity bug**, not real reach |
+| 19 | #343 | Group-Mod-J | Ryedale/Scarborough/Grimsby/Bridlington/Hull "getting people joined up from all over" | unspecified | Reach-too-large, general |
+| 20 | #356 | Jos (relaying member) | North Bristol member: "shown ads 40 mins to an hour's drive away... only 6 within 5 miles out of 99" | 40-60 min | Reach-too-large, dense-ish city |
+| 21 | #362 | Melissa | KT5 (Surbiton) → Pyrford GU22 (14mi), Reigate RH2 (15mi) | 14-15 miles, "without a car, entirely inaccessible" | Reach + **no-car accessibility** confound |
+| 22 | #365/368 | Derek (relaying Bishop Auckland member) | → Penrith / Newcastle / Northumberland | unspecified, "half the country" | Reach-too-large |
+| 23 | #370 | Michael (relaying member Robin) | West London → Oxford, Slough, "random areas of North and West London" | unspecified, "hundreds and hundreds" | Reach-too-large |
+| 24 | #373 | Jos | Portobello → Livingston, "narrow corridor around the M8" | unspecified | **Motorway-corridor artifact** — isochrone stretches along fast roads, member sees only the far endpoint not the narrow path |
+| 25 | #389 | Group-Mod-J | Castleford → Hull (via Howden, "just inside Hull's area") | 29 min by car (per Edward, #390) | Disputed — mod says "blatantly out of area," Edward says 29 min is legitimately within reach |
+| 26 | #391 | Neville_Reid | Harlow (CM20) → Tower Hamlets | 42-70 min depending on traffic (M11/A12), rippled after **3 hours** not 1 | Reach-too-large + **isochrone volatility** (same route showed 70min then 47min within the same session) |
+| 27 | #402 | Vee | unspecified, "rippled out at 21:22, 3 minutes after I approved it" to 11 groups | — | Speed complaint |
+
+### Distinct place-pairs with a stated distance/time (deduplicated, for the "concrete examples" ask)
+
+1. **NW London → Chilterns/East London**: ~1 hour drive each way, post visible on 32 groups (#250) — *the flagship complaint, matches project brief*
+2. **Swindon vs London/Islington** at same slider position: 30 min (Swindon, judged fine) vs 50+ min (London, judged too far); 1,000 vs 27,000 members reachable (#248)
+3. **Glenrothes (KY7) → Blackhall, Edinburgh**: shown as 16 miles, actually ~30 miles/1h by road (#272) — crow-flies display bug
+4. **Glenrothes (KY7) → Cameron Toll, Edinburgh**: shown 18mi, actual ~45 miles/1h drive (#215) — same bug
+5. **Croydon → S. Kensington & Chelsea**: crosses the Thames, ~half the reach slider (#209)
+6. **Harrow → "pretty much all of London"**: half the slider (#207)
+7. **Brent → Hemel Hempstead**: 40 miles, shown as "near me" first (#255)
+8. **(Medway area) → Thurrock**: 35 miles (#321)
+9. **Harlow (CM20) → Tower Hamlets**: 42-70 min via M11/A12, rippled after 3h not the stated 1h (#391)
+10. **North Bristol**: 40-60 min drive-time posts dominating feed, only 6/99 within 5 miles (#356)
+11. **Surbiton (KT5) → Pyrford (14mi) / Reigate (15mi)**: reachable but "entirely inaccessible" without a car (#362)
+12. **Portobello → Livingston**: M8 corridor artifact (#373)
+13. **Castleford → Hull (via Howden)**: 29 min by car — disputed whether "too far" (#389/390)
+
+### Structural pattern in the genuine complaints
+
+The single clearest, most quantified, most repeatable complaint is the **Swindon-vs-London
+"same slider position, wildly different real-world reach" problem** (#248, echoed by Neville_Reid
+#250 and implicitly by Jos #209/224). This is exactly the problem statement in the project brief
+(the ~80x active-member-pool spread at fixed drive-time). Everything else in the "genuinely too
+large" bucket is either (a) an instance of that same structural issue in a different London/dense
+location, (b) a **crow-flies-vs-road-distance display bug** feeding perceived unfairness (distinct
+technical issue, already flagged as fixable by Edward in #217/274/point 217's "may now be possible
+to change to road distance"), or (c) a **motorway-corridor artifact** where the isochrone shape
+stretches narrowly along a fast road and the member only sees "reaches X" without seeing that it's
+a thin sliver, not an area (#373).
+
+---
+
+## 3. (b) "Perception/communication" complaints
+
+Complaints where the underlying mechanism is arguably working as designed, but the *presentation*,
+*framing*, or *mod's own lack of situational awareness* is the actual problem.
+
+- **#12 (Edward)**: explicitly frames Fife itself as "a massive group... someone near one edge has
+  very little in common with someone near the far opposite" — i.e. mods complaining about their
+  group's own span not realizing their own group is *already* large/heterogeneous.
+- **#129/130/133 (Edward)**: the single most repeated rebuttal in the whole thread — "Unless you live
+  dead in the centre of a circular group, many people in rippled out groups are closer than many
+  people in the home group... only 0.14% of active freeglers live somewhere where everyone in their
+  home group is quicker to reach than anyone in another group is" (CV37 8GY / North Cotswold example:
+  Tetbury 1h vs Evesham 20min, Shipston 15min, Stratford 17min, Worcester 20min, Chipping Norton 20min
+  — all *closer* than the far end of the poster's own home group).
+- **#155/223/235/396 (Edward)**: repeated "being on the touch-list ≠ being shown to everyone" framing
+  — mods conflate "post appears in ModTools as touching my group" with "all my members are bombarded."
+  Edward: "So: worry less" (#210); "please can people stop posting complaints about how they think it
+  works rather than how I have repeatedly explained that it does" (#235, visibly frustrated).
+- **#237 (Neville_Reid)**: this is explicitly identified and *accepted* as a communication/wording
+  problem, not a mechanism problem: "For years, volunteers have interpreted 'on my group' –
+  correctly until now – as 'shown to everyone in my group'... how about 'May also be shown to some
+  members in'?" — Edward agrees (#238) and implements it.
+- **#343 (Group-Mod-J / Jools)**: "regardless of what 'the data' says I think rippling is ruining
+  things" — explicit statement that the objection is to the *principle* (loss of local control,
+  historically-curated boundaries "hoovered up" by out-of-area members) not to a specific measured
+  distance.
+- **#400 (Sheila)**: "Our suggestions are slapped down with quotes of data, that we can't possibly
+  have fully" — trust-in-data breakdown, a communication/authority problem more than a metrics
+  problem.
+- **#7 (Edward, very early)**: "If it doesn't match your feeling about what it should be, please
+  consider that it's probably got a more rigorous sound basis than that feeling" — sets an
+  adversarial, data-vs-gut-feel tone from post #7 that recurs (and visibly costs goodwill) throughout;
+  several later posters (Sylvain #69, Lorraine #67, Angelika #102) react specifically to being told
+  their concerns don't matter versus being consulted.
+- **#391 (Neville_Reid)**: self-corrects mid-post ("I think I was misunderstanding what '40 minutes
+  ago' meant") — a case of a mod initially misreading the UI, then admitting a chunk of their own
+  complaint was a misunderstanding, not a real problem. Still lands on "that kind of giving is not
+  FreeGLE, it's only FreeG" as a principle objection once the number is corrected to 3h not 1h.
+- **#61 (Beth)**: explicit self-aware counter-example — Norfolk coastal village member routinely
+  travels an hour to Norwich/Cambridge/Ely, "for me it would never be an extra trip." Shows the
+  "genuinely too far" judgment is itself locally-contingent and some mods already understand this.
+
+**Verdict on this bucket**: real and substantial. A meaningful fraction of the volume in the thread
+is mods not having internalized that (a) "touches group" ≠ "shown to all members," (b) their own
+"home" group is itself heterogeneous, and (c) the mechanism already down-weights/de-prioritizes
+distant posts even when they're technically "reachable." Any design for the tuning parameter needs
+an accompanying **legible explanation artifact** (see requirements section) independent of getting
+the number right, because some of this heat is orthogonal to the number.
+
+---
+
+## 4. (c) In-thread proposals from mods
+
+What moderators themselves proposed, in the order raised:
+
+1. **#289 (Derek)**, echoed **#309 (Derek)** "I proposed a slider for members to use so they could
+   set their own limit for the ripple," referencing the existing ChitChat feature that lets members
+   pick 1/2/5/10/20/50 miles. **This is the per-user distance slider that eventually shipped** (#382,
+   "I've made some changes... a new slider. This allows a user to further restrict the posts they
+   see"). NOTE: this is a **per-member** slider (self-selected max distance), explicitly different
+   from the **per-group** slider the product owner already rejected per the task brief — worth
+   flagging that this in-thread ask was already granted in a different form (member-level opt-down)
+   by the end of the thread, and the complaint volume visibly drops afterward (#383 "Brilliant",
+   #385 "already a happier Freegler," #397 Jax "we've come a long way," #408 "I'm loving the slider").
+2. **#211/224 (Jax/Jos)**: "starting at 1 mile and moving outwards more slowly" — i.e. slow down the
+   time-based schedule, especially in dense areas (this is a *schedule*, not *ceiling*, proposal).
+2b. Related: **#128 (Derek)** — push the first ripple step out from 1h to "4 or 6 hours."
+3. **#304 (Neville_Reid)**: per-post "Approve locally" flag/button for mods to mark certain posts
+   (school-specific items, high-demand WANTEDs like TVs/laptops) as **not eligible for wide ripple**
+   — a per-post override rather than a global parameter change. Edward's response (#306): "a good
+   idea, though there are some things to think through" — not rejected outright.
+4. **#307/308/311/312 (Neville_Reid, Jax, Jos)**: stop rippling WANTEDs for "popular"/high-demand
+   items (TVs, laptops) specifically, on the theory these get satisfied locally or not at all.
+   Edward's response (#310): can't reliably classify WANTED-likely-to-be-satisfied; proposes reordering
+   (OFFERs first, no consecutive WANTEDs) instead of suppressing ripple.
+5. **#373 (Jos)**: truncate/collapse motorway-corridor slivers in the displayed reach shape so members
+   don't see "reaches Livingston" without realizing it's a narrow M8 sliver, not an area.
+6. **#217/219/274 (Edward, responding to Derek's repeated crow-flies complaint)**: switch the
+   *displayed* per-post distance from crow-flies to road-distance — a display-truthfulness fix, not a
+   reach-radius change, but directly reduces perceived unfairness (multiple posters, e.g. #204, #215,
+   #272, cite the crow-flies number as evidence the system is broken).
+7. **#325 (May_Stirling_Freegle)**: use AI/population-based "levelling" — i.e. adjust for local
+   population density so remote/rural members aren't structurally under-reached. (This is the flip
+   side of the "too large" complaint — a call for asymmetric ceiling by area type, which the project's
+   ONS-rural-urban N* stratification concept already addresses in spirit.)
+8. **#156/160 (Neville_Reid, Edward)**: use Multiple Index of Deprivation to bias ripple direction
+   toward under-connected/deprived areas (already implemented per Edward, #158) — a fairness-of-reach
+   proposal, not a ceiling proposal, but relevant as prior art for using external indices to modulate
+   reach.
+9. **#159/162/163 (Diz, Group-Mod-J, Edward)**: avoid rippling across water/via tolls unless there's
+   a real bridge/tunnel — implemented same-day (#163/164/165).
+10. **#3/9 (Derek)**: stop TrashNothing members from manually crossposting to multiple groups at
+    once, since rippling now supersedes it — a scope-reduction proposal for a related but distinct
+    mechanism.
+11. **#319 (Angelika)**: auto-join members to groups for *visibility to mods* only, without
+    subscribing them to that group's posts/emails — decouples "membership as post-eligibility record"
+    from "membership as notification source." Addresses the auto-join clutter complaint, not reach
+    per se, but frequently conflated with reach complaints in the thread (many "reach too large"
+    complaints are actually "I got auto-joined to too many groups and now get emails from all of
+    them" — see #229/246/255/279 Jax, #354/357 Sheila, #386 Vee).
+12. **#397 (Jax, summarizing state as of end of thread)**: explicit ask for "a way for moderators to
+    restrict certain posts to a more local area, for example, a drop down list, tick box" — i.e. a
+    **per-post, mod-settable cap**, distinct from both the per-group slider (rejected) and the
+    per-member slider (shipped). Edward's tracked response per Neil's summary (#410): "Yes, this can
+    be done" (unspecific on timeline).
+
+**No mod proposed a data-derived/self-calibrating mechanism themselves** — every mod proposal is
+either (i) a manual dial (per-member slider, per-post flag, per-group cap) or (ii) a schedule/timing
+tweak (slow the ripple down, delay first step). The "principled, data-derived, self-maintaining"
+framing in the project brief is **not something any mod asked for or would recognize as satisfying
+their complaint on its own** — they want a *dial*, and got a partial one (the per-member slider).
+This is an important design constraint: a fully-automatic invisible parameter, however well-derived,
+risks re-triggering the "we're not being listened to / not in control" complaint (#343, #400, #392)
+unless it comes with a visible, explainable "why this number" artifact per area.
+
+---
+
+## 5. (d) What defenders/positive reports say works
+
+Useful as calibration for "what does a good outcome look like" and to weight against the complaint
+volume:
+
+- **#17, #34, #74, #84, #107 (Jacky)**: general thanks/support, not reach-specific.
+- **#42 (Jacky)**: wristwatch offer, 3 replies within 8h from Lowestoft(17mi)/Cromer(28mi)/Norwich(22mi);
+  collector cycled from Norwich. Rural example where wider reach clearly helped.
+- **#61 (Beth)**: rural Norfolk, routinely travels 1h+ to Norwich/Cambridge/Ely; "for me it would
+  never be an extra trip."
+- **#122 (Michael)**: Wellingborough reply on MK-area coffee jars post turned out to be "a few doors
+  down" — the *shown* distance/group was misleading but the *actual* match was hyperlocal; used as
+  evidence the ordering/relevance logic, not just the ceiling, is doing real work.
+- **#199 (Diz)**: friend's chairs offer, stuck for weeks locally, rippled to a neighbouring group,
+  got a reply "she's really pleased."
+  #257/#256 (Edward): agreement that a specific false-positive "suspicious" flag has been fixed.
+- **#254 (Jacky)**: "It's always been absurd to me too... our members are used to seeing posts from
+  lots of different places... our way of working hasn't demonstrably created more freegling so I am
+  hoping that rippling does."
+- **#331 (Edward)**: cites member-churn data — daily departures did **not** increase post-rollout
+  (graph shown, no raw numbers given in text) as evidence against "mass exodus" narrative.
+- **#347 (Jos)**: "I'm very much for local but ultimately if no one local wants something it may be
+  better for someone a bit further away to get a chance... Freegle is 16 years old, we can't not
+  change."
+- **#382-385, 397, 406, 408 (Edward, Melissa, Jax, Lorraine)**: once the **per-member distance
+  slider** shipped (2026-07-01, i.e. day 11 of a 12-day-observed thread), sentiment measurably
+  improves — "Brilliant - thank you" (#383), "already a happier Freegler on ChitChat" (#385), "we've
+  come a long way" (#397), Lorraine's detailed positive post #406 ("together with the slider I have
+  got a much busier list of items but they are closer to home"), "I'm loving the slider" (#408).
+- **#411 (Diz)**: Dursley → North Bristol summerhouse furniture match, explicitly positive outcome
+  from a "far" ripple.
+- **#412 (Jos)**: "Thus proving you can't please everyone" — realistic closing tone.
+
+**What "works" for defenders, distilled**: rural/low-density posters and posters whose actual
+collector distance was modest even when the *displayed* group/reach looked wide. The chief lever
+that visibly reduced complaint volume in-thread was not a reach-radius change but the **per-member
+opt-down slider** — i.e. giving individuals a way to see they have agency over what they're shown,
+even though the underlying reach-emission mechanism didn't change.
+
+---
+
+## 6. Quantification summary
+
+- **414 posts**, 30 distinct human posters (+ Edward 120, Neil 8) over 12 days.
+- **~10-12 distinct posters** (a third of the human population) raised genuine reach/distance
+  complaints with concrete detail; **~13 distinct place-pairs** cited with a number attached.
+- Of those 13, **the majority cluster in Greater London** (7 of 13: Chilterns/NW-London, Harrow,
+  Croydon/K&C, Brent/Hemel Hempstead, Watford, Kensington multi-group, Portobello M8) — consistent
+  with the brief's "mostly dense/urban areas" framing. The remainder are Scotland (Fife/Edinburgh, x2),
+  Bristol, Thurrock/Medway, Harlow/Tower Hamlets, Hull/Castleford.
+- At least **2 of the 13 cited "complaints" turned out to be bugs/artifacts on investigation**, not
+  reach-radius problems: the Farnborough-Kent/Farnborough-Hampshire name confusion (#341→#346), and
+  the crow-flies-vs-road-distance display (affects perception of essentially every example that cites
+  a "shown distance").
+- **2 experienced moderators explicitly resigned mid-thread** citing rippling (Sylvain #69, and one
+  other referenced anonymously in #83) and **2 more (Sheila #400, Group-Mod-J #343) stated they were
+  seriously considering quitting** by the end — these are opinion-leader losses, disproportionate to
+  the raw complainant count, and Neil (Board Chair) intervened personally multiple times (#57, #349,
+  #375, #380, #394, #395, #409, #410) to retain them.
+- **1,525 offers/day systemwide** (per project brief) vs. **~10-12 distinct vocal reach-complainants**
+  over 12 days — even generously assuming each complainant represents 50-100 silently-annoyed members,
+  this is consistent with the brief's framing that reach dissatisfaction is a **real but numerically
+  small, geographically concentrated (dense/urban), high-influence (moderator-level) problem** rather
+  than a mass-member revolt (Edward's own churn-graph evidence in #331 supports this).
+- The volume of complaint **dropped visibly after the per-member slider shipped** on day 11 — this is
+  the single most effective visible intervention in the thread, even though it's a different lever
+  (opt-down floor on what an individual sees) from the reach-ceiling parameter the design task is
+  about.
+
+---
+
+## 7. Requirements the design must meet to land with this audience
+
+Distilled from the above, not just "get the number right":
+
+1. **Must be explainable per-area, on demand, in plain language** — not just "trust the stats"
+   (#7's framing visibly backfired repeatedly; #237's wording fix worked). A mod or member asking
+   "why does my post reach 32 groups?" needs an answer better than "the data says so." The existing
+   ModTools "Who can see this?"/Rippling Explorer map is the right *substrate* for this but needs a
+   plain-English "why this far, why not further" annotation, ideally referencing the same N*/audience
+   logic the design will use.
+
+2. **Must visibly explain the density/audience-size asymmetry** — the Swindon-vs-London complaint
+   (#248/250) is the single clearest articulation of the actual problem the design is meant to solve;
+   any credible design should be able to show, on the same map/UI, "reaching N active members here vs
+   M there" so mods can see *why* equal drive-time isn't equal audience, rather than having to infer
+   it from screenshots of the reach slider as Jos did manually.
+
+3. **Must not re-centralize the "we have no control" grievance** — a fully automatic, invisible
+   parameter (how ever well-calibrated) risks the same "not being listened to" reaction (#343, #392,
+   #400) that plagued the rollout, unless paired with a visible **per-area published number** ("your
+   area's typical burst size / effective ceiling is X minutes because Y") so mods can see the
+   mechanism is systematic and locally-responsive, not arbitrary or opaque.
+
+4. **Must distinguish itself clearly from the already-shipped per-member slider** — several
+   complainants (#383-408) are now satisfied largely because of the member-level opt-down slider,
+   which is a different mechanism from the ceiling/burst-size parameter. The design should make clear
+   it is not duplicating that fix, and ideally should note that the member slider **already provides
+   a release valve** that reduces the urgency/stakes of getting the systemic ceiling perfectly right
+   for every individual (errors are recoverable by the user, not just centrally).
+
+5. **Should account for or explicitly address transport-mode fairness** — several complaints
+   (#157 tolls/water, #362 Melissa "without a car, entirely inaccessible", #244 Jax) are really about
+   *reachability* mode (car vs public transport vs no car), which drive-time-by-road does not fully
+   capture; a "genuinely too large" perception is sometimes actually "too large for me, a non-driver"
+   — worth flagging as adjacent-but-distinct from the core ceiling-calibration problem, already
+   partially addressed by the deprivation-index adjustment (#158) and toll/water avoidance (#158-165).
+
+6. **Should collapse/flag motorway-corridor artifacts in the display**, independent of the ceiling
+   value itself (#373) — a design that changes *how far* without also fixing *how the far reach is
+   drawn/communicated* will leave this specific complaint unaddressed regardless of the calibration
+   quality.
+
+7. **Should fix (or at minimum decouple from) the crow-flies-distance display bug** (#204, #215, #217,
+   #272, #274) — several "reach is too large" complaints are partly fueled by a *separate*, already
+   half-acknowledged bug (displayed per-post distance is crow-flies, not road-distance), which
+   inflates the sense that the system is getting geography wrong even when the underlying ripple
+   mechanism is using road/drive-time correctly. This should be fixed regardless of what the new
+   design does, or the new design will inherit blame for an unrelated defect.
+
+8. **Should offer a mod-facing, not just member-facing, lever** — Jax's end-of-thread ask (#397,
+   "a way for moderators to restrict certain posts to a more local area... drop down list, tick box")
+   and Neville_Reid's per-post "Approve locally" idea (#304) indicate mods want *some* agency over
+   individual posts even if a global per-group slider is off the table. A principled per-area ceiling
+   doesn't preclude a narrow, per-post, mod-triggered override for edge cases (school-specific items,
+   high-demand WANTEDs) — consider whether the design should explicitly allow (or explicitly and
+   visibly reject, with reasoning) that kind of override, rather than leaving it unaddressed.
+
+---
+
+## Appendix: Discourse API auth note (for reproducibility)
+
+The documented header combo (`User-Api-Key` + `User-Api-Client-Id`) returns HTTP 500 on this
+Discourse instance/key. The working combo is **`User-Api-Key` header only** (confirmed against
+`/session/current.json`, `/t/9808.json`, and `/t/9808/posts.json?post_ids[]=...`). This matches
+prior finding in memory file `reference_discourse_api_key.md`. Full topic (414 posts) was fetched
+in 20 chunks of ~20 `post_ids[]` each via `/t/9808/posts.json`.

--- a/plans/2026-07-02-reach-design-evidence/3-behaviour.md
+++ b/plans/2026-07-02-reach-design-evidence/3-behaviour.md
@@ -1,0 +1,324 @@
+# Revealed Travel Behaviour: How Far Do Freeglers Actually Travel?
+
+Data pulled read-only from live prod DB, 2026-07-02. All SQL shown inline. Crow-flies (haversine) km
+throughout — no road-network distance available cheaply at this volume, so all figures **understate**
+true drive distance/time (roads are never straight lines; typical rule of thumb is road distance ≈
+1.2-1.4x crow-flies in urban areas, more in rural areas with rivers/motorways-only crossings).
+
+## THE CENTRAL CAVEAT — read this before using any number below
+
+**Every distance in this report is a behaviour-WITHIN-EXPOSURE distribution, not free demand.**
+A freegler can only reply to, or collect, a post that was already visible to them. Since go-live
+(~2026-06-14) that visibility is capped at ~30 min drive-time reach (post-ripple) or group membership
+(pre-ripple / non-members). So:
+
+- We are measuring "how far did people travel, **given that reach already capped what they could see**",
+  not "how far would people be willing to travel if reach were unlimited".
+- The tail of the distribution is mechanically truncated at the current reach ceiling. We cannot see
+  the counterfactual demand beyond it — that requires the separate randomized reach experiment (already
+  specced, ~3 weeks to result).
+- This dataset is therefore usable for one thing with confidence: **"what cap would preserve X% of
+  collections we are currently getting"** — i.e. a safe *floor* for any new parameter, verified against
+  what's actually happening today. It is **not** usable to conclude "nobody would travel further than
+  Nkm" — some might, if shown the post; we just can't see them yet.
+- Second-order caveat: `users_approxlocs` is a **current-location snapshot** (one row per user, no
+  history), not a point-in-time record. For the pre-rippling (March/April) comparison this means we are
+  using each user's *current* (June/July) location for their March collection — if a meaningful number
+  of users moved house in between, the pre-period numbers are somewhat noisy. Coverage rate is similar
+  in both periods (99.5% pre vs 95.3% post of taker-records had a resolvable location), so this is not a
+  coverage bias, only a possible drift-in-location bias, believed small over a ~3 month window.
+- Third-order caveat: about half of Taken/Received outcomes have no matching `messages_promises` row
+  (some transactions go straight to "Taken" without a formal promise step), so the taker-distance sample
+  is a ~50% sub-sample of all collections, not all of them. No obvious reason to expect this to bias
+  distance (promise usage looks like a UI-adoption effect, not a proximity effect), but flagging it.
+
+## Data sources used
+
+- **Taker location**: `messages_promises` (msgid, userid, promisedat) — the person promised the item,
+  taken as the most recent promise per msgid at/around the Taken outcome. `messages_outcomes` has no
+  `takenby`/`userid` column, so this is the best available "who actually took it" signal. Verified
+  reasonable coverage: 29,636 / 60,025 (49%) of Taken/Received outcomes since 2026-05-01 have a promise
+  record; 96% of those promised users have a resolvable location.
+- **Replier location / taker location**: `users_approxlocs` (userid, lat, lng) — current best-guess
+  location per user, 174,786 rows. This is a snapshot, not a log (see caveat above).
+- **Post location**: `messages.lat`/`messages.lng` — always populated (100% of the Taken/Received sample).
+- **Reply events**: `chat_messages` where `type='Interested'`, joined via `refmsgid` to the post and
+  `chatid`→`chat_rooms.chattype='User2User'` to isolate person-to-person replies (excludes system/mod
+  chat). Replier identified as `chat_messages.userid`.
+- **Home group / membership class**: `messages_groups` (picking one canonical group per message,
+  preferring an `Approved` collection row) joined to `memberships` to classify the taker as
+  `home_member` (member of that group, not via rippling), `rippled_member` (member via rippling —
+  `memberships.rippled=1`), or `non_member` (not a member of the post's group at all — took/replied
+  purely via reach exposure without ever joining).
+- **Density proxy**: no ready-made ONS rural-urban class column exists on `groups`. Built proxy =
+  `membercount / polygon_area_km2`, area computed from `groups.polyindex` (a `POLYGON` whose vertices are
+  stored as raw lng/lat degrees — despite an `ST_SRID` tag of 3857, `ST_Area()` on it returns degrees²,
+  not m², so area was converted manually: `area_km2 = area_deg2 * 111.32 * 111.32 * cos(group_lat)`).
+  Exemplar groups requested: Hull(21473), TowerHamletsFreegle(21662), Oxford-Freegle(21555),
+  ribblevalleyfreegle(21589), Swindon-Freegle(92103), EdinburghFreegle(21354). "NW-London Offers" as
+  named in the Discourse complaint does not match any current group `nameshort`/`namefull` — it is
+  presumably a legacy Yahoo-era group name; not analysed as a named exemplar, but London-area coverage is
+  reasonably proxied by TowerHamletsFreegle here.
+
+## 1. Taker distance (post → collector), since 2026-05-01
+
+SQL (haversine distance, most-recent promise per msgid, joined to Taken/Received outcomes):
+
+```sql
+SELECT ROUND(dist_km,2) FROM (
+  SELECT m.id as msgid,
+    (6371 * ACOS(LEAST(1, GREATEST(-1,
+        COS(RADIANS(m.lat)) * COS(RADIANS(ua.lat)) * COS(RADIANS(ua.lng) - RADIANS(m.lng)) +
+        SIN(RADIANS(m.lat)) * SIN(RADIANS(ua.lat))
+    )))) as dist_km
+  FROM messages m
+  JOIN messages_outcomes mo ON mo.msgid = m.id AND mo.outcome IN ('Taken','Received')
+  JOIN (
+    SELECT p.msgid, p.userid,
+      ROW_NUMBER() OVER (PARTITION BY p.msgid ORDER BY p.promisedat DESC) as rn
+    FROM messages_promises p
+  ) plat ON plat.msgid = m.id AND plat.rn = 1
+  JOIN users_approxlocs ua ON ua.userid = plat.userid
+  WHERE mo.timestamp >= '2026-05-01' AND m.lat IS NOT NULL AND m.lng IS NOT NULL
+) x
+```
+
+Sanity check: 60,025 Taken/Received rows since 2026-05-01, all with post lat/lng; 29,636 have a promise
+record; 28,896 of those resolve to a location (n used below).
+
+**Overall taker distance, n=28,893** (after also joining membership class, see below — 3 rows dropped by
+that join's group resolution edge cases):
+
+| Percentile | Distance (km) |
+|---|---|
+| p50 | 2.1 |
+| p75 | 5.9 |
+| p90 | 12.7 |
+| p95 | 18.8 |
+| p99 | 37.6 |
+| mean | 5.5 |
+| max | 710 (data-quality outlier — stale/incorrect approxloc or postal exchange, not representative) |
+
+**Split by membership class relative to the post's home group** (`home_member` = joined that group
+normally; `rippled_member` = joined that group via a rippling-triggered membership
+(`memberships.rippled=1`); `non_member` = took the item without ever being a member of that group at
+all — i.e. pure reach-exposure collection):
+
+| Class | n | p50 | p75 | p90 | p95 | p99 | mean |
+|---|---|---|---|---|---|---|---|
+| home_member | 28,418 | 2.1 | 5.9 | 12.5 | 18.4 | 36.6 | 5.4 |
+| rippled_member | 30 | 4.5 | 7.3 | 8.7 | 8.9 | 23.2 | 5.0 |
+| non_member | 445 | 4.1 | 11.3 | 25.9 | 44.0 | 219.2 | 13.0 |
+
+Read with caution — `rippled_member` is a very small sample (30) since formal rippled-membership
+creation is rare (most reach interactions don't convert to membership). `non_member` (445, ~1.5% of all
+takers) is the cleanest signal of "genuine ripple-only collection" and is markedly longer-tailed than
+home members (p90 26km vs 12.5km) — consistent with rippling successfully extending collection distance
+for the minority of transactions it drives, but also shows some very long tail outliers (>100km) that are
+likely delivery arrangements or stale-location noise rather than drive-and-collect.
+
+**What cap would preserve X% of ALL observed collections** (n=28,893, all classes combined):
+
+| Cap | % of collections captured |
+|---|---|
+| 2 km | 48.7% |
+| 3 km | 58.2% |
+| 5 km | 70.8% |
+| 8 km | 81.6% |
+| 10 km | 85.9% |
+| 15 km | 92.5% |
+| 20 km | 95.6% |
+| 25 km | 97.2% |
+| 30 km | 98.2% |
+| 40 km | 99.2% |
+| 50 km | 99.4% |
+
+At a very rough 25 km/h effective urban drive-time conversion, 20km ≈ ~48 min, i.e. today's ~30min /
+~45km ceiling is already generous relative to where 95%+ of actual collections happen — consistent with
+the "feels too large" complaint. (Conversion is approximate; see time/distance caveat below.)
+
+## 2. Reply-distance decay, since rippling went live (2026-06-14)
+
+SQL (all `Interested` replies in User2User chats, replier location vs post location; also flags whether
+that specific replier was the one who ultimately got the message promised to them):
+
+```sql
+SELECT
+  ROUND((6371 * ACOS(LEAST(1, GREATEST(-1,
+      COS(RADIANS(m.lat)) * COS(RADIANS(ua.lat)) * COS(RADIANS(ua.lng) - RADIANS(m.lng)) +
+      SIN(RADIANS(m.lat)) * SIN(RADIANS(ua.lat))
+  )))), 2) as dist_km,
+  m.id as msgid, cm.userid as replier,
+  CASE WHEN plat.takerid = cm.userid THEN 1 ELSE 0 END as replier_was_taker
+FROM chat_messages cm
+JOIN chat_rooms cr ON cr.id = cm.chatid AND cr.chattype='User2User'
+JOIN messages m ON m.id = cm.refmsgid
+JOIN users_approxlocs ua ON ua.userid = cm.userid
+LEFT JOIN (
+  SELECT p.msgid, p.userid as takerid,
+    ROW_NUMBER() OVER (PARTITION BY p.msgid ORDER BY p.promisedat DESC) as rn
+  FROM messages_promises p
+) plat ON plat.msgid = m.id AND plat.rn = 1
+WHERE cm.type = 'Interested' AND cm.date >= '2026-06-14'
+  AND m.lat IS NOT NULL AND m.lng IS NOT NULL
+```
+
+Sanity check: 27,013 `Interested` chat_messages since 2026-06-14; 23,738 (88%) resolve to a replier
+location. 3,464 of those replies (14.6%) belong to the replier who eventually got the item promised to
+them ("converted" replies).
+
+**Overall reply distance distribution, n=23,738:**
+
+| Percentile | Distance (km) |
+|---|---|
+| p50 | 6.0 |
+| p75 | 11.8 |
+| p90 | 20.0 |
+| p95 | 27.1 |
+| p99 | 50.4 |
+
+(Note replies are further out than takers on average — makes sense, replying is low-cost/high-hope,
+whereas actually collecting selects for people who are close enough to bother.)
+
+**Replies per post by distance band, and conversion rate (did that replier become the taker):**
+
+| Band | Replies in band | % of all replies | Taker-replies in band | % of all taker-replies | Conversion rate (taker / replies in band) |
+|---|---|---|---|---|---|
+| 0-2 km | 3,724 | 15.7% | 628 | 18.1% | 16.9% |
+| 2-5 km | 6,350 | 26.8% | 1,027 | 29.6% | 16.2% |
+| 5-10 km | 6,244 | 26.3% | 876 | 25.3% | 14.0% |
+| 10-20 km | 5,049 | 21.3% | 652 | 18.8% | 12.9% |
+| 20-40 km | 1,942 | 8.2% | 238 | 6.9% | 12.3% |
+| 40km+ | 429 | 1.8% | 43 | 1.2% | 10.0% |
+
+**This is the clearest decay signal in the whole dataset**: conversion rate drops monotonically with
+distance, from 16.9% at <2km to 10.0% at 40km+ — roughly a 40% relative drop end to end, gentle rather
+than a cliff. Cumulatively, 91.9% of all taker-conversions happen within 20km of the post, 98.8% within
+40km. There is no sharp elbow — decay is smooth, which argues against there being one universal "correct"
+cutoff distance and supports a probabilistic/percentile-based design (e.g. "cover the drive-time radius
+that historically yields 90-95% of conversions for this area's density") over a single hard constant.
+
+## 3. Density splits (exemplar groups)
+
+Density proxy: `membercount / polygon_area_km2` (see Data Sources for area computation method).
+
+| Group | Members | Area (km²) | Density (members/km²) |
+|---|---|---|---|
+| TowerHamletsFreegle | 26,137 | 20.2 | **1,292.0** |
+| Oxford-Freegle | 50,177 | 206.1 | 243.4 |
+| EdinburghFreegle | 47,617 | 402.8 | 118.2 |
+| Swindon-Freegle | 9,067 | 559.4 | 16.2 |
+| ribblevalleyfreegle | 5,338 | 574.4 | 9.3 |
+| HullFreegle | 3,360 | 1,156.8 | **2.9** |
+
+(Hull's low density despite being a city is because its group polygon extends over a large rural
+hinterland catchment beyond the urban core — density here is a property of the *group's drawn boundary*,
+not just population density; a real implementation should probably use population/member density in a
+fixed-radius disc around the post rather than group-polygon-average, to avoid this artefact.)
+
+**Taker distance by exemplar group** (same promise-based method as section 1, filtered to messages whose
+canonical group is one of the six), since 2026-05-01:
+
+| Group | n takers | p50 | p75 | p90 | p95 | p99 | mean |
+|---|---|---|---|---|---|---|---|
+| TowerHamletsFreegle | 105 | 0.54 | 1.04 | 4.99 | 8.54 | 12.57 | 1.60 |
+| Oxford-Freegle | 785 | 2.84 | 4.99 | 9.69 | 13.44 | 29.25 | 4.37 |
+| EdinburghFreegle | 510 | 3.49 | 5.95 | 8.56 | 12.28 | 49.32 | 6.31 |
+| Swindon-Freegle | 39 | 3.93 | 5.85 | 21.97 | 26.84 | 191.26 | 10.02 |
+| HullFreegle | 44 | 3.73 | 7.76 | 12.95 | 16.91 | 23.56 | 5.55 |
+| ribblevalleyfreegle | 3 | 18.31 | 19.6 | 19.6 | 19.6 | 19.6 | 15.34 |
+
+(Ribble Valley n=3 — too small to draw any conclusion, shown only because it was a named exemplar in the
+Discourse complaint; treat as anecdote not data.)
+
+**What cap captures X% of collections, per group** (this is the direct empirical input for a per-density
+extent parameter):
+
+| Group | 2km | 5km | 8km | 10km | 15km | 20km | 30km |
+|---|---|---|---|---|---|---|---|
+| TowerHamletsFreegle (dense) | 81.0% | 90.5% | 94.3% | 98.1% | 99.0% | 100% | 100% |
+| Oxford-Freegle | 35.3% | 75.0% | 86.0% | 90.8% | 96.1% | 97.6% | 99.4% |
+| EdinburghFreegle | 30.8% | 64.1% | 87.1% | 92.2% | 96.5% | 97.3% | 98.2% |
+| HullFreegle | 25.0% | 63.6% | 77.3% | 88.6% | 93.2% | 95.5% | 100% |
+| Swindon-Freegle (sparse) | 38.5% | 69.2% | 82.1% | 84.6% | 87.2% | 89.7% | 97.4% |
+
+This is the single most decision-relevant table in the report: **the same percentage-of-collections-
+captured target implies wildly different distance caps by density.** To hit "95% of collections
+captured": TowerHamlets needs ~5km, Oxford/Edinburgh/Hull need ~15-18km, Swindon needs >30km. This
+directly supports the extent-governor's premise (equal-N* audience-sizing beats equal-drive-time) and
+gives concrete per-density calibration points rather than a guess.
+
+Reply-distance data (section 2) by the same exemplar groups, since 2026-06-14 (small samples for several
+— treat non-Oxford/Edinburgh rows as indicative only):
+
+| Group | n replies | p50 | p75 | p90 | p95 | n taker-replies |
+|---|---|---|---|---|---|---|
+| Oxford-Freegle | 600 | 3.93 | 6.91 | 12.96 | 26.6 | 72 |
+| EdinburghFreegle | 447 | 4.91 | 8.74 | 19.14 | 48.7 | 64 |
+| HullFreegle | 59 | 3.88 | 7.68 | 11.68 | 16.91 | 12 |
+| Swindon-Freegle | 17 | 4.64 | 12.3 | 24.45 | 26.84 | 4 |
+| TowerHamletsFreegle | 30 | 3.40 | 5.87 | 6.49 | 9.85 | 2 |
+| ribblevalleyfreegle | 11 | 9.51 | 14.63 | 24.7 | 26.08 | 1 |
+
+## 4. Pre- vs post-rippling comparison (taker distance)
+
+Pre = outcomes 2026-03-01 to 2026-05-01 (before rippling went live 2026-06-14). Post = outcomes from
+2026-06-01 onward. Same promise-based taker-distance method as section 1.
+
+Sanity check: pre period 59,269 Taken/Received rows, 30,167 (51%) with a promise, 30,021 resolve to
+location. Post period 29,335 Taken/Received rows, 14,157 (48%) with a promise, 13,493 resolve to
+location. Coverage rates are consistent between periods (99.5% and 95.3% resolvable), so this is not a
+coverage-bias artefact.
+
+| Period | n | p50 | p75 | p90 | p95 | p99 | mean |
+|---|---|---|---|---|---|---|---|
+| Pre (Mar-Apr) | 30,021 | 2.21 | 6.15 | 13.29 | 20.18 | 55.76 | 6.47 |
+| Post (Jun-Jul) | 13,493 | 2.04 | 5.79 | 12.30 | 18.23 | 36.30 | 5.14 |
+
+**Bottom line on pre/post: no evidence that rippling has meaningfully lengthened typical collection
+distance so far.** The median is essentially unchanged (2.21km → 2.04km), and the observed tail actually
+*shrank* (p99 55.8km → 36.3km, mean 6.5km → 5.1km) rather than grew. Two plausible readings, not
+distinguishable from this data alone:
+1. Rippling genuinely hasn't shifted typical collector behaviour yet (early days, ~2.5 weeks live at
+   measurement time; adoption/awareness of extended reach may be low; and the earlier "0.9-1.0 distinct
+   repliers/post, 56-66% zero-reply" facts suggest most posts aren't yet being seen/acted on by the newly
+   reachable population).
+2. The `users_approxlocs` current-location-snapshot confound (see top caveat) could be smoothing out a
+   real shift if it exists — this comparison is the one most exposed to that caveat, since it spans the
+   longest time gap (up to ~4 months between the pre-period transaction and the location snapshot).
+Given the extent-governor's stated purpose is to *rein in* excess reach in dense areas rather than
+*grow* it, this "no lengthening yet" finding is not alarming — it's mainly a reminder that revealed
+pre/post data cannot yet answer "how much MORE would people collect from if given more reach" (that's
+what the separate reach experiment is for), only "has typical behaviour visibly shifted so far" (answer:
+not yet, materially).
+
+## Bottom line: what cap would capture X% of observed successful collections, by density class
+
+Using the taker-distance-by-group table (section 3) as the primary evidence, converted to an
+**approximate** drive-time using a rough 25 km/h effective speed for dense urban and 35-40 km/h for
+lower-density areas (conversion is illustrative only — no road-network data was used; real drive-times
+should replace this before any implementation):
+
+| Density class (exemplar) | Distance cap for 90% of collections | Distance cap for 95% | Approx drive-time cap for 95%* |
+|---|---|---|---|
+| Very dense (TowerHamlets, ~1,300/km²) | ~5 km | ~5-8 km | ~12-20 min |
+| Dense (Oxford, ~240/km²) | ~10 km | ~15 km | ~25-30 min |
+| Medium (Edinburgh, ~120/km²) | ~9 km (noisy tail) | ~15 km | ~25-30 min |
+| Low (Hull's drawn catchment, ~3/km²) | ~9 km | ~15-18 km | ~25-30 min |
+| Sparse (Swindon, ~16/km²) | >20 km (still climbing) | >20 km | 35-45+ min |
+
+*Time conversion is a rough illustrative placeholder, not a measured value — treat the km columns as the
+credible numbers and the time column as "roughly what this would mean in the current drive-time-based
+reach system", pending either real routing-engine conversion or a switch to a distance/audience-based
+metric that sidesteps the conversion problem entirely.
+
+**Overall recommendation implied by this data**: a single global drive-time constant cannot satisfy "95%
+of collections captured" across this density range without being needlessly large in dense areas (where
+5-8km covers 95%) or too small in sparse areas (where even 20km+ doesn't). This is exactly the
+"~80x active-member-pool spread" finding restated in collection-distance terms, and supports deriving the
+extent-governor's N* (or an equivalent distance/time cap) from **local density**, calibrated so that the
+captured fraction of *currently observed* successful collections (e.g. targeting the 90-95% band) is held
+roughly constant across areas — rather than holding drive-time constant. The concrete per-density
+percentile tables above (sections 1 and 3) are a ready-made calibration anchor for that N*/cap function,
+though should be treated as a **floor** (today's exposure-limited behaviour), refreshed once genuine
+demand data exists from the separate randomized reach experiment.

--- a/plans/2026-07-02-reach-design-evidence/4-audience-curves.md
+++ b/plans/2026-07-02-reach-design-evidence/4-audience-curves.md
@@ -1,0 +1,316 @@
+# Rippling reach: audience-vs-drive-time curves from real persisted schedules
+
+Dark-compute of the extent-governor MVP (audience-sized burst, N\* target) directly from
+`rippling_reach.schedule`, which already stores each post's real routing-server tick schedule
+(`drive_min`, `cumulative_users` per tick). No new instrumentation, no implementation — this is a
+read-only replay of production data to answer: **what would different N\* choices actually produce,
+geographically, right now?**
+
+Data pulled from live prod DB, 2026-07-02.
+
+---
+
+## 0. Method and data caveats
+
+- `rippling_reach` has 50,831 rows total (data starts 2026-06-22 — 10 days of rippling-live traffic,
+  not the 3-4 weeks originally asked for; that's all that exists post-launch).
+- `status`: `stopped` = 26,619 rows (52%), ALL with `schedule IS NULL` / `total_freeglers = 0` — these
+  never got a first tick at all (killed immediately: not an Offer, no usable location, reach-gated for
+  other reasons — see `finding_reach_gate*` prior work). They carry no audience-curve information and
+  are excluded from the curve analysis below (but see §3c for what this means for "never fills").
+- `status IN ('done','expanding')` = 24,213 rows **with a real schedule** — this is the analysis
+  population. `done` (11,994) completed all `total_ticks=9` scheduled ticks (fixed schedule design,
+  confirmed: every post uses exactly 9 ticks). `expanding` (12,219) is mid-flight, still dwell-gated
+  waiting for its next tick (all 12,219 have a future `next_expansion_at`, none stalled).
+- For "current final audience" stats (§1) I used **`done`-only** (unbiased, fully expanded) —
+  12,219 `expanding` rows would understate audience since they haven't finished. In practice the two
+  populations are statistically close (p50 2,457 done vs 2,314 expanding-so-far), because most
+  `expanding` posts already stopped early via the reply-stop/dwell gate rather than being far from done.
+- For "drive-time to cross N\*" (§2-4) I used **all 24,213** posts' curves — reading a curve up to
+  whatever tick a post has currently reached is valid data regardless of whether the post has finished;
+  it only under-counts "never reached N\*" slightly for `expanding` posts that might still cross N\*
+  on a future tick. Flagged where relevant.
+- Confirmed ceiling: **max_drive_min caps at exactly 30.0 minutes** (not 45 — the 45min figure in the
+  brief was speculative and is not what's live). `done` posts range from 13.5 to 30.0 min drive-time
+  (reply-stop / audience plateau can end expansion well before the ceiling even today).
+- Home group joins: `messages_groups` WHERE `rippled_in=0` (the group the post originated in, i.e. not
+  a group it rippled into) — 24,201/24,213 (99.95%) resolved to exactly one home group.
+- All SQL/JS shown below; raw intermediate files in this directory (`curves_raw.tsv`,
+  `msg_home_group.tsv`, `results.json`, `group_stats.json`, `notified_counts.tsv`).
+
+### Extraction SQL (avoids ever selecting the huge `wkt` polygon field)
+
+```sql
+-- Schema check
+DESCRIBE rippling_reach;
+-- schedule shape confirmed: [{"tick":1,"drive_min":15.88,"cumulative_users":2800,"wkt":"POLYGON(...)"}...]
+
+-- Curves: pull ONLY drive_min/cumulative_users arrays via JSON_EXTRACT, never the wkt
+SELECT r.msgid, r.lat, r.lng, r.total_freeglers, r.max_drive_min, r.status,
+  JSON_EXTRACT(r.schedule, '$[*].drive_min')        AS dm,
+  JSON_EXTRACT(r.schedule, '$[*].cumulative_users')  AS cu
+FROM rippling_reach r
+WHERE r.status IN ('done','expanding') AND r.schedule IS NOT NULL;
+-- 24,213 rows
+
+-- Home group per message (origin group, not rippled-in)
+SELECT mg.msgid, mg.groupid, g.nameshort, g.region
+FROM messages_groups mg
+JOIN rippling_reach r ON r.msgid = mg.msgid AND r.status IN ('done','expanding') AND r.schedule IS NOT NULL
+JOIN `groups` g ON g.id = mg.groupid
+WHERE mg.rippled_in = 0;
+
+-- Notification fan-out
+SELECT msgid, COUNT(*) AS n FROM rippling_reach_notified GROUP BY msgid;
+-- 18,143 distinct msgids, 930,344 total notification rows
+```
+
+### N\*-crossing JS (linear interpolation between ticks, origin assumed (0,0))
+
+```js
+function driveTimeToReachN(post, N) {
+  const ticks = post.ticks; // [{drive_min, cumulative_users}, ...] sorted by tick
+  if (ticks[0].cumulative_users >= N) {
+    if (ticks[0].cumulative_users === 0) return ticks[0].drive_min;
+    return ticks[0].drive_min * (N / ticks[0].cumulative_users); // interpolate from origin
+  }
+  for (let i = 1; i < ticks.length; i++) {
+    if (ticks[i].cumulative_users >= N) {
+      const t0 = ticks[i-1], t1 = ticks[i];
+      const frac = (N - t0.cumulative_users) / (t1.cumulative_users - t0.cumulative_users);
+      return t0.drive_min + frac * (t1.drive_min - t0.drive_min);
+    }
+  }
+  return null; // never reached within the post's observed ticks
+}
+```
+
+---
+
+## 1. Distribution of total audience at current full reach (30-min ceiling)
+
+`done`-only, n=11,994 (fully expanded posts, unbiased):
+
+| Percentile | total_freeglers |
+|---|---|
+| p10 | 602 |
+| p25 | 1,257 |
+| p50 | 2,457 |
+| p75 | 4,743 |
+| p90 | 8,696 |
+| p99 | 15,012 |
+| max | 17,776 |
+| mean | 3,656 |
+
+**Spread confirmed and quantified precisely**: p90/p10 = **14.4x**, max/p10 = **29.5x**. (All
+24,213 done+expanding posts together: max/p10 = 34.0x, p90/p10 = 16.3x — consistent.) This is somewhat
+lower than the ~80x figure quoted from the prior "active-member-pool" measurement, because
+`total_freeglers` here is the routing server's *realized, eligibility-filtered* audience at the fixed
+30-min polygon (already excludes ineligible/duplicate/opted-out members etc.), whereas the ~80x figure
+was the raw active-member-pool-within-30-min-drive (p50 2,900 → max 15,236). Both point the same
+direction — a large, real, order-of-magnitude spread in what "30 minutes" delivers depending on area —
+just measured at different pipeline stages. The routing-server output (this data) is the more direct
+answer to "what audience does the CURRENT rule actually produce", so treat 14-30x as the operative
+figure, not 80x.
+
+---
+
+## 2. Drive-time to cross candidate N\* targets (dark-computed governor MVP)
+
+All 24,213 posts with curves. For each N\*, the drive-time at which cumulative_users first reaches N\*
+(interpolated), and the fraction of posts that **never** cross it within their observed schedule
+(would ride to the ceiling under an audience-sized-burst rule with that N\*).
+
+| N\* | % posts reaching N\* | drive-time p10 | p25 | p50 | p75 | p90 | p99 | mean | % NEVER reach (→ ceiling) |
+|---|---|---|---|---|---|---|---|---|---|
+| 1,000 | 81.1% | 6.2 | 7.6 | **11.2** | 18.5 | 25.7 | 29.6 | 13.6 | 18.9% |
+| 2,000 | 57.3% | 11.9 | 13.8 | **17.4** | 24.3 | 28.2 | 29.8 | 18.8 | 42.7% |
+| 3,000 | 42.0% | 16.7 | 18.8 | **22.3** | 26.1 | 28.5 | 29.9 | 22.4 | 58.0% |
+| 4,000 | 30.0% | 17.9 | 20.3 | **23.3** | 26.7 | 28.6 | 29.9 | 23.3 | 70.0% |
+| 6,000 | 0.004% (1 post) | — | — | — | — | — | — | — | ~100% |
+| 8,000 | 0% | — | — | — | — | — | — | — | 100% |
+
+**Reading this**: at N\*=2000, half of all posts would already be satisfied by ~17 minutes (well under
+today's fixed 30), but 43% of posts would never reach 2,000 people at all and would ride to whatever
+ceiling is set regardless — this population is intrinsically low-density and N\* doesn't discriminate
+for them (a ceiling, not N\*, controls their behaviour). N\*=6000/8000 are **not usable as global
+targets** — essentially no post in the current network reaches that audience even at 30 min, so those
+values would degenerate to "always ceiling" for ~100% of posts, i.e. no different from today for nearly
+everyone. Usable N\* range for a "burst until crowd is big enough" rule, given today's network density,
+is roughly **1,000-4,000**.
+
+---
+
+## 3. Exemplar groups — dark-computed governor outcomes
+
+Sample sizes are posts-in-window (2026-06-22 to 2026-07-02) attributed to each **home** group.
+"NW-London Offers" is not an actual group name in the DB (likely informal/Discourse shorthand); the
+London boroughs bordering the Chilterns-to-East-London complaint corridor (Brent, Ealing, Harrow-area)
+are covered by the region-level and top-group tables in §3c/§3d, which validate the complaint directly.
+
+| Group | n | current audience p50 (@ 30min ceiling) | current drive_min p50 | N\*=2000 drive-time p50 | N\*=2000 never-reach % | N\*=4000 drive-time p50 | N\*=4000 never-reach % |
+|---|---|---|---|---|---|---|---|
+| Hull (21473) | 51 | 659 | 30.0 | — | **100%** | — | **100%** |
+| Oxford (21555) | 509 | 3,829 | 30.0 (p10=28.4) | 14.4 | 0.6% | 28.7 | 74.1% |
+| Ribble Valley (21589) | 15 | 1,446 | 30.0 | 27.5 | **80%** | — | **100%** |
+| Tower Hamlets (21662) | 65 | 13,336 | **17.8** | **11.3** | 0% | **17.8** | 1.5% |
+| Swindon (92103) | 52 | 672 | 30.0 | — | **100%** | — | **100%** |
+| Edinburgh (21354) | 414 | 2,144 | 30.0 | 26.5 | 23.4% | — | **100%** |
+
+**This is the direct dark-compute of the complaint.** Tower Hamlets already stops expanding at a p50
+of 17.8 minutes today (the extent-governor's existing reply-stop/dwell gate is doing *some* of this
+work already, on top of the fixed 30-min ceiling) — but its audience at that point is 13,336, ~6x
+Oxford's full-ceiling audience and ~20x Hull/Swindon's. An N\*=2000 rule would cut Tower Hamlets to
+~11.3 minutes (a further ~6.5min tightening from its already-gated 17.8) while leaving Hull, Swindon,
+and Ribble Valley completely unaffected (they never reach 2,000 people regardless — they're
+ceiling-bound, not N\*-bound).
+
+---
+
+## 3c. Full network view: who never fills at N\*=2000 (rural/dense split)
+
+Across all 354 home groups with ≥10 posts in the sample, grouped by median audience at full reach:
+
+**15 lowest-audience groups** (all 100% never-reach-N\*=2000, i.e. every single post from these areas
+would ride to whatever ceiling is chosen, at N\* up to at least 2,000):
+
+| Group | n | audience p50 |
+|---|---|---|
+| Anglesey | 16 | 50 |
+| Halesworth | 27 | 54 |
+| North Northumberland | 15 | 71 |
+| Ayr | 12 | 97 |
+| West Norfolk/March | 29 | 98 |
+| Denbighshire | 11 | 104 |
+| Perth and Kinross | 42 | 125 |
+| Barrow | 15 | 155 |
+| Penzance | 31 | 164 |
+| St Austell | 20 | 167 |
+| Hungerford | 10 | 175 |
+| Bishop's Castle | 50 | 177 |
+| Neath Port Talbot | 12 | 177 |
+| Bangor | 48 | 184 |
+| Cromer/Sheringham | 13 | 189 |
+
+**15 highest-audience groups** (all 0% never-reach; would be tightened by any N\* ≤ 4,000) — every
+single one is inner/west London:
+
+| Group | n | audience p50 |
+|---|---|---|
+| Hammersmith & Fulham | 106 | 14,792 |
+| Kensington & Chelsea | 78 | 14,204 |
+| Tower Hamlets | 65 | 13,336 |
+| Camden South | 11 | 13,038 |
+| Islington South | 35 | 12,856 |
+| Ealing | 126 | 12,811 |
+| Wandsworth | 201 | 12,639 |
+| Lambeth | 126 | 12,579 |
+| Hackney | 89 | 12,569 |
+| Westminster | 74 | 12,544 |
+| Brent | 98 | 12,544 |
+| Barnet | 108 | 12,012 |
+| Islington North | 20 | 11,601 |
+| Islington West | 35 | 11,433 |
+| Southwark | 115 | 11,380 |
+
+**124 of 354 groups (35%) with ≥10 posts have 100% of their posts never reaching N\*=2000** — these are
+uniformly rural/small-town groups (Wales, Scottish Highlands/Perthshire, Cornwall, Northumberland, East
+Anglia coast). For these, **N\* choice in the 1,000-4,000 range is irrelevant**: only the ceiling
+(currently 30 min) governs their reach, because there simply isn't enough population density within
+any plausible drive-time. A governor that only changes N\* (leaving the 30-min ceiling untouched) does
+nothing for the *low* end of the complaint spectrum (nobody there is complaining — they want more
+reach if anything, not less) — its whole effect is concentrated on the dense/urban tail, which is
+exactly the target of the Discourse complaints.
+
+## 3d. Region-level rollup (proxy for ONS rural-urban class, since that field isn't populated here)
+
+| Region | n | audience p50 (full ceiling) | N\*=2000 drive-time p50 | % never reach 2000 |
+|---|---|---|---|---|
+| London | 3,652 | 9,897 | **13.0** | **0%** |
+| Yorkshire & Humber | 1,456 | 3,181 | 17.4 | 35% |
+| South East | 5,916 | 2,528 | 19.5 | 38% |
+| East | 2,926 | 2,402 | 19.8 | 41% |
+| West Midlands | 1,942 | 1,888 | 16.7 | 52% |
+| North West | 2,936 | 1,875 | 17.9 | 52% |
+| East Midlands | 1,402 | 1,972 | 24.2 | 53% |
+| Scotland | 977 | 1,636 | 26.8 | 61% |
+| North East | 342 | 1,438 | 26.2 | 75% |
+| South West | 2,076 | 1,329 | 26.5 | 79% |
+| Wales | 523 | 242 | 29.5 | 99% |
+| Northern Ireland | 51 | 649 | N/A | 100% |
+
+London is categorically different from every other region: it's the only region where **0%** of posts
+fail to reach N\*=2000, and its median drive-time to do so (13.0 min) is barely half of the next-lowest
+region. Every other English region and all of Scotland/Wales/NI sit in a fairly compressed
+17-30 minute band for N\*=2000, with 35-100% never reaching it. This strongly supports treating "London
+vs everywhere else" (or a density-banded version of the same idea) as the dominant axis for any N\*
+scheme — a single national N\* in the 1,500-2,500 range would meaningfully tighten London specifically
+while leaving most of the rest of the country essentially at today's ceiling-bound behaviour.
+
+---
+
+## 4. Notification fan-out today (`rippling_reach_notified`)
+
+Per-post distinct-users-notified, 18,143 posts that have notified at least one rippled-in user
+(930,344 total notification rows):
+
+| Percentile | notified users/post |
+|---|---|
+| p10 | 14 |
+| p25 | 26 |
+| p50 | 44 |
+| p75 | 67 |
+| p90 | 96 |
+| p95 | 117 |
+| p99 | 207 |
+| max | 324 |
+| mean | 51 |
+
+This is much smaller than `total_freeglers` (the eligible audience within the reach polygon) because
+notification is presumably further gated (e.g. only users who haven't seen it, digest/frequency caps,
+opt-in preferences) — but it has the same shape: a long tail, with p99/p50 ≈ 4.7x. It's a useful sanity
+check that the *practical* fan-out today (tens of people notified per post, not thousands) is much
+smaller than the raw audience-in-polygon numbers in §1, though every one of those thousands is still
+theoretically able to see the post organically (browse/search), so audience-in-polygon is still the
+right basis for tuning reach.
+
+---
+
+## Bottom line
+
+**What N\* values produce what reach geography, and who never fills:**
+
+- The current rule (fixed 30-min drive-time everywhere) produces a 14-30x spread in realized audience
+  between the top and bottom deciles of home groups (602 → 8,696-17,776), which is the root of the
+  "feels too large" complaints — those come exclusively from the small number of extremely dense areas
+  (inner/west London: Hammersmith & Fulham, Kensington & Chelsea, Tower Hamlets, Islington, Ealing,
+  Wandsworth, Lambeth, Hackney, Westminster, Brent, Barnet, Camden, Southwark — 15 groups median
+  11,000-15,000 realized audience at 30 min) versus everywhere else (median audience under ~4,000 even
+  at Oxford/Edinburgh scale, and under 700 for Hull/Swindon-scale areas).
+- An audience-sized-burst rule (expand until cumulative_users ≥ N\*, existing floor/ceiling) is
+  **usable in the N\*=1,000-4,000 range** for this network; N\*≥6,000 is not usable — virtually no post
+  reaches that population within the 30-min ceiling today, so it would degenerate to "always ceiling"
+  and change nothing.
+- **N\*=2,000** dark-computes to: London posts cross it at a p50 of 13.0 min (vs today's fixed 30,
+  Tower Hamlets specifically at 11.3 min vs its already-gated 17.8 min) — a genuine, substantial
+  tightening exactly where the complaints originate — while **35% of all groups nationally (124/354
+  sampled, concentrated in Wales, Scottish Highlands/Perthshire, Cornwall, Northumberland, rural East
+  Anglia) never reach 2,000 people at all** and would be completely unaffected, continuing to ride to
+  whatever ceiling is set (their reach is ceiling-bound, not N\*-bound, at any N\* up to 4,000).
+- **N\*=4,000** is a gentler version of the same shape: still fully resolves Tower Hamlets (17.8 min,
+  matching what the existing reply-stop gate already does for it) and meaningfully trims Oxford
+  (28.7 min, only slightly under its current ~30), but 70% of all posts nationally never reach it —
+  i.e. it would act almost like "leave everyone alone except the most extreme handful of boroughs",
+  which may or may not be enough to satisfy the moderators who complained (Oxford, a mid-size university
+  city, barely moves).
+- The practical recommendation this data supports: **N\* should not be a single national constant** —
+  region/density banding (even the coarse ONS-region split in §3d, where London is categorically
+  different from all 11 other regions) captures almost all of the actionable signal. A national
+  N\*≈2,000 with London (or a density-derived equivalent) singled out for tighter treatment, OR a
+  smooth function of local density (e.g. N\* scaled by home-group's own audience-at-10-min, which is
+  cheap to compute from each post's own early ticks with zero extra instrumentation) would directly
+  target the complaint population without perturbing the 35%+ of the network that's already
+  ceiling-bound today. This reframes the "needs a product decision" N\* calibration gap: the DATA shows
+  N\* only matters (is only binding) for roughly the top 30-45% of the density distribution — pick N\*
+  in 1,000-4,000 for that stratum, and the remaining rural/small-town majority is untouched regardless
+  of the exact value chosen.

--- a/plans/2026-07-02-reach-design-evidence/5-demand.md
+++ b/plans/2026-07-02-reach-design-evidence/5-demand.md
@@ -1,0 +1,372 @@
+# 5. Demand sufficiency — how much audience is ENOUGH?
+
+**Scope:** OFFER posts on rippling_reach, live prod DB, sampled 2026-07-02. All SQL and figures below are
+reproducible with the queries shown (read-only, `mysql:8` client via the V2 tunnel).
+
+## 0. Data-quality gate (read this first — it changes the population)
+
+`rippling_reach` has **one row per msgid** (PK on `msgid`), overwritten in place as a post's reach
+expands tick-by-tick. On 2026-07-01 a **backfill job ran retrospectively** (`BackfillReachCommand` in
+`iznik-batch`) and created placeholder rows for ~26,619 OLDER posts (some going back to 2020) with
+`status='stopped', tick=0, total_freeglers=0` — these are NOT posts whose reach was intentionally
+stopped at zero audience; they are pre-rippling posts touched by the backfill and never actually
+expanded. 16,865 of them already have a `Taken`/`Received` outcome from years ago.
+
+**Every query below therefore filters:**
+```sql
+NOT (r.status='stopped' AND r.tick=0)            -- excludes backfill placeholders
+AND m.arrival >= '2026-06-23'                     -- TRUE post arrival (not rippling_reach.arrival,
+                                                   -- which is overwritten each tick and can show a
+                                                   -- 2026-07-01 backfill-run timestamp on a 2020 post)
+```
+`2026-06-23` is used (not `2026-06-14`) because daily volume of *genuinely* ripple-processed posts
+jumps from ~60-110/day to 1,100-2,300/day exactly on that date — the real network-wide go-live; the
+06-14 to 06-22 window was low-volume pilot/early-rollout traffic. This matches `enabled_at =
+'2026-06-23'` in `config/freegle.php`'s `ripple.enabled_at` flood-guard cutoff.
+
+**Resulting clean population:** 10,742 genuinely-rippled OFFER posts, arrival 2026-06-23 to
+2026-07-02, mean audience (`total_freeglers`) 3,821.
+
+Also fixed along the way: `groups` is a MySQL 8 reserved word (needs backticks); a `messages_groups`
+join can return multiple rows per msgid for rippled-in cross-posted messages, so "home group" is taken
+as `MIN(groupid)` among `collection='Approved'` rows (earliest/lowest id = the origin group in
+practice); `chat_messages.type='Interested'` lookups need the existing `refmsgid` index and must be
+pre-filtered through a temp table join (a raw CTE without materialisation was not using the index and
+timed out).
+
+## 1. Audience deciles vs replies
+
+```sql
+CREATE TEMPORARY TABLE t_base AS
+SELECT r.msgid, r.total_freeglers, m.arrival AS post_arrival
+FROM rippling_reach r JOIN messages m ON m.id = r.msgid
+WHERE m.type='Offer' AND m.arrival >= '2026-06-23'
+  AND NOT (r.status='stopped' AND r.tick=0);
+
+CREATE TEMPORARY TABLE t_decile AS
+SELECT msgid, total_freeglers, NTILE(10) OVER (ORDER BY total_freeglers) AS decile FROM t_base;
+
+CREATE TEMPORARY TABLE t_replies AS
+SELECT cm.refmsgid AS msgid, COUNT(DISTINCT cm.userid) AS repliers
+FROM chat_messages cm JOIN t_base b ON b.msgid = cm.refmsgid
+WHERE cm.type='Interested' GROUP BY cm.refmsgid;
+
+SELECT d.decile, COUNT(*) n_posts, MIN(d.total_freeglers) min_aud, MAX(d.total_freeglers) max_aud,
+  ROUND(AVG(d.total_freeglers)) avg_aud, ROUND(AVG(COALESCE(rp.repliers,0)),3) mean_repliers,
+  ROUND(100*AVG(COALESCE(rp.repliers,0)>=1),1) pct_ge1,
+  ROUND(100*AVG(COALESCE(rp.repliers,0)>=3),1) pct_ge3,
+  ROUND(100*AVG(COALESCE(rp.repliers,0)>=5),1) pct_ge5
+FROM t_decile d LEFT JOIN t_replies rp ON rp.msgid = d.msgid
+GROUP BY d.decile ORDER BY d.decile;
+```
+
+| decile | n_posts | audience range | avg audience | mean repliers | P(≥1) | P(≥3) | P(≥5) |
+|---|---|---|---|---|---|---|---|
+| 1 | 1,075 | 1–695 | 353 | 0.512 | 31.5% | 3.9% | 0.7% |
+| 2 | 1,075 | 695–1,102 | 916 | 0.563 | 33.5% | 5.7% | 0.7% |
+| 3 | 1,074 | 1,102–1,575 | 1,327 | 0.613 | 35.8% | 6.8% | 1.0% |
+| 4 | 1,074 | 1,575–1,972 | 1,788 | 0.559 | 33.2% | 5.3% | 0.9% |
+| 5 | 1,074 | 1,972–2,485 | 2,205 | 0.599 | 35.9% | 5.1% | 0.8% |
+| 6 | 1,074 | 2,487–3,348 | 2,917 | 0.554 | 33.0% | 5.4% | 0.8% |
+| 7 | 1,074 | 3,351–4,229 | 3,726 | 0.650 | 38.5% | 6.7% | 0.7% |
+| 8 | 1,074 | 4,231–6,131 | 5,136 | 0.541 | 30.8% | 6.1% | 0.7% |
+| 9 | 1,074 | 6,131–9,586 | 7,643 | 0.418 | 23.6% | 4.0% | 0.7% |
+| 10 | 1,074 | 9,586–17,656 | 12,206 | 0.404 | 22.1% | 4.7% | 1.0% |
+
+**Reading it:** mean repliers and P(≥1 reply) are essentially FLAT from decile 1 through decile 8
+(0.51–0.65 repliers, 31–39% chance of ≥1 reply) despite a **12x** audience range (353 → 5,136 avg). In
+deciles 9–10 (the very largest audiences, 7,600–12,200 avg) the reply rate is **lower**, not higher, than
+the middle deciles — the biggest-reach posts are disproportionately in saturated dense areas competing
+for the same small pool of active repliers per unit area, or arriving in bursts that dilute individual
+post visibility.
+
+**P(≥5 replies) never exceeds 1.0% in any decile.** Sanity check on the whole clean population (not
+just deciles): only **89 of 10,745** genuinely-rippled posts (0.83%) ever reach 5 distinct repliers,
+at ANY audience size up to 17,656. This directly bears on a config value already live in the codebase:
+`ripple.reply_saturation_stop = 5` (`config/freegle.php`, "5 = the figure from the Discourse rippling
+thread") is meant to stop expansion once a post has 5 repliers. **It has never fired on any real post in
+production** — confirmed by querying for `status='stopped'` rows with `total_freeglers > 0` (zero
+results; every `stopped` row is the tick=0 backfill artifact). A threshold of 5 is set far above what
+demand ever produces, so today it is a dead parameter, not a live governor.
+
+### Finer-grained bins at the low-audience end (deciles are coarse where the action is)
+
+```sql
+SELECT CASE WHEN b.total_freeglers < 250 THEN '0-250' WHEN ... END AS aud_bucket,
+  COUNT(*), ROUND(AVG(total_freeglers)), ROUND(AVG(COALESCE(rp.repliers,0)),3), ...
+FROM t_base b LEFT JOIN t_replies rp ON rp.msgid=b.msgid GROUP BY aud_bucket;
+```
+
+| audience bucket | n_posts | avg audience | mean repliers | P(≥1) | P(≥2) | P(≥3) |
+|---|---|---|---|---|---|---|
+| 0–250 | 355 | 131 | 0.431 | 27.0% | 10.4% | 3.1% |
+| 250–500 | 447 | 379 | 0.494 | 31.8% | 11.4% | 2.9% |
+| 500–1,000 | 1,001 | 780 | 0.581 | 34.2% | 14.3% | 6.1% |
+| 1,000–1,500 | 1,312 | 1,237 | 0.602 | 35.2% | 14.6% | 6.4% |
+| 1,500–2,000 | 1,265 | 1,778 | 0.557 | 33.1% | 11.9% | 5.4% |
+| 2,000–3,000 | 1,638 | 2,423 | 0.585 | 35.2% | 14.3% | 5.1% |
+| 3,000–4,000 | 1,332 | 3,505 | 0.608 | 35.5% | 13.9% | 6.5% |
+| 4,000–6,000 | 1,176 | 4,927 | 0.565 | 32.7% | 12.8% | 6.2% |
+| 6,000–9,000 | 986 | 7,272 | 0.453 | 26.2% | 10.3% | 4.4% |
+| 9,000–13,000 | 858 | 10,710 | 0.347 | 18.6% | 7.2% | 3.6% |
+| 13,000+ | 375 | 14,372 | 0.499 | 27.2% | 12.8% | 6.1% |
+
+**Where the curve flattens:** it is already essentially flat from the very smallest observed bucket.
+Even a **131-member audience** returns 27% P(≥1 reply) and 0.43 mean repliers — not dramatically below
+a 12,000-member audience (22-27% P(≥1), 0.40-0.50 mean repliers). The demand curve doesn't have a
+clean knee at some large N — it rises gently from ~0 to ~1,000-1,500 members, plateaus 1,000-6,000,
+and mildly DECLINES 6,000-13,000 before a noisy uptick in the top bucket (small n=375, likely dominated
+by a few very dense/London posts with unusually high engagement — treat with caution). There is no
+audience size in this data at which adding more members reliably buys more replies.
+
+## 2. Outcome (Taken) vs audience decile — posts ≥14 days old
+
+Caveat up front: because real (post-06-23) volume only exceeds 1,000/day from 06-23, and "today" in
+the live DB is 2026-07-02, there are almost no genuinely-rippled posts yet 14 days old. Relaxing to
+`arrival >= 2026-06-14` (the earlier, low-volume pilot window) gives a usable but SMALL sample.
+
+```sql
+CREATE TEMPORARY TABLE t_base14 AS
+SELECT r.msgid, r.total_freeglers
+FROM rippling_reach r JOIN messages m ON m.id = r.msgid
+WHERE m.type='Offer' AND m.arrival >= '2026-06-14'
+  AND m.arrival <= DATE_SUB(NOW(), INTERVAL 14 DAY)
+  AND NOT (r.status='stopped' AND r.tick=0);
+-- ... NTILE(10), LEFT JOIN messages_outcomes (MAX(outcome='Taken'))
+```
+
+Population: **429 posts**, arrival 2026-06-14 to 2026-06-18 only.
+
+| decile | n_posts | avg audience | posts w/ any outcome row | % Taken (of ALL posts in decile) |
+|---|---|---|---|---|
+| 1 | 43 | 297 | 6 | 14.0% |
+| 2 | 43 | 774 | 13 | 30.2% |
+| 3 | 43 | 1,124 | 8 | 18.6% |
+| 4 | 43 | 1,419 | 8 | 18.6% |
+| 5 | 43 | 1,812 | 7 | 16.3% |
+| 6 | 43 | 2,582 | 10 | 23.3% |
+| 7 | 43 | 3,414 | 5 | 11.6% |
+| 8 | 43 | 3,922 | 7 | 16.3% |
+| 9 | 43 | 6,150 | 6 | 14.0% |
+| 10 | 42 | 11,693 | 8 | 19.0% |
+
+No monotonic trend, no visible relationship between audience size and Taken rate — consistent with the
+reply-rate finding above (if replies don't increase with audience, downstream Taken outcomes shouldn't
+either). **However this table is underpowered** (n=42-43/decile, ~15-30% report any outcome at all —
+most posters never mark an outcome) and should not be treated as more than directionally consistent
+with §1. It does NOT contradict §1; it simply can't independently confirm it yet. Re-run this query
+after ~2026-07-15 once real 06-23+ volume clears the 14-day mark (n will be ~10,000+, one to two orders
+of magnitude more powered).
+
+## 3. Speed: time to first Interested reply, by audience decile
+
+```sql
+CREATE TEMPORARY TABLE t_ttr AS
+SELECT d.decile, d.msgid, TIMESTAMPDIFF(MINUTE, d.post_arrival, fr.first_reply) AS mins_to_reply, ...
+FROM t_decile d JOIN t_replies fr ON fr.msgid = d.msgid
+WHERE TIMESTAMPDIFF(MINUTE, d.post_arrival, fr.first_reply) >= 0;   -- excludes backfill-artifact negatives
+```
+(0 rows excluded as negative once the `m.arrival >= 2026-06-23` filter above is applied — the negative
+timestamps only appeared when `rippling_reach.arrival`, which can be a stale/overwritten tick
+timestamp, was used instead of `messages.arrival`.)
+
+| decile | n with reply | mean mins to 1st reply | median mins to 1st reply |
+|---|---|---|---|
+| 1 | 339 | 1,094 | 513 |
+| 2 | 360 | 963 | 404 |
+| 3 | 384 | 836 | 347 |
+| 4 | 357 | 987 | 372 |
+| 5 | 386 | 926 | 286 |
+| 6 | 354 | 963 | 259 |
+| 7 | 414 | 818 | 175 |
+| 8 | 331 | 832 | 262 |
+| 9 | 253 | 840 | 141 |
+| 10 | 237 | 789 | **174** |
+
+**This is the one metric that DOES move cleanly with audience size.** Median time-to-first-reply drops
+from **513 minutes (decile 1, ~350 avg audience) to 141-174 minutes (deciles 9-10, ~7,600-12,200 avg
+audience)** — roughly a 3x speedup. Combined with §1 (eventual reply COUNT is flat), the conclusion is:
+
+**Bigger audience mainly buys SPEED, not eventual success.** A post that would eventually get ~0.5-0.6
+replies gets that first reply faster with a bigger audience, but does not get MORE total replies. This
+matters for the design: if speed-to-first-reply is the actual value being purchased by extra reach
+(quicker collection, less time an item sits around), the stopping rule should be framed around "how much
+speed is worth the marginal notification cost" rather than "how many more replies". Diminishing returns
+on speed likely also flatten well before 30 min — the curve above still shows *some* speed gain out to
+decile 10, but the deceleration is visible (decile 1→3: 513→347 mins, -166; decile 8→10: 262→174, -88 —
+roughly half the per-decile speed gain in the tail vs the head).
+
+## 4. Where replies come from: home group vs beyond
+
+```sql
+CREATE TEMPORARY TABLE t_home AS
+SELECT mg.msgid, MIN(mg.groupid) AS home_groupid FROM messages_groups mg
+JOIN t_base b ON b.msgid = mg.msgid WHERE mg.collection='Approved' GROUP BY mg.msgid;
+
+-- distinct (msgid,userid) Interested repliers, joined to memberships on the home group
+SELECT COUNT(*) total_distinct, SUM(is_home_member) home_distinct,
+  ROUND(100*SUM(is_home_member)/COUNT(*),1) pct_home
+FROM (SELECT DISTINCT msgid, userid, is_home_member FROM t_reply_home) x;
+```
+
+**82.5%** of distinct Interested repliers (4,794 / 5,813) are members of the post's home group; the
+remaining **17.5%** are reached only via rippling (rippled-in, non-home-group members). This is a
+**meaningful drop from the ~98% figure in the prior (pre-2026-06-22) measurement** — worth flagging
+explicitly since the task brief asked whether it has moved:
+
+- Rippling has now been live at full volume for ~9 days at time of sampling (vs. essentially day-zero /
+  low-volume-pilot when ~98% was measured), so more genuinely-rippled-in replies have had time to
+  accumulate.
+- 17.5% "beyond home group" is a much larger fraction of value overall than the earlier reading
+  suggested — it says rippling IS finding real incremental demand beyond the home group, just that
+  (per §1) that incremental demand doesn't keep growing once the reach is already a few hundred to a
+  few thousand members.
+
+**By audience decile** (does the home/beyond mix shift with reach size?):
+
+| decile | total reply rows | home-group reply rows | % home |
+|---|---|---|---|
+| 1 | 578 | 504 | 87.2% |
+| 2 | 636 | 528 | 83.0% |
+| 3 | 685 | 558 | 81.5% |
+| 4 | 628 | 535 | 85.2% |
+| 5 | 676 | 584 | 86.4% |
+| 6 | 624 | 481 | 77.1% |
+| 7 | 733 | 604 | 82.4% |
+| 8 | 631 | 527 | 83.5% |
+| 9 | 472 | 380 | 80.5% |
+| 10 | 462 | 353 | 76.4% |
+
+Mild downward drift (87% → 76%) from smallest to largest audience deciles — larger reach does pull in a
+slightly higher proportion of non-home-group repliers, as expected, but the effect is small (11
+percentage points across a 35x audience range) and the ABSOLUTE count of beyond-home-group replies
+barely changes (74 in decile 1 vs 109 in decile 10) because total replies per post are themselves flat
+or falling in the big-audience deciles (§1).
+
+## 5. Overshoot cost: notifications per incremental distinct replier
+
+```sql
+CREATE TEMPORARY TABLE t_notified AS
+SELECT rn.msgid, COUNT(*) n_notified FROM rippling_reach_notified rn
+JOIN t_base b ON b.msgid = rn.msgid GROUP BY rn.msgid;
+-- decile-level: SUM(notified)/SUM(repliers) per decile
+```
+
+| decile | n_posts | avg audience | avg notified/post | avg repliers/post | notified per replier (decile total) |
+|---|---|---|---|---|---|
+| 1 | 1,075 | 353 | 19 | 0.512 | **36.3** |
+| 2 | 1,075 | 916 | 21 | 0.563 | 37.3 |
+| 3 | 1,074 | 1,327 | 37 | 0.613 | 60.4 |
+| 4 | 1,074 | 1,788 | 30 | 0.559 | 53.2 |
+| 5 | 1,074 | 2,205 | 32 | 0.599 | 54.2 |
+| 6 | 1,074 | 2,917 | 39 | 0.554 | 70.3 |
+| 7 | 1,074 | 3,726 | 44 | 0.650 | 67.7 |
+| 8 | 1,074 | 5,136 | 46 | 0.541 | 85.9 |
+| 9 | 1,074 | 7,643 | 46 | 0.418 | 109.1 |
+| 10 | 1,074 | 12,206 | 45 | 0.404 | **112.3** |
+
+**The marginal cost curve rises monotonically and roughly TRIPLES** from decile 1 (36 notifications
+sent per distinct replier obtained) to decile 10 (112 notifications per replier). Note `avg_notified`
+per post plateaus around 40-46 from decile 3 onward (`rippling_reach_notified` tracks direct-mail/push
+notification sends, which are themselves capped/throttled independent of raw polygon audience size —
+so this is not literally "everyone in total_freeglers gets notified", it's the subset actually mailed).
+Even on that already-throttled notification count, the cost-per-outcome still climbs sharply because the
+denominator (repliers) FALLS in the large-audience deciles while the notification count stays flat or
+rises slightly. This is the clearest single number for "how much is enough": **every notification sent
+beyond roughly decile 2-3 (audience ≈ 1,000-1,500) buys measurably less marginal reply than the
+notifications already sent**.
+
+## 6. Within-density-class comparison (controls for the exposure confound)
+
+The brief's caveat — audience size correlates with density which correlates with everything — is real,
+so deciles above could in principle just be re-discovering "dense areas behave differently" rather than
+"audience size itself doesn't matter". To check, posts were bucketed into **terciles of home-group
+active-member count** (memberships with `lastaccess` in the last 90 days, `collection='Approved'`),
+then WITHIN each density tercile, split into quintiles by the post's own `total_freeglers` audience:
+
+```sql
+CREATE TEMPORARY TABLE t_group_active AS
+SELECT mem.groupid, COUNT(DISTINCT mem.userid) active_members FROM memberships mem
+JOIN users u ON u.id = mem.userid
+WHERE mem.collection='Approved' AND u.lastaccess >= DATE_SUB(NOW(), INTERVAL 90 DAY) AND u.deleted IS NULL
+GROUP BY mem.groupid;
+-- NTILE(3) on active_members -> density_tercile; NTILE(5) PARTITION BY density_tercile ON total_freeglers -> sub_quintile
+```
+
+| density tercile (home-group active members) | audience sub-quintile | n_posts | avg audience | mean repliers | P(≥1) |
+|---|---|---|---|---|---|
+| 1 (34–1,000 active) | 1 | 717 | 265 | 0.481 | 31.2% |
+| 1 | 2 | 716 | 770 | 0.527 | 31.8% |
+| 1 | 3 | 716 | 1,224 | 0.543 | 29.3% |
+| 1 | 4 | 716 | 1,882 | 0.489 | 28.9% |
+| 1 | 5 | 716 | 3,444 | 0.503 | 31.0% |
+| 2 (1,000–1,726 active) | 1 | 717 | 1,021 | 0.696 | **41.3%** |
+| 2 | 2 | 716 | 1,815 | 0.574 | 34.5% |
+| 2 | 3 | 716 | 2,801 | 0.527 | 33.5% |
+| 2 | 4 | 716 | 4,069 | 0.704 | 37.6% |
+| 2 | 5 | 716 | 7,715 | 0.415 | **24.7%** |
+| 3 (1,726–3,469 active, densest) | 1 | 716 | 1,731 | 0.676 | **38.8%** |
+| 3 | 2 | 716 | 3,345 | 0.564 | 35.8% |
+| 3 | 3 | 716 | 5,572 | 0.585 | 31.6% |
+| 3 | 4 | 716 | 8,588 | 0.436 | 25.1% |
+| 3 | 5 | 716 | 13,082 | 0.401 | **21.8%** |
+
+**This is the strongest single result in the dataset.** WITHIN every density tercile, the SMALLEST
+audience sub-quintile of that tercile does at least as well (density tercile 1, roughly flat) or
+noticeably BETTER (density terciles 2 and 3: sub-quintile 1 has the HIGHEST P(≥1) of all 5, and
+sub-quintile 5 — the largest audience for that density class — has the LOWEST) than the largest audience
+sub-quintile. The exposure confound is not driving the flat/declining curve in §1 — it survives
+controlling for density. If anything, within dense areas (tercile 3), pushing audience from ~1,700 to
+~13,000 members actively HALVES the reply probability (38.8% → 21.8%), which is exactly the London
+over-ripple complaint pattern from Discourse #9808/250, now visible directly in the reply data, not just
+member-count spread.
+
+## Bottom line
+
+**"The audience beyond which marginal replies ≈ zero, by density class":**
+
+| density class (home-group active members) | audience where reply-rate ADDS anything | audience where it visibly HURTS |
+|---|---|---|
+| Sparse (< ~1,000 active) | flat throughout observed range (~250–3,400); no clear ceiling reached, small samples get roughly the same P(≥1) as large ones | not observed in this data (ceiling ~3,400, driven by drive-time not sparse density) |
+| Medium (~1,000–1,700 active) | best P(≥1) at ~1,000 audience (41%); no gain by 1,800–2,800 | clearly worse by ~7,700 audience (25%, down from 41%) |
+| Dense (> ~1,700 active, e.g. London) | best P(≥1) at ~1,700 audience (39%); no gain by 3,300–5,600 | clearly worse by 8,600+ (25%) and worst at 13,000+ (22%) |
+
+**A single principled number, if the parameter must be one N\*:** somewhere in the **~1,000–2,000
+member** range captures essentially all of the achievable reply probability for every density class
+observed; by ~5,000-6,000 the curve has already started falling in medium/dense areas, and by
+~9,000-13,000+ it is clearly worse than sending fewer notifications would have been. This is
+consistent with — and now empirically calibrates — the previously-uncalibrated `extent.target_users`
+default of 4,000 in `config/freegle.php` (`RIPPLE_EXTENT_TARGET_USERS`, currently `enabled=false`,
+dark): 4,000 sits past the point where reply probability peaks (which is nearer 1,000-1,700) but before
+the point where it visibly degrades (~6,000+), so it is a reasonably conservative single global
+starting value, though the density-stratified table above suggests urban/dense classes could bind
+noticeably tighter (~1,500-2,000) without losing measurable reply probability, which is exactly the
+`target_by_ru` per-RU-class stratification the MVP plan already earmarks as the next step.
+
+The one place a bigger audience clearly still pays for itself is **speed** (§3: 3x faster first reply
+from smallest to largest decile), so a stopping rule keyed purely to "P(reply) has flattened" would
+sacrifice that speed benefit; a design that stops audience growth once expected marginal reply
+probability drops below some threshold, but explicitly also considers or logs the speed benefit
+foregone, would be more defensible than optimising on reply-count alone.
+
+## Caveats carried through
+
+- **Exposure confound**: addressed directly in §6 (within-density stratification); the flat/declining
+  curve survives controlling for density, so it is not simply "big audience = dense area = different
+  behaviour for unrelated reasons".
+- **Outcome data (§2) is underpowered** (n=429, mostly <1 day since 14-day-old real-rippling volume
+  became available) — re-run after 2026-07-15+ for a properly powered check.
+- **`reply_saturation_stop=5` has never fired in prod** — either disabled or set far above what real
+  demand produces (only 0.83% of posts ever reach 5 repliers at any audience size). If this parameter
+  is intended as a working governor, 5 is not currently doing anything; a threshold nearer 2-3 would
+  bind on a non-trivial share of posts (§1: P(≥3) is 4-8% across deciles vs P(≥5) at ~1%).
+- **Notification counts in `rippling_reach_notified` are already throttled** independent of raw
+  polygon/`total_freeglers` size (avg notified plateaus ~40-46/post from decile 3 up even as audience
+  keeps growing 10x) — so §5's cost curve is a lower bound on true overshoot waste; the WASTED reach
+  (members who were IN the polygon and eligible but never actually mailed) is larger still and not
+  visible in this table.
+- **Backfill contamination (§0)** was significant (56% of all rippling_reach rows) and, if not filtered,
+  would have produced nonsensical results (negative "time to reply", diluted deciles, wrong "N* already
+  low" conclusion driven by zero-audience placeholders). Any future query against `rippling_reach` MUST
+  apply the same two filters or re-derive an equivalent freshness check, since the backfill job is not a
+  one-off — check whether `BackfillReachCommand` runs again before reusing these numbers unfiltered.

--- a/plans/2026-07-02-reach-design-evidence/6-external-anchors.md
+++ b/plans/2026-07-02-reach-design-evidence/6-external-anchors.md
@@ -1,0 +1,321 @@
+# External anchors: what counts as a "reasonable" travel time/distance to collect a free item
+
+Design-only input to the rippling reach parameter question. This note asks: independent of Freegle's own
+data, what do (a) the UK's official travel-behaviour statistics, (b) comparable sharing/marketplace
+platforms, and (c) retail-geography / urban-planning literature treat as a normal, acceptable travel
+budget for a **discretionary, non-essential, low-value** trip like collecting a free secondhand item?
+
+Method: web search + fetch, cross-checked against primary sources where possible. DfT National Travel
+Survey figures below were pulled directly from the official ODS data tables (NTS0403e/f, NTS9912b,
+NTS9914b — "Average trip length/duration by trip purpose, region and rural-urban classification of
+residence: England"), not from secondary summaries. Everything else is attributed inline; anything I
+could not verify from a primary or clearly-authoritative secondary source is flagged as unverified.
+
+---
+
+## 1. UK DfT National Travel Survey (NTS) — the closest official proxy
+
+There is no NTS purpose category for "collecting a free item" or "freecycling." The two closest official
+purposes are **Shopping** and **Personal business** (errands: banking, post office, medical, etc. — closer
+in character to a discretionary short errand than "shopping" is). Figures are for **England**, weighted,
+from the DfT's official NTS data tables (dataset last updated 27 Aug 2025, series runs 2002–2024).
+
+### 1a. National averages, all areas (NTS0403e trip length in miles, NTS0403f trip duration in minutes)
+
+| Year | Purpose | Avg. trip length (miles) | Avg. trip duration (minutes) |
+|---|---|---|---|
+| 2023 | Shopping | 3.7 | 17 |
+| 2023 | Personal business | 5.1 | 19 |
+| 2024 | Shopping | 3.7 | 17 |
+| 2024 | Personal business | 5.0 | 20 |
+| 2023 | All purposes (avg.) | 6.5 | 23 |
+| 2024 | All purposes (avg.) | 6.6 | 24 |
+
+Trip duration is *total journey time including waiting* (DfT note 2), not just drive time, so these are a
+conservative (i.e. slightly generous) proxy for a pure drive-time budget. Shopping trip duration has been
+remarkably stable: 16–19 minutes every year 2002–2024, regardless of big swings in distance and mode share.
+That stability across two decades is itself informative — it suggests **people have a roughly fixed time
+budget for shopping-type trips (~17 min), and distance/speed adjust to fit that budget**, not the reverse.
+This is consistent with the well-known "travel time budget" literature in transport economics (Marchetti's
+constant, ~consistent ~1hr/day, ~20-30 min one-way commute budget across cultures and eras) though I have
+not independently verified Marchetti's constant here — flagging as background colour, not a load-bearing
+figure.
+
+### 1b. Rural/urban split (NTS9912b length, NTS9914b duration) — 2023, old classification
+
+The old 4-way rural-urban classification of residence (used through 2023) gives directly what's needed:
+urban-vs-rural asymmetry for the same purposes.
+
+| Area type (2023) | Shopping: length (mi) / duration (min) | Personal business: length (mi) / duration (min) |
+|---|---|---|
+| Urban Conurbation | 2.9 / 17 | 4.0 / 21 |
+| Urban City and Town | 3.5 / 16 | 5.2 / 19 |
+| Rural Town and Fringe | 5.8 / 18 | 5.8 / 18 |
+| Rural Village, Hamlet and Isolated Dwelling | 6.4 / 18 | 7.8 / 21 |
+| **All areas** | **3.7 / 17** | **5.1 / 19** |
+
+Key pattern: **duration barely moves (16-18 min shopping across all four settlement types) while distance
+more than doubles (2.9 mi urban conurbation → 6.4 mi rural village)**. i.e. rural people travel roughly
+2.2x the distance in roughly the same time, because rural average speeds are higher (fewer junctions/lights,
+more A-road driving vs urban stop-start). This is the single most load-bearing external fact for Freegle's
+problem: **it is time budgets, not distance budgets, that stay constant across urban/rural — which is
+exactly what a drive-time-based reach (rather than a fixed-radius reach) already gets right.** The thing
+that's wrong isn't the choice of drive-time as the unit; it's that Freegle holds the time constant instead
+of holding something else (audience size) constant, and time and audience diverge by ~80x urban/rural (per
+prior Freegle measurement, see main design doc).
+
+### 1c. 2024 classification change — a useful reframing
+
+From 2024 the ONS/DfT rural-urban classification changed to a 6-way split based on settlement type AND
+proximity to a major town/city ("Urban: nearer", "Urban: further", "Larger Rural: nearer/further",
+"Smaller Rural: nearer/further"). 2024 shopping figures:
+
+| Area type (2024, new classification) | Shopping: length (mi) / duration (min) |
+|---|---|
+| Urban, nearer to a major town/city | 3.2 / 16 |
+| Urban, further from a major town/city | 3.7 / 16 |
+| Larger Rural, nearer to a major town/city | 5.2 / 17 |
+| Larger Rural, further from a major town/city | 6.1 / 17 |
+| Smaller Rural, nearer to a major town/city | 6.3 / 17 |
+| Smaller Rural, further from a major town/city | 8.1 / 20 |
+| **All areas** | **3.7 / 17** |
+
+Same pattern holds even more granularly — duration is flat at 16-20 minutes across all six settlement
+bands; distance ranges 3.2 to 8.1 miles (2.5x spread). This strengthens the case: DfT's own more granular
+"how rural/remote are you" classification still finds travel *time* for shopping essentially constant, so
+using minutes as Freegle's reach unit is externally well supported — the question is what number of
+minutes, and the "hold the time constant" logic is exactly what generates the 80x audience spread problem
+that started this whole design effort.
+
+### 1d. Sanity check against Freegle's own reach ceiling
+
+Freegle's current max reach is ~30 min drive (with a discussed 45 min ceiling for an extent-governor MVP).
+NTS shopping-trip duration nationally is 16-20 minutes **one-way, all-purpose, all-mode** (car and non-car
+blended; car-only would likely be a few minutes higher due to faster average speeds pulling harder on the
+mean, but DfT doesn't publish shopping-only car-only duration in the tables pulled here — flagging as a
+gap, not fabricating a number). Freegle's 30-45 min drive-time ceiling is therefore roughly **1.5-2.5x the
+national average one-way shopping trip time**, even before accounting for the fact that collecting a free
+item is a lower-stakes, more discretionary trip than "shopping" as a category (which includes routine
+grocery runs people make out of necessity). This is directionally consistent with the moderator complaints
+that reach "feels too large," at least for the outer part of the reach envelope — though it doesn't by
+itself tell you the right number, since NTS is an average across ALL shopping (including the weekly big
+supermarket shop that people plan to spend real time on), not specifically the marginal, optional "would I
+go get this free thing" decision, which is likely to sit below the shopping-trip average, not above it.
+
+### Sources
+- [NTS0403: Average number of trips, miles and time spent travelling by trip purpose: England, 2002 onwards](https://www.gov.uk/government/statistical-data-sets/nts04-purpose-of-trips) — sheets NTS0403e (trip length) and NTS0403f (trip duration), .ods downloaded and parsed directly, last updated 27 Aug 2025.
+- [NTS9912: Average trip length by trip purpose, region and rural-urban classification of residence](https://www.gov.uk/government/statistical-data-sets/ad-hoc-national-travel-survey-analysis) — sheet NTS9912b, same vintage.
+- [NTS9914: Average trip duration by trip purpose, region and rural-urban classification of residence](https://www.gov.uk/government/statistical-data-sets/ad-hoc-national-travel-survey-analysis) — sheet NTS9914b, same vintage.
+- [NTS 2023: Trips by purpose, age, mode and sex](https://www.gov.uk/government/statistics/national-travel-survey-2023/nts-2023-trips-by-purpose-age-mode-and-sex) — corroborates 169 shopping trips/person/yr, 622 miles/person/yr in 2023.
+- [National Travel Survey 2023 factsheet (PDF)](https://assets.publishing.service.gov.uk/media/66c5c0b6cbe60889bddd278d/nts-2023-factsheet.pdf)
+
+---
+
+## 2. How comparable platforms bound visibility
+
+| Platform | Unit used to bound reach | Value / mechanism | Rationale given (if any) |
+|---|---|---|---|
+| **Olio** | Distance (user-chosen radius) + a hard time cap for food safety | User-settable 0.3-16 miles for browsing; but for **Food Waste Hero collections specifically**, Olio's own guidance is "ideally within 2 km" and a hard ceiling of "never more than 1.5 hours" travel with the food | Two different rationales for two different bounds: the *ideal* 2 km is explicitly about **fostering local community connections** (a social/behavioural goal, not a technical one); the *hard* 1.5h ceiling is **food safety**, not community design. Notably Olio explicitly says it will let advertised distance extend beyond 2 km in rural areas or where volunteers are scarce — i.e. Olio already does something like an audience/availability-based fallback, not a fixed radius everywhere. |
+| **Nextdoor** | Administrative/social unit ("neighbourhood"), not distance or time | Boundaries generated to enclose a target **number of households**, snapped to real/perceived boundaries (roads, rivers, school catchments, existing neighbourhood edges) rather than a radius; minimum 10 households to found a neighbourhood page | Patent filings describe explicit design goal: bound by household count first, then adjust the resulting polygon to avoid crossing "major boundaries" and to keep the group socially homogeneous (shared schools, similar house prices) — i.e. **audience size is the primary bounded unit, geography is secondary and adjusted to fit it**. This is structurally the same idea as Freegle's already-drafted extent-governor (expand until N* reached), just for a different content type. |
+| **Buy Nothing Project** | Audience size (population), explicitly, with a defined split trigger | Target population **10,000-35,000 residents** per group footprint (lower end for high-engagement/high-internet-access communities, higher end for lower-engagement ones); groups are told to "sprout" (split) once they hit **~800-1,000 members** engaged, or population coverage gets too large | Explicit, named, and number-anchored rationale for population-based (not distance-based) bounding: too large → community feel and visibility of individual posts collapses; too small → not enough activity. This is the single clearest existing precedent for "bound by audience size, not distance," and it's exactly the audience-sized/extent-governor logic already drafted for Freegle. **Caveat (important, and directly relevant to the "no per-group slider" decision)**: BNP's *original* method of snapping group boundaries to existing informal/administrative neighbourhood lines reproduced historic redlining patterns and drew public criticism (Vice/other coverage, and an internal "equity overhaul" in 2020); BNP responded by changing its *boundary-drawing guidance* to explicitly avoid reproducing segregation lines, while keeping the population-count target. Lesson for Freegle: an audience-size target is sound, but the geographic *shape* used to reach that audience needs a rule that isn't a manual/local decision (which is exactly why the product owner rejected a per-group slider) — it should be a symmetric, algorithmic expansion (e.g. drive-time isochrone, which Freegle already uses) rather than a hand-drawn or locally-negotiated boundary. |
+| **Freecycle** | Administrative unit (town) + a distance/population viability rule for *starting* a group, not for member-level reach | Coverage area described internally as "a circle with radius 10-20 miles depending on population density/transport"; but the *rule for whether a new town group is allowed to exist* is explicitly audience-based: "at least 20,000 people within a 30-minute [drive] radius of your proposed town" | This is a hybrid: distance is the descriptive shape, but the actual **decision rule for whether a boundary is viable is audience-size-within-a-drive-time**, i.e. almost exactly Freegle's own extent-governor formula (expand a drive-time isochrone until it contains N* people) — except Freecycle applies it once, at group-founding time, not dynamically per post. |
+| **Gumtree** | Distance (user/search-chosen radius, km) | No official published default found; user sets a km radius per search | No stated rationale found; distance is just a search filter, not a moderation/visibility control — not really comparable to Freegle's problem (Freegle bounds who *sees a post exists*, Gumtree bounds a live search over an unbounded index). |
+| **Facebook Marketplace** | Distance, but a "soft" radius | Reports of default radius varying (as low as 1 mi/km, commonly cited 25-50 mi); confirmed by multiple sources that the radius filter is soft — listings from well outside the chosen radius still surface | Not a considered design choice as far as could be found — more a side-effect of a recommendation-ranking system that treats distance as one signal among many, not a hard boundary. Weak comparator for Freegle's use case (which needs a genuine hard/near-hard cutoff for moderator sanity and email-blast volume control). |
+| **Trash Nothing / OfferUp** | Distance (user-settable radius) | User-configurable distance filter in settings; no published default or rationale found | Not useful as an anchor beyond confirming "distance slider" is the generic default UX pattern most platforms fall back to — which is precisely the pattern Freegle's product owner already rejected for groups (for good reason: users/mods would set it arbitrarily, same failure mode BNP explicitly built its 10-35k *fixed target with algorithmic derivation* to avoid). |
+
+### Bottom-line pattern across platforms
+Two clusters emerge:
+1. **Search-style marketplaces** (Gumtree, FB Marketplace, OfferUp, Trash Nothing) bound by **user-chosen
+   distance**, because they are pull/search systems — the user decides how far they're willing to look, and
+   a "wrong" radius just costs the user a wasted search, not anyone else anything. This is not a good
+   precedent for Freegle, which is a push/broadcast system (the platform decides who gets emailed/notified
+   about a post), where an over-wide radius costs *other people's* attention, not just the searcher's.
+2. **Community/group-style platforms with a genuine push/membership component** (Nextdoor, Buy Nothing,
+   Freecycle-at-founding-time) bound by **audience size** (households/residents/members), using distance or
+   drive-time only as the *mechanism* to reach that audience target, not as the target itself. Freegle's
+   own draft extent-governor MVP already follows this second, better-precedented pattern; the open gap is
+   only the *calibration* of N* (the audience-size parameter), which none of these platforms publish a
+   transferable numeric rationale for — BNP's 10k-35k is a *community cohesion* number for a slow-moving,
+   low-frequency friendship-and-gifting community, not a *transaction-clearing* number for a
+   high-frequency, one-off item exchange, so it should not be imported directly as Freegle's N*.
+
+### Sources
+- [Olio: How far can I travel for Food Waste Hero collections?](https://help.olioapp.com/article/649-traveling-distance)
+- [Olio (app) — Grokipedia summary](https://grokipedia.com/page/Olio_(app)) (secondary, cross-checked against Olio's own help centre above)
+- [Nextdoor neighborhood social network method, apparatus, and system (US patent)](https://image-ppubs.uspto.gov/dirsearch-public/print/downloadPdf/8863245)
+- [Nextdoor: Add or modify your agency's jurisdictional boundary](https://help.nextdoor.com/s/article/How-to-modify-your-service-area?language=en_US)
+- [Buy Nothing Project: Determining Group Footprints](http://buynothingproject.org/determine-group-footprint)
+- [Buy Nothing Project: Various Sprout Posts](http://buynothingproject.org/various-sprout-posts)
+- [Are Buy Nothing Groups Really Free? — Next City](https://nextcity.org/urbanist-news/are-buy-nothing-groups-really-free) (redlining/equity-overhaul context)
+- [Buy Nothing Project — Wikipedia](https://en.wikipedia.org/wiki/Buy_Nothing_Project)
+- [Freecycle: Point-Centered Town Groups](https://www.freecycle.org/pages/Teams/Point-Centered_Groups)
+- [Freecycle: Start a New Town](https://www.freecycle.org/pages/StartATown)
+- [Facebook: Sort by distance or new listings on Marketplace](https://www.facebook.com/help/fblite/248514105820200)
+- [Understanding Facebook Marketplace's Distance Dilemma](https://www.oreateai.com/blog/understanding-facebook-marketplaces-distance-dilemma/c60552e73b900f7a1088fd9fc39597d5)
+- [Gumtree search settings](https://www.gumtree.com/uk/srpsearch+settings)
+
+---
+
+## 3. Distance-decay literature: gravity/Huff models, 15/20-minute norms, willingness-to-travel
+
+### 3a. Gravity/Huff retail models — decay exponent by good type
+The Huff model's distance-decay exponent (λ in P ∝ Attractiveness / Distance^λ) is **empirically
+data-fitted per study/city**, not a fixed universal constant — commonly reported in the **1.5-2.0** range
+overall, but with a clear and consistently-replicated qualitative pattern: **convenience goods (groceries,
+everyday small purchases) have a *larger* exponent (steeper decay, i.e. people are much less willing to
+travel far) than comparison goods (furniture, big one-off purchases), which have a *smaller* exponent
+(shallower decay, willing to travel further)**. This is the standard retail-geography finding and is
+repeated across multiple independent secondary sources (GIS Geography's Huff-model explainer, ArcGIS Pro's
+own Huff-model documentation, and academic Huff-calibration papers), though I was not able to pin an
+exact, single, citable numeric pair (e.g. "grocery = 2.2, furniture = 0.9") to one primary study in the
+time available — flagging the *qualitative* direction as well-supported, the *specific numbers* as
+unverified/likely-varies-by-study.
+
+**Relevance to Freegle**: a free secondhand item sits ambiguously between the two categories. It has
+convenience-good economics (zero price, no real reason to travel far — nobody "needs" this specific free
+lamp) but comparison-good psychology for anything with perceived resale/desirability value (a good sofa,
+a bike). The gravity-model literature would predict **most free-item collection trips should look more
+like convenience-good trips (short decay, most collectors very close) with a long thin tail for unusually
+desirable items** — which is consistent with Freegle's own measured facts (0.9-1.0 distinct repliers/post,
+56-66% zero-reply, and the "dense collector is typically the ~1,719th nearest active member" pattern
+described in the design brief, i.e. even where lots of people COULD reply, in practice almost nobody comes
+from far away for a typical item).
+
+### 3b. 20-minute neighbourhood / 15-minute city — the wrong mode, right ballpark number
+- **15-minute city** (Carlos Moreno, popularised via Paris 2020-21): daily essentials reachable within
+  **15 minutes by foot or bicycle** — explicitly **not** a car-based or driving standard.
+- **20-minute neighbourhood** (Melbourne/Portland planning policy, adopted from ~2014): "living locally"
+  within a **20-minute walk, cycle, or local public transport trip**; Victorian state government
+  operationalised it as an 800m radius for a round trip on foot. Also explicitly **not** a driving
+  standard — "the concept is not about travel by car."
+
+**Important caveat for Freegle**: both of these are **active-travel/public-transport, not-driving**
+policy norms aimed at reducing car dependency, and they bound a *resident's* walk to fixed *amenities*
+(shops, GP, park), not a *platform's* broadcast radius for a one-off transaction. They are not directly
+transferable as a numeric anchor for Freegle's *drive-time* reach parameter — importing "15" or "20" as
+literal minutes would be a category error, since Freegle's constant is drive-minutes and these are
+walk/cycle-minutes (roughly 4-5x shorter distance for the same minute value than driving). Their value here
+is as **corroborating evidence that ~15-20 minutes is a broadly-recognised, cross-domain threshold for
+"an acceptable amount of everyday-life friction,"** not as a number to copy directly into a drive-time
+parameter.
+
+### 3c. Retail trade-area convention: the "10-minute drive" primary catchment
+Independent of Huff-model math, applied retail site-selection practice commonly treats the **first
+5-10 minutes' drive time as the "primary trade area,"** generating the majority (commonly cited 50-80%) of
+a convenience-oriented retailer's footfall, with a rapidly-thinning "secondary" catchment beyond that.
+This is standard commercial-geography practice (used by chains/site-selection consultancies) rather than a
+single peer-reviewed number, so should be read as an industry heuristic, not a scientific constant — but it
+is a second independent line of evidence (alongside NTS's flat ~17min shopping-trip duration) pointing at
+a **single-digit-to-low-teens-minutes core catchment for convenience-type activity**, with the "tail"
+beyond that generating rapidly diminishing returns per additional minute.
+
+### 3d. Willingness-to-travel for free/secondhand goods specifically — thin evidence base
+- Explicit freecycling-and-distance academic literature is **thin**. A 2026 cross-cultural study
+  ("Exploring the associations of generalized trust, climate change conspiracy beliefs and freecycling,"
+  *British Journal of Psychology*) exists and studies freecycling behaviour across 34 cultures, but its
+  focus is trust/psychology, not travel distance, and the full text was paywalled (HTTP 402) so its
+  distance-related content (if any) could not be verified here — **do not cite this as a distance-anchor
+  source**, flagging only that it exists as the closest named academic freecycling study found.
+- Secondhand/charity-shop retail research (multiple sources) confirms travel distance for secondhand
+  shopping is driven mainly by **store-specific attitude, perceived quality, and economic motivation**
+  rather than distance being a fixed, universal budget — i.e. willingness to travel for secondhand goods is
+  **item/venue-dependent, not a flat constant**, which supports Freegle's own instinct that reach should
+  probably not be one fixed number but adapt to something (which is exactly what the extent-governor MVP
+  already proposes, just currently uncalibrated).
+- No rigorous, citable primary study was found that puts a specific minute or mile figure on "how far
+  people will travel to collect a free item." This is a genuine evidence gap, not just a search-failure —
+  worth stating plainly rather than papering over with a low-confidence number.
+
+### Sources
+- [Huff Gravity Model: Store Customer Predictions — GIS Geography](https://gisgeography.com/huff-gravity-model/)
+- [How Huff Model works — ArcGIS Pro documentation (Esri)](https://pro.arcgis.com/en/pro-app/3.5/tool-reference/business-analyst/understanding-huff-model.htm)
+- [Accessibility Analysis: Reach, Gravity, and Huff Model — Medium/AxU Platform](https://axuplatform.medium.com/advanced-huff-mode-894e0012c5d5)
+- [The Distance-Decay Function of Geographical Gravity Model: Power Law or Exponential Law? (arXiv)](https://arxiv.org/pdf/1503.02915)
+- [15-minute city — Wikipedia](https://en.wikipedia.org/wiki/15-minute_city)
+- [Operationalising the 20-minute neighbourhood — International Journal of Behavioral Nutrition and Physical Activity (Springer)](https://link.springer.com/article/10.1186/s12966-021-01243-3)
+- [People love the idea of 20-minute neighbourhoods — The Conversation](https://theconversation.com/people-love-the-idea-of-20-minute-neighbourhoods-so-why-isnt-it-top-of-the-agenda-131193)
+- [Trade Area Analysis for Retail Site Selection — Geod](https://www.geod.app/blog/trade-area-analysis)
+- [Trade Area: Definition, Mapping Methods & Analysis Guide — GrowthFactor](https://www.growthfactor.ai/resources/blog/what-is-a-trade-area)
+- [Research: How Far Will Consumers Travel to Make Routine Purchases? — Access Development / Gary Toyn, Aug 2021](https://blog.accessdevelopment.com/research-how-far-will-consumers-travel-to-make-routine-purchases) (national US survey, n=2,131; 87% travel ≤15min, 93.2% ≤20min for everyday purchases; urban 97.2% ≤20min vs rural 70.3% ≥20min — note this is a commissioned industry survey, not peer-reviewed, treat as directional not definitive)
+- [Effects of store image and attitude toward secondhand stores on shopping frequency and distance traveled (ResearchGate)](https://www.researchgate.net/publication/235289697_Effects_of_store_image_and_attitude_toward_secondhand_stores_on_shopping_frequency_and_distance_traveled)
+- Freecycling/trust study (BJP, paywalled, not independently verified beyond its existence): [Exploring the associations of generalized trust, climate change conspiracy beliefs and freecycling — BJoP](https://bpspsychub.onlinelibrary.wiley.com/doi/10.1111/bjop.70058)
+
+---
+
+## 4. Urban-rural asymmetry — direct answer
+
+Combining sections 1 and 3:
+
+- **DfT NTS (official, primary source, England, 2023-24)**: shopping trip **duration** is flat at
+  16-20 minutes across all rural/urban settlement bands (old 4-way and new 6-way ONS classifications alike);
+  shopping trip **distance** ranges from **2.9-3.5 miles in urban areas to 5.8-8.1 miles in rural areas**
+  — i.e. **rural residents travel roughly 2-2.5x further, in essentially the same time**, because rural
+  average road speeds are higher. This is the single most robust, directly-applicable, quantified
+  urban-rural asymmetry finding in this research, and it independently corroborates Freegle's own measured
+  ~80x active-member-pool spread at a *fixed* drive-time: if Freegle holds drive-time constant, and rural
+  roads are faster so the isochrone footprint is larger in km² for the same minutes, AND rural population
+  density is far lower per km², the two effects compound multiplicatively rather than cancelling — which
+  is exactly the mechanism generating the reported 80x urban/rural active-member-pool spread.
+- **Industry survey (Access Development, US, 2021, non-peer-reviewed)**: 97.2% of urban consumers travel
+  ≤20 min for everyday purchases vs only 29.7% of rural consumers doing so (i.e. 70.3% of rural consumers
+  need >20 min) — same qualitative direction as DfT, though this is a different national context
+  (US, industry-commissioned) so should be weighted as corroborating, not primary, evidence.
+
+---
+
+## Anchor table (source, metric, value, applicability)
+
+| # | Source | Metric | Value | Applicability to Freegle's reach parameter |
+|---|---|---|---|---|
+| 1 | DfT NTS0403f (2023-24, England, official) | Avg. shopping trip duration, all areas | **17 min** (one-way, all modes, incl. waiting) | High — closest official proxy for "how long is a normal discretionary local errand." Freegle's 30-45 min ceiling is ~1.5-2.5x this. |
+| 2 | DfT NTS0403f (2023-24) | Avg. personal-business trip duration, all areas | 19-20 min | High — a second, independent official purpose-category giving the same ballpark (17-20 min). |
+| 3 | DfT NTS9914b (2023, England, official) | Shopping trip duration, urban conurbation vs rural village | 17 min vs 18 min (**time ≈ constant**) | Very high — direct evidence that drive-*time* budgets, not distance budgets, are the invariant across settlement types; validates time as the reach unit, not the reach ceiling. |
+| 4 | DfT NTS9912b (2023, England, official) | Shopping trip length, urban conurbation vs rural village | 2.9 mi vs 6.4 mi (**~2.2x**) | High — quantifies the urban-rural asymmetry that a fixed drive-time reach must reconcile; helps explain (not fully — density does the rest) Freegle's ~80x audience spread. |
+| 5 | Access Development survey (2021, US, industry, n=2,131) | % travelling ≤20 min for everyday purchases | Urban 97.2% vs rural 29.7% | Medium — corroborating (different country, non-peer-reviewed), same direction as DfT. |
+| 6 | Retail trade-area convention (industry heuristic) | "Primary trade area" drive time for convenience retail | 5-10 min generates 50-80% of custom | Medium — supports a short "core" catchment with a fast-thinning tail, i.e. non-linear value of extra minutes; not a scientific constant. |
+| 7 | Huff/gravity model literature | Distance-decay exponent, convenience vs comparison goods | λ≈1.5-2.0 typical; convenience > comparison qualitatively | Medium — direction well-supported across sources, exact numbers not pinned to one citable study; free items sit ambiguously between the two categories. |
+| 8 | Buy Nothing Project (self-published policy) | Target population per hyperlocal group | 10,000-35,000 residents; split trigger ~800-1,000 active members | High as a *precedent for audience-size bounding*, low as a *transferable number* (different use-case: slow-moving gift community, not fast-clearing transaction platform). Also carries an explicit cautionary tale: hand-drawn/local boundary-setting reproduced redlining — reinforces why an algorithmic (not per-group-manual) rule is right. |
+| 9 | Nextdoor (patent filings) | Bounding unit | Household count, with geography adjusted to fit it, not the reverse | High as a structural precedent — same "expand geography to hit an audience target" logic as Freegle's draft extent-governor. |
+| 10 | Freecycle (self-published policy) | New-town viability rule | ≥20,000 people within a 30-min drive radius | High as structural precedent (drive-time isochrone containing a population threshold = literally Freegle's extent-governor formula), applied once at founding rather than per-post. |
+| 11 | Olio (self-published policy) | Ideal vs hard collection distance | Ideal ≤2 km (community-cohesion rationale); hard ceiling 1.5h (food-safety rationale, not comparable) | Medium — shows a platform explicitly separating a "soft, socially-motivated" target from a "hard, safety-motivated" ceiling, a pattern Freegle could mirror (soft audience-based target, hard outer drive-time ceiling) but Olio's own numbers aren't transferable (food perishability ≠ Freegle's item durability). |
+| 12 | 15-minute city (Moreno) / 20-minute neighbourhood (Melbourne/Portland) policy | "Acceptable" walk/cycle/transit minutes for daily needs | 15-20 min | Low-medium — corroborates the general ~15-20 min order of magnitude as a widely-recognised "everyday life" threshold, but wrong travel mode (walk/cycle, not drive) so not directly transferable; a category error to import literally. |
+
+---
+
+## Bottom line
+
+External evidence brackets **reasonable discretionary local-errand travel time at roughly 15-20 minutes
+one-way** as the *typical/average* case, essentially flat across urban and rural England when measured in
+time (DfT NTS, official, primary) — with rural residents covering **~2-2.5x the distance** in that same
+time window due to higher average road speeds. Industry retail-geography practice independently converges
+on a similar **5-10 minute "primary" catchment** with fast-diminishing marginal value beyond that, and
+namesake urban-planning norms (15-minute city, 20-minute neighbourhood) independently converge on the same
+15-20 minute order of magnitude for "acceptable everyday friction," albeit for walk/cycle modes, not
+driving — so should be read as directionally corroborating, not numerically transferable.
+
+**Platforms bound broadcast/push-style community reach by audience size (households, residents, members)
+far more often — and far more deliberately — than by distance or time; distance/time in the well-designed
+examples (Nextdoor, Buy Nothing, Freecycle-at-founding) is only the *mechanism* used to reach a target
+audience size, not the target itself.** Distance-only bounding (Gumtree, Facebook Marketplace, Trash
+Nothing/OfferUp) appears mainly in pure user-initiated *search* systems where an oversized radius only
+costs the searcher, not a whole community's attention — not a good precedent for Freegle's *push*
+notification model, where an oversized reach costs everyone else's inbox.
+
+**Neither of these two facts alone tells Freegle what N* (target audience size) or T_max (drive-time
+ceiling) should be** — no external source publishes a number calibrated to "free, low-value, one-off item
+collection" specifically, which remains a genuine evidence gap best filled by Freegle's own historical data
+and/or the already-scoped reach experiment, not by external benchmarking. What external evidence robustly
+supports is the **shape** of the answer: (a) drive-*time* is the right unit to hold as the outer bound,
+because time (not distance) is empirically the thing that stays roughly constant across urban/rural in
+real travel behaviour — validating Freegle's existing choice of drive-time as the reach primitive; (b) the
+*current* 30-45 minute ceiling looks generous against the ~17-20 minute "typical discretionary local trip"
+anchor from official DfT data, which is at least directionally consistent with the moderator complaints
+that reach feels too large; and (c) the fix precedented by the platforms that do this well is not a smaller
+fixed time (which would just move the same asymmetry problem to a different point on the curve) but an
+**audience-size-governed expansion** — which is exactly the shape of the extent-governor MVP already
+drafted, with external evidence here contributing mainly (i) confidence that time-based bounding is
+directionally right, (ii) a rough order-of-magnitude sanity check that today's ceiling sits high relative
+to normal discretionary-trip behaviour, and (iii) real-world precedent that algorithmic
+audience-size-to-geography expansion (not manual/local distance-setting) is how mature platforms solve
+this same problem without reproducing the "everyone sets it randomly" failure mode the product owner
+already correctly rejected.

--- a/plans/2026-07-02-reach-design-evidence/D1-audience-target.md
+++ b/plans/2026-07-02-reach-design-evidence/D1-audience-target.md
@@ -1,0 +1,457 @@
+# Design D1 — Audience Normalization: reach governed by expected-active-audience, not drive-time
+
+**Philosophy 1 of 4.** The tuning parameter is an audience size, N\* (expected active members reached),
+not a time. Equal drive-time across areas is the bug — it produces a 14-80x spread in realized audience
+for identical "30 minutes" depending on where you live (§ Evidence). Equal-*audience* is the fix: every
+post expands, area-appropriately, until it has reached a calibrated number of people, and drive-time
+becomes an *output* of that process (and a safety envelope), not the control variable.
+
+Author's stance up front: this is not a new invention. It is the existing, already-coded, currently-dark
+Stage-A extent governor (`RIPPLE_EXTENT_ENABLED`, `RIPPLE_EXTENT_TARGET_USERS=4000` in
+`config/freegle.php`) — this design's job is to answer the question the MVP plan explicitly left open:
+**how is N\* derived, stratified, and kept correct**, not whether the audience-budget mechanism is the
+right shape (the mechanism already exists end-to-end in `iznik-routing-go/ripple.go` and
+`ReachService.php`; see Mechanics report §1 rows 14-15, §5 point 2).
+
+---
+
+## 1. The rule, precisely
+
+### 1.1 Core mechanic (unchanged from the existing MVP — this is the "adopt" part)
+
+Expansion proceeds tick-by-tick exactly as today (the live 9-tick hazard schedule
+`[1,3,6,12,24,48,72,120,168]` hours, step-70 curve — Mechanics report §2). At every tick, stop expanding
+a post's reach polygon as soon as **either**:
+
+- `cumulative_users >= N*(post)` (the audience-budget stop — currently coded, dark), **or**
+- `drive_min >= T_max` (the geometry ceiling — currently 30 min, live), **or**
+- distinct Interested repliers `>= reply_saturation_stop` (currently 5, live but never fires in
+  practice — see §1.4 for why this parameter is itself miscalibrated and should move in lockstep).
+
+`T_min` (floor) sets a minimum drive-time below which expansion cannot stop even if `N*` is already
+exceeded at tick 1 (protects very dense areas from a single-tick, sub-10-minute reach that would feel
+arbitrarily small and defeat the "give it a fair local area" intent of rippling at all).
+
+This is precisely the MVP plan's Stage-A mechanism. What's new in this design is §1.2-1.3: **how N\*
+itself is set, per area, and kept correct** — the piece the MVP plan explicitly punted on ("needs a
+product decision").
+
+### 1.2 Deriving N\* — three converging lines of evidence, triangulated to one number
+
+**This is the crux of the audience-normalization philosophy: N\* is not chosen, it is measured.** Three
+independent analyses in the evidence base all point to the same order of magnitude, and each is a
+non-arbitrary estimation procedure, not a guess:
+
+**(a) Demand-sufficiency flattening point** (Demand report §1, §6 — the primary evidence). Reply
+probability P(≥1 reply) and mean distinct repliers, plotted against realized audience, are **flat to
+gently declining** across the entire observed range (131 to 17,656 members), with no clean knee. But the
+within-density-tercile breakdown (Demand §6, the strongest single result in the whole evidence base)
+shows a real, reproducible peak-then-decline shape *within* each density class:
+
+| Density class (home-group active members) | Audience at peak P(≥1 reply) | P(≥1) at peak | Audience where it's visibly worse |
+|---|---|---|---|
+| Sparse (<1,000 active) | flat throughout (~250-3,400 observed) | ~31% | not reached in data |
+| Medium (1,000-1,726 active) | ~1,000 | 41.3% | ~7,700 → 24.7% |
+| Dense (1,726-3,469 active) | ~1,700 | 38.8% | ~13,000 → 21.8% |
+
+The peak sits at **roughly 1x the home group's own active-member count**, for both the medium and dense
+terciles (the only two where a peak is actually observed within range — sparse groups never generate
+enough audience to see the decline). This is the estimation procedure:
+
+> **N\*_demand(group) ≈ active_members(group)** — a group's own active membership, refreshed by the
+> existing membership/`lastaccess` machinery, is itself the best predictor of the audience size at which
+> reply probability peaks for that specific local reply-density.
+
+This is elegant because it requires no new stratification variable at all: it falls directly out of a
+number Freegle already computes per group.
+
+**(b) Catch-rate / collection-coverage curves** (Behaviour report, cap-to-coverage table + density
+split). The realistic, revealed-preference target for "how many people is enough to reliably produce a
+collector" is where taker-distance coverage saturates. Network-wide, 20km captures 95.6% of all
+collections and 30km captures 98.2% — i.e. returns beyond a certain radius are minimal. Translated to
+audience terms via the exemplar groups (Behaviour §, density split): TowerHamlets reaches 95% collection
+coverage at ~5-8km (a dense-area radius corresponding to an audience in the low thousands at TowerHamlets
+density), while Swindon is still climbing at 20km+. This independently corroborates (a): the "enough"
+point scales with local density, not with a fixed radius or a fixed population number.
+
+**(c) Reply-saturation-stop precedent** (Discourse #8415, cited in Mechanics as "the sole cited basis"
+for `reply_saturation_stop=5`; corroborated as a real community-derived number). Five distinct repliers
+was the community's own answer to "how many replies do you need before an Offer has enough interest".
+Converting that reply target to an equivalent audience via the measured reply rate `r_reply,active ≈
+1/1,403` (1 reply per 1,403 active members reached — Mechanics §6, from historical calibration) gives
+`N_t0 ≈ 5 × 1,403 ≈ 7,015` active members. This is materially higher than (a)'s ~1,000-2,000 peak because
+the community's "5 replies" bar was set without knowledge that reply *rate* declines, not just plateaus,
+past ~2,000; 7,015 is best read as an **upper anchor / sanity ceiling** on N\*, not the target itself —
+the demand data (a) says you'd be well past the peak and into the decline zone by 7,015 for medium/dense
+groups.
+
+**Triangulation.** (a) and (b) agree tightly (low-thousands, scaled by local density); (c) sits above
+both, consistent with a community expectation formed before rippling existed (when reaching 5 repliers
+required going far outside a small home group, so more reach genuinely helped). Since (a) is the most
+direct, freshest, causally-clean signal (with the exposure confound explicitly ruled out — Demand §6),
+**(a) is the primary derivation, (b) is the cross-check, and (c) is the outer sanity bound.**
+
+### 1.3 The formula
+
+```
+N*(post) = clip( k × active_members(home_group),  N*_min,  N*_max )
+```
+
+where:
+
+- **`active_members(home_group)`** — count of memberships with `collection='Approved'` and
+  `lastaccess` within the last 90 days on the post's home group. This is a metric Freegle already
+  computes (it is literally the denominator used to build the density terciles in Demand §6). No new
+  data pipeline is required.
+
+- **`k`** (the multiplier) **= 1.0**, derived directly from Demand §6: the observed reply-probability
+  peak sits at approximately 1x each tercile's own active-member scale (medium tercile active-member
+  midpoint ~1,363, peak audience ~1,000; dense tercile active-member midpoint ~2,598, peak audience
+  ~1,700 — both are 0.65-1.0x, so k=1.0 is a defensible, round, slightly-conservative (errs toward more
+  reach, not less) fit rather than an overfit to two noisy points). **Re-fit each quarter** from fresh
+  reply-decile data (§5) — k is exactly the kind of single scalar a periodic re-fit job can safely
+  adjust without a product conversation each time, because it's derived the same way every time.
+
+- **`N*_min` = 1,000.** Floor. Derived from Demand §1's fine bucket table: the 500-1,000 bucket already
+  shows P(≥1)=34.2%, materially better than the 0-250 bucket (27.0%) and close to the observed peak
+  (~35-41%) — going below ~1,000 measurably costs reply probability even in the sparsest observed data,
+  so 1,000 is the point below which N\* should never be allowed to shrink regardless of how small a
+  group's active-member count is. This also matches the "usable N\* range" lower bound independently
+  identified by the Audience-curves dark-compute (§2 there: N\*=1,000 is the smallest value that
+  discriminates at all — below it, the schedule's own tick granularity dominates, not the target).
+
+- **`N*_max` = 4,000.** Ceiling on the multiplier's output, *not* a promise that every post reaches
+  4,000 — it exists to stop `k × active_members` from over-extending very large-membership groups (e.g.
+  a 15,000-member urban group would otherwise target 15,000, deep into the demonstrated decline zone).
+  Derived directly: Demand §6 shows the dense tercile's decline is unambiguous by audience ~8,600+ and
+  severe by ~13,000; 4,000 sits comfortably below both, and not coincidentally is the **existing coded
+  default** (`RIPPLE_EXTENT_TARGET_USERS=4000`) — this design keeps that value rather than silently
+  changing it, since the evidence base independently justifies it as "past peak, short of decline" (Demand
+  bottom-line quote). If a future re-fit (§5) finds the decline threshold has moved, `N*_max` moves with
+  it — it is not hand-picked twice, only once, and thereafter tracked.
+
+- **`T_min` = 10 minutes.** Floor on drive-time regardless of how fast N\* is reached. Derived from the
+  external-anchors evidence: DfT NTS0403f national average one-way shopping-trip duration is 17 minutes
+  (flat across urban/rural settlement bands — Anchors report), and retail "primary trade area" convention
+  is 5-10 minutes generating 50-80% of footfall. 10 minutes is the lower edge of that convention band —
+  below it, a post has barely left its immediate postcode and the "give the local area first look"
+  principle of rippling is defeated even if N\* is nominally satisfied by a single dense tick-1 burst.
+  This also matches the existing MVP plan's stated floor (Mechanics report), so it is an adoption, not a
+  change.
+
+- **`T_max` = 30 minutes.** Ceiling, **kept at the current live value**, not raised to the previously
+  floated 45. Two reasons: (1) the external anchor data suggests even 30 is already ~1.75x the national
+  17-minute shopping-trip average, so raising it further has no supporting evidence and every complaint
+  in Discourse #9808 is about reach being *too large*, not too small; (2) the audience-curves dark-compute
+  (§2, Audience-curves report) shows T_max is already the *only* binding constraint for the 35%+ of groups
+  that never reach even N\*=2,000 — raising T_max would only ever expand rural reach further (already
+  intended and uncontroversial), while N\* is what reins in the complained-about dense-area cases. Under
+  this design T_max stops being the *primary* stop condition for dense/urban areas (N\* binds first there)
+  and remains the sole practical stop condition for the rural majority — exactly matching the "rural
+  posts riding to the ceiling is intended, not a bug" decision already made (Mechanics §6).
+
+### 1.4 A companion fix this design surfaces (not this design's primary deliverable, but a direct implication)
+
+`reply_saturation_stop=5` has never fired in 10,742 genuinely-rippled posts (Demand §1). Under audience
+normalization, a stop that literally cannot trigger is not a governor. Since N\* now does the
+area-appropriate audience-limiting, `reply_saturation_stop` should either move to a genuinely-binding
+value (Demand §1 fine table: P(≥3) is 4-8% across deciles vs P(≥5) at ~1%, so **3** would bind on a
+non-trivial share of posts and is defensible as "the 5-target was probably meant as an early-success
+signal, and 3 replies is where deciles start showing daylight") or be left as a rare early-exit
+safety-valve for exceptional posts, not the primary demand-based stop (N\* is). This is flagged, not
+specified in detail, because it is adjacent rather than core to the audience-normalization design.
+
+---
+
+## 2. Worked examples
+
+All figures from the Audience-curves dark-compute (real persisted `rippling_reach.schedule` ticks,
+2026-06-22 to 2026-07-02) and Demand report, unless marked "assumption" (evidence missing).
+
+| Group | Active members (proxy: audience-curves exemplar `n`/density tercile inputs) | N\* = clip(1.0×active, 1000, 4000) | Today (T_max=30 fixed): audience @ 30min | Today: drive-time to reach it | Under D1: drive-time to reach N\* | Under D1: final audience |
+|---|---|---|---|---|---|---|
+| **NW-London Offers** (no exact DB match — proxied by inner-London borough cluster, e.g. Ealing/Brent) | ~12,000-14,000 active (Audience-curves §3c top-15 table, e.g. Ealing p50 audience 12,811 @ 30min implies comparably large active pool) | **4,000** (capped) | ~12,500-14,800 | ~30.0 min (rides ceiling like all top-15 London groups) | ~17-19 min (interpolated between the N\*=2000 row's London p50 of 13.0min and N\*=4000's ~17-23min band — Audience-curves §2/§3d) | ~4,000 (vs today's ~12,500+) — **this is the fix the Discourse complaint (#248/#250) is asking for: same principle-of-locality, ~3x smaller audience, ~13 fewer minutes of drive-time** |
+| **Tower Hamlets** | ~3,469 (top of the "dense" tercile band, Demand §6) — consistent with it already self-gating via reply-stop | **N\* = 3,469×1.0 = 3,469**, within [1000,4000], no clipping | 13,336 @ p50 17.8min (already self-gated by reply-stop today, ahead of the 30min ceiling — Audience-curves §3) | 17.8 min | ~13-15 min (between the N\*=2000 row's 11.3min and N\*=4000 row's 17.8min, interpolated toward N\*≈3,469 — Audience-curves §3) | ~3,469 (vs today's already-reduced 13,336 — a further ~4-5min, ~4x audience tightening) |
+| **Oxford** | ~3,829 audience @ ceiling reported (Audience-curves §3); active-member proxy assumed comparable, ~3,000-3,800 (ASSUMPTION: no direct active-member count pulled for Oxford in evidence; audience-curves' own `total_freeglers` at full ceiling is used as an upper-bound proxy since Oxford rarely rides all the way to 30min-only-if-dense, per §3 p10=28.4) | **N\* ≈ 3,600** (within band) | 3,829 @ p50 30.0 min (p10=28.4 — Oxford is near-ceiling-bound already) | 30.0 min | ~28-29 min (barely changed — N\* and the current audience are already close, consistent with Oxford being "barely moves" under N\*=4000 in Audience-curves §3) | ~3,600 (vs today's 3,829 — a small, appropriate tightening; Oxford was never the complaint case) |
+| **Swindon** | ~672 audience @ ceiling (Audience-curves §3) — **never reaches even N\*=1,000** (Audience-curves §2: N\*=1000 has 18.9% never-reach nationally, and Swindon/Hull/Ribble Valley are named as 100% never-reach even at N\*=2000) | **N\* = clip(k×active, 1000, 4000) → floor of 1,000 applies since active members here are well under 1,000×k** (ASSUMPTION: Swindon's active-member count itself, not just audience-at-ceiling, is likely in the 600-1,000 range — not directly measured; audience-at-ceiling of 672 is a lower bound since it's already rate-limited by density not by N\*) | 672 @ 30.0 min | 30.0 min | **30.0 min — unchanged.** Swindon never reaches N\*, so `T_max` alone governs, exactly as today. | 672 (unchanged) — **this is the design working as intended: Swindon was never the problem, and D1 leaves it untouched** |
+| **Hull** | ~659 audience @ ceiling (Audience-curves §3) — 100% never-reach at N\*=2,000 or 4,000 | Floor 1,000 applies (active members plausibly near or under this) | 659 @ 30.0 min | 30.0 min | 30.0 min — unchanged | 659 (unchanged) — same as Swindon, ceiling-bound, D1-neutral |
+| **Ribble Valley** | ~1,446 audience @ ceiling (Audience-curves §3); 80% never-reach at N\*=2,000 | Floor likely near 1,000-1,446 (ASSUMPTION: active-member count not directly measured, audience-at-ceiling used as a proxy) | 1,446 @ 30.0 min | 30.0 min | ~27-29 min for the ~20% of posts that do cross N\*≈1,000-1,400 early; ~30 min (unchanged) for the 80% majority that don't | ~1,000-1,446 (essentially unchanged — a very small tightening for a minority of posts only) |
+
+**Pattern the worked examples demonstrate**: D1 is *inert* for Hull, Swindon, and (mostly) Ribble
+Valley — exactly the areas nobody is complaining about — and *materially binding* for Tower Hamlets and
+the wider inner-London cluster that generated every quantified Discourse complaint (#248 Swindon-vs-
+Islington, #250 Chilterns-to-East-London). Oxford sits in between, appropriately barely moved. This
+directly falsifies the "a people-count cap that decreases with density is wrong" concern flagged in
+Mechanics §6 — D1's cap does not decrease with density in absolute terms; because it's proportional to
+each group's own active-member base (not a fixed number, and not inversely related to density), dense
+groups still get large N\* values (just capped below their full uncapped potential), while sparse groups
+get the same protective floor as today.
+
+---
+
+## 3. Failure modes and mitigations
+
+**Coastal / estuary geometry.** N\* is defined on active-member *count*, not distance or area, so a
+half-circle catchment (e.g. a coastal town) simply takes longer (more drive-time) to accumulate the same
+N\* than a full-circle inland town of equal density — the mechanism self-corrects for shape automatically,
+unlike a fixed-radius design. Mitigation is structural, not a patch: **this is a genuine strength of the
+audience-normalization philosophy over a fixed-time or fixed-distance design.** Residual risk: extremely
+elongated coastal corridors could still hit `T_max` before N\* if the *linear* population density along
+the coast is too low even though the town itself is dense — acceptable, because this reduces to the
+"rural riding the ceiling is intended" case, not a new failure mode.
+
+**Group-boundary gerrymandering.** Because N\* is derived from `active_members(home_group)`, a group
+could in principle inflate its own N\* by encouraging low-engagement sign-ups that count toward
+`active_members` (defined via `lastaccess`, so this requires genuine 90-day activity, not just
+membership — a meaningfully higher bar than raw membercount). Mitigation: (a) use `active_members`
+(lastaccess-gated), never raw membercount, exactly as this design already specifies — raw membercount
+control (which a bad-faith admin *can* trivially inflate by mass-inviting) is explicitly rejected as the
+input; (b) cap via `N*_max=4,000` bounds the maximum possible gain from gaming even a huge group; (c) the
+periodic re-fit (§5) uses *reply outcomes*, not `active_members` itself, as the fitness signal — if a
+group's inflated `active_members` doesn't produce more replies, the re-fit's k multiplier trends down
+for that density band over time, self-correcting. This is a slower mitigation than a hard rule, flagged
+honestly as a residual risk in §6.
+
+**Seasonal actives (student towns, holiday areas).** `active_members` with a 90-day lastaccess window
+already partially self-corrects (a university town's active count naturally drops over summer, N\*
+drops with it, matching genuinely lower local reply capacity). Risk: a step change (start of term) could
+cause an abrupt N\* jump mid-quarter, before the next scheduled re-fit of `k`. Mitigation: `active_members`
+is recomputed on every post (it's a live query, not a cached quarterly figure) — only the multiplier `k`
+and the min/max clips are on a slower refresh cycle (§5); the *count* itself tracks seasonality in
+real time already, by construction. No further mitigation needed beyond documenting this behaviour is
+intentional.
+
+**TrashNothing / cross-posted members.** If a meaningful fraction of "active members" are actually
+TrashNothing-side users whose reply behaviour differs structurally (different app, different reply
+conventions) this design's `active_members` input and its reply-rate calibration (`r_reply,active`,
+Mechanics §6) could be systematically biased for groups with high TrashNothing crossover. **Not resolved
+by the current evidence base** — no report in this batch measured TrashNothing member share or
+reply-rate differential. Flagged as an explicit gap: before rollout, run one query segmenting
+`active_members` and reply rate by primary access channel; if TrashNothing-heavy groups show a
+materially different reply-rate-per-audience curve, they need their own `k`, not a shared one.
+
+**Data drift (network growth, rippling's own second-order effects).** Two distinct drift risks: (1)
+overall membership grows over time, shifting the density terciles the peak was calibrated on; (2)
+rippling itself changes membership patterns (rippled-in users sometimes convert to full members — the
+"rejoin-suppression" and "Rippled" marker mechanisms already exist per prior work), so the very
+`active_members` input is not static under this policy, it's partly a *consequence* of the policy.
+Mitigation: this is precisely why §5 specifies a **periodic re-fit**, not a one-time calibration — k must
+be re-derived from fresh reply-decile data on a fixed cadence, not set once and left. The circularity
+(reach changes membership changes N\* changes reach) is real but bounded: `active_members` changes slowly
+(months) relative to the re-fit cadence (quarterly, §5), so each re-fit sees a settled input, not a
+same-cycle feedback loop.
+
+**Cold start (new/tiny groups).** A brand-new group has an `active_members` count near zero — under the
+raw formula N\* would floor-clip to 1,000 immediately (§1.3's `N*_min`), which is exactly the desired
+behaviour: a new group gets the same protective floor as any small/sparse group, not a broken near-zero
+target. No special-casing required; the floor *is* the cold-start handling. Verify at rollout: confirm
+the floor applies before a group has accumulated 90 days of `lastaccess` history (i.e. a group younger
+than 90 days should not have `active_members` silently read as zero due to a lastaccess-window artifact —
+this needs a one-line "if group age < 90 days, use raw membercount as the active_members proxy" guard,
+noted in the implementation sketch, §5).
+
+**Scotland / Northern Ireland (thin data generally).** Audience-curves §3d shows Scotland at 61%
+never-reach-N\*2000 and NI at 100% (n=51, small sample) — i.e. under this design, NI and most of Scotland
+are **entirely T_max-bound, D1-inert**, same as Hull/Swindon. This is not a failure mode requiring
+mitigation — it's the correct outcome (nobody there is complaining, and the design should not touch
+areas it has no evidence about). The only actual risk is the *re-fit* (§5): with n=51 for NI, any
+density-banded k re-fit computed from NI's own data would be dangerously noisy. Mitigation: the re-fit
+must be done on **density bands, not individual regions/nations** — NI's few dense pockets (Belfast)
+should be re-fit as part of a shared "small dense" band with similarly-sized dense clusters elsewhere in
+the UK, not fit on NI's n=51 alone. This is specified explicitly in §5.
+
+---
+
+## 4. Mod-facing explanation
+
+The exact sentence(s) a moderator would see, in-product (e.g. on a "why did this reach so far" or
+group-settings explainer page), written to survive a hostile audience per the Discourse evidence
+(direct rebuttal of the "equal time ≠ equal fairness" complaint, and pre-empting "why can't I set my
+own number"):
+
+> **How far your group's posts ripple**
+>
+> Every Offer expands outward until it has reached roughly as many active Freeglers as your own group
+> normally has active — capped between 1,000 and 4,000 people, whichever this group's own membership
+> works out to. That means a small rural group and a large London borough both get a "fair local
+> audience" for their area, rather than both being forced to travel the same number of minutes down the
+> road. In a dense area, that audience is reached in a few minutes; in a sparse area, it can take up to
+> 30 minutes' drive to find that many people at all, and the post keeps expanding that far because there
+> simply aren't more people any closer.
+>
+> This number isn't set by us, and it isn't a dial groups can turn — it's recalculated automatically from
+> how many of your own members are actually replying to posts at different reach sizes, checked afresh
+> every three months. If it's consistently missing genuine local interest, or reaching a lot further than
+> it needs to, that shows up in the data and the number moves on its own next review — tell us on
+> Discourse and we'll check the numbers behind your group specifically.
+
+This directly answers the two structurally distinct hostile-audience objections seen in the evidence:
+(1) "why does my post go as far as someone in a totally different density area" (#248/#250) — answered
+by "equal audience, not equal time", the design's core claim; (2) "why can't I just set this myself" (the
+rejected-slider precedent, and the in-thread manual-dial proposals in #289/#304/#373/#397) — answered by
+making clear the number is derived from evidence and re-measured, not arbitrary, and specifically not a
+per-group toggle.
+
+---
+
+## 5. Rollout: dark-compute → scoped → network-wide
+
+**Stage 0 — Dark-compute validation (no live change).** This design's core claim (N\*≈active_members
+peaks reply probability) is already directly testable against the *existing* Demand report data without
+touching config: re-run the Demand §6 density-tercile analysis with `k` swept over {0.5, 0.75, 1.0, 1.25,
+1.5} and confirm k=1.0 remains at or near the empirical peak, not just plausible. This is pure SQL against
+already-collected data — do this before flipping `RIPPLE_EXTENT_ENABLED` anywhere. Deliverable: a
+one-page confirmation (or correction) of the k=1.0 fit before any code path changes behaviour.
+
+**Stage 1 — Scoped canary (single density band, small blast radius).** Enable
+`RIPPLE_EXTENT_ENABLED=true` with the derived N\* formula for a small number of **dense-tercile** test
+groups only (the population where D1 is expected to bind — Tower Hamlets-like groups; per §2, ~5-10
+groups covering the top-15 London-cluster + a couple of mid-density comparators like Oxford, to see both
+a strongly-binding and a barely-binding case). Rural/sparse groups are automatically unaffected by
+definition (they're T_max-bound regardless), so there is no need to separately canary them — they are the
+built-in control group.
+
+**What to measure during canary** (all metrics already instrumented per Mechanics report, zero new
+pipeline needed):
+- Reply rate (P(≥1), mean repliers) for canary posts vs. matched historical baseline (same groups,
+  pre-canary window) — the primary success metric, must not regress below baseline.
+- Time-to-first-reply (Demand §3 metric) — must not regress materially; D1 intentionally trades some
+  audience (and the speed that audience buys) for less mod-load/complaint, so a *small* speed regression
+  in the canary group is expected and acceptable, a *large* one is not (define threshold: no more than
+  the deceleration already observed between deciles 8-10 in Demand §3, i.e. don't regress speed below
+  where audience 4,000-6,000 already sits today).
+- Notified-count and notifications-per-replier (Demand §5 metric) — expected to *improve* (fall) for
+  canary groups, this is the mechanism's direct cost saving.
+- Taker-distance / collection-coverage (Behaviour report methodology) — must not regress; this is the
+  "did we accidentally miss real collectors" check the evidence base explicitly flags as the necessary
+  validation (Mechanics §6: "primary test... must be the taker-distance/collection-catch validation, not
+  just a volume-reduction number").
+- Discourse/mod-complaint volume from canary-group moderators specifically — qualitative but the actual
+  target outcome.
+
+**Duration**: minimum 3 weeks (matches the existing reach-experiment's own stated timescale for
+dose-response to resolve — Demand/Mechanics reference the ~3-week figure directly) to get past the
+7-day hazard schedule's full tail and accumulate enough Taken-outcome lag (Demand §2 notes real
+Taken-rate signal needs ~14+ days from post arrival).
+
+**Stage 2 — Network-wide rollout, banded.** Roll `RIPPLE_EXTENT_ENABLED=true` out region/density-band by
+band, in descending order of expected impact (matches Audience-curves §3d's region rollup — London first,
+since it's both the most-affected and the best-measured; then South East/Yorkshire &
+Humber/East/mid-density bands; sparse/rural bands last, since they are D1-inert and rollout order there
+is a formality, not a risk). At each band, re-check the same canary metrics before proceeding to the next.
+
+**Kill criteria** (any one triggers an immediate revert to `RIPPLE_EXTENT_ENABLED=false`, i.e. back to
+pure `T_max`, for the affected band):
+- Reply rate (P(≥1)) drops by more than 15% relative to the pre-D1 baseline for that band, sustained
+  over >1 week (not a single noisy day).
+- Collection-coverage (taker-distance capture rate at the group's *previous* effective radius) drops by
+  more than 5 percentage points — i.e. D1 is provably causing real missed collectors, not just
+  hypothetically.
+- Any single canary/band group's moderator escalates a reach-related complaint of the same severity
+  class as the resignation-triggering complaints already seen in Discourse #9808 (a qualitative but
+  real, board-visible trigger given two moderators already resigned over rippling and two more nearly
+  did — Discourse report).
+- The self-tuning re-fit (below) produces a `k` outside a sane band (e.g. <0.3 or >3.0) — this indicates
+  the input data or method has broken, not that the true optimum moved that far, and should halt
+  auto-application pending manual review, not be applied blindly.
+
+**Self-maintenance — periodic re-fit.** Every quarter, re-run the Demand §6 style analysis
+(density-tercile × audience-quintile reply-rate table) on the trailing 90 days of live data, and:
+1. Re-derive `k` per density band (not globally — see the Scotland/NI mitigation in §3: re-fit on
+   density bands with adequate n, pooling small/thin regions into a shared band rather than fitting
+   nation-by-nation).
+2. Re-derive `N*_min`/`N*_max` only if the fine-bucket reply-rate table (Demand §1 style) shows the
+   flattening/decline points have moved by more than a defined tolerance (e.g. 20%) from the values
+   used to set today's 1,000/4,000 — small quarter-to-quarter noise should not move the clips.
+3. Write the new values to `rippling_params` (the existing, currently-unwired scaffold table — Mechanics
+   report notes this exists but nothing reads it back into the pipeline; this design is the first
+   concrete consumer of it) and have `ReachService.php` read `k`/`N*_min`/`N*_max` from there instead of
+   the static config constant, with the static config value retained only as the fallback default.
+4. This directly replaces the currently-stubbed `RippleTuneService::categoryVolumeDeltas()` — instead of
+   an unconditional empty array, it should compute exactly the density-tercile reply-decile table this
+   design's derivation already specifies, making the "self-tuning loop" scaffold finally do real work,
+   using a method this design has already validated rather than inventing a new one at implementation
+   time.
+
+**Relationship to the existing extent-governor MVP**: **adopt and complete it.** The MVP's mechanism
+(audience-budget stop, already coded in `ripple.go`/`ExpandService.php`) is not replaced by this design —
+it is exactly what this design turns on. The only change is supplying the previously-missing derivation
+for `target_users` (this design's §1.2-1.3) in place of the flat, uncalibrated placeholder 4,000, and
+wiring the dark self-tuning scaffold (`RippleTuneService`/`rippling_params`) to actually maintain it.
+
+**Relationship to the planned reach experiment**: **complementary, sequenced after where possible, in
+parallel where not.** The reach experiment's stated purpose (Mechanics/Demand: "benefit of extra reach is
+structurally unobservable from history — everyone extra reach would add is currently unexposed") answers
+a different question than this design: the experiment measures whether reach *beyond* today's ceiling
+would help (an upper-bound/expansion question); this design answers whether today's reach is *already
+enough, unevenly distributed* (a reallocation/efficiency question) — and the demand-flattening evidence
+(Demand §1, §6) suggests the answer to "would more help" is *already visible in-sample* as "no, mostly,
+and in dense areas it actively hurts" without needing the randomized experiment to find that out. Given
+that, this design's canary (Stage 1) can and should run concurrently with the reach experiment's
+user-level randomization, provided the two are **statistically disentangled** (e.g. the reach experiment
+excludes canary-band groups from its treatment arms, or the canary is deferred to start after the
+experiment's ~3-week read-out if analytical interference is a concern). Recommend a brief coordination
+check before Stage 1 begins to confirm no overlap in the specific groups/posts each touches.
+
+---
+
+## 6. Honest cons — where this philosophy is weakest
+
+**1. The core derivation (§1.2a, k=1.0) rests on exactly two data points.** The within-tercile peak was
+observed cleanly in the medium and dense terciles only (two ticks of evidence), not three — the sparse
+tercile never showed a decline in the observed range, so `k` for sparse areas is *assumed* to generalize
+from the same ratio rather than independently confirmed. If sparse-area demand behaves qualitatively
+differently (e.g. never truly saturates, unlike medium/dense), `k=1.0` there is unverified, though it's
+also functionally inert for those groups (§3's Hull/Swindon/Ribble-Valley worked examples) since they're
+floor/ceiling-bound regardless — so the risk is contained, but the derivation confidence is genuinely
+asymmetric across density bands, and this should be stated plainly rather than hidden behind a single
+clean-looking formula.
+
+**2. Audience is a worse-measured, one-step-removed proxy for what mods and the product actually care
+about (mod load, member irritation, "did the item get collected"), not the thing itself.** The evidence
+base is explicit that mod-load is governed by group-*count*, not audience-size, under the current
+"ripple into every intersecting group" engine (Mechanics §6: "capping members alone does not shrink group
+count... chunking is required for that"). This means **D1, on its own, does not fix the mod-facing
+complaint's most literal mechanism** (moderators are annoyed partly because posts appear in many
+groups they oversee, not only because of raw audience size) — it fixes the audience-fairness dimension of
+the complaint cleanly, but leaves the group-chunking dimension (T2.1b in the MVP plan, "not started" per
+Mechanics §7 point 7) as a separate, unimplemented dependency this design does not itself deliver. Any
+rollout communication should not overclaim "this fixes mod overload" — it fixes "equal-time is unfair",
+which is the specific, quantified, most-cited complaint (#248/#250), but is a narrower claim than "fixes
+rippling complaints" broadly.
+
+**3. Reply-rate-as-optimization-target may itself be gameable/mis-specified over the long run.** By
+design, this method treats "reply probability peaks near 1x local active members" as ground truth to
+optimize toward — but replies are influenced by many things this design doesn't model (post quality,
+photo presence, time of day, category desirability), and the periodic re-fit (§5) implicitly assumes any
+drift in the *reply-vs-audience* relationship is due to the audience parameter being wrong, when it could
+equally be due to a shift in post mix, seasonality in item categories, or the deliverability feedback loop
+explicitly flagged as unresolved in Mechanics §7 point 10 ("high volume → spam-foldering → measured r
+looks artificially low → bigger N_t0 computed → more volume", a genuine self-reinforcing risk this design
+inherits from the MVP plan rather than solving).
+
+**4. The "equal audience" framing has its own fairness critique, symmetric to the one it's replacing.**
+Just as equal-time was criticized as producing wildly unequal audiences, equal-audience (capped at 4,000)
+means a genuinely huge, dense group's posts get *proportionally* less exposure relative to their own
+membership than a small group's posts do (a 15,000-active-member group is capped at 4,000 = ~27% of its
+own base; a 1,000-active-member group gets the full 1,000 = 100% of its base). This is the entire point
+for the density complaint, but it is a real, different-axis inequality this design deliberately trades
+in — worth naming explicitly rather than presenting N\* normalization as a free lunch.
+
+**5. Depends on data that is itself only 10 days old (Audience-curves report §0) and pre-dates full-volume
+rippling maturity (Demand report notes home-group reply share already drifted from ~98% to 82.5% in just
+9 days).** A derivation built on 10 days of post-launch data, in a system whose own behavior is still
+visibly settling, carries meaningfully more re-fit risk in its first year than the "quarterly re-fit"
+cadence in §5 assumes — the first 2-3 quarterly re-fits should be treated as provisional/high-variance,
+and the design should say so rather than presenting quarter-1's `k` as equally trustworthy as quarter-5's.
+
+---
+
+## Evidence sources cited
+
+- `/tmp/claude-1000/-home-edward-FreegleDockerWSL/32f74873-7429-488e-b2f3-7ded306eaba4/scratchpad/reach-design/1-mechanics.md`
+- `/tmp/claude-1000/-home-edward-FreegleDockerWSL/32f74873-7429-488e-b2f3-7ded306eaba4/scratchpad/reach-design/2-discourse.md`
+- `/tmp/claude-1000/-home-edward-FreegleDockerWSL/32f74873-7429-488e-b2f3-7ded306eaba4/scratchpad/reach-design/3-behaviour.md`
+- `/tmp/claude-1000/-home-edward-FreegleDockerWSL/32f74873-7429-488e-b2f3-7ded306eaba4/scratchpad/reach-design/4-audience-curves.md`
+- `/tmp/claude-1000/-home-edward-FreegleDockerWSL/32f74873-7429-488e-b2f3-7ded306eaba4/scratchpad/reach-design/5-demand.md`
+- `/tmp/claude-1000/-home-edward-FreegleDockerWSL/32f74873-7429-488e-b2f3-7ded306eaba4/scratchpad/reach-design/6-external-anchors.md`

--- a/plans/2026-07-02-reach-design-evidence/D2-behavioural-percentile.md
+++ b/plans/2026-07-02-reach-design-evidence/D2-behavioural-percentile.md
@@ -1,0 +1,397 @@
+# Design D2 — Revealed-Behaviour Percentile Cap
+
+**Philosophy**: the reach ceiling should be a travel-*time* cap set from what freeglers
+*demonstrably do* in that area's density class, not from an audience-count target, an
+external planning norm, or a moderator's gut feel. Distance/time is the primitive people
+actually experience and complain about ("an hour's drive each way" — Discourse #250); this
+design derives the cap directly from Freegle's own collection-distance data, cross-braced
+against DfT National Travel Survey norms so the number is externally defensible, not just
+an artefact of Freegle's own exposure history.
+
+Author's honesty note up front: this is Philosophy 2 of 4 competing designs. Where I think
+another philosophy (e.g. audience-size, Philosophy-1-style) does something structurally
+better, I say so in §6 rather than papering over it.
+
+---
+
+## 0. One-paragraph summary
+
+Set each post's drive-time ceiling `T_max(area)` to the **P90 of revealed successful-collection
+drive-time** for posts of similar local density, recomputed monthly from a trailing 90-day
+window, with a **95% "safety" secondary check** that must also be satisfied (see §1.3), floored
+at 10 minutes and capped at 30 minutes (today's ceiling — this design tightens, never loosens,
+in v1), and defaulting new/thin-data groups to a **density-matched value from a small number of
+density bands calibrated on established groups**, cross-checked against the DfT NTS ~17-20 min
+national discretionary-trip anchor. The censoring problem (today's data is truncated at today's
+30-min reach) is handled explicitly, not ignored: P90/P95 computed on censored data is a
+*lower bound* on true willingness-to-travel, which is exactly the conservative direction we want
+for a cap that mods currently think is too generous — so censoring biases this design *safe*,
+not dangerous, and is fully decensored once the separate reach experiment reports.
+
+---
+
+## 1. The rule, precisely
+
+### 1.1 Core formula
+
+For a post originating in group *g*, in density band *d(g)*:
+
+```
+T_max(d) = clamp( P90_time( collections | density_band = d, trailing 90 days ), 10, 30 )   [minutes]
+```
+
+where `P90_time(...)` is the 90th-percentile **drive-time** (not crow-flies distance — see
+§1.4 for the distance→time conversion) of successful collections (`messages_outcomes.outcome
+IN ('Taken','Received')`, resolved via `messages_promises` taker location, same method as the
+behaviour report) whose post originated in a group in density band `d`, over the trailing 90
+days.
+
+This T_max replaces `RIPPLE_MAX_MINUTES` (today a single global constant, 30) with a **density-
+banded** value. It is a ceiling on the existing drive-time isochoring mechanism — nothing about
+`step-70`, the 9-tick hazard schedule, or the reply-saturation-stop (≥5) changes. Only the outer
+geometry bound becomes density-aware instead of flat.
+
+### 1.2 Why P90, specifically
+
+- **Not P50/median**: median collection distance (2.1km overall, per behaviour report §1) is
+  where *most* collections happen, but a cap set at the median would exclude essentially half
+  of today's real, already-happening collections. That is not tightening a too-generous reach,
+  that is breaking the product for half of current users. A cap must sit *above* typical
+  behaviour, not *at* it.
+- **Not P99**: the behaviour report's overall P99 (37.6km / ~40+ min) is dominated by exactly
+  the pattern moderators are complaining about — long-tail rural-corridor and motorway-artifact
+  collections that make up a small fraction of transactions but a disproportionate fraction of
+  mod irritation (Discourse: Chilterns-to-East-London, #250). Setting the cap at P99 would
+  preserve almost every current collection but barely move the needle on the complaint.
+- **P90 is the standard "cover the overwhelming majority, trim the true long tail" choice**,
+  consistent with: (a) the behaviour report's own per-group coverage tables, which frame the
+  question as "what cap captures 90-95% of collections" (behaviour report §3, explicit
+  recommendation); (b) retail-geography convention, where "primary trade area" analysis
+  typically reports the drive-time that captures the large majority of footfall while
+  explicitly discounting the long low-density tail (anchors report §3c); (c) it leaves a
+  visible, quantifiable 10% of currently-happening collections outside the new cap — small
+  enough to not be a regression story, large enough that mods can see the parameter is doing
+  real work, not just a token gesture.
+- Reply-distance decay (behaviour report §2) is **smooth, no elbow** — there is no
+  distance at which conversion rate cliffs to zero, so no percentile is "objectively correct."
+  P90 is a defensible, standard, explainable choice among a continuum, not a uniquely provable
+  optimum — stated honestly in §6.
+
+### 1.3 The secondary "collection-catch" safety check
+
+Because P90-of-collections is measured on **censored data** (see §1.5), a pure percentile rule
+risks a slow, self-reinforcing tightening spiral: shrink the cap → fewer far collections happen
+→ next month's P90 is smaller → shrink further. To break this, T_max is **not allowed to drop
+by more than 15% month-over-month per density band**, and any proposed reduction must clear a
+**collection-catch check**: re-running last month's actual collections against the *proposed*
+new, smaller polygon must still capture ≥90% of them (i.e. the new cap must have been able to
+serve 90% of what already happened, not just 90% of a percentile computed on a population that
+may already reflect an earlier, tighter cap). This is a computed guardrail, not a manual override
+— see §5 for the exact procedure.
+
+### 1.4 Distance → drive-time: use the routing engine, not a flat km/h constant
+
+The behaviour report's own km→minute conversion (§ Bottom line table) is explicitly flagged as
+an illustrative placeholder ("no road-network data was used"). This design does **not** import
+that placeholder. Instead: `iznik-routing-go` already computes real drive-time isochrones for
+every rippling post (`/v1/ripple-schedule`) and every post's `rippling_reach.schedule` already
+stores `{tick, drive_min, cumulative_users}`. The P90 collection-time computation should use
+**the actual drive-time from the post's own tick schedule that contains the taker's location**
+(interpolating between the two bracketing ticks by `cumulative_users`/geometry, the same
+interpolation already used in the audience-curves dark-compute), not a haversine-km-to-minutes
+conversion. For **pre-rippling posts** (no `rippling_reach` row — the March/April baseline used
+for decensoring, see §1.5), fall back to a one-off batch routing-engine call per taker/post pair
+(`iznik-routing-go` already exposes single-route drive-time; this is a batch job, not a live
+dependency) — expensive to do live, cheap to do once as a calibration input.
+
+### 1.5 Handling the exposure/censoring confound — the load-bearing part of this design
+
+This is the crux of Philosophy 2 and the reason a naive "just take P90 of today's data" rule
+would be circular: today's collections can only happen within today's ~30-min reach (or group
+membership, pre-ripple), so the observed P90 is mechanically capped at whatever the current
+ceiling already is. Three concrete de-censoring mechanisms, layered:
+
+**(a) Use the pre-rippling baseline as the primary calibration input, not post-rippling data.**
+Pre-rippling (Mar-Apr 2026) collections were bounded by *group membership geography*, not a
+drive-time isochoring rule — group boundaries are typically drawn far larger than 30 minutes'
+drive in many areas (Swindon-Freegle's polygon is 559 km², Hull's 1,157 km², per the behaviour
+report's density table), so the pre-rippling P90 is **less censored** than anything measured
+after rippling launched, for the sparse/large-boundary groups that matter most for setting a
+*generous-enough* floor. (For dense groups with small polygons, membership itself is the
+binding constraint pre-ripple, so this doesn't fully decensor them either — see (b).) Pre/post
+comparison (behaviour report §4) already shows this is usable: pre-period P90=13.29km/P99=55.76km
+vs post-period P90=12.30km/P99=36.30km — the *tail* is measurably more censored post-rippling
+already, direct evidence the censoring effect is real and operating in the expected direction.
+
+**(b) Treat the resulting P90 explicitly as a floor, and say so to the business.** Per the
+behaviour report's own framing (repeated verbatim in its central caveat): revealed data is
+"usable for one thing with confidence: what cap would preserve X% of collections we are
+currently getting... not usable to conclude nobody would travel further." This design adopts
+that framing exactly. T_max computed this way is a **conservative floor** — a mathematically
+defensible statement of the form "cutting here would not have broken more than 10% of what's
+already working," not a claim about optimal reach. This is stated in the mod-facing copy (§4)
+and in the internal documentation, so nobody mistakes a censored floor for a demand ceiling.
+
+**(c) De-censor fully once the reach experiment reports.** The separately-specced,
+already-scoped reach experiment (user-level ADD randomization, ~3 weeks) is the only mechanism
+that can observe genuinely uncensored demand (some users get materially more reach than today's
+ceiling; their collection-distance distribution is not truncated by the current cap). This
+design's relationship to that experiment (§ explicit, per constraints) is: **the percentile-cap
+rule is the pre-experiment interim (what we can defensibly ship now, from data we already
+have), and the experiment's treatment-arm collection-distance P90 becomes the new calibration
+input the moment it reports — full replacement of the input distribution, same rule structure.**
+Concretely: re-run this design's §2 worked-example numbers using treatment-arm-only collections
+once the experiment concludes; if the experiment's P90 is meaningfully higher than the
+pre-rippling-baseline P90 used at launch, T_max should be revised upward for the affected
+density bands (this design does not assume the floor is exactly right — it assumes it is a
+safe, defensible starting point, correctable in one direction with real evidence).
+
+**(d) Monitor for the self-reinforcing spiral, mechanically, not just conceptually.** The
+15%-per-period cap and collection-catch check in §1.3 are the concrete implementation of "handle
+the exposure confound honestly" — they stop the rule from tightening past what current behaviour
+actually supports, using computed thresholds rather than a human eyeballing a chart.
+
+### 1.6 Density stratification: which axis, and why
+
+**Axis chosen: the group's own trailing-90-day "collector density"**, defined as:
+
+```
+density(g) = (distinct takers within 10km of g's centroid, trailing 90d) / (area within 10km, km²)
+```
+
+This is **not** the behaviour report's `membercount / polygon_area_km2` proxy (flagged in that
+report as an artefact of the *drawn boundary*, not real local population — Hull's low score
+despite being a city is the report's own cited example). Instead it's a fixed-radius disc
+around the post origin (10km, a round number inside the observed P90 collection range for
+every density class in the behaviour report's table, so it's measuring genuine local activity
+density rather than boundary-shape). This sidesteps the Hull artefact: Hull's fixed-radius urban
+core density looks like a city because it's measured on a disc, not a hand-drawn polygon that
+happens to include rural hinterland.
+
+**Why not ONS Rural-Urban class** (the axis both existing design docs assume): RU-class is a
+*residential settlement* classification (is this postcode's home area urban/rural), computed
+from Census geography, not a *transaction* classification. It's a reasonable proxy but one step
+removed from what actually matters here — how many people are actually transacting nearby. It
+also, per the mechanics report, doesn't exist anywhere in the live pipeline today (only in an
+offline extractor) — wiring a genuinely new axis (RU-class join) is more implementation surface
+than reusing data already flowing through `rippling_reach`/`messages_promises`. This design's
+density measure requires **zero new data sources** — it's computable entirely from
+`messages_promises` + `users_approxlocs` + `messages`, all already used by the behaviour report's
+SQL. (RU-class remains a reasonable **cold-start fallback key** — see §1.7 — since it's
+available for every UK postcode from day one, unlike a rolling 90-day transaction density which
+needs live history to exist.)
+
+**Number of bands**: 5, chosen to match the behaviour report's exemplar spread (TowerHamlets
+1,292/km² down to Hull's 2.9/km² is a ~450x range across 6 named exemplars; 5 log-spaced bands
+gives each band a genuinely distinct P90 without over-fragmenting into bands too thin on data
+to estimate reliably — see §3 cold-start thresholds). Bands are defined by **quintile of the
+density distribution across all groups with ≥90 days of history**, recomputed at the same
+monthly cadence as T_max itself (§5), so band boundaries drift with the network rather than
+being hand-picked constants.
+
+### 1.7 Cold start default: from the external anchor, not a guess
+
+For a post whose group has <90 days of history, or fewer than the minimum sample size (§3), or
+is entirely new: default `T_max = 20 minutes`. Derivation, not a guess:
+
+- DfT NTS0403f (national, 2023-24, official): average shopping-trip duration 17 min; personal-
+  business 19-20 min (anchors report §1a). This is the closest available proxy for "a normal
+  discretionary local errand" with a citable, primary, government source.
+- The anchors report's own conclusion (§ Bottom line): "reasonable discretionary local-errand
+  travel time [is] roughly 15-20 minutes one-way... essentially flat across urban and rural
+  England when measured in time" — i.e. the ONE number external evidence robustly supports is
+  a **time band that does not need density-stratifying**, because DfT's own data shows time is
+  the invariant, not distance, across settlement type (anchors report §1b, the single most
+  load-bearing external fact in that report).
+- 20 minutes sits at the upper end of the 17-20 min DfT band deliberately: a cold-start default
+  should be intentionally slightly generous (new groups have the least data to detect if it's
+  wrong, so err toward not choking off a brand-new area's early collections) while still being
+  materially tighter than today's flat 30-min ceiling.
+- This default is **not** a permanent per-group override (that would smuggle the rejected
+  manual-slider pattern back in via "just for new groups") — it expires automatically the moment
+  the group crosses the minimum-sample threshold in §3, at which point the group is assigned to
+  its measured density band like every other group.
+
+---
+
+## 2. Worked examples
+
+Method: use the behaviour report's per-exemplar taker-distance table (§3) as the distance input,
+converted to time using the group's own `rippling_reach.schedule` where available (dense groups
+have real post-rippling schedule data; sparse groups' schedule is thinner, flagged). Where the
+report itself only has distance, I state the km figure and give an honest, flagged time estimate
+rather than inventing false precision.
+
+| Group | Density (members/km², report proxy — used only for framing, not the rule) | Taker distance P90 (km, from report §3) | **Estimated drive-time P90** | Density band (this design's disc-based measure, estimated) | **T_max (this design)** | Today's flat ceiling |
+|---|---|---|---|---|---|---|
+| TowerHamletsFreegle | 1,292 | 4.99 | ~13-15 min (urban stop-start, slow effective speed; TowerHamlets already self-gates to drive_min p50=17.8min per audience-curves report exemplar) | Band 5 (densest) | **~15 min** | 30 min |
+| Oxford-Freegle | 243 | 9.69 | ~18-20 min (mixed urban/ring-road) | Band 4 | **~18-20 min** | 30 min |
+| EdinburghFreegle | 118 | 8.56 | ~16-18 min | Band 4 | **~18-20 min** | 30 min |
+| HullFreegle | 2.9 (artefact — see §1.6, this design's disc-measure would likely place Hull higher than this boundary-proxy suggests) | 12.95 | ~20-22 min | Band 3 (disc-based, not boundary-based — Hull's real urban core is denser than its polygon-average) | **~22-25 min** | 30 min |
+| Swindon-Freegle | 16.2 | 21.97 | ~28-32 min (rural/A-road, higher effective speed per DfT rural-speed finding) | Band 2 | **~28-30 min (effectively unchanged from today)** | 30 min |
+| Ribble Valley | 9.3 | 19.6 (**n=3, anecdotal only** — report's own flag) | Not estimable with confidence | Band 1 (sparsest) — **falls back to cold-start default (§1.7) or, once ≥90 days/min-n available, its own P90** | **20 min (cold-start) until real data qualifies it**, likely →~30 min once qualified given its rural profile | 30 min |
+| "NW-London Offers" (Discourse #250 complaint) | Not a real current group name (behaviour report confirms; likely legacy Yahoo-era name) | N/A directly — proxied by the London-borough cluster (audience-curves report: top-15-audience groups are ALL inner/west London boroughs, 11,000-15,000 median audience) | Proxy via TowerHamlets/inner-London figures above | Band 5 | **~15 min**, i.e. this design would have capped the Chilterns-to-East-London (#250) complaint at roughly a third of the ~50+ min extent the complainant experienced | 30 min |
+
+**Read of this table**: the design does exactly what the philosophy promises — it tightens
+materially in London/dense areas (TowerHamlets/inner-London: 30→~15 min, roughly halving the
+ceiling, directly answering the #250/#248 complaints) while leaving Swindon and Ribble Valley
+essentially where they are today (rural areas are correctly *not* penalised, per the existing
+design docs' explicit "rural riding to the ceiling is intended, not a bug" decision, which this
+design inherits and agrees with). Oxford/Edinburgh/Hull sit in a middle band, tightened
+moderately (~30→~20 min).
+
+**Honesty flag**: the drive-time estimates in this table are derived from the behaviour report's
+haversine-km figures via a rough conversion, exactly as flagged in that report — **this is a
+worked-example illustration of the rule's shape, not production-ready numbers.** Before
+implementation, §1.4's actual-routing-engine recomputation must replace every estimate in this
+table with a real `iznik-routing-go` drive-time. I have not fabricated false precision beyond
+what the source evidence supports.
+
+---
+
+## 3. Failure modes and mitigations
+
+| Failure mode | Mechanism | Mitigation in this design |
+|---|---|---|
+| **Coastal/estuary geometry** | A drive-time isochrone from a coastal town has genuinely far collectors (bridge/ferry detours) that a naive distance-based rule would wrongly exclude, because the *road* distance for a legitimately-close collector (across an estuary) is much longer than crow-flies. | This design already uses **drive-time**, not crow-flies distance, as the primitive (§1.4) — this is exactly the failure mode drive-time isochoring exists to solve, and it's inherited correctly from the current mechanism. The P90 is computed on real routing-engine drive-times, so a coastal group's genuinely-necessary detour collectors are captured in its own P90, not penalised by a distance rule. |
+| **Group-boundary gerrymandering** | A group draws an artificially large or small polygon to game its density band. | Density (§1.6) is computed from a **fixed 10km disc around the post origin and real transaction history**, not from the group's drawn polygon at all — there is nothing to gerrymander. A group cannot change its T_max by redrawing its boundary. |
+| **Seasonal actives (e.g. student towns, holiday areas)** | A university town's active-member density swings termly; a coastal town's swings with tourist season. A yearly-cadence recompute would badly lag these swings. | Monthly recompute (§5) with a trailing 90-day window is short enough to track a typical term/season transition within roughly one cycle, while the 15%-per-period cap (§1.3) prevents a single anomalous month (e.g. university move-out week) from swinging T_max wildly. |
+| **TrashNothing / cross-posted members** | Members who joined via TrashNothing or other federated import may have stale or low-quality `users_approxlocs` data, distorting distance measurement for their transactions. | This is an existing data-quality issue for *all* current reach measurement (not unique to this design) — the behaviour report already surfaces the >100km outlier tail as "likely stale-location or delivery-arrangement noise, not drive-and-collect" (§1). Recommend a **hard data-quality trim** at the P99.5 level before computing P90 (P90 itself is already robust to a small fraction of extreme outliers, but a documented trim step should be added to the actual query so this isn't left to chance). Does not require solving the underlying data-quality problem, just not letting it corrupt the percentile calculation. |
+| **Data drift (network grows/changes over time)** | The whole point of "self-maintaining" — if T_max is set once and never revisited, the same staleness problem (that produced the original 30-min flat-constant complaint) recurs slowly. | §5's monthly re-estimation cadence with automatic band-boundary recompute IS the self-maintenance mechanism — no separate drift-detection layer needed beyond what's already in §1.3's guardrail (which catches both directions: too-fast tightening AND, implicitly, would show if collections are being missed if catch-rate degrades). |
+| **Cold start (new/small groups, Scotland/NI sparse regions)** | A brand-new group, or a low-volume rural region, has too few transactions to compute a reliable P90 — a percentile on n<30 is noise, not signal. | Two-tier fallback, both derived (not guessed): (1) **minimum sample size gate**: require ≥50 collections in the trailing 90-day window before a group gets its own measured T_max (50 chosen as a standard-practice minimum for a stable percentile estimate — below this, standard error on P90 is too wide to trust, consistent with why the behaviour report itself flags n=3/n=15 rows as "anecdotal only, not data"); (2) below that threshold, fall back to the group's **density band's aggregate P90** (pooling across all qualifying groups in the same band gives enough n even for a thin single group); (3) if the group cannot even be density-banded yet (truly brand new, no transaction history at all), use the **§1.7 external-anchor cold-start default (20 min)** until enough history accrues to assign a band. Scotland/NI groups with genuinely low volume (not zero, just thin) sit at tier (2) — pooled by density band, which for most of Scotland/NI (per the audience-curves report's region rollup: rural/Highland areas cluster at the sparse end) means they inherit a wide, generous, rural-appropriate T_max from other sparse-band groups nationally, not a data-starved single-group estimate. |
+| **Circular tightening spiral** (the central methodological risk of this whole philosophy) | P90 measured on censored (reach-capped) data → cap set slightly below true demand → next period's data is measured on the *new*, tighter cap → P90 shrinks again → repeat, converging toward zero. | This is the single most important failure mode for Philosophy 2 specifically, and is handled three ways, all already specified above rather than bolted on: (a) §1.3's hard 15%-per-period-per-band tightening limit; (b) §1.3's collection-catch check (a proposed new T_max must be shown to have caught ≥90% of *last month's actual* collections, not just satisfy a percentile computed on a possibly-already-shrunk population); (c) §1.5(c)'s explicit plan to swap in the reach experiment's uncensored treatment-arm data the moment it's available, which structurally breaks the spiral by introducing a genuinely uncensored input at least once. |
+
+---
+
+## 4. Mod-facing explanation
+
+Two short sentences, shown wherever a moderator currently sees (or asks about) their group's
+reach setting — deliberately not a slider, not a raw number without context, matching the
+"explainable to a hostile moderator audience" constraint:
+
+> **"Freegle sets how far an Offer ripples based on how far people in your area actually
+> travel to collect free items — currently up to about [T_max] minutes' drive, covering 9 in
+> 10 of the collections that already happen here. This is recalculated every month from real
+> collections, not set by hand, so it adjusts automatically as your area changes."**
+
+If a mod asks "why is my number different from [other group]": a second sentence, used only on
+demand (e.g. an FAQ/tooltip, not the default copy, to avoid inviting district-level slider-style
+comparisons):
+
+> **"Denser areas naturally have shorter typical collection distances — city-centre collectors
+> are usually a few minutes away, while collectors in a rural area often need 20-30 minutes'
+> drive to reach the same number of options. We match the reach to what's normal for your
+> area, so a dense group and a rural group can both cover 9 in 10 of their real collections
+> without either one over- or under-reaching."**
+
+This is deliberately framed around **the mod's own group's real collections** (something a mod
+cannot dispute — it's their own transaction history) rather than an audience-count or a national
+policy analogy, since Discourse evidence (report 2) shows mods respond to concrete,
+locally-verifiable claims ("Swindon ~1,000 members... perfect", #248) far better than abstract
+governance language.
+
+---
+
+## 5. Rollout: dark-compute -> scoped -> network-wide
+
+**Stage 0 — Dark-compute (no product change, 1-2 weeks)**
+- Compute the full density-band table and each band's P90/P95 from real `messages_promises` +
+  `users_approxlocs` + `messages` history (pre-rippling baseline per §1.5(a), reusing exactly the
+  behaviour report's SQL pattern) — this document's §2 already prototypes this read-only.
+- Run the **collection-catch backtest**: for every band, simulate "what if T_max had been the
+  computed value for the last 90 days" and measure what % of *actual* collections would have
+  been outside the simulated polygon. This is the same check specified as an ongoing guardrail
+  in §1.3, run once here as a pre-launch validation.
+- Publish the dark-compute table (band boundaries, T_max per band, backtest catch-rate) for
+  product sign-off before touching any live config.
+
+**Stage 1 — Scoped (2-4 weeks, `RIPPLE_WITHIN_GROUPS` mechanism already exists per mechanics
+report item 3)**
+- Enable density-banded T_max for a deliberately chosen mixed set: 2-3 groups from the densest
+  band (the complaint population — e.g. Tower Hamlets, an Islington-area group), 2-3 from the
+  sparsest (Ribble Valley-like, to confirm no regression), 2-3 mid-band (Oxford/Edinburgh-like).
+- **What to measure**: (a) collection rate (Taken/Received per post) before vs during, per group
+  — must not measurably drop for any scoped group; (b) reply-saturation-stop firing rate
+  (currently near-zero per demand report — should remain near-zero, a sudden change would
+  indicate the new cap is interacting oddly with the existing stop); (c) mod-reported sentiment
+  via a direct, short survey to the scoped groups' mods (not just Discourse-watching, since
+  Discourse participants are a self-selected, vocal minority per report 2's own caveat);
+  (d) notification volume per post (should drop for dense-band groups, roughly flat for
+  sparse-band); (e) the collection-catch backtest re-run live, weekly, during this stage.
+- **Duration**: minimum 4 weeks, to span at least one full trailing-90-day-window recompute
+  cycle end-to-end (so Stage 1 validates not just the initial cap but the re-estimation
+  mechanism itself, not just a one-off number).
+
+**Stage 2 — Network-wide**
+- Roll out density-banded T_max to all groups with ≥90 days history / ≥50 collections (§3);
+  cold-start default (§1.7) for the remainder.
+- Monthly automated recompute (§5's own cadence) becomes a scheduled job from day one of network
+  rollout — not a manual re-run, to avoid the parameter drifting stale again (matching the
+  "self-maintaining" constraint from the brief).
+
+**Kill criteria** (any one triggers an immediate rollback to the flat 30-min ceiling for the
+affected scope, investigated before re-attempting):
+- Collection rate (Taken/Received ÷ Offers posted) drops >10% relative, week-over-week, for any
+  scoped/rolled-out density band, sustained for >2 weeks (not a single noisy week).
+- The collection-catch backtest (§1.3) shows actual catch-rate falling below 85% for two
+  consecutive monthly recomputes in any band (signals the tightening spiral is winning despite
+  the 15% clamp — investigate before allowing a third cycle).
+- Reply-saturation-stop (≥5) firing rate rises materially (would indicate posts are now
+  under-reached relative to real interest, contradicting the "expand until interest is served"
+  logic the current system already encodes).
+- Sustained, specific mod complaints (not general rippling sentiment, which is confounded by
+  the unrelated per-member opt-down slider shipped 2026-07-01 per Discourse report — must
+  isolate T_max-band complaints specifically) about *under*-reach in a band that was tightened.
+
+---
+
+## 6. Honest cons — where this philosophy is weakest
+
+- **It answers "what does the current system already achieve" better than "what would the
+  system achieve if freed from today's constraints."** This is the single biggest weakness,
+  and it's structural, not fixable within this philosophy: because the primary calibration
+  data is inherently a *behaviour-within-exposure* distribution (behaviour report's own central
+  caveat, quoted verbatim in §1.5), this design is fundamentally better at defending a
+  **conservative floor** than at discovering the *right* answer. If true demand is meaningfully
+  higher than what's revealed today (plausible — rippling is only ~2.5 weeks old at time of
+  writing, adoption/awareness is still low per the behaviour report's pre/post section), this
+  design will under-shoot and require the experiment-driven correction in §1.5(c) to fix later —
+  i.e. it is deliberately not a self-sufficient final answer, it is a defensible interim that
+  needs the experiment to complete it. A philosophy anchored on *audience size* (what Freegle's
+  own extent-governor MVP already sketches) doesn't have this specific circularity, because
+  audience count isn't self-referentially capped by the very geometry it's trying to size —
+  though it has its own calibration problem (§ the "what should N* be" question the demand report
+  shows is *also* not fully solved by audience data alone).
+- **P90 is a defensible convention, not a provably optimal choice** (§1.2 already says this
+  honestly) — the reply-distance decay is smooth with no elbow, so any percentile choice is
+  ultimately a judgment call dressed up as a formula. A hostile mod could reasonably ask "why
+  90 and not 85 or 95" and the honest answer is "industry/statistical convention for
+  'overwhelming majority, trim genuine tail'," not "because the data proves 90 is correct."
+- **Density-by-transaction-disc (§1.6) requires enough live transaction history to compute at
+  all** — which means this design's core input doesn't fully exist yet for brand-new areas
+  (handled by cold-start fallback, §1.7/§3, but that fallback is external-anchor-derived, not
+  Freegle-data-derived, so it inherits DfT's "general UK discretionary trip" number rather than
+  anything Freegle-specific for exactly the groups where local specificity would matter most).
+- **The collection-catch backtest (§1.3), which is this design's main defence against the
+  tightening spiral, itself relies on continuing to have real collections happening in the
+  wider (pre-tightening) area to backtest against** — once a band has been tightened for a full
+  cycle, the "actual collections" used for the next backtest are already partially shaped by
+  the tightened cap, so the guardrail's power to detect over-tightening weakens exactly as it
+  becomes most needed. This is a smaller, second-order version of the same censoring problem
+  the whole design is built to manage, and is only fully resolved by §1.5(c)'s experiment-data
+  swap-in, not by anything internal to this design.
+- **Doesn't natively address mod load** (the number of *groups* a post ripples into) — this
+  design only changes the geometric ceiling, not the "ripple into every intersecting group"
+  behaviour flagged in the mechanics report as unbuilt (`home-first chunking`). A smaller T_max
+  does indirectly reduce group-count somewhat (smaller polygon intersects fewer group
+  boundaries), but that's a side-effect, not a designed mechanism — a mod-load-focused design
+  would need that separately regardless of which reach philosophy wins.
+- **Does not use the schedule/hazard-tick infrastructure's audience data at all** (`cumulative_users`
+  per tick, already persisted per the mechanics report, zero schema change) — a design that used
+  that data (Philosophy 1-style, audience-sized burst) gets a more direct, more explainable
+  read on "how many people will see this" per post, which is arguably closer to what actually
+  drives mod-load and notification-fatigue complaints than travel-time is. This design is
+  travel-time-first because that's the assigned philosophy and because it maps most directly
+  onto the exact language moderators used in their complaints ("an hour's drive", #250) — but
+  it is deliberately not claiming travel-time is the *only* right lens, just the best-evidenced
+  one for *this* philosophy's brief.

--- a/plans/2026-07-02-reach-design-evidence/D3-community-relative.md
+++ b/plans/2026-07-02-reach-design-evidence/D3-community-relative.md
@@ -1,0 +1,457 @@
+# Design D3 — Community-Relative Reach
+
+**Philosophy 3: the reach cap should be measured relative to the community's own geography, not
+absolute time or audience.** A post should not reach further than the moderator's own group already
+spans, times a small, evidence-derived multiplier. Zero sliders; the "dial" is the shape of the group
+itself, which every mod already understands because they drew it (or inherited it).
+
+Author's framing in one sentence: **"posts shouldn't come from further than my own group already
+reaches"** — this is the literal mental model at least four Discourse mods reached for unprompted
+(Jax's "40 miles... near me first", Jos's "half the slider ≈ pretty much all of London", Group-Mod-J's
+"over the water" framing of Hull vs Scunthorpe as a different community despite short distance).
+
+---
+
+## 0. Why this philosophy, in one paragraph
+
+The other three designs (audience-sized burst, drive-time-anchored-to-national-survey,
+demand-plateau) all answer "how many people/minutes is *enough*". This one answers a different
+question the moderators are actually asking, verbatim, in the Discourse thread: **"is this still
+recognisably part of my patch, or has it left my patch and entered someone else's?"** Neville_Reid's
+Chilterns complaint is not "27,000 people is too many" — Jos's own Islington example puts the audience
+number front and centre, but Neville's framing (#250) is about *place*: "an hour's drive each way",
+"32 groups", the word "communities" used repeatedly by Group-Mod-J ("over the water", i.e. Hull vs.
+the East Riding — a *cultural* boundary, not a distance one) and by Jos (Croydon → Kensington "crosses
+the river", explicitly flagged as psychological, not metric). A community-structure rule answers the
+complaint in the vocabulary the complainants used, which is the strongest possible answer to a
+"must be explainable to a hostile moderator audience" constraint.
+
+---
+
+## 1. The rule, precisely
+
+### 1.1 Core formula
+
+For a post originating in home group *G*:
+
+```
+reach_cap_time(G)  =  clamp( α · span(G),  T_floor,  T_ceiling )
+```
+
+where:
+
+- **`span(G)`** = the drive-time diameter of G's own catchment polygon, defined as the 90th-percentile
+  pairwise drive-time between points on G's boundary, approximated cheaply (§1.3) as the drive-time
+  from G's centroid to its furthest boundary vertex, doubled (there-and-back proxy for "corner to
+  corner"), OR — cheaper and preferred — reuse the existing "widest span" computation already being
+  built for the moderator catchment UI (task #21/#22 in the current backlog: widest-span box with
+  distance + postcodes + road-distance in miles). **This is a hard dependency**: D3 needs exactly the
+  primitive that UI feature already computes. If that lands first, D3 is materially cheaper to ship.
+- **`α`** (alpha) = a single, network-wide constant, **not per-group**, derived from behavioural
+  evidence (§1.2) — this is the "no slider" guarantee: every group gets the same multiplier, only
+  `span(G)` varies, and `span(G)` is a geometric fact about a polygon the mod already drew, not a
+  free-form dial.
+- **`T_floor`** = 10 minutes (existing extent-governor MVP floor — adopted unchanged, §5).
+- **`T_ceiling`** = 30 minutes (existing live `RIPPLE_MAX_MINUTES` — adopted unchanged as the hard
+  outer bound; see §5 for why this stays even under this philosophy).
+
+### 1.2 Deriving α — not arbitrary
+
+α cannot be picked by eye ("feels about right") because that reproduces exactly the per-group-slider
+problem the product owner rejected, just moved into a config file. It must come from evidence. Two
+independent evidence sources triangulate on the same number:
+
+**(a) From the reply/collection distance-decay data (behaviour report §2, §3).** Across every
+exemplar group, the distance cap needed to capture 90-95% of *actual observed collections* is
+consistently **2-4x the group's own characteristic radius**:
+
+| Group | group "radius" proxy (√(area/π), km) | 95%-collection-capture distance (km) | ratio |
+|---|---|---|---|
+| TowerHamlets (1,292/km²) | √(20.2/π) ≈ 2.5 | ~5-8 | **2.0-3.2x** |
+| Oxford (243/km²) | √(206.1/π) ≈ 8.1 | ~15 | **1.9x** |
+| Edinburgh (118/km²) | √(402.8/π) ≈ 11.3 | ~15 | **1.3x** |
+| Hull (2.9/km², catchment artefact) | √(1156.8/π) ≈ 19.2 | ~15-18 | **0.8-0.9x** |
+| Swindon (16.2/km²) | √(559.4/π) ≈ 13.3 | >20 (still climbing) | **≥1.5x** |
+
+This is noisy (Hull's catchment-boundary artefact pulls its ratio below 1, flagged explicitly in the
+behaviour report as a group-boundary artefact, not a density fact — see §3 gaming discussion) but the
+central tendency across the non-artefact rows (TowerHamlets, Oxford, Edinburgh, Swindon) sits in the
+**1.5-2.5x** band, with dense areas nearer 2-3x and mid/low density nearer 1.5-2x.
+
+**(b) From the audience-curve data (audience report §3).** Tower Hamlets' own reply-stop gate already
+self-limits it to a p50 of 17.8 min / 13,336 audience today — call this the community's own
+*revealed* comfortable ceiling. Tower Hamlets' own catchment, at typical UK urban drive speeds
+(≈20-25km/h effective, per the 25-40km/h range used as an illustrative conversion in the behaviour
+report), spans roughly 8-10 minutes corner-to-corner. 17.8 / 9 ≈ **2.0x**.
+
+**(c) From the DfT external anchor (anchors report).** Shopping-trip duration is flat at ~17 minutes
+nationally regardless of settlement type, while *distance* varies ~2-2.5x by rural/urban band. This is
+independent confirmation that "the multiplier that keeps *time* investment felt-equal across densities
+is around 2-2.5x the local characteristic scale" — structurally the same ratio D3 is trying to encode,
+arrived at from a completely different (national travel-survey) dataset.
+
+**Chosen value: α = 2.0**, i.e. reach extends to twice the group's own drive-time span, floored at 10
+minutes and ceilinged at 30. This is a genuinely evidence-triangulated constant (three independent
+methods land in 1.3-3.2x, centring on ~2), not a guess — but it is the single weakest link in this
+design and should be treated as v1, revisited once the reach experiment (§5) provides free-demand data
+rather than the exposure-capped floor used here. **α is a network-wide constant that never needs a
+per-group override — that is the entire point of this design.**
+
+### 1.3 Computing span(G) cheaply
+
+Two options, cheapest first:
+
+1. **Reuse the widest-span primitive already scheduled for the moderator catchment UI** (backlog
+   tasks #21/#22: "widest-span box with distance + postcodes + road-distance in miles"). If that ships
+   first, D3 literally reads the same number the UI shows the mod — which has the pleasant side effect
+   that **the mod-facing explanation and the parameter are provably the same fact**, closing the
+   "explainable to a hostile audience" requirement by construction rather than by prose.
+2. **Fallback (if built independently/first)**: `span(G)` = drive-time (via the existing
+   `iznik-routing-go` Dijkstra used for `/v1/ripple-schedule`) from G's centroid to the single furthest
+   vertex of `groups.polyindex`, doubled. This needs one Dijkstra call per group, cached (groups'
+   polygons change rarely — recompute on group-boundary edit, not per-post). Cost: negligible (~500
+   published groups, one-off + on-edit).
+
+Either way, **`span(G)` is computed once per group (cached, recomputed on boundary edit), not once per
+post** — cheap, and crucially decouples the reach parameter from post-time load.
+
+### 1.4 Full worked formula per post
+
+```
+T_max(post) = clamp( 2.0 × span(home_group(post)),  10 min,  30 min )
+```
+
+This T_max replaces `RIPPLE_MAX_MINUTES` as the per-post ceiling fed to `/v1/ripple-schedule`
+(`max_minutes` parameter — already an accepted parameter of the existing API, per mechanics report
+§2.2: `mode=drive, ticks=9, max_minutes=<T_max>, curve=step-70`). Everything else in the existing
+pipeline (step-70 curve, 9-tick hazard schedule, reply-saturation-stop=5) is **unchanged** — D3 is a
+drop-in replacement for the single constant `30`, not a new pipeline.
+
+---
+
+## 2. Worked examples
+
+Using `span(G)` computed as (√(area_km²/π) × 2, converted to drive-time at ~25km/h dense / ~35km/h
+rural — the same illustrative conversion the behaviour report uses, flagged there as needing real
+routing data before implementation) as the fallback method (§1.3 option 2), since the true widest-span
+primitive isn't built yet:
+
+| Group | Area (km²) | Radius proxy (km) | Corner-to-corner span (2×radius, km) | Illustrative drive speed | span(G) as drive-time | T_max = clamp(2.0×span, 10, 30) | Today's T_max | Direction of change |
+|---|---|---|---|---|---|---|---|---|
+| Tower Hamlets | 20.2 | 2.5 | 5.1 | 20 km/h (dense) | ~15 min | **30 min** (clamped — 2×15=30) | 30 min (but self-gates to 17.8 via reply-stop) | **No change to ceiling**, but see §2a below |
+| Oxford | 206.1 | 8.1 | 16.2 | 25 km/h | ~39 min | **30 min** (clamped) | 30 min | No change |
+| Hull (catchment) | 1,156.8 | 19.2 | 38.4 | 35 km/h (rural) | ~66 min | **30 min** (clamped) | 30 min | No change |
+| Swindon | 559.4 | 13.3 | 26.7 | 30 km/h | ~53 min | **30 min** (clamped) | 30 min | No change |
+| Ribble Valley | 574.4 | 13.5 | 27.0 | 35 km/h (rural) | ~46 min | **30 min** (clamped) | 30 min | No change |
+| Edinburgh | 402.8 | 11.3 | 22.6 | 22 km/h (urban) | ~62 min | **30 min** (clamped) | 30 min | No change |
+| "NW-London" (proxy: dense inner-London boroughs, e.g. Brent/Ealing/Islington, per audience report §3d) | ~15-20 (typical inner-London borough) | ~2.3-2.5 | ~4.6-5.0 | 18-20 km/h (heavy congestion) | ~14-17 min | **28-34 → clamped 30** | 30 min | **No change at this α** |
+
+**This table is the single most important — and uncomfortable — finding of this design: at α=2.0, the
+ceiling clamp (30 min) dominates for almost every exemplar group, including the dense London ones,
+because London boroughs, while dense in *members*, are not small in *drawn area* (a typical London
+borough group spans 5-8km across, not the sub-1km "postcode-sized" patch the mental model implies).**
+The community-structure rule as literally stated (`α × own span`) does **not**, by itself, tighten
+Tower Hamlets or the Chilterns-complaint boroughs below today's ceiling — because those groups' own
+polygons are themselves several km across, and 2x that is still ≥30 minutes almost everywhere except
+the very smallest, tightest urban patches.
+
+### 2a. Where the rule *does* bind — and the honest fix
+
+The rule only produces a **tighter-than-30-min** cap for groups whose own span, doubled, is under 30
+minutes — i.e. genuinely small/tight polygons. Scanning the exemplar set, none qualify at α=2.0. This
+means **either α must be lower for this design to do useful work in the complaint geography, or the
+"own group span" concept must be replaced with a tighter definition** — most plausibly **not the
+group's own polygon, but the *adjacent-ring* formulation** the philosophy brief also names ("at most
+the adjacent ring of neighbouring groups"):
+
+```
+T_max(post) = drive-time to the FURTHEST BOUNDARY of the union of
+              {home_group ∪ groups sharing a border with home_group}
+```
+
+i.e. reach extends only as far as it takes to cross the *next* group over, wherever that boundary
+falls — no multiplier at all, purely topological. This is a **materially different, arguably stronger**
+formulation of the same philosophy: it directly answers "communities crossed" (cap = 1 community
+crossed) rather than "multiple of my own size", and it naturally self-scales because adjacent small
+London boroughs are close by (short drive-time to their far edge) while adjacent rural groups are large
+(long drive-time to their far edge) — it doesn't need α at all, and it degenerates gracefully. **This
+is the recommended primary formulation; §1's α×span formula is retained as a documented alternative
+because the brief explicitly asked for the multiplier derivation, but the ring formulation is what I'd
+actually ship.**
+
+Re-worked table using the **adjacent-ring formulation** (drive-time to the far edge of home ∪
+immediately-bordering published groups, computed via the same Dijkstra/`polyindex` union already used
+for cross-posting in `rippleIntoNewGroups`):
+
+| Group | Adjacent groups (illustrative, from geography) | Union span drive-time | T_max = clamp(span, 10, 30) |
+|---|---|---|---|
+| Tower Hamlets | Hackney, Newham, Southwark, Islington, City of London | ~18-22 min (dense boroughs, tightly packed) | **~20 min** — meaningfully below today's 30 |
+| Oxford | Oxfordshire-surrounding rural groups (Abingdon, Kidlington, Witney) | ~28-30 min (rural neighbours are large) | **~28-30 min** — near-unchanged |
+| Hull | East Riding, Beverley, Bridlington (Group-Mod-J's actual "over the water" complaint) | ~35-40 min (large rural neighbours) | **clamped 30 min** — unchanged, correctly (this is the "over the water" case the mod explicitly wants preserved, see §4b) |
+| Swindon | Wiltshire rural groups | ~35+ min | **clamped 30 min** — unchanged |
+| Ribble Valley | Lancashire rural groups (Clitheroe, Preston fringe) | ~30-35 min | **clamped 30 min** — unchanged |
+| Edinburgh | Midlothian, East/West Lothian | ~30-35 min | **clamped 30 min** — mostly unchanged |
+| Inner-London boroughs (Brent/Ealing/Islington complaint cluster) | Each other, tightly packed (5-15 adjacent groups per borough in inner London, per the top-15-audience-groups list in the audience report — "every single one is inner/west London") | **~12-18 min** (boroughs are small and densely tiled) | **~15-18 min** — a real, substantial tightening, directly answering the Chilterns/Islington complaints |
+
+**This is the version of D3 that actually resolves the complaint**: inner London boroughs are small
+*and* densely tiled with other small boroughs, so "one ring out" is genuinely short (12-18 min);
+rural groups are large *and* sparsely tiled, so "one ring out" is genuinely long (often clamped at the
+30-min ceiling) — which is exactly the intended behaviour ("rural posts riding to the ceiling is
+intended, not a bug", per mechanics report §6). No α needed; the adjacency graph and the union-polygon
+Dijkstra call are both primitives the pipeline already has (group `polyindex` intersection is already
+computed every tick for cross-posting).
+
+**Recommendation: ship the adjacent-ring formulation, not the α×span formulation.** I include both
+because the brief specifically asks me to "derive alpha", and the honest answer is that the
+alpha-multiplier version of this philosophy, calibrated against real evidence, does not bind in the
+complaint geography — a genuine, load-bearing negative finding, not a rounding error. The ring
+formulation both satisfies the philosophy (community-structure, zero sliders, explainable) and
+actually moves the numbers where the complaints are.
+
+---
+
+## 3. Failure modes + mitigations
+
+**3.1 Coastal/estuary geometry.** A group whose polygon includes sea/estuary (e.g. a Solent-facing or
+Thames-estuary group) has geometric area that overstates its "real" span, because part of the polygon
+is uninhabited water — inflating `span(G)` upward under the α formula, or inflating the adjacent-ring
+union under the ring formula if a neighbour is drawn to include the same water. *Mitigation*: compute
+span/adjacency using the drive-time network (road graph), not raw polygon geometry — the existing
+`iznik-routing-go` Dijkstra already only traverses road nodes, so water is naturally excluded (you
+cannot drive across the Thames estuary without going via a bridge/tunnel node) — this failure mode is
+**already mitigated by construction** as long as span is computed via routing, not via straight-line
+polygon geometry (which is why §1.3 explicitly rejects a pure-geometry radius in favour of a Dijkstra
+call). The illustrative worked examples above used geometry-based radius only because true routing data
+wasn't pulled in this design pass — a real implementation must use the routing engine, not `ST_Area`.
+
+**3.2 Group-boundary gerrymandering (does this reward drawing a huge polygon?).** Direct answer under
+the α formula: **yes, partially** — a group that draws its own polygon larger gets a larger `span(G)`
+and therefore a larger cap, which is a genuine gaming vector (a mod unhappy with a 20-min cap could, in
+principle, ask to redraw their boundary bigger to inflate their own ceiling). This is a real weakness
+of the α×span formulation. **Under the ring formulation, the incentive inverts and mostly cancels**:
+inflating your own polygon does increase the union span slightly (you now include more of your own
+larger area before even reaching a neighbour), but the dominant term is the neighbours' span, which the
+group doesn't control — and inflating your own boundary also means you now overlap more neighbours
+(triggering more `rippleIntoNewGroups` insertions per tick, i.e. *more* mod-load on you, not less) and
+raises legitimate "your boundary looks gerrymandered" scrutiny that a human review process (boundary
+changes already require Freegle HQ sign-off per existing group-management practice) can catch. It is
+not gameable to zero, but the ring formulation is materially harder to game profitably than the α
+formulation, and gaming is visible (boundary-edit history is auditable) rather than silent (unlike a
+manual reach slider, which was rejected specifically because it's an invisible, ungoverned dial).
+*Mitigation*: (a) prefer the ring formulation; (b) log every group-boundary edit's effect on computed
+`span`/ring-reach and flag outlier deltas (>50% change in one edit) for HQ review before it takes
+effect — cheap, and reuses the existing boundary-edit approval workflow rather than building new
+governance.
+
+**3.3 Seasonal actives / member churn.** This design has **no active-member-count term at all** — it
+is purely geometric (group shape + adjacency), which means it is **immune** to seasonal
+active/dormant member swings, unlike an audience-sized (N\*) design. This is a genuine structural
+strength of this philosophy relative to D1/D2-style audience designs: geometry doesn't have a summer
+dip. The corresponding weakness: it cannot respond to a group's membership *growing* into genuinely
+higher local demand over time except via the demand-plateau overlay in §3.6 below.
+
+**3.4 TrashNothing / cross-posted members.** Out of scope for the extent formula itself (TrashNothing
+sync affects *who* is notified within a computed reach polygon, not the polygon's size) — no
+interaction with this design. Flagged as a non-issue for this philosophy specifically, unlike audience
+designs which must dedupe reach denominators against TrashNothing membership.
+
+**3.5 Data drift (routing graph changes, e.g. a new bridge/bypass opens).** Drive-time spans and
+adjacency unions should be **recomputed on a schedule, not just on boundary edit** — the OSM road graph
+underlying `iznik-routing-go` updates periodically (new roads, closures). *Mitigation*: recompute
+`span(G)`/ring-reach for all groups on a **monthly batch job** (cheap: ~500 groups, one Dijkstra call
+each, well within existing `compute_concurrency=8` throughput), not per-post — this is the
+self-maintenance mechanism (§5's "how does the parameter stay correct over time" requirement): the
+number silently tracks the real road network and any group-boundary edits, with zero manual
+recalibration, forever, because it's a geometric fact re-derived from source data, not a fitted
+statistic that goes stale.
+
+**3.6 Cold start (new/small groups, Scotland/NI thin-data areas).** This is this philosophy's
+**strongest area**, not a weakness: span/adjacency depend only on the group's drawn polygon and the
+(static, nationwide) road network — both exist on day one for a brand-new group, with **zero
+dependency on post volume, reply history, or any per-post statistic**. A brand-new Highlands group with
+one member gets exactly the same, immediately-computable ring-reach as an established neighbour of
+similar shape. Contrast with N\*/audience-sized designs, which need enough historical posts to
+calibrate a demand curve and are explicitly thin in Scotland/NI (audience report §3d: Scotland 61%
+never-reach-N\*=2000, NI 100%, n=51 — too small to calibrate anything from post history alone). **D3
+has no cold-start problem** because it never reads post-outcome data at all — this is arguably its
+single best property.
+
+**3.7 Group deleted/merged/inactive neighbour.** If a bordering group is deleted, merges, or goes
+dormant, the adjacency graph must be recomputed (covered by §3.5's monthly job) — otherwise a ring
+computed against a stale neighbour list either under- or over-extends. *Mitigation*: trigger
+recomputation on group status change (deleted/merged/dormant-flagged), not just monthly — cheap event
+hook, existing group-lifecycle code already fires status-change events.
+
+---
+
+## 4. Mod-facing explanation
+
+### 4a. The exact sentence(s)
+
+For a group's settings/help page (static per group, computed once, cached):
+
+> **Your group's reach: up to {T_max} minutes' drive.**
+> Offers from your group are shown to nearby Freeglers out to about as far as it takes to drive across
+> your own group's area and into the next one over — roughly {T_max} minutes today. In a tightly-packed
+> area like yours, that's a short hop to your immediate neighbours; in a spread-out area, "the next
+> group over" can itself be a long way, so the reach is naturally larger, up to a maximum of 30 minutes
+> either way.
+
+For the moderator catchment-map UI (dovetailing directly with backlog tasks #21/#22, the widest-span
+box): show the group's own computed span **and** the resulting ring-reach on the same map, so the mod
+sees cause and effect in one view rather than being told a number in isolation — e.g. "Your group spans
+{span} at its widest. Posts reach into the {N} neighbouring groups shown shaded, out to {T_max}
+minutes." This is deliberately the same primitive as the catchment UI already being built, so there is
+**one number, shown in two places, always consistent** — no risk of the help text and the map
+disagreeing, which would itself become a new complaint vector.
+
+### 4b. Why this lands with a hostile audience specifically
+
+It directly answers the two sharpest structural complaints verbatim:
+
+- Jos's Swindon-vs-Islington comparison (#248): under this rule, Swindon's ring-reach is large (rural
+  neighbours are far apart) and Islington's is small (inner-London boroughs are packed tight) — **the
+  rule produces the asymmetry the mods are already demanding**, without a slider, and the explanation
+  ("your neighbours are close/far, so your reach is short/long") requires no statistics literacy.
+- Group-Mod-J's "over the water" framing (Hull vs. East Riding, #328-ish territory per discourse
+  report): a topological/community-boundary rule is the **only one of the four designs that can
+  represent "crossing the water counts as leaving the community" natively** — if the neighbouring
+  group across an estuary is itself large/far (as Hull's rural neighbours are), the ring formulation
+  naturally produces a long reach only because the *real* geography is sparse there, which the mod can
+  verify by looking at the same map they already use.
+
+---
+
+## 5. Rollout: dark-compute → scoped → network-wide
+
+**Relationship to the existing extent-governor MVP**: this design **replaces** the MVP's `target_users`
+audience-cap mechanism as the *primary* extent control, but **adopts unchanged** its scaffolding:
+the floor (10 min), the overall ceiling (30 min — retained as belt-and-braces even under a
+community-structure primary rule, because a routing-graph anomaly or a mis-drawn polygon could
+otherwise produce a pathological span; keeping the existing hard ceiling costs nothing and prevents a
+new class of bug), the `RIPPLE_EXTENT_ENABLED`-style dark flag pattern, and — crucially — the
+`rippling_reach.schedule` JSON storage, which needs **zero schema change**: `max_minutes` is already a
+per-request parameter to `/v1/ripple-schedule` (mechanics report, parameter #6), so swapping the
+constant `30` for a per-post `T_max(post)` computed from the home group is a parameter-plumbing change
+in `ReachService::scheduleParams()`, not a new pipeline. It does **not** need `target_users` at all —
+this design and the audience-sized-burst MVP are alternative primary levers, not layered (running both
+simultaneously would double-constrain and make failures hard to attribute; pick one as primary, or run
+D3 as primary with `target_users` as an emergency-only ultra-high secondary cap, off by default).
+
+**Relationship to the planned reach experiment**: unaffected and complementary. The experiment
+randomizes *who receives extra reach* to measure whether extra reach converts to real demand (the
+"unobservable extra reach" problem, evidence digest). D3's α/ring-reach values in this document are
+calibrated against **exposure-capped historical behaviour** (today's collection/reply distances, which
+can only reflect what people could already see) — exactly the same "floor not ceiling" caveat the
+behaviour report states explicitly. The experiment, once it runs, should be used to **re-validate**, not
+to derive, D3's parameters: if extra reach beyond a group's ring turns out to convert well, that's
+evidence for loosening the ceiling generally (a global, not per-group, change) — it does not argue for
+abandoning the community-relative *shape* of the rule, since the experiment is about magnitude
+(how much further is worth it) not shape (whether "further" should be uniform or community-relative).
+
+**Phased rollout**:
+
+1. **Dark-compute (no live effect), 1-2 weeks.** Compute `span(G)`/ring-reach for all ~500 published
+   groups from the existing road graph (batch job, §3.5), and for every post since `enabled_at`
+   (2026-06-23), recompute what its `T_max` would have been under D3 vs. the actual (flat 30) it got.
+   Compare against actual observed audience/collection-distance/reply-rate for that post (using exactly
+   the demand report's decile methodology) to sanity-check: does D3's tighter cap for dense groups still
+   capture ≥90-95% of the collections those groups actually had? (This is a direct rerun of the
+   behaviour report's §3 "what cap captures X%" table, but per-post rather than per-exemplar-group —
+   cheap, all inputs already exist.) **Kill criterion at this stage**: if D3's computed caps would have
+   excluded >10% of real historical collections in any density band, do not proceed — recalibrate the
+   ring definition (e.g. two rings instead of one) before touching any live traffic.
+2. **Scoped pilot, 2-4 weeks, `RIPPLE_WITHIN_GROUPS`-gated** (mechanism already exists per mechanics
+   report parameter #3). Select ~15-20 groups spanning the full density range that the audience report's
+   region rollup identifies as bimodal: several inner-London boroughs (the complaint cluster — Brent,
+   Ealing, Islington, Tower Hamlets), several mid-density (Oxford, Edinburgh), several rural (Hull,
+   Swindon, Ribble Valley, a Scotland/NI representative for cold-start validation). Run D3 live for these
+   groups' posts only; measure against control (remaining network, still on flat 30 min):
+   - Reply rate, distinct repliers, time-to-first-reply (per demand report's existing metrics)
+   - Collection/Taken rate and time-to-Taken
+   - Collection distance distribution (does it still match or exceed the group's own historical
+     percentile-capture rate from §2's dark-compute check)
+   - Mod-load proxy: count of groups a post rippled into (should drop for the dense pilot groups if the
+     ring formulation is working as intended)
+   - **Direct complaint-resolution check**: manually verify the exact Discourse-cited place-pairs
+     (Chilterns↔East-London, Fife↔Queensferry, Brent↔Hemel-Hempstead) no longer occur for pilot-group
+     posts, or occur measurably less often
+3. **Network-wide**, once pilot passes kill criteria (below), rolled out group-by-group or in one
+   cutover (cheap either way since it's a per-post parameter, not a migration) — announce via the
+   Discourse thread (#9808) with the mod-facing explanation (§4a) and the same catchment-map visual mods
+   already see, timed to coincide with (not compete with) the recently-shipped per-member opt-down
+   slider (#382), which is a different, complementary lever (member-level self-service vs. this
+   group-level structural default).
+
+**What to measure (ongoing, post-rollout)**: reply rate, collection rate, collection-distance
+percentile-capture (all per demand/behaviour report methodology, rerun monthly), mod-load (groups
+rippled into per post), and — specific to this design — **span/ring-reach drift over time** (are groups'
+computed values changing due to boundary edits or road-network changes, and if so, is that drift
+correlated with complaint volume in Discourse). This last one is D3's own self-maintenance monitor: since
+the parameter is a re-derived geometric fact rather than a fitted statistic, "is it still correct"
+reduces to "is the underlying map data still correct", which is a much easier ongoing question than "is
+our calibration stale" (the audience-sized design's equivalent question).
+
+**Kill criteria**:
+- Any pilot group's collection rate or Taken-rate drops >15% relative to its own pre-pilot baseline
+  (adjusted for network-wide trend) with no confounding explanation
+- Collection-distance percentile-capture for a pilot group falls measurably below its dark-compute
+  prediction (i.e. the live rollout is worse than the historical replay predicted — sign of a routing
+  or adjacency-graph bug)
+- Complaint volume on Discourse from *pilot* groups does not measurably improve relative to control
+  groups over the pilot window (the whole point is complaint resolution — if it doesn't move the needle
+  on the actual Discourse thread, the design has failed on its own terms regardless of what the
+  telemetry says)
+- Gaming detected: a group boundary edit that produces a >50% span/ring-reach jump without a
+  corresponding genuine geography change (§3.2's mitigation should catch this before it ships, but this
+  is the backstop)
+
+---
+
+## 6. Honest cons: where this philosophy is weakest
+
+1. **The naive α×span formulation, calibrated against real evidence, does not actually bind in the
+   complaint geography** (§2's central negative finding) — London boroughs are geometrically several km
+   across, so "twice your own span" still clamps at 30 minutes for exactly the groups that are
+   complaining. I had to fall back to a materially different formulation (adjacent-ring, no multiplier)
+   to get a design that does real work. This means the philosophy as literally stated in the brief
+   ("reach cap = f(group's own road diameter)") is weaker than a topological alternative
+   ("adjacent groups crossed") that lives in the same conceptual family but isn't quite the same rule —
+   an honest reviewer should treat §1 (α formula) as *demonstrated inadequate* and §2a (ring formula) as
+   the actual proposal, not a minor variant.
+
+2. **No connection to real demand or engagement signal at all.** Unlike D2 (demand-plateau) or the
+   audience-sized MVP, this design is purely geometric — it has no mechanism to notice that, say, a
+   particular sparse group's posts are chronically under-replied-to even at the 30-min ceiling (which
+   the demand report shows is common: 56-66% zero-reply rate) and might benefit from *more* reach than
+   its own geometry implies, nor to notice that a particular dense group's audience is chronically
+   oversaturated even within its ring. It optimises for "geographically sensible", which is what the
+   complaint is actually about, but it is silent on "did this help anyone collect anything" — that
+   question needs the reach experiment or a demand-plateau overlay layered on top, which this design
+   explicitly does not attempt (§5 recommends validating against demand data, not deriving from it).
+
+3. **Adjacency graphs are more operationally fragile than a single global constant.** A flat 30-min
+   ceiling never needs recomputation. A per-group adjacency-derived reach needs a maintained,
+   periodically-refreshed graph of which groups border which, robust to boundary edits, group mergers,
+   and (rarely, but it happens) genuinely gerrymandered or overlapping boundaries where "adjacent" is
+   ambiguous (e.g. two groups covering the same area at different times, or an enclave group fully
+   inside a larger one). This is real, ongoing engineering surface area that the other three designs
+   (which mostly key off audience counts or drive-time alone) don't carry to the same degree.
+
+4. **Reinforces existing boundaries rather than questioning them.** If a group's boundary is itself
+   badly drawn (too large, too small, historically arbitrary — a known issue independent of rippling),
+   this design faithfully propagates that flaw into the reach parameter, because it's defined entirely
+   in terms of the boundary. An audience-sized design is comparatively boundary-agnostic (it only cares
+   about people-density in a radius, not which polygon they're nominally inside), so it's more robust to
+   bad historical boundary-drawing. This design makes getting group boundaries right a harder
+   prerequisite than it otherwise would be.
+
+5. **Multiplier/ring-depth choice (α=2.0 or "one ring") is still ultimately a single global judgment
+   call**, even though it's evidence-triangulated (§1.2) rather than arbitrary — a genuinely hostile
+   critic could reasonably ask "why one ring and not half a ring, or one-and-a-half rings" and the honest
+   answer is "this is the smallest whole-number topological unit that maps onto 'the next community
+   over', chosen for explainability over precision, and validated against, not derived purely from,
+   the collection-distance evidence" — i.e. it is principled and evidence-checked, but the *specific*
+   choice of "exactly one ring, not some fractional distance into ring two" carries a design judgment
+   that a different designer might reasonably make differently. I'd defend it as the most explainable
+   choice available, not as the unique mathematically optimal one.

--- a/plans/2026-07-02-reach-design-evidence/D4-adaptive-control.md
+++ b/plans/2026-07-02-reach-design-evidence/D4-adaptive-control.md
@@ -1,0 +1,694 @@
+# Design D4 — The Parameter Should Not Exist As A Constant
+
+**Philosophy: reach is the OUTPUT of a per-post feedback/stopping rule plus a
+continuously-estimated model, never a hand-set number.** Humans set only meta-parameters
+(cost/benefit weights, safety floor/ceiling). Everything else — including "N\*" itself — is
+estimated from data and re-estimated forever.
+
+Date: 2026-07-02. Design only, per instructions. Grounded in the six evidence reports in this
+directory (`1-mechanics.md` … `6-external-anchors.md`); every constant below cites its source.
+
+---
+
+## 0. The one-sentence pitch
+
+Stop asking "what should N\* be?" — that is exactly the per-group-slider question in a
+statistics costume, just answered by an algorithm instead of a mod. Ask instead: **"for this
+post, right now, is the next marginal notification worth more than it costs?"** — a question
+answerable per-post, per-tick, from data the system already has (evidence: `rippling_reach.schedule`
+already stores `cumulative_users` per tick, zero schema change — `1-mechanics.md` §3) and data
+one extra experiment gives it (the already-scoped user-level ADD reach experiment). N\* is not
+eliminated; it becomes a **derived quantity**, recomputed continuously per stratum, not a value
+anyone — human or algorithm — picks once and freezes.
+
+---
+
+## 1. The rule, precisely
+
+### 1.1 Core decision at every tick
+
+At routing-schedule tick `k` for post `p`, before committing to expand from `cumulative_users[k-1]`
+to `cumulative_users[k]`, evaluate:
+
+```
+marginal_users(k)   = cumulative_users[k] - cumulative_users[k-1]
+marginal_benefit(k) = marginal_users(k) × r_hat(stratum, k) × V
+marginal_cost(k)    = marginal_users(k) × C
+CONTINUE tick k  iff  marginal_benefit(k) / marginal_cost(k) >= θ
+                       AND drive_min[k] <= T_ceiling
+                       AND distinct_repliers < reply_stop
+                       AND status not terminal (claimed/withdrawn)
+```
+
+Where:
+
+- **`r_hat(stratum, k)`** — the estimated probability that one additional notified member
+  produces one unit of benefit (reply, or reply-weighted-by-speed-value — see §1.4), for the
+  post's **stratum** (density band × tick-position — not "the group", see §1.3) and **tick
+  position** (early ticks buy speed, evidence: `5-demand.md` §3, median time-to-first-reply
+  drops 513min→141-174min decile1→decile10 — the speed benefit is front-loaded and decays with
+  tick, exactly mirroring the feed-forward/closed-loop split in §2).
+- **`V`** — value of one unit of benefit, in the same currency as `C`. A **meta-parameter**
+  (human-set once, see §1.5), not re-derived per post.
+- **`C`** — cost of one notification (mod-load-adjacent nuisance cost + literal send cost +
+  externality of moderator trust erosion). A **meta-parameter** (human-set once, see §1.5).
+- **`θ`** — the stop threshold on the benefit/cost ratio. Default **θ=1** (stop when marginal
+  benefit no longer exceeds marginal cost) unless a safety margin is deliberately chosen (see
+  §7, cons: θ itself needs to be *fitted*, not simply asserted at 1 — flagged honestly there).
+- **`T_ceiling`** — the drive-time safety ceiling. Fixed at **30 min**, i.e. the currently-live
+  value (evidence: `1-mechanics.md` — confirmed no 45 exists in code; `4-audience-curves.md`
+  confirms max_drive_min caps at exactly 30.0 across 24,213 real schedules). This is a
+  **meta-parameter (floor/ceiling), not derived** — it exists purely as a backstop so a
+  mis-estimated `r_hat` cannot run away geographically. Not touched by this design at launch;
+  raising or lowering it is a separate, later decision once the control loop has run long
+  enough to show whether it ever actually binds (§5).
+- **`reply_stop`** — retained as-is at **5** (Discourse community consensus, `1-mechanics.md`
+  #10), but demoted from "the governor" to "an absolute backstop" (see §1.6 — it currently
+  never fires, `5-demand.md`: P(≥5 replies) never exceeds 1.4% at any audience size, 0.83% of
+  posts overall reach it — so it is not doing governing work today; the marginal-benefit rule
+  is what actually governs, this stays only as a circuit breaker for the rare post that goes
+  viral).
+
+**This IS the extent-governor MVP's "expand until N\*" idea (`1-mechanics.md` #14/15,
+`effectiveScheduleTotal`), reframed.** N\* is not gone — it is what falls out of solving
+`marginal_benefit(N*) = marginal_cost(N*)` for the implied audience size. The MVP's mistake
+(per this design) is not the mechanism, it's treating N\* as a single number to be "decided"
+rather than a root of an equation whose inputs are estimated continuously. **Relationship to
+the MVP: ADOPT the mechanism (Stage-A budget cap, already coded end-to-end per `1-mechanics.md`
+§5.2), REPLACE the input** (a fixed `target_users=4000` placeholder becomes
+`solve_for_N(r_hat, V, C, θ)`, recomputed, not typed into config).
+
+### 1.2 How `r_hat` is estimated — the permanent calibration engine
+
+This is where Philosophy 4's actual content lives: **`r_hat` is never fitted once and frozen.**
+It is maintained by an always-on small holdout, structurally identical to the already-scoped
+user-level ADD reach experiment (per task brief: "benefit of extra reach is structurally
+unobservable from history — everyone extra reach would add is currently unexposed").
+
+- **Holdout design**: for every post, a small, randomly-assigned slice of the *marginal*
+  audience at each tick (the members who would be newly notified at tick k) is **held out**
+  (not notified this tick) with probability `p_holdout` (start **5%**, see §1.2.1 for why).
+  Their later behaviour (do they ever reply/collect via organic browse, i.e. would they have
+  converted anyway without the notification) is compared against the treated group's
+  conversion rate. This is the ADD (average dose-response derivative) design already specced —
+  this rule does not invent a new experiment, it makes the existing planned experiment
+  **permanent infrastructure** instead of a one-off 3-week study.
+- **Estimator**: for stratum `s` (see §1.3) and tick-position `k`,
+  `r_hat(s,k) = (conversion_rate_treated(s,k) - conversion_rate_holdout(s,k))`, i.e. the
+  causal lift attributable to notification, not raw conversion rate (raw rate conflates
+  "would have replied anyway via browse" with "replied because notified" — the holdout isolates
+  the causal increment, which is the number that actually belongs in a marginal-benefit
+  calculation).
+- **Shrinkage / partial pooling**: `r_hat(s,k)` is an empirical-Bayes shrinkage estimate toward
+  a network-wide prior (see §1.2.2), not a raw per-stratum sample mean — this is what makes
+  cold-start and sparse strata behave sanely (§3, cold start).
+- **Update cadence**: nightly batch re-estimation (matches existing `RippleTuneService`
+  scaffold's intended cadence, `1-mechanics.md` #24 — this design **reactivates and completes**
+  that scaffold rather than building a new one). `categoryVolumeDeltas()` today returns `[]`
+  unconditionally (stub) — this design specifies what it should actually compute (§8,
+  implementation sketch).
+
+#### 1.2.1 Why 5% holdout, not smaller/larger — an explicit estimation procedure, not a guess
+
+Sizing rule: the holdout fraction must be large enough that `r_hat(s,k)` has an acceptable
+standard error within one week for the **median-volume stratum**, not the largest. Using the
+observed baseline conversion rate (`5-demand.md`: P(≥1 reply) ≈ 22-39% across deciles, use
+30% as central) and the median post volume for a mid-density stratum (Yorkshire & Humber,
+n=1,456 posts over the 10-day measurement window per `4-audience-curves.md` §3d ≈ 145/day),
+a 5% holdout yields ~7 held-out posts/day/stratum with a marginal-audience of order hundreds
+each — sufficient for a two-proportion z-test to detect a 3-5 percentage-point lift at 80%
+power within roughly a week of pooled data. This is a **procedure** (re-run the power
+calculation against real per-stratum volume once strata are defined, §1.3), not an arbitrary
+5% — the number is a first cut to be checked against live volume in the dark-compute phase
+(§5) before any holdout traffic is real.
+
+#### 1.2.2 The network-wide prior (feed-forward) and its role in the blind-burst problem
+
+This is the design's most load-bearing mechanical fact, and it is why a pure closed loop
+cannot work: **~70% of a post's eventual audience is committed by tick 1, roughly 1 hour after
+posting** (evidence: `1-mechanics.md` #12, "step-70" hazard curve; tick 1 fires at t=1h not
+literally t=0). At that moment, **zero holdout signal exists for this specific post** — there
+has been no time for anyone to reply, let alone for a treated-vs-holdout gap to be measurable.
+The tick-1 decision is necessarily **feed-forward**: it must use the *prior* `r_hat`
+(yesterday's shrinkage estimate for this stratum/tick-position), not a within-post live signal.
+
+- **The prior is sized, not asserted**: it is the shrinkage-estimated `r_hat(s, tick=1)` from
+  the rolling 14-day window of holdout data for stratum `s`, using an empirical-Bayes beta-
+  binomial pool (stratum sample blended with the network-wide tick-1 rate in proportion to
+  stratum sample size — standard partial pooling, weight on the stratum mean =
+  `n_s / (n_s + k_pool)` where `k_pool` is fitted from the observed between-stratum variance,
+  not hand-picked).
+- **The prior updates nightly** on the trailing 14-day holdout window (14 days chosen as the
+  shortest window that: (a) spans day-of-week effects — offers arrive at different rates
+  weekday vs weekend — and (b) is short enough that a real shift in stratum behaviour (e.g. a
+  group gaining members, a season change) is reflected within two weeks rather than being
+  diluted by months of stale data. This is a meta-parameter set once at design time, revisited
+  if the loop is observed to be too slow/fast to react in the rollout phase, §5).
+- **What this means concretely**: tick 1's burst size is governed by *yesterday's* estimate of
+  "how much good does a tick-1 notification do in this stratum", not by anything this specific
+  post's own repliers have done yet. Only ticks 2-9 (the trailing 30%, spread over hours 3
+  through 168 — `1-mechanics.md` #12) can incorporate this post's *own* early signal (its own
+  reply count so far) as an additional, post-specific adjustment layered on top of the prior
+  (§1.4). This is explicitly **not** a design flaw to be engineered away — it is a structural
+  fact about how fast human replies arrive relative to how fast tick 1 fires, and the design
+  must be honest that governance of the dominant burst is necessarily a (frequently-updated)
+  feed-forward prior, not real-time control. (This matches the existing design docs' own
+  conclusion, `1-mechanics.md` #12 "givens" — this design does not relitigate it, it specifies
+  exactly how the prior is estimated and refreshed, which the prior designs left open.)
+
+### 1.3 Strata — the per-area axis, derived not assumed
+
+The MVP plan assumed ONS Rural-Urban class as the stratification key (`target_by_ru`,
+`1-mechanics.md` #21/#22) but that field is **not populated in the live path at all** — only
+used offline by the simulator. Rather than wait for that plumbing, this design strata on a
+quantity **already available for free from each post's own first tick**:
+
+```
+stratum(post) = decile of cumulative_users[tick=1] across all live posts in a trailing 14-day window
+```
+
+i.e. **the post's own early realized audience is the density proxy**, not a static group
+attribute. This is explicitly recommended by `4-audience-curves.md`'s bottom line ("N\* scaled
+by home-group's own audience-at-10-min... cheap to compute from each post's own early ticks
+with zero extra instrumentation") and sidesteps two problems the RU-class approach has:
+
+1. **RU-class is a static, group-level label; density is a post-level, seasonally-live
+   quantity.** A group's actual reachable population changes (membership growth, seasonal
+   actives, new housing) — a stratum recomputed from live tick-1 data tracks that automatically
+   (self-maintenance, §4), whereas an ONS lookup from a 2011 census table does not.
+2. **RU-class is not populated in the live pipeline** (confirmed absent, `1-mechanics.md` #22)
+   — using it would require new plumbing this design's philosophy explicitly avoids leaning on
+   (a static external table is itself a frozen assumption, in tension with "continuously
+   estimated").
+
+Ten deciles is itself a meta-parameter (chosen for enough within-stratum sample for the
+holdout power calculation, §1.2.1, while keeping the density gradient reasonably fine — halving
+to 5 or doubling to 20 changes statistical power per stratum but not the mechanism; revisit in
+rollout, §5). A special always-separate top stratum is carved out for the **12 boroughs at
+p10=602 → max=17,776 audience spread** (`4-audience-curves.md` §1 — the 15 highest-audience
+groups, all inner/west London, `4-audience-curves.md` §3c) because that population is where the
+Discourse complaints concentrate and deserves faster-updating, tighter confidence intervals —
+practically this falls out automatically as "decile 10", no special-casing needed beyond making
+sure decile 10 gets adequate holdout volume (it does: London = 3,652 of ~24,213 posts in the
+10-day window, `4-audience-curves.md` §3d, ample volume).
+
+### 1.4 What `V` (benefit) actually measures — reply-lift AND speed
+
+`5-demand.md` §3 is the single most important empirical finding for this design: **eventual
+reply COUNT is flat-to-declining with audience (P(≥1 reply) 22-39% across a 35x audience range,
+no clean knee), but TIME-TO-FIRST-REPLY improves monotonically and substantially (513min →
+141-174min, ~3x, decile 1 → decile 10).** A rule that only counts eventual replies as `V` would
+correctly conclude "audience beyond ~1,000-2,000 members buys almost nothing" (matching
+`5-demand.md`'s bottom line) and would starve the one benefit that DOES scale: speed.
+
+`V` is therefore not a single scalar but a **two-term benefit function**, fit from the same
+holdout data:
+
+```
+V(marginal_users) = w_reply × ΔP(reply)  +  w_speed × Δ(1/time_to_first_reply)
+```
+
+`w_reply` and `w_speed` are **meta-parameters** (relative worth of "gets a reply at all" vs
+"gets it faster") — genuinely a product/values decision, not a data-derivable ratio (see §1.5,
+these are the honest human-set knobs). The *shapes* `ΔP(reply)` and `Δ(1/ttfr)` are both
+estimated from the holdout, per stratum/tick — this is what makes the design's claim "buys
+speed not more eventual success" (matching `5-demand.md`'s own conclusion) something the
+control loop can act on rather than something a human has to remember to account for.
+
+### 1.5 The meta-parameters (the ONLY human-set values) — and how they get sane defaults
+
+| Meta-parameter | Role | Suggested default | Basis |
+|---|---|---|---|
+| `θ` | stop threshold, ratio of benefit/cost | 1.0 (initially), see §7 for why this is the weakest link | Definitional — "stop when marginal cost exceeds marginal benefit" is the textbook rule; whether 1.0 is the right operating point given estimation noise is exactly the open question flagged in §7 |
+| `V` decomposition weights `w_reply`, `w_speed` | relative value of eventual-reply-probability vs speed-to-reply | `w_reply=1, w_speed` calibrated so a 3x speed gain (the observed decile1→10 delta) is worth roughly the same as the reply-probability gain the same audience jump buys at low deciles (empirically, decile1→3 in `5-demand.md`: P(≥1) 31.5%→35.8%, +4.3pp, alongside 513→347min speed gain) — **an explicit starting ratio derived from matching the two effect sizes observed in the SAME data range where both still move together**, not asserted from nowhere | `5-demand.md` §1, §3 |
+| `C` (notification cost) | cost per marginal notification | Set so `C` reflects the **overshoot-cost curve already measured**: `5-demand.md` §5 shows cost-per-replier triples from 36 (decile 1) to 112 (decile 10) — `C` should be picked such that the rule naturally stops around decile 2-3 (audience ≈1,000-1,500) for a typical stratum where reply-lift has flattened, matching `5-demand.md`'s own stated "somewhere in the ~1,000-2,000 member range captures essentially all of the achievable reply probability" | `5-demand.md` bottom line |
+| `T_ceiling` | absolute drive-time safety cap | 30 min (unchanged from today) | `1-mechanics.md`, `4-audience-curves.md` — matches live system, no regression |
+| `reply_stop` | absolute circuit-breaker on distinct repliers | 5 (unchanged) | Discourse #8415 precedent, `1-mechanics.md` #10 |
+| `p_holdout` | fraction of marginal audience withheld per tick for calibration | 5% | §1.2.1 power calculation |
+| `prior_window_days` | trailing window for nightly `r_hat` re-estimation | 14 days | §1.2.2 — day-of-week coverage vs staleness tradeoff |
+
+**Calibrating `C` and the `w_reply`/`w_speed` ratio is itself done by a documented, repeatable
+back-solve against the evidence tables above** (shown in the table), not by intuition — but they
+remain the two places genuine human judgement enters (how much do we value speed vs eventual
+success; how costly is a notification really, including the soft cost of moderator trust —
+`2-discourse.md`'s finding that 2 mods resigned and 2 more nearly did is a real input into `C`
+that no amount of reply-rate data can supply on its own). This is the honest boundary: **data
+derives the shape, humans set how much the shape matters.**
+
+### 1.6 Backstops, not governors
+
+`reply_stop=5` and `T_ceiling=30min` remain in the rule but are demoted to **circuit
+breakers**, not the primary mechanism (today they effectively ARE the mechanism — reply_stop
+never fires per `5-demand.md`, so in practice today reach is governed by nothing except the
+flat 30-min ceiling, which is exactly the complaint). Under this design, the marginal-
+benefit/cost stop does the actual work; the backstops exist only to bound worst-case behaviour
+if `r_hat` is badly wrong (stale prior, data pipeline break, adversarial gaming) — see §3 and
+§6 (anti-runaway guards).
+
+---
+
+## 2. The control loop, precisely (feed-forward + closed-loop, explicit)
+
+```
+NIGHTLY (batch, all strata):
+  1. Pull yesterday's holdout-vs-treated conversion + time-to-reply data, by (stratum, tick).
+  2. Update r_hat(stratum, tick) via empirical-Bayes shrinkage against 14-day trailing window.
+  3. Update V(stratum, tick) shape (ΔP(reply), Δ(1/ttfr)) same way.
+  4. Recompute implied N*(stratum) = smallest audience at which
+     marginal_benefit/marginal_cost crosses θ, for tick=1 (feed-forward prior) and
+     for each subsequent tick (informs the closed-loop layer).
+  5. Guard-rail checks (§6) before promoting new estimates to "live":
+     - Max per-tick change in N*(stratum) capped (anti-oscillation, §6.1).
+     - Minimum holdout sample size per stratum before trusting a new estimate (else keep
+       prior night's value — cold-start / thin-stratum fallback, §3).
+     - Explosion-detector: if network-wide notification volume for the day is >X% above
+       trailing 7-day average, freeze all N* updates and alert (§6.2).
+  6. Write updated (stratum, tick) -> N*, r_hat, V table. This IS `rippling_params`,
+     repurposed (§8) — the table already exists; it just needs a real writer and a reader.
+
+PER-POST, PER-TICK (real-time, ExpandService::advanceDue / initialiseNew):
+  1. tick=1: use last night's N*(stratum, tick=1) as the target_users cap for THIS tick
+     (feed-forward — no live signal exists yet for this specific post, §1.2.2).
+  2. tick>=2: blend the feed-forward prior with this SPECIFIC post's own observed signal
+     so far (its own reply count, its own time-to-first-reply if any) via a simple
+     posterior update — a post that already has 2 replies at tick 2 gets a smaller
+     marginal-benefit boost from further expansion (matches its own realized r far
+     exceeding the stratum prior -> converges faster to a stop); a post with zero replies
+     by tick 4 gets no penalty (absence of a reply this early is not yet informative,
+     evidence: 5-demand.md decile1 median-time-to-reply is 513 minutes -- ~8.5h -- so "no
+     reply by tick 2 (3h)" is not yet a signal of anything).
+  3. Apply reply_stop / T_ceiling backstops (always checked, independent of the above).
+  4. Route holdout: for the marginal_users computed for this tick, withhold p_holdout
+     fraction from notification (still counted in polygon/browse-visible audience --
+     NOT excluded from the post being findable, only from the PUSH notification -- this
+     matters, see caveat below).
+```
+
+**Important scoping note on the holdout mechanism**: the holdout withholds the *push
+notification*, not visibility. A held-out member can still find the post by browsing/searching
+their group feed — this is what makes the ADD design measure the causal lift of *notification*
+specifically (matching the already-scoped experiment's framing) without making held-out members
+worse off than "a member who happens not to check their email that day" — a real, already-
+existing state, not a new harm introduced by the experiment. This should be stated explicitly
+in any GDPR/LIA review (still an open item per `1-mechanics.md` #29, not resolved by this
+design).
+
+### 2.1 Relationship to the existing extent-governor MVP and the reach experiment — explicit
+
+- **Extent-governor MVP (`RIPPLE_EXTENT_ENABLED`, `target_users`, `effectiveScheduleTotal`)**:
+  **ADOPTED AS THE MECHANISM, EXTENDED AS THE INPUT.** The Stage-A audience-budget cap plumbing
+  (`1-mechanics.md` #14/15, coded end-to-end, currently dark) is exactly the enforcement point
+  this design needs — `target_users` becomes a per-(stratum,tick) value read nightly from the
+  updated `rippling_params` table (§8) instead of a single flat 4000 constant. No new
+  enforcement code is needed; only the *source* of the number changes from "config constant" to
+  "nightly-computed table lookup."
+- **Reach experiment (user-level ADD design)**: **ADOPTED AS PERMANENT INFRASTRUCTURE, NOT A
+  ONE-OFF STUDY.** The already-scoped ~3-week experiment is not run once to get an answer and
+  then shut off — it becomes the always-on 5% holdout described in §1.2, running forever at low
+  volume, because the dose-response `r_hat` this design depends on is a moving target (member
+  churn, seasonal actives, group boundary changes — §4) that a one-off measurement cannot track.
+  This is the central philosophical move of Design 4: an experiment that was scoped as a
+  point-in-time measurement becomes the sensing organ of a permanent control loop.
+- **Self-tuning-loop scaffold (`RippleTuneService`, `rippling_params`)**: **REACTIVATED, NOT
+  REPLACED.** `1-mechanics.md` #24 found this scaffold already exists but is a stub
+  (`categoryVolumeDeltas()` returns `[]`, `ripple:tune` unscheduled, no reader). This design is,
+  concretely, "finish building what's already half-built" — §8 gives the implementation sketch.
+
+---
+
+## 3. Failure modes + mitigations
+
+| Failure mode | Why it breaks a naive version | Mitigation in this design |
+|---|---|---|
+| **Coastal/estuary geometry** (e.g. Hull's catchment spanning a rural hinterland, `3-behaviour.md` density-proxy artefact) | A post near a coastline/estuary has a real drive-time isochrone that is asymmetric and low-density on one side; if strata were geographic (e.g. postcode-area based) this could misclassify a genuinely dense area as sparse because the polygon average includes empty sea/estuary | Stratifying on **the post's own realized tick-1 audience** (§1.3), not on a static geographic label, sidesteps this entirely — a coastal post's tick-1 audience already reflects its real (asymmetric) reachable population, no geometry-shape correction needed |
+| **Group-boundary gerrymandering** (a mod redraws their group polygon to inflate/deflate density stratum) | If stratification used group polygon area (as the `3-behaviour.md` density proxy did, an artefact acknowledged in that report), a mod could game their stratum by redrawing boundaries | Stratifying on **post-level realized audience** (not group polygon) means redrawing a group boundary changes membership/routing inputs, not the stratum computation directly — gaming would require actually changing the reachable population, which has real-world consequences (fewer/more genuine members) rather than being free to manipulate. Residual risk: a mod could still influence membership counts through recruitment drives; this is treated as legitimate area-representation activity, not gaming, and is explicitly out of scope for this design to police |
+| **Seasonal actives** (student towns emptying over summer, e.g. Oxford — `4-audience-curves.md` names Oxford explicitly; holiday-driven member activity swings) | A `target_users` constant calibrated once in term-time would be wrong in summer | The nightly re-estimation (§2) over a 14-day trailing window means `r_hat`/`N*` tracks seasonal member-activity swings automatically within about two weeks — this is a **structural** advantage of "recompute forever" over "set once," and is the single strongest argument for Philosophy 4 over a fixed-constant design |
+| **TrashNothing members** (cross-posted members who may behave differently — inflated notification counts, different engagement patterns) | If TrashNothing-sourced members are counted in `cumulative_users` but behave differently (lower conversion), a stratum with many such members would get a systematically wrong `r_hat` if not distinguished | Add a covariate (not a separate stratum, to avoid combinatorial explosion of thin strata) to the empirical-Bayes model: proportion of TrashNothing-sourced members in the marginal audience, entered as a regression term when re-estimating `r_hat`. Deferred to rollout phase (§5) once volume is large enough to fit it reliably — flagged, not solved, in this design (see §7) |
+| **Data drift** (BackfillReachCommand-style contamination — `5-demand.md` §0 found 56% of `rippling_reach` rows were backfill placeholders that would have silently corrupted any naive analysis) | A recurring batch job or schema change could silently poison the nightly re-estimation the same way it poisoned the one-off analysis | Nightly job **must** apply the same population-cleanliness filters documented in `5-demand.md` §0 (`NOT(status='stopped' AND tick=0)`, `messages.arrival` not `rippling_reach.arrival`) as a standing data-quality gate, not a one-off fix — and should alert (not silently proceed) if the daily volume of "clean" posts drops sharply below trailing average (this doubles as an early-warning signal for other pipeline breaks, not just backfill contamination) |
+| **Cold start** (new group, or a stratum with too few posts for reliable holdout signal — Scotland/NI explicitly, `4-audience-curves.md` §3d: Northern Ireland n=51, 100% never-reach-2000; Wales n=523, 99% never-reach) | A brand-new group, or a genuinely thin stratum, has no holdout history to estimate `r_hat` from — naive per-stratum estimation would either refuse to serve (bad) or use a wildly noisy small-sample estimate (worse) | Empirical-Bayes shrinkage (§1.2) is specifically chosen for this: a thin stratum's estimate is pulled heavily toward the network-wide prior (weight `n_s/(n_s+k_pool)` → 0 as `n_s`→0), so a brand-new group or a 51-post NI stratum gets essentially the network average `r_hat`, not a wild extrapolation from a handful of posts and not a refusal to compute anything. As real volume accrues, the estimate smoothly specializes. This is also why sparse areas are *not disadvantaged*: `4-audience-curves.md` already shows sparse areas are overwhelmingly ceiling-bound (100% never-reach N\*=2000 in Wales/NI/Highlands) — meaning for these strata the marginal-benefit rule will almost always say "keep going" all the way to `T_ceiling` regardless of estimation noise, because at low absolute audience the marginal cost stays low too. The backstop ceiling (unchanged 30 min) ensures these areas are never worse off than today |
+
+---
+
+## 4. Self-maintenance — how the parameter stays correct over time
+
+This is the core promise of Philosophy 4, stated explicitly rather than left implicit:
+
+1. **No value is ever "set."** Every `N*(stratum, tick)` in the live `rippling_params` table
+   is overwritten nightly by the batch job (§2), sourced from the trailing 14-day holdout.
+   There is no code path where a human or a one-off script writes a permanent value — the only
+   human inputs are the meta-parameters (§1.5), which are versioned and rarely touched.
+2. **Drift is absorbed automatically, within the trailing-window lag** (~14 days for a full
+   behavioural shift to be reflected, faster for partial shifts as the shrinkage weight moves).
+   Membership growth, seasonal actives, a group's real density changing (new housing
+   development, a group merging/splitting) all flow through "this stratum's posts now have
+   different tick-1 audiences and different holdout conversion rates" without anyone touching
+   config.
+3. **The strata definition itself (decile boundaries) is recomputed nightly too** (§1.3 —
+   deciles of yesterday's tick-1-audience distribution), so if the whole network's density
+   distribution shifts (e.g. mass onboarding of a new large city), the strata boundaries move
+   with it rather than becoming stale.
+4. **What does NOT self-maintain, and must be reviewed periodically by a human**: the
+   meta-parameters themselves (§1.5) — `θ`, `w_reply`/`w_speed`, `C`. These encode value
+   judgements (how much do we value speed vs eventual reply; how costly is a notification) that
+   data cannot supply on its own. Recommended cadence: quarterly review, informed by the
+   same evidence tables this design was built from, refreshed with then-current data — this is
+   explicit human governance of the *values*, while the *arithmetic* runs unattended.
+
+---
+
+## 5. Rollout: dark-compute → scoped → network-wide
+
+### Phase 0 — Dark-compute (0 risk, no behaviour change)
+
+- Reuse the exact method `4-audience-curves.md` already used: replay `rippling_reach.schedule`
+  history against the proposed marginal-benefit rule, entirely offline, to see what N\* the rule
+  *would have* chosen per post, per stratum, against real historical ticks.
+  - **This has effectively already been done** in this evidence-gathering phase — `5-demand.md`
+    §1/§3/§5/§6 IS this dark-compute, just not yet expressed as a live-updating table. The
+    concrete next step is to turn those one-off SQL queries into the nightly batch job (§8).
+- Also dark-run the holdout logic: retroactively simulate "what if 5% of each tick's marginal
+  audience had been withheld" using existing `rippling_reach_notified` vs
+  `messages_likes.pageview` data, to sanity check the estimator code before it touches real
+  notification decisions.
+- **Exit criterion**: nightly job runs cleanly for 2 full weeks against historical data,
+  producing stable-looking `r_hat`/`N*` estimates per stratum that pass the guard-rail checks
+  (§6) without ever tripping them on real history.
+
+### Phase 1 — Scoped (real holdout traffic, single stratum, reversible)
+
+- Turn on the real 5% holdout (§1.2) for **one stratum only** — recommend starting with the
+  **densest decile** (the 15 inner/west London boroughs, `4-audience-curves.md` §3c) because
+  that is (a) where the complaint pressure is concentrated (`2-discourse.md`: 7 of 13 place-pair
+  complaints are Greater London), (b) has ample daily volume for fast holdout convergence
+  (3,652 posts/10 days, `4-audience-curves.md` §3d), and (c) is exactly the population where the
+  marginal-benefit rule is expected to bind (evidence: reply probability actively HALVES from
+  38.8%→21.8% as audience grows 1,700→13,000 within the densest tercile, `5-demand.md` §6 — the
+  strongest single result in the whole evidence base, meaning this stratum is where getting the
+  rule right matters most and where getting it wrong is most visible/costly).
+- Run via the existing `RIPPLE_WITHIN_GROUPS` experiment-scoping mechanism
+  (`1-mechanics.md` #3 — already built, currently unused), so this is fully reversible with a
+  config flip, no code path shared with the rest of the network.
+- **What to measure** (weekly review during this phase):
+  - Realized `N*` trajectory for the stratum — does it converge and stabilize, or oscillate?
+  - Reply probability, time-to-first-reply, Taken-rate for the scoped stratum vs a matched
+    control stratum (e.g. the next-densest decile, left on the unchanged fixed-30-min rule) —
+    is the marginal-benefit rule actually preserving/improving reply outcomes while cutting
+    audience, or just cutting audience?
+  - Mod sentiment for the scoped group(s) specifically — direct outreach (not just Discourse
+    monitoring) to the mods of the piloted boroughs, given `2-discourse.md`'s finding that
+    2 mods resigned and 2 more nearly did over this exact issue; this is a case where a
+    qualitative check matters as much as the quantitative one.
+  - Guard-rail trip rate (§6) — any anti-oscillation or explosion-detector trips during the
+    pilot are treated as a hard stop-and-investigate, not noise.
+- **Kill criteria** (any one triggers immediate rollback to fixed-30-min for the pilot
+  stratum): (a) Taken-rate for the pilot stratum drops >10% vs matched control over a
+  2-week window; (b) `N*` for any (stratum,tick) cell oscillates by >2x from one night to the
+  next more than twice in a rolling 4-week window (§6.1 should already prevent this
+  algorithmically, so a real occurrence indicates the guard itself is miscalibrated); (c) any
+  single explosion-detector trip (§6.2) that isn't explained by a genuine viral post; (d) mod
+  complaint volume for the piloted group(s) does not measurably improve within 6 weeks (this
+  is the actual product goal — if the data-derived rule doesn't reduce the "feels too large"
+  complaints in the group where it's most aggressively applied, the design has failed on its
+  own terms regardless of what the reply-rate numbers say).
+- **Duration**: minimum 6 weeks (long enough to clear the 14-day prior window twice over and
+  see whether the rule is stable, plus time for mod sentiment to actually shift and be
+  reported/observed).
+
+### Phase 2 — Network-wide
+
+- Only after Phase 1's exit criteria are clearly met. Roll stratum-by-stratum (densest → least
+  dense, since the effect is concentrated in dense strata per `4-audience-curves.md` — sparse
+  strata are largely unaffected by any N\* choice in the plausible range, so there is little
+  urgency or risk in extending to them, but they should still go through the same holdout
+  mechanism for the self-maintenance property to hold everywhere).
+- **What to measure ongoing** (permanent dashboard, not just rollout): per-stratum `N*`
+  trajectory over time (is it stable? trending?), guard-rail trip frequency, reply/Taken-rate
+  trend vs pre-rollout baseline, notification-cost-per-replier trend (should trend down or
+  flatten, per `5-demand.md` §5's overshoot-cost finding), mod-facing complaint volume
+  (Discourse + direct) as the ultimate product-level success metric.
+- **Kill criteria (network-wide)**: same categories as Phase 1, evaluated per-stratum — a
+  problem in one stratum triggers rollback of that stratum only (the `RIPPLE_WITHIN_GROUPS`
+  scoping mechanism makes per-stratum kill switches cheap), not a network-wide revert, unless
+  the guard-rails (§6) themselves are shown to be inadequate, in which case the master
+  `RIPPLE_EXTENT_ENABLED` flag reverts everyone to the flat 30-min ceiling (the existing,
+  known-safe fallback).
+
+---
+
+## 6. Anti-oscillation / runaway guards
+
+The two failure modes unique to a self-tuning system (that a fixed constant cannot have):
+
+### 6.1 Anti-oscillation
+
+**Risk**: a naive feedback loop can hunt — widen reach because yesterday's `r_hat` looked good,
+narrow it because the wider reach diluted per-notification conversion (exactly the pattern
+already observed in real data, `5-demand.md` §6: dense-tercile reply probability HALVES as
+audience grows — a naive loop could over-correct downward, then under-shoot, then correct back
+up, indefinitely.
+
+**Guards**:
+- **Rate-of-change cap**: `N*(stratum,tick)` may not change by more than ±20% from one night's
+  value to the next (a meta-parameter; 20% chosen as roughly the smallest step that still lets
+  the loop converge within the 6-week pilot window from a cold-start guess to the
+  `5-demand.md`-implied ~1,000-2,000 range, without single-night estimation noise causing a
+  visible swing in live reach from one day to the next — mods should never see reach jump
+  wildly day to day, §7 mod-facing stability).
+- **Smoothing**: the nightly estimate feeding the rate-of-change cap is itself an exponential
+  moving average (not the raw latest night's holdout result) — half-life matched to the
+  14-day prior window (§1.2.2), so a single noisy night cannot whipsaw the live value.
+- **Hysteresis on the stop decision itself**: within a single post's own tick progression
+  (§2, per-post per-tick step 2), the blend between prior and this-post's-own-signal is a
+  smoothed posterior update, not a hard threshold crossing — avoids a post flip-flopping
+  between "expand" and "stop" from tick to tick due to a single new reply arriving right at a
+  decision boundary.
+
+### 6.2 Runaway / explosion guards
+
+**Risk 1 — geometric runaway**: a bad `r_hat` estimate (data pipeline bug, adversarial gaming,
+genuine black-swan event) could push `N*` for a stratum far above sane bounds, effectively
+notifying far more people than intended.
+**Guard**: absolute ceiling meta-parameters independent of the estimation loop — `T_ceiling`
+(30min, unchanged) is never overridden by the marginal-benefit rule regardless of what `r_hat`
+says (§1.1, `CONTINUE` requires `drive_min[k] <= T_ceiling` as a hard AND, not something the
+benefit/cost ratio can override). This is the single most important guard: **the marginal-
+benefit rule can only ever narrow reach relative to today's ceiling-bound default, never widen
+it past 30 minutes.** This is a deliberate, conservative design choice for launch — it means
+the system literally cannot make the "feels too large" problem worse than it already is, only
+better, which matters enormously for a hostile mod audience (§7 cons: this also means the
+design cannot yet fix genuine UNDER-reach in sparse areas, a real limitation, stated honestly).
+
+**Risk 2 — the deliverability feedback trap** (flagged as unsolved in `1-mechanics.md` #10: high
+volume → spam-foldering → measured `r_hat` looks artificially low → system computes a bigger
+`N*` to compensate → even more volume → worse deliverability — a genuine positive-feedback
+failure mode specific to a self-tuning design). **Guard**: the explosion-detector checks
+*absolute* daily notification volume network-wide (and per major mail provider/domain where
+bounce/complaint data is available) against a trailing 7-day average; if volume is >X% above
+trend (X is a meta-parameter, suggest starting at 50%, the same order of magnitude as the
+existing self-tuning scaffold's ±50% "widen" band, `1-mechanics.md` #24), all `N*` updates
+freeze network-wide (not just the anomalous stratum, because deliverability degradation is a
+domain-level, not stratum-level, phenomenon) and an alert fires for human review. This does not
+fully solve the deliverability trap (a genuinely slow-building degradation under the 50%/day
+threshold could still occur) — flagged honestly as a residual risk requiring a separate,
+dedicated deliverability-metrics feed (bounce rate, spam-complaint rate) as a second guard input
+once that data is available; not solved by this design alone.
+
+**Risk 3 — gaming**: a moderator or member group could attempt to influence their own stratum's
+`r_hat` (e.g. coordinated fake replies to inflate apparent demand and win a bigger N\*, or
+conversely to shrink it). **Guard**: `r_hat` is estimated from the causal LIFT (treated vs
+holdout), not raw reply count — inflating raw replies without also inflating the *counterfactual*
+holdout replies does not move the lift estimate, because both groups would see the same
+coordinated activity. Residual risk (not fully closed by this design): a sufficiently
+sophisticated actor coordinating only within the "would be notified" group and not the holdout
+group could still bias things; treated as low-probability/low-impact for a reuse platform at
+Freegle's stakes level, not engineered against further at launch.
+
+---
+
+## 7. Mod-facing explanation
+
+Given the Discourse evidence (`2-discourse.md`: no moderator proposed a data-derived mechanism;
+every in-thread proposal was a manual dial; 2 mods resigned, 2 more nearly did, over exactly
+this issue), **stability and legibility of the explanation matter as much as the mechanism
+itself.** A mod who sees "the number changes every night for reasons I can't see" will trust
+this LESS than a fixed 30-minute rule, even if the adaptive rule objectively performs better.
+
+**What a mod sees, on their group's dashboard/settings page:**
+
+> **Your group's typical reach today: about [N] members, [T] minutes' drive.**
+> This isn't a fixed setting — it's calculated automatically from how people in your area
+> actually respond to posts, and re-checked every night. Denser areas reach fewer minutes
+> because there are more people per minute of drive-time; sparse areas reach further because
+> there are fewer. The system stops expanding a post's reach once, on average, sending it to
+> one more person stops meaningfully increasing replies or speeding up collection for people in
+> areas like yours.
+>
+> Over the last 4 weeks, your group's typical reach has [gone up / stayed about the same / come
+> down] by about [X]%. [If flagged as an outlier: This is noticeably [wider/narrower] than
+> similar-sized areas — we're keeping an eye on it.]
+>
+> This never reaches further than a 30-minute drive, and always stops once a post already has
+> 5 people interested.
+
+**Design intent behind this exact wording** (traced to evidence):
+
+- **"calculated automatically... re-checked every night"** — pre-empts the "why is this
+  different from last month" question before it's asked; directly answers the self-maintenance
+  property (§4) in plain language.
+- **"denser areas reach fewer minutes... sparse areas reach further"** — states the actual
+  mechanism (audience-based, not distance-based) in the vocabulary a mod already uses
+  (minutes of drive-time is what they see today), rather than introducing new jargon like "N\*"
+  or "marginal benefit" — matches `2-discourse.md`'s finding that mods think and complain in
+  terms of minutes and place-names (Chilterns, Islington), not statistics.
+- **"stops... once sending it to one more person stops meaningfully increasing replies or
+  speeding up collection"** — states the actual decision rule in a sentence a non-technical mod
+  can verify against their own experience, rather than hiding it as an opaque "the algorithm
+  decided." This is a deliberate choice to be MORE explainable than the current system (which
+  has no explanation at all beyond "30 minutes, always") — turning the adaptive design's
+  complexity into a selling point ("smarter, not just fixed") rather than a liability
+  ("mysterious black box"), which only works if the explanation is genuinely this concrete.
+- **"over the last 4 weeks... gone up/down by X%"** — gives the mod a trend they can sanity
+  check against their own sense of the group, and — critically — makes drift *visible* rather
+  than silent, which is the antidote to "why did this change without telling me" complaints.
+- **The two hard-ceiling sentences at the end** ("never reaches further than 30 minutes",
+  "always stops once 5 people interested") — deliberately restates the backstops (§1.6) in
+  plain language, because these are the guarantees that make the system feel bounded and safe
+  to a mod who does not trust "the algorithm decided" on its own — this directly answers
+  `2-discourse.md`'s core finding that trust, not just outcomes, is what's at stake.
+
+**What is deliberately NOT shown to mods**: the internal `r_hat`, `θ`, per-tick marginal
+benefit/cost numbers, or the holdout mechanism's existence. `2-discourse.md`'s evidence
+(30 vocal participants, self-selected, technical sophistication varies widely) argues strongly
+for a plain-language summary over a dashboard of statistics — a mod who wants more detail can
+be pointed to a (separate, opt-in) "how reach is calculated" explainer page, but the default
+view should be the four sentences above, no more.
+
+---
+
+## 8. Implementation sketch (what changes where — no code)
+
+This section names the concrete surfaces; it does not write code, per the design-only
+instruction.
+
+1. **`iznik-batch/app/Services/Ripple/RippleTuneService.php`**: complete the stubbed
+   `categoryVolumeDeltas()` (currently returns `[]` unconditionally, `1-mechanics.md` #24) to
+   instead compute, per stratum (§1.3, deciles of yesterday's tick-1 `cumulative_users`, not
+   the current `ons_category` — this is a change to the stratification key, see below), the
+   holdout-vs-treated lift `r_hat` and the speed-benefit `Δ(1/ttfr)`, replacing the current
+   flat ±10%/+50% volume-delta-band logic entirely (that logic answers a different, weaker
+   question — "did volume change" — not "did the marginal value of an extra notification
+   change").
+2. **New holdout-assignment step in `ExpandService::advanceDue` / `initialiseNew`**: for each
+   tick's marginal audience, randomly split by `p_holdout` before calling
+   `mailNewlyReachedForPost` — held-out members still get the `messages_groups`/polygon
+   inclusion (so they can browse-find the post) but are excluded from
+   `rippling_reach_notified` writes for that tick specifically (needs a new column or a
+   companion table, e.g. `rippling_reach_holdout(msgid, userid, tick)`, to record who was
+   held out for later cohort comparison — this is the one schema addition this design
+   requires beyond what already exists).
+3. **`rippling_params` table (`1-mechanics.md` #24, migration `2026_06_18_000010`)**:
+   repurpose its `ons_category` column's role to hold the post-audience-decile stratum key
+   instead of (or alongside) ONS RU-class — needs either a migration to add a `density_decile`
+   column or a redefinition of what's written to the existing key. This table already has the
+   right shape (`curve`, `max_minutes`, `target_density`, `hazard_schedule` per category) —
+   this design adds `r_hat`, `V_shape` (or its two components), and reads `target_users` from
+   it as the per-(stratum,tick) `N*` rather than the flat config constant.
+4. **`ReachService::scheduleParams()`**: currently conditionally sends `target_users` only when
+   `RIPPLE_EXTENT_ENABLED=true`, sourced from the flat config constant
+   (`1-mechanics.md` #15). Change the source to a lookup against the (now-populated)
+   `rippling_params` table keyed by the post's own predicted stratum (needs a fast, cheap
+   proxy at *initialiseNew* time, before tick-1 audience is known — recommend using the
+   group's own trailing-30-day median `total_freeglers` as the stratum-assignment proxy for
+   tick 1 specifically, since the true stratum key requires tick-1 data that doesn't exist yet
+   at decision time — a chicken-and-egg resolved by "yesterday's typical audience for this
+   group" as the entry-point proxy, refined by the post's own realized tick-1 number for all
+   subsequent ticks, consistent with §2's per-post per-tick blending).
+5. **`iznik-routing-go/ripple.go` `effectiveScheduleTotal()`**: already accepts a
+   `target_users` parameter end-to-end and is unit-tested (`ripple_extent_test.go`,
+   `1-mechanics.md` #14) — **no change needed here**, this is the part of the MVP plumbing this
+   design adopts as-is.
+6. **`routes/console.php`**: schedule `ripple:tune` (currently explicitly commented-out /
+   unscheduled, `1-mechanics.md` #24) to run nightly, after the completion of item 1 above.
+7. **`messages_likes.source` producer gap** (`1-mechanics.md` §5.1 — schema exists, nothing
+   writes `?src=ripple_notify`): needs fixing for clean channel-attributed eyeball data,
+   feeding the speed-benefit (`Δ(1/ttfr)`) estimate cleanly — currently `ttfr` can be computed
+   from `chat_messages` timestamps without this (used in `5-demand.md` §3 already), so this is
+   not a hard blocker for launch, but should be fixed to make the eyeball-vs-reply distinction
+   available for a future refinement of `V` (an explicit "later" item, not required for v1).
+8. **New: guard-rail service** (rate-of-change cap §6.1, explosion-detector §6.2) — a genuinely
+   new component, no existing scaffold to build on; should sit alongside `RippleTuneService`
+   as the gatekeeper between "nightly-computed new estimates" and "live-served
+   `rippling_params` values" (i.e. compute-then-validate-then-promote, not compute-and-write
+   directly).
+9. **Mod-facing dashboard copy** (§7): a new, small UI surface (ModTools group settings or
+   sysadmin/reach page — the existing rippling killswitch/sysadmin page per memory
+   `project_rippling_killswitch_and_sysadmin_page.md` is a natural home) showing the four
+   sentences plus the trend percentage; reads from `rippling_live_metrics` (`1-mechanics.md`
+   #24 — already exists, currently dormant, would become live under this design).
+
+---
+
+## 9. Honest cons — where this philosophy is weakest
+
+1. **`θ=1` is asserted, not derived — and this is the single weakest point in the whole
+   design.** The rule says "stop when marginal benefit no longer exceeds marginal cost," which
+   sounds principled, but `V` and `C` are meta-parameters chosen partly by back-solving to match
+   the observed data (§1.5) — there is a real risk of circularity (choosing `C` so the rule
+   produces the answer `5-demand.md` already suggested, then presenting that as "derived").
+   Being honest about this: the *shape* of the marginal-benefit curve is genuinely derived from
+   data (the flat-then-declining reply curve, the speed curve); the *operating point* on that
+   curve (exactly where θ crosses 1) is a value judgement dressed in the same units as the data,
+   not itself free of human choice. A hostile reading of this design is "you've just moved the
+   arbitrary constant from N\*=4000 to θ=1 plus two weight parameters" — which is not entirely
+   wrong. The genuine improvement is that θ/weights are far fewer, far more stable, and far more
+   *reusable across strata* than a per-area N\* would be — but it is not constant-free, it is
+   constant-minimized and constant-relocated to a place where the constants are meta-level
+   (apply everywhere, rarely revisited) rather than per-area (apply differently everywhere, must
+   be revisited per area).
+2. **Complexity is a real cost against a hostile/technical-skeptic mod audience.**
+   `2-discourse.md` shows the actual moderator population is not statistically sophisticated and
+   already distrusts "the algorithm decided" framing generally (multiple posts about auto-join
+   clutter and loss of local control, beyond just reach). A system whose actual mechanism is "a
+   nightly empirical-Bayes shrinkage estimator computing a causal lift from a live experimental
+   holdout" is genuinely harder to explain honestly than "we picked 2,000 members based on where
+   your city's density puts it" (Design 2/3's likely framing, by comparison). §7's mod-facing
+   copy is an attempt to bridge this, but there is real risk the plain-language version reads as
+   evasive ("just tell me the number") to exactly the skeptical audience this needs to win over.
+3. **The permanent holdout has a real, ongoing cost that a static rule does not.** Every post,
+   forever, has some members deliberately not notified who otherwise would be, in the name of
+   calibration. This is a genuine tradeoff (lower expected reply-conversion in aggregate, in
+   exchange for a system that stays correct over time) that a fixed-constant design does not
+   pay. At 5% holdout this is likely small in absolute terms, but it is non-zero and permanent,
+   and it means a small number of real transactions are, by design, made slightly less likely
+   to happen (a held-out member who would have replied to a direct notification, but doesn't
+   browse-find the post organically) purely for the system's own benefit. This is an ethically
+   non-trivial tradeoff to make permanently rather than for a bounded 3-week experiment, and
+   deserves explicit sign-off (tied to the still-open GDPR/LIA item, `1-mechanics.md` #29) that
+   goes beyond the original one-off experiment's likely approval scope.
+4. **Feed-forward dominance limits how "adaptive" tick-1 actually is.** Because ~70% of the
+   audience is committed at tick 1, ~1h post-arrival, before any of THIS post's own signal
+   exists (§1.2.2), the headline claim "reach adapts per-post" is materially weaker than it
+   sounds for the majority of the committed audience — the dominant lever is still a
+   feed-forward, stratum-level prior updated once a day, not a live per-post read of what's
+   actually happening. A skeptical reviewer could fairly say "most of the adaptivity you're
+   claiming is actually just a slower-refreshing, better-derived constant" — which is true, and
+   should be stated plainly rather than oversold. The genuinely live, closed-loop part of this
+   design only really governs the trailing 30% of the audience (ticks 2-9), which is smaller in
+   volume but is exactly the part most amenable to true per-post adaptation.
+5. **Cold-start shrinkage means genuinely-different-from-network-average areas take time to be
+   recognized as such.** A real, unusual area (say, a group with an atypically high genuine
+   demand-per-member ratio for structural reasons — a retirement community with unusually high
+   engagement, say) will initially be shrunk toward the network average and only slowly
+   specialize as its own data accrues — meaning this design is systematically slower to serve
+   genuinely-unusual-but-legitimate areas well than a human who could simply notice "this place
+   is different" immediately. This is the standard bias-variance cost of shrinkage estimation,
+   inherited deliberately (§3, cold start) but worth stating as a real, not hypothetical, cost.
+6. **Operational fragility**: this design has materially more moving parts than a constant
+   (nightly batch job, holdout routing, guard-rail service, a new schema table's worth of
+   holdout bookkeeping) — more surface area for the exact kind of silent data-quality failure
+   already observed once in this evidence base (`5-demand.md` §0, the 56%-of-rows backfill
+   contamination). A bug in the nightly job that goes unnoticed for a week is a materially worse
+   failure mode than a wrong constant sitting in a config file, because it is less visible and
+   harder to reason about after the fact. The guard-rails (§6) mitigate but do not eliminate
+   this; ongoing operational vigilance is a real, continuing cost this design incurs that a
+   fixed-constant design (Designs 1-3, presumably) does not.

--- a/plans/2026-07-02-reach-design-evidence/J1-judge.md
+++ b/plans/2026-07-02-reach-design-evidence/J1-judge.md
@@ -1,0 +1,133 @@
+# Judge 1 — Product & Moderator-Trust Lens
+
+Scoring the four rippling-reach designs (D1 audience-target, D2 behavioural-percentile,
+D3 community-relative, D4 adaptive-control) against the fixed criteria, read through the lens of:
+**would a real, skeptical, already-burned Freegle moderator population trust this, would it visibly
+fix the complaint they raised, and does it survive contact with the actual Discourse thread?**
+
+Grounding fact that dominates this lens (from `2-discourse.md`, confirmed by direct re-read): **no
+moderator proposed a data-derived/self-calibrating mechanism.** Every in-thread ask was either a
+manual dial (rejected per-group slider, shipped per-member slider, requested per-post flag `#397`) or
+a timing tweak. Two experienced moderators resigned mid-thread over rippling; two more seriously
+considered it; the Board Chair personally intervened repeatedly. The evidence base explicitly warns:
+"a fully-automatic invisible parameter, however well-derived, risks re-triggering the 'we're not being
+listened to / not in control' complaint... unless it comes with a visible, explainable 'why this
+number' artifact per area." That sentence is close to the whole ballgame for this lens.
+
+---
+
+## Scoring matrix (1-10 per criterion)
+
+| # | Criterion | D1 Audience-target | D2 Behavioural-percentile | D3 Community-relative | D4 Adaptive-control |
+|---|---|---|---|---|---|
+| C1 | Fixes dense-area complaint | 8 | 8 | 7 | 8 |
+| C2 | Preserves rural utility | 9 | 8 | 9 | 8 |
+| C3 | Principled derivation | 8 | 7 | 6 | 5 |
+| C4 | Explainability & mod trust | 7 | 8 | 9 | 4 |
+| C5 | Self-maintenance | 7 | 7 | 8 | 8 |
+| C6 | Robustness (edge cases) | 6 | 6 | 6 | 7 |
+| C7 | Buildability & fit | 9 | 7 | 8 | 5 |
+| C8 | Scientific honesty | 9 | 9 | 8 | 8 |
+| | **Total (/80)** | **63** | **60** | **61** | **53** |
+
+### Rationale, one sentence each
+
+**C1 — Fixes the dense-area complaint**
+- D1 (8): Tower Hamlets self-gates from 13,336→~3,469 audience and inner-London N* caps at 4,000 vs today's 12,500+, a direct ~3x cut matching #248/#250 verbatim.
+- D2 (8): Worked examples show TowerHamlets/inner-London ~30min→~15min, roughly halving the ceiling and directly answering "an hour's drive each way."
+- D3 (7): Only the ring-formulation (not the brief's own α×span formula, which the design admits fails to bind) gets inner-London to ~15-18min — real but the design's own honesty that the literal assigned rule doesn't work costs a point of confidence.
+- D4 (8): Densest decile is explicitly targeted first and the marginal-benefit rule mechanically produces the same ~1,000-2,000-member outcome as D1, so the numeric fix is comparable.
+
+**C2 — Preserves rural utility**
+- D1 (9): Provably inert for Hull/Swindon/Ribble Valley since they never reach even N*=1,000-2,000 — floor/ceiling-bound exactly as today, by construction.
+- D2 (8): Sparse bands stay near 28-30min in worked examples, correctly un-penalised, though the P90-of-censored-data mechanism could in principle tighten a thin rural band via noise before the guardrail catches it.
+- D3 (9): Ring formulation gives rural groups long unions of large sparse neighbours, clamping at 30min identically to today, and is the only design with literally zero dependency on post/reply history so it cannot mis-fire on thin rural data.
+- D4 (8): Sparse strata are explicitly shown to be "almost always keep going to T_ceiling" under the marginal-cost rule, matching today, but this rests on an estimated (not geometric) property so carries slightly more tail risk than D1/D3.
+
+**C3 — Principled derivation (no arbitrary constants)**
+- D1 (8): k=1.0 is triangulated from three independent evidence lines with the strongest single result in the whole base (within-tercile reply peak, confound explicitly ruled out) as primary; honestly flags k rests on only two clean data points.
+- D2 (7): P90 is explicitly conceded to be "a defensible convention, not a provably optimal cutoff" since decay is smooth with no elbow — principled procedure, arbitrary percentile choice, and the design says so.
+- D3 (6): α=2.0 is evidence-triangulated but the design's own worked examples prove the literal brief formula doesn't work in the complaint geography, forcing a pivot to a different (ring) rule not directly derived from the same α-evidence — a real derivation gap, honestly flagged as "designer improvisation" risk.
+- D4 (5): θ=1 and the V-weights are conceded in the design's own strongest self-critique to be "back-solved to roughly reproduce the answer the evidence already suggested" — the most honest design about this, but also the one with the least defensible claim to eliminating arbitrary constants, only relocating them.
+
+**C4 — Explainability & mod trust (survives the flame-war audience)**
+- D1 (7): "Equal audience, not equal time" is a clean one-sentence pitch and directly rebuts the Swindon-vs-Islington framing, but a raw people-count is one level more abstract than what mods actually said in the thread (which was almost entirely in minutes and place-names).
+- D2 (8): Anchored on "9 in 10 of the collections that already happen here" — the mod's own transaction history, which the Discourse evidence itself says mods respond to best ("concrete, locally-verifiable claims") — and stays in minutes, the vocabulary mods actually used.
+- D3 (9): Uses the mods' own vocabulary almost verbatim (Jax's "near me first," Group-Mod-J's "over the water," Jos's "crosses the river") and — uniquely among the four — the parameter and the mod-facing catchment-map number become the literal same computed value via backlog #21/#22, closing the explainability requirement by construction, not by copy-writing.
+- D4 (4): This is the design's own admitted Achilles heel against exactly this lens — nightly empirical-Bayes shrinkage over a permanent causal holdout is genuinely hard to explain honestly to a self-declared non-technical population that already distrusts "algorithm decided" framing, and the mod-facing copy deliberately hides the internals, which risks reading as evasive to the exact skeptical audience that produced two resignations.
+
+**C5 — Self-maintenance (stays correct as behaviour/actives drift)**
+- D1 (7): Quarterly re-fit of k per density band is specified and reactivates the dead RippleTuneService scaffold, but a quarterly cadence is slow relative to D4's nightly loop and the design flags its own circularity/deliverability-feedback risk as unresolved.
+- D2 (7): Monthly recompute with a live 15%-tightening clamp and collection-catch backtest is a genuinely mechanical anti-drift design, though it inherits a "does the backtest itself degrade as tightening continues" second-order weakness the design names honestly.
+- D3 (8): Because span/adjacency are re-derived geometric facts (road graph + polygon), not fitted statistics, "is it still correct" reduces to "is the map still accurate" — a genuinely easier and more robust self-maintenance question than a calibrated demand curve, its strongest property.
+- D4 (8): Nightly re-estimation with shrinkage is the fastest-reacting and most literally "continuously correct" of the four by design intent, but the added operational surface (holdout routing, guard-rail service) is itself a new thing that can silently drift or break, which the design admits is a real, not hypothetical, risk (citing the 56%-backfill-contamination precedent against itself).
+
+**C6 — Robustness (coastal, tiny groups, overlaps, gaming, cold start, TN)**
+- D1 (6): Handles coastal/seasonal well structurally, but is explicitly gameable via active-member inflation (mitigated only slowly via re-fit) and has a genuinely unresolved TrashNothing gap the design itself flags as unmeasured.
+- D2 (6): Coastal handled correctly (drive-time primitive), gerrymandering essentially un-gameable (disc-based density), but cold-start relies on an external DfT anchor with no Freegle-specific local signal and the design's own P90-of-censored-data is structurally the most exposed to the central chicken-and-egg failure mode of any design.
+- D3 (6): Cold-start is this design's best property (zero dependency on post history, works day one for a brand-new Highlands group) and coastal is mitigated by construction via routing-graph use, but the α-formulation is honestly conceded gameable by boundary-redrawing, and adjacency-graph maintenance is flagged as more operationally fragile than a global constant.
+- D4 (7): Stratifying on post-level realized audience (not group polygon) sidesteps both the coastal-boundary artefact and gerrymandering more cleanly than any other design, and empirical-Bayes shrinkage is a textbook-correct cold-start answer, but this is also the design with by far the most moving parts (nightly batch, holdout bookkeeping, guard-rail service) so has more distinct places to silently fail.
+
+**C7 — Buildability & fit (leverages existing schedule/governor MVP/experiment; realistic increment)**
+- D1 (9): Is explicitly "adopt and complete" the already-coded, already-unit-tested Stage-A extent governor — the smallest realistic increment of the four, reusing `cumulative_users` in `rippling_reach.schedule` with zero schema change and reactivating the dead RippleTuneService scaffold for real work.
+- D2 (7): Extends the existing drive-time isochoring mechanism cleanly (only the ceiling constant becomes banded) and reuses RIPPLE_WITHIN_GROUPS, but needs a new density-disc computation pipeline and a new monthly backtest job not currently scaffolded anywhere.
+- D3 (8): Needs zero schema change (`max_minutes` is already a per-request parameter) and reuses the exact polyindex-intersection primitive ExpandService already computes for cross-posting, but has a real hard dependency on an unbuilt UI primitive (#21/#22 widest-span) for its cheapest implementation path.
+- D4 (5): Most ambitious increment by far — one new schema table, a new guard-rail gatekeeper service, permanent holdout-routing logic layered into `ExpandService`, and turns a scoped 3-week experiment into permanent infrastructure with an unresolved GDPR/LIA question — realistic only as a second-generation project, not a next ship.
+
+**C8 — Scientific honesty (handles exposure-censoring/chicken-and-egg credibly)**
+- D1 (9): Explicitly rules out the exposure confound via within-density-tercile stratification (the strongest result in the evidence base) rather than assuming it away, and separately names the deliverability-feedback-loop risk as unsolved and inherited, not hidden.
+- D2 (9): This is D2's entire structural centerpiece — pre-rippling baseline as primary input specifically because it's less censored, explicit floor-not-ceiling framing in both internal docs and mod copy, a mechanical 15%-clamp + backtest guardrail against the tightening spiral, and a named full-swap-in plan once the reach experiment reports; arguably the most mechanically rigorous treatment of the censoring problem of the four.
+- D3 (8): Names the same "floor not ceiling" caveat and defers to the reach experiment for re-validation rather than re-derivation, and is honest that its own literal brief-formula doesn't work — but as a purely geometric design it has comparatively less to be honest about on the censoring axis specifically, since geometry isn't itself censored the way behaviour data is.
+- D4 (8): Names its own chicken-and-egg problem sharply (θ=1 "back-solved," a hostile reviewer could fairly say "you've just hidden the slider inside an algorithm") and the causal-holdout mechanism is the only one of the four that structurally, not just retrospectively, de-censors demand by design — but this honesty is undercut by the sheer number of meta-parameters doing quiet work.
+
+---
+
+## Recommendation
+
+**Ship D1 (Audience Normalization).**
+
+Through the product-and-moderator-trust lens specifically, D1 wins not because it is the most
+sophisticated (D4 is) or the most rhetorically native to the mods' own words (D3 is), but because it
+is the design most likely to actually **ship and hold** against this specific, already-wounded
+moderator population: it completes machinery that is already coded, tested, and dark rather than
+proposing new operational surface area at exactly the moment two moderators have already resigned and
+trust in "the algorithm decided" is at its lowest; its one-sentence pitch ("equal audience, not equal
+time") is a direct, falsifiable rebuttal to the single most-quoted complaint in the thread (#248,
+Swindon-vs-Islington); and unlike D4 it does not ask the org to explain a permanent experimental
+holdout or a shrinkage estimator to a population the evidence base itself says is not statistically
+sophisticated and already suspicious of invisible automation. D2 is a very close second on pure
+scientific rigor (its censoring-handling is arguably the best-engineered of the four) and D3 is the
+single most emotionally resonant with the actual words mods used — but D1's combination of minimal
+build risk, the strongest single evidence result in the whole base as its primary derivation, and a
+mod-facing story that pre-empts both live objection classes ("why does distance differ" and "why can't
+I set my own number") makes it the safest bet to actually survive a second Discourse thread.
+
+The decisive product-trust risk this recommendation must carry forward explicitly: the evidence base
+states flatly that **no moderator asked for a data-derived mechanism at all** — they want a visible
+dial. D1's rollout must therefore not stop at "the number is derived" copy; it needs the same kind of
+visible, per-group "why this number" artifact D3 gets for free from the catchment-map UI (backlog
+#21/#22). That is precisely the graft below.
+
+## Grafts — one must-have idea from each losing design, into D1
+
+- **From D2**: adopt the **collection-catch backtest guardrail** (before shrinking any group's N* at
+  a quarterly re-fit, mechanically verify the proposed new value would still have captured ≥90% of
+  that group's actual recent collections) — D1's quarterly re-fit currently only checks reply-rate
+  drift, and D2's concrete, computed anti-tightening-spiral check is a stronger, more auditable
+  guardrail against the same circularity risk D1 admits it inherits from the MVP plan.
+
+- **From D3**: **surface N* and the resulting drive-time on the same moderator catchment-map UI
+  already in the backlog (#21/#22)**, so "why did my group's reach change" is answered by a picture
+  the mod can see and verify against their own area, not just an in-product sentence — this is D3's
+  single strongest property (one number, shown in two places, always consistent) and directly
+  addresses the Discourse evidence's core warning that an invisible, well-derived parameter still
+  risks the "we're not being listened to" complaint unless paired with a visible artifact.
+
+- **From D4**: adopt the **feed-forward/closed-loop split as an explicit design acknowledgment**, not
+  necessarily the full permanent-holdout machinery — D1 should state plainly (as D4 does) that ~70% of
+  audience is committed by tick 1 on a periodically-refreshed prior (quarterly k), and only frame the
+  remaining ticks as responsive to a specific post's own early signal if/when D1 is extended to do so;
+  this prevents D1's mod-facing copy from overclaiming real-time responsiveness it doesn't actually
+  have, which is exactly the kind of gap a technically literate hostile reviewer (the same population
+  that already caught the "45 min" figure being aspirational-not-live) would find and use to undermine
+  trust in the "re-measured every three months" framing.

--- a/plans/2026-07-02-reach-design-evidence/J2-judge.md
+++ b/plans/2026-07-02-reach-design-evidence/J2-judge.md
@@ -1,0 +1,349 @@
+# Judge 2 — Statistical Validity & Causal Inference Review
+
+Lens: is the derivation of the tuning parameter actually supported by the evidence claimed for
+it — sample sizes, confounding, censoring/selection bias, identification strategy, stability of
+estimates, and honesty about uncertainty? I am not scoring "is this a good product idea" in the
+abstract; I am scoring whether the *statistical reasoning underneath each rule* would survive a
+methods review.
+
+Reviewed in full: D1-audience-target.md, D2-behavioural-percentile.md, D3-community-relative.md,
+D4-adaptive-control.md, plus the demand (5-demand.md §6 in particular — the within-density-tercile
+table), behaviour (3-behaviour.md), audience-curves (4-audience-curves.md) and mechanics
+(1-mechanics.md) evidence files.
+
+---
+
+## Scoring matrix (1-10, higher = better)
+
+| Criterion | D1 Audience-target | D2 Behavioural-percentile | D3 Community-relative | D4 Adaptive-control |
+|---|---|---|---|---|
+| C1 Fixes dense-area complaint | 8 | 8 | 7 (only under the ring reformulation, not the assigned α-rule) | 8 |
+| C2 Preserves rural utility | 9 | 8 | 9 | 8 |
+| C3 Principled derivation | 8 | 6 | 4 | 5 |
+| C4 Explainability & mod trust | 8 | 7 | 8 | 5 |
+| C5 Self-maintenance | 6 | 6 | 7 | 7 |
+| C6 Robustness (edge cases) | 7 | 6 | 6 | 7 |
+| C7 Buildability & fit | 9 | 7 | 6 | 6 |
+| C8 Scientific honesty (censoring/chicken-egg) | 8 | 9 | 5 | 8 |
+| **Total (/80)** | **63** | **57** | **52** | **54** |
+
+---
+
+## Per-criterion rationale
+
+### C1 — Fixes the dense-area complaint
+
+- **D1 (8).** N* proportional to home group's active members, capped 1,000-4,000, directly binds
+  Tower Hamlets/inner-London (audience-curves shows these groups already at 11,000-15,000 —
+  clipping to 4,000 is a real ~3x cut) and is demonstrated inert exactly where it should be
+  (Hull/Swindon never reach even N*=2,000). The worked-example numbers are read off real
+  `rippling_reach.schedule` interpolation, not invented.
+- **D2 (8).** Density-banded P90 collapses TowerHamlets from 30min to an estimated ~15min in the
+  worked table — a real, large, defensible move. Docked slightly because the worked-example
+  drive-times are explicitly flagged as haversine-derived placeholders, not real routing output —
+  the actual magnitude of the fix is unverified pending real `iznik-routing-go` numbers.
+- **D3 (7).** The document itself proves, with real area data, that the *literal assigned rule*
+  (α × own span) does **not** bind in the complaint geography — every London borough clamps at 30
+  min regardless. The design only fixes the complaint after silently substituting a different rule
+  (adjacent-ring). That substitute rule does work (~15-18 min for inner London), so the *design as
+  actually shipped* scores well, but a design that has to abandon its assigned formulation to
+  produce a result is a genuine mark against "does the rule as specified solve the problem."
+- **D4 (8).** The marginal-benefit stopping rule is calibrated directly against the single
+  strongest empirical result in the whole evidence base (dense-tercile P(≥1 reply) halving from
+  38.8%→21.8% as audience 1,700→13,000) — this predicts a real, large tightening for exactly the
+  complaint population, and the densest-decile-first rollout targets it directly.
+
+### C2 — Preserves rural utility
+
+- **D1 (9).** N* scales with the home group's own active-member count and floors at 1,000; Hull/
+  Swindon/Ribble Valley never cross even the floor's implied audience before hitting T_max=30, so
+  they are provably untouched — this is shown with real data (audience-curves §3), not asserted.
+- **D2 (8).** Density-band P90 for sparse bands lands near 28-30 min in the worked table — correctly
+  near-unchanged — but because the underlying P90 estimate for very-low-n groups (Ribble Valley,
+  n=3) is explicitly "not estimable with confidence," the sparse-band number rests more on the
+  cold-start fallback (DfT 20min anchor) than on a genuine local percentile, which is a slightly
+  weaker guarantee of "never starved" than D1's structural floor-and-ceiling logic.
+- **D3 (9).** Purely geometric and immune to sample-size problems — a sparse group's ring/span is
+  always computable from the road graph on day one, so there's no statistical risk of a data-thin
+  estimate for rural rides at all. Strongest of the four on this specific point, methodologically
+  (no minimum-n gate is even needed).
+- **D4 (8).** Rural strata are shown to be "backstop-bound" (T_ceiling governs, not the
+  marginal-benefit rule) because at low absolute audience the marginal cost stays low too — a
+  reasonable qualitative argument, but this is asserted rather than derived from a rural-specific
+  worked calculation the way D1's Hull/Swindon table is.
+
+### C3 — Principled derivation (no arbitrary constants; every number traces to evidence)
+
+- **D1 (8).** The strongest triangulation of the four: k=1.0 is read directly off the
+  within-density-tercile peak (5-demand.md §6), independently cross-checked against the
+  behaviour report's coverage curves and the reply-saturation-stop-derived outer ceiling. Genuinely
+  three different evidence sources, two of them causally cleaner than anything the other designs
+  cite (see C8). Docked because the design itself is candid that k=1.0 rests on only two observed
+  tercile peaks (medium, dense) — sparse never shows a decline in range — so the fit, while
+  triangulated, is thin at the edges.
+- **D2 (6).** P90 is defended as a "standard convention" (retail-geography, "cover the overwhelming
+  majority") rather than a value that falls out of a model fit to data the way D1's k does. The
+  design is explicit and honest about this ("not a provably optimal cutoff... smooth decay, no
+  elbow") — good scientific honesty, but that same honesty is an admission the *derivation* itself
+  is weaker: P90 vs P85 vs P95 is not distinguished by any statistical argument in the evidence, it
+  is a convention borrowed from an unrelated industry (retail catchment areas) applied by analogy.
+- **D3 (4).** Lowest here, for a specific, well-documented reason: the assigned philosophy's formula
+  (α × span) is evidence-triangulated to α≈2.0 from three sources, but the design's own worked
+  examples then show that formula produces the *wrong answer* (no tightening anywhere in the
+  complaint geography) — so the design abandons it for a topologically different, zero-parameter
+  rule (adjacent-ring). The ring rule is elegant and honestly presented as "1 ring, no tuning," but
+  "exactly 1 ring, not 0.5 or 1.5" is itself an unederived, purely judgment-based choice that the
+  document admits ("a genuinely hostile critic could reasonably ask..."). A design that had to
+  discard its own core evidence-derived constant to work is weaker on this criterion than one
+  whose central constant survives its own worked examples.
+- **D4 (5).** The most self-aware about this weakness of any document (§9.1 leads with it): θ=1 and
+  the V-weights are "back-solved to roughly reproduce the answer the evidence already suggested"
+  — i.e. the design explicitly concedes the meta-parameters were reverse-engineered to hit
+  ~1,000-2,000, the same number D1 derives forward from the tercile peak. This is honest, but
+  honesty about circularity doesn't earn back the statistical-validity points the circularity
+  costs. The *r_hat causal-lift* piece (§1.2, ADD holdout design) is genuinely principled and the
+  best piece of causal-inference thinking in any of the four documents (see C8) — but it estimates
+  the wrong-side-of-the-equation quantity (marginal benefit of one more notification) while the
+  actual stopping point (θ, V, C) remains asserted, so the "principled" label applies to the
+  *measurement machinery*, not to the *decision rule* it feeds.
+
+### C4 — Explainability & mod trust
+
+- **D1 (8).** "Equal audience, not equal time" is a genuinely one-sentence, testable, falsifiable
+  claim a mod can hold Freegle to, and it directly rebuts both classes of hostile Discourse
+  objection (unequal audience for equal time; "why can't I set my own number"). Mod copy is
+  concrete and specific.
+- **D2 (7).** "Covers 9 in 10 of the collections that already happen here" is concrete and
+  locally-verifiable (a mod can, in principle, check this against their own group's history) —
+  Discourse evidence says this style of claim lands best with this specific audience. Docked
+  slightly relative to D1 because "P90 of collections" is a subtler statistical concept for a
+  non-technical mod to sanity-check than "roughly as many active members as your own group has."
+- **D3 (8).** The ring formulation ("reach = one community over") is the most intuitively graspable
+  of any of the four rules — it maps directly onto mod vocabulary already seen in Discourse
+  ("over the water," "crosses the river"), and ties to the same widest-span number the catchment UI
+  will show, so mod-facing copy and computed value are provably the same fact. High mark despite
+  the C3 weakness — explainability and derivation-purity are different axes, and D3 is strongest on
+  the former precisely because it gave up statistical purity for topological simplicity.
+- **D4 (5).** The document itself flags this as a serious risk: "a nightly empirical-Bayes
+  shrinkage estimator computing a causal lift from a live experimental holdout" is much harder to
+  explain honestly than a fixed number tied to local density, and the Discourse evidence shows this
+  specific mod population already distrusts "algorithm decided" framing. The mod-facing copy
+  (§7) is a reasonable mitigation but explicitly hides the actual mechanism (r_hat, θ, holdout) from
+  mods — meaning the "explanation" a mod gets is a plausible-sounding gloss over a system whose real
+  logic is not what's described, which is a genuine trust risk if a technically-minded mod digs in
+  (as several Discourse participants clearly are capable of doing).
+
+### C5 — Self-maintenance (stays correct as behaviour/actives drift, without hand-tuning)
+
+- **D1 (6).** `active_members` itself updates live (good), but k, N*_min, N*_max only refresh on a
+  quarterly re-fit cadence — reasonable, but slower than D2/D4's monthly/nightly cadence, and the
+  design's own honest-cons section flags the circularity risk (rippling itself changes membership,
+  which changes the input the re-fit uses) as "bounded but real."
+- **D2 (6).** Monthly recompute with an explicit anti-spiral guardrail (15%/period clamp +
+  collection-catch backtest) is a genuinely well-specified self-maintenance mechanism — mechanically
+  concrete, not just "we'll re-run it." Docked because the design is explicit that its core
+  calibration data (post-rippling collections) is structurally self-referential with the very cap
+  it's setting, and the "fix" (swap in experiment data once available) is a one-time correction, not
+  an ongoing solution to the circularity.
+- **D3 (7).** The strongest "doesn't go stale" story of the four, for a genuinely different reason
+  than the others: because span/adjacency are geometric facts re-derived from the road graph and
+  group boundaries, not fitted statistics, "is it still correct" reduces to "is the map still
+  accurate" — a much easier operational question with no sampling-noise dimension at all. The
+  trade-off (named honestly in the doc) is that it therefore cannot track genuine demand drift.
+- **D4 (7).** Nightly re-estimation with empirical-Bayes shrinkage and an explicit anti-oscillation
+  rate-of-change cap is the most statistically sophisticated self-maintenance mechanism of the
+  four, and correctly identifies seasonal drift (Oxford term-time) as its strongest use case. Not
+  higher because operational fragility (nightly batch, holdout routing, a new schema table) is
+  itself a maintenance burden the simpler designs don't carry, and the design's own honest-cons
+  section flags this explicitly.
+
+### C6 — Robustness (coastal, tiny groups, overlaps, gaming, cold start, TN)
+
+- **D1 (7).** Coastal geometry self-corrects by construction (audience-based, not shape-based) —
+  genuine strength. Gerrymandering is only partially mitigated (lastaccess-gated active_members
+  raises the bar but doesn't close the loophole; the design admits the re-fit mitigation is
+  "slower than a hard rule"). TrashNothing crossover honestly flagged as an unresolved gap, not
+  measured — the design does not pretend to have solved it.
+- **D2 (6).** Coastal handled correctly via drive-time-not-crow-flies. Gerrymandering is genuinely
+  closed (density measured on a fixed 10km disc, ungameable by boundary redraw) — this is a real
+  strength over D1 and D3 on this specific point. Cold start (20min DfT anchor) is well-derived.
+  Docked because the design's own minimum-sample gate (n≥50) implicitly concedes that a meaningful
+  fraction of the network (small/thin groups) will sit on the cold-start default indefinitely if
+  volume never crosses the threshold — not clearly bounded in the document.
+- **D3 (6).** Coastal handled by construction (drive-time via road graph excludes water). Cold-start
+  is this design's best property (zero dependency on post/reply history at all). But gerrymandering
+  is honestly conceded as a real, only partially-closed vulnerability under the ring formulation
+  (inflating your own polygon does increase the union span, even if the dominant term is neighbours'
+  span) — the design's own §3.2 admits this outright. Adjacency-graph fragility (merges, deletions,
+  ambiguous "adjacent" cases) is a real, distinct operational risk not shared by the other three.
+- **D4 (7).** Coastal and gerrymandering are both well-handled by stratifying on post-level realized
+  audience rather than any static geographic or group-polygon proxy — a genuinely clean solution to
+  both failure modes simultaneously, better than D1/D3's partial mitigations. Cold start via
+  empirical-Bayes shrinkage is textbook-correct. Docked for the frankly-acknowledged deliverability
+  feedback-trap risk (§6.2, Risk 2) which is a real, only partially-guarded, self-reinforcing
+  failure mode unique to a closed-loop design, plus materially higher overall operational surface
+  area for a silent-corruption failure (explicitly analogized to the real 56%-backfill-contamination
+  incident already observed in this evidence base).
+
+### C7 — Buildability & fit (leverages schedule/governor MVP/experiment; realistic increment)
+
+- **D1 (9).** The cleanest fit of the four: this is explicitly "supply the missing derivation for
+  the already-coded, currently-dark Stage-A extent governor" — zero new mechanism, only a formula
+  for a parameter the code already reads. Reactivates the RippleTuneService/rippling_params stub
+  with a concretely specified computation, not a vague "make it smarter."
+- **D2 (7).** Extends (doesn't replace) the existing isochroning mechanism — a real, modest
+  increment (density-banded ceiling instead of one flat constant) — but does not reuse the
+  cumulative_users/schedule audience data that's already persisted, and doesn't touch the
+  already-half-built extent governor at all, so it's a partially-separate piece of new
+  infrastructure (new density-disc computation, new monthly job) rather than a direct completion of
+  existing dark code.
+- **D3 (6).** Needs zero schema change (`max_minutes` already a per-request parameter) — genuinely
+  cheap to wire. But it has a hard, named external dependency (the not-yet-built widest-span
+  UI primitive, backlog #21/#22) for its cheapest computation path, and its fallback path (per-group
+  Dijkstra + adjacency-graph maintenance) is new machinery the pipeline doesn't have today, unlike
+  D1's reuse of already-coded audience-budget plumbing.
+- **D4 (6).** Correctly identifies and reuses the most existing scaffold of any design (extent-
+  governor Stage-A cap, RippleTuneService stub, RIPPLE_WITHIN_GROUPS scoping) — strong marks for
+  recognizing what's already built. But it also requires materially new infrastructure the others
+  don't (permanent 5% holdout routing, a new schema table for holdout bookkeeping, a new guard-rail
+  gatekeeper service) — the document's own honest-cons section (§9.6) concedes this is "materially
+  more operational surface area" than a constant-based design, which is a legitimate buildability
+  cost, not just a risk.
+
+### C8 — Scientific honesty (handles the exposure-censoring/chicken-and-egg problem credibly)
+
+- **D1 (8).** This is where D1's core evidence is actually strongest on causal grounds, and it is
+  under-sold in the design's own self-description: the within-density-tercile analysis
+  (5-demand.md §6) is a genuine confound-control exercise — it explicitly tests and rules out
+  "audience size is just a proxy for density" by holding density (tercile) fixed and varying
+  audience (quintile) within it, finding the decline survives. That is real, if simple, causal
+  reasoning (a stratified analysis, not a randomized experiment, so still correlational — density
+  terciles could still correlate with unmeasured post-quality or category-mix differences — but
+  meaningfully stronger than a raw marginal correlation). The design is honest that this whole
+  edifice sits on only 10 days of post-launch data and that "reply-rate-as-target" is itself
+  susceptible to a flagged deliverability feedback loop it does not solve. Docked one point
+  relative to D2/D4 because the design does not explicitly reckon with censoring in the sense D2
+  does (today's *audience* itself is capped at 30min reach, so the tercile-quintile table is itself
+  measured within an exposure-limited population — a post that "would" have reached 20,000 members
+  absent T_max never appears in decile 10 at all, so the observed decline past ~2,000-13,000 could
+  in principle be curvature within an already-truncated range rather than the true global shape).
+  This is a real, unaddressed gap in D1's evidentiary chain that D2 names explicitly for its own
+  data and D1 does not name for its own (structurally identical) data.
+- **D2 (9).** Highest score on this specific criterion, deservedly — this is the one design whose
+  entire raison d'être is naming and mechanically defusing the censoring problem: it explicitly
+  states the P90 is a *conservative floor, not a demand ceiling* (matching the behaviour report's
+  own central caveat verbatim), uses the *pre-rippling* baseline as a less-censored primary input
+  (a genuinely clever identification move — pre-ripple, the binding constraint was group-polygon
+  geography, not a drive-time isochore, so for large-polygon sparse groups it's meaningfully less
+  truncated), cites direct evidence the censoring is real and operating (P99 shrank 55.8km→36.3km
+  pre/post), and builds a *mechanical* anti-spiral guardrail (15%/period clamp + 90%-catch backtest)
+  rather than just a promise to "keep an eye on it." It is the only design to specify exactly how
+  it will be superseded once the reach experiment's uncensored data lands (full input-distribution
+  swap-in, same rule structure) — a genuinely testable, falsifiable transition plan.
+- **D3 (5).** The design does not really engage with censoring as a statistical problem at all —
+  its calibration inputs (behaviour report's 90-95%-coverage-distance and reply-distance-decay
+  figures) are the *same* censored, exposure-limited data D1 and D2 use, but D3 does not name or
+  discuss the censoring issue anywhere in its own text (§1.2's α-derivation table cites the
+  coverage-capture distances without flagging that those distances are themselves capped by
+  existing 30-min reach). This is a real gap: D3's own honest-cons section (item 2) admits "no
+  connection to real demand/engagement signal at all" as a weakness, but frames it purely as "can't
+  detect under/oversaturation," not as "the geometric constant itself was calibrated on
+  exposure-truncated behavioural data" — the latter is the more fundamental issue and it's absent
+  from the document.
+- **D4 (8).** The second-strongest treatment of this problem, via a genuinely different and
+  arguably more rigorous mechanism than D1/D2: rather than trying to de-censor observational data
+  after the fact, D4 proposes to *make the already-scoped randomized ADD experiment permanent
+  infrastructure* — i.e. solve censoring by generating genuinely uncensored (holdout vs treated)
+  data forever, rather than reasoning around a censored historical sample. This is the only design
+  of the four with an actual identification strategy for causal lift (r_hat = treated-conversion
+  minus holdout-conversion) rather than an observational proxy. Docked one point below D2 because:
+  (a) the *decision rule itself* (θ, V, C) is not derived from the holdout, only r_hat is, so the
+  causal-inference rigor doesn't extend all the way to the stopping point (see C3); (b) the
+  document's own §9.1 admits the meta-parameters were partly back-solved to match pre-existing
+  observational conclusions, which is a form of the same circularity D2 is more careful to avoid
+  (D2's guardrails are computed thresholds, not fitted-to-match-the-answer weights).
+
+---
+
+## Which design would I ship
+
+**Ship D1 (Audience Normalization), total 63/80.**
+
+From a statistical-validity/causal-inference standpoint, D1 wins for a specific, defensible
+reason that the other three don't match: its central empirical claim (the audience level at which
+reply probability peaks scales with a group's own active-member base) is the only claim in any of
+the four documents that has actually been tested against a real, if simple, confound-control
+design — stratify by density tercile, then vary audience within each stratum. That is meaningfully
+different from D2's percentile-of-observational-data approach (no confound control, honestly named
+as a floor not a ceiling) and categorically different from D3's purely geometric constant (no
+attempt to connect to outcome data, confound or otherwise) and from D4's back-solved meta-parameters
+(admittedly circular per its own §9.1). D1 also has the best fit-to-existing-infrastructure story
+(C7) of the four, which matters for actually getting a principled number into production rather than
+staying a design document.
+
+D1's real, unresolved weakness on this lens is the same one D2 is honest about and D1 is not: both
+designs' calibration data is exposure-censored (today's realized audiences are capped by the
+existing 30-min ceiling), so neither can distinguish "reply probability truly peaks near 1x active
+members" from "reply probability appears to peak because we've only ever observed a truncated
+range of audiences." D2's percentile design names this explicitly and builds a mechanical
+anti-spiral guardrail; D1 does not name it for its own tercile-quintile analysis at all. That is
+D1's most serious statistical gap and the reason it should not claim more certainty than D2 does
+about "the peak" being a true global optimum rather than an artifact of truncation. D4's permanent-
+holdout mechanism is the only one of the four that actually resolves this by generating unbiased
+data going forward rather than reasoning around biased data retrospectively — which is why D1
+should not be shipped as a static, one-time-calibrated rule; it should be shipped with an explicit
+commitment to validate its k against the reach experiment's (or a permanent holdout's) uncensored
+data once available, exactly as D2 already specifies for its own P90.
+
+## Grafts — one must-have idea from each losing design, into D1
+
+- **From D2 (behavioural-percentile):** graft the **explicit censoring-honesty apparatus** —
+  (a) name the exposure-censoring problem for D1's own tercile-quintile evidence, not just for D2's;
+  (b) adopt D2's mechanical anti-spiral guardrail pattern (a hard per-period % cap on how far a
+  re-fit can move k, plus a "would this k have still captured ≥90% of last quarter's actual replies"
+  backtest) for D1's quarterly re-fit, replacing the current soft "re-fit uses reply outcomes" story
+  with a computed, falsifiable check; (c) explicitly commit, as D2 does, to swap in the reach
+  experiment's (or D4's permanent-holdout) uncensored data the moment it exists, with a pre-specified
+  procedure for how k changes if the uncensored peak differs materially from the censored one.
+
+- **From D3 (community-relative):** graft the **ring-formulation's mod-load side effect** — D1
+  correctly limits *audience*, but the evidence base is explicit that mod-load is driven by
+  *group-count* under the current "ripple into every intersecting group" engine, which D1 alone does
+  not touch. D3's adjacent-ring idea (bound reach to the union of home group + immediately-bordering
+  published groups) is a natural, near-zero-cost **secondary cap** layered on top of D1's N*: expand
+  until `cumulative_users >= N*` OR the reach polygon would cross into a *second* ring of groups,
+  whichever binds first. This directly starts to address the group-count/mod-load dimension of the
+  complaint that D1's own honest-cons section (§6, con #2) admits it does not fix on its own,
+  without taking on D3's full adjacency-graph machinery as the primary lever.
+
+- **From D4 (adaptive-control):** graft the **causal-lift (ADD holdout) measurement of r as the
+  input to k's re-fit**, replacing D1's current re-fit design (which infers "audience level where
+  reply probability peaks" from raw, uncontrolled conversion rates, i.e. correlational, not causal).
+  D4's r_hat = conversion(treated) - conversion(holdout) is the only genuinely causal quantity in
+  any of the four documents. D1 does not need D4's full nightly closed-loop machinery, meta-
+  parameter apparatus, or permanent 5%-of-every-tick holdout — but it should borrow the *measurement
+  primitive*: run D1's quarterly re-fit against a small, scoped holdout (even a periodic 2-week
+  experiment rather than D4's permanent always-on version) so that the k re-fit is estimating a
+  causal lift, not a raw observational correlation that the D1 document itself (and this review, C8)
+  flags as potentially confounded by the very exposure-censoring the design doesn't fully reckon
+  with.
+
+---
+
+## One-line summary per design (for cross-judge comparison)
+
+- **D1**: Best-triangulated, best-evidenced, best-fit-to-existing-code; its confound control
+  (density-tercile stratification) is real methodology, not just correlation-and-hope — but it
+  under-claims its own censoring exposure relative to D2, and doesn't fix mod-load/group-count.
+- **D2**: Most scientifically honest treatment of censoring of any of the four (explicit floor-not-
+  ceiling framing, mechanical anti-spiral guardrails, pre-registered swap-in plan) — but its central
+  constant (P90) is admitted convention, not a fitted optimum, and it doesn't use the audience data
+  the pipeline already persists.
+- **D3**: Best cold-start/self-maintenance story of the four (pure geometry, no sampling
+  uncertainty at all) — but its assigned core formula demonstrably fails on its own worked examples,
+  forcing a mid-document pivot to a different rule, and it never engages with the censoring issue
+  that the very same behavioural data (which it borrows uncritically) is subject to.
+- **D4**: Only design with an actual causal identification strategy (randomized holdout for r_hat)
+  — the most rigorous piece of statistics in any document — but the decision threshold built on top
+  of that measurement (θ, V, C) is candidly conceded to be back-solved/circular, and the operational
+  complexity is the highest of the four by a wide margin.

--- a/plans/2026-07-02-reach-design-evidence/J3-judge.md
+++ b/plans/2026-07-02-reach-design-evidence/J3-judge.md
@@ -1,0 +1,335 @@
+# Judge 3 — Engineering, Operations & Safety Lens
+
+Scoring the four rippling-reach designs against the eight criteria, from the perspective of:
+"if I have to build this, run it in prod, be on call for it, and defend it when it breaks at 3am,
+which one do I want to own?" Read in full: D1-audience-target.md, D2-behavioural-percentile.md,
+D3-community-relative.md, D4-adaptive-control.md, plus the six evidence reports
+(1-mechanics.md through 6-external-anchors.md) for grounding on what's actually coded/dark/stubbed
+in prod today.
+
+---
+
+## Scoring matrix (1-10 per criterion)
+
+| # | Criterion | D1 (audience-target) | D2 (behavioural-percentile) | D3 (community-relative) | D4 (adaptive-control) |
+|---|---|---|---|---|---|
+| C1 | Fixes dense-area complaint | 8 | 8 | 7 | 8 |
+| C2 | Preserves rural utility | 9 | 9 | 9 | 9 |
+| C3 | Principled derivation | 7 | 6 | 5 | 5 |
+| C4 | Explainability & mod trust | 8 | 8 | 9 | 5 |
+| C5 | Self-maintenance | 6 | 7 | 8 | 7 |
+| C6 | Robustness (edge cases) | 7 | 7 | 6 | 6 |
+| C7 | Buildability & fit | 9 | 7 | 6 | 4 |
+| C8 | Scientific honesty (censoring) | 6 | 9 | 6 | 7 |
+| | **Total (raw sum /80)** | **60** | **61** | **56** | **51** |
+
+---
+
+## Per-criterion rationale
+
+### C1 — Fixes the dense-area complaint
+
+- **D1 (8/10)**: Audience-curves dark-compute directly shows N*=2000-4000 cuts Tower Hamlets from
+  17.8min/13,336 audience to ~11-15min/~3,469, and inner-London top-15 groups from ~30min/12-15k
+  audience down to a ~4,000 cap — this is a *measured*, not hypothetical, tightening on exactly
+  the complaint population. Docked two points because it fixes the audience-fairness axis of the
+  complaint but explicitly does not touch mod-load (group-count), which is part of the same
+  complaint's lived mechanism (posts appearing in too many groups a mod oversees).
+- **D2 (8/10)**: Worked examples (flagged as illustrative, pending real routing data) show
+  TowerHamlets/inner-London ~30min→~15min — a comparable, evidence-consistent tightening. Docked
+  for the same mod-load gap as D1, plus the worked-example numbers are explicitly a placeholder
+  conversion (km→min via assumed speed) rather than real routing-engine output, so as-specified
+  today it is one step further from "would actually ship this number" than D1's numbers (which
+  come from real persisted `rippling_reach.schedule` ticks).
+- **D3 (7/10)**: The literal brief formulation (α×span) is proven by the design's own worked
+  examples to NOT bind in the complaint geography at all — a genuine, admitted failure to solve
+  the stated problem as specified. The design recovers by substituting a different formulation
+  (adjacent-ring) that does bind (~15-18min for inner-London). Scored lower than D1/D2 specifically
+  for engineering-process risk: shipping "the assigned rule doesn't work, here's a different one
+  that does" is a legitimate design pivot, but it means the actual specified mechanism has less
+  empirical runway behind it (the ring formulation's worked numbers are geometry estimates, not
+  measured ticks) and a reviewer has less confidence the *next* edge case won't need another pivot.
+- **D4 (8/10)**: Grounded in the single strongest evidence result (reply probability actively
+  HALVES 38.8%→21.8% within the densest tercile as audience grows) and the mechanism (marginal
+  benefit/cost) is designed to bind hardest exactly where that decline is steepest — dense London.
+  Same mod-load caveat as D1/D2. Not scored higher than D1 because the actual bound achieved
+  depends on meta-parameters (θ, C, w_reply/w_speed) that are back-solved to "roughly reproduce"
+  the same ~1,000-2,000 answer D1 derives more directly — so the *outcome* is not obviously better
+  than D1's, only reached by a more roundabout, harder-to-verify path.
+
+### C2 — Preserves rural utility
+
+All four designs explicitly verify (via the audience-curves dark-compute or equivalent) that
+Hull/Swindon/Ribble Valley are ceiling-bound and therefore untouched by the new mechanism — this is
+a shared strength across all four, reflecting that they all correctly read the same evidence.
+- **D1 (9)**: Direct: floor/ceiling structure is unchanged, N* simply never binds for these groups
+  (measured, not assumed).
+- **D2 (9)**: Direct: P90-of-local-collections naturally sits near 28-30min for sparse/low-density
+  bands; cold-start default (20min) is even a touch more generous than nothing. Slight residual
+  risk noted in D2 itself: the 15%/period tightening clamp could, in a genuinely thin-data rural
+  band, spuriously tighten if a bad month of data comes through — mitigated but not zero risk.
+- **D3 (9)**: Ring formulation clamps at 30min for every rural exemplar (Hull's "over the water"
+  case explicitly preserved) — geometrically guaranteed, not measured, which is arguably even
+  safer (no data-dependency at all for this population).
+- **D4 (9)**: Explicitly shown structurally immune — sparse strata almost always satisfy "keep
+  going" under the marginal-benefit rule because both benefit and cost stay low, and the hard
+  T_ceiling=30min backstop guarantees no regression regardless of estimator error.
+
+### C3 — Principled derivation (no arbitrary constants)
+
+- **D1 (7/10)**: k=1.0 is triangulated from three sources, one of which (Demand §6 within-tercile
+  peak) is explicitly the strongest single result in the whole evidence base and has the exposure
+  confound directly ruled out. But the design itself admits this rests on only two clean data
+  points (medium/dense terciles) — a real, acknowledged weakness. N*_min/N*_max derivations are
+  reasonable and traced to specific evidence rows.
+- **D2 (6/10)**: P90 is honestly flagged, in the design's own words, as "a defensible convention,
+  not a provably optimal cutoff" — the design is scientifically honest about this but that is
+  itself an admission the choice is not fully principled, only reasonable. Cold-start default (20
+  min) is well-anchored to DfT. Density-banding axis (10km transaction disc) is a genuinely
+  cleaner, more principled choice than group polygon — a real strength within this criterion.
+- **D3 (5/10)**: The headline number the brief asked for (α=2.0) is triangulated from three sources
+  similarly to D1's k, but the design's own worked examples then show it doesn't produce the needed
+  behavior — so the "principled" α is not actually what ships; the shipped rule (adjacent-ring, no
+  multiplier) has no equivalent derivation at all beyond "one ring feels like the right topological
+  unit" — explicitly conceded in the design's own cons section as a single global judgment call
+  with no evidence-derived depth parameter. This is the most honest self-own of over-claiming
+  principled-ness in any of the four designs, which is worth crediting under C8 but costs real
+  points here under C3.
+- **D4 (5/10)**: The functional form (marginal benefit vs marginal cost) is elegant and the shapes
+  (ΔP(reply), Δ(1/ttfr)) are genuinely data-derived. But θ=1, C, and the w_reply/w_speed ratio are,
+  by the design's own admission in §9.1, "meta-parameters... back-solved to roughly reproduce the
+  answer the evidence already suggested" — i.e. the design does not eliminate an arbitrary constant,
+  it relocates and multiplies it (four meta-parameters instead of one N*). The design's honesty
+  here is commendable but the derivation itself is weaker than D1's on this specific axis.
+
+### C4 — Explainability & mod trust
+
+- **D1 (8/10)**: Clean one-sentence mental model ("equal audience, not equal time") that directly
+  rebuts both classes of hostile Discourse objection. Slight complexity cost: mods must accept
+  "your reach is capped by comparing to your OWN membership," an abstraction one level removed
+  from something they can visually verify (unlike D3's map).
+  D4's own critique of D1-style designs — that "your own group's active count" is somewhat harder
+  to make concrete/inspectable than a place-based ring — is fair and costs D1 a point relative to
+  D3.
+- **D2 (8/10)**: Anchored on "your own group's real collection history" — concrete and
+  locally-verifiable, matching the Discourse evidence's finding that mods respond best to
+  concrete claims. Slightly abstract in explaining *why* P90 specifically (a mod could reasonably
+  ask "why not P95").
+- **D3 (9/10)**: The strongest of the four on this axis specifically: the ring-formulation
+  explanation ("reach = to your immediate neighbouring groups") is the literal mental model at
+  least four Discourse mods reached for unprompted (Jax, Jos, Group-Mod-J's "over the water"
+  framing) — this is not a retrofit explanation, it's the actual vocabulary the complainants used.
+  It also dovetails with an already-planned catchment-map UI (#21/#22), meaning the mod-facing
+  number and a visual map become provably the same fact — the single strongest trust-building
+  property among the four designs, because it eliminates "trust me, the algorithm is right" in
+  favor of "look at the map, this is where your neighbours are."
+- **D4 (5/10)**: The design's own honest cons section states the core risk plainly: a system whose
+  actual mechanism is "nightly empirical-Bayes shrinkage estimator computing a causal lift from a
+  live experimental holdout" is fundamentally harder to explain honestly to a non-technical,
+  already-skeptical mod population than a fixed number tied to geography or their own group's
+  data. The mod-facing copy in §7 is explicitly designed to hide the internals (θ, r_hat, holdout)
+  rather than expose them — which the design itself flags as "risk it reads as evasive." Given
+  that this evidence base shows two mods already resigned and two more nearly did over exactly a
+  trust deficit, shipping the design with the least defensible trust story is a genuine
+  engineering-operations risk, not just a communications nuisance.
+
+### C5 — Self-maintenance
+
+- **D1 (6/10)**: Quarterly re-fit of k per density band is specified, concretely tied to reusing
+  the existing (currently dead) `RippleTuneService`/`rippling_params` scaffold. But quarterly is a
+  slow cadence relative to the seasonal/drift risks named in the design's own §3 (seasonal actives,
+  data drift, deliverability feedback loop) — the design acknowledges active_members itself updates
+  live (good) but the *k multiplier* and clips only move every 3 months, and the design's own §6
+  admits the first 2-3 quarterly re-fits should be treated as "provisional/high-variance" given
+  only 10 days of underlying data at design time.
+- **D2 (7/10)**: Monthly recompute (faster cadence than D1's quarterly) with a mechanical
+  15%-per-period tightening clamp and a live collection-catch backtest guardrail — this is a
+  genuinely concrete, computed anti-drift mechanism, not just a cadence promise. Slightly below D3
+  because it still depends on live transaction volume for every band's recompute (thin bands are
+  more fragile than D3's zero-data-dependency geometry).
+- **D3 (8/10)**: The strongest self-maintenance story structurally: because span/adjacency are
+  re-derived geometric facts (recomputed monthly + event-triggered on boundary edits/group status
+  changes), "is this still correct" reduces to "is the map still accurate" — a categorically easier
+  operational question than "is our statistical calibration still valid," and one with essentially
+  zero risk of the kind of silent numerical drift the other three designs must guard against with
+  explicit clamps/backtests. Docked two points because it is not "self-maintaining" in the sense of
+  responding to demand signal at all — a group whose real local demand shifts (grows or shrinks)
+  independent of its geography gets no adjustment; the design is honest about this in its own cons.
+- **D4 (7/10)**: On paper the most sophisticated self-maintenance mechanism (nightly re-estimation,
+  automatic drift absorption within ~14 days, strata that redefine themselves nightly) — genuinely
+  the fastest-reacting of the four to real behavioural drift. But this is also the design's biggest
+  operational liability: more moving parts (nightly batch, holdout routing, guard-rail service, new
+  schema) means more ways for the self-maintenance mechanism ITSELF to silently break — and this
+  evidence base already recorded one real incident of exactly that failure mode (56% of
+  `rippling_reach` rows corrupted by an unnoticed backfill job). D4's own §9.6 names this risk
+  candidly. Scored above D1 for reaction speed, below D3 for operational safety.
+
+### C6 — Robustness (coastal, tiny groups, overlaps, gaming, cold start, TN members)
+
+- **D1 (7/10)**: Coastal geometry self-corrects well (audience-based, not shape-based — a genuine
+  strength). Cold start handled by the N*_min floor, with one flagged one-line guard needed for
+  groups <90 days old. Gaming (inflating active_members) is honestly discussed with a real but
+  slow mitigation (re-fit trends down if inflated members don't reply). TrashNothing crossover is
+  explicitly flagged as an unresolved gap, not measured — a real gap for a "read-only sampling
+  encouraged" design phase that had the data available to at least attempt.
+- **D2 (7/10)**: Coastal geometry handled correctly via drive-time-based P90 computation (not
+  crow-flies). Gerrymandering is well-defended (fixed 10km disc, ungerrymanderable by construction
+  — one of the strongest anti-gaming stories among the four). Cold start has a clean three-tier
+  fallback (min-sample gate → density-band pooling → DfT anchor). TrashNothing handled as a
+  documented pre-existing data-quality issue with a concrete mitigation (P99.5 trim) rather than a
+  flagged gap — slightly more resolved than D1's treatment. Docked for the circular-tightening-
+  spiral risk being the design's own central, load-bearing vulnerability, even though it's well
+  mitigated (15% clamp + backtest) — this is a real, structurally-inherent fragility other designs
+  don't share to the same degree.
+- **D3 (6/10)**: Coastal geometry explicitly deferred to "must use routing engine, not ST_Area" —
+  correctly identified but not actually computed in the worked examples (illustrative geometry-
+  radius numbers used instead), a real gap between claim and demonstration. Gaming is the honest
+  weak point: the design itself states the α-formula IS gameable (draw a bigger polygon → bigger
+  cap) and only "mostly cancels" under the ring formulation, relying on a human HQ-review process
+  as backstop rather than an algorithmic guard — weaker than D1/D2's mitigations. Cold start is
+  D3's best property (zero dependency on any post/reply history). TrashNothing is out-of-scope by
+  design (doesn't affect polygon size) — a legitimate "not applicable" rather than a resolved gap.
+  Adjacency-graph fragility (merged/deleted/enclave groups) is a genuinely new operational surface
+  the other designs don't have, honestly flagged in the design's own §3.7 and §6.3.
+- **D4 (6/10)**: Coastal/gerrymandering handled elegantly by construction (stratifying on
+  post-level realized audience sidesteps both, a genuinely clever design choice not shared by
+  D1-D3). Cold start via empirical-Bayes shrinkage is textbook-correct and well-specified. But this
+  is the only design that introduces THREE genuinely new operational risks with no precedent
+  elsewhere in the evidence base: (1) the deliverability feedback trap (explicitly named as
+  "unsolved" even after mitigation), (2) permanent-holdout GDPR/LIA exposure with "no natural
+  expiry" (explicitly flagged as needing sign-off beyond the original one-off experiment's scope),
+  (3) anti-oscillation guards that are themselves new, untested machinery layered on top of an
+  already-complex estimator. Each is honestly flagged, but stacking three novel, not-yet-built
+  safety mechanisms onto a live user-notification pipeline is a materially higher-risk profile than
+  D1-D3's edge cases, which are mostly extensions of statistical/geometric machinery that already
+  exists.
+
+### C7 — Buildability & fit (leverages existing infra, realistic increment)
+
+- **D1 (9/10)**: The cleanest fit of the four. It adopts the Stage-A audience-budget mechanism that
+  is *already coded end-to-end* (`ripple.go`, `ReachService.php`, unit-tested) and dark only for
+  lack of a calibrated `target_users`. The single missing piece — how to derive N* — is exactly
+  what this design supplies. No new schema, no new pipeline, no new experiment infrastructure. The
+  quarterly re-fit reactivates (rather than replaces) the existing dead `RippleTuneService`/
+  `rippling_params` scaffold. This is about as close to "flip a flag with a calibrated number" as
+  a data-derived design can get.
+- **D2 (7/10)**: Extends (doesn't replace) the existing isochroning mechanism — genuinely
+  incremental, and reuses `RIPPLE_WITHIN_GROUPS` for scoping. But it does NOT use the
+  already-persisted `cumulative_users` audience data (a design-time miss the design itself
+  concedes in its own weakest-point section), and its core input (10km transaction-disc density) is
+  a genuinely new computed axis requiring new monthly batch infrastructure that doesn't exist today
+  (unlike D1's reuse of an already-built pipeline). Distance→drive-time conversion via real routing
+  data is specified correctly but not yet demonstrated (worked examples use placeholder
+  conversions).
+- **D3 (6/10)**: Needs zero schema change (`max_minutes` is already a per-request parameter) and
+  reuses the polyindex-intersection primitive `ExpandService` already computes for cross-posting —
+  genuinely lightweight in one respect. But its cheapest implementation path is an explicit **hard
+  dependency on an unbuilt feature** (the moderator catchment-map "widest-span" UI, backlog #21/22)
+  — if that lands first, D3 is cheap; if not, D3 needs its own span-computation batch job built
+  from scratch. The design is honest about this dependency, but "the cheap path requires something
+  else to ship first" is a real buildability risk that D1 doesn't share. The adjacency-graph
+  maintenance (recompute on boundary edit + group status change + monthly refresh) is also new
+  operational surface with no existing equivalent to build on.
+- **D4 (4/10)**: The lowest score on this criterion, deliberately. Yes, it reuses the same Stage-A
+  enforcement point as D1 (`effectiveScheduleTotal`, genuinely "no change needed" per its own
+  implementation sketch item 5) and reactivates the same dead `RippleTuneService` scaffold. But
+  everything else is new, substantial engineering: a permanent 5% holdout requiring a new
+  `rippling_reach_holdout` table and new routing logic in `ExpandService::advanceDue`/
+  `initialiseNew`; a wholly new guard-rail/gatekeeper service (explicitly "no existing scaffold to
+  build on"); nightly empirical-Bayes shrinkage estimation logic that doesn't exist in any form
+  today; and the already-scoped reach experiment being repurposed from a bounded 3-week study into
+  permanent infrastructure (a scope change with its own approval implications). The design's own
+  §9.6 concedes "materially more operational surface area... than a constant." This is by far the
+  largest actual build for a "design only, read-only sampling encouraged" brief whose stated
+  purpose was to find a way to set ONE parameter — D4 answers a more ambitious question (build a
+  permanent control system) than the one asked (derive a value), and an engineering-ops reviewer
+  should weight that mismatch heavily.
+
+### C8 — Scientific honesty (exposure-censoring / chicken-and-egg problem)
+
+- **D1 (6/10)**: Acknowledges the deliverability feedback loop as an "unresolved" inherited risk
+  and is honest that reply-rate-as-target is itself susceptible to confounds (post quality,
+  category, seasonality) it doesn't model. But D1's core derivation (Demand §6 within-tercile
+  analysis) is explicitly checked and shown NOT to be explained by the exposure confound — a
+  genuine, credited strength — which is why it isn't scored lower. It does not, however, name or
+  mechanically defend against a *tightening spiral* the way D2 does, because D1's mechanism
+  (audience-count target) is less structurally exposed to that specific failure mode than D2's
+  (percentile-of-censored-data) — so there is less for D1 to need to defend on this exact axis, but
+  correspondingly it also gets less credit for defending it.
+- **D2 (9/10)**: This is D2's standout strength and the reason it doesn't lose on this criterion
+  despite being weaker elsewhere. The censoring problem is not just named, it is mechanically
+  defended on four independent fronts: (a) using the less-censored pre-rippling baseline as primary
+  input, with direct measured evidence the censoring effect is real (P99 shrank 55.8km→36.3km
+  pre/post); (b) explicitly documenting the resulting P90 as a floor, not a demand ceiling, in both
+  internal docs AND mod-facing copy; (c) a fully specified swap-in plan for the reach experiment's
+  uncensored data the moment it reports; (d) a *computed*, not just named, guardrail (15%/period cap
+  + 90%-collection-catch backtest) against the self-reinforcing spiral. This is the most rigorous,
+  concrete treatment of the chicken-and-egg problem among the four designs — it doesn't just say
+  "this is a risk," it builds the mechanical defense into the rule itself.
+- **D3 (6/10)**: Honestly reports that its primary formulation doesn't work — a high-integrity
+  finding that deserves credit under "scientific honesty" broadly. But D3 doesn't really engage with
+  exposure-censoring as a *statistical* problem at all, because its shipped mechanism (adjacent-ring)
+  is deliberately non-statistical/purely geometric — this sidesteps censoring rather than solving it,
+  which is a legitimate design choice (named as a strength in D3's own §3.3) but means the design
+  earns fewer points specifically for *handling the censoring problem credibly*, since it mostly
+  opts out of the question by construction.
+- **D4 (7/10)**: The permanent holdout (ADD design) is the only one of the four mechanisms that
+  actually generates genuinely *uncensored* causal data going forward, rather than working around
+  censored historical data — structurally the most rigorous long-run answer to the chicken-and-egg
+  problem. But at launch, tick-1 (70% of the audience) is explicitly conceded to be governed by a
+  feed-forward prior with "zero holdout signal" for that specific post — so the design's headline
+  claim of solving censoring is real for the trailing 30% of audience but structurally weaker for
+  the dominant burst, a limitation the design states honestly (crediting it here) but that measurably
+  caps how much of the actual censoring problem gets solved by launch day.
+
+---
+
+## Which design would I ship, and why
+
+**Ship D1 (Audience Normalization).** Through the engineering-operations-and-safety lens
+specifically — not "which is the most elegant idea" but "which one do I want to be woken up for at
+3am, and which one can I actually get through a change-review board this quarter" — D1 wins on the
+criteria that matter most for that judgment: buildability (9/10, the only design that is close to
+"flip an already-coded, already-unit-tested flag with a calibrated number"), a genuinely principled
+central derivation with the exposure confound explicitly ruled out (the single strongest empirical
+result in the whole evidence base), and a risk profile that adds essentially zero new operational
+surface area (no new schema, no new services, no new experiment infrastructure, reuses a dead
+scaffold rather than building parallel machinery). D2 scores marginally higher on raw honesty about
+censoring and is a very close second — if D1's k=1.0 derivation were shown at Stage 0 dark-compute
+to not hold up, D2 would be my fallback pick, precisely because its tightening-spiral defense is the
+most mechanically rigorous of the four. D3's core weakness (the assigned formulation demonstrably
+doesn't solve the stated problem, and the design pivots mid-flight to a different rule) makes it hard
+to fully trust the rest of its derivation chain, even though its explainability and cold-start
+properties are genuinely best-in-class. D4 is the most intellectually ambitious and arguably the
+"correct" long-run answer, but it answers a bigger question than was asked, triples the honest
+constant-count while claiming to eliminate constants, and stacks three novel safety-critical
+mechanisms (holdout routing, guard-rail service, permanent GDPR-relevant experiment) onto a live
+user-notification pipeline for a first release — that is a legitimate v2/v3 evolution once D1 (or
+D2) has run safely in prod for a couple of quarters and proven the underlying data pipeline is
+trustworthy, not a safe v1.
+
+## One must-graft idea from each losing design, into D1
+
+- **From D2**: Graft the **mechanical anti-circularity guardrails** — a hard per-period
+  rate-of-change cap (D2's 15%) plus a live backtest that any tightening must still capture ≥90% of
+  what actually happened last period. D1's own re-fit process (§5) currently only has a soft "if k
+  falls outside a sane band, halt and review" trigger; it should adopt D2's concrete, computed,
+  automatic guardrail rather than relying on a human noticing an out-of-band k after the fact.
+
+- **From D3**: Graft the **mod-facing catchment-map co-location principle** — show the mod-facing
+  N*/reach number on the same visual (a map showing the reached area and, ideally, the comparison
+  group of "how many members like this reach represents") that any group-settings/catchment UI
+  already displays, rather than only a prose explanation. D3's single best property is that its
+  parameter and its explanation are provably the same fact shown in two places; D1's audience-count
+  explanation is currently pure prose, which is a materially weaker trust story for the same
+  hostile-mod audience that resigned moderators over exactly this kind of "trust me" framing.
+
+- **From D4**: Graft the **causal-lift (holdout-based) calibration signal**, in a minimal,
+  low-risk form, as the input to D1's quarterly re-fit — instead of re-fitting k purely from raw
+  reply-rate-vs-audience curves (which D1 itself admits conflates "would have replied via browse
+  anyway" with "replied because notified," and is explicitly named as vulnerable to the
+  deliverability feedback loop), reuse the already-scoped, bounded, one-off reach experiment (not
+  D4's *permanent* 5%-forever holdout) to get one clean causal-lift measurement per density band and
+  use that measurement to sanity-check/adjust k at the next quarterly re-fit. This gets most of
+  D4's scientific rigor on the specific point where D1 is weakest, without adopting D4's much larger,
+  permanent, GDPR-exposed operational commitment.

--- a/plans/2026-07-02-reach-design-evidence/SYNTHESIS.md
+++ b/plans/2026-07-02-reach-design-evidence/SYNTHESIS.md
@@ -1,0 +1,475 @@
+# Rippling Reach: Audience-Normalized Extent, with Anti-Spiral Guardrails and Catchment-Map Co-Location
+
+**Status: design only, no implementation.** Synthesized from four independently-authored designs
+(D1-D4), scored by three judges on independent lenses (product/moderator-trust, statistical
+validity, engineering/operations), and six evidence reports covering current mechanics, the
+Discourse complaint thread, revealed collector behaviour, real dark-computed audience curves,
+demand sufficiency, and external travel-time anchors. All three judges independently selected
+**D1 — Audience Normalization** as the base philosophy (scores 63/63/60 of 70, versus 60/57/61,
+53/54/56, and 51/52/54 for D2/D3/D4 respectively). This document is D1 as the spine, with three
+concrete grafts the judges converged on, resolving the one open contradiction between them.
+
+---
+
+## 1. The rule, in one sentence
+
+> **Every Offer expands, tick by tick, until it has reached roughly as many active local Freeglers
+> as its own group normally has — not until it has driven a fixed number of minutes.**
+
+Formally:
+
+```
+N*(post) = clip( k × active_members(home_group),  N*_min = 1,000,  N*_max = 4,000 )
+
+At every tick, STOP expanding as soon as ANY of:
+  cumulative_users  >= N*(post)                         (the audience-budget stop — NEW, this design)
+  drive_min         >= T_max = 30 min                     (the geometry ceiling — EXISTING, unchanged)
+  distinct repliers >= reply_saturation_stop = 3           (demand-exhaustion stop — RECALIBRATED, was 5)
+  AND never stop before drive_min >= T_min = 10 min       (locality floor — EXISTING, unchanged)
+
+k = 1.0, re-fit quarterly per density band, subject to two anti-spiral guardrails (§4)
+```
+
+Drive-time becomes an **output** of this process (and a safety envelope for the areas where
+audience is genuinely scarce), not the control variable. This directly answers the flagship
+Discourse complaint — "same slider position, ~1,000 members in Swindon judged 'pretty perfect',
+~27,000 in Islington judged too far" (post #248) — by making the *audience*, not the *time*, the
+thing that is held equal-ish across areas, within a floor and ceiling that keep sparse areas
+protected.
+
+This is not a new invention: it completes an already-coded, unit-tested, currently-dark feature.
+`RIPPLE_EXTENT_ENABLED` and `RIPPLE_EXTENT_TARGET_USERS=4000` already exist end-to-end in
+`iznik-routing-go/ripple.go` and `ReachService.php` — wired, tested, switched off, with a flat,
+uncalibrated placeholder value. This design's entire job is to answer the question the original
+MVP plan explicitly left open: **how is the target derived, stratified by area, and kept correct
+over time** — not whether the audience-budget mechanism is the right shape.
+
+---
+
+## 2. Why this rule, and not the other three
+
+All three judges converged on D1 despite scoring it through genuinely different lenses (product
+trust, statistical rigor, engineering risk), which is itself evidence the choice is robust rather
+than an artefact of one evaluation frame. The convergent reasoning:
+
+- **It is the only design whose central claim was confound-checked, not just correlated.** The
+  demand report's within-density-tercile analysis (stratifying by each group's own active-member
+  scale, then looking at the reply-rate-vs-audience curve *inside* each stratum) rules out the
+  obvious objection that "more audience just means more density, and density alone explains more
+  replies." Holding density fixed and varying audience within it, reply probability still peaks
+  near roughly 1x the tercile's own scale and *declines* past it (dense tercile: 38.8% at ~1,700
+  members down to 21.8% at ~13,000). No other design's core number survives this kind of check.
+- **It completes shipped infrastructure rather than adding new machinery.** D1 needs zero new
+  schema, zero new services, zero new experiment apparatus — it supplies a missing number to code
+  that already runs the full pipeline in shadow. D2 needs new monthly density-banding
+  infrastructure; D3's literal formula needs an unbuilt UI primitive to be cheap and, worse, its
+  own worked examples show the literal brief formulation (2x a London borough's own span) never
+  binds in the complaint geography, forcing a pivot to a different rule the design didn't set out
+  to build. D4 triples the constant count while claiming to eliminate constants, and stacks a
+  permanent 5% notification holdout (open GDPR/LIA question), a new gatekeeper service, and nightly
+  empirical-Bayes estimation onto a population that has already lost two moderators to resignation
+  over a trust deficit around "the algorithm decided."
+- **It is provably inert exactly where nobody is complaining, and provably binding exactly where
+  everybody is.** Real dark-computed data (not simulation) shows Hull, Swindon and Ribble Valley
+  never cross even N\*=2,000 — they stay 100% ceiling-bound, completely untouched by this design —
+  while every group in the flagship complaint geography (inner/west London boroughs) sits at 3-5x
+  the proposed cap today and would tighten materially. This directly falsifies the standing
+  objection in the evidence base that "a cap which decreases with density is wrong": D1's cap
+  does *not* decrease with density — it scales with each group's *own* active-member base, so
+  dense groups still get large N\* values, just capped below their uncapped potential, while
+  sparse groups keep today's protective floor.
+
+D1 is not perfect, and this document does not pretend otherwise (§9). What it wins on is a
+narrower, more defensible claim than "solves rippling complaints": it fixes the *audience-fairness*
+dimension of the single most quantified, most cited complaint (equal time producing 14-80x
+unequal audiences), using data and infrastructure that already exist, with a rollback path that
+costs one config flag.
+
+---
+
+## 3. Deriving every constant
+
+No number in this design is asserted; each has a stated evidence source and an explicit re-fit
+mechanism (§7). This table is the complete constant inventory.
+
+| Constant | Value | Derivation | Source |
+|---|---|---|---|
+| `k` (multiplier on active members) | **1.0** | Within-density-tercile reply-probability peak sits at ~0.65-1.0x each tercile's own active-member scale (medium tercile: active-member midpoint ~1,363, peak audience ~1,000 → 0.73x; dense tercile: midpoint ~2,598, peak audience ~1,700 → 0.65x). 1.0 is a round, slightly-conservative fit (errs toward more reach, not less) rather than an overfit to two noisy points. | `5-demand.md` §6 (confound-controlled, the strongest single result in the evidence base) |
+| `N*_min` (floor on target) | **1,000** | Fine-bucket table: 500-1,000 members already shows P(≥1 reply)=34.2%, materially above the 0-250 bucket's 27.0% and close to the observed peak (35-41%); below ~1,000, reply probability measurably degrades even in the sparsest observed data. Independently, the audience-curves dark-compute finds 1,000 is the smallest N\* that discriminates at all — below it, the 9-tick schedule's own granularity dominates the number, not the target. | `5-demand.md` §1; `4-audience-curves.md` §2 |
+| `N*_max` (ceiling on target) | **4,000** | Dense-tercile decline is unambiguous by audience ~8,600+ and severe by ~13,000; 4,000 sits comfortably below both ("past the reply-rate peak, short of the demonstrated decline"). Not coincidentally the existing coded default (`RIPPLE_EXTENT_TARGET_USERS=4000`) — kept, not silently changed, since the evidence independently re-justifies it. | `5-demand.md` §6 |
+| `active_members(group)` | live query | Memberships with `collection='Approved'` and `lastaccess` within 90 days on the post's home group — a number Freegle already computes (it is literally the denominator behind the density terciles). Zero new data pipeline. | `5-demand.md` §6 methodology |
+| `T_min` (floor, drive-time) | **10 min** | DfT NTS0403f: national one-way shopping-trip duration averages 17 min, flat across urban/rural bands. Retail "primary trade area" convention: 5-10 min generates 50-80% of footfall. 10 min is the lower edge of that convention band — below it, "give the local area first look" is defeated even if N\* is nominally already met by a single dense tick-1 burst. Matches the existing MVP floor (adoption, not a change). | `6-external-anchors.md` §NTS0403f, §retail convention |
+| `T_max` (ceiling, drive-time) | **30 min, unchanged** | Already ~1.75x the 17-min national shopping-trip average; every Discourse complaint is about reach being too *large*, none about too small; T_max is already the *only* binding constraint for the 35%+ of groups that never reach even N\*=2,000 (Wales, Scottish Highlands, Cornwall, Northumberland, rural East Anglia) — raising it would only expand rural reach further (uncontroversial), while N\* is what tightens dense areas. No case exists in the evidence to raise it to the previously-floated 45. | `4-audience-curves.md` §3d; `2-discourse.md` (zero requests to increase reach) |
+| `reply_saturation_stop` | **3** (was 5) | The live value of 5 has fired **zero times** in 10,742 genuinely-rippled posts — it is not a governor, it is dead code. P(≥3 replies) is 4-8% across audience deciles vs P(≥5) at ~1% — 3 is where deciles start showing daylight, i.e. the smallest threshold that actually discriminates between posts. Flagged as a companion fix, not this design's primary lever (N\* is). | `5-demand.md` §1 |
+| Quarterly re-fit cadence | **90 days, density-banded not region-banded** | Balances tracking real drift (membership growth, seasonal actives) against noise from Scotland/NI's small samples (NI n=51 at N\*=2,000 sweep) — re-fit must pool thin regions into shared density bands, never fit nation-by-nation on small n. | `4-audience-curves.md` §3d; graft from D2's monthly-banding practice, cadence kept quarterly per D1's slower/more-stable posture |
+| Anti-spiral rate cap | **±15% per re-fit period on `k`**, plus **collection-catch backtest ≥90%** | Graft from D2 (§4 below) — a computed, mechanical circuit-breaker against the "tighter cap → thinner data → tighter cap" spiral this class of self-tuning design is structurally exposed to. | `D2-behavioural-percentile.md` §1.3 (adopted wholesale, adapted from T_max to N*/k) |
+
+**What is explicitly NOT re-derived per group:** `α`-style multipliers, per-group manual dials, or
+region-by-region hand-picked constants. The only per-group-varying input is `active_members`,
+which is a fact Freegle already tracks about every group, not a judgment call made about it.
+
+---
+
+## 4. The graft: anti-spiral guardrails (from D2)
+
+D1's honest cons (§9) name a real risk: the periodic re-fit could enter a self-reinforcing
+tightening spiral if a shrunk N\* mechanically produces a lower measured reply rate next quarter
+(because fewer people were ever notified, not because fewer people would have replied), and the
+re-fit reads that as "confirmation" that N\* should shrink further. All three judges flagged this
+independently and all three named the same fix, taken directly from D2's percentile-cap design,
+which had to solve an equivalent problem for its own `T_max` parameter.
+
+Two mechanical guardrails, both computed, neither a manual override:
+
+**(a) Hard per-period rate-of-change cap.** No quarterly re-fit may move `k` (or the derived
+`N*_min`/`N*_max` clips) by more than **15% from the previous quarter's value**, per density
+band. A re-fit that would move `k` further than that is not applied automatically — it is a
+signal something has broken (input data, methodology, or a genuine but implausibly large real
+shift) and routes to manual review before any live change.
+
+**(b) Collection-catch backtest.** Before any re-fit is allowed to *shrink* `N*` for a density
+band, replay last quarter's actual collections (Taken/Received outcomes with a resolved taker
+location, exactly the methodology already used in the behaviour report) against the *proposed*
+smaller N\*. The proposed value may only go live if it would still have captured **≥90% of those
+real collections** — i.e. the new, tighter number is shown to serve what already happened, not
+just satisfy a percentile computed on an already-shrunk population. This is D2's exact mechanism
+(§1.3 of that design), ported from a distance percentile to an audience target: same logic, same
+threshold, different unit.
+
+Together these convert D1's soft "halt on out-of-band k, review manually" trigger (§8 of the
+original design) into something with a computed pass/fail gate *before* any live change, not a
+qualitative judgment call made after the fact. This is the single highest-value graft: it is cheap
+(no new infrastructure, reuses data both designs already needed), and it directly answers the
+statistical-validity lens's strongest objection to self-tuning designs of this shape (Judge 2:
+"today's realized audiences are already capped at 30min, so the observed 'peak' could be curvature
+within a truncated range" — the exact chicken-and-egg risk these guardrails exist to catch).
+
+---
+
+## 5. The graft: catchment-map co-location (from D3)
+
+D3's single strongest property, independently praised by all three judges, is that its parameter
+and its mod-facing explanation are provably the same fact — a mod sees a number on a map, and that
+number *is* the parameter, not a separately-asserted claim about it. This directly answers the
+Discourse evidence's core warning: an invisible-but-well-derived parameter still needs a **visible
+"why this number" artefact**, because the moderator population is non-technical, already
+distrustful of "the algorithm decided" framing, and has already lost members over exactly this
+trust gap.
+
+Freegle already has the artefact this needs. The **Group Catchment map / Rippling Explorer tab**
+(modtools task list #12-#24 in this codebase; component files `RipplingExplanation.vue`,
+`RipplingExplanationGeneral.vue`, `RipplingHelpModal.vue`, `PostMap.vue` already exist) shows a
+group's catchment heat-shaded by ripple-in time, alongside the group's own internal road span
+("widest span" box — task #21/#22, distance + postcodes + road-distance in miles) — built and
+awaiting release.
+
+**The graft, concretely:** surface `N*(group)` and the resulting drive-time on that same map, not
+in separate prose. Specifically:
+
+- The catchment heat-shading (already built, time-banded) gets one more overlay ring: the drive-time
+  at which this group's posts *actually* stop today under the audience-budget rule, computed live
+  from the same `active_members` count the rule uses.
+- The "widest span" box (task #21/#22, already scheduled, not yet built) sits directly alongside
+  the audience-normalized ripple boundary, so a mod can visually compare "how far my own group
+  reaches internally" against "how far my group's posts currently ripple" on one screen, without
+  reading a paragraph of justification first.
+- The mod-facing copy (§6 below) becomes a caption *underneath* that map, not a freestanding
+  explainer page — the same discipline D3 argued for, applied to D1's parameter instead of D3's.
+
+This costs nothing new to compute (the map and the N\* value are both already-planned or
+already-built independently) — it is a UI sequencing decision, not new engineering: **ship the
+Rippling Explorer tab and the audience-normalized N\* value together, on the same screen**, rather
+than the map landing first and the parameter explanation landing later as a separate feature.
+
+---
+
+## 6. The graft: feed-forward honesty (from D4)
+
+D4's single most defensible technical point, again independently flagged by all three judges, is
+mechanical rather than philosophical: **~70% of a post's eventual audience is committed by tick 1,
+roughly one hour after posting** (the "step-70" hazard curve — tick 1 fires at t=1h, not t=0, and
+the remaining 30% spreads linearly across 8 more ticks out to 168 hours). This means any design
+that talks about the reach parameter "adapting" is, for the large majority of the audience, really
+describing a **periodically-refreshed prior**, not live per-post responsiveness.
+
+D1's rule is exactly this shape (tick-by-tick expansion governed by a quarterly-refreshed `k`,
+not a live per-post feedback loop), and this design should say so plainly rather than let the
+"self-tuning" framing in §7 imply more real-time adaptiveness than actually exists. Concretely,
+this synthesis's own documentation and mod-facing copy state explicitly:
+
+> "The reach target is recalculated from real data every three months, not live for each post. For
+> most of a post's audience — the majority reached within the first hour — the number in effect is
+> the one set at the last quarterly review, not a fresh calculation for that specific post."
+
+This is a one-paragraph honesty addition, not new engineering. It costs nothing to build and
+directly forecloses a specific, technically well-founded objection ("you're claiming this adapts
+per-post, but 70% of the audience was already locked in before your algorithm saw any signal from
+this post") that a technically literate critic — or a future audit — could otherwise raise. D4's
+own honest-cons section makes exactly this admission about its own more elaborate design; there is
+no reason D1 should claim a cleaner story than the ground truth supports.
+
+---
+
+## 7. Per-area worked examples
+
+All figures below are taken from the real dark-computed `rippling_reach.schedule` data (persisted
+routing-server ticks, 2026-06-22 to 2026-07-02, no simulation), the demand report's
+density-tercile table, and the audience-curves exemplar-group breakdown. Where a group's exact
+`active_members` count was not directly pulled in the underlying reports, the audience-at-ceiling
+figure is used as a conservative proxy and flagged as an assumption.
+
+| Area | Active members (or proxy) | N* = clip(1.0×active, 1000, 4000) | Today: audience @ 30min ceiling | Today: drive-time to reach it | Under this design: drive-time to reach N* | Under this design: final audience | What changes |
+|---|---|---|---|---|---|---|---|
+| **NW-London Offers** (Discourse-cited, no exact DB match — proxied by the inner-London borough cluster: Ealing/Brent/Hammersmith&Fulham) | ~12,000-14,000 active | **4,000 (capped)** | ~12,500-14,800 | ~30.0 min (rides ceiling, like all top-15 London groups) | ~17-19 min (interpolated between the N\*=2,000 London p50 of 13.0min and the N\*=4,000 band) | **~4,000** (vs ~12,500+ today) | This is the flagship fix: same locality-first principle, ~3x smaller audience, ~11-13 fewer minutes of drive-time. Directly answers post #250 (Chilterns-to-East-London, "an hour's drive each way", 32 groups). |
+| **Tower Hamlets** | ~3,469 (dense tercile top) | **3,469** (uncapped, within [1000,4000]) | 13,336 @ p50 17.8 min (already partially self-gated by the un-fixed reply-stop today) | 17.8 min | ~13-15 min (interpolated toward N\*≈3,469) | **~3,469** | A further ~3-5 min tightening on top of today's already-reduced figure — roughly a 4x audience reduction versus the raw 30-min ceiling case. |
+| **Oxford** | ~3,600-3,800 (proxy: audience-at-ceiling) | **~3,600** | 3,829 @ p50 30.0 min (near-ceiling-bound already) | 30.0 min | ~28-29 min | **~3,600** | Small, appropriate tightening. Oxford was never named in any Discourse complaint — this design correctly leaves it close to today's behaviour. |
+| **Swindon** | ~600-1,000 (proxy: audience-at-ceiling 672; never reaches even N\*=1,000) | **1,000 (floor)** | 672 @ 30.0 min | 30.0 min | **30.0 min — unchanged** | **672 (unchanged)** | Design working exactly as intended: Swindon was the "fine as-is" comparator in post #248 and stays untouched. |
+| **Hull** | ~659 (proxy: audience-at-ceiling; 100% never-reach at N\*=2,000/4,000) | **1,000 (floor)** | 659 @ 30.0 min | 30.0 min | 30.0 min — unchanged | **659 (unchanged)** | Same as Swindon — ceiling-bound, design-inert. Answers Group-Mod-J's "over the water" (Hull vs East Riding) complaint by *not* pretending to fix it with this lever (a purely cultural-boundary complaint this design cannot and should not try to solve; see §9). |
+| **Ribble Valley** | ~1,000-1,446 (proxy: audience-at-ceiling 1,446; 80% never-reach at N\*=2,000) | **~1,000-1,446** | 1,446 @ 30.0 min | 30.0 min | ~27-29 min for the ~20% of posts that do cross the floor early; 30 min (unchanged) for the 80% majority | **~1,000-1,446** | Essentially unchanged; a very small tightening for a minority of posts only. Rural riding to the ceiling remains the intended, undisturbed behaviour. |
+
+**The pattern this table demonstrates**: the design is inert for Hull, Swindon, and (mostly)
+Ribble Valley — exactly the areas nobody is complaining about — and materially binding for Tower
+Hamlets and the wider inner-London cluster that generated every quantified Discourse complaint.
+Oxford sits appropriately in between. This is not an assertion; it is what the real persisted tick
+data already shows would happen, computed without touching any code.
+
+---
+
+## 8. Mod-facing explanation, tied to the catchment map
+
+Per §5, this text is designed to sit as a caption directly under the Rippling Explorer / Group
+Catchment map, not as a standalone page:
+
+> **How far your group's posts ripple**
+>
+> Every Offer expands outward until it has reached roughly as many active Freeglers as your own
+> group normally has — shown on the map above, capped between 1,000 and 4,000 people depending on
+> your group's own size. That means a small rural group and a large London borough both get a fair
+> local audience for their area, instead of both being forced to travel the same number of minutes
+> down the road regardless of how many people that covers.
+>
+> In a dense area, that audience is reached in a few minutes. In a sparse area, it can take up to
+> 30 minutes' drive to find that many people at all — and the post keeps expanding that far because
+> there simply aren't more people any closer. The shaded map above shows exactly where that
+> boundary sits for your group right now.
+>
+> This number isn't set by us, and it isn't a dial groups can turn. It's recalculated automatically
+> every three months from how many of your own members are actually replying to posts at different
+> reach sizes — for most posts, that means the number in effect was set at the last quarterly
+> review, not freshly calculated for that specific post. If it's consistently missing genuine local
+> interest, or reaching further than it needs to, that shows up in the data and the number moves on
+> its own at the next review. Tell us on Discourse and we'll check the numbers behind your group
+> specifically.
+
+This directly answers the two structurally distinct hostile-audience objections on record: (1)
+"why does my post go as far as someone in a totally different density area" (posts #248, #250) —
+answered by "equal audience, not equal time", shown visually on the map, not just asserted in
+prose; (2) "why can't I just set this myself" (the rejected-slider precedent, and the in-thread
+manual-dial proposals at #289, #304, #373, #397) — answered by making explicit the number is
+derived from evidence and re-measured, specifically not a per-group toggle, while being honest
+(§6's graft) about what "automatically recalculated" actually means in practice.
+
+---
+
+## 9. Failure modes and mitigations
+
+| Failure mode | Risk | Mitigation |
+|---|---|---|
+| **Coastal / estuary geometry** | A half-circle catchment (coastal town) could behave oddly under a fixed-radius rule. | Self-corrects structurally: N\* is defined on active-member count, not distance or area, so a coastal town simply takes longer to accumulate the same N\* than an inland town of equal density. A genuine strength of audience-normalization over any fixed-time or fixed-distance design. |
+| **Group-boundary gerrymandering** | A group could inflate its own N\* by encouraging low-engagement sign-ups that count toward membership. | `active_members` is `lastaccess`-gated (90-day genuine activity), not raw membercount — a materially higher bar than mass-inviting. `N*_max=4,000` bounds the maximum possible gain even for a huge group. The re-fit (§4) uses *reply outcomes*, not `active_members` itself, as the fitness signal — an inflated count that doesn't produce more replies drags that density band's `k` down over time. |
+| **Seasonal actives (student towns, holiday areas)** | A university town's active count swings termly; a coastal town's swings with tourist season. | `active_members` is a live query recomputed on every post, not a cached quarterly figure — the count itself already tracks seasonality in real time. Only `k` and the min/max clips are on the slower quarterly cycle. |
+| **TrashNothing / cross-posted members** | If a meaningful share of "active members" are TrashNothing-side users with structurally different reply behaviour, the input and its reply-rate calibration could be systematically biased for high-crossover groups. | **Not resolved by the current evidence base** — no report measured TrashNothing member share or reply-rate differential. Explicit gap: before rollout, segment `active_members` and reply rate by primary access channel; if TrashNothing-heavy groups show a materially different curve, they need their own `k`. |
+| **Data drift / policy-induced circularity** | Rippling itself changes membership patterns (rippled-in users sometimes convert to full members), so `active_members` is partly a *consequence* of the very policy being tuned by it. | This is precisely why the re-fit is periodic, not one-time. `active_members` changes on a scale of months, materially slower than the quarterly re-fit cadence, so each re-fit sees a settled input rather than a same-cycle feedback loop. The anti-spiral guardrails (§4) are the concrete backstop against this risk compounding unnoticed. |
+| **Cold start (new/tiny groups)** | A brand-new group has `active_members` near zero. | The floor (`N*_min=1,000`) handles this directly — a new group gets the same protective floor as any small/sparse group. One implementation guard needed: a group younger than 90 days should use raw membercount as the `active_members` proxy, not read a `lastaccess`-windowed zero. |
+| **Scotland / Northern Ireland (thin data)** | Small samples (NI n=51) make a nation-specific re-fit dangerously noisy. | NI and most of Scotland are already entirely T_max-bound under this design (same as Hull/Swindon) — not a failure mode requiring mitigation for the *rule* itself. The re-fit must be done on density bands pooled across regions, never fit nation-by-nation on thin data — specified explicitly in §3/§4. |
+| **Self-reinforcing tightening spiral** | Shrunk N\* → fewer people notified → lower measured reply rate next quarter → re-fit reads that as confirmation → shrinks further. | The §4 graft: hard 15%-per-period rate cap plus the ≥90% collection-catch backtest, both computed, both gating any *shrinking* re-fit before it goes live. |
+| **Mod-load (group-count) — the complaint's most literal mechanism** | Moderators are also annoyed because posts appear in many groups they oversee, not only because of raw audience size. Mod-load is governed by group-*count* under the current "ripple into every intersecting group" engine, and capping audience alone does not shrink group count. | **Explicitly not fixed by this design.** Requires separate, unbuilt group-chunking work (the MVP plan's T2.1b, "not started"). Stated honestly here rather than oversold: this design fixes "equal time is unfair" (the specific, quantified, most-cited complaint), not "rippling causes mod overload" broadly. |
+
+---
+
+## 10. Rollout: dark-compute first, then scoped, then network-wide
+
+**Stage 0 — Dark-compute re-validation (no live change, days).** Before flipping any flag, re-run
+the demand report's density-tercile analysis with `k` swept over {0.5, 0.75, 1.0, 1.25, 1.5} on
+already-collected data, confirming `k=1.0` remains at or near the empirical peak. Pure SQL against
+existing tables. Deliverable: a one-page confirmation (or correction) before any code path changes
+behaviour.
+
+**Stage 1 — Scoped canary, dense-tercile only (~5-10 groups, 3+ weeks).** Enable
+`RIPPLE_EXTENT_ENABLED=true` with the derived formula for a small number of dense-tercile test
+groups (the population where this design is expected to bind — the top-15 London-cluster plus a
+mid-density comparator like Oxford, to see both a strongly-binding and a barely-binding case).
+Rural/sparse groups are automatically the built-in control group — they are unaffected by
+definition, so no separate canary is needed for them.
+
+Metrics tracked (all already instrumented, zero new pipeline):
+- Reply rate (P(≥1), mean repliers) vs. matched historical baseline — must not regress.
+- Time-to-first-reply — a *small* regression is expected and acceptable (this design intentionally
+  trades some audience, and the speed it buys, for less mod-load/complaint); a large one is not.
+- Notified-count and notifications-per-replier — expected to *fall* for canary groups; this is the
+  mechanism's direct cost saving.
+- Taker-distance / collection-coverage — must not regress; this is the "did we accidentally miss
+  real collectors" check.
+- Discourse/mod-complaint volume from canary-group moderators specifically.
+
+Duration: minimum 3 weeks, to clear the 7-day hazard schedule's tail and accumulate enough
+Taken-outcome lag (real signal needs ~14+ days from post arrival).
+
+**Stage 2 — Network-wide rollout, density-band by density-band, London first.** Roll out in
+descending order of expected impact: London (most-affected, best-measured) → South East/Yorkshire
+& Humber/East mid-density bands → sparse/rural bands last (design-inert there, so rollout order is
+a formality, not a risk). Re-check the same canary metrics at each band before proceeding.
+
+**Kill criteria (any one triggers immediate revert to `RIPPLE_EXTENT_ENABLED=false` for the
+affected band):**
+- Reply rate (P(≥1)) drops >15% relative to pre-rollout baseline, sustained over more than one
+  week (not a single noisy day).
+- Collection-coverage (taker-distance capture rate at the group's previous effective radius) drops
+  by more than 5 percentage points — provable, not hypothetical, missed collectors.
+- Any canary/band group's moderator escalates a complaint of the same severity class as the
+  resignation-triggering complaints already on record (a qualitative but real, board-visible
+  trigger, given two moderators already resigned over rippling and two more nearly did).
+- A quarterly re-fit is blocked by the §4 anti-spiral guardrails more than twice in a row for the
+  same density band — this indicates the input data or method has degraded, not that the true
+  optimum is genuinely moving, and should halt automated re-fitting pending manual review.
+
+---
+
+## 11. Self-maintenance loop
+
+Every quarter (90 days):
+
+1. **Re-derive `k` per density band** (not per region — Scotland/NI's thin samples get pooled into
+   a shared "small dense" or "small sparse" band with similarly-sized clusters elsewhere, never
+   fit alone) from the trailing 90 days of live reply-decile data, using exactly the demand
+   report's §6 methodology.
+2. **Check both anti-spiral guardrails (§4)** before applying any proposed change: the 15%
+   rate-of-change cap, and the ≥90% collection-catch backtest for any shrinking move. A re-fit
+   that fails either gate routes to manual review, not automatic application.
+3. **Re-derive `N*_min`/`N*_max` only if the fine-bucket reply-rate table shows the
+   flattening/decline points have moved by more than 20%** from the values that set today's
+   1,000/4,000 — small quarter-to-quarter noise should not move the clips.
+4. **Write the new values to `rippling_params`** — the existing, currently-unwired scaffold table
+   — and have `ReachService.php` read `k`/`N*_min`/`N*_max` from there instead of the static config
+   constant, with the static value retained only as a fallback default.
+5. **This is the first real consumer of the stubbed `RippleTuneService::categoryVolumeDeltas()`**,
+   which today unconditionally returns an empty array. Instead of inventing new self-tuning logic
+   at implementation time, it computes exactly the density-tercile reply-decile table this design
+   already specifies and has already validated.
+
+**Relationship to the existing extent-governor MVP:** adopt and complete it. The MVP's mechanism
+(audience-budget stop, already coded) is not replaced — it is exactly what this design turns on.
+The only change is supplying the previously-missing derivation for the target in place of the
+flat, uncalibrated placeholder, and wiring the dark self-tuning scaffold to actually maintain it.
+
+**Relationship to the planned reach experiment:** complementary, not competing, and answers a
+different question. The reach experiment (user-level ADD randomization, ~3 weeks) measures whether
+reach *beyond* today's ceiling would help — an expansion/upper-bound question, structurally
+unobservable from history because everyone extra reach would add is currently unexposed. This
+design answers whether today's reach is *already enough, unevenly distributed* — a
+reallocation/efficiency question, and the demand-flattening evidence already visible in-sample
+suggests the answer is "mostly yes, and in dense areas more reach actively hurts." The two can run
+concurrently provided they are statistically disentangled (the experiment should exclude
+canary-band groups from its treatment arms, or the canary should be sequenced to start after the
+experiment's ~3-week readout if analytical interference is a concern) — a brief coordination check
+before Stage 1 begins is recommended.
+
+---
+
+## 12. Honest cons
+
+**1. The core derivation rests on exactly two clean data points.** The within-tercile peak was
+observed cleanly in the medium and dense terciles only — the sparse tercile never showed a decline
+in the observed range, so `k` for sparse areas is assumed to generalize from the same ratio rather
+than independently confirmed. This risk is *contained* (sparse groups are floor/ceiling-bound
+regardless, so an unverified `k` there is functionally inert per §7's worked examples) but the
+derivation confidence is genuinely asymmetric across density bands, and that should be stated
+plainly rather than hidden behind one clean-looking formula.
+
+**2. Mod-load (group-count) is not fixed by this design.** Covered fully in §9's failure-mode
+table — worth repeating here because it is the single most important scope boundary. This design
+fixes the audience-fairness dimension of the flagship complaint cleanly; it does not fix "posts
+appear in too many groups a moderator oversees", which needs separate, unbuilt group-chunking work.
+
+**3. Reply-rate-as-optimization-target is itself gameable/mis-specified over the long run.**
+Replies are influenced by many things this design doesn't model (post quality, photo presence, time
+of day, category desirability), and the periodic re-fit implicitly assumes any drift in the
+reply-vs-audience relationship is due to the audience parameter being wrong, when it could equally
+be a shift in post mix, seasonality, or the deliverability feedback loop flagged elsewhere in the
+evidence base as unresolved (high volume → spam-foldering → measured reply rate looks artificially
+low → an over-correction in the wrong direction). The §4 anti-spiral guardrails are a partial
+defence against this, not a complete one.
+
+**4. Equal-audience has its own fairness critique, symmetric to the one it replaces.** A genuinely
+huge, dense group's posts get proportionally less exposure relative to their own membership than a
+small group's posts do (a 15,000-active-member group capped at 4,000 = ~27% of its own base; a
+1,000-active-member group gets the full 1,000 = 100% of its own base). This is the entire point for
+the density complaint, but it is a real, different-axis inequality this design deliberately trades
+in — worth naming explicitly rather than presenting audience-normalization as a free lunch.
+
+**5. Depends on data that is itself only 10 days old and pre-dates full-volume rippling maturity**
+(home-group reply share already drifted from ~98% to 82.5% in nine days). A derivation built on 10
+days of post-launch data, in a system whose own behaviour is still visibly settling, carries
+meaningfully more re-fit risk in its first year than the quarterly cadence assumes. The first 2-3
+quarterly re-fits should be treated as provisional and higher-variance than quarter-5's will be,
+and communicated as such internally.
+
+**6. Feed-forward dominance limits how "adaptive" this design actually is for most of the audience**
+(the §6 graft's own honest admission) — for the ~70% of a post's audience committed within the
+first hour, the number in effect is a quarterly-refreshed prior, not a live per-post calculation.
+This is stated plainly in the mod-facing copy (§8) precisely so the design does not overclaim
+real-time responsiveness it does not have.
+
+---
+
+## 13. Open questions
+
+- **TrashNothing crossover** — does a materially different reply-rate curve exist for
+  high-crossover groups, requiring a separate `k`? No report in the evidence base measured this;
+  it is a one-query check that should happen before Stage 1, not a blocker to Stage 0.
+- **Deliverability feedback loop** — is high-volume rippling itself suppressing measured reply rate
+  via spam-foldering, in a way that could bias the quarterly re-fit toward an incorrectly larger
+  (not smaller) `N*` in exactly the areas already generating the most volume? Flagged, not
+  resolved, in the underlying mechanics evidence; worth a dedicated check before the re-fit is
+  first allowed to run unattended.
+- **Exact sequencing with the Rippling Explorer / Group Catchment map release** — §5's graft
+  assumes the map and the audience-normalized N\* land together on the same screen; if the map
+  ships materially before this design's Stage 1, is there value in a stopgap that at least surfaces
+  today's flat 30-min ceiling on the map before the audience-normalized replacement is ready, or is
+  it better to hold the map release until both can land together?
+- **Exact sequencing with the reach experiment** — §11 recommends a coordination check before
+  Stage 1 to avoid statistical interference between the two; the exact mechanism (excluding
+  canary-band groups from experiment treatment arms, versus sequencing one after the other) has not
+  been decided and needs an owner.
+- **Group-chunking (mod-load fix)** — this design explicitly does not address it (§9, §12). Is
+  there appetite to scope that as a distinct, parallel effort, given it is the one dimension of the
+  flagship complaint this design leaves untouched?
+- **Should `reply_saturation_stop` move from 5 to 3 as a standalone change, ahead of the main N\*
+  rollout?** It is dead code today (never fired in 10,742 posts) and the fix is a one-line config
+  change with no dependency on anything else in this design — but it was not the evidence base's
+  primary target and deserves its own small validation pass rather than being bundled silently into
+  Stage 1.
+- **First-year re-fit variance (con #5)** — should the first 2-3 quarterly re-fits use a tighter
+  rate-of-change cap than 15% (e.g. 10%), given the acknowledged higher noise in the founding
+  dataset, reverting to 15% once the system has a full year of settled data?
+
+---
+
+## Evidence and design sources
+
+- `/tmp/claude-1000/-home-edward-FreegleDockerWSL/32f74873-7429-488e-b2f3-7ded306eaba4/scratchpad/reach-design/1-mechanics.md`
+- `/tmp/claude-1000/-home-edward-FreegleDockerWSL/32f74873-7429-488e-b2f3-7ded306eaba4/scratchpad/reach-design/2-discourse.md`
+- `/tmp/claude-1000/-home-edward-FreegleDockerWSL/32f74873-7429-488e-b2f3-7ded306eaba4/scratchpad/reach-design/3-behaviour.md`
+- `/tmp/claude-1000/-home-edward-FreegleDockerWSL/32f74873-7429-488e-b2f3-7ded306eaba4/scratchpad/reach-design/4-audience-curves.md`
+- `/tmp/claude-1000/-home-edward-FreegleDockerWSL/32f74873-7429-488e-b2f3-7ded306eaba4/scratchpad/reach-design/5-demand.md`
+- `/tmp/claude-1000/-home-edward-FreegleDockerWSL/32f74873-7429-488e-b2f3-7ded306eaba4/scratchpad/reach-design/6-external-anchors.md`
+- `/tmp/claude-1000/-home-edward-FreegleDockerWSL/32f74873-7429-488e-b2f3-7ded306eaba4/scratchpad/reach-design/D1-audience-target.md` (base philosophy — winning design, all three judges)
+- `/tmp/claude-1000/-home-edward-FreegleDockerWSL/32f74873-7429-488e-b2f3-7ded306eaba4/scratchpad/reach-design/D2-behavioural-percentile.md` (graft: anti-spiral guardrails, §4)
+- `/tmp/claude-1000/-home-edward-FreegleDockerWSL/32f74873-7429-488e-b2f3-7ded306eaba4/scratchpad/reach-design/D3-community-relative.md` (graft: catchment-map co-location, §5)
+- `/tmp/claude-1000/-home-edward-FreegleDockerWSL/32f74873-7429-488e-b2f3-7ded306eaba4/scratchpad/reach-design/D4-adaptive-control.md` (graft: feed-forward honesty, §6)
+- `/tmp/claude-1000/-home-edward-FreegleDockerWSL/32f74873-7429-488e-b2f3-7ded306eaba4/scratchpad/reach-design/J1-judge.md`, `J2-judge.md`, `J3-judge.md` (three independent scoring passes)
+- Live codebase: `RIPPLE_EXTENT_ENABLED`, `RIPPLE_EXTENT_TARGET_USERS` in `config/freegle.php`;
+  `iznik-routing-go/ripple.go`; `ReachService.php`; `RippleTuneService`; `rippling_params` table;
+  modtools components `RipplingExplanation.vue`, `RipplingExplanationGeneral.vue`,
+  `RipplingHelpModal.vue`, `PostMap.vue` (Rippling Explorer / Group Catchment map, built, awaiting
+  release — modtools task list items #12-#24 in this working tree)

--- a/plans/2026-07-02-reach-design-evidence/V1-attack.md
+++ b/plans/2026-07-02-reach-design-evidence/V1-attack.md
@@ -1,0 +1,355 @@
+# Adversary 1: The Hostile Moderator — Attack on SYNTHESIS.md
+
+**Posture**: I am Jax, or Jos, or Group-Mod-J, reading this design with the Discourse thread
+(#9808) open in the next tab, primed to believe "the algorithm decided" is a fig leaf, and
+already burned by post #7's "your feeling is probably wrong" framing. My job is to find where
+this design would fail against a real complainant, not to be satisfied by good intentions.
+
+**Method**: every claim in SYNTHESIS.md checked against the six evidence files it cites. Verdicts
+are FATAL (design is wrong as written — must change before proposing), MAJOR (must fix before
+this goes to a mod or a product owner), or MINOR (note in doc, doesn't block).
+
+---
+
+## FATAL-1: The flagship worked example's key number is not what it says it is
+
+**Claim (§7, first row)**: NW-London Offers has "~12,000-14,000 active [members]", so
+`N* = clip(1.0 × 12,000-14,000, 1000, 4000) = 4,000 (capped)`.
+
+**What the evidence actually supports**: SYNTHESIS.md's own caption under the §7 table admits:
+"Where a group's exact `active_members` count was not directly pulled in the underlying reports,
+the audience-at-ceiling figure is used as a conservative proxy and flagged as an assumption."
+For NW-London, the "~12,000-14,000 active" figure in the `active_members` column is **numerically
+identical** to the "Today: audience @ 30min ceiling" column two columns over (~12,500-14,800) —
+because it *is* that number, relabelled. `total_freeglers` (audience-curves.md §1, the realized
+reach-polygon population at 30 minutes) and `active_members(home_group)` (5-demand.md §6, a
+membership-table count with a `lastaccess` gate) are **defined as different things by this same
+design** — one is "how many people are in the group," the other is "how many people are
+reachable within 30 minutes drive of a post from that group." They are not interchangeable, and
+for a dense borough group with heavy rippled-in reach they will diverge hard: `total_freeglers`
+already includes everyone the *current, uncapped* 30-min rule pulls in from neighbouring groups,
+which is exactly the quantity the new rule is trying to shrink. Using it as the input to the
+formula that's supposed to *replace* it is circular — it bakes today's "too large" reach into
+tomorrow's "principled" target.
+
+**Why this is FATAL, not MINOR**: this is not a random row in the table. It is the flagship
+example — the one built to answer post #250, the "Chilterns to East London, an hour's drive
+each way" complaint that is the canonical citation for the whole project brief. Every number a
+hostile mod would check first (does this actually fix Jax's complaint?) sits on top of a
+proxy that was explicitly flagged as an assumption in a footnote, three columns away from where
+it's used to compute the load-bearing N* value. A mod who reads the footnote (and Jax, at 55
+posts in the thread, reads carefully) will find: "the group's own membership, which is what your
+formula claims to key off, was never actually measured for the one example you built to convince
+me." That is a credibility hole roughly one Discourse post away from resurfacing as "so it's not
+even based on real numbers for the case that started this."
+
+**Concrete check that would catch this**: query `active_members` (memberships,
+`collection='Approved'`, `lastaccess >= 90 days`) directly for Ealing/Brent/Hammersmith & Fulham
+— the design already names these three as the proxy cluster (§7 caption) and 5-demand.md's own
+SQL (§6) is the exact query needed. This is a five-minute SQL query against a table this design
+already reads from, not new instrumentation.
+
+**Fix**: before this design is shown to anyone outside engineering, re-run the §7 table with
+real `active_members(home_group)` for every named exemplar (Tower Hamlets, Oxford, Swindon, Hull,
+Ribble Valley, and the NW-London proxy cluster), not `total_freeglers`-as-proxy. If real
+`active_members` for Ealing/Brent/H&F comes back materially lower than 12,000-14,000 (plausible —
+`total_freeglers` already includes rippled-in reach from neighbouring dense boroughs, which
+inflates it well past a group's own membership), the resulting N* is still 4,000 (ceiling-capped
+either way, since anything above 4,000 active members clips to the same value) — so the *final
+number* may survive, but the *story* ("N* = a group's own size, not an arbitrary constant")
+currently rests on an unmeasured, mislabelled input for its single most important case, and that
+must be fixed even if the output number doesn't move.
+
+---
+
+## FATAL-2: k=1.0 is fit on data that never goes near the group this design's flagship
+## example is about — this is extrapolation dressed as calibration
+
+**Claim (§2, §3)**: "the demand report's within-density-tercile analysis... rules out the
+obvious objection that 'more audience just means more density'... No other design's core number
+survives this kind of check." k=1.0 is presented as *the* confound-checked, evidence-backed
+number the whole design stands on.
+
+**What the evidence actually supports**: 5-demand.md §6's density terciles are built from real
+posts in the current network. The **densest tercile tops out at 1,726-3,469 active members**
+(the table's own row label: "3 (1,726-3,469 active, densest)"). Tower Hamlets, at 3,469 active
+members, is *literally the top of the calibration range this design's core constant was fit on*.
+There is no data point anywhere in the cited evidence for a group with active_members in the
+12,000-14,000 range — because (per FATAL-1) no report ever actually measured that number for any
+real group; every group the demand report's tercile analysis covers already tops out below
+3,500 active members, by construction of the tercile split on the network's actual density
+distribution.
+
+This means: for the single case this design was built to fix (NW-London / the 27,000-active-audience
+complaint per post #248), k=1.0 is not "confound-checked, not just correlated" — it is
+**extrapolated 3-4x past the edge of the only range it was ever checked against**. The
+within-tercile finding ("reply probability peaks near ~1x the tercile's own scale, declines past
+it") was demonstrated on groups scaling up to ~3,469 active members. Whether the same 1.0x
+relationship holds, over-predicts, or under-predicts for a hypothetical ~12,000-14,000-active
+group is **not evidence the report contains** — it's an assumption the design makes silently by
+applying the same formula uniformly.
+
+**Why FATAL not MAJOR**: §2's own selling point — "the only design whose central claim was
+confound-checked, not just correlated" — is the design's single strongest argument for beating
+D2/D3/D4. If the flagship application of that claim is actually an extrapolation past the fitted
+range, the design's core differentiator doesn't survive contact with its own headline example.
+A statistically literate hostile reader (Judge 2's own objection pattern: "the observed 'peak'
+could be curvature within a truncated range") will find this in about the time it takes to
+compare the tercile boundaries against the worked example — the same five minutes as FATAL-1,
+and for the same underlying reason (no real ultra-dense group has ever been measured).
+
+**Fix**: (a) explicitly and separately verify whether any group in the network — even outside
+the reach dataset used for the tercile split, e.g. a single dense London borough sampled on its
+own — has active_members materially above 3,469, and if so, whether its post-level reply-vs-audience
+curve looks like a continuation of the tercile-3 trend or something different (a plateau,
+a further decline, a discontinuity). This is the honest version of Stage 0's re-validation sweep,
+and should explicitly include "does k=1.0 hold above the fitted range" as a named check, not just
+"sweep k over {0.5...1.5} on the same data" (which re-tests the fit, not the extrapolation). (b)
+Until that check exists, the design should state plainly that **for the single highest-stakes
+case in the whole document, N* is a capped value (4,000, hitting `N*_max`) precisely because k
+was never measured there** — the ceiling is doing the work of masking an untested extrapolation,
+which is a materially different and much weaker claim than "your own group's size, scaled by an
+evidence-backed multiplier."
+
+---
+
+## MAJOR-1: The anti-spiral collection-catch backtest protects the wrong transition
+
+**Claim (§4, §9's "self-reinforcing tightening spiral" row)**: the ≥90% collection-catch
+backtest is presented as the mechanism that stops N* from spiralling down to something that
+misses real collectors — directly answering the mechanics report's own explicit prior finding
+(§6 of 1-mechanics.md, listed as a decision "already made, do not relitigate"): "**A people-count
+cap that DECREASES with density is wrong** — the taker-distance validation... refutes it:
+dense-area real takers rank ~1,719th nearest active member (mean 5,126th), so a tight cap
+(1,500) misses 54% of real collectors."
+
+**What the evidence actually supports**: read §4 and §11 of SYNTHESIS.md carefully — the
+backtest is gated on *quarterly re-fits*, and specifically only "before any re-fit is allowed to
+**shrink** N\* for a density band." It is never run against the **initial** move from today's
+uncapped ~30-min-ceiling reach down to the newly-derived N* at rollout (Stage 1/2, §10). But the
+single biggest cut in the entire design **is** that initial move — Tower Hamlets goes from
+13,336 (today, at its already-gated 17.8min) to 3,469 under N*, and the NW-London proxy cluster
+goes from ~12,500-14,800 to 4,000 — both far bigger single-step cuts than any conceivable
+15%-per-quarter drift the anti-spiral cap is designed to catch. The mechanics report's own cited
+validation — the exact statistic ("1,500 cap misses 54% of real collectors", taker rank
+~1,719th/mean 5,126th nearest active member) — is never actually run against the proposed
+N*=3,469-4,000 values for these specific dense groups anywhere in this evidence base. The
+closest thing offered is the *reply*-rate confound check (5-demand.md §6), which is a different
+outcome variable from *collection* (Taken/Received) — and 5-demand.md §2 explicitly flags its own
+Taken-outcome analysis as underpowered (n=429, "should not be treated as more than directionally
+consistent... re-run after 2026-07-15+").
+
+**Why MAJOR not FATAL**: the mechanism (collection-catch backtest) is sound in principle and
+correctly identified by all three judges as the right kind of guardrail — it just isn't wired to
+fire at the one moment (initial rollout) where the mechanics report's own prior warning about
+density-decreasing caps is most directly on point. This is fixable without redesigning anything.
+
+**Fix**: run the collection-catch backtest **before Stage 1 begins**, not just at each quarterly
+re-fit — replay the actual taker-distance data (the exact methodology already in
+1-mechanics.md §6 and 6-external-anchors.md §1/§3: taker rank vs cap, % of real collections
+captured at a given cap) against the proposed N*=3,469 (Tower Hamlets) and N*=4,000 (NW-London
+cluster) specifically, using real taker-rank-among-active-members data, not the reply-rate proxy.
+If real dense-area takers cluster mostly under rank ~4,000 (plausible, given the cited "1,500
+misses 54%, E*=5→~7,015 active misses only 19%" finding implies the true collector distribution
+has a long tail well past 4,000), this initial-rollout backtest could show the flagship N*=4,000
+cap itself materially undershoots real collector coverage — which would be a genuinely
+inconvenient, load-bearing finding this design currently has no mechanism to surface before
+shipping, because the backtest as specified never looks at the rollout transition at all.
+
+---
+
+## MAJOR-2: "It's not a slider" is a half-truth a technically literate mod will unpick
+
+**Claim (§8, mod-facing copy)**: "This number isn't set by us, and it isn't a dial groups can
+turn. It's recalculated automatically every three months from how many of your own members are
+actually replying to posts at different reach sizes."
+
+**What the design actually contains**: §4 specifies a hard 15%-per-period cap on how much `k`
+(and the derived clips) can move, with any larger proposed move **"routed to manual review before
+any live change."** §11 step 2 restates: "A re-fit that fails either gate routes to manual
+review, not automatic application." §9's failure-mode table for the mod-load-count problem and
+§13's open questions ("should the first 2-3 quarterly re-fits use a tighter... cap... given the
+acknowledged higher noise") both treat "someone manually decides" as a live, expected pathway,
+not a hypothetical.
+
+This means: in any quarter where the data would move `k` (or the min/max clips) by more than 15%,
+**a human being decides what number to use** — the same shape of decision a rejected per-group
+slider would produce, just gated by a bigger threshold and routed to engineering/product instead
+of the group's own moderator. The mod-facing copy's claim "it isn't a dial groups can turn" is
+true in the narrow sense (mods themselves don't turn it) but glosses over the fact that *someone*
+still turns it by hand whenever the data is noisy or the guardrail trips — which, per honest-con
+#5 (10-day-old data, "should be treated as provisional and higher-variance"), is explicitly
+expected to be common in year one. A hostile, technically-literate mod (Derek, Jos — both cite
+screenshots and specific numbers, not vibes) reading §4/§11/§13 alongside §8's mod copy will spot
+the gap: "recalculated automatically" is doing a lot of work to paper over "except when it isn't,
+which the design itself expects to happen often at first."
+
+**Why MAJOR**: this isn't a fabrication — the manual-review pathway is a genuinely good safety
+mechanism (§4's whole point). But the mod-facing copy in §8 doesn't mention it at all, and this
+document has already lived through one trust collapse triggered by an authority figure (#7,
+"trust the data") appearing to oversimplify or steamroll moderator concerns (2-discourse.md §3:
+"#400 (Sheila): 'Our suggestions are slapped down with quotes of data, that we can't possibly have
+fully' — trust-in-data breakdown"). If a mod later discovers via a Discourse thread or a change-log
+that "automatic" quarterly re-fits were in fact manually adjusted three times in year one, the
+resulting "I told you it was secretly a slider" reaction will land with more force *because* the
+copy claimed otherwise, not less — this is a worse trust outcome than being upfront about it from
+the start.
+
+**Fix**: rewrite §8's mod copy to say something closer to the truth: "recalculated automatically
+from real data every three months, within safety limits; if the data suggests a bigger jump than
+usual, that's flagged for a person to check before it goes live — same as any other unusual change
+we make." This is a small wording change, it makes the guardrail a selling point (careful, not
+capricious) instead of a hidden trapdoor, and it forecloses the specific "gotcha" a Discourse
+regular would otherwise eventually find and post about.
+
+---
+
+## MAJOR-3: "Can a mod predict tomorrow's reach?" — no, and the design doesn't say what a mod
+## actually needs to predict it
+
+**Claim (§6 graft, §8 mod copy)**: the design is explicit that ~70% of audience is committed by
+tick 1 and the number in effect is a "quarterly-refreshed prior, not live" — presented as an
+honesty win (which it partly is: at least it isn't overclaiming). But this doesn't actually answer
+the hostile question underneath: **given the mod-facing copy, can Jax, reading it, predict what
+her Wednesday-morning post will reach?**
+
+**What the design actually supports**: no. Even fully informed, a mod cannot compute N* herself
+— `active_members(home_group)` is a live, internal query result (5-demand.md's SQL, not exposed
+anywhere in ModTools per the current task list — item #21/#22, "widest span" box, is about
+distance/postcodes, not active-member counts or N*). The mod-facing copy (§8) says the boundary
+"is shown on the map above" (per the §5 graft), which is the right instinct, but that graft is
+explicitly **not yet built** ("awaiting release" — modtools task list items #12-#24, several
+still `pending` per this project's own task tracker: #16, #21, #22, #23, #24 open as of this
+design). So today, and for however long the Catchment map / N* co-location graft takes to ship,
+a mod asking "why does my post reach 32 groups" has **no artifact at all** to point to — §5's
+whole graft, the thing all three judges praised as solving exactly this objection, is vaporware
+relative to this design's own timeline. The design's Stage 1/2 rollout plan (§10) does not gate
+on the map shipping first; §13's open question ("if the map ships materially before this design's
+Stage 1... is it better to hold the map release until both can land together?") explicitly leaves
+this **unresolved**, i.e. the single graft that answers "can a mod see why" might not exist when
+the audience-cap first goes live.
+
+**Why MAJOR**: shipping the audience-cap mechanism (Stage 1 canary) before the explainability
+artifact it depends on (§5's graft) reproduces exactly the failure mode 2-discourse.md's
+requirements section names as non-negotiable: "Must not re-centralize the 'we have no control'
+grievance... unless paired with a visible per-area published number" (2-discourse.md §7,
+requirement 3). An invisible N* landing before its visible explanation is the single scenario
+this whole design was supposed to avoid, and the open question in §13 currently allows it to
+happen by default (silence = no ordering constraint = Stage 1 can proceed independently).
+
+**Fix**: make "the Rippling Explorer / Catchment map + N* overlay ships to mods BEFORE or
+simultaneously with Stage 1 canary" a hard sequencing gate in §10, not an open question in §13.
+If the map isn't ready, Stage 0 (dark-compute re-validation) can proceed on schedule, but Stage 1
+(the first live canary, i.e. the first real mod-visible behaviour change) should not start until
+a mod can click through to see their own group's N* and boundary — otherwise this design ships
+the exact "invisible algorithm changed my reach and I found out from a complaint, not a screen"
+pattern that caused two resignations already.
+
+---
+
+## MAJOR-4: Would the flame war accept the mod-facing text? — testing it against the thread's
+## own vocabulary shows a mismatch on the density framing
+
+**Claim (§8)**: "a small rural group and a large London borough both get a fair local audience
+for their area, instead of both being forced to travel the same number of minutes down the road
+regardless of how many people that covers."
+
+**What the evidence actually supports**: this sentence is designed to answer #248/#250 (Jos,
+Neville_Reid — the Swindon-vs-London complaint). But re-read what those posts actually say
+(2-discourse.md §2, item 11): the complaint is framed as "*halfway on reach slider* = ~30 min
+travel Swindon (judged 'pretty perfect') vs ~50+ min London/Islington (judged too far)" — i.e.
+the mods are talking in **slider position and minutes**, not audience counts. Nobody in the
+thread ever says "my post should reach N people" — 2-discourse.md §4 is explicit: **"No mod
+proposed a data-derived/self-calibrating mechanism themselves... The 'principled, data-derived,
+self-maintaining' framing in the project brief is not something any mod asked for or would
+recognize as satisfying their complaint on its own — they want a dial, and got a partial one (the
+per-member slider)."**
+
+This means the mod-facing copy's chosen framing ("equal audience, not equal time") is a genuine,
+correct technical fix to the *underlying* problem the complaints are gesturing at, but it is not
+phrased in a vocabulary the actual complainants have ever used. A hostile-but-fair reading: Jax
+and Jos will read "fair local audience... instead of the same number of minutes" and their first
+reaction, based on their own in-thread history, is likely to be "why are you telling me about
+audience counts, I never asked for that, I asked why my post goes to 32 groups an hour's drive
+away" — i.e. the copy answers a question in the language of the analyst, not the language of the
+complaint. The design is not wrong to fix audience-fairness (the underlying math is sound and
+D1's diagnostic case for *why* audience, not time, is the right invariant is genuinely strong) —
+but §8's copy, as currently drafted, risks landing as another instance of "the data says so"
+(#7's framing, which 2-discourse.md documents as having "visibly backfired repeatedly") dressed
+in nicer prose, rather than as an answer to "why does my post reach 32 groups."
+
+**Why MAJOR not MINOR**: 2-discourse.md §7 requirement 1 is explicit that any design "needs an
+answer better than 'the data says so.'" The current copy leads with the mechanism (audience vs
+time) before it leads with the complainant's own framing (group count, minutes, "how far will
+this actually go"). This is a copy-ordering problem, not a math problem, but it's exactly the kind
+of thing that determined the difference between #237's wording fix (accepted, implemented same-day)
+and #7's data-first framing (which "visibly backfired repeatedly" per the same evidence file).
+
+**Fix**: reorder §8's copy to open with the complainant's own vocabulary — group count and
+minutes — before introducing audience-size as the mechanism: e.g. "Your post won't be shown to
+every group within a fixed number of minutes any more — instead it stops once it's reached a fair
+number of people for an area like yours, which in a dense area happens much sooner (fewer
+minutes, fewer groups) than it used to." Lead with the outcome mods actually complained about
+(fewer minutes, fewer groups touched), not the mechanism (audience counted, not time). This is a
+wording change, not a design change, but §8 as currently drafted risks re-triggering the exact
+"you're explaining, not listening" reaction the thread's own history warns about.
+
+---
+
+## MINOR-1: "Punishes rural groups?" — checked, does not hold, but the honest-cons section
+## undersells how asymmetric the confidence really is
+
+The design does NOT punish rural groups on any axis actually checked: §7's worked examples (Hull,
+Swindon, Ribble Valley) are unchanged or near-unchanged, and honest-con #1 already flags that
+sparse-tercile k "is assumed to generalize... rather than independently confirmed," correctly
+noting this is "functionally inert" because sparse groups are floor/ceiling-bound regardless.
+This is a fair characterization — no fix needed on the substance. One nuance worth adding: the
+"functionally inert" framing is true for *audience size* but the design never checks whether the
+**drive-time to reach the floor** changes meaningfully for any rural group under the new rule
+(§7's Ribble Valley row gestures at "~27-29 min for the ~20% of posts that do cross the floor
+early" but doesn't quantify how many rural groups fall into that 20%-early-crossing bucket
+nationally, vs. the 80%+ that stay ceiling-bound). Given 35% of all groups nationally never reach
+even N*=2,000 (4-audience-curves.md §3c), a small verification that this 20%-early-crossing
+pattern isn't concentrated in some particular rural cluster (e.g. small commuter-belt towns just
+under the sparse/medium tercile boundary) would close this off entirely. Low stakes, cheap check,
+worth doing during Stage 0.
+
+## MINOR-2: reply_saturation_stop recalibration (5→3) shares an evidence base with k but is
+## validated on the SAME flat/declining data the FATAL-2 extrapolation concern applies to
+
+§3's table justifies dropping `reply_saturation_stop` from 5 to 3 using 5-demand.md §1's
+P(≥3)=4-8% vs P(≥5)≈1% figures — reasonable on its own terms, and correctly flagged in §13 as
+deserving separate validation rather than silent bundling. No additional finding beyond what §13
+already states; noting only that this constant inherits the same "no real ultra-dense group in
+the underlying tercile split" caveat as FATAL-2, so its own separate validation pass should
+explicitly check whether P(≥3) holds at higher audience levels too, not just re-confirm the
+existing decile table.
+
+---
+
+## Summary verdict
+
+| # | Finding | Verdict | Blocks the flagship complaint fix? |
+|---|---|---|---|
+| FATAL-1 | NW-London worked example's `active_members` is actually `total_freeglers` (circular, mislabelled) | FATAL | Yes — undermines the single example built to answer #250 |
+| FATAL-2 | k=1.0 extrapolated 3-4x past the densest fitted tercile (max 3,469 active) for the flagship case | FATAL | Yes — same example, deeper problem: even a correctly-measured input would still be outside the fitted range |
+| MAJOR-1 | Collection-catch backtest never runs against the initial rollout transition, only future re-fits | MAJOR | Indirectly — the exact prior finding it's supposed to honor ("cap that decreases with density is wrong") is untested for the actual proposed cut |
+| MAJOR-2 | Mod copy claims "not a dial" while §4/§11/§13 describe a real manual-review pathway | MAJOR | No, but risks a second trust collapse if discovered later |
+| MAJOR-3 | Explainability graft (§5, the map) has no shipping-order guarantee relative to the audience-cap itself | MAJOR | Yes — could ship the invisible parameter before the visible artifact that's supposed to justify it |
+| MAJOR-4 | Mod-facing copy leads with mechanism (audience) not complainant vocabulary (minutes, group count) | MAJOR | Partially — risks the same "explaining not listening" reaction that already cost trust once |
+| MINOR-1 | Rural early-crossing minority not quantified | MINOR | No |
+| MINOR-2 | reply_saturation_stop recalibration shares FATAL-2's evidence-range caveat | MINOR | No |
+
+**Bottom line for the hostile moderator**: the underlying philosophy (audience, not time, should
+be the invariant) is sound and well-evidenced for every group this design's own data actually
+measured — Tower Hamlets, Oxford, Swindon, Hull, Ribble Valley all check out. The design breaks
+down exactly where it matters most: the single flagship case (NW-London / post #250) that the
+whole project exists to fix rests on a proxied, mislabelled input variable and an untested
+extrapolation of its core multiplier, and the collection-catch guardrail that's supposed to
+catch exactly this kind of problem is wired to fire on the wrong transition (future re-fits, not
+the initial rollout). None of these are reasons to abandon D1's approach — they are reasons not
+to present the NW-London row as demonstrated, and not to start Stage 1 until (a) real
+`active_members` is measured for at least one genuinely ultra-dense group, (b) the collection-catch
+backtest is run against the actual proposed initial cut for that group, and (c) the Catchment-map
+explainability graft is confirmed to ship no later than Stage 1, not left as an open scheduling
+question.

--- a/plans/2026-07-02-reach-design-evidence/V2-attack.md
+++ b/plans/2026-07-02-reach-design-evidence/V2-attack.md
@@ -1,0 +1,327 @@
+# Adversary 2 (Statistician) — Attack on SYNTHESIS.md
+
+Scope: attack the derivations in `SYNTHESIS.md` (the D1-based audience-normalization design with
+D2/D3/D4 grafts). Checked every load-bearing number against the underlying evidence files
+(`1-mechanics.md`, `2-discourse.md`, `3-behaviour.md`, `4-audience-curves.md`, `5-demand.md`,
+`6-external-anchors.md`) and against the four candidate designs (`D1`-`D4`) and the three judge
+transcripts (`J1`-`J3`), which had already flagged some of this territory. Findings below are
+either (a) genuinely new — not named anywhere in J1-J3 or SYNTHESIS's own §12/§13 — or (b) named
+somewhere in the evidence base but **silently dropped or weakened when merged into SYNTHESIS.md**,
+which is a distinct and more serious problem than "known limitation," because a reader of the
+synthesis alone would not know the caveat exists or was ever stronger.
+
+Verdicts: **FATAL** = the design is wrong as specified and must change before proposing to a
+product owner. **MAJOR** = must be fixed before this is safe to build, but the core philosophy
+survives. **MINOR** = worth noting in the doc, does not block.
+
+---
+
+## FATAL-1: The anti-spiral "collection-catch backtest" cannot detect the spiral it exists to catch
+
+**Location:** `SYNTHESIS.md` §4 (lines 130-138), restated in §11 step 2 and the failure-mode table
+(§9, "Self-reinforcing tightening spiral" row).
+
+**The claim:** the backtest replays "last quarter's actual collections" against a proposed smaller
+`N*` and requires ≥90% capture, and this is presented — twice, explicitly — as proof the proposal
+"is shown to serve what already happened, **not just satisfy a percentile computed on an
+already-shrunk population**" (§4, emphasis in original).
+
+**Why this is false, mechanically:** "last quarter's actual collections" are themselves the output
+of *last quarter's* `N*`/`k`. If quarter Q's re-fit shrinks `N*` (even within the 15% band), then
+every collection in quarter Q+1 that the backtest replays happened under the *already-shrunk*
+reach. A person who would have collected the item only if reach had been wider than Q's shrunk
+`N*` never appears in the outcome table at all — they were never notified, never saw the post,
+never converted. The backtest cannot "catch" a collection that structurally could not have
+happened. It is not an independent check against the true, unshrunk demand; it is a check against
+demand-as-already-filtered-by-the-thing-being-tuned. This is precisely the "already-shrunk
+population" failure mode the synthesis's own sentence claims to rule out — it does not rule it
+out, it restates it with different words and a specific number (90%) that gives false confidence.
+
+**This was already correctly diagnosed in the source evidence and dropped in synthesis.**
+`D2-behavioural-percentile.md` §1.3's own risk table (line 262) states the backtest is only *one
+of three* mechanisms needed to actually break the spiral, and names the third explicitly as
+load-bearing: *"(c) §1.5(c)'s explicit plan to swap in the reach experiment's uncensored
+treatment-arm data the moment it's available, which **structurally breaks the spiral** by
+introducing a genuinely uncensored input at least once."* D2 is explicit that (a) the 15% cap and
+(b) the backtest **alone** only slow the spiral, they do not break it — only (c), the eventual
+injection of experimentally-uncensored data, does that. `SYNTHESIS.md` §4 ports (a) and (b)
+verbatim ("This is D2's exact mechanism... same logic, same threshold") but drops (c) entirely
+from the graft. §11 (the self-maintenance loop) never once mentions the reach experiment as a
+required input to the re-fit; §11's "Relationship to the planned reach experiment" (also §11)
+treats the experiment as an independent, parallel workstream answering "a different question"
+rather than as a necessary structural component of the anti-spiral guardrail it borrowed from D2.
+The synthesis's own §12 con #1 talks about the sparse-tercile-peak problem but never states this
+one, despite it being visible in the exact source document (D2) the graft was copied from.
+
+**Concrete failure scenario:** Dense-tercile `k` sits at 1.0 (N*=~1,700-3,469 by §7's Tower
+Hamlets example). Quarter 1 re-fit: reply rate has dipped slightly (noise, or a genuine but
+unrelated cause — see FATAL-2/MAJOR-3 below), `k` moves down 10% (within the 15% band, so it
+applies automatically). Quarter 2's collections are now measured under the 10%-smaller reach.
+Some previously-reachable-but-marginal collectors (the ones between the old and new boundary) are
+never notified and never collect. The backtest at the next re-fit replays Q2's (already-narrowed)
+collections against a further-proposed cut — of course it clears 90%, because the marginal
+collectors who would have failed that check were already excised from the sample one cycle
+earlier by the previous cut. Nothing in the mechanism as specified would ever produce a "backtest
+fails" result purely from over-tightening, because the population the backtest checks against
+shrinks in lockstep with the cap. The 15% rate cap slows the descent; it does not stop it, and the
+backtest provides false reassurance that it has been stopped when it has only been slowed.
+
+**Fix (concrete):**
+1. Import D2's dropped mechanism (c) as a **hard precondition**, not an optional parallel
+   workstream: no re-fit is permitted to shrink `N*`/`k` for a density band **unless** that band
+   has at least one completed reach-experiment readout (or an equivalent permanent small holdout —
+   see D4's mechanism, which SYNTHESIS.md's own judge scores rate highest on exactly this
+   criterion, C8, "scientific honesty" in `J2-judge.md`) providing an uncensored estimate of
+   demand beyond the current cap. Until that exists for a band, the guardrail should be "may only
+   *widen*, never shrink" for that band — asymmetric, and safe by construction, until real
+   uncensored data exists.
+2. Alternatively (cheaper, if a permanent holdout is judged too costly to run indefinitely): keep
+   a **fixed, small, permanent random holdout per density band** (analogous to D4's 5% notification
+   holdout, but scoped only to measurement, not to full notification suppression) that is *never*
+   subject to `N*` tightening, specifically to give each re-fit one genuinely uncensored reference
+   population to backtest against, instead of backtesting the proposal against its own recently-
+   narrowed population.
+3. At minimum, the mod-facing copy (§8) and the internal documentation must stop describing the
+   backtest as proof the new number "serves what already happened, not just a percentile on an
+   already-shrunk population" — that sentence is the specific false claim; it should instead say
+   the backtest is a **necessary but not sufficient** check, pending genuinely uncensored data.
+
+---
+
+## FATAL-2: The `k=1.0` "peak" is read off the left edge of a censored curve, not an interior maximum
+
+**Location:** `SYNTHESIS.md` §3 constant table, `k` row (line 97), and §2's headline claim ("the
+demand report's within-density-tercile analysis... rules out the obvious objection... Holding
+density fixed and varying audience within it, reply probability still peaks near roughly 1x the
+tercile's own scale and *declines* past it").
+
+**The claim:** within-tercile, P(≥1 reply) "peaks" at sub-quintile 1 (audience ≈ tercile's own
+active-member scale) and declines monotonically afterward, which is offered as the empirical basis
+for `k=1.0`.
+
+**Why this is not what the data shows.** Checking `5-demand.md` §6's own table directly:
+
+| tercile | sub-quintile 1 (smallest audience) | sub-quintile 2 | 3 | 4 | 5 (largest) |
+|---|---|---|---|---|---|
+| 2 (medium) | **41.3%** @ avg aud 1,021 | 34.5% @ 1,815 | 33.5% @ 2,801 | 37.6% @ 4,069 | 24.7% @ 7,715 |
+| 3 (dense)  | **38.8%** @ avg aud 1,731 | 35.8% @ 3,345 | 31.6% @ 5,572 | 25.1% @ 8,588 | 21.8% @ 13,082 |
+
+In both terciles, **sub-quintile 1 is the smallest audience bucket that exists in the sample for
+that tercile** — not an interior point on a curve with data on both sides of it. There is no
+observed data point at, say, 400 or 600 active-member-equivalent audience for either tercile;
+sub-quintile 1's ~1,021 (tercile 2) and ~1,731 (tercile 3) are the left edge of what was measured,
+determined by `NTILE(5)` splitting whatever audience range that tercile's posts actually reached,
+not by any independent choice of bucket boundaries. Calling this a "peak" asserts the curve turns
+over and heads back down below that point — nothing in the table shows this. It is equally
+consistent with the true curve continuing to *rise* below audience ≈1,000-1,700 (i.e. the true
+optimum for medium/dense areas could be even smaller than sub-quintile 1's range, and `k` should be
+correspondingly smaller than 1.0), or genuinely flattening (matching the sparse-tercile pattern,
+where §6's own text admits "tercile 1... roughly flat," i.e. no decline observed at all across the
+full range 265→3,444). The synthesis's own §12 con #1 partially concedes the *sparse* tercile
+never showed a decline, but frames this as "asymmetric confidence across bands," not as "the
+medium/dense terciles' own claimed peak is unverified on the low side too" — the same structural
+gap exists at the bottom of every tercile's range, not just the sparse one.
+
+**This directly compounds FATAL-1's censoring problem, one level down.** `5-demand.md` §6 is
+itself built from `total_freeglers` (realized, post-30-min-ceiling audience) — a post that, absent
+the 30-min ceiling, "would" have had an even smaller natural audience simply doesn't exist in this
+data at all (every post has *some* minimum floor set by the existing schedule's tick-1 burst, not
+zero). `J2-judge.md` (line 228, C8 write-up on D1) already flags this exact problem for the *high*
+end of the tercile-quintile table ("a post that 'would' have reached 20,000 members absent T_max
+never appears in decile 10 at all") but the identical argument applies symmetrically at the *low*
+end for the peak-location claim specifically, and neither J2 nor SYNTHESIS.md's §3/§12 name it
+there. The peak location — the single number `k` is fit to — is exactly the number most exposed to
+this gap, more so than the general "decline is real" claim (which the high-end truncation doesn't
+threaten in the same way, since decline-after-a-point is visible regardless of what's below the
+window).
+
+**Fix (concrete):**
+1. Before adopting `k=1.0`, run the **Stage 0 dark-compute re-validation** (already planned in
+   §10) with a specific addition: don't just sweep `k ∈ {0.5, 0.75, 1.0, 1.25, 1.5}` against
+   existing data (which cannot resolve this, since existing data has the same left-censoring at
+   every sweep value ≥ what's observed) — instead, find or construct a genuinely lower-audience
+   comparison population. Two candidates already exist in the evidence base: (a) the **pre-ripple
+   period** (`3-behaviour.md` §4, pre-2026-06-14), where audience was bounded by group-polygon
+   membership rather than a 30-min isochrone, which for many groups is *smaller* than today's
+   floor and gives genuine sub-1,000 data points for dense/medium terciles; (b) posts that stopped
+   early via the existing (dead, but data-generating) `reply_saturation_stop` mechanism, whose
+   *actual* realized audience at stop-time might sit below sub-quintile 1's range for some
+   density classes even under the current pipeline.
+2. State the `k` derivation's confidence honestly as **"lower bound only, unverified whether truly
+   optimal or merely the smallest available sample"** rather than "confound-checked, the strongest
+   single result in the evidence base" (§2) — the confound-check (density held fixed) is real and
+   correctly done; the *peak-location* claim is a separate, unverified claim smuggled in under the
+   same sentence.
+3. Until (1) resolves this, treat `k=1.0` as the **upper edge of a plausible range**, not a point
+   estimate — i.e. do not let downstream honest-cons language ("1.0 is a round, slightly
+   conservative fit, erring toward more reach not less" — §3 table) do the work of hand-waving away
+   an actual unresolved identification gap. "Errs toward more reach" is true only if the untested
+   region below sub-quintile 1 would show *further* decline, which is asserted, not shown.
+
+---
+
+## MAJOR-1: `T_min=10` is not derived from evidence at all — it contradicts the cited anchor
+
+**Location:** `SYNTHESIS.md` §3 constant table, `T_min` row (line 101): *"DfT NTS0403f: national
+one-way shopping-trip duration averages 17 min, flat across urban/rural bands. Retail 'primary
+trade area' convention: 5-10 min generates 50-80% of footfall. 10 min is the lower edge of that
+convention band."*
+
+**Why this is arbitrary in disguise.** The two cited anchors give two different numbers — 17 min
+(NTS shopping trip) and 5-10 min (retail footfall convention) — for two different activities
+(a paid discretionary shopping trip vs. unpaid casual footfall to a convenience store). The design
+picks **neither** number as `T_min`; it picks the *lower edge of the second, less-relevant anchor's
+range*, which happens to sit below the first anchor entirely. There is no stated principle for why
+"lower edge of the footfall convention" is the right selection rule rather than, say, "midpoint of
+the footfall convention" (7.5 min) or "some fraction of the NTS figure" (e.g. 17×0.5≈8.5,
+17×0.6≈10.2 — coincidentally close to 10, but this arithmetic is not shown or claimed). Reading
+`6-external-anchors.md` directly (line 291): the anchors report's own bottom line describes "a
+similar 5-10 minute 'primary' catchment with fast-diminishing marginal value beyond that" as
+supporting evidence for a *short* floor generally, but never states or implies 10 specifically
+should be the chosen number over, say, 8 or 12 — the anchors report is silent on exactly which
+value within its own cited ranges to pick, and SYNTHESIS.md's derivation column asserts a specific
+selection rule ("lower edge") that appears nowhere in the source evidence, effectively inventing a
+selection principle post hoc to justify a value that (not coincidentally) matches the pre-existing
+live config default.
+
+**This is functionally identical to the "flat, uncalibrated placeholder" problem the whole design
+effort exists to solve for `N*`** — except here it's happening to `T_min`, is unexamined, and the
+table entry's parenthetical ("Matches the existing MVP floor (adoption, not a change)") is honest
+about the number being unchanged from today, but that honesty doesn't retroactively make the
+*evidence-based derivation* claimed in the same row true. `T_min` is being *justified after the
+fact* with anchors that don't actually converge on 10, not *derived from* them.
+
+**Fix (concrete):** Either (a) state plainly that `T_min=10` is a **retained operational default,
+not a re-derived constant** — move it out of the "every number has a derivation" table (§3) into a
+short explicit "constants we are choosing not to touch" list, alongside `T_max=30` (which the
+design is honest is unchanged, but at least doesn't claim a specific numeric derivation path that
+doesn't check out); or (b) if a genuine derivation is wanted, use the anchors report's own primary,
+most-relevant, most-official source (NTS0403f, 17 min duration) with an explicit, stated
+discount factor for "unpaid casual local errand vs. paid discretionary shopping trip" (the anchors
+report itself gestures at this on line 103 — "likely to sit below the shopping-trip average" — but
+never quantifies it), rather than switching anchors mid-derivation to the retail-footfall
+convention, which measures a different behaviour (drive to a fixed retail location) that has only
+a loose analogy to "how long should Freegle wait before rippling."
+
+---
+
+## MAJOR-2: The demand-flattening evidence and the "confound is ruled out" claim overclaim relative to what a stratified (non-randomized) analysis can actually show
+
+**Location:** `SYNTHESIS.md` §2 (bullet 1, lines 55-61) and the `k` derivation row (§3, line 97,
+"confound-controlled, the strongest single result in the evidence base").
+
+**The claim:** "It is the only design whose central claim was confound-checked, not just
+correlated... No other design's core number survives this kind of check."
+
+**Why this overclaims.** Controlling for density-tercile (a 3-bucket coarsening of one confounder)
+is a real and useful step, correctly credited by `J2-judge.md` (line 217-219: "a genuine
+confound-control exercise... real, if simple, causal reasoning"), but J2's own next clause — which
+SYNTHESIS.md's §2 does not carry forward — immediately qualifies it: *"still correlational — density
+terciles could still correlate with unmeasured post-quality or category-mix differences."* Density
+is not the only variable that plausibly correlates with realized audience size in this dataset:
+posts in denser areas are also disproportionately likely to be posted by higher-frequency,
+higher-reputation posters (who write better listings, add photos, post desirable categories more
+often — London posting *volume* is ~327/day of the network's ~1,525/day per the known measured
+facts, meaning London posters are structurally different in composition, not just location). None
+of that is stratified on. "Within-tercile" controls for the *group's* density, not for the *post's*
+quality, category, photo-presence, or time-of-day — all explicitly named as unmodelled confounders
+in SYNTHESIS.md's own §12 con #3, but con #3 is framed there as a *forward-looking* re-fit risk
+("the periodic re-fit implicitly assumes any drift... is due to the audience parameter"), not as a
+caveat on the *original* tercile-quintile evidence that `k=1.0` is fit to in the first place. The
+same unmodelled confounders that threaten the re-fit going forward already threaten the founding
+measurement.
+
+**Fix:** Downgrade the language in §2 from "confound-checked, not just correlated" (implying the
+matter is closed) to "partially confound-checked (density only); category mix, post quality, and
+poster-composition differences between dense and sparse areas remain unstratified and could still
+be driving some of the observed within-tercile decline." Add a Stage 0 check: repeat the §6
+tercile-quintile analysis with an additional stratification or regression control for post
+category and photo-presence (both already in `messages`/`messages_attachments` — no new data
+needed) before treating `k=1.0` as validated, not just directionally plausible.
+
+---
+
+## MAJOR-3: The re-fit's chosen fitness signal (reply rate) is exactly the metric structurally coupled to the deliverability feedback loop the design itself flags as unresolved
+
+**Location:** `SYNTHESIS.md` §11 step 1 ("Re-derive `k` per density band... from the trailing 90
+days of live reply-decile data") and §13 open question #2 ("Deliverability feedback loop... Flagged,
+not resolved").
+
+**Why this is a MAJOR, not just a listed open question.** The design already *names* this risk in
+§13 as an open question to check "before the re-fit is first allowed to run unattended" — but §11,
+the actual operational procedure, contains no such gate. Step 1 of the self-maintenance loop simply
+re-derives `k` from trailing reply-decile data every 90 days with no stated precondition that the
+deliverability check has been run first. This is an internal inconsistency: the design's own §13
+correctly identifies that "high volume → spam-foldering → measured reply rate looks artificially
+low → an over-correction in the wrong direction" is a *live risk to the primary fitness signal*,
+but the mechanism in §11/§4 that would need to guard against it (the anti-spiral rate cap) only
+looks at the *magnitude* of change (≤15%/period), not the *direction or cause*. A spam-foldering-
+driven reply-rate suppression in a high-volume dense band would look, to the 15%-cap mechanism,
+identical to a genuine over-reach signal — both present as "reply rate fell, propose shrinking
+k" — and the cap would happily approve up to 15% of exactly the wrong correction, repeatedly,
+quarter after quarter, without ever being distinguished from the correct case. This is a second,
+independent spiral risk (distinct from FATAL-1's audience-censoring spiral): a **deliverability-
+driven spiral**, where tightening reach in response to suppressed reply-rate makes the audience
+smaller, which (if spam-foldering scales with volume, as the mechanism the design itself
+describes implies) could paradoxically *worsen* deliverability-driven suppression in the surviving
+audience, or at minimum provides zero signal either way since the two causes are unidentified from
+reply-rate alone.
+
+**Fix:** Before the re-fit is allowed to treat a reply-rate decline as evidence for shrinking `k`,
+require an independent deliverability check (e.g. bounce/spam-complaint rate or open-rate trend
+for the density band, both plausibly already logged by the mail pipeline) confirming the decline
+isn't attributable to delivery suppression. This is a precondition on step 1 of §11, not merely an
+"open question" to check once before Stage 1 — it needs to run **every quarter**, not once,
+because deliverability conditions can change over any 90-day window, same as the thing being
+re-fit.
+
+---
+
+## MINOR-1: The "provably inert / provably binding" claim in §2 is true only for realized (post-ceiling) audiences, but the design's own worked table (§7) already shows this being interpreted more strongly than warranted for near-boundary groups
+
+`SYNTHESIS.md` §2 states the design is "provably inert exactly where nobody is complaining" —
+correct for Hull/Swindon/Ribble Valley, which never cross even N*=2,000 (per `4-audience-curves.md`
+§3c, "100% never-reach"). But Ribble Valley's own row (§7) shows "~20% of posts... cross the floor
+early" — i.e. not 100% inert, ~1-in-5 posts from a group nobody has complained about would see
+some tightening under this design. This is a small population and the practical effect is
+described accurately in §7's own "what changes" column ("essentially unchanged... very small
+tightening for a minority"), so this is not a correctness bug, only a rhetorical overreach in §2's
+summary framing ("provably inert... completely untouched") that the design's own detailed table
+one section later already contradicts for one of its three "inert" exemplars. Tighten the §2
+language to "inert for the large majority of posts in these groups" rather than "completely
+untouched."
+
+## MINOR-2: `N*_min=1,000` derivation conflates "smallest bucket that discriminates" with "correct floor"
+
+`SYNTHESIS.md` §3's `N*_min` row cites the fine-bucket table (500-1,000: 34.2% P(≥1)) as "close to
+the observed peak," and separately cites "1,000 is the smallest N* that discriminates at all" from
+the dark-compute schedule granularity. These are two different justifications for the same number
+that happen to agree — worth flagging (not blocking) that the second justification is really an
+artifact of the 9-tick schedule's own coarseness (`4-audience-curves.md` §0: fixed 9 ticks; small
+N* values are hard to resolve precisely against a coarse tick ladder) rather than a demand-side
+fact, and conflating a measurement-resolution limit with a demand-based floor risks the number
+surviving a future re-derivation for the wrong reason (e.g. if tick granularity changes, this
+"smallest N* that discriminates" argument silently stops applying, but the table wouldn't
+necessarily flag it, since the demand-side co-justification (34.2% at 500-1,000) would still read
+as if it independently supported 1,000).
+
+---
+
+## Summary table
+
+| # | Verdict | One-line finding | Fix scope |
+|---|---|---|---|
+| FATAL-1 | FATAL | Collection-catch backtest checks the shrunk population against itself; cannot detect the spiral it's named to catch; D2's own third mitigation (uncensored experiment data) was dropped in the graft | Make experiment/holdout data a hard precondition for any *shrinking* re-fit, not a parallel workstream; fix mod copy claiming this is solved |
+| FATAL-2 | FATAL | `k=1.0` "peak" is the left edge of censored data, not a verified interior maximum; identical structural gap to the already-flagged high-end truncation, unaddressed at the low end | Use pre-ripple or early-stop-saturation data to get genuine sub-1,000/1,700 data points before trusting `k=1.0`; state as upper-bound estimate, not point estimate |
+| MAJOR-1 | MAJOR | `T_min=10` cites two anchors (17min, 5-10min) that don't converge on 10; "lower edge" selection rule invented post hoc | Either declare it an unchanged operational default (no derivation claimed) or derive properly from the primary NTS anchor with a stated discount factor |
+| MAJOR-2 | MAJOR | "Confound-checked, not just correlated" overclaims — only density is controlled; post quality/category/poster-composition remain unstratified confounders | Downgrade language; add category/photo-presence stratification to Stage 0 before trusting `k` |
+| MAJOR-3 | MAJOR | Deliverability-feedback risk named in §13 as an open question but has no operational gate in §11's actual re-fit procedure; second, independent spiral risk not covered by the 15%/backtest guardrails | Require a per-quarter deliverability check as a precondition on every re-fit, not a one-time pre-Stage-1 check |
+| MINOR-1 | MINOR | §2's "completely untouched" for ceiling-bound exemplars is contradicted by §7's own Ribble Valley row (~20% affected) | Soften language |
+| MINOR-2 | MINOR | `N*_min=1,000` derivation conflates tick-schedule resolution limit with demand-based floor | Note the two justifications are not independent |
+
+All FATAL/MAJOR findings above are either genuinely new (FATAL-2's low-end symmetry, MAJOR-1,
+MAJOR-3's operational-gate gap) or represent evidence that was **already correctly identified
+somewhere in the source material (D2's own text, J2's own scoring) and then lost, weakened, or
+contradicted during the synthesis step** (FATAL-1, MAJOR-2) — which is arguably the more
+actionable category, since the fix in both cases is to restore language/mechanism the project's
+own prior work had already produced, not to invent new analysis from scratch.

--- a/plans/2026-07-02-reach-design-evidence/V3-attack.md
+++ b/plans/2026-07-02-reach-design-evidence/V3-attack.md
@@ -1,0 +1,457 @@
+# Adversary 3 — Engineer/Operator Attack on the Rippling Reach Synthesis
+
+**Target document**: `SYNTHESIS.md` ("Rippling Reach: Audience-Normalized Extent, with Anti-Spiral
+Guardrails and Catchment-Map Co-Location"), cross-checked against `1-mechanics.md` through
+`6-external-anchors.md` and the live codebase (`iznik-batch/app/Services/Ripple/*.php`,
+`iznik-routing-go/ripple.go`, `config/freegle.php`).
+
+**Lens**: buildability and safety only. Does the design really need only what's already persisted?
+What breaks operationally — routing server down, schedule JSON missing, new groups, boundary
+changes, midnight parameter flips, explosion scenarios, compute cost at 1,525 posts/day, interaction
+with reply-holding and the notified-ledger, the 6 named exemplar groups' real geometries (Hull
+estuary)?
+
+**Method**: every claim below was checked against the actual PHP/Go source in this working tree, not
+just the design prose. File:line references are given so each finding is falsifiable.
+
+---
+
+## FATAL
+
+### F1. The core mechanism the synthesis is "completing" cannot express its own parameter — `target_users` has no per-post/per-group input path anywhere in the code
+
+**Claim under attack** (SYNTHESIS §1, §3): `N*(post) = clip(k × active_members(home_group), 1000,
+4000)` — a value computed **per post**, from that post's home group's live active-member count.
+SYNTHESIS's central buildability argument (§2, "why D1 wins") is: *"D1 needs zero new schema, zero
+new services, zero new experiment apparatus — it supplies a missing number to code that already runs
+the full pipeline in shadow."*
+
+**What the code actually does**: `ReachService::__construct` reads `target_users` **once**, from a
+single flat Laravel config value, at service-construction time:
+
+```php
+// ReachService.php:46-48
+$this->targetUsers = config('freegle.ripple.extent.enabled')
+    ? max(0, (int) config('freegle.ripple.extent.target_users', 0))
+    : 0;
+```
+
+This is a **process-lifetime scalar**, not a per-post value. `scheduleParams()` (line 158-160) sends
+this one number to the routing server for every origin in the batch, indiscriminately. The Go side
+(`ripple.go:289`, `effectiveScheduleTotal`, line 250-255) also takes a single `targetUsers int` per
+HTTP request — there is no `home_group_id` parameter in the `/v1/ripple-schedule` request at all
+(confirmed: `scheduleParams()` sends `lat, lng, mode, ticks, max_minutes, curve, target_users` only —
+no group identifier of any kind).
+
+To compute `N*(post) = clip(k × active_members(home_group), ...)` as specified, someone has to:
+1. Resolve each post's home group (a join that doesn't happen anywhere in `initialiseNew`'s current
+   hot path — home-group resolution happens *after* rippling, in downstream tables, not before it).
+2. Query that group's live `active_members` count (a `memberships` × `users.lastaccess` join — not
+   cached, not currently computed in the ripple pipeline at all; §6 of `5-demand.md` is the *only*
+   place in the entire evidence base this query is run, as an ad-hoc analysis query, not production
+   code).
+3. Look up that group's current density band's `k` (a value that, per §11, lives in `rippling_params`
+   — a table confirmed to have **zero readers anywhere in the codebase**: `grep -rn rippling_params
+   iznik-batch/app/Services/Ripple/*.php` returns only `RippleTuneService.php`'s own writer).
+4. Compute and clip `N*`, then pass it through to `ReachService` as a **per-call**, not
+   per-construction, parameter.
+
+None of steps 1-4 exist in code today. This is not "supply a missing number" — it is "add a new
+per-post computation stage to a service that is currently architected around a single static
+config value," plus wire a genuinely new reader for a genuinely dead table, plus change
+`ReachService`'s constructor-time parameter into a call-time parameter (a real, if modest,
+refactor touching `computeSchedule`, `computeSchedulesBatch`, and `scheduleParams`). SYNTHESIS's
+central "completes shipped infrastructure, zero new services" claim (§2, bullet 2) is **false as
+stated** — what's shipped is a single-global-scalar audience cap; what's proposed is a per-group,
+periodically-refreshed function, and the gap between those two is a real, non-trivial engineering
+task, not a config flip.
+
+**Verdict: FATAL.** The single strongest sentence in the whole synthesis's case for D1 ("zero new
+schema, zero new services... supplies a missing number") does not survive contact with
+`ReachService.php`.
+
+**Concrete fix**: rewrite §2/§3 honestly — this design requires (a) a home-group-active-members
+lookup added to `initialiseNew`'s per-post loop (cheap: one indexed query per distinct home group
+per batch run, not per post — group membership counts change slowly, can be cached for the run),
+(b) `ReachService::computeSchedule`/`computeSchedulesBatch` changed to accept `target_users` as a
+per-call argument instead of a constructor-time field, (c) an actual reader for `rippling_params`
+wired into step (a)'s lookup. None of this is large — it is a real, scoped, one-to-two-day PHP
+change — but it must be scoped and estimated, not waved away as "zero new services."
+
+---
+
+### F2. The origin-blur reuse cache will silently serve the WRONG N* once target_users varies per post — a real, deterministic data-corruption bug, not a hypothetical
+
+**Claim under attack**: implicit throughout — the design assumes `computeSchedule` can be called
+per-post with a per-post `target_users` and everything downstream continues to work as today.
+
+**What the code actually does**: `ExpandService::initialiseNew` deduplicates routing calls by
+**blurred origin only** (`ExpandService.php:707-728`), and — critically — reuses any existing
+`rippling_reach` row's stored schedule for the same blurred `(lat,lng)` key without re-querying the
+routing server at all (`ExpandService.php:740-772`, the "Reuse" block). The code's own comment states
+the precondition explicitly:
+
+```php
+// ExpandService.php:732-739
+// Reuse: a reach schedule is a deterministic function of the blurred origin (+ global ripple
+// config - see the Phase-1 note above), so if another live post at the SAME blurred origin
+// already has a real computed reach, copy its schedule rather than hit the routing server
+// again. ... Exact because blurOrigin quantises to 4dp and only the blurred origin + global
+// config feed the schedule. If that config (curve/max_minutes/extent) ever changes, set
+// freegle.ripple.reuse_reach=false for one full recompute so stale reaches are not reused.
+```
+
+The entire correctness argument for this cache is **"only the blurred origin + GLOBAL config feed
+the schedule."** That precondition is true today (one global `target_users` for the whole network)
+and becomes **false** the moment `target_users` is computed per-post from `active_members(home
+group)`, because two posts can share a blurred origin (~400m quantisation — the code's own comment
+notes this is measured at "~2.6x" reuse rate on prod, i.e. it fires constantly, not rarely) while
+belonging to **different home groups with different `active_members`**, which is common near any
+group boundary (exactly the geography the Discourse complaints are about — dense, overlapping,
+adjacent London boroughs). The second post posted from that shared blurred origin would silently
+receive the *first* post's `N*`-derived schedule, not its own — an invisible, un-logged, wrong-cap
+bug that would fire routinely in exactly the highest-value target area (inner London), not at the
+edges.
+
+This is not a one-off migration hazard (the "set `reuse_reach=false` for one recompute" comment
+addresses global config changes, e.g. changing `k` at a quarterly re-fit — a temporary, known, planned
+event). It is a **structural, permanent** violation of the cache's invariant for as long as `k`/`N*`
+varies below the level of "global config," which is the design's entire premise.
+
+**Verdict: FATAL.** The reuse-cache optimization this codebase already relies on for throughput
+(§F5 below covers the cost consequence of losing it) is invalidated by the design's own core idea,
+and nothing in SYNTHESIS or its constant-derivation table (§3) mentions this at all — it is a genuine
+blind spot, not a deprioritized risk.
+
+**Concrete fix**: either (a) extend the reuse-cache key to include a coarse discriminator (e.g.
+`(blurred_lat, blurred_lng, density_band)` instead of just `(blurred_lat, blurred_lng)` — cheap,
+since density band changes quarterly not per-post, so cache hit rate stays high within a quarter), or
+(b) disable `reuse_reach` entirely once per-group `target_users` ships and accept the compute-cost
+hit (quantify against F5 before deciding). Either way this must be an explicit line item in the
+implementation plan, not an afterthought.
+
+---
+
+## MAJOR
+
+### M1. `recomputeReach` can only SHRINK an already-scheduled post, never grow it — the quarterly re-fit is one-directional for the ~24,000 posts already mid-flight at any given moment, contradicting the "self-maintaining" framing
+
+**Claim under attack** (SYNTHESIS §11, step 4): *"Write the new values to `rippling_params`... and
+have `ReachService.php` read `k`/`N*_min`/`N*_max` from there... This is the first real consumer of
+the stubbed `RippleTuneService::categoryVolumeDeltas()`."* The design frames the quarterly re-fit as
+symmetric maintenance — values can move up or down as evidence dictates (§4's anti-spiral guardrails
+are explicitly two-sided in spirit: "no quarterly re-fit may move `k`... by more than 15%... in
+either direction" is the natural reading, and §12 con #1 explicitly discusses `k` needing to possibly
+be *raised* for the sparse tercile if the untested assumption turns out wrong).
+
+**What the code actually does**: the only mechanism that applies a changed `target_users` value to a
+post that has *already* been scheduled is `ExpandService::recomputeReach()`
+(`ExpandService.php:162-246`), and it is **hard-coded shrink-only**:
+
+```php
+// ExpandService.php:166-168
+$target = (int) config('freegle.ripple.extent.target_users', 0);
+if (!config('freegle.ripple.extent.enabled') || $target <= 0) {
+    return $stats; // cap not active — there is nothing smaller to shrink to
+}
+...
+// ExpandService.php:175
+->where('total_freeglers', '>', $target);      // only rows that can exceed the cap
+...
+// ExpandService.php:196-200
+// Only proceed if the recomputed reach really is smaller than the pool
+// (i.e. the cap actually bound for this origin).
+if ($newMax <= 0 || $newMax >= (int) $row->total_freeglers) {
+    $stats['skipped']++;
+    continue;
+}
+```
+
+There is no symmetric "grow" path. If a quarterly re-fit *raises* `k` for a density band (e.g.
+because the anti-spiral backtest catches an over-tightening, or genuinely because a sparse tercile's
+`k` needed correcting upward per con #1's own admission), every post that is currently `expanding` or
+was already `done` under the old, smaller `N*` **stays capped at the old, smaller value** — because
+`advanceDue` (`ExpandService.php:897+`) re-plays the schedule that was frozen into the row's `schedule`
+JSON at creation time (`tickForElapsedHours`, `entryForTick` — never a fresh routing call), and
+`recomputeReach` explicitly refuses to act unless the *new* target is *smaller* than the post's
+existing `total_freeglers`.
+
+This means: **the quarterly re-fit only ever tightens the world it can already see, and can never
+widen an already-emitted post even when the design's own backtest says it should.** For the roughly
+24,000 posts in-flight at any moment (per `4-audience-curves.md` §0: 12,219 `expanding` +
+some fraction of `done` still within the 7-day notification window), a re-fit that raises `N*`
+mid-quarter has **zero effect** on them — only future, not-yet-created posts benefit. This directly
+undercuts §9's failure-mode table entry "Self-reinforcing tightening spiral... Mitigation: the §4
+graft" — the graft (backtest before shrinking) governs new posts going forward; it does nothing to
+*reverse* an over-tightening already baked into thousands of live rows, because there is no live
+"widen" path to reverse into.
+
+**Verdict: MAJOR.** This is a real, verifiable asymmetry in the existing code that the design's
+"self-maintaining, symmetric" framing does not acknowledge and the anti-spiral guardrails do not
+address (they gate the *decision* to shrink, not the *irreversibility* once applied to a cohort of
+live posts).
+
+**Concrete fix**: either (a) build a symmetric "grow" path in `recomputeReach` (drop the `>` filter,
+re-fetch schedule unconditionally for a bounded sample when `k` moves, apply if `newMax` differs from
+`total_freeglers` in either direction — this doubles the query volume of an already-manual, unscheduled
+command, so needs its own cost/scheduling plan), or (b) state explicitly and simply in the design that
+quarterly re-fits are "forward-looking only, in either direction" — i.e. a raised `k` only benefits
+posts created after the re-fit, exactly mirroring how a lowered `k` currently only benefits posts
+recomputed via the *manual, unscheduled* `ripple:recompute` command (see M2). Document which of (a)/(b)
+is chosen; SYNTHESIS currently implies (a)'s behaviour while the code only supports (b), and does not
+say so.
+
+---
+
+### M2. The activation path this design depends on (`ripple:recompute`) is not scheduled, so "Stage 1 canary" and the quarterly re-fit both require someone to remember to run a manual command — no automatic linkage exists between "new `k` written" and "already-live posts adjusted"
+
+**Claim under attack** (SYNTHESIS §10, Stage 1): *"Enable `RIPPLE_EXTENT_ENABLED=true` with the
+derived formula for a small number of dense-tercile test groups"* — phrased as a flag flip.
+
+**What the code actually does**: `grep -rn recomputeReach|ripple:recompute
+iznik-batch/routes/console.php` returns **nothing** — `RecomputeReachCommand` exists
+(`app/Console/Commands/Ripple/RecomputeReachCommand.php`) but is not wired into the Laravel
+scheduler, same unscheduled-command pattern already flagged for `ripple:tune` in `1-mechanics.md`
+§5.3 ("`ripple:tune` is coded but **not scheduled**... pending decision on production rollout"). This
+is a second, independent instance of the same "coded but not wired to run" gap, not covered by the
+mechanics report because it wasn't asked about in that pass.
+
+Practically: turning `RIPPLE_EXTENT_ENABLED` on changes behaviour **only for posts not yet given a
+schedule** (new posts, from that moment). Every post already `expanding` (12,219 rows at last count)
+or recently `done` continues on its already-baked, uncapped schedule until it separately falls out of
+the 7-day notification window — there is no automatic "apply the newly-enabled cap to the current
+in-flight cohort" step; that requires someone to separately invoke `ripple:recompute` (manually, since
+it's unscheduled) immediately after the flag flip, and to re-invoke it after every subsequent
+quarterly re-fit for the "shrink" direction specifically (M1 shows "grow" isn't even supported).
+
+**Verdict: MAJOR.** Not fatal — the flag-flip-then-forget behaviour is at worst a slow rollout
+(new posts adopt the new value within hours, all posts within 7 days), which for a *quarterly*
+cadence is a tolerable lag. But SYNTHESIS's "Stage 1... enable `RIPPLE_EXTENT_ENABLED=true`" language,
+and the self-maintenance loop's step 4-5 in §11, describe a system that "writes the new values" as
+if that alone changes live behaviour. It does not, for the in-flight cohort, without a second manual
+step this design never names.
+
+**Concrete fix**: name `ripple:recompute` explicitly in the rollout plan (§10) and the self-maintenance
+loop (§11) as a required step after every `k`/`N*` change, decide whether it should be scheduled
+(cron, run once per re-fit) or remain a manually-triggered, ops-runbook step, and state the expected
+lag this introduces (new posts: immediate; in-flight posts: only if `recompute` is run and only in
+the shrink direction per M1; already-`done`-and-past-notification posts: never, by design, since
+there's nothing left to adjust).
+
+---
+
+### M3. No explosion detector, no per-post notification cap, no fatigue cap exist anywhere in `ExpandService` today — the design inherits, unmodified, a documented absence of the one safety mechanism every prior design doc calls a hard precondition for any governor change
+
+**Claim under attack**: SYNTHESIS's failure-mode table (§9) and kill-criteria (§10) present the
+design as operationally safe, with rollback ("one config flag") as the stated safety net.
+
+**What the mechanics report already established** (not re-derived here, cited as load-bearing):
+`1-mechanics.md` row 23 confirms, by direct grep, that the reach-mail caps named as required
+blockers in the experiment spec (3,000-member notification cap, 24h fatigue cap, 5,000-threshold
+explosion detector, per-post group-insertion cap of 5) are **"Not present in `ExpandService.php` at
+all."** §7 item 5 restates this as an open decision explicitly: *"The explosion-detector / auto-pause
+circuit breaker — repeatedly named across all docs as the thing that must exist and be wired before
+re-enabling/scaling any governor change... Confirmed absent from `ExpandService`."*
+
+SYNTHESIS does not mention this gap anywhere in its own text (§9's failure-mode table has no row for
+"routing/compute output produces an anomalously large N\* or schedule and nothing catches it before
+it mails" — the closest is the anti-spiral 15%-per-period cap in §4, which governs the *quarterly
+re-fit's proposed constant*, not a **per-post runtime anomaly** such as a bad `active_members` count
+for one group on one day, a group merge that suddenly doubles a group's membership overnight, or a
+routing-server bug that returns a wrong `cumulative_users` for one origin). The 15%-per-quarter cap on
+`k` cannot catch a same-day anomaly, because it only fires at the 90-day re-fit boundary — a bad
+`active_members` read for one group is live and mailing immediately, for up to a full quarter, before
+the guardrail even evaluates it.
+
+This matters specifically because the design's *own mechanism* (`active_members(group)`, "a live
+query recomputed on every post" — §9's cold-start/seasonality row) is precisely the kind of
+per-request, unvalidated, ungated input an explosion detector exists to catch: if `active_members`
+returns a corrupted or anomalously large number for one group on one day (e.g. a membership-import
+bug, a bot signup wave counted as "active," or a JOIN bug after a schema change), `N*` for every post
+from that group that day inherits the bad number, uncapped except by the static `N*_max=4,000` ceiling
+— which itself only bounds the *target*, not the notification volume actually sent (per `5-demand.md`
+§5, notification volume is separately throttled and only loosely correlated with `total_freeglers`
+today; this design does not change that separately-throttled layer at all).
+
+**Verdict: MAJOR**, not FATAL, because the *existing* system (before this design) already has this
+gap and has been running in production since go-live without an explosion detector — so this design
+does not introduce a *new* class of failure, it just fails to close a pre-existing one while adding a
+new, more variable input (`active_members`, refreshed quarterly, per-group) into the same ungated
+pipeline. Rated MAJOR rather than MINOR because the design's own worked examples (§7) show `N*` for
+dense London groups near the top of the 1,000-4,000 band, i.e. this design specifically increases how
+much day-to-day variance a bad `active_members` read could inject relative to today's flat, single,
+manually-set 4,000 constant (a bad per-group input has a blast radius today's flat config cannot have).
+
+**Concrete fix**: state explicitly, as an explicit rollout precondition (not an open question buried
+in §13), that Stage 1 should not begin until at minimum a same-day sanity check exists — e.g.
+"`active_members(group)` read at schedule-compute time must be within some bounded ratio (say 2x) of
+that group's `active_members` value from the last successful quarterly re-fit, else fall back to the
+static default and alert" — a cheap, code-level guard that does not require the full experiment-spec
+explosion detector to be built, but closes the specific new failure mode this design introduces.
+
+---
+
+### M4. Hull's real geometry is an estuary/toll-avoidance case with existing water-crossing logic — the synthesis's "audience-normalization self-corrects coastal geometry" claim (§9) is asserted, not verified against how Hull's polygon is actually shaped
+
+**Claim under attack** (SYNTHESIS §9, failure-mode table, row 1): *"Coastal / estuary geometry... A
+half-circle catchment (coastal town) could behave oddly under a fixed-radius rule... Self-corrects
+structurally: N\* is defined on active-member count, not distance or area, so a coastal town simply
+takes longer to accumulate the same N\* than an inland town of equal density. A genuine strength of
+audience-normalization over any fixed-time or fixed-distance design."**
+
+**What the evidence base actually shows about Hull specifically**:
+- `2-discourse.md` §2 (#389/390) and §4 confirm the live, named Hull complaint is not "coastal
+  geometry produces a slow-filling half-circle" (the benign case SYNTHESIS's mitigation addresses) —
+  it is **"over the water"**: a mod objecting that Castleford reaches Hull's area via Howden, "just
+  inside Hull's area," 29 minutes by car, which Edward confirms is legitimately within the drive-time
+  isochrone. This is exactly the opposite failure mode from the one SYNTHESIS's mitigation discusses:
+  the complaint is that the **estuary-adjacent isochrone reaches too far around the water via a land
+  detour**, not that it fills too slowly. Water/toll avoidance logic already exists and was
+  specifically added for this class of complaint (#159-165, "avoid rippling across water/via tolls
+  unless there's a real bridge/tunnel").
+- `4-audience-curves.md` §3/§3c confirms Hull (group 21473, n=51 posts) has **audience p50 = 659 at
+  the 30-min ceiling**, and is **100% never-reach even at N\*=2,000** — i.e. under this design, Hull
+  is entirely `T_max`-bound (unchanged from today), exactly as SYNTHESIS's own §7 worked-example table
+  states. On this specific numeric point SYNTHESIS is internally consistent with the evidence (Hull
+  does stay at the floor, unaffected) — but that is a *different* claim from "audience normalization
+  self-corrects the estuary geometry," which is not demonstrated anywhere. Hull being N\*-inert says
+  nothing about whether its *isochrone shape* is well-behaved; it only says the design's audience
+  target never binds there, so the isochrone shape is exactly as good or bad as it is **today**,
+  unchanged, ceiling-bound, water-avoidance-gated exactly as now. The "self-corrects structurally"
+  language in §9 asserts a *causal mechanism* (audience-normalization fixes weird coastal shapes) that
+  the evidence does not test and the Hull numbers do not demonstrate — the correct, narrower claim is
+  "this design does not make Hull's existing water-avoidance-gated shape any better or worse, because
+  it never binds there."
+
+**Verdict: MAJOR.** Not because the design breaks Hull (it doesn't — it's correctly inert there per
+the dark-compute), but because §9's stated *mechanism* ("N* self-corrects coastal geometry") is an
+unverified causal claim dressed as a demonstrated property, sitting in the one place (the failure-mode
+table) a reader would trust as rigorously checked. The actual, defensible claim is much narrower and
+should replace it.
+
+**Concrete fix**: reword §9's coastal/estuary row to the narrower, evidence-backed claim: "Coastal
+and estuary groups (Hull confirmed via dark-compute) sit below `N*_min` at essentially all observed
+audience sizes and remain entirely governed by `T_max` and the existing water/toll-avoidance isochrone
+logic (#159-165), unchanged by this design. This design neither fixes nor worsens estuary-shaped
+reach; it simply doesn't engage there." Drop the "self-corrects" framing, which implies a mechanism
+this design does not actually exercise for the one named exemplar with real coastal/estuary geometry.
+
+---
+
+### M5. Compute-cost claim ("dark-compute... zero new pipeline") is understated once the reuse-cache breaks (F2) — Stage 0's own re-validation sweep (5 values of `k` × 10,742 posts) was cheap only because it replayed *stored* schedules, not because live per-post computation at this scale is cheap
+
+**Claim under attack** (SYNTHESIS §10, Stage 0): *"Pure SQL against existing tables"* — true for
+Stage 0's *validation* sweep, which replays already-persisted `rippling_reach.schedule` JSON. But §10
+and §3's constant-derivation table imply the live production mechanism is equally cheap ("`k` ...
+re-fit quarterly," "`active_members(group)`... a live query... zero new data pipeline").
+
+**What the actual cost structure is**: today, `initialiseNew` dedupes routing calls by blurred origin
+at a **measured 2.6x reuse rate** on prod (`ExpandService.php:710`, comment: "measured ~2.6x on
+prod"). At 1,525 offers/day, that means roughly 1,525 / 2.6 ≈ **587 actual routing-server Dijkstra
+calls/day** today, not 1,525. Per F2, once `target_users` varies per home group, the reuse-cache's
+correctness precondition breaks for any two co-located posts from different groups — meaning either
+(a) the cache silently serves wrong answers (F2's fatal finding), or (b) the fix is to disable/narrow
+`reuse_reach`, which **restores routing-call volume toward the full 1,525/day** (or higher, since
+`recomputeReach` drains — M1/M2 — add a second, separate wave of routing calls per re-fit cycle,
+sized by however many of the ~24,000 in-flight rows are candidates). This is roughly a **2.6x
+increase in routing-server load** at minimum, concentrated in exactly the London/dense-tercile
+geography (§7's worked examples) where posts are already highest-volume and the reuse rate is
+presumably even higher than the network average (dense areas → more co-located posts → more cache
+hits today → more cache invalidation cost once per-group `target_users` breaks the key).
+
+**Verdict: MAJOR.** Not FATAL — 1,525-4,000 routing calls/day is very likely still well within the
+`compute_concurrency=8` Dijkstra-per-request routing host's headroom (no load-test data exists either
+way in the evidence base to confirm or deny this, which is itself the gap). But the design's own
+framing ("zero new pipeline," "already computes... zero new data pipeline") describes the *validation*
+step's cost, not the *production* mechanism's cost once F2's cache-key fix is applied, and nowhere in
+SYNTHESIS is this quantified or flagged as a thing to load-test before Stage 1.
+
+**Concrete fix**: before Stage 1, measure actual routing-server request volume/latency under
+`reuse_reach=false` (or the F2-fixed cache key) at current 1,525/day production volume, not just at
+Stage-0's already-persisted-data replay cost. If headroom is fine, say so with a number; if it isn't,
+the compute_concurrency knob (already a config value, `ripple.compute_concurrency=8`) is the lever,
+and that trade-off belongs in this design, not left implicit.
+
+---
+
+## MINOR
+
+### N1. `reply_saturation_stop` dead-code claim is correct but the "was 5, now 3" language in §3/§13 undersells that this is a *separate*, already-identified, trivially-shippable fix the design bundles in without its own validation gate
+
+`5-demand.md` §1 and `1-mechanics.md` row 10 independently confirm `reply_saturation_stop=5` has
+never fired (0/10,742 posts). SYNTHESIS §3 recalibrates it to 3 as part of "the complete constant
+inventory" and §13 correctly flags it as "not the evidence base's primary target, deserves its own
+small validation pass." This is honestly caveated already — noted here only because §1's one-sentence
+formal rule states `reply_saturation_stop = 3` as if already decided, which is inconsistent with §13
+correctly treating it as still open; tighten §1's phrasing to "3 (proposed, pending its own
+validation pass — see §13)" so the two sections agree.
+
+### N2. The motorway-corridor artifact (#373, Portobello→Livingston) is not fixed and could be made LESS visible, not more, by audience-normalization
+
+Discourse #373 (`2-discourse.md` §4 item 5) describes an isochrone that stretches narrowly along the
+M8 rather than covering an area — a real, named, unaddressed display/shape problem. Audience-count-based
+`N*` does not fix this (a thin fast corridor accumulates `cumulative_users` at whatever rate the
+addressable population along that corridor implies, same distortion, different stopping rule) and
+arguably makes it *harder to spot* for a mod glancing at the catchment map, because the map now shows
+"stopped because it hit its people-target," which sounds authoritative/deliberate, rather than
+"stopped at a fixed time," which more obviously invites "why does this weird shape reach that far."
+SYNTHESIS's §5 catchment-map graft does not mention this interaction. Worth one sentence in §5 or §9
+noting the corridor-artifact problem is orthogonal to and not addressed by this design, matching the
+honesty already applied to mod-load (§9's explicit "not fixed by this design" entries).
+
+### N3. Sample schedule data shows tick-4-through-tick-9 sharing an *identical* WKT polygon while `cumulative_users` climbs 3,250→4,000 — a resolution artifact in the underlying routing output that a tight per-post `N*` will interpolate across, producing spuriously precise drive-time numbers
+
+Inspecting `sample_schedule.txt` (a real persisted `rippling_reach.schedule` row) shows ticks 4-9 all
+report `drive_min=16.295733642578124` with the byte-identical polygon WKT, while `cumulative_users`
+still increases each tick (3250, 3400, 3550, 3700, 3850, 4000). This means the underlying routing
+isochrone snapped to the same node/resolution boundary for six consecutive ticks while the audience
+count kept incrementing on synthetic/estimated grounds (a modelling artifact, not a road-network
+change). `4-audience-curves.md`'s N\*-crossing JS (§0) linearly interpolates `drive_min` between ticks
+to report "time to cross N\*" — for a post like this one, interpolating between two ticks that share a
+polygon produces a `drive_min` estimate that looks precise (e.g. "13.2 minutes") but is actually
+reporting a resolution ambiguity as if it were a real number. This does not invalidate the aggregate
+tables (large-N statistics average this out), but it means any *single-post* or *single-group*
+worked-example drive-time figure quoted to a moderator (per §5/§8's map graft, which shows a live
+per-group number) could show spurious precision for posts landing in one of these resolution
+plateaus. Worth a rounding/precision caveat in the mod-facing copy (§8) or the map implementation.
+
+---
+
+## Summary table
+
+| # | Severity | One-line finding |
+|---|---|---|
+| F1 | FATAL | `target_users` has no per-post/per-group code path anywhere; "zero new services" claim is false |
+| F2 | FATAL | Origin-blur reuse cache silently serves wrong `N*` once target varies per group (same postcode, different home groups) |
+| M1 | MAJOR | `recomputeReach` is shrink-only; a raised `k` never reaches the ~24,000 in-flight posts |
+| M2 | MAJOR | `ripple:recompute` is unscheduled/manual; flag-flip alone does not touch in-flight posts |
+| M3 | MAJOR | No explosion detector/notification cap exists; a bad per-group `active_members` read is now a live, ungated input with a bigger blast radius than today's flat constant |
+| M4 | MAJOR | "Audience-normalization self-corrects coastal geometry" is an unverified causal claim; Hull's real complaint (estuary detour, water/toll-avoidance) is untouched by this design, not fixed by it |
+| M5 | MAJOR | Compute-cost claim describes Stage-0's cheap SQL replay, not production cost once the reuse-cache is fixed/disabled (~2.6x routing-call increase, unquantified, concentrated in dense areas) |
+| N1 | MINOR | §1's formal rule states `reply_saturation_stop=3` as settled; §13 correctly treats it as still-open — align the two |
+| N2 | MINOR | Motorway-corridor artifact (#373) not addressed, possibly obscured by audience-normalization's authoritative-sounding stop reason |
+| N3 | MINOR | Sample schedule data shows resolution-plateau ticks; interpolated single-post drive-time figures can be spuriously precise |
+
+## What would need to change before this design is buildable as specified
+
+1. Rewrite §2's "zero new services" claim to name the real scope: a new per-post
+   home-group/active-members lookup, a `ReachService` call-time (not construction-time) parameter
+   change, and an actual `rippling_params` reader (F1).
+2. Fix or explicitly disable the origin-blur reuse cache before any per-group `target_users` ships,
+   and re-measure routing-server load under the fixed/disabled cache (F2, M5).
+3. Decide and document whether quarterly re-fits are forward-only (cheapest, but weakens the
+   "self-maintaining, corrects both ways" framing) or build a symmetric grow path in
+   `recomputeReach`, and either way name `ripple:recompute` explicitly as a required step with an
+   owner and a schedule (M1, M2).
+4. Add a minimal same-day sanity guard on `active_members(group)` before Stage 1 — this design's
+   quarterly-refreshed, per-group input is a new class of blast-radius risk the existing flat
+   config never had, and no explosion detector exists anywhere in `ExpandService` to catch it (M3).
+5. Reword the coastal/estuary failure-mode entry to the evidence-backed claim (N\*-inert, not
+   "self-correcting"), and explicitly state Hull's real Discourse complaint (estuary detour via
+   Howden) is untouched by this design (M4).
+
+None of these five is a reason to abandon D1/the synthesis's overall direction — the audience-target
+philosophy, the within-tercile confound-check, and the dark-compute worked examples remain the
+strongest evidence-backed part of the whole exercise. But as specified, §2's buildability claim is
+overstated, and Stage 1 should not begin until F1/F2 are scoped as real engineering work and M1-M3
+have explicit answers, not implicit assumptions.


### PR DESCRIPTION
Tidy-up: commits the previously-untracked reach-design research pack (plans/2026-07-02-reach-design-evidence/) and three monitor-fsm operational scripts. Docs and ops scripts only - no code paths.