### PR TITLE
fix(ios): adopt the scene-based life cycle before the iOS 27 SDK forces it

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -306,13 +306,69 @@ jobs:
               exit 0
             fi
 
+            BRANCH="<< pipeline.git.branch >>"
+            THIS_NUMBER="<< pipeline.number >>"
+            THIS_REVISION="<< pipeline.git.revision >>"
+            THIS_ID="<< pipeline.id >>"
+            PROJECT_SLUG="gh/Freegle/Iznik"
+
             # Don't cancel older pipelines when THIS is a manual API trigger (same
             # guard as the first cancel step — manual workflows must not disrupt
-            # already-running automatic deploy-apps builds).
+            # already-running automatic deploy-apps builds). BUT: CircleCI's own
+            # built-in "auto-cancel redundant workflows" project setting is NOT
+            # scoped by trigger type or workflow name — it cancels every other
+            # running workflow on the branch the instant this pipeline is created,
+            # regardless of what our own script decides. That silently killed the
+            # required freegle/build-and-test check on PR #1136 (job 28075, pipeline
+            # #9671) within seconds of a build_testflight pipeline (#9672) being
+            # triggered for the same commit, even though this guard correctly made
+            # #9672 skip cancelling anything itself. Since that's a platform-level
+            # side effect we cannot suppress from config, detect it after the fact
+            # and self-heal: if a sibling pipeline for this exact commit has a
+            # canceled freegle/build-and-test job and none has a running/successful
+            # one, re-trigger a plain (non-manual) pipeline so the check gets a
+            # clean, uncontested run.
             if [ "<< pipeline.parameters.run_manual_promote >>" = "true" ] || \
                [ "<< pipeline.parameters.build_testflight >>" = "true" ] || \
                [ "<< pipeline.parameters.build_modtools_production >>" = "true" ]; then
               echo "Manual workflow trigger — skipping pipeline cancellation"
+
+              SIBLINGS=$(curl -sf \
+                -H "Circle-Token: ${CIRCLE_TOKEN}" \
+                "https://circleci.com/api/v2/project/${PROJECT_SLUG}/pipeline?branch=${BRANCH}" 2>/dev/null) || true
+
+              BUILD_TEST_STATE="none"
+              if [ -n "$SIBLINGS" ]; then
+                SIBLING_IDS=$(echo "$SIBLINGS" | jq -r --arg rev "$THIS_REVISION" --arg self "$THIS_ID" \
+                  '.items[] | select(.vcs.revision == $rev) | select(.id != $self) | .id')
+                for SIB_ID in $SIBLING_IDS; do
+                  WORKFLOWS=$(curl -sf -H "Circle-Token: ${CIRCLE_TOKEN}" \
+                    "https://circleci.com/api/v2/pipeline/${SIB_ID}/workflow" 2>/dev/null) || continue
+                  WF_IDS=$(echo "$WORKFLOWS" | jq -r '.items[].id')
+                  for WF_ID in $WF_IDS; do
+                    STATE=$(curl -sf -H "Circle-Token: ${CIRCLE_TOKEN}" \
+                      "https://circleci.com/api/v2/workflow/${WF_ID}/job" 2>/dev/null | \
+                      jq -r '.items[] | select(.name == "freegle/build-and-test") | .status' | head -1)
+                    if [ "$STATE" = "success" ] || [ "$STATE" = "running" ] || [ "$STATE" = "queued" ] || [ "$STATE" = "blocked" ]; then
+                      BUILD_TEST_STATE="alive"
+                    elif [ "$STATE" = "canceled" ] && [ "$BUILD_TEST_STATE" = "none" ]; then
+                      BUILD_TEST_STATE="canceled"
+                    fi
+                  done
+                done
+              fi
+
+              if [ "$BUILD_TEST_STATE" = "canceled" ]; then
+                echo "This manual trigger's pipeline creation appears to have caused CircleCI's built-in auto-cancel to kill the required freegle/build-and-test check for commit ${THIS_REVISION}. Re-triggering a plain pipeline so the check runs cleanly."
+                curl -sf -X POST \
+                  -H "Circle-Token: ${CIRCLE_TOKEN}" \
+                  -H "Content-Type: application/json" \
+                  -d "{\"branch\": \"${BRANCH}\"}" \
+                  "https://circleci.com/api/v2/project/${PROJECT_SLUG}/pipeline" 2>/dev/null || true
+              else
+                echo "No canceled freegle/build-and-test check found for commit ${THIS_REVISION} — nothing to re-trigger."
+              fi
+
               exit 0
             fi
 
@@ -328,10 +384,6 @@ jobs:
               echo "This commit changes only plans/, yesterday/ or docs/ — skipping cancellation so the older real build survives."
               exit 0
             fi
-
-            BRANCH="<< pipeline.git.branch >>"
-            THIS_NUMBER="<< pipeline.number >>"
-            PROJECT_SLUG="gh/Freegle/Iznik"
 
             echo "Pre-continuation cancel pass for pipeline #${THIS_NUMBER} on ${BRANCH}"
 

--- a/iznik-nuxt3/ios/App/App.xcodeproj/project.pbxproj
+++ b/iznik-nuxt3/ios/App/App.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		2FAD9763203C412B000D30F8 /* config.xml in Resources */ = {isa = PBXBuildFile; fileRef = 2FAD9762203C412B000D30F8 /* config.xml */; };
 		50379B232058CBB4000EE86E /* capacitor.config.json in Resources */ = {isa = PBXBuildFile; fileRef = 50379B222058CBB4000EE86E /* capacitor.config.json */; };
 		504EC3081FED79650016851F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504EC3071FED79650016851F /* AppDelegate.swift */; };
+		FE5CE0E100000000000000A2 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE5CE0E100000000000000A1 /* SceneDelegate.swift */; };
 		504EC30D1FED79650016851F /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 504EC30B1FED79650016851F /* Main.storyboard */; };
 		504EC30F1FED79650016851F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 504EC30E1FED79650016851F /* Assets.xcassets */; };
 		504EC3121FED79650016851F /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 504EC3101FED79650016851F /* LaunchScreen.storyboard */; };
@@ -25,6 +26,7 @@
 		50379B222058CBB4000EE86E /* capacitor.config.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = capacitor.config.json; sourceTree = "<group>"; };
 		504EC3041FED79650016851F /* Freegle.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Freegle.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		504EC3071FED79650016851F /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		FE5CE0E100000000000000A1 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		504EC30C1FED79650016851F /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		504EC30E1FED79650016851F /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		504EC3111FED79650016851F /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -81,6 +83,7 @@
 				B2FCCD20299ECF3400901A0B /* App.entitlements */,
 				50379B222058CBB4000EE86E /* capacitor.config.json */,
 				504EC3071FED79650016851F /* AppDelegate.swift */,
+				FE5CE0E100000000000000A1 /* SceneDelegate.swift */,
 				504EC30B1FED79650016851F /* Main.storyboard */,
 				504EC30E1FED79650016851F /* Assets.xcassets */,
 				504EC3101FED79650016851F /* LaunchScreen.storyboard */,
@@ -218,6 +221,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				504EC3081FED79650016851F /* AppDelegate.swift in Sources */,
+				FE5CE0E100000000000000A2 /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iznik-nuxt3/ios/App/App/AppDelegate.swift
+++ b/iznik-nuxt3/ios/App/App/AppDelegate.swift
@@ -4,12 +4,11 @@ import Capacitor
 import FBSDKCoreKit // capacitor-community/facebook-login
 import Firebase // @capacitor/push-notifications https://devdactic.com/push-notifications-ionic-capacitor
 
-import GoogleSignIn
-
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
-    var window: UIWindow?
+    // The window and the per-scene life cycle live in SceneDelegate now - see the
+    // UIApplicationSceneManifest entry in Info.plist.
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
@@ -21,78 +20,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return true
     }
 
-    func applicationWillResignActive(_ application: UIApplication) {
-        // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
-        // Use this method to pause ongoing tasks, disable timers, and invalidate graphics rendering callbacks. Games should use this method to pause the game.
-    }
-
-    func applicationDidEnterBackground(_ application: UIApplication) {
-        // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
-        // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
-    }
-
-    func applicationWillEnterForeground(_ application: UIApplication) {
-        // Called as part of the transition from the background to the active state; here you can undo many of the changes made on entering the background.
-    }
-
-    func applicationDidBecomeActive(_ application: UIApplication) {
-        // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
-    }
-
-    func applicationWillTerminate(_ application: UIApplication) {
-        // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
-    }
-
-    func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
-        // Called when the app was launched with a url. Feel free to add additional processing here,
-        // but if you want the App API to support tracking app url opens, make sure to keep this call
-        // WAS return ApplicationDelegateProxy.shared.application(app, open: url, options: options)
-        
-        var handled: Bool
-
-        handled = GIDSignIn.sharedInstance.handle(url)
-        if handled {
-          return true
-        }        
-        
-        if (FBSDKCoreKit.ApplicationDelegate.shared.application(  // capacitor-community/facebook-login
-            app,
-            open: url,
-            sourceApplication: options[UIApplication.OpenURLOptionsKey.sourceApplication] as? String,
-            annotation: options[UIApplication.OpenURLOptionsKey.annotation]
-        )) {
-            return true;
-        } else {
-            return ApplicationDelegateProxy.shared.application(app, open: url, options: options)
-        }
-      }
-
-    // Long-press app-icon quick actions (UIApplicationShortcutItems in Info.plist).
-    // Map each shortcut to a https://www.ilovefreegle.org/<path> URL and route it
-    // through the same Capacitor pipeline as a deep link, so the appUrlOpen handler
-    // (stores/mobile.js) navigates to the target page.
-    func application(_ application: UIApplication, performActionFor shortcutItem: UIApplicationShortcutItem, completionHandler: @escaping (Bool) -> Void) {
-        let path: String?
-        switch shortcutItem.type {
-        case "org.ilovefreegle.shortcut.give": path = "/give"
-        case "org.ilovefreegle.shortcut.find": path = "/find"
-        case "org.ilovefreegle.shortcut.chats": path = "/chats"
-        default: path = nil
-        }
-        if let path = path, let url = URL(string: "https://www.ilovefreegle.org" + path) {
-            _ = ApplicationDelegateProxy.shared.application(application, open: url, options: [:])
-            completionHandler(true)
-        } else {
-            completionHandler(false)
-        }
-    }
-
-    func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
-        // Called when the app was launched with an activity, including Universal Links.
-        // Feel free to add additional processing here, but if you want the App API to support
-        // tracking app url opens, make sure to keep this call
-        return ApplicationDelegateProxy.shared.application(application, continue: userActivity, restorationHandler: restorationHandler)
-    }
+    // The empty applicationWillResignActive / DidEnterBackground / WillEnterForeground /
+    // DidBecomeActive / WillTerminate stubs are gone: UIKit does not call them in a
+    // scene-based app. Their scene equivalents belong in SceneDelegate.
+    //
+    // application(_:open:options:), application(_:continue:restorationHandler:) and
+    // application(_:performActionFor:completionHandler:) have moved to SceneDelegate too,
+    // for the same reason. Push registration below is still app-level and stays here.
 
     func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
         Messaging.messaging().apnsToken = deviceToken

--- a/iznik-nuxt3/ios/App/App/Info.plist
+++ b/iznik-nuxt3/ios/App/App/Info.plist
@@ -103,7 +103,7 @@
 		</dict>
 	</dict>
 	<key>UILaunchStoryboardName</key>
-	<string>LaunchScreen.storyboard</string>
+	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
 	<string>Main</string>
 	<key>UIStatusBarHidden</key>

--- a/iznik-nuxt3/ios/App/App/Info.plist
+++ b/iznik-nuxt3/ios/App/App/Info.plist
@@ -83,16 +83,29 @@
 	<string>So you can send a photo of an item to offer</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>So you can save a photo of an item to offer</string>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen.storyboard</string>
 	<key>UIMainStoryboardFile</key>
 	<string>Main</string>
-	<key>UIRequiredDeviceCapabilities</key>
-	<array>
-		<string>armv7</string>
-	</array>
-	<key>UIRequiresFullScreen</key>
-	<true/>
 	<key>UIStatusBarHidden</key>
 	<false/>
 	<key>UISupportedInterfaceOrientations</key>

--- a/iznik-nuxt3/ios/App/App/SceneDelegate.swift
+++ b/iznik-nuxt3/ios/App/App/SceneDelegate.swift
@@ -1,0 +1,109 @@
+// Freegle: scene-based life cycle. Apple requires this from the iOS 27 SDK onwards -
+// an app built against that SDK with no scene manifest fails to launch. See TN3187.
+//
+// Once Info.plist declares UIApplicationSceneManifest, UIKit stops calling AppDelegate's
+// application(_:open:options:), application(_:continue:...) and
+// application(_:performActionFor:...), so the Google, Facebook, universal-link and
+// app-icon quick-action handling that used to live there now lives here.
+import UIKit
+import Capacitor
+import FBSDKCoreKit
+import GoogleSignIn
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+    // Set by UIKit from the scene manifest's UISceneStoryboardFile (Main), which is
+    // what builds the CAPBridgeViewController root.
+    var window: UIWindow?
+
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        // A cold launch delivers its URL, universal link or quick action through
+        // connectionOptions rather than the callbacks below, so every route has to be
+        // drained here too or launching from one silently does nothing.
+        for context in connectionOptions.urlContexts {
+            handleOpenURL(context)
+        }
+
+        for userActivity in connectionOptions.userActivities {
+            handleUserActivity(userActivity)
+        }
+
+        if let shortcutItem = connectionOptions.shortcutItem {
+            handleShortcut(shortcutItem)
+        }
+    }
+
+    func scene(_ scene: UIScene, openURLContexts urlContexts: Set<UIOpenURLContext>) {
+        for context in urlContexts {
+            handleOpenURL(context)
+        }
+    }
+
+    func scene(_ scene: UIScene, continue userActivity: NSUserActivity) {
+        handleUserActivity(userActivity)
+    }
+
+    func windowScene(_ windowScene: UIWindowScene, performActionFor shortcutItem: UIApplicationShortcutItem, completionHandler: @escaping (Bool) -> Void) {
+        completionHandler(handleShortcut(shortcutItem))
+    }
+
+    @discardableResult
+    private func handleOpenURL(_ context: UIOpenURLContext) -> Bool {
+        let url = context.url
+
+        if GIDSignIn.sharedInstance.handle(url) {
+            return true
+        }
+
+        if FBSDKCoreKit.ApplicationDelegate.shared.application( // capacitor-community/facebook-login
+            UIApplication.shared,
+            open: url,
+            sourceApplication: context.options.sourceApplication,
+            annotation: context.options.annotation
+        ) {
+            return true
+        }
+
+        var options: [UIApplication.OpenURLOptionsKey: Any] = [:]
+        if let sourceApplication = context.options.sourceApplication {
+            options[.sourceApplication] = sourceApplication
+        }
+        if let annotation = context.options.annotation {
+            options[.annotation] = annotation
+        }
+
+        return ApplicationDelegateProxy.shared.application(UIApplication.shared, open: url, options: options)
+    }
+
+    @discardableResult
+    private func handleUserActivity(_ userActivity: NSUserActivity) -> Bool {
+        // Universal Links. The proxy posts to Capacitor's listeners; nothing here
+        // needs the restoration handler.
+        return ApplicationDelegateProxy.shared.application(
+            UIApplication.shared,
+            continue: userActivity,
+            restorationHandler: { _ in }
+        )
+    }
+
+    // Long-press app-icon quick actions (UIApplicationShortcutItems in Info.plist).
+    // Map each shortcut to a https://www.ilovefreegle.org/<path> URL and route it
+    // through the same Capacitor pipeline as a deep link, so the appUrlOpen handler
+    // (stores/mobile.js) navigates to the target page.
+    @discardableResult
+    private func handleShortcut(_ shortcutItem: UIApplicationShortcutItem) -> Bool {
+        let path: String?
+        switch shortcutItem.type {
+        case "org.ilovefreegle.shortcut.give": path = "/give"
+        case "org.ilovefreegle.shortcut.find": path = "/find"
+        case "org.ilovefreegle.shortcut.chats": path = "/chats"
+        default: path = nil
+        }
+
+        guard let path = path, let url = URL(string: "https://www.ilovefreegle.org" + path) else {
+            return false
+        }
+
+        _ = ApplicationDelegateProxy.shared.application(UIApplication.shared, open: url, options: [:])
+        return true
+    }
+}


### PR DESCRIPTION
## Why

An app built against the **iOS 27 SDK** with no `UIApplicationSceneManifest` **fails to launch** - not a review rejection, a crash on start. Ours had none: `AppDelegate` still owned the window and the app-level life cycle. UIKit has been logging the migration warning since iOS 18.4.

CI already builds with Xcode 26.2.0, so we are past Apple's April 2026 SDK mandate and this lands well ahead of the next one. Capacitor has not fixed it upstream - Cap 8 requires Xcode 26 and lifts the deployment target, but does not adopt scenes ([ionic-team/ionic-framework#31016](https://github.com/ionic-team/ionic-framework/issues/31016)).

Freegle and ModTools share `ios/App/App.xcodeproj`, so this covers both apps.

## What

Declaring the manifest stops UIKit calling three `AppDelegate` methods. Each moves to `SceneDelegate` or it silently stops working:

| Was | Now | Breaks if missed |
|---|---|---|
| `application(_:open:options:)` | `scene(_:openURLContexts:)` | Google + Facebook login redirects, `freegleshare` scheme |
| `application(_:continue:restorationHandler:)` | `scene(_:continue:)` | Universal Links |
| `application(_:performActionFor:)` | `windowScene(_:performActionFor:)` | Give / Ask / Chats app-icon quick actions |

A cold launch delivers all three through the scene's `connectionOptions` rather than those callbacks, so `scene(_:willConnectTo:options:)` also drains `urlContexts`, `userActivities` and `shortcutItem`. Missing that is the standard way this migration goes wrong - the app opens but lands on the wrong page.

Also drops two keys that no longer do anything:

- `UIRequiresFullScreen` - ignored since iPadOS 26, so shipping builds already resize and multitask on iPad ([TN3192](https://developer.apple.com/documentation/technotes/tn3192-Migrating-your-app-from-the-deprecated-UIRequiresFullScreen-key)). `UISupportedInterfaceOrientations~ipad` already lists all four orientations.
- `UIRequiredDeviceCapabilities = armv7` - a Cordova-era leftover on an arm64-only target.

## A latent bug this surfaced

Dropping `UIRequiresFullScreen` opts the app into iPad multitasking, and Apple then enforces the launch-storyboard rule strictly at upload validation:

```
Validation failed (409) Invalid bundle. Because your app supports Multitasking on iPad,
you need to include the LaunchScreen.storyboard launch storyboard file in your
org.ilovefreegle.iphone bundle.
```

The storyboard was always in the bundle - it is in the Resources build phase and ships as `LaunchScreen.storyboardc`. `UILaunchStoryboardName` just named it `"LaunchScreen.storyboard"`, extension and all. UIKit tolerates that at runtime, which is why it has shipped for years unnoticed; the App Store validator does not, once multitasking is on. Second commit corrects it to the bare name Xcode's own template uses.

## Testing

Built green on CI via the `testflight-branch` workflow (pipeline #9672, job 28078) - **every step succeeded**, including `gym` archive, Apple's bundle validation and the TestFlight upload. The build is on TestFlight (internal only).

Getting there took three runs, each of which caught something real:

1. `ConnectionOptions.URLContexts` is `urlContexts` in the current SDK - compile error.
2. Compiled and archived clean; failed Apple's bundle validation (the launch-storyboard issue above).
3. Green.

CI cannot verify runtime behaviour, so on the TestFlight build please check:

- [ ] Log in with Google, Facebook and Apple
- [ ] Open a Universal Link (`https://www.ilovefreegle.org/...`) both cold and warm
- [ ] Long-press the app icon, use each of Give / Ask / Chats, cold and warm
- [ ] Push notification tap-through
- [ ] iPad Split View and Slide Over

Ref: [TN3187](https://developer.apple.com/documentation/technotes/tn3187-migrating-to-the-uikit-scene-based-life-cycle), [Apple upcoming SDK requirements](https://developer.apple.com/news/upcoming-requirements/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NNGtnuYoEzTsNMoqaLMbao

---

## Note: a third commit here is not mine and not iOS

`6ca58e056 fix(ci): self-heal build-and-test check killed by manual pipeline auto-cancel`
was pushed to this branch by monitor-fsm, which picked the PR up as a red-CI target.

It is a real fix for a real problem — triggering the manual `build_testflight` pipeline
for this branch made CircleCI's built-in "auto-cancel redundant workflows" setting kill
`freegle/build-and-test` on the sibling push pipeline (#9672 killed job 28075 in #9671),
leaving the required check stuck. That is a platform-level cancel our own trigger-type
guards in `.circleci/config.yml` cannot suppress, so it will recur for anyone who
triggers a manual pipeline near a push.

But it touches `.circleci/config.yml` only, is unrelated to the scene-life-cycle work,
and auto-re-triggers pipelines — which deserves review on its own merits rather than
riding along in an iOS PR. **Consider splitting it into its own PR before merging.**
