### PR TITLE
ci(docs): only commit regenerated screenshots on master, not PR branches

### DIFF
--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -311,7 +311,18 @@ workflows:
                   if ! command -v compare >/dev/null 2>&1; then
                     sudo apt-get update -qq >/dev/null 2>&1 && sudo apt-get install -y -qq imagemagick >/dev/null 2>&1 || echo "imagemagick unavailable (will commit all changes)"
                   fi
-                  DOCS_ALLOW_MASTER=1 bash docs/screenshots/regenerate-and-commit.sh --commit-only || echo "commit step non-fatal"
+                  # Only commit + push the regenerated screenshots on master. On a PR
+                  # branch the shots are still generated and uploaded as CI artifacts
+                  # (store_artifacts below) for review, but NOT committed to the branch:
+                  # pushing a "docs: regenerate screenshots" commit onto a PR branch emails
+                  # the PR author a GitHub notification on every run, which is pure noise.
+                  # Screenshots stay current because master regenerates them on its own
+                  # build after merge; the docs-freshness gate ignores the assets dir.
+                  if [ "${CIRCLE_BRANCH:-}" = "master" ]; then
+                    DOCS_ALLOW_MASTER=1 bash docs/screenshots/regenerate-and-commit.sh --commit-only || echo "commit step non-fatal"
+                  else
+                    echo "PR branch (${CIRCLE_BRANCH:-unknown}): screenshots uploaded as artifacts only, not committed to the branch."
+                  fi
                   exit 0
             - store_artifacts:
                 path: ~/artifacts/doc-screenshots


### PR DESCRIPTION
## Problem
The "Regenerate doc screenshots (best effort)" post-step runs on **every** build-and-test — including PR-branch builds — and pushes a `docs: regenerate screenshots [skip ci]` commit back to the branch (`git push HEAD:$CIRCLE_BRANCH`). On a PR branch that fires a GitHub notification to the **PR author on every run**. Since you're auto-subscribed to your own PRs, that's a stream of noise email on every push, on every PR.

The step's own comment even says the shots should be *"committed onto master"* — it just wasn't gated to master.

## Fix
Gate the commit + push to `master` only:
- **master**: regenerates, commits, and pushes the screenshots (keeps master's docs current after merge — unchanged behaviour).
- **PR branches**: screenshots are still generated and uploaded as CI artifacts (`store_artifacts`) for review, but **not** committed to the branch → no push → no author notification.

## Safe
- The docs-freshness gate (`scripts/check-docs-freshness.mjs`) explicitly skips the `assets` dir, so it doesn't depend on in-PR screenshots.
- No CI job fails on stale screenshots (the step is best-effort).
- YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)