### PR TITLE
fix(modtools): don't show cross-group held-by wording on an already-approved copy

### DIFF
--- a/iznik-nuxt3/composables/rippleStatus.js
+++ b/iznik-nuxt3/composables/rippleStatus.js
@@ -148,3 +148,44 @@ export function isHomeGroup(group, groups) {
   const gid = group.groupid ?? group.id
   return gid != null && parseInt(gid) === homeId
 }
+
+function normaliseHeldById(h) {
+  if (h === null || h === undefined) return null
+  if (typeof h === 'object') return h.id ?? null
+  const n = parseInt(h)
+  return Number.isNaN(n) ? null : n
+}
+
+/**
+ * The id of the moderator holding THIS message on THIS group - i.e. the group's own
+ * messages_groups row - never the legacy cross-group messages.heldby, which is set
+ * whenever ANY group holds ANY copy of a rippled post. Reading that legacy field leaked a
+ * hold placed on one group's copy into every other group's view of the same message: a mod
+ * saw their own already-approved copy display "Held by X, check with them before releasing
+ * it" even though their copy was never held (Discourse 9904).
+ *
+ * This is the ONLY place that should read/coerce a message-level heldby - every consumer
+ * (the held-by banner, the Hold/Release button toggle, the confirm-before-acting check)
+ * must call this rather than inspecting message.heldby or a group row directly, so they
+ * can't drift out of sync with each other.
+ *
+ * Returns:
+ *  - a numeric user id if the group's own copy is held
+ *  - null if a matching group row exists and is definitely NOT held
+ *  - undefined if the group's row can't be identified at all (message still loading, or
+ *    groupid doesn't correspond to any group the post is on) - callers must not guess who
+ *    holds it in this case, since that mod may be on a group the reader can't act on.
+ *
+ * @param {{groups?: Array<{groupid:number|string, heldby?:number|string|{id:number}|null}>}} message
+ * @param {number|string} groupid
+ * @returns {number|null|undefined}
+ */
+export function messageGroupHeldById(message, groupid) {
+  const groups = message?.groups
+  if (!Array.isArray(groups) || !groups.length) return undefined
+  const gid = parseInt(groupid)
+  if (Number.isNaN(gid)) return undefined
+  const row = groups.find((g) => parseInt(g.groupid) === gid)
+  if (!row) return undefined
+  return normaliseHeldById(row.heldby)
+}

--- a/iznik-nuxt3/modtools/components/ModMessage.vue
+++ b/iznik-nuxt3/modtools/components/ModMessage.vue
@@ -323,7 +323,7 @@
                 at
                 {{ datetimeshort(message.outcomes[0].timestamp) }}
               </NoticeMessage>
-              <div v-if="message.heldby">
+              <div v-if="heldByThisGroup">
                 <NoticeMessage variant="warning" class="mb-2">
                   <p v-if="me.id === heldbyId">
                     You held this. Other people will see a warning to check with
@@ -342,6 +342,13 @@
                     release
                     label="Release"
                   />
+                </NoticeMessage>
+              </div>
+              <div v-else-if="heldByUnknownGroup">
+                <NoticeMessage variant="warning" class="mb-2">
+                  <p>
+                    Held on another group. Please check before releasing it.
+                  </p>
                 </NoticeMessage>
               </div>
             </div>
@@ -721,7 +728,7 @@
         </b-row>
       </b-card-body>
       <b-card-footer v-if="!noactions && expanded">
-        <div v-if="message.heldby && heldbyId !== myid">
+        <div v-if="heldAndNotByMe">
           This message is held by someone else. The buttons are hidden so you
           don't click them by accident. Please check with them before releasing
           the message.
@@ -734,11 +741,7 @@
           This message needs editing so that we know where it is.
         </NoticeMessage>
         <div
-          v-if="
-            pending &&
-            (!message.heldby || (message.heldby && heldbyId === myid)) &&
-            !editing
-          "
+          v-if="pending && !heldAndNotByMe && !editing"
           class="text-end mb-1"
         >
           <b-button variant="danger" @click="spamReport">
@@ -746,10 +749,7 @@
           </b-button>
         </div>
         <ModMessageButtons
-          v-if="
-            (!message.heldby || (message.heldby && heldbyId === myid)) &&
-            !editing
-          "
+          v-if="!heldAndNotByMe && !editing"
           :messageid="message.id"
           :groupid="currentGroupid"
           :modconfigid="configid"
@@ -832,6 +832,7 @@ import {
   isRippledInToContextGroup as isRippledIn,
   earliestArrivalGroupId,
   homeGroupId,
+  messageGroupHeldById,
 } from '~/composables/rippleStatus'
 
 const props = defineProps({
@@ -1113,7 +1114,9 @@ const isRippledInToContextGroup = computed(() =>
 // (both fields non-null) when the routing server said quicker=true at ripple-in time.
 const rippleProximity = computed(() => {
   const gid = currentGroupid.value
-  const g = (message.value?.groups || []).find((row) => parseInt(row.groupid) === gid)
+  const g = (message.value?.groups || []).find(
+    (row) => parseInt(row.groupid) === gid
+  )
   if (g?.ripple_proximity_p && g?.ripple_proximity_q) {
     return { p: g.ripple_proximity_p, q: g.ripple_proximity_q }
   }
@@ -1177,23 +1180,43 @@ const eBody = computed(() => {
   return twem(message.value.textbody)
 })
 
-// Handle heldby as either numeric ID (Go API) or object (PHP API).
+// Held state for the group this copy is being administered on - i.e. this group's own
+// messages_groups row, never the legacy cross-group messages.heldby, which is set whenever
+// ANY group holds ANY copy of a rippled post. Reading that legacy field leaked a hold placed
+// on one group's copy into every other group's (already-approved, unheld) view of the same
+// message (Discourse 9904).
+const heldByThisGroupResult = computed(() =>
+  messageGroupHeldById(message.value, currentGroupid.value)
+)
+
+const heldByThisGroup = computed(
+  () => typeof heldByThisGroupResult.value === 'number'
+)
+
+// Fail-safe fallback: we couldn't identify this group's own row at all (message still
+// loading, or currentGroupid doesn't correspond to any group on the post), but the legacy
+// field says it's held somewhere. We deliberately don't name a holder here - they may be a
+// moderator on a group this reader can't act on or even see.
+const heldByUnknownGroup = computed(
+  () =>
+    heldByThisGroupResult.value === undefined && Boolean(message.value?.heldby)
+)
+
 const heldbyId = computed(() => {
-  if (!message.value) return null
-  const h = message.value.heldby
-  if (!h) return null
-  return Number.isInteger(h) ? h : h.id
+  return heldByThisGroup.value ? heldByThisGroupResult.value : null
 })
 
 const heldbyName = computed(() => {
-  if (!message.value) return ''
-  const h = message.value.heldby
-  if (!h) return ''
-  if (Number.isInteger(h)) {
-    const user = userStore.byId(h)
-    return user?.displayname || ''
-  }
-  return h.displayname || ''
+  if (!heldByThisGroup.value) return ''
+  const user = userStore.byId(heldbyId.value)
+  return user?.displayname || ''
+})
+
+// Should action buttons be hidden because this group's own copy is held by somebody
+// else (or, in the fail-safe fallback, might be)?
+const heldAndNotByMe = computed(() => {
+  if (heldByThisGroup.value) return heldbyId.value !== myid.value
+  return heldByUnknownGroup.value
 })
 
 const membership = computed(() => {
@@ -1443,9 +1466,9 @@ onMounted(() => {
       : []
     findHomeGroup()
 
-    // Fetch heldby user if message is held (Go API returns numeric ID).
-    if (message.value.heldby && Number.isInteger(message.value.heldby)) {
-      userStore.fetch(message.value.heldby)
+    // Fetch heldby user if this group's own copy is held (Go API returns numeric ID).
+    if (heldByThisGroup.value) {
+      userStore.fetch(heldbyId.value)
     }
   }
 })

--- a/iznik-nuxt3/modtools/components/ModMessageButton.vue
+++ b/iznik-nuxt3/modtools/components/ModMessageButton.vue
@@ -59,8 +59,8 @@
           community where it was first posted.
         </p>
         <p class="mb-0">
-          The freegler won't be told, because they don't need to know unless it's
-          rejected on their home community. So there's no message to send.
+          The freegler won't be told, because they don't need to know unless
+          it's rejected on their home community. So there's no message to send.
         </p>
       </template>
     </ConfirmModal>
@@ -74,6 +74,7 @@ import { useMessageStore } from '~/stores/message'
 import { useStdmsgStore } from '~/stores/stdmsg'
 import { useUserStore } from '~/stores/user'
 import { useModMe } from '~/composables/useModMe'
+import { messageGroupHeldById } from '~/composables/rippleStatus'
 
 const props = defineProps({
   messageid: {
@@ -239,7 +240,13 @@ const spinclass = computed(() => {
 
 const confirmButton = computed(() => {
   // We confirm any actions on held messages, except where we have a separate confirm.
-  return message.value?.heldby && !props.spam && !props.delete
+  // Scoped to THIS group's own row - never the legacy cross-group message.heldby, which
+  // is set whenever ANY group holds ANY copy of a rippled post (Discourse 9904).
+  return (
+    typeof messageGroupHeldById(message.value, groupid.value) === 'number' &&
+    !props.spam &&
+    !props.delete
+  )
 })
 
 async function approveIt() {

--- a/iznik-nuxt3/modtools/components/ModMessageButtons.vue
+++ b/iznik-nuxt3/modtools/components/ModMessageButtons.vue
@@ -55,7 +55,7 @@
         label="Delete"
       />
       <ModMessageButton
-        v-if="!message.heldby"
+        v-if="!heldByThisGroup"
         :messageid="message.id"
         :groupid="groupid"
         variant="warning"
@@ -186,6 +186,7 @@ import { ref, computed, watch } from 'vue'
 import { useMessageStore } from '~/stores/message'
 import { useModConfigStore } from '~/stores/modconfig'
 import { copyStdMsgs, icon, variant } from '~/composables/useStdMsgs'
+import { messageGroupHeldById } from '~/composables/rippleStatus'
 
 const props = defineProps({
   messageid: {
@@ -259,6 +260,12 @@ function hasCollection(coll) {
 
 const pending = computed(() => {
   return hasCollection('Pending')
+})
+
+// Whether THIS group's own copy is held - never the legacy cross-group message.heldby,
+// which is set whenever ANY group holds ANY copy of a rippled post (Discourse 9904).
+const heldByThisGroup = computed(() => {
+  return typeof messageGroupHeldById(message.value, props.groupid) === 'number'
 })
 
 const approved = computed(() => {

--- a/iznik-nuxt3/tests/unit/components/modtools/ModMessage.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModMessage.spec.js
@@ -452,7 +452,11 @@ describe('ModMessage', () => {
         {
           spamreason: 'Flagged as spam',
           groups: [
-            { groupid: 789, collection: 'Pending', spamreason: 'Flagged as spam' },
+            {
+              groupid: 789,
+              collection: 'Pending',
+              spamreason: 'Flagged as spam',
+            },
           ],
         }
       )
@@ -826,12 +830,23 @@ describe('ModMessage', () => {
 
   describe('Held message', () => {
     it('shows release button when held, warning when held by someone else', async () => {
+      // Held state is scoped to THIS group's own row (groupid 789, matching
+      // authStore/myModGroups) - not the legacy top-level message.heldby
+      // (Discourse 9904).
       const wrapper1 = mountComponent(
         {
           summary: false,
         },
         {
-          heldby: { id: 999, displayname: 'Test Mod' },
+          heldby: 999,
+          groups: [
+            {
+              groupid: 789,
+              namedisplay: 'Test Group',
+              collection: 'Pending',
+              heldby: 999,
+            },
+          ],
         }
       )
       await wrapper1.vm.$nextTick()
@@ -842,11 +857,66 @@ describe('ModMessage', () => {
           summary: false,
         },
         {
-          heldby: { id: 888, displayname: 'Other Mod' },
+          heldby: 888,
+          groups: [
+            {
+              groupid: 789,
+              namedisplay: 'Test Group',
+              collection: 'Pending',
+              heldby: { id: 888, displayname: 'Other Mod' },
+            },
+          ],
         }
       )
       await wrapper2.vm.$nextTick()
       expect(wrapper2.text()).toContain('Held by')
+    })
+
+    it('does not show a held banner when this group is unheld even though the legacy cross-group message.heldby is set by a rippled-to group holding its own copy (Discourse 9904)', async () => {
+      const wrapper = mountComponent(
+        {
+          summary: false,
+        },
+        {
+          heldby: 888,
+          groups: [
+            {
+              groupid: 789,
+              namedisplay: 'Test Group',
+              collection: 'Approved',
+              heldby: null,
+            },
+            {
+              groupid: 790,
+              namedisplay: 'Other Group',
+              collection: 'Pending',
+              heldby: { id: 888, displayname: 'Other Mod' },
+            },
+          ],
+        }
+      )
+      await wrapper.vm.$nextTick()
+      expect(wrapper.text()).not.toContain('Held by')
+      expect(wrapper.text()).not.toContain('Held on another group')
+    })
+
+    it('fails safe with generic wording (no named mod) when this group cannot be identified at all but the legacy field says it is held somewhere', async () => {
+      // Defensive fallback only: no group rows to match against (e.g. still loading), but
+      // the legacy cross-group field says SOME copy is held. We must not guess which mod -
+      // they may not be on a group this reader can act on.
+      const wrapper = mountComponent(
+        {
+          summary: false,
+        },
+        {
+          heldby: 888,
+          groups: [],
+        }
+      )
+      await wrapper.vm.$nextTick()
+      expect(wrapper.text()).toContain('Held on another group')
+      expect(wrapper.text()).not.toContain('Held by')
+      expect(wrapper.text()).not.toContain('Other Mod')
     })
   })
 
@@ -1238,7 +1308,15 @@ describe('ModMessage', () => {
       const wrapper2 = mountComponent(
         { summary: false },
         {
-          heldby: { id: 888, displayname: 'Other Mod' },
+          heldby: 888,
+          groups: [
+            {
+              groupid: 789,
+              namedisplay: 'Test Group',
+              collection: 'Pending',
+              heldby: { id: 888, displayname: 'Other Mod' },
+            },
+          ],
         }
       )
       await wrapper2.vm.$nextTick()
@@ -1408,7 +1486,12 @@ describe('ModMessage', () => {
         { contextGroupid: 789 },
         {
           groups: [
-            { groupid: 999, namedisplay: 'Origin', collection: 'Approved', arrival: rippleEarlier },
+            {
+              groupid: 999,
+              namedisplay: 'Origin',
+              collection: 'Approved',
+              arrival: rippleEarlier,
+            },
             {
               groupid: 789,
               namedisplay: 'Context',
@@ -1433,7 +1516,12 @@ describe('ModMessage', () => {
         { contextGroupid: 789 },
         {
           groups: [
-            { groupid: 999, namedisplay: 'Origin', collection: 'Approved', arrival: rippleEarlier },
+            {
+              groupid: 999,
+              namedisplay: 'Origin',
+              collection: 'Approved',
+              arrival: rippleEarlier,
+            },
             {
               groupid: 789,
               namedisplay: 'Context',
@@ -1446,9 +1534,9 @@ describe('ModMessage', () => {
         }
       )
       expect(wrapper.vm.isRippledInToContextGroup).toBe(true)
-      expect(
-        wrapper.find('[data-test="ripple-proximity-note"]').exists()
-      ).toBe(false)
+      expect(wrapper.find('[data-test="ripple-proximity-note"]').exists()).toBe(
+        false
+      )
     })
 
     it('does not warn when the post has not rippled in', () => {

--- a/iznik-nuxt3/tests/unit/components/modtools/ModMessageButton.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModMessageButton.spec.js
@@ -186,23 +186,49 @@ describe('ModMessageButton', () => {
   })
 
   describe('confirmButton computed', () => {
+    // Held state must be scoped to THIS group's own row (groupid 456, the default group
+    // resolved when no groupid prop is given) - not the legacy top-level message.heldby,
+    // which is set whenever ANY group holds ANY copy of a rippled post (Discourse 9904).
     it('returns true when message is held and action is not spam or delete', () => {
-      const wrapper = mountComponent({ approve: true }, { heldby: { id: 1 } })
+      const wrapper = mountComponent(
+        { approve: true },
+        { groups: [{ groupid: 456, collection: 'Pending', heldby: { id: 1 } }] }
+      )
       expect(wrapper.vm.confirmButton).toBe(true)
     })
 
     it('returns false when message is held but action is spam', () => {
-      const wrapper = mountComponent({ spam: true }, { heldby: { id: 1 } })
+      const wrapper = mountComponent(
+        { spam: true },
+        { groups: [{ groupid: 456, collection: 'Pending', heldby: { id: 1 } }] }
+      )
       expect(wrapper.vm.confirmButton).toBe(false)
     })
 
     it('returns false when message is held but action is delete', () => {
-      const wrapper = mountComponent({ delete: true }, { heldby: { id: 1 } })
+      const wrapper = mountComponent(
+        { delete: true },
+        { groups: [{ groupid: 456, collection: 'Pending', heldby: { id: 1 } }] }
+      )
       expect(wrapper.vm.confirmButton).toBe(false)
     })
 
     it('returns falsy when message is not held', () => {
       const wrapper = mountComponent({ approve: true }, { heldby: null })
+      expect(wrapper.vm.confirmButton).toBeFalsy()
+    })
+
+    it('does not confirm when a DIFFERENT group holds its own copy (Discourse 9904)', () => {
+      const wrapper = mountComponent(
+        { approve: true, groupid: 456 },
+        {
+          heldby: 1,
+          groups: [
+            { groupid: 456, collection: 'Approved', heldby: null },
+            { groupid: 789, collection: 'Pending', heldby: { id: 1 } },
+          ],
+        }
+      )
       expect(wrapper.vm.confirmButton).toBeFalsy()
     })
   })
@@ -254,7 +280,10 @@ describe('ModMessageButton', () => {
     it('calls messageStore.hold when hold prop is true', async () => {
       const wrapper = mountComponent({ hold: true }, { id: 555 })
       await wrapper.vm.click()
-      expect(mockMessageStore.hold).toHaveBeenCalledWith({ id: 555, groupid: 456 })
+      expect(mockMessageStore.hold).toHaveBeenCalledWith({
+        id: 555,
+        groupid: 456,
+      })
     })
 
     it('calls checkWorkDeferGetMessages after hold', async () => {
@@ -268,7 +297,10 @@ describe('ModMessageButton', () => {
     it('calls messageStore.release when release prop is true', async () => {
       const wrapper = mountComponent({ release: true }, { id: 666 })
       await wrapper.vm.click()
-      expect(mockMessageStore.release).toHaveBeenCalledWith({ id: 666, groupid: 456 })
+      expect(mockMessageStore.release).toHaveBeenCalledWith({
+        id: 666,
+        groupid: 456,
+      })
     })
 
     it('calls checkWorkDeferGetMessages after release', async () => {

--- a/iznik-nuxt3/tests/unit/components/modtools/ModMessageButtons.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModMessageButtons.spec.js
@@ -224,24 +224,43 @@ describe('ModMessageButtons', () => {
 
     it('shows hold button for pending messages without heldby', () => {
       const wrapper = mountComponent(
-        {},
+        { groupid: 456 },
         {
-          groups: [{ groupid: 456, collection: 'Pending' }],
+          groups: [{ groupid: 456, collection: 'Pending', heldby: null }],
           heldby: null,
         }
       )
       expect(wrapper.find('.mod-message-button.hold').exists()).toBe(true)
     })
 
-    it('hides hold button when message is held', () => {
+    it('hides hold button when message is held on this group', () => {
       const wrapper = mountComponent(
-        {},
+        { groupid: 456 },
         {
-          groups: [{ groupid: 456, collection: 'Pending' }],
+          groups: [{ groupid: 456, collection: 'Pending', heldby: { id: 1 } }],
           heldby: { id: 1 },
         }
       )
       expect(wrapper.find('.mod-message-button.hold').exists()).toBe(false)
+      expect(wrapper.find('.mod-message-button.release').exists()).toBe(true)
+    })
+
+    it('offers Hold (not Release) when a DIFFERENT group holds its own copy - the exact Discourse 9904 scenario', () => {
+      // My group's copy (10) is unheld; another group's copy (20) rippled to and is
+      // held there. The legacy message.heldby is set globally, but must not leak into
+      // my group's Hold/Release toggle.
+      const wrapper = mountComponent(
+        { groupid: 10 },
+        {
+          heldby: { id: 1 },
+          groups: [
+            { groupid: 10, collection: 'Pending', heldby: null },
+            { groupid: 20, collection: 'Pending', heldby: { id: 1 } },
+          ],
+        }
+      )
+      expect(wrapper.find('.mod-message-button.hold').exists()).toBe(true)
+      expect(wrapper.find('.mod-message-button.release').exists()).toBe(false)
     })
 
     it('shows spam button for pending messages', () => {

--- a/iznik-nuxt3/tests/unit/composables/rippleStatus.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/rippleStatus.spec.js
@@ -6,6 +6,7 @@ import {
   homeGroupFirst,
   isHomeGroup,
   RIPPLE_ORIGIN_WINDOW_MS,
+  messageGroupHeldById,
 } from '~/composables/rippleStatus'
 
 // Helper: an ISO arrival N minutes after a fixed base.
@@ -359,5 +360,64 @@ describe('isHomeGroup', () => {
     expect(isHomeGroup(null, groups)).toBe(false)
     expect(isHomeGroup({ groupid: 1 }, [])).toBe(false)
     expect(isHomeGroup({ groupid: 1 }, null)).toBe(false)
+  })
+})
+
+describe('messageGroupHeldById (Discourse 9904)', () => {
+  it("returns null when this group's own row is not held, even though another group holds its copy", () => {
+    // The exact 9904 scenario: my group's copy was approved (heldby null), but the post
+    // rippled to another group whose copy is held. The legacy message.heldby is set (some
+    // copy is held somewhere) but must never leak into my group's result.
+    const message = {
+      heldby: 1,
+      groups: [
+        { groupid: 10, heldby: null },
+        { groupid: 20, heldby: 1 },
+      ],
+    }
+    expect(messageGroupHeldById(message, 10)).toBeNull()
+  })
+
+  it("returns the holder id when this group's own row is held", () => {
+    const message = {
+      heldby: 1,
+      groups: [
+        { groupid: 10, heldby: null },
+        { groupid: 20, heldby: 1 },
+      ],
+    }
+    expect(messageGroupHeldById(message, 20)).toBe(1)
+  })
+
+  it('coerces a numeric-string groupid and a numeric-string heldby identically', () => {
+    const message = {
+      groups: [{ groupid: '20', heldby: '7' }],
+    }
+    expect(messageGroupHeldById(message, '20')).toBe(7)
+    expect(messageGroupHeldById(message, 20)).toBe(7)
+  })
+
+  it('coerces an object-shaped heldby ({id}) to its numeric id', () => {
+    const message = {
+      groups: [{ groupid: 20, heldby: { id: 5 } }],
+    }
+    expect(messageGroupHeldById(message, 20)).toBe(5)
+  })
+
+  it('returns undefined (not a guessed holder) when no row matches the groupid', () => {
+    const message = {
+      heldby: 1,
+      groups: [{ groupid: 20, heldby: 1 }],
+    }
+    expect(messageGroupHeldById(message, 30)).toBeUndefined()
+  })
+
+  it('returns undefined for missing/empty groups or unresolvable groupid', () => {
+    expect(messageGroupHeldById({ groups: [] }, 10)).toBeUndefined()
+    expect(messageGroupHeldById({}, 10)).toBeUndefined()
+    expect(messageGroupHeldById(null, 10)).toBeUndefined()
+    expect(
+      messageGroupHeldById({ groups: [{ groupid: 10, heldby: 1 }] }, null)
+    ).toBeUndefined()
   })
 })

--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -224,7 +224,14 @@ type Message struct {
 	Locationid         uint64              `json:"-"`
 	Location           *location.Location  `json:"location,omitempty" gorm:"-"`
 	Item               *item.Item          `json:"item" gorm:"-"`
-	Heldby           *uint64    `json:"heldby"`
+	// Heldby is the legacy cross-group hold field: it's set whenever ANY group holds ANY
+	// copy of a rippled post, so it can't tell a moderator whether THEIR group's copy is
+	// held. It's deliberately not serialised - callers must use groups[].heldby (this
+	// message's per-group MessageGroup rows), which is scoped to the exact group. Serving
+	// this field let a hold placed on one group's copy leak into every other group's view
+	// of the same message, showing an already-approved copy as held by an unrelated
+	// moderator on an unrelated group (Discourse 9904).
+	Heldby           *uint64    `json:"-"`
 	Source           *string    `json:"source"`
 	Sourceheader     *string    `json:"sourceheader"`
 	Fromaddr         *string    `json:"fromaddr"`

--- a/iznik-server-go/test/message_test.go
+++ b/iznik-server-go/test/message_test.go
@@ -8751,6 +8751,60 @@ func TestListMessagesGroupsIncludesHeldby(t *testing.T) {
 	assert.True(t, found, "Message should appear in list")
 }
 
+// Regression: a moderator's already-approved copy of a rippled post must not show as held
+// just because a DIFFERENT group's copy of the same post is held. The GET /api/message/:id
+// payload used to include the legacy cross-group messages.heldby field, which is set
+// whenever ANY group holds ANY copy - so a mod on the (unheld, approved) origin group saw
+// their copy displayed as held by a moderator on the group that rippled it in and held it
+// there. The fix removes that field from the payload; every caller must use the per-group
+// groups[].heldby, which is correctly scoped (Discourse 9904).
+func TestGetMessageOmitsLegacyCrossGroupHeldby(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("msg_crossheld")
+
+	groupA := CreateTestGroup(t, prefix+"_a") // mine: approved, unheld
+	groupB := CreateTestGroup(t, prefix+"_b") // rippled-to: held
+	posterID := CreateTestUser(t, prefix+"_poster", "User")
+	modID := CreateTestUser(t, prefix+"_mod", "Moderator")
+	otherModID := CreateTestUser(t, prefix+"_othermod", "Moderator")
+	CreateTestMembership(t, posterID, groupA, "Member")
+	CreateTestMembership(t, modID, groupA, "Moderator")
+	_, modToken := CreateTestSession(t, modID)
+
+	msgID := CreateTestMessage(t, posterID, groupA, prefix+" Test Item", 55.9533, -3.1883)
+	db.Exec("INSERT INTO messages_groups (msgid, groupid, arrival, collection, autoreposts, heldby) "+
+		"VALUES (?, ?, NOW(), 'Pending', 0, ?)", msgID, groupB, otherModID)
+	// handleHold also mirrors the hold onto the legacy message-level field - simulate that.
+	db.Exec("UPDATE messages SET heldby = ? WHERE id = ?", otherModID, msgID)
+
+	resp, err := getApp().Test(httptest.NewRequest("GET", fmt.Sprintf("/api/message/%d?jwt=%s", msgID, modToken), nil))
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var raw map[string]interface{}
+	json2.Unmarshal(rsp(resp), &raw)
+
+	_, hasHeldby := raw["heldby"]
+	assert.False(t, hasHeldby, "response must not expose the legacy cross-group messages.heldby field")
+
+	groups, ok := raw["groups"].([]interface{})
+	require.True(t, ok, "response should include groups")
+	var sawA, sawB bool
+	for _, gi := range groups {
+		g := gi.(map[string]interface{})
+		switch uint64(g["groupid"].(float64)) {
+		case groupA:
+			sawA = true
+			assert.Nil(t, g["heldby"], "group A's own copy is not held and must not appear held")
+		case groupB:
+			sawB = true
+			assert.Equal(t, float64(otherModID), g["heldby"], "group B's copy is held by otherModID")
+		}
+	}
+	assert.True(t, sawA, "group A should be present")
+	assert.True(t, sawB, "group B should be present")
+}
+
 // Cross-group authorization tests: a mod of group A must not be able to
 // perform moderation actions on a message that's only on group B, even
 // though the message is visible to them (because they mod one of its groups).


### PR DESCRIPTION
## Root Cause
ModTools read the legacy, cross-group `messages.heldby` field to decide whether the message being viewed was held - instead of the per-group `messages_groups.heldby` row for the group actually being moderated. That legacy field is set whenever **any** group holds **any** copy of a rippled post, so a mod who approved a post on their own group, which then rippled to another group and was held/rejected there, saw their own (Approved, unheld) copy display "Held by X. Please check with them before releasing it" - nonsensical, since their copy was never held. The same unscoped field also drove the Hold/Release button toggle and the "confirm before acting" check, so a mod could in principle be offered Release for a copy that was never held on their group.

This is a fresh re-attempt of a previously-blocked PR (#1065, closed). That review found: the Release/unhold gate in `ModMessageButtons.vue` was left on the legacy field (so Hold+Release could render together); the heldby→id coercion was duplicated and inconsistent between components; `ModMessageButtons.vue` had no direct test coverage; the fail-safe fallback named an arbitrary, possibly-unreachable mod; and the Go API still served the cross-group field, so every reader (present and future) inherited the bug. All five are addressed below.

## Evidence
AssertFlip - reverted the four production files (composable + 3 components), kept only the new/updated tests, ran the affected specs:
```
Test Files  4 failed | 1 passed (5)
     Tests  12 failed | 221 passed (233)

 FAIL  tests/unit/composables/rippleStatus.spec.js > messageGroupHeldById (Discourse 9904) > returns null when this group's own row is not held, even though another group holds its copy
 FAIL  tests/unit/composables/rippleStatus.spec.js > messageGroupHeldById (Discourse 9904) > returns the holder id when this group's own row is held
 FAIL  tests/unit/composables/rippleStatus.spec.js > messageGroupHeldById (Discourse 9904) > coerces a numeric-string groupid and a numeric-string heldby identically
 FAIL  tests/unit/composables/rippleStatus.spec.js > messageGroupHeldById (Discourse 9904) > coerces an object-shaped heldby ({id}) to its numeric id
 FAIL  tests/unit/composables/rippleStatus.spec.js > messageGroupHeldById (Discourse 9904) > returns undefined (not a guessed holder) when no row matches the groupid
 FAIL  tests/unit/composables/rippleStatus.spec.js > messageGroupHeldById (Discourse 9904) > returns undefined for missing/empty groups or unresolvable groupid
 FAIL  tests/unit/components/modtools/ModMessage.spec.js > ModMessage > Held message > does not show a held banner when this group is unheld even though the legacy cross-group message.heldby is set by a rippled-to group holding its own copy (Discourse 9904)
 FAIL  tests/unit/components/modtools/ModMessageButton.spec.js > ModMessageButton > confirmButton computed > returns true when message is held and action is not spam or delete
 FAIL  tests/unit/components/modtools/ModMessageButton.spec.js > ModMessageButton > confirmButton computed > returns false when message is held but action is spam
 FAIL  tests/unit/components/modtools/ModMessageButton.spec.js > ModMessageButton > confirmButton computed > returns false when message is held but action is delete
 FAIL  tests/unit/components/modtools/ModMessageButton.spec.js > ModMessageButton > confirmButton computed > does not confirm when a DIFFERENT group holds its own copy (Discourse 9904)
 FAIL  tests/unit/components/modtools/ModMessageButtons.spec.js > ModMessageButtons > pending message buttons > offers Hold (not Release) when a DIFFERENT group holds its own copy - the exact Discourse 9904 scenario
```
All fail on the pre-fix (reverted) code; all pass once the fix is restored. Full local run after restoring: `npx vitest run tests/unit/` → `Test Files 669 passed (669)` / `Tests 14284 passed | 4 skipped (14288)` - no regressions.

Go side: `go build ./...` and `go vet ./message/...` are clean, and the new Go test (`TestGetMessageOmitsLegacyCrossGroupHeldby`) compiles (`go test ./test/... -run TestGetMessageOmitsLegacyCrossGroupHeldby -c`). I could not run the Go suite against a live DB in this sandboxed session (no bound MySQL test instance was safely reachable without touching another active worktree's shared containers) - CI will run the full Go suite on this PR before merge, per the usual gate.

## Fix
- **`composables/rippleStatus.js`**: added `messageGroupHeldById(message, groupid)` - the single place that finds the matching `messages_groups` row for the group in context and coerces `heldby` (numeric, numeric-string, or `{id}` object) to a plain user id. Returns `null` when that group's row is confirmed unheld, `undefined` when the row can't be identified at all (never guesses).
- **`ModMessage.vue`**: `heldbyId`/`heldbyName`/the held banner/the button-hiding logic all now derive from `messageGroupHeldById(message.value, currentGroupid.value)` instead of `message.heldby`. Added a narrow, distinct fallback (`heldByUnknownGroup`) for when the group's own row genuinely can't be resolved (e.g. still loading) but the legacy field says it's held somewhere - shows generic "Held on another group" copy, naming no one, rather than an arbitrary (possibly unreachable) mod.
- **`ModMessageButtons.vue`**: the Hold/Release toggle (`heldByThisGroup`) now uses the same helper. Hold and Release are rendered via `v-if`/`v-else` on one boolean, so they're structurally mutually exclusive - fixes the previous attempt's gap where Release stayed on the legacy field.
- **`ModMessageButton.vue`**: `confirmButton` (extra confirm-before-acting dialog) now uses the same helper too, so it can't drift from the other two.
- **`iznik-server-go/message/message.go`**: the single-message `Message.Heldby` field (the cross-group `messages.heldby` column) is no longer serialised (`json:"-"`) - root-caused server-side so every current and future JSON consumer is forced onto the correctly-scoped `groups[].heldby`.

## Other Call Sites
Grepped `heldby` across `iznik-nuxt3` (not just `modtools`) for every message-related consumer:
- `ModMessage.vue` (banner text, button-hiding, `heldbyId`/`heldbyName`, the held-user fetch in `onMounted`) - fixed.
- `ModMessageButtons.vue` (`heldByThisGroup`, gates Hold vs Release) - fixed.
- `ModMessageButton.vue` (`confirmButton`) - fixed.
- `ModMessages.vue` and the pending-queue list views don't reference `heldby` at all.
- `member.heldby` / `membership.heldby` / `admin.heldby` (`ModMember.vue`, `ModMemberButtons.vue`, `ModMemberReviewActions.vue`, `ModAdmin.vue`, `stores/spammer.js`, `stores/member.js`) are unrelated: those rows are inherently per-object with no rippling/multi-group concept, so they don't share this bug - left untouched.
- Go: `message_list.go`'s `MessageGroupInfo.Heldby` (used by the list/queue endpoint) was already correctly per-group - no change needed there. Only the single-message `Message.Heldby` (used by `GET /api/message/:ids`, which the frontend calls via `messageStore.fetch`/`fetchMT`) carried the cross-group leak.

## Test
- Files: `iznik-nuxt3/tests/unit/composables/rippleStatus.spec.js`, `tests/unit/components/modtools/ModMessage.spec.js`, `tests/unit/components/modtools/ModMessageButtons.spec.js`, `tests/unit/components/modtools/ModMessageButton.spec.js`, `iznik-server-go/test/message_test.go` (`TestGetMessageOmitsLegacyCrossGroupHeldby`).
- Command: `npx vitest run tests/unit/` (whole unit suite) - `669 passed (669)` files, `14284 passed | 4 skipped` tests.
- Proves fail-before/pass-after via AssertFlip (see Evidence above).

## Discourse
https://discourse.ilovefreegle.org/t/9904