### PR TITLE
fix(alert): fall back to text when the HTML body is only an empty-editor sentinel

### DIFF
--- a/iznik-server-go/alert/alert.go
+++ b/iznik-server-go/alert/alert.go
@@ -2,6 +2,7 @@ package alert
 
 import (
 	"encoding/json"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -9,6 +10,23 @@ import (
 	"github.com/freegle/iznik-server-go/user"
 	"github.com/gofiber/fiber/v2"
 )
+
+var htmlTagRE = regexp.MustCompile(`(?s)<[^>]*>`)
+
+// htmlIsBlank reports whether an HTML fragment carries no visible text. The ModTools alert
+// composer has a plain-text textarea AND a separate Quill editor, and only the textarea is
+// required. An untouched Quill editor does not serialise to "" — it emits an empty-document
+// sentinel like "<p><br></p>". A bare `html == ""` check therefore lets that through, and the
+// alert mails out with the boilerplate wrapper and no message in it (hit live 2026-07-13 on a
+// Freegle-wide alert to every mod). Strip tags and blank entities and see if anything is left,
+// so any editor's flavour of "empty" falls back to the text body.
+func htmlIsBlank(s string) bool {
+	t := htmlTagRE.ReplaceAllString(s, "")
+	t = strings.ReplaceAll(t, "&nbsp;", " ")
+	t = strings.ReplaceAll(t, "&#160;", " ")
+	t = strings.ReplaceAll(t, "\u00a0", " ")
+	return strings.TrimSpace(t) == ""
+}
 
 type Alert struct {
 	ID        uint64  `json:"id" gorm:"primary_key"`
@@ -200,7 +218,7 @@ func CreateAlert(c *fiber.Ctx) error {
 	if req.To == "" {
 		req.To = "Mods"
 	}
-	if req.Html == "" {
+	if htmlIsBlank(req.Html) {
 		req.Html = strings.ReplaceAll(req.Text, "\n", "<br>")
 	}
 

--- a/iznik-server-go/alert/alert_unit_test.go
+++ b/iznik-server-go/alert/alert_unit_test.go
@@ -1,0 +1,38 @@
+package alert
+
+import "testing"
+
+// The ModTools alert composer has a required plain-text textarea and an OPTIONAL Quill editor.
+// An untouched Quill editor serialises to an empty-document sentinel ("<p><br></p>"), not "", so
+// the old `req.Html == ""` guard let it through and createAlert stored a visually empty HTML body.
+// The alert then mailed out to every mod as just the boilerplate wrapper with no message in it
+// (live incident 2026-07-13, Freegle-wide alert 11194). htmlIsBlank is what decides whether to
+// fall back to the text body, so the empty-editor sentinels are pinned here.
+func TestHtmlIsBlank(t *testing.T) {
+	blank := []string{
+		"",                       // never filled in
+		"<p><br></p>",            // Quill's empty document — the one that caused the incident
+		"<p></p>",                // other editors' empty document
+		"<br>",                   // bare break
+		"   \n\t ",               // whitespace only
+		"<p>&nbsp;</p>",          // entity-only
+		"<p>\u00a0</p>",          // literal non-breaking space
+		"<div><p><br></p></div>", // nested empty
+	}
+	for _, s := range blank {
+		if !htmlIsBlank(s) {
+			t.Errorf("htmlIsBlank(%q) = false, want true (should fall back to the text body)", s)
+		}
+	}
+
+	notBlank := []string{
+		"<p>Can you help another Freegle group thrive?</p>",
+		"Hello fellow Freegle volunteer",
+		"<p><br></p><p>Real content after an empty para</p>",
+	}
+	for _, s := range notBlank {
+		if htmlIsBlank(s) {
+			t.Errorf("htmlIsBlank(%q) = true, want false (real content must not be discarded)", s)
+		}
+	}
+}


### PR DESCRIPTION
## Incident

Freegle-wide alert **11194** ("Can you help another Freegle group thrive?", from the Chair, to Mods, all groups) mailed out with **no message in it** — recipients got only the boilerplate wrapper:

> Dear …, This is being sent to all Freegle groups. You will only get one copy. … I got this … web beacons

**288 mod emails across 154 of 506 groups** went out empty before the send was stopped (row marked complete, so the cron skips it).

## Root cause

The ModTools alert composer (`ModSupportContactGroup.vue`) has a **required** plain-text `<b-form-textarea>` (`text`) and a **separate, optional** `QuillEditor` (`html`). The submit gate requires `text` but not `html`.

An untouched Quill editor does **not** serialise to `""` — it emits its empty-document sentinel, `<p><br></p>`. `createAlert` guarded its fallback with:

```go
if req.Html == "" {
    req.Html = strings.ReplaceAll(req.Text, "\n", "<br>")
}
```

`<p><br></p>` is not `""`, so the fallback never fired. The alert was stored with a visually empty HTML body (12 bytes) while the real message sat in the `text` column. The mailer renders the HTML → empty email.

**Not caused by `9d1f53ec7`** ("accept AllFreegle in createAlert"), which only changed `groupid` typing. But that change is what first let an *all-groups* alert through, so this latent bug hit every group at once instead of one.

## Fix

Replace the equality check with `htmlIsBlank()`, which strips tags and blank entities (`&nbsp;`, `&#160;`, U+00A0) and falls back to the text body if nothing visible remains. That catches **any** editor's flavour of "empty", not just Quill's exact string.

Unit test pins the sentinels (`<p><br></p>`, `<p></p>`, `<br>`, entity-only, nested empty) and pins that real content is never discarded — including `<p><br></p><p>Real content</p>`.

## Recovery (done separately, not in this PR)

- Alert 11194 stopped (`complete` set) — no further empty emails.
- A single-group test alert to EdinburghFreegle with corrected HTML is queued to verify the render before any decision on re-sending to the 352 groups that were never reached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)