### PR TITLE
fix(ChitChat distance filter): bound Nearby's radius fallback instead of disabling geo filtering

### DIFF
--- a/iznik-server-go/newsfeed/newsfeed.go
+++ b/iznik-server-go/newsfeed/newsfeed.go
@@ -102,6 +102,15 @@ type Newsfeed struct {
 	Previews       []NewsfeedPreview `json:"previews" gorm:"-"`
 }
 
+// maxNearbyKm bounds the "Nearby" feed radius when there isn't enough recent
+// local activity to compute a tighter one. The pre-#459 implementation always
+// searched a bounded box (doubling from 1km up to, at most, 128km before
+// giving up), so a quiet area never fell all the way back to a completely
+// unfiltered, nationwide feed. The #459 spatial-server rewrite returned 0 in
+// that case, which callers treat as "no geographic filtering at all" — that's
+// what let posts hundreds of miles away appear under "Nearby" (Discourse #9937).
+const maxNearbyKm = 128.0
+
 func GetNearbyDistance(uid uint64) (float64, utils.LatLng, float64, float64, float64, float64) {
 	const nearbyLimit = 10
 	// Over-fetch from the spatial index so that, after dropping alerts and posts
@@ -113,40 +122,39 @@ func GetNearbyDistance(uid uint64) (float64, utils.LatLng, float64, float64, flo
 		return 0, latlng, 0, 0, 0, 0
 	}
 
+	// Default to the bounded fallback radius; narrowed below if we find enough
+	// recent local candidates to compute a tighter one.
+	distKm := maxNearbyKm
+
 	results, err := spatial.KNN("newsfeed", float64(latlng.Lng), float64(latlng.Lat), nearbyLimit*overFetch, "")
-	if err != nil || len(results) < nearbyLimit {
-		return 0, latlng, 0, 0, 0, 0
-	}
-
-	// The spatial "newsfeed" index has no type/timestamp columns, so it can't
-	// exclude alerts or stale posts — applying that here restores the
-	// pre-spatial query's behaviour (otherwise alerts/old posts shrink the
-	// computed radius).
-	ids := make([]int64, len(results))
-	for i, r := range results {
-		ids[i] = r.ID
-	}
-	allowed := RecentNonAlertNewsfeedIDs(ids)
-
-	// Walk the KNN results in distance order; the nearbyLimit-th allowed entry
-	// sets the radius (decimal degrees → km, 1 degree ≈ 111 km).
-	count := 0
-	distDeg := 0.0
-	for _, r := range results {
-		if _, ok := allowed[r.ID]; !ok {
-			continue
+	if err == nil && len(results) >= nearbyLimit {
+		// The spatial "newsfeed" index has no type/timestamp columns, so it can't
+		// exclude alerts or stale posts — applying that here restores the
+		// pre-spatial query's behaviour (otherwise alerts/old posts shrink the
+		// computed radius).
+		ids := make([]int64, len(results))
+		for i, r := range results {
+			ids[i] = r.ID
 		}
-		count++
-		if count == nearbyLimit {
-			distDeg = r.Distance
-			break
+		allowed := RecentNonAlertNewsfeedIDs(ids)
+
+		// Walk the KNN results in distance order; the nearbyLimit-th allowed entry
+		// sets the radius (decimal degrees → km, 1 degree ≈ 111 km).
+		count := 0
+		for _, r := range results {
+			if _, ok := allowed[r.ID]; !ok {
+				continue
+			}
+			count++
+			if count == nearbyLimit {
+				distKm = r.Distance * 111.0
+				break
+			}
 		}
-	}
-	if count < nearbyLimit {
-		return 0, latlng, 0, 0, 0, 0
+		// If count never reaches nearbyLimit, distKm stays at maxNearbyKm — there
+		// isn't enough recent local activity to narrow the radius further.
 	}
 
-	distKm := distDeg * 111.0
 	p := geo.NewPoint(float64(latlng.Lat), float64(latlng.Lng))
 	ne := p.PointAtDistanceAndBearing(distKm, 45)
 	sw := p.PointAtDistanceAndBearing(distKm, 225)

--- a/iznik-server-go/test/newsfeed_nearby_filter_test.go
+++ b/iznik-server-go/test/newsfeed_nearby_filter_test.go
@@ -1,0 +1,70 @@
+package test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/freegle/iznik-server-go/database"
+	newsfeed2 "github.com/freegle/iznik-server-go/newsfeed"
+	"github.com/stretchr/testify/assert"
+)
+
+// Regression test for Discourse #9937 post 1: selecting "Nearby" in the
+// ChitChat distance filter showed the same unfiltered feed as "Anywhere",
+// with a post 169 miles away appearing at the top.
+//
+// GetNearbyDistance falls back to "no reasonable radius found" whenever the
+// spatial "newsfeed" KNN index can't supply nearbyLimit (10) recent,
+// non-alert candidates near the user - which is exactly what the test
+// spatial mock does (it only serves the "postcodes" dataset; every other
+// dataset, including "newsfeed", gets an empty result - see
+// ensureSpatialMock in main_test.go). The pre-#459 implementation always
+// bounded this fallback to a maximum search radius; the #459 rewrite
+// returned 0, which callers (newsfeed.getFeed) treat as "apply no
+// geographic filtering at all".
+func TestFeedNearbyDistanceExcludesFarAwayPost(t *testing.T) {
+	prefix := uniquePrefix("nearbyfilter")
+	userID, token := CreateFullTestUser(t, prefix)
+
+	// A post right where the user is (Edinburgh, set by CreateTestUser).
+	localMessage := fmt.Sprintf("Local test post %s", prefix)
+	CreateTestNewsfeed(t, userID, 55.9533, -3.1883, localMessage)
+
+	// A post in London - about 534km / 332 miles from Edinburgh, far beyond
+	// any reasonable "Nearby" radius.
+	farMessage := fmt.Sprintf("Far away test post %s", prefix)
+	CreateTestNewsfeed(t, userID, 51.5074, -0.1278, farMessage)
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/newsfeed?distance=nearby&jwt="+token, nil))
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var feed []newsfeed2.NewsfeedSummary
+	json.Unmarshal(rsp(resp), &feed)
+
+	ids := make(map[uint64]bool)
+	for _, entry := range feed {
+		ids[entry.ID] = true
+	}
+
+	localID := findNewsfeedIDByMessage(t, localMessage)
+	farID := findNewsfeedIDByMessage(t, farMessage)
+
+	assert.True(t, ids[localID], "the local post should be in the Nearby feed")
+
+	// The far-away post must NOT leak into "Nearby". Before the fix,
+	// GetNearbyDistance fell back to an unfiltered (zero/disabled) radius
+	// whenever it couldn't find nearbyLimit recent local candidates, so this
+	// assertion fails on the bug and passes once Nearby is bounded.
+	assert.False(t, ids[farID], "far-away post should NOT appear under Nearby")
+}
+
+func findNewsfeedIDByMessage(t *testing.T, message string) uint64 {
+	var id uint64
+	database.DBConn.Raw("SELECT id FROM newsfeed WHERE message = ? ORDER BY id DESC LIMIT 1", message).Scan(&id)
+	if id == 0 {
+		t.Fatalf("could not find newsfeed entry for message %q", message)
+	}
+	return id
+}


### PR DESCRIPTION
## Root Cause
`GetNearbyDistance` (iznik-server-go/newsfeed/newsfeed.go) computes the "Nearby" search radius by asking the spatial KNN index for the user's 100 nearest newsfeed posts, then narrowing to the 10th-nearest **recent** (last 31 days), **non-alert** one. If fewer than 10 such candidates exist among those 100 (a quiet area, or simply a location where recent chitchat activity is thin), it returned `0`. Callers (`getFeed`) treat `reasonable == 0` as "no reasonable radius could be computed", which disables geographic filtering entirely - the feed falls back to the same nationwide, recency-sorted query used for "Anywhere". That's why selecting "Nearby" showed the same unfiltered feed as "Anywhere", with a distant post (169 miles per the report) at the top - it's simply whatever was posted most recently anywhere in the country.

This is a regression from PR #459 (spatial-server migration, 2026-06-15). The pre-#459 implementation searched radii doubling from 1km up to a worst case of ~128km and always used the best bounded box it found - it never fell all the way back to zero/unfiltered, even when it couldn't find enough nearby posts.

## Evidence
Failing-test output before the fix (AssertFlip step 3b, inverted assertion):
```
=== RUN   TestFeedNearbyDistanceExcludesFarAwayPost
    newsfeed_nearby_filter_test.go:60:
        	Error Trace:	.../newsfeed_nearby_filter_test.go:60
        	Error:      	Should be false
        	Test:       	TestFeedNearbyDistanceExcludesFarAwayPost
        	Messages:   	far-away post should NOT appear under Nearby
--- FAIL: TestFeedNearbyDistanceExcludesFarAwayPost (0.87s)
FAIL
```
After the fix, the same test passes.

## Fix
`GetNearbyDistance` now defaults to a bounded `maxNearbyKm` (128km, matching the old worst-case radius) instead of returning 0 when it can't find enough recent local candidates, and only narrows the radius when it actually finds 10 recent, non-alert posts nearby. A known/no location (`latlng.Lat==0 && latlng.Lng==0`) still returns 0, since there's genuinely nothing to filter by - unchanged from before.

## Other Call Sites
`GetNearbyDistance` has a single caller (`getFeed`, iznik-server-go/newsfeed/newsfeed.go) - confirmed via `grep -rn GetNearbyDistance`. Separately, the `/newsfeedcount` handler (`Count()`, same file, ~line 815-825) has its own, differently-shaped bug in its `distance=nearby` handling (an inverted `if err != nil` check) - that only affects the unread-count badge, not the feed contents Wendy reported, so it's out of scope here but worth a follow-up.

## Test
- File: `iznik-server-go/test/newsfeed_nearby_filter_test.go` (`TestFeedNearbyDistanceExcludesFarAwayPost`)
- Command: `go test ./test/... -run TestFeedNearbyDistanceExcludesFarAwayPost -v` (via the Go test DB)
- Proves fail-before/pass-after: written per AssertFlip - first asserted the buggy behaviour (far-away post leaks into Nearby) and confirmed it passed on unfixed code, then inverted to assert it's excluded, confirmed it failed on unfixed code, then confirmed it passes with the fix applied.
- Full-suite regression check: `go test ./test/...` run in its entirety against a freshly-reset test database - **all tests pass, 0 failures** (323s). An earlier attempt had shown `TestBulkOfferAuthorityStats` failing with doubled counts; root-caused to a prior timed-out `go test` invocation leaving partial data in the shared test DB that a subsequent run then double-counted (a side effect of re-running against unreset state, not a product or test-suite defect). Resetting the schema and running the full suite once, cleanly, confirmed there is no real failure - green across the board.

## Discourse
https://discourse.ilovefreegle.org/t/9937/1