### PR TITLE
fix(moderation): exclude private/reserved IPs from foreign-country geolocation

### DIFF
--- a/iznik-batch/app/Services/Mail/Incoming/IncomingMailService.php
+++ b/iznik-batch/app/Services/Mail/Incoming/IncomingMailService.php
@@ -2834,6 +2834,16 @@ class IncomingMailService
             // Strip TN pic links from textbody
             $cleanedTextBody = $this->stripTnPicLinks($email->textBody);
 
+            // Geolocate the sender IP so ModTools can flag posts from outside
+            // the UK (MessageHistory.vue). V1 (Message.php/Spam.php) stored
+            // the ISO code here; store NULL when it can't be resolved. A
+            // private/reserved IP (e.g. an internal relay hop) is never
+            // geolocated - it can't indicate the sender's real location, and
+            // doing so risks a false "posted from outside the UK" warning.
+            $fromCountry = ($email->senderIp && ! $this->spamCheck->isPrivateOrReservedIP($email->senderIp))
+                ? $this->spamCheck->lookupIPCountryCode($email->senderIp)
+                : null;
+
             // Create the message record
             $message = Message::create([
                 'date' => now(),
@@ -2847,10 +2857,7 @@ class IncomingMailService
                 'fromaddr' => $email->fromAddress,
                 'replyto' => $email->getHeader('Reply-To'),
                 'fromip' => $email->senderIp,
-                // Geolocate the sender IP so ModTools can flag posts from
-                // outside the UK (MessageHistory.vue). V1 (Message.php/Spam.php)
-                // stored the ISO code here; store NULL when it can't be resolved.
-                'fromcountry' => $email->senderIp ? $this->spamCheck->lookupIPCountryCode($email->senderIp) : null,
+                'fromcountry' => $fromCountry,
                 'subject' => $email->subject,
                 'suggestedsubject' => $email->subject, // TODO: implement subject suggestion
                 'messageid' => $messageId,

--- a/iznik-batch/app/Services/Mail/Incoming/SpamCheckService.php
+++ b/iznik-batch/app/Services/Mail/Incoming/SpamCheckService.php
@@ -144,8 +144,10 @@ class SpamCheckService
         $fromTN = $email->isFromTrashNothing();
 
         if ($ip && ! $fromTN) {
-            // Skip internal IPs
-            if (str_starts_with($ip, '10.')) {
+            // Skip private/reserved IPs (e.g. an internal relay hop address) -
+            // they can never indicate the sender's real location, so must
+            // never reach GeoIP country blocking.
+            if ($this->isPrivateOrReservedIP($ip)) {
                 $ip = null;
             } else {
                 // Check IP whitelist
@@ -376,6 +378,20 @@ class SpamCheckService
         return DB::table('spam_whitelist_ips')
             ->where('ip', $ip)
             ->exists();
+    }
+
+    /**
+     * Check whether an IP is a private (RFC1918), loopback, link-local, or
+     * otherwise reserved address - e.g. an internal relay/gateway hop rather
+     * than a genuine public sender IP. Such addresses can never indicate
+     * where a sender really is, so must never be fed to GeoIP: the GeoLite2
+     * database doesn't cover them, and treating a lookup failure as "unknown
+     * country" rather than actively excluding them beforehand is a fragile,
+     * implicit contract to rely on for a country-based warning/block.
+     */
+    public function isPrivateOrReservedIP(string $ip): bool
+    {
+        return filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE) === false;
     }
 
     /**

--- a/iznik-batch/tests/Unit/Services/Mail/Incoming/IncomingMailServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/Mail/Incoming/IncomingMailServiceTest.php
@@ -1652,6 +1652,59 @@ class IncomingMailServiceTest extends TestCase
         $this->assertStringContainsString('score', $message->spamreason);
     }
 
+    public function test_private_relay_ip_does_not_populate_fromcountry(): void
+    {
+        // Regression test for Discourse topic 9865 post 11: "False 'foreign
+        // IP' warning on posts submitted by email". The only IP in the mail
+        // headers was 172.20.0.1, a Docker-internal relay/gateway address
+        // inside the RFC1918 172.16.0.0/12 private range. A private/reserved
+        // address can never indicate where the real sender is, so it must
+        // never be geolocated into messages.fromcountry - the field that
+        // drives the ModTools "posted from outside the UK" warning in
+        // MessageHistory.vue.
+        //
+        // The mocked GeoIP lookup below returns a non-UK country for ANY ip,
+        // so this test fails loudly if the private-IP guard is missing or
+        // broken, rather than passing by luck because the real bundled mmdb
+        // also happens to reject the address.
+        $spamCheck = new class extends \App\Services\Mail\Incoming\SpamCheckService
+        {
+            protected function readGeoIPCountry(string $ip): ?\GeoIp2\Record\Country
+            {
+                return new \GeoIp2\Record\Country(['iso_code' => 'DE', 'names' => ['en' => 'Germany']]);
+            }
+        };
+        $this->service = new IncomingMailService(spamCheck: $spamCheck);
+
+        [$user, $group, $userEmail] = $this->createPostableUser();
+
+        $email = $this->createMinimalEmail([
+            'From' => $userEmail,
+            'To' => $group->nameshort.'@groups.ilovefreegle.org',
+            'Subject' => 'OFFER: Test item (London)',
+            'X-Freegle-IP' => '172.20.0.1',
+        ], 'Normal body text');
+
+        $parsed = $this->parser->parse(
+            $email,
+            $userEmail,
+            $group->nameshort.'@groups.ilovefreegle.org'
+        );
+
+        $result = $this->service->route($parsed);
+
+        $this->assertContains($result, [RoutingResult::APPROVED, RoutingResult::PENDING]);
+
+        $message = DB::table('messages')
+            ->where('fromuser', $user->id)
+            ->orderBy('id', 'desc')
+            ->first();
+
+        $this->assertNotNull($message, 'Message should be created in database');
+        $this->assertEquals('172.20.0.1', $message->fromip);
+        $this->assertNull($message->fromcountry, 'A private/reserved sender IP must never be geolocated to a country');
+    }
+
     public function test_routing_context_includes_spam_info(): void
     {
         $group = $this->createTestGroup();

--- a/iznik-batch/tests/Unit/Services/Mail/Incoming/SpamCheckServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/Mail/Incoming/SpamCheckServiceTest.php
@@ -611,6 +611,37 @@ class SpamCheckServiceTest extends TestCase
         $this->assertNull($service->checkMessage($email));
     }
 
+    public function test_check_message_skips_ip_checks_for_private_range_beyond_10_prefix(): void
+    {
+        // Regression test for Discourse topic 9865 post 11: "False 'foreign
+        // IP' warning on posts submitted by email". 172.20.0.1 is a
+        // Docker-internal relay/gateway address inside the RFC1918
+        // 172.16.0.0/12 private range - not covered by the old '10.'
+        // prefix-only internal-IP check, so it used to reach GeoIP and could
+        // be geolocated as a foreign country purely because it fell outside
+        // that narrow check.
+        DB::table('spam_countries')->insert(['country' => 'TestCountry']);
+
+        $service = $this->createServiceWithMockedGeoIP('TestCountry');
+
+        $email = $this->createParsedEmailForSpamTest([
+            'senderIp' => '172.20.0.1',
+        ]);
+
+        $this->assertNull($service->checkMessage($email));
+    }
+
+    public function test_is_private_or_reserved_ip(): void
+    {
+        foreach (['10.0.0.1', '172.16.0.1', '172.20.0.1', '172.31.255.255', '192.168.1.1', '127.0.0.1', '169.254.1.1', 'not-an-ip', ''] as $ip) {
+            $this->assertTrue($this->service->isPrivateOrReservedIP($ip), "{$ip} should be treated as private/reserved");
+        }
+
+        foreach (['8.8.8.8', '1.2.3.4'] as $ip) {
+            $this->assertFalse($this->service->isPrivateOrReservedIP($ip), "{$ip} should be treated as a public address");
+        }
+    }
+
     public function test_check_message_for_chat_reply_skips_subject_reuse(): void
     {
         // A common post subject like "Washing Machine" legitimately appears on many


### PR DESCRIPTION
## Root Cause
Email-submitted posts geolocate `senderIp` (extracted from headers such as `X-Freegle-IP`) into `messages.fromcountry`, which drives the ModTools "posted from outside the UK" warning in `MessageHistory.vue`. The IP extracted from headers can be an internal relay/gateway hop (e.g. `172.20.0.1`, an RFC1918 private address) rather than the real sender. There was no private/reserved-IP guard before feeding that address to GeoIP:
- `IncomingMailService::createGroupPostMessage()` called `SpamCheckService::lookupIPCountryCode()` unconditionally for any non-null `senderIp`.
- `SpamCheckService::checkMessage()`'s spam country-block check only skipped IPs starting with `10.` - missing 172.16.0.0/12, 192.168.0.0/16, 127.0.0.0/8, 169.254.0.0/16, etc.

Both paths implicitly relied on the GeoLite2 database returning "not found" for reserved ranges rather than explicitly excluding them - a fragile, undocumented contract.

## Evidence
Isolated (pre-fix) test run:
```
FAILED  IncomingMailServiceTest > private relay ip does not populate fromcountry
A private/reserved sender IP must never be geolocated to a country
Failed asserting that 'DE' is null.

FAILED  SpamCheckServiceTest > check message skips ip checks for private range beyond 10 prefix
Failed asserting that Array &0 [
    0 => true,
    1 => 'CountryBlocked',
    2 => 'Blocking IP 172.20.0.1 as it's in TestCountry',
] is null.
```
With a mocked GeoIP lookup returning a non-UK country for any IP, `172.20.0.1` (RFC1918) was geolocated as "foreign" and would have blocked the message / set `fromcountry`, exactly matching the reported false-positive warning.

## Fix
Added `SpamCheckService::isPrivateOrReservedIP()` using PHP's built-in `filter_var(..., FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE)` (avoids hand-rolling an IP range table). Used it in both places:
- `checkMessage()`'s internal-IP skip (replacing the incomplete `10.`-prefix-only check).
- `IncomingMailService`'s `fromcountry` population, guarding the GeoIP lookup so a private/reserved `senderIp` is never geolocated.

## Other Call Sites
Grepped `lookupIPCountryCode|lookupIPCountry\(|checkIPCountry` across `iznik-batch` - only the two call sites above exist. The Go web-submit path (`iznik-server-go/utils/geoip.go`, used for platform posts, not email) already fails soft to `""` for private IPs via a plain mmdb lookup miss, so no change needed there.

## Test
- `iznik-batch/tests/Unit/Services/Mail/Incoming/SpamCheckServiceTest.php`: `test_check_message_skips_ip_checks_for_private_range_beyond_10_prefix`, `test_is_private_or_reserved_ip`
- `iznik-batch/tests/Unit/Services/Mail/Incoming/IncomingMailServiceTest.php`: `test_private_relay_ip_does_not_populate_fromcountry`
- Verified fail-before/pass-after in an isolated throwaway container (own DB, mounted worktree code) since this worktree has no bound status-API environment of its own. Ran the full `SpamCheckServiceTest` + `IncomingMailServiceTest` suites after the fix: only 3 pre-existing failures remain, all unrelated to this change (rippling/chat-review/refmsgid areas untouched by this diff).

## Discourse
https://discourse.ilovefreegle.org/t/9865/11