### PR TITLE
feat(modtools): colour group-select work counts red (active) / blue (backup)

### DIFF
--- a/iznik-nuxt3/modtools/components/ModGroupSelect.vue
+++ b/iznik-nuxt3/modtools/components/ModGroupSelect.vue
@@ -6,13 +6,26 @@
       :class="labelSrOnly ? 'visually-hidden' : ''"
       >{{ label }}</label
     >
+    <!-- Options are rendered as children rather than via :options so each
+         row can carry a colour class. An <option> can't contain markup, so
+         the whole row is coloured, not just the count; browsers that use
+         the OS-native picker (e.g. Safari) ignore option colours and fall
+         back to the plain text, which still has the " - backup" suffix. -->
     <b-form-select
       id="communitieslist"
       v-model="selectedGroup"
       :size="size"
-      :options="groupOptions"
       :disabled="disabled"
-    />
+    >
+      <b-form-select-option
+        v-for="option in groupOptions"
+        :key="option.value"
+        :value="option.value"
+        :class="option.class"
+      >
+        {{ option.text }}
+      </b-form-select-option>
+    </b-form-select>
   </div>
 </template>
 <script setup>
@@ -236,15 +249,19 @@ const groupOptions = computed(() => {
       group.role === 'Moderator'
     ) {
       let text = group.namedisplay
+      let hasWork = false
 
       if (props.work) {
         props.work.forEach((type) => {
           if (group.work && group.work[type]) {
             text += ' (' + group.work[type] + ')'
+            hasWork = true
           }
         })
       }
-      if (group.mysettings && group.mysettings.active === 0) {
+
+      const backup = group.mysettings && group.mysettings.active === 0
+      if (backup) {
         text += ' - backup'
       }
 
@@ -252,6 +269,9 @@ const groupOptions = computed(() => {
         value: group.id,
         text,
         selected: selectedGroup.value === group.id,
+        // Rows with work use the same palette as the menu badges: red for
+        // active groups, blue for backup groups.
+        class: hasWork ? (backup ? 'text-info' : 'text-danger') : null,
       })
     }
   }

--- a/iznik-nuxt3/tests/unit/components/modtools/ModGroupSelect.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModGroupSelect.spec.js
@@ -91,12 +91,14 @@ describe('ModGroupSelect', () => {
                 :disabled="disabled"
                 @change="$emit('update:modelValue', parseInt($event.target.value))"
               >
-                <option v-for="opt in options" :key="opt.value" :value="opt.value">
-                  {{ opt.text }}
-                </option>
+                <slot />
               </select>
             `,
-            props: ['modelValue', 'options', 'size', 'disabled'],
+            props: ['modelValue', 'size', 'disabled'],
+          },
+          'b-form-select-option': {
+            template: '<option :value="value"><slot /></option>',
+            props: ['value'],
           },
         },
       },
@@ -297,6 +299,39 @@ describe('ModGroupSelect', () => {
       const options = wrapper.vm.groupOptions
       const gammaOption = options.find((o) => o.value === 3)
       expect(gammaOption.text).toContain('- backup')
+    })
+
+    it('colours work counts red for active groups', () => {
+      const wrapper = mountComponent({ work: ['pending'] })
+      const options = wrapper.vm.groupOptions
+      const alphaOption = options.find((o) => o.value === 1)
+      expect(alphaOption.class).toBe('text-danger')
+    })
+
+    it('colours work counts blue for backup groups', () => {
+      mockModGroupStore.list = {
+        ...sampleGroups,
+        3: { ...sampleGroups[3], work: { pending: 4 } },
+      }
+      const wrapper = mountComponent({ work: ['pending'] })
+      const options = wrapper.vm.groupOptions
+      const gammaOption = options.find((o) => o.value === 3)
+      expect(gammaOption.text).toBe('Gamma Group (4) - backup')
+      expect(gammaOption.class).toBe('text-info')
+    })
+
+    it('does not colour groups without work', () => {
+      const wrapper = mountComponent({ work: ['pending'] })
+      const options = wrapper.vm.groupOptions
+      const deltaOption = options.find((o) => o.value === 4)
+      expect(deltaOption.class).toBeNull()
+    })
+
+    it('applies the colour class to the rendered option', () => {
+      const wrapper = mountComponent({ work: ['pending'] })
+      const domOptions = wrapper.findAll('option')
+      const alpha = domOptions.find((o) => o.text().includes('Alpha Group'))
+      expect(alpha.classes()).toContain('text-danger')
     })
 
     it('sets selected property correctly for selected group', () => {


### PR DESCRIPTION
## What

The ModTools group-select dropdown appends work counts to group names (`Alpha Freegle (5)`) but gives no cue whether that work sits on an active or a backup group. This colours rows that have work using the same palette as the existing menu badges: **red** (`text-danger`) for active groups, **blue** (`text-info`) for backup groups. Rows without work are unchanged.

## Why the whole row, not just the number

The control is a native `<select>`, and an `<option>` cannot contain styled sub-elements - colouring only the number would require replacing the control with a custom dropdown everywhere it's used. Colouring the row is the closest the platform allows: options are now rendered as `b-form-select-option` children (instead of the `:options` array) so each can carry a class. Verified rendering in Chrome against the ModTools Bootstrap theme.

**Degradation**: browsers that use the OS-native picker (Safari/iOS) ignore option colours and show today's plain text, which still carries the `- backup` suffix.

## Tests

Unit tests cover: red class on active groups with work, blue class on backup groups with work, no class without work, and the class landing on the rendered `<option>`. Existing spec's `b-form-select` stub updated to the slot-based rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)