### PR TITLE
fix(modtools): member settings toggles now persist (Discourse 9923)

### DIFF
--- a/iznik-nuxt3/modtools/components/ModMember.vue
+++ b/iznik-nuxt3/modtools/components/ModMember.vue
@@ -523,8 +523,14 @@ function settingsChange(param, groupidArg, val) {
   memberStore.update(params)
 }
 
+// OurToggle emits its `change` event with the new value directly (emit('change',
+// newVal)), NOT wrapped as { value }. Reading e.value gave `undefined`, which
+// JSON.stringify strips from the request body, so the one field being toggled was
+// the one key missing from the PATCH - JSON_MERGE_PATCH then left it unchanged and
+// the toggle silently "didn't stick" (Discourse 9923). Use the emitted value `e`,
+// matching the member-facing settings sections (EmailSettingsSection, etc.).
 async function changeNotification(e, notifType) {
-  const notificationsObj = { ...notifications.value, [notifType]: e.value }
+  const notificationsObj = { ...notifications.value, [notifType]: e }
 
   await userStore.edit({
     id: user.value.id,
@@ -535,28 +541,28 @@ async function changeNotification(e, notifType) {
 async function changeRelevant(e) {
   await userStore.edit({
     id: user.value.id,
-    relevantallowed: e.value,
+    relevantallowed: e,
   })
 }
 
 async function changeNotifChitchat(e) {
   await userStore.edit({
     id: user.value.id,
-    settings: { notificationmails: e.value },
+    settings: { notificationmails: e },
   })
 }
 
 async function changeNewsletter(e) {
   await userStore.edit({
     id: user.value.id,
-    newslettersallowed: e.value,
+    newslettersallowed: e,
   })
 }
 
 async function changeAutorepost(e) {
   await userStore.edit({
     id: member.value?.userid,
-    settings: { autorepostsdisable: !e.value },
+    settings: { autorepostsdisable: !e },
   })
 }
 

--- a/iznik-nuxt3/tests/unit/components/modtools/ModMember.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModMember.spec.js
@@ -208,8 +208,10 @@ describe('ModMember', () => {
             ],
           },
           OurToggle: {
+            // Matches the real OurToggle contract: change emits the new value
+            // directly (emit('change', newVal)), NOT wrapped as { value } (9923).
             template:
-              '<button class="our-toggle" :data-checked="modelValue" @click="$emit(\'change\', { value: !modelValue })"><slot /></button>',
+              '<button class="our-toggle" :data-checked="modelValue" @click="$emit(\'change\', !modelValue)"><slot /></button>',
             props: [
               'modelValue',
               'height',
@@ -718,13 +720,24 @@ describe('ModMember', () => {
       })
     })
 
-    it('changeNotification sends only notifications field', async () => {
+    // OurToggle emits the new value directly (a boolean), so the handlers receive
+    // it as `e`, not `e.value` (9923). Passing `{ value }` here previously masked
+    // the bug where the toggled field was sent as `undefined` and stripped.
+    it('changeNotification sends the toggled key with the emitted value', async () => {
       const wrapper = mountComponent()
-      await wrapper.vm.changeNotification({ value: false }, 'email')
+      await wrapper.vm.changeNotification(false, 'email')
       expect(mockUserStore.edit).toHaveBeenCalledWith({
         id: 123,
         settings: { notifications: expect.objectContaining({ email: false }) },
       })
+      // Regression: the toggled key must actually be present (not undefined /
+      // stripped by JSON.stringify) so JSON_MERGE_PATCH changes it.
+      const sentNotifications =
+        mockUserStore.edit.mock.calls[0][0].settings.notifications
+      expect(Object.prototype.hasOwnProperty.call(sentNotifications, 'email')).toBe(
+        true
+      )
+      expect(sentNotifications.email).toBe(false)
       // Must NOT send mod-specific fields like modnotifs/backupmodnotifs.
       const sentSettings = mockUserStore.edit.mock.calls[0][0].settings
       expect(sentSettings).not.toHaveProperty('modnotifs')
@@ -733,7 +746,7 @@ describe('ModMember', () => {
 
     it('changeRelevant updates relevantallowed', async () => {
       const wrapper = mountComponent()
-      await wrapper.vm.changeRelevant({ value: false })
+      await wrapper.vm.changeRelevant(false)
       expect(mockUserStore.edit).toHaveBeenCalledWith({
         id: 123, // user.value.id is member.id, not member.userid
         relevantallowed: false,
@@ -742,7 +755,7 @@ describe('ModMember', () => {
 
     it('changeNotifChitchat sends only notificationmails field', async () => {
       const wrapper = mountComponent()
-      await wrapper.vm.changeNotifChitchat({ value: true })
+      await wrapper.vm.changeNotifChitchat(true)
       expect(mockUserStore.edit).toHaveBeenCalledWith({
         id: 123,
         settings: { notificationmails: true },
@@ -751,7 +764,7 @@ describe('ModMember', () => {
 
     it('changeNewsletter updates newslettersallowed', async () => {
       const wrapper = mountComponent()
-      await wrapper.vm.changeNewsletter({ value: false })
+      await wrapper.vm.changeNewsletter(false)
       expect(mockUserStore.edit).toHaveBeenCalledWith({
         id: 123, // user.value.id is member.id, not member.userid
         newslettersallowed: false,
@@ -760,10 +773,13 @@ describe('ModMember', () => {
 
     it('changeAutorepost sends only autorepostsdisable field', async () => {
       const wrapper = mountComponent()
-      await wrapper.vm.changeAutorepost({ value: false })
+      // Toggle Autorepost ON (e=true) => autorepostsdisable=false. Uses `true`
+      // deliberately: with the old `!e.value` bug this evaluated to `!undefined`
+      // = true regardless, so testing with false would not catch the regression.
+      await wrapper.vm.changeAutorepost(true)
       expect(mockUserStore.edit).toHaveBeenCalledWith({
         id: 456,
-        settings: { autorepostsdisable: true },
+        settings: { autorepostsdisable: false },
       })
     })
 


### PR DESCRIPTION
## What

ModTools member-settings toggles never persisted. Reported at
https://discourse.ilovefreegle.org/t/unable-to-change-settings/9923 (mod: a
member's "Chat" setting was off, she toggled it on, "none of the buttons on his
membership record are sticking").

## Root cause

`ModMember.vue`'s toggle handlers read **`e.value`**, but `OurToggle` emits its
`change` event with the new value **directly** (`emit('change', newVal)`), not
wrapped as `{ value }`. So `e.value` was `undefined`; `JSON.stringify` strips
undefined-valued keys, so the exact field being toggled was the one key **absent**
from the PATCH body. The server's `JSON_MERGE_PATCH` (recursive merge) then left
that field unchanged - a genuine no-op that still returned `200 Success`, so the
toggle "didn't stick" on every retry.

Confirmed from the live PATCH request bodies (Loki): 16 attempts, each sending
`settings.notifications` **without** the `email` key it was meant to change.

This affects all six OurToggle handlers (Chat, Own Chats, Notification/ChitChat,
Suggestions, Newsletters, Autorepost) for every member. The email-frequency
dropdown was unaffected (it passes `$event` correctly), which is why other
controls appeared to work.

## Fix

- `ModMember.vue`: five handlers now use the emitted value `e` directly, matching
  OurToggle's contract and the member-facing settings sections
  (`components/settings/EmailSettingsSection.vue` etc.), which already do this.

## Code Quality Review

- The test `OurToggle` stub previously emitted `{ value }` (the wrong shape),
  which is why the existing tests passed and the bug hid. Corrected the stub to
  emit the bare value, updated the handler tests to pass real booleans, and made
  `changeAutorepost` assert with `true` (with `false` the old `!e.value` =
  `!undefined` = `true` coincidentally matched).

## Test Plan

- Vitest `ModMember.spec.js`: handler tests now exercise the real OurToggle
  contract and assert the toggled key is present with the emitted boolean value
  (would fail on the old `e.value` code).

## Future Improvements

- Server-side hardening of `PATCH /apiv2/user` so a settings write can never
  silently return 200 without persisting (surface the `db.Exec` error; return 403
  instead of silently falling back to the caller's own account when a non-Support
  mod lacks rights on the target). Follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rm8xqAcBsnaYWZkrp5KAMA
