### PR TITLE
feat(logs): record account reinstatement after self-deletion

### DIFF
--- a/iznik-batch/database/migrations/2026_07_06_000001_add_restored_to_logs_subtype_enum.php
+++ b/iznik-batch/database/migrations/2026_07_06_000001_add_restored_to_logs_subtype_enum.php
@@ -1,0 +1,70 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (!Schema::hasTable('logs')) {
+            return;
+        }
+
+        // Append-only ENUM widening: 'Restored' records an account being
+        // reinstated after self-deletion (PATCH /session with deleted:null in
+        // the Go API), pairing with the existing (User, Deleted) log so mods
+        // can see a deletion was reversed. Without the enum member MySQL
+        // silently truncates the value to '' in non-strict mode. Original
+        // values kept in order; new value appended at the end so storage stays
+        // at 1 byte. INPLACE + LOCK=NONE is valid for end-append on Percona
+        // 8.0; INSTANT is not supported for ENUM modification.
+        DB::statement("
+            ALTER TABLE logs
+              MODIFY COLUMN subtype ENUM(
+                'Created','Deleted','Received','Sent','Failure','ClassifiedSpam',
+                'Joined','Left','Approved','Rejected','YahooDeliveryType',
+                'YahooPostingStatus','NotSpam','Login','Hold','Release','Edit',
+                'RoleChange','Merged','Split','Replied','Mailed','Applied',
+                'Suspect','Licensed','LicensePurchase','YahooApplied',
+                'YahooConfirmed','YahooJoined','MailOff','EventsOff',
+                'NewslettersOff','RelevantOff','Logout','Bounce','SuspendMail',
+                'Autoreposted','Outcome','OurPostingStatus','OurEmailFrequency',
+                'VolunteersOff','Autoapproved','Unbounce','WorryWords',
+                'NoteAdded','PostcodeChange','Repost',
+                'Restored'
+              ) DEFAULT NULL,
+              ALGORITHM=INPLACE, LOCK=NONE
+        ");
+    }
+
+    public function down(): void
+    {
+        if (!Schema::hasTable('logs')) {
+            return;
+        }
+
+        // Remove rows using the new value before narrowing the column,
+        // otherwise the ALTER fails on rows whose value is no longer in the
+        // enum.
+        DB::statement("DELETE FROM logs WHERE type = 'User' AND subtype = 'Restored'");
+
+        DB::statement("
+            ALTER TABLE logs
+              MODIFY COLUMN subtype ENUM(
+                'Created','Deleted','Received','Sent','Failure','ClassifiedSpam',
+                'Joined','Left','Approved','Rejected','YahooDeliveryType',
+                'YahooPostingStatus','NotSpam','Login','Hold','Release','Edit',
+                'RoleChange','Merged','Split','Replied','Mailed','Applied',
+                'Suspect','Licensed','LicensePurchase','YahooApplied',
+                'YahooConfirmed','YahooJoined','MailOff','EventsOff',
+                'NewslettersOff','RelevantOff','Logout','Bounce','SuspendMail',
+                'Autoreposted','Outcome','OurPostingStatus','OurEmailFrequency',
+                'VolunteersOff','Autoapproved','Unbounce','WorryWords',
+                'NoteAdded','PostcodeChange','Repost'
+              ) DEFAULT NULL,
+              ALGORITHM=INPLACE, LOCK=NONE
+        ");
+    }
+};

--- a/iznik-batch/database/migrations/2026_07_06_000001_add_restored_to_logs_subtype_enum.php
+++ b/iznik-batch/database/migrations/2026_07_06_000001_add_restored_to_logs_subtype_enum.php
@@ -18,14 +18,14 @@ return new class extends Migration
         // can see a deletion was reversed. Without the enum member MySQL
         // silently truncates the value to '' in non-strict mode. Original
         // values kept in order; new value appended at the end so storage stays
-        // at 1 byte — which makes this INSTANT-eligible on MySQL/Percona 8.0
-        // (metadata-only): end-append with unchanged storage width is in the
-        // instant-DDL list. That matters on the Galera cluster: under TOI an
-        // INSTANT DDL pauses the cluster for milliseconds instead of the
-        // duration of a table rebuild, so it needs no maintenance window.
-        // (Verified on Percona 8.0.43 locally; prod is 8.0.45.) INPLACE +
-        // LOCK=NONE kept as a fallback for any environment where INSTANT is
-        // refused.
+        // at 1 byte. We try ALGORITHM=INSTANT first (accepted on some Percona
+        // 8.0 builds - worked on 8.0.43 locally) but prod 8.0.45 REFUSES
+        // INSTANT for this change, so the INPLACE + LOCK=NONE path below is
+        // the one that actually runs there. That is still fine to run without
+        // a maintenance window: an end-append that keeps the enum at 1 byte is
+        // a metadata-only INPLACE change - NO table rebuild, no row copying,
+        // concurrent DML permitted - so under Galera TOI the cluster pause is
+        // the metadata update itself (seconds), not a scan of logs.
         try {
             DB::statement("
             ALTER TABLE logs

--- a/iznik-batch/database/migrations/2026_07_06_000001_add_restored_to_logs_subtype_enum.php
+++ b/iznik-batch/database/migrations/2026_07_06_000001_add_restored_to_logs_subtype_enum.php
@@ -18,9 +18,35 @@ return new class extends Migration
         // can see a deletion was reversed. Without the enum member MySQL
         // silently truncates the value to '' in non-strict mode. Original
         // values kept in order; new value appended at the end so storage stays
-        // at 1 byte. INPLACE + LOCK=NONE is valid for end-append on Percona
-        // 8.0; INSTANT is not supported for ENUM modification.
-        DB::statement("
+        // at 1 byte — which makes this INSTANT-eligible on MySQL/Percona 8.0
+        // (metadata-only): end-append with unchanged storage width is in the
+        // instant-DDL list. That matters on the Galera cluster: under TOI an
+        // INSTANT DDL pauses the cluster for milliseconds instead of the
+        // duration of a table rebuild, so it needs no maintenance window.
+        // (Verified on Percona 8.0.43 locally; prod is 8.0.45.) INPLACE +
+        // LOCK=NONE kept as a fallback for any environment where INSTANT is
+        // refused.
+        try {
+            DB::statement("
+            ALTER TABLE logs
+              MODIFY COLUMN subtype ENUM(
+                'Created','Deleted','Received','Sent','Failure','ClassifiedSpam',
+                'Joined','Left','Approved','Rejected','YahooDeliveryType',
+                'YahooPostingStatus','NotSpam','Login','Hold','Release','Edit',
+                'RoleChange','Merged','Split','Replied','Mailed','Applied',
+                'Suspect','Licensed','LicensePurchase','YahooApplied',
+                'YahooConfirmed','YahooJoined','MailOff','EventsOff',
+                'NewslettersOff','RelevantOff','Logout','Bounce','SuspendMail',
+                'Autoreposted','Outcome','OurPostingStatus','OurEmailFrequency',
+                'VolunteersOff','Autoapproved','Unbounce','WorryWords',
+                'NoteAdded','PostcodeChange','Repost',
+                'Restored'
+              ) DEFAULT NULL,
+              ALGORITHM=INSTANT
+            ");
+        } catch (\Illuminate\Database\QueryException $e) {
+            // INSTANT refused (older server / storage growth): online fallback.
+            DB::statement("
             ALTER TABLE logs
               MODIFY COLUMN subtype ENUM(
                 'Created','Deleted','Received','Sent','Failure','ClassifiedSpam',
@@ -36,7 +62,8 @@ return new class extends Migration
                 'Restored'
               ) DEFAULT NULL,
               ALGORITHM=INPLACE, LOCK=NONE
-        ");
+            ");
+        }
     }
 
     public function down(): void

--- a/iznik-nuxt3/modtools/components/ModLog.vue
+++ b/iznik-nuxt3/modtools/components/ModLog.vue
@@ -248,6 +248,10 @@
             <ModLogGroup :logid="logid" tag="on" />
             <ModLogStdMsg :logid="logid" />
           </span>
+          <span v-else-if="log.subtype === 'Restored'">
+            Account reinstated (deletion cancelled)
+            <ModLogUser :userid="logUser.id" />
+          </span>
           <span v-else-if="log.subtype === 'Mailed'" class="text-danger">
             Mod sent
             <span v-if="log.text && log.text.length > 0">

--- a/iznik-server-go/log/log.go
+++ b/iznik-server-go/log/log.go
@@ -26,6 +26,8 @@ const LOG_SUBTYPE_CREATED = "Created"
 
 const LOG_SUBTYPE_DELETED = "Deleted"
 
+const LOG_SUBTYPE_RESTORED = "Restored"
+
 const LOG_SUBTYPE_EDIT = "Edit"
 
 const LOG_SUBTYPE_APPROVED = "Approved"

--- a/iznik-server-go/session/session.go
+++ b/iznik-server-go/session/session.go
@@ -1827,6 +1827,15 @@ func PatchSession(c *fiber.Ctx) error {
 
 	if string(req.Deleted) == "null" {
 		setClauses = append(setClauses, "deleted = NULL")
+
+		// Deletion writes a (User, Deleted) audit log; record the matching
+		// reinstatement so mods can see the full story. The INSERT..SELECT only
+		// fires if the account is actually flagged deleted right now (the UPDATE
+		// clearing the flag runs after this), so a routine settings save that
+		// happens to include deleted:null doesn't spam the log.
+		db.Exec("INSERT INTO logs (timestamp, type, subtype, user, byuser) "+
+			"SELECT NOW(), ?, ?, id, id FROM users WHERE id = ? AND deleted IS NOT NULL",
+			log2.LOG_TYPE_USER, log2.LOG_SUBTYPE_RESTORED, myid)
 	}
 
 	if req.Marketingconsent != nil {

--- a/iznik-server-go/test/session_test.go
+++ b/iznik-server-go/test/session_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/freegle/iznik-server-go/database"
+	log2 "github.com/freegle/iznik-server-go/log"
 	"github.com/freegle/iznik-server-go/session"
 	"github.com/stretchr/testify/assert"
 )
@@ -992,6 +993,50 @@ func TestPatchSessionSettings(t *testing.T) {
 	var settings string
 	db.Raw("SELECT settings FROM users WHERE id = ?", userID).Scan(&settings)
 	assert.Contains(t, settings, `"email":"daily"`)
+}
+
+func TestPatchSessionReinstateLogsRestored(t *testing.T) {
+	prefix := uniquePrefix("patch_restore")
+	db := database.DBConn
+	userID := CreateTestUser(t, prefix, "User")
+
+	// Soft-delete the account as self-service deletion does, then create the
+	// session afterwards, mirroring a user logging back in during the grace
+	// period to recover their account.
+	db.Exec("UPDATE users SET deleted = NOW() WHERE id = ?", userID)
+	_, token := CreateTestSession(t, userID)
+
+	body, _ := json.Marshal(map[string]interface{}{
+		"deleted": nil,
+	})
+
+	req := httptest.NewRequest("PATCH", "/api/session?jwt="+token, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	// The deleted flag is cleared.
+	var deleted *string
+	db.Raw("SELECT deleted FROM users WHERE id = ?", userID).Scan(&deleted)
+	assert.Nil(t, deleted)
+
+	// The reinstatement is recorded in the audit log, matching the
+	// (User, Deleted) entry written when the account was deleted.
+	var count int64
+	db.Raw("SELECT COUNT(*) FROM logs WHERE user = ? AND type = ? AND subtype = ?",
+		userID, log2.LOG_TYPE_USER, log2.LOG_SUBTYPE_RESTORED).Scan(&count)
+	assert.Equal(t, int64(1), count)
+
+	// A repeat PATCH with deleted:null on an already-live account must not
+	// write another Restored log.
+	req = httptest.NewRequest("PATCH", "/api/session?jwt="+token, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ = getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	db.Raw("SELECT COUNT(*) FROM logs WHERE user = ? AND type = ? AND subtype = ?",
+		userID, log2.LOG_TYPE_USER, log2.LOG_SUBTYPE_RESTORED).Scan(&count)
+	assert.Equal(t, int64(1), count)
 }
 
 func TestPatchSessionSettingsPostcodeChange(t *testing.T) {


### PR DESCRIPTION
## Problem

Self-deletion writes a `(User, Deleted)` audit log, but recovering the account within the 14-day grace period (`PATCH /session` with `deleted:null`) wrote nothing. Support asked (Nov 2025) for the logs to show when a member deletes their account and then has it reinstated - previously they couldn't tell whether or when a deletion had been reversed, or confirm it for a specific member.

## Fix

- Go API: write a `(User, Restored)` log in `PatchSession`. The `INSERT..SELECT` only fires when the account is actually flagged deleted at that moment (the flag-clearing UPDATE runs afterwards), so a routine settings save that happens to include `deleted:null` cannot spam the log.
- Migration: append `'Restored'` to the `logs.subtype` enum (append-only, `INPLACE, LOCK=NONE`, following the `chat_messages.reportreason` widening precedent). Without it MySQL silently truncates the value to `''` - caught by the new test against the real schema.
- ModTools: displays as "Account reinstated (deletion cancelled)" alongside the existing "User left platform" entry.

## Tests

- New `TestPatchSessionReinstateLogsRestored`: reinstatement writes exactly one log; a repeat `deleted:null` PATCH on a live account writes none.
- Full local suites (worktree, status API): **Go 3410 passed**, **Laravel 4732 passed** (validates migration), **vitest 14134 passed** (ModLog change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E5jyvZJ7xJB58tbrVjj86L
