### PR TITLE
ci(embedding-sidecar): ride out huggingface outages with backoff retries

### DIFF
--- a/docker/embedding-sidecar/Dockerfile
+++ b/docker/embedding-sidecar/Dockerfile
@@ -4,21 +4,27 @@ WORKDIR /app
 COPY package.json .
 # npm's --fetch-retries only retries individual package fetches; a mid-stream
 # ECONNRESET (connection reset by the registry/proxy on a build VM) still aborts
-# the whole command. Retry the entire install at the shell level to survive it.
-RUN n=0; until npm install --fetch-retries=5 --fetch-retry-mintimeout=20000 --fetch-retry-maxtimeout=120000; do \
+# the whole command. Retry the entire install at the shell level to survive it,
+# with exponential backoff so we ride out a sustained registry wobble.
+RUN n=0; delay=15; until npm install --fetch-retries=5 --fetch-retry-mintimeout=20000 --fetch-retry-maxtimeout=120000; do \
       n=$((n+1)); \
-      [ "$n" -ge 5 ] && { echo "npm install failed after $n attempts" >&2; exit 1; }; \
-      echo "npm install attempt $n hit a transient network error; retrying in 15s..."; \
-      sleep 15; \
+      [ "$n" -ge 8 ] && { echo "npm install failed after $n attempts" >&2; exit 1; }; \
+      echo "npm install attempt $n hit a transient network error; retrying in ${delay}s..."; \
+      sleep "$delay"; delay=$((delay*2)); [ "$delay" -gt 120 ] && delay=120; \
     done
 COPY server.mjs .
-# Pre-download model on build so startup is fast
+# Pre-download model on build so startup is fast. This fetches from huggingface.co,
+# which has sustained gateway-timeout windows that outlast a short flat retry — and a
+# build-time fetch failure aborts the WHOLE "Build containers" step, so it breaks every
+# PR's CI at once, not just this image. Retry generously with exponential backoff
+# (8 attempts, 15s->120s cap, ~10 min total) instead of 5x15s (~75s) so a passing
+# build no longer hinges on huggingface being up for one ~minute window.
 RUN echo "import {pipeline,env} from '@huggingface/transformers'; env.cacheDir='/app/model-cache'; await pipeline('feature-extraction','nomic-ai/nomic-embed-text-v1.5',{quantized:true}); console.log('Model cached.');" > /app/prebuild.mjs && \
-    n=0; until node /app/prebuild.mjs; do \
+    n=0; delay=15; until node /app/prebuild.mjs; do \
       n=$((n+1)); \
-      [ "$n" -ge 5 ] && { echo "model prebuild failed after $n attempts" >&2; exit 1; }; \
-      echo "model prebuild attempt $n hit a transient network error; retrying in 15s..."; \
-      sleep 15; \
+      [ "$n" -ge 8 ] && { echo "model prebuild failed after $n attempts" >&2; exit 1; }; \
+      echo "model prebuild attempt $n hit a transient network error; retrying in ${delay}s..."; \
+      sleep "$delay"; delay=$((delay*2)); [ "$delay" -gt 120 ] && delay=120; \
     done && rm /app/prebuild.mjs
 EXPOSE 3200
 CMD ["node", "server.mjs"]


### PR DESCRIPTION
## Problem

The `embedding-sidecar` image pre-downloads the `nomic-embed-text-v1.5` model from **huggingface.co at build time**. huggingface has sustained gateway-timeout windows, and the old **5×15s (~75s)** flat retry can't outlast one. Because a build-time fetch failure aborts the whole **"Build containers"** step, a single huggingface wobble red-lines **every open PR's CI at once**.

Observed today across two unconnected PRs with the identical failure:
- #1057 (`build-and-test` job 27334) and #1085 (job 27337) both aborted "Build containers" with `Error: Gateway timeout ... huggingface.co/nomic-ai/nomic-embed-text-v1.5/resolve/main/tokenizer.json` → `model prebuild failed after 5 attempts`. Neither commit touches the embedding sidecar, and the test suites never ran.

## Fix

Widen both the npm-install and model-prebuild retry loops to **8 attempts with exponential backoff** (15s → 120s cap, ~10 min total window) instead of 5×15s. A passing build no longer hinges on huggingface being reachable for one ~minute window. Behaviour is unchanged when the network is healthy — the first attempt succeeds.

## Test Plan

- Built `docker/embedding-sidecar/Dockerfile` locally with the change: build **succeeds**, `Model cached.` on the first attempt (backoff loop shell syntax verified, model fetch works).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rm8xqAcBsnaYWZkrp5KAMA