### PR TITLE
fix(moderation): re-check content on edit so filters cannot be permanently bypassed

### DIFF
--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -3338,6 +3338,20 @@ func applyPatchMessageCore(c *fiber.Ctx, myid uint64, req patchMessageRequest) e
 	itemsChanged := !stringPtrEqual(oldItemsJSON, newItemsJSON)
 	imagesChanged := !stringPtrEqual(oldImagesJSON, newImagesJSON)
 
+	// Subject, textbody, and item name are exactly the fields
+	// ContentCheckService::checkMessage() scans (concern keywords, per-group
+	// worry words, phone numbers, vague-item, not-an-item, URLs, ...).
+	// processUnprocessed() only re-scans messages_groups rows where
+	// contentcheck_checked_at IS NULL, so once a row has been checked, editing
+	// in new content otherwise leaves it unchecked forever - the automated
+	// moderation filters silently skip it and it can only be caught by a mod
+	// noticing manually. Clearing the stamp here re-queues the row for a fresh
+	// check, for both mods and owners: mods stripping an issue that triggered a
+	// flag also need the clean edit re-verified.
+	if subjectChanged || textChanged || itemsChanged {
+		db.Exec("UPDATE messages_groups SET contentcheck_checked_at = NULL, contentcheck_reasons = NULL WHERE msgid = ?", req.ID)
+	}
+
 	if (subjectChanged || textChanged || typeChanged || locationChanged || itemsChanged || imagesChanged) && !isMod {
 		// Store oldtype/newtype only when type actually changed.
 		var oldType, newType interface{}

--- a/iznik-server-go/test/message_test.go
+++ b/iznik-server-go/test/message_test.go
@@ -7581,6 +7581,112 @@ func TestPatchMessageEditReviewRequiredGroupModerated(t *testing.T) {
 	assert.Equal(t, 1, reviewRequired, "Group-moderated edit of approved message should set reviewrequired=1")
 }
 
+// TestPatchMessageTextEditResetsContentCheck: a message that has already passed the
+// automated content-check (contentcheck_checked_at stamped, e.g. because it was
+// approved) must be re-queued for a fresh check when the owner edits its textbody.
+// Without this, content added via an edit (worry words, phone numbers, banned
+// keywords, ...) is never scanned by ContentCheckService.processUnprocessed(),
+// which only picks up rows where contentcheck_checked_at IS NULL — so the automated
+// moderation filters silently skip edited content forever, and it can only be
+// caught by a mod noticing it manually.
+func TestPatchMessageTextEditResetsContentCheck(t *testing.T) {
+	prefix := uniquePrefix("msgedit_recheck_text")
+	db := database.DBConn
+
+	groupID := CreateTestGroup(t, prefix)
+	ownerID := CreateTestUser(t, prefix+"_owner", "User")
+	CreateTestMembership(t, ownerID, groupID, "Member")
+	_, ownerToken := CreateTestSession(t, ownerID)
+
+	msgID := createPendingMessage(t, ownerID, groupID, prefix)
+	db.Exec("UPDATE messages_groups SET collection = 'Approved', contentcheck_checked_at = NOW(), contentcheck_reasons = ? WHERE msgid = ? AND groupid = ?",
+		`[{"check":"Vague","detail":"stale reason from the original check"}]`, msgID, groupID)
+
+	var checkedAtSet bool
+	db.Raw("SELECT contentcheck_checked_at IS NOT NULL FROM messages_groups WHERE msgid = ? AND groupid = ?", msgID, groupID).Scan(&checkedAtSet)
+	require.True(t, checkedAtSet, "test setup: message should start already content-checked")
+
+	body := map[string]interface{}{
+		"id":       msgID,
+		"textbody": prefix + " edited body with newly added content",
+	}
+	bodyBytes, _ := json.Marshal(body)
+	req := httptest.NewRequest("PATCH", "/api/message?jwt="+ownerToken, bytes.NewBuffer(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := getApp().Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode, "Edit should succeed")
+
+	var checkedAtStillSet bool
+	var reasons *string
+	db.Raw("SELECT contentcheck_checked_at IS NOT NULL, contentcheck_reasons FROM messages_groups WHERE msgid = ? AND groupid = ?", msgID, groupID).
+		Row().Scan(&checkedAtStillSet, &reasons)
+	assert.False(t, checkedAtStillSet, "editing the textbody should clear contentcheck_checked_at so the batch job re-checks the new content")
+	assert.Nil(t, reasons, "stale contentcheck_reasons from the pre-edit check should be cleared too")
+}
+
+// TestPatchMessageSubjectEditResetsContentCheck mirrors the textbody case for the
+// subject field, which checkMessage() also scans (Vague/NotAnItem/SubjectRepeat).
+func TestPatchMessageSubjectEditResetsContentCheck(t *testing.T) {
+	prefix := uniquePrefix("msgedit_recheck_subj")
+	db := database.DBConn
+
+	groupID := CreateTestGroup(t, prefix)
+	ownerID := CreateTestUser(t, prefix+"_owner", "User")
+	CreateTestMembership(t, ownerID, groupID, "Member")
+	_, ownerToken := CreateTestSession(t, ownerID)
+
+	msgID := createPendingMessage(t, ownerID, groupID, prefix)
+	db.Exec("UPDATE messages_groups SET collection = 'Approved', contentcheck_checked_at = NOW() WHERE msgid = ? AND groupid = ?", msgID, groupID)
+
+	body := map[string]interface{}{
+		"id":      msgID,
+		"subject": prefix + " edited subject",
+	}
+	bodyBytes, _ := json.Marshal(body)
+	req := httptest.NewRequest("PATCH", "/api/message?jwt="+ownerToken, bytes.NewBuffer(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := getApp().Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode, "Edit should succeed")
+
+	var checkedAtStillSet bool
+	db.Raw("SELECT contentcheck_checked_at IS NOT NULL FROM messages_groups WHERE msgid = ? AND groupid = ?", msgID, groupID).Scan(&checkedAtStillSet)
+	assert.False(t, checkedAtStillSet, "editing the subject should clear contentcheck_checked_at so the batch job re-checks the new content")
+}
+
+// TestPatchMessageNonContentEditKeepsContentCheck: editing a field that
+// ContentCheckService::checkMessage() never inspects (availablenow) must NOT
+// discard the existing content-check stamp — only subject/textbody/item edits
+// should trigger a re-check.
+func TestPatchMessageNonContentEditKeepsContentCheck(t *testing.T) {
+	prefix := uniquePrefix("msgedit_recheck_noop")
+	db := database.DBConn
+
+	groupID := CreateTestGroup(t, prefix)
+	ownerID := CreateTestUser(t, prefix+"_owner", "User")
+	CreateTestMembership(t, ownerID, groupID, "Member")
+	_, ownerToken := CreateTestSession(t, ownerID)
+
+	msgID := createPendingMessage(t, ownerID, groupID, prefix)
+	db.Exec("UPDATE messages_groups SET collection = 'Approved', contentcheck_checked_at = NOW() WHERE msgid = ? AND groupid = ?", msgID, groupID)
+
+	body := map[string]interface{}{
+		"id":           msgID,
+		"availablenow": 1,
+	}
+	bodyBytes, _ := json.Marshal(body)
+	req := httptest.NewRequest("PATCH", "/api/message?jwt="+ownerToken, bytes.NewBuffer(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := getApp().Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode, "Edit should succeed")
+
+	var checkedAtStillSet bool
+	db.Raw("SELECT contentcheck_checked_at IS NOT NULL FROM messages_groups WHERE msgid = ? AND groupid = ?", msgID, groupID).Scan(&checkedAtStillSet)
+	assert.True(t, checkedAtStillSet, "a non-content edit should not discard the existing content-check stamp")
+}
+
 // --- tnpostid and expiresat tests ---
 
 func TestGetMessageTnpostid(t *testing.T) {


### PR DESCRIPTION
## Root Cause
`applyPatchMessageCore` (iznik-server-go/message/message.go) never reset `messages_groups.contentcheck_checked_at` when a message's subject, textbody, or item name was edited. `ContentCheckService::processUnprocessed()` (iznik-batch) only re-scans rows where that column `IS NULL`, so once a row had been content-checked (e.g. on initial approval), any content added later via an edit — including exactly the kind of content the concern-keyword / worry-word / phone-number / URL / vague-item filters exist to catch — was never scanned again by the automated pipeline. The only way it got caught was a moderator manually noticing the live post, which matches the reported symptom: "not caught by the automated moderation filters ... had to be manually flagged by another mod."

## Evidence
Failing test (before fix), reproducing the false negative — a message already stamped as content-checked keeps that stamp after a content-changing edit, so it is never re-queued for a check:

```
=== RUN   TestPatchMessageTextEditResetsContentCheck
    message_test.go:7471: Error: Should be false
        Messages: editing the textbody should clear contentcheck_checked_at so the batch job re-checks the new content
    message_test.go:7472: Error: Expected nil, but got: (*string)(0xc000041520)
        Messages: stale contentcheck_reasons from the pre-edit check should be cleared too
--- FAIL: TestPatchMessageTextEditResetsContentCheck (0.20s)
=== RUN   TestPatchMessageSubjectEditResetsContentCheck
    message_test.go:7502: Error: Should be false
        Messages: editing the subject should clear contentcheck_checked_at so the batch job re-checks the new content
--- FAIL: TestPatchMessageSubjectEditResetsContentCheck (0.28s)
=== RUN   TestPatchMessageNonContentEditKeepsContentCheck
--- PASS: TestPatchMessageNonContentEditKeepsContentCheck (0.10s)
FAIL
```

## Fix
When a PATCH to a message changes its subject, textbody, or item (the exact fields `ContentCheckService::checkMessage()` scans), clear `contentcheck_checked_at` and `contentcheck_reasons` on all of that message's `messages_groups` rows. This re-queues the message for the batch job's next pass, which for Pending posts is unbounded by age and for Approved posts covers edits within the existing 24h-from-arrival window — so the automated filters get a real chance to catch content introduced by an edit, instead of silently skipping it forever. Applies to both owner and mod edits (a mod's "fixed" edit should also be re-verified). Purely non-content edits (e.g. `availablenow`) are left untouched, so a message's existing check state isn't discarded unnecessarily.

## Other Call Sites
Grepped for other writers of `subject`/`textbody` on `messages`: `handleApproveEdits`/`handleRevertEdits` (mod approve/revert-edit actions) and the bulk-offer summary rebuild all funnel through `applyPatchMessageCore`, so they're covered. `handleRevertEdits` reverts content back to a prior (already-approved) version rather than introducing new content, so it's out of scope for this false-negative fix.

## Test
File: `iznik-server-go/test/message_test.go`
Added: `TestPatchMessageTextEditResetsContentCheck`, `TestPatchMessageSubjectEditResetsContentCheck` (AssertFlip — fail before the fix, pass after), plus `TestPatchMessageNonContentEditKeepsContentCheck` as a guard against over-resetting on unrelated field edits.
Command: `go test ./test/... -run 'TestPatchMessageTextEditResetsContentCheck|TestPatchMessageSubjectEditResetsContentCheck|TestPatchMessageNonContentEditKeepsContentCheck' -v`
Regression: ran the full `TestPatchMessage*`/`TestMessageEdit*`/`TestContentcheck*` suites (48 tests) — all pass.

## Discourse
https://discourse.ilovefreegle.org/t/9889/11