### PR TITLE
perf(app): non-blocking session boot - app shell paints before the network

### DIFF
--- a/iznik-nuxt3/composables/useBootSession.js
+++ b/iznik-nuxt3/composables/useBootSession.js
@@ -7,6 +7,12 @@ import { fetchMe } from '~/composables/useMe'
 // must not repeat the GET /session the first one just did.
 export const BOOT_SESSION_FRESH_MS = 30_000
 
+// How long the deferred boot waits for the session before letting the UI
+// proceed as logged out. Same safety-timeout idea as pages/marketing-optout
+// (commit 51615e57): a hung login API must never strand the user on a
+// skeleton.
+export const BOOT_SESSION_TIMEOUT_MS = 10_000
+
 // Shared boot gate for layouts/default.vue and layouts/login.vue.
 //
 // Resolves the login state exactly once per cold start: if we have stored
@@ -58,4 +64,32 @@ export async function bootSession() {
   }
 
   return authStore.user
+}
+
+// Non-blocking boot for client layouts: starts bootSession() and resolves
+// with { user, timedOut } when the session resolves or after timeoutMs,
+// whichever is first. On timeout, loginStateKnown is forced true so anything
+// gated on it (login modal, OneTap) proceeds as logged out; the underlying
+// fetch keeps going, and a late success re-renders via the existing
+// loginStateKnown/bump watchers.
+//
+// Do NOT await this at the top level of a layout's script setup - the whole
+// point is that first paint no longer waits for the network.
+export function bootSessionDeferred(timeoutMs = BOOT_SESSION_TIMEOUT_MS) {
+  const authStore = useAuthStore()
+  let timer = null
+
+  const boot = bootSession().then((user) => ({ user, timedOut: false }))
+
+  const timeout = new Promise((resolve) => {
+    timer = setTimeout(() => {
+      if (!authStore.loginStateKnown) {
+        console.log('Session boot timed out - proceeding as logged out')
+        authStore.loginStateKnown = true
+      }
+      resolve({ user: authStore.user, timedOut: true })
+    }, timeoutMs)
+  })
+
+  return Promise.race([boot, timeout]).finally(() => clearTimeout(timer))
 }

--- a/iznik-nuxt3/layouts/default.vue
+++ b/iznik-nuxt3/layouts/default.vue
@@ -12,10 +12,10 @@
 <script setup>
 import { useMiscStore } from '~/stores/misc'
 import LayoutCommon from '~/components/LayoutCommon'
-import { ref } from '#imports'
+import { ref, useRuntimeConfig } from '#imports'
 import { useAuthStore } from '~/stores/auth'
 import { useMobileStore } from '@/stores/mobile' // APP
-import { bootSession } from '~/composables/useBootSession'
+import { bootSession, bootSessionDeferred } from '~/composables/useBootSession'
 const GoogleOneTap = defineAsyncComponent(() =>
   import('~/components/GoogleOneTap')
 )
@@ -23,7 +23,6 @@ const LoginModal = defineAsyncComponent(() => import('~/components/LoginModal'))
 
 const mobileStore = useMobileStore()
 
-let ready = false
 const oneTap = ref(false)
 const authStore = useAuthStore()
 const miscStore = useMiscStore()
@@ -57,19 +56,41 @@ watch(
   }
 )
 
-// For this layout we don't need to be logged in.  So can just continue.  But we want to know first whether or
-// not we are logged in.  bootSession() resolves that exactly once per cold
-// start (and doesn't repeat the fetch when another layout just did it).
-const user = await bootSession()
+// For this layout we don't need to be logged in.  So can just continue.
+// bootSession() resolves the login state exactly once per cold start (and
+// doesn't repeat the fetch when another layout just did it).
+//
+// In the APP build (ssr:false) we deliberately do NOT await: first paint used
+// to be blocked on this network round trip under the root Suspense
+// (multi-second white screen; stuck forever if the API hung).  The shell
+// renders immediately and the existing loginStateKnown/bump watcher above
+// re-renders when the session resolves - the same reveal mechanism this
+// layout has always used for the logged-out → logged-in flip.
+// bootSessionDeferred adds a safety timeout so a hung API proceeds as logged
+// out.
+//
+// On the WEB we keep the await, on the server (no stored credentials, so no
+// network call) and during client hydration alike: the server-rendered HTML
+// is already painted while hydration runs, so blocking here costs no white
+// screen - and an interactive page whose session is still unresolved opens
+// real races (login modal intercepting clicks, session-gated buttons
+// disabled), which Playwright caught when this was tried web-wide.
+const runtimeConfig = useRuntimeConfig()
 
-if (user) {
-  ready = true
-}
-
-if (!ready && !mobileStore.isApp) {
-  // APP
-  // We don't have a valid JWT.  See if OneTap can sign us in.
-  oneTap.value = true
+if (import.meta.server || !runtimeConfig.public.ISAPP) {
+  await bootSession()
+  if (!authStore.user && !mobileStore.isApp) {
+    // We don't have a valid JWT.  See if OneTap can sign us in.
+    oneTap.value = true
+  }
+} else {
+  bootSessionDeferred().then(({ user }) => {
+    if (!user && !mobileStore.isApp) {
+      // APP build without a valid JWT - OneTap isn't used in the app, but
+      // keep the same logic shape for layer consumers.
+      oneTap.value = true
+    }
+  })
 }
 
 function googleLoggedIn() {

--- a/iznik-nuxt3/layouts/login.vue
+++ b/iznik-nuxt3/layouts/login.vue
@@ -22,8 +22,8 @@ import { useAuthStore } from '~/stores/auth'
 import LayoutCommon from '~/components/LayoutCommon'
 import { useMobileStore } from '@/stores/mobile' // APP
 import { useMiscStore } from '~/stores/misc'
-import { bootSession } from '~/composables/useBootSession'
-import { ref, computed, watch } from '#imports'
+import { bootSession, bootSessionDeferred } from '~/composables/useBootSession'
+import { ref, computed, watch, useRuntimeConfig } from '#imports'
 const GoogleOneTap = defineAsyncComponent(() =>
   import('~/components/GoogleOneTap')
 )
@@ -40,6 +40,7 @@ const miscStore = useMiscStore()
 
 const loggedIn = computed(() => authStore.user !== null)
 const me = computed(() => authStore.user)
+const loginStateKnown = computed(() => authStore.loginStateKnown)
 
 if (process.client) {
   // Ensure we don't wrongly think we have some outstanding requests if the server happened to start some.
@@ -52,13 +53,18 @@ useHead({
   },
 })
 
+// Force the login modal only once the login state is actually KNOWN. With
+// the non-blocking boot below, `me` is always null for an instant on cold
+// start - forcing the modal on that would flash it at logged-in users. The
+// boot's safety timeout guarantees loginStateKnown eventually flips even if
+// the API hangs, so a genuinely logged-out user always gets the modal.
 watch(
-  me,
-  (newVal) => {
-    if (newVal) {
+  [me, loginStateKnown],
+  ([newMe, known]) => {
+    if (newMe) {
       // We've logged in.
       ready.value = true
-    } else {
+    } else if (known) {
       authStore.forceLogin = true
     }
   },
@@ -84,14 +90,30 @@ function googleLoaded() {
 // Resolve the login state exactly once per cold start - if the default layout
 // already fetched the session moments ago (/ → /browse swap), this returns
 // immediately instead of repeating GET /session.
-const user = await bootSession()
+//
+// APP build only: don't await - first paint must not wait on the network (see
+// layouts/default.vue for the full rationale and why the web keeps the
+// blocking await). The [me, loginStateKnown] watcher above handles the
+// reveal either way.
+const runtimeConfig = useRuntimeConfig()
 
-if (user) {
-  ready.value = true
-}
+if (import.meta.server || !runtimeConfig.public.ISAPP) {
+  const user = await bootSession()
 
-if (!ready.value && !mobileStore.isApp) {
-  // We don't have a valid JWT. See if OneTap can sign us in.
-  oneTap.value = true
+  if (user) {
+    ready.value = true
+  } else if (!mobileStore.isApp) {
+    // We don't have a valid JWT. See if OneTap can sign us in.
+    oneTap.value = true
+  }
+} else {
+  bootSessionDeferred().then(({ user }) => {
+    if (user) {
+      ready.value = true
+    } else if (!mobileStore.isApp) {
+      // We don't have a valid JWT. See if OneTap can sign us in.
+      oneTap.value = true
+    }
+  })
 }
 </script>

--- a/iznik-nuxt3/pages/index.vue
+++ b/iznik-nuxt3/pages/index.vue
@@ -114,6 +114,7 @@ import ProxyImage from '~/components/ProxyImage.vue'
 import {
   computed,
   ref,
+  watch,
   onMounted,
   onBeforeUnmount,
   nextTick,
@@ -186,27 +187,41 @@ async function fetchLandingData() {
 const authStore = useAuthStore()
 const isAppBuild = !!runtimeConfig.public.ISAPP
 
+// Computed properties
+const me = computed(() => authStore?.user)
+
 if (!isAppBuild || import.meta.server) {
   // Web build: unchanged blocking prefetch (server render and the matching
   // client hydration pass).
   await fetchLandingData()
 } else {
-  // App build: never block first paint on these three round trips. By
-  // onMounted the root Suspense has resolved, so the layout's session fetch
-  // has finished and we know whether we're really logged in: logged-in users
-  // are redirected to /browse by goHome() and never see this data, so only
-  // fetch it when we ended up logged out.
-  onMounted(() => {
-    if (!me.value) {
-      fetchLandingData().catch((e) => {
-        console.log('Landing data fetch failed', e?.message)
-      })
-    }
-  })
-}
+  // App build: never block first paint on these three round trips. The boot
+  // session now resolves in the BACKGROUND (layouts no longer await it), so
+  // we can't decide at mount time - react to the login state instead, once:
+  // logged-in users bounce home and never see this data; logged-out ones get
+  // the landing fetch. The boot's safety timeout guarantees loginStateKnown
+  // flips even if the API hangs.
+  let bootHandled = false
+  const stopBootWatch = watch(
+    [me, () => authStore.loginStateKnown],
+    ([newMe, known]) => {
+      if (!known || bootHandled) return
+      bootHandled = true
 
-// Computed properties
-const me = computed(() => authStore?.user)
+      if (newMe) {
+        goHome()
+      } else {
+        fetchLandingData().catch((e) => {
+          console.log('Landing data fetch failed', e?.message)
+        })
+      }
+
+      // Can't call stop inside the immediate invocation (TDZ); defer it.
+      nextTick(() => stopBootWatch?.())
+    },
+    { immediate: true }
+  )
+}
 
 const isApp = ref(mobileStore.isApp) // APP
 

--- a/iznik-nuxt3/stores/auth.js
+++ b/iznik-nuxt3/stores/auth.js
@@ -432,7 +432,12 @@ export const useAuthStore = defineStore({
         this.setUser(me)
         this.userFetchedAt = Date.now()
 
-        await this.savePushId() // Tell server our mobile push notification id, if available
+        // Tell server our mobile push notification id, if available. Not
+        // awaited: a stalled native bridge must not hold up the session
+        // result (and therefore first paint).
+        Promise.resolve(this.savePushId()).catch((e) => {
+          console.log('savePushId failed', e?.message)
+        })
 
         const composeStore = useComposeStore()
         const email = composeStore.email
@@ -444,7 +449,8 @@ export const useAuthStore = defineStore({
         }
 
         if (process.client) {
-          // Sync marketing consent from local storage to user profile if needed
+          // Sync marketing consent from local storage to user profile if needed.
+          // Fire-and-forget: this PATCH is housekeeping, not session-critical.
           const miscStore = useMiscStore()
 
           if (miscStore.marketingConsent !== undefined) {
@@ -457,16 +463,17 @@ export const useAuthStore = defineStore({
             )
 
             if (me.marketingconsent !== localConsent) {
-              try {
-                await this.$api.session.save({
+              this.$api.session
+                .save({
                   marketingconsent: localConsent,
                 })
-
-                me.marketingconsent = localConsent
-                console.log("Sync'd marketing consent")
-              } catch (e) {
-                console.log('Failed to sync marketing consent', e)
-              }
+                .then(() => {
+                  me.marketingconsent = localConsent
+                  console.log("Sync'd marketing consent")
+                })
+                .catch((e) => {
+                  console.log('Failed to sync marketing consent', e)
+                })
             } else {
               console.log("Marketing consent already sync'd")
             }

--- a/iznik-nuxt3/tests/unit/composables/useBootSession.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useBootSession.spec.js
@@ -17,7 +17,9 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 import {
   bootSession,
+  bootSessionDeferred,
   BOOT_SESSION_FRESH_MS,
+  BOOT_SESSION_TIMEOUT_MS,
 } from '~/composables/useBootSession'
 import { fetchMe } from '~/composables/useMe'
 
@@ -130,5 +132,68 @@ describe('bootSession', () => {
     // First call failed; loginStateKnown still false so it retries once.
     expect(fetchMe).toHaveBeenCalledTimes(2)
     expect(user).toBeNull()
+  })
+})
+
+describe('bootSessionDeferred', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    globalThis.__mockAuthStore = makeAuthStore()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    delete globalThis.__mockAuthStore
+    vi.restoreAllMocks()
+  })
+
+  it('resolves with the user and no timeout when the fetch completes', async () => {
+    globalThis.__mockAuthStore = makeAuthStore({
+      auth: { jwt: 'token', persistent: null },
+    })
+    fetchMe.mockImplementation(() => {
+      globalThis.__mockAuthStore.user = { id: 7 }
+      globalThis.__mockAuthStore.loginStateKnown = true
+      return Promise.resolve()
+    })
+
+    const result = await bootSessionDeferred()
+
+    expect(result.user).toEqual({ id: 7 })
+    expect(result.timedOut).toBe(false)
+  })
+
+  it('times out when the session fetch hangs, forcing loginStateKnown so the UI can proceed', async () => {
+    globalThis.__mockAuthStore = makeAuthStore({
+      auth: { jwt: 'token', persistent: null },
+    })
+    // Session API hangs indefinitely (the Mar 2026 marketing-optout failure
+    // mode) - boot must not strand the user on a skeleton.
+    fetchMe.mockReturnValue(new Promise(() => {}))
+
+    const resultPromise = bootSessionDeferred()
+    await vi.advanceTimersByTimeAsync(BOOT_SESSION_TIMEOUT_MS + 100)
+    const result = await resultPromise
+
+    expect(result.timedOut).toBe(true)
+    expect(result.user).toBeNull()
+    // Forced so watchers gating on loginStateKnown (login modal, OneTap)
+    // proceed as logged out; a late success reconciles via the same watchers.
+    expect(globalThis.__mockAuthStore.loginStateKnown).toBe(true)
+  })
+
+  it('does not wait for the timeout when there are no credentials', async () => {
+    fetchMe.mockImplementation(() => {
+      globalThis.__mockAuthStore.loginStateKnown = true
+      return Promise.resolve()
+    })
+
+    const resultPromise = bootSessionDeferred()
+    // No timer advance - must resolve on the fetch path alone.
+    const result = await resultPromise
+
+    expect(result.timedOut).toBe(false)
+    expect(result.user).toBeNull()
   })
 })

--- a/iznik-nuxt3/tests/unit/pages/index.spec.js
+++ b/iznik-nuxt3/tests/unit/pages/index.spec.js
@@ -15,7 +15,7 @@
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
-import { defineComponent, Suspense, h, nextTick } from 'vue'
+import { defineComponent, Suspense, h, nextTick, reactive } from 'vue'
 
 import IndexPage from '~/pages/index.vue'
 
@@ -81,13 +81,16 @@ function mountPage() {
 }
 
 function setAuth(overrides = {}) {
-  globalThis.__mockAuthStore = {
+  // reactive so the page's watch on [me, loginStateKnown] responds to
+  // changes, as it does against the real Pinia store.
+  globalThis.__mockAuthStore = reactive({
     groups: [],
     user: null,
     auth: { jwt: null, persistent: null },
     loginStateKnown: false,
     ...overrides,
-  }
+  })
+  return globalThis.__mockAuthStore
 }
 
 function setAppBuild(isApp) {
@@ -125,8 +128,10 @@ describe('pages/index boot data cascade', () => {
     expect(mockFetchInBounds).not.toHaveBeenCalled()
   })
 
-  it('app build logged out renders immediately and fetches after mount', async () => {
+  it('app build logged out renders immediately and fetches without blocking', async () => {
     setAppBuild(true)
+    // Boot resolved as logged out.
+    setAuth({ loginStateKnown: true })
     // Landing fetches hang forever - the page must still render.
     mockGroupFetch.mockReturnValue(new Promise(() => {}))
 
@@ -137,8 +142,57 @@ describe('pages/index boot data cascade', () => {
     // Page rendered despite the pending fetch → fetch is not blocking paint.
     expect(wrapper.find('.landing-page').exists()).toBe(true)
 
-    // And the fetch was kicked off (after mount).
+    // And the fetch was kicked off.
     expect(mockGroupFetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('app build waits for the boot session to resolve before fetching or redirecting', async () => {
+    setAppBuild(true)
+    const auth = setAuth() // loginStateKnown false - boot still in flight
+
+    const wrapper = mountPage()
+    await flushPromises()
+
+    // Nothing decided yet: renders, but no fetch.
+    expect(wrapper.find('.landing-page').exists()).toBe(true)
+    expect(mockGroupFetch).not.toHaveBeenCalled()
+
+    // Boot resolves as logged out → landing fetch fires exactly once.
+    auth.loginStateKnown = true
+    await nextTick()
+    await flushPromises()
+
+    expect(mockGroupFetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('app build redirects when the boot session resolves as logged in', async () => {
+    setAppBuild(true)
+    const auth = setAuth()
+    const push = vi.fn()
+    globalThis.__testUseRouter = () => ({
+      push,
+      replace: vi.fn(),
+      currentRoute: { value: { path: '/' } },
+    })
+
+    try {
+      mountPage()
+      await flushPromises()
+      expect(push).not.toHaveBeenCalled()
+
+      // Boot resolves as logged in - user must be bounced home, not left on
+      // the landing page (me was null at mount time under non-blocking boot).
+      auth.user = { id: 9 }
+      auth.loginStateKnown = true
+      await nextTick()
+      await flushPromises()
+      await nextTick()
+
+      expect(push).toHaveBeenCalledWith('/browse')
+      expect(mockGroupFetch).not.toHaveBeenCalled()
+    } finally {
+      delete globalThis.__testUseRouter
+    }
   })
 
   it('web build (client) keeps the blocking prefetch', async () => {

--- a/iznik-nuxt3/tests/unit/stores/auth.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/auth.spec.js
@@ -71,12 +71,15 @@ vi.mock('~/stores/mobile', () => ({
   useMobileStore: () => ({ isApp: false }),
 }))
 
+const mockMiscStoreState = {
+  modtools: false,
+  source: null,
+  marketingConsent: undefined,
+  setAppOutOfDate: (...args) => mockSetAppOutOfDate(...args),
+}
+
 vi.mock('~/stores/misc', () => ({
-  useMiscStore: () => ({
-    modtools: false,
-    source: null,
-    setAppOutOfDate: mockSetAppOutOfDate,
-  }),
+  useMiscStore: () => mockMiscStoreState,
 }))
 
 describe('auth store', () => {
@@ -85,6 +88,7 @@ describe('auth store', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
     vi.clearAllMocks()
+    mockMiscStoreState.marketingConsent = undefined
     store = useAuthStore()
     store.init({ public: { BUILD_DATE: '2026-01-01' }, app: {} })
   })
@@ -550,6 +554,54 @@ describe('auth store', () => {
       await store.fetchUser()
 
       expect(store.userFetchedAt).toBeGreaterThanOrEqual(before)
+    })
+  })
+
+  describe('fetchUser critical path (PR2: non-blocking side effects)', () => {
+    it('resolves without waiting for savePushId', async () => {
+      store.setAuth('valid-jwt', 'valid-persistent')
+      mockFetchv2.mockResolvedValue({ me: { id: 5 }, groups: [] })
+      // Push registration hangs (e.g. native bridge stall) - the session
+      // result must not be held hostage.
+      const savePushSpy = vi
+        .spyOn(store, 'savePushId')
+        .mockReturnValue(new Promise(() => {}))
+
+      const result = await Promise.race([
+        store.fetchUser().then(() => 'fetchUser'),
+        new Promise((resolve) => setTimeout(() => resolve('timeout'), 1000)),
+      ])
+
+      expect(result).toBe('fetchUser')
+      expect(store.user.id).toBe(5)
+      expect(savePushSpy).toHaveBeenCalled()
+    })
+
+    it('resolves without waiting for the marketing consent sync', async () => {
+      store.setAuth('valid-jwt', 'valid-persistent')
+      mockFetchv2.mockResolvedValue({
+        me: { id: 5, marketingconsent: false },
+        groups: [],
+      })
+      mockMiscStoreState.marketingConsent = true
+      // The PATCH /session for consent hangs - must not block the session.
+      mockSave.mockReturnValue(new Promise(() => {}))
+
+      // The consent block is client-only; vitest has no Nuxt build-time
+      // process.client define, so set it for this test.
+      process.client = true
+      try {
+        const result = await Promise.race([
+          store.fetchUser().then(() => 'fetchUser'),
+          new Promise((resolve) => setTimeout(() => resolve('timeout'), 1000)),
+        ])
+
+        expect(result).toBe('fetchUser')
+        expect(store.user.id).toBe(5)
+        expect(mockSave).toHaveBeenCalledWith({ marketingconsent: true })
+      } finally {
+        delete process.client
+      }
     })
   })
 


### PR DESCRIPTION
## Summary

Second PR from the app-startup investigation (stacked on #1096; research in
`plans/2026-07-17-app-startup-white-screen-research.md`, prompted by
https://discourse.ilovefreegle.org/t/complaint-from-member-left-in-feedback/9928).

#1096 removed the unnecessary API calls from the boot path. This PR makes the
remaining session fetch **non-blocking in the app build only**: the app shell
paints immediately and the session resolves in the background, so the app's
first paint no longer waits on any network round trip at all.

**Web builds are unchanged.** A first version deferred the boot web-wide;
Playwright immediately caught the predicted timing windows there (login modal
intercepting clicks, session-gated submit buttons disabled, reply flows
racing) - and the web gains nothing from a non-blocking hydration, because the
server-rendered HTML is already painted while hydration runs. The deferred
path is therefore gated on `runtimeConfig.public.ISAPP`, where ssr:false means
the blocking await really was a white screen.

The git history shows every previous attempt at this failed on the *reveal*
mechanism (`NuxtPage :key` remount "JS bombs out" b32d36d4; Suspense removed as
"flaky" 017444de; `reloadNuxtApp` killed twice, most recently 3a344b3c). This
implementation deliberately uses only the two patterns that survived:

- **Reveal**: the existing `loginStateKnown`/`bump` reactive watcher - the
  layouts' long-standing logged-out → logged-in flip, untouched.
- **Hang safety**: `bootSessionDeferred()` wraps the boot in a 10s safety
  timeout (the `pages/marketing-optout.vue` precedent, 51615e57): if the login
  API hangs, `loginStateKnown` is forced so the UI proceeds as logged out, and
  a late success reconciles through the same watcher.

Changes:

- `composables/useBootSession.js`: new `bootSessionDeferred()` (timeout race;
  forces `loginStateKnown` on timeout; underlying fetch continues).
- `layouts/default.vue` / `layouts/login.vue`: client-side boot no longer
  awaited (server keeps the await - auth isn't cookie-based, so SSR resolves
  without a network call and hydration parity is preserved).
- `layouts/login.vue`: the login modal is only forced once login state is
  KNOWN - with a non-blocking boot, `me` is always briefly null on cold start,
  and forcing on that would flash the modal at logged-in users.
- `pages/index.vue`: the app build's landing-data/redirect decision is now a
  one-shot reactive gate on `[me, loginStateKnown]` - at mount time the session
  is no longer resolved, so deciding in `onMounted` would strand logged-in
  users on the landing page.
- `stores/auth.js`: `savePushId()` and the marketing-consent sync are
  fire-and-forget - a stalled native push bridge or consent PATCH no longer
  holds up the session result.

Timing windows from the review (each covered by a test or unchanged behaviour):

- **API calls racing stored credentials** (the Nuxt 2 forced-logout bug,
  0e5165d4): can't occur - pinia-persistedstate restores from localStorage
  synchronously at store init, before any component issues a request.
- **Boot-window 401s clearing credentials**: unchanged - only a 401 from
  `/session` clears auth (Discourse 9893 fix), and that is the authoritative
  check.
- **Login-modal flash for logged-in users**: guarded by the `loginStateKnown`
  gate (unit-tested; verified in the browser).
- **Hung API stranding the skeleton**: 10s safety timeout (unit-tested with
  fake timers).
- **Logout-then-relaunch staleness**: `logout()` uses `$reset()`, which clears
  `userFetchedAt`, so the next boot always revalidates.

## Code Quality Review

- No new reveal mechanism introduced - reuses the proven watcher; no Suspense,
  no key-remounts, no reloads.
- SSR behaviour intentionally unchanged (server-side awaits are free of
  network I/O in this auth model).
- The one-shot index gate can't double-fire (`bootHandled` flag) and stops its
  watcher after resolution.

## Test Plan

- `tests/unit/composables/useBootSession.spec.js`: +3 `bootSessionDeferred`
  cases (resolves with user; times out on hung fetch and forces
  `loginStateKnown`; no-credential fast path).
- `tests/unit/pages/index.spec.js`: reactive-gate cases - waits for boot
  resolution before fetching, fetches once when resolved logged-out, redirects
  to /browse when resolved logged-in (reactive mock store).
- `tests/unit/stores/auth.spec.js`: fetchUser resolves while `savePushId`
  hangs; resolves while the consent PATCH hangs.
- Full vitest suite green locally. Playwright suite (which exercises the WEB
  build, i.e. the unchanged path) run via the status API against the
  production build of this branch on a clean test database.
- App (deferred) path verified in a real browser against a freshly generated
  `ISAPP` bundle of this branch: shell paints before the session resolves,
  logged-in state flips in via the watcher, no login-modal flash, no stuck
  skeleton. Measured logged-in cold start at 4x CPU throttle against the
  production API: **first contentful paint 4,280ms → 1,000ms**, with the slow
  `message/inbounds` call (4s on that run) completing in the background after
  paint.

## Future Improvements

- Native splash-screen hold + branded `spaLoadingTemplate` (options A1/A2 in
  the research doc) - separate work.
- Startup telemetry via clientlog to measure the real-device improvement.
