### PR TITLE
fix(browse): card age shows the origin group arrival, not a ripple bump

### DIFF
--- a/iznik-nuxt3/composables/useMessageDisplay.js
+++ b/iznik-nuxt3/composables/useMessageDisplay.js
@@ -127,32 +127,34 @@ export function useMessageDisplay(messageId) {
     return message.value?.attachments?.length || 0
   })
 
+  // The timestamp the card's age reads from. Group arrival gives accurate
+  // autopost/repost times (like MessageHistory) - but under rippling, groups[]
+  // also contains rippled-IN copies whose arrival is the ripple-bump time, and
+  // groups[0] is whichever row the API returned first. Showing a bump time made
+  // a 7-hour-old post read "1 hour" while "Newest posted" (correctly) sorted it
+  // by original post time, so the feed order looked shuffled. Use the ORIGIN
+  // row (rippled_in = 0; absent on non-rippled feeds where !rippled_in is true).
+  const displayTimestamp = computed(() => {
+    const origin = message.value?.groups?.find((g) => !g.rippled_in)
+    return origin?.arrival || message.value?.arrival || message.value?.date
+  })
+
   const timeAgo = computed(() => {
-    // Use group arrival time (like MessageHistory does) for accurate autopost times
-    const timestamp =
-      message.value?.groups?.[0]?.arrival ||
-      message.value?.arrival ||
-      message.value?.date
+    const timestamp = displayTimestamp.value
     if (!timestamp) return ''
     return timeagoShort(timestamp)
   })
 
   const fullTimeAgo = computed(() => {
     // Full time description for tooltip
-    const timestamp =
-      message.value?.groups?.[0]?.arrival ||
-      message.value?.arrival ||
-      message.value?.date
+    const timestamp = displayTimestamp.value
     if (!timestamp) return ''
     return `Posted ${timeago(timestamp)}`
   })
 
   const timeAgoExpanded = computed(() => {
     // Medium time format for lg+ screens: "2 hours", "3 days"
-    const timestamp =
-      message.value?.groups?.[0]?.arrival ||
-      message.value?.arrival ||
-      message.value?.date
+    const timestamp = displayTimestamp.value
     if (!timestamp) return ''
     return timeagoMedium(timestamp)
   })

--- a/iznik-nuxt3/tests/unit/composables/useMessageDisplay.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useMessageDisplay.spec.js
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { ref, effectScope } from 'vue'
 
+// ~/stores/auth is pre-aliased to tests/unit/mocks/auth-store.js;
+// override via globalThis.__mockAuthStore.
+
+import { useMessageDisplay } from '~/composables/useMessageDisplay'
+
 // ---- mocks (vi.mock is hoisted before imports) ----
 
 const mockTimeagoShort = vi.fn()
@@ -58,11 +63,6 @@ const mockMe = ref(null)
 vi.mock('~/composables/useMe', () => ({
   useMe: () => ({ me: mockMe }),
 }))
-
-// ~/stores/auth is pre-aliased to tests/unit/mocks/auth-store.js;
-// override via globalThis.__mockAuthStore.
-
-import { useMessageDisplay } from '~/composables/useMessageDisplay'
 
 // ---- helpers ----
 
@@ -122,7 +122,10 @@ afterEach(() => {
 describe('useMessageDisplay', () => {
   describe('messageId can be a plain value (non-ref)', () => {
     it('resolves message when messageId is a plain number', () => {
-      mockByIdMessage.mockReturnValue({ id: 42, subject: 'OFFER: Plain ID test' })
+      mockByIdMessage.mockReturnValue({
+        id: 42,
+        subject: 'OFFER: Plain ID test',
+      })
       let c
       const scope = effectScope()
       scope.run(() => {
@@ -199,7 +202,11 @@ describe('useMessageDisplay', () => {
 
     it('uses custom group keyword for offer when provided', () => {
       const c = make(
-        { id: 1, subject: 'GIVE: Custom keyword item', groups: [{ groupid: 10 }] },
+        {
+          id: 1,
+          subject: 'GIVE: Custom keyword item',
+          groups: [{ groupid: 10 }],
+        },
         { group: { settings: { keywords: { offer: 'GIVE' } } } }
       )
       expect(c.strippedSubject.value).toBe('Custom keyword item')
@@ -216,7 +223,7 @@ describe('useMessageDisplay', () => {
     it('falls back to default keywords when group has no settings', () => {
       const c = make(
         { id: 1, subject: 'OFFER: Fallback test', groups: [{ groupid: 10 }] },
-        { group: {} }  // group without settings
+        { group: {} } // group without settings
       )
       expect(c.strippedSubject.value).toBe('Fallback test')
     })
@@ -239,7 +246,10 @@ describe('useMessageDisplay', () => {
     })
 
     it('returns stripped subject unchanged when no parentheses at end', () => {
-      const c = make({ id: 1, subject: 'OFFER: Item name with (parens) in middle' })
+      const c = make({
+        id: 1,
+        subject: 'OFFER: Item name with (parens) in middle',
+      })
       // Parens not at end — no trailing location
       expect(c.subjectItemName.value).toBe('Item name with (parens) in middle')
     })
@@ -284,11 +294,14 @@ describe('useMessageDisplay', () => {
       [[], false, 0],
       [[{ id: 1 }], true, 1],
       [[{ id: 1 }, { id: 2 }, { id: 3 }], true, 3],
-    ])('attachments %j → gotAttachments=%s, count=%d', (attachments, gotAtt, count) => {
-      const c = make({ id: 1, attachments })
-      expect(c.gotAttachments.value).toBe(gotAtt)
-      expect(c.attachmentCount.value).toBe(count)
-    })
+    ])(
+      'attachments %j → gotAttachments=%s, count=%d',
+      (attachments, gotAtt, count) => {
+        const c = make({ id: 1, attachments })
+        expect(c.gotAttachments.value).toBe(gotAtt)
+        expect(c.attachmentCount.value).toBe(count)
+      }
+    )
 
     it('returns false/0 when attachments property is absent', () => {
       const c = make({ id: 1 })
@@ -322,13 +335,43 @@ describe('useMessageDisplay', () => {
       expect(mockTimeagoShort).toHaveBeenCalledWith('2026-05-16T10:00:00Z')
     })
 
+    it('uses the ORIGIN group arrival, not a rippled-in copy that happens to be first', () => {
+      // Rippling adds a messages_groups row per group the post spreads to, with
+      // arrival = the ripple-bump time, and groups[] order is arbitrary. Showing a
+      // bump time made a 7-hour-old post read "1 hour" and the "Newest posted"
+      // order look shuffled - the sort correctly uses original post time.
+      const c = make({
+        id: 1,
+        groups: [
+          { arrival: '2026-05-16T10:00:00Z', rippled_in: 1 },
+          { arrival: '2026-05-14T10:00:00Z', rippled_in: 0 },
+          { arrival: '2026-05-15T10:00:00Z', rippled_in: 1 },
+        ],
+        arrival: '2026-05-13T10:00:00Z',
+      })
+      expect(c.timeAgo.value).toBe('2h')
+      expect(mockTimeagoShort).toHaveBeenCalledWith('2026-05-14T10:00:00Z')
+    })
+
+    it('falls back to message arrival when every group row is rippled-in', () => {
+      // Should not happen (there is always an origin row), but a bump time must
+      // never be shown as the posted age.
+      const c = make({
+        id: 1,
+        groups: [{ arrival: '2026-05-16T10:00:00Z', rippled_in: 1 }],
+        arrival: '2026-05-15T10:00:00Z',
+      })
+      expect(c.timeAgo.value).toBe('2h')
+      expect(mockTimeagoShort).toHaveBeenCalledWith('2026-05-15T10:00:00Z')
+    })
+
     it('falls back to arrival when groups arrival is absent', () => {
       const c = make({
         id: 1,
         groups: [{}],
         arrival: '2026-05-15T10:00:00Z',
       })
-      c.timeAgo.value // trigger
+      expect(c.timeAgo.value).toBe('2h')
       expect(mockTimeagoShort).toHaveBeenCalledWith('2026-05-15T10:00:00Z')
     })
 
@@ -337,7 +380,7 @@ describe('useMessageDisplay', () => {
         id: 1,
         date: '2026-05-14T10:00:00Z',
       })
-      c.timeAgo.value // trigger
+      expect(c.timeAgo.value).toBe('2h')
       expect(mockTimeagoShort).toHaveBeenCalledWith('2026-05-14T10:00:00Z')
     })
 
@@ -360,13 +403,13 @@ describe('useMessageDisplay', () => {
         groups: [{ arrival: '2026-05-16T10:00:00Z' }],
         arrival: '2026-05-15T10:00:00Z',
       })
-      c.timeAgoExpanded.value
+      expect(c.timeAgoExpanded.value).toBe('2 hours')
       expect(mockTimeagoMedium).toHaveBeenCalledWith('2026-05-16T10:00:00Z')
     })
 
     it('falls back to arrival when groups arrival is absent', () => {
       const c = make({ id: 1, groups: [{}], arrival: '2026-05-15T10:00:00Z' })
-      c.timeAgoExpanded.value
+      expect(c.timeAgoExpanded.value).toBe('2 hours')
       expect(mockTimeagoMedium).toHaveBeenCalledWith('2026-05-15T10:00:00Z')
     })
 
@@ -412,13 +455,13 @@ describe('useMessageDisplay', () => {
         groups: [{ arrival: '2026-05-16T10:00:00Z' }],
         arrival: '2026-05-15T10:00:00Z',
       })
-      c.fullTimeAgo.value // trigger
+      expect(c.fullTimeAgo.value).toBe('Posted 2 hours ago')
       expect(mockTimeago).toHaveBeenCalledWith('2026-05-16T10:00:00Z')
     })
 
     it('falls back to arrival when groups arrival is absent', () => {
       const c = make({ id: 1, groups: [{}], arrival: '2026-05-15T10:00:00Z' })
-      c.fullTimeAgo.value
+      expect(c.fullTimeAgo.value).toBe('Posted 2 hours ago')
       expect(mockTimeago).toHaveBeenCalledWith('2026-05-15T10:00:00Z')
     })
   })


### PR DESCRIPTION
## Summary
- "Newest posted" on browse looked shuffled (ages reading 6h, 1h, 8h down the feed). The sort is correct - it orders by original post time (the Discourse 9844 fix) - but the card's clock badge read `message.groups[0].arrival`. Under rippling, `groups[]` also contains rippled-in copies whose `arrival` is the ripple-bump time, and `groups[0]` is whichever row the API returned first - so a 7-hour-old post that rippled into a new group an hour ago displayed "1 hour" while sorting (correctly) between 6h and 8h posts.
- `useMessageDisplay` now derives one shared `displayTimestamp`: the ORIGIN group row's arrival (`rippled_in = 0`, already present in the API's group JSON), falling back to the message arrival - never a bump time. `timeAgo`, `timeAgoExpanded` and `fullTimeAgo` all read it. Non-rippled feeds are unchanged (`rippled_in` absent means the first group row still wins). Same `groups[0]`-under-rippling bug family as the ModTools posting-history ones.
- The spec's bare `c.x.value // trigger` expressions are now real assertions - they failed `no-unused-expressions` once the file entered the changed set.

## Test Plan
- New cases: origin row not first among rippled rows; all rows rippled (falls back to message arrival). Verified red against master's composable (2 fail / 94 pass) and green with the fix (96 pass).
- Full frontend unit suite via status API: **14,231 passed**.
- Verified live on dev-live with the reporting account's feed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)