### PR TITLE
fix(email/admin-mail): tracking pixel breaks Outlook rendering (blank on reopen)

### DIFF
--- a/iznik-batch/resources/views/emails/mjml/admin/admin.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/admin/admin.blade.php
@@ -82,7 +82,11 @@
         @include('emails.mjml.partials.footer', ['email' => $user->email_preferred, 'settingsUrl' => $settingsUrl])
 
         @if(isset($trackingPixelMjml))
-        {!! $trackingPixelMjml !!}
+        <mj-section padding="0">
+            <mj-column>
+                {!! $trackingPixelMjml !!}
+            </mj-column>
+        </mj-section>
         @endif
     </mj-body>
 </mjml>

--- a/iznik-batch/resources/views/emails/mjml/digest/unified.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/digest/unified.blade.php
@@ -426,7 +426,11 @@
         @include('emails.mjml.partials.footer', ['email' => $user->email_preferred, 'settingsUrl' => $settingsUrl])
 
         @if(isset($trackingPixelMjml))
-        {!! $trackingPixelMjml !!}
+        <mj-section padding="0">
+            <mj-column>
+                {!! $trackingPixelMjml !!}
+            </mj-column>
+        </mj-section>
         @endif
 
         @endif

--- a/iznik-batch/tests/Unit/Mail/AdminMailTest.php
+++ b/iznik-batch/tests/Unit/Mail/AdminMailTest.php
@@ -254,4 +254,40 @@ class AdminMailTest extends TestCase
         $this->assertStringContainsString('3 days', $html,
             'Preheader must state how long the admin has been pending');
     }
+
+    public function test_admin_mail_tracking_pixel_is_wrapped_in_section_and_column(): void
+    {
+        // A bare <mj-image> as a direct child of <mj-body> violates the MJML
+        // schema (mj-image must live inside mj-column > mj-section). mrml
+        // renders that malformed nesting without the Outlook-conditional
+        // wrapper table every other section gets, which is what left the
+        // reported admin email blank on reopen in Outlook (topic 9925). Every
+        // other mailable (welcome, chase, digest siblings, etc.) wraps its
+        // tracking pixel in its own <mj-section padding="0"><mj-column> - this
+        // pins admin.blade.php to the same pattern.
+        $pixel = '<mj-image src="https://example.com/pixel.png" width="1px" height="1px" alt="" padding="0" />';
+
+        $html = view('emails.mjml.admin.admin', [
+            'user' => (object) ['email_preferred' => 'test@example.com', 'displayname' => 'Test User'],
+            'userSite' => config('freegle.sites.user'),
+            'adminSubject' => 'Test Subject',
+            'adminText' => 'Test body text',
+            'ctaLink' => null,
+            'ctaText' => null,
+            'groupName' => 'Test Group',
+            'modsEmail' => null,
+            'essential' => true,
+            'settingsUrl' => 'https://www.ilovefreegle.org/settings',
+            'marketingOptOutUrl' => null,
+            'unsubscribeUrl' => 'https://www.ilovefreegle.org/unsubscribe',
+            'volunteers' => [],
+            'trackingPixelMjml' => $pixel,
+        ])->render();
+
+        $this->assertMatchesRegularExpression(
+            '#<mj-section[^>]*>\s*<mj-column>\s*'.preg_quote($pixel, '#').'\s*</mj-column>\s*</mj-section>#',
+            $html,
+            'Tracking pixel must be wrapped in its own mj-section/mj-column, not a bare mj-body child.'
+        );
+    }
 }


### PR DESCRIPTION
## Root Cause
`admin.blade.php`'s tracking pixel was appended as a bare `<mj-image>` directly under `<mj-body>` instead of being wrapped in `<mj-section><mj-column>`. This violates MJML's schema (an `mj-image` must live inside `mj-column` > `mj-section`). The in-process `mrml` compiler renders that malformed nesting without the Outlook-conditional (`<!--[if mso | IE]>`) wrapper table that every other section in the email gets, leaving the compiled HTML without the well-formed structure Outlook's Word rendering engine needs — matching the reporter's admin email going blank on reopen in Outlook.

Confirmed by rendering the real Blade view: every properly-nested section produces a `<!--[if mso | IE]><table ... bgcolor=... width="600">...` wrapper plus a `max-width:600px` centred `<div>`; the pixel's `<table>` at the very end of `<body>` has neither.

## Evidence
Failing test before the fix (`tests/Unit/Mail/AdminMailTest.php::test_admin_mail_tracking_pixel_is_wrapped_in_section_and_column`), reverted temporarily to prove it catches the bug:

```
1) Tests\Unit\Mail\AdminMailTest::test_admin_mail_tracking_pixel_is_wrapped_in_section_and_column
Failed asserting that '...<mj-image src="https://example.com/pixel.png" .../>\n            </mj-body>\n</mjml>\n' matches PCRE pattern
"#<mj-section[^>]*>\s*<mj-column>\s*<mj\-image src\="https\://example\.com/pixel\.png" .../>\s*</mj-column>\s*</mj-section>#".

  at tests/Unit/Mail/AdminMailTest.php:287
  Tests: 1 failed (1 assertions)
```

After the fix, the same test passes.

## Fix
Wrapped the tracking pixel include in both affected templates in `<mj-section padding="0"><mj-column>...</mj-column></mj-section>` — the exact same pattern already used correctly by 13 other mailables (welcome, admin/chase, digest siblings, donation, session).

## Other Call Sites
Grepped every `{!! $trackingPixelMjml !!}` usage. Two templates had the bug:
- `resources/views/emails/mjml/admin/admin.blade.php` (this report — topic 9925)
- `resources/views/emails/mjml/digest/unified.blade.php` (Daily Unified Digest — same literal defect, fixed in this PR since it's the identical root cause)

13 other templates (`welcome/welcome.blade.php`, `admin/chase.blade.php`, `message/{chaseup,autorepost-warning,deadline-reached,chaseup-promised,mod-std-message}.blade.php`, `donation/{giftaid-chaseup,thank-you,ask}.blade.php`, `session/{merge-offer,forgot-password,verify-email}.blade.php`) already wrap it correctly — no changes needed there.

## Test
- File: `iznik-batch/tests/Unit/Mail/AdminMailTest.php::test_admin_mail_tracking_pixel_is_wrapped_in_section_and_column`
- Command: `php artisan test --filter=test_admin_mail_tracking_pixel_is_wrapped_in_section_and_column`
- Proves fail-before/pass-after: confirmed by reverting the blade fix, re-running (fails, output above), restoring the fix, re-running (passes).
- Regression check: ran `AdminMailTest`, `SendAdminCommandTest`, `UnifiedDigestTest`, `UnifiedDigestSummaryTest`, `UnifiedDigestRetryTest`, `EmailDeliveryIntegrationTest` together — 107 passed, 0 failed (6 integration tests gracefully skipped, no Mailpit in this isolated test environment).

## Discourse
https://discourse.ilovefreegle.org/t/9925/1