### PR TITLE
fix(modtools): group centre point saves; unset centre no longer breaks the region map (9932)

### DIFF
--- a/iznik-nuxt3/composables/useNumericInput.js
+++ b/iznik-nuxt3/composables/useNumericInput.js
@@ -1,0 +1,18 @@
+// Coerce a form value to a number for a numeric JSON API field, or null when blank/invalid.
+//
+// bootstrap-vue-next's `<b-form-input type="number">` emits its model value as a STRING, and the
+// Go API types numeric fields (a group's centre lat/lng, altlat/altlng, ...) as `*float64`. A
+// JSON string in one of those fields fails Fiber's BodyParser, so the WHOLE PATCH is rejected
+// with 400 and nothing in that request saves - which is why a new group's centre point silently
+// never stuck while the CGA (a string field, sent in a separate request) did (Discourse 9932).
+//
+// Returning null for '', null, undefined or a non-numeric value means the caller can omit the
+// field (the API treats a missing field as "leave unchanged") rather than send an unparseable
+// string or a stray 0 that would move the point to the Atlantic.
+export function toNumberOrNull(value) {
+  if (value === '' || value === null || value === undefined) {
+    return null
+  }
+  const n = typeof value === 'number' ? value : Number(value)
+  return Number.isFinite(n) ? n : null
+}

--- a/iznik-nuxt3/modtools/components/ModSupportAddGroup.vue
+++ b/iznik-nuxt3/modtools/components/ModSupportAddGroup.vue
@@ -73,6 +73,7 @@
 <script setup>
 import { ref, computed } from 'vue'
 import { useGroupStore } from '~/stores/group'
+import { toNumberOrNull } from '~/composables/useNumericInput'
 
 const groupStore = useGroupStore()
 
@@ -144,8 +145,10 @@ async function add(callback) {
       namefull: namefull.value,
       cga: cga.value,
       dpa: dpa.value,
-      lat: lat.value,
-      lng: lng.value,
+      // Send real numbers, not the number-input strings: the API's lat/lng are float and a
+      // string there fails the request parse, so the new group's centre never got set (9932).
+      lat: toNumberOrNull(lat.value),
+      lng: toNumberOrNull(lng.value),
     })
 
     if (groupId) {

--- a/iznik-nuxt3/modtools/components/ModSupportFindGroup.vue
+++ b/iznik-nuxt3/modtools/components/ModSupportFindGroup.vue
@@ -166,6 +166,9 @@
         class="mt-2"
         @handle="saveCentres"
       />
+      <p v-if="centreError" class="text-danger">
+        {{ centreError }}
+      </p>
       <h4 class="mt-2">CGA</h4>
       <b-form-textarea v-model="group.cga" rows="4" class="mb-2" />
       <p v-if="CGAerror" class="text-danger">
@@ -212,6 +215,7 @@
 import { ref, computed, watch } from 'vue'
 import { useMemberStore } from '~/stores/member'
 import { useModGroupStore } from '@/stores/modgroup'
+import { toNumberOrNull } from '~/composables/useNumericInput'
 
 const modGroupStore = useModGroupStore()
 const memberStore = useMemberStore()
@@ -221,6 +225,7 @@ const searchgroup = ref(null)
 const fetchingVolunteers = ref(false)
 const CGAerror = ref(null)
 const DPAerror = ref(null)
+const centreError = ref(null)
 
 const groups = computed(() => {
   return Object.values(modGroupStore.allGroups)
@@ -397,14 +402,22 @@ function saveNames(callback) {
   callback()
 }
 
-function saveCentres(callback) {
-  modGroupStore.updateMT({
-    id: groupid.value,
-    lat: group.value.lat,
-    lng: group.value.lng,
-    altlat: group.value.altlat,
-    altlng: group.value.altlng,
-  })
+async function saveCentres(callback) {
+  centreError.value = null
+  // Coerce the number-input strings to real numbers (or null when blank). The API's lat/lng
+  // fields are float; a string there fails the request body parse and the whole save is
+  // rejected, which is why the centre point never stuck (Discourse 9932).
+  try {
+    await modGroupStore.updateMT({
+      id: groupid.value,
+      lat: toNumberOrNull(group.value.lat),
+      lng: toNumberOrNull(group.value.lng),
+      altlat: toNumberOrNull(group.value.altlat),
+      altlng: toNumberOrNull(group.value.altlng),
+    })
+  } catch (e) {
+    centreError.value = e.message
+  }
   callback()
 }
 

--- a/iznik-nuxt3/pages/explore/region/[region].vue
+++ b/iznik-nuxt3/pages/explore/region/[region].vue
@@ -74,7 +74,13 @@ for (const ix in allGroups) {
     group.onmap &&
     group.publish &&
     group.region &&
-    group.region.trim().toLowerCase() === region
+    group.region.trim().toLowerCase() === region &&
+    // Ignore a group with an unset centre. A new/mis-set group whose lat/lng is 0 (or
+    // missing) would otherwise pull the region's bounding box down to (0, 0) in the Atlantic,
+    // so "Wales" zoomed off North Africa (Discourse 9932).
+    Number.isFinite(group.lat) &&
+    Number.isFinite(group.lng) &&
+    (group.lat !== 0 || group.lng !== 0)
   ) {
     swlat = swlat === null ? group.lat : Math.min(swlat, group.lat)
     swlng = swlng === null ? group.lng : Math.min(swlng, group.lng)

--- a/iznik-nuxt3/tests/unit/composables/useNumericInput.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useNumericInput.spec.js
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest'
+import { toNumberOrNull } from '~/composables/useNumericInput'
+
+describe('toNumberOrNull', () => {
+  it('returns null for blank/absent values (so the field is omitted, not sent as "")', () => {
+    expect(toNumberOrNull('')).toBe(null)
+    expect(toNumberOrNull(null)).toBe(null)
+    expect(toNumberOrNull(undefined)).toBe(null)
+  })
+
+  it('coerces the number-input string to a real number (the 9932 fix)', () => {
+    expect(toNumberOrNull('51.80362')).toBe(51.80362)
+    expect(toNumberOrNull('-4.96315')).toBe(-4.96315)
+    expect(toNumberOrNull(' 51.8 ')).toBe(51.8) // Number() trims surrounding whitespace
+  })
+
+  it('passes real numbers through unchanged, including zero', () => {
+    expect(toNumberOrNull(51.80362)).toBe(51.80362)
+    expect(toNumberOrNull(0)).toBe(0)
+    expect(toNumberOrNull('0')).toBe(0)
+  })
+
+  it('returns null for non-numeric junk rather than NaN', () => {
+    expect(toNumberOrNull('abc')).toBe(null)
+    expect(toNumberOrNull('12.3.4')).toBe(null)
+  })
+})


### PR DESCRIPTION
Addresses [Mapping of new group /t/9932](https://discourse.ilovefreegle.org/t/mapping-of-new-group/9932): a new group's centre point wouldn't save in Support (saved, then gone on return; the CGA saved fine), so no pin showed on Explore — and Explore → Wales zoomed to North Africa.

## Root cause (one bug, two symptoms)

`bootstrap-vue-next`'s `<b-form-input type="number">` emits its model value as a **string**, but the Go API types a group's `lat`/`lng`/`altlat`/`altlng` as `*float64`. A JSON string in one of those fields fails Fiber's `BodyParser`, so the **whole PATCH is rejected (400)** and nothing in that request saves. The CGA only saved because it goes in a **separate** request as a string field. The same string reached `CreateGroup`, so a new group's centre was never set at creation either — leaving it at the seeded `POINT(0 0)`.

That unset `(0,0)` centre is also why **Wales → North Africa**: the region map builds its bounding box from member groups' `lat`/`lng`, and one group sitting at `(0,0)` drags the box down into the Atlantic off North Africa.

## Fix

- **`composables/useNumericInput.js` → `toNumberOrNull()`**: coerce the number-input string to a real number, or `null` (omit) when blank/invalid — never a stray `0`.
- **`ModSupportFindGroup.saveCentres`** and **`ModSupportAddGroup`**: send coerced numbers. `saveCentres` now `await`s and surfaces any error instead of failing silently.
- **Explore region map**: skip groups with an unset `(0,0)`/missing centre when computing the region bounds, so one such group can't throw the whole region off the map.
- Unit tests for `toNumberOrNull` (blank → null, `'51.8'` → 51.8, `0` preserved, junk → null).

## Not in this PR
The greyed-out **"On Trashnothing"** toggle Derek mentioned is a separate issue (its own disabled-state logic) and needs its own look — flagged, not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQZ56NwFYEuhrtaoU7oYoM
