### PR TITLE
fix(worryword): match keyword whitelist case-insensitively so whitelisted phrases stop flagging

### DIFF
--- a/iznik-batch/app/Services/ContentCheckService.php
+++ b/iznik-batch/app/Services/ContentCheckService.php
@@ -702,18 +702,20 @@ class ContentCheckService
 
     public function checkConcernKeywords(string $subject, string $textbody, int $groupid): ?array
     {
-        $keywords = DB::table('concern_keywords')
-            ->where(function ($q) use ($groupid) {
-                $q->where('scope', 'global')
-                  ->orWhere(function ($q2) use ($groupid) {
-                      $q2->where('scope', 'group')->where('group_id', $groupid);
-                  });
-            })
+        $keywords = $this->scopedConcernKeywords($groupid)
             ->where('category', '!=', 'allowed')
             ->get();
 
-        $haystack = strtolower($subject . ' ' . $textbody);
-        $original = $subject . ' ' . $textbody;
+        // 'allowed' rows are the whitelist (ModSupportConcernKeywords.vue labels the
+        // category "Allowed (whitelist)"), but they're excluded from $keywords above so
+        // they never trigger a match themselves. That's not enough on its own: a SHORTER
+        // keyword can still match inside an allowed phrase (e.g. 'cash' fuzzy-matches the
+        // 'cashes' in the whitelisted place name 'Cashes Green'), so the moderator's
+        // whitelist had no effect (Discourse #9944/6). Blank out whitelisted phrases
+        // before matching so they can't feed a match to any other keyword, while text
+        // outside those phrases is still checked normally.
+        $original = $this->stripAllowedPhrases($subject . ' ' . $textbody, $groupid);
+        $haystack = strtolower($original);
 
         foreach ($keywords as $kw) {
             $word = trim($kw->keyword);
@@ -752,6 +754,54 @@ class ContentCheckService
         }
 
         return null;
+    }
+
+    /**
+     * concern_keywords rows in scope for $groupid (global + this group's own
+     * group-scoped rows), unfiltered by category. Shared by checkConcernKeywords()
+     * and stripAllowedPhrases() so the scope rule lives in one place.
+     */
+    private function scopedConcernKeywords(int $groupid)
+    {
+        return DB::table('concern_keywords')
+            ->where(function ($q) use ($groupid) {
+                $q->where('scope', 'global')
+                  ->orWhere(function ($q2) use ($groupid) {
+                      $q2->where('scope', 'group')->where('group_id', $groupid);
+                  });
+            });
+    }
+
+    /**
+     * Blank out any whitelisted ('allowed' category) phrases in scope for this group,
+     * word-boundary and case-insensitively, so they can't feed a match to a different
+     * keyword contained within them. Text outside a whitelisted phrase is untouched, so
+     * a keyword occurring elsewhere in the same message is still flagged. Shared by
+     * checkConcernKeywords() and checkPerGroupWorryWords() (Discourse #9944/6: a
+     * previous fix attempt covered only checkConcernKeywords(), leaving the legacy
+     * per-group worrywords list - a completely separate keyword source with no
+     * whitelist concept of its own - still flagging the whitelisted phrase).
+     */
+    private function stripAllowedPhrases(string $text, int $groupid): string
+    {
+        $phrases = $this->scopedConcernKeywords($groupid)
+            ->where('category', 'allowed')
+            ->pluck('keyword');
+
+        foreach ($phrases as $phrase) {
+            $phrase = trim($phrase);
+            if ($phrase === '') {
+                continue;
+            }
+
+            $text = (string) preg_replace(
+                '/\b' . preg_quote($phrase, '/') . '\b/i',
+                str_repeat(' ', strlen($phrase)),
+                $text
+            );
+        }
+
+        return $text;
     }
 
     // -------------------------------------------------------------------------
@@ -1171,8 +1221,14 @@ class ContentCheckService
             return null;
         }
 
-        $words    = array_filter(array_map('trim', explode(',', $raw)));
-        $haystack = strtolower($subject . ' ' . $textbody);
+        $words = array_filter(array_map('trim', explode(',', $raw)));
+
+        // This legacy list has no whitelist concept of its own (V1 parity), so without
+        // stripping the same 'allowed' concern_keywords phrases used by
+        // checkConcernKeywords(), a moderator whitelisting a phrase (e.g. 'Cashes
+        // Green') would see it keep flagging here even though checkConcernKeywords()
+        // now suppresses it (Discourse #9944/6).
+        $haystack = strtolower($this->stripAllowedPhrases($subject . ' ' . $textbody, $groupid));
 
         foreach ($words as $word) {
             if ($word === '') {

--- a/iznik-batch/tests/Feature/Message/ContentCheckTest.php
+++ b/iznik-batch/tests/Feature/Message/ContentCheckTest.php
@@ -1628,6 +1628,108 @@ class ContentCheckTest extends TestCase
     }
 
     // -------------------------------------------------------------------------
+    // Whitelist ('allowed' concern_keywords) suppresses a shorter/unrelated
+    // keyword matched INSIDE the whitelisted phrase. Discourse #9944/6: Edward
+    // whitelisted the Stroud place name 'Cashes Green' because the global
+    // concern keyword 'cash' fuzzy-matches the 'cashes' inflection contained in
+    // it. Production data confirms this exact shape: concern_keywords has a
+    // global fuzzy 'cash' row (id 521) AND a global allowed 'Cashes Green' row
+    // (id 3791); StroudFreegle's legacy per-group worrywords list (checked
+    // separately by checkPerGroupWorryWords()) ALSO contains 'cash'.
+    // -------------------------------------------------------------------------
+
+    public function test_allowed_phrase_suppresses_shorter_keyword_matched_within_it_in_chat(): void
+    {
+        // checkChatMessage() (global scope, groupid=0) is the method
+        // ChatProcessService::processMessage() calls to decide whether a chat
+        // message is held for review - this is the exact path that flagged
+        // Jos's chat message even after the whitelist was added.
+        DB::table('concern_keywords')->insert([
+            'keyword'    => 'testcashwl_cc',
+            'category'   => 'review',
+            'match_mode' => 'fuzzy',
+            'action'     => 'flag',
+            'scope'      => 'global',
+            'group_id'   => 0,
+        ]);
+
+        // Sanity: without a whitelist, the plural inflection does fuzzy-match.
+        $before = $this->service->checkChatMessage('see you near testcashwl_cces green please');
+        $this->assertNotNull($before, 'sanity: keyword fuzzy-matches its plural before any whitelist exists');
+
+        // Whitelisted with different case/spacing than the chat message below,
+        // to prove the comparison is case-insensitive.
+        DB::table('concern_keywords')->insert([
+            'keyword'    => 'Testcashwl_cces Green',
+            'category'   => 'allowed',
+            'match_mode' => 'literal',
+            'action'     => 'flag',
+            'scope'      => 'global',
+            'group_id'   => 0,
+        ]);
+
+        $result = $this->service->checkChatMessage('see you near testcashwl_cces green please');
+        $this->assertNull($result, "whitelisting 'Testcashwl_cces Green' must suppress the lowercase-variant match of 'testcashwl_cc' inside it");
+    }
+
+    public function test_allowed_phrase_does_not_suppress_keyword_match_elsewhere_in_chat_message(): void
+    {
+        // Bound the fix: whitelisting a phrase must not blanket-suppress every
+        // concern keyword in a message that merely also contains that phrase.
+        DB::table('concern_keywords')->insert([
+            'keyword'    => 'testcashwl2_cc',
+            'category'   => 'review',
+            'match_mode' => 'fuzzy',
+            'action'     => 'flag',
+            'scope'      => 'global',
+            'group_id'   => 0,
+        ]);
+        DB::table('concern_keywords')->insert([
+            'keyword'    => 'testcashwl2_cces green',
+            'category'   => 'allowed',
+            'match_mode' => 'literal',
+            'action'     => 'flag',
+            'scope'      => 'global',
+            'group_id'   => 0,
+        ]);
+
+        $result = $this->service->checkChatMessage('near testcashwl2_cces green, only testcashwl2_cc accepted');
+        $this->assertNotNull($result, 'a keyword occurrence outside the whitelisted phrase must still be flagged');
+    }
+
+    public function test_allowed_phrase_suppresses_match_in_per_group_worry_words_too(): void
+    {
+        // PR #1147 (a previous attempt at this bug) fixed checkConcernKeywords()
+        // alone and was rejected: checkMessage() also runs
+        // checkPerGroupWorryWords() on posts, which reads groups.settings ->
+        // spammers.worrywords - a completely separate list with no whitelist
+        // concept at all. Live production data confirms StroudFreegle (the
+        // group that requested this exact whitelist) has 'cash' in BOTH
+        // concern_keywords (global, fuzzy) and its legacy per-group worrywords
+        // list, so a Stroud post containing 'cashes green' would still be
+        // wrongly flagged here even after checkConcernKeywords() was fixed.
+        $group = $this->createTestGroup([
+            'settings' => ['spammers' => ['worrywords' => 'testcashwl3_cc']],
+        ]);
+
+        // Sanity: without a whitelist, the plural inflection does fuzzy-match.
+        $before = $this->service->checkPerGroupWorryWords('see you near testcashwl3_cces green please', '', $group->id);
+        $this->assertNotNull($before, 'sanity: per-group worry word fuzzy-matches its plural before any whitelist exists');
+
+        DB::table('concern_keywords')->insert([
+            'keyword'    => 'testcashwl3_cces green',
+            'category'   => 'allowed',
+            'match_mode' => 'literal',
+            'action'     => 'flag',
+            'scope'      => 'global',
+            'group_id'   => 0,
+        ]);
+
+        $result = $this->service->checkPerGroupWorryWords('see you near testcashwl3_cces green please', '', $group->id);
+        $this->assertNull($result, "whitelisting 'testcashwl3_cces green' must also suppress the match in the legacy per-group worrywords list");
+    }
+
+    // -------------------------------------------------------------------------
     // checkSubjectRepeat — flag mass-submission spam (V1 parity)
     // -------------------------------------------------------------------------
 


### PR DESCRIPTION
## Root Cause
`ContentCheckService::checkConcernKeywords()` excludes `concern_keywords` rows with `category = 'allowed'` from the keyword list it matches against, so a whitelisted phrase can never flag itself. But that's the *only* thing the `allowed` category did — it never suppressed a **different, shorter** keyword matching *inside* the whitelisted phrase. Production data confirms the exact shape reported: `concern_keywords` has a global fuzzy keyword `cash` (id 521) and a global allowed phrase `Cashes Green` (id 3791). `cash` fuzzy-matches the `cashes` inflection contained in `cashes green` (via the existing `-es` suffix rule), so a chat message containing the whitelisted phrase kept getting flagged with `reportreason = WorryWord` — the whitelist had no effect. `ChatProcessService::processMessage()` (the path that decides whether a chat message is held for review) calls `checkChatMessage()` → `checkConcernKeywords('', $message, 0)`, so this is the exact code that flagged Jos's chat.

Separately, `checkPerGroupWorryWords()` — the legacy per-group `groups.settings->$.spammers.worrywords` list, checked for **posts** via `checkMessage()` — has no whitelist concept of its own at all, since it doesn't read `concern_keywords`. Live data confirms StroudFreegle (the group that requested this exact whitelist) has `cash` in that legacy list too (`help yourself, tablets, hayfever, knife, knives, firewood, cash, bank transfer, flea, worm`), so a Stroud **post** containing "cashes green" would still be wrongly flagged even after fixing `checkConcernKeywords()` alone.

## Evidence
Targeted test run against the fix (`ContentCheckTest`, 159 tests / 285 assertions, all passing):
```
PASS  Tests\Feature\Message\ContentCheckTest
✓ allowed phrase suppresses shorter keyword matched within it in chat  0.03s
✓ allowed phrase does not suppress keyword match elsewhere in chat message
✓ allowed phrase suppresses match in per group worry words too         0.03s
Tests:    159 passed (285 assertions)
```
Before the fix, the first and third tests fail: `checkChatMessage()` returns a `ConcernKeyword` match instead of `null` for a message containing the case-different variant of a whitelisted phrase, and `checkPerGroupWorryWords()` returns a `PerGroupWorryWord` match instead of `null`.

## Fix
Added a shared `stripAllowedPhrases()` helper (blanks out any in-scope `allowed`-category phrase from the text, word-boundary and case-insensitive, before matching) and a `scopedConcernKeywords()` helper for the shared global-or-this-group scope query. Both `checkConcernKeywords()` and `checkPerGroupWorryWords()` now call `stripAllowedPhrases()` before matching, so a keyword that only matched because it was a substring/inflection of a whitelisted phrase no longer matches in *either* check, while a keyword occurring anywhere else in the same message is unaffected and still flags.

Verified this is the correct target behaviour independently (not by analogy) by reading Go's `checkWorryWords`/`matchWorryWords` (`iznik-server-go/message/message.go`), which already does exactly this for the real-time post-side worry indicator: it merges global `concern_keywords` and the legacy per-group list into one combined word set, then strips `Allowed` words from the scanned text before matching against the *whole* combined set. This Laravel fix brings `checkConcernKeywords()`/`checkPerGroupWorryWords()` to the same parity.

## Previous attempt
#1147 was closed by the monitor's auto-review: it fixed `checkConcernKeywords()` only, and the review correctly flagged that `checkPerGroupWorryWords()` runs immediately afterwards (in `checkMessage()`, the post-checking path) on the same raw text with no whitelist concept of its own. This PR fixes both call sites via the shared `stripAllowedPhrases()` helper, and adds a dedicated test (`test_allowed_phrase_suppresses_match_in_per_group_worry_words_too`) proving the per-group list also now respects the whitelist — validated against the real StroudFreegle data that made the gap in #1147 concrete, not just theoretical.

## Other Call Sites
Grepped for every place a keyword/whitelist list is compared:
- `IncomingMailService::containsWorryWords()` (legacy `worrywords` table, used for chat replies/posts that arrive by email) — **already correct**: it strips `type = 'Allowed'` words before checking other keywords.
- `iznik-server-go` `enrichReviewReason()` (`chat/chatmessage.go`) — cosmetic relabelling only (runs after a message is already flagged, to give a more specific reason string); already filters `category != 'allowed'` and never participates in the flag decision, so it's unaffected by this bug.
- `iznik-server-go` `checkWorryWords`/`matchWorryWords` (`message/message.go`) — the real-time post-side indicator; already strips `Allowed` words correctly (used as the reference behaviour this PR ports to Laravel).

## Test
- File: `iznik-batch/tests/Feature/Message/ContentCheckTest.php`
- Command: `php artisan test --filter=ContentCheckTest` (via a throwaway container on the shared dev network, since the isolated FSM worktree has no docker-compose stack of its own)
- New tests: `test_allowed_phrase_suppresses_shorter_keyword_matched_within_it_in_chat` (reproduces the reported chat bug via `checkChatMessage()`), `test_allowed_phrase_does_not_suppress_keyword_match_elsewhere_in_chat_message` (bounds the fix — a keyword elsewhere in the message still flags), `test_allowed_phrase_suppresses_match_in_per_group_worry_words_too` (the gap #1147 was rejected for)
- Proves fail-before / pass-after: without the fix, `checkChatMessage()` returns a match instead of `null`, and `checkPerGroupWorryWords()` returns a match instead of `null`

## Discourse
https://discourse.ilovefreegle.org/t/9944/6