### PR TITLE
fix(chitchat): event-driven scroll pin - centred target, no timers, collapse-aware deep links

### DIFF
--- a/iznik-nuxt3/components/NewsReplies.vue
+++ b/iznik-nuxt3/components/NewsReplies.vue
@@ -39,6 +39,7 @@
           class="reply-content"
           :depth="depth"
           @rendered="rendered"
+          @subtree-rendered="childSubtreeRendered"
           @expand-combined="expandCombined"
         />
       </div>
@@ -46,7 +47,7 @@
   </div>
 </template>
 <script setup>
-import { ref, computed, defineAsyncComponent } from 'vue'
+import { ref, computed, watch, onMounted, defineAsyncComponent } from 'vue'
 import { useNewsfeedStore } from '~/stores/newsfeed'
 import { useAuthStore } from '~/stores/auth'
 import NewsRefer from '~/components/NewsRefer'
@@ -85,7 +86,7 @@ const props = defineProps({
   },
 })
 
-const emit = defineEmits(['rendered'])
+const emit = defineEmits(['rendered', 'subtree-rendered'])
 
 const newsfeedStore = useNewsfeedStore()
 const authStore = useAuthStore()
@@ -118,7 +119,9 @@ const seenBeforeVisit = computed(() => newsfeedStore.seenBeforeVisit)
 function isReplyNew(reply) {
   if (!seenBeforeVisit.value) return false
   if (reply.combinedIds) {
-    return reply.combinedIds[reply.combinedIds.length - 1] > seenBeforeVisit.value
+    return (
+      reply.combinedIds[reply.combinedIds.length - 1] > seenBeforeVisit.value
+    )
   }
   return reply.id > seenBeforeVisit.value
 }
@@ -318,11 +321,47 @@ const collapsePlan = computed(() => {
 
 const renderEntries = computed(() => collapsePlan.value.entries)
 
-const hiddenCount = computed(() => collapsePlan.value.hidden.length)
+// Deterministic completion for the deep-link scroll: this list's subtree is
+// rendered once every NewsReply row in the current render plan has reported
+// its own subtree mounted. NewsRefer rows are synchronous imports (mounted
+// with this component) and expander rows render nothing async, so neither
+// is waited on. Re-evaluated when the render plan changes (e.g. expanding
+// the collapse adds rows, regressing completion until they mount too).
+const completedSubtrees = new Set()
+let subtreeSatisfied = false
 
-const showExpander = computed(
-  () => shouldCollapse.value && hiddenCount.value > 0
-)
+function expectedSubtreeIds() {
+  return renderEntries.value
+    .filter(
+      (e) =>
+        !e.expander && !(e.reply.type && e.reply.type.indexOf('ReferTo') === 0)
+    )
+    .map((e) => e.reply.id)
+}
+
+function evaluateSubtree() {
+  const done = expectedSubtreeIds().every((id) => completedSubtrees.has(id))
+  if (done && !subtreeSatisfied) {
+    subtreeSatisfied = true
+    emit('subtree-rendered', props.id)
+  } else if (!done) {
+    subtreeSatisfied = false
+  }
+}
+
+function childSubtreeRendered(id) {
+  completedSubtrees.add(id)
+  evaluateSubtree()
+}
+
+watch(renderEntries, evaluateSubtree)
+
+onMounted(() => {
+  // Nothing async to wait for (all rows NewsRefer, or none) - report now.
+  evaluateSubtree()
+})
+
+const hiddenCount = computed(() => collapsePlan.value.hidden.length)
 
 // Hidden entries never contain new activity (they are exempted above), so the
 // label only ever describes older conversation.

--- a/iznik-nuxt3/components/NewsReply.vue
+++ b/iznik-nuxt3/components/NewsReply.vue
@@ -170,7 +170,8 @@
     </div>
     <!-- Forward rendered events from nested replies: without this the
          notification deep-link scroll in NewsThread never hears about
-         depth 2+ replies mounting. -->
+         depth 2+ replies mounting. When the nested list reports that its
+         whole subtree has mounted, this reply's subtree is complete too. -->
     <NewsReplies
       v-if="reply?.replies?.length"
       :id="id"
@@ -179,6 +180,7 @@
       :reply-to="reply.id"
       :depth="depth + 1"
       @rendered="$emit('rendered', $event)"
+      @subtree-rendered="$emit('subtree-rendered', id)"
     />
     <div v-if="showReplyBox" class="mb-2 pb-1 ms-4">
       <div v-if="enterNewLine" class="w-100">
@@ -331,7 +333,9 @@ import { useNewsfeedStore } from '~/stores/newsfeed'
 import { useMiscStore } from '~/stores/misc'
 import {
   scrollToAndPin,
-  fixedHeaderOffset,
+  imagesComplete,
+  whenImagesComplete,
+  whenAllSettled,
 } from '~/composables/useScrollAnchor'
 import { twem, untwem } from '~/composables/useTwem'
 import NewsUserInfo from '~/components/NewsUserInfo'
@@ -384,7 +388,7 @@ const props = defineProps({
   },
 })
 
-const emit = defineEmits(['rendered', 'expand-combined'])
+const emit = defineEmits(['rendered', 'subtree-rendered', 'expand-combined'])
 
 // Stores
 const newsfeedStore = useNewsfeedStore()
@@ -506,15 +510,6 @@ const hasMoreActions = computed(() => {
 
 // Watchers
 watch(
-  () => props.scrollTo,
-  (newVal) => {
-    if (parseInt(props.scrollTo) === props.id && scrollIntoView) {
-      scrollIntoView()
-    }
-  }
-)
-
-watch(
   currentAtts,
   (newVal) => {
     if (newVal.length > 0) {
@@ -533,8 +528,15 @@ let ownPin = null
 // Lifecycle hooks
 onMounted(() => {
   // This will get propogated up the stack so that we know if the reply to which we'd like to scroll has been
-  // rendered.  We'll then come through the watch above.
+  // rendered.  The deep-link scroll in NewsThread is driven by these events.
   emit('rendered', props.id)
+
+  // Completion signal for the deep-link pin: a reply with no children IS its
+  // whole subtree. With children, the nested <NewsReplies> reports when all
+  // of them (recursively) have mounted - forwarded below in the template.
+  if (!reply.value?.replies?.length) {
+    emit('subtree-rendered', props.id)
+  }
 })
 
 onBeforeUnmount(() => {
@@ -606,14 +608,41 @@ async function sendReply(callback) {
 function scrollReplyIntoView(id) {
   if (!id) return
   nextTick(() => {
-    // The pin re-resolves the selector every frame, so it simply waits for
-    // the refetched thread to render the new reply, then holds it centered
-    // through the re-order shuffle.
+    // The pin re-resolves the selector on every correction, so it simply
+    // waits for the refetched thread to render the new reply, then holds it
+    // centered until the post-send refetch and image loads are complete.
     ownPin = scrollToAndPin(
       () => document.querySelector(`[data-reply-id="${id}"]`),
-      { block: 'center' }
+      { block: 'center', done: contentSettled() }
     )
   })
+}
+
+// Resolves when nothing that could still move the layout is outstanding:
+// no in-flight API requests and no images still loading. Event-driven -
+// built on store reactivity and image load/error events, not timers.
+function contentSettled() {
+  return whenAllSettled([
+    {
+      ok: () => !miscStore.apiCount,
+      wait: () =>
+        new Promise((resolve) => {
+          const stop = watch(
+            () => miscStore.apiCount,
+            (n) => {
+              if (!n) {
+                stop()
+                resolve()
+              }
+            }
+          )
+        }),
+    },
+    {
+      ok: () => imagesComplete(),
+      wait: () => whenImagesComplete(),
+    },
+  ])
 }
 
 function newlineReply() {
@@ -692,17 +721,6 @@ function photoAdd() {
   // Flag that we're uploading. This will trigger the render of the filepond instance and subsequently the
   // init callback below.
   uploading.value = true
-}
-
-function scrollIntoView() {
-  // The reply rows are stamped with data-reply-id by NewsReplies. Long
-  // threads keep rendering async reply chunks and images for several seconds
-  // after this fires, so a one-shot smooth scroll aims at a stale position -
-  // pin the row instead and let the pin follow the layout until it settles.
-  ownPin = scrollToAndPin(
-    () => document.querySelector(`[data-reply-id="${props.id}"]`),
-    { block: 'start', offset: fixedHeaderOffset() }
-  )
 }
 
 function showReplyPhotoModal() {

--- a/iznik-nuxt3/components/NewsThread.vue
+++ b/iznik-nuxt3/components/NewsThread.vue
@@ -121,7 +121,7 @@
           v-if="newsfeed?.replies?.length"
           :id="id"
           :threadhead="newsfeed.id"
-          :scroll-to="scrollDownTo"
+          :scroll-to="scrollTo"
           :reply-to="replyingTo"
           :depth="1"
           :class="newsfeed.deleted ? 'strike me-1' : 'me-1'"
@@ -363,7 +363,6 @@ const threadcommentref = ref(null)
 const threadcommentautoheight = ref(null)
 
 // Reactive state
-const scrollDownTo = ref(null)
 const replyingTo = ref(null)
 const uploading = ref(false)
 const imageid = ref(null)
@@ -538,24 +537,23 @@ function threadContentSettled() {
 
 // Methods
 function rendered(id) {
-  if (parseInt(id) === parseInt(props.scrollTo)) {
-    scrollDownTo.value = props.scrollTo
-
-    // Deep link (/chitchat/<replyid>): hold the reply centred while the
-    // rest of the thread streams in around it, releasing only when the
-    // content is provably complete. Once per page - re-mounts of the same
-    // target must not restart a released pin.
-    if (!deepLinkPinned) {
-      deepLinkPinned = true
-      ownPin = scrollToAndPin(
-        () => document.querySelector(`[data-reply-id="${props.scrollTo}"]`),
-        {
-          block: 'center',
-          offset: fixedHeaderOffset(),
-          done: threadContentSettled(),
-        }
-      )
-    }
+  // Deep link (/chitchat/<replyid>): hold the reply centred while the
+  // rest of the thread streams in around it, releasing only when the
+  // content is provably complete. The scrollTo prop flows down from mount
+  // (NOT set after the target renders - the collapse must know the target
+  // up front, or a target hidden behind "Show older replies" could never
+  // mount to tell us). Once per page - re-mounts of the same target must
+  // not restart a released pin.
+  if (parseInt(id) === parseInt(props.scrollTo) && !deepLinkPinned) {
+    deepLinkPinned = true
+    ownPin = scrollToAndPin(
+      () => document.querySelector(`[data-reply-id="${props.scrollTo}"]`),
+      {
+        block: 'center',
+        offset: fixedHeaderOffset(),
+        done: threadContentSettled(),
+      }
+    )
   }
 }
 

--- a/iznik-nuxt3/components/NewsThread.vue
+++ b/iznik-nuxt3/components/NewsThread.vue
@@ -126,6 +126,7 @@
           :depth="1"
           :class="newsfeed.deleted ? 'strike me-1' : 'me-1'"
           @rendered="rendered"
+          @subtree-rendered="repliesRendered = true"
         />
         <span v-if="!newsfeed?.closed">
           <div v-if="enterNewLine">
@@ -276,6 +277,7 @@ import {
   defineAsyncComponent,
   watch,
   onMounted,
+  onBeforeUnmount,
   nextTick,
 } from 'vue'
 import AutoHeightTextarea from './AutoHeightTextarea'
@@ -283,7 +285,13 @@ import { useNewsfeedStore } from '~/stores/newsfeed'
 import { useMiscStore } from '~/stores/misc'
 import NewsReplies from '~/components/NewsReplies'
 import { untwem } from '~/composables/useTwem'
-import { scrollToAndPin } from '~/composables/useScrollAnchor'
+import {
+  scrollToAndPin,
+  fixedHeaderOffset,
+  imagesComplete,
+  whenImagesComplete,
+  whenAllSettled,
+} from '~/composables/useScrollAnchor'
 import { useAuthStore } from '~/stores/auth'
 import { useMe } from '~/composables/useMe'
 
@@ -484,10 +492,70 @@ onMounted(() => {
   emit('rendered')
 })
 
+// True once the whole reply tree has reported mounting (or there was
+// nothing to mount). Feeds the deep-link pin's completion signal.
+const repliesRendered = ref(!newsfeed.value?.replies?.length)
+
+// The pin this component started, if any, so unmount can stop it.
+let ownPin = null
+let deepLinkPinned = false
+
+onBeforeUnmount(() => {
+  if (ownPin) ownPin()
+})
+
+// An {ok, wait} condition from any reactive getter, for whenAllSettled.
+function condition(get) {
+  return {
+    ok: () => !!get(),
+    wait: () =>
+      new Promise((resolve) => {
+        const stop = watch(get, (v) => {
+          if (v) {
+            stop()
+            resolve()
+          }
+        })
+      }),
+  }
+}
+
+// Resolves when nothing that could still move the layout is outstanding:
+// the reply tree has fully mounted, no API requests are in flight and no
+// images are still loading. Entirely event-driven - component rendered
+// events, store reactivity and image load/error events. No timers: if a
+// chunk takes ten seconds, the pin simply holds for ten seconds.
+function threadContentSettled() {
+  return whenAllSettled([
+    condition(() => repliesRendered.value),
+    condition(() => !miscStore.apiCount),
+    {
+      ok: () => imagesComplete(),
+      wait: () => whenImagesComplete(),
+    },
+  ])
+}
+
 // Methods
 function rendered(id) {
   if (parseInt(id) === parseInt(props.scrollTo)) {
     scrollDownTo.value = props.scrollTo
+
+    // Deep link (/chitchat/<replyid>): hold the reply centred while the
+    // rest of the thread streams in around it, releasing only when the
+    // content is provably complete. Once per page - re-mounts of the same
+    // target must not restart a released pin.
+    if (!deepLinkPinned) {
+      deepLinkPinned = true
+      ownPin = scrollToAndPin(
+        () => document.querySelector(`[data-reply-id="${props.scrollTo}"]`),
+        {
+          block: 'center',
+          offset: fixedHeaderOffset(),
+          done: threadContentSettled(),
+        }
+      )
+    }
   }
 }
 
@@ -521,13 +589,20 @@ async function sendComment(callback) {
     // property. Keep the poster anchored to their reply: the post-send refetch
     // re-renders in the server's new order (replied-to parents get bumped), so
     // without this the viewport content swaps and the reply lands off-screen.
-    // The pin re-resolves the selector every frame, so it waits for the
-    // refetch to render the new reply and holds it through the shuffle.
+    // The pin re-resolves the selector on every correction, so it waits for
+    // the refetch to render the new reply and holds it through the shuffle,
+    // releasing when the refetch and image loads are complete.
     if (newid) {
       nextTick(() => {
-        scrollToAndPin(
+        ownPin = scrollToAndPin(
           () => document.querySelector(`[data-reply-id="${newid}"]`),
-          { block: 'center' }
+          {
+            block: 'center',
+            done: whenAllSettled([
+              condition(() => !miscStore.apiCount),
+              { ok: () => imagesComplete(), wait: () => whenImagesComplete() },
+            ]),
+          }
         )
       })
     }

--- a/iznik-nuxt3/composables/useScrollAnchor.js
+++ b/iznik-nuxt3/composables/useScrollAnchor.js
@@ -1,15 +1,20 @@
 // Scroll an element into view and KEEP it there while late-rendering content
 // (async reply chunks, images, link previews) shifts the layout underneath.
 //
-// A smooth scrollIntoView aims at where the target was when the animation
-// started; on a page that is still streaming in content the destination is
-// stale before the animation lands, and re-firing it produces the
-// scroll-past/overshoot chase seen on long ChitChat threads. So instead:
-// jump instantly, then re-pin instantly whenever the target's DOCUMENT
-// position changes, until the layout has been quiet for SETTLE_MS.
-
-export const SETTLE_MS = 750
-export const MAX_PIN_MS = 8000
+// Fully event-driven - no timers, no polling, no rAF sampling:
+// - corrections happen when layout-change EVENTS fire (ResizeObserver on the
+//   observed root, MutationObserver for node churn, both of which cover
+//   async chunks mounting and images getting their real height)
+// - release happens when the caller's `done` promise resolves - built from
+//   component rendered events, the API request counter reaching zero and
+//   image load/error events - with one final correction on the way out
+// - user input (wheel/touch/pointer/key) cancels instantly; the pin never
+//   fights the user. Unmount and pin-supersession also cancel.
+//
+// A smooth scrollIntoView chase can't work here: it aims at where the target
+// was when the animation started, and on a page still streaming in content
+// the destination is stale before the animation lands. Instant event-driven
+// re-pins mean the target visibly holds still while everything else loads.
 
 // Only one auto-scroll intent can be live at a time - a newer pin (e.g.
 // anchoring a just-sent reply) supersedes an older one (a deep-link scroll).
@@ -28,38 +33,99 @@ export function fixedHeaderOffset() {
   return height + 8
 }
 
+// True when every image under root has finished (loaded or errored).
+export function imagesComplete(root = document.body) {
+  for (const img of root.querySelectorAll('img')) {
+    if (!img.complete) return false
+  }
+  return true
+}
+
+// Resolves once every image currently under root - plus any added while
+// waiting - has fired load or error.
+export function whenImagesComplete(root = document.body) {
+  return new Promise((resolve) => {
+    const pending = new Set()
+    let observer = null
+
+    function finish() {
+      if (pending.size === 0) {
+        if (observer) observer.disconnect()
+        resolve()
+      }
+    }
+
+    function track(img) {
+      if (img.complete || pending.has(img)) return
+      pending.add(img)
+      const done = () => {
+        img.removeEventListener('load', done)
+        img.removeEventListener('error', done)
+        pending.delete(img)
+        finish()
+      }
+      img.addEventListener('load', done)
+      img.addEventListener('error', done)
+    }
+
+    observer = new MutationObserver((mutations) => {
+      for (const m of mutations) {
+        for (const node of m.addedNodes) {
+          if (node.nodeName === 'IMG') track(node)
+          else if (node.querySelectorAll) {
+            for (const img of node.querySelectorAll('img')) track(img)
+          }
+        }
+      }
+    })
+    observer.observe(root, { childList: true, subtree: true })
+
+    for (const img of root.querySelectorAll('img')) track(img)
+    finish()
+  })
+}
+
+// Awaits a set of {ok, wait} conditions until ALL hold at the same moment.
+// Each wait() resolves on its condition's next satisfaction; after every
+// round the conditions are re-checked together, so one flipping back (a
+// fresh API call, a new image) just triggers another round.
+export async function whenAllSettled(conditions) {
+  for (;;) {
+    await Promise.all(conditions.map((c) => (c.ok() ? null : c.wait())))
+    if (conditions.every((c) => c.ok())) return
+  }
+}
+
 /**
- * @param {() => Element|null} getEl re-resolved every frame so v-if/key churn
- *   that replaces the node doesn't strand the pin on a detached element.
+ * @param {() => Element|null} getEl re-resolved on every correction so
+ *   v-if/key churn that replaces the node doesn't strand the pin.
  * @param {object} options
  * @param {'start'|'center'} options.block viewport placement of the target
- * @param {number} options.offset viewport top the target sits at (block=start)
- * @param {number} options.settleMs quiet period after which the pin ends
- * @param {number} options.maxMs hard cap on the pin's lifetime
+ * @param {number} options.offset viewport top the target sits at (block=start);
+ *   for block=center it is the minimum top, so an over-tall target still
+ *   starts below the fixed header
+ * @param {Promise} options.done content-complete signal: the pin holds until
+ *   this resolves, then applies one final correction and releases
+ * @param {Element} options.root subtree whose layout changes drive
+ *   corrections (defaults to document.body)
  * @returns {() => void} cancel
  */
 export function scrollToAndPin(getEl, options = {}) {
-  const {
-    block = 'start',
-    offset = 0,
-    settleMs = SETTLE_MS,
-    maxMs = MAX_PIN_MS,
-  } = options
+  const { block = 'start', offset = 0, done = null, root = null } = options
 
   if (activeCancel) activeCancel()
 
+  const observedRoot = root || document.body
   let cancelled = false
-  let frame = null
   let lastDocTop = null
-  const startedAt = performance.now()
-  // Until the element first appears there is nothing to settle - deep-link
-  // targets can take a while to mount through the async component chain.
-  let quietSince = null
+  let resizeObserver = null
+  let mutationObserver = null
 
   function cancel() {
     if (cancelled) return
     cancelled = true
-    if (frame !== null) cancelAnimationFrame(frame)
+    if (resizeObserver) resizeObserver.disconnect()
+    if (mutationObserver) mutationObserver.disconnect()
     for (const ev of CANCEL_EVENTS) {
       window.removeEventListener(ev, cancel, { capture: true })
     }
@@ -79,38 +145,48 @@ export function scrollToAndPin(getEl, options = {}) {
     return offset
   }
 
-  function tick() {
+  // force pins even when the document position hasn't changed - used for
+  // the final correction so the target ends exactly placed.
+  function pinNow(force) {
     if (cancelled) return
-
-    const now = performance.now()
-    if (now - startedAt > maxMs) {
-      cancel()
-      return
-    }
-
     const el = getEl()
-    if (el) {
-      const rect = el.getBoundingClientRect()
-      const docTop = rect.top + window.scrollY
-      if (lastDocTop === null || Math.abs(docTop - lastDocTop) > 1) {
-        // The layout moved the target (or this is the first sighting):
-        // re-pin instantly. Our own scrolls don't re-trigger this because
-        // they change rect.top and scrollY by opposite amounts.
-        lastDocTop = docTop
-        quietSince = now
-        window.scrollTo({
-          top: Math.max(0, docTop - desiredViewportTop(rect)),
-          behavior: 'instant',
-        })
-      } else if (quietSince !== null && now - quietSince > settleMs) {
-        cancel()
-        return
-      }
+    if (!el) return
+    const rect = el.getBoundingClientRect()
+    const docTop = rect.top + window.scrollY
+    if (force || lastDocTop === null || Math.abs(docTop - lastDocTop) > 1) {
+      // The layout moved the target (or this is the first sighting):
+      // re-pin instantly. Our own scrolls don't re-trigger the observers
+      // because scrolling changes no element's size or the DOM tree.
+      lastDocTop = docTop
+      window.scrollTo({
+        top: Math.max(0, docTop - desiredViewportTop(rect)),
+        behavior: 'instant',
+      })
     }
-
-    frame = requestAnimationFrame(tick)
   }
 
-  tick()
+  function finish() {
+    if (cancelled) return
+    pinNow(true)
+    cancel()
+  }
+
+  if (done) {
+    done.then(finish, finish)
+  }
+
+  // Content growing, shrinking or replacing above the target changes the
+  // observed root's size and/or its subtree - both observers deliver the
+  // event; pinNow() is idempotent so overlap is harmless.
+  resizeObserver = new ResizeObserver(() => pinNow(false))
+  resizeObserver.observe(observedRoot)
+  mutationObserver = new MutationObserver(() => pinNow(false))
+  mutationObserver.observe(observedRoot, {
+    childList: true,
+    subtree: true,
+    attributes: true,
+  })
+
+  pinNow(false)
   return cancel
 }

--- a/iznik-nuxt3/tests/unit/components/NewsReplies.spec.js
+++ b/iznik-nuxt3/tests/unit/components/NewsReplies.spec.js
@@ -97,7 +97,7 @@ describe('NewsReplies', () => {
             template:
               '<div class="news-reply" :data-id="id"><slot />{{ replyData?.message }}</div>',
             props: ['id', 'replyData', 'threadhead', 'scrollTo', 'depth'],
-            emits: ['rendered', 'expand-combined'],
+            emits: ['rendered', 'subtree-rendered', 'expand-combined'],
           },
           NewsRefer: {
             template: '<div class="news-refer" :data-id="id" />',
@@ -186,7 +186,9 @@ describe('NewsReplies', () => {
       })
 
       const wrapper = createWrapper()
-      expect(wrapper.find('.show-more-btn').text()).toContain('Show 3 older replies')
+      expect(wrapper.find('.show-more-btn').text()).toContain(
+        'Show 3 older replies'
+      )
     })
 
     it('expander label shows correct hidden count for N=25 remaining', () => {
@@ -198,7 +200,9 @@ describe('NewsReplies', () => {
       })
 
       const wrapper = createWrapper()
-      expect(wrapper.find('.show-more-btn').text()).toContain('Show 25 older replies')
+      expect(wrapper.find('.show-more-btn').text()).toContain(
+        'Show 25 older replies'
+      )
     })
 
     it('uses singular "reply" when hidden count is 1', () => {
@@ -222,7 +226,9 @@ describe('NewsReplies', () => {
 
       const wrapper = createWrapper()
       // 7 total - 2 head - 3 tail = 2 hidden
-      expect(wrapper.find('.show-more-btn').text()).toContain('Show 2 older replies')
+      expect(wrapper.find('.show-more-btn').text()).toContain(
+        'Show 2 older replies'
+      )
     })
 
     it('does not show expander for 3 replies', () => {
@@ -364,7 +370,9 @@ describe('NewsReplies', () => {
       })
 
       const wrapper = createWrapper()
-      expect(wrapper.find('.show-more-btn').attributes('aria-expanded')).toBe('false')
+      expect(wrapper.find('.show-more-btn').attributes('aria-expanded')).toBe(
+        'false'
+      )
     })
   })
 
@@ -546,6 +554,58 @@ describe('NewsReplies', () => {
 
       const wrapper = createWrapper()
       expect(wrapper.findAll('.reply-thread').length).toBe(0)
+    })
+  })
+
+  describe('subtree rendered', () => {
+    // Default mock data combines replies 10+11 (same user, close in time)
+    // into one entry keyed 10, so the render plan is [10 (combined), 12].
+
+    it('emits subtree-rendered once every child reply has reported', async () => {
+      const wrapper = createWrapper()
+      const children = wrapper.findAllComponents('.news-reply')
+      expect(children.length).toBe(2)
+
+      children[0].vm.$emit('subtree-rendered', 10)
+      await wrapper.vm.$nextTick()
+      expect(wrapper.emitted('subtree-rendered')).toBeFalsy()
+
+      children[1].vm.$emit('subtree-rendered', 12)
+      await wrapper.vm.$nextTick()
+      expect(wrapper.emitted('subtree-rendered')).toBeTruthy()
+      expect(wrapper.emitted('subtree-rendered')[0]).toEqual([1])
+    })
+
+    it('does not emit while any child is still outstanding', async () => {
+      const wrapper = createWrapper()
+      const children = wrapper.findAllComponents('.news-reply')
+
+      children[0].vm.$emit('subtree-rendered', 10)
+      await wrapper.vm.$nextTick()
+
+      expect(wrapper.emitted('subtree-rendered')).toBeFalsy()
+    })
+
+    it('emits immediately when there is nothing asynchronous to wait for', () => {
+      // All rows are NewsRefer (synchronous import): complete at mount.
+      const referReplies = [
+        {
+          id: 30,
+          userid: 100,
+          displayname: 'User One',
+          message: 'Referred',
+          added: '2024-01-15T10:00:00Z',
+          deleted: false,
+          type: 'ReferToOffer',
+        },
+      ]
+      mockNewsfeedStore.byId.mockImplementation((id) => {
+        if (id === 1) return { id: 1, replies: [30] }
+        return referReplies.find((r) => r.id === id)
+      })
+
+      const wrapper = createWrapper()
+      expect(wrapper.emitted('subtree-rendered')).toBeTruthy()
     })
   })
 })

--- a/iznik-nuxt3/tests/unit/components/NewsReply.spec.js
+++ b/iznik-nuxt3/tests/unit/components/NewsReply.spec.js
@@ -65,6 +65,9 @@ const mockScrollToAndPin = vi.fn(() => vi.fn())
 vi.mock('~/composables/useScrollAnchor', () => ({
   scrollToAndPin: (...args) => mockScrollToAndPin(...args),
   fixedHeaderOffset: () => 74,
+  imagesComplete: () => true,
+  whenImagesComplete: () => Promise.resolve(),
+  whenAllSettled: () => Promise.resolve(),
 }))
 
 vi.mock('pluralize', () => ({
@@ -218,7 +221,7 @@ describe('NewsReply', () => {
           NewsReplies: {
             template: '<div class="news-replies"></div>',
             props: ['id', 'threadhead', 'scrollTo', 'replyTo', 'depth'],
-            emits: ['rendered'],
+            emits: ['rendered', 'subtree-rendered'],
           },
           OurUploader: {
             template: '<div class="our-uploader"></div>',
@@ -525,30 +528,31 @@ describe('NewsReply', () => {
       expect(wrapper.find('.bg-info').exists()).toBe(false)
     })
 
-    it('pins the reply row when scrollTo changes to match the id', async () => {
+    it('does not start a pin itself - NewsThread owns the deep-link pin', async () => {
       const wrapper = createWrapper({ scrollTo: '' })
-      expect(mockScrollToAndPin).not.toHaveBeenCalled()
-
       await wrapper.setProps({ scrollTo: '100' })
+      expect(mockScrollToAndPin).not.toHaveBeenCalled()
+    })
+  })
 
-      expect(mockScrollToAndPin).toHaveBeenCalledTimes(1)
-      const [getEl, opts] = mockScrollToAndPin.mock.calls[0]
-      // Anchored to the top, below the fixed navbar.
-      expect(opts).toEqual({ block: 'start', offset: 74 })
-
-      // The resolver re-queries the row NewsReplies stamps with
-      // data-reply-id, so re-renders that replace the node are followed.
-      const row = document.createElement('div')
-      row.setAttribute('data-reply-id', '100')
-      document.body.appendChild(row)
-      expect(getEl()).toBe(row)
-      row.remove()
+  describe('subtree rendered', () => {
+    it('a reply without children reports its subtree on mount', () => {
+      const wrapper = createWrapper()
+      expect(wrapper.emitted('subtree-rendered')).toBeTruthy()
+      expect(wrapper.emitted('subtree-rendered')[0]).toEqual([100])
     })
 
-    it('does not pin when scrollTo changes to a different id', async () => {
-      const wrapper = createWrapper({ scrollTo: '' })
-      await wrapper.setProps({ scrollTo: '200' })
-      expect(mockScrollToAndPin).not.toHaveBeenCalled()
+    it('a reply with children waits for the nested list to report', async () => {
+      const withNested = { ...mockReply, replies: [{ id: 456 }] }
+      const wrapper = createWrapper({}, withNested)
+      expect(wrapper.emitted('subtree-rendered')).toBeFalsy()
+
+      const nested = wrapper.findComponent('.news-replies')
+      nested.vm.$emit('subtree-rendered', 100)
+      await flushPromises()
+
+      expect(wrapper.emitted('subtree-rendered')).toBeTruthy()
+      expect(wrapper.emitted('subtree-rendered')[0]).toEqual([100])
     })
   })
 

--- a/iznik-nuxt3/tests/unit/components/NewsThread.spec.js
+++ b/iznik-nuxt3/tests/unit/components/NewsThread.spec.js
@@ -1275,19 +1275,14 @@ describe('NewsThread', () => {
     })
   })
 
-  describe('rendered event', () => {
-    it('updates scrollDownTo when rendered id matches scrollTo prop', async () => {
+  describe('scrollTo pass-through', () => {
+    it('hands the deep-link target to NewsReplies from mount, not after render', async () => {
+      // The collapse logic must know the target up front: a target hidden
+      // behind "Show older replies" can never mount to announce itself.
+      mockNewsfeed.value.replies = [5]
       const wrapper = await createWrapper({ scrollTo: '5' })
-      const comp = wrapper.findComponent(NewsThread)
-      comp.vm.rendered(5)
-      expect(comp.vm.scrollDownTo).toBe('5')
-    })
-
-    it('does not update scrollDownTo when ids do not match', async () => {
-      const wrapper = await createWrapper({ scrollTo: '5' })
-      const comp = wrapper.findComponent(NewsThread)
-      comp.vm.rendered(10)
-      expect(comp.vm.scrollDownTo).toBe(null)
+      const replies = wrapper.findComponent('.news-replies')
+      expect(replies.props('scrollTo')).toBe('5')
     })
   })
 

--- a/iznik-nuxt3/tests/unit/components/NewsThread.spec.js
+++ b/iznik-nuxt3/tests/unit/components/NewsThread.spec.js
@@ -142,6 +142,9 @@ const mockScrollToAndPin = vi.fn(() => vi.fn())
 vi.mock('~/composables/useScrollAnchor', () => ({
   scrollToAndPin: (...args) => mockScrollToAndPin(...args),
   fixedHeaderOffset: () => 74,
+  imagesComplete: () => true,
+  whenImagesComplete: () => Promise.resolve(),
+  whenAllSettled: () => Promise.resolve(),
 }))
 
 // Mock child components
@@ -169,7 +172,7 @@ vi.mock('~/components/NewsReplies', () => ({
     name: 'NewsReplies',
     template: '<div class="news-replies"></div>',
     props: ['id', 'threadhead', 'scrollTo', 'replyTo', 'depth'],
-    emits: ['rendered'],
+    emits: ['rendered', 'subtree-rendered'],
   },
 }))
 
@@ -1035,7 +1038,9 @@ describe('NewsThread', () => {
 
       expect(mockScrollToAndPin).toHaveBeenCalledTimes(1)
       const [getEl, opts] = mockScrollToAndPin.mock.calls[0]
-      expect(opts).toEqual({ block: 'center' })
+      expect(opts.block).toBe('center')
+      // Released by the content-complete signal, not a timer.
+      expect(typeof opts.done?.then).toBe('function')
 
       const row = document.createElement('div')
       row.setAttribute('data-reply-id', '9876')
@@ -1053,6 +1058,53 @@ describe('NewsThread', () => {
 
       const comp = wrapper.findComponent(NewsThread)
       await comp.vm.sendComment()
+      await flushPromises()
+
+      expect(mockScrollToAndPin).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('deep-link pin', () => {
+    it('pins the target centred when the scrolled-to reply reports rendered', async () => {
+      mockNewsfeed.value.replies = [456]
+      const wrapper = await createWrapper({ scrollTo: '456' })
+
+      const replies = wrapper.findComponent('.news-replies')
+      expect(replies.exists()).toBe(true)
+      replies.vm.$emit('rendered', 456)
+      await flushPromises()
+
+      expect(mockScrollToAndPin).toHaveBeenCalledTimes(1)
+      const [getEl, opts] = mockScrollToAndPin.mock.calls[0]
+      expect(opts.block).toBe('center')
+      expect(opts.offset).toBe(74)
+      expect(typeof opts.done?.then).toBe('function')
+
+      const row = document.createElement('div')
+      row.setAttribute('data-reply-id', '456')
+      document.body.appendChild(row)
+      expect(getEl()).toBe(row)
+      row.remove()
+    })
+
+    it('pins only once even if the target re-reports', async () => {
+      mockNewsfeed.value.replies = [456]
+      const wrapper = await createWrapper({ scrollTo: '456' })
+
+      const replies = wrapper.findComponent('.news-replies')
+      replies.vm.$emit('rendered', 456)
+      replies.vm.$emit('rendered', 456)
+      await flushPromises()
+
+      expect(mockScrollToAndPin).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not pin for renders of other replies', async () => {
+      mockNewsfeed.value.replies = [456]
+      const wrapper = await createWrapper({ scrollTo: '456' })
+
+      const replies = wrapper.findComponent('.news-replies')
+      replies.vm.$emit('rendered', 999)
       await flushPromises()
 
       expect(mockScrollToAndPin).not.toHaveBeenCalled()

--- a/iznik-nuxt3/tests/unit/composables/useScrollAnchor.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useScrollAnchor.spec.js
@@ -2,25 +2,38 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import {
   scrollToAndPin,
   fixedHeaderOffset,
-  SETTLE_MS,
-  MAX_PIN_MS,
+  imagesComplete,
+  whenImagesComplete,
+  whenAllSettled,
 } from '~/composables/useScrollAnchor.js'
 
-// The pin loop runs on requestAnimationFrame. Fake it alongside timers so
-// advanceTimersByTime drives frames deterministically.
-function fakeAllTimers() {
-  vi.useFakeTimers({
-    toFake: [
-      'setTimeout',
-      'clearTimeout',
-      'setInterval',
-      'clearInterval',
-      'requestAnimationFrame',
-      'cancelAnimationFrame',
-      'performance',
-    ],
-  })
+// The pin is event-driven: corrections fire from ResizeObserver /
+// MutationObserver callbacks, release from the done promise. jsdom has no
+// ResizeObserver, so install a controllable fake and drive corrections by
+// triggering it - no timers anywhere, faked or otherwise.
+const resizeObservers = []
+
+class FakeResizeObserver {
+  constructor(callback) {
+    this.callback = callback
+    this.disconnected = false
+    resizeObservers.push(this)
+  }
+
+  observe() {}
+
+  disconnect() {
+    this.disconnected = true
+  }
 }
+
+function triggerLayoutEvent() {
+  for (const ro of resizeObservers) {
+    if (!ro.disconnected) ro.callback([])
+  }
+}
+
+const microtasks = () => Promise.resolve().then(() => Promise.resolve())
 
 // A stand-in for a rendered reply row. documentTop is its offset in the
 // document; getBoundingClientRect derives the viewport-relative top from
@@ -44,7 +57,8 @@ describe('scrollToAndPin', () => {
   let cancelPin
 
   beforeEach(() => {
-    fakeAllTimers()
+    resizeObservers.length = 0
+    vi.stubGlobal('ResizeObserver', FakeResizeObserver)
     scrollCalls = []
     Object.defineProperty(window, 'scrollY', {
       value: 0,
@@ -66,166 +80,175 @@ describe('scrollToAndPin', () => {
   afterEach(() => {
     if (cancelPin) cancelPin()
     vi.restoreAllMocks()
-    vi.useRealTimers()
+    vi.unstubAllGlobals()
   })
 
-  it('pins the element to the requested viewport offset instantly', () => {
+  it('pins the element to the requested viewport offset instantly on start', () => {
     const el = makeElement({ documentTop: 1000 })
     cancelPin = scrollToAndPin(() => el, { offset: 74 })
-
-    vi.advanceTimersByTime(20)
 
     expect(scrollCalls.length).toBe(1)
     expect(scrollCalls[0]).toEqual({ top: 1000 - 74, behavior: 'instant' })
   })
 
-  it('waits for the element to appear, then pins (no settle timeout while absent)', () => {
-    let el = null
-    cancelPin = scrollToAndPin(() => el, { offset: 0 })
-
-    // Element absent for longer than the settle window - the pin must not
-    // give up, because async chunks can take a while to mount the target.
-    vi.advanceTimersByTime(SETTLE_MS + 500)
-    expect(scrollCalls.length).toBe(0)
-
-    el = makeElement({ documentTop: 2000 })
-    vi.advanceTimersByTime(50)
-    expect(scrollCalls.length).toBe(1)
-    expect(scrollCalls[0].top).toBe(2000)
-  })
-
-  it('re-pins when late-rendering content moves the element in the document', () => {
+  it('re-pins when a layout event moves the element in the document', () => {
     const el = makeElement({ documentTop: 1000 })
     cancelPin = scrollToAndPin(() => el, { offset: 0 })
-    vi.advanceTimersByTime(20)
     expect(scrollCalls.length).toBe(1)
 
-    // Content above the target grows by 800px (images/async replies).
+    // Content above the target grows by 800px (images/async replies), and
+    // the observers deliver a layout event.
     el.documentTop = 1800
-    vi.advanceTimersByTime(50)
+    triggerLayoutEvent()
 
     expect(scrollCalls.length).toBe(2)
     expect(scrollCalls[1].top).toBe(1800)
   })
 
-  it('does NOT re-pin when only the viewport scrolled (element document position unchanged)', () => {
+  it('does NOT re-pin on a layout event when the element did not move in the document', () => {
     const el = makeElement({ documentTop: 1000 })
     cancelPin = scrollToAndPin(() => el, { offset: 0 })
-    vi.advanceTimersByTime(20)
     expect(scrollCalls.length).toBe(1)
 
-    // Simulate a scroll not caused by us: viewport moves, document doesn't.
+    // A scroll not caused by us: viewport moves, document position doesn't.
     window.scrollY = 400
-    vi.advanceTimersByTime(200)
+    triggerLayoutEvent()
 
     expect(scrollCalls.length).toBe(1)
   })
 
-  it('stops correcting once layout has been quiet for the settle window', () => {
-    const el = makeElement({ documentTop: 1000 })
+  it('waits for the element to appear, then pins on the next layout event', () => {
+    let el = null
     cancelPin = scrollToAndPin(() => el, { offset: 0 })
-    vi.advanceTimersByTime(20)
+    expect(scrollCalls.length).toBe(0)
 
-    vi.advanceTimersByTime(SETTLE_MS + 100)
+    triggerLayoutEvent()
+    expect(scrollCalls.length).toBe(0)
 
-    // A shift after settling is the user's problem no longer - we must not
-    // yank the viewport around once we've declared the scroll done.
+    // The target's async chunk mounts - observers fire.
+    el = makeElement({ documentTop: 2000 })
+    triggerLayoutEvent()
+
+    expect(scrollCalls.length).toBe(1)
+    expect(scrollCalls[0].top).toBe(2000)
+  })
+
+  it('releases when done resolves: one final forced correction, then no more', async () => {
+    let resolveDone
+    const done = new Promise((resolve) => {
+      resolveDone = resolve
+    })
+    const el = makeElement({ documentTop: 1000 })
+    cancelPin = scrollToAndPin(() => el, { offset: 0, done })
+    expect(scrollCalls.length).toBe(1)
+
+    resolveDone()
+    await microtasks()
+
+    // Final correction is forced even though the position was already right.
+    expect(scrollCalls.length).toBe(2)
+    expect(resizeObservers[0].disconnected).toBe(true)
+
+    // Anything after release is ignored - never re-yank a released page.
     el.documentTop = 3000
-    vi.advanceTimersByTime(200)
-
-    expect(scrollCalls.length).toBe(1)
+    triggerLayoutEvent()
+    expect(scrollCalls.length).toBe(2)
   })
 
-  it('keeps pinning through repeated shifts, then settles', () => {
+  it('holds indefinitely while done is unresolved - loading, not time, decides', () => {
     const el = makeElement({ documentTop: 1000 })
-    cancelPin = scrollToAndPin(() => el, { offset: 0 })
-    vi.advanceTimersByTime(20)
+    cancelPin = scrollToAndPin(() => el, {
+      offset: 0,
+      done: new Promise(() => {}),
+    })
 
-    for (let i = 1; i <= 5; i++) {
-      el.documentTop = 1000 + i * 300
-      vi.advanceTimersByTime(SETTLE_MS - 100) // each shift inside the window
+    for (let i = 1; i <= 20; i++) {
+      el.documentTop = 1000 + i * 250
+      triggerLayoutEvent()
     }
 
-    expect(scrollCalls.length).toBe(6)
-    expect(scrollCalls[5].top).toBe(2500)
+    expect(scrollCalls.length).toBe(21)
+    expect(scrollCalls[20].top).toBe(6000)
   })
 
   it('cancels immediately on user input', () => {
     const el = makeElement({ documentTop: 1000 })
     cancelPin = scrollToAndPin(() => el, { offset: 0 })
-    vi.advanceTimersByTime(20)
     expect(scrollCalls.length).toBe(1)
 
     window.dispatchEvent(new Event('wheel'))
 
     el.documentTop = 2000
-    vi.advanceTimersByTime(200)
+    triggerLayoutEvent()
     expect(scrollCalls.length).toBe(1)
   })
 
-  it('gives up at the hard cap even if layout never settles', () => {
+  it('does not apply the final correction if the user already took over', async () => {
+    let resolveDone
+    const done = new Promise((resolve) => {
+      resolveDone = resolve
+    })
     const el = makeElement({ documentTop: 1000 })
-    cancelPin = scrollToAndPin(() => el, { offset: 0 })
+    cancelPin = scrollToAndPin(() => el, { offset: 0, done })
 
-    // Perpetually shifting layout - move the target every frame-ish.
-    for (let t = 0; t < MAX_PIN_MS + 1000; t += 100) {
-      el.documentTop += 50
-      vi.advanceTimersByTime(100)
-    }
-    const callsAtCap = scrollCalls.length
+    window.dispatchEvent(new Event('touchstart'))
+    resolveDone()
+    await microtasks()
 
-    el.documentTop += 500
-    vi.advanceTimersByTime(500)
-    expect(scrollCalls.length).toBe(callsAtCap)
+    expect(scrollCalls.length).toBe(1)
   })
 
   it('centers the element when block is center', () => {
     const el = makeElement({ documentTop: 5000, height: 100 })
     cancelPin = scrollToAndPin(() => el, { block: 'center' })
-    vi.advanceTimersByTime(20)
 
-    // Centered: element top sits at (innerHeight - height) / 2.
     const expectedViewportTop = (667 - 100) / 2
     expect(scrollCalls[0].top).toBe(5000 - expectedViewportTop)
+  })
+
+  it('keeps an over-tall centered element below the fixed header', () => {
+    // Taller than the viewport: naive centering would put its top above
+    // the viewport (negative), hiding the start of the reply.
+    const el = makeElement({ documentTop: 5000, height: 900 })
+    cancelPin = scrollToAndPin(() => el, { block: 'center', offset: 74 })
+
+    expect(scrollCalls[0].top).toBe(5000 - 74)
   })
 
   it('starting a new pin cancels the previous one', () => {
     const elA = makeElement({ documentTop: 1000 })
     const elB = makeElement({ documentTop: 4000 })
     cancelPin = scrollToAndPin(() => elA, { offset: 0 })
-    vi.advanceTimersByTime(20)
-
     cancelPin = scrollToAndPin(() => elB, { offset: 0 })
-    vi.advanceTimersByTime(20)
     expect(scrollCalls.length).toBe(2)
 
     // Only B is live: A's shifts are ignored, B's are corrected.
     elA.documentTop = 1500
-    vi.advanceTimersByTime(100)
+    triggerLayoutEvent()
     expect(scrollCalls.length).toBe(2)
 
     elB.documentTop = 4500
-    vi.advanceTimersByTime(100)
+    triggerLayoutEvent()
     expect(scrollCalls.length).toBe(3)
     expect(scrollCalls[2].top).toBe(4500)
   })
 
-  it('returned cancel stops the pin', () => {
+  it('returned cancel stops the pin and disconnects the observers', () => {
     const el = makeElement({ documentTop: 1000 })
     cancelPin = scrollToAndPin(() => el, { offset: 0 })
-    vi.advanceTimersByTime(20)
+    expect(scrollCalls.length).toBe(1)
 
     cancelPin()
+    expect(resizeObservers[0].disconnected).toBe(true)
 
     el.documentTop = 2000
-    vi.advanceTimersByTime(200)
+    triggerLayoutEvent()
     expect(scrollCalls.length).toBe(1)
   })
 
   it('never scrolls to a negative offset', () => {
     const el = makeElement({ documentTop: 20 })
     cancelPin = scrollToAndPin(() => el, { offset: 74 })
-    vi.advanceTimersByTime(20)
 
     expect(scrollCalls[0].top).toBe(0)
   })
@@ -263,5 +286,171 @@ describe('fixedHeaderOffset', () => {
 
   it('returns just the breathing room when there is no fixed navbar', () => {
     expect(fixedHeaderOffset()).toBe(8)
+  })
+})
+
+// jsdom marks an img as complete only once it has no pending src load; we
+// model loading state explicitly.
+function makeImg({ complete }) {
+  const img = document.createElement('img')
+  Object.defineProperty(img, 'complete', {
+    value: complete,
+    writable: true,
+    configurable: true,
+  })
+  return img
+}
+
+describe('imagesComplete', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('is true with no images', () => {
+    expect(imagesComplete(document.body)).toBe(true)
+  })
+
+  it('is false while an image is still loading', () => {
+    document.body.appendChild(makeImg({ complete: false }))
+    expect(imagesComplete(document.body)).toBe(false)
+  })
+
+  it('is true when all images have finished', () => {
+    document.body.appendChild(makeImg({ complete: true }))
+    document.body.appendChild(makeImg({ complete: true }))
+    expect(imagesComplete(document.body)).toBe(true)
+  })
+})
+
+describe('whenImagesComplete', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('resolves immediately when nothing is loading', async () => {
+    document.body.appendChild(makeImg({ complete: true }))
+    await expect(whenImagesComplete(document.body)).resolves.toBeUndefined()
+  })
+
+  it('waits for a pending image to load', async () => {
+    const img = makeImg({ complete: false })
+    document.body.appendChild(img)
+
+    let resolved = false
+    const p = whenImagesComplete(document.body).then(() => {
+      resolved = true
+    })
+    await microtasks()
+    expect(resolved).toBe(false)
+
+    img.dispatchEvent(new Event('load'))
+    await p
+    expect(resolved).toBe(true)
+  })
+
+  it('counts a failed image as finished', async () => {
+    const img = makeImg({ complete: false })
+    document.body.appendChild(img)
+
+    const p = whenImagesComplete(document.body)
+    img.dispatchEvent(new Event('error'))
+    await expect(p).resolves.toBeUndefined()
+  })
+
+  it('tracks images added while waiting', async () => {
+    const first = makeImg({ complete: false })
+    document.body.appendChild(first)
+
+    let resolved = false
+    const p = whenImagesComplete(document.body).then(() => {
+      resolved = true
+    })
+
+    // A late chunk mounts another still-loading image.
+    const second = makeImg({ complete: false })
+    document.body.appendChild(second)
+    // MutationObserver delivery is asynchronous.
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    first.dispatchEvent(new Event('load'))
+    await microtasks()
+    expect(resolved).toBe(false)
+
+    second.dispatchEvent(new Event('load'))
+    await p
+    expect(resolved).toBe(true)
+  })
+})
+
+describe('whenAllSettled', () => {
+  it('resolves once all conditions hold together', async () => {
+    let aOk = false
+    let releaseA
+    const a = {
+      ok: () => aOk,
+      wait: () =>
+        new Promise((resolve) => {
+          releaseA = () => {
+            aOk = true
+            resolve()
+          }
+        }),
+    }
+    const b = { ok: () => true, wait: () => Promise.resolve() }
+
+    let settled = false
+    const p = whenAllSettled([a, b]).then(() => {
+      settled = true
+    })
+    await microtasks()
+    expect(settled).toBe(false)
+
+    releaseA()
+    await p
+    expect(settled).toBe(true)
+  })
+
+  it('goes another round when a condition regresses before the others settle', async () => {
+    // b regresses while a is still being waited on: the first joint check
+    // fails and whenAllSettled must wait for b's NEXT satisfaction rather
+    // than resolving on stale results.
+    let aOk = false
+    let bOk = true
+    let releaseA
+    let releaseB
+    const a = {
+      ok: () => aOk,
+      wait: () =>
+        new Promise((resolve) => {
+          releaseA = () => {
+            aOk = true
+            resolve()
+          }
+        }),
+    }
+    const b = {
+      ok: () => bOk,
+      wait: () =>
+        new Promise((resolve) => {
+          releaseB = () => {
+            bOk = true
+            resolve()
+          }
+        }),
+    }
+
+    let settled = false
+    const p = whenAllSettled([a, b]).then(() => {
+      settled = true
+    })
+
+    bOk = false // a new API call / image appeared mid-wait
+    releaseA()
+    await microtasks()
+    expect(settled).toBe(false)
+
+    releaseB()
+    await p
+    expect(settled).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary
Follow-up to #1000 from Edward's testing: the settle-window release was time-based ("inherently flaky"), the reply reads better centred, and deep links into collapsed regions never scrolled at all.

- **Fully event-driven pin** (`useScrollAnchor` rewrite): corrections fire from `ResizeObserver` + `MutationObserver` when layout actually changes - no rAF sampling, no quiet-window heuristics, no lifetime cap. Release fires when content is provably complete: every reply component has reported `subtree-rendered` (recursive completion through the component chain, so combined rows and collapse exemptions are counted by the component that renders them), the API request counter is idle (store reactivity), and every image has fired `load`/`error` (with images added mid-wait tracked). If a chunk takes ten seconds, the pin holds ten seconds - loading, not time, decides. User input still cancels instantly.
- **Centred target**: the deep-linked reply is held at `block: center` (min-top = fixed header for over-tall replies), so it sits mid-screen with context above and below. Pin initiation moved from NewsReply to NewsThread, which owns the completion signal.
- **Collapse-aware deep links** (the `/chitchat/613361` failure): the collapse previously keyed off `scrollDownTo`, set only *after* the target rendered - but a target hidden behind "Show older replies" can never mount to report. NewsThread now passes `scrollTo` down from mount, so `filteredReplies` bypasses the collapse and the target always mounts. The `scrollDownTo` indirection is gone.
- Post-send anchors share the completion signal (API idle + images). Removed the unused `showExpander` computed.

## Validation (dev-live, 375x667, live data)
- `/chitchat/613438`: 58 instant event-driven corrections in ~0.7s, zero smooth scrolls, ends exactly centred ((667-168)/2 = 250px).
- `/chitchat/613361` (nested reply behind the expander, previously no scroll at all): mounts, highlights, pinned centred at (667-192)/2, no expander shown.
- Edward tested interactively on dev-live and approved.

## Code Quality Review
- Observers disconnect on release/cancel/unmount/supersession; the singleton guarantees one live pin.
- Own scrolls can't feed back (scrolling changes no element size or DOM), and user scrolls without layout shifts are not corrected.
- Completion conditions are re-checked jointly after each satisfaction round, so a condition regressing mid-wait (fresh API call, late image) just triggers another round.

## Test Plan
- 25 composable specs: event-driven corrections, done-release with final forced correction, hold-indefinitely-while-loading, input cancel incl. post-cancel done, centring incl. over-tall clamp, supersession, image tracking (load/error/added-mid-wait), `whenAllSettled` regression rounds, header offset incl. hidden-navbar.
- `subtree-rendered` emission specs: NewsReply leaf/nested bridging; NewsReplies aggregation over the render plan incl. NewsRefer-only and partial cases.
- NewsThread: deep-link pin wiring (centred, offset, done thenable, once-only, non-matching ids), scrollTo pass-through from mount, post-send anchor.
- Scoped runs green (25 + 632). Full unit suite running at time of opening; CI validates the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)