### PR TITLE
fix(modtools): Release/Approve must ignore holds on deleted group rows

### DIFF
--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -2015,10 +2015,13 @@ func handleApprove(c *fiber.Ctx, myid uint64, req PostMessageRequest) error {
 	db.Exec("UPDATE messages_groups SET heldby = NULL WHERE msgid = ? AND groupid IN ?", req.ID, authorizedGroups)
 
 	// Check if still held on any group — if not, clear messages.heldby for backwards compat.
+	// Only live rows count: a soft-deleted messages_groups row (e.g. a crosspost copy the
+	// member withdrew) can still carry a stale heldby, and without the deleted = 0 filter it
+	// would pin messages.heldby forever, leaving the message stuck showing "Held".
 	// Pin to the write host: this gates a cascade on rows we just UPDATEd, so it must
 	// read the source rather than a possibly-lagging replica.
 	var stillHeldCount int64
-	db.Clauses(dbresolver.Write).Raw("SELECT COUNT(*) FROM messages_groups WHERE msgid = ? AND heldby IS NOT NULL", req.ID).Scan(&stillHeldCount)
+	db.Clauses(dbresolver.Write).Raw("SELECT COUNT(*) FROM messages_groups WHERE msgid = ? AND heldby IS NOT NULL AND deleted = 0", req.ID).Scan(&stillHeldCount)
 	if stillHeldCount == 0 {
 		db.Exec("UPDATE messages SET heldby = NULL WHERE id = ?", req.ID)
 	}
@@ -2468,10 +2471,13 @@ func handleRelease(c *fiber.Ctx, myid uint64, req PostMessageRequest) error {
 	db.Exec("UPDATE messages_groups SET heldby = NULL WHERE msgid = ? AND groupid IN ?", req.ID, authorizedGroups)
 
 	// Check if still held on any group — if not, clear messages.heldby for backwards compat.
+	// Only live rows count: a soft-deleted messages_groups row (e.g. a crosspost copy the
+	// member withdrew) can still carry a stale heldby, and without the deleted = 0 filter it
+	// would pin messages.heldby forever, leaving the message stuck showing "Held".
 	// Pin to the write host: this gates a cascade on rows we just UPDATEd, so it must
 	// read the source rather than a possibly-lagging replica.
 	var stillHeldCount int64
-	db.Clauses(dbresolver.Write).Raw("SELECT COUNT(*) FROM messages_groups WHERE msgid = ? AND heldby IS NOT NULL", req.ID).Scan(&stillHeldCount)
+	db.Clauses(dbresolver.Write).Raw("SELECT COUNT(*) FROM messages_groups WHERE msgid = ? AND heldby IS NOT NULL AND deleted = 0", req.ID).Scan(&stillHeldCount)
 	if stillHeldCount == 0 {
 		db.Exec("UPDATE messages SET heldby = NULL WHERE id = ?", req.ID)
 	}

--- a/iznik-server-go/test/message_test.go
+++ b/iznik-server-go/test/message_test.go
@@ -7967,6 +7967,53 @@ func TestPostMessageReleasePerGroupClearsMessageWhenLastGroup(t *testing.T) {
 	assert.Nil(t, msgHeldby)
 }
 
+// Regression: a soft-deleted crosspost copy that still carries a stale heldby (e.g. the
+// member withdrew the message from another group while it was held there) must NOT keep
+// messages.heldby pinned. Before the fix, the "still held on any group?" count ignored
+// deleted rows, so Release returned Success but the message stayed stuck showing "Held"
+// and no number of retries could clear it. See prod msg 120888286 ("Fob Watch").
+func TestPostMessageReleaseIgnoresDeletedGroupHold(t *testing.T) {
+	prefix := uniquePrefix("rel_deleted_hold")
+	db := database.DBConn
+
+	groupA := CreateTestGroup(t, prefix+"_a") // live group the mod moderates
+	groupB := CreateTestGroup(t, prefix+"_b") // withdrawn crosspost copy, still held
+	posterID := CreateTestUser(t, prefix+"_poster", "User")
+	modID := CreateTestUser(t, prefix+"_mod", "User")
+	otherModID := CreateTestUser(t, prefix+"_othermod", "User")
+	CreateTestMembership(t, posterID, groupA, "Member")
+	CreateTestMembership(t, modID, groupA, "Moderator")
+	_, modToken := CreateTestSession(t, modID)
+
+	msgID := createPendingMessage(t, posterID, groupA, prefix)
+
+	// Orphaned hold: a soft-deleted messages_groups row on groupB still carrying heldby,
+	// set by a mod (otherModID) on a group our releasing mod has no rights to.
+	db.Exec("INSERT INTO messages_groups (msgid, groupid, arrival, collection, autoreposts, heldby, deleted) VALUES (?, ?, NOW(), 'Pending', 0, ?, 1)", msgID, groupB, otherModID)
+	// The message-level hold that mirrors it (as handleHold would have set).
+	db.Exec("UPDATE messages SET heldby = ? WHERE id = ?", otherModID, msgID)
+
+	// Release on the live group.
+	body := map[string]interface{}{
+		"id":      msgID,
+		"action":  "Release",
+		"groupid": groupA,
+	}
+	bodyBytes, _ := json.Marshal(body)
+	url2 := fmt.Sprintf("/api/message?jwt=%s", modToken)
+	req2 := httptest.NewRequest("POST", url2, bytes.NewBuffer(bodyBytes))
+	req2.Header.Set("Content-Type", "application/json")
+	resp2, err2 := getApp().Test(req2)
+	assert.NoError(t, err2)
+	assert.Equal(t, 200, resp2.StatusCode)
+
+	// messages.heldby must be cleared: the only row that still holds it is soft-deleted,
+	// so it must not count towards "still held".
+	var msgHeldby *uint64
+	db.Raw("SELECT heldby FROM messages WHERE id = ?", msgID).Scan(&msgHeldby)
+	assert.Nil(t, msgHeldby, "deleted group's stale hold must not keep messages.heldby pinned")
+}
+
 func TestPostMessageDeletePerGroup(t *testing.T) {
 	prefix := uniquePrefix("del_pg")
 	db := database.DBConn


### PR DESCRIPTION
## Problem

Moderators could not release/clear a "Held" message no matter how many times they tried. The Release API returned `Success` (`ret:0`) each time, but the message stayed flagged **Held** in ModTools.

Observed on prod msg **120888286** ("OFFER: Fob Watch", Barnet EN5). It had been crossposted to ~20 groups; every copy was later removed (`deleted=1`) except the live Barnet origin. One removed copy — on **Hertford Freegle** — still carried `heldby` (a Hertford mod held it before the member withdrew it there).

## Root cause

`handleRelease` (and the Approve path) decide whether to clear message-level `messages.heldby` with:

```sql
SELECT COUNT(*) FROM messages_groups WHERE msgid = ? AND heldby IS NOT NULL
```

with **no `deleted = 0` filter**. The orphaned soft-deleted Hertford row counted → the code concluded "still held somewhere" → `messages.heldby` was never cleared → the message was permanently stuck showing "Held", un-releasable.

## Fix

Add `AND deleted = 0` to both still-held count queries (`iznik-server-go/message/message.go`, `handleRelease` ~line 2474 and the Approve path ~line 2021) so only live group rows gate the clear. Adds a regression test (`TestPostMessageReleaseIgnoresDeletedGroupHold`) reproducing the orphaned deleted-row hold.

The mod work-count queries in `session.go` already filter `deleted = 0`, so badge counts were unaffected — this was isolated to the release/approve hold-clearing logic.

## Backfill

6 messages are currently stuck in a live Pending queue with a phantom hold; these are being cleared with per-row `UPDATE messages SET heldby = NULL WHERE id = ?` (Galera-safe, one at a time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)