### PR TITLE
fix(ModTools iPhone landscape layout): drop stray height transition on chat pane

### DIFF
--- a/iznik-nuxt3/modtools/components/ModChatPane.vue
+++ b/iznik-nuxt3/modtools/components/ModChatPane.vue
@@ -264,7 +264,6 @@ function typing(val) {
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  transition: height 1s;
 
   height: calc(100vh - 60px);
 


### PR DESCRIPTION
## Root Cause
`.chatHolder` in `iznik-nuxt3/modtools/components/ModChatPane.vue` is sized with `height: calc(100vh - 60px)` / the `100dvh` `@supports` variant — i.e. it fills almost the entire visible screen below the fixed navbar on any ModTools chat page. It also carried `transition: height 1s;`, which is **not** present on the equivalent `.chatHolder` rule in the Freegle app's `components/ChatPane.vue` (the component `ModChatPane.vue` was cloned from in commit `cdf99b840`, "Create self-contained MT chat components"). Git blame confirms the transition was introduced only in that copy, with no comment or rationale — the copy's only other `transition` is the pre-existing `opacity 0.1s` one shared with the original.

Nothing in the codebase ever toggles the `navBarHidden`/`stickyAdRendered` classes this rule reacts to from within ModTools (`setNavBarHidden`/`updateScrollTime` are never called there), so in practice the only thing that ever changes this element's effective height is the raw `vh`/`dvh` viewport size itself. On iOS, rotating the device causes the browser to resolve `100vh`/`100dvh` through several different intermediate values across the multi-frame native rotation/toolbar animation. With `transition: height 1s` in place, the container kept CSS-animating toward each new intermediate height for up to a second, and since new values kept arriving faster than the transition could settle, the whole chat pane visibly wobbled/"shook" for about a second after rotating to landscape — matching the report exactly (works fine in portrait, "shakes and is unreadable" after rotating to landscape).

## Evidence
- `git diff HEAD~ -- components/ChatPane.vue modtools/components/ModChatPane.vue` (conceptually): `ChatPane.vue`'s `.chatHolder` has no `transition: height` at any nesting level; `ModChatPane.vue`'s did, on the very first line of the rule.
- `git blame` on `modtools/components/ModChatPane.vue` attributes the line to `cdf99b84063a9e5c468b83bf8586d98a45f025d4` ("fix: Create self-contained MT chat components with dedicated composable"), which created the file wholesale from the shared Freegle chat components — the transition was added, not carried over.
- `setNavBarHidden`/`updateScrollTime` (the only functions that mutate the `navBarHidden` ref this transition might have been meant to smooth) are never invoked anywhere under `modtools/`, confirming the transition had no live purpose other than amplifying viewport-height churn.

This is a pure CSS regression with no JS-observable behaviour: nothing reads, writes, computes, or watches this `transition` declaration, and jsdom (the unit-test DOM) doesn't implement CSS transition/animation timing at all, so there is no meaningful JS-level assertion that could fail-before/pass-after here. Per the testless-CSS carve-out, no new test was added — regression coverage is the existing `tests/unit/components/modtools/ModChatPane.spec.js` (33 tests, still green) plus the full `tests/unit/components/modtools/` suite (162 files / 4246 tests, all green) confirming no behavioural change to the component's rendered classes/structure.

## Fix
Removed the stray `transition: height 1s;` line from `.chatHolder` in `ModChatPane.vue`, restoring exact parity with `ChatPane.vue`. Viewport-height changes (including the rapid ones during a rotation) now apply to the element's height instantly, as they do — and always have — in the Freegle app, instead of being smeared into a visible animation. Portrait mode is unaffected (no transition ever fired there since there's no repeated viewport-height churn while stationary).

## Other Call Sites
Repo-wide `grep -rn 'transition:\s*height'`:
- `components/ChatFooter.vue:1125` / `modtools/components/ModChatFooter.vue:1048` — `transition: height 0.1s` / `1s` on the reply `<textarea>`, driven by `v-bind(height)` from a JS-computed value tied to *text content length*, not viewport size. Present with matching intent in both the Freegle and ModTools versions (parity) — out of scope for this bug and left untouched.
- `assets/css/uploader.scss:349` / `modtools/assets/css/uploader.scss:349` — identical in both apps (shared file), on an unrelated resizable panel, not viewport-height-based. Out of scope.

No other `100vh`/`100dvh` container in ModTools carries a `transition` on `height`/`min-height`.

## Test
`tests/unit/components/modtools/ModChatPane.spec.js` — unchanged, 33/33 passing before and after (this is a pure CSS removal with no JS-observable surface, so there's no fail-before/pass-after pair to show; see the testless-CSS justification above).
Ran `npx vitest run tests/unit/components/modtools/` — 162 files / 4246 tests, all green, no regressions.
Ran `eslint --fix` on the changed file — no issues.

## Discourse
https://discourse.ilovefreegle.org/t/9935/1