### PR TITLE
fix(modtools): standard-message Reject on a rippled-in copy scopes like the button (9862/16-17)

### DIFF
--- a/iznik-nuxt3/modtools/components/ModMessageButton.vue
+++ b/iznik-nuxt3/modtools/components/ModMessageButton.vue
@@ -59,8 +59,8 @@
           community where it was first posted.
         </p>
         <p class="mb-0">
-          The freegler won't be told, because they don't need to know unless it's
-          rejected on their home community. So there's no message to send.
+          The freegler won't be told, because they don't need to know unless
+          it's rejected on their home community. So there's no message to send.
         </p>
       </template>
     </ConfirmModal>
@@ -339,6 +339,22 @@ async function click(callback) {
       showRejectNoMsgModal.value = true
       if (callback) callback()
       return
+    }
+
+    if (props.stdmsgid && !props.isHomeGroup) {
+      // A standard message whose action is Reject, applied to a rippled-in copy,
+      // must behave exactly like the Reject button above: scope the removal to
+      // this group with NO message to the member, and show the same "stop
+      // appearing on your community" confirmation (Discourse 9862/16-17). We only
+      // take this DESTRUCTIVE scoped path when the action is DEFINITIVELY 'Reject':
+      // if the standard message can't be resolved we fall through to the normal
+      // compose modal (fail closed; cf. the fail-open flaw that closed PR #1071).
+      const stdmsg = await stdmsgStore.fetch(props.stdmsgid)
+      if (stdmsg?.action === 'Reject') {
+        showRejectNoMsgModal.value = true
+        if (callback) callback()
+        return
+      }
     }
 
     if (props.reject) {

--- a/iznik-nuxt3/modtools/components/ModMessageButtons.vue
+++ b/iznik-nuxt3/modtools/components/ModMessageButtons.vue
@@ -150,6 +150,7 @@
         :stdmsgid="stdmsg.id"
         :messageid="message.id"
         :groupid="groupid"
+        :is-home-group="isHomeGroup"
         :autosend="Boolean(stdmsg.autosend && allowAutoSend)"
       />
       <b-button

--- a/iznik-nuxt3/tests/unit/components/modtools/ModMessageButton.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModMessageButton.spec.js
@@ -254,7 +254,10 @@ describe('ModMessageButton', () => {
     it('calls messageStore.hold when hold prop is true', async () => {
       const wrapper = mountComponent({ hold: true }, { id: 555 })
       await wrapper.vm.click()
-      expect(mockMessageStore.hold).toHaveBeenCalledWith({ id: 555, groupid: 456 })
+      expect(mockMessageStore.hold).toHaveBeenCalledWith({
+        id: 555,
+        groupid: 456,
+      })
     })
 
     it('calls checkWorkDeferGetMessages after hold', async () => {
@@ -268,7 +271,10 @@ describe('ModMessageButton', () => {
     it('calls messageStore.release when release prop is true', async () => {
       const wrapper = mountComponent({ release: true }, { id: 666 })
       await wrapper.vm.click()
-      expect(mockMessageStore.release).toHaveBeenCalledWith({ id: 666, groupid: 456 })
+      expect(mockMessageStore.release).toHaveBeenCalledWith({
+        id: 666,
+        groupid: 456,
+      })
     })
 
     it('calls checkWorkDeferGetMessages after release', async () => {
@@ -362,23 +368,65 @@ describe('ModMessageButton', () => {
 
   describe('stdmsgid action (fetch standard message)', () => {
     it('fetches standard message when stdmsgid prop is set', async () => {
-      const wrapper = mountComponent({ stdmsgid: 42 })
+      const wrapper = mountComponent({ stdmsgid: 42, isHomeGroup: true })
       await wrapper.vm.click()
       await flushPromises()
       expect(mockStdmsgStore.fetch).toHaveBeenCalledWith(42)
     })
 
     it('sets stdmsgId from prop after fetch', async () => {
-      const wrapper = mountComponent({ stdmsgid: 42 })
+      const wrapper = mountComponent({ stdmsgid: 42, isHomeGroup: true })
       await wrapper.vm.click()
       await flushPromises()
       expect(wrapper.vm.stdmsgId).toBe(42)
     })
 
     it('shows stdmsg modal when stdmsgid is set', async () => {
-      const wrapper = mountComponent({ stdmsgid: 42 })
+      const wrapper = mountComponent({ stdmsgid: 42, isHomeGroup: true })
       await wrapper.vm.click()
       await flushPromises()
+      expect(wrapper.vm.showStdMsgModal).toBe(true)
+    })
+  })
+
+  describe('stdmsg reject on a rippled-in copy (Discourse 9862/16-17)', () => {
+    it('routes a Reject standard message on a rippled-in copy to the scoped no-message removal', async () => {
+      // action:'Reject' from the default mock; isHomeGroup:false = rippled-in copy.
+      const wrapper = mountComponent({ stdmsgid: 42, isHomeGroup: false })
+      await wrapper.vm.click()
+      await flushPromises()
+      // Same scoped confirmation as the Reject button - NOT the compose modal.
+      expect(wrapper.vm.showRejectNoMsgModal).toBe(true)
+      expect(wrapper.vm.showStdMsgModal).toBe(false)
+    })
+
+    it('still opens the compose modal for a Reject standard message on the HOME group', async () => {
+      const wrapper = mountComponent({ stdmsgid: 42, isHomeGroup: true })
+      await wrapper.vm.click()
+      await flushPromises()
+      expect(wrapper.vm.showStdMsgModal).toBe(true)
+      expect(wrapper.vm.showRejectNoMsgModal).toBe(false)
+    })
+
+    it('opens the compose modal (does NOT scope-delete) for a non-Reject standard message on a rippled-in copy', async () => {
+      mockStdmsgStore.fetch.mockResolvedValueOnce({
+        id: 42,
+        action: 'Leave Member',
+      })
+      const wrapper = mountComponent({ stdmsgid: 42, isHomeGroup: false })
+      await wrapper.vm.click()
+      await flushPromises()
+      expect(wrapper.vm.showStdMsgModal).toBe(true)
+      expect(wrapper.vm.showRejectNoMsgModal).toBe(false)
+    })
+
+    it('fails closed: opens the compose modal (does NOT scope-delete) when the action cannot be resolved', async () => {
+      // fetch returns no usable object → action undefined → must not treat as Reject.
+      mockStdmsgStore.fetch.mockResolvedValueOnce(null)
+      const wrapper = mountComponent({ stdmsgid: 42, isHomeGroup: false })
+      await wrapper.vm.click()
+      await flushPromises()
+      expect(wrapper.vm.showRejectNoMsgModal).toBe(false)
       expect(wrapper.vm.showStdMsgModal).toBe(true)
     })
   })


### PR DESCRIPTION
Follow-up to #1079 (9862/15, already merged), covering Neville's posts 16-17 on https://discourse.ilovefreegle.org/t/reporting-posts/9862/16

## Problem
On a rippled-in copy the **Reject button** already scopes correctly: the "stop this post appearing on your community" confirmation, a removal from just this group, and no message to the member. But a **standard message with action=Reject** went through the compose modal instead - it sent a message and did a full (global) reject. So a mod using a local standard message got a different dialog and a "Rejected" (not scoped) outcome.

## Fix
`ModMessageButton.click()` now routes a standard message whose action is `Reject`, on a rippled-in copy, through the **same scoped path as the Reject button**: the no-message confirmation + a reject scoped to this group, no message to the member.

- **Fail closed**: only takes the destructive scoped path when the action is *definitively* `Reject`; an unresolvable standard message falls through to the compose modal (the fail-open handling of an unknown action is what closed #1071).
- Passes `is-home-group` to the standard-message buttons (previously only the Reject button got it, so they defaulted to home-group and never scoped).

## Verification
`iznik-nuxt3/tests/unit/components/modtools/ModMessageButton.spec.js` - scoped on rippled-in, home group still opens the modal, non-Reject not scoped, and fails-closed on an unresolved action. Full suite green (14260).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rm8xqAcBsnaYWZkrp5KAMA
