### PR TITLE
fix(mail): drop out-of-office auto-replies to chat notify/replyto addresses

### DIFF
--- a/iznik-batch/app/Services/Mail/Incoming/IncomingMailService.php
+++ b/iznik-batch/app/Services/Mail/Incoming/IncomingMailService.php
@@ -1522,6 +1522,18 @@ class IncomingMailService
             return $this->handleBounce($email);
         }
 
+        // Drop auto-replies (out-of-office, vacation responders etc.). These are
+        // machine responses to our digest/notification mails; delivering them would
+        // open a chat with the poster containing someone's OOO text.
+        if ($email->isAutoReply()) {
+            Log::info('Dropping auto-reply to replyto address', [
+                'envelope_to' => $email->envelopeTo,
+                'subject' => $email->subject,
+            ]);
+
+            return $this->dropped("Auto-reply to replyto address");
+        }
+
         // Parse replyto-{msgid}-{fromid}
         $parts = explode('-', $localPart);
         if (count($parts) < 3) {
@@ -1800,6 +1812,26 @@ class IncomingMailService
             ]);
 
             return $this->dropped("Reply to non-existent chat");
+        }
+
+        // Drop auto-replies (out-of-office, vacation responders etc.) - delivering
+        // them as chat messages sends one member's OOO text to other freeglers.
+        // An Auto-Submitted header (RFC 3834) is definitive, so always drop on it.
+        // The subject/body patterns can false-positive on genuine human wording, so
+        // (matching legacy MailRouter::replyToChatNotification) only trust them when
+        // the chat had a message within the last 5 hours: real auto-responders fire
+        // rapidly after our notification, late replies are usually human.
+        $recentMessage = $chat->latestmessage
+            && $chat->latestmessage->gt(now()->subHours(5));
+
+        if ($email->isAutoSubmitted() || ($recentMessage && $email->isAutoReply())) {
+            Log::info('Dropping auto-reply to chat notification', [
+                'chat_id' => $chatId,
+                'user_id' => $userId,
+                'subject' => $email->subject,
+            ]);
+
+            return $this->dropped("Auto-reply to chat notification");
         }
 
         // Check if chat is stale and sender email is unfamiliar

--- a/iznik-batch/app/Services/Mail/Incoming/ParsedEmail.php
+++ b/iznik-batch/app/Services/Mail/Incoming/ParsedEmail.php
@@ -208,13 +208,24 @@ class ParsedEmail
     }
 
     /**
+     * Check the Auto-Submitted header (RFC 3834) only. Unlike the subject/body
+     * patterns in isAutoReply(), this header is a definitive machine-generation
+     * marker with no false-positive risk from a human's wording.
+     */
+    public function isAutoSubmitted(): bool
+    {
+        $autoSubmitted = $this->getHeader('auto-submitted');
+
+        return $autoSubmitted !== null && strtolower($autoSubmitted) !== 'no';
+    }
+
+    /**
      * Check if this is an auto-reply (vacation, OOO, etc.).
      */
     public function isAutoReply(): bool
     {
         // Check Auto-Submitted header (RFC 3834)
-        $autoSubmitted = $this->getHeader('auto-submitted');
-        if ($autoSubmitted !== null && strtolower($autoSubmitted) !== 'no') {
+        if ($this->isAutoSubmitted()) {
             return TRUE;
         }
 

--- a/iznik-batch/tests/Unit/Services/Mail/Incoming/IncomingMailServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/Mail/Incoming/IncomingMailServiceTest.php
@@ -2905,11 +2905,12 @@ class IncomingMailServiceTest extends TestCase
         return [$user, $group, $userEmail];
     }
 
-    public function test_autoreply_to_notify_address_is_not_globally_dropped(): void
+    public function test_autoreply_to_notify_address_is_dropped(): void
     {
-        // Legacy code routes notify- addresses BEFORE checking auto-reply globally.
-        // An auto-reply to a notify address should reach handleChatNotificationReply(),
-        // not be dropped by the global auto-reply filter.
+        // An out-of-office / vacation auto-reply to a chat notification address is a
+        // machine response to our own email. It must be dropped, not delivered into
+        // the chat as if the member had replied - real OOO texts have been sent on
+        // to other freeglers this way.
         $user1 = $this->createTestUser(['email_preferred' => $this->uniqueEmail('user1')]);
         $user2 = $this->createTestUser(['email_preferred' => $this->uniqueEmail('user2')]);
         $chat = $this->createTestChatRoom($user1, $user2);
@@ -2919,6 +2920,8 @@ class IncomingMailServiceTest extends TestCase
         DB::table('chat_rooms')
             ->where('id', $chat->id)
             ->update(['latestmessage' => now()->subDays(1)]);
+
+        $chatMessagesBefore = DB::table('chat_messages')->where('chatid', $chat->id)->count();
 
         $email = $this->createMinimalEmail([
             'From' => $user2Email,
@@ -2935,7 +2938,102 @@ class IncomingMailServiceTest extends TestCase
 
         $result = $this->service->route($parsed);
 
-        // Should be routed to user (chat reply), NOT dropped
+        $this->assertEquals(RoutingResult::DROPPED, $result);
+        $this->assertEquals(
+            $chatMessagesBefore,
+            DB::table('chat_messages')->where('chatid', $chat->id)->count(),
+            'auto-reply must not create a chat message'
+        );
+    }
+
+    public function test_human_reply_to_notify_address_is_not_dropped_as_autoreply(): void
+    {
+        // A genuine reply without auto-reply markers must still be delivered.
+        $user1 = $this->createTestUser(['email_preferred' => $this->uniqueEmail('user1')]);
+        $user2 = $this->createTestUser(['email_preferred' => $this->uniqueEmail('user2')]);
+        $chat = $this->createTestChatRoom($user1, $user2);
+        $user2Email = $user2->emails->first()->email;
+
+        DB::table('chat_rooms')
+            ->where('id', $chat->id)
+            ->update(['latestmessage' => now()->subDays(1)]);
+
+        $email = $this->createMinimalEmail([
+            'From' => $user2Email,
+            'To' => "notify-{$chat->id}-{$user2->id}@users.ilovefreegle.org",
+            'Subject' => 'Re: Your message',
+        ], 'Yes please, I can collect tomorrow evening.');
+
+        $parsed = $this->parser->parse(
+            $email,
+            $user2Email,
+            "notify-{$chat->id}-{$user2->id}@users.ilovefreegle.org"
+        );
+
+        $result = $this->service->route($parsed);
+
+        $this->assertEquals(RoutingResult::TO_USER, $result);
+    }
+
+    public function test_pattern_only_autoreply_dropped_when_chat_recently_active(): void
+    {
+        // No Auto-Submitted header, but the body matches an OOO pattern and the chat
+        // had a message within the last 5 hours - a real auto-responder firing right
+        // after our notification. Matches legacy MailRouter recency behaviour.
+        $user1 = $this->createTestUser(['email_preferred' => $this->uniqueEmail('user1')]);
+        $user2 = $this->createTestUser(['email_preferred' => $this->uniqueEmail('user2')]);
+        $chat = $this->createTestChatRoom($user1, $user2);
+        $user2Email = $user2->emails->first()->email;
+
+        DB::table('chat_rooms')
+            ->where('id', $chat->id)
+            ->update(['latestmessage' => now()->subHours(1)]);
+
+        $email = $this->createMinimalEmail([
+            'From' => $user2Email,
+            'To' => "notify-{$chat->id}-{$user2->id}@users.ilovefreegle.org",
+            'Subject' => 'Re: Your message',
+        ], 'I am currently away from the office until Monday.');
+
+        $parsed = $this->parser->parse(
+            $email,
+            $user2Email,
+            "notify-{$chat->id}-{$user2->id}@users.ilovefreegle.org"
+        );
+
+        $result = $this->service->route($parsed);
+
+        $this->assertEquals(RoutingResult::DROPPED, $result);
+    }
+
+    public function test_pattern_only_autoreply_delivered_when_chat_not_recently_active(): void
+    {
+        // No Auto-Submitted header and the chat has been quiet for over 5 hours: a
+        // late reply whose wording merely matches an OOO pattern is usually human,
+        // so it must be delivered (legacy MailRouter tradeoff, kept deliberately).
+        $user1 = $this->createTestUser(['email_preferred' => $this->uniqueEmail('user1')]);
+        $user2 = $this->createTestUser(['email_preferred' => $this->uniqueEmail('user2')]);
+        $chat = $this->createTestChatRoom($user1, $user2);
+        $user2Email = $user2->emails->first()->email;
+
+        DB::table('chat_rooms')
+            ->where('id', $chat->id)
+            ->update(['latestmessage' => now()->subDays(1)]);
+
+        $email = $this->createMinimalEmail([
+            'From' => $user2Email,
+            'To' => "notify-{$chat->id}-{$user2->id}@users.ilovefreegle.org",
+            'Subject' => 'Re: Your message',
+        ], 'Sorry, I was away from the office yesterday. Yes please, still available?');
+
+        $parsed = $this->parser->parse(
+            $email,
+            $user2Email,
+            "notify-{$chat->id}-{$user2->id}@users.ilovefreegle.org"
+        );
+
+        $result = $this->service->route($parsed);
+
         $this->assertEquals(RoutingResult::TO_USER, $result);
     }
 
@@ -2982,16 +3080,19 @@ class IncomingMailServiceTest extends TestCase
         }
     }
 
-    public function test_autoreply_to_replyto_address_is_not_globally_dropped(): void
+    public function test_autoreply_to_replyto_address_is_dropped(): void
     {
-        // Auto-replies to replyto- addresses should reach handleReplyToAddress(),
-        // not be dropped by the global auto-reply filter.
+        // An out-of-office auto-reply to a replyto- address is a machine response to
+        // our digest/notification mail. It must not open a chat with the poster - a
+        // member's OOO responder replied to digest posts and confused the posters.
         $poster = $this->createTestUser(['email_preferred' => $this->uniqueEmail('poster')]);
         $replier = $this->createTestUser(['email_preferred' => $this->uniqueEmail('replier')]);
         $group = $this->createTestGroup();
         $this->createMembership($poster, $group);
         $message = $this->createTestMessage($poster, $group);
         $replierEmail = $replier->emails->first()->email;
+
+        $chatMessagesBefore = DB::table('chat_messages')->count();
 
         $email = $this->createMinimalEmail([
             'From' => $replierEmail,
@@ -3008,8 +3109,12 @@ class IncomingMailServiceTest extends TestCase
 
         $result = $this->service->route($parsed);
 
-        // Should be routed to user (reply to message), NOT dropped by global auto-reply filter
-        $this->assertEquals(RoutingResult::TO_USER, $result);
+        $this->assertEquals(RoutingResult::DROPPED, $result);
+        $this->assertEquals(
+            $chatMessagesBefore,
+            DB::table('chat_messages')->count(),
+            'auto-reply must not create a chat message to the poster'
+        );
     }
 
     /**


### PR DESCRIPTION
## Problem

Out-of-office auto-replies to our chat notification (`notify-`) and digest reply (`replyto-`) addresses were delivered as real chat messages. A support case (Mar 2026) had an auto-joined member's OOO responder "replying" to several posters' digest mails, confusing everyone involved.

`route()` deliberately dispatches `notify-`/`replyto-` before the global auto-reply filter on the basis that each handler applies its own filtering (commit `e543cc4a3`) - but neither handler actually did, and `test_autoreply_to_notify_address_is_not_globally_dropped` enshrined the delivery behaviour.

## Fix

- **`replyto-`**: drop when `isAutoReply()` - matches legacy `MailRouter::replyToSingleMessage` exactly.
- **`notify-`**: drop always on the definitive `Auto-Submitted` header (RFC 3834); for the fuzzier subject/body patterns, drop only when the chat had a message within the last 5 hours - the same guard legacy `MailRouter::replyToChatNotification` used to avoid false-positives on genuine human wording ("I was away from the office yesterday...").
- Adds `ParsedEmail::isAutoSubmitted()` for the header-only check.

## Tests

- Flipped the two tests that asserted delivery; both now assert DROPPED and that no chat message is created.
- New coverage: pattern-only auto-reply dropped when chat recently active; pattern-only delivered when chat quiet (deliberate legacy tradeoff); genuine human reply still delivered.
- Full local Laravel suite: **4735 passed** (worktree, status API).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E5jyvZJ7xJB58tbrVjj86L