### PR TITLE
feat(digest): sink already-seen posts in the daily digest and browse feed

### DIFF
--- a/iznik-batch/app/Console/Commands/Mail/MarkDigestSeenCommand.php
+++ b/iznik-batch/app/Console/Commands/Mail/MarkDigestSeenCommand.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Console\Commands\Mail;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Turn "the member opened/clicked a digest" into a per-(member, post) "seen" signal.
+ *
+ * A digest mail records the msgids it showed in email_tracking.metadata.post_msgids
+ * (see UnifiedDigest). When email_tracking marks that mail opened or clicked, the
+ * member has HAD A CHANCE to see every post it contained - so we write a
+ * messages_likes 'View' row for each (msgid, userid). That is the same signal the
+ * browse feed already sorts unseen-first on (message/bounds.go), and that the daily
+ * digest now down-ranks on (UnifiedDigestService::getPostsForUser seen_by_user) - so
+ * both surfaces stop re-showing posts the member has already seen.
+ *
+ * We deliberately key off open/click, not send: sending a digest doesn't mean it was
+ * read, and we must never sink a post for someone who never had a chance to see it.
+ * insertOrIgnore makes re-processing the overlapping look-back window harmless.
+ */
+class MarkDigestSeenCommand extends Command
+{
+    protected $signature = 'mail:digest:mark-seen
+        {--hours=3 : Look back this many hours over digest opens/clicks (overlap the schedule for safety)}
+        {--limit=20000 : Max digest emails to process in one run}';
+
+    protected $description = 'Mark digest posts as seen for members who opened/clicked the digest that contained them';
+
+    /** Digest email types whose metadata carries post_msgids. */
+    private const DIGEST_TYPES = ['UnifiedDigestImmediate', 'UnifiedDigestDaily'];
+
+    public function handle(): int
+    {
+        $since = now()->subHours((int) $this->option('hours'));
+
+        // email_type is indexed; the open/click time bound keeps the window small.
+        $rows = DB::table('email_tracking')
+            ->whereIn('email_type', self::DIGEST_TYPES)
+            ->whereNotNull('userid')
+            ->whereNotNull('metadata')
+            ->where(function ($q) use ($since) {
+                $q->where('opened_at', '>=', $since)
+                    ->orWhere('clicked_at', '>=', $since);
+            })
+            ->orderByDesc('id')
+            ->limit((int) $this->option('limit'))
+            ->get(['userid', 'metadata']);
+
+        $emails = 0;
+        $marked = 0;
+
+        foreach ($rows as $row) {
+            $meta = json_decode((string) $row->metadata, true);
+            $msgids = is_array($meta) ? ($meta['post_msgids'] ?? []) : [];
+            if (empty($msgids)) {
+                continue;
+            }
+            $emails++;
+
+            $userid = (int) $row->userid;
+            foreach (array_chunk($msgids, 500) as $chunk) {
+                $insert = [];
+                foreach ($chunk as $mid) {
+                    $mid = (int) $mid;
+                    if ($mid > 0) {
+                        // count=0: existence marks "seen" (browse + digest read the ROW,
+                        // not the count) without inflating the global 'View' engagement
+                        // sum used for scoring. A later real in-app view still upserts its
+                        // own count via the app's own path.
+                        $insert[] = ['msgid' => $mid, 'userid' => $userid, 'type' => 'View', 'count' => 0];
+                    }
+                }
+                if ($insert) {
+                    $marked += DB::table('messages_likes')->insertOrIgnore($insert);
+                }
+            }
+        }
+
+        $this->info("mail:digest:mark-seen: {$emails} opened/clicked digests, {$marked} new seen markers.");
+
+        return self::SUCCESS;
+    }
+}

--- a/iznik-batch/app/Console/Commands/Mail/MarkDigestSeenCommand.php
+++ b/iznik-batch/app/Console/Commands/Mail/MarkDigestSeenCommand.php
@@ -34,19 +34,32 @@ class MarkDigestSeenCommand extends Command
     public function handle(): int
     {
         $since = now()->subHours((int) $this->option('hours'));
+        $limit = (int) $this->option('limit');
 
-        // email_type is indexed; the open/click time bound keeps the window small.
-        $rows = DB::table('email_tracking')
+        // Two index-driven reads rather than one `opened_at OR clicked_at` scan:
+        // email_tracking.opened_at is indexed but clicked_at is NOT, so an OR across
+        // them can't use the opened_at index and degrades to a backward PRIMARY(id)
+        // scan of the whole (multi-million row) table. Opens come from the opened_at
+        // range; clicks come via email_tracking_clicks (its clicked_at IS indexed).
+        $opens = DB::table('email_tracking')
             ->whereIn('email_type', self::DIGEST_TYPES)
             ->whereNotNull('userid')
             ->whereNotNull('metadata')
-            ->where(function ($q) use ($since) {
-                $q->where('opened_at', '>=', $since)
-                    ->orWhere('clicked_at', '>=', $since);
-            })
-            ->orderByDesc('id')
-            ->limit((int) $this->option('limit'))
+            ->where('opened_at', '>=', $since)
+            ->limit($limit)
             ->get(['userid', 'metadata']);
+
+        $clicks = DB::table('email_tracking_clicks as etc')
+            ->join('email_tracking as et', 'et.id', '=', 'etc.email_tracking_id')
+            ->whereIn('et.email_type', self::DIGEST_TYPES)
+            ->whereNotNull('et.userid')
+            ->whereNotNull('et.metadata')
+            ->where('etc.clicked_at', '>=', $since)
+            ->limit($limit)
+            ->get(['et.userid as userid', 'et.metadata as metadata']);
+
+        // A digest in both sets is harmless - insertOrIgnore dedupes the markers.
+        $rows = $opens->concat($clicks);
 
         $emails = 0;
         $marked = 0;

--- a/iznik-batch/app/Services/UnifiedDigestService.php
+++ b/iznik-batch/app/Services/UnifiedDigestService.php
@@ -1493,6 +1493,12 @@ class UnifiedDigestService
             // like counts; replies = approved 'Interested' chat replies).
             ->selectRaw("(SELECT COALESCE(SUM(ml.count),0) FROM messages_likes ml WHERE ml.msgid = messages.id AND ml.type = 'View') AS views")
             ->selectRaw("(SELECT COUNT(*) FROM chat_messages cm WHERE cm.refmsgid = messages.id AND cm.type = 'Interested' AND cm.reviewrejected = 0 AND cm.reviewrequired = 0) AS replies")
+            // Has THIS recipient already had a chance to see the post? A messages_likes
+            // 'View' row means they viewed it in-app OR opened/clicked a digest that
+            // contained it (mail:digest:mark-seen writes the latter). Used to sink
+            // already-seen posts in the daily order, mirroring the browse feed's
+            // unseen-first sort which reads the same signal.
+            ->selectRaw('EXISTS(SELECT 1 FROM messages_likes mlseen WHERE mlseen.msgid = messages.id AND mlseen.userid = ? AND mlseen.type = ?) AS seen_by_user', [$user->id, 'View'])
             ->join('messages_groups', 'messages.id', '=', 'messages_groups.msgid')
             ->whereIn('messages_groups.groupid', $groupIds)
             ->where('messages_groups.collection', MessageGroup::COLLECTION_APPROVED)
@@ -1859,7 +1865,13 @@ class UnifiedDigestService
                 $weights,
                 $env
             );
-            $post->_score = $s['total'];
+            // Sink posts the recipient has already had a chance to see (in-app view
+            // or an opened/clicked digest) so the digest leads with fresh posts.
+            $score = (float) $s['total'];
+            if (! empty($post->seen_by_user)) {
+                $score *= (float) config('freegle.digest.seen_penalty', 0.15);
+            }
+            $post->_score = $score;
             $post->_dist = $dist;
         }
 
@@ -1879,7 +1891,10 @@ class UnifiedDigestService
         if ($sorted->count() <= 2) {
             return $sorted;
         }
-        $closest = $sorted->sortBy('_dist')->take(2)->values();
+        // Pin only among posts the recipient hasn't already seen, so a nearby
+        // already-seen post isn't forced back to the very top.
+        $closest = $sorted->filter(fn ($p) => empty($p->seen_by_user))
+            ->sortBy('_dist')->take(2)->values();
         $closestIds = $closest->pluck('id')->all();
         $rest = $sorted->reject(fn ($p) => in_array($p->id, $closestIds, true))->values();
         return $closest->concat($rest)->values();

--- a/iznik-batch/config/freegle.php
+++ b/iznik-batch/config/freegle.php
@@ -21,6 +21,13 @@ return [
     // track UK wall-clock pin to this zone so Laravel resolves BST/GMT.
     'timezone' => env('FREEGLE_TIMEZONE', 'Europe/London'),
 
+    'digest' => [
+        // Score multiplier for a daily-digest post the recipient has already had a
+        // chance to see (an in-app view, or an opened/clicked digest that contained
+        // it). Below 1 sinks seen posts beneath fresh ones without hard-dropping them.
+        'seen_penalty' => (float) env('FREEGLE_DIGEST_SEEN_PENALTY', 0.15),
+    ],
+
     'api' => [
         'base_url' => env('FREEGLE_API_BASE_URL', 'https://api.ilovefreegle.org'),
         'v2_url' => env('FREEGLE_API_V2_URL', 'https://api.ilovefreegle.org/apiv2'),

--- a/iznik-batch/routes/console.php
+++ b/iznik-batch/routes/console.php
@@ -248,6 +248,13 @@ Schedule::command('users:remove-spammers')
 
 // Process bounced emails — mark as invalid.
 // V1: cron/bounce.php + bounce_users.php
+// Turn digest opens/clicks into per-member 'seen' markers so the digest and browse
+// feed stop re-showing posts a member has already had a chance to see.
+Schedule::command('mail:digest:mark-seen')
+    ->hourly()
+    ->withoutOverlapping(30)
+    ->sendOutputTo(cronLog('mail:digest:mark-seen'));
+
 Schedule::command('mail:bounced')
     ->hourly()
     ->withoutOverlapping(120)

--- a/iznik-batch/tests/Feature/Mail/MarkDigestSeenCommandTest.php
+++ b/iznik-batch/tests/Feature/Mail/MarkDigestSeenCommandTest.php
@@ -55,7 +55,14 @@ class MarkDigestSeenCommandTest extends TestCase
         $group = $this->createTestGroup();
         $msg = $this->createTestMessage($this->createTestUser(), $group);
 
-        $this->seedDigest($user->id, [$msg->id], ['clicked_at' => Carbon::now()->subMinutes(5)]);
+        // Clicks are detected via email_tracking_clicks (indexed clicked_at), not the
+        // denormalised email_tracking.clicked_at.
+        $etid = $this->seedDigest($user->id, [$msg->id], ['clicked_at' => Carbon::now()->subMinutes(5)]);
+        DB::table('email_tracking_clicks')->insert([
+            'email_tracking_id' => $etid,
+            'link_url' => 'https://www.ilovefreegle.org/message/' . $msg->id,
+            'clicked_at' => Carbon::now()->subMinutes(5),
+        ]);
 
         $this->artisan('mail:digest:mark-seen')->assertExitCode(0);
         $this->assertSame(1, $this->seenCount($msg->id, $user->id));

--- a/iznik-batch/tests/Feature/Mail/MarkDigestSeenCommandTest.php
+++ b/iznik-batch/tests/Feature/Mail/MarkDigestSeenCommandTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Tests\Feature\Mail;
+
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+/**
+ * mail:digest:mark-seen turns "opened/clicked a digest" into a per-(member, post)
+ * 'View' marker - the same signal the browse feed and the daily digest sink
+ * already-seen posts on. Sending alone must NOT mark seen.
+ */
+class MarkDigestSeenCommandTest extends TestCase
+{
+    private function seedDigest(int $userid, array $msgids, array $times): int
+    {
+        return (int) DB::table('email_tracking')->insertGetId(array_merge([
+            'tracking_id' => bin2hex(random_bytes(8)),
+            'email_type' => 'UnifiedDigestDaily',
+            'userid' => $userid,
+            'recipient_email' => 'r_' . uniqid('', true) . '@test.com',
+            'metadata' => json_encode(['post_count' => count($msgids), 'post_msgids' => $msgids]),
+            'sent_at' => Carbon::now()->subHours(1),
+            'created_at' => Carbon::now()->subHours(1),
+            'updated_at' => Carbon::now(),
+        ], $times));
+    }
+
+    private function seenCount(int $msgid, int $userid): int
+    {
+        return DB::table('messages_likes')
+            ->where('msgid', $msgid)->where('userid', $userid)->where('type', 'View')->count();
+    }
+
+    public function test_opened_digest_marks_its_posts_seen_for_the_recipient(): void
+    {
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $poster = $this->createTestUser();
+        $a = $this->createTestMessage($poster, $group);
+        $b = $this->createTestMessage($poster, $group);
+
+        $this->seedDigest($user->id, [$a->id, $b->id], ['opened_at' => Carbon::now()->subMinutes(10)]);
+
+        $this->artisan('mail:digest:mark-seen')->assertExitCode(0);
+
+        $this->assertSame(1, $this->seenCount($a->id, $user->id), 'post A marked seen');
+        $this->assertSame(1, $this->seenCount($b->id, $user->id), 'post B marked seen');
+    }
+
+    public function test_clicked_digest_marks_seen(): void
+    {
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $msg = $this->createTestMessage($this->createTestUser(), $group);
+
+        $this->seedDigest($user->id, [$msg->id], ['clicked_at' => Carbon::now()->subMinutes(5)]);
+
+        $this->artisan('mail:digest:mark-seen')->assertExitCode(0);
+        $this->assertSame(1, $this->seenCount($msg->id, $user->id));
+    }
+
+    public function test_sent_but_not_opened_digest_does_not_mark_seen(): void
+    {
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $msg = $this->createTestMessage($this->createTestUser(), $group);
+
+        // Delivered, never opened or clicked - we must not sink a post the member
+        // may never have had a chance to see.
+        $this->seedDigest($user->id, [$msg->id], ['delivered_at' => Carbon::now()->subMinutes(10)]);
+
+        $this->artisan('mail:digest:mark-seen')->assertExitCode(0);
+        $this->assertSame(0, $this->seenCount($msg->id, $user->id));
+    }
+
+    public function test_open_outside_the_lookback_window_is_ignored(): void
+    {
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $msg = $this->createTestMessage($this->createTestUser(), $group);
+
+        $this->seedDigest($user->id, [$msg->id], ['opened_at' => Carbon::now()->subHours(10)]);
+
+        $this->artisan('mail:digest:mark-seen --hours=3')->assertExitCode(0);
+        $this->assertSame(0, $this->seenCount($msg->id, $user->id));
+    }
+
+    public function test_reprocessing_is_idempotent(): void
+    {
+        $user = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $msg = $this->createTestMessage($this->createTestUser(), $group);
+
+        $this->seedDigest($user->id, [$msg->id], ['opened_at' => Carbon::now()->subMinutes(10)]);
+
+        $this->artisan('mail:digest:mark-seen')->assertExitCode(0);
+        $this->artisan('mail:digest:mark-seen')->assertExitCode(0);
+
+        $this->assertSame(1, $this->seenCount($msg->id, $user->id), 'no duplicate seen rows');
+    }
+}

--- a/iznik-batch/tests/Unit/Services/UnifiedDigestServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/UnifiedDigestServiceTest.php
@@ -299,6 +299,40 @@ class UnifiedDigestServiceTest extends TestCase
         $this->assertEquals(0, $stats['emails_sent'], 'a withdrawn/taken post must not be digested');
     }
 
+    public function test_daily_digest_flags_already_seen_posts_for_the_recipient(): void
+    {
+        // A messages_likes 'View' (in-app view, or an opened/clicked digest via
+        // mail:digest:mark-seen) marks the post seen for THAT recipient, so the
+        // daily digest can sink it below fresh posts (config freegle.digest.seen_penalty).
+        $poster = $this->createTestUser();
+        $recipient = $this->createTestUser();
+        $group = $this->createTestGroup();
+        $this->createMembership($poster, $group);
+        $this->createMembership($recipient, $group, [
+            'emailfrequency' => Membership::EMAIL_FREQUENCY_DAILY,
+        ]);
+
+        $seen = $this->createTestMessage($poster, $group);
+        $unseen = $this->createTestMessage($poster, $group);
+
+        DB::table('messages_likes')->insert([
+            'msgid' => $seen->id, 'userid' => $recipient->id, 'type' => 'View', 'count' => 0,
+        ]);
+
+        $tracker = UserDigest::create([
+            'userid' => $recipient->id,
+            'mode' => UnifiedDigestService::MODE_DAILY,
+            'lastmsgid' => 0,
+        ]);
+
+        $posts = $this->service->getPostsForUser($recipient, $tracker, UnifiedDigestService::MODE_DAILY);
+        $byId = $posts->keyBy('id');
+
+        $this->assertNotNull($byId->get($seen->id), 'seen post is a candidate');
+        $this->assertTrue((bool) $byId->get($seen->id)->seen_by_user, 'viewed post is flagged seen_by_user');
+        $this->assertFalse((bool) $byId->get($unseen->id)->seen_by_user, 'un-viewed post is not flagged');
+    }
+
     public function test_daily_digest_with_available_and_taken_still_sends(): void
     {
         // An available post + a Taken post: the digest still goes (1 email);


### PR DESCRIPTION
## What

Stop re-showing a member posts they've already had a chance to see — in **both** the
daily digest and the browse feed. Design: `plans/2026-07-16-digest-reduce-repeat-views.md`.

The signal is **"they opened/clicked a digest that contained the post, or viewed it
in-app"** — deliberately **not** "we sent them a digest". Sending isn't seeing, and we
must never hide a post from someone who dipped out before reading it. (Live check: 65%
of digest recipients have an open/click within 30 days, so coverage is there; the other
35% simply keep today's behaviour — nothing is hidden from them.)

## How (no schema change)

- **`mail:digest:mark-seen`** (new, scheduled hourly): reads `email_tracking` digest
  rows (`UnifiedDigest*`) **opened or clicked** in a look-back window, pulls the
  `metadata.post_msgids` they showed (the digest mailable already records these), and
  writes a `messages_likes` `View` marker per `(msgid, userid)`. Keyed on open/click,
  idempotent, `count=0` so it flags "seen" without inflating the global `View`
  engagement sum used for scoring.
- **Browse: zero change.** `message/bounds.go` / `authority/message.go` already sort
  `unseen DESC` on exactly that `messages_likes` `View` join — so digest-opened posts
  now sink in browse automatically.
- **Daily digest:** `getPostsForUser` flags `seen_by_user` (in-app view **or** digest
  open/click) and `scoreAndSortAvailable` multiplies seen posts by
  `freegle.digest.seen_penalty` (`0.15`) so they fall below fresh posts without being
  hard-dropped; seen posts are also excluded from the "pin nearest two".

## Design notes

- **Opens are noisy** (Apple Mail Privacy pre-fetches the tracking pixel → false opens),
  so opens feed the **down-rank** path only (recoverable). A real **click** or **in-app
  view** is the strong signal. Nothing is ever hard-hidden on an open alone.
- Unifying on `messages_likes` `View` means one seen source drives both surfaces and
  needs no new table, no enum change, no browse code.

## Test Plan

Laravel suite green (4818 tests, 0 failures). New tests:
- `MarkDigestSeenCommandTest`: opened marks seen; clicked marks seen; **sent-but-not-
  opened does not**; out-of-window ignored; reprocessing idempotent.
- `UnifiedDigestServiceTest::test_daily_digest_flags_already_seen_posts_for_the_recipient`:
  a viewed post is flagged `seen_by_user`, an un-viewed one isn't.

## Follow-ups (not here)

Immediate-stream de-dup (skip an already-seen repost); finer per-post "seen" from
`email_tracking_images` scroll positions (which posts were actually scrolled to).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rm8xqAcBsnaYWZkrp5KAMA
