### PR TITLE
fix(chitchat): anchor poster to their reply after send; fix notification deep-link scroll

### DIFF
--- a/iznik-nuxt3/components/NewsReply.vue
+++ b/iznik-nuxt3/components/NewsReply.vue
@@ -555,7 +555,7 @@ async function sendReply(callback) {
   if (replybox.value && replybox.value.trim()) {
     const msg = untwem(replybox.value)
 
-    await newsfeedStore.send(
+    const newid = await newsfeedStore.send(
       msg,
       replyingTo.value,
       props.threadhead,
@@ -563,6 +563,12 @@ async function sendReply(callback) {
     )
 
     // New message will be shown because it's in the store and we have a computed property.
+    //
+    // The refetch after send re-renders the thread in the server's new order
+    // (the server bumps the replied-to parent to the end), so the content
+    // under the viewport changes and the fresh reply can land off-screen.
+    // Keep the poster anchored to what they just wrote.
+    scrollReplyIntoView(newid)
 
     // Clear and hide the textarea now it's sent.
     replybox.value = null
@@ -580,6 +586,18 @@ async function sendReply(callback) {
   if (typeof callback === 'function') {
     callback()
   }
+}
+
+function scrollReplyIntoView(id) {
+  if (!id) return
+  nextTick(() => {
+    setTimeout(() => {
+      const el = document.querySelector(`[data-reply-id="${id}"]`)
+      if (el) {
+        el.scrollIntoView({ behavior: 'smooth', block: 'center' })
+      }
+    }, 100)
+  })
 }
 
 function newlineReply() {
@@ -667,8 +685,11 @@ function scrollIntoView() {
     // Try later
     setTimeout(scrollIntoView, 100)
   } else {
-    // No outstanding requests, so we can scroll.
-    const el = document.getElementById(`newsreply-${props.id}`)
+    // No outstanding requests, so we can scroll. The reply rows are stamped
+    // with data-reply-id by NewsReplies; the historical getElementById
+    // ('newsreply-{id}') target was never rendered anywhere, so notification
+    // deep-links (/chitchat/{replyid}) silently failed to scroll.
+    const el = document.querySelector(`[data-reply-id="${props.id}"]`)
     if (el) {
       el.scrollIntoView({
         behavior: 'smooth',

--- a/iznik-nuxt3/components/NewsThread.vue
+++ b/iznik-nuxt3/components/NewsThread.vue
@@ -509,9 +509,27 @@ async function sendComment(callback) {
   if (threadcomment.value && threadcomment.value.trim()) {
     // Encode up any emojis.
     const msg = untwem(threadcomment.value)
-    await newsfeedStore.send(msg, replyingTo.value, props.id, imageid.value)
+    const newid = await newsfeedStore.send(
+      msg,
+      replyingTo.value,
+      props.id,
+      imageid.value
+    )
 
-    // New message will be shown because it's in the store and we have a computed property.
+    // New message will be shown because it's in the store and we have a computed
+    // property. Keep the poster anchored to their reply: the post-send refetch
+    // re-renders in the server's new order (replied-to parents get bumped), so
+    // without this the viewport content swaps and the reply lands off-screen.
+    if (newid) {
+      nextTick(() => {
+        setTimeout(() => {
+          const el = document.querySelector(`[data-reply-id="${newid}"]`)
+          if (el) {
+            el.scrollIntoView({ behavior: 'smooth', block: 'center' })
+          }
+        }, 100)
+      })
+    }
 
     // Clear the textarea now it's sent.
     threadcomment.value = null


### PR DESCRIPTION
## Summary
Follow-up to #988 (this commit was pushed to that branch minutes after it merged, so re-raised here).

Two scroll bugs on long nested threads, both browser-reproduced (Chromium --disable-gpu, WSL) with instrumented traces:

- **"Thread jumps around when I post"**: not a scroll jump - a content swap. The server bumps the replied-to parent to the end of the thread; the post-send refetch renders the new order, so the same scroll position shows different replies and the fresh reply is buried off-screen. Fix: after send, scroll the just-posted reply into view (`[data-reply-id]`, smooth, block:center) in both `NewsReply.sendReply` and `NewsThread`'s send. Verified: reply centred in viewport within 1s on 1280x800 and 390x844, 18/18 DOM nodes survive.
- **Notification deep-links never scrolled** (e.g. /chitchat/613423 first notification): `scrollIntoView()` targeted `getElementById('newsreply-{id}')` - an element id **no template has ever rendered**. Now targets the stamped `[data-reply-id]` rows that #988 introduced.

## Test Plan
- Browser verification with scrollY traces + node-survival marking (details above).
- Full unit suite via status API: **14,160 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MAMpjuyJgnUSEAsdUcpJr6