### PR TITLE
fix(chitchat): bubble rendered events from depth 2+ replies so deep-links can scroll to nested replies

### DIFF
--- a/iznik-nuxt3/components/NewsReply.vue
+++ b/iznik-nuxt3/components/NewsReply.vue
@@ -170,6 +170,9 @@
         </div>
       </div>
     </div>
+    <!-- Forward rendered events from nested replies: without this the
+         notification deep-link scroll in NewsThread never hears about
+         depth 2+ replies mounting. -->
     <NewsReplies
       v-if="reply?.replies?.length"
       :id="id"
@@ -177,6 +180,7 @@
       :scroll-to="scrollTo"
       :reply-to="reply.id"
       :depth="depth + 1"
+      @rendered="$emit('rendered', $event)"
     />
     <div v-if="showReplyBox" class="mb-2 pb-1 ms-4">
       <div v-if="enterNewLine" class="w-100">

--- a/iznik-nuxt3/tests/unit/components/NewsReply.spec.js
+++ b/iznik-nuxt3/tests/unit/components/NewsReply.spec.js
@@ -212,6 +212,7 @@ describe('NewsReply', () => {
           NewsReplies: {
             template: '<div class="news-replies"></div>',
             props: ['id', 'threadhead', 'scrollTo', 'replyTo', 'depth'],
+            emits: ['rendered'],
           },
           OurUploader: {
             template: '<div class="our-uploader"></div>',
@@ -539,6 +540,21 @@ describe('NewsReply', () => {
       const wrapper = createWrapper()
       expect(wrapper.emitted('rendered')).toBeTruthy()
       expect(wrapper.emitted('rendered')[0]).toEqual([100])
+    })
+
+    it('forwards rendered events from nested replies (depth 2+)', async () => {
+      // A reply with sub-replies renders a nested <NewsReplies>. Its
+      // rendered events must bubble through this component, otherwise
+      // NewsThread never hears about depth 2+ replies mounting and the
+      // notification deep-link scroll can't target them.
+      const withNested = { ...mockReply, replies: [{ id: 456 }] }
+      const wrapper = createWrapper({}, withNested)
+      const nested = wrapper.findComponent('.news-replies')
+      expect(nested.exists()).toBe(true)
+      nested.vm.$emit('rendered', 456)
+      await flushPromises()
+      const events = wrapper.emitted('rendered')
+      expect(events.some(([id]) => id === 456)).toBe(true)
     })
   })
 


### PR DESCRIPTION
## What

Notification deep-links (`/chitchat/{replyid}`) scroll to the target reply when NewsThread hears a `rendered(id)` event for it. `NewsReplies` forwards these events from each `NewsReply`, but the nested `<NewsReplies>` inside `NewsReply.vue` had no `@rendered` listener, so events from depth 2+ replies were lost at that boundary: deep-links to nested replies got the `bg-info` highlight but never auto-scrolled.

This forwards the event up the chain (`@rendered="$emit('rendered', $event)"`), which recursively covers any nesting depth.

## Why depth 1 already worked

The common case - a notification for a direct reply - is depth 1, where the `NewsReplies → NewsThread` hop already existed. This was verified working during the PR 988 checks; the depth 2+ gap was found in the same verification.

## Test

New unit test mounts `NewsReply` with a sub-reply so the nested `<NewsReplies>` renders, emits `rendered` from it, and asserts the event re-emits from the component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)