### PR TITLE
fix(spatial): skip recent-message upsert when the parent was deleted mid-run

### DIFF
--- a/iznik-batch/app/Services/MessageSpatialService.php
+++ b/iznik-batch/app/Services/MessageSpatialService.php
@@ -4,6 +4,7 @@ namespace App\Services;
 
 use App\Models\Message;
 use App\Models\MessageGroup;
+use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 
@@ -78,25 +79,48 @@ class MessageSpatialService
             ->get();
 
         $count = 0;
+        $skippedVanished = 0;
         foreach ($msgs as $msg) {
             if (!$dryRun) {
                 // Coordinates come from DB, not user input — safe to embed in WKT.
                 $wkt = "POINT({$msg->lng} {$msg->lat})";
                 $srid = self::SRID;
 
-                DB::statement(
-                    "INSERT INTO messages_spatial (msgid, point, groupid, msgtype, arrival)
-                     VALUES (?, ST_GeomFromText('$wkt', $srid), ?, ?, ?)
-                     ON DUPLICATE KEY UPDATE
-                       point = ST_GeomFromText('$wkt', $srid),
-                       groupid = ?,
-                       msgtype = ?,
-                       arrival = ?",
-                    [$msg->id, $msg->groupid, $msg->msgtype, $msg->arrival,
-                     $msg->groupid, $msg->msgtype, $msg->arrival]
-                );
+                try {
+                    DB::statement(
+                        "INSERT INTO messages_spatial (msgid, point, groupid, msgtype, arrival)
+                         VALUES (?, ST_GeomFromText('$wkt', $srid), ?, ?, ?)
+                         ON DUPLICATE KEY UPDATE
+                           point = ST_GeomFromText('$wkt', $srid),
+                           groupid = ?,
+                           msgtype = ?,
+                           arrival = ?",
+                        [$msg->id, $msg->groupid, $msg->msgtype, $msg->arrival,
+                         $msg->groupid, $msg->msgtype, $msg->arrival]
+                    );
+                } catch (QueryException $e) {
+                    // errno 1452 = the messages_spatial->messages(id) FK failed: the parent
+                    // message no longer exists. The candidate list is SELECTed on the read
+                    // node (db2) but this INSERT runs on the write node (db3), and the split
+                    // is not sticky with wsrep_sync_wait=0, so Galera can still be applying a
+                    // delete on db2's queue that db3 has already committed. When purge:messages
+                    // (02:30 daily) hard-deletes a message, this reconciler — running every 5
+                    // minutes — can read the stale db2 row and then fail the insert on db3.
+                    // That message simply shouldn't be indexed: skip it and carry on. Aborting
+                    // here would drop every later upsert AND skip the four cleanup passes in
+                    // updateSpatialIndex() for a whole run. Re-throw anything that isn't 1452.
+                    if (($e->errorInfo[1] ?? null) !== 1452) {
+                        throw $e;
+                    }
+                    $skippedVanished++;
+                    continue;
+                }
             }
             $count++;
+        }
+
+        if ($skippedVanished > 0) {
+            Log::info("MessageSpatialIndex: skipped {$skippedVanished} recent upsert(s) whose message was deleted between the read-node snapshot and the write-node insert");
         }
 
         return $count;

--- a/iznik-batch/tests/Unit/Services/MessageSpatialServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/MessageSpatialServiceTest.php
@@ -92,6 +92,85 @@ class MessageSpatialServiceTest extends TestCase
         $this->assertEquals(0, DB::table('messages_spatial')->where('msgid', $message->id)->count());
     }
 
+    public function test_message_deleted_between_snapshot_and_insert_is_skipped_not_fatal(): void
+    {
+        // upsertRecentMessages SELECTs its candidates on the read node (db2) and INSERTs on the
+        // write node (db3). The split is not sticky and Galera runs with wsrep_sync_wait=0, so a
+        // delete committed on db3 can still be in db2's apply queue when the SELECT reads. When
+        // purge:messages (02:30 daily) hard-deletes a message, this every-5-minute reconciler can
+        // read the stale still-present row and then fail the insert on the FK to messages(id)
+        // (errno 1452). That one vanished message must NOT abort the run — otherwise every later
+        // upsert is dropped and all four cleanup passes are skipped. It must be skipped, and a
+        // valid sibling must still be indexed.
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+
+        // The message that will be deleted mid-run.
+        $doomed = Message::create([
+            'type' => Message::TYPE_OFFER,
+            'fromuser' => $user->id,
+            'subject' => 'OFFER: vanishing (London)',
+            'textbody' => 'Gone before insert.',
+            'source' => 'Platform',
+            'date' => now()->subDays(3),
+            'arrival' => now()->subDays(3),
+            'lat' => 51.5,
+            'lng' => -0.1,
+        ]);
+        MessageGroup::create([
+            'msgid' => $doomed->id,
+            'groupid' => $group->id,
+            'collection' => MessageGroup::COLLECTION_APPROVED,
+            'arrival' => now()->subDays(3),
+        ]);
+
+        // A valid sibling that must still be indexed despite the sibling's disappearance.
+        $survivor = Message::create([
+            'type' => Message::TYPE_OFFER,
+            'fromuser' => $user->id,
+            'subject' => 'OFFER: survivor (London)',
+            'textbody' => 'Still here.',
+            'source' => 'Platform',
+            'date' => now()->subDays(3),
+            'arrival' => now()->subDays(3),
+            'lat' => 51.6,
+            'lng' => -0.2,
+        ]);
+        MessageGroup::create([
+            'msgid' => $survivor->id,
+            'groupid' => $group->id,
+            'collection' => MessageGroup::COLLECTION_APPROVED,
+            'arrival' => now()->subDays(3),
+        ]);
+
+        // Reproduce the race deterministically: the candidate SELECT is the only query carrying an
+        // ST_X() term (its change-detection WHERE). DB::listen fires after a query completes, which
+        // is exactly the snapshot->insert gap — hard-delete the doomed message there, before the
+        // per-row inserts run. Scoped to $doomed->id so it is a harmless no-op if it ever re-fires.
+        $done = false;
+        DB::listen(function ($query) use ($doomed, &$done) {
+            if (!$done && stripos($query->sql, 'st_x(') !== false) {
+                $done = true;
+                DB::table('messages_groups')->where('msgid', $doomed->id)->delete();
+                DB::table('messages')->where('id', $doomed->id)->delete();
+            }
+        });
+
+        // Must not throw, even though the doomed message's parent row is gone at insert time.
+        $this->service->updateSpatialIndex();
+
+        $this->assertEquals(
+            0,
+            DB::table('messages_spatial')->where('msgid', $doomed->id)->count(),
+            'the deleted message is not indexed'
+        );
+        $this->assertEquals(
+            1,
+            DB::table('messages_spatial')->where('msgid', $survivor->id)->count(),
+            'the valid sibling is still indexed — the loop was not aborted by the vanished message'
+        );
+    }
+
     public function test_pending_rippled_in_row_keeps_approved_origin_spatial_row(): void
     {
         // #6 regression: removeNonApprovedMessages keys on (msgid, groupid), not msgid alone.


### PR DESCRIPTION
## The exception

```
PDOException 1452: Cannot add or update a child row: a foreign key constraint fails
(`iznik`.`messages_spatial`, CONSTRAINT `messages_spatial_ibfk_1`
 FOREIGN KEY (`msgid`) REFERENCES `messages` (`id`))
INSERT INTO messages_spatial (msgid, ...) VALUES (119128577, ...)
  at MessageSpatialService::upsertRecentMessages (line 87)
```

## Root cause (investigated, not assumed)

I initially guessed a same-node purge race; the evidence says something more specific.

**Audit trail for msgid 119128577** (`logs` table): rippled to 7 groups → origin removed **07-01** (`messages_groups.deleted=1` on the rippled copies, message row untouched) → autoreposted on its origin group **07-08** (arrival set to the value in the failing insert) → hard-deleted **07-14**.

**Timing**: the FK error fired **once**, at `2026-07-14 02:30:31`. `purge:messages` runs `dailyAt('02:30')`. The reconciler runs every 5 minutes; the one run that errored is the one that overlapped the purge.

**Mechanism** (confirmed against live config, not inferred):
- batch-prod splits reads → db2 (`DB_HOST_READ`=10.220.0.150), writes → db3 (`DB_HOST`=10.220.0.47); `config/database.php` has `'sticky' => false`.
- Both nodes report `wsrep_sync_wait = 0`.
- Laravel routes `->get()` (the candidate SELECT) to the read PDO (db2) and `DB::statement()` (the INSERT) to the write PDO (db3).

Galera certifies writes synchronously but **applies** them to other nodes asynchronously. With sync-wait off and no stickiness, the reconciler's SELECT on db2 read message 119128577 as still-present (its delete was committed on db3 but not yet applied on db2), then the INSERT on db3 failed the FK because the parent was already gone there. `config/database.php:62-64` explicitly assumes "a committed write is visible on the read nodes without meaningful delay" — true for read-after-*write*-of-your-own-row-in-a-txn, **false for read-after-delete across the split**.

The message's deletion itself was normal purge behaviour — nothing corrupt about it.

## Impact

The exception propagated out of the per-row loop, so a **single** vanished message aborted the entire run: every later `messages_spatial` upsert in that batch was dropped, and all four cleanup passes in `updateSpatialIndex()` (outcomes, removed_deleted, removed_old, removed_non_approved) were skipped. Self-clearing the next run (the SELECT no longer returns a purged message), but it recurs whenever the 02:30 purge overlaps a reconciler pass.

## Fix

Catch errno **1452** per row and skip — a candidate that passed the SELECT's `whereNull('messages.deleted')` filter but fails the FK can only mean the parent was deleted after the snapshot, which is always a benign "don't index it" case. Anything other than 1452 is re-thrown so real errors still surface. A count of skips is logged.

Regression test reproduces the snapshot→insert deletion deterministically with a `DB::listen` hook (fires after the candidate SELECT, before the inserts) and asserts (a) no exception and (b) a valid sibling message is still indexed.

## Deliberately not done here

- **Not** setting `wsrep_sync_wait=1` — that forces causal reads cluster-wide and would add latency to every read across the site (db3 is already CPU-bound). Too broad for this.
- **Not** forcing this reconciler's SELECT onto the write PDO — it would pile a heavy candidate scan onto the hottest node and only fixes this one job. The per-row skip is the correct resilience posture for an eventually-consistent reconciler and defends against any cause of the parent vanishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)