### PR TITLE
fix(remap): don't abort nightly postcode remap on a transient spatial-server blip

### DIFF
--- a/iznik-batch/app/Services/PostcodeRemapService.php
+++ b/iznik-batch/app/Services/PostcodeRemapService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
@@ -105,12 +106,20 @@ class PostcodeRemapService
         // type=Area restricts the expanding-buffer search to non-postcode
         // locations, matching the V1 PostGIS candidate pool (which synced
         // everything except postcodes).
-        $response = Http::get("{$this->spatialServerUrl}/v1/locations/knn", [
-            'lng'   => $lng,
-            'lat'   => $lat,
-            'limit' => 1,
-            'type'  => 'Area',
-        ]);
+        try {
+            $response = Http::get("{$this->spatialServerUrl}/v1/locations/knn", [
+                'lng'   => $lng,
+                'lat'   => $lat,
+                'limit' => 1,
+                'type'  => 'Area',
+            ]);
+        } catch (ConnectionException $e) {
+            // A transient blip on the spatial server (e.g. mid-rebuild) must not
+            // abort the whole remap. Treat it like a failed lookup: skip this
+            // postcode (return null => no update) so the run continues.
+            Log::warning("PostcodeRemapService: spatial server unreachable for lng={$lng} lat={$lat}: {$e->getMessage()}");
+            return null;
+        }
 
         if ($response->successful()) {
             $results = $response->json('results', []);

--- a/iznik-batch/tests/Unit/Services/PostcodeRemapServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/PostcodeRemapServiceTest.php
@@ -49,6 +49,24 @@ class PostcodeRemapServiceTest extends TestCase
         $this->assertNull($result);
     }
 
+    public function test_find_nearest_area_returns_null_when_server_connection_refused(): void
+    {
+        // A transient blip (spatial server mid-rebuild) makes Http::get throw a
+        // ConnectionException rather than return a response. This must be
+        // swallowed so a single failed lookup does not abort the whole remap.
+        Http::fake([
+            '*/v1/locations/knn*' => function () {
+                throw new \Illuminate\Http\Client\ConnectionException(
+                    'cURL error 7: Failed to connect to spatial-knn port 8194'
+                );
+            },
+        ]);
+
+        $result = $this->service->findNearestArea(-1.5491, 53.8008);
+
+        $this->assertNull($result);
+    }
+
     public function test_find_nearest_area_queries_locations_knn_with_area_filter(): void
     {
         Http::fake([


### PR DESCRIPTION
## What

Overnight Sentry (batch) showed **BATCH-60** at 01:34 2026-07-10: an uncaught `ConnectionException` (cURL 7, `spatial-knn:8194` connection refused) from `PostcodeRemapService::findNearestArea`, thrown during the nightly postcode→area remap while the spatial server was momentarily not listening (mid-rebuild).

`findNearestArea` already handled bad HTTP **status codes** gracefully — log a warning and return `null`, which the caller treats as "skip this postcode, no update". But `Http::get` **throws** on a connection *refusal* rather than returning a response, so that guard never ran. The exception propagated up through the `chunkById` loop and **killed the entire remap run** the instant the spatial server blipped.

There was never a corruption risk (the caller only writes on a non-null area), just the whole nightly job dying on a ~1-second transient.

## Change

- Wrap the `Http::get` in `try/catch (ConnectionException)`, logging a warning and returning `null` — matching the existing "skip this postcode, keep going" contract.
- Add a regression test (`test_find_nearest_area_returns_null_when_server_connection_refused`) faking a thrown `ConnectionException`.

## Testing

`php -l` clean on both files. Full batch suite runs in CI (not run locally per standing rule that test suites run on CI, not the FD host).

🤖 Generated with [Claude Code](https://claude.com/claude-code)