### PR TITLE
feat(moderation): route vague-item posts to Pending instead of auto-approving

### DIFF
--- a/iznik-batch/app/Helpers/ItemQuality.php
+++ b/iznik-batch/app/Helpers/ItemQuality.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Helpers;
+
+/**
+ * Quality checks on a post's item — the subject text between "OFFER:"/"WANTED:" and the
+ * trailing "(location)". Used to route low-quality/vague posts to Pending for a moderator to
+ * review rather than auto-approving them.
+ *
+ * Intentionally MORE aggressive than the client-side compose gate
+ * (iznik-nuxt3/composables/useItemValidation.js): routing to Pending is reversible — a mod
+ * approves the genuine ones — so it can afford a wider net (filler variants like "anything
+ * nice", and "<vague> for/to X" like "things for the garden"). Sized against 30 days of
+ * production posts at ~3/day across Freegle, with the sampled matches all genuinely vague.
+ */
+class ItemQuality
+{
+    // Content-free / vague item patterns. The item is lower-cased, trimmed and location-stripped
+    // before matching. The "<vague> for/to X" rule only fires when the LEADING word is itself
+    // content-free, so a specific request ("bike for a toddler") is never matched.
+    private const VAGUE_PATTERNS = [
+        '/^(any|anything|everything|every ?thing|all|stuff|things|items|goods|various|various items|various stuff|free stuff|free items|free things|freebies|something|owt|whatever|unwanted|unwanted items|unwanted stuff|misc|miscellaneous|sundries|no idea|not sure|nothing specific)$/',
+        '/^(anything|everything|something) (else|nice|really|useful|good|free|at all)$/',
+        '/^(anything|something|stuff|things|items|bits) (for|to) /',
+    ];
+
+    /**
+     * Extract the item from a "TYPE: item (area)" subject — lower-cased and trimmed. Returns ''
+     * when there's no usable item.
+     */
+    public static function itemFromSubject(?string $subject): string
+    {
+        if ($subject === null || $subject === '') {
+            return '';
+        }
+        // Strip a leading "OFFER:"/"WANTED:" (any case) and a trailing "(area)".
+        $s = preg_replace('/^\s*(OFFER|WANTED)\s*:\s*/i', '', $subject);
+        $s = preg_replace('/\s*\([^)]*\)\s*$/', '', $s);
+
+        return strtolower(trim($s));
+    }
+
+    /**
+     * True when the post's item carries no real information — a content-free catch-all
+     * ("anything", "free stuff", "various items", "things for the garden"). Such posts are
+     * routed to Pending rather than auto-approved.
+     */
+    public static function subjectItemIsVague(?string $subject): bool
+    {
+        $item = self::itemFromSubject($subject);
+        if ($item === '') {
+            return false;
+        }
+        foreach (self::VAGUE_PATTERNS as $re) {
+            if (preg_match($re, $item)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/iznik-batch/app/Services/AutoApproveService.php
+++ b/iznik-batch/app/Services/AutoApproveService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Helpers\ItemQuality;
 use App\Models\Group;
 use App\Models\MessageGroup;
 use Illuminate\Support\Facades\DB;
@@ -221,6 +222,15 @@ class AutoApproveService
         // membership gate — the group publish/closed/override checks above still apply.
         if ((int) ($candidate->rippled_in ?? 0) === 1) {
             return true;
+        }
+
+        // Low-quality / vague item ("anything", "free stuff", "various items", "things for the
+        // garden"): do NOT auto-approve — leave it Pending so a moderator reviews it (they can
+        // approve the genuine ones). This is deliberately more aggressive than the client-side
+        // compose gate because Pending is reversible; live-data sized at ~3 posts/day across
+        // Freegle. Applied to ORIGIN rows only — a rippled-in copy was already vetted above.
+        if (ItemQuality::subjectItemIsVague($candidate->subject ?? null)) {
+            return false;
         }
 
         // V1: $joined = $u->getMembershipAtt($gid, 'added');

--- a/iznik-batch/tests/Unit/Helpers/ItemQualityTest.php
+++ b/iznik-batch/tests/Unit/Helpers/ItemQualityTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Tests\Unit\Helpers;
+
+use App\Helpers\ItemQuality;
+use Tests\TestCase;
+
+class ItemQualityTest extends TestCase
+{
+    public function test_extracts_the_item_from_a_subject(): void
+    {
+        $this->assertSame('anything', ItemQuality::itemFromSubject('WANTED: Anything (Bristol BS1)'));
+        $this->assertSame('red sofa', ItemQuality::itemFromSubject('OFFER: Red sofa (Leeds LS1)'));
+        $this->assertSame(
+            'things for the garden!',
+            ItemQuality::itemFromSubject('WANTED: Things for the garden!  (Little Hulton M38)')
+        );
+        $this->assertSame('', ItemQuality::itemFromSubject(null));
+        $this->assertSame('', ItemQuality::itemFromSubject(''));
+    }
+
+    public function test_flags_vague_catch_all_items(): void
+    {
+        $vague = [
+            'WANTED: Anything (X BS1)',
+            'WANTED: All (X)',
+            'WANTED: Free stuff (X)',
+            'WANTED: Various items (X)',
+            'WANTED: Something (X)',
+            'WANTED: Freebies (X)',
+            'WANTED: Unwanted items (X)',
+            'OFFER: stuff (X)',
+            'WANTED: owt (X)',
+            'WANTED: Anything nice (X)',
+            'WANTED: everything really (X)',
+            // "<vague> for/to X" — more aggressive than the compose block (Pending is reversible).
+            'WANTED: Things for the garden (X)',
+            'WANTED: Items for house (X)',
+            'WANTED: Anything to resell (X)',
+        ];
+        foreach ($vague as $s) {
+            $this->assertTrue(ItemQuality::subjectItemIsVague($s), "should be vague: $s");
+        }
+    }
+
+    public function test_allows_specific_items(): void
+    {
+        $specific = [
+            'WANTED: Bike (Wavertree L8)',
+            'WANTED: Fan (Coventry CV1)',
+            'OFFER: Red sofa (Leeds LS1)',
+            'WANTED: Washing machine (X)',
+            'OFFER: Fridge freezer (X)',
+            'WANTED: Football boots (X)',
+            // These start with an otherwise-vague word but carry real content, so are allowed.
+            'WANTED: Various board games (X)',
+            'WANTED: Free weights (X)',
+        ];
+        foreach ($specific as $s) {
+            $this->assertFalse(ItemQuality::subjectItemIsVague($s), "should be allowed: $s");
+        }
+    }
+}

--- a/iznik-batch/tests/Unit/Services/AutoApproveServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/AutoApproveServiceTest.php
@@ -78,6 +78,40 @@ class AutoApproveServiceTest extends TestCase
         ]);
     }
 
+    public function test_does_not_auto_approve_a_vague_item_leaving_it_pending(): void
+    {
+        // A vague item ("anything") must be routed to Pending for a moderator to review, even for
+        // a long-standing member whose posts would otherwise auto-approve after 48h.
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $this->createMembership($user, $group, ['added' => now()->subHours(72)]);
+
+        $message = $this->createTestMessage($user, $group, [
+            'type' => 'Wanted',
+            'subject' => 'WANTED: Anything (TestLocation)',
+        ]);
+        DB::table('messages_groups')
+            ->where('msgid', $message->id)
+            ->where('groupid', $group->id)
+            ->update([
+                'collection' => MessageGroup::COLLECTION_PENDING,
+                'arrival' => now()->subHours(49),
+                'contentcheck_checked_at' => now(),
+            ]);
+
+        $this->service->process();
+
+        $mg = DB::table('messages_groups')
+            ->where('msgid', $message->id)
+            ->where('groupid', $group->id)
+            ->first();
+        $this->assertEquals(
+            MessageGroup::COLLECTION_PENDING,
+            $mg->collection,
+            'a vague-item post must stay Pending for moderator review, not auto-approve'
+        );
+    }
+
     public function test_auto_approve_mails_newly_reached_members_of_a_done_rippling_post(): void
     {
         // A rippling post auto-approved on a group AFTER its reach has finished expanding
@@ -829,7 +863,7 @@ class AutoApproveServiceTest extends TestCase
         ]);
 
         $message = $this->createTestMessage($user, $group, [
-            'subject' => 'OFFER: Something',
+            'subject' => 'OFFER: Sofa',
         ]);
 
         DB::table('messages')->where('id', $message->id)->update([
@@ -849,7 +883,7 @@ class AutoApproveServiceTest extends TestCase
 
         // Should NOT whitelist subject for non-SubjectUsedForDifferentGroups spamtype.
         $this->assertDatabaseMissing('spam_whitelist_subjects', [
-            'subject' => AutoApproveService::getPrunedSubject('OFFER: Something'),
+            'subject' => AutoApproveService::getPrunedSubject('OFFER: Sofa'),
         ]);
 
         // But Ham should still be recorded.


### PR DESCRIPTION
## Summary

Following reports of low-quality vague posts, this routes them to **Pending for a moderator** rather than auto-approving — a softer, reversible action than blocking, so it can be more aggressive than the compose-time gate.

- New `App\Helpers\ItemQuality::subjectItemIsVague()` — extracts the item from a `TYPE: item (area)` subject and flags content-free catch-alls.
- Wired into `AutoApproveService::shouldApproveOnGroup`: a vague item returns `false`, so the post **stays Pending** (a mod approves the genuine ones). Catches every source (web/email/TN), can't be client-bypassed. Applied to origin rows only — a rippled-in copy was already vetted.

**More aggressive than the compose block** (which must be precise): it also catches filler variants (`anything nice`, `everything really`) and `<vague> for/to X` (`things for the garden`, `anything to resell`).

**Live-data sized (30 days):** ~**84 WANTED + 13 OFFER (~3/day)** across all of Freegle — negligible mod-load — and the sampled matches were all genuinely low-quality (`Anything`, `All`, `Free stuff`, `Something`, `Things for the garden!`).

## Code Quality Review
- Specific requests are untouched: `bike`, `washing machine`, `various board games`, `free weights` — verified by tests.
- One existing spamham test used the incidental subject `OFFER: Something` (now correctly vague); swapped to `OFFER: Sofa` so its precondition (auto-approval) holds. Its assertion is unchanged — a genuine behaviour interaction, not a masked bug.

## Test Plan
- `ItemQualityTest`: extraction + vague vs specific.
- `AutoApproveServiceTest`: a vague post from a 72h member stays Pending instead of auto-approving.
- Full Laravel green: **4776 ✓**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
