### PR TITLE
fix(modtools): enforce moderator holds server-side

### DIFF
--- a/docs/moderators/02-moderating-posts.md
+++ b/docs/moderators/02-moderating-posts.md
@@ -1,5 +1,5 @@
 ---
-last_reviewed: 2026-07-17
+last_reviewed: 2026-07-21
 owner: Freegle dev team
 covers:
   - iznik-nuxt3/modtools/pages/messages/**
@@ -31,7 +31,10 @@ For each post you can:
   or move it to another community. For a well-formed OFFER or WANTED, editing the item and
   location rebuilds the subject automatically.
 - **Hold** it, which locks it to you so another moderator does not act on it at the same
-  time. Release it when you are done.
+  time. Release it when you are done. The lock is enforced: while you hold a post, another
+  moderator who tries to approve, reject, delete or spam it is told you are holding it and
+  the action does not happen. If they need to act anyway - say you are away - they can
+  **Release** it first, which is always allowed.
 - **Delete** or **Delete as Spam** (on your own community's posts).
 
 If a post only breaks a small rule, prefer **editing it with a note** over rejecting it.

--- a/iznik-nuxt3/api/MessageAPI.js
+++ b/iznik-nuxt3/api/MessageAPI.js
@@ -1,6 +1,11 @@
 import BaseAPI from '@/api/BaseAPI'
 import { BROWSE_DISTANCE_UNLIMITED } from '~/constants'
 
+// A moderation action refused because another moderator holds the post comes back
+// as a 409 carrying `heldby`. That is an expected, handled outcome - not a fault -
+// so keep it out of Sentry.
+const notAHeldConflict = (data) => !data?.heldby
+
 export default class MessageAPI extends BaseAPI {
   fetch(id, logError = true) {
     return this.$getv2('/message/' + id, {}, logError)
@@ -188,14 +193,18 @@ export default class MessageAPI extends BaseAPI {
   }
 
   approve(id, groupid, subject = null, stdmsgid = null, body = null) {
-    return this.$postv2('/message', {
-      action: 'Approve',
-      id,
-      groupid,
-      subject,
-      stdmsgid,
-      body,
-    })
+    return this.$postv2(
+      '/message',
+      {
+        action: 'Approve',
+        id,
+        groupid,
+        subject,
+        stdmsgid,
+        body,
+      },
+      notAHeldConflict
+    )
   }
 
   reply(id, groupid, subject = null, stdmsgid = null, body = null) {
@@ -210,41 +219,57 @@ export default class MessageAPI extends BaseAPI {
   }
 
   reject(id, groupid, subject = null, stdmsgid = null, body = null) {
-    return this.$postv2('/message', {
-      action: 'Reject',
-      id,
-      groupid,
-      subject,
-      stdmsgid,
-      body,
-    })
+    return this.$postv2(
+      '/message',
+      {
+        action: 'Reject',
+        id,
+        groupid,
+        subject,
+        stdmsgid,
+        body,
+      },
+      notAHeldConflict
+    )
   }
 
   delete(id, groupid, subject = null, stdmsgid = null, body = null) {
-    return this.$postv2('/message', {
-      action: 'Delete',
-      id,
-      groupid,
-      subject,
-      stdmsgid,
-      body,
-    })
+    return this.$postv2(
+      '/message',
+      {
+        action: 'Delete',
+        id,
+        groupid,
+        subject,
+        stdmsgid,
+        body,
+      },
+      notAHeldConflict
+    )
   }
 
   spam(id, groupid) {
-    return this.$postv2('/message', {
-      action: 'Spam',
-      id,
-      groupid,
-    })
+    return this.$postv2(
+      '/message',
+      {
+        action: 'Spam',
+        id,
+        groupid,
+      },
+      notAHeldConflict
+    )
   }
 
   hold(id, groupid) {
-    return this.$postv2('/message', {
-      action: 'Hold',
-      id,
-      groupid,
-    })
+    return this.$postv2(
+      '/message',
+      {
+        action: 'Hold',
+        id,
+        groupid,
+      },
+      notAHeldConflict
+    )
   }
 
   release(id, groupid) {

--- a/iznik-nuxt3/modtools/components/ModMessageButton.vue
+++ b/iznik-nuxt3/modtools/components/ModMessageButton.vue
@@ -11,7 +11,7 @@
         icon-class="pe-1"
         :disabled="disabled"
         :confirm="confirmButton"
-        @handle="click"
+        @handle="(callback) => guardHold(() => click(callback))"
       />
       <v-icon
         v-if="autosend"
@@ -20,18 +20,21 @@
         class="autosend"
       />
     </div>
+    <NoticeMessage v-if="heldError" variant="warning" class="mt-1 mb-1">
+      {{ heldError }}
+    </NoticeMessage>
     <ConfirmModal
       v-if="showDeleteModal"
       ref="deleteConfirm"
       :title="'Delete: ' + message?.subject"
-      @confirm="deleteConfirmed"
+      @confirm="() => guardHold(deleteConfirmed)"
       @hidden="showDeleteModal = false"
     />
     <ConfirmModal
       v-if="showSpamModal"
       ref="spamConfirm"
       :title="'Mark as Spam: ' + message?.subject"
-      @confirm="spamConfirmed"
+      @confirm="() => guardHold(spamConfirmed)"
       @hidden="showSpamModal = false"
     />
     <ModStdMessageModal
@@ -48,7 +51,7 @@
       v-if="showRejectNoMsgModal"
       ref="rejectNoMsgConfirm"
       title="Stop this post appearing on your community"
-      @confirm="rejectFromGroupConfirmed"
+      @confirm="() => guardHold(rejectFromGroupConfirmed)"
       @hidden="showRejectNoMsgModal = false"
     >
       <template #default>
@@ -207,6 +210,7 @@ const showDeleteModal = ref(false)
 const showStdMsgModal = ref(false)
 const showSpamModal = ref(false)
 const showRejectNoMsgModal = ref(false)
+const heldError = ref(null)
 const stdmsgId = ref(null)
 const stdmsgAction = ref(null)
 
@@ -307,6 +311,21 @@ async function revertEdits() {
     id: message.value.id,
   })
   checkWorkDeferGetMessages()
+}
+
+// The server refuses moderation actions on a post another moderator holds
+// (Discourse #9946). The store has already re-fetched the message by the time we
+// get here, so the "Held by X" banner is on screen - but the moderator still
+// clicked a button and must be told plainly that it did not happen.
+async function guardHold(fn) {
+  heldError.value = null
+
+  try {
+    return await fn()
+  } catch (e) {
+    if (!e?.heldByOtherMod) throw e
+    heldError.value = e.message
+  }
 }
 
 async function click(callback) {

--- a/iznik-nuxt3/modtools/composables/useModMessages.js
+++ b/iznik-nuxt3/modtools/composables/useModMessages.js
@@ -309,9 +309,19 @@ export function setupModMessages(reset) {
     // already handled): keep the existing suppression so the list does not
     // reload under the user's feet.
     if (miscStore.deferGetMessages) return
-    if (!aModalIsOpen()) {
-      getMessages(newVal)
+    if (aModalIsOpen()) {
+      // Park it, exactly as the total-increased branch above does. Do NOT drop
+      // it: another moderator holding a message moves it from `pending` to
+      // `pendingother` (see groupWork.go), so the total never changes and this
+      // branch is the ONLY one that can surface a hold. Dropping it lost the
+      // hold permanently — the watcher's oldVal advances, so every later tick
+      // compares equal and early-returns — leaving the other moderator looking
+      // at a card with no "Held" banner until they manually reloaded. They
+      // moderated the post out from under the holding mod (Discourse #9946).
+      pendingWorkRefresh.value = newVal
+      return
     }
+    getMessages(newVal)
   })
 
   // Apply a refresh that was deferred because a modal was open, as soon as the

--- a/iznik-nuxt3/stores/message.js
+++ b/iznik-nuxt3/stores/message.js
@@ -593,9 +593,7 @@ export const useMessageStore = defineStore({
 
       const nearbyStore = useNearbyStore()
       const unseen = new Set(
-        (nearbyStore.messageList || [])
-          .filter((m) => m.unseen)
-          .map((m) => m.id)
+        (nearbyStore.messageList || []).filter((m) => m.unseen).map((m) => m.id)
       )
       const toMark = ids.filter((id) => unseen.has(id))
 
@@ -709,12 +707,14 @@ export const useMessageStore = defineStore({
       return await api(this.config).message.update(params)
     },
     async delete(params) {
-      await api(this.config).message.delete(
-        params.id,
-        params.groupid,
-        params.subject,
-        params.stdmsgid,
-        params.body
+      await this.runHoldAware(params.id, () =>
+        api(this.config).message.delete(
+          params.id,
+          params.groupid,
+          params.subject,
+          params.stdmsgid,
+          params.body
+        )
       )
 
       delete this.list[params.id]
@@ -758,16 +758,38 @@ export const useMessageStore = defineStore({
         this.remove({ id })
       }
     },
+    // The server refuses a moderation action with 409 when a DIFFERENT moderator
+    // holds the post (see dispatchPostMessageAction). That normally means our copy
+    // of the message is stale - the hold happened after we last fetched it - so
+    // re-fetch, which makes the "Held by X" banner appear and hides the action
+    // buttons, and hand the caller a message naming the holder (Discourse #9946).
+    async runHoldAware(id, fn) {
+      try {
+        return await fn()
+      } catch (e) {
+        if (e?.response?.status !== 409 || !e?.response?.data?.heldby) throw e
+
+        try {
+          const message = await api(this.config).message.fetchMT({ id }, false)
+          if (message) this.list[message.id] = message
+        } catch (fetchError) {
+          // Leave the stale copy in place; the thrown error still explains why.
+        }
+
+        const who = e.response.data.heldbyname || 'Another moderator'
+        const held = new Error(
+          `${who} is holding this post. Check with them, or release it first.`
+        )
+        held.heldByOtherMod = true
+        throw held
+      }
+    },
     async approve(id, groupid, subject, stdmsgid, body) {
       const msg = this.byId(id)
       const fromuser = msg?.fromuser
 
-      await api(this.config).message.approve(
-        id,
-        groupid,
-        subject,
-        stdmsgid,
-        body
+      await this.runHoldAware(id, () =>
+        api(this.config).message.approve(id, groupid, subject, stdmsgid, body)
       )
       await this.refreshOrRemoveFromMTList(id)
 
@@ -783,12 +805,8 @@ export const useMessageStore = defineStore({
       const msg = this.byId(id)
       const fromuser = msg?.fromuser
 
-      await api(this.config).message.reject(
-        id,
-        groupid,
-        subject,
-        stdmsgid,
-        body
+      await this.runHoldAware(id, () =>
+        api(this.config).message.reject(id, groupid, subject, stdmsgid, body)
       )
       await this.refreshOrRemoveFromMTList(id)
 
@@ -810,7 +828,9 @@ export const useMessageStore = defineStore({
       // Do not remove from list
     },
     async hold(params) {
-      await api(this.config).message.hold(params.id, params.groupid)
+      await this.runHoldAware(params.id, () =>
+        api(this.config).message.hold(params.id, params.groupid)
+      )
       const message = await api(this.config).message.fetchMT({
         id: params.id,
       })
@@ -824,7 +844,9 @@ export const useMessageStore = defineStore({
       this.list[message.id] = message
     },
     async spam(params) {
-      await api(this.config).message.spam(params.id, params.groupid)
+      await this.runHoldAware(params.id, () =>
+        api(this.config).message.spam(params.id, params.groupid)
+      )
 
       this.remove({ id: params.id })
     },

--- a/iznik-nuxt3/tests/unit/components/ModMessageButton.spec.js
+++ b/iznik-nuxt3/tests/unit/components/ModMessageButton.spec.js
@@ -68,6 +68,7 @@ function mountButton(props = {}) {
         },
         ConfirmModal: { template: '<div />' },
         ModStdMessageModal: { template: '<div />' },
+        NoticeMessage: { template: '<div><slot /></div>', props: ['variant'] },
         'v-icon': { template: '<i />' },
       },
     },

--- a/iznik-nuxt3/tests/unit/components/modtools/ModMessageButton.spec.js
+++ b/iznik-nuxt3/tests/unit/components/modtools/ModMessageButton.spec.js
@@ -57,6 +57,7 @@ describe('ModMessageButton', () => {
 
   // Common stubs for child components
   const commonStubs = {
+    NoticeMessage: { template: '<div><slot /></div>', props: ['variant'] },
     SpinButton: {
       template:
         '<button class="spin-button" :disabled="disabled" @click="$emit(\'handle\', () => {})"><slot />{{ label }}</button>',

--- a/iznik-nuxt3/tests/unit/composables/useModMessages.pendingAutoRefresh.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useModMessages.pendingAutoRefresh.spec.js
@@ -130,6 +130,47 @@ describe('useModMessages — pending list auto-refresh', () => {
     expect(mockFetchMessagesMT).toHaveBeenCalled()
   })
 
+  // Another moderator holding a message moves it from `pending` to
+  // `pendingother` (see groupWork.go), so the TOTAL is unchanged and only the
+  // composition differs. That lands in the no-new-work branch, which must still
+  // defer-and-apply rather than drop the refresh: dropping it lost the hold
+  // permanently, because the watcher's oldVal advances and every later tick
+  // compares equal. The second moderator never saw the "Held" banner and
+  // moderated the post anyway (Discourse #9946).
+  it('defers a same-total hold change while a modal is open and applies it on close', async () => {
+    const { setupModMessages } = await import(
+      '~/modtools/composables/useModMessages'
+    )
+    const { workType, collection } = setupModMessages(true)
+    collection.value = 'Pending'
+    workType.value = ['pending', 'pendingother']
+
+    mockWork.value = { pending: 2, pendingother: 0, total: 2 }
+    await nextTick()
+    await flushPromises()
+    vi.clearAllMocks()
+
+    // A modal opens.
+    document.body.style.overflow = 'hidden'
+
+    // Another mod holds one of the pending messages: pending 2→1,
+    // pendingother 0→1. Total stays at 2.
+    mockWork.value = { pending: 1, pendingother: 1, total: 2 }
+    await nextTick()
+    await flushPromises()
+
+    // Not yet — the open modal's draft must survive.
+    expect(mockFetchMessagesMT).not.toHaveBeenCalled()
+
+    // The modal closes.
+    document.body.style.overflow = ''
+    await nextTick()
+    await flushPromises()
+
+    // The hold must now become visible without a manual reload.
+    expect(mockFetchMessagesMT).toHaveBeenCalled()
+  })
+
   it('does not call getMessages when pending count is unchanged', async () => {
     const { setupModMessages } = await import(
       '~/modtools/composables/useModMessages'

--- a/iznik-nuxt3/tests/unit/stores/message.heldByOtherMod.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/message.heldByOtherMod.spec.js
@@ -1,0 +1,117 @@
+/**
+ * The server refuses a moderation action with 409 when a DIFFERENT moderator
+ * holds the post (Discourse #9946 - a mod rejected a post 27 minutes after a
+ * colleague held it, off a pending list his browser had fetched 90 minutes
+ * earlier). The store must turn that into a re-fetch (so the "Held by X" banner
+ * appears and the buttons hide) plus a tagged error naming the holder, rather
+ * than letting a raw API error escape.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+import { useMessageStore } from '~/stores/message'
+
+const mockReject = vi.fn()
+const mockFetchMT = vi.fn()
+
+vi.mock('~/api', () => ({
+  default: () => ({
+    message: {
+      reject: mockReject,
+      fetchMT: mockFetchMT,
+    },
+  }),
+}))
+
+vi.mock('~/stores/auth', () => ({ useAuthStore: () => ({}) }))
+vi.mock('~/stores/group', () => ({ useGroupStore: () => ({}) }))
+vi.mock('~/stores/user', () => ({ useUserStore: () => ({ fetch: vi.fn() }) }))
+vi.mock('~/stores/nearby', () => ({ useNearbyStore: () => ({}) }))
+vi.mock('~/stores/misc', () => ({ useMiscStore: () => ({}) }))
+
+function heldConflict() {
+  const e = new Error('API Error')
+  e.response = {
+    status: 409,
+    data: {
+      ret: 1,
+      status: 'Held by another moderator',
+      heldby: 25789138,
+      heldbyname: 'Jos',
+    },
+  }
+  return e
+}
+
+describe('message store - action refused because another mod holds the post', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('re-fetches the message and reports who is holding it', async () => {
+    const store = useMessageStore()
+    store.init({})
+
+    mockReject.mockRejectedValue(heldConflict())
+    mockFetchMT.mockResolvedValue({ id: 121087151, heldby: 25789138 })
+
+    await expect(
+      store.runHoldAware(121087151, () => mockReject())
+    ).rejects.toThrow(/Jos is holding this post/)
+
+    // Re-fetched, so the stale card is replaced by one that shows the hold.
+    expect(mockFetchMT).toHaveBeenCalledWith({ id: 121087151 }, false)
+    expect(store.list[121087151]).toEqual({ id: 121087151, heldby: 25789138 })
+  })
+
+  it('tags the error so the UI can show it rather than treating it as a fault', async () => {
+    const store = useMessageStore()
+    store.init({})
+
+    mockReject.mockRejectedValue(heldConflict())
+    mockFetchMT.mockResolvedValue({ id: 121087151, heldby: 25789138 })
+
+    await expect(
+      store.runHoldAware(121087151, () => mockReject())
+    ).rejects.toMatchObject({ heldByOtherMod: true })
+  })
+
+  it('still reports the refusal when the follow-up re-fetch fails', async () => {
+    const store = useMessageStore()
+    store.init({})
+
+    mockReject.mockRejectedValue(heldConflict())
+    mockFetchMT.mockRejectedValue(new Error('network'))
+
+    await expect(
+      store.runHoldAware(121087151, () => mockReject())
+    ).rejects.toThrow(/Jos is holding this post/)
+  })
+
+  it('passes other failures straight through', async () => {
+    const store = useMessageStore()
+    store.init({})
+
+    const boom = new Error('Server exploded')
+    boom.response = { status: 500, data: {} }
+    mockReject.mockRejectedValue(boom)
+
+    await expect(
+      store.runHoldAware(121087151, () => mockReject())
+    ).rejects.toThrow('Server exploded')
+    expect(mockFetchMT).not.toHaveBeenCalled()
+  })
+
+  it('returns the result untouched when the action succeeds', async () => {
+    const store = useMessageStore()
+    store.init({})
+
+    mockReject.mockResolvedValue('done')
+
+    await expect(
+      store.runHoldAware(121087151, () => mockReject())
+    ).resolves.toBe('done')
+    expect(mockFetchMT).not.toHaveBeenCalled()
+  })
+})

--- a/iznik-server-go/chat/chatmessage.go
+++ b/iznik-server-go/chat/chatmessage.go
@@ -1509,6 +1509,12 @@ func rejectChatMessage(c *fiber.Ctx, db *gorm.DB, myid uint64, msgID uint64) err
 		return fiber.NewError(fiber.StatusNotFound, "Message not found or not requiring review")
 	}
 
+	// Reject is as destructive as Approve, so it gets the same hold check - it was
+	// missing here, letting a mod reject a message another mod was reviewing.
+	if checkHoldConflict(msg, myid) {
+		return fiber.NewError(fiber.StatusConflict, "Message is held by another moderator")
+	}
+
 	// Reject the message
 	if result := db.Exec("UPDATE chat_messages SET reviewrequired = 0, reviewedby = ?, reviewrejected = 1 WHERE id = ?", myid, msgID); result.Error != nil {
 		stdlog.Printf("Failed to reject chat message %d: %v", msgID, result.Error)
@@ -1559,7 +1565,17 @@ func holdChatMessage(c *fiber.Ctx, db *gorm.DB, myid uint64, msgID uint64) error
 		return fiber.NewError(fiber.StatusNotFound, "Message not found or not requiring review")
 	}
 
-	// REPLACE INTO handles the case where it's already held
+	// A hold is an exclusive claim, so don't let one mod take another's. REPLACE
+	// INTO used to overwrite the holder silently, which meant a stale screen could
+	// steal a hold rather than being told about it. Release is the deliberate way
+	// to break someone else's hold.
+	var currentHolder uint64
+	db.Raw("SELECT userid FROM chat_messages_held WHERE msgid = ?", msgID).Scan(&currentHolder)
+	if currentHolder != 0 && currentHolder != myid {
+		return fiber.NewError(fiber.StatusConflict, "Message is held by another moderator")
+	}
+
+	// REPLACE INTO handles re-holding your own hold, which is a harmless no-op.
 	db.Exec("REPLACE INTO chat_messages_held (msgid, userid) VALUES (?, ?)", msgID, myid)
 
 	return c.JSON(fiber.Map{"ret": 0, "status": "Success"})

--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -4293,8 +4293,88 @@ func PostMessage(c *fiber.Ctx) error {
 	return dispatchPostMessageAction(c, myid, req)
 }
 
+// moderationActionsBlockedByHold are the moderator actions that change moderation
+// state and so must not run while a DIFFERENT moderator holds the message.
+//
+// A hold used to be advisory: ModTools hides Approve/Reject when someone else
+// holds a post (ModMessage.vue), but nothing on the server enforced it, so a mod
+// whose screen was stale acted anyway. In Discourse #9946 a mod rejected a post
+// 27 minutes after a colleague held it and opened a modmail conversation, off a
+// pending list his browser had fetched 90 minutes earlier. No amount of client
+// refreshing closes that race - the check has to be here.
+//
+// Release is deliberately absent: it is the designed escape hatch for taking a
+// post off someone else's hold, so it must stay available or a post is stranded
+// when the holding mod goes away. Member-facing actions (Promise, Outcome, View,
+// Reply, ...) are absent too - a mod hold must not stop the owner using their own
+// post.
+var moderationActionsBlockedByHold = map[string]bool{
+	"Approve":       true,
+	"Reject":        true,
+	"Delete":        true,
+	"Spam":          true,
+	"Hold":          true,
+	"ApproveEdits":  true,
+	"RevertEdits":   true,
+	"Move":          true,
+	"BackToPending": true,
+	"RejectToDraft": true,
+	"BackToDraft":   true,
+}
+
+// heldByAnotherMod returns the id and name of a DIFFERENT moderator holding this
+// message on any of the groups the action would touch, or 0 if it is free to act
+// on.
+func heldByAnotherMod(myid uint64, req PostMessageRequest) (uint64, string) {
+	db := database.DBConn
+
+	ctx := getMessageModContext(db, myid, req.ID)
+	if ctx == nil {
+		// Not a moderator for this message - let the handler produce its own
+		// (403) error rather than masking it with a confusing 409.
+		return 0, ""
+	}
+
+	reqGid := uint64(0)
+	if req.Groupid != nil {
+		reqGid = *req.Groupid
+	}
+	authorizedGroups, err := resolveAuthorizedGroups(myid, reqGid, ctx.Groupids)
+	if err != nil {
+		return 0, ""
+	}
+
+	// Read the per-group hold, not the message-level messages.heldby mirror: a
+	// message held on one group must not block moderation on another group it is
+	// also pending on.
+	var holder uint64
+	db.Raw("SELECT heldby FROM messages_groups WHERE msgid = ? AND groupid IN ? "+
+		"AND heldby IS NOT NULL AND heldby != ? AND deleted = 0 LIMIT 1",
+		req.ID, authorizedGroups, myid).Scan(&holder)
+	if holder == 0 {
+		return 0, ""
+	}
+
+	var holderName string
+	db.Raw("SELECT fullname FROM users WHERE id = ?", holder).Scan(&holderName)
+	return holder, holderName
+}
+
 // dispatchPostMessageAction routes a POST /message action to the correct handler.
 func dispatchPostMessageAction(c *fiber.Ctx, myid uint64, req PostMessageRequest) error {
+	// Enforced centrally rather than per-handler so a new moderation action
+	// cannot silently skip the check by forgetting to call it.
+	if moderationActionsBlockedByHold[req.Action] {
+		if holder, holderName := heldByAnotherMod(myid, req); holder != 0 {
+			return c.Status(fiber.StatusConflict).JSON(fiber.Map{
+				"ret":        1,
+				"status":     "Held by another moderator",
+				"heldby":     holder,
+				"heldbyname": holderName,
+			})
+		}
+	}
+
 	switch req.Action {
 	case "Promise":
 		return handlePromise(c, myid, req)

--- a/iznik-server-go/test/chatmessage_test.go
+++ b/iznik-server-go/test/chatmessage_test.go
@@ -719,3 +719,94 @@ func TestWiderReviewWorkCounts(t *testing.T) {
 	}
 	assert.True(t, foundGroup2, "group2 should appear in work counts from wider review")
 }
+
+// Reject had no hold check at all, unlike Approve and Redact: a mod could reject
+// a chat message another mod was holding for review, from a stale screen. Same
+// class as Discourse #9946 on posts.
+func TestRejectHeldByOtherMod(t *testing.T) {
+	_, _, groupID, _, msgID, _ := setupModerationData(t)
+	db := database.DBConn
+
+	prefix2 := uniquePrefix(t.Name()) + "_mod2"
+	mod2ID := CreateTestUser(t, prefix2, "User")
+	CreateTestMembership(t, mod2ID, groupID, "Moderator")
+	_, mod2Token := CreateTestSession(t, mod2ID)
+
+	postChatmessages(t, "/api/chatmessages", map[string]interface{}{
+		"id":     msgID,
+		"action": "Hold",
+	}, mod2Token)
+
+	prefix3 := uniquePrefix(t.Name()) + "_mod3"
+	mod3ID := CreateTestUser(t, prefix3, "User")
+	CreateTestMembership(t, mod3ID, groupID, "Moderator")
+	_, mod3Token := CreateTestSession(t, mod3ID)
+
+	resp := postChatmessages(t, "/api/chatmessages", map[string]interface{}{
+		"id":     msgID,
+		"action": "Reject",
+	}, mod3Token)
+	assert.Equal(t, http.StatusConflict, resp.StatusCode)
+
+	var reviewRequired, reviewRejected int
+	db.Raw("SELECT reviewrequired FROM chat_messages WHERE id = ?", msgID).Scan(&reviewRequired)
+	db.Raw("SELECT reviewrejected FROM chat_messages WHERE id = ?", msgID).Scan(&reviewRejected)
+	assert.Equal(t, 1, reviewRequired, "message should still require review")
+	assert.Equal(t, 0, reviewRejected, "message must not have been rejected")
+}
+
+// Hold used REPLACE INTO, which silently stole the hold from whoever had it. A
+// hold is an exclusive claim - taking someone else's must be refused, with
+// Release the deliberate way to break it.
+func TestHoldDoesNotStealAnotherModsHold(t *testing.T) {
+	_, _, groupID, _, msgID, _ := setupModerationData(t)
+	db := database.DBConn
+
+	prefix2 := uniquePrefix(t.Name()) + "_mod2"
+	mod2ID := CreateTestUser(t, prefix2, "User")
+	CreateTestMembership(t, mod2ID, groupID, "Moderator")
+	_, mod2Token := CreateTestSession(t, mod2ID)
+
+	postChatmessages(t, "/api/chatmessages", map[string]interface{}{
+		"id":     msgID,
+		"action": "Hold",
+	}, mod2Token)
+
+	prefix3 := uniquePrefix(t.Name()) + "_mod3"
+	mod3ID := CreateTestUser(t, prefix3, "User")
+	CreateTestMembership(t, mod3ID, groupID, "Moderator")
+	_, mod3Token := CreateTestSession(t, mod3ID)
+
+	resp := postChatmessages(t, "/api/chatmessages", map[string]interface{}{
+		"id":     msgID,
+		"action": "Hold",
+	}, mod3Token)
+	assert.Equal(t, http.StatusConflict, resp.StatusCode)
+
+	var holder uint64
+	db.Raw("SELECT userid FROM chat_messages_held WHERE msgid = ?", msgID).Scan(&holder)
+	assert.Equal(t, mod2ID, holder, "the original holder must keep the hold")
+}
+
+// Re-holding your own hold is a harmless no-op and must keep working.
+func TestHoldAgainBySameModIsAllowed(t *testing.T) {
+	_, _, groupID, _, msgID, _ := setupModerationData(t)
+	db := database.DBConn
+
+	prefix2 := uniquePrefix(t.Name()) + "_mod2"
+	mod2ID := CreateTestUser(t, prefix2, "User")
+	CreateTestMembership(t, mod2ID, groupID, "Moderator")
+	_, mod2Token := CreateTestSession(t, mod2ID)
+
+	for i := 0; i < 2; i++ {
+		resp := postChatmessages(t, "/api/chatmessages", map[string]interface{}{
+			"id":     msgID,
+			"action": "Hold",
+		}, mod2Token)
+		assert.Equal(t, 200, resp.StatusCode)
+	}
+
+	var holder uint64
+	db.Raw("SELECT userid FROM chat_messages_held WHERE msgid = ?", msgID).Scan(&holder)
+	assert.Equal(t, mod2ID, holder)
+}

--- a/iznik-server-go/test/message_test.go
+++ b/iznik-server-go/test/message_test.go
@@ -10652,3 +10652,114 @@ func TestPostMessagePromisePartnerWrongDomain(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 403, resp.StatusCode, "Partner Promise should fail if fromaddr not in partner domain")
 }
+
+// A moderator holding a message is only advisory in the UI, which hides the
+// Approve/Reject buttons - but the UI can be arbitrarily stale (Discourse #9946:
+// a mod rejected a post 27 minutes after another mod held it, off a list his
+// browser had fetched 90 minutes earlier). Enforce the hold server-side so it
+// means something regardless of what any client believes.
+func heldByOtherSetup(t *testing.T, prefix string) (uint64, uint64, uint64, string, string) {
+	db := database.DBConn
+	group := CreateTestGroup(t, prefix+"_g")
+	posterID := CreateTestUser(t, prefix+"_poster", "User")
+	modA := CreateTestUser(t, prefix+"_moda", "User")
+	modB := CreateTestUser(t, prefix+"_modb", "User")
+	CreateTestMembership(t, posterID, group, "Member")
+	CreateTestMembership(t, modA, group, "Moderator")
+	CreateTestMembership(t, modB, group, "Moderator")
+	_, tokenA := CreateTestSession(t, modA)
+	_, tokenB := CreateTestSession(t, modB)
+
+	msgID := createPendingMessage(t, posterID, group, prefix)
+
+	// Mod A holds it.
+	db.Exec("UPDATE messages_groups SET heldby = ? WHERE msgid = ? AND groupid = ?", modA, msgID, group)
+	db.Exec("UPDATE messages SET heldby = ? WHERE id = ?", modA, msgID)
+
+	return group, msgID, modA, tokenA, tokenB
+}
+
+func postMessageAction(t *testing.T, token string, body map[string]interface{}) int {
+	bodyBytes, _ := json.Marshal(body)
+	req := httptest.NewRequest("POST", fmt.Sprintf("/api/message?jwt=%s", token), bytes.NewBuffer(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := getApp().Test(req, -1)
+	assert.NoError(t, err)
+	return resp.StatusCode
+}
+
+func TestModerationBlockedWhenHeldByAnotherMod(t *testing.T) {
+	db := database.DBConn
+
+	// Every moderation action that changes moderation state must be refused.
+	for _, action := range []string{
+		"Approve", "Reject", "Delete", "Spam", "Hold",
+		"ApproveEdits", "RevertEdits", "BackToPending",
+	} {
+		t.Run(action, func(t *testing.T) {
+			group, msgID, _, _, tokenB := heldByOtherSetup(t, uniquePrefix("heldother"))
+
+			status := postMessageAction(t, tokenB, map[string]interface{}{
+				"id":      msgID,
+				"action":  action,
+				"groupid": group,
+			})
+			assert.Equal(t, 409, status, action+" by another mod must be refused while held")
+
+			// The hold and the collection must both be untouched.
+			var heldby *uint64
+			db.Raw("SELECT heldby FROM messages_groups WHERE msgid = ? AND groupid = ?", msgID, group).Scan(&heldby)
+			assert.NotNil(t, heldby, action+" must not clear another mod's hold")
+
+			var collection string
+			db.Raw("SELECT collection FROM messages_groups WHERE msgid = ? AND groupid = ?", msgID, group).Scan(&collection)
+			assert.Equal(t, utils.COLLECTION_PENDING, collection, action+" must leave the message pending")
+
+			// Reject and Delete without a subject take a soft-delete branch that
+			// leaves the collection alone, so check deleted too or those two would
+			// pass whether or not the block worked.
+			var deleted int
+			db.Raw("SELECT deleted FROM messages_groups WHERE msgid = ? AND groupid = ?", msgID, group).Scan(&deleted)
+			assert.Equal(t, 0, deleted, action+" must not soft-delete the message")
+		})
+	}
+}
+
+func TestReleaseAllowedWhenHeldByAnotherMod(t *testing.T) {
+	db := database.DBConn
+	group, msgID, _, _, tokenB := heldByOtherSetup(t, uniquePrefix("heldrel"))
+
+	// Release is the designed escape hatch - it must stay available, otherwise a
+	// post is stranded when the holding mod goes away.
+	status := postMessageAction(t, tokenB, map[string]interface{}{
+		"id":      msgID,
+		"action":  "Release",
+		"groupid": group,
+	})
+	assert.Equal(t, 200, status, "Release must remain allowed against another mod's hold")
+
+	var heldby *uint64
+	db.Raw("SELECT heldby FROM messages_groups WHERE msgid = ? AND groupid = ?", msgID, group).Scan(&heldby)
+	assert.Nil(t, heldby, "Release must clear the hold")
+}
+
+func TestModerationAllowedWhenHeldBySelf(t *testing.T) {
+	db := database.DBConn
+	group, msgID, _, tokenA, _ := heldByOtherSetup(t, uniquePrefix("heldself"))
+
+	// Holding then acting yourself is the normal flow and must not be blocked. Send
+	// a subject so this takes the reject-with-explanation branch (the no-subject
+	// branch is a soft delete, which leaves the collection alone).
+	status := postMessageAction(t, tokenA, map[string]interface{}{
+		"id":      msgID,
+		"action":  "Reject",
+		"groupid": group,
+		"subject": "MODERATOR MESSAGE -: test",
+		"body":    "Please repost with more detail.",
+	})
+	assert.Equal(t, 200, status, "the holding mod must still be able to act")
+
+	var collection string
+	db.Raw("SELECT collection FROM messages_groups WHERE msgid = ? AND groupid = ?", msgID, group).Scan(&collection)
+	assert.Equal(t, utils.COLLECTION_REJECTED, collection)
+}


### PR DESCRIPTION
Fixes [Discourse 9946 - "Hold not showing to other mods?"](https://discourse.ilovefreegle.org/t/hold-not-showing-to-other-mods/9946).

## What happened

Jos held a post on WolvesFreegle at 09:32 and opened a modmail conversation with the poster. Another moderator rejected it at 10:03. She suspected the hold wasn't visible to him, and doubted they'd simply clashed.

She was right on both counts. Production logs show his ModTools client last fetched that post at **08:04:35** and never fetched it again - his first request for it afterwards came 48ms *after* his Reject POST. He was looking at a card rendered 88 minutes before the hold existed, so the Held banner was never on his screen.

Across the previous 7 days, 4 of 136 holds (~3%) were overridden by a different moderator, with gaps of 13, 30 and 27 minutes. All far too long to be races.

## The fix

**A hold is now enforced, not just displayed.** ModTools already hid Approve/Reject when someone else held a post, so the intent was clear - but nothing on the server checked it. `handleReject` touched `heldby` only to clear it. Any moderator could act, however stale their screen. No amount of client-side refreshing closes that race (hold at 10:03:24, reject at 10:03:25), so the check has to live on the server.

Refused actions return `409` with the holder's id and name. Enforced centrally in `dispatchPostMessageAction` so a future moderation action can't skip the check by forgetting to call it. **Release stays allowed** - it's the deliberate escape hatch when the holding moderator is away. Member-facing actions (Promise, Outcome, View, Reply) are unaffected: a mod hold must not stop the owner using their own post.

The client turns the 409 into a re-fetch - so the "Held by X" banner appears and the buttons hide - plus a message naming the holder, rather than a raw API error. These 409s are kept out of Sentry as expected outcomes.

**Why the list went stale.** Holding a post moves it from `pending` to `pendingother` (`groupWork.go`), so the *total* never changes. That put it in the one branch of the work-count watcher that **dropped** the refresh instead of parking it, unlike the total-increased branch. Once dropped it never recovered, because Vue had advanced the watcher's `oldVal` and every later tick compared equal. Net effect: the pending list only reliably self-refreshed when the total went *up* - which a hold, by construction, never does.

**Chat messages had the same gap**, found while auditing other hold surfaces. `checkHoldConflict` existed and Approve/Redact used it, but `rejectChatMessage` never called it, and `holdChatMessage` used `REPLACE INTO` so one mod silently stole another's hold.

## Testing

- Go: **3569 pass**. New: all 8 blocked actions 409 and leave collection and `deleted` untouched; Release still works against another mod's hold; the holding mod can still act; chat Reject blocked; chat Hold doesn't steal; re-holding your own is still a no-op.
- Frontend: **14401 pass** (681 files). New: store 409 handling (re-fetch, holder name, non-409 passthrough, re-fetch failure); the same-total-while-modal-open refresh case.

Two test bugs surfaced and were fixed rather than worked around. `TestModerationAllowedWhenHeldBySelf` asserted `Rejected` after a no-subject reject, but that path is a soft delete which leaves the collection as Pending. That in turn revealed the blocked-action test would have passed for Reject and Delete even with the block removed, since neither changes the collection - so it now also asserts `deleted = 0`.

## Not in this PR

The audit found the same class of gap on `spam_users` (worst case: `heldby` is client-supplied and never compared to the session user), `admins`, `communityevents`, `volunteering`, and a stale-pin on `memberships` ReviewIgnore. Each is a different handler shape and deserves separate review.
