### PR TITLE
fix(reengage): record each onboarding tip once per member

### DIFF
--- a/iznik-batch/app/Services/ReengageService.php
+++ b/iznik-batch/app/Services/ReengageService.php
@@ -230,7 +230,9 @@ class ReengageService
         // Control arm: record the send position but mail nothing (holdout).
         if ($arm === 'control') {
             if (! $dryRun) {
-                DB::table('reengage')->insert([
+                // insertOrIgnore against the unique (userid, stage) guard so an
+                // overlapping run can never record the same holdout position twice.
+                DB::table('reengage')->insertOrIgnore([
                     'userid' => $userId,
                     'stage' => $stage,
                     'template' => null,
@@ -264,9 +266,13 @@ class ReengageService
 
             $trackingId = $mail->getTrackingId();
 
-            app(EmailSpoolerService::class)->spool($mail, $email, 'reengage');
-
-            DB::table('reengage')->insert([
+            // Claim this (userid, stage) slot BEFORE spooling. The unique index
+            // means a concurrent run (e.g. a manual invocation racing the cron)
+            // that already claimed it inserts zero rows here, so we skip without
+            // sending and the member never gets the same tip twice. Recording
+            // before the spool also means a crash between the two leaves a
+            // recorded-but-undelivered tip rather than re-sending on the next run.
+            $claimed = DB::table('reengage')->insertOrIgnore([
                 'userid' => $userId,
                 'stage' => $stage,
                 'template' => $template,
@@ -283,6 +289,12 @@ class ReengageService
                 'volunteer_source' => $content['volunteerSource'] ?? 'none',
                 'sentat' => now(),
             ]);
+
+            if ($claimed === 0) {
+                return 'skipped';
+            }
+
+            app(EmailSpoolerService::class)->spool($mail, $email, 'reengage');
         }
 
         return 'sent';

--- a/iznik-batch/database/migrations/2026_07_22_000000_add_unique_userid_stage_to_reengage_table.php
+++ b/iznik-batch/database/migrations/2026_07_22_000000_add_unique_userid_stage_to_reengage_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('reengage', function (Blueprint $table) {
+            // One row per (member, tip). This is the backstop that lets the send
+            // path claim a tip with insertOrIgnore before spooling it, so an
+            // overlapping run (a manual invocation racing the cron) or a process
+            // that dies mid-send can never record or deliver the same onboarding
+            // tip to a member twice.
+            $table->unique(['userid', 'stage'], 'reengage_userid_stage_unique');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('reengage', function (Blueprint $table) {
+            $table->dropUnique('reengage_userid_stage_unique');
+        });
+    }
+};

--- a/iznik-batch/tests/Feature/Mail/ReengageEmailsCommandTest.php
+++ b/iznik-batch/tests/Feature/Mail/ReengageEmailsCommandTest.php
@@ -277,6 +277,33 @@ class ReengageEmailsCommandTest extends TestCase
         $this->assertDatabaseHas('reengage', ['userid' => $user->id, 'stage' => 2]);
     }
 
+    public function test_records_each_tip_at_most_once_per_member(): void
+    {
+        // The unique (userid, stage) guard backs the claim-before-send: an
+        // overlapping run (a manual invocation racing the cron) that has already
+        // recorded a tip inserts zero rows and never re-sends it. A second
+        // insertOrIgnore for the same slot is silently dropped.
+        $user = $this->createNewMember(3);
+        $this->insertTip($user->id, 1, now());
+
+        $second = DB::table('reengage')->insertOrIgnore([
+            'userid' => $user->id,
+            'stage' => 1,
+            'template' => 'tip1',
+            'experiment' => '',
+            'arm' => 'a',
+            'bucket' => 0,
+            'segment' => 'other',
+            'sentat' => now(),
+        ]);
+
+        $this->assertSame(0, $second, 'a duplicate (userid, stage) must be ignored');
+        $this->assertSame(
+            1,
+            DB::table('reengage')->where('userid', $user->id)->where('stage', 1)->count()
+        );
+    }
+
     public function test_completes_after_five_tips(): void
     {
         $user = $this->createNewMember(7);


### PR DESCRIPTION
## Problem

The `reengage` table (first-week onboarding tips, merged in #754) had no unique `(userid, stage)` constraint and recorded a send **after** spooling the mail. So an overlapping run — a manual `mail:reengage` invocation racing the daily cron — or a process that dies between the spool and the insert could send the **same onboarding tip to a member twice**.

## Fix

- Migration adds a unique `(userid, stage)` index to `reengage`.
- The send path claims the slot with `insertOrIgnore` **before** spooling. A run that loses the race inserts zero rows and skips without sending; recording before the spool means a crash leaves a recorded-but-undelivered tip rather than re-sending on the next run. The control-arm (holdout) insert is likewise `insertOrIgnore`.

## Tests

`ReengageEmailsCommandTest::test_records_each_tip_at_most_once_per_member` asserts a duplicate `(userid, stage)` is dropped by the guard. Full batch suite: 4885 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)