### PR TITLE
fix(ai-images): Regenerate doesn't handle multi-item post names

### DIFF
--- a/iznik-server-go/aiimage/aiimage.go
+++ b/iznik-server-go/aiimage/aiimage.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -249,10 +250,44 @@ func subjectForName(name string) string {
 	return name
 }
 
+// andSplitRe splits a compound item name (e.g. "sofa and a bed") on the word "and". The word
+// boundaries stop it matching inside words like "Android".
+var andSplitRe = regexp.MustCompile(`(?i)\s+and\s+`)
+
+// splitItems splits a name into its component items on "and". Returns a single-element slice
+// unchanged when there is no "and" separator (the common case).
+func splitItems(subject string) []string {
+	parts := andSplitRe.Split(subject, -1)
+	items := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			items = append(items, p)
+		}
+	}
+	if len(items) == 0 {
+		return []string{subject}
+	}
+	return items
+}
+
 // buildImagePrompt constructs the AI image generation prompt.
 // For job titles, subjectForName() maps them to their canonical object first.
+// Names listing multiple items joined by "and" (e.g. "sofa and a bed") get a prompt that
+// asks for every item to be shown together, instead of the single-object prompt below, which
+// otherwise leads the model to draw only the first item and drop the rest.
 func buildImagePrompt(name string) string {
 	subject := subjectForName(name)
+	items := splitItems(subject)
+
+	if len(items) > 1 {
+		return "Product illustration: " + strings.Join(items, " and ") + " shown together, arranged neatly side by side on plain dark green background. " +
+			"Style: friendly cartoon white line drawing, moderate shading, cute and quirky, UK audience. " +
+			"Every one of these items must be clearly visible in the illustration, sitting on a simple surface or floating in space. " +
+			"Simple illustration style, clean lines. " +
+			"These are common UK household or everyday items. " +
+			"Use American English terminology."
+	}
+
 	return "Product illustration: single isolated " + subject + " centered on plain dark green background. " +
 		"Style: friendly cartoon white line drawing, moderate shading, cute and quirky, UK audience. " +
 		"The object sits alone on a simple surface or floats in space. " +

--- a/iznik-server-go/aiimage/aiimage_unit_test.go
+++ b/iznik-server-go/aiimage/aiimage_unit_test.go
@@ -273,3 +273,24 @@ func TestBuildImagePrompt_UsesAmericanEnglish(t *testing.T) {
 	assert.Contains(t, prompt, "American English",
 		"prompt must instruct the model to use American English terminology")
 }
+
+func TestBuildImagePrompt_MultiItemName_DoesNotForceSingleObjectOnly(t *testing.T) {
+	// Regression test for Discourse topic 9630/53: a post for "a sofa and a bed" stores
+	// ai_images.name = "sofa and a bed" verbatim. Regenerate (aiimage.Regenerate) calls
+	// buildImagePrompt() with that stored name, so a fix must live here — parsing "and" to
+	// detect multiple items and dropping the self-contradictory "single object only"
+	// instruction, which otherwise makes the model draw only the first item every time,
+	// including on Regenerate.
+	prompt := buildImagePrompt("sofa and a bed")
+	assert.NotContains(t, prompt, "single object only",
+		"a compound item name must not be forced into a 'single object only' prompt")
+	assert.Contains(t, prompt, "sofa")
+	assert.Contains(t, prompt, "bed")
+}
+
+func TestBuildImagePrompt_SingleItemName_StillForcesSingleObjectOnly(t *testing.T) {
+	// Single-item names are unaffected — the existing "single object only" constraint
+	// still applies so ordinary items keep their focused, uncluttered illustration.
+	prompt := buildImagePrompt("sofa")
+	assert.Contains(t, prompt, "single object only")
+}


### PR DESCRIPTION
## Root Cause
`buildImagePrompt()` in `iznik-server-go/aiimage/aiimage.go` embeds `ai_images.name` verbatim as the subject of a `"single isolated ... single object only"` prompt, with no parsing for compound names like "sofa and a bed". The Regenerate button (`POST /api/admin/ai-images/:id/regenerate`) calls this exact function with the stored name, so it reproduces the same defective image every time — it never picks up on "and" to detect there are multiple items.

## Evidence
Failing test before the fix (`TestBuildImagePrompt_MultiItemName_DoesNotForceSingleObjectOnly`):
```
=== RUN   TestBuildImagePrompt_MultiItemName_DoesNotForceSingleObjectOnly
    aiimage_unit_test.go:285:
        Error Trace:  aiimage_unit_test.go:285
        Error:        "Product illustration: single isolated sofa and a bed centered on plain dark green background. Style: friendly cartoon white line drawing, moderate shading, cute and quirky, UK audience. The object sits alone on a simple surface or floats in space. Simple illustration style, clean lines, single object only. This is a common UK household or everyday item. Use American English terminology." should not contain "single object only"
        Test:         TestBuildImagePrompt_MultiItemName_DoesNotForceSingleObjectOnly
        Messages:     a compound item name must not be forced into a 'single object only' prompt
--- FAIL: TestBuildImagePrompt_MultiItemName_DoesNotForceSingleObjectOnly (0.00s)
FAIL
```
Confirmed against production data: 2,467 of 45,302 `ai_images` rows have `name LIKE '% and %'` — this is a common, non-edge-case shape for post names, not a rare occurrence.

## Fix
Added `splitItems()`, which splits a name on the word "and" (word-boundary, case-insensitive). `buildImagePrompt()` now checks the item count: for a single item, behaviour is unchanged (the existing "single isolated ... single object only" prompt). For 2+ items, it builds a prompt asking the model to show every item together, instead of a prompt that both names multiple things and simultaneously insists on drawing only one — the contradiction that was causing the model to draw just the first item.

This fixes the Regenerate flow specifically, since it always reads the stored `ai_images.name`, which is unaffected by the fact that the *original* cron-generated image (via `iznik-batch`'s `MessageIllustrationsService`/`PollinationsService`) may still only depict one item — that's a separate batch-job code path not touched by this PR.

## Other Call Sites
`iznik-batch/app/Services/PollinationsService.php` (`buildMessagePrompt`, `buildJobPrompt`) has the same `"single object only"` pattern, used only for the initial cron-generated illustration, not the Regenerate flow. Left out of scope for this PR — the reporter's concrete complaint was specifically that Regenerate doesn't pick up on "and", which is now fixed.

## Test
`iznik-server-go/aiimage/aiimage_unit_test.go`:
- `TestBuildImagePrompt_MultiItemName_DoesNotForceSingleObjectOnly` — fails before the fix (shown above), passes after.
- `TestBuildImagePrompt_SingleItemName_StillForcesSingleObjectOnly` — guards against regressing single-item behaviour.

Run: `go test ./aiimage/...` (pure function, no DB). Full package suite passes, including all pre-existing tests.

## Discourse
https://discourse.ilovefreegle.org/t/9630/53