### PR TITLE
fix(modtools): explain when a post is moved back to Pending

### DIFF
--- a/docs/moderators/02-moderating-posts.md
+++ b/docs/moderators/02-moderating-posts.md
@@ -1,5 +1,5 @@
 ---
-last_reviewed: 2026-07-09
+last_reviewed: 2026-07-13
 owner: Freegle dev team
 covers:
   - iznik-nuxt3/modtools/pages/messages/**
@@ -107,6 +107,11 @@ re-approving a copy does **not** re-notify members or re-ripple from scratch. Re
 rippled-in copy simply removes it from your community; the poster is not told, and other
 communities are unaffected. There is a full walk-through in
 [./rippling-out.md](./rippling-out.md).
+
+When a post reappears in your Pending queue this way - even one you had already approved -
+the pending post now shows the reason (for example *"A moderator moved this post back to
+pending for review."*), so you can see why it is back rather than assuming your Approve did
+not work.
 
 ## Next steps
 

--- a/iznik-nuxt3/modtools/components/ModMessage.vue
+++ b/iznik-nuxt3/modtools/components/ModMessage.vue
@@ -383,6 +383,24 @@
             >
               {{ message.spamreason }}
             </NoticeMessage>
+            <!-- When a post is back in Pending because a moderator moved it there (e.g. a
+                 "Back to Pending" on any community pulls every copy back for per-group
+                 review), the reason is stored on THIS group's copy (contextGroup.spamreason),
+                 not the message-level spamreason. Surface it so a mod who approved the post
+                 understands why it has reappeared and isn't left clicking Approve with no
+                 explanation. -->
+            <NoticeMessage
+              v-if="
+                contextGroup &&
+                contextGroup.collection === 'Pending' &&
+                contextGroup.spamreason &&
+                contextGroup.spamreason !== message.spamreason
+              "
+              variant="info"
+              class="mb-2"
+            >
+              {{ contextGroup.spamreason }}
+            </NoticeMessage>
             <NoticeMessage
               v-if="
                 pending &&

--- a/iznik-nuxt3/tests/unit/components/modtools/ModMessage.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModMessage.spec.js
@@ -416,6 +416,52 @@ describe('ModMessage', () => {
     })
   })
 
+  describe('Back to Pending explanation', () => {
+    // A "Back to Pending" on any community pulls every copy of a rippled post back to
+    // Pending for per-group review, and stores the reason on THAT group's copy
+    // (contextGroup.spamreason). Without surfacing it, a mod who already approved the post
+    // sees it reappear in Pending with no explanation and clicks Approve repeatedly
+    // (Discourse 9909). We show the per-group reason so they understand what happened.
+    it('surfaces the per-group reason when a copy is back in Pending', async () => {
+      const wrapper = mountComponent(
+        {},
+        {
+          groups: [
+            {
+              groupid: 789,
+              namedisplay: 'Test Group',
+              collection: 'Pending',
+              spamreason:
+                'A moderator moved this post back to pending for review.',
+            },
+          ],
+        }
+      )
+      await flushPromises()
+      expect(wrapper.vm.contextGroup.spamreason).toBe(
+        'A moderator moved this post back to pending for review.'
+      )
+      expect(wrapper.text()).toContain(
+        'A moderator moved this post back to pending for review.'
+      )
+    })
+
+    it('does not duplicate the message-level spamreason', async () => {
+      const wrapper = mountComponent(
+        {},
+        {
+          spamreason: 'Flagged as spam',
+          groups: [
+            { groupid: 789, collection: 'Pending', spamreason: 'Flagged as spam' },
+          ],
+        }
+      )
+      await flushPromises()
+      const count = wrapper.text().split('Flagged as spam').length - 1
+      expect(count).toBe(1)
+    })
+  })
+
   describe('Computed: alreadyOnHomeGroup', () => {
     // Regression: a post must not be told it "Possibly should be on" a group it is ALREADY
     // on (its origin, or a group it has rippled onto). The hint previously fired whenever the


### PR DESCRIPTION
## Problem

A **Back to Pending** (a moderator's action, or a two-member report quorum) pulls **every** copy of a rippled post back to Pending for per-group review, and stores the reason on that group's copy (`messages_groups.spamreason`, e.g. *"A moderator moved this post back to pending for review."*).

`ModMessage` only surfaced the **message-level** `spamreason`, not the per-group one. So a moderator who had already approved a post saw it reappear in their Pending queue with **no explanation**, assumed their Approve was broken, and clicked it repeatedly.

Reported on Discourse: [post-approved-by-me-then-held-by-another-now-back-in-pending](https://discourse.ilovefreegle.org/t/post-approved-by-me-then-held-by-another-now-back-in-pending/9909) (Gary), with others confirming the same confusion.

## Fix

Surface the **per-group** reason (`contextGroup.spamreason`) in the pending notice when the context copy is Pending and the reason differs from the message-level one. The moderator now sees *why* the post is back.

**Explanation-only** — no change to the approve / hold / Back-to-Pending / reach logic.

## Changes
- `ModMessage.vue` — add a `NoticeMessage` for `contextGroup.spamreason`.
- `ModMessage.spec.js` — assert it renders, and is not duplicated with `message.spamreason`.
- `docs/moderators/02-moderating-posts.md` — note the reason is now shown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Umaif747nFHpmDibKqbT7i