### PR TITLE
fix(apiv2): collision-safe chat room consolidation on email-verify account merge

### DIFF
--- a/iznik-server-go/session/merge.go
+++ b/iznik-server-go/session/merge.go
@@ -1,0 +1,129 @@
+package session
+
+import (
+	"gorm.io/gorm"
+)
+
+// MergeUserAccounts merges the account `loser` into `survivor` after the
+// survivor proves ownership of one of the loser's email addresses via email
+// verification. All references move to the surviving user and the loser is
+// marked deleted. Everything runs in one transaction so a failure rolls back
+// cleanly rather than leaving the merge half-applied.
+func MergeUserAccounts(db *gorm.DB, survivor uint64, loser uint64) error {
+	return db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Exec("UPDATE messages SET fromuser = ? WHERE fromuser = ?", survivor, loser).Error; err != nil {
+			return err
+		}
+
+		if err := mergeChatRooms(tx, survivor, loser); err != nil {
+			return err
+		}
+
+		if err := tx.Exec("UPDATE chat_messages SET userid = ? WHERE userid = ?", survivor, loser).Error; err != nil {
+			return err
+		}
+
+		if err := tx.Exec("UPDATE users_emails SET userid = ? WHERE userid = ?", survivor, loser).Error; err != nil {
+			return err
+		}
+
+		// The survivor may already belong to some of the loser's groups —
+		// IGNORE skips those, then the leftovers are removed.
+		if err := tx.Exec("UPDATE IGNORE memberships SET userid = ? WHERE userid = ?", survivor, loser).Error; err != nil {
+			return err
+		}
+		if err := tx.Exec("DELETE FROM memberships WHERE userid = ?", loser).Error; err != nil {
+			return err
+		}
+
+		return tx.Exec("UPDATE users SET deleted = NOW() WHERE id = ?", loser).Error
+	})
+}
+
+// mergeChatRooms reassigns the loser's chat rooms to the survivor without
+// tripping the unique key on (user1, user2, chattype). A blind UPDATE fails
+// with a duplicate-key error when both users already have a room with the
+// same counterparty, aborting the whole statement and stranding those rooms
+// (and their history) on the about-to-be-deleted loser. Instead:
+//
+//  1. Rooms directly between the pair would become self-chats after the
+//     merge — delete them (their chat_messages and chat_roster rows go via
+//     FK cascade).
+//  2. Where both users have a room with the same counterparty and chattype
+//     (in either user1/user2 ordering), move the loser room's history into
+//     the survivor's room, then delete the loser room.
+//  3. Reassign whatever remains, which can no longer collide.
+func mergeChatRooms(tx *gorm.DB, survivor uint64, loser uint64) error {
+	// 1. Direct rooms between the two users, plus any degenerate self-rooms.
+	if err := tx.Exec(`DELETE FROM chat_rooms
+		WHERE (user1 = ? AND user2 = ?) OR (user1 = ? AND user2 = ?) OR (user1 = ? AND user2 = ?)`,
+		survivor, loser, loser, survivor, loser, loser).Error; err != nil {
+		return err
+	}
+
+	// 2. Loser rooms whose counterparty+chattype the survivor already has.
+	// The counterparty can sit in user1 or user2 on either side, so match via
+	// IF() rather than on raw columns. A NULL counterparty (User2Mod rooms
+	// have user2 NULL) never matches here — those rooms can't collide anyway
+	// because the unique key permits repeated NULLs. MIN() picks one surviving
+	// room if the survivor somehow has rooms in both orderings.
+	var pairs []struct {
+		LoserID    uint64
+		SurvivorID uint64
+	}
+	if err := tx.Raw(`SELECT lr.id AS loser_id, MIN(sr.id) AS survivor_id
+		FROM chat_rooms lr
+		JOIN chat_rooms sr
+		  ON sr.chattype = lr.chattype
+		 AND (   (sr.user1 = ? AND sr.user2 = IF(lr.user1 = ?, lr.user2, lr.user1))
+		      OR (sr.user2 = ? AND sr.user1 = IF(lr.user1 = ?, lr.user2, lr.user1)))
+		WHERE lr.user1 = ? OR lr.user2 = ?
+		GROUP BY lr.id`,
+		survivor, loser, survivor, loser, loser, loser).Scan(&pairs).Error; err != nil {
+		return err
+	}
+
+	for _, p := range pairs {
+		// Move the history before deleting the room — chat_messages.chatid
+		// cascades on room deletion.
+		if err := tx.Exec("UPDATE chat_messages SET chatid = ? WHERE chatid = ?", p.SurvivorID, p.LoserID).Error; err != nil {
+			return err
+		}
+		if err := tx.Exec("UPDATE chat_messages SET refchatid = ? WHERE refchatid = ?", p.SurvivorID, p.LoserID).Error; err != nil {
+			return err
+		}
+		// Carry roster presence (unread pointers etc.) across where the
+		// surviving room doesn't already have a row for that user.
+		if err := tx.Exec("UPDATE IGNORE chat_roster SET chatid = ? WHERE chatid = ?", p.SurvivorID, p.LoserID).Error; err != nil {
+			return err
+		}
+		// Surface the merged history's recency in chat list ordering.
+		if err := tx.Exec(`UPDATE chat_rooms surv JOIN chat_rooms lose ON lose.id = ?
+			SET surv.latestmessage = lose.latestmessage
+			WHERE surv.id = ? AND lose.latestmessage IS NOT NULL
+			  AND (surv.latestmessage IS NULL OR surv.latestmessage < lose.latestmessage)`,
+			p.LoserID, p.SurvivorID).Error; err != nil {
+			return err
+		}
+		if err := tx.Exec("DELETE FROM chat_rooms WHERE id = ?", p.LoserID).Error; err != nil {
+			return err
+		}
+	}
+
+	// 3. The remaining rooms can't collide: colliding counterparties were
+	// consolidated above, and User2Mod-style rooms have a NULL column the
+	// unique key doesn't enforce over.
+	if err := tx.Exec("UPDATE chat_rooms SET user1 = ? WHERE user1 = ?", survivor, loser).Error; err != nil {
+		return err
+	}
+	if err := tx.Exec("UPDATE chat_rooms SET user2 = ? WHERE user2 = ?", survivor, loser).Error; err != nil {
+		return err
+	}
+
+	// Move the loser's roster presence to the survivor; where the survivor
+	// already sits in a room, keep theirs and drop the loser's.
+	if err := tx.Exec("UPDATE IGNORE chat_roster SET userid = ? WHERE userid = ?", survivor, loser).Error; err != nil {
+		return err
+	}
+	return tx.Exec("DELETE FROM chat_roster WHERE userid = ?", loser).Error
+}

--- a/iznik-server-go/session/session.go
+++ b/iznik-server-go/session/session.go
@@ -1725,38 +1725,21 @@ func PatchSession(c *fiber.Ctx) error {
 
 		for _, mail := range emails {
 			if mail.UserID != 0 && mail.UserID != myid {
-				// Email belongs to another user — merge their account into ours.
-				// Move references from the other user to this user.
-				var wg2 sync.WaitGroup
-				wg2.Add(5)
-
-				go func() {
-					defer wg2.Done()
-					db.Exec("UPDATE messages SET fromuser = ? WHERE fromuser = ?", myid, mail.UserID)
-				}()
-				go func() {
-					defer wg2.Done()
-					db.Exec("UPDATE chat_rooms SET user1 = ? WHERE user1 = ?", myid, mail.UserID)
-				}()
-				go func() {
-					defer wg2.Done()
-					db.Exec("UPDATE chat_rooms SET user2 = ? WHERE user2 = ?", myid, mail.UserID)
-				}()
-				go func() {
-					defer wg2.Done()
-					db.Exec("UPDATE chat_messages SET userid = ? WHERE userid = ?", myid, mail.UserID)
-				}()
-				go func() {
-					defer wg2.Done()
-					db.Exec("UPDATE users_emails SET userid = ? WHERE userid = ?", myid, mail.UserID)
-				}()
-				wg2.Wait()
-
-				db.Exec("UPDATE IGNORE memberships SET userid = ? WHERE userid = ?", myid, mail.UserID)
-				db.Exec("DELETE FROM memberships WHERE userid = ?", mail.UserID)
-				db.Exec("UPDATE users SET deleted = NOW() WHERE id = ?", mail.UserID)
-
-				stdlog.Printf("Merged user %d into %d during email verify of %s", mail.UserID, myid, mail.Email)
+				// Email belongs to another user — merge their account into
+				// ours. Chat rooms need collision-safe consolidation (the
+				// unique key on user1/user2/chattype forbids a blind
+				// reassignment), so the whole merge runs transactionally in
+				// MergeUserAccounts.
+				if err := MergeUserAccounts(db, myid, mail.UserID); err != nil {
+					// Rolled back — nothing half-applied, and the email is
+					// still confirmed below so verification succeeds for the
+					// user. The duplicate account survives; a later
+					// verification or support action can merge it.
+					stdlog.Printf("ERROR: merge of user %d into %d failed during email verify of %s: %v",
+						mail.UserID, myid, mail.Email, err)
+				} else {
+					stdlog.Printf("Merged user %d into %d during email verify of %s", mail.UserID, myid, mail.Email)
+				}
 			}
 
 			// Clear all preferred flags for this user, then set the confirmed email as preferred.

--- a/iznik-server-go/test/session_test.go
+++ b/iznik-server-go/test/session_test.go
@@ -1232,6 +1232,161 @@ func TestPatchSessionConfirmEmailMergesUser(t *testing.T) {
 	db.Exec("DELETE FROM users_emails WHERE email = ?", testEmail)
 }
 
+// TestPatchSessionConfirmEmailMergeConsolidatesChatRooms covers the account
+// merge when both users already chat to the same counterparties. chat_rooms
+// has a unique key on (user1, user2, chattype), so blindly reassigning the
+// merged user's rooms collides when the surviving user already has a room
+// with the same counterparty — historically that aborted the UPDATE and
+// orphaned the rooms (and their chat history) on the deleted user. The merge
+// must instead migrate messages into the surviving room and delete the
+// duplicate, matching on counterparty in either user1/user2 ordering.
+func TestPatchSessionConfirmEmailMergeConsolidatesChatRooms(t *testing.T) {
+	prefix := uniquePrefix("merge_rooms")
+	survivor := CreateTestUser(t, prefix+"_srv", "User")
+	_, token := CreateTestSession(t, survivor)
+	loser := CreateTestUser(t, prefix+"_los", "User")
+	zed := CreateTestUser(t, prefix+"_zed", "User")   // both users chat to zed, same ordering
+	yana := CreateTestUser(t, prefix+"_yan", "User")  // both users chat to yana, opposite ordering
+	wendy := CreateTestUser(t, prefix+"_wen", "User") // only the loser chats to wendy
+
+	db := database.DBConn
+
+	insertRoom := func(user1, user2 uint64, latest string) uint64 {
+		db.Exec("INSERT INTO chat_rooms (user1, user2, chattype, latestmessage) VALUES (?, ?, 'User2User', ?)",
+			user1, user2, latest)
+		var id uint64
+		db.Raw("SELECT id FROM chat_rooms WHERE user1 = ? AND user2 = ? AND chattype = 'User2User' ORDER BY id DESC LIMIT 1",
+			user1, user2).Scan(&id)
+		assert.NotZero(t, id)
+		t.Cleanup(func() { db.Exec("DELETE FROM chat_rooms WHERE id = ?", id) })
+		return id
+	}
+
+	insertMessage := func(chatID, fromUser uint64, text string) uint64 {
+		db.Exec("INSERT INTO chat_messages (chatid, userid, message) VALUES (?, ?, ?)", chatID, fromUser, text)
+		var id uint64
+		db.Raw("SELECT id FROM chat_messages WHERE message = ? ORDER BY id DESC LIMIT 1", text).Scan(&id)
+		assert.NotZero(t, id)
+		t.Cleanup(func() { db.Exec("DELETE FROM chat_messages WHERE id = ?", id) })
+		return id
+	}
+
+	// Colliding pair, same ordering: both rooms have zed as user2, so the raw
+	// user1 reassignment would hit the unique key.
+	roomSurvivorZed := insertRoom(survivor, zed, "2026-01-01 00:00:00")
+	roomLoserZed := insertRoom(loser, zed, "2026-01-02 03:04:05")
+	m1 := insertMessage(roomSurvivorZed, survivor, prefix+"_m1")
+	m2 := insertMessage(roomLoserZed, loser, prefix+"_m2")
+	m3 := insertMessage(roomLoserZed, zed, prefix+"_m3")
+
+	// Colliding pair, opposite ordering: the loser's room has yana as user1.
+	// A raw reassignment would not collide but would leave two rooms between
+	// the same pair — consolidation must match on counterparty, not column.
+	roomSurvivorYana := insertRoom(survivor, yana, "2026-01-01 00:00:00")
+	roomLoserYana := insertRoom(yana, loser, "2026-01-01 00:00:00")
+	m4 := insertMessage(roomLoserYana, loser, prefix+"_m4")
+
+	// Direct room between the two accounts: becomes a self-chat after merge,
+	// so it must be deleted along with its messages.
+	roomDirect := insertRoom(loser, survivor, "2026-01-01 00:00:00")
+	insertMessage(roomDirect, loser, prefix+"_m5")
+
+	// Non-colliding room: simply reassigned to the survivor.
+	roomLoserWendy := insertRoom(loser, wendy, "2026-01-01 00:00:00")
+	m6 := insertMessage(roomLoserWendy, wendy, prefix+"_m6")
+
+	// Roster rows: the survivor sits in their zed room, the loser and zed sit
+	// in the loser's zed room.
+	db.Exec("INSERT INTO chat_roster (chatid, userid) VALUES (?, ?), (?, ?), (?, ?), (?, ?)",
+		roomSurvivorZed, survivor, roomLoserZed, loser, roomLoserZed, zed, roomLoserWendy, loser)
+
+	// The loser owns an email with a validatekey; the survivor confirms it.
+	testEmail := prefix + "_rooms@test.com"
+	canon := strings.ToLower(strings.ReplaceAll(testEmail, ".", ""))
+	validateKey := prefix[:24]
+	db.Exec("INSERT INTO users_emails (email, canon, backwards, validatekey, userid) VALUES (?, ?, ?, ?, ?)",
+		testEmail, canon, reverseString(canon), validateKey, loser)
+	t.Cleanup(func() { db.Exec("DELETE FROM users_emails WHERE email = ?", testEmail) })
+
+	body, _ := json.Marshal(map[string]interface{}{
+		"key": validateKey,
+	})
+	req := httptest.NewRequest("PATCH", "/api/session?jwt="+token, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := getApp().Test(req)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&result)
+	assert.Equal(t, float64(0), result["ret"])
+
+	// No chat rooms may be left referencing the merged user.
+	var loserRooms int64
+	db.Raw("SELECT COUNT(*) FROM chat_rooms WHERE user1 = ? OR user2 = ?", loser, loser).Scan(&loserRooms)
+	assert.Equal(t, int64(0), loserRooms, "merged user must not be left holding chat rooms")
+
+	// Same-ordering collision: the loser's room is gone and its history moved
+	// into the surviving room. Authorship follows the merge for the loser's
+	// own messages; the counterparty's messages keep their author.
+	var count int64
+	db.Raw("SELECT COUNT(*) FROM chat_rooms WHERE id = ?", roomLoserZed).Scan(&count)
+	assert.Equal(t, int64(0), count, "colliding room (same ordering) should be deleted")
+	var chatID, fromID uint64
+	db.Raw("SELECT chatid, userid FROM chat_messages WHERE id = ?", m2).Row().Scan(&chatID, &fromID)
+	assert.Equal(t, roomSurvivorZed, chatID, "loser's message should move to the surviving room")
+	assert.Equal(t, survivor, fromID, "loser's message should be re-authored to the survivor")
+	db.Raw("SELECT chatid, userid FROM chat_messages WHERE id = ?", m3).Row().Scan(&chatID, &fromID)
+	assert.Equal(t, roomSurvivorZed, chatID, "counterparty's message should move to the surviving room")
+	assert.Equal(t, zed, fromID, "counterparty's message should keep its author")
+	db.Raw("SELECT chatid FROM chat_messages WHERE id = ?", m1).Scan(&chatID)
+	assert.Equal(t, roomSurvivorZed, chatID, "surviving room's own message should be untouched")
+
+	// The surviving room should surface the merged history's recency.
+	var latest string
+	db.Raw("SELECT latestmessage FROM chat_rooms WHERE id = ?", roomSurvivorZed).Scan(&latest)
+	assert.Contains(t, latest, "2026-01-02", "surviving room should take the newer latestmessage")
+
+	// Opposite-ordering collision: consolidated too, leaving exactly one room
+	// between the survivor and yana.
+	db.Raw("SELECT COUNT(*) FROM chat_rooms WHERE id = ?", roomLoserYana).Scan(&count)
+	assert.Equal(t, int64(0), count, "colliding room (opposite ordering) should be deleted")
+	db.Raw("SELECT COUNT(*) FROM chat_rooms WHERE (user1 = ? AND user2 = ?) OR (user1 = ? AND user2 = ?)",
+		survivor, yana, yana, survivor).Scan(&count)
+	assert.Equal(t, int64(1), count, "exactly one room should remain between survivor and yana")
+	db.Raw("SELECT chatid FROM chat_messages WHERE id = ?", m4).Scan(&chatID)
+	assert.Equal(t, roomSurvivorYana, chatID, "message should move to the surviving yana room")
+
+	// The direct room between the two accounts is deleted with its history.
+	db.Raw("SELECT COUNT(*) FROM chat_rooms WHERE id = ?", roomDirect).Scan(&count)
+	assert.Equal(t, int64(0), count, "direct room between merged accounts should be deleted")
+	db.Raw("SELECT COUNT(*) FROM chat_messages WHERE chatid = ?", roomDirect).Scan(&count)
+	assert.Equal(t, int64(0), count, "direct room's messages should be deleted")
+
+	// The non-colliding room is reassigned intact.
+	var w1, w2 uint64
+	db.Raw("SELECT user1, user2 FROM chat_rooms WHERE id = ?", roomLoserWendy).Row().Scan(&w1, &w2)
+	assert.Equal(t, survivor, w1, "non-colliding room should be reassigned to the survivor")
+	assert.Equal(t, wendy, w2)
+	db.Raw("SELECT chatid, userid FROM chat_messages WHERE id = ?", m6).Row().Scan(&chatID, &fromID)
+	assert.Equal(t, roomLoserWendy, chatID, "reassigned room keeps its messages")
+	assert.Equal(t, wendy, fromID)
+
+	// Roster: no rows may be left for the merged user; the counterparty's
+	// roster presence migrates to the surviving room.
+	db.Raw("SELECT COUNT(*) FROM chat_roster WHERE userid = ?", loser).Scan(&count)
+	assert.Equal(t, int64(0), count, "merged user must not be left on any roster")
+	db.Raw("SELECT COUNT(*) FROM chat_roster WHERE chatid = ? AND userid = ?", roomSurvivorZed, zed).Scan(&count)
+	assert.Equal(t, int64(1), count, "counterparty's roster row should migrate to the surviving room")
+
+	// Standard merge outcomes still hold.
+	var dbUserID uint64
+	db.Raw("SELECT userid FROM users_emails WHERE email = ?", testEmail).Scan(&dbUserID)
+	assert.Equal(t, survivor, dbUserID)
+	var deletedAt *string
+	db.Raw("SELECT deleted FROM users WHERE id = ?", loser).Scan(&deletedAt)
+	assert.NotNil(t, deletedAt)
+}
+
 // reverseString reverses a string for the backwards column.
 func reverseString(s string) string {
 	runes := []rune(s)


### PR DESCRIPTION
## Summary

- Fixes chat history loss during email-verify account merges. When a user verifies an email owned by another account, `PatchSession` merges that account into theirs. The chat_rooms reassignment used two bare `UPDATE`s, and `chat_rooms` has a unique key on `(user1, user2, chattype)` - so when both accounts already had a room with the same counterparty, the `UPDATE` failed with a duplicate-key error, the rooms stayed on the merged account, and the merge then marked that account deleted. Those rooms and their `chat_messages` were stranded on a deleted user. **Correction to the figures originally quoted here:** db3's log covers 26 May-17 Jul, and in that window there were 121 merges with 68 collision aborts - roughly one history-losing merge every day or two, not "68 in 2h". The damage per event is large, though: a collision aborts the whole multi-row `UPDATE`, stranding every room on that side for that user. Of the 119 merged users in the log, 42 still have stranded rooms: 2,410 rooms holding 17,030 chat messages.
- The merge now runs in a single transaction (`MergeUserAccounts` in `session/merge.go`), so a failure rolls back cleanly instead of half-applying across unsynchronized goroutines.
- Chat rooms are consolidated instead of blindly reassigned (`mergeChatRooms`):
  - Rooms directly between the two accounts (which would become self-chats) are deleted; FK cascade removes their messages and roster rows.
  - Rooms whose counterparty+chattype the survivor already holds get their `chat_messages` (and `refchatid` references), roster presence, and `latestmessage` recency migrated into the surviving room before the duplicate is deleted. Messages must move before the delete because `chat_messages.chatid` cascades on room deletion. Counterparty matching handles either `user1`/`user2` ordering, so opposite-ordering duplicates are consolidated too instead of leaving two rooms for the same pair.
  - Only collision-free rooms are reassigned.
- Roster rows for the merged user move to the survivor (`UPDATE IGNORE` + delete of leftovers), so unread pointers carry over where possible.
- `User2Mod`-style rooms (NULL `user2`) can't collide on the unique key (MySQL permits repeated NULLs), so they flow through the plain reassignment path unchanged.
- If the merge transaction fails, the email verification still succeeds and the failure is logged loudly; the duplicate account survives intact for a later merge instead of being half-dismembered.

## Code Quality Review

- The `Merged user %d into %d` log line format is unchanged - existing log greps keep working.
- Idempotent for accounts already half-merged by the old code: consolidation recomputes collisions from current state.
- Pre-existing gofmt drift elsewhere in `session.go` / `session_test.go` on master was left untouched; the new/edited regions are gofmt-clean.
- No docs page `covers:` these paths, so no docs updates are required.

## Test Plan

- New Go test `TestPatchSessionConfirmEmailMergeConsolidatesChatRooms` exercises, in one merge: a same-ordering collision (the case that aborted with error 1062 before), an opposite-ordering duplicate, a direct room between the two accounts, a non-colliding room, roster migration, message re-authoring, and `latestmessage` recency. Verified red against the old handler (fails with the exact production signature - error 1062 on `chat_rooms.user1_2`, rooms stranded on the merged user) and green with the fix.
- New Go test `TestMergeUserAccountsRollsBackOnFailure` forces a mid-merge foreign-key failure and proves the transaction rolls back atomically - nothing half-applied.
- Existing `TestPatchSessionConfirmEmailMergesUser` still passes.
- Full local Go suite green via the status API (3502 tests).

## Future Improvements

- **Backfill**: precisely identifiable from the node logs: 42 merged users with 2,410 stranded rooms / 17,030 messages (db3 log back to 26 May; db1/db2 logs only reach 7 Jul and add one more user). Merges before log coverage (the Go path shipped ~end of March) are an unknown extra tail without reliable DB-only identification. Because the new consolidation is idempotent, the natural backfill is to re-run it for each logged (survivor, loser) pair. Scope/approval pending.
- Merges run ~2/day, dominated by old accounts merging into freshly created ones - returning users signing up anew and then verifying their old email. Low volume, but the pattern may still interest product.
- After a merge the survivor can hold two `User2Mod` rooms for the same group (the unique key doesn't constrain NULL `user2`); pre-existing behaviour, not addressed here.
- V1's merge handled more reference tables (e.g. `users_chatlists_index` is left to its cache-refresh cycle); unchanged in scope here.
