### PR TITLE
fix(login): don't report a DB lookup error as an unknown email

### DIFF
--- a/iznik-server-go/session/session.go
+++ b/iznik-server-go/session/session.go
@@ -536,11 +536,21 @@ func handleEmailPasswordLogin(c *fiber.Ctx, email string, password string) error
 
 	// Find user by email. Deleted users can still log in so they see the
 	// "restore your account" banner.
+	//
+	// Use RetryQuery rather than a bare db.Raw().Scan(): that discarded the
+	// query's error, so a transient read failure (e.g. a replica connection
+	// dropped mid-query - see database/failover.go) left userID at its zero
+	// value and was reported identically to a genuinely unknown email (#9941).
+	// RetryQuery retries recoverable connection errors; anything left after
+	// that is a real backend failure, not a missing user, and must not be
+	// reported as "we don't know that email address".
 	var userID uint64
-	db.Raw("SELECT u.id FROM users u "+
+	if err := database.RetryQuery(db, &userID, "SELECT u.id FROM users u "+
 		"JOIN users_emails ue ON ue.userid = u.id "+
 		"WHERE ue.email = ? "+
-		"LIMIT 1", email).Scan(&userID)
+		"LIMIT 1", email); err != nil {
+		return fiber.NewError(fiber.StatusInternalServerError, "Failed to look up email address")
+	}
 
 	if userID == 0 {
 		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{

--- a/iznik-server-go/test/session_test.go
+++ b/iznik-server-go/test/session_test.go
@@ -18,6 +18,8 @@ import (
 	log2 "github.com/freegle/iznik-server-go/log"
 	"github.com/freegle/iznik-server-go/session"
 	"github.com/stretchr/testify/assert"
+	"gorm.io/driver/mysql"
+	"gorm.io/gorm"
 )
 
 func postSession(body string) *http.Response {
@@ -798,6 +800,52 @@ func TestLoginUnknownEmail(t *testing.T) {
 	json.NewDecoder(resp.Body).Decode(&result)
 	assert.Equal(t, float64(2), result["ret"])
 	assert.Contains(t, result["status"], "email")
+}
+
+// TestLoginEmailLookupDBErrorNotReportedAsUnknownEmail is a regression test for
+// Discourse #9941 post 1. A moderator's ModTools session crashed; on reopening
+// they re-entered their correct credentials and got "We don't know that email
+// address", then the same credentials worked moments later. handleEmailPasswordLogin
+// looked up the user with a bare db.Raw(...).Scan(&userID) that discarded the
+// query's error - so a transient DB failure (e.g. a read-replica connection
+// dropped mid-query, see database/failover.go) left userID at its zero value
+// and was reported identically to a genuinely unknown email. A lookup ERROR must
+// be surfaced as a backend failure, not misreported as an unknown-email login.
+func TestLoginEmailLookupDBErrorNotReportedAsUnknownEmail(t *testing.T) {
+	// Point DBConn at the (always-present) information_schema database, which
+	// has no `users` table. The connection succeeds - only the query errors -
+	// so this deterministically reproduces "lookup ERRORED", as distinct from
+	// "lookup found no rows", without relying on flaky network-level failures.
+	dsn := fmt.Sprintf(
+		"%s:%s@%s(%s:%s)/information_schema?charset=utf8mb4&parseTime=True&loc=Local&interpolateParams=true",
+		os.Getenv("MYSQL_USER"), os.Getenv("MYSQL_PASSWORD"), os.Getenv("MYSQL_PROTOCOL"),
+		os.Getenv("MYSQL_HOST"), os.Getenv("MYSQL_PORT"),
+	)
+	badDB, err := gorm.Open(mysql.Open(dsn), &gorm.Config{})
+	assert.NoError(t, err, "connecting to information_schema should succeed - only the users query should fail")
+
+	original := database.DBConn
+	database.DBConn = badDB
+	defer func() { database.DBConn = original }()
+
+	body, _ := json.Marshal(map[string]interface{}{
+		"email":    "doesnt-matter-9941@example.com",
+		"password": "whatever",
+	})
+
+	req := httptest.NewRequest("POST", "/api/session", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, reqErr := getApp().Test(req, 5000)
+	assert.NoError(t, reqErr)
+
+	var result map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&result)
+
+	// A DB lookup ERROR must not be reported as ret=2 "We don't know that email
+	// address" (404) - that message means "genuinely unknown", not "we couldn't
+	// check". It must surface as a backend failure instead.
+	assert.NotEqual(t, 404, resp.StatusCode, "a DB error must not produce the same 404 as a genuinely unknown email")
+	assert.NotEqual(t, float64(2), result["ret"], "ret=2 means unknown email - must not be used for a lookup error")
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Root Cause
`handleEmailPasswordLogin` (iznik-server-go/session/session.go) looked up the user by email with a bare `db.Raw(...).Scan(&userID)` that discarded the query's `.Error`. When the lookup query itself errored (e.g. a read-replica connection dropped mid-query - the read/write split and replica failover were both added within the last two weeks, see `database/failover.go` and `database/database.go`), `userID` stayed at its Go zero value and was reported identically to a genuinely unknown email: `ret:2 "We don't know that email address."` A backend failure was indistinguishable from "this account doesn't exist."

This matches the report exactly: a moderator's ModTools session crashed mid-navigation; on reopening they were shown the login page, entered their correct credentials, got "We don't know that email address.", then the same credentials worked moments later with no other change.

## Evidence
AssertFlip test run against the pre-fix code, forcing the lookup query to error (pointed `database.DBConn` at `information_schema`, which has no `users` table, so the connection succeeds but the query errors - deterministically reproducing "lookup ERRORED" as distinct from "lookup found no rows"):

```
=== RUN   TestLoginEmailLookupDBErrorNotReportedAsUnknownEmail

[31;1m.../session/session.go:543 [35;1mError 1109 (42S02): Unknown table 'USERS' in information_schema
[33m[0.746ms] [34;1m[SELECT u.id FROM users u JOIN users_emails ue ON ue.userid = u.id WHERE ue.email = 'doesnt-matter-9941@example.com' LIMIT 1
    session_test.go:847: Error Trace: session_test.go:847
        Error:      Should not be: 404
        Messages:   a DB error must not produce the same 404 as a genuinely unknown email
    session_test.go:848: Error Trace: session_test.go:848
        Error:      Should not be: 2
        Messages:   ret=2 means unknown email - must not be used for a lookup error
--- FAIL: TestLoginEmailLookupDBErrorNotReportedAsUnknownEmail (0.01s)
```

## Fix
Use `database.RetryQuery` for the email lookup instead of a bare `db.Raw().Scan()`. `RetryQuery` already existed in `database/retry.go` for exactly this purpose (mirrors V1's `LoggedPDO::prex()` retry-on-transient-connection-error behaviour) but had zero callers anywhere in the codebase before this change. Recoverable connection errors ("has gone away", "lost connection", "wsrep has not yet prepared") are now retried; any error left after that returns a 500 ("Failed to look up email address") instead of the "unknown email" response. A genuinely unknown email (query succeeds, zero rows) is unaffected - still returns `ret:2` as before.

No enumeration risk introduced: the fix strictly *removes* a case where a backend failure leaked as "unknown email" - it doesn't add any new distinguishing signal for real not-found vs. found.

## Other Call Sites
Same "bare `db.Raw(...).Scan()`, error discarded, zero value treated as not-found" pattern exists elsewhere but is out of scope for this fix (different reported symptom / different endpoints):
- `session/session.go` `handleLostPassword` (email lookup) and `handleUnsubscribe` (email lookup)
- `session/social_auth.go` (email/social-login lookup during OAuth signup-or-login)
- `user/user.go` (email-exists checks, ~L229, L2563, L2574)
- `auth/auth.go` `VerifyPassword` (password-credentials lookup - a DB error here currently surfaces as "the password is wrong" (ret=3), not "unknown email")

## Test
- File: `iznik-server-go/test/session_test.go`, `TestLoginEmailLookupDBErrorNotReportedAsUnknownEmail`
- Command: `go test ./test/... -run TestLoginEmailLookupDBErrorNotReportedAsUnknownEmail -v`
- Proves fail-before / pass-after: see Evidence above (404/ret:2 before the fix); passes after the fix (500, ret != 2). Full session/login test suite (78 tests) re-run clean after the fix, including `TestLoginUnknownEmail` confirming genuinely-unknown emails are unaffected.

## Discourse
https://discourse.ilovefreegle.org/t/9941/1