### PR TITLE
fix(app/calendar): Add to Calendar no longer silently fails; valid .ics for import (9927)

### DIFF
--- a/iznik-nuxt3/README-APP.md
+++ b/iznik-nuxt3/README-APP.md
@@ -326,6 +326,12 @@ The mobile app requires specific Capacitor plugins and dependencies for native f
 }
 ```
 
+**Add to Calendar** (`components/AddToCalendar.vue`): uses `window.plugins.calendar`
+(cordova-plugin-calendar) to add a handover to the device calendar. If the plugin is not
+exposed in the WebView, or the native call errors, it falls back to downloading a `.ics`
+file (built by `composables/useCalendarEvent.js`) so the button is never a silent no-op — the
+symptom reported in Discourse 9927. On the web it always uses the `.ics`.
+
 </details>
 
 ---

--- a/iznik-nuxt3/components/AddToCalendar.vue
+++ b/iznik-nuxt3/components/AddToCalendar.vue
@@ -9,7 +9,7 @@
       <v-icon icon="calendar-alt" />
       Add to Calendar
     </b-button>
-    {{ message }}
+    <div v-if="message" class="mt-1 small text-muted">{{ message }}</div>
   </div>
 </template>
 <script setup>
@@ -17,6 +17,7 @@ import saveAs from 'save-file'
 import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
 import timezone from 'dayjs/plugin/timezone'
+import { buildIcs } from '~/composables/useCalendarEvent'
 import { useMobileStore } from '@/stores/mobile' // APP
 
 dayjs.extend(utc)
@@ -44,162 +45,146 @@ const props = defineProps({
   },
 })
 
-const message = ref(null) // TODO Seems unused
+// Shown to the member when we fall back to a downloaded file or something goes wrong, so the
+// button never silently does nothing (Discourse 9927).
+const message = ref(null)
 
-async function download(e) {
-  console.log('AddToCalendar button clicked!')
-  e.preventDefault()
-  e.stopPropagation()
-
-  // Extract and decode the calendar data from the link
-  console.log('calendarLink:', props.calendarLink)
-  const url = new URL(props.calendarLink)
-  const encodedData = url.searchParams.get('data')
+// Pull the base64 event payload out of the calendar link.
+function parseEventData(link) {
+  const encodedData = new URL(link).searchParams.get('data')
   if (!encodedData) {
-    console.error('No calendar data found in link')
-    return
+    return null
   }
+  return JSON.parse(atob(encodedData))
+}
 
-  console.log('Decoding calendar data...')
-  const decodedData = atob(encodedData)
-  const eventData = JSON.parse(decodedData)
-  console.log('Event data:', eventData)
+// Download an .ics that any calendar app can import. Used for the web, and as the app fallback
+// when the native calendar hook is unavailable or errors - so the button always does something.
+async function downloadIcs(eventData) {
+  const blob = new Blob([buildIcs(eventData)], {
+    type: 'text/calendar;charset=utf-8',
+  })
+  await saveAs(blob, 'freegle-handover.ics')
+}
 
-  const mobileStore = useMobileStore()
-  console.log('Is app?', mobileStore.isApp)
-  if (!mobileStore.isApp) {
-    // Web version - generate ICS file from the structured data
-    const startDateTime = `${eventData.startDate.replace(
-      /-/g,
-      ''
-    )}T${eventData.startTime.replace(/:/g, '')}00`
-    const endDateTime = `${eventData.startDate.replace(
-      /-/g,
-      ''
-    )}T${eventData.endTime.replace(/:/g, '')}00`
-
-    const icsContent = [
-      'BEGIN:VCALENDAR',
-      'VERSION:2.0',
-      'PRODID:-//Freegle//NONSGML Event//EN',
-      'BEGIN:VEVENT',
-      `DTSTART;TZID=${eventData.timeZone}:${startDateTime}`,
-      `DTEND;TZID=${eventData.timeZone}:${endDateTime}`,
-      `SUMMARY:${eventData.name}`,
-      `DESCRIPTION:${eventData.description}`,
-      `LOCATION:${eventData.location}`,
-      'END:VEVENT',
-      'END:VCALENDAR',
-    ].join('\r\n')
-
-    const blob = new Blob([icsContent], { type: 'text/calendar;charset=utf-8' })
-    await saveAs(blob, 'freegle-handover.ics')
-    return
-  }
-
-  // APP version - use Cordova calendar plugin with structured data
-  let startDate, endDate
-
+// Parse the event's start/end into Date objects in its own timezone, falling back to local time.
+function eventDates(eventData) {
   try {
-    // Try to use timezone-aware parsing
-    const startDateTime = `${eventData.startDate} ${eventData.startTime}`
-    const endDateTime = `${eventData.startDate} ${eventData.endTime}`
-
-    startDate = dayjs.tz(startDateTime, eventData.timeZone).toDate()
-    endDate = dayjs.tz(endDateTime, eventData.timeZone).toDate()
-
-    // Validate the dates
-    if (isNaN(startDate.getTime()) || isNaN(endDate.getTime())) {
+    const start = dayjs
+      .tz(`${eventData.startDate} ${eventData.startTime}`, eventData.timeZone)
+      .toDate()
+    const end = dayjs
+      .tz(`${eventData.startDate} ${eventData.endTime}`, eventData.timeZone)
+      .toDate()
+    if (isNaN(start.getTime()) || isNaN(end.getTime())) {
       throw new TypeError('Invalid dates from timezone parsing')
     }
-    console.log('Using timezone-aware dates:', startDate, endDate)
+    return { start, end }
   } catch (err) {
-    // Fallback to simple local time parsing if timezone parsing fails
-    console.log('Timezone parsing failed, using fallback:', err)
     const [year, month, day] = eventData.startDate.split('-').map(Number)
-    const [startHour, startMin] = eventData.startTime.split(':').map(Number)
-    const [endHour, endMin] = eventData.endTime.split(':').map(Number)
+    const [sh, sm] = eventData.startTime.split(':').map(Number)
+    const [eh, em] = eventData.endTime.split(':').map(Number)
+    return {
+      start: new Date(year, month - 1, day, sh, sm, 0),
+      end: new Date(year, month - 1, day, eh, em, 0),
+    }
+  }
+}
 
-    startDate = new Date(year, month - 1, day, startHour, startMin, 0)
-    endDate = new Date(year, month - 1, day, endHour, endMin, 0)
-    console.log('Using fallback dates:', startDate, endDate)
+async function download(e) {
+  e.preventDefault()
+  e.stopPropagation()
+  message.value = null
+
+  let eventData
+  try {
+    eventData = parseEventData(props.calendarLink)
+  } catch (err) {
+    eventData = null
+  }
+  if (!eventData) {
+    console.error(
+      'AddToCalendar: could not read the calendar link',
+      props.calendarLink
+    )
+    message.value = 'Sorry, we could not read the event details.'
+    return
   }
 
+  const mobileStore = useMobileStore()
+
+  // Web: hand the browser an .ics to import.
+  if (!mobileStore.isApp) {
+    try {
+      await downloadIcs(eventData)
+    } catch (err) {
+      console.error('AddToCalendar: failed to build/save the .ics', err)
+      message.value = "Sorry, we couldn't create the calendar file."
+    }
+    return
+  }
+
+  // App: try the native calendar plugin. If it is missing (it may not be exposed in the
+  // WebView) or it errors, fall back to the .ics download so the button is never a silent
+  // no-op - the symptom reported in 9927.
+  const fallback = async () => {
+    try {
+      await downloadIcs(eventData)
+      message.value =
+        "We've saved a calendar file - open it to add this to your calendar."
+    } catch (err) {
+      console.error('AddToCalendar: fallback .ics failed', err)
+      message.value = "Sorry, we couldn't add this to your calendar."
+    }
+  }
+
+  const cal = window.plugins?.calendar
+  if (!cal) {
+    console.warn(
+      'AddToCalendar: native calendar plugin unavailable; using .ics fallback'
+    )
+    await fallback()
+    return
+  }
+
+  const { start, end } = eventDates(eventData)
   const title = eventData.name
   const eventLocation = eventData.location || ''
   const notes = eventData.description
 
-  // Check if calendar plugin is available
-  console.log('Checking for calendar plugin...')
-  console.log('window:', typeof window)
-  console.log('window.plugins:', window.plugins)
-  console.log('window.plugins.calendar:', window.plugins?.calendar)
-
-  if (!window.plugins || !window.plugins.calendar) {
-    console.error('❌ Calendar plugin not available!')
-    console.error('This might mean:')
-    console.error('1. Plugin not synced to Android project')
-    console.error('2. Cordova plugins not loaded yet')
-    console.error('3. Plugin not installed correctly')
-    // Don't return - let it fail naturally so we see the error
-  } else {
-    console.log('✅ Calendar plugin is available!')
+  const onError = async (msg) => {
+    console.error('AddToCalendar: native calendar error', msg)
+    await fallback()
   }
-
-  console.log('Creating calendar event:', {
-    title,
-    location: eventLocation,
-    notes,
-    startDate,
-    endDate,
-  })
-
-  // Call hasWritePermission
-  // Then requestWritePermission if necessary
-  // Then createEventInteractively if possible
-  const success = function (message) {
-    console.log('Add calendar success', JSON.stringify(message))
+  const onSuccess = () => {
+    message.value = null
   }
-  const error = function (message) {
-    console.error('Add calendar error:', message)
-  }
-  const error1 = function (message) {
-    console.error('hasWritePermission error:', message)
-  }
-  const errorw = function (message) {
-    console.error('requestWritePermission error:', message)
-  }
-  const successw = function () {
-    console.log('requestWritePermission success')
-    window.plugins.calendar.createEventInteractively(
-      title,
-      eventLocation,
-      notes,
-      startDate,
-      endDate,
-      success,
-      error
-    )
-  }
-  const success1 = function (message) {
-    console.log('hasWritePermission success:', JSON.stringify(message))
-    if (message || !mobileStore.isiOS) {
-      console.log('Calling createEventInteractively directly')
-      window.plugins.calendar.createEventInteractively(
+  const createEvent = () => {
+    try {
+      cal.createEventInteractively(
         title,
         eventLocation,
         notes,
-        startDate,
-        endDate,
-        success,
-        error
+        start,
+        end,
+        onSuccess,
+        onError
       )
-    } else {
-      console.log('Requesting write permission first')
-      window.plugins.calendar.requestWritePermission(successw, errorw)
+    } catch (err) {
+      onError(err)
     }
   }
 
-  window.plugins.calendar.hasWritePermission(success1, error1)
+  try {
+    cal.hasWritePermission((has) => {
+      if (has || !mobileStore.isiOS) {
+        createEvent()
+      } else {
+        cal.requestWritePermission(createEvent, onError)
+      }
+    }, onError)
+  } catch (err) {
+    onError(err)
+  }
 }
 </script>

--- a/iznik-nuxt3/composables/useCalendarEvent.js
+++ b/iznik-nuxt3/composables/useCalendarEvent.js
@@ -1,0 +1,59 @@
+// Build a calendar .ics (RFC 5545) from the structured event data used by AddToCalendar.
+// Extracted as a pure function so the .ics - the part Google Calendar and other importers
+// actually parse - can be unit tested. The previous inline version omitted UID and DTSTAMP and
+// did not escape the text fields, so Google Calendar rejected the file with an error when a
+// member tried to add a handover from the confirmation email (Discourse 9927).
+
+// Escape a text value for an ICS property per RFC 5545 section 3.3.11: backslash, semicolon and
+// comma are escaped, and any line break becomes the literal `\n`. Without this a description or
+// location containing a comma (very common in an address) or a line break yields a malformed
+// file that importers refuse.
+export function escapeIcsText(value) {
+  return String(value ?? '')
+    .replace(/\\/g, '\\\\')
+    .replace(/;/g, '\\;')
+    .replace(/,/g, '\\,')
+    .replace(/\r\n|\r|\n/g, '\\n')
+}
+
+// Compact a 'YYYY-MM-DD' date and 'HH:MM' time into the ICS local-time form YYYYMMDDTHHMMSS.
+function compactLocal(date, time) {
+  return `${String(date).replace(/-/g, '')}T${String(time).replace(/:/g, '')}00`
+}
+
+// Build the full VCALENDAR/VEVENT text.
+//
+// eventData: { startDate 'YYYY-MM-DD', startTime 'HH:MM', endTime 'HH:MM', timeZone, name,
+//              description, location }
+// opts.now: injectable Date for a deterministic DTSTAMP in tests.
+//
+// A VEVENT MUST carry a UID and a DTSTAMP (RFC 5545 3.6.1); Google Calendar rejects files
+// without them. DTSTAMP is UTC. DTSTART/DTEND carry the event's own timezone via TZID (falling
+// back to floating local time if none is given). The UID is derived from the event's start/end
+// so re-importing the same handover updates one event rather than creating duplicates.
+export function buildIcs(eventData, opts = {}) {
+  const now = opts.now || new Date()
+  const start = compactLocal(eventData.startDate, eventData.startTime)
+  const end = compactLocal(eventData.startDate, eventData.endTime)
+  const dtstamp = now.toISOString().replace(/[-:]/g, '').replace(/\.\d{3}Z$/, 'Z')
+  const uid = `freegle-${start}-${end}@ilovefreegle.org`
+  const tz = eventData.timeZone
+
+  return [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'PRODID:-//Freegle//NONSGML Event//EN',
+    'CALSCALE:GREGORIAN',
+    'METHOD:PUBLISH',
+    'BEGIN:VEVENT',
+    `UID:${uid}`,
+    `DTSTAMP:${dtstamp}`,
+    tz ? `DTSTART;TZID=${tz}:${start}` : `DTSTART:${start}`,
+    tz ? `DTEND;TZID=${tz}:${end}` : `DTEND:${end}`,
+    `SUMMARY:${escapeIcsText(eventData.name)}`,
+    `DESCRIPTION:${escapeIcsText(eventData.description)}`,
+    `LOCATION:${escapeIcsText(eventData.location)}`,
+    'END:VEVENT',
+    'END:VCALENDAR',
+  ].join('\r\n')
+}

--- a/iznik-nuxt3/tests/unit/composables/useCalendarEvent.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useCalendarEvent.spec.js
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest'
+import { buildIcs, escapeIcsText } from '~/composables/useCalendarEvent'
+
+const event = {
+  startDate: '2026-08-01',
+  startTime: '14:30',
+  endTime: '15:00',
+  timeZone: 'Europe/London',
+  name: 'Freegle handover: blue sofa',
+  description: 'Meet at the door. Ring the bell, second flat.',
+  location: '10 High Street, Anytown, AN1 2BC',
+}
+const now = new Date('2026-07-18T09:08:07.123Z')
+
+describe('escapeIcsText', () => {
+  it('escapes backslash, semicolon, comma and newlines per RFC 5545', () => {
+    expect(escapeIcsText('a, b; c\\ d')).toBe('a\\, b\\; c\\\\ d')
+    expect(escapeIcsText('line one\nline two')).toBe('line one\\nline two')
+    expect(escapeIcsText('crlf\r\nhere')).toBe('crlf\\nhere')
+  })
+
+  it('handles null/undefined as empty', () => {
+    expect(escapeIcsText(undefined)).toBe('')
+    expect(escapeIcsText(null)).toBe('')
+  })
+})
+
+describe('buildIcs', () => {
+  const ics = buildIcs(event, { now })
+  const lines = ics.split('\r\n')
+
+  it('is CRLF-delimited and wrapped in VCALENDAR/VEVENT', () => {
+    expect(ics).toContain('\r\n')
+    expect(lines[0]).toBe('BEGIN:VCALENDAR')
+    expect(lines).toContain('BEGIN:VEVENT')
+    expect(lines).toContain('END:VEVENT')
+    expect(lines[lines.length - 1]).toBe('END:VCALENDAR')
+  })
+
+  // The bug in 9927: Google Calendar rejected the file because the VEVENT had no UID and no
+  // DTSTAMP. Both must be present.
+  it('includes a UID and a UTC DTSTAMP (Google Calendar rejects files without them)', () => {
+    expect(lines.some((l) => l.startsWith('UID:'))).toBe(true)
+    expect(ics).toContain('DTSTAMP:20260718T090807Z')
+  })
+
+  it('writes DTSTART/DTEND with the event timezone and compact local times', () => {
+    expect(ics).toContain('DTSTART;TZID=Europe/London:20260801T143000')
+    expect(ics).toContain('DTEND;TZID=Europe/London:20260801T150000')
+  })
+
+  it('escapes the comma in SUMMARY, DESCRIPTION and LOCATION', () => {
+    expect(ics).toContain('SUMMARY:Freegle handover: blue sofa') // ':' is not an escaped ICS char
+    expect(ics).toContain('DESCRIPTION:Meet at the door. Ring the bell\\, second flat.')
+    expect(ics).toContain('LOCATION:10 High Street\\, Anytown\\, AN1 2BC')
+  })
+
+  it('omits TZID when the event has no timezone (floating local time)', () => {
+    const floating = buildIcs({ ...event, timeZone: undefined }, { now })
+    expect(floating).toContain('DTSTART:20260801T143000')
+    expect(floating).not.toContain('TZID')
+  })
+})


### PR DESCRIPTION
Addresses [Add to calendar button not working /t/9927](https://discourse.ilovefreegle.org/t/add-to-calendar-button-not-working/9927): on the Freegle app the "Add to Calendar" button "turns grey but nothing happens", and the confirmation email's Add to Calendar led to a page whose button errored when the reporter chose Google Calendar.

## Two defects

**1. The app path threw silently.** `AddToCalendar.vue` called `window.plugins.calendar.hasWritePermission(...)` with no guard. If the Cordova calendar plugin isn't exposed in the Capacitor WebView, that line throws and the click does nothing — exactly "turns grey, nothing happens". The old code even commented "let it fail naturally so we see the error", but the member sees nothing.

**2. The `.ics` was malformed.** The web/email path built a `VEVENT` with **no `UID`**, **no `DTSTAMP`**, and **no escaping** of `SUMMARY`/`DESCRIPTION`/`LOCATION`. Google Calendar rejects VEVENTs without UID/DTSTAMP, and an unescaped comma in an address (very common) breaks the file — matching "selected Google Calendar → error".

## Fix

- Extracted **`buildIcs()`** into `composables/useCalendarEvent.js` — a pure, unit-tested function that emits a valid VEVENT with `UID`, a UTC `DTSTAMP`, `TZID` start/end, and RFC-5545 escaping.
- `AddToCalendar.vue` now **guards and wraps** the native path: a missing plugin or any native error falls back to downloading the `.ics`, and a short message is shown, so the button is **never a silent no-op**. The web path uses the `.ics` as before (now well-formed).
- Unit tests cover UID/DTSTAMP presence, timezone start/end, comma escaping, and the no-timezone (floating) case.
- `README-APP.md` documents the fallback.

## Scope / honesty

This makes the feature **degrade to a working calendar file** instead of failing invisibly, and fixes the emailed-`.ics` import error. Full native in-app calendar integration on the newest Android (Michael is on Android 16) still needs on-device testing — the Cordova plugin is bundled (package.json + capacitor config + Android manifest), so the remaining question is why it isn't exposed/working at runtime there. That's follow-up native work, not covered here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQZ56NwFYEuhrtaoU7oYoM
