### PR TITLE
fix(coverage): stop SpinButton onConfirmClosed flipping Playwright coverage

### DIFF
--- a/iznik-nuxt3/components/SpinButton.vue
+++ b/iznik-nuxt3/components/SpinButton.vue
@@ -204,6 +204,13 @@ const confirmed = () => {
 }
 
 const onConfirmClosed = () => {
+  // Whether any Playwright run covers this line depends on a test happening
+  // to dismiss (rather than confirm) a SpinButton confirm dialog, so it flips
+  // in and out of e2e coverage run-to-run and trips Coveralls on unrelated
+  // PRs - same class as the timeout reset in finishSpinner above. Excluded
+  // from V8/Playwright coverage only; vitest (istanbul, which ignores v8
+  // comments) still counts it, and the unit spec covers it deterministically.
+  /* v8 ignore next */
   showConfirm.value = false
 }
 

--- a/iznik-nuxt3/tests/unit/components/SpinButton.spec.js
+++ b/iznik-nuxt3/tests/unit/components/SpinButton.spec.js
@@ -48,7 +48,8 @@ describe('SpinButton', () => {
             props: ['icon'],
           },
           ConfirmModal: {
-            template: '<div class="confirm-modal" v-if="true" />',
+            template:
+              '<div class="confirm-modal"><button class="cancel-btn" @click="$emit(\'hidden\')" /></div>',
             emits: ['confirm', 'hidden'],
           },
         },
@@ -185,6 +186,18 @@ describe('SpinButton', () => {
       await wrapper.find('button').trigger('click')
 
       expect(wrapper.vm.showConfirm).toBe(true)
+    })
+
+    it('resets showConfirm when the confirm modal is dismissed', async () => {
+      const wrapper = createWrapper({ confirm: true })
+      await wrapper.find('button').trigger('click')
+      expect(wrapper.find('.confirm-modal').exists()).toBe(true)
+
+      await wrapper.find('.cancel-btn').trigger('click')
+
+      expect(wrapper.find('.confirm-modal').exists()).toBe(false)
+      expect(wrapper.vm.showConfirm).toBe(false)
+      expect(wrapper.emitted('handle')).toBeFalsy()
     })
   })
 


### PR DESCRIPTION
## What

Kills the recurring spurious "Coveralls - playwright: Coverage decreased" red check on unrelated PRs, by fixing the one remaining nondeterministic line.

Diagnosed with per-line Coveralls data (method from the PR #910 investigation): diffing master build 80471664 against PR #1006's build 80472473 shows exactly one file changed - `SpinButton.vue`, 10/11 → 9/11 - and per-line data pinpoints it to `onConfirmClosed`'s body (line 207). Master's baseline run happened to include a run dismissing a SpinButton confirm dialog; the PR's run didn't. Whether any e2e run takes the dismiss-rather-than-confirm path varies run to run. (PR #910 predicted a residual flipper and guessed LoginModal - it turned out to be a second line in SpinButton itself.)

## Fix (two parts, mirroring #910)

- `/* v8 ignore next */` on the line so monocart/Playwright coverage stops sampling it. vitest uses istanbul, which ignores v8 comments, so unit coverage still counts it.
- A new unit spec covering the dismiss path deterministically (stub emits `hidden`, asserts the modal unmounts, `showConfirm` resets, and no `handle` is emitted). Follows the proven `PostPhoto.spec.js` pattern for stubbing the async-declared ConfirmModal.

A one-time small baseline shift lands on this commit, then the flip-flopping stops.

eslint + prettier clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014V1ihELPDZSe3CWT461fyK
