### PR TITLE
fix(modtools-feedback): scope Feedback tab to the origin group (Discourse 9808/633)

### DIFF
--- a/iznik-server-go/group/groupWork.go
+++ b/iznik-server-go/group/groupWork.go
@@ -334,6 +334,10 @@ func GetGroupWork(c *fiber.Ctx) error {
 			"INNER JOIN messages_groups mg ON mg.msgid = mo.msgid "+
 			"WHERE mo.timestamp >= ? AND mg.arrival >= ? "+
 			"AND mg.groupid IN ? "+
+			// rippled_in = 0: count Feedback only for posts that originated on the
+			// group, not rippled-in copies, so the badge matches the Feedback list
+			// (getHappinessMembers) and the Edit badge above. Discourse 9808/633.
+			"AND mg.rippled_in = 0 "+
 			"AND mo.comments IS NOT NULL AND mo.comments != '' "+
 			"AND mo.comments != 'Sorry, this is no longer available.' "+
 			"AND mo.comments != 'Thanks, this has now been taken.' "+

--- a/iznik-server-go/membership/membership.go
+++ b/iznik-server-go/membership/membership.go
@@ -917,7 +917,11 @@ func getHappinessMembers(c *fiber.Ctx, myid uint64, groupid uint64, limit int) e
 		"SELECT mo.id, mo.timestamp, mo.msgid, mo.outcome, mo.happiness, mo.comments, mo.reviewed, "+
 			"m.fromuser, mg.groupid, m.subject "+
 			"FROM messages_outcomes mo "+
-			"INNER JOIN messages_groups mg ON mg.msgid = mo.msgid AND mg.groupid IN (%s) "+
+			// rippled_in = 0: only Feedback for posts that ORIGINATED on the
+			// group, not copies that rippled in from elsewhere (the badge count
+			// queries in groupWork.go / session.go apply the same filter, and it
+			// mirrors the Edit badge). Discourse 9808/633.
+			"INNER JOIN messages_groups mg ON mg.msgid = mo.msgid AND mg.groupid IN (%s) AND mg.rippled_in = 0 "+
 			"INNER JOIN messages m ON m.id = mo.msgid "+
 			"WHERE mo.timestamp > ?"+
 			"%s%s"+

--- a/iznik-server-go/session/session.go
+++ b/iznik-server-go/session/session.go
@@ -1354,6 +1354,10 @@ func GetSession(c *fiber.Ctx) error {
 					"INNER JOIN messages_groups mg ON mg.msgid = mo.msgid "+
 					"WHERE mo.timestamp >= ? AND mg.arrival >= ? "+
 					"AND mg.groupid IN ? "+
+					// rippled_in = 0: the aggregate Feedback work count must match
+					// the per-group badge (groupWork.go) and the list — only posts
+					// that originated on the group, not rippled-in copies. 9808/633.
+					"AND mg.rippled_in = 0 "+
 					"AND mo.comments IS NOT NULL "+
 					"AND mo.comments != 'Sorry, this is no longer available.' "+
 					"AND mo.comments != 'Thanks, this has now been taken.' "+

--- a/iznik-server-go/test/groupWork_test.go
+++ b/iznik-server-go/test/groupWork_test.go
@@ -790,3 +790,45 @@ func TestGetGroupWork_HappinessExcludesEmptyComments(t *testing.T) {
 	assert.NotNil(t, found2)
 	assert.Equal(t, int64(1), found2.Happiness, "Real comments should count in happiness badge")
 }
+
+// The Feedback (Happiness) badge count must match the Feedback list: a post that
+// rippled INTO a group counts only for its ORIGIN group, not the rippled-into
+// one. Regression guard for the badge/list mismatch that got PR #1144 rejected
+// (only the list was scoped). Discourse 9808/633.
+func TestGetGroupWork_HappinessExcludesRippledIn(t *testing.T) {
+	prefix := uniquePrefix("gwhapripple")
+	db := database.DBConn
+	originGroup := CreateTestGroup(t, prefix+"_origin")
+	rippledGroup := CreateTestGroup(t, prefix+"_rippled")
+
+	// One moderator of BOTH groups, so /api/group/work returns both counts.
+	modID := CreateTestUser(t, prefix+"_mod", "User")
+	CreateTestMembership(t, modID, originGroup, "Moderator")
+	CreateTestMembership(t, modID, rippledGroup, "Moderator")
+	_, token := CreateTestSession(t, modID)
+
+	userID := CreateTestUser(t, prefix+"_user", "User")
+	msgID := CreateTestMessage(t, userID, originGroup, prefix+" offer item", 52.5, -1.8)
+	db.Exec("INSERT INTO messages_outcomes (msgid, outcome, happiness, comments, reviewed) VALUES (?, 'Taken', 'Happy', 'Great!', 0)", msgID)
+	// Ripple the same post into rippledGroup (Approved copy, rippled_in = 1).
+	db.Exec("INSERT INTO messages_groups (msgid, groupid, collection, arrival, rippled_in) VALUES (?, ?, 'Approved', NOW(), 1)", msgID, rippledGroup)
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET", "/api/group/work?jwt="+token, nil))
+	assert.Equal(t, 200, resp.StatusCode)
+	var result []group.GroupWork
+	json2.Unmarshal(rsp(resp), &result)
+
+	var origin, rippled *group.GroupWork
+	for i := range result {
+		if result[i].Groupid == originGroup {
+			origin = &result[i]
+		} else if result[i].Groupid == rippledGroup {
+			rippled = &result[i]
+		}
+	}
+	assert.NotNil(t, origin)
+	assert.Equal(t, int64(1), origin.Happiness, "origin group's badge counts the item")
+	if rippled != nil {
+		assert.Equal(t, int64(0), rippled.Happiness, "rippled-into group's badge must not count the rippled-in copy")
+	}
+}

--- a/iznik-server-go/test/membership_test.go
+++ b/iznik-server-go/test/membership_test.go
@@ -2211,6 +2211,65 @@ func TestGetHappinessBasic(t *testing.T) {
 	db.Exec("DELETE FROM messages_outcomes WHERE id = ?", outcomeID)
 }
 
+// A post that rippled INTO a group must NOT appear in that group's Feedback
+// (Happiness) list — only the group where it ORIGINATED should show it. The
+// rippled-in copy has an Approved messages_groups row with rippled_in = 1, and
+// getHappinessMembers filters those out. Discourse 9808/633 (Neville).
+func TestGetHappinessExcludesRippledInCopies(t *testing.T) {
+	prefix := uniquePrefix("happy_ripple")
+	db := database.DBConn
+
+	originGroup := CreateTestGroup(t, prefix+"_origin")
+	rippledGroup := CreateTestGroup(t, prefix+"_rippled")
+
+	posterID := CreateTestUser(t, prefix+"_poster", "User")
+	CreateTestMembership(t, posterID, originGroup, "Member")
+
+	// Native post on originGroup (origin messages_groups row, rippled_in = 0).
+	msgID := CreateTestMessage(t, posterID, originGroup, prefix+" offer item", 55.95, -3.19)
+	outcomeID := createHappinessOutcome(t, msgID, "Happy", "Great experience!")
+
+	// The SAME post ripples INTO rippledGroup: an Approved copy, rippled_in = 1.
+	db.Exec("INSERT INTO messages_groups (msgid, groupid, collection, arrival, rippled_in) "+
+		"VALUES (?, ?, 'Approved', NOW(), 1)", msgID, rippledGroup)
+
+	// A moderator of the RIPPLED-INTO group must NOT see the item in Feedback.
+	rippledModID := CreateTestUser(t, prefix+"_rmod", "User")
+	CreateTestMembership(t, rippledModID, rippledGroup, "Moderator")
+	_, rippledToken := CreateTestSession(t, rippledModID)
+
+	resp, err := getApp().Test(httptest.NewRequest("GET",
+		fmt.Sprintf("/api/memberships?groupid=%d&collection=Happiness&jwt=%s", rippledGroup, rippledToken), nil), -1)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+	rippledResults, _ := parseHappinessResponse(t, resp)
+	for _, r := range rippledResults {
+		assert.NotEqual(t, float64(outcomeID), r["id"], "rippled-in item must not show in the rippled-into group's Feedback")
+	}
+
+	// The ORIGIN group's moderator still sees it.
+	originModID := CreateTestUser(t, prefix+"_omod", "User")
+	CreateTestMembership(t, originModID, originGroup, "Moderator")
+	_, originToken := CreateTestSession(t, originModID)
+
+	resp2, err := getApp().Test(httptest.NewRequest("GET",
+		fmt.Sprintf("/api/memberships?groupid=%d&collection=Happiness&jwt=%s", originGroup, originToken), nil), -1)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp2.StatusCode)
+	originResults, _ := parseHappinessResponse(t, resp2)
+	foundInOrigin := false
+	for _, r := range originResults {
+		if uint64(r["id"].(float64)) == outcomeID {
+			foundInOrigin = true
+			break
+		}
+	}
+	assert.True(t, foundInOrigin, "origin group's Feedback should still include the item")
+
+	// Cleanup.
+	db.Exec("DELETE FROM messages_outcomes WHERE id = ?", outcomeID)
+}
+
 func TestGetHappinessFilterHappy(t *testing.T) {
 	prefix := uniquePrefix("happy_filt")
 	db := database.DBConn


### PR DESCRIPTION
## Problem

The ModTools **Feedback tab** (Happiness) showed outcomes for posts that rippled **into** a moderator's groups, not just posts that originated there. A mod saw feedback for items from outside their area (e.g. Chigwell/Enfield), and the same rippled item was attributed to whichever group was selected ("Hackney Freegle", then "Newham Freegle"). Reported by Neville — Discourse 9808/633.

## Root cause

Three queries compute the tab's data and none excluded rippled-in copies (each rippled-in copy has an Approved `messages_groups` row with `rippled_in = 1`):

- `getHappinessMembers` — the item **list** (`membership/membership.go`)
- the per-group Feedback **badge count** (`group/groupWork.go`)
- the aggregate Feedback **work count** (`session/session.go`)

## Fix

Add `mg.rippled_in = 0` to all three queries — mirroring the Edit badge, which already scopes this way. Feedback now shows only posts that **originated** on the group, and the badge counts match the list.

## Tests

- `TestGetHappinessExcludesRippledInCopies` — a rippled-in post shows in the origin group's Feedback list but not the rippled-into group's; the origin group still sees it.
- `TestGetGroupWork_HappinessExcludesRippledIn` — the per-group badge counts the origin group but not the rippled-into one.

Discourse: https://discourse.ilovefreegle.org/t/rippling-out/9808/633

🤖 Generated with [Claude Code](https://claude.com/claude-code)
