### PR TITLE
fix(modtools): persist typed-but-unsent chat drafts in ModChatFooter

### DIFF
--- a/iznik-nuxt3/modtools/components/ModChatFooter.vue
+++ b/iznik-nuxt3/modtools/components/ModChatFooter.vue
@@ -419,6 +419,7 @@ import {
   computed,
   watch,
   onMounted,
+  onBeforeUnmount,
   nextTick,
   defineAsyncComponent,
 } from 'vue'
@@ -432,6 +433,7 @@ import { useMiscStore } from '~/stores/misc'
 import { fetchOurOffers } from '~/composables/useThrottle'
 import { useAuthStore } from '~/stores/auth'
 import { useAddressStore } from '~/stores/address'
+import { useChatDraftStore } from '~/stores/chatdraft'
 import { untwem } from '~/composables/useTwem'
 import 'floating-vue/dist/style.css'
 import Api from '~/api'
@@ -499,10 +501,15 @@ const authStore = useAuthStore()
 const miscStore = useMiscStore()
 const addressStore = useAddressStore()
 const userStore = useUserStore()
+const chatDraftStore = useChatDraftStore()
 
-// Setup chat data using MT-specific composable
+// Setup chat data using MT-specific composable. setupChatMT() is synchronous and must NOT
+// be awaited: a top-level await in <script setup> makes Vue treat setup as async and
+// silently detaches watch()/onBeforeUnmount() registered afterwards (they never fire),
+// which would break the compose-draft flush-on-switch below. Mirrors the same fix in the
+// Freegle ChatFooter (topic 9884).
 const { chat, otheruser, tooSoonToNudge, chatStore, chatmessages } =
-  await setupChatMT(props.id)
+  setupChatMT(props.id)
 
 // Extract writable state from store
 const { lastTyping } = storeToRefs(miscStore)
@@ -518,6 +525,9 @@ const showPromiseMaybe = ref(false)
 const showProfileModal = ref(false)
 const showAddress = ref(false)
 const sendmessage = ref(null)
+// Composing-draft persistence: how long after the last keystroke the draft is saved.
+const DRAFT_SAVE_DEBOUNCE = 500
+let draftSaveTimer = null
 const RSVP = ref(false)
 const likelymsg = ref(null)
 const ouroffers = ref([])
@@ -822,8 +832,10 @@ const send = async (callback) => {
       // Send it
       await chatStore.send(props.id, msg)
 
-      // Clear the message now it's sent.
+      // Clear the message now it's sent - and drop the saved draft so it can't be restored.
       sendmessage.value = ''
+      if (draftSaveTimer) clearTimeout(draftSaveTimer)
+      chatDraftStore.clearDraft(props.id)
 
       await _updateAfterSend()
 
@@ -898,6 +910,37 @@ watch(sendmessage, (newVal, oldVal) => {
   if ((newVal && !oldVal) || (!newVal && oldVal)) {
     emit('typing', newVal?.length)
   }
+
+  // Persist the typed-but-unsent text (debounced) so switching to another chat - or reloading -
+  // doesn't lose it. Cleared on a successful send and when the box is emptied.
+  if (draftSaveTimer) clearTimeout(draftSaveTimer)
+  draftSaveTimer = setTimeout(() => {
+    chatDraftStore.saveDraft(props.id, sendmessage.value)
+  }, DRAFT_SAVE_DEBOUNCE)
+})
+
+// Restore this chat's saved draft into the compose box. On an in-place id change, save the
+// previous chat's draft first so switching never loses text. Only fills an empty box, never
+// clobbering live typing.
+watch(
+  () => props.id,
+  (newId, oldId) => {
+    if (oldId && oldId !== newId) {
+      chatDraftStore.saveDraft(oldId, sendmessage.value)
+    }
+    const saved = chatDraftStore.getDraft(newId)
+    if (saved && !sendmessage.value) {
+      sendmessage.value = saved
+    }
+  },
+  { immediate: true }
+)
+
+// A draft typed just before switching may still be sitting in the debounce timer when this
+// component is torn down on the switch - flush it so nothing is lost.
+onBeforeUnmount(() => {
+  if (draftSaveTimer) clearTimeout(draftSaveTimer)
+  chatDraftStore.saveDraft(props.id, sendmessage.value)
 })
 
 watch(

--- a/iznik-nuxt3/tests/unit/components/modtools/ModChatFooter.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModChatFooter.spec.js
@@ -169,6 +169,16 @@ vi.mock('pinia', () => {
   }
 })
 
+// Mock the chat-draft store. pinia is mocked above (no defineStore), so the
+// real store module can't initialise here - stub the API the footer uses.
+vi.mock('~/stores/chatdraft', () => ({
+  useChatDraftStore: () => ({
+    saveDraft: vi.fn(),
+    getDraft: vi.fn(() => ''),
+    clearDraft: vi.fn(),
+  }),
+}))
+
 // Mock composables
 vi.mock('~/composables/useMe', () => ({
   useMe: () => ({


### PR DESCRIPTION
## Summary
Brings the **ModTools** chat compose box to parity with the Freegle chat (`ChatFooter`): typed-but-unsent text is now saved per-chat and restored when switching chats or reloading, instead of being lost. Uses the shared `useChatDraftStore` (localStorage-backed, 24h window).

## Changes (`modtools/components/ModChatFooter.vue`)
- Debounced save (500ms) on keystroke via `watch(sendmessage)`.
- Restore the chat's saved draft into an **empty** box on chat switch, saving the previous chat's draft first (`watch(() => props.id, { immediate: true })`).
- Flush any pending debounced draft on `onBeforeUnmount`.
- Clear the draft (and pending timer) on a successful send.
- **`setupChatMT()` is no longer awaited.** It is synchronous; a top-level `await` in `<script setup>` makes Vue treat setup as async and silently detaches the `watch()`/`onBeforeUnmount()` registered afterwards (they never fire), which would break the draft flush-on-switch. This mirrors the fix already applied to the Freegle `ChatFooter` (topic 9884), and also re-activates the existing hooks (typing indicator, address suggestions, notices auto-hide).

## Test
- Lints clean; the ModTools app compiles and renders with the change (verified on modtools-dev-live).
- Draft logic is identical to the shipped Freegle `ChatFooter` implementation and the same `useChatDraftStore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)