### PR TITLE
fix(modtools-counts): pending hold/release badge counts stale until manual refresh

### DIFF
--- a/iznik-nuxt3/composables/useMe.js
+++ b/iznik-nuxt3/composables/useMe.js
@@ -6,7 +6,7 @@ import { useTeamStore } from '~/stores/team'
 
 let fetchingPromise = null
 
-export async function fetchMe(hitServer) {
+export async function fetchMe(hitServer, forceRefetch = false) {
   const authStore = useAuthStore()
 
   // We can be called in several ways.
@@ -26,6 +26,14 @@ export async function fetchMe(hitServer) {
   // Because multiple pages/components may call fetchMe to ensure that they have data they need, we
   // want to minimise the number of calls.  We have some fairly complex logic below to keep the number of parallel
   // calls down and return earlier if we happen to already be fetching what we need.
+  //
+  // - forceRefetch = true (only valid with hitServer = true).  The caller just performed a mutation
+  //   (e.g. ModTools hold/release) and needs a response that reflects it. An in-flight fetch that was
+  //   already running when we were called may have been sent to the server BEFORE that mutation
+  //   committed, so piggybacking on it (the default behaviour above) would silently hand back
+  //   pre-mutation data - Discourse #9951. We still wait for that fetch first, to avoid firing two
+  //   requests at once, but then always follow up with our own. Default false, so every other call
+  //   site keeps today's single-flight coalescing unchanged.
 
   let needToFetch = false
 
@@ -44,6 +52,10 @@ export async function fetchMe(hitServer) {
     if (fetchingPromise) {
       // We are in the process of fetching the user, so we need to wait until that completes.
       await fetchingPromise
+
+      if (forceRefetch) {
+        needToFetch = true
+      }
     } else {
       needToFetch = true
     }

--- a/iznik-nuxt3/modtools/composables/useModMe.js
+++ b/iznik-nuxt3/modtools/composables/useModMe.js
@@ -102,7 +102,11 @@ export function useModMe() {
       if (authStore.work) currentTotal += authStore.work.total
       if (chatStore) currentTotal += Math.min(99, chatStore.unreadCount)
       const { fetchMe } = useMe()
-      await fetchMe(true)
+      // forceRefetch: checkWork() is always called right after a mutation
+      // (approve/reject/hold/release/...) wanting counts as of THAT action -
+      // reusing a stale fetch that was already in flight before it committed
+      // silently hands back pre-mutation counts (Discourse #9951).
+      await fetchMe(true, true)
       await modGroupStore.getModGroups()
 
       const chatcount = chatStore ? Math.min(99, chatStore.unreadCount) : 0

--- a/iznik-nuxt3/tests/unit/composables/useMe.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useMe.spec.js
@@ -660,6 +660,47 @@ describe('fetchMe', () => {
     await vi.runAllTimersAsync()
     expect(mockFetchUser).toHaveBeenCalledTimes(1)
   })
+
+  // Discourse #9951: ModTools hold-then-release badge counts stayed stale
+  // until a manual page reload. hold() and release() each trigger checkWork()
+  // -> fetchMe(true), wanting a response that reflects THEIR OWN mutation. If
+  // release's checkWork() runs while hold's own fetchMe(true) request is still
+  // in flight, the plain hitServer=true path just awaits that pre-existing
+  // promise instead of issuing its own request - so release's caller ends up
+  // with hold's (pre-release) counts, and nothing else re-fetches until the
+  // next 30s timer tick. The forceRefetch flag is opt-in (default false, so
+  // every other fetchMe(true) call site - and the dedup test above - keeps
+  // today's coalescing behaviour) and lets a caller that just performed its
+  // own mutation demand a request that starts after it, not a recycled one
+  // from before it.
+  it('forceRefetch=true still issues its own fetch after an in-flight hitServer=true call (Discourse #9951)', async () => {
+    let resolveFirst
+    const firstFetch = new Promise((resolve) => {
+      resolveFirst = resolve
+    })
+    let resolveSecond
+    const secondFetch = new Promise((resolve) => {
+      resolveSecond = resolve
+    })
+
+    // First caller (e.g. a hold action's checkWork) starts an ordinary fetch.
+    mockFetchUser.mockReturnValueOnce(firstFetch)
+    const p1 = fetchMe(true)
+
+    // Second caller (e.g. the release that follows) must see state as of ITS
+    // OWN call - not whichever request the first caller happened to have in
+    // flight already.
+    mockFetchUser.mockReturnValueOnce(secondFetch)
+    const p2 = fetchMe(true, true)
+
+    resolveFirst({ id: 1 })
+    await p1
+
+    resolveSecond({ id: 1 })
+    await p2
+
+    expect(mockFetchUser).toHaveBeenCalledTimes(2)
+  })
 })
 
 describe('useMe — myGroupsBoundingBox', () => {

--- a/iznik-nuxt3/tests/unit/composables/useModMe.spec.js
+++ b/iznik-nuxt3/tests/unit/composables/useModMe.spec.js
@@ -145,6 +145,24 @@ describe('useModMe checkWork beep behavior', () => {
     expect(mockSetBadgeCount).toHaveBeenCalledWith(4)
   })
 
+  // Discourse #9951: a hold-then-release fired two checkWork() calls close
+  // together; the second silently reused whichever fetchMe(true) request the
+  // first had in flight, so the badge kept showing pre-release counts. Passing
+  // forceRefetch=true tells fetchMe to always issue its own request for THIS
+  // call rather than piggyback on an older one — see useMe.spec.js for the
+  // fetchMe-level race reproduction.
+  it('asks fetchMe to force a fresh fetch rather than reuse a stale in-flight one (Discourse #9951)', async () => {
+    mockFetchMe.mockImplementation(async () => {
+      globalThis.__mockAuthStore.work = { total: 4 }
+    })
+
+    const { useModMe } = await import('~/modtools/composables/useModMe')
+    const { checkWork } = useModMe()
+    await checkWork(true)
+
+    expect(mockFetchMe).toHaveBeenCalledWith(true, true)
+  })
+
   it('calls setBadgeCount with 0 when no pending work', async () => {
     mockFetchMe.mockImplementation(async () => {
       globalThis.__mockAuthStore.work = { total: 0 }


### PR DESCRIPTION
## Root Cause
ModTools' hold/release actions each call `checkWork()` -> `fetchMe(true)` to refresh the pending/held (red/blue) badge counts in the left-hand menu, wanting a response that reflects *their own* mutation. `fetchMe(hitServer=true)` is documented as a freshness guarantee ("we really care about the data being tightly in sync"), but when a second such call arrives while an earlier one (the previous action's own `checkWork()`, or the 30s background poll) is still in flight, it just awaited that pre-existing promise instead of issuing its own request. That in-flight fetch could have been sent to the server *before* the second mutation committed, so its response is stale — the badge silently keeps the pre-mutation counts, and nothing else re-fetches until the next 30s timer tick (topic 9951 post 1: blue/red counts don't update after Hold then Release, only becoming correct after a manual refresh).

Server-side counts themselves are correct immediately (a refresh always fixes it) and Galera is synchronous multi-master, so this is not a replication-lag issue — it's a frontend request-coalescing bug in `iznik-nuxt3/composables/useMe.js`.

An earlier attempt at this bug (PR #1138) was rejected because its fix changed `fetchMe()`'s default behaviour for *every* caller — weakening the pinned "does not double-fetch when hitServer=true and already fetching" test and risking a request pile-up for unrelated concurrent callers elsewhere in the app. This PR takes a narrower approach (see Fix).

## Evidence
Failing test (before fix), `tests/unit/composables/useMe.spec.js`:
```
× fetchMe > forceRefetch=true still issues its own fetch after an in-flight hitServer=true call (Discourse #9951)
  → expected "spy" to be called 2 times, but got 1 times
```

## Fix
`composables/useMe.js` `fetchMe()` gains an opt-in `forceRefetch` parameter (default `false`). When `true` and a fetch is already in flight, it still waits for that fetch first (so we never fire two requests at once), then always follows up with its own `authStore.fetchUser()` call — guaranteeing the response reflects state as of *this* call. Default is unchanged for every other call site, so the pinned dedup test is untouched.

`modtools/composables/useModMe.js` `checkWork()` passes `fetchMe(true, true)`: it always runs right after a mutation (approve/reject/hold/release/...), so it should never accept a stale in-flight response.

## Other Call Sites
`fetchMe(true)` is also called (without `forceRefetch`, so unaffected by this change) from: `composables/useNavbar.js`, `composables/useBootSession.js`, `composables/useReplyStateMachine.js`, `components/settings/ProfileSection.vue`, `components/NewsAboutMe.vue`, `components/MicroVolunteering.vue`, `pages/settings/index.vue`, `pages/browse/[[term]].vue`, `pages/microvolunteering/index.client.vue`, `modtools/components/ModSettingsGroup.vue`, `modtools/pages/members/feedback.vue`.

`modtools/stores/spammer.js` (5 call sites, spam-member review counts) has the same mutation-then-refresh shape as `checkWork()` and could theoretically hit the same race, but the reported bug is specifically about the pending-message badges, so it's left out of scope here rather than widening this PR's surface.

## Test
- File: `iznik-nuxt3/tests/unit/composables/useMe.spec.js` (new test in the `fetchMe` describe block) + `iznik-nuxt3/tests/unit/composables/useModMe.spec.js` (asserts `checkWork()` calls `fetchMe(true, true)`)
- Command: status API `POST /api/tests/vitest {"filter":"useMe.spec.js"}` (and `useModMe.spec.js`)
- Proves fail-before (1 fetchUser call, expected 2) / pass-after (2 calls). Also re-ran `useModMe.spec.js` (10✓), `ModMessageButton.spec.js` (both, 51✓ combined), `ModMenuItemLeft.spec.js` (19✓), `message.heldByOtherMod.spec.js` (5✓), `useModMessages.pendingAutoRefresh.spec.js`, `useBootSession.spec.js` against the fix — 147 tests total, no regressions.

## Discourse
https://discourse.ilovefreegle.org/t/9951/1