### PR TITLE
fix(mapping): new areas were invisible after saving

### DIFF
--- a/iznik-server-go/location/location.go
+++ b/iznik-server-go/location/location.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
+	"log"
 	"math"
 	"sort"
 	"strconv"
@@ -733,16 +734,24 @@ func CreateLocation(c *fiber.Ctx) error {
 		id = uint64(lastID)
 	}
 
-	// Sync to PostgreSQL spatial index (required by PostcodeRemapService).
 	if id > 0 {
+		// Sync to the spatial index table (required by PostcodeRemapService).
 		db.Exec(
 			fmt.Sprintf("REPLACE INTO locations_spatial (locationid, geometry) VALUES (?, ST_GeomFromText(?, %d))", utils.SRID),
 			id, req.Polygon,
 		)
-	}
 
-	// Queue postcode remapping for the new area.
-	if id > 0 {
+		// Cache centroid and max dimension, as UpdateLocation does. Without this a
+		// created area has NULL lat/lng, unlike every edited one.
+		db.Exec("UPDATE locations SET maxdimension = GetMaxDimension(geometry), lat = ST_Y(ST_Centroid(geometry)), lng = ST_X(ST_Centroid(geometry)) WHERE id = ?", id)
+
+		// Put the new area into the spatial KNN index before the remap below runs,
+		// otherwise the remap can't find it and the area gets no postcodes.
+		if err := spatial.UpsertLocation(id, req.Polygon, req.Name, "Polygon"); err != nil {
+			log.Printf("CreateLocation: spatial upsert of %d failed, postcodes may not remap until the next delta sync: %v", id, err)
+		}
+
+		// Queue postcode remapping for the new area.
 		go queue.QueueTask(queue.TaskRemapPostcodes, map[string]interface{}{
 			"location_id": id,
 			"polygon":     req.Polygon,
@@ -835,6 +844,14 @@ func UpdateLocation(c *fiber.Ctx) error {
 
 		// Update cached centroid and max dimensions.
 		db.Exec("UPDATE locations SET maxdimension = GetMaxDimension(ourgeometry), lat = ST_Y(ST_Centroid(ourgeometry)), lng = ST_X(ST_Centroid(ourgeometry)) WHERE id = ?", req.ID)
+
+		// Refresh the spatial KNN index before the remap below runs, so it remaps
+		// against the new shape rather than the one from the last delta sync.
+		var locName string
+		db.Raw("SELECT name FROM locations WHERE id = ?", req.ID).Scan(&locName)
+		if err := spatial.UpsertLocation(req.ID, *req.Polygon, locName, "Polygon"); err != nil {
+			log.Printf("UpdateLocation: spatial upsert of %d failed, postcodes may not remap until the next delta sync: %v", req.ID, err)
+		}
 
 		// Queue postcode remapping. Matching V1: remap the union if geometries overlap,
 		// or remap both old and new separately if they don't.

--- a/iznik-server-go/spatial/client.go
+++ b/iznik-server-go/spatial/client.go
@@ -1,12 +1,14 @@
 package spatial
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
 	"os"
+	"strings"
 	"time"
 )
 
@@ -21,6 +23,50 @@ func baseURL() string {
 		return u
 	}
 	return "http://localhost:8194"
+}
+
+// adminBaseURL returns the spatial server's admin API, which listens on its own
+// port (SPATIAL_ADMIN_PORT, default 8195) alongside the query API on 8194.
+func adminBaseURL() string {
+	if u := os.Getenv("SPATIAL_ADMIN_URL"); u != "" {
+		return u
+	}
+	return strings.Replace(baseURL(), ":8194", ":8195", 1)
+}
+
+// UpsertLocation inserts or replaces one location in the spatial index straight
+// away, rather than waiting for the next delta sync.
+//
+// This matters because postcode remapping asks the spatial index which area is
+// nearest. The index only picks up MySQL changes on a 15-minute delta, but the
+// remap for a newly drawn area is queued immediately, so without this the remap
+// runs against an index that has never heard of the area, keeps every postcode
+// pointing where it already pointed, and leaves the area with no postcodes. The
+// ModTools map only draws areas that have at least one postcode pointing at
+// them, so the area then appears not to have saved at all (Discourse #9950).
+func UpsertLocation(id uint64, wkt, name, locType string) error {
+	body, err := json.Marshal(map[string]any{
+		"items": []map[string]any{{
+			"id":    id,
+			"wkt":   wkt,
+			"extra": map[string]any{"name": name, "type": locType},
+		}},
+	})
+	if err != nil {
+		return fmt.Errorf("spatial upsert marshal: %w", err)
+	}
+
+	reqURL := fmt.Sprintf("%s/v1/locations/upsert", adminBaseURL())
+	resp, err := httpClient.Post(reqURL, "application/json", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("spatial upsert: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("spatial upsert: HTTP %d", resp.StatusCode)
+	}
+	return nil
 }
 
 // QueryResult mirrors the JSON shape returned by /v1/:dataset/knn.

--- a/iznik-server-go/spatial/client_pure_test.go
+++ b/iznik-server-go/spatial/client_pure_test.go
@@ -1,0 +1,85 @@
+package spatial
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// The admin API lives on its own port next to the query API. If this derivation
+// breaks, UpsertLocation silently posts to the query port, the upsert never
+// lands, and newly drawn areas go back to picking up no postcodes.
+func TestAdminBaseURLDerivedFromQueryURL(t *testing.T) {
+	t.Setenv("SPATIAL_ADMIN_URL", "")
+	t.Setenv("SPATIAL_KNN_URL", "http://spatial-knn:8194")
+
+	if got := adminBaseURL(); got != "http://spatial-knn:8195" {
+		t.Errorf("adminBaseURL() = %q, want http://spatial-knn:8195", got)
+	}
+}
+
+func TestAdminBaseURLExplicitOverrideWins(t *testing.T) {
+	t.Setenv("SPATIAL_KNN_URL", "http://spatial-knn:8194")
+	t.Setenv("SPATIAL_ADMIN_URL", "http://elsewhere:9999")
+
+	if got := adminBaseURL(); got != "http://elsewhere:9999" {
+		t.Errorf("adminBaseURL() = %q, want the explicit override", got)
+	}
+}
+
+func TestUpsertLocationPostsItem(t *testing.T) {
+	var gotPath string
+	var payload struct {
+		Items []struct {
+			ID    int64          `json:"id"`
+			WKT   string         `json:"wkt"`
+			Extra map[string]any `json:"extra"`
+		} `json:"items"`
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &payload)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"upserted":1}`))
+	}))
+	defer srv.Close()
+
+	t.Setenv("SPATIAL_ADMIN_URL", srv.URL)
+
+	if err := UpsertLocation(42, "POLYGON((0 0,1 0,1 1,0 1,0 0))", "Watermead", "Polygon"); err != nil {
+		t.Fatalf("UpsertLocation returned %v", err)
+	}
+
+	if gotPath != "/v1/locations/upsert" {
+		t.Errorf("posted to %q, want /v1/locations/upsert", gotPath)
+	}
+	if len(payload.Items) != 1 {
+		t.Fatalf("sent %d items, want 1", len(payload.Items))
+	}
+	if payload.Items[0].ID != 42 {
+		t.Errorf("sent id %d, want 42", payload.Items[0].ID)
+	}
+	if payload.Items[0].Extra["type"] != "Polygon" {
+		t.Errorf("sent type %v, want Polygon - the remap only considers non-Postcode types", payload.Items[0].Extra["type"])
+	}
+	if payload.Items[0].Extra["name"] != "Watermead" {
+		t.Errorf("sent name %v, want Watermead", payload.Items[0].Extra["name"])
+	}
+}
+
+func TestUpsertLocationReportsHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	t.Setenv("SPATIAL_ADMIN_URL", srv.URL)
+
+	if err := UpsertLocation(42, "POLYGON((0 0,1 0,1 1,0 1,0 0))", "X", "Polygon"); err == nil {
+		t.Error("UpsertLocation returned nil on HTTP 500; the caller needs to know so it can log")
+	}
+}


### PR DESCRIPTION
Fixes the Mapping problem reported in [Discourse #9950](https://discourse.ilovefreegle.org/t/unable-to-make-mapping-changes/9950) (Michael, via Dee).

## Symptom

Drawing a new area appears to do nothing. The polygon vanishes, so moderators redraw it, rename neighbouring areas to work around it, and eventually give up. Michael went through this on Aylesbury three times over four days.

## What is actually happening

The area saves fine. The row is there. What fails is everything after it.

1. `CreateLocation` / `UpdateLocation` queue a postcode remap immediately.
2. The remap (`PostcodeRemapService`) asks the **spatial KNN server** which area is nearest to each postcode.
3. The spatial index only picks up MySQL changes on a **15-minute delta sync**, and the remap runs within a minute of the write.

So the remap consults an index that has never heard of the new area. Every postcode keeps the `areaid` it already had, and the new area ends up with nothing pointing at it.

That matters because the ModTools bbox query only returns areas reachable via a postcode's `areaid`:

```sql
FROM (SELECT DISTINCT locationid FROM locations_spatial
      INNER JOIN locations l2 ON l2.areaid = locations_spatial.locationid
      ...
```

An area with no postcodes is never drawn. Indistinguishable, from the moderator's seat, from the save having failed.

It also explains why this looked intermittent: an area only came good if something later re-triggered a remap once the index had caught up.

## Evidence from production

Michael's Watermead polygon (id 9907628, created 14:52:59) exists, geometry valid, centroid correct, `locations_spatial` row present. Its remap task ran 41 seconds later and completed without error. It has **0 postcodes**.

Areas created this way are identifiable by `lat IS NULL` (see below), and they are exactly the ones with no or almost no postcodes:

| id | name | created | lat NULL | postcodes |
|----|------|---------|----------|-----------|
| 1886229 | Watermead | 21 Jul 14:55 | no | 169 |
| 9907628 | Watermead | 21 Jul 14:52 | **yes** | **0** |
| 9907625 | Aylesbury-Freegle CGA | 20 Jul 13:18 | **yes** | 29 |
| 9907622 | Aylesbury-Freegle CGA | 20 Jul 13:16 | **yes** | 1 |
| 1859055 | Stoke Newington | 16 Jul 15:58 | no | 1412 |

The `lat IS NULL` rows are new areas; the others are pre-existing areas that were edited.

## Fix

Push the geometry into the spatial index synchronously at write time, via the spatial server's admin `upsert` endpoint, before queueing the remap. The remap then runs against an index that knows about the area.

A failed upsert is logged and non-fatal: the 15-minute delta still catches up, which is exactly today's behaviour, so this can only improve matters.

Also sets `lat`/`lng`/`maxdimension` on create. `UpdateLocation` already did this, which is why created areas were the only ones left with NULL coordinates.

## Verification

Go suite 3581 pass (4 new tests covering the admin URL derivation and the upsert payload, including that `type` is sent as `Polygon` since the remap only considers non-Postcode types).

Worth noting the fix cannot be fully exercised locally, since it depends on the interaction between apiv2, the spatial server's delta timing and the batch remap worker. The unit tests cover the client contract; the causal chain above is evidenced from production data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
