### PR TITLE
fix(chat): stop an unnecessary await breaking the chat draft flush on switch

### DIFF
--- a/iznik-nuxt3/components/ChatFooter.vue
+++ b/iznik-nuxt3/components/ChatFooter.vue
@@ -423,7 +423,11 @@ const miscStore = useMiscStore()
 const addressStore = useAddressStore()
 const chatDraftStore = useChatDraftStore()
 
-// Setup chat data
+// Setup chat data. setupChat() is a plain synchronous function - it must not be
+// awaited here. A top-level await in <script setup> makes Vue treat the whole
+// component as async setup(), which silently detaches any watch()/onMounted()/
+// onBeforeUnmount() registered afterwards from the component instance (they never
+// fire). That broke the draft-save-on-chat-switch flush below (topic 9884 post 2).
 const {
   chat,
   otheruser,
@@ -432,7 +436,7 @@ const {
   chatmessages,
   milesaway,
   milesstring,
-} = await setupChat(props.id)
+} = setupChat(props.id)
 
 // Extract writable state from store
 const { lastTyping } = storeToRefs(miscStore)

--- a/iznik-nuxt3/tests/unit/components/ChatFooterDraftPersistence.spec.js
+++ b/iznik-nuxt3/tests/unit/components/ChatFooterDraftPersistence.spec.js
@@ -1,0 +1,193 @@
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { defineComponent, h, ref, watch, onBeforeUnmount, Suspense } from 'vue'
+import { useChatDraftStore } from '~/stores/chatdraft'
+
+// setupChat() (composables/useChat.js) is a plain synchronous function - it never
+// awaits anything.
+function setupChat(id) {
+  return { id }
+}
+
+// Buggy shape: mirrors ChatFooter.vue as it stood before this fix - it awaited
+// setupChat() (a top-level await in <script setup>, which makes Vue treat the
+// whole component as async setup) BEFORE registering the sendmessage ref, the
+// draft-save watchers and the onBeforeUnmount flush that PR #1031 (0d71728de)
+// added. Vue's own docs warn that lifecycle hooks/watchers registered after the
+// first await in an async setup() are not bound to the component instance, so
+// onBeforeUnmount silently never fires - the root cause of topic 9884 post 2.
+function buildBuggyFooter() {
+  return defineComponent({
+    props: { id: { type: Number, required: true } },
+    async setup(props) {
+      const chatDraftStore = useChatDraftStore()
+
+      await setupChat(props.id)
+
+      const sendmessage = ref(null)
+
+      // Intentionally reproducing the historic bug for this regression test: these
+      // hooks are registered after the await above, so they never bind to the
+      // component instance.
+      // eslint-disable-next-line vue/no-watch-after-await
+      watch(
+        () => props.id,
+        (newId, oldId) => {
+          if (oldId && oldId !== newId) {
+            chatDraftStore.saveDraft(oldId, sendmessage.value)
+          }
+          const saved = chatDraftStore.getDraft(newId)
+          if (saved && !sendmessage.value) {
+            sendmessage.value = saved
+          }
+        },
+        { immediate: true }
+      )
+
+      // eslint-disable-next-line vue/no-lifecycle-after-await
+      onBeforeUnmount(() => {
+        chatDraftStore.saveDraft(props.id, sendmessage.value)
+      })
+
+      return () =>
+        h('textarea', {
+          value: sendmessage.value,
+          onInput: (e) => {
+            sendmessage.value = e.target.value
+          },
+        })
+    },
+  })
+}
+
+// Fixed shape: the hooks are registered before the await, so they stay bound to
+// the component instance and fire normally.
+function buildFixedFooter() {
+  return defineComponent({
+    props: { id: { type: Number, required: true } },
+    async setup(props) {
+      const chatDraftStore = useChatDraftStore()
+      const sendmessage = ref(null)
+
+      watch(
+        () => props.id,
+        (newId, oldId) => {
+          if (oldId && oldId !== newId) {
+            chatDraftStore.saveDraft(oldId, sendmessage.value)
+          }
+          const saved = chatDraftStore.getDraft(newId)
+          if (saved && !sendmessage.value) {
+            sendmessage.value = saved
+          }
+        },
+        { immediate: true }
+      )
+
+      onBeforeUnmount(() => {
+        chatDraftStore.saveDraft(props.id, sendmessage.value)
+      })
+
+      await setupChat(props.id)
+
+      return () =>
+        h('textarea', {
+          value: sendmessage.value,
+          onInput: (e) => {
+            sendmessage.value = e.target.value
+          },
+        })
+    },
+  })
+}
+
+function mountChatPane(Footer, chatId) {
+  const Parent = defineComponent({
+    props: { chatId: { type: Number, required: true } },
+    setup(props) {
+      return () =>
+        h(Suspense, null, {
+          default: () =>
+            h(Footer, {
+              id: props.chatId,
+              // Mirrors pages/chats/[[id]].vue keying ChatPane by
+              // 'chatpane-' + selectedChatId, which forces a full unmount/remount
+              // of ChatFooter on every chat switch.
+              key: 'chatpane-' + props.chatId,
+            }),
+          fallback: () => h('div', 'loading'),
+        })
+    },
+  })
+  return mount(Parent, { props: { chatId } })
+}
+
+async function settle(wrapper) {
+  // Async setup() needs a couple of microtask/tick rounds to resolve and patch.
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  await wrapper.vm.$nextTick()
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  await wrapper.vm.$nextTick()
+}
+
+describe('ChatFooter chat-switch draft persistence (topic 9884 post 2)', () => {
+  let originalWarn
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    // The repo's test setup escalates [Vue warn] console output into a thrown
+    // error (see tests/unit/setup.ts) so it can't leak past dev builds. That's
+    // exactly the warning this bug trips ("onBeforeUnmount is called when there
+    // is no active component instance... register lifecycle hooks before the
+    // first await"). In production Vue only warns (and only in dev builds) - it
+    // does not throw - so silence it here to observe the real broken behaviour
+    // instead of crashing the test.
+    originalWarn = console.warn
+    console.warn = () => {}
+  })
+
+  afterEach(() => {
+    console.warn = originalWarn
+  })
+
+  it('does NOT save the draft on chat switch when hooks are registered after the await (bug)', async () => {
+    const wrapper = mountChatPane(buildBuggyFooter(), 1)
+    await settle(wrapper)
+
+    await wrapper.find('textarea').setValue('hello world')
+
+    await wrapper.setProps({ chatId: 2 })
+    await settle(wrapper)
+
+    const store = useChatDraftStore()
+    expect(store.getDraft(1)).toBe('')
+  })
+
+  it('saves the draft on chat switch when hooks are registered before the await (fixed)', async () => {
+    const wrapper = mountChatPane(buildFixedFooter(), 1)
+    await settle(wrapper)
+
+    await wrapper.find('textarea').setValue('hello world')
+
+    await wrapper.setProps({ chatId: 2 })
+    await settle(wrapper)
+
+    const store = useChatDraftStore()
+    expect(store.getDraft(1)).toBe('hello world')
+  })
+
+  it('ChatFooter.vue does not await setupChat() at the top level', () => {
+    // Ties the reproduction above to the real file: setupChat() is a plain
+    // synchronous function (composables/useChat.js), so awaiting it is not just
+    // unnecessary - it's a top-level await in <script setup>, which makes Vue
+    // treat the component as async setup. That silently detaches any watch()/
+    // onBeforeUnmount() registered after it - the root cause of this bug.
+    const source = readFileSync(
+      resolve(__dirname, '../../../components/ChatFooter.vue'),
+      'utf-8'
+    )
+    expect(source).not.toMatch(/await\s+setupChat\(/)
+  })
+})


### PR DESCRIPTION
## Root Cause
`ChatFooter.vue` awaited `setupChat(props.id)` even though `setupChat()` (`composables/useChat.js`) is a plain synchronous function that never awaits anything. That single top-level `await` in `<script setup>` makes Vue compile the whole component as an async `setup()`. Per Vue's own docs, lifecycle hooks and watchers registered *after* the first `await` in an async `setup()` are not bound to the component instance. The chat-switch draft-save logic added in 0d71728de (PR #1031) registered its `watch(() => props.id, ...)` and the `onBeforeUnmount` flush *after* that pre-existing await, so neither ever actually attached — switching to another chat lost the typed-but-unsent draft, even though the debounced auto-save while typing (a separate `watch(sendmessage, ...)` also declared after the await) happened to still work because `watch()` degrades more gracefully than the unmount hook.

## Evidence
Added `tests/unit/components/ChatFooterDraftPersistence.spec.js`, which reproduces the exact shape of `ChatFooter.vue`'s `setup()` (a top-level await before the draft-persistence hooks) using the real `chatdraft` store. Before the fix:
```
✓ does NOT save the draft on chat switch when hooks are registered after the await (bug)
✗ ChatFooter.vue does not await setupChat() at the top level
  TypeError: expect(received).not.toMatch(expected)
  Expected substring: not /await\s+setupChat\(/
  Received string:     "...} = await setupChat(props.id)..."
```
Also confirmed with Vue's own runtime warning when reproducing the pattern outside the test harness's warn-suppression:
```
[Vue warn]: onBeforeUnmount is called when there is no active component instance to be associated with.
Lifecycle injection APIs can only be used during execution of setup().
If you are using async setup(), make sure to register lifecycle hooks before the first await statement.
```

## Fix
Removed the unnecessary `await` before `setupChat(props.id)` in `components/ChatFooter.vue`. `setupChat()` never did anything asynchronous, so this changes no data/timing — it just stops Vue from treating the component as async setup, so `watch(() => props.id, ...)` and `onBeforeUnmount` (and the pre-existing `watch(sendmessage, ...)` typing-notify watcher) all bind to the component instance correctly. This fixes draft persistence for every unmount path (switching chats, navigating away entirely, browser back) — not just the specific "click another chat" case reported.

## Other Call Sites
The same `await setupChat(...)` (awaiting a synchronous function) pattern also exists in `ChatPane.vue`, `ChatHeader.vue`, `ChatMessage.vue`, `ChatMobileNavbar.vue`, and `modtools/components/ModChatModal.vue`. Several of those (`ChatPane.vue`, `ChatMobileNavbar.vue`) also register `onMounted`/`onBeforeUnmount` after their own `await setupChat(...)`, so they carry the same latent risk for whatever those hooks do — but none of them touch chat-draft persistence (the modtools chat footer has no draft-save feature at all), so they're out of scope for this fix. Worth a follow-up cleanup ticket.

Confirmed this is not working-as-designed: no `iznik-server` PHP equivalent (the feature is new), no doc says drafts save only on pane close, and `git log` shows the draft-save mechanism was added by 0d71728de (PR #1031) 2 days before this report — a gap in a just-shipped feature.

## Test
- File: `iznik-nuxt3/tests/unit/components/ChatFooterDraftPersistence.spec.js`
- Command: `npx vitest run tests/unit/components/ChatFooterDraftPersistence.spec.js`
- Proves fail-before/pass-after: the "does NOT save the draft..." case reproduces the bug pattern directly; the "ChatFooter.vue does not await setupChat()" canary check fails against the pre-fix file and passes after the fix. Full unit suite (`npx vitest run`, 667 files / 14243 tests) passes with no regressions.

## Discourse
https://discourse.ilovefreegle.org/t/9884/2