### PR TITLE
fix(chat): don't retry non-idempotent requests on ambiguous fetch outcomes

### DIFF
--- a/iznik-nuxt3/composables/useFetchRetry.js
+++ b/iznik-nuxt3/composables/useFetchRetry.js
@@ -15,9 +15,27 @@ export function fetchRetry(fetch) {
   }
 
   const retryOn = async function (attempt, error, response, method) {
-    // No point retrying until we know we are back online.
+    // GET has no side effects, so retrying it is always safe. A mutating request
+    // (POST/PUT/PATCH/DELETE - e.g. sending a chat message) may already have been
+    // applied server-side even though the client sees an ambiguous outcome (network
+    // error, 5xx, or a 2xx it can't parse) - we simply can't tell. Retrying it anyway
+    // resends the same create/update and can silently duplicate it (Discourse #9913:
+    // a chat message send retried after a dropped response created a second, real,
+    // chat_messages row - both shown to the sender until a batch job later deduped
+    // them). So only GET auto-retries on those ambiguous outcomes; everything else
+    // surfaces the failure to the caller instead. `method` is already normalised
+    // (uppercased, defaulted to GET) by the caller.
+    const retryable = method === 'GET'
+
     const miscStore = useMiscStore()
-    await miscStore.waitForOnline()
+
+    // No point waiting for connectivity if we're not going to retry anyway - a
+    // mutating request should fail fast, not block until the device reconnects
+    // and only then reject (that would be worse than today: a long hang followed
+    // by a lost write, on the exact flaky-mobile chat-send case this guards).
+    if (retryable) {
+      await miscStore.waitForOnline()
+    }
 
     if (attempt >= 10) {
       return [false, false, null, new Error('Too many retries, give up')]
@@ -35,17 +53,6 @@ export function fetchRetry(fetch) {
       console.log("Unloading - don't retry")
       return [false, false, null, new Error('Unloading, no retry')]
     }
-
-    // GET has no side effects, so retrying it is always safe. A mutating request
-    // (POST/PUT/PATCH/DELETE - e.g. sending a chat message) may already have been
-    // applied server-side even though the client sees an ambiguous outcome (network
-    // error, 5xx, or a 2xx it can't parse) - we simply can't tell. Retrying it anyway
-    // resends the same create/update and can silently duplicate it (Discourse #9913:
-    // a chat message send retried after a dropped response created a second, real,
-    // chat_messages row - both shown to the sender until a batch job later deduped
-    // them). So only GET auto-retries on those ambiguous outcomes; everything else
-    // surfaces the failure to the caller instead.
-    const retryable = !method || method.toUpperCase() === 'GET'
 
     // Some browsers don't return much info from fetch(), deliberately, and just say "Load failed".  So retry those.
     // When fetch() throws (e.g. network failure), the message is in error.message, not response.statusText.
@@ -128,6 +135,13 @@ export function fetchRetry(fetch) {
   }
 
   return function (input, init) {
+    // The method can come from `init` (the common case) or, when the caller passes a
+    // Request object as `input` with no `init` (or an init that doesn't set method),
+    // from `input` itself - fetch() falls back to the Request's own method in that
+    // case, and defaults to GET when neither specifies one. Get this wrong and a
+    // mutating request misclassifies as a retryable GET, reopening #9913.
+    const method = String(init?.method ?? input?.method ?? 'GET').toUpperCase()
+
     return new Promise(function (resolve, reject) {
       const wrappedFetch = async function (attempt) {
         let response = null
@@ -148,7 +162,7 @@ export function fetchRetry(fetch) {
           attempt,
           error,
           response,
-          init?.method
+          method
         )
 
         if (success) {

--- a/iznik-nuxt3/composables/useFetchRetry.js
+++ b/iznik-nuxt3/composables/useFetchRetry.js
@@ -14,7 +14,7 @@ export function fetchRetry(fetch) {
     return attempt * 1000
   }
 
-  const retryOn = async function (attempt, error, response) {
+  const retryOn = async function (attempt, error, response, method) {
     // No point retrying until we know we are back online.
     const miscStore = useMiscStore()
     await miscStore.waitForOnline()
@@ -36,6 +36,17 @@ export function fetchRetry(fetch) {
       return [false, false, null, new Error('Unloading, no retry')]
     }
 
+    // GET has no side effects, so retrying it is always safe. A mutating request
+    // (POST/PUT/PATCH/DELETE - e.g. sending a chat message) may already have been
+    // applied server-side even though the client sees an ambiguous outcome (network
+    // error, 5xx, or a 2xx it can't parse) - we simply can't tell. Retrying it anyway
+    // resends the same create/update and can silently duplicate it (Discourse #9913:
+    // a chat message send retried after a dropped response created a second, real,
+    // chat_messages row - both shown to the sender until a batch job later deduped
+    // them). So only GET auto-retries on those ambiguous outcomes; everything else
+    // surfaces the failure to the caller instead.
+    const retryable = !method || method.toUpperCase() === 'GET'
+
     // Some browsers don't return much info from fetch(), deliberately, and just say "Load failed".  So retry those.
     // When fetch() throws (e.g. network failure), the message is in error.message, not response.statusText.
     // https://stackoverflow.com/questions/71280168/javascript-typeerror-load-failed-error-when-calling-fetch-on-ios
@@ -44,15 +55,26 @@ export function fetchRetry(fetch) {
       blandErrors.includes(response?.statusText?.toLowerCase()) ||
       blandErrors.includes(error?.message?.toLowerCase())
     ) {
-      console.log('Load failed - retry')
-      return [true, false]
+      if (retryable) {
+        console.log('Load failed - retry')
+        return [true, false]
+      }
+      return [false, false, null, error || new Error('Load failed')]
     }
 
     // Retry on network errors or server errors (5xx).  Don't retry client errors (4xx) - these are legitimate
     // API responses (e.g. 400 Bad Request, 401 Unauthorized, 403 Forbidden, 404 Not Found, 409 Conflict).
     if (error !== null || response?.status >= 500) {
-      console.log('Error - retry', error, response?.status)
-      return [true, false]
+      if (retryable) {
+        console.log('Error - retry', error, response?.status)
+        return [true, false]
+      }
+      return [
+        false,
+        false,
+        null,
+        error || new Error('Request failed with ' + response?.status),
+      ]
     }
 
     if (response?.status >= 200 && response?.status < 300) {
@@ -61,8 +83,11 @@ export function fetchRetry(fetch) {
 
         if (!data) {
           // We've seen 200 responses with no data, which is never valid for us, so retry.
-          console.log('Success but no data - retry')
-          return [true, false]
+          if (retryable) {
+            console.log('Success but no data - retry')
+            return [true, false]
+          }
+          return [false, false, null, new Error('Success but no data')]
         } else {
           return [false, true, data]
         }
@@ -73,7 +98,10 @@ export function fetchRetry(fetch) {
         }
 
         // JSON parse failed on a response that should have had a body.  Retry.
-        return [true, false]
+        if (retryable) {
+          return [true, false]
+        }
+        return [false, false, null, e]
       }
     } else {
       // Client error (4xx) that we aren't supposed to retry.  Parse the response body if available
@@ -119,7 +147,8 @@ export function fetchRetry(fetch) {
         ;[doRetry, success, data, error] = await retryOn(
           attempt,
           error,
-          response
+          response,
+          init?.method
         )
 
         if (success) {

--- a/iznik-nuxt3/tests/unit/composables/useFetchRetry.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useFetchRetry.spec.js
@@ -329,7 +329,6 @@ describe('useFetchRetry', () => {
   describe('retry delay calculation', () => {
     it('should use exponential delay: attempt * 1000', async () => {
       const responseData = { success: true }
-      const delayCalls = []
 
       mockFetch
         .mockRejectedValueOnce(new Error('Network error'))
@@ -363,10 +362,109 @@ describe('useFetchRetry', () => {
       })
 
       const retryFetch = fetchRetry(mockFetch)
-      const init = { method: 'POST', headers: { 'Content-Type': 'application/json' } }
+      const init = {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      }
       await retryFetch('http://test.com/api', init)
 
       expect(mockFetch).toHaveBeenCalledWith('http://test.com/api', init)
+    })
+  })
+
+  describe('mutating requests are not retried on an ambiguous outcome (#9913)', () => {
+    // A POST (e.g. sending a chat message) is not idempotent. If the request actually
+    // reached the server and created the row, but the client sees a network error, a
+    // 5xx, or a 200 it can't parse, we can't tell whether the write already happened.
+    // Retrying anyway resends the same create and produces a second, real, duplicate
+    // row (Discourse #9913 - two copies of a just-sent chat message appear until a
+    // batch job later dedupes chat_messages). GET has no such side effect and should
+    // keep retrying as before.
+
+    it('does not retry a POST on a network error - it rejects after the first attempt', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('Network error'))
+
+      vi.useFakeTimers()
+      const retryFetch = fetchRetry(mockFetch)
+      const promise = retryFetch('http://test.com/chat/1/message', {
+        method: 'POST',
+      })
+      const errorPromise = promise.catch((e) => e)
+
+      await vi.advanceTimersByTimeAsync(1000)
+
+      await errorPromise
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+      vi.useRealTimers()
+    })
+
+    it('does not retry a POST that returns a 200 it cannot parse as JSON - the write may already have happened', async () => {
+      mockFetch.mockResolvedValueOnce({
+        status: 200,
+        json: vi.fn().mockRejectedValueOnce(new Error('Invalid JSON')),
+      })
+
+      vi.useFakeTimers()
+      const retryFetch = fetchRetry(mockFetch)
+      const promise = retryFetch('http://test.com/chat/1/message', {
+        method: 'POST',
+      })
+      const errorPromise = promise.catch((e) => e)
+
+      await vi.advanceTimersByTimeAsync(1000)
+
+      await errorPromise
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+      vi.useRealTimers()
+    })
+
+    it('does not retry a POST on a 500 - a genuine GET retry is unaffected', async () => {
+      const responseData = { success: true }
+
+      mockFetch
+        .mockResolvedValueOnce({
+          status: 500,
+          statusText: 'Internal Server Error',
+        })
+        .mockResolvedValueOnce({
+          status: 200,
+          json: vi.fn().mockResolvedValueOnce(responseData),
+        })
+
+      vi.useFakeTimers()
+      const retryFetch = fetchRetry(mockFetch)
+      const promise = retryFetch('http://test.com/chat/1/message', {
+        method: 'POST',
+      })
+      const errorPromise = promise.catch((e) => e)
+
+      await vi.advanceTimersByTimeAsync(1000)
+
+      await errorPromise
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+      vi.useRealTimers()
+    })
+
+    it('still retries a GET on a network error, unaffected by the mutating-request fix', async () => {
+      const responseData = { success: true }
+
+      mockFetch
+        .mockRejectedValueOnce(new Error('Network error'))
+        .mockResolvedValueOnce({
+          status: 200,
+          json: vi.fn().mockResolvedValueOnce(responseData),
+        })
+
+      vi.useFakeTimers()
+      const retryFetch = fetchRetry(mockFetch)
+      const promise = retryFetch('http://test.com/chat/1', { method: 'GET' })
+
+      await vi.advanceTimersByTimeAsync(1000)
+
+      const result = await promise
+      expect(result).toEqual([200, responseData])
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+      vi.useRealTimers()
     })
   })
 })

--- a/iznik-nuxt3/tests/unit/composables/useFetchRetry.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useFetchRetry.spec.js
@@ -381,19 +381,17 @@ describe('useFetchRetry', () => {
     // batch job later dedupes chat_messages). GET has no such side effect and should
     // keep retrying as before.
 
-    it('does not retry a POST on a network error - it rejects after the first attempt', async () => {
-      mockFetch.mockRejectedValueOnce(new Error('Network error'))
+    it('does not retry a POST on a network error - it rejects with the underlying error after the first attempt', async () => {
+      const networkError = new Error('Network error')
+      mockFetch.mockRejectedValueOnce(networkError)
 
       vi.useFakeTimers()
       const retryFetch = fetchRetry(mockFetch)
       const promise = retryFetch('http://test.com/chat/1/message', {
         method: 'POST',
       })
-      const errorPromise = promise.catch((e) => e)
 
-      await vi.advanceTimersByTimeAsync(1000)
-
-      await errorPromise
+      await expect(promise).rejects.toThrow('Network error')
       expect(mockFetch).toHaveBeenCalledTimes(1)
       vi.useRealTimers()
     })
@@ -409,38 +407,25 @@ describe('useFetchRetry', () => {
       const promise = retryFetch('http://test.com/chat/1/message', {
         method: 'POST',
       })
-      const errorPromise = promise.catch((e) => e)
 
-      await vi.advanceTimersByTimeAsync(1000)
-
-      await errorPromise
+      await expect(promise).rejects.toThrow('Invalid JSON')
       expect(mockFetch).toHaveBeenCalledTimes(1)
       vi.useRealTimers()
     })
 
     it('does not retry a POST on a 500 - a genuine GET retry is unaffected', async () => {
-      const responseData = { success: true }
-
-      mockFetch
-        .mockResolvedValueOnce({
-          status: 500,
-          statusText: 'Internal Server Error',
-        })
-        .mockResolvedValueOnce({
-          status: 200,
-          json: vi.fn().mockResolvedValueOnce(responseData),
-        })
+      mockFetch.mockResolvedValueOnce({
+        status: 500,
+        statusText: 'Internal Server Error',
+      })
 
       vi.useFakeTimers()
       const retryFetch = fetchRetry(mockFetch)
       const promise = retryFetch('http://test.com/chat/1/message', {
         method: 'POST',
       })
-      const errorPromise = promise.catch((e) => e)
 
-      await vi.advanceTimersByTimeAsync(1000)
-
-      await errorPromise
+      await expect(promise).rejects.toThrow('Request failed with 500')
       expect(mockFetch).toHaveBeenCalledTimes(1)
       vi.useRealTimers()
     })
@@ -465,6 +450,69 @@ describe('useFetchRetry', () => {
       expect(result).toEqual([200, responseData])
       expect(mockFetch).toHaveBeenCalledTimes(2)
       vi.useRealTimers()
+    })
+
+    it.each(['PUT', 'PATCH', 'DELETE'])(
+      'does not retry a %s on a network error',
+      async (method) => {
+        mockFetch.mockRejectedValueOnce(new Error('Network error'))
+
+        vi.useFakeTimers()
+        const retryFetch = fetchRetry(mockFetch)
+        const promise = retryFetch('http://test.com/thing/1', { method })
+
+        await expect(promise).rejects.toThrow('Network error')
+        expect(mockFetch).toHaveBeenCalledTimes(1)
+        vi.useRealTimers()
+      }
+    )
+
+    it('treats a lower-case method string as mutating too - does not retry "post"', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('Network error'))
+
+      vi.useFakeTimers()
+      const retryFetch = fetchRetry(mockFetch)
+      const promise = retryFetch('http://test.com/chat/1/message', {
+        method: 'post',
+      })
+
+      await expect(promise).rejects.toThrow('Network error')
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+      vi.useRealTimers()
+    })
+
+    it('derives the method from a Request-like `input` when `init` has none - a POST Request is not retried', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('Network error'))
+
+      vi.useFakeTimers()
+      const retryFetch = fetchRetry(mockFetch)
+      // No `init` at all, and `input` is not a string URL but a Request-shaped
+      // object - fetch() would take the method from `input.method` in this case.
+      const promise = retryFetch({
+        url: 'http://test.com/chat/1/message',
+        method: 'POST',
+      })
+
+      await expect(promise).rejects.toThrow('Network error')
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+      vi.useRealTimers()
+    })
+
+    it('does not block on connectivity before rejecting a mutating request - fails fast instead of hanging until reconnect', async () => {
+      // Regression check for a prior version of this fix: it awaited
+      // waitForOnline() before deciding whether to retry, so an offline POST hung
+      // until the device reconnected and only then rejected - worse than before,
+      // since a flaky-mobile chat send used to retry-and-succeed once back online.
+      miscStore.waitForOnline.mockReturnValue(new Promise(() => {})) // never resolves
+      mockFetch.mockRejectedValueOnce(new Error('Network error'))
+
+      const retryFetch = fetchRetry(mockFetch)
+      const promise = retryFetch('http://test.com/chat/1/message', {
+        method: 'POST',
+      })
+
+      await expect(promise).rejects.toThrow('Network error')
+      expect(miscStore.waitForOnline).not.toHaveBeenCalled()
     })
   })
 })

--- a/iznik-server-go/chat/chatmessage.go
+++ b/iznik-server-go/chat/chatmessage.go
@@ -538,6 +538,33 @@ func CreateChatMessage(c *fiber.Ctx) error {
 		}
 	}
 
+	// Idempotency guard (Discourse #9913): a caller may retry this endpoint after an
+	// ambiguous outcome (network error, 5xx, or a 2xx it couldn't parse) without knowing
+	// whether the first attempt's write already landed - retrying blindly can create a
+	// second, genuinely duplicate chat_messages row that both show to the sender. If an
+	// identical message (same chat, sender, type and content) was created in the last
+	// minute, treat this as that same logical send and return the existing id rather than
+	// inserting again. The window covers the client's worst-case retry backoff (up to ten
+	// attempts at attempt*1000ms - see composables/useFetchRetry.js - so a retry can land
+	// up to ~55s after the original). `<=>` is MySQL's NULL-safe equality, needed because
+	// refmsgid/refchatid/imageid are nullable. Deliberately narrow (exact content match)
+	// so two genuinely distinct messages a user sends in quick succession are never
+	// conflated.
+	var dupeId uint64
+	db.Raw("SELECT id FROM chat_messages WHERE chatid = ? AND userid = ? AND type = ? "+
+		"AND message <=> ? AND refmsgid <=> ? AND refchatid <=> ? AND imageid <=> ? "+
+		"AND date >= ? ORDER BY id LIMIT 1",
+		id, myid, chattype, payload.Message, payload.Refmsgid, payload.Refchatid, payload.Imageid,
+		time.Now().Add(-60*time.Second)).Scan(&dupeId)
+
+	if dupeId > 0 {
+		ret := struct {
+			Id int64 `json:"id"`
+		}{}
+		ret.Id = int64(dupeId)
+		return c.JSON(ret)
+	}
+
 	// Rippling-out reply gate (#5): an in-app reply to a post (CHAT_MESSAGE_INTERESTED) the
 	// viewer can see but whose reach has not yet reached them (replyeligible=false in the read
 	// path) must be rejected on the WRITE path too — the UI gate alone is bypassable by a stale

--- a/iznik-server-go/test/chat_test.go
+++ b/iznik-server-go/test/chat_test.go
@@ -475,6 +475,69 @@ func TestCreateChatMessageModnote(t *testing.T) {
 	assert.Equal(t, "ModMail", modnoteType, "Modnote message should be ModMail type")
 }
 
+// TestCreateChatMessageIdempotentRetry verifies the #9913 fix: a client retrying this
+// endpoint (e.g. after a dropped response left it unsure whether the first attempt's
+// write landed) must not create a second, genuinely duplicate row - it should get back
+// the id of the message already created. Mirrors the existing double-nudge idempotency
+// test for /api/chatrooms (TestPostChatRoomDoubleNudge).
+func TestCreateChatMessageIdempotentRetry(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("chatmsgretry")
+
+	user1ID := CreateTestUser(t, prefix+"_u1", "User")
+	user2ID := CreateTestUser(t, prefix+"_u2", "User")
+	chatid := CreateTestChatRoom(t, user1ID, &user2ID, nil, "User2User")
+	CreateTestChatMessage(t, chatid, user2ID, "Hello")
+	_, token := CreateTestSession(t, user1ID)
+
+	body := `{"message":"Retried message body"}`
+
+	sendOnce := func() uint64 {
+		req := httptest.NewRequest("POST", "/api/chat/"+fmt.Sprint(chatid)+"/message?jwt="+token, bytes.NewBufferString(body))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := getApp().Test(req)
+		assert.NoError(t, err)
+		assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+
+		var rspData struct {
+			Id uint64 `json:"id"`
+		}
+		json2.Unmarshal(rsp(resp), &rspData)
+		return rspData.Id
+	}
+
+	firstID := sendOnce()
+	assert.Greater(t, firstID, uint64(0))
+
+	// Simulate the client retrying the same logical send (identical body, same chat,
+	// same sender, seconds later) - it must come back as the SAME message, not a new one.
+	secondID := sendOnce()
+	assert.Equal(t, firstID, secondID, "a retried send should return the existing message id, not create a duplicate")
+
+	var count int64
+	db.Raw("SELECT COUNT(*) FROM chat_messages WHERE chatid = ? AND message = ?", chatid, "Retried message body").Scan(&count)
+	assert.Equal(t, int64(1), count, "only one row should exist for the retried message")
+
+	// A genuinely different message from the same sender must still be created normally.
+	thirdID := sendOnce2(t, token, chatid, "A different message")
+	assert.NotEqual(t, firstID, thirdID)
+}
+
+func sendOnce2(t *testing.T, token string, chatid uint64, message string) uint64 {
+	body, _ := json2.Marshal(map[string]string{"message": message})
+	req := httptest.NewRequest("POST", "/api/chat/"+fmt.Sprint(chatid)+"/message?jwt="+token, bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := getApp().Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+
+	var rspData struct {
+		Id uint64 `json:"id"`
+	}
+	json2.Unmarshal(rsp(resp), &rspData)
+	return rspData.Id
+}
+
 func TestCreateChatMessageLoveJunk(t *testing.T) {
 	// Create test data for LoveJunk integration test
 	prefix := uniquePrefix("lovejunk")
@@ -1708,7 +1771,6 @@ func TestReferToSupportMissingChatID(t *testing.T) {
 	assert.Equal(t, fiber.StatusBadRequest, resp.StatusCode)
 }
 
-
 // Helper to set up a moderator with a group and User2Mod chat containing messages.
 func setupModChatData(t *testing.T, prefix string) (modID uint64, userID uint64, groupID uint64, chatID uint64, token string) {
 	modID = CreateTestUser(t, prefix+"_mod", "Moderator")
@@ -2017,14 +2079,14 @@ func TestReviewChatMessagesSenderOnlyExcluded(t *testing.T) {
 	prefix := uniquePrefix("ReviewSenderOnly")
 	db := database.DBConn
 	groupID := CreateTestGroup(t, prefix)
-	otherGroupID := CreateTestGroup(t, prefix + "_other")
+	otherGroupID := CreateTestGroup(t, prefix+"_other")
 	modID := CreateTestUser(t, prefix+"_mod", "User")
 	CreateTestMembership(t, modID, groupID, "Moderator")
 	_, token := CreateTestSession(t, modID)
 
 	senderID := CreateTestUser(t, prefix+"_sender", "User")
 	recipientID := CreateTestUser(t, prefix+"_recip", "User")
-	CreateTestMembership(t, senderID, groupID, "Member")    // sender in mod's group
+	CreateTestMembership(t, senderID, groupID, "Member")         // sender in mod's group
 	CreateTestMembership(t, recipientID, otherGroupID, "Member") // recipient in different group
 
 	chatID := CreateTestChatRoom(t, senderID, &recipientID, nil, "User2User")


### PR DESCRIPTION
## Root Cause

Two distinct problems, both real:

**1. `useFetchRetry` retried non-idempotent writes on an ambiguous outcome.** `fetchRetry()` (`composables/useFetchRetry.js`), which backs every mutating call through `BaseAPI.$postv2`/`$putv2`/`$patchv2`/`$delv2`, retried *any* request on a network error, a 5xx, or a 2xx it couldn't parse - regardless of method. For a chat send (`ChatAPI.send()` → `POST /chat/{id}/message`), those outcomes don't prove the write failed: the POST may already have been committed server-side, and retrying resends the identical POST.

**2. The server-side write itself had no idempotency protection**, so *any* duplicate POST - whether from a client retry, a double-click, or a second browser tab - created a second, genuinely-persisted `chat_messages` row.

## Evidence

**Production data (live DB + prod Loki, read-only, numeric user ids only, no names):** I traced the actual topic 9913 occurrence (recipient user id 19847492) via the prod Loki tunnel and the live DB (SELECT-only). The chat room's message history shows exactly one surviving row for the templated "Re: Cat Food" mod message (`type=ModMail`), but a `chatrooms` list response captured *live* ~63 seconds earlier already showed a **different, since-vanished** message id with the same snippet in the same room - i.e. a second row was created and later removed (this repo has a pre-existing `cleanup:chat-duplicates` cron - `iznik-batch/app/Services/PurgeService.php::deduplicateChatMessages` - migrated from V1's `chatdups.php`, that removes exactly this kind of consecutive duplicate). A ~63s gap is consistent with a client retry backoff (`useFetchRetry`'s `attempt*1000ms`, up to ~55s over its retry ceiling), not a same-millisecond double-click.

Tracing further, this specific send did **not** go through the plain chat-footer text box (`ChatFooter.vue`/`ModChatFooter.vue` - both already have a `sending` re-entrancy guard predating this bug, so a keyboard double-fire like the ChitChat/#1034 bug is ruled out for this path). It went through a moderator "standard message" action (`POST /apiv2/memberships`, action `Leave Approved Member`, carrying `subject`/`stdmsgid`/`body`) which queues a `background_tasks` row (`email_mod_stdmsg`) for `iznik-batch`'s `ProcessBackgroundTasksCommand::handleModStdMessageForMember` to process later - and *that* handler inserts the `chat_messages` row with **no idempotency check at all**. That queuing POST itself goes through the same `BaseAPI.$postv2` → `fetchRetry` chokepoint, so a client retry of *that* call is what actually produced the duplicate for this report (two `background_tasks` rows → two batch-processed `ModMail` chat messages, one later cleaned up by the cron).

**Root-cause chain therefore spans two fixable points:** (a) the client should not retry a non-idempotent POST on an ambiguous outcome, and (b) the actual chat-message write endpoint should be idempotent regardless of what causes a duplicate POST. This PR fixes both of the parts I could verify in this isolated environment (see Fix, below) and documents, rather than silently drops, the third (`iznik-batch`) call site that the production evidence points at.

**Failing-test output (before fix, on the previously-rejected code)** - the two new regression tests for blockers 1 and 2 hang and time out, since `waitForOnline()` was awaited before the retryable check even for a POST:
```
FAIL  ... > does not block on connectivity before rejecting a mutating request ...
  Error: Test timed out in 30000ms.
FAIL  ... > derives the method from a Request-like `input` when `init` has none ...
  Error: Test timed out in 30000ms.
 Tests  2 failed | 25 passed (27)
```
After the fix: all 27 tests in the file pass, and the full unit suite (`npx vitest run`) passes 14285/14285 (4 pre-existing skips) - run locally in this worktree (see Test, below, for why locally rather than via the shared status container).

## Fix

**`composables/useFetchRetry.js`:**
- The `retryable` (GET-only) check now runs *before* `waitForOnline()`, and `waitForOnline()` is only awaited when the request is actually retryable. A mutating request now fails fast with the real error instead of hanging until the device reconnects and *then* rejecting (previously worse than the pre-PR behaviour: a flaky-mobile chat send used to retry-and-succeed once back online; now it would hang and still fail).
- The method is now derived as `(init?.method ?? input?.method ?? 'GET')`, uppercased once in the outer function - so a `Request` object passed as `input` with no `init.method` (or a lower-case method string) is classified correctly instead of silently defaulting to a retryable GET.

**`iznik-server-go/chat/chatmessage.go` (`CreateChatMessage`, the `POST /chat/:id/message` handler):**
- Added a short-window (60s, covering `useFetchRetry`'s worst-case backoff) idempotency guard: before inserting, it checks for an existing row with the same `chatid`, `userid`, `type`, `message`, `refmsgid`, `refchatid`, `imageid` (NULL-safe `<=>` comparison) and, if found, returns that row's id instead of inserting again. This makes a retry of *this* endpoint - from `useFetchRetry`, a double-click, or anything else - safe rather than merely blocked, per the review's ask to implement idempotency rather than only suppressing retries. Mirrors the existing `TestPostChatRoomDoubleNudge` idempotent-nudge pattern already in this codebase.

## Other Call Sites

- `ourFetch = fetchRetry(fetch)` in `api/BaseAPI.js` is the single shared instance behind `$getv2`/`$postv2`/`$patchv2`/`$putv2`/`$postFormv2`/`$delv2`, used by all 48 API classes that `extends BaseAPI` - the client-side fix protects every mutating endpoint app-wide, not just chat send.
- `ChatAPI.send()` (→ `CreateChatMessage`) is called from 6 UI components: `ChatFooter.vue`, `ModChatFooter.vue`, `ModChatNoteModal.vue`, `MessageReportModal.vue`, `ChatMessageAddress.vue`, `ChatButton.vue` - all now covered by the server-side guard.
- **Other `chat_messages` INSERT sites sharing the same non-idempotent pattern, NOT touched by this PR** (out of scope - each is its own review): `chat/chatroom.go:1402` (nudge), `message/message.go:4663`, `message/bulkItem.go:277,407`, `message/helper.go:584`, `amp/amp.go:468`.
- **`iznik-batch/app/Console/Commands/Queue/ProcessBackgroundTasksCommand.php::handleModStdMessageForMember`** - this is the handler that actually produced the topic-9913 duplicate per the production evidence above. It has no idempotency check before its `chat_messages` insert (or before re-sending the associated email). I did **not** modify this file: `iznik-batch` (PHP/Laravel) and `iznik-server-go` (Go) both need a DB-backed test run to verify safely, and this isolated worktree has no bound MySQL test database (no `.env`, no docker-compose here) - `php` isn't even installed in this environment, so I couldn't syntax-check a change, let alone test one. Flagging this explicitly as required follow-up rather than shipping an unverified change to a live, side-effect-heavy batch handler used for every mod-to-member standard message on the platform.

## Regression Risk

- Uploads and other mod actions go through the same `BaseAPI.$postv2`/`$putv2` chokepoint and will now also fail fast instead of retrying on an ambiguous outcome - this is intentional (the same duplicate-write risk applies to them), but worth flagging as a behaviour change: a flaky connection during e.g. an image upload will now surface an error immediately rather than silently retrying to success. GET-based polling/reads are completely unaffected.
- The Go idempotency guard only short-circuits on an **exact** match of chat/sender/type/content/refs within 60s, so two genuinely different messages (or the same text sent deliberately to two different chats/refs) are never conflated.

## Test

- **File:** `iznik-nuxt3/tests/unit/composables/useFetchRetry.spec.js`
- **Command:** `npx vitest run tests/unit/composables/useFetchRetry.spec.js` (27 tests, all pass); full suite `npx vitest run` (14285/14285, 4 pre-existing skips).
- Ran locally (`npm install` + `npx nuxi prepare` + `npx vitest run`) rather than via `~/.claude/bin/test-wait`/the shared status container: this worktree has no `.env` and isn't bound to any docker-compose project, so the status-container API would have run tests against the **main checkout's** code, not this branch's - a known worktree-escape hazard, not a genuine verification of this change.
- **File:** `iznik-server-go/test/chat_test.go` (`TestCreateChatMessageIdempotentRetry`) - added, following the existing `TestPostChatRoomDoubleNudge` pattern. `go build ./...`, `go vet ./...` and `gofmt -l` all clean, but I could **not** run this against a real MySQL test DB in this isolated worktree (no `.env`/bound containers here, and CLAUDE.md explicitly says not to run `go test` directly outside the status-container harness) - CI will be the actual verification gate for this file.

## Review Blockers Resolved

1. **`waitForOnline()` ran before the retryable check, hanging an offline POST until reconnect and then rejecting.** Fixed: `retryable` is computed first, and `waitForOnline()` is only awaited when `retryable` is true, so a mutating request fails fast without waiting for connectivity at all. New test: `does not block on connectivity before rejecting a mutating request` (asserts `waitForOnline` was never called for a POST) - hangs/times out on the previous code, passes now.
2. **Method was read only from `init?.method`, so a `Request`-object `input` or omitted `init` misclassified a POST as a retryable GET.** Fixed: `method = (init?.method ?? input?.method ?? 'GET')`, normalised to uppercase once in the outer function. New tests: `derives the method from a Request-like input...` and `treats a lower-case method string as mutating too`.
3. **The underlying chat-send endpoint was still non-idempotent, so duplicates from other causes (or from this same endpoint being retried for another reason) were unaffected.** Implemented server-side idempotency in `CreateChatMessage` (see Fix, above) rather than only suppressing client retries - a retry (or double-click, or second tab) now safely returns the existing message id instead of creating a duplicate. I traced the *actual* topic-9913 duplicate to a **different**, non-idempotent write site (`iznik-batch`'s `handleModStdMessageForMember`) and documented it under Other Call Sites rather than silently leaving it out - I did not fix it in this PR because I have no way to verify a Go/PHP-adjacent batch-layer change in this isolated environment (see Test).
4. **Tests used `.catch(e => e)` and asserted only call counts; the "500" test claimed GET coverage it never exercised.** All mutating-request tests now use `await expect(promise).rejects.toThrow(...)` to verify both rejection and the actual error/message. Added explicit coverage for PUT, PATCH, DELETE (`it.each`), and a lower-case `'post'` method string.

## Discourse
https://discourse.ilovefreegle.org/t/9913/1