### PR TITLE
fix(add-to-calendar): fix tryst calendarLink format and Android intent error

### DIFF
--- a/iznik-nuxt3/package-lock.json
+++ b/iznik-nuxt3/package-lock.json
@@ -12363,15 +12363,19 @@
       "license": "MIT"
     },
     "node_modules/add-to-calendar-button": {
-      "version": "2.12.12",
-      "resolved": "https://registry.npmjs.org/add-to-calendar-button/-/add-to-calendar-button-2.12.12.tgz",
-      "integrity": "sha512-BPGTZQexbTWhWXHZg0ZrmeZcAnOWWpyUCudb/7w4GMWMwqBlDMqi/ePRju3cZXLHrmNvKg4zo59eD2iASeTM8w==",
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/add-to-calendar-button/-/add-to-calendar-button-2.15.0.tgz",
+      "integrity": "sha512-NzWgWLQv0FsJmYXCDku14FhxtLXG6OWK5l+foLz5WetZnbnPHQ879aYODHounQc0sxiwhKjjgIOQq0kDAvLRvA==",
+      "license": "ELv2",
       "dependencies": {
-        "timezones-ical-library": "^1.10.0"
+        "timezones-ical-library": "^2.2.1"
       },
       "engines": {
         "node": ">=18.17.0",
         "npm": ">=9.6.7"
+      },
+      "funding": {
+        "url": "https://github.com/add2cal/add-to-calendar-button?sponsor=1"
       }
     },
     "node_modules/address": {
@@ -28300,13 +28304,10 @@
       "peer": true
     },
     "node_modules/timezones-ical-library": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/timezones-ical-library/-/timezones-ical-library-1.10.0.tgz",
-      "integrity": "sha512-aSwylC0FyyxMqMjkuaYz56HBhhooYabGT74CbTuY1uOeIcBXSQTXf+u/mTR0MWJFPQDe21REjex+4wt0OdFDpA==",
-      "engines": {
-        "node": ">=18.17.0",
-        "npm": ">=9.6.7"
-      }
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/timezones-ical-library/-/timezones-ical-library-2.3.0.tgz",
+      "integrity": "sha512-cjYULc9c8bvzy9fUYtso6Dqya1t9aT1W2KtrK30acmF7uWJ1USn4siyRSn//xZIACKqucjDkh41UQK7qljzkpQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/tiny-emitter": {
       "version": "2.1.0",

--- a/iznik-nuxt3/tests/unit/config/addToCalendarButtonVersion.spec.js
+++ b/iznik-nuxt3/tests/unit/config/addToCalendarButtonVersion.spec.js
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+import { dirname, resolve } from 'path'
+
+/**
+ * Verifies the pinned add-to-calendar-button version used by
+ * pages/calendar.client.vue (topic 9927 post 1).
+ *
+ * On Android, add-to-calendar-button < 2.13.0 opens the Google Calendar
+ * option via an `intent://...#Intent;scheme=https;package=com.google.android.calendar;end`
+ * URL with no `S.browser_fallback_url` fallback, and does not skip that
+ * intent scheme when running inside a WebView. If the intent can't be
+ * resolved (app not installed, or opened from a context that can't handle
+ * custom URL schemes, e.g. an in-app browser tab), the OS/browser shows an
+ * error instead of falling back to the normal Google Calendar web page.
+ * 2.13.0 added both the fallback URL and an isWebView() check that avoids
+ * the intent scheme entirely in that case.
+ */
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const lockPath = resolve(__dirname, '../../../package-lock.json')
+const lock = JSON.parse(readFileSync(lockPath, 'utf-8'))
+
+describe('add-to-calendar-button pinned version', () => {
+  it('is at least 2.13.0, which fixes the Android Google Calendar intent:// error', () => {
+    const resolvedVersion = lock.packages['node_modules/add-to-calendar-button'].version
+    const [major, minor] = resolvedVersion.split('.').map(Number)
+
+    expect(major > 2 || (major === 2 && minor >= 13)).toBe(true)
+  })
+})

--- a/iznik-server-go/test/tryst_test.go
+++ b/iznik-server-go/test/tryst_test.go
@@ -2,9 +2,11 @@ package test
 
 import (
 	"bytes"
+	"encoding/base64"
 	json2 "encoding/json"
 	"fmt"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -258,8 +260,19 @@ func TestGetTrystSingleIncludesCalendarLink(t *testing.T) {
 	tryst := result["tryst"].(map[string]interface{})
 	calLink, ok := tryst["calendarLink"].(string)
 	assert.True(t, ok, "calendarLink should be a string")
-	assert.Contains(t, calLink, "google.com/calendar", "calendarLink should be a Google Calendar URL")
-	assert.Contains(t, calLink, "Freegle", "calendarLink should mention Freegle")
+
+	// AddToCalendar.vue's download() extracts and decodes this the same way.
+	u, err := url.Parse(calLink)
+	assert.NoError(t, err)
+	encoded := u.Query().Get("data")
+	assert.NotEmpty(t, encoded, "calendarLink should have a data= param the frontend can parse")
+
+	decoded, err := base64.RawURLEncoding.DecodeString(encoded)
+	assert.NoError(t, err)
+
+	var eventData map[string]string
+	assert.NoError(t, json2.Unmarshal(decoded, &eventData))
+	assert.Contains(t, eventData["name"], "Freegle", "calendarLink event data should mention Freegle")
 }
 
 func TestGetTrystListIncludesCalendarLink(t *testing.T) {
@@ -286,7 +299,10 @@ func TestGetTrystListIncludesCalendarLink(t *testing.T) {
 	first := trysts[0].(map[string]interface{})
 	calLink, ok := first["calendarLink"].(string)
 	assert.True(t, ok, "calendarLink should be present in tryst list items")
-	assert.Contains(t, calLink, "google.com/calendar")
+
+	u, err := url.Parse(calLink)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, u.Query().Get("data"), "calendarLink should have a data= param the frontend can parse")
 }
 
 func TestGetTrystV2Path(t *testing.T) {

--- a/iznik-server-go/tryst/tryst.go
+++ b/iznik-server-go/tryst/tryst.go
@@ -1,10 +1,12 @@
 package tryst
 
 import (
-	"strings"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
-	"net/url"
+	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/freegle/iznik-server-go/database"
@@ -29,8 +31,15 @@ func canSee(myid uint64, t *Tryst) bool {
 	return t.ID > 0 && (t.User1 == myid || t.User2 == myid)
 }
 
-// calendarLink generates a Google Calendar link for a tryst.
-// The link creates a 1-hour event starting at the arrangedfor time.
+// calendarLink generates an Add to Calendar link for a tryst, creating a
+// 1-hour event starting at the arrangedfor time.
+//
+// The event data is base64url-encoded JSON in a `data` query param, matching
+// the format iznik-batch's TrystService::buildCalendarLink() already uses for
+// the calendar invite email, and that AddToCalendar.vue / pages/calendar.client.vue
+// expect. A previous version of this function returned a raw Google Calendar
+// render URL, which those consumers can't parse - the button appeared to do
+// nothing when tapped.
 func calendarLink(arrangedfor *string) string {
 	if arrangedfor == nil || *arrangedfor == "" {
 		return ""
@@ -45,16 +54,27 @@ func calendarLink(arrangedfor *string) string {
 		}
 	}
 
-	start := t.UTC().Format("20060102T150405Z")
-	end := t.Add(time.Hour).UTC().Format("20060102T150405Z")
+	t = t.UTC()
+	end := t.Add(time.Hour)
 
-	return fmt.Sprintf(
-		"https://www.google.com/calendar/render?action=TEMPLATE&text=%s&dates=%s/%s&details=%s&sf=true&output=xml",
-		url.QueryEscape("Freegle Handover"),
-		start,
-		end,
-		url.QueryEscape("Arrange handover of Freegle item"),
-	)
+	eventData := map[string]string{
+		"name":        "Freegle Handover",
+		"description": "Arrange handover of Freegle item",
+		"startDate":   t.Format("2006-01-02"),
+		"startTime":   t.Format("15:04"),
+		"endTime":     end.Format("15:04"),
+		"timeZone":    "UTC",
+		"location":    "",
+	}
+
+	jsonData, err := json.Marshal(eventData)
+	if err != nil {
+		return ""
+	}
+
+	encoded := base64.RawURLEncoding.EncodeToString(jsonData)
+
+	return fmt.Sprintf("https://%s/calendar?data=%s", os.Getenv("USER_SITE"), encoded)
 }
 
 // GetTryst handles GET /tryst - list user's trysts or single by ID.

--- a/iznik-server-go/tryst/tryst_test.go
+++ b/iznik-server-go/tryst/tryst_test.go
@@ -1,6 +1,9 @@
 package tryst
 
 import (
+	"encoding/base64"
+	"encoding/json"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -77,62 +80,83 @@ func TestCalendarLink_PartialDateReturnsEmpty(t *testing.T) {
 	assert.Equal(t, "", calendarLink(strPtr("2024-06-15")))
 }
 
+// decodeCalendarLinkData parses the `data` query param out of a calendarLink()
+// result the same way AddToCalendar.vue's download() does: extract, base64url
+// decode, then JSON unmarshal.
+func decodeCalendarLinkData(t *testing.T, link string) map[string]string {
+	t.Helper()
+
+	u, err := url.Parse(link)
+	assert.NoError(t, err)
+
+	encoded := u.Query().Get("data")
+	assert.NotEmpty(t, encoded)
+
+	decoded, err := base64.RawURLEncoding.DecodeString(encoded)
+	assert.NoError(t, err)
+
+	var eventData map[string]string
+	assert.NoError(t, json.Unmarshal(decoded, &eventData))
+
+	return eventData
+}
+
 func TestCalendarLink_MySQLDatetimeFormat(t *testing.T) {
 	link := calendarLink(strPtr("2024-06-15 10:30:00"))
-	assert.Contains(t, link, "https://www.google.com/calendar/render")
-	assert.Contains(t, link, "20240615T103000Z") // start
-	assert.Contains(t, link, "20240615T113000Z") // end = start + 1h
+	eventData := decodeCalendarLinkData(t, link)
+	assert.Equal(t, "2024-06-15", eventData["startDate"])
+	assert.Equal(t, "10:30", eventData["startTime"])
+	assert.Equal(t, "11:30", eventData["endTime"]) // end = start + 1h
 }
 
 func TestCalendarLink_RFC3339Format(t *testing.T) {
 	link := calendarLink(strPtr("2024-06-15T10:30:00Z"))
-	assert.Contains(t, link, "20240615T103000Z")
-	assert.Contains(t, link, "20240615T113000Z")
+	eventData := decodeCalendarLinkData(t, link)
+	assert.Equal(t, "10:30", eventData["startTime"])
+	assert.Equal(t, "11:30", eventData["endTime"])
 }
 
 func TestCalendarLink_RFC3339WithOffset(t *testing.T) {
 	// +01:00 offset → stored as UTC 09:30, end UTC 10:30.
 	link := calendarLink(strPtr("2024-06-15T10:30:00+01:00"))
-	assert.Contains(t, link, "20240615T093000Z")
-	assert.Contains(t, link, "20240615T103000Z")
+	eventData := decodeCalendarLinkData(t, link)
+	assert.Equal(t, "09:30", eventData["startTime"])
+	assert.Equal(t, "10:30", eventData["endTime"])
 }
 
 func TestCalendarLink_ContainsFreegleTitle(t *testing.T) {
 	link := calendarLink(strPtr("2024-01-01 00:00:00"))
-	assert.Contains(t, link, "Freegle+Handover")
+	eventData := decodeCalendarLinkData(t, link)
+	assert.Contains(t, eventData["name"], "Freegle")
 }
 
 func TestCalendarLink_ContainsDetails(t *testing.T) {
 	link := calendarLink(strPtr("2024-01-01 00:00:00"))
-	assert.Contains(t, link, "Arrange+handover+of+Freegle+item")
+	eventData := decodeCalendarLinkData(t, link)
+	assert.Contains(t, eventData["description"], "handover")
 }
 
-func TestCalendarLink_ContainsActionTemplate(t *testing.T) {
+func TestCalendarLink_IncludesTimeZone(t *testing.T) {
 	link := calendarLink(strPtr("2024-01-01 00:00:00"))
-	assert.Contains(t, link, "action=TEMPLATE")
-}
-
-func TestCalendarLink_ContainsSFAndOutput(t *testing.T) {
-	link := calendarLink(strPtr("2024-01-01 00:00:00"))
-	assert.Contains(t, link, "sf=true")
-	assert.Contains(t, link, "output=xml")
-}
-
-func TestCalendarLink_DatesSlashSeparated(t *testing.T) {
-	// Google Calendar expects dates=START/END.
-	link := calendarLink(strPtr("2024-03-10 09:00:00"))
-	assert.Contains(t, link, "20240310T090000Z/20240310T100000Z")
+	eventData := decodeCalendarLinkData(t, link)
+	assert.NotEmpty(t, eventData["timeZone"])
 }
 
 func TestCalendarLink_MidnightRollsOverToNextDay(t *testing.T) {
 	// Start at 23:30, end should be 00:30 the following day.
 	link := calendarLink(strPtr("2024-06-30 23:30:00"))
-	assert.Contains(t, link, "20240630T233000Z/20240701T003000Z")
+	eventData := decodeCalendarLinkData(t, link)
+	assert.Equal(t, "2024-06-30", eventData["startDate"])
+	assert.Equal(t, "23:30", eventData["startTime"])
+	assert.Equal(t, "00:30", eventData["endTime"])
 }
 
-func TestCalendarLink_URLStartsWithGoogleCalendar(t *testing.T) {
+func TestCalendarLink_URLPointsToCalendarPage(t *testing.T) {
 	link := calendarLink(strPtr("2024-01-01 12:00:00"))
-	assert.True(t, strings.HasPrefix(link, "https://www.google.com/calendar/render"))
+	u, err := url.Parse(link)
+	assert.NoError(t, err)
+	assert.Equal(t, "/calendar", u.Path)
+	assert.True(t, strings.HasPrefix(link, "https://"))
 }
 
 func TestCalendarLink_NonEmptyForValidInput(t *testing.T) {
@@ -143,11 +167,34 @@ func TestCalendarLink_NonEmptyForValidInput(t *testing.T) {
 func TestCalendarLink_NewYearMidnight(t *testing.T) {
 	// Edge: 2023-12-31 23:00:00 UTC → end 2024-01-01 00:00:00 UTC.
 	link := calendarLink(strPtr("2023-12-31 23:00:00"))
-	assert.Contains(t, link, "20231231T230000Z/20240101T000000Z")
+	eventData := decodeCalendarLinkData(t, link)
+	assert.Equal(t, "2023-12-31", eventData["startDate"])
+	assert.Equal(t, "23:00", eventData["startTime"])
+	assert.Equal(t, "00:00", eventData["endTime"])
 }
 
 func TestCalendarLink_LeapDay(t *testing.T) {
 	// Leap day should parse fine.
 	link := calendarLink(strPtr("2024-02-29 08:00:00"))
-	assert.Contains(t, link, "20240229T080000Z/20240229T090000Z")
+	eventData := decodeCalendarLinkData(t, link)
+	assert.Equal(t, "2024-02-29", eventData["startDate"])
+	assert.Equal(t, "08:00", eventData["startTime"])
+	assert.Equal(t, "09:00", eventData["endTime"])
+}
+
+// TestCalendarLink_DataParamMatchesFrontendContract reproduces topic 9927 post 1:
+// the in-app "Add to Calendar" button greys out and does nothing when tapped.
+// AddToCalendar.vue's download() does the equivalent of decodeCalendarLinkData()
+// above, and bails out silently (console.error only) if there is no `data` param
+// or the fields it needs are missing. This test performs that same parse against
+// the real calendarLink() output.
+func TestCalendarLink_DataParamMatchesFrontendContract(t *testing.T) {
+	link := calendarLink(strPtr("2024-06-15 10:30:00"))
+	eventData := decodeCalendarLinkData(t, link)
+
+	assert.Equal(t, "2024-06-15", eventData["startDate"])
+	assert.Equal(t, "10:30", eventData["startTime"])
+	assert.Equal(t, "11:30", eventData["endTime"])
+	assert.NotEmpty(t, eventData["timeZone"])
+	assert.NotEmpty(t, eventData["name"])
 }


### PR DESCRIPTION
## Root Cause

Two distinct bugs behind one report:

1. **In-app / web button does nothing ("turns grey")**: the Go `/tryst` API's `calendarLink()` returned a raw `https://www.google.com/calendar/render?...` URL. But `AddToCalendar.vue` (used by `MyMessagePromisedTo.vue` and `ChatMessagePromised.vue` for promised handovers, both in-app and on the web) expects a base64url-encoded JSON payload in a `data` query param - the same format `iznik-batch`'s `TrystService::buildCalendarLink()` already produces for the calendar-invite email. Because the formats didn't match, `download()` found no `data` param, logged a console error, and returned - no visible feedback, matching "turns grey, but nothing happens".

2. **Email-linked page button errors on Google Calendar**: `pages/calendar.client.vue` renders a third-party `add-to-calendar-button` web component, pinned to v2.12.12. On Android, that version opens the Google Calendar option via an `intent://...#Intent;scheme=https;package=com.google.android.calendar;end` URL with no `S.browser_fallback_url` fallback, and without a WebView guard. If the intent can't resolve (app not installed, or the browser/tab context can't handle custom URL schemes), the OS shows an error instead of falling back to the normal Google Calendar web page. v2.13.0 added both fixes.

## Evidence

Go unit test (`iznik-server-go/tryst`), before the fix:

```
=== RUN   TestCalendarLink_DataParamMatchesFrontendContract
    tryst_test.go:184: Not equal: expected: "10:30" actual: ""
    tryst_test.go:185: Not equal: expected: "11:30" actual: ""
    tryst_test.go:186: Should NOT be empty, but was
    tryst_test.go:187: Should NOT be empty, but was
--- FAIL: TestCalendarLink_DataParamMatchesFrontendContract (0.00s)
FAIL
```

This replicates exactly what `AddToCalendar.vue`'s `download()` does: parse the URL, pull the `data` query param, base64-decode it, `JSON.parse` it. The old `calendarLink()` output had no `data` param at all.

Dependency check (`iznik-nuxt3`), before the fix:

```
resolved version: 2.12.12
meets >=2.13.0: false
```

## Fix

- `iznik-server-go/tryst/tryst.go`: `calendarLink()` now builds `https://{USER_SITE}/calendar?data=<base64url JSON>` (name/description/startDate/startTime/endTime/timeZone/location), matching the format `AddToCalendar.vue` and `iznik-batch`'s `TrystService` already agree on.
- `iznik-nuxt3/package-lock.json`: bumped `add-to-calendar-button` from 2.12.12 to 2.15.0 (`package.json`'s existing `^2.12.12` range already permitted this; only the lockfile was stale). Diff is scoped to that package and its own `timezones-ical-library` dependency.

## Other Call Sites

- `promise.tryst.calendarLink` (the Go-produced link) is only consumed by `AddToCalendar.vue`, via `MyMessagePromisedTo.vue` and `ChatMessagePromised.vue` (x2). All three go through the same `download()` code path - no other consumer exists.
- `add-to-calendar-button` is only used on `pages/calendar.client.vue` - no other page embeds it.

## Test

- `iznik-server-go/tryst/tryst_test.go`: new `TestCalendarLink_DataParamMatchesFrontendContract`, plus updated the existing `TestCalendarLink_*` suite (previously asserted the old, buggy Google-URL format) to decode and check the new `data` payload.
- `iznik-server-go/test/tryst_test.go`: updated `TestGetTrystSingleIncludesCalendarLink` / `TestGetTrystListIncludesCalendarLink` (endpoint-level) to check for the `data` param instead of a `google.com/calendar` substring.
- `iznik-nuxt3/tests/unit/config/addToCalendarButtonVersion.spec.js`: new test asserting the pinned `add-to-calendar-button` lockfile version is >= 2.13.0.
- Ran `go test ./tryst/... -v` directly in the isolated worktree (no DB in this environment) - all pass, confirmed fail-before/pass-after via the AssertFlip test above. `go build ./...` and `go vet ./tryst/... ./test/...` are clean. The two DB-backed endpoint tests in `test/tryst_test.go` compile cleanly but weren't run live (no DB in this isolated worktree) - please confirm on CI.
- Vitest couldn't be run locally (no `node_modules` in this isolated worktree, no local vitest path in this project); verified the test's underlying logic directly with `node -e` against `package-lock.json` before and after the bump (`false` → `true`). Please confirm on CI.

## Discourse
https://discourse.ilovefreegle.org/t/9927/1