### PR TITLE
fix(similarity): recalibrate both vector floors against measured precision

### DIFF
--- a/docker/embedding-sidecar/server.mjs
+++ b/docker/embedding-sidecar/server.mjs
@@ -18,6 +18,12 @@ env.cacheDir = process.env.HF_CACHE_DIR || '/app/model-cache';
 
 console.log(JSON.stringify({ level: 'info', event: 'startup', num_threads: NUM_THREADS }));
 
+// NOTE: `quantized` is a transformers.js **v2** option and is ignored by the v3
+// runtime we are on: this loads the fp32 model.onnx (~547MB), not an int8 one.
+// Leave it that way. The 194k embeddings in messages_embeddings were all
+// generated fp32, and switching this process to `dtype: 'q8'` would quantize
+// query vectors only, putting them in a different space from every stored
+// document vector. Changing it means re-embedding the whole corpus first.
 const extractor = await pipeline(
   'feature-extraction',
   'nomic-ai/nomic-embed-text-v1.5',

--- a/docs/developers/reference/matched-posts-email.md
+++ b/docs/developers/reference/matched-posts-email.md
@@ -1,5 +1,5 @@
 ---
-last_reviewed: 2026-07-19
+last_reviewed: 2026-07-20
 owner: Freegle dev team
 covers:
   - iznik-server-go/message/postmatches.go
@@ -32,7 +32,8 @@ This is a **separate** mail from the daily digest's relevance ranking
    (`iznik-server-go/message/postmatches.go`), which returns the opposite-type
    open posts near it from the in-memory vector store — bbox-scoped, reach-filtered
    against the *post owner* (the caller is unauthenticated batch), above
-   `MinSimilarScore`. The vector maths lives only in Go; there is no SQL KNN.
+   `MinMatchedPostScore` (see [Similarity floor](#similarity-floor)). The vector
+   maths lives only in Go; there is no SQL KNN.
 4. **Both directions** fall out of that one search: the fresh post's owner is shown
    the matches, and each matched post's owner is shown the fresh post.
 5. **Guards** (`MatchedPostsService::applyEligibility`): never the recipient's own
@@ -87,3 +88,44 @@ renders it into Mailpit with real recent posts as stand-in matches.
 
 `fresh_window_minutes`, `match_limit_per_post`, `max_items_per_email`,
 `cooldown_hours`, `min_lastaccess_days` — all env-overridable.
+
+## Similarity floor
+
+The only quality gate is `MinMatchedPostScore` in `iznik-server-go/message/postmatches.go`.
+Laravel does not apply a floor of its own (it sorts on the scores the API returns),
+so this constant alone decides what lands in someone's inbox.
+
+It is **0.85, deliberately not** the similar-posts `MinSimilarScore` (0.60). Two
+reasons the surfaces differ: matched posts are pushed to an inbox unasked rather
+than offered to someone already browsing, and both sides of the comparison are
+stored `search_document:` embeddings, so the cosines run far higher than the
+query-vs-document scores 0.60 was chosen against.
+
+Measured by scoring 150 randomly sampled live Offers against the live Wanted pool
+and hand-judging the top match. Precision is a cliff, not a slope:
+
+| top-1 score | matches | precision |
+|---|---|---|
+| >= 0.90 | 20 | 1.00 |
+| 0.85-0.90 | 25 | 0.92 |
+| 0.80-0.85 | 21 | 0.43 |
+| 0.75-0.80 | 47 | 0.36 |
+| 0.60-0.75 | 37 | 0.11 |
+
+At 0.60 just under half the emails carry an irrelevant item (Bed lever -> "Bed",
+Screen protectors -> "Curtains", Keyrings -> "Rugs"). At 0.85 precision is 0.96
+and 30% of sampled posts still match, which is ample for a 10-minute job. The
+trade is recall, about 59% of true matches are kept, and that is the right way
+round for unsolicited mail.
+
+Two things that sound like improvements and measurably are not, both tested on
+400 gold Offer/Wanted pairs:
+
+- **Embedding the body as well as the subject makes it much worse** (recall@1
+  0.905 -> 0.535). Bodies are dominated by shared boilerplate ("collection times",
+  "no resellers"), which swamps the item itself.
+- **Storing 768 dims instead of the Matryoshka-truncated 256** buys almost
+  nothing (recall@1 0.905 -> 0.912) for 3x the storage and resident memory.
+
+Retrieval itself is not the weak link: at the production setting, when a true
+match exists it is ranked first 90% of the time and in the top 5 98% of the time.

--- a/docs/developers/reference/matched-posts-email.md
+++ b/docs/developers/reference/matched-posts-email.md
@@ -95,11 +95,18 @@ The only quality gate is `MinMatchedPostScore` in `iznik-server-go/message/postm
 Laravel does not apply a floor of its own (it sorts on the scores the API returns),
 so this constant alone decides what lands in someone's inbox.
 
-It is **0.85, deliberately not** the similar-posts `MinSimilarScore` (0.60). Two
-reasons the surfaces differ: matched posts are pushed to an inbox unasked rather
-than offered to someone already browsing, and both sides of the comparison are
-stored `search_document:` embeddings, so the cosines run far higher than the
-query-vs-document scores 0.60 was chosen against.
+It is **0.85, deliberately higher** than the similar-posts `MinSimilarScore`
+(0.80, itself raised from 0.60 by the same exercise). Matched posts are pushed to
+an inbox unasked rather than offered to someone already browsing, so the bar is
+higher here: a slightly-off suggestion beside something you are already looking
+at costs little, while a weak match in an inbox teaches people to ignore the next
+one.
+
+Both floors were originally too low for the same reason. They were picked against
+query-vs-document cosines (a typed `search_query:` embedding against stored
+`search_document:` ones), but both surfaces actually compare two *stored*
+document embeddings, where cosines run much higher. The old numbers were not on
+the scale they were assumed to be on.
 
 Measured by scoring 150 randomly sampled live Offers against the live Wanted pool
 and hand-judging the top match. Precision is a cliff, not a slope:

--- a/iznik-batch/resources/js/embed.mjs
+++ b/iznik-batch/resources/js/embed.mjs
@@ -15,7 +15,11 @@ const BATCH_SIZE = 64;
 // Cache model files alongside the script
 env.cacheDir = process.env.HF_CACHE_DIR || '/tmp/hf-cache';
 
-// Load model once
+// Load model once.
+// `quantized` is a transformers.js v2 option that the v3 runtime ignores, so
+// this is the fp32 model. Keep it fp32: every stored embedding was generated
+// this way, and quantizing only one side of the comparison would put queries in
+// a different space from documents. Re-embed the corpus before changing it.
 const extractor = await pipeline(
   'feature-extraction',
   'nomic-ai/nomic-embed-text-v1.5',

--- a/iznik-server-go/message/postmatches.go
+++ b/iznik-server-go/message/postmatches.go
@@ -17,6 +17,32 @@ func matchedPostsEnabled() bool {
 	return os.Getenv("FEATURE_MATCHED_POSTS") != "off"
 }
 
+// MinMatchedPostScore is the minimum subject cosine for an opposite-type post to
+// be worth emailing about. Deliberately NOT MinSimilarScore (0.60): that floor
+// was tuned for the on-site similar-posts strip, where the viewer is already
+// browsing and a weak suggestion costs nothing. Two things make this surface
+// different: the match is pushed into someone's inbox unasked, and both sides
+// are stored "search_document:" embeddings, so cosines sit far higher than the
+// query-vs-document scores 0.60 was picked against.
+//
+// Measured on 150 randomly sampled live Offers scored against the live Wanted
+// pool, hand-judging the top match ("would someone who posted this Wanted be
+// glad to see this Offer?"). Precision by band is a cliff, not a slope:
+//
+//	>= 0.90   20 matches, precision 1.00
+//	0.85-0.90 25 matches, precision 0.92
+//	0.80-0.85 21 matches, precision 0.43   <-- falls off here
+//	0.75-0.80 47 matches, precision 0.36
+//	0.60-0.75 37 matches, precision 0.11
+//
+// At 0.60 just under half the emails would carry an irrelevant item (Bed lever →
+// "Bed", Screen protectors → "Curtains", Keyrings → "Rugs"). At 0.85 precision
+// is 0.96 and 30% of sampled posts still produce a match, which is ample volume
+// for an every-10-minutes job. Recall is the thing being traded away (59% of
+// true matches kept) and that is the right trade for unsolicited mail: a missed
+// match costs one email, a junk match teaches people to ignore the next one.
+const MinMatchedPostScore = 0.85
+
 // oppositeType maps Offer↔Wanted; any other type yields "" (no matching).
 func oppositeType(t string) string {
 	switch t {
@@ -138,7 +164,7 @@ func PostMatches(c *fiber.Ctx) error {
 		if cnd.Fromuser == srcFromuser {
 			continue // the owner's own posts
 		}
-		if cnd.SubjectCos < MinSimilarScore {
+		if cnd.SubjectCos < MinMatchedPostScore {
 			continue
 		}
 		if blocked[cnd.Msgid] {

--- a/iznik-server-go/message/postmatches.go
+++ b/iznik-server-go/message/postmatches.go
@@ -18,12 +18,12 @@ func matchedPostsEnabled() bool {
 }
 
 // MinMatchedPostScore is the minimum subject cosine for an opposite-type post to
-// be worth emailing about. Deliberately NOT MinSimilarScore (0.60): that floor
-// was tuned for the on-site similar-posts strip, where the viewer is already
-// browsing and a weak suggestion costs nothing. Two things make this surface
-// different: the match is pushed into someone's inbox unasked, and both sides
-// are stored "search_document:" embeddings, so cosines sit far higher than the
-// query-vs-document scores 0.60 was picked against.
+// be worth emailing about. Deliberately higher than MinSimilarScore (0.80):
+// that floor governs the on-site similar-posts strip, where the viewer is
+// already browsing and a weak suggestion costs nothing. Two things make this
+// surface different: the match is pushed into someone's inbox unasked, and
+// both sides are stored "search_document:" embeddings, so cosines sit far
+// higher than the query-vs-document scores these floors were picked against.
 //
 // Measured on 150 randomly sampled live Offers scored against the live Wanted
 // pool, hand-judging the top match ("would someone who posted this Wanted be
@@ -64,7 +64,7 @@ func oppositeType(t string) string {
 // (3) reach-filtered against the POST's own location, not the caller's — the
 // batch calls this unauthenticated, and the recipient is the post's owner, so a
 // candidate that hasn't rippled out to the post's area is dropped. Excludes the
-// owner's own posts and applies MinSimilarScore. Uses the stored subject
+// owner's own posts and applies MinMatchedPostScore. Uses the stored subject
 // embedding (in-memory store, else one indexed read). Empty (never 500) when the
 // post has no embedding, no location, or isn't an Offer/Wanted.
 //

--- a/iznik-server-go/message/similar.go
+++ b/iznik-server-go/message/similar.go
@@ -6,25 +6,53 @@ import (
 
 	"github.com/freegle/iznik-server-go/database"
 	"github.com/freegle/iznik-server-go/embedding"
+	"github.com/freegle/iznik-server-go/misc"
 	"github.com/freegle/iznik-server-go/user"
 	"github.com/freegle/iznik-server-go/utils"
 	"github.com/gofiber/fiber/v2"
 )
 
 // MinSimilarScore is the minimum subject-field cosine for a post to count as
-// "similar". Lower than search's MinVectorScore (0.65) because this is an
-// exploratory surface (a recommendation strip, not a search query), but high
-// enough to keep out junk. Tune from the recommendations telemetry.
+// "similar". This is an exploratory surface (a recommendation strip, not a
+// search query), so the bar is lower than for the matched-posts email, which
+// pushes into an inbox unasked and uses MinMatchedPostScore (0.85).
 //
-// Worth knowing before tuning: this compares two STORED embeddings, both built
-// with the "search_document:" prefix, so the cosines sit much higher than the
-// query-vs-document scores 0.60 was originally picked against. The same floor
-// turned out to be far too loose on the matched-posts email, where measurement
-// put the useful cut at 0.85 (see MinMatchedPostScore in postmatches.go). This
-// surface has not been measured the same way. It is lower stakes, since a weak
-// suggestion in a browse strip costs nothing like a weak match pushed to an
-// inbox, but do not assume 0.60 is filtering much here either.
-const MinSimilarScore = 0.60
+// It is NOT lower than search's MinVectorScore (0.65), which is what the
+// original 0.60 assumed. Search compares a typed "search_query:" embedding
+// against stored "search_document:" ones; this compares two stored document
+// embeddings, and those cosines run much higher, so 0.60 here is a far weaker
+// filter than 0.65 there. The two numbers are not on the same scale.
+//
+// Measured by scoring 150 randomly sampled live Offers against the live Offer
+// pool (same type, self and verbatim reprints excluded) and hand-judging the
+// top suggestion, asking "would someone looking at this plausibly want that?":
+//
+//	0.90-1.00  44 shown, precision 0.98
+//	0.85-0.90  34 shown, precision 1.00
+//	0.80-0.85  33 shown, precision 0.67
+//	0.75-0.80  21 shown, precision 0.43
+//	below 0.75 18 shown, precision 0.17
+//
+// At 0.60 about a quarter of strips led with something unrelated that merely
+// shared a word: Crocosmia -> "Crockery", Motherboard -> "Headboard", Laptop
+// arm -> "Arm chair", Green House -> "Hedgehog House". 0.80 lifts precision
+// from 0.74 to 0.89 while still showing a strip on 74% of posts.
+//
+// 0.85 would give 0.99 precision but halves coverage to 52%, which is the wrong
+// trade here: unlike the email, a slightly-off suggestion beside something you
+// are already looking at costs little, whereas an empty strip loses the
+// exploration entirely.
+//
+// Live telemetry agrees the old floor was not working. Over 14 days to
+// 2026-07-20, source='similar_posts' saw 714 impressions and 3 clicks, a 0.4%
+// click-through, against 16% for 'wanted_match' (163/26). Placement differs so
+// they are not strictly comparable, but a 40x gap is not placement alone.
+//
+// Both numbers above are hand-judged, because until now nothing recorded the
+// score behind an impression. logSimilarImpressions (below) now does, so the
+// next revision of this constant can be made on click-through per score band
+// instead.
+const MinSimilarScore = 0.80
 
 // similarPostsEnabled reports whether the similar-posts feature is on.
 // FEATURE_SIMILAR_POSTS=off is a no-deploy killswitch (default on); when off the
@@ -159,5 +187,46 @@ func Similar(c *fiber.Ctx) error {
 		}
 	}
 
+	logSimilarImpressions(id, myid, out)
+
 	return c.JSON(out)
+}
+
+// logSimilarImpressions records what this strip actually served, one line per
+// candidate, so the floor above can be tuned on evidence rather than judgement.
+//
+// The gap this closes: messages_likes tags a recommendation impression with
+// `source` and whether it was opened (`pageview`), but not the similarity score
+// that caused it to be shown. So the funnel in recommendations/stats.go can say
+// the strip converts at 0.4%, but not whether the clicks come from the 0.95
+// suggestions and the 0.82 ones are dead weight, which is the number needed to
+// set MinSimilarScore. Joining these lines to the click rows on (msgid, userid)
+// within the view window gives click-through per score band.
+//
+// Deliberately NOT a score column on messages_likes: that table is 65M rows and
+// 11GB on prod, so widening it is an online-DDL job on a hot write path, for a
+// surface serving ~50 impressions a day. Logging is free and enough at this
+// volume. Revisit if the strip ever gets heavily used.
+//
+// To read it back:
+//
+//	{app="freegle", source="similar_posts", event="impression"} | json
+//
+// giving msgid, score, src_msgid and userid per served candidate. Bucket by
+// score and join to the clicks (messages_likes, type='View', source='similar_posts',
+// pageview=1) on (msgid, userid) to get click-through per band.
+func logSimilarImpressions(srcMsgid, myid uint64, served []SimilarResult) {
+	loki := misc.GetLoki()
+	if loki == nil || !loki.IsEnabled() || len(served) == 0 {
+		return
+	}
+
+	for _, r := range served {
+		loki.LogCustom("similar_posts", map[string]string{"event": "impression"}, map[string]interface{}{
+			"src_msgid": srcMsgid,
+			"msgid":     r.Msgid,
+			"score":     r.Score,
+			"userid":    myid, // 0 when logged out
+		})
+	}
 }

--- a/iznik-server-go/message/similar.go
+++ b/iznik-server-go/message/similar.go
@@ -15,6 +15,15 @@ import (
 // "similar". Lower than search's MinVectorScore (0.65) because this is an
 // exploratory surface (a recommendation strip, not a search query), but high
 // enough to keep out junk. Tune from the recommendations telemetry.
+//
+// Worth knowing before tuning: this compares two STORED embeddings, both built
+// with the "search_document:" prefix, so the cosines sit much higher than the
+// query-vs-document scores 0.60 was originally picked against. The same floor
+// turned out to be far too loose on the matched-posts email, where measurement
+// put the useful cut at 0.85 (see MinMatchedPostScore in postmatches.go). This
+// surface has not been measured the same way. It is lower stakes, since a weak
+// suggestion in a browse strip costs nothing like a weak match pushed to an
+// inbox, but do not assume 0.60 is filtering much here either.
 const MinSimilarScore = 0.60
 
 // similarPostsEnabled reports whether the similar-posts feature is on.

--- a/iznik-server-go/test/postmatches_test.go
+++ b/iznik-server-go/test/postmatches_test.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"encoding/json"
+	"math"
 	"net/http/httptest"
 	"testing"
 	"time"
@@ -13,8 +14,74 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// makeVecWithCosine returns a unit vector whose cosine with base is approximately
+// target, by mixing base with a vector orthogonal to it. The orthogonal component
+// is built by rotating adjacent pairs of base's components (a, b) -> (b, -a),
+// which is orthogonal to base because each pair contributes ab - ba = 0.
+// Lets a test pin behaviour at a specific similarity rather than just "parallel"
+// or "antiparallel".
+func makeVecWithCosine(base [embedding.EmbeddingDim]float32, target float64) [embedding.EmbeddingDim]float32 {
+	var orth [embedding.EmbeddingDim]float32
+	for i := 0; i+1 < embedding.EmbeddingDim; i += 2 {
+		orth[i] = base[i+1]
+		orth[i+1] = -base[i]
+	}
+	a := float32(target)
+	b := float32(math.Sqrt(1 - target*target))
+
+	var v [embedding.EmbeddingDim]float32
+	var norm float32
+	for i := 0; i < embedding.EmbeddingDim; i++ {
+		v[i] = a*base[i] + b*orth[i]
+		norm += v[i] * v[i]
+	}
+	norm = float32(math.Sqrt(float64(norm)))
+	for i := 0; i < embedding.EmbeddingDim; i++ {
+		v[i] /= norm
+	}
+	return v
+}
+
+// TestPostMatchesThresholdExcludesMidBand pins the matched-posts floor at
+// MinMatchedPostScore rather than the similar-posts MinSimilarScore (0.60).
+//
+// The band between them is exactly where this feature used to hurt: on 150
+// hand-judged live samples, candidates scoring 0.75-0.85 were relevant only ~36%
+// of the time, so a 0.60 floor put an irrelevant item in roughly half the emails.
+// A 0.78-similarity candidate clears the old floor comfortably and must still be
+// dropped here; without this test, reverting to MinSimilarScore stays green.
+func TestPostMatchesThresholdExcludesMidBand(t *testing.T) {
+	base := makeTestVec(0.5)
+	const srcID, midID, strongID = 852001, 852002, 852003
+	const u1, u2 = uint64(94001), uint64(94002)
+
+	mid := makeVecWithCosine(base, 0.78)    // above old 0.60, below new 0.85
+	strong := makeVecWithCosine(base, 0.95) // clears the new floor
+
+	embedding.Global.SetEntries([]embedding.Entry{
+		{Msgid: srcID, Fromuser: u1, Groupid: 100, Msgtype: "Offer", Lat: 51.5, Lng: -0.1, Subject: "Bed lever", Arrival: time.Now(), SubjectVec: base},
+		{Msgid: midID, Fromuser: u2, Groupid: 100, Msgtype: "Wanted", Lat: 51.5, Lng: -0.1, Subject: "Bed", Arrival: time.Now(), SubjectVec: mid},
+		{Msgid: strongID, Fromuser: u2, Groupid: 100, Msgtype: "Wanted", Lat: 51.5, Lng: -0.1, Subject: "Bed lever wanted", Arrival: time.Now(), SubjectVec: strong},
+	})
+	defer embedding.Global.SetEntries(nil)
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/message/852001/matches", nil), 60000)
+	require.Equal(t, 200, resp.StatusCode)
+
+	var results []message.SimilarResult
+	json.NewDecoder(resp.Body).Decode(&results)
+
+	got := map[uint64]bool{}
+	for _, r := range results {
+		got[r.Msgid] = true
+		assert.GreaterOrEqual(t, r.Score, float32(message.MinMatchedPostScore))
+	}
+	assert.True(t, got[uint64(strongID)], "0.95 similarity is emailed")
+	assert.False(t, got[uint64(midID)], "0.78 similarity clears the old 0.60 floor but must not be emailed")
+}
+
 // TestPostMatchesReturnsOppositeType: given a source Offer, /message/:id/matches
-// returns only open OPPOSITE-type (Wanted) posts, above MinSimilarScore, by a
+// returns only open OPPOSITE-type (Wanted) posts, above MinMatchedPostScore, by a
 // DIFFERENT author. Same-type, weak, and same-author candidates are all dropped.
 func TestPostMatchesReturnsOppositeType(t *testing.T) {
 	base := makeTestVec(0.5)
@@ -39,7 +106,7 @@ func TestPostMatchesReturnsOppositeType(t *testing.T) {
 
 	require.Len(t, results, 1, "only the opposite-type, above-threshold, different-author match qualifies")
 	assert.Equal(t, uint64(wantedID), results[0].Msgid)
-	assert.GreaterOrEqual(t, results[0].Score, float32(message.MinSimilarScore))
+	assert.GreaterOrEqual(t, results[0].Score, float32(message.MinMatchedPostScore))
 	assert.NotZero(t, results[0].Lat, "lat populated (blurred)")
 	assert.NotZero(t, results[0].Lng, "lng populated (blurred)")
 	assert.Equal(t, uint64(100), results[0].Groupid)

--- a/iznik-server-go/test/similar_test.go
+++ b/iznik-server-go/test/similar_test.go
@@ -14,6 +14,80 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestSimilarImpressionLoggingDoesNotAffectResults covers the impression
+// logging added so MinSimilarScore can be tuned on click-through per score band.
+//
+// It asserts the endpoint's output is unchanged with Loki enabled, not that a
+// line was written: misc.GetLoki() is a sync.Once singleton, so whichever test
+// runs first fixes its enabled/disabled state for the whole process and a
+// file-content assertion would pass or fail on test ordering. What matters here
+// is that instrumentation on the serving path cannot change or break what the
+// strip returns.
+func TestSimilarImpressionLoggingDoesNotAffectResults(t *testing.T) {
+	t.Setenv("LOKI_ENABLED", "true")
+	t.Setenv("LOKI_JSON_PATH", t.TempDir())
+
+	base := makeTestVec(0.5)
+	strong := makeVecWithCosine(base, 0.93)
+	const srcID, okID = 813001, 813002
+	const u1, u2 = uint64(96001), uint64(96002)
+
+	embedding.Global.SetEntries([]embedding.Entry{
+		{Msgid: srcID, Fromuser: u1, Groupid: 100, Msgtype: "Offer", Lat: 51.5, Lng: -0.1, Subject: "Dining table", Arrival: time.Now(), SubjectVec: base},
+		{Msgid: okID, Fromuser: u2, Groupid: 100, Msgtype: "Offer", Lat: 51.5, Lng: -0.1, Subject: "Dining table and chairs", Arrival: time.Now(), SubjectVec: strong},
+	})
+	defer embedding.Global.SetEntries(nil)
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/message/813001/similar", nil), 60000)
+	require.Equal(t, 200, resp.StatusCode)
+
+	var results []message.SimilarResult
+	json.NewDecoder(resp.Body).Decode(&results)
+
+	require.Len(t, results, 1, "logging must not drop or duplicate served candidates")
+	assert.Equal(t, uint64(okID), results[0].Msgid)
+	assert.GreaterOrEqual(t, results[0].Score, float32(message.MinSimilarScore))
+}
+
+// TestSimilarThresholdExcludesWeakBand pins the strip's floor at the measured
+// 0.80 rather than the original 0.60.
+//
+// The band between them is where the strip used to embarrass itself: on 150
+// hand-judged live samples, top suggestions scoring 0.75-0.80 were useful only
+// 43% of the time and below 0.75 only 17%, producing pairings that shared a word
+// and nothing else (Crocosmia -> "Crockery", Motherboard -> "Headboard"). A 0.70
+// candidate clears the old floor comfortably and must still be dropped; without
+// this, lowering the constant back to 0.60 stays green.
+func TestSimilarThresholdExcludesWeakBand(t *testing.T) {
+	base := makeTestVec(0.5)
+	const srcID, weakID, strongID = 812001, 812002, 812003
+	const u1, u2 = uint64(95001), uint64(95002)
+
+	weak := makeVecWithCosine(base, 0.70)   // above old 0.60, below new 0.80
+	strong := makeVecWithCosine(base, 0.92) // clears the new floor
+
+	embedding.Global.SetEntries([]embedding.Entry{
+		{Msgid: srcID, Fromuser: u1, Groupid: 100, Msgtype: "Offer", Lat: 51.5, Lng: -0.1, Subject: "Crocosmia", Arrival: time.Now(), SubjectVec: base},
+		{Msgid: weakID, Fromuser: u2, Groupid: 100, Msgtype: "Offer", Lat: 51.5, Lng: -0.1, Subject: "Crockery", Arrival: time.Now(), SubjectVec: weak},
+		{Msgid: strongID, Fromuser: u2, Groupid: 100, Msgtype: "Offer", Lat: 51.5, Lng: -0.1, Subject: "Crocosmia bulbs", Arrival: time.Now(), SubjectVec: strong},
+	})
+	defer embedding.Global.SetEntries(nil)
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/message/812001/similar", nil), 60000)
+	require.Equal(t, 200, resp.StatusCode)
+
+	var results []message.SimilarResult
+	json.NewDecoder(resp.Body).Decode(&results)
+
+	got := map[uint64]bool{}
+	for _, r := range results {
+		got[r.Msgid] = true
+		assert.GreaterOrEqual(t, r.Score, float32(message.MinSimilarScore))
+	}
+	assert.True(t, got[uint64(strongID)], "0.92 similarity is shown")
+	assert.False(t, got[uint64(weakID)], "0.70 similarity clears the old 0.60 floor but must not be shown")
+}
+
 // TestSimilarReturnsNearMatchesSameType: given a source Offer, /similar returns
 // only open posts that are the same type, above MinSimilarScore, by a DIFFERENT
 // author, and not the source itself.


### PR DESCRIPTION
Both vector-similarity floors were set against the wrong scale, and both were measured and corrected here.

The floors were picked as if they applied to query-vs-document cosines (a typed `search_query:` embedding against stored `search_document:` ones). Both surfaces actually compare two *stored* document embeddings, whose cosines run far higher. `MinSimilarScore = 0.60` was even justified in a comment as "lower than search's MinVectorScore (0.65)", which reads as deliberate but compares two numbers that were never on the same scale.

Method for both: sample live posts, score them against the live pool, hand-judge the top result, and read precision by score band.

## Matched-posts email: 0.60 (reused `MinSimilarScore`) -> `MinMatchedPostScore` 0.85

150 random live Offers against the live Wanted pool. "Would someone who posted this Wanted be glad to see this Offer?"

| top-1 score | matches | precision |
|---|---|---|
| >= 0.90 | 20 | 1.00 |
| 0.85-0.90 | 25 | 0.92 |
| 0.80-0.85 | 21 | 0.43 |
| 0.75-0.80 | 47 | 0.36 |
| 0.60-0.75 | 37 | 0.11 |

At 0.60 just under half the emails carried an irrelevant item: Bed lever -> "Bed", Screen protectors -> "Curtains", Keyrings -> "Rugs", Casio Watches -> "Apple watch". At 0.85 precision is 0.96 and 30% of sampled posts still match, ample for a job running every 10 minutes. The trade is recall (about 59% of true matches kept), the right way round for unsolicited mail: a missed match costs one email, a junk match teaches people to ignore the next one.

## Similar-posts strip: `MinSimilarScore` 0.60 -> 0.80

150 random live Offers against the live Offer pool, same type, self and verbatim reprints excluded. "Would someone looking at this plausibly want that?"

| top-1 score | shown | precision |
|---|---|---|
| 0.90-1.00 | 44 | 0.98 |
| 0.85-0.90 | 34 | 1.00 |
| 0.80-0.85 | 33 | 0.67 |
| 0.75-0.80 | 21 | 0.43 |
| below 0.75 | 18 | 0.17 |

At 0.60 roughly a quarter of strips led with something sharing a word and nothing else: Crocosmia -> "Crockery", Motherboard -> "Headboard", Laptop arm -> "Arm chair", Green House -> "Hedgehog House". 0.80 lifts precision from 0.74 to 0.89 while still showing a strip on 74% of posts.

Not 0.85 (precision 0.99): that halves coverage to 52%. Unlike the email, a slightly-off suggestion next to something you are already reading costs little, while an empty strip loses the exploration entirely.

Live telemetry agrees the old floor was not working. Over 14 days to 2026-07-20, `source='similar_posts'` saw **714 impressions and 3 clicks, 0.4% click-through**, against 16% for `wanted_match` (163/26). Placement differs so it is not a clean comparison, but a 40x gap is not placement alone.

## Making the next revision evidence-based

Both sets of numbers are hand-judged because nothing recorded the score behind an impression. `messages_likes` tags `source` and `pageview`, so the funnel in `recommendations/stats.go` can say the strip converts at 0.4% but not which scores the clicks came from, which is the number needed to set the floor. That is very likely why 0.60 went unrevised.

`logSimilarImpressions` now emits one line per served candidate (msgid, score, src_msgid, userid). Joining those to the existing click rows gives click-through per band. The LogQL query is in the code comment.

No `score` column was added to `messages_likes` to achieve this: at 65M rows and 11GB on prod that is an online-DDL job on a hot write path, for a surface serving ~50 impressions a day. Logging gives the same answer for no schema change, and the reasoning is recorded so the column does not get proposed again.

## Retrieval was never the weak link

On 400 gold Offer/Wanted pairs the production setting ranks a true match first 90.5% of the time and top-5 97.8%. Two changes that sound like improvements measurably are not, and are recorded in the doc so they do not get retried:

- **Subject+body embedding is much worse**: recall@1 0.905 -> 0.535. Bodies are dominated by shared boilerplate ("collection times", "no resellers") that swamps the item.
- **768 dims instead of Matryoshka-256**: 0.905 -> 0.912, for 3x the storage and resident memory.

## Also in here

- Regression tests pinning both floors. A 0.78 candidate for the email and a 0.70 candidate for the strip each clear the old 0.60 comfortably and must still be dropped, so reverting either constant cannot stay green.
- Both embedders gain a comment recording that `quantized: true` is a transformers.js v2 option the v3 runtime ignores, so they run fp32. Switching to `dtype: 'q8'` would quantize query vectors only and put them in a different space from all 194k stored document vectors. No behaviour change.
- `wanted_match` is untouched: it uses `MinVectorScore` and converts at 16%.

## Testing

Full suites green locally: apiv2 3562, batch 4868, frontend 14390.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UdLP1MADbXW9vPAh4JSWNM
