### PR TITLE
fix(chitchat): prevent duplicate replies from Enter double-fire

### DIFF
--- a/iznik-nuxt3/components/NewsReply.vue
+++ b/iznik-nuxt3/components/NewsReply.vue
@@ -422,6 +422,11 @@ const showProfileModal = ref(false)
 const showNewsPhotoModal = ref(false)
 const currentAtts = ref([])
 const bump = ref(0) // Used to force re-renders
+// Guards sendReply against double-submit. The reply box binds Enter on BOTH keydown (parent div)
+// and keyup (textarea), so one Enter press can call sendReply twice; because replybox is only
+// cleared AFTER the async send, both calls pass the non-empty check and post twice, creating
+// duplicate replies (seen on live: newsfeed 613876/613879). Also covers double-click / slow network.
+const sending = ref(false)
 
 // Computed properties
 const enterNewLine = computed(() => {
@@ -568,36 +573,46 @@ function replyReply() {
 }
 
 async function sendReply(callback) {
+  // Re-entrancy guard: a single Enter can fire this twice (keydown + keyup bindings); without this
+  // both would post before replybox is cleared, creating a duplicate reply.
+  if (sending.value) {
+    return
+  }
   // Encode up any emojis.
   if (replybox.value && replybox.value.trim()) {
-    const msg = untwem(replybox.value)
+    sending.value = true
+    try {
+      const msg = untwem(replybox.value)
 
-    const newid = await newsfeedStore.send(
-      msg,
-      replyingTo.value,
-      props.threadhead,
-      imageid.value
-    )
+      const newid = await newsfeedStore.send(
+        msg,
+        replyingTo.value,
+        props.threadhead,
+        imageid.value
+      )
 
-    // New message will be shown because it's in the store and we have a computed property.
-    //
-    // The refetch after send re-renders the thread in the server's new order
-    // (the server bumps the replied-to parent to the end), so the content
-    // under the viewport changes and the fresh reply can land off-screen.
-    // Keep the poster anchored to what they just wrote.
-    scrollReplyIntoView(newid)
+      // New message will be shown because it's in the store and we have a computed property.
+      //
+      // The refetch after send re-renders the thread in the server's new order
+      // (the server bumps the replied-to parent to the end), so the content
+      // under the viewport changes and the fresh reply can land off-screen.
+      // Keep the poster anchored to what they just wrote.
+      scrollReplyIntoView(newid)
 
-    // Clear and hide the textarea now it's sent.
-    replybox.value = null
-    showReplyBox.value = false
+      // Clear and hide the textarea now it's sent.
+      replybox.value = null
+      showReplyBox.value = false
 
-    // And any image id
-    imageid.value = null
-    imageuid.value = null
-    imagemods.value = null
+      // And any image id
+      imageid.value = null
+      imageuid.value = null
+      imagemods.value = null
 
-    // Force re-render. Store reactivity doesn't seem to work nicely with the nested reply structure we have.
-    bump.value++
+      // Force re-render. Store reactivity doesn't seem to work nicely with the nested reply structure we have.
+      bump.value++
+    } finally {
+      sending.value = false
+    }
   }
 
   if (typeof callback === 'function') {

--- a/iznik-nuxt3/components/NewsThread.vue
+++ b/iznik-nuxt3/components/NewsThread.vue
@@ -365,6 +365,9 @@ const threadcommentautoheight = ref(null)
 // Reactive state
 const replyingTo = ref(null)
 const uploading = ref(false)
+// Guards sendComment against double-submit (Enter binds keydown here; a stray double-fire or
+// double-click would otherwise post twice before threadcomment is cleared). See NewsReply.vue.
+const sending = ref(false)
 const imageid = ref(null)
 const ouruid = ref(null)
 const imageuid = ref(null)
@@ -573,46 +576,58 @@ function focusedComment() {
 }
 
 async function sendComment(callback) {
+  // Re-entrancy guard against double-submit (see the sending ref above).
+  if (sending.value) {
+    return
+  }
   if (threadcomment.value && threadcomment.value.trim()) {
-    // Encode up any emojis.
-    const msg = untwem(threadcomment.value)
-    const newid = await newsfeedStore.send(
-      msg,
-      replyingTo.value,
-      props.id,
-      imageid.value
-    )
+    sending.value = true
+    try {
+      // Encode up any emojis.
+      const msg = untwem(threadcomment.value)
+      const newid = await newsfeedStore.send(
+        msg,
+        replyingTo.value,
+        props.id,
+        imageid.value
+      )
 
-    // New message will be shown because it's in the store and we have a computed
-    // property. Keep the poster anchored to their reply: the post-send refetch
-    // re-renders in the server's new order (replied-to parents get bumped), so
-    // without this the viewport content swaps and the reply lands off-screen.
-    // The pin re-resolves the selector on every correction, so it waits for
-    // the refetch to render the new reply and holds it through the shuffle,
-    // releasing when the refetch and image loads are complete.
-    if (newid) {
-      nextTick(() => {
-        ownPin = scrollToAndPin(
-          () => document.querySelector(`[data-reply-id="${newid}"]`),
-          {
-            block: 'center',
-            done: whenAllSettled([
-              condition(() => !miscStore.apiCount),
-              { ok: () => imagesComplete(), wait: () => whenImagesComplete() },
-            ]),
-          }
-        )
-      })
+      // New message will be shown because it's in the store and we have a computed
+      // property. Keep the poster anchored to their reply: the post-send refetch
+      // re-renders in the server's new order (replied-to parents get bumped), so
+      // without this the viewport content swaps and the reply lands off-screen.
+      // The pin re-resolves the selector on every correction, so it waits for
+      // the refetch to render the new reply and holds it through the shuffle,
+      // releasing when the refetch and image loads are complete.
+      if (newid) {
+        nextTick(() => {
+          ownPin = scrollToAndPin(
+            () => document.querySelector(`[data-reply-id="${newid}"]`),
+            {
+              block: 'center',
+              done: whenAllSettled([
+                condition(() => !miscStore.apiCount),
+                {
+                  ok: () => imagesComplete(),
+                  wait: () => whenImagesComplete(),
+                },
+              ]),
+            }
+          )
+        })
+      }
+
+      // Clear the textarea now it's sent.
+      threadcomment.value = null
+
+      // And any image id
+      imageid.value = null
+      imageuid.value = null
+      ouruid.value = null
+      imagemods.value = null
+    } finally {
+      sending.value = false
     }
-
-    // Clear the textarea now it's sent.
-    threadcomment.value = null
-
-    // And any image id
-    imageid.value = null
-    imageuid.value = null
-    ouruid.value = null
-    imagemods.value = null
   }
 
   if (typeof callback === 'function') {

--- a/iznik-nuxt3/tests/unit/components/NewsReply.spec.js
+++ b/iznik-nuxt3/tests/unit/components/NewsReply.spec.js
@@ -635,4 +635,22 @@ describe('NewsReply', () => {
       expect(pill.attributes('aria-label')).toBeTruthy()
     })
   })
+
+  describe('double-submit guard', () => {
+    it('posts a reply only once when send fires twice (Enter keydown+keyup double-fire)', async () => {
+      // Live bug (newsfeed 613876/613879): one Enter fires both the keydown (parent div) and keyup
+      // (textarea) sendReply bindings; without a re-entrancy guard both pass the non-empty check
+      // (replybox is cleared only after the async send) and post duplicate replies.
+      mockNewsfeedSend.mockResolvedValue(999)
+      const wrapper = createWrapper()
+      await wrapper.find('.reply-action').trigger('click') // open the reply box
+      const ta = wrapper.findComponent({ name: 'AutoHeightTextarea' })
+      await ta.setValue('hello world')
+      // Rapid double-fire, no await between, so the 2nd call hits the in-flight guard.
+      ta.trigger('keyup.enter')
+      ta.trigger('keyup.enter')
+      await flushPromises()
+      expect(mockNewsfeedSend).toHaveBeenCalledTimes(1)
+    })
+  })
 })


### PR DESCRIPTION
## Problem

A member edited a ChitChat post and then saw **both the original and the edited copy side by side**. Reported on live.

## Root cause — reply double-submit, not an edit bug

The Go `Edit` handler does an in-place `UPDATE newsfeed SET message=? WHERE id=?`, so editing never duplicates. The duplicate is created at **reply time**.

The reply/comment box binds Enter twice:

- `@keydown.enter.exact.prevent="sendReply"` on the wrapping `<div>`
- `@keyup.enter.exact="sendReply"` on the `<AutoHeightTextarea>`

So a single Enter press can call `sendReply` (and `sendComment` in `NewsThread`) **twice**. The input is cleared only *after* the async `newsfeedStore.send()` resolves, so both invocations pass the `if (replybox…)` non-empty check and each posts a reply.

Confirmed on live — `newsfeed` **613876** and **613879**: same author, same `replyto` parent, both `added` at `07:56:59`. The member then edited them, which is why one showed as "original" and one as "new".

## Fix

Add a `sending` re-entrancy guard to `NewsReply.sendReply` and `NewsThread.sendComment`: an in-flight send short-circuits any repeat call, and `sending` is reset in a `finally`. This also covers double-click and slow-network double submits.

## Test

`NewsReply.spec.js` opens the reply box, types, then double-fires the textarea's Enter/send path with no await between, and asserts `newsfeedStore.send` is called **exactly once**. Full vitest suite green (14241 passed, 0 failed).

## Live data

The two live rows had each been edited with different unique text, so they were merged into one (613879, keeping both edits) and the duplicate (613876) soft-deleted — no member content lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VXKgf7Xquudc6CwP2RN6jX
