### PR TITLE
feat(apiv2): GET /item/impact — per-item weight, CO2e and £ benefit estimates

### DIFF
--- a/iznik-server-go/item/impact.go
+++ b/iznik-server-go/item/impact.go
@@ -27,8 +27,14 @@ const (
 	SourceAverage = "average"
 )
 
-// wordSplitRe mirrors PHP's preg_split('/\s+/', $sentence).
-var wordSplitRe = regexp.MustCompile(`\s+`)
+// maxImpactQty caps the caller-supplied qty so a single request can't
+// produce an unbounded totalWeightKg/co2eKg/benefitGbp in the response.
+const maxImpactQty = 100000
+
+// wordSplitRe mirrors PHP's preg_split('/\s+/', $sentence). PCRE's default
+// \s class includes vertical tab (0x0B), unlike Go RE2's \s, so the class is
+// spelled out explicitly to match PHP's tokenisation exactly.
+var wordSplitRe = regexp.MustCompile("[\t\n\f\r \v]+")
 
 // nonAlphanumericRe mirrors PHP's preg_replace('/[^\da-z]/i', ”, $word)
 // applied after strtolower() - i.e. strip everything but digits and letters.
@@ -149,13 +155,19 @@ type itemsExactMatch struct {
 	Weight float64 `gorm:"column:weight"`
 }
 
-// findExactItemWeight looks up an exact (case-insensitive) match in the
-// `items` catalog with a usable (non-null, non-zero) weight. This is a
-// plain SELECT - it never inserts, unlike ItemService::findOrCreate().
+// findExactItemWeight looks up an exact match in the `items` catalog with a
+// usable (non-null, non-zero) weight. The `items.name` column has a UNIQUE
+// index under the table's default utf8mb4_unicode_ci collation, which is
+// already case-insensitive, so a plain equality comparison both matches
+// case-insensitively and uses the index - matching the convention used
+// elsewhere in this codebase (e.g. message/message.go, test/testUtils.go).
+// Wrapping the column in LOWER() would prevent the unique index from being
+// used, forcing a full table scan on every call. This is a plain SELECT -
+// it never inserts, unlike ItemService::findOrCreate().
 func findExactItemWeight(db *gorm.DB, name string) (weight float64, matched string, ok bool) {
 	var row itemsExactMatch
 	result := db.Raw(
-		"SELECT name, weight FROM items WHERE LOWER(name) = LOWER(?) AND weight IS NOT NULL AND weight != 0 LIMIT 1",
+		"SELECT name, weight FROM items WHERE name = ? AND weight IS NOT NULL AND weight != 0 LIMIT 1",
 		name,
 	).Scan(&row)
 
@@ -226,6 +238,9 @@ func Impact(c *fiber.Ctx) error {
 	qty := c.QueryInt("qty", 1)
 	if qty < 1 {
 		qty = 1
+	}
+	if qty > maxImpactQty {
+		qty = maxImpactQty
 	}
 
 	db := database.DBConn

--- a/iznik-server-go/item/impact.go
+++ b/iznik-server-go/item/impact.go
@@ -1,0 +1,279 @@
+package item
+
+import (
+	"math"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/gofiber/fiber/v2"
+	"gorm.io/gorm"
+)
+
+// Weight estimation and reuse-impact lookup for free-text item names.
+//
+// Ported from iznik-batch/app/Services/ItemService.php (estimateWeight() and
+// the wordsInCommon/canonSentence/canonWord word-similarity helpers, ported
+// there "verbatim from V1 Utils"). This file is READ-ONLY: unlike
+// ItemService::findOrCreate(), it never inserts novel names into the items
+// catalog - a public endpoint must not be able to pollute it.
+
+// Source values for the ImpactResponse.Source field.
+const (
+	SourceItems   = "items"
+	SourceWeights = "weights"
+	SourceAverage = "average"
+)
+
+// wordSplitRe mirrors PHP's preg_split('/\s+/', $sentence).
+var wordSplitRe = regexp.MustCompile(`\s+`)
+
+// nonAlphanumericRe mirrors PHP's preg_replace('/[^\da-z]/i', ”, $word)
+// applied after strtolower() - i.e. strip everything but digits and letters.
+var nonAlphanumericRe = regexp.MustCompile(`[^0-9a-z]`)
+
+// canonWord canonicalises a single word for fuzzy matching: lowercase, strip
+// non-alphanumerics, and - for words longer than 3 characters - sort the
+// letters alphabetically so typos/anagrams of the same word still match.
+// Ported verbatim from ItemService::canonWord().
+func canonWord(word string) string {
+	word = strings.ToLower(word)
+	word = nonAlphanumericRe.ReplaceAllString(word, "")
+
+	if len(word) > 3 {
+		b := []byte(word)
+		sort.Slice(b, func(i, j int) bool { return b[i] < b[j] })
+		word = string(b)
+	}
+
+	return word
+}
+
+// canonSentence splits a sentence on whitespace, canonicalises each word,
+// and de-duplicates while preserving first-seen order (matches PHP's
+// array_values(array_unique(...))). Ported from ItemService::canonSentence().
+func canonSentence(sentence string) []string {
+	words := wordSplitRe.Split(sentence, -1)
+
+	seen := make(map[string]bool, len(words))
+	canon := make([]string, 0, len(words))
+	for _, w := range words {
+		cw := canonWord(w)
+		if !seen[cw] {
+			seen[cw] = true
+			canon = append(canon, cw)
+		}
+	}
+
+	return canon
+}
+
+// wordsInCommon returns the percentage (0-100) of words two sentences have
+// in common, relative to the longer sentence's (de-duplicated) word count.
+// Ported verbatim from ItemService::wordsInCommon(), including its
+// single-word-list edge case (returns 0, not 100, when the longer list has
+// exactly one word).
+func wordsInCommon(sentence1, sentence2 string) float64 {
+	words1 := canonSentence(sentence1)
+	words2 := canonSentence(sentence2)
+
+	ret := 0
+	for _, w1 := range words1 {
+		for _, w2 := range words2 {
+			if w1 == w2 {
+				ret++
+			}
+		}
+	}
+
+	limit := len(words1)
+	if len(words2) > limit {
+		limit = len(words2)
+	}
+
+	if limit == 1 {
+		return 0
+	}
+
+	return 100 * float64(ret) / float64(limit)
+}
+
+// standardWeight is one row of the `weights` reference table, with
+// simplename preferred over name - matches ItemService::standardWeights()'s
+// `CASE WHEN simplename IS NOT NULL THEN simplename ELSE name END`.
+type standardWeight struct {
+	Name   string  `gorm:"column:name"`
+	Weight float64 `gorm:"column:weight"`
+}
+
+// loadStandardWeights fetches every row of the `weights` reference table.
+func loadStandardWeights(db *gorm.DB) []standardWeight {
+	var rows []standardWeight
+	db.Raw("SELECT CASE WHEN simplename IS NOT NULL THEN simplename ELSE name END AS name, weight FROM weights").Scan(&rows)
+	return rows
+}
+
+// estimateWeightFromStandardWeights picks the `weights` entry with the most
+// words in common with name, and returns it only if the match is good
+// enough (V1/ItemService threshold: words-in-common strictly > 10%). Ported
+// verbatim from ItemService::estimateWeight().
+func estimateWeightFromStandardWeights(name string, weights []standardWeight) (weight float64, matched string, ok bool) {
+	var bestWeight float64
+	var bestName string
+	var bestWic float64
+	found := false
+
+	for _, w := range weights {
+		wic := wordsInCommon(name, w.Name)
+		if !found || wic > bestWic {
+			bestWic = wic
+			bestWeight = w.Weight
+			bestName = w.Name
+			found = true
+		}
+	}
+
+	if found && bestWic > 10 {
+		return bestWeight, bestName, true
+	}
+
+	return 0, "", false
+}
+
+// itemsExactMatch is the row shape for the exact case-insensitive `items`
+// lookup.
+type itemsExactMatch struct {
+	Name   string  `gorm:"column:name"`
+	Weight float64 `gorm:"column:weight"`
+}
+
+// findExactItemWeight looks up an exact (case-insensitive) match in the
+// `items` catalog with a usable (non-null, non-zero) weight. This is a
+// plain SELECT - it never inserts, unlike ItemService::findOrCreate().
+func findExactItemWeight(db *gorm.DB, name string) (weight float64, matched string, ok bool) {
+	var row itemsExactMatch
+	result := db.Raw(
+		"SELECT name, weight FROM items WHERE LOWER(name) = LOWER(?) AND weight IS NOT NULL AND weight != 0 LIMIT 1",
+		name,
+	).Scan(&row)
+
+	if result.Error != nil || row.Name == "" {
+		return 0, "", false
+	}
+
+	return row.Weight, row.Name, true
+}
+
+// populationAverageWeight returns the popularity-weighted average item
+// weight across the whole `items` catalog:
+// SUM(popularity*weight)/SUM(popularity) WHERE weight IS NOT NULL AND weight
+// != 0 - identical to AuthorityStatsService.php, StatsGenerationService.php
+// and authority/stats.go's GetStatsByAuthority. Used as the last-resort
+// fallback when neither an exact items match nor a fuzzy weights match is
+// found. Returns 0 if the catalog has no usable weights yet.
+func populationAverageWeight(db *gorm.DB) float64 {
+	var result struct {
+		Average *float64 `gorm:"column:average"`
+	}
+
+	db.Raw("SELECT SUM(popularity*weight)/SUM(popularity) AS average FROM items WHERE weight IS NOT NULL AND weight != 0").Scan(&result)
+
+	if result.Average == nil {
+		return 0
+	}
+
+	return *result.Average
+}
+
+// ImpactResponse is the response shape for GET /item/impact.
+type ImpactResponse struct {
+	Name            string  `json:"name"`
+	Matched         *string `json:"matched"`
+	Source          string  `json:"source"`
+	Qty             int     `json:"qty"`
+	PerUnitWeightKg float64 `json:"perUnitWeightKg"`
+	TotalWeightKg   float64 `json:"totalWeightKg"`
+	Co2eKg          float64 `json:"co2eKg"`
+	BenefitGbp      float64 `json:"benefitGbp"`
+	BenefitPerTonne float64 `json:"benefitPerTonne"`
+	Year            int     `json:"year"`
+}
+
+// round2dp rounds to 2 decimal places for tidy JSON output.
+func round2dp(v float64) float64 {
+	return math.Round(v*100) / 100
+}
+
+// Impact estimates the weight, CO2e and financial benefit of reusing qty
+// units of a free-text item name.
+// @Summary Estimate reuse impact for an item name
+// @Description Estimates weight, CO2e saved and financial benefit of reuse for qty units of a free-text item name. Read-only: never writes to the items catalog. Lookup order: (1) exact case-insensitive match against the items catalog with a known weight, (2) fuzzy word-overlap match (>10%) against the standard weights reference table, (3) popularity-weighted average item weight.
+// @Tags item
+// @Produce json
+// @Param name query string true "Free-text item name"
+// @Param qty query integer false "Quantity (default 1)"
+// @Success 200 {object} item.ImpactResponse
+// @Failure 400 {object} fiber.Error "Missing or empty name"
+// @Router /item/impact [get]
+func Impact(c *fiber.Ctx) error {
+	name := strings.TrimSpace(c.Query("name"))
+	if name == "" {
+		return fiber.NewError(fiber.StatusBadRequest, "name is required")
+	}
+
+	qty := c.QueryInt("qty", 1)
+	if qty < 1 {
+		qty = 1
+	}
+
+	db := database.DBConn
+
+	var (
+		perUnitWeightKg float64
+		matched         *string
+		source          string
+	)
+
+	// (a) Exact case-insensitive items match with a usable weight.
+	if weight, matchedName, ok := findExactItemWeight(db, name); ok {
+		perUnitWeightKg = weight
+		m := matchedName
+		matched = &m
+		source = SourceItems
+	} else if weight, matchedName, ok := estimateWeightFromStandardWeights(name, loadStandardWeights(db)); ok {
+		// (b) Fuzzy match against the standard weights reference table.
+		perUnitWeightKg = weight
+		m := matchedName
+		matched = &m
+		source = SourceWeights
+	} else {
+		// (c) Popularity-weighted average across the whole catalog.
+		perUnitWeightKg = populationAverageWeight(db)
+		matched = nil
+		source = SourceAverage
+	}
+
+	totalWeightKg := perUnitWeightKg * float64(qty)
+
+	year := time.Now().UTC().Year()
+	cpiData := LoadCPIData(db)
+	benefitPerTonne := GetBenefitPerTonne(year, cpiData)
+
+	co2eKg := totalWeightKg * CO2PerTonne
+	benefitGbp := totalWeightKg * benefitPerTonne / 1000
+
+	return c.JSON(ImpactResponse{
+		Name:            name,
+		Matched:         matched,
+		Source:          source,
+		Qty:             qty,
+		PerUnitWeightKg: round2dp(perUnitWeightKg),
+		TotalWeightKg:   round2dp(totalWeightKg),
+		Co2eKg:          round2dp(co2eKg),
+		BenefitGbp:      round2dp(benefitGbp),
+		BenefitPerTonne: benefitPerTonne,
+		Year:            year,
+	})
+}

--- a/iznik-server-go/item/impact_test.go
+++ b/iznik-server-go/item/impact_test.go
@@ -1,0 +1,119 @@
+package item
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Pure-logic tests for the word-similarity helpers ported from
+// ItemService.php. None of these touch the database - they exercise
+// canonWord/canonSentence/wordsInCommon/estimateWeightFromStandardWeights
+// directly against hand-computed expectations.
+
+func TestCanonWordShortWordUnchanged(t *testing.T) {
+	// <=3 chars: no letter-sorting, just lowercase + strip punctuation.
+	assert.Equal(t, "bed", canonWord("Bed"))
+	assert.Equal(t, "big", canonWord("Big!!"))
+	assert.Equal(t, "2", canonWord("2"))
+}
+
+func TestCanonWordLongWordSortsLetters(t *testing.T) {
+	// >3 chars: lowercase, strip punctuation, then sort letters alphabetically
+	// (anagram/typo tolerance). "sofa" -> s,o,f,a -> sorted -> "afos".
+	assert.Equal(t, "afos", canonWord("Sofa"))
+	assert.Equal(t, "afos", canonWord("sofa"))
+	// An anagram of "sofa" canonicalises to the same value.
+	assert.Equal(t, "afos", canonWord("Foas"))
+}
+
+func TestCanonWordStripsNonAlphanumericButKeepsDigits(t *testing.T) {
+	// Digits are kept ([^0-9a-z] is stripped, digits are not in that class),
+	// and mixed alnum >3 chars still gets letter-sorted (ASCII order, so
+	// digits sort before letters).
+	assert.Equal(t, "2achirs", canonWord("chairs2"))
+
+	// Punctuation/apostrophes are stripped entirely, then the remaining
+	// letters are sorted: "Sofa-Bed's!" -> "sofabeds" -> sorted -> "abdefoss".
+	assert.Equal(t, "abdefoss", canonWord("Sofa-Bed's!"))
+}
+
+func TestWordsInCommonMatchingWord(t *testing.T) {
+	// "Big Comfy Sofa" canonicalises to {big, cfmoy, afos}; "sofa" to {afos}.
+	// 1 common word out of a longer list of 3 -> 100/3 = 33.33%.
+	score := wordsInCommon("Big Comfy Sofa", "sofa")
+	assert.InDelta(t, 100.0/3.0, score, 0.001)
+}
+
+func TestWordsInCommonNoOverlap(t *testing.T) {
+	assert.Equal(t, float64(0), wordsInCommon("Xylophone", "sofa"))
+}
+
+func TestWordsInCommonSingleWordListsReturnZeroEvenOnExactMatch(t *testing.T) {
+	// Ported edge case: when the LONGER (de-duplicated) word list has exactly
+	// one word, the function returns 0 regardless of match - even for an
+	// identical single word on both sides. This is a real V1/ItemService
+	// quirk, not a bug in the port: a naive implementation would return 100
+	// here.
+	assert.Equal(t, float64(0), wordsInCommon("Sofa", "sofa"))
+	assert.Equal(t, float64(0), wordsInCommon("Sofa", "Settee"))
+}
+
+func TestWordsInCommonThresholdBoundary(t *testing.T) {
+	// 10 unique words on one side, 1 shared word -> exactly 10.0%, at the
+	// boundary. estimateWeightFromStandardWeights requires STRICTLY > 10.
+	tenWords := "aa bb cc dd ee ff gg hh ii sofa"
+	assert.InDelta(t, 10.0, wordsInCommon(tenWords, "sofa"), 0.001)
+
+	// Drop to 9 unique words -> 100/9 = 11.11%, clears the threshold.
+	nineWords := "aa bb cc dd ee ff gg hh sofa"
+	assert.InDelta(t, 100.0/9.0, wordsInCommon(nineWords, "sofa"), 0.001)
+}
+
+func TestEstimateWeightFromStandardWeightsPicksBestMatch(t *testing.T) {
+	weights := []standardWeight{
+		{Name: "chair", Weight: 5.0},
+		{Name: "sofa", Weight: 40.0},
+		{Name: "table", Weight: 15.0},
+	}
+
+	weight, matched, ok := estimateWeightFromStandardWeights("Big Comfy Sofa", weights)
+	assert.True(t, ok)
+	assert.Equal(t, 40.0, weight)
+	assert.Equal(t, "sofa", matched)
+}
+
+func TestEstimateWeightFromStandardWeightsNoMatchBelowThreshold(t *testing.T) {
+	weights := []standardWeight{
+		{Name: "sofa", Weight: 40.0},
+	}
+
+	_, _, ok := estimateWeightFromStandardWeights("Xylophone", weights)
+	assert.False(t, ok)
+}
+
+func TestEstimateWeightFromStandardWeightsExactlyTenPercentIsRejected(t *testing.T) {
+	weights := []standardWeight{
+		{Name: "sofa", Weight: 40.0},
+	}
+
+	// "aa bb cc dd ee ff gg hh ii sofa" vs "sofa" is exactly 10% (see
+	// TestWordsInCommonThresholdBoundary) - must NOT be accepted since the
+	// V1/ItemService rule is "> 10", not ">= 10".
+	_, _, ok := estimateWeightFromStandardWeights("aa bb cc dd ee ff gg hh ii sofa", weights)
+	assert.False(t, ok)
+}
+
+func TestEstimateWeightFromStandardWeightsEmptyList(t *testing.T) {
+	_, _, ok := estimateWeightFromStandardWeights("anything", nil)
+	assert.False(t, ok)
+}
+
+func TestRound2dp(t *testing.T) {
+	// Avoid asserting exact behaviour at the x.xx5 boundary - float64 can't
+	// represent decimals like 1.235 exactly, so which way it rounds is a
+	// binary-representation detail, not something this port needs to pin.
+	assert.Equal(t, 1.23, round2dp(1.2313))
+	assert.Equal(t, 1.24, round2dp(1.2368))
+	assert.Equal(t, 0.0, round2dp(0))
+}

--- a/iznik-server-go/item/impact_test.go
+++ b/iznik-server-go/item/impact_test.go
@@ -38,6 +38,15 @@ func TestCanonWordStripsNonAlphanumericButKeepsDigits(t *testing.T) {
 	assert.Equal(t, "abdefoss", canonWord("Sofa-Bed's!"))
 }
 
+func TestCanonSentenceSplitsOnVerticalTab(t *testing.T) {
+	// PHP's preg_split('/\s+/', ...) uses PCRE's default \s, which includes
+	// vertical tab (0x0B) - unlike Go RE2's \s. wordSplitRe must split on it
+	// too, so "foo\x0bbar" tokenises the same way as the PHP original does:
+	// as two words, not one.
+	words := canonSentence("foo\x0bbar")
+	assert.Equal(t, []string{"foo", "bar"}, words)
+}
+
 func TestWordsInCommonMatchingWord(t *testing.T) {
 	// "Big Comfy Sofa" canonicalises to {big, cfmoy, afos}; "sofa" to {afos}.
 	// 1 common word out of a longer list of 3 -> 100/3 = 33.33%.

--- a/iznik-server-go/item/reusebenefit.go
+++ b/iznik-server-go/item/reusebenefit.go
@@ -1,0 +1,155 @@
+package item
+
+import (
+	"encoding/json"
+	"math"
+	"strconv"
+
+	"gorm.io/gorm"
+)
+
+// Reuse benefit calculation with inflation adjustment.
+//
+// Ported from iznik-batch/app/Support/ReuseBenefit.php (and the CPI-fetch
+// half of iznik-batch/app/Services/CPIService.php). The base benefit of
+// reuse value (GBP 711 per tonne) comes from the WRAP "Benefits of Reuse"
+// tool, originally published in 2011, up-rated by UK CPI inflation to
+// current prices. The CO2 impact (0.51 tCO2eq per tonne) is a physical
+// quantity and is not inflation-adjusted.
+//
+// By default the hardcoded FallbackCPIData table is used. A CPI data map may
+// optionally be supplied (e.g. loaded from the `config` table's
+// 'cpi_annual_data' row via LoadCPIData) for callers that want the latest
+// published figures.
+
+// CPIConfigKey is the config table key for CPI data (matches iznik-batch
+// CPIService::CONFIG_KEY / ReuseBenefit::CONFIG_KEY).
+const CPIConfigKey = "cpi_annual_data"
+
+// BaseYear is the base year for the WRAP benefits-of-reuse value.
+const BaseYear = 2011
+
+// BaseBenefitPerTonne is the base benefit of reuse value in GBP per tonne
+// (2011 prices).
+const BaseBenefitPerTonne = 711
+
+// CO2PerTonne is the CO2 impact per tonne (tCO2eq) - not inflation adjusted.
+const CO2PerTonne = 0.51
+
+// FallbackCPIData is the hardcoded fallback UK CPI Annual Averages
+// (2015=100). Source: ONS MM23 dataset, series D7BT. Last updated: January
+// 2025. Copied verbatim from ReuseBenefit::FALLBACK_CPI_DATA /
+// CPIService::FALLBACK_CPI_DATA.
+var FallbackCPIData = map[int]float64{
+	2011: 93.4,
+	2012: 96.1,
+	2013: 98.5,
+	2014: 100.0,
+	2015: 100.0,
+	2016: 100.7,
+	2017: 103.4,
+	2018: 105.9,
+	2019: 107.8,
+	2020: 108.7,
+	2021: 111.6,
+	2022: 121.7,
+	2023: 130.5,
+	2024: 133.9,
+}
+
+// cpiYearRange returns the min and max years present in cpiData.
+func cpiYearRange(cpiData map[int]float64) (minYear int, maxYear int) {
+	first := true
+	for year := range cpiData {
+		if first {
+			minYear, maxYear = year, year
+			first = false
+			continue
+		}
+		if year < minYear {
+			minYear = year
+		}
+		if year > maxYear {
+			maxYear = year
+		}
+	}
+	return minYear, maxYear
+}
+
+// GetCPI returns the CPI value for a given year, clamped to the available
+// range: it returns the latest available year if the requested year is in
+// the future, and the earliest available year if before the first year we
+// have. Pass nil for cpiData to use FallbackCPIData.
+func GetCPI(year int, cpiData map[int]float64) float64 {
+	if len(cpiData) == 0 {
+		cpiData = FallbackCPIData
+	}
+
+	minYear, maxYear := cpiYearRange(cpiData)
+
+	if year < minYear {
+		return cpiData[minYear]
+	}
+	if year > maxYear {
+		return cpiData[maxYear]
+	}
+	return cpiData[year]
+}
+
+// GetInflationMultiplier calculates the inflation multiplier from BaseYear
+// to targetYear. Pass nil for cpiData to use FallbackCPIData.
+func GetInflationMultiplier(targetYear int, cpiData map[int]float64) float64 {
+	baseCPI := GetCPI(BaseYear, cpiData)
+	targetCPI := GetCPI(targetYear, cpiData)
+	return targetCPI / baseCPI
+}
+
+// GetBenefitPerTonne returns the inflation-adjusted benefit per tonne in GBP
+// (rounded to the nearest int, as a float64 to match the PHP round()
+// return type). Pass nil for cpiData to use FallbackCPIData.
+func GetBenefitPerTonne(targetYear int, cpiData map[int]float64) float64 {
+	multiplier := GetInflationMultiplier(targetYear, cpiData)
+	return math.Round(BaseBenefitPerTonne * multiplier)
+}
+
+// cpiConfigRow mirrors the JSON shape CPIService::storeCPIData() writes into
+// the `config` table: {"data": {"2011": 93.4, ...}, "updated_at": ..., "source": ...}.
+type cpiConfigRow struct {
+	Data map[string]float64 `json:"data"`
+}
+
+// LoadCPIData reads the 'cpi_annual_data' row from the `config` table
+// (written by iznik-batch's CPIService::fetchAndStoreCPI) and returns it as
+// a year->CPI map. Mirrors CPIService::getCPIData(): any failure (missing
+// row, malformed JSON, empty data) is tolerated and FallbackCPIData is
+// returned instead - callers never need to nil-check.
+func LoadCPIData(db *gorm.DB) map[int]float64 {
+	var row struct {
+		Value string `gorm:"column:value"`
+	}
+
+	result := db.Raw("SELECT value FROM config WHERE `key` = ? LIMIT 1", CPIConfigKey).Scan(&row)
+	if result.Error != nil || row.Value == "" {
+		return FallbackCPIData
+	}
+
+	var decoded cpiConfigRow
+	if err := json.Unmarshal([]byte(row.Value), &decoded); err != nil || len(decoded.Data) == 0 {
+		return FallbackCPIData
+	}
+
+	cpiData := make(map[int]float64, len(decoded.Data))
+	for yearStr, value := range decoded.Data {
+		year, err := strconv.Atoi(yearStr)
+		if err != nil {
+			continue
+		}
+		cpiData[year] = value
+	}
+
+	if len(cpiData) == 0 {
+		return FallbackCPIData
+	}
+
+	return cpiData
+}

--- a/iznik-server-go/item/reusebenefit_test.go
+++ b/iznik-server-go/item/reusebenefit_test.go
@@ -1,0 +1,59 @@
+package item
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Pure-logic tests for the CPI/benefit-of-reuse math ported from
+// iznik-batch/app/Support/ReuseBenefit.php. These pin the same values the
+// Laravel test suite pins (AuthorityStatsServiceTest::test_reuse_benefit_inflation_and_clamping),
+// so the Go and PHP implementations can't silently drift apart.
+
+func TestGetCPIExactYears(t *testing.T) {
+	assert.Equal(t, 93.4, GetCPI(2011, nil))
+	assert.Equal(t, 133.9, GetCPI(2024, nil))
+}
+
+func TestGetCPIClampsOutOfRangeYears(t *testing.T) {
+	assert.Equal(t, 93.4, GetCPI(2000, nil), "clamps below the range")
+	assert.Equal(t, 133.9, GetCPI(2100, nil), "clamps above the range")
+}
+
+func TestGetBenefitPerTonneMatchesLaravelPinnedValues(t *testing.T) {
+	// Exact values pinned in AuthorityStatsServiceTest.php - must stay in
+	// sync with the PHP port.
+	assert.Equal(t, 711.0, GetBenefitPerTonne(2011, nil))
+	assert.Equal(t, 1019.0, GetBenefitPerTonne(2024, nil))
+}
+
+func TestCO2PerTonneConstant(t *testing.T) {
+	assert.Equal(t, 0.51, CO2PerTonne)
+}
+
+func TestGetBenefitPerTonneClampsToLatestKnownYear(t *testing.T) {
+	// 2026 (a year beyond FallbackCPIData's last entry, 2024) must clamp to
+	// the 2024 CPI value, giving the same benefit as GetBenefitPerTonne(2024).
+	assert.Equal(t, GetBenefitPerTonne(2024, nil), GetBenefitPerTonne(2026, nil))
+}
+
+func TestGetBenefitPerTonneHonoursCustomCPIData(t *testing.T) {
+	custom := map[int]float64{
+		2011: 100.0,
+		2020: 200.0,
+	}
+
+	// Inflation multiplier = 200/100 = 2; benefit = round(711*2) = 1422.
+	assert.Equal(t, 1422.0, GetBenefitPerTonne(2020, custom))
+}
+
+func TestGetCPIEmptyMapFallsBackToDefault(t *testing.T) {
+	// An empty (non-nil) map should behave exactly like nil - matches PHP's
+	// `$cpiData ?: self::FALLBACK_CPI_DATA` (empty array is falsy in PHP).
+	assert.Equal(t, 93.4, GetCPI(2011, map[int]float64{}))
+}
+
+func TestGetInflationMultiplierAtBaseYearIsOne(t *testing.T) {
+	assert.Equal(t, 1.0, GetInflationMultiplier(BaseYear, nil))
+}

--- a/iznik-server-go/router/routes.go
+++ b/iznik-server-go/router/routes.go
@@ -48,6 +48,7 @@ import (
 	"github.com/freegle/iznik-server-go/housekeeper"
 	"github.com/freegle/iznik-server-go/image"
 	"github.com/freegle/iznik-server-go/isochrone"
+	"github.com/freegle/iznik-server-go/item"
 	"github.com/freegle/iznik-server-go/job"
 	"github.com/freegle/iznik-server-go/location"
 	"github.com/freegle/iznik-server-go/logs"
@@ -260,6 +261,18 @@ func SetupRoutes(app *fiber.App) {
 		// @Param id path integer true "Authority ID"
 		// @Success 200 {array} authority.Message
 		rg.Get("/authority/:id/message", authority.Messages)
+
+		// Item impact estimate
+		// @Router /item/impact [get]
+		// @Summary Estimate reuse impact for an item name
+		// @Description Estimates weight, CO2e saved and financial benefit of reuse for qty units of a free-text item name. Public, read-only - never writes to the items catalog. Lookup order: (1) exact case-insensitive match against the items catalog with a known weight, (2) fuzzy word-overlap match (>10%) against the standard weights reference table, (3) popularity-weighted average item weight.
+		// @Tags item
+		// @Produce json
+		// @Param name query string true "Free-text item name"
+		// @Param qty query integer false "Quantity (default 1)"
+		// @Success 200 {object} item.ImpactResponse
+		// @Failure 400 {object} fiber.Error "Missing or empty name"
+		rg.Get("/item/impact", item.Impact)
 
 		// Chats
 		// @Router /chat [get]

--- a/iznik-server-go/test/item_impact_test.go
+++ b/iznik-server-go/test/item_impact_test.go
@@ -1,0 +1,226 @@
+package test
+
+// DB-backed tests for GET /item/impact (item.Impact), covering the
+// three-step lookup (exact items match -> fuzzy weights match -> popularity-
+// weighted average fallback), qty multiplication, and the 400 on a missing
+// or empty name. Pure-logic coverage (canonWord/wordsInCommon/CPI math)
+// lives alongside the implementation in item/impact_test.go and
+// item/reusebenefit_test.go, with no DB required there.
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/freegle/iznik-server-go/item"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func fetchImpact(t *testing.T, name string, qty int) (int, item.ImpactResponse) {
+	t.Helper()
+
+	q := url.Values{}
+	q.Set("name", name)
+	if qty > 0 {
+		q.Set("qty", fmt.Sprintf("%d", qty))
+	}
+
+	req := httptest.NewRequest("GET", "/apiv2/item/impact?"+q.Encode(), nil)
+	resp, err := getApp().Test(req)
+	require.NoError(t, err)
+
+	body, _ := io.ReadAll(resp.Body)
+
+	var result item.ImpactResponse
+	if resp.StatusCode == 200 {
+		require.NoError(t, json.Unmarshal(body, &result), "response body: %s", string(body))
+	}
+
+	return resp.StatusCode, result
+}
+
+func TestItemImpactMissingNameReturns400(t *testing.T) {
+	req := httptest.NewRequest("GET", "/apiv2/item/impact", nil)
+	resp, err := getApp().Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, 400, resp.StatusCode)
+}
+
+func TestItemImpactEmptyNameReturns400(t *testing.T) {
+	status, _ := fetchImpact(t, "   ", 0)
+	assert.Equal(t, 400, status)
+}
+
+func TestItemImpactMissingNameReturns400V1(t *testing.T) {
+	// /api alias must behave the same as /apiv2.
+	req := httptest.NewRequest("GET", "/api/item/impact", nil)
+	resp, err := getApp().Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, 400, resp.StatusCode)
+}
+
+// TestItemImpactExactItemsMatch covers lookup step (a): an exact,
+// case-insensitive items-table match with a known weight wins over
+// everything else, and is found regardless of query casing.
+func TestItemImpactExactItemsMatch(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("ItemImpactExact")
+	itemName := fmt.Sprintf("TestImpactWidget %s", prefix)
+	const knownWeight = 12.5
+
+	itemID := CreateTestItem(t, itemName)
+	db.Exec("UPDATE items SET weight = ? WHERE id = ?", knownWeight, itemID)
+	t.Cleanup(func() {
+		db.Exec("DELETE FROM items WHERE id = ?", itemID)
+	})
+
+	// Query with different casing to prove the match is case-insensitive.
+	status, result := fetchImpact(t, "testimpactwidget "+prefix, 1)
+	require.Equal(t, 200, status)
+
+	assert.Equal(t, "items", result.Source)
+	require.NotNil(t, result.Matched)
+	assert.Equal(t, itemName, *result.Matched)
+	assert.Equal(t, knownWeight, result.PerUnitWeightKg)
+	assert.Equal(t, knownWeight, result.TotalWeightKg)
+	assert.Equal(t, 1, result.Qty)
+}
+
+// TestItemImpactFuzzyWeightsMatch covers lookup step (b): no items-table
+// match, but the query name shares the word "sofa" with the fixture weights
+// row ('2 seater sofa' / simplename 'sofa' / 37.00, scripts/test-fixtures.sql).
+func TestItemImpactFuzzyWeightsMatch(t *testing.T) {
+	prefix := uniquePrefix("ItemImpactFuzzy")
+	// A name that shares exactly the word "sofa" with the weights fixture,
+	// and is otherwise guaranteed not to exist in the items table.
+	name := prefix + " sofa"
+
+	status, result := fetchImpact(t, name, 1)
+	require.Equal(t, 200, status)
+
+	assert.Equal(t, "weights", result.Source)
+	require.NotNil(t, result.Matched)
+	assert.Equal(t, "sofa", *result.Matched)
+	assert.Equal(t, 37.0, result.PerUnitWeightKg)
+}
+
+// TestItemImpactPopulationAverageFallback covers lookup step (c): a name
+// with no items-table match and no usable word-overlap with any weights row
+// falls back to the popularity-weighted average across the items catalog.
+// The expected average is computed with the same SQL the endpoint uses,
+// rather than hardcoded, since it's a genuine global aggregate over
+// whatever items rows exist at test time.
+func TestItemImpactPopulationAverageFallback(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("ItemImpactAvg")
+	// Multiple unrelated words so this can't accidentally trip the
+	// wordsInCommon "single word list" edge case in a way that matters -
+	// the assertion is against the true average either way.
+	name := prefix + " zzqxvbnk unmatchable probe item"
+
+	var avgResult struct {
+		Average *float64
+	}
+	db.Raw("SELECT SUM(popularity*weight)/SUM(popularity) AS average FROM items WHERE weight IS NOT NULL AND weight != 0").Scan(&avgResult)
+	expectedAvg := 0.0
+	if avgResult.Average != nil {
+		expectedAvg = *avgResult.Average
+	}
+	expectedAvg = roundForTest(expectedAvg)
+
+	status, result := fetchImpact(t, name, 1)
+	require.Equal(t, 200, status)
+
+	assert.Equal(t, "average", result.Source)
+	assert.Nil(t, result.Matched)
+	assert.Equal(t, expectedAvg, result.PerUnitWeightKg)
+}
+
+// TestItemImpactQtyMultiplication covers total-weight/CO2e/benefit scaling:
+// totalWeightKg = qty * perUnitWeightKg, and co2e/benefit are computed on
+// that total (not the per-unit weight).
+func TestItemImpactQtyMultiplication(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("ItemImpactQty")
+	itemName := fmt.Sprintf("TestImpactQtyWidget %s", prefix)
+	const knownWeight = 4.0
+	const qty = 3
+
+	itemID := CreateTestItem(t, itemName)
+	db.Exec("UPDATE items SET weight = ? WHERE id = ?", knownWeight, itemID)
+	t.Cleanup(func() {
+		db.Exec("DELETE FROM items WHERE id = ?", itemID)
+	})
+
+	status, result := fetchImpact(t, itemName, qty)
+	require.Equal(t, 200, status)
+
+	assert.Equal(t, qty, result.Qty)
+	assert.Equal(t, knownWeight, result.PerUnitWeightKg)
+
+	expectedTotal := roundForTest(knownWeight * qty)
+	assert.Equal(t, expectedTotal, result.TotalWeightKg)
+
+	expectedCo2e := roundForTest(expectedTotal * 0.51)
+	assert.Equal(t, expectedCo2e, result.Co2eKg)
+
+	expectedBenefit := roundForTest(expectedTotal * result.BenefitPerTonne / 1000)
+	assert.Equal(t, expectedBenefit, result.BenefitGbp)
+}
+
+// TestItemImpactDefaultQtyIsOne covers the qty default when omitted.
+func TestItemImpactDefaultQtyIsOne(t *testing.T) {
+	prefix := uniquePrefix("ItemImpactDefaultQty")
+	status, result := fetchImpact(t, prefix+" sofa", 0)
+	require.Equal(t, 200, status)
+	assert.Equal(t, 1, result.Qty)
+}
+
+// roundForTest mirrors item.round2dp() (unexported, so duplicated here) -
+// using math.Round directly, not a hand-rolled tie-break, so it can't
+// diverge from the implementation's own rounding.
+func roundForTest(v float64) float64 {
+	return math.Round(v*100) / 100
+}
+
+// TestLoadCPIDataFallsBackWhenNoConfigRow covers CPIService's tolerate-
+// absence behaviour: with no 'cpi_annual_data' row in `config` (the default
+// state - no fixture seeds it), LoadCPIData must return data equivalent to
+// FallbackCPIData, not error or panic.
+func TestLoadCPIDataFallsBackWhenNoConfigRow(t *testing.T) {
+	db := database.DBConn
+
+	var exists int64
+	db.Raw("SELECT COUNT(*) FROM config WHERE `key` = ?", item.CPIConfigKey).Scan(&exists)
+	if exists > 0 {
+		t.Skip("a 'cpi_annual_data' config row already exists - not the default-state scenario this test covers")
+	}
+
+	cpiData := item.LoadCPIData(db)
+	assert.Equal(t, item.GetBenefitPerTonne(2011, nil), item.GetBenefitPerTonne(2011, cpiData))
+	assert.Equal(t, item.GetBenefitPerTonne(2024, nil), item.GetBenefitPerTonne(2024, cpiData))
+}
+
+// TestLoadCPIDataHonoursConfigTableOverride covers the override path: a
+// 'cpi_annual_data' row written in CPIService::storeCPIData()'s JSON shape
+// must be read back and change the computed benefit.
+func TestLoadCPIDataHonoursConfigTableOverride(t *testing.T) {
+	db := database.DBConn
+
+	configJSON := `{"data":{"2011":100.0,"2020":200.0},"updated_at":"2026-01-01T00:00:00+00:00","source":"test"}`
+	db.Exec("INSERT INTO config (`key`, value) VALUES (?, ?) ON DUPLICATE KEY UPDATE value = ?",
+		item.CPIConfigKey, configJSON, configJSON)
+	t.Cleanup(func() {
+		db.Exec("DELETE FROM config WHERE `key` = ?", item.CPIConfigKey)
+	})
+
+	cpiData := item.LoadCPIData(db)
+	// Inflation multiplier = 200/100 = 2; benefit = round(711*2) = 1422.
+	assert.Equal(t, 1422.0, item.GetBenefitPerTonne(2020, cpiData))
+}

--- a/iznik-server-go/test/item_impact_test.go
+++ b/iznik-server-go/test/item_impact_test.go
@@ -182,6 +182,17 @@ func TestItemImpactDefaultQtyIsOne(t *testing.T) {
 	assert.Equal(t, 1, result.Qty)
 }
 
+// TestItemImpactQtyIsCapped covers the qty upper bound: a caller-supplied
+// qty far beyond any sane real-world value is clamped down to the server's
+// maximum, rather than being multiplied through unbounded into the
+// response's weight/CO2e/benefit fields.
+func TestItemImpactQtyIsCapped(t *testing.T) {
+	prefix := uniquePrefix("ItemImpactQtyCap")
+	status, result := fetchImpact(t, prefix+" sofa", 999999999)
+	require.Equal(t, 200, status)
+	assert.Equal(t, 100000, result.Qty)
+}
+
 // roundForTest mirrors item.round2dp() (unexported, so duplicated here) -
 // using math.Round directly, not a hand-rolled tie-break, so it can't
 // diverge from the implementation's own rounding.

--- a/iznik-server-go/test/item_impact_test.go
+++ b/iznik-server-go/test/item_impact_test.go
@@ -93,12 +93,17 @@ func TestItemImpactExactItemsMatch(t *testing.T) {
 }
 
 // TestItemImpactFuzzyWeightsMatch covers lookup step (b): no items-table
-// match, but the query name shares the word "sofa" with the fixture weights
-// row ('2 seater sofa' / simplename 'sofa' / 37.00, scripts/test-fixtures.sql).
+// match, but the query name shares the word "sofa" with a weights reference
+// row ('2 seater sofa' / simplename 'sofa' / 37.00 — the same row
+// scripts/test-fixtures.sql ships for the dev DB). iznik_go_test is a
+// SCHEMA-ONLY clone (setup-test-database.sh: "Go tests create their own
+// fixture data at runtime"), so the test seeds the row itself.
 func TestItemImpactFuzzyWeightsMatch(t *testing.T) {
+	database.DBConn.Exec("INSERT IGNORE INTO weights (name, simplename, weight, source) VALUES ('2 seater sofa', 'sofa', 37.00, 'FRN 2009')")
+
 	prefix := uniquePrefix("ItemImpactFuzzy")
-	// A name that shares exactly the word "sofa" with the weights fixture,
-	// and is otherwise guaranteed not to exist in the items table.
+	// A name that shares exactly the word "sofa" with the seeded weights
+	// row, and is otherwise guaranteed not to exist in the items table.
 	name := prefix + " sofa"
 
 	status, result := fetchImpact(t, name, 1)


### PR DESCRIPTION
## Summary
- New public read-only endpoint `GET /item/impact?name=<free text>&qty=<n>` (registered under both `/api` and `/apiv2`), returning `{name, matched, source, qty, perUnitWeightKg, totalWeightKg, co2eKg, benefitGbp, benefitPerTonne, year}`.
- Ports the canonical Laravel impact model to Go so external consumers (first: the Community Clearance app) get the same numbers Freegle itself uses:
  - `item/reusebenefit.go`: WRAP Benefits-of-Reuse constants (CO2 0.51 t/t; £711/t at 2011 prices, CPI-inflated via ONS MM23 D7BT with the `cpi_annual_data` config-table override and the same hardcoded fallback table as `ReuseBenefit.php`).
  - `item/impact.go`: the `ItemService` weight-matching algorithm ported faithfully (canon-word letter-sorting for words >3 chars, word-overlap percentage against the longer list, >10% acceptance) with the three-step lookup: exact `items` catalog match → fuzzy `weights` (FRN 2009) match → popularity-weighted population average.
- Deliberately **read-only**: unlike `ItemService::findOrCreate`, the endpoint never inserts novel names into the `items` catalog, so a public API can't pollute the weight data.
- qty is clamped to [1, 100000]; empty/missing name → 400.

## Code Quality Review
- Adversarially reviewed in two passes (port fidelity vs the PHP originals; Go quality/security). Findings fixed: a `LOWER(name)` wrapper that defeated the case-insensitive unique index (full-table scan per request on a public endpoint), a PCRE-vs-RE2 `\v` tokenisation divergence, and the missing qty upper bound.
- Benefit maths pinned to the same values as the Laravel suite (711 for 2011, 1019 for 2024).

## Test Plan
- Pure-logic tests (no DB): canon-word/word-overlap edge cases incl. the exact-10% boundary and single-word-list quirk; CPI/benefit values matching `AuthorityStatsServiceTest`.
- DB-backed integration tests in `test/`: exact match (case-insensitive), fuzzy match (test self-seeds the FRN 2009 sofa row — `iznik_go_test` is schema-only by design), population-average fallback, qty multiplication/cap, 400s, CPI config override/fallback.
- Full Go suite run locally in an isolated worktree stack via the status API: **3552 passed, 0 failed**.

## Future Improvements
- A short docs/developers page for the endpoint (no existing doc page covers these paths, so the freshness gate is unaffected).
- Community Clearance already ships a client for this endpoint (remote-with-local-fallback via `FREEGLE_API_BASE`), so it lights up on deploy with no further changes.