### PR TITLE
fix(monitor): contentcheck backlog check must skip held posts

### DIFF
--- a/iznik-batch/app/Monitoring/ScheduledOutcomeRegistry.php
+++ b/iznik-batch/app/Monitoring/ScheduledOutcomeRegistry.php
@@ -83,9 +83,10 @@ class ScheduledOutcomeRegistry
             // posts and always stamps contentcheck_checked_at. A Pending,
             // un-checked, undeleted post whose message+user are live (mirrors
             // the worker's exact join) that has sat past $backlogMin = a stalled
-            // moderation pipeline. The joins exclude rows the worker skips
-            // permanently (deleted message / null fromuser) so they don't
-            // false-alarm.
+            // moderation pipeline. The predicates exclude rows the worker skips
+            // (deleted message / null fromuser / held-by-a-mod) so they don't
+            // false-alarm: a held post is deliberately pulled back for review and
+            // is never checked until a mod releases it, so it can sit indefinitely.
             (new BacklogCheck(
                 'messages:contentcheck',
                 'messages_groups as mg',
@@ -97,6 +98,7 @@ class ScheduledOutcomeRegistry
                     ->where('mg.collection', MessageGroup::COLLECTION_PENDING)
                     ->whereNull('mg.contentcheck_checked_at')
                     ->where('mg.deleted', 0)
+                    ->whereNull('mg.heldby')
                     ->whereNull('m.deleted')
                     ->whereNotNull('m.fromuser')
                     ->whereNull('u.deleted'),

--- a/iznik-batch/tests/Feature/Monitor/ScheduledOutcomeRegistryTest.php
+++ b/iznik-batch/tests/Feature/Monitor/ScheduledOutcomeRegistryTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Monitor;
 use App\Monitoring\OutcomeCheck;
 use App\Monitoring\OutcomeResult;
 use App\Monitoring\ScheduledOutcomeRegistry;
+use App\Models\MessageGroup;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
@@ -155,5 +156,59 @@ class ScheduledOutcomeRegistryTest extends TestCase
 
         // No rows in jobs -> breach ("no rows"), proving the seenat query ran.
         $this->assertTrue($result->isBreach(), $result->message);
+    }
+
+    /**
+     * The contentcheck worker deliberately skips held-by-a-mod rows
+     * (->whereNull('mg.heldby')): a held post is pulled back for review and is
+     * never auto-checked until the mod releases it, so it can sit indefinitely
+     * without ever getting contentcheck_checked_at stamped. The backlog check
+     * must mirror that skip, otherwise every held post false-alarms as a stalled
+     * moderation pipeline. A non-held stale post, by contrast, must still breach.
+     */
+    public function test_contentcheck_check_ignores_held_pending_but_flags_unheld(): void
+    {
+        Carbon::setTestNow(Carbon::create(2026, 6, 12, 14, 0, 0));
+
+        $group = $this->createTestGroup();
+        $user  = $this->createTestUser();
+
+        $seedStalePending = function (?int $heldby) use ($group, $user): void {
+            $msgid = DB::table('messages')->insertGetId([
+                'fromuser' => $user->id,
+                'type'     => 'Offer',
+                'subject'  => 'OFFER: Stale post',
+                'textbody' => 'A stale post. Collection only.',
+                'message'  => 'A stale post. Collection only.',
+                'arrival'  => Carbon::now()->subHour(),
+                'date'     => Carbon::now()->subHour(),
+                'source'   => 'Platform',
+            ]);
+            DB::table('messages_groups')->insert([
+                'msgid'                   => $msgid,
+                'groupid'                 => $group->id,
+                'collection'              => MessageGroup::COLLECTION_PENDING,
+                'arrival'                 => Carbon::now()->subHour(),
+                'deleted'                 => 0,
+                'heldby'                  => $heldby,
+                'contentcheck_checked_at' => null,
+            ]);
+        };
+
+        $check = $this->check('messages:contentcheck');
+
+        // Only a held stale post exists -> the worker skips it, so no breach.
+        $seedStalePending($user->id);
+        $this->assertTrue(
+            $check->evaluate(Carbon::now())->isOk(),
+            'A held Pending post must not count as a contentcheck backlog'
+        );
+
+        // Add an unheld stale post -> worker would have checked it, so breach.
+        $seedStalePending(null);
+        $this->assertTrue(
+            $check->evaluate(Carbon::now())->isBreach(),
+            'An unheld stale Pending post must breach the contentcheck backlog'
+        );
     }
 }


### PR DESCRIPTION
## Problem

The `monitor:scheduled-outcomes` monitor fired a false breach:

```
[breach] messages:contentcheck — messages_groups as mg: 2 pending row(s) older than 15 min (threshold 0) — worker stuck?
```

The two flagged rows (msgs 121080107, 121108187) are both **held by a moderator** (`heldby` set). The `messages:contentcheck` worker deliberately skips held rows (`->whereNull('mg.heldby')` in `ContentCheckService::processUnprocessed`) — a held post is pulled back for review and is never auto-checked until a mod releases it, so it can sit indefinitely without ever getting `contentcheck_checked_at` stamped.

The scheduled-outcome `BacklogCheck` omitted that predicate, so **every held post false-alarms as a stalled moderation pipeline**. The comment above the check even claimed the predicates exclude rows the worker skips — but `heldby` was never added.

## Fix

Add `->whereNull('mg.heldby')` to the check so it mirrors the worker's exact join, plus a regression test asserting a held stale Pending post does not breach while an unheld one does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)