### PR TITLE
perf(ripple): checked-once-forever negative memoization for proximity notes

### DIFF
--- a/iznik-batch/app/Console/Commands/Ripple/ProximityNotesCommand.php
+++ b/iznik-batch/app/Console/Commands/Ripple/ProximityNotesCommand.php
@@ -15,9 +15,17 @@ use Illuminate\Support\Facades\Log;
  * yet have a rippling_proximity row, resolves P (nearest in-group point to the offer) and Q
  * (furthest in-group point from P) to place names, and stores them only when quicker=true.
  *
- * Idempotent (skips rows that already have a note), bounded per run (--limit), and disabled by a
- * dedicated flag (freegle.ripple.proximity_notes) so it can be turned off without touching the
- * master RIPPLE_ENABLED switch.
+ * Negative memoization (Phase 0, plans/routing-performance-step-change.md): every DEFINITIVE
+ * routing answer — note written, not quicker, or unreachable within budget — also writes a
+ * checked-once-forever marker to rippling_proximity_checked, and marked rows are excluded from
+ * future runs. Without this, "no note needed" rows (the majority) were recomputed every 5-minute
+ * run for the whole 8-day window: up to ~12 CPU-hours/day of wasted routing work (the 2026-07-06
+ * group-21521 Sentry storm's standing tax). Failed calls (PROX_ERROR: timeout/non-2xx/mid-restart)
+ * are NOT marked, so those rows retry next run.
+ *
+ * Idempotent (skips rows that already have a note or a marker), bounded per run (--limit), and
+ * disabled by a dedicated flag (freegle.ripple.proximity_notes) so it can be turned off without
+ * touching the master RIPPLE_ENABLED switch.
  */
 class ProximityNotesCommand extends Command
 {
@@ -32,16 +40,28 @@ class ProximityNotesCommand extends Command
             return Command::SUCCESS;
         }
 
-        // Rippled-in copies still inside the ripple window that have no note yet, with the origin
-        // (degrees) from the reach row. leftJoin+whereNull keeps it idempotent; the group's own
-        // posts (rippled_in=0) are excluded.
+        // Purge markers past any possible candidacy: candidates require mg.arrival within 8
+        // days, so a marker older than that can never match again. 14 days keeps a margin;
+        // cheap (indexed on checked_at). Checked-once-forever is preserved by the arrival
+        // window, not by the marker's lifetime.
+        DB::table('rippling_proximity_checked')->where('checked_at', '<', now()->subDays(14))->delete();
+
+        // Rippled-in copies still inside the ripple window that have no note yet AND no
+        // checked-once-forever marker, with the origin (degrees) from the reach row.
+        // leftJoin+whereNull keeps it idempotent; the group's own posts (rippled_in=0) are
+        // excluded. The rp join stays alongside the marker join so pre-marker note rows
+        // (written before rippling_proximity_checked existed) are still excluded.
         $rows = DB::table('messages_groups as mg')
             ->join('rippling_reach as rr', 'rr.msgid', '=', 'mg.msgid')
             ->leftJoin('rippling_proximity as rp', function ($j) {
                 $j->on('rp.msgid', '=', 'mg.msgid')->on('rp.groupid', '=', 'mg.groupid');
             })
+            ->leftJoin('rippling_proximity_checked as rpc', function ($j) {
+                $j->on('rpc.msgid', '=', 'mg.msgid')->on('rpc.groupid', '=', 'mg.groupid');
+            })
             ->where('mg.rippled_in', 1)
             ->whereNull('rp.msgid')
+            ->whereNull('rpc.msgid')
             ->where('mg.arrival', '>=', now()->subDays(8))
             ->orderByDesc('mg.arrival')
             ->limit((int) $this->option('limit'))
@@ -55,21 +75,31 @@ class ProximityNotesCommand extends Command
                 // over-exploring is pure waste and trips the slow-call Sentry warning.
                 $budget = isset($r->max_drive_min) ? (float) $r->max_drive_min : null;
                 $prox = $reach->groupProximity((float) $r->lat, (float) $r->lng, (int) $r->groupid, $budget);
-                if ($prox === null || !($prox['quicker'] ?? false)) {
-                    continue; // not quicker, or routing unreachable — no note (re-tried next run)
+                if ($prox['status'] === ReachService::PROX_ERROR) {
+                    continue; // no usable answer (routing down/mid-restart) — retry next run, never memoized
                 }
-                $p = Location::describeNearest((float) $prox['closest']['lat'], (float) $prox['closest']['lng']);
-                $q = Location::describeNearest((float) $prox['furthest']['lat'], (float) $prox['furthest']['lng']);
-                if ($p === null || $q === null) {
-                    continue;
+
+                if ($prox['status'] === ReachService::PROX_OK && ($prox['body']['quicker'] ?? false)) {
+                    $p = Location::describeNearest((float) $prox['body']['closest']['lat'], (float) $prox['body']['closest']['lng']);
+                    $q = Location::describeNearest((float) $prox['body']['furthest']['lat'], (float) $prox['body']['furthest']['lng']);
+                    if ($p === null || $q === null) {
+                        continue; // place names unavailable (KNN gap) — retry next run rather than mark half-done
+                    }
+                    DB::table('rippling_proximity')->insertOrIgnore([
+                        'msgid' => (int) $r->msgid,
+                        'groupid' => (int) $r->groupid,
+                        'p' => $p,
+                        'q' => $q,
+                    ]);
+                    $written++;
                 }
-                DB::table('rippling_proximity')->insertOrIgnore([
+
+                // Definitive outcome (note written, not quicker, or unreachable): write the
+                // checked-once-forever marker so this row is never re-queried.
+                DB::table('rippling_proximity_checked')->insertOrIgnore([
                     'msgid' => (int) $r->msgid,
                     'groupid' => (int) $r->groupid,
-                    'p' => $p,
-                    'q' => $q,
                 ]);
-                $written++;
             } catch (\Throwable $e) {
                 Log::warning("ripple: proximity note failed for msg {$r->msgid} group {$r->groupid}: {$e->getMessage()}");
             }

--- a/iznik-batch/app/Services/Ripple/ReachService.php
+++ b/iznik-batch/app/Services/Ripple/ReachService.php
@@ -21,6 +21,19 @@ use Illuminate\Support\Facades\Log;
  */
 class ReachService
 {
+    /** groupProximity() status: definitive answer; body carries closest/furthest/quicker. */
+    public const PROX_OK = 'ok';
+
+    /** groupProximity() status: definitive answer - group not reachable within the budget. */
+    public const PROX_UNREACHABLE = 'unreachable';
+
+    /**
+     * groupProximity() status: no usable answer (exception, timeout, non-2xx - e.g. the routing
+     * server mid-restart). NOT definitive: callers must retry later and never memoize this,
+     * otherwise a routing restart would permanently suppress notes for rows checked during it.
+     */
+    public const PROX_ERROR = 'error';
+
     private string $url;
     private string $curve;
     private string $mode;
@@ -145,11 +158,16 @@ class ReachService
     /**
      * P/Q proximity for a post rippling into a group: P = nearest in-group point to the offer,
      * Q = the in-group point furthest FROM P, each with road drive-time. Backs the moderator
-     * "quicker to get to" line. Returns null on any failure/unreachable (never throws).
+     * "quicker to get to" line. Never throws.
      *
-     * @return array{closest:array{lat:float,lng:float,drive_min:float},furthest:array{lat:float,lng:float,drive_min:float},quicker:bool}|null
+     * Tri-state so callers can tell a definitive "no" (safe to memoize checked-once-forever)
+     * from a failed call (must retry): PROX_OK carries the routing body, PROX_UNREACHABLE means
+     * the routing server answered that the group is beyond the budget, PROX_ERROR means no
+     * usable answer was obtained (timeout/non-2xx/exception) and nothing may be memoized.
+     *
+     * @return array{status:string, body:?array{closest:array{lat:float,lng:float,drive_min:float},furthest:array{lat:float,lng:float,drive_min:float},quicker:bool}}
      */
-    public function groupProximity(float $lat, float $lng, int $groupid, ?float $maxMinutes = null): ?array
+    public function groupProximity(float $lat, float $lng, int $groupid, ?float $maxMinutes = null): array
     {
         // Best-effort moderator note, computed OUT of the hot ripple:expand cron (by the
         // ripple:proximity-notes command), so a slacker timeout is fine here. Slow or failed calls
@@ -175,22 +193,22 @@ class ReachService
                 ->get("{$this->url}/v1/group-proximity", $query);
         } catch (\Throwable $e) {
             $this->reportProximityTiming($groupid, (microtime(true) - $started) * 1000, $e->getMessage());
-            return null;
+            return ['status' => self::PROX_ERROR, 'body' => null];
         }
 
         $elapsedMs = (microtime(true) - $started) * 1000;
         if (!$response->successful()) {
             $this->reportProximityTiming($groupid, $elapsedMs, "HTTP {$response->status()}");
-            return null;
+            return ['status' => self::PROX_ERROR, 'body' => null];
         }
         $this->reportProximityTiming($groupid, $elapsedMs, null);
 
         $body = $response->json() ?? [];
         if (!($body['reachable'] ?? false)) {
-            return null;
+            return ['status' => self::PROX_UNREACHABLE, 'body' => null];
         }
 
-        return $body;
+        return ['status' => self::PROX_OK, 'body' => $body];
     }
 
     /**

--- a/iznik-batch/database/migrations/2026_07_07_000002_create_rippling_proximity_checked_table.php
+++ b/iznik-batch/database/migrations/2026_07_07_000002_create_rippling_proximity_checked_table.php
@@ -1,0 +1,55 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * rippling_proximity_checked — checked-once-forever negative-memoization marker for
+ * ripple:proximity-notes (Phase 0 of plans/routing-performance-step-change.md). A row means this
+ * (msgid, groupid) rippled-in copy got a DEFINITIVE proximity answer (note written, not quicker,
+ * or unreachable within budget) and is never re-queried. Without it, "no note needed" rows were
+ * recomputed on every 5-minute run for the whole 8-day candidate window — up to ~12 CPU-hours/day
+ * of routing work re-deriving already-known answers (2026-07-06 Sentry storm, group 21521).
+ *
+ * Deliberately a separate marker table rather than nullable p/q columns on rippling_proximity:
+ * iznik-server-go reads rippling_proximity and scans p/q as non-null strings. Failed calls
+ * (timeout, non-2xx, routing server mid-restart) are NOT marked, so those rows retry next run.
+ *
+ * The command purges rows older than 14 days: candidates require mg.arrival within 8 days, so a
+ * marker past that window can never match a candidate again — "checked once, forever" is
+ * guaranteed by the arrival window, not by keeping the marker around.
+ */
+return new class extends Migration {
+    public function up(): void
+    {
+        if (Schema::hasTable('rippling_proximity_checked')) {
+            return;
+        }
+
+        Schema::create('rippling_proximity_checked', function (Blueprint $t) {
+            $t->unsignedBigInteger('msgid');
+            $t->unsignedBigInteger('groupid');
+            $t->timestamp('checked_at')->useCurrent();
+            $t->primary(['msgid', 'groupid']);
+            $t->index('checked_at');
+        });
+
+        DB::statement(
+            'ALTER TABLE rippling_proximity_checked
+                ADD CONSTRAINT rippling_proximity_checked_msgid_foreign
+                FOREIGN KEY (msgid) REFERENCES messages (id) ON DELETE CASCADE'
+        );
+        DB::statement(
+            'ALTER TABLE rippling_proximity_checked
+                ADD CONSTRAINT rippling_proximity_checked_groupid_foreign
+                FOREIGN KEY (groupid) REFERENCES `groups` (id) ON DELETE CASCADE'
+        );
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('rippling_proximity_checked');
+    }
+};

--- a/iznik-batch/database/migrations/2026_07_07_000002_create_rippling_proximity_checked_table_migration.sql
+++ b/iznik-batch/database/migrations/2026_07_07_000002_create_rippling_proximity_checked_table_migration.sql
@@ -1,0 +1,22 @@
+-- Idempotent production SQL for 2026_07_07_000002_create_rippling_proximity_checked_table.php
+--
+-- Checked-once-forever negative-memoization marker for ripple:proximity-notes (Phase 0 of
+-- plans/routing-performance-step-change.md). A row means the (msgid, groupid) rippled-in copy got
+-- a definitive proximity answer (note written, not quicker, or unreachable within budget) and is
+-- never re-queried; failed routing calls are NOT marked and retry next run. The command purges
+-- rows older than 14 days (candidates only span 8 days of arrivals).
+--
+-- Safe to run multiple times: CREATE TABLE IF NOT EXISTS. Run before deploying the updated
+-- ripple:proximity-notes command (it INSERTs into this table).
+
+CREATE TABLE IF NOT EXISTS rippling_proximity_checked (
+    msgid      BIGINT UNSIGNED NOT NULL,
+    groupid    BIGINT UNSIGNED NOT NULL,
+    checked_at TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (msgid, groupid),
+    INDEX rippling_proximity_checked_checked_at_index (checked_at),
+    CONSTRAINT rippling_proximity_checked_msgid_foreign FOREIGN KEY (msgid)
+        REFERENCES messages (id) ON DELETE CASCADE,
+    CONSTRAINT rippling_proximity_checked_groupid_foreign FOREIGN KEY (groupid)
+        REFERENCES `groups` (id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/iznik-batch/tests/Unit/Services/Ripple/ExpandServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/Ripple/ExpandServiceTest.php
@@ -910,6 +910,10 @@ class ExpandServiceTest extends TestCase
             $this->assertNotNull($note, 'proximity note written for the rippled-in copy');
             $this->assertSame('AB10 1XG (Gilcomston)', $note->p);
             $this->assertSame('AB11 5QN (Aberdeen)', $note->q);
+            $this->assertNotNull(
+                DB::table('rippling_proximity_checked')->where('msgid', $msgid)->where('groupid', $groupB->id)->first(),
+                'noted row is also marked checked'
+            );
         } finally {
             $this->removeSpatial('postcodes', [$pId, $qId]);
             DB::table('locations')->whereIn('id', [$pId, $qId, $pAreaId, $qAreaId])->delete();
@@ -986,6 +990,140 @@ class ExpandServiceTest extends TestCase
 
         $this->assertNull(
             DB::table('rippling_proximity')->where('msgid', $msgid)->where('groupid', $groupB->id)->first()
+        );
+    }
+
+    /** Count of /v1/group-proximity requests recorded by Http::fake so far. */
+    private function proximityRequestCount(): int
+    {
+        return Http::recorded(fn ($req) => str_contains($req->url(), 'group-proximity'))->count();
+    }
+
+    /**
+     * Negative memoization (Phase 0, plans/routing-performance-step-change.md): a definitive
+     * "not quicker" answer writes a rippling_proximity_checked marker, so the row is never
+     * re-queried. Previously these rows were recomputed on every 5-minute run for the whole
+     * 8-day candidate window (the 2026-07-06 group-21521 Sentry storm's standing tax).
+     */
+    public function test_proximity_not_quicker_writes_marker_and_is_never_rechecked(): void
+    {
+        $this->fakeRouting(1);
+        $this->fakeGroupProximity(true, false, 58.0, 1.0, 58.5, 1.5);
+        $msgid = $this->seedSpatialPost(now()->subMinutes(30));
+        $groupB = $this->createTestGroup();
+        DB::statement(
+            "UPDATE `groups` SET publish = 1, polyindex = ST_GeomFromText(?, ?) WHERE id = ?",
+            ['POLYGON((-0.18 51.52,-0.12 51.52,-0.12 51.58,-0.18 51.58,-0.18 51.52))', 3857, $groupB->id]
+        );
+
+        $this->service()->process(false, 500);
+        $this->artisan('ripple:proximity-notes')->assertExitCode(0);
+
+        $this->assertNull(
+            DB::table('rippling_proximity')->where('msgid', $msgid)->where('groupid', $groupB->id)->first(),
+            'not quicker - no note'
+        );
+        $this->assertNotNull(
+            DB::table('rippling_proximity_checked')->where('msgid', $msgid)->where('groupid', $groupB->id)->first(),
+            'definitive not-quicker answer - checked marker written'
+        );
+
+        $before = $this->proximityRequestCount();
+        $this->artisan('ripple:proximity-notes')->assertExitCode(0);
+        $this->assertSame(
+            $before,
+            $this->proximityRequestCount(),
+            'marked row must not be re-queried on subsequent runs'
+        );
+    }
+
+    /**
+     * A definitive "unreachable within budget" answer (HTTP 200, reachable=false) is also
+     * memoized: marker written, no re-query on later runs.
+     */
+    public function test_proximity_unreachable_writes_marker_and_is_never_rechecked(): void
+    {
+        $this->fakeRouting(1);
+        $this->fakeGroupProximity(false);
+        $msgid = $this->seedSpatialPost(now()->subMinutes(30));
+        $groupB = $this->createTestGroup();
+        DB::statement(
+            "UPDATE `groups` SET publish = 1, polyindex = ST_GeomFromText(?, ?) WHERE id = ?",
+            ['POLYGON((-0.18 51.52,-0.12 51.52,-0.12 51.58,-0.18 51.58,-0.18 51.52))', 3857, $groupB->id]
+        );
+
+        $this->service()->process(false, 500);
+        $this->artisan('ripple:proximity-notes')->assertExitCode(0);
+
+        $this->assertNotNull(
+            DB::table('rippling_proximity_checked')->where('msgid', $msgid)->where('groupid', $groupB->id)->first(),
+            'definitive unreachable answer - checked marker written'
+        );
+
+        $before = $this->proximityRequestCount();
+        $this->artisan('ripple:proximity-notes')->assertExitCode(0);
+        $this->assertSame($before, $this->proximityRequestCount(), 'unreachable row not re-queried');
+    }
+
+    /**
+     * An HTTP failure is NOT a definitive answer: no marker may be written (else a routing
+     * restart would permanently suppress notes for whatever rows were checked during it),
+     * and the row IS re-queried on the next run.
+     */
+    public function test_proximity_http_failure_writes_no_marker_and_is_retried(): void
+    {
+        $this->fakeRouting(1);
+        $this->fakeGroupProximity(true, status: 500);
+        $msgid = $this->seedSpatialPost(now()->subMinutes(30));
+        $groupB = $this->createTestGroup();
+        DB::statement(
+            "UPDATE `groups` SET publish = 1, polyindex = ST_GeomFromText(?, ?) WHERE id = ?",
+            ['POLYGON((-0.18 51.52,-0.12 51.52,-0.12 51.58,-0.18 51.58,-0.18 51.52))', 3857, $groupB->id]
+        );
+
+        $this->service()->process(false, 500);
+        $this->artisan('ripple:proximity-notes')->assertExitCode(0);
+
+        $this->assertNull(
+            DB::table('rippling_proximity_checked')->where('msgid', $msgid)->where('groupid', $groupB->id)->first(),
+            'HTTP failure is not definitive - no marker'
+        );
+
+        $before = $this->proximityRequestCount();
+        $this->artisan('ripple:proximity-notes')->assertExitCode(0);
+        $this->assertSame(
+            $before + 1,
+            $this->proximityRequestCount(),
+            'failed row is retried on the next run'
+        );
+    }
+
+    /**
+     * Markers older than the candidate window are purged by the command (candidates require
+     * mg.arrival within 8 days, so a 14-day-old marker can never be needed again); fresh
+     * markers are kept.
+     */
+    public function test_proximity_marker_purge_removes_only_expired_rows(): void
+    {
+        $this->fakeRouting(1);
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $oldMsg = $this->createTestMessage($user, $group);
+        $freshMsg = $this->createTestMessage($user, $group);
+        DB::table('rippling_proximity_checked')->insert([
+            ['msgid' => $oldMsg->id, 'groupid' => $group->id, 'checked_at' => now()->subDays(20)],
+            ['msgid' => $freshMsg->id, 'groupid' => $group->id, 'checked_at' => now()->subDays(2)],
+        ]);
+
+        $this->artisan('ripple:proximity-notes')->assertExitCode(0);
+
+        $this->assertNull(
+            DB::table('rippling_proximity_checked')->where('msgid', $oldMsg->id)->first(),
+            'marker past the candidate window is purged'
+        );
+        $this->assertNotNull(
+            DB::table('rippling_proximity_checked')->where('msgid', $freshMsg->id)->first(),
+            'recent marker is kept'
         );
     }
 

--- a/plans/routing-performance-step-change.md
+++ b/plans/routing-performance-step-change.md
@@ -1,0 +1,187 @@
+# Routing / isochrone performance: step-change design
+
+**Date:** 2026-07-07
+**Status:** DESIGN ONLY - nothing implemented. Produced by a multi-agent design study
+(4 survey agents, 6 design angles, adversarial review of each, synthesis).
+**Scope:** iznik-routing-go (the routing/isochrone server) and its batch callers
+(iznik-batch ripple crons). Goal: a step change in steady-state efficiency; startup
+secondary.
+
+---
+
+## 1. Measured ground truth
+
+All numbers measured this session against the real UK graph unless marked otherwise.
+
+**Graph** (built from uk-latest.osm.pbf on every process start, no cache):
+- 56,874,451 nodes / 117,157,737 directed edges; average out-degree 2.06.
+- Nodes are ALL OSM way nodes: 77.9% are degree-2 geometry pass-throughs.
+- Drive-usable edges: 59.2%. One 26.46M-node connected drive component (46.5% of N);
+  most of the rest is footway/cycleway-only geometry. Orkney is a genuine separate
+  42k-node component (any component pruning must be size-thresholded).
+- Build time ~90-98s on a 24-core box; 5-16 min observed on prod/dev under load.
+
+**Isochrone engine** (`dijkstra.go`): plain bounded Dijkstra, `dist` is a
+`map[NodeID]float32`, heap items are individually allocated pointers, and there is a
+haversine call per edge relaxation.
+- London 30-min drive: 377,947 nodes reached in ~286-310ms.
+- London 120-min drive: 7,334,766 nodes in ~12.05-12.55s (44x time for 19x nodes -
+  superlinear, the map degrades as it grows).
+- pprof shares of Isochrone CPU: map ops 16.8% (30-min) rising to 28.4% (120-min);
+  heap 17.4% / 10.3%; haversine ~6%; EdgesFrom CSR access 17.9% / 9.2%.
+
+**The decisive finding - the sweep is NOT the hot endpoint's main cost.**
+`handleRippleSchedule` Step 3 (ripple.go:424 area) calls `nearestNodeForMode` once per
+candidate freegler in the reach bbox with NO location dedup (`snapMembers` right next to
+it DOES dedup). Measured 74-184µs per snap:
+- 10k candidate freeglers -> ~1.8s; 50k -> ~9.2s. Versus 280-676ms for the whole
+  Dijkstra sweep of the same call.
+
+**Recomputation waste (workload analysis):**
+- `ripple:proximity-notes` (every 5 min, limit 200): a `rippling_proximity` row is only
+  written when `quicker=true`, so "not quicker / unreachable" rows are re-checked every
+  run for the full 8-day window. Standing tax ceiling: 200 rows x ~754ms x 288 runs/day
+  ~= **12 CPU-hours/day**. (The 2026-07-06 Sentry storm - 4282 slow-call warnings from
+  group 21521 - was this plus the missing max_minutes budget; the budget fix is already
+  in the working tree.)
+- `ripple:expand` (every minute): tick geometry is fetched per post per tick via live
+  `/v1/catchment` (one Dijkstra + one rasterise each), ~185 calls/min. The numeric
+  schedule is origin-deduped (2.6x); the geometry is not. A fully-expanding post pays
+  9 Dijkstras for one deterministic isochrone.
+- Server has essentially no caching: the only cache anywhere is `activesCache`
+  (group_actives.go, 1h TTL). Group seeds (`groupSeedNodes`: DB fetch + WKT parse +
+  nearest-node snap per polygon vertex) are recomputed on every group-proximity /
+  group-extent / catchment?groupid call.
+
+---
+
+## 2. Recommended program (phases are independently shippable, in priority order)
+
+### Phase 0 - negative memoization for proximity notes (Laravel, ~2-3 days)
+- New marker table `rippling_proximity_checked (msgid, groupid, checked_at)` written on
+  EVERY definitive check ("quicker" or "genuinely not quicker / unreachable").
+  NOT nullable columns on `rippling_proximity`: iznik-server-go/message/message.go scans
+  p/q as non-null and would break.
+- Widen `ReachService::groupProximity` to a tri-state: quicker / genuinely-no /
+  transient-failure (HTTP error, timeout, routing server mid-restart). Only definitive
+  results are memoized; transient failures retry next run. Without this, a routing
+  restart would permanently suppress notes for whatever rows were in flight.
+- Effect: ~12 CPU-hr/day recurring -> one-time backlog drain (~15 min), then organic
+  new-row volume only.
+
+### Phase 1 - dedup/cache the freegler snap loop (Go, ~2-3 days)
+- In `handleRippleSchedule` Step 3 and `handleRippleEval`: dedup candidate freegler
+  locations before snapping (mirror `snapMembers`' per-request nodeCache), and consider
+  a small LRU keyed by quantized (lat,lng,mode) across requests.
+- Biggest wall-clock win available on the hottest endpoint; trivial risk.
+- (Optional follow-up: persist snapped NodeID per user approx-location, invalidated on
+  graph rebuild - only if the LRU proves insufficient.)
+
+### Phase 2 - flat-epoch Dijkstra core (Go, ~1 week)
+- Replace `map[NodeID]float32` with pooled per-call buffers of
+  `struct{cost float32; epoch uint32}` sized N+1 (455MB per buffer; pool bounded to
+  concurrency). Epoch bump = O(1) reset, no clearing.
+- Allocation-free index-based heap (no per-push pointer allocs).
+- Replace per-edge haversine prune with a safety-margined squared-equirectangular test.
+- Apply to ALL FOUR sweep implementations - `Isochrone` (dijkstra.go), `costToTargets`
+  (proximity.go), `multiSourceIsochrone` (catchment.go), and the inline copy in
+  `FairnessIsochrone` (fairness.go) - unifying them behind one engine type.
+- Projected from live pprof decomposition: 1.46x at 30-min, 1.57x at 120-min; gains
+  grow exactly where the 3000ms Sentry threshold bites (large/dense sweeps).
+
+### Phase 3 - never compute the same isochrone twice (Go + minor batch, ~1-2 weeks)
+- In-process superset cache keyed by (snapped origin NodeID, mode): store the largest
+  reached-set computed for that origin; serve any smaller budget by filtering. Extend to
+  memoize the fine-resolution `/v1/catchment` polygon per exact tick budget. Kills 8 of
+  9 Dijkstra+rasterise calls per fully-expanding post and collapses the ~185/min tick
+  geometry churn to one computation per distinct origin. Zero change to what is stored
+  in `rippling_reach.polygon` (three live exact consumers depend on it - see rejected
+  designs).
+- Group-seed / group-diameter TTL cache keyed (groupid, mode), same pattern as the
+  existing `activesCache`. Shared by /v1/group-proximity, /v1/group-extent,
+  /v1/catchment?groupid.
+- Diff-test cached vs fresh responses on fixed probes before enabling by default.
+
+### Phase 4 - weak-component fix for disconnected snapping (Go, ~2-3 days)
+- Build-time union-find over undirected adjacency (NOT directed SCC - Kosaraju/Tarjan
+  would fragment one-way-heavy urban gyratories), size-thresholded so genuine islands
+  (Orkney, IoW, IoM) stay separately routable.
+- `nearestNodeForMode` prefers nodes in a sufficiently large component: fixes the
+  known blurOrigin-snaps-to-disconnected-island -> empty isochrone bug.
+
+### Phase 5 - mmap graph snapshot (opportunistic, ~1 week)
+- Serialize the built CSR (+ grid + component labels) to a versioned snapshot at
+  OSM-refresh time; on start, mmap and validate, else fall back to PBF build.
+- Restart: 5-16 min -> seconds. Eliminates the monit rebuild-loop outage class
+  entirely. Startup was declared secondary, but this is cheap, independent, and
+  removes a whole failure mode.
+
+**Rough sequencing:** 0 and 1 in parallel first (both small, immediate production
+relief), then 2, then 3, then 4/5 as capacity allows. Total ~4-6 engineer-weeks.
+
+---
+
+## 3. Evaluated and NOT adopted
+
+**Junction-graph contraction (deferred, revisit after Phases 1-3 + production data).**
+Collapsing degree-2 chains to a junction-only graph is genuinely attractive on paper and
+was measured properly: 12,899,893 junctions (22.68% of N) using a corrected per-mode
+junction rule (a naive any-mode rule undercounts - 523,929 nodes have any-mode degree 2
+but are genuine per-mode branch points because way usability differs per mode);
+16.1M contracted chain edges (26.8% of unique undirected edges); contraction build pass
+~7.5s measured. But the adversarial review rated it weak FOR NOW:
+- Wrong denominator: after Phase 1, the sweep is a minority of the hot endpoint's cost;
+  a perfect 2.9x sweep speedup moves /v1/ripple-schedule end-to-end by only ~2-30%.
+- polygon.go rasterisation and NetworkResolution call `g.EdgesFrom(u)` on every reached
+  node - absorbed nodes need synthesized adjacency or the old CSR stays resident
+  (breaking the memory claims).
+- Four sweep implementations to port; chain breaks needed at every oneway transition,
+  per-node quintile fidelity for fairness, pathMetres exactness, max-reach pruning per
+  absorbed node - a large correctness surface.
+If revisited: only for the polygon-heavy endpoints (/v1/catchment, /v1/fairness,
+/v1/digest-simulator, /v1/posts-for-member), with lazy expansion (junction-only sweep +
+O(1) point lookups via a NodeID->(chain,offset) table) for the point-lookup endpoints.
+
+**CH / PHAST / CRP preprocessing:** not justified for 30-120 min regional bounded
+isochrones at this scale; the win over a well-implemented flat-array Dijkstra does not
+cover the preprocessing complexity and memory.
+
+**REJECTED - verified would-be bugs:**
+- Replacing groupProximity's first sweep with a per-group forward multi-source distance
+  field: directionally wrong on one-way streets (forward-from-seeds is not
+  time-TO-seeds). Any batching of that path needs a reverse-CSR sweep instead.
+- Replacing `rippling_reach.polygon` with coarse grid cells: the column is read by three
+  live exact consumers with no compensating check - browse-feed ST_Contains, the
+  chat-reply hard 403 "not_in_reach" gate, and reachBlocked flagging.
+
+**Deferred (real but lower value now):**
+- Reverse-CSR multi-source batching of proximity notes (one sweep per group settling all
+  pending posts): mathematically sound (edge costs are direction-symmetric per way, so
+  From/To swap is exact), but Phase 0 shrinks day-to-day volume so far that this becomes
+  backlog-surge insurance. Revisit only if post-Phase-0 telemetry says so.
+- Spatial (Hilbert/BFS) node renumbering and per-mode compact graphs: literature-derived
+  multipliers only; gate behind on-box perf measurement after Phase 2 ships.
+
+---
+
+## 4. Open questions (maintainer decisions)
+
+1. **Tombstone retry policy:** should a definitive "unreachable" ever be retried within
+   the 8-day window (e.g. after an OSM graph rebuild), or is checked-once-forever fine?
+2. **Group-seed cache invalidation:** TTL-only (matches activesCache precedent) or a
+   ModTools group-boundary-save hook?
+3. **RAM budget:** pooled flat buffers (Phase 2) + superset cache (Phase 3) add real RSS
+   on db1/2/3 - set explicit byte ceilings before rollout.
+4. **rippling_reach.polygon future:** harden the three exact consumers with a
+   compensating check now (opening the door to cheaper geometry later), or accept
+   fine-resolution-forever?
+
+---
+
+## 5. Artifacts
+
+- Full design/verdict JSON, survey reports, synthesis: session scratchpad
+  (`synthesis.md`, `designs.json`, `surveys.txt`); workflow run `wf_737eba3c-5cf`.
+- Baseline timings taken against the local full-UK instance (spatial-live):
+  catchment 30-min Manchester ~1.7s vs 10-min ~85ms; ripple-schedule 30-min slim ~2.0s;
+  group-proximity 21521 ~1.1-1.6s.


### PR DESCRIPTION
## Summary

- `ripple:proximity-notes` re-computed "not quicker" / "unreachable" rows on every 5-minute run for the whole 8-day candidate window, because a `rippling_proximity` row is only written when `quicker=true`. For the 2026-07-06 group-21521 Sentry storm that was 406 of 635 rows recomputed forever - a standing tax of up to ~12 CPU-hours/day of routing work (200-row cap x ~754ms x 288 runs/day).
- New `rippling_proximity_checked` marker table (Laravel migration + idempotent production SQL): a row means this (msgid, groupid) rippled-in copy got a **definitive** answer and is never re-queried. A separate table rather than nullable p/q columns because iznik-server-go scans `rippling_proximity.p/q` as non-null strings.
- `ReachService::groupProximity` widened to a tri-state (`PROX_OK` / `PROX_UNREACHABLE` / `PROX_ERROR`): failed calls (timeout, non-2xx, exception - e.g. the routing server mid-PBF-rebuild) are never memoized and retry next run, so a routing restart cannot permanently suppress notes.
- The command excludes marked rows (keeping the existing note-row exclusion for pre-marker rows), writes the marker only on definitive outcomes (note written / not quicker / unreachable - not on geocode gaps), and purges markers older than 14 days (candidates only span 8 days of arrivals, so checked-once-forever still holds while the table stays small).
- Includes `plans/routing-performance-step-change.md` - the full routing/isochrone performance design study this is Phase 0 of.

## Code Quality Review

- Tri-state contract documented on the constants and method; the only caller is `ProximityNotesCommand` (verified by grep across the monorepo).
- Marker writes use `insertOrIgnore` inside the existing per-row try/catch, so a mid-run failure degrades to "retry next run", never to a wrong tombstone.
- Purge is a single indexed DELETE per run (`checked_at` index) and can never expire a marker that could still match a candidate (14d > 8d arrival window).
- FKs cascade with messages/groups, mirroring `rippling_proximity`.

## Future Improvements

Later phases of the design study (see the plan doc): dedup the per-freegler nearest-node loop in the routing server's `/v1/ripple-schedule` (measured as the real hot-path cost), flat-epoch Dijkstra core, superset isochrone caching, weak-component snap fix, mmap graph snapshot.

## Test Plan

- Red-first TDD: the 4 new tests + 1 extended assertion failed before the implementation (verified), pass after.
- New tests in `ExpandServiceTest`: marker on not-quicker + never re-queried (HTTP request count is flat across runs); marker on unreachable + never re-queried; **no** marker on HTTP 500 and the row IS retried (request count grows); purge removes only expired markers; quicker path writes note + marker.
- Full Laravel suite via the status API: **4751 tests passed** (includes fresh `migrate:fresh` exercising the new migration).