### PR TITLE
fix(9865): stop posts going live with no location; fix false "outside UK" scam warning

### DIFF
--- a/iznik-batch/app/Services/ContentCheckService.php
+++ b/iznik-batch/app/Services/ContentCheckService.php
@@ -285,7 +285,13 @@ class ContentCheckService
 
                         $isModerated = $this->isUserModerated((int) $row->msgid, (int) $row->groupid, (int) $row->fromuser)
                                     || $this->isGroupModerated((int) $row->groupid);
-                        $promote     = empty($reasons) && !$isModerated;
+                        // Never auto-promote an Offer/Wanted we couldn't locate (NULL lat -
+                        // subject didn't geocode and no usable poster fallback): it would go
+                        // live undiscoverable. Keep it in the mod queue so a moderator adds a
+                        // postcode via the "add a postcode" prompt (Discourse #9865).
+                        $missingLocation = $row->lat === null
+                                        && in_array($row->msgtype, ['Offer', 'Wanted'], true);
+                        $promote     = empty($reasons) && !$isModerated && !$missingLocation;
                         $hasBlock    = !$promote && !empty(array_filter(
                             $reasons,
                             fn($r) => ($r['action'] ?? 'flag') === 'block'
@@ -381,7 +387,7 @@ class ContentCheckService
         $base = fn () => DB::table('messages_groups as mg')
             ->join('messages as m', 'm.id', '=', 'mg.msgid')
             ->join('users as u', 'u.id', '=', 'm.fromuser')
-            ->select('mg.msgid', 'mg.groupid', 'mg.collection', DB::raw('m.type as msgtype'), DB::raw('m.fromuser as fromuser'))
+            ->select('mg.msgid', 'mg.groupid', 'mg.collection', DB::raw('m.type as msgtype'), DB::raw('m.fromuser as fromuser'), DB::raw('m.lat as lat'))
             ->whereNull('mg.contentcheck_checked_at')
             ->where('mg.deleted', 0)
             // Never fight a mod: a held message has been deliberately pulled back /

--- a/iznik-batch/tests/Feature/Message/ContentCheckTest.php
+++ b/iznik-batch/tests/Feature/Message/ContentCheckTest.php
@@ -261,6 +261,59 @@ class ContentCheckTest extends TestCase
         $this->assertNull($rippledRow->contentcheck_reasons, 'rippled-into group not flagged');
     }
 
+    public function test_offer_with_no_location_is_not_auto_promoted(): void
+    {
+        // An Offer/Wanted we couldn't locate (NULL lat) must NOT be auto-promoted -
+        // it would go live undiscoverable. It stays Pending for a moderator to add a
+        // postcode via the "add a postcode" prompt (Discourse #9865). An otherwise
+        // identical located post from the same unmoderated poster is auto-promoted.
+        $group = $this->createTestGroup();
+        $user  = $this->createTestUser();
+        $this->createMembership($user, $group, ['ourPostingStatus' => 'DEFAULT']);
+
+        $noLocId = DB::table('messages')->insertGetId([
+            'fromuser' => $user->id,
+            'type'     => 'Offer',
+            'subject'  => 'OFFER: Dining Table (unlocatable)',
+            'textbody' => 'A dining table. Collection only.',
+            'message'  => 'A dining table. Collection only.',
+            'arrival'  => now(),
+            'date'     => now(),
+            'source'   => 'Platform',
+            'lat'      => null,
+            'lng'      => null,
+        ]);
+        $locId = DB::table('messages')->insertGetId([
+            'fromuser' => $user->id,
+            'type'     => 'Offer',
+            'subject'  => 'OFFER: Bookshelf (SW1A)',
+            'textbody' => 'A bookshelf. Collection only.',
+            'message'  => 'A bookshelf. Collection only.',
+            'arrival'  => now(),
+            'date'     => now(),
+            'source'   => 'Platform',
+            'lat'      => 51.50,
+            'lng'      => -0.13,
+        ]);
+        foreach ([$noLocId, $locId] as $mid) {
+            DB::table('messages_groups')->insert([
+                'msgid'      => $mid,
+                'groupid'    => $group->id,
+                'collection' => 'Pending',
+                'arrival'    => now(),
+                'deleted'    => 0,
+            ]);
+        }
+
+        $this->service->processUnprocessed();
+
+        $noLocColl = DB::table('messages_groups')->where('msgid', $noLocId)->value('collection');
+        $locColl   = DB::table('messages_groups')->where('msgid', $locId)->value('collection');
+
+        $this->assertSame('Pending', $noLocColl, 'no-location Offer is kept Pending for a mod');
+        $this->assertSame('Approved', $locColl, 'located Offer is auto-promoted as normal');
+    }
+
     public function test_allowed_category_keywords_are_not_flagged(): void
     {
         // 'allowed' is a category (whitelist) in concern_keywords, not an action.
@@ -865,6 +918,8 @@ class ContentCheckTest extends TestCase
             'arrival'  => now(),
             'date'     => now(),
             'source'   => 'Platform',
+            'lat'      => 51.50,
+            'lng'      => -0.13,
         ]);
         DB::table('items')->insertOrIgnore(['name' => 'Solid oak table']);
         $itemId = DB::table('items')->where('name', 'Solid oak table')->value('id');
@@ -1134,6 +1189,8 @@ class ContentCheckTest extends TestCase
             'arrival'  => now(),
             'date'     => now(),
             'source'   => 'Platform',
+            'lat'      => 51.50,
+            'lng'      => -0.13,
         ]);
         DB::table('messages_groups')->insert([
             'msgid'   => $msgid,
@@ -1467,6 +1524,8 @@ class ContentCheckTest extends TestCase
             'arrival'  => $originalArrival,
             'date'     => $originalArrival,
             'source'   => 'Platform',
+            'lat'      => 51.50,
+            'lng'      => -0.13,
         ]);
         DB::table('items')->insertOrIgnore(['name' => 'Good chair']);
         $itemId = DB::table('items')->where('name', 'Good chair')->value('id');
@@ -2720,6 +2779,8 @@ class ContentCheckTest extends TestCase
             'arrival'  => now(),
             'date'     => now(),
             'source'   => 'Platform',
+            'lat'      => 51.50,
+            'lng'      => -0.13,
         ]);
         DB::table('messages_groups')->insert([
             'msgid'      => $msgid,

--- a/iznik-nuxt3/modtools/components/ModMessage.vue
+++ b/iznik-nuxt3/modtools/components/ModMessage.vue
@@ -371,6 +371,12 @@
                 {{ fromUser.activedistance }} miles apart.
               </NoticeMessage>
             </div>
+            <NoticeMessage v-if="noLocation" variant="warning" class="mb-2">
+              We couldn't work out where this post is (often an emailed post whose
+              subject has no recognised place name). Please click
+              <strong>Edit</strong> and add a postcode (it doesn't have to be
+              exactly right - do your best) so members can find it.
+            </NoticeMessage>
             <NoticeMessage v-if="outsideUK" variant="warning" class="mb-2">
               This message may be from outside the UK ({{ position.lat }},
               {{ position.lng }}), which means it might be a scam. Please check
@@ -1153,8 +1159,19 @@ const position = computed(() => {
   return ret
 })
 
+// No resolved location: either the API returned no point, or the point collapsed
+// to ~(0,0) - an unset/ungeocoded lat/lng (e.g. an email post whose subject location
+// couldn't be geocoded, stored NULL and read back as 0). That is "location unknown",
+// NOT a real foreign location, so it must not trip the outside-UK scam warning
+// (Discourse #9865). UK lat is ~49-61, so a real post is never within 0.5deg of (0,0).
+const noLocation = computed(() => {
+  const p = position.value
+  return !p || (Math.abs(p.lat) < 0.5 && Math.abs(p.lng) < 0.5)
+})
+
 const outsideUK = computed(() => {
   return (
+    !noLocation.value &&
     position.value &&
     (position.value.lng < -16 ||
       position.value.lat < 49 ||

--- a/iznik-nuxt3/tests/unit/components/modtools/ModMessage.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModMessage.spec.js
@@ -566,9 +566,30 @@ describe('ModMessage', () => {
       ['UK position', { lat: 52.0, lng: -1.0 }, false],
       ['outside UK (west)', { lat: 52.0, lng: -20.0 }, true],
       ['outside UK (south)', { lat: 40.0, lng: -1.0 }, true],
+      // (0,0) and its blurred form are unresolved locations, not foreign ones -
+      // they must NOT trip the scam warning (Discourse #9865).
+      ['null island (0,0) is not outside UK', { lat: 0, lng: 0 }, false],
+      ['blurred null island (0.004,0) is not outside UK', { lat: 0.004, lng: 0 }, false],
     ])('%s returns %s', (_desc, location, expected) => {
       const wrapper = mountComponent({}, { location })
       expect(wrapper.vm.outsideUK).toBe(expected)
+    })
+  })
+
+  describe('Computed: noLocation', () => {
+    it.each([
+      ['real UK location', { lat: 51.5, lng: -0.1 }, false],
+      ['genuinely foreign location (New York)', { lat: 40.7, lng: -74.0 }, false],
+      ['null island (0,0)', { lat: 0, lng: 0 }, true],
+      ['blurred null island (0.004,0)', { lat: 0.004, lng: 0 }, true],
+    ])('%s -> %s', (_desc, location, expected) => {
+      const wrapper = mountComponent({}, { location })
+      expect(wrapper.vm.noLocation).toBe(expected)
+    })
+
+    it('is true when there is no position at all', () => {
+      const wrapper = mountComponent({}, { location: null, lat: null, lng: null })
+      expect(wrapper.vm.noLocation).toBe(true)
     })
   })
 

--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -3114,13 +3114,30 @@ func applyPatchMessageCore(c *fiber.Ctx, myid uint64, req patchMessageRequest) e
 		setClauses = append(setClauses, "locationid = ?")
 		args = append(args, *req.Locationid)
 	}
-	if req.Lat != nil {
-		setClauses = append(setClauses, "lat = ?")
-		args = append(args, *req.Lat)
+	// Effective coordinates for this edit. Use the coords the client sent; but if the
+	// location changed without matching coords, derive lat/lng from the chosen location.
+	// Without this a location-only edit sets locationid yet leaves lat/lng stale or NULL,
+	// making the post undiscoverable — browse/search read messages.lat/lng directly
+	// (Discourse 9865). Locations are static reference data, so this lookup returns the
+	// row reliably; it is not a timing/race concern.
+	effLat, effLng := req.Lat, req.Lng
+	if req.Locationid != nil && (effLat == nil || effLng == nil) {
+		var llat, llng *float64
+		db.Raw("SELECT lat, lng FROM locations WHERE id = ?", *req.Locationid).Row().Scan(&llat, &llng)
+		if effLat == nil {
+			effLat = llat
+		}
+		if effLng == nil {
+			effLng = llng
+		}
 	}
-	if req.Lng != nil {
+	if effLat != nil {
+		setClauses = append(setClauses, "lat = ?")
+		args = append(args, *effLat)
+	}
+	if effLng != nil {
 		setClauses = append(setClauses, "lng = ?")
-		args = append(args, *req.Lng)
+		args = append(args, *effLng)
 	}
 
 	if len(setClauses) > 0 {
@@ -3132,9 +3149,9 @@ func applyPatchMessageCore(c *fiber.Ctx, myid uint64, req patchMessageRequest) e
 	// changes. We deliberately UPDATE only — never INSERT — so editing a Pending
 	// message's location cannot leak it into messages_spatial (which backs the public
 	// browse). Only Approved messages have a spatial row; the approval path inserts.
-	if req.Lat != nil && req.Lng != nil {
+	if effLat != nil && effLng != nil {
 		db.Exec("UPDATE messages_spatial SET point = ST_GeomFromText(CONCAT('POINT(', ?, ' ', ?, ')'), 3857) WHERE msgid = ?",
-			*req.Lng, *req.Lat, req.ID)
+			*effLng, *effLat, req.ID)
 	}
 
 	// PHP parity (message.php:371-372): when a groupid is supplied, persist it to
@@ -3970,10 +3987,11 @@ func PutMessage(c *fiber.Ctx) error {
 	// the chosen locationid; if the client didn't send one, fall back to the user's
 	// last known location so the post is still findable (parity with the email path,
 	// IncomingMailService). Resolve lat/lng with a JOIN on the WRITE connection in a
-	// single statement: the previous SELECT-then-guarded-UPDATE could be routed to a
-	// read replica that missed the location and, with the Scan error unchecked, would
-	// silently leave lat/lng NULL — an undiscoverable post (Discourse 9865). If
-	// nothing resolves (no locationid and no lastlocation), lat/lng stay NULL and
+	// single statement. The previous code only denormalised when the client sent a
+	// locationid, and did it via a separate best-effort SELECT whose Scan error was
+	// unchecked and whose !=0 guard silently skipped the UPDATE on any miss — so a post
+	// could go live with no lat/lng and be undiscoverable (Discourse 9865). If nothing
+	// resolves (no locationid and no lastlocation), lat/lng stay NULL and
 	// ContentCheckService holds the post for a moderator to add a postcode.
 	db.Exec("UPDATE messages m "+
 		"JOIN users u ON u.id = ? "+

--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -3959,35 +3959,45 @@ func PutMessage(c *fiber.Ctx) error {
 		saveAccessInstructions(db, newMsgID, req.Accessinstructions)
 	}
 
-	// Add spatial data if locationid is provided, and update the user's last known location
-	// (so that GET /isochrone can auto-create an isochrone for the user).
+	// If the user explicitly chose a location, remember it (GET /isochrone
+	// auto-creates an isochrone for the user from lastlocation).
 	if req.Locationid != nil && *req.Locationid > 0 {
 		db.Exec("UPDATE users SET lastlocation = ? WHERE id = ?", *req.Locationid, myid)
+	}
 
-		var lat, lng float64
-		db.Raw("SELECT lat, lng FROM locations WHERE id = ?", *req.Locationid).Row().Scan(&lat, &lng)
-		if lat != 0 || lng != 0 {
-			db.Exec("UPDATE messages SET locationid = ?, lat = ?, lng = ? WHERE id = ?",
-				*req.Locationid, lat, lng, newMsgID)
-			// Do NOT insert into messages_spatial here — drafts must not appear
-			// in browse/search results. Spatial index is populated by handleJoinAndPost
-			// after the message is submitted to a group (matching V1 behaviour).
-		}
+	// Denormalise the post's location onto the message so it is discoverable in
+	// browse/search, which read messages.lat/lng directly (see bounds.go). Prefer
+	// the chosen locationid; if the client didn't send one, fall back to the user's
+	// last known location so the post is still findable (parity with the email path,
+	// IncomingMailService). Resolve lat/lng with a JOIN on the WRITE connection in a
+	// single statement: the previous SELECT-then-guarded-UPDATE could be routed to a
+	// read replica that missed the location and, with the Scan error unchecked, would
+	// silently leave lat/lng NULL — an undiscoverable post (Discourse 9865). If
+	// nothing resolves (no locationid and no lastlocation), lat/lng stay NULL and
+	// ContentCheckService holds the post for a moderator to add a postcode.
+	db.Exec("UPDATE messages m "+
+		"JOIN users u ON u.id = ? "+
+		"JOIN locations l ON l.id = COALESCE(m.locationid, u.lastlocation) "+
+		"SET m.locationid = l.id, m.lat = l.lat, m.lng = l.lng "+
+		"WHERE m.id = ? AND (m.lat IS NULL OR m.lng IS NULL)",
+		myid, newMsgID)
+	// Do NOT insert into messages_spatial here — drafts must not appear in
+	// browse/search results. Spatial index is populated by handleJoinAndPost
+	// after the message is submitted to a group (matching V1 behaviour).
 
-		// Reconstruct subject with location.
-		// The initial subject was set as "Type: Item" without location.
-		// Now that locationid is set, rebuild as "KEYWORD: Item (Area PC)".
-		locStr := constructLocationString(db, newMsgID)
-		if locStr != "" && req.Item != "" {
-			groupid := req.Groupid
-			if groupid == 0 {
-				// Draft may not have a group yet; use item name without location keyword.
-				groupid = getPrimaryGroupForMessage(db, newMsgID)
-			}
-			keyword := getGroupKeyword(db, groupid, req.Type)
-			newSubject := keyword + ": " + req.Item + " (" + locStr + ")"
-			db.Exec("UPDATE messages SET subject = ?, suggestedsubject = ? WHERE id = ?", newSubject, newSubject, newMsgID)
+	// Reconstruct subject with location, now that locationid is set.
+	// The initial subject was set as "Type: Item" without location; rebuild as
+	// "KEYWORD: Item (Area PC)". Skipped when no location could be resolved.
+	locStr := constructLocationString(db, newMsgID)
+	if locStr != "" && req.Item != "" {
+		groupid := req.Groupid
+		if groupid == 0 {
+			// Draft may not have a group yet; use item name without location keyword.
+			groupid = getPrimaryGroupForMessage(db, newMsgID)
 		}
+		keyword := getGroupKeyword(db, groupid, req.Type)
+		newSubject := keyword + ": " + req.Item + " (" + locStr + ")"
+		db.Exec("UPDATE messages SET subject = ?, suggestedsubject = ? WHERE id = ?", newSubject, newSubject, newMsgID)
 	}
 
 	resp := fiber.Map{"ret": 0, "status": "Success", "id": newMsgID}

--- a/iznik-server-go/test/message_test.go
+++ b/iznik-server-go/test/message_test.go
@@ -2225,6 +2225,48 @@ func TestPutMessageBackfillsLocationFromUserWhenNoLocationid(t *testing.T) {
 	assert.InDelta(t, locLng, *gotLng, 0.0001)
 }
 
+// A location-only edit (client sends locationid but no lat/lng) must denormalise
+// lat/lng from the chosen location, not leave them stale/NULL. Otherwise the post
+// becomes undiscoverable - browse/search read messages.lat/lng directly. This is
+// the live msg 119554658 shape: a valid locationid, but NULL lat/lng (Discourse 9865).
+func TestPatchMessageLocationOnlyEditDenormalisesLatLng(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("patch_locdenorm")
+	groupID := CreateTestGroup(t, prefix)
+	ownerID := CreateTestUser(t, prefix+"_owner", "User")
+	CreateTestMembership(t, ownerID, groupID, "Member")
+	token := getToken(t, ownerID)
+
+	msgID := CreateTestMessage(t, ownerID, groupID, prefix+" chair", 55.95, -3.18)
+
+	// A real location (postcode) with its own lat/lng.
+	var locID uint64
+	var locLat, locLng float64
+	db.Raw("SELECT id, lat, lng FROM locations WHERE lat IS NOT NULL AND lng IS NOT NULL AND lat <> 0 LIMIT 1").
+		Row().Scan(&locID, &locLat, &locLng)
+	require.NotZero(t, locID, "test DB needs a location with lat/lng")
+
+	// Edit ONLY the location - send locationid, deliberately no lat/lng.
+	body := map[string]interface{}{"id": msgID, "locationid": locID}
+	bb, _ := json.Marshal(body)
+	req := httptest.NewRequest("PATCH", "/api/message?jwt="+token, bytes.NewBuffer(bb))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := getApp().Test(req, 10000)
+	require.NoError(t, err)
+	require.Equal(t, 200, resp.StatusCode)
+
+	// lat/lng must now match the chosen location, derived server-side.
+	var gotLat, gotLng *float64
+	var gotLoc *uint64
+	db.Raw("SELECT lat, lng, locationid FROM messages WHERE id = ?", msgID).Row().Scan(&gotLat, &gotLng, &gotLoc)
+	require.NotNil(t, gotLoc)
+	assert.Equal(t, locID, *gotLoc)
+	require.NotNil(t, gotLat, "location-only edit must derive lat from the location, not leave it NULL (9865)")
+	require.NotNil(t, gotLng, "location-only edit must derive lng from the location, not leave it NULL (9865)")
+	assert.InDelta(t, locLat, *gotLat, 0.0001)
+	assert.InDelta(t, locLng, *gotLng, 0.0001)
+}
+
 func TestJoinAndPostSavesDeadline(t *testing.T) {
 	prefix := uniquePrefix("msgmod_jap_dl")
 	db := database.DBConn

--- a/iznik-server-go/test/message_test.go
+++ b/iznik-server-go/test/message_test.go
@@ -2176,6 +2176,55 @@ func TestPostMessageJoinAndPost(t *testing.T) {
 	assert.Equal(t, int64(1), logCount, "JoinAndPost should create a Joined log entry")
 }
 
+// A web/app Offer created without a locationid must still get a discoverable
+// location: the create path falls back to the user's last known location and
+// denormalises lat/lng onto the message. Otherwise the post has NULL lat/lng and
+// is invisible in browse/search (which read messages.lat/lng directly) — the
+// Discourse 9865 "why is this outside the UK?" bug, where NULL lat/lng blurred to
+// Null Island (0.004, 0). Live: 4+ Platform Offers reached this state.
+func TestPutMessageBackfillsLocationFromUserWhenNoLocationid(t *testing.T) {
+	prefix := uniquePrefix("msg_noloc_backfill")
+	db := database.DBConn
+
+	groupID := CreateTestGroup(t, prefix)
+	userID := CreateTestUser(t, prefix+"_user", "User")
+	_, token := CreateTestSession(t, userID)
+
+	// Give the user a last known location (a real postcode with lat/lng).
+	var locID uint64
+	var locLat, locLng float64
+	db.Raw("SELECT id, lat, lng FROM locations WHERE lat IS NOT NULL AND lng IS NOT NULL AND lat <> 0 LIMIT 1").
+		Row().Scan(&locID, &locLat, &locLng)
+	require.NotZero(t, locID, "test DB needs a location with lat/lng")
+	db.Exec("UPDATE users SET lastlocation = ? WHERE id = ?", locID, userID)
+
+	// Create a draft WITHOUT a locationid — the client omitted it (the 9865 bug).
+	body := map[string]interface{}{
+		"messagetype": "Offer",
+		"item":        "Located Chair",
+		"collection":  "Draft",
+		"groupid":     groupID,
+	}
+	bb, _ := json.Marshal(body)
+	req := httptest.NewRequest("PUT", "/api/message?jwt="+token, bytes.NewBuffer(bb))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := getApp().Test(req, 10000)
+	require.NoError(t, err)
+	require.Equal(t, 200, resp.StatusCode)
+	var result map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&result)
+	msgID := uint64(result["id"].(float64))
+	require.NotZero(t, msgID)
+
+	// The post must be discoverable: lat/lng backfilled from the user's lastlocation.
+	var gotLat, gotLng *float64
+	db.Raw("SELECT lat, lng FROM messages WHERE id = ?", msgID).Row().Scan(&gotLat, &gotLng)
+	require.NotNil(t, gotLat, "message lat must be backfilled from user location, not left NULL (9865)")
+	require.NotNil(t, gotLng, "message lng must be backfilled from user location, not left NULL (9865)")
+	assert.InDelta(t, locLat, *gotLat, 0.0001)
+	assert.InDelta(t, locLng, *gotLng, 0.0001)
+}
+
 func TestJoinAndPostSavesDeadline(t *testing.T) {
 	prefix := uniquePrefix("msgmod_jap_dl")
 	db := database.DBConn

--- a/iznik-server-go/utils/utils.go
+++ b/iznik-server-go/utils/utils.go
@@ -249,6 +249,16 @@ func NilIfZero(v uint64) interface{} {
 func Blur(lat float64, lng float64, dist float64) (float64, float64) {
 	var dlat, dlng float64
 
+	// (0,0) is not a real location - it's what an unset/unresolved lat/lng (e.g. an
+	// email post whose subject location couldn't be geocoded, stored NULL and read
+	// back as 0) collapses to. Blurring it would step off Null Island to ~(0.004, 0),
+	// fabricating a fake location that then reads as "outside the UK" (ModMessage.vue
+	// outsideUK bbox check) and hides the "add a postcode" edit prompt. Leave it at
+	// (0,0) so downstream can treat it as "no location known" (Discourse #9865).
+	if lat == 0 && lng == 0 {
+		return 0, 0
+	}
+
 	// Some old posts have invalid lat/lng values, which would result in us returning NaN.
 	if lat > 90 || lat < -90 || lng > 180 || lng < -180 {
 		// Use the center of Britain.  Dunsop Bridge has lovely ducks.

--- a/iznik-server-go/utils/utils_test.go
+++ b/iznik-server-go/utils/utils_test.go
@@ -277,6 +277,17 @@ func TestBlur_ZeroDistanceNoChange(t *testing.T) {
 	assert.InDelta(t, -0.1, lng, 0.001)
 }
 
+func TestBlur_ZeroZeroIsNotFabricated(t *testing.T) {
+	// (0,0) is an unset/unresolved location (e.g. an email post whose subject
+	// location couldn't be geocoded, stored NULL and read back as 0), not a real
+	// point. Blurring must leave it at exactly (0,0) rather than stepping off Null
+	// Island to ~(0.004, 0) - which would fabricate a fake location that then reads
+	// as "outside the UK" and hides the "add a postcode" prompt (Discourse #9865).
+	lat, lng := Blur(0, 0, BLUR_USER)
+	assert.Equal(t, 0.0, lat)
+	assert.Equal(t, 0.0, lng)
+}
+
 // ---------------------------------------------------------------------------
 // Haversine
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What & why

A member's email Offer showed a red **"This message may be from outside the UK (0.004, 0)... might be a scam"** warning in ModTools. Discourse report: https://discourse.ilovefreegle.org/t/what-does-this-mean/9865

There's no foreign IP and no scam. `(0.004, 0)` is **Null Island**, fabricated from a post with **NULL** `lat`/`lng`: the Go API reads NULL back as `0`, `Blur(0,0)` jitters it to `(0.004,0)`, and ModTools' bounding-box check then cries "outside the UK". This PR replaces the earlier private-IP guess (#1089, closed) with the actual fix — and the investigation turned up a real root cause behind the NULL locations.

## Root cause: posts going live with no location

Chasing "how does an Offer end up with NULL lat/lng", live data (SELECT-only V2 tunnel) shows **12 Offer/Wanted posts in the last 12 months went Approved (live) with NULL lat** — 8 email, 4 web. A NULL-lat post is **undiscoverable**: browse/search read `messages.lat/lng` directly (`bounds.go`), so it appears nowhere on the map or in distance-sorted feeds. Two distinct sources:

**1. Web/app posting lost the location (the surprising one).** Web posting requires a postcode, yet 4 `source='Platform'` Offers had NULL lat. The denorm of location → `messages.lat/lng` was entirely **client-dependent**, with two gaps:
- **Create** (`PutMessage`): the message is INSERTed without lat/lng, then a best-effort `SELECT lat,lng FROM locations …; if lat!=0||lng!=0 UPDATE …` runs only when the client sent a `locationid`. The Scan error was **unchecked** and the `!=0` guard **silently skipped** the UPDATE on any miss; and when the client sent no `locationid` at all, the block was skipped entirely with **no fallback** (unlike the email path, which falls back to the user's location). → 3 of the 4 posts (no locationid).
- **Edit** (`applyPatchMessageCore`): sets `locationid` from the request but only sets `lat`/`lng` if the client *also* sent coordinates, so a location-only edit left them stale/NULL. → the 4th post (msg 119554658: valid locationid CR2 7EN, but NULL coords).

**2. Email posts that genuinely can't be geocoded.** Subject won't geocode and the poster is unmapped → NULL lat. There's no location to recover, so a human must add one.

## The fix (five small parts)

**1. Go — reliably denormalise the location on both create and edit** (`iznik-server-go/message/message.go`)
- Create: replace the fragile SELECT-then-guarded-UPDATE with a single JOIN UPDATE, and fall back to the user's `lastlocation` when no `locationid` was sent (parity with the email path):
```
UPDATE messages m JOIN users u ON u.id = ?
  JOIN locations l ON l.id = COALESCE(m.locationid, u.lastlocation)
  SET m.locationid = l.id, m.lat = l.lat, m.lng = l.lng
  WHERE m.id = ? AND (m.lat IS NULL OR m.lng IS NULL)
```
- Edit: derive lat/lng from the chosen location server-side when the client sends `locationid` without coords, and drive the `messages_spatial` point update from the same effective coords (so an Approved post's browse position follows a location edit).

No unchecked Scan, no silent skip, no client-dependent gap. If nothing resolves, lat/lng stay NULL and part 4 holds the post. (Location rows are static reference data present on every DB node, so the lookup is reliable — not a timing concern.)

**2. Go — don't fabricate a coordinate from nothing** (`iznik-server-go/utils/utils.go`)
`Blur(0,0,…)` now returns `(0,0)` unchanged instead of jittering to `(0.004,0)` — `(0,0)` is what an unset location collapses to, not a real blurred point.

**3. ModTools — say what's actually wrong** (`iznik-nuxt3/modtools/components/ModMessage.vue`)
A `noLocation` computed gates the `outsideUK` scam banner off, and shows instead: *"We couldn't work out where this post is. Please click Edit and add a postcode to the subject so members can find it."*

**4. Batch — don't auto-publish an unlocatable post** (`iznik-batch/app/Services/ContentCheckService.php`)
`processUnprocessed()` promotes clean Pending posts to Approved. A NULL-lat Offer/Wanted would go live undiscoverable, so it's now kept in the mod queue for a human to add a postcode. This is where auto-approval happens (all posts start Pending), so the gate holds a bad-location post even for a member who would otherwise be auto-approved — a backstop for both the email case and any web post that still slips through. Tiny blast radius: NULL-lat is ~1 in 26,920 email Offer/Wanted.

**5. Tests** — legacy inline-insert tests in `ContentCheckTest.php` created Offers with no location and expected approval; they now set a location (real approved Offers always have one), and a new `test_offer_with_no_location_is_not_auto_promoted` covers the gate.

## Test plan

- **Go**: `TestPutMessageBackfillsLocationFromUserWhenNoLocationid` (create without locationid → lat/lng backfilled from user); `TestPatchMessageLocationOnlyEditDenormalisesLatLng` (location-only edit → lat/lng derived from the location); `TestBlur_ZeroZeroIsNotFabricated`. Full Go suite green (3479).
- **Vue**: `ModMessage.spec.js` — `noLocation` describe + `(0,0)`/`(0.004,0)` cases. Full ModMessage specs green.
- **Laravel**: `ContentCheckTest` full class green, incl. the new no-location test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rm8xqAcBsnaYWZkrp5KAMA
