### PR TITLE
fix(chat): refresh chat-list entry after sending, not just listByChatId

### DIFF
--- a/iznik-nuxt3/stores/chat.js
+++ b/iznik-nuxt3/stores/chat.js
@@ -294,15 +294,29 @@ export const useChatStore = defineStore({
         try {
           const chat = await api(this.config).chat.fetchChat(id, false)
           if (chat) {
-            // Merge to preserve any existing data (e.g. from listing).
-            this.listByChatId[id] = {
+            // Merge to preserve any existing data (e.g. from listing), and keep
+            // listByChatId and the list array pointing at the SAME merged object.
+            // Previously these were two separate copies (a spread into
+            // listByChatId, the raw fetch result into list), so an in-place
+            // mutation of one (e.g. send() patching the snippet) was invisible
+            // in the other. The chat list panel renders from `list`, so a chat
+            // whose only update went through listByChatId never appeared to
+            // have moved/changed - including its lastmsg, which gates whether
+            // the row renders at all (Discourse 9955).
+            const merged = {
               ...this.listByChatId[id],
               ...chat,
             }
-            // If this chat isn't in the list (e.g. too old to appear in fetchChats
-            // results), add it so it can be rendered in the chat list panel.
-            if (!this.list.find((c) => c.id === id)) {
-              this.list.push(chat)
+            this.listByChatId[id] = merged
+
+            const idx = this.list.findIndex((c) => c.id === id)
+            if (idx === -1) {
+              // Not in the list (e.g. too old to appear in fetchChats results,
+              // or brand new) - add it so it can be rendered in the chat list panel.
+              this.list.push(merged)
+            } else {
+              // Already in the list - refresh it in place with the fresh data.
+              this.list[idx] = merged
             }
           }
         } catch (e) {
@@ -441,10 +455,13 @@ export const useChatStore = defineStore({
 
       await api(this.config).chat.send(data)
 
-      // Update the snippet in the chat list entry so it shows immediately.
-      if (message && this.listByChatId[chatid]) {
-        this.listByChatId[chatid].snippet = message
-      }
+      // Refresh this chat's list entry (snippet/lastmsg/lastdate) so it shows up
+      // immediately in the chat list panel. This matters most for the very first
+      // message in a chat opened via the reply-to-post flow (ChatButton.openChat):
+      // that entry starts with no messages at all, and the chat list only renders
+      // a row once it has one (lastmsg > 0) - without this, a brand-new chat never
+      // appeared in the list, however long the member waited (Discourse 9955).
+      await this.fetchChat(chatid)
 
       // Get the latest messages back.
       this.fetchMessages(chatid)

--- a/iznik-nuxt3/tests/unit/stores/chat.spec.js
+++ b/iznik-nuxt3/tests/unit/stores/chat.spec.js
@@ -85,6 +85,11 @@ vi.mock('~/stores/user', () => ({
 describe('chat store', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    // clearAllMocks() only resets call history, not implementations set via
+    // mockResolvedValue() - reset this one explicitly since `send()` now calls
+    // fetchChat() internally, so a value set by one test would otherwise leak
+    // into unrelated later tests that don't care about it.
+    mockFetchChat.mockResolvedValue(null)
     setActivePinia(createPinia())
   })
 
@@ -221,6 +226,7 @@ describe('chat store', () => {
       const store = useChatStore()
       store.config = {}
       store.listByChatId[10] = { id: 10, snippet: 'old message' }
+      mockFetchChat.mockResolvedValue({ id: 10, snippet: 'new message' })
       mockFetchMessages.mockResolvedValue([])
 
       await store.send(10, 'new message')
@@ -230,6 +236,35 @@ describe('chat store', () => {
         message: 'new message',
       })
       expect(store.listByChatId[10].snippet).toBe('new message')
+    })
+
+    // Reply-to-post flow (ChatButton.openChat -> chatStore.send): the chat room is
+    // opened and pushed into the store BEFORE any message exists, so its list entry
+    // starts with lastmsg = 0. The chat list panel only renders a row when
+    // `lastmsg > 0` (or it's the currently open chat) - see pages/chats/[[id]].vue.
+    // Sending the first reply must refresh that entry's lastmsg (and the `list`
+    // array specifically, not just listByChatId) or the new chat never appears in
+    // the sidebar, however long the member waits (Discourse 9955 - Derek replied to
+    // a Wanted via the reply overlay and the chat never showed up in his list).
+    it('refreshes the list entry lastmsg after sending so a brand-new chat becomes visible (#9955)', async () => {
+      const store = useChatStore()
+      store.config = {}
+      const entry = { id: 10, snippet: null, lastmsg: 0 }
+      store.list = [entry]
+      store.listByChatId[10] = entry
+      mockFetchChat.mockResolvedValue({
+        id: 10,
+        snippet: 'Can you help with this?',
+        lastmsg: 555,
+      })
+      mockFetchMessages.mockResolvedValue([])
+
+      await store.send(10, 'Can you help with this?', null, null, 321)
+
+      // The chat list panel reads `list`, not `listByChatId` - both must reflect
+      // the freshly-sent message so the row's visibility gate (lastmsg > 0) opens.
+      expect(store.list[0].lastmsg).toBe(555)
+      expect(store.list[0].snippet).toBe('Can you help with this?')
     })
 
     it('includes optional params when provided', async () => {


### PR DESCRIPTION
## Root Cause
`chatStore.fetchChat(id)` in `iznik-nuxt3/stores/chat.js` wrote a freshly-merged object into `listByChatId[id]` but pushed the *raw* API response into the `list` array - two separate object references for the same chat. Any later in-place update via `listByChatId` (e.g. `send()`'s snippet patch) was therefore invisible in `list`, which is what the chat list sidebar actually renders (`pages/chats/[[id]].vue`), and whose row-visibility gate is `c.lastmsg > 0`.

A chat opened via the reply-to-post flow (`ChatButton.openChat`, used by `ChatReplyPane`'s state machine) starts with **no messages at all**, so `lastmsg` is 0 until the first message is sent. `chatStore.send()` never refreshed `lastmsg` after posting - it only patched `snippet` on `listByChatId`, which (per the above) never reached `list` anyway. Net effect: a chat created by replying to a Wanted/Offer post could never appear in the sidebar list, no matter how long the member waited.

Discourse 9955: Derek replied to a Wanted via the reply overlay and the resulting chat never showed up in his chat list, blocking him from attaching a photo to his reply.

## Evidence
Failing test (before the fix), run via the targeted vitest suite:
```
× tests/unit/stores/chat.spec.js > chat store > send > refreshes the list entry lastmsg after sending so a brand-new chat becomes visible (#9955) 6ms
  → expected +0 to be 555 // Object.is equality
FAIL  tests/unit/stores/chat.spec.js > chat store > send > refreshes the list entry lastmsg after sending so a brand-new chat becomes visible (#9955)
AssertionError: expected +0 to be 555 // Object.is equality
```
All other 50 existing tests in the file passed unchanged, confirming this was an isolated gap.

## Fix
- `fetchChat(id)`: merge into a single object and keep `listByChatId[id]` and the matching `list` array entry pointing at the *same* object (replacing it in place when already present, instead of only pushing when absent).
- `send()`: replaced the incomplete local-only `listByChatId[chatid].snippet = message` patch with `await this.fetchChat(chatid)`, so `lastmsg`/`lastdate`/`snippet`/`unseen` all refresh from the server immediately after any send - for every caller, not just the ones that separately remembered to call `fetchChat` afterwards (e.g. `ChatFooter.vue` already did this via `_updateAfterSend`; the reply-to-post flow via `ChatButton.vue` did not).

## Other Call Sites
`chatStore.send()` is called from `ChatFooter.vue`, `ModChatFooter.vue`, `ChatButton.vue` (reply-to-post), `ChatMessageAddress.vue`, `MessageReportModal.vue`, and `ModChatNoteModal.vue`. Since the fix lives inside the shared `send()`/`fetchChat()` store actions, all of these now consistently refresh the list entry - not just the reply-to-post path that exposed the bug. `unhide()` (which also calls `fetchChat`) benefits from the same in-place `list` refresh.

## Test
File: `iznik-nuxt3/tests/unit/stores/chat.spec.js` (new test in the `send` describe block, plus a `mockFetchChat` reset in `beforeEach` to avoid cross-test leakage now that `send()` depends on it).
Command: `POST /api/tests/vitest {"filter":"tests/unit/stores/chat.spec.js"}` via the status API.
Proves fail-before (`expected +0 to be 555`) / pass-after (51/51 passed) against the exact production code path.

## Discourse
https://discourse.ilovefreegle.org/t/9955/1