### PR TITLE
fix(chitchat): poster always sees their own reply immediately

### DIFF
--- a/iznik-nuxt3/stores/newsfeed.js
+++ b/iznik-nuxt3/stores/newsfeed.js
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia'
 import { nextTick } from 'vue'
 import api from '~/api'
+import { useAuthStore } from '~/stores/auth'
 
 export const useNewsfeedStore = defineStore({
   id: 'newsfeed',
@@ -204,6 +205,36 @@ export const useNewsfeedStore = defineStore({
         await this.fetchFeed()
       } else {
         await this.fetch(threadhead, true)
+
+        // Read-your-own-writes guarantee: the refetch above can miss the reply
+        // we just posted (replica lag on a degraded cluster, caches). The
+        // poster must ALWAYS see their own reply immediately, so if it is not
+        // in the store after the refetch, add an optimistic copy - a later
+        // fetch of the real row simply overwrites it by id.
+        if (id && replyto && !this.list[id]) {
+          const me = useAuthStore(this.config).user
+          this.addItems([
+            {
+              id,
+              userid: me?.id,
+              displayname: me?.displayname,
+              profile: me?.profile,
+              message,
+              replyto,
+              threadhead,
+              type: 'Message',
+              timestamp: new Date().toISOString(),
+              replies: [],
+              loves: 0,
+              optimistic: true,
+            },
+          ])
+
+          const parent = this.list[replyto]
+          if (parent && !parent.replies.includes(id)) {
+            parent.replies.push(id)
+          }
+        }
       }
 
       return id

--- a/iznik-nuxt3/tests/unit/stores/newsfeed.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/newsfeed.spec.js
@@ -16,6 +16,12 @@ const mockConvertToStory = vi.fn()
 const mockReferto = vi.fn()
 const mockReport = vi.fn()
 
+vi.mock('~/stores/auth', () => ({
+  useAuthStore: () => ({
+    user: { id: 77, displayname: 'Poster', profile: { paththumb: 'p.jpg' } },
+  }),
+}))
+
 vi.mock('~/api', () => ({
   default: () => ({
     news: {
@@ -717,6 +723,53 @@ describe('newsfeed store', () => {
       const users = store.tagusers
       expect(users).toHaveLength(1)
       expect(users[0].displayname).toBe('Alice')
+    })
+  })
+
+  describe('send: read-your-own-writes', () => {
+    it('adds an optimistic copy when the refetch misses the fresh reply', async () => {
+      const store = useNewsfeedStore()
+      store.init({ public: {} })
+      mockSend.mockResolvedValue(999)
+      // Thread refetch returns WITHOUT the new reply (replica lag).
+      mockFetchNews.mockResolvedValue({ id: 1, replies: [{ id: 2, replies: [] }] })
+
+      await store.send('hello there', 1, 1, null)
+
+      expect(store.list[999]).toBeTruthy()
+      expect(store.list[999].optimistic).toBe(true)
+      expect(store.list[999].message).toBe('hello there')
+      expect(store.list[999].userid).toBe(77)
+      expect(store.list[1].replies).toContain(999)
+    })
+
+    it('does not duplicate when the refetch already includes the reply', async () => {
+      const store = useNewsfeedStore()
+      store.init({ public: {} })
+      mockSend.mockResolvedValue(999)
+      mockFetchNews.mockResolvedValue({
+        id: 1,
+        replies: [{ id: 999, message: 'hello there', replies: [] }],
+      })
+
+      await store.send('hello there', 1, 1, null)
+
+      expect(store.list[999]).toBeTruthy()
+      expect(store.list[999].optimistic).toBeUndefined()
+      expect(store.list[1].replies.filter((r) => r === 999).length).toBe(1)
+    })
+
+    it('attaches the optimistic reply to a nested parent', async () => {
+      const store = useNewsfeedStore()
+      store.init({ public: {} })
+      mockSend.mockResolvedValue(1000)
+      // Replying to reply 2 within thread 1; refetch misses it.
+      mockFetchNews.mockResolvedValue({ id: 1, replies: [{ id: 2, replies: [] }] })
+
+      await store.send('nested reply', 2, 1, null)
+
+      expect(store.list[1000]).toBeTruthy()
+      expect(store.list[2].replies).toContain(1000)
     })
   })
 })


### PR DESCRIPTION
## Summary
Replies on ChitChat sometimes didn't appear for a while after posting. Diagnosis: **not** background content processing - replies insert fully visible (`reviewrequired=0`, no batch gate) and the client refetches immediately. The signature matches the post-send refetch SELECT hitting a lagging read node under the read/write split (acute during cluster degradation, as today).

Fix: read-your-own-writes in the newsfeed store. If the post-send refetch lacks the just-sent reply, an optimistic copy (author fields from the logged-in user, `optimistic: true`) is added and attached to its parent - nested or top-level. Later fetches of the real row overwrite by id.

## Test Plan
- New specs: refetch-miss → optimistic copy present with author fields; refetch-hit → no duplicate, no optimistic flag; nested parent attachment.
- Full unit suite via status API: **14,137 pass**.

Related: #993 handles the read replica being fully DOWN (fallback to master); this handles it being merely BEHIND.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MAMpjuyJgnUSEAsdUcpJr6