### PR TITLE
feat(browse): 'Near: <places>' hint under the distance slider

### DIFF
--- a/iznik-nuxt3/api/TownAPI.js
+++ b/iznik-nuxt3/api/TownAPI.js
@@ -1,0 +1,9 @@
+import BaseAPI from '@/api/BaseAPI'
+
+export default class TownAPI extends BaseAPI {
+  // Up to 5 town names the browse/feed distance slider reaches from (lat,lng), by travel
+  // (drive-time), furthest-selected and ordered biggest-first. Names only - no distance/time units.
+  fetchNear(lat, lng, miles) {
+    return this.$getv2('/town/near', { lat, lng, miles })
+  }
+}

--- a/iznik-nuxt3/api/index.js
+++ b/iznik-nuxt3/api/index.js
@@ -42,6 +42,7 @@ import NewsAPI from './NewsAPI.js'
 import NoticeboardAPI from './NoticeboardAPI.js'
 import NotificationAPI from './NotificationAPI.js'
 import RipplingAPI from './RipplingAPI.js'
+import TownAPI from './TownAPI.js'
 import SessionAPI from './SessionAPI.js'
 import ShortlinksAPI from './ShortlinksAPI.js'
 import SpammersAPI from './SpammersAPI.js'
@@ -93,6 +94,7 @@ export default (config) => {
     noticeboard: new NoticeboardAPI(options),
     notification: new NotificationAPI(options),
     rippling: new RipplingAPI(options),
+    town: new TownAPI(options),
     session: new SessionAPI(options),
     shortlinks: new ShortlinksAPI(options),
     spammers: new SpammersAPI(options),

--- a/iznik-nuxt3/components/NearbyTowns.vue
+++ b/iznik-nuxt3/components/NearbyTowns.vue
@@ -6,7 +6,7 @@
     pulsating loader while fetching, the list when found, and nothing (space kept) when none.
   -->
   <div
-    v-observe-visibility="{ callback: onVisibility, once: true }"
+    v-observe-visibility="onVisibility"
     class="nearby-towns text-muted small mt-1"
     aria-live="polite"
   >

--- a/iznik-nuxt3/components/NearbyTowns.vue
+++ b/iznik-nuxt3/components/NearbyTowns.vue
@@ -1,0 +1,47 @@
+<template>
+  <p v-if="towns.length" class="nearby-towns text-muted small mb-0 mt-1">
+    Near: {{ towns.join(', ') }}
+  </p>
+</template>
+
+<script setup>
+import { ref, watch } from 'vue'
+import { useMe } from '~/composables/useMe'
+import api from '~/api'
+
+// "Near: <places>" under a distance slider - the (up to 5) FURTHEST towns the current setting
+// reaches by travel, biggest first. Names only, no units, so the miles-slider / drive-time
+// mismatch is invisible. Debounced so dragging doesn't spam the routing pass.
+const props = defineProps({
+  miles: { type: Number, required: true },
+})
+
+const runtimeConfig = useRuntimeConfig()
+const apiInstance = api(runtimeConfig)
+const { me } = useMe()
+
+const towns = ref([])
+let timer = null
+
+watch(
+  () => props.miles,
+  (miles) => {
+    if (timer) clearTimeout(timer)
+    timer = setTimeout(async () => {
+      const lat = me.value?.lat
+      const lng = me.value?.lng
+      if ((!lat && !lng) || !miles) {
+        towns.value = []
+        return
+      }
+      try {
+        const r = await apiInstance.town.fetchNear(lat, lng, miles)
+        towns.value = r?.towns || []
+      } catch (e) {
+        towns.value = []
+      }
+    }, 350)
+  },
+  { immediate: true }
+)
+</script>

--- a/iznik-nuxt3/components/NearbyTowns.vue
+++ b/iznik-nuxt3/components/NearbyTowns.vue
@@ -1,7 +1,18 @@
 <template>
-  <p v-if="towns.length" class="nearby-towns text-muted small mb-0 mt-1">
-    Near: {{ towns.join(', ') }}
-  </p>
+  <!--
+    "Near: <places>" hint under a distance slider. Fixed single-line height so the async result
+    never shifts the page (CLS-safe). Renders lazily - the routing-backed fetch (~1-3s) only fires
+    once this is actually scrolled into view (most settings visits never reach it). Shows a
+    pulsating loader while fetching, the list when found, and nothing (space kept) when none.
+  -->
+  <div
+    v-observe-visibility="{ callback: onVisibility, once: true }"
+    class="nearby-towns text-muted small mt-1"
+    aria-live="polite"
+  >
+    <span v-if="loading" class="pulsate">Finding nearby places…</span>
+    <span v-else-if="towns.length">Near: {{ towns.join(', ') }}</span>
+  </div>
 </template>
 
 <script setup>
@@ -9,9 +20,8 @@ import { ref, watch } from 'vue'
 import { useMe } from '~/composables/useMe'
 import api from '~/api'
 
-// "Near: <places>" under a distance slider - the (up to 5) FURTHEST towns the current setting
-// reaches by travel, biggest first. Names only, no units, so the miles-slider / drive-time
-// mismatch is invisible. Debounced so dragging doesn't spam the routing pass.
+// Up to 5 FURTHEST towns the current setting reaches by travel, biggest-population first. Names
+// only, no units, so the miles-slider / drive-time mismatch is invisible.
 const props = defineProps({
   miles: { type: Number, required: true },
 })
@@ -21,27 +31,64 @@ const apiInstance = api(runtimeConfig)
 const { me } = useMe()
 
 const towns = ref([])
+const loading = ref(false)
+const visible = ref(false)
 let timer = null
+let seq = 0
 
+// Debounce so dragging the slider doesn't spam the (expensive) routing pass.
+function schedule() {
+  if (timer) clearTimeout(timer)
+  timer = setTimeout(fetchTowns, 350)
+}
+
+async function fetchTowns() {
+  if (!visible.value) return
+  const lat = me.value?.lat
+  const lng = me.value?.lng
+  const miles = props.miles
+  if ((!lat && !lng) || !miles) {
+    towns.value = []
+    loading.value = false
+    return
+  }
+  const mySeq = ++seq
+  loading.value = true
+  try {
+    const r = await apiInstance.town.fetchNear(lat, lng, miles)
+    if (mySeq !== seq) return // a newer request superseded this one
+    towns.value = r?.towns || []
+  } catch (e) {
+    if (mySeq === seq) towns.value = []
+  } finally {
+    if (mySeq === seq) loading.value = false
+  }
+}
+
+// Lazy: first time it scrolls into view, fetch. Thereafter re-fetch on slider changes.
+function onVisibility(isVisible) {
+  if (isVisible && !visible.value) {
+    visible.value = true
+    schedule()
+  }
+}
 watch(
   () => props.miles,
-  (miles) => {
-    if (timer) clearTimeout(timer)
-    timer = setTimeout(async () => {
-      const lat = me.value?.lat
-      const lng = me.value?.lng
-      if ((!lat && !lng) || !miles) {
-        towns.value = []
-        return
-      }
-      try {
-        const r = await apiInstance.town.fetchNear(lat, lng, miles)
-        towns.value = r?.towns || []
-      } catch (e) {
-        towns.value = []
-      }
-    }, 350)
-  },
-  { immediate: true }
+  () => {
+    if (visible.value) schedule()
+  }
 )
 </script>
+
+<style scoped>
+.nearby-towns {
+  /* Reserve exactly one line, always, so the loader/results appearing never shift the layout
+     (CLS). One line + ellipsis: names are ordered biggest-first, so any overflow drops the
+     smaller places, never the significant ones. */
+  height: 1.25rem;
+  line-height: 1.25rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+</style>

--- a/iznik-nuxt3/components/PostFilters.vue
+++ b/iznik-nuxt3/components/PostFilters.vue
@@ -35,6 +35,7 @@
             aria-label="Maximum distance"
             @change="onSliderChange"
           />
+          <NearbyTowns :miles="sliderValue" />
         </div>
         <div class="sort mb-2">
           <label for="sortOptions">Sort by:</label>
@@ -139,6 +140,7 @@ import { useAuthStore } from '~/stores/auth'
 import { useMe } from '~/composables/useMe'
 import { BROWSE_DISTANCE_UNLIMITED } from '~/constants'
 import RangeSlider from '~/components/RangeSlider.vue'
+import NearbyTowns from '~/components/NearbyTowns.vue'
 import WhichPostsModal from '~/components/WhichPostsModal.vue'
 
 const props = defineProps({

--- a/iznik-nuxt3/components/settings/FeedSettingsSection.vue
+++ b/iznik-nuxt3/components/settings/FeedSettingsSection.vue
@@ -26,6 +26,7 @@
         aria-label="How far away"
         @change="onSliderChange"
       />
+      <NearbyTowns :miles="sliderValue" />
     </div>
   </div>
 </template>
@@ -35,6 +36,7 @@ import { ref, computed, watch, defineEmits } from 'vue'
 import { useAuthStore } from '~/stores/auth'
 import { useMe } from '~/composables/useMe'
 import RangeSlider from '~/components/RangeSlider.vue'
+import NearbyTowns from '~/components/NearbyTowns.vue'
 import { BROWSE_DISTANCE_UNLIMITED } from '~/constants'
 
 const emit = defineEmits(['update'])

--- a/iznik-server-go/router/routes.go
+++ b/iznik-server-go/router/routes.go
@@ -73,6 +73,7 @@ import (
 	"github.com/freegle/iznik-server-go/story"
 	"github.com/freegle/iznik-server-go/systemlogs"
 	"github.com/freegle/iznik-server-go/team"
+	"github.com/freegle/iznik-server-go/town"
 	"github.com/freegle/iznik-server-go/tryst"
 	"github.com/freegle/iznik-server-go/user"
 	"github.com/freegle/iznik-server-go/userdump"
@@ -849,6 +850,7 @@ func SetupRoutes(app *fiber.App) {
 
 		// Location Search (GET /locations - search by lat/lng, typeahead, or bounding box)
 		rg.Get("/locations", location.SearchLocations)
+		rg.Get("/town/near", town.Near)
 
 		// Location Write Operations
 		rg.Put("/locations", location.CreateLocation)

--- a/iznik-server-go/test/town_near_test.go
+++ b/iznik-server-go/test/town_near_test.go
@@ -1,0 +1,31 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/freegle/iznik-server-go/town"
+	"github.com/stretchr/testify/assert"
+)
+
+func townDriveMin(v float64) *float64 { return &v }
+
+// SelectNear picks the FURTHEST towns reachable within the drive-time budget (so the "Near: ..."
+// hint changes as the slider widens) and returns their names in descending-population order
+// (ascending town id). Unreachable (nil) and beyond-budget towns are excluded.
+func TestTownSelectNear(t *testing.T) {
+	cands := []town.TownCand{
+		{ID: 1, Name: "Big", DriveMin: townDriveMin(5)},
+		{ID: 2, Name: "MidFar", DriveMin: townDriveMin(28)},
+		{ID: 3, Name: "Near2", DriveMin: townDriveMin(8)},
+		{ID: 4, Name: "FarSmall", DriveMin: townDriveMin(25)},
+		{ID: 5, Name: "Unreachable", DriveMin: nil},
+		{ID: 6, Name: "TooFar", DriveMin: townDriveMin(40)},
+	}
+	// Furthest 3 reachable within 30 min, displayed by population (ascending id).
+	assert.Equal(t, []string{"MidFar", "Near2", "FarSmall"}, town.SelectNear(cands, 30, 3))
+	// Fewer reachable than the limit -> all reachable, population order.
+	assert.Equal(t, []string{"Big", "MidFar", "Near2", "FarSmall"}, town.SelectNear(cands, 30, 5))
+	// None reachable in a tight budget, and empty input.
+	assert.Empty(t, town.SelectNear(cands, 3, 5))
+	assert.Empty(t, town.SelectNear(nil, 30, 5))
+}

--- a/iznik-server-go/town/town.go
+++ b/iznik-server-go/town/town.go
@@ -1,0 +1,162 @@
+package town
+
+// The "Near: ..." hint under the browse/feed distance slider. Given the user's location and the
+// slider's distance, list up to 5 towns the setting reaches - by REAL travel (drive-time via the
+// routing server's ripple-eval), not crow-flies. We show place NAMES only, never any distance or
+// time units, so the miles-slider / drive-time-metric mismatch is invisible: the user just sees
+// which places their setting covers, and the list changes as they drag.
+
+import (
+	"bytes"
+	"encoding/json"
+	"math"
+	"net/http"
+	"os"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/gofiber/fiber/v2"
+)
+
+// routingEvalURL / routingClient reach the routing server's /v1/ripple-eval (real drive times).
+// Mirrors rippling/analytics.go's client, kept local so the packages stay independent.
+func routingEvalURL() string {
+	if u := os.Getenv("ROUTING_EVAL_URL"); u != "" {
+		return u
+	}
+	if u := os.Getenv("SPATIAL_KNN_URL"); u != "" {
+		return u
+	}
+	return "http://spatial:8194"
+}
+
+var routingClient = &http.Client{Timeout: 15 * time.Second}
+
+// milesToDriveMinutes turns the slider's miles into a drive-time budget for the isochrone. No units
+// are ever shown, so this only needs to be monotonic and roughly realistic: ~2 min/mile (a blended
+// ~30mph). Floored/capped so the extremes stay sane ("no limit" doesn't route the whole country).
+func milesToDriveMinutes(miles float64) float64 {
+	m := miles * 2.0
+	if m > 120 {
+		m = 120
+	}
+	if m < 5 {
+		m = 5
+	}
+	return m
+}
+
+// TownCand is a candidate town with its drive-time from the user (nil = unreachable in the budget).
+type TownCand struct {
+	ID       uint64
+	Name     string
+	DriveMin *float64
+}
+
+// SelectNear picks the FURTHEST towns reachable within maxMinutes (so the list changes as the range
+// widens, rather than always showing the same nearest places), then returns their names ordered by
+// population. The towns table is curated in descending-population order by ascending id, so a
+// smaller id is a bigger place. Returns up to `limit` names.
+func SelectNear(cands []TownCand, maxMinutes float64, limit int) []string {
+	reachable := make([]TownCand, 0, len(cands))
+	for _, c := range cands {
+		if c.DriveMin != nil && *c.DriveMin <= maxMinutes {
+			reachable = append(reachable, c)
+		}
+	}
+	// Furthest first (largest drive-time); tie-break by bigger population (smaller id) for stability.
+	sort.Slice(reachable, func(i, j int) bool {
+		if *reachable[i].DriveMin != *reachable[j].DriveMin {
+			return *reachable[i].DriveMin > *reachable[j].DriveMin
+		}
+		return reachable[i].ID < reachable[j].ID
+	})
+	if len(reachable) > limit {
+		reachable = reachable[:limit]
+	}
+	// Display order: population descending (ascending id).
+	sort.Slice(reachable, func(i, j int) bool { return reachable[i].ID < reachable[j].ID })
+	out := make([]string, 0, len(reachable))
+	for _, c := range reachable {
+		out = append(out, c.Name)
+	}
+	return out
+}
+
+type rippleEvalReq struct {
+	Lat        float64      `json:"lat"`
+	Lng        float64      `json:"lng"`
+	Mode       string       `json:"mode"`
+	MaxMinutes float64      `json:"max_minutes"`
+	Points     [][2]float64 `json:"points"`
+}
+type rippleEvalResp struct {
+	Results []struct {
+		DriveMin *float64 `json:"drive_min"`
+	} `json:"results"`
+}
+
+// Near returns up to 5 town names the given slider distance reaches from (lat,lng), by travel,
+// furthest-selected and population-ordered - for the "Near: ..." hint under the distance slider.
+// Names only, no units. Best-effort: any routing/DB failure returns an empty list (the hint hides).
+//
+// @Router /town/near [get]
+// @Summary Up to 5 towns the browse/feed distance slider reaches (by drive-time), names only
+// @Tags location
+// @Produce json
+// @Success 200 {object} map[string]interface{}
+func Near(c *fiber.Ctx) error {
+	lat, _ := strconv.ParseFloat(c.Query("lat"), 64)
+	lng, _ := strconv.ParseFloat(c.Query("lng"), 64)
+	miles, _ := strconv.ParseFloat(c.Query("miles"), 64)
+	empty := fiber.Map{"towns": []string{}}
+	if (lat == 0 && lng == 0) || miles <= 0 {
+		return c.JSON(empty)
+	}
+	maxMin := milesToDriveMinutes(miles)
+
+	// Candidate towns within a generous crow-flies box (travel >= crow-flies, and fast roads can
+	// cover ~2x the miles in the same minutes) so we don't route the whole country. The towns
+	// table is tiny (~234 rows), so this stays cheap.
+	boxMiles := miles*2 + 5
+	latDeg := boxMiles / 69.0
+	lngDeg := boxMiles / (69.0 * math.Cos(lat*math.Pi/180))
+	db := database.DBConn
+	type row struct {
+		ID   uint64
+		Name string
+		Lat  float64
+		Lng  float64
+	}
+	var rows []row
+	db.Raw(`SELECT id, name, lat, lng FROM towns
+		WHERE lat IS NOT NULL AND lng IS NOT NULL
+		  AND lat BETWEEN ? AND ? AND lng BETWEEN ? AND ?
+		ORDER BY id`,
+		lat-latDeg, lat+latDeg, lng-lngDeg, lng+lngDeg).Scan(&rows)
+	if len(rows) == 0 {
+		return c.JSON(empty)
+	}
+
+	points := make([][2]float64, len(rows))
+	for i, r := range rows {
+		points[i] = [2]float64{r.Lng, r.Lat} // [lng, lat] GeoJSON order
+	}
+	body, _ := json.Marshal(rippleEvalReq{Lat: lat, Lng: lng, Mode: "drive", MaxMinutes: maxMin, Points: points})
+	resp, err := routingClient.Post(routingEvalURL()+"/v1/ripple-eval", "application/json", bytes.NewReader(body))
+	if err != nil {
+		return c.JSON(empty)
+	}
+	defer resp.Body.Close()
+	var r rippleEvalResp
+	if resp.StatusCode != http.StatusOK || json.NewDecoder(resp.Body).Decode(&r) != nil || len(r.Results) != len(rows) {
+		return c.JSON(empty)
+	}
+	cands := make([]TownCand, len(rows))
+	for i, rw := range rows {
+		cands[i] = TownCand{ID: rw.ID, Name: rw.Name, DriveMin: r.Results[i].DriveMin}
+	}
+	return c.JSON(fiber.Map{"towns": SelectNear(cands, maxMin, 5)})
+}


### PR DESCRIPTION
## What
The distance slider (browse **and** feed settings) sits next to a map that's hard to read on mobile. This adds a plain-text hint **under the slider**: *"Near: Leeds, Bradford, Rochdale, Huddersfield, Ashton-under-Lyne"* — up to 5 towns the current setting reaches.

Design choices (per discussion):
- **Travel, not crow-flies** — drive-time via the routing server's `ripple-eval`.
- **Furthest-selected** — the 5 *furthest* reachable towns, so the list actually changes as you drag the slider (nearest towns are always covered and wouldn't change).
- **Biggest first** — ordered by population.
- **No units** — names only, so the miles-slider / drive-time-metric mismatch is invisible.
- Always shown under the slider (both places).

## How
**Backend** — `GET /town/near?lat&lng&miles` → `{ "towns": [...] }`:
- Candidate towns from the curated **`towns`** table (234 UK towns, already population-ordered by ascending `id`) within a generous crow-flies box.
- Scored for drive-time via `ripple-eval` (reuses the routing client).
- `SelectNear` (pure, unit-tested) filters to reachable, takes the furthest N, orders by population.
- Best-effort: any routing/DB failure returns an empty list, so the hint just hides.

**Frontend** — `<NearbyTowns :miles="sliderValue" />` under the `RangeSlider` in `PostFilters.vue` (browse) and `FeedSettingsSection.vue` (settings); debounced, keyed on the user's `me.lat/lng`.

## Tests
- Go: `TestTownSelectNear` covers furthest-selection + population ordering, unreachable/over-budget exclusion, and empty input.

## Note
Uses drive-time as the travel metric (no routing-server change/deploy needed). A true road-**miles** metric would need a small `iznik-routing-go` endpoint (`costToTargets`+`pathMetres`) + deploy — deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)