### PR TITLE
fix(monitor-fsm): stop scoped topic refs falsely reconciling unrelated bugs

### DIFF
--- a/monitor-fsm/src/__tests__/actions.reconcile_direct_master.test.ts
+++ b/monitor-fsm/src/__tests__/actions.reconcile_direct_master.test.ts
@@ -79,6 +79,34 @@ describe('matchDirectMasterFixCommits', () => {
     ])
   })
 
+  it('does NOT match a scoped topic ref to an unrelated post via the single-bug fallback', () => {
+    // Regression: a reach-slider commit that referenced Neville's OTHER posts
+    // "(9808 #585/#600)" and "(Neville, 9808 #584)" was matched to the only open
+    // 9808 bug at the time (9808/633, a different problem), falsely marking it
+    // fixed and auto-posting "please retest" — which Neville rejected (2026-07-22).
+    const m = matchDirectMasterFixCommits(
+      [
+        {
+          sha: '0370f67',
+          subj: "fix(reach-slider): show the rippling explainer at all widths + 'Close to' wording",
+          body: 'Un-hide the line Neville reported missing (9808 #585/#600). Wording per (Neville, 9808 #584).',
+        },
+      ],
+      [{ topic: 9808, post: 633 }],
+    )
+    expect(m).toEqual([])
+  })
+
+  it('still matches the exact scoped post it does reference', () => {
+    const m = matchDirectMasterFixCommits(
+      [{ sha: 'abc1234', subj: 'fix(reach): explainer', body: 'the missing line (9808 #585)' }],
+      [{ topic: 9808, post: 585 }],
+    )
+    expect(m).toEqual([
+      { topic: 9808, post: 585, sha: 'abc1234', subj: 'fix(reach): explainer' },
+    ])
+  })
+
   it('returns nothing when no commit references the bug', () => {
     const m = matchDirectMasterFixCommits(
       [{ sha: 'iii9999', subj: 'fix(x): unrelated', body: '' }],

--- a/monitor-fsm/src/actions/index.ts
+++ b/monitor-fsm/src/actions/index.ts
@@ -538,7 +538,14 @@ export function matchDirectMasterFixCommits(
       const key = `${m[1]}/${m[2]}`
       if (!tpRefs.has(key)) tpRefs.set(key, { sha: c.sha, subj: c.subj })
     }
-    for (const m of msg.matchAll(/(?:\(|discourse\s+|#)(9\d{3})\b/gi)) {
+    // Topic-only ref, used by the single-unfixed-bug fallback below. A topic
+    // number that is immediately followed by a post reference ("(9808 #585)")
+    // is SCOPED to that post, not the whole topic — registering it as a
+    // topic-only ref let a reach-slider commit that mentioned "(9808 #585/#600)"
+    // get matched to an unrelated open bug (9808/633) via the fallback, marking
+    // it fixed and posting a bogus retest (Neville, 2026-07-22). The negative
+    // lookahead keeps scoped references out of topicRefs.
+    for (const m of msg.matchAll(/(?:\(|discourse\s+|#)(9\d{3})\b(?!\s*[/#]\s*\d)/gi)) {
       const t = Number(m[1])
       if (!topicRefs.has(t)) topicRefs.set(t, { sha: c.sha, subj: c.subj })
     }


### PR DESCRIPTION
## Problem

`reconcile_direct_master` marks a Discourse bug fixed when a master commit references it. As a fallback, a commit that references a topic **without a post** matches the topic's bug *when that topic has exactly one unfixed bug*. The topic-only regex, however, also matched the topic number inside a **scoped** reference: `"(9808 #585/#600)"` registered a topic-only ref for 9808 even though the commit was clearly about posts 585/600.

On 2026-07-22, a five-day-old **reach-slider** commit (`0370f674`, referencing `9808 #584/#585/#600`) was matched via this fallback to `9808/633` — an unrelated *ModTools Feedback tab* bug that happened to be the only open 9808 bug at that moment. The FSM marked it fixed and auto-posted "AI Edward: possible fix applied, please retest", which the reporter (Neville) rejected ("no change").

## Fix

A negative lookahead (`(?!\s*[/#]\s*\d)`) keeps a topic number that is immediately followed by a post reference out of the topic-only ref set, so a scoped `(9808 #585)` no longer hijacks the single-unfixed-bug fallback for a different post. Exact `topic/post` matching is unchanged.

## Tests

`actions.reconcile_direct_master.test.ts` gains the regression case (the reach-slider commit must NOT match `9808/633`) and a check that the exact scoped post it *does* reference still matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)