### PR TITLE
fix(modtools): don't clear the session on a 401 from a non-session endpoint

### DIFF
--- a/iznik-nuxt3/api/BaseAPI.js
+++ b/iznik-nuxt3/api/BaseAPI.js
@@ -200,11 +200,25 @@ export default class BaseAPI {
       }
 
       if (status === 401) {
-        // Not authorised - our JWT and/or persistent token must be wrong.  Clear them.  This may force a login, or
-        // not, depending on whether the page requires it.
-        console.log('Not authorised - force logged out')
-        authStore.setAuth(null, null)
-        authStore.setUser(null)
+        // A 401 on THIS request doesn't prove the whole session is dead - only
+        // GET/PATCH/DELETE /session, the authoritative "am I logged in" check,
+        // does (fetchUser() in stores/auth.js already handles that case on its
+        // own 401/404).  Clearing auth here unconditionally, for every one of
+        // the many background calls a page fires (chat polls, notification
+        // counts, ModTools work-count refresh, newsfeed, etc.), meant a single
+        // transient/edge-case 401 on any of them force-logged the user out even
+        // though the session was still good - the cause of moderators being
+        // asked to log in to ModTools unexpectedly often (Discourse #9893).
+        const isSessionCheck =
+          path === '/session' || path.startsWith('/session?')
+
+        if (isSessionCheck) {
+          console.log('Not authorised on /session - force logged out')
+          authStore.setAuth(null, null)
+          authStore.setUser(null)
+        } else {
+          console.log('Not authorised for this request - session left intact')
+        }
 
         // For specific paths, we want to silently allow 401 errors and swallow them.
         // This can happen if a login token is invalid, and we don't want to show errors to the user.

--- a/iznik-nuxt3/tests/unit/api/BaseAPI.spec.js
+++ b/iznik-nuxt3/tests/unit/api/BaseAPI.spec.js
@@ -76,13 +76,36 @@ describe('BaseAPI', () => {
       expect(mockCaptureMessage).not.toHaveBeenCalled()
     })
 
-    it('clears auth state on 401', async () => {
+    it('does not clear auth state on a 401 from a non-session endpoint (Discourse #9893)', async () => {
+      // A 401 from a background/secondary call (chat poll, notification count,
+      // ModTools work-count refresh, newsfeed, etc.) does not prove the whole
+      // session is dead - only GET/PATCH/DELETE /session, the authoritative
+      // login check, does. Wiping auth here caused moderators to be bounced
+      // to the login screen from a single transient 401 on any one of the
+      // many background requests ModTools fires.
       mockFetch.mockResolvedValue([401, {}])
 
       const api = createApi()
 
       try {
         await api.$requestv2('GET', '/test', {})
+      } catch (e) {
+        // expected
+      }
+
+      expect(mockSetAuth).not.toHaveBeenCalled()
+      expect(mockSetUser).not.toHaveBeenCalled()
+    })
+
+    it('clears auth state on a 401 from the /session endpoint', async () => {
+      // /session is the authoritative "am I still logged in" check, so a 401
+      // from it genuinely means the session is dead and auth must be cleared.
+      mockFetch.mockResolvedValue([401, {}])
+
+      const api = createApi()
+
+      try {
+        await api.$requestv2('GET', '/session', {})
       } catch (e) {
         // expected
       }


### PR DESCRIPTION
## Root Cause
`BaseAPI.js`'s `$requestv2` cleared the JWT/persistent token and the logged-in user (`authStore.setAuth(null, null)` + `authStore.setUser(null)`) on **any** HTTP 401 response, from **any** endpoint - not just the authoritative `GET /session` login check. ModTools fires a large number of background API calls (`checkWork` polling every 30s for work counts, chat unread counts, notification counts, Discourse stats, etc.), so a single transient/edge-case 401 on any one of those secondary calls wiped the entire session client-side and forced a full re-login, even though the session itself was still valid server-side. This directly contradicts the codebase's own established pattern (see `components/LayoutCommon.vue`'s `monitorTabVisibility()`, which already treats a secondary-call failure as "double-check via `fetchUser()`", not "log out immediately") - except that pattern couldn't work here because `BaseAPI.js` had already destroyed the credentials needed to make that check.

Heavy ModTools users (many background polls = many chances for a stray 401) see this "several times a day"; lighter users see it more rarely ("one after a week") - matching all three reports on Discourse topic 9893.

## Evidence
Failing test before the fix (`does not clear auth state on a 401 from a non-session endpoint`):
```
FAIL  tests/unit/api/BaseAPI.spec.js > BaseAPI > 401 handling > does not clear auth state on a 401 from a non-session endpoint (Discourse #9893)
AssertionError: expected "spy" to not be called at all, but actually been called 1 times
  1st spy call:
    Array [ null, null ]
```

## Fix
In `api/BaseAPI.js`, only clear `authStore` on a 401 when the request path is `/session` (GET/PATCH/DELETE) - the one endpoint that authoritatively determines "am I still logged in". Every other endpoint's 401 now just throws the `APIError` as before (callers still see and can react to the failure), but no longer nukes the whole session. `fetchUser()` in `stores/auth.js` already has its own correct 401/404 handling for `/session` specifically, so genuine session invalidation (expired JWT, deleted session row, real logout elsewhere) is still detected and still clears auth - just via the one authoritative check instead of via every background request.

This does **not** weaken auth: the server still rejects every request with an invalid/expired token with 401 regardless of this change - no token lifetime was extended and no endpoint became more permissive. The only thing that changed is what the *client* does locally in response to a non-authoritative 401: it no longer discards a still-valid token based on a single secondary-endpoint hiccup.

## Other Call Sites
```
$ grep -rn "setAuth(null|setUser(null)" --include=*.js
stores/auth.js:468-469   (fetchUser() - the authoritative /session check, unchanged, correct)
api/BaseAPI.js:217-218   (this PR - now scoped to /session only)
```
No other call site duplicates this pattern. `api/BaseAPI.js` is shared by both the Freegle site and ModTools builds (same file, same `stores/auth.js`), so the fix applies to both.

## Test
- File: `iznik-nuxt3/tests/unit/api/BaseAPI.spec.js`
- Command: `npx vitest run tests/unit/api/BaseAPI.spec.js`
- Proves fail-before / pass-after: the inverted test (`does not clear auth state on a 401 from a non-session endpoint`) fails on the pre-fix code (shown above) and passes after the fix; a companion test (`clears auth state on a 401 from the /session endpoint`) proves genuine session invalidation still works. Full unit suite (666 files / 14241 tests) passes with no regressions.

## Discourse
https://discourse.ilovefreegle.org/t/9893/1