### PR TITLE
fix(monitor-fsm): survive a truncated instance store instead of dying at startup

### DIFF
--- a/monitor-fsm/src/__tests__/instance-store.test.ts
+++ b/monitor-fsm/src/__tests__/instance-store.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describeUnusableStore, ensureUsableInstanceStore } from '../instance-store.js'
+
+/**
+ * On 2026-07-19 iteration 3832 was killed mid-write and left
+ * instance-store.json at zero bytes. ai-flower's JSONFileStorage only guards
+ * against a MISSING file, so every later run died on JSON.parse('') before the
+ * brain ran — two silent days of a monitor that looked idle rather than broken.
+ */
+describe('describeUnusableStore', () => {
+  it('flags the empty file that an interrupted write leaves behind', () => {
+    expect(describeUnusableStore('')).toMatch(/empty/)
+    expect(describeUnusableStore('   \n')).toMatch(/empty/)
+  })
+
+  it('flags a half-written file', () => {
+    expect(describeUnusableStore('{"instances": {')).toMatch(/invalid JSON/)
+  })
+
+  it('flags valid JSON that is not a store', () => {
+    expect(describeUnusableStore('[]')).toMatch(/not an object/)
+    expect(describeUnusableStore('null')).toMatch(/not an object/)
+    expect(describeUnusableStore('{"workflows": {}}')).toMatch(/instances/)
+    expect(describeUnusableStore('{"instances": {}}')).toMatch(/workflows/)
+  })
+
+  it('accepts a healthy store, populated or not', () => {
+    expect(describeUnusableStore('{"instances": {}, "workflows": {}}')).toBeNull()
+    expect(
+      describeUnusableStore('{"instances": {"a": {"id": "a"}}, "workflows": {"w": {"id": "w"}}}')
+    ).toBeNull()
+  })
+})
+
+describe('ensureUsableInstanceStore', () => {
+  let dir: string
+  let file: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'fsm-store-'))
+    file = join(dir, 'instance-store.json')
+  })
+
+  afterEach(() => rmSync(dir, { recursive: true, force: true }))
+
+  it('leaves a missing file alone so ai-flower can start fresh', () => {
+    expect(ensureUsableInstanceStore(file).repaired).toBe(false)
+    expect(existsSync(file)).toBe(false)
+  })
+
+  it('leaves a healthy store untouched', () => {
+    const healthy = '{"instances": {"a": {"id": "a"}}, "workflows": {}}'
+    writeFileSync(file, healthy)
+
+    expect(ensureUsableInstanceStore(file).repaired).toBe(false)
+    expect(readFileSync(file, 'utf8')).toBe(healthy)
+  })
+
+  it('resets a zero-byte store and keeps the original for inspection', () => {
+    writeFileSync(file, '')
+
+    const result = ensureUsableInstanceStore(file, new Date('2026-07-21T18:29:04.000Z'))
+
+    expect(result.repaired).toBe(true)
+    expect(result.reason).toMatch(/empty/)
+    expect(JSON.parse(readFileSync(file, 'utf8'))).toEqual({ instances: {}, workflows: {} })
+    expect(existsSync(result.backupPath!)).toBe(true)
+    expect(readFileSync(result.backupPath!, 'utf8')).toBe('')
+  })
+
+  it('preserves the corrupt content in the backup', () => {
+    writeFileSync(file, '{"instances": {')
+
+    const result = ensureUsableInstanceStore(file)
+
+    expect(result.repaired).toBe(true)
+    expect(readFileSync(result.backupPath!, 'utf8')).toBe('{"instances": {')
+  })
+
+  it('produces a store that round-trips, so the next run starts clean', () => {
+    writeFileSync(file, '')
+    ensureUsableInstanceStore(file)
+
+    expect(ensureUsableInstanceStore(file).repaired).toBe(false)
+  })
+})

--- a/monitor-fsm/src/driver.ts
+++ b/monitor-fsm/src/driver.ts
@@ -56,6 +56,7 @@ import { ClaudeCodeAdapter } from 'ai-flower/adapters/claude-code'
 
 import { actions } from './actions/index.js'
 import { sanitizeLLMDecision } from './llm-json.js'
+import { ensureUsableInstanceStore } from './instance-store.js'
 import { partitionFailedChecks } from './coverage-checks.js'
 import { getDb, startIteration, endIteration } from './db/index.js'
 import { renderAllViews } from './db/views.js'
@@ -280,6 +281,13 @@ async function main() {
   const releaseLock = await acquireDriverLock()
 
   const definition = JSON.parse(await readFile(WORKFLOW_PATH, 'utf8')) as WorkflowDefinition
+
+  // An interrupted write leaves this file empty, which ai-flower cannot load.
+  // Reset rather than abort: monitor.db holds the durable history.
+  const repair = ensureUsableInstanceStore(INSTANCE_STORE)
+  if (repair.repaired) {
+    out(`⚠ instance store unusable (${repair.reason}) — reset it; previous file kept at ${repair.backupPath}`)
+  }
 
   const storage = new JSONFileStorage(INSTANCE_STORE)
   await storage.saveWorkflow(definition)

--- a/monitor-fsm/src/instance-store.ts
+++ b/monitor-fsm/src/instance-store.ts
@@ -1,0 +1,69 @@
+import { existsSync, readFileSync, writeFileSync, renameSync } from 'node:fs'
+
+/**
+ * ai-flower's JSONFileStorage handles a MISSING store file (fresh start) but not
+ * an empty or corrupt one: existsSync passes, then JSON.parse('') throws
+ * "Unexpected end of JSON input" and the whole iteration dies before the brain
+ * is ever consulted. Its persist() is a plain writeFile, so a crash or kill
+ * mid-write truncates the file to zero bytes.
+ *
+ * That combination cost two silent days on 2026-07-19: iteration 3832 died
+ * mid-write, and every run afterwards aborted at startup. The FSM logged a
+ * one-line fatal and exited 0, so nothing looked alarming from outside.
+ *
+ * The store is disposable - monitor.db holds the durable history, this file
+ * only holds in-flight ai-flower instances - so resetting it is cheap and far
+ * better than refusing to start. Keep the old file so a corrupt one can still
+ * be examined.
+ */
+
+export interface StoreRepair {
+  repaired: boolean
+  reason?: string
+  backupPath?: string
+}
+
+const EMPTY_STORE = { instances: {}, workflows: {} }
+
+/** Describes why a store file is unusable, or null if it is fine. */
+export function describeUnusableStore(raw: string): string | null {
+  if (raw.trim() === '') return 'file is empty (truncated by an interrupted write)'
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch (err) {
+    return `invalid JSON: ${(err as Error).message}`
+  }
+
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return 'top level is not an object'
+  }
+
+  const store = parsed as Record<string, unknown>
+  if (typeof store.instances !== 'object' || store.instances === null) {
+    return 'missing "instances" object'
+  }
+  if (typeof store.workflows !== 'object' || store.workflows === null) {
+    return 'missing "workflows" object'
+  }
+
+  return null
+}
+
+/**
+ * Reset the instance store if it cannot be loaded. Returns what was done so the
+ * caller can log it loudly - a silent reset would hide a recurring crash.
+ */
+export function ensureUsableInstanceStore(filePath: string, now: Date = new Date()): StoreRepair {
+  if (!existsSync(filePath)) return { repaired: false }
+
+  const reason = describeUnusableStore(readFileSync(filePath, 'utf8'))
+  if (!reason) return { repaired: false }
+
+  const backupPath = `${filePath}.corrupt-${now.toISOString().replace(/[:.]/g, '-')}`
+  renameSync(filePath, backupPath)
+  writeFileSync(filePath, `${JSON.stringify(EMPTY_STORE, null, 2)}\n`, 'utf8')
+
+  return { repaired: true, reason, backupPath }
+}


### PR DESCRIPTION
## The monitor was dead for two days and looked idle

`instance-store.json` was left at zero bytes when iteration 3832 was killed mid-write on 2026-07-19. Every run afterwards aborted before the brain was ever consulted:

```
18:29:04 ⚠ fatal: SyntaxError: Unexpected end of JSON input
```

`fsm-status` showed iterations with `prs_created 0`, which reads as *"nothing to fix"* rather than *"cannot start"* — and the driver **exits 0** on this path, so nothing downstream flagged it either.

## Root cause

ai-flower's `JSONFileStorage.load()` guards against a **missing** store file but not an **empty or corrupt** one:

```ts
if (!existsSync(this.filePath)) { /* fresh store */ }
const raw = await readFile(this.filePath, 'utf-8')
this.cache = JSON.parse(raw)   // <- throws on ''
```

And `persist()` is a plain `writeFile`, so any crash or kill mid-write truncates the file to zero bytes. One interrupted write poisons every subsequent run, permanently.

## Fix

A preflight that resets an unusable store and logs it loudly, keeping the old file as `<path>.corrupt-<timestamp>` so a recurring crash is still diagnosable.

Resetting is the right call here: the store is disposable. `monitor.db` holds the durable history (iterations, PRs, Sentry dispositions); this file only carries in-flight ai-flower instances. Refusing to start costs far more than dropping them.

**This makes truncation self-healing, not impossible.** The non-atomic write is the deeper bug and lives in the dependency (`github:Freegle/ai-flower`) — it wants a write-temp-then-rename fix there. Patching `node_modules` would evaporate on the next install, so this guard sits in our own code where it survives.

## Testing

`npx tsc --noEmit` clean. Full monitor-fsm suite **286 passing** (9 new).

New tests cover the zero-byte file, a half-written file, valid-JSON-that-isn't-a-store, both healthy cases, and that a reset store round-trips so the next run starts clean.

Verified end to end: after restoring the store by hand, the FSM completed a full 11-step iteration (`status=completed state=END`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NNGtnuYoEzTsNMoqaLMbao