### PR TITLE
security: SSRF hardening, calendar XSS, CSP report-only

### DIFF
--- a/delivery-nginx.conf
+++ b/delivery-nginx.conf
@@ -133,19 +133,18 @@ http {
     weserv_deny_ip 0.0.0.0/8;
     weserv_deny_ip ::/128;
 
-    # Still deny multicast and link-local (but allow loopback and private IPs for dev)
+    # Always deny multicast, link-local and the cloud-metadata range (169.254.169.254) - never
+    # legitimate for image fetches, in any environment.
     weserv_deny_ip 169.254.0.0/16;
     weserv_deny_ip 224.0.0.0/4;
     weserv_deny_ip fe80::/64;
     weserv_deny_ip ff00::/8;
 
-    # DEVELOPMENT: Allow loopback and private IP addresses for local Docker development
-    # weserv_deny_ip 127.0.0.0/8;     # COMMENTED OUT - allow loopback
-    # weserv_deny_ip ::1/128;         # COMMENTED OUT - allow loopback IPv6
-    # weserv_deny_ip 10.0.0.0/8;     # COMMENTED OUT - allow private IPs
-    # weserv_deny_ip 172.16.0.0/12;  # COMMENTED OUT - allow Docker network IPs
-    # weserv_deny_ip 192.168.0.0/16; # COMMENTED OUT - allow private IPs
-    # weserv_deny_ip fc00::/7;        # COMMENTED OUT - allow private IPv6
+    # Loopback + private (RFC1918) ranges are environment-specific: production must deny them so the
+    # public proxy cannot be pointed at internal services (SSRF), but local dev needs them to reach
+    # images on the Docker network. The edge/production compose mounts the full deny list here; the
+    # base (local dev) compose mounts an empty file. See delivery-weserv-deny-private.*.conf.
+    include /etc/nginx/weserv-deny-private.conf;
 
     # Store temporary files in the shared memory
     proxy_temp_path /dev/shm/proxy_temp;

--- a/delivery-weserv-deny-private.dev.conf
+++ b/delivery-weserv-deny-private.dev.conf
@@ -1,0 +1,7 @@
+# LOCAL DEVELOPMENT ONLY — mounted at /etc/nginx/weserv-deny-private.conf by the base compose.
+#
+# Intentionally empty: private/loopback ranges are NOT denied here so the weserv delivery proxy can
+# fetch images from other containers on the Docker network during local development.
+#
+# Production uses delivery-weserv-deny-private.edge.conf instead (mounted by
+# docker-compose.override.edge.yml), which denies these ranges to prevent SSRF.

--- a/delivery-weserv-deny-private.edge.conf
+++ b/delivery-weserv-deny-private.edge.conf
@@ -1,0 +1,12 @@
+# PRODUCTION SSRF protection — mounted at /etc/nginx/weserv-deny-private.conf by
+# docker-compose.override.edge.yml (overrides the empty local-dev file).
+#
+# The public delivery proxy fetches an attacker-supplied ?url=. Deny loopback and private ranges so
+# it can never be pointed at internal services (loki, other containers, the 10.220.0.0/22 network).
+# (Link-local / cloud metadata 169.254.0.0/16 is already denied unconditionally in delivery-nginx.conf.)
+weserv_deny_ip 127.0.0.0/8;
+weserv_deny_ip ::1/128;
+weserv_deny_ip 10.0.0.0/8;
+weserv_deny_ip 172.16.0.0/12;
+weserv_deny_ip 192.168.0.0/16;
+weserv_deny_ip fc00::/7;

--- a/docker-compose.override.edge.yml
+++ b/docker-compose.override.edge.yml
@@ -90,6 +90,13 @@ services:
     deploy:
       replicas: 1
     cgroup_parent: interactive.slice
+    # Production SSRF protection: replace the base's empty dev deny file with the full private-range
+    # deny list so the public image proxy cannot be pointed at internal hosts. (All base volumes are
+    # re-listed because compose merges by mount target, and this must win at that path.)
+    volumes:
+      - ./delivery-nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./delivery-imagesweserv.conf:/etc/nginx/imagesweserv.conf:ro
+      - ./delivery-weserv-deny-private.edge.conf:/etc/nginx/weserv-deny-private.conf:ro
 
   tusd:
     deploy:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -297,6 +297,9 @@ services:
     volumes:
       - ./delivery-nginx.conf:/etc/nginx/nginx.conf:ro
       - ./delivery-imagesweserv.conf:/etc/nginx/imagesweserv.conf:ro
+      # Local dev: empty deny file (allows Docker-network fetches). Edge overrides this with the
+      # full private-range deny list (docker-compose.override.edge.yml) for SSRF protection.
+      - ./delivery-weserv-deny-private.dev.conf:/etc/nginx/weserv-deny-private.conf:ro
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:80/ || exit 1"]
       interval: 10s

--- a/iznik-batch/app/Services/NewsfeedLinkPreviewService.php
+++ b/iznik-batch/app/Services/NewsfeedLinkPreviewService.php
@@ -74,14 +74,71 @@ class NewsfeedLinkPreviewService
         return $this->create($url);
     }
 
+    /**
+     * Reject URLs that resolve to a non-public address, to stop SSRF: a member can put any URL in a
+     * newsfeed post and this job fetches it server-side. Without this an attacker points it at
+     * internal services (cloud metadata, other containers) and reads a slice of the response back
+     * via the stored preview title/description. Host resolution is split into resolveHostIps() so
+     * tests can supply deterministic IPs (there is no external DNS in the test environment) while
+     * these range checks still run for real.
+     */
+    protected function resolveHostIps(string $host): array
+    {
+        if (filter_var($host, FILTER_VALIDATE_IP)) {
+            return [$host];
+        }
+        $ips = [];
+        $v4 = @gethostbynamel($host);
+        if ($v4) {
+            $ips = array_merge($ips, $v4);
+        }
+        foreach (@dns_get_record($host, DNS_AAAA) ?: [] as $r) {
+            if (!empty($r['ipv6'])) {
+                $ips[] = $r['ipv6'];
+            }
+        }
+        return $ips;
+    }
+
+    protected function isFetchableUrl(string $url): bool
+    {
+        $parts = parse_url($url);
+        $scheme = strtolower($parts['scheme'] ?? '');
+        // parse_url keeps the [...] around an IPv6 literal host; strip them so it validates as an IP.
+        $host = trim($parts['host'] ?? '', '[]');
+        if (!in_array($scheme, ['http', 'https'], true) || $host === '') {
+            return false;
+        }
+
+        $ips = $this->resolveHostIps($host);
+        if (empty($ips)) {
+            return false;
+        }
+        foreach ($ips as $ip) {
+            // Reject private (RFC1918) and reserved (loopback, link-local, etc.) ranges.
+            if (!filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     protected function create(string $url): ?int
     {
         $fetchUrl = str_replace('http://', 'https://', $url);
 
+        // SECURITY: block SSRF before fetching a user-supplied URL server-side (see isFetchableUrl).
+        // Redirects are disabled below so a public URL cannot bounce us to an internal one.
+        if (!$this->isFetchableUrl($fetchUrl)) {
+            return $this->upsertInvalid($url);
+        }
+
         try {
-            $response = Http::timeout(15)->withHeaders([
-                'User-Agent' => 'Mozilla/5.0 (compatible; Freegle/1.0)',
-            ])->get($fetchUrl);
+            $response = Http::timeout(15)
+                ->withOptions(['allow_redirects' => false])
+                ->withHeaders([
+                    'User-Agent' => 'Mozilla/5.0 (compatible; Freegle/1.0)',
+                ])->get($fetchUrl);
 
             if (!$response->successful()) {
                 return $this->upsertInvalid($url);

--- a/iznik-batch/tests/Feature/Newsfeed/GenerateLinkPreviewsCommandTest.php
+++ b/iznik-batch/tests/Feature/Newsfeed/GenerateLinkPreviewsCommandTest.php
@@ -2,12 +2,27 @@
 
 namespace Tests\Feature\Newsfeed;
 
+use App\Services\NewsfeedLinkPreviewService;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Http;
 use Tests\TestCase;
 
 class GenerateLinkPreviewsCommandTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // The command resolves the service from the container; bind one whose host resolution is
+        // deterministic (there is no external DNS in tests) so the SSRF check runs for real against a
+        // public IP rather than failing to resolve the test hostnames.
+        $this->app->bind(NewsfeedLinkPreviewService::class, fn () => new class extends NewsfeedLinkPreviewService {
+            protected function resolveHostIps(string $host): array
+            {
+                return filter_var($host, FILTER_VALIDATE_IP) ? [$host] : ['93.184.216.34'];
+            }
+        });
+    }
+
     private function insertNewsfeed(array $attrs): void
     {
         DB::table('newsfeed')->insert(array_merge([

--- a/iznik-batch/tests/Unit/Services/NewsfeedLinkPreviewServiceTest.php
+++ b/iznik-batch/tests/Unit/Services/NewsfeedLinkPreviewServiceTest.php
@@ -31,6 +31,19 @@ class TestableNewsfeedLinkPreviewService extends NewsfeedLinkPreviewService
     {
         return $this->upsertInvalid($url);
     }
+
+    public function isFetchableUrlPublic(string $url): bool
+    {
+        return $this->isFetchableUrl($url);
+    }
+
+    // Deterministic host resolution for tests (no external DNS): literal IPs pass through so the SSRF
+    // range checks run against them; hostnames resolve to a public IP so fetch-logic tests reach the
+    // (faked) HTTP call with the SSRF check still active.
+    protected function resolveHostIps(string $host): array
+    {
+        return filter_var($host, FILTER_VALIDATE_IP) ? [$host] : ['93.184.216.34'];
+    }
 }
 
 class NewsfeedLinkPreviewServiceTest extends TestCase
@@ -41,6 +54,33 @@ class NewsfeedLinkPreviewServiceTest extends TestCase
     {
         parent::setUp();
         $this->service = new TestableNewsfeedLinkPreviewService();
+    }
+
+    // -------------------------------------------------------------------------
+    // isFetchableUrl — SSRF guard
+    // -------------------------------------------------------------------------
+
+    public function test_isFetchableUrl_blocks_internal_and_bad_schemes(): void
+    {
+        // Literal-IP URLs so no DNS lookup is needed. Internal/private/link-local and non-http(s)
+        // schemes must all be rejected before the server-side fetch happens.
+        foreach ([
+            'http://127.0.0.1/x',
+            'https://10.0.0.1/x',
+            'http://172.16.0.1/x',
+            'https://192.168.1.1/x',
+            'http://169.254.169.254/latest/meta-data/',
+            'http://[::1]/x',
+            'ftp://8.8.8.8/x',
+            'javascript:alert(1)',
+        ] as $url) {
+            $this->assertFalse($this->service->isFetchableUrlPublic($url), "must reject SSRF/bad url: $url");
+        }
+    }
+
+    public function test_isFetchableUrl_allows_public_ip(): void
+    {
+        $this->assertTrue($this->service->isFetchableUrlPublic('https://8.8.8.8/image.png'));
     }
 
     // -------------------------------------------------------------------------

--- a/iznik-nuxt3/pages/calendar.client.vue
+++ b/iznik-nuxt3/pages/calendar.client.vue
@@ -127,11 +127,30 @@ const eventData = computed(() => {
   }
 })
 
+/**
+ * Escape HTML so attacker-controlled text can never inject markup when rendered
+ * via v-html. The event `description` comes entirely from the `?data=` query
+ * param (see rawData/parsed above) and is never seen by the server, so it must
+ * be treated as hostile.
+ */
+function escapeHtml(s) {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
 const descriptionWithLinks = computed(() => {
   if (!eventData.value.description) return ''
-  return eventData.value.description.replace(
-    /(https?:\/\/[^\s]+)/g,
-    '<a href="$1" target="_blank">$1</a>'
+  // SECURITY: escape BEFORE linkifying (escape-then-linkify). Rendering the raw
+  // description via v-html was a reflected XSS: a crafted /calendar?data=... link
+  // executed script in the ilovefreegle.org origin. After escaping, no '<', '>',
+  // '"' or "'" survives, so only our own <a> markup and http(s) links remain.
+  return escapeHtml(eventData.value.description).replace(
+    /(https?:\/\/[^\s<]+)/g,
+    '<a href="$1" target="_blank" rel="noopener noreferrer nofollow">$1</a>'
   )
 })
 

--- a/iznik-nuxt3/public/_headers
+++ b/iznik-nuxt3/public/_headers
@@ -1,3 +1,12 @@
-# Headers for Netlify.  csp.js seems to kick in during dev but not when deployed.
-# Disabled because we show ads which come in from a variety of domains.
-# Content-Security-Policy: worker-src blob:; object-src 'none'; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.facebook.net *.facebook.com *.sentry.io *.google.com *.googletagservices.com *.gstatic.com accounts.google.com/gsi/client cdn.jsdelivr.net *.paypalobjects.com googleads.g.doubleclick.net *.gumgum.com *.adnxs.com securepubads.g.doubleclick.net *.googlesyndication.com *.netlify.app cdn-cookieyes.com api.rlcdn.com ads.pubmatic.com; report-uri https://fdapilive.ilovefreegle.org/csp.php
+# Security headers for the Netlify-hosted site.
+#
+# The CSP is REPORT-ONLY: it reports violations to csp.php without blocking, so we can tune it
+# against the ad/analytics domains before enforcing. Enforcing CSP was previously disabled entirely
+# because ads load from many domains; report-only is safe alongside ads and gives us the violation
+# data (including any cross-origin framing, via frame-ancestors) needed to move to enforcement later.
+# Note the policy keeps 'unsafe-inline'/'unsafe-eval' for now, so it is defence-in-depth (blocks
+# external script injection from non-allowlisted hosts), not a complete XSS control on its own.
+/*
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
+  Content-Security-Policy-Report-Only: worker-src blob:; object-src 'none'; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.facebook.net *.facebook.com *.sentry.io *.google.com *.googletagservices.com *.gstatic.com accounts.google.com/gsi/client cdn.jsdelivr.net *.paypalobjects.com googleads.g.doubleclick.net *.gumgum.com *.adnxs.com securepubads.g.doubleclick.net *.googlesyndication.com *.netlify.app cdn-cookieyes.com api.rlcdn.com ads.pubmatic.com; frame-ancestors 'self'; report-uri https://fdapilive.ilovefreegle.org/csp.php

--- a/iznik-server-go/message/bulkItem.go
+++ b/iznik-server-go/message/bulkItem.go
@@ -1,9 +1,11 @@
 package message
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"sort"
 	"strings"
@@ -582,11 +584,65 @@ func buildBulkSummary(items []BulkItemInput, slots []string) string {
 
 // fetchRemoteImage downloads an image from an http(s) URL, returning its bytes
 // and MIME type. Bounded size/time; verifies the content is an image.
+// isDisallowedIP reports whether an IP is one a user-supplied fetch must never reach: loopback,
+// private (RFC1918), link-local (incl. the 169.254.169.254 cloud-metadata endpoint), unspecified
+// or multicast.
+// allowLoopbackFetch relaxes the SSRF dialer to permit loopback/private targets. It exists solely so
+// unit tests can fetch from a local httptest server (which listens on 127.0.0.1); it stays false in
+// production, where the dialer must block every internal address.
+var allowLoopbackFetch = false
+
+func isDisallowedIP(ip net.IP) bool {
+	if ip == nil {
+		return true
+	}
+	return ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() || ip.IsUnspecified() || ip.IsMulticast()
+}
+
+// ssrfSafeDialContext resolves the target host and refuses to connect to any non-public address,
+// checked on the ACTUAL resolved IP. http.Transport calls this for every connection including each
+// redirect hop, so it also defeats DNS rebinding and redirects to internal hosts.
+func ssrfSafeDialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, err
+	}
+	ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+	if err != nil {
+		return nil, err
+	}
+	d := &net.Dialer{Timeout: 10 * time.Second}
+	var lastErr error = fmt.Errorf("no usable address for %s", host)
+	for _, ipa := range ips {
+		if !allowLoopbackFetch && isDisallowedIP(ipa.IP) {
+			return nil, fmt.Errorf("refusing to connect to non-public address %s", ipa.IP)
+		}
+		conn, derr := d.DialContext(ctx, network, net.JoinHostPort(ipa.IP.String(), port))
+		if derr == nil {
+			return conn, nil
+		}
+		lastErr = derr
+	}
+	return nil, lastErr
+}
+
 func fetchRemoteImage(url string) ([]byte, string, error) {
 	if !strings.HasPrefix(url, "http://") && !strings.HasPrefix(url, "https://") {
 		return nil, "", fmt.Errorf("not an http(s) url")
 	}
-	client := &http.Client{Timeout: 20 * time.Second}
+	// SECURITY: this fetches an attacker-supplied bulk-offer photo URL server-side. Use an SSRF-safe
+	// dialer that blocks internal/private targets, and cap redirects.
+	client := &http.Client{
+		Timeout:   20 * time.Second,
+		Transport: &http.Transport{DialContext: ssrfSafeDialContext},
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 3 {
+				return fmt.Errorf("too many redirects")
+			}
+			return nil
+		},
+	}
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, "", err

--- a/iznik-server-go/message/bulkitem_pure_test.go
+++ b/iznik-server-go/message/bulkitem_pure_test.go
@@ -71,6 +71,9 @@ func TestFetchRemoteImage_RejectsNonHTTPURL(t *testing.T) {
 }
 
 func TestFetchRemoteImage_Non200IsError(t *testing.T) {
+	// Allow the loopback httptest server so we test the non-200 handling, not the SSRF block.
+	allowLoopbackFetch = true
+	defer func() { allowLoopbackFetch = false }()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
@@ -81,6 +84,9 @@ func TestFetchRemoteImage_Non200IsError(t *testing.T) {
 }
 
 func TestFetchRemoteImage_NonImageContentIsError(t *testing.T) {
+	// Allow the loopback httptest server so we test the content-type check, not the SSRF block.
+	allowLoopbackFetch = true
+	defer func() { allowLoopbackFetch = false }()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/plain")
 		_, _ = w.Write([]byte("this is definitely not an image, just some plain text body"))
@@ -92,6 +98,10 @@ func TestFetchRemoteImage_NonImageContentIsError(t *testing.T) {
 }
 
 func TestFetchRemoteImage_DetectsImageWhenContentTypeMissing(t *testing.T) {
+	// httptest listens on loopback, which the SSRF dialer blocks in production; allow it here.
+	allowLoopbackFetch = true
+	defer func() { allowLoopbackFetch = false }()
+
 	// PNG signature; with no Content-Type header the fetcher must sniff the bytes.
 	png := []byte{0x89, 'P', 'N', 'G', 0x0d, 0x0a, 0x1a, 0x0a, 0, 0, 0, 0}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/iznik-server-go/message/bulkitem_ssrf_test.go
+++ b/iznik-server-go/message/bulkitem_ssrf_test.go
@@ -1,0 +1,31 @@
+package message
+
+import (
+	"net"
+	"testing"
+)
+
+// TestIsDisallowedIP guards the bulk-offer photo SSRF fix: a user-supplied photo URL that resolves
+// to an internal/private/link-local address must be blocked, while public addresses are allowed.
+func TestIsDisallowedIP(t *testing.T) {
+	blocked := []string{
+		"127.0.0.1", "::1", "10.0.0.5", "172.16.0.1", "172.31.255.255",
+		"192.168.1.1", "169.254.169.254", "0.0.0.0", "fc00::1", "fe80::1", "224.0.0.1",
+	}
+	for _, ip := range blocked {
+		if !isDisallowedIP(net.ParseIP(ip)) {
+			t.Errorf("isDisallowedIP(%s) = false, want true (internal/private must be blocked)", ip)
+		}
+	}
+
+	allowed := []string{"8.8.8.8", "1.1.1.1", "185.199.221.13", "2606:4700:4700::1111"}
+	for _, ip := range allowed {
+		if isDisallowedIP(net.ParseIP(ip)) {
+			t.Errorf("isDisallowedIP(%s) = true, want false (public must be allowed)", ip)
+		}
+	}
+
+	if !isDisallowedIP(nil) {
+		t.Error("isDisallowedIP(nil) should be true (fail closed on unparseable address)")
+	}
+}


### PR DESCRIPTION
Second batch of security-audit fixes. Each is scoped and has tests; the local suites pass (Go **3590✓**, Laravel **4911✓**), and C5 was verified in the running dev environment.

## Fixes
- **Calendar reflected XSS (C4)** — `calendar.client.vue` escapes the `?data=`-supplied description before linkifying (escape-then-linkify), closing an anonymous account-takeover link.
- **CSP + security headers** — `public/_headers`: report-only Content-Security-Policy (safe with the ad domains) + `X-Content-Type-Options: nosniff` + `Referrer-Policy`, with `frame-ancestors` reporting for clickjacking.
- **Bulk-offer photo SSRF (Go)** — `message/bulkItem.go`: SSRF-safe dialer that blocks loopback/private/link-local on the resolved IP (defeats DNS-rebinding and internal redirects) + capped redirects.
- **Newsfeed link-preview SSRF (PHP)** — `NewsfeedLinkPreviewService`: rejects URLs resolving to a non-public address, disables redirects; host resolution is a `resolveHostIps()` seam so tests run the range checks without real DNS.
- **Delivery image-proxy SSRF (C5)** — `delivery-nginx.conf` includes an environment-specific deny file: production (edge) mounts the full loopback/RFC1918 deny list; local dev mounts an empty file so it can still reach Docker-network images. Verified in dev (nginx valid, container healthy, image serves 200).

## Tests
New/updated: `bulkitem_ssrf_test.go` (`isDisallowedIP`), `bulkitem_pure_test.go` (loopback seam), `NewsfeedLinkPreviewServiceTest` (`isFetchableUrl` + deterministic resolver), `GenerateLinkPreviewsCommandTest` (bound test resolver).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XiA7sSnYSHi6mFJSWKz1h5
