### PR TITLE
fix(message): re-derive locationid from lat/lng on PATCH so TN postcode edits stick

### DIFF
--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -1787,6 +1787,31 @@ func getAllGroupsForMessage(db *gorm.DB, msgid uint64) []uint64 {
 	return groupids
 }
 
+// resolvePatchLocationID determines the locationid to persist for a PATCH /message
+// edit. An explicit locationid (whether supplied directly or resolved from a location
+// name) always wins over lat/lng. Otherwise, when the caller supplies new coordinates
+// but no locationid — as partner integrations like Trash Nothing do, since they have
+// no concept of Freegle's location IDs — the nearest postcode for those coordinates is
+// derived instead. Without this, messages.lat/lng update but locationid stays pinned to
+// its pre-edit value; since locationid (not raw lat/lng) is what both the subject-line
+// reconstruction and the owner/mod-facing location display prefer, the postcode appears
+// to revert and stays stuck no matter how many times the coordinates are corrected
+// (Discourse 9908).
+func resolvePatchLocationID(explicit *uint64, lat, lng *float64, nearestPostcode func(lat, lng float32) location.Location) *uint64 {
+	if explicit != nil {
+		return explicit
+	}
+	if lat == nil || lng == nil {
+		return nil
+	}
+	nearest := nearestPostcode(float32(*lat), float32(*lng))
+	if nearest.ID == 0 {
+		return nil
+	}
+	id := nearest.ID
+	return &id
+}
+
 // constructLocationString builds a location string for a message's subject,
 // using the area name + vague postcode format.
 // The vague postcode is the outward code only (e.g., "CB22" from "CB22 3AA").
@@ -3110,6 +3135,7 @@ func applyPatchMessageCore(c *fiber.Ctx, myid uint64, req patchMessageRequest) e
 			req.Locationid = &locID
 		}
 	}
+	req.Locationid = resolvePatchLocationID(req.Locationid, req.Lat, req.Lng, location.ClosestPostcode)
 	if req.Locationid != nil {
 		setClauses = append(setClauses, "locationid = ?")
 		args = append(args, *req.Locationid)

--- a/iznik-server-go/message/message_patch_location_pure_test.go
+++ b/iznik-server-go/message/message_patch_location_pure_test.go
@@ -1,0 +1,84 @@
+package message
+
+import (
+	"testing"
+
+	"github.com/freegle/iznik-server-go/location"
+)
+
+// Pure unit tests for resolvePatchLocationID, the PATCH /message location-derivation
+// helper behind Discourse 9908: a TN edit that supplies corrected lat/lng but no
+// locationid must not leave the stale locationid in place, since locationid (not raw
+// lat/lng) drives both the subject line and the owner/mod-facing postcode display.
+func TestResolvePatchLocationID(t *testing.T) {
+	nearestMK2 := func(lat, lng float32) location.Location { return location.Location{ID: 555, Name: "MK2 5AB"} }
+	notFound := func(lat, lng float32) location.Location { return location.Location{} }
+	shouldNotBeCalled := func(lat, lng float32) location.Location {
+		t.Fatal("nearestPostcode should not be called when an explicit locationid is supplied or coordinates are incomplete")
+		return location.Location{}
+	}
+
+	lat, lng := 52.0, -0.75
+	explicitID := uint64(42)
+
+	tests := []struct {
+		name     string
+		explicit *uint64
+		lat, lng *float64
+		nearest  func(lat, lng float32) location.Location
+		wantID   uint64
+		wantNil  bool
+	}{
+		{
+			name:     "explicit locationid wins over lat/lng",
+			explicit: &explicitID,
+			lat:      &lat,
+			lng:      &lng,
+			nearest:  shouldNotBeCalled,
+			wantID:   42,
+		},
+		{
+			name:    "lat/lng without locationid derives nearest postcode",
+			lat:     &lat,
+			lng:     &lng,
+			nearest: nearestMK2,
+			wantID:  555,
+		},
+		{
+			name:    "no lat, no lng, no locationid leaves it untouched",
+			nearest: shouldNotBeCalled,
+			wantNil: true,
+		},
+		{
+			name:    "lat without lng leaves it untouched (incomplete coordinate pair)",
+			lat:     &lat,
+			nearest: shouldNotBeCalled,
+			wantNil: true,
+		},
+		{
+			name:    "nearest postcode not found leaves it untouched",
+			lat:     &lat,
+			lng:     &lng,
+			nearest: notFound,
+			wantNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolvePatchLocationID(tt.explicit, tt.lat, tt.lng, tt.nearest)
+			if tt.wantNil {
+				if got != nil {
+					t.Fatalf("resolvePatchLocationID() = %v, want nil", *got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("resolvePatchLocationID() = nil, want %d", tt.wantID)
+			}
+			if *got != tt.wantID {
+				t.Fatalf("resolvePatchLocationID() = %d, want %d", *got, tt.wantID)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Root Cause
`applyPatchMessageCore` (`iznik-server-go/message/message.go`, backing `PATCH /message` and `PATCH /message/tn/:tnpostid`) applies `req.Lat`/`req.Lng` straight to `messages.lat`/`messages.lng` but never re-derives `messages.locationid`. Both the subject-line reconstruction (`constructLocationString`) and the owner/mod-facing location display (`GetMessage`) always prefer `locationid` over raw lat/lng — falling back to lat/lng only when `locationid == 0`. So when a Trash Nothing (TN) edit supplies only corrected coordinates (TN has no concept of Freegle's internal location IDs), `lat`/`lng` update but the stale `locationid` from before the edit keeps winning everywhere the postcode is shown — the postcode appears to "revert" and stays stuck no matter how many times it's corrected. This was introduced in ff8efe130 ("apply lat/lng in PATCH /message"), which added lat/lng persistence for partner edits but never synced `locationid`.

## Evidence
New pure unit test `TestResolvePatchLocationID`, written before the fix, failed to compile because the fix function didn't exist yet — i.e. no code path re-derives `locationid` from lat/lng today:
```
message/message_patch_location_pure_test.go:69:11: undefined: resolvePatchLocationID
FAIL	iznik-server-go/message [build failed]
```
After adding `resolvePatchLocationID` (without yet wiring it into `applyPatchMessageCore`), the test passes, confirming the derivation logic itself is correct:
```
--- PASS: TestResolvePatchLocationID (0.00s)
    --- PASS: TestResolvePatchLocationID/explicit_locationid_wins_over_lat/lng (0.00s)
    --- PASS: TestResolvePatchLocationID/lat/lng_without_locationid_derives_nearest_postcode (0.00s)
    --- PASS: TestResolvePatchLocationID/no_lat,_no_lng,_no_locationid_leaves_it_untouched (0.00s)
    --- PASS: TestResolvePatchLocationID/lat_without_lng_leaves_it_untouched_(incomplete_coordinate_pair) (0.00s)
    --- PASS: TestResolvePatchLocationID/nearest_postcode_not_found_leaves_it_untouched (0.00s)
PASS
```
(This worktree had no isolated Docker/DB stack — see note below — so the AssertFlip was done as a pure unit test against the new helper per the task's fallback guidance, rather than a full DB-backed PATCH request.)

## Fix
Added `resolvePatchLocationID(explicit, lat, lng, nearestPostcode)`: an explicit `locationid` (direct, or resolved from a `location` name) always wins; otherwise, when lat/lng are supplied without a locationid, the nearest postcode is derived via `location.ClosestPostcode` — the same nearest-postcode mechanism already used by the read path (`GetMessage`'s lat/lng fallback) and by TN mail ingestion (`findClosestPostcodeId` in `iznik-batch`). Wired into `applyPatchMessageCore` immediately before the existing `locationid` UPDATE clause. Because `req.Locationid` is now populated whenever lat/lng are supplied, the existing subject-rebuild trigger (`req.Item != nil || req.Type != nil || req.Location != nil || req.Locationid != nil`) fires correctly and rebuilds the subject from the *new* locationid — fixing both reported surfaces (stored/displayed location and the subject line) with one root-cause change.

No frontend caller (`iznik-nuxt3`, `iznik-nuxt3-modtools`) sends `lat`/`lng` on `PATCH /message` — only partner (TN) integrations use those fields, per the original ff8efe130 commit message — so this change is scoped to the TN edit path and doesn't affect native web/app location edits (which use `location`/`locationid`).

## Other Call Sites
Grepped `iznik-server-go` for other `lat`/`lng` writes to `messages`: the only other site is the message-create path (`PutMessage`, message.go:3996), which already derives `lat`/`lng` *from* the given `locationid` (opposite, already-consistent direction) — no fix needed there. TN's create-time location resolution lives in `iznik-batch`'s `IncomingMailService` (email ingestion) and already keeps `locationId` and coordinates in sync — a different, unaffected mechanism.

## Test
- File: `iznik-server-go/message/message_patch_location_pure_test.go`
- Command: `go test ./message/... -run TestResolvePatchLocationID -v`
- Proves fail-before (compile failure, function didn't exist) / pass-after (all 5 table cases pass)
- Full `message` package regression check: `go test ./message/...` — 240 pure tests pass, 0 failures. `go build ./...` and `go vet ./message/...` clean.

## Discourse
https://discourse.ilovefreegle.org/t/9908