### PR TITLE
fix(apiv2): surface failed settings writes in PatchUser

### DIFF
--- a/iznik-server-go/test/user_test.go
+++ b/iznik-server-go/test/user_test.go
@@ -4836,3 +4836,40 @@ func TestGetUserInfoWantedsNotInflatedByRippling(t *testing.T) {
 	assert.Equal(t, uint64(1), u.Info.Openwanteds,
 		"a WANTED rippled into an extra group must count once in openwanteds, not once per group it reached")
 }
+
+// A group moderator editing the settings of a member on a group they moderate is
+// allowed, and the change must actually persist to the target's row.
+func TestPatchUserSettingsBySharedGroupModPersists(t *testing.T) {
+	prefix := uniquePrefix("patchshared")
+	db := database.DBConn
+
+	modID := CreateTestUser(t, prefix+"_mod", "User")
+	targetID := CreateTestUser(t, prefix+"_target", "User")
+	groupID := CreateTestGroup(t, prefix)
+	CreateTestMembership(t, modID, groupID, "Moderator")
+	CreateTestMembership(t, targetID, groupID, "Member")
+	_, modToken := CreateTestSession(t, modID)
+
+	db.Exec(`UPDATE users SET settings = '{"notifications":{"email":false}}' WHERE id = ?`, targetID)
+
+	payload := map[string]interface{}{
+		"id": targetID,
+		"settings": map[string]interface{}{
+			"notifications": map[string]interface{}{"email": true},
+		},
+	}
+	s, _ := json.Marshal(payload)
+	request := httptest.NewRequest("PATCH", "/api/user?jwt="+modToken, bytes.NewBuffer(s))
+	request.Header.Set("Content-Type", "application/json")
+	resp, err := getApp().Test(request)
+	assert.NoError(t, err)
+	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+
+	var stored string
+	db.Raw("SELECT settings FROM users WHERE id = ?", targetID).Scan(&stored)
+	var settings map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(stored), &settings))
+	notifications, ok := settings["notifications"].(map[string]interface{})
+	require.True(t, ok, "notifications object should be present")
+	assert.Equal(t, true, notifications["email"], "shared-group mod's settings write must persist")
+}

--- a/iznik-server-go/user/user.go
+++ b/iznik-server-go/user/user.go
@@ -2227,6 +2227,13 @@ func PatchUser(c *fiber.Ctx) error {
 		}
 	}
 
+	// Note: when a caller targets another user they aren't authorised to moderate,
+	// targetID intentionally falls back to their own id - the mod-editable fields
+	// then apply to self and the other user is left untouched (see
+	// TestPatchUserSettingsNonModCannotUpdateOther). This is a deliberate safe
+	// default, not the cause of the 9923 "settings won't stick" report (that was a
+	// frontend value-reading bug, fixed separately).
+
 	// Self-only updates always target the logged-in user.
 	if req.Displayname != nil {
 		db.Exec("UPDATE users SET fullname = ?, firstname = NULL, lastname = NULL WHERE id = ?",
@@ -2243,7 +2250,11 @@ func PatchUser(c *fiber.Ctx) error {
 			setClauses = append(setClauses, "settings = JSON_MERGE_PATCH(COALESCE(settings, '{}'), CAST(? AS JSON))")
 			setArgs = append(setArgs, string(settingsJSON))
 			setArgs = append(setArgs, targetID)
-			db.Exec("UPDATE users SET "+strings.Join(setClauses, ", ")+" WHERE id = ?", setArgs...)
+			// Surface a failed write rather than swallowing it and returning 200
+			// (a silent no-op is how "settings won't stick" bugs hide).
+			if res := db.Exec("UPDATE users SET "+strings.Join(setClauses, ", ")+" WHERE id = ?", setArgs...); res.Error != nil {
+				return fiber.NewError(fiber.StatusInternalServerError, "Failed to update settings")
+			}
 		}
 	}
 


### PR DESCRIPTION
## What

Small server-side hardening found while investigating
https://discourse.ilovefreegle.org/t/unable-to-change-settings/9923.

`PatchUser` ran the settings `UPDATE` via `db.Exec(...)` and ignored the returned
error, so a genuinely failed write still responded `200 {"ret":0,"status":"Success"}`.
A silent no-op like that is exactly how "my setting won't stick" reports hide. Now
the error is checked and surfaced as a 500.

## Not changed (deliberately)

The self-fallback for an unauthorised cross-user edit (targetID falls back to the
caller's own id; the other user is left untouched) is **intended, specified**
behaviour - `TestPatchUserSettingsNonModCannotUpdateOther` asserts `200` + no change
to the other user. Left as-is.

The actual 9923 "toggles don't stick" symptom was a **frontend** value-reading bug
(ModMember.vue read `e.value` from OurToggle's bare-value `change` event) - fixed
separately.

## Test Plan

- Full Go suite green via the status API (3465 passing).
- New `TestPatchUserSettingsBySharedGroupModPersists`: a moderator editing a member's
  settings on a group they moderate returns 200 and the change persists to the
  target's row (guards the authorised mod-write path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rm8xqAcBsnaYWZkrp5KAMA
