### PR TITLE
Distance preference caps who sees your posts + frontier-range town hint

### DIFF
--- a/docs/developers/reference/rippling-algorithm.md
+++ b/docs/developers/reference/rippling-algorithm.md
@@ -217,7 +217,11 @@ retracted, so re-approval restores the copy without re-rippling.
 
 - **Browse / Nearby feed:** members see rippled-in posts via
   `ST_Contains(rippling_reach.polygon, member point)`, filtered by the member's own distance
-  preference (`browseMaxDistance`), which also filters their mail.
+  preference (`browseMaxDistance`), which also filters their mail. `browseMaxDistance` is
+  applied in **both directions**: INBOUND (the viewer only sees/receives posts within their
+  own distance) and OUTBOUND (a post is only shown/mailed to people within the *poster's*
+  distance of it - the author-side cap in `isochrone/message.go`'s `authorReachCapWhere` and
+  the digest's `DistancePreferenceFilter::passesBothPreferences`).
 - **Unified digest distance scoring:** the reach polygon feeds each post's closeness score.
 - **Reach mail:** the join notification when a post ripples to within reach.
 - **Held replies:** replies to rippled posts held for moderator Chat Review where applicable.

--- a/docs/members/rippling-out.md
+++ b/docs/members/rippling-out.md
@@ -148,13 +148,21 @@ everything in the communities you belong to.
 
 ### A distance slider, if you want one
 
-In the browse filters there is a simple slider marked **"Nearer"** at one end and
-**"Further"** at the other - no numbers, just a feel for how far you would like posts to
-come from. It starts set to "Further", which means no extra limit beyond the posts that
-have naturally reached you. If you would rather only see things from close by, drag it
-towards "Nearer" at any time; drag it back whenever you like. Freegle remembers your
-choice, along with your other filters (which posts, which communities, and sort order), so
-you do not need to set them again next time you visit.
+In the browse filters - and in your **Settings**, under "Feed" - there is a simple slider
+marked **"Nearer"** at one end and **"Further"** at the other - no numbers, just a feel for
+how far you would like posts to come from. It starts set to "Further", which means no extra
+limit beyond the posts that have naturally reached you. If you would rather only see things
+from close by, drag it towards "Nearer" at any time; drag it back whenever you like.
+
+The same setting works **both ways**. As well as narrowing which posts you see and get
+emailed about, moving it towards "Nearer" also limits **how far away other people see your
+own posts** - handy if you would rather only hear from people who can easily get to you.
+Left at "Further", your posts reach as far as rippling naturally takes them. (It measures
+distance by road distance and travel time, not a straight line, so it follows real geography
+like estuaries and coastlines.)
+
+Freegle remembers your choice, along with your other filters (which posts, which communities,
+and sort order), so you do not need to set them again next time you visit.
 
 ### When you post, there is no group to choose
 
@@ -182,7 +190,7 @@ shows as "waiting to send" until then. Nothing is lost.
 |---|---|
 | Your post | Shown to people nearby first, then gradually further away |
 | Nearby browse order | Unseen posts first, then seen; each ordered by closeness, freshness and interest, not just newest |
-| Distance slider | Optional "Nearer/Further" filter in Browse; starts at "Further" (no extra limit) |
+| Distance slider | Optional "Nearer/Further" control in Browse and Settings; narrows what you see and are emailed about, and how far away other people see your own posts; starts at "Further" (no extra limit) |
 | Browse filters | Remembered between visits, including the distance slider |
 | New communities | You are joined automatically so replies and contact work |
 | Email defaults | Immediate is switched to daily; no-email and daily are unchanged |

--- a/docs/moderators/rippling-out.md
+++ b/docs/moderators/rippling-out.md
@@ -106,16 +106,23 @@ section above Email Settings. It is a **personal preference each member sets for
 themselves** - by default it is left at "Further" (no extra limit beyond their normal
 rippling reach), and moving it towards "Nearer" narrows how far away posts can be.
 
-Importantly, this preference now applies **both to what they see when browsing and to the
-posts in the emails we send them** (their daily digest and immediate emails). A member who
-sets it "Nearer" will stop seeing - and stop being emailed about - posts from further away,
-including rippled-in ones. It still has **no effect on rippling itself, on what other
-members see, or on moderation**, and their choice is remembered between visits.
+Importantly, this preference now applies in **three** ways:
+
+- **What they see when browsing** - moving it "Nearer" hides posts from further away.
+- **The posts we email them** (their daily digest and immediate emails) - the same narrowing.
+- **How far away other people see their own posts** (new). Setting it "Nearer" also caps who
+  their own offers and wanteds reach: someone far away won't see the post in their Nearby feed
+  or be emailed about it, even though rippling had carried it that far. Left at "Further" (the
+  default), there is no such cap and the post reaches as far as rippling takes it.
+
+It still has **no effect on the rippling engine itself** (what it approves or joins, or how far
+it carries a post) **or on moderation**, and their choice is remembered between visits.
 
 A practical consequence worth knowing: a rippled-in post is shown to the members of your
-community who are **closest to the poster and whose own distance preference reaches that
-far - not necessarily everyone**. If a member says a post "isn't showing for them", their
-distance slider being set to "Nearer" is a likely reason.
+community who are **closest to the poster, whose own distance preference reaches that far, and
+whom the poster's own distance preference reaches - not necessarily everyone**. If a member
+says a post "isn't showing for them", either their own slider *or the poster's* slider being
+set to "Nearer" is a likely reason.
 
 ---
 

--- a/iznik-batch/app/Services/Ripple/DistancePreferenceFilter.php
+++ b/iznik-batch/app/Services/Ripple/DistancePreferenceFilter.php
@@ -89,6 +89,31 @@ class DistancePreferenceFilter
     }
 
     /**
+     * Whether a candidate post passes BOTH distance caps that apply to a
+     * (post, recipient) pair, measured against the single recipient<->post
+     * great-circle distance $distanceMiles:
+     *
+     *   - INBOUND  ($recipientMaxMiles): the recipient only wants to see posts
+     *     within their chosen distance of them (settings.browseMaxDistance).
+     *   - OUTBOUND ($authorMaxMiles): the post author only wants their post shown
+     *     to people within their chosen distance of it (the same setting, read
+     *     from the author). This makes "How far away" also cap who sees your posts.
+     *
+     * Either cap being the DISTANCE_UNLIMITED sentinel disables that side (the
+     * common case). Own posts bypass both (the author is always looped back their
+     * own post), matching passes()'s own-post rule.
+     */
+    public function passesBothPreferences(
+        float $distanceMiles,
+        float $recipientMaxMiles,
+        float $authorMaxMiles,
+        bool $isOwnPost
+    ): bool {
+        return $this->passes($distanceMiles, $recipientMaxMiles, $isOwnPost)
+            && $this->passes($distanceMiles, $authorMaxMiles, $isOwnPost);
+    }
+
+    /**
      * Great-circle (haversine) distance in MILES between two (lat,lng)
      * points in degrees. The canonical distance calculation used by all
      * three insertion points, consolidating what would otherwise be a third

--- a/iznik-batch/app/Services/UnifiedDigestService.php
+++ b/iznik-batch/app/Services/UnifiedDigestService.php
@@ -367,7 +367,8 @@ class UnifiedDigestService
                     $message->lat,
                     $message->lng,
                     $user,
-                    $isOwnPost
+                    $isOwnPost,
+                    $this->authorMaxMiles((int) $message->fromuser)
                 )) {
                     continue;
                 }
@@ -719,7 +720,8 @@ class UnifiedDigestService
                     $msg->lat,
                     $msg->lng,
                     $user,
-                    $isOwnPost
+                    $isOwnPost,
+                    $this->authorMaxMiles((int) $msg->fromuser)
                 )) {
                     continue;
                 }
@@ -1263,7 +1265,8 @@ class UnifiedDigestService
                 $p->lat,
                 $p->lng,
                 $user,
-                (int) $p->fromuser === (int) $user->id
+                (int) $p->fromuser === (int) $user->id,
+                $this->authorMaxMiles((int) $p->fromuser)
             ))->values();
         }
 
@@ -1625,7 +1628,7 @@ class UnifiedDigestService
      * @param mixed $lat Post/message latitude (numeric or null).
      * @param mixed $lng Post/message longitude (numeric or null).
      */
-    private function passesDistancePreference(?array $recipientLatLng, $lat, $lng, User $user, bool $isOwnPost): bool
+    private function passesDistancePreference(?array $recipientLatLng, $lat, $lng, User $user, bool $isOwnPost, ?float $authorMaxMiles = null): bool
     {
         if ($isOwnPost) {
             return true;
@@ -1642,9 +1645,14 @@ class UnifiedDigestService
         }
 
         $filter = app(DistancePreferenceFilter::class);
-        $maxMiles = $filter->maxDistanceMiles($user);
-        if ($maxMiles >= DistancePreferenceFilter::DISTANCE_UNLIMITED) {
-            // Fast path: absent/sentinel setting, the majority case. No haversine needed.
+        // INBOUND cap: the recipient only wants posts within their chosen distance.
+        // OUTBOUND cap: the post author only wants their post shown to people within
+        // their chosen distance of it (the same setting, read from the author).
+        $recipientMax = $filter->maxDistanceMiles($user);
+        $authorMax = $authorMaxMiles ?? (float) DistancePreferenceFilter::DISTANCE_UNLIMITED;
+        if ($recipientMax >= DistancePreferenceFilter::DISTANCE_UNLIMITED
+            && $authorMax >= DistancePreferenceFilter::DISTANCE_UNLIMITED) {
+            // Fast path: neither side limits distance, the majority case. No haversine needed.
             return true;
         }
 
@@ -1655,7 +1663,27 @@ class UnifiedDigestService
             (float) $lng
         );
 
-        return $filter->passes($distanceMiles, $maxMiles, false);
+        return $filter->passesBothPreferences($distanceMiles, $recipientMax, $authorMax, false);
+    }
+
+    /**
+     * The post author's OUTBOUND distance cap in miles (settings.browseMaxDistance),
+     * memoised per author id so repeated posts by the same freegler — across
+     * recipients and groups within a run — cost a single lookup. Absent author or
+     * absent/sentinel setting resolves to DISTANCE_UNLIMITED (no outbound cap).
+     */
+    private array $authorMaxMilesCache = [];
+
+    private function authorMaxMiles(int $fromuser): float
+    {
+        if (!array_key_exists($fromuser, $this->authorMaxMilesCache)) {
+            $author = User::select('id', 'settings')->find($fromuser);
+            $this->authorMaxMilesCache[$fromuser] = $author
+                ? app(DistancePreferenceFilter::class)->maxDistanceMiles($author)
+                : (float) DistancePreferenceFilter::DISTANCE_UNLIMITED;
+        }
+
+        return $this->authorMaxMilesCache[$fromuser];
     }
 
     /**

--- a/iznik-batch/tests/Unit/Services/Ripple/DistancePreferenceFilterTest.php
+++ b/iznik-batch/tests/Unit/Services/Ripple/DistancePreferenceFilterTest.php
@@ -119,6 +119,50 @@ class DistancePreferenceFilterTest extends TestCase
         $this->assertTrue($this->filter()->passes(1000000.0, 2.0, true));
     }
 
+    // ─── OUTBOUND (author-side) distance preference ─────────────────────
+    // passesBothPreferences enforces BOTH the recipient's inbound cap AND the post
+    // author's outbound cap on the SAME recipient<->post distance: a post is shown
+    // only to people within the author's chosen distance of it, as well as within
+    // the recipient's own chosen distance. Own posts always pass.
+
+    public function test_passes_both_within_both_limits(): void
+    {
+        $this->assertTrue($this->filter()->passesBothPreferences(1.0, 2.0, 3.0, false));
+    }
+
+    public function test_passes_both_fails_when_beyond_author_limit_only(): void
+    {
+        // The recipient is happy to see far posts (cap 50) but the author capped at 2.
+        $this->assertFalse($this->filter()->passesBothPreferences(10.0, 50.0, 2.0, false));
+    }
+
+    public function test_passes_both_fails_when_beyond_recipient_limit_only(): void
+    {
+        $this->assertFalse($this->filter()->passesBothPreferences(10.0, 2.0, 50.0, false));
+    }
+
+    public function test_passes_both_fails_when_beyond_both_limits(): void
+    {
+        $this->assertFalse($this->filter()->passesBothPreferences(100.0, 2.0, 3.0, false));
+    }
+
+    public function test_passes_both_author_boundary_is_inclusive(): void
+    {
+        $this->assertTrue($this->filter()->passesBothPreferences(2.0, 50.0, 2.0, false));
+    }
+
+    public function test_passes_both_own_post_bypasses_both_limits(): void
+    {
+        $this->assertTrue($this->filter()->passesBothPreferences(1000000.0, 2.0, 2.0, true));
+    }
+
+    public function test_passes_both_unlimited_author_defers_to_recipient(): void
+    {
+        $unlimited = (float) DistancePreferenceFilter::DISTANCE_UNLIMITED;
+        $this->assertTrue($this->filter()->passesBothPreferences(10.0, 50.0, $unlimited, false));
+        $this->assertFalse($this->filter()->passesBothPreferences(10.0, 5.0, $unlimited, false));
+    }
+
     public function test_distance_miles_is_zero_at_the_same_point(): void
     {
         $this->assertSame(0.0, $this->filter()->distanceMiles(51.5, -0.1, 51.5, -0.1));

--- a/iznik-batch/tests/Unit/Services/UnifiedDigestServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/UnifiedDigestServiceTest.php
@@ -2523,6 +2523,79 @@ class UnifiedDigestServiceTest extends TestCase
         $this->assertEquals(1, $stats['emails_sent'], 'the sentinel value means unlimited — unaffected by the new filter');
     }
 
+    // ─── OUTBOUND (author-side) distance preference ─────────────────────
+    // The SAME setting, read from the POST AUTHOR, also caps who sees their post:
+    // a recipient beyond the author's browseMaxDistance of the post is filtered
+    // out even when the recipient themselves has no distance limit. (51.5, 0.4) is
+    // ~22.7 miles from the London recipient — inside a 50-mile author cap, outside
+    // a 2-mile one.
+
+    public function test_daily_digest_filters_out_post_beyond_authors_distance_preference(): void
+    {
+        config(['freegle.digest.daily_allowlist' => '*']);
+
+        // Recipient has NO distance limit of their own, so any filtering is the author's doing.
+        $recipient = $this->createTestUser();
+        $recipient->settings = [
+            'simplemail' => User::SIMPLE_MAIL_BASIC,
+            'mylocation' => ['lat' => 51.5074, 'lng' => -0.1278],
+        ];
+        $recipient->lastaccess = now();
+        $recipient->save();
+
+        // Poster caps how far away their post is shown at 2 miles.
+        $poster = $this->createTestUser();
+        $poster->settings = ['browseMaxDistance' => 2];
+        $poster->save();
+
+        $group = $this->createTestGroup();
+        $this->createMembership($recipient, $group, ['emailfrequency' => Membership::EMAIL_FREQUENCY_DAILY]);
+        $this->createMembership($poster, $group);
+
+        // ~22.7 miles from the recipient — outside the poster's 2-mile outbound cap.
+        $this->createTestMessage($poster, $group, [
+            'subject' => 'OFFER: Local-only item',
+            'lat' => 51.5,
+            'lng' => 0.4,
+        ]);
+
+        $stats = $this->service->sendDigests(UnifiedDigestService::MODE_DAILY, $recipient->id);
+
+        $this->assertEquals(0, $stats['emails_sent'], "the post is filtered out by the author's 2-mile cap, despite the recipient having no limit");
+    }
+
+    public function test_daily_digest_keeps_post_within_authors_distance_preference(): void
+    {
+        config(['freegle.digest.daily_allowlist' => '*']);
+
+        $recipient = $this->createTestUser();
+        $recipient->settings = [
+            'simplemail' => User::SIMPLE_MAIL_BASIC,
+            'mylocation' => ['lat' => 51.5074, 'lng' => -0.1278],
+        ];
+        $recipient->lastaccess = now();
+        $recipient->save();
+
+        // Poster's cap (50 miles) comfortably includes the ~22.7-mile recipient.
+        $poster = $this->createTestUser();
+        $poster->settings = ['browseMaxDistance' => 50];
+        $poster->save();
+
+        $group = $this->createTestGroup();
+        $this->createMembership($recipient, $group, ['emailfrequency' => Membership::EMAIL_FREQUENCY_DAILY]);
+        $this->createMembership($poster, $group);
+
+        $this->createTestMessage($poster, $group, [
+            'subject' => 'OFFER: Wider-reach item',
+            'lat' => 51.5,
+            'lng' => 0.4,
+        ]);
+
+        $stats = $this->service->sendDigests(UnifiedDigestService::MODE_DAILY, $recipient->id);
+
+        $this->assertEquals(1, $stats['emails_sent'], "a recipient within the author's cap still gets the post");
+    }
+
     public function test_daily_digest_own_post_bypasses_distance_preference(): void
     {
         config(['freegle.digest.daily_allowlist' => '*']);

--- a/iznik-nuxt3/api/TownAPI.js
+++ b/iznik-nuxt3/api/TownAPI.js
@@ -1,0 +1,9 @@
+import BaseAPI from '@/api/BaseAPI'
+
+export default class TownAPI extends BaseAPI {
+  // Up to 5 town names the browse/feed distance slider reaches from (lat,lng), by travel
+  // (drive-time), furthest-selected and ordered biggest-first. Names only - no distance/time units.
+  fetchNear(lat, lng, miles) {
+    return this.$getv2('/town/near', { lat, lng, miles })
+  }
+}

--- a/iznik-nuxt3/api/index.js
+++ b/iznik-nuxt3/api/index.js
@@ -42,6 +42,7 @@ import NewsAPI from './NewsAPI.js'
 import NoticeboardAPI from './NoticeboardAPI.js'
 import NotificationAPI from './NotificationAPI.js'
 import RipplingAPI from './RipplingAPI.js'
+import TownAPI from './TownAPI.js'
 import SessionAPI from './SessionAPI.js'
 import ShortlinksAPI from './ShortlinksAPI.js'
 import SpammersAPI from './SpammersAPI.js'
@@ -93,6 +94,7 @@ export default (config) => {
     noticeboard: new NoticeboardAPI(options),
     notification: new NotificationAPI(options),
     rippling: new RipplingAPI(options),
+    town: new TownAPI(options),
     session: new SessionAPI(options),
     shortlinks: new ShortlinksAPI(options),
     spammers: new SpammersAPI(options),

--- a/iznik-nuxt3/components/NearbyTowns.vue
+++ b/iznik-nuxt3/components/NearbyTowns.vue
@@ -1,0 +1,189 @@
+<template>
+  <!--
+    Reach hint below the distance slider, from a single routing pass server-side:
+    "Upto X-Y miles by road" (X-Y = min/max frontier road-distance across directions) followed by
+    example places it covers ("e.g. Town, Town", biggest-population first) - or the nearest place
+    when none are in reach. Responsive: on mobile the town list drops to its own line and truncates
+    with an ellipsis; on tablet and up it's one line, ellipsis-truncated. Fixed per-breakpoint height
+    so the async result doesn't shift the page (CLS-safe). Fetches lazily, only once scrolled into
+    view. Pulsates while fetching.
+  -->
+  <div
+    v-observe-visibility="onVisibility"
+    class="nearby-towns text-muted small mt-1"
+    aria-live="polite"
+  >
+    <span v-if="loading" class="pulsate">Finding nearby places…</span>
+    <template v-else-if="bits.lead || bits.tail">
+      <span class="nt-lead">{{ bits.lead }}</span
+      ><span v-if="bits.sep" class="nt-sep">{{ bits.sep }}</span
+      ><span class="nt-tail">{{ bits.tail }}</span>
+    </template>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, watch } from 'vue'
+import { useMe } from '~/composables/useMe'
+import api from '~/api'
+
+// Furthest towns the setting reaches (biggest-population first) as examples, plus the road-distance
+// reach range. Real miles - the reach follows road distance and travel time, which the slider copy
+// explains.
+const props = defineProps({
+  miles: { type: Number, required: true },
+})
+
+const runtimeConfig = useRuntimeConfig()
+const apiInstance = api(runtimeConfig)
+const { me } = useMe()
+
+const towns = ref([])
+const closer = ref('')
+const frontierMedian = ref(null)
+const frontierMax = ref(null)
+const loading = ref(false)
+const visible = ref(false)
+let timer = null
+let seq = 0
+
+// Split into a fixed lead ("Upto X-Y miles by road") that always stays visible and a tail (the town
+// examples, or the nearest place) that truncates with an ellipsis. `sep` joins them on one line
+// (tablet+); it's hidden on mobile where the tail drops to its own line.
+const bits = computed(() => {
+  const lo = frontierMedian.value
+  const hi = frontierMax.value
+  let lead = ''
+  if (lo != null && hi != null) {
+    const a = Math.round(lo)
+    const b = Math.round(hi)
+    if (b > 0) {
+      const unit = b === 1 ? 'mile' : 'miles'
+      const dist = a > 0 && a < b ? `${a}-${b}` : `${b}`
+      lead = `Max ${dist} ${unit} by road`
+    }
+  }
+  if (towns.value.length) {
+    return {
+      lead,
+      sep: lead ? ', ' : '',
+      tail: `e.g. ${towns.value.join(', ')}`,
+    }
+  }
+  if (closer.value) {
+    return { lead, sep: lead ? '. ' : '', tail: `Closer than ${closer.value}` }
+  }
+  return { lead, sep: '', tail: '' }
+})
+
+// Debounce so dragging the slider doesn't spam the (expensive) routing pass.
+function schedule() {
+  if (timer) clearTimeout(timer)
+  timer = setTimeout(fetchTowns, 350)
+}
+
+function reset() {
+  towns.value = []
+  closer.value = ''
+  frontierMedian.value = null
+  frontierMax.value = null
+}
+
+async function fetchTowns() {
+  if (!visible.value) return
+  const lat = me.value?.lat
+  const lng = me.value?.lng
+  const miles = props.miles
+  if ((!lat && !lng) || !miles) {
+    reset()
+    loading.value = false
+    return
+  }
+  const mySeq = ++seq
+  loading.value = true
+  try {
+    const r = await apiInstance.town.fetchNear(lat, lng, miles)
+    if (mySeq !== seq) return // a newer request superseded this one
+    towns.value = r?.towns || []
+    closer.value = r?.closer_than || ''
+    frontierMedian.value =
+      typeof r?.frontier_median_miles === 'number'
+        ? r.frontier_median_miles
+        : null
+    frontierMax.value =
+      typeof r?.frontier_max_miles === 'number' ? r.frontier_max_miles : null
+  } catch (e) {
+    if (mySeq === seq) reset()
+  } finally {
+    if (mySeq === seq) loading.value = false
+  }
+}
+
+// Lazy: first time it scrolls into view, fetch. Thereafter re-fetch on slider changes.
+function onVisibility(isVisible) {
+  if (isVisible && !visible.value) {
+    visible.value = true
+    schedule()
+  }
+}
+watch(
+  () => props.miles,
+  () => {
+    if (visible.value) schedule()
+  }
+)
+</script>
+
+<style scoped>
+/* Mobile-first: two lines - the range on line 1, the town examples on line 2, ellipsis-truncated.
+   min-height reserves both lines so the async result never shifts the page (CLS-safe). */
+.nearby-towns {
+  min-height: 2.5rem;
+  line-height: 1.25rem;
+}
+.nt-lead {
+  display: block;
+  white-space: nowrap;
+}
+.nt-sep {
+  display: none; /* only used to join lead + tail inline on tablet+ */
+}
+.nt-tail {
+  display: block;
+  max-width: 100%;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Tablet and up: a single line, ellipsis-truncated. Inline (not flex) so a parent text-align:center
+   actually centres the line when it fits; when it overflows, the container's own ellipsis clips the
+   tail (the town list) while the lead ("Upto X-Y miles by road") stays visible. */
+@media (min-width: 768px) {
+  .nearby-towns {
+    min-height: 1.25rem;
+    height: 1.25rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .nt-lead,
+  .nt-sep,
+  .nt-tail {
+    display: inline;
+  }
+}
+
+.pulsate {
+  animation: pulsate 1.2s ease-in-out infinite;
+}
+@keyframes pulsate {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.45;
+  }
+}
+</style>

--- a/iznik-nuxt3/components/PostFilters.vue
+++ b/iznik-nuxt3/components/PostFilters.vue
@@ -24,6 +24,14 @@
         </div>
         <div v-if="showDistanceSlider" class="distance">
           <label for="distanceSlider">How far away:</label>
+          <span class="distance-desc d-block text-muted small">
+            You'll see mostly nearby posts, but some from further away.
+            <span class="drag-hint"
+              >Drag towards <strong>Nearer</strong> or
+              <strong>Further</strong>. </span
+            >We use road distance and travel time, not crow flies. Applies to
+            Browse, notifications and who sees your posts.
+          </span>
           <RangeSlider
             id="distanceSlider"
             v-model="sliderValue"
@@ -35,6 +43,7 @@
             aria-label="Maximum distance"
             @change="onSliderChange"
           />
+          <NearbyTowns :miles="sliderValue" />
         </div>
         <div class="sort mb-2">
           <label for="sortOptions">Sort by:</label>
@@ -139,6 +148,7 @@ import { useAuthStore } from '~/stores/auth'
 import { useMe } from '~/composables/useMe'
 import { BROWSE_DISTANCE_UNLIMITED } from '~/constants'
 import RangeSlider from '~/components/RangeSlider.vue'
+import NearbyTowns from '~/components/NearbyTowns.vue'
 import WhichPostsModal from '~/components/WhichPostsModal.vue'
 
 const props = defineProps({
@@ -576,6 +586,20 @@ const hasNonDefaultFilters = computed(() => {
   color: var(--color-gray-600);
   margin-top: 0.5rem;
   margin-bottom: 0;
+}
+
+.distance-desc {
+  margin-bottom: 0.25rem;
+}
+
+// Match the Settings Feed slider: the drag instruction is redundant on touch and costs a line,
+// so hide it on mobile.
+.drag-hint {
+  display: none;
+
+  @include media-breakpoint-up(md) {
+    display: inline;
+  }
 }
 
 /* "Filters active" indicator on the collapsed "Map & Filters" button - a small red

--- a/iznik-nuxt3/components/settings/FeedSettingsSection.vue
+++ b/iznik-nuxt3/components/settings/FeedSettingsSection.vue
@@ -9,23 +9,28 @@
       <div class="option-info mb-2">
         <span class="option-label">How far away</span>
         <span class="option-desc">
-          How far away posts can be &mdash; this applies both when you browse
-          <em>and</em> to the posts in the emails we send you. Drag towards
-          <strong>Nearer</strong> to see only nearby posts, or
-          <strong>Further</strong> for no distance limit.
+          You'll see mostly nearby posts, but some from further away.
+          <span class="drag-hint"
+            >Drag towards <strong>Nearer</strong> or
+            <strong>Further</strong>. </span
+          >We use road distance and travel time, not crow flies. Applies to
+          Browse, notifications and who sees your posts.
         </span>
       </div>
 
-      <RangeSlider
-        v-model="sliderValue"
-        :min="0.5"
-        :max="feedMax"
-        :step="0.5"
-        left-label="Nearer"
-        right-label="Further"
-        aria-label="How far away"
-        @change="onSliderChange"
-      />
+      <div class="slider-frame">
+        <RangeSlider
+          v-model="sliderValue"
+          :min="0.5"
+          :max="feedMax"
+          :step="0.5"
+          left-label="Nearer"
+          right-label="Further"
+          aria-label="How far away"
+          @change="onSliderChange"
+        />
+        <NearbyTowns :miles="sliderValue" />
+      </div>
     </div>
   </div>
 </template>
@@ -35,6 +40,7 @@ import { ref, computed, watch, defineEmits } from 'vue'
 import { useAuthStore } from '~/stores/auth'
 import { useMe } from '~/composables/useMe'
 import RangeSlider from '~/components/RangeSlider.vue'
+import NearbyTowns from '~/components/NearbyTowns.vue'
 import { BROWSE_DISTANCE_UNLIMITED } from '~/constants'
 
 const emit = defineEmits(['update'])
@@ -128,5 +134,29 @@ async function onSliderChange(val) {
 .option-desc {
   font-size: 0.8rem;
   color: var(--color-gray-600);
+}
+
+/* The drag instruction is redundant on a touch screen and costs a line, so hide it on mobile. */
+.drag-hint {
+  display: none;
+}
+@media (min-width: 768px) {
+  .drag-hint {
+    display: inline;
+  }
+}
+
+/* Framed rounded box around the slider + its reach hint, matching the settings card curves. */
+.slider-frame {
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: var(--radius-lg, 0.75rem);
+  padding: 0.75rem 1rem 0.5rem;
+  margin-top: 0.5rem;
+}
+
+/* Centre the reach hint under the slider, within the frame. text-align centres the two-line block
+   layout on mobile and the single inline line on tablet+ (when it fits). */
+.slider-frame :deep(.nearby-towns) {
+  text-align: center;
 }
 </style>

--- a/iznik-nuxt3/tests/unit/components/PostFilters.spec.js
+++ b/iznik-nuxt3/tests/unit/components/PostFilters.spec.js
@@ -117,6 +117,9 @@ describe('PostFilters', () => {
       },
       global: {
         stubs: {
+          // NearbyTowns fires a routing-backed API call and uses IntersectionObserver; stub it
+          // out so these filter tests don't depend on either.
+          NearbyTowns: true,
           'b-collapse': {
             template:
               '<div class="b-collapse" :class="{ show: modelValue }"><slot /></div>',

--- a/iznik-nuxt3/tests/unit/components/settings/FeedSettingsSection.spec.js
+++ b/iznik-nuxt3/tests/unit/components/settings/FeedSettingsSection.spec.js
@@ -27,7 +27,9 @@ vi.mock('~/components/RangeSlider.vue', () => ({
 function mountWith(browseMaxDistance) {
   me.value = { settings: { browseMaxDistance } }
   return mount(FeedSettingsSection, {
-    global: { stubs: { 'v-icon': true, 'nuxt-link': true } },
+    // Stub NearbyTowns - it fires a routing-backed API call and uses IntersectionObserver,
+    // neither of which this section's tests should depend on.
+    global: { stubs: { 'v-icon': true, 'nuxt-link': true, NearbyTowns: true } },
   })
 }
 
@@ -42,10 +44,13 @@ describe('FeedSettingsSection', () => {
     expect(wrapper.find('.range-slider').exists()).toBe(true)
   })
 
-  it('explains it applies to both browse and emails', () => {
+  it('explains the distance preference applies to browse, notifications and who sees your posts', () => {
     const wrapper = mountWith(BROWSE_DISTANCE_UNLIMITED)
-    expect(wrapper.text()).toContain('browse')
-    expect(wrapper.text().toLowerCase()).toContain('emails')
+    const text = wrapper.text().toLowerCase()
+    expect(text).toContain('browse')
+    expect(text).toContain('notifications')
+    // The outbound half: the setting also caps who sees the member's own posts.
+    expect(text).toContain('who sees your posts')
   })
 
   it('has no numeric miles readout (matches the browse slider; avoids janky drag)', () => {

--- a/iznik-routing-go/dijkstra.go
+++ b/iznik-routing-go/dijkstra.go
@@ -8,6 +8,11 @@ import (
 // IsochroneResult is the set of nodes reachable within a time budget.
 type IsochroneResult struct {
 	ReachedNodes map[NodeID]float32
+	// DistM is the road distance in metres along the time-optimal path to each reached node,
+	// accumulated in the SAME Dijkstra pass (great-circle per edge, matching pathMetres). Lets
+	// callers read how far a node is BY ROAD, not just by time, for free - a nearby node reads
+	// as a small distance even if the isochrone sprawls much further in other directions.
+	DistM map[NodeID]float32
 }
 
 // item is a priority queue entry.
@@ -42,7 +47,7 @@ func modeMaxSpeed(mode Mode) float64 {
 func Isochrone(g *Graph, lat, lng float64, limitSeconds float32, mode Mode) IsochroneResult {
 	origin := nearestNodeForMode(g, lat, lng, mode)
 	if origin == noNode {
-		return IsochroneResult{ReachedNodes: map[NodeID]float32{}}
+		return IsochroneResult{ReachedNodes: map[NodeID]float32{}, DistM: map[NodeID]float32{}}
 	}
 
 	startLat := float64(g.Nodes[origin].Lat)
@@ -50,7 +55,9 @@ func Isochrone(g *Graph, lat, lng float64, limitSeconds float32, mode Mode) Isoc
 	maxReachM := modeMaxSpeed(mode) * float64(limitSeconds)
 
 	dist := make(map[NodeID]float32)
+	distM := make(map[NodeID]float32)
 	dist[origin] = 0
+	distM[origin] = 0
 
 	q := &pq{}
 	heap.Push(q, &item{id: origin, cost: 0})
@@ -63,6 +70,7 @@ func Isochrone(g *Graph, lat, lng float64, limitSeconds float32, mode Mode) Isoc
 		if cur.cost > limitSeconds {
 			break
 		}
+		curNode := g.Nodes[cur.id]
 		for _, e := range g.EdgesFrom(cur.id) {
 			edgeCost := e.Seconds[mode]
 			if edgeCost < 0 {
@@ -78,12 +86,14 @@ func Isochrone(g *Graph, lat, lng float64, limitSeconds float32, mode Mode) Isoc
 			}
 			if prev, seen := dist[e.To]; !seen || newCost < prev {
 				dist[e.To] = newCost
+				// Carry road distance along the same time-optimal path (great-circle per edge).
+				distM[e.To] = distM[cur.id] + float32(haversineM(float64(curNode.Lat), float64(curNode.Lng), float64(n.Lat), float64(n.Lng)))
 				heap.Push(q, &item{id: e.To, cost: newCost})
 			}
 		}
 	}
 
-	return IsochroneResult{ReachedNodes: dist}
+	return IsochroneResult{ReachedNodes: dist, DistM: distM}
 }
 
 // nearestNodeForMode returns the NodeID closest to (lat, lng) with an edge usable by mode.

--- a/iznik-routing-go/frontier_test.go
+++ b/iznik-routing-go/frontier_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"math"
+	"testing"
+)
+
+// TestFrontierMilesMedianMax covers the median/max summary of the per-sector road-distance
+// frontiers. Nodes are placed in known compass directions from the origin so each falls in a
+// distinct 22.5-degree sector; distM sets each one's frontier distance directly, so only the
+// bearing matters for bucketing.
+func TestFrontierMilesMedianMax(t *testing.T) {
+	const lat0, lng0 = 51.5, -0.1
+	g := &Graph{Nodes: []Node{
+		{},                     // 0 sentinel
+		{Lat: 51.6, Lng: -0.1}, // 1 due N  -> sector 0
+		{Lat: 51.5, Lng: 0.0},  // 2 due E  -> sector 4
+		{Lat: 51.4, Lng: -0.1}, // 3 due S  -> sector 8
+		{Lat: 51.5, Lng: -0.2}, // 4 due W  -> sector 12
+		{Lat: 51.7, Lng: -0.1}, // 5 also N -> sector 0
+	}}
+
+	approx := func(gotMiles, wantMetres float64) bool {
+		return math.Abs(gotMiles-wantMetres/metresPerMile) < 1e-6
+	}
+
+	t.Run("even count: median of the four sector frontiers", func(t *testing.T) {
+		distM := map[NodeID]float32{1: 1000, 2: 2000, 3: 3000, 4: 4000}
+		med, mx := frontierMilesMedianMax(g, lat0, lng0, distM)
+		if !approx(med, 2500) { // (2000+3000)/2
+			t.Errorf("median = %v mi, want %v mi", med, 2500.0/metresPerMile)
+		}
+		if !approx(mx, 4000) {
+			t.Errorf("max = %v mi, want %v mi", mx, 4000.0/metresPerMile)
+		}
+	})
+
+	t.Run("odd count: the middle sector frontier", func(t *testing.T) {
+		distM := map[NodeID]float32{1: 1000, 2: 3000, 3: 2000}
+		med, mx := frontierMilesMedianMax(g, lat0, lng0, distM)
+		if !approx(med, 2000) {
+			t.Errorf("median = %v mi, want %v mi", med, 2000.0/metresPerMile)
+		}
+		if !approx(mx, 3000) {
+			t.Errorf("max = %v mi, want %v mi", mx, 3000.0/metresPerMile)
+		}
+	})
+
+	t.Run("furthest node per sector wins", func(t *testing.T) {
+		// Nodes 1 and 5 are both due north; the sector keeps the furthest (1500, not 500).
+		distM := map[NodeID]float32{1: 500, 5: 1500, 2: 2000}
+		med, mx := frontierMilesMedianMax(g, lat0, lng0, distM)
+		if !approx(med, 1750) { // (1500+2000)/2
+			t.Errorf("median = %v mi, want %v mi", med, 1750.0/metresPerMile)
+		}
+		if !approx(mx, 2000) {
+			t.Errorf("max = %v mi, want %v mi", mx, 2000.0/metresPerMile)
+		}
+	})
+
+	t.Run("no reached nodes: zero range", func(t *testing.T) {
+		med, mx := frontierMilesMedianMax(g, lat0, lng0, map[NodeID]float32{})
+		if med != 0 || mx != 0 {
+			t.Errorf("empty distM = (%v, %v), want (0, 0)", med, mx)
+		}
+	})
+}

--- a/iznik-routing-go/ripple.go
+++ b/iznik-routing-go/ripple.go
@@ -26,6 +26,13 @@ type rippleEvalRequest struct {
 	Mode       string       `json:"mode"`
 	MaxMinutes float64      `json:"max_minutes"`
 	Points     [][2]float64 `json:"points"` // [[lng, lat], ...] (GeoJSON order)
+	// PointsOnly skips the freegler enumeration (the within_coords KNN call + per-freegler
+	// nearestNodeForMode loop - the routing bottleneck). Callers that only need per-point
+	// drive-times (and don't read `rank`) set this to avoid seconds of unused work. rank comes
+	// back null.
+	PointsOnly bool `json:"points_only,omitempty"`
+	// Frontier also returns the isochrone's road-distance reach range (frontier_{min,max}_miles).
+	Frontier bool `json:"frontier,omitempty"`
 }
 
 type rippleEvalPoint struct {
@@ -36,6 +43,11 @@ type rippleEvalPoint struct {
 type rippleEvalResponse struct {
 	TotalReachable int               `json:"total_reachable"`
 	Results        []rippleEvalPoint `json:"results"`
+	// FrontierMedianMiles/FrontierMaxMiles: how far the isochrone reaches BY ROAD across directions -
+	// the median and max of the per-sector furthest road-distance. Present only when Frontier was
+	// requested.
+	FrontierMedianMiles *float64 `json:"frontier_median_miles,omitempty"`
+	FrontierMaxMiles    *float64 `json:"frontier_max_miles,omitempty"`
 }
 
 // handleRippleEval returns, for a post at (lat, lng), each input point's
@@ -75,64 +87,67 @@ func handleRippleEval(g *Graph, spatialURL string) fiber.Handler {
 			return c.JSON(empty)
 		}
 
-		// --- collect all reachable freegler drive-times ---
-		// Candidates come from the reach's bbox (not the detailed boundary, which is
-		// unsimplified and too large for a WKT query); the nearest-node-in-reached-set
-		// test below filters each candidate exactly, so the result is unchanged.
-		evMinLat, evMaxLat, evMinLng, evMaxLng := reachedBBox(g, iso.ReachedNodes)
-		wkt := fmt.Sprintf("POLYGON((%[1]f %[3]f, %[2]f %[3]f, %[2]f %[4]f, %[1]f %[4]f, %[1]f %[3]f))",
-			evMinLng, evMaxLng, evMinLat, evMaxLat)
+		// --- collect all reachable freegler drive-times (for the `rank` field only) ---
+		// Skipped when points_only: this is the routing bottleneck (a within_coords KNN call +
+		// a no-dedup nearestNodeForMode per freegler - seconds in a dense area, dwarfing the
+		// isochrone), and callers that only want per-point drive-times never read rank.
+		var freeglerSecs []float32
+		if !req.PointsOnly {
+			// Candidates come from the reach's bbox (not the detailed boundary, which is
+			// unsimplified and too large for a WKT query); the nearest-node-in-reached-set
+			// test below filters each candidate exactly, so the result is unchanged.
+			evMinLat, evMaxLat, evMinLng, evMaxLng := reachedBBox(g, iso.ReachedNodes)
+			wkt := fmt.Sprintf("POLYGON((%[1]f %[3]f, %[2]f %[3]f, %[2]f %[4]f, %[1]f %[4]f, %[1]f %[3]f))",
+				evMinLng, evMaxLng, evMinLat, evMaxLat)
 
-		reqURL := spatialURL + "/v1/userapproxlocs/within_coords"
-		resp, err := http.Post(reqURL, "text/plain", strings.NewReader(wkt)) //nolint:gosec
-		if err != nil || resp.StatusCode != 200 {
-			log.Printf("ripple-eval: within_coords failed (status=%v err=%v)", func() int {
-				if resp != nil {
-					return resp.StatusCode
+			reqURL := spatialURL + "/v1/userapproxlocs/within_coords"
+			resp, err := http.Post(reqURL, "text/plain", strings.NewReader(wkt)) //nolint:gosec
+			if err != nil || resp.StatusCode != 200 {
+				log.Printf("ripple-eval: within_coords failed (status=%v err=%v)", func() int {
+					if resp != nil {
+						return resp.StatusCode
+					}
+					return 0
+				}(), err)
+				return c.JSON(empty)
+			}
+			defer resp.Body.Close()
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return c.JSON(empty)
+			}
+			var within struct {
+				Results []struct {
+					Extra map[string]any `json:"extra"`
+				} `json:"results"`
+			}
+			if err := json.Unmarshal(body, &within); err != nil {
+				return c.JSON(empty)
+			}
+			for _, r := range within.Results {
+				if r.Extra == nil {
+					continue
 				}
-				return 0
-			}(), err)
-			return c.JSON(empty)
-		}
-		defer resp.Body.Close()
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return c.JSON(empty)
-		}
-		var within struct {
-			Results []struct {
-				Extra map[string]any `json:"extra"`
-			} `json:"results"`
-		}
-		if err := json.Unmarshal(body, &within); err != nil {
-			return c.JSON(empty)
-		}
-
-		// All freegler drive-times in seconds, sorted ascending.
-		freeglerSecs := make([]float32, 0, len(within.Results))
-		for _, r := range within.Results {
-			if r.Extra == nil {
-				continue
+				lat, ok1 := r.Extra["lat"].(float64)
+				lng, ok2 := r.Extra["lng"].(float64)
+				if !ok1 || !ok2 {
+					continue
+				}
+				nid := nearestNodeForMode(g, lat, lng, mode)
+				if nid == noNode {
+					continue
+				}
+				t, ok := iso.ReachedNodes[nid]
+				if !ok {
+					continue
+				}
+				freeglerSecs = append(freeglerSecs, t)
 			}
-			lat, ok1 := r.Extra["lat"].(float64)
-			lng, ok2 := r.Extra["lng"].(float64)
-			if !ok1 || !ok2 {
-				continue
-			}
-			nid := nearestNodeForMode(g, lat, lng, mode)
-			if nid == noNode {
-				continue
-			}
-			t, ok := iso.ReachedNodes[nid]
-			if !ok {
-				continue
-			}
-			freeglerSecs = append(freeglerSecs, t)
+			sort.Slice(freeglerSecs, func(i, j int) bool { return freeglerSecs[i] < freeglerSecs[j] })
 		}
-		sort.Slice(freeglerSecs, func(i, j int) bool { return freeglerSecs[i] < freeglerSecs[j] })
 		total := len(freeglerSecs)
 
-		// --- per-input-point drive_min + rank ---
+		// --- per-input-point drive_min (+ rank, unless points_only) ---
 		results := make([]rippleEvalPoint, len(req.Points))
 		for i, p := range req.Points {
 			lng, lat := p[0], p[1]
@@ -145,16 +160,67 @@ func handleRippleEval(g *Graph, spatialURL string) fiber.Handler {
 				continue
 			}
 			dMin := float64(t) / 60.0
-			// rank = count of freeglers with drive_min <= this point's drive_min
-			rank := sort.Search(total, func(j int) bool { return freeglerSecs[j] > t })
-			results[i] = rippleEvalPoint{DriveMin: &dMin, Rank: &rank}
+			pt := rippleEvalPoint{DriveMin: &dMin}
+			if !req.PointsOnly {
+				rank := sort.Search(total, func(j int) bool { return freeglerSecs[j] > t })
+				pt.Rank = &rank
+			}
+			results[i] = pt
 		}
 
-		return c.JSON(rippleEvalResponse{
-			TotalReachable: total,
-			Results:        results,
-		})
+		out := rippleEvalResponse{TotalReachable: total, Results: results}
+		if req.Frontier {
+			fmed, fmax := frontierMilesMedianMax(g, req.Lat, req.Lng, iso.DistM)
+			out.FrontierMedianMiles = &fmed
+			out.FrontierMaxMiles = &fmax
+		}
+		return c.JSON(out)
 	}
+}
+
+// frontierMilesMedianMax summarises how far the isochrone reaches BY ROAD across directions: it
+// buckets every reached node into one of 16 compass sectors around the origin, takes the furthest
+// road distance in each sector (that direction's frontier), then returns the MEDIAN and MAX of those
+// per-sector frontiers. Median rather than min because the min is dominated by whichever single
+// direction a coast/edge cuts short, making a min..max range far too wide to be useful; the median
+// is the typical reach, so median..max reads as "usually reaches this far, up to this far down a
+// fast road". Uses iso.DistM (road metres per node, accumulated in the isochrone's own Dijkstra
+// pass), so there is no extra routing cost. metresPerMile is defined in proximity.go.
+func frontierMilesMedianMax(g *Graph, lat0, lng0 float64, distM map[NodeID]float32) (fmedian, fmax float64) {
+	const sectors = 16
+	var sectorMax [sectors]float32
+	cosLat := math.Cos(lat0 * math.Pi / 180)
+	for nid, dM := range distM {
+		n := g.Nodes[nid]
+		// Bearing from origin; atan2(east, north) so 0 = due north, increasing clockwise.
+		ang := math.Atan2((float64(n.Lng)-lng0)*cosLat, float64(n.Lat)-lat0)
+		if ang < 0 {
+			ang += 2 * math.Pi
+		}
+		s := int(ang/(2*math.Pi/sectors)) % sectors
+		if dM > sectorMax[s] {
+			sectorMax[s] = dM
+		}
+	}
+	// Non-empty sector frontiers, in metres, ascending.
+	vals := make([]float64, 0, sectors)
+	for _, m := range sectorMax {
+		if m > 0 { // skip empty sectors - the reach doesn't extend that way at all
+			vals = append(vals, float64(m))
+		}
+	}
+	if len(vals) == 0 {
+		return 0, 0
+	}
+	sort.Float64s(vals)
+	n := len(vals)
+	var medM float64
+	if n%2 == 1 {
+		medM = vals[n/2]
+	} else {
+		medM = (vals[n/2-1] + vals[n/2]) / 2
+	}
+	return medM / metresPerMile, vals[n-1] / metresPerMile
 }
 
 // curveFraction maps "elapsed fraction" (k/ticks ∈ [0,1]) to "notified fraction"

--- a/iznik-server-go/isochrone/message.go
+++ b/iznik-server-go/isochrone/message.go
@@ -21,6 +21,28 @@ import (
 // already governs", so the fast, unfiltered count/feed path is used.
 const BrowseDistanceUnlimited = 9007199254740991 // Number.MAX_SAFE_INTEGER
 
+// authorReachCapWhere is the OUTBOUND half of the distance preference: a post is only visible to
+// viewers within the POST AUTHOR's own settings.browseMaxDistance of it ("how far away can people
+// see your posts"), mirroring the inbound recipient-side cap in the Laravel digest. Applied in SQL
+// (not Go) so the feed and its unread-count badge stay in lock-step - both queries add this same
+// clause. Absent settings / missing key / <= 0 / the sentinel all DISABLE the cap (the common
+// case). Distance is real great-circle from the viewer to the post point (like the ST_Contains
+// reach gate), not the blurred distance the viewer-side slider uses. Placeholders, in order:
+// sentinel, viewerLng, viewerLat. Requires `au` (users, joined on messages.fromuser) and `ms`
+// (messages_spatial, for the post point) to be in scope.
+// Distance is an inline great-circle (Haversine, 3959-mile earth radius matching the Laravel
+// filter) over ST_X/ST_Y of ms.point as plain lng/lat degrees, NOT ST_Distance_Sphere - the latter
+// errors on the SRID-3857-tagged points Freegle stores (its degrees carry a projected SRID that
+// ST_Distance_Sphere rejects). LEAST(1.0, ...) guards ACOS against float overshoot at ~0 distance.
+const authorReachCapWhere = "AND (au.settings IS NULL " +
+	"OR JSON_EXTRACT(au.settings, '$.browseMaxDistance') IS NULL " +
+	"OR CAST(JSON_UNQUOTE(JSON_EXTRACT(au.settings, '$.browseMaxDistance')) AS DECIMAL(20,6)) <= 0 " +
+	"OR CAST(JSON_UNQUOTE(JSON_EXTRACT(au.settings, '$.browseMaxDistance')) AS DECIMAL(20,6)) >= ? " +
+	"OR (3959 * ACOS(LEAST(1.0, " +
+	"COS(RADIANS(?)) * COS(RADIANS(ST_Y(ms.point))) * COS(RADIANS(ST_X(ms.point)) - RADIANS(?)) " +
+	"+ SIN(RADIANS(?)) * SIN(RADIANS(ST_Y(ms.point)))))) " +
+	"<= CAST(JSON_UNQUOTE(JSON_EXTRACT(au.settings, '$.browseMaxDistance')) AS DECIMAL(20,6))) "
+
 // reachCandidateRow is the intermediate scan target for both the reach arm
 // and the viewer's-own-posts arm of Messages: a post's identity/visibility
 // columns plus the raw ingredients (views, replies, reach polygon/origin)
@@ -149,6 +171,8 @@ func fetchReachCandidates(db *gorm.DB, myid uint64, latlng utils.LatLng, unseenO
 			// JOIN messages for the ORIGINAL post arrival (m.arrival). ms.arrival is
 			// the ripple-bumped spatial arrival, so it can't stand in for "posted".
 			"INNER JOIN messages m ON m.id = ms.msgid "+
+			// users au = the post AUTHOR, for the outbound distance cap below.
+			"INNER JOIN users au ON au.id = m.fromuser "+
 			"INNER JOIN rippling_reach rr ON rr.msgid = ms.msgid "+
 			"LEFT JOIN messages_likes ml ON ml.msgid = ms.msgid AND ml.userid = ? AND ml.type = ? "+
 			"WHERE ms.successful = 0 "+
@@ -158,10 +182,13 @@ func fetchReachCandidates(db *gorm.DB, myid uint64, latlng utils.LatLng, unseenO
 			// consumer already skips held rows; without this filter the reported
 			// post kept appearing in the nearby browse feed (Discourse 9862).
 			"AND rr.status != 'held' "+
-			"AND ST_Contains(rr.polygon, ST_SRID(POINT(?, ?), ?))",
+			"AND ST_Contains(rr.polygon, ST_SRID(POINT(?, ?), ?)) "+
+			// Outbound cap: only show this post to viewers within the author's chosen distance.
+			authorReachCapWhere,
 		utils.MESSAGE_LIKES_VIEW, utils.CHAT_MESSAGE_INTERESTED,
 		myid, utils.MESSAGE_LIKES_VIEW,
 		latlng.Lng, latlng.Lat, utils.SRID,
+		BrowseDistanceUnlimited, latlng.Lat, latlng.Lng, latlng.Lat,
 	).Scan(&candidates)
 
 	return candidates
@@ -648,13 +675,19 @@ func nearbyCount(myid uint64, maxDistanceMiles float64) uint64 {
 	}
 
 	if maxDistanceMiles >= BrowseDistanceUnlimited {
+		// Viewer sets no inbound limit, but the OUTBOUND author cap still applies (and must match
+		// the feed), so join the author and add authorReachCapWhere here too.
 		db.Raw("SELECT COUNT(DISTINCT ms.msgid) "+
 			"FROM messages_spatial ms "+
+			"INNER JOIN messages m ON m.id = ms.msgid "+
+			"INNER JOIN users au ON au.id = m.fromuser "+
 			"INNER JOIN rippling_reach rr ON rr.msgid = ms.msgid "+
 			"LEFT JOIN messages_likes ml ON ml.msgid = ms.msgid AND ml.userid = ? AND ml.type = ? "+
 			"WHERE ms.successful = 0 AND ml.msgid IS NULL "+
-			"AND ST_Contains(rr.polygon, ST_SRID(POINT(?, ?), ?))",
-			myid, utils.MESSAGE_LIKES_VIEW, latlng.Lng, latlng.Lat, utils.SRID).Scan(&count)
+			"AND ST_Contains(rr.polygon, ST_SRID(POINT(?, ?), ?)) "+
+			authorReachCapWhere,
+			myid, utils.MESSAGE_LIKES_VIEW, latlng.Lng, latlng.Lat, utils.SRID,
+			BrowseDistanceUnlimited, latlng.Lat, latlng.Lng, latlng.Lat).Scan(&count)
 		return count
 	}
 

--- a/iznik-server-go/router/routes.go
+++ b/iznik-server-go/router/routes.go
@@ -73,6 +73,7 @@ import (
 	"github.com/freegle/iznik-server-go/story"
 	"github.com/freegle/iznik-server-go/systemlogs"
 	"github.com/freegle/iznik-server-go/team"
+	"github.com/freegle/iznik-server-go/town"
 	"github.com/freegle/iznik-server-go/tryst"
 	"github.com/freegle/iznik-server-go/user"
 	"github.com/freegle/iznik-server-go/userdump"
@@ -541,9 +542,6 @@ func SetupRoutes(app *fiber.App) {
 		ripplingAdmin.Use(config.RequireSupportOrAdminMiddleware())
 		ripplingAdmin.Get("/metrics", rippling.Metrics)
 		ripplingAdmin.Get("/analytics", rippling.Analytics)
-		// The slow sampled drive-time pass is fetched separately so the fast SQL KPIs above
-		// aren't blocked on ~250 isochrone calls against the routing graph.
-		ripplingAdmin.Get("/analytics/drivetime", rippling.AnalyticsDriveTimes)
 
 		// Create a protected route group for admin endpoints
 		adminConfig := rg.Group("/config/admin")
@@ -852,6 +850,7 @@ func SetupRoutes(app *fiber.App) {
 
 		// Location Search (GET /locations - search by lat/lng, typeahead, or bounding box)
 		rg.Get("/locations", location.SearchLocations)
+		rg.Get("/town/near", town.Near)
 
 		// Location Write Operations
 		rg.Put("/locations", location.CreateLocation)

--- a/iznik-server-go/test/isochrone_reach_test.go
+++ b/iznik-server-go/test/isochrone_reach_test.go
@@ -351,3 +351,86 @@ func TestNearbyReachFeedExcludesHeld(t *testing.T) {
 	assert.True(t, got[live], "a post with a live reach appears in the nearby feed")
 	assert.False(t, got[held], "a post whose reach is held for moderation is absent from the nearby feed")
 }
+
+// TestNearbyFeedHonoursAuthorDistanceLimit: the OUTBOUND half of the distance preference. A post
+// author's settings.browseMaxDistance also caps WHO SEES their post — a viewer beyond that distance
+// of the post does not see it in the nearby feed (or unread count) even when the viewer has no
+// distance limit of their own and the post's reach polygon covers them. Mirrors the recipient-side
+// TestNearbyFeedHonoursDistanceLimit, but the cap is set on the POSTER, not the viewer.
+func TestNearbyFeedHonoursAuthorDistanceLimit(t *testing.T) {
+	db := database.DBConn
+
+	db.Exec(`CREATE TABLE IF NOT EXISTS rippling_reach (
+		msgid BIGINT UNSIGNED NOT NULL PRIMARY KEY,
+		lat DOUBLE NOT NULL, lng DOUBLE NOT NULL,
+		polygon GEOMETRY NOT NULL SRID 3857,
+		status VARCHAR(16) NOT NULL DEFAULT 'expanding',
+		SPATIAL INDEX msgreach_poly (polygon)
+	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`)
+
+	prefix := uniquePrefix("nearbyauthordist")
+	posterID := CreateTestUser(t, prefix+"_poster", "Poster")
+	// The poster caps how far away their posts are shown at 10 miles.
+	db.Exec("UPDATE users SET settings = JSON_SET(COALESCE(settings,'{}'), '$.browseMaxDistance', 10) WHERE id = ?", posterID)
+
+	group := CreateTestGroup(t, prefix)
+	near := CreateTestMessage(t, posterID, group, "OFFER: near author-cap (nearbyauthordist)", 51.5, -0.1)
+	far := CreateTestMessage(t, posterID, group, "OFFER: far author-cap (nearbyauthordist)", 51.9, -0.1)
+	db.Exec("UPDATE messages_spatial SET successful = 0 WHERE msgid IN (?, ?)", near, far)
+	defer db.Exec("DELETE FROM rippling_reach WHERE msgid IN (?, ?)", near, far)
+
+	// The viewer has NO distance limit of their own, so any filtering is the author's doing.
+	viewerID, token := CreateFullTestUser(t, prefix+"_viewer")
+	db.Exec("UPDATE users SET settings = JSON_SET(COALESCE(settings,'{}'), '$.mylocation', "+
+		"JSON_OBJECT('lat', 51.5, 'lng', -0.1)) WHERE id = ?", viewerID)
+
+	// Both reach polygons cover the viewer; 'near' is at the viewer (~0mi), 'far' is ~27mi away.
+	db.Exec("INSERT INTO rippling_reach (msgid, lat, lng, polygon, status) VALUES (?, 51.5, -0.1, "+
+		"ST_GeomFromText('POLYGON((-0.2 51.4, 0.0 51.4, 0.0 51.6, -0.2 51.6, -0.2 51.4))', 3857), 'expanding') "+
+		"ON DUPLICATE KEY UPDATE polygon = VALUES(polygon)", near)
+	db.Exec("INSERT INTO rippling_reach (msgid, lat, lng, polygon, status) VALUES (?, 51.9, -0.1, "+
+		"ST_GeomFromText('POLYGON((-0.3 51.3, 0.1 51.3, 0.1 52.0, -0.3 52.0, -0.3 51.3))', 3857), 'expanding') "+
+		"ON DUPLICATE KEY UPDATE polygon = VALUES(polygon)", far)
+
+	inFeed := func(url string) map[float64]bool {
+		resp, _ := getApp().Test(httptest.NewRequest("GET", url, nil))
+		assert.Equal(t, 200, resp.StatusCode)
+		var msgs []map[string]interface{}
+		json2.Unmarshal(rsp(resp), &msgs)
+		got := map[float64]bool{}
+		for _, m := range msgs {
+			if id, ok := m["id"].(float64); ok {
+				got[id] = true
+			}
+		}
+		return got
+	}
+
+	// The viewer has no distance limit of their own, so the unread count takes the fast (no per-post
+	// distance) path - which must ALSO honour the author cap so the badge matches the feed.
+	countOf := func() float64 {
+		resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/message/count?jwt="+token, nil))
+		assert.Equal(t, 200, resp.StatusCode)
+		var body map[string]interface{}
+		json2.Unmarshal(rsp(resp), &body)
+		if c, ok := body["count"].(float64); ok {
+			return c
+		}
+		return -1
+	}
+
+	// With the poster's 10-mile cap, the ~27-mile far viewer position drops the far post; near stays.
+	capped := inFeed("/api/isochrone/message?jwt=" + token)
+	assert.True(t, capped[float64(near)], "the near post (within the author's 10-mile cap) appears")
+	assert.False(t, capped[float64(far)],
+		"the ~27-mile far post is hidden by the author's 10-mile outbound cap, despite being in reach and the viewer having no limit")
+	cappedCount := countOf()
+
+	// Control: remove the author's cap and the far in-reach post reappears — proving the cap, not
+	// reach or the viewer's own setting, is what hid it.
+	db.Exec("UPDATE users SET settings = JSON_REMOVE(settings, '$.browseMaxDistance') WHERE id = ?", posterID)
+	uncapped := inFeed("/api/isochrone/message?jwt=" + token)
+	assert.True(t, uncapped[float64(far)], "with no author cap, the far in-reach post appears again")
+	assert.Less(t, cappedCount, countOf(),
+		"the fast-path unread count excludes the far post while the author caps distance, and re-includes it once uncapped - staying in lock-step with the feed")
+}

--- a/iznik-server-go/test/town_near_test.go
+++ b/iznik-server-go/test/town_near_test.go
@@ -1,0 +1,31 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/freegle/iznik-server-go/town"
+	"github.com/stretchr/testify/assert"
+)
+
+func townDriveMin(v float64) *float64 { return &v }
+
+// SelectNear picks the FURTHEST towns reachable within the drive-time budget (so the "Near: ..."
+// hint changes as the slider widens) and returns their names in descending-population order
+// (ascending town id). Unreachable (nil) and beyond-budget towns are excluded.
+func TestTownSelectNear(t *testing.T) {
+	cands := []town.TownCand{
+		{ID: 1, Name: "Big", DriveMin: townDriveMin(5)},
+		{ID: 2, Name: "MidFar", DriveMin: townDriveMin(28)},
+		{ID: 3, Name: "Near2", DriveMin: townDriveMin(8)},
+		{ID: 4, Name: "FarSmall", DriveMin: townDriveMin(25)},
+		{ID: 5, Name: "Unreachable", DriveMin: nil},
+		{ID: 6, Name: "TooFar", DriveMin: townDriveMin(40)},
+	}
+	// Furthest 3 reachable within 30 min, displayed by population (ascending id).
+	assert.Equal(t, []string{"MidFar", "Near2", "FarSmall"}, town.SelectNear(cands, 30, 3))
+	// Fewer reachable than the limit -> all reachable, population order.
+	assert.Equal(t, []string{"Big", "MidFar", "Near2", "FarSmall"}, town.SelectNear(cands, 30, 5))
+	// None reachable in a tight budget, and empty input.
+	assert.Empty(t, town.SelectNear(cands, 3, 5))
+	assert.Empty(t, town.SelectNear(nil, 30, 5))
+}

--- a/iznik-server-go/town/town.go
+++ b/iznik-server-go/town/town.go
@@ -1,0 +1,191 @@
+package town
+
+// The "Near: ..." hint under the browse/feed distance slider. Given the user's location and the
+// slider's distance, list up to 5 towns the setting reaches - by REAL travel (drive-time via the
+// routing server's ripple-eval), not crow-flies. We show place NAMES only, never any distance or
+// time units, so the miles-slider / drive-time-metric mismatch is invisible: the user just sees
+// which places their setting covers, and the list changes as they drag.
+
+import (
+	"bytes"
+	"encoding/json"
+	"math"
+	"net/http"
+	"os"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/gofiber/fiber/v2"
+)
+
+// routingEvalURL / routingClient reach the routing server's /v1/ripple-eval (real drive times).
+// Mirrors rippling/analytics.go's client, kept local so the packages stay independent.
+func routingEvalURL() string {
+	if u := os.Getenv("ROUTING_EVAL_URL"); u != "" {
+		return u
+	}
+	if u := os.Getenv("SPATIAL_KNN_URL"); u != "" {
+		return u
+	}
+	return "http://spatial:8194"
+}
+
+var routingClient = &http.Client{Timeout: 15 * time.Second}
+
+// milesToDriveMinutes turns the slider's miles into a drive-time budget for the isochrone. No units
+// are ever shown, so this only needs to be monotonic and roughly realistic: ~2 min/mile (a blended
+// ~30mph). Floored/capped so the extremes stay sane ("no limit" doesn't route the whole country).
+func milesToDriveMinutes(miles float64) float64 {
+	m := miles * 2.0
+	if m > 120 {
+		m = 120
+	}
+	if m < 5 {
+		m = 5
+	}
+	return m
+}
+
+// TownCand is a candidate town with its drive-time from the user (nil = unreachable in the budget).
+type TownCand struct {
+	ID       uint64
+	Name     string
+	DriveMin *float64
+}
+
+// SelectNear picks the FURTHEST towns reachable within maxMinutes (so the list changes as the range
+// widens, rather than always showing the same nearest places), then returns their names ordered by
+// population. The towns table is curated in descending-population order by ascending id, so a
+// smaller id is a bigger place. Returns up to `limit` names.
+func SelectNear(cands []TownCand, maxMinutes float64, limit int) []string {
+	reachable := make([]TownCand, 0, len(cands))
+	for _, c := range cands {
+		if c.DriveMin != nil && *c.DriveMin <= maxMinutes {
+			reachable = append(reachable, c)
+		}
+	}
+	// Furthest first (largest drive-time); tie-break by bigger population (smaller id) for stability.
+	sort.Slice(reachable, func(i, j int) bool {
+		if *reachable[i].DriveMin != *reachable[j].DriveMin {
+			return *reachable[i].DriveMin > *reachable[j].DriveMin
+		}
+		return reachable[i].ID < reachable[j].ID
+	})
+	if len(reachable) > limit {
+		reachable = reachable[:limit]
+	}
+	// Display order: population descending (ascending id).
+	sort.Slice(reachable, func(i, j int) bool { return reachable[i].ID < reachable[j].ID })
+	out := make([]string, 0, len(reachable))
+	for _, c := range reachable {
+		out = append(out, c.Name)
+	}
+	return out
+}
+
+type rippleEvalReq struct {
+	Lat        float64      `json:"lat"`
+	Lng        float64      `json:"lng"`
+	Mode       string       `json:"mode"`
+	MaxMinutes float64      `json:"max_minutes"`
+	Points     [][2]float64 `json:"points"`
+	// We only read drive_min per town, never rank, so skip the freegler enumeration (the routing
+	// bottleneck). And ask for the road-distance frontier range so the UI can show how far the
+	// setting reaches by road.
+	PointsOnly bool `json:"points_only"`
+	Frontier   bool `json:"frontier"`
+}
+type rippleEvalResp struct {
+	Results []struct {
+		DriveMin *float64 `json:"drive_min"`
+	} `json:"results"`
+	FrontierMedianMiles *float64 `json:"frontier_median_miles"`
+	FrontierMaxMiles    *float64 `json:"frontier_max_miles"`
+}
+
+// Near returns up to 5 town names the given slider distance reaches from (lat,lng), by travel,
+// furthest-selected and population-ordered - for the "Near: ..." hint under the distance slider.
+// Names only, no units. Best-effort: any routing/DB failure returns an empty list (the hint hides).
+//
+// @Router /town/near [get]
+// @Summary Up to 5 towns the browse/feed distance slider reaches (by drive-time), names only
+// @Tags location
+// @Produce json
+// @Success 200 {object} map[string]interface{}
+func Near(c *fiber.Ctx) error {
+	lat, _ := strconv.ParseFloat(c.Query("lat"), 64)
+	lng, _ := strconv.ParseFloat(c.Query("lng"), 64)
+	miles, _ := strconv.ParseFloat(c.Query("miles"), 64)
+	empty := fiber.Map{"towns": []string{}}
+	if (lat == 0 && lng == 0) || miles <= 0 {
+		return c.JSON(empty)
+	}
+	maxMin := milesToDriveMinutes(miles)
+
+	// Candidate towns within a generous crow-flies box (travel >= crow-flies, and fast roads can
+	// cover ~2x the miles in the same minutes) so we don't route the whole country. The towns
+	// table is tiny (~234 rows), so this stays cheap.
+	boxMiles := miles*2 + 5
+	latDeg := boxMiles / 69.0
+	lngDeg := boxMiles / (69.0 * math.Cos(lat*math.Pi/180))
+	db := database.DBConn
+	type row struct {
+		ID   uint64
+		Name string
+		Lat  float64
+		Lng  float64
+	}
+	var rows []row
+	db.Raw(`SELECT id, name, lat, lng FROM towns
+		WHERE lat IS NOT NULL AND lng IS NOT NULL
+		  AND lat BETWEEN ? AND ? AND lng BETWEEN ? AND ?
+		ORDER BY id`,
+		lat-latDeg, lat+latDeg, lng-lngDeg, lng+lngDeg).Scan(&rows)
+	if len(rows) == 0 {
+		return c.JSON(empty)
+	}
+
+	points := make([][2]float64, len(rows))
+	for i, r := range rows {
+		points[i] = [2]float64{r.Lng, r.Lat} // [lng, lat] GeoJSON order
+	}
+	body, _ := json.Marshal(rippleEvalReq{
+		Lat: lat, Lng: lng, Mode: "drive", MaxMinutes: maxMin, Points: points,
+		PointsOnly: true, Frontier: true,
+	})
+	resp, err := routingClient.Post(routingEvalURL()+"/v1/ripple-eval", "application/json", bytes.NewReader(body))
+	if err != nil {
+		return c.JSON(empty)
+	}
+	defer resp.Body.Close()
+	var r rippleEvalResp
+	if resp.StatusCode != http.StatusOK || json.NewDecoder(resp.Body).Decode(&r) != nil || len(r.Results) != len(rows) {
+		return c.JSON(empty)
+	}
+	cands := make([]TownCand, len(rows))
+	for i, rw := range rows {
+		cands[i] = TownCand{ID: rw.ID, Name: rw.Name, DriveMin: r.Results[i].DriveMin}
+	}
+
+	// The road-distance reach range ("reaches median..max miles by road"), shown alongside the town
+	// list. Comes free from the isochrone, so it's present even when no named town falls inside the
+	// reach.
+	out := fiber.Map{"frontier_median_miles": r.FrontierMedianMiles, "frontier_max_miles": r.FrontierMaxMiles}
+
+	towns := SelectNear(cands, maxMin, 5)
+	if len(towns) > 0 {
+		out["towns"] = towns
+		return c.JSON(out)
+	}
+
+	// Nothing within reach: return the single nearest town so the UI can say "Closer than: X"
+	// instead of showing nothing - useful for rural users whose nearest town is beyond the reach.
+	var closer string
+	db.Raw(`SELECT name FROM towns WHERE lat IS NOT NULL AND lng IS NOT NULL
+		ORDER BY ST_Distance_Sphere(POINT(lng, lat), POINT(?, ?)) LIMIT 1`, lng, lat).Scan(&closer)
+	out["towns"] = []string{}
+	out["closer_than"] = closer
+	return c.JSON(out)
+}

--- a/iznik-server-go/town/town_test.go
+++ b/iznik-server-go/town/town_test.go
@@ -1,0 +1,40 @@
+package town
+
+import "testing"
+
+// milesToDriveMinutes turns the slider's miles into a drive-time budget: ~2 min/mile, floored at 5
+// and capped at 120 so the extremes stay sane.
+func TestMilesToDriveMinutes(t *testing.T) {
+	cases := []struct{ miles, want float64 }{
+		{0, 5},     // 0 -> floored to 5
+		{1, 5},     // 2 -> floored to 5
+		{3, 6},     // 3 * 2
+		{15, 30},   // 15 * 2
+		{60, 120},  // 120, at the cap
+		{100, 120}, // 200 -> capped at 120
+	}
+	for _, c := range cases {
+		if got := milesToDriveMinutes(c.miles); got != c.want {
+			t.Errorf("milesToDriveMinutes(%v) = %v, want %v", c.miles, got, c.want)
+		}
+	}
+}
+
+// routingEvalURL prefers ROUTING_EVAL_URL, then SPATIAL_KNN_URL, then the in-cluster default.
+func TestRoutingEvalURL(t *testing.T) {
+	t.Setenv("ROUTING_EVAL_URL", "")
+	t.Setenv("SPATIAL_KNN_URL", "")
+	if got := routingEvalURL(); got != "http://spatial:8194" {
+		t.Errorf("default routingEvalURL = %q, want http://spatial:8194", got)
+	}
+
+	t.Setenv("SPATIAL_KNN_URL", "http://knn:1")
+	if got := routingEvalURL(); got != "http://knn:1" {
+		t.Errorf("routingEvalURL fell through to SPATIAL_KNN_URL = %q, want http://knn:1", got)
+	}
+
+	t.Setenv("ROUTING_EVAL_URL", "http://routing:2")
+	if got := routingEvalURL(); got != "http://routing:2" {
+		t.Errorf("routingEvalURL = %q, want ROUTING_EVAL_URL http://routing:2", got)
+	}
+}


### PR DESCRIPTION
## What

Two related additions to the **"How far away" distance preference** (`settings.browseMaxDistance`), shown on the browse filters and (new) the Settings → Feed section.

### 1. Outbound distance filter — the slider now caps *who sees your posts*
Previously `browseMaxDistance` was inbound only (it narrowed *your* browse feed and *your* emails). It now **also** caps how far away other people see *your* posts: a viewer/recipient beyond the **poster's** chosen distance of a post no longer sees it in the Nearby feed or is emailed about it.

- **Laravel (email/digest):** `DistancePreferenceFilter::passesBothPreferences()` applies the recipient's inbound cap **and** the author's outbound cap to the single recipient↔post distance; wired into all three `UnifiedDigestService` pipelines (daily digest, immediate cursor, reach-mail) with a per-author memoised lookup (`authorMaxMiles`).
- **Go (browse feed + unread count):** an `authorReachCapWhere` SQL fragment (inline Haversine — `ST_Distance_Sphere` rejects the SRID-3857 points) added to **both** the feed query and the count query, so the feed and its nav badge stay in lock-step.
- Own posts always bypass; absent/sentinel/≤0 disables the cap (fast path). **Scoped** to the nearby feed + email — *not* the `mygroups` (explicit-membership) view or the reply reach-gate.

### 2. "Max X-Y miles by road" reach hint + towns
Under the distance slider we now show how far the setting reaches by road and example places it covers:

- Routing server (`iznik-routing-go`) accumulates road distance in the isochrone's own Dijkstra pass and returns the **median** and **max** of the 16-sector road-distance frontier (`frontier_median_miles`/`frontier_max_miles`). Median rather than min so the range isn't dominated by a single coast-cut direction.
- `GET /apiv2/town/near` lists up to 5 furthest reachable towns (names only, biggest-population first, `points_only` skips the freegler-enumeration bottleneck), or the nearest town when none are in reach.
- Frontend `NearbyTowns.vue` renders "Max {median}-{max} miles by road, e.g. Town, Town" (or "… Closer than Town"), responsive (two lines on mobile, one on tablet+), CLS-safe.

## Tests
- Laravel: `DistancePreferenceFilterTest` (`passesBothPreferences` cases) + `UnifiedDigestServiceTest` (author-side filter/keep). **All 4797 Laravel tests pass.**
- Go: `TestNearbyFeedHonoursAuthorDistanceLimit`, `TestTownSelectNear`. **All 3457 Go tests pass.**
- routing-go: `TestFrontierMilesMedianMax`.

## Docs
`docs/moderators/rippling-out.md`, `docs/members/rippling-out.md`, `docs/developers/reference/rippling-algorithm.md` updated for the inbound **and** outbound behaviour.

## Notes
- Supersedes the earlier NearbyTowns-hint branch (that content is included here).
- Verified end-to-end on the dev-live stack (settings + browse, mobile + desktop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)