### PR TITLE
fix(chitchat): pin deep-link scroll target through late layout shifts

### DIFF
--- a/iznik-nuxt3/components/NewsReply.vue
+++ b/iznik-nuxt3/components/NewsReply.vue
@@ -1,8 +1,5 @@
 <template>
-  <div
-    v-observe-visibility="visibilityChanged"
-    :class="{ 'bg-info': scrollToThis }"
-  >
+  <div :class="{ 'bg-info': scrollToThis }">
     <div v-if="mod || myid === reply.userid || !reply.hidden" class="reply">
       <!-- More actions dropdown - positioned at top right of reply -->
       <button
@@ -114,7 +111,8 @@
             v-if="isNew"
             class="reply-new-pill ms-1 me-1"
             aria-label="New reply"
-          >New</span>
+            >New</span
+          >
           <NewsUserInfo :id="id" class="me-1 d-inline" />
         </div>
         <div class="reply-actions">
@@ -326,10 +324,15 @@ import {
   defineAsyncComponent,
   nextTick,
   onMounted,
+  onBeforeUnmount,
   watch,
 } from 'vue'
 import { useNewsfeedStore } from '~/stores/newsfeed'
 import { useMiscStore } from '~/stores/misc'
+import {
+  scrollToAndPin,
+  fixedHeaderOffset,
+} from '~/composables/useScrollAnchor'
 import { twem, untwem } from '~/composables/useTwem'
 import NewsUserInfo from '~/components/NewsUserInfo'
 import NewsHighlight from '~/components/NewsHighlight'
@@ -411,8 +414,6 @@ const imagemods = ref(null)
 const showDeleteModal = ref(false)
 const showLoveModal = ref(false)
 const showEditModal = ref(false)
-const hasBecomeVisible = ref(false)
-const isVisible = ref(false)
 const showProfileModal = ref(false)
 const showNewsPhotoModal = ref(false)
 const currentAtts = ref([])
@@ -526,11 +527,18 @@ watch(
   { deep: true }
 )
 
+// The pin this component started, if any, so unmount can stop it.
+let ownPin = null
+
 // Lifecycle hooks
 onMounted(() => {
   // This will get propogated up the stack so that we know if the reply to which we'd like to scroll has been
   // rendered.  We'll then come through the watch above.
   emit('rendered', props.id)
+})
+
+onBeforeUnmount(() => {
+  if (ownPin) ownPin()
 })
 
 // Methods
@@ -598,12 +606,13 @@ async function sendReply(callback) {
 function scrollReplyIntoView(id) {
   if (!id) return
   nextTick(() => {
-    setTimeout(() => {
-      const el = document.querySelector(`[data-reply-id="${id}"]`)
-      if (el) {
-        el.scrollIntoView({ behavior: 'smooth', block: 'center' })
-      }
-    }, 100)
+    // The pin re-resolves the selector every frame, so it simply waits for
+    // the refetched thread to render the new reply, then holds it centered
+    // through the re-order shuffle.
+    ownPin = scrollToAndPin(
+      () => document.querySelector(`[data-reply-id="${id}"]`),
+      { block: 'center' }
+    )
   })
 }
 
@@ -686,43 +695,14 @@ function photoAdd() {
 }
 
 function scrollIntoView() {
-  const api = miscStore.apiCount
-
-  if (api) {
-    // Try later
-    setTimeout(scrollIntoView, 100)
-  } else {
-    // No outstanding requests, so we can scroll. The reply rows are stamped
-    // with data-reply-id by NewsReplies; the historical getElementById
-    // ('newsreply-{id}') target was never rendered anywhere, so notification
-    // deep-links (/chitchat/{replyid}) silently failed to scroll.
-    const el = document.querySelector(`[data-reply-id="${props.id}"]`)
-    if (el) {
-      el.scrollIntoView({
-        behavior: 'smooth',
-        block: 'start',
-        inline: 'nearest',
-      })
-
-      nextTick(() => {
-        if (!isVisible.value) {
-          setTimeout(scrollIntoView, 200)
-        } else {
-          hasBecomeVisible.value = true
-        }
-      })
-    }
-  }
-}
-
-function visibilityChanged(visible) {
-  if (parseInt(props.scrollTo) === props.id && !hasBecomeVisible.value) {
-    isVisible.value = visible
-
-    if (!visible) {
-      scrollIntoView()
-    }
-  }
+  // The reply rows are stamped with data-reply-id by NewsReplies. Long
+  // threads keep rendering async reply chunks and images for several seconds
+  // after this fires, so a one-shot smooth scroll aims at a stale position -
+  // pin the row instead and let the pin follow the layout until it settles.
+  ownPin = scrollToAndPin(
+    () => document.querySelector(`[data-reply-id="${props.id}"]`),
+    { block: 'start', offset: fixedHeaderOffset() }
+  )
 }
 
 function showReplyPhotoModal() {

--- a/iznik-nuxt3/components/NewsThread.vue
+++ b/iznik-nuxt3/components/NewsThread.vue
@@ -283,6 +283,7 @@ import { useNewsfeedStore } from '~/stores/newsfeed'
 import { useMiscStore } from '~/stores/misc'
 import NewsReplies from '~/components/NewsReplies'
 import { untwem } from '~/composables/useTwem'
+import { scrollToAndPin } from '~/composables/useScrollAnchor'
 import { useAuthStore } from '~/stores/auth'
 import { useMe } from '~/composables/useMe'
 
@@ -520,14 +521,14 @@ async function sendComment(callback) {
     // property. Keep the poster anchored to their reply: the post-send refetch
     // re-renders in the server's new order (replied-to parents get bumped), so
     // without this the viewport content swaps and the reply lands off-screen.
+    // The pin re-resolves the selector every frame, so it waits for the
+    // refetch to render the new reply and holds it through the shuffle.
     if (newid) {
       nextTick(() => {
-        setTimeout(() => {
-          const el = document.querySelector(`[data-reply-id="${newid}"]`)
-          if (el) {
-            el.scrollIntoView({ behavior: 'smooth', block: 'center' })
-          }
-        }, 100)
+        scrollToAndPin(
+          () => document.querySelector(`[data-reply-id="${newid}"]`),
+          { block: 'center' }
+        )
       })
     }
 

--- a/iznik-nuxt3/composables/useScrollAnchor.js
+++ b/iznik-nuxt3/composables/useScrollAnchor.js
@@ -1,0 +1,116 @@
+// Scroll an element into view and KEEP it there while late-rendering content
+// (async reply chunks, images, link previews) shifts the layout underneath.
+//
+// A smooth scrollIntoView aims at where the target was when the animation
+// started; on a page that is still streaming in content the destination is
+// stale before the animation lands, and re-firing it produces the
+// scroll-past/overshoot chase seen on long ChitChat threads. So instead:
+// jump instantly, then re-pin instantly whenever the target's DOCUMENT
+// position changes, until the layout has been quiet for SETTLE_MS.
+
+export const SETTLE_MS = 750
+export const MAX_PIN_MS = 8000
+
+// Only one auto-scroll intent can be live at a time - a newer pin (e.g.
+// anchoring a just-sent reply) supersedes an older one (a deep-link scroll).
+let activeCancel = null
+
+const CANCEL_EVENTS = ['wheel', 'touchstart', 'pointerdown', 'keydown']
+
+// Viewport offset the target should sit at, allowing for the fixed navbar.
+// There are separate desktop and mobile navbars, each display:none at the
+// other's breakpoint (offsetHeight 0), so take the tallest visible one.
+export function fixedHeaderOffset() {
+  let height = 0
+  for (const nav of document.querySelectorAll('.navbar.fixed-top')) {
+    height = Math.max(height, nav.offsetHeight)
+  }
+  return height + 8
+}
+
+/**
+ * @param {() => Element|null} getEl re-resolved every frame so v-if/key churn
+ *   that replaces the node doesn't strand the pin on a detached element.
+ * @param {object} options
+ * @param {'start'|'center'} options.block viewport placement of the target
+ * @param {number} options.offset viewport top the target sits at (block=start)
+ * @param {number} options.settleMs quiet period after which the pin ends
+ * @param {number} options.maxMs hard cap on the pin's lifetime
+ * @returns {() => void} cancel
+ */
+export function scrollToAndPin(getEl, options = {}) {
+  const {
+    block = 'start',
+    offset = 0,
+    settleMs = SETTLE_MS,
+    maxMs = MAX_PIN_MS,
+  } = options
+
+  if (activeCancel) activeCancel()
+
+  let cancelled = false
+  let frame = null
+  let lastDocTop = null
+  const startedAt = performance.now()
+  // Until the element first appears there is nothing to settle - deep-link
+  // targets can take a while to mount through the async component chain.
+  let quietSince = null
+
+  function cancel() {
+    if (cancelled) return
+    cancelled = true
+    if (frame !== null) cancelAnimationFrame(frame)
+    for (const ev of CANCEL_EVENTS) {
+      window.removeEventListener(ev, cancel, { capture: true })
+    }
+    if (activeCancel === cancel) activeCancel = null
+  }
+
+  // The user grabbing the page always wins - never fight their scroll.
+  for (const ev of CANCEL_EVENTS) {
+    window.addEventListener(ev, cancel, { passive: true, capture: true })
+  }
+  activeCancel = cancel
+
+  function desiredViewportTop(rect) {
+    if (block === 'center') {
+      return Math.max((window.innerHeight - rect.height) / 2, offset)
+    }
+    return offset
+  }
+
+  function tick() {
+    if (cancelled) return
+
+    const now = performance.now()
+    if (now - startedAt > maxMs) {
+      cancel()
+      return
+    }
+
+    const el = getEl()
+    if (el) {
+      const rect = el.getBoundingClientRect()
+      const docTop = rect.top + window.scrollY
+      if (lastDocTop === null || Math.abs(docTop - lastDocTop) > 1) {
+        // The layout moved the target (or this is the first sighting):
+        // re-pin instantly. Our own scrolls don't re-trigger this because
+        // they change rect.top and scrollY by opposite amounts.
+        lastDocTop = docTop
+        quietSince = now
+        window.scrollTo({
+          top: Math.max(0, docTop - desiredViewportTop(rect)),
+          behavior: 'instant',
+        })
+      } else if (quietSince !== null && now - quietSince > settleMs) {
+        cancel()
+        return
+      }
+    }
+
+    frame = requestAnimationFrame(tick)
+  }
+
+  tick()
+  return cancel
+}

--- a/iznik-nuxt3/tests/unit/components/NewsReply.spec.js
+++ b/iznik-nuxt3/tests/unit/components/NewsReply.spec.js
@@ -61,6 +61,12 @@ vi.mock('~/composables/useTimeFormat', () => ({
   timeagoShort: (date) => '2h',
 }))
 
+const mockScrollToAndPin = vi.fn(() => vi.fn())
+vi.mock('~/composables/useScrollAnchor', () => ({
+  scrollToAndPin: (...args) => mockScrollToAndPin(...args),
+  fixedHeaderOffset: () => 74,
+}))
+
 vi.mock('pluralize', () => ({
   default: (word, count, includeCount) =>
     includeCount ? `${count} ${word}${count !== 1 ? 's' : ''}` : word,
@@ -517,6 +523,32 @@ describe('NewsReply', () => {
     it('does not highlight when scrollTo does not match', () => {
       const wrapper = createWrapper({ scrollTo: '200' })
       expect(wrapper.find('.bg-info').exists()).toBe(false)
+    })
+
+    it('pins the reply row when scrollTo changes to match the id', async () => {
+      const wrapper = createWrapper({ scrollTo: '' })
+      expect(mockScrollToAndPin).not.toHaveBeenCalled()
+
+      await wrapper.setProps({ scrollTo: '100' })
+
+      expect(mockScrollToAndPin).toHaveBeenCalledTimes(1)
+      const [getEl, opts] = mockScrollToAndPin.mock.calls[0]
+      // Anchored to the top, below the fixed navbar.
+      expect(opts).toEqual({ block: 'start', offset: 74 })
+
+      // The resolver re-queries the row NewsReplies stamps with
+      // data-reply-id, so re-renders that replace the node are followed.
+      const row = document.createElement('div')
+      row.setAttribute('data-reply-id', '100')
+      document.body.appendChild(row)
+      expect(getEl()).toBe(row)
+      row.remove()
+    })
+
+    it('does not pin when scrollTo changes to a different id', async () => {
+      const wrapper = createWrapper({ scrollTo: '' })
+      await wrapper.setProps({ scrollTo: '200' })
+      expect(mockScrollToAndPin).not.toHaveBeenCalled()
     })
   })
 

--- a/iznik-nuxt3/tests/unit/components/NewsThread.spec.js
+++ b/iznik-nuxt3/tests/unit/components/NewsThread.spec.js
@@ -138,6 +138,12 @@ vi.mock('~/composables/useTwem', () => ({
   untwem: vi.fn((text) => text),
 }))
 
+const mockScrollToAndPin = vi.fn(() => vi.fn())
+vi.mock('~/composables/useScrollAnchor', () => ({
+  scrollToAndPin: (...args) => mockScrollToAndPin(...args),
+  fixedHeaderOffset: () => 74,
+}))
+
 // Mock child components
 vi.mock('~/components/AutoHeightTextarea', () => ({
   default: {
@@ -1011,6 +1017,45 @@ describe('NewsThread', () => {
       const comp = wrapper.findComponent(NewsThread)
       await comp.vm.sendComment()
       expect(mockSend).not.toHaveBeenCalled()
+    })
+
+    it('anchors the freshly sent reply with a centered pin', async () => {
+      // The post-send refetch re-orders the thread, so the new reply can
+      // land off-screen. sendComment must pin it, re-resolving by
+      // data-reply-id so it finds the row once the refetch renders it.
+      mockSend.mockResolvedValue(9876)
+      const wrapper = await createWrapper()
+      const textarea = wrapper.find('.auto-height-textarea')
+      await textarea.setValue('Anchor me')
+      await textarea.trigger('focus')
+
+      const comp = wrapper.findComponent(NewsThread)
+      await comp.vm.sendComment()
+      await flushPromises()
+
+      expect(mockScrollToAndPin).toHaveBeenCalledTimes(1)
+      const [getEl, opts] = mockScrollToAndPin.mock.calls[0]
+      expect(opts).toEqual({ block: 'center' })
+
+      const row = document.createElement('div')
+      row.setAttribute('data-reply-id', '9876')
+      document.body.appendChild(row)
+      expect(getEl()).toBe(row)
+      row.remove()
+    })
+
+    it('does not pin when send returns no id', async () => {
+      mockSend.mockResolvedValue(null)
+      const wrapper = await createWrapper()
+      const textarea = wrapper.find('.auto-height-textarea')
+      await textarea.setValue('No id back')
+      await textarea.trigger('focus')
+
+      const comp = wrapper.findComponent(NewsThread)
+      await comp.vm.sendComment()
+      await flushPromises()
+
+      expect(mockScrollToAndPin).not.toHaveBeenCalled()
     })
   })
 

--- a/iznik-nuxt3/tests/unit/composables/useScrollAnchor.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useScrollAnchor.spec.js
@@ -1,0 +1,267 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import {
+  scrollToAndPin,
+  fixedHeaderOffset,
+  SETTLE_MS,
+  MAX_PIN_MS,
+} from '~/composables/useScrollAnchor.js'
+
+// The pin loop runs on requestAnimationFrame. Fake it alongside timers so
+// advanceTimersByTime drives frames deterministically.
+function fakeAllTimers() {
+  vi.useFakeTimers({
+    toFake: [
+      'setTimeout',
+      'clearTimeout',
+      'setInterval',
+      'clearInterval',
+      'requestAnimationFrame',
+      'cancelAnimationFrame',
+      'performance',
+    ],
+  })
+}
+
+// A stand-in for a rendered reply row. documentTop is its offset in the
+// document; getBoundingClientRect derives the viewport-relative top from
+// the current (mocked) window.scrollY, like a real element.
+function makeElement({ documentTop = 1000, height = 120 } = {}) {
+  return {
+    documentTop,
+    getBoundingClientRect() {
+      return {
+        top: this.documentTop - window.scrollY,
+        height,
+        width: 300,
+        bottom: this.documentTop - window.scrollY + height,
+      }
+    },
+  }
+}
+
+describe('scrollToAndPin', () => {
+  let scrollCalls
+  let cancelPin
+
+  beforeEach(() => {
+    fakeAllTimers()
+    scrollCalls = []
+    Object.defineProperty(window, 'scrollY', {
+      value: 0,
+      writable: true,
+      configurable: true,
+    })
+    Object.defineProperty(window, 'innerHeight', {
+      value: 667,
+      writable: true,
+      configurable: true,
+    })
+    vi.spyOn(window, 'scrollTo').mockImplementation((opts) => {
+      scrollCalls.push(opts)
+      window.scrollY = Math.max(0, opts.top)
+    })
+    cancelPin = null
+  })
+
+  afterEach(() => {
+    if (cancelPin) cancelPin()
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+  })
+
+  it('pins the element to the requested viewport offset instantly', () => {
+    const el = makeElement({ documentTop: 1000 })
+    cancelPin = scrollToAndPin(() => el, { offset: 74 })
+
+    vi.advanceTimersByTime(20)
+
+    expect(scrollCalls.length).toBe(1)
+    expect(scrollCalls[0]).toEqual({ top: 1000 - 74, behavior: 'instant' })
+  })
+
+  it('waits for the element to appear, then pins (no settle timeout while absent)', () => {
+    let el = null
+    cancelPin = scrollToAndPin(() => el, { offset: 0 })
+
+    // Element absent for longer than the settle window - the pin must not
+    // give up, because async chunks can take a while to mount the target.
+    vi.advanceTimersByTime(SETTLE_MS + 500)
+    expect(scrollCalls.length).toBe(0)
+
+    el = makeElement({ documentTop: 2000 })
+    vi.advanceTimersByTime(50)
+    expect(scrollCalls.length).toBe(1)
+    expect(scrollCalls[0].top).toBe(2000)
+  })
+
+  it('re-pins when late-rendering content moves the element in the document', () => {
+    const el = makeElement({ documentTop: 1000 })
+    cancelPin = scrollToAndPin(() => el, { offset: 0 })
+    vi.advanceTimersByTime(20)
+    expect(scrollCalls.length).toBe(1)
+
+    // Content above the target grows by 800px (images/async replies).
+    el.documentTop = 1800
+    vi.advanceTimersByTime(50)
+
+    expect(scrollCalls.length).toBe(2)
+    expect(scrollCalls[1].top).toBe(1800)
+  })
+
+  it('does NOT re-pin when only the viewport scrolled (element document position unchanged)', () => {
+    const el = makeElement({ documentTop: 1000 })
+    cancelPin = scrollToAndPin(() => el, { offset: 0 })
+    vi.advanceTimersByTime(20)
+    expect(scrollCalls.length).toBe(1)
+
+    // Simulate a scroll not caused by us: viewport moves, document doesn't.
+    window.scrollY = 400
+    vi.advanceTimersByTime(200)
+
+    expect(scrollCalls.length).toBe(1)
+  })
+
+  it('stops correcting once layout has been quiet for the settle window', () => {
+    const el = makeElement({ documentTop: 1000 })
+    cancelPin = scrollToAndPin(() => el, { offset: 0 })
+    vi.advanceTimersByTime(20)
+
+    vi.advanceTimersByTime(SETTLE_MS + 100)
+
+    // A shift after settling is the user's problem no longer - we must not
+    // yank the viewport around once we've declared the scroll done.
+    el.documentTop = 3000
+    vi.advanceTimersByTime(200)
+
+    expect(scrollCalls.length).toBe(1)
+  })
+
+  it('keeps pinning through repeated shifts, then settles', () => {
+    const el = makeElement({ documentTop: 1000 })
+    cancelPin = scrollToAndPin(() => el, { offset: 0 })
+    vi.advanceTimersByTime(20)
+
+    for (let i = 1; i <= 5; i++) {
+      el.documentTop = 1000 + i * 300
+      vi.advanceTimersByTime(SETTLE_MS - 100) // each shift inside the window
+    }
+
+    expect(scrollCalls.length).toBe(6)
+    expect(scrollCalls[5].top).toBe(2500)
+  })
+
+  it('cancels immediately on user input', () => {
+    const el = makeElement({ documentTop: 1000 })
+    cancelPin = scrollToAndPin(() => el, { offset: 0 })
+    vi.advanceTimersByTime(20)
+    expect(scrollCalls.length).toBe(1)
+
+    window.dispatchEvent(new Event('wheel'))
+
+    el.documentTop = 2000
+    vi.advanceTimersByTime(200)
+    expect(scrollCalls.length).toBe(1)
+  })
+
+  it('gives up at the hard cap even if layout never settles', () => {
+    const el = makeElement({ documentTop: 1000 })
+    cancelPin = scrollToAndPin(() => el, { offset: 0 })
+
+    // Perpetually shifting layout - move the target every frame-ish.
+    for (let t = 0; t < MAX_PIN_MS + 1000; t += 100) {
+      el.documentTop += 50
+      vi.advanceTimersByTime(100)
+    }
+    const callsAtCap = scrollCalls.length
+
+    el.documentTop += 500
+    vi.advanceTimersByTime(500)
+    expect(scrollCalls.length).toBe(callsAtCap)
+  })
+
+  it('centers the element when block is center', () => {
+    const el = makeElement({ documentTop: 5000, height: 100 })
+    cancelPin = scrollToAndPin(() => el, { block: 'center' })
+    vi.advanceTimersByTime(20)
+
+    // Centered: element top sits at (innerHeight - height) / 2.
+    const expectedViewportTop = (667 - 100) / 2
+    expect(scrollCalls[0].top).toBe(5000 - expectedViewportTop)
+  })
+
+  it('starting a new pin cancels the previous one', () => {
+    const elA = makeElement({ documentTop: 1000 })
+    const elB = makeElement({ documentTop: 4000 })
+    cancelPin = scrollToAndPin(() => elA, { offset: 0 })
+    vi.advanceTimersByTime(20)
+
+    cancelPin = scrollToAndPin(() => elB, { offset: 0 })
+    vi.advanceTimersByTime(20)
+    expect(scrollCalls.length).toBe(2)
+
+    // Only B is live: A's shifts are ignored, B's are corrected.
+    elA.documentTop = 1500
+    vi.advanceTimersByTime(100)
+    expect(scrollCalls.length).toBe(2)
+
+    elB.documentTop = 4500
+    vi.advanceTimersByTime(100)
+    expect(scrollCalls.length).toBe(3)
+    expect(scrollCalls[2].top).toBe(4500)
+  })
+
+  it('returned cancel stops the pin', () => {
+    const el = makeElement({ documentTop: 1000 })
+    cancelPin = scrollToAndPin(() => el, { offset: 0 })
+    vi.advanceTimersByTime(20)
+
+    cancelPin()
+
+    el.documentTop = 2000
+    vi.advanceTimersByTime(200)
+    expect(scrollCalls.length).toBe(1)
+  })
+
+  it('never scrolls to a negative offset', () => {
+    const el = makeElement({ documentTop: 20 })
+    cancelPin = scrollToAndPin(() => el, { offset: 74 })
+    vi.advanceTimersByTime(20)
+
+    expect(scrollCalls[0].top).toBe(0)
+  })
+})
+
+describe('fixedHeaderOffset', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('returns the fixed navbar height plus breathing room', () => {
+    const nav = document.createElement('nav')
+    nav.className = 'navbar fixed-top'
+    Object.defineProperty(nav, 'offsetHeight', { value: 66 })
+    document.body.appendChild(nav)
+
+    expect(fixedHeaderOffset()).toBe(66 + 8)
+  })
+
+  it('uses the visible navbar when a hidden one precedes it in the DOM', () => {
+    // Desktop and mobile navbars coexist; the hidden one reports
+    // offsetHeight 0 and must not win just because it comes first.
+    const desktopNav = document.createElement('nav')
+    desktopNav.className = 'navbar fixed-top d-none d-xl-flex'
+    Object.defineProperty(desktopNav, 'offsetHeight', { value: 0 })
+    document.body.appendChild(desktopNav)
+
+    const mobileNav = document.createElement('nav')
+    mobileNav.className = 'navbar fixed-top'
+    Object.defineProperty(mobileNav, 'offsetHeight', { value: 66 })
+    document.body.appendChild(mobileNav)
+
+    expect(fixedHeaderOffset()).toBe(66 + 8)
+  })
+
+  it('returns just the breathing room when there is no fixed navbar', () => {
+    expect(fixedHeaderOffset()).toBe(8)
+  })
+})


### PR DESCRIPTION
## Summary
- Deep-linking into a long ChitChat thread (`/chitchat/<replyid>`) "scrolls past or overshoots": the scroller issued repeated **smooth** `scrollIntoView` calls while async reply chunks, images and previews were still streaming in, so every animation aimed at a stale position. Observed live on the reported thread: 33 smooth scrolls over ~6s, ending with the target 937px off-screen, with layout-shift bursts up to 0.87 CLS during the chase.
- New `useScrollAnchor` composable replaces the chase with a **pin**: jump instantly, then instantly re-pin whenever the target's *document* position changes, until layout is quiet for 750ms (hard cap 8s). Any user input (wheel/touch/pointer/key) cancels immediately, so it never fights the user. Only one pin is live at a time; unmount cancels.
- Offsets by the tallest **visible** fixed navbar - desktop and mobile navbars coexist, and the hidden one reports `offsetHeight` 0, so `querySelector`-first-match put the reply's opening lines under the 66px mobile header.
- The target is re-resolved by `[data-reply-id]` every frame, so v-if/key churn that replaces the node can't strand the pin.
- Post-send anchors in `NewsReply`/`NewsThread` use the same pin (`block: center`): it waits for the refetch to render the new reply and holds it through the server-order shuffle. The visibility-observer retry loop is removed.

## Validation
- Instrumented before/after on the reported thread (`/chitchat/613438`, 375x667):
  - **Before (prod)**: 33 smooth scrolls over 6s, viewport bouncing (y: 8811→6606, 14410→12597...), final position 937px past the target, target not visible.
  - **After (dev-live)**: 18 instant corrections over ~2.5s, target visibly held at header+8px throughout, settles cleanly, fully readable.

## Code Quality Review
- The pin loop is rAF-based and self-terminating (settle/cap/input/unmount all cancel); no timers leak.
- Own scrolls don't retrigger corrections (document position is invariant under viewport scrolls), so no feedback loop.
- User scrolls without layout shifts are deliberately not corrected, and any input cancels outright.

## Test Plan
- 15 new composable specs: initial pin, wait-for-element, re-pin on layout shift, no re-pin on viewport-only scroll, settle window, repeated shifts, input cancel, hard cap, center block, pin supersession, explicit cancel, negative clamp, header offset incl. hidden-navbar case.
- `NewsReply` deep-link pin wiring + non-matching id; `NewsThread` post-send centered anchor + no-id guard.
- Full frontend unit suite via status API: **14,203 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)