### PR TITLE
fix(posting): ClosestGroups no longer drops the genuinely nearest group on early exit

### DIFF
--- a/iznik-server-go/location/location.go
+++ b/iznik-server-go/location/location.go
@@ -146,24 +146,23 @@ func ClosestGroups(lat float64, lng float64, radius float64, limit int) []Closes
 	results := []ClosestGroup{}
 	var wg sync.WaitGroup
 	var mu sync.Mutex
-	count := 0
 
+	// Every band's query must complete before we can trust `results`: a group's
+	// "hav" (distance to its registered centre) gates which band can see it at
+	// all, independent of "dist" (distance to its actual polygon boundary), which
+	// is what determines "nearest" for ranking. A large or awkwardly-shaped group
+	// can have a polygon boundary very close to the point while its registered
+	// centre is comparatively far away, so it is only discoverable via a wider
+	// (and slower) band. Stopping as soon as any one band alone had accumulated
+	// `limit` candidates - as this used to do - could return before a still-running
+	// wider band completed, silently dropping a genuinely nearer group in favour of
+	// worse-but-faster-to-find ones (Discourse #9905).
 	for {
-		count++
-		currradius = currradius * 2
+		wg.Add(1)
 
-		if currradius >= radius {
-			break
-		}
-	}
-
-	currradius = math.Round(float64(radius)/16.0 + 0.5)
-	wg.Add(1)
-
-	done := false
-
-	for {
 		go func(currradius float64) {
+			defer wg.Done()
+
 			batch := []ClosestGroup{}
 			var nelat, nelng, swlat, swlng float64
 			p := geo.NewPoint(lat, lng)
@@ -196,39 +195,18 @@ func ClosestGroups(lat float64, lng float64, radius float64, limit int) []Closes
 				currradius,
 				limit).Scan(&batch)
 
-			mu.Lock()
-			defer mu.Unlock()
-
-			count--
-
-			if len(results) < limit {
-				if len(batch) > 0 {
-					// We found some.
-					for i, r := range batch {
-						if len(r.Namefull) > 0 {
-							batch[i].Namedisplay = r.Namefull
-						} else {
-							batch[i].Namedisplay = r.Nameshort
-						}
-					}
-
-					results = append(results, batch...)
-
-					if len(results) >= limit {
-						if !done {
-							done = true
-							defer wg.Done()
-						}
+			if len(batch) > 0 {
+				for i, r := range batch {
+					if len(r.Namefull) > 0 {
+						batch[i].Namedisplay = r.Namefull
+					} else {
+						batch[i].Namedisplay = r.Nameshort
 					}
 				}
 
-				if count == 0 {
-					// We've run out of areas to search.
-					if !done {
-						done = true
-						defer wg.Done()
-					}
-				}
+				mu.Lock()
+				results = append(results, batch...)
+				mu.Unlock()
 			}
 		}(currradius)
 

--- a/iznik-server-go/test/location_test.go
+++ b/iznik-server-go/test/location_test.go
@@ -1124,3 +1124,114 @@ func TestClosestGroupsContainingPolygonIsAuthoritative(t *testing.T) {
 			"non-containing group B must not appear when a containing group exists")
 	}
 }
+
+// Reproduces Discourse #9905 post #1: an FD member posted to their second-nearest
+// group instead of their nearest.
+//
+// ClosestGroups' radius-stepping search fires one query per doubling radius band
+// (currradius = NEARBY/16, then x2, x4, x8...) CONCURRENTLY, and stops as soon as
+// ANY completed band has accumulated `limit` candidates - it does not wait for the
+// other, larger-radius bands still in flight (see the "done"/wg.Done() handling in
+// ClosestGroups). A band's HAVING clause admits a group only if that group's
+// registered *centre* ("hav"/haversine distance) is within that band's own radius -
+// independent of "dist", the distance to the group's actual polygon boundary, which
+// is what determines "nearest" for ranking. A group whose boundary is very close to
+// the point but whose registered centre is comparatively far away (a large or
+// awkwardly-shaped catchment - the exact case the alt-lat/lng workaround at the top
+// of ClosestGroups exists for) is therefore only discoverable via a wider, slower
+// band. If enough closer-centred (but farther-boundary) decoy groups are found by
+// the faster, narrower bands first, the early exit fires and the genuinely nearest
+// group is silently dropped from the result - so groups[0] ends up being a group
+// that is not actually nearest.
+func TestClosestGroupsFarCentreNearBoundaryGroupNotDroppedByEarlyExit(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("closest_earlyexit")
+
+	pointLat := 20.0
+	pointLng := 20.0
+
+	// The true nearest group: polygon boundary ~0.05 miles from the point (closer
+	// than any decoy below), but a registered centre ~20 miles away - inside
+	// NEARBY(50mi) overall, but only found by the currradius=32 band (16 <= 20 < 32),
+	// which is dispatched last and has the largest bounding box to scan.
+	nameNorth := "EarlyExitNorth_" + prefix
+	db.Exec(fmt.Sprintf(
+		"INSERT INTO `groups` (nameshort, namefull, type, onhere, publish, listable, lat, lng, altlat, altlng, polyindex) "+
+			"VALUES (?, ?, 'Freegle', 1, 1, 1, %f, %f, NULL, NULL, ST_GeomFromText('POLYGON((20.0005 20.0005, 20.0005 20.0015, 20.0015 20.0015, 20.0015 20.0005, 20.0005 20.0005))', %d))",
+		pointLat+0.29, pointLng, utils.SRID), nameNorth, "Nearest North Group")
+	var groupNorth uint64
+	db.Raw("SELECT id FROM `groups` WHERE nameshort = ? ORDER BY id DESC LIMIT 1", nameNorth).Scan(&groupNorth)
+	assert.Greater(t, groupNorth, uint64(0))
+
+	// Ten decoy groups: registered centre right next to the point (hav ~0.07mi, so
+	// every band's HAVING clause admits them from the very first, narrowest band),
+	// but a polygon boundary further away (~0.3mi) than the true nearest group's -
+	// a correct, complete search still ranks them all behind it.
+	groupIDs := []uint64{groupNorth}
+	for i := 0; i < 10; i++ {
+		name := fmt.Sprintf("EarlyExitDecoy%d_%s", i, prefix)
+		off := float64(i) * 0.0001
+		db.Exec(fmt.Sprintf(
+			"INSERT INTO `groups` (nameshort, namefull, type, onhere, publish, listable, lat, lng, altlat, altlng, polyindex) "+
+				"VALUES (?, ?, 'Freegle', 1, 1, 1, %f, %f, NULL, NULL, ST_GeomFromText('POLYGON((%f 20.003, %f 20.004, 20.004 20.004, 20.004 20.003, %f 20.003))', %d))",
+			pointLat+0.001, pointLng+off, 20.003+off, 20.003+off, 20.003+off, utils.SRID), name, "Decoy Group "+name)
+		var decoyID uint64
+		db.Raw("SELECT id FROM `groups` WHERE nameshort = ? ORDER BY id DESC LIMIT 1", name).Scan(&decoyID)
+		assert.Greater(t, decoyID, uint64(0))
+		groupIDs = append(groupIDs, decoyID)
+	}
+
+	// ClosestGroups fires one query per radius band CONCURRENTLY and races them -
+	// whichever band's goroutine grabs the results-slice mutex first and already
+	// has `limit` candidates wins, regardless of which bands have or haven't
+	// finished. Bands 1-3 (radius 4/8/16) reach the decoys' 10-of-10 quickly
+	// because their bounding box is tiny. Band 4 (radius 32, the one that can also
+	// see the true nearest group) has to spatially scan a much wider box - in real
+	// production that is exactly the "may be slow even with a spatial index"
+	// tradeoff ClosestGroups' own top-of-function comment describes for a wide
+	// search area with many candidate groups. Reproduce that cost differential here
+	// (rather than relying on incidental goroutine-scheduling luck) by seeding a
+	// wide ring of filler groups that only band 4's bounding box scans: they never
+	// satisfy any band's HAVING clause (their registered centre is far outside even
+	// band 4's radius), so they can never appear in the result, but they force
+	// band 4's query to do real extra spatial + haversine work band 1-3 don't.
+	fillerPrefix := "EarlyExitFiller_" + prefix
+	var fillerValues strings.Builder
+	for i := 0; i < 3000; i++ {
+		if i > 0 {
+			fillerValues.WriteString(",")
+		}
+		// Tiny jitter (<=0.005 degrees) just to keep polygons distinct - the whole
+		// cluster stays well inside band 4's ~0.2 degree bounding box and well
+		// outside band 3's ~0.1 degree one.
+		jitter := float64(i%50) * 0.0001
+		fillerValues.WriteString(fmt.Sprintf(
+			"('%s%d', '%s%d', 'Freegle', 1, 1, 1, 29.0, 29.0, NULL, NULL, "+
+				"ST_GeomFromText('POLYGON((%f %f, %f %f, %f %f, %f %f, %f %f))', %d))",
+			fillerPrefix, i, fillerPrefix, i,
+			20.15+jitter, 20.15, 20.15+jitter, 20.151, 20.151+jitter, 20.151, 20.151+jitter, 20.15, 20.15+jitter, 20.15,
+			utils.SRID))
+	}
+	db.Exec("INSERT INTO `groups` (nameshort, namefull, type, onhere, publish, listable, lat, lng, altlat, altlng, polyindex) VALUES " +
+		fillerValues.String())
+
+	defer func() {
+		db.Exec("DELETE FROM `groups` WHERE id IN (?)", groupIDs)
+		db.Exec("DELETE FROM `groups` WHERE nameshort LIKE ?", fillerPrefix+"%")
+	}()
+
+	groups := location.ClosestGroups(pointLat, pointLng, float64(location.NEARBY), 10)
+	assert.Greater(t, len(groups), 0, "should find some groups near the point")
+
+	found := false
+	for _, g := range groups {
+		if g.ID == groupNorth {
+			found = true
+		}
+	}
+	assert.True(t, found, "the group that is genuinely nearest by polygon boundary distance must not be dropped just because narrower/faster search bands already filled the result up to the limit")
+
+	if found && len(groups) > 0 {
+		assert.Equal(t, groupNorth, groups[0].ID, "the genuinely nearest group must rank first")
+	}
+}


### PR DESCRIPTION
## Root Cause
`ClosestGroups` (`iznik-server-go/location/location.go`) fires one query per doubling radius band (currradius = NEARBY/16, x2, x4, x8...) concurrently. It used to stop as soon as **any single completed band** had accumulated `limit` candidates, without waiting for other, wider bands still in flight (`wg.Add(1)` called once, with an early `wg.Done()` fired by whichever band's goroutine first pushed `len(results) >= limit`).

A group's `hav` (haversine distance to its *registered centre*) gates which band's `HAVING` clause admits it at all - independent of `dist` (distance to its actual *polygon boundary*), which is what determines "nearest" for ranking and display. A large or awkwardly-shaped community group can have a polygon boundary very close to a point while its registered centre is comparatively far away (the exact scenario the pre-existing alt-lat/lng workaround at the top of the function exists for), so such a group is only discoverable via a wider (and slower to query) band.

If enough closer-centred-but-farther-boundary groups were found by the faster, narrower bands first, the early exit fired and the genuinely nearest group was silently dropped from the returned list - before the wider band's query (which would have found it) ever got a chance to complete. `GroupsNear[0]` from this function is what the FD compose flow (`ComposeGroup.vue`, part of the rippling-out "origin group" design from PR #10) uses as the **sole** posting target - no manual picker anymore - so a dropped nearest group meant the post went to a farther group instead. This matches Discourse #9905 post #1: FD member 43239520 posted to their second-nearest group (south) instead of their nearest (north).

**Confirmed against live production data.** Member 43239520 (Discourse #9905) is at NE65 9DL (55.295, -1.602). Ranking nearby groups by polygon-boundary distance: `NorthNorthumberlandFreegle` has its boundary **0.78 mi** from the point but its registered centre **19.36 mi** away (a large rural group), while `Morpeth-Freegle` to the south is 6.51 mi from its boundary but only 9.91 mi from its centre. So a narrow band finds Morpeth first, and the old early-exit dropped NorthNorthumberland before the wider band that alone could see it completed — the member was matched south instead of the genuinely-nearest north, exactly as reported.

## Evidence
New test `TestClosestGroupsFarCentreNearBoundaryGroupNotDroppedByEarlyExit` reproduces the bug against the pre-fix code: a synthetic group with a polygon boundary ~0.05 miles from the point but a registered centre ~20 miles away, plus 10 decoy groups with centres right next to the point but boundaries ~0.3 miles away. Failing output against the buggy code:
```
=== RUN   TestClosestGroupsFarCentreNearBoundaryGroupNotDroppedByEarlyExit
    location_test.go:1232:
        Error Trace:  /app/test/location_test.go:1232
        Error:        Should be true
        Test:         TestClosestGroupsFarCentreNearBoundaryGroupNotDroppedByEarlyExit
        Messages:     the group that is genuinely nearest by polygon boundary distance must not be dropped just because narrower/faster search bands already filled the result up to the limit
--- FAIL: TestClosestGroupsFarCentreNearBoundaryGroupNotDroppedByEarlyExit (0.55s)
```
(A ring of filler groups visible only to the widest band's bounding box is seeded to make that band's query genuinely costlier than the narrow bands', so the repro isn't dependent on incidental goroutine-scheduling luck - it mirrors the real cost asymmetry the function's own comment describes.)

## Fix
Rewrote the band dispatch loop so `wg.Add(1)`/`wg.Done()` are matched 1:1 with each dispatched goroutine, and removed the "stop once we have `limit` results" short-circuit. Every band's query now always completes and contributes to `results` before the function sorts/dedupes/truncates and returns - guaranteeing the truly-closest groups (by `dist`) are found, at the bounded cost the function's own comment already documents (~0.03s worst case for a 50-mile search). This also removes an unsynchronized read of `results` after `wg.Wait()` that could race with a late-finishing goroutine's `append`.

## Performance
The change only affects the radius-stepping path, which is reached **only when the point is not inside any group polygon** — the `ST_Contains` fast-path at the top returns first and is untouched. Measured against live data, **97.6% of recent posts fall inside a group polygon** (781/800 sampled), so the fast-path covers the overwhelming majority and the mainline posting flow is unaffected.

For the ~2.4% not-inside-any-polygon lookups, waiting for all bands does give up the early-exit optimisation the top-of-function comment describes (each such lookup now pays roughly the widest band's scan — the ~0.03s/50-mile case). Two things bound the cost: the bands run **concurrently**, so wall-clock is the *max* band time, not the sum; and the wide bands' queries already executed in the old version too (it early-*returned* but left those goroutines running — "a bit mean to the database server"), so this is added *latency* on a small minority of calls, not added DB load. It also removes that goroutine leak and the post-`wg.Wait()` data race.

## Other Call Sites
`grep -rn "ClosestGroups\|ClosestSingleGroup"` outside `location/location.go`: `user/user.go:1087` (`ClosestSingleGroup`, which calls `ClosestGroups(..., 1)`) and three call sites in `message/message.go` (mod-only message location views). All share the same underlying function, so all are fixed by this change with no separate edits needed. No other function in the codebase has the same "done"/early-exit-on-accumulated-count pattern (`grep -rn "done := false"` outside this file: none).

## Test
File: `iznik-server-go/test/location_test.go`
Command: `POST http://localhost:8081/api/tests/go` (status container API)
Proves fail-before/pass-after: failed with `3465✓ 1✗` against the pre-fix code (the new test failing), passed with `3466✓` after the fix - full suite, no regressions.

## Discourse
https://discourse.ilovefreegle.org/t/9905/1
