### PR TITLE
test(e2e): wait for hydration before bulk register-interest interactions

### DIFF
--- a/iznik-nuxt3/tests/e2e/test-bulk-offer-flow.spec.js
+++ b/iznik-nuxt3/tests/e2e/test-bulk-offer-flow.spec.js
@@ -12,6 +12,7 @@ const path = require('path')
 const { test, expect } = require('./fixtures')
 const { timeouts } = require('./config')
 const { loginViaHomepage, logoutIfLoggedIn } = require('./utils/user')
+const { waitForNuxtHydration } = require('./utils/reply-helpers')
 
 const ASSET = (f) => path.join(__dirname, 'assets', f)
 
@@ -46,7 +47,9 @@ test.describe('Bulk offer (clearance) end-to-end', () => {
     })
 
     // Where are you? — enter postcode, wait for it to resolve a community.
-    const pc = page.locator('.pcinp, input[placeholder="Type postcode"]').first()
+    const pc = page
+      .locator('.pcinp, input[placeholder="Type postcode"]')
+      .first()
     await pc.waitFor({ state: 'visible', timeout: timeouts.ui.appearance })
     await pc.fill(postcode)
     await page
@@ -205,9 +208,18 @@ async function registerInterest(page, msgId, indices, takeScreenshot, who) {
   await page.gotoAndVerify(`/message/${msgId}`, {
     timeout: timeouts.navigation.default,
   })
+  // The toggles, photos AND the register button all render server-side, so
+  // their visibility says nothing about interactivity. Every interaction
+  // below relies on Vue click handlers (the empty-submit error in particular
+  // only renders after a live handler sets bulkTriedRegister) - clicking
+  // before hydration lands on inert SSR DOM and silently does nothing, which
+  // is exactly how this test failed on a loaded CI box.
+  await waitForNuxtHydration(page)
   // Wait for the bulk catalogue toggles to render.
   const toggles = page.locator('[data-testid^="pick-"]')
-  await toggles.first().waitFor({ state: 'visible', timeout: timeouts.ui.appearance })
+  await toggles
+    .first()
+    .waitFor({ state: 'visible', timeout: timeouts.ui.appearance })
 
   // Every item photo that renders must actually load — i.e. the dev image
   // pipeline (apiv2 delivery URL → resizer → local tusd) really serves it.


### PR DESCRIPTION
## What

Fixes the bulk-offer e2e failure on master pipeline #8990 (the first post-#894 build): the empty-submit assertion clicked `register-interest` and timed out waiting for the `register-error` banner.

## Root cause

`registerInterest()` in the spec never waits for Nuxt hydration. Every element it waits on before clicking - the pick toggles, item photos, and the register button itself - renders **server-side**, so their visibility proves nothing about interactivity. On a loaded CI box (this run had a parallel worker hammering the same containers) the click landed on inert pre-hydration DOM: no Vue handler ran, `bulkTriedRegister` was never set, and the banner - whose render is gated on that ref - never appeared. 67.5s timeout with "element(s) not found".

Static analysis rules out the alternatives: with nothing picked, `BulkItemsInterest`'s `validationError` computed is unconditionally non-empty and emitted immediately, and `registerBulkInterest()` shows the banner on every path; and `getByTestId` had already located the button, so `isBulk` was true. The only path to "banner never enters the DOM" is the handler never running.

## Fix

`await waitForNuxtHydration(page)` after navigation in `registerInterest()` - the exact pattern the reply-to-chat CTA spec already uses before interacting. Covers r1's empty-submit check plus all subsequent toggle/slot/submit interactions for both repliers.

eslint + prettier clean. Spec-only change; CI executes it (local Playwright runs test the main checkout tree, not this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014V1ihELPDZSe3CWT461fyK
