### PR TITLE
fix(modtools): standard-message reject on a rippled-in group no longer silently swallows the send

### DIFF
--- a/iznik-nuxt3/modtools/components/ModMessageButton.vue
+++ b/iznik-nuxt3/modtools/components/ModMessageButton.vue
@@ -59,8 +59,8 @@
           community where it was first posted.
         </p>
         <p class="mb-0">
-          The freegler won't be told, because they don't need to know unless it's
-          rejected on their home community. So there's no message to send.
+          The freegler won't be told, because they don't need to know unless
+          it's rejected on their home community. So there's no message to send.
         </p>
       </template>
     </ConfirmModal>
@@ -347,7 +347,20 @@ async function click(callback) {
       stdmsgAction.value = 'Leave'
     } else if (props.stdmsgid) {
       // We have a standard message.  Fetch it into the store.
-      await stdmsgStore.fetch(props.stdmsgid)
+      const fetched = await stdmsgStore.fetch(props.stdmsgid)
+
+      if (fetched?.action === 'Reject' && !props.isHomeGroup) {
+        // A Reject-type standard message on a rippled-in (non-home) copy hits the
+        // same silent-to-the-poster path as the plain Reject button server-side -
+        // the Go API drops the notification for a secondary group (handleReject),
+        // so composing and "sending" one here looks successful but leaves no
+        // record anywhere (Discourse 9862/13). Show the same no-message
+        // confirmation as the plain Reject button instead of the compose modal.
+        showRejectNoMsgModal.value = true
+        if (callback) callback()
+        return
+      }
+
       stdmsgId.value = props.stdmsgid
     }
 

--- a/iznik-nuxt3/modtools/components/ModMessageButtons.vue
+++ b/iznik-nuxt3/modtools/components/ModMessageButtons.vue
@@ -150,6 +150,7 @@
         :stdmsgid="stdmsg.id"
         :messageid="message.id"
         :groupid="groupid"
+        :is-home-group="isHomeGroup"
         :autosend="Boolean(stdmsg.autosend && allowAutoSend)"
       />
       <b-button

--- a/iznik-nuxt3/tests/unit/components/modtools/ModMessageButton.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModMessageButton.spec.js
@@ -254,7 +254,10 @@ describe('ModMessageButton', () => {
     it('calls messageStore.hold when hold prop is true', async () => {
       const wrapper = mountComponent({ hold: true }, { id: 555 })
       await wrapper.vm.click()
-      expect(mockMessageStore.hold).toHaveBeenCalledWith({ id: 555, groupid: 456 })
+      expect(mockMessageStore.hold).toHaveBeenCalledWith({
+        id: 555,
+        groupid: 456,
+      })
     })
 
     it('calls checkWorkDeferGetMessages after hold', async () => {
@@ -268,7 +271,10 @@ describe('ModMessageButton', () => {
     it('calls messageStore.release when release prop is true', async () => {
       const wrapper = mountComponent({ release: true }, { id: 666 })
       await wrapper.vm.click()
-      expect(mockMessageStore.release).toHaveBeenCalledWith({ id: 666, groupid: 456 })
+      expect(mockMessageStore.release).toHaveBeenCalledWith({
+        id: 666,
+        groupid: 456,
+      })
     })
 
     it('calls checkWorkDeferGetMessages after release', async () => {
@@ -380,6 +386,44 @@ describe('ModMessageButton', () => {
       await wrapper.vm.click()
       await flushPromises()
       expect(wrapper.vm.showStdMsgModal).toBe(true)
+    })
+  })
+
+  describe('reject via standard message on a rippled-in (non-home) group (Discourse 9862/13)', () => {
+    it('shows the no-message confirm instead of the compose modal when the standard message action is Reject', async () => {
+      const wrapper = mountComponent({ stdmsgid: 42, isHomeGroup: false })
+      await wrapper.vm.click()
+      await flushPromises()
+
+      expect(wrapper.vm.showRejectNoMsgModal).toBe(true)
+      expect(wrapper.vm.showStdMsgModal).toBe(false)
+      expect(wrapper.vm.stdmsgId).toBeNull()
+    })
+
+    it('still opens the compose modal for a Reject standard message on the home group', async () => {
+      const wrapper = mountComponent({ stdmsgid: 42, isHomeGroup: true })
+      await wrapper.vm.click()
+      await flushPromises()
+
+      expect(wrapper.vm.showRejectNoMsgModal).toBe(false)
+      expect(wrapper.vm.showStdMsgModal).toBe(true)
+      expect(wrapper.vm.stdmsgId).toBe(42)
+    })
+
+    it('still opens the compose modal for a non-Reject standard message on a non-home group', async () => {
+      mockStdmsgStore.fetch.mockResolvedValueOnce({
+        id: 42,
+        title: 'Blank Reply',
+        body: 'Test body',
+        action: 'Leave',
+      })
+      const wrapper = mountComponent({ stdmsgid: 42, isHomeGroup: false })
+      await wrapper.vm.click()
+      await flushPromises()
+
+      expect(wrapper.vm.showRejectNoMsgModal).toBe(false)
+      expect(wrapper.vm.showStdMsgModal).toBe(true)
+      expect(wrapper.vm.stdmsgId).toBe(42)
     })
   })
 


### PR DESCRIPTION
## Root Cause
`ModMessageButtons.vue` renders the per-standard-message buttons (the `v-for="stdmsg in filtered"` loop) without passing `:is-home-group`, so `ModMessageButton.vue`'s `isHomeGroup` prop defaults to `true` even when the copy being moderated is a rippled-in (secondary) group. Clicking a Reject-type standard message (e.g. a canned "duplicate post" message) there skips the "no message to send" branch that the plain Reject button correctly takes for a non-home group, and instead composes and appears to send a real message via `ModStdMessageModal`.

That request reaches the Go API's `handleReject`, which (by design, `d342d4557` "secondary-group rejection is silent to the poster") drops the `background_tasks` row entirely for a non-origin group so the poster isn't emailed - but that background task is also the *only* thing that creates the `logs` row and the User2Mod chat message mods see in ModTools. So the mod composes and "sends" a message that vanishes without a trace, while the plain Reject button on the same non-home group instead shows an explicit "there's no message to send" dialog and never attempts to send anything - consistent, honest UI, but currently only on one of the two paths.

## Evidence
Failing test (AssertFlip) against the pre-fix code:
```
❯ tests/unit/components/modtools/ModMessageButton.spec.js > ModMessageButton > reject via standard message on a rippled-in (non-home) group (Discourse 9862/13) > shows the no-message confirm instead of the compose modal when the standard message action is Reject
AssertionError: expected false to be true // Object.is equality
- Expected: true
+ Received: false
 ❯ tests/unit/components/modtools/ModMessageButton.spec.js:392:47
    expect(wrapper.vm.showRejectNoMsgModal).toBe(true)
```

## Fix
- `ModMessageButtons.vue`: pass `:is-home-group="isHomeGroup"` to the per-standard-message `ModMessageButton` loop, matching what's already passed to the plain Reject/Delete/Spam buttons.
- `ModMessageButton.vue`: after fetching a standard message, if its action is `Reject` and the group isn't the home group, show the same "no message to send" confirmation as the plain Reject button instead of opening the compose modal - so behaviour is consistent regardless of which UI element the mod uses.

## Other Call Sites
```
grep -rn "ModMessageButton\b" iznik-nuxt3/modtools --include=*.vue
```
Only two render sites: `ModMessageButtons.vue` (fixed here) and one plain `release` button in `ModMessage.vue` (not stdmsg-driven, no `isHomeGroup` concern). `ModMemberButton.vue` has an analogous `stdmsgid` fetch path but no `isHomeGroup` concept at all - membership actions aren't per-group-rippled, so that gap doesn't apply there.

## Test
- File: `iznik-nuxt3/tests/unit/components/modtools/ModMessageButton.spec.js`
- Command: `npx vitest run tests/unit/components/modtools/ModMessageButton.spec.js`
- 3 new tests added: fails-before (no-message dialog wasn't shown), passes-after for the Reject/non-home case; unaffected passes for Reject/home and for a non-Reject standard message on a non-home group (kept composing, as before).
- Full local vitest suite: 669 files / 14276 tests passed, 4 pre-existing skips, no regressions.

## Discourse
https://discourse.ilovefreegle.org/t/9862/13