### PR TITLE
fix(login): don't conflate a DB lookup error with unknown-email/wrong-password

### DIFF
--- a/iznik-server-go/auth/auth.go
+++ b/iznik-server-go/auth/auth.go
@@ -20,6 +20,7 @@ import (
 	"github.com/freegle/iznik-server-go/utils"
 	"github.com/gofiber/fiber/v2"
 	"github.com/golang-jwt/jwt/v4"
+	"gorm.io/gorm"
 )
 
 // PersistentToken represents the old-style session token from the Authorization2 header.
@@ -241,14 +242,23 @@ func GetPasswordSalt() string {
 
 // VerifyPassword checks a plaintext password against a user's stored Native login.
 // We filter by userid only (not uid) because some legacy Native logins have NULL uid.
-func VerifyPassword(userID uint64, password string) bool {
-	db := database.DBConn
-
+//
+// Returns a non-nil error when the credentials lookup itself failed (a backend
+// problem) - retried via database.RetryQuery for transient connection errors.
+// Callers must not treat that the same as "password did not match": a DB error
+// here is a different failure mode from a wrong password and must be reported
+// as a backend failure, not a false claim about the supplied credentials
+// (Discourse #9941 - the same swallowed-error pattern that misreported the
+// email lookup as "unknown email" existed here too, one call further into the
+// same login path).
+func VerifyPassword(db *gorm.DB, userID uint64, password string) (bool, error) {
 	var logins []struct {
 		Credentials string
 		Salt        string
 	}
-	db.Raw("SELECT credentials, salt FROM users_logins WHERE userid = ? AND type = ? ORDER BY lastaccess DESC", userID, utils.LOGIN_TYPE_NATIVE).Scan(&logins)
+	if err := database.RetryQuery(db, &logins, "SELECT credentials, salt FROM users_logins WHERE userid = ? AND type = ? ORDER BY lastaccess DESC", userID, utils.LOGIN_TYPE_NATIVE); err != nil {
+		return false, err
+	}
 
 	for _, login := range logins {
 		if login.Credentials == "" {
@@ -260,10 +270,10 @@ func VerifyPassword(userID uint64, password string) bool {
 		}
 		hashed := HashPassword(password, salt)
 		if strings.EqualFold(hashed, login.Credentials) {
-			return true
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
 }
 
 // CreateSessionAndJWT creates a sessions row and returns the persistent token data and a JWT.

--- a/iznik-server-go/session/session.go
+++ b/iznik-server-go/session/session.go
@@ -357,6 +357,57 @@ func PostSession(c *fiber.Ctx) error {
 	}
 }
 
+// LookupUserIDByEmail resolves a login email to a user id. A non-nil error means
+// the lookup itself failed (a backend problem) and must never be treated the same
+// as "zero rows found" (a genuinely unknown email). Exported so it can be unit
+// tested in isolation, without exercising the whole HTTP request pipeline
+// (Discourse #9941: a swallowed lookup error was misreported as "we don't know
+// that email address").
+func LookupUserIDByEmail(db *gorm.DB, email string) (uint64, error) {
+	var userID uint64
+	err := database.RetryQuery(db, &userID, "SELECT u.id FROM users u "+
+		"JOIN users_emails ue ON ue.userid = u.id "+
+		"WHERE ue.email = ? "+
+		"LIMIT 1", email)
+	return userID, err
+}
+
+// LookupUserAndEmailByEmail is like LookupUserIDByEmail but also returns the
+// stored (canonical) form of the matched address, needed by handleLostPassword to
+// send the reset link to the exact address the user typed. Exported for the same
+// isolation-testing reason as LookupUserIDByEmail.
+func LookupUserAndEmailByEmail(db *gorm.DB, email string) (uint64, string, error) {
+	var match struct {
+		ID    uint64 `gorm:"column:id"`
+		Email string `gorm:"column:email"`
+	}
+	err := database.RetryQuery(db, &match, "SELECT users.id, users_emails.email FROM users "+
+		"INNER JOIN users_emails ON users_emails.userid = users.id "+
+		"WHERE users_emails.email = ? "+
+		"LIMIT 1", email)
+	return match.ID, match.Email, err
+}
+
+// LookupUserExists reports whether a user id exists. A non-nil error means the
+// check itself failed and must not be reported as "unknown user". Exported for
+// isolation testing.
+func LookupUserExists(db *gorm.DB, uid uint64) (bool, error) {
+	var exists uint64
+	err := database.RetryQuery(db, &exists, "SELECT id FROM users WHERE id = ? LIMIT 1", uid)
+	return exists != 0, err
+}
+
+// LookupLinkCredentials returns the stored auto-login key for a user (empty
+// string if none set). Shared by handleLinkLogin (verifying a supplied key) and
+// getOrCreateLoginKey (finding an existing key before minting a new one) - a DB
+// error here must not be treated as "no key exists yet", which would mint a
+// spurious duplicate credentials row. Exported for isolation testing.
+func LookupLinkCredentials(db *gorm.DB, uid uint64) (string, error) {
+	var key string
+	err := database.RetryQuery(db, &key, "SELECT credentials FROM users_logins WHERE userid = ? AND type = ? LIMIT 1", uid, utils.LOGIN_TYPE_LINK)
+	return key, err
+}
+
 // handleLostPassword finds the user by email and queues a forgot-password email.
 func handleLostPassword(c *fiber.Ctx, email string) error {
 	if email == "" {
@@ -370,15 +421,10 @@ func handleLostPassword(c *fiber.Ctx, email string) error {
 	// (canonical) form of the matched address so we send the login link to the
 	// exact email the user used - not their preferred address, which may differ
 	// and may be the one that is bouncing.
-	var match struct {
-		ID    uint64 `gorm:"column:id"`
-		Email string `gorm:"column:email"`
+	userID, matchEmail, err := LookupUserAndEmailByEmail(db, email)
+	if err != nil {
+		return fiber.NewError(fiber.StatusInternalServerError, "Failed to look up email address")
 	}
-	db.Raw("SELECT users.id, users_emails.email FROM users "+
-		"INNER JOIN users_emails ON users_emails.userid = users.id "+
-		"WHERE users_emails.email = ? "+
-		"LIMIT 1", email).Scan(&match)
-	userID := match.ID
 
 	if userID == 0 {
 		// Return ret=2 for unknown email.
@@ -423,7 +469,7 @@ func handleLostPassword(c *fiber.Ctx, email string) error {
 
 	// Send the login link to the address the user actually used. Prefer the
 	// canonical stored form of the matched address; fall back to the typed value.
-	destEmail := match.Email
+	destEmail := matchEmail
 	if destEmail == "" {
 		destEmail = email
 	}
@@ -452,11 +498,10 @@ func handleUnsubscribe(c *fiber.Ctx, email string) error {
 	db := database.DBConn
 
 	// Find user by email. Deleted users can still unsubscribe.
-	var userID uint64
-	db.Raw("SELECT users.id FROM users "+
-		"INNER JOIN users_emails ON users_emails.userid = users.id "+
-		"WHERE users_emails.email = ? "+
-		"LIMIT 1", email).Scan(&userID)
+	userID, err := LookupUserIDByEmail(db, email)
+	if err != nil {
+		return fiber.NewError(fiber.StatusInternalServerError, "Failed to look up email address")
+	}
 
 	if userID == 0 {
 		// Return unknown:true so the frontend can branch to a "Contact support" fallback
@@ -511,8 +556,10 @@ func getOrCreateLoginKey(userID uint64) (string, error) {
 	db := database.DBConn
 
 	// Check for existing key.
-	var existingKey string
-	db.Raw("SELECT credentials FROM users_logins WHERE userid = ? AND type = ? LIMIT 1", userID, utils.LOGIN_TYPE_LINK).Scan(&existingKey)
+	existingKey, err := LookupLinkCredentials(db, userID)
+	if err != nil {
+		return "", err
+	}
 
 	if existingKey != "" {
 		return existingKey, nil
@@ -536,11 +583,10 @@ func handleEmailPasswordLogin(c *fiber.Ctx, email string, password string) error
 
 	// Find user by email. Deleted users can still log in so they see the
 	// "restore your account" banner.
-	var userID uint64
-	db.Raw("SELECT u.id FROM users u "+
-		"JOIN users_emails ue ON ue.userid = u.id "+
-		"WHERE ue.email = ? "+
-		"LIMIT 1", email).Scan(&userID)
+	userID, err := LookupUserIDByEmail(db, email)
+	if err != nil {
+		return fiber.NewError(fiber.StatusInternalServerError, "Failed to look up email address")
+	}
 
 	if userID == 0 {
 		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
@@ -549,7 +595,11 @@ func handleEmailPasswordLogin(c *fiber.Ctx, email string, password string) error
 		})
 	}
 
-	if !auth.VerifyPassword(userID, password) {
+	verified, err := auth.VerifyPassword(db, userID, password)
+	if err != nil {
+		return fiber.NewError(fiber.StatusInternalServerError, "Failed to verify credentials")
+	}
+	if !verified {
 		return c.Status(fiber.StatusForbidden).JSON(fiber.Map{
 			"ret":    3,
 			"status": "The password is wrong.",
@@ -575,10 +625,12 @@ func handleLinkLogin(c *fiber.Ctx, uid uint64, key string) error {
 
 	// Verify the user exists. Deleted users can still log in so they see the
 	// "restore your account" banner.
-	var exists uint64
-	db.Raw("SELECT id FROM users WHERE id = ? LIMIT 1", uid).Scan(&exists)
+	exists, err := LookupUserExists(db, uid)
+	if err != nil {
+		return fiber.NewError(fiber.StatusInternalServerError, "Failed to look up user")
+	}
 
-	if exists == 0 {
+	if !exists {
 		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
 			"ret":    2,
 			"status": "Unknown user.",
@@ -586,8 +638,10 @@ func handleLinkLogin(c *fiber.Ctx, uid uint64, key string) error {
 	}
 
 	// Verify the link key.
-	var storedKey string
-	db.Raw("SELECT credentials FROM users_logins WHERE userid = ? AND type = ? LIMIT 1", uid, utils.LOGIN_TYPE_LINK).Scan(&storedKey)
+	storedKey, err := LookupLinkCredentials(db, uid)
+	if err != nil {
+		return fiber.NewError(fiber.StatusInternalServerError, "Failed to look up login key")
+	}
 
 	if storedKey == "" || subtle.ConstantTimeCompare([]byte(storedKey), []byte(key)) != 1 {
 		return c.Status(fiber.StatusForbidden).JSON(fiber.Map{

--- a/iznik-server-go/test/login_dberror_test.go
+++ b/iznik-server-go/test/login_dberror_test.go
@@ -1,0 +1,70 @@
+package test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/freegle/iznik-server-go/auth"
+	"github.com/freegle/iznik-server-go/session"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/mysql"
+	"gorm.io/gorm"
+)
+
+// brokenLookupDB opens a *fresh, independent* connection pointed at the
+// (always-present) information_schema database, which has no `users` or
+// `users_logins` tables. The connection itself succeeds - only queries against
+// those tables fail - so this deterministically reproduces "lookup ERRORED",
+// as distinct from "lookup found no rows", without relying on flaky
+// network-level failures.
+//
+// Crucially this does NOT touch database.DBConn: it is a standalone *gorm.DB
+// passed directly into the function under test, so only that one call is
+// affected. Nothing else in the process - middleware, other queries, other
+// tests - is touched. This is a regression test for Discourse #9941 post 1,
+// where a previous attempt at this fix swapped the global database.DBConn for
+// the whole request, breaking every query in the pipeline rather than
+// isolating the one lookup being tested.
+func brokenLookupDB(t *testing.T) *gorm.DB {
+	dsn := fmt.Sprintf(
+		"%s:%s@%s(%s:%s)/information_schema?charset=utf8mb4&parseTime=True&loc=Local&interpolateParams=true",
+		os.Getenv("MYSQL_USER"), os.Getenv("MYSQL_PASSWORD"), os.Getenv("MYSQL_PROTOCOL"),
+		os.Getenv("MYSQL_HOST"), os.Getenv("MYSQL_PORT"),
+	)
+	badDB, err := gorm.Open(mysql.Open(dsn), &gorm.Config{})
+	require.NoError(t, err, "connecting to information_schema should succeed - only queries against users/users_logins should fail")
+	return badDB
+}
+
+func TestLookupUserIDByEmail_DBErrorNotConfusedWithUnknownEmail(t *testing.T) {
+	userID, err := session.LookupUserIDByEmail(brokenLookupDB(t), "doesnt-matter-9941@example.com")
+	assert.Error(t, err, "a DB error must be surfaced, not silently treated as zero rows found")
+	assert.Equal(t, uint64(0), userID)
+}
+
+func TestLookupUserAndEmailByEmail_DBErrorNotConfusedWithUnknownEmail(t *testing.T) {
+	userID, email, err := session.LookupUserAndEmailByEmail(brokenLookupDB(t), "doesnt-matter-9941@example.com")
+	assert.Error(t, err, "a DB error must be surfaced, not silently treated as zero rows found")
+	assert.Equal(t, uint64(0), userID)
+	assert.Equal(t, "", email)
+}
+
+func TestLookupUserExists_DBErrorNotConfusedWithUnknownUser(t *testing.T) {
+	exists, err := session.LookupUserExists(brokenLookupDB(t), 123456789)
+	assert.Error(t, err, "a DB error must be surfaced, not silently treated as the user not existing")
+	assert.False(t, exists)
+}
+
+func TestLookupLinkCredentials_DBErrorNotConfusedWithNoKey(t *testing.T) {
+	key, err := session.LookupLinkCredentials(brokenLookupDB(t), 123456789)
+	assert.Error(t, err, "a DB error must be surfaced, not silently treated as no key set")
+	assert.Equal(t, "", key)
+}
+
+func TestVerifyPassword_DBErrorNotConfusedWithWrongPassword(t *testing.T) {
+	verified, err := auth.VerifyPassword(brokenLookupDB(t), 123456789, "whatever")
+	assert.Error(t, err, "a DB error must be surfaced, not silently treated as a wrong password")
+	assert.False(t, verified)
+}

--- a/iznik-server-go/user/user.go
+++ b/iznik-server-go/user/user.go
@@ -1868,18 +1868,24 @@ func PutUser(c *fiber.Ctx) error {
 
 		// If they provided a correct password, treat signup as login — avoids
 		// forcing users to switch to the login screen and re-enter credentials.
-		if req.Password != "" && auth.VerifyPassword(existingUID, req.Password) {
-			persistent, jwtString, err := auth.CreateSessionAndJWT(existingUID)
+		if req.Password != "" {
+			verified, err := auth.VerifyPassword(db, existingUID, req.Password)
 			if err != nil {
-				return fiber.NewError(fiber.StatusInternalServerError, "Failed to create session")
+				return fiber.NewError(fiber.StatusInternalServerError, "Failed to verify credentials")
 			}
-			return c.JSON(fiber.Map{
-				"ret":        0,
-				"status":     "Success",
-				"id":         existingUID,
-				"persistent": persistent,
-				"jwt":        jwtString,
-			})
+			if verified {
+				persistent, jwtString, err := auth.CreateSessionAndJWT(existingUID)
+				if err != nil {
+					return fiber.NewError(fiber.StatusInternalServerError, "Failed to create session")
+				}
+				return c.JSON(fiber.Map{
+					"ret":        0,
+					"status":     "Success",
+					"id":         existingUID,
+					"persistent": persistent,
+					"jwt":        jwtString,
+				})
+			}
 		}
 
 		return c.Status(fiber.StatusConflict).JSON(fiber.Map{


### PR DESCRIPTION
## Root Cause
`PostSession`'s login-related handlers (`handleEmailPasswordLogin`, `handleLostPassword`, `handleUnsubscribe`, `handleLinkLogin`) and `auth.VerifyPassword` each looked up a user with a bare `db.Raw(...).Scan(&x)`, discarding the query's own error. When the lookup query itself errored (not just found zero rows), the destination variable stayed at its Go zero value and was reported identically to "genuinely not found": `ret:2 "We don't know that email address."` for `handleEmailPasswordLogin`'s email lookup - the exact string in the report - or `ret:3 "The password is wrong."` from `VerifyPassword` one call further into the same path.

This matches the report: a ModTools session crashed mid-navigation; on reopening the reporter was shown the login page, entered correct credentials, got "We don't know that email address.", then the same credentials worked moments later with no other change (Discourse #9941 post 1).

**Prior attempts on this bug** (#1119, #1121, both closed): #1119 fixed only `handleEmailPasswordLogin`'s own lookup and was rejected as a partial implementation (the identical pattern existed in sibling handlers in the same dispatcher) with a test that broke the whole request pipeline instead of isolating the one lookup. #1121 extracted the lookups into isolated, unit-testable functions across the whole dispatcher (correctly addressing both prior criticisms) but was auto-closed because the agent timed out before completing verification/self-review - not because the diagnosis was wrong. This PR independently re-verified that diagnosis against the current code (confirmed the recent read-replica failover/read-write-split changes that motivate it, confirmed `database.RetryQuery` still exists with zero callers) and completes the fix with full AssertFlip evidence and a clean full regression run.

## Evidence
AssertFlip: 5 new tests, each opening an independent `*gorm.DB` pointed at `information_schema` (has no `users`/`users_logins` tables - the connection succeeds, only the query errors, deterministically reproducing "lookup ERRORED" distinct from "lookup found no rows" without touching `database.DBConn` or any other part of the pipeline).

Run against the pre-fix code (lookups extracted into functions but still using a bare `db.Raw().Scan()`, i.e. current buggy behaviour):
```
=== RUN   TestLookupUserIDByEmail_DBErrorNotConfusedWithUnknownEmail
    Error: An error is expected but got nil.
--- FAIL: TestLookupUserIDByEmail_DBErrorNotConfusedWithUnknownEmail (0.00s)
=== RUN   TestLookupUserAndEmailByEmail_DBErrorNotConfusedWithUnknownEmail
    Error: An error is expected but got nil.
--- FAIL: TestLookupUserAndEmailByEmail_DBErrorNotConfusedWithUnknownEmail (0.00s)
=== RUN   TestLookupUserExists_DBErrorNotConfusedWithUnknownUser
    Error: An error is expected but got nil.
--- FAIL: TestLookupUserExists_DBErrorNotConfusedWithUnknownUser (0.00s)
=== RUN   TestLookupLinkCredentials_DBErrorNotConfusedWithNoKey
    Error: An error is expected but got nil.
--- FAIL: TestLookupLinkCredentials_DBErrorNotConfusedWithNoKey (0.00s)
=== RUN   TestVerifyPassword_DBErrorNotConfusedWithWrongPassword
    Error: An error is expected but got nil.
--- FAIL: TestVerifyPassword_DBErrorNotConfusedWithWrongPassword (0.00s)
FAIL	iznik-server-go/test	10.318s
```
With the fix applied (bare `Scan()` replaced by `database.RetryQuery`), all 5 pass:
```
--- PASS: TestLookupUserIDByEmail_DBErrorNotConfusedWithUnknownEmail (0.00s)
--- PASS: TestLookupUserAndEmailByEmail_DBErrorNotConfusedWithUnknownEmail (0.00s)
--- PASS: TestLookupUserExists_DBErrorNotConfusedWithUnknownUser (0.00s)
--- PASS: TestLookupLinkCredentials_DBErrorNotConfusedWithNoKey (0.00s)
--- PASS: TestVerifyPassword_DBErrorNotConfusedWithWrongPassword (0.00s)
PASS	iznik-server-go/test	0.194s
```
Full suite (`go test ./...`, isolated DB, fresh schema clone) passes clean with the fix applied - confirmed both against this branch and against an unmodified master baseline in the same environment (a couple of unrelated tests - browse/bulk-offer-stats/email-tracking, nothing touching login/session/auth - showed transient failures on earlier runs and passed on rerun with no code change; a clean rerun of the full suite reproduced zero failures on both master and this branch, confirming pre-existing test-parallelism flakiness unrelated to this change).

## Fix
Extracted each lookup into a small, exported, dependency-injected function taking `db *gorm.DB` explicitly, using `database.RetryQuery` (already existed in `database/retry.go` for exactly this purpose - mirrors V1's `LoggedPDO::prex()` retry-on-transient-connection-error behaviour - but had zero callers anywhere before this change):
- `LookupUserIDByEmail`, `LookupUserAndEmailByEmail`, `LookupUserExists`, `LookupLinkCredentials` (session/session.go)
- `auth.VerifyPassword` now takes `db` explicitly and returns `(bool, error)`

Every one of `handleEmailPasswordLogin`, `handleLostPassword`, `handleUnsubscribe`, `handleLinkLogin`, the shared `getOrCreateLoginKey` helper, and `auth.VerifyPassword` now propagates a lookup error as a `500` backend failure instead of misreporting it as "unknown email" / "unknown user" / "wrong password". A genuinely unknown email/user (query succeeds, zero rows) is unaffected - still returns the same `ret` codes as before.

No new account-existence disclosure: a DB error happens at query-execution time regardless of whether the email/user actually exists, so the new 500 response is not correlated with account existence - it strictly removes a case where a backend failure leaked as "unknown", it doesn't add a new distinguishing signal.

## Other Call Sites
The same "bare `db.Raw(...).Scan()`, error discarded, zero value treated as not-found" pattern is pervasive elsewhere (428 occurrences repo-wide) but out of scope for this fix - a repo-wide sweep is a separate, much larger change. This PR fixes every instance in the credential/account lookup chain reachable from `PostSession`'s login/lost-password/unsubscribe/link-login dispatch (the exact scope the first review flagged as incomplete), plus `auth.VerifyPassword` one call further into that same chain. `user.PutUser`'s call site of `VerifyPassword` was updated only for the new signature. Secondary, non-authorization lookups within the same handlers (e.g. `handleLostPassword`'s native/social login-type check, `handleUnsubscribe`'s preferred-email-for-sending lookup) are untouched - a failure there doesn't produce a false "unknown"/"wrong password" claim.

## Test
- File: `iznik-server-go/test/login_dberror_test.go` (new)
- Tests: `TestLookupUserIDByEmail_DBErrorNotConfusedWithUnknownEmail`, `TestLookupUserAndEmailByEmail_DBErrorNotConfusedWithUnknownEmail`, `TestLookupUserExists_DBErrorNotConfusedWithUnknownUser`, `TestLookupLinkCredentials_DBErrorNotConfusedWithNoKey`, `TestVerifyPassword_DBErrorNotConfusedWithWrongPassword`
- Command: `go test ./test/... -run 'TestLookup|TestVerifyPassword_DBError' -v`
- Fail-before/pass-after: see Evidence above.
- Full regression: `go test ./...` (all packages) passes clean against a freshly-migrated test database.

## Discourse
https://discourse.ilovefreegle.org/t/9941/1