### PR TITLE
fix(ai-images): don't split single item names that merely contain "and"

### DIFF
--- a/iznik-server-go/aiimage/aiimage.go
+++ b/iznik-server-go/aiimage/aiimage.go
@@ -254,10 +254,28 @@ func subjectForName(name string) string {
 // boundaries stop it matching inside words like "Android".
 var andSplitRe = regexp.MustCompile(`(?i)\s+and\s+`)
 
-// splitItems splits a name into its component items on "and". Returns a single-element slice
-// unchanged when there is no "and" separator (the common case).
+// newItemStartRe matches the start of a new item after an "and": an article/quantifier
+// ("a", "an", "some", "another") or a digit. Go's RE2 has no lookahead, so splitItems()
+// applies this to each piece rather than baking it into andSplitRe.
+var newItemStartRe = regexp.MustCompile(`(?i)^(a|an|some|another|\d)\b`)
+
+// splitItems splits a name into its component items on "and" - but only when every piece
+// after an "and" starts like a new item (article/quantifier/digit). This keeps genuine
+// multi-item posts splitting ("sofa and a bed", "3 chairs and a table") while leaving a
+// single item whose name merely contains "and" intact: "Black and Decker drill", "Pride and
+// Prejudice", "salt and pepper set", "Marks and Spencer jumper". Returns a single-element
+// slice for the common no-"and" case.
 func splitItems(subject string) []string {
 	parts := andSplitRe.Split(subject, -1)
+	if len(parts) < 2 {
+		return []string{subject}
+	}
+	for _, p := range parts[1:] {
+		if !newItemStartRe.MatchString(strings.TrimSpace(p)) {
+			// "and" is inside a single item's name (brand/title/set), not a separator.
+			return []string{subject}
+		}
+	}
 	items := make([]string, 0, len(parts))
 	for _, p := range parts {
 		if p = strings.TrimSpace(p); p != "" {

--- a/iznik-server-go/aiimage/aiimage_unit_test.go
+++ b/iznik-server-go/aiimage/aiimage_unit_test.go
@@ -294,3 +294,27 @@ func TestBuildImagePrompt_SingleItemName_StillForcesSingleObjectOnly(t *testing.
 	prompt := buildImagePrompt("sofa")
 	assert.Contains(t, prompt, "single object only")
 }
+
+func TestBuildImagePrompt_BrandOrTitleName_NotSplitAsMultiItem(t *testing.T) {
+	// Regression: a single item whose name merely contains "and" (a brand name, a title, or
+	// a set) must NOT be treated as multiple items - that made the model draw two separate
+	// objects side by side. Only an "and" that introduces a new item (article/quantifier/
+	// digit) is a separator.
+	for _, name := range []string{
+		"Black and Decker drill",
+		"Pride and Prejudice",
+		"salt and pepper set",
+		"Marks and Spencer jumper",
+	} {
+		prompt := buildImagePrompt(name)
+		assert.Contains(t, prompt, "single object only",
+			name+" is one item and must keep the single-object prompt")
+	}
+}
+
+func TestBuildImagePrompt_GenuineMultiItem_StillSplits(t *testing.T) {
+	for _, name := range []string{"sofa and a bed", "3 chairs and a table"} {
+		prompt := buildImagePrompt(name)
+		assert.NotContains(t, prompt, "single object only", name+" lists multiple items")
+	}
+}


### PR DESCRIPTION
Follow-up to #1046 (merged). The adversarial review flagged this and it's a real live bug.

## Bug
`splitItems()` split on any `" and "`, so a **single** item whose name contains "and" was treated as multiple items:

| Name | Split into | AI prompt result |
|------|-----------|------------------|
| Black and Decker drill | Black · Decker drill | "…shown together, side by side…" (2 objects) |
| Pride and Prejudice | Pride · Prejudice | 2 objects |
| salt and pepper set | salt · pepper set | 2 objects |
| Marks and Spencer jumper | Marks · Spencer jumper | 2 objects |

`buildImagePrompt()` then told the image model to draw two separate objects for what is one item. (#1046's own test only used `"sofa"`, which has no "and", so it never caught this.)

## Fix
Only split when the piece after "and" starts like a new item — an article/quantifier (`a`, `an`, `some`, `another`) or a digit. Genuine multi-item posts still split: "sofa and a bed" (the original 9630/53 case), "3 chairs and a table".

Go's RE2 has **no lookahead**, so the check is applied per-piece via `newItemStartRe` (`^(a|an|some|another|\d)\b`) rather than baked into `andSplitRe` — verified it compiles and matches correctly under RE2.

## Residual (not fixed here)
Multi-item names phrased without an article ("bike and helmet") still won't split — but that was never handled (pre-#1046 gave them a single-object prompt too), so it's no regression. A fuller pass could validate against the production `name LIKE '% and %'` set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
