### PR TITLE
fix(browse): scope group filter via membership, not messages_spatial.groupid

### DIFF
--- a/iznik-nuxt3/components/PostMap.vue
+++ b/iznik-nuxt3/components/PostMap.vue
@@ -798,6 +798,12 @@ async function getMessages() {
   const nelat = bounds.getNorthEast().lat
   const nelng = bounds.getNorthEast().lng
   let ret = null
+  // Set when `ret` already comes from a group-membership-scoped fetch (fetchMyGroups or
+  // search's groupids, both of which test messages_groups via EXISTS server-side) so the
+  // client-side groupid re-filter below - which instead compares the single, often-wrong
+  // messages_spatial.groupid column - is skipped rather than re-dropping posts the server
+  // already correctly included (Discourse 9933/8).
+  let groupScopedByServer = false
 
   // Nearby (reach) view: the reachable set is worked out server-side from the member's
   // location and does NOT change as they pan or zoom the map. So always show exactly that
@@ -806,7 +812,23 @@ async function getMessages() {
   // "not many showing, zoom out and refetch" padding below, which was the source of far,
   // unreachable posts leaking into the nearby list. Search within nearby is handled in the
   // showIsochrones branch further down (it intersects the reach feed with a bounds search).
-  if (props.showIsochrones && !props.search && (me?.lat || me?.lng)) {
+  //
+  // Excluded when props.groupid is set: picking a single group from the "Show posts
+  // from:" filter does not change browseView away from 'nearby' (PostFilters.vue's
+  // watch(group) only flips browseView for the -1/"Nearby" and 0/"All my communities"
+  // sentinels), so showIsochrones stays true. Without this guard the raw, group-blind
+  // reach feed was returned and PostMapAndList's client-side filter narrowed it by
+  // matching a single `groupid` column (messages_spatial.groupid) that holds only ONE of
+  // a message's possibly-many approved groups - silently dropping posts genuinely
+  // approved in the selected group (Discourse 9933/8). Falling through here reaches the
+  // `props.groupid` branch below, which fetches via the membership-correct
+  // fetchMyGroups(groupid) instead.
+  if (
+    props.showIsochrones &&
+    !props.search &&
+    !props.groupid &&
+    (me?.lat || me?.lng)
+  ) {
     console.log('GetMessages - nearby reach feed')
     const nearby = await nearbyStore.fetchMessages()
     if (nearby && !destroyed.value) {
@@ -837,6 +859,7 @@ async function getMessages() {
     }
   } else if (props.groupid) {
     // We have been asked to show a specific group.
+    groupScopedByServer = true
     if (props.search) {
       // So search within that group.
       console.log('GetMessages - search on specific group')
@@ -1001,7 +1024,14 @@ async function getMessages() {
   }
 
   if (messages?.length) {
-    if (props.groupid) {
+    if (props.groupid && !groupScopedByServer) {
+      // Best-effort client-side narrowing for paths that didn't scope to the group
+      // server-side (e.g. a map-bounds fetch while a group filter is active). This still
+      // only matches the single messages_spatial.groupid column, so it can miss posts
+      // approved in the group via a different row - but there's no membership-correct
+      // fetch available here. When the fetch WAS already group-scoped server-side
+      // (groupScopedByServer), skip this: re-applying it would wrongly drop posts the
+      // EXISTS-based server query already correctly included (Discourse 9933/8).
       messages = messages.filter((m) => {
         return m.groupid === props.groupid
       })

--- a/iznik-nuxt3/components/PostMapAndList.vue
+++ b/iznik-nuxt3/components/PostMapAndList.vue
@@ -344,9 +344,13 @@ const messagesForList = computed(() => {
 
   msgs = sortedMessagesOnMap.value
 
-  if (props.selectedGroup) {
-    msgs = msgs.filter((m) => m.groupid === props.selectedGroup)
-  }
+  // No group re-filter here: PostMap's getMessages already scopes to props.selectedGroup
+  // (its groupid prop) before it ever emits `messages` - server-side via
+  // fetchMyGroups/search's messages_groups EXISTS check, or as a client-side fallback for
+  // the map-bounds-fetch path. Re-filtering here on the single, often-mismatched
+  // `groupid` column (messages_spatial.groupid - see message.Groups' comment on why it
+  // isn't used for group membership) silently dropped posts genuinely approved in the
+  // selected group, undoing that correct scoping (Discourse 9933/8).
 
   // Distance slider: the feed already returns the full reach set, so this is a local,
   // instant filter rather than a refetch. Posts with no distance (e.g. an older feed

--- a/iznik-nuxt3/tests/unit/components/PostMap.spec.js
+++ b/iznik-nuxt3/tests/unit/components/PostMap.spec.js
@@ -782,6 +782,36 @@ describe('PostMap', () => {
       expect(mockNearbyFetchMessages).not.toHaveBeenCalled()
       expect(mockMessageStore.fetchInBounds).toHaveBeenCalled()
     })
+
+    // Discourse 9933/8: a member applies the "Show posts from: <group>" filter while still
+    // on the nearby/"New to You" view (selecting one group doesn't change browseView away
+    // from 'nearby' - see PostFilters.vue's watch(group)). The nearby-reach branch above
+    // must not swallow that case: it ignores props.groupid entirely and returns the raw,
+    // unfiltered reach feed, leaving the group scoping to a client-side
+    // `m.groupid === selectedGroup` filter over messages_spatial.groupid - a column that
+    // holds only ONE of a message's possibly-many approved groups (see message.Groups'
+    // "without relying on messages_spatial.groupid" comment), so posts genuinely approved
+    // in the selected group get silently dropped. Selecting a specific group must fall
+    // through to the membership-correct fetchMyGroups(groupid) call instead.
+    it('uses the group-membership fetch, not the raw reach feed, when a specific group filter is selected while browsing nearby', async () => {
+      mockAuthStore.user = {
+        id: 1,
+        lat: 53.945,
+        lng: -2.5209,
+        settings: { mylocation: { name: 'AB1 2CD' } },
+      }
+      mockMessageStore.fetchMyGroups.mockResolvedValue([
+        { id: 1, lat: 52.5, lng: -1, groupid: 21467, type: 'Offer' },
+      ])
+      await createWrapper({ showIsochrones: true, groupid: 21467 })
+      mockNearbyBounds.value = [
+        [51, -2],
+        [54, 0],
+      ]
+      await flushPromises()
+
+      expect(mockMessageStore.fetchMyGroups).toHaveBeenCalledWith(21467)
+    })
   })
 
   describe('zoom behavior', () => {

--- a/iznik-nuxt3/tests/unit/components/PostMapAndList.spec.js
+++ b/iznik-nuxt3/tests/unit/components/PostMapAndList.spec.js
@@ -534,6 +534,37 @@ describe('PostMapAndList', () => {
       await nextTick()
       expect(wrapper.find('.message-list').exists()).toBe(true)
     })
+
+    // Discourse 9933/8: PostMap's getMessages already scopes to the selected group before
+    // emitting `messages` (server-side via messages_groups EXISTS, not the single,
+    // often-mismatched messages_spatial.groupid column). Re-filtering that already-scoped
+    // list here by comparing m.groupid === selectedGroup silently dropped posts genuinely
+    // approved in the group whenever their spatial groupid recorded a different group (a
+    // message can be approved in several groups). This must not re-drop them.
+    it('does not re-drop posts by their spatial groupid once PostMap has already scoped the feed to the selected group', async () => {
+      const wrapper = createWrapper({
+        startOnGroups: false,
+        selectedGroup: 21467,
+      })
+      await nextTick()
+
+      const postMap = wrapper.findComponent('.post-map')
+      await postMap.vm.$emit('messages', [
+        // Approved in group 21467 via messages_groups, but its messages_spatial row
+        // happens to record a different group - exactly what fetchMyGroups(21467)
+        // legitimately returns.
+        {
+          id: 200,
+          arrival: '2024-01-20T10:00:00Z',
+          unseen: true,
+          groupid: 999,
+        },
+      ])
+      await nextTick()
+
+      const list = wrapper.find('.message-list')
+      expect(list.attributes('data-ids')).toContain('200')
+    })
   })
 
   describe('search functionality', () => {


### PR DESCRIPTION
## Root Cause
Selecting a specific group in the "Show posts from:" filter while browsing the default "New to You" (nearby) view does not change `browseView` away from `nearby` (`PostFilters.vue`'s `watch(group)` only flips `browseView` for the "-1/Nearby" and "0/All my communities" sentinels). So `PostMap.vue`'s `getMessages()` reach-feed early return (`if (props.showIsochrones && !props.search && (me?.lat || me?.lng))`) still fired first and ignored the selected group entirely, returning the raw, group-blind reach feed.

That raw feed was then narrowed only client-side, by comparing each post's single `groupid` field (`messages_spatial.groupid`) against the selected group. That column holds only ONE of a message's possibly-many approved groups (a post can be cross-posted/approved in several groups) - `message.Groups`' own Go comment already documents this: "without relying on messages_spatial.groupid (which stores only ONE group for multi-group messages)". So posts genuinely approved in the selected group, whose spatial row happened to record a different group, were silently dropped from the filtered list - even though the (unfiltered) list showed them.

Confirmed against live production data: of 836 messages approved in one group's `messages_groups` in the last 31 days, only 135 had `messages_spatial.groupid` matching that group - 617 (74%) recorded a different group and would be wrongly dropped by the buggy filter.

This is a regression from `2709216582` / `d2dc66f8c` ("flip Nearby to the rippling reach model", 2026-07-01), which added the early-return branch and a matching client-side group-narrowing filter in `PostMapAndList.vue`, both specifically because the new reach feed doesn't accept a groupid. Before that commit, selecting a group correctly fell through to the `fetchMyGroups(groupid)` branch. The prior "possible fix" (#1106, `fix/browse-own-posts-top-9933`) addressed a different symptom (the poster's own posts being buried by sort order), not this group-filter/cross-posted-message-dropping path - hence this retest.

## Evidence
Failing test before the fix (AssertFlip - see full run in PR):
```
FAIL  tests/unit/components/PostMap.spec.js > PostMap > message fetching > uses the group-membership fetch, not the raw reach feed, when a specific group filter is selected while browsing nearby
AssertionError: expected "spy" to be called with arguments: [ 21467 ]
Number of calls: 0
```
```
FAIL  tests/unit/components/PostMapAndList.spec.js > PostMapAndList > message filtering > does not re-drop posts by their spatial groupid once PostMap has already scoped the feed to the selected group
AssertionError: expected '' to contain '200'
```
Both pass after the fix; full suite (671 files / 14320 tests) passes with no regressions.

## Fix
- `PostMap.vue`: exclude `props.groupid` from the nearby-reach early return, so a group-filtered fetch falls through to the existing `else if (props.groupid)` branch, which already correctly scopes via `fetchMyGroups`/`search` (both test `messages_groups` via `EXISTS` server-side). Track that with a `groupScopedByServer` flag and skip the old single-column re-filter for those already-scoped results (kept, unchanged, as a best-effort fallback for the one remaining unscoped path: panning the map while a group filter is active).
- `PostMapAndList.vue`: removed the now-redundant/incorrect `m.groupid === props.selectedGroup` re-filter in `messagesForList` - PostMap already fully scopes group membership before it ever emits `messages`, so re-filtering by the single column here was undoing that correct scoping.

## Other Call Sites
```
grep -rn "\.groupid === \|=== props.groupid\|=== props.selectedGroup" components/ pages/ stores/ composables/
```
One other match: `PostMap.vue`'s `secondaryMessagesForMap` (the faded/secondary map markers shown alongside a group-scoped list). That's always sourced from an unscoped `fetchInBounds` call with no membership-correct alternative available, and only affects decorative map markers, not the list Jeni reported - left unchanged.

## Test
- `iznik-nuxt3/tests/unit/components/PostMap.spec.js` - `uses the group-membership fetch, not the raw reach feed, when a specific group filter is selected while browsing nearby`
- `iznik-nuxt3/tests/unit/components/PostMapAndList.spec.js` - `does not re-drop posts by their spatial groupid once PostMap has already scoped the feed to the selected group`
- Both fail on current master (AssertFlip), pass after the fix. Full vitest suite (14320 tests) run locally, all passing.

## Discourse
https://discourse.ilovefreegle.org/t/9933/8