### PR TITLE
fix(share): Copy button copies text + link, matching Email

### DIFF
--- a/iznik-nuxt3/components/MessageShareModal.vue
+++ b/iznik-nuxt3/components/MessageShareModal.vue
@@ -158,7 +158,10 @@ const message = computed(() => {
 })
 
 async function doCopy() {
-  await navigator.clipboard.writeText(message.value.url)
+  // Match the "email" ShareNetwork payload (subject/description/url), so Copy
+  // is consistent with the Email share button rather than a bare link.
+  const shareText = `${message.value.subject}\n\n${message.value.textbody}\n\n${message.value.url}`
+  await navigator.clipboard.writeText(shareText)
   copied.value = true
 }
 

--- a/iznik-nuxt3/tests/unit/components/MessageShareModal.spec.js
+++ b/iznik-nuxt3/tests/unit/components/MessageShareModal.spec.js
@@ -191,15 +191,16 @@ describe('MessageShareModal', () => {
       expect(wrapper.text()).toContain('Copy')
     })
 
-    it('copies URL to clipboard on click', async () => {
+    it('copies link and descriptive text to clipboard on click, matching the Email payload', async () => {
       const wrapper = createWrapper()
       const copyBtn = wrapper
         .findAll('.b-button')
         .find((b) => b.text().includes('Copy'))
       await copyBtn.trigger('click')
-      expect(mockClipboard.writeText).toHaveBeenCalledWith(
-        'https://freegle.org/message/1'
-      )
+      expect(mockClipboard.writeText).toHaveBeenCalledTimes(1)
+      const copiedText = mockClipboard.writeText.mock.calls[0][0]
+      expect(copiedText).toContain(mockMessage.textbody)
+      expect(copiedText).toContain(mockMessage.url)
     })
 
     it('shows check icon after copy', async () => {


### PR DESCRIPTION
## Root Cause
In `MessageShareModal.vue` (the desktop "Share a post" dialog), the Copy button's `doCopy()` wrote only `message.value.url` to the clipboard. The Email button, by contrast, is a `ShareNetwork network="email"` component from `vue-social-sharing`, whose network template (`mailto:?subject=@t&body=@u%0D%0A@d`) builds the mailto body from the message's `title`/`description`/`url` props - i.e. link *and* descriptive text. Copy bypassed this and hand-rolled a bare-URL string, so it was inconsistent with Email (and with the mobile app's `Share.share()` payload, which also includes title + text + url).

## Evidence
Failing test output before the fix (inverted assertion, run against unmodified code):

```
❯ tests/unit/components/MessageShareModal.spec.js (18 tests | 1 failed) 99ms
   × MessageShareModal > copy button > copies link and descriptive text to clipboard on click, matching the Email payload 13ms
     → expected 'https://freegle.org/message/1' to contain 'A lovely item for free'

AssertionError: expected 'https://freegle.org/message/1' to contain 'A lovely item for free'
Expected: "A lovely item for free"
Received: "https://freegle.org/message/1"
```

## Fix
`doCopy()` now builds `${message.value.subject}\n\n${message.value.textbody}\n\n${message.value.url}` and copies that combined text, so the clipboard payload contains the same subject/description/url fields the Email button already sends - not a second, divergent payload builder.

## Other Call Sites
Same URL-only `doCopy()` pattern also exists in `NewsShareModal.vue` and `StoryShareModal.vue` (chitchat/story share dialogs). Left unchanged - out of scope for this post-share bug (topic 9901 post 3), but worth a follow-up if the same inconsistency is reported there.

## Test
- File: `iznik-nuxt3/tests/unit/components/MessageShareModal.spec.js`
- Command: `npx vitest run tests/unit/components/MessageShareModal.spec.js`
- Proves fail-before/pass-after: the existing "copies URL to clipboard" test already encoded the buggy bare-URL behaviour and passed unmodified; inverted it to assert the clipboard text contains both the descriptive text and the link. It failed against the original code (see Evidence) and passes after the fix. Full unit suite (`npx vitest run`, 666 files / 14240 tests) passes with no regressions.

## Discourse
https://discourse.ilovefreegle.org/t/9901/3