### PR TITLE
test(laravel): make wall-clock and 24h-boundary coverage deterministic

### DIFF
--- a/iznik-batch/tests/Feature/Chat/ChaseupExpectedCommandTest.php
+++ b/iznik-batch/tests/Feature/Chat/ChaseupExpectedCommandTest.php
@@ -186,8 +186,15 @@ class ChaseupExpectedCommandTest extends TestCase
         // still chase the user only once (V1 GROUP BY expectee, chatid).
         [$expecter, $expectee, $room] = $this->makeExpectedScenario();
 
+        // NOT subDays(2): the expectee's lastaccess is now()-1d, so a message
+        // at now()-2d sits on the exact TIMESTAMPDIFF >= 1440-minute grace
+        // boundary - whether it qualified depended on sub-second timing
+        // between the two now() calls, so the dedupe path only sometimes ran
+        // (flipping its coverage on unrelated PRs) and this test only
+        // sometimes tested what its name claims. 2h of headroom makes the
+        // second row qualify every run.
         $message2 = $this->createTestChatMessage($room, $expecter, [
-            'date' => now()->subDays(2),
+            'date' => now()->subDays(2)->subHours(2),
             'replyexpected' => 1,
             'replyreceived' => 0,
         ]);

--- a/iznik-batch/tests/Unit/Commands/Mail/SendModNotifsCommandTest.php
+++ b/iznik-batch/tests/Unit/Commands/Mail/SendModNotifsCommandTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit\Commands\Mail;
 
 use App\Services\EmailSpoolerService;
 use App\Services\ModNotifService;
+use Carbon\Carbon;
 use Illuminate\Support\Facades\Mail;
 use Tests\TestCase;
 
@@ -20,10 +21,33 @@ class SendModNotifsCommandTest extends TestCase
             ->assertExitCode(0);
     }
 
-    public function test_without_force_returns_success(): void
+    public function test_without_force_outside_window_skips(): void
     {
-        // Without --force the command respects the hour window.
-        // We cannot control the clock in tests, so just verify exit code = 0.
+        // Freeze the clock outside the 8:00-21:00 London window so the guard
+        // path runs deterministically. This test previously used the real
+        // clock ("we cannot control the clock" - we can: travelTo), so which
+        // branch executed depended on what hour CI ran, flipping these lines
+        // in and out of coverage and tripping Coveralls on unrelated PRs.
+        $this->travelTo(Carbon::parse('2026-01-15 22:30:00', 'Europe/London'));
+
+        $service = $this->createMock(ModNotifService::class);
+        $service->method('getNotificationsToSend')->willReturn([]);
+        $this->app->instance(ModNotifService::class, $service);
+
+        Mail::fake();
+
+        $this->artisan('mail:mod-notifs')
+            ->expectsOutputToContain('Outside notification window')
+            ->assertExitCode(0);
+
+        Mail::assertNothingSent();
+        $this->travelBack();
+    }
+
+    public function test_without_force_inside_window_runs(): void
+    {
+        $this->travelTo(Carbon::parse('2026-01-15 10:30:00', 'Europe/London'));
+
         $service = $this->createMock(ModNotifService::class);
         $service->method('getNotificationsToSend')->willReturn([]);
         $this->app->instance(ModNotifService::class, $service);
@@ -32,6 +56,8 @@ class SendModNotifsCommandTest extends TestCase
 
         $this->artisan('mail:mod-notifs')
             ->assertExitCode(0);
+
+        $this->travelBack();
     }
 
     public function test_force_flag_skips_hour_window(): void

--- a/iznik-batch/tests/Unit/Services/AutoRepostServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/AutoRepostServiceTest.php
@@ -614,6 +614,16 @@ class AutoRepostServiceTest extends TestCase
         foreach ($rows as $r) {
             $this->assertNotNull($r->lastautopostwarning, 'every group of the item must be stamped');
         }
+
+        // And prove that claim with a second pass: every row now carries the
+        // fresh stamp, so nothing may re-warn (or repost - still mid-window).
+        // This also makes coverage of the lastwarnago computation
+        // deterministic: groups iterate in random order (V1 ORDER BY RAND()),
+        // so in one first-pass ordering out of three the home group processed
+        // last and no row ever reached that code with the stamp already set.
+        $stats2 = $this->service->process();
+        $this->assertEquals(0, $stats2['warned'], 'stamped rows must not re-warn within 24h');
+        $this->assertEquals(0, $stats2['reposted']);
     }
 
     /**


### PR DESCRIPTION
## What

Kills all three sources of the flip-flopping "Coveralls - laravel: Coverage decreased" red on unrelated PRs (seen at -0.005% on PR #1007, which touches no Laravel code).

Per-line Coveralls diff between PR #1007's laravel job (184383938) and master's baseline (184371561) shows exactly three files flipping, four lines total:

1. **`SendModNotifsCommand.php:49,51`** - the outside-hour-window guard. The without-force test ran against the **real clock** (its own comment claimed "we cannot control the clock in tests" - `travelTo` exists), so which branch executed depended on what hour CI ran in London time. Fixed: two frozen-clock tests, one at 22:30 London asserting the "Outside notification window" skip, one at 10:30 covering the proceed path.

2. **`ChatChaseupExpectedService.php:75`** - the per-expectee dedupe `continue`. `test_one_email_per_expectee_per_chat` put its second message at `now()-2d` against a `lastaccess` of `now()-1d`: the exact `TIMESTAMPDIFF >= 1440` grace boundary, decided by **sub-second timing between the two `now()` calls**. When the second row didn't qualify, the test silently degenerated into a single-row run that tested nothing about dedupe. Fixed with 2h of headroom - the test now actually tests what its name claims, every run.

3. **`AutoRepostService.php:184`** - the `lastwarnago` computation true-arm. `process()` iterates groups `inRandomOrder()` (V1 `ORDER BY RAND()` parity), and in the rippled-groups test the line is only reached when a row processes AFTER the home group stamps `lastautopostwarning` - uncovered in exactly the 1-in-3 orderings where the home group came last. Fixed with a second `process()` pass, which also finally verifies what the test comment promised all along: stamped rows must not re-warn (warned=0, reposted=0 on pass 2).

## Validation

`php -l` clean on both files; patterns mirror in-repo precedent (`travelTo` per DonationServiceTest, artisan expectations identical to sibling tests). Local execution isn't possible for a non-main-checkout tree (freegle-batch bind-mounts the main checkout, which has unrelated WIP) - CI runs the full Laravel suite on this PR and is the executing validator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014V1ihELPDZSe3CWT461fyK