### PR TITLE
fix(birthday): include email-only mods in group birthday volunteer list

### DIFF
--- a/iznik-batch/app/Services/BirthdayService.php
+++ b/iznik-batch/app/Services/BirthdayService.php
@@ -102,8 +102,6 @@ class BirthdayService
 
     private function getActiveVolunteers(int $groupId): array
     {
-        $oneYearAgo = now()->subYear()->format('Y-m-d H:i:s');
-
         // Match the source of truth used by the modtools "Show me as a volunteer"
         // toggle, the Go API's group volunteer list (iznik-server-go
         // group/groupVolunteer.go:45), and every other on-site volunteer display:
@@ -116,13 +114,18 @@ class BirthdayService
         // from the volunteer line in the birthday email even though their UI
         // showed "Show me". V1 papered over this with a periodic
         // fix_list_birthday_moderators.php back-fill; this avoids the divergence.
+        //
+        // No lastaccess filter, again matching the Go volunteer list: lastaccess
+        // only updates on an authenticated web/app login, so a mod who moderates
+        // purely by email would be silently dropped from the birthday mail every
+        // year while appearing as an active volunteer everywhere else on the site
+        // (reported for Oxford's group birthday email).
         $mods = DB::table('memberships')
             ->join('users', 'users.id', '=', 'memberships.userid')
             ->where('memberships.groupid', $groupId)
             ->where('memberships.collection', 'Approved')
             ->whereIn('memberships.role', ['Moderator', 'Owner'])
             ->whereNull('users.deleted')
-            ->where('users.lastaccess', '>=', $oneYearAgo)
             ->whereRaw("(JSON_EXTRACT(users.settings, '$.showmod') IS NULL OR JSON_EXTRACT(users.settings, '$.showmod') = TRUE)")
             ->select(['users.id', 'users.fullname', 'users.firstname'])
             ->get();

--- a/iznik-batch/tests/Unit/Services/BirthdayServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/BirthdayServiceTest.php
@@ -44,6 +44,49 @@ class BirthdayServiceTest extends TestCase
         $this->assertSame(1, $count, 'only the genuine member receives the birthday appeal');
     }
 
+    /**
+     * The volunteer list must match the Go API's group volunteer query, which has
+     * no lastaccess filter. lastaccess only updates on web/app login, so a mod who
+     * moderates purely by email must still appear in the birthday email's volunteer
+     * line (an Oxford mod was silently dropped every year by a lastaccess filter).
+     */
+    public function test_email_only_mod_included_in_birthday_volunteers(): void
+    {
+        $group = $this->createTestGroup();
+
+        $webMod = $this->makeBirthdayVolunteer($group->id, 'Web Mod', now());
+        $emailOnlyMod = $this->makeBirthdayVolunteer($group->id, 'Email Mod', now()->subYears(2));
+        $hiddenMod = $this->makeBirthdayVolunteer($group->id, 'Hidden Mod', now());
+        DB::table('users')->where('id', $hiddenMod->id)->update([
+            'settings' => json_encode(['showmod' => false]),
+        ]);
+
+        $method = new \ReflectionMethod(BirthdayService::class, 'getActiveVolunteers');
+        $volunteers = $method->invoke(new BirthdayService(), $group->id);
+
+        $names = array_column($volunteers, 'displayname');
+        $this->assertContains('Web Mod', $names);
+        $this->assertContains('Email Mod', $names, 'mod who only moderates by email must be included');
+        $this->assertNotContains('Hidden Mod', $names, 'showmod=false must still be respected');
+    }
+
+    /** A moderator on the group with the given display name and lastaccess. */
+    private function makeBirthdayVolunteer(int $groupId, string $name, $lastaccess): object
+    {
+        $user = $this->createTestUser();
+        DB::table('users')->where('id', $user->id)->update([
+            'fullname' => $name,
+            'deleted' => null,
+            'lastaccess' => $lastaccess,
+        ]);
+        DB::table('memberships')->insert([
+            'userid' => $user->id, 'groupid' => $groupId,
+            'role' => 'Moderator', 'collection' => 'Approved', 'added' => now(),
+        ]);
+
+        return $user;
+    }
+
     /** A user who passes every birthday gate: consenting, active, contactable, no recent appeal. */
     private function makeBirthdayRecipient(): object
     {


### PR DESCRIPTION
## Problem

The "Happy Birthday to X Freegle!" email lists the group's volunteers, but `BirthdayService::getActiveVolunteers()` filtered mods on `users.lastaccess` within a year. `lastaccess` only updates on an authenticated web/app login - a mod who moderates purely by email reply never refreshes it, so they were silently dropped from the volunteer line every year while appearing as an active volunteer everywhere else on the site. Reported by support for Oxford's birthday email (one mod consistently missing).

## Fix

Drop the `lastaccess` filter to match the canonical volunteer query (`iznik-server-go/group/groupVolunteer.go`), which has no such filter - the same source of truth this method's comment already claims to mirror. Role, collection, deleted and `showmod` filtering are unchanged.

## Tests

- Adds the first direct test of `getActiveVolunteers`: a mod with `lastaccess` two years ago is included; `showmod=false` is still respected.
- Full local Laravel suite: **4733 passed** (worktree, status API).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E5jyvZJ7xJB58tbrVjj86L