### PR TITLE
fix(reengage): track every rendered link so onboarding-tip effectiveness is measurable

### DIFF
--- a/iznik-batch/app/Mail/Reengage/ReengageMail.php
+++ b/iznik-batch/app/Mail/Reengage/ReengageMail.php
@@ -115,19 +115,35 @@ class ReengageMail extends MjmlMailable
         // Do the click/open tracking here and pass it into the view as plain
         // strings. NEVER put $this (the Mailable) into the view data: a Mailable
         // is a large, self-referential object and extracting it into the Blade
-        // scope segfaults the renderer under PHP 8.4. So pre-wrap the CTA links
-        // with tracked redirects and hand the open pixel over as ready MJML.
+        // scope segfaults the renderer under PHP 8.4. So pre-wrap the links with
+        // tracked redirects and hand the open pixel over as ready MJML.
         $content = $this->content;
 
-        $ctas = [
-            'findUrl'     => 'find',
-            'giveUrl'     => 'give',
-            'browseUrl'   => 'browse',
-            'settingsUrl' => 'settings',
+        // Wrap every clickable link the template actually renders so the
+        // onboarding funnel's click-through is measurable (opens come from the
+        // pixel). The shared tip template renders exactly three: the per-day
+        // primary button ($ctaUrl -> give/find/browse) and the footer
+        // settings/unsubscribe links. Matches the digest/chat tracking
+        // convention (position + action).
+        //
+        // IMPORTANT: wrap only this LOCAL $content copy — never $this->content.
+        // addListUnsubscribeHeaders() reads $this->content['unsubscribeUrl'] to
+        // build the RFC 8058 keyed one-click List-Unsubscribe HEADER, which must
+        // stay the direct keyed URL; a tracked redirect there would break the
+        // no-session one-click POST from Gmail/Yahoo.
+        if (! empty($content['ctaUrl']) && is_string($content['ctaUrl'])) {
+            // Keep the give/find/browse distinction in the click's action code.
+            $slug = basename((string) parse_url($content['ctaUrl'], PHP_URL_PATH));
+            $content['ctaUrl'] = $this->trackedUrl($content['ctaUrl'], 'primary_cta', $slug !== '' ? $slug : 'cta');
+        }
+
+        $footerLinks = [
+            'settingsUrl'    => 'settings',
+            'unsubscribeUrl' => 'unsubscribe',
         ];
-        foreach ($ctas as $key => $action) {
+        foreach ($footerLinks as $key => $action) {
             if (! empty($content[$key]) && is_string($content[$key])) {
-                $content[$key] = $this->trackedUrl($content[$key], 'cta', $action);
+                $content[$key] = $this->trackedUrl($content[$key], "footer_{$action}", $action);
             }
         }
 

--- a/iznik-batch/app/Services/ReengageContentService.php
+++ b/iznik-batch/app/Services/ReengageContentService.php
@@ -121,7 +121,7 @@ class ReengageContentService
                     'items' => [
                         'A clear title - just say what it is ("Single duvet", "Pine bookshelf").',
                         'A photo - even a quick phone snap makes all the difference.',
-                        "The condition - honest is perfect. Well-loved and working is very welcome.",
+                        "The condition - well-loved is fine, and even broken things can find a home, but people need to know what they're getting.",
                     ],
                 ],
                 'ctaLabel' => 'Offer something',

--- a/iznik-batch/tests/Unit/Mail/ReengageMailRenderTest.php
+++ b/iznik-batch/tests/Unit/Mail/ReengageMailRenderTest.php
@@ -140,4 +140,87 @@ class ReengageMailRenderTest extends TestCase
         $this->assertStringContainsString('Your local Freegle volunteer', $text);
         $this->assertStringNotContainsString('<mj-', $text);
     }
+
+    // ── Link tracking (effectiveness measurement) ────────────────────────────
+
+    /**
+     * A real send (userId > 0) must route EVERY clickable link the template
+     * renders through a tracked redirect (/e/d/r/...), so the onboarding funnel's
+     * click-through is measurable: the per-day primary button plus the footer
+     * settings and unsubscribe links. (Opens are covered separately by the pixel.)
+     */
+    public function test_real_send_tracks_every_rendered_link(): void
+    {
+        $mail = new ReengageMail('Alex', 'alex@example.com', 'Subject', 'tip', 987654321, $this->data(1));
+
+        $html = $mail->render();
+
+        // Tracked-redirect wrapper present at all.
+        $this->assertStringContainsString('/e/d/r/', $html);
+        // Primary CTA button, with the give/find/browse distinction preserved in
+        // the click action (day 1's CTA is /give).
+        $this->assertStringContainsString('p=primary_cta', $html);
+        $this->assertStringContainsString('a=give', $html);
+        // Footer links.
+        $this->assertStringContainsString('p=footer_settings', $html);
+        $this->assertStringContainsString('p=footer_unsubscribe', $html);
+    }
+
+    /**
+     * The tracked CTA follows the day's destination: day 3 points at /find.
+     */
+    public function test_cta_action_matches_the_day_destination(): void
+    {
+        $mail = new ReengageMail('Alex', 'alex@example.com', 'Subject', 'tip', 987654321, $this->data(3));
+
+        $html = $mail->render();
+
+        $this->assertStringContainsString('p=primary_cta', $html);
+        $this->assertStringContainsString('a=find', $html);
+    }
+
+    /**
+     * Previews (userId 0) stay deliberately untracked so sample renders never
+     * pollute the effectiveness stats: links remain raw.
+     */
+    public function test_preview_leaves_links_untracked(): void
+    {
+        $mail = new ReengageMail('Alex', 'alex@example.com', 'Subject', 'tip', 0, $this->data(1));
+
+        $html = $mail->render();
+
+        $this->assertStringNotContainsString('/e/d/r/', $html);
+        $this->assertStringContainsString('/give', $html);   // raw CTA destination
+    }
+
+    /**
+     * Tracking the VISIBLE unsubscribe link must not disturb the keyed one-click
+     * URL that addListUnsubscribeHeaders() reads from $this->content for the RFC
+     * 8058 List-Unsubscribe header: build() must wrap only its local copy. A
+     * tracked redirect in that header would break no-session one-click
+     * unsubscribe from Gmail/Yahoo.
+     */
+    public function test_real_send_keeps_keyed_unsubscribe_url_for_header(): void
+    {
+        $data = $this->data(1);
+        $mail = new ReengageMail('Alex', 'alex@example.com', 'Subject', 'tip', 987654321, $data);
+
+        $mail->render();
+
+        // The property the List-Unsubscribe header is built from is untouched.
+        $this->assertSame($data['unsubscribeUrl'], $mail->content['unsubscribeUrl']);
+        $this->assertStringNotContainsString('/e/d/r/', $mail->content['unsubscribeUrl']);
+    }
+
+    /**
+     * The reworked day-1 condition tip drops the awkward "honest is perfect"
+     * phrasing for the clearer "even broken things can find a home" wording.
+     */
+    public function test_day1_condition_tip_uses_reworded_copy(): void
+    {
+        $html = view('emails.mjml.reengage.tip', $this->data(1))->render();
+
+        $this->assertStringContainsString('even broken things can find a home', $html);
+        $this->assertStringNotContainsString('honest is perfect', $html);
+    }
 }


### PR DESCRIPTION
## Summary
- **Fix untracked links in the first-week onboarding tip emails** (`ReengageMail`). The `build()` method wrapped `findUrl`/`giveUrl`/`browseUrl`/`settingsUrl` for click tracking, but the shared `tip` template renders the **primary button** from `$ctaUrl` and the footer **settings/unsubscribe** links — so on real sends the main CTA button and the unsubscribe link were *untracked*, while `give/find/browseUrl` were wrapped but never rendered. Net effect: the onboarding funnel's click-through was unmeasurable.
- Now wraps exactly the links the template renders:
  - `ctaUrl` → position `primary_cta`, action = `give`/`find`/`browse` (from the URL slug, so the per-day destination stays distinguishable in click analytics)
  - `settingsUrl` → `footer_settings` / `settings`
  - `unsubscribeUrl` → `footer_unsubscribe` / `unsubscribe`
  - matches the `UnifiedDigest` / `ChatNotification` tracking convention. Opens are already covered by the tracking pixel.
- **Compliance preserved:** wrapping is applied only to `build()`'s *local* `$content` copy, never `$this->content`. `addListUnsubscribeHeaders()` reads `$this->content['unsubscribeUrl']` for the RFC 8058 keyed one-click `List-Unsubscribe` **header**, which stays a direct URL — a tracked redirect there would break no-session one-click unsubscribe from Gmail/Yahoo.
- **Copy:** reworded the day-1 "condition" tip from the awkward *"honest is perfect. Well-loved and working is very welcome."* to *"well-loved is fine, and even broken things can find a home, but people need to know what they're getting."*
- Previews (`userId = 0`) remain intentionally untracked so sample renders never pollute the effectiveness stats — unchanged.

## Code Quality Review
- No behaviour change to previews or to the `offers[].url` tracking block (left intact).
- Removed the dead `give/find/browseUrl` wrapping (those keys are never rendered), so the wrapped set now matches the rendered set exactly — no misleading dead code.
- The `List-Unsubscribe` header path is explicitly protected by a comment and a regression test, since it's a non-obvious invariant (local-copy vs `$this->content`).
- Consistent with the established `trackedUrl(url, position, action)` pattern used by the digest and chat mailables.

## Future Improvements
- Consider a template-level "wrap every `<a href>`" pass (post-render) so new links are tracked automatically without touching `build()`, as a longer-term guard against this class of omission.

## Test Plan
- `ReengageMailRenderTest` (new assertions):
  - `test_real_send_tracks_every_rendered_link` — a `userId>0` render routes CTA + footer settings + unsubscribe through `/e/d/r/…` with `p=primary_cta` / `a=give` / `p=footer_settings` / `p=footer_unsubscribe`.
  - `test_cta_action_matches_the_day_destination` — day 3's CTA tracks as `a=find`.
  - `test_preview_leaves_links_untracked` — `userId=0` render stays raw (no `/e/d/r/`).
  - `test_real_send_keeps_keyed_unsubscribe_url_for_header` — `$mail->content['unsubscribeUrl']` (the header source) is unchanged/untracked after render.
  - `test_day1_condition_tip_uses_reworded_copy` — new wording present, old removed.
- Local validation (no test suite run on this host / no prod writes): `php -l` clean on all three files; `userId=0` smoke render confirmed the new copy renders, old copy gone, preview links raw, MJML compiles; tracked-URL token format verified in-memory (`/e/d/r/…?url=…&p=primary_cta&a=give`). `userId>0` assertions validated by CI.

Note: the re-engagement feature remains dark by default in production (`FREEGLE_REENGAGE_ALLOWLIST` empty); this change only affects link markup when it is enabled.
