### PR TITLE
fix(browse): stabilise distance slider - fixed reach-anchored max + no overflow

### DIFF
--- a/iznik-nuxt3/components/PostFilters.vue
+++ b/iznik-nuxt3/components/PostFilters.vue
@@ -142,7 +142,6 @@
 <script setup>
 import { useMiscStore } from '~/stores/misc'
 import { useMessageStore } from '~/stores/message'
-import { useNearbyStore } from '~/stores/nearby'
 import { ref, watch } from '#imports'
 import { useAuthStore } from '~/stores/auth'
 import { useMe } from '~/composables/useMe'
@@ -217,7 +216,6 @@ watch(
 const { me } = useMe()
 const authStore = useAuthStore()
 const messageStore = useMessageStore()
-const nearbyStore = useNearbyStore()
 
 // Modal for the shared "which posts do I see?" explainer (#K). Always mounted (not
 // v-if-gated) so its ref is available as soon as the button is clicked, matching the
@@ -370,32 +368,16 @@ const sort = computed({
 // far-right ("Further") position stores BROWSE_DISTANCE_UNLIMITED rather than that
 // feed max, so the server's own reach limit keeps governing and newly-arriving distant
 // posts keep showing without the client capping them out.
-const FEED_MAX_FLOOR = 2
-
-const feedMax = computed(() => {
-  // Scale the slider's right end to the farthest post in the CURRENTLY-SHOWN feed. Which feed
-  // that is depends on the view: the nearby (reach) view is in nearbyStore, the "all my
-  // communities" view is in messageStore.myGroupsList. Reading the wrong one (nearbyStore is
-  // empty on mygroups) collapsed the slider max to its floor and mis-scaled the slider there.
-  //
-  // It depends ONLY on the feed (not on the saved browseMaxDistance), so it stays STABLE while
-  // the member drags: coupling it to browseMaxDistance made feedMax grow on every change, which
-  // moved the slider's right edge mid-interaction and, via the [maxDistance, feedMax] watch
-  // below, kept yanking the thumb back - a janky "clicking back" drag.
-  const feed =
-    browseView.value === 'mygroups'
-      ? messageStore.myGroupsList
-      : nearbyStore.messageList
-  const distances = (feed || [])
-    .map((m) => m.distance)
-    .filter((d) => typeof d === 'number' && isFinite(d))
-
-  if (!distances.length) {
-    return FEED_MAX_FLOOR
-  }
-
-  return Math.max(FEED_MAX_FLOOR, Math.ceil(Math.max(...distances)))
-})
+// The slider's right end ("Further") is a FIXED extent anchored to the server's reach ceiling, NOT
+// the farthest post in the currently-loaded feed. The default reach is a 30-minute drive-time
+// budget and milesToDriveMinutes maps ~2 min per mile, so 15 miles corresponds to that ~30-minute
+// max travel time. Anchoring the far end there keeps the "Max X-Y miles by road" hint stable and
+// meaningful - it tracks the real reach instead of jumping (e.g. 2-4 -> 10-22 miles on reload) as
+// more distant posts load and rescale the max, which made the slider unpredictable as an input
+// control (Discourse 9808). The far-right still stores BROWSE_DISTANCE_UNLIMITED, so the server's
+// own reach limit keeps governing and newly-arriving distant posts still show.
+const FEED_MAX = 15
+const feedMax = computed(() => FEED_MAX)
 
 // Distance is meaningless without a known location.
 const hasLocation = computed(() => {
@@ -542,6 +524,11 @@ const hasNonDefaultFilters = computed(() => {
   .distance {
     grid-column: 1 / 2;
     grid-row: 2 / 3;
+    /* Grid cells default to min-width:auto, so the NearbyTowns single-line hint
+       ("Max X-Y miles by road, e.g. ...") expanded this cell past its track and spilled
+       out of the filter panel. min-width:0 lets the cell hold its track width so the hint
+       ellipsis-truncates inside the panel instead of overflowing. */
+    min-width: 0;
 
     @include media-breakpoint-up(md) {
       grid-column: 1 / 2;

--- a/iznik-nuxt3/tests/unit/components/PostFilters.spec.js
+++ b/iznik-nuxt3/tests/unit/components/PostFilters.spec.js
@@ -476,22 +476,24 @@ describe('PostFilters', () => {
       expect(wrapper.find('.range-slider-stub').exists()).toBe(true)
     })
 
-    it('scales the slider max to the farthest distance in the feed (rounded up)', () => {
+    // The slider's right end is now a FIXED extent (matching the Settings slider), not scaled to
+    // the farthest post in the loaded feed. Feed-scaling made the "Max X-Y miles by road" hint jump
+    // as more distant posts loaded and rescaled the max (Discourse 9808), so the max is now stable
+    // regardless of the feed.
+    it('uses a fixed slider max (not scaled to the feed)', () => {
       const wrapper = createWrapper({ forceShowFilters: true })
       const input = wrapper.find('.range-slider-stub')
-      expect(Number(input.attributes('max'))).toBe(7) // ceil(6.7)
+      expect(Number(input.attributes('max'))).toBe(15)
     })
 
-    it('floors the slider max at 2 when the feed is tiny/empty', () => {
+    it('keeps the fixed slider max even when the feed is empty', () => {
       mockNearbyMessageList.value = []
       const wrapper = createWrapper({ forceShowFilters: true })
       const input = wrapper.find('.range-slider-stub')
-      expect(Number(input.attributes('max'))).toBe(2)
+      expect(Number(input.attributes('max'))).toBe(15)
     })
 
-    it('scales the slider max from the mygroups feed on the all-my-communities view', () => {
-      // On mygroups the nearby store is empty - the feed lives in messageStore.myGroupsList.
-      // The slider must scale to THAT, not collapse to the floor (the mis-scaling bug).
+    it('keeps the fixed slider max on the all-my-communities view regardless of that feed', () => {
       mockMe.value = meWithLocation({ browseView: 'mygroups' })
       mockNearbyMessageList.value = []
       mockMyGroupsList.value = [
@@ -500,7 +502,7 @@ describe('PostFilters', () => {
       ]
       const wrapper = createWrapper({ forceShowFilters: true })
       const input = wrapper.find('.range-slider-stub')
-      expect(Number(input.attributes('max'))).toBe(9) // ceil(8.4), from the mygroups feed
+      expect(Number(input.attributes('max'))).toBe(15)
     })
 
     it('has a minimum of 0.5 miles and a step of 0.5', () => {
@@ -519,7 +521,7 @@ describe('PostFilters', () => {
     it('renders the thumb at the far right by default (unlimited sentinel)', () => {
       const wrapper = createWrapper({ forceShowFilters: true })
       const input = wrapper.find('.range-slider-stub')
-      expect(Number(input.element.value)).toBe(7)
+      expect(Number(input.element.value)).toBe(15) // the fixed slider max
     })
 
     it('renders the thumb at the real value when a distance limit is already saved', () => {
@@ -529,12 +531,12 @@ describe('PostFilters', () => {
       expect(Number(input.element.value)).toBe(3)
     })
 
-    // The slider's right end (feedMax) must depend ONLY on the loaded feed, never on the saved
-    // browseMaxDistance - coupling the two made feedMax grow on every slider change, moving the
-    // right edge mid-drag and yanking the thumb back (a janky "clicking back" drag). Here a 5mi
-    // limit is saved but the feed still reaches ~6.7mi, so the scale is the feed extent (7), not
-    // a headroom value derived from the saved distance.
-    it('scales the slider max to the feed extent, independent of the saved distance', () => {
+    // The slider's right end is a FIXED extent, independent of both the loaded feed and the saved
+    // browseMaxDistance. Feed-scaling made feedMax grow as more distant posts loaded, moving the
+    // right edge mid-drag and yanking the thumb back (a janky "clicking back" drag, Discourse 9808).
+    // Here a 5mi limit is saved and the feed reaches ~6.7mi, but the max stays the fixed 15 and the
+    // thumb sits at the saved 5.
+    it('uses the fixed slider max regardless of the feed or the saved distance', () => {
       mockMe.value = meWithLocation({ browseMaxDistance: 5 })
       mockNearbyMessageList.value = [
         { id: 1, distance: 1.2 },
@@ -542,14 +544,14 @@ describe('PostFilters', () => {
       ]
       const wrapper = createWrapper({ forceShowFilters: true })
       const input = wrapper.find('.range-slider-stub')
-      expect(Number(input.attributes('max'))).toBe(7) // ceil(6.7), not a fn of the saved 5
+      expect(Number(input.attributes('max'))).toBe(15) // fixed, not a fn of the feed or saved 5
       expect(Number(input.element.value)).toBe(5) // thumb at the saved distance
     })
 
-    it('stores BROWSE_DISTANCE_UNLIMITED (not the feed max) when dragged to the rightmost stop', async () => {
+    it('stores BROWSE_DISTANCE_UNLIMITED (not the slider max) when dragged to the rightmost stop', async () => {
       const wrapper = createWrapper({ forceShowFilters: true })
       const input = wrapper.find('.range-slider-stub')
-      input.element.value = 7
+      input.element.value = 15 // the fixed slider max
       await input.trigger('change')
       await flushPromises()
       expect(mockMe.value.settings.browseMaxDistance).toBe(


### PR DESCRIPTION
Follow-up to #1030, addressing the distance-slider feedback in [Discourse 9808/551](https://discourse.ilovefreegle.org/t/rippling-out/9808/551).

### Problem
On Browse, the "How far away" slider scaled its right end (`feedMax`) to the farthest post in the currently-loaded feed. As more distant posts loaded and rescaled the max, the **"Max X-Y miles by road"** hint jumped (e.g. 2-4 → 10-22 miles on reload) and the slider behaved unpredictably as an input control. The screenshot also showed the long town line spilling **out of the filter panel** (width overflow).

### Fix
1. **Reach-anchored fixed extent.** Anchor the slider's far end ("Further") to the server's reach ceiling instead of the feed. The default reach is a 30-minute drive-time budget and `milesToDriveMinutes` maps ~2 min/mile, so **15 miles ≈ 30 minutes**. The hint now tracks the real reach and stays stable across reloads. The far end reads ~"Max 19-23 miles by road, e.g. Rochdale, Ashton-under-Lyne, Bury" (from Manchester) rather than the old 37-46 that came from routing a 60-minute, double-reach radius. The far-right stop still stores `BROWSE_DISTANCE_UNLIMITED`, so the server's own reach limit keeps governing and newly-arriving distant posts still show.

2. **Width overflow.** The `.distance` grid cell defaulted to `min-width:auto`, so the single-line NearbyTowns hint expanded the cell past its track and spilled out of the filter panel. `min-width: 0` lets the cell hold its track width so the hint ellipsis-truncates inside the panel.

### Verification
- PostFilters distance-slider unit tests updated from the old feed-scaling expectations to the fixed reach-anchored max — **54 tests green** via the status API.
- Confirmed against live routing data that the hint now scales smoothly and monotonically across the slider (1mi → "Closer than Salford"; 15mi → "Max 19-23 miles by road, e.g. Rochdale, Ashton-under-Lyne, Bury").
- Width fix verified in-browser on dev-live (ellipsis-truncates inside the panel, no overflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VXKgf7Xquudc6CwP2RN6jX