### PR TITLE
fix(monitor-fsm): stop the nonsensical 'please retest' auto-reply on a confirmed post (9932/8)

### DIFF
--- a/monitor-fsm/src/__tests__/actions.persist_classifications.test.ts
+++ b/monitor-fsm/src/__tests__/actions.persist_classifications.test.ts
@@ -42,6 +42,55 @@ describe('persist_classifications action', () => {
     expect(bug?.reporter).toBe('alice')
   })
 
+  it('treats a confirming retest of an already-fixed bug as success feedback, not a regression', async () => {
+    // Original bug, already fixed by a PR.
+    upsertDiscourseBug(db, {
+      topic: 9932, post: 1, reporter: 'Derek', state: 'fixed', prNumber: 1108,
+      symptomTags: ['mapping', 'centre-point'], featureArea: 'group mapping',
+    })
+    db.prepare(`UPDATE discourse_bug SET fixed_at = datetime('now') WHERE topic = 9932 AND post = 1`).run()
+
+    const result = await persistClassificationsHandler({}, {
+      classifications: [
+        {
+          topic: 9932, post: 7, type: 'retest', user: 'Derek',
+          summary: 'Derek confirms the centre point now saves and the Wales link works',
+          originalPostText: 'Thanks Centre point now showing and the Wales click takes me to Wales',
+          symptom_tags: ['mapping', 'centre-point'], code_area: 'nuxt:Mapping',
+        },
+      ],
+    })
+
+    // The confirmation must NOT become a new (regression) bug that would draw a
+    // "please retest" auto-reply on the post that confirmed the fix.
+    expect(getDiscourseBug(db, 9932, 7)).toBeNull()
+    expect(result.skipped).toBe(1)
+    expect(getDiscourseBug(db, 9932, 1)?.state).toBe('fixed')
+  })
+
+  it('still flags a STILL-BROKEN retest of a fixed bug as a regression', async () => {
+    upsertDiscourseBug(db, {
+      topic: 940, post: 1, reporter: 'sam', state: 'fixed', prNumber: 500,
+      symptomTags: ['login', 'crash'], featureArea: 'login',
+    })
+    db.prepare(`UPDATE discourse_bug SET fixed_at = datetime('now') WHERE topic = 940 AND post = 1`).run()
+
+    await persistClassificationsHandler({}, {
+      classifications: [
+        {
+          topic: 940, post: 4, type: 'retest', user: 'sam',
+          summary: 'still crashing on login', originalPostText: 'Tried again and it is still not working',
+          symptom_tags: ['login', 'crash'], code_area: 'go-api:Login',
+        },
+      ],
+    })
+
+    // A genuine still-broken retest IS persisted (flagged as a regression).
+    const row = getDiscourseBug(db, 940, 4)
+    expect(row).not.toBeNull()
+    expect(row?.state).toBe('deferred')
+  })
+
   it('accepts post_number as alias for post', async () => {
     const result = await persistClassificationsHandler({}, {
       classifications: [{ topic: 124, post_number: 2, type: 'bug', user: 'bob' }],

--- a/monitor-fsm/src/actions/index.ts
+++ b/monitor-fsm/src/actions/index.ts
@@ -267,10 +267,28 @@ export async function fetchReporterQuote(topicId: number, postNumber: number, ma
   try {
     const resp = await fetch(`${DISCOURSE_BASE}/t/${topicId}.json`, { headers: { 'Api-Key': apiKey } })
     if (!resp.ok) return ''
-    const j = (await resp.json()) as { post_stream?: { posts?: Array<{ post_number: number; cooked?: string }> } }
-    const post = j.post_stream?.posts?.find((p) => p.post_number === postNumber)
-    if (!post?.cooked) return ''
-    let text = post.cooked
+    const j = (await resp.json()) as {
+      posts_count?: number
+      highest_post_number?: number
+      post_stream?: { posts?: Array<{ post_number: number; cooked?: string }>; stream?: number[] }
+    }
+    let cooked = j.post_stream?.posts?.find((p) => p.post_number === postNumber)?.cooked
+    if (!cooked) {
+      // The reporting post isn't on the topic's first page (~20 posts). Resolve
+      // its id from the stream (anchored from the end so mid-thread deletions
+      // don't shift the index) and fetch that specific post, rather than silently
+      // falling back to our summary.
+      const stream = j.post_stream?.stream ?? []
+      const highest = j.highest_post_number ?? j.posts_count ?? stream.length
+      const idx = stream.length - 1 - (highest - postNumber)
+      const postId = idx >= 0 && idx < stream.length ? stream[idx] : undefined
+      if (postId) {
+        const r2 = await fetch(`${DISCOURSE_BASE}/posts/${postId}.json`, { headers: { 'Api-Key': apiKey } })
+        if (r2.ok) cooked = ((await r2.json()) as { cooked?: string }).cooked
+      }
+    }
+    if (!cooked) return ''
+    let text = cooked
       .replace(/<aside[\s\S]*?<\/aside>/gi, ' ') // drop nested quote blocks — never quote a quote
       .replace(/<[^>]+>/g, ' ')
       .replace(/&amp;/g, '&')
@@ -283,6 +301,22 @@ export async function fetchReporterQuote(topicId: number, postNumber: number, ma
   } catch {
     return ''
   }
+}
+
+/**
+ * A "retest" post can either CONFIRM a fix works ("showing now, thanks") or
+ * report it is STILL BROKEN. Only the latter, against an already-fixed bug, is a
+ * regression; a positive confirmation is success feedback. Misreading a
+ * confirmation as a regression creates a bogus bug that then draws a nonsensical
+ * "please retest" auto-reply on the very post that confirmed the fix (topic
+ * 9932/8). "still broken" wins if both are present ("thanks but still not
+ * working").
+ */
+export function retestConfirmsFix(text: string): boolean {
+  const t = (text || '').toLowerCase()
+  const stillBroken = /\b(still|not working|does ?n'?t work|no better|same (problem|issue|thing)|not fixed|worse|broken|spoke too soon|back again|happening again)\b/.test(t)
+  if (stillBroken) return false
+  return /\b(works? now|working now|now works?|fixed|resolved|sorted|all good|thank(s| you)|great|perfect|now (showing|shows|working)|takes me to|no longer|can now)\b/.test(t)
 }
 
 /**
@@ -2837,7 +2871,24 @@ ANALYSIS_COMPLETE is for tasks that involve NO code changes (e.g. Discourse tria
             skipped++
             continue
           }
-          // No existing open bug → treat as potential regression, fall through to persist as 'open'
+          // No OPEN bug in the topic. If there is an already-FIXED bug here and
+          // this retest is a positive confirmation ("works now"), it is success
+          // feedback, NOT a regression. Record it against the fixed bug and skip —
+          // otherwise it becomes a bogus regression bug that draws a "please
+          // retest" auto-reply on the post that just confirmed the fix (9932/8).
+          const priorFixedBug = db.prepare(
+            `SELECT topic, post FROM discourse_bug WHERE topic = ? AND state = 'fixed' ORDER BY fixed_at DESC LIMIT 1`
+          ).get(Number(c.topic)) as { topic: number; post: number } | undefined
+          const retestText = `${c.summary ?? ''} ${c.originalPostText ?? ''}`
+          if (priorFixedBug && retestConfirmsFix(retestText)) {
+            db.prepare(`UPDATE discourse_bug SET last_seen_at = datetime('now') WHERE topic = ? AND post = ?`)
+              .run(priorFixedBug.topic, priorFixedBug.post)
+            out(`persist_classifications: ${c.topic}/${post} confirms fix of ${priorFixedBug.topic}/${priorFixedBug.post} — success feedback, skipping new entry`)
+            skipped++
+            continue
+          }
+          // No existing open bug and not a positive confirmation → treat as a
+          // potential regression, fall through to persist as 'open'.
         }
         // Parse tags from classification output (TRIAGE emits symptom_tags + code_area)
         const symptomTags: string[] = Array.isArray(c.symptom_tags)

--- a/monitor-fsm/src/actions/index.ts
+++ b/monitor-fsm/src/actions/index.ts
@@ -247,6 +247,45 @@ export async function postDiscourseReply(
 }
 
 /**
+ * Fetch the reporter's ACTUAL words for a post so an auto-reply quotes what they
+ * wrote — not our paraphrased `excerpt`/summary. Quoting the stored summary
+ * produced replies that quoted a third-person paraphrase back at the reporter as
+ * if they'd said it (e.g. a `[quote="Derek"]` containing "Derek confirms two
+ * bugs are now fixed"). Returns a short verbatim excerpt (HTML + any nested
+ * quotes stripped), or '' when it can't be fetched so callers fall back to the
+ * stored excerpt/title.
+ */
+export async function fetchReporterQuote(topicId: number, postNumber: number, maxLen = 300): Promise<string> {
+  let apiKey: string | null = null
+  try {
+    const profile = JSON.parse(await readFile('/home/edward/profile.json', 'utf8')) as {
+      auth_pairs?: Array<{ user_api_key?: string }>
+    }
+    apiKey = profile.auth_pairs?.[0]?.user_api_key ?? null
+  } catch { /* no profile / unreadable */ }
+  if (!apiKey) return ''
+  try {
+    const resp = await fetch(`${DISCOURSE_BASE}/t/${topicId}.json`, { headers: { 'Api-Key': apiKey } })
+    if (!resp.ok) return ''
+    const j = (await resp.json()) as { post_stream?: { posts?: Array<{ post_number: number; cooked?: string }> } }
+    const post = j.post_stream?.posts?.find((p) => p.post_number === postNumber)
+    if (!post?.cooked) return ''
+    let text = post.cooked
+      .replace(/<aside[\s\S]*?<\/aside>/gi, ' ') // drop nested quote blocks — never quote a quote
+      .replace(/<[^>]+>/g, ' ')
+      .replace(/&amp;/g, '&')
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>')
+      .replace(/\s+/g, ' ')
+      .trim()
+    if (text.length > maxLen) text = text.slice(0, maxLen).replace(/\s+\S*$/, '') + '…'
+    return text
+  } catch {
+    return ''
+  }
+}
+
+/**
  * Compare a commit SHA against a reference SHA using the GitHub compare API.
  * Returns behind_by: how many commits in baseSha are NOT in headSha.
  * behind_by == 0 means headSha contains all of baseSha's history → headSha is "at or past" baseSha.
@@ -985,10 +1024,11 @@ print(json.dumps({'confirmations': results, 'edwardUpdates': edward_updates}))
         const APP_CAVEAT = ' (but app releases may take up to one week)'
         const body = 'AI Edward: possible fix applied, please retest and report back'
           + (affectsApp ? APP_CAVEAT : '')
-        // Fallback chain so there is ALWAYS quoted text: the reporting post's excerpt,
-        // else the topic title (a topic always has one). If both were somehow empty the
-        // posting guard would refuse to post rather than post a context-less reply.
-        const quote = (bug.excerpt || bug.topic_title || '').trim()
+        // Quote the reporter's ACTUAL words (fetched verbatim) so the reply quotes
+        // what they wrote, not our paraphrased summary. Fall back to the stored
+        // excerpt/title only if the live fetch yields nothing; the posting guard
+        // still refuses a context-less reply.
+        const quote = (await fetchReporterQuote(bug.topic, bug.post)) || (bug.excerpt || bug.topic_title || '').trim()
         const username = bug.reporter ?? 'there'
 
         // Auto-post (explicitly approved): post the verbatim reply threaded under
@@ -1077,7 +1117,7 @@ print(json.dumps({'confirmations': results, 'edwardUpdates': edward_updates}))
         const existing = db.prepare(`SELECT id FROM discourse_draft WHERE topic = ? AND post = ?`).get(bug.topic, bug.post)
         if (existing) { skipped.push(`${tag} (reply already exists)`); continue }
 
-        const quote = (bug.excerpt || bug.topic_title || '').trim()
+        const quote = (await fetchReporterQuote(bug.topic, bug.post)) || (bug.excerpt || bug.topic_title || '').trim()
         if (!quote) { skipped.push(`${tag} (no quote text — marked fixed, no reply)`); continue }
         const body = 'AI Edward: possible fix applied, please retest and report back'
           + (live.touchesFrontend ? ' (but app releases may take up to one week)' : '')


### PR DESCRIPTION
## Summary

The monitor posted a nonsensical reply on https://discourse.ilovefreegle.org/t/9932/8: a `[quote="Derek"]` containing *"Derek confirms two previously reported bugs are now fixed"* (a paraphrase Derek never wrote), followed by "possible fix applied, please retest" — on a post where Derek had just **confirmed the fixes work**. (The post itself is already corrected in place.) Three distinct FSM defects combined to produce it; all three are fixed here.

## Root cause chain

1. **A confirmation was treated as a regression.** When Derek's "works now" retest (post 7) arrived, its original bug was already `fixed`, so `persist_classifications` found no *open* bug to attach it to and fell through to the regression check — which never distinguished "works now" from "still broken" — and created a bogus bug row for the confirmation post.
2. **That bogus bug drew a "please retest" auto-reply**, on the very post that confirmed the fix.
3. **The reply quoted our summary, not the reporter.** Both auto-post paths built the `[quote]` from `bug.excerpt` (the FSM's paraphrased summary) instead of the reporter's words.

## Fixes (all in `monitor-fsm/`)

- **`retestConfirmsFix()`** — a retest of an already-fixed bug that reads as a positive confirmation (and *not* "still broken") is success feedback, not a regression: record it against the fixed bug and skip creating a row. Genuine "still broken" retests still flag as regressions.
- **`fetchReporterQuote(topic, post)`** — quotes the reporter's **verbatim** words (HTML + nested quotes stripped), used by both auto-post paths; resolves a reporting post beyond the topic's first page via the post stream + `/posts/{id}` so it never silently falls back to the summary. Falls back to the stored excerpt only if the live fetch yields nothing.

## Test Plan

- `npm run build` (tsc) — clean.
- `npx vitest run` — 16 files, **277 tests pass** (+2 new persist_classifications cases: a confirming retest is skipped; a still-broken retest is flagged as a regression).
- Functional: `fetchReporterQuote(9932, 7)` returns Derek's actual words; the deep-thread stream fallback returns verbatim text for a post beyond page 1.
- Live for the next iteration (`tsc && node` rebuilds `dist/`).

## Discourse
- https://discourse.ilovefreegle.org/t/9932/8
