### PR TITLE
fix(voicepost): use the transcript verbatim as the description, LLM only for the title

### DIFF
--- a/iznik-nuxt3/pages/voicepost.vue
+++ b/iznik-nuxt3/pages/voicepost.vue
@@ -117,7 +117,7 @@
         </button>
       </div>
 
-      <!-- FINISHING: single transcription + tidy-up -->
+      <!-- FINISHING: single transcription (no rewrite) -->
       <div v-else-if="phase === 'finishing'" class="voicepost__stage">
         <b-spinner class="voicepost__spinner" />
         <p class="voicepost__lead">Writing down what you said&hellip;</p>
@@ -129,8 +129,7 @@
           Here's your post - have a read
         </h1>
         <p class="voicepost__lead voicepost__lead--tight">
-          We tidied up what you said - same words, just neatened. Change anything
-          you like.
+          Here's what you said, word for word. Change anything you like.
         </p>
 
         <img

--- a/iznik-server-go/voicepost/voicepost.go
+++ b/iznik-server-go/voicepost/voicepost.go
@@ -4,12 +4,15 @@
 // the server in small chunks *while they are still talking*, so by the time they
 // stop the recording is already buffered on the server and there is no big upload
 // to wait for. Only then - once - do we transcribe the complete recording with
-// Groq Whisper and run a quick Groq copy-edit that punctuates and lightly tidies
-// their words into a title and description without rewriting them.
+// Groq Whisper. The transcript is used verbatim as the post description: we do
+// NOT run any LLM rewrite of what they said, because in practice it confabulated
+// details the speaker never mentioned (invented provenance, condition, etc.). We
+// use the LLM for one narrow job only - extracting a short item name for the
+// title.
 //
 // Design decisions (see docs spec):
-//   - Groq for BOTH transcription (whisper-large-v3-turbo) and the copy-edit (a
-//     small fast llama model). One GROQ_API_KEY.
+//   - Groq for transcription (whisper-large-v3-turbo) and, separately, a small
+//     fast llama model used ONLY to name the item for the title. One GROQ_API_KEY.
 //   - Transport is plain chunked HTTP, not a WebSocket to a real-time STT engine.
 //     We stream to hide upload latency, not to get sub-second live captions, so a
 //     few seconds of "human latency" after the user stops is the budget.
@@ -188,11 +191,11 @@ type FinishResult struct {
 
 // Finish handles POST /api/voicepost/finish. The client calls this once the user
 // has stopped talking and the final chunk has been sent. We transcribe the whole
-// buffered recording once, then run a Groq copy-edit to punctuate and lightly
-// tidy the transcript into a title and description. The audio file is left in
-// place to be pruned later.
+// buffered recording once and return the transcript verbatim as the description;
+// the LLM is used only to extract a short item name for the title. The audio file
+// is left in place to be pruned later.
 //
-// @Summary Finalise a voice post: transcribe once, then tidy into title/description
+// @Summary Finalise a voice post: transcribe once, return the transcript as the description with an extracted item title
 // @Tags VoicePost
 // @Accept json
 // @Produce json
@@ -222,13 +225,14 @@ func Finish(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusBadRequest, "We couldn't hear anything in that recording - please try again.")
 	}
 
-	title, description := summarise(transcript)
-
+	// The description is the transcript verbatim - we never let the LLM rewrite it,
+	// because it confabulated details the speaker never said. The LLM is used only
+	// to extract a short item name for the title.
 	return c.JSON(FinishResult{
 		ID:          s.id,
 		Transcript:  transcript,
-		Title:       title,
-		Description: description,
+		Title:       itemTitle(transcript),
+		Description: transcript,
 	})
 }
 
@@ -244,8 +248,8 @@ func transcribeModel() string {
 	return "whisper-large-v3-turbo"
 }
 
-func summariseModel() string {
-	if m := os.Getenv("VOICEPOST_SUMMARISE_MODEL"); m != "" {
+func titleModel() string {
+	if m := os.Getenv("VOICEPOST_TITLE_MODEL"); m != "" {
 		return m
 	}
 	return "llama-3.1-8b-instant"
@@ -309,41 +313,39 @@ var transcribe = func(path string) (string, error) {
 	return strings.TrimSpace(out.Text), nil
 }
 
-// summarise lightly copy-edits a raw spoken transcript into a short item title
-// and a tidied description, keeping the poster's own words. Any failure falls
-// back to using the transcript itself so the user is never blocked.
-var summarise = func(transcript string) (string, string) {
+// itemTitle asks Groq for a short plain name of the item described in the
+// transcript - just the item, nothing invented. It deliberately does NOT touch
+// the description: the transcript is used verbatim there, because letting the LLM
+// rewrite what was said confabulated details the speaker never mentioned. Any
+// failure falls back to the first few words of the transcript so the user is
+// never blocked.
+var itemTitle = func(transcript string) string {
 	key := os.Getenv("GROQ_API_KEY")
 	if key == "" {
-		return fallbackTitle(transcript), transcript
+		return fallbackTitle(transcript)
 	}
 
-	system := "You are lightly copy-editing what someone said out loud while giving away an item for free " +
-		"on Freegle, a UK reuse community. Return their OWN words, just cleaned up - this is a copy-edit, " +
-		"NOT a rewrite. Do NOT paraphrase, summarise, reword or add anything.\n" +
-		"For the DESCRIPTION: keep their exact wording, phrasing and personality (including chatty openers like " +
-		"'Hiya' and personal details like 'my nan had it for years'); fix capitalisation and punctuation; join " +
-		"fragments into coherent sentences; and drop only obvious filler, false starts and stutters. You may " +
-		"correct a word the speech-to-text clearly misheard, but change as little as possible and invent NOTHING " +
-		"(no condition, size, colour or collection details they didn't say).\n" +
-		"For the TITLE: a short plain name for the item, 2-5 words, using their words - no marketing adjectives " +
-		"they didn't use, no 'OFFER:' prefix.\n" +
-		"Use British English. Respond ONLY with JSON: {\"title\": \"...\", \"description\": \"...\"}."
+	system := "Someone recorded themselves describing an item they are giving away for free, " +
+		"or looking for, on Freegle, a UK reuse community. From their words, give a short plain " +
+		"name for the item itself: 2-5 words, British English, using their own words. No 'OFFER:' " +
+		"or 'WANTED:' prefix, no marketing adjectives, and invent NOTHING (no condition, size, " +
+		"colour, brand or backstory they did not say). If they mention several items, name the main " +
+		"one. Respond ONLY with JSON: {\"title\": \"...\"}."
 
 	reqBody, _ := json.Marshal(map[string]interface{}{
-		"model": summariseModel(),
+		"model": titleModel(),
 		"messages": []map[string]string{
 			{"role": "system", "content": system},
 			{"role": "user", "content": "Transcript:\n\n" + transcript},
 		},
-		// Low temperature: we want a faithful copy-edit, not a creative rewrite.
-		"temperature":     0.1,
+		// Zero temperature: we want the literal item name, not a creative one.
+		"temperature":     0,
 		"response_format": map[string]string{"type": "json_object"},
 	})
 
 	req, err := http.NewRequest("POST", groqBase+"/chat/completions", bytes.NewReader(reqBody))
 	if err != nil {
-		return fallbackTitle(transcript), transcript
+		return fallbackTitle(transcript)
 	}
 	req.Header.Set("Authorization", "Bearer "+key)
 	req.Header.Set("Content-Type", "application/json")
@@ -351,12 +353,12 @@ var summarise = func(transcript string) (string, string) {
 	client := &http.Client{Timeout: 30 * time.Second}
 	resp, err := client.Do(req)
 	if err != nil {
-		return fallbackTitle(transcript), transcript
+		return fallbackTitle(transcript)
 	}
 	defer resp.Body.Close()
 	rb, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != 200 {
-		return fallbackTitle(transcript), transcript
+		return fallbackTitle(transcript)
 	}
 
 	var out struct {
@@ -367,25 +369,20 @@ var summarise = func(transcript string) (string, string) {
 		} `json:"choices"`
 	}
 	if err := json.Unmarshal(rb, &out); err != nil || len(out.Choices) == 0 {
-		return fallbackTitle(transcript), transcript
+		return fallbackTitle(transcript)
 	}
 
 	var parsed struct {
-		Title       string `json:"title"`
-		Description string `json:"description"`
+		Title string `json:"title"`
 	}
 	if err := json.Unmarshal([]byte(out.Choices[0].Message.Content), &parsed); err != nil {
-		return fallbackTitle(transcript), transcript
+		return fallbackTitle(transcript)
 	}
 	title := strings.TrimSpace(parsed.Title)
-	desc := strings.TrimSpace(parsed.Description)
 	if title == "" {
-		title = fallbackTitle(transcript)
+		return fallbackTitle(transcript)
 	}
-	if desc == "" {
-		desc = transcript
-	}
-	return title, desc
+	return title
 }
 
 // fallbackTitle derives a rough title from the first few words of the transcript.

--- a/iznik-server-go/voicepost/voicepost_test.go
+++ b/iznik-server-go/voicepost/voicepost_test.go
@@ -21,19 +21,20 @@ func testApp() *fiber.App {
 }
 
 // TestChunkAndFinish walks the happy path: a first chunk allocates a session and
-// returns the transcript so far, and finish returns the tidied title/description.
-// The Groq calls are stubbed via the package-level transcribe/summarise vars.
+// returns the transcript so far, and finish returns the transcript verbatim as
+// the description with an LLM-extracted item title. The Groq calls are stubbed
+// via the package-level transcribe/itemTitle vars.
 func TestChunkAndFinish(t *testing.T) {
 	os.Setenv("GROQ_API_KEY", "test-key")
 	defer os.Unsetenv("GROQ_API_KEY")
 
-	origT, origS := transcribe, summarise
-	defer func() { transcribe = origT; summarise = origS }()
+	origT, origIT := transcribe, itemTitle
+	defer func() { transcribe = origT; itemTitle = origIT }()
 	transcribe = func(path string) (string, error) {
 		return "hiya i've got an old chair going free", nil
 	}
-	summarise = func(transcript string) (string, string) {
-		return "Old Chair", "A lovely old chair going free to a good home."
+	itemTitle = func(transcript string) string {
+		return "Old Chair"
 	}
 
 	app := testApp()
@@ -51,7 +52,7 @@ func TestChunkAndFinish(t *testing.T) {
 	assert.NoError(t, json.NewDecoder(resp.Body).Decode(&chunkResp))
 	assert.NotEmpty(t, chunkResp.Session)
 
-	// Finish the same session: this is where transcription + tidy-up happen.
+	// Finish the same session: this is where transcription happens.
 	freq := httptest.NewRequest("POST", "/api/voicepost/finish?session="+chunkResp.Session, nil)
 	fresp, err := app.Test(freq, -1)
 	assert.NoError(t, err)
@@ -61,8 +62,9 @@ func TestChunkAndFinish(t *testing.T) {
 	assert.NoError(t, json.NewDecoder(fresp.Body).Decode(&fin))
 	assert.Equal(t, chunkResp.Session, fin.ID)
 	assert.Equal(t, "Old Chair", fin.Title)
-	assert.Equal(t, "A lovely old chair going free to a good home.", fin.Description)
-	assert.NotEmpty(t, fin.Transcript)
+	// The description is the transcript verbatim - no LLM rewrite.
+	assert.Equal(t, "hiya i've got an old chair going free", fin.Description)
+	assert.Equal(t, "hiya i've got an old chair going free", fin.Transcript)
 }
 
 // TestChunkRequiresKey verifies the endpoint refuses to run when unconfigured.
@@ -86,8 +88,8 @@ func TestFinishUnknownSession(t *testing.T) {
 	assert.Equal(t, fiber.StatusNotFound, resp.StatusCode)
 }
 
-// TestFallbackTitle covers the transcript-derived title used when the LLM tidy-up
-// is unavailable.
+// TestFallbackTitle covers the transcript-derived title used when the LLM item
+// extraction is unavailable.
 func TestFallbackTitle(t *testing.T) {
 	assert.Equal(t, "Item to give away", fallbackTitle(""))
 	assert.Equal(t, "one two three", fallbackTitle("one two three"))


### PR DESCRIPTION
## Problem

The voice-posting flow ran the Whisper transcript through a Groq Llama "copy-edit"
stage before showing it. Despite a prompt telling it to invent nothing, it
confabulated. Real example:

- **What they said:** *"I'm looking for a kettle. Mine has just died."*
- **What it generated:** *"Hiya, my kettle's just died and I'm after a new one ...
  it's been my nan's for years"* — a provenance the person never mentioned.

## Fix

Scrap the rewrite. The Whisper transcript is now used **verbatim** as the post
description, so what the member sees is exactly what they said. The LLM is kept
for one narrow job only: extracting a short plain **item name for the title**
(e.g. "Kettle"), falling back to the first few words of the transcript when Groq
is unavailable.

- `voicepost.go`: `summarise()` (title + description rewrite) → `itemTitle()`
  (title only); `Finish()` returns the transcript as `Description`. Renamed
  `summariseModel`/`VOICEPOST_SUMMARISE_MODEL` → `titleModel`/`VOICEPOST_TITLE_MODEL`.
- `voicepost.vue`: review copy no longer claims we "tidied up" the words.
- Tests updated: the description now asserts the verbatim transcript.

## Testing

Full Go suite via the status API: **3461 passed, 0 failed**, including the
`iznik-server-go/voicepost` package (`TestChunkAndFinish`, `TestChunkRequiresKey`,
`TestFinishUnknownSession`, `TestFallbackTitle`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
