### PR TITLE
fix(mail): no group name in chat-notify subjects; DeadlineReached uses the origin group

### DIFF
--- a/iznik-batch/app/Mail/Chat/ChatNotification.php
+++ b/iznik-batch/app/Mail/Chat/ChatNotification.php
@@ -603,14 +603,20 @@ class ChatNotification extends MjmlMailable implements RetryableMailable
         $interestedInfo = $this->getLastInterestedMessageInfo();
 
         if ($interestedInfo) {
-            // Format: "Regarding: [GroupName] ItemSubject"
+            // Format: "Regarding: ItemSubject" - deliberately NO group name. With
+            // rippling a post sits on many groups and any single pick can mislead:
+            // the old "most relevant" pick (recipient's memberships sorted by
+            // messages_groups.arrival DESC) chose the most-recently-RIPPLED group,
+            // so a Bristol post's replies arrived as [Bath Freegle], [Dursley],
+            // [North Cotswolds] - changing as the poster's rippled memberships
+            // changed. The item subject's own location suffix says where it is.
             // Strip any existing "Regarding:" or "Re:" prefixes from the subject.
             $subject = $interestedInfo['subject'];
             $subject = str_replace('Regarding:', '', $subject);
             $subject = str_replace('Re: ', '', $subject);
             $subject = trim($subject);
 
-            return "Regarding: [{$interestedInfo['groupName']}] {$subject}";
+            return "Regarding: {$subject}";
         }
 
         // Fallback if no interested message found.
@@ -621,9 +627,9 @@ class ChatNotification extends MjmlMailable implements RetryableMailable
      * Get the last "interested in" message info for this chat.
      *
      * This queries the chat for the most recent TYPE_INTERESTED message and returns
-     * the associated item's subject and group name.
+     * the associated item's subject.
      *
-     * @return array{subject: string, groupName: string}|null
+     * @return array{subject: string}|null
      */
     protected function getLastInterestedMessageInfo(): ?array
     {
@@ -638,24 +644,13 @@ class ChatNotification extends MjmlMailable implements RetryableMailable
             return NULL;
         }
 
-        // Get the referenced message with its group.
         $refMessage = $interestedMessage->refMessage;
         if (!$refMessage) {
             return NULL;
         }
 
-        // Get the group for this message.
-        $userGroupIds = $this->recipient->memberships->pluck('groupid')->map(fn ($id) => (int) $id)->all();
-        $group = $refMessage->groups
-            ->filter(fn ($g) => in_array((int) $g->id, $userGroupIds, true))
-            ->sortByDesc(fn ($g) => $g->pivot->arrival ?? null)
-            ->first()
-            ?? $refMessage->groups->first();
-        $groupName = $group?->namefull ?? $group?->nameshort ?? 'Freegle';
-
         return [
             'subject' => $refMessage->subject,
-            'groupName' => $groupName,
         ];
     }
 

--- a/iznik-batch/app/Mail/Message/DeadlineReached.php
+++ b/iznik-batch/app/Mail/Message/DeadlineReached.php
@@ -47,7 +47,7 @@ class DeadlineReached extends MjmlMailable
             ? Message::OUTCOME_TAKEN
             : Message::OUTCOME_RECEIVED;
 
-        $group = $this->recipientGroupForMessage($message, $user);
+        $group = $this->originGroupForMessage($message);
 
         $this->initTracking(
             'DeadlineReached',
@@ -60,20 +60,21 @@ class DeadlineReached extends MjmlMailable
     }
 
     /**
-     * Pick the group most relevant to the recipient for a message.
+     * The group to show the poster for their own message: the ORIGIN group,
+     * the one they actually posted to.
      *
-     * Prefers a group the recipient is a member of, sorted by most-recent
-     * arrival. Falls back to the first group if there is no overlap.
+     * Rippling adds a messages_groups row per group the post spreads into
+     * (rippled_in = 1, arrival = the ripple time) and auto-joins the poster
+     * there, so the old "recipient's membership with the most recent arrival"
+     * pick named whichever distant group the post most recently rippled into.
+     * Falls back to the earliest-arrival row for pre-rippling data.
      */
-    protected function recipientGroupForMessage(Message $message, User $user): ?object
+    protected function originGroupForMessage(Message $message): ?object
     {
-        $userGroupIds = $user->memberships->pluck('groupid')->map(fn ($id) => (int) $id)->all();
+        $groups = $message->groups;
 
-        return $message->groups
-            ->filter(fn ($g) => in_array((int) $g->id, $userGroupIds, true))
-            ->sortByDesc(fn ($g) => $g->pivot->arrival ?? null)
-            ->first()
-            ?? $message->groups->first();
+        return $groups->first(fn ($g) => !($g->pivot->rippled_in ?? 0))
+            ?? $groups->sortBy(fn ($g) => $g->pivot->arrival ?? null)->first();
     }
 
     /**
@@ -82,7 +83,7 @@ class DeadlineReached extends MjmlMailable
     public function build(): static
     {
         $userSite = config('freegle.sites.user');
-        $group = $this->recipientGroupForMessage($this->message, $this->user);
+        $group = $this->originGroupForMessage($this->message);
         $groupName = $group?->nameshort ?? 'Freegle';
 
         return $this->to($this->user->email_preferred, $this->user->displayname)

--- a/iznik-batch/app/Models/Message.php
+++ b/iznik-batch/app/Models/Message.php
@@ -261,11 +261,15 @@ class Message extends Model implements Auditable
 
     /**
      * Get the message's groups.
+     *
+     * rippled_in distinguishes the ORIGIN row (0 - the group the member actually
+     * posted to) from copies the rippling engine spread the post into (1, with
+     * arrival = the ripple time, not the post time).
      */
     public function groups(): BelongsToMany
     {
         return $this->belongsToMany(Group::class, 'messages_groups', 'msgid', 'groupid')
-            ->withPivot(['collection', 'arrival', 'approvedby', 'deleted']);
+            ->withPivot(['collection', 'arrival', 'approvedby', 'deleted', 'rippled_in']);
     }
 
     /**

--- a/iznik-batch/tests/Unit/Mail/ChatNotificationTest.php
+++ b/iznik-batch/tests/Unit/Mail/ChatNotificationTest.php
@@ -218,9 +218,15 @@ class ChatNotificationTest extends TestCase
         );
 
         // Subject should be based on the "interested in" message's referenced item.
-        $this->assertStringStartsWith('Regarding:', $mail->replySubject);
-        $this->assertStringContainsString('[' . $group->namefull . ']', $mail->replySubject);
-        $this->assertStringContainsString('OFFER: Double Bed Frame (London)', $mail->replySubject);
+        // NO group name: with rippling a post sits on many groups and any pick can
+        // mislead (support case: a Bristol post's replies arrived as [Bath Freegle],
+        // [Dursley], [North Cotswolds] as the poster's rippled memberships changed).
+        // The item's own location suffix already says where it is.
+        $this->assertEquals(
+            'Regarding: OFFER: Double Bed Frame (London)',
+            $mail->replySubject
+        );
+        $this->assertStringNotContainsString('[', $mail->replySubject);
     }
 
     public function test_chat_notification_user2mod_subject(): void
@@ -412,9 +418,9 @@ class ChatNotificationTest extends TestCase
             ChatRoom::TYPE_USER2USER
         );
 
-        // Subject should be based on the interested message.
+        // Subject should be based on the interested message - no group name.
         $this->assertStringContainsString('Regarding:', $mail->replySubject);
-        $this->assertStringContainsString('[' . $group->namefull . ']', $mail->replySubject);
+        $this->assertStringNotContainsString($group->namefull, $mail->replySubject);
         $this->assertStringContainsString('OFFER: Test Item', $mail->replySubject);
 
         $mail->build();
@@ -638,8 +644,12 @@ class ChatNotificationTest extends TestCase
         // Verify "Regarding:" is used instead of "Re:".
         $this->assertStringStartsWith('Regarding:', $mail->replySubject);
         $this->assertStringNotContainsString('Re:', $mail->replySubject);
-        // Also verify group name is included.
-        $this->assertStringContainsString('[' . $group->namefull . ']', $mail->replySubject);
+        // And no group name - the subject is just "Regarding: <item subject>".
+        $this->assertStringNotContainsString($group->namefull, $mail->replySubject);
+        $this->assertEquals(
+            'Regarding: OFFER: Test Item (Location)',
+            $mail->replySubject
+        );
     }
 
     public function test_chat_notification_chat_url_contains_room_id(): void

--- a/iznik-batch/tests/Unit/Mail/MessageMailTest.php
+++ b/iznik-batch/tests/Unit/Mail/MessageMailTest.php
@@ -73,6 +73,37 @@ class MessageMailTest extends TestCase
         $this->assertEquals(Message::OUTCOME_TAKEN, $mail->outcomeType);
     }
 
+    public function test_deadline_reached_names_the_origin_group_not_a_rippled_copy(): void
+    {
+        // Rippling adds messages_groups rows (rippled_in=1, arrival=ripple time)
+        // and auto-joins the poster to those groups, so the old "recipient's
+        // membership with the most recent arrival" pick told a poster their
+        // deadline was on whichever distant group the post last rippled into.
+        $user = $this->createTestUser();
+        $origin = $this->createTestGroup();
+        $rippled = $this->createTestGroup();
+        $this->createMembership($user, $origin);
+        $this->createMembership($user, $rippled);
+
+        $message = $this->createTestMessage($user, $origin, [
+            'arrival' => now()->subDays(2),
+        ]);
+        // A rippled-in copy with a NEWER arrival - the bait the old pick took.
+        MessageGroup::create([
+            'msgid' => $message->id,
+            'groupid' => $rippled->id,
+            'collection' => MessageGroup::COLLECTION_APPROVED,
+            'arrival' => now(),
+            'rippled_in' => 1,
+        ]);
+
+        $mail = new DeadlineReached($message->fresh(), $user);
+        $mail->build();
+
+        $mjmlData = (new \ReflectionProperty($mail, 'mjmlData'))->getValue($mail);
+        $this->assertEquals($origin->nameshort, $mjmlData['groupName']);
+    }
+
     public function test_deadline_reached_wanted_has_received_outcome(): void
     {
         $user = $this->createTestUser();
@@ -115,10 +146,12 @@ class MessageMailTest extends TestCase
         $this->assertEquals('Deadline reached: OFFER: Test Item (Location)', $envelope->subject);
     }
 
-    public function test_deadline_reached_tracking_uses_recipients_group_for_cross_post(): void
+    public function test_deadline_reached_tracking_uses_origin_group_for_cross_post(): void
     {
-        // Message on groupA and groupB; recipient is a member of groupB only.
-        // Tracking groupid must reference groupB, not the arbitrary first group.
+        // Message posted to groupA, also on groupB; recipient (the poster) is a
+        // member of groupB only. Tracking must reference the ORIGIN group (where
+        // they posted), not whichever copy their memberships happen to match -
+        // under rippling that heuristic picked the most-recently-rippled group.
         $groupA = $this->createTestGroup();
         $groupB = $this->createTestGroup();
 
@@ -131,13 +164,14 @@ class MessageMailTest extends TestCase
             'groupid' => $groupB->id,
             'collection' => MessageGroup::COLLECTION_APPROVED,
             'arrival' => now(),
+            'rippled_in' => 1,
         ]);
         $message = Message::with('groups')->find($message->id);
 
         $mail = new DeadlineReached($message, $user);
 
-        $this->assertEquals($groupB->id, $mail->getTracking()->groupid);
-        $this->assertNotEquals($groupA->id, $mail->getTracking()->groupid);
+        $this->assertEquals($groupA->id, $mail->getTracking()->groupid);
+        $this->assertNotEquals($groupB->id, $mail->getTracking()->groupid);
     }
 
     public function test_deadline_reached_falls_back_to_first_group_when_no_membership_overlap(): void


### PR DESCRIPTION
## Summary
Support case (Warwick, via Dee): reply notifications for his Bristol OFFER arrived as `Regarding: [Bath Freegle] OFFER: ...`, then `[Dursley]`, then `[North Cotswolds]` - a different group per email within one thread, changing as he unjoined groups he'd been rippled into.

Root cause: `49fc7c705` picked the "most relevant group" as the recipient's membership with the newest `messages_groups.arrival` - under rippling that is always the most-recently-rippled-in group, and rippling auto-joins the poster to every rippled group, so the subject tracked his rippled memberships rather than his post.

- **ChatNotification**: per Edward's decision (Warwick's own suggestion), the subject carries **no group name**: `Regarding: OFFER: Item (Location)`. The item's location suffix already says where it is; any single group pick can mislead on a many-group post. The group lookup is removed entirely.
- **DeadlineReached** (same commit, same pick): names a group in its body/tracking to the *poster* about their own post - now uses the **origin** group (`rippled_in = 0`, newly exposed on `Message::groups()` `withPivot`), falling back to earliest arrival for pre-rippling rows.

## Test Plan
- Subjects pinned exactly (`Regarding: OFFER: Test Item (Location)`, no brackets, no group name) across the three subject tests.
- New DeadlineReached case: origin row not first + rippled row newer - body `groupName` and tracking groupid must be the origin. Red against the old code, green with the fix.
- Cross-post tracking test updated to origin semantics.
- Full Laravel suite via status API: **4,766 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)