### PR TITLE
fix(modtools-feedback): scope Feedback tab happiness rows to origin group

### DIFF
--- a/iznik-server-go/group/groupWork.go
+++ b/iznik-server-go/group/groupWork.go
@@ -330,8 +330,14 @@ func GetGroupWork(c *fiber.Ctx) error {
 		}
 		hapCutoff := time.Now().AddDate(0, 0, -utils.CHAT_ACTIVE_LIMIT).Format("2006-01-02")
 		var rows []countRow
+		// rippled_in = 0: a happiness rating belongs to the post's ORIGIN group only.
+		// A post rippled INTO a group has an Approved messages_groups row (rippled_in=1)
+		// there, so without this filter its rating is counted in every receiving group's
+		// Feedback badge while the Feedback list (which filters rippled_in=0 in
+		// getHappinessMembers) shows nothing — a "ghost" count, same class as the Edit
+		// badge fix (Discourse 9839) applied here to the Happiness badge (Discourse 9808).
 		db.Raw("SELECT mg.groupid, COUNT(DISTINCT mo.id) as count FROM messages_outcomes mo "+
-			"INNER JOIN messages_groups mg ON mg.msgid = mo.msgid "+
+			"INNER JOIN messages_groups mg ON mg.msgid = mo.msgid AND mg.rippled_in = 0 "+
 			"WHERE mo.timestamp >= ? AND mg.arrival >= ? "+
 			"AND mg.groupid IN ? "+
 			"AND mo.comments IS NOT NULL AND mo.comments != '' "+

--- a/iznik-server-go/membership/membership.go
+++ b/iznik-server-go/membership/membership.go
@@ -913,11 +913,17 @@ func getHappinessMembers(c *fiber.Ctx, myid uint64, groupid uint64, limit int) e
 	args = append(args, start)
 	args = append(args, limit)
 
+	// rippled_in = 0 restricts the join to each post's ORIGIN messages_groups row.
+	// Rippling-out adds an Approved messages_groups row (rippled_in = 1) per group a
+	// post reaches, so without this filter a post that only rippled into one of the
+	// caller's groups would be shown as if it had been posted there, and mg.groupid
+	// (used as the display label) would report the queried group instead of the true
+	// origin. Matches the rippled_in=0 filter already used for Edit review counts.
 	sql := fmt.Sprintf(
 		"SELECT mo.id, mo.timestamp, mo.msgid, mo.outcome, mo.happiness, mo.comments, mo.reviewed, "+
 			"m.fromuser, mg.groupid, m.subject "+
 			"FROM messages_outcomes mo "+
-			"INNER JOIN messages_groups mg ON mg.msgid = mo.msgid AND mg.groupid IN (%s) "+
+			"INNER JOIN messages_groups mg ON mg.msgid = mo.msgid AND mg.groupid IN (%s) AND mg.rippled_in = 0 "+
 			"INNER JOIN messages m ON m.id = mo.msgid "+
 			"WHERE mo.timestamp > ?"+
 			"%s%s"+

--- a/iznik-server-go/session/session.go
+++ b/iznik-server-go/session/session.go
@@ -1350,8 +1350,12 @@ func GetSession(c *fiber.Ctx) error {
 			defer wg2.Done()
 			if len(activeGroupIDs) > 0 {
 				hapCutoff := time.Now().AddDate(0, 0, -utils.CHAT_ACTIVE_LIMIT).Format("2006-01-02")
+				// rippled_in = 0: matches the groupWork.go per-group Happiness count and
+				// the getHappinessMembers list filter — without it a post rippled INTO one
+				// of the caller's active groups inflates this aggregate badge for a group
+				// whose own Feedback list never shows it (Discourse 9808).
 				db.Raw("SELECT COUNT(DISTINCT mo.id) FROM messages_outcomes mo "+
-					"INNER JOIN messages_groups mg ON mg.msgid = mo.msgid "+
+					"INNER JOIN messages_groups mg ON mg.msgid = mo.msgid AND mg.rippled_in = 0 "+
 					"WHERE mo.timestamp >= ? AND mg.arrival >= ? "+
 					"AND mg.groupid IN ? "+
 					"AND mo.comments IS NOT NULL "+

--- a/iznik-server-go/test/groupWork_test.go
+++ b/iznik-server-go/test/groupWork_test.go
@@ -790,3 +790,59 @@ func TestGetGroupWork_HappinessExcludesEmptyComments(t *testing.T) {
 	assert.NotNil(t, found2)
 	assert.Equal(t, int64(1), found2.Happiness, "Real comments should count in happiness badge")
 }
+
+// Regression (Discourse 9808): a happiness rating on a post that only rippled INTO a
+// group must NOT inflate that group's Feedback badge count. The rippled-in copy is
+// Approved with rippled_in=1; the Feedback list (getHappinessMembers) filters
+// rippled_in=0, so a count that ignored that showed a "ghost" badge against a group
+// whose Feedback list is empty — the same bug class as TestGetGroupWork_EditReviewExcludesRippledIn.
+func TestGetGroupWork_HappinessExcludesRippledIn(t *testing.T) {
+	db := database.DBConn
+	prefix := uniquePrefix("gwhaprip")
+
+	originGroup := CreateTestGroup(t, prefix+"_orig")
+	rippledGroup := CreateTestGroup(t, prefix+"_rip")
+	originMod := CreateTestUser(t, prefix+"_omod", "User")
+	rippledMod := CreateTestUser(t, prefix+"_rmod", "User")
+	CreateTestMembership(t, originMod, originGroup, "Moderator")
+	CreateTestMembership(t, rippledMod, rippledGroup, "Moderator")
+	_, originToken := CreateTestSession(t, originMod)
+	_, rippledToken := CreateTestSession(t, rippledMod)
+
+	memberID := CreateTestUser(t, prefix+"_member", "User")
+	msgID := CreateTestMessage(t, memberID, originGroup, prefix+" rippled feedback item", 55.95, -3.19)
+
+	// Ripple the same post into rippledGroup — an Approved copy marked rippled_in = 1.
+	db.Exec("INSERT INTO messages_groups (msgid, groupid, collection, arrival, autoreposts, rippled_in) "+
+		"VALUES (?, ?, 'Approved', NOW(), 0, 1)", msgID, rippledGroup)
+
+	var outcomeID uint64
+	db.Exec("INSERT INTO messages_outcomes (msgid, outcome, happiness, comments, reviewed, timestamp) "+
+		"VALUES (?, 'Taken', 'Happy', 'Lovely, thanks!', 0, NOW())", msgID)
+	db.Raw("SELECT id FROM messages_outcomes WHERE msgid = ? ORDER BY id DESC LIMIT 1", msgID).Scan(&outcomeID)
+
+	t.Cleanup(func() {
+		db.Exec("DELETE FROM messages_outcomes WHERE id = ?", outcomeID)
+		db.Exec("DELETE FROM messages_groups WHERE msgid = ? AND groupid = ?", msgID, rippledGroup)
+		db.Exec("DELETE FROM messages_groups WHERE msgid = ? AND groupid = ?", msgID, originGroup)
+		db.Exec("DELETE FROM messages WHERE id = ?", msgID)
+	})
+
+	happinessCountFor := func(token string, gid uint64) int64 {
+		resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/group/work?jwt="+token, nil))
+		assert.Equal(t, 200, resp.StatusCode)
+		var result []group.GroupWork
+		json2.Unmarshal(rsp(resp), &result)
+		for i := range result {
+			if result[i].Groupid == gid {
+				return result[i].Happiness
+			}
+		}
+		return 0
+	}
+
+	assert.GreaterOrEqual(t, happinessCountFor(originToken, originGroup), int64(1),
+		"origin group's Feedback badge should include the rating")
+	assert.Equal(t, int64(0), happinessCountFor(rippledToken, rippledGroup),
+		"rippled-into group's Feedback badge must NOT include the rippled-in copy's rating (Discourse 9808)")
+}

--- a/iznik-server-go/test/membership_test.go
+++ b/iznik-server-go/test/membership_test.go
@@ -2364,6 +2364,74 @@ func TestGetHappinessAllGroups(t *testing.T) {
 	db.Exec("DELETE FROM messages_outcomes WHERE id = ?", outcomeID)
 }
 
+// TestGetHappinessExcludesRippledInScopeAndLabel verifies two things reported together
+// (Discourse topic 9808 post 633): a post that only rippled INTO a group must not appear
+// in that group's Feedback tab (scope), and when it IS shown (queried via its true origin
+// group) it must be labelled with its origin group, not whichever group happened to be
+// selected. Rippling-out adds an Approved messages_groups row (rippled_in=1) per group a
+// post reaches; without a rippled_in=0 filter the join in getHappinessMembers matches on
+// the rippled-in copy and reports the QUERIED group as if it were the post's origin.
+func TestGetHappinessExcludesRippledInScopeAndLabel(t *testing.T) {
+	prefix := uniquePrefix("happy_rin")
+	db := database.DBConn
+
+	origin := CreateTestGroup(t, prefix+"Origin")
+	rippledTo := CreateTestGroup(t, prefix+"RippledTo")
+
+	modID := CreateTestUser(t, prefix+"_mod", "User")
+	CreateTestMembership(t, modID, origin, "Moderator")
+	CreateTestMembership(t, modID, rippledTo, "Moderator")
+	_, token := CreateTestSession(t, modID)
+
+	posterID := CreateTestUser(t, prefix+"_poster", "User")
+	CreateTestMembership(t, posterID, origin, "Member")
+
+	// Native post on the origin group (origin row, rippled_in defaults to 0).
+	msgID := CreateTestMessage(t, posterID, origin, prefix+" rippled item", 55.95, -3.19)
+
+	// Ripple the SAME post into rippledTo — an Approved copy marked rippled_in = 1.
+	db.Exec("INSERT INTO messages_groups (msgid, groupid, collection, arrival, autoreposts, rippled_in) "+
+		"VALUES (?, ?, 'Approved', NOW(), 0, 1)", msgID, rippledTo)
+
+	outcomeID := createHappinessOutcome(t, msgID, "Happy", "Loved it!")
+	t.Cleanup(func() {
+		db.Exec("DELETE FROM messages_outcomes WHERE id = ?", outcomeID)
+		db.Exec("DELETE FROM messages_groups WHERE msgid = ? AND groupid = ?", msgID, rippledTo)
+	})
+
+	// Querying the RIPPLED-INTO group must NOT show the item: it was not posted there.
+	urlRippledTo := fmt.Sprintf("/api/memberships?groupid=%d&collection=Happiness&jwt=%s", rippledTo, token)
+	req := httptest.NewRequest("GET", urlRippledTo, nil)
+	resp, err := getApp().Test(req, -1)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	results, _ := parseHappinessResponse(t, resp)
+	for _, r := range results {
+		assert.NotEqual(t, float64(outcomeID), r["id"],
+			"a post that only rippled into this group must not appear in its Feedback tab")
+	}
+
+	// Querying the ORIGIN group must show the item, labelled with the origin group.
+	urlOrigin := fmt.Sprintf("/api/memberships?groupid=%d&collection=Happiness&jwt=%s", origin, token)
+	req = httptest.NewRequest("GET", urlOrigin, nil)
+	resp, err = getApp().Test(req, -1)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	results, _ = parseHappinessResponse(t, resp)
+	found := false
+	for _, r := range results {
+		if uint64(r["id"].(float64)) == outcomeID {
+			found = true
+			assert.Equal(t, float64(origin), r["groupid"],
+				"the item must be labelled with its origin group, not the rippled-into group")
+			break
+		}
+	}
+	assert.True(t, found, "the item should be visible on its origin group")
+}
+
 func TestGetHappinessNotMod(t *testing.T) {
 	prefix := uniquePrefix("happy_nmod")
 	groupID := CreateTestGroup(t, prefix)

--- a/iznik-server-go/test/session_test.go
+++ b/iznik-server-go/test/session_test.go
@@ -3028,26 +3028,43 @@ func TestWorkCountInactiveModChatReviewGoesToOther(t *testing.T) {
 	assert.GreaterOrEqual(t, chatreviewother, float64(1), "Inactive mod: chatreview should go to chatreviewother (blue)")
 }
 
+// TestWorkCountWiderChatReviewGoesToOther exercises the actual "wider review" path:
+// the mod moderates ownGroupID (which has widerchatreview=1, granting them
+// HasWiderReview permission) but the message's recipient is on a SEPARATE
+// widerchatreview=1 group the mod does not moderate at all. This must be picked
+// up by the wider-review add-on and land in chatreviewother.
+//
+// The recipient must NOT also be a member of one of the mod's own groups: the
+// wider-review query deliberately excludes recipients who are (session.go's
+// "NOT EXISTS ... m2.groupid IN (mod's own groups)" guard, to avoid double-
+// counting a message that the base chatReviewSQL already counts via direct
+// group membership). Putting the recipient in the mod's own group — as this
+// test originally did — exercises the BASE chatreview path (recipient in
+// mod's own group, unheld -> chatreview) instead of the wider-review add-on,
+// so it never reaches chatreviewother regardless of the wider-review logic.
 func TestWorkCountWiderChatReviewGoesToOther(t *testing.T) {
 	prefix := uniquePrefix("wc_wider_chat")
 	db := database.DBConn
 
-	// Create a group with widerchatreview=1.
-	widerGroupID := CreateTestGroup(t, prefix+"_wider")
-	db.Exec("UPDATE `groups` SET settings = JSON_SET(COALESCE(settings, '{}'), '$.widerchatreview', 1) WHERE id = ?", widerGroupID)
-
-	// Create a mod ON the wider group (they must be on a group with
-	// widerchatreview=1 to participate in wider review, matching PHP).
+	// The mod's own group: widerchatreview=1 grants HasWiderReview, but the mod
+	// does not otherwise moderate the recipient's group below.
+	ownGroupID := CreateTestGroup(t, prefix+"_own")
+	db.Exec("UPDATE `groups` SET settings = JSON_SET(COALESCE(settings, '{}'), '$.widerchatreview', 1) WHERE id = ?", ownGroupID)
 	modID := CreateTestUser(t, prefix+"_mod", "User")
-	CreateTestMembership(t, modID, widerGroupID, "Moderator")
+	CreateTestMembership(t, modID, ownGroupID, "Moderator")
 	_, token := CreateTestSession(t, modID)
 
-	// Create two users — user1 on the wider group, user2 elsewhere.
+	// A separate widerchatreview=1 group the mod does NOT moderate or belong to.
+	otherWiderGroupID := CreateTestGroup(t, prefix+"_otherwider")
+	db.Exec("UPDATE `groups` SET settings = JSON_SET(COALESCE(settings, '{}'), '$.widerchatreview', 1) WHERE id = ?", otherWiderGroupID)
+
+	// Recipient (user1) is a member of the OTHER wider group only; sender (user2)
+	// has no Freegle group membership at all.
 	user1ID := CreateTestUser(t, prefix+"_u1", "User")
 	user2ID := CreateTestUser(t, prefix+"_u2", "User")
-	CreateTestMembership(t, user1ID, widerGroupID, "Member")
+	CreateTestMembership(t, user1ID, otherWiderGroupID, "Member")
 
-	// Create a chat and review-required message.
+	// Create a chat and review-required message from user2 to user1 (the recipient).
 	chatID := CreateTestChatRoom(t, user1ID, &user2ID, nil, "User2User")
 	var msgID uint64
 	db.Exec("INSERT INTO chat_messages (chatid, userid, message, date, reviewrequired, reviewrejected, reportreason) "+
@@ -3056,9 +3073,12 @@ func TestWorkCountWiderChatReviewGoesToOther(t *testing.T) {
 	defer db.Exec("DELETE FROM chat_messages WHERE id = ?", msgID)
 
 	work := getSessionWork(t, token)
+	chatreview := work["chatreview"].(float64)
 	chatreviewother := work["chatreviewother"].(float64)
+	assert.Equal(t, float64(0), chatreview,
+		"the mod does not moderate the recipient's group, so this must not land in the base chatreview count")
 	assert.GreaterOrEqual(t, chatreviewother, float64(1),
-		"Wider chat review messages should appear in chatreviewother (blue badge)")
+		"wider chat review messages (recipient on a different widerchatreview group) should appear in chatreviewother (blue badge)")
 }
 
 // ---------------------------------------------------------------------------

--- a/iznik-server-go/test/session_test.go
+++ b/iznik-server-go/test/session_test.go
@@ -2153,6 +2153,47 @@ func TestWorkCountHappinessAutoCommentExcluded(t *testing.T) {
 	assert.Equal(t, float64(0), happiness, "Should exclude all auto-generated comments")
 }
 
+// Regression (Discourse 9808): a happiness rating on a post that only rippled INTO a
+// mod's group must NOT inflate their aggregate session Feedback badge. The rippled-in
+// copy is Approved with rippled_in=1; the Feedback list (getHappinessMembers) filters
+// rippled_in=0, so a count that ignored that showed a "ghost" badge for a mod whose
+// Feedback list for that group is empty.
+func TestWorkCountHappinessExcludesRippledIn(t *testing.T) {
+	prefix := uniquePrefix("wc_happy_rip")
+	db := database.DBConn
+
+	originGroup := CreateTestGroup(t, prefix+"_orig")
+	rippledGroup := CreateTestGroup(t, prefix+"_rip")
+	// The mod is only a member of the rippled-into group, not the origin group.
+	modID := CreateTestUser(t, prefix+"_mod", "User")
+	CreateTestMembership(t, modID, rippledGroup, "Moderator")
+	_, token := CreateTestSession(t, modID)
+
+	memberID := CreateTestUser(t, prefix+"_member", "User")
+	msgID := CreateTestMessage(t, memberID, originGroup, prefix+" rippled feedback item", 55.95, -3.19)
+
+	// Ripple the same post into the mod's group — an Approved copy marked rippled_in = 1.
+	db.Exec("INSERT INTO messages_groups (msgid, groupid, collection, arrival, autoreposts, rippled_in) "+
+		"VALUES (?, ?, 'Approved', NOW(), 0, 1)", msgID, rippledGroup)
+
+	var outcomeID uint64
+	db.Exec("INSERT INTO messages_outcomes (msgid, outcome, happiness, comments, reviewed, timestamp) "+
+		"VALUES (?, 'Taken', 'Happy', 'Lovely, thanks!', 0, NOW())", msgID)
+	db.Raw("SELECT id FROM messages_outcomes WHERE msgid = ? ORDER BY id DESC LIMIT 1", msgID).Scan(&outcomeID)
+
+	t.Cleanup(func() {
+		db.Exec("DELETE FROM messages_outcomes WHERE id = ?", outcomeID)
+		db.Exec("DELETE FROM messages_groups WHERE msgid = ? AND groupid = ?", msgID, rippledGroup)
+		db.Exec("DELETE FROM messages_groups WHERE msgid = ? AND groupid = ?", msgID, originGroup)
+		db.Exec("DELETE FROM messages WHERE id = ?", msgID)
+	})
+
+	work := getSessionWork(t, token)
+	happiness := work["happiness"].(float64)
+	assert.Equal(t, float64(0), happiness,
+		"a rating on a post that only rippled into the mod's group must not inflate their Feedback badge (Discourse 9808)")
+}
+
 // ---------------------------------------------------------------------------
 // Work Counts: Gift Aid
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Root Cause
Three separate queries compute the ModTools Feedback tab's data, and only one of them was fixed in the previous attempt:

1. `getHappinessMembers` (`iznik-server-go/membership/membership.go`) — the item **list** shown under the Feedback tab.
2. The per-group Feedback **badge count** (`iznik-server-go/group/groupWork.go`, `GetGroupWork`'s Happiness goroutine).
3. The aggregate Feedback **badge count** across all a mod's active groups (`iznik-server-go/session/session.go`, the session `work.happiness` field).

All three join `messages_outcomes` to `messages_groups` on `groupid IN (caller's groups)` without excluding rippled-in copies. Rippling-out writes an extra Approved `messages_groups` row (`rippled_in = 1`) per group a post reaches. Without a `rippled_in = 0` filter:
- A post that only rippled into one of the moderator's groups matches the join and is shown in that group's Feedback tab even though it originated elsewhere (**scope**).
- The returned `groupid` — used as the "on `<Group>`" label — is constrained only to be one of the caller's queried groups, so it reports whichever group the join happened to match rather than the post's true origin (**label**, e.g. "Hackney Freegle" vs "Newham Freegle" for the same item).
- The two count queries inflate the badge for a group whose own Feedback list is empty (a "ghost" count) — the same bug class already fixed for the Edit badge (Discourse 9839).

`getHappinessMembers` was added 2026-03-11, before rippling went fully live (2026-07-07), so this is a regression against a query written to be group-scoped, not a deliberate design choice. Confirmed as a real, non-empty population: the reporter's own account (Neville_Reid, topic 9808/633) directly describes seeing this in production.

## Why attempt 1 (PR #1144) was rejected / what changed
Attempt 1 added `rippled_in = 0` only to `getHappinessMembers` (the list query), fixing the reported scope + label symptoms in the list itself. The monitor's adversarial review rejected it because the two **count** queries feeding the ModTools badge — `group/groupWork.go:334` and `session.go`'s aggregate Happiness count — still joined without the filter. That left a real, user-visible inconsistency: the badge could show e.g. "1" while the (now-correctly-filtered) list underneath showed nothing for that group.

This attempt keeps attempt 1's `membership.go` change (it was correct) and additionally applies the identical `rippled_in = 0` filter to both count queries, so the badge and the list always agree. This isn't reuse-by-analogy: each site's join and surrounding filters (comment exclusions, date cutoffs, `arrival` bounds) were read and confirmed independently before adding the filter, and the fix matches the same idiom already used for the Edit badge (`groupWork.go`'s Editreview count, `session.go`'s editreview count) rather than inventing a new pattern.

## Evidence
Targeted tests, run against the buggy code first (fail), then against the fix (pass):

```
=== RUN   TestGetGroupWork_HappinessExcludesRippledIn
    groupWork_test.go:846: Not equal: expected 0, actual 1
--- FAIL: TestGetGroupWork_HappinessExcludesRippledIn (0.74s)
=== RUN   TestGetHappinessExcludesRippledInScopeAndLabel
    membership_test.go:2411: Should not be: 55
--- FAIL: TestGetHappinessExcludesRippledInScopeAndLabel (0.26s)
=== RUN   TestWorkCountHappinessExcludesRippledIn
    session_test.go:2193: Not equal: expected 0, actual 1
--- FAIL: TestWorkCountHappinessExcludesRippledIn (0.36s)
FAIL
```

After the fix, all three pass, plus the full existing `TestGetHappiness*`, `TestGetGroupWork*` and `TestWorkCount*` suites (88 test groups, one unrelated pre-existing failure — see below).

## Fix
Added `AND mg.rippled_in = 0` to the `messages_groups` join in:
- `iznik-server-go/membership/membership.go` (`getHappinessMembers`) — fixes scope (item no longer shown on the rippled-into group) and label (the returned `groupid`, used verbatim as the row's "on `<Group>`" label by `ModMemberHappiness.vue`, is now always the item's true origin group and can no longer flip based on which group is selected).
- `iznik-server-go/group/groupWork.go` (per-group Happiness badge count).
- `iznik-server-go/session/session.go` (aggregate Happiness badge count).

## Other Call Sites
- `dashboard/dashboard.go`'s `getHappiness` (the pie/bar chart on the internal admin Dashboard page, a *different* page from the ModTools Feedback tab) has the same unfiltered join. Left unfixed to keep this PR scoped to the reported ModTools bug — noted as a follow-up in attempt 1 too.
- Frontend note (checked, not changed): `modtools/stores/member.js` has a fallback (`if (!members[i].groupid) members[i].groupid = params.groupid`) that would only trigger on a falsy API `groupid`. Since all three fixed queries use an `INNER JOIN`, `groupid` is never null/falsy in the response, so this fallback is inert given the API fix — not the root cause, and left alone to avoid unrelated scope creep.
- Confirmed this is *not* about member cross-posting: `rippled_in` is only ever set to `1` by the rippling propagation code path (see the existing comment at `message/message.go:1168`); a member's own deliberate cross-post to multiple groups creates independent `rippled_in = 0` rows, so this fix does not hide genuine crossposted feedback.

## Test
- Files: `iznik-server-go/test/membership_test.go`, `iznik-server-go/test/groupWork_test.go`, `iznik-server-go/test/session_test.go`
- Tests: `TestGetHappinessExcludesRippledInScopeAndLabel`, `TestGetGroupWork_HappinessExcludesRippledIn`, `TestWorkCountHappinessExcludesRippledIn`
- Command: `go test ./test/... -run 'TestGetHappinessExcludesRippledInScopeAndLabel|TestGetGroupWork_HappinessExcludesRippledIn|TestWorkCountHappinessExcludesRippledIn' -v`
- Proves fail-before (item wrongly shown/labelled on the rippled-into group, badge counts inflated) / pass-after (item only visible+labelled on its origin group, badge counts match the list).
- Also re-ran the full `TestGetHappiness*`, `TestGetGroupWork*`, `TestWorkCount*` suites: all pass except `TestWorkCountWiderChatReviewGoesToOther`, which fails identically against unmodified `origin/master` (verified directly) — a pre-existing, unrelated ChatReview issue, not touched by this change.

## Discourse
https://discourse.ilovefreegle.org/t/9808/633

## Follow-up: unrelated pre-existing test failure fixed in the same branch
While verifying the fix above, the full `TestGetHappiness*`/`TestGetGroupWork*`/`TestWorkCount*` suite surfaced one failure unrelated to rippling: `TestWorkCountWiderChatReviewGoesToOther`. Confirmed by running it against unmodified `origin/master` (same failure there, unrelated to this branch's changes) that this was a standing defect in the test itself, not something to wave off.

Root cause: the test put the message recipient in the *same* group the mod moderates. That message is already counted by the base `chatReviewSQL` direct-membership path (into `chatreview`), so the wider-review add-on's deliberate anti-double-counting guard (`NOT EXISTS ... recipient in mod's own groups`, in `session.go`) correctly excluded it from `chatreviewother` — but the test asserted on `chatreviewother` regardless, so it never actually exercised the wider-review code path it was meant to test.

Fixed the test (not the production code, which was correct) to give the recipient membership in a second, separate `widerchatreview=1` group the mod does not moderate — the actual scenario the wider-review path exists to catch. Also added an assertion that the message does NOT land in the base `chatreview` count, to make the distinction explicit. Verified: fails on the original scenario, passes with the corrected one, and the full related suite (89 test groups) now passes clean.