### PR TITLE
ci(hooks): broaden should-continue Stop hook to catch any offer-to-do-work

### DIFF
--- a/.claude/check-should-continue.sh
+++ b/.claude/check-should-continue.sh
@@ -29,13 +29,22 @@ CONTINUE_PATTERNS=(
   'TODO:?\s'
   'should (now|next|also|then)'
   'would (now|next|also|then) need to'
-  # Offering to do work
-  'shall I (proceed|continue|go ahead|do|fix|run|start|implement|update|add|create|write)'
-  'want me to (proceed|continue|go ahead|do|fix|run|start|implement|update|add|create|write)'
+  # Offering to do work. Key off the OFFER PHRASE itself, not a hand-maintained
+  # verb allowlist: the old list missed "shall I close", "want me to go in that
+  # order", etc., which are exactly the stops we want to block. Any "shall I <verb>"
+  # / "want me to <verb>" / "should I <verb>?" at the end of a turn is an offer to
+  # do work we should just be doing.
+  'shall I [a-z]'
+  'should I [a-z][a-z]+'
+  '(do you |would you )?want me to [a-z]'
   'would you like me to'
-  'I can (proceed|continue|go ahead|do this|fix|run|start|implement|update|add|create|write)'
-  'let me know if you.*(want|need|like)'
-  "if you'?d like.*(I can|we can)"
+  'would you prefer'
+  'I can (just )?(proceed|continue|go|do|fix|run|start|implement|update|add|create|write|close|handle|tackle|push|commit|open|merge|verify|check|investigate|boost|apply|wire|remove|delete|refactor|test|review|look|kick)'
+  'let me know'
+  "if you'?d like"
+  # Choosing between options / asking which to do first
+  'which .*(would you like|do you want|should I|first)'
+  'in (that|which) order'
   # Summarising remaining work
   'remaining (work|tasks|items|steps)'
   'left to do'


### PR DESCRIPTION
## Problem

`check-should-continue.sh` (Stop hook) blocks ending a turn with actionable work still only *described* in the summary. Its offer-detection gated on a **narrow verb allowlist**:

```
'shall I (proceed|continue|go ahead|do|fix|run|start|implement|update|add|create|write)'
'want me to (proceed|continue|go ahead|do|fix|run|start|implement|update|add|create|write)'
```

Real offers slipped through and the turn stopped:
- **"shall I close #1089"** — `close` not in the list
- **"Want me to go in that order?"** — `go`, not `go ahead`

## Fix

Key off the **offer phrase itself**, not a hand-maintained verb list: `shall I <verb>`, `should I <verb>?`, `(do you|would you) want me to <verb>`, broadened `I can <verb>`, bare `let me know`, and option-picking (`which … first`, `in that order`).

## Test Plan

Simulated hook input per case:
- **Blocks now** (previously slipped through): the exact "Want me to go in that order? … shall I close #1089 …"; "shall I close …"; "want me to push …"; "should I use the first one …?"
- **Still does NOT fire**: a genuine completion ("fixed, tested, pushed, CI green, ready for merge") and a well-phrased authorization request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rm8xqAcBsnaYWZkrp5KAMA