### PR TITLE
fix(modtools): scope standard message + signature to moderating group on rippled posts

### DIFF
--- a/iznik-nuxt3/modtools/components/ModMessage.vue
+++ b/iznik-nuxt3/modtools/components/ModMessage.vue
@@ -1212,9 +1212,15 @@ const configid = computed(() => {
   // Look up configid from authStore.groups (always populated from session)
   // rather than relying on modGroupStore.list[].mysettings which may not be
   // populated yet due to a race condition with fetchGroupMT().
-  if (groupid.value && authStore.groups) {
+  //
+  // Anchor to currentGroupid (the group this copy is being administered on),
+  // not groupid (which falls back to groups[0] - no guaranteed order). Using
+  // groupid here let a rippled post's standard-message list and substitutions
+  // ($groupname etc.) come from a different group's config than the one shown
+  // as "moderating for" and used to send/sign the reply (Discourse 9862/15).
+  if (currentGroupid.value && authStore.groups) {
     const sessionGroup = authStore.groups.find(
-      (g) => parseInt(g.groupid) === parseInt(groupid.value)
+      (g) => parseInt(g.groupid) === parseInt(currentGroupid.value)
     )
     if (sessionGroup?.configid) {
       id = sessionGroup.configid

--- a/iznik-nuxt3/tests/unit/components/modtools/ModMessage.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModMessage.spec.js
@@ -1556,6 +1556,49 @@ describe('ModMessage', () => {
       }
     })
 
+    // Discourse 9862/15: a mod found a standard message configured only for other
+    // groups (Newham/Hackney) available on a rippled post, auto-signed as Tower
+    // Hamlets (the group they were actually moderating it under). configid drives
+    // which group's stdmsg config is offered/substituted, so it must anchor to
+    // currentGroupid (the group being moderated) - not groups[0], which has no
+    // guaranteed order and can be the rippled-in copy.
+    it('resolves configid from the group being moderated (currentGroupid), not groups[0], for a rippled post with no contextGroupid', () => {
+      mockMyModGroups.push({ id: 111 })
+      mockAuthStore.groups.push({ groupid: 111, configid: 2 })
+      try {
+        const wrapper = mountComponent(
+          {},
+          {
+            groups: [
+              // Rippled-in copy (e.g. Newham/Hackney): approved most recently, so
+              // its arrival is the NEWEST, and it happens to be groups[0].
+              {
+                groupid: 789,
+                namedisplay: 'Rippled-in',
+                collection: 'Approved',
+                arrival: rippleLater,
+                rippled_in: 1,
+              },
+              // Origin (e.g. Tower Hamlets): where the mod is actually administering
+              // this post from - currentGroupid anchors here.
+              {
+                groupid: 111,
+                namedisplay: 'Origin',
+                collection: 'Approved',
+                arrival: rippleEarlier,
+                rippled_in: 0,
+              },
+            ],
+          }
+        )
+        expect(wrapper.vm.currentGroupid).toBe(111)
+        expect(wrapper.vm.configid).toBe(2)
+      } finally {
+        mockMyModGroups.pop()
+        mockAuthStore.groups.pop()
+      }
+    })
+
     it('computes contextGroup from the correct group', () => {
       const wrapper = mountComponent(
         { contextGroupid: 999 },


### PR DESCRIPTION
## Root Cause
`ModMessage.vue`'s `configid` computed - which selects which group's standard-message config is offered in `ModMessageButtons` and used for `$groupname`/`$volunteersemail`/etc. substitutions when composing a reply - was derived from the naive `groupid` computed (`props.contextGroupid` or, failing that, `message.groups[0].groupid`). `message.groups` has no guaranteed order (documented explicitly in `composables/rippleStatus.js`), so `groups[0]` can be any group the post is on.

Every other group-resolution computed in this component (`isHomeGroup`, `group`, `otherGroups`, `currentGroupName`, `contextGroup`) was already migrated to anchor on `currentGroupid` - a rippling-aware resolver that anchors to the group actually being moderated (home/origin group, restricted to groups the mod moderates) - specifically to avoid this class of bug (see Discourse 9518/9808/565 fixes). `configid` was the one call site left behind, still keyed off the pre-rippling `groupid`.

In a specific group's queue (`contextGroupid` set), `groupid` and `currentGroupid` are identical, so the bug is invisible there. It only shows up in views with no explicit context group (e.g. the all-communities pending queue): if a mod moderates several groups and a rippled post's `groups[0]` entry happens to be a different group than the one `currentGroupid` resolves to (the post's actual home/origin group being moderated), `configid` pulls in the wrong group's standard-message config while the send/sign path (`:groupid="currentGroupid"`, correctly threaded through `ModMessageButtons` → `ModMessageButton` → `ModStdMessageModal`) uses the right one.

## Evidence
AssertFlip: added a test that mirrors the existing "anchors to the origin group, not a newer rippled-in copy" test's setup (mod moderating both a rippled-in group and the post's origin group, no `contextGroupid`), asserting `configid` matches the origin group's config rather than `groups[0]`'s. It fails against the pre-fix code:
```
FAIL  ModMessage.spec.js > ModMessage > multi-group support > resolves configid from the group being moderated (currentGroupid), not groups[0], for a rippled post with no contextGroupid
AssertionError: expected 1 to be 2 // Object.is equality
- Expected: 2
+ Received: 1
 ❯ tests/unit/components/modtools/ModMessage.spec.js:1549:37
    expect(wrapper.vm.currentGroupid).toBe(111)
    expect(wrapper.vm.configid).toBe(2)
```
After the fix: full `ModMessage.spec.js` (88 tests) and the `tests/unit/components/modtools/` regression suite (161 files / 4231 tests) all pass.

## Fix
`ModMessage.vue`: `configid` now looks up `authStore.groups` by `currentGroupid.value` instead of `groupid.value`, matching every other group-resolution computed in the component.

## Other Call Sites
- `ModMember.vue` has its own, unrelated `configid` computed for membership (not message) contexts - memberships belong to a single group, not multi-group rippled posts, so it's out of scope.
- `ModMessageButton.vue`, `ModStdMessageModal.vue`, `ModMessageCrosspost.vue`, `ModMessageDuplicate.vue` all have a `groups[0]` fallback too, but each is guarded by an explicit `groupid` prop first, and that prop is always supplied (as `currentGroupid`) by the current call chain - so they're unaffected.
- Go API (`iznik-server-go/modconfig/modconfig.go`, `GetModConfig`) filters `mod_stdmsgs` by a single `configid` server-side - no cross-group leakage there; the bug was entirely in which `configid` the frontend requested.

## Test
`iznik-nuxt3/tests/unit/components/modtools/ModMessage.spec.js` - `npx vitest run tests/unit/components/modtools/ModMessage.spec.js`. New test fails-before / passes-after (see Evidence); full `tests/unit/components/modtools/` suite (161 files, 4231 tests) passes with no regressions.

## Discourse
https://discourse.ilovefreegle.org/t/9862/15