### PR TITLE
fix(reach-slider): full panel width on desktop so the towns list stops truncating (9808)

### DIFF
--- a/iznik-nuxt3/components/NearbyTowns.vue
+++ b/iznik-nuxt3/components/NearbyTowns.vue
@@ -81,10 +81,12 @@ const bits = computed(() => {
     // example or two still leaves a useful hint), this tail is a single town name and IS the
     // whole message. Ellipsis-truncating it can hide the only information it conveys, so it
     // wraps instead of clipping (`wrap: true` -> .nt-tail--wrap, Discourse 9808).
+    // "Close to X" not "Closer than X": at the minimum setting the reach still includes
+    // areas beyond X, so "closer than" is misleading (Neville, Discourse 9808/584).
     return {
       lead,
       sep: lead ? '. ' : '',
-      tail: `Closer than ${closer.value}`,
+      tail: `Close to ${closer.value}`,
       wrap: true,
     }
   }
@@ -170,7 +172,7 @@ watch(
   overflow: hidden;
   text-overflow: ellipsis;
 }
-/* The "Closer than X" nearest-town name IS the whole message, unlike the "e.g. Town, Town"
+/* The "Close to X" nearest-town name IS the whole message, unlike the "e.g. Town, Town"
    examples list above (safe to ellipsis-clip - losing an example or two still leaves a useful
    hint). Clipping the single town name could hide the only information it conveys, so it wraps
    onto another line instead of truncating (Discourse 9808). */
@@ -191,7 +193,7 @@ watch(
     overflow: hidden;
     text-overflow: ellipsis;
   }
-  /* The "Closer than X" name wraps rather than clips (bits.wrap -> .nt-tail--wrap).
+  /* The "Close to X" name wraps rather than clips (bits.wrap -> .nt-tail--wrap).
      That case is breakpoint-agnostic (set from server data, not viewport), so at
      >=768px the fixed single-line box above would clip the wrapped 2nd line
      vertically with no ellipsis. Let the container grow to fit instead (Discourse

--- a/iznik-nuxt3/components/PostFilters.vue
+++ b/iznik-nuxt3/components/PostFilters.vue
@@ -70,9 +70,7 @@
            already-reaching posts are shown - it isn't a manual travel-time control. -->
       <div v-if="browseView === 'nearby'" class="nearby-help">
         <p class="help-text mt-0">
-          <span class="d-none d-md-inline"
-            >We show posts near you first, then gradually further away.
-          </span>
+          We show posts near you first, then gradually further away.
           <a href="#" @click.prevent="whichPostsModal?.show()">
             How does this work?
           </a>
@@ -543,9 +541,10 @@ const hasNonDefaultFilters = computed(() => {
   }
 }
 
-// Help text - the intro sentence is hidden on mobile to save space (see the d-none d-md-inline
-// span in the template), but the "How does this work?" / "Change postcode" links inside it must
-// stay visible at every width - they're the only way to reach the rippling explainer (Discourse 9808).
+// Help text - the whole rippling explanation ("We show posts near you first ..." plus the
+// "How does this work?" / "Change postcode" links) stays visible at every width. It was
+// previously hidden on mobile, which lost the explanatory line members asked for (Discourse
+// 9808, Neville #585/#600).
 .help-text {
   font-size: 0.8rem;
   color: var(--color-gray-600);

--- a/iznik-nuxt3/components/PostFilters.vue
+++ b/iznik-nuxt3/components/PostFilters.vue
@@ -502,8 +502,12 @@ const hasNonDefaultFilters = computed(() => {
     min-width: 0;
 
     @include media-breakpoint-up(md) {
-      grid-column: 1 / 2;
-      grid-row: 3 / 4;
+      /* Span the FULL panel width on its own row rather than sharing the 2fr column
+         with Sort. The reach hint / nearby-towns list then has the whole panel to use,
+         so its (deliberate) ellipsis-truncation only bites when genuinely tight instead
+         of at every larger width (Discourse 9808, Neville #600). */
+      grid-column: 1 / 4;
+      grid-row: 2 / 3;
     }
   }
 
@@ -512,7 +516,8 @@ const hasNonDefaultFilters = computed(() => {
     grid-row: 4 / 5;
 
     @include media-breakpoint-up(md) {
-      grid-column: 2 / 3;
+      /* Sort drops below the now full-width distance slider. */
+      grid-column: 1 / 2;
       grid-row: 3 / 4;
     }
   }


### PR DESCRIPTION
Fixes the reach-slider issues Neville rejected in [/t/9808/600](https://discourse.ilovefreegle.org/t/9808/600) (original reports [/t/9808/584](https://discourse.ilovefreegle.org/t/9808/584) and [/t/9808/585](https://discourse.ilovefreegle.org/t/9808/585)). All three of his points are addressed here.

## 1. Towns list truncates at larger widths

On the browse filter panel, `.distance` (the reach slider and its `NearbyTowns` "e.g. Town, Town" hint) was pinned to the `2fr` column of a `2fr 1fr 3rem` grid, sharing the row with Sort. So at larger widths the towns list ellipsis-truncated even though the panel had room. The truncation itself is deliberate (`min-width: 0` fallback), it should only bite when genuinely tight.

**Fix:** give `.distance` the full panel width on its own row at `md+`, with Sort dropping below it.

## 2. Rippling explainer disappears at small widths

The "We show posts near you first ..." explanatory line was `d-none` below `md`. That line is exactly what Neville reported missing on mobile. #1088 had kept only the links visible, not the sentence.

**Fix:** show the whole explanation (sentence + links) at every width.

## 3. "Closer than X" wording

At the minimum setting the reach still includes areas beyond X, so "closer than" was misleading.

**Fix:** "Closer than X" → "Close to X" in `NearbyTowns.vue`.

## Why #1088 didn't fix it

#1088 read "truncated" as the "Closer than X" fallback hint (made it wrap) and hid only the explainer's intro sentence rather than showing it, and never looked at the grid, which is the actual cause of the towns-list truncation. Neville's retest (#600) confirmed no improvement.

## Please eyeball

Layout change, so worth a look at the browse filter panel at desktop and mobile widths. The exact placement of Sort under the slider is easy to move if you'd prefer it elsewhere.

## Still open (separate)

`.nearby-help` is a sibling of `.filters`, so the `.filters .nearby-help` grid CSS is dead, and the block is `v-if="browseView === 'nearby'"` (only the Nearby feed). Not touched here; flag if you want the explainer surfaced in group browse too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQZ56NwFYEuhrtaoU7oYoM
