### PR TITLE
fix(chat): empty-chat spacer no longer reads as a blank white banner

### DIFF
--- a/iznik-nuxt3/components/ChatPane.vue
+++ b/iznik-nuxt3/components/ChatPane.vue
@@ -188,8 +188,18 @@
            to the bottom of the pane. Without it the footer becomes the only child of
            the column (the profile header is desktop-only and the message list is not
            rendered when empty), so it jumps up under the mobile navbar leaving a large
-           blank space below - Discourse 9918. -->
-      <div v-else class="chatContentEmpty" />
+           blank space below - Discourse 9918. The card mirrors .empty-state-content
+           below (used for "no chat selected") - the pattern background alone reads as
+           a blank white banner with nothing to anchor the eye (Discourse 9918/5). -->
+      <div v-else class="chatContentEmpty">
+        <div class="chatContentEmpty-card">
+          <v-icon icon="comments" class="chatContentEmpty-icon" />
+          <p class="chatContentEmpty-text">Say hello!</p>
+          <p class="chatContentEmpty-hint">
+            Send a message below to start the conversation.
+          </p>
+        </div>
+      </div>
       <ChatFooter
         v-bind="$props"
         class="chatFooter"
@@ -588,14 +598,47 @@ function typing() {
 /* Placeholder that fills the space of an empty chat (no messages yet) so the
    compose footer stays pinned to the bottom rather than jumping up under the
    header. Mirrors .chatContent's background so an empty chat still looks like a
-   chat, not a blank white void (Discourse 9918). */
+   chat, not a blank white void (Discourse 9918). The textured background alone
+   is too faint to read as intentional once there is no message content sitting
+   on top of it, so it needs a floating card (like .empty-state-content) to avoid
+   looking like a blank white banner (Discourse 9918/5). */
 .chatContentEmpty {
   order: 3;
   flex-grow: 1;
+  display: flex;
+  justify-content: center;
+  align-items: center;
   background-color: $color-gray--lighter;
   background-image: url('/chat-pattern.svg');
   background-repeat: repeat;
   background-size: 200px 200px;
+}
+
+.chatContentEmpty-card {
+  text-align: center;
+  background: white;
+  padding: 24px 32px;
+  border-radius: var(--radius-lg, 0.75rem);
+  box-shadow: var(--shadow-md);
+}
+
+.chatContentEmpty-icon {
+  font-size: 2rem;
+  color: $color-green-background;
+  margin-bottom: 10px;
+}
+
+.chatContentEmpty-text {
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: $color-gray--darker;
+  margin-bottom: 4px;
+}
+
+.chatContentEmpty-hint {
+  font-size: 0.85rem;
+  color: var(--color-gray-500);
+  margin: 0;
 }
 
 .itemwrapper {

--- a/iznik-nuxt3/tests/unit/components/ChatPane.spec.js
+++ b/iznik-nuxt3/tests/unit/components/ChatPane.spec.js
@@ -43,6 +43,24 @@ describe('ChatPane empty-chat footer position (Discourse 9918)', () => {
   })
 })
 
+describe('ChatPane empty-chat spacer content (Discourse 9918/5)', () => {
+  it('renders a card (icon + text) inside the empty-chat spacer instead of a bare textured div', () => {
+    // The bare .chatContentEmpty spacer (chat-pattern.svg tiled over
+    // $color-gray--lighter, no content on top) is too faint to read as an
+    // intentional chat backdrop once there are no message bubbles giving it
+    // visual weight - it looks like a blank white banner (Discourse 9918/5).
+    // Fix: give it a floating card, matching the existing .empty-state-content
+    // pattern already used below for "no chat selected".
+    const between = chatPaneSource.slice(
+      chatPaneSource.indexOf('chatBusy'),
+      chatPaneSource.indexOf('<ChatFooter')
+    )
+    expect(between).not.toMatch(/<div v-else class="chatContentEmpty"\s*\/>/)
+    expect(between).toMatch(/chatContentEmpty-card/)
+    expect(between).toMatch(/v-icon/)
+  })
+})
+
 describe('ChatPane', () => {
   describe('component structure', () => {
     it('is the main chat pane component', () => {


### PR DESCRIPTION
## Root Cause
6120ac714 fixed the empty-chat compose footer jumping to the top on mobile (Discourse 9918), by adding a growing `.chatContentEmpty` spacer div (order 3, flex-grow 1) so the footer stays pinned to the bottom. That spacer relies purely on the tiled `chat-pattern.svg` over `$color-gray--lighter` (#F5F5F5) to signal "this is a chat, not blank space" — the same backdrop `.chatContent` uses for the real message list.

The SVG's icon linework is drawn at only 10% opacity on an almost-white `#f8f6f1` tile, so in the populated `.chatContent` view it's invisible under the message bubbles and nobody notices. In the empty state there is nothing else rendered on top of it, so the whole pane is effectively a near-white rectangle with a barely-perceptible texture — which reads as a residual "blank white banner", not an intentional design (Discourse 9918/5).

The fix that was already established in this exact file for a similar situation — `.empty-state-pane` (shown when no chat is selected) — pairs the same textured backdrop with a floating white card (icon + text) so it clearly reads as intentional. `.chatContentEmpty` never got that treatment.

## Evidence
Verified by diffing against the pre-fix source (`git show 6120ac714:...ChatPane.vue`) and running the new assertions as plain Node against both versions (vitest itself needs `.nuxt/tsconfig.json`, generated by `nuxt prepare`, which isn't present by default in an isolated worktree — confirmed this is pre-existing/CI-only infra, not something this PR broke, by running an unrelated existing spec and seeing the identical failure before running `nuxt prepare`):

```
Buggy (post-6120ac714, pre this fix):
  self-closing match (expect true):        true
  chatContentEmpty-card match (expect false): false
  v-icon match (expect false):              false

Fixed (this PR):
  self-closing match (expect false):        false
  chatContentEmpty-card match (expect true): true
  v-icon match (expect true):                true
```

After generating `.nuxt/` locally, the full unit suite (`npx vitest run tests/unit/`) passes: **669 files / 14304 tests passed, 4 pre-existing skips**, including the new assertions.

## Fix
`iznik-nuxt3/components/ChatPane.vue`:
- The `v-else` empty-chat spacer now renders a floating card (comments icon + "Say hello! Send a message below to start the conversation.") instead of a bare self-closing div, matching the existing `.empty-state-content` pattern used just below for "no chat selected".
- `.chatContentEmpty` keeps its `order: 3; flex-grow: 1;` (footer-pinning behaviour from 6120ac714 is unchanged) and gains `display: flex; justify-content: center; align-items: center;` to centre the new card.
- Added `.chatContentEmpty-card/-icon/-text/-hint` rules mirroring `.empty-state-content/-icon/-text/-hint`.

No change to `.chatContent` (the populated message list) or its background — regression risk there is nil, confirmed by the full suite pass above.

## Other Call Sites
Grepped for `chatContentEmpty` and for other bare `chat-pattern.svg` "empty" spacers:
- Only `ChatPane.vue` defines `.chatContentEmpty` — no other call site to update.
- `ChatReplyPane.vue` also uses `chat-pattern.svg`, but as the backdrop for a populated reply pane (always has the original message rendered), not an empty-state spacer — not affected by this bug.
- `.empty-state-pane` / `.empty-state-content` (same file, "no chat selected") already use the card treatment — this PR brings `.chatContentEmpty` in line with it, no changes needed there.

## Test
File: `iznik-nuxt3/tests/unit/components/ChatPane.spec.js`, new describe block `ChatPane empty-chat spacer content (Discourse 9918/5)`.
Asserts the empty-chat spacer is not a bare self-closing div and contains a `.chatContentEmpty-card` with a `v-icon` — fails against the pre-fix source, passes after this change (see Evidence above). Follows the existing source-string assertion pattern in this file, since `ChatPane` awaits `setupChat()` in `<script setup>` and can't be cleanly mounted.

## Discourse
https://discourse.ilovefreegle.org/t/9918/5