### PR TITLE
fix(email): admin-email tracking pixel blank on reopen in Outlook

### DIFF
--- a/iznik-batch/resources/views/emails/mjml/admin/admin.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/admin/admin.blade.php
@@ -81,8 +81,12 @@
 
         @include('emails.mjml.partials.footer', ['email' => $user->email_preferred, 'settingsUrl' => $settingsUrl])
 
-        @if(isset($trackingPixelMjml))
-        {!! $trackingPixelMjml !!}
+        @if(!empty($trackingPixelMjml))
+        <mj-section padding="0">
+            <mj-column>
+                {!! $trackingPixelMjml !!}
+            </mj-column>
+        </mj-section>
         @endif
     </mj-body>
 </mjml>

--- a/iznik-batch/tests/Unit/Mail/AdminMailTest.php
+++ b/iznik-batch/tests/Unit/Mail/AdminMailTest.php
@@ -254,4 +254,40 @@ class AdminMailTest extends TestCase
         $this->assertStringContainsString('3 days', $html,
             'Preheader must state how long the admin has been pending');
     }
+
+    public function test_admin_mail_tracking_pixel_is_wrapped_in_section_and_column(): void
+    {
+        // A bare <mj-image> as a direct child of <mj-body> violates the MJML
+        // schema (mj-image must live inside mj-column > mj-section). mrml
+        // renders that malformed nesting without the Outlook-conditional
+        // wrapper table every other section gets, which is what left the
+        // reported admin email blank on reopen in Outlook (topic 9925). Every
+        // other mailable (welcome, chase, digest siblings, etc.) wraps its
+        // tracking pixel in its own <mj-section padding="0"><mj-column> - this
+        // pins admin.blade.php to the same pattern.
+        $pixel = '<mj-image src="https://example.com/pixel.png" width="1px" height="1px" alt="" padding="0" />';
+
+        $html = view('emails.mjml.admin.admin', [
+            'user' => (object) ['email_preferred' => 'test@example.com', 'displayname' => 'Test User'],
+            'userSite' => config('freegle.sites.user'),
+            'adminSubject' => 'Test Subject',
+            'adminText' => 'Test body text',
+            'ctaLink' => null,
+            'ctaText' => null,
+            'groupName' => 'Test Group',
+            'modsEmail' => null,
+            'essential' => true,
+            'settingsUrl' => 'https://www.ilovefreegle.org/settings',
+            'marketingOptOutUrl' => null,
+            'unsubscribeUrl' => 'https://www.ilovefreegle.org/unsubscribe',
+            'volunteers' => [],
+            'trackingPixelMjml' => $pixel,
+        ])->render();
+
+        $this->assertMatchesRegularExpression(
+            '#<mj-section[^>]*>\s*<mj-column>\s*'.preg_quote($pixel, '#').'\s*</mj-column>\s*</mj-section>#',
+            $html,
+            'Tracking pixel must be wrapped in its own mj-section/mj-column, not a bare mj-body child.'
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- The admin email's tracking pixel was emitted as a bare `<mj-image>` directly under `<mj-body>`, which violates the MJML schema (`mj-image` must sit inside `mj-column` > `mj-section`).
- `mrml` renders that malformed nesting without the Outlook-conditional wrapper table every other section gets, which is what left the admin email blank when reopened in Outlook.
- Wrapped the pixel in its own `<mj-section padding="0"><mj-column>`, matching the pattern every other mailable (welcome, chase, digest siblings, donation, etc.) already uses.

## Code Quality Review
- Follows the existing house pattern verbatim (checked `donation/ask.blade.php` and message templates) — no new idiom introduced.
- Guard changed from `isset()` to `!empty()` to match the sibling templates (empty-string pixel now also skipped).

## Test Plan
- New unit test `AdminMailTest::test_admin_mail_tracking_pixel_is_wrapped_in_section_and_column` renders `emails.mjml.admin.admin` and asserts the pixel is wrapped in an `mj-section`/`mj-column`, not a bare body child. Red before the fix, green after.
- Full Laravel suite green locally: 4853 passed, 0 failures.

## Future Improvements
- A lint/CI check that no `<mj-image>`/`<mj-text>` is a direct child of `<mj-body>` across all templates would catch this class of bug generally.

## Discourse
- https://discourse.ilovefreegle.org/t/9925