### PR TITLE
infra(edge): bring images tier up in interactive.slice (plan §3 prep)

### DIFF
--- a/docker-compose.override.edge.yml
+++ b/docker-compose.override.edge.yml
@@ -40,6 +40,16 @@ services:
     restart: unless-stopped
     ports:
       - "8080:80"
+    environment:
+      # Cap renderd render threads. confident_curran ran THREADS=100 as a
+      # near-dedicated tile host; on THIS shared 8-core box (batch/spatial/wiki
+      # co-resident) 100 render threads saturate CPU on every replication cycle
+      # (renderd "Failed to send render cmd", growing expiry backlog, load 100+).
+      # Serving already-rendered tiles is unaffected (they come from the
+      # osm-tiles volume); this only bounds the background re-render concurrency.
+      # cgroup: tile-server is in the default slice (weight 100) — it yields to
+      # interactive image serving (800) and outranks batch (25).
+      - THREADS=4
 
   wiki-mysql:
     # Adopt the already-initialised DB datadir in place (zero copy).

--- a/docker-compose.override.edge.yml
+++ b/docker-compose.override.edge.yml
@@ -57,29 +57,54 @@ services:
       - /var/wiki/html:/var/www/html
       - /var/wiki/sharewiki:/var/www/share
 
-  # --- Not-yet-migrated images tier: kept in the `edge` profile but held DOWN
-  # on this host until its own stage (plan §3). replicas:0 means a bare
-  # `docker compose up -d` or a reboot auto-start never brings the images tier
-  # up prematurely.
+  # --- Images tier (plan §3) — brought UP 2026-07-08 for validation + cache
+  # warming on the new ports (:8180/:8188). NOT yet fronting live traffic: the
+  # HAProxy cutover on ha-internal (repoint tusd_backend, add delivery_backend)
+  # is the separate human-gated step. Until then these serve only Host-header
+  # test curls and the low-priority cache rsync; no user reaches them.
+  #
+  # cgroup_parent: interactive.slice — latency-sensitive user serving, same
+  # priority tier as embedding-sidecar (CPUWeight=800). Requires the slice
+  # units from PR #1006 installed (they are). The digest job (07:00-12:00,
+  # batch.slice weight 25) *causes* the edge image peak, so this weighting is
+  # what lets image serving win under that exact contention.
   frontend-nginx:
     deploy:
-      replicas: 0
+      replicas: 1
+    cgroup_parent: interactive.slice
     ports:
       - "8180:80"     # HAProxy reaches this with send-proxy (PROXY protocol)
       - "8188:8080"   # plain — the :8080 upload-URL form (apps/Freebie Alerts)
 
   delivery:
     deploy:
-      replicas: 0
+      replicas: 1
+    cgroup_parent: interactive.slice
 
   tusd:
     deploy:
-      replicas: 0
+      replicas: 1
+    cgroup_parent: interactive.slice
+    # Prod flags, replicating app1 EXACTLY: -upload-dir on the shared NFS,
+    # -behind-proxy, -base-path /, -disable-cors (all tus CORS comes from
+    # HAProxy). NO -hooks-http — app1 prod runs without hooks (plan §3/§5).
+    command: -upload-dir=/srv/tusd-data -behind-proxy -base-path / -disable-cors
+    # Base healthcheck probes /tus/ (the dev base-path); prod base-path is /,
+    # where tusd returns 405 for GET and 404 at /tus/. Probe / and accept 405.
+    healthcheck:
+      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:8080/ 2>&1 | grep -E '(200|405)' || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+      start_period: 15s
     volumes:
-      # /srv/tusd-data on the host is the shared-NFS mount
+      # /srv/tusd-data is the shared-NFS mount
       # (nfs2.nlc.storage.katapult.io:/katapult/fsv_5ivInYUXp22oVueE), mounted
-      # read-only during prep and flipped to rw only at the human-gated upload
-      # cutover (plan §7/§11). Inert while replicas:0.
+      # READ-WRITE (decided 2026-07-08: uploads migrate here, so provision rw
+      # now — a second rw NFS client is the intended shared-store design, and
+      # pre-cutover this tusd gets no traffic so it writes nothing until the
+      # HAProxy upload cutover routes uploads here). app1 and this host use
+      # unique tusd IDs, so they never collide on the shared store.
       - /srv/tusd-data:/srv/tusd-data
 
 volumes:


### PR DESCRIPTION
Follow-up to #1008/#1006. Brings the edge **images tier** (`frontend-nginx`/`delivery`/`tusd`) up on the prod host for validation + cache warming — **not** yet fronting live traffic (the HAProxy cutover on ha-internal is the separate human-gated step).

## Changes (`docker-compose.override.edge.yml`, host-only)
- `replicas: 0 → 1` on all three; ports `:8180` (proxy_protocol) / `:8188` (plain :8080-form).
- `cgroup_parent: interactive.slice` on all three (PR #1006, CPUWeight=800 — same tier as embedding-sidecar). The digest job that *causes* the edge image peak is in `batch.slice` (weight 25), so this is the weighting that lets image serving win under that contention.
- tusd: prod flags replicating app1 exactly — `-upload-dir=/srv/tusd-data -behind-proxy -base-path / -disable-cors`, **no hooks** — on the shared NFS mount (now **rw**; uploads migrate here, a second rw client is the intended shared-store design, and pre-cutover tusd gets no traffic).
- Override the base tusd healthcheck to probe `/` (405) not `/tus/` (404), since prod base-path is `/`.

## Validated on the new ports (real PROXY framing via `--haproxy-protocol`)
- uploads → tusd reachable through the front door; **zero** nginx CORS (HAProxy owns tus CORS).
- delivery MISS→HIT, **exactly one** `X-Cache-Status`.
- on-disk cache `KEY: https://wsrv.nl/?url=...&w=22` — **matches app1's format**, so the 41 G `/wsrv_cache` rsync will hit, not orphan.
- catch-all unknown Host → 444; all three confirmed in `interactive.slice`; tiles/wiki unaffected by the tile-server recreate.

## Host-side (not in repo)
- NFS `/images` mounted **rw** at `/srv/tusd-data` (Katapult export allowlist updated for this host's IP; durable `/etc/fstab` entry with `_netdev,nofail`).
- `.env` `COMPOSE_FILE` now includes `docker-compose.override.batchprod.yml` (slices) + slice units installed in `/etc/systemd/system/`.

## Next (gated)
Low-priority rsync of app1's 41 G `/wsrv_cache` → replay-validate >90% HIT → **human GO** → HAProxy cutover (repoint `tusd_backend`, add `delivery_backend`, keep app1 as `backup`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ka6SXbZyznGYXyCyC9C86h