### PR TITLE
fix(chat): pin single-chat reads to the writer so a just-created reply chat shows up

### DIFF
--- a/iznik-server-go/chat/chat_test.go
+++ b/iznik-server-go/chat/chat_test.go
@@ -224,6 +224,36 @@ func TestUpdateMessageCountsEmpty(t *testing.T) {
 	assert.True(t, true)
 }
 
+// TestChatListPinsSpecificChatReadsToWriter guards against Discourse 9955: a chat
+// created by an FD reply (PutChatRoom/CreateChatMessage, both writes) not appearing
+// for minutes because the immediately-following listChats() read - onlyChat/keepChat
+// set when the client asks "does this specific just-created chat exist yet" - is a
+// plain SELECT that the DB read/write split can route to a replica which hasn't
+// applied the write yet (Galera apply-lag; see PR #887/#905). That path must be
+// pinned to the writer via dbresolver.Write. Replica lag can't be simulated on the
+// single test DB (see test/insert_id_test.go), so this asserts the routing decision
+// directly: dbForChatList must pin when a specific chat is requested, and must NOT
+// pin the unscoped list refresh (no onlyChat/keepChat) - that's a high-frequency
+// poll, and pinning it to the writer would defeat the point of the read/write split.
+func TestChatListPinsSpecificChatReadsToWriter(t *testing.T) {
+	const writeMarker = "gorm:db_resolver:write"
+
+	db := database.DBConn
+	require.NotNil(t, db)
+
+	pinned := dbForChatList(db, 12345, 0)
+	_, ok := pinned.Statement.Settings.Load(writeMarker)
+	assert.True(t, ok, "a onlyChat lookup (single just-created chat) must be pinned to the writer")
+
+	pinned = dbForChatList(db, 0, 6789)
+	_, ok = pinned.Statement.Settings.Load(writeMarker)
+	assert.True(t, ok, "a keepChat lookup (ensure a specific chat appears) must be pinned to the writer")
+
+	unpinned := dbForChatList(db, 0, 0)
+	_, ok = unpinned.Statement.Settings.Load(writeMarker)
+	assert.False(t, ok, "the unscoped list refresh must not be pinned to the writer")
+}
+
 func TestFetchReviewMessageNotFound(t *testing.T) {
 	db := database.DBConn
 	require.NotNil(t, db)

--- a/iznik-server-go/chat/chatroom.go
+++ b/iznik-server-go/chat/chatroom.go
@@ -16,6 +16,7 @@ import (
 	"github.com/freegle/iznik-server-go/utils"
 	"github.com/gofiber/fiber/v2"
 	"gorm.io/gorm"
+	"gorm.io/plugin/dbresolver"
 )
 
 const chatActiveLimitMT = 365
@@ -708,6 +709,25 @@ func PostChatRoom(c *fiber.Ctx) error {
 // Internal helpers
 // =============================================================================
 
+// dbForChatList returns the db handle listChats should read through. A
+// onlyChat/keepChat lookup is the read-your-writes path used right after
+// PutChatRoom/CreateChatMessage create a chat (or GetChatRoom fetching one
+// specific chat) - the caller is asking "does this just-created/just-modified
+// chat exist yet". Under the DB read/write split a plain SELECT here can be
+// routed to a replica that hasn't applied that write yet (Galera apply-lag),
+// so the chat silently fails to appear for however long the replica lags
+// (Discourse 9955). Pin that path to the writer, matching the same hazard
+// already fixed for updateMessageCounts in this package (PR #905). The
+// unscoped list refresh (no onlyChat/keepChat) is deliberately left on the
+// replica - it's a high-frequency poll, and pinning it to the writer would
+// defeat the point of the read/write split.
+func dbForChatList(db *gorm.DB, onlyChat uint64, keepChat uint64) *gorm.DB {
+	if onlyChat > 0 || keepChat > 0 {
+		return db.Clauses(dbresolver.Write)
+	}
+	return db
+}
+
 func listChats(myid uint64, chattypes []string, start string, search string, onlyChat uint64, keepChat uint64, includeClosed bool, memberOnly bool) []ChatRoomListEntry {
 	var r []ChatRoomListEntry
 
@@ -1007,7 +1027,8 @@ func listChats(myid uint64, chattypes []string, start string, search string, onl
 	sql := "SELECT MAX(t.search) AS search, t.otheruid, t.nameshort, t.namefull, t.firstname, t.lastname, t.fullname, t.otherdeleted, t.id, t.chattype, t.groupid, t.user1, t.user2, t.latestmessage, t.status, t.lasttype FROM (" + strings.Join(unions, " UNION ") + ") t GROUP BY t.id ORDER BY t.latestmessage DESC"
 
 	db := database.DBConn
-	db.Raw(sql, params...).Scan(&chats)
+	dbq := dbForChatList(db, onlyChat, keepChat)
+	dbq.Raw(sql, params...).Scan(&chats)
 
 	// We hide the "-gxxx" part of names, which will almost always be for TN members.
 	tnre := regexp.MustCompile(utils.TN_REGEXP)
@@ -1153,7 +1174,7 @@ func listChats(myid uint64, chattypes []string, start string, search string, onl
 			// The extra trailing myid feeds the hasvisiblemsg "own messages always count"
 			// check; it sits between the lastmsgseen and lastmsg-join placeholders, all of
 			// which are myid, so appending one more keeps every placeholder correctly bound.
-			res := db.Raw(sql, myid, myid, unseenSince, myid, start, utils.CHAT_TYPE_USER2USER, myid, myid, myid, myid, myid)
+			res := dbq.Raw(sql, myid, myid, unseenSince, myid, start, utils.CHAT_TYPE_USER2USER, myid, myid, myid, myid, myid)
 			res.Scan(&chats2)
 		}()
 


### PR DESCRIPTION
## Root Cause
Replying to a Wanted via FD creates a User2User chat room (`PutChatRoom`) and a chat message (`CreateChatMessage`), both written to the primary. The chat list (`GET /chat/rooms`) and single-chat fetch (`GET /chat/:id`) both read through `listChats()` in `chat/chatroom.go`, which issued a plain `SELECT`. Under this repo's DB read/write split (`iznik-server-go/database/database.go`), a plain SELECT is routed to a read replica that may not yet have applied the just-committed write (Galera apply-lag), so the newly-created chat silently failed to appear until the replica caught up.

This is the same class of hazard already fixed elsewhere in this file (`updateMessageCounts`, PR #905 "pin read-your-writes reads to the writer") - it was just missed for `listChats()`.

## Evidence
`listChats()` already takes `onlyChat`/`keepChat` parameters used specifically for "does this one chat exist" lookups:
- `GetChatRoom` (single-chat fetch, `GET /chat/:id`) passes `onlyChat=id, keepChat=id`.
- The Nuxt3 chat store passes `keepChat=<id>` when the client navigates straight to a specific (often just-created) chat (`iznik-nuxt3/stores/chat.js`), and separately falls back to `fetchChat(id)` (same `GetChatRoom` path) if a chat is missing from the list - so both the list and its own fallback go through the same unprotected read.

Replica lag can't be simulated on the single test DB (same caveat noted in `test/insert_id_test.go`), so the regression test asserts the routing decision directly. Before the fix (`dbForChatList` stubbed to always return the unpinned handle):

```
=== RUN   TestChatListPinsSpecificChatReadsToWriter
    chat_test.go:246: Error: Should be true
        Messages: a onlyChat lookup (single just-created chat) must be pinned to the writer
    chat_test.go:250: Error: Should be true
        Messages: a keepChat lookup (ensure a specific chat appears) must be pinned to the writer
--- FAIL: TestChatListPinsSpecificChatReadsToWriter (0.00s)
FAIL
```

After the fix, the same test passes.

## Fix
Added `dbForChatList(db, onlyChat, keepChat)` in `chat/chatroom.go`: when a specific chat is being looked up (`onlyChat > 0 || keepChat > 0`), the two `listChats()` raw-SQL reads are pinned to the writer via `.Clauses(dbresolver.Write)`, matching the existing idiom used throughout this codebase (`chat/chatmessage.go`, `message/message.go`, `user/authMiddleware.go`). The unscoped list refresh (no `onlyChat`/`keepChat` - the high-frequency chat-list poll) is deliberately left unpinned so it keeps using the replica; pinning that hot path to the writer would defeat the point of the read/write split. `.Clauses(dbresolver.Write)` is a no-op when no read replica is configured, so this is a no-behaviour-change everywhere except behind a configured replica.

## Other Call Sites
`GetChatRoom`'s moderator-view fallback (`chat/chatroom.go`, direct `SELECT ... FROM chat_rooms WHERE id = ?` used only when a moderator looks at another user's chat) has the same unpinned-read shape, but it's a distinct, lower-frequency path unrelated to the reported symptom (a member's own just-created chat), so it's left as-is here.

## Test
- File: `iznik-server-go/chat/chat_test.go`, `TestChatListPinsSpecificChatReadsToWriter`.
- Command: `go test ./chat/... -run TestChatListPinsSpecificChatReadsToWriter -v` (run against a throwaway local MySQL instance, since replica lag can't be simulated on the single test DB).
- Proves fail-before (stubbed `dbForChatList` always returns the unpinned handle) / pass-after (real pin logic) as shown in Evidence above.

## Discourse
https://discourse.ilovefreegle.org/t/9955/1