### PR TITLE
fix(ModTools): pending hold/release badge counts stale until manual refresh

### DIFF
--- a/iznik-nuxt3/composables/useMe.js
+++ b/iznik-nuxt3/composables/useMe.js
@@ -26,6 +26,13 @@ export async function fetchMe(hitServer) {
   // Because multiple pages/components may call fetchMe to ensure that they have data they need, we
   // want to minimise the number of calls.  We have some fairly complex logic below to keep the number of parallel
   // calls down and return earlier if we happen to already be fetching what we need.
+  //
+  // hitServer = true is a guarantee of freshness (see above), so it must never settle for an
+  // already-in-flight fetch on its own: that fetch may have been sent before whatever change the
+  // caller is waiting to see (e.g. a moderator's own hold/release) reached the server, in which case
+  // its response is stale. Wait for it to keep request ordering sane, then always issue a fresh one.
+  // Discourse #9951: ModTools pending-message hold/release badge counts only updated after a manual
+  // page refresh, because checkWork()'s fetchMe(true) silently reused a stale in-flight fetch.
 
   let needToFetch = false
 
@@ -39,14 +46,14 @@ export async function fetchMe(hitServer) {
     // We always need to fetch to do the background update.
     needToFetch = true
   } else {
-    // We have been asked to hit the server.
-    // eslint-disable-next-line no-lonely-if
+    // We have been asked to hit the server and guarantee up-to-date data.
     if (fetchingPromise) {
-      // We are in the process of fetching the user, so we need to wait until that completes.
+      // Wait for the in-progress fetch first so we don't fire two requests at once...
       await fetchingPromise
-    } else {
-      needToFetch = true
     }
+    // ...but always follow up with our own fetch: the one we waited for may predate whatever
+    // change this caller needs reflected.
+    needToFetch = true
   }
 
   if (needToFetch) {

--- a/iznik-nuxt3/tests/unit/composables/useMe.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useMe.spec.js
@@ -624,7 +624,17 @@ describe('fetchMe', () => {
     expect(mockFetchUser).toHaveBeenCalledTimes(1)
   })
 
-  it('does not double-fetch when hitServer=true and already fetching', async () => {
+  it('fetches again when hitServer=true arrives while an earlier fetch is still in flight (Discourse #9951)', async () => {
+    // Regression test for the ModTools pending-message hold/release badge not
+    // updating live (Discourse topic 9951): checkWork() calls fetchMe(true)
+    // expecting a guaranteed up-to-date result (its own doc comment says "we
+    // really care about the data being tightly in sync"). A moderator can
+    // trigger a second hitServer=true call (e.g. holding a second message)
+    // while an earlier one — started BEFORE that hold committed — is still
+    // in flight. If the second call just piggybacks on the first one's
+    // promise instead of making its own request, it silently returns data
+    // from before the mutation, and the badge only corrects itself on a full
+    // page reload (which has no in-flight promise to collide with).
     let resolveFirst
     const firstFetch = new Promise((resolve) => {
       resolveFirst = resolve
@@ -633,13 +643,15 @@ describe('fetchMe', () => {
     mockFetchUser.mockReturnValueOnce(firstFetch)
     // Start a concurrent hitServer=true call
     const p1 = fetchMe(true)
-    // Before p1 resolves, a second hitServer=true comes in — it should wait
-    // for p1, not start a new fetch
+    // Before p1 resolves, a second hitServer=true comes in wanting fresh data
+    // — it must trigger its own server round trip, not just wait for p1's.
+    mockFetchUser.mockResolvedValueOnce({ id: 1 })
     const p2 = fetchMe(true)
     resolveFirst({ id: 1 })
     await Promise.all([p1, p2])
-    // fetchUser should only have been called once (by p1)
-    expect(mockFetchUser).toHaveBeenCalledTimes(1)
+    // fetchUser must have been called twice: once for each hitServer=true
+    // caller that explicitly asked for guaranteed-fresh data.
+    expect(mockFetchUser).toHaveBeenCalledTimes(2)
   })
 
   it('returns immediately when hitServer=false and user already loaded', async () => {


### PR DESCRIPTION
## Root Cause
ModTools' hold/release actions call `checkWork()` → `fetchMe(true)` to refresh the pending/held (red/blue) badge counts in the left-hand menu. `fetchMe(hitServer=true)` is documented as a freshness guarantee ("we really care about the data being tightly in sync"), but when another fetch (the 30s background poll, or an earlier hold's own `checkWork()`) was already in flight, the function just awaited that pre-existing promise instead of issuing its own request. That in-flight fetch could have been sent to the server *before* the hold/release committed, so its response is stale — the badge silently keeps the pre-mutation counts. A manual page reload has no in-flight promise to collide with, which is why it always "fixed" the badge, matching the report exactly (topic 9951 post 1: no blue counter after Hold, no red counter after Release, correct only after a refresh).

`iznik-server-go/group/groupWork.go` / `session/session.go` (Galera, synchronous) rule out DB replication lag — this is purely a frontend request-coalescing bug in `iznik-nuxt3/composables/useMe.js`.

## Evidence
Failing test (before fix), `tests/unit/composables/useMe.spec.js`:
```
× fetchMe > fetches again when hitServer=true arrives while an earlier fetch is still in flight (Discourse #9951)
  → expected "spy" to be called 2 times, but got 1 times
```
This is the inverse of a pre-existing test that had explicitly codified the buggy dedup-instead-of-refetch behaviour as intentional.

## Fix
`composables/useMe.js` `fetchMe()`: for `hitServer=true`, still wait for any in-flight fetch first (avoids firing two requests at once), but always follow up with its own `authStore.fetchUser()` call afterwards, guaranteeing the response reflects state as of *this* call rather than whichever earlier fetch happened to be in flight.

## Other Call Sites
`fetchMe(true)` is the shared session-fetch helper, used by (all now correctly get freshness guarantees):
- `modtools/composables/useModMe.js` (`checkWork` — this bug)
- `modtools/stores/spammer.js` (5 call sites — spam review counts)
- `composables/useNavbar.js`, `composables/useReplyStateMachine.js`, `composables/useBootSession.js`
- `components/settings/ProfileSection.vue`, `components/NewsAboutMe.vue`, `components/MicroVolunteering.vue`
- `pages/settings/index.vue`, `pages/browse/[[term]].vue`, `pages/microvolunteering/index.client.vue`
- `modtools/components/ModSettingsGroup.vue`, `modtools/pages/members/feedback.vue`

No other code changes needed — fixing the shared helper at its source addresses all of these.

## Test
- File: `iznik-nuxt3/tests/unit/composables/useMe.spec.js` (`fetchMe` describe block)
- Command: status API `POST /api/tests/vitest {"filter":"useMe.spec.js"}`
- Proves fail-before (1 fetchUser call, expected 2) / pass-after (2 calls) — confirmed via targeted run. Also re-ran `useModMe.spec.js` (37✓), `useBootSession.spec.js` (6✓), `ModMessageButton.spec.js` (101✓) against the fix with no regressions.

## Discourse
https://discourse.ilovefreegle.org/t/9951/1