### PR TITLE
feat(browse): pin the viewer's own recent posts to the top of every sort order (9933)

### DIFF
--- a/docs/developers/reference/rippling-algorithm.md
+++ b/docs/developers/reference/rippling-algorithm.md
@@ -223,6 +223,14 @@ retracted, so re-approval restores the copy without re-rippling.
   distance of it - the author-side cap in `isochrone/message.go`'s `authorReachCapWhere` and
   the digest's `DistancePreferenceFilter::passesBothPreferences`).
 
+  **The viewer's own posts always come first.** A member's own open posts are included in the
+  feed regardless of reach (`isochrone/message.go` own-posts arm) and flagged with `mine`
+  (`MessageSummary.Mine`, set when `messages.fromuser` = the viewer). The client
+  (`composables/useMessageSort.js`) floats `mine` posts to the top of *every* sort order (New
+  to you / Newest / Closest), newest-first, just below any paid pinned clearance. Without this,
+  members lost their own posts among the reach-ordered feed and assumed they were not showing
+  (Discourse 9933).
+
   The containment test itself is served through **sandwich bounds**
   (plans/2026-07-17-db3-cpu-reach-sql-prefilter.md): the exact polygons are grid-fill
   isochrones averaging ~11k vertices / 178 KB, so the hot queries first consult two small

--- a/iznik-nuxt3/composables/useMessageSort.js
+++ b/iznik-nuxt3/composables/useMessageSort.js
@@ -8,6 +8,10 @@
 //   messages     - array of feed summary objects
 //   selectedSort - 'Unseen' | 'Nearby' | anything else (treated as Newest-first)
 //
+// Whatever the sort, a paid pinned clearance (m.pinned) leads the feed and then the viewer's
+// own recent posts (m.mine, flagged by the server) come next, newest-first, so members can
+// always find their own posts instead of losing them in the reach order (Discourse 9933).
+//
 // Returns a NEW array; the input is not mutated (matches the old messages.slice()).
 export function sortBrowseMessages(messages, selectedSort) {
   const list = messages || []
@@ -40,10 +44,13 @@ export function sortBrowseMessages(messages, selectedSort) {
     return new Date(m.arrival).getTime()
   }
 
+  // The viewer's own posts pin to the top (below), newest-first, so compute their timestamp
+  // even in 'Unseen' mode (which otherwise skips recency) - otherwise own posts would tie and
+  // fall back to arbitrary DB order rather than most-recent-first.
   const decorated = list.map((m) => ({
     m,
     dist: isNearby && Number.isFinite(m.distance) ? m.distance : Infinity,
-    ts: needsRecency ? recencyTs(m) : 0,
+    ts: needsRecency || m.mine ? recencyTs(m) : 0,
   }))
 
   decorated.sort((a, b) => {
@@ -54,6 +61,18 @@ export function sortBrowseMessages(messages, selectedSort) {
     const bpin = b.m.pinned ? 1 : 0
     if (apin !== bpin) {
       return bpin - apin
+    }
+    // The viewer's own recent posts pin to the top of EVERY sort order (New to you / Newest /
+    // Closest), just below any paid pinned clearance - members otherwise lose track of their
+    // own posts in the reach-ordered feed and assume they aren't showing (Discourse 9933). The
+    // server flags them via `mine`. Among the member's own posts, show the most recent first.
+    const amine = a.m.mine ? 1 : 0
+    const bmine = b.m.mine ? 1 : 0
+    if (amine !== bmine) {
+      return bmine - amine
+    }
+    if (amine && bmine) {
+      return b.ts - a.ts
     }
     if (selectedSort === 'Unseen') {
       // Unseen first, then by descending rippling relevance score. Successful posts are

--- a/iznik-nuxt3/tests/unit/composables/useMessageSort.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useMessageSort.spec.js
@@ -254,4 +254,51 @@ describe('sortBrowseMessages', () => {
       expect(order(msgs, 'Unseen')).toEqual([2, 1, 3])
     })
   })
+
+  // Discourse 9933: members could not find their own posts in the reach-ordered feed and
+  // assumed they were not showing. The viewer's own posts (m.mine, flagged by the server)
+  // pin to the top of every sort order, just below any paid pinned clearance, newest-first.
+  describe('own posts (mine)', () => {
+    it('floats the viewer own post to the top under Unseen, ahead of an unseen higher score', () => {
+      const msgs = [
+        { id: 1, unseen: true, score: 9 },
+        { id: 2, unseen: false, score: 0, mine: true, posted: '2024-05-01T00:00:00Z' },
+      ]
+      // Own post leads even though it is seen and scores 0.
+      expect(order(msgs, 'Unseen')).toEqual([2, 1])
+    })
+
+    it('keeps the viewer own post first under Newest, ahead of a newer non-own post', () => {
+      const msgs = [
+        { id: 'newer', posted: '2024-06-01T00:00:00Z' },
+        { id: 'mineOlder', posted: '2024-01-01T00:00:00Z', mine: true },
+      ]
+      expect(order(msgs, 'Newest')).toEqual(['mineOlder', 'newer'])
+    })
+
+    it('keeps the viewer own post first under Nearby, ahead of a nearer non-own post', () => {
+      const msgs = [
+        { id: 'near', distance: 0.5 },
+        { id: 'mineFar', distance: 50, mine: true, posted: '2024-01-01T00:00:00Z' },
+      ]
+      expect(order(msgs, 'Nearby')).toEqual(['mineFar', 'near'])
+    })
+
+    it('orders multiple own posts newest-first among themselves, ignoring score', () => {
+      const msgs = [
+        { id: 'mineOld', mine: true, posted: '2024-01-01T00:00:00Z', unseen: true, score: 9 },
+        { id: 'mineNew', mine: true, posted: '2024-06-01T00:00:00Z', unseen: true, score: 1 },
+        { id: 'other', unseen: true, score: 5 },
+      ]
+      expect(order(msgs, 'Unseen')).toEqual(['mineNew', 'mineOld', 'other'])
+    })
+
+    it('keeps a paid pinned clearance above the viewer own post', () => {
+      const msgs = [
+        { id: 'mine', mine: true, posted: '2024-06-01T00:00:00Z' },
+        { id: 'paid', pinned: true, posted: '2024-01-01T00:00:00Z' },
+      ]
+      expect(order(msgs, 'Newest')).toEqual(['paid', 'mine'])
+    })
+  })
 })

--- a/iznik-server-go/isochrone/message.go
+++ b/iznik-server-go/isochrone/message.go
@@ -57,6 +57,10 @@ type reachCandidateRow struct {
 	Promised   bool    `gorm:"column:promised"`
 	Groupid    uint64  `gorm:"column:groupid"`
 	Type       string  `gorm:"column:type"`
+	// Fromuser is the post's author (messages.fromuser). When it equals the viewer, the
+	// post is flagged as theirs (MessageSummary.Mine) so the client can pin the viewer's
+	// own recent posts to the top of every browse sort order (Discourse 9933).
+	Fromuser uint64 `gorm:"column:fromuser"`
 	// Arrival is the messages_spatial arrival, which the reach engine bumps
 	// forward each time the post ripples into a new group — so it tracks "when
 	// did this most recently expand", NOT the original post time. It feeds the
@@ -105,7 +109,7 @@ func (r reachCandidateRow) blurredDistanceMiles(viewerLat, viewerLng float64) (b
 // blurred lat/lng already allow. distanceMiles (Distance) and the metres
 // figure fed into Score are the same underlying measurement, just converted,
 // so the client's distance slider and the server's ordering agree.
-func (r reachCandidateRow) toSummary(viewerLat, viewerLng float64, w ScoreWeights, env ScoreEnv) message.MessageSummary {
+func (r reachCandidateRow) toSummary(viewerLat, viewerLng float64, w ScoreWeights, env ScoreEnv, myid uint64) message.MessageSummary {
 	blurLat, blurLng, distanceMiles := r.blurredDistanceMiles(viewerLat, viewerLng)
 	distanceMetres := distanceMiles * milesToMetres
 
@@ -134,6 +138,7 @@ func (r reachCandidateRow) toSummary(viewerLat, viewerLng float64, w ScoreWeight
 		Unseen:     r.Unseen,
 		Distance:   distanceMiles,
 		Score:      comps.Total,
+		Mine:       r.Fromuser != 0 && r.Fromuser == myid,
 	}
 }
 
@@ -171,7 +176,7 @@ func fetchReachCandidates(db *gorm.DB, myid uint64, latlng utils.LatLng, unseenO
 	db.Raw(
 		"SELECT ST_Y(ms.point) AS lat, ST_X(ms.point) AS lng, "+
 			"ms.msgid AS id, ms.successful, ms.promised, ms.groupid, "+
-			"ms.msgtype AS type, ms.arrival, m.arrival AS posted, "+
+			"ms.msgtype AS type, m.fromuser AS fromuser, ms.arrival, m.arrival AS posted, "+
 			"CASE WHEN ml.msgid IS NULL THEN 1 ELSE 0 END AS unseen, "+
 			"COALESCE((SELECT SUM(mlv.count) FROM messages_likes mlv WHERE mlv.msgid = ms.msgid AND mlv.type = ?), 0) AS views, "+
 			"(SELECT COUNT(*) FROM chat_messages cm WHERE cm.refmsgid = ms.msgid AND cm.type = ? AND cm.reviewrejected = 0 AND cm.reviewrequired = 0) AS replies, "+
@@ -281,7 +286,7 @@ func Messages(c *fiber.Ctx) error {
 		// `unseen`), so unseenOnly is false; nearbyCount uses the same helper with
 		// unseenOnly=true so the two can never disagree on what "in reach" means.
 		for _, cand := range fetchReachCandidates(db, myid, latlng, false) {
-			res = append(res, cand.toSummary(viewerLat, viewerLng, weights, env))
+			res = append(res, cand.toSummary(viewerLat, viewerLng, weights, env, myid))
 		}
 
 		// Include the viewer's own recent open posts regardless of reach, so a poster still
@@ -296,7 +301,7 @@ func Messages(c *fiber.Ctx) error {
 			"SELECT m.lat, m.lng, m.id, "+
 				"ANY_VALUE(CASE WHEN mo.outcome IN (?, ?) THEN 1 ELSE 0 END) AS successful, "+
 				"ANY_VALUE(CASE WHEN mp.id IS NOT NULL THEN 1 ELSE 0 END) AS promised, "+
-				"ANY_VALUE(mg.groupid) AS groupid, m.type, "+
+				"ANY_VALUE(mg.groupid) AS groupid, m.type, m.fromuser AS fromuser, "+
 				"MAX(mg.arrival) AS arrival, m.arrival AS posted, "+
 				"ANY_VALUE(CASE WHEN ml.msgid IS NULL THEN 1 ELSE 0 END) AS unseen, "+
 				"COALESCE((SELECT SUM(mlv.count) FROM messages_likes mlv WHERE mlv.msgid = m.id AND mlv.type = ?), 0) AS views, "+
@@ -337,7 +342,7 @@ func Messages(c *fiber.Ctx) error {
 		// own candidates to summaries, then drop the expired ones.
 		ownSummaries := make([]message.MessageSummary, 0, len(ownCandidates))
 		for _, cand := range ownCandidates {
-			ownSummaries = append(ownSummaries, cand.toSummary(viewerLat, viewerLng, weights, env))
+			ownSummaries = append(ownSummaries, cand.toSummary(viewerLat, viewerLng, weights, env, myid))
 		}
 		activeOwn := message.FilterExpiredSummaries(db, ownSummaries)
 
@@ -494,7 +499,7 @@ func myGroupsMessages(c *fiber.Ctx, db *gorm.DB, myid uint64) error {
 		db.Raw(fmt.Sprintf(
 			"SELECT ST_Y(ms.point) AS lat, ST_X(ms.point) AS lng, "+
 				"ms.msgid AS id, ms.successful, ms.promised, ms.groupid, "+
-				"ms.msgtype AS type, ms.arrival, m.arrival AS posted, "+
+				"ms.msgtype AS type, m.fromuser AS fromuser, ms.arrival, m.arrival AS posted, "+
 				"CASE WHEN ml.msgid IS NULL THEN 1 ELSE 0 END AS unseen, "+
 				"COALESCE((SELECT SUM(mlv.count) FROM messages_likes mlv WHERE mlv.msgid = ms.msgid AND mlv.type = ?), 0) AS views, "+
 				"(SELECT COUNT(*) FROM chat_messages cm WHERE cm.refmsgid = ms.msgid AND cm.type = ? AND cm.reviewrejected = 0 AND cm.reviewrequired = 0) AS replies, "+
@@ -515,7 +520,7 @@ func myGroupsMessages(c *fiber.Ctx, db *gorm.DB, myid uint64) error {
 			weights := LoadScoreWeights()
 			env := LoadScoreEnv()
 			for _, cand := range candidates {
-				res = append(res, cand.toSummary(viewerLat, viewerLng, weights, env))
+				res = append(res, cand.toSummary(viewerLat, viewerLng, weights, env, myid))
 			}
 			// Rippling relevance order (score desc, arrival tie-break), mirroring the nearby
 			// arm, so the client's "New to you" sort has a meaningful score to rank on.
@@ -542,6 +547,7 @@ func myGroupsMessages(c *fiber.Ctx, db *gorm.DB, myid uint64) error {
 					Lat:        blurLat,
 					Lng:        blurLng,
 					Unseen:     cand.Unseen,
+					Mine:       cand.Fromuser != 0 && cand.Fromuser == myid,
 				})
 			}
 		}

--- a/iznik-server-go/message/messageSummary.go
+++ b/iznik-server-go/message/messageSummary.go
@@ -38,4 +38,9 @@ type MessageSummary struct {
 	// clearance): the browse feed floats it to the top whenever it already qualifies
 	// to appear. Only set on the browse feed; omitted (false) elsewhere.
 	Pinned bool `json:"pinned,omitempty" gorm:"-"`
+	// Mine is true when the post's author is the viewer. The browse feed sets it so the
+	// client can float the viewer's own recent posts to the top of every sort order —
+	// members otherwise lose track of their own posts among the reach-ordered feed and
+	// assume they are not showing (Discourse 9933). Only set on the browse feed.
+	Mine bool `json:"mine,omitempty" gorm:"-"`
 }

--- a/iznik-server-go/test/isochrone_own_mine_test.go
+++ b/iznik-server-go/test/isochrone_own_mine_test.go
@@ -1,0 +1,69 @@
+package test
+
+import (
+	json2 "encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/freegle/iznik-server-go/message"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestNearbyFeed_OwnPostFlaggedMine verifies the browse feed (GET /isochrone/message) flags the
+// viewer's own posts with `mine` (MessageSummary.Mine), and includes them even when they are NOT
+// in the viewer's reach — the own-posts arm queries messages directly, not the reach polygon. The
+// client pins `mine` posts to the top of every sort order so members can always find their own
+// posts instead of losing them in the reach order (Discourse 9933).
+func TestNearbyFeed_OwnPostFlaggedMine(t *testing.T) {
+	db := database.DBConn
+
+	db.Exec(`CREATE TABLE IF NOT EXISTS rippling_reach (
+		msgid BIGINT UNSIGNED NOT NULL PRIMARY KEY,
+		lat DOUBLE NOT NULL, lng DOUBLE NOT NULL,
+		polygon GEOMETRY NOT NULL SRID 3857,
+		status VARCHAR(16) NOT NULL DEFAULT 'expanding',
+		SPATIAL INDEX msgreach_poly (polygon)
+	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`)
+
+	prefix := uniquePrefix("ownmine")
+	group := CreateTestGroup(t, prefix)
+	otherID := CreateTestUser(t, prefix+"_other", "Other")
+
+	viewerID, token := CreateFullTestUser(t, prefix+"_viewer")
+	db.Exec("UPDATE users SET settings = JSON_SET(COALESCE(settings,'{}'), '$.mylocation', "+
+		"JSON_OBJECT('lat', 51.5, 'lng', -0.1)) WHERE id = ?", viewerID)
+
+	// 'rival': another member's post, in reach of the viewer -> appears via the reach arm, NOT mine.
+	rival := CreateTestMessage(t, otherID, group, "OFFER: someone else, in reach (ownmine)", 51.5, -0.1)
+	// 'own': the viewer's OWN post, placed far away with NO reach row covering the viewer, so it can
+	// only reach the feed via the own-posts arm — proving own posts show regardless of reach.
+	own := CreateTestMessage(t, viewerID, group, "OFFER: my own post, out of reach (ownmine)", 53.0, 2.0)
+	db.Exec("UPDATE messages_spatial SET successful = 0 WHERE msgid IN (?, ?)", rival, own)
+	defer db.Exec("DELETE FROM rippling_reach WHERE msgid IN (?, ?)", rival, own)
+
+	// Only the rival gets a reach polygon covering the viewer; the own post gets none.
+	db.Exec("INSERT INTO rippling_reach (msgid, lat, lng, polygon, outer_bound, status) VALUES (?, 51.5, -0.1, "+
+		"ST_GeomFromText('POLYGON((-0.2 51.4, 0.0 51.4, 0.0 51.6, -0.2 51.6, -0.2 51.4))', 3857), ST_Envelope(ST_GeomFromText('POLYGON((-0.2 51.4, 0.0 51.4, 0.0 51.6, -0.2 51.6, -0.2 51.4))', 3857)), 'expanding') "+
+		"ON DUPLICATE KEY UPDATE polygon = VALUES(polygon)", rival)
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/isochrone/message?jwt="+token, nil))
+	assert.Equal(t, 200, resp.StatusCode)
+	var msgs []message.MessageSummary
+	json2.Unmarshal(rsp(resp), &msgs)
+
+	byID := map[uint64]message.MessageSummary{}
+	for _, m := range msgs {
+		byID[m.ID] = m
+	}
+
+	// The viewer's own out-of-reach post is present and flagged mine.
+	ownMsg, ownPresent := byID[own]
+	assert.True(t, ownPresent, "the viewer's own post appears even though it is not in reach")
+	assert.True(t, ownMsg.Mine, "the viewer's own post is flagged mine")
+
+	// The other member's in-reach post is present and NOT flagged mine.
+	rivalMsg, rivalPresent := byID[rival]
+	assert.True(t, rivalPresent, "another member's in-reach post appears")
+	assert.False(t, rivalMsg.Mine, "another member's post is not flagged mine")
+}


### PR DESCRIPTION
Fixes [Group Listings /t/9933](https://discourse.ilovefreegle.org/t/group-listings/9933): members reported they couldn't see their own items in the group listing and, in a couple of cases, withdrew a post because they assumed it was no longer showing to anyone.

## Cause

Their own posts **are** in the browse feed already (the `isochrone.Messages` own-posts arm includes a member's open posts regardless of reach). But the feed is ordered by rippling relevance on the server and then re-sorted client-side by New to you / Newest / Closest, and none of those privilege the viewer's own posts, so they get buried among everyone else's.

## Fix

Show the viewer's own recent posts at the **top of every sort order** (what Edward promised on the thread).

**Server** — flag each browse-feed post with `mine` (`MessageSummary.Mine`) when `messages.fromuser` is the viewer. Set uniformly from the post author across all three feed paths (reach arm, own-posts arm, mygroups) via a new `reachCandidateRow.Fromuser` and `toSummary(…, myid)`.

**Client** — `sortBrowseMessages` floats `mine` posts to the top of New to you / Newest / Closest alike, **newest-first**, just below any paid pinned clearance (so the paid feature still leads). No change when a post isn't the viewer's own.

## Tests

- **Go** (`isochrone_own_mine_test.go`): an out-of-reach own post appears and is flagged `mine`; another member's in-reach post is present and is not.
- **vitest** (`useMessageSort.spec.js`): own-first under all three sorts, newest-first among own posts (ignoring score), and a paid pinned clearance still ranks above own. Existing sort behaviour unchanged when nothing is `mine`.
- `docs/developers/reference/rippling-algorithm.md` updated (browse-feed consumers section).

Jeni also asked about specific posts appearing/not appearing at odd distances; Edward asked her for screenshots on the thread. That's a separate diagnosis from this "can't find my own posts" fix and isn't addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQZ56NwFYEuhrtaoU7oYoM
