### PR TITLE
fix(stats): state the date range so complete-month windows don't look like stale data

### DIFF
--- a/iznik-nuxt3/pages/stats/[[groupname]].vue
+++ b/iznik-nuxt3/pages/stats/[[groupname]].vue
@@ -10,7 +10,7 @@
               :group="group"
               :show-join="false"
             />
-            <div v-if="route.query.financialYear" class="mt-2 mb-3">
+            <div v-if="dateRangeDescription" class="mt-2 mb-3">
               <div class="bg-light p-2 rounded">
                 <small class="text-muted">
                   <strong>Showing data for: {{ dateRangeDescription }}</strong>
@@ -27,9 +27,9 @@
                   Give and get stuff for free in your local community. Don't
                   throw it away, give it away!
                 </h5>
-                <div v-if="route.query.financialYear" class="mt-1">
+                <div v-if="dateRangeDescription" class="mt-1">
                   <small class="text-muted">
-                    <strong>{{ dateRangeDescription }}</strong>
+                    <strong>Showing data for: {{ dateRangeDescription }}</strong>
                   </small>
                 </div>
               </div>
@@ -292,7 +292,15 @@ const dateRangeDescription = computed(() => {
         .substring(2)} (Apr 6 ${startYear} - Apr 5 ${startYear + 1})`
     }
   }
-  return 'the last 12 months'
+  // Default: the last 12 COMPLETE months. The current, part-finished month is
+  // deliberately excluded so it can't render as a cliff on the monthly charts.
+  // Name the end date explicitly - without it the page silently looks stale for
+  // the whole of the current month (e.g. all through July it ends on 30 June).
+  if (end.value) {
+    return `the 12 months to ${end.value.format('D MMMM YYYY')}`
+  }
+
+  return 'the last 12 complete months'
 })
 
 const totalWeight = computed(() => {

--- a/iznik-nuxt3/tests/unit/pages/stats.spec.js
+++ b/iznik-nuxt3/tests/unit/pages/stats.spec.js
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import { defineComponent, Suspense, h } from 'vue'
+import dayjs from 'dayjs'
 import { DASHBOARD_CHART_HEADER } from '~/composables/useAuthoritySearch'
 
 import StatsPage from '~/pages/stats/[[groupname]].vue'
@@ -233,6 +234,40 @@ describe('pages/stats/[[groupname]].vue', () => {
         .findAllComponents({ name: 'GChart' })
         .filter((c) => c.props('type') === 'LineChart')
       expect(lineCharts.length).toBeGreaterThan(0)
+    })
+  })
+
+  describe('date range — complete months only', () => {
+    // The page deliberately ends the window at the last COMPLETE month so a
+    // part-finished month can't render as a cliff on the monthly charts. That
+    // means for the whole of the current month the newest data shown is the end
+    // of the previous month, which reads as "the stats have stopped updating"
+    // unless the range is stated on the page.
+    it('requests data up to the end of the previous month, not today', async () => {
+      mountPage()
+      await flushPromises()
+
+      const params = mockStatsFetch.mock.calls[0][0]
+      expect(params.end).toBe(
+        dayjs().subtract(1, 'month').endOf('month').format('YYYY-MM-DD')
+      )
+    })
+
+    it('states the range on the page so a complete-months window is not mistaken for stale data', async () => {
+      const wrapper = mountPage()
+      await flushPromises()
+
+      expect(wrapper.text()).toContain('Showing data for:')
+      expect(wrapper.text()).toContain(
+        dayjs().subtract(1, 'month').endOf('month').format('D MMMM YYYY')
+      )
+    })
+
+    it('does not claim "the last 12 months" when the window excludes the current month', async () => {
+      const wrapper = mountPage()
+      await flushPromises()
+
+      expect(wrapper.text()).not.toContain('the last 12 months')
     })
   })
 })


### PR DESCRIPTION
## Summary
- The stats page looked like it had **stopped updating on 30 June**. It hasn't — the data is fine. The page deliberately requests **whole months only**:
  ```js
  // Default behavior - last 12 months minus current month
  end.value = dayjs().subtract(1, 'month').endOf('month')
  ```
  so for the whole of July the newest data shown is 30 June. It will roll to 31 July on 1 August. The exclusion is intentional: a part-finished month would render as a cliff on the monthly charts.
- The page did nothing to explain that, and actively misdescribed it:
  - the default `dateRangeDescription` returned **`'the last 12 months'`**, which is not true — it is the 12 months *ending at the last complete month*;
  - that description was only rendered when `?financialYear` was set, so the **default view stated no date range at all**.
- This PR states the real window — `the 12 months to 30 June 2026` — and shows it in both header branches (group and systemwide). **No change to which data is fetched or displayed.**

## Verification that the data is healthy (not a regression)
- `stats` table has rows through 2026-07-22, steady ~4,200/day through July.
- `GET /apiv2/dashboard?components=Outcomes&systemwide=true&start=2026-07-01&end=2026-07-23` returns **22 rows, 1 Jul → 22 Jul** (count 813 → 975).
- The date logic is long-standing (last touched by "Add option to display stats for last FY"); the only recent change to this page was `50bdadcdf fix(stats): pass components param…`, which does not touch the window.

## Code Quality Review
- Reuses the existing `dateRangeDescription` computed rather than adding a parallel one; the financial-year branches are untouched and still return first.
- Guards on `end.value` (it is `ref(null)` until `onMounted`), falling back to `'the last 12 complete months'`.
- A comment records *why* the current month is excluded, so the window is not later "fixed" by someone reading it as a bug.

## Future Improvements
- If showing month-to-date is ever wanted, the honest version is a separate partial-month series styled distinctly, rather than extending the window and distorting the monthly bars.

## Test Plan
- `tests/unit/pages/stats.spec.js`, 3 new cases:
  - the `end` param equals the end of the previous month (pins the complete-months contract);
  - the rendered page states `Showing data for:` plus the end date;
  - the page no longer claims `the last 12 months`.
- These could not be exercised on this host: the status-API runner targets `freegledocker-modtools-dev-local`, which is not deployed under this host's `COMPOSE_PROFILES=backend,production,mail,edge`. `node --check` on the spec passes; CI covers the rest.
