### PR TITLE
feat(rippling): graded per-reply attribution - evidence ladder, client provenance, channel dashboard

### DIFF
--- a/iznik-batch/app/Console/Commands/Ripple/BackfillReplyAttributionCommand.php
+++ b/iznik-batch/app/Console/Commands/Ripple/BackfillReplyAttributionCommand.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Console\Commands\Ripple;
+
+use App\Console\Concerns\PreventsOverlapping;
+use App\Services\Ripple\ReplyAttributionBackfillService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * One-shot backfill of the durable graded-attribution evidence onto legacy
+ * rippling_reply_attribution rows (attribution IS NULL). Run once on production after applying
+ * migration 2026_07_07_000002; safe to re-run (idempotent - only visits unfilled rows). See
+ * ReplyAttributionBackfillService for what is (and deliberately is not) derivable.
+ */
+class BackfillReplyAttributionCommand extends Command
+{
+    use PreventsOverlapping;
+
+    protected $signature = 'ripple:backfill-reply-attribution
+                            {--dry-run : Report how many rows would be backfilled without changing anything}
+                            {--limit=0 : Max rows to process (0 = no limit)}
+                            {--batch=500 : Rows per UPDATE statement}';
+
+    protected $description = 'Backfill durable graded-attribution evidence (notified ledger, rippled-group membership, hard guard) onto legacy rippling reply-attribution rows';
+
+    public function handle(ReplyAttributionBackfillService $service): int
+    {
+        if (!$this->acquireLock()) {
+            $this->info('Already running, exiting.');
+
+            return Command::SUCCESS;
+        }
+
+        try {
+            $pending = $service->pendingCount();
+
+            if ($this->option('dry-run')) {
+                $this->info("[DRY RUN] {$pending} row(s) would be backfilled. Pass no --dry-run to apply.");
+
+                return Command::SUCCESS;
+            }
+
+            $updated = $service->backfill(
+                max(1, (int) $this->option('batch')),
+                (int) $this->option('limit'),
+                fn (int $total) => $this->output->write("\rBackfilled {$total} of {$pending}...")
+            );
+            $this->output->writeln('');
+            $this->info("Backfilled {$updated} row(s); " . $service->pendingCount() . ' still pending.');
+            Log::info('ripple:backfill-reply-attribution complete', [
+                'updated' => $updated,
+                'pending_before' => $pending,
+            ]);
+
+            return Command::SUCCESS;
+        } finally {
+            $this->releaseLock();
+        }
+    }
+}

--- a/iznik-batch/app/Services/Ripple/ReplyAttributionBackfillService.php
+++ b/iznik-batch/app/Services/Ripple/ReplyAttributionBackfillService.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace App\Services\Ripple;
+
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Backfill the DURABLE graded-attribution evidence onto legacy rippling_reply_attribution rows
+ * (attribution IS NULL - written before migration 2026_07_07_000002 / the Go capture deploy).
+ *
+ * Durable bits are re-derivable from timestamped tables, so freezing them now - before the
+ * evidence decays further - is the whole point:
+ *   was_notified            <- rippling_reach_notified (notified_at <= replied_at)
+ *   was_ripple_group_member <- an approved membership of a group the post rippled into, added
+ *                              before the copy arrived (decays when members leave, hence freeze)
+ *   post_had_rippled        <- a rippled-in copy or a reach row existed by reply time
+ *
+ * The LOCATION bits (in_origin_catchment / in_reach) are NOT backfillable - locations drift and
+ * reach polygons grow - so they stay NULL and the derived attribution for backfilled rows can
+ * only be home / ripple_notified / ripple_group / unknown (never organic_local / ripple_reach).
+ * The ladder matches rippling.DeriveAttribution in iznik-server-go (home wins - conservative -
+ * then notified, then rippled-group, else unknown).
+ *
+ * Idempotent: only visits attribution IS NULL rows, and every visited row gets attribution set.
+ */
+class ReplyAttributionBackfillService
+{
+    /**
+     * Rows still awaiting backfill.
+     */
+    public function pendingCount(): int
+    {
+        return (int) DB::table('rippling_reply_attribution')->whereNull('attribution')->count();
+    }
+
+    /**
+     * Backfill in batches. Returns the number of rows updated.
+     *
+     * @param int $batchSize rows per UPDATE statement
+     * @param int $limit     max rows to process (0 = all)
+     * @param callable|null $progress called with the running total after each batch
+     */
+    public function backfill(int $batchSize = 500, int $limit = 0, ?callable $progress = null): int
+    {
+        $total = 0;
+
+        while (true) {
+            $chunk = $batchSize;
+            if ($limit > 0) {
+                $chunk = min($chunk, $limit - $total);
+                if ($chunk <= 0) {
+                    break;
+                }
+            }
+
+            /*
+             * One set-based statement per batch. The evidence EXISTS clauses are repeated in
+             * the attribution CASE rather than referencing the just-assigned columns: in a
+             * multi-table UPDATE, MySQL does not guarantee assignments see earlier ones.
+             */
+            $affected = DB::affectingStatement("
+                UPDATE rippling_reply_attribution rra
+                JOIN (
+                    SELECT msgid, userid FROM rippling_reply_attribution
+                    WHERE attribution IS NULL
+                    ORDER BY msgid, userid
+                    LIMIT {$chunk}
+                ) batch ON batch.msgid = rra.msgid AND batch.userid = rra.userid
+                SET
+                    rra.was_notified = EXISTS(
+                        SELECT 1 FROM rippling_reach_notified rrn
+                        WHERE rrn.msgid = rra.msgid AND rrn.userid = rra.userid
+                          AND rrn.notified_at <= rra.replied_at),
+                    rra.was_ripple_group_member = EXISTS(
+                        SELECT 1 FROM messages_groups mg
+                        INNER JOIN memberships mem ON mem.groupid = mg.groupid
+                          AND mem.userid = rra.userid AND mem.collection = 'Approved'
+                          AND mem.added < mg.arrival
+                        WHERE mg.msgid = rra.msgid AND mg.rippled_in = 1
+                          AND mg.deleted = 0 AND mg.arrival <= rra.replied_at),
+                    rra.post_had_rippled = (
+                        EXISTS(
+                            SELECT 1 FROM messages_groups mg2
+                            WHERE mg2.msgid = rra.msgid AND mg2.rippled_in = 1
+                              AND mg2.deleted = 0 AND mg2.arrival <= rra.replied_at)
+                        OR EXISTS(
+                            SELECT 1 FROM rippling_reach rr
+                            WHERE rr.msgid = rra.msgid
+                              AND (rr.created_at IS NULL OR rr.created_at <= rra.replied_at))),
+                    rra.attribution = CASE
+                        WHEN rra.was_home_member = 1 THEN 'home'
+                        WHEN EXISTS(
+                            SELECT 1 FROM rippling_reach_notified rrn2
+                            WHERE rrn2.msgid = rra.msgid AND rrn2.userid = rra.userid
+                              AND rrn2.notified_at <= rra.replied_at) THEN 'ripple_notified'
+                        WHEN EXISTS(
+                            SELECT 1 FROM messages_groups mg3
+                            INNER JOIN memberships mem3 ON mem3.groupid = mg3.groupid
+                              AND mem3.userid = rra.userid AND mem3.collection = 'Approved'
+                              AND mem3.added < mg3.arrival
+                            WHERE mg3.msgid = rra.msgid AND mg3.rippled_in = 1
+                              AND mg3.deleted = 0 AND mg3.arrival <= rra.replied_at) THEN 'ripple_group'
+                        ELSE 'unknown'
+                    END
+            ");
+
+            $total += $affected;
+
+            if ($progress) {
+                $progress($total);
+            }
+
+            if ($affected < $chunk) {
+                break;
+            }
+        }
+
+        return $total;
+    }
+}

--- a/iznik-batch/database/migrations/2026_07_07_000002_add_attribution_evidence_to_rippling_reply_attribution.php
+++ b/iznik-batch/database/migrations/2026_07_07_000002_add_attribution_evidence_to_rippling_reply_attribution.php
@@ -1,0 +1,104 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Graded reply attribution: widen rippling_reply_attribution from the single negative
+ * was_home_member bit to separate evidence bits + a derived attribution channel, all
+ * snapshotted AT REPLY TIME by the Go reply handler (chat/chatmessage.go).
+ *
+ * Evidence bits (nullable: NULL = not captured, pre-migration row or evidence unavailable):
+ *   was_notified             - (msgid, userid) hit in rippling_reach_notified before the reply:
+ *                              we SENT this user the ripple mail for this post. Durable; backfillable.
+ *   was_ripple_group_member  - established member (added < the copy's arrival) of a group the
+ *                              post rippled INTO by reply time. Durable-ish (leavers decay);
+ *                              backfillable, which is why the backfill freezes it.
+ *   in_origin_catchment      - replier's location inside an origin group's catchment
+ *                              (groups.polyindex). Location drifts, so NOT backfillable.
+ *   in_reach                 - replier's location inside the post's rippling_reach polygon at
+ *                              reply time. The polygon grows, so NOT backfillable.
+ *   post_had_rippled         - the post had rippled at all (a rippled_in copy or a reach row)
+ *                              by reply time. Durable; backfillable. The hard guard: when 0,
+ *                              the reply can never be ripple-attributed.
+ *
+ * attribution is the derived channel (the ladder, in precedence order):
+ *   home            - established origin-group member (conservative: wins over all ripple evidence)
+ *   ripple_notified - we mailed them the post via the ripple
+ *   ripple_group    - they saw it in their own group because it rippled in
+ *   organic_local   - non-member inside the origin catchment: would have seen it in Browse anyway
+ *   ripple_reach    - outside the origin catchment, inside the reach: exposure existed only
+ *                     because the ripple extended there (Browse/nearby is reach-fed)
+ *   unknown         - none of the above resolvable (search / deep link / share, or no location)
+ * NULL = not yet derived (pre-migration row the backfill hasn't visited).
+ *
+ * client_source is the client-reported surface the reply came from (browse, search,
+ * message_page, notification, ...). Advisory only - it is client-supplied and spoofable -
+ * so it is NEVER folded into the attribution ladder; it cross-checks it.
+ *
+ * Bits are stored separately (not just the enum) so the ladder can be re-derived or
+ * re-weighted later without losing information.
+ *
+ * Read by the sysadmin rippling dashboard (reply_source_split in rippling/metrics.go).
+ * Backfilled for durable bits by ripple:backfill-reply-attribution.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // Each column guarded separately: partial prior runs must not wedge the migration.
+        if (!Schema::hasColumn('rippling_reply_attribution', 'was_notified')) {
+            Schema::table('rippling_reply_attribution', function (Blueprint $t) {
+                $t->boolean('was_notified')->nullable()->after('was_home_member');
+            });
+        }
+        if (!Schema::hasColumn('rippling_reply_attribution', 'was_ripple_group_member')) {
+            Schema::table('rippling_reply_attribution', function (Blueprint $t) {
+                $t->boolean('was_ripple_group_member')->nullable()->after('was_notified');
+            });
+        }
+        if (!Schema::hasColumn('rippling_reply_attribution', 'in_origin_catchment')) {
+            Schema::table('rippling_reply_attribution', function (Blueprint $t) {
+                $t->boolean('in_origin_catchment')->nullable()->after('was_ripple_group_member');
+            });
+        }
+        if (!Schema::hasColumn('rippling_reply_attribution', 'in_reach')) {
+            Schema::table('rippling_reply_attribution', function (Blueprint $t) {
+                $t->boolean('in_reach')->nullable()->after('in_origin_catchment');
+            });
+        }
+        if (!Schema::hasColumn('rippling_reply_attribution', 'post_had_rippled')) {
+            Schema::table('rippling_reply_attribution', function (Blueprint $t) {
+                $t->boolean('post_had_rippled')->nullable()->after('in_reach');
+            });
+        }
+        if (!Schema::hasColumn('rippling_reply_attribution', 'attribution')) {
+            // New column, so the enum order is ours to choose (no prod divergence risk);
+            // ladder precedence order for readability.
+            DB::statement(
+                "ALTER TABLE rippling_reply_attribution ADD COLUMN attribution " .
+                "ENUM('home','ripple_notified','ripple_group','organic_local','ripple_reach','unknown') " .
+                "NULL DEFAULT NULL AFTER post_had_rippled"
+            );
+        }
+        if (!Schema::hasColumn('rippling_reply_attribution', 'client_source')) {
+            Schema::table('rippling_reply_attribution', function (Blueprint $t) {
+                $t->string('client_source', 32)->nullable()->after('attribution');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        foreach (['client_source', 'attribution', 'post_had_rippled', 'in_reach',
+            'in_origin_catchment', 'was_ripple_group_member', 'was_notified'] as $col) {
+            if (Schema::hasColumn('rippling_reply_attribution', $col)) {
+                Schema::table('rippling_reply_attribution', function (Blueprint $t) use ($col) {
+                    $t->dropColumn($col);
+                });
+            }
+        }
+    }
+};

--- a/iznik-batch/database/migrations/2026_07_07_000002_add_attribution_evidence_to_rippling_reply_attribution_migration.sql
+++ b/iznik-batch/database/migrations/2026_07_07_000002_add_attribution_evidence_to_rippling_reply_attribution_migration.sql
@@ -1,0 +1,101 @@
+-- Production deploy SQL for the Laravel migration of the same name (idempotent).
+-- Widens rippling_reply_attribution with graded-attribution evidence bits + the derived
+-- attribution channel + the client-reported surface. All nullable: NULL = not captured
+-- (pre-migration row). See the .php migration for the full semantics of each column.
+--
+-- Run once on production BEFORE deploying the iznik-server-go build that writes these
+-- columns (the Go handler checks column existence at startup and falls back to the
+-- legacy insert until they exist, so order is not critical - but the new data only
+-- accrues once both are live). Then run: php artisan ripple:backfill-reply-attribution
+
+SET @exists := (
+    SELECT COUNT(*) FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'rippling_reply_attribution'
+      AND COLUMN_NAME = 'was_notified'
+);
+SET @sql := IF(@exists = 0,
+    'ALTER TABLE rippling_reply_attribution ADD COLUMN was_notified TINYINT(1) NULL DEFAULT NULL AFTER was_home_member',
+    'DO 0');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @exists := (
+    SELECT COUNT(*) FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'rippling_reply_attribution'
+      AND COLUMN_NAME = 'was_ripple_group_member'
+);
+SET @sql := IF(@exists = 0,
+    'ALTER TABLE rippling_reply_attribution ADD COLUMN was_ripple_group_member TINYINT(1) NULL DEFAULT NULL AFTER was_notified',
+    'DO 0');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @exists := (
+    SELECT COUNT(*) FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'rippling_reply_attribution'
+      AND COLUMN_NAME = 'in_origin_catchment'
+);
+SET @sql := IF(@exists = 0,
+    'ALTER TABLE rippling_reply_attribution ADD COLUMN in_origin_catchment TINYINT(1) NULL DEFAULT NULL AFTER was_ripple_group_member',
+    'DO 0');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @exists := (
+    SELECT COUNT(*) FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'rippling_reply_attribution'
+      AND COLUMN_NAME = 'in_reach'
+);
+SET @sql := IF(@exists = 0,
+    'ALTER TABLE rippling_reply_attribution ADD COLUMN in_reach TINYINT(1) NULL DEFAULT NULL AFTER in_origin_catchment',
+    'DO 0');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @exists := (
+    SELECT COUNT(*) FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'rippling_reply_attribution'
+      AND COLUMN_NAME = 'post_had_rippled'
+);
+SET @sql := IF(@exists = 0,
+    'ALTER TABLE rippling_reply_attribution ADD COLUMN post_had_rippled TINYINT(1) NULL DEFAULT NULL AFTER in_reach',
+    'DO 0');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- New column (not an enum widen), so no Galera COPY-rebuild concern; order is ladder precedence.
+SET @exists := (
+    SELECT COUNT(*) FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'rippling_reply_attribution'
+      AND COLUMN_NAME = 'attribution'
+);
+SET @sql := IF(@exists = 0,
+    'ALTER TABLE rippling_reply_attribution ADD COLUMN attribution ENUM(''home'',''ripple_notified'',''ripple_group'',''organic_local'',''ripple_reach'',''unknown'') NULL DEFAULT NULL AFTER post_had_rippled',
+    'DO 0');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @exists := (
+    SELECT COUNT(*) FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'rippling_reply_attribution'
+      AND COLUMN_NAME = 'client_source'
+);
+SET @sql := IF(@exists = 0,
+    'ALTER TABLE rippling_reply_attribution ADD COLUMN client_source VARCHAR(32) NULL DEFAULT NULL AFTER attribution',
+    'DO 0');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;

--- a/iznik-batch/tests/Feature/Ripple/BackfillReplyAttributionCommandTest.php
+++ b/iznik-batch/tests/Feature/Ripple/BackfillReplyAttributionCommandTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\Feature\Ripple;
+
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+/**
+ * ripple:backfill-reply-attribution - the one-shot production backfill wrapper around
+ * ReplyAttributionBackfillService. Dry-run reports without touching rows; a real run derives
+ * attribution for legacy rows and exits cleanly when nothing is pending.
+ */
+class BackfillReplyAttributionCommandTest extends TestCase
+{
+    private function seedLegacyRow(): array
+    {
+        $poster = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $message = $this->createTestMessage($poster, $group);
+        $replier = $this->createTestUser();
+
+        DB::table('rippling_reply_attribution')->insert([
+            'msgid' => $message->id,
+            'userid' => $replier->id,
+            'replied_at' => now()->subHours(2),
+            'was_home_member' => 1,
+        ]);
+
+        return [$message->id, $replier->id];
+    }
+
+    public function test_dry_run_reports_without_changing_rows(): void
+    {
+        [$msgid, $userid] = $this->seedLegacyRow();
+
+        $this->artisan('ripple:backfill-reply-attribution', ['--dry-run' => true])
+            ->expectsOutputToContain('DRY RUN')
+            ->assertExitCode(0);
+
+        $row = DB::table('rippling_reply_attribution')
+            ->where('msgid', $msgid)->where('userid', $userid)->first();
+        $this->assertNull($row->attribution, 'dry-run must not derive anything');
+    }
+
+    public function test_backfills_legacy_rows(): void
+    {
+        [$msgid, $userid] = $this->seedLegacyRow();
+
+        $this->artisan('ripple:backfill-reply-attribution')->assertExitCode(0);
+
+        $row = DB::table('rippling_reply_attribution')
+            ->where('msgid', $msgid)->where('userid', $userid)->first();
+        $this->assertSame('home', $row->attribution);
+    }
+
+    public function test_no_pending_rows_is_a_clean_noop(): void
+    {
+        $this->artisan('ripple:backfill-reply-attribution')->assertExitCode(0);
+    }
+}

--- a/iznik-batch/tests/Unit/Services/Ripple/ReplyAttributionBackfillServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/Ripple/ReplyAttributionBackfillServiceTest.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace Tests\Unit\Services\Ripple;
+
+use App\Services\Ripple\ReplyAttributionBackfillService;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+/**
+ * The backfill derives the DURABLE graded-attribution evidence onto legacy rows
+ * (attribution IS NULL): notified ledger -> ripple_notified, pre-arrival membership of a
+ * rippled-into group -> ripple_group, home bit -> home, nothing -> unknown with the
+ * post_had_rippled hard-guard bit frozen. Location bits stay NULL (not derivable
+ * retrospectively), and already-derived rows are never revisited.
+ */
+class ReplyAttributionBackfillServiceTest extends TestCase
+{
+    private ReplyAttributionBackfillService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new ReplyAttributionBackfillService();
+    }
+
+    private function insertLegacyRow(int $msgid, int $userid, int $wasHome, string $repliedAt = null): void
+    {
+        DB::table('rippling_reply_attribution')->insert([
+            'msgid' => $msgid,
+            'userid' => $userid,
+            'replied_at' => $repliedAt ?? now()->subHours(2),
+            'was_home_member' => $wasHome,
+        ]);
+    }
+
+    private function attributionRow(int $msgid, int $userid): object
+    {
+        return DB::table('rippling_reply_attribution')
+            ->where('msgid', $msgid)->where('userid', $userid)->first();
+    }
+
+    public function test_backfills_durable_channels_and_hard_guard(): void
+    {
+        $poster = $this->createTestUser();
+        $originGroup = $this->createTestGroup();
+        $rippledGroup = $this->createTestGroup();
+        $message = $this->createTestMessage($poster, $originGroup);
+
+        // The post rippled into a second group yesterday.
+        DB::table('messages_groups')->insert([
+            'msgid' => $message->id,
+            'groupid' => $rippledGroup->id,
+            'collection' => 'Approved',
+            'arrival' => now()->subDay(),
+            'rippled_in' => 1,
+        ]);
+
+        // Home member of the origin group.
+        $homeUser = $this->createTestUser();
+        $this->insertLegacyRow($message->id, $homeUser->id, 1);
+
+        // Notified via the ripple mail ledger before replying.
+        $notifiedUser = $this->createTestUser();
+        DB::table('rippling_reach_notified')->insert([
+            'msgid' => $message->id,
+            'userid' => $notifiedUser->id,
+            'notified_at' => now()->subDay(),
+        ]);
+        $this->insertLegacyRow($message->id, $notifiedUser->id, 0);
+
+        // Established member of the rippled-into group (added before the copy arrived).
+        $groupUser = $this->createTestUser();
+        $this->createMembership($groupUser, $rippledGroup, ['added' => now()->subDays(3)]);
+        $this->insertLegacyRow($message->id, $groupUser->id, 0);
+
+        // No evidence at all.
+        $unknownUser = $this->createTestUser();
+        $this->insertLegacyRow($message->id, $unknownUser->id, 0);
+
+        $updated = $this->service->backfill();
+        $this->assertGreaterThanOrEqual(4, $updated);
+        $this->assertSame(0, $this->service->pendingCount());
+
+        $home = $this->attributionRow($message->id, $homeUser->id);
+        $this->assertSame('home', $home->attribution);
+
+        $notified = $this->attributionRow($message->id, $notifiedUser->id);
+        $this->assertSame('ripple_notified', $notified->attribution);
+        $this->assertSame(1, (int) $notified->was_notified);
+        $this->assertSame(1, (int) $notified->post_had_rippled);
+        $this->assertNull($notified->in_origin_catchment, 'location bits are not backfillable');
+        $this->assertNull($notified->in_reach, 'location bits are not backfillable');
+
+        $group = $this->attributionRow($message->id, $groupUser->id);
+        $this->assertSame('ripple_group', $group->attribution);
+        $this->assertSame(1, (int) $group->was_ripple_group_member);
+
+        $unknown = $this->attributionRow($message->id, $unknownUser->id);
+        $this->assertSame('unknown', $unknown->attribution);
+        // The post HAD rippled (yesterday's copy predates the reply), so the hard-guard bit
+        // is 1 - the reply just carries no positive ripple evidence.
+        $this->assertSame(1, (int) $unknown->post_had_rippled);
+    }
+
+    public function test_never_rippled_post_freezes_hard_guard_zero(): void
+    {
+        $poster = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $message = $this->createTestMessage($poster, $group);
+
+        $replier = $this->createTestUser();
+        $this->insertLegacyRow($message->id, $replier->id, 0);
+
+        $this->service->backfill();
+
+        $row = $this->attributionRow($message->id, $replier->id);
+        $this->assertSame('unknown', $row->attribution);
+        $this->assertSame(0, (int) $row->post_had_rippled);
+    }
+
+    public function test_join_to_reply_membership_is_not_ripple_group(): void
+    {
+        $poster = $this->createTestUser();
+        $originGroup = $this->createTestGroup();
+        $rippledGroup = $this->createTestGroup();
+        $message = $this->createTestMessage($poster, $originGroup);
+
+        DB::table('messages_groups')->insert([
+            'msgid' => $message->id,
+            'groupid' => $rippledGroup->id,
+            'collection' => 'Approved',
+            'arrival' => now()->subDay(),
+            'rippled_in' => 1,
+        ]);
+
+        // Membership added AFTER the rippled copy arrived (the join-to-reply shape): they were
+        // not already there when it rippled in, so this must not count as ripple_group.
+        $joiner = $this->createTestUser();
+        $this->createMembership($joiner, $rippledGroup, ['added' => now()->subHours(3)]);
+        $this->insertLegacyRow($message->id, $joiner->id, 0);
+
+        $this->service->backfill();
+
+        $row = $this->attributionRow($message->id, $joiner->id);
+        $this->assertSame(0, (int) $row->was_ripple_group_member);
+        $this->assertSame('unknown', $row->attribution);
+    }
+
+    public function test_already_derived_rows_are_untouched_and_limit_respected(): void
+    {
+        $poster = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $message = $this->createTestMessage($poster, $group);
+
+        // A row the Go capture already derived - including location evidence the backfill
+        // could never reconstruct. It must not be revisited.
+        $captured = $this->createTestUser();
+        DB::table('rippling_reply_attribution')->insert([
+            'msgid' => $message->id,
+            'userid' => $captured->id,
+            'replied_at' => now()->subHour(),
+            'was_home_member' => 0,
+            'in_origin_catchment' => 0,
+            'in_reach' => 1,
+            'post_had_rippled' => 1,
+            'attribution' => 'ripple_reach',
+            'client_source' => 'browse',
+        ]);
+
+        $legacyA = $this->createTestUser();
+        $legacyB = $this->createTestUser();
+        $this->insertLegacyRow($message->id, $legacyA->id, 0);
+        $this->insertLegacyRow($message->id, $legacyB->id, 0);
+
+        // limit=1 processes exactly one of the two legacy rows.
+        $updated = $this->service->backfill(500, 1);
+        $this->assertSame(1, $updated);
+        $this->assertSame(1, DB::table('rippling_reply_attribution')
+            ->where('msgid', $message->id)->whereNull('attribution')->count());
+
+        $row = $this->attributionRow($message->id, $captured->id);
+        $this->assertSame('ripple_reach', $row->attribution, 'captured rows are never revisited');
+        $this->assertSame('browse', $row->client_source);
+    }
+}

--- a/iznik-nuxt3/api/RipplingAPI.js
+++ b/iznik-nuxt3/api/RipplingAPI.js
@@ -4,14 +4,11 @@ export default class RipplingAPI extends BaseAPI {
   // Rippling-out live event counters for sysadmin (§15/§16). Support/Admin only.
   // Optional groupid scopes the reply/reuse KPIs to one origin group (0 = all);
   // start/end bound the headline KPI date range (default last 30 days server-side).
-  // trialOnly scopes every KPI to the RIPPLE_WITHIN_GROUPS trial set so the trial
-  // signal isn't buried by the majority of groups that aren't rippling yet.
-  fetchMetrics(groupid = 0, start = '', end = '', trialOnly = false) {
+  fetchMetrics(groupid = 0, start = '', end = '') {
     const params = {}
     if (groupid) params.groupid = groupid
     if (start) params.start = start
     if (end) params.end = end
-    if (trialOnly) params.trialOnly = 1
     return this.$getv2('/rippling/metrics', params)
   }
 }

--- a/iznik-nuxt3/components/ChatButton.vue
+++ b/iznik-nuxt3/components/ChatButton.vue
@@ -104,7 +104,8 @@ const openChat = async (
   firstmessage,
   firstmsgid,
   openInNewTab,
-  noNavigate = false
+  noNavigate = false,
+  replySource = null
 ) => {
   emit('click')
   console.log(
@@ -146,7 +147,15 @@ const openChat = async (
       if (firstmessage) {
         console.log('First message to send', firstmessage)
         try {
-          await chatStore.send(chatid, firstmessage, null, null, firstmsgid)
+          await chatStore.send(
+            chatid,
+            firstmessage,
+            null,
+            null,
+            firstmsgid,
+            false,
+            replySource
+          )
           console.log('Sent')
 
           action('chat_message_sent', {

--- a/iznik-nuxt3/components/ChatReplyPane.vue
+++ b/iznik-nuxt3/components/ChatReplyPane.vue
@@ -289,6 +289,7 @@ import {
   ReplyState,
 } from '~/composables/useReplyStateMachine'
 import { action } from '~/composables/useClientLog'
+import { replySurfaceForRoute } from '~/composables/useReplySurface'
 import EmailValidator from '~/components/EmailValidator'
 import NewUserInfo from '~/components/NewUserInfo'
 import ChatButton from '~/components/ChatButton'
@@ -325,6 +326,9 @@ const faraway = FAR_AWAY
 
 const messageStore = useMessageStore()
 const userStore = useUserStore()
+// Captured at setup (useRoute needs the component context); read at send time -
+// the route object is reactive so it reflects wherever the user actually is then.
+const route = useRoute()
 const miscStore = useMiscStore()
 const authStore = useAuthStore()
 const forceLogin = computed(() => authStore.forceLogin)
@@ -478,7 +482,7 @@ onMounted(() => {
 
   action('chat_reply_pane_viewed', {
     message_id: props.messageId,
-    reply_source: 'chat_reply_pane',
+    reply_source: replySurfaceForRoute(route),
     message_type: message.value?.type,
     is_logged_in: !!me.value,
   })
@@ -545,7 +549,10 @@ async function handleSend(callback) {
     emailValidator: emailValidatorRef.value,
   })
 
-  stateMachine.setReplySource('chat_reply_pane')
+  // The surface the user is committing the reply from (browse, search, message_page,
+  // email deep link, ...) - sent to the server as advisory provenance for the rippling
+  // reply attribution, and logged with the Loki reply_* events.
+  stateMachine.setReplySource(replySurfaceForRoute(route))
   await stateMachine.submit(callback)
 }
 

--- a/iznik-nuxt3/components/ChatReplyPane.vue
+++ b/iznik-nuxt3/components/ChatReplyPane.vue
@@ -288,6 +288,7 @@ import {
   useReplyStateMachine,
   ReplyState,
 } from '~/composables/useReplyStateMachine'
+import { useRoute } from '#imports'
 import { action } from '~/composables/useClientLog'
 import { replySurfaceForRoute } from '~/composables/useReplySurface'
 import EmailValidator from '~/components/EmailValidator'

--- a/iznik-nuxt3/composables/useReplyStateMachine.js
+++ b/iznik-nuxt3/composables/useReplyStateMachine.js
@@ -1143,6 +1143,9 @@ export function useReplyStateMachine(messageId, options = {}) {
     }
 
     replyStore.replyingAt = Date.now()
+    // Persist the committing surface too, so provenance survives the
+    // login/registration redirect and reaches the server with the send.
+    replyStore.replySource = replySource.value
     persistState()
 
     log('Reply saved to store:', {

--- a/iznik-nuxt3/composables/useReplySurface.js
+++ b/iznik-nuxt3/composables/useReplySurface.js
@@ -1,0 +1,33 @@
+// Which surface is the user replying from? Derived from the current route at the moment
+// they commit the reply, and sent to the server as advisory provenance (replysource on the
+// chat message POST; stored in rippling_reply_attribution.client_source). It cross-checks
+// the server-derived rippling attribution - it never feeds it, since it's client-supplied.
+//
+// Values are deliberately coarse route-level surfaces, not component names:
+//   email links land on /message/<id> with ?src= (kept verbatim) or bare ?reply=1 -> 'email';
+//   a plain /message deep link -> 'message_page'; /browse with a search term -> 'search',
+//   without -> 'browse'; anything else -> its first path segment (e.g. 'myposts', 'chitchat').
+// The server sanitises to ^[a-z0-9][a-z0-9_-]{0,31}$ and drops anything else.
+
+// Derive the surface from a route object. Split from the composable so it's trivially
+// unit-testable with plain objects.
+export function replySurfaceForRoute(route) {
+  if (!route) return 'unknown'
+  const path = route.path || ''
+  const query = route.query || {}
+
+  if (path.startsWith('/message/')) {
+    if (query.src) {
+      return String(query.src)
+    }
+    // ?reply=1 without src only comes from the email post-card click.
+    return query.reply ? 'email' : 'message_page'
+  }
+
+  if (path.startsWith('/browse')) {
+    return route.params?.term ? 'search' : 'browse'
+  }
+
+  const segment = path.split('/')[1]
+  return segment || 'home'
+}

--- a/iznik-nuxt3/composables/useReplyToPost.js
+++ b/iznik-nuxt3/composables/useReplyToPost.js
@@ -18,6 +18,7 @@ export function useReplyToPost() {
         replyMsgId: replyStore.replyMsgId,
         replyMessage: replyStore.replyMessage,
         replyingAt: replyStore.replyingAt,
+        replySource: replyStore.replySource,
       }
 
       if (
@@ -79,13 +80,15 @@ export function useReplyToPost() {
         replyToSend.value.replyMessage,
         replyToSend.value.replyMsgId,
         false,
-        noNavigate
+        noNavigate,
+        replyToSend.value.replySource
       )
 
       // Clear the store of any message to avoid repeatedly sending it.
       replyStore.replyMsgId = null
       replyStore.replyMessage = null
       replyStore.replyingAt = Date.now()
+      replyStore.replySource = null
 
       // Clear the composing draft for this item too.  The state-machine path
       // does this via clearReply() → clearDraft() in the COMPLETED transition,

--- a/iznik-nuxt3/modtools/components/ModSysAdminRippling.vue
+++ b/iznik-nuxt3/modtools/components/ModSysAdminRippling.vue
@@ -21,25 +21,8 @@
     </div>
     <div v-else-if="error" class="text-danger">Failed to load: {{ error }}</div>
     <div v-else>
-      <b-form-checkbox
-        v-model="trialOnly"
-        switch
-        size="sm"
-        class="mb-2"
-        @change="onTrialChange"
-      >
-        Trial groups only<span
-          v-if="trialOnly && trialGroupIds.length"
-          class="text-muted small"
-        >
-          ({{ trialGroupIds.length }} in RIPPLE_WITHIN_GROUPS)</span>
-      </b-form-checkbox>
-      <p v-if="trialOnly && !trialGroupIds.length" class="text-warning small mb-2">
-        No trial groups configured (RIPPLE_WITHIN_GROUPS is empty) - nothing to show.
-      </p>
-
       <b-form-group
-        v-if="groupOptions.length && !trialOnly"
+        v-if="groupOptions.length"
         label="Group:"
         label-cols="auto"
         label-class="small fw-bold"
@@ -77,7 +60,8 @@
           style="width: 100%; height: 300px"
         />
         <p v-if="replyRateChart" class="text-muted small fst-italic mt-1 mb-0">
-          The dashed tail is still settling - the most recent posts haven't had a full 36h to get a reply yet.
+          The dashed tail is still settling - the most recent posts haven't had
+          a full 36h to get a reply yet.
         </p>
         <p v-if="!replyRateChart" class="text-muted small">No data yet.</p>
       </div>
@@ -108,25 +92,59 @@
       </div>
 
       <div class="mb-3">
-        <strong class="small">Share of replies from rippling</strong>
+        <strong class="small">Where do replies come from?</strong>
         <p class="text-muted small mb-1">
-          Share of replies that came via rippling vs your own members.
-          <span class="text-success fw-bold">Good:</span> a real share - the
-          lift is coming from reach.
-          <span class="text-danger fw-bold">Bad:</span> ~0% - reach isn't
-          producing replies.
+          Each reply is attributed at reply time to the channel that led the
+          replier to the post. <span class="fw-bold">Greens are rippling</span>
+          (we mailed them / it rippled into their group / reach-fed browse);
+          teal is your own established members; greys couldn't be credited
+          either way (local non-members, search, deep links).
+          <span class="text-success fw-bold">Good:</span> a real green share -
+          the lift is coming from reach, and the split says which ripple channel
+          earns it.
+        </p>
+        <p v-if="!attributionChannelsAvailable" class="text-warning small mb-1">
+          This database doesn't have the graded-attribution columns yet
+          (migration pending), so only the durable channels are derived here:
+          location-based channels (reach-fed browse, local non-members) show as
+          unknown.
         </p>
         <GChart
           v-if="replySourceChart"
-          type="LineChart"
+          type="AreaChart"
           :data="replySourceChart"
-          :options="pctChartOptions('Share of replies (%)', '#007bff')"
-          style="width: 100%; height: 300px"
+          :options="channelStackOptions()"
+          style="width: 100%; height: 340px"
         />
         <p v-else class="text-muted small">
           No data yet — accrues from reply-time capture
           (<code>rippling_reply_attribution</code>).
         </p>
+
+        <div v-if="clientSourceSummary.length" class="mt-2">
+          <strong class="small">What the app says (cross-check)</strong>
+          <p class="text-muted small mb-1">
+            The surface the replier's own app reported sending the reply from.
+            Client-supplied, so it never feeds the attribution above - but the
+            two should broadly agree.
+          </p>
+          <b-table-simple hover responsive small class="w-auto">
+            <b-thead>
+              <b-tr>
+                <b-th>Surface</b-th>
+                <b-th>Replies</b-th>
+              </b-tr>
+            </b-thead>
+            <b-tbody>
+              <b-tr v-for="(s, ix) in clientSourceSummary" :key="ix">
+                <b-td>
+                  <code>{{ s.source }}</code>
+                </b-td>
+                <b-td>{{ s.count }}</b-td>
+              </b-tr>
+            </b-tbody>
+          </b-table-simple>
+        </div>
       </div>
 
       <div class="mb-3">
@@ -162,7 +180,8 @@
           style="width: 100%; height: 300px"
         />
         <p v-if="takenRateChart" class="text-muted small fst-italic mt-1 mb-0">
-          The dashed tail is still settling - recent posts haven't had time to be collected yet.
+          The dashed tail is still settling - recent posts haven't had time to
+          be collected yet.
         </p>
         <p v-if="!takenRateChart" class="text-muted small">No data yet.</p>
       </div>
@@ -269,11 +288,10 @@ const takenRate = ref([])
 // Per-group KPI filter (results differ a lot by place; 0 = all groups).
 const groupOptions = ref([])
 const groupFilter = ref(0)
-// Trial scope: limit every KPI to the RIPPLE_WITHIN_GROUPS trial set so the trial
-// signal isn't masked by the majority of groups that aren't rippling. trialGroupIds
-// echoes the resolved set back from the server (drives the count + empty warning).
-const trialOnly = ref(false)
-const trialGroupIds = ref([])
+// Client-reported reply surfaces (advisory cross-check of the attribution chart) and
+// whether this DB has the graded-attribution columns yet (location channels pending).
+const clientSourceSummary = ref([])
+const attributionChannelsAvailable = ref(true)
 
 const COHORT_HEADER = (allLabel) => [
   'Date',
@@ -289,7 +307,15 @@ const replyRateChart = computed(() => {
   if (!replyRate.value.length) return null
   const rows = [...replyRate.value].reverse().map((r) => {
     const certain = !r.provisional
-    return [new Date(r.day), r.reply_pct, certain, r.home_pct, certain, r.ripple_pct, certain]
+    return [
+      new Date(r.day),
+      r.reply_pct,
+      certain,
+      r.home_pct,
+      certain,
+      r.ripple_pct,
+      certain,
+    ]
   })
   return [COHORT_HEADER('All offers'), ...rows]
 })
@@ -309,29 +335,50 @@ const repliesPerPostChart = computed(() => {
   })
   return [COHORT_HEADER('All offers'), ...rows]
 })
+// Attribution channels in stack order (bottom -> top): non-ripple first, then the
+// ripple family as one block of greens so its share reads at a glance.
+const CHANNELS = [
+  { key: 'home', label: 'Home members' },
+  { key: 'organic_local', label: 'Local non-members' },
+  { key: 'unknown', label: 'Unknown' },
+  { key: 'ripple_group', label: 'Rippled into their group' },
+  { key: 'ripple_notified', label: 'Ripple mail' },
+  { key: 'ripple_reach', label: 'Reach-fed browse' },
+]
+
 const replySourceChart = computed(() => {
   if (!startDate.value || !endDate.value) return null
-  // Zero-fill the whole filter range. The backend only returns days that had a
-  // rippling-attributed reply, so early in the rollout this was a single lone
-  // point. A day with no rippling reply genuinely has a 0% rippling share, so
-  // filling the gaps draws a continuous line across the same range as the other
-  // charts instead of one dot floating on a one-day axis.
-  const byDay = new Map(replySource.value.map((r) => [r.day, r.ripple_pct]))
+  if (!replySource.value.length) return null
+  // Zero-fill the whole filter range so the composition spans the same axis as the
+  // other charts; a day with no replies stacks to nothing (a gap), which is honest.
+  const byDay = new Map(replySource.value.map((r) => [r.day, r]))
   const start = new Date(startDate.value)
   const end = new Date(endDate.value)
   if (isNaN(start) || isNaN(end) || end < start) return null
   const rows = []
-  for (const d = new Date(start); d <= end; d.setDate(d.getDate() + 1)) {
+  const days = Math.round((end - start) / 86400000)
+  for (let i = 0; i <= days; i++) {
+    const d = new Date(start)
+    d.setDate(d.getDate() + i)
     const key = d.toISOString().slice(0, 10)
-    rows.push([new Date(d), byDay.has(key) ? byDay.get(key) : 0])
+    const r = byDay.get(key)
+    rows.push([d, ...CHANNELS.map((c) => (r ? r[c.key] || 0 : 0))])
   }
-  return [['Date', '% of replies via rippling'], ...rows]
+  return [['Date', ...CHANNELS.map((c) => c.label)], ...rows]
 })
 const replyDistanceChart = computed(() => {
   if (!replyDistance.value.length) return null
-  const rows = [...replyDistance.value].reverse().map((r) => [
-    new Date(r.day), r.median_km, true, r.home_median_km, true, r.ripple_median_km, true,
-  ])
+  const rows = [...replyDistance.value]
+    .reverse()
+    .map((r) => [
+      new Date(r.day),
+      r.median_km,
+      true,
+      r.home_median_km,
+      true,
+      r.ripple_median_km,
+      true,
+    ])
   // Distance is a median over replies, not a count of offers, so label the "all" line accordingly.
   return [COHORT_HEADER('All replies'), ...rows]
 })
@@ -339,7 +386,15 @@ const takenRateChart = computed(() => {
   if (!takenRate.value.length) return null
   const rows = [...takenRate.value].reverse().map((r) => {
     const certain = !r.provisional
-    return [new Date(r.day), r.taken_pct, certain, r.home_pct, certain, r.ripple_pct, certain]
+    return [
+      new Date(r.day),
+      r.taken_pct,
+      certain,
+      r.home_pct,
+      certain,
+      r.ripple_pct,
+      certain,
+    ]
   })
   return [COHORT_HEADER('All offers'), ...rows]
 })
@@ -357,8 +412,10 @@ function dateTicks() {
   const days = Math.round((end - start) / 86400000)
   const step = Math.max(1, Math.ceil((days + 1) / 8))
   const ticks = []
-  for (let d = new Date(start); d <= end; d.setDate(d.getDate() + step)) {
-    ticks.push(new Date(d))
+  for (let i = 0; i <= days; i += step) {
+    const d = new Date(start)
+    d.setDate(d.getDate() + i)
+    ticks.push(d)
   }
   return ticks
 }
@@ -376,14 +433,28 @@ function dateHAxis() {
   return h
 }
 
-function pctChartOptions(vTitle, color) {
+// Percent-stacked area of the attribution channels. Colors validated (dataviz six
+// checks, light surface): the two greys are DELIBERATELY low-chroma - they are the
+// "couldn't credit either way" buckets - and the ripple family is one green hue,
+// lightness-stepped, so the total green band = the ripple share. Legend + tooltips
+// carry exact identities/values (the greys/light green sit below the 3:1 fill
+// contrast line, which is acceptable for large stacked fills with those two reliefs).
+function channelStackOptions() {
   return {
-    curveType: 'function',
-    legend: { position: 'none' },
-    chartArea: { width: '85%', height: '70%' },
-    vAxis: { title: vTitle, viewWindow: { min: 0 }, format: '#.#' },
+    isStacked: 'percent',
+    legend: { position: 'bottom' },
+    chartArea: { width: '85%', height: '65%' },
+    vAxis: { title: 'Share of replies', format: 'percent' },
     hAxis: dateHAxis(),
-    series: { 0: { color } },
+    areaOpacity: 0.85,
+    series: {
+      0: { color: '#1592a6' }, // Home members — teal (matches the cohort charts)
+      1: { color: '#6c757d' }, // Local non-members — grey (deliberately neutral)
+      2: { color: '#98a2ab' }, // Unknown — light grey (deliberately neutral)
+      3: { color: '#28a745' }, // Rippled into their group — green
+      4: { color: '#146c43' }, // Ripple mail — dark green
+      5: { color: '#45b463' }, // Reach-fed browse — light green
+    },
     animation: { startup: true, duration: 400, easing: 'out' },
   }
 }
@@ -426,18 +497,19 @@ async function fetchMetrics() {
     const result = await apiInstance.rippling.fetchMetrics(
       groupFilter.value,
       startDate.value,
-      endDate.value,
-      trialOnly.value
+      endDate.value
     )
     hotspots.value = result?.hotspots || []
     heldReplySummary.value = result?.held_reply_summary || []
     replyRate.value = result?.reply_rate_36h || []
     repliesPerPost.value = result?.replies_per_post || []
     replySource.value = result?.reply_source_split || []
+    clientSourceSummary.value = result?.client_source_summary || []
+    attributionChannelsAvailable.value =
+      result?.attribution_channels_available !== false
     replyDistance.value = result?.reply_distance_median || []
     takenRate.value = result?.taken_rate || []
     groupOptions.value = result?.groups || []
-    trialGroupIds.value = result?.trial_group_ids || []
   } catch (e) {
     error.value = e.message || 'Unknown error'
   } finally {
@@ -446,13 +518,6 @@ async function fetchMetrics() {
 }
 
 function onGroupChange() {
-  fetchMetrics()
-}
-
-function onTrialChange() {
-  // Trial scope and a single-group filter are mutually exclusive (the server lets
-  // groupid win), so clear the group filter when switching to trial-only.
-  groupFilter.value = 0
   fetchMetrics()
 }
 
@@ -469,8 +534,5 @@ defineExpose({
   groupFilter,
   onGroupChange,
   onFilterFetch,
-  trialOnly,
-  trialGroupIds,
-  onTrialChange,
 })
 </script>

--- a/iznik-nuxt3/modtools/components/ModSysAdminRippling.vue
+++ b/iznik-nuxt3/modtools/components/ModSysAdminRippling.vue
@@ -102,6 +102,11 @@
           <span class="text-success fw-bold">Good:</span> a real green share -
           the lift is coming from reach, and the split says which ripple channel
           earns it.
+          <span v-if="attributionCaptureFrom">
+            Left of the "Live capture" line the history is derived after the
+            fact, so only the mail and group ripple channels can be credited -
+            reach-fed browse and local non-members sit in Unknown there.
+          </span>
         </p>
         <p v-if="!attributionChannelsAvailable" class="text-warning small mb-1">
           This database doesn't have the graded-attribution columns yet
@@ -292,6 +297,10 @@ const groupFilter = ref(0)
 // whether this DB has the graded-attribution columns yet (location channels pending).
 const clientSourceSummary = ref([])
 const attributionChannelsAvailable = ref(true)
+// First day with reply-time-captured evidence: before this the location channels are
+// structurally zero (derived history can only see mail/group evidence), so the chart marks
+// the boundary rather than letting it read as reach-browse suddenly springing to life.
+const attributionCaptureFrom = ref('')
 
 const COHORT_HEADER = (allLabel) => [
   'Date',
@@ -362,9 +371,20 @@ const replySourceChart = computed(() => {
     d.setDate(d.getDate() + i)
     const key = d.toISOString().slice(0, 10)
     const r = byDay.get(key)
-    rows.push([d, ...CHANNELS.map((c) => (r ? r[c.key] || 0 : 0))])
+    // A domain annotation draws a vertical marker where live reply-time capture began:
+    // to its left the history is derived (mail/group channels only, the rest in
+    // Unknown), to its right the full six-way split applies. One chart, two eras,
+    // boundary explicit.
+    const marker =
+      attributionCaptureFrom.value && key === attributionCaptureFrom.value
+        ? 'Live capture from here'
+        : null
+    rows.push([d, marker, ...CHANNELS.map((c) => (r ? r[c.key] || 0 : 0))])
   }
-  return [['Date', ...CHANNELS.map((c) => c.label)], ...rows]
+  return [
+    ['Date', { role: 'annotation' }, ...CHANNELS.map((c) => c.label)],
+    ...rows,
+  ]
 })
 const replyDistanceChart = computed(() => {
   if (!replyDistance.value.length) return null
@@ -446,6 +466,8 @@ function channelStackOptions() {
     chartArea: { width: '85%', height: '65%' },
     vAxis: { title: 'Share of replies', format: 'percent' },
     hAxis: dateHAxis(),
+    // The domain annotation marking where live capture began renders as a vertical line.
+    annotations: { style: 'line' },
     areaOpacity: 0.85,
     series: {
       0: { color: '#1592a6' }, // Home members — teal (matches the cohort charts)
@@ -507,6 +529,7 @@ async function fetchMetrics() {
     clientSourceSummary.value = result?.client_source_summary || []
     attributionChannelsAvailable.value =
       result?.attribution_channels_available !== false
+    attributionCaptureFrom.value = result?.attribution_capture_from || ''
     replyDistance.value = result?.reply_distance_median || []
     takenRate.value = result?.taken_rate || []
     groupOptions.value = result?.groups || []

--- a/iznik-nuxt3/stores/chat.js
+++ b/iznik-nuxt3/stores/chat.js
@@ -335,7 +335,15 @@ export const useChatStore = defineStore({
     async typing(chatid) {
       await api(this.config).chat.typing(chatid)
     },
-    async send(chatid, message, addressid, imageid, refmsgid, modnote) {
+    async send(
+      chatid,
+      message,
+      addressid,
+      imageid,
+      refmsgid,
+      modnote,
+      replysource
+    ) {
       const data = {
         roomid: chatid,
       }
@@ -359,6 +367,13 @@ export const useChatStore = defineStore({
 
       if (modnote) {
         data.modnote = true
+      }
+
+      // Advisory reply provenance (which surface the reply came from) - only
+      // meaningful alongside refmsgid; the server sanitises and stores it with
+      // the rippling reply attribution.
+      if (refmsgid && replysource) {
+        data.replysource = replysource
       }
 
       await api(this.config).chat.send(data)

--- a/iznik-nuxt3/stores/reply.js
+++ b/iznik-nuxt3/stores/reply.js
@@ -8,6 +8,7 @@ export const useReplyStore = defineStore({
       'replyMsgId',
       'replyMessage',
       'replyingAt',
+      'replySource',
       'machineState',
       'isNewUser',
       'draftMsgId',
@@ -24,6 +25,10 @@ export const useReplyStore = defineStore({
     replyMsgId: null,
     replyMessage: null,
     replyingAt: null,
+    // The surface the reply was committed from (browse, search, message_page,
+    // email, ...) - persisted so provenance survives the login/registration
+    // redirect and still reaches the server with the eventual send.
+    replySource: null,
     // State machine state for resume capability
     machineState: null,
     isNewUser: false,
@@ -45,6 +50,7 @@ export const useReplyStore = defineStore({
       this.replyMsgId = null
       this.replyMessage = null
       this.replyingAt = null
+      this.replySource = null
       this.machineState = null
       this.isNewUser = false
       this.clearDraft()

--- a/iznik-nuxt3/tests/unit/components/ChatReplyPane.spec.js
+++ b/iznik-nuxt3/tests/unit/components/ChatReplyPane.spec.js
@@ -100,6 +100,16 @@ vi.mock('~/constants', () => ({
   FAR_AWAY: 20,
 }))
 
+// ChatReplyPane captures the current route at setup to derive the reply surface
+// (provenance) at send time.
+vi.mock('#imports', async () => {
+  const actual = await vi.importActual('#imports')
+  return {
+    ...actual,
+    useRoute: () => ({ path: '/browse', query: {}, params: {} }),
+  }
+})
+
 vi.hoisted(() => {
   vi.resetModules()
 })

--- a/iznik-nuxt3/tests/unit/components/modtools/ModSysAdminRippling.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModSysAdminRippling.spec.js
@@ -112,6 +112,7 @@ describe('ModSysAdminRippling', () => {
     const data = charts[0].props('data')
     expect(data[0]).toEqual([
       'Date',
+      { role: 'annotation' },
       'Home members',
       'Local non-members',
       'Unknown',
@@ -125,10 +126,34 @@ describe('ModSysAdminRippling', () => {
         (r) =>
           r[0] instanceof Date && r[0].toISOString().startsWith('2026-06-20')
       )
-    // Channel counts in header order after the date.
-    expect(row.slice(1)).toEqual([4, 1, 1, 1, 2, 1])
+    // Channel counts in header order after the date + annotation columns.
+    expect(row.slice(2)).toEqual([4, 1, 1, 1, 2, 1])
     // The stack is a percent composition.
     expect(charts[0].props('options').isStacked).toBe('percent')
+    wrapper.unmount()
+  })
+
+  it('marks the live-capture boundary on the attribution chart', async () => {
+    mockFetchMetrics.mockResolvedValue({
+      reply_source_split: [
+        { day: '2026-06-20', replies: 5, home: 5 },
+        { day: '2026-06-21', replies: 6, home: 3, ripple_reach: 3 },
+      ],
+      attribution_channels_available: true,
+      attribution_capture_from: '2026-06-21',
+    })
+
+    const wrapper = mountComponent()
+    await flushPromises()
+
+    const charts = wrapper.findAllComponents({ name: 'GChart' })
+    const rows = charts[0].props('data').slice(1)
+    const marked = rows.filter((r) => r[1] !== null)
+    expect(marked.length).toBe(1)
+    expect(marked[0][0].toISOString().startsWith('2026-06-21')).toBe(true)
+    expect(marked[0][1]).toBe('Live capture from here')
+    // The boundary is explained to the reader.
+    expect(wrapper.html()).toContain('Live capture')
     wrapper.unmount()
   })
 

--- a/iznik-nuxt3/tests/unit/components/modtools/ModSysAdminRippling.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModSysAdminRippling.spec.js
@@ -68,40 +68,100 @@ describe('ModSysAdminRippling', () => {
     const wrapper = mountComponent()
     await flushPromises()
 
-    expect(mockFetchMetrics).toHaveBeenCalledWith(0, '2026-05-24', '2026-06-23', false)
+    expect(mockFetchMetrics).toHaveBeenCalledWith(0, '2026-05-24', '2026-06-23')
     wrapper.unmount()
   })
 
-  it('scopes the metrics to the trial groups when "Trial groups only" is on', async () => {
-    mockFetchMetrics.mockResolvedValue({ trial_group_ids: [111, 222] })
-
-    const wrapper = mountComponent()
-    await flushPromises()
-    mockFetchMetrics.mockClear()
-
-    // Turn on the trial scope and refetch via the exposed handler.
-    wrapper.vm.trialOnly = true
-    wrapper.vm.onTrialChange()
-    await flushPromises()
-
-    // The refetch carries trialOnly=true (4th arg) with the group filter reset to 0,
-    // and the resolved trial set is surfaced in the UI.
-    expect(mockFetchMetrics).toHaveBeenCalledWith(0, '2026-05-24', '2026-06-23', true)
-    expect(wrapper.html()).toContain('in RIPPLE_WITHIN_GROUPS')
-    wrapper.unmount()
-  })
-
-  it('warns when trial scope is on but no trial groups are configured', async () => {
-    mockFetchMetrics.mockResolvedValue({ trial_group_ids: [] })
+  it('has retired the trial-groups scope (rippling is fully live)', async () => {
+    mockFetchMetrics.mockResolvedValue({})
 
     const wrapper = mountComponent()
     await flushPromises()
 
-    wrapper.vm.trialOnly = true
-    wrapper.vm.onTrialChange()
+    expect(wrapper.html()).not.toContain('Trial groups only')
+    expect(wrapper.vm.trialOnly).toBeUndefined()
+    wrapper.unmount()
+  })
+
+  it('renders the attribution-channel composition from reply_source_split', async () => {
+    mockFetchMetrics.mockResolvedValue({
+      reply_source_split: [
+        {
+          day: '2026-06-20',
+          replies: 10,
+          home: 4,
+          ripple_notified: 2,
+          ripple_group: 1,
+          ripple_reach: 1,
+          organic_local: 1,
+          unknown: 1,
+          ripple: 4,
+          ripple_pct: 40,
+        },
+      ],
+      attribution_channels_available: true,
+    })
+
+    const wrapper = mountComponent()
     await flushPromises()
 
-    expect(wrapper.html()).toContain('No trial groups configured')
+    expect(wrapper.html()).toContain('Where do replies come from?')
+
+    const charts = wrapper.findAllComponents({ name: 'GChart' })
+    expect(charts.length).toBe(1)
+    const data = charts[0].props('data')
+    expect(data[0]).toEqual([
+      'Date',
+      'Home members',
+      'Local non-members',
+      'Unknown',
+      'Rippled into their group',
+      'Ripple mail',
+      'Reach-fed browse',
+    ])
+    const row = data
+      .slice(1)
+      .find(
+        (r) =>
+          r[0] instanceof Date && r[0].toISOString().startsWith('2026-06-20')
+      )
+    // Channel counts in header order after the date.
+    expect(row.slice(1)).toEqual([4, 1, 1, 1, 2, 1])
+    // The stack is a percent composition.
+    expect(charts[0].props('options').isStacked).toBe('percent')
+    wrapper.unmount()
+  })
+
+  it('notes when the graded-attribution migration has not run on this DB', async () => {
+    mockFetchMetrics.mockResolvedValue({
+      attribution_channels_available: false,
+    })
+
+    const wrapper = mountComponent()
+    await flushPromises()
+
+    expect(wrapper.html()).toContain('graded-attribution columns yet')
+    wrapper.unmount()
+  })
+
+  it('renders the client-reported surface cross-check table when present', async () => {
+    mockFetchMetrics.mockResolvedValue({
+      client_source_summary: [
+        { source: 'browse', count: 12 },
+        { source: 'message_page', count: 5 },
+        { source: '(not reported)', count: 2 },
+      ],
+      attribution_channels_available: true,
+    })
+
+    const wrapper = mountComponent()
+    await flushPromises()
+
+    const html = wrapper.html()
+    expect(html).toContain('What the app says')
+    expect(html).toContain('browse')
+    expect(html).toContain('message_page')
+    expect(html).toContain('(not reported)')
     wrapper.unmount()
   })
 
@@ -188,33 +248,66 @@ describe('ModSysAdminRippling', () => {
     })
   })
 
-  it('retitles the reply-source chart and renders cohort series', async () => {
+  it('renders cohort series with certainty flags on settling days', async () => {
     mockFetchMetrics.mockResolvedValue({
       reply_rate_36h: [
-        { day: '2026-06-20', posts: 10, replied: 4, reply_pct: 40,
-          home_posts: 6, home_replied: 2, home_pct: 33.3,
-          ripple_posts: 4, ripple_replied: 2, ripple_pct: 50, provisional: false },
-        { day: '2026-06-23', posts: 5, replied: 1, reply_pct: 20,
-          home_posts: 3, home_replied: 0, home_pct: 0,
-          ripple_posts: 2, ripple_replied: 1, ripple_pct: 50, provisional: true },
+        {
+          day: '2026-06-20',
+          posts: 10,
+          replied: 4,
+          reply_pct: 40,
+          home_posts: 6,
+          home_replied: 2,
+          home_pct: 33.3,
+          ripple_posts: 4,
+          ripple_replied: 2,
+          ripple_pct: 50,
+          provisional: false,
+        },
+        {
+          day: '2026-06-23',
+          posts: 5,
+          replied: 1,
+          reply_pct: 20,
+          home_posts: 3,
+          home_replied: 0,
+          home_pct: 0,
+          ripple_posts: 2,
+          ripple_replied: 1,
+          ripple_pct: 50,
+          provisional: true,
+        },
       ],
       reply_distance_median: [
-        { day: '2026-06-20', replies: 8, median_km: 5,
-          home_replies: 5, home_median_km: 3, ripple_replies: 3, ripple_median_km: 9 },
+        {
+          day: '2026-06-20',
+          replies: 8,
+          median_km: 5,
+          home_replies: 5,
+          home_median_km: 3,
+          ripple_replies: 3,
+          ripple_median_km: 9,
+        },
       ],
       taken_rate: [
-        { day: '2026-06-15', posts: 12, taken: 6, taken_pct: 50,
-          home_posts: 8, home_taken: 4, home_pct: 50,
-          ripple_posts: 4, ripple_taken: 2, ripple_pct: 50, provisional: false },
+        {
+          day: '2026-06-15',
+          posts: 12,
+          taken: 6,
+          taken_pct: 50,
+          home_posts: 8,
+          home_taken: 4,
+          home_pct: 50,
+          ripple_posts: 4,
+          ripple_taken: 2,
+          ripple_pct: 50,
+          provisional: false,
+        },
       ],
     })
 
     const wrapper = mountComponent()
     await flushPromises()
-
-    // Chart 2 retitled.
-    expect(wrapper.html()).toContain('Share of replies from rippling')
-    expect(wrapper.html()).not.toContain('How much of the lift is rippling?')
 
     const charts = wrapper.findAllComponents({ name: 'GChart' })
     // charts[0] is the reply-rate chart (reply-source is omitted from this mock, so it doesn't render).

--- a/iznik-nuxt3/tests/unit/composables/useReplySurface.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useReplySurface.spec.js
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+
+import { replySurfaceForRoute } from '~/composables/useReplySurface'
+
+// The committing-surface derivation for reply provenance. Pure function over the
+// route, so these are exhaustive table tests of the mapping the server will see
+// in rippling_reply_attribution.client_source.
+describe('replySurfaceForRoute', () => {
+  it('keeps an email src param verbatim on the message page', () => {
+    expect(
+      replySurfaceForRoute({
+        path: '/message/123',
+        query: { src: 'digest', reply: '1' },
+      })
+    ).toBe('digest')
+  })
+
+  it('maps a bare ?reply=1 message deep link to email (post-card click)', () => {
+    expect(
+      replySurfaceForRoute({ path: '/message/123', query: { reply: '1' } })
+    ).toBe('email')
+  })
+
+  it('maps a plain message deep link to message_page', () => {
+    expect(replySurfaceForRoute({ path: '/message/123', query: {} })).toBe(
+      'message_page'
+    )
+  })
+
+  it('maps browse without a term to browse and with a term to search', () => {
+    expect(
+      replySurfaceForRoute({ path: '/browse', query: {}, params: {} })
+    ).toBe('browse')
+    expect(
+      replySurfaceForRoute({
+        path: '/browse/bike',
+        query: {},
+        params: { term: 'bike' },
+      })
+    ).toBe('search')
+  })
+
+  it('falls back to the first path segment elsewhere', () => {
+    expect(replySurfaceForRoute({ path: '/myposts', query: {} })).toBe(
+      'myposts'
+    )
+    expect(replySurfaceForRoute({ path: '/', query: {} })).toBe('home')
+  })
+
+  it('is defensive about a missing route', () => {
+    expect(replySurfaceForRoute(null)).toBe('unknown')
+  })
+})

--- a/iznik-nuxt3/tests/unit/composables/useReplyToPost.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useReplyToPost.spec.js
@@ -144,6 +144,7 @@ describe('useReplyToPost', () => {
         replyMsgId: 42,
         replyMessage: 'Hello, is this still available?',
         replyingAt: RECENT_AT,
+        replySource: 'browse',
       })
     })
 
@@ -154,17 +155,19 @@ describe('useReplyToPost', () => {
       expect(replyToSend.value.replyMsgId).toBe(42)
     })
 
-    it('includes all three store fields in the returned object', () => {
+    it('includes the pending-send store fields in the returned object', () => {
       mockReplyStore = freshReplyStore({
         replyMsgId: 99,
         replyMessage: 'Test message',
         replyingAt: RECENT_AT,
+        replySource: 'message_page',
       })
       const { replyToSend } = useReplyToPost()
       expect(replyToSend.value).toEqual({
         replyMsgId: 99,
         replyMessage: 'Test message',
         replyingAt: RECENT_AT,
+        replySource: 'message_page',
       })
     })
   })

--- a/iznik-nuxt3/tests/unit/composables/useReplyToPost.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useReplyToPost.spec.js
@@ -48,6 +48,7 @@ function freshReplyStore(overrides = {}) {
     replyMsgId: 42,
     replyMessage: 'Hello, is this still available?',
     replyingAt: RECENT_AT,
+    replySource: 'browse',
     draftMsgId: null,
     clearDraft: vi.fn(),
     ...overrides,
@@ -264,13 +265,15 @@ describe('useReplyToPost', () => {
       const chatButtonRef = { openChat }
       const { replyToPost } = useReplyToPost()
       await replyToPost(chatButtonRef)
-      // openInNewTab=false, noNavigate=false by default.
+      // openInNewTab=false, noNavigate=false by default; the committing surface
+      // (reply provenance) rides along as the final argument.
       expect(openChat).toHaveBeenCalledWith(
         null,
         'Hello, is this still available?',
         42,
         false,
-        false
+        false,
+        'browse'
       )
     })
 
@@ -284,7 +287,8 @@ describe('useReplyToPost', () => {
         'Hello, is this still available?',
         42,
         false,
-        true
+        true,
+        'browse'
       )
     })
 
@@ -301,6 +305,7 @@ describe('useReplyToPost', () => {
       await replyToPost(chatButtonRef)
       expect(mockReplyStore.replyMsgId).toBeNull()
       expect(mockReplyStore.replyMessage).toBeNull()
+      expect(mockReplyStore.replySource).toBeNull()
     })
 
     it('clears a composing draft for the same item after sending', async () => {

--- a/iznik-nuxt3/tests/unit/stores/chat.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/chat.spec.js
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
 
+// Import the REAL store directly — vitest.config.mts aliases ~/stores/chat
+// to a global mock for other tests. We need the actual implementation here.
+import { useChatStore } from '../../../stores/chat'
+
 const mockListChats = vi.fn().mockResolvedValue([])
 const mockListChatsMT = vi.fn().mockResolvedValue({ chatrooms: [] })
 const mockFetchChat = vi.fn().mockResolvedValue(null)
@@ -18,9 +22,7 @@ const mockSendMT = vi.fn().mockResolvedValue()
 const mockUnseenCountMT = vi.fn().mockResolvedValue(0)
 const mockAllSeen = vi.fn().mockResolvedValue()
 const mockRsvp = vi.fn().mockResolvedValue()
-const mockFetchReviewChatsMT = vi
-  .fn()
-  .mockResolvedValue({ chatmessages: [] })
+const mockFetchReviewChatsMT = vi.fn().mockResolvedValue({ chatmessages: [] })
 
 vi.mock('~/api', () => ({
   default: () => ({
@@ -80,12 +82,7 @@ vi.mock('~/stores/user', () => ({
   }),
 }))
 
-// Import the REAL store directly — vitest.config.mts aliases ~/stores/chat
-// to a global mock for other tests. We need the actual implementation here.
-import { useChatStore } from '../../../stores/chat'
-
 describe('chat store', () => {
-
   beforeEach(() => {
     vi.clearAllMocks()
     setActivePinia(createPinia())
@@ -228,7 +225,10 @@ describe('chat store', () => {
 
       await store.send(10, 'new message')
 
-      expect(mockSend).toHaveBeenCalledWith({ roomid: 10, message: 'new message' })
+      expect(mockSend).toHaveBeenCalledWith({
+        roomid: 10,
+        message: 'new message',
+      })
       expect(store.listByChatId[10].snippet).toBe('new message')
     })
 
@@ -238,7 +238,7 @@ describe('chat store', () => {
       store.listByChatId[10] = { id: 10 }
       mockFetchMessages.mockResolvedValue([])
 
-      await store.send(10, 'hi', 1, 2, 3, true)
+      await store.send(10, 'hi', 1, 2, 3, true, 'browse')
 
       expect(mockSend).toHaveBeenCalledWith({
         roomid: 10,
@@ -247,6 +247,7 @@ describe('chat store', () => {
         imageid: 2,
         refmsgid: 3,
         modnote: true,
+        replysource: 'browse',
       })
     })
 
@@ -256,6 +257,19 @@ describe('chat store', () => {
       mockFetchMessages.mockResolvedValue([])
 
       await store.send(10, 'hi', null, null, null, false)
+
+      expect(mockSend).toHaveBeenCalledWith({
+        roomid: 10,
+        message: 'hi',
+      })
+    })
+
+    it('only sends replysource alongside a refmsgid (reply provenance, not chat chatter)', async () => {
+      const store = useChatStore()
+      store.config = {}
+      mockFetchMessages.mockResolvedValue([])
+
+      await store.send(10, 'hi', null, null, null, false, 'browse')
 
       expect(mockSend).toHaveBeenCalledWith({
         roomid: 10,

--- a/iznik-server-go/chat/chatmessage.go
+++ b/iznik-server-go/chat/chatmessage.go
@@ -552,8 +552,8 @@ func CreateChatMessage(c *fiber.Ctx) error {
 			latlng := user.GetLatLng(myid)
 			if latlng.Lat != 0 || latlng.Lng != 0 {
 				reach.haveLocation = true
-				reach.lat = latlng.Lat
-				reach.lng = latlng.Lng
+				reach.lat = float64(latlng.Lat)
+				reach.lng = float64(latlng.Lng)
 				// One query answers both "does a reach row exist" and "does it contain the
 				// replier" (msgid is the PK, so at most one row): the gate blocks when a reach
 				// row exists that does NOT contain the point, and the attribution capture

--- a/iznik-server-go/chat/chatmessage.go
+++ b/iznik-server-go/chat/chatmessage.go
@@ -14,6 +14,7 @@ import (
 	"github.com/freegle/iznik-server-go/log"
 	"github.com/freegle/iznik-server-go/microvolunteering"
 	"github.com/freegle/iznik-server-go/misc"
+	"github.com/freegle/iznik-server-go/rippling"
 	"github.com/freegle/iznik-server-go/user"
 	"github.com/freegle/iznik-server-go/utils"
 	"github.com/gofiber/fiber/v2"
@@ -51,8 +52,13 @@ type ChatMessage struct {
 	HeldByRippling bool    `json:"heldbyrippling,omitempty" gorm:"-"`
 	Addressid      *uint64 `json:"addressid" gorm:"-"`
 	Modnote        bool    `json:"modnote" gorm:"-"`
-	Archived       int     `json:"-" gorm:"-"`
-	Deleted        bool    `json:"-"`
+	// Replysource is the client-reported surface an Interested reply came from (browse,
+	// search, message_page, notification, ...). Advisory reply-provenance evidence for the
+	// rippling attribution capture - sanitised there, stored in rippling_reply_attribution,
+	// never a chat_messages column.
+	Replysource *string `json:"replysource" gorm:"-"`
+	Archived    int     `json:"-" gorm:"-"`
+	Deleted     bool    `json:"-"`
 }
 
 // We need a separate struct for the query so that we can return image info in a single query.  If we put the
@@ -336,6 +342,114 @@ func GetReviewChatMessages(c *fiber.Ctx) error {
 // POST / CREATE handlers
 // =============================================================================
 
+// replyReachEvidence carries what the rippling reply gate already computed about the replier's
+// location vs the post's reach polygon, so the attribution capture doesn't repeat the spatial
+// query. checked distinguishes "gate ran and found no reach row" from "gate couldn't run"
+// (no location, or rippling_reach doesn't exist yet).
+type replyReachEvidence struct {
+	haveLocation bool
+	lat, lng     float64
+	checked      bool
+	reachRows    int
+	inReach      int
+}
+
+// recordReplyAttribution snapshots, at reply time, the evidence for how the replier came to see
+// the post, plus the derived attribution channel (see rippling.DeriveAttribution for the ladder
+// and the rippling_reply_attribution migration for column semantics). Snapshotting matters
+// because the evidence decays: the Nuxt reply flow joins the replier to the group in order to
+// reply (useReplyStateMachine.handleJoinGroup) so a retrospective membership check would
+// mis-count every rippling reply as home-group; members leave; locations drift; reach polygons
+// grow. INSERT IGNORE = first reply only; frozen so none of that can rewrite history.
+// Best-effort throughout: attribution must never break replying, so errors are swallowed, and
+// until the graded columns are migrated (production lags dev) it falls back to the legacy
+// was_home_member-only insert.
+func recordReplyAttribution(db *gorm.DB, myid uint64, refmsgid uint64, reach replyReachEvidence, clientSource *string) {
+	// Established member of an ORIGIN (non-rippled-in) group of the post, whose membership
+	// predates this reply by more than the join grace (300s)? A join made to reply
+	// (added ~ now) is excluded.
+	var wasHome int
+	db.Raw("SELECT EXISTS(SELECT 1 FROM messages_groups mg "+
+		"INNER JOIN memberships mem ON mem.groupid = mg.groupid AND mem.userid = ? "+
+		"AND mem.collection = ? AND mem.added < NOW() - INTERVAL 300 SECOND "+
+		"WHERE mg.msgid = ? AND mg.rippled_in = 0 AND mg.deleted = 0)",
+		myid, utils.COLLECTION_APPROVED, refmsgid).Scan(&wasHome)
+
+	if !rippling.AttributionSchemaReady(db) {
+		db.Exec("INSERT IGNORE INTO rippling_reply_attribution (msgid, userid, replied_at, was_home_member) "+
+			"VALUES (?, ?, NOW(), ?)", refmsgid, myid, wasHome)
+		return
+	}
+
+	// Did we send this user the ripple "new post near you" mail for this post? Keyed lookup on
+	// the notified ledger - the strongest direct ripple-delivery evidence.
+	var wasNotified int
+	db.Raw("SELECT EXISTS(SELECT 1 FROM rippling_reach_notified WHERE msgid = ? AND userid = ?)",
+		refmsgid, myid).Scan(&wasNotified)
+
+	// Established member of a group the post rippled INTO: added before the rippled copy
+	// arrived, so they were already there when it rippled in and saw it in their own group's
+	// feed/digest because of the ripple. The cut is the copy's arrival, NOT the 300s grace:
+	// the join-to-reply flow can join the rippled copy's group, and a pre-arrival membership
+	// is the only sound "they were already there" test.
+	var wasRippleGroup int
+	db.Raw("SELECT EXISTS(SELECT 1 FROM messages_groups mg "+
+		"INNER JOIN memberships mem ON mem.groupid = mg.groupid AND mem.userid = ? "+
+		"AND mem.collection = ? AND mem.added < mg.arrival "+
+		"WHERE mg.msgid = ? AND mg.rippled_in = 1 AND mg.deleted = 0)",
+		myid, utils.COLLECTION_APPROVED, refmsgid).Scan(&wasRippleGroup)
+
+	// Had the post rippled AT ALL by reply time (a rippled-in copy, or a reach row)? This is
+	// the ladder's hard guard: when 0, the reply can never be ripple-attributed. Reuse the
+	// gate's reach lookup when it ran; only query rippling_reach (which may not exist yet -
+	// best-effort) when it didn't.
+	var postHadRippled int
+	db.Raw("SELECT EXISTS(SELECT 1 FROM messages_groups WHERE msgid = ? AND rippled_in = 1 AND deleted = 0)",
+		refmsgid).Scan(&postHadRippled)
+	if postHadRippled == 0 && reach.reachRows > 0 {
+		postHadRippled = 1
+	}
+	if postHadRippled == 0 && !reach.checked {
+		var hasReach int
+		if err := db.Raw("SELECT EXISTS(SELECT 1 FROM rippling_reach WHERE msgid = ?)",
+			refmsgid).Scan(&hasReach).Error; err == nil && hasReach == 1 {
+			postHadRippled = 1
+		}
+	}
+
+	// Location evidence - nil (NULL in the row) when the replier has no usable location, which
+	// is distinct from a definite "outside".
+	var inOrigin, inReach *int
+	if reach.haveLocation {
+		v := 0
+		// Inside any origin group's catchment? polyindex is the group's DPA-or-CGA; groups
+		// with only a POINT placeholder can't contain anything and are excluded.
+		db.Raw("SELECT EXISTS(SELECT 1 FROM messages_groups mg "+
+			"INNER JOIN `groups` g ON g.id = mg.groupid "+
+			"WHERE mg.msgid = ? AND mg.rippled_in = 0 AND mg.deleted = 0 "+
+			"AND g.polyindex IS NOT NULL AND ST_GeometryType(g.polyindex) <> 'POINT' "+
+			"AND ST_Contains(g.polyindex, ST_SRID(POINT(?, ?), ?)))",
+			refmsgid, reach.lng, reach.lat, utils.SRID).Scan(&v)
+		inOrigin = &v
+		if reach.checked {
+			r := 0
+			if reach.reachRows > 0 && reach.inReach == 1 {
+				r = 1
+			}
+			inReach = &r
+		}
+	}
+
+	attribution := rippling.DeriveAttribution(wasHome, wasNotified, wasRippleGroup, postHadRippled, inOrigin, inReach)
+
+	db.Exec("INSERT IGNORE INTO rippling_reply_attribution "+
+		"(msgid, userid, replied_at, was_home_member, was_notified, was_ripple_group_member, "+
+		"in_origin_catchment, in_reach, post_had_rippled, attribution, client_source) "+
+		"VALUES (?, ?, NOW(), ?, ?, ?, ?, ?, ?, ?, ?)",
+		refmsgid, myid, wasHome, wasNotified, wasRippleGroup, inOrigin, inReach, postHadRippled,
+		attribution, rippling.SanitizeClientSource(clientSource))
+}
+
 func CreateChatMessage(c *fiber.Ctx) error {
 	myid := user.WhoAmI(c)
 	db := database.DBConn
@@ -428,18 +542,37 @@ func CreateChatMessage(c *fiber.Ctx) error {
 	// typed CHAT_MESSAGE_INTERESTED, so without this scope a report of a rippled post 403s when the
 	// reporter is outside the post's reach polygon (Discourse #9852). Restricting to User2User does
 	// not weaken reply-eligibility, since genuine Interested replies are always User2User.
+	// The room type also scopes the attribution capture below (a refmsgid message in a
+	// User2Mod room is a REPORT, not a reply), so fetch it once here.
+	roomType := ""
+	reach := replyReachEvidence{}
 	if chattype == utils.CHAT_MESSAGE_INTERESTED && payload.Refmsgid != nil {
-		var roomType string
 		db.Raw("SELECT chattype FROM chat_rooms WHERE id = ?", id).Scan(&roomType)
 		if roomType == utils.CHAT_TYPE_USER2USER {
 			latlng := user.GetLatLng(myid)
 			if latlng.Lat != 0 || latlng.Lng != 0 {
-				var blocked int
+				reach.haveLocation = true
+				reach.lat = latlng.Lat
+				reach.lng = latlng.Lng
+				// One query answers both "does a reach row exist" and "does it contain the
+				// replier" (msgid is the PK, so at most one row): the gate blocks when a reach
+				// row exists that does NOT contain the point, and the attribution capture
+				// below reuses the containment result instead of repeating the spatial query.
 				// rippling_reach may not exist until the reach engine (PR A) ships → fail open (allow).
-				if err := db.Raw("SELECT COUNT(*) FROM rippling_reach WHERE msgid = ? "+
-					"AND ST_Contains(polygon, ST_SRID(POINT(?, ?), ?)) = 0",
-					*payload.Refmsgid, latlng.Lng, latlng.Lat, utils.SRID).Scan(&blocked).Error; err == nil && blocked > 0 {
-					return fiber.NewError(fiber.StatusForbidden, "not_in_reach")
+				var rc struct {
+					ReachRows int `gorm:"column:reach_rows"`
+					InReach   int `gorm:"column:in_reach"`
+				}
+				if err := db.Raw("SELECT COUNT(*) AS reach_rows, "+
+					"COALESCE(MAX(ST_Contains(polygon, ST_SRID(POINT(?, ?), ?))), 0) AS in_reach "+
+					"FROM rippling_reach WHERE msgid = ?",
+					latlng.Lng, latlng.Lat, utils.SRID, *payload.Refmsgid).Scan(&rc).Error; err == nil {
+					reach.checked = true
+					reach.reachRows = rc.ReachRows
+					reach.inReach = rc.InReach
+					if rc.ReachRows > 0 && rc.InReach == 0 {
+						return fiber.NewError(fiber.StatusForbidden, "not_in_reach")
+					}
 				}
 			}
 		}
@@ -466,23 +599,12 @@ func CreateChatMessage(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusInternalServerError, "Error creating chat message")
 	}
 
-	// Rippling reply attribution (sysadmin KPI): for an Interested reply, snapshot whether the
-	// replier was already an ESTABLISHED home-group member at the instant they replied. The Nuxt
-	// reply flow joins the group in order to reply (useReplyStateMachine.handleJoinGroup), so a
-	// membership existing right now isn't enough - we require an approved membership of an ORIGIN
-	// (non-rippled-in) group of the post that predates this reply by more than the join grace
-	// (300s). A join made to reply (added ~ now) is therefore excluded and counts as rippling.
-	// Frozen here so a later leave can't erase the signal. INSERT IGNORE = first reply only.
-	// Best-effort: never blocks the reply.
-	if chattype == utils.CHAT_MESSAGE_INTERESTED && payload.Refmsgid != nil {
-		var wasHome int
-		db.Raw("SELECT EXISTS(SELECT 1 FROM messages_groups mg "+
-			"INNER JOIN memberships mem ON mem.groupid = mg.groupid AND mem.userid = ? "+
-			"AND mem.collection = ? AND mem.added < NOW() - INTERVAL 300 SECOND "+
-			"WHERE mg.msgid = ? AND mg.rippled_in = 0 AND mg.deleted = 0)",
-			myid, utils.COLLECTION_APPROVED, *payload.Refmsgid).Scan(&wasHome)
-		db.Exec("INSERT IGNORE INTO rippling_reply_attribution (msgid, userid, replied_at, was_home_member) "+
-			"VALUES (?, ?, NOW(), ?)", *payload.Refmsgid, myid, wasHome)
+	// Rippling reply attribution (sysadmin KPI): for a genuine Interested reply, snapshot the
+	// evidence for HOW the replier came to see the post, and the derived attribution channel.
+	// Scoped to User2User: a refmsgid message in a User2Mod room is a report of the post, not
+	// a reply, and must not pollute the reply-source metric. Best-effort: never blocks the reply.
+	if chattype == utils.CHAT_MESSAGE_INTERESTED && payload.Refmsgid != nil && roomType == utils.CHAT_TYPE_USER2USER {
+		recordReplyAttribution(db, myid, *payload.Refmsgid, reach, payload.Replysource)
 	}
 
 	// A report from the website is a User2Mod chat message referencing the reported

--- a/iznik-server-go/rippling/attribution.go
+++ b/iznik-server-go/rippling/attribution.go
@@ -1,0 +1,91 @@
+package rippling
+
+import (
+	"regexp"
+	"sync"
+
+	"gorm.io/gorm"
+)
+
+// Attribution channel values - must match the rippling_reply_attribution.attribution enum
+// (migration 2026_07_07_000002). Ladder precedence order.
+const (
+	AttributionHome           = "home"
+	AttributionRippleNotified = "ripple_notified"
+	AttributionRippleGroup    = "ripple_group"
+	AttributionOrganicLocal   = "organic_local"
+	AttributionRippleReach    = "ripple_reach"
+	AttributionUnknown        = "unknown"
+)
+
+var attributionSchemaOnce sync.Once
+var attributionSchemaWide bool
+
+// AttributionSchemaReady reports whether rippling_reply_attribution has the graded-attribution
+// columns (migration 2026_07_07_000002). The reply capture and the sysadmin metrics both need
+// to work against a production DB that may not have been migrated yet, so each picks its wide
+// or legacy variant off this. Checked once per process (schema changes need a restart to be
+// noticed - deploys restart the API anyway).
+func AttributionSchemaReady(db *gorm.DB) bool {
+	attributionSchemaOnce.Do(func() {
+		var n int
+		db.Raw("SELECT COUNT(*) FROM information_schema.COLUMNS "+
+			"WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'rippling_reply_attribution' "+
+			"AND COLUMN_NAME = 'attribution'").Scan(&n)
+		attributionSchemaWide = n > 0
+	})
+	return attributionSchemaWide
+}
+
+// DeriveAttribution runs the attribution ladder over the evidence bits captured at reply time
+// and returns the channel. Precedence, and why:
+//
+//  1. home - an established origin-group member. Wins over all ripple evidence (conservative:
+//     when exposure is ambiguous we do NOT credit rippling).
+//  2. ripple_notified - we sent this user the ripple mail for this post. Direct delivery evidence.
+//  3. ripple_group - they were already a member of a group the post rippled into, so they saw it
+//     in their own group's feed/digest because of the ripple.
+//  4. organic_local - non-member inside an origin group's catchment: they'd plausibly have seen
+//     the post in Browse regardless of rippling. Deliberately ranked ABOVE ripple_reach because
+//     the reach polygon always covers the origin area - without this ordering every local
+//     non-member would mis-classify as reach.
+//  5. ripple_reach - outside the origin catchment but inside the reach polygon: their Browse
+//     exposure existed only because the ripple extended there (the nearby feed is reach-fed).
+//  6. unknown - nothing resolvable (search / deep link / share, or no location on file).
+//
+// The hard guard - a post that never rippled can never be ripple-attributed - is structural:
+// with no ripple there are no notified-ledger rows and no rippled-in copies (so 2-3 can't fire),
+// and 5 additionally requires postHadRippled.
+//
+// inOriginCatchment/inReach are pointers because location evidence can be unavailable
+// (replier has no location on file): nil = unknown, distinct from a definite 0.
+func DeriveAttribution(wasHomeMember, wasNotified, wasRippleGroupMember, postHadRippled int, inOriginCatchment, inReach *int) string {
+	switch {
+	case wasHomeMember == 1:
+		return AttributionHome
+	case wasNotified == 1:
+		return AttributionRippleNotified
+	case wasRippleGroupMember == 1:
+		return AttributionRippleGroup
+	case inOriginCatchment != nil && *inOriginCatchment == 1:
+		return AttributionOrganicLocal
+	case postHadRippled == 1 && inReach != nil && *inReach == 1:
+		return AttributionRippleReach
+	default:
+		return AttributionUnknown
+	}
+}
+
+var clientSourceRE = regexp.MustCompile(`^[a-z0-9][a-z0-9_-]{0,31}$`)
+
+// SanitizeClientSource validates the client-reported reply surface (browse, search,
+// message_page, notification, ...). It is client-supplied and spoofable, so it is stored as
+// advisory evidence only, never folded into the attribution ladder. A regex constraint rather
+// than a whitelist: new client surfaces shouldn't need an API deploy, but arbitrary strings
+// (or injection attempts) must not reach the DB. Returns nil when absent or invalid.
+func SanitizeClientSource(source *string) *string {
+	if source == nil || !clientSourceRE.MatchString(*source) {
+		return nil
+	}
+	return source
+}

--- a/iznik-server-go/rippling/metrics.go
+++ b/iznik-server-go/rippling/metrics.go
@@ -3,8 +3,6 @@
 package rippling
 
 import (
-	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -133,18 +131,36 @@ type RepliesPerPostRow struct {
 	Provisional bool `json:"provisional"` // computed in Go (day within the 36h settling window)
 }
 
-// ReplySourceRow is the daily split of Interested replies by whether the replier reached the post
-// via rippling or via their own (home) group. A reply counts as "home" only if the replier was an
-// approved member of an ORIGIN (rippled_in=0) group of the post BEFORE the post arrived
-// (memberships.added < arrival). We key on the join TIMESTAMP, not current membership, because
-// replying can join the member to the group - a naive membership check would mis-label every
-// rippling reply as home-group. Everything else is rippling-attributable.
+// ReplySourceRow is the daily split of Interested replies by attribution channel (the graded
+// ladder captured at reply time in rippling_reply_attribution - see rippling/attribution.go):
+// home (established origin-group member), ripple_notified (we mailed them the post via the
+// ripple), ripple_group (saw it in their own group because it rippled in), ripple_reach
+// (Browse exposure that existed only because the reach extended to them), organic_local
+// (non-member who'd have seen it in Browse anyway), unknown (search / deep link / no location).
+// Rows the backfill hasn't derived yet fold into home/unknown off the legacy was_home_member
+// bit. Ripple/RipplePct is the headline: channels that are DEFINITELY rippling - unlike the
+// old replies-minus-home number, unknown is not credited to rippling.
 type ReplySourceRow struct {
-	Day       string  `json:"day"     gorm:"column:day"`
-	Replies   int     `json:"replies" gorm:"column:replies"`
-	Home      int     `json:"home"    gorm:"column:home"`
-	Ripple    int     `json:"ripple"`     // computed in Go (replies - home)
+	Day     string `json:"day"     gorm:"column:day"`
+	Replies int    `json:"replies" gorm:"column:replies"`
+	Home    int    `json:"home"    gorm:"column:home"`
+
+	RippleNotified int `json:"ripple_notified" gorm:"column:ripple_notified"`
+	RippleGroup    int `json:"ripple_group"    gorm:"column:ripple_group"`
+	RippleReach    int `json:"ripple_reach"    gorm:"column:ripple_reach"`
+	OrganicLocal   int `json:"organic_local"   gorm:"column:organic_local"`
+	Unknown        int `json:"unknown"         gorm:"column:unknown"`
+
+	Ripple    int     `json:"ripple"`     // computed in Go (notified + group + reach)
 	RipplePct float64 `json:"ripple_pct"` // computed in Go
+}
+
+// ClientSourceCount is one row of the client-reported reply-surface summary (browse, search,
+// message_page, notification, ...). Advisory: client-supplied, so it cross-checks the
+// server-derived attribution rather than feeding it.
+type ClientSourceCount struct {
+	Source string `json:"source" gorm:"column:source"`
+	Count  int    `json:"count"  gorm:"column:count"`
 }
 
 // ReplyDistanceRow is the daily median crow-flies distance (km) from a post's location to the
@@ -188,30 +204,54 @@ type GroupOption struct {
 	Name string `json:"name" gorm:"column:name"`
 }
 
-// trialGroupIDs returns the rippling trial group set. Laravel mirrors the current
-// RIPPLE_WITHIN_GROUPS value into the shared `config` table (key 'ripple.within_groups')
-// because the Go API runs on a different server and can't read that batch env var
-// directly. Returns an empty slice when the key is absent/empty or holds no valid ids.
-func trialGroupIDs() []uint64 {
-	var value string
-	database.DBConn.Raw("SELECT value FROM config WHERE `key` = 'ripple.within_groups'").Scan(&value)
-	ids := []uint64{}
-	for _, p := range strings.Split(value, ",") {
-		if n, err := strconv.ParseUint(strings.TrimSpace(p), 10, 64); err == nil && n > 0 {
-			ids = append(ids, n)
-		}
+// ReplySourceSplitSQL builds the per-day attribution-channel query over
+// rippling_reply_attribution. Exported (and parameterised) so the legacy variant - which only
+// runs against an unmigrated production DB - stays testable against a migrated test DB.
+//
+//   - wide: read the attribution channel the reply handler derived at capture time; rows the
+//     backfill hasn't visited (attribution NULL) fold into home/unknown off the legacy
+//     was_home_member bit.
+//   - legacy (graded columns not yet migrated): derive the durable channels live from the
+//     notified ledger and rippled-group memberships. Correct for home/notified/group; the
+//     location channels (ripple_reach/organic_local) are not derivable retrospectively
+//     (locations drift, polygons grow) so they read 0 and those replies sit in unknown.
+//
+// srcGroup is the optional origin-group scoping JOIN (aliases rra); it takes one bind arg
+// before the two replied_at window args.
+func ReplySourceSplitSQL(wide bool, srcGroup string) string {
+	bucket := "COALESCE(rra.attribution, IF(rra.was_home_member = 1, 'home', 'unknown'))"
+	if !wide {
+		bucket = `CASE
+		       WHEN rra.was_home_member = 1 THEN 'home'
+		       WHEN EXISTS(SELECT 1 FROM rippling_reach_notified rrn
+		                   WHERE rrn.msgid = rra.msgid AND rrn.userid = rra.userid
+		                     AND rrn.notified_at <= rra.replied_at) THEN 'ripple_notified'
+		       WHEN EXISTS(SELECT 1 FROM messages_groups mgr
+		                   INNER JOIN memberships mem ON mem.groupid = mgr.groupid
+		                     AND mem.userid = rra.userid AND mem.collection = 'Approved'
+		                     AND mem.added < mgr.arrival
+		                   WHERE mgr.msgid = rra.msgid AND mgr.rippled_in = 1
+		                     AND mgr.deleted = 0 AND mgr.arrival <= rra.replied_at) THEN 'ripple_group'
+		       ELSE 'unknown'
+		       END`
 	}
-	return ids
-}
-
-// uint64InList renders ids as a comma-separated SQL IN(...) body. Safe to inline:
-// the values are validated uint64s, not user-supplied strings.
-func uint64InList(ids []uint64) string {
-	parts := make([]string, len(ids))
-	for i, id := range ids {
-		parts[i] = strconv.FormatUint(id, 10)
-	}
-	return strings.Join(parts, ",")
+	return `
+		SELECT day,
+		       COUNT(*) AS replies,
+		       SUM(bucket = 'home') AS home,
+		       SUM(bucket = 'ripple_notified') AS ripple_notified,
+		       SUM(bucket = 'ripple_group') AS ripple_group,
+		       SUM(bucket = 'ripple_reach') AS ripple_reach,
+		       SUM(bucket = 'organic_local') AS organic_local,
+		       SUM(bucket = 'unknown') AS unknown
+		FROM (
+		    SELECT DATE_FORMAT(rra.replied_at, '%Y-%m-%d') AS day,
+		           ` + bucket + ` AS bucket
+		    FROM rippling_reply_attribution rra` + srcGroup + `
+		    WHERE rra.replied_at >= ? AND rra.replied_at < ?
+		) b
+		GROUP BY day
+		ORDER BY day DESC`
 }
 
 // Metrics returns the rippling-out event counters plus the §15/§16 rollout-health metrics.
@@ -239,20 +279,8 @@ func Metrics(c *fiber.Ctx) error {
 	// rippled_in=0 messages_groups row), so results read per place - dense Croydon won't look
 	// like rural Ribble Valley. 0 = all groups. Each scoped query takes one gid arg.
 	gid := c.QueryInt("groupid", 0)
-	// Optional ?trialOnly=1 scopes every KPI to the rippling TRIAL groups (the set in
-	// RIPPLE_WITHIN_GROUPS). During the trial only a handful of groups ripple, so stats
-	// over all groups bury the signal under the majority that aren't rippling. The Go API
-	// runs on a different server from the batch container that holds that env var, so
-	// Laravel mirrors the current value into the shared `config` table (key
-	// 'ripple.within_groups') and we read it here. ?groupid= (a single group) wins when both
-	// are given.
-	trialOnly := c.QueryBool("trialOnly", false)
-	trialIDs := []uint64{}
-	if trialOnly && gid == 0 {
-		trialIDs = trialGroupIDs()
-	}
 	// Optional ?start= & ?end= date range bounds every KPI below; default to the last 30 days.
-	// This is what lets you read a treatment group's before vs after rippling went on.
+	// This is what lets you read a group's before vs after rippling went on.
 	start := c.Query("start")
 	end := c.Query("end")
 	if start == "" {
@@ -261,24 +289,15 @@ func Metrics(c *fiber.Ctx) error {
 	if end == "" {
 		end = time.Now().Format("2006-01-02 15:04:05")
 	}
+	// Whether the graded-attribution columns exist yet (production may lag the migration):
+	// picks the reply-source query variant and is surfaced to the dashboard so it can note
+	// that the location-based channels are pending.
+	attributionWide := AttributionSchemaReady(db)
 	rateGroup, srcGroup, distGroup := "", "", ""
 	if gid > 0 {
 		rateGroup = " AND mg.groupid = ? AND mg.rippled_in = 0"
 		srcGroup = " JOIN messages_groups mg ON mg.msgid = rra.msgid AND mg.groupid = ? AND mg.rippled_in = 0 AND mg.deleted = 0"
 		distGroup = " JOIN messages_groups mg ON mg.msgid = m.id AND mg.groupid = ? AND mg.rippled_in = 0 AND mg.deleted = 0"
-	} else if trialOnly {
-		// Inline the trial group ids as an IN(...) literal: they are validated uint64s read
-		// from trusted config, so there is no injection risk and no new bind args (the
-		// arg-builders only add a value when gid>0, so they stay correct). When the trial set
-		// is unset we scope to IN(0) so "trial only" honestly yields no data rather than
-		// silently showing all groups.
-		inList := "0"
-		if len(trialIDs) > 0 {
-			inList = uint64InList(trialIDs)
-		}
-		rateGroup = " AND mg.groupid IN (" + inList + ") AND mg.rippled_in = 0"
-		srcGroup = " JOIN messages_groups mg ON mg.msgid = rra.msgid AND mg.groupid IN (" + inList + ") AND mg.rippled_in = 0 AND mg.deleted = 0"
-		distGroup = " JOIN messages_groups mg ON mg.msgid = m.id AND mg.groupid IN (" + inList + ") AND mg.rippled_in = 0 AND mg.deleted = 0"
 	}
 	// Per-query args: the group filter (when set) sits in a JOIN before the date-bounded WHERE,
 	// so gid comes first, then start, end.
@@ -341,6 +360,7 @@ func Metrics(c *fiber.Ctx) error {
 	replyRates := []ReplyRateRow{}
 	repliesPerPost := []RepliesPerPostRow{}
 	replySources := []ReplySourceRow{}
+	clientSources := []ClientSourceCount{}
 	replyDistances := []ReplyDistanceRow{}
 	takenRates := []TakenRateRow{}
 	groupOpts := []GroupOption{}
@@ -510,19 +530,39 @@ func Metrics(c *fiber.Ctx) error {
 			ORDER BY day DESC`, replyRateArgs(gid, start, end)...).Scan(&repliesPerPost)
 	}()
 
-	// (2) Rippling vs home-group replies, per day, from rippling_reply_attribution (captured at
+	// (2) Reply attribution channels, per day, from rippling_reply_attribution (captured at
 	//     reply time - the only sound attribution, since replying joins the member to the group).
+	//     Two variants sharing one output shape:
+	//     - wide: read the attribution channel the Go reply handler derived at capture time.
+	//       Rows the backfill hasn't visited (attribution NULL) fold into home/unknown off the
+	//       legacy was_home_member bit.
+	//     - legacy (graded columns not yet migrated, e.g. production before the deploy): derive
+	//       the durable channels live from the notified ledger and rippled-group memberships.
+	//       Correct for notified/group/home; the location channels (ripple_reach/organic_local)
+	//       are not derivable retrospectively (locations drift, polygons grow) so they read 0
+	//       and those replies sit in unknown - attribution_channels_available tells the
+	//       dashboard to say so.
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
+		db.Raw(ReplySourceSplitSQL(attributionWide, srcGroup), gargs()...).Scan(&replySources)
+	}()
+
+	// (2b) Client-reported reply surfaces over the same window (wide schema only - the column
+	//      arrives with the graded-attribution migration). Advisory cross-check of (2).
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if !attributionWide {
+			return
+		}
 		db.Raw(`
-			SELECT DATE_FORMAT(rra.replied_at, '%Y-%m-%d') AS day,
-			       COUNT(*) AS replies,
-			       COALESCE(SUM(rra.was_home_member), 0) AS home
+			SELECT COALESCE(rra.client_source, '(not reported)') AS source,
+			       COUNT(*) AS count
 			FROM rippling_reply_attribution rra`+srcGroup+`
 			WHERE rra.replied_at >= ? AND rra.replied_at < ?
-			GROUP BY DATE_FORMAT(rra.replied_at, '%Y-%m-%d')
-			ORDER BY day DESC`, gargs()...).Scan(&replySources)
+			GROUP BY source
+			ORDER BY count DESC`, gargs()...).Scan(&clientSources)
 	}()
 
 	// (3) Median crow-flies distance (km) from post to replier, per reply day. The origin-group
@@ -647,9 +687,11 @@ func Metrics(c *fiber.Ctx) error {
 		repliesPerPost[i].Provisional = repliesPerPost[i].Day >= reply36hCutoff
 	}
 
-	// Compute derived fields for reply-source rows.
+	// Compute derived fields for reply-source rows. The headline ripple share counts only the
+	// channels that are DEFINITELY rippling - unknown is not credited (the old replies-minus-home
+	// number silently attributed every un-evidenced reply to rippling).
 	for i := range replySources {
-		replySources[i].Ripple = replySources[i].Replies - replySources[i].Home
+		replySources[i].Ripple = replySources[i].RippleNotified + replySources[i].RippleGroup + replySources[i].RippleReach
 		if replySources[i].Replies > 0 {
 			replySources[i].RipplePct = float64(replySources[i].Ripple) / float64(replySources[i].Replies) * 100
 		}
@@ -699,13 +741,15 @@ func Metrics(c *fiber.Ctx) error {
 		"reply_rate_36h":        replyRates,
 		"replies_per_post":      repliesPerPost,
 		"reply_source_split":    replySources,
-		"reply_distance_median": replyDistances,
-		"taken_rate":            takenRates,
-		"groups":                groupOpts,
-		"groupid":               gid,
-		"trial_only":            trialOnly,
-		"trial_group_ids":       trialIDs,
-		"start":                 start,
-		"end":                   end,
+		"client_source_summary": clientSources,
+		// False until the graded-attribution migration has run on this DB: the location
+		// channels (ripple_reach/organic_local) read 0 and client sources are absent.
+		"attribution_channels_available": attributionWide,
+		"reply_distance_median":          replyDistances,
+		"taken_rate":                     takenRates,
+		"groups":                         groupOpts,
+		"groupid":                        gid,
+		"start":                          start,
+		"end":                            end,
 	})
 }

--- a/iznik-server-go/rippling/metrics.go
+++ b/iznik-server-go/rippling/metrics.go
@@ -208,9 +208,11 @@ type GroupOption struct {
 // rippling_reply_attribution. Exported (and parameterised) so the legacy variant - which only
 // runs against an unmigrated production DB - stays testable against a migrated test DB.
 //
-//   - wide: read the attribution channel the reply handler derived at capture time; rows the
-//     backfill hasn't visited (attribution NULL) fold into home/unknown off the legacy
-//     was_home_member bit.
+//   - wide: read the attribution channel the reply handler derived at capture time. Rows
+//     without one (pre-migration rows the backfill hasn't visited yet) fall back PER ROW to
+//     the same live derivation as the legacy variant - otherwise the window between the
+//     migration landing and the backfill running would read as a misleading zero-ripple
+//     chart (every attribution NULL folding to home/unknown).
 //   - legacy (graded columns not yet migrated): derive the durable channels live from the
 //     notified ledger and rippled-group memberships. Correct for home/notified/group; the
 //     location channels (ripple_reach/organic_local) are not derivable retrospectively
@@ -219,21 +221,22 @@ type GroupOption struct {
 // srcGroup is the optional origin-group scoping JOIN (aliases rra); it takes one bind arg
 // before the two replied_at window args.
 func ReplySourceSplitSQL(wide bool, srcGroup string) string {
-	bucket := "COALESCE(rra.attribution, IF(rra.was_home_member = 1, 'home', 'unknown'))"
-	if !wide {
-		bucket = `CASE
-		       WHEN rra.was_home_member = 1 THEN 'home'
-		       WHEN EXISTS(SELECT 1 FROM rippling_reach_notified rrn
-		                   WHERE rrn.msgid = rra.msgid AND rrn.userid = rra.userid
-		                     AND rrn.notified_at <= rra.replied_at) THEN 'ripple_notified'
-		       WHEN EXISTS(SELECT 1 FROM messages_groups mgr
-		                   INNER JOIN memberships mem ON mem.groupid = mgr.groupid
-		                     AND mem.userid = rra.userid AND mem.collection = 'Approved'
-		                     AND mem.added < mgr.arrival
-		                   WHERE mgr.msgid = rra.msgid AND mgr.rippled_in = 1
-		                     AND mgr.deleted = 0 AND mgr.arrival <= rra.replied_at) THEN 'ripple_group'
-		       ELSE 'unknown'
-		       END`
+	derive := `CASE
+	       WHEN rra.was_home_member = 1 THEN 'home'
+	       WHEN EXISTS(SELECT 1 FROM rippling_reach_notified rrn
+	                   WHERE rrn.msgid = rra.msgid AND rrn.userid = rra.userid
+	                     AND rrn.notified_at <= rra.replied_at) THEN 'ripple_notified'
+	       WHEN EXISTS(SELECT 1 FROM messages_groups mgr
+	                   INNER JOIN memberships mem ON mem.groupid = mgr.groupid
+	                     AND mem.userid = rra.userid AND mem.collection = 'Approved'
+	                     AND mem.added < mgr.arrival
+	                   WHERE mgr.msgid = rra.msgid AND mgr.rippled_in = 1
+	                     AND mgr.deleted = 0 AND mgr.arrival <= rra.replied_at) THEN 'ripple_group'
+	       ELSE 'unknown'
+	       END`
+	bucket := derive
+	if wide {
+		bucket = "COALESCE(rra.attribution, " + derive + ")"
 	}
 	return `
 		SELECT day,
@@ -361,6 +364,7 @@ func Metrics(c *fiber.Ctx) error {
 	repliesPerPost := []RepliesPerPostRow{}
 	replySources := []ReplySourceRow{}
 	clientSources := []ClientSourceCount{}
+	captureFrom := ""
 	replyDistances := []ReplyDistanceRow{}
 	takenRates := []TakenRateRow{}
 	groupOpts := []GroupOption{}
@@ -565,6 +569,24 @@ func Metrics(c *fiber.Ctx) error {
 			ORDER BY count DESC`, gargs()...).Scan(&clientSources)
 	}()
 
+	// (2c) When did LIVE capture start? The first row carrying evidence only the reply-time
+	//      capture can write (location containment or a client-reported surface - the backfill
+	//      never sets those). The dashboard draws this as a boundary on the attribution chart:
+	//      before it the location channels are structurally zero (those replies sit in
+	//      unknown), after it the full split applies. Deliberately unscoped by ?groupid=
+	//      (it marks a deploy moment, not a per-group property).
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if !attributionWide {
+			return
+		}
+		db.Raw("SELECT COALESCE(DATE_FORMAT(MIN(replied_at), '%Y-%m-%d'), '') " +
+			"FROM rippling_reply_attribution " +
+			"WHERE in_origin_catchment IS NOT NULL OR in_reach IS NOT NULL " +
+			"OR client_source IS NOT NULL").Scan(&captureFrom)
+	}()
+
 	// (3) Median crow-flies distance (km) from post to replier, per reply day. The origin-group
 	//     join is added only when filtering (avoids multi-group row inflation in the all view).
 	wg.Add(1)
@@ -745,6 +767,9 @@ func Metrics(c *fiber.Ctx) error {
 		// False until the graded-attribution migration has run on this DB: the location
 		// channels (ripple_reach/organic_local) read 0 and client sources are absent.
 		"attribution_channels_available": attributionWide,
+		// First day with reply-time-captured evidence ('' until the capture deploy has seen
+		// a reply): the boundary the dashboard marks on the attribution chart.
+		"attribution_capture_from": captureFrom,
 		"reply_distance_median":          replyDistances,
 		"taken_rate":                     takenRates,
 		"groups":                         groupOpts,

--- a/iznik-server-go/test/chatmessage_reach_test.go
+++ b/iznik-server-go/test/chatmessage_reach_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/freegle/iznik-server-go/chat"
 	"github.com/freegle/iznik-server-go/database"
+	"github.com/freegle/iznik-server-go/utils"
 	"github.com/gofiber/fiber/v2"
 	"github.com/stretchr/testify/assert"
 )
@@ -119,20 +120,64 @@ func TestCreateChatMessage_ReportToModsNotReachGated(t *testing.T) {
 
 	assert.Equal(t, fiber.StatusOK, resp.StatusCode,
 		"a report to mods (User2Mod) must NOT be reach-gated even when the reporter is outside the post's reach")
+
+	// A report is not a reply: it must not pollute the reply-source metric with an
+	// attribution row (the capture is scoped to User2User).
+	var reportRows int
+	db.Raw("SELECT COUNT(*) FROM rippling_reply_attribution WHERE msgid = ? AND userid = ?",
+		msgID, reporterID).Scan(&reportRows)
+	assert.Equal(t, 0, reportRows, "no reply-attribution row is recorded for a report")
 }
 
-// TestCreateChatMessage_RecordsReplyAttribution verifies the rippling reply-source capture: posting
-// an Interested reply records, in rippling_reply_attribution, whether the replier was an ESTABLISHED
-// home-group member at reply time. A membership made well before the reply -> home (1). A non-member
-// (and, identically, a join-to-reply whose membership is younger than the 300s grace) -> rippling (0).
+// attributionRow is the full evidence snapshot the graded capture writes; shared by the
+// attribution tests below.
+type attributionRow struct {
+	WasHomeMember  int     `gorm:"column:was_home_member"`
+	WasNotified    *int    `gorm:"column:was_notified"`
+	WasRippleGroup *int    `gorm:"column:was_ripple_group_member"`
+	InOrigin       *int    `gorm:"column:in_origin_catchment"`
+	InReach        *int    `gorm:"column:in_reach"`
+	PostHadRippled *int    `gorm:"column:post_had_rippled"`
+	Attribution    *string `gorm:"column:attribution"`
+	ClientSource   *string `gorm:"column:client_source"`
+}
+
+func fetchAttribution(t *testing.T, msgID, uid uint64) (attributionRow, bool) {
+	var rows []attributionRow
+	database.DBConn.Raw("SELECT was_home_member, was_notified, was_ripple_group_member, "+
+		"in_origin_catchment, in_reach, post_had_rippled, attribution, client_source "+
+		"FROM rippling_reply_attribution WHERE msgid = ? AND userid = ?", msgID, uid).Scan(&rows)
+	if len(rows) == 0 {
+		return attributionRow{}, false
+	}
+	return rows[0], true
+}
+
+// postInterestedReply posts an Interested User2User reply to msgID as replierID, optionally
+// carrying the client-reported surface, and returns the HTTP status.
+func postInterestedReply(t *testing.T, replierID, posterID, msgID uint64, replysource string) int {
+	chatID := CreateTestChatRoom(t, replierID, &posterID, nil, "User2User")
+	_, token := CreateTestSession(t, replierID)
+	var payload chat.ChatMessage
+	payload.Message = "I'd like this please"
+	payload.Refmsgid = &msgID
+	if replysource != "" {
+		payload.Replysource = &replysource
+	}
+	s, _ := json.Marshal(payload)
+	req := httptest.NewRequest("POST", fmt.Sprintf("/api/chat/%d/message?jwt=%s", chatID, token), bytes.NewBuffer(s))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req)
+	return resp.StatusCode
+}
+
+// TestCreateChatMessage_RecordsReplyAttribution verifies the graded reply-source capture on a
+// post that never rippled: an ESTABLISHED origin-group member -> home; a non-member -> unknown
+// (the hard guard: with no ripple the reply can never be ripple-attributed - under the old
+// single-bit scheme this non-member would have been silently credited to rippling).
 func TestCreateChatMessage_RecordsReplyAttribution(t *testing.T) {
 	db := database.DBConn
 	prefix := uniquePrefix("replyattr")
-
-	db.Exec(`CREATE TABLE IF NOT EXISTS rippling_reply_attribution (
-		msgid BIGINT UNSIGNED NOT NULL, userid BIGINT UNSIGNED NOT NULL,
-		replied_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, was_home_member TINYINT(1) NOT NULL,
-		PRIMARY KEY (msgid, userid), KEY rra_replied_at (replied_at))`)
 
 	groupID := CreateTestGroup(t, prefix)
 	posterID := CreateTestUser(t, prefix+"_poster", "User")
@@ -140,40 +185,138 @@ func TestCreateChatMessage_RecordsReplyAttribution(t *testing.T) {
 	msgID := CreateTestMessage(t, posterID, groupID, "OFFER: reply attribution test item", 51.5, -0.1)
 	defer db.Exec("DELETE FROM rippling_reply_attribution WHERE msgid = ?", msgID)
 
-	postReply := func(replierID uint64) int {
-		chatID := CreateTestChatRoom(t, replierID, &posterID, nil, "User2User")
-		_, token := CreateTestSession(t, replierID)
-		var payload chat.ChatMessage
-		payload.Message = "I'd like this please"
-		payload.Refmsgid = &msgID
-		s, _ := json.Marshal(payload)
-		req := httptest.NewRequest("POST", fmt.Sprintf("/api/chat/%d/message?jwt=%s", chatID, token), bytes.NewBuffer(s))
-		req.Header.Set("Content-Type", "application/json")
-		resp, _ := getApp().Test(req)
-		return resp.StatusCode
-	}
-	attribution := func(uid uint64) (int, bool) {
-		var rows []int
-		db.Raw("SELECT was_home_member FROM rippling_reply_attribution WHERE msgid = ? AND userid = ?", msgID, uid).Scan(&rows)
-		if len(rows) == 0 {
-			return 0, false
-		}
-		return rows[0], true
-	}
-
-	// Established member: approved membership added an hour ago -> home (was_home_member = 1).
+	// Established member: approved membership added an hour ago -> home.
 	memberID := CreateTestUser(t, prefix+"_member", "User")
 	CreateTestMembership(t, memberID, groupID, "Member")
 	db.Exec("UPDATE memberships SET added = NOW() - INTERVAL 1 HOUR, collection = 'Approved' WHERE userid = ? AND groupid = ?", memberID, groupID)
-	assert.Equal(t, fiber.StatusOK, postReply(memberID))
-	v, ok := attribution(memberID)
+	assert.Equal(t, fiber.StatusOK, postInterestedReply(t, memberID, posterID, msgID, ""))
+	row, ok := fetchAttribution(t, msgID, memberID)
 	assert.True(t, ok, "attribution row recorded for the established-member reply")
-	assert.Equal(t, 1, v, "established member reply recorded as home-group (was_home_member=1)")
+	assert.Equal(t, 1, row.WasHomeMember, "established member reply recorded as home-group")
+	if assert.NotNil(t, row.Attribution) {
+		assert.Equal(t, "home", *row.Attribution)
+	}
 
-	// Non-member: no membership of the origin group -> reached via rippling (was_home_member = 0).
+	// Non-member on a NEVER-RIPPLED post: not home, but not rippling either - unknown, with
+	// the hard-guard evidence bit post_had_rippled = 0 frozen in the row.
 	nonMemberID := CreateTestUser(t, prefix+"_nonmember", "User")
-	assert.Equal(t, fiber.StatusOK, postReply(nonMemberID))
-	v, ok = attribution(nonMemberID)
+	assert.Equal(t, fiber.StatusOK, postInterestedReply(t, nonMemberID, posterID, msgID, ""))
+	row, ok = fetchAttribution(t, msgID, nonMemberID)
 	assert.True(t, ok, "attribution row recorded for the non-member reply")
-	assert.Equal(t, 0, v, "non-member reply recorded as rippling (was_home_member=0)")
+	assert.Equal(t, 0, row.WasHomeMember)
+	if assert.NotNil(t, row.PostHadRippled) {
+		assert.Equal(t, 0, *row.PostHadRippled, "post never rippled -> hard guard bit is 0")
+	}
+	if assert.NotNil(t, row.Attribution) {
+		assert.Equal(t, "unknown", *row.Attribution,
+			"a reply to a never-rippled post is never credited to rippling")
+	}
+}
+
+// TestCreateChatMessage_AttributionLadder walks the graded ladder end-to-end on a rippled post:
+// notified-ledger hit -> ripple_notified; established member of the rippled-into group ->
+// ripple_group; non-member inside the origin catchment -> organic_local (would have seen it in
+// Browse anyway - outranks ripple_reach because the reach polygon always covers the origin area);
+// non-member outside the catchment but inside the reach -> ripple_reach. Also verifies the
+// client-reported surface: a well-formed value is stored, an ill-formed one is dropped.
+func TestCreateChatMessage_AttributionLadder(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("attrladder")
+
+	db.Exec(`CREATE TABLE IF NOT EXISTS rippling_reach (
+		msgid BIGINT UNSIGNED NOT NULL PRIMARY KEY,
+		lat DOUBLE NOT NULL, lng DOUBLE NOT NULL,
+		polygon GEOMETRY NOT NULL SRID 3857,
+		status VARCHAR(16) NOT NULL DEFAULT 'expanding',
+		SPATIAL INDEX msgreach_poly (polygon)
+	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`)
+	db.Exec(`CREATE TABLE IF NOT EXISTS rippling_reach_notified (
+		msgid BIGINT UNSIGNED NOT NULL, userid BIGINT UNSIGNED NOT NULL,
+		notified_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		PRIMARY KEY (msgid, userid), KEY rrn_userid (userid))`)
+
+	originGroup := CreateTestGroup(t, prefix+"_origin")
+	rippledGroup := CreateTestGroup(t, prefix+"_rippled")
+	posterID := CreateTestUser(t, prefix+"_poster", "User")
+	CreateTestMembership(t, posterID, originGroup, "Member")
+	msgID := CreateTestMessage(t, posterID, originGroup, "OFFER: attribution ladder test item", 51.5, -0.1)
+	defer db.Exec("DELETE FROM rippling_reply_attribution WHERE msgid = ?", msgID)
+	defer db.Exec("DELETE FROM rippling_reach_notified WHERE msgid = ?", msgID)
+	defer db.Exec("DELETE FROM rippling_reach WHERE msgid = ?", msgID)
+
+	// Origin group's catchment covers (-0.1, 51.5) only; the reach polygon covers both that
+	// and (0.5, 51.5) - reach always covers the origin area, which is exactly why
+	// organic_local must outrank ripple_reach.
+	db.Exec(fmt.Sprintf("UPDATE `groups` SET polyindex = ST_GeomFromText("+
+		"'POLYGON((-0.2 51.4,0.0 51.4,0.0 51.6,-0.2 51.6,-0.2 51.4))', %d) WHERE id = ?", utils.SRID),
+		originGroup)
+	db.Exec("INSERT INTO rippling_reach (msgid, lat, lng, polygon) VALUES (?, 51.5, -0.1, ST_GeomFromText("+
+		"'POLYGON((-0.3 51.3,0.7 51.3,0.7 51.7,-0.3 51.7,-0.3 51.3))', 3857))", msgID)
+	// The post rippled into a second group just now.
+	db.Exec("INSERT INTO messages_groups (msgid, groupid, arrival, collection, autoreposts, rippled_in) "+
+		"VALUES (?, ?, NOW(), 'Approved', 0, 1)", msgID, rippledGroup)
+
+	// 1. Notified-ledger hit (no location on file, no memberships) -> ripple_notified.
+	notifiedID := CreateTestUser(t, prefix+"_notified", "User")
+	db.Exec("INSERT INTO rippling_reach_notified (msgid, userid, notified_at) VALUES (?, ?, NOW() - INTERVAL 1 HOUR)",
+		msgID, notifiedID)
+	assert.Equal(t, fiber.StatusOK, postInterestedReply(t, notifiedID, posterID, msgID, ""))
+	row, ok := fetchAttribution(t, msgID, notifiedID)
+	assert.True(t, ok)
+	if assert.NotNil(t, row.Attribution) {
+		assert.Equal(t, "ripple_notified", *row.Attribution)
+	}
+	if assert.NotNil(t, row.WasNotified) {
+		assert.Equal(t, 1, *row.WasNotified)
+	}
+	assert.Nil(t, row.InOrigin, "no location on file -> location evidence is NULL, not 0")
+
+	// 2. Established member of the group the post rippled INTO -> ripple_group.
+	rippleMemberID := CreateTestUser(t, prefix+"_rgmember", "User")
+	CreateTestMembership(t, rippleMemberID, rippledGroup, "Member")
+	db.Exec("UPDATE memberships SET added = NOW() - INTERVAL 1 HOUR, collection = 'Approved' WHERE userid = ? AND groupid = ?",
+		rippleMemberID, rippledGroup)
+	assert.Equal(t, fiber.StatusOK, postInterestedReply(t, rippleMemberID, posterID, msgID, ""))
+	row, ok = fetchAttribution(t, msgID, rippleMemberID)
+	assert.True(t, ok)
+	if assert.NotNil(t, row.Attribution) {
+		assert.Equal(t, "ripple_group", *row.Attribution)
+	}
+
+	// 3. Non-member INSIDE the origin catchment (and inside the reach) -> organic_local, with
+	//    a well-formed client surface stored verbatim.
+	localID := CreateTestUser(t, prefix+"_local", "User")
+	db.Exec(`UPDATE users SET settings = '{"mylocation":{"lat":51.5,"lng":-0.1}}' WHERE id = ?`, localID)
+	assert.Equal(t, fiber.StatusOK, postInterestedReply(t, localID, posterID, msgID, "browse"))
+	row, ok = fetchAttribution(t, msgID, localID)
+	assert.True(t, ok)
+	if assert.NotNil(t, row.Attribution) {
+		assert.Equal(t, "organic_local", *row.Attribution,
+			"inside the origin catchment outranks inside the reach")
+	}
+	if assert.NotNil(t, row.InOrigin) {
+		assert.Equal(t, 1, *row.InOrigin)
+	}
+	if assert.NotNil(t, row.InReach) {
+		assert.Equal(t, 1, *row.InReach)
+	}
+	if assert.NotNil(t, row.ClientSource) {
+		assert.Equal(t, "browse", *row.ClientSource)
+	}
+
+	// 4. Non-member OUTSIDE the origin catchment but inside the reach -> ripple_reach: their
+	//    Browse exposure existed only because the ripple extended to them. An ill-formed
+	//    client surface is dropped, not stored.
+	reachID := CreateTestUser(t, prefix+"_reach", "User")
+	db.Exec(`UPDATE users SET settings = '{"mylocation":{"lat":51.5,"lng":0.5}}' WHERE id = ?`, reachID)
+	assert.Equal(t, fiber.StatusOK, postInterestedReply(t, reachID, posterID, msgID, "Bad Source!"))
+	row, ok = fetchAttribution(t, msgID, reachID)
+	assert.True(t, ok)
+	if assert.NotNil(t, row.Attribution) {
+		assert.Equal(t, "ripple_reach", *row.Attribution)
+	}
+	if assert.NotNil(t, row.InOrigin) {
+		assert.Equal(t, 0, *row.InOrigin)
+	}
+	assert.Nil(t, row.ClientSource, "an ill-formed client surface is dropped")
 }

--- a/iznik-server-go/test/chatmessage_reach_test.go
+++ b/iznik-server-go/test/chatmessage_reach_test.go
@@ -256,23 +256,35 @@ func TestCreateChatMessage_AttributionLadder(t *testing.T) {
 	db.Exec("INSERT INTO messages_groups (msgid, groupid, arrival, collection, autoreposts, rippled_in) "+
 		"VALUES (?, ?, NOW(), 'Approved', 0, 1)", msgID, rippledGroup)
 
-	// 1. Notified-ledger hit (no location on file, no memberships) -> ripple_notified.
+	// CreateTestUser defaults every user's settings.mylocation to Edinburgh, which is
+	// OUTSIDE this post's reach polygon - the write-path reach gate would 403 the reply
+	// before the capture ever ran. Repliers below are placed inside the reach (or have
+	// their location removed entirely for the no-location case).
+
+	// 1. Notified-ledger hit -> ripple_notified. Inside the reach, outside the origin
+	//    catchment - the notified rung must outrank the location rungs.
 	notifiedID := CreateTestUser(t, prefix+"_notified", "User")
+	db.Exec(`UPDATE users SET settings = '{"mylocation":{"lat":51.5,"lng":0.5}}' WHERE id = ?`, notifiedID)
 	db.Exec("INSERT INTO rippling_reach_notified (msgid, userid, notified_at) VALUES (?, ?, NOW() - INTERVAL 1 HOUR)",
 		msgID, notifiedID)
 	assert.Equal(t, fiber.StatusOK, postInterestedReply(t, notifiedID, posterID, msgID, ""))
 	row, ok := fetchAttribution(t, msgID, notifiedID)
 	assert.True(t, ok)
 	if assert.NotNil(t, row.Attribution) {
-		assert.Equal(t, "ripple_notified", *row.Attribution)
+		assert.Equal(t, "ripple_notified", *row.Attribution,
+			"notified outranks the location rungs")
 	}
 	if assert.NotNil(t, row.WasNotified) {
 		assert.Equal(t, 1, *row.WasNotified)
 	}
-	assert.Nil(t, row.InOrigin, "no location on file -> location evidence is NULL, not 0")
+	if assert.NotNil(t, row.InReach) {
+		assert.Equal(t, 1, *row.InReach)
+	}
 
-	// 2. Established member of the group the post rippled INTO -> ripple_group.
+	// 2. Established member of the group the post rippled INTO -> ripple_group (also
+	//    outranks the location rungs).
 	rippleMemberID := CreateTestUser(t, prefix+"_rgmember", "User")
+	db.Exec(`UPDATE users SET settings = '{"mylocation":{"lat":51.5,"lng":0.5}}' WHERE id = ?`, rippleMemberID)
 	CreateTestMembership(t, rippleMemberID, rippledGroup, "Member")
 	db.Exec("UPDATE memberships SET added = NOW() - INTERVAL 1 HOUR, collection = 'Approved' WHERE userid = ? AND groupid = ?",
 		rippleMemberID, rippledGroup)
@@ -281,6 +293,19 @@ func TestCreateChatMessage_AttributionLadder(t *testing.T) {
 	assert.True(t, ok)
 	if assert.NotNil(t, row.Attribution) {
 		assert.Equal(t, "ripple_group", *row.Attribution)
+	}
+
+	// 2b. No location on file at all: the reach gate fails open, and the location
+	//     evidence is NULL (unknown), not a definite 0 -> unknown attribution.
+	nolocID := CreateTestUser(t, prefix+"_noloc", "User")
+	db.Exec("UPDATE users SET settings = NULL WHERE id = ?", nolocID)
+	assert.Equal(t, fiber.StatusOK, postInterestedReply(t, nolocID, posterID, msgID, ""))
+	row, ok = fetchAttribution(t, msgID, nolocID)
+	assert.True(t, ok)
+	assert.Nil(t, row.InOrigin, "no location on file -> location evidence is NULL, not 0")
+	assert.Nil(t, row.InReach, "no location on file -> location evidence is NULL, not 0")
+	if assert.NotNil(t, row.Attribution) {
+		assert.Equal(t, "unknown", *row.Attribution)
 	}
 
 	// 3. Non-member INSIDE the origin catchment (and inside the reach) -> organic_local, with

--- a/iznik-server-go/test/rippling_attribution_test.go
+++ b/iznik-server-go/test/rippling_attribution_test.go
@@ -1,0 +1,62 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/freegle/iznik-server-go/rippling"
+	"github.com/stretchr/testify/assert"
+)
+
+func iptr(v int) *int { return &v }
+func sptr(s string) *string { return &s }
+
+// The attribution ladder over the evidence bits. Precedence and the hard guard are the whole
+// point of the graded scheme, so every rung and the interesting overlaps are pinned here.
+func TestDeriveAttribution(t *testing.T) {
+	cases := []struct {
+		name                                             string
+		wasHome, wasNotified, wasRippleGroup, hadRippled int
+		inOrigin, inReach                                *int
+		want                                             string
+	}{
+		{"home member", 1, 0, 0, 1, nil, nil, rippling.AttributionHome},
+		{"home wins over ripple evidence (conservative: never over-credit rippling)",
+			1, 1, 1, 1, iptr(1), iptr(1), rippling.AttributionHome},
+		{"notified ledger hit", 0, 1, 0, 1, nil, nil, rippling.AttributionRippleNotified},
+		{"notified outranks rippled-group membership", 0, 1, 1, 1, nil, nil, rippling.AttributionRippleNotified},
+		{"established member of a rippled-into group", 0, 0, 1, 1, nil, nil, rippling.AttributionRippleGroup},
+		{"non-member inside origin catchment: would have seen it in Browse anyway",
+			0, 0, 0, 1, iptr(1), iptr(1), rippling.AttributionOrganicLocal},
+		{"outside catchment, inside reach: exposure existed only because of the ripple",
+			0, 0, 0, 1, iptr(0), iptr(1), rippling.AttributionRippleReach},
+		{"inside reach but post never rippled: hard guard blocks ripple_reach",
+			0, 0, 0, 0, iptr(0), iptr(1), rippling.AttributionUnknown},
+		{"no location on file: reach containment unknowable", 0, 0, 0, 1, nil, nil, rippling.AttributionUnknown},
+		{"outside both", 0, 0, 0, 1, iptr(0), iptr(0), rippling.AttributionUnknown},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := rippling.DeriveAttribution(c.wasHome, c.wasNotified, c.wasRippleGroup, c.hadRippled, c.inOrigin, c.inReach)
+			assert.Equal(t, c.want, got)
+		})
+	}
+}
+
+// The client-reported surface is spoofable input: well-formed values pass through, anything
+// else (uppercase, spaces, injection shapes, over-long, empty, absent) is dropped to nil.
+func TestSanitizeClientSource(t *testing.T) {
+	assert.Nil(t, rippling.SanitizeClientSource(nil))
+	assert.Nil(t, rippling.SanitizeClientSource(sptr("")))
+	assert.Nil(t, rippling.SanitizeClientSource(sptr("Bad Source!")))
+	assert.Nil(t, rippling.SanitizeClientSource(sptr("UPPER")))
+	assert.Nil(t, rippling.SanitizeClientSource(sptr("a'; DROP TABLE x--")))
+	assert.Nil(t, rippling.SanitizeClientSource(sptr("_leading")))
+	assert.Nil(t, rippling.SanitizeClientSource(sptr("this-is-well-over-thirty-two-characters-long")))
+
+	for _, ok := range []string{"browse", "search", "message_page", "email", "myposts", "digest-2"} {
+		got := rippling.SanitizeClientSource(sptr(ok))
+		if assert.NotNil(t, got, ok) {
+			assert.Equal(t, ok, *got)
+		}
+	}
+}

--- a/iznik-server-go/test/rippling_metrics_test.go
+++ b/iznik-server-go/test/rippling_metrics_test.go
@@ -629,6 +629,10 @@ func TestRipplingMetricsClientSourceSummary(t *testing.T) {
 
 	summary, has := result["client_source_summary"].([]interface{})
 	assert.True(t, has, "client_source_summary present")
+	// The seeded rows carry client_source - evidence only live capture writes - so the
+	// live-capture boundary date must be surfaced for the dashboard's chart marker.
+	assert.NotEmpty(t, result["attribution_capture_from"],
+		"attribution_capture_from set once live-captured evidence exists")
 	counts := map[string]float64{}
 	for _, r := range summary {
 		if m, ok := r.(map[string]interface{}); ok {
@@ -703,6 +707,24 @@ func TestReplySourceSplitLegacyVariant(t *testing.T) {
 		assert.Equal(t, 0, row.RippleReach, "location channels are not derivable retrospectively")
 		assert.Equal(t, 0, row.OrganicLocal, "location channels are not derivable retrospectively")
 		assert.GreaterOrEqual(t, row.Unknown, 1, "un-evidenced replies sit in unknown")
+	}
+
+	// The WIDE variant must derive these same attribution-NULL rows per row, not fold them
+	// into home/unknown - otherwise the window between the migration landing on production
+	// and the backfill running reads as a misleading zero-ripple chart (seen live 2026-07-07).
+	wideRows := []rippling.ReplySourceRow{}
+	err = db.Raw(rippling.ReplySourceSplitSQL(true, ""), start, end).Scan(&wideRows).Error
+	assert.NoError(t, err)
+	var wideRow *rippling.ReplySourceRow
+	for i := range wideRows {
+		if wideRows[i].Replies >= 4 && wideRows[i].Home >= 1 {
+			wideRow = &wideRows[i]
+			break
+		}
+	}
+	if assert.NotNil(t, wideRow, "the seeded day is present in the wide variant") {
+		assert.GreaterOrEqual(t, wideRow.RippleNotified, 1, "NULL-attribution notified reply derived per row")
+		assert.GreaterOrEqual(t, wideRow.RippleGroup, 1, "NULL-attribution rippled-group reply derived per row")
 	}
 }
 

--- a/iznik-server-go/test/rippling_metrics_test.go
+++ b/iznik-server-go/test/rippling_metrics_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/freegle/iznik-server-go/database"
+	"github.com/freegle/iznik-server-go/rippling"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -285,13 +286,15 @@ func TestRipplingMetricsReplyKPIs(t *testing.T) {
 	_, token := CreateTestSession(t, adminID)
 
 	db := database.DBConn
-	db.Exec(`CREATE TABLE IF NOT EXISTS rippling_reply_attribution (
-		msgid BIGINT UNSIGNED NOT NULL, userid BIGINT UNSIGNED NOT NULL,
-		replied_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, was_home_member TINYINT(1) NOT NULL,
-		PRIMARY KEY (msgid, userid), KEY rra_replied_at (replied_at))`)
-	// Two replies on an isolated day (5 days ago): one established member (home), one via rippling.
-	db.Exec("INSERT IGNORE INTO rippling_reply_attribution (msgid, userid, replied_at, was_home_member) VALUES " +
-		"(900000091, 900000091, NOW() - INTERVAL 5 DAY, 1), (900000091, 900000092, NOW() - INTERVAL 5 DAY, 0)")
+	// Four replies on an isolated day (5 days ago), one per interesting bucket: a home
+	// member, a graded ripple_notified capture, a graded ripple_reach capture, and a
+	// legacy pre-migration row (attribution NULL, was_home_member=0) which must fold into
+	// unknown - NOT be credited to rippling as the old replies-minus-home number did.
+	db.Exec("INSERT IGNORE INTO rippling_reply_attribution (msgid, userid, replied_at, was_home_member, attribution) VALUES " +
+		"(900000091, 900000091, NOW() - INTERVAL 5 DAY, 1, 'home'), " +
+		"(900000091, 900000092, NOW() - INTERVAL 5 DAY, 0, 'ripple_notified'), " +
+		"(900000091, 900000093, NOW() - INTERVAL 5 DAY, 0, 'ripple_reach'), " +
+		"(900000091, 900000094, NOW() - INTERVAL 5 DAY, 0, NULL)")
 	defer db.Exec("DELETE FROM rippling_reply_attribution WHERE msgid = 900000091")
 
 	resp, _ := getApp().Test(httptest.NewRequest("GET", fmt.Sprintf("/api/rippling/metrics?jwt=%s", token), nil))
@@ -300,24 +303,31 @@ func TestRipplingMetricsReplyKPIs(t *testing.T) {
 	var result map[string]interface{}
 	json.Unmarshal(rsp(resp), &result)
 
-	// All three reply-KPI keys are present (arrays).
+	// All three reply-KPI keys are present (arrays), and the graded columns are flagged live.
 	_, hasRate := result["reply_rate_36h"].([]interface{})
 	_, hasDist := result["reply_distance_median"].([]interface{})
 	split, hasSplit := result["reply_source_split"].([]interface{})
 	assert.True(t, hasRate, "reply_rate_36h present")
 	assert.True(t, hasDist, "reply_distance_median present")
 	assert.True(t, hasSplit, "reply_source_split present")
+	assert.Equal(t, true, result["attribution_channels_available"],
+		"graded columns exist on the migrated test DB")
 
-	// The seeded day's split row: 2 replies, 1 home, 1 ripple -> 50% rippling.
+	// The seeded day's split row: 4 replies -> 1 home, 1 notified, 1 reach, 1 unknown;
+	// ripple share counts only the definite ripple channels (2/4 = 50%).
 	found := false
 	for _, r := range split {
-		if m, ok := r.(map[string]interface{}); ok && m["replies"] == float64(2) && m["home"] == float64(1) {
+		if m, ok := r.(map[string]interface{}); ok && m["replies"] == float64(4) && m["home"] == float64(1) {
 			found = true
-			assert.Equal(t, float64(1), m["ripple"], "one rippling reply")
-			assert.Equal(t, float64(50), m["ripple_pct"], "50% of replies via rippling")
+			assert.Equal(t, float64(1), m["ripple_notified"], "one notified-ledger reply")
+			assert.Equal(t, float64(1), m["ripple_reach"], "one reach-fed browse reply")
+			assert.Equal(t, float64(1), m["unknown"],
+				"a legacy un-evidenced row folds into unknown, not ripple")
+			assert.Equal(t, float64(2), m["ripple"], "ripple = notified + group + reach only")
+			assert.Equal(t, float64(50), m["ripple_pct"])
 		}
 	}
-	assert.True(t, found, "the seeded rippling/home split is surfaced")
+	assert.True(t, found, "the seeded channel split is surfaced")
 }
 
 // The ?start= / ?end= range bounds every headline KPI so a treatment group's before-vs-after can
@@ -330,10 +340,6 @@ func TestRipplingMetricsDateRange(t *testing.T) {
 	_, token := CreateTestSession(t, adminID)
 
 	db := database.DBConn
-	db.Exec(`CREATE TABLE IF NOT EXISTS rippling_reply_attribution (
-		msgid BIGINT UNSIGNED NOT NULL, userid BIGINT UNSIGNED NOT NULL,
-		replied_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, was_home_member TINYINT(1) NOT NULL,
-		PRIMARY KEY (msgid, userid), KEY rra_replied_at (replied_at))`)
 	db.Exec("INSERT IGNORE INTO rippling_reply_attribution (msgid, userid, replied_at, was_home_member) VALUES " +
 		"(900000291, 900000291, '2020-01-15 12:00:00', 0)")
 	defer db.Exec("DELETE FROM rippling_reply_attribution WHERE msgid = 900000291")
@@ -584,38 +590,120 @@ func TestRipplingMetricsDistanceCohorts(t *testing.T) {
 	assert.Greater(t, row["ripple_median_km"].(float64), row["home_median_km"].(float64), "rippled replies are further away")
 }
 
-// ?trialOnly=1 scopes the metrics to the RIPPLE_WITHIN_GROUPS trial set, which Laravel mirrors
-// into config['ripple.within_groups'] (the Go API runs on a different server and can't read that
-// batch env var). The endpoint echoes the resolved set so the dashboard can show it. Without the
-// param there is no trial scope and the set is empty.
-func TestRipplingMetricsTrialScope(t *testing.T) {
+// The trial is over - rippling is fully live - so the trial scoping is retired: the endpoint
+// ignores a stale ?trialOnly=1 from a cached client (no filtering, no trial keys in the
+// response) instead of scoping to the old RIPPLE_WITHIN_GROUPS set.
+func TestRipplingMetricsTrialScopeRetired(t *testing.T) {
 	prefix := uniquePrefix("rippletrial")
 	adminID := CreateTestUser(t, prefix+"_admin", "Support")
 	_, token := CreateTestSession(t, adminID)
 
-	db := database.DBConn
-	db.Exec("INSERT INTO config (`key`, value) VALUES ('ripple.within_groups', '99000001,99000002') " +
-		"ON DUPLICATE KEY UPDATE value = VALUES(value)")
-	defer db.Exec("DELETE FROM config WHERE `key` = 'ripple.within_groups'")
-
-	// With the param: trial_only flagged and trial_group_ids echoes the config-mirrored set.
 	resp, _ := getApp().Test(httptest.NewRequest("GET", fmt.Sprintf("/api/rippling/metrics?trialOnly=1&jwt=%s", token), nil))
 	assert.Equal(t, 200, resp.StatusCode)
 	var result map[string]interface{}
 	json.Unmarshal(rsp(resp), &result)
-	assert.Equal(t, true, result["trial_only"], "trial_only flagged when ?trialOnly=1")
-	ids, _ := result["trial_group_ids"].([]interface{})
-	assert.ElementsMatch(t, []interface{}{float64(99000001), float64(99000002)}, ids,
-		"trial_group_ids echoes RIPPLE_WITHIN_GROUPS mirrored via config")
+	_, hasTrialOnly := result["trial_only"]
+	_, hasTrialIDs := result["trial_group_ids"]
+	assert.False(t, hasTrialOnly, "trial_only no longer in the response")
+	assert.False(t, hasTrialIDs, "trial_group_ids no longer in the response")
+}
 
-	// Without the param: no trial scope, empty set (even though the config row exists).
-	resp2, _ := getApp().Test(httptest.NewRequest("GET", fmt.Sprintf("/api/rippling/metrics?jwt=%s", token), nil))
-	assert.Equal(t, 200, resp2.StatusCode)
-	var result2 map[string]interface{}
-	json.Unmarshal(rsp(resp2), &result2)
-	assert.Equal(t, false, result2["trial_only"], "trial_only false without the param")
-	ids2, _ := result2["trial_group_ids"].([]interface{})
-	assert.Empty(t, ids2, "trial_group_ids empty without the param")
+// The client-reported reply surfaces (advisory cross-check of the attribution channels) are
+// summarised over the same window, with NULL reported as '(not reported)'.
+func TestRipplingMetricsClientSourceSummary(t *testing.T) {
+	prefix := uniquePrefix("ripplesrc")
+	adminID := CreateTestUser(t, prefix+"_admin", "Support")
+	_, token := CreateTestSession(t, adminID)
+
+	db := database.DBConn
+	db.Exec("INSERT IGNORE INTO rippling_reply_attribution (msgid, userid, replied_at, was_home_member, attribution, client_source) VALUES " +
+		"(900000391, 900000391, NOW() - INTERVAL 3 DAY, 0, 'ripple_notified', 'browse'), " +
+		"(900000391, 900000392, NOW() - INTERVAL 3 DAY, 0, 'ripple_notified', 'browse'), " +
+		"(900000391, 900000393, NOW() - INTERVAL 3 DAY, 1, 'home', NULL)")
+	defer db.Exec("DELETE FROM rippling_reply_attribution WHERE msgid = 900000391")
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET", fmt.Sprintf("/api/rippling/metrics?jwt=%s", token), nil))
+	assert.Equal(t, 200, resp.StatusCode)
+	var result map[string]interface{}
+	json.Unmarshal(rsp(resp), &result)
+
+	summary, has := result["client_source_summary"].([]interface{})
+	assert.True(t, has, "client_source_summary present")
+	counts := map[string]float64{}
+	for _, r := range summary {
+		if m, ok := r.(map[string]interface{}); ok {
+			counts[m["source"].(string)] += m["count"].(float64)
+		}
+	}
+	assert.GreaterOrEqual(t, counts["browse"], float64(2), "browse surfaces counted")
+	assert.GreaterOrEqual(t, counts["(not reported)"], float64(1), "NULL surfaces reported honestly")
+}
+
+// The legacy reply-source variant - what runs against a production DB that predates the
+// graded-attribution migration - must derive the durable channels live: a notified-ledger hit
+// outranks a rippled-group membership, home wins over both, and everything else is unknown
+// (never silently credited to rippling). Runs the legacy SQL directly against the migrated
+// test DB: the variant reads none of the graded columns, so its behaviour is identical there.
+func TestReplySourceSplitLegacyVariant(t *testing.T) {
+	prefix := uniquePrefix("legacysplit")
+	db := database.DBConn
+
+	groupID := CreateTestGroup(t, prefix)
+	posterID := CreateTestUser(t, prefix+"_poster", "User")
+	CreateTestMembership(t, posterID, groupID, "Member")
+	msgID := CreateTestMessage(t, posterID, groupID, "OFFER: legacy split test item", 51.5, -0.1)
+	defer db.Exec("DELETE FROM rippling_reply_attribution WHERE msgid = ?", msgID)
+	defer db.Exec("DELETE FROM rippling_reach_notified WHERE msgid = ?", msgID)
+
+	db.Exec(`CREATE TABLE IF NOT EXISTS rippling_reach_notified (
+		msgid BIGINT UNSIGNED NOT NULL, userid BIGINT UNSIGNED NOT NULL,
+		notified_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		PRIMARY KEY (msgid, userid), KEY rrn_userid (userid))`)
+
+	// A rippled-in copy of the post, and a replier who was an established member of that
+	// group before it arrived.
+	rippledGroup := CreateTestGroup(t, prefix+"_rippled")
+	db.Exec("INSERT INTO messages_groups (msgid, groupid, arrival, collection, autoreposts, rippled_in) "+
+		"VALUES (?, ?, NOW() - INTERVAL 1 DAY, 'Approved', 0, 1)", msgID, rippledGroup)
+	groupMemberID := CreateTestUser(t, prefix+"_member", "User")
+	CreateTestMembership(t, groupMemberID, rippledGroup, "Member")
+	db.Exec("UPDATE memberships SET added = NOW() - INTERVAL 2 DAY, collection = 'Approved' WHERE userid = ? AND groupid = ?",
+		groupMemberID, rippledGroup)
+
+	notifiedID := CreateTestUser(t, prefix+"_notified", "User")
+	db.Exec("INSERT INTO rippling_reach_notified (msgid, userid, notified_at) VALUES (?, ?, NOW() - INTERVAL 1 DAY)",
+		msgID, notifiedID)
+
+	unknownID := CreateTestUser(t, prefix+"_unknown", "User")
+
+	// Legacy rows: was_home_member only, graded columns untouched (as an unmigrated DB would have).
+	db.Exec("INSERT IGNORE INTO rippling_reply_attribution (msgid, userid, replied_at, was_home_member) VALUES "+
+		"(?, ?, NOW() - INTERVAL 2 HOUR, 1), "+ // home member
+		"(?, ?, NOW() - INTERVAL 2 HOUR, 0), "+ // notified
+		"(?, ?, NOW() - INTERVAL 2 HOUR, 0), "+ // rippled-group member
+		"(?, ?, NOW() - INTERVAL 2 HOUR, 0)", // no evidence -> unknown
+		msgID, posterID, msgID, notifiedID, msgID, groupMemberID, msgID, unknownID)
+
+	rows := []rippling.ReplySourceRow{}
+	start := time.Now().AddDate(0, 0, -1).Format("2006-01-02 15:04:05")
+	end := time.Now().Format("2006-01-02 15:04:05")
+	err := db.Raw(rippling.ReplySourceSplitSQL(false, ""), start, end).Scan(&rows).Error
+	assert.NoError(t, err)
+
+	var row *rippling.ReplySourceRow
+	for i := range rows {
+		if rows[i].Replies >= 4 && rows[i].Home >= 1 {
+			row = &rows[i]
+			break
+		}
+	}
+	if assert.NotNil(t, row, "the seeded day is present") {
+		assert.GreaterOrEqual(t, row.RippleNotified, 1, "notified-ledger reply derived live")
+		assert.GreaterOrEqual(t, row.RippleGroup, 1, "rippled-group membership derived live")
+		assert.Equal(t, 0, row.RippleReach, "location channels are not derivable retrospectively")
+		assert.Equal(t, 0, row.OrganicLocal, "location channels are not derivable retrospectively")
+		assert.GreaterOrEqual(t, row.Unknown, 1, "un-evidenced replies sit in unknown")
+	}
 }
 
 // Anchor regression (Discourse #9808): a RIPPLED post's reply-rate day/window must key on its


### PR DESCRIPTION
## Summary

The old "share of replies from rippling" was a single negative bit: any replier who wasn't an established origin-group member was credited to rippling - including search arrivals, deep links, and new members replying to posts that never rippled. This replaces it with graded per-reply attribution plus a client-reported provenance cross-check.

- **Evidence ladder captured at reply time** (Go `CreateChatMessage` → `recordReplyAttribution`): `home` → `ripple_notified` (notified-ledger hit - we sent them the ripple mail) → `ripple_group` (established member of a group the post rippled into, membership predating the copy's arrival) → `organic_local` (non-member inside the origin catchment - would have seen it in Browse anyway) → `ripple_reach` (outside the catchment, inside the reach polygon - exposure existed only because of the ripple) → `unknown`. Evidence bits are stored separately so the ladder can be re-derived later.
- **Hard guard**: a post that never rippled can never be ripple-attributed (`post_had_rippled`).
- **Conservative precedence**: `home` outranks all ripple evidence; `organic_local` outranks `ripple_reach` because the reach polygon always covers the origin area.
- **Reports no longer pollute the metric**: capture is scoped to User2User (a refmsgid message in a User2Mod room is a report, and previously wrote an attribution row).
- **Semantics change on the dashboard**: `ripple`/`ripple_pct` now counts only the definite ripple channels - `unknown` is no longer silently credited to rippling.
- **Client provenance** (advisory, never folded into the ladder): the reply flow derives its surface from the route (`?src=` verbatim → bare `?reply=1` = `email` → `message_page` / `browse` / `search` / first path segment), persists it across the login/registration redirect, and sends it as `replysource`; the server regex-sanitises into `client_source`.
- **Dashboard**: "Where do replies come from?" percent-stacked composition (ripple family = one green hue lightness-stepped so the green band reads as the ripple share; greys deliberately neutral for the not-creditable buckets), plus a client-surface cross-check table. Trial-groups scoping retired end to end (rippling is fully live).
- **Correct in every rollout state**: until migration `2026_07_07_000002` runs, the Go API derives the durable channels (home/notified/group) live from timestamped tables and flags `attribution_channels_available=false`; once migrated, rows the capture/backfill haven't derived yet (`attribution` NULL) fall back PER ROW to the same derivation - without this, the window between the migration landing and the backfill running read as a misleading zero-ripple chart (seen live on prod). The capture falls back to the legacy insert pre-migration. Column existence is checked once per process - restart the Go API after migrating.
- **Live-capture boundary on the chart**: the API reports `attribution_capture_from` (first row carrying evidence only reply-time capture writes - location containment or client source) and the dashboard draws a vertical "Live capture from here" annotation: left of it the history is derived (mail/group ripple channels only; reach-browse/local sit in Unknown), right of it the full six-way split applies.
- **Backfill**: `ripple:backfill-reply-attribution` freezes the durable bits onto legacy rows (set-based chunked UPDATE, idempotent, dry-run by flag). Location bits are deliberately not backfillable (locations drift, polygons grow).

## Production rollout

1. Run `2026_07_07_000002_add_attribution_evidence_to_rippling_reply_attribution_migration.sql` (idempotent).
2. Deploy Go API + batch + Nuxt; restart the Go API (schema check is once-per-process).
3. `php artisan ripple:backfill-reply-attribution` (idempotent; `--dry-run` first if preferred).

Order is safe in any sequence - both the capture and the metrics degrade gracefully either side of the migration.

## Code Quality Review

- The reach gate's spatial query was consolidated (one keyed query answers "reach row exists" and "contains replier"; msgid is the PK) and its result reused by the capture - gate semantics unchanged, verified by the existing gate tests.
- `ReplySourceSplitSQL(wide)` is exported so the legacy variant - which only ever runs against an unmigrated production DB - stays testable against the migrated test DB (it reads none of the graded columns).
- Client source is regex-constrained (`^[a-z0-9][a-z0-9_-]{0,31}$`), not enum-whitelisted, so new client surfaces don't need an API deploy while injection shapes are dropped.
- Best-effort throughout the capture: attribution can never block a reply.

## Future Improvements

- Tag ripple immediate-mail links with a distinct `src=` so client provenance can distinguish ripple mail from digest clicks without the notified-ledger join.
- Surface a per-channel reply→Taken conversion so the channels can be judged on outcomes, not just volume.
- The r-drift / fan-out alarm tiles from the sysadmin redesign notes remain open (separate work).

## Test Plan

- Go suite: 3422 passed (status API). New: attribution ladder end-to-end (notified / ripple_group / organic_local / ripple_reach / no-location NULL evidence / never-rippled hard guard / client-source sanitisation), report-writes-no-row regression, legacy SQL variant derivation, metrics channel split + client-source summary + retired trial keys, pure ladder/sanitiser table tests.
- Laravel suite: 4765 passed. New: backfill service (durable channels, hard guard freeze, join-to-reply not ripple_group, already-derived rows untouched, limit) + command (dry-run, apply, clean no-op).
- Vitest: 14193 passed. New/updated: channel-chart data mapping + percent stacking, migration-pending note, client-surface table, trial-toggle retirement, reply-surface route derivation table tests, replysource payload plumbing (only alongside refmsgid), provenance persistence across login redirect.
- Deployed to the live-tunnel containers and verified: apiv2-live healthy with the new build (`/api/rippling/metrics` auth-gated, not 500), ModTools dev-live renders; dashboard shows the designed unmigrated-DB fallback against prod data.
