### PR TITLE
perf(recommendations): index messages_likes for the sysadmin stats funnel

### DIFF
--- a/iznik-batch/database/migrations/2026_07_22_000001_add_messages_likes_stats_indexes.php
+++ b/iznik-batch/database/migrations/2026_07_22_000001_add_messages_likes_stats_indexes.php
@@ -1,0 +1,51 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * messages_likes(source, timestamp, userid) index for the ModTools sysadmin
+ * "Recommendations" funnel (iznik-server-go/recommendations/stats.go). Its three
+ * queries all filter on source + timestamp; the holdout cohort adds DISTINCT userid.
+ *
+ * Without this index, `SELECT DISTINCT userid ... WHERE source = ? AND timestamp >= ?`
+ * picks a pathological plan: it walks the whole (userid) secondary index (~64.5M
+ * entries) doing a row lookup per entry to test the predicate, which is WORSE than a
+ * table scan and times the endpoint out (seen live at /modtools/recommendations/stats).
+ * The covering (source, timestamp, userid) order lets all three queries seek on the
+ * tagged, recent rows and keeps the DISTINCT userid index-only.
+ *
+ * PRODUCTION NOTE: messages_likes is ~75M rows and HOT (every markseen writes it), and
+ * prod is Percona/Galera with wsrep_OSU_method=TOI, so a plain ALTER serialises
+ * cluster-wide for the whole index build. If the auto-migrate stall is unacceptable,
+ * deploy the companion _migration.sql node-by-node under wsrep_OSU_method=RSU instead
+ * of the auto-migrate path. Online (ALGORITHM=INPLACE, LOCK=NONE) and idempotent:
+ * guarded on information_schema so a re-run is a no-op.
+ */
+return new class extends Migration {
+    public function up(): void
+    {
+        $exists = DB::selectOne(
+            "SELECT COUNT(*) AS n FROM information_schema.statistics
+             WHERE table_schema = DATABASE() AND table_name = 'messages_likes'
+               AND index_name = 'messages_likes_source_ts_user'"
+        );
+        if ((int) ($exists->n ?? 0) === 0) {
+            DB::statement(
+                'ALTER TABLE messages_likes ADD INDEX messages_likes_source_ts_user (source, timestamp, userid), ALGORITHM=INPLACE, LOCK=NONE'
+            );
+        }
+    }
+
+    public function down(): void
+    {
+        $exists = DB::selectOne(
+            "SELECT COUNT(*) AS n FROM information_schema.statistics
+             WHERE table_schema = DATABASE() AND table_name = 'messages_likes'
+               AND index_name = 'messages_likes_source_ts_user'"
+        );
+        if ((int) ($exists->n ?? 0) > 0) {
+            DB::statement('ALTER TABLE messages_likes DROP INDEX messages_likes_source_ts_user');
+        }
+    }
+};

--- a/iznik-batch/database/migrations/2026_07_22_000001_add_messages_likes_stats_indexes_migration.sql
+++ b/iznik-batch/database/migrations/2026_07_22_000001_add_messages_likes_stats_indexes_migration.sql
@@ -1,0 +1,20 @@
+-- Production idempotent SQL: messages_likes(source, timestamp, userid) index for the
+-- ModTools sysadmin "Recommendations" funnel (iznik-server-go/recommendations/stats.go).
+-- Without it, DISTINCT userid over an unindexed (source, timestamp) predicate picks a
+-- pathological plan (walks the ~64.5M-entry userid index, a row lookup per entry) that
+-- is worse than a table scan and times the endpoint out.
+--
+-- messages_likes is ~75M rows and HOT, and prod is Galera (wsrep_OSU_method=TOI): a
+-- plain ALTER serialises cluster-wide writes for the whole index build. To avoid that
+-- stall, run this node-by-node under RSU so no single node blocks the cluster:
+--   SET SESSION wsrep_OSU_method = 'RSU';
+--   -- run the guarded ALTER below on this node
+--   SET SESSION wsrep_OSU_method = 'TOI';
+-- Online (ALGORITHM=INPLACE, LOCK=NONE) and guarded so a re-run is a no-op.
+SET @idx_exists := (SELECT COUNT(*) FROM information_schema.statistics
+    WHERE table_schema = DATABASE() AND table_name = 'messages_likes'
+      AND index_name = 'messages_likes_source_ts_user');
+SET @ddl := IF(@idx_exists = 0,
+    'ALTER TABLE messages_likes ADD INDEX messages_likes_source_ts_user (source, timestamp, userid), ALGORITHM=INPLACE, LOCK=NONE',
+    'SELECT 1');
+PREPARE stmt FROM @ddl; EXECUTE stmt; DEALLOCATE PREPARE stmt;

--- a/iznik-server-go/recommendations/stats.go
+++ b/iznik-server-go/recommendations/stats.go
@@ -93,6 +93,14 @@ func Stats(c *fiber.Ctx) error {
 	}
 	since := time.Now().AddDate(0, 0, -days).Format("2006-01-02 15:04:05")
 
+	// These queries aggregate messages_likes (~75M rows). They are fast ONLY with
+	// the messages_likes_source_ts_user (source, timestamp, userid) index; without
+	// it the DISTINCT-userid cohort picks a plan that walks the whole userid index
+	// and hangs the request. Cap each with MAX_EXECUTION_TIME so a missing index
+	// degrades the panel (an aborted query leaves its slice empty and sets
+	// `degraded`) rather than timing the whole request out.
+	degraded := false
+
 	// Per-day impressions + clicks per source.
 	var funnelRows []struct {
 		D           string `gorm:"column:d"`
@@ -100,12 +108,14 @@ func Stats(c *fiber.Ctx) error {
 		Impressions int64  `gorm:"column:impressions"`
 		Clicks      int64  `gorm:"column:clicks"`
 	}
-	db.Raw(`SELECT DATE(timestamp) d, source,
+	if err := db.Raw(`SELECT /*+ MAX_EXECUTION_TIME(10000) */ DATE(timestamp) d, source,
 	               COUNT(*) impressions,
 	               SUM(pageview = 1) clicks
 	        FROM messages_likes
 	        WHERE type = 'View' AND source IN ? AND timestamp >= ?
-	        GROUP BY d, source`, trackedSources, since).Scan(&funnelRows)
+	        GROUP BY d, source`, trackedSources, since).Scan(&funnelRows).Error; err != nil {
+		degraded = true
+	}
 
 	// Per-day attributed replies per source: an opened (pageview=1) tagged view
 	// followed within 7 days by an Interested reply to that post by the same user.
@@ -114,13 +124,15 @@ func Stats(c *fiber.Ctx) error {
 		Source  string `gorm:"column:source"`
 		Replies int64  `gorm:"column:replies"`
 	}
-	db.Raw(`SELECT DATE(ml.timestamp) d, ml.source, COUNT(DISTINCT cm.id) replies
+	if err := db.Raw(`SELECT /*+ MAX_EXECUTION_TIME(10000) */ DATE(ml.timestamp) d, ml.source, COUNT(DISTINCT cm.id) replies
 	        FROM messages_likes ml
 	        JOIN chat_messages cm ON cm.refmsgid = ml.msgid AND cm.userid = ml.userid
 	             AND cm.type = 'Interested'
 	             AND cm.date BETWEEN ml.timestamp AND ml.timestamp + INTERVAL 7 DAY
 	        WHERE ml.source IN ? AND ml.pageview = 1 AND ml.timestamp >= ?
-	        GROUP BY d, ml.source`, trackedSources, since).Scan(&replyRows)
+	        GROUP BY d, ml.source`, trackedSources, since).Scan(&replyRows).Error; err != nil {
+		degraded = true
+	}
 
 	// Assemble per-source aggregates keyed by (source -> date -> point).
 	bySource := make(map[string]*SourceStats)
@@ -200,7 +212,7 @@ func Stats(c *fiber.Ctx) error {
 		Users   int64 `gorm:"column:users"`
 		Replies int64 `gorm:"column:replies"`
 	}
-	db.Raw(`SELECT (u.userid % 10 = 0) holdout,
+	if err := db.Raw(`SELECT /*+ MAX_EXECUTION_TIME(10000) */ (u.userid % 10 = 0) holdout,
 	               COUNT(*) users,
 	               COALESCE(SUM(r.replies), 0) replies
 	        FROM (SELECT DISTINCT userid FROM messages_likes
@@ -208,7 +220,9 @@ func Stats(c *fiber.Ctx) error {
 	        LEFT JOIN (SELECT userid, COUNT(*) replies FROM chat_messages
 	                   WHERE type = 'Interested' AND date >= ?
 	                   GROUP BY userid) r ON r.userid = u.userid
-	        GROUP BY holdout`, holdoutCohortSource, since, since).Scan(&cohortRows)
+	        GROUP BY holdout`, holdoutCohortSource, since, since).Scan(&cohortRows).Error; err != nil {
+		degraded = true
+	}
 
 	var holdout HoldoutStats
 	for _, r := range cohortRows {
@@ -233,6 +247,10 @@ func Stats(c *fiber.Ctx) error {
 		"days":    days,
 		"sources": out,
 		"holdout": holdout,
+		// True when a query hit MAX_EXECUTION_TIME (the messages_likes stats index
+		// is not deployed yet); the figures above are then partial/empty. The panel
+		// can surface this rather than showing the aborted counts as real zeros.
+		"degraded": degraded,
 	})
 }
 

--- a/iznik-server-go/test/recommendations_test.go
+++ b/iznik-server-go/test/recommendations_test.go
@@ -90,6 +90,26 @@ func TestRecommendationsStatsFunnel(t *testing.T) {
 	assert.Equal(t, int64(1), rep-baseRep, "only the within-7-day reply is attributed")
 }
 
+// The stats response carries a `degraded` flag, set true only when a query hits
+// its MAX_EXECUTION_TIME cap (the messages_likes stats index is not deployed and a
+// query would otherwise hang the request). Against the test DB the queries
+// complete, so it must be false — proving the flag is wired and the guarded
+// queries still run normally.
+func TestRecommendationsStatsNotDegraded(t *testing.T) {
+	support := CreateTestUser(t, uniquePrefix("recdeg")+"_support", "Support")
+	token := getToken(t, support)
+
+	resp, _ := getApp().Test(httptest.NewRequest("GET",
+		"/api/modtools/recommendations/stats?days=30&jwt="+token, nil), 60000)
+	require.Equal(t, 200, resp.StatusCode)
+
+	var body struct {
+		Degraded bool `json:"degraded"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.False(t, body.Degraded, "queries complete against the test DB, so the panel is not degraded")
+}
+
 // holdoutStats fetches the holdout block as the given Support user. Values are
 // global to the DB, so callers compare deltas around their own fixture.
 func holdoutStats(t *testing.T, token string) (holdoutUsers, holdoutReplies, shownUsers, shownReplies int64) {


### PR DESCRIPTION
## Problem

`/modtools/recommendations/stats` (the sysadmin **Recommendations** panel) times out on live. Its three queries aggregate `messages_likes` (~75M rows) filtered on `source` + `timestamp`, and the holdout cohort runs `SELECT DISTINCT userid` over that predicate.

`messages_likes` has **no `source` or `timestamp` index** (only `msgid`, `msgid_2`, `userid`, confirmed against prod). So the `DISTINCT userid ... WHERE source = ? AND timestamp >= ?` query picks a pathological plan: it walks the whole `(userid)` secondary index (~64.5M entries) doing a row lookup per entry to test the predicate — worse than a table scan — and the request times out.

## Fix

Add `messages_likes_source_ts_user (source, timestamp, userid)`. The tagged sources (`similar_posts` 856 rows, `wanted_match` 176, `message_page` ~50k) are tiny, so seeking on `(source, timestamp)` narrows to them immediately, and the trailing `userid` keeps the cohort's `DISTINCT userid` index-only.

Online (`ALGORITHM=INPLACE, LOCK=NONE`) and idempotent (guarded on `information_schema`).

## Deploying to production ⚠️

`messages_likes` is ~75M rows and **hot** (every markseen writes it), and prod is Percona/**Galera** with `wsrep_OSU_method=TOI`, so a plain `ALTER` serialises cluster-wide writes for the whole build. Deploy the companion `_migration.sql` **node-by-node under RSU** to avoid the stall:

```sql
SET SESSION wsrep_OSU_method = 'RSU';
ALTER TABLE messages_likes
  ADD INDEX messages_likes_source_ts_user (source, timestamp, userid),
  ALGORITHM=INPLACE, LOCK=NONE;
SET SESSION wsrep_OSU_method = 'TOI';
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)