### PR TITLE
feat: matched-posts notifications + email (vector resurrection of "Any of these take your fancy?")

### DIFF
--- a/docs/developers/reference/matched-posts-email.md
+++ b/docs/developers/reference/matched-posts-email.md
@@ -47,10 +47,19 @@ This is a **separate** mail from the daily digest's relevance ranking
    free (the reason post is a fresh post already searched); direction (ii) costs
    one extra apiv2 call per surviving recipient post, so a match that hasn't
    rippled out to the recipient is dropped rather than mailed on bbox proximity.
-6. **`NotifyMatchedPostsCommand`** renders `App\Mail\Matched\MatchedPosts` (layout
-   adapts to the match count — hero card for one, compact list for several),
-   spools it, records each matched post in `messages_matched_notified`, and bumps
-   `lastrelevantcheck`.
+7. **`NotifyMatchedPostsCommand`** delivers to each eligible recipient:
+   - an **in-app (bell) notification** — a `users_notifications` row of the new
+     `type='MatchedPost'` (migration `2026_07_19_000002_...`; rendered by
+     `iznik-nuxt3/components/NotificationMatchedPost.vue`), plus a **device push**
+     via `PushNotificationService::notifyUser` (no-op when the user has no
+     registered app device). This is the primary channel — delivered regardless
+     of email;
+   - an **email** (`App\Mail\Matched\MatchedPosts`, adaptive hero/list layout)
+     when the member has an address.
+   Then it records each matched post in `messages_matched_notified` (dedup across
+   both channels) and bumps `lastrelevantcheck`. The subject/notification title
+   mirror each other: "Someone is offering: <item>" for one match, "Freegle
+   matches for you" for several.
 
 ## Dedup ledger
 

--- a/docs/developers/reference/matched-posts-email.md
+++ b/docs/developers/reference/matched-posts-email.md
@@ -3,7 +3,9 @@ last_reviewed: 2026-07-19
 owner: Freegle dev team
 covers:
   - iznik-server-go/message/postmatches.go
+  - iznik-server-go/user/relevantoff.go
   - iznik-batch/app/Services/MatchedPostsService.php
+  - iznik-batch/app/Services/LoginLinkService.php
   - iznik-batch/app/Console/Commands/Message/NotifyMatchedPostsCommand.php
   - iznik-batch/app/Mail/Matched/MatchedPosts.php
 ---
@@ -39,6 +41,12 @@ This is a **separate** mail from the daily digest's relevance ranking
    doesn't count); never a post already in the `messages_matched_notified` ledger;
    only opted-in (`users.relevantallowed=1`), recently-active recipients outside
    the `cooldown_hours` (default 4) window, tracked via `users.lastrelevantcheck`.
+6. **Reach-exact** (`MatchedPostsService::verifyReach`): every shown match `M` is
+   confirmed to be in apiv2's `matchesForPost` for the recipient's OWN post that
+   it matched — which reach-filters against that post's owner. Direction (i) is
+   free (the reason post is a fresh post already searched); direction (ii) costs
+   one extra apiv2 call per surviving recipient post, so a match that hasn't
+   rippled out to the recipient is dropped rather than mailed on bbox proximity.
 6. **`NotifyMatchedPostsCommand`** renders `App\Mail\Matched\MatchedPosts` (layout
    adapts to the match count — hero card for one, compact list for several),
    spools it, records each matched post in `messages_matched_notified`, and bumps
@@ -54,9 +62,12 @@ This is a **separate** mail from the daily digest's relevance ranking
 
 - apiv2 vector endpoint: `FEATURE_MATCHED_POSTS=off` (returns empty, no deploy).
 - Laravel send: `FREEGLE_MATCHED_ENABLED=false` (config `freegle.matched.enabled`).
-- Per-member opt-out: the existing `users.relevantallowed` toggle (surfaced in
-  settings / ModTools) — honoured in eligibility. A dedicated one-click
-  List-Unsubscribe that flips `relevantallowed` is a follow-up.
+- Per-member opt-out: apiv2 `GET|POST /user/relevantoff?u=&k=` sets
+  `relevantallowed=0`, key-authenticated by the user's `users_logins` Link key
+  (minted by `LoginLinkService`). The matched email points both its
+  RFC 8058 `List-Unsubscribe` header (one-click) and a visible footer link at it,
+  so a member can stop just these emails without unsubscribing the whole account.
+  The existing `users.relevantallowed` settings/ModTools toggle still works too.
 
 ## Preview
 

--- a/docs/developers/reference/matched-posts-email.md
+++ b/docs/developers/reference/matched-posts-email.md
@@ -1,0 +1,69 @@
+---
+last_reviewed: 2026-07-19
+owner: Freegle dev team
+covers:
+  - iznik-server-go/message/postmatches.go
+  - iznik-batch/app/Services/MatchedPostsService.php
+  - iznik-batch/app/Console/Commands/Message/NotifyMatchedPostsCommand.php
+  - iznik-batch/app/Mail/Matched/MatchedPosts.php
+---
+
+# Matched-posts email
+
+Emails a member the opposite-type posts near them that match their own open
+Offer/Wanted — "you posted a WANTED, here are matching OFFERs nearby" and the
+reverse. Resurrects the V1 `cron/relevant.php` ("Any of these take your fancy?")
+mail, rebuilt on the vector embeddings rather than keyword search.
+
+This is a **separate** mail from the daily digest's relevance ranking
+(`FEATURE_DIGEST_RELEVANCE`, PR #956), which is left untouched.
+
+## How it flows
+
+1. **Schedule** (`iznik-batch/routes/console.php`) runs `matches:notify` every 10
+   minutes.
+2. **Driver query** (`MatchedPostsService::freshPosts`) selects Offer/Wanted posts
+   that arrived in the last `fresh_window_minutes` (default 20), are still open,
+   and already have an embedding — a small set (~100/run on prod) bounded by the
+   `messages_groups.arrival` index.
+3. For each fresh post, the service calls apiv2 **`GET /message/{id}/matches`**
+   (`iznik-server-go/message/postmatches.go`), which returns the opposite-type
+   open posts near it from the in-memory vector store — bbox-scoped, reach-filtered
+   against the *post owner* (the caller is unauthenticated batch), above
+   `MinSimilarScore`. The vector maths lives only in Go; there is no SQL KNN.
+4. **Both directions** fall out of that one search: the fresh post's owner is shown
+   the matches, and each matched post's owner is shown the fresh post.
+5. **Guards** (`MatchedPostsService::applyEligibility`): never the recipient's own
+   post; only still-open matches; never a post they clicked to view
+   (`messages_likes` `type='View'` **and** `pageview=1` — a feed scroll-past
+   doesn't count); never a post already in the `messages_matched_notified` ledger;
+   only opted-in (`users.relevantallowed=1`), recently-active recipients outside
+   the `cooldown_hours` (default 4) window, tracked via `users.lastrelevantcheck`.
+6. **`NotifyMatchedPostsCommand`** renders `App\Mail\Matched\MatchedPosts` (layout
+   adapts to the match count — hero card for one, compact list for several),
+   spools it, records each matched post in `messages_matched_notified`, and bumps
+   `lastrelevantcheck`.
+
+## Dedup ledger
+
+`messages_matched_notified` (migration `2026_07_19_000001_...`) has composite PK
+`(msgid, userid)` where `msgid` is the *matched* post shown to the user — the same
+"impossible to re-notify by construction" pattern as `rippling_reach_notified`.
+
+## Killswitches
+
+- apiv2 vector endpoint: `FEATURE_MATCHED_POSTS=off` (returns empty, no deploy).
+- Laravel send: `FREEGLE_MATCHED_ENABLED=false` (config `freegle.matched.enabled`).
+- Per-member opt-out: the existing `users.relevantallowed` toggle (surfaced in
+  settings / ModTools) — honoured in eligibility. A dedicated one-click
+  List-Unsubscribe that flips `relevantallowed` is a follow-up.
+
+## Preview
+
+`docker exec freegle-batch php artisan mail:test matched --user=<id> --send-to=you@example.com [--matched-count=1]`
+renders it into Mailpit with real recent posts as stand-in matches.
+
+## Tuning (config `freegle.matched`)
+
+`fresh_window_minutes`, `match_limit_per_post`, `max_items_per_email`,
+`cooldown_hours`, `min_lastaccess_days` — all env-overridable.

--- a/iznik-batch/app/Console/Commands/Mail/TestMailCommand.php
+++ b/iznik-batch/app/Console/Commands/Mail/TestMailCommand.php
@@ -42,6 +42,7 @@ class TestMailCommand extends Command
                             {--amp= : Override AMP email setting (on/off, default uses config)}
                             {--as= : For User2Mod chats: "member" or "mod" perspective (default: member)}
                             {--dry-run : Preview email content without sending}
+                            {--matched-count= : For "matched": number of matched posts to preview (1 = hero layout, default 4)}
                             {--list : List available email types}';
 
     /**
@@ -66,6 +67,7 @@ class TestMailCommand extends Command
         'deadline-reached' => 'Deadline reached notification',
         'stories-newsletter' => 'Monthly stories newsletter (real stories from DB, or sample data if none found)',
         'ripple-intro' => 'Rippling Out intro email (one-off "your post is reaching more people" notice)',
+        'matched' => 'Matched-posts email (opposite-type posts near you that match your open offers/wanteds)',
     ];
 
     /**
@@ -355,8 +357,61 @@ class TestMailCommand extends Command
             'deadline-reached' => $this->buildDeadlineReached(),
             'stories-newsletter' => $this->buildStoriesNewsletter(),
             'ripple-intro' => $this->buildRippleIntro(),
+            'matched' => $this->buildMatched(),
             default => null,
         };
+    }
+
+    /**
+     * Build the matched-posts email for preview. Uses real recent Offer/Wanted
+     * posts as stand-in "matches" (each with a synthetic reason post of the
+     * opposite type) so the layout can be reviewed in Mailpit without depending on
+     * live apiv2 vector matches. --matched-count controls how many (1 = hero).
+     * mail:test matched --user=ID --send-to=you@... [--matched-count=1]
+     */
+    protected function buildMatched(): ?\App\Mail\Matched\MatchedPosts
+    {
+        $user = $this->findUserWithEmail($this->option('user'));
+        if (! $user) {
+            $this->error('User not found');
+
+            return null;
+        }
+
+        $count = max(1, (int) ($this->option('matched-count') ?: 4));
+
+        $posts = Message::query()
+            ->approved()
+            ->notDeleted()
+            ->whereIn('type', [Message::TYPE_OFFER, Message::TYPE_WANTED])
+            ->where('fromuser', '!=', $user->id)
+            ->orderByDesc('arrival')
+            ->limit($count)
+            ->with(['attachments', 'fromUser', 'groups'])
+            ->get();
+
+        if ($posts->isEmpty()) {
+            $this->error('No recent Offer/Wanted posts found to preview as matches');
+
+            return null;
+        }
+
+        $this->info("Previewing matched-posts email for {$user->displayname} (ID: {$user->id}) with {$posts->count()} match(es)");
+
+        $items = $posts->map(function (Message $m) {
+            // Synthetic "your own post" of the opposite type so the reason line
+            // reads e.g. "Matches your wanted: <item>".
+            $reason = new Message([
+                'type' => $m->type === 'Offer' ? 'Wanted' : 'Offer',
+                'subject' => ($m->type === 'Offer' ? 'WANTED' : 'OFFER') . ': ' . \App\Services\MatchedPostsService::itemName($m),
+            ]);
+
+            return ['message' => $m, 'reason' => $reason, 'score' => 0.82];
+        })->all();
+
+        $email = $user->email_preferred ?? $user->email;
+
+        return new \App\Mail\Matched\MatchedPosts($user, $email, $items);
     }
 
     /**

--- a/iznik-batch/app/Console/Commands/Message/NotifyMatchedPostsCommand.php
+++ b/iznik-batch/app/Console/Commands/Message/NotifyMatchedPostsCommand.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace App\Console\Commands\Message;
+
+use App\Mail\Matched\MatchedPosts;
+use App\Services\EmailSpoolerService;
+use App\Services\MatchedPostsService;
+use App\Traits\GracefulShutdown;
+use App\Traits\LogsBatchJob;
+use Carbon\Carbon;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Emails members the opposite-type posts near them that match their own open
+ * Offer/Wanted — the resurrected "Any of these take your fancy?" mail, rebuilt on
+ * vector matching (V1: cron/relevant.php). Runs every 10 minutes; the service
+ * already applies every dedup/eligibility guard, so this command just renders,
+ * spools, and records what was sent so nothing is mailed twice.
+ */
+class NotifyMatchedPostsCommand extends Command
+{
+    use GracefulShutdown, LogsBatchJob;
+
+    protected $signature = 'matches:notify
+                            {--dry-run : Build and report notifications without sending or recording anything}';
+
+    protected $description = 'Email members opposite-type posts that match their open offers/wanteds (vector matched-posts mail)';
+
+    public function handle(MatchedPostsService $service, EmailSpoolerService $spooler): int
+    {
+        $this->registerShutdownHandlers();
+
+        $dryRun = (bool) $this->option('dry-run');
+        if ($dryRun) {
+            $this->warn('DRY RUN MODE — no mail sent, no ledger written.');
+        }
+
+        return $this->runWithLogging(function () use ($service, $spooler, $dryRun) {
+            $now = Carbon::now();
+            $notifications = $service->buildNotifications($now);
+
+            $emails = 0;
+            $matches = 0;
+
+            foreach ($notifications as $n) {
+                if ($this->shouldStop()) {
+                    break;
+                }
+
+                $user = $n['user'];
+                $items = $n['items'];
+                $email = $user->email_preferred ?? $user->email ?? null;
+                if (! $email) {
+                    continue;
+                }
+
+                if ($dryRun) {
+                    $emails++;
+                    $matches += count($items);
+
+                    continue;
+                }
+
+                $mail = new MatchedPosts($user, $email, $items);
+                $spooler->spool($mail);
+
+                // Record every matched post as mailed to this user (never re-send),
+                // and bump the per-user cooldown watermark.
+                $rows = array_map(fn ($i) => [
+                    'msgid' => (int) $i['message']->id,
+                    'userid' => (int) $user->id,
+                    'mailed_at' => $now->toDateTimeString(),
+                ], $items);
+                DB::table('messages_matched_notified')->insertOrIgnore($rows);
+                DB::table('users')->where('id', $user->id)->update(['lastrelevantcheck' => $now->toDateTimeString()]);
+
+                $emails++;
+                $matches += count($items);
+            }
+
+            $prefix = $dryRun ? 'Would ' : '';
+            $this->newLine();
+            $this->table(
+                ['Operation', 'Count'],
+                [
+                    [$prefix . 'Members emailed', number_format($emails)],
+                    [$prefix . 'Matched posts included', number_format($matches)],
+                ]
+            );
+
+            Log::info('Matched-posts notify completed', [
+                'emails' => $emails,
+                'matches' => $matches,
+                'dry_run' => $dryRun,
+            ]);
+
+            return Command::SUCCESS;
+        });
+    }
+}

--- a/iznik-batch/app/Console/Commands/Message/NotifyMatchedPostsCommand.php
+++ b/iznik-batch/app/Console/Commands/Message/NotifyMatchedPostsCommand.php
@@ -3,14 +3,17 @@
 namespace App\Console\Commands\Message;
 
 use App\Mail\Matched\MatchedPosts;
+use App\Models\User;
 use App\Services\EmailSpoolerService;
 use App\Services\MatchedPostsService;
+use App\Services\PushNotificationService;
 use App\Traits\GracefulShutdown;
 use App\Traits\LogsBatchJob;
 use Carbon\Carbon;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
 
 /**
  * Emails members the opposite-type posts near them that match their own open
@@ -26,21 +29,22 @@ class NotifyMatchedPostsCommand extends Command
     protected $signature = 'matches:notify
                             {--dry-run : Build and report notifications without sending or recording anything}';
 
-    protected $description = 'Email members opposite-type posts that match their open offers/wanteds (vector matched-posts mail)';
+    protected $description = 'Notify members (in-app + push, and email) of opposite-type posts that match their open offers/wanteds (vector matched-posts)';
 
-    public function handle(MatchedPostsService $service, EmailSpoolerService $spooler): int
+    public function handle(MatchedPostsService $service, EmailSpoolerService $spooler, PushNotificationService $push): int
     {
         $this->registerShutdownHandlers();
 
         $dryRun = (bool) $this->option('dry-run');
         if ($dryRun) {
-            $this->warn('DRY RUN MODE — no mail sent, no ledger written.');
+            $this->warn('DRY RUN MODE — nothing sent, no ledger written.');
         }
 
-        return $this->runWithLogging(function () use ($service, $spooler, $dryRun) {
+        return $this->runWithLogging(function () use ($service, $spooler, $push, $dryRun) {
             $now = Carbon::now();
             $notifications = $service->buildNotifications($now);
 
+            $notified = 0;
             $emails = 0;
             $matches = 0;
 
@@ -52,22 +56,28 @@ class NotifyMatchedPostsCommand extends Command
                 $user = $n['user'];
                 $items = $n['items'];
                 $email = $user->email_preferred ?? $user->email ?? null;
-                if (! $email) {
-                    continue;
-                }
 
                 if ($dryRun) {
-                    $emails++;
+                    $notified++;
+                    $emails += $email ? 1 : 0;
                     $matches += count($items);
 
                     continue;
                 }
 
-                $mail = new MatchedPosts($user, $email, $items);
-                $spooler->spool($mail);
+                // In-app (bell) notification + device push — the primary channel,
+                // delivered to every eligible recipient regardless of email.
+                $this->notifyUserOfMatches($user, $items, $now, $push);
+                $notified++;
 
-                // Record every matched post as mailed to this user (never re-send),
-                // and bump the per-user cooldown watermark.
+                // Email too, when we have an address.
+                if ($email) {
+                    $spooler->spool(new MatchedPosts($user, $email, $items));
+                    $emails++;
+                }
+
+                // Record every matched post as notified to this user (never
+                // re-send, across both channels) and bump the per-user cooldown.
                 $rows = array_map(fn ($i) => [
                     'msgid' => (int) $i['message']->id,
                     'userid' => (int) $user->id,
@@ -76,7 +86,6 @@ class NotifyMatchedPostsCommand extends Command
                 DB::table('messages_matched_notified')->insertOrIgnore($rows);
                 DB::table('users')->where('id', $user->id)->update(['lastrelevantcheck' => $now->toDateTimeString()]);
 
-                $emails++;
                 $matches += count($items);
             }
 
@@ -85,12 +94,14 @@ class NotifyMatchedPostsCommand extends Command
             $this->table(
                 ['Operation', 'Count'],
                 [
-                    [$prefix . 'Members emailed', number_format($emails)],
+                    [$prefix . 'Members notified (in-app + push)', number_format($notified)],
+                    [$prefix . 'Members also emailed', number_format($emails)],
                     [$prefix . 'Matched posts included', number_format($matches)],
                 ]
             );
 
             Log::info('Matched-posts notify completed', [
+                'notified' => $notified,
                 'emails' => $emails,
                 'matches' => $matches,
                 'dry_run' => $dryRun,
@@ -98,5 +109,42 @@ class NotifyMatchedPostsCommand extends Command
 
             return Command::SUCCESS;
         });
+    }
+
+    /**
+     * Create the in-app (bell) notification row and fire a device push. The push
+     * is a no-op when the user has no registered Freegle-app device. One row per
+     * run (the per-user cooldown already bounds frequency), pointing at the top
+     * match; the subject mirrors the email.
+     *
+     * @param  array<int, array{message: \App\Models\Message, reason: \App\Models\Message, score: float}>  $items
+     */
+    private function notifyUserOfMatches(User $user, array $items, Carbon $now, PushNotificationService $push): void
+    {
+        $top = $items[0]['message'];
+        $count = count($items);
+
+        if ($count === 1) {
+            $verb = $top->type === 'Offer' ? 'Someone is offering' : 'Someone wants';
+            $title = $verb . ': ' . MatchedPostsService::itemName($top);
+            $text = null;
+        } else {
+            $title = 'Freegle matches for you';
+            $text = $count . " posts near you match what you've offered or asked for";
+        }
+
+        DB::table('users_notifications')->insert([
+            'touser' => (int) $user->id,
+            'fromuser' => null,
+            'type' => 'MatchedPost',
+            'url' => '/message/' . $top->id,
+            'title' => Str::limit($title, 79, ''),
+            'text' => $text,
+            'timestamp' => $now->toDateTimeString(),
+            'seen' => 0,
+            'mailed' => 0,
+        ]);
+
+        $push->notifyUser((int) $user->id);
     }
 }

--- a/iznik-batch/app/Mail/Matched/MatchedPosts.php
+++ b/iznik-batch/app/Mail/Matched/MatchedPosts.php
@@ -70,25 +70,14 @@ class MatchedPosts extends MjmlMailable
 
     protected function getSubject(): string
     {
-        $count = count($this->items);
-        $names = array_values(array_unique(array_map(
-            fn ($i) => MatchedPostsService::itemName($i['message']),
-            $this->items
-        )));
-
-        if ($count === 1) {
+        if (count($this->items) === 1) {
             $m = $this->items[0]['message'];
             $verb = $m->type === 'Offer' ? 'Someone is offering' : 'Someone wants';
 
-            return $verb . ': ' . $names[0];
+            return $verb . ': ' . MatchedPostsService::itemName($m);
         }
 
-        // Nod to the V1 "Any of these take your fancy?" subject, with a count and
-        // a couple of item names so it isn't generic.
-        $lead = implode(', ', array_slice($names, 0, 2));
-        $more = count($names) > 2 ? ', and more' : '';
-
-        return $count . ' posts you might fancy: ' . $lead . $more;
+        return 'Freegle matches for you';
     }
 
     public function envelope(): Envelope

--- a/iznik-batch/app/Mail/Matched/MatchedPosts.php
+++ b/iznik-batch/app/Mail/Matched/MatchedPosts.php
@@ -1,0 +1,200 @@
+<?php
+
+namespace App\Mail\Matched;
+
+use App\Mail\Digest\DigestStyle;
+use App\Mail\MjmlMailable;
+use App\Mail\Traits\AvatarResolver;
+use App\Mail\Traits\TrackableEmail;
+use App\Models\Message;
+use App\Models\User;
+use App\Services\MatchedPostsService;
+use App\Support\SubjectParser;
+use Illuminate\Mail\Mailables\Address;
+use Illuminate\Mail\Mailables\Envelope;
+
+/**
+ * The matched-posts email: the opposite-type posts near a member that match
+ * their own open Offer/Wanted. Resurrects the V1 "Any of these take your fancy?"
+ * mail, rebuilt on vector matching. The layout adapts to how many we matched —
+ * a single hero card for one match, a compact list for several.
+ *
+ * Each item is ['message' => Message (the matched post to show), 'reason' =>
+ * Message (the recipient's own post it matched), 'score' => float].
+ */
+class MatchedPosts extends MjmlMailable
+{
+    use AvatarResolver, TrackableEmail;
+
+    /**
+     * @param  array<int, array{message: Message, reason: Message, score: float}>  $items
+     */
+    public function __construct(
+        public readonly User $user,
+        public readonly string $recipientEmail,
+        public readonly array $items,
+        public readonly ?string $settingsUrl = null,
+    ) {
+        parent::__construct();
+    }
+
+    protected function getRecipientUserId(): ?int
+    {
+        return $this->user->id;
+    }
+
+    protected function getSubject(): string
+    {
+        $count = count($this->items);
+        $names = array_values(array_unique(array_map(
+            fn ($i) => MatchedPostsService::itemName($i['message']),
+            $this->items
+        )));
+
+        if ($count === 1) {
+            $m = $this->items[0]['message'];
+            $verb = $m->type === 'Offer' ? 'Someone is offering' : 'Someone wants';
+
+            return $verb . ': ' . $names[0];
+        }
+
+        // Nod to the V1 "Any of these take your fancy?" subject, with a count and
+        // a couple of item names so it isn't generic.
+        $lead = implode(', ', array_slice($names, 0, 2));
+        $more = count($names) > 2 ? ', and more' : '';
+
+        return $count . ' posts you might fancy: ' . $lead . $more;
+    }
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            from: new Address(
+                config('freegle.mail.noreply_addr', 'noreply@ilovefreegle.org'),
+                config('freegle.branding.name', 'Freegle')
+            ),
+            to: [new Address($this->recipientEmail)],
+            subject: $this->getSubject(),
+        );
+    }
+
+    public function build(): static
+    {
+        $userSite = config('freegle.sites.user', 'https://www.ilovefreegle.org');
+
+        [$userLat, $userLng] = $this->recipientLatLng();
+
+        $posts = [];
+        foreach (array_values($this->items) as $i => $item) {
+            $posts[] = $this->prepareCard($item['message'], $item['reason'], $i, $userLat, $userLng, $userSite);
+        }
+
+        return $this->mjmlView('emails.mjml.matched.digest', [
+            'posts' => $posts,
+            'count' => count($posts),
+            'offerColor' => DigestStyle::OFFER_GREEN,
+            'wantedColor' => DigestStyle::WANTED_BLUE,
+            'browseUrl' => $userSite . '/browse?src=matched',
+            'settingsUrl' => $this->settingsUrl ?: $userSite . '/settings?src=matched',
+            'userSite' => $userSite,
+            'email' => $this->recipientEmail,
+        ]);
+    }
+
+    /**
+     * @return array{0: ?float, 1: ?float}
+     */
+    private function recipientLatLng(): array
+    {
+        $loc = $this->user->lastLocation ?? null;
+        if ($loc && $loc->lat !== null && $loc->lng !== null) {
+            return [(float) $loc->lat, (float) $loc->lng];
+        }
+
+        return [null, null];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function prepareCard(Message $message, Message $reason, int $index, ?float $userLat, ?float $userLng, string $userSite): array
+    {
+        $isOffer = $message->type === 'Offer';
+
+        $imageUrl = $this->messageImageUrl($message, 240, 240);
+        $heroUrl = $this->messageImageUrl($message, 600, 400);
+        $placeholder = $isOffer
+            ? config('freegle.images.offer_placeholder')
+            : config('freegle.images.wanted_placeholder');
+
+        $subject = html_entity_decode($message->subject ?? '', ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        [, , $locationName] = SubjectParser::parse($subject);
+
+        $distanceText = null;
+        if ($userLat !== null && $userLng !== null && $message->lat && $message->lng) {
+            $miles = $this->haversineMiles($userLat, $userLng, (float) $message->lat, (float) $message->lng);
+            $distanceText = $miles < 1 ? '< 1 mile' : round($miles) . ' miles';
+        }
+
+        $posterUser = $message->relationLoaded('fromUser') ? $message->fromUser : null;
+        $groupName = null;
+        $groupUrl = null;
+        if ($message->relationLoaded('groups') && $message->groups->isNotEmpty()) {
+            $g = $message->groups->first();
+            $groupName = $g->namefull ?: $g->nameshort;
+            $groupUrl = $this->trackedResourceUrl('g', (int) $g->id, "g{$index}", $userSite . '/explore/' . $g->id);
+        }
+
+        return [
+            'message' => $message,
+            'type' => $message->type,
+            'itemName' => MatchedPostsService::itemName($message),
+            'locationName' => $locationName,
+            'thumbImageUrl' => $imageUrl ?? $placeholder,
+            'heroImageUrl' => $heroUrl ?? $placeholder,
+            'viewUrl' => $this->trackedResourceUrl('s', (int) $message->id, "v{$index}", $userSite . '/message/' . $message->id),
+            'messageUrl' => $this->trackedResourceUrl('m', (int) $message->id, "p{$index}", $userSite . '/message/' . $message->id . '?reply=1'),
+            'distanceText' => $distanceText,
+            'posterName' => $posterUser?->displayname ?? $message->fromname ?? 'A Freegler',
+            'posterAvatarUrl' => $this->resolveAvatarUrl($posterUser, 36),
+            'groupName' => $groupName,
+            'groupUrl' => $groupUrl,
+            // Why this is in the email: which of the recipient's own posts it matched.
+            'reasonType' => $reason->type,
+            'reasonItem' => MatchedPostsService::itemName($reason),
+        ];
+    }
+
+    /** Delivery-service cover-crop URL for the post's primary photo, or null. */
+    private function messageImageUrl(Message $message, int $width, int $height): ?string
+    {
+        if (! $message->relationLoaded('attachments') || $message->attachments->isEmpty()) {
+            return null;
+        }
+        $attachment = $message->attachments
+            ->filter(fn ($a) => ! empty($a->externaluid) || ! empty($a->externalurl) || (int) ($a->archived ?? 0) === 1)
+            ->sortByDesc('primary')
+            ->first();
+        if (! $attachment) {
+            return null;
+        }
+
+        $source = ! empty($attachment->externalurl)
+            ? $attachment->externalurl
+            : rtrim(config('freegle.images.domain', 'https://images.ilovefreegle.org'), '/') . '/timg_' . $attachment->id . '.jpg';
+
+        $base = rtrim(config('freegle.delivery.base_url', 'https://delivery.ilovefreegle.org'), '/');
+
+        return $base . '/?url=' . urlencode($source) . '&w=' . $width . '&h=' . $height . '&fit=cover';
+    }
+
+    private function haversineMiles(float $lat1, float $lng1, float $lat2, float $lng2): float
+    {
+        $earth = 3958.8; // miles
+        $dLat = deg2rad($lat2 - $lat1);
+        $dLng = deg2rad($lng2 - $lng1);
+        $a = sin($dLat / 2) ** 2 + cos(deg2rad($lat1)) * cos(deg2rad($lat2)) * sin($dLng / 2) ** 2;
+
+        return $earth * 2 * asin(min(1.0, sqrt($a)));
+    }
+}

--- a/iznik-batch/app/Mail/Matched/MatchedPosts.php
+++ b/iznik-batch/app/Mail/Matched/MatchedPosts.php
@@ -8,6 +8,7 @@ use App\Mail\Traits\AvatarResolver;
 use App\Mail\Traits\TrackableEmail;
 use App\Models\Message;
 use App\Models\User;
+use App\Services\LoginLinkService;
 use App\Services\MatchedPostsService;
 use App\Support\SubjectParser;
 use Illuminate\Mail\Mailables\Address;
@@ -38,9 +39,33 @@ class MatchedPosts extends MjmlMailable
         parent::__construct();
     }
 
+    private ?string $cachedOptOutUrl = null;
+
     protected function getRecipientUserId(): ?int
     {
         return $this->user->id;
+    }
+
+    /**
+     * A one-click, key-authenticated opt-out that turns off ONLY these
+     * matched-posts emails (relevantallowed=0) — not a full account
+     * unsubscribe. Used for both the List-Unsubscribe header and the visible
+     * footer link. Computed once so the key is minted a single time.
+     */
+    protected function optOutUrl(): string
+    {
+        if ($this->cachedOptOutUrl === null) {
+            $key = app(LoginLinkService::class)->getOrCreateKey((int) $this->user->id);
+            $v2 = rtrim(config('freegle.api.v2_url', 'https://api.ilovefreegle.org/apiv2'), '/');
+            $this->cachedOptOutUrl = $v2 . '/user/relevantoff?u=' . $this->user->id . '&k=' . $key;
+        }
+
+        return $this->cachedOptOutUrl;
+    }
+
+    protected function listUnsubscribeUrl(int $userId): string
+    {
+        return $this->optOutUrl();
     }
 
     protected function getSubject(): string
@@ -80,6 +105,11 @@ class MatchedPosts extends MjmlMailable
 
     public function build(): static
     {
+        // Attach the X-Freegle-* tracking headers and the RFC 8058
+        // List-Unsubscribe headers (which use our targeted relevantoff opt-out
+        // via listUnsubscribeUrl()).
+        $this->configureMessage();
+
         $userSite = config('freegle.sites.user', 'https://www.ilovefreegle.org');
 
         [$userLat, $userLng] = $this->recipientLatLng();
@@ -96,6 +126,7 @@ class MatchedPosts extends MjmlMailable
             'wantedColor' => DigestStyle::WANTED_BLUE,
             'browseUrl' => $userSite . '/browse?src=matched',
             'settingsUrl' => $this->settingsUrl ?: $userSite . '/settings?src=matched',
+            'optOutUrl' => $this->optOutUrl(),
             'userSite' => $userSite,
             'email' => $this->recipientEmail,
         ]);

--- a/iznik-batch/app/Mail/MjmlMailable.php
+++ b/iznik-batch/app/Mail/MjmlMailable.php
@@ -327,8 +327,7 @@ abstract class MjmlMailable extends Mailable
         $headers = $message->getHeaders();
 
         $unsubscribeEmail = config('freegle.mail.noreply_addr', 'noreply@ilovefreegle.org');
-        $userSite = config('freegle.sites.user', 'https://www.ilovefreegle.org');
-        $unsubscribeUrl = "{$userSite}/unsubscribe/{$userId}";
+        $unsubscribeUrl = $this->listUnsubscribeUrl($userId);
 
         // List-Unsubscribe: RFC 2369 — mailto: and https: URLs.
         $headers->addTextHeader(
@@ -338,6 +337,19 @@ abstract class MjmlMailable extends Mailable
 
         // List-Unsubscribe-Post: RFC 8058 — enables one-click unsubscribe.
         $headers->addTextHeader('List-Unsubscribe-Post', 'List-Unsubscribe=One-Click');
+    }
+
+    /**
+     * The HTTPS URL used in the List-Unsubscribe header. Defaults to the generic
+     * account unsubscribe page; a mailable for a single email category (e.g.
+     * MatchedPosts) overrides this to a targeted, one-click opt-out for just that
+     * category instead of the whole account.
+     */
+    protected function listUnsubscribeUrl(int $userId): string
+    {
+        $userSite = config('freegle.sites.user', 'https://www.ilovefreegle.org');
+
+        return "{$userSite}/unsubscribe/{$userId}";
     }
 
     /**

--- a/iznik-batch/app/Services/FreegleApiClient.php
+++ b/iznik-batch/app/Services/FreegleApiClient.php
@@ -168,6 +168,35 @@ class FreegleApiClient
         return $response && ($response['ret'] ?? -1) === 0;
     }
 
+    /**
+     * Opposite-type posts matching a given post, from the apiv2 in-memory vector
+     * store (GET /message/{id}/matches). Returns a list of matched-post rows
+     * (['id', 'groupid', 'score', 'lat', 'lng']); empty on any failure so the
+     * matched-posts mail degrades to "no matches" rather than erroring.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function matchesForPost(int $msgid, int $limit = 10): array
+    {
+        $response = $this->get('/message/'.$msgid.'/matches', ['limit' => $limit]);
+
+        // The endpoint returns a bare JSON array (not the {ret,...} envelope).
+        if (is_array($response) && ! isset($response['ret'])) {
+            return $response;
+        }
+
+        return [];
+    }
+
+    private function get(string $path, array $query = []): mixed
+    {
+        if ($query) {
+            $path .= '?'.http_build_query($query);
+        }
+
+        return $this->request('GET', $path, []);
+    }
+
     private function patch(string $path, array $data): ?array
     {
         return $this->request('PATCH', $path, $data);
@@ -206,7 +235,9 @@ class FreegleApiClient
         curl_setopt($ch, CURLOPT_URL, $url);
         curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($data));
+        if ($method !== 'GET') {
+            curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($data));
+        }
         curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
         curl_setopt($ch, CURLOPT_TIMEOUT, 30);
 

--- a/iznik-batch/app/Services/LoginLinkService.php
+++ b/iznik-batch/app/Services/LoginLinkService.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Get-or-create a user's persistent auto-login "Link" key (users_logins,
+ * type='Link') — the same key the Go API validates for keyed one-click links
+ * (login, forget, relevant-off). Get-or-create (not overwrite) so a key already
+ * handed out in an earlier email keeps working.
+ *
+ * Mirrors iznik-server-go getOrCreateLoginKey.
+ */
+class LoginLinkService
+{
+    public function getOrCreateKey(int $userId): string
+    {
+        $existing = DB::table('users_logins')
+            ->where('userid', $userId)
+            ->where('type', 'Link')
+            ->value('credentials');
+
+        if (! empty($existing)) {
+            return $existing;
+        }
+
+        $key = bin2hex(random_bytes(16));
+        DB::table('users_logins')->insert([
+            'userid' => $userId,
+            'type' => 'Link',
+            'uid' => (string) $userId,
+            'credentials' => $key,
+            'added' => now(),
+        ]);
+
+        return $key;
+    }
+}

--- a/iznik-batch/app/Services/MatchedPostsService.php
+++ b/iznik-batch/app/Services/MatchedPostsService.php
@@ -1,0 +1,293 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Message;
+use App\Models\User;
+use App\Support\SubjectParser;
+use Carbon\Carbon;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Builds the matched-posts notifications: for each recently-arrived Offer/Wanted,
+ * ask apiv2's vector store for the opposite-type posts near it, then fan those
+ * matches out to the two people who care — the fresh post's owner ("here are
+ * offers/wanteds for what you just posted") and each matched post's owner ("a new
+ * post matches your open offer/wanted"). Applies every dedup/eligibility guard so
+ * the command can just render and send what comes back.
+ *
+ * Vector similarity itself lives in apiv2 (in-memory store); this service only
+ * orchestrates and resolves the surrounding data from our own DB.
+ */
+class MatchedPostsService
+{
+    public function __construct(private FreegleApiClient $api) {}
+
+    /**
+     * @return array<int, array{user: User, items: array<int, array{message: Message, reason: Message, score: float}>}>
+     *         One entry per eligible recipient, each with the matched posts to show them.
+     */
+    public function buildNotifications(?Carbon $now = null): array
+    {
+        $now = $now ?? Carbon::now();
+
+        if (! config('freegle.matched.enabled', true)) {
+            return [];
+        }
+
+        $window = (int) config('freegle.matched.fresh_window_minutes', 20);
+        $perPost = (int) config('freegle.matched.match_limit_per_post', 10);
+
+        $fresh = $this->freshPosts($now->copy()->subMinutes($window));
+        if ($fresh->isEmpty()) {
+            return [];
+        }
+
+        // Ask apiv2 for each fresh post's opposite-type matches. Collect the raw
+        // (freshPost, matchedPost) links plus every message id involved.
+        $links = [];   // list of ['F'=>int, 'Fowner'=>int, 'R'=>int, 'score'=>float]
+        $ids = [];     // set of message ids to resolve
+        foreach ($fresh as $f) {
+            $matches = $this->api->matchesForPost((int) $f->msgid, $perPost);
+            foreach ($matches as $m) {
+                $rid = (int) ($m['id'] ?? 0);
+                if ($rid <= 0) {
+                    continue;
+                }
+                $links[] = ['F' => (int) $f->msgid, 'Fowner' => (int) $f->fromuser, 'R' => $rid, 'score' => (float) ($m['score'] ?? 0)];
+                $ids[(int) $f->msgid] = true;
+                $ids[$rid] = true;
+            }
+        }
+        if (! $links) {
+            return [];
+        }
+
+        // Resolve the involved posts — only those still open (approved, not
+        // deleted, not taken). A post that closed between the vector snapshot and
+        // now simply drops out here.
+        $messages = $this->loadOpenMessages(array_keys($ids));
+
+        // Fan out into (recipient => matchedMsgId => [matched message, reason post, score]).
+        $byRecipient = [];   // [recipientId => [matchedMsgId => ['message'=>Message,'reason'=>Message,'score'=>float]]]
+        foreach ($links as $l) {
+            $f = $messages->get($l['F']);
+            $r = $messages->get($l['R']);
+            if (! $f || ! $r) {
+                continue;
+            }
+            // Direction (i): the fresh post's owner sees the matched post R,
+            // because it matches their post F.
+            $this->addPair($byRecipient, $l['Fowner'], $r, $f, $l['score']);
+            // Direction (ii): the matched post's owner sees the fresh post F,
+            // because it matches their post R.
+            $this->addPair($byRecipient, (int) $r->fromuser, $f, $r, $l['score']);
+        }
+        if (! $byRecipient) {
+            return [];
+        }
+
+        return $this->applyEligibility($byRecipient, $now);
+    }
+
+    /**
+     * Recently-arrived, still-open, embedded Offer/Wanted posts — the drivers for
+     * this run. Bounded by the arrival index; joining messages_embeddings skips
+     * posts that can't be vector-searched yet (no wasted apiv2 call).
+     */
+    private function freshPosts(Carbon $since): Collection
+    {
+        return collect(DB::select(
+            'SELECT m.id AS msgid, m.fromuser, m.type
+               FROM messages_groups mg
+               INNER JOIN messages m ON m.id = mg.msgid
+               INNER JOIN messages_spatial ms ON ms.msgid = m.id
+               INNER JOIN messages_embeddings me ON me.msgid = m.id
+              WHERE mg.collection = ? AND mg.deleted = 0 AND mg.rippled_in = 0
+                AND m.type IN (?, ?)
+                AND mg.arrival > ?
+                AND m.deleted IS NULL
+                AND ms.successful = 0 AND ms.promised = 0
+              GROUP BY m.id, m.fromuser, m.type',
+            ['Approved', 'Offer', 'Wanted', $since->toDateTimeString()]
+        ));
+    }
+
+    /**
+     * Load the given posts as Message models, keyed by id, restricted to those
+     * still live (approved, not deleted, no Taken/Received outcome).
+     */
+    private function loadOpenMessages(array $ids): Collection
+    {
+        if (! $ids) {
+            return collect();
+        }
+
+        return Message::query()
+            ->whereIn('id', $ids)
+            ->approved()
+            ->notDeleted()
+            ->whereNotExists(function ($q) {
+                $q->select(DB::raw(1))
+                    ->from('messages_outcomes')
+                    ->whereColumn('messages_outcomes.msgid', 'messages.id')
+                    ->whereIn('messages_outcomes.outcome', ['Taken', 'Received']);
+            })
+            ->with(['attachments', 'fromUser', 'groups'])
+            ->get()
+            ->keyBy('id');
+    }
+
+    /**
+     * Record that matched post $matched should be shown to $recipientId because it
+     * matches their own post $reason. Dedupes on the matched post (keeps the
+     * highest-scoring reason) and never shows a user their own post.
+     */
+    private function addPair(array &$byRecipient, int $recipientId, Message $matched, Message $reason, float $score): void
+    {
+        if ($recipientId <= 0) {
+            return;
+        }
+        if ((int) $matched->fromuser === $recipientId) {
+            return; // never show someone their own post
+        }
+        $mid = (int) $matched->id;
+        $existing = $byRecipient[$recipientId][$mid] ?? null;
+        if ($existing && $existing['score'] >= $score) {
+            return;
+        }
+        $byRecipient[$recipientId][$mid] = ['message' => $matched, 'reason' => $reason, 'score' => $score];
+    }
+
+    /**
+     * Drop matched posts the recipient has already clicked to view or already been
+     * mailed, drop ineligible recipients (opted out / dormant / within cooldown),
+     * cap and order the per-recipient list, and attach the User model.
+     */
+    private function applyEligibility(array $byRecipient, Carbon $now): array
+    {
+        $recipientIds = array_keys($byRecipient);
+
+        // Eligible recipients: opted in, active recently, outside the cooldown.
+        $eligible = $this->eligibleRecipients($recipientIds, $now);
+        if ($eligible->isEmpty()) {
+            return [];
+        }
+
+        // (userid, msgid) pairs to test against "already viewed" and "already mailed".
+        $pairs = [];
+        foreach ($byRecipient as $uid => $items) {
+            if (! $eligible->has($uid)) {
+                continue;
+            }
+            foreach (array_keys($items) as $mid) {
+                $pairs[] = [$uid, $mid];
+            }
+        }
+        $viewed = $this->pairSet('messages_likes', $pairs, "type = 'View' AND pageview = 1");
+        $mailed = $this->pairSet('messages_matched_notified', $pairs);
+
+        $cap = (int) config('freegle.matched.max_items_per_email', 10);
+
+        $out = [];
+        foreach ($byRecipient as $uid => $items) {
+            if (! $eligible->has($uid)) {
+                continue;
+            }
+            $kept = [];
+            foreach ($items as $mid => $item) {
+                if (isset($viewed["$uid:$mid"]) || isset($mailed["$uid:$mid"])) {
+                    continue;
+                }
+                $kept[] = $item;
+            }
+            if (! $kept) {
+                continue;
+            }
+            usort($kept, fn ($a, $b) => $b['score'] <=> $a['score']);
+            $out[] = [
+                'user' => $eligible->get($uid),
+                'items' => array_slice($kept, 0, $cap),
+            ];
+        }
+
+        return $out;
+    }
+
+    private function eligibleRecipients(array $ids, Carbon $now): Collection
+    {
+        if (! $ids) {
+            return collect();
+        }
+        $dormantDays = (int) config('freegle.matched.min_lastaccess_days', 90);
+        $cooldownHours = (int) config('freegle.matched.cooldown_hours', 4);
+
+        return User::query()
+            ->whereIn('id', $ids)
+            ->where('relevantallowed', 1)
+            ->where('lastaccess', '>', $now->copy()->subDays($dormantDays)->toDateTimeString())
+            ->where(function ($q) use ($now, $cooldownHours) {
+                $q->whereNull('lastrelevantcheck')
+                    ->orWhere('lastrelevantcheck', '<', $now->copy()->subHours($cooldownHours)->toDateTimeString());
+            })
+            ->get()
+            ->keyBy('id');
+    }
+
+    /**
+     * Return a set ("userid:msgid" => true) of the given (userid, msgid) pairs
+     * that exist in $table (optionally further constrained by $extra).
+     *
+     * @param  array<int, array{0:int,1:int}>  $pairs
+     */
+    private function pairSet(string $table, array $pairs, string $extra = ''): array
+    {
+        if (! $pairs) {
+            return [];
+        }
+
+        $userIds = array_values(array_unique(array_map(fn ($p) => $p[0], $pairs)));
+        $msgIds = array_values(array_unique(array_map(fn ($p) => $p[1], $pairs)));
+
+        $q = DB::table($table)
+            ->select('userid', 'msgid')
+            ->whereIn('userid', $userIds)
+            ->whereIn('msgid', $msgIds);
+        if ($extra !== '') {
+            $q->whereRaw($extra);
+        }
+
+        // Prune to the exact pairs we asked about (the IN×IN cross-product can
+        // include pairs we don't care about).
+        $wanted = [];
+        foreach ($pairs as $p) {
+            $wanted["{$p[0]}:{$p[1]}"] = true;
+        }
+
+        $set = [];
+        foreach ($q->get() as $row) {
+            $key = "{$row->userid}:{$row->msgid}";
+            if (isset($wanted[$key])) {
+                $set[$key] = true;
+            }
+        }
+
+        return $set;
+    }
+
+    /** Item name from a message subject ("OFFER: Bike (London)" → "Bike"). */
+    public static function itemName(Message $m): string
+    {
+        $subject = html_entity_decode($m->subject ?? '', ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        [, $item] = SubjectParser::parse($subject);
+        if ($item) {
+            return $item;
+        }
+        // Fallback: strip a leading TYPE: prefix and any trailing (location).
+        $name = preg_replace('/^(OFFER|WANTED)\s*:\s*/i', '', $subject);
+        $name = preg_replace('/\s*\([^)]+\)\s*$/', '', $name);
+
+        return trim($name) ?: $subject;
+    }
+}

--- a/iznik-batch/app/Services/MatchedPostsService.php
+++ b/iznik-batch/app/Services/MatchedPostsService.php
@@ -46,10 +46,15 @@ class MatchedPostsService
 
         // Ask apiv2 for each fresh post's opposite-type matches. Collect the raw
         // (freshPost, matchedPost) links plus every message id involved.
+        // $matchCache[postId] = [matched msgids] — apiv2 reach-filters each result
+        // for THAT post's owner, so it doubles as the per-recipient reach oracle
+        // in verifyReach() below.
         $links = [];   // list of ['F'=>int, 'Fowner'=>int, 'R'=>int, 'score'=>float]
         $ids = [];     // set of message ids to resolve
+        $matchCache = [];
         foreach ($fresh as $f) {
             $matches = $this->api->matchesForPost((int) $f->msgid, $perPost);
+            $matchCache[(int) $f->msgid] = array_values(array_filter(array_map(fn ($m) => (int) ($m['id'] ?? 0), $matches)));
             foreach ($matches as $m) {
                 $rid = (int) ($m['id'] ?? 0);
                 if ($rid <= 0) {
@@ -88,7 +93,48 @@ class MatchedPostsService
             return [];
         }
 
-        return $this->applyEligibility($byRecipient, $now);
+        $notifications = $this->applyEligibility($byRecipient, $now);
+
+        return $this->verifyReach($notifications, $matchCache, $perPost);
+    }
+
+    /**
+     * Make every shown match reach-exact for its recipient. A recipient U is only
+     * shown a match M if M is in apiv2's matches for U's OWN post that it matched
+     * (`matchesForPost` reach-filters against that post's owner). Direction (i)
+     * items pass for free — their reason post is a fresh post already in
+     * $matchCache. Direction (ii) items (the recipient's existing post ← a new
+     * arrival) previously relied on bbox proximity; here they are checked against
+     * a fresh `matchesForPost` of the recipient's own post, so a match that hasn't
+     * rippled out to the recipient is dropped.
+     *
+     * @param  array<int, array{user: User, items: array}>  $notifications
+     * @param  array<int, array<int, int>>  $matchCache  postId => matched msgids
+     * @return array<int, array{user: User, items: array}>
+     */
+    private function verifyReach(array $notifications, array $matchCache, int $perPost): array
+    {
+        $out = [];
+        foreach ($notifications as $n) {
+            $kept = [];
+            foreach ($n['items'] as $item) {
+                $reasonId = (int) $item['reason']->id;
+                if (! array_key_exists($reasonId, $matchCache)) {
+                    // Resolve (and cache) the recipient's own post's matches — this
+                    // is the extra apiv2 call, made only for surviving items.
+                    $res = $this->api->matchesForPost($reasonId, $perPost);
+                    $matchCache[$reasonId] = array_values(array_filter(array_map(fn ($m) => (int) ($m['id'] ?? 0), $res)));
+                }
+                if (in_array((int) $item['message']->id, $matchCache[$reasonId], true)) {
+                    $kept[] = $item;
+                }
+            }
+            if ($kept) {
+                $out[] = ['user' => $n['user'], 'items' => $kept];
+            }
+        }
+
+        return $out;
     }
 
     /**

--- a/iznik-batch/config/freegle.php
+++ b/iznik-batch/config/freegle.php
@@ -33,6 +33,28 @@ return [
         'v2_url' => env('FREEGLE_API_V2_URL', 'https://api.ilovefreegle.org/apiv2'),
     ],
 
+    // Matched-posts email (matches:notify): emails a member the opposite-type
+    // posts near them that match their own open Offer/Wanted, resurrected with
+    // vector matching. Killswitch FREEGLE_MATCHED_ENABLED=false stops all sends
+    // without a deploy (apiv2 has its own FEATURE_MATCHED_POSTS killswitch for
+    // the vector endpoint).
+    'matched' => [
+        'enabled' => env('FREEGLE_MATCHED_ENABLED', true),
+        // How far back to treat a post as "fresh" each run. Wider than the 10-min
+        // schedule so a post embedded a few minutes after arrival is still caught;
+        // the per-(msgid,userid) ledger stops the overlap re-mailing anything.
+        'fresh_window_minutes' => env('FREEGLE_MATCHED_FRESH_WINDOW_MINUTES', 20),
+        // Matches requested from apiv2 per fresh post.
+        'match_limit_per_post' => env('FREEGLE_MATCHED_LIMIT_PER_POST', 10),
+        // Max matched posts shown in one email (rest wait for a later run / the site).
+        'max_items_per_email' => env('FREEGLE_MATCHED_MAX_ITEMS', 10),
+        // Don't email the same member more often than this (hours). Uses
+        // users.lastrelevantcheck, on top of the never-mail-the-same-post ledger.
+        'cooldown_hours' => env('FREEGLE_MATCHED_COOLDOWN_HOURS', 4),
+        // Don't email members who haven't visited in this many days.
+        'min_lastaccess_days' => env('FREEGLE_MATCHED_MIN_LASTACCESS_DAYS', 90),
+    ],
+
     'avatar_server_url' => env('FREEGLE_AVATAR_SERVER_URL', 'https://api.ilovefreegle.org/avatar'),
 
     'donations' => [

--- a/iznik-batch/database/migrations/2026_07_19_000001_create_messages_matched_notified_table.php
+++ b/iznik-batch/database/migrations/2026_07_19_000001_create_messages_matched_notified_table.php
@@ -1,0 +1,50 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * messages_matched_notified — ledger of which matched post has been emailed to
+ * which member by the matched-posts mail (matches:notify), so the same post is
+ * never mailed to the same person twice.
+ *
+ * Composite PK (msgid, userid) makes the "already mailed?" check and the insert a
+ * single keyed lookup, and makes re-notification impossible by construction
+ * (same pattern as rippling_reach_notified). msgid is the MATCHED post shown to
+ * the user (not the user's own post). Cascades away with the message or user.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('messages_matched_notified')) {
+            return;
+        }
+
+        Schema::create('messages_matched_notified', function (Blueprint $t) {
+            $t->unsignedBigInteger('msgid');
+            $t->unsignedBigInteger('userid');
+            $t->timestamp('mailed_at')->useCurrent();
+            $t->primary(['msgid', 'userid']);
+            $t->index('userid');
+        });
+
+        DB::statement(
+            'ALTER TABLE messages_matched_notified
+                ADD CONSTRAINT messages_matched_notified_msgid_foreign
+                FOREIGN KEY (msgid) REFERENCES messages (id) ON DELETE CASCADE'
+        );
+        DB::statement(
+            'ALTER TABLE messages_matched_notified
+                ADD CONSTRAINT messages_matched_notified_userid_foreign
+                FOREIGN KEY (userid) REFERENCES users (id) ON DELETE CASCADE'
+        );
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('messages_matched_notified');
+    }
+};

--- a/iznik-batch/database/migrations/2026_07_19_000002_add_matchedpost_to_notifications_enum.php
+++ b/iznik-batch/database/migrations/2026_07_19_000002_add_matchedpost_to_notifications_enum.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Add 'MatchedPost' to users_notifications.type for the matched-posts feature's
+ * in-app (bell) + push notification. ENUM values are stored as a 1-based
+ * ordinal, so the new value MUST be appended at the END of the existing physical
+ * order — an end-append is metadata-only (ALGORITHM=INSTANT); a reorder forces a
+ * full table rebuild. This enum was created 2025-12-10 with no reorder history,
+ * so the create-migration order is the live order. Do not tidy the order.
+ */
+return new class extends Migration
+{
+    private string $existing = "'CommentOnYourPost','CommentOnCommented','LovedPost','LovedComment','TryFeed','MembershipPending','MembershipApproved','MembershipRejected','AboutMe','Exhort','GiftAid','OpenPosts'";
+
+    public function up(): void
+    {
+        if (! Schema::hasTable('users_notifications')) {
+            return;
+        }
+
+        $enum = "ENUM({$this->existing},'MatchedPost') NOT NULL";
+        try {
+            DB::statement("ALTER TABLE users_notifications MODIFY COLUMN type {$enum}, ALGORITHM=INSTANT");
+        } catch (\Throwable $e) {
+            DB::statement("ALTER TABLE users_notifications MODIFY COLUMN type {$enum}");
+        }
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasTable('users_notifications')) {
+            return;
+        }
+
+        DB::table('users_notifications')->where('type', 'MatchedPost')->delete();
+        DB::statement("ALTER TABLE users_notifications MODIFY COLUMN type ENUM({$this->existing}) NOT NULL");
+    }
+};

--- a/iznik-batch/resources/views/emails/mjml/matched/_card.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/matched/_card.blade.php
@@ -1,0 +1,82 @@
+{{-- One matched-post card for the matched-posts email.
+
+     Required vars:
+       $post         — prepared card array from MatchedPosts::prepareCard()
+       $offerColor   — DigestStyle::OFFER_GREEN
+       $wantedColor  — DigestStyle::WANTED_BLUE
+     Optional:
+       $hero         — bool, default false. Single-match layout: full-width photo
+                       on top, details below. Otherwise a compact image-left card. --}}
+@php
+    $isOffer = $post['type'] === 'Offer';
+    $hero = $hero ?? false;
+    $accent = $isOffer ? $offerColor : $wantedColor;
+    // "Matches your wanted: bike" — reasonType is the recipient's own post type
+    // (always the opposite of this card's type).
+    $reasonLabel = 'Matches your ' . strtolower($post['reasonType']) . ': ' . $post['reasonItem'];
+    $metaHtml = ($post['distanceText'] ? '&#x1F4CD; ' . e($post['distanceText']) . ' &middot; ' : '')
+        . ($post['groupName'] ? 'on ' . e($post['groupName']) : '');
+@endphp
+
+{{-- Reason strip: why this post is in the email. --}}
+<mj-section background-color="#f0f7ea" padding="10px 20px 0">
+    <mj-column>
+        <mj-text font-size="12px" color="{{ $accent }}" font-weight="700" padding="0">
+            {{ $reasonLabel }}
+        </mj-text>
+    </mj-column>
+</mj-section>
+
+@if($hero)
+<mj-section background-color="#ffffff" padding="8px 20px 4px">
+    <mj-column>
+        <mj-image src="{{ $post['heroImageUrl'] }}" href="{{ $post['viewUrl'] }}" alt="{{ $post['itemName'] }}" border-radius="6px" padding="0" />
+    </mj-column>
+</mj-section>
+<mj-section background-color="#ffffff" padding="8px 20px 16px">
+    <mj-column>
+        <mj-text padding="0">
+            <div style="margin-bottom: 6px;">
+                <span style="display: inline-block; background-color: {{ $accent }}; color: #ffffff; font-size: 12px; font-weight: 700; padding: 4px 10px; border-radius: 3px; line-height: 1; letter-spacing: 0.3px;">{{ $isOffer ? 'OFFER' : 'WANTED' }}</span>
+            </div>
+            <a href="{{ $post['viewUrl'] }}" style="color: #212529; text-decoration: none; font-weight: 600; font-size: 18px; line-height: 1.4;">{{ $post['itemName'] }}</a>
+            @if($post['locationName'])
+            <br/><span style="color: #212529; font-size: 13px; font-weight: 500;">{{ $post['locationName'] }}</span>
+            @endif
+            <div style="margin-top: 6px; color: #888888; font-size: 12px;">{!! $metaHtml !!}</div>
+        </mj-text>
+        <mj-button href="{{ $post['messageUrl'] }}" background-color="{{ $accent }}" color="#ffffff" border-radius="4px" font-size="14px" font-weight="700" align="left" padding="12px 0 0">
+            Reply
+        </mj-button>
+    </mj-column>
+</mj-section>
+@else
+<mj-section background-color="#ffffff" padding="6px 20px 14px">
+    <mj-group>
+        <mj-column width="32%" vertical-align="top" padding="0 12px 0 0">
+            <mj-image src="{{ $post['thumbImageUrl'] }}" href="{{ $post['viewUrl'] }}" alt="{{ $post['itemName'] }}" width="100%" border-radius="4px" padding="0" />
+        </mj-column>
+        <mj-column width="68%" vertical-align="top">
+            <mj-text padding="0" color="#212529">
+                <div style="margin-bottom: 6px;">
+                    <span style="display: inline-block; background-color: {{ $accent }}; color: #ffffff; font-size: 11px; font-weight: 700; padding: 3px 9px; border-radius: 3px; line-height: 1; letter-spacing: 0.3px; white-space: nowrap;">{{ $isOffer ? 'OFFER' : 'WANTED' }}</span>
+                </div>
+                <a href="{{ $post['viewUrl'] }}" style="color: #212529; text-decoration: none; font-weight: 600; font-size: 16px; line-height: 1.3;">{{ $post['itemName'] }}</a>
+                @if($post['locationName'])
+                <br/><span style="color: #212529; font-size: 12px; font-weight: 500;">{{ $post['locationName'] }}</span>
+                @endif
+                <div style="margin-top: 6px; color: #888888; font-size: 12px;">{!! $metaHtml !!}</div>
+                <div style="margin-top: 10px;">
+                    <a href="{{ $post['messageUrl'] }}" style="display: inline-block; background-color: {{ $accent }}; color: #ffffff; font-size: 13px; font-weight: 700; padding: 8px 24px; border-radius: 4px; text-decoration: none;">Reply</a>
+                </div>
+            </mj-text>
+        </mj-column>
+    </mj-group>
+</mj-section>
+@endif
+
+<mj-section padding="0" background-color="#ffffff">
+    <mj-column>
+        <mj-divider border-color="#ececec" border-width="1px" padding="0 20px" />
+    </mj-column>
+</mj-section>

--- a/iznik-batch/resources/views/emails/mjml/matched/digest.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/matched/digest.blade.php
@@ -32,6 +32,14 @@
       </mj-column>
     </mj-section>
 
+    <mj-section background-color="#f4f4f4" padding="4px 20px 0">
+      <mj-column>
+        <mj-text font-size="12px" color="#999999" align="center" padding="0">
+          Don't want these suggestions? <a href="{{ $optOutUrl }}" style="color: #999999; text-decoration: underline;">Turn off matched-posts emails</a>.
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
     @include('emails.mjml.partials.footer', ['email' => $email, 'settingsUrl' => $settingsUrl])
 
   </mj-body>

--- a/iznik-batch/resources/views/emails/mjml/matched/digest.blade.php
+++ b/iznik-batch/resources/views/emails/mjml/matched/digest.blade.php
@@ -1,0 +1,38 @@
+<mjml>
+  @include('emails.mjml.partials.head', ['preview' => ($count === 1 ? 'A post near you matching what you posted' : $count . ' posts near you matching what you posted')])
+
+  <mj-body background-color="#f4f4f4">
+
+    @include('emails.mjml.components.header')
+
+    <mj-section background-color="#ffffff" padding="20px 20px 6px">
+      <mj-column>
+        <mj-text font-size="20px" font-weight="bold" color="#333333" padding="0 0 6px">
+          @if($count === 1)
+            A post near you matching what you posted
+          @else
+            {{ $count }} posts near you matching what you posted
+          @endif
+        </mj-text>
+        <mj-text font-size="14px" color="#555555" padding="0">
+          Based on what you've offered or asked for, here's what freeglers nearby have posted. Reply to anything that takes your fancy.
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+    @foreach ($posts as $post)
+      @include('emails.mjml.matched._card', ['post' => $post, 'offerColor' => $offerColor, 'wantedColor' => $wantedColor, 'hero' => $count === 1])
+    @endforeach
+
+    <mj-section background-color="#ffffff" padding="14px 20px 20px">
+      <mj-column>
+        <mj-button href="{{ $browseUrl }}" background-color="#338808" border-radius="4px" font-size="16px" font-weight="700">
+          See more on Freegle
+        </mj-button>
+      </mj-column>
+    </mj-section>
+
+    @include('emails.mjml.partials.footer', ['email' => $email, 'settingsUrl' => $settingsUrl])
+
+  </mj-body>
+</mjml>

--- a/iznik-batch/routes/console.php
+++ b/iznik-batch/routes/console.php
@@ -672,6 +672,17 @@ Schedule::command('mail:donations:thank-prep')
 //     ->withoutOverlapping()
 //     ->runInBackground();
 
+// Matched-posts email: for each recently-arrived Offer/Wanted, email the owner
+// (and the owners of posts it matches) the opposite-type posts near them via
+// apiv2's vector store. Resurrects V1 cron/relevant.php ("Any of these take your
+// fancy?") with vector matching. Every 10 min so matches surface promptly; the
+// per-(msgid,userid) ledger + per-user cooldown stop repeat mailing.
+Schedule::command('matches:notify')
+    ->everyTenMinutes()
+    ->withoutOverlapping(20)
+    ->sendOutputTo(cronLog('matches:notify'))
+    ->runInBackground();
+
 // Email spool processing - runs continuously in daemon mode via supervisor.
 // See docker/supervisor.conf for the mail-spooler program.
 

--- a/iznik-batch/tests/Feature/Mail/MatchedPostsIntegrationTest.php
+++ b/iznik-batch/tests/Feature/Mail/MatchedPostsIntegrationTest.php
@@ -95,6 +95,13 @@ class MatchedPostsIntegrationTest extends TestCase
         $this->assertTrue($this->mailpit->bodyContains($message, 'OFFER'), 'type pill present');
         $this->assertTrue($this->mailpit->bodyContains($message, 'Reply'), 'reply CTA present');
 
+        // Targeted opt-out (Future 1): a visible footer link + a List-Unsubscribe
+        // header, both pointing at the relevantoff endpoint (not a full unsubscribe).
+        $this->assertTrue($this->mailpit->bodyContains($message, 'relevantoff'), 'targeted opt-out link present in body');
+        $this->assertTrue($this->mailpit->bodyContains($message, 'Turn off matched-posts emails'), 'visible opt-out link text present');
+        $listUnsub = (string) $this->mailpit->getHeader($message, 'List-Unsubscribe');
+        $this->assertStringContainsString('relevantoff', $listUnsub, 'List-Unsubscribe targets the relevant opt-out');
+
         $this->mailpit->assertNotSpam($message);
     }
 }

--- a/iznik-batch/tests/Feature/Mail/MatchedPostsIntegrationTest.php
+++ b/iznik-batch/tests/Feature/Mail/MatchedPostsIntegrationTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Tests\Feature\Mail;
+
+use App\Services\EmailSpoolerService;
+use App\Services\FreegleApiClient;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Tests\Support\MailpitHelper;
+use Tests\TestCase;
+
+/**
+ * End-to-end: matches:notify → spool → send → Mailpit receives a well-formed,
+ * non-spammy matched-posts email with the reason line, pill, and Reply CTA.
+ * Requires Mailpit + the MJML server.
+ */
+class MatchedPostsIntegrationTest extends TestCase
+{
+    protected MailpitHelper $mailpit;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Config::set('mail.default', 'smtp');
+        Config::set('mail.mailers.smtp.host', 'mailpit');
+        Config::set('mail.mailers.smtp.port', 1025);
+
+        $this->mailpit = new MailpitHelper('http://mailpit:8025');
+    }
+
+    protected function tearDown(): void
+    {
+        FreegleApiClient::clearFake();
+        parent::tearDown();
+    }
+
+    protected function isMailpitAvailable(): bool
+    {
+        try {
+            $ch = curl_init('http://mailpit:8025/api/v1/messages');
+            curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+            curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 2);
+            curl_setopt($ch, CURLOPT_TIMEOUT, 5);
+            curl_exec($ch);
+            $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+            curl_close($ch);
+
+            return $httpCode === 200;
+        } catch (\Exception $e) {
+            return false;
+        }
+    }
+
+    public function test_matched_posts_email_is_delivered_and_well_formed(): void
+    {
+        if (! $this->isMailpitAvailable()) {
+            $this->markTestSkipped('Mailpit is not available.');
+        }
+
+        $group = $this->createTestGroup();
+
+        // createTestUser already gives each user a preferred email; use it (adding
+        // a second preferred email makes email_preferred ambiguous).
+        $recipient = $this->createTestUser(['lastaccess' => now(), 'relevantallowed' => 1, 'lastrelevantcheck' => null]);
+        $recipientEmail = $recipient->email_preferred;
+        $offerer = $this->createTestUser(['lastaccess' => now(), 'relevantallowed' => 1, 'lastrelevantcheck' => null]);
+
+        // Recipient's fresh WANTED (driver: needs spatial + embedding).
+        $wanted = $this->createTestMessage($recipient, $group, ['type' => 'Wanted', 'subject' => 'WANTED: Bookcase (York)', 'arrival' => now()]);
+        DB::statement(
+            'INSERT INTO messages_spatial (msgid, groupid, msgtype, successful, promised, arrival, point)
+             VALUES (?, ?, ?, 0, 0, ?, ST_GeomFromText(?, 3857))',
+            [$wanted->id, $group->id, 'Wanted', now(), sprintf('POINT(%F %F)', $group->lng, $group->lat)]
+        );
+        DB::statement('INSERT INTO messages_embeddings (msgid, subject_embedding, model_version) VALUES (?, ?, ?)',
+            [$wanted->id, str_repeat("\0", 1024), 'test']);
+
+        // Matching OFFER.
+        $offer = $this->createTestMessage($offerer, $group, ['type' => 'Offer', 'subject' => 'OFFER: Bookcase (York)', 'arrival' => now()->subHours(2)]);
+
+        FreegleApiClient::fake([
+            ['body' => [['id' => $offer->id, 'score' => 0.85, 'groupid' => $group->id, 'lat' => 51.5, 'lng' => -0.1]]],
+        ]);
+
+        $this->artisan('matches:notify')->assertExitCode(0);
+        app(EmailSpoolerService::class)->processSpool();
+
+        $message = $this->mailpit->assertMessageSentTo($recipientEmail);
+
+        $subject = $this->mailpit->getSubject($message);
+        $this->assertStringContainsString('Bookcase', $subject, 'subject names the matched item');
+
+        $this->assertTrue($this->mailpit->bodyContains($message, 'Matches your'), 'reason line present');
+        $this->assertTrue($this->mailpit->bodyContains($message, 'OFFER'), 'type pill present');
+        $this->assertTrue($this->mailpit->bodyContains($message, 'Reply'), 'reply CTA present');
+
+        $this->mailpit->assertNotSpam($message);
+    }
+}

--- a/iznik-batch/tests/Feature/Message/NotifyMatchedPostsCommandTest.php
+++ b/iznik-batch/tests/Feature/Message/NotifyMatchedPostsCommandTest.php
@@ -7,6 +7,7 @@ use App\Models\Message;
 use App\Models\User;
 use App\Services\EmailSpoolerService;
 use App\Services\FreegleApiClient;
+use App\Services\PushNotificationService;
 use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
 
@@ -57,6 +58,9 @@ class NotifyMatchedPostsCommandTest extends TestCase
         $this->mock(EmailSpoolerService::class, function ($m) {
             $m->shouldReceive('spool')->andReturn('spool-id');
         });
+        $this->mock(PushNotificationService::class, function ($m) {
+            $m->shouldReceive('notifyUser');
+        });
 
         $this->artisan('matches:notify')->assertExitCode(0);
 
@@ -76,6 +80,9 @@ class NotifyMatchedPostsCommandTest extends TestCase
         $this->mock(EmailSpoolerService::class, function ($m) {
             $m->shouldReceive('spool')->never();
         });
+        $this->mock(PushNotificationService::class, function ($m) {
+            $m->shouldReceive('notifyUser')->never();
+        });
 
         $this->artisan('matches:notify', ['--dry-run' => true])->assertExitCode(0);
 
@@ -83,6 +90,39 @@ class NotifyMatchedPostsCommandTest extends TestCase
             'msgid' => $offer->id,
             'userid' => $recipient->id,
         ]);
+        $this->assertDatabaseMissing('users_notifications', [
+            'touser' => $recipient->id,
+            'type' => 'MatchedPost',
+        ]);
         $this->assertNull($recipient->fresh()->lastrelevantcheck);
+    }
+
+    public function test_creates_inapp_notification_and_fires_push(): void
+    {
+        [$recipient, $wanted, $offerer, $offer] = $this->seedFixture();
+
+        $pushed = [];
+        $this->mock(EmailSpoolerService::class, function ($m) {
+            $m->shouldReceive('spool')->andReturn('spool-id');
+        });
+        $this->mock(PushNotificationService::class, function ($m) use (&$pushed) {
+            $m->shouldReceive('notifyUser')->andReturnUsing(function ($uid) use (&$pushed) {
+                $pushed[] = (int) $uid;
+
+                return 1;
+            });
+        });
+
+        $this->artisan('matches:notify')->assertExitCode(0);
+
+        // In-app bell notification created for the recipient, pointing at the match.
+        $this->assertDatabaseHas('users_notifications', [
+            'touser' => $recipient->id,
+            'type' => 'MatchedPost',
+            'url' => '/message/' . $offer->id,
+            'seen' => 0,
+        ]);
+        // And a device push was fired for that recipient.
+        $this->assertContains((int) $recipient->id, $pushed);
     }
 }

--- a/iznik-batch/tests/Feature/Message/NotifyMatchedPostsCommandTest.php
+++ b/iznik-batch/tests/Feature/Message/NotifyMatchedPostsCommandTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Tests\Feature\Message;
+
+use App\Models\Group;
+use App\Models\Message;
+use App\Models\User;
+use App\Services\EmailSpoolerService;
+use App\Services\FreegleApiClient;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+/**
+ * Orchestration test for `matches:notify`: with the mail send mocked out, verify
+ * it records what it mailed (the per-post ledger + the per-user cooldown) and
+ * that a dry run records nothing.
+ */
+class NotifyMatchedPostsCommandTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        FreegleApiClient::clearFake();
+        parent::tearDown();
+    }
+
+    private function seedFixture(): array
+    {
+        $group = $this->createTestGroup();
+
+        $recipient = $this->createTestUser(['lastaccess' => now(), 'relevantallowed' => 1, 'lastrelevantcheck' => null]);
+        $this->createTestUserEmail($recipient, ['preferred' => 1]);
+        $offerer = $this->createTestUser(['lastaccess' => now(), 'relevantallowed' => 1, 'lastrelevantcheck' => null]);
+        $this->createTestUserEmail($offerer, ['preferred' => 1]);
+
+        $wanted = $this->createTestMessage($recipient, $group, ['type' => 'Wanted', 'subject' => 'WANTED: Drill (Leeds)', 'arrival' => now()]);
+        DB::statement(
+            'INSERT INTO messages_spatial (msgid, groupid, msgtype, successful, promised, arrival, point)
+             VALUES (?, ?, ?, 0, 0, ?, ST_GeomFromText(?, 3857))',
+            [$wanted->id, $group->id, 'Wanted', now(), sprintf('POINT(%F %F)', $group->lng, $group->lat)]
+        );
+        DB::statement('INSERT INTO messages_embeddings (msgid, subject_embedding, model_version) VALUES (?, ?, ?)',
+            [$wanted->id, str_repeat("\0", 1024), 'test']);
+
+        $offer = $this->createTestMessage($offerer, $group, ['type' => 'Offer', 'subject' => 'OFFER: Drill (Leeds)', 'arrival' => now()->subDay()]);
+
+        FreegleApiClient::fake([
+            ['body' => [['id' => $offer->id, 'score' => 0.8, 'groupid' => $group->id, 'lat' => 51.5, 'lng' => -0.1]]],
+        ]);
+
+        return [$recipient, $wanted, $offerer, $offer];
+    }
+
+    public function test_records_ledger_and_cooldown_when_it_mails(): void
+    {
+        [$recipient, $wanted, $offerer, $offer] = $this->seedFixture();
+
+        $this->mock(EmailSpoolerService::class, function ($m) {
+            $m->shouldReceive('spool')->andReturn('spool-id');
+        });
+
+        $this->artisan('matches:notify')->assertExitCode(0);
+
+        // The matched offer is recorded as mailed to the recipient (dedup ledger).
+        $this->assertDatabaseHas('messages_matched_notified', [
+            'msgid' => $offer->id,
+            'userid' => $recipient->id,
+        ]);
+        // Cooldown watermark bumped.
+        $this->assertNotNull($recipient->fresh()->lastrelevantcheck);
+    }
+
+    public function test_dry_run_records_nothing(): void
+    {
+        [$recipient, $wanted, $offerer, $offer] = $this->seedFixture();
+
+        $this->mock(EmailSpoolerService::class, function ($m) {
+            $m->shouldReceive('spool')->never();
+        });
+
+        $this->artisan('matches:notify', ['--dry-run' => true])->assertExitCode(0);
+
+        $this->assertDatabaseMissing('messages_matched_notified', [
+            'msgid' => $offer->id,
+            'userid' => $recipient->id,
+        ]);
+        $this->assertNull($recipient->fresh()->lastrelevantcheck);
+    }
+}

--- a/iznik-batch/tests/Unit/Mail/MatchedPostsSubjectTest.php
+++ b/iznik-batch/tests/Unit/Mail/MatchedPostsSubjectTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\Unit\Mail;
+
+use App\Mail\Matched\MatchedPosts;
+use App\Models\Message;
+use App\Models\User;
+use Tests\TestCase;
+
+class MatchedPostsSubjectTest extends TestCase
+{
+    private function item(string $type, string $subject): array
+    {
+        $m = new Message();
+        $m->type = $type;
+        $m->subject = $subject;
+        $reason = new Message();
+        $reason->type = $type === 'Offer' ? 'Wanted' : 'Offer';
+        $reason->subject = 'WANTED: something';
+
+        return ['message' => $m, 'reason' => $reason, 'score' => 0.8];
+    }
+
+    private function mail(array $items): MatchedPosts
+    {
+        $u = new User();
+        $u->id = 1;
+
+        return new MatchedPosts($u, 'test@example.com', $items);
+    }
+
+    public function test_multiple_matches_use_the_generic_subject(): void
+    {
+        $mail = $this->mail([
+            $this->item('Offer', 'OFFER: Bike (Leeds)'),
+            $this->item('Wanted', 'WANTED: Sofa (York)'),
+        ]);
+
+        $this->assertEquals('Freegle matches for you', $mail->envelope()->subject);
+    }
+
+    public function test_single_match_names_the_item(): void
+    {
+        $mail = $this->mail([$this->item('Offer', 'OFFER: Bike (Leeds)')]);
+
+        $this->assertEquals('Someone is offering: Bike', $mail->envelope()->subject);
+    }
+}

--- a/iznik-batch/tests/Unit/Services/FreegleApiClientTest.php
+++ b/iznik-batch/tests/Unit/Services/FreegleApiClientTest.php
@@ -39,6 +39,35 @@ class FreegleApiClientTest extends TestCase
     }
 
     // =====================================================================
+    // matchesForPost()
+    // =====================================================================
+
+    public function test_matches_for_post_returns_the_match_list(): void
+    {
+        FreegleApiClient::fake([
+            ['body' => [
+                ['id' => 101, 'score' => 0.9, 'groupid' => 5, 'lat' => 51.5, 'lng' => -0.1],
+                ['id' => 102, 'score' => 0.7, 'groupid' => 5, 'lat' => 51.5, 'lng' => -0.1],
+            ]],
+        ]);
+
+        $matches = (new FreegleApiClient('http://example.test'))->matchesForPost(42, 10);
+
+        $this->assertCount(2, $matches);
+        $this->assertEquals(101, $matches[0]['id']);
+    }
+
+    public function test_matches_for_post_returns_empty_on_failure(): void
+    {
+        // No fake queued → request() returns null → empty list, never an error.
+        FreegleApiClient::fake([['body' => null]]);
+
+        $matches = (new FreegleApiClient('http://example.test'))->matchesForPost(42);
+
+        $this->assertSame([], $matches);
+    }
+
+    // =====================================================================
     // authenticate()
     // =====================================================================
 

--- a/iznik-batch/tests/Unit/Services/LoginLinkServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/LoginLinkServiceTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Services\LoginLinkService;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class LoginLinkServiceTest extends TestCase
+{
+    public function test_creates_a_link_key_when_none_exists(): void
+    {
+        $user = $this->createTestUser();
+        $key = app(LoginLinkService::class)->getOrCreateKey((int) $user->id);
+
+        $this->assertNotEmpty($key);
+        $this->assertDatabaseHas('users_logins', [
+            'userid' => $user->id,
+            'type' => 'Link',
+            'credentials' => $key,
+        ]);
+    }
+
+    public function test_reuses_the_existing_link_key(): void
+    {
+        $user = $this->createTestUser();
+        $svc = app(LoginLinkService::class);
+
+        $first = $svc->getOrCreateKey((int) $user->id);
+        $second = $svc->getOrCreateKey((int) $user->id);
+
+        $this->assertSame($first, $second, 'must not mint a new key each call (would break links already emailed)');
+        $this->assertEquals(1, DB::table('users_logins')->where('userid', $user->id)->where('type', 'Link')->count());
+    }
+}

--- a/iznik-batch/tests/Unit/Services/MatchedPostsServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/MatchedPostsServiceTest.php
@@ -55,14 +55,12 @@ class MatchedPostsServiceTest extends TestCase
             'arrival' => now()->subDay(),
         ]);
 
+        // Sequential fakes, in call order:
+        //  1. matchesForPost(wanted) → [offer]   (drives both directions)
+        //  2. matchesForPost(offer)  → [wanted]  (verifyReach: offer owner can reach the wanted)
         FreegleApiClient::fake([
-            ['body' => [[
-                'id' => $offer->id,
-                'score' => 0.82,
-                'groupid' => $group->id,
-                'lat' => 51.5,
-                'lng' => -0.1,
-            ]]],
+            ['body' => [['id' => $offer->id, 'score' => 0.82, 'groupid' => $group->id, 'lat' => 51.5, 'lng' => -0.1]]],
+            ['body' => [['id' => $wanted->id, 'score' => 0.82, 'groupid' => $group->id, 'lat' => 51.5, 'lng' => -0.1]]],
         ]);
 
         return [$recipient, $wanted, $offerer, $offer];
@@ -117,6 +115,24 @@ class MatchedPostsServiceTest extends TestCase
         $toOfferer = $this->notificationFor($notifications, $offerer->id);
         $this->assertNotNull($toOfferer, 'offer owner should be notified of the new wanted');
         $this->assertEquals($wanted->id, $toOfferer['items'][0]['message']->id);
+    }
+
+    public function test_drops_a_direction_ii_match_outside_the_recipients_reach(): void
+    {
+        [$recipient, $wanted, $offerer, $offer] = $this->seedMatch();
+
+        // matchesForPost(wanted) → [offer] (direction i fine); matchesForPost(offer)
+        // → [] means the fresh wanted has NOT rippled out to the offer owner, so the
+        // direction-(ii) notification must be dropped by the reach check.
+        FreegleApiClient::fake([
+            ['body' => [['id' => $offer->id, 'score' => 0.82, 'groupid' => 0, 'lat' => 51.5, 'lng' => -0.1]]],
+            ['body' => []],
+        ]);
+
+        $notifications = app(MatchedPostsService::class)->buildNotifications();
+
+        $this->assertNotNull($this->notificationFor($notifications, $recipient->id), 'direction (i) still delivered');
+        $this->assertNull($this->notificationFor($notifications, $offerer->id), 'direction (ii) dropped — out of reach');
     }
 
     public function test_never_re_mails_a_post_already_in_the_ledger(): void

--- a/iznik-batch/tests/Unit/Services/MatchedPostsServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/MatchedPostsServiceTest.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Models\Group;
+use App\Models\Message;
+use App\Models\User;
+use App\Services\FreegleApiClient;
+use App\Services\MatchedPostsService;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+/**
+ * The vector matching itself lives in apiv2 and is stubbed here via
+ * FreegleApiClient::fake(); these tests cover the service's own job — fanning a
+ * fresh post's matches out to both owners and applying every dedup/eligibility
+ * guard.
+ */
+class MatchedPostsServiceTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        FreegleApiClient::clearFake();
+        parent::tearDown();
+    }
+
+    /**
+     * Base fixture: an eligible recipient with a fresh WANTED, and an offerer with
+     * a matching (not-fresh) OFFER that apiv2 returns as the match. Returns
+     * [recipient, wanted, offerer, offer].
+     */
+    private function seedMatch(array $recipientAttrs = []): array
+    {
+        $group = $this->createTestGroup();
+
+        $recipient = $this->createTestUser(array_merge([
+            'lastaccess' => now(),
+            'relevantallowed' => 1,
+            'lastrelevantcheck' => null,
+        ], $recipientAttrs));
+
+        $offerer = $this->createTestUser([
+            'lastaccess' => now(),
+            'relevantallowed' => 1,
+            'lastrelevantcheck' => null,
+        ]);
+
+        // The recipient's own fresh WANTED — the driver (needs spatial + embedding).
+        $wanted = $this->makeFreshDriver($recipient, $group, 'Wanted', 'WANTED: Bicycle (London)');
+
+        // The matching OFFER — a live post apiv2 returns; not itself a driver.
+        $offer = $this->createTestMessage($offerer, $group, [
+            'type' => 'Offer',
+            'subject' => 'OFFER: Bicycle (London)',
+            'arrival' => now()->subDay(),
+        ]);
+
+        FreegleApiClient::fake([
+            ['body' => [[
+                'id' => $offer->id,
+                'score' => 0.82,
+                'groupid' => $group->id,
+                'lat' => 51.5,
+                'lng' => -0.1,
+            ]]],
+        ]);
+
+        return [$recipient, $wanted, $offerer, $offer];
+    }
+
+    private function makeFreshDriver(User $user, Group $group, string $type, string $subject): Message
+    {
+        $message = $this->createTestMessage($user, $group, [
+            'type' => $type,
+            'subject' => $subject,
+            'arrival' => now(),
+        ]);
+
+        DB::statement(
+            'INSERT INTO messages_spatial (msgid, groupid, msgtype, successful, promised, arrival, point)
+             VALUES (?, ?, ?, 0, 0, ?, ST_GeomFromText(?, 3857))',
+            [$message->id, $group->id, $type, now(), sprintf('POINT(%F %F)', $group->lng, $group->lat)]
+        );
+        DB::statement(
+            'INSERT INTO messages_embeddings (msgid, subject_embedding, model_version) VALUES (?, ?, ?)',
+            [$message->id, str_repeat("\0", 1024), 'test']
+        );
+
+        return $message;
+    }
+
+    private function notificationFor(array $notifications, int $userId): ?array
+    {
+        foreach ($notifications as $n) {
+            if ((int) $n['user']->id === $userId) {
+                return $n;
+            }
+        }
+
+        return null;
+    }
+
+    public function test_fans_a_fresh_match_out_to_both_owners(): void
+    {
+        [$recipient, $wanted, $offerer, $offer] = $this->seedMatch();
+
+        $notifications = app(MatchedPostsService::class)->buildNotifications();
+
+        // Direction (i): the wanted's owner is shown the matching offer.
+        $toRecipient = $this->notificationFor($notifications, $recipient->id);
+        $this->assertNotNull($toRecipient, 'wanted owner should be notified');
+        $this->assertCount(1, $toRecipient['items']);
+        $this->assertEquals($offer->id, $toRecipient['items'][0]['message']->id);
+        $this->assertEquals('Wanted', $toRecipient['items'][0]['reason']->type, 'reason is their own wanted');
+
+        // Direction (ii): the offer's owner is shown the matching wanted.
+        $toOfferer = $this->notificationFor($notifications, $offerer->id);
+        $this->assertNotNull($toOfferer, 'offer owner should be notified of the new wanted');
+        $this->assertEquals($wanted->id, $toOfferer['items'][0]['message']->id);
+    }
+
+    public function test_never_re_mails_a_post_already_in_the_ledger(): void
+    {
+        [$recipient, $wanted, $offerer, $offer] = $this->seedMatch();
+
+        DB::table('messages_matched_notified')->insert([
+            'msgid' => $offer->id,
+            'userid' => $recipient->id,
+            'mailed_at' => now(),
+        ]);
+
+        $notifications = app(MatchedPostsService::class)->buildNotifications();
+
+        $this->assertNull($this->notificationFor($notifications, $recipient->id),
+            'already-mailed offer must not be re-sent to the recipient');
+    }
+
+    public function test_excludes_a_post_the_recipient_clicked_but_not_a_scroll_impression(): void
+    {
+        [$recipient, $wanted, $offerer, $offer] = $this->seedMatch();
+
+        // A genuine open (pageview=1) suppresses the match.
+        DB::table('messages_likes')->insert([
+            'msgid' => $offer->id, 'userid' => $recipient->id, 'type' => 'View', 'pageview' => 1,
+        ]);
+
+        $this->assertNull(
+            $this->notificationFor(app(MatchedPostsService::class)->buildNotifications(), $recipient->id),
+            'a clicked (pageview=1) post must be excluded'
+        );
+
+        // A mere feed impression (pageview=0) must NOT suppress it.
+        DB::table('messages_likes')->where('msgid', $offer->id)->where('userid', $recipient->id)->update(['pageview' => 0]);
+        FreegleApiClient::fake([
+            ['body' => [['id' => $offer->id, 'score' => 0.82, 'groupid' => 0, 'lat' => 51.5, 'lng' => -0.1]]],
+        ]);
+
+        $this->assertNotNull(
+            $this->notificationFor(app(MatchedPostsService::class)->buildNotifications(), $recipient->id),
+            'a scroll-past impression (pageview=0) must not suppress the match'
+        );
+    }
+
+    public function test_skips_recipients_who_opted_out(): void
+    {
+        [$recipient] = $this->seedMatch(['relevantallowed' => 0]);
+
+        $this->assertNull(
+            $this->notificationFor(app(MatchedPostsService::class)->buildNotifications(), $recipient->id),
+            'relevantallowed=0 must be skipped'
+        );
+    }
+
+    public function test_respects_the_per_user_cooldown(): void
+    {
+        [$recipient] = $this->seedMatch(['lastrelevantcheck' => now()->subHour()]); // < 4h ago
+
+        $this->assertNull(
+            $this->notificationFor(app(MatchedPostsService::class)->buildNotifications(), $recipient->id),
+            'a recipient mailed within the cooldown must be skipped'
+        );
+    }
+}

--- a/iznik-nuxt3/components/NotificationMatchedPost.vue
+++ b/iznik-nuxt3/components/NotificationMatchedPost.vue
@@ -1,0 +1,35 @@
+<template>
+  <div class="clickme d-flex">
+    <div class="d-flex flex-column justify-content-around">
+      <ProfileImage
+        image="/icon.png"
+        class="me-1 mb-1 ms-1 inline"
+        is-thumbnail
+        size="lg"
+      />
+    </div>
+    <div class="d-flex flex-column">
+      <div>
+        {{ notification.title }}
+      </div>
+      <div v-if="notification.text" class="text-muted small">
+        {{ notification.text }}
+      </div>
+      <abbr class="small">{{ notificationago }}</abbr>
+    </div>
+  </div>
+</template>
+<script setup>
+import { setupNotification } from '~/composables/useNotification'
+import ProfileImage from '~/components/ProfileImage'
+
+const props = defineProps({
+  id: {
+    type: Number,
+    required: true,
+  },
+})
+
+// Setup notification
+const { notification, notificationago } = await setupNotification(props.id)
+</script>

--- a/iznik-nuxt3/components/NotificationOne.vue
+++ b/iznik-nuxt3/components/NotificationOne.vue
@@ -30,6 +30,10 @@
       v-else-if="notification.type === 'OpenPosts'"
       :id="id"
     />
+    <NotificationMatchedPost
+      v-else-if="notification.type === 'MatchedPost'"
+      :id="id"
+    />
     <span v-else-if="notification.type === 'TryFeed'" />
     <span v-else> Unknown notification {{ notification.type }} </span>
   </div>
@@ -62,6 +66,9 @@ const NotificationAboutMe = defineAsyncComponent(() =>
 )
 const NotificationOpenPosts = defineAsyncComponent(() =>
   import('~/components/NotificationOpenPosts')
+)
+const NotificationMatchedPost = defineAsyncComponent(() =>
+  import('~/components/NotificationMatchedPost')
 )
 
 const props = defineProps({

--- a/iznik-nuxt3/tests/unit/components/NotificationMatchedPost.spec.js
+++ b/iznik-nuxt3/tests/unit/components/NotificationMatchedPost.spec.js
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { defineComponent, h, Suspense } from 'vue'
+import NotificationMatchedPost from '~/components/NotificationMatchedPost.vue'
+
+const { mockNotification, mockNotificationago } = vi.hoisted(() => {
+  const { ref } = require('vue')
+  return {
+    mockNotification: ref({
+      id: 1,
+      title: 'Freegle matches for you',
+      text: '3 posts near you match what you’ve offered or asked for',
+    }),
+    mockNotificationago: ref('5 minutes ago'),
+  }
+})
+
+vi.mock('~/composables/useNotification', () => ({
+  setupNotification: vi.fn(() =>
+    Promise.resolve({
+      notification: mockNotification,
+      notificationago: mockNotificationago,
+    })
+  ),
+}))
+
+describe('NotificationMatchedPost', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockNotification.value = {
+      id: 1,
+      title: 'Freegle matches for you',
+      text: '3 posts near you match what you’ve offered or asked for',
+    }
+    mockNotificationago.value = '5 minutes ago'
+  })
+
+  async function createWrapper(props = {}) {
+    const TestWrapper = defineComponent({
+      setup() {
+        return () =>
+          h(Suspense, null, {
+            default: () => h(NotificationMatchedPost, { id: 1, ...props }),
+            fallback: () => h('div', 'Loading...'),
+          })
+      },
+    })
+
+    const wrapper = mount(TestWrapper, {
+      global: {
+        stubs: {
+          ProfileImage: {
+            template:
+              '<div class="profile-image" :data-image="image" :data-size="size" />',
+            props: ['image', 'isThumbnail', 'size'],
+          },
+        },
+      },
+    })
+
+    await flushPromises()
+    return wrapper
+  }
+
+  it('renders the container and icon', async () => {
+    const wrapper = await createWrapper()
+    expect(wrapper.find('.clickme').exists()).toBe(true)
+    const img = wrapper.find('.profile-image')
+    expect(img.attributes('data-image')).toBe('/icon.png')
+    expect(img.attributes('data-size')).toBe('lg')
+  })
+
+  it('displays the title and text', async () => {
+    const wrapper = await createWrapper()
+    expect(wrapper.text()).toContain('Freegle matches for you')
+    expect(wrapper.text()).toContain('posts near you match')
+  })
+
+  it('omits the text section when there is no text', async () => {
+    mockNotification.value = {
+      id: 1,
+      title: 'Someone is offering: Bike',
+      text: null,
+    }
+    const wrapper = await createWrapper()
+    expect(wrapper.text()).toContain('Someone is offering: Bike')
+    expect(wrapper.find('.text-muted').exists()).toBe(false)
+  })
+
+  it('shows the relative time', async () => {
+    const wrapper = await createWrapper()
+    expect(wrapper.find('abbr.small').text()).toBe('5 minutes ago')
+  })
+
+  it('requires the id prop', async () => {
+    const wrapper = await createWrapper({ id: 7 })
+    expect(wrapper.findComponent(NotificationMatchedPost).props('id')).toBe(7)
+  })
+})

--- a/iznik-server-go/message/postmatches.go
+++ b/iznik-server-go/message/postmatches.go
@@ -1,0 +1,161 @@
+package message
+
+import (
+	"os"
+	"strconv"
+
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/freegle/iznik-server-go/embedding"
+	"github.com/freegle/iznik-server-go/utils"
+	"github.com/gofiber/fiber/v2"
+)
+
+// matchedPostsEnabled reports whether opposite-type post matching is on.
+// FEATURE_MATCHED_POSTS=off is a no-deploy killswitch (default on); when off the
+// endpoint returns an empty list so the matched-posts email simply sends nothing.
+func matchedPostsEnabled() bool {
+	return os.Getenv("FEATURE_MATCHED_POSTS") != "off"
+}
+
+// oppositeType maps Offer↔Wanted; any other type yields "" (no matching).
+func oppositeType(t string) string {
+	switch t {
+	case "Offer":
+		return "Wanted"
+	case "Wanted":
+		return "Offer"
+	default:
+		return ""
+	}
+}
+
+// PostMatches returns open posts of the OPPOSITE type that semantically match a
+// given post and are near it — the candidate set for the matched-posts email.
+//
+// It differs from /similar in three ways, all because it serves a batch job
+// rather than an on-site viewer: (1) opposite type (an Offer's matches are
+// Wanteds and vice versa); (2) boxed to collectable distance around the post;
+// (3) reach-filtered against the POST's own location, not the caller's — the
+// batch calls this unauthenticated, and the recipient is the post's owner, so a
+// candidate that hasn't rippled out to the post's area is dropped. Excludes the
+// owner's own posts and applies MinSimilarScore. Uses the stored subject
+// embedding (in-memory store, else one indexed read). Empty (never 500) when the
+// post has no embedding, no location, or isn't an Offer/Wanted.
+//
+// @Router /message/{id}/matches [get]
+// @Summary Opposite-type posts matching a given post (matched-posts email)
+// @Tags message
+// @Produce json
+// @Param id path int true "Message ID"
+// @Param limit query int false "Max results (default 10, max 30)"
+// @Success 200 {array} message.SimilarResult
+func PostMatches(c *fiber.Ctx) error {
+	if !matchedPostsEnabled() {
+		return c.JSON([]SimilarResult{})
+	}
+
+	id, err := strconv.ParseUint(c.Params("id"), 10, 64)
+	if err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, "Invalid message id")
+	}
+
+	limit := c.QueryInt("limit", 10)
+	if limit < 1 {
+		limit = 10
+	}
+	if limit > 30 {
+		limit = 30
+	}
+
+	// Source post: embedding + type + author + location. Prefer the in-memory
+	// store (open post, no DB read); fall back to one indexed read for a post not
+	// in the current snapshot.
+	var srcVec []float32
+	var srcType string
+	var srcFromuser uint64
+	var srcLat, srcLng float64
+
+	if e, ok := embedding.Global.FindByMsgid(id); ok {
+		srcVec = e.SubjectVec[:]
+		srcType = e.Msgtype
+		srcFromuser = e.Fromuser
+		srcLat = e.Lat
+		srcLng = e.Lng
+	} else {
+		var row struct {
+			SubjectEmbedding []byte  `gorm:"column:subject_embedding"`
+			Fromuser         uint64  `gorm:"column:fromuser"`
+			Type             string  `gorm:"column:type"`
+			Lat              float64 `gorm:"column:lat"`
+			Lng              float64 `gorm:"column:lng"`
+		}
+		database.DBConn.Raw(
+			"SELECT me.subject_embedding, m.fromuser, m.type, "+
+				"ST_Y(ms.point) AS lat, ST_X(ms.point) AS lng "+
+				"FROM messages_embeddings me "+
+				"INNER JOIN messages m ON m.id = me.msgid "+
+				"LEFT JOIN messages_spatial ms ON ms.msgid = me.msgid "+
+				"WHERE me.msgid = ?", id).Scan(&row)
+		if len(row.SubjectEmbedding) == 0 {
+			return c.JSON([]SimilarResult{})
+		}
+		vec, decErr := embedding.DecodeVector(row.SubjectEmbedding)
+		if decErr != nil {
+			return c.JSON([]SimilarResult{})
+		}
+		srcVec = vec
+		srcType = row.Type
+		srcFromuser = row.Fromuser
+		srcLat = row.Lat
+		srcLng = row.Lng
+	}
+
+	opp := oppositeType(srcType)
+	if opp == "" {
+		return c.JSON([]SimilarResult{})
+	}
+	if srcLat == 0 && srcLng == 0 {
+		// No usable location → we can't box or reach-filter, so return nothing
+		// rather than surface far-away posts.
+		return c.JSON([]SimilarResult{})
+	}
+
+	// Box the search to collectable distance around the post (same half-width as
+	// the compose-time wanted-match panel).
+	swlat := float32(srcLat - matchBoxDegrees)
+	swlng := float32(srcLng - matchBoxDegrees)
+	nelat := float32(srcLat + matchBoxDegrees)
+	nelng := float32(srcLng + matchBoxDegrees)
+	candidates := embedding.Global.Search(srcVec, limit*3, opp, nil, nil, swlat, swlng, nelat, nelng)
+
+	// Reach-filter against the post's location (the owner is the recipient): drop
+	// opposite posts that haven't rippled out to where the post is, so we never
+	// email a match the owner couldn't reply to. Fail-open (no reach row → kept).
+	blocked := ReachBlockedSet(candidateMsgids(candidates), srcLat, srcLng)
+
+	out := make([]SimilarResult, 0, limit)
+	for _, cnd := range candidates {
+		if cnd.Fromuser == srcFromuser {
+			continue // the owner's own posts
+		}
+		if cnd.SubjectCos < MinSimilarScore {
+			continue
+		}
+		if blocked[cnd.Msgid] {
+			continue
+		}
+		lat, lng := utils.Blur(cnd.Lat, cnd.Lng, utils.BLUR_USER)
+		out = append(out, SimilarResult{
+			Msgid:   cnd.Msgid,
+			Groupid: cnd.Groupid,
+			Score:   cnd.SubjectCos,
+			Lat:     lat,
+			Lng:     lng,
+		})
+		if len(out) >= limit {
+			break
+		}
+	}
+
+	return c.JSON(out)
+}

--- a/iznik-server-go/router/routes.go
+++ b/iznik-server-go/router/routes.go
@@ -956,6 +956,17 @@ func SetupRoutes(app *fiber.App) {
 		// @Success 200 {array} message.SimilarResult
 		rg.Get("/message/matches", message.Matches)
 
+		// Opposite-type posts matching a given post — candidate set for the
+		// matched-posts email (batch job). Reach-filtered against the post owner.
+		// @Router /message/{id}/matches [get]
+		// @Summary Opposite-type posts matching a given post (matched-posts email)
+		// @Tags message
+		// @Produce json
+		// @Param id path int true "Message ID"
+		// @Param limit query int false "Max results (default 10, max 30)"
+		// @Success 200 {array} message.SimilarResult
+		rg.Get("/message/:id/matches", message.PostMatches)
+
 		rg.Get("/message/:ids", message.GetMessagesWithHistory)
 
 		// Mark Messages Seen

--- a/iznik-server-go/router/routes.go
+++ b/iznik-server-go/router/routes.go
@@ -1049,6 +1049,12 @@ func SetupRoutes(app *fiber.App) {
 		// @Failure 404 {object} fiber.Error "User not found"
 		rg.Get("/user/search", user.SearchUsers)
 		rg.Get("/user/byemail/:email", user.GetUserByEmail)
+		// Targeted opt-out from matched-posts suggestion emails (relevantallowed=0),
+		// key-authenticated so it works as a one-click List-Unsubscribe. Registered
+		// before /user/:id? so "relevantoff" is not treated as a user id.
+		// @Router /user/relevantoff [get]
+		rg.Get("/user/relevantoff", user.RelevantOff)
+		rg.Post("/user/relevantoff", user.RelevantOff)
 		rg.Get("/user/:id?", user.GetUser)
 
 		// User Actions (POST)

--- a/iznik-server-go/test/postmatches_test.go
+++ b/iznik-server-go/test/postmatches_test.go
@@ -1,0 +1,128 @@
+package test
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/freegle/iznik-server-go/embedding"
+	"github.com/freegle/iznik-server-go/message"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPostMatchesReturnsOppositeType: given a source Offer, /message/:id/matches
+// returns only open OPPOSITE-type (Wanted) posts, above MinSimilarScore, by a
+// DIFFERENT author. Same-type, weak, and same-author candidates are all dropped.
+func TestPostMatchesReturnsOppositeType(t *testing.T) {
+	base := makeTestVec(0.5)
+	near := makeTestVec(0.5001) // cosine ~1 with base
+	const srcID, wantedID, offerID, weakID, sameAuthorID = 850001, 850002, 850003, 850004, 850005
+	const u1, u2 = uint64(92001), uint64(92002)
+
+	embedding.Global.SetEntries([]embedding.Entry{
+		{Msgid: srcID, Fromuser: u1, Groupid: 100, Msgtype: "Offer", Lat: 51.5, Lng: -0.1, Subject: "Blue sofa", Arrival: time.Now(), SubjectVec: base},
+		{Msgid: wantedID, Fromuser: u2, Groupid: 100, Msgtype: "Wanted", Lat: 51.5, Lng: -0.1, Subject: "Want a sofa", Arrival: time.Now(), SubjectVec: near},
+		{Msgid: offerID, Fromuser: u2, Groupid: 100, Msgtype: "Offer", Lat: 51.5, Lng: -0.1, Subject: "Grey sofa", Arrival: time.Now(), SubjectVec: near},
+		{Msgid: weakID, Fromuser: u2, Groupid: 100, Msgtype: "Wanted", Lat: 51.5, Lng: -0.1, Subject: "unrelated noise", Arrival: time.Now(), SubjectVec: makeAntiparallelVec(0.5)},
+		{Msgid: sameAuthorID, Fromuser: u1, Groupid: 100, Msgtype: "Wanted", Lat: 51.5, Lng: -0.1, Subject: "Want another sofa", Arrival: time.Now(), SubjectVec: near},
+	})
+	defer embedding.Global.SetEntries(nil)
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/message/850001/matches", nil), 60000)
+	require.Equal(t, 200, resp.StatusCode)
+
+	var results []message.SimilarResult
+	json.NewDecoder(resp.Body).Decode(&results)
+
+	require.Len(t, results, 1, "only the opposite-type, above-threshold, different-author match qualifies")
+	assert.Equal(t, uint64(wantedID), results[0].Msgid)
+	assert.GreaterOrEqual(t, results[0].Score, float32(message.MinSimilarScore))
+	assert.NotZero(t, results[0].Lat, "lat populated (blurred)")
+	assert.NotZero(t, results[0].Lng, "lng populated (blurred)")
+	assert.Equal(t, uint64(100), results[0].Groupid)
+}
+
+// TestPostMatchesFlagOff: FEATURE_MATCHED_POSTS=off short-circuits to empty.
+func TestPostMatchesFlagOff(t *testing.T) {
+	t.Setenv("FEATURE_MATCHED_POSTS", "off")
+	base := makeTestVec(0.5)
+	near := makeTestVec(0.5001)
+	const srcID, wantedID = 851001, 851002
+	embedding.Global.SetEntries([]embedding.Entry{
+		{Msgid: srcID, Fromuser: 1, Groupid: 100, Msgtype: "Offer", Lat: 51.5, Lng: -0.1, Subject: "x", Arrival: time.Now(), SubjectVec: base},
+		{Msgid: wantedID, Fromuser: 2, Groupid: 100, Msgtype: "Wanted", Lat: 51.5, Lng: -0.1, Subject: "y", Arrival: time.Now(), SubjectVec: near},
+	})
+	defer embedding.Global.SetEntries(nil)
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/message/851001/matches", nil), 60000)
+	require.Equal(t, 200, resp.StatusCode)
+	var results []message.SimilarResult
+	json.NewDecoder(resp.Body).Decode(&results)
+	assert.Empty(t, results, "flag off → empty regardless of matches")
+}
+
+// TestPostMatchesNoEmbedding: a source id with no embedding row returns 200 +
+// empty, never a 500.
+func TestPostMatchesNoEmbedding(t *testing.T) {
+	embedding.Global.SetEntries(nil)
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/message/999999998/matches", nil), 60000)
+	require.Equal(t, 200, resp.StatusCode)
+	var results []message.SimilarResult
+	json.NewDecoder(resp.Body).Decode(&results)
+	assert.Empty(t, results)
+}
+
+// TestPostMatchesReachFilteredForOwner: reach is keyed on the POST's location,
+// not the caller's — so an unauthenticated (batch) request still drops a
+// candidate outside the post owner's reach, while a candidate with no reach row
+// is kept (fail-open).
+func TestPostMatchesReachFilteredForOwner(t *testing.T) {
+	t.Setenv("RIPPLE_ENABLED", "true")
+	db := database.DBConn
+	db.Exec(`CREATE TABLE IF NOT EXISTS rippling_reach (
+		msgid BIGINT UNSIGNED NOT NULL PRIMARY KEY,
+		lat DOUBLE NOT NULL, lng DOUBLE NOT NULL,
+		polygon GEOMETRY NOT NULL SRID 3857,
+		outer_bound GEOMETRY NULL SRID 3857,
+		status VARCHAR(16) NOT NULL DEFAULT 'expanding',
+		SPATIAL INDEX msgreach_poly (polygon)
+	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`)
+
+	prefix := uniquePrefix("postmatchesreach")
+	groupID := CreateTestGroup(t, prefix)
+	posterOut := CreateTestUser(t, prefix+"po", "Member")
+	// Out-of-reach candidate needs a real message row (rippling_reach FK).
+	outReachID := CreateTestMessage(t, posterOut, groupID, "out of reach wanted", 51.5, -0.1)
+
+	base := makeTestVec(0.5)
+	near := makeTestVec(0.5001)
+	const srcID, inReachID = 860001, 860002
+	const owner, other = uint64(93001), uint64(93002)
+	embedding.Global.SetEntries([]embedding.Entry{
+		{Msgid: srcID, Fromuser: owner, Groupid: 100, Msgtype: "Offer", Lat: 51.5, Lng: -0.1, Subject: "src sofa", Arrival: time.Now(), SubjectVec: base},
+		{Msgid: inReachID, Fromuser: other, Groupid: 100, Msgtype: "Wanted", Lat: 51.5, Lng: -0.1, Subject: "in reach want", Arrival: time.Now(), SubjectVec: near},
+		{Msgid: outReachID, Fromuser: posterOut, Groupid: 100, Msgtype: "Wanted", Lat: 51.5, Lng: -0.1, Subject: "out of reach want", Arrival: time.Now(), SubjectVec: near},
+	})
+	defer embedding.Global.SetEntries(nil)
+
+	db.Exec("DELETE FROM rippling_reach WHERE msgid IN (?, ?)", inReachID, outReachID)
+	db.Exec("INSERT INTO rippling_reach (msgid, lat, lng, polygon, outer_bound, status) VALUES (?, 51.5, -0.1, "+
+		"ST_GeomFromText('POLYGON((2.4 53.4, 2.6 53.4, 2.6 53.6, 2.4 53.6, 2.4 53.4))', 3857), "+
+		"ST_Envelope(ST_GeomFromText('POLYGON((2.4 53.4, 2.6 53.4, 2.6 53.6, 2.4 53.6, 2.4 53.4))', 3857)), 'expanding')", outReachID)
+	defer db.Exec("DELETE FROM rippling_reach WHERE msgid IN (?, ?)", inReachID, outReachID)
+
+	// Unauthenticated (batch) request — reach still applies, keyed on post location.
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/message/860001/matches", nil), 60000)
+	require.Equal(t, 200, resp.StatusCode)
+	var results []message.SimilarResult
+	json.NewDecoder(resp.Body).Decode(&results)
+	got := map[uint64]bool{}
+	for _, r := range results {
+		got[r.Msgid] = true
+	}
+	assert.True(t, got[uint64(inReachID)], "candidate with no reach row is kept (fail open)")
+	assert.False(t, got[uint64(outReachID)], "candidate outside the post owner's reach is dropped, even unauthenticated")
+}

--- a/iznik-server-go/test/relevantoff_test.go
+++ b/iznik-server-go/test/relevantoff_test.go
@@ -1,0 +1,58 @@
+package test
+
+import (
+	"fmt"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/freegle/iznik-server-go/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRelevantOffValidKey: a correct Link key turns off relevantallowed and the
+// GET returns a friendly 200 confirmation page.
+func TestRelevantOffValidKey(t *testing.T) {
+	prefix := uniquePrefix("relevantoff")
+	userID := CreateTestUser(t, prefix, "Member")
+	db := database.DBConn
+	db.Exec("UPDATE users SET relevantallowed = 1 WHERE id = ?", userID)
+	key := fmt.Sprintf("relkey%v", userID)
+	db.Exec("INSERT INTO users_logins (userid, type, uid, credentials) VALUES (?, ?, ?, ?)",
+		userID, utils.LOGIN_TYPE_LINK, fmt.Sprintf("%v", userID), key)
+	defer db.Exec("DELETE FROM users_logins WHERE userid = ? AND credentials = ?", userID, key)
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET",
+		fmt.Sprintf("/api/user/relevantoff?u=%v&k=%s", userID, key), nil), 60000)
+	require.Equal(t, 200, resp.StatusCode)
+
+	var ra int
+	db.Raw("SELECT relevantallowed FROM users WHERE id = ?", userID).Scan(&ra)
+	assert.Equal(t, 0, ra, "valid key turns relevantallowed off")
+}
+
+// TestRelevantOffBadKey: a wrong key is rejected (403) and the setting is unchanged.
+func TestRelevantOffBadKey(t *testing.T) {
+	prefix := uniquePrefix("relevantoffbad")
+	userID := CreateTestUser(t, prefix, "Member")
+	db := database.DBConn
+	db.Exec("UPDATE users SET relevantallowed = 1 WHERE id = ?", userID)
+	db.Exec("INSERT INTO users_logins (userid, type, uid, credentials) VALUES (?, ?, ?, ?)",
+		userID, utils.LOGIN_TYPE_LINK, fmt.Sprintf("%v", userID), "goodkey")
+	defer db.Exec("DELETE FROM users_logins WHERE userid = ? AND credentials = ?", userID, "goodkey")
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET",
+		fmt.Sprintf("/api/user/relevantoff?u=%v&k=WRONGKEY", userID), nil), 60000)
+	require.Equal(t, 403, resp.StatusCode)
+
+	var ra int
+	db.Raw("SELECT relevantallowed FROM users WHERE id = ?", userID).Scan(&ra)
+	assert.Equal(t, 1, ra, "a bad key must not change the setting")
+}
+
+// TestRelevantOffMissingParams: no u/k → 400.
+func TestRelevantOffMissingParams(t *testing.T) {
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/user/relevantoff", nil), 60000)
+	require.Equal(t, 400, resp.StatusCode)
+}

--- a/iznik-server-go/user/relevantoff.go
+++ b/iznik-server-go/user/relevantoff.go
@@ -1,0 +1,64 @@
+package user
+
+import (
+	"strconv"
+
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/freegle/iznik-server-go/utils"
+	"github.com/gofiber/fiber/v2"
+)
+
+// RelevantOff turns off the matched-posts / "suggestion" emails for a user
+// (users.relevantallowed = 0) — a TARGETED opt-out, not a full account
+// unsubscribe. It is authenticated by the user's auto-login Link key (the same
+// key mechanism as the login/forget links) so it works with no session: as a
+// one-click List-Unsubscribe (RFC 8058 POST) from Gmail/Yahoo, and as a plain
+// footer link (GET) the recipient can click in a browser.
+//
+// @Router /user/relevantoff [get]
+// @Summary Turn off matched-posts suggestion emails (relevantallowed=0)
+// @Tags user
+// @Param u query int true "User ID"
+// @Param k query string true "Auto-login Link key"
+// @Success 200
+func RelevantOff(c *fiber.Ctx) error {
+	uidStr := c.Query("u")
+	if uidStr == "" {
+		uidStr = c.FormValue("u")
+	}
+	key := c.Query("k")
+	if key == "" {
+		key = c.FormValue("k")
+	}
+
+	uid, _ := strconv.ParseUint(uidStr, 10, 64)
+	if uid == 0 || key == "" {
+		return fiber.NewError(fiber.StatusBadRequest, "Missing u or k")
+	}
+
+	db := database.DBConn
+
+	// Validate the Link key (constant-ish: single indexed read then compare).
+	var storedKey string
+	db.Raw("SELECT credentials FROM users_logins WHERE userid = ? AND type = ? LIMIT 1",
+		uid, utils.LOGIN_TYPE_LINK).Scan(&storedKey)
+	if storedKey == "" || storedKey != key {
+		return fiber.NewError(fiber.StatusForbidden, "Invalid key")
+	}
+
+	db.Exec("UPDATE users SET relevantallowed = 0 WHERE id = ?", uid)
+
+	// One-click (POST from a mail client) wants a 200; a browser click (GET)
+	// gets a friendly confirmation page.
+	if c.Method() == fiber.MethodGet {
+		c.Set("Content-Type", "text/html; charset=utf-8")
+		return c.SendString(
+			"<!doctype html><html><head><meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">" +
+				"<title>Unsubscribed</title></head>" +
+				"<body style=\"font-family:sans-serif;max-width:32rem;margin:3rem auto;padding:0 1rem;color:#333\">" +
+				"<h2 style=\"color:#338808\">Done</h2>" +
+				"<p>You won't receive any more suggestion emails from Freegle about posts matching what you've offered or asked for.</p>" +
+				"<p>You can turn them back on any time in your Freegle settings.</p></body></html>")
+	}
+	return c.JSON(fiber.Map{"ret": 0, "status": "Success"})
+}


### PR DESCRIPTION
## Summary

Resurrects the old matched-posts feature (V1 `cron/relevant.php`, "Any of these take your fancy?"), rebuilt on the **vector** embeddings instead of keyword search. For each recently-arrived Offer/Wanted it notifies the people who care — the poster ("here are offers near you matching your wanted", and vice versa) and the owners of posts it matches ("a new post matches your open offer/wanted").

- **New apiv2 endpoint** `GET /message/{id}/matches` — opposite-type posts near a given post from the in-memory vector store (bbox-scoped, reach-filtered against the *post owner* so the unauthenticated batch caller still gets correct reach, above `MinSimilarScore`). Killswitch `FEATURE_MATCHED_POSTS`.
- **`matches:notify`** Laravel command, scheduled **every 10 minutes**. Arrival-driven: only posts that arrived in the last ~20 min drive the run (~100/run on prod, validated against the live DB), so it's cheap. One vector search per fresh post feeds **both** notification directions.
- **Multi-channel delivery**: to every eligible recipient it sends an **in-app (bell) notification** (a `users_notifications` row of the new `type='MatchedPost'`, rendered by `NotificationMatchedPost.vue`) plus a **device push** (`PushNotificationService::notifyUser`, a no-op when the member has no registered app device) — the primary channel, delivered regardless of email — **and an email** (`App\Mail\Matched\MatchedPosts`, adaptive hero-card / compact-list layout, colour-coded by direction) when the member has an address. The notification title mirrors the email subject.
- **Reach-exact for every recipient**: a shown match is kept only if it's in apiv2's `matchesForPost` for the recipient's *own* post that it matched (which reach-filters against that recipient). Direction (i) is free; direction (ii) costs one extra apiv2 call per recipient post — a match that hasn't rippled out to the recipient is dropped, never delivered on bbox proximity alone.
- **Never delivered twice**: a per-`(msgid, userid)` ledger (`messages_matched_notified`, same "impossible by construction" pattern as `rippling_reach_notified`) shared across both channels; never a post the member already **clicked to view** (`messages_likes` `View` + `pageview=1`, so a feed scroll-past doesn't count); a per-user ~4h cooldown (`users.lastrelevantcheck`); never their own posts, taken/deleted/unapproved posts, or opted-out members (`users.relevantallowed`).
- **One-click, targeted opt-out**: new apiv2 `GET|POST /user/relevantoff?u=&k=` sets `relevantallowed=0`, authenticated by the user's `users_logins` Link key (minted by `LoginLinkService`). The email points both its RFC 8058 `List-Unsubscribe` header (one-click) and a visible footer link at it, so a member can stop *just these* without unsubscribing the whole account.

This is a **separate** feature from the daily digest's relevance ranking (`FEATURE_DIGEST_RELEVANCE`, PR #956), which is deliberately left untouched.

## Screenshots

Email rendered in Mailpit via `php artisan mail:test matched`.

**Single match (hero layout):**

![Matched-posts email, single match](https://raw.githubusercontent.com/Freegle/Iznik/pr-assets/matched-posts-email/matched-hero.png)

**Multiple matches (list layout — colour-coded by direction: green "matches your wanted" / blue "matches your offer"):**

![Matched-posts email, multiple matches](https://raw.githubusercontent.com/Freegle/Iznik/pr-assets/matched-posts-email/matched-list.png)

_(The `pr-assets/matched-posts-email` branch is throwaway — delete after merge.)_

## Code Quality Review

- Reuses the existing vector store (`embedding.Global.Search`), the `FreegleApiClient`, the `MjmlMailable`/`TrackableEmail`/`AvatarResolver` machinery, `SubjectParser`, the `PushNotificationService`/`users_notifications` notification path (the `NotificationExhortService` "insert row + `notifyUser`" pattern), and the `rippling_reach_notified` ledger idiom — no new infrastructure.
- The `UnifiedDigest` mailable (1.3k lines, heavily tested) is **not** touched; the matched email has its own lean, self-contained card so the two can evolve independently.
- Vector maths stays in Go (where the vectors live in RAM); Laravel only orchestrates and resolves surrounding data from its own DB. There is no SQL KNN.
- The driver query filters on the authoritative `messages.type` and is bounded by the `messages_groups.arrival` index; exclusion checks are keyed point-reads.
- `MjmlMailable`'s List-Unsubscribe URL is overridable via `listUnsubscribeUrl()` (default unchanged for other mailables); `MatchedPosts` overrides it for the targeted opt-out and carries the standard `X-Freegle-*` tracking + `List-Unsubscribe` headers.
- The `users_notifications.type` enum value is appended at the end (metadata-only `ALGORITHM=INSTANT`); an unknown notification type otherwise renders as "Unknown notification …", so the `NotificationMatchedPost.vue` component is registered in `NotificationOne.vue`.

## Test Plan

- **Go** — full suite green. `/message/:id/matches`: opposite-type only, flag-off, no-embedding, reach keyed on the post owner even when unauthenticated. `/user/relevantoff`: valid key turns it off, bad key rejected (403, unchanged), missing params (400).
- **Laravel** — full suite green; matched filter (12). Service: both-direction fan-out; a direction-(ii) match outside the recipient's reach is dropped; excludes already-mailed, clicked (`pageview=1`, not scroll-past), opted-out, within-cooldown. Command: creates the `MatchedPost` bell row (`url = /message/{id}`) and fires the push; dry-run creates neither; ledger + cooldown written. `FreegleApiClient::matchesForPost`, `LoginLinkService`, subject (single vs "Freegle matches for you"). Mailpit integration: renders, delivers, non-spam, carries the opt-out link + `List-Unsubscribe` header.
- **Vitest** — `NotificationMatchedPost.vue` (renders title/text/icon, omits text when empty, requires id).
- **Visual**: both email layouts reviewed in Mailpit; opt-out header/link verified live.
