### PR TITLE
feat(stats): bulk offers count per item everywhere; fix dead authority stats endpoint

### DIFF
--- a/iznik-batch/app/Services/StatsGenerationService.php
+++ b/iznik-batch/app/Services/StatsGenerationService.php
@@ -180,8 +180,8 @@ class StatsGenerationService
             $activeUsers[(int) $row->gid] = (int) $row->cnt;
         }
 
-        // OUTCOMES: distinct messages with a Taken/Received outcome dated $date,
-        // per native group. (Replaces the per-group distinct count.)
+        // OUTCOMES non-bulk: distinct messages with a Taken/Received outcome dated $date,
+        // per native group, excluding bulk-offer messages (counted via available=0 flips below).
         $outcomes = [];
         foreach (
             DB::table('messages_outcomes')
@@ -190,11 +190,52 @@ class StatsGenerationService
                 ->where('messages_outcomes.timestamp', '>=', $date)
                 ->where('messages_outcomes.timestamp', '<', $next)
                 ->whereIn('messages_outcomes.outcome', [Message::OUTCOME_TAKEN, Message::OUTCOME_RECEIVED])
+                ->whereNotExists(function ($q) {
+                    $q->select(DB::raw(1))
+                        ->from('messages_bulk_items')
+                        ->whereColumn('messages_bulk_items.msgid', 'messages_outcomes.msgid');
+                })
                 ->groupBy('messages_groups.groupid')
                 ->selectRaw('messages_groups.groupid AS gid, COUNT(DISTINCT messages_outcomes.msgid) AS cnt')
                 ->get() as $row
         ) {
             $outcomes[(int) $row->gid] = (int) $row->cnt;
+        }
+
+        // OUTCOMES bulk flip: catalogue items flipped to available=0 on $date count by
+        // their quantity (remaining units at flip time).
+        foreach (
+            DB::table('messages_bulk_items')
+                ->join('messages_groups', 'messages_groups.msgid', '=', 'messages_bulk_items.msgid')
+                ->where('messages_groups.rippled_in', 0) // native posts only
+                ->where('messages_bulk_items.available', 0)
+                ->where('messages_bulk_items.updated_at', '>=', $date)
+                ->where('messages_bulk_items.updated_at', '<', $next)
+                ->groupBy('messages_groups.groupid')
+                ->selectRaw('messages_groups.groupid AS gid, SUM(messages_bulk_items.quantity) AS cnt')
+                ->get() as $row
+        ) {
+            $gid = (int) $row->gid;
+            $outcomes[$gid] = ($outcomes[$gid] ?? 0) + (int) $row->cnt;
+        }
+
+        // OUTCOMES collected: in-app collections (interest rows flipped to Collected on $date)
+        // count by the interest-row quantity. These units were already deducted from
+        // messages_bulk_items.quantity before any flip, so there is no overlap with the
+        // available=0 arm above.
+        foreach (
+            DB::table('messages_bulk_items_interest')
+                ->join('messages_groups', 'messages_groups.msgid', '=', 'messages_bulk_items_interest.msgid')
+                ->where('messages_groups.rippled_in', 0) // native posts only
+                ->where('messages_bulk_items_interest.state', 'Collected')
+                ->where('messages_bulk_items_interest.updated_at', '>=', $date)
+                ->where('messages_bulk_items_interest.updated_at', '<', $next)
+                ->groupBy('messages_groups.groupid')
+                ->selectRaw('messages_groups.groupid AS gid, SUM(messages_bulk_items_interest.quantity) AS cnt')
+                ->get() as $row
+        ) {
+            $gid = (int) $row->gid;
+            $outcomes[$gid] = ($outcomes[$gid] ?? 0) + (int) $row->cnt;
         }
 
         // APPROVED_MESSAGE_COUNT: distinct approved native messages arriving $date.
@@ -211,6 +252,34 @@ class StatsGenerationService
                 ->get() as $row
         ) {
             $approvedMessages[(int) $row->gid] = (int) $row->cnt;
+        }
+
+        // BULK TOP-UP: bulk messages count by initial unit total (messages.availableinitially),
+        // not 1 per message. The base query already counted each bulk message as 1; add
+        // availableinitially - 1 per bulk message per group. Using availableinitially (set at
+        // creation) keeps the arrival-day figure immune to same-day collections shrinking
+        // messages_bulk_items.quantity.
+        foreach (
+            DB::table('messages_groups')
+                ->join('messages', 'messages.id', '=', 'messages_groups.msgid')
+                ->whereExists(function ($q) {
+                    $q->select(DB::raw(1))
+                        ->from('messages_bulk_items')
+                        ->whereColumn('messages_bulk_items.msgid', 'messages_groups.msgid');
+                })
+                ->where('messages_groups.rippled_in', 0)
+                ->where('messages.arrival', '>=', $date)
+                ->where('messages.arrival', '<', $next)
+                ->where('messages_groups.collection', Membership::COLLECTION_APPROVED)
+                ->groupBy('messages_groups.groupid')
+                ->selectRaw('messages_groups.groupid AS gid, SUM(messages.availableinitially - 1) AS topup')
+                ->get() as $row
+        ) {
+            $gid = (int) $row->gid;
+            $topup = (int) $row->topup;
+            if ($topup > 0) {
+                $approvedMessages[$gid] = ($approvedMessages[$gid] ?? 0) + $topup;
+            }
         }
 
         // APPROVED_MEMBER_COUNT: cumulative approved members as of $date
@@ -316,8 +385,8 @@ class StatsGenerationService
             $ourPosting[(int) $row->gid][$row->ourPostingStatus] = (int) $row->cnt;
         }
 
-        // REPLIES: "Interested" chat messages referring to approved native
-        // posts on $date, per group.
+        // REPLIES non-bulk: "Interested" chat messages referring to approved native
+        // non-bulk posts on $date, per group.
         $replies = [];
         foreach (
             DB::table('chat_messages')
@@ -326,6 +395,11 @@ class StatsGenerationService
                 ->where('chat_messages.date', '<', $next)
                 ->where('chat_messages.type', ChatMessage::TYPE_INTERESTED)
                 ->where('messages_groups.rippled_in', 0) // native posts only
+                ->whereNotExists(function ($q) {
+                    $q->select(DB::raw(1))
+                        ->from('messages_bulk_items')
+                        ->whereColumn('messages_bulk_items.msgid', 'chat_messages.refmsgid');
+                })
                 ->groupBy('messages_groups.groupid')
                 ->selectRaw('messages_groups.groupid AS gid, COUNT(*) AS cnt')
                 ->get() as $row
@@ -333,11 +407,56 @@ class StatsGenerationService
             $replies[(int) $row->gid] = (int) $row->cnt;
         }
 
-        // WEIGHT: estimated kg moved on $date per group, using the same
+        // REPLIES bulk part 1: structured interest rows created on $date — one row
+        // per (item, user) pair counts as one reply signal.
+        foreach (
+            DB::table('messages_bulk_items_interest')
+                ->join('messages_groups', 'messages_groups.msgid', '=', 'messages_bulk_items_interest.msgid')
+                ->where('messages_groups.rippled_in', 0)
+                ->where('messages_bulk_items_interest.created_at', '>=', $date)
+                ->where('messages_bulk_items_interest.created_at', '<', $next)
+                ->groupBy('messages_groups.groupid')
+                ->selectRaw('messages_groups.groupid AS gid, COUNT(*) AS cnt')
+                ->get() as $row
+        ) {
+            $gid = (int) $row->gid;
+            $replies[$gid] = ($replies[$gid] ?? 0) + (int) $row->cnt;
+        }
+
+        // REPLIES bulk part 2: free-text Interested chat messages for bulk msgids
+        // where the sender has no interest row — they replied outside the structured
+        // flow and would otherwise be missed entirely.
+        foreach (
+            DB::table('chat_messages')
+                ->join('messages_groups', 'chat_messages.refmsgid', '=', 'messages_groups.msgid')
+                ->where('chat_messages.date', '>=', $date)
+                ->where('chat_messages.date', '<', $next)
+                ->where('chat_messages.type', ChatMessage::TYPE_INTERESTED)
+                ->where('messages_groups.rippled_in', 0)
+                ->whereExists(function ($q) {
+                    $q->select(DB::raw(1))
+                        ->from('messages_bulk_items')
+                        ->whereColumn('messages_bulk_items.msgid', 'chat_messages.refmsgid');
+                })
+                ->whereNotExists(function ($q) {
+                    $q->select(DB::raw(1))
+                        ->from('messages_bulk_items_interest')
+                        ->whereColumn('messages_bulk_items_interest.msgid', 'chat_messages.refmsgid')
+                        ->whereColumn('messages_bulk_items_interest.userid', 'chat_messages.userid');
+                })
+                ->groupBy('messages_groups.groupid')
+                ->selectRaw('messages_groups.groupid AS gid, COUNT(*) AS cnt')
+                ->get() as $row
+        ) {
+            $gid = (int) $row->gid;
+            $replies[$gid] = ($replies[$gid] ?? 0) + (int) $row->cnt;
+        }
+
+        // WEIGHT non-bulk: estimated kg moved on $date per group, using the same
         // grouped subquery as regenerateWeightForRange() — DISTINCT
         // (msgid, groupid, eff_weight) with items.weight when known/non-zero,
         // else the popularity-weighted population mean. Equivalent to the old
-        // per-group distinct()+foreach.
+        // per-group distinct()+foreach. Bulk-offer messages are excluded here.
         $weight = [];
         foreach (
             DB::select(
@@ -351,12 +470,58 @@ class StatsGenerationService
                 . '  LEFT JOIN items i ON i.id = mi.itemid '
                 . '  WHERE mo.timestamp >= ? AND mo.timestamp < ? '
                 . '    AND mo.outcome IN (?, ?)'
+                . '    AND NOT EXISTS (SELECT 1 FROM messages_bulk_items bxi WHERE bxi.msgid = mo.msgid)'
                 . ') sub '
                 . 'GROUP BY sub.groupid',
                 [$avg, $date, $next, Message::OUTCOME_TAKEN, Message::OUTCOME_RECEIVED]
             ) as $row
         ) {
             $weight[(int) $row->gid] = (int) $row->total_weight;
+        }
+
+        // WEIGHT bulk flip: catalogue items marked available=0 on $date, weighted by
+        // items.weight matched by name (not itemid), multiplied by remaining quantity.
+        foreach (
+            DB::select(
+                'SELECT mg.groupid AS gid, '
+                . '  ROUND(SUM(COALESCE(NULLIF(i.weight, 0), ?) * bi.quantity)) AS bulk_weight '
+                . 'FROM messages_bulk_items bi '
+                . 'INNER JOIN messages_groups mg ON mg.msgid = bi.msgid AND mg.rippled_in = 0 '
+                . 'LEFT JOIN items i ON i.name = bi.name '
+                . 'WHERE bi.available = 0 '
+                . '  AND bi.updated_at >= ? AND bi.updated_at < ? '
+                . 'GROUP BY mg.groupid',
+                [$avg, $date, $next]
+            ) as $row
+        ) {
+            $gid = (int) $row->gid;
+            $bw = (int) $row->bulk_weight;
+            if ($bw !== 0) {
+                $weight[$gid] = ($weight[$gid] ?? 0) + $bw;
+            }
+        }
+
+        // WEIGHT collected: in-app collections attributed on updated_at day, weighted by
+        // items.weight matched via the parent bulk item's name, times interest-row quantity.
+        foreach (
+            DB::select(
+                'SELECT mg.groupid AS gid, '
+                . '  ROUND(SUM(COALESCE(NULLIF(i.weight, 0), ?) * mbi.quantity)) AS coll_weight '
+                . 'FROM messages_bulk_items_interest mbi '
+                . 'INNER JOIN messages_bulk_items bi ON bi.id = mbi.bulkitemid '
+                . 'INNER JOIN messages_groups mg ON mg.msgid = mbi.msgid AND mg.rippled_in = 0 '
+                . 'LEFT JOIN items i ON i.name = bi.name '
+                . 'WHERE mbi.state = ? '
+                . '  AND mbi.updated_at >= ? AND mbi.updated_at < ? '
+                . 'GROUP BY mg.groupid',
+                [$avg, 'Collected', $date, $next]
+            ) as $row
+        ) {
+            $gid = (int) $row->gid;
+            $cw = (int) $row->coll_weight;
+            if ($cw !== 0) {
+                $weight[$gid] = ($weight[$gid] ?? 0) + $cw;
+            }
         }
 
         return [
@@ -506,7 +671,7 @@ class StatsGenerationService
             // one (msgid, eff_weight) tuple counts once, but a msgid linked
             // to multiple items with different weights contributes all of
             // them — same shape as the PHP `distinct()` + foreach the old
-            // path had.
+            // path had. Bulk-offer messages are excluded and handled below.
             $rows = DB::select(
                 'SELECT sub.groupid, ROUND(SUM(sub.eff_weight)) AS total_weight '
                 . 'FROM ('
@@ -518,27 +683,77 @@ class StatsGenerationService
                 . '  LEFT JOIN items i ON i.id = mi.itemid '
                 . '  WHERE mo.timestamp >= ? AND mo.timestamp < ? '
                 . '    AND mo.outcome IN (?, ?)'
+                . '    AND NOT EXISTS (SELECT 1 FROM messages_bulk_items bxi WHERE bxi.msgid = mo.msgid)'
                 . ') sub '
                 . 'GROUP BY sub.groupid',
                 [$avg, $date, $next, Message::OUTCOME_TAKEN, Message::OUTCOME_RECEIVED]
             );
 
+            // Merge non-bulk results into a groupid-keyed array.
+            $weightByGroup = [];
+            foreach ($rows as $row) {
+                $w = (int) $row->total_weight;
+                if ($w !== 0) {
+                    $weightByGroup[(int) $row->groupid] = $w;
+                }
+            }
+
+            // WEIGHT bulk flip arm: catalogue items marked available=0 on this date,
+            // weighted by items.weight matched by name, multiplied by remaining quantity.
+            foreach (
+                DB::select(
+                    'SELECT mg.groupid, '
+                    . '  ROUND(SUM(COALESCE(NULLIF(i.weight, 0), ?) * bi.quantity)) AS bulk_weight '
+                    . 'FROM messages_bulk_items bi '
+                    . 'INNER JOIN messages_groups mg ON mg.msgid = bi.msgid AND mg.rippled_in = 0 '
+                    . 'LEFT JOIN items i ON i.name = bi.name '
+                    . 'WHERE bi.available = 0 '
+                    . '  AND bi.updated_at >= ? AND bi.updated_at < ? '
+                    . 'GROUP BY mg.groupid',
+                    [$avg, $date, $next]
+                ) as $bulkRow
+            ) {
+                $gid = (int) $bulkRow->groupid;
+                $bw = (int) $bulkRow->bulk_weight;
+                if ($bw !== 0) {
+                    $weightByGroup[$gid] = ($weightByGroup[$gid] ?? 0) + $bw;
+                }
+            }
+
+            // WEIGHT collected arm: in-app collections attributed on updated_at day.
+            foreach (
+                DB::select(
+                    'SELECT mg.groupid, '
+                    . '  ROUND(SUM(COALESCE(NULLIF(i.weight, 0), ?) * mbi.quantity)) AS coll_weight '
+                    . 'FROM messages_bulk_items_interest mbi '
+                    . 'INNER JOIN messages_bulk_items bi ON bi.id = mbi.bulkitemid '
+                    . 'INNER JOIN messages_groups mg ON mg.msgid = mbi.msgid AND mg.rippled_in = 0 '
+                    . 'LEFT JOIN items i ON i.name = bi.name '
+                    . 'WHERE mbi.state = ? '
+                    . '  AND mbi.updated_at >= ? AND mbi.updated_at < ? '
+                    . 'GROUP BY mg.groupid',
+                    [$avg, 'Collected', $date, $next]
+                ) as $collRow
+            ) {
+                $gid = (int) $collRow->groupid;
+                $cw = (int) $collRow->coll_weight;
+                if ($cw !== 0) {
+                    $weightByGroup[$gid] = ($weightByGroup[$gid] ?? 0) + $cw;
+                }
+            }
+
             $datesProcessed++;
 
             if ($dryRun) {
-                $rowsWritten += count(array_filter($rows, fn ($r) => (int) $r->total_weight !== 0));
+                $rowsWritten += count($weightByGroup);
                 continue;
             }
 
             $placeholders = [];
             $values = [];
-            foreach ($rows as $row) {
-                $w = (int) $row->total_weight;
-                if ($w === 0) {
-                    continue;
-                }
+            foreach ($weightByGroup as $gid => $w) {
                 $placeholders[] = '(?, ?, ?, ?)';
-                array_push($values, $date, (int) $row->groupid, self::TYPE_WEIGHT, $w);
+                array_push($values, $date, $gid, self::TYPE_WEIGHT, $w);
             }
 
             if (!empty($placeholders)) {

--- a/iznik-batch/tests/Unit/Services/StatsGenerationServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/StatsGenerationServiceTest.php
@@ -505,4 +505,120 @@ class StatsGenerationServiceTest extends TestCase
 
         $this->assertBreakdown($groupB->id, StatsGenerationService::TYPE_POST_METHOD_BREAKDOWN, []);
     }
+
+    // ── Bulk-offer per-item counting ──────────────────────────────────────────
+    //
+    // A "bulk offer" message has rows in messages_bulk_items. Each stat type must
+    // count by item quantity rather than by message count:
+    //
+    //   ApprovedMessageCount — SUM(quantity) over all bulk items (not 1 per message)
+    //   Outcomes             — SUM(quantity) for items flipped available=0 on $date
+    //   Weight               — SUM(weight * quantity) matched by items.name
+    //   Replies              — interest rows + free-text Interested with no interest row
+    //
+    // A normal (non-bulk) control message must be unaffected.
+
+    public function test_bulk_offer_per_item_counting(): void
+    {
+        $group = $this->createTestGroup();
+        $owner = $this->createTestUser();
+        $replier1 = $this->createTestUser();
+        $freeTextReplier = $this->createTestUser();
+
+        // ── Control: one normal message with one Interested reply ──────────────
+        $control = $this->createTestMessage($owner, $group, ['arrival' => $this->date.' 08:00:00']);
+        $controlRoom = $this->createTestChatRoom($owner, $replier1);
+        $this->createTestChatMessage($controlRoom, $replier1, [
+            'type' => ChatMessage::TYPE_INTERESTED,
+            'refmsgid' => $control->id,
+            'date' => $this->date.' 08:30:00',
+        ]);
+
+        // ── Bulk offer message: availableinitially=6 (item1 qty=3 + item2 qty=3). ──────
+        // 1 unit of item1 was collected in-app (quantity decremented to 2), then
+        // the offerer flipped the remainder to available=0 on $date. Item2 is still
+        // available.
+        $bulk = $this->createTestMessage($owner, $group, [
+            'arrival' => $this->date.' 10:00:00',
+            'availableinitially' => 6,
+        ]);
+
+        // Item 1 (qty=2 remaining after 1 collected): flipped available=0 on $date;
+        // matched by name in the items table with weight=10.
+        $item1Name = 'BulkItemA_'.uniqid();
+        $item1Id = DB::table('messages_bulk_items')->insertGetId([
+            'msgid' => $bulk->id,
+            'name' => $item1Name,
+            'quantity' => 2,
+            'available' => 0,
+            'updated_at' => $this->date.' 11:00:00',
+            'created_at' => $this->date.' 09:00:00',
+        ]);
+
+        // Item 2 (qty=3): still available; no items-table row.
+        $item2Id = DB::table('messages_bulk_items')->insertGetId([
+            'msgid' => $bulk->id,
+            'name' => 'BulkItemB_'.uniqid(),
+            'quantity' => 3,
+            'available' => 1,
+            'updated_at' => $this->date.' 09:00:00',
+            'created_at' => $this->date.' 09:00:00',
+        ]);
+
+        // Items-table row for item1 with known weight=10.
+        DB::table('items')->insert(['name' => $item1Name, 'weight' => 10.0, 'popularity' => 1.0]);
+
+        // ── Collected interest row for item1: 1 unit collected in-app on $date ──
+        // state=Collected, updated_at in day, qty=1 (the 1 unit that was collected).
+        // created_at in day so it also counts in the Replies part-1 arm.
+        DB::table('messages_bulk_items_interest')->insert([
+            'bulkitemid' => $item1Id,
+            'msgid' => $bulk->id,
+            'userid' => $replier1->id,
+            'quantity' => 1,
+            'state' => 'Collected',
+            'created_at' => $this->date.' 10:30:00',
+            'updated_at' => $this->date.' 10:30:00',
+        ]);
+
+        // ── Structured interest for item2 (Interested, not yet collected) ────
+        DB::table('messages_bulk_items_interest')->insert([
+            'bulkitemid' => $item2Id,
+            'msgid' => $bulk->id,
+            'userid' => $replier1->id,
+            'quantity' => 1,
+            'state' => 'Interested',
+            'created_at' => $this->date.' 10:30:00',
+            'updated_at' => $this->date.' 10:30:00',
+        ]);
+
+        // ── Free-text reply: freeTextReplier sends an Interested chat message
+        //    but has no interest row for the bulk message ──────────────────────
+        $bulkRoom = $this->createTestChatRoom($owner, $freeTextReplier);
+        $this->createTestChatMessage($bulkRoom, $freeTextReplier, [
+            'type' => ChatMessage::TYPE_INTERESTED,
+            'refmsgid' => $bulk->id,
+            'date' => $this->date.' 10:45:00',
+        ]);
+
+        $this->service->generate($group->id, $this->date);
+
+        // ApprovedMessageCount uses availableinitially (not current quantity):
+        //   base = 2 (control + bulk message), top-up = availableinitially(6) - 1 = 5
+        //   total = 2 + 5 = 7.
+        $this->assertStat($group->id, StatsGenerationService::TYPE_APPROVED_MESSAGE_COUNT, 7);
+
+        // Outcomes = 2 (flip arm: item1 qty=2 remaining) + 1 (collected arm: interest qty=1) = 3.
+        $this->assertStat($group->id, StatsGenerationService::TYPE_OUTCOMES, 3);
+
+        // Weight = 10*2 (flip arm) + 10*1 (collected arm) = 30.
+        $this->assertStat($group->id, StatsGenerationService::TYPE_WEIGHT, 30);
+
+        // Replies = 1 (control) + 2 (interest rows: item1 Collected + item2 Interested,
+        //   both counted by created_at) + 1 (free-text bulk) = 4.
+        $this->assertStat($group->id, StatsGenerationService::TYPE_REPLIES, 4);
+
+        // Activity = approvedMessages + replies = 7 + 4 = 11.
+        $this->assertStat($group->id, StatsGenerationService::TYPE_ACTIVITY, 11);
+    }
 }

--- a/iznik-server-go/authority/stats.go
+++ b/iznik-server-go/authority/stats.go
@@ -33,55 +33,70 @@ type PostcodeStats struct {
 // GetStatsByAuthority retrieves statistics for an authority area.
 // Returns a map of partial postcodes to their stats.
 func GetStatsByAuthority(authorityID uint64, start, end string) (map[string]PostcodeStats, error) {
-	// Every statement here must run on the WRITE host. The temporary table `pc`
-	// is connection-local, so the SELECTs that read it must hit the same server
-	// that created it. Under the read/write split a plain SELECT would otherwise
-	// be routed to the read replica, where `pc` does not exist. writer() returns
-	// a fresh handle pinned to the source; .Clauses(dbresolver.Write) is a no-op
-	// when no replica is configured. A new handle per call is required because a
-	// .Clauses() result is not safe to reuse across multiple queries.
-	writer := func() *gorm.DB { return database.DBConn.Clauses(dbresolver.Write) }
+	// Every statement here must run on the WRITE host (under the read/write
+	// split a plain SELECT would otherwise route to the read replica, where the
+	// temp table does not exist). .Clauses(dbresolver.Write) is a no-op when no
+	// replica is configured.
+	ret := make(map[string]PostcodeStats)
 
-	// Parse dates, defaulting to last 365 days.
-	startTime, err := parseRelativeDate(start)
-	if err != nil {
-		startTime = time.Now().AddDate(-1, 0, 0)
+	// Temporary tables are CONNECTION-local, but DBConn is a pool: without
+	// pinning, the CREATE TEMPORARY TABLE and the SELECTs that read `pc` can
+	// land on different pooled connections. A transaction is the pin that
+	// dbresolver respects: Begin() on the Write clause fixes ONE connection on
+	// the source pool and every statement inside stays on it (gorm.Connection()
+	// does NOT give that guarantee under dbresolver - its per-statement routing
+	// acquires fresh pool connections, which both defeats the pin and can
+	// deadlock a capped pool). Read-only + temp table, so Rollback suffices.
+	txh := database.DBConn.Clauses(dbresolver.Write).Begin()
+	if txh.Error != nil {
+		return nil, txh.Error
 	}
-	endTime, err := parseRelativeDate(end)
-	if err != nil {
-		endTime = time.Now()
-	}
+	defer txh.Rollback()
 
-	startStr := startTime.Format("2006-01-02")
-	endStr := endTime.Format("2006-01-02 23:59:59")
+	connErr := func(tx *gorm.DB) error {
+		writer := func() *gorm.DB { return tx }
 
-	// Create temporary table of locationids for postcodes within the authority.
-	// Use a temporary table of postcode locationids within the authority.
-	err = writer().Exec(`DROP TEMPORARY TABLE IF EXISTS pc`).Error
-	if err != nil {
-		return nil, err
-	}
+		// Parse dates, defaulting to last 365 days.
+		startTime, err := parseRelativeDate(start)
+		if err != nil {
+			startTime = time.Now().AddDate(-1, 0, 0)
+		}
+		endTime, err := parseRelativeDate(end)
+		if err != nil {
+			endTime = time.Now()
+		}
 
-	err = writer().Exec(`CREATE TEMPORARY TABLE pc AS (
+		startStr := startTime.Format("2006-01-02")
+		// NB "23:59:59" cannot live inside the Format layout - Go treats those
+		// digits as reference-time directives and renders garbage (e.g.
+		// "78:369:369"), which MySQL cannot parse, so every BETWEEN silently
+		// matched nothing and this endpoint always returned empty.
+		endStr := endTime.Format("2006-01-02") + " 23:59:59"
+
+		// Create temporary table of locationids for postcodes within the authority.
+		// Use a temporary table of postcode locationids within the authority.
+		if err := writer().Exec(`DROP TEMPORARY TABLE IF EXISTS pc`).Error; err != nil {
+			return err
+		}
+
+		err = writer().Exec(`CREATE TEMPORARY TABLE pc AS (
 		SELECT locationid
 		FROM authorities
 		INNER JOIN locations_spatial ON authorities.id = ?
 			AND ST_Contains(authorities.polygon, locations_spatial.geometry)
 	)`, authorityID).Error
-	if err != nil {
-		return nil, err
-	}
-
-	ret := make(map[string]PostcodeStats)
-
-	// Query offers and wanteds.
-	for _, msgType := range []string{TypeOffer, TypeWanted} {
-		var stats []struct {
-			PartialPostcode string `gorm:"column:PartialPostcode"`
-			Count           int    `gorm:"column:count"`
+		if err != nil {
+			return err
 		}
 
-		writer().Raw(`
+		// Query offers and wanteds.
+		for _, msgType := range []string{TypeOffer, TypeWanted} {
+			var stats []struct {
+				PartialPostcode string `gorm:"column:PartialPostcode"`
+				Count           int    `gorm:"column:count"`
+			}
+
+			if err := writer().Raw(`
 			SELECT SUBSTRING(locations.name, 1, LENGTH(locations.name) - 2) AS PartialPostcode,
 				   COUNT(*) as count
 			FROM pc
@@ -92,27 +107,30 @@ func GetStatsByAuthority(authorityID uint64, start, end string) (map[string]Post
 				AND messages.type = ?
 				AND messages.arrival BETWEEN ? AND ?
 			GROUP BY PartialPostcode
-			ORDER BY locations.name`, utils.LOCATION_TYPE_POSTCODE, msgType, startStr, endStr).Scan(&stats)
-
-		for _, stat := range stats {
-			ps := ret[stat.PartialPostcode]
-			if msgType == TypeOffer {
-				ps.Offer += stat.Count
-			} else {
-				ps.Wanted += stat.Count
+			ORDER BY locations.name`, utils.LOCATION_TYPE_POSTCODE, msgType, startStr, endStr).Scan(&stats).Error; err != nil {
+				return err
 			}
-			ret[stat.PartialPostcode] = ps
-		}
-	}
 
-	// Query replies (Interested chat messages).
-	for _, msgType := range []string{TypeOffer, TypeWanted} {
-		var stats []struct {
-			PartialPostcode string `gorm:"column:PartialPostcode"`
-			Count           int    `gorm:"column:count"`
+			for _, stat := range stats {
+				ps := ret[stat.PartialPostcode]
+				if msgType == TypeOffer {
+					ps.Offer += stat.Count
+				} else {
+					ps.Wanted += stat.Count
+				}
+				ret[stat.PartialPostcode] = ps
+			}
 		}
 
-		writer().Raw(`
+		// Query replies (Interested chat messages) for non-bulk messages.
+		// Bulk messages are excluded here; their replies are counted separately below.
+		for _, msgType := range []string{TypeOffer, TypeWanted} {
+			var stats []struct {
+				PartialPostcode string `gorm:"column:PartialPostcode"`
+				Count           int    `gorm:"column:count"`
+			}
+
+			if err := writer().Raw(`
 			SELECT SUBSTRING(locations.name, 1, LENGTH(locations.name) - 2) AS PartialPostcode,
 				   COUNT(*) as count
 			FROM pc
@@ -123,23 +141,93 @@ func GetStatsByAuthority(authorityID uint64, start, end string) (map[string]Post
 				AND LOCATE(' ', locations.name) > 0
 				AND messages.type = ?
 				AND messages.arrival BETWEEN ? AND ?
+				AND NOT EXISTS (SELECT 1 FROM messages_bulk_items bi WHERE bi.msgid = messages.id)
 			GROUP BY PartialPostcode
-			ORDER BY locations.name`, utils.LOCATION_TYPE_POSTCODE, utils.CHAT_MESSAGE_INTERESTED, msgType, startStr, endStr).Scan(&stats)
+			ORDER BY locations.name`, utils.CHAT_MESSAGE_INTERESTED, utils.LOCATION_TYPE_POSTCODE, msgType, startStr, endStr).Scan(&stats).Error; err != nil {
+				return err
+			}
 
-		for _, stat := range stats {
-			ps := ret[stat.PartialPostcode]
-			ps.Replies += stat.Count
-			ret[stat.PartialPostcode] = ps
+			for _, stat := range stats {
+				ps := ret[stat.PartialPostcode]
+				ps.Replies += stat.Count
+				ret[stat.PartialPostcode] = ps
+			}
 		}
-	}
 
-	// Query outcomes (Taken/Received).
-	var outcomeStats []struct {
-		PartialPostcode string `gorm:"column:PartialPostcode"`
-		Count           int    `gorm:"column:count"`
-	}
+		// Query replies for bulk messages: structured interest rows.
+		for _, msgType := range []string{TypeOffer, TypeWanted} {
+			var stats []struct {
+				PartialPostcode string `gorm:"column:PartialPostcode"`
+				Count           int    `gorm:"column:count"`
+			}
 
-	writer().Raw(`
+			if err := writer().Raw(`
+			SELECT SUBSTRING(locations.name, 1, LENGTH(locations.name) - 2) AS PartialPostcode,
+				   COUNT(*) as count
+			FROM pc
+			INNER JOIN messages ON messages.locationid = pc.locationid
+			INNER JOIN locations ON messages.locationid = locations.id
+			INNER JOIN messages_bulk_items_interest mbi ON mbi.msgid = messages.id
+			WHERE locations.type = ?
+				AND LOCATE(' ', locations.name) > 0
+				AND messages.type = ?
+				AND messages.arrival BETWEEN ? AND ?
+			GROUP BY PartialPostcode
+			ORDER BY locations.name`, utils.LOCATION_TYPE_POSTCODE, msgType, startStr, endStr).Scan(&stats).Error; err != nil {
+				return err
+			}
+
+			for _, stat := range stats {
+				ps := ret[stat.PartialPostcode]
+				ps.Replies += stat.Count
+				ret[stat.PartialPostcode] = ps
+			}
+		}
+
+		// Query replies for bulk messages: Interested chat messages where no structured
+		// interest row exists for that user (free-text replies not via the interest flow).
+		for _, msgType := range []string{TypeOffer, TypeWanted} {
+			var stats []struct {
+				PartialPostcode string `gorm:"column:PartialPostcode"`
+				Count           int    `gorm:"column:count"`
+			}
+
+			if err := writer().Raw(`
+			SELECT SUBSTRING(locations.name, 1, LENGTH(locations.name) - 2) AS PartialPostcode,
+				   COUNT(*) as count
+			FROM pc
+			INNER JOIN messages ON messages.locationid = pc.locationid
+			INNER JOIN locations ON messages.locationid = locations.id
+			INNER JOIN chat_messages cm ON messages.id = cm.refmsgid AND cm.type = ?
+			WHERE locations.type = ?
+				AND LOCATE(' ', locations.name) > 0
+				AND messages.type = ?
+				AND messages.arrival BETWEEN ? AND ?
+				AND EXISTS (SELECT 1 FROM messages_bulk_items bi WHERE bi.msgid = messages.id)
+				AND NOT EXISTS (
+					SELECT 1 FROM messages_bulk_items_interest
+					WHERE msgid = messages.id AND userid = cm.userid
+				)
+			GROUP BY PartialPostcode
+			ORDER BY locations.name`, utils.CHAT_MESSAGE_INTERESTED, utils.LOCATION_TYPE_POSTCODE, msgType, startStr, endStr).Scan(&stats).Error; err != nil {
+				return err
+			}
+
+			for _, stat := range stats {
+				ps := ret[stat.PartialPostcode]
+				ps.Replies += stat.Count
+				ret[stat.PartialPostcode] = ps
+			}
+		}
+
+		// Query outcomes (Taken/Received) for non-bulk messages.
+		// Bulk messages are excluded here; their per-item outcomes are counted separately below.
+		var outcomeStats []struct {
+			PartialPostcode string `gorm:"column:PartialPostcode"`
+			Count           int    `gorm:"column:count"`
+		}
+
+		if err := writer().Raw(`
 		SELECT SUBSTRING(locations.name, 1, LENGTH(locations.name) - 2) AS PartialPostcode,
 			   COUNT(*) AS count
 		FROM pc
@@ -150,34 +238,100 @@ func GetStatsByAuthority(authorityID uint64, start, end string) (map[string]Post
 			AND LOCATE(' ', locations.name) > 0
 			AND messages.arrival BETWEEN ? AND ?
 			AND outcome IN (?, ?)
+			AND NOT EXISTS (SELECT 1 FROM messages_bulk_items WHERE msgid = messages.id)
 		GROUP BY PartialPostcode
-		ORDER BY locations.name`, utils.LOCATION_TYPE_POSTCODE, startStr, endStr, utils.OUTCOME_TAKEN, utils.OUTCOME_RECEIVED).Scan(&outcomeStats)
+		ORDER BY locations.name`, utils.LOCATION_TYPE_POSTCODE, startStr, endStr, utils.OUTCOME_TAKEN, utils.OUTCOME_RECEIVED).Scan(&outcomeStats).Error; err != nil {
+			return err
+		}
 
-	for _, stat := range outcomeStats {
-		ps := ret[stat.PartialPostcode]
-		ps.Outcomes += stat.Count
-		ret[stat.PartialPostcode] = ps
-	}
+		for _, stat := range outcomeStats {
+			ps := ret[stat.PartialPostcode]
+			ps.Outcomes += stat.Count
+			ret[stat.PartialPostcode] = ps
+		}
 
-	// Query weights.
-	// First get the average weight.
-	var avgResult struct {
-		Average *float64 `gorm:"column:average"`
-	}
-	writer().Raw(`SELECT SUM(popularity * weight) / SUM(popularity) AS average
-		FROM items WHERE weight IS NOT NULL AND weight != 0`).Scan(&avgResult)
+		// Query outcomes for bulk messages: SUM(bi.quantity) for items marked taken
+		// (available=0), one item at a time rather than one per message.
+		var bulkOutcomeStats []struct {
+			PartialPostcode string `gorm:"column:PartialPostcode"`
+			Count           int    `gorm:"column:count"`
+		}
 
-	avg := float64(0)
-	if avgResult.Average != nil {
-		avg = *avgResult.Average
-	}
+		if err := writer().Raw(`
+		SELECT SUBSTRING(locations.name, 1, LENGTH(locations.name) - 2) AS PartialPostcode,
+			   CAST(SUM(bi.quantity) AS SIGNED) AS count
+		FROM pc
+		INNER JOIN messages ON messages.locationid = pc.locationid
+		INNER JOIN messages_bulk_items bi ON bi.msgid = messages.id AND bi.available = 0
+		INNER JOIN locations ON messages.locationid = locations.id
+		WHERE locations.type = ?
+			AND LOCATE(' ', locations.name) > 0
+			AND messages.arrival BETWEEN ? AND ?
+		GROUP BY PartialPostcode
+		ORDER BY locations.name`, utils.LOCATION_TYPE_POSTCODE, startStr, endStr).Scan(&bulkOutcomeStats).Error; err != nil {
+			return err
+		}
 
-	var weightStats []struct {
-		PartialPostcode string  `gorm:"column:PartialPostcode"`
-		Weight          float64 `gorm:"column:weight"`
-	}
+		for _, stat := range bulkOutcomeStats {
+			ps := ret[stat.PartialPostcode]
+			ps.Outcomes += stat.Count
+			ret[stat.PartialPostcode] = ps
+		}
 
-	writer().Raw(fmt.Sprintf(`
+		// Query outcomes for bulk messages collected in-app: interest rows with
+		// state='Collected'. In-app collection deducts from bi.quantity before the
+		// owner may flip available=0, so the available=0 arm only counts what remained
+		// at the flip; this arm counts what was collected via the interest flow.
+		// Together the two arms sum to the true total with no overlap.
+		var bulkInterestOutcomeStats []struct {
+			PartialPostcode string `gorm:"column:PartialPostcode"`
+			Count           int    `gorm:"column:count"`
+		}
+
+		if err := writer().Raw(`
+		SELECT SUBSTRING(locations.name, 1, LENGTH(locations.name) - 2) AS PartialPostcode,
+			   CAST(SUM(mbii.quantity) AS SIGNED) AS count
+		FROM pc
+		INNER JOIN messages ON messages.locationid = pc.locationid
+		INNER JOIN messages_bulk_items_interest mbii ON mbii.msgid = messages.id AND mbii.state = 'Collected'
+		INNER JOIN locations ON messages.locationid = locations.id
+		WHERE locations.type = ?
+			AND LOCATE(' ', locations.name) > 0
+			AND messages.arrival BETWEEN ? AND ?
+		GROUP BY PartialPostcode
+		ORDER BY locations.name`, utils.LOCATION_TYPE_POSTCODE, startStr, endStr).Scan(&bulkInterestOutcomeStats).Error; err != nil {
+			return err
+		}
+
+		for _, stat := range bulkInterestOutcomeStats {
+			ps := ret[stat.PartialPostcode]
+			ps.Outcomes += stat.Count
+			ret[stat.PartialPostcode] = ps
+		}
+
+		// Query weights.
+		// First get the average weight.
+		var avgResult struct {
+			Average *float64 `gorm:"column:average"`
+		}
+		if err := writer().Raw(`SELECT SUM(popularity * weight) / SUM(popularity) AS average
+		FROM items WHERE weight IS NOT NULL AND weight != 0`).Scan(&avgResult).Error; err != nil {
+			return err
+		}
+
+		avg := float64(0)
+		if avgResult.Average != nil {
+			avg = *avgResult.Average
+		}
+
+		// Weight for non-bulk messages: existing per-message-item join.
+		// Bulk messages are excluded here; their per-item weight is counted separately below.
+		var weightStats []struct {
+			PartialPostcode string  `gorm:"column:PartialPostcode"`
+			Weight          float64 `gorm:"column:weight"`
+		}
+
+		if err := writer().Raw(fmt.Sprintf(`
 		SELECT SUBSTRING(locations.name, 1, LENGTH(locations.name) - 2) AS PartialPostcode,
 			   SUM(COALESCE(weight, %f)) AS weight
 		FROM pc
@@ -190,22 +344,85 @@ func GetStatsByAuthority(authorityID uint64, start, end string) (map[string]Post
 			AND LOCATE(' ', locations.name) > 0
 			AND messages.arrival BETWEEN ? AND ?
 			AND outcome IN (?, ?)
+			AND NOT EXISTS (SELECT 1 FROM messages_bulk_items WHERE msgid = messages.id)
 		GROUP BY PartialPostcode
-		ORDER BY locations.name`, avg), utils.LOCATION_TYPE_POSTCODE, startStr, endStr, utils.OUTCOME_TAKEN, utils.OUTCOME_RECEIVED).Scan(&weightStats)
+		ORDER BY locations.name`, avg), utils.LOCATION_TYPE_POSTCODE, startStr, endStr, utils.OUTCOME_TAKEN, utils.OUTCOME_RECEIVED).Scan(&weightStats).Error; err != nil {
+			return err
+		}
 
-	for _, stat := range weightStats {
-		ps := ret[stat.PartialPostcode]
-		ps.Weight += stat.Weight
-		ret[stat.PartialPostcode] = ps
-	}
+		for _, stat := range weightStats {
+			ps := ret[stat.PartialPostcode]
+			ps.Weight += stat.Weight
+			ret[stat.PartialPostcode] = ps
+		}
 
-	// Query searches.
-	var searchStats []struct {
-		PartialPostcode string `gorm:"column:PartialPostcode"`
-		Count           int    `gorm:"column:count"`
-	}
+		// Weight for bulk messages: per item weight × quantity for items marked taken
+		// (available=0). Matches by item name to the items catalogue; falls back to the
+		// global average weight when there is no name match or the matched weight is 0.
+		var bulkWeightStats []struct {
+			PartialPostcode string  `gorm:"column:PartialPostcode"`
+			Weight          float64 `gorm:"column:weight"`
+		}
 
-	writer().Raw(`
+		if err := writer().Raw(fmt.Sprintf(`
+		SELECT SUBSTRING(locations.name, 1, LENGTH(locations.name) - 2) AS PartialPostcode,
+			   SUM(COALESCE(NULLIF(i.weight, 0), %f) * bi.quantity) AS weight
+		FROM pc
+		INNER JOIN messages ON messages.locationid = pc.locationid
+		INNER JOIN messages_bulk_items bi ON bi.msgid = messages.id AND bi.available = 0
+		LEFT JOIN items i ON i.name = bi.name
+		INNER JOIN locations ON messages.locationid = locations.id
+		WHERE locations.type = ?
+			AND LOCATE(' ', locations.name) > 0
+			AND messages.arrival BETWEEN ? AND ?
+		GROUP BY PartialPostcode
+		ORDER BY locations.name`, avg), utils.LOCATION_TYPE_POSTCODE, startStr, endStr).Scan(&bulkWeightStats).Error; err != nil {
+			return err
+		}
+
+		for _, stat := range bulkWeightStats {
+			ps := ret[stat.PartialPostcode]
+			ps.Weight += stat.Weight
+			ret[stat.PartialPostcode] = ps
+		}
+
+		// Weight for bulk messages collected in-app: mirrors the interest-Collected
+		// outcomes arm above. Uses the same items-table name match and average fallback.
+		var bulkInterestWeightStats []struct {
+			PartialPostcode string  `gorm:"column:PartialPostcode"`
+			Weight          float64 `gorm:"column:weight"`
+		}
+
+		if err := writer().Raw(fmt.Sprintf(`
+		SELECT SUBSTRING(locations.name, 1, LENGTH(locations.name) - 2) AS PartialPostcode,
+			   SUM(COALESCE(NULLIF(i.weight, 0), %f) * mbii.quantity) AS weight
+		FROM pc
+		INNER JOIN messages ON messages.locationid = pc.locationid
+		INNER JOIN messages_bulk_items_interest mbii ON mbii.msgid = messages.id AND mbii.state = 'Collected'
+		INNER JOIN messages_bulk_items bi ON bi.id = mbii.bulkitemid
+		LEFT JOIN items i ON i.name = bi.name
+		INNER JOIN locations ON messages.locationid = locations.id
+		WHERE locations.type = ?
+			AND LOCATE(' ', locations.name) > 0
+			AND messages.arrival BETWEEN ? AND ?
+		GROUP BY PartialPostcode
+		ORDER BY locations.name`, avg), utils.LOCATION_TYPE_POSTCODE, startStr, endStr).Scan(&bulkInterestWeightStats).Error; err != nil {
+			return err
+		}
+
+		for _, stat := range bulkInterestWeightStats {
+			ps := ret[stat.PartialPostcode]
+			ps.Weight += stat.Weight
+			ret[stat.PartialPostcode] = ps
+		}
+
+		// Query searches.
+		var searchStats []struct {
+			PartialPostcode string `gorm:"column:PartialPostcode"`
+			Count           int    `gorm:"column:count"`
+		}
+
+		if err := writer().Raw(`
 		SELECT SUBSTRING(locations.name, 1, LENGTH(locations.name) - 2) AS PartialPostcode,
 			   COUNT(*) AS count
 		FROM pc
@@ -215,18 +432,23 @@ func GetStatsByAuthority(authorityID uint64, start, end string) (map[string]Post
 			AND LOCATE(' ', locations.name) > 0
 			AND search_history.date BETWEEN ? AND ?
 		GROUP BY PartialPostcode
-		ORDER BY locations.name`, utils.LOCATION_TYPE_POSTCODE, startStr, endStr).Scan(&searchStats)
+		ORDER BY locations.name`, utils.LOCATION_TYPE_POSTCODE, startStr, endStr).Scan(&searchStats).Error; err != nil {
+			return err
+		}
 
-	for _, stat := range searchStats {
-		ps := ret[stat.PartialPostcode]
-		ps.Searches += stat.Count
-		ret[stat.PartialPostcode] = ps
-	}
+		for _, stat := range searchStats {
+			ps := ret[stat.PartialPostcode]
+			ps.Searches += stat.Count
+			ret[stat.PartialPostcode] = ps
+		}
 
-	// Clean up temporary table.
-	writer().Exec(`DROP TEMPORARY TABLE IF EXISTS pc`)
+		// Clean up temporary table.
+		writer().Exec(`DROP TEMPORARY TABLE IF EXISTS pc`)
 
-	return ret, nil
+		return nil
+	}(txh)
+
+	return ret, connErr
 }
 
 // parseRelativeDate parses dates like "365 days ago", "30 days ago", "today".

--- a/iznik-server-go/message/bulkEdit.go
+++ b/iznik-server-go/message/bulkEdit.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/freegle/iznik-server-go/database"
 	"github.com/freegle/iznik-server-go/misc"
+	"github.com/freegle/iznik-server-go/utils"
 	"github.com/gofiber/fiber/v2"
 	"gorm.io/gorm"
 )
@@ -165,6 +166,25 @@ func recomputeBulkAvailableNow(db *gorm.DB, msgid uint64) {
 		"WHERE id = ?", msgid, msgid)
 }
 
+// recordBulkOutcomeIfComplete inserts a Taken outcome row for a bulk offer once
+// its availablenow reaches zero, making the completed offer visible to every
+// legacy stats pipeline (heatmap, happiness, V1 readers). Called after either
+// recompute path. Idempotent: a second call when a Taken or Received row already
+// exists is a no-op.
+func recordBulkOutcomeIfComplete(db *gorm.DB, msgid uint64) {
+	var availablenow int
+	db.Raw("SELECT availablenow FROM messages WHERE id = ?", msgid).Scan(&availablenow)
+	if availablenow > 0 {
+		return
+	}
+	db.Exec(
+		"INSERT INTO messages_outcomes (msgid, outcome) "+
+			"SELECT ?, ? WHERE NOT EXISTS "+
+			"(SELECT 1 FROM messages_outcomes WHERE msgid = ? AND outcome IN (?, ?))",
+		msgid, utils.OUTCOME_TAKEN,
+		msgid, utils.OUTCOME_TAKEN, utils.OUTCOME_RECEIVED)
+}
+
 // GetBulkEditOffer returns a bulk offer's catalogue for the logged-out owner
 // page, authorised solely by the secret token in the path. No JWT, no PII.
 //
@@ -255,6 +275,7 @@ func PostBulkEditOffer(c *fiber.Ctx) error {
 	}
 
 	recomputeBulkAvailableNow(db, msgid)
+	recordBulkOutcomeIfComplete(db, msgid)
 
 	items := bulkEditItems(db, msgid)
 	return c.JSON(fiber.Map{

--- a/iznik-server-go/message/bulkItem.go
+++ b/iznik-server-go/message/bulkItem.go
@@ -20,11 +20,11 @@ import (
 // A message is a bulk offer when it has rows in messages_bulk_items; the message
 // itself stays a normal Offer. See plans/active/bulk-offer-clearance-design.md.
 type BulkItem struct {
-	ID          uint64  `json:"id" gorm:"primary_key"`
-	Msgid       uint64  `json:"-"`
-	Position    uint    `json:"position"`
-	Name        string  `json:"name"`
-	Quantity    uint    `json:"quantity"`
+	ID       uint64 `json:"id" gorm:"primary_key"`
+	Msgid    uint64 `json:"-"`
+	Position uint   `json:"position"`
+	Name     string `json:"name"`
+	Quantity uint   `json:"quantity"`
 	// Available is the owner's per-item on-offer flag: false once they mark the
 	// item taken/gone (here or via the logged-out secret-link update page).
 	Available   bool    `json:"available"`
@@ -328,11 +328,13 @@ func handleBulkInterestState(c *fiber.Ctx, myid uint64, req PostMessageRequest) 
 		sendAccessInstructions(db, msgid, fromuser, *req.Userid)
 	}
 
-	// Collected: record who collected the item (messages_by) and reduce the
-	// post's available count. This is the per-item equivalent of the messages_by
-	// insert in handleOutcome for a single-item post. ON DUPLICATE KEY UPDATE
-	// accumulates quantities when one collector takes several items from the same
-	// bulk post, so their profile "collected" count stays accurate.
+	// Collected: record who collected the item (messages_by) and update the
+	// post's available count via a full recompute. Using recomputeBulkAvailableNow
+	// instead of a raw decrement prevents a double-deduction when the external-owner
+	// toggle (PostBulkEditOffer) has already marked this item available=0 and
+	// recomputed: a second recompute from the same source table is a no-op rather
+	// than a further subtraction. Reducing the item's quantity first ensures the
+	// recompute reflects the collected units.
 	if *req.State == "Collected" && priorState != "Collected" {
 		var qty int
 		db.Raw("SELECT COALESCE(quantity, 1) FROM messages_bulk_items_interest WHERE bulkitemid = ? AND userid = ?",
@@ -342,7 +344,12 @@ func handleBulkInterestState(c *fiber.Ctx, myid uint64, req PostMessageRequest) 
 		}
 		db.Exec("INSERT INTO messages_by (msgid, userid, count) VALUES (?, ?, ?) "+
 			"ON DUPLICATE KEY UPDATE count = count + VALUES(count)", msgid, *req.Userid, qty)
-		db.Exec("UPDATE messages SET availablenow = GREATEST(0, availablenow - ?) WHERE id = ?", qty, msgid)
+		db.Exec("UPDATE messages_bulk_items SET quantity = GREATEST(0, quantity - ?) WHERE id = ?", qty, *req.Bulkitemid)
+		// If collecting cleared the remaining stock, mark the line unavailable so
+		// the external-owner page reflects it and updated_at bumps for flip-day arms.
+		db.Exec("UPDATE messages_bulk_items SET available = 0 WHERE id = ? AND quantity = 0", *req.Bulkitemid)
+		recomputeBulkAvailableNow(db, msgid)
+		recordBulkOutcomeIfComplete(db, msgid)
 	}
 
 	return c.JSON(fiber.Map{"ret": 0, "status": "Success"})

--- a/iznik-server-go/test/bulk_offer_stats_test.go
+++ b/iznik-server-go/test/bulk_offer_stats_test.go
@@ -1,0 +1,275 @@
+package test
+
+// Tests for bulk-offer lifecycle integration and per-item authority statistics.
+// These tests cover three additions that were absent from the existing suite:
+//
+//  (a) Collected path uses recomputeBulkAvailableNow - no double-deduction when
+//      the external-owner toggle has already fired for the same item.
+//  (b) The last item collected (or toggled taken) inserts exactly one
+//      messages_outcomes Taken row for the message, and a second trigger is a no-op.
+//  (c) GetStatsByAuthority counts bulk items correctly: outcomes = SUM(bi.quantity)
+//      for taken items, weight uses the items-table name match or fallback average,
+//      replies count structured interest rows.
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/freegle/iznik-server-go/authority"
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBulkCollectedPathRecomputesNoDoubleDeduction proves that when the
+// external-owner toggle marks an item available=0 (firing recomputeBulkAvailableNow),
+// a subsequent in-app BulkInterestState=Collected does NOT further subtract from
+// availablenow — because the Collected path now calls the same recompute rather
+// than a raw decrement.
+//
+// Scenario: two items, Item A and Item B, totalling 10 available.
+// External toggle marks Item A unavailable → availablenow drops to 6 (only Item B left).
+// Collected transition for Item A then fires.
+//
+// Without the fix the raw decrement would subtract the interest qty (2) again,
+// leaving availablenow = 4 instead of 6.
+// With the fix the recompute sees Item A still available=0 and returns 6.
+func TestBulkCollectedPathRecomputesNoDoubleDeduction(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("bulkdedupe")
+	groupID := CreateTestGroup(t, prefix)
+	ownerID := CreateTestUser(t, prefix+"_owner", "User")
+	wanterID := CreateTestUser(t, prefix+"_wanter", "User")
+	CreateTestMembership(t, ownerID, groupID, "Member")
+
+	msgID := CreateTestMessage(t, ownerID, groupID, prefix+" Clearance", 55.95, -3.18)
+	itemAID := addBulkItem(t, msgID, "DeskA", 4, "Good")
+	addBulkItem(t, msgID, "ChairB", 6, "Good")
+
+	// Seed availablenow to match the item totals.
+	db.Exec("UPDATE messages SET availablenow = 10 WHERE id = ?", msgID)
+
+	// Plant an interest row for Item A at qty=2, state=Reserved.
+	db.Exec("INSERT INTO messages_bulk_items_interest (bulkitemid, msgid, userid, quantity, state) VALUES (?, ?, ?, 2, 'Reserved')",
+		itemAID, msgID, wanterID)
+
+	// --- Step 1: External-owner toggle marks Item A unavailable. ---
+	// Call the logged-out POST endpoint to simulate the item-owner clicking "taken".
+	token := fmt.Sprintf("edittok_%s_0123456789abcdef", prefix)
+	setEditToken(t, msgID, token)
+	res := postUpdate(t, token, map[string]interface{}{"itemid": itemAID, "available": false})
+	require.Equal(t, 200, res.StatusCode, "external toggle should succeed")
+
+	var availAfterToggle int
+	db.Raw("SELECT availablenow FROM messages WHERE id = ?", msgID).Scan(&availAfterToggle)
+	// availablenow should now be 6 (only ChairB with qty=6 remains available=1).
+	assert.Equal(t, 6, availAfterToggle, "after external toggle, availablenow = ChairB qty = 6")
+
+	// --- Step 2: In-app Collected transition for Item A. ---
+	ownerToken := getToken(t, ownerID)
+	body := map[string]interface{}{
+		"action":     "BulkInterestState",
+		"id":         msgID,
+		"bulkitemid": itemAID,
+		"userid":     wanterID,
+		"state":      "Collected",
+	}
+	bb, _ := json.Marshal(body)
+	req := httptest.NewRequest("POST", "/api/message?jwt="+ownerToken, bytes.NewBuffer(bb))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := getApp().Test(req, 10000)
+	require.NoError(t, err)
+	require.Equal(t, 200, resp.StatusCode, "Collected transition should succeed")
+
+	// availablenow must stay at 6: the recompute sees Item A is still available=0
+	// from the external toggle and ChairB unchanged at qty=6. Without the fix the
+	// raw decrement would subtract 2 again, leaving 4.
+	var availAfterCollected int
+	db.Raw("SELECT availablenow FROM messages WHERE id = ?", msgID).Scan(&availAfterCollected)
+	assert.Equal(t, 6, availAfterCollected,
+		"Collected recompute must not double-deduct an item already excluded by the external toggle")
+}
+
+// TestBulkLastItemCollectedInsertsOutcomeRowOnce proves that when collecting the
+// last available units of a bulk offer, exactly one messages_outcomes Taken row
+// is created, and a second trigger (the external-owner toggle firing again on the
+// same item) is a no-op — the NOT EXISTS guard prevents duplication.
+func TestBulkLastItemCollectedInsertsOutcomeRowOnce(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("bulkoutcome")
+	groupID := CreateTestGroup(t, prefix)
+	ownerID := CreateTestUser(t, prefix+"_owner", "User")
+	wanterID := CreateTestUser(t, prefix+"_wanter", "User")
+	CreateTestMembership(t, ownerID, groupID, "Member")
+
+	msgID := CreateTestMessage(t, ownerID, groupID, prefix+" Clearance", 55.95, -3.18)
+	deskID := addBulkItem(t, msgID, "Desk", 2, "Good")
+	db.Exec("UPDATE messages SET availablenow = 2 WHERE id = ?", msgID)
+	// Interest at qty=2 (all of them), state=Reserved.
+	db.Exec("INSERT INTO messages_bulk_items_interest (bulkitemid, msgid, userid, quantity, state) VALUES (?, ?, ?, 2, 'Reserved')",
+		deskID, msgID, wanterID)
+
+	// Verify no outcomes row exists yet.
+	var priorCount int64
+	db.Raw("SELECT COUNT(*) FROM messages_outcomes WHERE msgid = ?", msgID).Scan(&priorCount)
+	assert.Equal(t, int64(0), priorCount, "no outcomes row before collection")
+
+	// --- Mark the entire desk quantity as Collected. ---
+	ownerToken := getToken(t, ownerID)
+	body := map[string]interface{}{
+		"action":     "BulkInterestState",
+		"id":         msgID,
+		"bulkitemid": deskID,
+		"userid":     wanterID,
+		"state":      "Collected",
+	}
+	bb, _ := json.Marshal(body)
+	req := httptest.NewRequest("POST", "/api/message?jwt="+ownerToken, bytes.NewBuffer(bb))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := getApp().Test(req, 10000)
+	require.NoError(t, err)
+	require.Equal(t, 200, resp.StatusCode)
+
+	// availablenow should be 0 (qty reduced 2→0, recompute = SUM where available=1 = 0).
+	var avail int
+	db.Raw("SELECT availablenow FROM messages WHERE id = ?", msgID).Scan(&avail)
+	assert.Equal(t, 0, avail, "availablenow must be 0 after collecting all units")
+
+	// Exactly one Taken outcomes row must exist.
+	var afterCount int64
+	db.Raw("SELECT COUNT(*) FROM messages_outcomes WHERE msgid = ? AND outcome = 'Taken'", msgID).Scan(&afterCount)
+	assert.Equal(t, int64(1), afterCount, "exactly one Taken outcomes row must be inserted")
+
+	// --- Fire the external-owner toggle on the same item (already available=0). ---
+	// This calls recomputeBulkAvailableNow again, then recordBulkOutcomeIfComplete.
+	// The NOT EXISTS guard must prevent a duplicate outcomes row.
+	token := fmt.Sprintf("edittok_%s_0123456789abcdef", prefix)
+	setEditToken(t, msgID, token)
+	res := postUpdate(t, token, map[string]interface{}{"itemid": deskID, "available": false})
+	require.Equal(t, 200, res.StatusCode, "external toggle on already-taken item should still return 200")
+
+	var finalCount int64
+	db.Raw("SELECT COUNT(*) FROM messages_outcomes WHERE msgid = ? AND outcome = 'Taken'", msgID).Scan(&finalCount)
+	assert.Equal(t, int64(1), finalCount, "second trigger must not duplicate the outcomes row")
+
+	// The fully-collected line must be marked available=0 so the external page
+	// reflects it and the flip-day stats arms count its remaining quantity (0).
+	var itemAvail int
+	db.Raw("SELECT available FROM messages_bulk_items WHERE id = ?", deskID).Scan(&itemAvail)
+	assert.Equal(t, 0, itemAvail, "fully-collected item must have available=0")
+}
+
+// TestBulkOfferAuthorityStats proves that GetStatsByAuthority includes bulk offer
+// items in the per-postcode stats: outcomes count taken-item quantities (not just
+// message counts), weight uses the items-table name match multiplied by quantity,
+// and replies count structured interest rows.
+//
+// Fixture design: main_test.go's setupLocationTestData seeds location 1000001
+// ("EH3 6SS", type=Postcode) and a matching locations_spatial entry at
+// POINT(-3.205333 55.957571) SRID 3857. We build an authority polygon that
+// contains that point and place the test message at locationid=1000001. This
+// avoids creating new locations_spatial rows whose SRID/FK behaviour in the test
+// DB would need separate validation.
+//
+// Join chain verified against the SQL in GetStatsByAuthority:
+//
+//	authorities.polygon (SRID 3857) ST_Contains locations_spatial.geometry (locid=1000001)
+//	→ pc.locationid = 1000001
+//	→ messages.locationid = 1000001
+//	→ locations.id = 1000001, type='Postcode', name='EH3 6SS'
+//	→ SUBSTRING('EH3 6SS', 1, 5) = "EH3 6"   [LENGTH=7, 7-2=5; LOCATE(' ',name)=4>0]
+//
+// Setup: one bulk offer with two items. Item A has available=0, qty=2 (remaining
+// after 1 was collected in-app), and a Collected interest row for qty=1. Item B
+// (qty=3, available=1) is live and excluded from Outcomes/Weight.
+//
+// Expected for partial postcode "EH3 6":
+//   - Outcomes = 3   (available=0 arm: qty=2) + (interest-Collected arm: qty=1)
+//   - Weight   = 30  (10 kg × 3 total units via items-table name match)
+//   - Replies  = 1   (one interest row regardless of state)
+func TestBulkOfferAuthorityStats(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("bulkstats")
+
+	// locationid=1000001 is seeded by setupLocationTestData in TestMain:
+	//   locations:         id=1000001, name='EH3 6SS', type='Postcode'
+	//   locations_spatial: locationid=1000001, geometry=POINT(-3.205333 55.957571) SRID 3857
+	const locID = uint64(1000001)
+	const partialPostcode = "EH3 6" // SUBSTRING('EH3 6SS', 1, 7-2)
+
+	// --- Create an authority whose polygon contains POINT(-3.205333 55.957571). ---
+	// Coordinates match the convention in locations_spatial: degree-like values
+	// stored in SRID 3857 as X=lng, Y=lat.
+	authName := "TestAuth_" + prefix
+	db.Exec("INSERT INTO authorities (name, polygon) VALUES (?, ST_GeomFromText('POLYGON((-4 55, -3 55, -3 57, -4 57, -4 55))', 3857))", authName)
+	var authorityID uint64
+	db.Raw("SELECT id FROM authorities WHERE name = ? ORDER BY id DESC LIMIT 1", authName).Scan(&authorityID)
+	require.NotZero(t, authorityID, "test authority must be created")
+	t.Cleanup(func() {
+		db.Exec("DELETE FROM authorities WHERE id = ?", authorityID)
+	})
+
+	// --- Create an items-table entry for weight matching. ---
+	ns := time.Now().UnixNano()
+	itemName := fmt.Sprintf("TestStatChair_%d", ns)
+	const knownWeight = 10.0
+	db.Exec("INSERT INTO items (name, weight, popularity) VALUES (?, ?, 1)", itemName, knownWeight)
+	var itemsRowID uint64
+	db.Raw("SELECT id FROM items WHERE name = ? ORDER BY id DESC LIMIT 1", itemName).Scan(&itemsRowID)
+	require.NotZero(t, itemsRowID, "test items row must be created")
+	t.Cleanup(func() {
+		db.Exec("DELETE FROM items WHERE id = ?", itemsRowID)
+	})
+
+	// --- Build a bulk offer message and point it at location 1000001. ---
+	groupID := CreateTestGroup(t, prefix)
+	ownerID := CreateTestUser(t, prefix+"_owner", "User")
+	wanterID := CreateTestUser(t, prefix+"_wanter", "User")
+	CreateTestMembership(t, ownerID, groupID, "Member")
+
+	msgID := CreateTestMessage(t, ownerID, groupID, prefix+" Clearance", 55.957571, -3.205333)
+	// Override the locationid to the seeded test postcode so pc picks it up.
+	db.Exec("UPDATE messages SET locationid = ? WHERE id = ?", locID, msgID)
+
+	// Item A: qty=2 remaining (after 1 was collected in-app), available=0 (owner flipped).
+	// Matches itemName in the items table for weight lookup.
+	itemAID := addBulkItem(t, msgID, itemName, 2, "Good")
+	db.Exec("UPDATE messages_bulk_items SET available = 0 WHERE id = ?", itemAID)
+	// Item B: qty=3, no weight match, still available — excluded from Outcomes/Weight.
+	addBulkItem(t, msgID, "NoWeightItemForStatsTest", 3, "Good")
+
+	// Interest row for Item A: state=Collected, qty=1 (the in-app-collected portion).
+	// Counted by the interest-Collected Outcomes/Weight arms; also counts as a reply.
+	db.Exec("INSERT INTO messages_bulk_items_interest (bulkitemid, msgid, userid, quantity, state) VALUES (?, ?, ?, 1, 'Collected')",
+		itemAID, msgID, wanterID)
+
+	// --- Call GetStatsByAuthority. ---
+	stats, err := authority.GetStatsByAuthority(authorityID, "365 days ago", "today")
+	require.NoError(t, err)
+
+	ps, found := stats[partialPostcode]
+	require.True(t, found, "stats must include postcode %q (got keys: %v)", partialPostcode, statsKeys(stats))
+
+	// Outcomes = 3: available=0 arm counts Item A's remaining qty=2; interest-Collected
+	// arm counts mbii.quantity=1. Together = 3, not 1 per message.
+	assert.Equal(t, 3, ps.Outcomes, "outcomes must sum remaining-at-flip (2) and in-app-collected (1)")
+
+	// Weight = 30: 10 kg × 3 total units (both arms); Item B available=1 is excluded.
+	assert.InDelta(t, 30.0, ps.Weight, 0.001, "weight must be items-table weight × total counted units (3)")
+
+	// Replies = 1: the single interest row (Collected state counts as a reply).
+	assert.Equal(t, 1, ps.Replies, "replies must count the interest row")
+}
+
+// statsKeys returns the postcode keys from a stats map for error messages.
+func statsKeys(m map[string]authority.PostcodeStats) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}


### PR DESCRIPTION
## Summary

Bulk offers (the `messages_bulk_items` clearance catalogues) were **invisible to every stats pipeline**: nothing ever wrote `messages_outcomes` for them, so a fully-cleared 50-item clearance contributed zero to outcomes, weight/CO2/£-benefit, happiness, heatmap and authority reporting. This PR makes every stat count bulk offers **per item quantity** (policy: a "chairs ×6" line = 6), with joins only - no schema changes.

### Lifecycle (Go)
- The in-app `Collected` path reduces the item's remaining quantity and **recomputes** `availablenow` (was a raw deduction that could double-deduct against the external owner's toggle); a fully-collected line flips `available=0`.
- When `availablenow` reaches 0, either path inserts one idempotent `messages_outcomes` 'Taken' row - completed bulk offers become visible to all legacy pipelines (heatmap, happiness, V1 readers).

### Per-item counting
- **Laravel daily stats**: posts count `availableinitially` units; Outcomes/Weight sum two non-overlapping per-item arms (units remaining at the owner's flip + units collected in-app); Replies = item-interest rows + free-text repliers; bulk msgids excluded from per-message arms (no double-counting). Weight resolves per item **by name** against the items table with the existing average fallback. Monthly rollups inherit via the stats table.
- **Go authority stats**: same arms.

### Bonus: the authority stats endpoint was dead in production
Writing real coverage for `GET /authority/stats` exposed that it has returned **empty since inception**, from three stacked defects - all fixed:
1. `Format("2006-01-02 23:59:59")` - Go renders the time digits as format directives (`78:369:369`); MySQL parses that as NULL and every `BETWEEN` matched nothing.
2. All 12 `Raw().Scan()` errors were unchecked - failures were silent empty maps. Now propagated.
3. The temp-table "pin" never pinned a connection: under dbresolver, per-statement routing acquires fresh pool connections (and `gorm.Connection()` deadlocks a capped pool - caught by the split-routing hazard test). The pin is now a `Begin()` transaction on the Write clause.

## Code Quality Review
- No schema changes - everything by joins; quantity semantics consistent with `availableinitially`/`availablenow`.
- The two per-item outcome arms are provably non-overlapping (in-app collections deduct from remaining quantity before any flip).
- Diagnostics used during root-causing were removed; the fix comment in `calendarLink`-style explains the Format pitfall for future readers.

## Test Plan
- Go: no-double-deduction across both collection paths; idempotent outcome-on-zero + available flip; authority per-item fixture (Outcomes=3, Weight=30, Replies=1 on a mixed in-app + external clearance). Full suite **3,412 pass**.
- Laravel: composite fixture - ApprovedMessageCount=7, Outcomes=3, Weight=30, Replies=4, Activity=11, with an untouched control message. Full suite **4,733 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MAMpjuyJgnUSEAsdUcpJr6
