### PR TITLE
fix(jobs page on iOS - scroll/layout): exclude /jobs from the sticky footer ad

### DIFF
--- a/iznik-nuxt3/components/LayoutCommon.vue
+++ b/iznik-nuxt3/components/LayoutCommon.vue
@@ -202,8 +202,14 @@ const allowAd = computed(() => {
     routePath.value === '/partnerships' ||
     routePath.value === '/partnerships/' ||
     routePath.value === '/together' ||
-    routePath.value === '/together/'
+    routePath.value === '/together/' ||
+    routePath.value === '/jobs' ||
+    routePath.value === '/jobs/'
   ) {
+    // The /jobs page already shows a full scrollable list of job ads, so the
+    // sticky footer ad (which duplicates the same jobs in its own small,
+    // independently-scrollable panel) would give the page two scroll regions
+    // instead of one - see Discourse topic 9363 post #38.
     return false
   }
   return routePath.value !== '/' || loggedIn.value

--- a/iznik-nuxt3/pages/jobs.vue
+++ b/iznik-nuxt3/pages/jobs.vue
@@ -79,11 +79,7 @@ useHead(
     route,
     runtimeConfig,
     'Jobs',
-    'Freegle gets a little bit to help keep us going if you click on them.',
-    null,
-    {
-      class: 'overflow-y-scroll',
-    }
+    'Freegle gets a little bit to help keep us going if you click on them.'
   )
 )
 
@@ -176,9 +172,40 @@ onMounted(async () => {
 @import 'bootstrap/scss/variables';
 @import 'bootstrap/scss/mixins/_breakpoints';
 
+/* The page's job list must be its own scrollable region, sized to the space
+   below the fixed navbar (same convention as ChatPane.vue / pages/chats), and
+   must NOT rely on document/body scroll. On iOS the app (WKWebView, see
+   capacitor.config.ts contentInset: 'automatic') can leave the document-level
+   scroll view unresponsive after returning from a backgrounded external
+   browser tab, while an element with its own `overflow-y: auto` keeps working
+   - which is exactly what the reporter saw (Discourse topic 9363 post #38):
+   the page's own list was stuck, but the ad panel's own scrollable div (which
+   always used `overflow-y: auto`, see JobsDaSlot.vue) kept scrolling fine. */
 .jobs-page {
-  min-height: 100vh;
+  height: calc(100vh - 60px);
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
   background: $gray-100;
+
+  @supports (height: 100dvh) {
+    height: calc(100dvh - 60px);
+  }
+
+  @include media-breakpoint-up(md) {
+    height: calc(100vh - 66px);
+
+    @supports (height: 100dvh) {
+      height: calc(100dvh - 66px);
+    }
+  }
+
+  @include media-breakpoint-up(xl) {
+    height: calc(100vh - 76px);
+
+    @supports (height: 100dvh) {
+      height: calc(100dvh - 76px);
+    }
+  }
 }
 
 .jobs-page-content {

--- a/iznik-nuxt3/tests/unit/components/LayoutCommon.spec.js
+++ b/iznik-nuxt3/tests/unit/components/LayoutCommon.spec.js
@@ -1,10 +1,13 @@
 import { readFileSync } from 'fs'
 import { resolve } from 'path'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
 import { ref } from 'vue'
+import LayoutCommon from '~/components/LayoutCommon.vue'
 
 const mockMiscStore = {
   stickyAdRendered: false,
+  replyOverlayOpen: false,
   visible: true,
   setTime: vi.fn(),
   startOnlineCheck: vi.fn(),
@@ -13,6 +16,9 @@ const mockMiscStore = {
 const mockAuthStore = {
   fetchUser: vi.fn(),
 }
+
+const mockLoggedIn = ref(true)
+const mockRecentDonor = ref(false)
 
 vi.mock('~/stores/misc', () => ({
   useMiscStore: () => mockMiscStore,
@@ -41,11 +47,20 @@ vi.mock('~/stores/chat', () => ({
   }),
 }))
 
+vi.mock('~/stores/mobile', () => ({
+  useMobileStore: () => ({ isApp: false, deviceuserinfo: null }),
+}))
+
+vi.mock('@/stores/mobile', () => ({
+  useMobileStore: () => ({ isApp: false, deviceuserinfo: null }),
+}))
+
 vi.mock('~/composables/useMe', () => ({
   useMe: () => ({
     me: ref({ id: 1 }),
     myid: ref(1),
-    loggedIn: ref(true),
+    loggedIn: mockLoggedIn,
+    recentDonor: mockRecentDonor,
   }),
 }))
 
@@ -57,9 +72,49 @@ vi.mock('~/composables/useReplyToPost', () => ({
   }),
 }))
 
+// Mounts the real LayoutCommon component (not a source-string stand-in) with
+// the current route stubbed to `path`, so allowAd's routePath-based logic
+// actually runs and we can assert on what it renders. Heavy/unrelated
+// descendants (ads, video, chat, error banners) are stubbed out - we only
+// care whether the sticky ad wrapper (div.sticky) is present.
+function mountLayoutAtRoute(path) {
+  globalThis.__testUseRoute = () => ({
+    path,
+    fullPath: path,
+    params: {},
+    query: {},
+    name: path,
+  })
+
+  return mount(LayoutCommon, {
+    slots: {
+      default: '<div class="page-slot-content" />',
+    },
+    global: {
+      stubs: {
+        'client-only': { template: '<div><slot /></div>' },
+        VisibleWhen: { template: '<div><slot /></div>' },
+        ExternalDa: true,
+        DaDisableCTA: true,
+        DeletedRestore: true,
+        BouncingEmail: true,
+        BreakpointFettler: true,
+        OrientationFettler: true,
+        SomethingWentWrong: true,
+        SupportLink: true,
+        ChatButton: true,
+        InterestedInOthersModal: true,
+      },
+    },
+  })
+}
+
 describe('LayoutCommon', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockLoggedIn.value = true
+    mockRecentDonor.value = false
+    delete globalThis.__testUseRoute
   })
 
   describe('main content area', () => {
@@ -102,16 +157,22 @@ describe('LayoutCommon', () => {
       // same job ads already shown in the page's own list) - i.e. two scroll
       // regions instead of one. allowAd must exclude /jobs, the same way it
       // already excludes /partnerships and /together.
-      const src = readFileSync(
-        resolve(__dirname, '../../../components/LayoutCommon.vue'),
-        'utf-8'
-      )
-      const allowAdMatch = src.match(
-        /const allowAd = computed\(\(\) => \{[\s\S]*?\n\}\)/
-      )
-      expect(allowAdMatch).not.toBeNull()
-      const allowAdSrc = allowAdMatch[0]
-      expect(allowAdSrc).toMatch(/routePath\.value\s*===\s*['"]\/jobs['"]/)
+      //
+      // This mounts the real component with the route stubbed to /jobs and
+      // asserts on what is actually rendered, rather than pattern-matching the
+      // component's source text (which would prove the string existed, not
+      // that the logic behaves correctly).
+      const wrapper = mountLayoutAtRoute('/jobs')
+      expect(wrapper.find('.sticky').exists()).toBe(false)
+    })
+
+    it('shows the sticky ad footer on an ordinary route', () => {
+      // Contrast case for the /jobs exclusion above: on a route with no
+      // exclusion, logged in and not a recent donor, the sticky ad still
+      // renders. Without this, a test that just asserts ".sticky" is absent
+      // on /jobs could pass vacuously (e.g. if the ad never rendered at all).
+      const wrapper = mountLayoutAtRoute('/browse')
+      expect(wrapper.find('.sticky').exists()).toBe(true)
     })
 
     it('shows DaDisableCTA after ad rendered', () => {

--- a/iznik-nuxt3/tests/unit/components/LayoutCommon.spec.js
+++ b/iznik-nuxt3/tests/unit/components/LayoutCommon.spec.js
@@ -1,7 +1,7 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { ref } from 'vue'
 import { readFileSync } from 'fs'
 import { resolve } from 'path'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ref } from 'vue'
 
 const mockMiscStore = {
   stickyAdRendered: false,
@@ -93,6 +93,25 @@ describe('LayoutCommon', () => {
     it('hides ad on landing page when logged out', () => {
       // routePath.value !== '/' || loggedIn.value
       expect(true).toBe(true)
+    })
+
+    it('hides the sticky jobs ad footer on the dedicated /jobs page', () => {
+      // Discourse topic 9363 post #38 (Neville_Reid): on iOS the /jobs page showed
+      // a non-scrollable job list at the top plus a separate ~2-row independently
+      // scrollable panel below it (JobsDaSlot's sticky footer, which duplicates the
+      // same job ads already shown in the page's own list) - i.e. two scroll
+      // regions instead of one. allowAd must exclude /jobs, the same way it
+      // already excludes /partnerships and /together.
+      const src = readFileSync(
+        resolve(__dirname, '../../../components/LayoutCommon.vue'),
+        'utf-8'
+      )
+      const allowAdMatch = src.match(
+        /const allowAd = computed\(\(\) => \{[\s\S]*?\n\}\)/
+      )
+      expect(allowAdMatch).not.toBeNull()
+      const allowAdSrc = allowAdMatch[0]
+      expect(allowAdSrc).toMatch(/routePath\.value\s*===\s*['"]\/jobs['"]/)
     })
 
     it('shows DaDisableCTA after ad rendered', () => {


### PR DESCRIPTION
## Root Cause

Two distinct bugs on iOS, per the reporter (Neville_Reid, iPhone SE3, iOS app 100.0.750):

1. The `/jobs` page's own job list relied entirely on document/body-level scroll (`.pageContent` in `LayoutCommon.vue` sets `max-height: 100vh`/`100dvh` but no `overflow-y`, so the page depends on the browser scrolling the whole document, enabled for list pages via a `class: 'overflow-y-scroll'` body class from `useHead`). On iOS the app is a Capacitor/WKWebView build (`capacitor.config.ts`: `ios.contentInset: 'automatic'`), and the reporter's repro path is specifically returning from a backgrounded external browser tab (they tapped a job, which opened the default browser, then returned to the app) - a known trigger for WKWebView's document-level scroll view becoming unresponsive after the page's dynamically-loaded (`client-only`, async-fetched) content changes height post-hydration.
2. `LayoutCommon.vue`'s sticky footer ad (`allowAd`) was shown on `/jobs` too, duplicating the same job ads in a small `position: fixed` panel with its own `overflow-y: auto` div (`JobsDaSlot.vue` `.jobs-slot`) - giving the page a second, independently-scrolling 2-row panel.

## Why the previous attempt was rejected

PR #1116 only fixed bug (2) - it excluded `/jobs` from `allowAd`, removing the duplicate panel - but left bug (1) (the page's own list not scrolling) completely unaddressed. Its test also didn't exercise any real logic: it read `LayoutCommon.vue` off disk as a string and regex-matched the `allowAd` computed block's source text, which would pass even if the logic did nothing at runtime.

What's different in this re-attempt:
- Fixes bug (1): `pages/jobs.vue`'s `.jobs-page` now has its own bounded, `overflow-y: auto` scroll region instead of depending on document scroll (see Fix below).
- Replaces the source-regex test with a real `@vue/test-utils` mount of `LayoutCommon.vue` that stubs `useRoute()` and asserts on what actually renders.

## Evidence

Failing-test output (`tests/unit/components/LayoutCommon.spec.js`) with the `/jobs` exclusion in `allowAd` temporarily reverted, proving the new test exercises real behaviour rather than passing vacuously:

```
 FAIL  tests/unit/components/LayoutCommon.spec.js > LayoutCommon > sticky ad > hides the sticky jobs ad footer on the dedicated /jobs page
AssertionError: expected true to be false // Object.is equality

- Expected
+ Received

- false
+ true

 ❯ tests/unit/components/LayoutCommon.spec.js:166:48
    164|       // that the logic behaves correctly).
    165|       const wrapper = mountLayoutAtRoute('/jobs')
    166|       expect(wrapper.find('.sticky').exists()).toBe(false)
       |                                                ^
```

With the fix restored, the same test (plus a contrasting "shows the sticky ad footer on an ordinary route" case, so the assertion can't pass by the ad simply never rendering) both pass: `tests/unit/components/LayoutCommon.spec.js (58 tests) passed`.

## Fix

- `iznik-nuxt3/pages/jobs.vue`: `.jobs-page` now gets `height: calc(100vh - <navbar height>)` (with `100dvh` fallback, at the same `md`/`xl` breakpoints `LayoutCommon.vue` uses for its navbar-height margin) plus `overflow-y: auto; -webkit-overflow-scrolling: touch;`, so the job list scrolls within its own CSS-computed region instead of depending on WKWebView's document-level scroll view. This mirrors the same already-working, iOS-tested pattern used by `ChatPane.vue` / `pages/chats/[[id]].vue` for full-height scrollable content below the fixed navbar. Also removed the now-unneeded `class: 'overflow-y-scroll'` body attribute, since the page no longer relies on body scroll.
- `iznik-nuxt3/components/LayoutCommon.vue`: unchanged in this re-attempt - the `/jobs` exclusion from `allowAd` (added in the original PR #1116 commit) is still correct and is kept.

This is a CSS/layout fix; the actual iOS WKWebView scroll-view bug this works around can't be reproduced in a unit-test environment (jsdom doesn't run real layout/scroll), so I couldn't write an automated test that fails specifically on that browser behaviour. I did verify the changed template compiles and renders correctly by copying it into a running dev container and confirming no Vite/SCSS compilation errors and a 200 response from `/jobs`; I did not have interactive browser-tool access in this session to visually confirm the scroll behaviour on an emulated iOS viewport.

## Other Call Sites

`grep -rn "routePath.value ===" --include=*.vue` finds only the one site in `LayoutCommon.vue` (unchanged). `grep -rn "jobs-page\|jobs-grid"` finds only `pages/jobs.vue` itself - no other component or e2e test depends on these classes.

## Test

File: `iznik-nuxt3/tests/unit/components/LayoutCommon.spec.js`
Command: `npx vitest run tests/unit/components/LayoutCommon.spec.js`
Proves fail-before (test fails when the `/jobs` exclusion is reverted, see Evidence) / pass-after (passes with the fix in place). Full unit suite (`npx vitest run`) also passes: 679 files, 14386 tests, 4 pre-existing skips - no regressions.

The `pages/jobs.vue` height/overflow CSS change itself is pure layout and not meaningfully testable at the unit level (see justification under Fix above).

## Discourse
https://discourse.ilovefreegle.org/t/9363/38