### PR TITLE
fix(chat): ModTools 'Mark all read' no longer wipes members' personal unread chats

### DIFF
--- a/iznik-server-go/chat/chatroom.go
+++ b/iznik-server-go/chat/chatroom.go
@@ -663,6 +663,7 @@ type ChatRoomPostRequest struct {
 	Allowback   bool   `json:"allowback"`
 	Reason      string `json:"reason"`
 	Comment     string `json:"comment"`
+	Modtools    bool   `json:"modtools"`
 }
 
 type RosterEntry struct {
@@ -686,7 +687,7 @@ func PostChatRoom(c *fiber.Ctx) error {
 
 	switch req.Action {
 	case "AllSeen":
-		return handleAllSeen(c, db, myid)
+		return handleAllSeen(c, db, myid, req.Modtools)
 	case "Nudge":
 		return handleNudge(c, db, myid, req.ID)
 	case "Typing":
@@ -1605,28 +1606,53 @@ func handleReportNoGroup(c *fiber.Ctx, db *gorm.DB, myid uint64, req ChatRoomPos
 	return c.JSON(fiber.Map{"ret": 0, "status": "Success"})
 }
 
-func handleAllSeen(c *fiber.Ctx, db *gorm.DB, myid uint64) error {
-	// Mark all chat messages as seen across all chats for this user.
-	// Sets lastmsgseen to the maximum message ID in each chat the user is rostered in.
-	db.Exec(`UPDATE chat_roster
-		SET lastmsgseen = (
-			SELECT COALESCE(MAX(id), 0) FROM chat_messages WHERE chatid = chat_roster.chatid
-		)
-		WHERE userid = ?`, myid)
+func handleAllSeen(c *fiber.Ctx, db *gorm.DB, myid uint64, modtools bool) error {
+	// Mark chat messages as seen, scoped to the chats the caller's client actually
+	// shows. The ModTools "Mark all read" button sits above a list of moderator
+	// chats (User2Mod/Mod2Mod), so it must not also clear the moderator's personal
+	// member chats - doing so silently suppresses the FD unread badge for messages
+	// they have never read.
+	if modtools {
+		// countUnseenMT uses LEFT JOIN chat_roster with COALESCE(lastmsgseen, 0), so
+		// moderator-visible chats without a roster row are treated as fully unread.
+		// Update existing roster rows and insert a seen pointer for chats that have
+		// none, so the MT badge is guaranteed to clear.
+		modChatIDs := getModeratorChatIDs(db, myid, []string{utils.CHAT_TYPE_USER2MOD, utils.CHAT_TYPE_MOD2MOD}, "", 0)
+		if len(modChatIDs) > 0 {
+			idlist := joinIDs(modChatIDs)
+			db.Exec(`UPDATE chat_roster
+				SET lastmsgseen = (
+					SELECT COALESCE(MAX(id), 0) FROM chat_messages WHERE chatid = chat_roster.chatid
+				)
+				WHERE userid = ? AND chatid IN (`+idlist+`)`, myid)
 
-	// countUnseenMT uses LEFT JOIN chat_roster with COALESCE(lastmsgseen, 0), so
-	// moderator-visible chats without a roster row are treated as fully unread.
-	// When a moderator joins new groups, those groups' chats have no roster entry for
-	// the mod yet. Insert a seen pointer for any such chats so they are cleared.
-	modChatIDs := getModeratorChatIDs(db, myid, []string{utils.CHAT_TYPE_USER2MOD, utils.CHAT_TYPE_MOD2MOD}, "", 0)
-	if len(modChatIDs) > 0 {
-		idlist := joinIDs(modChatIDs)
+			db.Exec(`INSERT INTO chat_roster (chatid, userid, lastmsgseen, date)
+				SELECT cr.id, ?, COALESCE((SELECT MAX(id) FROM chat_messages WHERE chatid = cr.id), 0), NOW()
+				FROM chat_rooms cr
+				WHERE cr.id IN (`+idlist+`)
+				AND NOT EXISTS (SELECT 1 FROM chat_roster r2 WHERE r2.chatid = cr.id AND r2.userid = ?)`,
+				myid, myid)
+		}
+	} else {
+		// FD: chats the user participates in - User2User, plus User2Mod chats they
+		// opened. Mod-side roster rows (Mod2Mod, or User2Mod where the user is the
+		// moderator rather than user1) are left alone.
+		db.Exec(`UPDATE chat_roster
+			SET lastmsgseen = (
+				SELECT COALESCE(MAX(id), 0) FROM chat_messages WHERE chatid = chat_roster.chatid
+			)
+			WHERE userid = ?
+			AND chatid IN (SELECT id FROM chat_rooms WHERE (user1 = ? OR user2 = ?) AND chattype IN (?, ?))`,
+			myid, myid, myid, utils.CHAT_TYPE_USER2USER, utils.CHAT_TYPE_USER2MOD)
+
+		// V1 parity: chats with no roster row yet (e.g. a brand-new conversation the
+		// user has never opened) also count as unread, so give them a seen pointer.
 		db.Exec(`INSERT INTO chat_roster (chatid, userid, lastmsgseen, date)
 			SELECT cr.id, ?, COALESCE((SELECT MAX(id) FROM chat_messages WHERE chatid = cr.id), 0), NOW()
 			FROM chat_rooms cr
-			WHERE cr.id IN (`+idlist+`)
+			WHERE (cr.user1 = ? OR cr.user2 = ?) AND cr.chattype IN (?, ?)
 			AND NOT EXISTS (SELECT 1 FROM chat_roster r2 WHERE r2.chatid = cr.id AND r2.userid = ?)`,
-			myid, myid)
+			myid, myid, myid, utils.CHAT_TYPE_USER2USER, utils.CHAT_TYPE_USER2MOD, myid)
 	}
 
 	return c.JSON(fiber.Map{"ret": 0, "status": "Success"})

--- a/iznik-server-go/test/chat_test.go
+++ b/iznik-server-go/test/chat_test.go
@@ -1627,6 +1627,98 @@ func TestAllSeenNoChats(t *testing.T) {
 	assert.Equal(t, "Success", result["status"])
 }
 
+func TestAllSeenModtoolsScopedToModChats(t *testing.T) {
+	prefix := uniquePrefix("allseen_mt")
+	db := database.DBConn
+
+	// A moderator with a group, an unread User2Mod chat, an unread Mod2Mod chat
+	// (no roster row), and an unread personal User2User chat.
+	modID, _, groupID, u2mChatID, token := setupModChatData(t, prefix)
+
+	mod2ID := CreateTestUser(t, prefix+"_mod2", "Moderator")
+	CreateTestMembership(t, mod2ID, groupID, "Moderator")
+	m2mChatID := CreateTestChatRoom(t, mod2ID, &modID, &groupID, "Mod2Mod")
+	db.Exec("INSERT INTO chat_messages (chatid, userid, message, date, processingsuccessful, reviewrequired, reviewrejected) VALUES (?, ?, 'Mod chat msg', NOW(), 1, 0, 0)",
+		m2mChatID, mod2ID)
+
+	otherID := CreateTestUser(t, prefix+"_other", "User")
+	personalChatID := CreateTestChatRoom(t, modID, &otherID, nil, "User2User")
+	personalMsgID := CreateTestChatMessage(t, personalChatID, otherID, "Unread personal message")
+
+	db.Exec("INSERT INTO chat_roster (chatid, userid, status, lastmsgseen, date) VALUES (?, ?, 'Online', 0, NOW()) ON DUPLICATE KEY UPDATE lastmsgseen = 0", personalChatID, modID)
+	db.Exec("INSERT INTO chat_roster (chatid, userid, status, lastmsgseen, date) VALUES (?, ?, 'Online', 0, NOW()) ON DUPLICATE KEY UPDATE lastmsgseen = 0", u2mChatID, modID)
+
+	// ModTools "Mark all read".
+	payload := map[string]interface{}{"action": "AllSeen", "modtools": true}
+	s, _ := json2.Marshal(payload)
+	request := httptest.NewRequest("POST", "/api/chatrooms?jwt="+token, bytes.NewBuffer(s))
+	request.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(request)
+	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+
+	// Moderator chats are cleared: existing roster row updated...
+	var u2mSeen uint64
+	db.Raw("SELECT lastmsgseen FROM chat_roster WHERE chatid = ? AND userid = ?", u2mChatID, modID).Scan(&u2mSeen)
+	assert.NotEqual(t, uint64(0), u2mSeen, "User2Mod chat should be marked seen")
+
+	// ...and a roster row inserted where none existed.
+	var m2mSeen uint64
+	db.Raw("SELECT lastmsgseen FROM chat_roster WHERE chatid = ? AND userid = ?", m2mChatID, modID).Scan(&m2mSeen)
+	assert.NotEqual(t, uint64(0), m2mSeen, "Mod2Mod chat should get a seen pointer")
+
+	// The personal member chat is untouched - its message is still unread, so the
+	// FD badge can still show it.
+	var personalSeen uint64
+	db.Raw("SELECT lastmsgseen FROM chat_roster WHERE chatid = ? AND userid = ?", personalChatID, modID).Scan(&personalSeen)
+	assert.Equal(t, uint64(0), personalSeen, "ModTools Mark all read must not mark personal member chats seen")
+	assert.Less(t, personalSeen, personalMsgID)
+}
+
+func TestAllSeenFDDoesNotTouchModChats(t *testing.T) {
+	prefix := uniquePrefix("allseen_fd")
+	db := database.DBConn
+
+	// A moderator with an unread User2Mod chat (mod side) and an unread personal
+	// User2User chat, including one with no roster row yet.
+	modID, _, _, u2mChatID, token := setupModChatData(t, prefix)
+
+	otherID := CreateTestUser(t, prefix+"_other", "User")
+	personalChatID := CreateTestChatRoom(t, modID, &otherID, nil, "User2User")
+	CreateTestChatMessage(t, personalChatID, otherID, "Unread personal message")
+	db.Exec("INSERT INTO chat_roster (chatid, userid, status, lastmsgseen, date) VALUES (?, ?, 'Online', 0, NOW()) ON DUPLICATE KEY UPDATE lastmsgseen = 0", personalChatID, modID)
+
+	// A second personal chat where the recipient has no roster row at all (the
+	// state a brand-new incoming conversation is in).
+	other2ID := CreateTestUser(t, prefix+"_other2", "User")
+	noRosterChatID := CreateTestChatRoom(t, modID, &other2ID, nil, "User2User")
+	CreateTestChatMessage(t, noRosterChatID, other2ID, "Unread in rosterless chat")
+	db.Exec("DELETE FROM chat_roster WHERE chatid = ? AND userid = ?", noRosterChatID, modID)
+
+	db.Exec("INSERT INTO chat_roster (chatid, userid, status, lastmsgseen, date) VALUES (?, ?, 'Online', 0, NOW()) ON DUPLICATE KEY UPDATE lastmsgseen = 0", u2mChatID, modID)
+
+	// FD "Mark all read".
+	payload := map[string]interface{}{"action": "AllSeen", "modtools": false}
+	s, _ := json2.Marshal(payload)
+	request := httptest.NewRequest("POST", "/api/chatrooms?jwt="+token, bytes.NewBuffer(s))
+	request.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(request)
+	assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+
+	// Personal chats are cleared, including the one with no roster row.
+	var personalSeen uint64
+	db.Raw("SELECT lastmsgseen FROM chat_roster WHERE chatid = ? AND userid = ?", personalChatID, modID).Scan(&personalSeen)
+	assert.NotEqual(t, uint64(0), personalSeen, "FD Mark all read should mark personal chats seen")
+
+	var noRosterSeen uint64
+	db.Raw("SELECT lastmsgseen FROM chat_roster WHERE chatid = ? AND userid = ?", noRosterChatID, modID).Scan(&noRosterSeen)
+	assert.NotEqual(t, uint64(0), noRosterSeen, "FD Mark all read should insert a seen pointer for rosterless chats")
+
+	// The mod-side User2Mod roster row is untouched.
+	var u2mSeen uint64
+	db.Raw("SELECT lastmsgseen FROM chat_roster WHERE chatid = ? AND userid = ?", u2mChatID, modID).Scan(&u2mSeen)
+	assert.Equal(t, uint64(0), u2mSeen, "FD Mark all read must not touch moderator-side chats")
+}
+
 // =============================================================================
 // ReferToSupport tests
 // =============================================================================
@@ -4448,8 +4540,9 @@ func TestModeratorUnreadCountClearedByMarkAllRead(t *testing.T) {
 	assert.GreaterOrEqual(t, countBefore, int64(numChats),
 		"should have at least %d unread messages before markAllRead", numChats)
 
-	// Call mark-all-read (POST /chatrooms with action=AllSeen).
-	payload := map[string]interface{}{"action": "AllSeen"}
+	// Call mark-all-read (POST /chatrooms with action=AllSeen). The ModTools client
+	// sends modtools:true, which scopes AllSeen to moderator chats (User2Mod/Mod2Mod).
+	payload := map[string]interface{}{"action": "AllSeen", "modtools": true}
 	s, _ := json2.Marshal(payload)
 	req2 := httptest.NewRequest("POST", "/api/chatrooms?jwt="+modToken, bytes.NewBuffer(s))
 	req2.Header.Set("Content-Type", "application/json")


### PR DESCRIPTION
## Summary

ModTools "Mark all read" was wiping members' personal unread chat state. The `AllSeen` action (`POST /apiv2/chatrooms {action: "AllSeen"}`) ran an unscoped `UPDATE chat_roster SET lastmsgseen = MAX(id) WHERE userid = ?`, so a moderator clicking "Mark all read" on the ModTools chats page (which only lists User2Mod/Mod2Mod chats) also marked every personal User2User chat as seen. The FD red chat badge then had nothing to show for messages they had never read.

Reported by Derek on Discourse: https://discourse.ilovefreegle.org/t/testing-please/9481/626 - traced in prod Loki/DB: his ModTools "Mark all read" click at 12:38:49 UTC on 16 July marked a brand-new member chat (an enquiry about his OFFER) as seen 43 seconds before his Freegle tab reloaded, so the unread badge never appeared.

This matches V1 behaviour (`upToDateAll` was called with chattypes NULL), so it is a longstanding bug rather than a Go-migration regression - but it is still wrong: the button acts on a list that only shows moderator chats.

## Change

`handleAllSeen` now scopes by the caller's client context (the client already sends `modtools` in the body):

- **ModTools** (`modtools: true`): only moderator chats, via `getModeratorChatIDs` (User2Mod/Mod2Mod) - the same set `countUnseenMT` counts for the MT badge, so the MT badge still clears fully. Keeps the existing insert of seen pointers for mod chats with no roster row.
- **FD** (`modtools: false` or absent): only chats the user participates in (User2User, plus User2Mod chats they opened). Also inserts a seen pointer for participant chats with no roster row yet (V1 parity - previously "mark all read" could not clear a brand-new conversation the user had never opened).

Older app clients that do not send `modtools` default to the FD scope, which is correct for them.

## Tests

- `TestAllSeenModtoolsScopedToModChats`: MT AllSeen clears User2Mod (existing roster row) and Mod2Mod (roster row inserted), and leaves a personal User2User chat unread.
- `TestAllSeenFDDoesNotTouchModChats`: FD AllSeen clears personal chats including a rosterless one, and leaves the moderator-side User2Mod roster untouched.
- Existing `TestAllSeen` / `TestAllSeenNotLoggedIn` / `TestAllSeenNoChats` unchanged and passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SCyyc1t3DrxcXmH9tzUTad
