### PR TITLE
fix(notifications): bound the app-icon push badge to the notification bell's 90-day window

### DIFF
--- a/iznik-batch/app/Services/PushNotificationService.php
+++ b/iznik-batch/app/Services/PushNotificationService.php
@@ -290,10 +290,25 @@ class PushNotificationService
      * channel).
      */
     /**
+     * How far back the in-app notification bell/list (iznik-server-go
+     * notification.List()/Count(), utils.NOTIFICATION_AGE) will show an unseen
+     * users_notifications row. Anything older is invisible in the app, so the
+     * member has no UI path to ever mark it seen. Must match that Go constant.
+     */
+    private const CONSUMER_NOTIFICATION_AGE_DAYS = 90;
+
+    /**
      * The unread counts that make up a consumer's app-icon badge: unseen
      * on-site notifications + unread User2User/User2Mod chats. This is the
      * "actionable items" count the badge should reflect - NOT informational
      * pushes such as the daily "new posts near you" digest.
+     *
+     * notifcount is bounded to the same age window as the in-app bell/list
+     * (see CONSUMER_NOTIFICATION_AGE_DAYS). Without this bound, a notification
+     * older than that window can never be marked seen (it's invisible in the
+     * app), so it would inflate every future push's badge forever - a
+     * permanent app-icon blob with nothing for the member to read (Discourse
+     * 9953).
      *
      * @return array{0:int,1:int} [chatcount, notifcount]
      */
@@ -302,6 +317,7 @@ class PushNotificationService
         $notifcount = (int) DB::table('users_notifications')
             ->where('touser', $userId)
             ->where('seen', 0)
+            ->where('timestamp', '>=', now()->subDays(self::CONSUMER_NOTIFICATION_AGE_DAYS))
             ->count();
 
         // Unseen chats: User2User/User2Mod rooms where a message from someone

--- a/iznik-batch/tests/Unit/Services/PushNotificationServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/PushNotificationServiceTest.php
@@ -422,6 +422,66 @@ class PushNotificationServiceTest extends TestCase
     }
 
     /**
+     * consumerUnreadCounts() feeds the FD app-icon push badge (buildUserNotificationPayload's
+     * 'badge' field, read by mobileStore.setBadgeCount() on the device). The in-app
+     * notification bell is populated by notification.List()/Count() (iznik-server-go),
+     * both of which only return users_notifications rows within utils.NOTIFICATION_AGE
+     * (90 days) — so a member can never see, and therefore never mark seen, a
+     * notification older than that window. If consumerUnreadCounts() counts it anyway,
+     * every future push (e.g. a routine Exhort nudge) re-sets the OS badge to a
+     * permanently non-zero count the member has no way to clear (Discourse 9953:
+     * "I have a permanent notification blob... and I don't [have any replies]").
+     *
+     * Confirmed against production: 3.78M of 3.93M unseen users_notifications rows
+     * (96%) are already older than 90 days, so this is a live, systemic source of
+     * phantom badges, not a theoretical edge case.
+     */
+    public function test_consumerUnreadCounts_excludes_notification_older_than_notification_age_window(): void
+    {
+        $member = $this->createTestUser();
+        $sender = $this->createTestUser();
+
+        // Unseen, but far outside the 90-day window the in-app bell/list use — the
+        // member has no UI path to ever see or dismiss this one.
+        DB::table('users_notifications')->insert([
+            'fromuser' => $sender->id,
+            'touser' => $member->id,
+            'type' => 'CommentOnYourPost',
+            'seen' => 0,
+            'timestamp' => now()->subDays(200),
+        ]);
+
+        [, $notifcount] = $this->service->consumerUnreadCounts($member->id);
+
+        $this->assertSame(0, $notifcount,
+            'A notification the member can never see in the bell/list must not permanently inflate the app badge');
+    }
+
+    /**
+     * Companion to the age-window test above: a genuinely recent unseen notification
+     * (one the member CAN see and clear via the bell) must still count, so the fix
+     * doesn't silently zero out real badges.
+     */
+    public function test_consumerUnreadCounts_still_counts_recent_unseen_notification(): void
+    {
+        $member = $this->createTestUser();
+        $sender = $this->createTestUser();
+
+        DB::table('users_notifications')->insert([
+            'fromuser' => $sender->id,
+            'touser' => $member->id,
+            'type' => 'CommentOnYourPost',
+            'seen' => 0,
+            'timestamp' => now()->subDays(1),
+        ]);
+
+        [, $notifcount] = $this->service->consumerUnreadCounts($member->id);
+
+        $this->assertSame(1, $notifcount,
+            'A recent unseen notification the member can still see and clear must count towards the badge');
+    }
+
+    /**
      * Chitchat notifications (CommentOnYourPost in users_notifications) must never
      * inflate the modtools badge count.
      *


### PR DESCRIPTION
## Root Cause
**Prior rejected attempt (PR #1139, closed):** targeted the client-side reactive chain in `useNavbar.js`/`mobileStore` (theorized the OS badge sync side-effect never fired while viewing a specific chat page). That PR was auto-rejected for adding a parallel/duplicate badge writer without removing the original path, and for tests that only exercised the new method rather than the reported trigger. This PR re-diagnoses from scratch and does not reuse that theory.

The native app-icon badge is set from the `badge` field of the FCM/APNs push payload (`mobileStore.setBadgeCount()` in `iznik-nuxt3/stores/mobile.js`, driven by `data.badge` on each push). That payload is built by `PushNotificationService::buildUserNotificationPayload()` (iznik-batch), which sums `consumerUnreadCounts()`: unseen `users_notifications` rows + unread chats.

`consumerUnreadCounts()`'s notification count had **no age bound**. But the in-app notification bell/list (`iznik-server-go` `notification.List()`/`Count()`, `utils.NOTIFICATION_AGE = 90` days) only ever returns `users_notifications` rows from the last 90 days. `NotificationOne.vue`'s `markSeen()` — the only client code path that ever sets `seen = 1` on an individual notification — can only fire for a notification that's actually rendered in that list. So a notification older than 90 days is invisible in the app **and therefore can never be marked seen**, yet the server kept counting it into every subsequent push's badge total forever: a permanent app-icon badge with nothing the member can find to read, exactly Diz's report — "I have a permanent notification blob... and I don't [have any replies]."

Confirmed against production (read-only, SELECT-only tunnel): of 3,928,493 unseen `users_notifications` rows, 3,783,672 (96%) are already older than 90 days, affecting 1,429,947 non-deleted users. This is a live, systemic source of phantom badges, not a theoretical edge case. The majority of the backlog is `Exhort` (engagement nudge) and `AboutMe` types, which recur periodically per user and have no bulk "mark all seen" path once they age out of the visible window.

## Evidence
Fail-before (current code counts a 200-day-old unseen notification into the badge):
```
1) Tests\Unit\Services\PushNotificationServiceTest::test_consumerUnreadCounts_excludes_notification_older_than_notification_age_window
A notification the member can never see in the bell/list must not permanently inflate the app badge
Failed asserting that 1 is identical to 0.
```
Pass-after (fix applied):
```
PHPUnit 11.5.46 by Sebastian Bergmann and contributors.
..............................................                    46 / 46 (100%)
Time: 00:01.365, Memory: 68.50 MB
OK (46 tests, 87 assertions)
```

## Fix
`PushNotificationService::consumerUnreadCounts()` now bounds the unseen-notification count to the same `CONSUMER_NOTIFICATION_AGE_DAYS = 90` window the in-app bell/list already uses, so the push-computed badge only ever reflects notifications the member can actually see and clear.

## Other Call Sites
`grep -rn "users_notifications" iznik-batch/app` — other queries against this table are unrelated (user dump/demerge/restore column lists, Exhort/matched-post inserts, `NotificationChaseUpService` which already has its own explicit `timestamp` bounds for the chase-up email feature, `SpamCleanupService` deletion). `buildUserNotificationPayload()`'s `$latest` lookup (used only for push title/route when `notifcount > 0`) needed no change — it's naturally gated by the now-correct `notifcount`, and since `id` is monotonic, the newest unseen row is never the stale one once the count itself excludes it. Not in scope: `notifcount` still doesn't exclude spam-flagged senders the way the Go `Count()`/`List()` endpoints do — the production data shows the age bound accounts for the overwhelming majority (96%) of the phantom backlog, so that's left as a separate, smaller, unvalidated concern rather than scope-creeping this fix.

## Test
File: `iznik-batch/tests/Unit/Services/PushNotificationServiceTest.php`
Command: `vendor/bin/phpunit tests/Unit/Services/PushNotificationServiceTest.php` (run in an isolated container against this branch's code + the shared `iznik_batch_test` DB)
Proves fail-before (old unseen notification inflates badge) / pass-after (excluded), plus a companion test confirming a genuinely recent unseen notification still counts (no over-fix).

## Discourse
https://discourse.ilovefreegle.org/t/9953/1