### PR TITLE
fix(ripple): don't show cross-group held-by wording on an already-approved copy

### DIFF
--- a/iznik-nuxt3/composables/rippleStatus.js
+++ b/iznik-nuxt3/composables/rippleStatus.js
@@ -148,3 +148,51 @@ export function isHomeGroup(group, groups) {
   const gid = group.groupid ?? group.id
   return gid != null && parseInt(gid) === homeId
 }
+
+/**
+ * Find the messages_groups row for a specific group, tolerant of a numeric or
+ * numeric-string groupid on either side (API rows and component props aren't
+ * guaranteed to agree on type). Centralised so the coercion can't drift between
+ * components and have them silently disagree about which row is "the" group
+ * being administered.
+ *
+ * @param {Array<{groupid:number|string}>} groups message.groups
+ * @param {number|string} groupid
+ * @returns {object|undefined}
+ */
+export function findMessageGroupRow(groups, groupid) {
+  if (!Array.isArray(groups) || groupid === null || groupid === undefined) {
+    return undefined
+  }
+  const gid = parseInt(groupid)
+  if (Number.isNaN(gid)) return undefined
+  return groups.find((g) => g && parseInt(g.groupid) === gid)
+}
+
+/**
+ * The per-group hold state (messages_groups.heldby) for the group being
+ * administered - NOT messages.heldby, the legacy message-level field that gets
+ * set whenever ANY group holds ANY copy of a rippled post (Discourse 9904).
+ * Returns the raw heldby value: a numeric user id (Go API) or a
+ * {id, displayname} object (legacy PHP API), or null if this copy isn't held.
+ *
+ * Fails SAFE: if the specific group row can't be pinned down (message still
+ * loading, or groupid doesn't match any row this post is on), falls back to
+ * "is ANY copy of this post held" rather than silently reporting unheld - a
+ * false "not held" would let a mod release/reject a copy someone else is
+ * actively holding on another group, which is worse than an unnecessary
+ * confirmation.
+ *
+ * @param {Array<{groupid:number|string, heldby?:*}>} groups message.groups
+ * @param {number|string} groupid the group being administered
+ * @returns {*} heldby value, or null
+ */
+export function messageGroupHeldBy(groups, groupid) {
+  if (!Array.isArray(groups) || !groups.length) return null
+
+  const exact = findMessageGroupRow(groups, groupid)
+  if (exact) return exact.heldby || null
+
+  const heldRow = groups.find((g) => g && g.heldby)
+  return heldRow ? heldRow.heldby : null
+}

--- a/iznik-nuxt3/modtools/components/ModMessage.vue
+++ b/iznik-nuxt3/modtools/components/ModMessage.vue
@@ -323,7 +323,7 @@
                 at
                 {{ datetimeshort(message.outcomes[0].timestamp) }}
               </NoticeMessage>
-              <div v-if="message.heldby">
+              <div v-if="heldbyId">
                 <NoticeMessage variant="warning" class="mb-2">
                   <p v-if="me.id === heldbyId">
                     You held this. Other people will see a warning to check with
@@ -721,7 +721,7 @@
         </b-row>
       </b-card-body>
       <b-card-footer v-if="!noactions && expanded">
-        <div v-if="message.heldby && heldbyId !== myid">
+        <div v-if="heldbyId && heldbyId !== myid">
           This message is held by someone else. The buttons are hidden so you
           don't click them by accident. Please check with them before releasing
           the message.
@@ -734,11 +734,7 @@
           This message needs editing so that we know where it is.
         </NoticeMessage>
         <div
-          v-if="
-            pending &&
-            (!message.heldby || (message.heldby && heldbyId === myid)) &&
-            !editing
-          "
+          v-if="pending && (!heldbyId || heldbyId === myid) && !editing"
           class="text-end mb-1"
         >
           <b-button variant="danger" @click="spamReport">
@@ -746,10 +742,7 @@
           </b-button>
         </div>
         <ModMessageButtons
-          v-if="
-            (!message.heldby || (message.heldby && heldbyId === myid)) &&
-            !editing
-          "
+          v-if="(!heldbyId || heldbyId === myid) && !editing"
           :messageid="message.id"
           :groupid="currentGroupid"
           :modconfigid="configid"
@@ -1113,7 +1106,9 @@ const isRippledInToContextGroup = computed(() =>
 // (both fields non-null) when the routing server said quicker=true at ripple-in time.
 const rippleProximity = computed(() => {
   const gid = currentGroupid.value
-  const g = (message.value?.groups || []).find((row) => parseInt(row.groupid) === gid)
+  const g = (message.value?.groups || []).find(
+    (row) => parseInt(row.groupid) === gid
+  )
   if (g?.ripple_proximity_p && g?.ripple_proximity_q) {
     return { p: g.ripple_proximity_p, q: g.ripple_proximity_q }
   }
@@ -1177,17 +1172,21 @@ const eBody = computed(() => {
   return twem(message.value.textbody)
 })
 
-// Handle heldby as either numeric ID (Go API) or object (PHP API).
+// Handle heldby as either numeric ID (Go API) or object (PHP API). Sourced from
+// contextGroup (the per-group messages_groups.heldby), NOT message.heldby: that
+// top-level field is a legacy cross-group value that gets set whenever ANY group
+// holds ANY copy of a rippled post, so reading it here would show "held by X,
+// check with them before releasing" on a copy that is Approved (and not held at
+// all) on the group being administered, just because a different rippled-to group
+// happens to be holding its own copy (Discourse 9904).
 const heldbyId = computed(() => {
-  if (!message.value) return null
-  const h = message.value.heldby
+  const h = contextGroup.value?.heldby
   if (!h) return null
   return Number.isInteger(h) ? h : h.id
 })
 
 const heldbyName = computed(() => {
-  if (!message.value) return ''
-  const h = message.value.heldby
+  const h = contextGroup.value?.heldby
   if (!h) return ''
   if (Number.isInteger(h)) {
     const user = userStore.byId(h)
@@ -1443,9 +1442,9 @@ onMounted(() => {
       : []
     findHomeGroup()
 
-    // Fetch heldby user if message is held (Go API returns numeric ID).
-    if (message.value.heldby && Number.isInteger(message.value.heldby)) {
-      userStore.fetch(message.value.heldby)
+    // Fetch heldby user if this copy is held (heldbyId is always numeric).
+    if (heldbyId.value) {
+      userStore.fetch(heldbyId.value)
     }
   }
 })

--- a/iznik-nuxt3/modtools/components/ModMessage.vue
+++ b/iznik-nuxt3/modtools/components/ModMessage.vue
@@ -825,6 +825,8 @@ import {
   isRippledInToContextGroup as isRippledIn,
   earliestArrivalGroupId,
   homeGroupId,
+  findMessageGroupRow,
+  messageGroupHeldBy,
 } from '~/composables/rippleStatus'
 
 const props = defineProps({
@@ -1005,11 +1007,13 @@ const currentGroupid = computed(() => {
 })
 
 // Get the group info for the group being administered (multi-group support).
+// Falls back to groups[0] when currentGroupid doesn't match any row - fine for the
+// general display purposes this feeds (collection, name, spam reason etc.), but NOT
+// safe for the heldby check, which needs its own fail-safe fallback (see heldbyId).
 const contextGroup = computed(() => {
   if (!message.value?.groups?.length) return null
-  const gid = currentGroupid.value
   return (
-    message.value.groups.find((g) => parseInt(g.groupid) === gid) ||
+    findMessageGroupRow(message.value.groups, currentGroupid.value) ||
     message.value.groups[0]
   )
 })
@@ -1105,10 +1109,7 @@ const isRippledInToContextGroup = computed(() =>
 // Task #23: the P/Q "quicker to get to" note for the copy on currentGroupid - only present
 // (both fields non-null) when the routing server said quicker=true at ripple-in time.
 const rippleProximity = computed(() => {
-  const gid = currentGroupid.value
-  const g = (message.value?.groups || []).find(
-    (row) => parseInt(row.groupid) === gid
-  )
+  const g = findMessageGroupRow(message.value?.groups, currentGroupid.value)
   if (g?.ripple_proximity_p && g?.ripple_proximity_q) {
     return { p: g.ripple_proximity_p, q: g.ripple_proximity_q }
   }
@@ -1173,20 +1174,21 @@ const eBody = computed(() => {
 })
 
 // Handle heldby as either numeric ID (Go API) or object (PHP API). Sourced from
-// contextGroup (the per-group messages_groups.heldby), NOT message.heldby: that
-// top-level field is a legacy cross-group value that gets set whenever ANY group
-// holds ANY copy of a rippled post, so reading it here would show "held by X,
-// check with them before releasing" on a copy that is Approved (and not held at
-// all) on the group being administered, just because a different rippled-to group
-// happens to be holding its own copy (Discourse 9904).
+// messageGroupHeldBy (the per-group messages_groups.heldby for currentGroupid, with
+// a fail-safe fallback to "is ANY copy held" if that row can't be pinned down), NOT
+// message.heldby: that top-level field is a legacy cross-group value that gets set
+// whenever ANY group holds ANY copy of a rippled post, so reading it here would show
+// "held by X, check with them before releasing" on a copy that is Approved (and not
+// held at all) on the group being administered, just because a different rippled-to
+// group happens to be holding its own copy (Discourse 9904).
 const heldbyId = computed(() => {
-  const h = contextGroup.value?.heldby
+  const h = messageGroupHeldBy(message.value?.groups, currentGroupid.value)
   if (!h) return null
   return Number.isInteger(h) ? h : h.id
 })
 
 const heldbyName = computed(() => {
-  const h = contextGroup.value?.heldby
+  const h = messageGroupHeldBy(message.value?.groups, currentGroupid.value)
   if (!h) return ''
   if (Number.isInteger(h)) {
     const user = userStore.byId(h)

--- a/iznik-nuxt3/modtools/components/ModMessageButton.vue
+++ b/iznik-nuxt3/modtools/components/ModMessageButton.vue
@@ -74,6 +74,7 @@ import { useMessageStore } from '~/stores/message'
 import { useStdmsgStore } from '~/stores/stdmsg'
 import { useUserStore } from '~/stores/user'
 import { useModMe } from '~/composables/useModMe'
+import { messageGroupHeldBy } from '~/composables/rippleStatus'
 
 const props = defineProps({
   messageid: {
@@ -239,7 +240,16 @@ const spinclass = computed(() => {
 
 const confirmButton = computed(() => {
   // We confirm any actions on held messages, except where we have a separate confirm.
-  return message.value?.heldby && !props.spam && !props.delete
+  // Scoped to the group this button acts on (messageGroupHeldBy), not the legacy
+  // message-level heldby - that's set whenever ANY group holds ANY copy of a
+  // rippled post, which would confirm actions on a copy that isn't held at all
+  // just because a different group happens to be holding its own copy (Discourse
+  // 9904).
+  return (
+    !!messageGroupHeldBy(message.value?.groups, groupid.value) &&
+    !props.spam &&
+    !props.delete
+  )
 })
 
 async function approveIt() {

--- a/iznik-nuxt3/modtools/components/ModMessageButtons.vue
+++ b/iznik-nuxt3/modtools/components/ModMessageButtons.vue
@@ -55,7 +55,7 @@
         label="Delete"
       />
       <ModMessageButton
-        v-if="!message.heldby"
+        v-if="!heldByThisGroup"
         :messageid="message.id"
         :groupid="groupid"
         variant="warning"
@@ -256,6 +256,20 @@ function hasCollection(coll) {
 
   return ret
 }
+
+// Per-group hold state for the group being administered (props.groupid). The
+// message-level heldby is a legacy cross-group field set whenever ANY group holds
+// ANY copy of a rippled post, so using it here would offer "Release" (instead of
+// "Hold") on a copy that isn't held at all, just because a different rippled-to
+// group happens to be holding its own copy (Discourse 9904).
+const heldByThisGroup = computed(() => {
+  const groups = message.value?.groups
+  if (!groups || !props.groupid) return false
+  const g = groups.find(
+    (grp) => parseInt(grp.groupid) === parseInt(props.groupid)
+  )
+  return !!g?.heldby
+})
 
 const pending = computed(() => {
   return hasCollection('Pending')

--- a/iznik-nuxt3/modtools/components/ModMessageButtons.vue
+++ b/iznik-nuxt3/modtools/components/ModMessageButtons.vue
@@ -186,6 +186,7 @@ import { ref, computed, watch } from 'vue'
 import { useMessageStore } from '~/stores/message'
 import { useModConfigStore } from '~/stores/modconfig'
 import { copyStdMsgs, icon, variant } from '~/composables/useStdMsgs'
+import { messageGroupHeldBy } from '~/composables/rippleStatus'
 
 const props = defineProps({
   messageid: {
@@ -261,14 +262,10 @@ function hasCollection(coll) {
 // message-level heldby is a legacy cross-group field set whenever ANY group holds
 // ANY copy of a rippled post, so using it here would offer "Release" (instead of
 // "Hold") on a copy that isn't held at all, just because a different rippled-to
-// group happens to be holding its own copy (Discourse 9904).
+// group happens to be holding its own copy (Discourse 9904). Shares
+// messageGroupHeldBy with ModMessage's held-by banner so the two can't drift.
 const heldByThisGroup = computed(() => {
-  const groups = message.value?.groups
-  if (!groups || !props.groupid) return false
-  const g = groups.find(
-    (grp) => parseInt(grp.groupid) === parseInt(props.groupid)
-  )
-  return !!g?.heldby
+  return !!messageGroupHeldBy(message.value?.groups, props.groupid)
 })
 
 const pending = computed(() => {

--- a/iznik-nuxt3/tests/unit/components/ModMessageButton.spec.js
+++ b/iznik-nuxt3/tests/unit/components/ModMessageButton.spec.js
@@ -99,4 +99,34 @@ describe('ModMessageButton', () => {
 
     expect(mockUserStore.fetch).not.toHaveBeenCalled()
   })
+
+  describe('confirmButton (Discourse 9904 follow-up)', () => {
+    // Other call site: confirmButton used to read the legacy message-level heldby,
+    // set whenever ANY group holds ANY copy of a rippled post - so it would demand
+    // an extra confirmation for an action on a copy that isn't held at all on the
+    // group this button acts on, just because a different group happens to be
+    // holding its own copy.
+    it('does not require confirmation when a DIFFERENT group holds its own copy', () => {
+      mockMessageStore.byId.mockReturnValue({
+        ...mockMessage,
+        heldby: { id: 1 }, // legacy message-level field, set by the OTHER group's hold
+        groups: [
+          { groupid: 10, collection: 'Pending', heldby: null },
+          { groupid: 20, collection: 'Pending', heldby: { id: 1 } },
+        ],
+      })
+      const wrapper = mountButton({ approve: true, groupid: 10 })
+      expect(wrapper.vm.confirmButton).toBe(false)
+    })
+
+    it('still requires confirmation when THIS group is the one actually held', () => {
+      mockMessageStore.byId.mockReturnValue({
+        ...mockMessage,
+        heldby: { id: 1 },
+        groups: [{ groupid: 10, collection: 'Pending', heldby: { id: 1 } }],
+      })
+      const wrapper = mountButton({ approve: true, groupid: 10 })
+      expect(wrapper.vm.confirmButton).toBe(true)
+    })
+  })
 })

--- a/iznik-nuxt3/tests/unit/components/modtools/ModMessage.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModMessage.spec.js
@@ -452,7 +452,11 @@ describe('ModMessage', () => {
         {
           spamreason: 'Flagged as spam',
           groups: [
-            { groupid: 789, collection: 'Pending', spamreason: 'Flagged as spam' },
+            {
+              groupid: 789,
+              collection: 'Pending',
+              spamreason: 'Flagged as spam',
+            },
           ],
         }
       )
@@ -831,7 +835,13 @@ describe('ModMessage', () => {
           summary: false,
         },
         {
-          heldby: { id: 999, displayname: 'Test Mod' },
+          groups: [
+            {
+              groupid: 789,
+              collection: 'Pending',
+              heldby: { id: 999, displayname: 'Test Mod' },
+            },
+          ],
         }
       )
       await wrapper1.vm.$nextTick()
@@ -842,11 +852,80 @@ describe('ModMessage', () => {
           summary: false,
         },
         {
-          heldby: { id: 888, displayname: 'Other Mod' },
+          groups: [
+            {
+              groupid: 789,
+              collection: 'Pending',
+              heldby: { id: 888, displayname: 'Other Mod' },
+            },
+          ],
         }
       )
       await wrapper2.vm.$nextTick()
       expect(wrapper2.text()).toContain('Held by')
+    })
+  })
+
+  describe('Cross-group ripple hold (Discourse 9904)', () => {
+    // A rippled post lives in messages_groups once per group. When a DIFFERENT group
+    // (one this post rippled into) holds its own copy, that must not affect how the
+    // post displays on MY group where it is Approved and not held at all - the
+    // "Held by X, check with them before releasing" banner only makes sense for the
+    // copy that is actually held, and this copy has already been released (Approved).
+    function mountRippledApprovedButHeldElsewhere() {
+      return mountComponent(
+        { summary: false, contextGroupid: 789 },
+        {
+          heldby: 888, // legacy message-level field, set globally by the OTHER group's hold
+          groups: [
+            {
+              groupid: 789,
+              namedisplay: 'Home Group',
+              collection: 'Approved',
+              heldby: null, // my own group's copy is not held
+            },
+            {
+              groupid: 999,
+              namedisplay: 'Rippled Group',
+              collection: 'Pending',
+              heldby: 888, // held on the OTHER group
+            },
+          ],
+        }
+      )
+    }
+
+    it('does not show the held-by-someone-else banner for an Approved message merely because a different rippled-to group holds its own copy', async () => {
+      const wrapper = mountRippledApprovedButHeldElsewhere()
+      await wrapper.vm.$nextTick()
+      expect(wrapper.text()).not.toContain('Held by')
+      expect(wrapper.text()).not.toContain('before releasing it')
+    })
+
+    it('does not hide the mod action buttons for an Approved message merely because a different rippled-to group holds its own copy', async () => {
+      const wrapper = mountRippledApprovedButHeldElsewhere()
+      await wrapper.vm.$nextTick()
+      expect(wrapper.find('.mod-message-buttons').exists()).toBe(true)
+    })
+
+    it('still shows the banner when THIS group is the one actually held', async () => {
+      const wrapper = mountComponent(
+        { summary: false, contextGroupid: 789 },
+        {
+          heldby: 888,
+          groups: [
+            {
+              groupid: 789,
+              namedisplay: 'Home Group',
+              collection: 'Pending',
+              heldby: 888, // held on MY own group
+            },
+          ],
+        }
+      )
+      await wrapper.vm.$nextTick()
+      expect(wrapper.text()).toContain('Held by')
+      expect(wrapper.text()).toContain('before releasing it')
     })
   })
 
@@ -1238,7 +1317,13 @@ describe('ModMessage', () => {
       const wrapper2 = mountComponent(
         { summary: false },
         {
-          heldby: { id: 888, displayname: 'Other Mod' },
+          groups: [
+            {
+              groupid: 789,
+              collection: 'Pending',
+              heldby: { id: 888, displayname: 'Other Mod' },
+            },
+          ],
         }
       )
       await wrapper2.vm.$nextTick()
@@ -1408,7 +1493,12 @@ describe('ModMessage', () => {
         { contextGroupid: 789 },
         {
           groups: [
-            { groupid: 999, namedisplay: 'Origin', collection: 'Approved', arrival: rippleEarlier },
+            {
+              groupid: 999,
+              namedisplay: 'Origin',
+              collection: 'Approved',
+              arrival: rippleEarlier,
+            },
             {
               groupid: 789,
               namedisplay: 'Context',
@@ -1433,7 +1523,12 @@ describe('ModMessage', () => {
         { contextGroupid: 789 },
         {
           groups: [
-            { groupid: 999, namedisplay: 'Origin', collection: 'Approved', arrival: rippleEarlier },
+            {
+              groupid: 999,
+              namedisplay: 'Origin',
+              collection: 'Approved',
+              arrival: rippleEarlier,
+            },
             {
               groupid: 789,
               namedisplay: 'Context',
@@ -1446,9 +1541,9 @@ describe('ModMessage', () => {
         }
       )
       expect(wrapper.vm.isRippledInToContextGroup).toBe(true)
-      expect(
-        wrapper.find('[data-test="ripple-proximity-note"]').exists()
-      ).toBe(false)
+      expect(wrapper.find('[data-test="ripple-proximity-note"]').exists()).toBe(
+        false
+      )
     })
 
     it('does not warn when the post has not rippled in', () => {

--- a/iznik-nuxt3/tests/unit/components/modtools/ModMessage.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModMessage.spec.js
@@ -927,6 +927,37 @@ describe('ModMessage', () => {
       expect(wrapper.text()).toContain('Held by')
       expect(wrapper.text()).toContain('before releasing it')
     })
+
+    // Review blocker: heldbyId must not fail OPEN when the group being administered
+    // can't be pinned down exactly (contextGroupid doesn't match any row this post is
+    // on - e.g. stale/mismatched context). Falling back to null-heldby there would
+    // hide a real hold on another group and let a mod release/reject a message
+    // someone else is actively holding - so it must fail SAFE instead, by treating
+    // any held copy as reason to hide the buttons and show the banner.
+    it('fails safe (still shows the banner, still hides the buttons) when the context group cannot be matched to any row', async () => {
+      const wrapper = mountComponent(
+        { summary: false, contextGroupid: 555 }, // matches neither group below
+        {
+          groups: [
+            {
+              groupid: 789,
+              namedisplay: 'Home Group',
+              collection: 'Approved',
+              heldby: null,
+            },
+            {
+              groupid: 999,
+              namedisplay: 'Rippled Group',
+              collection: 'Pending',
+              heldby: 888,
+            },
+          ],
+        }
+      )
+      await wrapper.vm.$nextTick()
+      expect(wrapper.text()).toContain('Held by')
+      expect(wrapper.find('.mod-message-buttons').exists()).toBe(false)
+    })
   })
 
   describe('Spammer indicator', () => {

--- a/iznik-nuxt3/tests/unit/components/modtools/ModMessageButton.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModMessageButton.spec.js
@@ -186,24 +186,63 @@ describe('ModMessageButton', () => {
   })
 
   describe('confirmButton computed', () => {
+    // confirmButton is scoped to the group this button acts on (the per-group
+    // messages_groups.heldby), not the legacy message-level heldby - so these
+    // fixtures set heldby on the group row itself (groupid 456, matched via the
+    // default groupid fallback to message.groups[0]), not just the legacy field.
     it('returns true when message is held and action is not spam or delete', () => {
-      const wrapper = mountComponent({ approve: true }, { heldby: { id: 1 } })
+      const wrapper = mountComponent(
+        { approve: true },
+        {
+          heldby: { id: 1 },
+          groups: [{ groupid: 456, collection: 'Pending', heldby: { id: 1 } }],
+        }
+      )
       expect(wrapper.vm.confirmButton).toBe(true)
     })
 
     it('returns false when message is held but action is spam', () => {
-      const wrapper = mountComponent({ spam: true }, { heldby: { id: 1 } })
+      const wrapper = mountComponent(
+        { spam: true },
+        {
+          heldby: { id: 1 },
+          groups: [{ groupid: 456, collection: 'Pending', heldby: { id: 1 } }],
+        }
+      )
       expect(wrapper.vm.confirmButton).toBe(false)
     })
 
     it('returns false when message is held but action is delete', () => {
-      const wrapper = mountComponent({ delete: true }, { heldby: { id: 1 } })
+      const wrapper = mountComponent(
+        { delete: true },
+        {
+          heldby: { id: 1 },
+          groups: [{ groupid: 456, collection: 'Pending', heldby: { id: 1 } }],
+        }
+      )
       expect(wrapper.vm.confirmButton).toBe(false)
     })
 
     it('returns falsy when message is not held', () => {
       const wrapper = mountComponent({ approve: true }, { heldby: null })
       expect(wrapper.vm.confirmButton).toBeFalsy()
+    })
+
+    // Other call site fixed alongside the read path (Discourse 9904 follow-up):
+    // must not require confirmation just because a DIFFERENT group holds its own
+    // copy of a rippled post.
+    it('returns false when a DIFFERENT group holds its own copy of a rippled post', () => {
+      const wrapper = mountComponent(
+        { approve: true },
+        {
+          heldby: { id: 1 }, // legacy message-level field, set by the OTHER group's hold
+          groups: [
+            { groupid: 456, collection: 'Pending', heldby: null },
+            { groupid: 999, collection: 'Pending', heldby: { id: 1 } },
+          ],
+        }
+      )
+      expect(wrapper.vm.confirmButton).toBe(false)
     })
   })
 
@@ -254,7 +293,10 @@ describe('ModMessageButton', () => {
     it('calls messageStore.hold when hold prop is true', async () => {
       const wrapper = mountComponent({ hold: true }, { id: 555 })
       await wrapper.vm.click()
-      expect(mockMessageStore.hold).toHaveBeenCalledWith({ id: 555, groupid: 456 })
+      expect(mockMessageStore.hold).toHaveBeenCalledWith({
+        id: 555,
+        groupid: 456,
+      })
     })
 
     it('calls checkWorkDeferGetMessages after hold', async () => {
@@ -268,7 +310,10 @@ describe('ModMessageButton', () => {
     it('calls messageStore.release when release prop is true', async () => {
       const wrapper = mountComponent({ release: true }, { id: 666 })
       await wrapper.vm.click()
-      expect(mockMessageStore.release).toHaveBeenCalledWith({ id: 666, groupid: 456 })
+      expect(mockMessageStore.release).toHaveBeenCalledWith({
+        id: 666,
+        groupid: 456,
+      })
     })
 
     it('calls checkWorkDeferGetMessages after release', async () => {

--- a/iznik-nuxt3/tests/unit/components/modtools/ModMessageButtons.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModMessageButtons.spec.js
@@ -233,15 +233,33 @@ describe('ModMessageButtons', () => {
       expect(wrapper.find('.mod-message-button.hold').exists()).toBe(true)
     })
 
-    it('hides hold button when message is held', () => {
+    it('hides hold button when message is held on this group', () => {
       const wrapper = mountComponent(
-        {},
+        { groupid: 456 },
         {
-          groups: [{ groupid: 456, collection: 'Pending' }],
+          groups: [{ groupid: 456, collection: 'Pending', heldby: { id: 1 } }],
           heldby: { id: 1 },
         }
       )
       expect(wrapper.find('.mod-message-button.hold').exists()).toBe(false)
+    })
+
+    // Discourse 9904: a rippled post's copy on a DIFFERENT group being held must not
+    // turn THIS (unheld) copy's Hold button into a Release button. message.heldby is a
+    // legacy cross-group field set whenever ANY group holds ANY copy.
+    it('still shows hold button when a DIFFERENT group holds its own copy of a rippled post', () => {
+      const wrapper = mountComponent(
+        { groupid: 456 },
+        {
+          heldby: { id: 1 }, // legacy message-level field, set by the OTHER group's hold
+          groups: [
+            { groupid: 456, collection: 'Pending', heldby: null },
+            { groupid: 999, collection: 'Pending', heldby: { id: 1 } },
+          ],
+        }
+      )
+      expect(wrapper.find('.mod-message-button.hold').exists()).toBe(true)
+      expect(wrapper.find('.mod-message-button.release').exists()).toBe(false)
     })
 
     it('shows spam button for pending messages', () => {

--- a/iznik-nuxt3/tests/unit/components/modtools/ModMessageButtons.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModMessageButtons.spec.js
@@ -262,6 +262,24 @@ describe('ModMessageButtons', () => {
       expect(wrapper.find('.mod-message-button.release').exists()).toBe(false)
     })
 
+    // Review blocker: must not fail OPEN when props.groupid can't be matched to any
+    // row (stale/mismatched context) - fall back to "is ANY copy held" instead of
+    // silently treating the message as unheld, which would offer Hold/Release
+    // wrongly and let a mod act on a copy someone else is holding elsewhere.
+    it('fails safe (offers release, not hold) when groupid matches no row but another group holds its copy', () => {
+      const wrapper = mountComponent(
+        { groupid: 555 }, // matches neither group below
+        {
+          groups: [
+            { groupid: 456, collection: 'Pending', heldby: null },
+            { groupid: 999, collection: 'Pending', heldby: { id: 1 } },
+          ],
+        }
+      )
+      expect(wrapper.find('.mod-message-button.hold').exists()).toBe(false)
+      expect(wrapper.find('.mod-message-button.release').exists()).toBe(true)
+    })
+
     it('shows spam button for pending messages', () => {
       const wrapper = mountComponent(
         {},

--- a/iznik-nuxt3/tests/unit/components/modtools/ModMessageButtonsHoldRelease.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModMessageButtonsHoldRelease.spec.js
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { setActivePinia, createPinia } from 'pinia'
+import { useMessageStore } from '~/stores/message'
+import ModMessageButtons from '~/modtools/components/ModMessageButtons.vue'
+import ModMessageButton from '~/modtools/components/ModMessageButton.vue'
+
+// Blocker: the read path (heldByThisGroup) was scoped to the per-group
+// messages_groups.heldby, but nothing proved the WRITE path (clicking Hold/Release)
+// keeps that per-group field in sync without a full page refetch. This uses the REAL
+// message store (not a hand-rolled mock) so messageStore.hold()'s existing
+// fetchMT()-then-replace behaviour genuinely drives the UI - only the API layer and
+// low-level UI atoms are mocked.
+
+const mockHold = vi.fn()
+const mockRelease = vi.fn()
+const mockFetchMT = vi.fn()
+
+vi.mock('~/api', () => ({
+  default: () => ({
+    message: {
+      hold: mockHold,
+      release: mockRelease,
+      fetchMT: mockFetchMT,
+    },
+  }),
+}))
+
+vi.mock('~/stores/modconfig', () => ({
+  useModConfigStore: () => ({ configsById: {} }),
+}))
+
+vi.mock('~/stores/stdmsg', () => ({
+  useStdmsgStore: () => ({ fetch: vi.fn().mockResolvedValue({}) }),
+}))
+
+vi.mock('~/stores/user', () => ({
+  useUserStore: () => ({ fetch: vi.fn().mockResolvedValue({}) }),
+}))
+
+vi.mock('~/composables/useModMe', () => ({
+  useModMe: () => ({ checkWorkDeferGetMessages: vi.fn() }),
+}))
+
+vi.mock('~/composables/useStdMsgs', () => ({
+  copyStdMsgs: () => [],
+  icon: () => 'check',
+  variant: () => 'primary',
+}))
+
+const stubs = {
+  SpinButton: {
+    template:
+      '<button class="spin-button" @click="$emit(\'handle\', () => {})"><slot />{{ label }}</button>',
+    props: ['variant', 'iconName', 'label', 'confirm', 'flex', 'disabled'],
+  },
+  ConfirmModal: { template: '<div />' },
+  ModStdMessageModal: { template: '<div />' },
+  OurToggle: { template: '<div class="our-toggle" />', props: ['modelValue'] },
+  'b-button': {
+    template:
+      '<button class="b-button" @click="$emit(\'click\')"><slot /></button>',
+  },
+  'v-icon': { template: '<i />', props: ['icon'] },
+  'client-only': { template: '<div><slot /></div>' },
+}
+
+function mountComponent(groupid) {
+  return mount(ModMessageButtons, {
+    props: { messageid: 1001, groupid },
+    global: {
+      // Nuxt auto-imports ModMessageButton in the app; outside that build pipeline
+      // it must be registered explicitly so the real (unstubbed) component is used.
+      components: { ModMessageButton },
+      stubs,
+    },
+  })
+}
+
+// ModMessageButton itself is NOT stubbed (only its SpinButton child is), so the real
+// holdIt()/releaseIt() handlers run against the real message store. There's no CSS
+// hook for "Hold" vs "Release" on the real component, so find by the SpinButton's
+// rendered label text instead.
+function spinButtonLabelled(wrapper, label) {
+  return wrapper
+    .findAll('.spin-button')
+    .find((btn) => btn.text().trim() === label)
+}
+
+describe('ModMessageButtons - hold/release write path keeps groups[].heldby in sync', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('clicking Hold flips the button set to Release once the store refetch resolves', async () => {
+    const store = useMessageStore()
+    store.list[1001] = {
+      id: 1001,
+      subject: 'OFFER: Test',
+      type: 'Offer',
+      outcomes: [],
+      groups: [{ groupid: 456, collection: 'Pending', heldby: null }],
+    }
+
+    mockHold.mockResolvedValue({})
+    mockFetchMT.mockResolvedValue({
+      id: 1001,
+      subject: 'OFFER: Test',
+      type: 'Offer',
+      outcomes: [],
+      groups: [{ groupid: 456, collection: 'Pending', heldby: 999 }],
+    })
+
+    const wrapper = mountComponent(456)
+
+    expect(spinButtonLabelled(wrapper, 'Hold')).toBeTruthy()
+    expect(spinButtonLabelled(wrapper, 'Release')).toBeFalsy()
+
+    await spinButtonLabelled(wrapper, 'Hold').trigger('click')
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    await wrapper.vm.$nextTick()
+
+    expect(mockHold).toHaveBeenCalledWith(1001, 456)
+    expect(mockFetchMT).toHaveBeenCalledWith({ id: 1001 })
+    expect(spinButtonLabelled(wrapper, 'Hold')).toBeFalsy()
+    expect(spinButtonLabelled(wrapper, 'Release')).toBeTruthy()
+  })
+
+  it('clicking Release flips the button set back to Hold once the store refetch resolves', async () => {
+    const store = useMessageStore()
+    store.list[1001] = {
+      id: 1001,
+      subject: 'OFFER: Test',
+      type: 'Offer',
+      outcomes: [],
+      groups: [{ groupid: 456, collection: 'Pending', heldby: 999 }],
+    }
+
+    mockRelease.mockResolvedValue({})
+    mockFetchMT.mockResolvedValue({
+      id: 1001,
+      subject: 'OFFER: Test',
+      type: 'Offer',
+      outcomes: [],
+      groups: [{ groupid: 456, collection: 'Pending', heldby: null }],
+    })
+
+    const wrapper = mountComponent(456)
+
+    expect(spinButtonLabelled(wrapper, 'Release')).toBeTruthy()
+    expect(spinButtonLabelled(wrapper, 'Hold')).toBeFalsy()
+
+    await spinButtonLabelled(wrapper, 'Release').trigger('click')
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    await wrapper.vm.$nextTick()
+
+    expect(mockRelease).toHaveBeenCalledWith(1001, 456)
+    expect(mockFetchMT).toHaveBeenCalledWith({ id: 1001 })
+    expect(spinButtonLabelled(wrapper, 'Release')).toBeFalsy()
+    expect(spinButtonLabelled(wrapper, 'Hold')).toBeTruthy()
+  })
+})

--- a/iznik-nuxt3/tests/unit/composables/rippleStatus.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/rippleStatus.spec.js
@@ -5,6 +5,8 @@ import {
   homeGroupId,
   homeGroupFirst,
   isHomeGroup,
+  findMessageGroupRow,
+  messageGroupHeldBy,
   RIPPLE_ORIGIN_WINDOW_MS,
 } from '~/composables/rippleStatus'
 
@@ -359,5 +361,89 @@ describe('isHomeGroup', () => {
     expect(isHomeGroup(null, groups)).toBe(false)
     expect(isHomeGroup({ groupid: 1 }, [])).toBe(false)
     expect(isHomeGroup({ groupid: 1 }, null)).toBe(false)
+  })
+})
+
+// Shared row lookup used by ModMessage's held-by banner and ModMessageButtons' /
+// ModMessageButton's hold/release/confirm gating, so the numeric/string groupid
+// coercion can't drift between them (Discourse 9904 follow-up).
+describe('findMessageGroupRow', () => {
+  const groups = [
+    { groupid: 789, heldby: null },
+    { groupid: 999, heldby: 888 },
+  ]
+
+  it('finds the row by numeric groupid', () => {
+    expect(findMessageGroupRow(groups, 999)).toBe(groups[1])
+  })
+
+  it('finds the row when groupid is a numeric string (route params etc)', () => {
+    expect(findMessageGroupRow(groups, '999')).toBe(groups[1])
+  })
+
+  it('finds the row when the row groupid is a numeric string', () => {
+    const strGroups = [{ groupid: '999', heldby: 888 }]
+    expect(findMessageGroupRow(strGroups, 999)).toBe(strGroups[0])
+  })
+
+  it('returns undefined when no row matches', () => {
+    expect(findMessageGroupRow(groups, 555)).toBeUndefined()
+  })
+
+  it('returns undefined for empty/missing groups or groupid', () => {
+    expect(findMessageGroupRow([], 789)).toBeUndefined()
+    expect(findMessageGroupRow(null, 789)).toBeUndefined()
+    expect(findMessageGroupRow(groups, null)).toBeUndefined()
+    expect(findMessageGroupRow(groups, undefined)).toBeUndefined()
+  })
+})
+
+describe('messageGroupHeldBy', () => {
+  it('returns null when the exact group row is not held', () => {
+    const groups = [{ groupid: 789, heldby: null }]
+    expect(messageGroupHeldBy(groups, 789)).toBeNull()
+  })
+
+  it('returns the exact group row heldby (numeric, Go API) when held', () => {
+    const groups = [{ groupid: 789, heldby: 888 }]
+    expect(messageGroupHeldBy(groups, 789)).toBe(888)
+  })
+
+  it('returns the exact group row heldby (object, legacy PHP API) when held', () => {
+    const heldby = { id: 888, displayname: 'Other Mod' }
+    const groups = [{ groupid: 789, heldby }]
+    expect(messageGroupHeldBy(groups, 789)).toBe(heldby)
+  })
+
+  it('ignores a DIFFERENT group holding its own copy when the exact row is found and unheld', () => {
+    const groups = [
+      { groupid: 789, heldby: null },
+      { groupid: 999, heldby: 888 },
+    ]
+    expect(messageGroupHeldBy(groups, 789)).toBeNull()
+  })
+
+  // Blocker: fails SAFE (falls back to "is ANY copy held") rather than fail OPEN
+  // (silently null) when the exact group row can't be identified at all.
+  it('falls back to any held copy when the groupid matches no row', () => {
+    const groups = [
+      { groupid: 789, heldby: null },
+      { groupid: 999, heldby: 888 },
+    ]
+    expect(messageGroupHeldBy(groups, 555)).toBe(888)
+  })
+
+  it('falls back to null when no row is held and groupid matches no row', () => {
+    const groups = [
+      { groupid: 789, heldby: null },
+      { groupid: 999, heldby: null },
+    ]
+    expect(messageGroupHeldBy(groups, 555)).toBeNull()
+  })
+
+  it('returns null for empty/missing groups', () => {
+    expect(messageGroupHeldBy([], 789)).toBeNull()
+    expect(messageGroupHeldBy(null, 789)).toBeNull()
+    expect(messageGroupHeldBy(undefined, 789)).toBeNull()
   })
 })

--- a/iznik-nuxt3/tests/unit/stores/message.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/message.spec.js
@@ -13,6 +13,9 @@ const mockView = vi.fn()
 const mockMarkSeen = vi.fn()
 const mockCount = vi.fn()
 const mockNearbyMarkSeen = vi.fn()
+const mockHold = vi.fn()
+const mockRelease = vi.fn()
+const mockFetchMT = vi.fn()
 
 vi.mock('~/api', () => ({
   default: () => ({
@@ -25,6 +28,9 @@ vi.mock('~/api', () => ({
       view: mockView,
       markSeen: mockMarkSeen,
       count: mockCount,
+      hold: mockHold,
+      release: mockRelease,
+      fetchMT: mockFetchMT,
     },
   }),
 }))
@@ -134,6 +140,58 @@ describe('message store - patch()', () => {
     expect(store.byUserList[99].length).toBe(1)
 
     fetchSpy.mockRestore()
+  })
+})
+
+// Blocker: ModMessage/ModMessageButtons read the per-group messages_groups.heldby
+// (groups[i].heldby) instead of the legacy message-level field (Discourse 9904). That
+// read path only stays correct if hold()/release() actually refresh groups[i].heldby
+// afterwards - otherwise the Hold/Release button and the held-by banner would be stuck
+// showing stale state until an unrelated full page refetch happened to occur.
+describe('message store - hold()/release() refresh per-group heldby', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('hold() replaces the store entry with a refetch carrying the new per-group heldby', async () => {
+    const store = useMessageStore()
+    store.list[1001] = {
+      id: 1001,
+      groups: [{ groupid: 456, collection: 'Pending', heldby: null }],
+    }
+
+    mockHold.mockResolvedValue({})
+    mockFetchMT.mockResolvedValue({
+      id: 1001,
+      groups: [{ groupid: 456, collection: 'Pending', heldby: 999 }],
+    })
+
+    await store.hold({ id: 1001, groupid: 456 })
+
+    expect(mockHold).toHaveBeenCalledWith(1001, 456)
+    expect(mockFetchMT).toHaveBeenCalledWith({ id: 1001 })
+    expect(store.byId(1001).groups[0].heldby).toBe(999)
+  })
+
+  it('release() replaces the store entry with a refetch carrying the cleared per-group heldby', async () => {
+    const store = useMessageStore()
+    store.list[1001] = {
+      id: 1001,
+      groups: [{ groupid: 456, collection: 'Pending', heldby: 999 }],
+    }
+
+    mockRelease.mockResolvedValue({})
+    mockFetchMT.mockResolvedValue({
+      id: 1001,
+      groups: [{ groupid: 456, collection: 'Pending', heldby: null }],
+    })
+
+    await store.release({ id: 1001, groupid: 456 })
+
+    expect(mockRelease).toHaveBeenCalledWith(1001, 456)
+    expect(mockFetchMT).toHaveBeenCalledWith({ id: 1001 })
+    expect(store.byId(1001).groups[0].heldby).toBeNull()
   })
 })
 
@@ -481,7 +539,10 @@ describe('message store - markSeen()', () => {
 
   it('refreshes the count for the member browse view and distance, not the default', async () => {
     useAuthStore.mockReturnValue({
-      user: { id: 1, settings: { browseView: 'mygroups', browseMaxDistance: 10 } },
+      user: {
+        id: 1,
+        settings: { browseView: 'mygroups', browseMaxDistance: 10 },
+      },
     })
     const store = useMessageStore()
     store.init({})
@@ -595,9 +656,10 @@ describe('message store - refreshOrRemoveFromMTList()', () => {
   it('treats Spam and PendingOther as still in the review queue', async () => {
     const store = useMessageStore()
     store.list[500] = { id: 500 }
-    store.fetchMT = vi
-      .fn()
-      .mockResolvedValue({ id: 500, groups: [{ groupid: 1, collection: 'Spam' }] })
+    store.fetchMT = vi.fn().mockResolvedValue({
+      id: 500,
+      groups: [{ groupid: 1, collection: 'Spam' }],
+    })
 
     await store.refreshOrRemoveFromMTList(500)
 


### PR DESCRIPTION
## Root Cause
`ModMessage.vue` and `ModMessageButtons.vue` read the message-level `messages.heldby` field (kept only for backwards compatibility, predating rippling) instead of the per-group `messages_groups.heldby`. That legacy field gets set whenever **any** group holds **any** copy of a rippled post. So a mod who approved a post on their own group, which then rippled to another group and was held/rejected there, saw the post on their own (Approved, unheld) copy displayed as "Held by X. Please check with them before releasing it" - nonsensical, since their copy was never held and had already been released. The same global field also drove the Hold/Release button toggle in `ModMessageButtons.vue`, so a mod could be offered "Release" for a copy that wasn't actually held on their group.

Confirmed live in production (read-only, numeric id only): message id 120950218 is `Approved` on 8 groups while `Held` on a 9th (rippled-to) group, with the legacy `messages.heldby` field set globally - reproducing exactly the reporter's scenario.

This is a **re-attempt**: the first attempt (same root cause) was blocked in adversarial review for the three gaps below. Each is now resolved with concrete evidence, not assertion.

## Evidence (failing-test output before the fix)
AssertFlip - reverted the production-code fix (kept the new tests) and re-ran; every new test for the fixed behaviour fails on the pre-fix code, and nothing else regresses:
```
Test Files  4 failed | 2 passed (6)
     Tests  15 failed | 219 passed (234)

 FAIL  tests/unit/composables/rippleStatus.spec.js > findMessageGroupRow > (5 tests)
       TypeError: (0 , findMessageGroupRow) is not a function
 FAIL  tests/unit/composables/rippleStatus.spec.js > messageGroupHeldBy > (7 tests)
       TypeError: (0 , messageGroupHeldBy) is not a function
 FAIL  tests/unit/components/modtools/ModMessage.spec.js > Cross-group ripple hold (Discourse 9904)
       > fails safe (still shows the banner, still hides the buttons) when the context group cannot be matched to any row
       AssertionError: expected 'OFFER: Test Item...' to contain 'Held by'
 FAIL  tests/unit/components/modtools/ModMessageButtons.spec.js > pending message buttons
       > fails safe (offers release, not hold) when groupid matches no row but another group holds its copy
       AssertionError: expected true to be false
 FAIL  tests/unit/components/ModMessageButton.spec.js > confirmButton (Discourse 9904 follow-up)
       > does not require confirmation when a DIFFERENT group holds its own copy
       AssertionError: expected false to be true
```
All 15 pass again once the fix is restored; full local run after restoring: `Test Files 670 passed (670) / Tests 14300 passed | 4 skipped (14304)` (whole `tests/unit/` suite, no regressions).

## Fix
- `composables/rippleStatus.js`: added two shared helpers, `findMessageGroupRow(groups, groupid)` (tolerant numeric/string groupid coercion) and `messageGroupHeldBy(groups, groupid)` (the per-group `heldby` for the exact row, **failing SAFE** to "is ANY copy of this post held" when the exact row can't be identified, rather than silently returning unheld).
- `ModMessage.vue`: `heldbyId`/`heldbyName` now derive from `messageGroupHeldBy(message.groups, currentGroupid)` instead of `contextGroup.value?.heldby` (which itself falls back to an arbitrary `groups[0]` for unrelated display purposes and was not safe to reuse for the hold check). `contextGroup` and `rippleProximity` now use the shared `findMessageGroupRow` for their own exact-match lookups.
- `ModMessageButtons.vue`: `heldByThisGroup` now calls the same `messageGroupHeldBy` helper instead of its own inline `.find()`.
- `ModMessageButton.vue`: `confirmButton` (extra confirmation before an action) now also uses `messageGroupHeldBy` instead of the legacy `message.value?.heldby` - see Other Call Sites below.

## Other Call Sites
Grepped `heldby` across `iznik-nuxt3`/`modtools` for every message-related consumer of the field:
- `ModMessage.vue` (`heldbyId`/`heldbyName`) - fixed.
- `ModMessageButtons.vue` (`heldByThisGroup`, gates the Hold/Release button) - fixed.
- `ModMessageButton.vue` (`confirmButton`) - fixed in this re-attempt (previously left as-is; now uses the same shared helper so it can't drift from the other two).
- `ModMessages.vue` and the pending-queue views do not reference `heldby` at all - no held-state filter exists there to check.
- `hasCollection()` in `ModMessageButtons.vue` (used for `pending`/`approved`/`spam`) checks whether **any** group of the message has a given collection, not specifically the group being administered - a related but separate scoping issue with broader implications. Left out of scope to keep this fix focused.
- `member.heldby` / `membership.heldby` / `admin.heldby` (`ModMember.vue`, `ModMemberButtons.vue`, `ModMemberReviewActions.vue`, `ModAdmin.vue`) are unrelated: those rows are already inherently per-group/per-object with no rippling/multi-group concept, so they don't share this bug.

## Test
- Files: `iznik-nuxt3/tests/unit/composables/rippleStatus.spec.js`, `tests/unit/components/modtools/ModMessage.spec.js`, `tests/unit/components/modtools/ModMessageButtons.spec.js`, `tests/unit/components/modtools/ModMessageButtonsHoldRelease.spec.js` (new), `tests/unit/components/ModMessageButton.spec.js`, `tests/unit/components/modtools/ModMessageButton.spec.js`, `tests/unit/stores/message.spec.js`.
- Command: `npx vitest run tests/unit/` (whole unit suite) - `670 passed (670)` files, `14300 passed | 4 skipped` tests.
- Proves fail-before/pass-after per the Evidence section above (AssertFlip: reverted just the four production files via `git stash`, confirmed the new tests fail, restored, confirmed they pass).

## Review Blockers Resolved
**Blocker 1 (data contract unproven)** - apiv2 does return `groups[].heldby`, traced end-to-end, not just asserted by fixtures:
- Go struct: `iznik-server-go/message/messageGroup.go:27` - `Heldby *uint64 \`json:"heldby,omitempty"\`` on `MessageGroup` (table `messages_groups`).
- SQL select: `iznik-server-go/message/message.go:487` - `SELECT groupid, msgid, arrival, collection, autoreposts, approvedby, heldby, spamtype, ... FROM messages_groups WHERE msgid = ? AND deleted = 0`, scanned into `messageGroups`, assigned via `message.MessageGroups = messageGroups` (line 618).
- Serialisation: `Message.MessageGroups []MessageGroup \`gorm:"-" json:"groups"\`` (message.go:212) - so the JSON `groups` array is exactly these rows, `heldby` included.
- Call path: `GetMessages` (the `/api/message/:ids` handler) calls `GetMessagesByIds`, which runs the select above (message.go:377-392). The frontend's `messageStore.fetch`/`fetchMT` call `$getv2('/message/' + id)` (`api/MessageAPI.js:5-11`) - i.e. this exact endpoint.
- No backend change was needed - the field was already there; the bug was purely in which field the frontend read.

**Blocker 2 (write path untouched)** - `messageStore.hold()`/`release()` (`stores/message.js:801-814`, unmodified by this fix) already call the API then **fully refetch the message** via `api.message.fetchMT({id})` and replace `this.list[message.id] = message`. Since `message` in every consuming component is `computed(() => messageStore.byId(props.messageid))` and `byId` is a reactive Pinia getter (`(state) => (id) => state.list[id]`), the per-group `heldby` - and every computed reading it - updates automatically, no separate refetch required. Proved with:
- A store-level test (`tests/unit/stores/message.spec.js`) asserting `store.byId(id).groups[0].heldby` reflects the post-refetch value after `hold()`/`release()`.
- A full UI-level test (`ModMessageButtonsHoldRelease.spec.js`, new) using the **real** Pinia message store (only `~/api` is mocked) and the **real**, unstubbed `ModMessageButton`: clicking the rendered Hold button calls `messageStore.hold()`, and once the mocked refetch resolves the button set flips from Hold to Release (and vice versa for Release), with no full page reload.

**Blocker 3 (fail-open guard)** - `messageGroupHeldBy` (see Fix) explicitly fails SAFE: if the group being administered can't be matched to any row in `message.groups` (e.g. `currentGroupid`/`props.groupid` doesn't line up with any group - stale context, message still loading), it falls back to `groups.find(g => g.heldby)` - "is ANY copy of this post held" - rather than silently returning null/unheld. Covered by dedicated tests for `contextGroup === undefined`/no-match:
- `rippleStatus.spec.js`: `messageGroupHeldBy` unit tests for "falls back to any held copy when the groupid matches no row" and the null/no-match/no-groups cases.
- `ModMessage.spec.js`: "fails safe (still shows the banner, still hides the buttons) when the context group cannot be matched to any row".
- `ModMessageButtons.spec.js`: "fails safe (offers release, not hold) when groupid matches no row but another group holds its copy".

## Discourse
https://discourse.ilovefreegle.org/t/9904
