### PR TITLE
refactor(notified): generalise reach ledger to messages_notified with channel

### DIFF
--- a/iznik-batch/app/Services/Ripple/ExpandService.php
+++ b/iznik-batch/app/Services/Ripple/ExpandService.php
@@ -107,7 +107,7 @@ class ExpandService
      * post and overwrites the stored polygon + schedule at the post's CURRENT
      * tick. It deliberately does NOT ripple into/out of groups, touch
      * memberships, or bump updated_at — so it generates no mail (sendReachDigests
-     * only scans recently-updated rows, and the rippling_reach_notified ledger
+     * only scans recently-updated rows, and the messages_notified ledger
      * blocks re-notification regardless) and never retracts copies already
      * delivered to far groups (we shrink future reach, we don't claw back).
      *

--- a/iznik-batch/app/Services/Ripple/ReplyAttributionBackfillService.php
+++ b/iznik-batch/app/Services/Ripple/ReplyAttributionBackfillService.php
@@ -10,7 +10,7 @@ use Illuminate\Support\Facades\DB;
  *
  * Durable bits are re-derivable from timestamped tables, so freezing them now - before the
  * evidence decays further - is the whole point:
- *   was_notified            <- rippling_reach_notified (notified_at <= replied_at)
+ *   was_notified            <- messages_notified (notified_at <= replied_at)
  *   was_ripple_group_member <- an approved membership of a group the post rippled into, added
  *                              before the copy arrived (decays when members leave, hence freeze)
  *   post_had_rippled        <- a rippled-in copy or a reach row existed by reply time
@@ -68,9 +68,9 @@ class ReplyAttributionBackfillService
                 ) batch ON batch.msgid = rra.msgid AND batch.userid = rra.userid
                 SET
                     rra.was_notified = EXISTS(
-                        SELECT 1 FROM rippling_reach_notified rrn
+                        SELECT 1 FROM messages_notified rrn
                         WHERE rrn.msgid = rra.msgid AND rrn.userid = rra.userid
-                          AND rrn.notified_at <= rra.replied_at),
+                          AND rrn.notified_at <= rra.replied_at AND rrn.channel = 'reach'),
                     rra.was_ripple_group_member = EXISTS(
                         SELECT 1 FROM messages_groups mg
                         INNER JOIN memberships mem ON mem.groupid = mg.groupid
@@ -90,9 +90,9 @@ class ReplyAttributionBackfillService
                     rra.attribution = CASE
                         WHEN rra.was_home_member = 1 THEN 'home'
                         WHEN EXISTS(
-                            SELECT 1 FROM rippling_reach_notified rrn2
+                            SELECT 1 FROM messages_notified rrn2
                             WHERE rrn2.msgid = rra.msgid AND rrn2.userid = rra.userid
-                              AND rrn2.notified_at <= rra.replied_at) THEN 'ripple_notified'
+                              AND rrn2.notified_at <= rra.replied_at AND rrn2.channel = 'reach') THEN 'ripple_notified'
                         WHEN EXISTS(
                             SELECT 1 FROM messages_groups mg3
                             INNER JOIN memberships mem3 ON mem3.groupid = mg3.groupid

--- a/iznik-batch/app/Services/UnifiedDigestService.php
+++ b/iznik-batch/app/Services/UnifiedDigestService.php
@@ -435,9 +435,10 @@ class UnifiedDigestService
                         // a ledger-write failure can't masquerade as a spool failure or abort the
                         // loop; harmless for non-rippling posts (the row is simply never read).
                         try {
-                            DB::table('rippling_reach_notified')->insertOrIgnore([
+                            DB::table('messages_notified')->insertOrIgnore([
                                 'msgid' => (int) $message->mg_msgid,
                                 'userid' => (int) $uid,
+                                'channel' => 'reach',
                                 'notified_at' => now(),
                             ]);
                         } catch (\Throwable $e) {
@@ -538,10 +539,10 @@ class UnifiedDigestService
      *
      * Processes rippling_reach rows whose reach changed recently (updated_at within the configured
      * window — reach only changes on init/advance, never on this pass, which writes only
-     * rippling_reach_notified), partitioned across parallel workers by MOD(msgid, shards) exactly
+     * messages_notified), partitioned across parallel workers by MOD(msgid, shards) exactly
      * as the immediate-digest cron partitions by MOD(groupid, shards). Disjoint partitions → shards
      * run concurrently with no locking. Idempotent regardless of window overlap: the
-     * rippling_reach_notified ledger means an already-notified member is never re-mailed.
+     * messages_notified ledger means an already-notified member is never re-mailed.
      *
      * @param int|null $limit Cap on posts processed per run (null = no cap).
      * @param int $shard Shard index (0..shards-1).
@@ -599,7 +600,7 @@ class UnifiedDigestService
      * pass (sendReachDigests) and by AutoApproveService (the post-'done' approval gap) — no longer
      * inline in ExpandService's serial loop. Mails the post to every immediate-eligible member of a
      * group it is APPROVED on whose location the reach NOW covers and who has not already been
-     * notified (rippling_reach_notified), recording each so a later tick — or another rippled-in
+     * notified (messages_notified), recording each so a later tick — or another rippled-in
      * group — never re-mails them. Because it re-runs every tick (no cursor), members the reach
      * reaches later are picked up; the cursor digest excludes reach-row posts so neither path
      * double-mails. Member point = settings.mylocation (both coords) else lastlocation. Returns
@@ -661,7 +662,7 @@ class UnifiedDigestService
                               ELSE l.lat END
                        ), ?))
                    AND NOT EXISTS (
-                         SELECT 1 FROM rippling_reach_notified n WHERE n.msgid = mg.msgid AND n.userid = u.id
+                         SELECT 1 FROM messages_notified n WHERE n.msgid = mg.msgid AND n.userid = u.id AND n.channel = 'reach'
                        )",
                 [Membership::EMAIL_FREQUENCY_IMMEDIATE, $msgid, now()->subDays(90), $srid]
             ));
@@ -706,7 +707,7 @@ class UnifiedDigestService
                     continue;
                 }
                 // Distance-preference filter (settings.browseMaxDistance). Deliberately
-                // does NOT write rippling_reach_notified on a filtered-out skip (unlike
+                // does NOT write messages_notified on a filtered-out skip (unlike
                 // the "already sent" path below) — see the design doc's "Reach-mail
                 // ledger semantics" edge case: leaving the ledger unwritten lets a later
                 // tick re-consider this (post, user) pair if the member widens their
@@ -736,9 +737,10 @@ class UnifiedDigestService
                         $user->email_preferred,
                         emailType: 'digest_immediate',
                     );
-                    DB::table('rippling_reach_notified')->insertOrIgnore([
+                    DB::table('messages_notified')->insertOrIgnore([
                         'msgid' => $msgid,
                         'userid' => (int) $user->id,
+                        'channel' => 'reach',
                         'notified_at' => now(),
                     ]);
                     $sent++;

--- a/iznik-batch/database/migrations/2026_07_02_000002_create_rippling_proximity_table.php
+++ b/iznik-batch/database/migrations/2026_07_02_000002_create_rippling_proximity_table.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Facades\Schema;
  * rippling_proximity — the moderator "quicker to get to" P/Q note for a post that has rippled
  * into a group, computed once at ripple-in time (ExpandService::recordRippleProximity). Kept in
  * its own rippling_* table rather than as columns on the hot messages_groups table (same approach
- * as rippling_reach / rippling_reach_notified / rippling_held_replies).
+ * as rippling_reach / messages_notified / rippling_held_replies).
  *
  * Composite PK (msgid, groupid): the note is per copy-in-a-group, written once. p/q are the
  * human place names ("AB10 1XG (Gilcomston)"). Cascades away with the message or the group.

--- a/iznik-batch/database/migrations/2026_07_07_000002_add_attribution_evidence_to_rippling_reply_attribution.php
+++ b/iznik-batch/database/migrations/2026_07_07_000002_add_attribution_evidence_to_rippling_reply_attribution.php
@@ -11,7 +11,7 @@ use Illuminate\Support\Facades\Schema;
  * snapshotted AT REPLY TIME by the Go reply handler (chat/chatmessage.go).
  *
  * Evidence bits (nullable: NULL = not captured, pre-migration row or evidence unavailable):
- *   was_notified             - (msgid, userid) hit in rippling_reach_notified before the reply:
+ *   was_notified             - (msgid, userid) hit in messages_notified before the reply:
  *                              we SENT this user the ripple mail for this post. Durable; backfillable.
  *   was_ripple_group_member  - established member (added < the copy's arrival) of a group the
  *                              post rippled INTO by reply time. Durable-ish (leavers decay);

--- a/iznik-batch/database/migrations/2026_07_16_000001_generalise_notified_ledger.php
+++ b/iznik-batch/database/migrations/2026_07_16_000001_generalise_notified_ledger.php
@@ -1,0 +1,73 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Generalise the per-(member, post) "we notified this member about this post"
+ * ledger from `rippling_reach_notified` to `messages_notified`, keyed by a
+ * `channel` so the same (msgid, userid) can be recorded once per delivery channel
+ * (currently 'reach'; the daily/immediate digest will add 'digest').
+ *
+ * Existing rows become channel='reach'. Consumers that mean "was the REACH mail
+ * sent?" now filter channel='reach' (reply attribution depends on it) — see the
+ * same-PR changes to UnifiedDigestService / ReplyAttributionBackfillService and
+ * the Go metrics/chatmessage reach checks.
+ *
+ * Behaviour-neutral: nothing writes a non-'reach' channel yet.
+ */
+return new class extends Migration {
+    public function up(): void
+    {
+        if (Schema::hasTable('messages_notified')) {
+            return; // already generalised
+        }
+
+        if (! Schema::hasTable('rippling_reach_notified')) {
+            // Fresh environment where the old table was never created: build the
+            // generalised table directly.
+            Schema::create('messages_notified', function ($t) {
+                $t->unsignedBigInteger('msgid');
+                $t->unsignedBigInteger('userid');
+                $t->string('channel', 16)->default('reach');
+                $t->timestamp('notified_at')->useCurrent();
+                $t->primary(['msgid', 'userid', 'channel']);
+                $t->index('userid');
+            });
+            DB::statement('ALTER TABLE messages_notified ADD CONSTRAINT messages_notified_msgid_foreign FOREIGN KEY (msgid) REFERENCES messages (id) ON DELETE CASCADE');
+            DB::statement('ALTER TABLE messages_notified ADD CONSTRAINT messages_notified_userid_foreign FOREIGN KEY (userid) REFERENCES users (id) ON DELETE CASCADE');
+
+            return;
+        }
+
+        // Generalise the existing reach ledger in place, then rename. Existing rows
+        // default to channel='reach'.
+        if (! Schema::hasColumn('rippling_reach_notified', 'channel')) {
+            DB::statement("ALTER TABLE rippling_reach_notified ADD COLUMN channel VARCHAR(16) NOT NULL DEFAULT 'reach'");
+        }
+
+        // Widen the PK to include channel. Single ALTER so msgid stays the leftmost
+        // key column throughout and the msgid FK index is never dropped.
+        DB::statement('ALTER TABLE rippling_reach_notified DROP PRIMARY KEY, ADD PRIMARY KEY (msgid, userid, channel)');
+
+        Schema::rename('rippling_reach_notified', 'messages_notified');
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasTable('messages_notified')) {
+            return;
+        }
+
+        // Drop any non-reach rows so the narrower PK can be restored.
+        DB::table('messages_notified')->where('channel', '!=', 'reach')->delete();
+
+        Schema::rename('messages_notified', 'rippling_reach_notified');
+        DB::statement('ALTER TABLE rippling_reach_notified DROP PRIMARY KEY, ADD PRIMARY KEY (msgid, userid)');
+
+        if (Schema::hasColumn('rippling_reach_notified', 'channel')) {
+            DB::statement('ALTER TABLE rippling_reach_notified DROP COLUMN channel');
+        }
+    }
+};

--- a/iznik-batch/database/migrations/2026_07_16_000001_generalise_notified_ledger_migration.sql
+++ b/iznik-batch/database/migrations/2026_07_16_000001_generalise_notified_ledger_migration.sql
@@ -1,0 +1,36 @@
+-- Production idempotent SQL for 2026_07_16_000001_generalise_notified_ledger.php
+--
+-- Generalise the per-(member, post) notified ledger: rippling_reach_notified ->
+-- messages_notified, adding channel VARCHAR(16) DEFAULT 'reach' and widening the
+-- PK to (msgid, userid, channel). Behaviour-neutral: existing rows stay 'reach'
+-- and nothing writes another channel until the digest code ships.
+--
+-- Run once on production BEFORE deploying the code that filters channel='reach'.
+-- Safe to re-run: guarded by information_schema so a second run is a no-op.
+
+SET @has_old := (SELECT COUNT(*) FROM information_schema.tables
+    WHERE table_schema = DATABASE() AND table_name = 'rippling_reach_notified');
+SET @has_new := (SELECT COUNT(*) FROM information_schema.tables
+    WHERE table_schema = DATABASE() AND table_name = 'messages_notified');
+
+-- 1. Add channel (existing rows default to 'reach').
+SET @col := (SELECT COUNT(*) FROM information_schema.columns
+    WHERE table_schema = DATABASE() AND table_name = 'rippling_reach_notified' AND column_name = 'channel');
+SET @sql := IF(@has_old > 0 AND @has_new = 0 AND @col = 0,
+    "ALTER TABLE rippling_reach_notified ADD COLUMN channel VARCHAR(16) NOT NULL DEFAULT 'reach'",
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- 2. Widen the PK to include channel (only while it is still the 2-column PK).
+SET @pkcols := (SELECT COUNT(*) FROM information_schema.statistics
+    WHERE table_schema = DATABASE() AND table_name = 'rippling_reach_notified' AND index_name = 'PRIMARY');
+SET @sql := IF(@has_old > 0 AND @has_new = 0 AND @pkcols = 2,
+    'ALTER TABLE rippling_reach_notified DROP PRIMARY KEY, ADD PRIMARY KEY (msgid, userid, channel)',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- 3. Rename to the generalised name.
+SET @sql := IF(@has_old > 0 AND @has_new = 0,
+    'RENAME TABLE rippling_reach_notified TO messages_notified',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;

--- a/iznik-batch/tests/Unit/Services/AutoApproveServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/AutoApproveServiceTest.php
@@ -144,7 +144,7 @@ class AutoApproveServiceTest extends TestCase
         $this->service->process();
 
         $this->assertTrue(
-            DB::table('rippling_reach_notified')->where('msgid', $message->id)->where('userid', $member->id)->exists(),
+            DB::table('messages_notified')->where('msgid', $message->id)->where('userid', $member->id)->exists(),
             'auto-approve mails a now-reachable immediate member of a done-reach rippling post'
         );
     }
@@ -185,7 +185,7 @@ class AutoApproveServiceTest extends TestCase
 
         $this->assertEquals(0, $sent, 'a taken post is not mailed to newly-reached members');
         $this->assertFalse(
-            DB::table('rippling_reach_notified')->where('msgid', $message->id)->exists(),
+            DB::table('messages_notified')->where('msgid', $message->id)->exists(),
             'no reach notification recorded for a taken post'
         );
     }

--- a/iznik-batch/tests/Unit/Services/Ripple/ReplyAttributionBackfillServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/Ripple/ReplyAttributionBackfillServiceTest.php
@@ -61,12 +61,23 @@ class ReplyAttributionBackfillServiceTest extends TestCase
 
         // Notified via the ripple mail ledger before replying.
         $notifiedUser = $this->createTestUser();
-        DB::table('rippling_reach_notified')->insert([
+        DB::table('messages_notified')->insert([
             'msgid' => $message->id,
             'userid' => $notifiedUser->id,
             'notified_at' => now()->subDay(),
         ]);
         $this->insertLegacyRow($message->id, $notifiedUser->id, 0);
+
+        // Notified only on a NON-reach channel (digest) - must NOT be read as a reach
+        // notification once the ledger is shared (channel guard).
+        $digestUser = $this->createTestUser();
+        DB::table('messages_notified')->insert([
+            'msgid' => $message->id,
+            'userid' => $digestUser->id,
+            'channel' => 'digest',
+            'notified_at' => now()->subDay(),
+        ]);
+        $this->insertLegacyRow($message->id, $digestUser->id, 0);
 
         // Established member of the rippled-into group (added before the copy arrived).
         $groupUser = $this->createTestUser();
@@ -90,6 +101,11 @@ class ReplyAttributionBackfillServiceTest extends TestCase
         $this->assertSame(1, (int) $notified->post_had_rippled);
         $this->assertNull($notified->in_origin_catchment, 'location bits are not backfillable');
         $this->assertNull($notified->in_reach, 'location bits are not backfillable');
+
+        $digest = $this->attributionRow($message->id, $digestUser->id);
+        $this->assertNotSame('ripple_notified', $digest->attribution,
+            'a digest-channel notify must not be read as a reach notification');
+        $this->assertSame(0, (int) $digest->was_notified);
 
         $group = $this->attributionRow($message->id, $groupUser->id);
         $this->assertSame('ripple_group', $group->attribution);

--- a/iznik-batch/tests/Unit/Services/UnifiedDigestServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/UnifiedDigestServiceTest.php
@@ -1045,7 +1045,7 @@ class UnifiedDigestServiceTest extends TestCase
 
         $this->service->mailNewlyReachedForPost($msg->id);
 
-        $ledgered = fn ($uid) => DB::table('rippling_reach_notified')
+        $ledgered = fn ($uid) => DB::table('messages_notified')
             ->where('msgid', $msg->id)->where('userid', $uid)->exists();
         $this->assertTrue($ledgered($memberA->id), 'reach-covered member A mailed + ledgered');
         $this->assertFalse($ledgered($memberB->id), 'out-of-reach member B not yet mailed');
@@ -1053,12 +1053,12 @@ class UnifiedDigestServiceTest extends TestCase
         // Reach grows to cover B; the re-run mails B and does NOT re-mail A (ledger dedup).
         DB::statement('UPDATE rippling_reach SET polygon = ST_GeomFromText(?, 3857) WHERE msgid = ?',
             ['POLYGON((-0.2 51.4,0.6 51.4,0.6 51.6,-0.2 51.6,-0.2 51.4))', $msg->id]);
-        $before = DB::table('rippling_reach_notified')->where('msgid', $msg->id)->count();
+        $before = DB::table('messages_notified')->where('msgid', $msg->id)->count();
         $this->service->mailNewlyReachedForPost($msg->id);
         $this->assertTrue($ledgered($memberB->id), 'newly-reached member B mailed on re-run');
         $this->assertSame(
             $before + 1,
-            DB::table('rippling_reach_notified')->where('msgid', $msg->id)->count(),
+            DB::table('messages_notified')->where('msgid', $msg->id)->count(),
             'only B newly notified — A not re-mailed'
         );
 
@@ -1113,7 +1113,7 @@ class UnifiedDigestServiceTest extends TestCase
 
         $this->assertSame(
             0,
-            DB::table('rippling_reach_notified')->where('msgid', $msg->id)->count(),
+            DB::table('messages_notified')->where('msgid', $msg->id)->count(),
             'no reach-coordination ledger rows are written while rippling is off'
         );
     }
@@ -1141,18 +1141,18 @@ class UnifiedDigestServiceTest extends TestCase
         // No reach row yet → the cursor immediate digest mails the group and records the ledger.
         $this->service->sendDigests(UnifiedDigestService::MODE_IMMEDIATE);
         $this->assertTrue(
-            DB::table('rippling_reach_notified')->where('msgid', $msg->id)->where('userid', $member->id)->exists(),
+            DB::table('messages_notified')->where('msgid', $msg->id)->where('userid', $member->id)->exists(),
             'cursor immediate send is recorded in the ledger'
         );
 
         // Reach row appears afterwards; the expander must not re-mail the already-mailed member.
         $this->seedReach($msg->id, 'POLYGON((-0.2 51.4,0.0 51.4,0.0 51.6,-0.2 51.6,-0.2 51.4))');
-        $before = DB::table('rippling_reach_notified')->where('msgid', $msg->id)->count();
+        $before = DB::table('messages_notified')->where('msgid', $msg->id)->count();
         $sent = $this->service->mailNewlyReachedForPost($msg->id);
         $this->assertSame(0, $sent, 'expander does not re-mail members the cursor digest already mailed');
         $this->assertSame(
             $before,
-            DB::table('rippling_reach_notified')->where('msgid', $msg->id)->count(),
+            DB::table('messages_notified')->where('msgid', $msg->id)->count(),
             'no new ledger rows — the shared ledger prevents the double-mail'
         );
     }
@@ -2359,7 +2359,7 @@ class UnifiedDigestServiceTest extends TestCase
 
         $this->assertGreaterThanOrEqual(1, $stats['emails_sent'], 'a reachable immediate member is mailed');
         $this->assertTrue(
-            DB::table('rippling_reach_notified')->where('msgid', $message->id)->where('userid', $member->id)->exists(),
+            DB::table('messages_notified')->where('msgid', $message->id)->where('userid', $member->id)->exists(),
             'the reach-mail pass records the notification in the ledger'
         );
     }
@@ -2385,14 +2385,14 @@ class UnifiedDigestServiceTest extends TestCase
         // The shard that does NOT own this msgid must skip it entirely.
         $this->service->sendReachDigests(null, false, $otherShard, $shards);
         $this->assertFalse(
-            DB::table('rippling_reach_notified')->where('msgid', $message->id)->exists(),
+            DB::table('messages_notified')->where('msgid', $message->id)->exists(),
             'a shard does not process posts outside its MOD(msgid, shards) partition'
         );
 
         // The owning shard processes it.
         $this->service->sendReachDigests(null, false, $ownShard, $shards);
         $this->assertTrue(
-            DB::table('rippling_reach_notified')->where('msgid', $message->id)->where('userid', $member->id)->exists(),
+            DB::table('messages_notified')->where('msgid', $message->id)->where('userid', $member->id)->exists(),
             'the owning shard mails the reachable member'
         );
     }
@@ -2839,7 +2839,7 @@ class UnifiedDigestServiceTest extends TestCase
         $this->service->mailNewlyReachedForPost($msg->id);
 
         $this->assertFalse(
-            DB::table('rippling_reach_notified')->where('msgid', $msg->id)->where('userid', $memberC->id)->exists(),
+            DB::table('messages_notified')->where('msgid', $msg->id)->where('userid', $memberC->id)->exists(),
             'inside reach but beyond the personal distance preference — not mailed, no ledger write'
         );
     }
@@ -2868,7 +2868,7 @@ class UnifiedDigestServiceTest extends TestCase
 
         $this->service->mailNewlyReachedForPost($msg->id);
         $this->assertFalse(
-            DB::table('rippling_reach_notified')->where('msgid', $msg->id)->where('userid', $memberC->id)->exists(),
+            DB::table('messages_notified')->where('msgid', $msg->id)->where('userid', $memberC->id)->exists(),
             'first run: filtered out, no ledger row written'
         );
 
@@ -2880,7 +2880,7 @@ class UnifiedDigestServiceTest extends TestCase
         $this->service->mailNewlyReachedForPost($msg->id);
 
         $this->assertTrue(
-            DB::table('rippling_reach_notified')->where('msgid', $msg->id)->where('userid', $memberC->id)->exists(),
+            DB::table('messages_notified')->where('msgid', $msg->id)->where('userid', $memberC->id)->exists(),
             'second run after widening: mailed and ledgered'
         );
     }
@@ -2909,7 +2909,7 @@ class UnifiedDigestServiceTest extends TestCase
         $this->service->mailNewlyReachedForPost($msg->id);
 
         $this->assertTrue(
-            DB::table('rippling_reach_notified')->where('msgid', $msg->id)->where('userid', $poster->id)->exists(),
+            DB::table('messages_notified')->where('msgid', $msg->id)->where('userid', $poster->id)->exists(),
             'own post is mailed and ledgered despite exceeding the personal distance preference'
         );
     }
@@ -2979,7 +2979,7 @@ class UnifiedDigestServiceTest extends TestCase
         $this->seedReach($reachMsg->id, 'POLYGON((-0.2 51.4,0.6 51.4,0.6 51.6,-0.2 51.6,-0.2 51.4))');
         $this->service->mailNewlyReachedForPost($reachMsg->id);
         $this->assertFalse(
-            DB::table('rippling_reach_notified')->where('msgid', $reachMsg->id)->where('userid', $reachRecipient->id)->exists(),
+            DB::table('messages_notified')->where('msgid', $reachMsg->id)->where('userid', $reachRecipient->id)->exists(),
             'reach-mail rejects the out-of-range post, same as the other two pipelines'
         );
     }

--- a/iznik-server-go/chat/chatmessage.go
+++ b/iznik-server-go/chat/chatmessage.go
@@ -392,7 +392,7 @@ func recordReplyAttribution(db *gorm.DB, myid uint64, refmsgid uint64, reach rep
 	// Did we send this user the ripple "new post near you" mail for this post? Keyed lookup on
 	// the notified ledger - the strongest direct ripple-delivery evidence.
 	var wasNotified int
-	db.Raw("SELECT EXISTS(SELECT 1 FROM rippling_reach_notified WHERE msgid = ? AND userid = ?)",
+	db.Raw("SELECT EXISTS(SELECT 1 FROM messages_notified WHERE msgid = ? AND userid = ? AND channel = 'reach')",
 		refmsgid, myid).Scan(&wasNotified)
 
 	// Established member of a group the post rippled INTO: added before the rippled copy

--- a/iznik-server-go/rippling/metrics.go
+++ b/iznik-server-go/rippling/metrics.go
@@ -232,9 +232,9 @@ type GroupOption struct {
 func ReplySourceSplitSQL(wide bool, srcGroup string) string {
 	derive := `CASE
 	       WHEN rra.was_home_member = 1 THEN 'home'
-	       WHEN EXISTS(SELECT 1 FROM rippling_reach_notified rrn
+	       WHEN EXISTS(SELECT 1 FROM messages_notified rrn
 	                   WHERE rrn.msgid = rra.msgid AND rrn.userid = rra.userid
-	                     AND rrn.notified_at <= rra.replied_at) THEN 'ripple_notified'
+	                     AND rrn.notified_at <= rra.replied_at AND rrn.channel = 'reach') THEN 'ripple_notified'
 	       WHEN EXISTS(SELECT 1 FROM messages_groups mgr
 	                   INNER JOIN memberships mem ON mem.groupid = mgr.groupid
 	                     AND mem.userid = rra.userid AND mem.collection = 'Approved'

--- a/iznik-server-go/test/chatmessage_reach_test.go
+++ b/iznik-server-go/test/chatmessage_reach_test.go
@@ -270,10 +270,11 @@ func TestCreateChatMessage_AttributionLadder(t *testing.T) {
 		status VARCHAR(16) NOT NULL DEFAULT 'expanding',
 		SPATIAL INDEX msgreach_poly (polygon)
 	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`)
-	db.Exec(`CREATE TABLE IF NOT EXISTS rippling_reach_notified (
+	db.Exec(`CREATE TABLE IF NOT EXISTS messages_notified (
 		msgid BIGINT UNSIGNED NOT NULL, userid BIGINT UNSIGNED NOT NULL,
+		channel VARCHAR(16) NOT NULL DEFAULT 'reach',
 		notified_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-		PRIMARY KEY (msgid, userid), KEY rrn_userid (userid))`)
+		PRIMARY KEY (msgid, userid, channel), KEY rrn_userid (userid))`)
 
 	originGroup := CreateTestGroup(t, prefix+"_origin")
 	rippledGroup := CreateTestGroup(t, prefix+"_rippled")
@@ -281,7 +282,7 @@ func TestCreateChatMessage_AttributionLadder(t *testing.T) {
 	CreateTestMembership(t, posterID, originGroup, "Member")
 	msgID := CreateTestMessage(t, posterID, originGroup, "OFFER: attribution ladder test item", 51.5, -0.1)
 	defer db.Exec("DELETE FROM rippling_reply_attribution WHERE msgid = ?", msgID)
-	defer db.Exec("DELETE FROM rippling_reach_notified WHERE msgid = ?", msgID)
+	defer db.Exec("DELETE FROM messages_notified WHERE msgid = ?", msgID)
 	defer db.Exec("DELETE FROM rippling_reach WHERE msgid = ?", msgID)
 
 	// Origin group's catchment covers (-0.1, 51.5) only; the reach polygon covers both that
@@ -305,7 +306,7 @@ func TestCreateChatMessage_AttributionLadder(t *testing.T) {
 	//    catchment - the notified rung must outrank the location rungs.
 	notifiedID := CreateTestUser(t, prefix+"_notified", "User")
 	db.Exec(`UPDATE users SET settings = '{"mylocation":{"lat":51.5,"lng":0.5}}' WHERE id = ?`, notifiedID)
-	db.Exec("INSERT INTO rippling_reach_notified (msgid, userid, notified_at) VALUES (?, ?, NOW() - INTERVAL 1 HOUR)",
+	db.Exec("INSERT INTO messages_notified (msgid, userid, notified_at) VALUES (?, ?, NOW() - INTERVAL 1 HOUR)",
 		msgID, notifiedID)
 	assert.Equal(t, fiber.StatusOK, postInterestedReply(t, notifiedID, posterID, msgID, ""))
 	row, ok := fetchAttribution(t, msgID, notifiedID)

--- a/iznik-server-go/test/rippling_metrics_test.go
+++ b/iznik-server-go/test/rippling_metrics_test.go
@@ -658,12 +658,13 @@ func TestReplySourceSplitLegacyVariant(t *testing.T) {
 	CreateTestMembership(t, posterID, groupID, "Member")
 	msgID := CreateTestMessage(t, posterID, groupID, "OFFER: legacy split test item", 51.5, -0.1)
 	defer db.Exec("DELETE FROM rippling_reply_attribution WHERE msgid = ?", msgID)
-	defer db.Exec("DELETE FROM rippling_reach_notified WHERE msgid = ?", msgID)
+	defer db.Exec("DELETE FROM messages_notified WHERE msgid = ?", msgID)
 
-	db.Exec(`CREATE TABLE IF NOT EXISTS rippling_reach_notified (
+	db.Exec(`CREATE TABLE IF NOT EXISTS messages_notified (
 		msgid BIGINT UNSIGNED NOT NULL, userid BIGINT UNSIGNED NOT NULL,
+		channel VARCHAR(16) NOT NULL DEFAULT 'reach',
 		notified_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-		PRIMARY KEY (msgid, userid), KEY rrn_userid (userid))`)
+		PRIMARY KEY (msgid, userid, channel), KEY rrn_userid (userid))`)
 
 	// A rippled-in copy of the post, and a replier who was an established member of that
 	// group before it arrived.
@@ -676,7 +677,7 @@ func TestReplySourceSplitLegacyVariant(t *testing.T) {
 		groupMemberID, rippledGroup)
 
 	notifiedID := CreateTestUser(t, prefix+"_notified", "User")
-	db.Exec("INSERT INTO rippling_reach_notified (msgid, userid, notified_at) VALUES (?, ?, NOW() - INTERVAL 1 DAY)",
+	db.Exec("INSERT INTO messages_notified (msgid, userid, notified_at) VALUES (?, ?, NOW() - INTERVAL 1 DAY)",
 		msgID, notifiedID)
 
 	unknownID := CreateTestUser(t, prefix+"_unknown", "User")

--- a/plans/ripple-monitor.sql
+++ b/plans/ripple-monitor.sql
@@ -43,4 +43,4 @@ FROM (
 SELECT '=== 4. reach rows total + last-hour activity ===' AS section;
 SELECT (SELECT COUNT(*) FROM rippling_reach) AS reach_rows_total,
        (SELECT COUNT(*) FROM rippling_reply_attribution WHERE replied_at >= NOW()-INTERVAL 1 HOUR) AS replies_last_hr,
-       (SELECT COUNT(*) FROM rippling_reach_notified WHERE notified_at >= NOW()-INTERVAL 1 HOUR) AS immediate_mails_last_hr;
+       (SELECT COUNT(*) FROM messages_notified WHERE notified_at >= NOW()-INTERVAL 1 HOUR) AS immediate_mails_last_hr;

--- a/scripts/test-fixtures.sql
+++ b/scripts/test-fixtures.sql
@@ -888,9 +888,9 @@ LOCK TABLES `rippling_reach` WRITE;
 /*!40000 ALTER TABLE `rippling_reach` ENABLE KEYS */;
 UNLOCK TABLES;
 
-LOCK TABLES `rippling_reach_notified` WRITE;
-/*!40000 ALTER TABLE `rippling_reach_notified` DISABLE KEYS */;
-/*!40000 ALTER TABLE `rippling_reach_notified` ENABLE KEYS */;
+LOCK TABLES `messages_notified` WRITE;
+/*!40000 ALTER TABLE `messages_notified` DISABLE KEYS */;
+/*!40000 ALTER TABLE `messages_notified` ENABLE KEYS */;
 UNLOCK TABLES;
 
 LOCK TABLES `rippling_reply_attribution` WRITE;


### PR DESCRIPTION
## What

Stage 1 of reducing repeat views in the digest (design:
`plans/2026-07-16-digest-reduce-repeat-views.md`). **Behaviour-neutral** groundwork:
generalise the per-(member, post) "we notified this member about this post" ledger so
the upcoming digest work can record its own sends in the *same* table instead of a
parallel one.

`rippling_reach_notified (msgid, userid, notified_at)` -> `messages_notified
(msgid, userid, channel, notified_at)`, PK `(msgid, userid, channel)`. Existing rows
become `channel='reach'`; nothing writes another channel yet.

## Why the `channel` guard matters

Several consumers treat "a row exists for (msgid, userid)" as "the **reach** mail was
sent" — reply attribution keys off `notified_at <= replied_at`. The moment another
channel shares the table, those checks must filter `channel='reach'` or a digest send
would be miscounted as reach. This PR adds that filter everywhere first, while all
rows are still `reach`, so it's provably a no-op now and correct later.

## Changes

- **Migration** `2026_07_16_000001_generalise_notified_ledger`: add `channel`
  (default `'reach'`), widen PK in a single `ALTER` (msgid stays leftmost so the
  msgid FK index is never dropped), `RENAME TABLE`. `down()` drops non-reach rows
  before narrowing the PK. + idempotent production `*_migration.sql`.
- **`channel='reach'`** on every reach read/write: `UnifiedDigestService`,
  `ReplyAttributionBackfillService`, Go `rippling/metrics.go`, Go
  `chat/chatmessage.go`.
- Table renamed across `test-fixtures.sql`, Go test table-creates, and doc comments.

## Test Plan

- `setup-test-database` runs the rename migration **and** reloads `test-fixtures.sql`
  cleanly (verified locally — no ERROR 1146 from the fixture's `LOCK TABLES`).
- Go suite green (reach/metrics attribution tests exercise the renamed table +
  `channel` filter end-to-end).
- Laravel reach/attribution/digest tests green, including a new assertion in
  `ReplyAttributionBackfillServiceTest`: a member notified only on `channel='digest'`
  is **not** read as reach-notified (`was_notified=0`, attribution != `ripple_notified`).
  (The 20 spatial `JobModel`/`Location`/`Newsfeed` failures seen on the local box are a
  local test-DB data gap — `iznik_batch_test` has no postcode/location rows — and are
  untouched by this branch.)

## Follow-ups (not in this PR)

Stage 2: digest writes `channel='digest'` on spool success. Stage 3: per-member
scorer penalty / immediate suppression using `messages_notified` + `messages_likes`
views. Both behind a config flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rm8xqAcBsnaYWZkrp5KAMA
