### PR TITLE
perf(db3): move the users.lastaccess throttle into the SQL guard

### DIFF
--- a/iznik-server-go/notification/notification.go
+++ b/iznik-server-go/notification/notification.go
@@ -60,8 +60,11 @@ func List(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusUnauthorized, "Not logged in")
 	}
 
-	// Update last-active timestamp so the system knows the user is online.
-	db.Exec("UPDATE users SET lastaccess = NOW() WHERE id = ?", myid)
+	// NOTE: users.lastaccess is deliberately NOT updated here. The auth middleware
+	// already maintains it (throttled to 10 minutes, guarded in SQL); an extra
+	// unthrottled same-row UPDATE on every 60s navbar poll sprayed same-row writes
+	// across the Galera hosts and caused certification conflicts
+	// (plans/2026-07-17-db3-cpu-reach-sql-prefilter.md, adjacent fix 1).
 
 	// V1 parity: notification.php GET calls $me->recordActive() which inserts a row into
 	// users_active (userid, timestamp) with timestamp truncated to the hour. This is used by

--- a/iznik-server-go/test/authmiddleware_test.go
+++ b/iznik-server-go/test/authmiddleware_test.go
@@ -39,3 +39,57 @@ func TestAuthEndpointWithStaleJWT(t *testing.T) {
 	resp, _ := getApp().Test(req)
 	assert.Equal(t, 401, resp.StatusCode, "Auth endpoint should return 401 for stale JWT")
 }
+
+// lastaccessAgeSecs returns how many seconds ago users.lastaccess was set,
+// or -1 if it is NULL.
+func lastaccessAgeSecs(t *testing.T, uid uint64) int64 {
+	var age []*int64
+	database.DBConn.Raw("SELECT TIMESTAMPDIFF(SECOND, lastaccess, NOW()) AS age FROM users WHERE id = ?", uid).Pluck("age", &age)
+	if len(age) == 0 || age[0] == nil {
+		return -1
+	}
+	return *age[0]
+}
+
+func TestLastaccessBumpedWhenNull(t *testing.T) {
+	// An authenticated request must set lastaccess when it is NULL.
+	uid, token := CreateFullTestUser(t, uniquePrefix("la_null"))
+	db := database.DBConn
+	db.Exec("UPDATE users SET lastaccess = NULL WHERE id = ?", uid)
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/notification/count?jwt="+token, nil))
+	assert.Equal(t, 200, resp.StatusCode)
+
+	age := lastaccessAgeSecs(t, uid)
+	assert.NotEqual(t, int64(-1), age, "lastaccess should have been set from NULL")
+	assert.Less(t, age, int64(240), "lastaccess should be recent after authenticated request")
+}
+
+func TestLastaccessBumpedWhenStale(t *testing.T) {
+	// An authenticated request must refresh lastaccess older than 10 minutes.
+	uid, token := CreateFullTestUser(t, uniquePrefix("la_stale"))
+	db := database.DBConn
+	db.Exec("UPDATE users SET lastaccess = DATE_SUB(NOW(), INTERVAL 1 HOUR) WHERE id = ?", uid)
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/notification/count?jwt="+token, nil))
+	assert.Equal(t, 200, resp.StatusCode)
+
+	age := lastaccessAgeSecs(t, uid)
+	assert.Less(t, age, int64(240), "stale lastaccess should be refreshed by authenticated request")
+}
+
+func TestLastaccessNotBumpedWhenFresh(t *testing.T) {
+	// lastaccess is throttled to every 10 minutes: a request must NOT bump a
+	// fresh (5 minutes old) value. The throttle lives in the SQL guard so that
+	// concurrent requests can't all write the same row (Galera certification
+	// conflicts - see plans/2026-07-17-db3-cpu-reach-sql-prefilter.md).
+	uid, token := CreateFullTestUser(t, uniquePrefix("la_fresh"))
+	db := database.DBConn
+	db.Exec("UPDATE users SET lastaccess = DATE_SUB(NOW(), INTERVAL 5 MINUTE) WHERE id = ?", uid)
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/notification/count?jwt="+token, nil))
+	assert.Equal(t, 200, resp.StatusCode)
+
+	age := lastaccessAgeSecs(t, uid)
+	assert.GreaterOrEqual(t, age, int64(240), "fresh lastaccess must not be bumped (10-minute throttle)")
+}

--- a/iznik-server-go/test/notifications_test.go
+++ b/iznik-server-go/test/notifications_test.go
@@ -140,3 +140,20 @@ func TestNotificationListRecordsUsersActive(t *testing.T) {
 	db.Raw("SELECT COUNT(*) FROM users_active WHERE userid = ?", userID).Scan(&count)
 	assert.Equal(t, int64(1), count, "GET /api/notification should insert a users_active row")
 }
+
+func TestNotificationListDoesNotBumpFreshLastaccess(t *testing.T) {
+	// The navbar polls GET /api/notification every 60s. It must NOT write
+	// users.lastaccess on every poll: the auth middleware already maintains
+	// lastaccess with a 10-minute throttle, and an unthrottled same-row UPDATE
+	// sprayed across Galera write hosts causes certification conflicts
+	// (plans/2026-07-17-db3-cpu-reach-sql-prefilter.md, adjacent fix 1).
+	uid, token := CreateFullTestUser(t, uniquePrefix("notif_la"))
+	db := database.DBConn
+	db.Exec("UPDATE users SET lastaccess = DATE_SUB(NOW(), INTERVAL 5 MINUTE) WHERE id = ?", uid)
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/notification?jwt="+token, nil))
+	assert.Equal(t, 200, resp.StatusCode)
+
+	age := lastaccessAgeSecs(t, uid)
+	assert.GreaterOrEqual(t, age, int64(240), "notification poll must not bump a fresh lastaccess")
+}

--- a/iznik-server-go/user/authMiddleware.go
+++ b/iznik-server-go/user/authMiddleware.go
@@ -84,9 +84,17 @@ func NewAuthMiddleware(config Config) fiber.Handler {
 		}
 
 		// Update the last access time for the user if it is null or older than ten minutes.
+		// The throttle MUST live in the SQL guard (matching sessions.lastactive below), not
+		// only in the app-side check: N parallel requests all read the same stale value, all
+		// pass the check, and all UPDATE the same row — and with writes sprayed across the
+		// Galera hosts those same-row writes cause certification conflicts (387ms avg,
+		// ~197 DB-hours/10d — plans/2026-07-17-db3-cpu-reach-sql-prefilter.md, adjacent
+		// fix 1). With the guard, the racers match zero rows and are cheap no-ops. The
+		// app-side staleness check is kept as a fast path only: it skips issuing the
+		// statement at all when the auth SELECT already saw a fresh value.
 		if userIdInJWT > 0 && userIdInDB.Id > 0 && (userIdInDB.Lastaccess.IsZero() || userIdInDB.Lastaccess.Before(time.Now().Add(-10*time.Minute))) {
 			db := database.DBConn
-			db.Exec("UPDATE users SET lastaccess = NOW() WHERE id = ?", userIdInDB.Id)
+			db.Exec("UPDATE users SET lastaccess = NOW() WHERE id = ? AND (lastaccess IS NULL OR lastaccess < DATE_SUB(NOW(), INTERVAL 10 MINUTE))", userIdInDB.Id)
 		}
 
 		// Refresh sessions.lastactive if older than 10 minutes — this gives the session


### PR DESCRIPTION
Split out of #1098 (per review) so it can deploy independently - **Go API only, no
migration, no config**.

## Problem

`UPDATE users SET lastaccess = NOW()` was db3's #3 CPU consumer over 10 days of
`performance_schema`: **1.8M calls, ~197 hours, 387 ms average** for a single-row PK
update. The 10-minute throttle lived app-side (`authMiddleware.go`) and is racy: a page
load fires N API requests in parallel, all N read the same stale `lastaccess`, all pass
the check, and all issue the same-row UPDATE. Sprayed across the Galera write hosts,
those concurrent same-row writes cause certification conflicts - that's the 387 ms.

A second writer had **no throttle at all**: `notification.go` updated `lastaccess` on
every 60-second navbar poll for any user with unread notifications, so an idle open tab
kept hammering the row.

## Fix

- The UPDATE now carries the throttle in SQL:
  `AND (lastaccess IS NULL OR lastaccess < DATE_SUB(NOW(), INTERVAL 10 MINUTE))` - the
  identical pattern `sessions.lastactive` uses three lines below, which runs at **11 ms**
  in production. Racing requests match zero rows and become no-ops; the app-side check
  stays as a fast path that skips issuing the statement at all.
- The unthrottled duplicate write in `notification.go` is deleted - the middleware
  already maintains `lastaccess` on every authenticated request.

## Test plan (TDD)

Red run failed exactly on the new `TestNotificationListDoesNotBumpFreshLastaccess`
(3,196✓ / 1✗) before the fix. Contract tests pin the throttle: NULL → set; stale (1h) →
refreshed; fresh (5min) → NOT bumped; notification poll → NOT bumped. This exact diff has
been through two full local Go suite runs green (3,483✓ and 3,485✓) as part of the #1098
tree, whose other changes don't touch these paths; CI runs the full suite on this branch
standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ZAyCpXy9jiHzQGi6jfzdJ