### PR TITLE
fix(moderation/content-checks): restore V1-parity 0.8 language-detection ratio

### DIFF
--- a/iznik-batch/app/Services/ContentCheckService.php
+++ b/iznik-batch/app/Services/ContentCheckService.php
@@ -1303,7 +1303,7 @@ class ContentCheckService
             $cyProb    = $lang['cy'] ?? 0;
             $ourProb   = max($enProb, $cyProb);
 
-            $isAcceptable = ($firstLang === 'en' || $firstLang === 'cy' || $ourProb >= 0.9 * $firstProb);
+            $isAcceptable = ($firstLang === 'en' || $firstLang === 'cy' || $ourProb >= 0.8 * $firstProb);
 
             if (!$isAcceptable) {
                 return [

--- a/iznik-batch/tests/Unit/Services/ContentCheckServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/ContentCheckServiceTest.php
@@ -579,6 +579,33 @@ class ContentCheckServiceTest extends TestCase
         $this->assertEquals(ContentCheckService::CHECK_LANGUAGE, $result['check']);
     }
 
+    public function test_check_language_real_world_structured_english_offer_not_flagged_as_french(): void
+    {
+        // Regression (Discourse #9919): production posts written as short,
+        // disjointed lines (typical of Freegle offer listings) lack the
+        // connecting words ("the", "is", "and") that signal English to the
+        // n-gram detector, so the real library ranks French marginally top
+        // (ratio ~0.86) even though the text is plainly English. Modelled on
+        // production msgid 121034104, which was live-flagged as French by
+        // this exact check. The V1-parity 0.8 ratio rescues it; the 0.9
+        // threshold introduced in 38ac48764 does not. Uses the REAL detector.
+        $text = "Ladies trousers\nWide leg\n4 pairs\nSize 14\n\nCollection Times:\nASAP\nPlease state a 15 minute time window";
+        $this->assertGreaterThan(80, strlen($text));
+        $result = $this->service->checkLanguage('', $text);
+        $this->assertNull($result, 'Structured English offer text must not be flagged as French');
+    }
+
+    public function test_check_language_genuine_french_still_flagged_at_v1_threshold(): void
+    {
+        // Genuinely French text must still be flagged after restoring the
+        // V1-parity 0.8 ratio — the #9919 fix must not be a blanket disable
+        // of the language check. Uses the REAL detector (not a mock).
+        $text = 'Bonjour, je vends plusieurs meubles de maison en tres bon etat, disponible immediatement pour recuperation, merci de me contacter rapidement.';
+        $result = $this->service->checkLanguage('', $text);
+        $this->assertNotNull($result, 'Genuine French text must still be flagged');
+        $this->assertEquals(ContentCheckService::CHECK_LANGUAGE, $result['check']);
+    }
+
     // =========================================================================
     // isGroupModerated — needs DB
     // =========================================================================


### PR DESCRIPTION
## Root Cause
`ContentCheckService::checkLanguage()` accepts a post as English/Welsh when it is the top-ranked language by the `patrickschur/language-detection` library, or when `P(en|cy) >= threshold * P(top language)`. That threshold was tightened from 0.8 to 0.9 in commit `38ac48764` to catch one ambiguous French test case, but the function's own doc comment still documents 0.8 as "the same lax threshold V1 uses" — the code and its own comment had drifted apart. The sibling email-ingestion path, `SpamCheckService::checkLanguage()`, was never changed and still uses 0.8.

At 0.9, short, disjointed, list-style text typical of real Freegle offer posts (item name / condition / collection-time lines with no connecting words like "the"/"is"/"and") scores weakly for English in the n-gram model, letting other Latin-alphabet languages (French, Dutch, Norwegian, German) edge marginally ahead even though the text is plainly English. The 0.9 ratio was too strict to rescue these.

Confirmed against production data (read-only): in the ~45 days since the language-set restriction landed (2026-06-03), **every** message flagged by this check (11 messages, languages fr/nl/nb/de) was genuine English — a 100% false-positive rate. Example (production msgid 121034104): "Ladies trousers / Wide leg / 4 pairs / Size 14 / Collection Times: / ASAP / Please state a 15 minute time window" was flagged as French.

## Evidence
Failing test before the fix (`test_check_language_real_world_structured_english_offer_not_flagged_as_french`, run against the unmodified code):
```
1) Tests\Unit\Services\ContentCheckServiceTest::test_check_language_real_world_structured_english_offer_not_flagged_as_french
Structured English offer text must not be flagged as French
Failed asserting that an array is null.
```
(Reproduced directly against the real detector library: the sample scores `fr=0.447, en=0.383`, ratio `0.856` — below the buggy 0.9 threshold, above the restored 0.8 one.)

## Fix
Changed the single ratio constant in `checkLanguage()` from `0.9` back to `0.8`, matching the function's own doc comment and the sibling `SpamCheckService` implementation. This is not a blanket disable: genuinely non-English text (French, Spanish, Polish, Romanian samples, and a new `test_check_language_genuine_french_still_flagged_at_v1_threshold` test using the real detector) is still flagged — all score well below 0.8 in practice.

## Other Call Sites
```
$ grep -rl "firstProb\|ourProb\|LanguageDetection" --include=*.php .
iznik-batch/app/Services/ContentCheckService.php   (fixed here)
iznik-batch/app/Services/Mail/Incoming/SpamCheckService.php   (already 0.8 — no change needed)
```

## Test
- File: `iznik-batch/tests/Unit/Services/ContentCheckServiceTest.php`
- Added `test_check_language_real_world_structured_english_offer_not_flagged_as_french` (modelled on live production msgid 121034104) and `test_check_language_genuine_french_still_flagged_at_v1_threshold`, both using the real detector library.
- Verified against the actual (unmodified vs. fixed) source file directly: buggy code flags the English sample as French; fixed code does not, and still flags genuine French.
- Verified no regression: re-ran every existing `checkLanguage`-related test text (English/Spanish/xxx-stripped/restricted-set samples) against the fixed code — all preserve their existing expected outcome.
- Could not run the full Laravel suite locally via the status container in this session (Docker's network address-pool was exhausted by many concurrent parallel worktree environments already running in this shared dev host); relying on CircleCI to run the full suite for final regression confirmation.

## Discourse
https://discourse.ilovefreegle.org/t/9919/1