### PR TITLE
infra(edge): Stage 1 — adopt standalone tiles + wiki into Compose

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -171,6 +171,7 @@ Browser → Traefik → freegle-dev-local → apiv1/apiv2 → percona
 |------|---------|-----------|
 | `docker-compose.yml` | Main compose configuration | Yes |
 | `docker-compose.override.yml` | Local overrides | No (gitignored) |
+| `docker-compose.override.edge.yml` | Prod-docker-host-only: user-facing `edge` services (tiles/wiki now; images tier later) | Yes |
 | `docker-compose.override.yesterday.yml` | Template for Yesterday server | Yes |
 | `.env` | Compose profiles, infrastructure IPs | No (gitignored) |
 | `.env.background` | Production secrets for batch-prod | No (gitignored) |
@@ -184,6 +185,7 @@ Browser → Traefik → freegle-dev-local → apiv1/apiv2 → percona
 | `production` | Production background services | batch-prod |
 | `monitoring` | Monitoring stack | (reserved for future use) |
 | `backup` | On-demand backup jobs | loki-backup |
+| `edge` | User-facing front-end services on the prod docker host (scale-in-place — see `plans/2026-06-25-frontend-server-migration.md`). In NO default profile set, so dev/CI never start these. | tile-server, wiki-media, wiki-mysql (adopted); frontend-nginx, delivery, tusd (images tier, held at `replicas:0` until their stage) |
 
 To enable profiles, set `COMPOSE_PROFILES` in `.env`:
 ```bash

--- a/docker-compose.override.edge.yml
+++ b/docker-compose.override.edge.yml
@@ -3,38 +3,76 @@
 # plans/2026-06-25-frontend-server-migration.md).
 #
 # Opt in ONLY on the existing prod docker/batch host by adding this file to
-# COMPOSE_FILE in its .env, alongside the batch-host slice override:
-#   COMPOSE_FILE=docker-compose.yml:docker-compose.override.batchprod.yml:docker-compose.override.edge.yml
+# COMPOSE_FILE in its .env, alongside the auto-loaded batch-prod override:
+#   COMPOSE_FILE=docker-compose.yml:docker-compose.override.yml:docker-compose.override.edge.yml
 #   COMPOSE_PROFILES=backend,production,mail,edge
-#   TUSD_COMMAND=-upload-dir=/srv/tusd-data -behind-proxy -base-path / -disable-cors
 #
 # It is NEVER part of the default COMPOSE_FILE, so local dev and CI are
-# unaffected. It does three things the base file deliberately omits:
-#   1. Publishes the front-door host ports. NOT :80/:8080 — on this host
-#      native nginx owns :80/:443 (certbot TLS for tiles/geocode/wiki) and the
-#      legacy standalone tile container published :8080. HAProxy backends
-#      simply target the new ports instead.
-#   2. Binds tusd's upload dir to the shared-NFS host mount so uploaded image
-#      originals are zero-copy (the same NFS app1 serves today — plan §2/§7).
-#   3. Remaps the osm volumes to the host's EXISTING unprefixed Docker volumes
-#      (used by the standalone confident_curran container) so the compose
-#      tile-server ADOPTS the 56G PostGIS + 44G tile data instead of creating
-#      empty project-scoped volumes (freegledocker_osm-data) and serving
-#      nothing.
+# unaffected.
+#
+# STAGE 1 (adopt-now — plan §2 step 2): bring the standalone tile + wiki
+# containers under Compose in place (same host, same data, zero copy) and drop
+# ors-app + the stale discourse vhost. The host-specific bits the base file
+# deliberately omits live here:
+#   1. tile-server / wiki-media republish the SAME host ports the standalone
+#      containers used (:8080 / :8088) so the native nginx vhosts that front
+#      tiles/wiki are untouched — a same-port container swap. (Native nginx
+#      keeps :80/:443 with its certbot TLS for tiles/geocode/wiki.)
+#   2. tile-server / wiki-* adopt the host's EXISTING data (the unprefixed osm
+#      volumes used by confident_curran + the /var/wiki binds) instead of
+#      creating empty project-scoped volumes and serving nothing.
+#   3. The not-yet-migrated images tier (frontend-nginx / delivery / tusd —
+#      plan §3) is held at replicas:0 so activating the edge profile does NOT
+#      start it. The ports/NFS bind are retained so step 3 is just a flip to
+#      replicas:1 (plus TUSD_COMMAND + the NFS mount at /srv/tusd-data).
 
 services:
+  # --- Stage 1: adopted services, come UP on this host ----------------------
+  tile-server:
+    # Native nginx `maps` vhost fronts tiles.ilovefreegle.org via 127.0.0.1:8080
+    # (unchanged), so the adopted container republishes :8080 exactly like the
+    # standalone confident_curran did. Swap: free :8080 (stop confident_curran)
+    # then start this.
+    ports:
+      - "8080:80"
+
+  wiki-mysql:
+    # Adopt the already-initialised DB datadir in place (zero copy).
+    volumes:
+      - /var/wiki/db:/var/lib/mysql
+      - /var/wiki/sharemysql:/var/sharemysql
+
+  wiki-media:
+    # Native nginx fronts wiki.ilovefreegle.org via 127.0.0.1:8088 (unchanged).
+    ports:
+      - "8088:80"
+    volumes:
+      - /var/wiki/html:/var/www/html
+      - /var/wiki/sharewiki:/var/www/share
+
+  # --- Not-yet-migrated images tier: kept in the `edge` profile but held DOWN
+  # on this host until its own stage (plan §3). replicas:0 means a bare
+  # `docker compose up -d` or a reboot auto-start never brings the images tier
+  # up prematurely.
   frontend-nginx:
+    deploy:
+      replicas: 0
     ports:
       - "8180:80"     # HAProxy reaches this with send-proxy (PROXY protocol)
       - "8188:8080"   # plain — the :8080 upload-URL form (apps/Freebie Alerts)
 
+  delivery:
+    deploy:
+      replicas: 0
+
   tusd:
+    deploy:
+      replicas: 0
     volumes:
       # /srv/tusd-data on the host is the shared-NFS mount
       # (nfs2.nlc.storage.katapult.io:/katapult/fsv_5ivInYUXp22oVueE), mounted
       # read-only during prep and flipped to rw only at the human-gated upload
-      # cutover (plan §7/§11). NFS reachability from this host verified
-      # 2026-07-08 (TCP 2049 via the default route).
+      # cutover (plan §7/§11). Inert while replicas:0.
       - /srv/tusd-data:/srv/tusd-data
 
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -397,14 +397,68 @@ services:
       - default
     command: run
     environment:
-      # Emit NO CORS here — frontend-nginx adds exactly one ACAO (plan §2
-      # double-CORS fix). Tiles need a real osm-data import before they render
-      # (plan §7); the service definition exists so the front door can be wired.
+      # Emit NO CORS here — the front door adds exactly one ACAO (plan §2
+      # double-CORS fix). In Stage 1 the front door is the host's native nginx
+      # `maps` vhost, which already adds one ACAO and proxies to :8080; keeping
+      # the container silent makes it exactly one header (and fixes today's
+      # confident_curran ALLOW_CORS=enabled double-CORS). frontend-nginx takes
+      # over the same single-ACAO role in a later stage.
       - ALLOW_CORS=disabled
+      # Operational config carried over verbatim from the standalone prod tile
+      # container (confident_curran) so the swap is behaviour-for-behaviour:
+      # keep serving the already-imported osm-data AND keep applying minutely
+      # OSM replication so tiles don't go stale after adoption. (The merged
+      # def, written for a fresh VM import, omitted these — adopting without
+      # them would silently freeze tile updates.)
+      - UPDATES=enabled
+      - REPLICATION_URL=https://planet.openstreetmap.org/replication/minute/
+      - MAX_INTERVAL_SECONDS=60
+      - THREADS=100
+      - OSM2PGSQL_EXTRA_ARGS=-C 4096
+      - AUTOVACUUM=on
+      - TZ=UTC
     shm_size: 256m
     volumes:
       - osm-data:/data/database
       - osm-tiles:/data/tiles
+
+  # --- wiki (wiki.ilovefreegle.org) — adopted in place from the standalone
+  # wiki-media + wiki-mysql containers (scale-in-place, plan §2 step 2). Same
+  # host, same data: the /var/wiki host binds and the :8088 publish live in the
+  # host-only docker-compose.override.edge.yml. MediaWiki reaches its DB by the
+  # hostname `wiki-mysql` ($wgDBserver in the bind-mounted LocalSettings.php),
+  # which the compose service name provides on the private `wikinet` network —
+  # mirroring the standalone containers. Native nginx keeps fronting the vhost
+  # via 127.0.0.1:8088, so this is a same-port container swap.
+  wiki-mysql:
+    image: wiki-mysql:v02   # local-only custom image (not in any registry); already on the host
+    container_name: ${COMPOSE_PROJECT_NAME:-freegle}-wiki-mysql
+    profiles:
+      - edge
+    networks:
+      - wikinet
+    command: mysqld
+    # No MYSQL_* env on purpose: the /var/wiki/db datadir (bound in the edge
+    # override) is already initialised, so the entrypoint skips first-init and
+    # ignores those vars. This keeps the DB root/user passwords OUT of the repo;
+    # MediaWiki authenticates with the creds already in LocalSettings.php.
+    healthcheck:
+      test: ["CMD-SHELL", "mysqladmin ping -h 127.0.0.1 --silent || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  wiki-media:
+    image: mediawiki:1.39
+    container_name: ${COMPOSE_PROJECT_NAME:-freegle}-wiki-media
+    profiles:
+      - edge
+    networks:
+      - wikinet
+    depends_on:
+      wiki-mysql:
+        condition: service_healthy
 
   # Old status container - replaced by status-nuxt (2026-01-18)
   # Keeping commented out for reference during transition
@@ -2032,6 +2086,11 @@ volumes:
 
 networks:
   default:
+    driver: bridge
+  # Private network for the adopted wiki pair (edge profile), isolating
+  # wiki-media <-> wiki-mysql exactly as the standalone `wikinet` did. Native
+  # nginx reaches wiki-media via its published host port, not this network.
+  wikinet:
     driver: bridge
 
 secrets:

--- a/plans/2026-07-03-host-reboot-runbook.md
+++ b/plans/2026-07-03-host-reboot-runbook.md
@@ -4,16 +4,29 @@ This host = FreegleDocker / batch-prod. It does NOT run the prod DB or apiv2 (th
 db1/2/3 + Netlify), so the Freegle site stays up during the reboot. What pauses: batch crons
 (digests, mail, ripple), the LOCAL spatial/routing/geocoder, and MJML email rendering.
 
+> **UPDATE 2026-07-08 — edge Stage 1 (adopt tiles + wiki into Compose).** The
+> standalone `confident_curran` (tile server), `wiki-media` and `wiki-mysql`
+> containers are now Compose services under the `edge` profile
+> (`freegledocker-tile-server`, `-wiki-media`, `-wiki-mysql`), so they are
+> started/stopped by `freegle-docker.service` like the rest of the stack — no
+> longer separate standalone containers. `ors-app` and the stale
+> `discourse.ilovefreegle.org` nginx vhost have been dropped (ORS is superseded
+> by the native spatial server on db1/2/3; Discourse is hosted externally). The
+> host `.env` now carries `COMPOSE_PROFILES=backend,production,mail,edge` and
+> `COMPOSE_FILE=docker-compose.yml:docker-compose.override.yml:docker-compose.override.edge.yml`.
+> The images tier (`frontend-nginx`/`delivery`/`tusd`) is defined under `edge`
+> but held at `replicas:0`, so it does NOT start on boot yet (its migration is a
+> later stage). The inventory below reflects this post-Stage-1 state.
+
 ## Reboot is graceful — no manual stop needed
 `sudo reboot` cleanly stops everything:
-- **freegledocker stack** → `freegle-docker.service` (enabled) `ExecStop=docker compose stop`, TimeoutStopSec=120.
-- **standalone containers** (ors-app, wiki-media, wiki-mysql, confident_curran) → dockerd shutdown SIGTERM (~15s).
+- **freegledocker stack** → `freegle-docker.service` (enabled) `ExecStop=docker compose stop`, TimeoutStopSec=120. As of edge Stage 1 this includes the adopted tile + wiki services (see the update note above); there are no non-`freegledocker` standalone app containers left.
 - **photon** (native java/ES, monit-managed) → systemd final-kill SIGTERM (90s) → ES clean shutdown.
 Everything auto-restarts on boot (systemd unit `compose up -d`, restart policies, monit).
 
 ## Everything that SHOULD be running after reboot
 
-### freegledocker compose project (auto-started by freegle-docker.service; COMPOSE_PROFILES=backend,production,mail)
+### freegledocker compose project (auto-started by freegle-docker.service; COMPOSE_PROFILES=backend,production,mail,edge)
 - freegledocker-batch-prod   (the scheduler — prod crons)      restart: unless-stopped
 - freegledocker-spatial       (iznik-routing-go, 8196, ~6G graph — rebuilds on start ~7 min) unless-stopped
 - freegledocker-spatial-knn   (iznik-spatial-go, 8194)          unless-stopped
@@ -26,24 +39,31 @@ Everything auto-restarts on boot (systemd unit `compose up -d`, restart policies
 - freegledocker-embedding-sidecar (semantic search)             unless-stopped
 - freegledocker-ai-support-helper                                **no**
 - freegledocker-status        (monitoring UI)                    **no**
+- freegledocker-tile-server   (overv tiles; adopted, `edge`)     restart: **no** (comes back via compose up); publishes :8080
+- freegledocker-wiki-mysql    (wiki DB; adopted, `edge`)         **no**
+- freegledocker-wiki-media    (wiki; adopted, `edge`)            **no**; publishes :8088, depends_on wiki-mysql healthy
 (the **no** ones only come back because freegle-docker.service runs `docker compose up -d` — a
-bare `docker start` after a crash would NOT restart them.)
-
-### Standalone containers (own restart policies)
-- ors-app          (OpenRouteService routing)   unless-stopped
-- wiki-media       (wiki)                        always
-- wiki-mysql       (wiki DB)                     always
-- confident_curran (overv/openstreetmap-tile-server) always
+bare `docker start` after a crash would NOT restart them. The adopted edge services previously had
+`restart: always` as standalone containers; under Compose they rely on the systemd unit like the
+rest of the stack. Hardening their restart policy is tracked with the images-tier migration.)
+- `edge` images tier (`freegledocker-frontend-nginx`/`-delivery`/`-tusd`) is defined but held at
+  `replicas:0` — it does NOT start yet (native nginx still owns :80/:443/:8080).
 
 ### Native, under monit
 - photon (geocoder, java, port 2322, /etc/photon, 6.3G ES index)
-- nginx
-- monit itself supervises: photon, spatial-knn, spatial-routing (Program checks), openrouteservice
-  (Remote Host), plus File/Filesystem checks (spatial-pbf, nginx bins, diskspace).
+- nginx (fronts tiles.ilovefreegle.org → :8080 and wiki.ilovefreegle.org → :8088; the stale
+  discourse vhost has been removed)
+- monit itself supervises: photon, spatial-knn, spatial-routing (Program checks), plus
+  File/Filesystem checks (spatial-pbf, nginx bins, diskspace). (The `openrouteservice` Remote Host
+  check was removed with the ors-app drop — remove it from the monit config as part of the swap.)
 
 ## Post-reboot verification checklist
-1. `systemctl status freegle-docker` → active (exited), and `docker ps` shows all ~16 containers Up.
-2. `sudo monit summary` → all OK (esp. photon, spatial-knn, spatial-routing, docker).
+1. `systemctl status freegle-docker` → active (exited), and `docker ps` shows the full stack Up,
+   now including `freegledocker-tile-server`, `-wiki-media`, `-wiki-mysql` (and NOT `ors-app`).
+2. `sudo monit summary` → all OK (esp. photon, spatial-knn, spatial-routing, docker). No
+   `openrouteservice` entry (removed with the ors-app drop).
+2a. **tiles**: `curl -s -o /dev/null -w '%{http_code}' -H 'Host: tiles.ilovefreegle.org' http://127.0.0.1:8080/tile/0/0/0.png` → 200, and `curl -sI -H 'Host: tiles.ilovefreegle.org' https://tiles.ilovefreegle.org/tile/0/0/0.png -k | grep -c -i access-control-allow-origin` → exactly 1.
+2b. **wiki**: `curl -s -o /dev/null -w '%{http_code}' -H 'Host: wiki.ilovefreegle.org' http://127.0.0.1:8088/` → 200/302 (MediaWiki reached its DB `wiki-mysql`).
 3. **photon** (its risk is startup, not shutdown): `curl -s -o /dev/null -w '%{http_code}' 'http://localhost:2322/api?q=london'` → 200. It rebuilds/loads the 6.3G ES index (~1–2 min). If it crash-loops (`Error occurred during initialization of VM`), that was the pre-upgrade heap-under-memory issue — the extra RAM should fix it; if not, `cd /var/www/photon && java -Xmx<N>g -jar photon-0.5.0.jar -listen-ip 127.0.0.1 -cors-any`.
 4. **spatial** container rebuilds its 7.3G routing graph on start (~7 min) before healthy — normal.
 5. **Daily digest**: the manual catch-up shards I was running die on reboot. The scheduled 4-shard

--- a/plans/2026-07-08-edge-stage1-runbook.md
+++ b/plans/2026-07-08-edge-stage1-runbook.md
@@ -1,0 +1,101 @@
+# Edge Stage 1 — adopt tiles + wiki into Compose, drop ors-app + discourse vhost
+
+Runbook for the host swap that the repo changes on branch
+`infra/edge-stage1-adopt-tile-wiki` enable. This is plan §2 step 2 of
+`plans/2026-06-25-frontend-server-migration.md`.
+
+**Nothing here changes prod until a human runs it.** Every step is individually
+reversible; rollback = restart the old container. Do it one service at a time.
+
+## What changes
+- `confident_curran` (standalone overv tile server, `:8080`) → Compose service
+  `freegledocker-tile-server` on the SAME `osm-data`/`osm-tiles` volumes,
+  republishing `:8080`. Native nginx `maps` vhost (tiles.ilovefreegle.org →
+  127.0.0.1:8080) is untouched.
+- `wiki-media` + `wiki-mysql` (standalone) → Compose services
+  `freegledocker-wiki-media`/`-wiki-mysql` on the SAME `/var/wiki` binds,
+  republishing `:8088`. Native nginx wiki vhost untouched.
+- `ors-app` → dropped (superseded by native spatial on db1/2/3).
+- stale `discourse.ilovefreegle.org` nginx vhost → removed (DNS points at the
+  external SaaS `178.156.182.236`, not this host).
+
+Zero data movement: the tile volumes and `/var/wiki` binds are reused in place.
+
+## Preconditions (verify, read-only)
+```bash
+cd /var/www/FreegleDocker
+git log --oneline -1                       # branch infra/edge-stage1-adopt-tile-wiki (or merged to master) is checked out
+docker volume ls | grep -E 'osm-data|osm-tiles'   # both present
+ls -d /var/wiki/{db,html,sharewiki,sharemysql}    # all present
+docker image inspect wiki-mysql:v02 >/dev/null && echo wiki-mysql:v02 present
+docker inspect confident_curran wiki-media wiki-mysql ors-app --format '{{.Name}} {{.State.Status}}'  # running
+```
+
+## Step A — host .env (enable the edge profile + override)
+The edit that activates everything. Additive: adds the `edge` profile and the
+edge override to the existing batch-prod config.
+```bash
+# BEFORE (current):
+#   COMPOSE_PROFILES=backend,production,mail
+#   (no COMPOSE_FILE line → auto-loads docker-compose.yml + docker-compose.override.yml)
+# AFTER:
+#   COMPOSE_PROFILES=backend,production,mail,edge
+#   COMPOSE_FILE=docker-compose.yml:docker-compose.override.yml:docker-compose.override.edge.yml
+```
+Sanity-check the render BEFORE touching any container (no-op, read-only):
+```bash
+docker compose config --services | sort            # tile-server, wiki-media, wiki-mysql now present
+docker compose config | grep -A3 'frontend-nginx:' | grep replicas   # images tier = replicas:0
+```
+Rollback: revert the two `.env` lines.
+
+## Step B — swap tiles (downtime = container start, ~tens of seconds)
+Pre-create the new container first so only the stop→start gap is downtime; it
+does NOT bind `:8080` until started, so it can be created while the old one runs.
+```bash
+docker compose create tile-server                  # create, not start (no port bind yet)
+docker update --restart=no confident_curran        # stop it fighting for :8080 on daemon restart; keep it for rollback
+docker stop confident_curran                        # frees :8080
+docker compose up -d tile-server                    # binds :8080, adopts osm-data/osm-tiles
+# verify:
+curl -s -o /dev/null -w '%{http_code}\n' -H 'Host: tiles.ilovefreegle.org' http://127.0.0.1:8080/tile/0/0/0.png   # 200
+curl -sI -H 'Host: tiles.ilovefreegle.org' http://127.0.0.1:8080/tile/0/0/0.png | grep -ci access-control-allow  # (0 from container; native nginx adds the 1)
+docker logs --tail=30 freegledocker-tile-server | grep -i 'replication\|renderd'   # replication resumed
+```
+Rollback: `docker compose stop tile-server && docker update --restart=always confident_curran && docker start confident_curran`.
+
+## Step C — swap wiki (downtime = container start)
+```bash
+docker compose create wiki-mysql wiki-media
+docker update --restart=no wiki-media wiki-mysql
+docker stop wiki-media wiki-mysql                   # frees :8088 and the /var/wiki/db lock
+docker compose up -d wiki-media                     # brings up wiki-mysql (dep) then wiki-media
+# verify:
+curl -s -o /dev/null -w '%{http_code}\n' -H 'Host: wiki.ilovefreegle.org' http://127.0.0.1:8088/   # 200/302
+docker exec freegledocker-wiki-media sh -c 'php maintenance/version.php 2>/dev/null || true'        # DB reachable via wiki-mysql
+```
+Rollback: `docker compose stop wiki-media wiki-mysql && docker update --restart=always wiki-media wiki-mysql && docker start wiki-mysql wiki-media`.
+
+## Step D — drop ors-app
+```bash
+docker compose -f /var/www/openrouteservice/docker-compose.yml down   # stops+removes ors-app
+```
+Then remove the monit `openrouteservice` Remote Host check (edit the monit
+config, `sudo monit reload`).
+Rollback: `docker compose -f /var/www/openrouteservice/docker-compose.yml up -d` and restore the monit check.
+
+## Step E — remove the stale discourse vhost
+```bash
+sudo rm /etc/nginx/sites-enabled/discourse         # keep sites-available/discourse for rollback
+sudo nginx -t && sudo nginx -s reload
+```
+Rollback: `sudo ln -s ../sites-available/discourse /etc/nginx/sites-enabled/discourse && sudo nginx -t && sudo nginx -s reload`.
+
+## Post-swap
+- `docker ps` shows `freegledocker-tile-server/-wiki-media/-wiki-mysql` Up, no `ors-app`.
+- Old `confident_curran`/`wiki-*` containers remain present but stopped with
+  `restart=no` (warm rollback). Remove them only after a clean soak (§9 of the
+  plan): `docker rm confident_curran wiki-media wiki-mysql`.
+- Full rollback of the whole stage: revert Step A `.env`, restart the old
+  containers (Steps B/C), `up -d` ors-app (Step D), re-link the discourse vhost
+  (Step E).


### PR DESCRIPTION
Plan §2 step 2 of `plans/2026-06-25-frontend-server-migration.md` (scale-in-place). Adopts the host's standalone **tile** + **wiki** containers into Compose under the `edge` profile *in place* — same host, same data, zero copy — and drops `ors-app` + the stale `discourse` vhost.

## No prod change on merge
This PR only lands the definitions. The host swap is separate and **human-gated**: switch the host `.env` to the edge profile/override and run `plans/2026-07-08-edge-stage1-runbook.md` (each step reversible; rollback = restart the old container). Merging is humans-only.

## What changed
**`docker-compose.yml`**
- `tile-server`: carry over `confident_curran`'s operational env — `UPDATES=enabled`, minutely `REPLICATION_URL`, `THREADS=100`, `OSM2PGSQL_EXTRA_ARGS`, `AUTOVACUUM`, `TZ`. The merged def (written for a *fresh VM import*) omitted these; adopting the live data without them would **silently freeze OSM tile updates**.
- add `wiki-mysql` + `wiki-media` (edge profile) on a private `wikinet`, so MediaWiki resolves its DB host `wiki-mysql` exactly as the standalone pair did. **No `MYSQL_*` env** (datadir already initialised) → no DB passwords in the repo.

**`docker-compose.override.edge.yml`** (prod-host-only)
- `tile-server` republishes `:8080`, `wiki-media` `:8088` + the `/var/wiki` binds → the native nginx vhosts fronting tiles/wiki are **untouched** (same-port swap).
- hold the not-yet-migrated **images tier** (`frontend-nginx`/`delivery`/`tusd`) at `replicas:0` so activating `edge` does **not** start it — native nginx still owns `:80`/`:443`/`:8080`; images cutover is a later stage.

## Zero-regression notes
- **CORS**: native nginx `maps` vhost already adds one ACAO, so `tile-server` keeps `ALLOW_CORS=disabled` — which also *fixes* today's `confident_curran` double-CORS.
- **ors-app**: confirmed no references in app code (Go/PHP/JS/Vue); superseded by native spatial on db1/2/3.
- **discourse**: `discourse.ilovefreegle.org` resolves to the external SaaS `178.156.182.236`, not this host → vhost is dead.

## Validation
- `docker compose config` renders clean for the **edge** activation (tile+wiki up on the right ports/volumes; images tier `replicas:0`) and for **dev/CI** (edge services absent, `delivery`/`tusd` normal, no `replicas:0`).
- `edge` is in no default profile set and the override is never in the default `COMPOSE_FILE`, so local dev and CI are unaffected.

## Docs synced
- `ARCHITECTURE.md` — edge profile row + edge override in the config-files table.
- `plans/2026-07-03-host-reboot-runbook.md` — container inventory updated (tiles/wiki now Compose services, `ors-app`/discourse dropped, monit `openrouteservice` check removed).
- `plans/2026-07-08-edge-stage1-runbook.md` — new, the gated host execution + rollback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ka6SXbZyznGYXyCyC9C86h