### PR TITLE
fix(login): don't conflate a DB lookup error with unknown-email/wrong-password across the login dispatcher

### DIFF
--- a/iznik-server-go/auth/auth.go
+++ b/iznik-server-go/auth/auth.go
@@ -20,6 +20,7 @@ import (
 	"github.com/freegle/iznik-server-go/utils"
 	"github.com/gofiber/fiber/v2"
 	"github.com/golang-jwt/jwt/v4"
+	"gorm.io/gorm"
 )
 
 // PersistentToken represents the old-style session token from the Authorization2 header.
@@ -241,14 +242,24 @@ func GetPasswordSalt() string {
 
 // VerifyPassword checks a plaintext password against a user's stored Native login.
 // We filter by userid only (not uid) because some legacy Native logins have NULL uid.
-func VerifyPassword(userID uint64, password string) bool {
-	db := database.DBConn
-
+//
+// Returns a non-nil error when the credentials lookup itself failed (a backend
+// problem) - retried via database.RetryQuery for transient connection errors.
+// Callers must not treat that the same as "password did not match": a DB error
+// here is a different failure mode from a wrong password and must be reported
+// as a backend failure, not a false claim about the supplied credentials
+// (Discourse #9941 - the same swallowed-error pattern that misreported the
+// email lookup as "unknown email" existed here too, one call further into the
+// same login path).
+func VerifyPassword(db *gorm.DB, userID uint64, password string) (bool, error) {
 	var logins []struct {
 		Credentials string
 		Salt        string
 	}
-	db.Raw("SELECT credentials, salt FROM users_logins WHERE userid = ? AND type = ? ORDER BY lastaccess DESC", userID, utils.LOGIN_TYPE_NATIVE).Scan(&logins)
+	err := database.RetryQuery(db, &logins, "SELECT credentials, salt FROM users_logins WHERE userid = ? AND type = ? ORDER BY lastaccess DESC", userID, utils.LOGIN_TYPE_NATIVE)
+	if err != nil {
+		return false, err
+	}
 
 	for _, login := range logins {
 		if login.Credentials == "" {
@@ -260,10 +271,10 @@ func VerifyPassword(userID uint64, password string) bool {
 		}
 		hashed := HashPassword(password, salt)
 		if strings.EqualFold(hashed, login.Credentials) {
-			return true
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
 }
 
 // CreateSessionAndJWT creates a sessions row and returns the persistent token data and a JWT.

--- a/iznik-server-go/session/session.go
+++ b/iznik-server-go/session/session.go
@@ -357,6 +357,59 @@ func PostSession(c *fiber.Ctx) error {
 	}
 }
 
+// LookupUserIDByEmail resolves a login email to a user id, retrying transient
+// DB errors (see database.RetryQuery). A non-nil error means the lookup itself
+// failed - the backend couldn't be checked - and must never be treated the
+// same as "zero rows found" (a genuinely unknown email). Exported so it can be
+// unit tested in isolation, without exercising the whole HTTP request pipeline
+// (Discourse #9941: a swallowed lookup error was misreported as "we don't know
+// that email address").
+func LookupUserIDByEmail(db *gorm.DB, email string) (uint64, error) {
+	var userID uint64
+	err := database.RetryQuery(db, &userID, "SELECT u.id FROM users u "+
+		"JOIN users_emails ue ON ue.userid = u.id "+
+		"WHERE ue.email = ? "+
+		"LIMIT 1", email)
+	return userID, err
+}
+
+// LookupUserAndEmailByEmail is like LookupUserIDByEmail but also returns the
+// stored (canonical) form of the matched address, needed by LostPassword to
+// send the reset link to the exact address the user typed. Exported for the
+// same isolation-testing reason as LookupUserIDByEmail.
+func LookupUserAndEmailByEmail(db *gorm.DB, email string) (uint64, string, error) {
+	var match struct {
+		ID    uint64 `gorm:"column:id"`
+		Email string `gorm:"column:email"`
+	}
+	err := database.RetryQuery(db, &match, "SELECT users.id, users_emails.email FROM users "+
+		"INNER JOIN users_emails ON users_emails.userid = users.id "+
+		"WHERE users_emails.email = ? "+
+		"LIMIT 1", email)
+	return match.ID, match.Email, err
+}
+
+// LookupUserExists reports whether a user id exists, retrying transient DB
+// errors. A non-nil error means the check itself failed and must not be
+// reported as "unknown user". Exported for isolation testing.
+func LookupUserExists(db *gorm.DB, uid uint64) (bool, error) {
+	var exists uint64
+	err := database.RetryQuery(db, &exists, "SELECT id FROM users WHERE id = ? LIMIT 1", uid)
+	return exists != 0, err
+}
+
+// LookupLinkCredentials returns the stored auto-login key for a user (empty
+// string if none set), retrying transient DB errors. Shared by handleLinkLogin
+// (verifying a supplied key) and getOrCreateLoginKey (finding an existing key
+// before minting a new one) - a DB error here must not be treated as "no key
+// exists yet", which would mint a spurious duplicate credentials row. Exported
+// for isolation testing.
+func LookupLinkCredentials(db *gorm.DB, uid uint64) (string, error) {
+	var key string
+	err := database.RetryQuery(db, &key, "SELECT credentials FROM users_logins WHERE userid = ? AND type = ? LIMIT 1", uid, utils.LOGIN_TYPE_LINK)
+	return key, err
+}
+
 // handleLostPassword finds the user by email and queues a forgot-password email.
 func handleLostPassword(c *fiber.Ctx, email string) error {
 	if email == "" {
@@ -370,15 +423,10 @@ func handleLostPassword(c *fiber.Ctx, email string) error {
 	// (canonical) form of the matched address so we send the login link to the
 	// exact email the user used - not their preferred address, which may differ
 	// and may be the one that is bouncing.
-	var match struct {
-		ID    uint64 `gorm:"column:id"`
-		Email string `gorm:"column:email"`
+	userID, matchEmail, err := LookupUserAndEmailByEmail(db, email)
+	if err != nil {
+		return fiber.NewError(fiber.StatusInternalServerError, "Failed to look up email address")
 	}
-	db.Raw("SELECT users.id, users_emails.email FROM users "+
-		"INNER JOIN users_emails ON users_emails.userid = users.id "+
-		"WHERE users_emails.email = ? "+
-		"LIMIT 1", email).Scan(&match)
-	userID := match.ID
 
 	if userID == 0 {
 		// Return ret=2 for unknown email.
@@ -423,7 +471,7 @@ func handleLostPassword(c *fiber.Ctx, email string) error {
 
 	// Send the login link to the address the user actually used. Prefer the
 	// canonical stored form of the matched address; fall back to the typed value.
-	destEmail := match.Email
+	destEmail := matchEmail
 	if destEmail == "" {
 		destEmail = email
 	}
@@ -452,11 +500,10 @@ func handleUnsubscribe(c *fiber.Ctx, email string) error {
 	db := database.DBConn
 
 	// Find user by email. Deleted users can still unsubscribe.
-	var userID uint64
-	db.Raw("SELECT users.id FROM users "+
-		"INNER JOIN users_emails ON users_emails.userid = users.id "+
-		"WHERE users_emails.email = ? "+
-		"LIMIT 1", email).Scan(&userID)
+	userID, err := LookupUserIDByEmail(db, email)
+	if err != nil {
+		return fiber.NewError(fiber.StatusInternalServerError, "Failed to look up email address")
+	}
 
 	if userID == 0 {
 		// Return unknown:true so the frontend can branch to a "Contact support" fallback
@@ -511,8 +558,10 @@ func getOrCreateLoginKey(userID uint64) (string, error) {
 	db := database.DBConn
 
 	// Check for existing key.
-	var existingKey string
-	db.Raw("SELECT credentials FROM users_logins WHERE userid = ? AND type = ? LIMIT 1", userID, utils.LOGIN_TYPE_LINK).Scan(&existingKey)
+	existingKey, err := LookupLinkCredentials(db, userID)
+	if err != nil {
+		return "", err
+	}
 
 	if existingKey != "" {
 		return existingKey, nil
@@ -536,11 +585,10 @@ func handleEmailPasswordLogin(c *fiber.Ctx, email string, password string) error
 
 	// Find user by email. Deleted users can still log in so they see the
 	// "restore your account" banner.
-	var userID uint64
-	db.Raw("SELECT u.id FROM users u "+
-		"JOIN users_emails ue ON ue.userid = u.id "+
-		"WHERE ue.email = ? "+
-		"LIMIT 1", email).Scan(&userID)
+	userID, err := LookupUserIDByEmail(db, email)
+	if err != nil {
+		return fiber.NewError(fiber.StatusInternalServerError, "Failed to look up email address")
+	}
 
 	if userID == 0 {
 		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
@@ -549,7 +597,11 @@ func handleEmailPasswordLogin(c *fiber.Ctx, email string, password string) error
 		})
 	}
 
-	if !auth.VerifyPassword(userID, password) {
+	verified, err := auth.VerifyPassword(db, userID, password)
+	if err != nil {
+		return fiber.NewError(fiber.StatusInternalServerError, "Failed to verify credentials")
+	}
+	if !verified {
 		return c.Status(fiber.StatusForbidden).JSON(fiber.Map{
 			"ret":    3,
 			"status": "The password is wrong.",
@@ -575,10 +627,12 @@ func handleLinkLogin(c *fiber.Ctx, uid uint64, key string) error {
 
 	// Verify the user exists. Deleted users can still log in so they see the
 	// "restore your account" banner.
-	var exists uint64
-	db.Raw("SELECT id FROM users WHERE id = ? LIMIT 1", uid).Scan(&exists)
+	exists, err := LookupUserExists(db, uid)
+	if err != nil {
+		return fiber.NewError(fiber.StatusInternalServerError, "Failed to look up user")
+	}
 
-	if exists == 0 {
+	if !exists {
 		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
 			"ret":    2,
 			"status": "Unknown user.",
@@ -586,8 +640,10 @@ func handleLinkLogin(c *fiber.Ctx, uid uint64, key string) error {
 	}
 
 	// Verify the link key.
-	var storedKey string
-	db.Raw("SELECT credentials FROM users_logins WHERE userid = ? AND type = ? LIMIT 1", uid, utils.LOGIN_TYPE_LINK).Scan(&storedKey)
+	storedKey, err := LookupLinkCredentials(db, uid)
+	if err != nil {
+		return fiber.NewError(fiber.StatusInternalServerError, "Failed to look up login key")
+	}
 
 	if storedKey == "" || subtle.ConstantTimeCompare([]byte(storedKey), []byte(key)) != 1 {
 		return c.Status(fiber.StatusForbidden).JSON(fiber.Map{

--- a/iznik-server-go/test/login_dberror_test.go
+++ b/iznik-server-go/test/login_dberror_test.go
@@ -1,0 +1,70 @@
+package test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/freegle/iznik-server-go/auth"
+	"github.com/freegle/iznik-server-go/session"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/mysql"
+	"gorm.io/gorm"
+)
+
+// brokenLookupDB opens a *fresh, independent* connection pointed at the
+// (always-present) information_schema database, which has no `users` or
+// `users_logins` tables. The connection itself succeeds - only queries against
+// those tables fail - so this deterministically reproduces "lookup ERRORED",
+// as distinct from "lookup found no rows", without relying on flaky
+// network-level failures.
+//
+// Crucially this does NOT touch database.DBConn: it is a standalone *gorm.DB
+// passed directly into the function under test, so only that one call is
+// affected. Nothing else in the process - middleware, other queries, other
+// tests - is touched. This is a regression test for Discourse #9941 post 1,
+// where a previous attempt at this fix swapped the global database.DBConn for
+// the whole request, breaking every query in the pipeline rather than
+// isolating the one lookup being tested.
+func brokenLookupDB(t *testing.T) *gorm.DB {
+	dsn := fmt.Sprintf(
+		"%s:%s@%s(%s:%s)/information_schema?charset=utf8mb4&parseTime=True&loc=Local&interpolateParams=true",
+		os.Getenv("MYSQL_USER"), os.Getenv("MYSQL_PASSWORD"), os.Getenv("MYSQL_PROTOCOL"),
+		os.Getenv("MYSQL_HOST"), os.Getenv("MYSQL_PORT"),
+	)
+	badDB, err := gorm.Open(mysql.Open(dsn), &gorm.Config{})
+	require.NoError(t, err, "connecting to information_schema should succeed - only queries against users/users_logins should fail")
+	return badDB
+}
+
+func TestLookupUserIDByEmail_DBErrorNotConfusedWithUnknownEmail(t *testing.T) {
+	userID, err := session.LookupUserIDByEmail(brokenLookupDB(t), "doesnt-matter-9941@example.com")
+	assert.Error(t, err, "a DB error must be surfaced, not silently treated as zero rows found")
+	assert.Equal(t, uint64(0), userID)
+}
+
+func TestLookupUserAndEmailByEmail_DBErrorNotConfusedWithUnknownEmail(t *testing.T) {
+	userID, email, err := session.LookupUserAndEmailByEmail(brokenLookupDB(t), "doesnt-matter-9941@example.com")
+	assert.Error(t, err, "a DB error must be surfaced, not silently treated as zero rows found")
+	assert.Equal(t, uint64(0), userID)
+	assert.Equal(t, "", email)
+}
+
+func TestLookupUserExists_DBErrorNotConfusedWithUnknownUser(t *testing.T) {
+	exists, err := session.LookupUserExists(brokenLookupDB(t), 123456789)
+	assert.Error(t, err, "a DB error must be surfaced, not silently treated as the user not existing")
+	assert.False(t, exists)
+}
+
+func TestLookupLinkCredentials_DBErrorNotConfusedWithNoKey(t *testing.T) {
+	key, err := session.LookupLinkCredentials(brokenLookupDB(t), 123456789)
+	assert.Error(t, err, "a DB error must be surfaced, not silently treated as no key set")
+	assert.Equal(t, "", key)
+}
+
+func TestVerifyPassword_DBErrorNotConfusedWithWrongPassword(t *testing.T) {
+	verified, err := auth.VerifyPassword(brokenLookupDB(t), 123456789, "whatever")
+	assert.Error(t, err, "a DB error must be surfaced, not silently treated as a wrong password")
+	assert.False(t, verified)
+}

--- a/iznik-server-go/user/user.go
+++ b/iznik-server-go/user/user.go
@@ -1868,18 +1868,24 @@ func PutUser(c *fiber.Ctx) error {
 
 		// If they provided a correct password, treat signup as login — avoids
 		// forcing users to switch to the login screen and re-enter credentials.
-		if req.Password != "" && auth.VerifyPassword(existingUID, req.Password) {
-			persistent, jwtString, err := auth.CreateSessionAndJWT(existingUID)
+		if req.Password != "" {
+			verified, err := auth.VerifyPassword(db, existingUID, req.Password)
 			if err != nil {
-				return fiber.NewError(fiber.StatusInternalServerError, "Failed to create session")
+				return fiber.NewError(fiber.StatusInternalServerError, "Failed to verify credentials")
 			}
-			return c.JSON(fiber.Map{
-				"ret":        0,
-				"status":     "Success",
-				"id":         existingUID,
-				"persistent": persistent,
-				"jwt":        jwtString,
-			})
+			if verified {
+				persistent, jwtString, err := auth.CreateSessionAndJWT(existingUID)
+				if err != nil {
+					return fiber.NewError(fiber.StatusInternalServerError, "Failed to create session")
+				}
+				return c.JSON(fiber.Map{
+					"ret":        0,
+					"status":     "Success",
+					"id":         existingUID,
+					"persistent": persistent,
+					"jwt":        jwtString,
+				})
+			}
 		}
 
 		return c.Status(fiber.StatusConflict).JSON(fiber.Map{


### PR DESCRIPTION
## Root Cause
`PostSession`'s login-related handlers (`handleEmailPasswordLogin`, `handleLostPassword`, `handleUnsubscribe`, `handleLinkLogin`) each looked up a user with a bare `db.Raw(...).Scan(&x)`, discarding the query's error. When a lookup query itself errored (e.g. a replica connection dropped mid-query), the destination variable stayed at its Go zero value and was reported identically to "genuinely not found" — e.g. `ret:2 "We don't know that email address."` for `handleEmailPasswordLogin`. A backend failure was indistinguishable from "this account doesn't exist."

This matches the report exactly: a moderator's ModTools session crashed mid-navigation; on reopening they were shown the login page, entered their correct credentials, got "We don't know that email address.", then the same credentials worked moments later with no other change (Discourse #9941 post 1).

## Previous attempt and why it was rejected
PR #1119 fixed only `handleEmailPasswordLogin`'s own lookup and was auto-closed on review for two reasons, both addressed here:
1. **partial-implementation** — the identical swallowed-error pattern existed elsewhere in the *same* login dispatcher: `handleLostPassword` (literally the same message string), `handleUnsubscribe`, and `handleLinkLogin` (which has *two* such lookups — the user-exists check and the stored-key check), plus one call further into the chain in `auth.VerifyPassword`.
2. **test-does-not-isolate-the-fix** — the regression test swapped the process-global `database.DBConn` to a bad connection for the whole HTTP request, breaking every query in the pipeline rather than isolating the one lookup under test.

## Fix
Extracted each lookup into a small, exported, dependency-injected function that takes `db *gorm.DB` explicitly and uses `database.RetryQuery` (which already existed for exactly this purpose but had no callers) instead of a bare `db.Raw().Scan()`:
- `LookupUserIDByEmail`, `LookupUserAndEmailByEmail`, `LookupUserExists`, `LookupLinkCredentials` (session/session.go)
- `auth.VerifyPassword` now takes `db` explicitly and returns `(bool, error)`

Every one of `handleEmailPasswordLogin`, `handleLostPassword`, `handleUnsubscribe`, `handleLinkLogin`, the shared `getOrCreateLoginKey` helper, and `auth.VerifyPassword` now propagates a lookup error as a `500` backend failure instead of misreporting it as "unknown email" / "unknown user" / "wrong password". Recoverable connection errors are retried by `RetryQuery`; anything left after that is a real backend failure.

Taking `db` as an explicit parameter (rather than reading the `database.DBConn` global) means each function can be called directly in a test with a real-but-broken `*gorm.DB`, without touching global state or exercising the rest of the HTTP pipeline.

No new account-existence disclosure: the change strictly *removes* a case where a backend failure leaked as "unknown"/"wrong password" — it does not add any new distinguishing signal for real not-found vs. found.

## Evidence
AssertFlip: with the bug pattern temporarily reintroduced (each helper swallowing its query error again, matching the pre-fix code), all 5 new isolation tests fail:
```
--- FAIL: TestLookupUserIDByEmail_DBErrorNotConfusedWithUnknownEmail
    Error: An error is expected but got nil.
--- FAIL: TestLookupUserAndEmailByEmail_DBErrorNotConfusedWithUnknownEmail
    Error: An error is expected but got nil.
--- FAIL: TestLookupUserExists_DBErrorNotConfusedWithUnknownUser
    Error: An error is expected but got nil.
--- FAIL: TestLookupLinkCredentials_DBErrorNotConfusedWithNoKey
    Error: An error is expected but got nil.
--- FAIL: TestVerifyPassword_DBErrorNotConfusedWithWrongPassword
    Error: An error is expected but got nil.
```
With the fix restored, all 5 pass, and the full `go test ./...` suite (all packages) and the full `iznik-server-go/test` package (3500+ tests) pass clean.

## Other Call Sites
Same "bare `db.Raw(...).Scan()`, error discarded, zero value treated as not-found" pattern exists broadly elsewhere in the codebase (profile-display queries, membership/role checks, signup's own duplicate-email check in `user.PutUser`, `session/social_auth.go`, etc.) but is out of scope here — a repo-wide sweep is a separate, much larger change. This PR fixes every instance specifically in the credential/account lookup chain reachable from `PostSession`'s login/lost-password/unsubscribe/link-login dispatch (the exact scope the previous review flagged as incomplete), plus `auth.VerifyPassword` one call further into that same chain. `user.PutUser`'s call site of `VerifyPassword` was updated only for the new signature (its own separate `existingUID` lookup is unchanged and untouched).

## Test
- File: `iznik-server-go/test/login_dberror_test.go` (new)
- Tests: `TestLookupUserIDByEmail_DBErrorNotConfusedWithUnknownEmail`, `TestLookupUserAndEmailByEmail_DBErrorNotConfusedWithUnknownEmail`, `TestLookupUserExists_DBErrorNotConfusedWithUnknownUser`, `TestLookupLinkCredentials_DBErrorNotConfusedWithNoKey`, `TestVerifyPassword_DBErrorNotConfusedWithWrongPassword`
- Command: `go test ./test/... -run TestLookup\|TestVerifyPassword_DBError -v`
- Each opens an independent `*gorm.DB` connection pointed at `information_schema` (which has no `users`/`users_logins` tables — the connection succeeds, only the query errors) and passes it directly to the function under test. This does not touch `database.DBConn` or exercise any other part of the request pipeline — addressing the previous review's isolation complaint directly.
- Proves fail-before/pass-after: see Evidence above.
- Full regression: `go test ./...` (all packages) and `go test ./test/...` (3500+ tests) both pass clean against a freshly-migrated test database.

## Discourse
https://discourse.ilovefreegle.org/t/9941/1