### PR TITLE
fix(reach-map): use CartoDB Voyager tiles so borough labels aren't clipped (9808/567)

### DIFF
--- a/iznik-nuxt3/modtools/composables/rippling/setupRipplingExplorer.js
+++ b/iznik-nuxt3/modtools/composables/rippling/setupRipplingExplorer.js
@@ -59,7 +59,7 @@ export async function setupRipplingExplorer({
 
   map = L.map('rippling-map', { zoomControl: true }).setView([52.5, -1.8], 7)
   L.tileLayer(
-    'https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png',
+    'https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png',
     {
       attribution: '© OpenStreetMap © CartoDB',
       subdomains: 'abcd',


### PR DESCRIPTION
Reported on Discourse (topic 9808/567, Neville_Reid): the **"Rippling reach"** map truncates place names — "CITY OF LONDON" showed as **"IDON"**, the rest only visible after panning.

## Not a Freegle DOM/CSS bug
The clipped text is **baked into the CartoDB `light_all` (Positron) raster tile PNG itself** — their server-side label placement clips the glyph run at a tile boundary. Fetching the raw tile directly (no Freegle code) reproduces the exact "IDON" fragment in the pixels. There is no Leaflet tooltip / HTML element to restyle, so this can only be fixed by changing the basemap.

## Fix
`setupRipplingExplorer.js` — swap the tile style `light_all` → `rastertiles/voyager` (CartoDB's actively-maintained style), which renders that borough label in full. This directly gives Neville the readable place name he wanted.

⚠️ **Palette change:** Voyager is a warmer, road-highlighted style vs Positron's flat grey — worth a glance in the deploy preview before merging. If you'd rather keep the grey, the alternative is `light_nolabels` (same palette, but drops all basemap place names — which loses the geographic context that prompted the report). Freegle's own group tooltips/reach overlays are DOM elements and unaffected either way.

Low priority (as Neville noted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
