### PR TITLE
chore(hooks): move Freegle-specific Claude hooks from personal config into the repo

### DIFF
--- a/.claude/check-dismissive-reasoning.sh
+++ b/.claude/check-dismissive-reasoning.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# PreToolUse hook: catch dismissive language ("unrelated", "pre-existing", and
+# kin) in Claude's reasoning MID-TURN. The existing project Stop hook
+# (check-dismissive-language.sh) only fires at turn end, reading the final
+# message — so a dismissal made mid-turn (in a response that then calls a tool)
+# slips through. This scans the LATEST assistant message (text + thinking) from
+# the transcript before each tool call; on a match it blocks the call and
+# reminds Claude to investigate/fix rather than wave the problem away.
+#
+# Registered in the Freegle repo (.claude/settings.json, PreToolUse matcher "*"), alongside
+# its turn-end sibling check-dismissive-language.sh.
+
+INPUT=$(cat 2>/dev/null)
+TRANS=$(printf '%s' "$INPUT" | jq -r '.transcript_path // empty' 2>/dev/null)
+[ -z "$TRANS" ] && exit 0
+[ ! -f "$TRANS" ] && exit 0
+
+# Pull the most recent assistant message's text + thinking. Only the tail is read
+# so this stays fast (PreToolUse runs before every tool call).
+MSG=$(tail -n 80 "$TRANS" 2>/dev/null | tac | python3 -c "
+import sys, json
+for line in sys.stdin:
+    try:
+        o = json.loads(line)
+    except Exception:
+        continue
+    m = o.get('message', {})
+    if isinstance(m, dict) and m.get('role') == 'assistant':
+        parts = []
+        for b in (m.get('content') or []):
+            if isinstance(b, dict):
+                parts.append(b.get('text') or b.get('thinking') or '')
+        print(' '.join(parts))
+        break
+" 2>/dev/null)
+
+[ "${#MSG}" -lt 15 ] && exit 0
+
+# Don't fire while discussing the hook itself or dismissive-language detection -
+# e.g. listing the trigger words, explaining a false positive. Otherwise the
+# guardrail cries wolf every time it is described, which trains it to be ignored.
+if printf '%s' "$MSG" | grep -iqE "dismissive|check-dismissive|this hook|the hook|a hook to|guardrail|self-monitor|reasoning hook|stop hook|pretooluse hook|trigger word|false positive|cry wolf|literal (word|string)|meta-exclusion|exclusion (list|regex|pattern)"; then
+  exit 0
+fi
+
+# Dismissive patterns. "unrelated" / "pre-existing" the user explicitly named;
+# the contextual forms catch the same move when phrased around a problem so
+# benign uses ("two unrelated features") don't trip it.
+PATTERNS=(
+  '\bpre-?existing\b'
+  '\bpre existing\b'
+  'unrelated.{0,40}(fail|test|error|bug|hang|issue|change|broken|flak|warning)'
+  '(fail|test|error|bug|hang|issue|broken|flak|warning).{0,40}unrelated'
+  '(fail|failing|failure|broke|broken|crash|error|red mark).{0,70}not (my|our|related to (my|our|the|this)) (change|code|commit|pr|branch|fault|problem|bug)'
+  'not (my|our|related to (my|our|the|this)) (change|code|commit|pr|branch|fault|problem|bug).{0,70}(fail|failing|failure|broke|broken|crash|error|red mark)'
+  '(fail|failing|failure|broke|broken|crash|error).{0,70}nothing to do with (my|our|this|the|what)'
+  'nothing to do with (my|our|this|the|what).{0,70}(fail|failing|failure|broke|broken|crash|error)'
+  'known (issue|failure|flak|bug).{0,40}(ignore|skip|move|proceed|leave)'
+  'already (failing|broken|flaky)( before)?'
+  '\b(out of|beyond) (the )?scope\b'
+  '(environmental|infra(structure)?|transient) (issue|flake|failure|hang)'
+)
+
+for p in "${PATTERNS[@]}"; do
+  if printf '%s' "$MSG" | grep -iqE "$p" 2>/dev/null; then
+    HIT=$(printf '%s' "$MSG" | grep -ioE "$p" 2>/dev/null | head -1)
+    echo "STOP — dismissive reasoning detected mid-turn: \"$HIT\". All bugs need fixes; calling a failure/bug 'unrelated', 'pre-existing', 'flaky', 'environmental', or 'out of scope' is cheating. Find the root cause and FIX it, or prove the dismissal with concrete evidence (a stack trace, a git blame, a passing run on a clean tree) before continuing." >&2
+    exit 2
+  fi
+done
+
+exit 0

--- a/.claude/check-replication-excuse.sh
+++ b/.claude/check-replication-excuse.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# PreToolUse hook: catch Claude blaming READ REPLICATION / replica lag as the
+# cause of a bug MID-TURN. Freegle runs on a Galera cluster (virtually-
+# synchronous replication), so "a read hit a stale replica" is an extremely
+# unlikely explanation — and it is essentially impossible for static reference
+# data (locations, groups, config) that exists identically on every node.
+# Reaching for replica lag is a recurring lazy diagnosis; this scans the latest
+# assistant message (text + thinking) before each tool call and, on a match that
+# is NOT a negation/acknowledgement, blocks and prompts for the real cause.
+#
+# Registered in the Freegle repo (.claude/settings.json, PreToolUse matcher "*") - it is
+# Freegle-Galera-specific, so it belongs with the project, not personal config.
+
+INPUT=$(cat 2>/dev/null)
+TRANS=$(printf '%s' "$INPUT" | jq -r '.transcript_path // empty' 2>/dev/null)
+[ -z "$TRANS" ] && exit 0
+[ ! -f "$TRANS" ] && exit 0
+
+MSG=$(tail -n 80 "$TRANS" 2>/dev/null | tac | python3 -c "
+import sys, json
+for line in sys.stdin:
+    try:
+        o = json.loads(line)
+    except Exception:
+        continue
+    m = o.get('message', {})
+    if isinstance(m, dict) and m.get('role') == 'assistant':
+        parts = []
+        for b in (m.get('content') or []):
+            if isinstance(b, dict):
+                parts.append(b.get('text') or b.get('thinking') or '')
+        print(' '.join(parts))
+        break
+" 2>/dev/null)
+
+[ "${#MSG}" -lt 15 ] && exit 0
+
+# Meta-exclusion: don't fire when discussing this hook, or when the reasoning is
+# ALREADY ruling replication OUT / acknowledging Galera. These are the correct
+# moves the hook exists to encourage, so they must not trip it.
+if printf '%s' "$MSG" | grep -iqE "check-replication|replication (hook|guard|excuse)|this hook|the hook|a hook to|guardrail|trigger word|false positive|galera|virtually.?synchronous|synchronous replication|not (a )?(read )?replica|isn.?t (a )?(read )?replica|not replication|isn.?t replication|rule out replica|ruled out replica|drop(ping)? the replica|without the replica|replica.{0,20}unlikely|unlikely.{0,20}replica|static reference data|on every node|present on every|not a (timing|race)"; then
+  exit 0
+fi
+
+# Replication-blame patterns: invoking replica lag / read-replica staleness as a
+# CAUSE. Legitimate read/write-split bugs exist ONLY for freshly-written rows
+# (e.g. a just-INSERTed id) — if that is genuinely the case, say so and cite the
+# write, which the exclusions above allow; otherwise this is the lazy excuse.
+PATTERNS=(
+  'repl(ica|ication) (lag|delay|latenc)'
+  'read.?replica.{0,45}(miss|lag|stale|behind|not yet|hadn.?t|didn.?t|old|absent|missing|return)'
+  '(miss|lag|stale|behind|not yet|hadn.?t|didn.?t|absent|missing).{0,45}read.?replica'
+  'routed to (a |the )?(read )?replica'
+  'stale (read|replica|read.?replica)'
+  'replica.{0,30}(behind|caught up|not yet|hadn.?t applied|didn.?t have|missing|lag)'
+  'eventual(ly)? consisten'
+  '(read/write|read-write|r/w) split.{0,45}(race|hazard|lag|miss|stale|caused|explain|left|silently|dropped)'
+  '(routed|sent|went) to (a |the )?replica'
+  'replica (that )?(missed|lacked|didn.?t have|hadn.?t)'
+)
+
+for p in "${PATTERNS[@]}"; do
+  if printf '%s' "$MSG" | grep -iqE "$p" 2>/dev/null; then
+    HIT=$(printf '%s' "$MSG" | grep -ioE "$p" 2>/dev/null | head -1)
+    echo "STOP — you are blaming read replication: \"$HIT\". Freegle runs a Galera cluster (virtually-synchronous), so replica lag is extremely unlikely, and impossible for static reference data (locations, groups, config) that is identical on every node. This is a recurring lazy diagnosis. Either PROVE it — the data is freshly written (name the INSERT/UPDATE it races) and cite concrete evidence — or find the actual root cause (a code path, an unchecked error, a missing lookup) before continuing." >&2
+    exit 2
+  fi
+done
+
+exit 0

--- a/.claude/freegle-stack-notice-hook.sh
+++ b/.claude/freegle-stack-notice-hook.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Claude Code UserPromptSubmit hook.
+#
+# If the idle-stack sweeper (freegle-stack-sweeper.sh) stopped the Docker Compose
+# containers for the worktree THIS session is working in, surface a one-time
+# message to the user AND to Claude (stdout from a UserPromptSubmit hook is added
+# to the conversation), so they know — and can restart the stack if they need it.
+#
+# Always exits 0. Near-instant on the common path (no stacks stopped -> no-op).
+
+set -uo pipefail
+
+NOTICE_DIR="${HOME:-/home/edward}/.claude/stack-stopped"
+
+# Fast path: nothing has been stopped -> do nothing at all.
+[ -d "$NOTICE_DIR" ] || exit 0
+[ -n "$(ls -A "$NOTICE_DIR" 2>/dev/null)" ] || exit 0
+
+payload="$(cat 2>/dev/null)"
+get() { printf '%s' "$payload" | python3 -c "import sys,json;print(json.load(sys.stdin).get('$1',''))" 2>/dev/null; }
+sid="$(get session_id)"
+cwd="$(get cwd)"
+base="${CLAUDE_PROJECT_DIR:-/home/edward/FreegleDockerWSL}"
+
+# Which worktree is this session bound to? The escape-guard state file written by
+# `./freegle switch` is the reliable mapping (the claude process cwd is the main
+# repo even while working in a worktree). Fall back to cwd.
+wt=""
+[ -n "$sid" ] && [ -f "$base/.claude/active-worktree.$sid" ] && wt="$(cat "$base/.claude/active-worktree.$sid" 2>/dev/null)"
+[ -n "$wt" ] || wt="$cwd"
+[ -n "$wt" ] && [ -f "$wt/.env" ] || exit 0
+
+proj="$(grep -E '^COMPOSE_PROJECT_NAME=' "$wt/.env" 2>/dev/null | cut -d= -f2)"
+[ -n "$proj" ] || exit 0
+
+marker="$NOTICE_DIR/$proj"
+[ -f "$marker" ] || exit 0
+
+# If the stack is already running again, the marker is stale — clear it silently.
+running="$(docker ps -q --filter "label=com.docker.compose.project=$proj" 2>/dev/null | grep -c .)"
+if [ "${running:-0}" -gt 0 ]; then
+  rm -f "$marker"
+  exit 0
+fi
+
+# Tell the user + Claude, then clear the marker so it shows only once.
+echo "[idle-stack sweeper] Heads up: this worktree's containers (project '$proj') are stopped."
+sed 's/^/  /' "$marker" 2>/dev/null
+echo "  To bring them back for this work, restart with:  ( cd $wt && docker compose start )"
+rm -f "$marker"
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -91,6 +91,21 @@
             "timeout": 5
           }
         ]
+      },
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/check-dismissive-reasoning.sh",
+            "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/check-replication-excuse.sh",
+            "timeout": 10
+          }
+        ]
       }
     ],
     "Stop": [
@@ -109,6 +124,17 @@
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/check-should-continue.sh",
             "timeout": 5
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/freegle-stack-notice-hook.sh"
           }
         ]
       }


### PR DESCRIPTION
Three Claude Code hooks were living in `~/.claude/settings.json` (personal, per-machine) even though they're Freegle-specific. Moved them into the repo so they're version-controlled and shared, and de-registered them from personal config so they fire once.

**Moved into `.claude/` (registered in `.claude/settings.json`):**
- `check-replication-excuse.sh` — blocks blaming Galera replica lag mid-turn (Freegle-DB rule)
- `check-dismissive-reasoning.sh` — blocks "unrelated/pre-existing" dismissals mid-turn; pairs with the already-in-repo Stop hook `check-dismissive-language.sh`
- `freegle-stack-notice-hook.sh` — surfaces when the worktree idle-stack sweeper stopped a stack

**Left personal (good reason — genuinely cross-project):**
- `hooks/tool-audit.sh` — tool-call audit to `~/.claude/audit`, used across all projects (in the global CLAUDE.md, not this repo)
- SessionStart `/usage` tip

Scripts smoke-tested (no-op exit 0 on non-matching input); both settings files re-validated as JSON; personal config no longer references the three (no double-firing). Already applied to this machine's live config in-session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQZ56NwFYEuhrtaoU7oYoM