### PR TITLE
chore(gcs): migrate gsutil to gcloud storage

### DIFF
--- a/docs/ops/reference/logging.md
+++ b/docs/ops/reference/logging.md
@@ -433,8 +433,8 @@ Production Loki stores data in Google Cloud Storage:
 
 ### Backup Strategy
 
-1. **Cross-Region Replication**: `gsutil replication set gs://freegle-loki gs://freegle-loki-backup-us`
-2. **Daily Snapshots**: `gsutil -m rsync -r gs://freegle-loki/ gs://freegle-backups/loki/$DATE/`
+1. **Cross-Region Replication**: `gcloud storage replication set gs://freegle-loki gs://freegle-loki-backup-us`
+2. **Daily Snapshots**: `gcloud storage rsync -r gs://freegle-loki/ gs://freegle-backups/loki/$DATE/`
 
 Retention: 7 days daily, 4 weeks weekly, 12 months monthly.
 
@@ -447,7 +447,7 @@ Configure yesterday's Loki to read from production bucket with read-only setting
 **Option B: Sync to local filesystem**
 
 ```bash
-gsutil -m rsync -r gs://freegle-loki/ /data/loki-restore/
+gcloud storage rsync -r gs://freegle-loki/ /data/loki-restore/
 ```
 
 </details>

--- a/scripts/backup/loki-backup.sh
+++ b/scripts/backup/loki-backup.sh
@@ -17,8 +17,8 @@ RETENTION_DAYS="${RETENTION_DAYS:-30}"
 
 echo "=== Loki Backup Started: $(date) ==="
 
-# Check for gcloud credentials by testing gsutil
-if ! gsutil ls "$GCS_BUCKET" >/dev/null 2>&1; then
+# Check for gcloud credentials by testing bucket access
+if ! gcloud storage ls "$GCS_BUCKET" >/dev/null 2>&1; then
     echo "⚠️  Cannot access GCS bucket (no credentials or bucket doesn't exist)"
     echo "   Skipping backup - this is expected in dev environments"
     echo "   To enable backups, mount gcloud credentials at /root/.config/gcloud"
@@ -59,7 +59,7 @@ echo "Backup size: $BACKUP_SIZE"
 
 # Upload to GCS
 echo "Uploading to GCS..."
-gsutil cp "$BACKUP_FILE" "$GCS_BUCKET/"
+gcloud storage cp "$BACKUP_FILE" "$GCS_BUCKET/"
 
 # Clean up local backup
 rm -f "$BACKUP_FILE"
@@ -77,12 +77,12 @@ if [ -z "$CUTOFF_DATE" ]; then
 fi
 echo "Cutoff date: $CUTOFF_DATE"
 
-gsutil ls "$GCS_BUCKET/" 2>/dev/null | while read backup; do
+gcloud storage ls "$GCS_BUCKET/" 2>/dev/null | while read backup; do
     # Extract date from filename (loki-backup-YYYYMMDD_HHMMSS.tar.gz)
     backup_date=$(basename "$backup" | grep -oE '[0-9]{8}' | head -1)
     if [ -n "$backup_date" ] && [ "$backup_date" -lt "$CUTOFF_DATE" ]; then
         echo "Removing old backup: $backup"
-        gsutil rm "$backup"
+        gcloud storage rm "$backup"
     fi
 done
 

--- a/yesterday/README.md
+++ b/yesterday/README.md
@@ -680,7 +680,7 @@ tail -f /var/log/yesterday-restore-YYYYMMDD.log
 4. **Partial upload** - Auto-restore skips backups less than 2 hours old:
    ```bash
    # Check backup timestamp
-   gsutil ls -l gs://freegle_backup_uk/iznik-*.xbstream | tail -5
+   gcloud storage ls -l gs://freegle_backup_uk/iznik-*.xbstream | tail -5
    ```
 
 ### API won't start

--- a/yesterday/api/Dockerfile
+++ b/yesterday/api/Dockerfile
@@ -1,6 +1,13 @@
 FROM node:22-alpine
 
-# Install Google Cloud SDK for gsutil (in /opt to avoid volume mount conflicts), Docker CLI, docker-compose, and git
+# Install Google Cloud SDK for `gcloud storage` (in /opt to avoid volume mount
+# conflicts), Docker CLI, docker-compose, and git.
+#
+# This pulls the rapid channel unpinned, so the image always gets the current
+# SDK. That is why nothing here uses gsutil any more: gsutil leaves the SDK
+# bundle after March 2027, and since this downloads at build time, the first
+# rebuild after that date would have produced an image with no gsutil and a
+# nightly restore that fails at run time rather than at build time.
 RUN apk add --no-cache python3 py3-pip curl bash docker-cli docker-cli-compose git && \
     curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-linux-x86_64.tar.gz && \
     tar -xf google-cloud-cli-linux-x86_64.tar.gz && \

--- a/yesterday/api/server.js
+++ b/yesterday/api/server.js
@@ -84,8 +84,15 @@ app.get('/api/backups', async (req, res) => {
   try {
     const bucket = process.env.BACKUP_BUCKET || 'gs://freegle_backup_uk';
 
-    // Get list of backups with size and date
-    const { stdout } = await execAsync(`gsutil ls -l "${bucket}/iznik-*.xbstream"`);
+    // Get list of backups with size and date.
+    //
+    // --json rather than the -l long listing: the columns of a long listing are
+    // a presentation format that differs between gsutil and gcloud storage, and
+    // this used to be scraped with a whitespace split. --json returns
+    // {url, type, metadata} per object, where metadata is the raw GCS API
+    // object, so `size` and `timeCreated` are documented API field names rather
+    // than column positions.
+    const { stdout } = await execAsync(`gcloud storage ls --json "${bucket}/iznik-*.xbstream"`);
 
     // Dates that have an LVM thin snapshot are instantly switchable (~1 min)
     // rather than a full restore (~1-2h). The host writes this manifest after
@@ -96,31 +103,29 @@ app.get('/api/backups', async (req, res) => {
     } catch (e) { /* no manifest yet */ }
 
     const backups = [];
-    const lines = stdout.trim().split('\n');
+    const items = JSON.parse(stdout.trim() || '[]');
 
-    for (const line of lines) {
-      if (line.includes('TOTAL:') || !line.trim()) continue;
+    for (const item of items) {
+      const url = item.url;
+      if (!url) continue;
 
-      const parts = line.trim().split(/\s+/);
-      if (parts.length >= 3) {
-        const size = parseInt(parts[0]);
-        const dateStr = parts[1];
-        const url = parts[2];
-        const filename = path.basename(url);
+      const metadata = item.metadata || {};
+      const size = parseInt(metadata.size, 10);
+      const dateStr = metadata.timeCreated || metadata.updated || '';
+      const filename = path.basename(url);
 
-        const backupDate = parseBackupDate(filename);
-        if (backupDate) {
-          backups.push({
-            date: backupDate,
-            filename: filename,
-            url: url,
-            size: size,
-            size_human: formatSize(size),
-            timestamp: dateStr,
-            loaded: await isBackupLoaded(backupDate),
-            instant: instantDates.includes(backupDate)
-          });
-        }
+      const backupDate = parseBackupDate(filename);
+      if (backupDate) {
+        backups.push({
+          date: backupDate,
+          filename: filename,
+          url: url,
+          size: Number.isFinite(size) ? size : 0,
+          size_human: Number.isFinite(size) ? formatSize(size) : 'unknown',
+          timestamp: dateStr,
+          loaded: await isBackupLoaded(backupDate),
+          instant: instantDates.includes(backupDate)
+        });
       }
     }
 

--- a/yesterday/scripts/auto-restore-latest.sh
+++ b/yesterday/scripts/auto-restore-latest.sh
@@ -31,21 +31,50 @@ fi
 echo ""
 echo "=== Auto-Restore Check: $(date) ==="
 
-# Get the latest backup from GCS
+# Get the latest backup from GCS.
+#
+# Deliberately uses a bare `ls` (URLs only, one per line) rather than `ls -l`,
+# and takes both the identity and the timestamp of the backup from its FILENAME.
+# Backup names are iznik-YYYY-MM-DD-HH-MM.xbstream, so a reverse lexical sort is
+# a reverse chronological sort, and the long-listing columns are not needed at
+# all. That keeps this independent of listing output format, which differs
+# between gsutil and gcloud storage (title-case keys, different object ordering,
+# timestamps coerced to UTC) and would otherwise silently feed a wrong value
+# into the age gate below.
 echo "Checking for latest backup in ${BACKUP_BUCKET}..."
-LATEST_BACKUP=$(gsutil ls -l "$BACKUP_BUCKET/iznik-*.xbstream" | grep -v TOTAL | sort -k2 -r | head -1)
+LATEST_FILE=$(gcloud storage ls "$BACKUP_BUCKET/iznik-*.xbstream" 2>/dev/null | sort -r | head -1)
 
-if [ -z "$LATEST_BACKUP" ]; then
+if [ -z "$LATEST_FILE" ]; then
     echo "❌ No backups found in bucket"
     exit 1
 fi
 
-LATEST_FILE=$(echo "$LATEST_BACKUP" | awk '{print $3}')
 LATEST_FILENAME=$(basename "$LATEST_FILE")
-LATEST_TIMESTAMP=$(echo "$LATEST_BACKUP" | awk '{print $2}')
 
 # Extract date from filename: iznik-2025-10-31-04-00.xbstream -> 20251031
 LATEST_DATE=$(echo "$LATEST_FILENAME" | grep -oP 'iznik-\K\d{4}-\d{2}-\d{2}' | tr -d '-')
+
+# The age check below must use the object's UPLOAD time, not the time encoded in
+# the filename. The filename says when the backup run started; the gate exists to
+# prove the upload has finished and the object is stable, so those are different
+# clocks and the filename would read as "older" than the upload actually is.
+LATEST_TIMESTAMP=$(gcloud storage objects describe "$LATEST_FILE" \
+    --format='value(creation_time)' 2>/dev/null)
+
+# Fail closed on the age gate, but do not wedge the pipeline: if the timestamp is
+# unreadable or unparseable we skip this run and try again on the next one,
+# rather than restoring on an unverified age or exiting in a way that leaves the
+# refresh stuck (see the "failed restores wedge the nightly refresh" fix).
+if [ -z "$LATEST_TIMESTAMP" ] || ! date -d "$LATEST_TIMESTAMP" +%s >/dev/null 2>&1; then
+    echo "⚠️  Could not read upload time for $LATEST_FILENAME (got: '${LATEST_TIMESTAMP}')"
+    echo "Skipping this run rather than restoring on an unverified backup age."
+    exit 0
+fi
+
+if [ -z "$LATEST_DATE" ]; then
+    echo "❌ Could not parse a date out of backup filename: $LATEST_FILENAME"
+    exit 1
+fi
 
 echo "Latest backup found: $LATEST_FILENAME (Date: $LATEST_DATE)"
 echo "Backup timestamp: $LATEST_TIMESTAMP"

--- a/yesterday/scripts/lib-yesterday-lvm.sh
+++ b/yesterday/scripts/lib-yesterday-lvm.sh
@@ -37,7 +37,7 @@ ylvm_project_name() {
 ylvm_find_backup() {
     local date8="$1"
     local fmt="${date8:0:4}-${date8:4:2}-${date8:6:2}"
-    gsutil ls "$YLVM_BUCKET/iznik-${fmt}-*.xbstream" 2>/dev/null | head -1
+    gcloud storage ls "$YLVM_BUCKET/iznik-${fmt}-*.xbstream" 2>/dev/null | head -1
 }
 
 # Prepare a full backup for a date into the staging mount, leaving a clean,
@@ -58,7 +58,7 @@ ylvm_prepare_to_stage() {
     fstrim "$YLVM_STAGE_MNT" 2>/dev/null || true
 
     ylvm_log "Streaming + extracting to staging ..."
-    gsutil cat "$backup_file" | xbstream -x -C "$YLVM_STAGE_MNT"
+    gcloud storage cat "$backup_file" | xbstream -x -C "$YLVM_STAGE_MNT"
 
     ylvm_log "Decompressing .zst files (parallel) ..."
     find "$YLVM_STAGE_MNT" -type f -name "*.zst" -print0 | xargs -0 -P "$(nproc)" -I {} zstd -d --rm {}

--- a/yesterday/scripts/nightly-refresh-lvm.sh
+++ b/yesterday/scripts/nightly-refresh-lvm.sh
@@ -25,7 +25,7 @@ STATE_FILE="$YLVM_COMPOSE_DIR/yesterday/data/current-backup.json"
 # Determine target date (arg, else newest in bucket).
 DATE8="${1:-}"
 if [ -z "$DATE8" ]; then
-    DATE8="$(gsutil ls "$YLVM_BUCKET/iznik-*.xbstream" 2>/dev/null \
+    DATE8="$(gcloud storage ls "$YLVM_BUCKET/iznik-*.xbstream" 2>/dev/null \
         | sed -E 's#.*/iznik-([0-9]{4})-([0-9]{2})-([0-9]{2})-.*#\1\2\3#' \
         | grep -E '^[0-9]{8}$' | sort -u | tail -1)"
 fi

--- a/yesterday/scripts/prime-backups.sh
+++ b/yesterday/scripts/prime-backups.sh
@@ -24,7 +24,7 @@ mountpoint -q "$YLVM_STAGE_MNT"  || ylvm_die "Staging not mounted — run setup-
 
 # Discover the most recent N backup dates available in the bucket (YYYYMMDD).
 ylvm_log "Listing last $N backups in $YLVM_BUCKET ..."
-mapfile -t DATES < <(gsutil ls "$YLVM_BUCKET/iznik-*.xbstream" 2>/dev/null \
+mapfile -t DATES < <(gcloud storage ls "$YLVM_BUCKET/iznik-*.xbstream" 2>/dev/null \
     | sed -E 's#.*/iznik-([0-9]{4})-([0-9]{2})-([0-9]{2})-.*#\1\2\3#' \
     | grep -E '^[0-9]{8}$' | sort -u | tail -n "$N")
 

--- a/yesterday/scripts/restore-backup.sh
+++ b/yesterday/scripts/restore-backup.sh
@@ -74,7 +74,7 @@ mkdir -p "$BACKUP_DIR"
 FORMATTED_DATE="${BACKUP_DATE:0:4}-${BACKUP_DATE:4:2}-${BACKUP_DATE:6:2}"
 
 echo "Finding backup for date ${FORMATTED_DATE}..."
-BACKUP_FILE=$(gsutil ls "$BACKUP_BUCKET/iznik-${FORMATTED_DATE}-*.xbstream" 2>/dev/null | head -1)
+BACKUP_FILE=$(gcloud storage ls "$BACKUP_BUCKET/iznik-${FORMATTED_DATE}-*.xbstream" 2>/dev/null | head -1)
 
 if [ -z "$BACKUP_FILE" ]; then
     echo "❌ Could not find backup for date ${FORMATTED_DATE}"
@@ -87,7 +87,19 @@ echo "Selected backup: $BACKUP_FILE"
 BACKUP_TIME=$(basename "$BACKUP_FILE" | grep -oP '\d{4}-\d{2}-\d{2}-\K\d{2}-\d{2}' | tr '-' ':')
 echo "Backup time: $BACKUP_TIME"
 
-BACKUP_SIZE=$(gsutil ls -l "$BACKUP_FILE" | grep -v TOTAL | awk '{print $1}')
+# Size comes from a single explicit field rather than a column of the long
+# listing: `gcloud storage` formats listings differently from gsutil, and this
+# value is not cosmetic. It feeds the disk-space estimate below and divides the
+# progress calculation, so an empty parse would silently disable the space check
+# and then divide by zero.
+BACKUP_SIZE=$(gcloud storage objects describe "$BACKUP_FILE" --format='value(size)' 2>/dev/null)
+
+if ! [[ "$BACKUP_SIZE" =~ ^[0-9]+$ ]] || [ "$BACKUP_SIZE" -eq 0 ]; then
+    echo "❌ Could not determine size of $BACKUP_FILE (got: '${BACKUP_SIZE}')"
+    echo "   Refusing to continue: the disk-space check and progress maths both depend on it."
+    exit 1
+fi
+
 BACKUP_SIZE_GB=$((BACKUP_SIZE / 1024 / 1024 / 1024))
 echo "Backup size: ${BACKUP_SIZE_GB}GB (compressed)"
 
@@ -165,7 +177,7 @@ update_status "extracting" "Downloading and extracting backup..."
 PROGRESS_PID=$!
 
 # Stream directly from GCS and extract to volume - no temp directory
-gsutil cat "$BACKUP_FILE" | xbstream -x -C "$VOLUME_PATH"
+gcloud storage cat "$BACKUP_FILE" | xbstream -x -C "$VOLUME_PATH"
 
 # Signal extraction is done
 touch "${VOLUME_PATH}/.extraction_done"
@@ -387,7 +399,7 @@ update_status "restoring_loki" "Restoring Loki logs..."
 # Find most recent Loki backup ON OR BEFORE the database backup date
 # This ensures log consistency - no logs for events after the DB snapshot
 echo "Looking for Loki backup on or before ${BACKUP_DATE}..."
-LOKI_BACKUP=$(gsutil ls "$BACKUP_BUCKET/loki/" 2>/dev/null | while read backup; do
+LOKI_BACKUP=$(gcloud storage ls "$BACKUP_BUCKET/loki/" 2>/dev/null | while read backup; do
     # Extract date from filename (loki-backup-YYYYMMDD_HHMMSS.tar.gz)
     loki_date=$(basename "$backup" | grep -oE '[0-9]{8}' | head -1)
     if [ -n "$loki_date" ] && [ "$loki_date" -le "$BACKUP_DATE" ]; then
@@ -398,7 +410,19 @@ done | sort -r | head -1)
 if [ -n "$LOKI_BACKUP" ]; then
     LOKI_BACKUP_DATE=$(basename "$LOKI_BACKUP" | grep -oE '[0-9]{8}' | head -1)
     echo "Found Loki backup: $LOKI_BACKUP (date: $LOKI_BACKUP_DATE)"
-    LOKI_SIZE=$(gsutil ls -l "$LOKI_BACKUP" | grep -v TOTAL | awk '{print $1}')
+    # As above, an explicit field rather than a listing column. LOKI_SIZE_GB
+    # gates the disk-space check further down, so an empty parse would make
+    # LOKI_NEEDED_GB zero and let that check pass without actually checking.
+    LOKI_SIZE=$(gcloud storage objects describe "$LOKI_BACKUP" --format='value(size)' 2>/dev/null)
+
+    if ! [[ "$LOKI_SIZE" =~ ^[0-9]+$ ]] || [ "$LOKI_SIZE" -eq 0 ]; then
+        echo "⚠️  Could not determine size of $LOKI_BACKUP (got: '${LOKI_SIZE}') - skipping Loki restore"
+        echo "   Loki will start with empty data. The database restore is unaffected."
+        LOKI_BACKUP=""
+    fi
+fi
+
+if [ -n "$LOKI_BACKUP" ]; then
     LOKI_SIZE_GB=$((LOKI_SIZE / 1024 / 1024 / 1024))
     echo "Loki backup size: ${LOKI_SIZE_GB}GB"
 
@@ -422,12 +446,12 @@ if [ -n "$LOKI_BACKUP" ]; then
         echo "   Loki will start with empty data. Free disk space and restore manually."
     else
         # Download Loki backup to local file first, then extract
-        # gsutil cp has built-in retries and resumable downloads, unlike gsutil cat which
+        # cp has built-in retries and resumable downloads, unlike cat which
         # streams through a single SSL connection that fails on large files (20GB+)
         LOKI_LOCAL="/tmp/loki-backup.tar.gz"
         echo "Downloading Loki backup to local file..."
         rm -f "$LOKI_LOCAL"
-        gsutil -o 'GSUtil:resumable_threshold=1048576' cp "$LOKI_BACKUP" "$LOKI_LOCAL"
+        gcloud storage cp "$LOKI_BACKUP" "$LOKI_LOCAL"
         echo "Extracting Loki backup to volume..."
         tar -xzf "$LOKI_LOCAL" -C "${LOKI_VOLUME_PATH}" --strip-components=1
         rm -f "$LOKI_LOCAL"


### PR DESCRIPTION
`gsutil` leaves the gcloud CLI bundle after **March 2027**, surviving only as a standalone PyPI install.

The exposure is not the date. It is `yesterday/api/Dockerfile`, which downloads the rapid channel **unpinned at build time**:

```
curl -O .../channels/rapid/downloads/google-cloud-cli-linux-x86_64.tar.gz
```

Nothing breaks in March 2027. It breaks the first time anyone rebuilds that image afterwards, and it surfaces as the nightly restore failing at run time, not as a build error.

## Most of it is a rename

`cat`, `cp`, `rm` keep their names. The `-o 'GSUtil:resumable_threshold=...'` on the Loki download drops, because `gcloud storage cp` is resumable by default.

## The part that needed care

Four sites scraped `ls -l` columns. `gcloud storage` formats listings differently (title-case keys, `None` fields omitted, different object ordering, timestamps coerced to UTC), and these values are **not cosmetic**:

| site | what the value does | failure if parsed empty |
|---|---|---|
| `restore-backup.sh` `BACKUP_SIZE` | disk-space estimate, divides progress calc | space check disabled, then divide-by-zero |
| `restore-backup.sh` `LOKI_SIZE` | gates Loki disk-space check | `LOKI_NEEDED_GB=0`, check passes vacuously |
| `auto-restore-latest.sh` `LATEST_TIMESTAMP` | `date -d` for the 30-min age gate | age gate misfires |
| `api/server.js` | builds the backup list for the UI | list empty or wrong |

So rather than re-derive column positions against a new layout, these now read **named fields**:

- Sizes and upload time come from `objects describe --format='value(size)'` / `value(creation_time)`, **validated before use**. A size that is not a positive integer fails the restore up front instead of corrupting the maths; an unreadable upload time skips the run rather than restoring on an unverified age or wedging the pipeline.
- The backup listing uses `ls --json`, which returns `{url, type, metadata}` where `metadata` is the raw GCS API object, so `size` and `timeCreated` are documented API field names rather than column indices.
- `auto-restore-latest.sh` picks the newest backup with a bare `ls` and a reverse lexical sort. Names are `iznik-YYYY-MM-DD-HH-MM.xbstream`, so that is already a reverse chronological sort and needs no listing metadata at all.

The age gate deliberately still uses the object's **upload** time, not the timestamp in the filename. The filename records when the backup run started, which is a different clock from when the upload finished, and the gate exists precisely to prove the upload finished.

## Testing, and what is not tested

- Every changed script passes `bash -n`; `server.js` passes `node --check`.
- The new JSON parsing is verified against the documented payload shape, including that the GCS API returns `size` as a *string*, that non-backup objects in the bucket are skipped, and that an empty listing does not throw.
- Field names (`size`, `creation_time`) were confirmed against the installed SDK's own `ObjectResource` definition rather than guessed.

**Not exercised against the real bucket** - local credentials need interactive reauth. A restore should be run before this merges. `plans/` still mentions gsutil; that is scratch and was left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UdLP1MADbXW9vPAh4JSWNM
