### PR TITLE
fix(reports): a moderator's report is quorum; held reach never shows in browse

### DIFF
--- a/iznik-server-go/isochrone/message.go
+++ b/iznik-server-go/isochrone/message.go
@@ -153,6 +153,11 @@ func fetchReachCandidates(db *gorm.DB, myid uint64, latlng utils.LatLng, unseenO
 			"LEFT JOIN messages_likes ml ON ml.msgid = ms.msgid AND ml.userid = ? AND ml.type = ? "+
 			"WHERE ms.successful = 0 "+
 			unseenFilter+
+			// held = the reach was frozen because the origin copy was pulled back
+			// to Pending (member reports / Back to Pending). Every batch-side reach
+			// consumer already skips held rows; without this filter the reported
+			// post kept appearing in the nearby browse feed (Discourse 9862).
+			"AND rr.status != 'held' "+
 			"AND ST_Contains(rr.polygon, ST_SRID(POINT(?, ?), ?))",
 		utils.MESSAGE_LIKES_VIEW, utils.CHAT_MESSAGE_INTERESTED,
 		myid, utils.MESSAGE_LIKES_VIEW,

--- a/iznik-server-go/microvolunteering/microvolunteering.go
+++ b/iznik-server-go/microvolunteering/microvolunteering.go
@@ -899,16 +899,6 @@ func SendForReviewAllGroups(db *gorm.DB, msgid uint64, reason string) {
 		utils.COLLECTION_PENDING, reason, msgid, utils.COLLECTION_APPROVED)
 }
 
-// sendForReviewGroup moves a single group's copy back to Pending - used for a
-// moderator's scoped report (they reported the post on that community only).
-func sendForReviewGroup(db *gorm.DB, msgid uint64, groupid uint64, reason string) {
-	if msgid == 0 || groupid == 0 {
-		return
-	}
-	db.Exec("UPDATE messages_groups SET collection = ?, spamreason = ? WHERE msgid = ? AND groupid = ? AND collection = ?",
-		utils.COLLECTION_PENDING, reason, msgid, groupid, utils.COLLECTION_APPROVED)
-}
-
 // FreezeReachIfOriginPending freezes a post's ripple once its ORIGIN copy is no longer
 // live-Approved (pulled back for review). Freezing keeps the rippling_reach row but sets
 // status='held' + next_expansion_at=NULL, so: (a) it stops expanding, (b) ExpandService's
@@ -947,10 +937,13 @@ func reporterIsModOf(db *gorm.DB, reporterID uint64, groupid uint64) bool {
 // RecordReportVerdict treats a report of a post (the User2Mod chat message the website
 // report flow sends, targeted at `groupid`) as a microvolunteering "Reject" verdict, so
 // website reports feed the SAME review quorum as in-app CheckMessage checks:
-//   - a MODERATOR of the reported group (or Support/Admin) pulls THAT community's copy to
-//     Pending on its own - scoped, their choice of which communities to report on;
-//   - once ApprovalQuorum distinct Reject verdicts accumulate, the post is pulled to
-//     Pending on ALL its groups (home + rippled-out).
+//   - a MODERATOR of the reported group (or Support/Admin) counts as quorum on their own:
+//     the post is pulled to Pending on ALL its groups (home + rippled-out) immediately.
+//     A scoped single-group pend proved insufficient - the other copies stayed live in
+//     browse and the next digest (Discourse 9862);
+//   - otherwise, once ApprovalQuorum distinct Reject verdicts accumulate, the post is
+//     pulled to Pending on ALL its groups.
+//
 // Whenever the origin copy ends up Pending the ripple is frozen, so the copies persist for
 // per-group moderation and it never re-ripples/re-notifies on a later re-approval.
 // Best-effort: never blocks the report itself.
@@ -979,19 +972,19 @@ func RecordReportVerdict(db *gorm.DB, reporterID uint64, msgid uint64, groupid u
 
 	const reason = "Members or moderators think there is something wrong with this message."
 
-	// A moderator's report is authoritative for the community they reported on.
+	// A moderator's report is quorum on its own: pull the post to Pending everywhere.
 	if reporterIsModOf(db, reporterID, groupid) {
-		sendForReviewGroup(db, msgid, groupid, reason)
-	}
-
-	// Aggregate quorum (all distinct Reject verdicts, reports or in-app checks) pulls
-	// the post to Pending on every community it is on.
-	var rejectCount int64
-	db.Raw(`SELECT COUNT(*) FROM microactions
+		SendForReviewAllGroups(db, msgid, reason)
+	} else {
+		// Aggregate quorum (all distinct Reject verdicts, reports or in-app checks)
+		// pulls the post to Pending on every community it is on.
+		var rejectCount int64
+		db.Raw(`SELECT COUNT(*) FROM microactions
 			WHERE msgid = ? AND result = 'Reject' AND comments IS NOT NULL
 			AND (msgcategory IS NULL OR msgcategory = 'ShouldntBeHere')`, msgid).Scan(&rejectCount)
-	if rejectCount >= int64(ApprovalQuorum) {
-		SendForReviewAllGroups(db, msgid, reason)
+		if rejectCount >= int64(ApprovalQuorum) {
+			SendForReviewAllGroups(db, msgid, reason)
+		}
 	}
 
 	// If the origin copy is now Pending, freeze the ripple (stops spread + re-reach).

--- a/iznik-server-go/test/isochrone_reach_test.go
+++ b/iznik-server-go/test/isochrone_reach_test.go
@@ -310,3 +310,44 @@ func TestNearbyFeedPostedIsOriginalArrival(t *testing.T) {
 			"posted (original post time) is strictly earlier than the ripple-bumped spatial arrival")
 	}
 }
+
+// A post whose reach has been frozen for moderation (rippling_reach.status = 'held' -
+// set when its origin copy is pulled back to Pending by reports or Back to Pending)
+// must NOT appear on the nearby browse feed. Every batch-side reach consumer already
+// excludes held rows; this pins the read side, which is how a reported post kept
+// showing in browse (https://discourse.ilovefreegle.org/t/reporting-posts/9862/7).
+func TestNearbyReachFeedExcludesHeld(t *testing.T) {
+	db := database.DBConn
+
+	prefix := uniquePrefix("nearbyheld")
+	posterID := CreateTestUser(t, prefix+"_poster", "Poster")
+	group := CreateTestGroup(t, prefix)
+	live := CreateTestMessage(t, posterID, group, "OFFER: live reach (nearbyheld)", 51.5, -0.1)
+	held := CreateTestMessage(t, posterID, group, "OFFER: held reach (nearbyheld)", 51.5, -0.1)
+	db.Exec("UPDATE messages_spatial SET successful = 0 WHERE msgid IN (?, ?)", live, held)
+	defer db.Exec("DELETE FROM rippling_reach WHERE msgid IN (?, ?)", live, held)
+
+	viewerID, token := CreateFullTestUser(t, prefix+"_viewer")
+	db.Exec("UPDATE users SET settings = JSON_SET(COALESCE(settings,'{}'), '$.mylocation', "+
+		"JSON_OBJECT('lat', 51.5, 'lng', -0.1)) WHERE id = ?", viewerID)
+
+	// Both reach polygons cover the viewer - only the status differs.
+	db.Exec("INSERT INTO rippling_reach (msgid, lat, lng, polygon, status) VALUES (?, 51.5, -0.1, "+
+		"ST_GeomFromText('POLYGON((-0.2 51.4, 0.0 51.4, 0.0 51.6, -0.2 51.6, -0.2 51.4))', 3857), 'expanding') "+
+		"ON DUPLICATE KEY UPDATE polygon = VALUES(polygon), status = VALUES(status)", live)
+	db.Exec("INSERT INTO rippling_reach (msgid, lat, lng, polygon, status) VALUES (?, 51.5, -0.1, "+
+		"ST_GeomFromText('POLYGON((-0.2 51.4, 0.0 51.4, 0.0 51.6, -0.2 51.6, -0.2 51.4))', 3857), 'held') "+
+		"ON DUPLICATE KEY UPDATE polygon = VALUES(polygon), status = VALUES(status)", held)
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/isochrone/message?jwt="+token, nil))
+	assert.Equal(t, 200, resp.StatusCode)
+	var msgs []message.MessageSummary
+	json2.Unmarshal(rsp(resp), &msgs)
+
+	got := map[uint64]bool{}
+	for _, m := range msgs {
+		got[m.ID] = true
+	}
+	assert.True(t, got[live], "a post with a live reach appears in the nearby feed")
+	assert.False(t, got[held], "a post whose reach is held for moderation is absent from the nearby feed")
+}

--- a/iznik-server-go/test/microvolunteering_report_test.go
+++ b/iznik-server-go/test/microvolunteering_report_test.go
@@ -69,9 +69,12 @@ func TestReportVerdictMemberQuorumPendsAllGroupsAndFreezes(t *testing.T) {
 	}
 }
 
-// A moderator's report is scoped to the community they reported on; other communities
-// (including the origin) are unaffected and the reach keeps running.
-func TestReportVerdictModScopedToReportedGroup(t *testing.T) {
+// A moderator's report counts as quorum on its own: EVERY community's copy (origin and
+// rippled) goes to Pending and the reach is frozen, so the post leaves browse and can
+// never make the next digest (digests only send Approved copies). Edward's decision on
+// Discourse 9862: a scoped mod report left 11 of 12 copies live, so the reported post
+// kept appearing in browse and the daily digest.
+func TestReportVerdictModReportIsQuorum(t *testing.T) {
 	db := database.DBConn
 	poster := CreateTestUser(t, "rvmodposter", "User")
 	origin := CreateTestGroup(t, "rvmodorigin")
@@ -85,13 +88,34 @@ func TestReportVerdictModScopedToReportedGroup(t *testing.T) {
 	microvolunteering.RecordReportVerdict(db, mod, msgid, rippled, "not ok here")
 
 	if collectionOf(msgid, rippled) != utils.COLLECTION_PENDING {
-		t.Errorf("a mod's report on the rippled group must pend that copy, got %s", collectionOf(msgid, rippled))
+		t.Errorf("a mod's report must pend the reported group's copy, got %s", collectionOf(msgid, rippled))
 	}
+	if collectionOf(msgid, origin) != utils.COLLECTION_PENDING {
+		t.Errorf("a mod's report must pend the origin copy too, got %s", collectionOf(msgid, origin))
+	}
+	if reachStatusOf(msgid) != "held" {
+		t.Errorf("a mod's report must freeze the reach (origin Pending), got %s", reachStatusOf(msgid))
+	}
+}
+
+// A member who is NOT a moderator of the reported group still needs the quorum - one
+// member report alone must not pend anything anywhere.
+func TestReportVerdictMemberBelowQuorumScopedNothing(t *testing.T) {
+	db := database.DBConn
+	poster := CreateTestUser(t, "rvbmposter", "User")
+	origin := CreateTestGroup(t, "rvbmorigin")
+	member := CreateTestUser(t, "rvbmmember", "User")
+	CreateTestMembership(t, member, origin, "Member")
+	msgid := CreateTestMessage(t, poster, origin, "OFFER: rvbelowquorum", 51.5, -0.1)
+	addReachRow(msgid, "expanding")
+
+	microvolunteering.RecordReportVerdict(db, member, msgid, origin, "spam")
+
 	if collectionOf(msgid, origin) != utils.COLLECTION_APPROVED {
-		t.Errorf("the origin must stay Approved when a mod reports only a rippled group, got %s", collectionOf(msgid, origin))
+		t.Errorf("a single member report must not pend the post, got %s", collectionOf(msgid, origin))
 	}
 	if reachStatusOf(msgid) == "held" {
-		t.Errorf("reach must NOT be frozen while the origin is still live")
+		t.Errorf("a single member report must not freeze the reach")
 	}
 }
 

--- a/plans/active/post-reporting-server-design.md
+++ b/plans/active/post-reporting-server-design.md
@@ -1,3 +1,11 @@
+> **STATUS (2026-07-07): NOT IMPLEMENTED - superseded.** The shipped reporting flow is the
+> microactions quorum in `iznik-server-go/microvolunteering` (`RecordReportVerdict`), not the
+> `messages_reports`/`reportcount` design below. Current behaviour (per Edward, Discourse 9862):
+> a report from a moderator of the reported community (or Support/Admin) counts as quorum on
+> its own - the post goes to Pending on ALL its communities and the ripple reach is frozen;
+> reports from members need 2 distinct Reject verdicts to do the same. Kept for the parts not
+> yet built (report reasons enum, mod-review loop prevention, DismissReports, metrics).
+
 # Post Reporting System — Server-Side Design
 
 ## 1. New Database Schema


### PR DESCRIPTION
## Summary
Fixes both halves of https://discourse.ilovefreegle.org/t/reporting-posts/9862/7 - a reported post that kept appearing in the reporter's browse feed and the next day's daily digest.

Live-DB verified root cause: the reporting mod's scoped report pended only the community he reported on - the origin and ten other rippled copies stayed Approved (one recorded Reject verdict; the quorum of 2 was never reached), and the reach was never frozen, so browse and the digest were both "working as designed". Edward's decision: a moderator's report should count as quorum.

1. **`RecordReportVerdict`**: a report from a moderator of the reported community (or Support/Admin) now pulls the post to Pending on **all** its communities - identical to the member-quorum path - and freezes the reach. Digests can no longer include it (they only send Approved copies) and, with (2), it leaves the nearby feed immediately. Member reports still need `ApprovalQuorum` distinct verdicts. The scoped `sendForReviewGroup` helper is removed.
2. **`fetchReachCandidates`** (the nearby browse feed) now excludes `rippling_reach.status = 'held'`. The freeze has set that status since 4 July (`861709e84`) but the read side never filtered on it, so any genuinely held post still appeared in browse for everyone in its reach polygon. Every batch-side reach consumer already skips held rows; this closes the one read-side gap.

Also marks `plans/active/post-reporting-server-design.md` as NOT IMPLEMENTED/superseded (it specs a `messages_reports` system that was never built) and records the new behaviour there.

## Test Plan
- New: `TestReportVerdictModReportIsQuorum` (single mod report → all copies Pending + reach `held`), `TestReportVerdictMemberBelowQuorumScopedNothing`, `TestNearbyReachFeedExcludesHeld` (held reach absent from the feed, live reach present alongside).
- Red verified: with the new tests against the old code, exactly those 2 new tests fail (3,422 pass). Green: full Go suite via status API **3,424 passed**, including the pre-existing member-quorum and own-post-report tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)