### PR TITLE
fix(chat): stop a stale message-fetch race from clobbering a just-sent message

### DIFF
--- a/iznik-nuxt3/stores/chat.js
+++ b/iznik-nuxt3/stores/chat.js
@@ -14,6 +14,7 @@ export const useChatStore = defineStore({
     listByChatId: {},
     listByChatMessageId: {},
     messages: {},
+    messagesFetchSeq: {},
     searchSince: null,
     showContactDetailsAskModal: false,
     showClosed: false,
@@ -27,6 +28,7 @@ export const useChatStore = defineStore({
       this.listByChatId = {}
       this.listByChatMessageId = {}
       this.messages = {}
+      this.messagesFetchSeq = {}
       this.searchSince = null
       this.showContactDetailsAskModal = false
       this.currentChatMT = null
@@ -258,10 +260,26 @@ export const useChatStore = defineStore({
       }
     },
     async fetchMessages(id, force) {
+      // Callers routinely fire off more than one fetchMessages(id) for the same chat in
+      // quick succession and don't wait for each other (e.g. send() triggers its own
+      // refresh and the caller of send() triggers another straight after). Network
+      // timing gives no guarantee the responses land in the order they were requested,
+      // so track which call is the most recent for this chat and ignore a response if a
+      // newer request has since been made - an older, slower response must never
+      // clobber fresher data (#9913).
+      const seq = (this.messagesFetchSeq[id] || 0) + 1
+      this.messagesFetchSeq[id] = seq
+
       let messages = []
       const miscStore = useMiscStore() // MT
       const params = miscStore.modtools ? { modtools: true } : {}
       messages = await api(this.config).chat.fetchMessages(id, params)
+
+      if (this.messagesFetchSeq[id] !== seq) {
+        // A newer fetchMessages(id) call has been made since this one started - this
+        // response is stale, so drop it rather than overwrite more current data.
+        return messages
+      }
 
       const update = () => {
         this.messages[id] = messages

--- a/iznik-nuxt3/tests/unit/stores/chat.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/chat.spec.js
@@ -352,6 +352,51 @@ describe('chat store', () => {
       // Force causes listByChatMessageId to be rebuilt
       expect(store.listByChatMessageId[10]).toBeTruthy()
     })
+
+    it('keeps the freshest data when an overlapping fetch resolves late (9913)', async () => {
+      // send() fires an un-awaited fetchMessages(chatid) internally (chat.js), and
+      // ChatFooter's _updateAfterSend() fires a second, explicit fetchMessages() right
+      // after — two concurrent, unsynchronised requests for the same chat on every
+      // send. If the earlier-dispatched one is slower (e.g. it lands on a lagging
+      // read replica) and resolves AFTER the later one, it must not clobber the
+      // fresher state with a stale snapshot that is missing the just-sent message.
+      const store = useChatStore()
+      store.config = {}
+      store.messages[10] = [{ id: 1, message: 'hi' }]
+
+      let resolveSlowStaleFetch
+      const slowStaleFetch = new Promise((resolve) => {
+        resolveSlowStaleFetch = resolve
+      })
+
+      mockFetchMessages
+        // Call #1: dispatched first (send()'s internal fire-and-forget refresh) but
+        // kept pending — simulates it losing the race to a lagging read replica.
+        .mockImplementationOnce(() => slowStaleFetch)
+        // Call #2: dispatched second (the explicit post-send refresh) but resolves
+        // immediately with the up-to-date list including the sent message.
+        .mockImplementationOnce(() =>
+          Promise.resolve([
+            { id: 1, message: 'hi' },
+            { id: 2, message: 'new message' },
+          ])
+        )
+
+      const call1 = store.fetchMessages(10)
+      await store.fetchMessages(10)
+
+      // The just-sent message is visible.
+      expect(store.messages[10]).toHaveLength(2)
+
+      // Call #1 now finally resolves with its stale, pre-send snapshot.
+      resolveSlowStaleFetch([{ id: 1, message: 'hi' }])
+      await call1
+
+      // The just-sent message must still be visible — a late, stale response must
+      // not be allowed to overwrite the fresher state.
+      expect(store.messages[10]).toHaveLength(2)
+      expect(store.messages[10].map((m) => m.id)).toEqual([1, 2])
+    })
   })
 
   describe('fetchChat', () => {


### PR DESCRIPTION
## Root Cause
`stores/chat.js` `send()` fires an **un-awaited** `this.fetchMessages(chatid)` as a fire-and-forget refresh after posting. Every current caller of `send()` (`ChatFooter.vue`'s `_updateAfterSend()`, `ChatMessageAddress.vue`, `ModChatFooter.vue`, etc.) then *also* makes its own explicit `fetchMessages()` call right afterwards. That means every single chat send dispatches **two unsynchronised, concurrent** `GET /chat/:id/message` requests for the same chat, with no guarantee they resolve in the order they were sent (read-replica lag, network jitter, etc. can easily reorder them — see the existing DB read/write-split issues in this codebase).

`fetchMessages()`'s update logic only compared array *lengths* to decide whether to apply a response:

```js
if (this.messages[id]?.length !== messages.length) {
  update()
}
```

There was no check for whether the response was still the *latest* outstanding request. So if the earlier-dispatched request happened to resolve *after* the later one (e.g. it hit a lagging read replica while the second request hit a fresher one), its stale, pre-send snapshot would silently overwrite the store — the just-sent message would flash into view and then vanish again, only reappearing once a later poll caught up. This is the race behind the transient duplicate/inconsistent rendering reported in direct member Chat.

I confirmed the mechanism directly in this code path rather than assuming the prior PR's ChitChat-style diagnosis applied: direct Chat's `ChatFooter.vue` binds only `@keyup.enter.exact="sendOnEnter"` (single handler, guarded synchronously by `sending.value`), so the ChitChat keydown+keyup double-submit bug does not exist here. There is also no optimistic local message append anywhere in `stores/chat.js` — every update is a full-array replace from the API response. The actual race is the redundant unguarded double-fetch above.

## Evidence
Failing test before the fix (`tests/unit/stores/chat.spec.js`):
```
❯ tests/unit/stores/chat.spec.js:397:34
AssertionError: expected [ { id: 1, message: 'hi' } ] to have a length of 2 but got 1
    395|       // The just-sent message must still be visible — a late, stale r…
    396|       // not be allowed to overwrite the fresher state.
    397|       expect(store.messages[10]).toHaveLength(2)
       |                                  ^
    398|       expect(store.messages[10].map((m) => m.id)).toEqual([1, 2])

 Test Files  1 failed (1)
      Tests  1 failed | 42 passed (43)
```
This reproduces the bug directly: a slow, stale `fetchMessages` response (dispatched first, resolves last) wipes out a freshly-rendered just-sent message.

## Fix
Added a per-chat monotonic sequence counter (`messagesFetchSeq`) in the chat store. Each `fetchMessages(id)` call stamps itself with the current sequence number for that chat on entry; when its response arrives, it only applies the update if it is still the most recently-dispatched call for that chat id. A response from a superseded (older) request is dropped instead of overwriting fresher state — regardless of network arrival order. This fixes the race at its root (in the shared store method), rather than papering over it in one caller, so it also covers ModTools' `ModChatPane`/`ModChatFooter`, which share the same `chatStore.fetchMessages`.

## Other Call Sites
Grepped all callers of `chatStore.send(` and `chatStore.fetchMessages(` — every one goes through the same shared store method, so this fix covers direct member chat (`ChatFooter.vue`), address sending (`ChatMessageAddress.vue`), message reporting (`MessageReportModal.vue`), and the ModTools chat panes uniformly. No separate optimistic-append pattern exists elsewhere in the chat code (verified via grep for `messages[...].push/unshift` — none found; all updates are full-array replaces).

## Test
- File: `iznik-nuxt3/tests/unit/stores/chat.spec.js`
- Command: `npx vitest run tests/unit/stores/chat.spec.js`
- Fail before / pass after: the new test `fetchMessages > keeps the freshest data when an overlapping fetch resolves late (9913)` fails on unfixed code (`expected length 2 but got 1`) and passes once the sequence-guard fix is applied.
- Full unit suite: `npx vitest run` — 669 files, 14289 tests passed, 4 pre-existing skips, no regressions.

## Discourse
https://discourse.ilovefreegle.org/t/9913/1