### PR TITLE
fix(compose): "Clear and start over" leaves a usable empty form, not a blank page

### DIFF
--- a/iznik-nuxt3/composables/useCompose.js
+++ b/iznik-nuxt3/composables/useCompose.js
@@ -251,10 +251,24 @@ export function makeCanSubmit({
   })
 }
 
-export async function deleteItem(id) {
+// "Clear and start over": reset the current item to empty IN PLACE, keeping its id and
+// type, so the store-bound inputs clear reactively and the compose form stays mounted.
+// The old handler deleted the message instead, which left the compose page with no item
+// to render - ids went empty, so the form disappeared (leaving just the stepper and the
+// "Add an item name..." hint) and the rest of the wizard read as invalid, e.g. the
+// whoami step showed a disabled "Enter email to continue" even for a logged-in user
+// (Discourse 9915). If there's somehow no message of this type yet, seed a blank one so
+// the form still renders.
+export function clearItem(id) {
   const composeStore = useComposeStore()
+  const type = postType.value
 
-  await composeStore.deleteMessage(id)
+  if (id !== undefined && id !== null && composeStore.message(id)) {
+    composeStore.clearMessage(id)
+  } else if (type && !composeStore.messages.some((m) => m && m.type === type)) {
+    const newId = composeStore.add()
+    composeStore.setType({ id: newId, type })
+  }
 }
 
 export function postcodeClear() {

--- a/iznik-nuxt3/pages/find/index.vue
+++ b/iznik-nuxt3/pages/find/index.vue
@@ -23,7 +23,7 @@
 
           <!-- Clear form - subtle link, shown only when there's content -->
           <div v-if="notblank" class="clear-form-section">
-            <a href="#" class="clear-link" @click.prevent="deleteItem(ids[0])">
+            <a href="#" class="clear-link" @click.prevent="clearAndStartOver">
               <v-icon icon="times" /> Clear and start over
             </a>
           </div>
@@ -59,7 +59,7 @@
 import { buildHead } from '~/composables/useBuildHead'
 import NoticeMessage from '~/components/NoticeMessage'
 import WizardProgressCompact from '~/components/WizardProgressCompact'
-import { setup, deleteItem } from '~/composables/useCompose'
+import { setup, clearItem } from '~/composables/useCompose'
 import { onMounted, computed, watch, nextTick, useRoute } from '#imports'
 import { useMiscStore } from '~/stores/misc'
 
@@ -120,6 +120,10 @@ useHead(
 const { me, ids, messageValid, uploadingPhoto, notblank } = await setup(
   'Wanted'
 )
+
+function clearAndStartOver() {
+  clearItem(ids.value[0])
+}
 
 // The 'Find an Item' conversion event fires on actual post completion in
 // freegleIt() (composables/useCompose.js), not on page mount - mounting the

--- a/iznik-nuxt3/pages/give/index.vue
+++ b/iznik-nuxt3/pages/give/index.vue
@@ -23,7 +23,7 @@
 
           <!-- Clear form - subtle link, shown only when there's content -->
           <div v-if="notblank" class="clear-form-section">
-            <a href="#" class="clear-link" @click.prevent="deleteItem(ids[0])">
+            <a href="#" class="clear-link" @click.prevent="clearAndStartOver">
               <v-icon icon="times" /> Clear and start over
             </a>
           </div>
@@ -59,7 +59,7 @@
 import { buildHead } from '~/composables/useBuildHead'
 import NoticeMessage from '~/components/NoticeMessage'
 import WizardProgressCompact from '~/components/WizardProgressCompact'
-import { setup, deleteItem } from '~/composables/useCompose'
+import { setup, clearItem } from '~/composables/useCompose'
 import { onMounted, computed, watch, nextTick, useRoute } from '#imports'
 import { useMiscStore } from '~/stores/misc'
 
@@ -122,6 +122,10 @@ useHead(
 )
 
 const { me, ids, messageValid, uploadingPhoto, notblank } = await setup('Offer')
+
+function clearAndStartOver() {
+  clearItem(ids.value[0])
+}
 
 // The 'Give an Item' conversion event fires on actual post completion in
 // freegleIt() (composables/useCompose.js), not on page mount - mounting the

--- a/iznik-nuxt3/stores/compose.js
+++ b/iznik-nuxt3/stores/compose.js
@@ -400,6 +400,20 @@ export const useComposeStore = defineStore({
     deleteMessage(id) {
       this.messages = this.messages.filter((m) => m.id !== id)
     },
+    // Reset a message's content to empty while keeping its id and type - used by "Clear
+    // and start over" so the compose form stays mounted (rather than vanishing when the
+    // message is deleted) and the store-bound inputs clear reactively. See
+    // useCompose.clearItem / Discourse 9915.
+    clearMessage(id) {
+      const idx = this.messages.findIndex((m) => m && m.id === id)
+      if (idx !== -1) {
+        this.messages[idx] = {
+          id,
+          type: this.messages[idx].type,
+          savedAt: Date.now(),
+        }
+      }
+    },
     async submit(params) {
       // This is the most important bit of code in the client :-).  We have our messages in the compose store.
       //

--- a/iznik-nuxt3/tests/unit/stores/compose.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/compose.spec.js
@@ -355,6 +355,41 @@ describe('compose store', () => {
     })
   })
 
+  describe('clearMessage', () => {
+    it('resets one message to empty, keeping its id and type', () => {
+      const store = useComposeStore()
+      store.messages = [
+        {
+          id: 0,
+          type: 'Offer',
+          item: 'bed and chair',
+          description: 'oak',
+          attachments: [{ id: 1 }],
+        },
+        { id: 1, type: 'Wanted', item: 'a bench' },
+      ]
+      store.clearMessage(0)
+      // Message 0 is reset to just id + type; others are untouched.
+      expect(store.messages[0].id).toBe(0)
+      expect(store.messages[0].type).toBe('Offer')
+      expect(store.messages[0].item).toBeUndefined()
+      expect(store.messages[0].description).toBeUndefined()
+      expect(store.messages[0].attachments).toBeUndefined()
+      expect(store.messages[1]).toEqual({
+        id: 1,
+        type: 'Wanted',
+        item: 'a bench',
+      })
+    })
+
+    it('does nothing when the id is not present', () => {
+      const store = useComposeStore()
+      store.messages = [{ id: 0, type: 'Offer', item: 'x' }]
+      store.clearMessage(99)
+      expect(store.messages[0].item).toBe('x')
+    })
+  })
+
   describe('calculateSteps', () => {
     it('counts 2 steps per new draft (id < 0)', () => {
       const store = useComposeStore()


### PR DESCRIPTION
## Problem
Discourse [/t/9915/1](https://discourse.ilovefreegle.org/t/clear-and-start-over/9915) — on the Give/Ask compose pages, clicking **"Clear and start over"** produced a blank grey page: the stepper and the *"Add an item name..."* hint, but **no form fields**. Because the wizard then read as invalid everywhere, the final email step showed a disabled **"Enter email to continue"** button even for a logged-in user, so the post couldn't be completed.

## Root cause
The handler deleted the compose message (`deleteMessage`). The item form renders `v-for="id in ids"` where `ids` is derived from the store, so deleting the only message left `ids` empty → the form unmounted entirely. The "ensure a message exists" seed only runs in `setup()` (page mount), not after a live delete.

## Fix
Reset the current item **in place** instead of deleting it:
- New compose-store `clearMessage(id)` action — empties the message's content but keeps its `id` and `type`, so the form stays mounted and the store-bound inputs clear reactively.
- `pages/give` and `pages/find` call a new `useCompose` `clearItem()` helper (resets in place, or seeds a blank message if somehow none of that type exists).
- Removed the now-unused `deleteItem` export.

## Test
- New unit tests for `clearMessage` in `tests/unit/stores/compose.spec.js` (resets one message, leaves others untouched, no-op for a missing id).
- Compose suites green locally: `compose.spec.js` 76, `useCompose.spec.js` 17, `useComposeFreegleIt.spec.js` 5, `ComposeGroup.spec.js` 8.
- Verified live on freegle-dev-live (Give **and** Ask): fill → **Clear** → empty usable form (Next hidden, hint shown) → re-enter → valid again and can proceed.

## Discourse
https://discourse.ilovefreegle.org/t/clear-and-start-over/9915

🤖 Generated with [Claude Code](https://claude.com/claude-code)