### PR TITLE
perf(app): stop blocking first paint on landing cascade and duplicate session fetches

### DIFF
--- a/docs/members/01-getting-started.md
+++ b/docs/members/01-getting-started.md
@@ -1,5 +1,5 @@
 ---
-last_reviewed: 2026-07-09
+last_reviewed: 2026-07-17
 owner: Freegle dev team
 covers:
   - iznik-nuxt3/pages/index.vue

--- a/iznik-nuxt3/composables/useBootSession.js
+++ b/iznik-nuxt3/composables/useBootSession.js
@@ -1,0 +1,61 @@
+import { useAuthStore } from '~/stores/auth'
+import { fetchMe } from '~/composables/useMe'
+
+// How recently the session must have been fetched for a layout to trust it
+// without firing a background refresh. Layout swaps (e.g. / → /browse on a
+// logged-in cold start) happen within a second or two, and the second layout
+// must not repeat the GET /session the first one just did.
+export const BOOT_SESSION_FRESH_MS = 30_000
+
+// Shared boot gate for layouts/default.vue and layouts/login.vue.
+//
+// Resolves the login state exactly once per cold start: if we have stored
+// credentials but no user yet, it waits for GET /session; if the user is
+// already in memory (another layout booted moments ago), it returns
+// immediately and refreshes in the background only when stale. Without
+// credentials it still resolves loginStateKnown, which fetchUser does without
+// a network call.
+//
+// Boot must never throw - fetch errors are logged and swallowed, and the
+// caller gets whatever user state we ended up with.
+export async function bootSession() {
+  const authStore = useAuthStore()
+  const { jwt, persistent } = authStore.auth
+
+  // fetchMe's dedup uses module-scope state, which the server would share
+  // across concurrent SSR requests - so only dedup on the client (where it
+  // matters: the / → /browse layout swap). On the server, hit the per-request
+  // store directly, as the layouts always did.
+  const fetchBlocking = import.meta.server
+    ? () => authStore.fetchUser()
+    : () => fetchMe(true)
+
+  if (jwt || persistent) {
+    if (authStore.user) {
+      if (Date.now() - (authStore.userFetchedAt || 0) > BOOT_SESSION_FRESH_MS) {
+        // Known but stale - refresh without blocking render.
+        fetchMe(false)
+      }
+
+      return authStore.user
+    }
+
+    try {
+      await fetchBlocking()
+    } catch (e) {
+      console.log('Error fetching user', e)
+    }
+  }
+
+  if (!authStore.loginStateKnown) {
+    // No credentials, or the fetch above failed: this marks the login state
+    // known (no network call happens when there are no credentials).
+    try {
+      await fetchBlocking()
+    } catch (e) {
+      console.log('Error in second fetchUser', e?.message)
+    }
+  }
+
+  return authStore.user
+}

--- a/iznik-nuxt3/layouts/default.vue
+++ b/iznik-nuxt3/layouts/default.vue
@@ -15,6 +15,7 @@ import LayoutCommon from '~/components/LayoutCommon'
 import { ref } from '#imports'
 import { useAuthStore } from '~/stores/auth'
 import { useMobileStore } from '@/stores/mobile' // APP
+import { bootSession } from '~/composables/useBootSession'
 const GoogleOneTap = defineAsyncComponent(() =>
   import('~/components/GoogleOneTap')
 )
@@ -57,40 +58,18 @@ watch(
 )
 
 // For this layout we don't need to be logged in.  So can just continue.  But we want to know first whether or
-// not we are logged in.  We might already know that from the server via cookies, but if not, find out.
-const jwt = authStore.auth.jwt
-const persistent = authStore.auth.persistent
+// not we are logged in.  bootSession() resolves that exactly once per cold
+// start (and doesn't repeat the fetch when another layout just did it).
+const user = await bootSession()
 
-if (jwt || persistent) {
-  // We have some credentials, which may or may not be valid on the server.  If they are, then we can crack on and
-  // start rendering the page.  This will be quicker than waiting for GoogleOneTap to load on the client and tell us
-  // whether or not we can log in that way.
-  let user = null
-
-  try {
-    user = await authStore.fetchUser()
-  } catch (e) {
-    console.log('Error fetching user', e)
-  }
-
-  if (user) {
-    ready = true
-  }
+if (user) {
+  ready = true
 }
 
 if (!ready && !mobileStore.isApp) {
   // APP
   // We don't have a valid JWT.  See if OneTap can sign us in.
   oneTap.value = true
-}
-
-if (!loginStateKnown.value) {
-  try {
-    await authStore.fetchUser()
-  } catch (e) {
-    // Can fail during SSR if API is not accessible - don't fail the page
-    console.log('Error in second fetchUser', e?.message)
-  }
 }
 
 function googleLoggedIn() {

--- a/iznik-nuxt3/layouts/login.vue
+++ b/iznik-nuxt3/layouts/login.vue
@@ -22,6 +22,7 @@ import { useAuthStore } from '~/stores/auth'
 import LayoutCommon from '~/components/LayoutCommon'
 import { useMobileStore } from '@/stores/mobile' // APP
 import { useMiscStore } from '~/stores/misc'
+import { bootSession } from '~/composables/useBootSession'
 import { ref, computed, watch } from '#imports'
 const GoogleOneTap = defineAsyncComponent(() =>
   import('~/components/GoogleOneTap')
@@ -80,22 +81,13 @@ function googleLoaded() {
   }
 }
 
-const jwt = authStore.auth.jwt
-const persistent = authStore.auth.persistent
+// Resolve the login state exactly once per cold start - if the default layout
+// already fetched the session moments ago (/ → /browse swap), this returns
+// immediately instead of repeating GET /session.
+const user = await bootSession()
 
-if (jwt || persistent) {
-  // We have some credentials, which may or may not be valid on the server.
-  let user = null
-
-  try {
-    user = await authStore.fetchUser()
-  } catch (e) {
-    console.log('Error fetching user', e)
-  }
-
-  if (user) {
-    ready.value = true
-  }
+if (user) {
+  ready.value = true
 }
 
 if (!ready.value && !mobileStore.isApp) {

--- a/iznik-nuxt3/pages/index.vue
+++ b/iznik-nuxt3/pages/index.vue
@@ -153,35 +153,60 @@ const head = buildHead(
 
 useHead(head)
 
-await groupStore.fetch()
+// The landing data cascade: group list → message inbounds → message details.
+// On the web this is an SSR prefetch so the landing page arrives fully
+// rendered. In the app build (ssr: false) these used to be top-level awaits,
+// blocking the app's first paint on three sequential API round trips - even
+// for logged-in users, who are redirected to /browse and never see this data.
+async function fetchLandingData() {
+  await groupStore.fetch()
 
-try {
-  const list = await messageStore.fetchInBounds(
-    49.45,
-    -9,
-    61,
-    2,
-    null,
-    50,
-    true
-  )
-  const offers = list.filter((item) => item.type === 'Offer')
+  try {
+    const list = await messageStore.fetchInBounds(
+      49.45,
+      -9,
+      61,
+      2,
+      null,
+      50,
+      true
+    )
+    const offers = list.filter((item) => item.type === 'Offer')
 
-  const preloadPromises = []
-  for (const offer of offers.slice(0, 12)) {
-    preloadPromises.push(messageStore.fetch(offer.id))
+    const preloadPromises = []
+    for (const offer of offers.slice(0, 12)) {
+      preloadPromises.push(messageStore.fetch(offer.id))
+    }
+    await Promise.all(preloadPromises)
+  } catch (e) {
+    console.log('SSR: Failed to prefetch messages', e)
   }
-  await Promise.all(preloadPromises)
-} catch (e) {
-  console.log('SSR: Failed to prefetch messages', e)
+}
+
+const authStore = useAuthStore()
+const isAppBuild = !!runtimeConfig.public.ISAPP
+
+if (!isAppBuild || import.meta.server) {
+  // Web build: unchanged blocking prefetch (server render and the matching
+  // client hydration pass).
+  await fetchLandingData()
+} else {
+  // App build: never block first paint on these three round trips. By
+  // onMounted the root Suspense has resolved, so the layout's session fetch
+  // has finished and we know whether we're really logged in: logged-in users
+  // are redirected to /browse by goHome() and never see this data, so only
+  // fetch it when we ended up logged out.
+  onMounted(() => {
+    if (!me.value) {
+      fetchLandingData().catch((e) => {
+        console.log('Landing data fetch failed', e?.message)
+      })
+    }
+  })
 }
 
 // Computed properties
-const me = computed(() => {
-  // Access the user store to get the current user
-  const authStore = useAuthStore()
-  return authStore?.user
-})
+const me = computed(() => authStore?.user)
 
 const isApp = ref(mobileStore.isApp) // APP
 

--- a/iznik-nuxt3/stores/auth.js
+++ b/iznik-nuxt3/stores/auth.js
@@ -38,6 +38,9 @@ export const useAuthStore = defineStore({
 
     loginStateKnown: false,
     forceLogin: false,
+    // When the session was last successfully fetched (ms epoch, not
+    // persisted). Lets boot code skip redundant refetches on layout swaps.
+    userFetchedAt: 0,
     user: null,
     groups: [],
     loggedInEver: false,
@@ -379,7 +382,14 @@ export const useAuthStore = defineStore({
             if (groups.length > 0) {
               const groupStore = useGroupStore()
 
-              await groupStore.fetchBatch(groups.map((g) => g.groupid))
+              // Deliberately not awaited: session resolution (and therefore
+              // first paint, which the layouts gate on fetchUser) must not
+              // wait for full group details - they fill in reactively.
+              Promise.resolve(
+                groupStore.fetchBatch(groups.map((g) => g.groupid))
+              ).catch((e) => {
+                console.log('Group batch fetch failed', e?.message)
+              })
             }
 
             // Update JWT/persistent if returned (session refresh).
@@ -420,6 +430,7 @@ export const useAuthStore = defineStore({
 
         // Set the user, which will trigger various re-rendering if we were required to be logged in.
         this.setUser(me)
+        this.userFetchedAt = Date.now()
 
         await this.savePushId() // Tell server our mobile push notification id, if available
 

--- a/iznik-nuxt3/tests/unit/composables/useBootSession.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useBootSession.spec.js
@@ -1,0 +1,134 @@
+/**
+ * bootSession() - the shared layout boot gate (layouts/default.vue and
+ * layouts/login.vue).
+ *
+ * Contract:
+ * - With stored credentials and NO in-memory user: awaits fetchMe(true) so the
+ *   session resolves before the layout renders (cold start).
+ * - With stored credentials and an in-memory user (layout swap after cold
+ *   start): does NOT block; fires a background fetchMe(false) refresh only if
+ *   the session data is stale (older than BOOT_SESSION_FRESH_MS).
+ * - With no credentials and login state unknown: awaits fetchMe(true), which
+ *   short-circuits in fetchUser without a network call but marks
+ *   loginStateKnown.
+ * - Errors from fetchMe are swallowed (boot must not throw).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+import {
+  bootSession,
+  BOOT_SESSION_FRESH_MS,
+} from '~/composables/useBootSession'
+import { fetchMe } from '~/composables/useMe'
+
+vi.mock('~/composables/useMe', () => ({
+  fetchMe: vi.fn(),
+}))
+
+function makeAuthStore(overrides = {}) {
+  return {
+    user: null,
+    auth: { jwt: null, persistent: null },
+    loginStateKnown: false,
+    userFetchedAt: 0,
+    ...overrides,
+  }
+}
+
+describe('bootSession', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    globalThis.__mockAuthStore = makeAuthStore()
+  })
+
+  afterEach(() => {
+    delete globalThis.__mockAuthStore
+    vi.restoreAllMocks()
+  })
+
+  it('awaits a server fetch when credentials exist but no user yet', async () => {
+    globalThis.__mockAuthStore = makeAuthStore({
+      auth: { jwt: 'token', persistent: null },
+    })
+    fetchMe.mockImplementation(() => {
+      globalThis.__mockAuthStore.user = { id: 123 }
+      globalThis.__mockAuthStore.loginStateKnown = true
+      return Promise.resolve()
+    })
+
+    const user = await bootSession()
+
+    expect(fetchMe).toHaveBeenCalledTimes(1)
+    expect(fetchMe).toHaveBeenCalledWith(true)
+    expect(user).toEqual({ id: 123 })
+  })
+
+  it('does not block or refetch when the user is already known and fresh', async () => {
+    globalThis.__mockAuthStore = makeAuthStore({
+      user: { id: 123 },
+      auth: { jwt: 'token', persistent: null },
+      loginStateKnown: true,
+      userFetchedAt: Date.now(),
+    })
+
+    const user = await bootSession()
+
+    expect(fetchMe).not.toHaveBeenCalled()
+    expect(user).toEqual({ id: 123 })
+  })
+
+  it('fires a non-blocking background refresh when the user is known but stale', async () => {
+    globalThis.__mockAuthStore = makeAuthStore({
+      user: { id: 123 },
+      auth: { jwt: 'token', persistent: null },
+      loginStateKnown: true,
+      userFetchedAt: Date.now() - BOOT_SESSION_FRESH_MS - 1000,
+    })
+    // A hanging refresh must not block bootSession.
+    fetchMe.mockReturnValue(new Promise(() => {}))
+
+    const user = await bootSession()
+
+    expect(fetchMe).toHaveBeenCalledTimes(1)
+    expect(fetchMe).toHaveBeenCalledWith(false)
+    expect(user).toEqual({ id: 123 })
+  })
+
+  it('marks login state known without credentials', async () => {
+    fetchMe.mockImplementation(() => {
+      globalThis.__mockAuthStore.loginStateKnown = true
+    })
+
+    const user = await bootSession()
+
+    expect(fetchMe).toHaveBeenCalledTimes(1)
+    expect(fetchMe).toHaveBeenCalledWith(true)
+    expect(user).toBeNull()
+  })
+
+  it('does nothing when logged out and login state already known', async () => {
+    globalThis.__mockAuthStore = makeAuthStore({ loginStateKnown: true })
+
+    const user = await bootSession()
+
+    expect(fetchMe).not.toHaveBeenCalled()
+    expect(user).toBeNull()
+  })
+
+  it('swallows fetch errors and still tries to resolve login state', async () => {
+    globalThis.__mockAuthStore = makeAuthStore({
+      auth: { jwt: 'token', persistent: null },
+    })
+    fetchMe
+      .mockRejectedValueOnce(new Error('server down'))
+      .mockImplementationOnce(() => {
+        globalThis.__mockAuthStore.loginStateKnown = true
+      })
+
+    const user = await bootSession()
+
+    // First call failed; loginStateKnown still false so it retries once.
+    expect(fetchMe).toHaveBeenCalledTimes(2)
+    expect(user).toBeNull()
+  })
+})

--- a/iznik-nuxt3/tests/unit/mocks/nuxt-app.js
+++ b/iznik-nuxt3/tests/unit/mocks/nuxt-app.js
@@ -21,7 +21,11 @@ export function useNuxtApp() {
   }
 }
 
+// Default mock for useRuntimeConfig - tests override via globalThis, e.g.
+// globalThis.__testRuntimeConfig = () => ({ public: { ISAPP: true } })
 export function useRuntimeConfig() {
+  if (typeof globalThis.__testRuntimeConfig === 'function')
+    return globalThis.__testRuntimeConfig()
   return {
     public: {},
   }

--- a/iznik-nuxt3/tests/unit/pages/index.spec.js
+++ b/iznik-nuxt3/tests/unit/pages/index.spec.js
@@ -1,0 +1,175 @@
+/**
+ * pages/index.vue boot behaviour.
+ *
+ * The landing page's data cascade (group list → message inbounds → message
+ * details) exists as an SSR prefetch for the web build. In the Capacitor app
+ * build (ssr: false, runtimeConfig.public.ISAPP) it used to run client-side as
+ * top-level awaits, blocking first paint on ~3 sequential API round trips even
+ * for logged-in users who are immediately redirected to /browse.
+ *
+ * Contract:
+ * - App build + stored session: no landing data fetches at all.
+ * - App build + logged out: fetches happen after mount, without blocking the
+ *   page from rendering.
+ * - Web build (client): blocking prefetch preserved (unchanged behaviour).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { defineComponent, Suspense, h, nextTick } from 'vue'
+
+import IndexPage from '~/pages/index.vue'
+
+vi.mock('~/composables/useBuildHead', () => ({
+  buildHead: vi.fn(() => ({})),
+}))
+
+vi.mock('~/stores/misc', () => ({
+  useMiscStore: () => ({ get: vi.fn() }),
+}))
+
+vi.mock('@/stores/mobile', () => ({
+  useMobileStore: () => ({ isApp: false }),
+}))
+
+const mockFetchInBounds = vi.fn()
+const mockMessageFetch = vi.fn()
+vi.mock('~/stores/message', () => ({
+  useMessageStore: () => ({
+    fetchInBounds: mockFetchInBounds,
+    fetch: mockMessageFetch,
+  }),
+}))
+
+const mockGroupFetch = vi.fn()
+vi.mock('~/stores/group', () => ({
+  useGroupStore: () => ({ fetch: mockGroupFetch }),
+}))
+
+vi.mock('~/api', () => ({
+  default: () => ({ bandit: { chosen: vi.fn() } }),
+}))
+
+vi.mock('~/components/FreeglerPhotoGrid.vue', () => ({
+  default: { template: '<div class="mock-photo-grid" />' },
+}))
+vi.mock('~/components/ProxyImage.vue', () => ({
+  default: { template: '<img />', props: ['src', 'alt', 'width', 'height'] },
+}))
+vi.mock('~/components/PlaceAutocomplete.vue', () => ({
+  default: { template: '<div />' },
+}))
+vi.mock('~/components/ExternalLink.vue', () => ({
+  default: { template: '<a><slot /></a>', props: ['href'] },
+}))
+
+const globalStubs = {
+  LazyBreakpointFettler: true,
+  LazyMobileVisualiseList: true,
+  LazyMainFooter: true,
+  'v-icon': true,
+  NuxtLink: { template: '<a><slot /></a>', props: ['to'] },
+}
+
+function mountPage() {
+  const Wrapper = defineComponent({
+    setup() {
+      return () => h(Suspense, null, { default: () => h(IndexPage) })
+    },
+  })
+
+  return mount(Wrapper, { global: { stubs: globalStubs } })
+}
+
+function setAuth(overrides = {}) {
+  globalThis.__mockAuthStore = {
+    groups: [],
+    user: null,
+    auth: { jwt: null, persistent: null },
+    loginStateKnown: false,
+    ...overrides,
+  }
+}
+
+function setAppBuild(isApp) {
+  globalThis.__testRuntimeConfig = () => ({ public: { ISAPP: isApp } })
+}
+
+describe('pages/index boot data cascade', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGroupFetch.mockResolvedValue(undefined)
+    mockFetchInBounds.mockResolvedValue([])
+    mockMessageFetch.mockResolvedValue({})
+    setAuth()
+    setAppBuild(false)
+  })
+
+  afterEach(() => {
+    delete globalThis.__mockAuthStore
+    delete globalThis.__testRuntimeConfig
+  })
+
+  it('app build with a resolved login skips the landing data fetches entirely', async () => {
+    setAppBuild(true)
+    // By mount time the layout's session fetch has resolved the user.
+    setAuth({
+      user: { id: 1 },
+      auth: { jwt: 'token', persistent: null },
+      loginStateKnown: true,
+    })
+
+    mountPage()
+    await flushPromises()
+
+    expect(mockGroupFetch).not.toHaveBeenCalled()
+    expect(mockFetchInBounds).not.toHaveBeenCalled()
+  })
+
+  it('app build logged out renders immediately and fetches after mount', async () => {
+    setAppBuild(true)
+    // Landing fetches hang forever - the page must still render.
+    mockGroupFetch.mockReturnValue(new Promise(() => {}))
+
+    const wrapper = mountPage()
+    await flushPromises()
+    await nextTick()
+
+    // Page rendered despite the pending fetch → fetch is not blocking paint.
+    expect(wrapper.find('.landing-page').exists()).toBe(true)
+
+    // And the fetch was kicked off (after mount).
+    expect(mockGroupFetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('web build (client) keeps the blocking prefetch', async () => {
+    setAppBuild(false)
+    // While the group fetch hangs, Suspense must NOT resolve - this is the
+    // existing web behaviour, preserved.
+    mockGroupFetch.mockReturnValue(new Promise(() => {}))
+
+    const wrapper = mountPage()
+    await flushPromises()
+    await nextTick()
+
+    expect(mockGroupFetch).toHaveBeenCalledTimes(1)
+    expect(wrapper.find('.landing-page').exists()).toBe(false)
+  })
+
+  it('web build completes the full cascade in order', async () => {
+    setAppBuild(false)
+    mockFetchInBounds.mockResolvedValue([
+      { id: 1, type: 'Offer' },
+      { id: 2, type: 'Wanted' },
+    ])
+
+    const wrapper = mountPage()
+    await flushPromises()
+
+    expect(mockGroupFetch).toHaveBeenCalledTimes(1)
+    expect(mockFetchInBounds).toHaveBeenCalledTimes(1)
+    // Only offers get detail-preloaded.
+    expect(mockMessageFetch).toHaveBeenCalledTimes(1)
+    expect(mockMessageFetch).toHaveBeenCalledWith(1)
+    expect(wrapper.find('.landing-page').exists()).toBe(true)
+  })
+})

--- a/iznik-nuxt3/tests/unit/stores/auth.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/auth.spec.js
@@ -62,8 +62,9 @@ vi.mock('~/stores/compose', () => ({
   useComposeStore: () => ({}),
 }))
 
+const mockFetchBatch = vi.fn()
 vi.mock('~/stores/group', () => ({
-  useGroupStore: () => ({ list: {}, fetchBatch: vi.fn() }),
+  useGroupStore: () => ({ list: {}, fetchBatch: mockFetchBatch }),
 }))
 
 vi.mock('~/stores/mobile', () => ({
@@ -501,6 +502,54 @@ describe('auth store', () => {
 
       expect(mockSetAppOutOfDate).not.toHaveBeenCalled()
       expect(store.user.id).toBe(5)
+    })
+  })
+
+  describe('fetchUser group batch off the critical path', () => {
+    it('resolves without waiting for the group detail batch', async () => {
+      store.setAuth('valid-jwt', 'valid-persistent')
+      mockFetchv2.mockResolvedValue({
+        me: { id: 5 },
+        groups: [{ groupid: 11 }, { groupid: 22 }],
+      })
+      // The batch hangs forever - fetchUser (and therefore first paint, which
+      // awaits it in the layouts) must not wait for group details.
+      mockFetchBatch.mockReturnValue(new Promise(() => {}))
+
+      const result = await Promise.race([
+        store.fetchUser().then(() => 'fetchUser'),
+        new Promise((resolve) => setTimeout(() => resolve('timeout'), 1000)),
+      ])
+
+      expect(result).toBe('fetchUser')
+      expect(store.user.id).toBe(5)
+      expect(mockFetchBatch).toHaveBeenCalledWith([11, 22])
+    })
+
+    it('survives a rejected group batch', async () => {
+      store.setAuth('valid-jwt', 'valid-persistent')
+      mockFetchv2.mockResolvedValue({
+        me: { id: 5 },
+        groups: [{ groupid: 11 }],
+      })
+      mockFetchBatch.mockRejectedValue(new Error('batch down'))
+
+      await store.fetchUser()
+      // Let the rejected batch settle - it must not become an unhandled
+      // rejection or clear the user.
+      await new Promise((resolve) => setTimeout(resolve, 0))
+
+      expect(store.user.id).toBe(5)
+    })
+
+    it('records when the session was fetched', async () => {
+      store.setAuth('valid-jwt', 'valid-persistent')
+      mockFetchv2.mockResolvedValue({ me: { id: 5 }, groups: [] })
+
+      const before = Date.now()
+      await store.fetchUser()
+
+      expect(store.userFetchedAt).toBeGreaterThanOrEqual(before)
     })
   })
 

--- a/plans/2026-07-17-app-startup-white-screen-research.md
+++ b/plans/2026-07-17-app-startup-white-screen-research.md
@@ -1,0 +1,384 @@
+# App startup white screen - research and options
+
+Date: 2026-07-17. Research only - nothing implemented. Prompted by slow app startup
+(white screen on launch) and Discourse 9928 (member: app fine in the morning, worse
+after 5pm).
+
+## TL;DR
+
+The white screen is real and has three stacked causes, all fixable independently:
+
+1. **The native splash dismisses onto a blank page.** No `@capacitor/splash-screen`
+   plugin is installed, so the OS splash goes away on the WebView's first (empty)
+   frame instead of staying up until the app is ready.
+2. **The web app paints nothing until the whole SPA boots.** App builds are
+   `ssr: false` with `spaLoadingTemplate: false`: the shipped `index.html` has an
+   empty body, one 515KB entry module, and ~92 JS files (~1.4MB) execute before
+   first render. Prior profiling (PR #282, Apr 2026) measured ~700ms of white
+   between splash dismiss and first Vue render on Android; older/mid devices pay
+   several seconds.
+3. **First paint is blocked on the network - much more than expected.** The app
+   always boots on `/`. Nuxt's root Suspense waits for BOTH of these parallel
+   chains before painting anything:
+   - Chain A: `layouts/default.vue:71` `await fetchUser()` = GET `/apiv2/session`,
+     then a chained group fetchBatch (2 sequential round trips).
+   - Chain B: `pages/index.vue:156-174` - `await groupStore.fetch()` (uncached),
+     then `await messageStore.fetchInBounds()` (the UK-wide-bbox query: p50 ~1.4s,
+     p95 ~3s in prod), then a batched message-detail fetch (+50ms debounce timer).
+     **3 sequential round trips that run unconditionally on every cold start, even
+     for logged-in users who are redirected to /browse and never see this data.**
+4. **The work is then done twice.** After paint, logged-in users are redirected to
+   `/browse`, which swaps to `layouts/login.vue:86-99` - re-running the identical
+   `await fetchUser()` (second GET `/apiv2/session` + group batch within ~1s; the
+   dedup wrapper `composables/useMe.js` `fetchMe()` exists but neither layout uses
+   it), plus a third uncached `groupStore.fetch()` in browse's onMounted.
+
+## Current cold-start sequence (verified in code + measured)
+
+| Step | What the user sees | Cost |
+|---|---|---|
+| Native launch | OS splash (iOS: full-screen logo storyboard; Android 12+: icon splash via `Theme.SplashScreen`, `AppTheme.NoActionBarLaunch`) | ~0.3-0.8s |
+| WebView first frame | **White** - splash dismisses immediately (no splash plugin, empty index.html body) | - |
+| JS parse + boot | **White** - 515KB entry (`mmlgqI5E.js`) + module graph, 31 Pinia store inits in `app.vue`; mobile init (push channels, device info, update check) fire-and-forget but competing for the main thread | ~0.7s (measured Apr 2026, modern Android) to multi-second on older devices; 0.8s warm / 3.4s cold in Chrome at 4x CPU throttle |
+| Root Suspense: max(Chain A, Chain B) | **White** - nothing paints until both resolve | Chain A: `/apiv2/session` (p50 98ms, p95 632ms, max 1.2s; prod Loki Wed 17:00Z) + chained group batch. Chain B: `/apiv2/group` + `/apiv2/message/inbounds` (UK-wide bbox p50 ~1.4s, p95 ~3s, max 8s; prod Loki + direct samples) + batched message fetch, all sequential. Chain B dominates. |
+| Landing page paints, then redirect | Logged-in users see the logged-out landing page flash, then `/browse` | onMounted → router.push('/browse') |
+| /browse | Second `await fetchUser()` in `layouts/login.vue` before browse renders (old page stays visible, so delay not white) + third uncached group fetch | second `/apiv2/session` + group batch |
+
+Measured end-to-end in Chrome (built app bundle served locally, 4x CPU throttle,
+production API): first-paint 752ms (white), first contentful paint 4,280ms. The
+paint was blocked by JS boot, then by `message/inbounds` which took 2.36s server-side.
+The app's own telemetry ('interactive' = `app:suspense:resolve` in
+`plugins/pageload-tracking.client.js:37`) uses exactly this gate, so if clientlog
+phases were recorded with timings we could measure this in the field.
+
+Key facts with sources:
+
+- `nuxt.config.ts:114-117` - `target: 'static'`, `ssr: false`, `spaLoadingTemplate: false` for ISAPP builds.
+- `capacitor.config.ts:34` - `webDir: '.output/public'`, bundled locally; no remote server.url.
+- No `@capacitor/splash-screen` anywhere (package.json, includePlugins, plugins block).
+- `layouts/default.vue:64-94` - two top-level `await authStore.fetchUser()` calls before layout renders.
+- `stores/auth.js:340+` - fetchUser = GET `/apiv2/session` then `await groupStore.fetchBatch(memberships)` (chunked, 25/call).
+- `app.vue:203-265` - 31 Pinia stores created + init'd synchronously in root setup.
+- `hooks['build:manifest']` in `nuxt.config.ts:323-331` strips ALL preload/prefetch links (helps web FCP, but for the app it removes hints that would let the local WebView parse chunks earlier).
+- Entry chunk analysis: `DQYUI595.js` (467KB) is almost entirely the Sentry SDK; leaflet, stripe, uppy etc. are route-lazy.
+- ~16MB of the 23MB `_nuxt` payload is sourcemaps (`sourcemap.client: true` unconditionally, `nuxt.config.ts:618`; no CI step strips `.map` before `npx cap sync`) - install-size cost, not runtime, but worth fixing.
+- Real-user startup telemetry: none today. `[STARTUP]` console instrumentation (commit cc8d930f6, Dec 2025) was added then removed. `pageload-tracking.client.js` only tags API calls with a phase; it does not record startup duration.
+- Prior art: PR #282 (monorepo 316705805, Apr 2026) - EmojiCompat disabled, duplicate Stripe registration removed, Sentry plugin made sync. Commit 72364748d - entryImportMap disabled for app builds (iOS < 16.4 white-screen fix).
+- No route middleware exists; the app has no "start on /browse when logged in" logic - the redirect happens in `pages/index.vue:239-245` onMounted, i.e. only AFTER the full blocked boot.
+- `pages/index.vue:156` and `pages/browse/[[term]].vue:718` both call `groupStore.fetch()` (no-id variant, `stores/group.js:134-146`) which has NO cache check - the full group list is fetched twice within ~1s on a logged-in cold start.
+- `composables/useMe.js:7-66` already contains a `fetchingPromise` dedup wrapper (`fetchMe()`) built to prevent duplicate session fetches, but neither `layouts/default.vue` nor `layouts/login.vue` uses it - both call `authStore.fetchUser()` directly.
+- API layer: `api/BaseAPI.js` + `composables/useFetchRetry.js` retry up to 10 times with linear backoff on network/5xx errors - on a flaky mobile connection a single failed boot call can extend the white screen by many seconds.
+- Evening slowness (Discourse 9928): API latency is load-dependent, but samples show the big boot-path costs (inbounds UK-wide bbox ~1.5-3s) are bad at ALL times of day; morning samples hit 8s. The fixed costs dominate; evening variance comes on top.
+
+## Options
+
+Grouped by what they attack. They are independent; the biggest wins are B1/B2
+(stop blocking paint on the network) and A1/A2 (make the remaining wait look
+intentional).
+
+### A. Perceived startup - kill the white flash (cheap, low risk)
+
+**A1. Install `@capacitor/splash-screen` and hold the native splash until the app
+is ready.** `launchAutoHide: false`, then call `SplashScreen.hide({ fadeOutDuration })`
+from the web app when it has painted something real (e.g. on `app:suspense:resolve`,
+with a hard timeout fallback so a hung API can never strand the splash). This is
+the single cheapest fix for "white screen while the app loads its code" - the
+user sees the branded splash the whole time instead.
+
+Verified facts (all 3-0 adversarial verification, official sources):
+- Without the plugin, Android dismisses the splash "as soon as your app draws its
+  first frame" (official Android docs) - the blank WebView frame counts. This is
+  the confirmed direct cause of our white screen appearing so early.
+- Plugin defaults are `launchAutoHide: true` + `launchShowDuration: 500ms`;
+  `launchAutoHide: false` is the documented way to hold the splash until
+  `SplashScreen.hide()` - there is no OS-imposed max duration, so we must add our
+  own fallback timer.
+- On Android 12+ the OS SplashScreen API takes over the launch splash and ignores
+  most plugin options at launch (backgroundColor, scale type, spinner, fullscreen);
+  our theme already has the required `Theme.SplashScreen` parent. The plugin wires
+  up `installSplashScreen()` itself - no MainActivity change needed.
+- Hazard (confirmed by a Capacitor maintainer, capacitor-plugins#1856): calling
+  `hide()` while the app is backgrounded crashes natively on Android 12 (and some
+  OEM Android 13 devices - Oppo/OnePlus). Guard the hide call with a foreground
+  check. (The claim that the auto-hide timeout path also crashes was refuted.)
+- iOS note: Apple's HIG says launch screens should mirror the app's first screen,
+  not be a branding moment - our current full-logo storyboard is technically
+  against HIG (common in practice, and unlikely to be an issue, but the HIG-purist
+  alternative is a launch screen that looks like the app's navbar/skeleton, which
+  dovetails with A2).
+
+**A2. Give the SPA a branded loading shell via `spaLoadingTemplate`.** We
+explicitly set it to `false`; instead, point it at a small HTML template (logo +
+spinner + app background colour, critical CSS inlined) so the very first WebView
+frame is branded rather than blank. Works for `ssr:false` static builds - the
+template is baked into the shipped `index.html` and replaced when Vue mounts.
+This also fixes the web-SPA routes' white flash for free.
+
+Verified facts: this is Nuxt's official app-shell mechanism for exactly our setup -
+the `app/spa-loading-template.html` contents are "inserted into any HTML page
+rendered with ssr: false" (official Nuxt docs, 3-0). Caveats: it must be enabled
+explicitly in nuxt.config (auto-discovery without config was refuted; Nuxt 3.7+
+defaults it OFF), and there is an unresolved question whether the old
+"template hides on app mount, before lazy page components render" gap
+(nuxt/nuxt#21721) affects our Nuxt version - needs a quick local test. If we also
+do B1/B2 the gap is moot: the shell hides straight into a rendered page skeleton.
+Belt-and-braces: A1's splash covers the template period anyway; A2 mainly protects
+web users and the app's second-navigation white flashes.
+
+**A3. Dynamic loading shell (the "store the HTML" idea, done safely).** The
+template file itself is static - baked into the shipped `index.html` at build
+time, and the app bundle can't be rewritten on device. But the template can
+contain a tiny inline `<script>` that runs as soon as the HTML parses - hundreds
+of ms before the 515KB entry compiles - and that script can synchronously read
+`localStorage` (same WebView origin; it's where pinia-persistedstate already
+lives) and build the shell DOM on the fly. Verified in our Nuxt (3.21.5): with the
+default `spaLoadingTemplateLocation: 'body'`, the loader div is a sibling of the
+app root and Nuxt removes it on `app:suspense:resolve`
+(`nuxt/dist/app/entry.js:54-58`) - it persists through the entire boot and is
+swapped out exactly when the real app is ready. Three levels:
+- **Static skeleton** (A2 as-is).
+- **Parameterised shell**: inline script picks logged-in vs logged-out chrome,
+  fills in user name/avatar, last route's skeleton shape - a few KB of logic,
+  big perceived win, low risk.
+- **Full DOM snapshot**: on `pause`/`visibilitychange`, save a sanitized HTML
+  snapshot of the current shell to localStorage (stamped with build hash +
+  user id); on launch, re-inject it instantly. Closest to "app reopens where
+  it was" - but sharpest edges.
+Hard limits (why this is a facade, not SSR): Vue in `ssr:false` mode mounts fresh
+and CANNOT hydrate/adopt the stored DOM - the snapshot is thrown away when the
+app mounts. So it cuts *perceived* latency to ~WebView-init time but does not
+make the app interactive any sooner; taps on the facade do nothing. If boot still
+takes seconds (blocking awaits unfixed), a real-looking dead UI frustrates more
+than a skeleton - so A3-full pairs with B1/B2, never replaces them. Other risks
+for the full-snapshot level: stale content (wrong unread badges, shows
+logged-in UI after logout), sensitive chat text persisted in plaintext on disk
+(snapshot only chrome/skeleton, never message bodies), and hashed CSS classes
+changing between builds (build-hash guard, fall back to generic skeleton).
+
+### B. Stop blocking first paint on the network (the big structural win)
+
+**B1. Don't run the landing-page data cascade in the app.** `pages/index.vue`
+unconditionally awaits group list → UK-wide `message/inbounds` (p50 ~1.4s) →
+message batch before ANYTHING paints, even for logged-in users who are
+immediately redirected to `/browse`. Options, cheapest first:
+- Make those awaits conditional (`if (!me && !mobileStore.isApp)`), or move them
+  out of the Suspense path (`onMounted` + skeleton) so paint isn't gated.
+- For app builds, boot straight into `/browse` (client-side: check persisted
+  `auth.jwt`/`loggedInEver` in a tiny route middleware or entry plugin before the
+  index page's setup ever runs).
+
+**B2. Don't `await fetchUser()` before painting the shell.** Render navbar +
+skeleton immediately; fetch the session in the background and let the UI update
+reactively (`loginStateKnown` already exists for exactly this kind of gating).
+
+⚠ History check (Edward, 2026-07-17): in principle "assume logged in, let the
+server call disprove it" is acceptable, but it opens many timing windows, so it
+needs extremely careful testing - and it HAS been lived with before. Verified
+from the archived iznik-nuxt (Nuxt 2) history:
+
+**The Nuxt 2 app ran optimistic boot for its whole life.** `target: 'static'`
+meant the shipped HTML was generic; the full user object was persisted client-side
+(Vuex + localForage/IndexedDB) and the UI rendered from that cache immediately,
+with a deliberately deferred (`setTimeout 100ms`) fire-and-forget `fetchMe()` to
+reconcile ("Defer it as we can get snappier rendering"). It was never a named
+experiment that got reverted - it was the architecture. The documented costs:
+- **`0e5165d4` (Mar 2022) "Possible fix for app being logged out"**: API calls
+  raced ahead of the IndexedDB credential restore, went out with no auth header,
+  the server answered "not logged in", and the axios interceptor treated that as
+  a genuine logout and wiped the store - a race that FORCED real users out.
+  Fixed with a hard sync point: `await this.store.restored` inside
+  `BaseAPI.$request` so no call path could outrun the restore.
+- **`d59936be`/`9bfd1d9c` (Oct 2021)**: stale pre-rendered content visibly
+  jumping when the client corrected it (Google-flagged CLS) - fixed by rendering
+  neutral content when the state was uncertain.
+- **`c4ebf919` (Oct 2023)**: the ModTools app flashed the Freegle landing page at
+  startup; fixed by abandoning the optimistic guess for that case and showing a
+  neutral loading spinner instead.
+- The Feb 2022 localStorage→IndexedDB persistence migration was rocky ("Fix up
+  corrupt store", "Clear new store when we log out", ~30 commits) - the cache
+  the optimistic render depends on is itself a failure surface.
+- No cross-user leakage bug was ever recorded (searched for it explicitly).
+
+Lessons if we retry it in nuxt3: (1) gate the API CLIENT, not the render - no
+request may leave before persisted auth is loaded (nuxt3's synchronous
+localStorage persistence makes this cheaper than Nuxt 2's async IndexedDB);
+(2) never let a boot-window 401/"not logged in" response clear stored credentials;
+(3) render neutral (skeleton) rather than guessing wherever the guess can be
+reliably wrong; (4) suppress layout-shifting corrections (CLS) when the truth
+arrives.
+
+**And the iznik-nuxt3 history confirms this ground has been walked repeatedly.**
+Why the blocking await exists (documented in commit history):
+- Jun 2022 `12a327e0`: first fetchUser was an ACCIDENTALLY non-blocking
+  `beforeCreate()` call. Jul 2022 `205f82cc` made it a deliberate top-level await.
+- Feb 2023 `2172a58d`/`75c60f6f`: the rationale, verbatim in a comment that
+  survives today: "We need this so that we don't trigger API calls without a JWT
+  when we are in fact logged in" - the same correctness concern as Nuxt 2's
+  forced-logout race. Also: the await was chosen as the FASTER of two delays
+  (vs waiting for GoogleOneTap), not because blocking was desired.
+
+Every nuxt3-era attempt at a non-blocking reveal mechanism failed:
+- `<NuxtPage :key="loginCount">` remount (2023): reverted in `b32d36d4` - "using
+  a key on NuxtPage results in errors which can cause the JS to bomb out".
+- `<Suspense>` in 5 components (2022-2023): removed codebase-wide in `017444de`
+  as "flaky".
+- `reloadNuxtApp` hard reload on login (Jul 2023): commented out Apr 2025
+  (`db794f4ec`, the dead block at app.vue:277-285); ModTools independently
+  reinvented it and killed it again in Apr 2026 (`3a344b3c`) after it raced
+  Playwright navigation ("Execution context was destroyed") - twice-proven bad.
+- Mar 2026 `51615e57`/`cac650cb` (marketing-optout page): live demonstration of
+  the blocking pattern's own failure mode - "Top-level await in script setup ...
+  causes the component to suspend until the API call completes. If the login API
+  hangs (e.g. in CI), the h1 never renders." Fixed with **onMounted + hard 10s
+  safety timeout** - the one surviving, recent, successful non-blocking pattern,
+  NOT yet backported to layouts/default.vue or login.vue.
+
+Read together, the two histories say: the OPTIMISTIC ASSUMPTION itself is
+workable (Nuxt 2 shipped it for years; the killer bugs were API calls racing
+credentials, and bad reveal mechanisms), but the REVEAL mechanism must be the
+already-proven reactive `loginStateKnown`/`bump` watcher (now also adopted by
+ModTools as "same pattern as Freegle") plus the Mar 2026 onMounted+timeout
+pattern - never Suspense, key-remounts of NuxtPage, or hard reloads. Timing
+windows to test exhaustively: API calls before credential load, boot-window 401
+handling, login flip mid-interaction, Playwright navigation races, CLS on
+correction, logout-then-relaunch staleness.
+
+Also found: `layouts/login.vue` only has the first (jwt-gated) fetchUser branch,
+not the second `!loginStateKnown` one default.vue gained in Dec 2025 - accidental
+drift worth tidying whichever way we go. And there has NEVER been a route
+middleware in this repo; gating has always lived in layout/app-root script setup.
+
+At minimum (these two are safe regardless of the optimistic-boot question):
+- Use the existing `fetchMe()` dedup (`composables/useMe.js`) in both layouts so
+  the session isn't fetched twice on every logged-in cold start.
+- Move the chained `groupStore.fetchBatch()` out of `fetchUser()`'s critical path
+  (nothing painted at boot needs full group details).
+
+**B3. Optimistic render from a persisted snapshot.** Persist a minimal user
+snapshot (id, name, group ids, unread counts) alongside the already-persisted JWT;
+on boot, hydrate stores from it and render the real UI instantly, then revalidate
+with `/apiv2/session` in the background and reconcile (logout/kill-switch paths
+must still work - ret 123 handling stays). This is the "how other apps feel
+instant" pattern: they render last-known state and refresh quietly.
+
+Research status: the external pass found essentially NO verified community
+guidance on optimistic Pinia-persisted session boot in Ionic/Capacitor apps -
+this angle survived on first principles only, so treat it as sound-but-unsourced
+engineering. Supporting precedent: iOS itself fakes instant resume by showing a
+cached screenshot of last state before the process is even alive (confirmed 3-0,
+matches Apple's `ignoreSnapshotOnNextApplicationLaunch` API). Design the
+reconciliation path carefully (stale unread counts, mid-flight logout, account
+switch via `userlist`).
+
+**B4. Server-side: fix or avoid the UK-wide `message/inbounds` query.** p50 ~1.4s,
+p95 ~3s, max 8s at all times of day for the whole-UK bbox. Even off the critical
+path it burns server capacity on data mostly never seen. Candidate: cached
+response for the default bbox, or a cheap "recent posts sample" endpoint.
+
+### C. Cut JS boot cost
+
+**C1. Lazy-load the Sentry SDK.** `DQYUI595.js` (467KB) is essentially the Sentry
+bundle; capture-and-replay early errors with a tiny queue, import the SDK after
+first paint.
+**C2. Restore modulepreload hints for app builds.** The `build:manifest` hook
+strips all preload/prefetch links for web-FCP reasons; for the app, assets are
+local files - preloading is nearly free and lets the WebView fetch/parse the
+92-file module graph in parallel instead of discovering it serially.
+**C3. Defer non-critical store/plugin work.** 31 stores init in root setup;
+mobile init (6 push channels, permissions, update check) competes for the main
+thread during boot. Delay to idle/post-paint.
+**C4. Housekeeping: stop shipping ~16MB of sourcemaps in the APK/IPA** (gate
+`sourcemap.client` on !ISAPP or strip `.map` before `npx cap sync`; Sentry upload
+happens at build time anyway). Install-size/download win, not runtime.
+
+External-research status for C: V8's bytecode cache is real (needs the same script
+loaded twice, and is gated on HTTP caching semantics - 304 keeps it, 200 clears
+it; official V8 blog, 3-0) but **whether Capacitor's custom local scheme
+(androidScheme https / capacitor://localhost) engages it at all is unverified** -
+an open question worth a 1-day experiment (relaunch twice, profile
+compile-vs-execute in DevTools) before betting on it. No verified WebView
+"warm-up" technique and no verified mid-range parse-cost figures survived the
+adversarial pass; popular blog prescriptions (capgo's "40% faster launch",
+nextnative's "170KB budget") were explicitly refuted as unsupported. C1-C3 stand
+on our own measurements (467KB Sentry chunk; 92 files before first API call).
+
+### D. Snapshot / screenshot-restore techniques (the "retain a screenshot" idea)
+
+Research verdict: **no maintained Capacitor or Cordova plugin exists** that shows
+a screenshot of the app's last state at cold launch - the pass found none, and
+flagged it as an open question. What IS confirmed (3-0):
+- iOS natively fakes instant resume with a cached snapshot of the last app state
+  (task switcher / warm relaunch); the OS handles it, and it can even make a
+  killed app look alive. We get this behaviour for free on iOS warm launches
+  already - it's cold starts where the white screen bites.
+- Nothing analogous is exposed on Android for app-controlled cold-start snapshots.
+Building it ourselves (native code: capture WebView bitmap on pause, show it as
+an overlay at launch until the web app signals ready) is feasible but is a custom
+native project with real risks: stale data on screen, showing logged-in content
+after logout, screenshots of sensitive chats persisted to disk. Given A1 gives us
+a held branded splash for a fraction of the effort, the snapshot trick is poor
+value; consider only if we later want "resume where you were" polish. iOS's own
+snapshot mechanism plus B3 (instant real UI from persisted state) achieves the
+same perceived effect more honestly.
+
+### E. Measure it for real
+
+**E1. Add startup telemetry.** The phases already exist
+(`pageload-tracking.client.js`; 'interactive' = suspense resolve). Record
+`performance.now()` at entry-script start, suspense resolve, and first API
+completion, send once via `/apiv2/clientlog`, so we can see real-device startup
+distributions and verify improvements (and the "worse after 5pm" claim) instead
+of relying on anecdote.
+
+### F. Ideas considered and rejected
+
+- **Prerendered logged-in shell HTML + hydration ("store the HTML like SSR").**
+  No verified evidence exists that a prerendered logged-in shell can be hydrated
+  by Nuxt ssr:false without mismatch; the research pass killed every claim in
+  this angle. Nuxt's supported answer for ssr:false is exactly
+  `spaLoadingTemplate` (A2) - same visual benefit, no hydration risk. A truly
+  hydratable personalised shell would mean SSR-style payload management we've
+  deliberately avoided in app builds.
+- **Screenshot-restore plugin** - doesn't exist; custom native build is poor
+  value vs A1 (see D).
+- **Relying on WebView bytecode caching** - unverified for Capacitor's local
+  scheme (open question; cheap experiment possible, but don't plan around it).
+- **Native "suspend first frame until ready" API** (ViewTreeObserver preDraw
+  trick) - refuted as a documented mechanism in this context; the splash plugin
+  achieves the same outcome supported.
+
+## Recommendation
+
+1. **A1 + A2 (splash held until app-ready + branded SPA loading shell).** Kills
+   the white screen outright for a few days' work, no structural risk. Include
+   the foreground-guard on `hide()` and a fallback timer.
+2. **B1 first, then B2 carefully.** B1 (stop `pages/index.vue`'s 3-round-trip
+   cascade blocking paint, skip it entirely for logged-in/app users) is safe and
+   uncontroversial - it doesn't touch the login-state machinery at all and
+   removes the biggest cost (the ~1.4-3s inbounds chain). B2 (non-blocking
+   `fetchUser()`) is approved in principle but history-laden: use ONLY the
+   proven patterns (reactive `loginStateKnown`/`bump` flip + Mar 2026
+   onMounted-with-timeout precedent, API client gated on credential load), never
+   Suspense/key-remount/hard-reload, and budget serious test effort for the
+   timing windows listed under B2. The `fetchMe()` dedup and moving group
+   fetchBatch off the critical path are safe regardless.
+3. **E1 (startup telemetry via clientlog)** in the same batch, so the wins are
+   measured on real devices and regressions get caught.
+4. Then: C1 (lazy Sentry), C2 (restore modulepreload for app builds), C3 (defer
+   store/mobile init), C4 (sourcemap stripping), B3 (optimistic boot from
+   persisted snapshot) as a second wave; B4 (inbounds server cost) as a
+   server-side ticket regardless.
+
+## Key sources (adversarially verified)
+
+- https://capacitorjs.com/docs/apis/splash-screen (plugin defaults, Android 12 option caveats)
+- https://developer.android.com/develop/ui/views/launch/splash-screen (dismiss-on-first-frame)
+- https://github.com/ionic-team/capacitor/discussions/5816 (maintainer guidance: launchAutoHide/theme/installSplashScreen)
+- https://github.com/ionic-team/capacitor-plugins/issues/1856 (backgrounded hide() crash)
+- https://nuxt.com/docs/3.x/guide/concepts/rendering + /api/nuxt-config (spaLoadingTemplate mechanism + explicit-config requirement)
+- https://v8.dev/blog/code-caching-for-devs (bytecode cache mechanics; applicability to Capacitor local scheme unverified)
+- https://developer.apple.com/design/human-interface-guidelines/launching (launch screen = first-screen mirror)
+- Workflow stats: 21 sources fetched, 78 claims extracted, 25 verified with 3-vote
+  adversarial panels, 14 confirmed / 11 refuted. Refuted claims are listed above
+  so they don't get relied on later.
+


### PR DESCRIPTION
## Summary

First of two PRs from the app-startup investigation (research in
`plans/2026-07-17-app-startup-white-screen-research.md`; prompted by
https://discourse.ilovefreegle.org/t/complaint-from-member-left-in-feedback/9928).
The app's first paint was blocked on up to five sequential API round trips.
This PR removes the unnecessary ones without touching the login-state machinery
(that riskier change is PR 2).

- **App builds no longer block first paint on the landing-page data cascade.**
  `pages/index.vue` unconditionally awaited group list → UK-wide
  `message/inbounds` (prod p50 ~1.4s, p95 ~3s) → message batch before anything
  painted - even for logged-in users who are immediately redirected to /browse
  and never see that data. App builds now fetch it after mount, and only when
  the user ended up logged out. Web builds are byte-for-byte unchanged (it's
  the SSR prefetch there).
- **`GET /session` is fetched once per cold start, not twice.** Both layouts
  independently awaited `fetchUser()`, so the logged-in `/` → `/browse` flow
  repeated the session fetch within ~1s. Both now share a new
  `composables/useBootSession.js` gate which returns immediately when the
  session is already fresh (< 30s) and refreshes in the background otherwise.
  This also fixes the drift where `layouts/login.vue` was missing the
  no-credentials `loginStateKnown` resolution that `default.vue` gained in
  Dec 2025.
- **Group details no longer block session resolution.** `fetchUser()` awaited
  a chained `groupStore.fetchBatch()` for every membership before the layouts
  would render; the batch is now fire-and-forget and fills in reactively
  (`useMe.myGroups` already tolerates missing details by design).
- Adds `authStore.userFetchedAt` (not persisted) to support the freshness
  check.

Verified in the browser on freegle-dev-live: a logged-in cold start at `/`
through the redirect to `/browse` now issues exactly one `GET /session`
(previously two) and one batched group fetch, and the app renders normally.

## Code Quality Review

- The boot gate is one shared composable, so the two layouts can't drift again.
- The invalid-JWT edge case is covered: the app decides whether to fetch
  landing data at `onMounted`, after the session fetch has resolved, not from
  stored credentials at setup.
- The fire-and-forget `fetchBatch` is wrapped in `Promise.resolve().catch` so a
  rejected batch can't become an unhandled rejection or clear the user.
- Landing-page fetch failures in the app path are caught and logged.

## Test Plan

- New `tests/unit/composables/useBootSession.spec.js` (6 cases: blocking fetch
  when credentials but no user, no refetch when fresh, background refresh when
  stale, no-credentials resolution, no-op when state known, error swallowing).
- New `tests/unit/pages/index.spec.js` (4 cases: app+logged-in skips the
  cascade, app+logged-out renders immediately and fetches post-mount,
  web keeps the blocking prefetch, web cascade order preserved). The two app
  cases were verified failing against the previous code.
- `tests/unit/stores/auth.spec.js`: fetchUser resolves while the group batch
  hangs; survives a rejected batch; records `userFetchedAt`.
- Full vitest suite green locally; Playwright suite run via the status API.

## Future Improvements (PR 2, in progress)

- Non-blocking session boot (render shell immediately, fetch session via
  onMounted + safety timeout, reveal via the existing `loginStateKnown`/`bump`
  watcher), plus moving `savePushId()` and the marketing-consent sync off
  `fetchUser()`'s critical path.
- Native splash-screen hold + branded `spaLoadingTemplate` (separate work,
  see the research doc).
