### PR TITLE
feat(infra): cgroup v2 slice prioritisation for the batch-prod host

### DIFF
--- a/batch.slice
+++ b/batch.slice
@@ -1,0 +1,20 @@
+# Background/batch tier on the batch-prod host (see interactive.slice for
+# install + rationale). batch-prod is the box's dominant CPU consumer; this
+# slice lets it soak up idle capacity while guaranteeing it yields to the
+# interactive tier under contention.
+#
+# CPUWeight=25 keeps ~3% of CPU guaranteed under full contention so scheduled
+# jobs (digests) still make progress. For a true scavenger class that gets
+# CPU only when nothing else wants it, use CPUWeight=idle instead.
+#
+# MemoryHigh throttles-and-reclaims batch before it drives the host into
+# swap; MemoryMax means a runaway job OOMs inside this cgroup instead of
+# taking out the interactive tier. Tune against `free -h` and
+# /proc/pressure/memory after observing real usage (batch-prod RSS was
+# ~2.7G, spatial ~5.8G when these defaults were chosen, host RAM 23G).
+
+[Slice]
+CPUWeight=25
+MemoryHigh=10G
+MemoryMax=14G
+IOWeight=50

--- a/docker-compose.override.batchprod.yml
+++ b/docker-compose.override.batchprod.yml
@@ -1,0 +1,39 @@
+# Batch-prod host ONLY - not used in dev or CI.
+#
+# Opt in on the prod batch host by setting in its .env:
+#   COMPOSE_FILE=docker-compose.yml:docker-compose.override.batchprod.yml
+#
+# Assigns compose services to cgroup v2 systemd slices so user-facing work is
+# guaranteed priority over batch under contention, without hard caps that
+# would waste idle capacity. Requires the systemd cgroup driver (already the
+# case on the prod host: `docker info` shows "Cgroup Driver: systemd") and the
+# slice units installed in /etc/systemd/system/ (see interactive.slice /
+# batch.slice at the repo root and plans/2026-07-08-batch-host-cgroup-slices.md).
+#
+# Tiers:
+#  - interactive.slice (CPUWeight=800): embedding-sidecar (apiv2 semantic
+#    search calls it live from user requests), postfix (mail flow).
+#  - batch.slice (CPUWeight=25): batch-prod (the scheduler and dominant CPU
+#    consumer) plus spatial/spatial-knn (serve the batch digest path on this
+#    host; the public spatial.ilovefreegle.org routing runs on db1/2/3).
+#  - Everything else (loki, redis, mjml, rspamd, spamassassin, ai-support-
+#    helper) stays in Docker's default cgroup under system.slice (weight 100).
+
+services:
+  embedding-sidecar:
+    cgroup_parent: interactive.slice
+    # memory.low on the container scope itself - protection independent of
+    # whether the cgroup2 mount propagates the slice's MemoryLow recursively.
+    mem_reservation: 2g
+
+  postfix:
+    cgroup_parent: interactive.slice
+
+  batch-prod:
+    cgroup_parent: batch.slice
+
+  spatial:
+    cgroup_parent: batch.slice
+
+  spatial-knn:
+    cgroup_parent: batch.slice

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -771,6 +771,11 @@ services:
     container_name: ${COMPOSE_PROJECT_NAME:-freegle}-spatial-knn
     profiles:
       - frontend
+      # Also in `production`: batch-prod hard-depends on this service, so the
+      # batch host (COMPOSE_PROFILES=backend,production,mail) must include it
+      # explicitly. Newer Compose (v5) auto-enables cross-profile dependencies,
+      # but older docker-compose binaries reject the project as invalid.
+      - production
     networks:
       default:
         aliases:
@@ -804,6 +809,8 @@ services:
     container_name: ${COMPOSE_PROJECT_NAME:-freegle}-spatial
     profiles:
       - frontend
+      # Also in `production`: see spatial-knn note above.
+      - production
     networks:
       default:
         aliases:

--- a/interactive.slice
+++ b/interactive.slice
@@ -1,0 +1,21 @@
+# User-facing / latency-sensitive tier on the batch-prod host.
+# Install: cp interactive.slice batch.slice /etc/systemd/system/ && systemctl daemon-reload
+# Wired to containers via cgroup_parent in docker-compose.override.batchprod.yml.
+#
+# Weights are work-conserving: they only bite under contention. With
+# interactive=800, unclassified containers + host daemons (system.slice,
+# weight 100) and batch (25), the interactive tier is guaranteed ~86% of CPU
+# when everything is busy, but batch may still use 100% of an idle machine.
+#
+# MemoryLow protects this tier's RAM *and page cache* from reclaim caused by
+# batch memory pressure. Verify /proc/mounts shows cgroup2 mounted with
+# memory_recursiveprot so the protection distributes to the container scopes;
+# the override file also sets mem_reservation per service as belt-and-braces.
+#
+# IOWeight only has effect if the block device scheduler is bfq
+# (cat /sys/block/sda/queue/scheduler) - see the deployment plan.
+
+[Slice]
+CPUWeight=800
+MemoryLow=4G
+IOWeight=500

--- a/plans/2026-07-03-host-reboot-runbook.md
+++ b/plans/2026-07-03-host-reboot-runbook.md
@@ -15,8 +15,8 @@ Everything auto-restarts on boot (systemd unit `compose up -d`, restart policies
 
 ### freegledocker compose project (auto-started by freegle-docker.service; COMPOSE_PROFILES=backend,production,mail)
 - freegledocker-batch-prod   (the scheduler — prod crons)      restart: unless-stopped
-- freegledocker-spatial       (iznik-routing-go, 8196, ~6G graph — rebuilds on start ~7 min) unless-stopped
-- freegledocker-spatial-knn   (iznik-spatial-go, 8194)          unless-stopped
+- freegledocker-spatial       (iznik-routing-go, 8196, ~6G graph — rebuilds on start ~7 min) **no** (comes back via compose up; a crashed spatial stays down and batch-prod only gates on it at startup)
+- freegledocker-spatial-knn   (iznik-spatial-go, 8194)          **no** (same as spatial)
 - freegledocker-mjml          (email render — digests need it)  restart: **no** (comes back via compose up)
 - freegledocker-redis                                            **no**
 - freegledocker-postfix                                          unless-stopped

--- a/plans/2026-07-08-batch-host-cgroup-slices.md
+++ b/plans/2026-07-08-batch-host-cgroup-slices.md
@@ -1,0 +1,110 @@
+# Batch host cgroup slices — work-conserving priority for user-facing services (2026-07-08)
+
+## Why
+
+The batch-prod host (185.44.254.12, 8 vCPU/23G) was measured at load 13.6 with
+`batch-prod` burning 428% CPU, 12G of 25G swap in active use, and PSI showing
+~25% sustained CPU stall - while `embedding-sidecar` (live apiv2 semantic
+search) and `postfix` share the same box with **no resource controls anywhere
+in the stack**. Separately, the front-end migration plan
+(`plans/2026-06-25-frontend-server-migration.md`, PR #894) partitions services
+across VMs to get priority - which wastes whichever box is idle.
+
+cgroup v2 **weights** solve prioritisation without waste: they are
+work-conserving ratios that only apply under contention. Batch may use 100% of
+an idle machine and is squeezed to its weight share the instant user-facing
+work needs the resources. Hard limits (`cpus:`, `mem_limit`) are the opposite -
+they reserve capacity that sits idle - so we use them only as a safety ceiling
+on batch memory.
+
+Weights are relative **among siblings**, so per-container `cpu_shares` doesn't
+give a tier guarantee (ten batch containers at 100 collectively outweigh one
+nginx at 400). Slices do: the split holds at tier level regardless of how many
+containers each side runs. The same pattern applies later to the edge VM
+(image cache vs tile-render storms), collapsing the old plan's VM-A/VM-B split
+into one VM.
+
+Prerequisites verified live on the host 2026-07-08: cgroup v2, Docker 29.2.1
+with `Cgroup Driver: systemd`, cpu/io/memory controllers delegated,
+runc 1.3.4. The only gap is the disk IO scheduler (`none`) - see step 4.
+
+## What
+
+- `interactive.slice` (CPUWeight=800, MemoryLow=4G, IOWeight=500):
+  embedding-sidecar, postfix.
+- `batch.slice` (CPUWeight=25, MemoryHigh=10G, MemoryMax=14G, IOWeight=50):
+  batch-prod, spatial, spatial-knn (the digest-serving path).
+- Everything else stays under system.slice (weight 100). Under full contention
+  CPU splits roughly 86% / 11% / 3%; idle capacity remains fully usable by
+  anyone.
+- Wiring: `docker-compose.override.batchprod.yml`, opted into via the host's
+  `COMPOSE_FILE`. Dev and CI never load it.
+- Also in this change: `spatial`/`spatial-knn` gain the `production` profile.
+  The batch host runs `COMPOSE_PROFILES=backend,production,mail` and only got
+  spatial because Compose v5 auto-enables hard `depends_on` targets across
+  profiles; older docker-compose binaries reject the project as "invalid".
+  Explicit inclusion fixes validation everywhere and documents reality.
+  (Do NOT "fix" this with `required: false` instead - that would make Compose
+  v5 skip starting spatial on the prod host, recreating the 2026-07-03
+  digest-hang incident.)
+
+## Deployment (human-gated, on the batch-prod host)
+
+Nothing here restarts services until step 3.
+
+1. Install slice units:
+   ```
+   cd /var/www/FreegleDocker && git pull
+   cp interactive.slice batch.slice /etc/systemd/system/
+   systemctl daemon-reload
+   ```
+2. Opt the host into the override - add to `/var/www/FreegleDocker/.env`:
+   ```
+   COMPOSE_FILE=docker-compose.yml:docker-compose.override.batchprod.yml
+   ```
+   Sanity check: `docker compose config | grep -A1 cgroup_parent` shows the
+   five services; `docker compose config --services` still lists the same 11.
+3. Recreate the five affected containers (cgroup_parent applies at create,
+   not live): `docker compose up -d` (recreates only changed services).
+   Note spatial takes ~7 min to become healthy (graph rebuild) and batch-prod
+   gates on it.
+4. IO weights need the bfq scheduler to have any effect:
+   ```
+   echo bfq > /sys/block/sda/queue/scheduler
+   ```
+   Persist with a udev rule if load tests look good:
+   `/etc/udev/rules.d/60-ioschedulers.rules`:
+   `ACTION=="add|change", KERNEL=="sda", ATTR{queue/scheduler}="bfq"`
+   (Skippable: CPU + memory weighting works without it; IO pressure was light
+   when measured.)
+
+## Verification (trust the cgroup files, not docker inspect)
+
+```
+systemctl show interactive.slice -p CPUWeight,MemoryLow,IOWeight
+cat /sys/fs/cgroup/batch.slice/cpu.weight            # 25
+cat /sys/fs/cgroup/interactive.slice/memory.low      # 4294967296
+# per-container scope, e.g.:
+cat /sys/fs/cgroup/batch.slice/docker-$(docker inspect -f '{{.Id}}' freegledocker-batch-prod).scope/cpu.weight
+grep cgroup2 /proc/mounts                             # want memory_recursiveprot
+```
+
+Then watch the thing this exists to fix:
+- `/proc/pressure/cpu` some avg60 should fall from ~25% for interactive work;
+- embedding-sidecar latency during a busy batch window;
+- swap: `free -h` + `grep -E 'pswpin|pswpout' /proc/vmstat` deltas - MemoryHigh
+  on batch.slice should stop batch driving the host into swap. If batch jobs
+  themselves start thrashing against MemoryHigh, raise it or fix the job; the
+  host likely needs a RAM upsize regardless (it was 12G into swap).
+
+Rollback: remove the override from `COMPOSE_FILE`, `docker compose up -d`.
+
+## Non-goals / follow-ups
+
+- wiki-media, wiki-mysql, ors-app, confident_curran are standalone containers
+  outside compose; they are being decommissioned/moved by the front-end
+  migration and are left in the default tier.
+- Why batch-prod burns 4+ cores is a separate investigation (likely the
+  undeduped ripple snap loop - see plans/routing-performance-step-change.md).
+- The same slice pattern should ship with the edge VM profile (PR #894) to
+  protect frontend-nginx/delivery/tusd from tile-server render storms.


### PR DESCRIPTION
## What

Work-conserving cgroup v2 priority tiers for the batch-prod host, so user-facing services are guaranteed resources under contention while batch can still use 100% of an idle box - replacing "nothing" (the stack currently has zero resource controls of any kind).

- **`interactive.slice`** (CPUWeight=800, MemoryLow=4G, IOWeight=500): `embedding-sidecar` (live apiv2 semantic search), `postfix`.
- **`batch.slice`** (CPUWeight=25, MemoryHigh=10G, MemoryMax=14G, IOWeight=50): `batch-prod`, `spatial`, `spatial-knn`.
- Everything else stays default (system.slice, weight 100). Under full contention CPU splits ~86/11/3; idle capacity stays fully usable by anyone.
- Wiring via new `docker-compose.override.batchprod.yml` - the prod host opts in through `COMPOSE_FILE`; **dev and CI never load it** (dev profile-set service list verified byte-identical to master).
- Deployment + verification runbook: `plans/2026-07-08-batch-host-cgroup-slices.md`. **Merging this changes nothing on prod** - deployment is a separate human-gated step (install slice units, add override to COMPOSE_FILE, recreate 5 containers).

## Why now

Measured on the host 2026-07-08: load 13.6 on 8 cores with `batch-prod` at 428% CPU, 12G/25G swap in active churn, PSI ~25% sustained CPU stall. Host prerequisites verified live: cgroup v2, systemd cgroup driver, controllers delegated. This is also the dress rehearsal for the same pattern on the edge VM (PR #894), where it collapses the plan's VM-A/VM-B split (image cache vs tile-render storms) into one VM.

## Also in this PR

- `spatial`/`spatial-knn` gain the **`production` profile**. The batch host (`COMPOSE_PROFILES=backend,production,mail`) only got them because Compose v5 auto-enables hard `depends_on` targets across profiles; older `docker-compose` binaries reject the whole project as "invalid compose project" (breaking local tooling against the prod profile set). Explicit inclusion fixes validation and documents reality. Deliberately **not** `required: false` - that would make Compose v5 skip starting spatial on prod, recreating the 2026-07-03 digest hang.
- Reboot runbook correction: `spatial`/`spatial-knn` are `restart: "no"` (come back via `compose up`, not the docker daemon), not `unless-stopped` as the table claimed.

## Validation

- Strict `docker-compose` v2.35 config matrix: prod profile set now resolves (previously invalid) to exactly the 11 services prod runs today, with and without the override; `cgroup_parent` renders on the intended 5 services; `mem_reservation` renders.
- Dev profile set (`frontend,database,backend,dev,monitoring`): resolved service list identical to master. Yesterday override unaffected (doesn't enable `production`).
- `systemd-analyze verify` clean on both slice units.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014V1ihELPDZSe3CWT461fyK