### PR TITLE
fix(mobile app notification badge): sync native icon badge from live unread state

### DIFF
--- a/iznik-nuxt3/stores/mobile.js
+++ b/iznik-nuxt3/stores/mobile.js
@@ -122,6 +122,34 @@ export const useMobileStore = defineStore({
       await this.initPushNotifications(PushNotifications, Badge)
       await this.checkForAppUpdate()
       this.initWakeUpActions(App)
+      this.startBadgeSync()
+    },
+
+    // Keep the native app-icon badge in sync with the member's own live
+    // unread state (chats + notifications), independent of which component
+    // happens to be on screen. useNavbar()'s chatCount computed also nudges
+    // the badge, but only as a side effect of NavbarMobile's bottom-nav badge
+    // being rendered - and that badge is hidden in favour of ChatMobileNavbar
+    // while viewing a specific chat on a phone (NavbarMobile.vue
+    // isSpecificChatPage), which is exactly when a chat gets marked read.
+    // ChatMobileNavbar calls useNavbar() too but never reads its chatCount,
+    // so that recompute (and its setBadgeCount call) never fires there. If
+    // the member reads the chat and backgrounds the app before visiting a
+    // screen where the bottom-nav badge re-renders, the icon badge is left
+    // showing a stale non-zero count forever (Discourse 9953). This watch
+    // lives in the store instead, so it fires on every count change
+    // regardless of what's mounted.
+    startBadgeSync() {
+      if (!this.isApp) return
+      const chatStore = useChatStore()
+      const notificationStore = useNotificationStore()
+      return watch(
+        () => (chatStore.unreadCount || 0) + (notificationStore.count || 0),
+        (total) => {
+          this.setBadgeCount(total)
+        },
+        { immediate: true }
+      )
     },
 
     async getDeviceInfo(Device) {
@@ -352,7 +380,10 @@ export const useMobileStore = defineStore({
           .filter(Boolean)
         if (!paths.length) return
         this.pendingSharedImages = paths.map((p) => Capacitor.convertFileSrc(p))
-        console.log('Shared images received (iOS)', this.pendingSharedImages.length)
+        console.log(
+          'Shared images received (iOS)',
+          this.pendingSharedImages.length
+        )
         const router = useRouter()
         router.push('/give/mobile/photos')
       } catch (e) {

--- a/iznik-nuxt3/tests/unit/stores/mobile.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/mobile.spec.js
@@ -1,5 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
+import { reactive, nextTick } from 'vue'
 
 let mockPlatform = 'web'
 vi.mock('@capacitor/core', () => ({
@@ -45,16 +46,26 @@ vi.mock('~/stores/auth', () => ({
 
 const mockFetchChats = vi.fn()
 const mockFetchMessages = vi.fn()
+// Reactive so startBadgeSync's watch() (a real Vue watch) reacts to changes,
+// exactly as it does against the real Pinia chat/notification stores.
+const mockChatState = reactive({ unreadCount: 0 })
 vi.mock('~/stores/chat', () => ({
   useChatStore: () => ({
     fetchChats: mockFetchChats,
     fetchMessages: mockFetchMessages,
+    get unreadCount() {
+      return mockChatState.unreadCount
+    },
   }),
 }))
 
+const mockNotificationState = reactive({ count: 0 })
 vi.mock('~/stores/notification', () => ({
   useNotificationStore: () => ({
     fetchCount: vi.fn(),
+    get count() {
+      return mockNotificationState.count
+    },
   }),
 }))
 
@@ -86,6 +97,8 @@ describe('mobile store', () => {
     mockPlatform = 'web'
     mockAuthUser = null
     mockMobileVersion = '1.0.0'
+    mockChatState.unreadCount = 0
+    mockNotificationState.count = 0
     setActivePinia(createPinia())
     const mod = await import('~/stores/mobile')
     useMobileStore = mod.useMobileStore
@@ -173,17 +186,13 @@ describe('mobile store', () => {
 
     it('returns false when no query string', () => {
       const store = useMobileStore()
-      const result = store.extractQueryStringParams(
-        'https://example.com/path'
-      )
+      const result = store.extractQueryStringParams('https://example.com/path')
       expect(result).toBe(false)
     })
 
     it('handles empty query string', () => {
       const store = useMobileStore()
-      const result = store.extractQueryStringParams(
-        'https://example.com?'
-      )
+      const result = store.extractQueryStringParams('https://example.com?')
       expect(result).toEqual({})
     })
 
@@ -282,6 +291,109 @@ describe('mobile store', () => {
     })
   })
 
+  describe('startBadgeSync', () => {
+    // Discourse 9953: the native app-icon badge was only ever set from an
+    // incoming push payload (or forced to 0 at startup) - reading a chat or
+    // notification *within* the app never told the OS to clear a
+    // previously-set badge, so it could get stuck showing a stale count
+    // forever even with nothing unread.
+    let badgeSetSpy
+    let stopWatch
+
+    beforeEach(() => {
+      badgeSetSpy = vi.fn()
+      stopWatch = null
+      vi.doMock('@capawesome/capacitor-badge', () => ({
+        Badge: { set: badgeSetSpy },
+      }))
+    })
+
+    afterEach(() => {
+      // The watch() set up by startBadgeSync() has no component lifecycle to
+      // auto-stop it — without this it keeps firing against the shared
+      // mockChatState/mockNotificationState in later tests.
+      if (stopWatch) stopWatch()
+    })
+
+    it('does nothing when not on the app', async () => {
+      const store = useMobileStore()
+      store.isApp = false
+      mockChatState.unreadCount = 2
+      mockNotificationState.count = 1
+
+      stopWatch = store.startBadgeSync()
+      await nextTick()
+
+      expect(badgeSetSpy).not.toHaveBeenCalled()
+    })
+
+    it('immediately applies the current live chat+notification total to the native badge', async () => {
+      const store = useMobileStore()
+      store.isApp = true
+      mockChatState.unreadCount = 2
+      mockNotificationState.count = 1
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+      stopWatch = store.startBadgeSync()
+
+      // AssertFlip: before the fix, nothing ever calls setBadgeCount() from
+      // live store state - only from a push payload - so this never fires
+      // and the badge is left however a past push last set it.
+      await vi.waitFor(() =>
+        expect(badgeSetSpy).toHaveBeenCalledWith({ count: 3 })
+      )
+      logSpy.mockRestore()
+    })
+
+    it('clears a stale non-zero badge once everything has been read in-app, with no new push', async () => {
+      const store = useMobileStore()
+      store.isApp = true
+      // A past push left the device badge on a real, non-zero count.
+      store.lastBadgeCount = 3
+      // The member has since read everything in-app - no unread chats or
+      // notifications remain - but no push arrives to say so.
+      mockChatState.unreadCount = 0
+      mockNotificationState.count = 0
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+      stopWatch = store.startBadgeSync()
+
+      await vi.waitFor(() =>
+        expect(badgeSetSpy).toHaveBeenCalledWith({ count: 0 })
+      )
+      expect(store.lastBadgeCount).toBe(0)
+      logSpy.mockRestore()
+    })
+
+    it('reacts live as the underlying chat/notification counts change', async () => {
+      const store = useMobileStore()
+      store.isApp = true
+      mockChatState.unreadCount = 0
+      mockNotificationState.count = 0
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+      stopWatch = store.startBadgeSync()
+      await vi.waitFor(() =>
+        expect(badgeSetSpy).toHaveBeenCalledWith({ count: 0 })
+      )
+
+      badgeSetSpy.mockClear()
+      mockChatState.unreadCount = 1
+      await nextTick()
+      await vi.waitFor(() =>
+        expect(badgeSetSpy).toHaveBeenCalledWith({ count: 1 })
+      )
+
+      badgeSetSpy.mockClear()
+      mockChatState.unreadCount = 0
+      await nextTick()
+      await vi.waitFor(() =>
+        expect(badgeSetSpy).toHaveBeenCalledWith({ count: 0 })
+      )
+      logSpy.mockRestore()
+    })
+  })
+
   describe('handleNotification', () => {
     let store
 
@@ -311,11 +423,7 @@ describe('mobile store', () => {
 
     it('ignores legacy notifications without channel_id', async () => {
       const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-      await store.handleNotification(
-        { data: { route: '/chats/1' } },
-        {},
-        {}
-      )
+      await store.handleNotification({ data: { route: '/chats/1' } }, {}, {})
       expect(store.route).toBe(false)
       logSpy.mockRestore()
     })
@@ -372,10 +480,7 @@ describe('mobile store', () => {
       const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
       mockChatSend.mockResolvedValue({})
 
-      await store.handleReplyAction(
-        { data: { chatids: '42' } },
-        'Hello!'
-      )
+      await store.handleReplyAction({ data: { chatids: '42' } }, 'Hello!')
 
       expect(mockChatSend).toHaveBeenCalledWith({
         roomid: 42,


### PR DESCRIPTION
## Root Cause
The native app-icon badge (`mobileStore.setBadgeCount`) was only ever updated from an incoming push payload, or force-reset to 0 at startup. There is a client-side reactive sync too — `useNavbar.js`'s `chatCount` computed calls `setBadgeCount()` as a side effect — but it only fires when `NavbarMobile`'s bottom-nav badge is actually being rendered. On a phone, while viewing a specific chat (`/chats/:id` at xs/sm breakpoints), `NavbarMobile` hides that badge in favour of `ChatMobileNavbar` (`isSpecificChatPage`), which is exactly when a chat gets marked as read. `ChatMobileNavbar` calls `useNavbar()` too, but only destructures `{ online, backButtonCount, backButton }` — its own copy of `chatCount` is never read, so its `setBadgeCount` side effect never fires there.

If a member reads a chat and backgrounds/closes the app before visiting a screen where the bottom-nav badge re-renders, the OS icon badge is left showing whatever stale non-zero count a past push last set — exactly the reported symptom: a permanent notification blob with no actual unread replies.

## Evidence
`tests/unit/stores/mobile.spec.js` — `startBadgeSync` (AssertFlip, confirmed fails on pre-fix code with `store.startBadgeSync is not a function`, 4/60 tests failing; passes after fix, 60/60):
```
✓ mobile store > startBadgeSync > does nothing when not on the app
✓ mobile store > startBadgeSync > immediately applies the current live chat+notification total to the native badge
✓ mobile store > startBadgeSync > clears a stale non-zero badge once everything has been read in-app, with no new push
✓ mobile store > startBadgeSync > reacts live as the underlying chat/notification counts change

 Test Files  1 passed (1)
      Tests  60 passed (60)
```

## Fix
Added `mobileStore.startBadgeSync()` — a store-level `watch()` on `chatStore.unreadCount + notificationStore.count` that calls `setBadgeCount()` on every change, independent of which navbar component happens to be mounted. Called once from `initApp()` alongside the other app-startup wiring, so it fires immediately on load and then on every subsequent count change for the lifetime of the app session — including while the user is on the specific-chat page where the old component-coupled sync was blind.

## Other Call Sites
`grep -rn "setBadgeCount" iznik-nuxt3` — other call sites (`useNavbar.js`, `modtools/layouts/default.vue`, `modtools/composables/useModMe.js`) are the pre-existing component-coupled syncs; left as-is since they're harmless (idempotent, guarded by `lastBadgeCount` in `setBadgeCount`) and this fix supersedes them with an always-on path. No other code computes/sends the native badge count.

## Test
File: `iznik-nuxt3/tests/unit/stores/mobile.spec.js` (`startBadgeSync` describe block)
Command: `npx vitest run tests/unit/stores/mobile.spec.js`
Proves fail-before (`startBadgeSync is not a function`) / pass-after (60/60, badge synced from live counts including the stale-clear case).

## Discourse
https://discourse.ilovefreegle.org/t/9953/1