### PR TITLE
feat(rippling): load sysadmin analytics drive-times progressively

### DIFF
--- a/iznik-nuxt3/api/RipplingAPI.js
+++ b/iznik-nuxt3/api/RipplingAPI.js
@@ -13,12 +13,23 @@ export default class RipplingAPI extends BaseAPI {
   }
 
   // On-the-fly rippling analytics KPIs (§ sysadmin analytics tab). stratum =
-  // all|rural|suburban|dense. Drive-time metrics are sampled server-side, so this can take
-  // ~10-20s — callers should show a spinner and allow a long timeout.
+  // all|rural|suburban|dense. Fast: pure-SQL KPIs only. The slow drive-time metrics are fetched
+  // separately via fetchAnalyticsDriveTimes so this returns (and the tab renders) immediately.
   fetchAnalytics(stratum = 'all', start = '', end = '') {
     const params = { stratum }
     if (start) params.start = start
     if (end) params.end = end
     return this.$getv2('/rippling/analytics', params)
+  }
+
+  // The SLOW half of the analytics tab: the sampled drive-time routing pass (reply/rippled mean
+  // drive-times, the per-day trend and the reliability bullseye). ~250 isochrone calls, so this
+  // can take tens of seconds — callers fetch it after the KPIs and fill the drive panels in
+  // progressively, with a long timeout.
+  fetchAnalyticsDriveTimes(stratum = 'all', start = '', end = '') {
+    const params = { stratum }
+    if (start) params.start = start
+    if (end) params.end = end
+    return this.$getv2('/rippling/analytics/drivetime', params)
   }
 }

--- a/iznik-nuxt3/modtools/components/ModSysAdminRipplingAnalytics.vue
+++ b/iznik-nuxt3/modtools/components/ModSysAdminRipplingAnalytics.vue
@@ -34,9 +34,7 @@
 
     <div v-if="loading" class="text-center py-5">
       <b-spinner />
-      <p class="text-muted small mt-2 mb-0">
-        Computing live — sampling drive-times from the routing graph…
-      </p>
+      <p class="text-muted small mt-2 mb-0">Computing live KPIs…</p>
     </div>
     <div v-else-if="error" class="text-danger">Failed to load: {{ error }}</div>
     <div v-else-if="s1">
@@ -103,6 +101,10 @@
                 ±{{ s1.reply_drive_min.ci_half_min.toFixed(1) }} · n =
                 {{ s1.reply_drive_min.n_replies.toLocaleString() }}
               </div>
+            </template>
+            <template v-else-if="driveLoading">
+              <b-spinner small />
+              <div class="sub muted">sampling drive-times…</div>
             </template>
             <div v-else class="sub">No drive-time sample.</div>
             <div class="divider"></div>
@@ -227,6 +229,10 @@
                 {{ s3.ripple_drive_min.n_replies.toLocaleString() }}
               </div>
             </template>
+            <template v-else-if="driveLoading">
+              <b-spinner small />
+              <div class="sub muted">sampling drive-times…</div>
+            </template>
             <div v-else class="sub">No sample.</div>
           </div>
         </div>
@@ -336,6 +342,12 @@
           </div>
         </div>
       </div>
+      <div v-else-if="driveLoading" class="text-center py-4">
+        <b-spinner small />
+        <p class="text-muted small mt-2 mb-0">
+          Sampling drive-times from the routing graph…
+        </p>
+      </div>
       <p v-else class="text-muted small">
         No drive-time sample for the bullseye in this window.
       </p>
@@ -433,6 +445,9 @@ const s1 = ref(null)
 const s2 = ref({ kpis: [], drive_time: [] })
 const s3 = ref(null)
 const bull = ref([])
+// The drive-time metrics are a slow sampled routing pass, fetched separately from the KPIs; this
+// tracks that second request so the drive panels can show their own spinner without blocking the tab.
+const driveLoading = ref(false)
 // Folded in from the retired dashboard: reply-source attribution + geographic hotspots
 // (fetched in parallel from the metrics endpoint, which already computes them).
 const replySource = ref([])
@@ -692,6 +707,42 @@ async function fetchAnalytics() {
     error.value = e.message || 'Unknown error'
   } finally {
     loading.value = false
+  }
+  // Drive-time metrics are a slow sampled routing pass (~250 isochrone calls). Load them AFTER the
+  // KPIs are on screen, not blocking them — the drive panels show their own spinner meanwhile.
+  // Skip it if the KPIs failed: there are no panels to fill, so don't hit the routing graph.
+  if (!error.value && s1.value) loadDriveTimes()
+}
+
+async function loadDriveTimes() {
+  // Remember which selection this pass is for, so a slow in-flight response can't overwrite the
+  // panels after the user has moved to a different density/window.
+  const forStratum = stratum.value
+  const forStart = startDate.value
+  const forEnd = endDate.value
+  const isStale = () =>
+    forStratum !== stratum.value ||
+    forStart !== startDate.value ||
+    forEnd !== endDate.value
+  driveLoading.value = true
+  try {
+    const d = await apiInstance.rippling.fetchAnalyticsDriveTimes(
+      forStratum,
+      forStart,
+      forEnd
+    )
+    if (isStale()) return
+    if (s1.value && d?.reply_drive_min)
+      s1.value.reply_drive_min = d.reply_drive_min
+    if (s3.value && d?.ripple_drive_min)
+      s3.value.ripple_drive_min = d.ripple_drive_min
+    s2.value = { ...s2.value, drive_time: d?.drive_time || [] }
+    bull.value = d?.bullseye || []
+  } catch (e) {
+    // Non-fatal: the KPIs are already shown. Leave the drive panels in their "no sample" state.
+  } finally {
+    // Only clear the spinner if a newer request hasn't already taken over.
+    if (!isStale()) driveLoading.value = false
   }
 }
 function setStratum(v) {

--- a/iznik-nuxt3/tests/unit/components/modtools/ModSysAdminRipplingAnalytics.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModSysAdminRipplingAnalytics.spec.js
@@ -4,12 +4,14 @@ import { mount, flushPromises } from '@vue/test-utils'
 import ModSysAdminRipplingAnalytics from '~/modtools/components/ModSysAdminRipplingAnalytics.vue'
 
 const mockFetchAnalytics = vi.fn()
+const mockFetchAnalyticsDriveTimes = vi.fn()
 const mockFetchMetrics = vi.fn().mockResolvedValue({})
 
 vi.mock('~/api', () => ({
   default: () => ({
     rippling: {
       fetchAnalytics: mockFetchAnalytics,
+      fetchAnalyticsDriveTimes: mockFetchAnalyticsDriveTimes,
       fetchMetrics: mockFetchMetrics,
     },
   }),
@@ -166,8 +168,39 @@ const FULL = {
   ],
 }
 
+// The endpoint is split: /rippling/analytics returns fast SQL KPIs (drive-time fields blank), and
+// /rippling/analytics/drivetime returns the slow sampled routing pass. These helpers split the
+// combined FULL fixture the same way, so the component is exercised through both requests.
+const BLANK_DRIVE = {
+  mean_min: 0,
+  ci_half_min: 0,
+  n_replies: 0,
+  available: false,
+}
+function fastOf(full) {
+  return {
+    ...full,
+    section1: { ...full.section1, reply_drive_min: { ...BLANK_DRIVE } },
+    section2: { ...full.section2, drive_time: [] },
+    section3: { ...full.section3, ripple_drive_min: { ...BLANK_DRIVE } },
+    bullseye: [],
+  }
+}
+function driveOf(full) {
+  return {
+    reply_drive_min: full.section1.reply_drive_min,
+    ripple_drive_min: full.section3.ripple_drive_min,
+    drive_time: full.section2.drive_time,
+    bullseye: full.bullseye,
+  }
+}
+
 describe('ModSysAdminRipplingAnalytics', () => {
-  beforeEach(() => mockFetchAnalytics.mockReset())
+  beforeEach(() => {
+    mockFetchAnalytics.mockReset()
+    mockFetchAnalyticsDriveTimes.mockReset()
+    mockFetchAnalyticsDriveTimes.mockResolvedValue(driveOf(FULL))
+  })
 
   it('fetches with the default stratum + date range on mount', async () => {
     mockFetchAnalytics.mockResolvedValue({})
@@ -182,7 +215,7 @@ describe('ModSysAdminRipplingAnalytics', () => {
   })
 
   it('renders Section 1 KPIs from the response', async () => {
-    mockFetchAnalytics.mockResolvedValue(FULL)
+    mockFetchAnalytics.mockResolvedValue(fastOf(FULL))
     const wrapper = mountComponent()
     await flushPromises()
     const html = wrapper.html()
@@ -198,7 +231,7 @@ describe('ModSysAdminRipplingAnalytics', () => {
   })
 
   it('uses one consistent green across every pie (positive slice first)', async () => {
-    mockFetchAnalytics.mockResolvedValue(FULL)
+    mockFetchAnalytics.mockResolvedValue(fastOf(FULL))
     const wrapper = mountComponent()
     await flushPromises()
     const pies = wrapper
@@ -212,7 +245,7 @@ describe('ModSysAdminRipplingAnalytics', () => {
   })
 
   it('renders a separate trend chart per metric (incl. freeglers + drive-time)', async () => {
-    mockFetchAnalytics.mockResolvedValue(FULL)
+    mockFetchAnalytics.mockResolvedValue(fastOf(FULL))
     const wrapper = mountComponent()
     await flushPromises()
     expect(wrapper.html()).toContain('Trends')
@@ -227,7 +260,7 @@ describe('ModSysAdminRipplingAnalytics', () => {
   })
 
   it('answers "is rippling helping?" as a contribution range with a rescue floor', async () => {
-    mockFetchAnalytics.mockResolvedValue(FULL)
+    mockFetchAnalytics.mockResolvedValue(fastOf(FULL))
     const wrapper = mountComponent()
     await flushPromises()
     const html = wrapper.html()
@@ -243,7 +276,7 @@ describe('ModSysAdminRipplingAnalytics', () => {
   })
 
   it('folds in the attribution channels + geographic hotspots from the metrics call', async () => {
-    mockFetchAnalytics.mockResolvedValue(FULL)
+    mockFetchAnalytics.mockResolvedValue(fastOf(FULL))
     mockFetchMetrics.mockResolvedValueOnce({
       reply_source_split: [
         { day: '2026-06-24', home: 5, ripple_notified: 2, ripple_reach: 1 },
@@ -271,7 +304,7 @@ describe('ModSysAdminRipplingAnalytics', () => {
   })
 
   it('draws the reliability bullseye: a ring per drive-time band, empty rings greyed', async () => {
-    mockFetchAnalytics.mockResolvedValue(FULL)
+    mockFetchAnalytics.mockResolvedValue(fastOf(FULL))
     const wrapper = mountComponent()
     await flushPromises()
     const html = wrapper.html()
@@ -296,7 +329,7 @@ describe('ModSysAdminRipplingAnalytics', () => {
   })
 
   it('highlights the active density and refetches on change (defaults to All)', async () => {
-    mockFetchAnalytics.mockResolvedValue(FULL)
+    mockFetchAnalytics.mockResolvedValue(fastOf(FULL))
     const wrapper = mountComponent()
     await flushPromises()
 
@@ -315,6 +348,37 @@ describe('ModSysAdminRipplingAnalytics', () => {
       '2026-07-08'
     )
     expect(wrapper.findAll('.seg-btn')[1].classes()).toContain('active')
+    wrapper.unmount()
+  })
+
+  it('renders KPIs immediately and fills the drive-time panels from a separate request', async () => {
+    mockFetchAnalytics.mockResolvedValue(fastOf(FULL))
+    // Hold the slow routing pass open so we can assert the page is usable before it resolves.
+    let resolveDrive
+    mockFetchAnalyticsDriveTimes.mockReturnValue(
+      new Promise((resolve) => {
+        resolveDrive = resolve
+      })
+    )
+    const wrapper = mountComponent()
+    await flushPromises()
+
+    // The SQL KPIs are on screen even though the routing pass has NOT resolved.
+    expect(wrapper.html()).toContain('51.2%')
+    // The drive-time value isn't shown yet — a sampling spinner is in its place.
+    expect(wrapper.html()).not.toContain('17.2')
+    expect(wrapper.html()).toContain('sampling drive-times')
+
+    // Resolve the routing pass: the drive panels + bullseye now fill in.
+    resolveDrive(driveOf(FULL))
+    await flushPromises()
+    expect(wrapper.html()).toContain('17.2') // reply drive-time
+    expect(wrapper.html()).toContain('How reliably does a reply convert') // bullseye
+    expect(mockFetchAnalyticsDriveTimes).toHaveBeenCalledWith(
+      'all',
+      '2026-06-24',
+      '2026-07-08'
+    )
     wrapper.unmount()
   })
 })

--- a/iznik-server-go/rippling/analytics.go
+++ b/iznik-server-go/rippling/analytics.go
@@ -408,18 +408,26 @@ type Section1KPI struct {
 // @Produce json
 // @Security BearerAuth
 // @Success 200 {object} map[string]interface{}
-func Analytics(c *fiber.Ctx) error {
-	db := database.DBConn
-	stratum := c.Query("stratum", "all")
-	start := c.Query("start")
-	end := c.Query("end")
+// analyticsWindow parses the shared stratum + [start,end) window query params, defaulting to the
+// last 30 days, and returns the density SQL predicate. Used by both the fast SQL Analytics handler
+// and the slow AnalyticsDriveTimes routing pass so their windows match exactly.
+func analyticsWindow(c *fiber.Ctx) (stratum, start, end, stratumSQL string) {
+	stratum = c.Query("stratum", "all")
+	start = c.Query("start")
+	end = c.Query("end")
 	if start == "" {
 		start = time.Now().AddDate(0, 0, -30).Format("2006-01-02 15:04:05")
 	}
 	if end == "" {
 		end = time.Now().Format("2006-01-02 15:04:05")
 	}
-	stratumSQL := StratumFilter(stratum)
+	stratumSQL = StratumFilter(stratum)
+	return
+}
+
+func Analytics(c *fiber.Ctx) error {
+	db := database.DBConn
+	stratum, start, end, stratumSQL := analyticsWindow(c)
 
 	// Section 1 counts - pure SQL, full set. Per-post nreplies/taken/freeglers, then aggregate.
 	var agg struct {
@@ -478,22 +486,25 @@ func Analytics(c *fiber.Ctx) error {
 		kpi.HeldRepliesPct = float64(held) / float64(agg.TotalReplies) * 100
 	}
 
-	// ONE sampled routing pass feeds every drive-time figure: the Section 1 overall mean, the
-	// Section 3 rippled-out mean, and the drive-time trend - no re-calling the graph.
-	obs := scoreSample(fetchDriveSample(start, end, stratumSQL, driveSampleSize()))
-	kpi.ReplyDrive = statFromObs(obs, false)
+	// The drive-time figures (the Section 1 overall mean, the Section 3 rippled-out mean, the
+	// per-day trend and the reliability bullseye) all come from a sampled routing pass - ~250
+	// isochrone calls that take tens of seconds (worse over the apiv2-live tunnel). They are NOT
+	// computed here: the frontend fetches them separately from AnalyticsDriveTimes so these fast
+	// SQL KPIs render immediately instead of the whole tab blocking on the routing graph.
+	// kpi.ReplyDrive and s3.RippleDrive keep their zero value (Available:false), so the UI shows a
+	// "sampling..." placeholder until the drive-time request fills them in.
 
 	// Section 2 - trends: the SQL KPIs (reply rate, taken rate, mean replies, freeglers reached)
-	// per arrival day, plus the sample-based drive-time trend from the pass above.
+	// per arrival day. The sample-based drive-time trend is merged in client-side from the
+	// separate drive-time request.
 	trend := fiber.Map{
 		"kpis":       trendSeries(start, end, stratumSQL),
-		"drive_time": driveTrendFromObs(obs),
+		"drive_time": []DriveTrendPoint{},
 	}
 
 	// Section 3 - is rippling helping? Server-derived rippled-out shares, the rescue floor and
-	// contribution range, the home-vs-rippled comparison, and the rippled-out mean drive-time.
+	// contribution range, and the home-vs-rippled comparison. RippleDrive fills in separately.
 	s3 := rippledOutSection(start, end, stratumSQL)
-	s3.RippleDrive = statFromObs(obs, true)
 
 	return c.JSON(fiber.Map{
 		"stratum":       stratum,
@@ -503,8 +514,37 @@ func Analytics(c *fiber.Ctx) error {
 		"section1":      kpi,
 		"section2":      trend,
 		"section3":      s3,
-		// Reliability bullseye: reply->take conversion by drive-time ring, from the same sample.
-		"bullseye": bullseyeFromObs(obs),
+	})
+}
+
+// AnalyticsDriveTimes is the SLOW half of the analytics tab: the sampled drive-time routing pass.
+// Split out from Analytics so the fast SQL KPIs render immediately and these figures fill in
+// progressively, rather than the whole tab blocking on ~250 isochrone calls against the routing
+// graph (tens of seconds, and slower still over the apiv2-live tunnel). ONE sampled pass still
+// feeds every figure - the Section 1 overall mean, the Section 3 rippled-out mean, the per-day
+// trend and the reliability bullseye - so nothing re-calls the graph. Support/Admin only. Read-only.
+//
+// @Router /rippling/analytics/drivetime [get]
+// @Summary Sampled drive-time rippling analytics (sysadmin) - slow routing pass, loaded separately
+// @Tags rippling
+// @Produce json
+// @Security BearerAuth
+// @Success 200 {object} map[string]interface{}
+func AnalyticsDriveTimes(c *fiber.Ctx) error {
+	stratum, start, end, stratumSQL := analyticsWindow(c)
+
+	// ONE sampled routing pass feeds every drive-time figure.
+	obs := scoreSample(fetchDriveSample(start, end, stratumSQL, driveSampleSize()))
+
+	return c.JSON(fiber.Map{
+		"stratum":          stratum,
+		"start":            start,
+		"end":              end,
+		"sample_target":    driveSampleSize(),
+		"reply_drive_min":  statFromObs(obs, false), // Section 1 overall mean
+		"ripple_drive_min": statFromObs(obs, true),  // Section 3 rippled-out mean
+		"drive_time":       driveTrendFromObs(obs),  // Section 2 per-day trend
+		"bullseye":         bullseyeFromObs(obs),    // reply->take conversion by drive-time ring
 	})
 }
 

--- a/iznik-server-go/router/routes.go
+++ b/iznik-server-go/router/routes.go
@@ -541,6 +541,9 @@ func SetupRoutes(app *fiber.App) {
 		ripplingAdmin.Use(config.RequireSupportOrAdminMiddleware())
 		ripplingAdmin.Get("/metrics", rippling.Metrics)
 		ripplingAdmin.Get("/analytics", rippling.Analytics)
+		// The slow sampled drive-time pass is fetched separately so the fast SQL KPIs above
+		// aren't blocked on ~250 isochrone calls against the routing graph.
+		ripplingAdmin.Get("/analytics/drivetime", rippling.AnalyticsDriveTimes)
 
 		// Create a protected route group for admin endpoints
 		adminConfig := rg.Group("/config/admin")

--- a/plans/active/rippling-sysadmin-analytics.md
+++ b/plans/active/rippling-sysadmin-analytics.md
@@ -99,6 +99,31 @@ existed only as a static SVG in the reach-tuning writeup - never wired into the 
   which the component didn't render. Reconciled the component copy to its spec (uncommitted; belongs
   with the hold-web-replies feature, not the bullseye PR).
 
+## Progressive drive-time load (2026-07-09)
+Edward: the tab "takes a crazy amount of time to load... stuck on sampling drive-times from the
+routing graph". Root cause: `Analytics` computed the sampled routing pass (`scoreSample` →
+~250 `/v1/ripple-eval` isochrone calls, tens of seconds, worse over the apiv2-live tunnel) INLINE
+and blocked the whole response — the fast SQL KPIs waited behind it, so the whole tab hung.
+- **Split the endpoint.** `GET /rippling/analytics` now returns only the pure-SQL KPIs
+  (section1/2/3), fast. The routing pass moved to a new `GET /rippling/analytics/drivetime`
+  (`AnalyticsDriveTimes`) returning just the drive-derived blocks: `reply_drive_min`,
+  `ripple_drive_min`, `drive_time` (trend) and `bullseye`. Shared `analyticsWindow(c)` helper keeps
+  both handlers' window/stratum parsing identical. Still ONE sampled pass — no extra routing cost.
+- **Frontend loads progressively.** `fetchAnalytics` renders the KPIs immediately, then fires
+  `loadDriveTimes()` (not awaited). The four drive panels (Section 1 travel, Section 3 rippled
+  travel, the drive-time trend chart, the bullseye) show their own `driveLoading` spinner and fill
+  in when the routing pass returns. A stale-guard (captured stratum+window) stops a slow in-flight
+  response overwriting the panels after the user switches density/window. On KPI error the routing
+  pass is skipped entirely.
+- Net: tab is usable in ~1s instead of hanging on the routing graph; drive-times trickle in.
+- **Follow-up (not done, needs a routing-server deploy):** `/v1/ripple-eval` computes a full 45-min
+  isochrone AND a `within_coords` freegler enumeration + per-freegler `nearestNodeForMode` loop
+  (the known hottest loop per the routing-perf study), but analytics reads ONLY `drive_min` per
+  replier point. A lightweight point-to-point route reusing `costToTargets` (multi-target Dijkstra,
+  early-termination + bbox prune, already in `iznik-routing-go/proximity.go`) would cut each call
+  from full-isochrone+enumeration to settling a handful of targets — a step-change in the actual
+  drive-time latency, on top of the perceived-latency win above.
+
 ## Notes
 - Read-only prod convention: endpoint must not write. Sampling is read-only.
 - Coverage: this is exploratory sysadmin analytics; keep the routing helper thin + unit-test the pure bits (band/stratum classification, mean calc). Full routing not unit-tested (external).


### PR DESCRIPTION
## Problem
The sysadmin **Rippling** analytics tab hangs for tens of seconds before rendering anything. `GET /rippling/analytics` computed the sampled drive-time routing pass **inline** — ~250 `/v1/ripple-eval` isochrone calls (each a 45-min isochrone), tens of seconds on prod and worse over the apiv2-live tunnel. The fast pure-SQL KPIs waited behind it, so the whole tab was stuck on *"sampling drive-times from the routing graph…"*.

## Fix — split the endpoint, load progressively
- **`GET /rippling/analytics`** now returns only the fast SQL KPIs (sections 1–3), rendering in ~1s.
- **`GET /rippling/analytics/drivetime`** (new) runs the one sampled routing pass and returns just the drive-derived blocks: `reply_drive_min`, `ripple_drive_min`, the per-day `drive_time` trend, and the `bullseye`. A shared `analyticsWindow()` helper keeps both handlers' window/stratum identical. **No extra routing cost** — still one sampled pass.
- **Frontend** renders the KPIs immediately, then fetches drive-times separately; the four drive panels show their own spinner and fill in when ready. A stale-guard (captured stratum+window) stops a slow in-flight response overwriting the panels after a density/window switch; on a KPI error the routing pass is skipped.

Net: usable in ~1s instead of hanging on the routing graph.

## Tests
- Go: new `AnalyticsDriveTimes` handler + `/rippling/analytics/drivetime` route.
- Vitest: `ModSysAdminRipplingAnalytics.spec.js` splits the fixture across the two requests and adds a test asserting KPIs render **before** the routing pass resolves, then the panels fill in after.

## Follow-up (not in this PR)
`/v1/ripple-eval` computes a full isochrone **plus** a freegler enumeration analytics never reads. Pointing it at the existing `costToTargets` (multi-target Dijkstra, early-termination) in `iznik-routing-go` would cut actual drive-time latency ~10x on top of this perceived-latency win — needs a routing-server deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)