### PR TITLE
fix(ModTools message search): surface aborted all-communities searches instead of reporting empty

### DIFF
--- a/iznik-nuxt3/modtools/pages/messages/approved/[[id]]/[[term]].vue
+++ b/iznik-nuxt3/modtools/pages/messages/approved/[[id]]/[[term]].vue
@@ -21,7 +21,19 @@
       <ModtoolsViewControl misckey="modtoolsMessagesApprovedSummary" />
     </div>
     <div>
-      <NoticeMessage v-if="loaded && !messages.length && !busy" class="mt-2">
+      <NoticeMessage
+        v-if="loaded && !messages.length && !busy && messageStore.messageSearchTimedOut"
+        variant="warning"
+        class="mt-2"
+      >
+        That search took too long across all your communities and was
+        stopped before it finished, so this isn't necessarily "nothing
+        found". Try picking a specific community, or search again.
+      </NoticeMessage>
+      <NoticeMessage
+        v-else-if="loaded && !messages.length && !busy"
+        class="mt-2"
+      >
         Nothing found. Almost always this is because the member or message
         doesn't exist (or has been very deleted).
       </NoticeMessage>

--- a/iznik-nuxt3/stores/message.js
+++ b/iznik-nuxt3/stores/message.js
@@ -32,6 +32,12 @@ export const useMessageStore = defineStore({
     // The context from the last fetch, used for fetchMore (ModTools)
     context: null,
 
+    // Whether the last fetchMessagesMT search was aborted by the server's
+    // query time cap rather than genuinely completing with no matches
+    // (Discourse 9938 - an all-communities member search that times out
+    // must not look identical to "no such member" in the UI).
+    messageSearchTimedOut: false,
+
     // Freegle Helper (AI concierge) state per bulk-offer msgid:
     // { batch, repliers, proposals, sent }. Loaded by the clearance management page.
     helper: {},
@@ -666,6 +672,7 @@ export const useMessageStore = defineStore({
       if (!params.context) params.context = null
 
       const data = await api(this.config).message.fetchMessages(params)
+      this.messageSearchTimedOut = !!data.timedOut
       if (!data.messages || data.messages.length === 0) return
       const messageIDs = data.messages // Now returns IDs only (uint64 array)
       const context = data.context // Can be undefined if search complete

--- a/iznik-server-go/message/message_list.go
+++ b/iznik-server-go/message/message_list.go
@@ -2,11 +2,14 @@ package message
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
+
+	rawmysql "github.com/go-sql-driver/mysql"
 
 	"github.com/freegle/iznik-server-go/database"
 	"github.com/freegle/iznik-server-go/misc"
@@ -14,6 +17,15 @@ import (
 	"github.com/freegle/iznik-server-go/utils"
 	"github.com/gofiber/fiber/v2"
 )
+
+// isQueryTimeoutErr reports whether err is the abort raised by the
+// MAX_EXECUTION_TIME optimizer hint used in buildMTUnionAllMsgIDQuery
+// (MySQL error 3024, ER_QUERY_TIMEOUT), as opposed to a genuine
+// zero-rows result or an unrelated error.
+func isQueryTimeoutErr(err error) bool {
+	var mysqlErr *rawmysql.MySQLError
+	return errors.As(err, &mysqlErr) && mysqlErr.Number == 3024
+}
 
 // --- Message List types and handler ---
 
@@ -450,6 +462,13 @@ func ListMessagesMT(c *fiber.Ctx) error {
 	fromuser, _ := strconv.ParseUint(fromuserStr, 10, 64)
 
 	var msgIDs []uint64
+	// timedOut records whether any search query below was aborted by the
+	// MAX_EXECUTION_TIME cap (see buildMTUnionAllMsgIDQuery) rather than
+	// genuinely completing with zero matches. Discourse 9938: an
+	// all-communities member-name search that hits the cap previously
+	// looked identical to "no such member" — the client has no way to
+	// tell a completed empty search from an aborted one.
+	timedOut := false
 
 	// Hide Pending messages not yet processed by the content-check batch job.
 	// The 30-minute fallback ensures mods always see messages if the batch job is down,
@@ -487,7 +506,9 @@ func ListMessagesMT(c *fiber.Ctx) error {
 				contentcheckFilter +
 				" ORDER BY mg.arrival DESC, mg.msgid DESC LIMIT ?"
 			sql, args := buildMTUnionAllMsgIDQuery(branchSQL, []interface{}{collection, searchID}, groupIDs, limit)
-			db.Raw(sql, args...).Pluck("msgid", &msgIDs)
+			if r := db.Raw(sql, args...).Pluck("msgid", &msgIDs); isQueryTimeoutErr(r.Error) {
+				timedOut = true
+			}
 		}
 		if len(msgIDs) == 0 {
 			searchTerm := "%" + search + "%"
@@ -499,7 +520,9 @@ func ListMessagesMT(c *fiber.Ctx) error {
 				contentcheckFilter +
 				" ORDER BY mg.arrival DESC, mg.msgid DESC LIMIT ?"
 			sql, args := buildMTUnionAllMsgIDQuery(branchSQL, []interface{}{collection, searchTerm}, groupIDs, limit)
-			db.Raw(sql, args...).Pluck("msgid", &msgIDs)
+			if r := db.Raw(sql, args...).Pluck("msgid", &msgIDs); isQueryTimeoutErr(r.Error) {
+				timedOut = true
+			}
 		}
 	} else if subaction == "searchmemb" && search != "" {
 		// If search is a numeric user ID, do a fast direct lookup first.
@@ -516,7 +539,9 @@ func ListMessagesMT(c *fiber.Ctx) error {
 				contentcheckFilter +
 				" ORDER BY mg.arrival DESC, mg.msgid DESC LIMIT ?"
 			sql, args := buildMTUnionAllMsgIDQuery(branchSQL, []interface{}{collection, searchUID}, groupIDs, limit)
-			db.Raw(sql, args...).Pluck("msgid", &msgIDs)
+			if r := db.Raw(sql, args...).Pluck("msgid", &msgIDs); isQueryTimeoutErr(r.Error) {
+				timedOut = true
+			}
 		}
 		if len(msgIDs) == 0 {
 			// Fall back to name/email LIKE search.  The LEFT JOIN to
@@ -534,7 +559,9 @@ func ListMessagesMT(c *fiber.Ctx) error {
 				contentcheckFilter +
 				" ORDER BY mg.arrival DESC, mg.msgid DESC LIMIT ?"
 			sql, args := buildMTUnionAllMsgIDQuery(branchSQL, []interface{}{collection, searchTerm, searchTerm}, groupIDs, limit)
-			db.Raw(sql, args...).Pluck("msgid", &msgIDs)
+			if r := db.Raw(sql, args...).Pluck("msgid", &msgIDs); isQueryTimeoutErr(r.Error) {
+				timedOut = true
+			}
 		}
 	} else {
 		// When listing the Pending review queue, also include Spam-collection messages.
@@ -571,11 +598,20 @@ func ListMessagesMT(c *fiber.Ctx) error {
 		branchSQL += "ORDER BY mg.arrival DESC, mg.msgid DESC LIMIT ?"
 
 		sql, args := buildMTUnionAllMsgIDQuery(branchSQL, branchArgs, groupIDs, limit)
-		db.Raw(sql, args...).Pluck("msgid", &msgIDs)
+		if r := db.Raw(sql, args...).Pluck("msgid", &msgIDs); isQueryTimeoutErr(r.Error) {
+			timedOut = true
+		}
 	}
 
 	if len(msgIDs) == 0 {
-		return c.JSON(fiber.Map{"messages": []uint64{}})
+		resp := fiber.Map{"messages": []uint64{}}
+		if timedOut {
+			// Tell the client this wasn't a completed search that found nothing —
+			// it was aborted by the query cap. The ModTools UI can then show a
+			// distinct message instead of implying the member/message doesn't exist.
+			resp["timedOut"] = true
+		}
+		return c.JSON(resp)
 	}
 
 	// Build pagination context from last ID.

--- a/iznik-server-go/message/message_list_pure_test.go
+++ b/iznik-server-go/message/message_list_pure_test.go
@@ -2,13 +2,49 @@ package message
 
 // Tests for pure (no-DB) functions in message_list.go.
 // buildMTUnionAllMsgIDQuery is a pure SQL-builder: no database or fiber context needed.
+// isQueryTimeoutErr is a pure error classifier: no database needed either.
 
 import (
+	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
+	rawmysql "github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/assert"
 )
+
+// TestIsQueryTimeoutErr_DetectsERQueryTimeout verifies the MySQL error raised
+// by the MAX_EXECUTION_TIME optimizer hint (error 3024, ER_QUERY_TIMEOUT) is
+// recognised as a timeout, not treated as a genuine zero-rows result.
+func TestIsQueryTimeoutErr_DetectsERQueryTimeout(t *testing.T) {
+	err := &rawmysql.MySQLError{Number: 3024, Message: "Query execution was interrupted, maximum statement execution time exceeded"}
+	assert.True(t, isQueryTimeoutErr(err))
+}
+
+// TestIsQueryTimeoutErr_WrappedError verifies detection still works when the
+// MySQLError has been wrapped by another error (as GORM/database-sql do).
+func TestIsQueryTimeoutErr_WrappedError(t *testing.T) {
+	err := errors.New("wrapped: " + (&rawmysql.MySQLError{Number: 3024, Message: "timeout"}).Error())
+	// A plain string-wrapped error (not errors.Wrap/fmt.Errorf %w) cannot be
+	// unwrapped, so this must NOT be misdetected as a timeout — errors.As only
+	// matches the concrete *MySQLError type through the error chain.
+	assert.False(t, isQueryTimeoutErr(err))
+
+	wrapped := fmt.Errorf("query failed: %w", &rawmysql.MySQLError{Number: 3024, Message: "timeout"})
+	assert.True(t, isQueryTimeoutErr(wrapped))
+}
+
+// TestIsQueryTimeoutErr_IgnoresOtherErrors verifies unrelated errors (a
+// different MySQL error number, a generic error, or nil) are not
+// misclassified as a query timeout.
+func TestIsQueryTimeoutErr_IgnoresOtherErrors(t *testing.T) {
+	assert.False(t, isQueryTimeoutErr(nil))
+	assert.False(t, isQueryTimeoutErr(errors.New("connection refused")))
+	assert.False(t, isQueryTimeoutErr(&rawmysql.MySQLError{Number: 1146, Message: "Table doesn't exist"}))
+	// gorm.ErrRecordNotFound-shaped generic error, still not a timeout.
+	assert.False(t, isQueryTimeoutErr(errors.New("record not found")))
+}
 
 // branchSQL with a single %GID% placeholder, one extra arg, plus the trailing LIMIT arg.
 const testBranchSQL = "SELECT mg.msgid, mg.arrival FROM messages_groups mg WHERE mg.groupid = %GID% AND mg.collection = ? ORDER BY mg.arrival DESC, mg.msgid DESC LIMIT ?"

--- a/iznik-server-go/message/message_list_timeout_test.go
+++ b/iznik-server-go/message/message_list_timeout_test.go
@@ -1,0 +1,69 @@
+package message
+
+// TestSearchTimeout_* are the only tests in this package that need a live
+// MySQL connection (the rest of message_list_*_test.go is deliberately
+// DB-free). They reproduce, against a real connection, the exact abort
+// mechanism behind buildMTUnionAllMsgIDQuery's production
+// MAX_EXECUTION_TIME(20000) cap (Discourse 9938) - using a small cap + SLEEP
+// so the same abort fires deterministically in about a second, instead of
+// waiting on the real 20s production cap.
+
+import (
+	"os"
+	"testing"
+
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ensureTestDB opens database.DBConn if this test binary hasn't already
+// connected. Reuses the same MYSQL_* env vars the go-api test container
+// already provides for the test/ package's integration suite; skips (rather
+// than panicking) when they're absent, e.g. a bare local `go test ./message/...`.
+func ensureTestDB(t *testing.T) {
+	t.Helper()
+	if database.DBConn != nil {
+		return
+	}
+	if os.Getenv("MYSQL_HOST") == "" {
+		t.Skip("MYSQL_HOST not set - skipping live-DB test")
+	}
+	database.InitDatabase()
+}
+
+// TestSearchTimeout_BuggyPluckPatternCannotDistinguishAbortFromEmpty
+// reproduces 9938's root defect using only APIs that existed before this fix
+// (a plain db.Raw(...).Pluck(...) call, exactly as every buildMTUnionAllMsgIDQuery
+// branch in ListMessagesMT used pre-fix). It asserts the BUGGY behaviour:
+// Pluck leaves ids empty on an abort, indistinguishable from a real empty
+// search, because nothing inspects the returned error. This test compiles
+// and passes on the pre-fix code (Pluck's own behaviour is unchanged) - it
+// documents the defect this fix works around.
+func TestSearchTimeout_BuggyPluckPatternCannotDistinguishAbortFromEmpty(t *testing.T) {
+	ensureTestDB(t)
+	db := database.DBConn
+
+	var ids []uint64
+	db.Raw("SELECT /*+ MAX_EXECUTION_TIME(100) */ 1 AS msgid FROM (SELECT SLEEP(1)) x").Pluck("msgid", &ids)
+
+	assert.Empty(t, ids, "an aborted query silently looks like zero rows when only Pluck's ids are read")
+}
+
+// TestSearchTimeout_RealAbortIsDetected is the inverted assertion: it proves
+// the fix (isQueryTimeoutErr) actually distinguishes the same abort from a
+// genuine empty result, instead of the client being told "nothing found".
+// This does not compile against the pre-fix code (isQueryTimeoutErr did not
+// exist) and must pass once the fix is present.
+func TestSearchTimeout_RealAbortIsDetected(t *testing.T) {
+	ensureTestDB(t)
+	db := database.DBConn
+
+	var ids []uint64
+	result := db.Raw("SELECT /*+ MAX_EXECUTION_TIME(100) */ 1 AS msgid FROM (SELECT SLEEP(1)) x")
+	result.Pluck("msgid", &ids)
+
+	require.Error(t, result.Error, "the deliberately slow query must actually be aborted by MySQL")
+	assert.Empty(t, ids)
+	assert.True(t, isQueryTimeoutErr(result.Error), "a MAX_EXECUTION_TIME abort must be classified as a timeout, err=%v", result.Error)
+}

--- a/iznik-server-go/test/message_test.go
+++ b/iznik-server-go/test/message_test.go
@@ -5742,6 +5742,42 @@ func TestListMessagesSearchMembByID(t *testing.T) {
 	assert.Greater(t, len(result.Messages), 0, "Should find messages by numeric member ID")
 }
 
+// TestListMessagesMT_SearchMembAllCommunities verifies that a ModTools
+// member-name search with no groupid (i.e. "all my communities") finds a
+// message that exists in one of the mod's several groups. Discourse 9938:
+// this exact search sometimes returned nothing even though the message
+// existed, because a query aborted by buildMTUnionAllMsgIDQuery's
+// MAX_EXECUTION_TIME cap looked identical to a genuinely empty result. This
+// guards the everyday (fast, non-aborted) path: it must keep finding real
+// matches and must not report timedOut for them.
+func TestListMessagesMT_SearchMembAllCommunities(t *testing.T) {
+	prefix := uniquePrefix("listmt_srchmb_all")
+
+	groupA := CreateTestGroup(t, prefix+"_a")
+	groupB := CreateTestGroup(t, prefix+"_b")
+	posterID := CreateTestUser(t, prefix+"_poster", "User")
+	modID := CreateTestUser(t, prefix+"_mod", "User")
+	CreateTestMembership(t, posterID, groupA, "Member")
+	CreateTestMembership(t, modID, groupA, "Moderator")
+	CreateTestMembership(t, modID, groupB, "Moderator")
+	_, modToken := CreateTestSession(t, modID)
+
+	CreateTestMessage(t, posterID, groupA, prefix+" Offer Bicycle", 55.9533, -3.1883)
+
+	// No groupid => search across all of the mod's communities (groupA + groupB).
+	mtURL := fmt.Sprintf("/api/modtools/messages?collection=Approved&subaction=searchmemb&search=%s&jwt=%s",
+		url.QueryEscape(prefix+"_poster"), modToken)
+	resp, err := getApp().Test(httptest.NewRequest("GET", mtURL, nil))
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&result)
+	msgs, _ := result["messages"].([]interface{})
+	assert.Greater(t, len(msgs), 0, "all-communities member search should find the message")
+	assert.Nil(t, result["timedOut"], "a fast, well-scoped search must not be reported as timed out")
+}
+
 func TestListMessagesInvalidCollection(t *testing.T) {
 	prefix := uniquePrefix("lstmsg_badcoll")
 	groupID := CreateTestGroup(t, prefix)


### PR DESCRIPTION
## Root Cause
`ListMessagesMT`'s all-communities member/message search runs a UNION-per-group query (`buildMTUnionAllMsgIDQuery`) capped with a `MAX_EXECUTION_TIME(20000)` hint, added in a previous fix (Discourse 9518/366) so a slow cross-group search returns rather than hanging forever. When that cap fires, MySQL aborts the statement with error 3024 (`ER_QUERY_TIMEOUT`) — but every `db.Raw(sql, args...).Pluck("msgid", &msgIDs)` call in `ListMessagesMT` discarded the returned error. An aborted search therefore left `msgIDs` empty, which the handler then reported as `{"messages": []}` — indistinguishable from a search that genuinely completed and found nothing. This exactly matches the report: a mod pastes a member name, the all-communities search silently returns nothing after ~20s (the cap), and searching again after picking one group (fast, well under the cap) finds it.

Live-DB check confirmed the mechanics: several moderators cover 20-79 groups, and `messages_groups` has ~7.4M Approved rows — a leading-wildcard `fullname`/`email` LIKE joined per group across that many groups is a realistic multi-second-to-timeout query, consistent with the "each search takes about 20 seconds" follow-up from the same reporter.

## Evidence
Failing-test output before the fix (from a temporarily-reverted copy of `message_list.go`):
```
$ go vet ./message/...
vet: message/message_list_timeout_test.go:68:17: undefined: isQueryTimeoutErr
```
The new detection logic doesn't exist pre-fix, so the inverted assertion can't even compile against the buggy code. The companion test in the same file (`TestSearchTimeout_BuggyPluckPatternCannotDistinguishAbortFromEmpty`), which uses only pre-existing APIs, compiles and **passes** both before and after the fix — it documents the defect directly: a real MySQL abort (verified against a live MySQL connection, error 3024) leaves `ids` empty with nothing to distinguish it from a genuine empty result.

## Fix
- Added `isQueryTimeoutErr` (`message/message_list.go`) to recognise MySQL error 3024 (`ER_QUERY_TIMEOUT`) via `errors.As`.
- Every `buildMTUnionAllMsgIDQuery`-backed query in `ListMessagesMT` (searchall by ID/subject, searchmemb by user ID/name, and the default listing) now checks the returned error; if any branch was aborted and the final result is empty, the response includes `"timedOut": true` instead of a bare empty list.
- `iznik-nuxt3`: `messageStore.fetchMessagesMT` now records `messageSearchTimedOut` from the response, and the ModTools approved-messages page shows a distinct warning ("that search took too long... try picking a specific community, or search again") instead of "Nothing found" when a search was aborted rather than completed.
- The 20s cap itself is unchanged — it still guards against the original hang (9518/366); this only stops the abort being reported as a definitive "not found".

## Other Call Sites
All 5 `db.Raw(...).Pluck("msgid", &msgIDs)` call sites in `ListMessagesMT` used the same discard-the-error pattern and are now fixed identically (searchall-by-id, searchall-by-subject, searchmemb-by-id, searchmemb-by-name, default listing). The `Edit`-collection branch uses a separate, unbounded query with no `MAX_EXECUTION_TIME` cap, so it isn't affected by this bug. The older `ListMessages` handler (`/api/messages`, used by the member-facing frontend, not ModTools) has no `MAX_EXECUTION_TIME` cap at all — out of scope for this fix.

## Test
- `iznik-server-go/message/message_list_pure_test.go`: unit tests for `isQueryTimeoutErr` (real 3024 error, wrapped error, unrelated errors, nil).
- `iznik-server-go/message/message_list_timeout_test.go`: live-DB AssertFlip pair reproducing a genuine MAX_EXECUTION_TIME abort (scaled down to ~100ms so it's deterministic and fast) and proving `isQueryTimeoutErr` correctly classifies it.
- `iznik-server-go/test/message_test.go`: `TestListMessagesMT_SearchMembAllCommunities` — regression test for the reported scenario (member-name search with no groupid across a mod's several communities finds the message, without `timedOut`).
- Full `message` package suite and the `ListMessagesMT`/search-related `test` package suite pass. The broader `test` package suite was run against an ad hoc throwaway DB (no dedicated status-API stack was provisioned for this isolated worktree); several unrelated pre-existing failures were found (session timezone drift, email-tracking config, rippling `outer_bound` schema quirk, missing routing/spatial fixtures) and each was individually confirmed to reproduce identically with this fix fully reverted, so they're environment gaps in that throwaway setup, not regressions from this change.

## Discourse
https://discourse.ilovefreegle.org/t/9938