### PR TITLE
fix(worrywords): whitelisted concern-keyword phrases suppress keywords matched inside them

### DIFF
--- a/iznik-batch/app/Services/ContentCheckService.php
+++ b/iznik-batch/app/Services/ContentCheckService.php
@@ -702,18 +702,20 @@ class ContentCheckService
 
     public function checkConcernKeywords(string $subject, string $textbody, int $groupid): ?array
     {
-        $keywords = DB::table('concern_keywords')
-            ->where(function ($q) use ($groupid) {
-                $q->where('scope', 'global')
-                  ->orWhere(function ($q2) use ($groupid) {
-                      $q2->where('scope', 'group')->where('group_id', $groupid);
-                  });
-            })
+        $keywords = $this->scopedConcernKeywords($groupid)
             ->where('category', '!=', 'allowed')
             ->get();
 
-        $haystack = strtolower($subject . ' ' . $textbody);
-        $original = $subject . ' ' . $textbody;
+        // 'allowed' rows are the whitelist (ModSupportConcernKeywords.vue labels the
+        // category "Allowed (whitelist)"), but they're excluded from $keywords above so
+        // they never trigger a match themselves. That's not enough on its own: a SHORTER
+        // keyword can still match inside an allowed phrase (e.g. 'cash' fuzzy-matches the
+        // 'cashes' in the whitelisted place name 'Cashes Green'), so the moderator's
+        // whitelist had no effect (Discourse #9944/6). Blank out whitelisted phrases
+        // before matching so they can't feed a match to any other keyword, while text
+        // outside those phrases is still checked normally.
+        $original = $this->stripAllowedPhrases($subject . ' ' . $textbody, $groupid);
+        $haystack = strtolower($original);
 
         foreach ($keywords as $kw) {
             $word = trim($kw->keyword);
@@ -752,6 +754,50 @@ class ContentCheckService
         }
 
         return null;
+    }
+
+    /**
+     * concern_keywords rows in scope for $groupid (global + this group's own
+     * group-scoped rows), unfiltered by category. Shared by checkConcernKeywords()
+     * and stripAllowedPhrases() so the scope rule lives in one place.
+     */
+    private function scopedConcernKeywords(int $groupid)
+    {
+        return DB::table('concern_keywords')
+            ->where(function ($q) use ($groupid) {
+                $q->where('scope', 'global')
+                  ->orWhere(function ($q2) use ($groupid) {
+                      $q2->where('scope', 'group')->where('group_id', $groupid);
+                  });
+            });
+    }
+
+    /**
+     * Blank out any whitelisted ('allowed' category) phrases in scope for this group,
+     * word-boundary and case-insensitively, so they can't feed a match to a different
+     * keyword contained within them. Text outside a whitelisted phrase is untouched, so
+     * a keyword occurring elsewhere in the same message is still flagged.
+     */
+    private function stripAllowedPhrases(string $text, int $groupid): string
+    {
+        $phrases = $this->scopedConcernKeywords($groupid)
+            ->where('category', 'allowed')
+            ->pluck('keyword');
+
+        foreach ($phrases as $phrase) {
+            $phrase = trim($phrase);
+            if ($phrase === '') {
+                continue;
+            }
+
+            $text = (string) preg_replace(
+                '/\b' . preg_quote($phrase, '/') . '\b/i',
+                str_repeat(' ', strlen($phrase)),
+                $text
+            );
+        }
+
+        return $text;
     }
 
     // -------------------------------------------------------------------------

--- a/iznik-batch/tests/Feature/Message/ContentCheckTest.php
+++ b/iznik-batch/tests/Feature/Message/ContentCheckTest.php
@@ -328,6 +328,65 @@ class ContentCheckTest extends TestCase
         $this->assertNull($result);
     }
 
+    public function test_allowed_phrase_suppresses_shorter_keyword_matched_within_it(): void
+    {
+        // Discourse #9944/6: a moderator whitelists a place-name phrase ('Cashes
+        // Green') that happens to contain the plural inflection of an unrelated,
+        // shorter concern keyword ('cash' -> 'cashes'). ModSupportConcernKeywords.vue
+        // labels the 'allowed' category as "Allowed (whitelist)", so a chat message
+        // containing the whitelisted phrase must not still be flagged by the
+        // shorter keyword matching inside it.
+        DB::table('concern_keywords')->insert([
+            'keyword'    => 'testcash_cc',
+            'category'   => 'scam',
+            'match_mode' => 'fuzzy',
+            'action'     => 'flag',
+            'scope'      => 'global',
+            'group_id'   => 0,
+        ]);
+
+        // Sanity: without a whitelist, the plural inflection does fuzzy-match.
+        $beforeWhitelist = $this->service->checkChatMessage('meet me at testcash_cces green please');
+        $this->assertNotNull($beforeWhitelist, 'sanity: keyword fuzzy-matches its plural before any whitelist exists');
+
+        DB::table('concern_keywords')->insert([
+            'keyword'    => 'testcash_cces green',
+            'category'   => 'allowed',
+            'match_mode' => 'literal',
+            'action'     => 'flag',
+            'scope'      => 'global',
+            'group_id'   => 0,
+        ]);
+
+        $result = $this->service->checkChatMessage('meet me at testcash_cces green please');
+        $this->assertNull($result, "whitelisting 'testcash_cces green' must suppress the 'testcash_cc' match contained within it");
+    }
+
+    public function test_allowed_phrase_does_not_suppress_keyword_match_elsewhere_in_message(): void
+    {
+        // Bound the fix: whitelisting a phrase must not blanket-suppress every
+        // concern keyword in a message that merely also contains that phrase.
+        DB::table('concern_keywords')->insert([
+            'keyword'    => 'testcash2_cc',
+            'category'   => 'scam',
+            'match_mode' => 'fuzzy',
+            'action'     => 'flag',
+            'scope'      => 'global',
+            'group_id'   => 0,
+        ]);
+        DB::table('concern_keywords')->insert([
+            'keyword'    => 'testcash2_cces green',
+            'category'   => 'allowed',
+            'match_mode' => 'literal',
+            'action'     => 'flag',
+            'scope'      => 'global',
+            'group_id'   => 0,
+        ]);
+
+        $result = $this->service->checkChatMessage('near testcash2_cces green, only testcash2_cc accepted');
+        $this->assertNotNull($result, 'a keyword occurrence outside the whitelisted phrase must still be flagged');
+    }
+
     // -------------------------------------------------------------------------
     // checkConcernKeywords — fuzzy match_mode (levenshtein, V1 parity)
     // -------------------------------------------------------------------------


### PR DESCRIPTION
## Root Cause
`ContentCheckService::checkConcernKeywords()` — the check `checkChatMessage()` uses to flag chat messages for review — excludes `concern_keywords` rows with `category = 'allowed'` from the keyword list it matches against (so a whitelisted phrase can never trigger a flag for itself). But that's the *only* thing the `allowed` category did: it never suppressed a **different, shorter** keyword matching *inside* the whitelisted phrase. When Stroud asked for `'Cashes Green'` to be whitelisted, the global concern keyword `cash` still fuzzy-matches the plural `cashes` (via the existing `-es` inflection rule), so a chat message containing `'cashes green'` kept getting flagged with reportreason `WorryWord` — the whitelist had no effect.

Go's real-time worry-word check for posts (`message/message.go`, `matchWorryWords`) already handles this correctly: it strips `Allowed`-type words out of the text before running the per-word match (`// Remove Allowed words before checking`). That behaviour was never carried over when the chat-message content check (`ChatProcessService` → `ContentCheckService::checkChatMessage()` → `checkConcernKeywords()`) was rebuilt on the unified `concern_keywords` table — this is a parity gap versus the working Go implementation, not an intentional design choice.

## Evidence
Failing-test output (before the fix, `checkChatMessage('meet me at testcash_cces green please')` with `testcash_cc` as a global concern keyword and `testcash_cces green` whitelisted via an `allowed`-category row):

```
FAILED  Tests\Feature\Message\ContentCheckTest > allowed phrase suppresse…
whitelisting 'testcash_cces green' must suppress the 'testcash_cc' match contained within it
Failed asserting that Array &0 [
    'check' => 'ConcernKeyword',
    'category' => 'scam',
    'action' => 'flag',
    'keyword' => 'testcash_cc',
    'detail' => 'Matched concern keyword 'testcash_cc'',
] is null.
  at tests/Feature/Message/ContentCheckTest.php:362
```

## Fix
`checkConcernKeywords()` now blanks out any in-scope `allowed`-category phrase from the subject/body text (word-boundary, case-insensitive) *before* running the match loop, via a new `stripAllowedPhrases()` helper. A keyword that only matched because it was substring/inflection of a whitelisted phrase no longer matches; a keyword occurring anywhere else in the same message is unaffected and still flags. Extracted the shared `scope = global OR (group AND this groupid)` query into `scopedConcernKeywords()` to avoid duplicating it between the two methods.

## Other Call Sites
`grep -rn "category.*allowed\|'allowed'" app/` shows `category = 'allowed'` is consulted in exactly one place, `ContentCheckService::checkConcernKeywords()` (now also `stripAllowedPhrases()`, called from the same method). `checkPerGroupWorryWords()` (the legacy per-group `groups.settings->$.spammers.worrywords` list) has no `allowed`/whitelist concept at all and is not part of the chat-flagging path (`checkChatMessage()` never calls it), so it's unaffected and out of scope for this fix.

## Test
- File: `iznik-batch/tests/Feature/Message/ContentCheckTest.php`
- Command: `POST http://localhost:8081/api/tests/laravel {"filter":"ContentCheckTest"}` (158 tests, 283 assertions, all passing after the fix)
- `test_allowed_phrase_suppresses_shorter_keyword_matched_within_it` — proves fail-before (whitelisted phrase still flagged) / pass-after (whitelisted phrase suppresses the contained keyword)
- `test_allowed_phrase_does_not_suppress_keyword_match_elsewhere_in_message` — bounds the fix: a keyword occurrence outside the whitelisted phrase still flags

## Discourse
https://discourse.ilovefreegle.org/t/9944/6