### PR TITLE
Voice posting on mobile (/voicepost, experiment-gated)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -859,6 +859,8 @@ services:
       - EMBEDDING_TOKENIZER_PATH=${EMBEDDING_TOKENIZER_PATH:-}
       - SPATIAL_KNN_URL=http://spatial-knn:8194
       - SPATIAL_SERVER_URL=http://spatial:8196
+      # Groq API key for the voice-posting endpoint (streaming transcription + tidy-up).
+      - GROQ_API_KEY=${GROQ_API_KEY:-}
     volumes:
       - apiv2_logs:/var/log/freegle
       - embedding_model_cache:/app/model-cache

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1033,6 +1033,8 @@ services:
       - DONATIONS_EXCLUDE=${DONATIONS_EXCLUDE:-}
       - CLOUDFLARE_ACCOUNT_ID=${CLOUDFLARE_ACCOUNT_ID:-}
       - CLOUDFLARE_AI_TOKEN=${CLOUDFLARE_AI_TOKEN:-}
+      # Groq API key for the voice-posting endpoint (streaming transcription + tidy-up).
+      - GROQ_API_KEY=${GROQ_API_KEY:-}
       - SPATIAL_SERVER_URL=${SPATIAL_SERVER_URL:-http://spatial:8196}
     volumes:
       - apiv2_logs:/var/log/freegle

--- a/iznik-nuxt3/api/VoicePostAPI.js
+++ b/iznik-nuxt3/api/VoicePostAPI.js
@@ -1,0 +1,25 @@
+import BaseAPI from '@/api/BaseAPI'
+
+// VoicePostAPI drives the streaming voice-post flow. Audio is streamed to the
+// server in small chunks while the user is still talking (chunk), then finalised
+// once they stop (finish). See iznik-server-go/voicepost.
+export default class VoicePostAPI extends BaseAPI {
+  // Send one chunk of recorded audio (a Blob). On the first call omit `session`
+  // and the server allocates one, returned in the response. Returns
+  // { session, transcript } where transcript is the best transcript so far.
+  async chunk(blob, session) {
+    const path =
+      '/voicepost/chunk' +
+      (session ? '?session=' + encodeURIComponent(session) : '')
+    return await this.$postFormv2(path, blob)
+  }
+
+  // Finalise the post once the user stops talking. Does a final full
+  // transcription and a tidy-up pass. Returns { id, transcript, title, description }.
+  async finish(session) {
+    return await this.$postv2(
+      '/voicepost/finish?session=' + encodeURIComponent(session),
+      {}
+    )
+  }
+}

--- a/iznik-nuxt3/api/index.js
+++ b/iznik-nuxt3/api/index.js
@@ -54,6 +54,7 @@ import TrystAPI from './TrystAPI.js'
 import UserAPI from './UserAPI.js'
 import UserSearchAPI from './UserSearchAPI.js'
 import VisualiseAPI from './VisualiseAPI.js'
+import VoicePostAPI from './VoicePostAPI.js'
 import VolunteeringAPI from './VolunteeringAPI.js'
 
 export default (config) => {
@@ -105,6 +106,7 @@ export default (config) => {
     user: new UserAPI(options),
     usersearch: new UserSearchAPI(options),
     visualise: new VisualiseAPI(options),
+    voicepost: new VoicePostAPI(options),
     volunteering: new VolunteeringAPI(options),
   }
 }

--- a/iznik-nuxt3/composables/useComposeChoice.js
+++ b/iznik-nuxt3/composables/useComposeChoice.js
@@ -10,7 +10,10 @@ import { useNuxtApp, useRoute } from '#imports'
 // completion are still recorded through the existing bandit endpoints
 // (uid = COMPOSE_CHOICE_UID) so the abtest table accumulates shown/action rates
 // per variant that we can compare.
-export const COMPOSE_CHOICE_UID = 'mobile-compose-voice'
+// Exposure experiment: did we show the choice variant, and did they complete a post?
+export const COMPOSE_CHOICE_UID = 'mobile-compose-variant'
+// Method measurement: of those offered the choice, did they pick voice or keyboard?
+export const COMPOSE_METHOD_UID = 'mobile-compose-method'
 
 // Percentage of eligible (mobile) users shown the voice option. Start at 0 and
 // raise to roll the experiment out to a slice of traffic. Per-visit override:
@@ -65,5 +68,34 @@ export function useComposeChoice() {
     }
   }
 
-  return { COMPOSE_CHOICE_UID, isMobile, assign, recordShown, recordConversion }
+  // Record that the voice/keyboard choice was presented (both methods) so the
+  // pick-rate per method is comparable.
+  function recordMethodShown() {
+    try {
+      $api.bandit.shown({ uid: COMPOSE_METHOD_UID, variant: 'voice' })
+      $api.bandit.shown({ uid: COMPOSE_METHOD_UID, variant: 'keyboard' })
+    } catch (e) {
+      // Tracking must never block the compose flow.
+    }
+  }
+
+  // Record which method they picked ('voice' or 'keyboard').
+  function recordMethodChosen(method) {
+    try {
+      $api.bandit.chosen({ uid: COMPOSE_METHOD_UID, variant: method })
+    } catch (e) {
+      // Tracking must never block the compose flow.
+    }
+  }
+
+  return {
+    COMPOSE_CHOICE_UID,
+    COMPOSE_METHOD_UID,
+    isMobile,
+    assign,
+    recordShown,
+    recordConversion,
+    recordMethodShown,
+    recordMethodChosen,
+  }
 }

--- a/iznik-nuxt3/composables/useComposeChoice.js
+++ b/iznik-nuxt3/composables/useComposeChoice.js
@@ -41,6 +41,15 @@ export function useComposeChoice() {
     return Math.abs(h) % 100
   }
 
+  // Whether the experiment is live at all. When it's off (the default), the
+  // compose entry keeps its original behaviour with zero side effects - so
+  // merging this changes nothing for existing users until ROLLOUT_PCT is raised.
+  function experimentActive() {
+    const q = route?.query?.voice
+    if (q === '1' || q === '0') return true
+    return ROLLOUT_PCT > 0
+  }
+
   // Returns 'voice' or 'control'.
   function assign() {
     const q = route?.query?.voice
@@ -92,6 +101,7 @@ export function useComposeChoice() {
     COMPOSE_CHOICE_UID,
     COMPOSE_METHOD_UID,
     isMobile,
+    experimentActive,
     assign,
     recordShown,
     recordConversion,

--- a/iznik-nuxt3/composables/useComposeChoice.js
+++ b/iznik-nuxt3/composables/useComposeChoice.js
@@ -1,0 +1,69 @@
+import { useMiscStore } from '~/stores/misc'
+import { useAuthStore } from '~/stores/auth'
+import { useNuxtApp, useRoute } from '#imports'
+
+// Experiment: on mobile, offer a voice-vs-keyboard choice for composing an OFFER
+// instead of going straight to the typed form, and measure whether it helps.
+//
+// Assignment is a fixed per-user % bucket (a clean A/B holdout, not the adaptive
+// bandit) so a stable slice of mobile users sees the voice option. Exposure and
+// completion are still recorded through the existing bandit endpoints
+// (uid = COMPOSE_CHOICE_UID) so the abtest table accumulates shown/action rates
+// per variant that we can compare.
+export const COMPOSE_CHOICE_UID = 'mobile-compose-voice'
+
+// Percentage of eligible (mobile) users shown the voice option. Start at 0 and
+// raise to roll the experiment out to a slice of traffic. Per-visit override:
+// ?voice=1 forces the voice variant, ?voice=0 forces control (handy for demos).
+const ROLLOUT_PCT = 0
+
+export function useComposeChoice() {
+  const miscStore = useMiscStore()
+  const authStore = useAuthStore()
+  const route = useRoute()
+  const { $api } = useNuxtApp()
+
+  const isMobile = () => ['xs', 'sm', 'md'].includes(miscStore.breakpoint)
+
+  // Deterministic 0..99 bucket per user (FNV-1a hash) so a given user always
+  // gets the same experience across visits.
+  function bucket() {
+    const id = authStore.user?.id || 0
+    let h = 2166136261
+    const s = 'voice:' + id
+    for (let i = 0; i < s.length; i++) {
+      h ^= s.charCodeAt(i)
+      h = Math.imul(h, 16777619)
+    }
+    return Math.abs(h) % 100
+  }
+
+  // Returns 'voice' or 'control'.
+  function assign() {
+    const q = route?.query?.voice
+    if (q === '1') return 'voice'
+    if (q === '0') return 'control'
+    if (!isMobile()) return 'control'
+    return bucket() < ROLLOUT_PCT ? 'voice' : 'control'
+  }
+
+  // Record that the user was put in a variant (exposure).
+  function recordShown(variant) {
+    try {
+      $api.bandit.shown({ uid: COMPOSE_CHOICE_UID, variant })
+    } catch (e) {
+      // Tracking must never block the compose flow.
+    }
+  }
+
+  // Record a completed post for a variant (conversion).
+  function recordConversion(variant, score) {
+    try {
+      $api.bandit.chosen({ uid: COMPOSE_CHOICE_UID, variant, score })
+    } catch (e) {
+      // Tracking must never block the compose flow.
+    }
+  }
+
+  return { COMPOSE_CHOICE_UID, isMobile, assign, recordShown, recordConversion }
+}

--- a/iznik-nuxt3/pages/give/mobile/index.vue
+++ b/iznik-nuxt3/pages/give/mobile/index.vue
@@ -9,9 +9,11 @@
 import { onMounted } from 'vue'
 import { useRouter } from '#imports'
 import { useComposeChoice } from '~/composables/useComposeChoice'
+import { useClientLog } from '~/composables/useClientLog'
 
 const router = useRouter()
 const { experimentActive, assign, recordShown, isMobile } = useComposeChoice()
+const { action: logEvent } = useClientLog()
 
 onMounted(() => {
   // Experiment off (default): behave exactly as before - straight to the existing
@@ -24,9 +26,11 @@ onMounted(() => {
   }
 
   const variant = assign()
+  const mobile = isMobile()
   // Only record exposure for the eligible (mobile) population so the experiment
   // rates aren't diluted by desktop control traffic.
-  if (isMobile()) recordShown(variant)
+  if (mobile) recordShown(variant)
+  logEvent('voicepost_entry', { variant, is_mobile: mobile })
   router.replace(variant === 'voice' ? '/voicepost' : '/give/mobile/photos')
 })
 </script>

--- a/iznik-nuxt3/pages/give/mobile/index.vue
+++ b/iznik-nuxt3/pages/give/mobile/index.vue
@@ -1,16 +1,30 @@
 <template>
   <div>
-    <!-- Redirect to photos page -->
+    <!-- Redirect: the voice-experiment cohort gets the choice screen; everyone
+         else goes straight to the existing typed photos flow. -->
   </div>
 </template>
 
 <script setup>
 import { onMounted } from 'vue'
 import { useRouter } from '#imports'
+import { useComposeChoice } from '~/composables/useComposeChoice'
 
 const router = useRouter()
+const { assign, recordShown, isMobile } = useComposeChoice()
 
 onMounted(() => {
-  router.replace('/give/mobile/photos')
+  const variant = assign()
+  // Only record exposure for the eligible (mobile) population so the experiment
+  // rates aren't diluted by desktop control traffic.
+  if (isMobile()) recordShown(variant)
+
+  if (variant === 'voice') {
+    // Offer the voice-or-keyboard choice.
+    router.replace('/voicepost')
+  } else {
+    // Control: the existing typed compose flow, unchanged.
+    router.replace('/give/mobile/photos')
+  }
 })
 </script>

--- a/iznik-nuxt3/pages/give/mobile/index.vue
+++ b/iznik-nuxt3/pages/give/mobile/index.vue
@@ -11,20 +11,22 @@ import { useRouter } from '#imports'
 import { useComposeChoice } from '~/composables/useComposeChoice'
 
 const router = useRouter()
-const { assign, recordShown, isMobile } = useComposeChoice()
+const { experimentActive, assign, recordShown, isMobile } = useComposeChoice()
 
 onMounted(() => {
+  // Experiment off (default): behave exactly as before - straight to the existing
+  // typed photos flow, with no assignment and no tracking side effects. This is
+  // what makes merging safe: the existing route is unchanged until the rollout is
+  // deliberately raised.
+  if (!experimentActive()) {
+    router.replace('/give/mobile/photos')
+    return
+  }
+
   const variant = assign()
   // Only record exposure for the eligible (mobile) population so the experiment
   // rates aren't diluted by desktop control traffic.
   if (isMobile()) recordShown(variant)
-
-  if (variant === 'voice') {
-    // Offer the voice-or-keyboard choice.
-    router.replace('/voicepost')
-  } else {
-    // Control: the existing typed compose flow, unchanged.
-    router.replace('/give/mobile/photos')
-  }
+  router.replace(variant === 'voice' ? '/voicepost' : '/give/mobile/photos')
 })
 </script>

--- a/iznik-nuxt3/pages/privacy.vue
+++ b/iznik-nuxt3/pages/privacy.vue
@@ -44,6 +44,27 @@
           location, the description and any photos. No personal details are made
           public unless in this information.
         </p>
+        <h3>2.1 Voice descriptions</h3>
+        <p>
+          You can describe an item by speaking instead of typing. If you do, we
+          record the audio and stream it to
+          <!-- eslint-disable-next-line -->
+          <ExternalLink href="https://groq.com/">Groq</ExternalLink>, a
+          third-party speech-to-text service, which transcribes your words so we
+          can turn them into a post. A short automated tidy-up then turns the
+          transcript into a suggested title and description, which you get to
+          review and edit before anything is posted. We don't send Groq your
+          name, email address or any other personal details - only the audio you
+          record.
+        </p>
+        <p>
+          We keep the original voice recording for no more than
+          <strong>90 days</strong>, after which it is deleted automatically -
+          after that, only the text of your post remains. When you record, we ask
+          whether you're happy for the person collecting your item to hear your
+          recording, and we will only ever let someone else hear it if you choose
+          to allow that.
+        </p>
         <h2>3. Cookies and Tracking</h2>
         <p>
           You'll have seen lots of irritating popups on websites about consent
@@ -216,6 +237,10 @@
         <h3>Change History</h3>
         <p>Here are the changes to this page.</p>
         <ul class>
+          <li>
+            08/07/2026: Add section 2.1 on voice descriptions, our use of Groq
+            for speech-to-text, and the 90-day retention of voice recordings.
+          </li>
           <li>
             10/05/2026: Restructure section 4 to clearly explain how to unsubscribe
             and request data deletion, with a prominent delete button, to satisfy

--- a/iznik-nuxt3/pages/voicepost.vue
+++ b/iznik-nuxt3/pages/voicepost.vue
@@ -218,6 +218,7 @@ import { useComposeStore } from '~/stores/compose'
 import { useAuthStore } from '~/stores/auth'
 import { useMiscStore } from '~/stores/misc'
 import { useComposeChoice } from '~/composables/useComposeChoice'
+import { useClientLog } from '~/composables/useClientLog'
 
 // Standalone route. Flow: add a photo, then choose voice or keyboard. For voice,
 // describe the item aloud (audio streams up while you talk) and review the tidied
@@ -231,10 +232,22 @@ const authStore = useAuthStore()
 const miscStore = useMiscStore()
 const { recordConversion, recordMethodShown, recordMethodChosen } =
   useComposeChoice()
+// Rich, session-correlated analytics for the whole funnel (see useClientLog).
+const { action: logVpEvent } = useClientLog()
 
 const phase = ref('photo') // photo | choose | idle | recording | finishing | review | done | error
 const errorMessage = ref('')
 const stickyAdRendered = computed(() => miscStore.stickyAdRendered)
+
+// Instrumentation state: lets us report duration, edit-or-not, re-records and
+// time-on-review so we can judge whether people trust and complete the flow.
+const originalTitle = ref('')
+const originalDescription = ref('')
+let recordDurationS = 0
+let reviewShownAt = 0
+let rerecordCount = 0
+let posted = false
+let played = false
 
 // Photo, held in the compose store (shared with the typed flow), mirroring
 // pages/give/mobile/photos.vue so either branch continues the same draft.
@@ -298,16 +311,26 @@ const formattedElapsed = computed(() => {
 function advanceFromPhoto() {
   phase.value = 'choose'
   recordMethodShown()
+  // How often the choice was shown, and whether they'd added a photo first.
+  logVpEvent('voicepost_choice_shown', { has_photo: hasPhotos.value })
 }
 
 function chooseVoice() {
   recordMethodChosen('voice')
+  logVpEvent('voicepost_method_chosen', {
+    method: 'voice',
+    has_photo: hasPhotos.value,
+  })
   phase.value = 'idle'
 }
 
 function chooseType() {
   // Keyboard branch: continue in the existing typed form (photo already added).
   recordMethodChosen('keyboard')
+  logVpEvent('voicepost_method_chosen', {
+    method: 'keyboard',
+    has_photo: hasPhotos.value,
+  })
   router.push('/give/mobile/details')
 }
 
@@ -336,6 +359,7 @@ async function startRecording() {
     !navigator.mediaDevices ||
     typeof MediaRecorder === 'undefined'
   ) {
+    logVpEvent('voicepost_record_error', { reason: 'unsupported' })
     fail("Your browser can't record audio. Try a recent Chrome, Edge or Safari.")
     return
   }
@@ -343,13 +367,17 @@ async function startRecording() {
   try {
     stream = await navigator.mediaDevices.getUserMedia({ audio: true })
   } catch (e) {
+    let reason = 'other'
     if (e && (e.name === 'NotAllowedError' || e.name === 'SecurityError')) {
+      reason = 'permission_denied'
       fail('We need permission to use your microphone. Allow it and try again.')
     } else if (e && e.name === 'NotFoundError') {
+      reason = 'no_microphone'
       fail("We couldn't find a microphone on your device.")
     } else {
       fail("We couldn't start recording. Please try again.")
     }
+    logVpEvent('voicepost_record_error', { reason })
     return
   }
 
@@ -373,6 +401,7 @@ async function startRecording() {
   // there's almost nothing left to upload when they stop.
   mediaRecorder.start(3000)
   phase.value = 'recording'
+  logVpEvent('voicepost_record_start', {})
 
   timer = setInterval(() => {
     elapsed.value += 1
@@ -396,6 +425,7 @@ function enqueueChunk(blob) {
 }
 
 function stopRecording() {
+  recordDurationS = elapsed.value
   if (timer) {
     clearInterval(timer)
     timer = null
@@ -411,6 +441,10 @@ async function finalise() {
   await sendQueue // ensure every chunk, including the last, is in the buffer
 
   if (!session.value) {
+    logVpEvent('voicepost_finish_error', {
+      reason: 'no_session',
+      duration_s: recordDurationS,
+    })
     fail("We didn't catch that recording - please try again.")
     return
   }
@@ -420,13 +454,28 @@ async function finalise() {
     title.value = res.title || ''
     description.value = res.description || ''
     rawTranscript.value = res.transcript || ''
+    // Remember what we produced so we can tell later if they edited it.
+    originalTitle.value = title.value
+    originalDescription.value = description.value
 
     if (chunks.length) {
       audioBlob.value = new Blob(chunks, { type: mimeType })
       audioUrl.value = URL.createObjectURL(audioBlob.value)
     }
+    reviewShownAt = Date.now()
+    logVpEvent('voicepost_transcribed', {
+      duration_s: recordDurationS,
+      transcript_chars: (res.transcript || '').length,
+      title_chars: title.value.length,
+      desc_chars: description.value.length,
+      rerecord_count: rerecordCount,
+    })
     phase.value = 'review'
   } catch (e) {
+    logVpEvent('voicepost_finish_error', {
+      reason: 'finish_failed',
+      duration_s: recordDurationS,
+    })
     fail('Something went wrong writing your post. Please try again.')
   }
 }
@@ -438,6 +487,10 @@ function togglePlay() {
     el.pause()
     playing.value = false
   } else {
+    if (!played) {
+      played = true
+      logVpEvent('voicepost_played_recording', {})
+    }
     el.play()
     playing.value = true
   }
@@ -446,6 +499,25 @@ function togglePlay() {
 function postIt() {
   // Demo stops here. The real flow would hand the photo, title, description and
   // consent (letThemHear.value) to the normal compose step.
+  const titleEdited = title.value !== originalTitle.value
+  const descEdited = description.value !== originalDescription.value
+  posted = true
+  // The full picture of a completed voice post: did they trust the words (edit
+  // or not), allow playback, listen back, re-record, and how long they mulled it.
+  logVpEvent('voicepost_posted', {
+    consent_play_voice: letThemHear.value,
+    title_edited: titleEdited,
+    desc_edited: descEdited,
+    title_chars: title.value.length,
+    desc_chars: description.value.length,
+    desc_char_delta: description.value.length - originalDescription.value.length,
+    had_photo: hasPhotos.value,
+    played_back: played,
+    rerecord_count: rerecordCount,
+    seconds_on_review: reviewShownAt
+      ? Math.round((Date.now() - reviewShownAt) / 1000)
+      : null,
+  })
   recordConversion('voice')
   phase.value = 'done'
 }
@@ -469,6 +541,8 @@ function fail(msg) {
 
 // Re-record the voice but keep the photo they already added.
 function reRecord() {
+  rerecordCount++
+  logVpEvent('voicepost_rerecord', { count: rerecordCount })
   clearVoice()
   phase.value = 'idle'
 }
@@ -477,6 +551,8 @@ function reRecord() {
 function resetAll() {
   clearVoice()
   attachments.value = []
+  rerecordCount = 0
+  posted = false
   phase.value = 'photo'
 }
 
@@ -487,16 +563,28 @@ function clearVoice() {
   }
   audioBlob.value = null
   playing.value = false
+  played = false
   showRaw.value = false
   letThemHear.value = false
   title.value = ''
   description.value = ''
   rawTranscript.value = ''
+  originalTitle.value = ''
+  originalDescription.value = ''
+  reviewShownAt = 0
   session.value = null
   chunks = []
 }
 
 onBeforeUnmount(() => {
+  // If they reached the review but navigated away without posting, that's a
+  // drop-off worth knowing about.
+  if (phase.value === 'review' && !posted) {
+    logVpEvent('voicepost_review_abandoned', {
+      had_photo: hasPhotos.value,
+      rerecord_count: rerecordCount,
+    })
+  }
   stopStream()
   if (timer) clearInterval(timer)
   if (audioUrl.value) URL.revokeObjectURL(audioUrl.value)

--- a/iznik-nuxt3/pages/voicepost.vue
+++ b/iznik-nuxt3/pages/voicepost.vue
@@ -1,15 +1,43 @@
 <template>
-  <div class="voicepost">
+  <div class="voicepost" :class="{ 'has-sticky-ad': stickyAdRendered }">
     <div class="voicepost__card">
-      <!-- STEP 0 - choose voice or keyboard -->
-      <div v-if="phase === 'choose'" class="voicepost__stage">
-        <h1 class="voicepost__title">How do you want to add your item?</h1>
+      <!-- STEP 1 - PHOTO first (PhotoUploader has its own Skip) -->
+      <div v-if="phase === 'photo'" class="voicepost__stage">
+        <h1 class="voicepost__title">Add a photo</h1>
+        <p class="voicepost__lead">
+          Show your item - a clear photo helps it get snapped up.
+        </p>
+        <div class="photo-wrap">
+          <PhotoUploader
+            v-model="attachments"
+            type="Message"
+            :recognise="false"
+            @skip="advanceFromPhoto"
+          />
+        </div>
+        <b-button
+          v-if="hasPhotos"
+          variant="primary"
+          size="lg"
+          class="w-100"
+          @click="advanceFromPhoto"
+        >
+          Next <v-icon icon="arrow-right" />
+        </b-button>
+      </div>
+
+      <!-- STEP 2 - choose voice or keyboard -->
+      <div v-else-if="phase === 'choose'" class="voicepost__stage">
+        <img
+          v-if="primaryPhoto"
+          :src="primaryPhoto"
+          class="idle-photo"
+          alt="Your item"
+        />
+        <h1 class="voicepost__title">How do you want to describe it?</h1>
         <p class="voicepost__lead">Talk to us, or type it in - whatever's easier.</p>
         <div class="choice-grid">
-          <button
-            class="choice-btn choice-btn--voice"
-            @click="chooseVoice"
-          >
+          <button class="choice-btn choice-btn--voice" @click="chooseVoice">
             <svg viewBox="0 0 24 24" class="choice-btn__icon" aria-hidden="true">
               <path
                 fill="currentColor"
@@ -36,33 +64,7 @@
         </div>
       </div>
 
-      <!-- STEP 1 - PHOTO first -->
-      <div v-else-if="phase === 'photo'" class="voicepost__stage">
-        <h1 class="voicepost__title">Add a photo</h1>
-        <p class="voicepost__lead">
-          Show your item - a clear photo helps it get snapped up. Then you'll
-          describe it out loud.
-        </p>
-        <div class="photo-wrap">
-          <PhotoUploader
-            v-model="attachments"
-            type="Message"
-            :recognise="false"
-            @skip="goToVoice"
-          />
-        </div>
-        <b-button
-          variant="primary"
-          size="lg"
-          class="w-100"
-          @click="goToVoice"
-        >
-          {{ attachments.length ? 'Next: describe it' : 'Skip photo - just talk' }}
-          <v-icon icon="arrow-right" />
-        </b-button>
-      </div>
-
-      <!-- STEP 2 - the big mic button -->
+      <!-- VOICE: the big mic button -->
       <div v-else-if="phase === 'idle'" class="voicepost__stage">
         <img
           v-if="primaryPhoto"
@@ -201,7 +203,7 @@
       <!-- ERROR -->
       <div v-else-if="phase === 'error'" class="voicepost__stage">
         <p class="voicepost__lead voicepost__error">{{ errorMessage }}</p>
-        <b-button variant="primary" size="lg" class="w-100" @click="goToVoice">
+        <b-button variant="primary" size="lg" class="w-100" @click="chooseVoice">
           Try again
         </b-button>
       </div>
@@ -212,22 +214,52 @@
 <script setup>
 import { ref, computed, onBeforeUnmount } from 'vue'
 import { useNuxtApp, useRouter } from '#imports'
+import { useComposeStore } from '~/stores/compose'
+import { useAuthStore } from '~/stores/auth'
+import { useMiscStore } from '~/stores/misc'
 import { useComposeChoice } from '~/composables/useComposeChoice'
 
-// Standalone route. Flow: choose voice or keyboard; for voice, add a photo,
-// describe the item aloud (audio streams to the server as you talk), then review
-// the tidied title/description. Transcription happens once, on stop - see
-// iznik-server-go/voicepost.
+// Standalone route. Flow: add a photo, then choose voice or keyboard. For voice,
+// describe the item aloud (audio streams up while you talk) and review the tidied
+// title/description. The photo lives in the compose store, so choosing "Type it"
+// carries it into the existing typed form. Transcription happens once, on stop.
 
 const { $api } = useNuxtApp()
 const router = useRouter()
-const { recordConversion } = useComposeChoice()
+const composeStore = useComposeStore()
+const authStore = useAuthStore()
+const miscStore = useMiscStore()
+const { recordConversion, recordMethodShown, recordMethodChosen } =
+  useComposeChoice()
 
-const phase = ref('choose') // choose | photo | idle | recording | finishing | review | done | error
+const phase = ref('photo') // photo | choose | idle | recording | finishing | review | done | error
 const errorMessage = ref('')
+const stickyAdRendered = computed(() => miscStore.stickyAdRendered)
 
-// Photo
-const attachments = ref([])
+// Photo, held in the compose store (shared with the typed flow), mirroring
+// pages/give/mobile/photos.vue so either branch continues the same draft.
+function getOrCreateMessageId() {
+  const myid = authStore.user?.id
+  const existing = composeStore.all.filter(
+    (m) =>
+      m.type === 'Offer' &&
+      (!m.savedBy || m.savedBy === myid) &&
+      composeStore.messages[m.id]
+  )
+  const id = existing.length > 0 ? existing[0].id : composeStore.add()
+  composeStore.setType({ id, type: 'Offer' })
+  return id
+}
+const messageId = ref(getOrCreateMessageId())
+const attachments = computed({
+  get() {
+    return composeStore.attachments(messageId.value) || []
+  },
+  set(v) {
+    composeStore.setAttachmentsForMessage(messageId.value, v)
+  },
+})
+const hasPhotos = computed(() => attachments.value.length > 0)
 const primaryPhoto = computed(() => {
   const a = attachments.value?.[0]
   return a ? a.preview || a.path || a.paththumb || null : null
@@ -263,17 +295,20 @@ const formattedElapsed = computed(() => {
   return `${m}:${s.toString().padStart(2, '0')}`
 })
 
+function advanceFromPhoto() {
+  phase.value = 'choose'
+  recordMethodShown()
+}
+
 function chooseVoice() {
-  phase.value = 'photo'
+  recordMethodChosen('voice')
+  phase.value = 'idle'
 }
 
 function chooseType() {
-  // Keyboard branch: hand off to the existing typed compose form.
-  router.push('/give/mobile/photos')
-}
-
-function goToVoice() {
-  phase.value = 'idle'
+  // Keyboard branch: continue in the existing typed form (photo already added).
+  recordMethodChosen('keyboard')
+  router.push('/give/mobile/details')
 }
 
 function pickMimeType() {
@@ -346,7 +381,7 @@ async function startRecording() {
 }
 
 // Serialise chunk uploads so the server appends them to the buffer in order.
-// (The response only carries the session id now - transcription is deferred.)
+// (The response only carries the session id - transcription is deferred.)
 function enqueueChunk(blob) {
   sendQueue = sendQueue.then(async () => {
     try {
@@ -392,7 +427,7 @@ async function finalise() {
     }
     phase.value = 'review'
   } catch (e) {
-    fail("Something went wrong writing your post. Please try again.")
+    fail('Something went wrong writing your post. Please try again.')
   }
 }
 
@@ -470,15 +505,29 @@ onBeforeUnmount(() => {
 
 <style scoped lang="scss">
 @import 'assets/css/_color-vars.scss';
+@import 'assets/css/sticky-banner.scss';
 
 .voicepost {
   min-height: 100vh;
   background: $color-gray--lighter;
   display: flex;
   justify-content: center;
-  // Extra bottom room so a fixed sticky-ad banner never covers the review
-  // buttons or consent toggle on short screens.
-  padding: 1rem 1rem 96px;
+  align-items: flex-start;
+  // Reserve room at the bottom so the fixed sticky-ad banner never covers the
+  // buttons or consent toggle (the banner is 73-273px depending on screen).
+  padding: 1rem 1rem 40px;
+
+  &.has-sticky-ad {
+    padding-bottom: calc(40px + $sticky-banner-height-mobile);
+
+    @media (min-height: $mobile-tall) {
+      padding-bottom: calc(40px + $sticky-banner-height-mobile-tall);
+    }
+
+    @media (min-height: $desktop-tall) {
+      padding-bottom: calc(40px + $sticky-banner-height-desktop-tall);
+    }
+  }
 }
 
 .voicepost__card {
@@ -488,7 +537,6 @@ onBeforeUnmount(() => {
   border-radius: 12px;
   box-shadow: var(--shadow-sm);
   padding: 1.5rem;
-  margin: auto 0;
 }
 
 .voicepost__stage {

--- a/iznik-nuxt3/pages/voicepost.vue
+++ b/iznik-nuxt3/pages/voicepost.vue
@@ -1,13 +1,79 @@
 <template>
   <div class="voicepost">
     <div class="voicepost__card">
-      <!-- IDLE: the big mic button -->
-      <div v-if="phase === 'idle'" class="voicepost__stage">
+      <!-- STEP 0 - choose voice or keyboard -->
+      <div v-if="phase === 'choose'" class="voicepost__stage">
+        <h1 class="voicepost__title">How do you want to add your item?</h1>
+        <p class="voicepost__lead">Talk to us, or type it in - whatever's easier.</p>
+        <div class="choice-grid">
+          <button
+            class="choice-btn choice-btn--voice"
+            @click="chooseVoice"
+          >
+            <svg viewBox="0 0 24 24" class="choice-btn__icon" aria-hidden="true">
+              <path
+                fill="currentColor"
+                d="M12 15a3 3 0 0 0 3-3V6a3 3 0 0 0-6 0v6a3 3 0 0 0 3 3Z"
+              />
+              <path
+                fill="currentColor"
+                d="M18 12a1 1 0 1 0-2 0 4 4 0 0 1-8 0 1 1 0 1 0-2 0 6 6 0 0 0 5 5.91V20H8a1 1 0 1 0 0 2h8a1 1 0 1 0 0-2h-3v-2.09A6 6 0 0 0 18 12Z"
+              />
+            </svg>
+            <span class="choice-btn__label">Say it</span>
+            <span class="choice-btn__sub">Describe it out loud</span>
+          </button>
+          <button class="choice-btn choice-btn--type" @click="chooseType">
+            <svg viewBox="0 0 24 24" class="choice-btn__icon" aria-hidden="true">
+              <path
+                fill="currentColor"
+                d="M4 5h16a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2Zm1 3v2h2V8H5Zm4 0v2h2V8H9Zm4 0v2h2V8h-2Zm4 0v2h2V8h-2ZM5 11v2h2v-2H5Zm4 0v2h2v-2H9Zm4 0v2h2v-2h-2Zm4 0v2h2v-2h-2ZM7 14v2h10v-2H7Z"
+              />
+            </svg>
+            <span class="choice-btn__label">Type it</span>
+            <span class="choice-btn__sub">Fill in the form</span>
+          </button>
+        </div>
+      </div>
+
+      <!-- STEP 1 - PHOTO first -->
+      <div v-else-if="phase === 'photo'" class="voicepost__stage">
+        <h1 class="voicepost__title">Add a photo</h1>
+        <p class="voicepost__lead">
+          Show your item - a clear photo helps it get snapped up. Then you'll
+          describe it out loud.
+        </p>
+        <div class="photo-wrap">
+          <PhotoUploader
+            v-model="attachments"
+            type="Message"
+            :recognise="false"
+            @skip="goToVoice"
+          />
+        </div>
+        <b-button
+          variant="primary"
+          size="lg"
+          class="w-100"
+          @click="goToVoice"
+        >
+          {{ attachments.length ? 'Next: describe it' : 'Skip photo - just talk' }}
+          <v-icon icon="arrow-right" />
+        </b-button>
+      </div>
+
+      <!-- STEP 2 - the big mic button -->
+      <div v-else-if="phase === 'idle'" class="voicepost__stage">
+        <img
+          v-if="primaryPhoto"
+          :src="primaryPhoto"
+          class="idle-photo"
+          alt="Your item"
+        />
         <h1 class="voicepost__title">Tell us about your item</h1>
         <p class="voicepost__lead">
           Tap the microphone and just describe what you're giving away, in your
-          own words. We'll turn it into a post for you - you can tidy it up
-          before anything goes live.
+          own words. We'll write it down for you to check.
         </p>
 
         <button
@@ -29,35 +95,30 @@
         <p class="voicepost__hint">Press to start &middot; press again to stop</p>
       </div>
 
-      <!-- RECORDING: live transcript builds up as they talk -->
+      <!-- RECORDING: no live transcript - we transcribe once you stop -->
       <div v-else-if="phase === 'recording'" class="voicepost__stage">
         <div class="recording-head">
           <span class="recording-dot" />
           <span class="recording-timer">{{ formattedElapsed }}</span>
         </div>
-        <p class="voicepost__lead voicepost__lead--tight">
-          Listening&hellip; describe your item and we'll write it down.
+        <p class="voicepost__lead">
+          Listening&hellip; tell us all about it, then tap Done.
         </p>
 
-        <div class="live-transcript" aria-live="polite">
-          <p v-if="liveTranscript" class="live-transcript__text">
-            {{ liveTranscript }}
-          </p>
-          <p v-else class="live-transcript__placeholder">
-            Your words will appear here&hellip;
-          </p>
+        <div class="equalizer" aria-hidden="true">
+          <span /><span /><span /><span /><span /><span /><span />
         </div>
 
         <button class="stop-btn" @click="stopRecording">
           <span class="stop-btn__square" aria-hidden="true" />
-          Stop &amp; write my post
+          Done
         </button>
       </div>
 
-      <!-- FINISHING: quick tidy-up pass -->
+      <!-- FINISHING: single transcription + tidy-up -->
       <div v-else-if="phase === 'finishing'" class="voicepost__stage">
         <b-spinner class="voicepost__spinner" />
-        <p class="voicepost__lead">Tidying up your words&hellip;</p>
+        <p class="voicepost__lead">Writing down what you said&hellip;</p>
       </div>
 
       <!-- REVIEW: editable result + consent -->
@@ -66,8 +127,16 @@
           Here's your post - have a read
         </h1>
         <p class="voicepost__lead voicepost__lead--tight">
-          We wrote this from what you said. Change anything you like.
+          We tidied up what you said - same words, just neatened. Change anything
+          you like.
         </p>
+
+        <img
+          v-if="primaryPhoto"
+          :src="primaryPhoto"
+          class="review-photo"
+          alt="Your item"
+        />
 
         <label class="field-label" for="vp-title">Item</label>
         <b-form-input id="vp-title" v-model="title" class="field-input" />
@@ -86,15 +155,10 @@
             <span aria-hidden="true">{{ playing ? '❚❚' : '▶' }}</span>
             {{ playing ? 'Pause' : 'Play your recording' }}
           </button>
-          <!-- eslint-disable-next-line vue/no-lone-template -->
           <audio ref="audioEl" :src="audioUrl" @ended="playing = false" />
         </div>
 
-        <button
-          class="raw-toggle"
-          type="button"
-          @click="showRaw = !showRaw"
-        >
+        <button class="raw-toggle" type="button" @click="showRaw = !showRaw">
           {{ showRaw ? 'Hide' : 'Show' }} exactly what you said
         </button>
         <p v-if="showRaw" class="raw-transcript">"{{ rawTranscript }}"</p>
@@ -115,8 +179,8 @@
           <b-button variant="primary" size="lg" class="w-100" @click="postIt">
             Looks good - post it
           </b-button>
-          <button class="restart-link" type="button" @click="reset">
-            Start again
+          <button class="restart-link" type="button" @click="reRecord">
+            Re-record
           </button>
         </div>
       </div>
@@ -124,12 +188,12 @@
       <!-- DONE: demo confirmation -->
       <div v-else-if="phase === 'done'" class="voicepost__stage">
         <div class="done-tick" aria-hidden="true">✓</div>
-        <h1 class="voicepost__title voicepost__title--sm">That's the words done!</h1>
+        <h1 class="voicepost__title voicepost__title--sm">That's your post ready!</h1>
         <p class="voicepost__lead">
-          <strong>{{ title }}</strong> is ready. In the full flow you'd add a
-          photo and choose your community next - this demo stops here.
+          <strong>{{ title }}</strong> is ready to go. In the full flow you'd
+          choose your community next - this demo stops here.
         </p>
-        <b-button variant="primary" size="lg" class="w-100" @click="reset">
+        <b-button variant="primary" size="lg" class="w-100" @click="resetAll">
           Do another
         </b-button>
       </div>
@@ -137,7 +201,7 @@
       <!-- ERROR -->
       <div v-else-if="phase === 'error'" class="voicepost__stage">
         <p class="voicepost__lead voicepost__error">{{ errorMessage }}</p>
-        <b-button variant="primary" size="lg" class="w-100" @click="reset">
+        <b-button variant="primary" size="lg" class="w-100" @click="goToVoice">
           Try again
         </b-button>
       </div>
@@ -147,19 +211,30 @@
 
 <script setup>
 import { ref, computed, onBeforeUnmount } from 'vue'
-import { useNuxtApp } from '#imports'
+import { useNuxtApp, useRouter } from '#imports'
+import { useComposeChoice } from '~/composables/useComposeChoice'
 
-// Standalone demo route: record your item description, stream it to the server
-// for live transcription (Groq), then review the tidied title/description.
+// Standalone route. Flow: choose voice or keyboard; for voice, add a photo,
+// describe the item aloud (audio streams to the server as you talk), then review
+// the tidied title/description. Transcription happens once, on stop - see
+// iznik-server-go/voicepost.
 
 const { $api } = useNuxtApp()
+const router = useRouter()
+const { recordConversion } = useComposeChoice()
 
-const phase = ref('idle') // idle | recording | finishing | review | done | error
+const phase = ref('choose') // choose | photo | idle | recording | finishing | review | done | error
 const errorMessage = ref('')
+
+// Photo
+const attachments = ref([])
+const primaryPhoto = computed(() => {
+  const a = attachments.value?.[0]
+  return a ? a.preview || a.path || a.paththumb || null : null
+})
 
 // Recording state
 const session = ref(null)
-const liveTranscript = ref('')
 const elapsed = ref(0)
 let mediaRecorder = null
 let stream = null
@@ -188,6 +263,19 @@ const formattedElapsed = computed(() => {
   return `${m}:${s.toString().padStart(2, '0')}`
 })
 
+function chooseVoice() {
+  phase.value = 'photo'
+}
+
+function chooseType() {
+  // Keyboard branch: hand off to the existing typed compose form.
+  router.push('/give/mobile/photos')
+}
+
+function goToVoice() {
+  phase.value = 'idle'
+}
+
 function pickMimeType() {
   const candidates = [
     'audio/webm;codecs=opus',
@@ -204,7 +292,6 @@ function pickMimeType() {
 
 async function startRecording() {
   errorMessage.value = ''
-  liveTranscript.value = ''
   session.value = null
   chunks = []
   elapsed.value = 0
@@ -222,9 +309,7 @@ async function startRecording() {
     stream = await navigator.mediaDevices.getUserMedia({ audio: true })
   } catch (e) {
     if (e && (e.name === 'NotAllowedError' || e.name === 'SecurityError')) {
-      fail(
-        'We need permission to use your microphone. Allow it and try again.'
-      )
+      fail('We need permission to use your microphone. Allow it and try again.')
     } else if (e && e.name === 'NotFoundError') {
       fail("We couldn't find a microphone on your device.")
     } else {
@@ -237,7 +322,6 @@ async function startRecording() {
   try {
     mediaRecorder = new MediaRecorder(stream, { mimeType })
   } catch (e) {
-    // Some browsers reject an explicit mimeType — fall back to the default.
     mediaRecorder = new MediaRecorder(stream)
     mimeType = mediaRecorder.mimeType || 'audio/webm'
   }
@@ -250,8 +334,9 @@ async function startRecording() {
   }
   mediaRecorder.onstop = finalise
 
-  // Emit a chunk every few seconds so transcription keeps pace with speech.
-  mediaRecorder.start(4000)
+  // Emit a chunk every few seconds so the audio streams up while they talk and
+  // there's almost nothing left to upload when they stop.
+  mediaRecorder.start(3000)
   phase.value = 'recording'
 
   timer = setInterval(() => {
@@ -260,15 +345,16 @@ async function startRecording() {
   }, 1000)
 }
 
-// Serialise chunk uploads so the server appends them in order.
+// Serialise chunk uploads so the server appends them to the buffer in order.
+// (The response only carries the session id now - transcription is deferred.)
 function enqueueChunk(blob) {
   sendQueue = sendQueue.then(async () => {
     try {
       const res = await $api.voicepost.chunk(blob, session.value)
       if (res?.session) session.value = res.session
-      if (res?.transcript) liveTranscript.value = res.transcript
     } catch (e) {
-      // Non-fatal: a partial pass may fail; the final pass will catch up.
+      // Non-fatal: a dropped chunk just means slightly less audio; the final
+      // pass transcribes whatever made it to the buffer.
     }
   })
   return sendQueue
@@ -287,7 +373,7 @@ function stopRecording() {
 
 async function finalise() {
   phase.value = 'finishing'
-  await sendQueue // ensure every chunk, including the last, has been sent
+  await sendQueue // ensure every chunk, including the last, is in the buffer
 
   if (!session.value) {
     fail("We didn't catch that recording - please try again.")
@@ -323,8 +409,9 @@ function togglePlay() {
 }
 
 function postIt() {
-  // Demo stops here — the real flow would hand title/description/consent to the
-  // normal compose step (photo + community). letThemHear.value carries consent.
+  // Demo stops here. The real flow would hand the photo, title, description and
+  // consent (letThemHear.value) to the normal compose step.
+  recordConversion('voice')
   phase.value = 'done'
 }
 
@@ -345,7 +432,20 @@ function fail(msg) {
   }
 }
 
-function reset() {
+// Re-record the voice but keep the photo they already added.
+function reRecord() {
+  clearVoice()
+  phase.value = 'idle'
+}
+
+// Full reset back to the start (new item).
+function resetAll() {
+  clearVoice()
+  attachments.value = []
+  phase.value = 'photo'
+}
+
+function clearVoice() {
   if (audioUrl.value) {
     URL.revokeObjectURL(audioUrl.value)
     audioUrl.value = null
@@ -357,10 +457,8 @@ function reset() {
   title.value = ''
   description.value = ''
   rawTranscript.value = ''
-  liveTranscript.value = ''
   session.value = null
   chunks = []
-  phase.value = 'idle'
 }
 
 onBeforeUnmount(() => {
@@ -440,6 +538,70 @@ onBeforeUnmount(() => {
   color: $color-red;
 }
 
+.photo-wrap {
+  width: 100%;
+  margin: 0.5rem 0;
+}
+
+/* Voice-vs-keyboard choice */
+.choice-grid {
+  display: flex;
+  gap: 1rem;
+  width: 100%;
+  margin: 1.25rem 0 0.5rem;
+}
+
+.choice-btn {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 1.6rem 0.75rem;
+  border-radius: 14px;
+  border: 2px solid $color-green--darker;
+  background: $color-white;
+  color: $color-green--darker;
+  cursor: pointer;
+  transition: transform 0.12s ease;
+
+  &:active {
+    transform: scale(0.97);
+  }
+
+  &--voice {
+    background: $color-green--darker;
+    color: $color-white;
+  }
+
+  &__icon {
+    width: 46px;
+    height: 46px;
+  }
+
+  &__label {
+    font-size: 1.15rem;
+    font-weight: 700;
+  }
+
+  &__sub {
+    font-size: 0.8rem;
+    opacity: 0.85;
+  }
+}
+
+.idle-photo,
+.review-photo {
+  width: 100%;
+  max-height: 220px;
+  object-fit: cover;
+  border-radius: 10px;
+}
+
+.idle-photo {
+  max-height: 160px;
+}
+
 /* Big mic button */
 .mic-btn {
   margin: 0.5rem 0;
@@ -507,25 +669,53 @@ onBeforeUnmount(() => {
   }
 }
 
-.live-transcript {
-  width: 100%;
-  min-height: 120px;
-  background: $color-gray--lighter;
-  border-radius: 10px;
-  padding: 1rem;
-  text-align: left;
+/* Listening equalizer - purely decorative, shows we're recording */
+.equalizer {
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  gap: 6px;
+  height: 72px;
+  margin: 0.5rem 0 1rem;
 
-  &__text {
-    margin: 0;
-    font-size: 1.05rem;
-    line-height: 1.6;
-    color: $color-black;
+  span {
+    display: block;
+    width: 8px;
+    background: $color-green--darker;
+    border-radius: 4px;
+    animation: eq 1s ease-in-out infinite;
   }
 
-  &__placeholder {
-    margin: 0;
-    color: $color-gray--normal;
-    font-style: italic;
+  span:nth-child(1) {
+    animation-delay: -0.9s;
+  }
+  span:nth-child(2) {
+    animation-delay: -0.7s;
+  }
+  span:nth-child(3) {
+    animation-delay: -0.5s;
+  }
+  span:nth-child(4) {
+    animation-delay: -0.3s;
+  }
+  span:nth-child(5) {
+    animation-delay: -0.5s;
+  }
+  span:nth-child(6) {
+    animation-delay: -0.7s;
+  }
+  span:nth-child(7) {
+    animation-delay: -0.9s;
+  }
+}
+
+@keyframes eq {
+  0%,
+  100% {
+    height: 16px;
+  }
+  50% {
+    height: 64px;
   }
 }
 
@@ -538,7 +728,7 @@ onBeforeUnmount(() => {
   color: $color-white;
   border: none;
   border-radius: 40px;
-  padding: 0.8rem 1.5rem;
+  padding: 0.8rem 1.6rem;
   font-size: 1.05rem;
   font-weight: 600;
   cursor: pointer;

--- a/iznik-nuxt3/pages/voicepost.vue
+++ b/iznik-nuxt3/pages/voicepost.vue
@@ -1,0 +1,638 @@
+<template>
+  <div class="voicepost">
+    <div class="voicepost__card">
+      <!-- IDLE: the big mic button -->
+      <div v-if="phase === 'idle'" class="voicepost__stage">
+        <h1 class="voicepost__title">Tell us about your item</h1>
+        <p class="voicepost__lead">
+          Tap the microphone and just describe what you're giving away, in your
+          own words. We'll turn it into a post for you - you can tidy it up
+          before anything goes live.
+        </p>
+
+        <button
+          class="mic-btn"
+          aria-label="Start recording"
+          @click="startRecording"
+        >
+          <svg viewBox="0 0 24 24" class="mic-btn__icon" aria-hidden="true">
+            <path
+              fill="currentColor"
+              d="M12 15a3 3 0 0 0 3-3V6a3 3 0 0 0-6 0v6a3 3 0 0 0 3 3Z"
+            />
+            <path
+              fill="currentColor"
+              d="M18 12a1 1 0 1 0-2 0 4 4 0 0 1-8 0 1 1 0 1 0-2 0 6 6 0 0 0 5 5.91V20H8a1 1 0 1 0 0 2h8a1 1 0 1 0 0-2h-3v-2.09A6 6 0 0 0 18 12Z"
+            />
+          </svg>
+        </button>
+        <p class="voicepost__hint">Press to start &middot; press again to stop</p>
+      </div>
+
+      <!-- RECORDING: live transcript builds up as they talk -->
+      <div v-else-if="phase === 'recording'" class="voicepost__stage">
+        <div class="recording-head">
+          <span class="recording-dot" />
+          <span class="recording-timer">{{ formattedElapsed }}</span>
+        </div>
+        <p class="voicepost__lead voicepost__lead--tight">
+          Listening&hellip; describe your item and we'll write it down.
+        </p>
+
+        <div class="live-transcript" aria-live="polite">
+          <p v-if="liveTranscript" class="live-transcript__text">
+            {{ liveTranscript }}
+          </p>
+          <p v-else class="live-transcript__placeholder">
+            Your words will appear here&hellip;
+          </p>
+        </div>
+
+        <button class="stop-btn" @click="stopRecording">
+          <span class="stop-btn__square" aria-hidden="true" />
+          Stop &amp; write my post
+        </button>
+      </div>
+
+      <!-- FINISHING: quick tidy-up pass -->
+      <div v-else-if="phase === 'finishing'" class="voicepost__stage">
+        <b-spinner class="voicepost__spinner" />
+        <p class="voicepost__lead">Tidying up your words&hellip;</p>
+      </div>
+
+      <!-- REVIEW: editable result + consent -->
+      <div v-else-if="phase === 'review'" class="voicepost__review">
+        <h1 class="voicepost__title voicepost__title--sm">
+          Here's your post - have a read
+        </h1>
+        <p class="voicepost__lead voicepost__lead--tight">
+          We wrote this from what you said. Change anything you like.
+        </p>
+
+        <label class="field-label" for="vp-title">Item</label>
+        <b-form-input id="vp-title" v-model="title" class="field-input" />
+
+        <label class="field-label" for="vp-desc">Description</label>
+        <b-form-textarea
+          id="vp-desc"
+          v-model="description"
+          rows="5"
+          max-rows="12"
+          class="field-input"
+        />
+
+        <div v-if="audioUrl" class="playback">
+          <button class="playback__btn" @click="togglePlay">
+            <span aria-hidden="true">{{ playing ? '❚❚' : '▶' }}</span>
+            {{ playing ? 'Pause' : 'Play your recording' }}
+          </button>
+          <!-- eslint-disable-next-line vue/no-lone-template -->
+          <audio ref="audioEl" :src="audioUrl" @ended="playing = false" />
+        </div>
+
+        <button
+          class="raw-toggle"
+          type="button"
+          @click="showRaw = !showRaw"
+        >
+          {{ showRaw ? 'Hide' : 'Show' }} exactly what you said
+        </button>
+        <p v-if="showRaw" class="raw-transcript">"{{ rawTranscript }}"</p>
+
+        <div class="consent">
+          <b-form-checkbox v-model="letThemHear">
+            Let the person collecting hear my voice description
+          </b-form-checkbox>
+          <p class="consent__help">
+            Optional. Your recording is kept for up to 90 days and then deleted -
+            see our
+            <nuxt-link no-prefetch to="/privacy">privacy policy</nuxt-link>. We'll
+            only ever play it to someone if you tick this.
+          </p>
+        </div>
+
+        <div class="review-actions">
+          <b-button variant="primary" size="lg" class="w-100" @click="postIt">
+            Looks good - post it
+          </b-button>
+          <button class="restart-link" type="button" @click="reset">
+            Start again
+          </button>
+        </div>
+      </div>
+
+      <!-- DONE: demo confirmation -->
+      <div v-else-if="phase === 'done'" class="voicepost__stage">
+        <div class="done-tick" aria-hidden="true">✓</div>
+        <h1 class="voicepost__title voicepost__title--sm">That's the words done!</h1>
+        <p class="voicepost__lead">
+          <strong>{{ title }}</strong> is ready. In the full flow you'd add a
+          photo and choose your community next - this demo stops here.
+        </p>
+        <b-button variant="primary" size="lg" class="w-100" @click="reset">
+          Do another
+        </b-button>
+      </div>
+
+      <!-- ERROR -->
+      <div v-else-if="phase === 'error'" class="voicepost__stage">
+        <p class="voicepost__lead voicepost__error">{{ errorMessage }}</p>
+        <b-button variant="primary" size="lg" class="w-100" @click="reset">
+          Try again
+        </b-button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onBeforeUnmount } from 'vue'
+import { useNuxtApp } from '#imports'
+
+// Standalone demo route: record your item description, stream it to the server
+// for live transcription (Groq), then review the tidied title/description.
+
+const { $api } = useNuxtApp()
+
+const phase = ref('idle') // idle | recording | finishing | review | done | error
+const errorMessage = ref('')
+
+// Recording state
+const session = ref(null)
+const liveTranscript = ref('')
+const elapsed = ref(0)
+let mediaRecorder = null
+let stream = null
+let chunks = []
+let mimeType = 'audio/webm'
+let sendQueue = Promise.resolve()
+let timer = null
+
+// Cap recordings so a forgotten mic can't stream forever.
+const MAX_SECONDS = 120
+
+// Review state
+const title = ref('')
+const description = ref('')
+const rawTranscript = ref('')
+const showRaw = ref(false)
+const letThemHear = ref(false)
+const audioBlob = ref(null)
+const audioUrl = ref(null)
+const audioEl = ref(null)
+const playing = ref(false)
+
+const formattedElapsed = computed(() => {
+  const m = Math.floor(elapsed.value / 60)
+  const s = elapsed.value % 60
+  return `${m}:${s.toString().padStart(2, '0')}`
+})
+
+function pickMimeType() {
+  const candidates = [
+    'audio/webm;codecs=opus',
+    'audio/webm',
+    'audio/mp4', // Safari
+    'audio/ogg;codecs=opus',
+  ]
+  if (typeof MediaRecorder === 'undefined') return ''
+  for (const c of candidates) {
+    if (MediaRecorder.isTypeSupported(c)) return c
+  }
+  return ''
+}
+
+async function startRecording() {
+  errorMessage.value = ''
+  liveTranscript.value = ''
+  session.value = null
+  chunks = []
+  elapsed.value = 0
+
+  if (
+    typeof navigator === 'undefined' ||
+    !navigator.mediaDevices ||
+    typeof MediaRecorder === 'undefined'
+  ) {
+    fail("Your browser can't record audio. Try a recent Chrome, Edge or Safari.")
+    return
+  }
+
+  try {
+    stream = await navigator.mediaDevices.getUserMedia({ audio: true })
+  } catch (e) {
+    if (e && (e.name === 'NotAllowedError' || e.name === 'SecurityError')) {
+      fail(
+        'We need permission to use your microphone. Allow it and try again.'
+      )
+    } else if (e && e.name === 'NotFoundError') {
+      fail("We couldn't find a microphone on your device.")
+    } else {
+      fail("We couldn't start recording. Please try again.")
+    }
+    return
+  }
+
+  mimeType = pickMimeType() || 'audio/webm'
+  try {
+    mediaRecorder = new MediaRecorder(stream, { mimeType })
+  } catch (e) {
+    // Some browsers reject an explicit mimeType — fall back to the default.
+    mediaRecorder = new MediaRecorder(stream)
+    mimeType = mediaRecorder.mimeType || 'audio/webm'
+  }
+
+  mediaRecorder.ondataavailable = (e) => {
+    if (e.data && e.data.size > 0) {
+      chunks.push(e.data)
+      enqueueChunk(e.data)
+    }
+  }
+  mediaRecorder.onstop = finalise
+
+  // Emit a chunk every few seconds so transcription keeps pace with speech.
+  mediaRecorder.start(4000)
+  phase.value = 'recording'
+
+  timer = setInterval(() => {
+    elapsed.value += 1
+    if (elapsed.value >= MAX_SECONDS) stopRecording()
+  }, 1000)
+}
+
+// Serialise chunk uploads so the server appends them in order.
+function enqueueChunk(blob) {
+  sendQueue = sendQueue.then(async () => {
+    try {
+      const res = await $api.voicepost.chunk(blob, session.value)
+      if (res?.session) session.value = res.session
+      if (res?.transcript) liveTranscript.value = res.transcript
+    } catch (e) {
+      // Non-fatal: a partial pass may fail; the final pass will catch up.
+    }
+  })
+  return sendQueue
+}
+
+function stopRecording() {
+  if (timer) {
+    clearInterval(timer)
+    timer = null
+  }
+  if (mediaRecorder && mediaRecorder.state !== 'inactive') {
+    mediaRecorder.stop() // fires ondataavailable (final chunk) then onstop
+  }
+  stopStream()
+}
+
+async function finalise() {
+  phase.value = 'finishing'
+  await sendQueue // ensure every chunk, including the last, has been sent
+
+  if (!session.value) {
+    fail("We didn't catch that recording - please try again.")
+    return
+  }
+
+  try {
+    const res = await $api.voicepost.finish(session.value)
+    title.value = res.title || ''
+    description.value = res.description || ''
+    rawTranscript.value = res.transcript || ''
+
+    if (chunks.length) {
+      audioBlob.value = new Blob(chunks, { type: mimeType })
+      audioUrl.value = URL.createObjectURL(audioBlob.value)
+    }
+    phase.value = 'review'
+  } catch (e) {
+    fail("Something went wrong writing your post. Please try again.")
+  }
+}
+
+function togglePlay() {
+  const el = audioEl.value
+  if (!el) return
+  if (playing.value) {
+    el.pause()
+    playing.value = false
+  } else {
+    el.play()
+    playing.value = true
+  }
+}
+
+function postIt() {
+  // Demo stops here — the real flow would hand title/description/consent to the
+  // normal compose step (photo + community). letThemHear.value carries consent.
+  phase.value = 'done'
+}
+
+function stopStream() {
+  if (stream) {
+    stream.getTracks().forEach((t) => t.stop())
+    stream = null
+  }
+}
+
+function fail(msg) {
+  errorMessage.value = msg
+  phase.value = 'error'
+  stopStream()
+  if (timer) {
+    clearInterval(timer)
+    timer = null
+  }
+}
+
+function reset() {
+  if (audioUrl.value) {
+    URL.revokeObjectURL(audioUrl.value)
+    audioUrl.value = null
+  }
+  audioBlob.value = null
+  playing.value = false
+  showRaw.value = false
+  letThemHear.value = false
+  title.value = ''
+  description.value = ''
+  rawTranscript.value = ''
+  liveTranscript.value = ''
+  session.value = null
+  chunks = []
+  phase.value = 'idle'
+}
+
+onBeforeUnmount(() => {
+  stopStream()
+  if (timer) clearInterval(timer)
+  if (audioUrl.value) URL.revokeObjectURL(audioUrl.value)
+})
+</script>
+
+<style scoped lang="scss">
+@import 'assets/css/_color-vars.scss';
+
+.voicepost {
+  min-height: 100vh;
+  background: $color-gray--lighter;
+  display: flex;
+  justify-content: center;
+  // Extra bottom room so a fixed sticky-ad banner never covers the review
+  // buttons or consent toggle on short screens.
+  padding: 1rem 1rem 96px;
+}
+
+.voicepost__card {
+  width: 100%;
+  max-width: 560px;
+  background: $color-white;
+  border-radius: 12px;
+  box-shadow: var(--shadow-sm);
+  padding: 1.5rem;
+  margin: auto 0;
+}
+
+.voicepost__stage {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 0.75rem;
+  padding: 1rem 0;
+}
+
+.voicepost__title {
+  font-size: 1.6rem;
+  font-weight: 700;
+  color: $color-green--darker;
+  margin: 0;
+
+  &--sm {
+    font-size: 1.35rem;
+  }
+}
+
+.voicepost__lead {
+  font-size: 1rem;
+  line-height: 1.55;
+  color: $color-gray--darker;
+  margin: 0;
+
+  &--tight {
+    font-size: 0.95rem;
+  }
+}
+
+.voicepost__hint {
+  font-size: 0.85rem;
+  color: $color-gray--normal;
+  margin: 0;
+}
+
+.voicepost__spinner {
+  color: $color-green--darker;
+  width: 2.5rem;
+  height: 2.5rem;
+}
+
+.voicepost__error {
+  color: $color-red;
+}
+
+/* Big mic button */
+.mic-btn {
+  margin: 0.5rem 0;
+  width: 132px;
+  height: 132px;
+  border-radius: 50%;
+  border: none;
+  background: $color-green--darker;
+  color: $color-white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  box-shadow: 0 8px 24px rgba(13, 51, 17, 0.35);
+  transition: transform 0.12s ease, box-shadow 0.12s ease;
+
+  &:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 12px 28px rgba(13, 51, 17, 0.4);
+  }
+
+  &:active {
+    transform: scale(0.96);
+  }
+
+  &__icon {
+    width: 60px;
+    height: 60px;
+  }
+}
+
+/* Recording */
+.recording-head {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.recording-dot {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: $color-red;
+  animation: pulse 1.2s infinite;
+}
+
+.recording-timer {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  color: $color-gray--darker;
+}
+
+@keyframes pulse {
+  0% {
+    opacity: 1;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 0.4;
+    transform: scale(0.8);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.live-transcript {
+  width: 100%;
+  min-height: 120px;
+  background: $color-gray--lighter;
+  border-radius: 10px;
+  padding: 1rem;
+  text-align: left;
+
+  &__text {
+    margin: 0;
+    font-size: 1.05rem;
+    line-height: 1.6;
+    color: $color-black;
+  }
+
+  &__placeholder {
+    margin: 0;
+    color: $color-gray--normal;
+    font-style: italic;
+  }
+}
+
+.stop-btn {
+  margin-top: 0.5rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  background: $color-red;
+  color: $color-white;
+  border: none;
+  border-radius: 40px;
+  padding: 0.8rem 1.5rem;
+  font-size: 1.05rem;
+  font-weight: 600;
+  cursor: pointer;
+
+  &__square {
+    width: 14px;
+    height: 14px;
+    background: $color-white;
+    border-radius: 2px;
+  }
+}
+
+/* Review */
+.voicepost__review {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.field-label {
+  font-weight: 600;
+  color: $color-gray--darker;
+  margin: 0.75rem 0 0.15rem;
+}
+
+.field-input {
+  font-size: 1rem;
+}
+
+.playback {
+  margin: 0.75rem 0 0.25rem;
+}
+
+.playback__btn,
+.raw-toggle,
+.restart-link {
+  background: none;
+  border: none;
+  color: $color-green--darker;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0.35rem 0;
+}
+
+.playback__btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.raw-toggle {
+  align-self: flex-start;
+  font-size: 0.9rem;
+}
+
+.raw-transcript {
+  font-style: italic;
+  color: $color-gray--normal;
+  background: $color-gray--lighter;
+  border-radius: 8px;
+  padding: 0.75rem;
+  margin: 0.25rem 0;
+}
+
+.consent {
+  margin: 0.75rem 0;
+  background: $color-gray--lighter;
+  border-radius: 10px;
+  padding: 0.9rem;
+
+  &__help {
+    font-size: 0.85rem;
+    color: $color-gray--normal;
+    margin: 0.4rem 0 0;
+  }
+}
+
+.review-actions {
+  margin-top: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.done-tick {
+  width: 72px;
+  height: 72px;
+  border-radius: 50%;
+  background: $color-green--darker;
+  color: $color-white;
+  font-size: 2.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+</style>

--- a/iznik-server-go/router/routes.go
+++ b/iznik-server-go/router/routes.go
@@ -77,6 +77,7 @@ import (
 	"github.com/freegle/iznik-server-go/user"
 	"github.com/freegle/iznik-server-go/userdump"
 	"github.com/freegle/iznik-server-go/visualise"
+	"github.com/freegle/iznik-server-go/voicepost"
 	"github.com/freegle/iznik-server-go/volunteering"
 	"github.com/gofiber/fiber/v2"
 )
@@ -730,6 +731,21 @@ func SetupRoutes(app *fiber.App) {
 		// @Security BearerAuth
 		// @Success 200 {object} map[string]interface{}
 		rg.Post("/image", image.Post)
+
+		// Voice posting: stream audio chunks in while recording, then finalise.
+		// @Router /voicepost/chunk [post]
+		// @Summary Stream a chunk of voice-post audio; returns the transcript so far
+		// @Tags VoicePost
+		// @Accept octet-stream
+		// @Produce json
+		// @Success 200 {object} map[string]interface{}
+		rg.Post("/voicepost/chunk", voicepost.Chunk)
+		// @Router /voicepost/finish [post]
+		// @Summary Finalise a voice post: full transcript plus tidied title/description
+		// @Tags VoicePost
+		// @Produce json
+		// @Success 200 {object} voicepost.FinishResult
+		rg.Post("/voicepost/finish", voicepost.Finish)
 
 		// Jobs
 		// @Router /job [get]

--- a/iznik-server-go/voicepost/voicepost.go
+++ b/iznik-server-go/voicepost/voicepost.go
@@ -1,28 +1,26 @@
 // Package voicepost implements a voice-first way to compose a Freegle post.
 //
 // The browser records the user describing their item and streams the audio to
-// the server in small chunks *while they are still talking* (rather than one big
-// upload at the end). As each chunk arrives the server re-runs Groq Whisper over
-// the audio-so-far and hands the growing transcript back, so the words build up
-// on screen with only a few seconds of latency. When the user stops, a final
-// transcription plus a quick Groq chat pass tidies the raw transcript into a
-// short item title and a friendly description that keeps the person's own words
-// and charm.
+// the server in small chunks *while they are still talking*, so by the time they
+// stop the recording is already buffered on the server and there is no big upload
+// to wait for. Only then - once - do we transcribe the complete recording with
+// Groq Whisper and run a quick Groq copy-edit that punctuates and lightly tidies
+// their words into a title and description without rewriting them.
 //
 // Design decisions (see docs spec):
-//   - Groq is used for BOTH transcription (whisper-large-v3-turbo) and the tidy-up
-//     (a small fast llama model). One GROQ_API_KEY. Groq turbo transcribes faster
-//     than real time and costs ~$0.0006/min, so re-transcribing the accumulated
-//     audio on every chunk is still fractions of a penny per post.
+//   - Groq for BOTH transcription (whisper-large-v3-turbo) and the copy-edit (a
+//     small fast llama model). One GROQ_API_KEY.
 //   - Transport is plain chunked HTTP, not a WebSocket to a real-time STT engine.
-//     "Human latency, a few seconds" is the budget, so we don't need (or want to
-//     pay for) sub-second streaming recognisers like Deepgram.
-//   - The streamed audio is written to a temp file and kept only briefly (the
-//     in-flight compose buffer is pruned within the hour). The transcript is the
-//     durable artifact. Per the privacy policy, a retained voice recording is
-//     kept for at most 90 days (voiceRetentionPolicyDays) and then deleted; this
-//     prototype does not yet persist audio beyond the compose session, so that
-//     ceiling is a forward-looking commitment rather than something enforced here.
+//     We stream to hide upload latency, not to get sub-second live captions, so a
+//     few seconds of "human latency" after the user stops is the budget.
+//   - Transcription happens ONCE, on stop, over the whole buffered recording. So
+//     there are no per-chunk re-transcription costs, no transcript-ordering races,
+//     and no chunk-boundary word splitting (a word spoken across a boundary is
+//     wholly present in the concatenated file).
+//   - The buffered audio is a temp file kept only briefly then pruned; the
+//     transcript is the durable artifact. Per the privacy policy a *retained*
+//     recording would be kept at most 90 days (voiceRetentionPolicyDays); this
+//     prototype does not persist audio beyond the compose session.
 package voicepost
 
 import (
@@ -54,21 +52,13 @@ const sessionRetention = 30 * time.Minute
 // here today.
 const voiceRetentionPolicyDays = 90
 
-// Re-transcribe at most this often per session, so a burst of chunks can't queue
-// up a pile of Groq calls. Chunks normally arrive every few seconds anyway.
-const minTranscribeInterval = 2500 * time.Millisecond
-
-// session holds the server-side state for one in-progress voice post. Audio is
-// appended to a temp file; the latest transcript is cached so chunk responses are
-// instant even while a Groq call is in flight.
+// session holds the server-side buffer for one in-progress voice post: audio
+// chunks are appended to a temp file as they stream in.
 type session struct {
-	mu             sync.Mutex
-	id             string
-	path           string
-	createdAt      time.Time
-	transcript     string
-	lastTranscribe time.Time
-	transcribing   bool
+	mu        sync.Mutex
+	id        string
+	path      string
+	createdAt time.Time
 }
 
 var (
@@ -140,17 +130,16 @@ func newSession() *session {
 // The audio chunk is the raw request body (application/octet-stream). Query params:
 //   - session: the session id; omit on the first chunk and the server creates one.
 //   - seq:     client-side sequence number (informational; chunks are appended in
-//     arrival order — the client sends them serially so order is preserved).
+//     arrival order - the client sends them serially so order is preserved).
 //
-// The response is JSON: {"session": "...", "transcript": "..."} where transcript
-// is the best transcript we have so far (it grows and sharpens as more audio
-// arrives). Partial-transcription failures are swallowed — we just return the last
-// good transcript and try again on the next chunk.
+// We do NOT transcribe here. Streaming exists purely to get the audio onto the
+// server while the user is still talking, so there is nothing to upload when they
+// stop. The response is JSON: {"session": "..."}.
 //
 // No authentication: like image upload, this happens during the give/post flow
 // before the user has necessarily logged in. The audio is transient and unlinked.
 //
-// @Summary Stream a chunk of voice-post audio and get the transcript so far
+// @Summary Stream a chunk of voice-post audio into the server buffer
 // @Tags VoicePost
 // @Accept octet-stream
 // @Produce json
@@ -170,7 +159,7 @@ func Chunk(c *fiber.Ctx) error {
 	} else {
 		s = getSession(sid)
 		if s == nil {
-			// Session expired or unknown — start a fresh one so the client can recover.
+			// Session expired or unknown - start a fresh one so the client can recover.
 			s = newSession()
 		}
 	}
@@ -186,36 +175,7 @@ func Chunk(c *fiber.Ctx) error {
 		s.mu.Unlock()
 	}
 
-	// Kick off a transcription of the audio-so-far if we're not already doing one
-	// and enough time has passed. This runs synchronously for a simple, ordered
-	// response, but is cheap (Groq turbo is sub-second for short clips).
-	s.mu.Lock()
-	due := !s.transcribing && time.Since(s.lastTranscribe) >= minTranscribeInterval
-	if due {
-		s.transcribing = true
-	}
-	path := s.path
-	s.mu.Unlock()
-
-	if due {
-		text, err := transcribe(path)
-		s.mu.Lock()
-		s.transcribing = false
-		s.lastTranscribe = time.Now()
-		if err == nil && strings.TrimSpace(text) != "" {
-			s.transcript = text
-		}
-		s.mu.Unlock()
-	}
-
-	s.mu.Lock()
-	transcript := s.transcript
-	s.mu.Unlock()
-
-	return c.JSON(fiber.Map{
-		"session":    s.id,
-		"transcript": transcript,
-	})
+	return c.JSON(fiber.Map{"session": s.id})
 }
 
 // FinishResult is the payload returned when a voice post is finalised.
@@ -227,12 +187,12 @@ type FinishResult struct {
 }
 
 // Finish handles POST /api/voicepost/finish. The client calls this once the user
-// has stopped talking and the final chunk has been sent. We do one last full
-// transcription (so the complete audio is captured, not just up to the last
-// partial pass), then a Groq chat pass to tidy the transcript into a title and
-// description. The audio file is left in place to be pruned later.
+// has stopped talking and the final chunk has been sent. We transcribe the whole
+// buffered recording once, then run a Groq copy-edit to punctuate and lightly
+// tidy the transcript into a title and description. The audio file is left in
+// place to be pruned later.
 //
-// @Summary Finalise a voice post: full transcript + tidied title/description
+// @Summary Finalise a voice post: transcribe once, then tidy into title/description
 // @Tags VoicePost
 // @Accept json
 // @Produce json
@@ -255,22 +215,12 @@ func Finish(c *fiber.Ctx) error {
 
 	s.mu.Lock()
 	path := s.path
-	cached := s.transcript
 	s.mu.Unlock()
 
-	// Final, authoritative transcription of the whole file.
 	transcript, err := transcribe(path)
 	if err != nil || strings.TrimSpace(transcript) == "" {
-		// Fall back to the best partial we streamed if the final pass hiccups.
-		transcript = cached
+		return fiber.NewError(fiber.StatusBadRequest, "We couldn't hear anything in that recording - please try again.")
 	}
-	if strings.TrimSpace(transcript) == "" {
-		return fiber.NewError(fiber.StatusBadRequest, "We couldn't hear anything in that recording — please try again.")
-	}
-
-	s.mu.Lock()
-	s.transcript = transcript
-	s.mu.Unlock()
 
 	title, description := summarise(transcript)
 
@@ -301,9 +251,8 @@ func summariseModel() string {
 	return "llama-3.1-8b-instant"
 }
 
-// transcribe sends the audio file to Groq's Whisper endpoint and returns the text.
-// A truncated (mid-recording) webm file decodes fine up to its last complete
-// cluster, so this works on the growing partial file as well as the final one.
+// transcribe sends the buffered audio file to Groq's Whisper endpoint and returns
+// the text. It is a package var so tests can stub it.
 var transcribe = func(path string) (string, error) {
 	key := os.Getenv("GROQ_API_KEY")
 	if key == "" {
@@ -360,8 +309,8 @@ var transcribe = func(path string) (string, error) {
 	return strings.TrimSpace(out.Text), nil
 }
 
-// summarise turns a raw spoken transcript into a short item title and a friendly
-// description, preserving the poster's own words and charm. Any failure falls
+// summarise lightly copy-edits a raw spoken transcript into a short item title
+// and a tidied description, keeping the poster's own words. Any failure falls
 // back to using the transcript itself so the user is never blocked.
 var summarise = func(transcript string) (string, string) {
 	key := os.Getenv("GROQ_API_KEY")
@@ -369,15 +318,17 @@ var summarise = func(transcript string) (string, string) {
 		return fallbackTitle(transcript), transcript
 	}
 
-	system := "You help someone give away an item for free on Freegle, a UK reuse community. " +
-		"They spoke a description of their item out loud and it was transcribed. " +
-		"Turn the transcript into a short catchy TITLE (just a few words naming the item, no 'OFFER:' prefix) " +
-		"and a warm, friendly DESCRIPTION for other freeglers to read. " +
-		"Keep the person's own words, voice and charm. Lightly tidy filler words, false starts and obvious " +
-		"transcription slips, and fix the item name if it was clearly mis-heard, but do NOT rewrite it into " +
-		"corporate or marketing language, and do NOT invent any details (condition, size, colour, collection " +
-		"arrangements) that they did not say. Use British English. " +
-		"Respond ONLY with JSON: {\"title\": \"...\", \"description\": \"...\"}."
+	system := "You are lightly copy-editing what someone said out loud while giving away an item for free " +
+		"on Freegle, a UK reuse community. Return their OWN words, just cleaned up - this is a copy-edit, " +
+		"NOT a rewrite. Do NOT paraphrase, summarise, reword or add anything.\n" +
+		"For the DESCRIPTION: keep their exact wording, phrasing and personality (including chatty openers like " +
+		"'Hiya' and personal details like 'my nan had it for years'); fix capitalisation and punctuation; join " +
+		"fragments into coherent sentences; and drop only obvious filler, false starts and stutters. You may " +
+		"correct a word the speech-to-text clearly misheard, but change as little as possible and invent NOTHING " +
+		"(no condition, size, colour or collection details they didn't say).\n" +
+		"For the TITLE: a short plain name for the item, 2-5 words, using their words - no marketing adjectives " +
+		"they didn't use, no 'OFFER:' prefix.\n" +
+		"Use British English. Respond ONLY with JSON: {\"title\": \"...\", \"description\": \"...\"}."
 
 	reqBody, _ := json.Marshal(map[string]interface{}{
 		"model": summariseModel(),
@@ -385,7 +336,8 @@ var summarise = func(transcript string) (string, string) {
 			{"role": "system", "content": system},
 			{"role": "user", "content": "Transcript:\n\n" + transcript},
 		},
-		"temperature":     0.4,
+		// Low temperature: we want a faithful copy-edit, not a creative rewrite.
+		"temperature":     0.1,
 		"response_format": map[string]string{"type": "json_object"},
 	})
 

--- a/iznik-server-go/voicepost/voicepost.go
+++ b/iznik-server-go/voicepost/voicepost.go
@@ -1,0 +1,449 @@
+// Package voicepost implements a voice-first way to compose a Freegle post.
+//
+// The browser records the user describing their item and streams the audio to
+// the server in small chunks *while they are still talking* (rather than one big
+// upload at the end). As each chunk arrives the server re-runs Groq Whisper over
+// the audio-so-far and hands the growing transcript back, so the words build up
+// on screen with only a few seconds of latency. When the user stops, a final
+// transcription plus a quick Groq chat pass tidies the raw transcript into a
+// short item title and a friendly description that keeps the person's own words
+// and charm.
+//
+// Design decisions (see docs spec):
+//   - Groq is used for BOTH transcription (whisper-large-v3-turbo) and the tidy-up
+//     (a small fast llama model). One GROQ_API_KEY. Groq turbo transcribes faster
+//     than real time and costs ~$0.0006/min, so re-transcribing the accumulated
+//     audio on every chunk is still fractions of a penny per post.
+//   - Transport is plain chunked HTTP, not a WebSocket to a real-time STT engine.
+//     "Human latency, a few seconds" is the budget, so we don't need (or want to
+//     pay for) sub-second streaming recognisers like Deepgram.
+//   - The streamed audio is written to a temp file and kept only briefly (the
+//     in-flight compose buffer is pruned within the hour). The transcript is the
+//     durable artifact. Per the privacy policy, a retained voice recording is
+//     kept for at most 90 days (voiceRetentionPolicyDays) and then deleted; this
+//     prototype does not yet persist audio beyond the compose session, so that
+//     ceiling is a forward-looking commitment rather than something enforced here.
+package voicepost
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+// Retention for the temporary audio files and in-memory sessions. The audio is
+// only needed for the life of a single compose flow; anything older is stale.
+const sessionRetention = 30 * time.Minute
+
+// voiceRetentionPolicyDays is the maximum time a *retained* voice recording may
+// be kept before deletion, as stated in the privacy policy. The prototype does
+// not yet persist audio beyond the compose session (see package doc), so this is
+// the ceiling a future persistent store must honour rather than a value enforced
+// here today.
+const voiceRetentionPolicyDays = 90
+
+// Re-transcribe at most this often per session, so a burst of chunks can't queue
+// up a pile of Groq calls. Chunks normally arrive every few seconds anyway.
+const minTranscribeInterval = 2500 * time.Millisecond
+
+// session holds the server-side state for one in-progress voice post. Audio is
+// appended to a temp file; the latest transcript is cached so chunk responses are
+// instant even while a Groq call is in flight.
+type session struct {
+	mu             sync.Mutex
+	id             string
+	path           string
+	createdAt      time.Time
+	transcript     string
+	lastTranscribe time.Time
+	transcribing   bool
+}
+
+var (
+	store   = map[string]*session{}
+	storeMu sync.Mutex
+)
+
+// dir returns the directory used for temporary audio files, creating it if needed.
+func dir() string {
+	d := os.Getenv("VOICEPOST_DIR")
+	if d == "" {
+		d = filepath.Join(os.TempDir(), "voiceposts")
+	}
+	_ = os.MkdirAll(d, 0o755)
+	return d
+}
+
+// newID returns a short random hex id used for both the session and the filename.
+func newID() string {
+	b := make([]byte, 16)
+	_, _ = rand.Read(b)
+	return hex.EncodeToString(b)
+}
+
+// prune removes sessions (and their audio files) older than the retention window.
+// Called opportunistically on each new session so we never accumulate stale files.
+func prune() {
+	storeMu.Lock()
+	defer storeMu.Unlock()
+	cutoff := time.Now().Add(-sessionRetention)
+	for id, s := range store {
+		if s.createdAt.Before(cutoff) {
+			_ = os.Remove(s.path)
+			delete(store, id)
+		}
+	}
+	// Belt and braces: sweep any orphaned files on disk too.
+	entries, _ := os.ReadDir(dir())
+	for _, e := range entries {
+		info, err := e.Info()
+		if err == nil && info.ModTime().Before(cutoff) {
+			_ = os.Remove(filepath.Join(dir(), e.Name()))
+		}
+	}
+}
+
+func getSession(id string) *session {
+	storeMu.Lock()
+	defer storeMu.Unlock()
+	return store[id]
+}
+
+func newSession() *session {
+	prune()
+	id := newID()
+	s := &session{
+		id:        id,
+		path:      filepath.Join(dir(), id+".webm"),
+		createdAt: time.Now(),
+	}
+	storeMu.Lock()
+	store[id] = s
+	storeMu.Unlock()
+	return s
+}
+
+// Chunk handles POST /api/voicepost/chunk.
+//
+// The audio chunk is the raw request body (application/octet-stream). Query params:
+//   - session: the session id; omit on the first chunk and the server creates one.
+//   - seq:     client-side sequence number (informational; chunks are appended in
+//     arrival order — the client sends them serially so order is preserved).
+//
+// The response is JSON: {"session": "...", "transcript": "..."} where transcript
+// is the best transcript we have so far (it grows and sharpens as more audio
+// arrives). Partial-transcription failures are swallowed — we just return the last
+// good transcript and try again on the next chunk.
+//
+// No authentication: like image upload, this happens during the give/post flow
+// before the user has necessarily logged in. The audio is transient and unlinked.
+//
+// @Summary Stream a chunk of voice-post audio and get the transcript so far
+// @Tags VoicePost
+// @Accept octet-stream
+// @Produce json
+// @Param session query string false "Session id (omit on first chunk)"
+// @Param seq query int false "Chunk sequence number"
+// @Success 200 {object} map[string]interface{}
+// @Router /voicepost/chunk [post]
+func Chunk(c *fiber.Ctx) error {
+	if os.Getenv("GROQ_API_KEY") == "" {
+		return fiber.NewError(fiber.StatusServiceUnavailable, "Voice posting is not configured (GROQ_API_KEY missing)")
+	}
+
+	sid := c.Query("session")
+	var s *session
+	if sid == "" {
+		s = newSession()
+	} else {
+		s = getSession(sid)
+		if s == nil {
+			// Session expired or unknown — start a fresh one so the client can recover.
+			s = newSession()
+		}
+	}
+
+	body := c.Body()
+	if len(body) > 0 {
+		s.mu.Lock()
+		f, err := os.OpenFile(s.path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+		if err == nil {
+			_, _ = f.Write(body)
+			_ = f.Close()
+		}
+		s.mu.Unlock()
+	}
+
+	// Kick off a transcription of the audio-so-far if we're not already doing one
+	// and enough time has passed. This runs synchronously for a simple, ordered
+	// response, but is cheap (Groq turbo is sub-second for short clips).
+	s.mu.Lock()
+	due := !s.transcribing && time.Since(s.lastTranscribe) >= minTranscribeInterval
+	if due {
+		s.transcribing = true
+	}
+	path := s.path
+	s.mu.Unlock()
+
+	if due {
+		text, err := transcribe(path)
+		s.mu.Lock()
+		s.transcribing = false
+		s.lastTranscribe = time.Now()
+		if err == nil && strings.TrimSpace(text) != "" {
+			s.transcript = text
+		}
+		s.mu.Unlock()
+	}
+
+	s.mu.Lock()
+	transcript := s.transcript
+	s.mu.Unlock()
+
+	return c.JSON(fiber.Map{
+		"session":    s.id,
+		"transcript": transcript,
+	})
+}
+
+// FinishResult is the payload returned when a voice post is finalised.
+type FinishResult struct {
+	ID          string `json:"id"`
+	Transcript  string `json:"transcript"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
+}
+
+// Finish handles POST /api/voicepost/finish. The client calls this once the user
+// has stopped talking and the final chunk has been sent. We do one last full
+// transcription (so the complete audio is captured, not just up to the last
+// partial pass), then a Groq chat pass to tidy the transcript into a title and
+// description. The audio file is left in place to be pruned later.
+//
+// @Summary Finalise a voice post: full transcript + tidied title/description
+// @Tags VoicePost
+// @Accept json
+// @Produce json
+// @Param session query string true "Session id"
+// @Success 200 {object} FinishResult
+// @Router /voicepost/finish [post]
+func Finish(c *fiber.Ctx) error {
+	if os.Getenv("GROQ_API_KEY") == "" {
+		return fiber.NewError(fiber.StatusServiceUnavailable, "Voice posting is not configured (GROQ_API_KEY missing)")
+	}
+
+	sid := c.Query("session")
+	if sid == "" {
+		sid = c.FormValue("session")
+	}
+	s := getSession(sid)
+	if s == nil {
+		return fiber.NewError(fiber.StatusNotFound, "Unknown or expired voice-post session")
+	}
+
+	s.mu.Lock()
+	path := s.path
+	cached := s.transcript
+	s.mu.Unlock()
+
+	// Final, authoritative transcription of the whole file.
+	transcript, err := transcribe(path)
+	if err != nil || strings.TrimSpace(transcript) == "" {
+		// Fall back to the best partial we streamed if the final pass hiccups.
+		transcript = cached
+	}
+	if strings.TrimSpace(transcript) == "" {
+		return fiber.NewError(fiber.StatusBadRequest, "We couldn't hear anything in that recording — please try again.")
+	}
+
+	s.mu.Lock()
+	s.transcript = transcript
+	s.mu.Unlock()
+
+	title, description := summarise(transcript)
+
+	return c.JSON(FinishResult{
+		ID:          s.id,
+		Transcript:  transcript,
+		Title:       title,
+		Description: description,
+	})
+}
+
+// --- Groq calls -------------------------------------------------------------
+
+// groqBase is the OpenAI-compatible Groq API base. Overridable in tests.
+var groqBase = "https://api.groq.com/openai/v1"
+
+func transcribeModel() string {
+	if m := os.Getenv("VOICEPOST_TRANSCRIBE_MODEL"); m != "" {
+		return m
+	}
+	return "whisper-large-v3-turbo"
+}
+
+func summariseModel() string {
+	if m := os.Getenv("VOICEPOST_SUMMARISE_MODEL"); m != "" {
+		return m
+	}
+	return "llama-3.1-8b-instant"
+}
+
+// transcribe sends the audio file to Groq's Whisper endpoint and returns the text.
+// A truncated (mid-recording) webm file decodes fine up to its last complete
+// cluster, so this works on the growing partial file as well as the final one.
+var transcribe = func(path string) (string, error) {
+	key := os.Getenv("GROQ_API_KEY")
+	if key == "" {
+		return "", fmt.Errorf("GROQ_API_KEY not set")
+	}
+
+	audio, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read audio: %w", err)
+	}
+	if len(audio) == 0 {
+		return "", nil
+	}
+
+	var buf bytes.Buffer
+	w := multipart.NewWriter(&buf)
+	part, err := w.CreateFormFile("file", "audio.webm")
+	if err != nil {
+		return "", err
+	}
+	if _, err := part.Write(audio); err != nil {
+		return "", err
+	}
+	_ = w.WriteField("model", transcribeModel())
+	_ = w.WriteField("response_format", "json")
+	_ = w.WriteField("language", "en")
+	_ = w.WriteField("temperature", "0")
+	_ = w.Close()
+
+	req, err := http.NewRequest("POST", groqBase+"/audio/transcriptions", &buf)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+key)
+	req.Header.Set("Content-Type", w.FormDataContentType())
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	rb, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != 200 {
+		return "", fmt.Errorf("groq transcribe status %d: %s", resp.StatusCode, string(rb))
+	}
+
+	var out struct {
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal(rb, &out); err != nil {
+		return "", fmt.Errorf("decode transcription: %w", err)
+	}
+	return strings.TrimSpace(out.Text), nil
+}
+
+// summarise turns a raw spoken transcript into a short item title and a friendly
+// description, preserving the poster's own words and charm. Any failure falls
+// back to using the transcript itself so the user is never blocked.
+var summarise = func(transcript string) (string, string) {
+	key := os.Getenv("GROQ_API_KEY")
+	if key == "" {
+		return fallbackTitle(transcript), transcript
+	}
+
+	system := "You help someone give away an item for free on Freegle, a UK reuse community. " +
+		"They spoke a description of their item out loud and it was transcribed. " +
+		"Turn the transcript into a short catchy TITLE (just a few words naming the item, no 'OFFER:' prefix) " +
+		"and a warm, friendly DESCRIPTION for other freeglers to read. " +
+		"Keep the person's own words, voice and charm. Lightly tidy filler words, false starts and obvious " +
+		"transcription slips, and fix the item name if it was clearly mis-heard, but do NOT rewrite it into " +
+		"corporate or marketing language, and do NOT invent any details (condition, size, colour, collection " +
+		"arrangements) that they did not say. Use British English. " +
+		"Respond ONLY with JSON: {\"title\": \"...\", \"description\": \"...\"}."
+
+	reqBody, _ := json.Marshal(map[string]interface{}{
+		"model": summariseModel(),
+		"messages": []map[string]string{
+			{"role": "system", "content": system},
+			{"role": "user", "content": "Transcript:\n\n" + transcript},
+		},
+		"temperature":     0.4,
+		"response_format": map[string]string{"type": "json_object"},
+	})
+
+	req, err := http.NewRequest("POST", groqBase+"/chat/completions", bytes.NewReader(reqBody))
+	if err != nil {
+		return fallbackTitle(transcript), transcript
+	}
+	req.Header.Set("Authorization", "Bearer "+key)
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fallbackTitle(transcript), transcript
+	}
+	defer resp.Body.Close()
+	rb, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != 200 {
+		return fallbackTitle(transcript), transcript
+	}
+
+	var out struct {
+		Choices []struct {
+			Message struct {
+				Content string `json:"content"`
+			} `json:"message"`
+		} `json:"choices"`
+	}
+	if err := json.Unmarshal(rb, &out); err != nil || len(out.Choices) == 0 {
+		return fallbackTitle(transcript), transcript
+	}
+
+	var parsed struct {
+		Title       string `json:"title"`
+		Description string `json:"description"`
+	}
+	if err := json.Unmarshal([]byte(out.Choices[0].Message.Content), &parsed); err != nil {
+		return fallbackTitle(transcript), transcript
+	}
+	title := strings.TrimSpace(parsed.Title)
+	desc := strings.TrimSpace(parsed.Description)
+	if title == "" {
+		title = fallbackTitle(transcript)
+	}
+	if desc == "" {
+		desc = transcript
+	}
+	return title, desc
+}
+
+// fallbackTitle derives a rough title from the first few words of the transcript.
+func fallbackTitle(transcript string) string {
+	words := strings.Fields(transcript)
+	if len(words) == 0 {
+		return "Item to give away"
+	}
+	if len(words) > 8 {
+		words = words[:8]
+	}
+	return strings.Join(words, " ")
+}

--- a/iznik-server-go/voicepost/voicepost_test.go
+++ b/iznik-server-go/voicepost/voicepost_test.go
@@ -1,0 +1,98 @@
+package voicepost
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+// testApp wires just the two voicepost routes onto a bare Fiber app so the
+// handlers can be exercised without the full API/DB stack.
+func testApp() *fiber.App {
+	app := fiber.New()
+	app.Post("/api/voicepost/chunk", Chunk)
+	app.Post("/api/voicepost/finish", Finish)
+	return app
+}
+
+// TestChunkAndFinish walks the happy path: a first chunk allocates a session and
+// returns the transcript so far, and finish returns the tidied title/description.
+// The Groq calls are stubbed via the package-level transcribe/summarise vars.
+func TestChunkAndFinish(t *testing.T) {
+	os.Setenv("GROQ_API_KEY", "test-key")
+	defer os.Unsetenv("GROQ_API_KEY")
+
+	origT, origS := transcribe, summarise
+	defer func() { transcribe = origT; summarise = origS }()
+	transcribe = func(path string) (string, error) {
+		return "hiya i've got an old chair going free", nil
+	}
+	summarise = func(transcript string) (string, string) {
+		return "Old Chair", "A lovely old chair going free to a good home."
+	}
+
+	app := testApp()
+
+	// First chunk with no session -> the server allocates one.
+	req := httptest.NewRequest("POST", "/api/voicepost/chunk", strings.NewReader("fake-audio-bytes"))
+	req.Header.Set("Content-Type", "application/octet-stream")
+	resp, err := app.Test(req, -1)
+	assert.NoError(t, err)
+	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+
+	var chunkResp struct {
+		Session    string `json:"session"`
+		Transcript string `json:"transcript"`
+	}
+	assert.NoError(t, json.NewDecoder(resp.Body).Decode(&chunkResp))
+	assert.NotEmpty(t, chunkResp.Session)
+	assert.Equal(t, "hiya i've got an old chair going free", chunkResp.Transcript)
+
+	// Finish the same session.
+	freq := httptest.NewRequest("POST", "/api/voicepost/finish?session="+chunkResp.Session, nil)
+	fresp, err := app.Test(freq, -1)
+	assert.NoError(t, err)
+	assert.Equal(t, fiber.StatusOK, fresp.StatusCode)
+
+	var fin FinishResult
+	assert.NoError(t, json.NewDecoder(fresp.Body).Decode(&fin))
+	assert.Equal(t, chunkResp.Session, fin.ID)
+	assert.Equal(t, "Old Chair", fin.Title)
+	assert.Equal(t, "A lovely old chair going free to a good home.", fin.Description)
+	assert.NotEmpty(t, fin.Transcript)
+}
+
+// TestChunkRequiresKey verifies the endpoint refuses to run when unconfigured.
+func TestChunkRequiresKey(t *testing.T) {
+	os.Unsetenv("GROQ_API_KEY")
+	app := testApp()
+	req := httptest.NewRequest("POST", "/api/voicepost/chunk", strings.NewReader("x"))
+	resp, err := app.Test(req, -1)
+	assert.NoError(t, err)
+	assert.Equal(t, fiber.StatusServiceUnavailable, resp.StatusCode)
+}
+
+// TestFinishUnknownSession verifies a stale/unknown session id is a 404.
+func TestFinishUnknownSession(t *testing.T) {
+	os.Setenv("GROQ_API_KEY", "test-key")
+	defer os.Unsetenv("GROQ_API_KEY")
+	app := testApp()
+	req := httptest.NewRequest("POST", "/api/voicepost/finish?session=does-not-exist", nil)
+	resp, err := app.Test(req, -1)
+	assert.NoError(t, err)
+	assert.Equal(t, fiber.StatusNotFound, resp.StatusCode)
+}
+
+// TestFallbackTitle covers the transcript-derived title used when the LLM tidy-up
+// is unavailable.
+func TestFallbackTitle(t *testing.T) {
+	assert.Equal(t, "Item to give away", fallbackTitle(""))
+	assert.Equal(t, "one two three", fallbackTitle("one two three"))
+	assert.Equal(t, "one two three four five six seven eight",
+		fallbackTitle("one two three four five six seven eight nine ten"))
+}

--- a/iznik-server-go/voicepost/voicepost_test.go
+++ b/iznik-server-go/voicepost/voicepost_test.go
@@ -46,14 +46,12 @@ func TestChunkAndFinish(t *testing.T) {
 	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
 
 	var chunkResp struct {
-		Session    string `json:"session"`
-		Transcript string `json:"transcript"`
+		Session string `json:"session"`
 	}
 	assert.NoError(t, json.NewDecoder(resp.Body).Decode(&chunkResp))
 	assert.NotEmpty(t, chunkResp.Session)
-	assert.Equal(t, "hiya i've got an old chair going free", chunkResp.Transcript)
 
-	// Finish the same session.
+	// Finish the same session: this is where transcription + tidy-up happen.
 	freq := httptest.NewRequest("POST", "/api/voicepost/finish?session="+chunkResp.Session, nil)
 	fresp, err := app.Test(freq, -1)
 	assert.NoError(t, err)

--- a/plans/voice-posting-prototype.md
+++ b/plans/voice-posting-prototype.md
@@ -1,0 +1,95 @@
+# Voice posting prototype
+
+A voice-first way to compose a Freegle OFFER. Instead of uploading a photo and
+filling in a form, the user taps a big microphone, describes their item out loud,
+and we turn their words into a post they can review and edit.
+
+Built as a self-contained demo route: **`/voicepost`**.
+
+## How it works
+
+```
+ Browser                         apiv2 (Go)                       Groq
+ ───────                         ──────────                       ────
+ MediaRecorder ──chunk (webm)──▶ append to temp file ──audio──▶  Whisper (turbo)
+   (~4s slices)  POST /voicepost/chunk   re-transcribe so-far  ◀──transcript
+   live transcript ◀── {transcript} ─────┘
+        │
+   user taps Stop
+        │
+        └──POST /voicepost/finish──▶ final transcribe + tidy-up ─▶ Whisper + Llama
+                                    ◀── {title, description} ◀──── (JSON)
+   review screen (editable) ──▶ post
+```
+
+- **Streaming, not one big upload.** The audio is streamed to the server in ~4s
+  chunks *while the user is still talking*. Each chunk triggers a re-transcription
+  of the audio-so-far, and the growing transcript is streamed back on the chunk
+  response, so words build up on screen. When they stop, it's essentially already
+  transcribed — only a ~1s tidy-up pass remains.
+- **Server-side transcription with Groq.** We deliberately did **not** use a
+  real-time streaming STT engine (Deepgram etc.) — those are priced for sub-second
+  latency we don't need. The budget is "human latency, a few seconds", so Groq's
+  batch Whisper (`whisper-large-v3-turbo`, faster than real time) re-run per chunk
+  is the right fit. We also did not use the browser's Web Speech API — quality
+  isn't good enough and it isn't consistently supported.
+- **Tidy-up keeps the charm.** A small fast Groq chat model (`llama-3.1-8b-instant`)
+  turns the raw transcript into a short title and a friendly description,
+  preserving the person's own words and voice, without inventing details.
+- **Ephemeral audio.** The streamed audio is written to a temp file and pruned
+  quickly; the transcript is the durable artifact. Per the privacy policy a
+  *retained* voice recording would be kept at most **90 days** then deleted — the
+  prototype does not persist audio beyond the compose session.
+- **Consent captured, playback deferred.** The review screen has a "Let the person
+  collecting hear my voice description" toggle. It is captured but the recipient-
+  side player is intentionally **not** built yet.
+
+## Files
+
+Backend (Go, apiv2):
+- `iznik-server-go/voicepost/voicepost.go` — `Chunk` + `Finish` handlers, Groq
+  transcription + tidy-up, in-memory session store, temp-file storage + prune.
+- `iznik-server-go/voicepost/voicepost_test.go` — handler unit tests (Groq stubbed).
+- `iznik-server-go/router/routes.go` — registers `POST /voicepost/chunk` and
+  `POST /voicepost/finish` (under both `/api` and `/apiv2`).
+- `docker-compose.yml` — passes `GROQ_API_KEY` through to the dev `apiv2` service.
+
+Frontend (Nuxt 3):
+- `iznik-nuxt3/pages/voicepost.vue` — the `/voicepost` page (record → live
+  transcript → review → done), MediaRecorder capture, serialized chunk upload.
+- `iznik-nuxt3/api/VoicePostAPI.js` + `api/index.js` — the `voicepost` API client.
+- `iznik-nuxt3/pages/privacy.vue` — new section 2.1 on voice descriptions, Groq,
+  and 90-day retention.
+
+Config (local only, not committed):
+- `GROQ_API_KEY` in the worktree `.env` (gitignored).
+
+## Cost
+
+A typical item description is ~15–45s. Groq `whisper-large-v3-turbo` is ~$0.0006/min.
+Because we re-transcribe the growing audio each chunk, a 60s note transcribes roughly
+6–7 audio-minutes in total — still **fractions of a penny per post** (~$0.004). The
+tidy-up is a few hundred tokens on an 8B model, also negligible. At 100k posts the
+whole feature is on the order of **tens of pounds**.
+
+If cost ever matters, transcribe only on `finish` (one pass) instead of per chunk —
+that trades the live transcript for ~10× lower spend.
+
+## Verified
+
+- Real speech (TTS "wooden kitchen chair" clip) → Groq transcript accurate →
+  tidy-up produced title **"Wobbly Pine Kitchen Chair"** with the charm intact.
+- Full browser flow on `/voicepost` (dev-local): record → live state → stop →
+  finish → editable review (title, description, playback, raw transcript, consent
+  + 90-day/privacy copy) → "post it" confirmation. No console errors.
+
+## Not done / next steps
+
+- Wire "post it" into the real compose flow (photo + community + submit) instead
+  of the demo confirmation.
+- Build the consent-gated recipient audio player and the persistent 90-day audio
+  store + prune job (needs a new `messages_audio`-style mechanism — the existing
+  attachment pipeline is image-only).
+- Session store is in-memory (single instance); production behind a load balancer
+  needs sticky routing or shared storage for the in-flight buffer.
+- iOS Safari records `audio/mp4`; verify Groq handling on-device.

--- a/plans/voice-posting-prototype.md
+++ b/plans/voice-posting-prototype.md
@@ -9,20 +9,26 @@ Demo route: **`/voicepost`**.
 ## Flow
 
 ```
- /give/mobile  ── A/B assign (mobile only) ──▶  voice cohort → /voicepost
-      │                                          control      → /give/mobile/photos (typed form)
+ /give/mobile ── A/B assign (mobile only) ──▶ variant cohort → /voicepost
+      │                                        control        → /give/mobile/photos (typed form)
       ▼
- /voicepost:  [ Say it ]   [ Type it ] ── Type it ─▶ /give/mobile/photos (existing form)
+ /voicepost:  photo (PhotoUploader, has its own Skip)
+      │
+      ▼
+   choose:  [ Say it ]        [ Type it ] ──▶ /give/mobile/details (typed form; photo kept)
       │ Say it
       ▼
-   photo  ──▶  record (audio streams up while talking)  ──▶  Stop
-                                                              │
-                       POST /voicepost/chunk (buffer only)    │
-                       POST /voicepost/finish ──▶ transcribe ONCE + copy-edit (Groq)
-                                                              ▼
-                                              review (editable title/desc, playback,
-                                              consent) ──▶ post
+   record (audio streams up while talking) ──▶ Stop
+        POST /voicepost/chunk  (buffer only)
+        POST /voicepost/finish (transcribe ONCE + copy-edit, Groq)
+      ▼
+   review (editable title/desc, playback, consent) ──▶ post
 ```
+
+Photo first, then the choice. The photo lives in the compose store, so "Type it"
+carries it straight into the existing typed form (`/give/mobile/details`).
+`/voicepost` always shows the choice; the experiment only controls whether the
+real give flow routes users here at all.
 
 ## Design decisions
 
@@ -54,13 +60,18 @@ Demo route: **`/voicepost`**.
 
 ## A/B experiment (mobile)
 
-`composables/useComposeChoice.js` assigns each mobile user to `voice` or `control`
-by a fixed per-user % bucket (`ROLLOUT_PCT`, default 0 = off; `?voice=1`/`?voice=0`
-overrides for demos). `pages/give/mobile/index.vue` routes the `voice` cohort to
-`/voicepost` and everyone else to the existing form. Exposure and completion are
-recorded through the existing bandit endpoints (`$api.bandit.shown/chosen`, uid
-`mobile-compose-voice`) so the `abtest` table accumulates comparable shown/action
-rates per variant. To run the test, raise `ROLLOUT_PCT`.
+Two things are measured, both through the existing bandit endpoints
+(`$api.bandit.shown/chosen`, so the `abtest` table accumulates comparable rates):
+
+1. **Exposure** (uid `mobile-compose-variant`): whether we showed the choice
+   variant vs the existing form, and whether they completed a post.
+   `composables/useComposeChoice.js` assigns each mobile user to `variant` or
+   `control` by a fixed per-user % bucket (`ROLLOUT_PCT`, default 0 = off;
+   `?voice=1`/`?voice=0` overrides for demos), and `pages/give/mobile/index.vue`
+   routes the `variant` cohort to `/voicepost`, everyone else to the typed form.
+   To run the test, raise `ROLLOUT_PCT`.
+2. **Method** (uid `mobile-compose-method`): of those shown the choice, whether
+   they picked `voice` or `keyboard` (recorded on the choice screen).
 
 ## Files
 

--- a/plans/voice-posting-prototype.md
+++ b/plans/voice-posting-prototype.md
@@ -1,95 +1,106 @@
 # Voice posting prototype
 
-A voice-first way to compose a Freegle OFFER. Instead of uploading a photo and
-filling in a form, the user taps a big microphone, describes their item out loud,
-and we turn their words into a post they can review and edit.
+A voice-first way to compose a Freegle OFFER. On mobile the user can choose to
+describe their item out loud instead of typing a form; we transcribe it and turn
+their words into a post they can review and edit.
 
-Built as a self-contained demo route: **`/voicepost`**.
+Demo route: **`/voicepost`**.
 
-## How it works
+## Flow
 
 ```
- Browser                         apiv2 (Go)                       Groq
- ───────                         ──────────                       ────
- MediaRecorder ──chunk (webm)──▶ append to temp file ──audio──▶  Whisper (turbo)
-   (~4s slices)  POST /voicepost/chunk   re-transcribe so-far  ◀──transcript
-   live transcript ◀── {transcript} ─────┘
-        │
-   user taps Stop
-        │
-        └──POST /voicepost/finish──▶ final transcribe + tidy-up ─▶ Whisper + Llama
-                                    ◀── {title, description} ◀──── (JSON)
-   review screen (editable) ──▶ post
+ /give/mobile  ── A/B assign (mobile only) ──▶  voice cohort → /voicepost
+      │                                          control      → /give/mobile/photos (typed form)
+      ▼
+ /voicepost:  [ Say it ]   [ Type it ] ── Type it ─▶ /give/mobile/photos (existing form)
+      │ Say it
+      ▼
+   photo  ──▶  record (audio streams up while talking)  ──▶  Stop
+                                                              │
+                       POST /voicepost/chunk (buffer only)    │
+                       POST /voicepost/finish ──▶ transcribe ONCE + copy-edit (Groq)
+                                                              ▼
+                                              review (editable title/desc, playback,
+                                              consent) ──▶ post
 ```
 
-- **Streaming, not one big upload.** The audio is streamed to the server in ~4s
-  chunks *while the user is still talking*. Each chunk triggers a re-transcription
-  of the audio-so-far, and the growing transcript is streamed back on the chunk
-  response, so words build up on screen. When they stop, it's essentially already
-  transcribed — only a ~1s tidy-up pass remains.
-- **Server-side transcription with Groq.** We deliberately did **not** use a
-  real-time streaming STT engine (Deepgram etc.) — those are priced for sub-second
-  latency we don't need. The budget is "human latency, a few seconds", so Groq's
-  batch Whisper (`whisper-large-v3-turbo`, faster than real time) re-run per chunk
-  is the right fit. We also did not use the browser's Web Speech API — quality
-  isn't good enough and it isn't consistently supported.
-- **Tidy-up keeps the charm.** A small fast Groq chat model (`llama-3.1-8b-instant`)
-  turns the raw transcript into a short title and a friendly description,
-  preserving the person's own words and voice, without inventing details.
-- **Ephemeral audio.** The streamed audio is written to a temp file and pruned
-  quickly; the transcript is the durable artifact. Per the privacy policy a
-  *retained* voice recording would be kept at most **90 days** then deleted — the
-  prototype does not persist audio beyond the compose session.
-- **Consent captured, playback deferred.** The review screen has a "Let the person
-  collecting hear my voice description" toggle. It is captured but the recipient-
-  side player is intentionally **not** built yet.
+## Design decisions
+
+- **Choice, not forced voice.** The entry is a voice-vs-keyboard choice. "Type it"
+  hands off to the existing typed compose flow unchanged.
+- **Stream to hide upload latency; transcribe on stop.** Audio streams to the
+  server in ~3s chunks *while the user talks* (`POST /voicepost/chunk` just buffers
+  it), so when they stop there's almost nothing left to upload. Transcription then
+  happens **once**, over the whole recording, on `POST /voicepost/finish`. This is
+  simpler and cheaper than per-chunk re-transcription and sidesteps two problems:
+  no transcript-ordering races, and no chunk-boundary word splitting (a word spoken
+  across a boundary is wholly present in the concatenated file).
+- **Groq, not real-time STT.** `whisper-large-v3-turbo` transcribes faster than
+  real time at ~$0.0006/min. We deliberately avoided a WebSocket real-time engine
+  (Deepgram ~$0.0077/min streaming, ~10× the cost) — the budget is "human latency,
+  a few seconds after stop", not sub-second live captions. Not the browser Web
+  Speech API either (quality + patchy support).
+- **Copy-edit, not rewrite.** A small Groq chat model (`llama-3.1-8b-instant`,
+  temperature 0.1) *lightly copy-edits* the transcript: fix capitalisation and
+  punctuation, join fragments, drop filler — but keep the person's own words and
+  personality ("Hiya", "my nan had it for years") and invent nothing. Plus a short
+  plain title.
+- **Ephemeral audio.** Buffered to a temp file, pruned quickly; the transcript is
+  the durable artifact. Per the privacy policy a *retained* recording would be kept
+  at most **90 days** then deleted — the prototype doesn't persist audio beyond the
+  compose session.
+- **Consent captured, playback deferred.** A "let the person collecting hear my
+  voice" toggle is captured; the recipient-side player is intentionally not built.
+
+## A/B experiment (mobile)
+
+`composables/useComposeChoice.js` assigns each mobile user to `voice` or `control`
+by a fixed per-user % bucket (`ROLLOUT_PCT`, default 0 = off; `?voice=1`/`?voice=0`
+overrides for demos). `pages/give/mobile/index.vue` routes the `voice` cohort to
+`/voicepost` and everyone else to the existing form. Exposure and completion are
+recorded through the existing bandit endpoints (`$api.bandit.shown/chosen`, uid
+`mobile-compose-voice`) so the `abtest` table accumulates comparable shown/action
+rates per variant. To run the test, raise `ROLLOUT_PCT`.
 
 ## Files
 
 Backend (Go, apiv2):
-- `iznik-server-go/voicepost/voicepost.go` — `Chunk` + `Finish` handlers, Groq
-  transcription + tidy-up, in-memory session store, temp-file storage + prune.
-- `iznik-server-go/voicepost/voicepost_test.go` — handler unit tests (Groq stubbed).
-- `iznik-server-go/router/routes.go` — registers `POST /voicepost/chunk` and
-  `POST /voicepost/finish` (under both `/api` and `/apiv2`).
-- `docker-compose.yml` — passes `GROQ_API_KEY` through to the dev `apiv2` service.
+- `iznik-server-go/voicepost/voicepost.go` (+ `_test.go`) — `Chunk` (buffer) and
+  `Finish` (transcribe once + copy-edit), session store, temp-file audio + prune.
+- `iznik-server-go/router/routes.go` — `POST /voicepost/{chunk,finish}`.
+- `docker-compose.yml` — `GROQ_API_KEY` passthrough to the dev `apiv2` service.
 
 Frontend (Nuxt 3):
-- `iznik-nuxt3/pages/voicepost.vue` — the `/voicepost` page (record → live
-  transcript → review → done), MediaRecorder capture, serialized chunk upload.
-- `iznik-nuxt3/api/VoicePostAPI.js` + `api/index.js` — the `voicepost` API client.
-- `iznik-nuxt3/pages/privacy.vue` — new section 2.1 on voice descriptions, Groq,
-  and 90-day retention.
+- `iznik-nuxt3/pages/voicepost.vue` — choice → photo → record → review → done.
+- `iznik-nuxt3/composables/useComposeChoice.js` — experiment assignment + tracking.
+- `iznik-nuxt3/pages/give/mobile/index.vue` — experiment gate at the mobile entry.
+- `iznik-nuxt3/api/VoicePostAPI.js` + `api/index.js` — the `voicepost` client.
+- `iznik-nuxt3/pages/privacy.vue` — §2.1 Groq transcription + 90-day retention.
 
-Config (local only, not committed):
-- `GROQ_API_KEY` in the worktree `.env` (gitignored).
+Config (local only, not committed): `GROQ_API_KEY` in the worktree `.env`.
 
-## Cost
+## Cost / latency
 
-A typical item description is ~15–45s. Groq `whisper-large-v3-turbo` is ~$0.0006/min.
-Because we re-transcribe the growing audio each chunk, a 60s note transcribes roughly
-6–7 audio-minutes in total — still **fractions of a penny per post** (~$0.004). The
-tidy-up is a few hundred tokens on an 8B model, also negligible. At 100k posts the
-whole feature is on the order of **tens of pounds**.
-
-If cost ever matters, transcribe only on `finish` (one pass) instead of per chunk —
-that trades the live transcript for ~10× lower spend.
+| | Groq turbo (used) | Deepgram Nova-3 streaming |
+|---|---|---|
+| After stop | ~2–3s (one transcribe + copy-edit) | ~1s (transcript already done) |
+| Live captions | none (transcribe on stop) | <300ms word-by-word |
+| Price/min | ~$0.0006 | ~$0.0077 |
+| 100k posts | ~$30 | ~$230 |
 
 ## Verified
 
-- Real speech (TTS "wooden kitchen chair" clip) → Groq transcript accurate →
-  tidy-up produced title **"Wobbly Pine Kitchen Chair"** with the charm intact.
-- Full browser flow on `/voicepost` (dev-local): record → live state → stop →
-  finish → editable review (title, description, playback, raw transcript, consent
-  + 90-day/privacy copy) → "post it" confirmation. No console errors.
+- Real TTS clip → accurate transcript → title "Old Wooden Kitchen Chair",
+  description **verbatim** ("Hiya… Lovely bit of pine. My nan had it for years…").
+- Full browser flow: choice → Say it → photo → record → review → Re-record →
+  Type it → existing form. No console errors from the page.
 
 ## Not done / next steps
 
-- Wire "post it" into the real compose flow (photo + community + submit) instead
-  of the demo confirmation.
-- Build the consent-gated recipient audio player and the persistent 90-day audio
-  store + prune job (needs a new `messages_audio`-style mechanism — the existing
-  attachment pipeline is image-only).
-- Session store is in-memory (single instance); production behind a load balancer
-  needs sticky routing or shared storage for the in-flight buffer.
-- iOS Safari records `audio/mp4`; verify Groq handling on-device.
+- Wire "post it" and the typed branch into real compose completion (and record the
+  control-variant conversion there, not just voice).
+- Persistent 90-day audio store + consent-gated recipient player (needs a new
+  `messages_audio` mechanism; the attachment pipeline is image-only).
+- In-memory session store is single-instance; production needs sticky routing or
+  shared storage for the in-flight buffer.
+- iOS Safari records `audio/mp4`; confirm Groq handling on-device.

--- a/plans/voice-posting-prototype.md
+++ b/plans/voice-posting-prototype.md
@@ -73,6 +73,33 @@ Two things are measured, both through the existing bandit endpoints
 2. **Method** (uid `mobile-compose-method`): of those shown the choice, whether
    they picked `voice` or `keyboard` (recorded on the choice screen).
 
+## Instrumentation (full funnel)
+
+The bandit counters above are just the headline A/B rates. For the full picture,
+rich per-session events go through `useClientLog` (`action(name, ctx)` →
+`POST /clientlog`, auto-tagged with `session_id` / `user_id` / `url` / timestamp),
+so every stage and dimension can be cross-tabulated per session. All events are
+prefixed `voicepost_`:
+
+| Event | When | Key context |
+|---|---|---|
+| `voicepost_entry` | give flow assigns the experiment (active only) | `variant`, `is_mobile` |
+| `voicepost_choice_shown` | choice screen shown | `has_photo` |
+| `voicepost_method_chosen` | Say it / Type it tapped | `method`, `has_photo` |
+| `voicepost_record_start` | recording begins | – |
+| `voicepost_record_error` | mic / record failure | `reason` (permission_denied / no_microphone / unsupported / other) |
+| `voicepost_transcribed` | review reached | `duration_s`, `transcript_chars`, `title_chars`, `desc_chars`, `rerecord_count` |
+| `voicepost_finish_error` | transcription / finish failed | `reason`, `duration_s` |
+| `voicepost_played_recording` | first playback of their own recording | – |
+| `voicepost_rerecord` | Re-record tapped | `count` |
+| `voicepost_posted` | "post it" | `consent_play_voice`, `title_edited`, `desc_edited`, `desc_char_delta`, `had_photo`, `played_back`, `rerecord_count`, `seconds_on_review` |
+| `voicepost_review_abandoned` | left review without posting | `has_photo`, `rerecord_count` |
+
+Together these answer: how often it was shown, the voice-vs-keyboard split,
+drop-off and errors through the funnel, the consent-to-play rate, whether people
+trusted the words (edited vs posted as-is, and by how much), and the time/effort
+they spent - i.e. whether the feature is actually working.
+
 ## Files
 
 Backend (Go, apiv2):


### PR DESCRIPTION
## Voice posting (mobile) — behind a separate route, experiment-gated

Adds an optional voice-first way to compose an OFFER on mobile: add a photo, then choose **Say it** (describe the item aloud) or **Type it** (the existing form). Speech streams to the server, is transcribed with Groq Whisper, and lightly **copy-edited** (not rewritten) into a title + description the user reviews before posting.

### What's included
- **New route `/voicepost`** (Nuxt): photo → voice/keyboard choice → record → review. Self-contained; always shows the choice.
- **New apiv2 endpoints** `POST /api/voicepost/{chunk,finish}` (Go `voicepost` package): `chunk` buffers streamed audio while the user talks; `finish` transcribes the whole recording **once** then copy-edits it via Groq. Audio is a temp file that's pruned; the transcript is the durable artifact.
- **Privacy policy §2.1**: names Groq as the third-party transcription service and states a 90-day voice-retention ceiling. Consent to play the recording to the collector is captured (recipient-side playback deliberately not built yet).
- **Mobile A/B experiment** (`composables/useComposeChoice.js`): a fixed per-user bucket (`ROLLOUT_PCT`, default **0 = off**) routes a mobile cohort to the choice; records exposure (`mobile-compose-variant`) and the voice-vs-keyboard pick (`mobile-compose-method`) through the existing bandit endpoints.

### Merge safety
- The only existing route touched is `pages/give/mobile/index.vue`. With the experiment off (the default), it short-circuits to the original redirect with **no assignment and no tracking** — existing behaviour is unchanged until `ROLLOUT_PCT` is deliberately raised.
- Everything else is additive: new Go package, new page/composable/API client, additive route registration, additive privacy text.
- `GROQ_API_KEY` is passed through docker-compose as `${GROQ_API_KEY:-}` (empty default → the endpoint returns 503 gracefully if unset). No secret is in the diff.

### Testing
- **Vitest**: 14,230 passing / 0 failing.
- **Go**: 3,429 passing / 0 failing (incl. the new `voicepost` package tests).
- Manually walked the full flow (photo → choice → voice → record → review → Re-record; keyboard → existing form) against real Groq transcription and confirmed the copy-edit keeps the poster's own words.

Design + cost/latency notes: `plans/voice-posting-prototype.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016VVSP4Wg6jB6CGetEjy7qG
