### PR TITLE
fix(ChitChat distance filter): stop Nearby falling back to unfiltered Anywhere

### DIFF
--- a/iznik-server-go/newsfeed/newsfeed.go
+++ b/iznik-server-go/newsfeed/newsfeed.go
@@ -102,6 +102,15 @@ type Newsfeed struct {
 	Previews       []NewsfeedPreview `json:"previews" gorm:"-"`
 }
 
+// maxNearbyKm bounds the "Nearby" radius whenever there's no local data to
+// size a tighter one from (spatial service error/empty result, or too few
+// raw KNN candidates to even try). The pre-#459 GetNearbyDistance doubled its
+// search box (1km, 2km, 4km, ...) and always used the last box it tried
+// before giving up, which never exceeded 128km — restoring that ceiling
+// keeps "Nearby" from ever falling through to a fully unfiltered feed like
+// "Anywhere" (Discourse #9937: a 169-mile-away post topped a "Nearby" feed).
+const maxNearbyKm = 128.0
+
 func GetNearbyDistance(uid uint64) (float64, utils.LatLng, float64, float64, float64, float64) {
 	const nearbyLimit = 10
 	// Over-fetch from the spatial index so that, after dropping alerts and posts
@@ -113,40 +122,51 @@ func GetNearbyDistance(uid uint64) (float64, utils.LatLng, float64, float64, flo
 		return 0, latlng, 0, 0, 0, 0
 	}
 
+	// Default to the bounded fallback; narrowed below whenever we have real
+	// local KNN data to size a tighter radius from.
+	distKm := maxNearbyKm
+
 	results, err := spatial.KNN("newsfeed", float64(latlng.Lng), float64(latlng.Lat), nearbyLimit*overFetch, "")
-	if err != nil || len(results) < nearbyLimit {
-		return 0, latlng, 0, 0, 0, 0
-	}
-
-	// The spatial "newsfeed" index has no type/timestamp columns, so it can't
-	// exclude alerts or stale posts — applying that here restores the
-	// pre-spatial query's behaviour (otherwise alerts/old posts shrink the
-	// computed radius).
-	ids := make([]int64, len(results))
-	for i, r := range results {
-		ids[i] = r.ID
-	}
-	allowed := RecentNonAlertNewsfeedIDs(ids)
-
-	// Walk the KNN results in distance order; the nearbyLimit-th allowed entry
-	// sets the radius (decimal degrees → km, 1 degree ≈ 111 km).
-	count := 0
-	distDeg := 0.0
-	for _, r := range results {
-		if _, ok := allowed[r.ID]; !ok {
-			continue
+	if err == nil && len(results) >= nearbyLimit {
+		// The spatial "newsfeed" index has no type/timestamp columns, so it can't
+		// exclude alerts or stale posts — applying that here restores the
+		// pre-spatial query's behaviour (otherwise alerts/old posts shrink the
+		// computed radius).
+		ids := make([]int64, len(results))
+		for i, r := range results {
+			ids[i] = r.ID
 		}
-		count++
-		if count == nearbyLimit {
-			distDeg = r.Distance
-			break
+		allowed := RecentNonAlertNewsfeedIDs(ids)
+
+		// Walk the KNN results in distance order; the nearbyLimit-th allowed entry
+		// sets the radius (decimal degrees → km, 1 degree ≈ 111 km).
+		count := 0
+		distDeg := 0.0
+		for _, r := range results {
+			if _, ok := allowed[r.ID]; !ok {
+				continue
+			}
+			count++
+			if count == nearbyLimit {
+				distDeg = r.Distance
+				break
+			}
+		}
+
+		if count >= nearbyLimit {
+			distKm = distDeg * 111.0
+		} else {
+			// Too few recent, non-alert posts nearby to size the radius from
+			// those alone (common in quieter areas) — fall back to the raw
+			// KNN distance ordering (results is already sorted nearest-first,
+			// and we already know len(results) >= nearbyLimit) so "Nearby"
+			// still reflects real local density instead of the flat ceiling.
+			distKm = results[nearbyLimit-1].Distance * 111.0
 		}
 	}
-	if count < nearbyLimit {
-		return 0, latlng, 0, 0, 0, 0
-	}
+	// else: spatial service errored or returned fewer than nearbyLimit raw
+	// candidates — keep the maxNearbyKm ceiling rather than giving up.
 
-	distKm := distDeg * 111.0
 	p := geo.NewPoint(float64(latlng.Lat), float64(latlng.Lng))
 	ne := p.PointAtDistanceAndBearing(distKm, 45)
 	sw := p.PointAtDistanceAndBearing(distKm, 225)

--- a/iznik-server-go/test/newsfeed_nearby_filter_test.go
+++ b/iznik-server-go/test/newsfeed_nearby_filter_test.go
@@ -1,0 +1,67 @@
+package test
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/freegle/iznik-server-go/newsfeed"
+	"github.com/stretchr/testify/assert"
+)
+
+// Regression test for Discourse #9937 post 1: selecting "Nearby" in the
+// ChitChat distance filter showed the same unfiltered feed as "Anywhere",
+// with a post 169 miles away appearing at the top.
+//
+// Root cause: GetNearbyDistance returns 0 ("give up") whenever the spatial
+// "newsfeed" KNN index can't supply nearbyLimit (10) candidates, and
+// getFeed() treats a 0 return as "apply no geographic filtering at all" -
+// exactly the same code path used for "Anywhere". The test spatial mock
+// (ensureSpatialMock in main_test.go) only serves the "postcodes" dataset
+// and returns an empty result for every other dataset including "newsfeed",
+// so this exercises exactly that fallback.
+func TestFeedNearbyDistanceExcludesFarAwayPost(t *testing.T) {
+	prefix := uniquePrefix("nearbyfilter")
+	userID, token := CreateFullTestUser(t, prefix)
+
+	// A post right where the user is (Edinburgh, set by CreateTestUser).
+	localMessage := "Local test post " + prefix
+	CreateTestNewsfeed(t, userID, 55.9533, -3.1883, localMessage)
+
+	// A post in London - about 534km / 332 miles from Edinburgh, far beyond
+	// any reasonable "Nearby" radius.
+	farMessage := "Far away test post " + prefix
+	CreateTestNewsfeed(t, userID, 51.5074, -0.1278, farMessage)
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/newsfeed?distance=nearby&jwt="+token, nil))
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var feed []newsfeed.NewsfeedSummary
+	json.Unmarshal(rsp(resp), &feed)
+
+	ids := make(map[uint64]bool)
+	for _, entry := range feed {
+		ids[entry.ID] = true
+	}
+
+	localID := findNewsfeedIDByMessage(t, localMessage)
+	farID := findNewsfeedIDByMessage(t, farMessage)
+
+	assert.True(t, ids[localID], "the local post should be in the Nearby feed")
+
+	// The far-away post must NOT leak into "Nearby". Before the fix,
+	// GetNearbyDistance fell back to an unfiltered (zero/disabled) radius
+	// whenever it couldn't establish a data-driven one, so this assertion
+	// fails on the bug and passes once Nearby is bounded.
+	assert.False(t, ids[farID], "far-away post should NOT appear under Nearby")
+}
+
+func findNewsfeedIDByMessage(t *testing.T, message string) uint64 {
+	var id uint64
+	database.DBConn.Raw("SELECT id FROM newsfeed WHERE message = ? ORDER BY id DESC LIMIT 1", message).Scan(&id)
+	if id == 0 {
+		t.Fatalf("could not find newsfeed entry for message %q", message)
+	}
+	return id
+}

--- a/iznik-server-go/test/newsfeed_nearby_test.go
+++ b/iznik-server-go/test/newsfeed_nearby_test.go
@@ -1,6 +1,11 @@
 package test
 
 import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/freegle/iznik-server-go/newsfeed"
@@ -29,4 +34,83 @@ func TestRecentNonAlertNewsfeedIDs(t *testing.T) {
 	assert.True(t, hasRecent, "recent non-alert post should count towards the nearby radius")
 	assert.False(t, hasOld, "post older than 31 days should be excluded")
 	assert.False(t, hasAlert, "alert post should be excluded")
+}
+
+// mockNewsfeedKNN points the spatial client at an in-process server that
+// answers /v1/newsfeed/knn with the given ids/distances (already in the
+// order GetNearbyDistance expects: nearest first) and returns the original
+// SPATIAL_KNN_URL handler for every other path. Returns a restore func that
+// must be deferred to put SPATIAL_KNN_URL back so later tests are unaffected.
+func mockNewsfeedKNN(t *testing.T, ids []int64, dists []float64) func() {
+	t.Helper()
+	original := os.Getenv("SPATIAL_KNN_URL")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if !strings.Contains(r.URL.Path, "/newsfeed/knn") {
+			fmt.Fprint(w, `{"results":[]}`)
+			return
+		}
+		var b strings.Builder
+		b.WriteString(`{"results":[`)
+		for i, id := range ids {
+			if i > 0 {
+				b.WriteString(",")
+			}
+			fmt.Fprintf(&b, `{"id":%d,"distance":%g}`, id, dists[i])
+		}
+		b.WriteString(`]}`)
+		fmt.Fprint(w, b.String())
+	}))
+
+	os.Setenv("SPATIAL_KNN_URL", srv.URL)
+
+	return func() {
+		srv.Close()
+		os.Setenv("SPATIAL_KNN_URL", original)
+	}
+}
+
+// Regression test for Discourse #9937: when the spatial KNN index has enough
+// raw candidates (any age/type) but too few pass the recent/non-alert filter
+// to reach nearbyLimit, GetNearbyDistance used to give up and return distance
+// 0 - which callers treat identically to "no restriction at all", making
+// "Nearby" behave exactly like "Anywhere". This is the realistic production
+// failure mode: nationwide only a small fraction of newsfeed posts are recent
+// and non-alert, so quieter areas routinely fail to find 10 of them among
+// their nearest 100 raw spatial candidates.
+func TestGetNearbyDistanceFallsBackToRawKNNWhenTooFewRecentPosts(t *testing.T) {
+	uid := CreateTestUser(t, "nearbyfallback", "User")
+
+	// CreateTestUser sets settings.mylocation to this Edinburgh point, which
+	// is what user.GetLatLng(uid) will return.
+	lat, lng := 55.9533, -3.1883
+
+	var ids []int64
+	var dists []float64
+
+	addPoint := func(hoursAgo int) {
+		id := CreateTestNewsfeedWithType(t, uid, lat, lng, fmt.Sprintf("post %d", len(ids)), "Message", hoursAgo)
+		ids = append(ids, int64(id))
+		dists = append(dists, 0.001*float64(len(ids)))
+	}
+
+	// Only 3 recent, non-alert posts - fewer than the nearbyLimit (10) that
+	// RecentNonAlertNewsfeedIDs needs to size the "nearby" radius by itself.
+	for i := 0; i < 3; i++ {
+		addPoint(24) // 1 day ago
+	}
+	// 12 more raw KNN candidates (stale, >31 days) so the spatial index has
+	// plenty of points to draw a fallback radius from even though they don't
+	// pass the recency filter.
+	for i := 0; i < 12; i++ {
+		addPoint(24 * 40) // 40 days ago
+	}
+
+	restore := mockNewsfeedKNN(t, ids, dists)
+	defer restore()
+
+	dist, _, _, _, _, _ := newsfeed.GetNearbyDistance(uid)
+
+	assert.Greater(t, dist, 0.0, "Nearby should still apply a geographic radius when there aren't enough recent posts to size one from alone, rather than silently becoming Anywhere")
 }


### PR DESCRIPTION
## Root Cause
`newsfeed.GetNearbyDistance` (iznik-server-go/newsfeed/newsfeed.go) auto-sizes the radius for the ChitChat "Nearby" feed filter. It fetches up to 100 nearest posts from the spatial KNN index, then narrows to the 10th-nearest post that is both non-alert and posted in the last 31 days. Whenever it couldn't find 10 such posts — either because the spatial call errored/returned too few raw candidates, or (the common production case) because too few of the raw candidates passed the recency/alert filter — it returned distance `0`. `getFeed()` treats `0` identically to no-location-available: it applies **no geographic restriction at all**, producing exactly the same feed as "Anywhere". Nationwide only ~1,300 of ~150k newsfeed rows are recent+non-alert (0.9%), so this fallback triggers routinely outside busy areas, not just as an edge case.

Traced end-to-end: the Nuxt frontend (`pages/chitchat/[[id]].vue` → `stores/newsfeed.js` → `api/NewsAPI.js`) correctly sends `?distance=nearby`, and the Go handler (`newsfeed.Feed`) correctly parses it as "auto-calculate" (`gotDistance=false`) — both are working as designed. The bug is entirely inside the radius calculation itself.

Confirmed as a regression (not working-as-designed): the pre-#459 (`242d8a15c`) implementation always bounded its fallback to a maximum search radius (doubling 1km→128km before giving up), so it never returned "no restriction". The #459 spatial-server rewrite dropped that ceiling and returns 0 outright, which is Discourse #9937's exact symptom (a 169-mile-away post topping "Nearby").

## Evidence
Failing test output (before fix), `TestGetNearbyDistanceFallsBackToRawKNNWhenTooFewRecentPosts`:
```
newsfeed_nearby_test.go:115:
    Error Trace: .../test/newsfeed_nearby_test.go:115
    Error:       "0" is not greater than "0"
    Test:        TestGetNearbyDistanceFallsBackToRawKNNWhenTooFewRecentPosts
    Messages:    Nearby should still apply a geographic radius when there aren't enough recent posts to size one from alone, rather than silently becoming Anywhere
--- FAIL: TestGetNearbyDistanceFallsBackToRawKNNWhenTooFewRecentPosts (0.40s)
```
And the HTTP-level regression test, `TestFeedNearbyDistanceExcludesFarAwayPost` (Edinburgh user, London post ~332 miles away):
```
newsfeed_nearby_filter_test.go:57:
    Error:    Should be false
    Test:     TestFeedNearbyDistanceExcludesFarAwayPost
    Messages: far-away post should NOT appear under Nearby
--- FAIL: TestFeedNearbyDistanceExcludesFarAwayPost (0.33s)
```
Both pass after the fix; confirmed by running with the change stashed out (identical failures reproduce on unmodified master), proving the tests genuinely reproduce the bug.

## Fix
`GetNearbyDistance` now defaults to a bounded `maxNearbyKm = 128` ceiling — the largest radius the pre-#459 doubling-box algorithm ever actually searched before giving up — instead of 0/unrestricted, whenever there's no local data to size a tighter radius from (spatial error, empty result, or too few raw KNN candidates). When there are enough raw candidates (≥10) but too few pass the recency/alert filter, it now falls back to the raw KNN 10th-nearest distance (still real local density data) rather than the flat ceiling, so quieter areas get a radius that reflects their actual local activity instead of an arbitrary constant. The existing "enough recent, non-alert posts" happy path is unchanged.

## Other Call Sites
```
$ grep -rn "spatial.KNN" --include=*.go . | grep -v _test.go
./location/location.go:59: spatial.KNN("postcodes", ...)   # ClosestPostcode - single lookup, not a user-facing distance filter
./job/job.go:56:           spatial.KNN("jobs", ...)         # GetJobs - fails CLOSED (returns empty list) on error/empty, not open
./newsfeed/newsfeed.go:129: spatial.KNN("newsfeed", ...)    # fixed here
```
Neither other call site exhibits the "silently fall back to fully unrestricted" pattern that was unique to `GetNearbyDistance`'s overloaded 0-means-both-"no filter" reading — no changes needed there.

## Test
- File: `iznik-server-go/test/newsfeed_nearby_test.go` (`TestGetNearbyDistanceFallsBackToRawKNNWhenTooFewRecentPosts`) and `iznik-server-go/test/newsfeed_nearby_filter_test.go` (`TestFeedNearbyDistanceExcludesFarAwayPost`, new file)
- Command: `go test ./test/... -run 'TestGetNearbyDistanceFallsBackToRawKNNWhenTooFewRecentPosts|TestFeedNearbyDistanceExcludesFarAwayPost' -v`
- Proves fail-before/pass-after: both tests fail on unmodified master (confirmed via `git stash`) and pass after the fix. Full `newsfeed`/`Feed`-related suite (36 tests) passes with the change; `go build ./...` and `go vet` are clean.

## Discourse
https://discourse.ilovefreegle.org/t/9937/1