### PR TITLE
fix(db): fall back to master when the read replica is down, with periodic retry

### DIFF
--- a/iznik-batch/app/Database/FailoverConnectionFactory.php
+++ b/iznik-batch/app/Database/FailoverConnectionFactory.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Database;
+
+use Closure;
+use Illuminate\Database\Connectors\ConnectionFactory;
+use Illuminate\Support\Facades\Log;
+use PDOException;
+
+/**
+ * A ConnectionFactory that falls back to the write host when all read-replica
+ * hosts are unreachable.
+ *
+ * Laravel's built-in ConnectionFactory::createPdoResolverWithHosts already
+ * cycles through every host in the read array on connection failure, but once
+ * all of them are exhausted it throws — it never tries the write host. This
+ * subclass wraps the read PDO resolver in a Closure that catches that final
+ * failure and re-resolves against the write-host config instead.
+ *
+ * Periodic retry is natural and free: Laravel resolves the read PDO lazily (the
+ * Closure is invoked the first time a read connection is needed after the pool
+ * reconnects). Long-running daemons reconnect on error; artisan runs are always
+ * fresh. Each reconnect re-enters the Closure and re-attempts the read hosts
+ * first — so the write fallback is only held for as long as replicas stay down.
+ *
+ * The wrapper is omitted entirely for single-host deployments (dev/CI) where the
+ * read and write host arrays are identical, keeping those environments unaffected.
+ */
+class FailoverConnectionFactory extends ConnectionFactory
+{
+    /**
+     * Create the lazy read-PDO resolver, wrapping it with write-host fallback.
+     *
+     * @param  array  $config  Full connection config including both 'read' and 'write' keys.
+     * @return Closure
+     */
+    protected function createReadPdo(array $config)
+    {
+        $readConfig  = $this->getReadConfig($config);
+        $writeConfig = $this->getWriteConfig($config);
+
+        // Compare host arrays to detect single-host / dev/CI deployments.
+        $readHosts  = array_values((array) ($readConfig['host'] ?? []));
+        $writeHosts = array_values((array) ($writeConfig['host'] ?? []));
+        sort($readHosts);
+        sort($writeHosts);
+
+        if ($readHosts === $writeHosts) {
+            // Read and write targets are the same — no failover wrapper needed.
+            return parent::createReadPdo($config);
+        }
+
+        $readResolver  = parent::createReadPdo($config);
+        $writeResolver = $this->createPdoResolverWithHosts($writeConfig);
+
+        // Return a Closure so connection establishment stays lazy (Laravel
+        // calls this Closure the first time a read connection is needed, not
+        // at boot). The try/catch inside the Closure is what gives us failover:
+        // if all read hosts fail, we fall back to the write host and log once.
+        return function () use ($readResolver, $writeResolver) {
+            try {
+                return $readResolver();
+            } catch (PDOException $e) {
+                Log::warning('read-replica unavailable, falling back to write host', [
+                    'error' => $e->getMessage(),
+                ]);
+
+                return $writeResolver();
+            }
+        };
+    }
+}

--- a/iznik-batch/app/Providers/AppServiceProvider.php
+++ b/iznik-batch/app/Providers/AppServiceProvider.php
@@ -6,6 +6,7 @@ use App\Console\FlockEventMutex;
 use App\Console\ResilientCacheEventMutex;
 use App\Console\SchedulerMutex;
 use App\Database\DeadlockRetryConnection;
+use App\Database\FailoverConnectionFactory;
 use App\Listeners\CronJobStatusListener;
 use App\Listeners\SpamCheckListener;
 use App\Services\LokiService;
@@ -26,6 +27,14 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
+        // Replace the default ConnectionFactory with our FailoverConnectionFactory so
+        // that when all read-replica hosts are unreachable, Laravel automatically falls
+        // back to the write host instead of throwing. This must be registered before
+        // the 'db' service provider resolves 'db.factory'.
+        $this->app->singleton('db.factory', function ($app) {
+            return new FailoverConnectionFactory($app);
+        });
+
         // Use DeadlockRetryConnection for MySQL — automatically retries
         // deadlocked statements at autocommit level with exponential backoff.
         \Illuminate\Database\Connection::resolverFor('mysql', function ($connection, $database, $prefix, $config) {

--- a/iznik-batch/config/database.php
+++ b/iznik-batch/config/database.php
@@ -51,6 +51,14 @@ return [
         // back to DB_HOST so single-host deployments (dev/CI) are unchanged. Both
         // accept a comma-separated list of hosts; Laravel picks one at random.
         //
+        // Replica failover: App\Database\FailoverConnectionFactory (registered in
+        // AppServiceProvider) wraps the read PDO resolver so that if ALL read hosts
+        // are unreachable, reads automatically fall back to the write host and a
+        // warning is logged. Recovery is natural: the read PDO resolver is lazy and
+        // called fresh on each reconnect, so the replica is re-attempted on the next
+        // connection after it recovers. Single-host deployments (read == write hosts)
+        // are unaffected.
+        //
         // No 'sticky': Galera replication is synchronous (certification-based), so a
         // committed write is visible on the read nodes without meaningful delay -
         // reads can always use the read host, even in long-running daemons (V1 had no

--- a/iznik-batch/tests/Feature/Database/FailoverConnectionFactoryTest.php
+++ b/iznik-batch/tests/Feature/Database/FailoverConnectionFactoryTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Tests\Feature\Database;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Tests\TestCase;
+
+/**
+ * Verifies that FailoverConnectionFactory falls back to the write host when all
+ * read-replica hosts are unreachable.
+ *
+ * Each test creates a fresh connection via the factory directly (using
+ * $factory->make()) so the main DB connection used by DatabaseTransactions is
+ * never touched. Overriding config and purging the registered connection in
+ * tearDown ensures subsequent tests get a clean slate.
+ */
+class FailoverConnectionFactoryTest extends TestCase
+{
+    /** @var array<string>|null */
+    private ?array $originalReadHosts = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->originalReadHosts = config('database.connections.mysql.read.host');
+    }
+
+    protected function tearDown(): void
+    {
+        // Restore the original read-host config before parent tearDown reconnects,
+        // and purge so the next test gets a clean connection with the restored config.
+        if ($this->originalReadHosts !== null) {
+            config(['database.connections.mysql.read.host' => $this->originalReadHosts]);
+        }
+        DB::purge('mysql');
+
+        parent::tearDown();
+    }
+
+    /**
+     * When all read-replica hosts are unreachable (DNS failure), the factory
+     * must transparently fall back to the write host so reads still work, and
+     * it must log a warning.
+     */
+    public function test_falls_back_to_write_host_when_read_replica_unreachable(): void
+    {
+        Log::spy();
+
+        // Override read config to a hostname that will never resolve.
+        config(['database.connections.mysql.read.host' => ['no-such-replica-host.invalid']]);
+
+        // Create a fresh connection via the registered factory so we exercise
+        // FailoverConnectionFactory with the bad read config, without touching
+        // the main DB connection (which DatabaseTransactions wrapped in a transaction).
+        /** @var \App\Database\FailoverConnectionFactory $factory */
+        $factory = $this->app->make('db.factory');
+        $config  = config('database.connections.mysql');
+        $connection = $factory->make($config, 'mysql');
+
+        // Reads should succeed via the write-host fallback.
+        $result = $connection->select('select 1 as val');
+        $this->assertNotEmpty($result);
+        $this->assertEquals(1, (int) ($result[0]->val ?? $result[0]['val'] ?? null));
+
+        $connection->disconnect();
+
+        // The warning must have been emitted.
+        Log::shouldHaveReceived('warning')
+            ->withArgs(fn ($message, $context = []) =>
+                str_contains((string) $message, 'read-replica'));
+    }
+
+    /**
+     * When read and write hosts are the same (single-host / dev/CI deployments),
+     * no failover wrapper is applied — the factory behaves as it always did.
+     */
+    public function test_single_host_deployment_unaffected(): void
+    {
+        $writeHosts = config('database.connections.mysql.write.host');
+
+        // Set read hosts == write hosts to simulate a single-host setup.
+        config(['database.connections.mysql.read.host' => $writeHosts]);
+
+        /** @var \App\Database\FailoverConnectionFactory $factory */
+        $factory = $this->app->make('db.factory');
+        $config  = config('database.connections.mysql');
+        $connection = $factory->make($config, 'mysql');
+
+        $result = $connection->select('select 1 as val');
+        $this->assertNotEmpty($result);
+        $this->assertEquals(1, (int) ($result[0]->val ?? $result[0]['val'] ?? null));
+
+        $connection->disconnect();
+    }
+}

--- a/iznik-server-go/database/database.go
+++ b/iznik-server-go/database/database.go
@@ -77,6 +77,15 @@ func InitDatabase() {
 	// SELECTs go to the replica. db.DB() still returns the source pool, so the
 	// LastInsertId write sites are unaffected.
 	//
+	// Replica failover: the Replicas dialector is backed by a failoverConnector
+	// (database/failover.go) that automatically falls back to the source when
+	// the replica is unreachable. After a failure it skips the replica for a
+	// 30-second window (to avoid stalling on a dial timeout), then re-probes it
+	// on the next new connection. Recovery is therefore automatic: once the
+	// replica is healthy again, the next connection attempt outside the window
+	// routes back to it. The 5-minute conn lifetime below bounds how long
+	// fallback-backed connections persist after recovery.
+	//
 	// When MYSQL_HOST_READ is empty the resolver is NOT registered and behaviour
 	// is byte-identical to a single-host deployment, so dev/CI/existing prod are
 	// unchanged until a replica is explicitly configured.
@@ -88,12 +97,16 @@ func InitDatabase() {
 		fmt.Println("Read replica enabled at", readHost)
 		resolverErr := DBConn.Use(
 			dbresolver.Register(dbresolver.Config{
-				Replicas: []gorm.Dialector{mysql.Open(buildDSN(readHost))},
+				Replicas: []gorm.Dialector{newFailoverDialector(buildDSN(readHost), buildDSN(writeHost))},
 				Policy:   dbresolver.RandomPolicy{},
 			}).
 				SetMaxOpenConns(200).
 				SetMaxIdleConns(200).
-				SetConnMaxLifetime(time.Hour),
+				// 5-minute lifetime ensures fallback-backed connections age out and
+				// reconnect via the primary (replica) path within 5 minutes of
+				// recovery, bounding how long the source carries replica-destined
+				// reads after the replica comes back.
+				SetConnMaxLifetime(5 * time.Minute),
 		)
 		if resolverErr != nil {
 			panic("failed to register read replica: " + resolverErr.Error())

--- a/iznik-server-go/database/failover.go
+++ b/iznik-server-go/database/failover.go
@@ -1,0 +1,116 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	rawmysql "github.com/go-sql-driver/mysql"
+	gormmysql "gorm.io/driver/mysql"
+	"gorm.io/gorm"
+)
+
+// failoverConnector implements database/sql/driver.Connector and wraps a
+// primary (replica) connector with a fallback (source/write) connector.
+//
+// When the primary is reachable it is always preferred. When it fails the
+// connector falls back to the source for every new connection until the
+// retryAfter window expires; after the window, it tries the primary again.
+// Recovery is therefore automatic and proportional to the conn-max-lifetime
+// of the resolver pool: once connections age out, new ones re-probe the
+// primary via this path.
+type failoverConnector struct {
+	primary    driver.Connector
+	fallback   driver.Connector
+	retryAfter time.Duration
+
+	// lastFail stores the unix-nanosecond timestamp of the most recent primary
+	// failure.  Zero means either "never failed" or "primary recovered".
+	lastFail atomic.Int64
+
+	// loggedDown is set to true on the first failure of each down episode so
+	// we emit exactly one log line per outage, not one per connection attempt.
+	loggedDown atomic.Bool
+}
+
+// Connect implements driver.Connector.  The retry-window check is the core of
+// the failover: after a failure we skip the primary for retryAfter to avoid
+// stalling every new connection on a dial timeout; each new pooled connection
+// after the window re-probes the primary, giving automatic periodic retry.
+func (f *failoverConnector) Connect(ctx context.Context) (driver.Conn, error) {
+	now := time.Now()
+	last := f.lastFail.Load()
+
+	if last != 0 && now.Sub(time.Unix(0, last)) < f.retryAfter {
+		// Within backoff window: go straight to fallback without attempting
+		// the primary, avoiding a dial-timeout stall on every new connection.
+		return f.fallback.Connect(ctx)
+	}
+
+	// Try the primary (read replica).
+	conn, err := f.primary.Connect(ctx)
+	if err == nil {
+		// Primary is healthy; clear the failure markers for the next episode.
+		f.lastFail.Store(0)
+		f.loggedDown.Store(false)
+		return conn, nil
+	}
+
+	// Primary failed.  Record the time (so the retry window starts now) and
+	// log exactly once per down episode.
+	f.lastFail.Store(now.UnixNano())
+	if f.loggedDown.CompareAndSwap(false, true) {
+		fmt.Printf("read replica unavailable, using source: %v\n", err)
+	}
+
+	return f.fallback.Connect(ctx)
+}
+
+// Driver implements driver.Connector.
+func (f *failoverConnector) Driver() driver.Driver {
+	return f.primary.Driver()
+}
+
+// newFailoverDialector builds a gorm Dialector that wraps the replica DSN
+// with a write-host fallback.  It parses both DSNs, sets a 2-second dial
+// timeout on the replica connector (so a down replica costs at most one brief
+// stall per 30-second retry window rather than a full TCP timeout), and
+// returns a gorm dialector backed by a *sql.DB opened over the
+// failoverConnector.
+//
+// This replaces the plain mysql.Open(replicaDSN) in dbresolver.Register.
+func newFailoverDialector(replicaDSN, sourceDSN string) gorm.Dialector {
+	replicaCfg, err := rawmysql.ParseDSN(replicaDSN)
+	if err != nil {
+		panic("database: failed to parse replica DSN for failover: " + err.Error())
+	}
+	// Short dial timeout on the replica only — a down replica must not stall
+	// every new connection for the OS default TCP timeout (~2 min).
+	replicaCfg.Timeout = 2 * time.Second
+
+	sourceCfg, err := rawmysql.ParseDSN(sourceDSN)
+	if err != nil {
+		panic("database: failed to parse source DSN for failover: " + err.Error())
+	}
+
+	primaryConn, err := rawmysql.NewConnector(replicaCfg)
+	if err != nil {
+		panic("database: failed to build replica connector: " + err.Error())
+	}
+	fallbackConn, err := rawmysql.NewConnector(sourceCfg)
+	if err != nil {
+		panic("database: failed to build source connector: " + err.Error())
+	}
+
+	fc := &failoverConnector{
+		primary:    primaryConn,
+		fallback:   fallbackConn,
+		retryAfter: 30 * time.Second,
+	}
+
+	sqlDB := sql.OpenDB(fc)
+	return gormmysql.New(gormmysql.Config{Conn: sqlDB})
+}

--- a/iznik-server-go/database/failover_test.go
+++ b/iznik-server-go/database/failover_test.go
@@ -89,36 +89,40 @@ func TestFailoverConnector_FallsBackWhenPrimaryDown(t *testing.T) {
 
 // TestFailoverConnector_RetryWindowSkipsPrimary proves that after the first
 // failure the connector enters a retry window and subsequent Connect calls go
-// straight to the fallback without re-attempting the primary, so the second
-// connection costs much less than the dial timeout.
+// straight to the fallback without re-attempting the primary.
+//
+// The proof is via call counts on a countingConnector wrapper: after the first
+// Connect (which calls the primary once and fails), the second Connect must not
+// increment the count — the primary was skipped entirely, not just fast.
 func TestFailoverConnector_RetryWindowSkipsPrimary(t *testing.T) {
-	const dialTimeout = 200 * time.Millisecond
+	// Wrap the unreachable connector in a counter so we can observe exactly
+	// how many times the primary is called.
+	counted := &countingConnector{
+		inner: testUnreachableConnector(t, 200*time.Millisecond),
+	}
 
 	fc := &failoverConnector{
-		primary:    testUnreachableConnector(t, dialTimeout),
+		primary:    counted,
 		fallback:   testFallbackConnector(t),
 		retryAfter: 30 * time.Second,
 	}
 
 	ctx := context.Background()
 
-	// First Connect: must probe the primary (paying dialTimeout), then fall back.
-	start := time.Now()
+	// First Connect: must probe the primary (fails), then fall back to source.
 	conn1, err := fc.Connect(ctx)
-	firstDuration := time.Since(start)
 	require.NoError(t, err, "first Connect should succeed via fallback")
 	conn1.Close()
-	assert.GreaterOrEqual(t, firstDuration, dialTimeout,
-		"first connect should spend at least dialTimeout probing the unreachable primary")
+	assert.Equal(t, int64(1), counted.count.Load(),
+		"first Connect must attempt the primary exactly once")
 
-	// Second Connect: within retry window, must skip the primary entirely.
-	start = time.Now()
+	// Second Connect: within the 30-second retry window.  The primary must
+	// NOT be called again — the connector goes straight to fallback.
 	conn2, err := fc.Connect(ctx)
-	secondDuration := time.Since(start)
 	require.NoError(t, err, "second Connect should succeed via fallback")
 	conn2.Close()
-	assert.Less(t, secondDuration, dialTimeout,
-		"second connect should be faster than dialTimeout (primary skipped during window)")
+	assert.Equal(t, int64(1), counted.count.Load(),
+		"second Connect must skip the primary (count stays at 1 within retry window)")
 }
 
 // TestFailoverConnector_PrefersHealthyPrimary proves that when the primary

--- a/iznik-server-go/database/failover_test.go
+++ b/iznik-server-go/database/failover_test.go
@@ -1,0 +1,148 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	rawmysql "github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testFallbackConnector builds a connector for the real test database, to be
+// used as the fallback in failover tests.  buildDSN is unexported but
+// accessible here because this file is in package database.
+func testFallbackConnector(t *testing.T) driver.Connector {
+	t.Helper()
+	host := os.Getenv("MYSQL_HOST")
+	if host == "" {
+		t.Skip("MYSQL_HOST not set; skipping failover integration test")
+	}
+	cfg, err := rawmysql.ParseDSN(buildDSN(host))
+	require.NoError(t, err, "parse test DB DSN")
+	conn, err := rawmysql.NewConnector(cfg)
+	require.NoError(t, err, "build test DB connector")
+	return conn
+}
+
+// testUnreachableConnector builds a connector whose Addr is 127.0.0.1:1 — a
+// port guaranteed closed on any host — with a short dial timeout so test
+// failures are detected quickly.
+func testUnreachableConnector(t *testing.T, timeout time.Duration) driver.Connector {
+	t.Helper()
+	host := os.Getenv("MYSQL_HOST")
+	if host == "" {
+		t.Skip("MYSQL_HOST not set; skipping failover integration test")
+	}
+	cfg, err := rawmysql.ParseDSN(buildDSN(host))
+	require.NoError(t, err, "parse DSN for unreachable connector")
+	cfg.Addr = "127.0.0.1:1"
+	cfg.Timeout = timeout
+	conn, err := rawmysql.NewConnector(cfg)
+	require.NoError(t, err, "build unreachable connector")
+	return conn
+}
+
+// countingConnector wraps a driver.Connector and counts how many times
+// Connect is called, allowing tests to assert that the primary was used.
+type countingConnector struct {
+	inner driver.Connector
+	count atomic.Int64
+}
+
+func (c *countingConnector) Connect(ctx context.Context) (driver.Conn, error) {
+	c.count.Add(1)
+	return c.inner.Connect(ctx)
+}
+
+func (c *countingConnector) Driver() driver.Driver {
+	return c.inner.Driver()
+}
+
+// TestFailoverConnector_FallsBackWhenPrimaryDown verifies that when the
+// primary (replica) connector is pointing at an unreachable host, the
+// failoverConnector transparently routes to the fallback (source) and the
+// resulting *sql.DB can Ping and run a SELECT.
+func TestFailoverConnector_FallsBackWhenPrimaryDown(t *testing.T) {
+	const dialTimeout = 200 * time.Millisecond
+
+	fc := &failoverConnector{
+		primary:    testUnreachableConnector(t, dialTimeout),
+		fallback:   testFallbackConnector(t),
+		retryAfter: 30 * time.Second,
+	}
+
+	db := sql.OpenDB(fc)
+	defer db.Close()
+
+	require.NoError(t, db.Ping(), "Ping should succeed via fallback when primary is down")
+
+	var got int
+	require.NoError(t, db.QueryRow("SELECT 1").Scan(&got))
+	assert.Equal(t, 1, got, "SELECT 1 should return 1 via fallback")
+}
+
+// TestFailoverConnector_RetryWindowSkipsPrimary proves that after the first
+// failure the connector enters a retry window and subsequent Connect calls go
+// straight to the fallback without re-attempting the primary, so the second
+// connection costs much less than the dial timeout.
+func TestFailoverConnector_RetryWindowSkipsPrimary(t *testing.T) {
+	const dialTimeout = 200 * time.Millisecond
+
+	fc := &failoverConnector{
+		primary:    testUnreachableConnector(t, dialTimeout),
+		fallback:   testFallbackConnector(t),
+		retryAfter: 30 * time.Second,
+	}
+
+	ctx := context.Background()
+
+	// First Connect: must probe the primary (paying dialTimeout), then fall back.
+	start := time.Now()
+	conn1, err := fc.Connect(ctx)
+	firstDuration := time.Since(start)
+	require.NoError(t, err, "first Connect should succeed via fallback")
+	conn1.Close()
+	assert.GreaterOrEqual(t, firstDuration, dialTimeout,
+		"first connect should spend at least dialTimeout probing the unreachable primary")
+
+	// Second Connect: within retry window, must skip the primary entirely.
+	start = time.Now()
+	conn2, err := fc.Connect(ctx)
+	secondDuration := time.Since(start)
+	require.NoError(t, err, "second Connect should succeed via fallback")
+	conn2.Close()
+	assert.Less(t, secondDuration, dialTimeout,
+		"second connect should be faster than dialTimeout (primary skipped during window)")
+}
+
+// TestFailoverConnector_PrefersHealthyPrimary proves that when the primary
+// connector is healthy, the failoverConnector routes through it — not the
+// fallback.  A countingConnector wrapper makes the usage count observable.
+func TestFailoverConnector_PrefersHealthyPrimary(t *testing.T) {
+	counter := &countingConnector{inner: testFallbackConnector(t)}
+
+	fc := &failoverConnector{
+		primary:    counter,
+		fallback:   testFallbackConnector(t),
+		retryAfter: 30 * time.Second,
+	}
+
+	db := sql.OpenDB(fc)
+	defer db.Close()
+
+	require.NoError(t, db.Ping(), "Ping should succeed via healthy primary")
+
+	var got int
+	require.NoError(t, db.QueryRow("SELECT 1").Scan(&got))
+	assert.Equal(t, 1, got)
+
+	// At least one connection must have gone through the primary (counter).
+	assert.Greater(t, counter.count.Load(), int64(0),
+		"at least one connection should have gone through the primary connector")
+}


### PR DESCRIPTION
## Summary

When the separate READ replica (MYSQL_HOST_READ / DB_HOST_READ) is down, both Go and Laravel previously **failed outright** on reads - one cluster node going away meant errors, not degradation. Both now fall back to the master and periodically retry the replica.

### iznik-server-go
- New `failoverConnector` (`database/failover.go`) at the `driver.Connector` level: each new pooled connection tries the replica first; on dial failure it logs once per outage episode and hands back a source connection instead. A 30s retry window stops every new connection paying the 2s replica dial timeout while it is down.
- Recovery is periodic by construction: the resolver pool's connection lifetime drops from 1h to 5 minutes, so fallback-backed connections age out and re-attempt the (recovered) replica within minutes - no coordinator, no health-check goroutine.
- Behaviour is byte-identical when `MYSQL_HOST_READ` is unset.

### iznik-batch (Laravel)
- Laravel's factory already walks the read-host list on connection failure but throws when the list is exhausted. `FailoverConnectionFactory` adds the final rung: read hosts exhausted → log a warning → resolve on the write host. Lazy PDO resolution means every reconnect re-attempts the read hosts first, giving natural periodic retry. Inert when read config equals write config (dev/CI).

## Test Plan
- Go (`database` package): dead replica (closed port) → Ping + SELECT succeed via fallback; retry window proven by dial-count (primary not re-dialled inside the window); healthy replica preferred (dial-count > 0).
- Laravel: read host set to an invalid DNS name → `SELECT 1` succeeds via the write host with the warning logged; single-host config bypasses the wrapper entirely.
- Full suites via status API on this tree: Go **3,412** pass, Laravel **4,734** pass (the two new failover tests verified individually via the filtered runner: 2/2, 5 assertions).

## Notes
- V1 PHP (`LoggedPDO`) manages its own host lists predating this; routing/spatial services have no read split - out of scope.
- The Go `database` package's tests don't currently run in the status-API suite (it runs `./test/... ./message/...`) - they run in CI's coverage variant via `-coverpkg` compilation and were verified compiling+passing via the filtered/live checks here. Adding `./database/...` to the runner is a small follow-up worth doing with the next status-container change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MAMpjuyJgnUSEAsdUcpJr6
