### PR TITLE
fix(moderation): ELD language detector — stop false 'foreign language' flags (9919, supersedes #1103)

### DIFF
--- a/iznik-batch/app/Services/ContentCheckService.php
+++ b/iznik-batch/app/Services/ContentCheckService.php
@@ -7,7 +7,7 @@ use App\Models\Message;
 use App\Models\MessageGroup;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
-use LanguageDetection\Language;
+use Nitotm\Eld\LanguageDetector;
 
 class ContentCheckService
 {
@@ -1267,50 +1267,46 @@ class ContentCheckService
     }
 
     // -------------------------------------------------------------------------
-    // Language detection — flag non-English/Welsh messages over 50 chars
-    // (V1 Spam.php parity using patrickschur/language-detection).
-    // English is accepted if it is the top language, or if P(en|cy) >= 0.8 *
-    // P(top language) — the same lax threshold V1 uses (Spam.php line 413).
-    // The optional $detector callable accepts the lowercased text and returns
-    // an array of language => probability; used in tests for deterministic results.
+    // Language detection — flag a message as non-English/Welsh ONLY when the
+    // detector is confident. Uses nitotm/efficient-language-detector (ELD): it
+    // picks the correct top language on short, list-style Freegle posts where the
+    // old trigram library (patrickschur) mis-ranked plain English as a Latinate
+    // language (Discourse #9919, #9481), and its isReliable() lets us leave
+    // genuinely ambiguous short text alone rather than false-flagging it.
+    // The optional $detector callable returns ['lang' => code, 'reliable' => bool];
+    // used in tests for deterministic results.
     // -------------------------------------------------------------------------
 
     public function checkLanguage(string $subject, string $textbody, ?callable $detector = null): ?array
     {
-        $text = trim(str_ireplace('xxx', '', strtolower($textbody)));
+        $text = trim(str_ireplace('xxx', '', $textbody));
 
-        // Skip text too short for reliable language detection. The detector is a
-        // coin-flip below ~80 chars (it mis-ranks terse English replies like
-        // "Yes please can collect. … Possible collection times: Asap"), and such
-        // short replies carry little spam risk, so checking them only generates
-        // false "not English" flags (Discourse #9481). V1 used 50; raised to 80.
+        // Skip very short text — low spam risk and inherently ambiguous for any
+        // language detector, so checking it only generates false flags (#9481).
         if (strlen($text) <= 80) {
             return null;
         }
 
         try {
-            $detect = $detector ?? static fn(string $t) => (new Language(self::LANGUAGE_DETECT_SET))->detect($t)->close();
-            $lang   = $detect($text);
+            $detect = $detector ?? static function (string $t): array {
+                static $eld = null;
+                $eld ??= new LanguageDetector();
+                $res = $eld->detect($t);
 
-            if (empty($lang)) {
-                return null;
-            }
+                return ['lang' => $res->language, 'reliable' => $res->isReliable()];
+            };
+            $result   = $detect($text);
+            $lang     = $result['lang'] ?? '';
+            $reliable = (bool) ($result['reliable'] ?? false);
 
-            reset($lang);
-            $firstLang = key($lang);
-            $firstProb = $lang[$firstLang] ?? 0;
-            $enProb    = $lang['en'] ?? 0;
-            $cyProb    = $lang['cy'] ?? 0;
-            $ourProb   = max($enProb, $cyProb);
-
-            $isAcceptable = ($firstLang === 'en' || $firstLang === 'cy' || $ourProb >= 0.9 * $firstProb);
-
-            if (!$isAcceptable) {
+            // Flag only when the detector is confident the text is neither English
+            // nor Welsh. Ambiguous text (isReliable() === false) is never flagged.
+            if ($lang !== '' && $lang !== 'en' && $lang !== 'cy' && $reliable) {
                 return [
                     'check'    => self::CHECK_LANGUAGE,
                     'category' => null,
                     'action'   => 'flag',
-                    'detail'   => "Post appears to be in language '{$firstLang}' rather than English or Welsh",
+                    'detail'   => "Post appears to be in language '{$lang}' rather than English or Welsh",
                 ];
             }
         } catch (\Exception $e) {

--- a/iznik-batch/app/Services/Mail/Incoming/SpamCheckService.php
+++ b/iznik-batch/app/Services/Mail/Incoming/SpamCheckService.php
@@ -812,30 +812,21 @@ class SpamCheckService
         }
 
         try {
-            if (! class_exists(\LanguageDetection\Language::class)) {
+            if (! class_exists(\Nitotm\Eld\LanguageDetector::class)) {
                 return null;
             }
 
-            $ld = new \LanguageDetection\Language;
-            $lang = $ld->detect($message)->close();
+            static $eld = null;
+            $eld ??= new \Nitotm\Eld\LanguageDetector();
+            $res = $eld->detect($message);
 
-            if (empty($lang)) {
-                return null;
+            // Flag only when confident the text is neither English nor Welsh; ELD's
+            // isReliable() leaves short/ambiguous text alone (Discourse #9919).
+            if ($res->language !== 'en' && $res->language !== 'cy' && $res->isReliable()) {
+                return self::REASON_LANGUAGE;
             }
 
-            reset($lang);
-            $firstLang = key($lang);
-            $firstProb = $lang[$firstLang] ?? 0;
-            $enProb = $lang['en'] ?? 0;
-            $cyProb = $lang['cy'] ?? 0;
-            $ourProb = max($enProb, $cyProb);
-
-            // Accept if English/Welsh is first, or our probability is >= 80% of the top language
-            if ($firstLang === 'en' || $firstLang === 'cy' || $ourProb >= 0.8 * $firstProb) {
-                return null;
-            }
-
-            return self::REASON_LANGUAGE;
+            return null;
         } catch (\Exception $e) {
             Log::debug('Language detection failed', ['error' => $e->getMessage()]);
 

--- a/iznik-batch/composer.json
+++ b/iznik-batch/composer.json
@@ -14,7 +14,7 @@
         "laravel/framework": "^12.0",
         "laravel/tinker": "^2.10.1",
         "owen-it/laravel-auditing": "^14.0",
-        "patrickschur/language-detection": "^5.2",
+        "nitotm/efficient-language-detector": "^3.2",
         "phpoffice/phpspreadsheet": "^3",
         "sentry/sentry-laravel": "^4.20",
         "simple-as-fuck/laravel-lock": "^0.4.0",

--- a/iznik-batch/composer.lock
+++ b/iznik-batch/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2367e1e318ad0eefc81635b5d5beecc7",
+    "content-hash": "2b6de5684d481428d4c3eabeb0f5c308",
     "packages": [
         {
             "name": "beste/clock",
@@ -4303,6 +4303,76 @@
             "time": "2025-12-06T11:56:16+00:00"
         },
         {
+            "name": "nitotm/efficient-language-detector",
+            "version": "v3.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nitotm/efficient-language-detector.git",
+                "reference": "3fbf88632dfa090960f73259305a6d104d649ddc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nitotm/efficient-language-detector/zipball/3fbf88632dfa090960f73259305a6d104d649ddc",
+                "reference": "3fbf88632dfa090960f73259305a6d104d649ddc",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": "^7.4 || ^8.0"
+            },
+            "bin": [
+                "bin/eld",
+                "bin/eld-php"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Nitotm\\Eld\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Nito T.M.",
+                    "homepage": "https://github.com/nitotm"
+                }
+            ],
+            "description": "Fast and accurate natural language detection. Detector written in PHP. Nito-ELD, ELD.",
+            "homepage": "https://github.com/nitotm/efficient-language-detector",
+            "keywords": [
+                "detection",
+                "detector",
+                "language",
+                "language classification",
+                "language detection",
+                "language detector",
+                "language identification",
+                "language recognition"
+            ],
+            "support": {
+                "issues": "https://github.com/nitotm/efficient-language-detector/issues",
+                "source": "https://github.com/nitotm/efficient-language-detector/tree/v3.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://linktr.ee/nitotm",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/nitotm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://ko-fi.com/nitotm",
+                    "type": "ko_fi"
+                }
+            ],
+            "time": "2026-03-20T21:53:25+00:00"
+        },
+        {
             "name": "nunomaduro/termwind",
             "version": "v2.3.3",
             "source": {
@@ -4550,57 +4620,6 @@
                 "source": "https://github.com/owen-it/laravel-auditing"
             },
             "time": "2026-03-27T13:27:17+00:00"
-        },
-        {
-            "name": "patrickschur/language-detection",
-            "version": "v5.3.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/patrickschur/language-detection.git",
-                "reference": "df8d32021b2ef9fde52e6fcccb83e3806822c9c6"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/patrickschur/language-detection/zipball/df8d32021b2ef9fde52e6fcccb83e3806822c9c6",
-                "reference": "df8d32021b2ef9fde52e6fcccb83e3806822c9c6",
-                "shasum": ""
-            },
-            "require": {
-                "ext-json": "*",
-                "ext-mbstring": "*",
-                "php": "^7.4 || ^8.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.5.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "LanguageDetection\\": "src/LanguageDetection"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Patrick Schur",
-                    "email": "patrick_schur@outlook.de"
-                }
-            ],
-            "description": "A language detection library for PHP. Detects the language from a given text string.",
-            "homepage": "https://github.com/patrickschur/language-detection",
-            "keywords": [
-                "detect",
-                "detection",
-                "language"
-            ],
-            "support": {
-                "issues": "https://github.com/patrickschur/language-detection/issues",
-                "source": "https://github.com/patrickschur/language-detection/tree/v5.3.1"
-            },
-            "time": "2025-03-25T22:47:08+00:00"
         },
         {
             "name": "php-di/invoker",

--- a/iznik-batch/tests/Feature/Message/ContentCheckTest.php
+++ b/iznik-batch/tests/Feature/Message/ContentCheckTest.php
@@ -2009,11 +2009,10 @@ class ContentCheckTest extends TestCase
 
     public function test_french_message_returns_reason(): void
     {
-        // Inject deterministic French scores (en/fr = 0.30 — well below the 0.8 V1 threshold).
-        // At 0.8: en(0.21) >= 0.8*fr(0.70)=0.56 → false → flagged correctly.
-        // Using injection because the real library returns borderline probabilities for
-        // mixed-cognate French text, making the live-library assertion threshold-dependent.
-        $frenchDetector = static fn(string $text) => ['fr' => 0.70, 'en' => 0.21];
+        // Inject a deterministic confident-French detector result. Using injection
+        // because the real ELD library's reliability on borderline mixed-cognate
+        // French text makes a live-library assertion threshold-dependent.
+        $frenchDetector = static fn(string $text) => ['lang' => 'fr', 'reliable' => true];
         $text = 'Bonjour, je donne une belle table en chêne massif en très bon état. Venez la chercher dans le quartier.';
 
         $result = $this->service->checkLanguage('OFFER: Table', $text, $frenchDetector);

--- a/iznik-batch/tests/Unit/Services/ContentCheckServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/ContentCheckServiceTest.php
@@ -591,9 +591,8 @@ class ContentCheckServiceTest extends TestCase
 
     public function test_clearly_non_english_still_flagged_with_v1_threshold(): void
     {
-        // A message where the top language is far above the English probability
-        // (ratio 0.3, well below both 0.8 and 0.9) must still be flagged.
-        $nonEnglishDetector = static fn(string $text) => ['fr' => 0.70, 'en' => 0.21];
+        // A message the detector confidently identifies as French must still be flagged.
+        $nonEnglishDetector = static fn(string $text) => ['lang' => 'fr', 'reliable' => true];
         $text = 'Hi, is the sofa still available? I can collect on Saturday morning if that works for you. Thanks.';
         $result = $this->service->checkLanguage('', $text, $nonEnglishDetector);
         $this->assertNotNull($result);

--- a/iznik-batch/tests/Unit/Services/ContentCheckServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/ContentCheckServiceTest.php
@@ -548,11 +548,32 @@ class ContentCheckServiceTest extends TestCase
 
     public function test_check_language_flagged_for_non_english(): void
     {
-        // Clear Spanish — well over 50 chars, will be detected as non-English
+        // Clear Spanish, well over 80 chars — ELD is confident, so it must flag.
         $text = 'Tengo un sofá que ya no necesito. Está en buenas condiciones y se puede recoger en cualquier momento del día. Contacta conmigo si estás interesado.';
         $result = $this->service->checkLanguage('', $text);
-        // Language detection may or may not flag this; we assert the return type is correct
-        $this->assertTrue($result === null || $result['check'] === ContentCheckService::CHECK_LANGUAGE);
+        $this->assertNotNull($result, 'Confident Spanish must be flagged');
+        $this->assertSame(ContentCheckService::CHECK_LANGUAGE, $result['check']);
+    }
+
+    public function test_check_language_terse_list_style_english_not_flagged(): void
+    {
+        // Regression (Discourse #9919): a plainly-English offer that is all English
+        // words, numbers and standard abbreviations. The old trigram library ranked
+        // this as a Latinate language and false-flagged it; ELD picks English. Real detector.
+        $text = 'Fridge freezer Beko W60 H180 good working order free to collect only from HA8 mon to fri evenings please, first to reply gets it.';
+        $this->assertGreaterThan(80, strlen($text));
+        $result = $this->service->checkLanguage('', $text);
+        $this->assertNull($result, 'All-English-words offer must not be flagged as foreign (#9919)');
+    }
+
+    public function test_check_language_french_offer_flagged(): void
+    {
+        // A genuinely French offer that the old 0.8 ratio let through as a false
+        // negative — ELD detects it confidently. Real detector.
+        $text = 'Bonjour, je donne un canapé en bon état, à récupérer rapidement chez moi cette semaine, merci beaucoup et bonne journée à tous.';
+        $result = $this->service->checkLanguage('', $text);
+        $this->assertNotNull($result, 'Confident French must be flagged');
+        $this->assertSame(ContentCheckService::CHECK_LANGUAGE, $result['check']);
     }
 
     public function test_check_language_text_below_80_chars_skipped(): void


### PR DESCRIPTION
Fixes the false "foreign language" flag reported in [/t/9919](https://discourse.ilovefreegle.org/t/foreign-langauge/9919) (a post of all English words + numbers + standard abbreviations flagged as French). **Supersedes #1103.**

## Why the old detector is wrong (not just mistuned)

`patrickschur/language-detection` is a **character-trigram** model — it compares character-frequency profiles, it has no concept of English *words*. On short, list-style Freegle posts that fails both ways, confirmed by running the real detector in `freegle-batch`:

- A terse English offer ("Kids bike age 5 7 vgc some rust rides fine collect tues pm Hackney E8") ranked **Norwegian #1**, English second by a hair — one nudge from a false flag.
- A genuine French offer ranked English at **92.8%** of French, so it **evaded the flag at both 0.9 and 0.8**.

So #1103's ratio tweak (0.9→0.8) just slides a see-saw: fewer English false-positives at the cost of more foreign false-negatives. It can't fix a word-blind detector.

## The fix

Swap both detection paths (`ContentCheckService::checkLanguage` and `Mail/Incoming/SpamCheckService::checkLanguage`) to **`nitotm/efficient-language-detector` (ELD)** — a modern, native-PHP detector (no sidecar, no extension). It picks the correct top language on short text and exposes **`isReliable()`**, so the rule becomes clean:

> flag as foreign only when the top language is not `en`/`cy` **and** the result is `isReliable()`.

Ambiguous short text is marked unreliable and left alone.

## Evidence (real detector, same posts)

| post | patrickschur | ELD |
|---|---|---|
| terse English offers (#9919 class) | ranked Norwegian / near-miss | top = en ✓ (not flagged) |
| French offer (that 0.8 let through) | en at 92.8% → missed | top = fr, reliable → flagged ✓ |
| Dutch / German / Spanish | flagged | flagged ✓ |

**0 false-positives, 0 false-negatives** on the failing set. Regression tests added for the all-English offer (must pass) and a French offer (must flag).

## Notes

- `patrickschur/language-detection` removed from `composer.json`/`composer.lock`; ELD v3.2 added.
- Verified `php -l` and ran the exact test texts through ELD in `freegle-batch`; the full PHPUnit run is on CI (needs the new dep installed).
- A longer-term option (not needed here) is a Lingua/fastText sidecar for best-in-class short-text ID; ELD clears our actual failure cases natively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQZ56NwFYEuhrtaoU7oYoM
