### PR TITLE
fix(reply): overlay silently fails to open if the message fetch rejects

### DIFF
--- a/iznik-nuxt3/components/ChatReplyPane.vue
+++ b/iznik-nuxt3/components/ChatReplyPane.vue
@@ -346,8 +346,17 @@ const newUserModal = ref(null)
 const replyToPostChatButton = ref(null)
 const emailValidatorRef = ref(null)
 
-// Fetch the message data
-await messageStore.fetch(props.messageId)
+// Fetch the message data. Guarded: this is a top-level await in async setup
+// under <Suspense>, so an unhandled rejection (e.g. a transient connectivity
+// blip) would mean the overlay never mounts and the Reply click is a silent
+// no-op. The message is almost always already in the store from the page
+// that opened this pane, so on failure render with cached data instead of
+// nothing; the composer gates itself if data is genuinely missing.
+try {
+  await messageStore.fetch(props.messageId)
+} catch (e) {
+  action('chatreplypane_fetch_failed', { message_id: props.messageId })
+}
 
 const message = computed(() => {
   return messageStore?.byId(props.messageId)

--- a/iznik-nuxt3/tests/unit/components/ChatReplyPane.spec.js
+++ b/iznik-nuxt3/tests/unit/components/ChatReplyPane.spec.js
@@ -256,6 +256,20 @@ describe('ChatReplyPane', () => {
     return wrapper
   }
 
+  describe('resilience', () => {
+    it('still renders the overlay when the message fetch rejects', async () => {
+      // Regression: the fetch is a top-level await under <Suspense>; an
+      // unhandled rejection meant the overlay never mounted and the Reply
+      // click was a silent no-op (seen in CI when the API blipped offline).
+      // The pane must render with whatever is cached in the store instead.
+      mockMessageStore.fetch.mockRejectedValueOnce(new Error('Failed to fetch'))
+      const wrapper = await createWrapper()
+
+      expect(wrapper.find('.reply-overlay').exists()).toBe(true)
+      expect(wrapper.find('.reply-card').exists()).toBe(true)
+    })
+  })
+
   describe('post photo zoom', () => {
     it('opens the photo carousel modal when a multi-photo post is tapped', async () => {
       // Multiple photos → the modal is the swipeable carousel (it shows all


### PR DESCRIPTION
## What

`ChatReplyPane` does a top-level `await messageStore.fetch()` in async setup under `<Suspense>`. If that fetch rejects - e.g. a transient connectivity blip - the Suspense never resolves, `.reply-overlay` never enters the DOM, and the user's Reply click is a **silent no-op**: no overlay, no error, no retry.

## How it was found

Root-caused from PR #1007's CI run: the standalone-page CTA reachability check timed out waiting for `.reply-overlay` ("element(s) not found", i.e. never mounted - not hidden) immediately after the app's own console logged `Gone offline TypeError: Failed to fetch`. 150/151 passed; the identical product code passed the same suite two hours earlier on PR #1006's run. The trigger is environmental (an API blip mid-run), but the defect - an unguarded top-level await under Suspense - is real, and would bite a real user replying during a connection blip.

## Fix

Guard the await: on failure, log a client action (`chatreplypane_fetch_failed`) and render with cached store data. The page that opened the pane has almost always just fetched the message, and the composer gates itself if data is genuinely missing. Includes a regression unit test: fetch rejects → overlay still mounts.

eslint + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014V1ihELPDZSe3CWT461fyK
