### PR TITLE
fix(chat): dedupe chat sends server-side via a client idempotency key

### DIFF
--- a/iznik-batch/database/migrations/2026_07_14_000001_add_idempotency_key_to_chat_messages.php
+++ b/iznik-batch/database/migrations/2026_07_14_000001_add_idempotency_key_to_chat_messages.php
@@ -1,0 +1,71 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * chat_messages.idempotencykey (+ unique index) - lets CreateChatMessage
+ * (iznik-server-go/chat/chatmessage.go) collapse a retried/duplicated POST (a client
+ * retry on an ambiguous fetch outcome, a double-click, a second tab) onto the SAME row
+ * via INSERT ... ON DUPLICATE KEY UPDATE id = LAST_INSERT_ID(id), instead of creating a
+ * second chat_messages row that briefly shows twice to the sender (Discourse #9913).
+ *
+ * Nullable: MySQL never treats two NULLs as equal in a unique index, so older clients
+ * that send no key are completely unaffected - no backfill needed.
+ *
+ * ALGORITHM=INPLACE, LOCK=NONE - same Galera-safe pattern as the existing chat_messages
+ * enum-widening migration (2026_05_27_000001_widen_chat_messages_reportreason_enum).
+ * chat_messages is a large, high-traffic production table; an online ADD COLUMN + ADD
+ * INDEX avoids a full table rebuild/lock. Guarded on BOTH the column and the index (not
+ * just the column) so a partial prior run - e.g. the column landed but the index DDL
+ * failed/was interrupted - is completed rather than skipped on re-run.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (!Schema::hasTable('chat_messages')) {
+            return;
+        }
+
+        if (!Schema::hasColumn('chat_messages', 'idempotencykey')) {
+            DB::statement("
+                ALTER TABLE chat_messages
+                  ADD COLUMN idempotencykey VARCHAR(64) NULL AFTER message,
+                  ALGORITHM=INPLACE, LOCK=NONE
+            ");
+        }
+
+        $indexExists = DB::selectOne(
+            "SELECT COUNT(*) AS n FROM information_schema.statistics
+             WHERE table_schema = DATABASE() AND table_name = 'chat_messages' AND index_name = 'chat_messages_idempotency_unique'"
+        );
+        if ((int) ($indexExists->n ?? 0) === 0) {
+            DB::statement("
+                ALTER TABLE chat_messages
+                  ADD UNIQUE INDEX chat_messages_idempotency_unique (chatid, userid, idempotencykey),
+                  ALGORITHM=INPLACE, LOCK=NONE
+            ");
+        }
+    }
+
+    public function down(): void
+    {
+        if (!Schema::hasTable('chat_messages')) {
+            return;
+        }
+
+        $indexExists = DB::selectOne(
+            "SELECT COUNT(*) AS n FROM information_schema.statistics
+             WHERE table_schema = DATABASE() AND table_name = 'chat_messages' AND index_name = 'chat_messages_idempotency_unique'"
+        );
+        if ((int) ($indexExists->n ?? 0) > 0) {
+            DB::statement('ALTER TABLE chat_messages DROP INDEX chat_messages_idempotency_unique, ALGORITHM=INPLACE, LOCK=NONE');
+        }
+
+        if (Schema::hasColumn('chat_messages', 'idempotencykey')) {
+            DB::statement('ALTER TABLE chat_messages DROP COLUMN idempotencykey, ALGORITHM=INPLACE, LOCK=NONE');
+        }
+    }
+};

--- a/iznik-batch/database/migrations/2026_07_14_000001_add_idempotency_key_to_chat_messages_migration.sql
+++ b/iznik-batch/database/migrations/2026_07_14_000001_add_idempotency_key_to_chat_messages_migration.sql
@@ -1,0 +1,22 @@
+-- Production idempotent SQL: chat_messages.idempotencykey (+ unique index), Discourse #9913.
+-- Lets CreateChatMessage (iznik-server-go/chat/chatmessage.go) collapse a retried/duplicated
+-- chat-send POST onto the same row via INSERT ... ON DUPLICATE KEY UPDATE id = LAST_INSERT_ID(id)
+-- instead of creating a second row. Nullable column: NULLs never collide in a unique index, so
+-- older clients that send no key are unaffected - no backfill needed.
+-- Online DDL (ALGORITHM=INPLACE, LOCK=NONE) - same Galera-safe pattern as the existing
+-- chat_messages enum-widening migration (2026_05_27_000001). Guarded on BOTH the column and the
+-- index (not just the column) so a re-run - including a partial prior run - is a no-op/completion.
+
+SET @col_exists := (SELECT COUNT(*) FROM information_schema.columns
+    WHERE table_schema = DATABASE() AND table_name = 'chat_messages' AND column_name = 'idempotencykey');
+SET @ddl := IF(@col_exists = 0,
+    'ALTER TABLE chat_messages ADD COLUMN idempotencykey VARCHAR(64) NULL AFTER message, ALGORITHM=INPLACE, LOCK=NONE',
+    'SELECT 1');
+PREPARE stmt FROM @ddl; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @idx_exists := (SELECT COUNT(*) FROM information_schema.statistics
+    WHERE table_schema = DATABASE() AND table_name = 'chat_messages' AND index_name = 'chat_messages_idempotency_unique');
+SET @ddl2 := IF(@idx_exists = 0,
+    'ALTER TABLE chat_messages ADD UNIQUE INDEX chat_messages_idempotency_unique (chatid, userid, idempotencykey), ALGORITHM=INPLACE, LOCK=NONE',
+    'SELECT 1');
+PREPARE stmt2 FROM @ddl2; EXECUTE stmt2; DEALLOCATE PREPARE stmt2;

--- a/iznik-nuxt3/components/ChatButton.vue
+++ b/iznik-nuxt3/components/ChatButton.vue
@@ -147,15 +147,12 @@ const openChat = async (
       if (firstmessage) {
         console.log('First message to send', firstmessage)
         try {
-          await chatStore.send(
+          await chatStore.send({
             chatid,
-            firstmessage,
-            null,
-            null,
-            firstmsgid,
-            false,
-            replySource
-          )
+            message: firstmessage,
+            refmsgid: firstmsgid,
+            replysource: replySource,
+          })
           console.log('Sent')
 
           action('chat_message_sent', {

--- a/iznik-nuxt3/components/ChatFooter.vue
+++ b/iznik-nuxt3/components/ChatFooter.vue
@@ -369,7 +369,7 @@ import { Dropdown } from 'floating-vue'
 import { storeToRefs } from 'pinia'
 import { FAR_AWAY, TYPING_TIME_INVERVAL } from '../constants'
 import SpinButton from './SpinButton'
-import { setupChat } from '~/composables/useChat'
+import { setupChat, getSendIdempotencyKey } from '~/composables/useChat'
 import { useMiscStore } from '~/stores/misc'
 import { useMessageStore } from '~/stores/message'
 import { useChatDraftStore } from '~/stores/chatdraft'
@@ -453,6 +453,11 @@ const showProfileModal = ref(false)
 const showAddress = ref(false)
 const sendmessage = ref(null)
 const sendError = ref(null)
+// The { message, key } of the last unconfirmed send attempt, so a "tap Send to retry"
+// of the same not-yet-sent text reuses the idempotency key (Discourse #9913) - see
+// getSendIdempotencyKey. Cleared on success, on a definitive 404 (the send never
+// reached the server - see below), and when switching to a different chat.
+const pendingSend = ref(null)
 // Composing-draft persistence: how long after the last keystroke the draft is saved.
 const DRAFT_SAVE_DEBOUNCE = 500
 let draftSaveTimer = null
@@ -805,13 +810,22 @@ const send = async (callback) => {
       // Encode up any emojis.
       msg = untwem(msg)
 
+      // Reuse the idempotency key from a previous failed attempt to send this exact
+      // pending text (a "tap Send to retry"), so that if that earlier request
+      // actually landed server-side despite the client seeing a failure, the server
+      // returns the existing message instead of creating a duplicate (Discourse
+      // #9913). Editing the text before retrying counts as a new logical send and
+      // gets a fresh key.
+      const idempotencyKey = getSendIdempotencyKey(pendingSend.value, msg)
+      pendingSend.value = { message: msg, key: idempotencyKey }
+
       // Send it. A failed send (e.g. a post that's since been purged -> 404) must not throw to the
       // global error.vue page: catch it, keep the typed text so they don't lose it, and show an
       // inline explanation instead. Note: a rippled post outside our reach no longer 403s — the
       // reply is now accepted and held server-side — so the 403 branch is a generic backstop.
       try {
         sendError.value = null
-        await chatStore.send(props.id, msg)
+        await chatStore.send({ chatid: props.id, message: msg, idempotencyKey })
       } catch (e) {
         sending.value = false
         const status = e?.response?.status
@@ -819,6 +833,10 @@ const send = async (callback) => {
           sendError.value =
             "Sorry, your message couldn't be sent just now. Please try again."
         } else if (status === 404) {
+          // A definitive rejection - the server never inserted a row (the refmsg-gone
+          // check runs before any insert), so there is nothing to dedupe against.
+          // Clear the pending key: a further attempt is a genuinely fresh send.
+          pendingSend.value = null
           sendError.value =
             "Sorry, this post is no longer available, so your message couldn't be sent."
         } else {
@@ -829,6 +847,7 @@ const send = async (callback) => {
       }
 
       // Clear the message now it's sent - and drop the saved draft so it can't be restored.
+      pendingSend.value = null
       sendmessage.value = ''
       if (draftSaveTimer) clearTimeout(draftSaveTimer)
       chatDraftStore.clearDraft(props.id)
@@ -855,7 +874,7 @@ const fetchMessages = async () => {
 }
 
 const sendAddress = async (id) => {
-  await chatStore.send(props.id, null, id)
+  await chatStore.send({ chatid: props.id, addressid: id })
   await _updateAfterSend()
 
   // If we've sent an address to someone who has recently replied to an offer, then it's quite likely that we
@@ -914,6 +933,10 @@ watch(
     if (saved && !sendmessage.value) {
       sendmessage.value = saved
     }
+
+    // A pending idempotency key is scoped to the chat it was created for - reusing it
+    // in a different chat would be meaningless (the server key is per chatid/userid).
+    pendingSend.value = null
   },
   { immediate: true }
 )
@@ -959,7 +982,7 @@ watch(
 
       newVal.forEach((att) => {
         console.log('Send', att.id, props.id)
-        promises.push(chatStore.send(props.id, null, null, att.id))
+        promises.push(chatStore.send({ chatid: props.id, imageid: att.id }))
       })
 
       await Promise.all(promises)

--- a/iznik-nuxt3/components/ChatMessageAddress.vue
+++ b/iznik-nuxt3/components/ChatMessageAddress.vue
@@ -196,7 +196,7 @@ const addressClosed = async () => {
 }
 
 const sendAddress = async (id) => {
-  await chatStore.send(props.chatid, null, id)
+  await chatStore.send({ chatid: props.chatid, addressid: id })
   showAddress.value = false
 }
 

--- a/iznik-nuxt3/components/MessageReportModal.vue
+++ b/iznik-nuxt3/components/MessageReportModal.vue
@@ -300,7 +300,11 @@ async function report() {
   for (const groupid of targetIds) {
     try {
       const chatid = await chatStore.openChatToMods(groupid)
-      await chatStore.send(chatid, reportMessage, null, null, props.id)
+      await chatStore.send({
+        chatid,
+        message: reportMessage,
+        refmsgid: props.id,
+      })
       anySucceeded = true
     } catch (error) {
       console.error('Failed to submit report to group ' + groupid, error)

--- a/iznik-nuxt3/composables/useChat.js
+++ b/iznik-nuxt3/composables/useChat.js
@@ -7,6 +7,20 @@ import { useAuthStore } from '~/stores/auth'
 import { useMessageStore } from '~/stores/message'
 import { useGroupStore } from '~/stores/group'
 import { twem } from '~/composables/useTwem'
+import { generateUUID } from '~/composables/useTrace'
+
+// A manual retry of a not-yet-confirmed message (e.g. after a failed/ambiguous send)
+// must reuse the SAME idempotency key, so the server's unique-key guard
+// (chat_messages.idempotencykey) can return the already-created row instead of a
+// genuine duplicate if the earlier request actually landed despite the client seeing
+// a failure. A different message - or a first attempt - always gets a fresh key
+// (Discourse #9913). `pending` is the { message, key } of the last attempt, or null.
+export function getSendIdempotencyKey(pending, message) {
+  if (pending && pending.message === message) {
+    return pending.key
+  }
+  return generateUUID()
+}
 
 export function chatCollate(msgs) {
   const ret = []

--- a/iznik-nuxt3/composables/useTrace.js
+++ b/iznik-nuxt3/composables/useTrace.js
@@ -105,4 +105,11 @@ export function useTrace() {
 }
 
 // Also export individual functions for use outside composable context.
-export { getSessionId, getTraceId, newTraceId, getTraceHeaders, onTraceChange }
+export {
+  getSessionId,
+  getTraceId,
+  newTraceId,
+  getTraceHeaders,
+  onTraceChange,
+  generateUUID,
+}

--- a/iznik-nuxt3/modtools/components/ModChatFooter.vue
+++ b/iznik-nuxt3/modtools/components/ModChatFooter.vue
@@ -820,7 +820,7 @@ const send = async (callback) => {
       msg = untwem(msg)
 
       // Send it
-      await chatStore.send(props.id, msg)
+      await chatStore.send({ chatid: props.id, message: msg })
 
       // Clear the message now it's sent.
       sendmessage.value = ''
@@ -847,7 +847,7 @@ const fetchMessages = async () => {
 }
 
 const sendAddress = async (id) => {
-  await chatStore.send(props.id, null, id)
+  await chatStore.send({ chatid: props.id, addressid: id })
   await _updateAfterSend()
 
   // If we've sent an address to someone who has recently replied to an offer, then it's quite likely that we
@@ -942,7 +942,7 @@ watch(
 
       newVal.forEach((att) => {
         console.log('Send', att.id, props.id)
-        promises.push(chatStore.send(props.id, null, null, att.id))
+        promises.push(chatStore.send({ chatid: props.id, imageid: att.id }))
       })
 
       await Promise.all(promises)

--- a/iznik-nuxt3/modtools/components/ModChatNoteModal.vue
+++ b/iznik-nuxt3/modtools/components/ModChatNoteModal.vue
@@ -99,7 +99,7 @@ async function addit() {
 
   console.log('addit', msg)
 
-  await chatStore.send(props.chatid, msg, null, null, null, true)
+  await chatStore.send({ chatid: props.chatid, message: msg, modnote: true })
 
   hide()
 }

--- a/iznik-nuxt3/stores/chat.js
+++ b/iznik-nuxt3/stores/chat.js
@@ -6,6 +6,7 @@ import { useGroupStore } from '~/stores/group'
 import { useMessageStore } from '~/stores/message'
 import { useMiscStore } from '~/stores/misc'
 import { useUserStore } from '~/stores/user'
+import { generateUUID } from '~/composables/useTrace'
 
 export const useChatStore = defineStore({
   id: 'chat',
@@ -335,15 +336,16 @@ export const useChatStore = defineStore({
     async typing(chatid) {
       await api(this.config).chat.typing(chatid)
     },
-    async send(
+    async send({
       chatid,
       message,
       addressid,
       imageid,
       refmsgid,
       modnote,
-      replysource
-    ) {
+      replysource,
+      idempotencyKey,
+    }) {
       const data = {
         roomid: chatid,
       }
@@ -376,6 +378,15 @@ export const useChatStore = defineStore({
         data.replysource = replysource
       }
 
+      // Idempotency key (Discourse #9913): the server dedupes on (chatid, userid,
+      // idempotencykey) via an atomic INSERT ... ON DUPLICATE KEY UPDATE, so a
+      // retried send of this exact call - e.g. a caller passing the SAME key back in
+      // after a failed/ambiguous attempt - returns the already-created row instead of
+      // a genuine duplicate. Callers that don't pass one (most of them: address
+      // sends, photo attachments, mod notes) just get a fresh one here, which still
+      // protects them from double-submission at no extra cost.
+      data.idempotencykey = idempotencyKey || generateUUID()
+
       await api(this.config).chat.send(data)
 
       // Update the snippet in the chat list entry so it shows immediately.
@@ -397,6 +408,7 @@ export const useChatStore = defineStore({
         reportreason: reason,
         message: comments,
         refchatid,
+        idempotencykey: generateUUID(),
       })
       this.fetchMessages(chatid)
     },

--- a/iznik-nuxt3/stores/mobile.js
+++ b/iznik-nuxt3/stores/mobile.js
@@ -665,11 +665,12 @@ export const useMobileStore = defineStore({
           return
         }
 
-        // Send the reply via API
-        await api(this.config).chat.send({
-          roomid: chatId,
-          message: replyText,
-        })
+        // Send the reply via the chat store, not the API directly, so it gets an
+        // idempotency key like every other send path (Discourse #9913) - a
+        // notification-action reply is just as susceptible to being retried/
+        // double-fired as a ChatFooter send.
+        const chatStore = useChatStore()
+        await chatStore.send({ chatid: chatId, message: replyText })
         console.log('handleReplyAction: message sent successfully')
       } catch (e) {
         console.error('handleReplyAction error:', e.message)

--- a/iznik-nuxt3/tests/unit/components/ChatFooterSendIdempotency.spec.js
+++ b/iznik-nuxt3/tests/unit/components/ChatFooterSendIdempotency.spec.js
@@ -1,0 +1,177 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { defineComponent, h, ref, watch } from 'vue'
+import { getSendIdempotencyKey } from '~/composables/useChat'
+
+// ChatFooter.vue can't be mounted directly in this suite - it pulls in ~10 Pinia
+// stores, several defineAsyncComponent children and Nuxt auto-imports with no test
+// harness for them (see ChatFooter.spec.js's header comment and
+// ChatFooterDraftPersistence.spec.js, which uses the same minimal-harness technique
+// for a different ChatFooter bug). This harness mirrors ONLY the send()/pendingSend
+// logic ChatFooter.vue now has (Discourse #9913) byte-for-byte in shape, uses the
+// REAL getSendIdempotencyKey (composables/useChat.js) rather than a re-implementation,
+// and is driven through real DOM interaction via @vue/test-utils mount() - not source
+// regex matching.
+function buildSendHarness(chatSend) {
+  return defineComponent({
+    props: { id: { type: Number, required: true } },
+    setup(props) {
+      const sendmessage = ref('')
+      const sendError = ref(null)
+      const pendingSend = ref(null)
+      const sentPayloads = []
+
+      // Mirrors the pendingSend-clear-on-chat-switch watcher added to ChatFooter.vue.
+      watch(
+        () => props.id,
+        () => {
+          pendingSend.value = null
+        }
+      )
+
+      const send = async () => {
+        const msg = sendmessage.value
+        if (!msg) return
+
+        const idempotencyKey = getSendIdempotencyKey(pendingSend.value, msg)
+        pendingSend.value = { message: msg, key: idempotencyKey }
+
+        try {
+          sendError.value = null
+          await chatSend({ chatid: props.id, message: msg, idempotencyKey })
+          sentPayloads.push({ message: msg, idempotencyKey })
+        } catch (e) {
+          const status = e?.response?.status
+          if (status === 404) {
+            pendingSend.value = null
+            sendError.value = 'gone'
+          } else {
+            sendError.value = 'retry'
+          }
+          return
+        }
+
+        pendingSend.value = null
+        sendmessage.value = ''
+      }
+
+      return { sendmessage, sendError, pendingSend, sentPayloads, send }
+    },
+    render() {
+      return h('div', [
+        h('textarea', {
+          value: this.sendmessage,
+          onInput: (e) => {
+            this.sendmessage = e.target.value
+          },
+        }),
+        h('button', { onClick: this.send }, 'Send'),
+        h('span', { class: 'send-error' }, this.sendError || ''),
+      ])
+    },
+  })
+}
+
+describe('ChatFooter send idempotency key handling (Discourse #9913)', () => {
+  let wrapper
+
+  async function typeAndSend(text) {
+    await wrapper.find('textarea').setValue(text)
+    await wrapper.find('button').trigger('click')
+    await wrapper.vm.$nextTick()
+  }
+
+  it('keeps the typed message and reuses the idempotency key when a send fails with an ambiguous (non-404) error, so a retry of the same attempt dedupes server-side', async () => {
+    let attempt = 0
+    const chatSend = () => {
+      attempt++
+      if (attempt === 1) {
+        const err = new Error('Network error')
+        err.response = null
+        return Promise.reject(err)
+      }
+      return Promise.resolve()
+    }
+    const Harness = buildSendHarness(chatSend)
+    wrapper = mount(Harness, { props: { id: 1 } })
+
+    await typeAndSend('hello there')
+    expect(wrapper.vm.sendError).toBe('retry')
+    // The typed text must not be lost on a failed send.
+    expect(wrapper.vm.sendmessage).toBe('hello there')
+    const keyAfterFailure = wrapper.vm.pendingSend.key
+
+    // Retry (tap Send again) with the same text - must reuse the same key.
+    await wrapper.find('button').trigger('click')
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.vm.sentPayloads).toHaveLength(1)
+    expect(wrapper.vm.sentPayloads[0].idempotencyKey).toBe(keyAfterFailure)
+    expect(wrapper.vm.pendingSend).toBeNull()
+  })
+
+  it('clears the pending key on a definitive 404 (post gone), so a further attempt is a genuinely fresh send', async () => {
+    const chatSend = () => {
+      const err = new Error('Not found')
+      err.response = { status: 404 }
+      return Promise.reject(err)
+    }
+    const Harness = buildSendHarness(chatSend)
+    wrapper = mount(Harness, { props: { id: 1 } })
+
+    await typeAndSend('hello there')
+    expect(wrapper.vm.sendError).toBe('gone')
+    expect(wrapper.vm.pendingSend).toBeNull()
+  })
+
+  it('clears pendingSend and the typed text after a successful send', async () => {
+    const chatSend = () => Promise.resolve()
+    const Harness = buildSendHarness(chatSend)
+    wrapper = mount(Harness, { props: { id: 1 } })
+
+    await typeAndSend('hello there')
+    expect(wrapper.vm.pendingSend).toBeNull()
+    expect(wrapper.vm.sendmessage).toBe('')
+  })
+
+  it('generates a fresh key rather than reusing a stale one when the text is edited before retrying', async () => {
+    let attempt = 0
+    const chatSend = () => {
+      attempt++
+      if (attempt === 1) {
+        const err = new Error('Network error')
+        err.response = null
+        return Promise.reject(err)
+      }
+      return Promise.resolve()
+    }
+    const Harness = buildSendHarness(chatSend)
+    wrapper = mount(Harness, { props: { id: 1 } })
+
+    await typeAndSend('first draft')
+    const keyAfterFailure = wrapper.vm.pendingSend.key
+
+    // Edit the text before retrying - counts as a new logical send.
+    await typeAndSend('edited draft')
+
+    expect(wrapper.vm.sentPayloads[0].idempotencyKey).not.toBe(keyAfterFailure)
+  })
+
+  it('clears a pending key when the chat (props.id) changes, so it is never reused across chats', async () => {
+    const chatSend = () => {
+      const err = new Error('Network error')
+      err.response = null
+      return Promise.reject(err)
+    }
+    const Harness = buildSendHarness(chatSend)
+    wrapper = mount(Harness, { props: { id: 1 } })
+
+    await typeAndSend('hello there')
+    expect(wrapper.vm.pendingSend).not.toBeNull()
+
+    await wrapper.setProps({ id: 2 })
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.vm.pendingSend).toBeNull()
+  })
+})

--- a/iznik-nuxt3/tests/unit/components/ChatMessageAddress.spec.js
+++ b/iznik-nuxt3/tests/unit/components/ChatMessageAddress.spec.js
@@ -256,7 +256,10 @@ describe('ChatMessageAddress', () => {
       const wrapper = createWrapper()
       wrapper.vm.showAddress = true
       await wrapper.vm.sendAddress(456)
-      expect(mockChatStore.send).toHaveBeenCalledWith(1, null, 456)
+      expect(mockChatStore.send).toHaveBeenCalledWith({
+        chatid: 1,
+        addressid: 456,
+      })
       expect(wrapper.vm.showAddress).toBe(false)
     })
   })

--- a/iznik-nuxt3/tests/unit/components/modtools/ModChatNoteModal.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModChatNoteModal.spec.js
@@ -160,14 +160,11 @@ describe('ModChatNoteModal', () => {
 
       await wrapper.vm.addit()
 
-      expect(mockSend).toHaveBeenCalledWith(
-        123, // chatid
-        'Test mod note\n\nTest Group Volunteer', // message with group suffix
-        null, // addressid
-        null, // imageid
-        null, // refmsgid
-        true // modnote
-      )
+      expect(mockSend).toHaveBeenCalledWith({
+        chatid: 123,
+        message: 'Test mod note\n\nTest Group Volunteer', // message with group suffix
+        modnote: true,
+      })
     })
   })
 })

--- a/iznik-nuxt3/tests/unit/composables/useChatSendIdempotency.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useChatSendIdempotency.spec.js
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+import { getSendIdempotencyKey } from '~/composables/useChat'
+
+// Discourse #9913: a manual retry of a not-yet-confirmed message (e.g. after a
+// failed/ambiguous send) must reuse the SAME idempotency key, so the server's
+// unique-key guard can return the already-created row instead of a genuine
+// duplicate if the earlier request actually landed. A different message - or a
+// first attempt - always gets a fresh key.
+describe('getSendIdempotencyKey', () => {
+  const UUID_RE =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+  it('generates a valid key when there is no pending attempt', () => {
+    const key = getSendIdempotencyKey(null, 'hello')
+    expect(key).toMatch(UUID_RE)
+  })
+
+  it('generates a fresh key each time when there is no pending attempt', () => {
+    const key1 = getSendIdempotencyKey(null, 'hello')
+    const key2 = getSendIdempotencyKey(null, 'hello')
+    expect(key1).not.toBe(key2)
+  })
+
+  it('reuses the pending key when retrying the exact same message text', () => {
+    const pending = { message: 'hello', key: 'abc-123' }
+    expect(getSendIdempotencyKey(pending, 'hello')).toBe('abc-123')
+  })
+
+  it('generates a fresh key when the message text has changed', () => {
+    const pending = { message: 'hello', key: 'abc-123' }
+    const key = getSendIdempotencyKey(pending, 'hello, edited')
+    expect(key).not.toBe('abc-123')
+    expect(key).toMatch(UUID_RE)
+  })
+
+  it('generates a fresh key when there was no prior message text (first send)', () => {
+    const pending = { message: '', key: 'abc-123' }
+    const key = getSendIdempotencyKey(pending, 'hello')
+    expect(key).not.toBe('abc-123')
+  })
+})

--- a/iznik-nuxt3/tests/unit/stores/chat.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/chat.spec.js
@@ -217,15 +217,22 @@ describe('chat store', () => {
   })
 
   describe('send', () => {
+    // Every send now carries a server-enforced idempotency key (Discourse #9913), and
+    // the value is random (crypto.randomUUID), so assertions below check the fields
+    // that matter individually rather than a single toHaveBeenCalledWith literal.
+    const UUID_RE =
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
     it('updates snippet in listByChatId immediately after sending', async () => {
       const store = useChatStore()
       store.config = {}
       store.listByChatId[10] = { id: 10, snippet: 'old message' }
       mockFetchMessages.mockResolvedValue([])
 
-      await store.send(10, 'new message')
+      await store.send({ chatid: 10, message: 'new message' })
 
-      expect(mockSend).toHaveBeenCalledWith({
+      expect(mockSend).toHaveBeenCalledTimes(1)
+      expect(mockSend.mock.calls[0][0]).toMatchObject({
         roomid: 10,
         message: 'new message',
       })
@@ -238,9 +245,17 @@ describe('chat store', () => {
       store.listByChatId[10] = { id: 10 }
       mockFetchMessages.mockResolvedValue([])
 
-      await store.send(10, 'hi', 1, 2, 3, true, 'browse')
+      await store.send({
+        chatid: 10,
+        message: 'hi',
+        addressid: 1,
+        imageid: 2,
+        refmsgid: 3,
+        modnote: true,
+        replysource: 'browse',
+      })
 
-      expect(mockSend).toHaveBeenCalledWith({
+      expect(mockSend.mock.calls[0][0]).toMatchObject({
         roomid: 10,
         message: 'hi',
         addressid: 1,
@@ -256,12 +271,15 @@ describe('chat store', () => {
       store.config = {}
       mockFetchMessages.mockResolvedValue([])
 
-      await store.send(10, 'hi', null, null, null, false)
+      await store.send({ chatid: 10, message: 'hi', modnote: false })
 
-      expect(mockSend).toHaveBeenCalledWith({
-        roomid: 10,
-        message: 'hi',
-      })
+      const sentData = mockSend.mock.calls[0][0]
+      expect(sentData.addressid).toBeUndefined()
+      expect(sentData.imageid).toBeUndefined()
+      expect(sentData.refmsgid).toBeUndefined()
+      expect(sentData.modnote).toBeUndefined()
+      expect(sentData.replysource).toBeUndefined()
+      expect(sentData).toMatchObject({ roomid: 10, message: 'hi' })
     })
 
     it('only sends replysource alongside a refmsgid (reply provenance, not chat chatter)', async () => {
@@ -269,12 +287,53 @@ describe('chat store', () => {
       store.config = {}
       mockFetchMessages.mockResolvedValue([])
 
-      await store.send(10, 'hi', null, null, null, false, 'browse')
+      await store.send({ chatid: 10, message: 'hi', replysource: 'browse' })
 
-      expect(mockSend).toHaveBeenCalledWith({
-        roomid: 10,
+      const sentData = mockSend.mock.calls[0][0]
+      expect(sentData.replysource).toBeUndefined()
+      expect(sentData).toMatchObject({ roomid: 10, message: 'hi' })
+    })
+
+    // Discourse #9913: the server dedupes on (chatid, userid, idempotencykey), so
+    // every send must carry a key - either the caller's (a retry reusing the same
+    // key) or a freshly generated one.
+    it('generates a fresh idempotency key when the caller does not supply one', async () => {
+      const store = useChatStore()
+      store.config = {}
+      mockFetchMessages.mockResolvedValue([])
+
+      await store.send({ chatid: 10, message: 'hi' })
+
+      expect(mockSend.mock.calls[0][0].idempotencykey).toMatch(UUID_RE)
+    })
+
+    it('passes a caller-supplied idempotency key through unchanged, so a retry of the same attempt dedupes server-side', async () => {
+      const store = useChatStore()
+      store.config = {}
+      mockFetchMessages.mockResolvedValue([])
+
+      await store.send({
+        chatid: 10,
         message: 'hi',
+        idempotencyKey: 'caller-retry-key',
       })
+
+      expect(mockSend.mock.calls[0][0].idempotencykey).toBe('caller-retry-key')
+    })
+
+    it('generates a different key for each independent send call', async () => {
+      const store = useChatStore()
+      store.config = {}
+      mockFetchMessages.mockResolvedValue([])
+
+      await store.send({ chatid: 10, message: 'hi' })
+      await store.send({ chatid: 10, message: 'bye' })
+
+      const key1 = mockSend.mock.calls[0][0].idempotencykey
+      const key2 = mockSend.mock.calls[1][0].idempotencykey
+      expect(key1).toMatch(UUID_RE)
+      expect(key2).toMatch(UUID_RE)
+      expect(key1).not.toBe(key2)
     })
   })
 

--- a/iznik-nuxt3/tests/unit/stores/mobile.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/mobile.spec.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
 
 let mockPlatform = 'web'
@@ -45,10 +45,12 @@ vi.mock('~/stores/auth', () => ({
 
 const mockFetchChats = vi.fn()
 const mockFetchMessages = vi.fn()
+const mockChatStoreSend = vi.fn()
 vi.mock('~/stores/chat', () => ({
   useChatStore: () => ({
     fetchChats: mockFetchChats,
     fetchMessages: mockFetchMessages,
+    send: mockChatStoreSend,
   }),
 }))
 
@@ -173,17 +175,13 @@ describe('mobile store', () => {
 
     it('returns false when no query string', () => {
       const store = useMobileStore()
-      const result = store.extractQueryStringParams(
-        'https://example.com/path'
-      )
+      const result = store.extractQueryStringParams('https://example.com/path')
       expect(result).toBe(false)
     })
 
     it('handles empty query string', () => {
       const store = useMobileStore()
-      const result = store.extractQueryStringParams(
-        'https://example.com?'
-      )
+      const result = store.extractQueryStringParams('https://example.com?')
       expect(result).toEqual({})
     })
 
@@ -311,11 +309,7 @@ describe('mobile store', () => {
 
     it('ignores legacy notifications without channel_id', async () => {
       const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-      await store.handleNotification(
-        { data: { route: '/chats/1' } },
-        {},
-        {}
-      )
+      await store.handleNotification({ data: { route: '/chats/1' } }, {}, {})
       expect(store.route).toBe(false)
       logSpy.mockRestore()
     })
@@ -366,19 +360,16 @@ describe('mobile store', () => {
   })
 
   describe('handleReplyAction', () => {
-    it('sends reply via API', async () => {
+    it('sends reply via the chat store (so it gets an idempotency key, #9913)', async () => {
       const store = useMobileStore()
       store.config = { public: {} }
       const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-      mockChatSend.mockResolvedValue({})
+      mockChatStoreSend.mockResolvedValue({})
 
-      await store.handleReplyAction(
-        { data: { chatids: '42' } },
-        'Hello!'
-      )
+      await store.handleReplyAction({ data: { chatids: '42' } }, 'Hello!')
 
-      expect(mockChatSend).toHaveBeenCalledWith({
-        roomid: 42,
+      expect(mockChatStoreSend).toHaveBeenCalledWith({
+        chatid: 42,
         message: 'Hello!',
       })
       logSpy.mockRestore()
@@ -391,7 +382,7 @@ describe('mobile store', () => {
       const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
       await store.handleReplyAction(null, 'Hello!')
-      expect(mockChatSend).not.toHaveBeenCalled()
+      expect(mockChatStoreSend).not.toHaveBeenCalled()
 
       logSpy.mockRestore()
       errorSpy.mockRestore()
@@ -404,7 +395,7 @@ describe('mobile store', () => {
       const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
       await store.handleReplyAction({ data: {} }, 'Hello!')
-      expect(mockChatSend).not.toHaveBeenCalled()
+      expect(mockChatStoreSend).not.toHaveBeenCalled()
 
       logSpy.mockRestore()
       errorSpy.mockRestore()

--- a/iznik-server-go/chat/chatmessage.go
+++ b/iznik-server-go/chat/chatmessage.go
@@ -59,9 +59,22 @@ type ChatMessage struct {
 	// rippling attribution capture - sanitised there, stored in rippling_reply_attribution,
 	// never a chat_messages column.
 	Replysource *string `json:"replysource" gorm:"-"`
-	Archived    int     `json:"-" gorm:"-"`
-	Deleted     bool    `json:"-"`
+	// Idempotencykey is a client-generated key (expected: a UUID) that lets a retried
+	// or double-submitted POST for the SAME logical send collapse onto the same row
+	// instead of creating a duplicate (Discourse #9913). Enforced via a unique
+	// (chatid, userid, idempotencykey) DB index; validated in CreateChatMessage before
+	// use (see idempotencyKeyRe) so a malformed/truncated value can never be used for
+	// dedup and silently collide two DIFFERENT sends.
+	Idempotencykey *string `json:"idempotencykey" gorm:"-"`
+	Archived       int     `json:"-" gorm:"-"`
+	Deleted        bool    `json:"-"`
 }
+
+// idempotencyKeyRe matches a canonical UUID (the only shape the client ever sends -
+// see composables/useTrace.js generateUUID). Anything else is rejected outright rather
+// than truncated/sanitised, so a malformed key can never be used for dedup and collide
+// with a different send that happens to share a truncated prefix.
+var idempotencyKeyRe = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
 
 // We need a separate struct for the query so that we can return image info in a single query.  If we put the
 // fields into the ChatMessage struct, GORM will try to set them when we create a new message.
@@ -478,6 +491,14 @@ func CreateChatMessage(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusBadRequest, "Invalid parameters")
 	}
 
+	// Reject a malformed idempotency key outright rather than truncating/sanitising it -
+	// a truncated key could make two DIFFERENT sends collide on the unique index and
+	// silently swallow a real message. Absent is fine (older clients); present-but-invalid
+	// is not (see idempotencyKeyRe).
+	if payload.Idempotencykey != nil && !idempotencyKeyRe.MatchString(*payload.Idempotencykey) {
+		return fiber.NewError(fiber.StatusBadRequest, "Invalid idempotency key")
+	}
+
 	chattype := utils.CHAT_MESSAGE_DEFAULT
 
 	// modnote flag creates a ModMail message (visible as group volunteer message).
@@ -599,15 +620,71 @@ func CreateChatMessage(c *fiber.Ctx) error {
 	payload.Type = chattype
 	payload.Processingrequired = true
 	payload.Date = time.Now()
-	if result := db.Create(&payload); result.Error != nil {
-		// Don't swallow the underlying DB error: without this, FK violations (e.g. a purged
-		// refmsgid/chatid) and any other insert failure vanish — the access log drops 500s and
-		// nothing reaches Sentry, leaving the user's "Oh Dear" undiagnosable.
-		stdlog.Printf("Failed to create chat message in chat %d for user %d (refmsgid=%v): %v",
-			id, myid, payload.Refmsgid, result.Error)
-		return fiber.NewError(fiber.StatusInternalServerError, "Error creating chat message")
+
+	var newid uint64
+
+	if payload.Idempotencykey != nil {
+		// A retried/double-submitted send (client retry on an ambiguous fetch outcome,
+		// double-click, second tab) carries the SAME key, so this collapses onto the
+		// existing row via the unique (chatid, userid, idempotencykey) index instead of
+		// creating a duplicate (Discourse #9913). Mirrors GetOrCreateUser2UserChat's
+		// established atomic pattern for this codebase. Uses the write connection
+		// directly (db.DB()) so there's no separate SELECT to race a lagging read
+		// replica.
+		sqlDB, dbErr := db.DB()
+		if dbErr != nil {
+			stdlog.Printf("Failed to get sql.DB for chat message insert: %v", dbErr)
+			return fiber.NewError(fiber.StatusInternalServerError, "Error creating chat message")
+		}
+
+		sqlResult, insErr := sqlDB.Exec(
+			`INSERT INTO chat_messages
+				(chatid, userid, type, reportreason, refmsgid, refchatid, imageid, date, message,
+				 seenbyall, mailedtoall, reviewrequired, reviewrejected, replyexpected, replyreceived,
+				 processingrequired, processingsuccessful, deleted, idempotencykey)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			 ON DUPLICATE KEY UPDATE id = LAST_INSERT_ID(id)`,
+			payload.Chatid, payload.Userid, payload.Type, payload.Reportreason, payload.Refmsgid,
+			payload.Refchatid, payload.Imageid, payload.Date, payload.Message,
+			payload.Seenbyall, payload.Mailedtoall, payload.Reviewrequired, payload.Reviewrejected,
+			payload.Replyexpected, payload.Replyreceived,
+			payload.Processingrequired, payload.Processingsuccessful, payload.Deleted,
+			*payload.Idempotencykey)
+		if insErr != nil {
+			stdlog.Printf("Failed to create chat message in chat %d for user %d (refmsgid=%v): %v",
+				id, myid, payload.Refmsgid, insErr)
+			return fiber.NewError(fiber.StatusInternalServerError, "Error creating chat message")
+		}
+
+		lastID, idErr := sqlResult.LastInsertId()
+		if idErr != nil || lastID == 0 {
+			stdlog.Printf("Failed to get last insert id for chat message in chat %d for user %d: %v",
+				id, myid, idErr)
+			return fiber.NewError(fiber.StatusInternalServerError, "Error creating chat message")
+		}
+
+		if affected, _ := sqlResult.RowsAffected(); affected == 0 {
+			// ON DUPLICATE KEY UPDATE with a no-op UPDATE (id = LAST_INSERT_ID(id)) reports
+			// 0 rows affected when it hit an EXISTING row rather than inserting a new one -
+			// i.e. this was a genuine retry, not a fresh send. Log so duplicate-key hits are
+			// visible without having to infer them from row counts.
+			stdlog.Printf("Duplicate chat message idempotency key hit: chat %d user %d key %s -> existing id %d",
+				id, myid, *payload.Idempotencykey, lastID)
+		}
+
+		newid = uint64(lastID)
+		payload.ID = newid
+	} else {
+		if result := db.Create(&payload); result.Error != nil {
+			// Don't swallow the underlying DB error: without this, FK violations (e.g. a purged
+			// refmsgid/chatid) and any other insert failure vanish — the access log drops 500s and
+			// nothing reaches Sentry, leaving the user's "Oh Dear" undiagnosable.
+			stdlog.Printf("Failed to create chat message in chat %d for user %d (refmsgid=%v): %v",
+				id, myid, payload.Refmsgid, result.Error)
+			return fiber.NewError(fiber.StatusInternalServerError, "Error creating chat message")
+		}
+		newid = payload.ID
 	}
-	newid := payload.ID
 
 	if newid == 0 {
 		return fiber.NewError(fiber.StatusInternalServerError, "Error creating chat message")

--- a/iznik-server-go/test/chat_test.go
+++ b/iznik-server-go/test/chat_test.go
@@ -417,6 +417,120 @@ func TestCreateChatMessage(t *testing.T) {
 	assert.Greater(t, chatrsp.Id, (uint64)(1))
 }
 
+// TestCreateChatMessageIdempotencyKeyDedup: two POSTs carrying the SAME idempotency
+// key must collapse onto a single row. This is the server-side half of the Discourse
+// #9913 fix - a client retry of an ambiguous fetch outcome (network blip, 5xx) must
+// not create a duplicate that briefly shows twice to the sender.
+func TestCreateChatMessageIdempotencyKeyDedup(t *testing.T) {
+	prefix := uniquePrefix("chatidem")
+	user1ID := CreateTestUser(t, prefix+"_u1", "User")
+	user2ID := CreateTestUser(t, prefix+"_u2", "User")
+	chatid := CreateTestChatRoom(t, user1ID, &user2ID, nil, "User2User")
+	_, token := CreateTestSession(t, user1ID)
+
+	key := "aaaaaaaa-1111-4111-8111-111111111111"
+	body := fmt.Sprintf(`{"message":"Retried send","idempotencykey":"%s"}`, key)
+
+	postSend := func() uint64 {
+		req := httptest.NewRequest("POST", "/api/chat/"+fmt.Sprint(chatid)+"/message?jwt="+token, bytes.NewBufferString(body))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := getApp().Test(req)
+		assert.NoError(t, err)
+		assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+		var r struct {
+			Id uint64 `json:"id"`
+		}
+		json2.Unmarshal(rsp(resp), &r)
+		assert.Greater(t, r.Id, uint64(0))
+		return r.Id
+	}
+
+	firstID := postSend()
+	retryID := postSend()
+	assert.Equal(t, firstID, retryID, "retried send with the same idempotency key must return the same, non-zero id")
+
+	db := database.DBConn
+	var count int
+	db.Raw("SELECT COUNT(*) FROM chat_messages WHERE chatid = ? AND idempotencykey = ?", chatid, key).Scan(&count)
+	assert.Equal(t, 1, count, "retried send with the same idempotency key must not create a duplicate row")
+}
+
+// TestCreateChatMessageIdempotencyKeyDeliberateResendCreatesNewRow: a deliberate
+// resend (a genuinely new message, given a fresh key) must never be swallowed by the
+// dedup guard - only a retry of the exact same key collapses.
+func TestCreateChatMessageIdempotencyKeyDeliberateResendCreatesNewRow(t *testing.T) {
+	prefix := uniquePrefix("chatidem2")
+	user1ID := CreateTestUser(t, prefix+"_u1", "User")
+	user2ID := CreateTestUser(t, prefix+"_u2", "User")
+	chatid := CreateTestChatRoom(t, user1ID, &user2ID, nil, "User2User")
+	_, token := CreateTestSession(t, user1ID)
+
+	send := func(key string) uint64 {
+		body := fmt.Sprintf(`{"message":"Deliberate resend","idempotencykey":"%s"}`, key)
+		req := httptest.NewRequest("POST", "/api/chat/"+fmt.Sprint(chatid)+"/message?jwt="+token, bytes.NewBufferString(body))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := getApp().Test(req)
+		assert.NoError(t, err)
+		assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+		var r struct {
+			Id uint64 `json:"id"`
+		}
+		json2.Unmarshal(rsp(resp), &r)
+		return r.Id
+	}
+
+	id1 := send("bbbbbbbb-2222-4222-8222-222222222222")
+	id2 := send("cccccccc-3333-4333-8333-333333333333")
+	assert.NotEqual(t, id1, id2, "a deliberate resend with a fresh key must create a new row, not be swallowed")
+}
+
+// TestCreateChatMessageNoIdempotencyKeyBackwardCompatible: older clients that send no
+// idempotency key are completely unaffected - MySQL never treats two NULLs as equal
+// in a unique index, so two key-less sends of identical content both create their own
+// row exactly as before this fix.
+func TestCreateChatMessageNoIdempotencyKeyBackwardCompatible(t *testing.T) {
+	prefix := uniquePrefix("chatidem3")
+	user1ID := CreateTestUser(t, prefix+"_u1", "User")
+	user2ID := CreateTestUser(t, prefix+"_u2", "User")
+	chatid := CreateTestChatRoom(t, user1ID, &user2ID, nil, "User2User")
+	_, token := CreateTestSession(t, user1ID)
+
+	body := `{"message":"No key send"}`
+
+	var ids []uint64
+	for i := 0; i < 2; i++ {
+		req := httptest.NewRequest("POST", "/api/chat/"+fmt.Sprint(chatid)+"/message?jwt="+token, bytes.NewBufferString(body))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := getApp().Test(req)
+		assert.NoError(t, err)
+		assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+		var r struct {
+			Id uint64 `json:"id"`
+		}
+		json2.Unmarshal(rsp(resp), &r)
+		ids = append(ids, r.Id)
+	}
+	assert.NotEqual(t, ids[0], ids[1], "sends without an idempotency key are unaffected and each create their own row")
+}
+
+// TestCreateChatMessageIdempotencyKeyInvalidRejected: a malformed key must be rejected
+// outright, never truncated/sanitised and used for dedup - a truncated key could make
+// two DIFFERENT sends collide on the unique index and silently swallow a real message.
+func TestCreateChatMessageIdempotencyKeyInvalidRejected(t *testing.T) {
+	prefix := uniquePrefix("chatidem4")
+	user1ID := CreateTestUser(t, prefix+"_u1", "User")
+	user2ID := CreateTestUser(t, prefix+"_u2", "User")
+	chatid := CreateTestChatRoom(t, user1ID, &user2ID, nil, "User2User")
+	_, token := CreateTestSession(t, user1ID)
+
+	body := `{"message":"Bad key send","idempotencykey":"not-a-uuid"}`
+	req := httptest.NewRequest("POST", "/api/chat/"+fmt.Sprint(chatid)+"/message?jwt="+token, bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := getApp().Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, fiber.StatusBadRequest, resp.StatusCode, "a malformed idempotency key must be rejected, never truncated/used for dedup")
+}
+
 func TestCreateChatMessageModnote(t *testing.T) {
 	// modnote=true should create a ModMail type message.
 	prefix := uniquePrefix("chatmodnote")
@@ -1708,7 +1822,6 @@ func TestReferToSupportMissingChatID(t *testing.T) {
 	assert.Equal(t, fiber.StatusBadRequest, resp.StatusCode)
 }
 
-
 // Helper to set up a moderator with a group and User2Mod chat containing messages.
 func setupModChatData(t *testing.T, prefix string) (modID uint64, userID uint64, groupID uint64, chatID uint64, token string) {
 	modID = CreateTestUser(t, prefix+"_mod", "Moderator")
@@ -2017,14 +2130,14 @@ func TestReviewChatMessagesSenderOnlyExcluded(t *testing.T) {
 	prefix := uniquePrefix("ReviewSenderOnly")
 	db := database.DBConn
 	groupID := CreateTestGroup(t, prefix)
-	otherGroupID := CreateTestGroup(t, prefix + "_other")
+	otherGroupID := CreateTestGroup(t, prefix+"_other")
 	modID := CreateTestUser(t, prefix+"_mod", "User")
 	CreateTestMembership(t, modID, groupID, "Moderator")
 	_, token := CreateTestSession(t, modID)
 
 	senderID := CreateTestUser(t, prefix+"_sender", "User")
 	recipientID := CreateTestUser(t, prefix+"_recip", "User")
-	CreateTestMembership(t, senderID, groupID, "Member")    // sender in mod's group
+	CreateTestMembership(t, senderID, groupID, "Member")         // sender in mod's group
 	CreateTestMembership(t, recipientID, otherGroupID, "Member") // recipient in different group
 
 	chatID := CreateTestChatRoom(t, senderID, &recipientID, nil, "User2User")


### PR DESCRIPTION
## Root Cause

`CreateChatMessage` (`iznik-server-go/chat/chatmessage.go`, `POST /chat/:id/message`) had no idempotency protection: `db.Create(&payload)` inserted unconditionally. `useFetchRetry.js` (which backs every `$postv2` call, including `ChatAPI.send()`) retries on a network error, a 5xx, or an unparseable 2xx - outcomes that don't prove the write failed. A retried/double-submitted send therefore created a **second, genuinely-persisted** `chat_messages` row. Both rows briefly showed to the sender until the pre-existing `cleanup:chat-duplicates` cron (`PurgeService::deduplicateChatMessages`) removed one - matching the reporter's own follow-up ("there is now only one copy").

**Validated against live production data** (read-only, numeric ids only): user 19847492's chat room 21002446 (most recent activity 2026-07-13, matching the report's timing) shows the sender's messages as `platform=1` (in-app), `chattype=User2User`, `type` in `Interested`/`Default`/`Completed` - i.e. the plain `ChatFooter.vue` compose path (`chatStore.send()` → `POST /chat/:id/message`), **not** the batch mod-standard-message flow a prior investigation on an earlier occurrence of this topic had traced. This confirms the fix belongs in the Go API + Vue chat-send path, matching the required scope for this round.

## Evidence

New tests fail against pre-fix code (AssertFlip - stashed the client fix and re-ran):

```
FAIL  tests/unit/stores/chat.spec.js > chat store > send > generates a fresh idempotency key when the caller does not supply one
TypeError: .toMatch() expects to receive a string, but got undefined
FAIL  tests/unit/stores/chat.spec.js > chat store > send > passes a caller-supplied idempotency key through unchanged...
AssertionError: expected undefined to be 'caller-retry-key'
FAIL  tests/unit/components/ChatFooterSendIdempotency.spec.js (all 5 tests)
TypeError: (0 , getSendIdempotencyKey) is not a function
FAIL  tests/unit/composables/useChatSendIdempotency.spec.js (all 5 tests)
 Test Files  3 failed (3)
      Tests  17 failed | 38 passed (55)
```

After the fix, all pass: `Test Files 671 passed (671)` / `Tests 14286 passed | 4 skipped (14290)` (full `npx vitest run`, run locally in this worktree - `npm ci` + `npx nuxi prepare`).

Go side: `go build ./...`, `go vet ./chat/... ./test/...`, `gofmt -l` all clean on the changed files. This isolated worktree has no bound MySQL test DB, so the new Go tests (below) run under CI, which is the verification gate for this suite per this repo's established practice.

## Fix

- **`iznik-server-go/chat/chatmessage.go`**: added `ChatMessage.Idempotencykey` (`gorm:"-"`, populated from the JSON body). A non-nil key is validated against a canonical-UUID regex and **rejected outright (400)** if malformed - never truncated/sanitised, so a bad key can't collide two different sends. When present and valid, `CreateChatMessage` does `INSERT ... ON DUPLICATE KEY UPDATE id = LAST_INSERT_ID(id)` on the write connection (`db.DB()`, mirroring `GetOrCreateUser2UserChat`'s established pattern) instead of `db.Create()`. `RowsAffected() == 0` (the update hit an existing row rather than inserting) is logged as a duplicate-key hit. No key (older clients) uses the original `db.Create()` path, unchanged.
- **`iznik-batch/database/migrations/2026_07_14_000001_add_idempotency_key_to_chat_messages.php`** (+ prod `_migration.sql`): adds nullable `chat_messages.idempotencykey VARCHAR(64)` and `UNIQUE (chatid, userid, idempotencykey)`. Guarded on **both** the column and the index via `information_schema` (not just the column), `ALGORITHM=INPLACE, LOCK=NONE` - same Galera-safe pattern as the existing `2026_05_27_000001_widen_chat_messages_reportreason_enum` migration on this same large, high-traffic table. Nullable: MySQL never treats two NULLs as equal in a unique index, so old clients sending no key are unaffected - no backfill.
- **`composables/useTrace.js`**: exported the existing `generateUUID()` (previously module-internal) for reuse.
- **`composables/useChat.js`**: new pure function `getSendIdempotencyKey(pending, message)` - reuses the pending attempt's key when retrying the *same* text, generates a fresh one otherwise.
- **`stores/chat.js`**: `send()` converted from 7 positional args to an options object (`{ chatid, message, addressid, imageid, refmsgid, modnote, replysource, idempotencyKey }`); always sends `idempotencykey` (caller-supplied or freshly generated), so every send path gets dedup protection.
- **`components/ChatFooter.vue`**: new `pendingSend` ref holds `{ message, key }` of the last unconfirmed attempt. `send()` computes the key via `getSendIdempotencyKey`, reuses it across a "tap Send to retry"; clears it on success, on a **definitive 404** (the refmsg-gone check runs before any insert, so there's nothing to dedupe against - a further attempt is genuinely fresh), and on a **chat (props.id) change** (a key is meaningless outside the chat it was minted for).
- **`useFetchRetry.js` deliberately NOT touched.** The prior attempt (#1069) restricted auto-retry to GET/HEAD/OPTIONS app-wide, which silently dropped retry (and `waitForOnline`) from signup, message post, membership and settings PUT/DELETE - unrelated regression risk for a fix that only needs to cover chat send. Server-side idempotency makes this unnecessary: `useFetchRetry` always resends the identical request body (same closure `input`/`init`), so a retry carries the SAME `idempotencykey` automatically and the server-side unique index makes it a no-op - no client retry-policy change needed at all. This satisfies "scope the change to chat send only" more conservatively than touching shared infrastructure would.

## Reviewer Blockers Addressed (PR #1069 retry round 4)

1. **Incomplete diff** - `chatmessage.go` now implements the idempotency-key read + `INSERT ... ON DUPLICATE KEY UPDATE`; new Go tests (`TestCreateChatMessageIdempotencyKeyDedup` et al.) prove two POSTs with the same key → one row, one non-zero id.
2. **Scope regression** - `useFetchRetry.js` is untouched; retry/`waitForOnline` behaviour for every other endpoint (signup, message post, membership, settings) is unchanged. See "Fix" above for why this is safe.
3. **Test proves nothing** - the `readFileSync`/regex spec pattern from #1069 was never introduced here. `getSendIdempotencyKey` is unit-tested directly (`useChatSendIdempotency.spec.js`); the send/pendingSend/404-clear/id-change-clear behaviour is exercised via a **mounted** component (`ChatFooterSendIdempotency.spec.js`, `@vue/test-utils` `mount()` + real DOM events) using the real `getSendIdempotencyKey` - not a re-implementation. (The real `ChatFooter.vue` itself can't be mounted in this suite - ~10 Pinia stores, several `defineAsyncComponent` children, no Nuxt-auto-import test harness; same pre-existing constraint documented in `ChatFooter.spec.js`'s header and worked around the same way by the existing `ChatFooterDraftPersistence.spec.js`.)
4. **Unvalidated input into a unique index** - malformed/oversized keys are rejected with 400 via `idempotencyKeyRe` before ever reaching the INSERT; duplicate-key hits are logged.
5. **Migration guard wrong** - both the Laravel `up()`/`down()` and the prod `.sql` guard check the **index** (`information_schema.statistics`) as well as the column; `ALGORITHM=INPLACE, LOCK=NONE` stated explicitly, matching the existing enum-widening migration on this table.
6. **Sibling call sites unprotected** - `stores/chat.js send()` is now an options object; every one of the 9 `chatStore.send()` call sites plus `stores/mobile.js`'s notification-reply path (previously bypassed the store entirely) was converted/updated (see below). `pendingSend` is cleared on the 404 branch and on `props.id` change.

## Other Call Sites

`chatStore.send()` callers, all converted to the options-object signature and now idempotency-protected: `ChatFooter.vue` (message/address/photo), `ModChatFooter.vue` (message/address/photo), `ModChatNoteModal.vue`, `ChatButton.vue`, `MessageReportModal.vue`, `ChatMessageAddress.vue`, `stores/mobile.js` (`handleReplyAction`, now routed through the store instead of calling the API directly).

Other raw `chat_messages` INSERT sites (server-generated messages, not user sends - deliberately not touched, same reasoning as #1069): `chat/chatroom.go:1402` (nudge - already has its own last-message idempotency guard, see `TestPostChatRoomDoubleNudge`), `message/message.go:4663`, `message/bulkItem.go:277,407`, `message/helper.go:584`, `amp/amp.go:468`.

## Test

- `iznik-server-go/test/chat_test.go`: 4 new tests - `TestCreateChatMessageIdempotencyKeyDedup` (same key twice → same id, exactly 1 row), `TestCreateChatMessageIdempotencyKeyDeliberateResendCreatesNewRow` (different keys → 2 rows), `TestCreateChatMessageNoIdempotencyKeyBackwardCompatible` (no key → unaffected, 2 rows), `TestCreateChatMessageIdempotencyKeyInvalidRejected` (malformed key → 400). `go build`/`go vet`/`gofmt` clean; runs under CI (no local test DB in this isolated worktree).
- `iznik-nuxt3/tests/unit/composables/useChatSendIdempotency.spec.js` (5 tests, new) and `tests/unit/components/ChatFooterSendIdempotency.spec.js` (5 tests, new, mounted) - both fail on pre-fix code (see Evidence).
- `tests/unit/stores/chat.spec.js` updated for the options-object signature + 3 new idempotency-key tests.
- `tests/unit/stores/mobile.spec.js`, `tests/unit/components/ChatMessageAddress.spec.js`, `tests/unit/components/modtools/ModChatNoteModal.spec.js` updated for the new call signature.
- Full suite: `npx vitest run` → 671 files / 14286 passed, 4 pre-existing skips. `eslint --fix` clean on all changed files.

## Discourse
https://discourse.ilovefreegle.org/t/9913/1