### PR TITLE
fix(donations): re-point donations stranded on deleted accounts

### DIFF
--- a/iznik-batch/app/Console/Commands/Donation/CorrectDonationUserIdsCommand.php
+++ b/iznik-batch/app/Console/Commands/Donation/CorrectDonationUserIdsCommand.php
@@ -7,10 +7,19 @@ use App\Traits\LogsBatchJob;
 use Illuminate\Console\Command;
 
 /**
- * One-shot backfill of users_donations.userid for the historical backlog of
- * unmatched donations. Deliberately NOT scheduled — the PayPal/Stripe IPN
- * handlers now match at receipt time (email/canon/prior donation); this just
- * cleans up donations that landed before that logic existed.
+ * Reconcile users_donations.userid against live accounts. Two populations:
+ *
+ *   1. donations never linked to any account (userid IS NULL) — the historical
+ *      backlog from before the IPN handlers matched at receipt time; and
+ *   2. donations stranded on a since-DELETED account (the donate/leave/rejoin
+ *      gap) — re-pointed to the live account that now owns the payer email.
+ *
+ * The PayPal/Stripe IPN handlers match new donations at receipt, but neither
+ * they nor the null-only backfill ever revisit population 2, and new strandings
+ * appear whenever an account holding donations is later deleted without its
+ * donations being reassigned — so this is now scheduled to run periodically.
+ * Donations already on a LIVE account are deliberately left alone: that is the
+ * duplicate-account case, resolved by a human account merge, not here.
  */
 class CorrectDonationUserIdsCommand extends Command
 {
@@ -18,9 +27,9 @@ class CorrectDonationUserIdsCommand extends Command
 
     protected $signature = 'donations:correct-userids
                             {--dry-run : Report what would change without writing}
-                            {--limit= : Only scan this many unmatched donations}';
+                            {--limit= : Only scan this many candidate donations}';
 
-    protected $description = 'Backfill unmatched donations to accounts by email/canon or a prior donation from the same Payer (one-shot; not scheduled).';
+    protected $description = 'Reconcile donation userids: backfill unlinked donations and re-point donations stranded on deleted accounts to the live account owning the payer email.';
 
     public function handle(DonationUserIdBackfillService $service): int
     {
@@ -34,18 +43,20 @@ class CorrectDonationUserIdsCommand extends Command
         return $this->runWithLogging(function () use ($service, $dryRun, $limit) {
             $r = $service->backfill($dryRun, $limit);
 
-            $verb = $dryRun ? 'Would link' : 'Linked';
+            $verb = $dryRun ? 'Would re-link' : 'Re-linked';
             $this->info(sprintf(
-                '%s %d of %d unmatched donation(s): %d by email/canon, %d by prior donation.',
+                '%s %d of %d candidate donation(s): %d unlinked backfilled, %d stranded on a deleted account re-pointed (%d by email/canon, %d by prior donation).',
                 $verb,
                 $r['updated'],
                 $r['scanned'],
+                $r['null_backfilled'],
+                $r['deleted_repointed'],
                 $r['matched_email'],
                 $r['matched_prior']
             ));
 
             if ($r['scanned'] === 0) {
-                $this->info('No unmatched donations found.');
+                $this->info('No candidate donations found.');
             }
 
             return Command::SUCCESS;

--- a/iznik-batch/app/Services/DonationUserIdBackfillService.php
+++ b/iznik-batch/app/Services/DonationUserIdBackfillService.php
@@ -6,90 +6,138 @@ use App\Models\User;
 use Illuminate\Support\Facades\DB;
 
 /**
- * One-shot backfill that re-links unmatched donations (users_donations.userid
- * IS NULL) to a Freegle account.
+ * Reconcile users_donations.userid against live Freegle accounts. It handles two
+ * populations of mis-linked donations:
  *
- * It restores V1 correctUserIdInDonations() parity (exact-email matching) and
- * adds the same two extra signals now used by the live Go IPN handlers
- * (donations.MatchUserByEmailOrPriorDonation):
+ *   A. donations never linked to any account (userid IS NULL) — the historical
+ *      backlog from before the IPN handlers matched at receipt time; and
+ *   B. donations stranded on a since-DELETED account — the donate/leave/rejoin
+ *      gap. Their userid is non-null (so population A's whereNull() never sees
+ *      them) but points at an account that was later deleted without its
+ *      donations being carried across. Where the payer's email now lives on a
+ *      live account, the donation is re-pointed there.
  *
- *   1. canonical-email matching (gmail dots/+tags, googlemail, TN variants) via
- *      the shared App\Models\User::canonMail(); and
+ * Both populations resolve a payer using the same signals as the live Go IPN
+ * handlers (donations.MatchUserByEmailOrPriorDonation):
+ *
+ *   1. exact/canonical email match against a live account (gmail dots/+tags,
+ *      googlemail, TN variants) via the shared App\Models\User::canonMail(); and
  *   2. a prior donation from the same Payer already linked to a non-deleted
  *      user — recovering recurring donors whose Freegle email later changed
  *      while the payment processor keeps billing the original address.
  *
- * Going forward the IPN handlers match at receipt time, so this command is NOT
- * scheduled; it exists to clean up the historical backlog.
+ * resolve() only ever returns a LIVE account, so donations already on a live
+ * account (the duplicate-account case) are deliberately never moved — that is
+ * resolved by a human account merge. Because new strandings keep appearing when
+ * accounts holding donations are deleted, the command is scheduled to run
+ * periodically as a safety net rather than being a one-shot backfill.
  */
 class DonationUserIdBackfillService
 {
     /**
-     * @return array{scanned:int, matched_email:int, matched_prior:int, updated:int}
+     * @return array{scanned:int, matched_email:int, matched_prior:int, updated:int, null_backfilled:int, deleted_repointed:int}
      */
     public function backfill(bool $dryRun = false, ?int $limit = null): array
     {
-        $scanned      = 0;
-        $matchedEmail = 0;
-        $matchedPrior = 0;
-        $updated      = 0;
+        // Shared state across both passes. Resolve once per distinct Payer —
+        // recurring donors have many rows that all resolve to the same account.
+        $state = [
+            'scanned'           => 0,
+            'matched_email'     => 0,
+            'matched_prior'     => 0,
+            'updated'           => 0,
+            'null_backfilled'   => 0, // rows that had NO account (userid IS NULL)
+            'deleted_repointed' => 0, // rows stranded on a since-deleted account
+            'resolved'          => [],
+            'remaining'         => $limit,
+        ];
 
-        // Resolve once per distinct Payer — recurring donors have many unmatched
-        // rows that all resolve to the same account.
-        $resolved = [];
-
-        $query = DB::table('users_donations')
+        // Pass 1 — donations that were never linked to any account. These landed
+        // before the IPN handlers matched at receipt time.
+        $nullQuery = DB::table('users_donations')
             ->whereNull('userid')
             ->whereNotNull('Payer')
             ->where('Payer', '<>', '')
             ->orderBy('id');
+        $this->processDonations($nullQuery, 'null_backfilled', $state, $dryRun, $limit);
 
-        $remaining = $limit;
+        // Pass 2 — the donate/leave/rejoin gap. Donations recorded against an
+        // account that was LATER deleted stay pinned to it: their userid is
+        // non-null, so pass 1's whereNull() never sees them, and the delete/merge
+        // that removed the account did not carry the donations across. When the
+        // same person's email now lives on a live account, re-point them there.
+        // resolve() only ever returns a LIVE account, so donations already on a
+        // live account (the duplicate-account/merge case) are deliberately left
+        // untouched — that is resolved by a human account merge, not here.
+        $deletedQuery = DB::table('users_donations')
+            ->whereNotNull('users_donations.userid')
+            ->whereNotNull('Payer')
+            ->where('Payer', '<>', '')
+            ->whereExists(function ($q) {
+                $q->select(DB::raw(1))
+                    ->from('users')
+                    ->whereColumn('users.id', 'users_donations.userid')
+                    ->whereNotNull('users.deleted');
+            })
+            ->orderBy('users_donations.id');
+        $this->processDonations($deletedQuery, 'deleted_repointed', $state, $dryRun, $limit);
 
-        $query->chunkById(500, function ($rows) use (
-            &$scanned, &$matchedEmail, &$matchedPrior, &$updated, &$resolved, &$remaining, $dryRun, $limit
-        ) {
+        return [
+            'scanned'           => $state['scanned'],
+            'matched_email'     => $state['matched_email'],
+            'matched_prior'     => $state['matched_prior'],
+            'updated'           => $state['updated'],
+            'null_backfilled'   => $state['null_backfilled'],
+            'deleted_repointed' => $state['deleted_repointed'],
+        ];
+    }
+
+    /**
+     * Scan a donation query in id-ordered chunks, resolve each Payer to a live
+     * account and (unless dry-running) re-point the donation. $bucket names the
+     * counter incremented for a successful update ('null_backfilled' or
+     * 'deleted_repointed'); $state carries the shared counters, per-Payer resolve
+     * cache and the combined remaining-limit budget across passes.
+     */
+    private function processDonations($query, string $bucket, array &$state, bool $dryRun, ?int $limit): void
+    {
+        $query->chunkById(500, function ($rows) use (&$state, $bucket, $dryRun, $limit) {
             foreach ($rows as $row) {
-                if ($limit !== null && $remaining !== null && $remaining <= 0) {
-                    return false; // stop chunking
+                if ($limit !== null && $state['remaining'] !== null && $state['remaining'] <= 0) {
+                    return false; // stop chunking — combined budget spent
                 }
 
-                $scanned++;
-                if ($remaining !== null) {
-                    $remaining--;
+                $state['scanned']++;
+                if ($state['remaining'] !== null) {
+                    $state['remaining']--;
                 }
 
                 $payer = (string) $row->Payer;
-                if (!array_key_exists($payer, $resolved)) {
-                    $resolved[$payer] = $this->resolve($payer);
+                if (!array_key_exists($payer, $state['resolved'])) {
+                    $state['resolved'][$payer] = $this->resolve($payer);
                 }
-                [$uid, $via] = $resolved[$payer];
+                [$uid, $via] = $state['resolved'][$payer];
 
-                if ($uid === null) {
+                if ($uid === null || (int) $uid === (int) $row->userid) {
+                    // No confident live account, or already there (defensive).
                     continue;
                 }
 
                 if ($via === 'email') {
-                    $matchedEmail++;
+                    $state['matched_email']++;
                 } else {
-                    $matchedPrior++;
+                    $state['matched_prior']++;
                 }
 
                 if (!$dryRun) {
                     DB::table('users_donations')->where('id', $row->id)->update(['userid' => $uid]);
                 }
-                $updated++;
+                $state['updated']++;
+                $state[$bucket]++;
             }
 
             return true;
-        });
-
-        return [
-            'scanned'       => $scanned,
-            'matched_email' => $matchedEmail,
-            'matched_prior' => $matchedPrior,
-            'updated'       => $updated,
-        ];
+        }, 'users_donations.id', 'id');
     }
 
     /**

--- a/iznik-batch/routes/console.php
+++ b/iznik-batch/routes/console.php
@@ -664,6 +664,19 @@ Schedule::command('mail:donations:thank-prep')
     ->sendOutputTo(cronLog('mail:donations:thank-prep'))
     ->runInBackground();
 
+// Reconcile donation userids: backfill donations never linked to an account and
+// re-point donations stranded on a since-deleted account (the donate/leave/rejoin
+// gap) onto the live account that now owns the payer email. The IPN handlers match
+// new donations at receipt, but new strandings appear whenever an account holding
+// donations is deleted without its donations being reassigned, so this runs as a
+// weekly safety net. Donations already on a live account (duplicate-account case)
+// are left for a human merge. Weekly, off-peak.
+Schedule::command('donations:correct-userids')
+    ->weeklyOn(2, '02:20')
+    ->withoutOverlapping(360)
+    ->sendOutputTo(cronLog('donations:correct-userids'))
+    ->runInBackground();
+
 // User management: Yahoo Groups removal, inactive-user forget, GDPR grace-period
 // forget, and hard delete of fully forgotten users with no messages left.
 // V1: cron/users_retention.php (User::userRetention + User::processForgets).

--- a/iznik-batch/tests/Feature/Donation/CorrectDonationUserIdsCommandTest.php
+++ b/iznik-batch/tests/Feature/Donation/CorrectDonationUserIdsCommandTest.php
@@ -99,4 +99,119 @@ class CorrectDonationUserIdsCommandTest extends TestCase
 
         $this->assertNull(DB::table('users_donations')->where('id', $newId)->value('userid'));
     }
+
+    /**
+     * The donate/leave/rejoin gap: donations recorded against an account that was
+     * later DELETED are stranded there (their userid is non-null, so the original
+     * whereNull() scan never saw them). When the same person's email now lives on
+     * a new, live account, re-point the stranded donations to it.
+     */
+    public function test_repoints_donation_stranded_on_deleted_account_via_email(): void
+    {
+        // Old account, since deleted (person left).
+        $deadUid = $this->insertUser(['fullname' => 'Left Donor', 'deleted' => now()->subMonth()]);
+        // New live account they rejoined with, holding the same email.
+        $liveUid = $this->insertUser(['fullname' => 'Rejoined Donor']);
+        $payer   = 'left-and-rejoined@example.test';
+        DB::table('users_emails')->insert([
+            'userid' => $liveUid,
+            'email'  => $payer,
+            'canon'  => User::canonMail($payer),
+        ]);
+
+        // Donation attached to the now-deleted account while it was still live.
+        $strandedId = $this->insertDonation(['userid' => $deadUid, 'Payer' => $payer, 'timestamp' => now()->subYear()]);
+
+        $this->artisan('donations:correct-userids')->assertExitCode(0);
+
+        $this->assertEquals(
+            $liveUid,
+            DB::table('users_donations')->where('id', $strandedId)->value('userid'),
+            'Donation stranded on a deleted account should be re-pointed to the live account owning the email.'
+        );
+    }
+
+    public function test_repoints_donation_stranded_on_deleted_account_via_canon(): void
+    {
+        $deadUid = $this->insertUser(['fullname' => 'Left Canon Donor', 'deleted' => now()->subMonth()]);
+        $liveUid = $this->insertUser(['fullname' => 'Rejoined Canon Donor']);
+        $payer   = 'jane.rejoin.canon@gmail.com';
+        DB::table('users_emails')->insert([
+            'userid' => $liveUid,
+            'email'  => 'janerejoincanon@gmail.com', // differs from payer, shares canon
+            'canon'  => User::canonMail($payer),
+        ]);
+
+        $strandedId = $this->insertDonation(['userid' => $deadUid, 'Payer' => $payer, 'timestamp' => now()->subYear()]);
+
+        $this->artisan('donations:correct-userids')->assertExitCode(0);
+
+        $this->assertEquals($liveUid, DB::table('users_donations')->where('id', $strandedId)->value('userid'));
+    }
+
+    /**
+     * Guard rail: donations already on a LIVE account must never be moved. That is
+     * the duplicate-live-account case, which is resolved by a human account merge,
+     * not by this backfill.
+     */
+    public function test_does_not_touch_donation_on_a_live_account(): void
+    {
+        $liveA = $this->insertUser(['fullname' => 'Live A (has the donation)']);
+        $liveB = $this->insertUser(['fullname' => 'Live B (now owns the email)']);
+        $payer = 'shared-live@example.test';
+        DB::table('users_emails')->insert([
+            'userid' => $liveB,
+            'email'  => $payer,
+            'canon'  => User::canonMail($payer),
+        ]);
+
+        $donationId = $this->insertDonation(['userid' => $liveA, 'Payer' => $payer, 'timestamp' => now()->subYear()]);
+
+        $this->artisan('donations:correct-userids')->assertExitCode(0);
+
+        $this->assertEquals(
+            $liveA,
+            DB::table('users_donations')->where('id', $donationId)->value('userid'),
+            'A donation on a live account must be left alone (merge case, not a re-point).'
+        );
+    }
+
+    public function test_deleted_account_repoint_respects_dry_run(): void
+    {
+        $deadUid = $this->insertUser(['fullname' => 'Dry Left Donor', 'deleted' => now()->subMonth()]);
+        $liveUid = $this->insertUser(['fullname' => 'Dry Rejoined Donor']);
+        $payer   = 'dryrun-left@example.test';
+        DB::table('users_emails')->insert([
+            'userid' => $liveUid,
+            'email'  => $payer,
+            'canon'  => User::canonMail($payer),
+        ]);
+
+        $strandedId = $this->insertDonation(['userid' => $deadUid, 'Payer' => $payer, 'timestamp' => now()->subYear()]);
+
+        $this->artisan('donations:correct-userids', ['--dry-run' => true])->assertExitCode(0);
+
+        $this->assertEquals(
+            $deadUid,
+            DB::table('users_donations')->where('id', $strandedId)->value('userid'),
+            'Dry run must not move a stranded donation.'
+        );
+    }
+
+    /**
+     * If no live account owns the payer email (and there is no prior live
+     * donation), a donation stranded on a deleted account stays put — we have
+     * nowhere confident to move it.
+     */
+    public function test_leaves_stranded_donation_when_no_live_account_owns_email(): void
+    {
+        $deadUid = $this->insertUser(['fullname' => 'Orphan Left Donor', 'deleted' => now()->subMonth()]);
+        $payer   = 'no-live-owner@example.test';
+
+        $strandedId = $this->insertDonation(['userid' => $deadUid, 'Payer' => $payer, 'timestamp' => now()->subYear()]);
+
+        $this->artisan('donations:correct-userids')->assertExitCode(0);
+
+        $this->assertEquals($deadUid, DB::table('users_donations')->where('id', $strandedId)->value('userid'));
+    }
 }


### PR DESCRIPTION
## Summary

- Fixes the **donate / leave / rejoin** gap: donations recorded against an account that was later **deleted** stay pinned to it. Their `users_donations.userid` is non-null (pointing at the dead account), so `DonationUserIdBackfillService` never saw them — its scan was gated on `whereNull('userid')`, which only rescues donations that were *never* linked at all.
- The live Go IPN matcher (`MatchUserByEmailOrPriorDonation`) already routes **new** donations correctly, and the null-only backfill rescued donations orphaned during the gap — but nothing ever revisited the donations that were attached to the old account **while it was still alive**.
- Adds a **second pass**: donations whose `userid` points at a deleted account are re-pointed to the live account that now owns the payer email, reusing the existing `resolve()` (exact/canonical email, then a prior donation from the same Payer on a live user).
- `resolve()` only ever returns a **live** account, so donations already on a live account — the **duplicate-account** case, which needs a human merge — are deliberately left untouched.
- The command now reports the two populations separately (null-backfilled vs deleted-account-repointed) and is **scheduled weekly** as a safety net: new strandings appear whenever an account holding donations is deleted without its donations being reassigned.

### Prod scale at time of writing
- ~**2,192** donations (£6,774) stranded on deleted accounts across **683** payer emails → swept up by this pass.
- ~**208** donations on *live* duplicate accounts (53 payer emails) are intentionally **not** touched here — handled by account merges (separate, human-reviewed).
- Re-linking also restores **Gift Aid** eligibility on the subset (~£36 within the 4-year claimable window) whose owners hold a Gift Aid declaration.

## Code Quality Review
- Reuses the existing `resolve()` resolver unchanged; both passes share one per-Payer resolution cache and a combined `--limit` budget.
- Pass 2 uses a correlated `whereExists` on `users.deleted` and `chunkById('users_donations.id')` to keep memory bounded and updates one row at a time (Galera-friendly).
- Guard rail covered by tests: a donation on a live account is never moved; a stranded donation with no live email owner is left in place; `--dry-run` writes nothing.
- Keeps the existing `DB` facade style of the service (consistent with the surrounding null-backfill code) rather than per-row Eloquent, appropriate for a bulk maintenance sweep.

## Future Improvements
- The live-duplicate set (208 donations) is resolved out-of-band via `User::merge()` (id1=keep, id2=discard), which reparents donations via `reparentRowIgnore(UserDonation…)`. Consider a companion report command to surface duplicate-live pairs for moderator review.

## Test Plan
`tests/Feature/Donation/CorrectDonationUserIdsCommandTest.php` (run in CI):
- existing null-backfill behaviour (email/canon/prior-donation, deleted-prior guard, dry-run) — unchanged & still asserted;
- **new:** re-points a donation stranded on a deleted account via exact email;
- **new:** re-points via canonical email;
- **new:** does **not** touch a donation on a live account (merge case);
- **new:** `--dry-run` leaves a stranded donation untouched;
- **new:** leaves a stranded donation in place when no live account owns the email.