### PR TITLE
fix(modtools): anchor multi-group post to origin, not rippled-in copy (9808/565)

### DIFF
--- a/iznik-nuxt3/modtools/components/ModMessage.vue
+++ b/iznik-nuxt3/modtools/components/ModMessage.vue
@@ -813,6 +813,7 @@ import { twem } from '~/composables/useTwem'
 import {
   isRippledInToContextGroup as isRippledIn,
   earliestArrivalGroupId,
+  homeGroupId,
 } from '~/composables/rippleStatus'
 
 const props = defineProps({
@@ -977,15 +978,16 @@ const currentGroupid = computed(() => {
       ['Pending', 'PendingOther', 'Spam'].includes(g.collection)
     )
     const pool = pending.length ? pending : mine
-    let pick = pool[0]
-    for (const g of pool) {
-      if (
-        g.arrival &&
-        (!pick.arrival || new Date(g.arrival) > new Date(pick.arrival))
-      )
-        pick = g
-    }
-    return parseInt(pick.groupid)
+    // Anchor to the group the post ORIGINATED on (home), not a copy that rippled in
+    // later. A mod active on both the origin and a group the post rippled into should
+    // act on / reply from the origin, so a Blank reply appends to the member's existing
+    // chat with the origin group's volunteers rather than starting a fresh one from the
+    // rippled-in group (Discourse 9808/565). rippled_in is authoritative here; arrival is
+    // not, because the approve path stamps arrival=NOW() on whichever copy was approved -
+    // which is exactly the just-approved rippled-in copy we must NOT pick.
+    const home = homeGroupId(pool)
+    if (home != null) return home
+    return parseInt(pool[0].groupid)
   }
   const gid = parseInt(groupid.value)
   return gid || null

--- a/iznik-nuxt3/tests/unit/components/modtools/ModMessage.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModMessage.spec.js
@@ -1471,6 +1471,45 @@ describe('ModMessage', () => {
       expect(wrapper.vm.groupid).toBe(789)
     })
 
+    // Discourse 9808/565: in the all-communities view a mod who is active on BOTH the
+    // origin group and a group the post rippled into must anchor to the ORIGIN, so a
+    // Blank reply appends to the member's existing chat rather than starting a new one
+    // from the rippled-in group. The rippled-in copy was approved most recently, so its
+    // arrival is newest - anchoring must use rippled_in, not most-recent arrival.
+    it('anchors to the origin group, not a newer rippled-in copy, with no contextGroupid', () => {
+      // The mod is active on BOTH the rippled-in group (789, in the default mock) and the
+      // origin group (111) - add the latter to the moderated set for this test.
+      mockMyModGroups.push({ id: 111 })
+      try {
+        const wrapper = mountComponent(
+          {},
+          {
+            groups: [
+              // Rippled-in copy: approved most recently, so its arrival is the NEWEST.
+              {
+                groupid: 789,
+                namedisplay: 'Rippled-in',
+                collection: 'Approved',
+                arrival: rippleLater,
+                rippled_in: 1,
+              },
+              // Origin: where the member's chat with volunteers actually lives.
+              {
+                groupid: 111,
+                namedisplay: 'Origin',
+                collection: 'Approved',
+                arrival: rippleEarlier,
+                rippled_in: 0,
+              },
+            ],
+          }
+        )
+        expect(wrapper.vm.currentGroupid).toBe(111)
+      } finally {
+        mockMyModGroups.pop()
+      }
+    })
+
     it('computes contextGroup from the correct group', () => {
       const wrapper = mountComponent(
         { contextGroupid: 999 },

--- a/iznik-nuxt3/tests/unit/composables/rippleStatus.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/rippleStatus.spec.js
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import {
   isRippledInToContextGroup,
   earliestArrivalGroupId,
+  homeGroupId,
   homeGroupFirst,
   isHomeGroup,
   RIPPLE_ORIGIN_WINDOW_MS,
@@ -213,6 +214,44 @@ describe('earliestArrivalGroupId', () => {
       { groupid: 7, arrival: at(10) },
     ]
     expect(earliestArrivalGroupId(groups)).toBe(7)
+  })
+})
+
+describe('homeGroupId', () => {
+  it('prefers a non-rippled origin even when a rippled-in copy has a newer arrival', () => {
+    // The approve path stamps arrival=NOW() on whichever copy was approved, so the
+    // just-approved rippled-in copy has the NEWEST arrival - rippled_in must win over
+    // arrival, or a Blank reply goes from the wrong (rippled-in) group (Discourse 9808/565).
+    const groups = [
+      { groupid: 789, arrival: at(60), rippled_in: 1 }, // rippled-in, newest arrival
+      { groupid: 1, arrival: at(10), rippled_in: 0 }, // origin
+    ]
+    expect(homeGroupId(groups)).toBe(1)
+  })
+
+  it('picks the earliest arrival among several non-rippled groups', () => {
+    const groups = [
+      { groupid: 5, arrival: at(30), rippled_in: 0 },
+      { groupid: 6, arrival: at(10), rippled_in: 0 },
+    ]
+    expect(homeGroupId(groups)).toBe(6)
+  })
+
+  it('falls back to earliest arrival when no rippled_in info is present', () => {
+    const groups = [
+      { groupid: 8, arrival: at(40) },
+      { groupid: 9, arrival: at(5) },
+    ]
+    expect(homeGroupId(groups)).toBe(9)
+  })
+
+  it('returns the only group even if it is rippled in', () => {
+    expect(homeGroupId([{ groupid: 3, arrival: at(0), rippled_in: 1 }])).toBe(3)
+  })
+
+  it('returns null for empty/invalid input', () => {
+    expect(homeGroupId([])).toBeNull()
+    expect(homeGroupId(null)).toBeNull()
   })
 })
 


### PR DESCRIPTION
## What

Reported by Neville_Reid in [Rippling out, post 565](https://discourse.ilovefreegle.org/t/rippling-out/9808/565):

> for messages where I'm a mod on the original group, please could search return the approved message on the original group, rather than a rippled-out group?

He approved a WANTED on **Tower Hamlets**; it rippled into **Hackney** (where he's also a mod). Searching for the member returned the **Hackney** (rippled-in) copy, so a **Blank reply** started a *new* chat from Hackney volunteers instead of appending to the member's existing chat with Tower Hamlets volunteers.

## Cause

`ModMessage.vue`'s `currentGroupid` (used for the displayed group, the "moderating for X" banner, and the reply group) picked, for a non-pending multi-group post, the copy with the **most-recent arrival**. But the approve path stamps `arrival=NOW()` on whichever copy was approved — i.e. the just-approved **rippled-in** copy — so it always beat the origin. Same recurring class as 9808/305, 9808/303, 9518/370.

## Fix

Use the authoritative `messages_groups.rippled_in` flag via the existing `homeGroupId()` helper: among the groups the mod moderates on the post, prefer a **non-rippled origin** copy (earliest arrival among those), falling back to arrival only when no `rippled_in` info is present. So the display + Blank reply anchor to the origin group, and the reply appends to the right chat.

- The specific-group queue view (`contextGroupid` set) and edit review are **unaffected**.
- `rippled_in` is populated in this path (`message_list.go` selects it into `message.groups`).

## Coverage

- `ModMessage.spec.js`: `currentGroupid` anchors to the origin over a newer rippled-in copy with no `contextGroupid`.
- `rippleStatus.spec.js`: direct `homeGroupId` coverage (origin preferred even when the rippled-in copy has a newer arrival).
- Full front-end unit suite green (14247 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
