### PR TITLE
fix(share): guard Copy payload so a body-less message can't paste "undefined"

### DIFF
--- a/iznik-nuxt3/components/MessageShareModal.vue
+++ b/iznik-nuxt3/components/MessageShareModal.vue
@@ -159,8 +159,14 @@ const message = computed(() => {
 
 async function doCopy() {
   // Match the "email" ShareNetwork payload (subject/description/url), so Copy
-  // is consistent with the Email share button rather than a bare link.
-  const shareText = `${message.value.subject}\n\n${message.value.textbody}\n\n${message.value.url}`
+  // is consistent with the Email share button rather than a bare link. Guard
+  // each field and drop empty parts: body-less messages (subject-only OFFERs /
+  // WANTEDs, or a nulled textbody) must never paste the literal "undefined" or
+  // "null" that a raw template literal would stringify.
+  const m = message.value
+  const shareText = [m?.subject, m?.textbody, m?.url]
+    .filter((part) => part != null && part !== '')
+    .join('\n\n')
   await navigator.clipboard.writeText(shareText)
   copied.value = true
 }

--- a/iznik-nuxt3/tests/unit/components/MessageShareModal.spec.js
+++ b/iznik-nuxt3/tests/unit/components/MessageShareModal.spec.js
@@ -191,16 +191,30 @@ describe('MessageShareModal', () => {
       expect(wrapper.text()).toContain('Copy')
     })
 
-    it('copies link and descriptive text to clipboard on click, matching the Email payload', async () => {
+    it('copies the full Email-style payload (subject, body, url) to the clipboard', async () => {
       const wrapper = createWrapper()
       const copyBtn = wrapper
         .findAll('.b-button')
         .find((b) => b.text().includes('Copy'))
       await copyBtn.trigger('click')
       expect(mockClipboard.writeText).toHaveBeenCalledTimes(1)
+      expect(mockClipboard.writeText).toHaveBeenCalledWith(
+        `${mockMessage.subject}\n\n${mockMessage.textbody}\n\n${mockMessage.url}`
+      )
+    })
+
+    it('omits a missing body so the clipboard never contains "undefined" / "null"', async () => {
+      // Body-less messages (subject-only OFFERs/WANTEDs, or the API nulling the
+      // body) must not stringify into the literal word "undefined"/"null".
+      mockMessageStore.byId.mockReturnValue({ ...mockMessage, textbody: null })
+      const wrapper = createWrapper()
+      const copyBtn = wrapper
+        .findAll('.b-button')
+        .find((b) => b.text().includes('Copy'))
+      await copyBtn.trigger('click')
       const copiedText = mockClipboard.writeText.mock.calls[0][0]
-      expect(copiedText).toContain(mockMessage.textbody)
-      expect(copiedText).toContain(mockMessage.url)
+      expect(copiedText).not.toMatch(/undefined|null/)
+      expect(copiedText).toBe(`${mockMessage.subject}\n\n${mockMessage.url}`)
     })
 
     it('shows check icon after copy', async () => {


### PR DESCRIPTION
Follow-up to #1045 (now merged).

## Bug
`doCopy()` built the clipboard text with a raw template literal:
```js
`${message.value.subject}\n\n${message.value.textbody}\n\n${message.value.url}`
```
A message with no body — subject-only OFFERs/WANTEDs, or the API nulling `textbody` — stringifies the missing field into the **literal word "undefined"/"null"** in the copied share text. (The Email `ShareNetwork` button doesn't have this issue because it passes the fields as props, not string interpolation.)

## Fix
Build the payload from only the present parts:
```js
const shareText = [m?.subject, m?.textbody, m?.url]
  .filter((part) => part != null && part !== '')
  .join('\n\n')
```

## Test
Assert the exact full payload, and add a body-less case asserting the clipboard never contains "undefined"/"null" (the previous `toContain` checks couldn't catch it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
