### PR TITLE
fix(moderation): approve must not resurrect a withdrawn message into an invisible state

### DIFF
--- a/iznik-server-go/message/message.go
+++ b/iznik-server-go/message/message.go
@@ -2116,11 +2116,25 @@ func handleApprove(c *fiber.Ctx, myid uint64, req PostMessageRequest) error {
 	// Set ctx.Groupid to the primary acted-on group (for logging).
 	ctx.Groupid = authorizedGroups[0]
 
+	// Restrict to authorised group rows that are still live. A withdraw racing this
+	// approve (handleOutcome) soft-deletes the messages_groups row (deleted = 1) but
+	// leaves collection = Pending; without this check the UPDATE below would still
+	// match it on "collection != Approved" and flip it to Approved while leaving
+	// deleted = 1 and messages.deleted set. That row then fails every listing AND
+	// Support Tools search query (they all require mg.deleted = 0 AND m.deleted IS
+	// NULL), so the message becomes findable nowhere even though the mod is told
+	// "Success" (Discourse #9954).
+	var liveGroups []uint64
+	db.Raw("SELECT groupid FROM messages_groups WHERE msgid = ? AND groupid IN ? AND deleted = 0",
+		req.ID, authorizedGroups).Scan(&liveGroups)
+	if len(liveGroups) == 0 {
+		return c.JSON(fiber.Map{"ret": 1, "status": "Message is no longer available and was not approved"})
+	}
+
 	// Move to Approved with arrival=NOW() so immediate-email recipients get it.
 	// Guard against double-approve by requiring collection != Approved.
-	// Restrict to groups the caller is authorised for.
 	if result := db.Exec("UPDATE messages_groups SET collection = ?, approvedby = ?, approvedat = NOW(), arrival = NOW() WHERE msgid = ? AND groupid IN ? AND collection != ?",
-		utils.COLLECTION_APPROVED, myid, req.ID, authorizedGroups, utils.COLLECTION_APPROVED); result.Error != nil {
+		utils.COLLECTION_APPROVED, myid, req.ID, liveGroups, utils.COLLECTION_APPROVED); result.Error != nil {
 		log.Printf("Failed to approve message %d: %v", req.ID, result.Error)
 	}
 

--- a/iznik-server-go/test/message_test.go
+++ b/iznik-server-go/test/message_test.go
@@ -1207,6 +1207,62 @@ func TestPostMessageApprove(t *testing.T) {
 	// (not synchronously in the Go API), so no log or push_notify_group_mods assertions here.
 }
 
+// TestPostMessageApproveWithdrawnRace covers the approve/withdraw race from Discourse
+// #9954: a member withdraws a still-Pending post at ~the same instant a moderator
+// approves it. handleOutcome's Withdrawn-while-pending path (message.go) soft-deletes
+// the messages_groups row (deleted = 1) and the message itself (messages.deleted set),
+// but leaves messages_groups.collection = Pending untouched. We drive that exact
+// post-withdrawal state directly (no goroutines/sleeps) and then call Approve against
+// it, to prove the handler never resurrects a soft-deleted row into "Approved but
+// deleted" - a combination that is findable in no listing (mg.deleted = 0 fails) and
+// not via Support Tools subject search either (m.deleted IS NULL fails too), even
+// though the moderator was told "Success".
+func TestPostMessageApproveWithdrawnRace(t *testing.T) {
+	prefix := uniquePrefix("msgmod_appr_race")
+	db := database.DBConn
+
+	groupID := CreateTestGroup(t, prefix)
+	posterID := CreateTestUser(t, prefix+"_poster", "User")
+	modID := CreateTestUser(t, prefix+"_mod", "User")
+	CreateTestMembership(t, posterID, groupID, "Member")
+	CreateTestMembership(t, modID, groupID, "Moderator")
+	_, modToken := CreateTestSession(t, modID)
+
+	msgID := createPendingMessage(t, posterID, groupID, prefix)
+
+	// Drive the interleaved state directly: the withdraw has already landed and
+	// soft-deleted this messages_groups row and the message, exactly as
+	// handleOutcome's Withdrawn-while-pending path leaves them (collection is
+	// NOT changed by that path - only deleted flags are set).
+	db.Exec("UPDATE messages_groups SET deleted = 1 WHERE msgid = ? AND groupid = ?", msgID, groupID)
+	db.Exec("UPDATE messages SET deleted = NOW(), messageid = NULL WHERE id = ?", msgID)
+
+	// The moderator's approve click, which raced behind the withdraw, now lands.
+	body, _ := json.Marshal(map[string]interface{}{"id": msgID, "action": "Approve"})
+	req := httptest.NewRequest("POST", fmt.Sprintf("/api/message?jwt=%s", modToken), bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := getApp().Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var collection string
+	var deleted int
+	db.Raw("SELECT collection, deleted FROM messages_groups WHERE msgid = ? AND groupid = ?", msgID, groupID).Row().Scan(&collection, &deleted)
+
+	// Coherence: a row that ends up in the Approved collection must be live
+	// (deleted = 0), or it is findable in no listing and no Support Tools search -
+	// exactly the "message vanished" report in #9954. This is the buggy-code
+	// assertion inverted: on unfixed code, collection flips to "Approved" while
+	// deleted stays 1, so this fails.
+	if collection == "Approved" {
+		assert.Equal(t, 0, deleted, "approve must not leave an Approved row soft-deleted - it becomes findable nowhere")
+	}
+
+	// And the withdrawal itself must not be silently undone: the row the member
+	// deleted must stay deleted.
+	assert.Equal(t, 1, deleted, "a withdrawn messages_groups row must stay soft-deleted, not be resurrected by a racing approve")
+}
+
 // TestApproveAddsApprovedMessageToSpatial verifies that a Pending message with a
 // location is not in messages_spatial, and that approving it adds it (so it then
 // shows in the public browse) with the correct coordinates.


### PR DESCRIPTION
## Root Cause
`handleApprove` (iznik-server-go/message/message.go) moved `messages_groups.collection` to `Approved` on any row not already `collection = 'Approved'`, without checking `deleted = 0`. When a member withdraws a still-Pending post at ~the same instant a moderator approves it, `handleOutcome`'s Withdrawn-while-pending path (message.go) soft-deletes the `messages_groups` row (`deleted = 1`) and the message itself (`messages.deleted` set), but leaves `collection = 'Pending'` untouched. If the approve request lands right after, its UPDATE still matched that row on `collection != 'Approved'` and flipped it to `Approved`, leaving `deleted = 1` and `messages.deleted` set. Every listing query requires `mg.deleted = 0`, and Support Tools subject search additionally requires `m.deleted IS NULL` - so the result is a message that is findable in no group listing and not via subject search either, even though the moderator was told "Success". This matches both reports in the Discourse topic: Angelika approved a Wanted post and it then vanished everywhere including Support Tools search; Derek separately reported the same "withdrawn at the same time as approved -> unfindable" pattern.

Validated against production (read-only): 651 `messages_groups` rows currently sit in exactly this incoherent combination (`collection = 'Approved'`, `deleted = 1`, parent message soft-deleted, `approvedat` within 5 minutes of the deletion timestamp) - confirming this is a real, non-empty population, not a hypothetical.

## Evidence
Failing-test output (test written against the pre-fix code, in `TestPostMessageApproveWithdrawnRace`):
```
=== RUN   TestPostMessageApproveWithdrawnRace
    message_test.go:1258:
        	Error Trace:	.../test/message_test.go:1258
        	Error:      	Not equal:
        	            	expected: 0
        	            	actual  : 1
        	Test:       	TestPostMessageApproveWithdrawnRace
        	Messages:   	approve must not leave an Approved row soft-deleted - it becomes findable nowhere
--- FAIL: TestPostMessageApproveWithdrawnRace (0.82s)
```
After the fix, the same test (plus the existing approve/reject/outcome/withdraw suite, 44 tests) passes.

## Fix
`handleApprove` now first resolves `liveGroups` (the authorised groups whose `messages_groups` row is still `deleted = 0`) and restricts the `Approved` UPDATE to those. If a race means none of the authorised groups are still live (the message was withdrawn out from under the approve), it returns early with a "no longer available" response instead of running approval side effects (spatial index add, ham-marking, "approved" email to the poster, freebie alerts) against a message that no longer exists. The withdrawn row itself is left exactly as the withdraw left it - it is not resurrected.

## Other Call Sites
Grepped for the same "flip `messages_groups.collection`" pattern:
- `microvolunteering.go:898` (`SendForReviewAllGroups`, Approved → Pending) and `message.go:3365` (owner-edit-of-rejected, Rejected → Pending) share the shape but transition from different source collections that aren't left in this specific deleted-while-still-that-collection state by the current withdraw path - not touched here to keep this fix minimal and targeted at the evidenced race.
- `handleReject` (message.go) already guards correctly: it pre-computes the pending groups with `deleted = 0` before acting (Discourse #9815 fix).

## Test
File: `iznik-server-go/test/message_test.go`, `TestPostMessageApproveWithdrawnRace`
Command: `go test ./test/... -run TestPostMessageApproveWithdrawnRace -v`
Proves fail-before (asserts fail against unmodified `handleApprove`) / pass-after (passes with the `liveGroups` guard in place).

## Discourse
https://discourse.ilovefreegle.org/t/9954/1