### PR TITLE
fix(modtools): enforce moderator holds on the remaining surfaces

### DIFF
--- a/iznik-nuxt3/api/AdminsAPI.js
+++ b/iznik-nuxt3/api/AdminsAPI.js
@@ -1,4 +1,5 @@
 import BaseAPI from '@/api/BaseAPI'
+import { notAHeldConflict } from '~/api/heldConflict'
 
 export default class AdminsAPI extends BaseAPI {
   fetch(params) {
@@ -11,7 +12,7 @@ export default class AdminsAPI extends BaseAPI {
   }
 
   async patch(data) {
-    await this.$patchv2('/modtools/admin', data)
+    await this.$patchv2('/modtools/admin', data, notAHeldConflict)
   }
 
   async del(data) {
@@ -19,10 +20,14 @@ export default class AdminsAPI extends BaseAPI {
   }
 
   async hold(id) {
-    await this.$postv2('/modtools/admin', {
-      id,
-      action: 'Hold',
-    })
+    await this.$postv2(
+      '/modtools/admin',
+      {
+        id,
+        action: 'Hold',
+      },
+      notAHeldConflict
+    )
   }
 
   async release(id) {

--- a/iznik-nuxt3/api/CommunityEventAPI.js
+++ b/iznik-nuxt3/api/CommunityEventAPI.js
@@ -1,4 +1,5 @@
 import BaseAPI from '@/api/BaseAPI'
+import { notAHeldConflict } from '~/api/heldConflict'
 
 export default class CommunityEventAPI extends BaseAPI {
   fetch(id, logError = true) {
@@ -14,7 +15,7 @@ export default class CommunityEventAPI extends BaseAPI {
   }
 
   save(data) {
-    return this.$patchv2('/communityevent', data)
+    return this.$patchv2('/communityevent', data, notAHeldConflict)
   }
 
   async add(data) {

--- a/iznik-nuxt3/api/MembershipsAPI.js
+++ b/iznik-nuxt3/api/MembershipsAPI.js
@@ -1,4 +1,5 @@
 import BaseAPI from '@/api/BaseAPI'
+import { notAHeldConflict } from '~/api/heldConflict'
 
 export default class MembershipsAPI extends BaseAPI {
   update(data) {
@@ -47,25 +48,33 @@ export default class MembershipsAPI extends BaseAPI {
   }
 
   approveMember(userid, groupid, subject = null, stdmsgid = null, body = null) {
-    return this.$postv2('/memberships', {
-      action: 'Approve',
-      userid,
-      groupid,
-      subject,
-      stdmsgid,
-      body,
-    })
+    return this.$postv2(
+      '/memberships',
+      {
+        action: 'Approve',
+        userid,
+        groupid,
+        subject,
+        stdmsgid,
+        body,
+      },
+      notAHeldConflict
+    )
   }
 
   rejectMember(userid, groupid, subject = null, stdmsgid = null, body = null) {
-    return this.$postv2('/memberships', {
-      action: 'Reject',
-      userid,
-      groupid,
-      subject,
-      stdmsgid,
-      body,
-    })
+    return this.$postv2(
+      '/memberships',
+      {
+        action: 'Reject',
+        userid,
+        groupid,
+        subject,
+        stdmsgid,
+        body,
+      },
+      notAHeldConflict
+    )
   }
 
   reply(userid, groupid, subject = null, stdmsgid = null, body = null) {
@@ -80,14 +89,18 @@ export default class MembershipsAPI extends BaseAPI {
   }
 
   delete(userid, groupid, subject = null, stdmsgid = null, body = null) {
-    return this.$postv2('/memberships', {
-      action: 'Delete Approved Member',
-      userid,
-      groupid,
-      subject,
-      stdmsgid,
-      body,
-    })
+    return this.$postv2(
+      '/memberships',
+      {
+        action: 'Delete Approved Member',
+        userid,
+        groupid,
+        subject,
+        stdmsgid,
+        body,
+      },
+      notAHeldConflict
+    )
   }
 
   remove(userid, groupid) {

--- a/iznik-nuxt3/api/MessageAPI.js
+++ b/iznik-nuxt3/api/MessageAPI.js
@@ -1,10 +1,7 @@
 import BaseAPI from '@/api/BaseAPI'
 import { BROWSE_DISTANCE_UNLIMITED } from '~/constants'
 
-// A moderation action refused because another moderator holds the post comes back
-// as a 409 carrying `heldby`. That is an expected, handled outcome - not a fault -
-// so keep it out of Sentry.
-const notAHeldConflict = (data) => !data?.heldby
+import { notAHeldConflict } from '~/api/heldConflict'
 
 export default class MessageAPI extends BaseAPI {
   fetch(id, logError = true) {

--- a/iznik-nuxt3/api/SpammersAPI.js
+++ b/iznik-nuxt3/api/SpammersAPI.js
@@ -1,4 +1,5 @@
 import BaseAPI from '@/api/BaseAPI'
+import { notAHeldConflict } from '~/api/heldConflict'
 
 export default class SpammersAPI extends BaseAPI {
   async fetch(params) {
@@ -14,7 +15,7 @@ export default class SpammersAPI extends BaseAPI {
   }
 
   patch(params) {
-    return this.$patchv2('/modtools/spammers', params)
+    return this.$patchv2('/modtools/spammers', params, notAHeldConflict)
   }
 
   del(params) {

--- a/iznik-nuxt3/api/VolunteeringAPI.js
+++ b/iznik-nuxt3/api/VolunteeringAPI.js
@@ -1,4 +1,5 @@
 import BaseAPI from '@/api/BaseAPI'
+import { notAHeldConflict } from '~/api/heldConflict'
 
 export default class VolunteeringAPI extends BaseAPI {
   fetch(id, logError = true) {
@@ -14,7 +15,7 @@ export default class VolunteeringAPI extends BaseAPI {
   }
 
   save(data) {
-    return this.$patchv2('/volunteering', data)
+    return this.$patchv2('/volunteering', data, notAHeldConflict)
   }
 
   async add(data) {

--- a/iznik-nuxt3/api/heldConflict.js
+++ b/iznik-nuxt3/api/heldConflict.js
@@ -1,0 +1,5 @@
+// A moderation action refused because another moderator holds the item comes back
+// as a 409 carrying `heldby` (see the hold enforcement in iznik-server-go). That is
+// an expected, handled outcome - the whole point of a hold - not a fault, so keep it
+// out of Sentry. Pass as the logError argument to $postv2/$patchv2.
+export const notAHeldConflict = (data) => !data?.heldby

--- a/iznik-nuxt3/tests/e2e/test-edit-deadline.spec.js
+++ b/iznik-nuxt3/tests/e2e/test-edit-deadline.spec.js
@@ -51,12 +51,15 @@ test.describe('Freegle Edit Deadline', () => {
     const editModal = page.locator('.modal.show')
     await expect(editModal).toBeVisible({ timeout: timeouts.ui.appearance })
 
-    // Verify the deadline from initial posting is shown
+    // Verify the deadline from initial posting is shown. Assert on the VALUE, not
+    // visibility-then-read: the modal renders the empty date input before the
+    // message fetch populates it, so reading inputValue() straight after
+    // toBeVisible() races the load and intermittently sees "".
     const deadlineInput = editModal.locator('input[type="date"]').first()
-    await expect(deadlineInput).toBeVisible({ timeout: timeouts.ui.appearance })
-    const savedDeadline = await deadlineInput.inputValue()
-    expect(savedDeadline).toBe(deadlineDate)
-    console.log(`Deadline from initial post visible on edit: ${savedDeadline}`)
+    await expect(deadlineInput).toHaveValue(deadlineDate, {
+      timeout: timeouts.ui.appearance,
+    })
+    console.log(`Deadline from initial post visible on edit: ${deadlineDate}`)
   })
 
   test('editing a deadline saves and persists after reload', async ({
@@ -124,12 +127,10 @@ test.describe('Freegle Edit Deadline', () => {
     await expect(editModal2).toBeVisible({ timeout: timeouts.ui.appearance })
 
     const deadlineInput2 = editModal2.locator('input[type="date"]').first()
-    await expect(deadlineInput2).toBeVisible({
+    await expect(deadlineInput2).toHaveValue(deadlineDate, {
       timeout: timeouts.ui.appearance,
     })
-    const savedDeadline = await deadlineInput2.inputValue()
-    expect(savedDeadline).toBe(deadlineDate)
-    console.log(`Re-opened modal shows deadline: ${savedDeadline}`)
+    console.log(`Re-opened modal shows deadline: ${deadlineDate}`)
 
     // Close modal
     await editModal2.locator('button:has-text("Cancel")').first().click()
@@ -155,11 +156,9 @@ test.describe('Freegle Edit Deadline', () => {
     await expect(editModal3).toBeVisible({ timeout: timeouts.ui.appearance })
 
     const deadlineInput3 = editModal3.locator('input[type="date"]').first()
-    await expect(deadlineInput3).toBeVisible({
+    await expect(deadlineInput3).toHaveValue(deadlineDate, {
       timeout: timeouts.ui.appearance,
     })
-    const reloadedDeadline = await deadlineInput3.inputValue()
-    expect(reloadedDeadline).toBe(deadlineDate)
-    console.log(`After reload, deadline persists: ${reloadedDeadline}`)
+    console.log(`After reload, deadline persists: ${deadlineDate}`)
   })
 })

--- a/iznik-server-go/admin/admin.go
+++ b/iznik-server-go/admin/admin.go
@@ -9,6 +9,7 @@ import (
 	"github.com/freegle/iznik-server-go/user"
 	"github.com/freegle/iznik-server-go/utils"
 	"github.com/gofiber/fiber/v2"
+	"gorm.io/gorm"
 )
 
 type Admin struct {
@@ -183,6 +184,11 @@ func PostAdmin(c *fiber.Ctx) error {
 			return fiber.NewError(fiber.StatusForbidden, "Must be a moderator of the admin's group")
 		}
 
+		// Don't take a hold off another mod - Release is the way to do that.
+		if holder, name := adminHeldByAnother(db, req.ID, myid); holder != 0 {
+			return heldByAnotherResponse(c, holder, name)
+		}
+
 		db.Exec("UPDATE admins SET heldby = ? WHERE id = ?", myid, req.ID)
 		return c.JSON(fiber.Map{"success": true})
 
@@ -286,6 +292,30 @@ type PatchAdminRequest struct {
 // @Produce json
 // @Success 200 {object} map[string]interface{}
 // @Router /modtools/admin [patch]
+// adminHeldByAnother returns the id and name of a DIFFERENT moderator holding this
+// admin message, or 0 if it is free to act on.
+func adminHeldByAnother(db *gorm.DB, id uint64, myid uint64) (uint64, string) {
+	var holder uint64
+	db.Raw("SELECT COALESCE(heldby, 0) FROM admins WHERE id = ?", id).Scan(&holder)
+	if holder == 0 || holder == myid {
+		return 0, ""
+	}
+	var name string
+	db.Raw("SELECT fullname FROM users WHERE id = ?", holder).Scan(&name)
+	return holder, name
+}
+
+// heldByAnotherResponse is the 409 a moderation action gets when someone else holds
+// the item, carrying who so the UI can name them rather than just failing.
+func heldByAnotherResponse(c *fiber.Ctx, holder uint64, name string) error {
+	return c.Status(fiber.StatusConflict).JSON(fiber.Map{
+		"ret":        1,
+		"status":     "Held by another moderator",
+		"heldby":     holder,
+		"heldbyname": name,
+	})
+}
+
 func PatchAdmin(c *fiber.Ctx) error {
 	myid := user.WhoAmI(c)
 	if myid == 0 {
@@ -310,6 +340,12 @@ func PatchAdmin(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusForbidden, "Must be a moderator of the admin's group")
 	}
 
+	// Editing or completing an admin message another mod is holding is exactly the
+	// case the hold exists to prevent.
+	if holder, name := adminHeldByAnother(db, req.ID, myid); holder != 0 {
+		return heldByAnotherResponse(c, holder, name)
+	}
+
 	if req.Subject != nil {
 		db.Exec("UPDATE admins SET subject = ? WHERE id = ?", *req.Subject, req.ID)
 	}
@@ -317,7 +353,10 @@ func PatchAdmin(c *fiber.Ctx) error {
 		db.Exec("UPDATE admins SET text = ? WHERE id = ?", *req.Text, req.ID)
 	}
 	if req.Complete != nil {
-		db.Exec("UPDATE admins SET complete = NOW() WHERE id = ?", req.ID)
+		// Completing is terminal, so drop the hold with it. Leaving it set pinned the
+		// message as "Held" indefinitely, so it stayed locked to a mod who had already
+		// finished with it and only a manual Release cleared it.
+		db.Exec("UPDATE admins SET complete = NOW(), heldby = NULL WHERE id = ?", req.ID)
 	}
 	if req.Pending != nil {
 		var val int

--- a/iznik-server-go/communityevent/communityEvent.go
+++ b/iznik-server-go/communityevent/communityEvent.go
@@ -351,6 +351,30 @@ type PatchRequest struct {
 // @Produce json
 // @Success 200 {object} map[string]interface{}
 // @Router /communityevent [patch]
+// eventHeldByAnother returns the id and name of a DIFFERENT moderator holding this
+// event, or 0 if it is free to act on.
+func eventHeldByAnother(db *gorm.DB, id uint64, myid uint64) (uint64, string) {
+	var holder uint64
+	db.Raw("SELECT COALESCE(heldby, 0) FROM communityevents WHERE id = ?", id).Scan(&holder)
+	if holder == 0 || holder == myid {
+		return 0, ""
+	}
+	var name string
+	db.Raw("SELECT fullname FROM users WHERE id = ?", holder).Scan(&name)
+	return holder, name
+}
+
+// heldByAnotherResponse is the 409 a moderation action gets when someone else holds
+// the item, carrying who so the UI can name them rather than just failing.
+func heldByAnotherResponse(c *fiber.Ctx, holder uint64, name string) error {
+	return c.Status(fiber.StatusConflict).JSON(fiber.Map{
+		"ret":        1,
+		"status":     "Held by another moderator",
+		"heldby":     holder,
+		"heldbyname": name,
+	})
+}
+
 func Update(c *fiber.Ctx) error {
 	myid := user.WhoAmI(c)
 	if myid == 0 {
@@ -377,6 +401,15 @@ func Update(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusForbidden, "Not authorized to modify this community event")
 	}
 
+	// A moderator holding this event has an exclusive claim on it. Only block other
+	// MODERATORS: canModify also passes the event's owner, and a mod hold must not
+	// stop an owner editing their own event. Release remains available below.
+	if req.Action != "Release" && isModerator(myid, req.ID) {
+		if holder, name := eventHeldByAnother(db, req.ID, myid); holder != 0 {
+			return heldByAnotherResponse(c, holder, name)
+		}
+	}
+
 	// Update settable attributes
 	if req.Title != nil {
 		db.Exec("UPDATE communityevents SET title = ? WHERE id = ?", *req.Title, req.ID)
@@ -385,7 +418,13 @@ func Update(c *fiber.Ctx) error {
 		db.Exec("UPDATE communityevents SET location = ? WHERE id = ?", *req.Location, req.ID)
 	}
 	if req.Pending != nil {
-		db.Exec("UPDATE communityevents SET pending = ? WHERE id = ?", *req.Pending, req.ID)
+		// Approving out of moderation is terminal, so clear the hold with it rather
+		// than leaving the event pinned as "Held" forever.
+		if *req.Pending {
+			db.Exec("UPDATE communityevents SET pending = ? WHERE id = ?", *req.Pending, req.ID)
+		} else {
+			db.Exec("UPDATE communityevents SET pending = ?, heldby = NULL WHERE id = ?", *req.Pending, req.ID)
+		}
 	}
 	if req.Contactname != nil {
 		db.Exec("UPDATE communityevents SET contactname = ? WHERE id = ?", *req.Contactname, req.ID)
@@ -447,6 +486,10 @@ func Update(c *fiber.Ctx) error {
 		}
 	case "Hold":
 		if isModerator(myid, req.ID) {
+			// Don't take a hold off another mod - Release is how you do that.
+			if holder, name := eventHeldByAnother(db, req.ID, myid); holder != 0 {
+				return heldByAnotherResponse(c, holder, name)
+			}
 			db.Exec("UPDATE communityevents SET heldby = ? WHERE id = ?", myid, req.ID)
 		}
 	case "Release":

--- a/iznik-server-go/membership/membership.go
+++ b/iznik-server-go/membership/membership.go
@@ -124,6 +124,28 @@ func PostMemberships(c *fiber.Ctx) error {
 
 	db := database.DBConn
 
+	// A hold on a membership is an exclusive claim, and was advisory only: ModTools
+	// shows "Held by X" but nothing stopped another mod acting from a stale screen.
+	// Refuse the actions that decide the membership, and refuse taking the hold off
+	// someone. Release/ReviewRelease are deliberately absent - they are the escape
+	// hatch when the holder is away.
+	switch req.Action {
+	case "Approve", "Reject", "Delete Approved Member", "Ban", "Hold", "ReviewHold", "ReviewIgnore":
+		var holder uint64
+		db.Raw("SELECT COALESCE(heldby, 0) FROM memberships WHERE userid = ? AND groupid = ?",
+			req.Userid, req.Groupid).Scan(&holder)
+		if holder != 0 && holder != myid {
+			var holderName string
+			db.Raw("SELECT fullname FROM users WHERE id = ?", holder).Scan(&holderName)
+			return c.Status(fiber.StatusConflict).JSON(fiber.Map{
+				"ret":        1,
+				"status":     "Held by another moderator",
+				"heldby":     holder,
+				"heldbyname": holderName,
+			})
+		}
+	}
+
 	switch req.Action {
 	case "Hold":
 		if result := db.Exec("UPDATE memberships SET heldby = ? WHERE userid = ? AND groupid = ?",
@@ -241,7 +263,11 @@ func PostMemberships(c *fiber.Ctx) error {
 
 	case "ReviewIgnore":
 		// Per-group: mods on adjacent communities make independent decisions (Discourse 9618 #8).
-		db.Exec("UPDATE memberships SET reviewedat = NOW(), reviewrequestedat = NULL "+
+		// Closing the review is terminal for THIS group, so drop our own hold with it -
+		// otherwise the row keeps a heldby that nothing clears, and the member shows as
+		// held again the next time they are flagged. Only this group's row is touched,
+		// so a hold on an adjacent community is left alone.
+		db.Exec("UPDATE memberships SET reviewedat = NOW(), reviewrequestedat = NULL, heldby = NULL "+
 			"WHERE userid = ? AND groupid = ?",
 			req.Userid, req.Groupid)
 		return c.JSON(fiber.Map{"ret": 0, "status": "Success"})
@@ -732,16 +758,16 @@ func getRelatedMembers(c *fiber.Ctx, myid uint64, groupid uint64, limit int) err
 
 // HappinessMember is the response struct for happiness/feedback items.
 type HappinessMember struct {
-	ID        uint64          `json:"id"`
-	Timestamp string          `json:"timestamp"`
-	Outcome   *string         `json:"outcome"`
-	Happiness *string         `json:"happiness"`
-	Comments  *string         `json:"comments"`
-	Reviewed  int             `json:"reviewed"`
-	Fromuser  uint64          `json:"fromuser"`
-	Groupid   uint64          `json:"groupid"`
-	User      HappinessUser   `json:"user"`
-	Message   HappinessMsg    `json:"message"`
+	ID        uint64        `json:"id"`
+	Timestamp string        `json:"timestamp"`
+	Outcome   *string       `json:"outcome"`
+	Happiness *string       `json:"happiness"`
+	Comments  *string       `json:"comments"`
+	Reviewed  int           `json:"reviewed"`
+	Fromuser  uint64        `json:"fromuser"`
+	Groupid   uint64        `json:"groupid"`
+	User      HappinessUser `json:"user"`
+	Message   HappinessMsg  `json:"message"`
 }
 
 // HappinessUser is the user info embedded in happiness results.

--- a/iznik-server-go/spammers/spammers.go
+++ b/iznik-server-go/spammers/spammers.go
@@ -6,11 +6,10 @@ import (
 
 	"github.com/freegle/iznik-server-go/auth"
 	"github.com/freegle/iznik-server-go/database"
-	"github.com/freegle/iznik-server-go/utils"
 	"github.com/freegle/iznik-server-go/user"
+	"github.com/freegle/iznik-server-go/utils"
 	"github.com/gofiber/fiber/v2"
 )
-
 
 // GetSpammers handles GET /spammers with search and pagination.
 //
@@ -254,11 +253,32 @@ func PatchSpammer(c *fiber.Ctx) error {
 		Collection string
 		Reason     string
 		Byuserid   *uint64
+		Heldby     *uint64
 	}
-	db.Raw("SELECT collection, reason, byuserid FROM spam_users WHERE id = ?", req.ID).Scan(&current)
+	db.Raw("SELECT collection, reason, byuserid, heldby FROM spam_users WHERE id = ?", req.ID).Scan(&current)
 
 	if current.Collection == "" {
 		return fiber.NewError(fiber.StatusNotFound, "Not found")
+	}
+
+	// Another mod's hold is an exclusive claim on this report. Refuse to resolve it
+	// (any collection change) or to take the hold off them, but keep the plain
+	// release working - it is the escape hatch when the holder is away. The client
+	// sends the unchanged collection for both hold and release, and a different one
+	// only for a real decision, so the collection is what distinguishes them.
+	if current.Heldby != nil && *current.Heldby != myid {
+		changingCollection := req.Collection != "" && req.Collection != current.Collection
+		takingHold := req.Heldby != nil
+		if changingCollection || takingHold {
+			var holderName string
+			db.Raw("SELECT fullname FROM users WHERE id = ?", *current.Heldby).Scan(&holderName)
+			return c.Status(fiber.StatusConflict).JSON(fiber.Map{
+				"ret":        1,
+				"status":     "Held by another moderator",
+				"heldby":     *current.Heldby,
+				"heldbyname": holderName,
+			})
+		}
 	}
 
 	// Permission: admins and SpamAdmin users can do anything.
@@ -291,10 +311,18 @@ func PatchSpammer(c *fiber.Ctx) error {
 		} else {
 			byuserid = current.Byuserid
 		}
+		// You can only hold something as yourself. The holder identity used to be
+		// taken verbatim from the request body, so a client could set the hold to an
+		// arbitrary user id. Presence of heldby means "hold", absence means release.
+		var heldby *uint64
+		if req.Heldby != nil {
+			heldby = &myid
+		}
+
 		db.Exec("UPDATE spam_users SET collection = ?, reason = ?, byuserid = ?, "+
 			"heldby = ?, heldat = CASE WHEN ? IS NOT NULL THEN NOW() ELSE NULL END "+
 			"WHERE id = ?",
-			req.Collection, reason, byuserid, req.Heldby, req.Heldby, req.ID)
+			req.Collection, reason, byuserid, heldby, heldby, req.ID)
 	}
 
 	return c.JSON(fiber.Map{"ret": 0, "status": "Success"})

--- a/iznik-server-go/test/hold_enforcement_test.go
+++ b/iznik-server-go/test/hold_enforcement_test.go
@@ -1,0 +1,225 @@
+package test
+
+import (
+	"fmt"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/freegle/iznik-server-go/database"
+	"github.com/stretchr/testify/assert"
+)
+
+// A "hold" is an exclusive moderator claim, but across most surfaces it was
+// advisory only: ModTools shows "Held by X" and hides the buttons, while the
+// server let anyone act. A moderator whose screen was stale then acted anyway -
+// the bug behind Discourse 9946 on posts. These cover the same enforcement on the
+// remaining surfaces, plus clearing the hold when the action is terminal so
+// nothing stays pinned as "Held" forever.
+
+// patchJSON PATCHes a JSON body and returns the status code.
+func patchJSON(t *testing.T, path string, token string, body string) int {
+	t.Helper()
+	req := httptest.NewRequest("PATCH", fmt.Sprintf("%s?jwt=%s", path, token), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := getApp().Test(req, -1)
+	assert.NoError(t, err)
+	return resp.StatusCode
+}
+
+// postJSON POSTs a JSON body and returns the status code.
+func postJSON(t *testing.T, path string, token string, body string) int {
+	t.Helper()
+	req := httptest.NewRequest("POST", fmt.Sprintf("%s?jwt=%s", path, token), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := getApp().Test(req, -1)
+	assert.NoError(t, err)
+	return resp.StatusCode
+}
+
+// --- spam_users ------------------------------------------------------------
+
+// The holder used to be taken verbatim from the request body and never compared
+// to the session user, so a client could hold a report as somebody else entirely.
+func TestPatchSpammerCannotHoldAsAnotherUser(t *testing.T) {
+	prefix := uniquePrefix("spam_holdas")
+	modID, token := createSpamAdminUser(t, prefix)
+
+	impersonated := CreateTestUser(t, prefix+"_other", "User")
+	targetID := CreateTestUser(t, prefix+"_target", "User")
+	spamID := createTestSpammer(t, targetID, "PendingAdd", "Suspicious")
+
+	body := fmt.Sprintf(`{"id":%d,"collection":"PendingAdd","reason":"Suspicious","heldby":%d}`,
+		spamID, impersonated)
+	status := patchJSON(t, "/api/modtools/spammers", token, body)
+	assert.Equal(t, 200, status)
+
+	var heldby *uint64
+	database.DBConn.Raw("SELECT heldby FROM spam_users WHERE id = ?", spamID).Scan(&heldby)
+	assert.NotNil(t, heldby)
+	assert.Equal(t, modID, *heldby, "the hold must be recorded against the acting mod, not the requested one")
+}
+
+func TestPatchSpammerBlockedWhenHeldByAnotherMod(t *testing.T) {
+	prefix := uniquePrefix("spam_heldother")
+	_, tokenA := createSpamAdminUser(t, prefix+"a")
+	modB, tokenB := createSpamAdminUser(t, prefix+"b")
+
+	targetID := CreateTestUser(t, prefix+"_target", "User")
+	spamID := createTestSpammer(t, targetID, "PendingAdd", "Suspicious")
+
+	// Mod A holds it.
+	status := patchJSON(t, "/api/modtools/spammers", tokenA,
+		fmt.Sprintf(`{"id":%d,"collection":"PendingAdd","reason":"Suspicious","heldby":1}`, spamID))
+	assert.Equal(t, 200, status)
+
+	// Mod B tries to resolve it.
+	status = patchJSON(t, "/api/modtools/spammers", tokenB,
+		fmt.Sprintf(`{"id":%d,"collection":"Spammer","reason":"Confirmed"}`, spamID))
+	assert.Equal(t, 409, status, "resolving a report another mod holds must be refused")
+
+	var collection string
+	database.DBConn.Raw("SELECT collection FROM spam_users WHERE id = ?", spamID).Scan(&collection)
+	assert.Equal(t, "PendingAdd", collection, "the report must be untouched")
+
+	// Mod B must not be able to steal the hold either.
+	status = patchJSON(t, "/api/modtools/spammers", tokenB,
+		fmt.Sprintf(`{"id":%d,"collection":"PendingAdd","reason":"Suspicious","heldby":%d}`, spamID, modB))
+	assert.Equal(t, 409, status, "taking another mod's hold must be refused")
+
+	// ...but releasing is the escape hatch and stays available.
+	status = patchJSON(t, "/api/modtools/spammers", tokenB,
+		fmt.Sprintf(`{"id":%d,"collection":"PendingAdd","reason":"Suspicious"}`, spamID))
+	assert.Equal(t, 200, status, "release must remain allowed")
+
+	var heldby *uint64
+	database.DBConn.Raw("SELECT heldby FROM spam_users WHERE id = ?", spamID).Scan(&heldby)
+	assert.Nil(t, heldby, "release must clear the hold")
+}
+
+// --- admins ----------------------------------------------------------------
+
+func adminHoldSetup(t *testing.T, prefix string) (uint64, uint64, string, string) {
+	t.Helper()
+	groupID := CreateTestGroup(t, prefix)
+	modA := CreateTestUser(t, prefix+"_moda", "User")
+	modB := CreateTestUser(t, prefix+"_modb", "User")
+	CreateTestMembership(t, modA, groupID, "Moderator")
+	CreateTestMembership(t, modB, groupID, "Moderator")
+	_, tokenA := CreateTestSession(t, modA)
+	_, tokenB := CreateTestSession(t, modB)
+
+	adminID := createTestAdmin(t, modA, groupID, "Hold Test "+prefix)
+	database.DBConn.Exec("UPDATE admins SET heldby = ? WHERE id = ?", modA, adminID)
+	return adminID, modA, tokenA, tokenB
+}
+
+func TestPatchAdminBlockedWhenHeldByAnotherMod(t *testing.T) {
+	adminID, _, _, tokenB := adminHoldSetup(t, uniquePrefix("adm_held"))
+
+	status := patchJSON(t, "/api/modtools/admin", tokenB,
+		fmt.Sprintf(`{"id":%d,"subject":"Hijacked"}`, adminID))
+	assert.Equal(t, 409, status, "editing an admin message another mod holds must be refused")
+
+	var subject string
+	database.DBConn.Raw("SELECT subject FROM admins WHERE id = ?", adminID).Scan(&subject)
+	assert.NotEqual(t, "Hijacked", subject)
+}
+
+func TestPatchAdminCompleteClearsHold(t *testing.T) {
+	adminID, _, tokenA, _ := adminHoldSetup(t, uniquePrefix("adm_compl"))
+
+	// complete is a *string on PatchAdminRequest, not a bool - the handler ignores
+	// the value and stamps NOW(), but it still has to parse.
+	status := patchJSON(t, "/api/modtools/admin", tokenA,
+		fmt.Sprintf(`{"id":%d,"complete":"2026-07-21 12:00:00"}`, adminID))
+	assert.Equal(t, 200, status)
+
+	var heldby *uint64
+	database.DBConn.Raw("SELECT heldby FROM admins WHERE id = ?", adminID).Scan(&heldby)
+	assert.Nil(t, heldby, "completing is terminal so the hold must not stay pinned")
+}
+
+func TestAdminHoldDoesNotStealAnotherModsHold(t *testing.T) {
+	adminID, modA, _, tokenB := adminHoldSetup(t, uniquePrefix("adm_steal"))
+
+	body := fmt.Sprintf(`{"action":"Hold","id":%d}`, adminID)
+	assert.Equal(t, 409, postJSON(t, "/api/modtools/admin", tokenB, body))
+
+	var heldby *uint64
+	database.DBConn.Raw("SELECT heldby FROM admins WHERE id = ?", adminID).Scan(&heldby)
+	assert.NotNil(t, heldby)
+	assert.Equal(t, modA, *heldby, "the original holder keeps the hold")
+}
+
+// --- memberships -----------------------------------------------------------
+
+func membershipHoldSetup(t *testing.T, prefix string) (uint64, uint64, uint64, string) {
+	t.Helper()
+	groupID := CreateTestGroup(t, prefix)
+	modA := CreateTestUser(t, prefix+"_moda", "User")
+	modB := CreateTestUser(t, prefix+"_modb", "User")
+	target := CreateTestUser(t, prefix+"_target", "User")
+	CreateTestMembership(t, modA, groupID, "Moderator")
+	CreateTestMembership(t, modB, groupID, "Moderator")
+	CreateTestMembership(t, target, groupID, "Member")
+	_, tokenB := CreateTestSession(t, modB)
+
+	database.DBConn.Exec("UPDATE memberships SET heldby = ? WHERE userid = ? AND groupid = ?",
+		modA, target, groupID)
+	return groupID, target, modA, tokenB
+}
+
+func TestMembershipActionsBlockedWhenHeldByAnotherMod(t *testing.T) {
+	for _, action := range []string{"Approve", "Reject", "Ban", "Hold", "ReviewHold", "ReviewIgnore"} {
+		t.Run(action, func(t *testing.T) {
+			groupID, target, modA, tokenB := membershipHoldSetup(t, uniquePrefix("mem_held"))
+
+			body := fmt.Sprintf(`{"action":"%s","userid":%d,"groupid":%d}`, action, target, groupID)
+			assert.Equal(t, 409, postJSON(t, "/api/memberships", tokenB, body), action+" must be refused while another mod holds the membership")
+
+			// The membership and the hold must both survive.
+			var heldby *uint64
+			database.DBConn.Raw("SELECT heldby FROM memberships WHERE userid = ? AND groupid = ?",
+				target, groupID).Scan(&heldby)
+			assert.NotNil(t, heldby, action+" must not clear another mod's hold")
+			assert.Equal(t, modA, *heldby)
+		})
+	}
+}
+
+func TestMembershipReleaseAllowedWhenHeldByAnotherMod(t *testing.T) {
+	groupID, target, _, tokenB := membershipHoldSetup(t, uniquePrefix("mem_rel"))
+
+	body := fmt.Sprintf(`{"action":"Release","userid":%d,"groupid":%d}`, target, groupID)
+	assert.Equal(t, 200, postJSON(t, "/api/memberships", tokenB, body), "Release is the escape hatch and must stay available")
+
+	var heldby *uint64
+	database.DBConn.Raw("SELECT heldby FROM memberships WHERE userid = ? AND groupid = ?",
+		target, groupID).Scan(&heldby)
+	assert.Nil(t, heldby)
+}
+
+// Closing the review is terminal for this group, so it must not leave a heldby
+// that nothing clears - otherwise the member shows as held again next time they
+// are flagged.
+func TestMembershipReviewIgnoreClearsOwnHold(t *testing.T) {
+	prefix := uniquePrefix("mem_rvign")
+	groupID := CreateTestGroup(t, prefix)
+	modID := CreateTestUser(t, prefix+"_mod", "User")
+	target := CreateTestUser(t, prefix+"_target", "User")
+	CreateTestMembership(t, modID, groupID, "Moderator")
+	CreateTestMembership(t, target, groupID, "Member")
+	_, token := CreateTestSession(t, modID)
+
+	database.DBConn.Exec("UPDATE memberships SET heldby = ? WHERE userid = ? AND groupid = ?",
+		modID, target, groupID)
+
+	body := fmt.Sprintf(`{"action":"ReviewIgnore","userid":%d,"groupid":%d}`, target, groupID)
+	assert.Equal(t, 200, postJSON(t, "/api/memberships", token, body))
+
+	var heldby *uint64
+	database.DBConn.Raw("SELECT heldby FROM memberships WHERE userid = ? AND groupid = ?",
+		target, groupID).Scan(&heldby)
+	assert.Nil(t, heldby, "ignoring the review must drop our own hold with it")
+}

--- a/iznik-server-go/volunteering/volunteering.go
+++ b/iznik-server-go/volunteering/volunteering.go
@@ -393,6 +393,30 @@ type PatchRequest struct {
 // @Produce json
 // @Success 200 {object} map[string]interface{}
 // @Router /volunteering [patch]
+// volunteeringHeldByAnother returns the id and name of a DIFFERENT moderator holding
+// this opportunity, or 0 if it is free to act on.
+func volunteeringHeldByAnother(db *gorm.DB, id uint64, myid uint64) (uint64, string) {
+	var holder uint64
+	db.Raw("SELECT COALESCE(heldby, 0) FROM volunteering WHERE id = ?", id).Scan(&holder)
+	if holder == 0 || holder == myid {
+		return 0, ""
+	}
+	var name string
+	db.Raw("SELECT fullname FROM users WHERE id = ?", holder).Scan(&name)
+	return holder, name
+}
+
+// heldByAnotherResponse is the 409 a moderation action gets when someone else holds
+// the item, carrying who so the UI can name them rather than just failing.
+func heldByAnotherResponse(c *fiber.Ctx, holder uint64, name string) error {
+	return c.Status(fiber.StatusConflict).JSON(fiber.Map{
+		"ret":        1,
+		"status":     "Held by another moderator",
+		"heldby":     holder,
+		"heldbyname": name,
+	})
+}
+
 func Update(c *fiber.Ctx) error {
 	myid := user.WhoAmI(c)
 	if myid == 0 {
@@ -420,6 +444,15 @@ func Update(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusForbidden, "Not authorized to modify this volunteering")
 	}
 
+	// A moderator holding this has an exclusive claim on it. Only block other
+	// MODERATORS: canModify also passes the owner, and a mod hold must not stop an
+	// owner editing their own opportunity. Release remains available below.
+	if req.Action != "Release" && isModerator(myid, req.ID) {
+		if holder, name := volunteeringHeldByAnother(db, req.ID, myid); holder != 0 {
+			return heldByAnotherResponse(c, holder, name)
+		}
+	}
+
 	// Update settable attributes
 	if req.Title != nil {
 		db.Exec("UPDATE volunteering SET title = ? WHERE id = ?", *req.Title, req.ID)
@@ -431,7 +464,13 @@ func Update(c *fiber.Ctx) error {
 		db.Exec("UPDATE volunteering SET online = ? WHERE id = ?", *req.Online, req.ID)
 	}
 	if req.Pending != nil {
-		db.Exec("UPDATE volunteering SET pending = ? WHERE id = ?", *req.Pending, req.ID)
+		// Approving out of moderation is terminal, so clear the hold with it rather
+		// than leaving the opportunity pinned as "Held" forever.
+		if *req.Pending {
+			db.Exec("UPDATE volunteering SET pending = ? WHERE id = ?", *req.Pending, req.ID)
+		} else {
+			db.Exec("UPDATE volunteering SET pending = ?, heldby = NULL WHERE id = ?", *req.Pending, req.ID)
+		}
 	}
 	if req.Contactname != nil {
 		db.Exec("UPDATE volunteering SET contactname = ? WHERE id = ?", *req.Contactname, req.ID)
@@ -500,6 +539,10 @@ func Update(c *fiber.Ctx) error {
 		db.Exec("UPDATE volunteering SET expired = 1 WHERE id = ?", req.ID)
 	case "Hold":
 		if isModerator(myid, req.ID) {
+			// Don't take a hold off another mod - Release is how you do that.
+			if holder, name := volunteeringHeldByAnother(db, req.ID, myid); holder != 0 {
+				return heldByAnotherResponse(c, holder, name)
+			}
 			db.Exec("UPDATE volunteering SET heldby = ? WHERE id = ?", myid, req.ID)
 		}
 	case "Release":


### PR DESCRIPTION
Follow-up to #1131, which enforced holds on posts and chat messages and noted the rest as out of scope. Related: [Discourse 9946](https://discourse.ilovefreegle.org/t/hold-not-showing-to-other-mods/9946).

## The problem

An audit of every `heldby` column found that outside posts and chat, **a hold was advisory only**. ModTools shows "Held by X" and hides the buttons, but nothing on the server checked - so a moderator working from a stale screen acted anyway. That is exactly the 9946 failure, where a mod rejected a post 27 minutes after a colleague held it, off a list his browser had fetched 90 minutes earlier.

Several surfaces also never cleared the hold on the terminal action, leaving items pinned as "Held" until someone remembered to Release.

| Surface | Was enforced? | Cleared on terminal action? |
|---|---|---|
| `spam_users` | no - and see below | value was client-controlled |
| `admins` | no | no - `Complete` left it set |
| `communityevents` | no | no - approving left it set |
| `volunteering` | no | no - same |
| `memberships` | no | Approve yes; Reject/Ban moot (row deleted) |

## `spam_users` was a permissions bug, not just a UX one

`PatchSpammer` took `heldby` **verbatim from the request body** and never compared it to the session user. It did not even read the current `heldby`. So a client could hold a report as an arbitrary user id, or clear another mod's hold, in the same call that resolved the report.

The holder is now forced to the acting mod, and resolving or taking the hold is refused while someone else holds it. A plain release still works: the client sends the unchanged collection for both hold and release, and a different one only for a real decision, so the collection is what distinguishes them.

## The rest

- **`admins`** - refuse `PatchAdmin` and hold-stealing; `Complete` clears `heldby`.
- **`communityevents` / `volunteering`** - refuse `Update` and hold-stealing; approving out of moderation (`pending=false`) clears `heldby`. Deliberately scoped to **moderators**: `canModify` also passes the event's owner, and a mod hold must not stop someone editing their own event.
- **`memberships`** - refuse Approve/Reject/Delete Approved Member/Ban/Hold/ReviewHold/ReviewIgnore.

Refusals return `409` with the holder's id and name, matching #1131. **Release stays available everywhere** - it is the escape hatch when the holder is away.

One correction to the audit that prompted this PR. It flagged `ReviewIgnore` leaving `heldby` as a stale-pin bug, but `TestReviewIgnoreSkipsHeldMembers` shows that behaviour is really about **per-group scoping** - Ignore on one group must not disturb a hold on another. So `ReviewIgnore` now clears only *our own* hold on the group actually acted on, which preserves that test's intent.

## Client

A shared `notAHeldConflict` predicate keeps these expected 409s out of Sentry, so holds working as designed don't raise issues (monitor-fsm scans Sentry and would otherwise open some). `MessageAPI`'s private copy from #1131 now uses it too.

## Testing

- Go: **3577 pass**. New `test/hold_enforcement_test.go` covers, per surface: the refusal, the item being left untouched, hold-stealing refused, Release still working, and the hold cleared on the terminal action. Includes the spammer impersonation case.
- Frontend: **14401 pass** (681 files).

`TestPatchAdminCompleteClearsHold` failed first time with a 400: `PatchAdminRequest.Complete` is a `*string`, not a `*bool`, so `{"complete":true}` never parsed. The test was wrong, not the handler.

## Not in this PR

User-facing "X is holding this" messaging for these five surfaces. #1131 added it for posts and chat; replicating it across five differently-shaped UIs is its own piece of work. Today a mod hitting one of these 409s gets a generic failure - the action correctly does not happen, but it isn't explained yet.
