### PR TITLE
fix(sentry): suppress two third-party ad-stack errors burying real bugs

### DIFF
--- a/iznik-nuxt3/composables/useSuppressException.js
+++ b/iznik-nuxt3/composables/useSuppressException.js
@@ -25,6 +25,32 @@ export function suppressSentryEvent(event) {
       if (isFtUtilsFrame && isFreestarFn) {
         return true
       }
+
+      // Third-party ad / IAB-TCF consent stack. These fire from anonymous/injected
+      // ad scripts (Prebid header bidding + the TCF __tcfapiLocator frame-walk) with
+      // no Freegle source frame, so match the exact vendor frame signature - our own
+      // code source-maps to real files and never hits these:
+      //   - RangeError "Maximum call stack size exceeded" in HTMLIFrameElement.get:
+      //     the TCF locator recursing up cross-origin iframes (Sentry 7372856855,
+      //     258 events / 78 users; breadcrumbs "TC String set" + "Prebid loaded").
+      //   - TypeError null.document in an anonymous HTMLDocument handler: an ad
+      //     bidder's document handler (Sentry 7377347048, 186 events / 75 users;
+      //     breadcrumbs are the Prebid SSP fan-out - teads / criteo / rubicon / ...).
+      const noSource = !frame.filename || frame.filename === '<anonymous>'
+      if (
+        fn === 'HTMLIFrameElement.get' &&
+        (ex.type === 'RangeError' ||
+          (ex.value || '').includes('Maximum call stack'))
+      ) {
+        return true
+      }
+      if (
+        fn === 'HTMLDocument.<anonymous>' &&
+        noSource &&
+        (ex.value || '').includes("reading 'document'")
+      ) {
+        return true
+      }
     }
   }
   return false

--- a/iznik-nuxt3/tests/unit/composables/useSuppressException.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useSuppressException.spec.js
@@ -68,9 +68,7 @@ describe('suppressException', () => {
   })
 
   it('returns false when neither message nor stack matches known patterns', () => {
-    expect(
-      suppressException({ message: 'foo', stack: 'bar' })
-    ).toBe(false)
+    expect(suppressException({ message: 'foo', stack: 'bar' })).toBe(false)
   })
 
   it('suppresses Freestar ftUtils.js null-document errors', () => {
@@ -143,7 +141,8 @@ describe('suppressException', () => {
       suppressException({
         name: 'TypeError',
         message: "Cannot read properties of null (reading 'document')",
-        stack: '    at MyComponent.vue:42 (https://example.com/MyComponent.vue)',
+        stack:
+          '    at MyComponent.vue:42 (https://example.com/MyComponent.vue)',
       })
     ).toBe(false)
   })
@@ -297,6 +296,90 @@ describe('suppressSentryEvent', () => {
       },
     }
     expect(suppressSentryEvent(event)).toBe(true)
+  })
+
+  it('suppresses the TCF/consent frame-walk RangeError (HTMLIFrameElement.get, Sentry 7372856855)', () => {
+    // The IAB-TCF __tcfapiLocator recurses up cross-origin iframes and overflows
+    // the stack via HTMLIFrameElement.get - third-party ad/consent code, not ours.
+    const event = {
+      exception: {
+        values: [
+          {
+            type: 'RangeError',
+            value: 'Maximum call stack size exceeded.',
+            stacktrace: {
+              frames: [
+                { function: 'HTMLIFrameElement.get', filename: '<anonymous>' },
+              ],
+            },
+          },
+        ],
+      },
+    }
+    expect(suppressSentryEvent(event)).toBe(true)
+  })
+
+  it('suppresses the ad-bidder null.document handler (HTMLDocument.<anonymous>, Sentry 7377347048)', () => {
+    // A Prebid SSP bidder's anonymous document handler reads .document on null.
+    const event = {
+      exception: {
+        values: [
+          {
+            type: 'TypeError',
+            value: "Cannot read properties of null (reading 'document')",
+            stacktrace: {
+              frames: [
+                {
+                  function: 'HTMLDocument.<anonymous>',
+                  filename: '<anonymous>',
+                },
+              ],
+            },
+          },
+        ],
+      },
+    }
+    expect(suppressSentryEvent(event)).toBe(true)
+  })
+
+  it('does NOT suppress a real RangeError / null.document from our own source', () => {
+    // Genuine infinite recursion or null-deref in our code source-maps to a real
+    // file with a named function - it must still be reported, not masked.
+    expect(
+      suppressSentryEvent({
+        exception: {
+          values: [
+            {
+              type: 'RangeError',
+              value: 'Maximum call stack size exceeded.',
+              stacktrace: {
+                frames: [
+                  {
+                    function: 'MyComponent.recurse',
+                    filename: '/MyComponent.vue',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      })
+    ).toBe(false)
+    expect(
+      suppressSentryEvent({
+        exception: {
+          values: [
+            {
+              type: 'TypeError',
+              value: "Cannot read properties of null (reading 'document')",
+              stacktrace: {
+                frames: [{ function: 'setup', filename: '/pages/browse.vue' }],
+              },
+            },
+          ],
+        },
+      })
+    ).toBe(false)
   })
 
   it('does not suppress ftUtils.js frames with unknown function names', () => {


### PR DESCRIPTION
## Summary

Reviewing the last monitor-fsm run's unclassified Sentry issues, two of them have in-app frames but turned out to be **unhandled exceptions inside the third-party ad stack, not Freegle code** — and they've been firing since **2026-03** (not a regression):

- `RangeError: Maximum call stack size exceeded` — **258 events / 78 users** (`7372856855`). The IAB-TCF `__tcfapiLocator` recurses up cross-origin iframes and overflows the stack via `HTMLIFrameElement.get`. Breadcrumbs right before: `TC data loaded and TC String set…`, `Prebid loaded`.
- `TypeError: Cannot read properties of null (reading 'document')` — **186 / 75** (`7377347048`). A Prebid SSP bidder's anonymous `HTMLDocument.<anonymous>` handler. Breadcrumbs are the full Prebid bidder fan-out: teads.tv, adsrvr.org, sharethrough, openx, criteo, casalemedia, rubicon.

We can't patch the vendors' code. Matching the ~20 existing curated third-party suppressions in `beforeSend`/`suppressException`, this adds **two surgical frame signatures** to `suppressSentryEvent` so they stop drowning genuine regressions:
- `HTMLIFrameElement.get` + `RangeError`/"Maximum call stack"
- `HTMLDocument.<anonymous>` with an anonymous filename + "reading 'document'"

## Code Quality Review
- Matched on the exact vendor **frame signature** (function + anonymous filename), not the generic message — our own code source-maps to real files and never matches.
- A **guard test** proves a genuine `RangeError` / null-`document` from our own source (real file + named function) is still reported, not masked.

## Test Plan
- New unit tests for both signatures + the negative guard.
- Full vitest green locally: **14236 ✓**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
