### PR TITLE
fix(reach-slider): keep 'Closer than X' readable and rippling explainer reachable on mobile

### DIFF
--- a/iznik-nuxt3/components/NearbyTowns.vue
+++ b/iznik-nuxt3/components/NearbyTowns.vue
@@ -17,7 +17,9 @@
     <template v-else-if="bits.lead || bits.tail">
       <span class="nt-lead">{{ bits.lead }}</span
       ><span v-if="bits.sep" class="nt-sep">{{ bits.sep }}</span
-      ><span class="nt-tail">{{ bits.tail }}</span>
+      ><span class="nt-tail" :class="{ 'nt-tail--wrap': bits.wrap }">{{
+        bits.tail
+      }}</span>
     </template>
   </div>
 </template>
@@ -70,12 +72,22 @@ const bits = computed(() => {
       lead,
       sep: lead ? ', ' : '',
       tail: `e.g. ${towns.value.join(', ')}`,
+      wrap: false,
     }
   }
   if (closer.value) {
-    return { lead, sep: lead ? '. ' : '', tail: `Closer than ${closer.value}` }
+    // Unlike the "e.g. Town, Town" examples list above (safe to ellipsis-clip - losing an
+    // example or two still leaves a useful hint), this tail is a single town name and IS the
+    // whole message. Ellipsis-truncating it can hide the only information it conveys, so it
+    // wraps instead of clipping (`wrap: true` -> .nt-tail--wrap, Discourse 9808).
+    return {
+      lead,
+      sep: lead ? '. ' : '',
+      tail: `Closer than ${closer.value}`,
+      wrap: true,
+    }
   }
-  return { lead, sep: '', tail: '' }
+  return { lead, sep: '', tail: '', wrap: false }
 })
 
 // Debounce so dragging the slider doesn't spam the (expensive) routing pass.
@@ -156,6 +168,15 @@ watch(
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+/* The "Closer than X" nearest-town name IS the whole message, unlike the "e.g. Town, Town"
+   examples list above (safe to ellipsis-clip - losing an example or two still leaves a useful
+   hint). Clipping the single town name could hide the only information it conveys, so it wraps
+   onto another line instead of truncating (Discourse 9808). */
+.nt-tail--wrap {
+  white-space: normal;
+  overflow: visible;
+  text-overflow: clip;
 }
 
 /* Tablet and up: a single line, ellipsis-truncated. Inline (not flex) so a parent text-align:center

--- a/iznik-nuxt3/components/PostFilters.vue
+++ b/iznik-nuxt3/components/PostFilters.vue
@@ -69,8 +69,10 @@
            out over time. The distance slider above only narrows which of those
            already-reaching posts are shown - it isn't a manual travel-time control. -->
       <div v-if="browseView === 'nearby'" class="nearby-help">
-        <p class="help-text d-none d-md-block mt-0">
-          We show posts near you first, then gradually further away.
+        <p class="help-text mt-0">
+          <span class="d-none d-md-inline"
+            >We show posts near you first, then gradually further away.
+          </span>
           <a href="#" @click.prevent="whichPostsModal?.show()">
             How does this work?
           </a>
@@ -536,7 +538,9 @@ const hasNonDefaultFilters = computed(() => {
   }
 }
 
-// Help text - hidden on mobile
+// Help text - the intro sentence is hidden on mobile to save space (see the d-none d-md-inline
+// span in the template), but the "How does this work?" / "Change postcode" links inside it must
+// stay visible at every width - they're the only way to reach the rippling explainer (Discourse 9808).
 .help-text {
   font-size: 0.8rem;
   color: var(--color-gray-600);

--- a/iznik-nuxt3/tests/unit/components/NearbyTowns.spec.js
+++ b/iznik-nuxt3/tests/unit/components/NearbyTowns.spec.js
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { ref } from 'vue'
+import NearbyTowns from '~/components/NearbyTowns.vue'
+
+const mockMe = ref({ lat: 51.5, lng: -0.1 })
+
+vi.mock('~/composables/useMe', () => ({
+  useMe: () => ({ me: mockMe }),
+}))
+
+const { mockFetchNear } = vi.hoisted(() => ({
+  mockFetchNear: vi.fn(),
+}))
+vi.mock('~/api', () => ({
+  default: () => ({ town: { fetchNear: mockFetchNear } }),
+}))
+
+function mountVisible(minutes = 15) {
+  return mount(NearbyTowns, {
+    props: { minutes },
+    global: {
+      directives: {
+        // Simulate the component having scrolled into view immediately, so fetchTowns fires
+        // without depending on a real IntersectionObserver.
+        'observe-visibility': {
+          mounted(el, binding) {
+            if (typeof binding.value === 'function') binding.value(true)
+          },
+        },
+      },
+    },
+  })
+}
+
+describe('NearbyTowns', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockMe.value = { lat: 51.5, lng: -0.1 }
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  // Nothing is within reach, so the API falls back to naming the single nearest town
+  // ("Closer than: X" per the server comment in iznik-server-go/town/town.go) - the only
+  // content in that message, unlike the safe-to-truncate "e.g. Town, Town" examples list.
+  it('does not ellipsis-truncate the single nearest-town name in "Closer than X" (Discourse 9808)', async () => {
+    mockFetchNear.mockResolvedValue({
+      towns: [],
+      closer_than: 'Barrow-in-Furness',
+      frontier_median_miles: null,
+      frontier_max_miles: null,
+    })
+    const wrapper = mountVisible()
+    await vi.advanceTimersByTimeAsync(350)
+    await flushPromises()
+
+    const tail = wrapper.find('.nt-tail')
+    expect(tail.text()).toBe('Closer than Barrow-in-Furness')
+    // A CSS class that keeps this specific message from being ellipsis-clipped at mobile
+    // widths - clipping it would hide the one piece of information ("Barrow-in-Furness")
+    // the message exists to convey.
+    expect(tail.classes()).toContain('nt-tail--wrap')
+  })
+
+  it('still ellipsis-truncates the safe-to-clip "e.g. Town, Town" examples list', async () => {
+    mockFetchNear.mockResolvedValue({
+      towns: ['Preston', 'Lancaster', 'Blackpool'],
+      closer_than: '',
+      frontier_median_miles: 5,
+      frontier_max_miles: 8,
+    })
+    const wrapper = mountVisible()
+    await vi.advanceTimersByTimeAsync(350)
+    await flushPromises()
+
+    const tail = wrapper.find('.nt-tail')
+    expect(tail.text()).toBe('e.g. Preston, Lancaster, Blackpool')
+    expect(tail.classes()).not.toContain('nt-tail--wrap')
+  })
+})

--- a/iznik-nuxt3/tests/unit/components/PostFilters.spec.js
+++ b/iznik-nuxt3/tests/unit/components/PostFilters.spec.js
@@ -424,6 +424,17 @@ describe('PostFilters', () => {
       await link.trigger('click')
       expect(mockWhichPostsShow).toHaveBeenCalled()
     })
+
+    it('keeps the "How does this work?" / "Change postcode" links reachable at small (mobile) widths (Discourse 9808)', () => {
+      const wrapper = createWrapper({ forceShowFilters: true })
+
+      // Bootstrap's `d-none d-md-block` hides an element below the md breakpoint - the whole
+      // paragraph (including the only links that open the rippling explainer and change
+      // postcode) carried that class, so mobile users had no way to reach either.
+      const helpText = wrapper.find('.help-text')
+      expect(helpText.exists()).toBe(true)
+      expect(helpText.classes()).not.toContain('d-none')
+    })
   })
 
   describe('search functionality', () => {


### PR DESCRIPTION
## Root Cause
Two mobile-only gaps on the browse reach slider:
1. `NearbyTowns.vue`'s `bits` computed applied the same ellipsis-truncation CSS to the "Closer than X" fallback hint (shown when nothing is within reach) as it did to the safe-to-clip "e.g. Town, Town" examples list. For the "Closer than X" case the town name IS the whole message, so clipping it at narrow widths hid the only information it conveys.
2. `PostFilters.vue` wrapped the entire "How does this work?" / "Change postcode" paragraph in Bootstrap's `d-none d-md-block`, hiding it completely below the md breakpoint. That paragraph is the *only* way to open the rippling explainer (`WhichPostsModal` / `WhichPostsExplanation.vue`), so mobile users had no way to reach it at all.

## Evidence
Failing test output before the fix:
```
FAIL  tests/unit/components/NearbyTowns.spec.js > NearbyTowns > does not ellipsis-truncate the single nearest-town name in "Closer than X" (Discourse 9808)
AssertionError: expected [ 'nt-tail' ] to include 'nt-tail--wrap'
 ❯ tests/unit/components/NearbyTowns.spec.js:66:28

FAIL  tests/unit/components/PostFilters.spec.js > PostFilters > nearby reach text (#1) > keeps the "How does this work?" / "Change postcode" links reachable at small (mobile) widths (Discourse 9808)
AssertionError: expected [ 'help-text', 'd-none', …(2) ] to not include 'd-none'
 ❯ tests/unit/components/PostFilters.spec.js:436:38
```

## Fix
- `NearbyTowns.vue`: the `bits` computed now returns a `wrap` flag, true only for the single-town "Closer than X" fallback. The template binds an `nt-tail--wrap` modifier class that switches that span from `white-space: nowrap; overflow: hidden; text-overflow: ellipsis` to wrapping normally, so the town name is never clipped. The "e.g. Town, Town" list keeps truncating as before (losing an example there is harmless).
- `PostFilters.vue`: only the intro sentence ("We show posts near you first...") is now wrapped in `d-none d-md-inline` (mirroring the existing `.drag-hint` pattern just above it in the same file); the "How does this work?" and "Change postcode" links stay visible at every width.

## Other Call Sites
Grepped for the same defect pattern (an entire only-access-point control hidden via `d-none d-md-block` with no mobile fallback) - none found. `d-none d-md-block` is used elsewhere (e.g. `ChatHeader.vue`) but for icon/label pairs where the icon remains visible on mobile, not for hiding an entire control.

## Test
- `iznik-nuxt3/tests/unit/components/NearbyTowns.spec.js` (new) - asserts the "Closer than X" tail carries `nt-tail--wrap` and stays fully readable, while the "e.g." examples list still truncates.
- `iznik-nuxt3/tests/unit/components/PostFilters.spec.js` - new test asserts `.help-text` no longer carries `d-none`.
- Both proven to fail on the pre-fix code (see Evidence) and pass after the fix. Full frontend unit suite (671 files / 14316 tests) passes with no regressions.

## Discourse
https://discourse.ilovefreegle.org/t/9808