### PR TITLE
fix(posting): regex lookbehind broke posting on iOS below 16.4

### DIFF
--- a/iznik-nuxt3/.eslintrc.js
+++ b/iznik-nuxt3/.eslintrc.js
@@ -32,6 +32,19 @@ module.exports = {
       },
     ],
 
+    // Regex lookbehind ((?<=...) / (?<!...)) is unsupported by Safari before
+    // 16.4. An unsupported regex *literal* fails to parse, which kills the
+    // whole chunk and white-screens the page - not just the check using it.
+    // Rewrite as (?:^|\D)-style alternation instead.
+    'no-restricted-syntax': [
+      'error',
+      {
+        selector: 'Literal[regex.pattern=/\\(\\?<[=!]/]',
+        message:
+          'Regex lookbehind is unsupported by Safari < 16.4 and breaks the whole chunk at parse time. Rewrite without it (e.g. (?<!\\d) becomes (?:^|\\D)).',
+      },
+    ],
+
     // We have a lot of legacy code which doesn't define emits.
     'vue/require-explicit-emits': 'off',
     // no-v-model-argument rule is broken for Vue3, which requires that syntax for .sync.

--- a/iznik-nuxt3/composables/usePersonalInfoWarning.js
+++ b/iznik-nuxt3/composables/usePersonalInfoWarning.js
@@ -1,10 +1,16 @@
 import { computed } from 'vue'
 
 // UK phone number pattern matching the server-side ContentCheckService.
-// Requires a proper UK prefix (0, +44, or 0044) followed by 9–10 digits
+// Requires a proper UK prefix (0, +44, or 0044) followed by 9-10 digits
 // (with optional spaces/hyphens). This mirrors the PHP regex:
 //   /(?<!\d)(?:(?:\+44|0044)\s?|0)(?:\d[\s\-]?){9,10}(?!\d)/
-const UK_PHONE_RE = /(?<!\d)(?:(?:\+44|0044)\s?|0)(?:\d[\s-]?){9,10}(?!\d)/
+//
+// NOTE: the PHP lookbehind (?<!\d) is expressed here as (?:^|\D) instead.
+// Lookbehind is unsupported by Safari before 16.4, and an unsupported regex
+// literal is a *parse* error, so it takes out the whole chunk rather than just
+// this check - which white-screened the posting flow for users on older iOS.
+// Do not reintroduce lookbehind here. (?:^|\D) is equivalent for .test().
+const UK_PHONE_RE = /(?:^|\D)(?:(?:\+44|0044)\s?|0)(?:\d[\s-]?){9,10}(?!\d)/
 
 // External email address pattern (freegle/trashnothing addresses are excluded).
 const EMAIL_RE = /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/

--- a/iznik-nuxt3/tests/unit/composables/usePersonalInfoWarning.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/usePersonalInfoWarning.spec.js
@@ -42,6 +42,22 @@ describe('detectPersonalInfo', () => {
     expect(detectPersonalInfo('It weighs about 123 grams').hasPhone).toBe(false)
   })
 
+  // The pattern must not match part-way into a longer run of digits. This was
+  // originally expressed as a lookbehind, which Safari < 16.4 cannot parse at
+  // all - so it is now (?:^|\D). These cases pin that equivalence.
+  it.each([
+    ['long digit run', '1234567890123'],
+    ['phone-like run preceded by a digit', '50791112345678'],
+    ['digits either side', 'ref 9900791112345600'],
+    ['leading zeroes mid-run', 'order 000123456789012'],
+  ])('does not detect a phone number mid-digit-run: %s', (_label, text) => {
+    expect(detectPersonalInfo(text).hasPhone).toBe(false)
+  })
+
+  it('still detects a phone number preceded by non-digit characters', () => {
+    expect(detectPersonalInfo('abc0791 112 3456').hasPhone).toBe(true)
+  })
+
   it('detects an external email address as hasEmail true', () => {
     const result = detectPersonalInfo('Reach me at bob@example.com thanks')
     expect(result.hasEmail).toBe(true)


### PR DESCRIPTION
## Problem

Freeglers on older iPhones could not post. They got a dead **"Oh dear! Something went wrong..."** page with:

```
Error was: {"message":"Invalid regular expression: invalid group specifier name","statusCode":500}
```

The `statusCode: 500` is a red herring. `error.vue` stringifies the Nuxt error object, and 500 is simply Nuxt's default for any unhandled client-side error. No API call failed, and there is nothing in the server logs.

## Cause

`composables/usePersonalInfoWarning.js` used a regex lookbehind, `(?<!\d)`, to mirror the PHP UK phone pattern in `ContentCheckService`. **WebKit only gained lookbehind support in Safari/iOS 16.4.**

An unsupported regex *literal* is a **parse** error, not a runtime one, so the entire JS chunk fails to load. That turns a minor warning feature into a completely broken page.

The composable is imported by `PostPersonalInfoWarning.vue`, used on the give/find `whereami` pages, so it broke the posting flow specifically.

Shipped in `71e5db5ad` (2026-06-17).

## Evidence

Production Loki, `{app="freegle",source="client"} |~ "invalid group specifier"`:

| URL | iOS |
|---|---|
| `capacitor://localhost/find/mobile/whereami` | 15.8.8 |
| `capacitor://localhost/give/mobile/whereami` | 16.0 |

Both below the 16.4 cutoff, both on the posting pages. This text only reaches Loki when the user happens to interact with the error page, so the observed count understates the real impact.

Reported via support by a freegler on iOS 16.0 whose last successful post was 2026-06-05, twelve days before the composable shipped.

## Fix

- Rewrote the pattern as `(?:^|\D)`, which is equivalent for `.test()`. Verified identical behaviour across 20 inputs, including the mid-digit-run cases the lookbehind existed to guard against.
- Added tests pinning those mid-digit-run cases so the equivalence cannot silently regress.
- Added an eslint `no-restricted-syntax` rule banning lookbehind in regex literals. Verified it fires on both `(?<=` and `(?<!`, and that no other violations exist in the codebase.

Worth noting that `@vitejs/plugin-legacy` cannot help here. Lookbehind is a runtime engine feature, so babel cannot transpile it away, and the `ios>=12` target at `nuxt.config.ts:608` gave false reassurance.

## Testing

Full unit suite run locally via the status API: **680 files, 14395 passed, 0 failed**.

While doing this I found the local `modtools-dev-local` container had drifted badly from the working tree, 31 stale source files and a stale `package-lock.json`, which produced 4 phantom failures. Those were container staleness rather than code, and all pass once synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UdLP1MADbXW9vPAh4JSWNM
